### PR TITLE
Skip SetupDi device discovery if Win32k system calls are disabled

### DIFF
--- a/onnxruntime/core/platform/windows/device_discovery.cc
+++ b/onnxruntime/core/platform/windows/device_discovery.cc
@@ -547,7 +547,7 @@ bool Win32kSystemCallsDisallowed() {
   PROCESS_MITIGATION_SYSTEM_CALL_DISABLE_POLICY policy = {};
   if (GetProcessMitigationPolicy(GetCurrentProcess(), ProcessSystemCallDisablePolicy,
                                  &policy, sizeof(policy))) {
-    return policy.Win32kSystemCallsDisallowed != 0;
+    return policy.DisallowWin32kSystemCalls != 0;
   }
   const auto error_code = ::GetLastError();
   LOGS_DEFAULT(ERROR) << "GetProcessMitigationPolicy failed errcode = " << error_code

--- a/onnxruntime/core/platform/windows/device_discovery.cc
+++ b/onnxruntime/core/platform/windows/device_discovery.cc
@@ -539,6 +539,18 @@ DeviceInfo GetDeviceInfoCPUID() {
 
   return cpu_info;
 }
+
+// Returns true if the Win32k system calls are disabled (e.g., in a sandboxed process), in which case calling
+// SetupDiGetClassDevs will throw an SEH exception.
+bool DisallowWin32kSystemCalls() {
+  PROCESS_MITIGATION_SYSTEM_CALL_DISABLE_POLICY policy = {};
+  if (GetProcessMitigationPolicy(GetCurrentProcess(), ProcessSystemCallDisablePolicy,
+                                 &policy, sizeof(policy))) {
+    return policy.DisallowWin32kSystemCalls != 0;
+  }
+  return false;
+}
+
 }  // namespace
 
 // Get devices from various sources and combine them into a single set of devices.
@@ -557,7 +569,12 @@ std::unordered_set<OrtHardwareDevice> DeviceDiscovery::DiscoverDevicesForPlatfor
 
   // setupapi_info. key is vendor_id+device_id
   bool have_remote_display_adapter = false;  // set if we see the RdpIdd_IndirectDisplay hardware ID.
-  std::unordered_map<uint64_t, DeviceInfo> setupapi_info = GetDeviceInfoSetupApi(npus, have_remote_display_adapter);
+  std::unordered_map<uint64_t, DeviceInfo> setupapi_info;
+  if (!DisallowWin32kSystemCalls()) {
+    setupapi_info = GetDeviceInfoSetupApi(npus, have_remote_display_adapter);
+  } else {
+    LOGS_DEFAULT(INFO) << "Skip SetupDi device discovery due to Win32k lockdown.";
+  }
 
   // d3d12 info. key is luid
   std::unordered_map<uint64_t, DeviceInfo> luid_to_d3d12_info = GetDeviceInfoD3D12(have_remote_display_adapter);

--- a/onnxruntime/core/platform/windows/device_discovery.cc
+++ b/onnxruntime/core/platform/windows/device_discovery.cc
@@ -542,11 +542,11 @@ DeviceInfo GetDeviceInfoCPUID() {
 
 // Returns true if the Win32k system calls are disabled (e.g., in a sandboxed process), in which case calling
 // SetupDiGetClassDevs will throw an SEH exception.
-bool DisallowWin32kSystemCalls() {
+bool Win32kSystemCallsDisallowed() {
   PROCESS_MITIGATION_SYSTEM_CALL_DISABLE_POLICY policy = {};
   if (GetProcessMitigationPolicy(GetCurrentProcess(), ProcessSystemCallDisablePolicy,
                                  &policy, sizeof(policy))) {
-    return policy.DisallowWin32kSystemCalls != 0;
+    return policy.Win32kSystemCallsDisallowed != 0;
   }
   return false;
 }
@@ -570,7 +570,7 @@ std::unordered_set<OrtHardwareDevice> DeviceDiscovery::DiscoverDevicesForPlatfor
   // setupapi_info. key is vendor_id+device_id
   bool have_remote_display_adapter = false;  // set if we see the RdpIdd_IndirectDisplay hardware ID.
   std::unordered_map<uint64_t, DeviceInfo> setupapi_info;
-  if (!DisallowWin32kSystemCalls()) {
+  if (!Win32kSystemCallsDisallowed()) {
     setupapi_info = GetDeviceInfoSetupApi(npus, have_remote_display_adapter);
   } else {
     LOGS_DEFAULT(INFO) << "Skip SetupDi device discovery due to Win32k lockdown.";

--- a/onnxruntime/core/platform/windows/device_discovery.cc
+++ b/onnxruntime/core/platform/windows/device_discovery.cc
@@ -8,6 +8,7 @@
 #include <codecvt>
 #include <locale>
 #include <string>
+#include <system_error>
 #include <unordered_set>
 
 #include "core/common/cpuid_info.h"
@@ -548,6 +549,9 @@ bool Win32kSystemCallsDisallowed() {
                                  &policy, sizeof(policy))) {
     return policy.Win32kSystemCallsDisallowed != 0;
   }
+  const auto error_code = ::GetLastError();
+  LOGS_DEFAULT(ERROR) << "GetProcessMitigationPolicy failed errcode = " << error_code
+                      << " - " << std::system_category().message(error_code);
   return false;
 }
 


### PR DESCRIPTION
### Description
Skip SetupDi device discovery when Win32k system calls are disabled. `SetupDiGetClassDevs` depends on win32k.sys and will crash with an SEH exception that cannot be caught by C++ try/catch.

```
00 0000004f`545fb2b0 00007ffa`a47a8911     KERNELBASE!RaiseException+0x8a
01 0000004f`545fb3b0 00007ffa`a47e014d     SETUPAPI!_delayLoadHelper2+0x521
02 0000004f`545fb460 00007ffa`a479e1af     SETUPAPI!_tailMerge_user32_dll+0x3f
03 0000004f`545fb4d0 00007ffa`a479d791     SETUPAPI!IsInteractiveWindowStation+0x113
04 0000004f`545fb560 00007ffa`a479d484     SETUPAPI!AllocateDeviceInfoSet+0x121
05 0000004f`545fb5c0 00007ffa`a479c6bd     SETUPAPI!SetupDiCreateDeviceInfoListExW+0x74
06 0000004f`545fb870 00007ffa`a479c2d6     SETUPAPI!SetupDiGetClassDevsExW+0x1ed
07 0000004f`545fb8f0 00007ff9`b6d12a72     SETUPAPI!SetupDiGetClassDevsA+0x76
08 0000004f`545fb960 00007ff9`b6d10aeb     onnxruntime!onnxruntime::`anonymous namespace'::GetDeviceInfoSetupApi+0x1a2
```

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
WebNN is migrating ORT graph compilation to a sandboxed process with PROCESS_MITIGATION_SYSTEM_CALL_DISABLE_POLICY.DisallowWin32kSystemCalls enabled. This prevents kernel-mode system calls through win32k.sys for security hardening.

This change has no effect on normal (unsandboxed) processes.