### PR TITLE
Add per-I/O memtype controls for plugin EPs

### DIFF
--- a/include/onnxruntime/core/framework/execution_provider.h
+++ b/include/onnxruntime/core/framework/execution_provider.h
@@ -54,11 +54,15 @@ class IResourceAccountant;
 using CreateFunctionStateFunc = std::function<int(ComputeContext*, FunctionState*)>;
 using ComputeFunc = std::function<Status(FunctionState, const OrtApi*, OrtKernelContext*)>;
 using DestroyFunctionStateFunc = std::function<void(FunctionState)>;
+// Per-I/O memtype overrides for compile-path fused nodes; counterpart to KernelDefBuilder::{Input,Output}MemoryType.
+using GetIoMemTypesFunc = std::function<Status(gsl::span<OrtMemType> mem_types)>;
 
 struct NodeComputeInfo {
   CreateFunctionStateFunc create_state_func;
   ComputeFunc compute_func;
   DestroyFunctionStateFunc release_state_func;
+  GetIoMemTypesFunc get_input_mem_types;
+  GetIoMemTypesFunc get_output_mem_types;
 };
 
 using RunOptions = ::OrtRunOptions;

--- a/include/onnxruntime/core/session/onnxruntime_ep_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_ep_c_api.h
@@ -718,6 +718,45 @@ struct OrtNodeComputeInfo {
    * \since Version 1.23.
    */
   void(ORT_API_CALL* ReleaseState)(_In_ OrtNodeComputeInfo* this_ptr, _Frees_ptr_opt_ void* compute_state);
+
+  /** \brief Optional. If set, called once between Compile() return and fused-KernelDef registration to fill in
+   * the OrtMemType for every input of the fused node. NULL means "no overrides — all inputs default to
+   * OrtMemTypeDefault".
+   *
+   * Mirrors the kernel-path EP capability provided by OrtKernelDefBuilder::SetInputMemType, but for compile-path
+   * (fused-node) EPs. Allows the EP to request placement such as OrtMemTypeCPUInput for specific inputs of the
+   * fused node so ORT can route producer tensors to a host-accessible allocator without inserting a copy.
+   *
+   * \param[in] this_ptr The OrtNodeComputeInfo instance.
+   * \param[in] count The number of input slots in `mem_types` (matches the EP's Compile-time view of the fused node).
+   * \param[out] mem_types Caller-allocated array of length `count`. The EP fills entry `i` with the desired
+   *                      OrtMemType for input index `i`. Slots left at OrtMemTypeDefault leave the input on the
+   *                      EP's default device memory.
+   *
+   * \snippet{doc} snippets.dox OrtStatus Return Value
+   *
+   * \since Version 1.27.
+   */
+  OrtStatus*(ORT_API_CALL* GetInputMemTypes)(_In_ const OrtNodeComputeInfo* this_ptr,
+                                             _In_ size_t count,
+                                             _Out_writes_all_(count) OrtMemType* mem_types);
+
+  /** \brief Optional. If set, called once between Compile() return and fused-KernelDef registration to fill in
+   * the OrtMemType for every output of the fused node. NULL means "no overrides — all outputs default to
+   * OrtMemTypeDefault".
+   *
+   * \param[in] this_ptr The OrtNodeComputeInfo instance.
+   * \param[in] count The number of output slots in `mem_types`.
+   * \param[out] mem_types Caller-allocated array of length `count`. The EP fills entry `i` with the desired
+   *                      OrtMemType for output index `i`.
+   *
+   * \snippet{doc} snippets.dox OrtStatus Return Value
+   *
+   * \since Version 1.27.
+   */
+  OrtStatus*(ORT_API_CALL* GetOutputMemTypes)(_In_ const OrtNodeComputeInfo* this_ptr,
+                                              _In_ size_t count,
+                                              _Out_writes_all_(count) OrtMemType* mem_types);
 };
 
 struct OrtKernelImpl;

