### PR TITLE
[WebGPU plugin EP] Add Win ARM64 Python package

### DIFF
--- a/tools/ci_build/github/azure-pipelines/plugin-webgpu-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/plugin-webgpu-pipeline.yml
@@ -63,9 +63,6 @@ variables:
   # Path (relative to the repository root) of the VERSION_NUMBER file used for plugin package versioning.
   - name: epVersionFile
     value: plugin-ep-webgpu/VERSION_NUMBER
-  # Windows ARM64 build requires Windows x64 build to be enabled (ARM64 cross-compilation depends on x64 build artifacts)
-  - name: invalidARM64Config
-    value: ${{ and(eq(parameters.build_windows_arm64, true), eq(parameters.build_windows_x64, false)) }}
   # Non-dev package versions (release, RC) must use Release build type
   - name: invalidBuildTypeConfig
     value: ${{ and(ne(parameters.package_version, 'dev'), ne(parameters.cmake_build_type, 'Release')) }}
@@ -100,7 +97,7 @@ extends:
 
     stages:
       # Validate parameter combinations
-      - ${{ if or(eq(variables['invalidARM64Config'], 'True'), eq(variables['invalidBuildTypeConfig'], 'True')) }}:
+      - ${{ if eq(variables['invalidBuildTypeConfig'], 'True') }}:
         - stage: Validate_Parameters
           displayName: 'Validate Parameters'
           dependsOn: []
@@ -112,16 +109,10 @@ extends:
               os: windows
             steps:
             - checkout: none
-            - ${{ if eq(variables['invalidARM64Config'], 'True') }}:
-              - script: |
-                  echo "##vso[task.logissue type=error]Windows ARM64 build requires Windows x64 build to be enabled."
-                  exit 1
-                displayName: 'ERROR: Windows ARM64 requires Windows x64'
-            - ${{ if eq(variables['invalidBuildTypeConfig'], 'True') }}:
-              - script: |
-                  echo "##vso[task.logissue type=error]Non-dev package version requires Release build type."
-                  exit 1
-                displayName: 'ERROR: Non-dev package version requires Release build type'
+            - script: |
+                echo "##vso[task.logissue type=error]Non-dev package version requires Release build type."
+                exit 1
+              displayName: 'ERROR: Non-dev package version requires Release build type'
       - ${{ else }}:
         - template: stages/plugin-webgpu-packaging-stage.yml
           parameters:

--- a/tools/ci_build/github/azure-pipelines/plugin-webgpu-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/plugin-webgpu-pipeline.yml
@@ -63,6 +63,9 @@ variables:
   # Path (relative to the repository root) of the VERSION_NUMBER file used for plugin package versioning.
   - name: epVersionFile
     value: plugin-ep-webgpu/VERSION_NUMBER
+  # Windows ARM64 build requires Windows x64 build to be enabled (ARM64 cross-compilation depends on x64 build artifacts)
+  - name: invalidARM64Config
+    value: ${{ and(eq(parameters.build_windows_arm64, true), eq(parameters.build_windows_x64, false)) }}
   # Non-dev package versions (release, RC) must use Release build type
   - name: invalidBuildTypeConfig
     value: ${{ and(ne(parameters.package_version, 'dev'), ne(parameters.cmake_build_type, 'Release')) }}
@@ -97,7 +100,7 @@ extends:
 
     stages:
       # Validate parameter combinations
-      - ${{ if eq(variables['invalidBuildTypeConfig'], 'True') }}:
+      - ${{ if or(eq(variables['invalidARM64Config'], 'True'), eq(variables['invalidBuildTypeConfig'], 'True')) }}:
         - stage: Validate_Parameters
           displayName: 'Validate Parameters'
           dependsOn: []
@@ -109,10 +112,16 @@ extends:
               os: windows
             steps:
             - checkout: none
-            - script: |
-                echo "##vso[task.logissue type=error]Non-dev package version requires Release build type."
-                exit 1
-              displayName: 'ERROR: Non-dev package version requires Release build type'
+            - ${{ if eq(variables['invalidARM64Config'], 'True') }}:
+              - script: |
+                  echo "##vso[task.logissue type=error]Windows ARM64 build requires Windows x64 build to be enabled."
+                  exit 1
+                displayName: 'ERROR: Windows ARM64 requires Windows x64'
+            - ${{ if eq(variables['invalidBuildTypeConfig'], 'True') }}:
+              - script: |
+                  echo "##vso[task.logissue type=error]Non-dev package version requires Release build type."
+                  exit 1
+                displayName: 'ERROR: Non-dev package version requires Release build type'
       - ${{ else }}:
         - template: stages/plugin-webgpu-packaging-stage.yml
           parameters:

