### PR TITLE
[webgpu] Add NTC layout support for CausalConvWithState

### DIFF
--- a/onnxruntime/contrib_ops/cpu/bert/causal_conv_with_state.cc
+++ b/onnxruntime/contrib_ops/cpu/bert/causal_conv_with_state.cc
@@ -47,6 +47,11 @@ CausalConvWithState<T>::CausalConvWithState(const OpKernelInfo& info) : OpKernel
   activation_ = info.GetAttrOrDefault<std::string>("activation", "none");
   ORT_ENFORCE(activation_ == "none" || activation_ == "silu" || activation_ == "swish",
               "activation must be one of: none, silu, swish");
+
+  std::string data_format = info.GetAttrOrDefault<std::string>("data_format", "NCT");
+  ORT_ENFORCE(data_format == "NCT",
+              "CPU CausalConvWithState only supports data_format='NCT' currently. "
+              "Got: ", data_format);
 }
 
 namespace {

--- a/onnxruntime/contrib_ops/cpu/bert/causal_conv_with_state.cc
+++ b/onnxruntime/contrib_ops/cpu/bert/causal_conv_with_state.cc
@@ -51,7 +51,8 @@ CausalConvWithState<T>::CausalConvWithState(const OpKernelInfo& info) : OpKernel
   std::string data_format = info.GetAttrOrDefault<std::string>("data_format", "NCT");
   ORT_ENFORCE(data_format == "NCT",
               "CPU CausalConvWithState only supports data_format='NCT' currently. "
-              "Got: ", data_format);
+              "Got: ",
+              data_format);
 }
 
 namespace {

--- a/onnxruntime/contrib_ops/cuda/bert/causal_conv_with_state.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/causal_conv_with_state.cc
@@ -39,7 +39,8 @@ CausalConvWithState<T>::CausalConvWithState(const OpKernelInfo& info) : CudaKern
   std::string data_format = info.GetAttrOrDefault<std::string>("data_format", "NCT");
   ORT_ENFORCE(data_format == "NCT",
               "CUDA CausalConvWithState only supports data_format='NCT' currently. "
-              "Got: ", data_format);
+              "Got: ",
+              data_format);
 }
 
 template <typename T>

--- a/onnxruntime/contrib_ops/cuda/bert/causal_conv_with_state.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/causal_conv_with_state.cc
@@ -35,6 +35,11 @@ CausalConvWithState<T>::CausalConvWithState(const OpKernelInfo& info) : CudaKern
   activation_ = info.GetAttrOrDefault<std::string>("activation", "none");
   ORT_ENFORCE(activation_ == "none" || activation_ == "silu" || activation_ == "swish",
               "activation must be one of: none, silu, swish");
+
+  std::string data_format = info.GetAttrOrDefault<std::string>("data_format", "NCT");
+  ORT_ENFORCE(data_format == "NCT",
+              "CUDA CausalConvWithState only supports data_format='NCT' currently. "
+              "Got: ", data_format);
 }
 
 template <typename T>

--- a/onnxruntime/contrib_ops/webgpu/bert/causal_conv_with_state.cc
+++ b/onnxruntime/contrib_ops/webgpu/bert/causal_conv_with_state.cc
@@ -22,6 +22,13 @@ CausalConvActivation ParseCausalConvActivation(const std::string& activation_str
   return CausalConvActivation::Invalid;
 }
 
+CausalConvDataFormat ParseCausalConvDataFormat(const std::string& fmt_str) {
+  if (fmt_str == "NTC") {
+    return CausalConvDataFormat::NTC;
+  }
+  return CausalConvDataFormat::NCT;
+}
+
 // =============================================================================
 // CausalConvWithState Implementation
 // =============================================================================
@@ -40,6 +47,10 @@ CausalConvWithState::CausalConvWithState(const OpKernelInfo& info)
   std::string activation_str = info.GetAttrOrDefault<std::string>("activation", "none");
   activation_ = ParseCausalConvActivation(activation_str);
   ORT_ENFORCE(info.GetAttr<int64_t>("ndim", &ndim_).IsOK(), "Attribute 'ndim' is required");
