### PR TITLE
Fix Cargo registry auth for network-isolated Linux Python wheel builds

### DIFF
--- a/tools/ci_build/github/azure-pipelines/stages/py-linux-gpu-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/py-linux-gpu-stage.yml
@@ -125,6 +125,7 @@ stages:
             $(extra_build_args)
         env:
           CUDA_VERSION: ${{ parameters.cuda_version }}
+          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
       - script: |
           set -e -x

--- a/tools/ci_build/github/azure-pipelines/stages/py-linux-webgpu-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/py-linux-webgpu-stage.yml
@@ -67,6 +67,8 @@ stages:
 
       - task: Bash@3
         displayName: 'Build Python Wheel'
+        env:
+          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
         inputs:
           targetType: filePath
           filePath: tools/ci_build/github/linux/run_python_dockerbuild.sh

--- a/tools/ci_build/github/azure-pipelines/templates/py-linux-qnn.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-linux-qnn.yml
@@ -79,3 +79,4 @@ jobs:
       arguments: -i onnxruntimecpubuildpythonx86_64_qnn -d "${{ parameters.device }}" -c ${{ parameters.cmake_build_type }} $(extra_build_args)
     env:
       ADDITIONAL_DOCKER_PARAMETER: "--volume $(QnnSDKRootDir):/qnn_sdk"
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)

--- a/tools/ci_build/github/azure-pipelines/templates/py-linux.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-linux.yml
@@ -89,6 +89,8 @@ jobs:
 
   - task: Bash@3
     displayName: 'Build Python Wheel'
+    env:
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
     inputs:
       targetType: filePath
       filePath: tools/ci_build/github/linux/run_python_dockerbuild.sh

--- a/tools/ci_build/github/azure-pipelines/templates/setup-feeds-and-python-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/setup-feeds-and-python-steps.yml
@@ -71,6 +71,34 @@ steps:
   inputs:
     artifactFeeds: ${{ parameters.artifactFeeds }}
 
+- task: PowerShell@2
+  displayName: 'Cargo - create config.toml to mirror crates.io via internal feed'
+  env:
+    artifact_feed: ${{ parameters.artifactFeeds }}
+  inputs:
+    targetType: 'inline'
+    script: |
+      # Write to CARGO_HOME (global) so cargo finds it regardless of working directory.
+      $cargoHome = if ($env:CARGO_HOME) { $env:CARGO_HOME } else { "~/.cargo" }
+      if (!(Test-Path -Path $cargoHome)) {
+        New-Item -ItemType Directory -Path $cargoHome
+      }
+      Set-Content -Force -Path "$cargoHome/config.toml" -Value @"
+      [registry]
+      global-credential-providers = ["cargo:token"]
+
+      [registries.onnxruntime]
+      index = "sparse+https://aiinfra.pkgs.visualstudio.com/_packaging/${env:artifact_feed}/Cargo/index/"
+
+      [source.crates-io]
+      replace-with = "onnxruntime"
+
+      [source.onnxruntime]
+      registry = "sparse+https://aiinfra.pkgs.visualstudio.com/_packaging/${env:artifact_feed}/Cargo/index/"
+      "@
+
+      Write-Host "Wrote cargo config to: $cargoHome/config.toml"
+
 - task: UsePythonVersion@0
   displayName: 'Use Python ${{ parameters.versionSpec }}'
   # aarch64 (aka arm64) is not currently available (2026-04-09). Skip installation.

--- a/tools/ci_build/github/linux/run_python_dockerbuild.sh
+++ b/tools/ci_build/github/linux/run_python_dockerbuild.sh
@@ -28,6 +28,20 @@ if [ "${BUILD_EXTR_PAR}" != "" ] ; then
 fi
 
 # HACK: `ADDITIONAL_DOCKER_PARAMETER` is passed in via env in some pipelines
+
+# Extract cargo registry token so it can be passed as an env var.
+# Puccinialin (maturin's Rust installer) overrides CARGO_HOME, so credentials.toml
+# at our mount point won't be found. The env var works regardless.
+set +x
+CARGO_REGISTRIES_ONNXRUNTIME_TOKEN=""
+if [ -n "${SYSTEM_ACCESSTOKEN:-}" ]; then
+    CARGO_REGISTRIES_ONNXRUNTIME_TOKEN="Basic $(printf ':%s' "${SYSTEM_ACCESSTOKEN}" | base64 -w0)"
+else
+    echo "WARNING: SYSTEM_ACCESSTOKEN not set. Cargo registry auth will not be available." >&2
+fi
+export CARGO_REGISTRIES_ONNXRUNTIME_TOKEN
+set -x
+
 docker run -e SYSTEM_COLLECTIONURI --rm \
     --volume /data/onnx:/data/onnx:ro \
     --volume "${BUILD_SOURCESDIRECTORY}:/onnxruntime_src" \
@@ -39,6 +53,8 @@ docker run -e SYSTEM_COLLECTIONURI --rm \
     --volume "${NPM_CONFIG_USERCONFIG}:/tmp/.npmrc:ro" \
     --volume "$HOME/.m2:/home/onnxruntimedev/.m2:ro" \
     --volume "$HOME/.gradle:/home/onnxruntimedev/.gradle" \
+    --volume "$HOME/.cargo/config.toml:/.cargo/config.toml:ro" \
+    -e CARGO_REGISTRIES_ONNXRUNTIME_TOKEN \
     -w /onnxruntime_src \
     -e NIGHTLY_BUILD \
     -e BUILD_BUILDNUMBER \


### PR DESCRIPTION
### Description
This PR

* Fixes the Linux Python wheel builds fail when pip installs `mypy>=2.1`, which depends on `ast-serialize` — a Rust-based package.  Cargo failed to fetch the package because of network isolation. Use the internal cargo feed URL and update the config to use the cargo repo URL of internal artifactory



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