--- a/tools/ci_build/github/azure-pipelines/plugin-webgpu-test-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/plugin-webgpu-test-pipeline.yml
@@ -34,8 +34,10 @@ parameters:
   type: boolean
   default: true
 
-# Note: Windows ARM64 is not tested here because the test runs on an x64
-# build agent, which cannot execute ARM64 binaries.
+- name: test_windows_arm64
+  displayName: 'Test Windows ARM64'
+  type: boolean
+  default: true
 
 - name: test_linux_x64
   displayName: 'Test Linux x64'
@@ -87,6 +89,12 @@ extends:
         - template: stages/plugin-win-webgpu-test-stage.yml
           parameters:
             arch: 'x64'
+
+      # Windows ARM64
+      - ${{ if eq(parameters.test_windows_arm64, true) }}:
+        - template: stages/plugin-win-webgpu-test-stage.yml
+          parameters:
+            arch: 'arm64'
 
       # Linux x64
       - ${{ if eq(parameters.test_linux_x64, true) }}:

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-mac-webgpu-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-mac-webgpu-stage.yml
@@ -70,7 +70,7 @@ stages:
           --wgsl_template static \
           --disable_rtti \
           --enable_lto \
-          --cmake_extra_defines CMAKE_OSX_ARCHITECTURES=arm64 onnxruntime_BUILD_UNIT_TESTS=ON $(PluginEpVersionDefine) \
+          --cmake_extra_defines CMAKE_OSX_ARCHITECTURES=arm64 onnxruntime_BUILD_UNIT_TESTS=OFF $(PluginEpVersionDefine) \
           --update --skip_submodule_sync --build --parallel
       displayName: 'Build WebGPU Plugin'
 

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-win-webgpu-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-win-webgpu-stage.yml
@@ -218,56 +218,62 @@ stages:
           type nul > "$(Build.ArtifactStagingDirectory)\version\$(PluginPackageVersion)"
         displayName: 'Create version marker file'
 
-    # Python package jobs (x64 only — arm64 cross-compiled binaries can't be
-    # packaged or tested on x64 agents)
-    - ${{ if eq(parameters.arch, 'x64') }}:
-      # Python package build job
-      - job: Win_plugin_webgpu_${{ parameters.arch }}_Python_Package
-        dependsOn: Win_plugin_webgpu_${{ parameters.arch }}_Build
-        timeoutInMinutes: 30
-        workspace:
-          clean: all
-        pool:
+    # Python package build job. Runs on a host whose architecture matches
+    # ${{ parameters.arch }} so that the produced wheel is tagged for that
+    # arch (PlatformBdistWheel.get_tag() picks up the host platform).
+    - job: Win_plugin_webgpu_${{ parameters.arch }}_Python_Package
+      dependsOn: Win_plugin_webgpu_${{ parameters.arch }}_Build
+      timeoutInMinutes: 30
+      workspace:
+        clean: all
+      pool:
+        ${{ if eq(parameters.arch, 'arm64') }}:
+          name: onnxruntime-qnn-windows-vs-2022-arm64
+          os: windows
+          hostArchitecture: Arm64
+          demands:
+            - Agent.Version -equals 4.264.2
+        ${{ else }}:
           name: onnxruntime-Win-CPU-VS2022-Latest
           os: windows
-        templateContext:
-          outputs:
-          - output: pipelineArtifact
-            targetPath: '$(Build.ArtifactStagingDirectory)\python'
-            artifactName: webgpu_plugin_python_win_${{ parameters.arch }}
-        variables:
-        - template: ../templates/common-variables.yml
-        steps:
-        - checkout: self
-          clean: true
-          submodules: none
+      templateContext:
+        outputs:
+        - output: pipelineArtifact
+          targetPath: '$(Build.ArtifactStagingDirectory)\python'
+          artifactName: webgpu_plugin_python_win_${{ parameters.arch }}
+      variables:
+      - template: ../templates/common-variables.yml
+      steps:
+      - checkout: self
+        clean: true
+        submodules: none
 
-        - template: ../templates/setup-build-tools.yml
-          parameters:
-            host_cpu_arch: 'x64'
+      - template: ../templates/setup-build-tools.yml
+        parameters:
+          host_cpu_arch: ${{ parameters.arch }}
 
-        - template: ../templates/set-nightly-build-option-variable-step.yml
+      - template: ../templates/set-nightly-build-option-variable-step.yml
 
