### PR TITLE
Add PEP 561 `py.typed` marker to the `onnxruntime` package

### DIFF
--- a/onnxruntime/test/python/test_pep561_py_typed_marker.py
+++ b/onnxruntime/test/python/test_pep561_py_typed_marker.py
@@ -1,0 +1,25 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+"""Regression test for issue #23108: PEP 561 `py.typed` marker presence."""
+
+from __future__ import annotations
+
+import os
+import unittest
+
+import onnxruntime
+
+
+class TestPep561Marker(unittest.TestCase):
+    def test_py_typed_marker_exists_in_installed_package(self):
+        package_root = os.path.dirname(onnxruntime.__file__)
+        marker_path = os.path.join(package_root, "py.typed")
+        self.assertTrue(
+            os.path.isfile(marker_path),
+            f"PEP 561 marker not found at {marker_path}; type checkers will fall back to 'import-untyped'.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -709,7 +709,7 @@ if enable_training or enable_training_apis:
 if package_name == "onnxruntime-tvm":
     packages += ["onnxruntime.providers.tvm"]
 
-package_data["onnxruntime"] = data + examples + extra
+package_data["onnxruntime"] = data + examples + extra + ["py.typed"]
 
 version_number = ""
 with open("VERSION_NUMBER") as f:


### PR DESCRIPTION
### Description

Adds the standard PEP 561 `py.typed` marker so type checkers (mypy, pyright) consider the inline annotations in `onnxruntime`. Without it, mypy emits:

```
error: Skipping analyzing "onnxruntime": module is installed,
       but missing library stubs or py.typed marker  [import-untyped]
```

### Changes

- `onnxruntime/py.typed` — empty marker at the importable package root.
- `setup.py` — include the marker in `package_data["onnxruntime"]`.
- `onnxruntime/test/python/test_pep561_py_typed_marker.py` — regression test.

### Verification

Tested locally with `mypy 2.0.0` against an installed `onnxruntime` wheel: the `import-untyped` error reproduces without the marker and disappears with it. `python setup.py sdist` packages `onnxruntime/py.typed` correctly. `lintrunner` clean.

### Motivation and Context

Fixes #23108.