--- a/include/onnxruntime/core/session/onnxruntime_ep_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_ep_c_api.h
@@ -2606,6 +2606,32 @@ struct OrtEp {
    * \since Version 1.27.
    */
   ORT_API2_STATUS(OnSessionInitializationEnd, _In_ OrtEp* this_ptr);
+
+  /** \brief Returns the OrtMemoryInfo the EP wants used for the given OrtMemType.
+   *
+   * Lets an EP declare, per OrtMemType, the memory the runtime should associate with that
+   * role (default device memory, CPU-side inputs, CPU-side outputs). ORT may consult this
+   * any time it needs to resolve placement for the EP.
+   *
+   * Implementations should be deterministic: a given OrtMemType should always map to the
+   * same OrtMemoryInfo for the lifetime of the OrtEp. Caching the answer up front is the
+   * recommended pattern; returned pointers must remain valid while the OrtEp is alive.
+   *
+   * Return nullptr for any OrtMemType to defer to ORT's built-in resolution for that type.
+   * Plugins may opt in selectively.
+   *
+   * \param[in] this_ptr The OrtEp instance.
+   * \param[in] mem_type The memory type to query.
+   * \return The OrtMemoryInfo the EP wants associated with the given mem_type, or nullptr
+   *         to defer to ORT.
+   *
+   * \note Implementation of this function is optional. If set to NULL, ORT applies its
+   *       built-in resolution for every OrtMemType.
+   *
+   * \since Version 1.27.
+   */
+  ORT_API_T(const OrtMemoryInfo*, GetMemoryInfoByMemType, _In_ const OrtEp* this_ptr,
+            _In_ OrtMemType mem_type);
 };
 
 /** \brief The function signature that ORT will call to create OrtEpFactory instances.

--- a/onnxruntime/core/framework/graph_partitioner.cc
+++ b/onnxruntime/core/framework/graph_partitioner.cc
@@ -85,6 +85,30 @@ static void BuildFusedKernelDef(KernelDefBuilder& builder, const IndexedSubGraph
       .Provider(provider_type);
 }
 
+static Status ApplyFusedNodeMemTypes(KernelDefBuilder& builder,
+                                     const NodeComputeInfo& info,
+                                     const IndexedSubGraph::MetaDef& metadef) {
+  if (info.get_input_mem_types && !metadef.inputs.empty()) {
+    std::vector<OrtMemType> mem_types(metadef.inputs.size(), OrtMemTypeDefault);
+    ORT_RETURN_IF_ERROR(info.get_input_mem_types(gsl::make_span(mem_types)));
+    for (size_t i = 0; i < mem_types.size(); ++i) {
+      if (mem_types[i] != OrtMemTypeDefault) {
+        builder.InputMemoryType(mem_types[i], gsl::narrow_cast<int>(i));
+      }
+    }
+  }
+  if (info.get_output_mem_types && !metadef.outputs.empty()) {
+    std::vector<OrtMemType> mem_types(metadef.outputs.size(), OrtMemTypeDefault);
+    ORT_RETURN_IF_ERROR(info.get_output_mem_types(gsl::make_span(mem_types)));
+    for (size_t i = 0; i < mem_types.size(); ++i) {
+      if (mem_types[i] != OrtMemTypeDefault) {
+        builder.OutputMemoryType(mem_types[i], gsl::narrow_cast<int>(i));
+      }
+    }
+  }
+  return Status::OK();
+}
+
 /// <summary>
 /// Check if a node can be placed on a specific provider. If yes, then set the nodes execution provider.
 /// Do nothing if the node is already assigned.
@@ -708,8 +732,6 @@ static Status PartitionOnnxFormatModelImpl(Graph& graph, FuncManager& func_mgr,
       for (size_t j = 0, end = nodes_to_compile.size(); j < end; j++) {
         auto* node = nodes_to_compile[j];
 
-        ORT_RETURN_IF_ERROR(func_mgr.AddFuncInfo(node->Name(), std::move(node_compute_funcs[j])));
-
         const auto& cur_capability = capabilities_to_compile[j];
         const IndexedSubGraph& indexed_sub_graph = *cur_capability->sub_graph;
         const IndexedSubGraph::MetaDef& metadef = *indexed_sub_graph.GetMetaDef();
@@ -719,6 +741,11 @@ static Status PartitionOnnxFormatModelImpl(Graph& graph, FuncManager& func_mgr,
         // used by SessionState
         KernelDefBuilder builder;
         BuildFusedKernelDef(builder, metadef, type);
+        // Must precede the std::move into func_mgr below.
+        ORT_RETURN_IF_ERROR(ApplyFusedNodeMemTypes(builder, node_compute_funcs[j], metadef));
+
+        ORT_RETURN_IF_ERROR(func_mgr.AddFuncInfo(node->Name(), std::move(node_compute_funcs[j])));
+
         ORT_RETURN_IF_ERROR(fused_kernel_registry.Register(
             builder,
             [](FuncManager& func_mgr, const OpKernelInfo& info, std::unique_ptr<OpKernel>& out) -> Status {
@@ -1329,7 +1356,6 @@ static Status PartitionOrtFormatModelImpl(const PartitionParams& partition_param
 
     ORT_RETURN_IF(single_node_compute_func.empty(), "single_node_compute_func should have 1 element.");
     auto& func_mgr = partition_params.func_mgr.get();
-    ORT_RETURN_IF_ERROR(func_mgr.AddFuncInfo(node.Name(), std::move(single_node_compute_func[0])));
 
     const ComputeCapability& cur_capability = compilation_entry.capability;
     const IndexedSubGraph& indexed_sub_graph = *cur_capability.sub_graph;
@@ -1337,6 +1363,11 @@ static Status PartitionOrtFormatModelImpl(const PartitionParams& partition_param
 
     KernelDefBuilder builder;
     BuildFusedKernelDef(builder, metadef, type);
+    // Must precede the std::move into func_mgr below.
+    ORT_RETURN_IF_ERROR(ApplyFusedNodeMemTypes(builder, single_node_compute_func[0], metadef));
+
+    ORT_RETURN_IF_ERROR(func_mgr.AddFuncInfo(node.Name(), std::move(single_node_compute_func[0])));
+
     auto kernel_def = builder.Build();
 
     auto& fused_kernel_registry = partition_params.fused_kernel_registry.get();

--- a/onnxruntime/core/framework/graph_partitioner.cc
+++ b/onnxruntime/core/framework/graph_partitioner.cc
@@ -85,9 +85,9 @@ static void BuildFusedKernelDef(KernelDefBuilder& builder, const IndexedSubGraph
       .Provider(provider_type);
 }
 
-static Status ApplyFusedNodeMemTypes(KernelDefBuilder& builder,
-                                     const NodeComputeInfo& info,
-                                     const IndexedSubGraph::MetaDef& metadef) {
+Status ApplyFusedNodeMemTypes(KernelDefBuilder& builder,
+                              const NodeComputeInfo& info,
+                              const IndexedSubGraph::MetaDef& metadef) {
   if (info.get_input_mem_types && !metadef.inputs.empty()) {
     std::vector<OrtMemType> mem_types(metadef.inputs.size(), OrtMemTypeDefault);
     ORT_RETURN_IF_ERROR(info.get_input_mem_types(gsl::make_span(mem_types)));

--- a/onnxruntime/core/framework/graph_partitioner_internal.h
+++ b/onnxruntime/core/framework/graph_partitioner_internal.h
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Internal header for tests of graph_partitioner.cc. Not part of any public API.
+
+#pragma once
+
+#if !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
+
+#include "core/common/status.h"
+#include "core/framework/execution_provider.h"
+#include "core/framework/kernel_def_builder.h"
+#include "core/graph/indexed_sub_graph.h"
+
+namespace onnxruntime {
+
+Status ApplyFusedNodeMemTypes(KernelDefBuilder& builder,
+                              const NodeComputeInfo& info,
+                              const IndexedSubGraph::MetaDef& metadef);
+
+}  // namespace onnxruntime
+
+#endif  // !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)

--- a/onnxruntime/core/session/plugin_ep/ep_plugin_provider_interfaces.cc
+++ b/onnxruntime/core/session/plugin_ep/ep_plugin_provider_interfaces.cc
@@ -219,6 +219,15 @@ PluginExecutionProvider::PluginExecutionProvider(UniqueOrtEp ep, const OrtSessio
   }
 }
 
+OrtDevice PluginExecutionProvider::GetOrtDeviceByMemType(OrtMemType mem_type) const {
+  if (ort_ep_->ort_version_supported >= 27 && ort_ep_->GetMemoryInfoByMemType != nullptr) {
+    if (const OrtMemoryInfo* info = ort_ep_->GetMemoryInfoByMemType(ort_ep_.get(), mem_type)) {
+      return info->device;
+    }
+  }
+  return IExecutionProvider::GetOrtDeviceByMemType(mem_type);
+}
+
 PluginExecutionProvider::~PluginExecutionProvider() {
   if (ort_ep_ && !api_node_compute_infos_.empty() && ort_ep_->ReleaseNodeComputeInfos != nullptr) {
     ort_ep_->ReleaseNodeComputeInfos(ort_ep_.get(), api_node_compute_infos_.data(),

--- a/onnxruntime/core/session/plugin_ep/ep_plugin_provider_interfaces.cc
+++ b/onnxruntime/core/session/plugin_ep/ep_plugin_provider_interfaces.cc
@@ -667,6 +667,19 @@ Status PluginExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& fu
       return Status::OK();
     };
 
+    if (api_node_compute_info->ort_version_supported >= 27) {
+      using MemTypesFn = OrtStatus*(ORT_API_CALL*)(const OrtNodeComputeInfo*, size_t, OrtMemType*);
+      auto bind = [api_node_compute_info](MemTypesFn api_fn, GetIoMemTypesFunc& out) {
+        if (api_fn != nullptr) {
+          out = [api_node_compute_info, api_fn](gsl::span<OrtMemType> mem_types) -> Status {
+            return ToStatusAndRelease(api_fn(api_node_compute_info, mem_types.size(), mem_types.data()));
+          };
+        }
+      };
+      bind(api_node_compute_info->GetInputMemTypes, compute_info.get_input_mem_types);
+      bind(api_node_compute_info->GetOutputMemTypes, compute_info.get_output_mem_types);
+    }
+
     node_compute_infos.push_back(std::move(compute_info));
   }
 

--- a/onnxruntime/core/session/plugin_ep/ep_plugin_provider_interfaces.h
+++ b/onnxruntime/core/session/plugin_ep/ep_plugin_provider_interfaces.h
@@ -151,6 +151,8 @@ class PluginExecutionProvider : public IExecutionProvider {
   common::Status ReplayGraph(int graph_annotation_id) override;
   OrtGraphCaptureNodeAssignmentPolicy GetGraphCaptureNodeAssignmentPolicy() const override;
 
+  OrtDevice GetOrtDeviceByMemType(OrtMemType mem_type) const override;
+
  private:
   const logging::Logger& GetEpLoggerOrDefault() const;
 

--- a/onnxruntime/test/autoep/library/example_plugin_ep/ep.cc
+++ b/onnxruntime/test/autoep/library/example_plugin_ep/ep.cc
@@ -182,6 +182,7 @@ ExampleEp::ExampleEp(ExampleEpFactory& factory, const std::string& name, const C
   Compile = CompileImpl;
   ReleaseNodeComputeInfos = ReleaseNodeComputeInfosImpl;
   CreateAllocator = CreateAllocatorImpl;                                      // optional. can be nullptr
+  GetMemoryInfoByMemType = GetMemoryInfoByMemTypeImpl;                        // optional. can be nullptr
   CreateSyncStreamForDevice = CreateSyncStreamForDeviceImpl;                  // optional. can be nullptr
   GetCompiledModelCompatibilityInfo = GetCompiledModelCompatibilityInfoImpl;  // compatibility info for compiled models
   Sync = SyncImpl;                                                            // optional. can be nullptr
@@ -564,6 +565,27 @@ OrtStatus* ORT_API_CALL ExampleEp::CreateAllocatorImpl(_In_ OrtEp* this_ptr,
 
   // for simplicity in this example we use the factory implementation.
   return ep->factory_.CreateAllocator(&ep->factory_, memory_info, nullptr, allocator);
+}
+
+/*static*/
+const OrtMemoryInfo* ORT_API_CALL ExampleEp::GetMemoryInfoByMemTypeImpl(_In_ const OrtEp* this_ptr,
+                                                                        _In_ OrtMemType mem_type) noexcept {
+  // Optional. Lets the EP declare, per OrtMemType, which registered OrtMemoryInfo ORT should
+  // use when placing graph inputs/outputs. Returning nullptr defers to ORT's built-in resolution.
+  //
+  // An EP that also registered a host-accessible OrtMemoryInfo would typically route
+  // OrtMemTypeCPUInput / OrtMemTypeCPUOutput to it here, e.g.:
+  //
+  //   case OrtMemTypeCPUInput:
+  //   case OrtMemTypeCPUOutput:
+  //     return ep->factory_.GetHostAccessibleMemoryInfo();
+  const auto* ep = static_cast<const ExampleEp*>(this_ptr);
+  switch (mem_type) {
+    case OrtMemTypeDefault:
+      return ep->factory_.GetDefaultMemoryInfo();
+    default:
+      return nullptr;
+  }
 }
 
 /*static*/