-        - template: ../templates/set-plugin-ep-build-variables-step.yml
-          parameters:
-            package_version: ${{ parameters.package_version }}
-            version_file: ${{ parameters.version_file }}
-            python_command: python
+      - template: ../templates/set-plugin-ep-build-variables-step.yml
+        parameters:
+          package_version: ${{ parameters.package_version }}
+          version_file: ${{ parameters.version_file }}
+          python_command: python
 
-        - task: DownloadPipelineArtifact@2
-          displayName: 'Download plugin build artifacts'
-          inputs:
-            artifactName: webgpu_plugin_win_${{ parameters.arch }}
-            targetPath: '$(Build.BinariesDirectory)\plugin_artifacts'
+      - task: DownloadPipelineArtifact@2
+        displayName: 'Download plugin build artifacts'
+        inputs:
+          artifactName: webgpu_plugin_win_${{ parameters.arch }}
+          targetPath: '$(Build.BinariesDirectory)\plugin_artifacts'
 
-        - task: PowerShell@2
-          displayName: 'Build Python wheel'
-          inputs:
-            targetType: inline
-            pwsh: true
-            script: |
-              python -m pip install -r "$(Build.SourcesDirectory)\plugin-ep-webgpu\python\requirements-build-wheel.txt"
-              python "$(Build.SourcesDirectory)\plugin-ep-webgpu\python\build_wheel.py" `
-                --binary_dir "$(Build.BinariesDirectory)\plugin_artifacts\bin" `
-                --version "$(PluginPythonPackageVersion)" `
-                --output_dir "$(Build.ArtifactStagingDirectory)\python"
+      - task: PowerShell@2
+        displayName: 'Build Python wheel'
+        inputs:
+          targetType: inline
+          pwsh: true
+          script: |
+            python -m pip install -r "$(Build.SourcesDirectory)\plugin-ep-webgpu\python\requirements-build-wheel.txt"
+            python "$(Build.SourcesDirectory)\plugin-ep-webgpu\python\build_wheel.py" `
+              --binary_dir "$(Build.BinariesDirectory)\plugin_artifacts\bin" `
+              --version "$(PluginPythonPackageVersion)" `
+              --output_dir "$(Build.ArtifactStagingDirectory)\python"

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-win-webgpu-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-win-webgpu-stage.yml
@@ -27,35 +27,33 @@ parameters:
 
 stages:
   - stage: Win_plugin_webgpu_${{ parameters.arch }}_Build
-    ${{ if eq(parameters.arch, 'arm64') }}:
-      # The ARM64 build consumes the x64 tblgen.exe artifact published by the Windows x64 stage.
-      dependsOn: Win_plugin_webgpu_x64_Build
-    ${{ else }}:
-      dependsOn: []
+    dependsOn: []
     jobs:
     - job: Win_plugin_webgpu_${{ parameters.arch }}_Build
       timeoutInMinutes: 360
       workspace:
         clean: all
       pool:
-        name: onnxruntime-Win-CPU-VS2022-Latest
-        os: windows
+        ${{ if eq(parameters.arch, 'arm64') }}:
+          name: onnxruntime-qnn-windows-vs-2022-arm64
+          os: windows
+          hostArchitecture: Arm64
+          demands:
+            - Agent.Version -equals 4.264.2
+        ${{ else }}:
+          name: onnxruntime-Win-CPU-VS2022-Latest
+          os: windows
       templateContext:
         sdl:
           codeSignValidation:
             enabled: true
             break: true
-            additionalTargetsGlobPattern: '-|**\clang-tblgen.exe;-|**\llvm-tblgen.exe'
           psscriptanalyzer:
             enabled: true
           binskim:
             enabled: true
             scanOutputDirectoryOnly: true
         outputs:
-        - ${{ if eq(parameters.arch, 'x64') }}:
-          - output: pipelineArtifact
-            targetPath: '$(Build.ArtifactStagingDirectory)\WebGPU_BuildTools'
-            artifactName: WebGPU_BuildTools_x64
         - output: pipelineArtifact
           targetPath: $(Build.ArtifactStagingDirectory)
           artifactName: webgpu_plugin_win_${{ parameters.arch }}
@@ -65,13 +63,6 @@ stages:
         value: '-Dorg.gradle.daemon=false'
       - name: VSGenerator
         value: 'Visual Studio 17 2022'
