### PR TITLE
Use weights_only=True for remaining torch.load() calls

### DIFF
--- a/onnxruntime/test/testdata/test_data_generation/lr_scheduler/lr_scheduler_test_data_generator.py
+++ b/onnxruntime/test/testdata/test_data_generation/lr_scheduler/lr_scheduler_test_data_generator.py
@@ -4,8 +4,24 @@
 """This file is used to generate test data for LR scheduler optimizer tests in
 orttraining/orttraining/test/training_api/core/training_api_tests.cc."""
 
+import logging
+
 import torch
 from torch.optim.lr_scheduler import LambdaLR
+
+logger = logging.getLogger(__name__)
+
+
+def _torch_load_weights_only(path: str, **kwargs):
+    try:
+        return torch.load(path, weights_only=True, **kwargs)
+    except TypeError:
+        logger.warning(
+            "Current PyTorch version does not support torch.load(..., weights_only=True); "
+            "falling back to default torch.load behavior for %s.",
+            path,
+        )
+        return torch.load(path, **kwargs)
 
 
 class SingleParameterModule(torch.nn.Module):
@@ -90,7 +106,7 @@ def main():
             json.dump(data, f, ensure_ascii=False, indent=4)
 
         data = []
-        state_dict = torch.load(fp.name)
+        state_dict = _torch_load_weights_only(fp.name)
         new_adamw_optimizer = torch.optim.AdamW(pt_model.parameters(), lr=1e-3)
         new_adamw_optimizer.load_state_dict(state_dict["optimizer"])
 

--- a/onnxruntime/test/testdata/test_data_generation/lr_scheduler/lr_scheduler_test_data_generator.py
+++ b/onnxruntime/test/testdata/test_data_generation/lr_scheduler/lr_scheduler_test_data_generator.py
@@ -4,6 +4,7 @@
 """This file is used to generate test data for LR scheduler optimizer tests in
 orttraining/orttraining/test/training_api/core/training_api_tests.cc."""
 
+import inspect
 import logging
 
 import torch
@@ -11,17 +12,19 @@ from torch.optim.lr_scheduler import LambdaLR
 
 logger = logging.getLogger(__name__)
 
+_TORCH_LOAD_HAS_WEIGHTS_ONLY = "weights_only" in inspect.signature(torch.load).parameters
+
 
 def _torch_load_weights_only(path: str, **kwargs):
-    try:
+    if _TORCH_LOAD_HAS_WEIGHTS_ONLY:
         return torch.load(path, weights_only=True, **kwargs)
-    except TypeError:
-        logger.warning(
-            "Current PyTorch version does not support torch.load(..., weights_only=True); "
-            "falling back to default torch.load behavior for %s.",
-            path,
-        )
-        return torch.load(path, **kwargs)
+
+    logger.warning(
+        "Current PyTorch version does not support torch.load(..., weights_only=True); "
+        "falling back to default torch.load behavior for %s.",
+        path,
+    )
+    return torch.load(path, **kwargs)
 
 
 class SingleParameterModule(torch.nn.Module):

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_pytorch_ddp.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_pytorch_ddp.py
@@ -1,6 +1,7 @@
 # This test script is a modified version of Pytorch's tutorial.
 # For details, see https://pytorch.org/tutorials/intermediate/ddp_tutorial.html.
 import argparse
+import logging
 import os
 import sys  # noqa: F401
 import tempfile
@@ -14,6 +15,20 @@ from torch.nn.parallel import DistributedDataParallel as DDP  # noqa: N817
 
 import onnxruntime  # noqa: F401
 from onnxruntime.training.ortmodule import ORTModule
+
+logger = logging.getLogger(__name__)
+
+
+def _torch_load_weights_only(path: str, **kwargs):
+    try:
+        return torch.load(path, weights_only=True, **kwargs)
+    except TypeError:
+        logger.warning(
+            "Current PyTorch version does not support torch.load(..., weights_only=True); "
+            "falling back to default torch.load behavior for %s.",
+            path,
+        )
+        return torch.load(path, **kwargs)
 
 
 def setup(rank, world_size):
@@ -113,7 +128,7 @@ def demo_checkpoint(rank, world_size, use_ort_module):
     dist.barrier()
     # configure map_location properly
     map_location = {"cuda:0": f"cuda:{rank}"}
-    ddp_model.load_state_dict(torch.load(CHECKPOINT_PATH, map_location=map_location))
+    ddp_model.load_state_dict(_torch_load_weights_only(CHECKPOINT_PATH, map_location=map_location))
 
     optimizer.zero_grad()
     outputs = ddp_model(torch.randn(20, 10))

--- a/orttraining/orttraining/test/python/orttraining_test_ortmodule_pytorch_ddp.py
+++ b/orttraining/orttraining/test/python/orttraining_test_ortmodule_pytorch_ddp.py
@@ -1,6 +1,7 @@
 # This test script is a modified version of Pytorch's tutorial.
 # For details, see https://pytorch.org/tutorials/intermediate/ddp_tutorial.html.
 import argparse
+import inspect
 import logging
 import os
 import sys  # noqa: F401
@@ -18,17 +19,19 @@ from onnxruntime.training.ortmodule import ORTModule
 
 logger = logging.getLogger(__name__)
 
+_TORCH_LOAD_HAS_WEIGHTS_ONLY = "weights_only" in inspect.signature(torch.load).parameters
+
 
 def _torch_load_weights_only(path: str, **kwargs):
-    try:
+    if _TORCH_LOAD_HAS_WEIGHTS_ONLY:
         return torch.load(path, weights_only=True, **kwargs)
-    except TypeError:
-        logger.warning(
-            "Current PyTorch version does not support torch.load(..., weights_only=True); "
-            "falling back to default torch.load behavior for %s.",
-            path,
-        )
-        return torch.load(path, **kwargs)
+
+    logger.warning(
+        "Current PyTorch version does not support torch.load(..., weights_only=True); "
+        "falling back to default torch.load behavior for %s.",
+        path,
+    )
+    return torch.load(path, **kwargs)
 
 
 def setup(rank, world_size):


### PR DESCRIPTION
### Description

Follow-up to PR #28097. Applies the same `_torch_load_weights_only()` wrapper to the two remaining `torch.load()` call sites.

`torch.load` can deserialize arbitrary Python pickle payloads. Using `weights_only=True` restricts loading to tensor/checkpoint data on supported PyTorch versions and is the safer default. The wrapper gracefully falls back to the default `torch.load` behavior on older PyTorch versions that do not support the `weights_only` parameter.

### Summary of Changes

| File | Change |
|------|--------|
| `onnxruntime/test/testdata/test_data_generation/lr_scheduler/lr_scheduler_test_data_generator.py` | Adds `_torch_load_weights_only()` helper and uses it when loading scheduler/optimizer state dicts. |
| `orttraining/orttraining/test/python/orttraining_test_ortmodule_pytorch_ddp.py` | Adds `_torch_load_weights_only()` helper and uses it when loading DDP model checkpoint. |

### Motivation and Context

These were the last two `torch.load()` calls in the repository without `weights_only=True`. While both are in test/tooling code with low direct risk, this change ensures consistency with the pattern established in PR #28097 and eliminates all unsafe deserialization call sites.