+  std::string data_format_str = info.GetAttrOrDefault<std::string>("data_format", "NCT");
+  data_format_ = ParseCausalConvDataFormat(data_format_str);
+  ORT_ENFORCE(!(data_format_ == CausalConvDataFormat::NTC && ndim_ != 1),
+              "data_format='NTC' is only supported for ndim=1");
 }
 
 Status CausalConvWithStateProgram::GenerateShaderCode(ShaderHelper& shader) const {
@@ -59,14 +70,15 @@ Status CausalConvWithStateProgram::GenerateShaderCode(ShaderHelper& shader) cons
   return WGSL_TEMPLATE_APPLY(shader, "bert/causal_conv_with_state.wgsl.template",
                              WGSL_TEMPLATE_PARAMETER(has_bias, has_bias_),
                              WGSL_TEMPLATE_PARAMETER(has_conv_state, has_conv_state_),
+                             WGSL_TEMPLATE_PARAMETER(is_ntc, data_format_ == CausalConvDataFormat::NTC),
                              WGSL_TEMPLATE_PARAMETER(use_silu, activation_ == CausalConvActivation::Silu));
 }
 
 Status CausalConvWithState::ComputeInternal(ComputeContext& context) const {
-  const Tensor* input = context.Input(0);       // (B, D, L)
+  const Tensor* input = context.Input(0);       // (B, D, L) NCT or (B, L, D) NTC
   const Tensor* weight = context.Input(1);      // (D, 1, K)
   const Tensor* bias = context.Input(2);        // optional (D,)
-  const Tensor* conv_state = context.Input(3);  // optional (B, D, K-1) — past_state
+  const Tensor* conv_state = context.Input(3);  // optional (B, D, K-1) — past_state, always NCT
 
   ORT_RETURN_IF(activation_ == CausalConvActivation::Invalid, "Invalid activation type");
   ORT_RETURN_IF(ndim_ != 1, "Only 1D convolution is supported");
@@ -74,13 +86,14 @@ Status CausalConvWithState::ComputeInternal(ComputeContext& context) const {
   const auto& weight_shape = weight->Shape();
 
   ORT_RETURN_IF(input_shape.NumDimensions() != 3,
-                "Input must be 3D (batch_size, channels, length)");
+                "Input must be 3D");
   ORT_RETURN_IF(weight_shape.NumDimensions() != 3,
                 "Weight must be 3D (channels, 1, kernel_size)");
 
+  const bool is_ntc = (data_format_ == CausalConvDataFormat::NTC);
   const int64_t batch_size = input_shape[0];
-  const int64_t channels = input_shape[1];
-  const int64_t input_length = input_shape[2];
+  const int64_t channels = is_ntc ? input_shape[2] : input_shape[1];
+  const int64_t input_length = is_ntc ? input_shape[1] : input_shape[2];
   const int64_t kernel_size = weight_shape[2];
   const int64_t state_length = kernel_size - 1;
 
@@ -106,11 +119,10 @@ Status CausalConvWithState::ComputeInternal(ComputeContext& context) const {
   const bool has_bias = (bias != nullptr);
   const bool has_conv_state = (conv_state != nullptr);
 
-  // Allocate outputs
-  // Output 0: (B, D, L)
+  // Allocate outputs (output shape == input shape, same layout)
   Tensor* output = context.Output(0, input_shape);
 
-  // Output 1: present_state (B, D, K-1)
+  // present_state always (B, C, K-1) regardless of data_format
   std::vector<int64_t> state_dims{batch_size, channels, state_length};
   Tensor* present_state = context.Output(1, TensorShape(state_dims));
 
@@ -124,11 +136,12 @@ Status CausalConvWithState::ComputeInternal(ComputeContext& context) const {
   }
 
   // Create and run the shader program
-  CausalConvWithStateProgram program{activation_, has_bias, has_conv_state};
+  CausalConvWithStateProgram program{activation_, has_bias, has_conv_state, data_format_};
 
   uint32_t output_size = static_cast<uint32_t>(batch_size * channels * input_length);
 
-  program.CacheHint(has_bias, has_conv_state, kernel_size, static_cast<int>(activation_));
+  program.CacheHint(has_bias, has_conv_state, kernel_size, static_cast<int>(activation_),
+                    static_cast<int>(data_format_));
 
   program.AddInput({input, ProgramTensorMetadataDependency::Type})
       .AddInput({weight, ProgramTensorMetadataDependency::None});

--- a/onnxruntime/contrib_ops/webgpu/bert/causal_conv_with_state.h
+++ b/onnxruntime/contrib_ops/webgpu/bert/causal_conv_with_state.h
@@ -24,14 +24,24 @@ enum class CausalConvActivation {
 
 CausalConvActivation ParseCausalConvActivation(const std::string& activation_str);
 
+// Data layout for CausalConvWithState input/output (state is always NCT).
+enum class CausalConvDataFormat {
+  NCT,  // (batch, channels, length)
+  NTC   // (batch, length, channels) — ndim=1 only
+};
+
+CausalConvDataFormat ParseCausalConvDataFormat(const std::string& fmt_str);
+
 // Program for CausalConvWithState
 class CausalConvWithStateProgram final : public Program<CausalConvWithStateProgram> {
  public:
-  CausalConvWithStateProgram(CausalConvActivation activation, bool has_bias, bool has_conv_state)
+  CausalConvWithStateProgram(CausalConvActivation activation, bool has_bias, bool has_conv_state,
+                             CausalConvDataFormat data_format)
       : Program{"CausalConvWithState"},
         activation_(activation),
         has_bias_(has_bias),
-        has_conv_state_(has_conv_state) {}
+        has_conv_state_(has_conv_state),
+        data_format_(data_format) {}
 
   Status GenerateShaderCode(ShaderHelper& sh) const override;
 
@@ -47,6 +57,7 @@ class CausalConvWithStateProgram final : public Program<CausalConvWithStateProgr
   CausalConvActivation activation_;
   bool has_bias_;
   bool has_conv_state_;
+  CausalConvDataFormat data_format_;
 };
 
 // Kernel for CausalConvWithState
@@ -57,6 +68,7 @@ class CausalConvWithState final : public WebGpuKernel {
 
  private:
   CausalConvActivation activation_;
+  CausalConvDataFormat data_format_;
   int64_t ndim_;
 };
 

--- a/onnxruntime/contrib_ops/webgpu/bert/causal_conv_with_state.wgsl.template
+++ b/onnxruntime/contrib_ops/webgpu/bert/causal_conv_with_state.wgsl.template
@@ -4,6 +4,7 @@
 #param has_bias
 #param has_conv_state
 #param use_silu
+#param is_ntc
 
 #use guardAgainstOutOfBoundsWorkgroupSizes
 
@@ -22,6 +23,8 @@ $MAIN {
   let kernel_size = uniforms.kernel_size;
   let state_length = uniforms.state_length;  // = kernel_size - 1
 
+  // Decompose linear thread index into (batch, channel, pos) regardless of layout.
+  // Dispatch always covers B*C*L, so global_idx mapping is independent of NCT/NTC.
   let pos = global_idx % input_length;
   let bc_idx = global_idx / input_length;
   let batch_idx = bc_idx / channels;
@@ -31,11 +34,6 @@ $MAIN {
   // The convolution window looks back kernel_size-1 positions.
   // With conv_state providing the history before position 0, the
   // "virtual" input is: [conv_state[0..state_length-1], input[0..L-1]]
-  //
-  // For output position pos:
-  //   output[pos] = sum_{j=0}^{kernel_size-1} weight[j] * virtual_input[pos + j]
-  // where virtual_input is state_length positions of conv_state
-  // followed by input_length positions of input.
 
   var acc: input_element_t = 0.0;
 
@@ -50,20 +48,29 @@ $MAIN {
 
 #if has_conv_state
     if (virtual_pos < state_length) {
-      // Read from conv_state: (B, D, state_length)
+      // Read from conv_state: always (B, D, state_length) — channels-first
       let state_idx = (batch_idx * channels + channel_idx) * state_length + virtual_pos;
       val = conv_state[state_idx];
     } else {
-      // Read from input: (B, D, L)
       let input_pos = virtual_pos - state_length;
+#if is_ntc
+      // NTC: input is (B, L, D) — index = (b*L + l)*D + c
+      let input_idx = (batch_idx * input_length + input_pos) * channels + channel_idx;
+#else
+      // NCT: input is (B, D, L) — index = (b*D + c)*L + l
       let input_idx = (batch_idx * channels + channel_idx) * input_length + input_pos;
+#endif
       val = input[input_idx];
     }
 #else
     // No conv_state: pad with zeros for positions before the input
     if (virtual_pos >= state_length) {
       let input_pos = virtual_pos - state_length;
+#if is_ntc
+      let input_idx = (batch_idx * input_length + input_pos) * channels + channel_idx;
+#else
       let input_idx = (batch_idx * channels + channel_idx) * input_length + input_pos;
+#endif
       val = input[input_idx];
     }
 #endif
@@ -80,13 +87,18 @@ $MAIN {
   acc = silu(acc);
 #endif
 
-  // Write output: (B, D, L)
+  // Write output: same layout as input
+#if is_ntc
+  let out_idx = (batch_idx * input_length + pos) * channels + channel_idx;
+#else
   let out_idx = (batch_idx * channels + channel_idx) * input_length + pos;
+#endif
   output[out_idx] = acc;
 
   // Write present_state: the last (kernel_size - 1) elements from the
   // virtual input [conv_state, input]. We only write present_state once
   // per (batch, channel), using the thread at pos == 0.
+  // present_state is always (B, D, K-1) — channels-first.
   if (pos == 0u) {
     for (var s: u32 = 0; s < state_length; s = s + 1) {
       var state_val: input_element_t = 0.0;
@@ -100,13 +112,21 @@ $MAIN {
         state_val = conv_state[si];
       } else {
         let ip = vp - state_length;
+#if is_ntc
+        let ii = (batch_idx * input_length + ip) * channels + channel_idx;
+#else
         let ii = (batch_idx * channels + channel_idx) * input_length + ip;
+#endif
         state_val = input[ii];
       }
 #else
       if (vp >= state_length) {
         let ip = vp - state_length;
+#if is_ntc
+        let ii = (batch_idx * input_length + ip) * channels + channel_idx;
+#else
         let ii = (batch_idx * channels + channel_idx) * input_length + ip;
+#endif
         state_val = input[ii];
       }
 #endif

--- a/onnxruntime/core/graph/contrib_ops/bert_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/bert_defs.cc
@@ -2226,9 +2226,12 @@ Replaces the 3-op pattern (Concat + Conv + Slice) with a single fused operation.
 The convolution is causal (looks only at current and past positions along the last
 spatial dimension) and depthwise (each channel is convolved independently with its own kernel).
 
-Input layout is channels-first: (batch_size, channels, ...).
+Input layout is selectable via the data_format attribute:
+  - "NCT" (default): (batch_size, channels, ...). Channels-first.
+  - "NTC": (batch_size, ..., channels). Channels-last (only valid for ndim=1).
 Weight layout: (channels, 1, k_1, ...) for depthwise convolution.
 The carry state stores the last (k-1) positions along the causal axis for incremental decode.
+The carry state is always (batch_size, channels, k-1) regardless of data_format.
 
 The ndim attribute generalizes the op to 1D, 2D, or 3D spatial dimensions. Causality is
 enforced on the last spatial dimension only.
@@ -2249,10 +2252,15 @@ ONNX_MS_OPERATOR_SET_SCHEMA(
               "Spatial dimensionality: 1, 2, or 3. Default is 1.",
               AttributeProto::INT,
               static_cast<int64_t>(1))
+        .Attr("data_format",
+              "Input/output data layout. 'NCT' (channels-first, default) or 'NTC' (channels-last). "
+              "'NTC' is only supported for ndim=1.",
+              AttributeProto::STRING,
+              std::string("NCT"))
         .Input(0,
                "input",
-               "Input tensor with shape (batch_size, channels, ...). Channels-first layout. "
-               "Spatial dims: 1D: (L,); 2D: (H, W); 3D: (D, H, W).",
+               "Input tensor. For data_format='NCT': (batch_size, channels, ...). "
+               "For data_format='NTC' (ndim=1 only): (batch_size, length, channels).",
                "T")
         .Input(1,
                "weight",
@@ -2267,6 +2275,7 @@ ONNX_MS_OPERATOR_SET_SCHEMA(
         .Input(3,
                "past_state",
                "Carry state from previous step. For ndim=1: (batch_size, channels, k_1 - 1). "
+               "Layout is always channels-first regardless of data_format. "
                "If not provided, padding is zero.",
                "T",
                OpSchema::Optional)
@@ -2277,6 +2286,7 @@ ONNX_MS_OPERATOR_SET_SCHEMA(
         .Output(1,
                 "present_state",
                 "Updated carry state. For ndim=1: (batch_size, channels, k_1 - 1). "
+                "Layout is always channels-first. "
                 "Contains the last (k-1) values from the virtual input along the causal axis.",
                 "T")
         .TypeConstraint("T",
@@ -2286,23 +2296,28 @@ ONNX_MS_OPERATOR_SET_SCHEMA(
           propagateElemTypeFromInputToOutput(ctx, 0, 0);
           propagateElemTypeFromInputToOutput(ctx, 0, 1);
 
-          // Output 0: same shape as input (batch_size, channels, ...)
+          // Output 0: same shape as input
           propagateShapeFromInputToOutput(ctx, 0, 0);
 
-          // Output 1: state shape is (batch_size, channels, [non-causal spatial dims...], k_last - 1)
-          // For ndim=1: (B, C, k_1-1)
-          // For ndim=2: (B, C, input_H, k_2-1)
-          // For ndim=3: (B, C, input_D, input_H, k_3-1)
+          // Output 1: state shape is always (B, C, [..., k_last - 1]) regardless of data_format.
+          // For NTC (ndim=1) input is (B, L, C); for NCT input is (B, C, L) or higher.
           if (hasInputShape(ctx, 0) && hasInputShape(ctx, 1)) {
             auto& input_shape = getInputShape(ctx, 0);
             auto& weight_shape = getInputShape(ctx, 1);
             int64_t ndim = getAttribute(ctx, "ndim", 1);
+            std::string data_format = getAttribute(ctx, "data_format", std::string("NCT"));
             TensorShapeProto state_shape;
             *state_shape.add_dim() = input_shape.dim(0);  // batch_size
-            *state_shape.add_dim() = input_shape.dim(1);  // channels
-            // Copy non-causal spatial dims from input (dims 2 .. 2+ndim-2)
-            for (int64_t i = 0; i < ndim - 1; ++i) {
-              *state_shape.add_dim() = input_shape.dim(static_cast<int>(2 + i));
+            // channels: from input dim 1 (NCT) or last dim (NTC)
+            if (data_format == "NTC") {
+              // NTC only supported for ndim=1, channels at last dim
+              *state_shape.add_dim() = input_shape.dim(input_shape.dim_size() - 1);
+            } else {
+              *state_shape.add_dim() = input_shape.dim(1);  // channels
+              // Copy non-causal spatial dims from input (dims 2 .. 2+ndim-2)
+              for (int64_t i = 0; i < ndim - 1; ++i) {
+                *state_shape.add_dim() = input_shape.dim(static_cast<int>(2 + i));
+              }
             }
             // Causal (last) spatial dim: kernel_size - 1
             int last_kernel_dim = weight_shape.dim_size() - 1;


### PR DESCRIPTION
Adds an optional `data_format` attribute (default "NCT") to com.microsoft.CausalConvWithState. When set to "NTC", the input/output tensor layout is channels-last [B, T, C] instead of channels-first [B, C, T].

Motivation:
- WebGPU coalesced reads favor channel as the innermost (contiguous) dim.
- For Qwen3.5 / Mamba-style models, the conv is wrapped between two Transposes (NTC->NCT before, NCT->NTC after) in the HuggingFace reference. Supporting NTC natively lets the model builder skip both Transposes (48 nodes removed for Qwen3.5-4B).
- Measured +7.4% gen TPS / +5.8% e2e on Qwen3.5-4B int4 (RTX 5080, prefill-1000, max_tokens=100).

Scope:
- WebGPU EP: supports both NCT and NTC. Layout is part of CacheHint so the two paths get separate compiled shaders.
- CPU / CUDA EP: NCT only. Explicitly reject NTC at kernel construction to fail loudly rather than silently mis-compute.
- Default value is "NCT" - existing models without the attribute behave unchanged.
