### PR TITLE
[WebGPU] LinearAttention: increase tile_v when subgroups are available

### DIFF
--- a/onnxruntime/contrib_ops/webgpu/bert/linear_attention.cc
+++ b/onnxruntime/contrib_ops/webgpu/bert/linear_attention.cc
@@ -213,12 +213,15 @@ Status LinearAttention::ComputeInternal(ComputeContext& context) const {
                               ? static_cast<int>(context.AdapterInfo().subgroupMinSize)
                               : 0;
   // When subgroup is enabled, use larger tile_v for better data reuse.
-  if (subgroup_min_size > 0) {
+  // Only expand for longer sequences (>=16) where the benefit outweighs the
+  // increased register pressure and shared memory usage.
+  if (subgroup_min_size > 0 && seq_length >= 16) {
     // Only expand if the vectorized dim has enough columns to fill the larger tile.
     if (head_dim_v / components >= tile_v * 4) {
       tile_v *= 4;
     }
   }
+
   const int head_dim_v_vectorized = onnxruntime::narrow<int>(head_dim_v) / components;
 
   constexpr uint32_t kMaxSupportedWorkgroupSize = 256;

--- a/onnxruntime/contrib_ops/webgpu/bert/linear_attention.cc
+++ b/onnxruntime/contrib_ops/webgpu/bert/linear_attention.cc
@@ -202,6 +202,19 @@ Status LinearAttention::ComputeInternal(ComputeContext& context) const {
   TensorShapeVector state_shape({batch_size, kv_num_heads_, head_dim_k, head_dim_v});
   Tensor* present_state = context.Output(1, state_shape);
 
+  constexpr uint32_t kMaxSupportedWorkgroupSize = 256;
+  ORT_RETURN_IF_NOT(head_dim_k <= static_cast<int64_t>(kMaxSupportedWorkgroupSize),
+                    "LinearAttention WebGPU kernel requires head_dim_k <= ",
+                    kMaxSupportedWorkgroupSize,
+                    ", got ",
+                    head_dim_k);
+  uint32_t workgroup_size = 1;
+  while (workgroup_size < static_cast<uint32_t>(head_dim_k)) {
+    workgroup_size *= 2;
+  }
+  // Cap at GPU limits
+  workgroup_size = std::min(workgroup_size, kMaxSupportedWorkgroupSize);
+
   // Vectorization: when head_dim_v is divisible by 4, use vec4 to pack 4 dv values
   // per element. This replaces scalar TILE_V loops with native vec4 SIMD operations,
   // reduces shared memory access overhead, and enables coalesced memory reads/writes.
@@ -216,27 +229,16 @@ Status LinearAttention::ComputeInternal(ComputeContext& context) const {
   // Only expand for longer sequences (>=16) where the benefit outweighs the
   // increased register pressure and shared memory usage.
   if (subgroup_min_size > 0 && seq_length >= 16) {
-    // Only expand if the vectorized dim has enough columns to fill the larger tile.
+    // Ensure the vectorized dimension is wide enough to warrant a larger tile.
     if (head_dim_v / components >= tile_v * 4) {
       tile_v *= 4;
     }
   }
+  // Clamp to workgroup_size since the shader assigns one thread per tile_v
+  // column (threads with dk_idx >= TILE_V are idle for output/state writes).
+  tile_v = std::min(tile_v, static_cast<int>(workgroup_size));
 
   const int head_dim_v_vectorized = onnxruntime::narrow<int>(head_dim_v) / components;
-
-  constexpr uint32_t kMaxSupportedWorkgroupSize = 256;
-  ORT_RETURN_IF_NOT(head_dim_k <= static_cast<int64_t>(kMaxSupportedWorkgroupSize),
-                    "LinearAttention WebGPU kernel requires head_dim_k <= ",
-                    kMaxSupportedWorkgroupSize,
-                    ", got ",
-                    head_dim_k);
-  uint32_t workgroup_size = 1;
-  while (workgroup_size < static_cast<uint32_t>(head_dim_k)) {
-    workgroup_size *= 2;
-  }
-  // Cap at GPU limits
-  workgroup_size = std::min(workgroup_size, kMaxSupportedWorkgroupSize);
-
   const int num_dv_tiles = (head_dim_v_vectorized + tile_v - 1) / tile_v;
   const uint32_t num_workgroups = onnxruntime::narrow<uint32_t>(batch_size * kv_num_heads_ * num_dv_tiles);
 

--- a/onnxruntime/contrib_ops/webgpu/bert/linear_attention.cc
+++ b/onnxruntime/contrib_ops/webgpu/bert/linear_attention.cc
@@ -219,7 +219,7 @@ Status LinearAttention::ComputeInternal(ComputeContext& context) const {
   // per element. This replaces scalar TILE_V loops with native vec4 SIMD operations,
   // reduces shared memory access overhead, and enables coalesced memory reads/writes.
   // TODO: support components == 2 (vec2) for head_dim_v divisible by 2 but not 4.
-  const int components = (head_dim_v % 4 == 0 && head_dim_v >= 4) ? 4 : 1;
+  const int components = (head_dim_v % 4 == 0) ? 4 : 1;
   int tile_v = (components == 4) ? 1 : std::min(4, onnxruntime::narrow<int>(head_dim_v));
 
   // subgroup_min_size > 0 enables subgroup-based reduction; 0 falls back to barrier-tree.

--- a/onnxruntime/contrib_ops/webgpu/bert/linear_attention.cc
+++ b/onnxruntime/contrib_ops/webgpu/bert/linear_attention.cc
@@ -206,9 +206,17 @@ Status LinearAttention::ComputeInternal(ComputeContext& context) const {
   // per element. This replaces scalar TILE_V loops with native vec4 SIMD operations,
   // reduces shared memory access overhead, and enables coalesced memory reads/writes.
   const int components = (head_dim_v % 4 == 0 && head_dim_v >= 4) ? 4 : 1;
-  int tile_v = (components == 4) ? 1 : 4;
-  if (components == 1 && head_dim_v <= 4) {
-    tile_v = onnxruntime::narrow<int>(head_dim_v);
+  int tile_v = (components == 4) ? 1 : std::min(4, onnxruntime::narrow<int>(head_dim_v));
+
+  int subgroup_min_size = context.HasFeature(wgpu::FeatureName::Subgroups)
+                              ? static_cast<int>(context.AdapterInfo().subgroupMinSize)
+                              : 0;
+  // When subgroup is enabled, use larger tile_v for better data reuse.
+  if (subgroup_min_size > 0) {
+    // Only expand if the vectorized dim has enough columns to fill the larger tile.
+    if (head_dim_v / components >= tile_v * 4) {
+      tile_v *= 4;
+    }
   }
   const int head_dim_v_vectorized = onnxruntime::narrow<int>(head_dim_v) / components;
 
@@ -242,11 +250,6 @@ Status LinearAttention::ComputeInternal(ComputeContext& context) const {
       decay_broadcast_dk = true;
     }
   }
-
-  // subgroup_min_size > 0 enables subgroup-based reduction; 0 falls back to barrier-tree.
-  int subgroup_min_size = context.HasFeature(wgpu::FeatureName::Subgroups)
-                              ? static_cast<int>(context.AdapterInfo().subgroupMinSize)
-                              : 0;
 
   LinearAttentionProgram program{update_rule_, has_initial_state, has_decay, has_beta, decay_broadcast_dk, tile_v, components, subgroup_min_size};
 

--- a/onnxruntime/contrib_ops/webgpu/bert/linear_attention.cc
+++ b/onnxruntime/contrib_ops/webgpu/bert/linear_attention.cc
@@ -218,6 +218,7 @@ Status LinearAttention::ComputeInternal(ComputeContext& context) const {
   // Vectorization: when head_dim_v is divisible by 4, use vec4 to pack 4 dv values
   // per element. This replaces scalar TILE_V loops with native vec4 SIMD operations,
   // reduces shared memory access overhead, and enables coalesced memory reads/writes.
+  // TODO: support components == 2 (vec2) for head_dim_v divisible by 2 but not 4.
   const int components = (head_dim_v % 4 == 0 && head_dim_v >= 4) ? 4 : 1;
   int tile_v = (components == 4) ? 1 : std::min(4, onnxruntime::narrow<int>(head_dim_v));
 

--- a/onnxruntime/contrib_ops/webgpu/bert/linear_attention.cc
+++ b/onnxruntime/contrib_ops/webgpu/bert/linear_attention.cc
@@ -208,6 +208,7 @@ Status LinearAttention::ComputeInternal(ComputeContext& context) const {
   const int components = (head_dim_v % 4 == 0 && head_dim_v >= 4) ? 4 : 1;
   int tile_v = (components == 4) ? 1 : std::min(4, onnxruntime::narrow<int>(head_dim_v));
 
+  // subgroup_min_size > 0 enables subgroup-based reduction; 0 falls back to barrier-tree.
   int subgroup_min_size = context.HasFeature(wgpu::FeatureName::Subgroups)
                               ? static_cast<int>(context.AdapterInfo().subgroupMinSize)
                               : 0;

--- a/onnxruntime/contrib_ops/webgpu/bert/linear_attention.wgsl.template
+++ b/onnxruntime/contrib_ops/webgpu/bert/linear_attention.wgsl.template
@@ -90,9 +90,6 @@ $MAIN {
 
   // Initialize state tile in private memory
   var state: array<vtype, TILE_V>;
-  for (var j = 0u; j < TILE_V; j++) {
-    state[j] = vtype(0.0);
-  }
 
   // Load initial state if provided
 #if has_initial_state


### PR DESCRIPTION
### Description
- Scale tile_v by 4x when subgroup is enabled and the vectorized dimension has enough columns, improving data reuse.
- Gate the tile_v expansion on seq_length >= 16, where the prefill benefit outweighs increased register pressure.
- Remove redundant zero-initialization of the state tile (WGSL default- initializes vars to zero).

**Intel Panther Lake (xe-3lpg)**
| Model        | Prefill | Baseline (TPS) | Optimized (TPS) | Change |
| :----------- | ------: | -------------: | --------------: | -----: |
| Qwen3.5-0.8B |     128 |        1534.30 |         1681.00 |  9.56% |
| Qwen3.5-0.8B |    1024 |        3267.30 |         3917.60 | 19.90% |
| Qwen3.5-0.8B |    4096 |        2864.50 |         3563.40 | 24.40% |
| Qwen3.5-2B   |     128 |        1295.60 |         1344.60 |  3.78% |
| Qwen3.5-2B   |    1024 |        2177.10 |         2344.00 |  7.67% |
| Qwen3.5-2B   |    4096 |        1942.60 |         2247.00 | 15.67% |
| Qwen3.5-4B   |     128 |         701.30 |          736.20 |  4.98% |
| Qwen3.5-4B   |    1024 |         946.90 |         1036.30 |  9.44% |
| Qwen3.5-4B   |    4096 |         824.10 |          912.00 | 10.67% |

### Motivation and Context
See above.