-      - name: CrossCompileDefines
-        value: ''
-      - name: ArchFlag
-        ${{ if eq(parameters.arch, 'arm64') }}:
-          value: '--arm64'
-        ${{ else }}:
-          value: ''
       steps:
       - checkout: self
         clean: true
@@ -79,7 +70,7 @@ stages:
 
       - template: ../templates/setup-build-tools.yml
         parameters:
-          host_cpu_arch: 'x64'
+          host_cpu_arch: ${{ parameters.arch }}
 
       - template: ../templates/set-nightly-build-option-variable-step.yml
 
@@ -95,28 +86,11 @@ stages:
         env:
           TMPDIR: "$(Agent.TempDirectory)"
 
-      - ${{ if eq(parameters.arch, 'arm64') }}:
-        - task: DownloadPipelineArtifact@2
-          displayName: 'Download WebGPU build tools from x64 build'
-          inputs:
-            artifactName: 'WebGPU_BuildTools_x64'
-            targetPath: '$(Build.BinariesDirectory)\WebGPU_BuildTools'
-        - script: |
-            @echo ##vso[task.setvariable variable=LLVM_TABLEGEN_PATH]$(Build.BinariesDirectory)\WebGPU_BuildTools\llvm-tblgen.exe
-            @echo ##vso[task.setvariable variable=CLANG_TABLEGEN_PATH]$(Build.BinariesDirectory)\WebGPU_BuildTools\clang-tblgen.exe
-          displayName: 'Set tablegen paths'
-        - powershell: |
-            Write-Host "Using LLVM_TABLEGEN_PATH: $(LLVM_TABLEGEN_PATH)"
-            Write-Host "Using CLANG_TABLEGEN_PATH: $(CLANG_TABLEGEN_PATH)"
-            Write-Host "##vso[task.setvariable variable=CrossCompileDefines]LLVM_TABLEGEN=$(LLVM_TABLEGEN_PATH) CLANG_TABLEGEN=$(CLANG_TABLEGEN_PATH)"
-          displayName: 'Set build flags for WebGPU cross-compilation'
-
       - task: PythonScript@0
         displayName: 'Build'
         inputs:
           scriptPath: '$(Build.SourcesDirectory)\tools\ci_build\build.py'
           arguments: >-
-            $(ArchFlag)
             --config ${{ parameters.cmake_build_type }}
             --build_dir $(Build.BinariesDirectory)
             --skip_submodule_sync
@@ -132,16 +106,9 @@ stages:
             --wgsl_template static
             --disable_rtti
             --enable_lto
-            --cmake_extra_defines onnxruntime_BUILD_UNIT_TESTS=OFF onnxruntime_ENABLE_DAWN_BACKEND_D3D12=1 onnxruntime_ENABLE_DAWN_BACKEND_VULKAN=1 $(PluginEpVersionDefine) $(CrossCompileDefines)
+            --cmake_extra_defines onnxruntime_BUILD_UNIT_TESTS=OFF onnxruntime_ENABLE_DAWN_BACKEND_D3D12=1 onnxruntime_ENABLE_DAWN_BACKEND_VULKAN=1 $(PluginEpVersionDefine)
             $(TelemetryOption)
           workingDirectory: '$(Build.BinariesDirectory)'
-
-      - ${{ if eq(parameters.arch, 'x64') }}:
-        - script: |
-            mkdir $(Build.ArtifactStagingDirectory)\WebGPU_BuildTools
-            copy $(Build.BinariesDirectory)\${{ parameters.cmake_build_type }}\_deps\dawn-build\third_party\dxc\${{ parameters.cmake_build_type }}\bin\llvm-tblgen.exe $(Build.ArtifactStagingDirectory)\WebGPU_BuildTools
-            copy $(Build.BinariesDirectory)\${{ parameters.cmake_build_type }}\_deps\dawn-build\third_party\dxc\${{ parameters.cmake_build_type }}\bin\clang-tblgen.exe $(Build.ArtifactStagingDirectory)\WebGPU_BuildTools
-          displayName: 'Copy WebGPU build tools'
 
       - powershell: |
           $dxcZipUrl = "https://github.com/microsoft/DirectXShaderCompiler/releases/download/v1.8.2502/dxc_2025_02_20.zip"

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-win-webgpu-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-win-webgpu-stage.yml
@@ -132,7 +132,7 @@ stages:
             --wgsl_template static
             --disable_rtti
             --enable_lto
