### PR TITLE
Fix MLAS LUT GEMM to support 2-bit MatMulNBits with N not divisible by 128

### DIFF
--- a/onnxruntime/core/mlas/lib/qlutgemm.cpp
+++ b/onnxruntime/core/mlas/lib/qlutgemm.cpp
@@ -124,7 +124,7 @@ MlasInitLutGemmKernelConfig(size_t M, size_t N, size_t nbits, size_t block_size,
     // search space
     std::vector<size_t> bms;
     if (nbits == 1 || nbits == 2 || nbits == 4) {
-        bms = {256, 512, 1024, 2048, 320, 640, 1280};
+        bms = {128, 256, 512, 1024, 2048, 320, 640, 1280};
     } else if (nbits == 3) {
         bms = {192, 384, 576, 758};
     }
@@ -367,7 +367,7 @@ MlasIsLutGemmAvailable(
             n_div = 256;
             break;
         case 2:
-            n_div = 128;
+            n_div = 64;
             break;
         case 3:
             n_div = 64;

--- a/onnxruntime/test/mlas/unittest/test_sqlutgemm.cpp
+++ b/onnxruntime/test/mlas/unittest/test_sqlutgemm.cpp
@@ -215,6 +215,11 @@ class SQLutGemmShortExecuteTest : public MlasTestFixture<MlasSQLutGemmTest<BlkBi
 
         count += RegisterSingleTest(1, 128, 128, with_threadpool, symmetric);
         count += RegisterSingleTest(1, 1024, 1024, with_threadpool, symmetric);
+
+        // Test N values that require bm=128 (N not divisible by 128 but divisible by 64)
+        count += RegisterSingleTest(1, 192, 1024, with_threadpool, symmetric);
+        count += RegisterSingleTest(1, 192, 64, with_threadpool, symmetric);
+        count += RegisterSingleTest(1, 64, 64, with_threadpool, symmetric);
       }
     }
     return count;


### PR DESCRIPTION
### Description

Fixes a performance regression where 2-bit quantized models with MatMulNBits nodes having N=192 (or any N divisible by 64 but not 128) fall back to slow FP32 dequantization on CPU EP instead of using the MLAS LUT GEMM kernel.

**Root cause:** The LUT GEMM availability check (\MlasIsLutGemmAvailable\) required \N % 128 == 0\ for 2-bit, and the tile-size search space (\ms\) had no value where \m/2\ divides 192. This caused 40 out of 120 MatMulNBits nodes in the affected model to bypass the LUT kernel entirely.

**Fix:**
- Add m=128 to the tile-size search space (gives tile size \m=64\, and \192 % 64 = 0\)
- Lower \
_div\ for 2-bit from 128 to 64 in \MlasIsLutGemmAvailable\
- Add unit tests for N=192 and N=64

**Note:** The existing penalty heuristic may now select \m=128\ for some shapes that previously used \m=256\ (e.g., N=384, N=1024). This reflects better thread utilization. Benchmarking across representative shapes is recommended.

### Motivation and Context

A 2-bit model benchmarked on AMD Ryzen AI 7 PRO 350 showed ~10x slower inference on CPU EP (225ms vs 21ms at seq=32) compared to the equivalent 4-bit model, because the LUT kernel rejected N=192 nodes.

### Testing
- Added MLAS unit tests for N=192 (with K=1024 and K=64) and N=64, across symmetric and asymmetric quantization
- Existing LUT GEMM tests continue to pass