### PR TITLE
Raise protobuf minimum version in Python requirements

### DIFF
--- a/docs/python/requirements.txt
+++ b/docs/python/requirements.txt
@@ -14,7 +14,7 @@ pydot
 flatbuffers
 numpy<2.0.0
 packaging
-protobuf
+protobuf>=4.25.8
 sympy
 onnx
 sphinx_exec_code

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,7 +9,7 @@ onnxmltools
 packaging
 pandas
 parameterized>=0.8.1
-protobuf
+protobuf>=4.25.8
 pydocstyle[toml]
 pytest
 pytest-cov

--- a/requirements-training.txt
+++ b/requirements-training.txt
@@ -4,6 +4,6 @@ h5py
 numpy >= 1.16.6
 onnx
 packaging
-protobuf
+protobuf>=4.25.8
 sympy
 setuptools>=61.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 flatbuffers
 numpy >= 1.21.6
 packaging
-protobuf
+protobuf>=4.25.8


### PR DESCRIPTION
## Changes
- Update `requirements.txt` to `protobuf>=4.25.8`
- Update `requirements-training.txt` to `protobuf>=4.25.8`
- Update `requirements-dev.txt` to `protobuf>=4.25.8`
- Update `docs/python/requirements.txt` to `protobuf>=4.25.8`

## Notes
This change addresses the direct Python manifest surface only. It does not claim to resolve every transitive Component Governance finding.