-            --cmake_extra_defines onnxruntime_BUILD_UNIT_TESTS=ON onnxruntime_ENABLE_DAWN_BACKEND_D3D12=1 onnxruntime_ENABLE_DAWN_BACKEND_VULKAN=1 $(PluginEpVersionDefine) $(CrossCompileDefines)
+            --cmake_extra_defines onnxruntime_BUILD_UNIT_TESTS=OFF onnxruntime_ENABLE_DAWN_BACKEND_D3D12=1 onnxruntime_ENABLE_DAWN_BACKEND_VULKAN=1 $(PluginEpVersionDefine) $(CrossCompileDefines)
             $(TelemetryOption)
           workingDirectory: '$(Build.BinariesDirectory)'
 

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-win-webgpu-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-win-webgpu-stage.yml
@@ -266,14 +266,10 @@ stages:
           artifactName: webgpu_plugin_win_${{ parameters.arch }}
           targetPath: '$(Build.BinariesDirectory)\plugin_artifacts'
 
-      - task: PowerShell@2
+      - powershell: |
+          python -m pip install -r "$(Build.SourcesDirectory)\plugin-ep-webgpu\python\requirements-build-wheel.txt"
+          python "$(Build.SourcesDirectory)\plugin-ep-webgpu\python\build_wheel.py" `
+            --binary_dir "$(Build.BinariesDirectory)\plugin_artifacts\bin" `
+            --version "$(PluginPythonPackageVersion)" `
+            --output_dir "$(Build.ArtifactStagingDirectory)\python"
         displayName: 'Build Python wheel'
-        inputs:
-          targetType: inline
-          pwsh: true
-          script: |
-            python -m pip install -r "$(Build.SourcesDirectory)\plugin-ep-webgpu\python\requirements-build-wheel.txt"
-            python "$(Build.SourcesDirectory)\plugin-ep-webgpu\python\build_wheel.py" `
-              --binary_dir "$(Build.BinariesDirectory)\plugin_artifacts\bin" `
-              --version "$(PluginPythonPackageVersion)" `
-              --output_dir "$(Build.ArtifactStagingDirectory)\python"

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-win-webgpu-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-win-webgpu-stage.yml
@@ -27,35 +27,33 @@ parameters:
 
 stages:
   - stage: Win_plugin_webgpu_${{ parameters.arch }}_Build
-    ${{ if eq(parameters.arch, 'arm64') }}:
-      # The ARM64 build consumes the x64 tblgen.exe artifact published by the Windows x64 stage.
-      dependsOn: Win_plugin_webgpu_x64_Build
-    ${{ else }}:
-      dependsOn: []
+    dependsOn: []
     jobs:
     - job: Win_plugin_webgpu_${{ parameters.arch }}_Build
       timeoutInMinutes: 360
       workspace:
         clean: all
       pool:
-        name: onnxruntime-Win-CPU-VS2022-Latest
-        os: windows
+        ${{ if eq(parameters.arch, 'arm64') }}:
+          name: onnxruntime-qnn-windows-vs-2022-arm64
+          os: windows
+          hostArchitecture: Arm64
+          demands:
+            - Agent.Version -equals 4.264.2
+        ${{ else }}:
+          name: onnxruntime-Win-CPU-VS2022-Latest
+          os: windows
       templateContext:
         sdl:
           codeSignValidation:
             enabled: true
             break: true
-            additionalTargetsGlobPattern: '-|**\clang-tblgen.exe;-|**\llvm-tblgen.exe'
           psscriptanalyzer:
             enabled: true
           binskim:
             enabled: true
             scanOutputDirectoryOnly: true
         outputs:
-        - ${{ if eq(parameters.arch, 'x64') }}:
-          - output: pipelineArtifact
-            targetPath: '$(Build.ArtifactStagingDirectory)\WebGPU_BuildTools'
-            artifactName: WebGPU_BuildTools_x64
         - output: pipelineArtifact
           targetPath: $(Build.ArtifactStagingDirectory)
           artifactName: webgpu_plugin_win_${{ parameters.arch }}
@@ -65,13 +63,6 @@ stages:
         value: '-Dorg.gradle.daemon=false'
       - name: VSGenerator
         value: 'Visual Studio 17 2022'
-      - name: CrossCompileDefines
-        value: ''
-      - name: ArchFlag
-        ${{ if eq(parameters.arch, 'arm64') }}:
-          value: '--arm64'
-        ${{ else }}:
-          value: ''
       steps:
       - checkout: self
         clean: true
@@ -79,7 +70,7 @@ stages:
 
       - template: ../templates/setup-build-tools.yml
         parameters:
-          host_cpu_arch: 'x64'
+          host_cpu_arch: ${{ parameters.arch }}
 
       - template: ../templates/set-nightly-build-option-variable-step.yml
 
