### PR TITLE
Fix WeaklyCanonicalPath ERROR_ACCESS_DENIED in Windows AppContainers

### DIFF
--- a/onnxruntime/core/framework/tensorprotoutils.cc
+++ b/onnxruntime/core/framework/tensorprotoutils.cc
@@ -11,9 +11,6 @@
 #if defined(__wasm__)
 #include <emscripten.h>
 #endif
-#if defined(_WIN32)
-#include <Windows.h>
-#endif
 
 #include <gsl/gsl>
 #include "core/common/logging/logging.h"
@@ -383,147 +380,13 @@ Status TensorProtoWithExternalDataToTensorProto(
   return Status::OK();
 }
 
-#if defined(_WIN32)
-namespace {
-
-constexpr std::wstring_view kGlobalRootPrefix{L"\\\\?\\GLOBALROOT"};
-
-HANDLE OpenHandleForFinalPath(const std::filesystem::path& path) {
-  CREATEFILE2_EXTENDED_PARAMETERS params{};
-  params.dwSize = sizeof(params);
-  params.dwFileFlags = FILE_FLAG_BACKUP_SEMANTICS;
-  return ::CreateFile2(path.c_str(),
-                       FILE_READ_ATTRIBUTES,
-                       FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
-                       OPEN_EXISTING,
-                       &params);
-}
-
-// Resolves `path` via GetFinalPathNameByHandleW with VOLUME_NAME_NT and prefixes the
-// result with "\\?\GLOBALROOT" so it remains a valid Win32 path.
-bool TryGetFinalPathNt(const std::filesystem::path& path, std::filesystem::path& result) {
-  HANDLE handle = OpenHandleForFinalPath(path);
-  if (handle == INVALID_HANDLE_VALUE) {
-    return false;
-  }
-
-  std::wstring buffer(MAX_PATH, L'\0');
-  constexpr DWORD kFlags = FILE_NAME_NORMALIZED | VOLUME_NAME_NT;
-  DWORD needed = ::GetFinalPathNameByHandleW(handle, buffer.data(),
-                                             static_cast<DWORD>(buffer.size()), kFlags);
-  if (needed != 0 && needed >= buffer.size()) {
-    buffer.resize(needed);
-    needed = ::GetFinalPathNameByHandleW(handle, buffer.data(),
-                                         static_cast<DWORD>(buffer.size()), kFlags);
-  }
-  ::CloseHandle(handle);
-
-  if (needed == 0 || needed >= buffer.size()) {
-    return false;
-  }
-  buffer.resize(needed);
-
-  std::wstring prefixed;
-  prefixed.reserve(kGlobalRootPrefix.size() + buffer.size());
-  prefixed.append(kGlobalRootPrefix);
-  prefixed.append(buffer);
-  result = std::filesystem::path(std::move(prefixed));
-  return true;
-}
-
-// Mirrors std::filesystem::weakly_canonical: walks `input` from the leaf upward to find
-// the longest existing prefix, canonicalizes it via TryGetFinalPathNt, then lexically
-// appends any nonexistent tail. Returns false if no canonical anchor exists.
-bool TryWeaklyCanonicalPathNtVolume(const std::filesystem::path& input,
-                                    std::filesystem::path& result) {
-  std::filesystem::path head = input;
-  std::filesystem::path tail;
-  std::filesystem::path canonical_head;
-  bool found_existing_prefix = false;
-
-  while (true) {
-    std::error_code ec;
-    const bool exists = std::filesystem::exists(head, ec);
-    if (ec) {
-      return false;
-    }
-    if (exists) {
-      if (!TryGetFinalPathNt(head, canonical_head)) {
-        return false;
-      }
-      found_existing_prefix = true;
-      break;
-    }
-    if (head.empty()) {
-      break;
-    }
-    const auto parent = head.parent_path();
-    if (parent == head) {
-      break;
-    }
-    const auto leaf = head.filename();
-    if (!leaf.empty()) {
-      // operator/ would insert a separator before an empty rhs, leaving a trailing
-      // separator that swallows the real filename later.
-      tail = tail.empty() ? leaf : (leaf / tail);
-    }
-    head = parent;
-  }
-
-  if (!found_existing_prefix) {
-    return false;
-  }
-
-  if (tail.empty()) {
-    result = std::move(canonical_head);
-  } else {
-    result = (canonical_head / tail).lexically_normal();
-  }
-  return true;
-}
-
-}  // namespace
-#endif  // defined(_WIN32)
-
-// Wraps std::filesystem::weakly_canonical with error_code handling.
-//
-// On Windows, std::filesystem::weakly_canonical uses GetFinalPathNameByHandleW with
-// VOLUME_NAME_DOS, which fails with ERROR_ACCESS_DENIED inside an AppContainer
-// (Volume Mount Manager queries are denied by the AppContainer token regardless of
-// file ACLs). Fall back to a manual canonicalization with VOLUME_NAME_NT, which
-// preserves volume identity so the cross-volume escape rejection in
-// ValidateExternalDataPath continues to hold. Do NOT switch the fallback to
-// VOLUME_NAME_NONE: it strips volume identity and re-introduces the cross-volume
-// escape that PR #26776 prevents.
+// Wraps Env::GetWeaklyCanonicalPath for std::filesystem::path.
 static Status WeaklyCanonicalPath(const std::filesystem::path& path, std::filesystem::path& result) {
-  std::error_code ec;
-  result = std::filesystem::weakly_canonical(path, ec);
-  if (!ec) {
-    return Status::OK();
-  }
-
-#if defined(_WIN32)
-  if (ec.value() == ERROR_ACCESS_DENIED) {
-    std::filesystem::path fallback;
-    if (TryWeaklyCanonicalPathNtVolume(path, fallback)) {
-      result = std::move(fallback);
-      return Status::OK();
-    }
-  }
-#endif
-
-  ORT_RETURN_IF(ec, "Failed to get the weakly canonical path: ", path, " - ", ec.message());
+  PathString canonical_str;
+  ORT_RETURN_IF_ERROR(Env::Default().GetWeaklyCanonicalPath(path.native(), canonical_str));
+  result = std::filesystem::path(std::move(canonical_str));
   return Status::OK();
 }
