### PR TITLE
fix(qdq): skip DQ forward propagation when DQ input is constant

### DIFF
--- a/onnxruntime/core/optimizer/qdq_transformer/qdq_propagation.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/qdq_propagation.cc
@@ -363,7 +363,8 @@ Status PropagateDQForward(Graph& graph, gsl::span<const NodeIndex> node_indices,
     const bool is_initializer_constant = graph_utils::NodeArgIsConstant(graph, *dq_data_input);
     const Node* dq_data_producer = graph.GetProducerNode(dq_data_input->Name());
     const bool is_constant_op_output = dq_data_producer != nullptr &&
-                                       dq_data_producer->OpType() == "Constant";
+                                       dq_data_producer->OpType() == "Constant" &&
+                                       dq_data_producer->Domain() == kOnnxDomain;
     if (is_initializer_constant || is_constant_op_output) {
       continue;
     }

--- a/onnxruntime/core/optimizer/qdq_transformer/qdq_propagation.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/qdq_propagation.cc
@@ -354,6 +354,20 @@ Status PropagateDQForward(Graph& graph, gsl::span<const NodeIndex> node_indices,
       continue;
     }
 
+    // Do not propagate DQ forward when its data input is a constant (graph initializer or
+    // Constant op output). Propagation would insert a Q -> DQ pair after any downstream
+    // reshape-like node; later passes (e.g. S8-to-U8 weight transformer) may flip the
+    // existing DQ to uint8 without touching the inserted Q, causing int8 negatives to
+    // be clamped to zero. See GitHub issue #28491.
+    const NodeArg* dq_data_input = dq_node.InputDefs()[QDQ::InputIndex::INPUT_ID];
+    const bool is_initializer_constant = graph_utils::NodeArgIsConstant(graph, *dq_data_input);
+    const Node* dq_data_producer = graph.GetProducerNode(dq_data_input->Name());
+    const bool is_constant_op_output = dq_data_producer != nullptr &&
+                                       dq_data_producer->OpType() == "Constant";
+    if (is_initializer_constant || is_constant_op_output) {
+      continue;
+    }
+
     auto& dq_scale = *dq_node.MutableInputDefs()[QDQ::InputIndex::SCALE_ID];
     auto* dq_zero_point = dq_zero_point_exists
                               ? dq_node.MutableInputDefs()[QDQ::InputIndex::ZERO_POINT_ID]

--- a/onnxruntime/test/optimizer/qdq_transformer_test.cc
+++ b/onnxruntime/test/optimizer/qdq_transformer_test.cc
@@ -3975,6 +3975,10 @@ TEST(QDQTransformerTests, QDQPropagation_DQForward_ConstantInput_NoPropagation) 
   }
 
   // Case 2: DQ data input is the output of a Constant op node.
+  // Run QDQPropagationTransformer directly (bypassing ConstantFolding) so the
+  // Constant op node is still present when PropagateDQForward evaluates it.
+  // Using TransformerTester would fold the Constant into an initializer first,
+  // masking the is_constant_op_output code path under test.
   {
     auto build_test_case = [&](ModelTestBuilder& builder) {
       auto* output_arg = builder.MakeOutput();
@@ -4001,23 +4005,21 @@ TEST(QDQTransformerTests, QDQPropagation_DQForward_ConstantInput_NoPropagation) 
       builder.AddNode("Reshape", {dq_output, reshape_shape}, {output_arg});
     };
 
-    auto check_graph = [&](InferenceSessionWrapper& session) {
-      const auto op_types = GetNodeOpTypesInTopologicalOrder(session.GetGraph(), true);
-      // No Q or DQ should have been inserted after Reshape.
+    // post_graph_checker runs on Graph& directly, after only QDQPropagationTransformer.
+    // QuantizeLinear must not have been inserted anywhere.
+    auto post_graph_checker = [&](Graph& graph) -> Status {
+      const auto op_counts = CountOpsInGraph(graph);
       const QDQOpKeys qdq_keys = GetQDQOpKeys(false);
-      // Constant op may be folded; Q must not appear ANYWHERE in the graph
-      // (the bug would insert it after Reshape, not necessarily at the tail).
-      const bool has_any_q =
-          std::find(op_types.begin(), op_types.end(), qdq_keys.quantize_linear) != op_types.end();
-      EXPECT_FALSE(has_any_q) << "QDQPropagation must not insert QuantizeLinear anywhere "
-                                 "when DQ input is a constant op output.";
+      TEST_RETURN_IF_NOT(op_counts.count(qdq_keys.quantize_linear) == 0 ||
+                         op_counts.at(qdq_keys.quantize_linear) == 0);
+      return Status::OK();
     };
 
-    TransformerTester(build_test_case,
-                      check_graph,
-                      TransformerLevel::Default,
-                      TransformerLevel::Level1,
-                      12);
+    const auto& logger = DefaultLoggingManager().DefaultLogger();
+    ASSERT_STATUS_OK(TestGraphTransformer(build_test_case, 12, logger,
+                                         std::make_unique<QDQPropagationTransformer>(),
+                                         TransformerLevel::Level1, 1,
+                                         nullptr, post_graph_checker));
   }
 }
 