@@ -95,28 +86,11 @@ stages:
         env:
           TMPDIR: "$(Agent.TempDirectory)"
 
-      - ${{ if eq(parameters.arch, 'arm64') }}:
-        - task: DownloadPipelineArtifact@2
-          displayName: 'Download WebGPU build tools from x64 build'
-          inputs:
-            artifactName: 'WebGPU_BuildTools_x64'
-            targetPath: '$(Build.BinariesDirectory)\WebGPU_BuildTools'
-        - script: |
-            @echo ##vso[task.setvariable variable=LLVM_TABLEGEN_PATH]$(Build.BinariesDirectory)\WebGPU_BuildTools\llvm-tblgen.exe
-            @echo ##vso[task.setvariable variable=CLANG_TABLEGEN_PATH]$(Build.BinariesDirectory)\WebGPU_BuildTools\clang-tblgen.exe
-          displayName: 'Set tablegen paths'
-        - powershell: |
-            Write-Host "Using LLVM_TABLEGEN_PATH: $(LLVM_TABLEGEN_PATH)"
-            Write-Host "Using CLANG_TABLEGEN_PATH: $(CLANG_TABLEGEN_PATH)"
-            Write-Host "##vso[task.setvariable variable=CrossCompileDefines]LLVM_TABLEGEN=$(LLVM_TABLEGEN_PATH) CLANG_TABLEGEN=$(CLANG_TABLEGEN_PATH)"
-          displayName: 'Set build flags for WebGPU cross-compilation'
-
       - task: PythonScript@0
         displayName: 'Build'
         inputs:
           scriptPath: '$(Build.SourcesDirectory)\tools\ci_build\build.py'
           arguments: >-
-            $(ArchFlag)
             --config ${{ parameters.cmake_build_type }}
             --build_dir $(Build.BinariesDirectory)
             --skip_submodule_sync
@@ -132,16 +106,9 @@ stages:
             --wgsl_template static
             --disable_rtti
             --enable_lto
-            --cmake_extra_defines onnxruntime_BUILD_UNIT_TESTS=ON onnxruntime_ENABLE_DAWN_BACKEND_D3D12=1 onnxruntime_ENABLE_DAWN_BACKEND_VULKAN=1 $(PluginEpVersionDefine) $(CrossCompileDefines)
+            --cmake_extra_defines onnxruntime_BUILD_UNIT_TESTS=ON onnxruntime_ENABLE_DAWN_BACKEND_D3D12=1 onnxruntime_ENABLE_DAWN_BACKEND_VULKAN=1 $(PluginEpVersionDefine)
             $(TelemetryOption)
           workingDirectory: '$(Build.BinariesDirectory)'
-
-      - ${{ if eq(parameters.arch, 'x64') }}:
-        - script: |
-            mkdir $(Build.ArtifactStagingDirectory)\WebGPU_BuildTools
-            copy $(Build.BinariesDirectory)\${{ parameters.cmake_build_type }}\_deps\dawn-build\third_party\dxc\${{ parameters.cmake_build_type }}\bin\llvm-tblgen.exe $(Build.ArtifactStagingDirectory)\WebGPU_BuildTools
-            copy $(Build.BinariesDirectory)\${{ parameters.cmake_build_type }}\_deps\dawn-build\third_party\dxc\${{ parameters.cmake_build_type }}\bin\clang-tblgen.exe $(Build.ArtifactStagingDirectory)\WebGPU_BuildTools
-          displayName: 'Copy WebGPU build tools'
 
       - powershell: |
           $dxcZipUrl = "https://github.com/microsoft/DirectXShaderCompiler/releases/download/v1.8.2502/dxc_2025_02_20.zip"

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-win-webgpu-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-win-webgpu-stage.yml
@@ -223,7 +223,7 @@ stages:
     # arch (PlatformBdistWheel.get_tag() picks up the host platform).
     - job: Win_plugin_webgpu_${{ parameters.arch }}_Python_Package
       dependsOn: Win_plugin_webgpu_${{ parameters.arch }}_Build
-      timeoutInMinutes: 30
+      timeoutInMinutes: 60
       workspace:
         clean: all
       pool:

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-win-webgpu-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-win-webgpu-stage.yml
@@ -27,33 +27,35 @@ parameters:
 
 stages:
   - stage: Win_plugin_webgpu_${{ parameters.arch }}_Build