-
-#if defined(_WIN32)
-namespace internal {
-bool WeaklyCanonicalPathNtVolumeFallbackForTesting(const std::filesystem::path& input,
-                                                   std::filesystem::path& result) {
-  return TryWeaklyCanonicalPathNtVolume(input, result);
-}
-}  // namespace internal
-#endif
 
 // Wraps std::filesystem::exists with error_code handling.
 static Status PathExists(const std::filesystem::path& path, bool& exists) {

--- a/onnxruntime/core/framework/tensorprotoutils.cc
+++ b/onnxruntime/core/framework/tensorprotoutils.cc
@@ -11,6 +11,9 @@
 #if defined(__wasm__)
 #include <emscripten.h>
 #endif
+#if defined(_WIN32)
+#include <Windows.h>
+#endif
 
 #include <gsl/gsl>
 #include "core/common/logging/logging.h"
@@ -380,13 +383,147 @@ Status TensorProtoWithExternalDataToTensorProto(
   return Status::OK();
 }
 
+#if defined(_WIN32)
+namespace {
+
+constexpr std::wstring_view kGlobalRootPrefix{L"\\\\?\\GLOBALROOT"};
+
+HANDLE OpenHandleForFinalPath(const std::filesystem::path& path) {
+  CREATEFILE2_EXTENDED_PARAMETERS params{};
+  params.dwSize = sizeof(params);
+  params.dwFileFlags = FILE_FLAG_BACKUP_SEMANTICS;
+  return ::CreateFile2(path.c_str(),
+                       FILE_READ_ATTRIBUTES,
+                       FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                       OPEN_EXISTING,
+                       &params);
+}
+
+// Resolves `path` via GetFinalPathNameByHandleW with VOLUME_NAME_NT and prefixes the
+// result with "\\?\GLOBALROOT" so it remains a valid Win32 path.
+bool TryGetFinalPathNt(const std::filesystem::path& path, std::filesystem::path& result) {
+  HANDLE handle = OpenHandleForFinalPath(path);
+  if (handle == INVALID_HANDLE_VALUE) {
+    return false;
+  }
+
+  std::wstring buffer(MAX_PATH, L'\0');
+  constexpr DWORD kFlags = FILE_NAME_NORMALIZED | VOLUME_NAME_NT;
+  DWORD needed = ::GetFinalPathNameByHandleW(handle, buffer.data(),
+                                             static_cast<DWORD>(buffer.size()), kFlags);
+  if (needed != 0 && needed >= buffer.size()) {
+    buffer.resize(needed);
+    needed = ::GetFinalPathNameByHandleW(handle, buffer.data(),
+                                         static_cast<DWORD>(buffer.size()), kFlags);
+  }
+  ::CloseHandle(handle);
+
+  if (needed == 0 || needed >= buffer.size()) {
+    return false;
+  }
+  buffer.resize(needed);
+
+  std::wstring prefixed;
+  prefixed.reserve(kGlobalRootPrefix.size() + buffer.size());
+  prefixed.append(kGlobalRootPrefix);
+  prefixed.append(buffer);
+  result = std::filesystem::path(std::move(prefixed));
+  return true;
+}
+
+// Mirrors std::filesystem::weakly_canonical: walks `input` from the leaf upward to find
+// the longest existing prefix, canonicalizes it via TryGetFinalPathNt, then lexically
+// appends any nonexistent tail. Returns false if no canonical anchor exists.
+bool TryWeaklyCanonicalPathNtVolume(const std::filesystem::path& input,
+                                    std::filesystem::path& result) {
+  std::filesystem::path head = input;
+  std::filesystem::path tail;
+  std::filesystem::path canonical_head;
+  bool found_existing_prefix = false;
+
+  while (true) {
+    std::error_code ec;
+    const bool exists = std::filesystem::exists(head, ec);
+    if (ec) {
+      return false;
+    }
+    if (exists) {
+      if (!TryGetFinalPathNt(head, canonical_head)) {
+        return false;
+      }
+      found_existing_prefix = true;
+      break;
+    }
+    if (head.empty()) {
+      break;
+    }
+    const auto parent = head.parent_path();
+    if (parent == head) {
+      break;
+    }
+    const auto leaf = head.filename();
+    if (!leaf.empty()) {
+      // operator/ would insert a separator before an empty rhs, leaving a trailing
+      // separator that swallows the real filename later.
+      tail = tail.empty() ? leaf : (leaf / tail);
+    }
+    head = parent;
+  }
+
+  if (!found_existing_prefix) {
+    return false;
+  }
+
+  if (tail.empty()) {
+    result = std::move(canonical_head);
+  } else {
+    result = (canonical_head / tail).lexically_normal();
+  }
+  return true;
+}
+
+}  // namespace
+#endif  // defined(_WIN32)
+
 // Wraps std::filesystem::weakly_canonical with error_code handling.
+//
+// On Windows, std::filesystem::weakly_canonical uses GetFinalPathNameByHandleW with
+// VOLUME_NAME_DOS, which fails with ERROR_ACCESS_DENIED inside an AppContainer
+// (Volume Mount Manager queries are denied by the AppContainer token regardless of
+// file ACLs). Fall back to a manual canonicalization with VOLUME_NAME_NT, which
+// preserves volume identity so the cross-volume escape rejection in
+// ValidateExternalDataPath continues to hold. Do NOT switch the fallback to
+// VOLUME_NAME_NONE: it strips volume identity and re-introduces the cross-volume
+// escape that PR #26776 prevents.
 static Status WeaklyCanonicalPath(const std::filesystem::path& path, std::filesystem::path& result) {
   std::error_code ec;
   result = std::filesystem::weakly_canonical(path, ec);
+  if (!ec) {
+    return Status::OK();
+  }
+
+#if defined(_WIN32)
+  if (ec.value() == ERROR_ACCESS_DENIED) {
+    std::filesystem::path fallback;
+    if (TryWeaklyCanonicalPathNtVolume(path, fallback)) {
+      result = std::move(fallback);
+      return Status::OK();
+    }
+  }
+#endif
+
   ORT_RETURN_IF(ec, "Failed to get the weakly canonical path: ", path, " - ", ec.message());
   return Status::OK();
 }
+
+#if defined(_WIN32)
+namespace internal {
+bool WeaklyCanonicalPathNtVolumeFallbackForTesting(const std::filesystem::path& input,
+                                                   std::filesystem::path& result) {
+  return TryWeaklyCanonicalPathNtVolume(input, result);
+}
+}  // namespace internal
+#endif
 
 // Wraps std::filesystem::exists with error_code handling.
 static Status PathExists(const std::filesystem::path& path, bool& exists) {

--- a/onnxruntime/core/framework/tensorprotoutils.h
+++ b/onnxruntime/core/framework/tensorprotoutils.h
@@ -589,6 +589,15 @@ Status TensorProtoWithExternalDataToTensorProto(
 Status ValidateExternalDataPath(const std::filesystem::path& model_path,
                                 const std::filesystem::path& external_data_path);
 
+#if defined(_WIN32)
+namespace internal {
+// Internal helper exposed for unit testing of the AppContainer fallback used by
+// WeaklyCanonicalPath. Not part of any public API; subject to change.
+bool WeaklyCanonicalPathNtVolumeFallbackForTesting(const std::filesystem::path& input,
+                                                   std::filesystem::path& result);
+}  // namespace internal
+#endif  // defined(_WIN32)
+
 #endif  // !defined(SHARED_PROVIDER)
 
 inline bool HasType(const ONNX_NAMESPACE::AttributeProto& at_proto) {

--- a/onnxruntime/core/framework/tensorprotoutils.h
+++ b/onnxruntime/core/framework/tensorprotoutils.h
@@ -589,15 +589,6 @@ Status TensorProtoWithExternalDataToTensorProto(
 Status ValidateExternalDataPath(const std::filesystem::path& model_path,
                                 const std::filesystem::path& external_data_path);
 
-#if defined(_WIN32)
-namespace internal {
-// Internal helper exposed for unit testing of the AppContainer fallback used by
-// WeaklyCanonicalPath. Not part of any public API; subject to change.
-bool WeaklyCanonicalPathNtVolumeFallbackForTesting(const std::filesystem::path& input,
-                                                   std::filesystem::path& result);
-}  // namespace internal
-#endif  // defined(_WIN32)
-
 #endif  // !defined(SHARED_PROVIDER)
 
 inline bool HasType(const ONNX_NAMESPACE::AttributeProto& at_proto) {

--- a/onnxruntime/core/platform/env.h
+++ b/onnxruntime/core/platform/env.h
@@ -231,6 +231,12 @@ class Env {
       const PathString& path,
       PathString& canonical_path) const = 0;
 
+  /** Like GetCanonicalPath, but the path is not required to exist. Mirrors
+   *  std::filesystem::weakly_canonical. */
+  virtual common::Status GetWeaklyCanonicalPath(
+      const PathString& path,
+      PathString& canonical_path) const = 0;
+
   // This functions is always successful. It can't fail.
   virtual PIDType GetSelfPid() const = 0;
 

--- a/onnxruntime/core/platform/posix/env.cc
+++ b/onnxruntime/core/platform/posix/env.cc
@@ -543,6 +543,19 @@ class PosixEnv : public Env {
     return Status::OK();
   }
 
+  common::Status GetWeaklyCanonicalPath(
+      const PathString& path,
+      PathString& canonical_path) const override {
+    std::error_code ec;
+    auto canonical = std::filesystem::weakly_canonical(std::filesystem::path{path}, ec);
+    if (ec) {
+      return common::Status(common::ONNXRUNTIME, common::FAIL,
+                            "Failed to get the weakly canonical path: " + path + " - " + ec.message());
+    }
+    canonical_path.assign(canonical.native());
+    return Status::OK();
+  }
+
   common::Status LoadDynamicLibrary(const PathString& library_filename, bool global_symbols, void** handle) const override {
     dlerror();  // clear any old error_str
     *handle = dlopen(library_filename.c_str(), RTLD_NOW | (global_symbols ? RTLD_GLOBAL : RTLD_LOCAL));

--- a/onnxruntime/core/platform/windows/env.cc
+++ b/onnxruntime/core/platform/windows/env.cc
@@ -20,6 +20,7 @@ limitations under the License.
 
 #include <iostream>
 #include <fstream>
+#include <filesystem>
 #include <optional>
 #include <string>
 #include <thread>
@@ -684,6 +685,137 @@ common::Status WindowsEnv::GetCanonicalPath(
 
   return Status::OK();
 }
+
+namespace {
+
+constexpr std::wstring_view kGlobalRootPrefix{L"\\\\?\\GLOBALROOT"};
+
+HANDLE OpenHandleForFinalPath(const std::filesystem::path& path) {
+  CREATEFILE2_EXTENDED_PARAMETERS params{};
+  params.dwSize = sizeof(params);
+  params.dwFileFlags = FILE_FLAG_BACKUP_SEMANTICS;
+  return ::CreateFile2(path.c_str(),
+                       FILE_READ_ATTRIBUTES,
+                       FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                       OPEN_EXISTING,
+                       &params);
+}
+
+// Final-path query using VOLUME_NAME_NT, prefixed with "\\?\GLOBALROOT" to stay a valid Win32 path.
+bool TryGetFinalPathNt(const std::filesystem::path& path, std::filesystem::path& result) {
+  HANDLE handle = OpenHandleForFinalPath(path);
+  if (handle == INVALID_HANDLE_VALUE) {
+    return false;
+  }
+
+  std::wstring buffer(MAX_PATH, L'\0');
+  constexpr DWORD kFlags = FILE_NAME_NORMALIZED | VOLUME_NAME_NT;
+  DWORD needed = ::GetFinalPathNameByHandleW(handle, buffer.data(),
+                                             static_cast<DWORD>(buffer.size()), kFlags);
+  if (needed != 0 && needed >= buffer.size()) {
+    buffer.resize(needed);
+    needed = ::GetFinalPathNameByHandleW(handle, buffer.data(),
+                                         static_cast<DWORD>(buffer.size()), kFlags);
+  }
+  ::CloseHandle(handle);
+
+  if (needed == 0 || needed >= buffer.size()) {
+    return false;
+  }
+  buffer.resize(needed);
+
+  std::wstring prefixed;
+  prefixed.reserve(kGlobalRootPrefix.size() + buffer.size());
+  prefixed.append(kGlobalRootPrefix);
+  prefixed.append(buffer);
+  result = std::filesystem::path(std::move(prefixed));
+  return true;
+}
+
+// weakly_canonical analogue using TryGetFinalPathNt for the existing prefix.
+bool TryWeaklyCanonicalPathNtVolume(const std::filesystem::path& input,
+                                    std::filesystem::path& result) {
+  std::filesystem::path head = input;
+  std::filesystem::path tail;
+  std::filesystem::path canonical_head;
+  bool found_existing_prefix = false;
+
+  while (true) {
+    std::error_code ec;
+    const bool exists = std::filesystem::exists(head, ec);
+    if (ec) {
+      return false;
+    }
+    if (exists) {
+      if (!TryGetFinalPathNt(head, canonical_head)) {
+        return false;
+      }
+      found_existing_prefix = true;
+      break;
+    }
+    if (head.empty()) {
+      break;
+    }
+    const auto parent = head.parent_path();
+    if (parent == head) {
+      break;
+    }
+    const auto leaf = head.filename();
+    if (!leaf.empty()) {
+      // path / empty would insert a trailing separator.
+      tail = tail.empty() ? leaf : (leaf / tail);
+    }
+    head = parent;
+  }
+
+  if (!found_existing_prefix) {
+    return false;
+  }
+
+  if (tail.empty()) {
+    result = std::move(canonical_head);
+  } else {
+    result = (canonical_head / tail).lexically_normal();
+  }
+  return true;
+}
+
+}  // namespace
+
+// On AppContainer, std::filesystem::weakly_canonical fails with ERROR_ACCESS_DENIED
+// because VOLUME_NAME_DOS goes through the Volume Mount Manager. Fall back to
+// VOLUME_NAME_NT, which preserves volume identity (cross-volume escape rejection in
+// ValidateExternalDataPath relies on this — do NOT use VOLUME_NAME_NONE).
+common::Status WindowsEnv::GetWeaklyCanonicalPath(
+    const PathString& path,
+    PathString& canonical_path) const {
+  std::filesystem::path fs_path{path};
+  std::error_code ec;
+  std::filesystem::path canonical = std::filesystem::weakly_canonical(fs_path, ec);
+  if (!ec) {
+    canonical_path = canonical.native();
+    return Status::OK();
+  }
+
+  if (ec.value() == ERROR_ACCESS_DENIED) {
+    std::filesystem::path fallback;
+    if (TryWeaklyCanonicalPathNtVolume(fs_path, fallback)) {
+      canonical_path = fallback.native();
+      return Status::OK();
+    }
+  }
+
+  return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
+                         "Failed to get the weakly canonical path: ",
+                         ToUTF8String(path), " - ", ec.message());
+}
+
+namespace internal {
+bool WeaklyCanonicalPathNtVolumeFallbackForTesting(const std::filesystem::path& input,
+                                                   std::filesystem::path& result) {
+  return TryWeaklyCanonicalPathNtVolume(input, result);
+}
+}  // namespace internal
 
 // Return the path of the executable/shared library for the current running code. This is to make it
 // possible to load other shared libraries installed next to our core runtime code.

--- a/onnxruntime/core/platform/windows/env.cc
+++ b/onnxruntime/core/platform/windows/env.cc
@@ -690,34 +690,33 @@ namespace {
 
 constexpr std::wstring_view kGlobalRootPrefix{L"\\\\?\\GLOBALROOT"};
 
-HANDLE OpenHandleForFinalPath(const std::filesystem::path& path) {
+wil::unique_hfile OpenHandleForFinalPath(const std::filesystem::path& path) {
   CREATEFILE2_EXTENDED_PARAMETERS params{};
   params.dwSize = sizeof(params);
   params.dwFileFlags = FILE_FLAG_BACKUP_SEMANTICS;
-  return ::CreateFile2(path.c_str(),
-                       FILE_READ_ATTRIBUTES,
-                       FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
-                       OPEN_EXISTING,
-                       &params);
+  return wil::unique_hfile{::CreateFile2(path.c_str(),
+                                         FILE_READ_ATTRIBUTES,
+                                         FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                                         OPEN_EXISTING,
+                                         &params)};
 }
 
 // Final-path query using VOLUME_NAME_NT, prefixed with "\\?\GLOBALROOT" to stay a valid Win32 path.
 bool TryGetFinalPathNt(const std::filesystem::path& path, std::filesystem::path& result) {
-  HANDLE handle = OpenHandleForFinalPath(path);
-  if (handle == INVALID_HANDLE_VALUE) {
+  wil::unique_hfile handle = OpenHandleForFinalPath(path);
+  if (handle.get() == INVALID_HANDLE_VALUE) {
     return false;
   }
 
   std::wstring buffer(MAX_PATH, L'\0');
   constexpr DWORD kFlags = FILE_NAME_NORMALIZED | VOLUME_NAME_NT;
-  DWORD needed = ::GetFinalPathNameByHandleW(handle, buffer.data(),
+  DWORD needed = ::GetFinalPathNameByHandleW(handle.get(), buffer.data(),
                                              static_cast<DWORD>(buffer.size()), kFlags);
   if (needed != 0 && needed >= buffer.size()) {
     buffer.resize(needed);
-    needed = ::GetFinalPathNameByHandleW(handle, buffer.data(),
+    needed = ::GetFinalPathNameByHandleW(handle.get(), buffer.data(),
                                          static_cast<DWORD>(buffer.size()), kFlags);
   }
-  ::CloseHandle(handle);
 
   if (needed == 0 || needed >= buffer.size()) {
     return false;

--- a/onnxruntime/core/platform/windows/env.h
+++ b/onnxruntime/core/platform/windows/env.h
@@ -18,6 +18,7 @@ limitations under the License.
 #include "core/platform/windows/telemetry.h"
 #include "core/common/inlined_containers.h"
 #include <Windows.h>
+#include <filesystem>
 
 namespace onnxruntime {
 
@@ -79,6 +80,7 @@ class WindowsEnv : public Env {
   common::Status FileOpenWr(const std::string& path, /*out*/ int& fd) const override;
   common::Status FileClose(int fd) const override;
   common::Status GetCanonicalPath(const PathString& path, PathString& canonical_path) const override;
+  common::Status GetWeaklyCanonicalPath(const PathString& path, PathString& canonical_path) const override;
   PathString GetRuntimePath() const override;
   Status LoadDynamicLibrary(const PathString& library_filename, bool /*global_symbols*/, void** handle) const override;
   Status UnloadDynamicLibrary(void* handle) const override;
@@ -140,5 +142,11 @@ class WindowsEnv : public Env {
   typedef VOID(WINAPI* FnGetSystemTimePreciseAsFileTime)(LPFILETIME);
   WindowsTelemetry telemetry_provider_;
 };
+
+namespace internal {
+// Test-only: exposes the AppContainer fallback used by WindowsEnv::GetWeaklyCanonicalPath.
+bool WeaklyCanonicalPathNtVolumeFallbackForTesting(const std::filesystem::path& input,
+                                                   std::filesystem::path& result);
+}  // namespace internal
 
 }  // namespace onnxruntime

--- a/onnxruntime/test/framework/tensorutils_test.cc
+++ b/onnxruntime/test/framework/tensorutils_test.cc
@@ -21,6 +21,7 @@
 
 #ifdef _WIN32
 #include <Windows.h>
+#include "core/platform/windows/env.h"
 #endif
 
 using namespace ::onnxruntime::utils;
@@ -716,12 +717,12 @@ TEST_F(PathValidationTest, ValidateExternalDataPathEmptyModelPathWithSymlinkOuts
 }
 
 #if defined(_WIN32)
-// Direct tests for the Windows AppContainer fallback used by WeaklyCanonicalPath.
-// The AppContainer trigger itself can't be reproduced in a unit test environment;
-// see the bug report referenced in WeaklyCanonicalPath's source comment.
+// Direct tests for the Windows AppContainer fallback used by
+// WindowsEnv::GetWeaklyCanonicalPath. The AppContainer trigger itself can't be
+// reproduced in a unit test environment; see microsoft/onnxruntime#28508.
 TEST_F(PathValidationTest, WeaklyCanonicalPathNtVolumeFallback_ExistingDirectory) {
   std::filesystem::path canonical;
-  ASSERT_TRUE(utils::internal::WeaklyCanonicalPathNtVolumeFallbackForTesting(base_dir_, canonical));
+  ASSERT_TRUE(onnxruntime::internal::WeaklyCanonicalPathNtVolumeFallbackForTesting(base_dir_, canonical));
 
   EXPECT_THAT(canonical.wstring(), testing::StartsWith(L"\\\\?\\GLOBALROOT\\Device\\"));
 
@@ -734,7 +735,7 @@ TEST_F(PathValidationTest, WeaklyCanonicalPathNtVolumeFallback_ExistingFile) {
 
   std::filesystem::path canonical;
   ASSERT_TRUE(
-      utils::internal::WeaklyCanonicalPathNtVolumeFallbackForTesting(base_dir_ / "data.bin", canonical));
+      onnxruntime::internal::WeaklyCanonicalPathNtVolumeFallbackForTesting(base_dir_ / "data.bin", canonical));
 
   EXPECT_THAT(canonical.wstring(), testing::StartsWith(L"\\\\?\\GLOBALROOT\\Device\\"));
 
@@ -746,7 +747,7 @@ TEST_F(PathValidationTest, WeaklyCanonicalPathNtVolumeFallback_ExistingFile) {
 TEST_F(PathValidationTest, WeaklyCanonicalPathNtVolumeFallback_NonExistentLeafLexicallyAppended) {
   const std::filesystem::path leaf{L"does_not_exist.bin"};
   std::filesystem::path canonical;
-  ASSERT_TRUE(utils::internal::WeaklyCanonicalPathNtVolumeFallbackForTesting(base_dir_ / leaf, canonical));
+  ASSERT_TRUE(onnxruntime::internal::WeaklyCanonicalPathNtVolumeFallbackForTesting(base_dir_ / leaf, canonical));
 
   EXPECT_THAT(canonical.wstring(), testing::StartsWith(L"\\\\?\\GLOBALROOT\\Device\\"));
   EXPECT_EQ(canonical.filename(), leaf);
@@ -754,7 +755,7 @@ TEST_F(PathValidationTest, WeaklyCanonicalPathNtVolumeFallback_NonExistentLeafLe
   // The canonicalized parent must be a path-component prefix of the result so that the
   // containment check in ValidateExternalDataPath still works.
   std::filesystem::path parent_canonical;
-  ASSERT_TRUE(utils::internal::WeaklyCanonicalPathNtVolumeFallbackForTesting(base_dir_, parent_canonical));
+  ASSERT_TRUE(onnxruntime::internal::WeaklyCanonicalPathNtVolumeFallbackForTesting(base_dir_, parent_canonical));
   auto [parent_end, full_it] = std::mismatch(parent_canonical.begin(), parent_canonical.end(),
                                              canonical.begin(), canonical.end());
   EXPECT_EQ(parent_end, parent_canonical.end())
@@ -763,7 +764,7 @@ TEST_F(PathValidationTest, WeaklyCanonicalPathNtVolumeFallback_NonExistentLeafLe
 
 TEST_F(PathValidationTest, WeaklyCanonicalPathNtVolumeFallback_NonExistentMiddleAndLeaf) {
   std::filesystem::path canonical;
-  ASSERT_TRUE(utils::internal::WeaklyCanonicalPathNtVolumeFallbackForTesting(
+  ASSERT_TRUE(onnxruntime::internal::WeaklyCanonicalPathNtVolumeFallbackForTesting(
       base_dir_ / L"missing_dir" / L"data.bin", canonical));
 
   EXPECT_THAT(canonical.wstring(), testing::StartsWith(L"\\\\?\\GLOBALROOT\\Device\\"));
@@ -777,7 +778,7 @@ TEST_F(PathValidationTest, WeaklyCanonicalPathNtVolumeFallback_AllNonExistentRet
   // unverified path.
   const std::filesystem::path bogus{L"\\\\?\\Volume{00000000-0000-0000-0000-000000000000}\\nope\\data.bin"};
   std::filesystem::path canonical;
-  EXPECT_FALSE(utils::internal::WeaklyCanonicalPathNtVolumeFallbackForTesting(bogus, canonical));
+  EXPECT_FALSE(onnxruntime::internal::WeaklyCanonicalPathNtVolumeFallbackForTesting(bogus, canonical));
 }
 
 TEST_F(PathValidationTest, WeaklyCanonicalPathNtVolumeFallback_MatchesWeaklyCanonicalAtFile) {
@@ -792,7 +793,7 @@ TEST_F(PathValidationTest, WeaklyCanonicalPathNtVolumeFallback_MatchesWeaklyCano
   ASSERT_FALSE(ec) << ec.message();
 
   std::filesystem::path fallback;
-  ASSERT_TRUE(utils::internal::WeaklyCanonicalPathNtVolumeFallbackForTesting(target, fallback));
+  ASSERT_TRUE(onnxruntime::internal::WeaklyCanonicalPathNtVolumeFallbackForTesting(target, fallback));
 
   EXPECT_TRUE(std::filesystem::equivalent(reference, fallback, ec))
       << "reference=" << reference << " fallback=" << fallback << " ec=" << ec.message();
@@ -810,8 +811,8 @@ TEST_F(PathValidationTest, WeaklyCanonicalPathNtVolumeFallback_ResolvesSymlinks)
 
   std::filesystem::path link_canonical;
   std::filesystem::path target_canonical;
-  ASSERT_TRUE(utils::internal::WeaklyCanonicalPathNtVolumeFallbackForTesting(link, link_canonical));
-  ASSERT_TRUE(utils::internal::WeaklyCanonicalPathNtVolumeFallbackForTesting(target, target_canonical));
+  ASSERT_TRUE(onnxruntime::internal::WeaklyCanonicalPathNtVolumeFallbackForTesting(link, link_canonical));
+  ASSERT_TRUE(onnxruntime::internal::WeaklyCanonicalPathNtVolumeFallbackForTesting(target, target_canonical));
 
   std::error_code ec;
   EXPECT_TRUE(std::filesystem::equivalent(link_canonical, target_canonical, ec))
@@ -822,11 +823,11 @@ TEST_F(PathValidationTest, WeaklyCanonicalPathNtVolumeFallback_ResolvesDotDot) {
   CreateDirectories(base_dir_ / "sub_for_dotdot");
 
   std::filesystem::path canonical;
-  ASSERT_TRUE(utils::internal::WeaklyCanonicalPathNtVolumeFallbackForTesting(
+  ASSERT_TRUE(onnxruntime::internal::WeaklyCanonicalPathNtVolumeFallbackForTesting(
       base_dir_ / "sub_for_dotdot" / "..", canonical));
 
   std::filesystem::path base_canonical;
-  ASSERT_TRUE(utils::internal::WeaklyCanonicalPathNtVolumeFallbackForTesting(base_dir_, base_canonical));
+  ASSERT_TRUE(onnxruntime::internal::WeaklyCanonicalPathNtVolumeFallbackForTesting(base_dir_, base_canonical));
 
   std::error_code ec;
   EXPECT_TRUE(std::filesystem::equivalent(canonical, base_canonical, ec))

--- a/onnxruntime/test/framework/tensorutils_test.cc
+++ b/onnxruntime/test/framework/tensorutils_test.cc
@@ -715,6 +715,125 @@ TEST_F(PathValidationTest, ValidateExternalDataPathEmptyModelPathWithSymlinkOuts
   EXPECT_THAT(status.ErrorMessage(), testing::HasSubstr("escapes working directory"));
 }
 
+#if defined(_WIN32)
+// Direct tests for the Windows AppContainer fallback used by WeaklyCanonicalPath.
+// The AppContainer trigger itself can't be reproduced in a unit test environment;
+// see the bug report referenced in WeaklyCanonicalPath's source comment.
+TEST_F(PathValidationTest, WeaklyCanonicalPathNtVolumeFallback_ExistingDirectory) {
+  std::filesystem::path canonical;
+  ASSERT_TRUE(utils::internal::WeaklyCanonicalPathNtVolumeFallbackForTesting(base_dir_, canonical));
+
+  EXPECT_THAT(canonical.wstring(), testing::StartsWith(L"\\\\?\\GLOBALROOT\\Device\\"));
+
+  std::error_code ec;
+  EXPECT_TRUE(std::filesystem::exists(canonical, ec)) << "ec=" << ec.message();
+}
+
+TEST_F(PathValidationTest, WeaklyCanonicalPathNtVolumeFallback_ExistingFile) {
+  CreateEmptyFile(base_dir_ / "data.bin");
+
+  std::filesystem::path canonical;
+  ASSERT_TRUE(
+      utils::internal::WeaklyCanonicalPathNtVolumeFallbackForTesting(base_dir_ / "data.bin", canonical));
+
+  EXPECT_THAT(canonical.wstring(), testing::StartsWith(L"\\\\?\\GLOBALROOT\\Device\\"));
+
+  std::error_code ec;
+  EXPECT_TRUE(std::filesystem::exists(canonical, ec)) << "ec=" << ec.message();
+  EXPECT_TRUE(std::filesystem::is_regular_file(canonical, ec)) << "ec=" << ec.message();
+}
+
+TEST_F(PathValidationTest, WeaklyCanonicalPathNtVolumeFallback_NonExistentLeafLexicallyAppended) {
+  const std::filesystem::path leaf{L"does_not_exist.bin"};
+  std::filesystem::path canonical;
+  ASSERT_TRUE(utils::internal::WeaklyCanonicalPathNtVolumeFallbackForTesting(base_dir_ / leaf, canonical));
+
+  EXPECT_THAT(canonical.wstring(), testing::StartsWith(L"\\\\?\\GLOBALROOT\\Device\\"));
+  EXPECT_EQ(canonical.filename(), leaf);
+
+  // The canonicalized parent must be a path-component prefix of the result so that the
+  // containment check in ValidateExternalDataPath still works.
+  std::filesystem::path parent_canonical;
+  ASSERT_TRUE(utils::internal::WeaklyCanonicalPathNtVolumeFallbackForTesting(base_dir_, parent_canonical));
+  auto [parent_end, full_it] = std::mismatch(parent_canonical.begin(), parent_canonical.end(),
+                                             canonical.begin(), canonical.end());
+  EXPECT_EQ(parent_end, parent_canonical.end())
+      << "parent: " << parent_canonical << " full: " << canonical;
+}
+
+TEST_F(PathValidationTest, WeaklyCanonicalPathNtVolumeFallback_NonExistentMiddleAndLeaf) {
+  std::filesystem::path canonical;
+  ASSERT_TRUE(utils::internal::WeaklyCanonicalPathNtVolumeFallbackForTesting(
+      base_dir_ / L"missing_dir" / L"data.bin", canonical));
+
+  EXPECT_THAT(canonical.wstring(), testing::StartsWith(L"\\\\?\\GLOBALROOT\\Device\\"));
+  EXPECT_EQ(canonical.filename(), std::filesystem::path{L"data.bin"});
+  EXPECT_EQ(canonical.parent_path().filename(), std::filesystem::path{L"missing_dir"});
+}
+
+TEST_F(PathValidationTest, WeaklyCanonicalPathNtVolumeFallback_AllNonExistentReturnsFalse) {
+  // Synthetic absolute path on a non-existent volume. The fallback must return false so
+  // the caller surfaces the original weakly_canonical error rather than substituting an
+  // unverified path.
+  const std::filesystem::path bogus{L"\\\\?\\Volume{00000000-0000-0000-0000-000000000000}\\nope\\data.bin"};
+  std::filesystem::path canonical;
+  EXPECT_FALSE(utils::internal::WeaklyCanonicalPathNtVolumeFallbackForTesting(bogus, canonical));
+}
+
+TEST_F(PathValidationTest, WeaklyCanonicalPathNtVolumeFallback_MatchesWeaklyCanonicalAtFile) {
+  // Compare via std::filesystem::equivalent: the fallback returns the NT form
+  // (\\?\GLOBALROOT\Device\HarddiskVolumeN\...) while weakly_canonical returns the DOS
+  // form (C:\...), but both must point at the same file.
+  CreateEmptyFile(base_dir_ / "compare.bin");
+  const auto target = base_dir_ / "compare.bin";
+
+  std::error_code ec;
+  const auto reference = std::filesystem::weakly_canonical(target, ec);
+  ASSERT_FALSE(ec) << ec.message();
+
+  std::filesystem::path fallback;
+  ASSERT_TRUE(utils::internal::WeaklyCanonicalPathNtVolumeFallbackForTesting(target, fallback));
+
+  EXPECT_TRUE(std::filesystem::equivalent(reference, fallback, ec))
+      << "reference=" << reference << " fallback=" << fallback << " ec=" << ec.message();
+}
+
+TEST_F(PathValidationTest, WeaklyCanonicalPathNtVolumeFallback_ResolvesSymlinks) {
+  const auto target = base_dir_ / "symlink_target.bin";
+  const auto link = base_dir_ / "symlink_link.bin";
+  try {
+    std::ofstream{target};
+    std::filesystem::create_symlink(target, link);
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << "Symlink creation not supported in this environment: " << e.what();
+  }
+
+  std::filesystem::path link_canonical;
+  std::filesystem::path target_canonical;
+  ASSERT_TRUE(utils::internal::WeaklyCanonicalPathNtVolumeFallbackForTesting(link, link_canonical));
+  ASSERT_TRUE(utils::internal::WeaklyCanonicalPathNtVolumeFallbackForTesting(target, target_canonical));
+
+  std::error_code ec;
+  EXPECT_TRUE(std::filesystem::equivalent(link_canonical, target_canonical, ec))
+      << "link=" << link_canonical << " target=" << target_canonical << " ec=" << ec.message();
+}
+
+TEST_F(PathValidationTest, WeaklyCanonicalPathNtVolumeFallback_ResolvesDotDot) {
+  CreateDirectories(base_dir_ / "sub_for_dotdot");
+
+  std::filesystem::path canonical;
+  ASSERT_TRUE(utils::internal::WeaklyCanonicalPathNtVolumeFallbackForTesting(
+      base_dir_ / "sub_for_dotdot" / "..", canonical));
+
+  std::filesystem::path base_canonical;
+  ASSERT_TRUE(utils::internal::WeaklyCanonicalPathNtVolumeFallbackForTesting(base_dir_, base_canonical));
+
+  std::error_code ec;
+  EXPECT_TRUE(std::filesystem::equivalent(canonical, base_canonical, ec))
+      << "canonical=" << canonical << " base=" << base_canonical << " ec=" << ec.message();
+}
+#endif  // defined(_WIN32)
+
 TEST(TensorProtoUtilsTest, GetNodeProtoLayeringAnnotation) {
   // Case 1: Annotation exists
   {


### PR DESCRIPTION
### Description

Adds a Windows-only fallback to `WeaklyCanonicalPath` (in `onnxruntime/core/framework/tensorprotoutils.cc`) for use inside Windows AppContainers, where `std::filesystem::weakly_canonical` always fails with `ERROR_ACCESS_DENIED` because the underlying `GetFinalPathNameByHandleW(VOLUME_NAME_DOS)` call goes through the Volume Mount Manager, which AppContainer tokens cannot query regardless of file ACL grants.

On `ERROR_ACCESS_DENIED`, fall back to a manual canonicalization that uses `GetFinalPathNameByHandleW(FILE_NAME_NORMALIZED | VOLUME_NAME_NT)` and prefixes the result with `\\?\GLOBALROOT` so it remains a valid Win32 path. All other error paths, non-Windows builds, and non-AppContainer Windows runs are unchanged.

`VOLUME_NAME_NT` (not `VOLUME_NAME_NONE`) is required: it preserves volume identity, so the cross-volume escape rejection in `ValidateExternalDataPath` introduced by #26776 continues to hold.

8 new unit tests cover the fallback helper directly (existing dir/file, non-existent leaf, multi-component miss, all-non-existent → false, equivalence with `weakly_canonical`, symlink resolution, `..` collapse). The AppContainer trigger itself cannot be reproduced in a unit test environment.

### Motivation and Context

Fixes #28508.

Regression introduced in v1.24.1 by #26776 (`ValidateExternalDataPath`); current `WeaklyCanonicalPath` wrapper from #27539 in v1.25.0. Loading any ONNX model with external data fails inside a Windows AppContainer with:

```
Failed to get the weakly canonical path: "<path>" - Access is denied.
```

Affected callers have no in-process workaround. Downstream report: microsoft/Foundry-Local#709.

CC @yuslepukhin (#26776), @adrianlizarraga (#27539), @tianleiwu (#27374).

