### PR TITLE
[MLAS] test: accept canonical NaN in activation NaN round-trip check

### DIFF
--- a/onnxruntime/test/mlas/unittest/test_activation.cpp
+++ b/onnxruntime/test/mlas/unittest/test_activation.cpp
@@ -247,7 +247,8 @@ class MlasActivationTest : public MlasTestBase {
       for (unsigned i = 0; i < _countof(TestData); i++) {
         // Sensitive to comparing positive/negative zero and NaNs.
         float error = std::min(std::fabs((Buffer[i].f - TestData[i][kind].f) / TestData[i][kind].f), std::fabs(Buffer[i].f - TestData[i][kind].f));
-        EXPECT_TRUE(Buffer[i].u == TestData[i][kind].u || Buffer[i].f == TestData[i][kind].f || error < 0.000001f)
+        EXPECT_TRUE(Buffer[i].u == TestData[i][kind].u || Buffer[i].f == TestData[i][kind].f || error < 0.000001f ||
+                    (std::isnan(Buffer[i].f) && std::isnan(TestData[i][kind].f)))
             << ", Scalar Activation Kind:" << (int)kind << ", i=" << i << ", value:"
             << std::setw(8) << std::setfill('0') << std::hex << Buffer[i].u << ", expecting:"
             << std::setw(8) << std::setfill('0') << std::hex << TestData[i][kind].u;


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

`MlasActivationTest.ExecuteShort` (`test_activation.cpp`) feeds NaN inputs
through `MlasActivation` and asserts the output matches the expected value
bit-for-bit. This change adds one accepted case: when the expected value is a
NaN, any NaN output passes.

Non-NaN comparisons are unchanged — a finite output where a NaN is expected
(or the reverse) still fails. Test-only change, no library behavior impact.

Verified: `onnxruntime_mlas_test --gtest_filter=Activation.ShortExecute` on
SpacemiT K3 (riscv64, RVV VLEN=256), rv-gcc 15.2 — FAILED before, PASSED
after (re-run x3). x86/x64 behavior unaffected.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

The bit-exact assertion (`Buffer[i].u == TestData[i][kind].u`) implicitly
assumes the input NaN payload survives the activation. For kinds evaluated by
floating-point arithmetic — LeakyRelu (`alpha * x`), HardSigmoid
(`alpha * x + beta`) — that only holds on ISAs that propagate NaN payloads
(x86, ARM).

IEEE-754 does not require NaN payload propagation. RISC-V's `F` extension
mandates that any FP operation producing a NaN yields the canonical quiet NaN
(`0x7fc00000` for f32), discarding the payload. So on riscv64 these kinds emit
`0x7fc00000` for a NaN input — a correct "NaN in → NaN out" result whose bit
pattern simply differs from the input — and the bit-exact check fails.

Accepting any NaN where a NaN is expected restores the test to the portable
IEEE-754 **contract.**

