### PR TITLE
Fix CUDA plugin EP test pipeline

### DIFF
--- a/onnxruntime/core/providers/cuda/plugin/cuda_allocator_plugin.cc
+++ b/onnxruntime/core/providers/cuda/plugin/cuda_allocator_plugin.cc
@@ -31,7 +31,7 @@ void RestoreDeviceIfKnown(bool restore_prev_device, int prev_device) noexcept {
 CudaDeviceAllocator::CudaDeviceAllocator(const OrtMemoryInfo* memory_info, int device_id)
     : CudaAllocatorBase(CudaAllocatorKind::kDevice, memory_info),
       device_id_(device_id) {
-  version = ORT_API_VERSION;
+  version = kCudaPluginEpMinOrtApiVersion;
   Alloc = AllocImpl;
   Free = FreeImpl;
   Info = InfoImpl;
@@ -92,7 +92,7 @@ CudaDeviceAllocator::CudaDeviceAllocator(const OrtMemoryInfo* memory_info, int d
 
 CudaPinnedAllocator::CudaPinnedAllocator(const OrtMemoryInfo* memory_info)
     : CudaAllocatorBase(CudaAllocatorKind::kPinned, memory_info) {
-  version = ORT_API_VERSION;
+  version = kCudaPluginEpMinOrtApiVersion;
   Alloc = AllocImpl;
   Free = FreeImpl;
   Info = InfoImpl;

--- a/onnxruntime/core/providers/cuda/plugin/cuda_arena.h
+++ b/onnxruntime/core/providers/cuda/plugin/cuda_arena.h
@@ -578,7 +578,7 @@ class CudaArenaAllocator final : public CudaAllocatorBase {
   CudaArenaAllocator(CudaAllocatorKind kind, const OrtMemoryInfo* memory_info,
                      std::unique_ptr<ArenaImpl> impl)
       : CudaAllocatorBase(kind, memory_info), impl_(std::move(impl)) {
-    version = ORT_API_VERSION;
+    version = kCudaPluginEpMinOrtApiVersion;
     Alloc = AllocImpl;
     Reserve = ReserveImpl;
     Free = FreeImpl;

--- a/onnxruntime/core/providers/cuda/plugin/cuda_controlflow_plugin.cc
+++ b/onnxruntime/core/providers/cuda/plugin/cuda_controlflow_plugin.cc
@@ -6,6 +6,7 @@
 // instead of inheriting from CPU base classes.
 
 #include "core/providers/cuda/plugin/cuda_controlflow_plugin.h"
+#include "cuda_plugin_utils.h"
 #include <cuda_runtime.h>
 
 namespace onnxruntime {
@@ -85,7 +86,7 @@ Status PluginIfKernel::CreateControlFlowKernelImpl(const OrtKernelInfo* info, Or
 // ===================================================================
 
 PluginLoopHelper::PluginLoopHelper() : OrtLoopKernelHelper{} {
-  ort_version_supported = ORT_API_VERSION;
+  ort_version_supported = kCudaPluginEpMinOrtApiVersion;
   Release = ReleaseImpl;
   ConcatOutput = ConcatOutputImpl;
 }
@@ -162,7 +163,7 @@ Status PluginLoopKernel::CreateControlFlowKernelImpl(const OrtKernelInfo* info, 
 // ===================================================================
 
 PluginScanHelper::PluginScanHelper() : OrtScanKernelHelper{} {
-  ort_version_supported = ORT_API_VERSION;
+  ort_version_supported = kCudaPluginEpMinOrtApiVersion;
   Release = ReleaseImpl;
   Transpose = TransposeImpl;
 }

--- a/onnxruntime/core/providers/cuda/plugin/cuda_data_transfer_plugin.cc
+++ b/onnxruntime/core/providers/cuda/plugin/cuda_data_transfer_plugin.cc
@@ -10,7 +10,7 @@ CudaDataTransfer::CudaDataTransfer(const OrtApi& ort_api, const OrtEpApi& ep_api
     : OrtDataTransferImpl{},
       ort_api_(ort_api),
       ep_api_(ep_api) {
-  ort_version_supported = ORT_API_VERSION;
+  ort_version_supported = kCudaPluginEpMinOrtApiVersion;
   Release = ReleaseImpl;
   CanCopy = CanCopyImpl;
   CopyTensors = CopyTensorsImpl;

--- a/onnxruntime/core/providers/cuda/plugin/cuda_ep.cc
+++ b/onnxruntime/core/providers/cuda/plugin/cuda_ep.cc
@@ -108,7 +108,7 @@ CudaEp::CudaEp(CudaEpFactory& factory, const Config& config, const OrtLogger& lo
       name_(factory.GetEpName()),
       config_(config),
       logger_(logger) {
-  ort_version_supported = ORT_API_VERSION;
+  ort_version_supported = kCudaPluginEpMinOrtApiVersion;
 
   // Set function pointers for kernel-registry-based EP
   GetName = GetNameImpl;

--- a/onnxruntime/core/providers/cuda/plugin/cuda_ep_factory.cc
+++ b/onnxruntime/core/providers/cuda/plugin/cuda_ep_factory.cc
@@ -26,7 +26,7 @@ CudaEpFactory::CudaEpFactory(const OrtApi& ort_api, const OrtEpApi& ep_api,
       ort_api_(ort_api),
       ep_api_(ep_api),
       default_logger_(default_logger) {
-  ort_version_supported = ORT_API_VERSION;
+  ort_version_supported = kCudaPluginEpMinOrtApiVersion;
 
   if (!::onnxruntime::ep::adapter::LoggingManager::HasDefaultLogger()) {
     ::onnxruntime::ep::adapter::LoggingManager::CreateDefaultLogger(&default_logger);

--- a/onnxruntime/core/providers/cuda/plugin/cuda_mempool_allocator_plugin.cc
+++ b/onnxruntime/core/providers/cuda/plugin/cuda_mempool_allocator_plugin.cc
@@ -158,7 +158,7 @@ CudaMempoolOrtAllocator::CudaMempoolOrtAllocator(const OrtMemoryInfo* memory_inf
       pool_(pool),
       pool_release_threshold_(pool_release_threshold),
       bytes_to_keep_on_shrink_(bytes_to_keep_on_shrink) {
-  version = ORT_API_VERSION;
+  version = kCudaPluginEpMinOrtApiVersion;
   Alloc = AllocImpl;
   AllocOnStream = AllocOnStreamImpl;
   Free = FreeImpl;

--- a/onnxruntime/core/providers/cuda/plugin/cuda_plugin_ep.cc
+++ b/onnxruntime/core/providers/cuda/plugin/cuda_plugin_ep.cc
@@ -19,7 +19,7 @@
 #endif
 
 namespace {
-constexpr uint32_t kMinCreateStatusOrtApiVersion = 1;
+constexpr uint32_t kMinOrtApiVersionForCreateStatus = 1;
 }
 
 extern "C" {
@@ -39,10 +39,11 @@ EXPORT_SYMBOL OrtStatus* CreateEpFactories(
 
   const OrtApi* ort_api = ort_api_base->GetApi(kCudaPluginEpMinOrtApiVersion);
   if (ort_api == nullptr) {
-    const OrtApi* fallback_api = ort_api_base->GetApi(kMinCreateStatusOrtApiVersion);
+    // Use API v1 only to construct an OrtStatus that explains the API v26 requirement.
+    const OrtApi* fallback_api = ort_api_base->GetApi(kMinOrtApiVersionForCreateStatus);
     if (fallback_api == nullptr) {
       // Critical failure path: no compatible API available to even construct an OrtStatus.
-      fprintf(stderr, "CUDA Plugin EP requires ONNX Runtime API version 26 or newer (ORT 1.26+).\n");
+      fprintf(stderr, "CUDA Plugin EP failed to obtain any compatible ONNX Runtime API from OrtApiBase.\n");
       std::abort();
     }
 

--- a/onnxruntime/core/providers/cuda/plugin/cuda_plugin_ep.cc
+++ b/onnxruntime/core/providers/cuda/plugin/cuda_plugin_ep.cc
@@ -5,6 +5,9 @@
 // Exports CreateEpFactories() and ReleaseEpFactory() as the
 // public interface for ORT to load and use the CUDA EP as a plugin.
 
+#include <cstdio>
+#include <cstdlib>
+
 #include "onnxruntime_cxx_api.h"
 
 #include "cuda_ep_factory.h"
@@ -34,11 +37,12 @@ EXPORT_SYMBOL OrtStatus* CreateEpFactories(
   if (ort_api == nullptr) {
     const OrtApi* fallback_api = ort_api_base->GetApi(1);
     if (fallback_api == nullptr) {
-      return nullptr;
+      fprintf(stderr, "CUDA Plugin EP requires ONNX Runtime API version 26 or newer (ORT 1.26+).\n");
+      std::abort();
     }
 
     return fallback_api->CreateStatus(
-        ORT_INVALID_ARGUMENT,
+        ORT_FAIL,
         "CUDA Plugin EP requires ONNX Runtime API version 26 or newer (ORT 1.26+).");
   }
 

--- a/onnxruntime/core/providers/cuda/plugin/cuda_plugin_ep.cc
+++ b/onnxruntime/core/providers/cuda/plugin/cuda_plugin_ep.cc
@@ -26,7 +26,7 @@ EXPORT_SYMBOL OrtStatus* CreateEpFactories(
     OrtEpFactory** factories,
     size_t max_factories,
     size_t* num_factories) {
-  const OrtApi* ort_api = ort_api_base->GetApi(ORT_API_VERSION);
+  const OrtApi* ort_api = ort_api_base->GetApi(kCudaPluginEpMinOrtApiVersion);
   const OrtEpApi* ep_api = ort_api->GetEpApi();
 
   // Initialize the C++ API FIRST before any C++ wrapper usage

--- a/onnxruntime/core/providers/cuda/plugin/cuda_plugin_ep.cc
+++ b/onnxruntime/core/providers/cuda/plugin/cuda_plugin_ep.cc
@@ -19,7 +19,7 @@
 #endif
 
 namespace {
-constexpr uint32_t kOrtApiV1 = 1;
+constexpr uint32_t kMinCreateStatusOrtApiVersion = 1;
 }
 
 extern "C" {
@@ -39,7 +39,7 @@ EXPORT_SYMBOL OrtStatus* CreateEpFactories(
 
   const OrtApi* ort_api = ort_api_base->GetApi(kCudaPluginEpMinOrtApiVersion);
   if (ort_api == nullptr) {
-    const OrtApi* fallback_api = ort_api_base->GetApi(kOrtApiV1);
+    const OrtApi* fallback_api = ort_api_base->GetApi(kMinCreateStatusOrtApiVersion);
     if (fallback_api == nullptr) {
       // Critical failure path: no compatible API available to even construct an OrtStatus.
       fprintf(stderr, "CUDA Plugin EP requires ONNX Runtime API version 26 or newer (ORT 1.26+).\n");

--- a/onnxruntime/core/providers/cuda/plugin/cuda_plugin_ep.cc
+++ b/onnxruntime/core/providers/cuda/plugin/cuda_plugin_ep.cc
@@ -19,7 +19,7 @@
 #endif
 
 namespace {
-constexpr uint32_t kMinOrtApiVersionForCreateStatus = 1;
+constexpr uint32_t kFallbackOrtApiVersion = 1;
 }
 
 extern "C" {
@@ -40,10 +40,11 @@ EXPORT_SYMBOL OrtStatus* CreateEpFactories(
   const OrtApi* ort_api = ort_api_base->GetApi(kCudaPluginEpMinOrtApiVersion);
   if (ort_api == nullptr) {
     // Use API v1 only to construct an OrtStatus that explains the API v26 requirement.
-    const OrtApi* fallback_api = ort_api_base->GetApi(kMinOrtApiVersionForCreateStatus);
+    const OrtApi* fallback_api = ort_api_base->GetApi(kFallbackOrtApiVersion);
     if (fallback_api == nullptr) {
       // Critical failure path: no compatible API available to even construct an OrtStatus.
-      fprintf(stderr, "CUDA Plugin EP failed to obtain any compatible ONNX Runtime API from OrtApiBase.\n");
+      fprintf(stderr, "CUDA Plugin EP requires ONNX Runtime API version 26+ but could not obtain any compatible "
+                      "API from OrtApiBase (fallback API v1 unavailable).\n");
       std::abort();
     }
 

--- a/onnxruntime/core/providers/cuda/plugin/cuda_plugin_ep.cc
+++ b/onnxruntime/core/providers/cuda/plugin/cuda_plugin_ep.cc
@@ -43,8 +43,9 @@ EXPORT_SYMBOL OrtStatus* CreateEpFactories(
     const OrtApi* fallback_api = ort_api_base->GetApi(kFallbackOrtApiVersion);
     if (fallback_api == nullptr) {
       // Critical failure path: no compatible API available to even construct an OrtStatus.
-      fprintf(stderr, "CUDA Plugin EP requires ONNX Runtime API version 26+ but could not obtain any compatible "
-                      "API from OrtApiBase (fallback API v1 unavailable).\n");
+      fprintf(stderr,
+              "CUDA Plugin EP requires ONNX Runtime API version 26+ but could not obtain any compatible "
+              "API from OrtApiBase (fallback API v1 unavailable).\n");
       std::abort();
     }
 

--- a/onnxruntime/core/providers/cuda/plugin/cuda_plugin_ep.cc
+++ b/onnxruntime/core/providers/cuda/plugin/cuda_plugin_ep.cc
@@ -26,7 +26,22 @@ EXPORT_SYMBOL OrtStatus* CreateEpFactories(
     OrtEpFactory** factories,
     size_t max_factories,
     size_t* num_factories) {
+  if (ort_api_base == nullptr) {
+    return nullptr;
+  }
+
   const OrtApi* ort_api = ort_api_base->GetApi(kCudaPluginEpMinOrtApiVersion);
+  if (ort_api == nullptr) {
+    const OrtApi* fallback_api = ort_api_base->GetApi(1);
+    if (fallback_api == nullptr) {
+      return nullptr;
+    }
+
+    return fallback_api->CreateStatus(
+        ORT_INVALID_ARGUMENT,
+        "CUDA Plugin EP requires ONNX Runtime API version 26 or newer (ORT 1.26+).");
+  }
+
   const OrtEpApi* ep_api = ort_api->GetEpApi();
 
   // Initialize the C++ API FIRST before any C++ wrapper usage

--- a/onnxruntime/core/providers/cuda/plugin/cuda_plugin_ep.cc
+++ b/onnxruntime/core/providers/cuda/plugin/cuda_plugin_ep.cc
@@ -18,6 +18,10 @@
 #define EXPORT_SYMBOL
 #endif
 
+namespace {
+constexpr uint32_t kOrtApiV1 = 1;
+}
+
 extern "C" {
 
 /// Create the CUDA EP factory instances.
@@ -35,8 +39,9 @@ EXPORT_SYMBOL OrtStatus* CreateEpFactories(
 
   const OrtApi* ort_api = ort_api_base->GetApi(kCudaPluginEpMinOrtApiVersion);
   if (ort_api == nullptr) {
-    const OrtApi* fallback_api = ort_api_base->GetApi(1);
+    const OrtApi* fallback_api = ort_api_base->GetApi(kOrtApiV1);
     if (fallback_api == nullptr) {
+      // Critical failure path: no compatible API available to even construct an OrtStatus.
       fprintf(stderr, "CUDA Plugin EP requires ONNX Runtime API version 26 or newer (ORT 1.26+).\n");
       std::abort();
     }

--- a/onnxruntime/core/providers/cuda/plugin/cuda_plugin_utils.h
+++ b/onnxruntime/core/providers/cuda/plugin/cuda_plugin_utils.h
@@ -11,6 +11,12 @@
 
 #include "core/common/common.h"
 
+// The minimum ORT API version required by the CUDA plugin EP.
+// This matches MIN_ONNXRUNTIME_VERSION (1.26.0) and must be used in GetApi()
+// and ort_version_supported so that the plugin is compatible with ORT 1.26+
+// without requesting v27-only OrtApi entries that ORT 1.26 does not provide.
+static constexpr uint32_t kCudaPluginEpMinOrtApiVersion = 26;
+
 #include <cuda_runtime_api.h>
 #include <cublas_v2.h>
 #include <cudnn.h>

--- a/onnxruntime/core/providers/cuda/plugin/cuda_profiler_plugin.cc
+++ b/onnxruntime/core/providers/cuda/plugin/cuda_profiler_plugin.cc
@@ -14,7 +14,7 @@ namespace cuda_plugin {
 
 CudaPluginEpProfiler::CudaPluginEpProfiler(const OrtEpApi& api)
     : OrtEpProfilerImpl{}, ep_api(api) {
-  ort_version_supported = ORT_API_VERSION;
+  ort_version_supported = kCudaPluginEpMinOrtApiVersion;
   Release = ReleaseImpl;
   StartProfiling = StartProfilingImpl;
   EndProfiling = EndProfilingImpl;

--- a/onnxruntime/core/providers/cuda/plugin/cuda_stream_plugin.cc
+++ b/onnxruntime/core/providers/cuda/plugin/cuda_stream_plugin.cc
@@ -44,7 +44,7 @@ CudaSyncStream::CudaSyncStream(CudaEpFactory& factory, int device_id,
     : OrtSyncStreamImpl{},
       factory_(factory),
       device_id_(device_id) {
-  ort_version_supported = ORT_API_VERSION;
+  ort_version_supported = kCudaPluginEpMinOrtApiVersion;
   GetHandle = GetHandleImpl;
   CreateNotification = CreateNotificationImpl;
   Flush = FlushImpl;
@@ -313,7 +313,7 @@ OrtStatus* CudaSyncStream::CleanupDeferredCPUBuffers() noexcept {
 CudaSyncNotification::CudaSyncNotification(CudaSyncStream& stream)
     : OrtSyncNotificationImpl{},
       stream_(stream) {
-  ort_version_supported = ORT_API_VERSION;
+  ort_version_supported = kCudaPluginEpMinOrtApiVersion;
   Activate = ActivateImpl;
   WaitOnDevice = WaitOnDeviceImpl;
   WaitOnHost = WaitOnHostImpl;

--- a/plugin-ep-cuda/python/test/test_cuda_plugin_ep.py
+++ b/plugin-ep-cuda/python/test/test_cuda_plugin_ep.py
@@ -16,7 +16,18 @@ import platform
 import sys
 import tempfile
 import traceback
+from contextlib import suppress
 from pathlib import Path
+
+# On Windows, Python 3.8+ no longer searches PATH when loading DLLs. Add each
+# PATH entry explicitly so that CUDA and cuDNN libraries placed there (e.g. via
+# ##vso[task.prependpath] in Azure Pipelines) are visible to LoadLibraryExW
+# when ORT loads the CUDA plugin EP shared library.
+if sys.platform == "win32" and sys.version_info >= (3, 8):
+    for _path_entry in os.environ.get("PATH", "").split(os.pathsep):
+        if _path_entry and os.path.isdir(_path_entry):
+            with suppress(OSError):
+                os.add_dll_directory(_path_entry)
 
 import numpy as np
 import onnx

--- a/plugin-ep-cuda/python/test/test_cuda_plugin_ep.py
+++ b/plugin-ep-cuda/python/test/test_cuda_plugin_ep.py
@@ -25,7 +25,7 @@ from pathlib import Path
 # when ORT loads the CUDA plugin EP shared library.
 if sys.platform == "win32" and sys.version_info >= (3, 8):
     for _path_entry in os.environ.get("PATH", "").split(os.pathsep):
-        _normalized_path_entry = _path_entry.strip().strip('"')
+        _normalized_path_entry = _path_entry.strip().strip('"').strip("'")
         if _normalized_path_entry and os.path.isdir(_normalized_path_entry):
             with suppress(OSError):
                 os.add_dll_directory(_normalized_path_entry)

--- a/plugin-ep-cuda/python/test/test_cuda_plugin_ep.py
+++ b/plugin-ep-cuda/python/test/test_cuda_plugin_ep.py
@@ -25,9 +25,10 @@ from pathlib import Path
 # when ORT loads the CUDA plugin EP shared library.
 if sys.platform == "win32" and sys.version_info >= (3, 8):
     for _path_entry in os.environ.get("PATH", "").split(os.pathsep):
-        if _path_entry and os.path.isdir(_path_entry):
+        _normalized_path_entry = _path_entry.strip().strip('"')
+        if _normalized_path_entry and os.path.isdir(_normalized_path_entry):
             with suppress(OSError):
-                os.add_dll_directory(_path_entry)
+                os.add_dll_directory(_normalized_path_entry)
 
 import numpy as np
 import onnx

--- a/tools/ci_build/github/azure-pipelines/plugin-cuda-test-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/plugin-cuda-test-pipeline.yml
@@ -38,14 +38,6 @@ parameters:
   type: boolean
   default: true
 
-- name: cuda_version
-  displayName: 'CUDA Version'
-  type: string
-  default: '12.8'
-  values:
-  - '12.8'
-  - '13.0'
-
 extends:
   # The pipeline extends the 1ES PT which will inject SDL and compliance
   # tasks. Uses "Official" to stay consistent with the companion
@@ -84,15 +76,7 @@ extends:
       # Windows x64
       - ${{ if eq(parameters.test_windows_x64, true) }}:
         - template: stages/plugin-win-cuda-test-stage.yml
-          parameters:
-            cuda_version: ${{ parameters.cuda_version }}
 
       # Linux x64
       - ${{ if eq(parameters.test_linux_x64, true) }}:
         - template: stages/plugin-linux-cuda-test-stage.yml
-          parameters:
-            cuda_version: ${{ parameters.cuda_version }}
-            ${{ if eq(parameters.cuda_version, '12.8') }}:
-              docker_base_image: 'onnxruntimebuildcache.azurecr.io/internal/azureml/onnxruntime/build/cuda12_x64_almalinux8_gcc14:20251017.1'
-            ${{ if eq(parameters.cuda_version, '13.0') }}:
-              docker_base_image: 'onnxruntimebuildcache.azurecr.io/internal/azureml/onnxruntime/build/cuda13_x64_almalinux8_gcc14:20251107.1'

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-cuda-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-cuda-packaging-stage.yml
@@ -72,6 +72,44 @@ parameters:
   default: ''
 
 stages:
+    # Publish a stable metadata artifact so downstream test pipelines can discover
+    # the CUDA version and artifact names from the selected packaging run.
+    - stage: CUDA_Plugin_Metadata
+      displayName: 'CUDA Plugin Metadata'
+      dependsOn: []
+      jobs:
+      - job: Publish_CUDA_Plugin_Metadata
+        displayName: 'Publish CUDA plugin metadata'
+        timeoutInMinutes: 5
+        workspace:
+          clean: all
+        templateContext:
+          outputs:
+          - output: pipelineArtifact
+            targetPath: '$(Build.ArtifactStagingDirectory)\metadata'
+            artifactName: cuda_plugin_metadata
+        steps:
+        - checkout: none
+
+        - pwsh: |
+            $ErrorActionPreference = 'Stop'
+
+            $metadataDir = '$(Build.ArtifactStagingDirectory)\metadata'
+            New-Item -ItemType Directory -Path $metadataDir -Force | Out-Null
+
+            $metadata = [ordered]@{
+              cuda_version = '${{ parameters.cuda_version }}'
+              cuda_version_no_dot = '${{ replace(parameters.cuda_version, '.', '') }}'
+              docker_base_image_linux_x64 = '${{ parameters.docker_base_image }}'
+              python_artifact_linux_x64 = 'cuda_plugin_python_linux_x64_cuda${{ replace(parameters.cuda_version, '.', '') }}'
+              python_artifact_win_x64 = 'cuda_plugin_python_win_x64_cuda${{ replace(parameters.cuda_version, '.', '') }}'
+              nuget_artifact = 'cuda_plugin_nuget'
+            }
+
+            $metadata | ConvertTo-Json | Set-Content -Path "$metadataDir\metadata.json" -Encoding UTF8
+            Get-Content "$metadataDir\metadata.json"
+          displayName: 'Create metadata.json'
+
     # Windows x64
     - ${{ if eq(parameters.build_windows_x64, true) }}:
       - template: plugin-win-cuda-stage.yml

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-cuda-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-cuda-packaging-stage.yml
@@ -119,43 +119,6 @@ stages:
           docker_python_exe_path: ${{ parameters.docker_python_exe_path }}
           artifact_name: cuda_plugin_linux_aarch64
 
-    # Merge Linux x64 and aarch64 artifacts into a single combined artifact
-    - ${{ if or(eq(parameters.build_linux_x64, true), eq(parameters.build_linux_aarch64, true)) }}:
-      - stage: Linux_plugin_cuda_Merge_Artifacts
-        dependsOn:
-        - ${{ if eq(parameters.build_linux_x64, true) }}:
-          - Linux_plugin_cuda_x64
-        - ${{ if eq(parameters.build_linux_aarch64, true) }}:
-          - Linux_plugin_cuda_aarch64
-        jobs:
-        - job: Linux_plugin_cuda_Merge_Artifacts
-          workspace:
-            clean: all
-          pool:
-            name: 'onnxruntime-Ubuntu2204-AMD-CPU'
-            os: linux
-          templateContext:
-            outputs:
-            - output: pipelineArtifact
-              targetPath: $(Build.ArtifactStagingDirectory)/cuda_plugin
-              artifactName: cuda_plugin_linux
-          steps:
-          - checkout: none
-
-          - ${{ if eq(parameters.build_linux_x64, true) }}:
-            - task: DownloadPipelineArtifact@2
-              displayName: 'Download - x64'
-              inputs:
-                artifact: cuda_plugin_linux_x64
-                targetPath: $(Build.ArtifactStagingDirectory)/cuda_plugin/x64
-
-          - ${{ if eq(parameters.build_linux_aarch64, true) }}:
-            - task: DownloadPipelineArtifact@2
-              displayName: 'Download - aarch64'
-              inputs:
-                artifact: cuda_plugin_linux_aarch64
-                targetPath: $(Build.ArtifactStagingDirectory)/cuda_plugin/aarch64
-
     # NuGet packaging (runs after all platform builds)
     - template: plugin-cuda-nuget-packaging-stage.yml
       parameters:

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-cuda-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-cuda-packaging-stage.yml
@@ -86,7 +86,7 @@ stages:
         templateContext:
           outputs:
           - output: pipelineArtifact
-            targetPath: '$(Build.ArtifactStagingDirectory)\metadata'
+            targetPath: '$(Build.ArtifactStagingDirectory)/metadata'
             artifactName: cuda_plugin_metadata
         steps:
         - checkout: none
@@ -94,7 +94,8 @@ stages:
         - pwsh: |
             $ErrorActionPreference = 'Stop'
 
-            $metadataDir = '$(Build.ArtifactStagingDirectory)\metadata'
+            $metadataDir = Join-Path '$(Build.ArtifactStagingDirectory)' 'metadata'
+            $metadataPath = Join-Path $metadataDir 'metadata.json'
             New-Item -ItemType Directory -Path $metadataDir -Force | Out-Null
 
             $metadata = [ordered]@{
@@ -106,8 +107,8 @@ stages:
               nuget_artifact = 'cuda_plugin_nuget'
             }
 
-            $metadata | ConvertTo-Json | Set-Content -Path "$metadataDir\metadata.json" -Encoding UTF8
-            Get-Content "$metadataDir\metadata.json"
+            $metadata | ConvertTo-Json | Set-Content -Path $metadataPath -Encoding UTF8
+            Get-Content $metadataPath
           displayName: 'Create metadata.json'
 
     # Windows x64

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-linux-cuda-test-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-linux-cuda-test-stage.yml
@@ -33,7 +33,12 @@ stages:
       parameters:
         Dockerfile: tools/ci_build/github/linux/docker/Dockerfile.manylinux2_28_cuda
         Context: tools/ci_build/github/linux/docker
-        DockerBuildArgs: "--network host --build-arg BASEIMAGE=${{ parameters.docker_base_image }} --build-arg TRT_VERSION= --build-arg BUILD_UID=$( id -u )"
+        DockerBuildArgs: >-
+          --network=host
+          --secret id=PIP_INDEX_URL
+          --build-arg BASEIMAGE=${{ parameters.docker_base_image }}
+          --build-arg TRT_VERSION=
+          --build-arg BUILD_UID=$( id -u )
         Repository: onnxruntimecuda${{ replace(parameters.cuda_version, '.', '') }}plugintestx64
 
     # Download the Python wheel produced by the packaging pipeline run that

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-linux-cuda-test-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-linux-cuda-test-stage.yml
@@ -3,14 +3,6 @@ parameters:
   type: string
   default: 'Onnxruntime-Linux-GPU-A10'
 
-- name: cuda_version
-  type: string
-  default: '12.8'
-
-- name: docker_base_image
-  type: string
-  default: 'onnxruntimebuildcache.azurecr.io/internal/azureml/onnxruntime/build/cuda12_x64_almalinux8_gcc14:20251017.1'
-
 stages:
 - stage: Linux_plugin_cuda_x64_Test
   dependsOn: []
@@ -29,6 +21,8 @@ stages:
 
     - template: ../templates/setup-feeds-and-python-steps.yml
 
+    - template: ../templates/read-cuda-plugin-metadata-steps.yml
+
     - template: ../templates/get-docker-image-steps.yml
       parameters:
         Dockerfile: tools/ci_build/github/linux/docker/Dockerfile.manylinux2_28_cuda
@@ -36,21 +30,21 @@ stages:
         DockerBuildArgs: >-
           --network=host
           --secret id=PIP_INDEX_URL
-          --build-arg BASEIMAGE=${{ parameters.docker_base_image }}
+          --build-arg BASEIMAGE=$(CudaDockerBaseImage)
           --build-arg TRT_VERSION=
           --build-arg BUILD_UID=$( id -u )
-        Repository: onnxruntimecuda${{ replace(parameters.cuda_version, '.', '') }}plugintestx64
+        Repository: onnxruntimecuda$(CudaVersionNoDot)plugintestx64
 
     # Download the Python wheel produced by the packaging pipeline run that
     # triggered this pipeline (or that was selected at queue time).
     - download: build
-      artifact: cuda_plugin_python_linux_x64_cuda${{ replace(parameters.cuda_version, '.', '') }}
+      artifact: $(CudaPluginPythonLinuxArtifactName)
       displayName: 'Download Python wheel'
 
     - script: |
         set -e -x
         mkdir -p "$(Build.BinariesDirectory)/python_wheel"
-        cp -R "$(Pipeline.Workspace)/build/cuda_plugin_python_linux_x64_cuda${{ replace(parameters.cuda_version, '.', '') }}/"* "$(Build.BinariesDirectory)/python_wheel/"
+        cp -R "$(Pipeline.Workspace)/build/$(CudaPluginPythonLinuxArtifactName)/"* "$(Build.BinariesDirectory)/python_wheel/"
       displayName: 'Stage Python wheel for test container'
 
     - script: |
@@ -61,7 +55,7 @@ stages:
           --env PIP_INDEX_URL \
           --env "NVIDIA_VISIBLE_DEVICES=all" \
           --env "ORT_TEST_VERBOSE=$(System.Debug)" \
-          onnxruntimecuda${{ replace(parameters.cuda_version, '.', '') }}plugintestx64 \
+          onnxruntimecuda$(CudaVersionNoDot)plugintestx64 \
           /bin/bash -c "
             set -e -x
             python3 -m venv /build/test_venv

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-win-cuda-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-win-cuda-stage.yml
@@ -113,7 +113,7 @@ stages:
             scriptLocation: 'inlineScript'
             inlineScript: |
               set AZCOPY_AUTO_LOGIN_TYPE=AZCLI
-              azcopy.exe cp --recursive https://lotusscus.blob.core.windows.net/models/cudnn_sdk/9.14.0.64_cuda13 "$(Agent.TempDirectory)"
+              azcopy.exe cp --recursive https://lotusscus.blob.core.windows.net/models/cudnn_sdk/$(cuda13_cudnn_folder) "$(Agent.TempDirectory)"
 
       # CUDA 12.x build (no separate cuDNN)
       - ${{ if ne(parameters.cuda_version, '13.0') }}:
@@ -162,7 +162,7 @@ stages:
               --build
               --use_cuda
               --cuda_home="$(Agent.TempDirectory)\v${{ parameters.cuda_version }}"
-              --cudnn_home="$(Agent.TempDirectory)\9.14.0.64_cuda13"
+              --cudnn_home="$(Agent.TempDirectory)\$(cuda13_cudnn_folder)"
               --skip_tests
               --cmake_extra_defines CMAKE_CUDA_ARCHITECTURES="${{ parameters.cmake_cuda_archs }}"
               --cmake_extra_defines onnxruntime_BUILD_CUDA_EP_AS_PLUGIN=ON

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-win-cuda-test-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-win-cuda-test-stage.yml
@@ -1,8 +1,3 @@
-parameters:
-- name: cuda_version
-  type: string
-  default: '12.8'
-
 stages:
 - stage: Win_plugin_cuda_x64_Test
   dependsOn: []
@@ -23,46 +18,48 @@ stages:
 
     - template: ../templates/setup-feeds-and-python-steps.yml
 
+    - template: ../templates/read-cuda-plugin-metadata-steps.yml
+
     # Download the Python wheel produced by the packaging pipeline run that
     # triggered this pipeline (or that was selected at queue time).
     - download: build
-      artifact: cuda_plugin_python_win_x64_cuda${{ replace(parameters.cuda_version, '.', '') }}
+      artifact: $(CudaPluginPythonWinArtifactName)
       displayName: 'Download Python wheel'
 
     - task: AzureCLI@2
-      displayName: 'Download CUDA SDK v${{ parameters.cuda_version }}'
+      displayName: 'Download CUDA SDK v$(CudaVersion)'
       inputs:
         azureSubscription: AIInfraBuildOnnxRuntimeOSS
         scriptType: 'batch'
         scriptLocation: 'inlineScript'
         inlineScript: |
           set AZCOPY_AUTO_LOGIN_TYPE=AZCLI
-          azcopy.exe cp --recursive https://lotusscus.blob.core.windows.net/models/cuda_sdk/v${{ parameters.cuda_version }} "%AGENT_TEMPDIRECTORY%"
+          azcopy.exe cp --recursive https://lotusscus.blob.core.windows.net/models/cuda_sdk/v$(CudaVersion) "%AGENT_TEMPDIRECTORY%"
 
-    # Download cuDNN separately for CUDA 13.0
-    - ${{ if eq(parameters.cuda_version, '13.0') }}:
-      - task: AzureCLI@2
-        displayName: 'Download cuDNN for CUDA 13.0'
-        inputs:
-          azureSubscription: AIInfraBuildOnnxRuntimeOSS
-          scriptType: 'batch'
-          scriptLocation: 'inlineScript'
-          inlineScript: |
-            set AZCOPY_AUTO_LOGIN_TYPE=AZCLI
+    - task: AzureCLI@2
+      displayName: 'Download cuDNN if required'
+      inputs:
+        azureSubscription: AIInfraBuildOnnxRuntimeOSS
+        scriptType: 'batch'
+        scriptLocation: 'inlineScript'
+        inlineScript: |
+          set AZCOPY_AUTO_LOGIN_TYPE=AZCLI
+          if "$(CudaVersion)"=="13.0" (
             azcopy.exe cp --recursive https://lotusscus.blob.core.windows.net/models/cudnn_sdk/$(cuda13_cudnn_folder) "%AGENT_TEMPDIRECTORY%"
+          ) else (
+            echo CUDA $(CudaVersion) does not require a separate cuDNN download.
+          )
 
     - powershell: |
         Write-Host "Adding CUDA to PATH"
-        Write-Host "##vso[task.prependpath]$env:AGENT_TEMPDIRECTORY\v${{ parameters.cuda_version }}\bin"
-        Write-Host "##vso[task.prependpath]$env:AGENT_TEMPDIRECTORY\v${{ parameters.cuda_version }}\bin\x64"
-        Write-Host "##vso[task.prependpath]$env:AGENT_TEMPDIRECTORY\v${{ parameters.cuda_version }}\extras\CUPTI\lib64"
-      displayName: 'Add CUDA to PATH'
-
-    - ${{ if eq(parameters.cuda_version, '13.0') }}:
-      - powershell: |
+        Write-Host "##vso[task.prependpath]$env:AGENT_TEMPDIRECTORY\v$(CudaVersion)\bin"
+        Write-Host "##vso[task.prependpath]$env:AGENT_TEMPDIRECTORY\v$(CudaVersion)\bin\x64"
+        Write-Host "##vso[task.prependpath]$env:AGENT_TEMPDIRECTORY\v$(CudaVersion)\extras\CUPTI\lib64"
+        if ('$(CudaVersion)' -eq '13.0') {
           Write-Host "Adding cuDNN to PATH"
           Write-Host "##vso[task.prependpath]$env:AGENT_TEMPDIRECTORY\$(cuda13_cudnn_folder)\bin"
-        displayName: 'Add cuDNN to PATH'
+        }
+      displayName: 'Add CUDA to PATH'
 
     - task: PowerShell@2
       displayName: 'Install and test Python package'
@@ -83,7 +80,7 @@ stages:
           echo "installing onnxruntime onnx numpy"
           python -m pip install onnxruntime onnx numpy
 
-          $wheelDir = "$env:PIPELINE_WORKSPACE\build\cuda_plugin_python_win_x64_cuda${{ replace(parameters.cuda_version, '.', '') }}"
+          $wheelDir = "$env:PIPELINE_WORKSPACE\build\$(CudaPluginPythonWinArtifactName)"
           $wheel = (Get-ChildItem "$wheelDir\onnxruntime*ep*cuda*.whl")[0]
           echo "installing $($wheel.Name)"
           python -m pip install $wheel.FullName
@@ -109,45 +106,47 @@ stages:
 
     - template: ../templates/setup-feeds-and-python-steps.yml
 
+    - template: ../templates/read-cuda-plugin-metadata-steps.yml
+
     - task: AzureCLI@2
-      displayName: 'Download CUDA SDK v${{ parameters.cuda_version }}'
+      displayName: 'Download CUDA SDK v$(CudaVersion)'
       inputs:
         azureSubscription: AIInfraBuildOnnxRuntimeOSS
         scriptType: 'batch'
         scriptLocation: 'inlineScript'
         inlineScript: |
           set AZCOPY_AUTO_LOGIN_TYPE=AZCLI
-          azcopy.exe cp --recursive https://lotusscus.blob.core.windows.net/models/cuda_sdk/v${{ parameters.cuda_version }} "%AGENT_TEMPDIRECTORY%"
+          azcopy.exe cp --recursive https://lotusscus.blob.core.windows.net/models/cuda_sdk/v$(CudaVersion) "%AGENT_TEMPDIRECTORY%"
 
-    # Download cuDNN separately for CUDA 13.0
-    - ${{ if eq(parameters.cuda_version, '13.0') }}:
-      - task: AzureCLI@2
-        displayName: 'Download cuDNN for CUDA 13.0'
-        inputs:
-          azureSubscription: AIInfraBuildOnnxRuntimeOSS
-          scriptType: 'batch'
-          scriptLocation: 'inlineScript'
-          inlineScript: |
-            set AZCOPY_AUTO_LOGIN_TYPE=AZCLI
+    - task: AzureCLI@2
+      displayName: 'Download cuDNN if required'
+      inputs:
+        azureSubscription: AIInfraBuildOnnxRuntimeOSS
+        scriptType: 'batch'
+        scriptLocation: 'inlineScript'
+        inlineScript: |
+          set AZCOPY_AUTO_LOGIN_TYPE=AZCLI
+          if "$(CudaVersion)"=="13.0" (
             azcopy.exe cp --recursive https://lotusscus.blob.core.windows.net/models/cudnn_sdk/$(cuda13_cudnn_folder) "%AGENT_TEMPDIRECTORY%"
+          ) else (
+            echo CUDA $(CudaVersion) does not require a separate cuDNN download.
+          )
 
     - powershell: |
         Write-Host "Adding CUDA to PATH"
-        Write-Host "##vso[task.prependpath]$env:AGENT_TEMPDIRECTORY\v${{ parameters.cuda_version }}\bin"
-        Write-Host "##vso[task.prependpath]$env:AGENT_TEMPDIRECTORY\v${{ parameters.cuda_version }}\bin\x64"
-        Write-Host "##vso[task.prependpath]$env:AGENT_TEMPDIRECTORY\v${{ parameters.cuda_version }}\extras\CUPTI\lib64"
-      displayName: 'Add CUDA to PATH'
-
-    - ${{ if eq(parameters.cuda_version, '13.0') }}:
-      - powershell: |
+        Write-Host "##vso[task.prependpath]$env:AGENT_TEMPDIRECTORY\v$(CudaVersion)\bin"
+        Write-Host "##vso[task.prependpath]$env:AGENT_TEMPDIRECTORY\v$(CudaVersion)\bin\x64"
+        Write-Host "##vso[task.prependpath]$env:AGENT_TEMPDIRECTORY\v$(CudaVersion)\extras\CUPTI\lib64"
+        if ('$(CudaVersion)' -eq '13.0') {
           Write-Host "Adding cuDNN to PATH"
           Write-Host "##vso[task.prependpath]$env:AGENT_TEMPDIRECTORY\$(cuda13_cudnn_folder)\bin"
-        displayName: 'Add cuDNN to PATH'
+        }
+      displayName: 'Add CUDA to PATH'
 
     # Download the NuGet package produced by the packaging pipeline run that
     # triggered this pipeline (or that was selected at queue time).
     - download: build
-      artifact: cuda_plugin_nuget
+      artifact: $(CudaPluginNuGetArtifactName)
       displayName: 'Download NuGet package'
 
     # Set up local NuGet feed and extract the package version from the .nupkg filename
@@ -158,10 +157,10 @@ stages:
         New-Item -ItemType Directory -Path $localFeedDir -Force | Out-Null
 
         # Locate the .nupkg.
-        $nupkg = Get-ChildItem "$(Pipeline.Workspace)\build\cuda_plugin_nuget\Microsoft.ML.OnnxRuntime.EP.Cuda.*.nupkg" |
+        $nupkg = Get-ChildItem "$(Pipeline.Workspace)\build\$(CudaPluginNuGetArtifactName)\Microsoft.ML.OnnxRuntime.EP.Cuda.*.nupkg" |
                  Select-Object -First 1
         if (-not $nupkg) {
-            throw "No matching .nupkg found under $(Pipeline.Workspace)\build\cuda_plugin_nuget"
+          throw "No matching .nupkg found under $(Pipeline.Workspace)\build\$(CudaPluginNuGetArtifactName)"
         }
         Copy-Item $nupkg.FullName $localFeedDir -Force
 

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-win-cuda-test-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-win-cuda-test-stage.yml
@@ -14,6 +14,8 @@ stages:
     pool:
       name: onnxruntime-Win2022-GPU-A10
       os: windows
+    variables:
+    - template: ../templates/common-variables.yml
     steps:
     - checkout: self
       clean: true
@@ -47,7 +49,7 @@ stages:
           scriptLocation: 'inlineScript'
           inlineScript: |
             set AZCOPY_AUTO_LOGIN_TYPE=AZCLI
-            azcopy.exe cp --recursive https://lotusscus.blob.core.windows.net/models/cudnn_sdk/9.14.0.64_cuda13 "%AGENT_TEMPDIRECTORY%"
+            azcopy.exe cp --recursive https://lotusscus.blob.core.windows.net/models/cudnn_sdk/$(cuda13_cudnn_folder) "%AGENT_TEMPDIRECTORY%"
 
     - powershell: |
         Write-Host "Adding CUDA to PATH"
@@ -59,7 +61,7 @@ stages:
     - ${{ if eq(parameters.cuda_version, '13.0') }}:
       - powershell: |
           Write-Host "Adding cuDNN to PATH"
-          Write-Host "##vso[task.prependpath]$env:AGENT_TEMPDIRECTORY\9.14.0.64_cuda13\bin"
+          Write-Host "##vso[task.prependpath]$env:AGENT_TEMPDIRECTORY\$(cuda13_cudnn_folder)\bin"
         displayName: 'Add cuDNN to PATH'
 
     - task: PowerShell@2
@@ -98,7 +100,9 @@ stages:
       name: onnxruntime-Win2022-GPU-A10
       os: windows
     variables:
-      CudaTestProject: '$(Build.SourcesDirectory)\plugin-ep-cuda\csharp\test\CudaEpNuGetTest\CudaEpNuGetTest.csproj'
+    - template: ../templates/common-variables.yml
+    - name: CudaTestProject
+      value: '$(Build.SourcesDirectory)\plugin-ep-cuda\csharp\test\CudaEpNuGetTest\CudaEpNuGetTest.csproj'
     steps:
     - checkout: self
       submodules: none
@@ -125,7 +129,7 @@ stages:
           scriptLocation: 'inlineScript'
           inlineScript: |
             set AZCOPY_AUTO_LOGIN_TYPE=AZCLI
-            azcopy.exe cp --recursive https://lotusscus.blob.core.windows.net/models/cudnn_sdk/9.14.0.64_cuda13 "%AGENT_TEMPDIRECTORY%"
+            azcopy.exe cp --recursive https://lotusscus.blob.core.windows.net/models/cudnn_sdk/$(cuda13_cudnn_folder) "%AGENT_TEMPDIRECTORY%"
 
     - powershell: |
         Write-Host "Adding CUDA to PATH"
@@ -137,7 +141,7 @@ stages:
     - ${{ if eq(parameters.cuda_version, '13.0') }}:
       - powershell: |
           Write-Host "Adding cuDNN to PATH"
-          Write-Host "##vso[task.prependpath]$env:AGENT_TEMPDIRECTORY\9.14.0.64_cuda13\bin"
+          Write-Host "##vso[task.prependpath]$env:AGENT_TEMPDIRECTORY\$(cuda13_cudnn_folder)\bin"
         displayName: 'Add cuDNN to PATH'
 
     # Download the NuGet package produced by the packaging pipeline run that

--- a/tools/ci_build/github/azure-pipelines/templates/common-variables.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/common-variables.yml
@@ -1,4 +1,5 @@
 variables:
+  cuda13_cudnn_folder: '9.14.0.64_cuda13'
   cuda12_trt_version: '10.14.1.48'
   cuda13_trt_version: '10.14.1.48'
   aarch64_trt_version: '10.15.1.29'

--- a/tools/ci_build/github/azure-pipelines/templates/read-cuda-plugin-metadata-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/read-cuda-plugin-metadata-steps.yml
@@ -1,0 +1,45 @@
+steps:
+- download: build
+  artifact: cuda_plugin_metadata
+  displayName: 'Download CUDA plugin metadata'
+
+- task: PowerShell@2
+  displayName: 'Read CUDA plugin metadata'
+  inputs:
+    targetType: inline
+    pwsh: true
+    script: |
+      $ErrorActionPreference = 'Stop'
+
+      $metadataPath = Join-Path $env:PIPELINE_WORKSPACE 'build/cuda_plugin_metadata/metadata.json'
+      if (-not (Test-Path $metadataPath)) {
+        throw "CUDA plugin metadata not found at $metadataPath"
+      }
+
+      $metadata = Get-Content $metadataPath -Raw | ConvertFrom-Json
+
+      $requiredProperties = @(
+        'cuda_version',
+        'cuda_version_no_dot',
+        'docker_base_image_linux_x64',
+        'python_artifact_linux_x64',
+        'python_artifact_win_x64',
+        'nuget_artifact'
+      )
+
+      foreach ($property in $requiredProperties) {
+        if (-not $metadata.PSObject.Properties.Name.Contains($property) -or [string]::IsNullOrWhiteSpace($metadata.$property)) {
+          throw "CUDA plugin metadata is missing required property '$property'."
+        }
+      }
+
+      Write-Host "Detected CUDA version: $($metadata.cuda_version)"
+      Write-Host "Linux Python artifact: $($metadata.python_artifact_linux_x64)"
+      Write-Host "Windows Python artifact: $($metadata.python_artifact_win_x64)"
+
+      Write-Host "##vso[task.setvariable variable=CudaVersion]$($metadata.cuda_version)"
+      Write-Host "##vso[task.setvariable variable=CudaVersionNoDot]$($metadata.cuda_version_no_dot)"
+      Write-Host "##vso[task.setvariable variable=CudaDockerBaseImage]$($metadata.docker_base_image_linux_x64)"
+      Write-Host "##vso[task.setvariable variable=CudaPluginPythonLinuxArtifactName]$($metadata.python_artifact_linux_x64)"
+      Write-Host "##vso[task.setvariable variable=CudaPluginPythonWinArtifactName]$($metadata.python_artifact_win_x64)"
+      Write-Host "##vso[task.setvariable variable=CudaPluginNuGetArtifactName]$($metadata.nuget_artifact)"


### PR DESCRIPTION
## Summary
- Fix CUDA plugin EP compatibility by requesting the minimum supported ORT API version instead of the build-time ORT API version.
- Make the CUDA plugin Python test load CUDA/cuDNN DLL directories from PATH on Windows.
- Simplify CUDA plugin packaging/test pipeline artifacts and let test jobs discover the packaging CUDA version from a published metadata artifact.

## Details
- Publish cuda_plugin_metadata/metadata.json from the CUDA plugin packaging pipeline with the CUDA version, Docker base image, and expected wheel/NuGet artifact names.
- Remove the manual cuda_version parameter from the CUDA plugin test pipeline so the selected packaging run is the source of truth.
- Read metadata in Windows and Linux test jobs before downloading artifacts, building the Linux test container, or installing CUDA/cuDNN.
- Centralize the CUDA 13 cuDNN folder in common pipeline variables.

## Testing
- test job is green: https://aiinfra.visualstudio.com/Lotus/_build/results?buildId=1212157&view=results
