### PR TITLE
Validate NodeArg creation

### DIFF
--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -1440,6 +1440,7 @@ void Graph::InitializeStateFromModelFileGraphProto() {
   for (auto& initializer : graph_proto_->initializer()) {
     auto& initializer_name = initializer.name();
     auto initializer_arg = GetNodeArg(initializer_name);
+    ORT_ENFORCE(initializer_arg, "Graph ctor should have created NodeArg for initializer. Missing:", initializer_name);
     graph_initializers.insert({initializer_name, initializer_arg});
   }
 

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -1440,7 +1440,7 @@ void Graph::InitializeStateFromModelFileGraphProto() {
   for (auto& initializer : graph_proto_->initializer()) {
     auto& initializer_name = initializer.name();
     auto initializer_arg = GetNodeArg(initializer_name);
-    ORT_ENFORCE(initializer_arg, "Graph ctor should have created NodeArg for initializer. Missing:", initializer_name);
+    ORT_ENFORCE(initializer_arg, "Graph ctor should have created NodeArg for initializer. Missing: ", initializer_name);
     graph_initializers.insert({initializer_name, initializer_arg});
   }
 

--- a/onnxruntime/test/ir/graph_test.cc
+++ b/onnxruntime/test/ir/graph_test.cc
@@ -3154,16 +3154,16 @@ TEST_F(GraphTest, MalformedModelInitializerWithoutNodeArg) {
 
   // Loading this model should fail with a proper error (not a crash)
   std::shared_ptr<Model> model;
-  auto status = Model::Load(std::move(model_proto), model, nullptr, *logger_);
-  EXPECT_FALSE(status.IsOK());
+  ASSERT_STATUS_NOT_OK_AND_HAS_SUBSTR(
+      Model::Load(std::move(model_proto), model, nullptr, *logger_),
+      "orphan_init");
 }
 
-// Test that a model with a node containing a subgraph attribute where the subgraph
-// is completely empty is properly rejected.
+// Test that a model with an If node containing empty subgraphs
+// (present but empty GraphProto) is properly rejected.
 TEST_F(GraphTest, MalformedModelEmptySubgraph) {
-  // Construct a minimal model with an Identity node that has a spurious graph attribute
-  // with an empty body (no inputs, no outputs, no nodes in the body).
-  // This simulates a structurally malformed model.
+  // Construct a model with an If node whose then_branch and else_branch
+  // subgraphs are present but completely empty (no inputs, no outputs, no nodes).
   ModelProto model_proto;
   model_proto.set_ir_version(9);
   auto* opset = model_proto.add_opset_import();
@@ -3173,24 +3173,30 @@ TEST_F(GraphTest, MalformedModelEmptySubgraph) {
   auto* graph_proto = model_proto.mutable_graph();
   graph_proto->set_name("test_graph");
 
-  // Add a graph input
-  auto* input = graph_proto->add_input();
-  input->set_name("X");
-  auto* input_type = input->mutable_type()->mutable_tensor_type();
-  input_type->set_elem_type(TensorProto_DataType_FLOAT);
-  input_type->mutable_shape()->add_dim()->set_dim_value(2);
+  // Add a boolean condition input for the If node
+  auto* cond_input = graph_proto->add_input();
+  cond_input->set_name("cond");
+  auto* cond_type = cond_input->mutable_type()->mutable_tensor_type();
+  cond_type->set_elem_type(TensorProto_DataType_BOOL);
+  cond_type->mutable_shape();  // scalar
 
-  // Add a node with an identity op that has a spurious graph attribute
+  // Add an If node with empty then_branch and else_branch subgraphs
   auto* node = graph_proto->add_node();
-  node->add_input("X");
+  node->add_input("cond");
   node->add_output("Y");
-  node->set_op_type("Identity");
+  node->set_op_type("If");
 
-  // Add an attribute with type GRAPH and an empty graph body
-  auto* attr = node->add_attribute();
-  attr->set_name("body");
-  attr->set_type(AttributeProto_AttributeType_GRAPH);
-  // Leave attr->mutable_g() as an empty GraphProto
+  // Add then_branch attribute with an empty GraphProto
+  auto* then_attr = node->add_attribute();
+  then_attr->set_name("then_branch");
+  then_attr->set_type(AttributeProto_AttributeType_GRAPH);
+  then_attr->mutable_g();  // allocate empty GraphProto
+
+  // Add else_branch attribute with an empty GraphProto
+  auto* else_attr = node->add_attribute();
+  else_attr->set_name("else_branch");
+  else_attr->set_type(AttributeProto_AttributeType_GRAPH);
+  else_attr->mutable_g();  // allocate empty GraphProto
 
   // Add graph output
   auto* output = graph_proto->add_output();
@@ -3199,11 +3205,10 @@ TEST_F(GraphTest, MalformedModelEmptySubgraph) {
   output_type->set_elem_type(TensorProto_DataType_FLOAT);
   output_type->mutable_shape()->add_dim()->set_dim_value(2);
 
-  // Loading and resolving the model should fail because Identity does not have
-  // a "body" graph attribute in its schema. The model should be rejected gracefully.
+  // Loading the model should fail gracefully — not crash.
+  // The empty subgraphs have no outputs, which violates the If op spec.
   std::shared_ptr<Model> model;
   auto status = Model::Load(std::move(model_proto), model, nullptr, *logger_);
-  // The model should be rejected at some point — either load or resolve — not crash.
   EXPECT_FALSE(status.IsOK());
 }
 

--- a/onnxruntime/test/ir/graph_test.cc
+++ b/onnxruntime/test/ir/graph_test.cc
@@ -3101,5 +3101,111 @@ TEST_F(GraphTest, CustomInitializerHandlingAfterConvertToOrtValues) {
   ASSERT_EQ(it->raw_data().size(), 32 * sizeof(int64_t));
 }
 
+// Test that a malformed model with an initializer that has no corresponding NodeArg
+// is properly rejected during graph loading.
+TEST_F(GraphTest, MalformedModelInitializerWithoutNodeArg) {
+  // Construct a model proto manually with ir_version < 4 where an initializer
+  // has no matching graph input (and therefore no NodeArg is created for it).
+  // The graph output references the orphaned initializer, but the output proto
+  // entry lacks type info so no NodeArg is created via the output loop either.
+  ModelProto model_proto;
+  model_proto.set_ir_version(3);  // ir_version < 4 requires initializers to be graph inputs
+  auto* opset = model_proto.add_opset_import();
+  opset->set_domain("");
+  opset->set_version(13);
+
+  auto* graph_proto = model_proto.mutable_graph();
+  graph_proto->set_name("test_graph");
+
+  // Add a valid graph input with type
+  auto* input = graph_proto->add_input();
+  input->set_name("X");
+  auto* input_type = input->mutable_type()->mutable_tensor_type();
+  input_type->set_elem_type(TensorProto_DataType_FLOAT);
+  input_type->mutable_shape()->add_dim()->set_dim_value(2);
+
+  // Add a node
+  auto* node = graph_proto->add_node();
+  node->add_input("X");
+  node->add_output("Y");
+  node->set_op_type("Identity");
+
+  // Add a normal graph output with type
+  auto* output = graph_proto->add_output();
+  output->set_name("Y");
+  auto* output_type = output->mutable_type()->mutable_tensor_type();
+  output_type->set_elem_type(TensorProto_DataType_FLOAT);
+  output_type->mutable_shape()->add_dim()->set_dim_value(2);
+
+  // Add an orphaned initializer (no matching graph input for ir_version < 4).
+  // This means no NodeArg is created for "orphan_init" in the constructor.
+  auto* initializer = graph_proto->add_initializer();
+  initializer->set_name("orphan_init");
+  initializer->set_data_type(TensorProto_DataType_FLOAT);
+  initializer->add_dims(2);
+  initializer->add_float_data(1.0f);
+  initializer->add_float_data(2.0f);
+
+  // Add a second output referencing the orphaned initializer.
+  // Intentionally omit type so that no NodeArg is created for it via the output loop.
+  auto* output2 = graph_proto->add_output();
+  output2->set_name("orphan_init");
+  // No type set - this means GetOrCreateNodeArg won't be called for this output
+
+  // Loading this model should fail with a proper error (not a crash)
+  std::shared_ptr<Model> model;
+  auto status = Model::Load(std::move(model_proto), model, nullptr, *logger_);
+  EXPECT_FALSE(status.IsOK());
+}
+
+// Test that a model with a node containing a subgraph attribute where the subgraph
+// is completely empty is properly rejected.
+TEST_F(GraphTest, MalformedModelEmptySubgraph) {
+  // Construct a minimal model with an Identity node that has a spurious graph attribute
+  // with an empty body (no inputs, no outputs, no nodes in the body).
+  // This simulates a structurally malformed model.
+  ModelProto model_proto;
+  model_proto.set_ir_version(9);
+  auto* opset = model_proto.add_opset_import();
+  opset->set_domain("");
+  opset->set_version(13);
+
+  auto* graph_proto = model_proto.mutable_graph();
+  graph_proto->set_name("test_graph");
+
+  // Add a graph input
+  auto* input = graph_proto->add_input();
+  input->set_name("X");
+  auto* input_type = input->mutable_type()->mutable_tensor_type();
+  input_type->set_elem_type(TensorProto_DataType_FLOAT);
+  input_type->mutable_shape()->add_dim()->set_dim_value(2);
+
+  // Add a node with an identity op that has a spurious graph attribute
+  auto* node = graph_proto->add_node();
+  node->add_input("X");
+  node->add_output("Y");
+  node->set_op_type("Identity");
+
+  // Add an attribute with type GRAPH and an empty graph body
+  auto* attr = node->add_attribute();
+  attr->set_name("body");
+  attr->set_type(AttributeProto_AttributeType_GRAPH);
+  // Leave attr->mutable_g() as an empty GraphProto
+
+  // Add graph output
+  auto* output = graph_proto->add_output();
+  output->set_name("Y");
+  auto* output_type = output->mutable_type()->mutable_tensor_type();
+  output_type->set_elem_type(TensorProto_DataType_FLOAT);
+  output_type->mutable_shape()->add_dim()->set_dim_value(2);
+
+  // Loading and resolving the model should fail because Identity does not have
+  // a "body" graph attribute in its schema. The model should be rejected gracefully.
+  std::shared_ptr<Model> model;
+  auto status = Model::Load(std::move(model_proto), model, nullptr, *logger_);
+  // The model should be rejected at some point — either load or resolve — not crash.
+  EXPECT_FALSE(status.IsOK());
+}
+
 }  // namespace test
 }  // namespace onnxruntime


### PR DESCRIPTION
This pull request improves the robustness of ONNX model loading and validation by adding stricter checks for malformed models and enhancing test coverage. The most important changes are:

**Model Loading Robustness:**

* Added an `ORT_ENFORCE` check in `Graph::InitializeStateFromModelFileGraphProto()` to ensure that every initializer in the model has a corresponding `NodeArg`, preventing crashes when loading malformed models.

**Test Coverage for Malformed Models:**

* Added a test (`MalformedModelInitializerWithoutNodeArg`) to verify that a model with an initializer lacking a matching `NodeArg` is properly rejected during loading, ensuring graceful error handling.
* Added a test (`MalformedModelEmptySubgraph`) to verify that a model with a node containing an empty subgraph attribute is rejected, further ensuring structural validation of models.