--- a/onnxruntime/test/optimizer/qdq_transformer_test.cc
+++ b/onnxruntime/test/optimizer/qdq_transformer_test.cc
@@ -4017,9 +4017,9 @@ TEST(QDQTransformerTests, QDQPropagation_DQForward_ConstantInput_NoPropagation) 
 
     const auto& logger = DefaultLoggingManager().DefaultLogger();
     ASSERT_STATUS_OK(TestGraphTransformer(build_test_case, 12, logger,
-                                         std::make_unique<QDQPropagationTransformer>(),
-                                         TransformerLevel::Level1, 1,
-                                         nullptr, post_graph_checker));
+                                          std::make_unique<QDQPropagationTransformer>(),
+                                          TransformerLevel::Level1, 1,
+                                          nullptr, post_graph_checker));
   }
 }
 

--- a/onnxruntime/test/optimizer/qdq_transformer_test.cc
+++ b/onnxruntime/test/optimizer/qdq_transformer_test.cc
@@ -3934,6 +3934,93 @@ TEST(QDQTransformerTests, QDQPropagation_DQForward) {
 #endif
 }
 
+// Regression test for GitHub issue #28491.
+// When a DQ node's data input is a constant (graph initializer or Constant op output),
+// PropagateDQForward must not insert a Q -> DQ pair downstream of a reshape-like node.
+// Doing so can cause subsequent S8-to-U8 weight transformers to flip the DQ dtype while
+// leaving the inserted Q node in its original dtype, clamping int8 negatives to zero.
+TEST(QDQTransformerTests, QDQPropagation_DQForward_ConstantInput_NoPropagation) {
+  // Case 1: DQ data input is a graph initializer.
+  {
+    auto build_test_case = [&](ModelTestBuilder& builder) {
+      // int8 constant weight as a graph initializer
+      auto* weight = builder.MakeInitializer<int8_t>({4}, {-10, 0, 10, 20});
+      auto* output_arg = builder.MakeOutput();
+
+      // DQ node that dequantizes the constant weight
+      constexpr float qdq_scale = 0.1f;
+      constexpr int8_t qdq_zero_point = 0;
+      auto* dq_output = builder.MakeIntermediate();
+      builder.AddDequantizeLinearNode<int8_t>(weight, qdq_scale, qdq_zero_point, dq_output);
+
+      // Reshape downstream of DQ
+      auto* reshape_shape = builder.Make1DInitializer<int64_t>({2, 2});
+      builder.AddNode("Reshape", {dq_output, reshape_shape}, {output_arg});
+    };
+
+    auto check_graph = [&](InferenceSessionWrapper& session) {
+      const auto op_types = GetNodeOpTypesInTopologicalOrder(session.GetGraph(), true);
+      // No Q or DQ should have been inserted after Reshape.
+      // Expected order: DequantizeLinear -> Reshape  (no trailing Q/DQ).
+      const QDQOpKeys qdq_keys = GetQDQOpKeys(false);
+      const std::vector<std::string> expected{qdq_keys.dequantize_linear, "Reshape"};
+      EXPECT_EQ(op_types, expected);
+    };
+
+    TransformerTester(build_test_case,
+                      check_graph,
+                      TransformerLevel::Default,
+                      TransformerLevel::Level1,
+                      12);
+  }
+
+  // Case 2: DQ data input is the output of a Constant op node.
+  {
+    auto build_test_case = [&](ModelTestBuilder& builder) {
+      auto* output_arg = builder.MakeOutput();
+
+      // Create a Constant op node that produces an int8 tensor.
+      ONNX_NAMESPACE::TensorProto constant_tensor;
+      constant_tensor.set_data_type(ONNX_NAMESPACE::TensorProto_DataType_INT8);
+      constant_tensor.add_dims(4);
+      const std::vector<int8_t> raw_vals = {-10, 0, 10, 20};
+      constant_tensor.set_raw_data(raw_vals.data(), raw_vals.size() * sizeof(int8_t));
+
+      auto* constant_output = builder.MakeIntermediate();
+      constant_tensor.set_name(constant_output->Name());
+      builder.AddNode("Constant", {}, {constant_output}).AddAttribute("value", constant_tensor);
+
+      // DQ node that dequantizes the Constant op output
+      constexpr float qdq_scale = 0.1f;
+      constexpr int8_t qdq_zero_point = 0;
+      auto* dq_output = builder.MakeIntermediate();
+      builder.AddDequantizeLinearNode<int8_t>(constant_output, qdq_scale, qdq_zero_point, dq_output);
+
+      // Reshape downstream of DQ
+      auto* reshape_shape = builder.Make1DInitializer<int64_t>({2, 2});
+      builder.AddNode("Reshape", {dq_output, reshape_shape}, {output_arg});
+    };
+
+    auto check_graph = [&](InferenceSessionWrapper& session) {
+      const auto op_types = GetNodeOpTypesInTopologicalOrder(session.GetGraph(), true);
+      // No Q or DQ should have been inserted after Reshape.
+      const QDQOpKeys qdq_keys = GetQDQOpKeys(false);
+      // Constant op may be folded; Q must not appear ANYWHERE in the graph
+      // (the bug would insert it after Reshape, not necessarily at the tail).
+      const bool has_any_q =
+          std::find(op_types.begin(), op_types.end(), qdq_keys.quantize_linear) != op_types.end();
+      EXPECT_FALSE(has_any_q) << "QDQPropagation must not insert QuantizeLinear anywhere "
+                                 "when DQ input is a constant op output.";
+    };
+
+    TransformerTester(build_test_case,
+                      check_graph,
+                      TransformerLevel::Default,
+                      TransformerLevel::Level1,
+                      12);
+  }
+}
+
 TEST(QDQTransformerTests, QDQPropagation_StopAtOtherQDQ) {
   auto test_case = [&](const std::vector<int64_t>& input_shape, bool same_scale, bool same_zp,
                        bool use_contrib_qdq) {


### PR DESCRIPTION
## Summary
- Guard `QDQPropagationTransformer::PropagateDQForward` against propagating a DQ whose data input is a constant (graph initializer or `Constant` op output).
- Prevents a stale `QuantizeLinear` insertion that the S8-to-U8 weight transformer fails to update, which silently clamps int8 negatives to zero under `ORT_ENABLE_ALL`.
- Adds a regression test in `qdq_transformer_test.cc` covering both constant-input shapes.

## Motivation
Fixes #28491.

Reported scenario: a model containing `Constant(int8) -> DequantizeLinear -> Reshape` produces correct outputs under `ORT_DISABLE_ALL` but wrong outputs (negatives clamped to 0) under `ORT_ENABLE_ALL`. Root cause: `PropagateDQForward` inserts a `Q -> DQ` pair after the Reshape, then `QDQS8ToU8Transformer` (or the avx2 weight transformer) flips the upstream DQ from int8 to uint8 without touching the freshly inserted `Q`. The orphaned uint8 `Q` then clamps the int8 weight's negative values to 0.

Propagating a DQ whose data is a constant weight has no benefit anyway: the constant is folded, so there is no runtime tensor that downstream nodes need re-quantized.

## Changes
- `onnxruntime/core/optimizer/qdq_transformer/qdq_propagation.cc`: inside `PropagateDQForward`'s per-DQ loop, after existing skip checks and before any graph mutation, `continue` if `dq_node.InputDefs()[QDQ::InputIndex::INPUT_ID]` is a graph initializer (`graph_utils::NodeArgIsConstant`) or the output of a `Constant` op node (`graph.GetProducerNode(...)->OpType() == "Constant"`). Both checks are required because `NodeArgIsConstant` only handles the initializer case.
- `onnxruntime/test/optimizer/qdq_transformer_test.cc`: new test `QDQPropagation_DQForward_ConstantInput_NoPropagation` with two cases — DQ fed by an initializer, and DQ fed by an explicit `Constant` op node — asserting no `QuantizeLinear` is inserted after the downstream Reshape.

`PropagateQBackward` is structurally not affected (its data input is a live activation, not a constant), so it does not need a symmetric guard.

## Test Plan
- New `QDQTransformerTests.QDQPropagation_DQForward_ConstantInput_NoPropagation` (gtest) covers both code paths and would fail on `main`.
- Existing `QDQPropagation_*` tests use `MakeInput` (graph inputs, not initializers) for their DQ data tensors, so the new guard does not regress them.
- The reproducer from #28491 should now produce identical results between `ORT_DISABLE_ALL` and `ORT_ENABLE_ALL`.
- CI will exercise `--gtest_filter=QDQTransformerTests.QDQPropagation*` under `onnxruntime_test_all`.

Fixes #28491