### PR TITLE
Address latent bug in LabelEncoder

### DIFF
--- a/onnxruntime/core/providers/cuda/ml/label_encoder.cc
+++ b/onnxruntime/core/providers/cuda/ml/label_encoder.cc
@@ -62,7 +62,9 @@ static bool TryGetScalarTensorAttribute(const OpKernelInfo& info, const std::str
   auto* attr_tensor_proto = GetTensorProto(attr_tensor_holder);
   auto result = info.GetAttr(tensor_name, attr_tensor_proto);
   if (result.IsOK() && utils::HasDataType(*attr_tensor_proto)) {
-    result = utils::UnpackTensor<T>(*attr_tensor_proto, nullptr, 0, &value, 1);
+    const void* raw_data = utils::HasRawData(*attr_tensor_proto) ? attr_tensor_proto->raw_data().data() : nullptr;
+    size_t raw_data_len = utils::HasRawData(*attr_tensor_proto) ? attr_tensor_proto->raw_data().size() : 0;
+    result = utils::UnpackTensor<T>(*attr_tensor_proto, raw_data, raw_data_len, &value, 1);
     ORT_ENFORCE(result.IsOK(), "LabelEncoder could not unpack tensor attribute ", attr_name);
     return true;
   }
@@ -113,7 +115,9 @@ static std::vector<T> GetAttrOrTensor(const OpKernelInfo& info, const std::strin
   }
   const SafeInt<size_t> tensor_size(element_count);
   std::vector<T> out(tensor_size);
-  result = utils::UnpackTensor<T>(*attr_tensor_proto, nullptr, 0, out.data(), tensor_size);
+  const void* raw_data = utils::HasRawData(*attr_tensor_proto) ? attr_tensor_proto->raw_data().data() : nullptr;
+  size_t raw_data_len = utils::HasRawData(*attr_tensor_proto) ? attr_tensor_proto->raw_data().size() : 0;
+  result = utils::UnpackTensor<T>(*attr_tensor_proto, raw_data, raw_data_len, out.data(), tensor_size);
   ORT_ENFORCE(result.IsOK(), "LabelEncoder could not unpack tensor attribute ", name);
   return out;
 #endif  // BUILD_CUDA_EP_AS_PLUGIN

--- a/onnxruntime/core/providers/cuda/ml/label_encoder.cc
+++ b/onnxruntime/core/providers/cuda/ml/label_encoder.cc
@@ -38,6 +38,15 @@ static ONNX_NAMESPACE::TensorProto* GetTensorProto(TensorProtoHolder& holder) {
   return &holder;
 }
 #endif
+
+// Returns the raw data pointer and length from a TensorProto, or {nullptr, 0} if not present.
+static std::pair<const void*, size_t> GetRawData(const ONNX_NAMESPACE::TensorProto& tensor_proto) {
+  if (utils::HasRawData(tensor_proto)) {
+    const auto& raw = tensor_proto.raw_data();
+    return {raw.data(), raw.size()};
+  }
+  return {nullptr, 0};
+}
 #endif
 
 template <typename T>
@@ -62,8 +71,7 @@ static bool TryGetScalarTensorAttribute(const OpKernelInfo& info, const std::str
   auto* attr_tensor_proto = GetTensorProto(attr_tensor_holder);
   auto result = info.GetAttr(tensor_name, attr_tensor_proto);
   if (result.IsOK() && utils::HasDataType(*attr_tensor_proto)) {
-    const void* raw_data = utils::HasRawData(*attr_tensor_proto) ? attr_tensor_proto->raw_data().data() : nullptr;
-    size_t raw_data_len = utils::HasRawData(*attr_tensor_proto) ? attr_tensor_proto->raw_data().size() : 0;
+    const auto [raw_data, raw_data_len] = GetRawData(*attr_tensor_proto);
     result = utils::UnpackTensor<T>(*attr_tensor_proto, raw_data, raw_data_len, &value, 1);
     ORT_ENFORCE(result.IsOK(), "LabelEncoder could not unpack tensor attribute ", attr_name);
     return true;
@@ -115,8 +123,7 @@ static std::vector<T> GetAttrOrTensor(const OpKernelInfo& info, const std::strin
   }
   const SafeInt<size_t> tensor_size(element_count);
   std::vector<T> out(tensor_size);
-  const void* raw_data = utils::HasRawData(*attr_tensor_proto) ? attr_tensor_proto->raw_data().data() : nullptr;
-  size_t raw_data_len = utils::HasRawData(*attr_tensor_proto) ? attr_tensor_proto->raw_data().size() : 0;
+  const auto [raw_data, raw_data_len] = GetRawData(*attr_tensor_proto);
   result = utils::UnpackTensor<T>(*attr_tensor_proto, raw_data, raw_data_len, out.data(), tensor_size);
   ORT_ENFORCE(result.IsOK(), "LabelEncoder could not unpack tensor attribute ", name);
   return out;


### PR DESCRIPTION
This pull request refines how tensor attributes are unpacked in the CUDA LabelEncoder implementation. The main improvement is ensuring that the raw data from tensor protos is explicitly passed to the `UnpackTensor` utility, enhancing correctness and compatibility with various tensor data formats.

**Tensor attribute unpacking improvements:**

* In both `TryGetScalarTensorAttribute` and `GetAttrOrTensor` functions in `label_encoder.cc`, the code now checks if the tensor proto contains raw data and, if so, passes the correct raw data pointer and length to `utils::UnpackTensor`. This replaces the previous approach of always passing `nullptr` and `0` for these parameters. [[1]](diffhunk://#diff-2fc4106da1ae063defd383893e035de8f260618ffd1dad0864b615361b4d2e2bL65-R67) [[2]](diffhunk://#diff-2fc4106da1ae063defd383893e035de8f260618ffd1dad0864b615361b4d2e2bL116-R120)