### PR TITLE
Add EP and hardware device type to Windows ML telemetry

### DIFF
--- a/onnxruntime/core/platform/telemetry.cc
+++ b/onnxruntime/core/platform/telemetry.cc
@@ -62,6 +62,8 @@ void Telemetry::LogSessionCreation(uint32_t session_id, int64_t ir_version, cons
                                    const std::string& model_weight_hash,
                                    const std::unordered_map<std::string, std::string>& model_metadata,
                                    const std::string& loadedFrom, const std::vector<std::string>& execution_provider_ids,
+                                   const std::string& hardware_device_types,
+                                   const std::string& hardware_vendor_ids,
                                    bool use_fp16, bool captureState) const {
   ORT_UNUSED_PARAMETER(session_id);
   ORT_UNUSED_PARAMETER(ir_version);
@@ -77,6 +79,8 @@ void Telemetry::LogSessionCreation(uint32_t session_id, int64_t ir_version, cons
   ORT_UNUSED_PARAMETER(model_metadata);
   ORT_UNUSED_PARAMETER(loadedFrom);
   ORT_UNUSED_PARAMETER(execution_provider_ids);
+  ORT_UNUSED_PARAMETER(hardware_device_types);
+  ORT_UNUSED_PARAMETER(hardware_vendor_ids);
   ORT_UNUSED_PARAMETER(use_fp16);
   ORT_UNUSED_PARAMETER(captureState);
 }
@@ -126,6 +130,28 @@ void Telemetry::LogRuntimePerf(uint32_t session_id, uint32_t total_runs_since_la
   ORT_UNUSED_PARAMETER(total_runs_since_last);
   ORT_UNUSED_PARAMETER(total_run_duration_since_last);
   ORT_UNUSED_PARAMETER(duration_per_batch_size);
+}
+
+void Telemetry::LogEpDeviceUsage(uint32_t session_id,
+                                 const std::string& ep_type,
+                                 const std::string& hardware_device_type,
+                                 uint32_t hardware_vendor_id,
+                                 uint32_t hardware_device_id,
+                                 const std::string& hardware_vendor,
+                                 const std::string& ep_vendor,
+                                 int assigned_node_count,
+                                 uint32_t total_runs_since_last,
+                                 int64_t total_run_duration_since_last) const {
+  ORT_UNUSED_PARAMETER(session_id);
+  ORT_UNUSED_PARAMETER(ep_type);
+  ORT_UNUSED_PARAMETER(hardware_device_type);
+  ORT_UNUSED_PARAMETER(hardware_vendor_id);
+  ORT_UNUSED_PARAMETER(hardware_device_id);
+  ORT_UNUSED_PARAMETER(hardware_vendor);
+  ORT_UNUSED_PARAMETER(ep_vendor);
+  ORT_UNUSED_PARAMETER(assigned_node_count);
+  ORT_UNUSED_PARAMETER(total_runs_since_last);
+  ORT_UNUSED_PARAMETER(total_run_duration_since_last);
 }
 
 void Telemetry::LogExecutionProviderEvent(LUID* adapterLuid) const {

--- a/onnxruntime/core/platform/telemetry.h
+++ b/onnxruntime/core/platform/telemetry.h
@@ -64,6 +64,8 @@ class Telemetry {
                                   const std::string& model_weight_hash,
                                   const std::unordered_map<std::string, std::string>& model_metadata,
                                   const std::string& loadedFrom, const std::vector<std::string>& execution_provider_ids,
+                                  const std::string& hardware_device_types,
+                                  const std::string& hardware_vendor_ids,
                                   bool use_fp16, bool captureState) const;
 
   virtual void LogCompileModelStart(uint32_t session_id,
@@ -86,6 +88,21 @@ class Telemetry {
 
   virtual void LogRuntimePerf(uint32_t session_id, uint32_t total_runs_since_last, int64_t total_run_duration_since_last,
                               const std::unordered_map<int64_t, long long>& duration_per_batch_size) const;
+
+  // Emits one event per (Execution Provider, hardware device) pairing in use by a session.
+  // Designed for downstream `GROUP BY executionProviderType, hardwareDeviceType` analytics
+  // and is fully self-contained (no joins to SessionCreation required) so it works for
+  // long-lived sessions that span beyond the telemetry pipeline's join window.
+  virtual void LogEpDeviceUsage(uint32_t session_id,
+                                const std::string& ep_type,
+                                const std::string& hardware_device_type,
+                                uint32_t hardware_vendor_id,
+                                uint32_t hardware_device_id,
+                                const std::string& hardware_vendor,
+                                const std::string& ep_vendor,
+                                int assigned_node_count,
+                                uint32_t total_runs_since_last,
+                                int64_t total_run_duration_since_last) const;
 
   virtual void LogExecutionProviderEvent(LUID* adapterLuid) const;
 

--- a/onnxruntime/core/platform/windows/telemetry.cc
+++ b/onnxruntime/core/platform/windows/telemetry.cc
@@ -316,6 +316,8 @@ void WindowsTelemetry::LogSessionCreation(uint32_t session_id, int64_t ir_versio
                                           const std::string& model_weight_hash,
                                           const std::unordered_map<std::string, std::string>& model_metadata,
                                           const std::string& loaded_from, const std::vector<std::string>& execution_provider_ids,
+                                          const std::string& hardware_device_types,
+                                          const std::string& hardware_vendor_ids,
                                           bool use_fp16, bool captureState) const {
   if (global_register_count_ == 0 || enabled_ == false)
     return;
@@ -370,7 +372,8 @@ void WindowsTelemetry::LogSessionCreation(uint32_t session_id, int64_t ir_versio
                       TraceLoggingKeyword(static_cast<uint64_t>(onnxruntime::logging::ORTTraceLoggingKeyword::Session)),
                       TraceLoggingLevel(WINEVENT_LEVEL_INFO),
                       // Telemetry info
-                      TraceLoggingUInt8(0, "schemaVersion"),
+                      // schemaVersion 1: added hardwareDeviceTypes and hardwareVendorIds
+                      TraceLoggingUInt8(1, "schemaVersion"),
                       TraceLoggingUInt32(session_id, "sessionId"),
                       TraceLoggingInt64(ir_version, "irVersion"),
                       TraceLoggingUInt32(projection_, "OrtProgrammingProjection"),
@@ -387,6 +390,8 @@ void WindowsTelemetry::LogSessionCreation(uint32_t session_id, int64_t ir_versio
                       TraceLoggingString(model_metadata_string.c_str(), "modelMetaData"),
                       TraceLoggingString(loaded_from.c_str(), "loadedFrom"),
                       TraceLoggingString(execution_provider_string.c_str(), "executionProviderIds"),
+                      TraceLoggingString(hardware_device_types.c_str(), "hardwareDeviceTypes"),
+                      TraceLoggingString(hardware_vendor_ids.c_str(), "hardwareVendorIds"),
                       TraceLoggingString(service_names.c_str(), "serviceNames"),
                       TraceLoggingString(ORT_CALLER_FRAMEWORK, "frameworkName"));
   } else {
@@ -398,7 +403,8 @@ void WindowsTelemetry::LogSessionCreation(uint32_t session_id, int64_t ir_versio
                       TraceLoggingKeyword(static_cast<uint64_t>(onnxruntime::logging::ORTTraceLoggingKeyword::Session)),
                       TraceLoggingLevel(WINEVENT_LEVEL_INFO),
                       // Telemetry info
-                      TraceLoggingUInt8(0, "schemaVersion"),
+                      // schemaVersion 1: added hardwareDeviceTypes and hardwareVendorIds
+                      TraceLoggingUInt8(1, "schemaVersion"),
                       TraceLoggingUInt32(session_id, "sessionId"),
                       TraceLoggingInt64(ir_version, "irVersion"),
                       TraceLoggingUInt32(projection_, "OrtProgrammingProjection"),
@@ -415,6 +421,8 @@ void WindowsTelemetry::LogSessionCreation(uint32_t session_id, int64_t ir_versio
                       TraceLoggingString(model_metadata_string.c_str(), "modelMetaData"),
                       TraceLoggingString(loaded_from.c_str(), "loadedFrom"),
                       TraceLoggingString(execution_provider_string.c_str(), "executionProviderIds"),
+                      TraceLoggingString(hardware_device_types.c_str(), "hardwareDeviceTypes"),
+                      TraceLoggingString(hardware_vendor_ids.c_str(), "hardwareVendorIds"),
                       TraceLoggingString(service_names.c_str(), "serviceNames"),
                       TraceLoggingString(ORT_CALLER_FRAMEWORK, "frameworkName"));
   }
@@ -556,6 +564,41 @@ void WindowsTelemetry::LogRuntimePerf(uint32_t session_id, uint32_t total_runs_s
                     TraceLoggingUInt32(total_runs_since_last, "totalRuns"),
                     TraceLoggingInt64(total_run_duration_since_last, "totalRunDuration"),
                     TraceLoggingString(total_duration_per_batch_size.c_str(), "totalRunDurationPerBatchSize"),
+                    TraceLoggingString(ORT_CALLER_FRAMEWORK, "frameworkName"));
+}
+
+void WindowsTelemetry::LogEpDeviceUsage(uint32_t session_id,
+                                        const std::string& ep_type,
+                                        const std::string& hardware_device_type,
+                                        uint32_t hardware_vendor_id,
+                                        uint32_t hardware_device_id,
+                                        const std::string& hardware_vendor,
+                                        const std::string& ep_vendor,
+                                        int assigned_node_count,
+                                        uint32_t total_runs_since_last,
+                                        int64_t total_run_duration_since_last) const {
+  if (global_register_count_ == 0 || enabled_ == false)
+    return;
+
+  TraceLoggingWrite(telemetry_provider_handle,
+                    "EpDeviceUsage",
+                    TraceLoggingBool(true, "UTCReplace_AppSessionGuid"),
+                    TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
+                    TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
+                    TraceLoggingKeyword(static_cast<uint64_t>(onnxruntime::logging::ORTTraceLoggingKeyword::Session)),
+                    TraceLoggingLevel(WINEVENT_LEVEL_INFO),
+                    // Telemetry info
+                    TraceLoggingUInt8(0, "schemaVersion"),
+                    TraceLoggingUInt32(session_id, "sessionId"),
+                    TraceLoggingString(ep_type.c_str(), "executionProviderType"),
+                    TraceLoggingString(hardware_device_type.c_str(), "hardwareDeviceType"),
+                    TraceLoggingUInt32(hardware_vendor_id, "hardwareVendorId"),
+                    TraceLoggingUInt32(hardware_device_id, "hardwareDeviceId"),
+                    TraceLoggingString(hardware_vendor.c_str(), "hardwareVendor"),
+                    TraceLoggingString(ep_vendor.c_str(), "epVendor"),
+                    TraceLoggingInt32(assigned_node_count, "assignedNodeCount"),
+                    TraceLoggingUInt32(total_runs_since_last, "totalRunsSinceLast"),
+                    TraceLoggingInt64(total_run_duration_since_last, "totalRunDurationSinceLast"),
                     TraceLoggingString(ORT_CALLER_FRAMEWORK, "frameworkName"));
 }
 

--- a/onnxruntime/core/platform/windows/telemetry.h
+++ b/onnxruntime/core/platform/windows/telemetry.h
@@ -57,6 +57,8 @@ class WindowsTelemetry : public Telemetry {
                           const std::string& model_weight_hash,
                           const std::unordered_map<std::string, std::string>& model_metadata,
                           const std::string& loadedFrom, const std::vector<std::string>& execution_provider_ids,
+                          const std::string& hardware_device_types,
+                          const std::string& hardware_vendor_ids,
                           bool use_fp16, bool captureState) const override;
 
   void LogCompileModelStart(uint32_t session_id,
@@ -79,6 +81,17 @@ class WindowsTelemetry : public Telemetry {
 
   void LogRuntimePerf(uint32_t session_id, uint32_t total_runs_since_last, int64_t total_run_duration_since_last,
                       const std::unordered_map<int64_t, long long>& duration_per_batch_size) const override;
+
+  void LogEpDeviceUsage(uint32_t session_id,
+                        const std::string& ep_type,
+                        const std::string& hardware_device_type,
+                        uint32_t hardware_vendor_id,
+                        uint32_t hardware_device_id,
+                        const std::string& hardware_vendor,
+                        const std::string& ep_vendor,
+                        int assigned_node_count,
+                        uint32_t total_runs_since_last,
+                        int64_t total_run_duration_since_last) const override;
 
   void LogExecutionProviderEvent(LUID* adapterLuid) const override;
 

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -8,6 +8,7 @@
 #include <sstream>
 #include <list>
 #include <string>
+#include <unordered_map>
 #include <thread>
 #include <queue>
 #include <iomanip>

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -65,6 +65,7 @@
 #endif
 #include "core/providers/cpu/controlflow/utils.h"
 #include "core/providers/cpu/cpu_execution_provider.h"
+#include "core/session/abi_devices.h"
 #ifdef USE_DML  // TODO: This is necessary for the workaround in TransformGraph
 #include "core/providers/dml/DmlExecutionProvider/src/DmlGraphFusionTransformer.h"
 #include "core/providers/dml/DmlExecutionProvider/src/DmlRuntimeGraphFusionTransformer.h"
@@ -298,6 +299,38 @@ Status GetMinimalBuildOptimizationHandling(
 };
 
 #endif  // !defined(ORT_MINIMAL_BUILD)
+
+// Maps an OrtHardwareDeviceType (from the V2 OrtEpDevice path) to a string
+// matching the EpDeviceUsage telemetry schema.
+const char* HardwareDeviceTypeToString(OrtHardwareDeviceType type) {
+  switch (type) {
+    case OrtHardwareDeviceType_CPU:
+      return "CPU";
+    case OrtHardwareDeviceType_GPU:
+      return "GPU";
+    case OrtHardwareDeviceType_NPU:
+      return "NPU";
+    default:
+      return "UNKNOWN";
+  }
+}
+
+// Maps a legacy OrtDevice::DeviceType (used by EPs that did not come through the V2
+// OrtEpDevice path) to a string matching the EpDeviceUsage telemetry schema.
+const char* OrtDeviceTypeToString(OrtDevice::DeviceType type) {
+  switch (type) {
+    case OrtDevice::CPU:
+      return "CPU";
+    case OrtDevice::GPU:
+      return "GPU";
+    case OrtDevice::NPU:
+      return "NPU";
+    case OrtDevice::FPGA:
+      return "FPGA";
+    default:
+      return "UNKNOWN";
+  }
+}
 
 }  // namespace
 
@@ -826,10 +859,20 @@ InferenceSession::~InferenceSession() {
   ORT_TRY {
     std::lock_guard<std::mutex> telemetry_lock(telemetry_mutex_);
     if (telemetry_.total_runs_since_last_ > 0) {
-      Env::Default().GetTelemetryProvider().LogRuntimePerf(session_id_,
-                                                           telemetry_.total_runs_since_last_,
-                                                           telemetry_.total_run_duration_since_last_,
-                                                           telemetry_.duration_per_batch_size_);
+      const auto& telemetry_provider = Env::Default().GetTelemetryProvider();
+      telemetry_provider.LogRuntimePerf(session_id_,
+                                        telemetry_.total_runs_since_last_,
+                                        telemetry_.total_run_duration_since_last_,
+                                        telemetry_.duration_per_batch_size_);
+      // Also flush a final EpDeviceUsage per (EP, device) to capture any runs
+      // that occurred between the last heartbeat and session destruction.
+      for (const auto& ep_info : telemetry_.ep_device_info_) {
+        telemetry_provider.LogEpDeviceUsage(
+            session_id_, ep_info.ep_type, ep_info.hardware_device_type,
+            ep_info.vendor_id, ep_info.device_id, ep_info.vendor, ep_info.ep_vendor,
+            ep_info.assigned_node_count,
+            telemetry_.total_runs_since_last_, telemetry_.total_run_duration_since_last_);
+      }
     }
   }
   ORT_CATCH(const std::exception& e) {
@@ -2722,10 +2765,29 @@ common::Status InferenceSession::Initialize() {
     std::filesystem::path model_path = graph.ModelPath();
     std::string model_file_name = PathToUTF8String(model_path.filename().native());
     bool model_has_fp16_inputs = ModelHasFP16Inputs(graph);
+
+    // Populate per-(EP, hardware-device) telemetry data captured once at session
+    // initialization. The graph partitioning is complete at this point, so we can
+    // count how many nodes each EP is assigned. This populates telemetry_.ep_device_info_
+    // and the comma-separated summary strings used to enrich SessionCreation.
+    PopulateEpDeviceInfo(graph);
+
     env.GetTelemetryProvider().LogSessionCreation(
         session_id_, model_->IrVersion(), model_->ProducerName(), model_->ProducerVersion(), model_->Domain(),
         graph.DomainToVersionMap(), model_file_name, graph.Name(), model_weight_type, model_graph_hash, model_weight_hash,
-        model_->MetaData(), telemetry_.event_name_, execution_providers_.GetIds(), model_has_fp16_inputs, false);
+        model_->MetaData(), telemetry_.event_name_, execution_providers_.GetIds(),
+        telemetry_.ep_device_types_summary_, telemetry_.ep_device_vendor_ids_summary_,
+        model_has_fp16_inputs, false);
+
+    // Emit one initial EpDeviceUsage event per (EP, device) pair with run counts of 0.
+    // Ensures we capture EP/device topology even for sessions that end before the
+    // first RuntimePerf heartbeat (2s after the first Run()).
+    for (const auto& ep_info : telemetry_.ep_device_info_) {
+      env.GetTelemetryProvider().LogEpDeviceUsage(
+          session_id_, ep_info.ep_type, ep_info.hardware_device_type,
+          ep_info.vendor_id, ep_info.device_id, ep_info.vendor, ep_info.ep_vendor,
+          ep_info.assigned_node_count, 0, 0);
+    }
 
     LOGS(*session_logger_, INFO) << "Session successfully initialized.";
   }
@@ -3381,6 +3443,18 @@ Status InferenceSession::RunImpl(const RunOptions& run_options,
         env.GetTelemetryProvider().LogRuntimePerf(session_id_, telemetry_.total_runs_since_last_,
                                                   telemetry_.total_run_duration_since_last_,
                                                   telemetry_.duration_per_batch_size_);
+
+        // Emit one EpDeviceUsage event per (EP, hardware device) tuple so
+        // downstream consumers can attribute usage to a specific EP+device combo
+        // without joining back to SessionCreation (which may fall outside the
+        // telemetry pipeline's lookback window for long-lived sessions).
+        for (const auto& ep_info : telemetry_.ep_device_info_) {
+          env.GetTelemetryProvider().LogEpDeviceUsage(
+              session_id_, ep_info.ep_type, ep_info.hardware_device_type,
+              ep_info.vendor_id, ep_info.device_id, ep_info.vendor, ep_info.ep_vendor,
+              ep_info.assigned_node_count,
+              telemetry_.total_runs_since_last_, telemetry_.total_run_duration_since_last_);
+        }
         // reset counters
         telemetry_.time_sent_last_ = std::chrono::high_resolution_clock::now();
         telemetry_.total_runs_since_last_ = 0;
@@ -3993,6 +4067,98 @@ void InferenceSession::ShrinkMemoryArenas(gsl::span<const AllocatorPtr> arenas_t
   }
 }
 
+void InferenceSession::PopulateEpDeviceInfo(const onnxruntime::Graph& graph) {
+  telemetry_.ep_device_info_.clear();
+  telemetry_.ep_device_types_summary_.clear();
+  telemetry_.ep_device_vendor_ids_summary_.clear();
+
+  // First, count nodes assigned to each EP type after graph partitioning.
+  // The graph node only carries the EP type string, so when a single EP targets
+  // multiple devices (e.g. QNN targeting both NPU and GPU on the same SoC) we
+  // cannot disambiguate node-to-device assignment here — every device row for the
+  // same EP type will carry the same total count. Downstream aggregation should
+  // use MAX (not SUM) across device rows to avoid double counting.
+  std::unordered_map<std::string, int> nodes_per_ep;
+  for (const auto& node : graph.Nodes()) {
+    const auto& ep = node.GetExecutionProviderType();
+    if (!ep.empty()) {
+      nodes_per_ep[ep]++;
+    }
+  }
+
+  // Then iterate registered EPs and emit one entry per (EP, OrtEpDevice) tuple,
+  // falling back to OrtDevice for legacy EPs that were not created via the V2
+  // OrtEpDevice path.
+  for (const auto& provider : execution_providers_) {
+    if (!provider) {
+      continue;
+    }
+
+    const std::string& ep_type = provider->Type();
+    const int assigned_nodes = nodes_per_ep.count(ep_type) ? nodes_per_ep[ep_type] : 0;
+    const auto& ep_devices = provider->GetEpDevices();
+
+    if (!ep_devices.empty()) {
+      // V2 path: full hardware metadata available via OrtEpDevice / OrtHardwareDevice.
+      for (const OrtEpDevice* ep_device : ep_devices) {
+        if (!ep_device) {
+          continue;
+        }
+
+        Telemetry::EpDeviceInfo entry;
+        entry.ep_type = ep_type;
+        entry.ep_vendor = ep_device->ep_vendor;
+        if (ep_device->device != nullptr) {
+          entry.hardware_device_type = HardwareDeviceTypeToString(ep_device->device->type);
+          entry.vendor_id = ep_device->device->vendor_id;
+          entry.device_id = ep_device->device->device_id;
+          entry.vendor = ep_device->device->vendor;
+        } else {
+          entry.hardware_device_type = "UNKNOWN";
+        }
+        entry.assigned_node_count = assigned_nodes;
+        telemetry_.ep_device_info_.push_back(std::move(entry));
+      }
+    } else {
+      // Legacy path: only OrtDevice is available. PCI vendor/device IDs and
+      // vendor name are not populated for legacy EPs — downstream consumers
+      // see vendor_id from OrtDevice (which matches PCI for known EPs) and
+      // empty vendor / device_id of 0.
+      const OrtDevice& device = provider->GetDevice();
+      Telemetry::EpDeviceInfo entry;
+      entry.ep_type = ep_type;
+      entry.hardware_device_type = OrtDeviceTypeToString(device.Type());
+      entry.vendor_id = device.Vendor();
+      entry.device_id = 0;
+      entry.vendor = std::string();
+      entry.ep_vendor = std::string();
+      entry.assigned_node_count = assigned_nodes;
+      telemetry_.ep_device_info_.push_back(std::move(entry));
+    }
+  }
+
+  // Build the comma-separated summaries used to enrich SessionCreation. Order
+  // matches execution_providers_.GetIds() iteration order so consumers can join
+  // by position against the existing executionProviderIds field.
+  std::ostringstream types_oss;
+  std::ostringstream vendor_ids_oss;
+  bool first = true;
+  for (const auto& entry : telemetry_.ep_device_info_) {
+    if (!first) {
+      types_oss << ',';
+      vendor_ids_oss << ',';
+    }
+    first = false;
+    types_oss << entry.hardware_device_type;
+    // Format vendor IDs as hex for readability (PCI IDs are conventionally hex).
+    vendor_ids_oss << "0x" << std::hex << std::uppercase << std::setw(4)
+                   << std::setfill('0') << entry.vendor_id
+                   << std::dec << std::nouppercase << std::setfill(' ');
+  }
+  telemetry_.ep_device_types_summary_ = types_oss.str();
+  telemetry_.ep_device_vendor_ids_summary_ = vendor_ids_oss.str();
+}
+
 #if !defined(ORT_MINIMAL_BUILD)
 // assumes model has already been loaded before
 common::Status InferenceSession::DoPostLoadProcessing(onnxruntime::Model& model) {
@@ -4235,7 +4401,9 @@ void InferenceSession::LogAllSessions() {
       env.GetTelemetryProvider().LogSessionCreation(
           session->session_id_, model->IrVersion(), model->ProducerName(), model->ProducerVersion(), model->Domain(),
           graph.DomainToVersionMap(), model_file_name, graph.Name(), model_weight_type, model_graph_hash, model_weight_hash,
-          model->MetaData(), session->telemetry_.event_name_, session->execution_providers_.GetIds(), model_has_fp16_inputs, true);
+          model->MetaData(), session->telemetry_.event_name_, session->execution_providers_.GetIds(),
+          session->telemetry_.ep_device_types_summary_, session->telemetry_.ep_device_vendor_ids_summary_,
+          model_has_fp16_inputs, true);
     }
 
     InferenceSession::TraceSessionOptions(session->session_options_, true, *session->session_logger_);

--- a/onnxruntime/core/session/inference_session.h
+++ b/onnxruntime/core/session/inference_session.h
@@ -1011,17 +1011,17 @@ class InferenceSession {
     // cadence as RuntimePerf so downstream consumers can attribute inference usage
     // to specific EP + device combinations without joining back to SessionCreation.
     struct EpDeviceInfo {
-      std::string ep_type;                  // e.g. "QNNExecutionProvider"
-      std::string hardware_device_type;     // "CPU", "GPU", "NPU", "FPGA", or "UNKNOWN"
-      uint32_t vendor_id = 0;               // PCI vendor ID (e.g. 0x5143 for Qualcomm)
-      uint32_t device_id = 0;               // PCI device ID (0 when unavailable)
-      std::string vendor;                   // e.g. "Qualcomm"
-      std::string ep_vendor;                // e.g. "Qualcomm" (from OrtEpDevice)
-      int assigned_node_count = 0;          // # graph nodes assigned to this EP type
+      std::string ep_type;               // e.g. "QNNExecutionProvider"
+      std::string hardware_device_type;  // "CPU", "GPU", "NPU", "FPGA", or "UNKNOWN"
+      uint32_t vendor_id = 0;            // PCI vendor ID (e.g. 0x5143 for Qualcomm)
+      uint32_t device_id = 0;            // PCI device ID (0 when unavailable)
+      std::string vendor;                // e.g. "Qualcomm"
+      std::string ep_vendor;             // e.g. "Qualcomm" (from OrtEpDevice)
+      int assigned_node_count = 0;       // # graph nodes assigned to this EP type
     };
     std::vector<EpDeviceInfo> ep_device_info_;
     // Pre-formatted comma-separated summaries used to enrich SessionCreation.
-    std::string ep_device_types_summary_;   // "NPU,CPU"
+    std::string ep_device_types_summary_;       // "NPU,CPU"
     std::string ep_device_vendor_ids_summary_;  // "0x5143,0x0000"
   } telemetry_;
 

--- a/onnxruntime/core/session/inference_session.h
+++ b/onnxruntime/core/session/inference_session.h
@@ -880,6 +880,11 @@ class InferenceSession {
    */
   void ShrinkMemoryArenas(gsl::span<const AllocatorPtr> arenas_to_shrink);
 
+  // Populates telemetry_.ep_device_info_ and the related summary strings used by
+  // the SessionCreation and EpDeviceUsage telemetry events. Must be called after
+  // graph partitioning is complete so node counts per EP are accurate.
+  void PopulateEpDeviceInfo(const onnxruntime::Graph& graph);
+
 #ifdef _WIN32
   static void LogAllSessions();
 #endif
@@ -1000,6 +1005,24 @@ class InferenceSession {
     constexpr static int64_t kRuntimePerfInitialInterval = 2 * 1000 * 1000;    // 2 seconds in (us)
     constexpr static int64_t kRuntimePerfMaxInterval = 1000 * 1000 * 60 * 10;  // 10 minutes in (us)
     int64_t runtime_perf_interval_ = kRuntimePerfInitialInterval;
+
+    // Per-(EP, hardware device) tuple captured once at session Initialize() time,
+    // after graph partitioning. Used to emit "EpDeviceUsage" events on the same
+    // cadence as RuntimePerf so downstream consumers can attribute inference usage
+    // to specific EP + device combinations without joining back to SessionCreation.
+    struct EpDeviceInfo {
+      std::string ep_type;                  // e.g. "QNNExecutionProvider"
+      std::string hardware_device_type;     // "CPU", "GPU", "NPU", "FPGA", or "UNKNOWN"
+      uint32_t vendor_id = 0;               // PCI vendor ID (e.g. 0x5143 for Qualcomm)
+      uint32_t device_id = 0;               // PCI device ID (0 when unavailable)
+      std::string vendor;                   // e.g. "Qualcomm"
+      std::string ep_vendor;                // e.g. "Qualcomm" (from OrtEpDevice)
+      int assigned_node_count = 0;          // # graph nodes assigned to this EP type
+    };
+    std::vector<EpDeviceInfo> ep_device_info_;
+    // Pre-formatted comma-separated summaries used to enrich SessionCreation.
+    std::string ep_device_types_summary_;   // "NPU,CPU"
+    std::string ep_device_vendor_ids_summary_;  // "0x5143,0x0000"
   } telemetry_;
 
   mutable std::mutex telemetry_mutex_;  // to ensure thread-safe access to telemetry data


### PR DESCRIPTION
## Problem

Windows ML engineers need telemetry that answers: **"Which Execution Providers and hardware device types are apps using for inference, and how much?"**

Today, the inference telemetry has these gaps:

| Event | Gap |
|---|---|
| SessionCreation | No hardware device type (CPU/GPU/NPU), no vendor ID. Fires once — falls out of the 24h pipeline join window for long-lived sessions. |
| RuntimePerf | No EP type, no hardware device — only session_id, requires a join back to SessionCreation. |
| ExecutionProviderEvent | Only fires for DML. Irrelevant for QNN/OpenVINO/etc. |

The new Windows ML EP plugin platform (OrtEpDevice / OrtEpFactory / OrtHardwareDevice) already has all the hardware metadata we need; we just weren't surfacing it.

## What this PR does

### 1. New `EpDeviceUsage` ETW event

Emitted once per `(EP, hardware device)` tuple at session init and on every `RuntimePerf` heartbeat (plus a destructor flush). Each event is self-contained:

| Field | Example |
|---|---|
| executionProviderType | `QNNExecutionProvider` |
| hardwareDeviceType | `NPU` / `GPU` / `CPU` / `FPGA` / `UNKNOWN` |
| hardwareVendorId / hardwareDeviceId | `0x5143` / `0x0901` (PCI IDs) |
| hardwareVendor | `Qualcomm` |
| epVendor | `Qualcomm` |
| assignedNodeCount | `89` (count after graph partitioning) |
| totalRunsSinceLast / totalRunDurationSinceLast | session-level run counters |

This gives downstream consumers a trivial `GROUP BY executionProviderType, hardwareDeviceType` without needing to join back to `SessionCreation`. Works for long-lived sessions that span past the 24h pipeline join window.

### 2. `SessionCreation` enrichment

Added `hardwareDeviceTypes` and `hardwareVendorIds` (comma-separated, positionally aligned with the existing `executionProviderIds`). Bumped `schemaVersion` 0 -> 1.

## Implementation notes

- `LogEpDeviceUsage` added to the `Telemetry` interface with a no-op default; `WindowsTelemetry` implements it via TraceLogging under the existing `Microsoft.ML.ONNXRuntime` provider (no new provider GUID).
- `InferenceSession::PopulateEpDeviceInfo` runs after graph partitioning. For EPs created via the V2 path (`AppendExecutionProvider_V2` / `SetEpSelectionPolicy` / `RegisterExecutionProviderLibrary`) it pulls full hardware metadata from `IExecutionProvider::GetEpDevices()`. For legacy EPs it falls back to `IExecutionProvider::GetDevice()` (OrtDevice type + vendor ID; no PCI device ID).
- Heartbeat block in `Run()` and destructor flush in `~InferenceSession` both emit `LogEpDeviceUsage` per entry.

## Testing

- Debug build with Ninja: clean build (1636 targets)
- `onnxruntime_test_all` (full suite): **1571 passed, 0 failed**, 3 skipped (CUDA-EP-gated, environment)
- No memory leaks reported

## Compatibility

- No public C API surface changes.
- `Telemetry::LogSessionCreation` virtual gains two `const std::string&` parameters — all in-tree overrides are updated.
- `LogEpDeviceUsage` has a no-op default, so non-Windows platforms are unaffected.