-    dependsOn: []
+    ${{ if eq(parameters.arch, 'arm64') }}:
+      # The ARM64 build consumes the x64 tblgen.exe artifact published by the Windows x64 stage.
+      dependsOn: Win_plugin_webgpu_x64_Build
+    ${{ else }}:
+      dependsOn: []
     jobs:
     - job: Win_plugin_webgpu_${{ parameters.arch }}_Build
       timeoutInMinutes: 360
       workspace:
         clean: all
       pool:
-        ${{ if eq(parameters.arch, 'arm64') }}:
-          name: onnxruntime-qnn-windows-vs-2022-arm64
-          os: windows
-          hostArchitecture: Arm64
-          demands:
-            - Agent.Version -equals 4.264.2
-        ${{ else }}:
-          name: onnxruntime-Win-CPU-VS2022-Latest
-          os: windows
+        name: onnxruntime-Win-CPU-VS2022-Latest
+        os: windows
       templateContext:
         sdl:
           codeSignValidation:
             enabled: true
             break: true
+            additionalTargetsGlobPattern: '-|**\clang-tblgen.exe;-|**\llvm-tblgen.exe'
           psscriptanalyzer:
             enabled: true
           binskim:
             enabled: true
             scanOutputDirectoryOnly: true
         outputs:
+        - ${{ if eq(parameters.arch, 'x64') }}:
+          - output: pipelineArtifact
+            targetPath: '$(Build.ArtifactStagingDirectory)\WebGPU_BuildTools'
+            artifactName: WebGPU_BuildTools_x64
         - output: pipelineArtifact
           targetPath: $(Build.ArtifactStagingDirectory)
           artifactName: webgpu_plugin_win_${{ parameters.arch }}
@@ -63,6 +65,13 @@ stages:
         value: '-Dorg.gradle.daemon=false'
       - name: VSGenerator
         value: 'Visual Studio 17 2022'
+      - name: CrossCompileDefines
+        value: ''
+      - name: ArchFlag
+        ${{ if eq(parameters.arch, 'arm64') }}:
+          value: '--arm64'
+        ${{ else }}:
+          value: ''
       steps:
       - checkout: self
         clean: true
@@ -70,7 +79,7 @@ stages:
 
       - template: ../templates/setup-build-tools.yml
         parameters:
-          host_cpu_arch: ${{ parameters.arch }}
+          host_cpu_arch: 'x64'
 
       - template: ../templates/set-nightly-build-option-variable-step.yml
 
@@ -86,11 +95,28 @@ stages:
         env:
           TMPDIR: "$(Agent.TempDirectory)"
 
+      - ${{ if eq(parameters.arch, 'arm64') }}:
+        - task: DownloadPipelineArtifact@2
+          displayName: 'Download WebGPU build tools from x64 build'
+          inputs:
+            artifactName: 'WebGPU_BuildTools_x64'
+            targetPath: '$(Build.BinariesDirectory)\WebGPU_BuildTools'
+        - script: |
+            @echo ##vso[task.setvariable variable=LLVM_TABLEGEN_PATH]$(Build.BinariesDirectory)\WebGPU_BuildTools\llvm-tblgen.exe
+            @echo ##vso[task.setvariable variable=CLANG_TABLEGEN_PATH]$(Build.BinariesDirectory)\WebGPU_BuildTools\clang-tblgen.exe
+          displayName: 'Set tablegen paths'
+        - powershell: |
+            Write-Host "Using LLVM_TABLEGEN_PATH: $(LLVM_TABLEGEN_PATH)"
+            Write-Host "Using CLANG_TABLEGEN_PATH: $(CLANG_TABLEGEN_PATH)"
+            Write-Host "##vso[task.setvariable variable=CrossCompileDefines]LLVM_TABLEGEN=$(LLVM_TABLEGEN_PATH) CLANG_TABLEGEN=$(CLANG_TABLEGEN_PATH)"
+          displayName: 'Set build flags for WebGPU cross-compilation'
+
       - task: PythonScript@0
         displayName: 'Build'
         inputs:
           scriptPath: '$(Build.SourcesDirectory)\tools\ci_build\build.py'
           arguments: >-
+            $(ArchFlag)
             --config ${{ parameters.cmake_build_type }}
             --build_dir $(Build.BinariesDirectory)
             --skip_submodule_sync
@@ -106,9 +132,16 @@ stages:
             --wgsl_template static
             --disable_rtti
             --enable_lto
