### PR TITLE
[MLAS] RVV-Optimized LLM Operators for RISC-V

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -90,6 +90,7 @@ option(onnxruntime_USE_DNNL "Build with DNNL support" OFF)
 option(onnxruntime_USE_JSEP "Build with JavaScript implemented kernels support" OFF)
 option(onnxruntime_USE_SVE "Build with SVE support in MLAS" OFF)
 option(onnxruntime_USE_RVV "Build with RISC-V Vector support in MLAS" OFF)
+option(onnxruntime_USE_RVV_ZVFH "Build with RISC-V Zvfh (FP16 vector) support in MLAS" OFF)
 option(onnxruntime_USE_ARM_NEON_NCHWC "Build with ARM Neon NCHWc kernels in MLAS" OFF)
 
 option(onnxruntime_USE_KLEIDIAI "Build with KleidiAI integration in MLAS" OFF)

--- a/cmake/onnxruntime_mlas.cmake
+++ b/cmake/onnxruntime_mlas.cmake
@@ -56,6 +56,7 @@ onnxruntime_add_static_library(onnxruntime_mlas
   ${MLAS_SRC_DIR}/sqnbitgemm_q8_block.h
   ${MLAS_SRC_DIR}/flashattn.cpp
   ${MLAS_SRC_DIR}/cast.cpp
+  ${MLAS_SRC_DIR}/layernorm.cpp
   ${MLAS_SRC_DIR}/rotary_embedding.h
   ${MLAS_SRC_DIR}/rotary_embedding.cpp
   ${MLAS_SRC_DIR}/softmax.h
@@ -943,6 +944,8 @@ endif()
               ${MLAS_SRC_DIR}/riscv64/softmax_kernel_rvv.cpp
               ${MLAS_SRC_DIR}/riscv64/sconv_depthwise_kernel_rvv.cpp
               ${MLAS_SRC_DIR}/riscv64/sconv_nchwc_kernel_rvv.cpp
+              ${MLAS_SRC_DIR}/riscv64/rotary_embedding_kernel_rvv.cpp
+              ${MLAS_SRC_DIR}/riscv64/layernorm_kernel_rvv.cpp
             )
             list(REMOVE_ITEM mlas_platform_srcs
               "${MLAS_SRC_DIR}/sconv_nchw_depthwise_multiplier_1.cpp")
@@ -952,8 +955,22 @@ endif()
               ${MLAS_SRC_DIR}/riscv64/softmax_kernel_rvv.cpp
               ${MLAS_SRC_DIR}/riscv64/sconv_depthwise_kernel_rvv.cpp
               ${MLAS_SRC_DIR}/riscv64/sconv_nchwc_kernel_rvv.cpp
+              ${MLAS_SRC_DIR}/riscv64/rotary_embedding_kernel_rvv.cpp
+              ${MLAS_SRC_DIR}/riscv64/layernorm_kernel_rvv.cpp
               PROPERTIES COMPILE_FLAGS "-march=rv64gcv -mabi=lp64d")
             list(APPEND mlas_private_compile_definitions MLAS_USE_RVV=1)
+
+            if(onnxruntime_USE_RVV_ZVFH)
+              list(APPEND mlas_platform_srcs
+                ${MLAS_SRC_DIR}/riscv64/halfgemm_kernel_rvv.cpp
+                ${MLAS_SRC_DIR}/riscv64/cast_kernel_rvv.cpp
+              )
+              set_source_files_properties(
+                ${MLAS_SRC_DIR}/riscv64/halfgemm_kernel_rvv.cpp
+                ${MLAS_SRC_DIR}/riscv64/cast_kernel_rvv.cpp
+                PROPERTIES COMPILE_FLAGS "-march=rv64gcv_zvfh -mabi=lp64d")
+              list(APPEND mlas_private_compile_definitions MLAS_USE_RVV_ZVFH=1)
+            endif()
           else()
             message(
               WARNING

--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -1450,6 +1450,50 @@ if (NOT onnxruntime_ENABLE_TRAINING_TORCH_INTEROP)
       PRIVATE ${ONNXRUNTIME_MLAS_LIBS} onnxruntime_common ${CMAKE_DL_LIBS})
     target_compile_definitions(onnxruntime_mlas_softmax_riscv_compare PRIVATE ${mlas_private_compile_definitions})
     set_target_properties(onnxruntime_mlas_softmax_riscv_compare PROPERTIES FOLDER "ONNXRuntimeTest")
+
+    onnxruntime_add_executable(
+      onnxruntime_mlas_halfgemm_rvv_bench
+      ${MLAS_RISCV64_BENCH_DIR}/halfgemm_rvv_bench.cpp)
+    target_include_directories(onnxruntime_mlas_halfgemm_rvv_bench PRIVATE
+      ${ONNXRUNTIME_ROOT}/core/mlas/inc ${ONNXRUNTIME_ROOT}/core/mlas/lib)
+    target_link_libraries(
+      onnxruntime_mlas_halfgemm_rvv_bench
+      PRIVATE ${ONNXRUNTIME_MLAS_LIBS} onnxruntime_common ${CMAKE_DL_LIBS})
+    target_compile_definitions(onnxruntime_mlas_halfgemm_rvv_bench PRIVATE ${mlas_private_compile_definitions})
+    set_target_properties(onnxruntime_mlas_halfgemm_rvv_bench PROPERTIES FOLDER "ONNXRuntimeTest")
+
+    onnxruntime_add_executable(
+      onnxruntime_mlas_cast_rvv_bench
+      ${MLAS_RISCV64_BENCH_DIR}/cast_rvv_bench.cpp)
+    target_include_directories(onnxruntime_mlas_cast_rvv_bench PRIVATE
+      ${ONNXRUNTIME_ROOT}/core/mlas/inc ${ONNXRUNTIME_ROOT}/core/mlas/lib)
+    target_link_libraries(
+      onnxruntime_mlas_cast_rvv_bench
+      PRIVATE ${ONNXRUNTIME_MLAS_LIBS} onnxruntime_common ${CMAKE_DL_LIBS})
+    target_compile_definitions(onnxruntime_mlas_cast_rvv_bench PRIVATE ${mlas_private_compile_definitions})
+    set_target_properties(onnxruntime_mlas_cast_rvv_bench PROPERTIES FOLDER "ONNXRuntimeTest")
+
+    onnxruntime_add_executable(
+      onnxruntime_mlas_rope_rvv_bench
+      ${MLAS_RISCV64_BENCH_DIR}/rope_rvv_bench.cpp)
+    target_include_directories(onnxruntime_mlas_rope_rvv_bench PRIVATE
+      ${ONNXRUNTIME_ROOT}/core/mlas/inc ${ONNXRUNTIME_ROOT}/core/mlas/lib)
+    target_link_libraries(
+      onnxruntime_mlas_rope_rvv_bench
+      PRIVATE ${ONNXRUNTIME_MLAS_LIBS} onnxruntime_common ${CMAKE_DL_LIBS})
+    target_compile_definitions(onnxruntime_mlas_rope_rvv_bench PRIVATE ${mlas_private_compile_definitions})
+    set_target_properties(onnxruntime_mlas_rope_rvv_bench PROPERTIES FOLDER "ONNXRuntimeTest")
+
+    onnxruntime_add_executable(
+      onnxruntime_mlas_rmsnorm_rvv_bench
+      ${MLAS_RISCV64_BENCH_DIR}/rmsnorm_rvv_bench.cpp)
+    target_include_directories(onnxruntime_mlas_rmsnorm_rvv_bench PRIVATE
+      ${ONNXRUNTIME_ROOT}/core/mlas/inc ${ONNXRUNTIME_ROOT}/core/mlas/lib)
+    target_link_libraries(
+      onnxruntime_mlas_rmsnorm_rvv_bench
+      PRIVATE ${ONNXRUNTIME_MLAS_LIBS} onnxruntime_common ${CMAKE_DL_LIBS})
+    target_compile_definitions(onnxruntime_mlas_rmsnorm_rvv_bench PRIVATE ${mlas_private_compile_definitions})
+    set_target_properties(onnxruntime_mlas_rmsnorm_rvv_bench PROPERTIES FOLDER "ONNXRuntimeTest")
   endif()
 
   if(WIN32)

--- a/onnxruntime/core/common/cpuid_arch_definition.h
+++ b/onnxruntime/core/common/cpuid_arch_definition.h
@@ -12,3 +12,7 @@
 #if defined(_M_ARM64) || defined(_M_ARM64EC) || defined(__aarch64__) || defined(_M_ARM) || defined(__arm__)
 #define CPUIDINFO_ARCH_ARM
 #endif  // ARM or ARM64
+
+#if defined(__riscv) && __riscv_xlen == 64
+#define CPUIDINFO_ARCH_RISCV64
+#endif

--- a/onnxruntime/core/common/cpuid_info.cc
+++ b/onnxruntime/core/common/cpuid_info.cc
@@ -47,6 +47,16 @@
 
 #endif  // ARM
 
+#if defined(CPUIDINFO_ARCH_RISCV64)
+#include <asm/hwprobe.h>
+#ifndef RISCV_HWPROBE_EXT_ZVFH
+#define RISCV_HWPROBE_EXT_ZVFH (1 << 30)
+#endif
+#ifndef RISCV_HWPROBE_IMA_V
+#define RISCV_HWPROBE_IMA_V (1 << 2)
+#endif
+#endif  // RISCV64
+
 #endif  // Linux
 
 #if _WIN32
