### PR TITLE
[WebGPU Plugin EP] Packaging pipelines minor updates

### DIFF
--- a/tools/ci_build/github/azure-pipelines/plugin-webgpu-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/plugin-webgpu-pipeline.yml
@@ -6,7 +6,7 @@
 trigger: none
 
 schedules:
-- cron: '0 17 * * *'  # Daily at 17:00 UTC
+- cron: '0 9 * * *'  # Daily at 09:00 UTC
   displayName: Nightly build
   branches:
     include:

--- a/tools/ci_build/github/azure-pipelines/plugin-webgpu-test-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/plugin-webgpu-test-pipeline.yml
@@ -20,7 +20,7 @@ variables:
 resources:
   pipelines:
   - pipeline: build
-    source: 'WebGPU Plugin EP Packaging Pipeline'
+    source: 'Plugin\WebGPU Plugin EP Packaging Pipeline'
     trigger: true
   repositories:
   - repository: 1esPipelines


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Minor updates to WebGPU plugin EP packaging pipelines:
- Update scheduled trigger time to 0900 UTC. Intent is to reduce build resource contention with daily development.
- Update packaging test pipeline's source pipeline name to reflect the updated packaging pipeline path. WebGPU plugin EP pipelines were moved to the "Plugin" folder.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Packaging pipeline updates.