### PR TITLE
[CoreML EP] Support Gather with scalar indices on the MLProgram path

### DIFF
--- a/onnxruntime/core/providers/coreml/builders/impl/gather_op_builder.cc
+++ b/onnxruntime/core/providers/coreml/builders/impl/gather_op_builder.cc
@@ -74,27 +74,46 @@ bool GatherOpBuilder::HasSupportedInputsImpl(const Node& node, const OpBuilderIn
   return true;
 }
 
-bool GatherOpBuilder::IsOpSupportedImpl(const Node& node, const OpBuilderInputParams& /*input_params*/,
+bool GatherOpBuilder::IsOpSupportedImpl(const Node& node, const OpBuilderInputParams& input_params,
                                         const logging::Logger& logger) const {
+  const auto& input_defs = node.InputDefs();
   std::vector<int64_t> data_shape, indices_shape;
-  if (!GetShape(*node.InputDefs()[0], data_shape, logger)) {
+  if (!GetShape(*input_defs[0], data_shape, logger)) {
     LOGS(logger, VERBOSE) << "Failed to get 'data' shape";
     return false;
   }
 
-  if (!GetShape(*node.InputDefs()[1], indices_shape, logger)) {
+  if (!GetShape(*input_defs[1], indices_shape, logger)) {
     LOGS(logger, VERBOSE) << "Failed to get 'indices' shape";
     return false;
   }
 
-  // Don't allow scalar 'indices' input.
-  // We convert scalar inputs to tensors with shape [1] before providing them to CoreML.
-  // This modification changes the shape of the Gather output.
+  // Scalar (rank-0) 'indices' input.
+  //
+  // MIL `gather` accepts rank-0 indices and produces the correct ONNX output
+  // (the gathered axis is dropped). However, the CoreML EP reshapes any rank-0
+  // *graph-boundary* tensor to {1} when it crosses into the CoreML subgraph
+  // (see ModelBuilder::RegisterModelInputOutput) and a rank-0 input cannot be
+  // represented as an MLMultiArray. So we only allow scalar indices when they
+  // are a constant initializer: those flow through OnnxTensorToCoreMLTensor
+  // with rank preserved and MIL gather can consume them directly.
+  //
+  // On the NeuralNetwork path scalar initializers are also reshaped to {1}
+  // (ModelBuilder::RegisterInitializers, LoadConstantND requires rank >= 1),
+  // so the gather output shape ends up wrong there. Keep rejecting that case.
   if (indices_shape.empty()) {
-    LOGS(logger, VERBOSE) << "Gather does not support scalar 'indices'";
-    return false;
+    if (!input_params.create_mlprogram) {
+      LOGS(logger, VERBOSE) << "Gather does not support scalar 'indices' on the NeuralNetwork path";
+      return false;
+    }
+    if (input_params.graph_viewer.GetConstantInitializer(input_defs[1]->Name()) == nullptr) {
+      LOGS(logger, VERBOSE) << "Gather with scalar 'indices' is only supported when 'indices' is a constant initializer";
+      return false;
+    }
   }
 
+  // ONNX Gather output rank = data_rank + indices_rank - 1.
+  // For scalar indices (rank 0) this is data_rank - 1, which is what MIL also produces.
   if (data_shape.size() + indices_shape.size() - 1 > 5) {
     LOGS(logger, VERBOSE) << "Gather does not support output with rank greater than 5";
     return false;


### PR DESCRIPTION
Fixes #28180.

PyTorch's ONNX exporter routinely emits `Gather` with a rank-0 (scalar) `indices` input — every per-layer style-code lookup in StyleGAN / StyleGAN2 derivatives is one. In the GFPGAN 1024×1024 generator that's 16 such Gathers, each splitting the CoreML subgraph and forcing a partition boundary. `GatherOpBuilder::IsOpSupportedImpl` historically rejected this shape outright.

### The actual blocker isn't MIL gather

MIL `gather` does accept rank-0 `indices` and produces the expected output (gathered axis dropped). Verified by building a small MIL program end-to-end against iOS 15:

```python
@mb.program(input_specs=[mb.TensorSpec(shape=(1, 16, 512), dtype=types.fp32)])
def prog(x):
    return mb.gather(x=x, indices=mb.const(val=np.int32(3)), axis=1)
```

```
main[CoreML3](%x: (1, 16, 512, fp32)) {
  %gather_0: (1, 512, fp32) = gather(x=%x, indices=3, axis=1)
}
```

The reason the EP rejected the case was ORT-side boundary handling, not MIL:

- `ModelBuilder::RegisterModelInputOutput` rewrites any rank-0 boundary tensor to `{1}` because `MLMultiArray` has no rank-0 representation.
- On the NeuralNetwork path, `RegisterInitializers` does the same for rank-0 initializers (`LoadConstantND` requires rank ≥ 1).

But constant initializers on the **MLProgram** path flow through `OnnxTensorToCoreMLTensor`, which preserves rank — so MIL `gather` can consume them directly.

### Change

`IsOpSupportedImpl`: allow rank-0 `indices` on the MLProgram path **only when it is a constant initializer**. NeuralNetwork path and non-initializer scalar `indices` remain rejected.

`AddToModelBuilderImpl`: unchanged from `main` — the existing code already passes `indices` straight through to MIL `gather`.

### Test

Existing CPU `OpTester` cases already cover the shape and run against every registered EP:

- `GatherOpTest.Gather_axis0_scalar_indices` (data `[2,2,2]`, scalar index, axis 0)
- `GatherOpTest.Gather_axis1_scalar_indices` (data `[2,2,2]`, scalar index, axis 1)

Both were skipped on CoreML before (`IsOpSupportedImpl` returned false); with this change they stay on CoreML EP and the OpTester output matches the reference.