### PR TITLE
Remove Universal Package publishing from plugin EP packaging pipelines.

### DIFF
--- a/tools/ci_build/github/azure-pipelines/stages/plugin-linux-cuda-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-linux-cuda-stage.yml
@@ -143,22 +143,6 @@ stages:
           touch "$(Build.ArtifactStagingDirectory)/version/$(PluginPackageVersion)"
         displayName: 'Create version marker file'
 
-      - script: |
-          set -e -x
-          mkdir -p "$(Build.BinariesDirectory)/universal_package"
-          cp -R "$(Build.ArtifactStagingDirectory)/bin/"* "$(Build.BinariesDirectory)/universal_package/"
-        displayName: 'Stage binaries for universal package'
-
-      - task: UniversalPackages@0
-        displayName: 'Publish universal package'
-        inputs:
-          command: publish
-          publishDirectory: '$(Build.BinariesDirectory)/universal_package'
-          vstsFeedPublish: 'PublicPackages/ORT-Nightly'
-          vstsFeedPackagePublish: "onnxruntime-plugin-ep-cuda${{ replace(parameters.cuda_version, '.', '') }}-linux-${{ parameters.arch }}"
-          versionOption: custom
-          versionPublish: '$(PluginUniversalPackageVersion)'
-
   - ${{ if eq(parameters.arch, 'x64') }}:
     - job: ${{ parameters.stage_name }}_Python_Package
       dependsOn: ${{ parameters.stage_name }}

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-linux-webgpu-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-linux-webgpu-stage.yml
@@ -85,22 +85,6 @@ stages:
           touch "$(Build.ArtifactStagingDirectory)/version/$(PluginPackageVersion)"
         displayName: 'Create version marker file'
 
-      - script: |
-          set -e -x
-          mkdir -p "$(Build.BinariesDirectory)/universal_package"
-          cp -R "$(Build.ArtifactStagingDirectory)/bin/"* "$(Build.BinariesDirectory)/universal_package/"
-        displayName: 'Stage binaries for universal package'
-
-      - task: UniversalPackages@0
-        displayName: 'Publish universal package'
-        inputs:
-          command: publish
-          publishDirectory: '$(Build.BinariesDirectory)/universal_package'
-          vstsFeedPublish: 'PublicPackages/ORT-Nightly'
-          vstsFeedPackagePublish: 'onnxruntime-plugin-ep-webgpu-linux-x64'
-          versionOption: custom
-          versionPublish: '$(PluginUniversalPackageVersion)'
-
   # Python package build job
   - job: Linux_plugin_webgpu_x64_Python_Package
     dependsOn: Linux_plugin_webgpu_x64_Build

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-mac-webgpu-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-mac-webgpu-stage.yml
@@ -117,22 +117,6 @@ stages:
         touch "$(Build.ArtifactStagingDirectory)/version/$(PluginPackageVersion)"
       displayName: 'Create version marker file'
 
-    - script: |
-        set -e -x
-        mkdir -p "$(Build.BinariesDirectory)/universal_package"
-        cp -R "$(Build.ArtifactStagingDirectory)/bin/"* "$(Build.BinariesDirectory)/universal_package/"
-      displayName: 'Stage binaries for universal package'
-
-    - task: UniversalPackages@0
-      displayName: 'Publish universal package'
-      inputs:
-        command: publish
-        publishDirectory: '$(Build.BinariesDirectory)/universal_package'
-        vstsFeedPublish: 'PublicPackages/ORT-Nightly'
-        vstsFeedPackagePublish: 'onnxruntime-plugin-ep-webgpu-macos-arm64'
-        versionOption: custom
-        versionPublish: '$(PluginUniversalPackageVersion)'
-
   # Python package build job
   - job: MacOS_plugin_webgpu_arm64_Python_Package
     dependsOn: MacOS_plugin_webgpu_arm64_Build

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-win-cuda-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-win-cuda-stage.yml
@@ -201,23 +201,6 @@ stages:
           type nul > "$(Build.ArtifactStagingDirectory)\version\$(PluginPackageVersion)"
         displayName: 'Create version marker file'
 
