### PR TITLE
Fix XNNPACK Gemm SIGSEGV on missing and scalar 'C' bias

### DIFF
--- a/onnxruntime/core/providers/xnnpack/math/gemm.cc
+++ b/onnxruntime/core/providers/xnnpack/math/gemm.cc
@@ -36,6 +36,10 @@ bool Gemm::IsOnnxNodeSupported(const NodeUnit& node_unit, const GraphViewer& gra
     const NodeArg* A_arg = input_defs[0];
     const NodeArg* B_arg = input_defs[1];
     const NodeArg* C_arg = input_defs.size() == 2 ? nullptr : input_defs[2];
+    // Single source of truth for "is C actually present?". Matches the kernel
+    // constructor's C_matrix_exists_ = C_arg && C_arg->Exists() contract and the
+    // has_bias convention used in xnnpack/nn/conv_base.cc.
+    const bool has_c = (C_arg != nullptr && C_arg->Exists());
 
     // we only support float currently
     const auto* A_type = A_arg->TypeAsProto();
@@ -51,14 +55,13 @@ bool Gemm::IsOnnxNodeSupported(const NodeUnit& node_unit, const GraphViewer& gra
       break;
     }
 
-    if (input_defs.size() == 3 && !graph.IsConstantInitializer(C_arg->Name(), true)) {
+    if (has_c && !graph.IsConstantInitializer(C_arg->Name(), true)) {
       break;
     }
 
     // making sure we are dealing with MatMul
     const ONNX_NAMESPACE::TensorShapeProto* A_shape = A_arg->Shape();
     const ONNX_NAMESPACE::TensorShapeProto* B_shape = B_arg->Shape();
-    const ONNX_NAMESPACE::TensorShapeProto* C_shape = C_arg->Shape();
 
     if (!A_shape || A_shape->dim_size() >= 3) {
       break;
@@ -68,12 +71,27 @@ bool Gemm::IsOnnxNodeSupported(const NodeUnit& node_unit, const GraphViewer& gra
       break;
     }
 
-    if (!C_shape || C_shape->dim_size() >= 3) {
-      break;
-    }
+    // Optional C: if the input slot is absent (2-input Gemm) C_arg is null and we must not
+    // call Shape() on it. If C_arg exists but Exists() is false (empty optional input slot)
+    // we treat it identically: per ONNX, an empty optional input is equivalent to omitting
+    // the input. The kernel constructor's C_matrix_exists_ contract agrees.
+    if (has_c) {
+      const ONNX_NAMESPACE::TensorShapeProto* C_shape = C_arg->Shape();
+      if (!C_shape || C_shape->dim_size() >= 3) {
+        break;
+      }
 
-    if (C_arg && C_arg->Exists() && (C_shape->dim(0).dim_value() != B_shape->dim(1).dim_value() && C_shape->dim(0).dim_value() != B_shape->dim(0).dim_value())) {
-      break;
+      // Rank-0 C would be out of bounds on the C_shape->dim(0) check below and the
+      // xnn_create_fully_connected_nc_* bias path requires a length-N vector, so reject
+      // and fall back to the CPU EP.
+      if (C_shape->dim_size() == 0) {
+        break;
+      }
+
+      if (C_shape->dim(0).dim_value() != B_shape->dim(1).dim_value() &&
+          C_shape->dim(0).dim_value() != B_shape->dim(0).dim_value()) {
+        break;
+      }
     }
 
     supported = true;

--- a/onnxruntime/test/providers/xnnpack/xnnpack_basic_test.cc
+++ b/onnxruntime/test/providers/xnnpack/xnnpack_basic_test.cc
@@ -574,6 +574,89 @@ TEST(XnnpackEP, DISABLED_TestResize_u8_and_s8_NHWC_pytorch_half_pixel) {  // [ON
                {ExpectedEPNodeAssignment::Some, 1e-2f /* fp32_abs_err */});
 }
 
+// Regression test for https://github.com/microsoft/onnxruntime/issues/28541.
+// A two-input Gemm (no optional C bias) used to dereference a null NodeArg pointer in
+// Gemm::IsOnnxNodeSupported, segfaulting InferenceSession::Initialize before any kernel
+// ran. The capability check must accept the missing-C case and let the node be assigned
+// to XNNPACK without crashing.
+TEST(XnnpackEP, TestGemm_NoC_NoSegfault) {
+  const std::vector<int64_t> a_shape = {2, 3};
+  const std::vector<int64_t> b_shape = {3, 4};
+  auto modelBuilder = [&](ModelTestBuilder& builder) {
+    auto* input_a = builder.MakeInput<float>(a_shape, -1.f, 1.f);
+    auto* input_b = builder.MakeInitializer<float>(b_shape, -1.f, 1.f);
+    auto* output_arg = builder.MakeOutput();
+    auto& gemm_node = builder.AddNode("Gemm", {input_a, input_b}, {output_arg});
+    gemm_node.AddAttribute("alpha", 1.0f);
+    gemm_node.AddAttribute("beta", 1.0f);
+    gemm_node.AddAttribute("transA", static_cast<int64_t>(0));
+    gemm_node.AddAttribute("transB", static_cast<int64_t>(0));
+  };
+  // ExpectedEPNodeAssignment::All asserts both that the session initialized without
+  // segfaulting AND that XNNPACK accepted the 2-input Gemm node.
+  RunModelTest(modelBuilder, "xnnpack_test_graph_gemm_no_c",
+               {
+                   ExpectedEPNodeAssignment::All,
+                   1e-4f /* fp32_abs_err */,
+               });
+}
+
+// Regression test for https://github.com/microsoft/onnxruntime/issues/28542.
+// A Gemm with a scalar (rank 0) C bias used to skip past the dim_size() >= 3 guard and
+// then crash on C_shape->dim(0) inside Gemm::IsOnnxNodeSupported. The capability check
+// must reject rank-0 C cleanly so the node falls back to the CPU EP and the session
+// initializes without segfaulting. RunModelTest compares the XNNPACK + CPU run against
+// the pure CPU baseline, so this also verifies numerical correctness end to end.
+TEST(XnnpackEP, TestGemm_ScalarC_NoSegfault) {
+  const std::vector<int64_t> a_shape = {2, 3};
+  const std::vector<int64_t> b_shape = {3, 4};
+  auto modelBuilder = [&](ModelTestBuilder& builder) {
+    auto* input_a = builder.MakeInput<float>(a_shape, -1.f, 1.f);
+    auto* input_b = builder.MakeInitializer<float>(b_shape, -1.f, 1.f);
+    auto* input_c = builder.MakeScalarInitializer<float>(0.5f);
+    auto* output_arg = builder.MakeOutput();
+    auto& gemm_node = builder.AddNode("Gemm", {input_a, input_b, input_c}, {output_arg});
+    gemm_node.AddAttribute("alpha", 1.0f);
+    gemm_node.AddAttribute("beta", 1.0f);
+    gemm_node.AddAttribute("transA", static_cast<int64_t>(0));
+    gemm_node.AddAttribute("transB", static_cast<int64_t>(0));
+  };
+  RunModelTest(modelBuilder, "xnnpack_test_graph_gemm_scalar_c",
+               {
+                   ExpectedEPNodeAssignment::None,
+                   1e-4f /* fp32_abs_err */,
+               });
+}
+
+// Defense-in-depth regression test for the C_arg->Exists() == false branch. A 3-input
+// Gemm whose C slot is an empty optional input (Exists() == false) is semantically
+// equivalent to a 2-input Gemm per ONNX (empty optional input == omitted input). The
+// XNNPACK support check now treats them identically: both are accepted and routed to
+// the bias=nullptr path in xnn_create_fully_connected_nc_*. This locks in the
+// consistency between the 2-input case (TestGemm_NoC_NoSegfault) and the empty-optional
+// case, matching the kernel constructor's C_matrix_exists_ = C_arg && C_arg->Exists()
+// contract.
+TEST(XnnpackEP, TestGemm_EmptyC_NoSegfault) {
+  const std::vector<int64_t> a_shape = {2, 3};
+  const std::vector<int64_t> b_shape = {3, 4};
+  auto modelBuilder = [&](ModelTestBuilder& builder) {
+    auto* input_a = builder.MakeInput<float>(a_shape, -1.f, 1.f);
+    auto* input_b = builder.MakeInitializer<float>(b_shape, -1.f, 1.f);
+    auto* input_c = builder.MakeEmptyInput();
+    auto* output_arg = builder.MakeOutput();
+    auto& gemm_node = builder.AddNode("Gemm", {input_a, input_b, input_c}, {output_arg});
+    gemm_node.AddAttribute("alpha", 1.0f);
+    gemm_node.AddAttribute("beta", 1.0f);
+    gemm_node.AddAttribute("transA", static_cast<int64_t>(0));
+    gemm_node.AddAttribute("transB", static_cast<int64_t>(0));
+  };
+  RunModelTest(modelBuilder, "xnnpack_test_graph_gemm_empty_c",
+               {
+                   ExpectedEPNodeAssignment::All,
+                   1e-4f /* fp32_abs_err */,
+               });
+}
+
 #endif
 
 }  // namespace test


### PR DESCRIPTION
### Description

Hardens the XNNPACK Gemm capability check against two SIGSEGV crashes during graph partitioning: one when the optional `C` input is omitted, one when `C` is a rank-0 (scalar) tensor. The check now guards the null `C` arg before calling `Shape()`, and rejects rank-0 `C` so the node falls back to the CPU EP cleanly.

Thanks @kadu-v, the minimal Python repros made the root cause easy to confirm. Both reproduced as a hard crash on the first `InferenceSession` construction.

### Motivation and Context

Fixes #28541
Fixes #28542

`Gemm::IsOnnxNodeSupported` dereferenced `C_arg->Shape()` without checking whether `C_arg` was non-null, so any Gemm without the optional bias segfaulted before the EP could decline the node. A rank-0 `C` then survived the existing checks and reached XNNPACK's fully-connected path, which doesn't implement scalar broadcast (there's already a TODO in that file noting it). That's the second SIGSEGV.

### Changes

`onnxruntime/core/providers/xnnpack/math/gemm.cc`:
- Null-check `C_arg` before reading its shape. Absent `C` is valid per the Gemm spec; treat it as "no bias".
- Reject `C` with rank 0 from `IsOnnxNodeSupported` so the node falls through to CPU. Adding scalar broadcast support belongs with the TODO in the fully-connected path, not in the capability check.

### Testing

Three regression tests in `onnxruntime/test/providers/xnnpack/xnnpack_basic_test.cc`:
- `TestGemm_NoC_NoSegfault` builds a Gemm with the `C` input omitted.
- `TestGemm_ScalarC_NoSegfault` builds a Gemm with a rank-0 `C`.
- `TestGemm_EmptyC_NoSegfault` covers an empty-shape `C` edge case.

Each test loads an `InferenceSession` with the XNNPACK EP registered and asserts no crash.

I also suspect `Gemm`'s constructor has pre-existing crashes when `A` or `B` is 1-D, before the capability check even runs. Haven't reproduced it. Can file a follow-up if useful.
