### PR TITLE
Fix mlasi_sve.h preprocessor guards to allow clang compilation

### DIFF
--- a/onnxruntime/core/mlas/lib/sve/mlasi_sve.h
+++ b/onnxruntime/core/mlas/lib/sve/mlasi_sve.h
@@ -20,6 +20,7 @@ Abstract:
 #ifndef __clang__
 #pragma GCC push_options
 #pragma GCC target("arch=armv8.2-a+sve")
+#endif
 
 // Use Clang-specific per-function attribute
 #ifdef __clang__
@@ -676,5 +677,4 @@ MlasSveCompareGreaterThan(svbool_t Pred, MLAS_SVFLOAT32 A, MLAS_SVFLOAT32 B)
 #pragma GCC pop_options
 #endif
 
-#endif
 


### PR DESCRIPTION
### Description

The outer `#ifndef __clang__` in `mlasi_sve.h` (line 20 to line 679) was intended to wrap the GCC-specific `#pragma GCC` directives, but it also ends up hiding every SVE kernel declaration and the typedefs from clang. The `#ifdef __clang__` block that defines `MLAS_SVE_TARGET` for clang's per-function `__attribute__((target("...")))` syntax is unreachable for the same reason.

This moves the closing `#endif` up to right after the GCC pragmas so only the pragmas are GCC-only, and the rest of the header (typedefs, kernel declarations, MLAS_SVE_TARGET) is visible to both compilers.

### Motivation and Context

Without this, building MLAS with clang for aarch64 fails at platform.cpp - the `MLAS_USE_SVE` runtime-dispatch block references `MlasSveErfKernel`, `MlasSveLogisticKernel`, and friends, all undeclared from clang's perspective. Confirmed working with clang 20.1.8.