-            --cmake_extra_defines onnxruntime_BUILD_UNIT_TESTS=ON onnxruntime_ENABLE_DAWN_BACKEND_D3D12=1 onnxruntime_ENABLE_DAWN_BACKEND_VULKAN=1 $(PluginEpVersionDefine)
+            --cmake_extra_defines onnxruntime_BUILD_UNIT_TESTS=ON onnxruntime_ENABLE_DAWN_BACKEND_D3D12=1 onnxruntime_ENABLE_DAWN_BACKEND_VULKAN=1 $(PluginEpVersionDefine) $(CrossCompileDefines)
             $(TelemetryOption)
           workingDirectory: '$(Build.BinariesDirectory)'
+
+      - ${{ if eq(parameters.arch, 'x64') }}:
+        - script: |
+            mkdir $(Build.ArtifactStagingDirectory)\WebGPU_BuildTools
+            copy $(Build.BinariesDirectory)\${{ parameters.cmake_build_type }}\_deps\dawn-build\third_party\dxc\${{ parameters.cmake_build_type }}\bin\llvm-tblgen.exe $(Build.ArtifactStagingDirectory)\WebGPU_BuildTools
+            copy $(Build.BinariesDirectory)\${{ parameters.cmake_build_type }}\_deps\dawn-build\third_party\dxc\${{ parameters.cmake_build_type }}\bin\clang-tblgen.exe $(Build.ArtifactStagingDirectory)\WebGPU_BuildTools
+          displayName: 'Copy WebGPU build tools'
 
       - powershell: |
           $dxcZipUrl = "https://github.com/microsoft/DirectXShaderCompiler/releases/download/v1.8.2502/dxc_2025_02_20.zip"

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-win-webgpu-test-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-win-webgpu-test-stage.yml
@@ -38,9 +38,7 @@ stages:
       artifact: webgpu_plugin_python_win_${{ parameters.arch }}
       displayName: 'Download Python wheel'
 
-    - pwsh: |
-        $ErrorActionPreference = 'Stop'
-
+    - powershell: |
         echo "creating test_venv"
         python -m venv "$(Build.BinariesDirectory)\test_venv"
 
@@ -91,8 +89,7 @@ stages:
 
       # Set up local NuGet feed and extract the package version from the .nupkg filename
       # so the test project can pin to it (instead of resolving via a floating version).
-      - pwsh: |
-          $ErrorActionPreference = 'Stop'
+      - powershell: |
           $localFeedDir = "$(Build.BinariesDirectory)\local_feed"
           New-Item -ItemType Directory -Path $localFeedDir -Force | Out-Null
 
@@ -134,7 +131,7 @@ stages:
           Get-ChildItem $localFeedDir | ForEach-Object { Write-Host "  $($_.Name)" }
         displayName: 'Set up local NuGet feed'
 
-      - pwsh: |
+      - powershell: |
           dotnet build `
             "$(WebGpuTestProject)" `
             --configuration Release `
@@ -142,7 +139,7 @@ stages:
             -p:OrtCoreTestVersion=$(OrtCoreTestVersion)
         displayName: 'Build test project'
 
-      - pwsh: |
+      - powershell: |
           dotnet run `
             --project "$(WebGpuTestProject)" `
             --configuration Release `

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-win-webgpu-test-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-win-webgpu-test-stage.yml
@@ -14,8 +14,15 @@ stages:
     workspace:
       clean: all
     pool:
-      name: onnxruntime-Win2022-VS2022-webgpu-A10
-      os: windows
+      ${{ if eq(parameters.arch, 'arm64') }}:
+        name: onnxruntime-qnn-windows-vs-2022-arm64
+        os: windows
+        hostArchitecture: Arm64
+        demands:
+          - Agent.Version -equals 4.264.2
+      ${{ else }}:
+        name: onnxruntime-Win2022-VS2022-webgpu-A10
+        os: windows
     steps:
     - checkout: self
       clean: true

--- a/tools/ci_build/github/linux/build_webgpu_plugin_package.sh
+++ b/tools/ci_build/github/linux/build_webgpu_plugin_package.sh
@@ -49,4 +49,4 @@ docker run --rm \
         --use_vcpkg_ms_internal_asset_cache \
         --update \
         --build \
-        --cmake_extra_defines onnxruntime_BUILD_UNIT_TESTS=ON ${EXTRA_CMAKE_DEFINES}"
+        --cmake_extra_defines onnxruntime_BUILD_UNIT_TESTS=OFF ${EXTRA_CMAKE_DEFINES}"


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

- Add WebGPU plugin EP Windows ARM64 Python package build and test
- Disable unit test building in packaging pipeline to reduce build time

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Add Windows ARM64 Python package.