### PR TITLE
Fix for the CUDA CI errors

### DIFF
--- a/onnxruntime/core/providers/cuda/ml/label_encoder.cc
+++ b/onnxruntime/core/providers/cuda/ml/label_encoder.cc
@@ -62,7 +62,7 @@ static bool TryGetScalarTensorAttribute(const OpKernelInfo& info, const std::str
   auto* attr_tensor_proto = GetTensorProto(attr_tensor_holder);
   auto result = info.GetAttr(tensor_name, attr_tensor_proto);
   if (result.IsOK() && utils::HasDataType(*attr_tensor_proto)) {
-    result = utils::UnpackTensor<T>(*attr_tensor_proto, nullptr, 0, &value, 1);
+    result = utils::UnpackTensor<T>(*attr_tensor_proto, std::filesystem::path(), &value, 1);
     ORT_ENFORCE(result.IsOK(), "LabelEncoder could not unpack tensor attribute ", attr_name);
     return true;
   }
@@ -113,7 +113,7 @@ static std::vector<T> GetAttrOrTensor(const OpKernelInfo& info, const std::strin
   }
   const SafeInt<size_t> tensor_size(element_count);
   std::vector<T> out(tensor_size);
-  result = utils::UnpackTensor<T>(*attr_tensor_proto, nullptr, 0, out.data(), tensor_size);
+  result = utils::UnpackTensor<T>(*attr_tensor_proto, std::filesystem::path(), out.data(), tensor_size);
   ORT_ENFORCE(result.IsOK(), "LabelEncoder could not unpack tensor attribute ", name);
   return out;
 #endif  // BUILD_CUDA_EP_AS_PLUGIN


### PR DESCRIPTION
Possible fix for the CUDA errors being seen on CI.

It seems that the failing test onnxruntime/test/providers/cpu/ml/label_encoder_test.cc:457 builds keys_tensor and values_tensor using SetRawDataInTensorProto(...) at onnxruntime/test/providers/cpu/ml/
  label_encoder_test.cc:471 and onnxruntime/test/providers/cpu/ml/label_encoder_test.cc:479.

  The CUDA helper then does this in onnxruntime/core/providers/cuda/ml/label_encoder.cc:116:

  result = utils::UnpackTensor<T>(*attr_tensor_proto, nullptr, 0, out.data(), tensor_size);

  That is the problem. Passing nullptr, 0 means it does not read TensorProto.raw_data; it only works for typed proto fields like int64_data. So raw-data tensor attributes fail to unpack, which is exactly what
  your test is exercising.

  The CPU implementation uses the correct overload in onnxruntime/core/providers/cpu/ml/label_encoder.h:128:

  result = utils::UnpackTensor<T>(attr_tensor_proto, std::filesystem::path(), out.data(), tensor_size);

  That overload handles raw data and external data correctly.

 The fix is to use the raw-data-aware UnpackTensor overload in the non-plugin CUDA path.


