### PR TITLE
[MLAS] Correcting Compilation Errors: onnxruntime/onnxruntime/core/mlas/lib/riscv64/sconv_depthwise_kernel_rvv.cpp:138:18: error: unused variable 'pad_bottom'

### DIFF
--- a/onnxruntime/core/mlas/lib/riscv64/sconv_depthwise_kernel_rvv.cpp
+++ b/onnxruntime/core/mlas/lib/riscv64/sconv_depthwise_kernel_rvv.cpp
@@ -135,7 +135,7 @@ MlasConv2dSingleChannel_CHW_Kernel3x3_Pad01_Dilation1(
 
     const size_t pad_top = Parameters->Padding[0];
     const size_t pad_left = Parameters->Padding[1];
-    const size_t pad_bottom = Parameters->Padding[2];
+    [[maybe_unused]] const size_t pad_bottom = Parameters->Padding[2];
     const size_t pad_right = Parameters->Padding[3];
 
     assert(pad_top <= 1);


### PR DESCRIPTION
…riscv64/sconv_depthwise_kernel_rvv.cpp:138:18: error: unused variable 'pad_bottom'

Correcting Compilation Errors: onnxruntime/onnxruntime/core/mlas/lib/riscv64/sconv_depthwise_kernel_rvv.cpp:138:18: error: unused variable 'pad_bottom'