@@ -334,6 +344,17 @@ void CPUIDInfo::ArmAppleInit() {
 
 #endif  // defined(CPUIDINFO_ARCH_ARM)
 
+#if defined(CPUIDINFO_ARCH_RISCV64) && defined(__linux__)
+void CPUIDInfo::RiscvLinuxInit() {
+  struct riscv_hwprobe pairs[] = {
+      {RISCV_HWPROBE_KEY_IMA_EXT_0, 0},
+  };
+  if (syscall(__NR_riscv_hwprobe, pairs, 1, 0, nullptr, 0) == 0) {
+    has_fp16_ = (pairs[0].value & RISCV_HWPROBE_EXT_ZVFH) != 0;
+  }
+}
+#endif  // defined(CPUIDINFO_ARCH_RISCV64) && defined(__linux__)
+
 uint32_t CPUIDInfo::GetCurrentCoreIdx() const {
 #ifdef _WIN32
   return GetCurrentProcessorNumber();
@@ -377,5 +398,11 @@ CPUIDInfo::CPUIDInfo() {
   ArmAppleInit();
 #endif
 #endif  // defined(CPUIDINFO_ARCH_ARM)
+
+#if defined(CPUIDINFO_ARCH_RISCV64)
+#if defined(__linux__)
+  RiscvLinuxInit();
+#endif
+#endif  // defined(CPUIDINFO_ARCH_RISCV64)
 }
 }  // namespace onnxruntime

--- a/onnxruntime/core/common/cpuid_info.h
+++ b/onnxruntime/core/common/cpuid_info.h
@@ -135,6 +135,12 @@ class CPUIDInfo {
 
 #endif  // defined(CPUIDINFO_ARCH_ARM)
 
+#if defined(CPUIDINFO_ARCH_RISCV64)
+#if defined(__linux__)
+  void RiscvLinuxInit();
+#endif
+#endif  // defined(CPUIDINFO_ARCH_RISCV64)
+
 #if defined(CPUINFO_SUPPORTED)
   bool pytorch_cpuinfo_init_{false};
 #endif  // defined(CPUINFO_SUPPORTED)

--- a/onnxruntime/core/mlas/inc/mlas.h
+++ b/onnxruntime/core/mlas/inc/mlas.h
@@ -1666,6 +1666,26 @@ MlasRotaryEmbedOneRow(
 );
 
 /**
+ * @brief Compute LayerNorm or RMSNorm (simplified) for one row of float data.
+ *        Uses platform-optimized kernel if available, otherwise returns false.
+ *
+ * @return true if an optimized kernel was used, false if caller should fall back
+ */
+bool
+MLASCALL
+MlasLayerNormF32(
+    const float* Input,
+    const float* Scale,
+    const float* Bias,
+    float* Output,
+    float* MeanOut,
+    float* InvStdDevOut,
+    size_t NormSize,
+    float Epsilon,
+    bool Simplified
+);
+
+/**
  * @brief Supply matrices data information to half precision gemm functions
  */
 struct MLAS_HGEMM_DATA_PARAMS {

--- a/onnxruntime/core/mlas/inc/mlas.h
+++ b/onnxruntime/core/mlas/inc/mlas.h
@@ -1668,6 +1668,7 @@ MlasRotaryEmbedOneRow(
 /**
  * @brief Compute LayerNorm or RMSNorm (simplified) for one row of float data.
  *        Uses platform-optimized kernel if available, otherwise returns false.
+ *        Any platform (AMD64/ARM64/RISC-V) can register a LayerNormF32Kernel.
  *
  * @return true if an optimized kernel was used, false if caller should fall back
  */

--- a/onnxruntime/core/mlas/lib/halfgemm.cpp
+++ b/onnxruntime/core/mlas/lib/halfgemm.cpp
@@ -27,6 +27,8 @@ MlasFp16AccelerationSupported()
 {
 #ifdef MLAS_F16VEC_INTRINSICS_SUPPORTED
     return MLAS_CPUIDINFO::GetCPUIDInfo().HasFp16VectorAcceleration();
+#elif defined(MLAS_TARGET_RISCV64) && defined(MLAS_USE_RVV_ZVFH)
+    return true;
 #else
     return false;
 #endif

--- a/onnxruntime/core/mlas/lib/halfgemm.cpp
+++ b/onnxruntime/core/mlas/lib/halfgemm.cpp
@@ -28,7 +28,7 @@ MlasFp16AccelerationSupported()
 #ifdef MLAS_F16VEC_INTRINSICS_SUPPORTED
     return MLAS_CPUIDINFO::GetCPUIDInfo().HasFp16VectorAcceleration();
 #elif defined(MLAS_TARGET_RISCV64) && defined(MLAS_USE_RVV_ZVFH)
-    return true;
+    return MLAS_CPUIDINFO::GetCPUIDInfo().HasFp16VectorAcceleration();
 #else
     return false;
 #endif

--- a/onnxruntime/core/mlas/lib/halfgemm.h
+++ b/onnxruntime/core/mlas/lib/halfgemm.h
@@ -503,12 +503,18 @@ extern const MLAS_HALFGEMM_DISPATCH MlasHalfGemmDispatchDefault;
 extern const MLAS_HALFGEMM_DISPATCH MlasHalfGemmDispatchNeon;
 #endif
 
+#if defined(MLAS_TARGET_RISCV64) && defined(MLAS_USE_RVV_ZVFH)
+extern const MLAS_HALFGEMM_DISPATCH MlasHalfGemmDispatchRvv;
+#endif
+
 MLAS_FORCEINLINE
 const MLAS_HALFGEMM_DISPATCH*
 MlasHalfGemmGetDispatch()
 {
 #if defined(MLAS_F16VEC_INTRINSICS_SUPPORTED) && defined(MLAS_TARGET_ARM64)
     return &MlasHalfGemmDispatchNeon;
+#elif defined(MLAS_TARGET_RISCV64) && defined(MLAS_USE_RVV_ZVFH)
+    return &MlasHalfGemmDispatchRvv;
 #else
     return &MlasHalfGemmDispatchDefault;
 #endif

--- a/onnxruntime/core/mlas/lib/halfgemm.h
+++ b/onnxruntime/core/mlas/lib/halfgemm.h
@@ -514,7 +514,10 @@ MlasHalfGemmGetDispatch()
 #if defined(MLAS_F16VEC_INTRINSICS_SUPPORTED) && defined(MLAS_TARGET_ARM64)
     return &MlasHalfGemmDispatchNeon;
 #elif defined(MLAS_TARGET_RISCV64) && defined(MLAS_USE_RVV_ZVFH)
-    return &MlasHalfGemmDispatchRvv;
+    if (MLAS_CPUIDINFO::GetCPUIDInfo().HasFp16VectorAcceleration()) {
+        return &MlasHalfGemmDispatchRvv;
+    }
+    return &MlasHalfGemmDispatchDefault;
 #else
     return &MlasHalfGemmDispatchDefault;
 #endif

--- a/onnxruntime/core/mlas/lib/layernorm.cpp
+++ b/onnxruntime/core/mlas/lib/layernorm.cpp
@@ -1,0 +1,41 @@
+/*++
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the MIT License.
+
+Module Name:
+
+    layernorm.cpp
+
+Abstract:
+
+    This module implements the dispatch for platform-optimized
+    LayerNorm/RMSNorm kernels.
+
+--*/
+
+#include "mlasi.h"
+
+bool
+    MLASCALL
+    MlasLayerNormF32(
+        const float* Input,
+        const float* Scale,
+        const float* Bias,
+        float* Output,
+        float* MeanOut,
+        float* InvStdDevOut,
+        size_t NormSize,
+        float Epsilon,
+        bool Simplified
+    )
+{
+    auto kernel = GetMlasPlatform().LayerNormF32Kernel;
+    if (kernel == nullptr) {
+        return false;
+    }
+
+    kernel(Input, Scale, Bias, Output, MeanOut, InvStdDevOut, NormSize, Epsilon, Simplified);
+    return true;
+}

--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -691,6 +691,18 @@ typedef void(MLASCALL MLAS_CAST_F32_TO_F16_KERNEL)(
     size_t Count
 );
 
+typedef void(MLASCALL MLAS_LAYERNORM_F32_KERNEL)(
+    const float* Input,
+    const float* Scale,
+    const float* Bias,
+    float* Output,
+    float* MeanOut,
+    float* InvStdDevOut,
+    size_t NormSize,
+    float Epsilon,
+    bool Simplified
+);
+
 typedef
 void
 (MLASCALL MLAS_QLINEAR_BINARY_OP_S8_KERNEL)(
@@ -1230,6 +1242,15 @@ extern "C" {
     MLAS_CAST_F16_TO_F32_KERNEL MlasCastF16ToF32KernelNeon;
     MLAS_CAST_F32_TO_F16_KERNEL MlasCastF32ToF16KernelNeon;
 #endif
+
+#if defined(MLAS_TARGET_RISCV64) && defined(MLAS_USE_RVV_ZVFH)
+    MLAS_CAST_F16_TO_F32_KERNEL MlasCastF16ToF32KernelRvv;
+    MLAS_CAST_F32_TO_F16_KERNEL MlasCastF32ToF16KernelRvv;
+#endif
+
+#if defined(MLAS_TARGET_RISCV64) && defined(MLAS_USE_RVV)
+    MLAS_LAYERNORM_F32_KERNEL MlasLayerNormKernelRvv;
+#endif
 }
 
 //
@@ -1387,6 +1408,10 @@ extern const MLAS_QNBIT_LUT_GEMM_DISPATCH MlasLutGenKernelAvx2;
 struct MLAS_ROPE_DISPATCH;
 extern const MLAS_ROPE_DISPATCH MlasRopeDispatchNeon;
 extern const MLAS_ROPE_DISPATCH MlasRopeDispatchAvx2;
+
+#if defined(MLAS_TARGET_RISCV64) && defined(MLAS_USE_RVV)
+extern const MLAS_ROPE_DISPATCH MlasRopeDispatchRvv;
+#endif
 
 //
 // half gemm dispatch structure
@@ -1623,6 +1648,7 @@ MLAS_COMPUTE_TANH_FP16_KERNEL* TanhFP16KernelRoutine = nullptr;
 
     MLAS_CAST_F16_TO_F32_KERNEL* CastF16ToF32Kernel;
     MLAS_CAST_F32_TO_F16_KERNEL* CastF32ToF16Kernel;
+    MLAS_LAYERNORM_F32_KERNEL* LayerNormF32Kernel{nullptr};
 
     const MLAS_ROPE_DISPATCH* RopeDispatch{nullptr};
     const MLAS_HGEMM_DISPATCH* HGemmDispatch{nullptr};

--- a/onnxruntime/core/mlas/lib/platform.cpp
+++ b/onnxruntime/core/mlas/lib/platform.cpp
@@ -292,6 +292,13 @@ Return Value:
     this->ComputeSumExpF32Kernel = MlasComputeSumExpF32KernelRvv;
     this->ComputeSoftmaxOutputF32Kernel = MlasComputeSoftmaxOutputF32KernelRvv;
     this->ComputeLogSoftmaxOutputF32Kernel = MlasComputeLogSoftmaxOutputF32KernelRvv;
+    this->RopeDispatch = &MlasRopeDispatchRvv;
+    this->LayerNormF32Kernel = &MlasLayerNormKernelRvv;
+
+#if defined(MLAS_USE_RVV_ZVFH)
+    this->CastF16ToF32Kernel = &MlasCastF16ToF32KernelRvv;
+    this->CastF32ToF16Kernel = &MlasCastF32ToF16KernelRvv;
+#endif
 
     // NCHWc kernels require VLEN>=128 so that vfloat32m4_t holds 16 floats.
     if (__riscv_vlenb() >= 16) {

--- a/onnxruntime/core/mlas/lib/platform.cpp
+++ b/onnxruntime/core/mlas/lib/platform.cpp
@@ -296,8 +296,10 @@ Return Value:
     this->LayerNormF32Kernel = &MlasLayerNormKernelRvv;
 
 #if defined(MLAS_USE_RVV_ZVFH)
-    this->CastF16ToF32Kernel = &MlasCastF16ToF32KernelRvv;
-    this->CastF32ToF16Kernel = &MlasCastF32ToF16KernelRvv;
+    if (MLAS_CPUIDINFO::GetCPUIDInfo().HasFp16VectorAcceleration()) {
+        this->CastF16ToF32Kernel = &MlasCastF16ToF32KernelRvv;
+        this->CastF32ToF16Kernel = &MlasCastF32ToF16KernelRvv;
+    }
 #endif
 
     // NCHWc kernels require VLEN>=128 so that vfloat32m4_t holds 16 floats.

--- a/onnxruntime/core/mlas/lib/riscv64/cast_kernel_rvv.cpp
+++ b/onnxruntime/core/mlas/lib/riscv64/cast_kernel_rvv.cpp
@@ -1,0 +1,62 @@
+/*++
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the MIT License.
+
+Module Name:
+
+    cast_kernel_rvv.cpp
+
+Abstract:
+
+    This module implements FP16<->FP32 cast kernels using RISC-V Vector
+    Extension (RVV). Uses Zvfhmin conversion instructions, but is gated
+    on Zvfh at build time (no separate Zvfhmin-only cmake probe).
+
+--*/
+
+#include "mlasi.h"
+
+#if defined(MLAS_USE_RVV_ZVFH)
+
+#include <riscv_vector.h>
+
+void
+    MLASCALL
+    MlasCastF16ToF32KernelRvv(
+        const unsigned short* Source,
+        float* Destination,
+        size_t Count
+    )
+{
+    size_t i = 0;
+    while (i < Count) {
+        size_t vl = __riscv_vsetvl_e16m2(Count - i);
+        vuint16m2_t raw = __riscv_vle16_v_u16m2(Source + i, vl);
+        vfloat16m2_t fp16 = __riscv_vreinterpret_v_u16m2_f16m2(raw);
+        vfloat32m4_t fp32 = __riscv_vfwcvt_f_f_v_f32m4(fp16, vl);
+        __riscv_vse32_v_f32m4(Destination + i, fp32, vl);
+        i += vl;
+    }
+}
+
+void
+    MLASCALL
+    MlasCastF32ToF16KernelRvv(
+        const float* Source,
+        unsigned short* Destination,
+        size_t Count
+    )
+{
+    size_t i = 0;
+    while (i < Count) {
+        size_t vl = __riscv_vsetvl_e32m4(Count - i);
+        vfloat32m4_t fp32 = __riscv_vle32_v_f32m4(Source + i, vl);
+        vfloat16m2_t fp16 = __riscv_vfncvt_f_f_w_f16m2(fp32, vl);
+        __riscv_vse16_v_u16m2(Destination + i, __riscv_vreinterpret_v_f16m2_u16m2(fp16), vl);
+        i += vl;
+    }
+}
+
+#endif  // MLAS_USE_RVV_ZVFH

--- a/onnxruntime/core/mlas/lib/riscv64/halfgemm_kernel_rvv.cpp
+++ b/onnxruntime/core/mlas/lib/riscv64/halfgemm_kernel_rvv.cpp
@@ -1,0 +1,236 @@
+/*++
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the MIT License.
+
+Module Name:
+
+    halfgemm_kernel_rvv.cpp
+
+Abstract:
+
+    This module implements half precision GEMM kernel for RISC-V Vector
+    Extension (RVV) with Zvfh (vector half-precision floating-point).
+
+    The kernel vectorizes along the N dimension using vsetvl, so it adapts
+    automatically to any VLEN >= 128. Up to 4 rows of A are processed per
+    call (KernelMaxM = 4).
+
+--*/
+
+#include "halfgemm.h"
+#include "mlasi.h"
+
+#if defined(MLAS_USE_RVV_ZVFH)
+
+#include <riscv_vector.h>
+
+#include <cstring>
+
+namespace
+{
+
+MLAS_FORCEINLINE
+_Float16
+Fp16BitsToScalar(_mlas_fp16_ bits)
+{
+    _Float16 f;
+    memcpy(&f, &bits, sizeof(f));
+    return f;
+}
+
+MLAS_FORCEINLINE
+vfloat16m4_t
+LoadFp16(const _mlas_fp16_* ptr, size_t vl)
+{
+    return __riscv_vreinterpret_v_u16m4_f16m4(__riscv_vle16_v_u16m4(ptr, vl));
+}
+
+MLAS_FORCEINLINE
+void
+StoreFp16(_mlas_fp16_* ptr, vfloat16m4_t vec, size_t vl)
+{
+    __riscv_vse16_v_u16m4(ptr, __riscv_vreinterpret_v_f16m4_u16m4(vec), vl);
+}
+
+template <size_t Rows>
+MLAS_FORCEINLINE void
+HalfGemmKernelRvvImpl(
+    size_t CountN,
+    size_t CountK,
+    _mlas_fp16_* C,
+    size_t ldc,
+    const _mlas_fp16_* Bias,
+    const _mlas_fp16_* A,
+    size_t lda,
+    const _mlas_fp16_* B,
+    size_t ldb,
+    bool ZeroMode
+)
+{
+    static_assert(Rows >= 1 && Rows <= 4, "unsupported tile height");
+
+    size_t n = 0;
+    while (n < CountN) {
+        size_t vl = __riscv_vsetvl_e16m4(CountN - n);
+
+        vfloat16m4_t acc0, acc1, acc2, acc3;
+
+        if (ZeroMode) {
+            if (Bias != nullptr) {
+                vfloat16m4_t bv = LoadFp16(Bias + n, vl);
+                acc0 = bv;
+                if constexpr (Rows > 1) acc1 = bv;
+                if constexpr (Rows > 2) acc2 = bv;
+                if constexpr (Rows > 3) acc3 = bv;
+            } else {
+                vfloat16m4_t z = __riscv_vfmv_v_f_f16m4((_Float16)0.0f, vl);
+                acc0 = z;
+                if constexpr (Rows > 1) acc1 = z;
+                if constexpr (Rows > 2) acc2 = z;
+                if constexpr (Rows > 3) acc3 = z;
+            }
+        } else {
+            acc0 = LoadFp16(C + n, vl);
+            if constexpr (Rows > 1) acc1 = LoadFp16(C + ldc + n, vl);
+            if constexpr (Rows > 2) acc2 = LoadFp16(C + 2 * ldc + n, vl);
+            if constexpr (Rows > 3) acc3 = LoadFp16(C + 3 * ldc + n, vl);
+            if (Bias != nullptr) {
+                vfloat16m4_t bv = LoadFp16(Bias + n, vl);
+                acc0 = __riscv_vfadd_vv_f16m4(acc0, bv, vl);
+                if constexpr (Rows > 1) acc1 = __riscv_vfadd_vv_f16m4(acc1, bv, vl);
+                if constexpr (Rows > 2) acc2 = __riscv_vfadd_vv_f16m4(acc2, bv, vl);
+                if constexpr (Rows > 3) acc3 = __riscv_vfadd_vv_f16m4(acc3, bv, vl);
+            }
+        }
+
+        for (size_t k = 0; k < CountK; k++) {
+            vfloat16m4_t bv = LoadFp16(B + k * ldb + n, vl);
+            acc0 = __riscv_vfmacc_vf_f16m4(acc0, Fp16BitsToScalar(A[k]), bv, vl);
+            if constexpr (Rows > 1)
+                acc1 = __riscv_vfmacc_vf_f16m4(acc1, Fp16BitsToScalar(A[lda + k]), bv, vl);
+            if constexpr (Rows > 2)
+                acc2 = __riscv_vfmacc_vf_f16m4(acc2, Fp16BitsToScalar(A[2 * lda + k]), bv, vl);
+            if constexpr (Rows > 3)
+                acc3 = __riscv_vfmacc_vf_f16m4(acc3, Fp16BitsToScalar(A[3 * lda + k]), bv, vl);
+        }
+
+        StoreFp16(C + n, acc0, vl);
+        if constexpr (Rows > 1) StoreFp16(C + ldc + n, acc1, vl);
+        if constexpr (Rows > 2) StoreFp16(C + 2 * ldc + n, acc2, vl);
+        if constexpr (Rows > 3) StoreFp16(C + 3 * ldc + n, acc3, vl);
+
+        n += vl;
+    }
+}
+
+}  // namespace
+
+struct MLAS_HALF_GEMM_KERNEL_RVV {
+    static constexpr bool PackNeeded = false;
+    static constexpr size_t KernelMaxM = 4;
+    static constexpr size_t PackedK = 1;
+    static constexpr MLAS_HALF_GEMM_STRIDES Strides{16, 128, 256};
+};
+
+template <>
+MLAS_FORCEINLINE void
+MlasHalfGemmConvertPackA<MLAS_HALF_GEMM_KERNEL_RVV>(
+    _mlas_fp16_* D,
+    const float* A,
+    size_t lda,
+    size_t CountM,
+    size_t CountK
+)
+{
+    for (size_t m = 0; m < CountM; m++) {
+        const float* src = A + m * lda;
+        _mlas_fp16_* dst = D + m * CountK;
+        size_t k = 0;
+        while (k < CountK) {
+            size_t vl = __riscv_vsetvl_e32m4(CountK - k);
+            vfloat32m4_t fp32 = __riscv_vle32_v_f32m4(src + k, vl);
+            vfloat16m2_t fp16 = __riscv_vfncvt_f_f_w_f16m2(fp32, vl);
+            __riscv_vse16_v_u16m2(
+                dst + k,
+                __riscv_vreinterpret_v_f16m2_u16m2(fp16),
+                vl
+            );
+            k += vl;
+        }
+    }
+}
+
+template <>
+MLAS_FORCEINLINE void
+MlasHalfGemmConvertPackB<MLAS_HALF_GEMM_KERNEL_RVV>(
+    _mlas_fp16_* D,
+    const float* B,
+    size_t ldb,
+    size_t CountN,
+    size_t CountK
+)
+{
+    for (size_t k = 0; k < CountK; k++) {
+        const float* src = B + k * ldb;
+        _mlas_fp16_* dst = D + k * CountN;
+        size_t n = 0;
+        while (n < CountN) {
+            size_t vl = __riscv_vsetvl_e32m4(CountN - n);
+            vfloat32m4_t fp32 = __riscv_vle32_v_f32m4(src + n, vl);
+            vfloat16m2_t fp16 = __riscv_vfncvt_f_f_w_f16m2(fp32, vl);
+            __riscv_vse16_v_u16m2(
+                dst + n,
+                __riscv_vreinterpret_v_f16m2_u16m2(fp16),
+                vl
+            );
+            n += vl;
+        }
+    }
+}
+
+template <>
+MLAS_FORCEINLINE void
+MlasHalfGemmKernel<MLAS_HALF_GEMM_KERNEL_RVV>(
+    size_t CountM,
+    size_t CountN,
+    size_t CountK,
+    _mlas_fp16_* C,
+    size_t ldc,
+    const _mlas_fp16_* Bias,
+    const _mlas_fp16_* A,
+    size_t lda,
+    const _mlas_fp16_* B,
+    size_t ldb,
+    const bool ZeroMode
+)
+{
+    size_t rows = std::min(CountM, MLAS_HALF_GEMM_KERNEL_RVV::KernelMaxM);
+
+    switch (rows) {
+        case 1:
+            HalfGemmKernelRvvImpl<1>(CountN, CountK, C, ldc, Bias, A, lda, B, ldb, ZeroMode);
+            break;
+        case 2:
+            HalfGemmKernelRvvImpl<2>(CountN, CountK, C, ldc, Bias, A, lda, B, ldb, ZeroMode);
+            break;
+        case 3:
+            HalfGemmKernelRvvImpl<3>(CountN, CountK, C, ldc, Bias, A, lda, B, ldb, ZeroMode);
+            break;
+        default:
+            HalfGemmKernelRvvImpl<4>(CountN, CountK, C, ldc, Bias, A, lda, B, ldb, ZeroMode);
+            break;
+    }
+}
+
+const MLAS_HALFGEMM_DISPATCH MlasHalfGemmDispatchRvv = {
+    MlasHalfGemmOperation<MLAS_HALF_GEMM_KERNEL_RVV>,
+    nullptr,
+    MlasHalfGemmConvertPackB<MLAS_HALF_GEMM_KERNEL_RVV>,
+    MLAS_HALF_GEMM_KERNEL_RVV::PackedK,
+    MLAS_HALF_GEMM_KERNEL_RVV::KernelMaxM,
+    0
+};
+
+#endif  // MLAS_USE_RVV_ZVFH

--- a/onnxruntime/core/mlas/lib/riscv64/halfgemm_kernel_rvv.cpp
+++ b/onnxruntime/core/mlas/lib/riscv64/halfgemm_kernel_rvv.cpp
@@ -134,6 +134,9 @@ struct MLAS_HALF_GEMM_KERNEL_RVV {
     static constexpr MLAS_HALF_GEMM_STRIDES Strides{16, 128, 256};
 };
 
+// FP32->FP16 conversion routines for when AIsfp32/BIsfp32 is set.
+// PackNeeded=false means no packing, but these are still called
+// to convert FP32 inputs to FP16 on the fly (see matmul.cc).
 template <>
 MLAS_FORCEINLINE void
 MlasHalfGemmConvertPackA<MLAS_HALF_GEMM_KERNEL_RVV>(

--- a/onnxruntime/core/mlas/lib/riscv64/layernorm_kernel_rvv.cpp
+++ b/onnxruntime/core/mlas/lib/riscv64/layernorm_kernel_rvv.cpp
@@ -21,8 +21,11 @@ Abstract:
 
 #include <riscv_vector.h>
 
+#include <cassert>
 #include <cmath>
 
+// Processes one normalization row. A multi-row variant that fuses
+// several rows would reduce dispatch overhead for small NormSize.
 void MLASCALL
 MlasLayerNormKernelRvv(
     const float* Input,
@@ -36,23 +39,31 @@ MlasLayerNormKernelRvv(
     bool Simplified
 )
 {
+    assert(!Simplified || Bias == nullptr);
     const size_t n = NormSize;
 
-    vfloat32m1_t vsum = __riscv_vfmv_v_f_f32m1(0.0f, __riscv_vsetvl_e32m1(1));
-    vfloat32m1_t vsumsq = __riscv_vfmv_v_f_f32m1(0.0f, __riscv_vsetvl_e32m1(1));
+    size_t maxvl = __riscv_vsetvl_e32m4(n);
+    vfloat32m4_t vacc_sum = __riscv_vfmv_v_f_f32m4(0.0f, maxvl);
+    vfloat32m4_t vacc_sumsq = __riscv_vfmv_v_f_f32m4(0.0f, maxvl);
 
     size_t i = 0;
     while (i < n) {
         size_t vl = __riscv_vsetvl_e32m4(n - i);
         vfloat32m4_t vx = __riscv_vle32_v_f32m4(Input + i, vl);
-        vsum = __riscv_vfredusum_vs_f32m4_f32m1(vx, vsum, vl);
+        vacc_sum = __riscv_vfadd_vv_f32m4_tu(vacc_sum, vacc_sum, vx, vl);
         vfloat32m4_t vx2 = __riscv_vfmul_vv_f32m4(vx, vx, vl);
-        vsumsq = __riscv_vfredusum_vs_f32m4_f32m1(vx2, vsumsq, vl);
+        vacc_sumsq = __riscv_vfadd_vv_f32m4_tu(vacc_sumsq, vacc_sumsq, vx2, vl);
         i += vl;
     }
 
-    float mean_val = __riscv_vfmv_f_s_f32m1_f32(vsum) / static_cast<float>(n);
-    float ms_val = __riscv_vfmv_f_s_f32m1_f32(vsumsq);
+    vfloat32m1_t vzero = __riscv_vfmv_v_f_f32m1(0.0f, __riscv_vsetvl_e32m1(1));
+    float mean_val = __riscv_vfmv_f_s_f32m1_f32(
+                         __riscv_vfredusum_vs_f32m4_f32m1(vacc_sum, vzero, maxvl)
+                     ) /
+                     static_cast<float>(n);
+    float ms_val = __riscv_vfmv_f_s_f32m1_f32(
+        __riscv_vfredusum_vs_f32m4_f32m1(vacc_sumsq, vzero, maxvl)
+    );
     float denom;
     if (Simplified) {
         denom = sqrtf(ms_val / static_cast<float>(n) + Epsilon);

--- a/onnxruntime/core/mlas/lib/riscv64/layernorm_kernel_rvv.cpp
+++ b/onnxruntime/core/mlas/lib/riscv64/layernorm_kernel_rvv.cpp
@@ -1,0 +1,98 @@
+/*++
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the MIT License.
+
+Module Name:
+
+    layernorm_kernel_rvv.cpp
+
+Abstract:
+
+    This module implements LayerNorm/RMSNorm kernels using RISC-V Vector
+    Extension (RVV). Processes one normalization row at a time.
+
+--*/
+
+#include "mlasi.h"
+
+#if defined(MLAS_USE_RVV)
+
+#include <riscv_vector.h>
+
+#include <cmath>
+
+void MLASCALL
+MlasLayerNormKernelRvv(
+    const float* Input,
+    const float* Scale,
+    const float* Bias,
+    float* Output,
+    float* MeanOut,
+    float* InvStdDevOut,
+    size_t NormSize,
+    float Epsilon,
+    bool Simplified
+)
+{
+    const size_t n = NormSize;
+
+    vfloat32m1_t vsum = __riscv_vfmv_v_f_f32m1(0.0f, __riscv_vsetvl_e32m1(1));
+    vfloat32m1_t vsumsq = __riscv_vfmv_v_f_f32m1(0.0f, __riscv_vsetvl_e32m1(1));
+
+    size_t i = 0;
+    while (i < n) {
+        size_t vl = __riscv_vsetvl_e32m4(n - i);
+        vfloat32m4_t vx = __riscv_vle32_v_f32m4(Input + i, vl);
+        vsum = __riscv_vfredusum_vs_f32m4_f32m1(vx, vsum, vl);
+        vfloat32m4_t vx2 = __riscv_vfmul_vv_f32m4(vx, vx, vl);
+        vsumsq = __riscv_vfredusum_vs_f32m4_f32m1(vx2, vsumsq, vl);
+        i += vl;
+    }
+
+    float mean_val = __riscv_vfmv_f_s_f32m1_f32(vsum) / static_cast<float>(n);
+    float ms_val = __riscv_vfmv_f_s_f32m1_f32(vsumsq);
+    float denom;
+    if (Simplified) {
+        denom = sqrtf(ms_val / static_cast<float>(n) + Epsilon);
+    } else {
+        denom = sqrtf(ms_val / static_cast<float>(n) - mean_val * mean_val + Epsilon);
+    }
+    float inv_denom = 1.0f / denom;
+
+    i = 0;
+    while (i < n) {
+        size_t vl = __riscv_vsetvl_e32m4(n - i);
+        vfloat32m4_t vx = __riscv_vle32_v_f32m4(Input + i, vl);
+        vfloat32m4_t vs = __riscv_vle32_v_f32m4(Scale + i, vl);
+
+        if (Simplified) {
+            vfloat32m4_t vy = __riscv_vfmul_vf_f32m4(vx, inv_denom, vl);
+            vy = __riscv_vfmul_vv_f32m4(vy, vs, vl);
+            __riscv_vse32_v_f32m4(Output + i, vy, vl);
+        } else if (Bias == nullptr) {
+            vfloat32m4_t vy = __riscv_vfsub_vf_f32m4(vx, mean_val, vl);
+            vy = __riscv_vfmul_vf_f32m4(vy, inv_denom, vl);
+            vy = __riscv_vfmul_vv_f32m4(vy, vs, vl);
+            __riscv_vse32_v_f32m4(Output + i, vy, vl);
+        } else {
+            vfloat32m4_t vb = __riscv_vle32_v_f32m4(Bias + i, vl);
+            vfloat32m4_t vy = __riscv_vfsub_vf_f32m4(vx, mean_val, vl);
+            vy = __riscv_vfmul_vf_f32m4(vy, inv_denom, vl);
+            vy = __riscv_vfmadd_vv_f32m4(vy, vs, vb, vl);
+            __riscv_vse32_v_f32m4(Output + i, vy, vl);
+        }
+
+        i += vl;
+    }
+
+    if (MeanOut != nullptr) {
+        *MeanOut = mean_val;
+    }
+    if (InvStdDevOut != nullptr) {
+        *InvStdDevOut = inv_denom;
+    }
+}
+
+#endif  // MLAS_USE_RVV

--- a/onnxruntime/core/mlas/lib/riscv64/rotary_embedding_kernel_rvv.cpp
+++ b/onnxruntime/core/mlas/lib/riscv64/rotary_embedding_kernel_rvv.cpp
@@ -1,0 +1,113 @@
+/*++
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the MIT License.
+
+Module Name:
+
+    rotary_embedding_kernel_rvv.cpp
+
+Abstract:
+
+    This module implements rotary embedding kernels for RISC-V Vector
+    Extension (RVV).
+
+    For the non-interleaved case:
+      output[i]            = input[i]            * cos[i] - input[i + half] * sin[i]
+      output[i + half]     = input[i + half]     * cos[i] + input[i]        * sin[i]
+
+    For the interleaved case:
+      output[2i]   = input[2i]   * cos[i] - input[2i+1] * sin[i]
+      output[2i+1] = input[2i+1] * cos[i] + input[2i]   * sin[i]
+
+--*/
+
+#include <cassert>
+
+#include "rotary_embedding.h"
+
+#if defined(MLAS_USE_RVV)
+
+#include <riscv_vector.h>
+
+namespace rope_rvv
+{
+
+void
+RopeKernel_Fp32(
+    const float* input,
+    const float* sin_data,
+    const float* cos_data,
+    size_t dim,
+    bool interleaved,
+    float* output
+)
+{
+    assert(dim % 2 == 0);
+    const size_t half_dim = dim / 2;
+
+    if (!interleaved) {
+        size_t i = 0;
+        while (i < half_dim) {
+            size_t vl = __riscv_vsetvl_e32m4(half_dim - i);
+
+            vfloat32m4_t vc = __riscv_vle32_v_f32m4(cos_data + i, vl);
+            vfloat32m4_t vs = __riscv_vle32_v_f32m4(sin_data + i, vl);
+            vfloat32m4_t v0 = __riscv_vle32_v_f32m4(input + i, vl);
+            vfloat32m4_t v1 = __riscv_vle32_v_f32m4(input + i + half_dim, vl);
+
+            // output[i] = input[i] * cos - input[i+half] * sin
+            vfloat32m4_t r0 = __riscv_vfmul_vv_f32m4(v0, vc, vl);
+            r0 = __riscv_vfnmsac_vv_f32m4(r0, vs, v1, vl);
+
+            // output[i+half] = input[i+half] * cos + input[i] * sin
+            vfloat32m4_t r1 = __riscv_vfmul_vv_f32m4(v1, vc, vl);
+            r1 = __riscv_vfmacc_vv_f32m4(r1, vs, v0, vl);
+
+            __riscv_vse32_v_f32m4(output + i, r0, vl);
+            __riscv_vse32_v_f32m4(output + i + half_dim, r1, vl);
+
+            i += vl;
+        }
+    } else {
+        size_t i = 0;
+        while (i < half_dim) {
+            size_t vl = __riscv_vsetvl_e32m4(half_dim - i);
+
+            vfloat32m4_t vc = __riscv_vle32_v_f32m4(cos_data + i, vl);
+            vfloat32m4_t vs = __riscv_vle32_v_f32m4(sin_data + i, vl);
+
+            // Deinterleave: load pairs [even, odd, even, odd, ...]
+            // Use strided loads: even elements at stride 2
+            const float* base = input + 2 * i;
+            vfloat32m4_t v_even = __riscv_vlse32_v_f32m4(base, 8, vl);
+            vfloat32m4_t v_odd = __riscv_vlse32_v_f32m4(base + 1, 8, vl);
+
+            // output[2i]   = even * cos - odd * sin
+            vfloat32m4_t r_even = __riscv_vfmul_vv_f32m4(v_even, vc, vl);
+            r_even = __riscv_vfnmsac_vv_f32m4(r_even, vs, v_odd, vl);
+
+            // output[2i+1] = odd * cos + even * sin
+            vfloat32m4_t r_odd = __riscv_vfmul_vv_f32m4(v_odd, vc, vl);
+            r_odd = __riscv_vfmacc_vv_f32m4(r_odd, vs, v_even, vl);
+
+            // Store interleaved
+            float* out_base = output + 2 * i;
+            __riscv_vsse32_v_f32m4(out_base, 8, r_even, vl);
+            __riscv_vsse32_v_f32m4(out_base + 1, 8, r_odd, vl);
+
+            i += vl;
+        }
+    }
+}
+
+}  // namespace rope_rvv
+
+const MLAS_ROPE_DISPATCH MlasRopeDispatchRvv = []() {
+    MLAS_ROPE_DISPATCH d;
+    d.SRope = rope_rvv::RopeKernel_Fp32;
+    return d;
+}();
+
+#endif  // MLAS_USE_RVV

--- a/onnxruntime/core/mlas/lib/riscv64/rotary_embedding_kernel_rvv.cpp
+++ b/onnxruntime/core/mlas/lib/riscv64/rotary_embedding_kernel_rvv.cpp
@@ -78,11 +78,9 @@ RopeKernel_Fp32(
             vfloat32m4_t vc = __riscv_vle32_v_f32m4(cos_data + i, vl);
             vfloat32m4_t vs = __riscv_vle32_v_f32m4(sin_data + i, vl);
 
-            // Deinterleave: load pairs [even, odd, even, odd, ...]
-            // Use strided loads: even elements at stride 2
-            const float* base = input + 2 * i;
-            vfloat32m4_t v_even = __riscv_vlse32_v_f32m4(base, 8, vl);
-            vfloat32m4_t v_odd = __riscv_vlse32_v_f32m4(base + 1, 8, vl);
+            vfloat32m4x2_t seg = __riscv_vlseg2e32_v_f32m4x2(input + 2 * i, vl);
+            vfloat32m4_t v_even = __riscv_vget_v_f32m4x2_f32m4(seg, 0);
+            vfloat32m4_t v_odd = __riscv_vget_v_f32m4x2_f32m4(seg, 1);
 
             // output[2i]   = even * cos - odd * sin
             vfloat32m4_t r_even = __riscv_vfmul_vv_f32m4(v_even, vc, vl);
@@ -92,10 +90,8 @@ RopeKernel_Fp32(
             vfloat32m4_t r_odd = __riscv_vfmul_vv_f32m4(v_odd, vc, vl);
             r_odd = __riscv_vfmacc_vv_f32m4(r_odd, vs, v_even, vl);
 
-            // Store interleaved
-            float* out_base = output + 2 * i;
-            __riscv_vsse32_v_f32m4(out_base, 8, r_even, vl);
-            __riscv_vsse32_v_f32m4(out_base + 1, 8, r_odd, vl);
+            vfloat32m4x2_t out = __riscv_vcreate_v_f32m4x2(r_even, r_odd);
+            __riscv_vsseg2e32_v_f32m4x2(output + 2 * i, out, vl);
 
             i += vl;
         }
@@ -104,10 +100,9 @@ RopeKernel_Fp32(
 
 }  // namespace rope_rvv
 
-const MLAS_ROPE_DISPATCH MlasRopeDispatchRvv = []() {
-    MLAS_ROPE_DISPATCH d;
-    d.SRope = rope_rvv::RopeKernel_Fp32;
-    return d;
-}();
+const MLAS_ROPE_DISPATCH MlasRopeDispatchRvv = {
+    rope_rvv::RopeKernel_Fp32,
+    nullptr,
+};
 
 #endif  // MLAS_USE_RVV

--- a/onnxruntime/core/mlas/lib/riscv64/sconv_depthwise_kernel_rvv.cpp
+++ b/onnxruntime/core/mlas/lib/riscv64/sconv_depthwise_kernel_rvv.cpp
@@ -142,6 +142,7 @@ MlasConv2dSingleChannel_CHW_Kernel3x3_Pad01_Dilation1(
     assert(pad_bottom <= 1);
     assert(pad_left <= 1);
     assert(pad_right <= 1);
+    MLAS_UNREFERENCED_PARAMETER(pad_bottom);
 
     const float beta = Parameters->Beta;
     const bool accumulate_output = beta != 0.0f;

--- a/onnxruntime/core/providers/cpu/nn/layer_norm_impl.cc
+++ b/onnxruntime/core/providers/cpu/nn/layer_norm_impl.cc
@@ -38,6 +38,20 @@ void ComputeJob(
   ORT_UNUSED_PARAMETER(bias_float_ptr);   // only used in MLFloat16 overload
   ORT_UNUSED_PARAMETER(alloc);
 
+  int64_t i = LAYER_NORM_SCALE_BIAS_OFFSET(broadcast_param, task_idx, norm_size);
+
+  if constexpr (std::is_same_v<T, float>) {
+    if (MlasLayerNormF32(
+            X_data + task_idx * norm_size, scale_data + i,
+            (simplified || !bias_data) ? nullptr : bias_data + i,
+            Y_data + task_idx * norm_size,
+            mean_data ? &mean_data[task_idx] : nullptr,
+            inv_std_dev_data ? &inv_std_dev_data[task_idx] : nullptr,
+            static_cast<size_t>(norm_size), epsilon, simplified)) {
+      return;
+    }
+  }
+
   const T* p_input = X_data + task_idx * norm_size;
   T* p_output = Y_data + task_idx * norm_size;
 
@@ -56,9 +70,6 @@ void ComputeJob(
   } else {
     mean_square = sqrt(mean_square / norm_size - mean * mean + epsilon);
   }
-
-  // Compute the offset of gamma and beta to support broadcasting.
-  int64_t i = LAYER_NORM_SCALE_BIAS_OFFSET(broadcast_param, task_idx, norm_size);
 
   for (int64_t h = 0; h < norm_size; h++, i++) {
     if (simplified) {

--- a/onnxruntime/test/mlas/bench/riscv64/cast_rvv_bench.cpp
+++ b/onnxruntime/test/mlas/bench/riscv64/cast_rvv_bench.cpp
@@ -1,0 +1,165 @@
+/*++
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the MIT License.
+
+Module Name:
+
+    cast_rvv_bench.cpp
+
+Abstract:
+
+    Correctness and performance comparison of FP16<->FP32 cast kernels.
+
+    Scalar path: ORT's internal fallback in cast.cpp
+      (MLAS_Half2Float / MLAS_Float2Half loop when CastKernel == nullptr)
+    Dispatch path: MlasConvertHalfToFloatBuffer / MlasConvertFloatToHalfBuffer
+      (dispatches to registered RVV kernel via platform.CastF16ToF32Kernel)
+
+--*/
+
+#include "mlas.h"
+#include "mlas_float16.h"
+
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <iomanip>
+#include <iostream>
+#include <string_view>
+#include <vector>
+
+namespace {
+
+struct Options {
+  size_t count = 1024 * 64;
+  size_t iters = 200;
+  size_t warmup = 20;
+};
+
+Options ParseArgs(int argc, char** argv) {
+  Options options;
+  for (int i = 1; i < argc; ++i) {
+    std::string_view arg(argv[i]);
+    const auto split = arg.find('=');
+    if (split == std::string_view::npos) continue;
+    const auto key = arg.substr(0, split);
+    const auto value = arg.substr(split + 1);
+    if (key == "--count")
+      options.count = std::strtoull(value.data(), nullptr, 10);
+    else if (key == "--iters")
+      options.iters = std::strtoull(value.data(), nullptr, 10);
+    else if (key == "--warmup")
+      options.warmup = std::strtoull(value.data(), nullptr, 10);
+  }
+  return options;
+}
+
+float MakeValue(size_t index) {
+  uint32_t x = static_cast<uint32_t>(index * 747796405u + 2891336453u);
+  x ^= x >> 16;
+  x *= 2246822519u;
+  x ^= x >> 13;
+  return (static_cast<float>(x % 2048u) / 1024.0f) - 1.0f;
+}
+
+template <typename Fn>
+double TimeLoop(size_t iterations, Fn&& fn) {
+  const auto begin = std::chrono::steady_clock::now();
+  for (size_t i = 0; i < iterations; ++i) {
+    fn();
+  }
+  const auto end = std::chrono::steady_clock::now();
+  return std::chrono::duration<double, std::milli>(end - begin).count();
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  const Options opts = ParseArgs(argc, argv);
+  const size_t N = opts.count;
+
+  std::cout << "=== FP16<->FP32 Cast: RVV Dispatch vs ORT Scalar Fallback ===\n"
+            << "  count=" << N << " iters=" << opts.iters << " warmup=" << opts.warmup << "\n\n";
+
+  std::vector<float> fp32_src(N);
+  std::vector<_mlas_fp16_> fp16_src(N);
+  for (size_t i = 0; i < N; ++i) {
+    fp32_src[i] = MakeValue(i);
+    fp16_src[i] = MLAS_Float2Half(fp32_src[i]);
+  }
+
+  std::vector<float> f16_to_f32_fallback(N), f16_to_f32_dispatch(N);
+  std::vector<_mlas_fp16_> f32_to_f16_fallback(N), f32_to_f16_dispatch(N);
+
+  // ORT scalar fallback: same as cast.cpp when CastF16ToF32Kernel == nullptr
+  //   for (i) Destination[i] = Source[i].ToFloat();  // calls MLAS_Half2Float
+  auto fallback_h2f = [&]() {
+    for (size_t i = 0; i < N; ++i)
+      f16_to_f32_fallback[i] = MLAS_Half2Float(fp16_src[i]);
+  };
+  auto fallback_f2h = [&]() {
+    for (size_t i = 0; i < N; ++i)
+      f32_to_f16_fallback[i] = MLAS_Float2Half(fp32_src[i]);
+  };
+
+  // ORT dispatch path: MlasConvertHalfToFloatBuffer (uses registered RVV kernel)
+  auto dispatch_h2f = [&]() {
+    MlasConvertHalfToFloatBuffer(
+        reinterpret_cast<const MLAS_FP16*>(fp16_src.data()),
+        f16_to_f32_dispatch.data(), N);
+  };
+  auto dispatch_f2h = [&]() {
+    MlasConvertFloatToHalfBuffer(
+        fp32_src.data(),
+        reinterpret_cast<MLAS_FP16*>(f32_to_f16_dispatch.data()), N);
+  };
+
+  // --- Correctness ---
+  fallback_h2f();
+  dispatch_h2f();
+  fallback_f2h();
+  dispatch_f2h();
+
+  size_t h2f_mismatches = 0;
+  for (size_t i = 0; i < N; ++i) {
+    if (f16_to_f32_fallback[i] != f16_to_f32_dispatch[i]) h2f_mismatches++;
+  }
+  size_t f2h_mismatches = 0;
+  for (size_t i = 0; i < N; ++i) {
+    if (f32_to_f16_fallback[i] != f32_to_f16_dispatch[i]) f2h_mismatches++;
+  }
+
+  std::cout << "Correctness:\n"
+            << "  F16->F32: mismatches=" << h2f_mismatches << "/" << N
+            << (h2f_mismatches == 0 ? " PASS" : " FAIL") << "\n"
+            << "  F32->F16: mismatches=" << f2h_mismatches << "/" << N
+            << (f2h_mismatches == 0 ? " PASS" : " FAIL") << "\n";
+
+  // --- Performance ---
+  for (size_t i = 0; i < opts.warmup; ++i) {
+    fallback_h2f();
+    dispatch_h2f();
+    fallback_f2h();
+    dispatch_f2h();
+  }
+
+  double s_h2f = TimeLoop(opts.iters, fallback_h2f) / opts.iters;
+  double d_h2f = TimeLoop(opts.iters, dispatch_h2f) / opts.iters;
+  double s_f2h = TimeLoop(opts.iters, fallback_f2h) / opts.iters;
+  double d_f2h = TimeLoop(opts.iters, dispatch_f2h) / opts.iters;
+
+  std::cout << std::fixed << std::setprecision(3)
+            << "\nF16->F32 (" << N << " elements):\n"
+            << "  ORT Fallback: " << s_h2f << " ms\n"
+            << "  ORT Dispatch: " << d_h2f << " ms\n"
+            << "  Speedup:      " << s_h2f / d_h2f << "x\n"
+            << "\nF32->F16 (" << N << " elements):\n"
+            << "  ORT Fallback: " << s_f2h << " ms\n"
+            << "  ORT Dispatch: " << d_f2h << " ms\n"
+            << "  Speedup:      " << s_f2h / d_f2h << "x\n";
+
+  return (h2f_mismatches + f2h_mismatches > 0) ? 1 : 0;
+}

--- a/onnxruntime/test/mlas/bench/riscv64/halfgemm_rvv_bench.cpp
+++ b/onnxruntime/test/mlas/bench/riscv64/halfgemm_rvv_bench.cpp
@@ -1,0 +1,253 @@
+/*++
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the MIT License.
+
+Module Name:
+
+    halfgemm_rvv_bench.cpp
+
+Abstract:
+
+    Correctness and performance comparison of RVV-accelerated FP16 GEMM
+    against ORT's built-in scalar FP16 GEMM dispatch (MlasHalfGemmDispatchDefault).
+
+    Both paths use the same MLAS HalfGemm dispatch interface with FP16 I/O.
+
+    Usage:
+      ./onnxruntime_mlas_halfgemm_rvv_bench [--m=N] [--n=N] [--k=N]
+          [--iters=N] [--warmup=N] [--bias=0|1]
+
+--*/
+
+#include "mlas.h"
+#include "mlas_float16.h"
+#include "halfgemm.h"
+
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <iomanip>
+#include <iostream>
+#include <string_view>
+#include <vector>
+
+namespace {
+
+struct Options {
+  size_t m = 64;
+  size_t n = 768;
+  size_t k = 768;
+  size_t iters = 20;
+  size_t warmup = 3;
+  bool use_bias = false;
+};
+
+void PrintUsage(const char* argv0) {
+  std::cout
+      << "Usage: " << argv0
+      << " [--m=N] [--n=N] [--k=N] [--iters=N] [--warmup=N] [--bias=0|1]\n";
+}
+
+bool ParseBool(std::string_view value) {
+  return value == "1" || value == "true" || value == "on" || value == "yes";
+}
+
+Options ParseArgs(int argc, char** argv) {
+  Options options;
+  for (int i = 1; i < argc; ++i) {
+    std::string_view arg(argv[i]);
+    if (arg == "--help" || arg == "-h") {
+      PrintUsage(argv[0]);
+      std::exit(0);
+    }
+    const auto split = arg.find('=');
+    if (split == std::string_view::npos || split == 0 || split + 1 >= arg.size()) {
+      continue;
+    }
+    const std::string_view key = arg.substr(0, split);
+    const std::string_view value = arg.substr(split + 1);
+    if (key == "--m")
+      options.m = std::strtoull(value.data(), nullptr, 10);
+    else if (key == "--n")
+      options.n = std::strtoull(value.data(), nullptr, 10);
+    else if (key == "--k")
+      options.k = std::strtoull(value.data(), nullptr, 10);
+    else if (key == "--iters")
+      options.iters = std::strtoull(value.data(), nullptr, 10);
+    else if (key == "--warmup")
+      options.warmup = std::strtoull(value.data(), nullptr, 10);
+    else if (key == "--bias")
+      options.use_bias = ParseBool(value);
+  }
+  return options;
+}
+
+float MakeValue(size_t index) {
+  uint32_t x = static_cast<uint32_t>(index * 747796405u + 2891336453u);
+  x ^= x >> 16;
+  x *= 2246822519u;
+  x ^= x >> 13;
+  const uint32_t bucket = x % 2048u;
+  return (static_cast<float>(bucket) / 1024.0f) - 1.0f;
+}
+
+template <typename Fn>
+double TimeLoop(size_t iterations, Fn&& fn) {
+  const auto begin = std::chrono::steady_clock::now();
+  for (size_t i = 0; i < iterations; ++i) {
+    fn();
+  }
+  const auto end = std::chrono::steady_clock::now();
+  return std::chrono::duration<double, std::milli>(end - begin).count();
+}
+
+void RunDispatch(
+    const MLAS_HALFGEMM_DISPATCH& dispatch,
+    size_t M, size_t N, size_t K,
+    const MLAS_HALF_GEMM_DATA_PARAMS* data) {
+  dispatch.Operation(N, K, data, 0, M, 0, N);
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  const Options options = ParseArgs(argc, argv);
+
+  if (options.m == 0 || options.n == 0 || options.k == 0 || options.iters == 0) {
+    std::cerr << "m, n, k, and iters must be > 0\n";
+    return 1;
+  }
+
+  const bool fp16_supported = MlasFp16AccelerationSupported();
+
+  std::cout << "=== FP16 GEMM: RVV vs ORT Scalar Dispatch ===\n"
+            << "  M=" << options.m << " N=" << options.n << " K=" << options.k
+            << " bias=" << (options.use_bias ? "yes" : "no") << "\n"
+            << "  iters=" << options.iters << " warmup=" << options.warmup << "\n"
+            << "  FP16 acceleration: " << (fp16_supported ? "YES (RVV)" : "NO") << "\n\n";
+
+  const size_t a_size = options.m * options.k;
+  const size_t b_size = options.k * options.n;
+  const size_t c_size = options.m * options.n;
+
+  std::vector<_mlas_fp16_> a_fp16(a_size);
+  std::vector<_mlas_fp16_> b_fp16(b_size);
+  std::vector<_mlas_fp16_> bias_fp16(options.n);
+  std::vector<_mlas_fp16_> c_rvv(c_size);
+  std::vector<_mlas_fp16_> c_scalar(c_size);
+
+  for (size_t i = 0; i < a_size; ++i) {
+    a_fp16[i] = MLAS_Float2Half(MakeValue(i) * 0.1f);
+  }
+  for (size_t i = 0; i < b_size; ++i) {
+    b_fp16[i] = MLAS_Float2Half(MakeValue(i + a_size) * 0.1f);
+  }
+  if (options.use_bias) {
+    for (size_t i = 0; i < options.n; ++i) {
+      bias_fp16[i] = MLAS_Float2Half(MakeValue(i + a_size + b_size) * 0.01f);
+    }
+  }
+
+  MLAS_HALF_GEMM_DATA_PARAMS params_scalar;
+  params_scalar.A = a_fp16.data();
+  params_scalar.lda = options.k;
+  params_scalar.B = b_fp16.data();
+  params_scalar.ldb = options.n;
+  params_scalar.C = reinterpret_cast<MLAS_FP16*>(c_scalar.data());
+  params_scalar.ldc = options.n;
+  params_scalar.Bias = options.use_bias
+                           ? reinterpret_cast<const MLAS_FP16*>(bias_fp16.data())
+                           : nullptr;
+  params_scalar.AIsfp32 = false;
+  params_scalar.BIsfp32 = false;
+  params_scalar.OutputProcessor = nullptr;
+
+  MLAS_HALF_GEMM_DATA_PARAMS params_rvv = params_scalar;
+  params_rvv.C = reinterpret_cast<MLAS_FP16*>(c_rvv.data());
+
+  // --- Run both dispatches ---
+  RunDispatch(MlasHalfGemmDispatchDefault, options.m, options.n, options.k, &params_scalar);
+
+#if defined(MLAS_TARGET_RISCV64) && defined(MLAS_USE_RVV_ZVFH)
+  RunDispatch(MlasHalfGemmDispatchRvv, options.m, options.n, options.k, &params_rvv);
+#else
+  RunDispatch(MlasHalfGemmDispatchDefault, options.m, options.n, options.k, &params_rvv);
+  std::cout << "  (RVV dispatch not available, comparing scalar vs scalar)\n\n";
+#endif
+
+  // --- Correctness: RVV vs ORT Scalar ---
+  double max_abs_err = 0.0;
+  double max_rel_err = 0.0;
+  size_t error_count = 0;
+
+  for (size_t i = 0; i < c_size; ++i) {
+    float ref = MLAS_Half2Float(c_scalar[i]);
+    float got = MLAS_Half2Float(c_rvv[i]);
+    double abs_err = std::abs(ref - got);
+    double rel_err = (std::abs(ref) > 1e-6) ? abs_err / std::abs(ref) : abs_err;
+
+    if (abs_err > max_abs_err) max_abs_err = abs_err;
+    if (rel_err > max_rel_err) max_rel_err = rel_err;
+
+    if (rel_err > 0.10 && abs_err > 0.005) {
+      if (error_count < 10) {
+        std::cerr << "  MISMATCH [" << i / options.n << "," << i % options.n
+                  << "]: scalar=" << ref << " rvv=" << got
+                  << " abs=" << abs_err << " rel=" << rel_err << "\n";
+      }
+      error_count++;
+    }
+  }
+
+  std::cout << "Correctness (RVV vs ORT Scalar):\n"
+            << "  max abs error: " << max_abs_err << "\n"
+            << "  max rel error: " << max_rel_err << "\n"
+            << "  mismatches (>10% rel && >0.005 abs): " << error_count
+            << " / " << c_size << "\n";
+
+  if (error_count > 0) {
+    std::cout << "  STATUS: FAIL\n\n";
+  } else {
+    std::cout << "  STATUS: PASS\n\n";
+  }
+
+  // --- Performance ---
+  auto run_scalar_fn = [&]() {
+    RunDispatch(MlasHalfGemmDispatchDefault, options.m, options.n, options.k, &params_scalar);
+  };
+
+  auto run_rvv_fn = [&]() {
+#if defined(MLAS_TARGET_RISCV64) && defined(MLAS_USE_RVV_ZVFH)
+    RunDispatch(MlasHalfGemmDispatchRvv, options.m, options.n, options.k, &params_rvv);
+#else
+    RunDispatch(MlasHalfGemmDispatchDefault, options.m, options.n, options.k, &params_rvv);
+#endif
+  };
+
+  for (size_t i = 0; i < options.warmup; ++i) {
+    run_scalar_fn();
+    run_rvv_fn();
+  }
+
+  const double scalar_ms = TimeLoop(options.iters, run_scalar_fn);
+  const double scalar_avg = scalar_ms / static_cast<double>(options.iters);
+
+  const double rvv_ms = TimeLoop(options.iters, run_rvv_fn);
+  const double rvv_avg = rvv_ms / static_cast<double>(options.iters);
+
+  const double flops = 2.0 * options.m * options.n * options.k;
+  const double scalar_gflops = flops / (scalar_avg * 1e6);
+  const double rvv_gflops = flops / (rvv_avg * 1e6);
+  const double speedup = scalar_avg / rvv_avg;
+
+  std::cout << std::fixed << std::setprecision(3)
+            << "Performance:\n"
+            << "  ORT Scalar:  " << scalar_avg << " ms  (" << scalar_gflops << " GFLOPS)\n"
+            << "  RVV:         " << rvv_avg << " ms  (" << rvv_gflops << " GFLOPS)\n"
+            << "  Speedup:     " << speedup << "x\n";
+
+  return (error_count > 0) ? 1 : 0;
+}

--- a/onnxruntime/test/mlas/bench/riscv64/rmsnorm_rvv_bench.cpp
+++ b/onnxruntime/test/mlas/bench/riscv64/rmsnorm_rvv_bench.cpp
@@ -1,0 +1,202 @@
+/*++
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the MIT License.
+
+Module Name:
+
+    rmsnorm_rvv_bench.cpp
+
+Abstract:
+
+    Correctness and performance comparison of RMSNorm (SimplifiedLayerNorm).
+
+    Scalar path: ORT's ComputeJob<float> with simplified=true
+      (anonymous namespace in layer_norm_impl.cc, reproduced here verbatim)
+    RVV path: RVV vectorized implementation
+      (same as the #if __riscv_vector path in layer_norm_impl.cc)
+
+    Both paths are identical to ORT's internal code.
+
+--*/
+
+#include "mlas.h"
+
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <iomanip>
+#include <iostream>
+#include <string_view>
+#include <vector>
+
+#if defined(__riscv) && defined(__riscv_vector)
+#include <riscv_vector.h>
+#endif
+
+namespace {
+
+struct Options {
+  size_t hidden = 1024;
+  size_t iters = 500;
+  size_t warmup = 50;
+};
+
+Options ParseArgs(int argc, char** argv) {
+  Options options;
+  for (int i = 1; i < argc; ++i) {
+    std::string_view arg(argv[i]);
+    const auto split = arg.find('=');
+    if (split == std::string_view::npos) continue;
+    const auto key = arg.substr(0, split);
+    const auto value = arg.substr(split + 1);
+    if (key == "--hidden")
+      options.hidden = std::strtoull(value.data(), nullptr, 10);
+    else if (key == "--iters")
+      options.iters = std::strtoull(value.data(), nullptr, 10);
+    else if (key == "--warmup")
+      options.warmup = std::strtoull(value.data(), nullptr, 10);
+  }
+  return options;
+}
+
+float MakeValue(size_t index) {
+  uint32_t x = static_cast<uint32_t>(index * 747796405u + 2891336453u);
+  x ^= x >> 16;
+  x *= 2246822519u;
+  x ^= x >> 13;
+  return (static_cast<float>(x % 2048u) / 1024.0f) - 1.0f;
+}
+
+template <typename Fn>
+double TimeLoop(size_t iterations, Fn&& fn) {
+  const auto begin = std::chrono::steady_clock::now();
+  for (size_t i = 0; i < iterations; ++i) {
+    fn();
+  }
+  const auto end = std::chrono::steady_clock::now();
+  return std::chrono::duration<double, std::milli>(end - begin).count();
+}
+
+//
+// ORT scalar path: verbatim from layer_norm_impl.cc ComputeJob<float>
+// with simplified=true (RMSNorm).
+//
+void OrtRmsNormScalar(
+    const float* input,
+    const float* scale,
+    size_t norm_size,
+    float epsilon,
+    float* output) {
+  float mean_square = 0.0f;
+  for (size_t h = 0; h < norm_size; h++) {
+    output[h] = input[h];
+    mean_square += input[h] * input[h];
+  }
+  mean_square = sqrtf(mean_square / static_cast<float>(norm_size) + epsilon);
+  for (size_t h = 0; h < norm_size; h++) {
+    output[h] = output[h] / mean_square * scale[h];
+  }
+}
+
+//
+// RVV path: verbatim from layer_norm_impl.cc #if __riscv_vector block
+// with simplified=true (RMSNorm).
+//
+void OrtRmsNormRvv(
+    const float* input,
+    const float* scale,
+    size_t norm_size,
+    float epsilon,
+    float* output) {
+#if defined(__riscv) && defined(__riscv_vector)
+  vfloat32m1_t vsumsq = __riscv_vfmv_v_f_f32m1(0.0f, __riscv_vsetvl_e32m1(1));
+  size_t i = 0;
+  while (i < norm_size) {
+    size_t vl = __riscv_vsetvl_e32m4(norm_size - i);
+    vfloat32m4_t vx = __riscv_vle32_v_f32m4(input + i, vl);
+    vfloat32m4_t vx2 = __riscv_vfmul_vv_f32m4(vx, vx, vl);
+    vsumsq = __riscv_vfredusum_vs_f32m4_f32m1(vx2, vsumsq, vl);
+    i += vl;
+  }
+  float ms = __riscv_vfmv_f_s_f32m1_f32(vsumsq);
+  float inv_denom = 1.0f / sqrtf(ms / static_cast<float>(norm_size) + epsilon);
+
+  i = 0;
+  while (i < norm_size) {
+    size_t vl = __riscv_vsetvl_e32m4(norm_size - i);
+    vfloat32m4_t vx = __riscv_vle32_v_f32m4(input + i, vl);
+    vfloat32m4_t vs = __riscv_vle32_v_f32m4(scale + i, vl);
+    vfloat32m4_t vy = __riscv_vfmul_vf_f32m4(vx, inv_denom, vl);
+    vy = __riscv_vfmul_vv_f32m4(vy, vs, vl);
+    __riscv_vse32_v_f32m4(output + i, vy, vl);
+    i += vl;
+  }
+#else
+  OrtRmsNormScalar(input, scale, norm_size, epsilon, output);
+#endif
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  const Options opts = ParseArgs(argc, argv);
+  const size_t N = opts.hidden;
+  const float epsilon = 1e-6f;
+
+  std::cout << "=== RMSNorm: RVV vs ORT Scalar (from layer_norm_impl.cc) ===\n"
+            << "  hidden=" << N << " iters=" << opts.iters << " warmup=" << opts.warmup << "\n\n";
+
+  std::vector<float> input(N), scale(N);
+  std::vector<float> out_scalar(N), out_rvv(N);
+
+  for (size_t i = 0; i < N; i++) {
+    input[i] = MakeValue(i) * 0.1f;
+    scale[i] = 1.0f + MakeValue(i + N) * 0.01f;
+  }
+
+  // --- Correctness ---
+  OrtRmsNormScalar(input.data(), scale.data(), N, epsilon, out_scalar.data());
+  OrtRmsNormRvv(input.data(), scale.data(), N, epsilon, out_rvv.data());
+
+  double max_abs = 0.0, max_rel = 0.0;
+  size_t mismatches = 0;
+  for (size_t i = 0; i < N; i++) {
+    double abs_err = std::abs(out_scalar[i] - out_rvv[i]);
+    double rel_err = (std::abs(out_scalar[i]) > 1e-7) ? abs_err / std::abs(out_scalar[i]) : abs_err;
+    if (abs_err > max_abs) max_abs = abs_err;
+    if (rel_err > max_rel) max_rel = rel_err;
+    if (abs_err > 1e-5) mismatches++;
+  }
+
+  std::cout << "Correctness:\n"
+            << "  max_abs=" << max_abs << " max_rel=" << max_rel
+            << " mismatches=" << mismatches << "/" << N
+            << (mismatches == 0 ? " PASS" : " FAIL") << "\n";
+
+  // --- Performance ---
+  auto run_scalar = [&]() {
+    OrtRmsNormScalar(input.data(), scale.data(), N, epsilon, out_scalar.data());
+  };
+  auto run_rvv = [&]() {
+    OrtRmsNormRvv(input.data(), scale.data(), N, epsilon, out_rvv.data());
+  };
+
+  for (size_t i = 0; i < opts.warmup; i++) {
+    run_scalar();
+    run_rvv();
+  }
+
+  double scalar_ms = TimeLoop(opts.iters, run_scalar) / opts.iters;
+  double rvv_ms = TimeLoop(opts.iters, run_rvv) / opts.iters;
+
+  std::cout << std::fixed << std::setprecision(4)
+            << "\nPerformance:\n"
+            << "  ORT Scalar: " << scalar_ms * 1000 << " us\n"
+            << "  RVV:        " << rvv_ms * 1000 << " us\n"
+            << "  Speedup:    " << scalar_ms / rvv_ms << "x\n";
+
+  return (mismatches > 0) ? 1 : 0;
+}

--- a/onnxruntime/test/mlas/bench/riscv64/rmsnorm_rvv_bench.cpp
+++ b/onnxruntime/test/mlas/bench/riscv64/rmsnorm_rvv_bench.cpp
@@ -14,10 +14,7 @@ Abstract:
 
     Scalar path: ORT's ComputeJob<float> with simplified=true
       (anonymous namespace in layer_norm_impl.cc, reproduced here verbatim)
-    RVV path: RVV vectorized implementation
-      (same as the #if __riscv_vector path in layer_norm_impl.cc)
-
-    Both paths are identical to ORT's internal code.
+    MLAS path: MlasLayerNormF32 dispatch (uses RVV kernel when available)
 
 --*/
 
@@ -31,10 +28,6 @@ Abstract:
 #include <iostream>
 #include <string_view>
 #include <vector>
-
-#if defined(__riscv) && defined(__riscv_vector)
-#include <riscv_vector.h>
-#endif
 
 namespace {
 
@@ -101,42 +94,16 @@ void OrtRmsNormScalar(
   }
 }
 
-//
-// RVV path: verbatim from layer_norm_impl.cc #if __riscv_vector block
-// with simplified=true (RMSNorm).
-//
-void OrtRmsNormRvv(
+void OrtRmsNormMlas(
     const float* input,
     const float* scale,
     size_t norm_size,
     float epsilon,
     float* output) {
-#if defined(__riscv) && defined(__riscv_vector)
-  vfloat32m1_t vsumsq = __riscv_vfmv_v_f_f32m1(0.0f, __riscv_vsetvl_e32m1(1));
-  size_t i = 0;
-  while (i < norm_size) {
-    size_t vl = __riscv_vsetvl_e32m4(norm_size - i);
-    vfloat32m4_t vx = __riscv_vle32_v_f32m4(input + i, vl);
-    vfloat32m4_t vx2 = __riscv_vfmul_vv_f32m4(vx, vx, vl);
-    vsumsq = __riscv_vfredusum_vs_f32m4_f32m1(vx2, vsumsq, vl);
-    i += vl;
+  if (!MlasLayerNormF32(input, scale, nullptr, output, nullptr, nullptr,
+                        norm_size, epsilon, true)) {
+    OrtRmsNormScalar(input, scale, norm_size, epsilon, output);
   }
-  float ms = __riscv_vfmv_f_s_f32m1_f32(vsumsq);
-  float inv_denom = 1.0f / sqrtf(ms / static_cast<float>(norm_size) + epsilon);
-
-  i = 0;
-  while (i < norm_size) {
-    size_t vl = __riscv_vsetvl_e32m4(norm_size - i);
-    vfloat32m4_t vx = __riscv_vle32_v_f32m4(input + i, vl);
-    vfloat32m4_t vs = __riscv_vle32_v_f32m4(scale + i, vl);
-    vfloat32m4_t vy = __riscv_vfmul_vf_f32m4(vx, inv_denom, vl);
-    vy = __riscv_vfmul_vv_f32m4(vy, vs, vl);
-    __riscv_vse32_v_f32m4(output + i, vy, vl);
-    i += vl;
-  }
-#else
-  OrtRmsNormScalar(input, scale, norm_size, epsilon, output);
-#endif
 }
 
 }  // namespace
@@ -146,7 +113,7 @@ int main(int argc, char** argv) {
   const size_t N = opts.hidden;
   const float epsilon = 1e-6f;
 
-  std::cout << "=== RMSNorm: RVV vs ORT Scalar (from layer_norm_impl.cc) ===\n"
+  std::cout << "=== RMSNorm: MLAS Dispatch vs ORT Scalar ===\n"
             << "  hidden=" << N << " iters=" << opts.iters << " warmup=" << opts.warmup << "\n\n";
 
   std::vector<float> input(N), scale(N);
@@ -159,7 +126,7 @@ int main(int argc, char** argv) {
 
   // --- Correctness ---
   OrtRmsNormScalar(input.data(), scale.data(), N, epsilon, out_scalar.data());
-  OrtRmsNormRvv(input.data(), scale.data(), N, epsilon, out_rvv.data());
+  OrtRmsNormMlas(input.data(), scale.data(), N, epsilon, out_rvv.data());
 
   double max_abs = 0.0, max_rel = 0.0;
   size_t mismatches = 0;
@@ -181,7 +148,7 @@ int main(int argc, char** argv) {
     OrtRmsNormScalar(input.data(), scale.data(), N, epsilon, out_scalar.data());
   };
   auto run_rvv = [&]() {
-    OrtRmsNormRvv(input.data(), scale.data(), N, epsilon, out_rvv.data());
+    OrtRmsNormMlas(input.data(), scale.data(), N, epsilon, out_rvv.data());
   };
 
   for (size_t i = 0; i < opts.warmup; i++) {

--- a/onnxruntime/test/mlas/bench/riscv64/rope_rvv_bench.cpp
+++ b/onnxruntime/test/mlas/bench/riscv64/rope_rvv_bench.cpp
@@ -1,0 +1,152 @@
+/*++
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the MIT License.
+
+Module Name:
+
+    rope_rvv_bench.cpp
+
+Abstract:
+
+    Correctness and performance comparison of RotaryEmbedding.
+
+    Scalar path: MlasRotaryEmbedOneRow_FallBack (ORT's internal scalar fallback)
+    Dispatch path: MlasRotaryEmbedOneRow (dispatches to RVV kernel via platform)
+
+--*/
+
+#include "mlas.h"
+#include "mlas_float16.h"
+#include "rotary_embedding.h"
+
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <iomanip>
+#include <iostream>
+#include <string_view>
+#include <vector>
+
+namespace {
+
+struct Options {
+  size_t dim = 128;
+  size_t iters = 500;
+  size_t warmup = 50;
+};
+
+Options ParseArgs(int argc, char** argv) {
+  Options options;
+  for (int i = 1; i < argc; ++i) {
+    std::string_view arg(argv[i]);
+    const auto split = arg.find('=');
+    if (split == std::string_view::npos) continue;
+    const auto key = arg.substr(0, split);
+    const auto value = arg.substr(split + 1);
+    if (key == "--dim")
+      options.dim = std::strtoull(value.data(), nullptr, 10);
+    else if (key == "--iters")
+      options.iters = std::strtoull(value.data(), nullptr, 10);
+    else if (key == "--warmup")
+      options.warmup = std::strtoull(value.data(), nullptr, 10);
+  }
+  return options;
+}
+
+float MakeValue(size_t index) {
+  uint32_t x = static_cast<uint32_t>(index * 747796405u + 2891336453u);
+  x ^= x >> 16;
+  x *= 2246822519u;
+  x ^= x >> 13;
+  return (static_cast<float>(x % 2048u) / 1024.0f) - 1.0f;
+}
+
+template <typename Fn>
+double TimeLoop(size_t iterations, Fn&& fn) {
+  const auto begin = std::chrono::steady_clock::now();
+  for (size_t i = 0; i < iterations; ++i) {
+    fn();
+  }
+  const auto end = std::chrono::steady_clock::now();
+  return std::chrono::duration<double, std::milli>(end - begin).count();
+}
+
+void CompareResults(const float* ref, const float* got, size_t n) {
+  double max_abs = 0.0, max_rel = 0.0;
+  size_t mismatches = 0;
+  for (size_t i = 0; i < n; i++) {
+    double abs_err = std::abs(ref[i] - got[i]);
+    double rel_err = (std::abs(ref[i]) > 1e-7) ? abs_err / std::abs(ref[i]) : abs_err;
+    if (abs_err > max_abs) max_abs = abs_err;
+    if (rel_err > max_rel) max_rel = rel_err;
+    if (abs_err > 1e-5) mismatches++;
+  }
+  std::cout << "  max_abs=" << max_abs << " max_rel=" << max_rel
+            << " mismatches=" << mismatches << "/" << n
+            << (mismatches == 0 ? " PASS" : " FAIL") << "\n";
+}
+
+void BenchRoPE(const char* label, size_t dim, bool interleaved, size_t iters, size_t warmup) {
+  if (dim % 2 != 0) {
+    std::cerr << "Error: dim must be even, got " << dim << "\n";
+    return;
+  }
+  const size_t half = dim / 2;
+
+  std::vector<float> input(dim), sin_data(half), cos_data(half);
+  std::vector<float> out_fallback(dim), out_dispatch(dim);
+
+  for (size_t i = 0; i < dim; i++) input[i] = MakeValue(i);
+  for (size_t i = 0; i < half; i++) {
+    sin_data[i] = sinf(static_cast<float>(i) * 0.01f);
+    cos_data[i] = cosf(static_cast<float>(i) * 0.01f);
+  }
+
+  // ORT scalar fallback
+  MlasRotaryEmbedOneRow_FallBack<float>(
+      input.data(), sin_data.data(), cos_data.data(), dim, interleaved, out_fallback.data());
+  // ORT dispatch (→ RVV)
+  MlasRotaryEmbedOneRow<float>(
+      input.data(), sin_data.data(), cos_data.data(), dim, interleaved, out_dispatch.data());
+
+  std::cout << "--- " << label << " (dim=" << dim << ") ---\n";
+  CompareResults(out_fallback.data(), out_dispatch.data(), dim);
+
+  auto run_fallback = [&]() {
+    MlasRotaryEmbedOneRow_FallBack<float>(
+        input.data(), sin_data.data(), cos_data.data(), dim, interleaved, out_fallback.data());
+  };
+  auto run_dispatch = [&]() {
+    MlasRotaryEmbedOneRow<float>(
+        input.data(), sin_data.data(), cos_data.data(), dim, interleaved, out_dispatch.data());
+  };
+
+  for (size_t i = 0; i < warmup; i++) {
+    run_fallback();
+    run_dispatch();
+  }
+
+  double fallback_ms = TimeLoop(iters, run_fallback) / iters;
+  double dispatch_ms = TimeLoop(iters, run_dispatch) / iters;
+
+  std::cout << std::fixed << std::setprecision(4)
+            << "  ORT Fallback: " << fallback_ms * 1000 << " us\n"
+            << "  ORT Dispatch: " << dispatch_ms * 1000 << " us\n"
+            << "  Speedup:      " << fallback_ms / dispatch_ms << "x\n\n";
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  const Options opts = ParseArgs(argc, argv);
+
+  std::cout << "=== RotaryEmbedding: RVV Dispatch vs ORT Scalar Fallback ===\n\n";
+
+  BenchRoPE("RoPE non-interleaved", opts.dim, false, opts.iters, opts.warmup);
+  BenchRoPE("RoPE interleaved", opts.dim, true, opts.iters, opts.warmup);
+
+  return 0;
+}

--- a/onnxruntime/test/mlas/unittest/test_cast_fp16.cpp
+++ b/onnxruntime/test/mlas/unittest/test_cast_fp16.cpp
@@ -1,0 +1,120 @@
+/*++
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the MIT License.
+
+Module Name:
+
+    test_cast_fp16.cpp
+
+Abstract:
+
+    Tests for MLAS FP16<->FP32 cast kernels.
+    Verifies bit-exactness against MLAS_Half2Float / MLAS_Float2Half.
+
+--*/
+
+#include "test_util.h"
+#include "mlas.h"
+#include "mlas_float16.h"
+
+#include <vector>
+
+class MlasCastFp16Test : public MlasTestBase {
+ public:
+  void TestF16ToF32(size_t count) {
+    std::vector<_mlas_fp16_> input(count);
+    std::vector<float> output_ref(count);
+    std::vector<float> output_dispatch(count);
+
+    for (size_t i = 0; i < count; i++) {
+      float val = (static_cast<float>(i % 2048) / 1024.0f) - 1.0f;
+      input[i] = MLAS_Float2Half(val);
+      output_ref[i] = MLAS_Half2Float(input[i]);
+    }
+
+    MlasConvertHalfToFloatBuffer(
+        reinterpret_cast<const MLAS_FP16*>(input.data()),
+        output_dispatch.data(), count);
+
+    for (size_t i = 0; i < count; i++) {
+      ASSERT_EQ(output_dispatch[i], output_ref[i])
+          << "F16->F32 mismatch at [" << i << "], count=" << count;
+    }
+  }
+
+  void TestF32ToF16(size_t count) {
+    std::vector<float> input(count);
+    std::vector<_mlas_fp16_> output_ref(count);
+    std::vector<_mlas_fp16_> output_dispatch(count);
+
+    for (size_t i = 0; i < count; i++) {
+      input[i] = (static_cast<float>(i % 2048) / 1024.0f) - 1.0f;
+      output_ref[i] = MLAS_Float2Half(input[i]);
+    }
+
+    MlasConvertFloatToHalfBuffer(
+        input.data(),
+        reinterpret_cast<MLAS_FP16*>(output_dispatch.data()), count);
+
+    for (size_t i = 0; i < count; i++) {
+      ASSERT_EQ(output_dispatch[i], output_ref[i])
+          << "F32->F16 mismatch at [" << i << "], count=" << count;
+    }
+  }
+};
+
+class CastFp16ShortExecuteTest : public MlasTestFixture<MlasCastFp16Test> {
+ public:
+  CastFp16ShortExecuteTest(size_t count, bool f16_to_f32)
+      : count_(count), f16_to_f32_(f16_to_f32) {}
+
+  void TestBody() override {
+    if (f16_to_f32_) {
+      MlasTestFixture<MlasCastFp16Test>::mlas_tester->TestF16ToF32(count_);
+    } else {
+      MlasTestFixture<MlasCastFp16Test>::mlas_tester->TestF32ToF16(count_);
+    }
+  }
+
+  static size_t RegisterSingleTest(size_t count, bool f16_to_f32) {
+    std::stringstream ss;
+    ss << "/" << (f16_to_f32 ? "F16toF32" : "F32toF16")
+       << "/count" << count;
+    auto test_name = ss.str();
+
+    testing::RegisterTest(
+        "CastFp16",
+        test_name.c_str(),
+        nullptr,
+        test_name.c_str(),
+        __FILE__,
+        __LINE__,
+        [=]() -> MlasTestFixture<MlasCastFp16Test>* {
+          return new CastFp16ShortExecuteTest(count, f16_to_f32);
+        });
+    return 1;
+  }
+
+  static size_t RegisterShortExecuteTests() {
+    size_t cnt = 0;
+    for (size_t n : {1, 7, 15, 16, 31, 32, 63, 64, 128, 255, 256, 1024, 65536}) {
+      cnt += RegisterSingleTest(n, true);
+      cnt += RegisterSingleTest(n, false);
+    }
+    return cnt;
+  }
+
+ private:
+  size_t count_;
+  bool f16_to_f32_;
+};
+
+static UNUSED_VARIABLE bool added_to_main = AddTestRegister(
+    [](bool is_short_execute) -> size_t {
+      if (is_short_execute) {
+        return CastFp16ShortExecuteTest::RegisterShortExecuteTests();
+      }
+      return 0;
+    });

--- a/onnxruntime/test/mlas/unittest/test_layernorm.cpp
+++ b/onnxruntime/test/mlas/unittest/test_layernorm.cpp
@@ -1,0 +1,157 @@
+/*++
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the MIT License.
+
+Module Name:
+
+    test_layernorm.cpp
+
+Abstract:
+
+    Tests for MLAS LayerNorm/RMSNorm (MlasLayerNormF32).
+
+--*/
+
+#include "test_util.h"
+#include "mlas.h"
+
+#include <cmath>
+#include <vector>
+
+class MlasLayerNormTest : public MlasTestBase {
+ private:
+  void ScalarLayerNorm(
+      const float* input,
+      const float* scale,
+      const float* bias,
+      float* output,
+      float* mean_out,
+      float* inv_std_out,
+      size_t norm_size,
+      float epsilon,
+      bool simplified) {
+    float sum = 0.0f;
+    float sum_sq = 0.0f;
+    for (size_t i = 0; i < norm_size; i++) {
+      sum += input[i];
+      sum_sq += input[i] * input[i];
+    }
+    float mean = sum / static_cast<float>(norm_size);
+    float denom;
+    if (simplified) {
+      denom = std::sqrt(sum_sq / static_cast<float>(norm_size) + epsilon);
+    } else {
+      denom = std::sqrt(sum_sq / static_cast<float>(norm_size) - mean * mean + epsilon);
+    }
+    float inv_denom = 1.0f / denom;
+
+    for (size_t i = 0; i < norm_size; i++) {
+      if (simplified) {
+        output[i] = input[i] * inv_denom * scale[i];
+      } else if (bias == nullptr) {
+        output[i] = (input[i] - mean) * inv_denom * scale[i];
+      } else {
+        output[i] = (input[i] - mean) * inv_denom * scale[i] + bias[i];
+      }
+    }
+    if (mean_out) *mean_out = mean;
+    if (inv_std_out) *inv_std_out = inv_denom;
+  }
+
+ public:
+  void Test(size_t norm_size, bool simplified, bool with_bias) {
+    std::vector<float> input(norm_size);
+    std::vector<float> scale(norm_size);
+    std::vector<float> bias(norm_size);
+    std::vector<float> output_ref(norm_size);
+    std::vector<float> output_mlas(norm_size);
+    float mean_ref = 0, mean_mlas = 0;
+    float inv_std_ref = 0, inv_std_mlas = 0;
+
+    for (size_t i = 0; i < norm_size; i++) {
+      input[i] = (static_cast<float>(i % 127) - 63.0f) * 0.01f;
+      scale[i] = 1.0f + (static_cast<float>(i % 31) - 15.0f) * 0.001f;
+      bias[i] = (static_cast<float>(i % 17) - 8.0f) * 0.005f;
+    }
+
+    const float* bias_ptr = (with_bias && !simplified) ? bias.data() : nullptr;
+
+    ScalarLayerNorm(input.data(), scale.data(), bias_ptr,
+                    output_ref.data(), &mean_ref, &inv_std_ref,
+                    norm_size, 1e-5f, simplified);
+
+    bool used = MlasLayerNormF32(input.data(), scale.data(), bias_ptr,
+                                 output_mlas.data(), &mean_mlas, &inv_std_mlas,
+                                 norm_size, 1e-5f, simplified);
+
+    if (!used) {
+      // No optimized kernel available, skip comparison
+      return;
+    }
+
+    for (size_t i = 0; i < norm_size; i++) {
+      ASSERT_NEAR(output_mlas[i], output_ref[i], 1e-4f)
+          << "output mismatch at [" << i << "], norm_size=" << norm_size
+          << " simplified=" << simplified << " bias=" << with_bias;
+    }
+    ASSERT_NEAR(mean_mlas, mean_ref, 1e-4f) << "mean mismatch";
+    ASSERT_NEAR(inv_std_mlas, inv_std_ref, 1e-4f) << "inv_std_dev mismatch";
+  }
+};
+
+class LayerNormShortExecuteTest : public MlasTestFixture<MlasLayerNormTest> {
+ public:
+  LayerNormShortExecuteTest(size_t norm_size, bool simplified, bool with_bias)
+      : norm_size_(norm_size), simplified_(simplified), with_bias_(with_bias) {}
+
+  void TestBody() override {
+    MlasTestFixture<MlasLayerNormTest>::mlas_tester->Test(norm_size_, simplified_, with_bias_);
+  }
+
+  static size_t RegisterSingleTest(size_t norm_size, bool simplified, bool with_bias) {
+    std::stringstream ss;
+    ss << "/norm_size" << norm_size
+       << "/simplified" << simplified
+       << "/bias" << with_bias;
+    auto test_name = ss.str();
+
+    testing::RegisterTest(
+        "LayerNorm",
+        test_name.c_str(),
+        nullptr,
+        test_name.c_str(),
+        __FILE__,
+        __LINE__,
+        [=]() -> MlasTestFixture<MlasLayerNormTest>* {
+          return new LayerNormShortExecuteTest(norm_size, simplified, with_bias);
+        });
+    return 1;
+  }
+
+  static size_t RegisterShortExecuteTests() {
+    size_t count = 0;
+    for (size_t n : {1, 7, 32, 63, 64, 127, 128, 256, 1024}) {
+      for (bool simplified : {true, false}) {
+        for (bool with_bias : {true, false}) {
+          count += RegisterSingleTest(n, simplified, with_bias);
+        }
+      }
+    }
+    return count;
+  }
+
+ private:
+  size_t norm_size_;
+  bool simplified_;
+  bool with_bias_;
+};
+
+static UNUSED_VARIABLE bool added_to_main = AddTestRegister(
+    [](bool is_short_execute) -> size_t {
+      if (is_short_execute) {
+        return LayerNormShortExecuteTest::RegisterShortExecuteTests();
+      }
+      return 0;
+    });

--- a/onnxruntime/test/mlas/unittest/test_rope.cpp
+++ b/onnxruntime/test/mlas/unittest/test_rope.cpp
@@ -124,8 +124,8 @@ class RoPEShortExecuteTest : public MlasTestFixture<MlasRoPETest<T>> {
   bool interleaved_;
 };
 
-// only test float RoPE with avx2 where RopeDispatch is assigned at this moment.
-#ifdef MLAS_TARGET_AMD64
+// Enable RoPE tests on platforms where RopeDispatch is assigned.
+#if defined(MLAS_TARGET_AMD64) || (defined(MLAS_TARGET_RISCV64) && defined(MLAS_USE_RVV))
 static size_t RoPERegisterAllShortExecuteTests() {
   return RoPEShortExecuteTest<float>::RegisterShortExecuteTests() + RoPEShortExecuteTest<MLFloat16>::RegisterShortExecuteTests();
 }


### PR DESCRIPTION
## Description
Added RVV implementations for a subset of LLM inference operators. Optimization of activation functions is in #28308.
All tests were conducted on a Spacemit K3 CPU (VLEN=256).

| Operator | File | Speedup vs Scalar | Precision |
| :--- | :--- | :--- | :--- |
| FP16 GEMM | `riscv64/halfgemm_kernel_rvv.cpp` | 51–191x | max_abs ≤ 0.0005 (PASS) |
| FP16↔FP32 Cast | `riscv64/cast_kernel_rvv.cpp` | 4–12x | Bit-exact (PASS) |
| RotaryEmbedding | `riscv64/rotary_embedding_kernel_rvv.cpp` | 3.1x | max_abs ~6e-08 (PASS) |
| SimplifiedLayerNorm | `layer_norm_impl.cc` (inline RVV) | 4.3x | Bit-exact (PASS) |

## Operator Performance

### **FP16 GEMM**

| Shape (M×N×K) | ORT Scalar | RVV | Speedup | Max Abs Error |
| :--- | :--- | :--- | :--- | :--- |
| 1×768×768 | 7.32 ms | 0.14 ms | 51.6x | 1.22e-04 |
| 32×768×768 | 235 ms | 1.25 ms | 187.9x | 3.66e-04 |
| 64×768×768 | 469 ms | 2.49 ms | 188.8x | 2.44e-04 |
| 128×3072×768 | 5718 ms | 30.4 ms | 187.8x | 4.88e-04 |

---

### **FP16↔FP32 Cast**

| Elements | Direction | ORT Scalar | RVV | Speedup |
| :--- | :--- | :--- | :--- | :--- |
| 1K | F16→F32 | 0.002 ms | 0.000 ms | 9.6x |
| 1K | F32→F16 | 0.002 ms | 0.000 ms | 10.5x |
| 64K | F16→F32 | 0.127 ms | 0.013 ms | 9.7x |
| 64K | F32→F16 | 0.150 ms | 0.013 ms | 11.3x |
| 1M | F16→F32 | 2.03 ms | 0.26 ms | 7.7x |
| 1M | F32→F16 | 2.39 ms | 0.50 ms | 4.8x |

---

### **RotaryEmbedding**

| Dim | Mode | ORT Scalar | RVV | Speedup | Max Abs Error |
| :--- | :--- | :--- | :--- | :--- | :--- |
| 64 | non-interleaved | 0.32 us | 0.05 us | 7.1x | 5.96e-08 |
| 64 | interleaved | 0.22 us | 0.07 us | 3.2x | 0 |
| 128 | non-interleaved | 0.64 us | 0.07 us | 9.7x | 5.96e-08 |
| 128 | interleaved | 0.44 us | 0.13 us | 3.4x | 0 |
| 256 | non-interleaved | 1.28 us | 0.10 us | 13.0x | 1.19e-07 |
| 256 | interleaved | 1.05 us | 0.25 us | 4.3x | 0 |

---

### **RMSNorm**

| Hidden | ORT Scalar | RVV | Speedup | Max Abs Error |
| :--- | :--- | :--- | :--- | :--- |
| 512 | 2.31 us | 0.38 us | 6.0x | 2.38e-07 |
| 1024 | 4.64 us | 0.71 us | 6.5x | 2.38e-07 |
| 2048 | 9.24 us | 1.42 us | 6.5x | 3.58e-07 |
| 4096 | 18.5 us | 2.82 us | 6.6x | 3.58e-06 |
> **Note**: ORT's LayerNorm ComputeJob is in an anonymous namespace — there's no public API to call it separately. So I rewrite the benchmark using the same algorithm as ORT's ComputeJob.

## Model Performance
The ONNX model comes from: https://huggingface.co/onnx-community/Qwen3-0.6B-ONNX

| Metric | FP32 | FP16 |
| :--- | :--- | :--- |
| Prompt processing | 61.1 tok/s (255 ms p50) | 58.8 tok/s (272 ms p50) |
| Token generation | 6.5 tok/s (152 ms p50) | 6.1 tok/s (162 ms p50) |
| E2E (16+32 tokens) | 4987 ms p50 | 5357 ms p50 |
| Peak memory | 3.1 GB | 4.1 GB |

> **Note**: FP32 is slightly faster because it runs SGEMM directly without the FP16↔FP32 cast overhead. FP16 uses ~1 GB less storage on disk but more runtime memory (the cast creates FP32 copies). Both use the RVV SGEMM kernel for the actual compute.