### PR TITLE
Derive ORT_TEST_VERBOSE from System.Debug via runtime coalesce in plugin test pipelines

### DIFF
--- a/tools/ci_build/github/azure-pipelines/plugin-cuda-test-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/plugin-cuda-test-pipeline.yml
@@ -15,6 +15,10 @@ variables:
   value: true
 - name: Codeql.SkipTaskAutoInjection
   value: true
+# Verbose-output flag for tests. Resolves to System.Debug when set
+# (e.g. queue-time "Enable system diagnostics"), else 'false'.
+- name: OrtTestVerbose
+  value: $[ coalesce(variables['System.Debug'], 'false') ]
 
 resources:
   pipelines:

--- a/tools/ci_build/github/azure-pipelines/plugin-webgpu-test-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/plugin-webgpu-test-pipeline.yml
@@ -16,6 +16,10 @@ variables:
   value: true
 - name: Codeql.SkipTaskAutoInjection
   value: true
+# Verbose-output flag for tests. Resolves to System.Debug when set
+# (e.g. queue-time "Enable system diagnostics"), else 'false'.
+- name: OrtTestVerbose
+  value: $[ coalesce(variables['System.Debug'], 'false') ]
 
 resources:
   pipelines:

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-linux-cuda-test-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-linux-cuda-test-stage.yml
@@ -54,7 +54,7 @@ stages:
           --volume "$(Build.BinariesDirectory):/build" \
           --env PIP_INDEX_URL \
           --env "NVIDIA_VISIBLE_DEVICES=all" \
-          --env "ORT_TEST_VERBOSE=$(System.Debug)" \
+          --env "ORT_TEST_VERBOSE=$(OrtTestVerbose)" \
           onnxruntimecuda$(CudaVersionNoDot)plugintestx64 \
           /bin/bash -c "
             set -e -x

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-linux-webgpu-test-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-linux-webgpu-test-stage.yml
@@ -71,7 +71,7 @@ stages:
           --env "PIP_INDEX_URL=${PIP_INDEX_URL}" \
           --env "VK_ICD_FILENAMES=${swiftshader_icd}" \
           --env "VK_DRIVER_FILES=${swiftshader_icd}" \
-          --env "ORT_TEST_VERBOSE=$(System.Debug)" \
+          --env "ORT_TEST_VERBOSE=$(OrtTestVerbose)" \
           --env "MIN_ORT_VERSION=${min_ort_version}" \
           onnxruntimewebgpuplugin \
           /bin/bash -c '

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-mac-webgpu-test-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-mac-webgpu-test-stage.yml
@@ -44,4 +44,4 @@ stages:
         python3 -u "$(Build.SourcesDirectory)/plugin-ep-webgpu/python/test/test_webgpu_plugin_ep.py"
       displayName: 'Install and test Python package'
       env:
-        ORT_TEST_VERBOSE: $(System.Debug)
+        ORT_TEST_VERBOSE: $(OrtTestVerbose)

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-win-cuda-test-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-win-cuda-test-stage.yml
@@ -64,7 +64,7 @@ stages:
     - task: PowerShell@2
       displayName: 'Install and test Python package'
       env:
-        ORT_TEST_VERBOSE: $(System.Debug)
+        ORT_TEST_VERBOSE: $(OrtTestVerbose)
       inputs:
         targetType: inline
         pwsh: true

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-win-webgpu-test-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-win-webgpu-test-stage.yml
@@ -56,7 +56,7 @@ stages:
         python -u "$(Build.SourcesDirectory)\plugin-ep-webgpu\python\test\test_webgpu_plugin_ep.py"
       displayName: 'Install and test Python package'
       env:
-        ORT_TEST_VERBOSE: $(System.Debug)
+        ORT_TEST_VERBOSE: $(OrtTestVerbose)
 
   # NuGet package test (x64 only — the NuGet package is multi-platform but
   # the test runs on a single Windows agent that exercises the WebGPU EP).


### PR DESCRIPTION
## Summary

Five plugin test stage YAMLs reference `$(System.Debug)`, a predefined ADO variable that is only set when "Enable system diagnostics" is checked at queue time. When undefined, two failure modes occur:

- **bash command lines** (Linux WebGPU/CUDA stages): bash interprets `$(System.Debug)` as command substitution and the step fails with `bash: line 14: System.Debug: command not found`.
- **YAML `env:` blocks** (Mac/Win WebGPU + Win CUDA stages): the env var is set to the literal string `$(System.Debug)`, meaningless to test code that expects `true`/`false`/`1`/`0`.

## Fix

Add a derived pipeline-level variable to the two test pipeline entry points:

```yaml
# Verbose-output flag for tests. Resolves to System.Debug when set
# (e.g. queue-time "Enable system diagnostics"), else 'false'.
- name: OrtTestVerbose
  value: $[ coalesce(variables['System.Debug'], 'false') ]
```

and switch the five stage references from `$(System.Debug)` to `$(OrtTestVerbose)`.

This avoids redefining the predefined `System.Debug` variable while preserving the "Enable system diagnostics" UI toggle — when that checkbox is set, `System.Debug` is `'true'` at runtime and the derived variable follows.

A compile-time `${{ if }}` template alternative was not used because template expressions are evaluated at compile time and cannot see queue-time runtime variables like `System.Debug`; only a runtime expression (`$[ ]`) can react to the standard system-diagnostics checkbox.

## Files changed

| File | Change |
|---|---|
| `plugin-webgpu-test-pipeline.yml` | Add `OrtTestVerbose` derived variable |
| `plugin-cuda-test-pipeline.yml` | Add `OrtTestVerbose` derived variable |
| `stages/plugin-linux-webgpu-test-stage.yml` | `$(System.Debug)` → `$(OrtTestVerbose)` |
| `stages/plugin-linux-cuda-test-stage.yml` | `$(System.Debug)` → `$(OrtTestVerbose)` |
| `stages/plugin-mac-webgpu-test-stage.yml` | `$(System.Debug)` → `$(OrtTestVerbose)` |
| `stages/plugin-win-webgpu-test-stage.yml` | `$(System.Debug)` → `$(OrtTestVerbose)` |
| `stages/plugin-win-cuda-test-stage.yml` | `$(System.Debug)` → `$(OrtTestVerbose)` |

Pipeline run verified ✅