### PR TITLE
Reserve WebGPU program vector capacity

### DIFF
--- a/onnxruntime/core/providers/webgpu/nn/conv.cc
+++ b/onnxruntime/core/providers/webgpu/nn/conv.cc
@@ -102,6 +102,9 @@ Status Conv<is_channels_last, is_fused>::ComputeInternal(ComputeContext& context
     const auto x_channels = static_cast<uint32_t>(input_shape[is_channels_last ? 4 : 1]);
     Conv3DNaiveProgram program(activation_, has_bias, is_channels_last);
     program.CacheHint(activation_.ToString(), std::to_string(is_channels_last))
+        .ReserveInputCapacity(has_bias ? 3 : 2)
+        .ReserveOutputCapacity(1)
+        .ReserveUniformVariableCapacity(7)
         .AddInput({input, ProgramTensorMetadataDependency::TypeAndRank, input_shape, 1})
         .AddInput({kernel, ProgramTensorMetadataDependency::TypeAndRank, kernel_shape, 1})
         .AddOutput({output, ProgramTensorMetadataDependency::TypeAndRank, output_shape, 1})
@@ -191,6 +194,9 @@ Status Conv<is_channels_last, is_fused>::ComputeInternal(ComputeContext& context
     auto reduced_kernel_shape = ReduceShapeByComponents(modified_input_output_shapes[1], components);
     auto reduced_output_shape = ReduceShapeByComponents(modified_input_output_shapes[has_bias ? 3 : 2], components);
     program.CacheHint(activation_.ToString(), std::to_string(components), std::to_string(is_channels_last))
+        .ReserveInputCapacity(has_bias ? 3 : 2)
+        .ReserveOutputCapacity(1)
+        .ReserveUniformVariableCapacity(6)
         .AddInput({inputs[0], ProgramTensorMetadataDependency::TypeAndRank, modified_input_output_shapes[0], 1})
         .AddInput({inputs[1], ProgramTensorMetadataDependency::TypeAndRank, reduced_kernel_shape, components})
         .AddOutput({output, ProgramTensorMetadataDependency::TypeAndRank, reduced_output_shape, components})
@@ -258,6 +264,9 @@ Status Conv<is_channels_last, is_fused>::ComputeInternal(ComputeContext& context
       MatMulNaiveProgram program(activation_, output_rank, output_number, has_bias, is_channels_last);
       program
           .CacheHint(std::to_string(components), std::to_string(a_components), std::to_string(output_number))
+          .ReserveInputCapacity(has_bias ? 3 : 2)
+          .ReserveOutputCapacity(1)
+          .ReserveUniformVariableCapacity(4)
           .AddInputs({{matmul_inputs[0], ProgramTensorMetadataDependency::TypeAndRank, ReduceShapeByComponents(matmul_input_reshapes[0], a_components), int(a_components)},
                       {matmul_inputs[1], ProgramTensorMetadataDependency::TypeAndRank, ReduceShapeByComponents(matmul_input_reshapes[1], components), int(components)}});
       if (has_bias) {

--- a/onnxruntime/core/providers/webgpu/nn/conv2d_mm.cc
+++ b/onnxruntime/core/providers/webgpu/nn/conv2d_mm.cc
@@ -207,6 +207,9 @@ Conv2dMMProgram CreateConv2dMMProgram(const Activation& activation, const std::v
   TensorShape reduced_input_shape = ReduceShapeByComponents(input_output_shapes[0], input_components);
   TensorShape reduced_weight_shape = ReduceShapeByComponents(input_output_shapes[1], components);
   TensorShape reduced_output_shape = ReduceShapeByComponents(input_output_shapes[has_bias ? 3 : 2], components);
+  program.ReserveInputCapacity(has_bias ? 3 : 2)
+      .ReserveOutputCapacity(1)
+      .ReserveUniformVariableCapacity(9);
   program.AddInputs({{input, ProgramTensorMetadataDependency::TypeAndRank, reduced_input_shape, input_components}, {weight, ProgramTensorMetadataDependency::TypeAndRank, reduced_weight_shape, components}});
   if (has_bias) {
     TensorShape reduced_bias_shape = ReduceShapeByComponents(input_output_shapes[2], components);

--- a/onnxruntime/core/providers/webgpu/program.cc
+++ b/onnxruntime/core/providers/webgpu/program.cc
@@ -339,7 +339,13 @@ ProgramBase& ProgramBase::AddInput(ProgramInput&& input) {
 }
 
 ProgramBase& ProgramBase::AddInputs(std::initializer_list<ProgramInput> inputs) {
+  inputs_.reserve(inputs_.size() + inputs.size());
   inputs_.insert(inputs_.end(), inputs.begin(), inputs.end());
+  return *this;
+}
+
+ProgramBase& ProgramBase::ReserveInputCapacity(size_t capacity) {
+  inputs_.reserve(capacity);
   return *this;
 }
 
@@ -349,7 +355,13 @@ ProgramBase& ProgramBase::AddOutput(ProgramOutput&& output) {
 }
 
 ProgramBase& ProgramBase::AddOutputs(std::initializer_list<ProgramOutput> outputs) {
+  outputs_.reserve(outputs_.size() + outputs.size());
   outputs_.insert(outputs_.end(), outputs.begin(), outputs.end());
+  return *this;
+}
+
+ProgramBase& ProgramBase::ReserveOutputCapacity(size_t capacity) {
+  outputs_.reserve(capacity);
   return *this;
 }
 
@@ -395,7 +407,13 @@ ProgramBase& ProgramBase::AddUniformVariable(ProgramUniformVariableValue&& varia
 }
 
 ProgramBase& ProgramBase::AddUniformVariables(std::initializer_list<ProgramUniformVariableValue> variables) {
+  variables_.reserve(variables_.size() + variables.size());
   variables_.insert(variables_.end(), variables.begin(), variables.end());
+  return *this;
+}
+
+ProgramBase& ProgramBase::ReserveUniformVariableCapacity(size_t capacity) {
+  variables_.reserve(capacity);
   return *this;
 }
 

--- a/onnxruntime/core/providers/webgpu/program.h
+++ b/onnxruntime/core/providers/webgpu/program.h
@@ -4,9 +4,10 @@
 #pragma once
 
 #include <array>
+#include <cstddef>
+#include <iosfwd>
 #include <string>
 #include <vector>
-#include <iosfwd>
 
 #ifdef _MSC_VER
 #pragma warning(push)
@@ -296,10 +297,14 @@ class ProgramBase {
   ProgramBase& AddInput(ProgramInput&& input);
   // add multiple program inputs
   ProgramBase& AddInputs(std::initializer_list<ProgramInput> inputs);
+  // reserve storage for program inputs
+  ProgramBase& ReserveInputCapacity(size_t capacity);
   // add a program output
   ProgramBase& AddOutput(ProgramOutput&& output);
   // add multiple program outputs
   ProgramBase& AddOutputs(std::initializer_list<ProgramOutput> outputs);
+  // reserve storage for program outputs
+  ProgramBase& ReserveOutputCapacity(size_t capacity);
   // add a program variable for indices
   template <typename... Args>
   ProgramBase& AddIndices(Args&&... args) {
@@ -334,6 +339,8 @@ class ProgramBase {
   // the specified uniform variables should match the uniform definition in the class,
   // specified by macro WEBGPU_PROGRAM_DEFINE_UNIFORM_VARIABLES.
   ProgramBase& AddUniformVariables(std::initializer_list<ProgramUniformVariableValue> variables);
+  // reserve storage for uniform variables
+  ProgramBase& ReserveUniformVariableCapacity(size_t capacity);
 
   // set the overridable constants
   //

--- a/onnxruntime/core/providers/webgpu/program_test.cc
+++ b/onnxruntime/core/providers/webgpu/program_test.cc
@@ -5,6 +5,9 @@
 // These static_asserts verify that is_const_std_array, the has_member_* variable templates,
 // and has_*_correct_type concepts correctly detect static const std::array members.
 
+#include <type_traits>
+#include <utility>
+
 #include "core/providers/webgpu/program.h"
 
 namespace onnxruntime {
@@ -29,6 +32,13 @@ static_assert(is_const_std_array<const std::array<int, 0>>::value);
 struct NoMembers {};
 static_assert(!has_member_constants<NoMembers>);
 static_assert(!has_constants_correct_type<NoMembers>);
+
+static_assert(std::is_same_v<decltype(std::declval<ProgramBase&>().ReserveInputCapacity(size_t{0})),
+                             ProgramBase&>);
+static_assert(std::is_same_v<decltype(std::declval<ProgramBase&>().ReserveOutputCapacity(size_t{0})),
+                             ProgramBase&>);
+static_assert(std::is_same_v<decltype(std::declval<ProgramBase&>().ReserveUniformVariableCapacity(size_t{0})),
+                             ProgramBase&>);
 
 struct Constants_WrongName {
   static constexpr std::array<int, 1> not_constants = {1};


### PR DESCRIPTION
Fixes #28516

## Summary
- add `ProgramBase` reserve helpers for inputs, outputs, and uniform variables
- reserve capacity when bulk-adding inputs, outputs, and uniform variables
- apply explicit capacity hints in WebGPU convolution program setup paths
- add compile-time checks that the new reserve helpers preserve chain-style `ProgramBase&` returns

## Validation
- `git diff --check`
- `PATH="$PWD/.venv/bin:$PATH" .venv/bin/lintrunner -a onnxruntime/core/providers/webgpu/program.h onnxruntime/core/providers/webgpu/program.cc onnxruntime/core/providers/webgpu/program_test.cc onnxruntime/core/providers/webgpu/nn/conv.cc onnxruntime/core/providers/webgpu/nn/conv2d_mm.cc`
- `PATH="$PWD/.venv/bin:$PATH" python3 tools/ci_build/build.py --build_dir /private/tmp/ort-webgpu-build --config Release --update --use_webgpu --cmake_path "$PWD/.venv/bin/cmake" --cmake_generator Ninja --skip_tests`
- `PATH="$PWD/.venv/bin:$PATH" .venv/bin/ninja -C /private/tmp/ort-webgpu-build/Release onnxruntime_providers_webgpu`
- `PATH="$PWD/.venv/bin:$PATH" .venv/bin/ninja -C /private/tmp/ort-webgpu-build/Release onnxruntime_test_all onnxruntime_provider_test onnx_test_runner`
- `PATH="$PWD/.venv/bin:$PATH" .venv/bin/ctest --test-dir /private/tmp/ort-webgpu-build/Release --output-on-failure`

CTest note: `onnx_test_pytorch_converted` and `onnx_test_pytorch_operator` passed locally. `onnxruntime_test_all` and `onnxruntime_provider_test` built successfully but abort on this local macOS environment because Dawn reports `Failed to get a WebGPU adapter: No supported adapters` while initializing the WebGPU EP, before completing the suite.
