### PR TITLE
Adjust ConvAveragePool test tolerance due to Resize changes

### DIFF
--- a/onnxruntime/test/optimizer/nchwc_optimizer_test.cc
+++ b/onnxruntime/test/optimizer/nchwc_optimizer_test.cc
@@ -474,6 +474,10 @@ TEST(NchwcOptimizerTests, ConvAveragePool) {
 
       helper.AddConvNode(input_arg, conv_output_arg, {128, 48, 5, 5});
 
+      // The NCHWc average pooling path may accumulate floats in a different
+      // order than the reference, producing small rounding differences.
+      helper.per_sample_tolerance_ = 0.002;
+
       auto& pool_node = helper.AddNode("AveragePool", {conv_output_arg}, {output_arg});
       pool_node.AddAttribute("auto_pad", "SAME_UPPER");
       pool_node.AddAttribute("kernel_shape", std::vector<int64_t>{4, 4});


### PR DESCRIPTION
This pull request makes a minor adjustment to the `NchwcOptimizerTests.ConvAveragePool` test to account for small numerical differences in floating-point calculations. Specifically, it increases the allowed per-sample tolerance to avoid false negatives due to minor rounding differences in average pooling computations.

- **Test tolerance adjustment:**
  * Increased `per_sample_tolerance_` to `0.002` in the `ConvAveragePool` test to accommodate small rounding differences caused by floating-point accumulation order in the NCHWc average pooling path.