--- a/onnxruntime/test/autoep/library/example_plugin_ep/ep.h
+++ b/onnxruntime/test/autoep/library/example_plugin_ep/ep.h
@@ -84,6 +84,9 @@ class ExampleEp : public OrtEp, public ApiPtrs {
                                                      _In_ const OrtMemoryInfo* memory_info,
                                                      _Outptr_result_maybenull_ OrtAllocator** allocator) noexcept;
 
+  static const OrtMemoryInfo* ORT_API_CALL GetMemoryInfoByMemTypeImpl(_In_ const OrtEp* this_ptr,
+                                                                      _In_ OrtMemType mem_type) noexcept;
+
   static OrtStatus* ORT_API_CALL CreateSyncStreamForDeviceImpl(_In_ OrtEp* this_ptr,
                                                                _In_ const OrtMemoryDevice* memory_device,
                                                                _Outptr_ OrtSyncStreamImpl** stream) noexcept;

--- a/onnxruntime/test/autoep/library/example_plugin_ep/ep_factory.h
+++ b/onnxruntime/test/autoep/library/example_plugin_ep/ep_factory.h
@@ -38,6 +38,10 @@ class ExampleEpFactory : public OrtEpFactory, public ApiPtrs {
     return vendor_id_;
   }
 
+  const Ort::MemoryInfo& GetDefaultMemoryInfo() const {
+    return default_memory_info_;
+  }
+
   const OrtLogger& default_logger_;  // default logger for the EP factory
 
  private:

--- a/onnxruntime/test/framework/ep_plugin_provider_test.cc
+++ b/onnxruntime/test/framework/ep_plugin_provider_test.cc
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <cstring>
 #include <filesystem>