-      - task: CopyFiles@2
-        displayName: 'Stage binaries for universal package'
-        inputs:
-          SourceFolder: '$(Build.ArtifactStagingDirectory)\bin'
-          Contents: '**'
-          TargetFolder: '$(Build.BinariesDirectory)\universal_package'
-
-      - task: UniversalPackages@0
-        displayName: 'Publish universal package'
-        inputs:
-          command: publish
-          publishDirectory: '$(Build.BinariesDirectory)\universal_package'
-          vstsFeedPublish: 'PublicPackages/ORT-Nightly'
-          vstsFeedPackagePublish: "onnxruntime-plugin-ep-cuda${{ replace(parameters.cuda_version, '.', '') }}-win-x64"
-          versionOption: custom
-          versionPublish: '$(PluginUniversalPackageVersion)'
-
     - job: Win_plugin_cuda_x64_Python_Package
       dependsOn: Win_plugin_cuda_x64_Build
       timeoutInMinutes: 30

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-win-webgpu-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-win-webgpu-stage.yml
@@ -218,23 +218,6 @@ stages:
           type nul > "$(Build.ArtifactStagingDirectory)\version\$(PluginPackageVersion)"
         displayName: 'Create version marker file'
 
-      - task: CopyFiles@2
-        displayName: 'Stage binaries for universal package'
-        inputs:
-          SourceFolder: '$(Build.ArtifactStagingDirectory)\bin'
-          Contents: '**'
-          TargetFolder: '$(Build.BinariesDirectory)\universal_package'
-
-      - task: UniversalPackages@0
-        displayName: 'Publish universal package'
-        inputs:
-          command: publish
-          publishDirectory: '$(Build.BinariesDirectory)\universal_package'
-          vstsFeedPublish: 'PublicPackages/ORT-Nightly'
-          vstsFeedPackagePublish: 'onnxruntime-plugin-ep-webgpu-win-${{ parameters.arch }}'
-          versionOption: custom
-          versionPublish: '$(PluginUniversalPackageVersion)'
-
     # Python package jobs (x64 only — arm64 cross-compiled binaries can't be
     # packaged or tested on x64 agents)
     - ${{ if eq(parameters.arch, 'x64') }}:

--- a/tools/ci_build/set_plugin_ep_build_variables.py
+++ b/tools/ci_build/set_plugin_ep_build_variables.py
@@ -48,7 +48,6 @@ def main():
 
     if package_version == "release":
         version_string = original_ver
-        universal_version = original_ver
         python_version = original_ver
 
     elif package_version == "rc":
@@ -79,10 +78,6 @@ def main():
             print(f"##vso[task.logissue type=error]Failed to get git info: {e}")
             sys.exit(1)
         version_string = f"{original_ver}-dev.{date_str}+{commit_sha}"
-        # Prefix the SHA with "commit-" so the pre-release identifier always contains a
-        # non-digit. Otherwise, an all-numeric short SHA with a leading zero (e.g. "01234567")
-        # would violate SemVer 2.0.0's rule against leading zeros in numeric identifiers.
-        universal_version = f"{original_ver}-dev.{date_str}.commit-{commit_sha}"
         python_version = f"{original_ver}.dev{date_str}"
 
     else:
@@ -92,21 +87,12 @@ def main():
         sys.exit(1)
 
     print(f"Plugin package version string: {version_string}")
-    print(f"Plugin universal package version string: {universal_version}")
     print(f"Plugin Python package version string: {python_version}")
 
     # Validate semver 2.0.0 format
     semver_pattern = r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"
     if not re.match(semver_pattern, version_string):
         print(f"##vso[task.logissue type=error]Version string '{version_string}' is not valid semver 2.0.0.")
-        sys.exit(1)
-
-    # Validate universal version (SemVer 2.0.0, without build metadata)
-    universal_semver_pattern = r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?$"
-    if not re.match(universal_semver_pattern, universal_version):
-        print(
-            f"##vso[task.logissue type=error]Universal version string '{universal_version}' is not valid semver 2.0.0 (without build metadata)."
-        )
         sys.exit(1)
 
     # Validate Python version (PEP 440)
@@ -116,7 +102,6 @@ def main():
         sys.exit(1)
 
     print(f"##vso[task.setvariable variable=PluginPackageVersion]{version_string}")
-    print(f"##vso[task.setvariable variable=PluginUniversalPackageVersion]{universal_version}")
     print(f"##vso[task.setvariable variable=PluginPythonPackageVersion]{python_version}")
     print(f"##vso[task.setvariable variable=PluginEpVersionDefine]onnxruntime_PLUGIN_EP_VERSION={version_string}")
 


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Remove Universal Package publishing from plugin EP packaging pipelines.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

The universal package doesn't seem to have any usage now. If we add it back, we should publish packages from a separate pipeline that can be run after the package test pipeline.