### PR TITLE
enable dynamic max_k_step in FA for nvidia

### DIFF
--- a/onnxruntime/contrib_ops/webgpu/bert/flash_attention.h
+++ b/onnxruntime/contrib_ops/webgpu/bert/flash_attention.h
@@ -92,8 +92,8 @@ class FlashAttentionProgram final : public Program<FlashAttentionProgram> {
         q_BNSH_(q_BNSH),
         use_seqlen_k_(use_seqlen_k),
         has_head_sink_(has_head_sink) {
-    if (is_apple) {
-      // On Apple GPUs, use an optimized loop-based path with dynamic max_k_step.
+    if (is_apple || is_nvidia) {
+      // On Apple and Nvidia, use an optimized loop-based path with dynamic max_k_step.
       // Compute max_k_step from shared memory budget: k_tile + v_tile = 2 * element_size * head_size * max_k_step
       const int element_size = is_fp16 ? 2 : 4;
       int max_k_from_shm = 16384 / (2 * element_size * qkv_head_size);

--- a/onnxruntime/contrib_ops/webgpu/bert/flash_attention.h
+++ b/onnxruntime/contrib_ops/webgpu/bert/flash_attention.h
@@ -93,10 +93,11 @@ class FlashAttentionProgram final : public Program<FlashAttentionProgram> {
         use_seqlen_k_(use_seqlen_k),
         has_head_sink_(has_head_sink) {
     if (is_apple || is_nvidia) {
-      // On Apple and Nvidia, use an optimized loop-based path with dynamic max_k_step.
-      // Compute max_k_step from shared memory budget: k_tile + v_tile = 2 * element_size * head_size * max_k_step
+      // On Apple and NVIDIA, use an optimized loop-based path with dynamic max_k_step.
+      // Compute max_k_step from workgroup shared memory budget: k_tile + v_tile = 2 * element_size * head_size * max_k_step
       const int element_size = is_fp16 ? 2 : 4;
-      int max_k_from_shm = 16384 / (2 * element_size * qkv_head_size);
+      constexpr int kMinWorkgroupStorageBudgetBytes = 16384;
+      int max_k_from_shm = kMinWorkgroupStorageBudgetBytes / (2 * element_size * qkv_head_size);
       if (max_k_from_shm >= 32) {
         max_k_step_ = 32;
       } else {


### PR DESCRIPTION
apply https://github.com/microsoft/onnxruntime/pull/27780 for nvidia.

I see 10-15% performance improvement for prefill on rtx5060ti
