### PR TITLE
Add transformer optimizer JSON report

### DIFF
--- a/onnxruntime/python/tools/transformers/README.md
+++ b/onnxruntime/python/tools/transformers/README.md
@@ -22,6 +22,8 @@ Models not in the list may only be partially optimized or not optimized at all.
 
 - **input**: input model path
 - **output**: output model path
+- **report**: (*optional*)
+    Write a JSON report with input/output paths, model type, optimization settings, operator statistics and fused operator statistics.
 - **model_type**: (*defaul: bert*)
     There are 4 model types: *bert* (exported by PyTorch), *gpt2* (exported by PyTorch), and *bert_tf* (BERT exported by tf2onnx), *bert_keras* (BERT exported by keras2onnx) respectively.
 - **num_heads**: (*default: 12*)

--- a/onnxruntime/python/tools/transformers/optimizer.py
+++ b/onnxruntime/python/tools/transformers/optimizer.py
@@ -18,6 +18,7 @@
 #  (3) Some model cannot be handled by OnnxRuntime, and you can modify this script to get optimized model.
 
 import argparse
+import json
 import logging
 import os
 import tempfile
@@ -427,6 +428,34 @@ def get_fusion_statistics(optimized_model_path: str) -> dict[str, int]:
     return optimizer.get_fused_operator_statistics()
 
 
+def create_optimization_report(
+    *,
+    input_path: str,
+    output_path: str,
+    model_type: str,
+    opt_level: int | None,
+    use_gpu: bool,
+    provider: str | None,
+    only_onnxruntime: bool,
+    operator_statistics: dict[str, int],
+    fused_operator_statistics: dict[str, int],
+    fully_optimized: bool,
+) -> dict:
+    """Create a JSON-serializable summary of transformer optimization results."""
+    return {
+        "input": input_path,
+        "output": output_path,
+        "model_type": model_type,
+        "opt_level": opt_level,
+        "use_gpu": use_gpu,
+        "provider": provider,
+        "only_onnxruntime": only_onnxruntime,
+        "operator_statistics": dict(sorted(operator_statistics.items())),
+        "fused_operator_statistics": dict(sorted(fused_operator_statistics.items())),
+        "fully_optimized": fully_optimized,
+    }
+
+
 def _parse_arguments():
     parser = argparse.ArgumentParser(
         description="Graph optimization tool for ONNX Runtime."
@@ -435,6 +464,14 @@ def _parse_arguments():
     parser.add_argument("--input", required=True, type=str, help="input onnx model path")
 
     parser.add_argument("--output", required=True, type=str, help="optimized onnx model path")
+
+    parser.add_argument(
+        "--report",
+        required=False,
+        type=str,
+        default=None,
+        help="optional path to write a JSON optimization report with operator and fusion statistics",
+    )
 
     parser.add_argument(
         "--model_type",
@@ -600,10 +637,13 @@ def main():
         optimizer.change_graph_inputs_to_int32()
 
     # Print the operator statistics might help end user.
-    optimizer.get_operator_statistics()
+    operator_statistics = optimizer.get_operator_statistics()
 
     fused_op_count = optimizer.get_fused_operator_statistics()
-    if "bert" in args.model_type and optimizer.is_fully_optimized(fused_op_count):
+    fully_optimized = "bert" in args.model_type and optimizer.is_fully_optimized(
+        fused_op_count
+    )
+    if fully_optimized:
         logger.info("The model has been fully optimized.")
     else:
         logger.info("The model has been optimized.")
@@ -615,6 +655,24 @@ def main():
             logger.warning("Packing mode only supports BERT like models")
 
     optimizer.save_model_to_file(args.output, args.use_external_data_format, convert_attribute=args.convert_attribute)
+
+    if args.report:
+        report = create_optimization_report(
+            input_path=args.input,
+            output_path=args.output,
+            model_type=args.model_type,
+            opt_level=args.opt_level,
+            use_gpu=args.use_gpu,
+            provider=args.provider,
+            only_onnxruntime=args.only_onnxruntime,
+            operator_statistics=operator_statistics,
+            fused_operator_statistics=fused_op_count,
+            fully_optimized=fully_optimized,
+        )
+        with open(args.report, "w", encoding="utf-8") as report_file:
+            json.dump(report, report_file, indent=2, sort_keys=True)
+            report_file.write("\n")
+        logger.info("Optimization report saved to %s", args.report)
 
 
 if __name__ == "__main__":

--- a/onnxruntime/test/python/transformers/test_optimizer.py
+++ b/onnxruntime/test/python/transformers/test_optimizer.py
@@ -17,11 +17,11 @@ from parity_utilities import find_transformers_source
 if find_transformers_source():
     from fusion_options import FusionOptions
     from onnx_model import OnnxModel
-    from optimizer import optimize_model
+    from optimizer import create_optimization_report, optimize_model
 else:
     from onnxruntime.transformers.fusion_options import FusionOptions
     from onnxruntime.transformers.onnx_model import OnnxModel
-    from onnxruntime.transformers.optimizer import optimize_model
+    from onnxruntime.transformers.optimizer import create_optimization_report, optimize_model
 
 TEST_MODELS = {
     "bert_keras_0": (
@@ -153,6 +153,26 @@ class TestModelOptimization(unittest.TestCase):
                 "ReduceSum": 0,
             }
             self.verify_node_count(model, expected_node_count, file)
+
+    def test_create_optimization_report(self):
+        report = create_optimization_report(
+            input_path="input.onnx",
+            output_path="output.onnx",
+            model_type="bert",
+            opt_level=1,
+            use_gpu=False,
+            provider=None,
+            only_onnxruntime=False,
+            operator_statistics={"MatMul": 2, "Add": 1},
+            fused_operator_statistics={"Attention": 1},
+            fully_optimized=True,
+        )
+
+        self.assertEqual(report["input"], "input.onnx")
+        self.assertEqual(report["output"], "output.onnx")
+        self.assertEqual(report["operator_statistics"], {"Add": 1, "MatMul": 2})
+        self.assertEqual(report["fused_operator_statistics"], {"Attention": 1})
+        self.assertTrue(report["fully_optimized"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Description

Add an optional `--report` argument to the transformer optimizer CLI. When provided, the optimizer writes a JSON report with:

- input and output model paths
- model type and optimization settings
- operator statistics
- fused operator statistics
- whether the model is considered fully optimized

This makes transformer optimizer output easier to consume in scripts and debug workflows without changing optimization behavior.

### Testing

- `python3 -m py_compile onnxruntime/python/tools/transformers/optimizer.py onnxruntime/test/python/transformers/test_optimizer.py`
- `git diff --check`