+#include <functional>
 #include <limits>
 #include "gsl/gsl"
 #include "gtest/gtest.h"
@@ -365,6 +366,108 @@ TEST(PluginExecutionProviderTest, InferOrtDeviceFromDeviceMemoryInfo) {
     ASSERT_THROW(test_plugin_ep::MakeTestOrtEp(ep_devices), OnnxRuntimeException);
   }
 #endif  // !defined(ORT_NO_EXCEPTIONS)
+}
+
+namespace get_mem_info_test {
+inline std::function<const OrtMemoryInfo*(OrtMemType)>& Configure() {
+  static std::function<const OrtMemoryInfo*(OrtMemType)> fn;
+  return fn;
+}
+
+inline const OrtMemoryInfo* ORT_API_CALL GetMemoryInfoByMemTypeImpl(const OrtEp* /*this_ptr*/,
+                                                                    OrtMemType mem_type) noexcept {
+  return Configure() ? Configure()(mem_type) : nullptr;
+}
+}  // namespace get_mem_info_test
+
+TEST(PluginExecutionProviderTest, GetOrtDeviceByMemType_VersionGate_PreV27) {
+  auto ort_device = test_plugin_ep::MakeTestOrtDevice(OrtDevice::GPU, OrtDevice::MemType::DEFAULT);
+  OrtMemoryInfo info{"TestOrtEp GPU", OrtAllocatorType::OrtDeviceAllocator, ort_device, OrtMemTypeDefault};
+  get_mem_info_test::Configure() = [&](OrtMemType) { return &info; };
+
+  auto [ep, ort_ep] = test_plugin_ep::MakeTestOrtEp();
+  ort_ep->ort_version_supported = 26;
+  ort_ep->GetMemoryInfoByMemType = get_mem_info_test::GetMemoryInfoByMemTypeImpl;
+
+  ASSERT_EQ(ep->GetOrtDeviceByMemType(OrtMemTypeCPUInput), OrtDevice());
+  ASSERT_EQ(ep->GetOrtDeviceByMemType(OrtMemTypeCPUOutput), OrtDevice());
+  ASSERT_EQ(ep->GetOrtDeviceByMemType(OrtMemTypeDefault), OrtDevice());
+}
+
+TEST(PluginExecutionProviderTest, GetOrtDeviceByMemType_NullCallback) {
+  auto [ep, ort_ep] = test_plugin_ep::MakeTestOrtEp();
+  ASSERT_GE(ort_ep->ort_version_supported, 27u);
+  ort_ep->GetMemoryInfoByMemType = nullptr;
+
+  ASSERT_EQ(ep->GetOrtDeviceByMemType(OrtMemTypeCPUInput), OrtDevice());
+  ASSERT_EQ(ep->GetOrtDeviceByMemType(OrtMemTypeCPUOutput), OrtDevice());
+  ASSERT_EQ(ep->GetOrtDeviceByMemType(OrtMemTypeDefault), OrtDevice());
+}
+
+TEST(PluginExecutionProviderTest, GetOrtDeviceByMemType_CallbackReturnsNullForMemtype) {
+  auto cpu_input_device = test_plugin_ep::MakeTestOrtDevice(OrtDevice::CPU, OrtDevice::MemType::HOST_ACCESSIBLE);
+  OrtMemoryInfo cpu_input_info{"TestOrtEp CPUInput", OrtAllocatorType::OrtDeviceAllocator,
+                               cpu_input_device, OrtMemTypeCPUInput};
+  get_mem_info_test::Configure() = [&](OrtMemType mt) -> const OrtMemoryInfo* {
+    return mt == OrtMemTypeCPUInput ? &cpu_input_info : nullptr;
+  };
+
+  auto [ep, ort_ep] = test_plugin_ep::MakeTestOrtEp();
+  ort_ep->GetMemoryInfoByMemType = get_mem_info_test::GetMemoryInfoByMemTypeImpl;
+
+  ASSERT_EQ(ep->GetOrtDeviceByMemType(OrtMemTypeCPUInput), cpu_input_device);
+  ASSERT_EQ(ep->GetOrtDeviceByMemType(OrtMemTypeCPUOutput), OrtDevice());
+  ASSERT_EQ(ep->GetOrtDeviceByMemType(OrtMemTypeDefault), OrtDevice());
+}
+
+TEST(PluginExecutionProviderTest, GetOrtDeviceByMemType_RoutesAllThreeMemTypes) {
+  auto default_device = test_plugin_ep::MakeTestOrtDevice(OrtDevice::GPU, OrtDevice::MemType::DEFAULT);
+  auto cpu_input_device = test_plugin_ep::MakeTestOrtDevice(OrtDevice::CPU, OrtDevice::MemType::HOST_ACCESSIBLE);
+  auto cpu_output_device = test_plugin_ep::MakeTestOrtDevice(OrtDevice::NPU, OrtDevice::MemType::HOST_ACCESSIBLE);
+  OrtMemoryInfo default_info{"def", OrtAllocatorType::OrtDeviceAllocator, default_device, OrtMemTypeDefault};
+  OrtMemoryInfo cpu_input_info{"in", OrtAllocatorType::OrtDeviceAllocator, cpu_input_device, OrtMemTypeCPUInput};
+  OrtMemoryInfo cpu_output_info{"out", OrtAllocatorType::OrtDeviceAllocator, cpu_output_device, OrtMemTypeCPUOutput};
+  get_mem_info_test::Configure() = [&](OrtMemType mt) -> const OrtMemoryInfo* {
+    switch (mt) {
+      case OrtMemTypeDefault:
+        return &default_info;
+      case OrtMemTypeCPUInput:
+        return &cpu_input_info;
+      case OrtMemTypeCPUOutput:
+        return &cpu_output_info;
+      default:
+        return nullptr;
+    }
+  };
+
+  auto [ep, ort_ep] = test_plugin_ep::MakeTestOrtEp();
+  ort_ep->GetMemoryInfoByMemType = get_mem_info_test::GetMemoryInfoByMemTypeImpl;
+
+  ASSERT_EQ(ep->GetOrtDeviceByMemType(OrtMemTypeDefault), default_device);
+  ASSERT_EQ(ep->GetOrtDeviceByMemType(OrtMemTypeCPUInput), cpu_input_device);
+  ASSERT_EQ(ep->GetOrtDeviceByMemType(OrtMemTypeCPUOutput), cpu_output_device);
+}
+
+TEST(PluginExecutionProviderTest, GetOrtDeviceByMemType_DefaultDeviceUnaffected) {
+  // The callback overrides GetOrtDeviceByMemType, but the EP's base-class default device
+  // (GetDevice()) must still come from GetOrtDeviceForPluginEp(ep_devices) — design decision #2.
+  auto callback_default_device = test_plugin_ep::MakeTestOrtDevice(OrtDevice::GPU, OrtDevice::MemType::DEFAULT);
+  OrtMemoryInfo callback_default_info{"cb", OrtAllocatorType::OrtDeviceAllocator, callback_default_device,
+                                      OrtMemTypeDefault};
+  get_mem_info_test::Configure() = [&](OrtMemType) { return &callback_default_info; };
+
+  auto base_default_device = test_plugin_ep::MakeTestOrtDevice(OrtDevice::CPU, OrtDevice::MemType::DEFAULT);
+  auto base_default_info = std::make_unique<OrtMemoryInfo>("base", OrtAllocatorType::OrtDeviceAllocator,
+                                                           base_default_device, OrtMemTypeDefault);
+  auto ort_hw_device = test_plugin_ep::MakeTestOrtHardwareDevice(OrtHardwareDeviceType_CPU);
+  auto ort_ep_device = test_plugin_ep::MakeTestOrtEpDevice(ort_hw_device.get(), base_default_info.get());
+  std::vector<const OrtEpDevice*> ep_devices{ort_ep_device.get()};
+
+  auto [ep, ort_ep] = test_plugin_ep::MakeTestOrtEp(ep_devices);
+  ort_ep->GetMemoryInfoByMemType = get_mem_info_test::GetMemoryInfoByMemTypeImpl;
+
+  ASSERT_EQ(ep->GetOrtDeviceByMemType(OrtMemTypeDefault), callback_default_device);
+  ASSERT_EQ(ep->GetDevice(), base_default_device);
 }
 
 static void LoadModelAndAssignNodesToEp(const ORTCHAR_T* model_path,

--- a/onnxruntime/test/framework/ep_plugin_provider_test.cc
+++ b/onnxruntime/test/framework/ep_plugin_provider_test.cc
@@ -12,6 +12,8 @@
 
 #include "core/common/logging/sinks/file_sink.h"
 #include "core/framework/config_options.h"
+#include "core/framework/execution_provider.h"
+#include "core/framework/graph_partitioner_internal.h"
 #include "core/framework/kernel_def_builder.h"
 #include "core/framework/op_kernel.h"
 #include "core/framework/resource_accountant.h"
@@ -1559,6 +1561,381 @@ TEST(PluginExecutionProviderTest, OnSessionInitializationEnd_OldVersionFallback)
   ort_ep->ort_version_supported = 26;
 
   ASSERT_STATUS_OK(ep->OnSessionInitializationEnd());
+}
+
+namespace mem_type_test {
+
+struct TestNodeComputeInfo : ::OrtNodeComputeInfo {
+  std::vector<OrtMemType> input_mem_types;
+  std::vector<OrtMemType> output_mem_types;
+  // If non-empty, the corresponding hook returns ORT_FAIL with this message instead of
+  // filling the output buffer.
+  std::string fail_inputs_message;
+  std::string fail_outputs_message;
+  const ::OrtApi* ort_api = ::OrtGetApiBase()->GetApi(ORT_API_VERSION);
+
+  TestNodeComputeInfo() : ::OrtNodeComputeInfo{} {
+    ort_version_supported = ORT_API_VERSION;
+    CreateState = CreateStateImpl;
+    Compute = ComputeImpl;
+    ReleaseState = ReleaseStateImpl;
+    // Memtype hooks are wired by the individual test as needed.
+  }
+
+  static OrtStatus* ORT_API_CALL CreateStateImpl(::OrtNodeComputeInfo* /*this_ptr*/,
+                                                 OrtNodeComputeContext* /*compute_context*/,
+                                                 void** compute_state) noexcept {
+    *compute_state = nullptr;
+    return nullptr;
+  }
+
+  static OrtStatus* ORT_API_CALL ComputeImpl(::OrtNodeComputeInfo* /*this_ptr*/, void* /*compute_state*/,
+                                             OrtKernelContext* /*kernel_context*/) noexcept {
+    return nullptr;
+  }
+
+  static void ORT_API_CALL ReleaseStateImpl(::OrtNodeComputeInfo* /*this_ptr*/,
+                                            void* /*compute_state*/) noexcept {}
+
+  static OrtStatus* ORT_API_CALL GetInputMemTypesImpl(const ::OrtNodeComputeInfo* this_ptr,
+                                                     size_t count, OrtMemType* mem_types) noexcept {
+    try {
+      const auto* self = static_cast<const TestNodeComputeInfo*>(this_ptr);
+      if (!self->fail_inputs_message.empty()) {
+        return self->ort_api->CreateStatus(ORT_FAIL, self->fail_inputs_message.c_str());
+      }
+      if (count != self->input_mem_types.size()) {
+        return self->ort_api->CreateStatus(ORT_FAIL, "input mem types count mismatch");
+      }
+      for (size_t i = 0; i < count; ++i) {
+        mem_types[i] = self->input_mem_types[i];
+      }
+      return nullptr;
+    } catch (...) {
+      return ::OrtGetApiBase()->GetApi(ORT_API_VERSION)->CreateStatus(ORT_FAIL, "unexpected exception");
+    }
+  }
+
+  static OrtStatus* ORT_API_CALL GetOutputMemTypesImpl(const ::OrtNodeComputeInfo* this_ptr,
+                                                      size_t count, OrtMemType* mem_types) noexcept {
+    try {
+      const auto* self = static_cast<const TestNodeComputeInfo*>(this_ptr);
+      if (!self->fail_outputs_message.empty()) {
+        return self->ort_api->CreateStatus(ORT_FAIL, self->fail_outputs_message.c_str());
+      }
+      if (count != self->output_mem_types.size()) {
+        return self->ort_api->CreateStatus(ORT_FAIL, "output mem types count mismatch");
+      }
+      for (size_t i = 0; i < count; ++i) {
+        mem_types[i] = self->output_mem_types[i];
+      }
+      return nullptr;
+    } catch (...) {
+      return ::OrtGetApiBase()->GetApi(ORT_API_VERSION)->CreateStatus(ORT_FAIL, "unexpected exception");
+    }
+  }
+};
+
+// Builds a minimal 2-input/1-output Add model: y = Add(a, b), with 'a' and 'b' as graph inputs
+// and 'y' as a graph output. Returned model owns the graph.
+inline std::shared_ptr<onnxruntime::Model> BuildSingleAddModel() {
+  std::unordered_map<std::string, int> domain_to_version;
+  domain_to_version[kOnnxDomain] = 13;
+  auto model = std::make_shared<onnxruntime::Model>("memtype_test", false, ModelMetaData(), PathString(),
+                                                    IOnnxRuntimeOpSchemaRegistryList(),
+                                                    domain_to_version,
+                                                    std::vector<ONNX_NAMESPACE::FunctionProto>(),
+                                                    DefaultLoggingManager().DefaultLogger());
+  Graph& graph = model->MainGraph();
+
+  ONNX_NAMESPACE::TypeProto float_type;
+  float_type.mutable_tensor_type()->set_elem_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+
+  auto& a = graph.GetOrCreateNodeArg("a", &float_type);
+  auto& b = graph.GetOrCreateNodeArg("b", &float_type);
+  auto& y = graph.GetOrCreateNodeArg("y", &float_type);
+  graph.AddNode("add_0", "Add", "", {&a, &b}, {&y});
+
+  EXPECT_TRUE(graph.Resolve().IsOK());
+  return model;
+}
+
+// Builds an IndexedSubGraph that fuses 'add_0' from the model under name 'fused_add'.
+inline std::unique_ptr<IndexedSubGraph> MakeAddSubGraph(const Graph& graph) {
+  auto sub_graph = std::make_unique<IndexedSubGraph>();
+  for (const auto& node : graph.Nodes()) {
+    sub_graph->nodes.push_back(node.Index());
+  }
+  auto metadef = std::make_unique<IndexedSubGraph::MetaDef>();
+  metadef->name = "fused_add";
+  metadef->domain = "test.domain";
+  metadef->since_version = 1;
+  metadef->inputs = {"a", "b"};
+  metadef->outputs = {"y"};
+  sub_graph->SetMetaDef(std::move(metadef));
+  return sub_graph;
+}
+
+// Drives IExecutionProvider::Compile against `ep` for the single Add node and returns the
+// resulting NodeComputeInfo vector. The TestOrtEp must have its Compile/ReleaseNodeComputeInfos
+// pointers populated by the caller.
+inline Status InvokeCompile(IExecutionProvider& ep, Graph& graph,
+                            const IndexedSubGraph& sub_graph,
+                            std::vector<NodeComputeInfo>& out_node_compute_infos) {
+  Node& fused_node = graph.BeginFuseSubGraph(sub_graph, "fused_add_node");
+  fused_node.SetExecutionProviderType("TestOrtEp");
+  GraphViewer filtered_viewer(graph, sub_graph);
+  std::vector<IExecutionProvider::FusedNodeAndGraph> fused_nodes_and_graphs;
+  fused_nodes_and_graphs.push_back({std::ref(fused_node), std::ref(filtered_viewer)});
+  return ep.Compile(fused_nodes_and_graphs, out_node_compute_infos);
+}
+
+// Per-test configurator for the next OrtNodeComputeInfo handed to ORT through Compile().
+// Each test sets g_configure, then invokes Compile through the EP, which fires CompileImpl.
+using TestNodeConfigureFn = void (*)(TestNodeComputeInfo&);
+inline TestNodeConfigureFn& Configure() {
+  static TestNodeConfigureFn fn = nullptr;
+  return fn;
+}
+
+inline OrtStatus* ORT_API_CALL CompileImpl(OrtEp* /*this_ptr*/, const OrtGraph** /*graphs*/,
+                                           const OrtNode** /*fused_nodes*/, size_t count,
+                                           OrtNodeComputeInfo** node_compute_infos,
+                                           OrtNode** /*ep_context_nodes*/) noexcept {
+  try {
+    for (size_t i = 0; i < count; ++i) {
+      auto info = std::make_unique<TestNodeComputeInfo>();
+      if (Configure() != nullptr) {
+        Configure()(*info);
+      }
+      node_compute_infos[i] = info.release();
+    }
+    return nullptr;
+  } catch (...) {
+    return ::OrtGetApiBase()->GetApi(ORT_API_VERSION)->CreateStatus(ORT_FAIL, "unexpected exception");
+  }
+}
+
+inline void ORT_API_CALL ReleaseNodeComputeInfosImpl(OrtEp* /*this_ptr*/,
+                                                    OrtNodeComputeInfo** node_compute_infos,
+                                                    size_t num) noexcept {
+  for (size_t i = 0; i < num; ++i) {
+    delete static_cast<TestNodeComputeInfo*>(node_compute_infos[i]);
+  }
+}
+
+}  // namespace mem_type_test
+
+TEST(PluginExecutionProviderTest, NodeComputeInfo_MemTypeHooks_HappyPath_BothDirections) {
+  auto [ep, ort_ep] = test_plugin_ep::MakeTestOrtEp();
+  ort_ep->ReleaseNodeComputeInfos = mem_type_test::ReleaseNodeComputeInfosImpl;
+  ort_ep->Compile = mem_type_test::CompileImpl;
+  mem_type_test::Configure() = [](mem_type_test::TestNodeComputeInfo& info) {
+    info.input_mem_types = {OrtMemTypeCPUInput, OrtMemTypeDefault};
+    info.output_mem_types = {OrtMemTypeCPUOutput};
+    info.GetInputMemTypes = mem_type_test::TestNodeComputeInfo::GetInputMemTypesImpl;
+    info.GetOutputMemTypes = mem_type_test::TestNodeComputeInfo::GetOutputMemTypesImpl;
+  };
+
+  auto model = mem_type_test::BuildSingleAddModel();
+  auto sub_graph = mem_type_test::MakeAddSubGraph(model->MainGraph());
+
+  std::vector<NodeComputeInfo> node_compute_infos;
+  ASSERT_STATUS_OK(mem_type_test::InvokeCompile(*ep, model->MainGraph(), *sub_graph, node_compute_infos));
+  ASSERT_EQ(node_compute_infos.size(), 1u);
+
+  ASSERT_TRUE(static_cast<bool>(node_compute_infos[0].get_input_mem_types));
+  ASSERT_TRUE(static_cast<bool>(node_compute_infos[0].get_output_mem_types));
+
+  std::vector<OrtMemType> in_buf(2, OrtMemTypeDefault);
+  ASSERT_STATUS_OK(node_compute_infos[0].get_input_mem_types(gsl::make_span(in_buf)));
+  EXPECT_EQ(in_buf[0], OrtMemTypeCPUInput);
+  EXPECT_EQ(in_buf[1], OrtMemTypeDefault);
+
+  std::vector<OrtMemType> out_buf(1, OrtMemTypeDefault);
+  ASSERT_STATUS_OK(node_compute_infos[0].get_output_mem_types(gsl::make_span(out_buf)));
+  EXPECT_EQ(out_buf[0], OrtMemTypeCPUOutput);
+}
+
+TEST(PluginExecutionProviderTest, NodeComputeInfo_MemTypeHooks_NullHooks_LeaveFunctorsEmpty) {
+  auto [ep, ort_ep] = test_plugin_ep::MakeTestOrtEp();
+  ort_ep->ReleaseNodeComputeInfos = mem_type_test::ReleaseNodeComputeInfosImpl;
+  ort_ep->Compile = mem_type_test::CompileImpl;
+  mem_type_test::Configure() = [](mem_type_test::TestNodeComputeInfo& info) {
+    info.GetInputMemTypes = nullptr;
+    info.GetOutputMemTypes = nullptr;
+  };
+
+  auto model = mem_type_test::BuildSingleAddModel();
+  auto sub_graph = mem_type_test::MakeAddSubGraph(model->MainGraph());
+
+  std::vector<NodeComputeInfo> node_compute_infos;
+  ASSERT_STATUS_OK(mem_type_test::InvokeCompile(*ep, model->MainGraph(), *sub_graph, node_compute_infos));
+  ASSERT_EQ(node_compute_infos.size(), 1u);
+
+  EXPECT_FALSE(static_cast<bool>(node_compute_infos[0].get_input_mem_types));
+  EXPECT_FALSE(static_cast<bool>(node_compute_infos[0].get_output_mem_types));
+}
+
+TEST(PluginExecutionProviderTest, NodeComputeInfo_MemTypeHooks_OldVersion_LeaveFunctorsEmpty) {
+  auto [ep, ort_ep] = test_plugin_ep::MakeTestOrtEp();
+  ort_ep->ReleaseNodeComputeInfos = mem_type_test::ReleaseNodeComputeInfosImpl;
+  ort_ep->Compile = mem_type_test::CompileImpl;
+  mem_type_test::Configure() = [](mem_type_test::TestNodeComputeInfo& info) {
+    info.ort_version_supported = 26;  // pre-feature version
+    info.input_mem_types = {OrtMemTypeCPUInput, OrtMemTypeDefault};
+    info.output_mem_types = {OrtMemTypeCPUOutput};
+    info.GetInputMemTypes = mem_type_test::TestNodeComputeInfo::GetInputMemTypesImpl;
+    info.GetOutputMemTypes = mem_type_test::TestNodeComputeInfo::GetOutputMemTypesImpl;
+  };
+
+  auto model = mem_type_test::BuildSingleAddModel();
+  auto sub_graph = mem_type_test::MakeAddSubGraph(model->MainGraph());
+
+  std::vector<NodeComputeInfo> node_compute_infos;
+  ASSERT_STATUS_OK(mem_type_test::InvokeCompile(*ep, model->MainGraph(), *sub_graph, node_compute_infos));
+  ASSERT_EQ(node_compute_infos.size(), 1u);
+
+  EXPECT_FALSE(static_cast<bool>(node_compute_infos[0].get_input_mem_types));
+  EXPECT_FALSE(static_cast<bool>(node_compute_infos[0].get_output_mem_types));
+}
+
+TEST(PluginExecutionProviderTest, NodeComputeInfo_MemTypeHooks_EpError_PropagatesAsStatus) {
+  auto [ep, ort_ep] = test_plugin_ep::MakeTestOrtEp();
+  ort_ep->ReleaseNodeComputeInfos = mem_type_test::ReleaseNodeComputeInfosImpl;
+  ort_ep->Compile = mem_type_test::CompileImpl;
+  mem_type_test::Configure() = [](mem_type_test::TestNodeComputeInfo& info) {
+    info.fail_inputs_message = "ep refused input memtypes";
+    info.GetInputMemTypes = mem_type_test::TestNodeComputeInfo::GetInputMemTypesImpl;
+    // outputs hook left null on purpose
+  };
+
+  auto model = mem_type_test::BuildSingleAddModel();
+  auto sub_graph = mem_type_test::MakeAddSubGraph(model->MainGraph());
+
+  std::vector<NodeComputeInfo> node_compute_infos;
+  ASSERT_STATUS_OK(mem_type_test::InvokeCompile(*ep, model->MainGraph(), *sub_graph, node_compute_infos));
+  ASSERT_EQ(node_compute_infos.size(), 1u);
+  ASSERT_TRUE(static_cast<bool>(node_compute_infos[0].get_input_mem_types));
+
+  std::vector<OrtMemType> buf(2, OrtMemTypeDefault);
+  Status status = node_compute_infos[0].get_input_mem_types(gsl::make_span(buf));
+  EXPECT_FALSE(status.IsOK());
+  EXPECT_THAT(status.ErrorMessage(), ::testing::HasSubstr("ep refused input memtypes"));
+}
+
+TEST(PluginExecutionProviderTest, ApplyFusedNodeMemTypes_InputsOnlyMixed) {
+  NodeComputeInfo info;
+  info.get_input_mem_types = [](gsl::span<OrtMemType> mem_types) -> Status {
+    EXPECT_EQ(mem_types.size(), 2u);
+    mem_types[0] = OrtMemTypeCPUInput;
+    mem_types[1] = OrtMemTypeDefault;
+    return Status::OK();
+  };
+
+  IndexedSubGraph::MetaDef metadef;
+  metadef.name = "fused";
+  metadef.domain = "test";
+  metadef.since_version = 1;
+  metadef.inputs = {"a", "b"};
+  metadef.outputs = {"y"};
+
+  KernelDefBuilder builder;
+  builder.SetName(metadef.name).SetDomain(metadef.domain).SinceVersion(metadef.since_version).Provider("TestOrtEp");
+  ASSERT_STATUS_OK(ApplyFusedNodeMemTypes(builder, info, metadef));
+  auto kd = builder.Build();
+  EXPECT_EQ(kd->InputMemoryType(0), OrtMemTypeCPUInput);
+  EXPECT_EQ(kd->InputMemoryType(1), OrtMemTypeDefault);
+  EXPECT_EQ(kd->OutputMemoryType(0), OrtMemTypeDefault);
+}
+
+TEST(PluginExecutionProviderTest, ApplyFusedNodeMemTypes_OutputsOnly) {
+  NodeComputeInfo info;
+  info.get_output_mem_types = [](gsl::span<OrtMemType> mem_types) -> Status {
+    EXPECT_EQ(mem_types.size(), 1u);
+    mem_types[0] = OrtMemTypeCPUOutput;
+    return Status::OK();
+  };
+
+  IndexedSubGraph::MetaDef metadef;
+  metadef.name = "fused";
+  metadef.domain = "test";
+  metadef.since_version = 1;
+  metadef.inputs = {"a", "b"};
+  metadef.outputs = {"y"};
+
+  KernelDefBuilder builder;
+  builder.SetName(metadef.name).SetDomain(metadef.domain).SinceVersion(metadef.since_version).Provider("TestOrtEp");
+  ASSERT_STATUS_OK(ApplyFusedNodeMemTypes(builder, info, metadef));
+  auto kd = builder.Build();
+  EXPECT_EQ(kd->OutputMemoryType(0), OrtMemTypeCPUOutput);
+  EXPECT_EQ(kd->InputMemoryType(0), OrtMemTypeDefault);
+  EXPECT_EQ(kd->InputMemoryType(1), OrtMemTypeDefault);
+}
+
+TEST(PluginExecutionProviderTest, ApplyFusedNodeMemTypes_BothFunctorsEmpty) {
+  NodeComputeInfo info;
+  IndexedSubGraph::MetaDef metadef;
+  metadef.name = "fused";
+  metadef.domain = "test";
+  metadef.since_version = 1;
+  metadef.inputs = {"a", "b"};
+  metadef.outputs = {"y"};
+
+  KernelDefBuilder builder;
+  builder.SetName(metadef.name).SetDomain(metadef.domain).SinceVersion(metadef.since_version).Provider("TestOrtEp");
+  ASSERT_STATUS_OK(ApplyFusedNodeMemTypes(builder, info, metadef));
+  auto kd = builder.Build();
+  EXPECT_EQ(kd->InputMemoryType(0), OrtMemTypeDefault);
+  EXPECT_EQ(kd->InputMemoryType(1), OrtMemTypeDefault);
+  EXPECT_EQ(kd->OutputMemoryType(0), OrtMemTypeDefault);
+}
+
+TEST(PluginExecutionProviderTest, ApplyFusedNodeMemTypes_CallbackReturnsError) {
+  NodeComputeInfo info;
+  info.get_input_mem_types = [](gsl::span<OrtMemType> /*mem_types*/) -> Status {
+    return Status(common::ONNXRUNTIME, common::FAIL, "ep boom");
+  };
+
+  IndexedSubGraph::MetaDef metadef;
+  metadef.name = "fused";
+  metadef.domain = "test";
+  metadef.since_version = 1;
+  metadef.inputs = {"a"};
+  metadef.outputs = {"y"};
+
+  KernelDefBuilder builder;
+  builder.SetName(metadef.name).SetDomain(metadef.domain).SinceVersion(metadef.since_version).Provider("TestOrtEp");
+  Status status = ApplyFusedNodeMemTypes(builder, info, metadef);
+  EXPECT_FALSE(status.IsOK());
+  EXPECT_THAT(status.ErrorMessage(), ::testing::HasSubstr("ep boom"));
+}
+
+// Helper must short-circuit on empty metadef I/O (the callbacks below would fail the test if invoked).
+TEST(PluginExecutionProviderTest, ApplyFusedNodeMemTypes_EmptyMetaDef) {
+  bool input_cb_called = false;
+  bool output_cb_called = false;
+  NodeComputeInfo info;
+  info.get_input_mem_types = [&input_cb_called](gsl::span<OrtMemType> /*mem_types*/) -> Status {
+    input_cb_called = true;
+    return Status(common::ONNXRUNTIME, common::FAIL, "should not be called");
+  };
+  info.get_output_mem_types = [&output_cb_called](gsl::span<OrtMemType> /*mem_types*/) -> Status {
+    output_cb_called = true;
+    return Status(common::ONNXRUNTIME, common::FAIL, "should not be called");
+  };
+
+  IndexedSubGraph::MetaDef metadef;
+  metadef.name = "fused";
+  metadef.domain = "test";
+  metadef.since_version = 1;
+  // inputs and outputs deliberately left empty
+
+  KernelDefBuilder builder;
+  builder.SetName(metadef.name).SetDomain(metadef.domain).SinceVersion(metadef.since_version).Provider("TestOrtEp");
+  ASSERT_STATUS_OK(ApplyFusedNodeMemTypes(builder, info, metadef));
+  EXPECT_FALSE(input_cb_called);
+  EXPECT_FALSE(output_cb_called);
 }
 
 }  // namespace onnxruntime::test


### PR DESCRIPTION
### Description

Two new optional hooks for plugin EPs so they can control I/O memory placement,
both gated on `ort_version_supported >= 27`:

  - **`OrtNodeComputeInfo::GetInputMemTypes` / `GetOutputMemTypes`** — per-fused-node,
    per-slot `OrtMemType` overrides. The compile-path counterpart to
    `KernelDefBuilder::{Input,Output}MemoryType`.
  - **`OrtEp::GetMemoryInfoByMemType`** — per-`OrtMemType` choice of which registered
    `OrtMemoryInfo` ORT should use when resolving placement.

  Together: the fused-node hooks decide *which memtype* a slot should be; the
  EP-wide hook decides *which OrtMemoryInfo* backs that memtype.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Allow plugin EPs that use compiled fused nodes to influence which allocators should be used to allocate their I/O.
Extended motivation: eventually allow eliminate copies between CPU/EP subgraphs when possible.

