### PR TITLE
TurboQuant KV cache (3/4): WebGPU kernels + Safari/Firefox fallback

### DIFF
--- a/include/onnxruntime/core/framework/int3.h
+++ b/include/onnxruntime/core/framework/int3.h
@@ -1,0 +1,116 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <cassert>
+#include <type_traits>
+#include "core/common/common.h"
+#include <gsl/gsl>
+
+namespace onnxruntime {
+
+// Stores 8 packed 3-bit unsigned elements in 3 bytes (24 bits exactly).
+//
+// Bit layout (within the 24-bit word, little-endian):
+//   word    = byte[0] | (byte[1] << 8) | (byte[2] << 16)
+//   value_i = (word >> (i * 3)) & 0x7    for i in [0, 8)
+//
+// This layout matches vLLM's TurboQuant store kernel
+// (vllm/v1/attention/ops/triton_turboquant_store.py) so binaries produced by
+// either runtime are interchangeable.
+//
+// Used for:
+//   - K-cache 3-bit Lloyd-Max codebook indices in TurboQuant.
+//   - V-cache 3-bit uniform-quant indices when value_quant_bits == 3.
+//
+// Storage tip: callers should always operate on whole 8-element groups
+// (i.e. tensor extents along the packed axis must be multiples of 8). The
+// 3-bit encoding has no clean partial-byte representation otherwise.
+struct UInt3x8 {
+  static constexpr uint8_t min_val = 0;
+  static constexpr uint8_t max_val = 7;
+  static constexpr size_t kElementsPerPack = 8;
+  static constexpr size_t kBytesPerPack = 3;
+
+  std::byte bytes_[kBytesPerPack]{};
+
+  UInt3x8() = default;
+
+  // Construct from 8 unpacked uint8 elements. All must be in [0, 7].
+  explicit UInt3x8(const uint8_t (&values)[kElementsPerPack]) {
+    uint32_t word = 0;
+    for (size_t i = 0; i < kElementsPerPack; ++i) {
+      assert(values[i] <= max_val);
+      word |= (static_cast<uint32_t>(values[i]) & 0x7u) << (i * 3);
+    }
+    bytes_[0] = static_cast<std::byte>(word & 0xFFu);
+    bytes_[1] = static_cast<std::byte>((word >> 8) & 0xFFu);
+    bytes_[2] = static_cast<std::byte>((word >> 16) & 0xFFu);
+  }
+
+  inline uint8_t GetElem(size_t index) const {
+    assert(index < kElementsPerPack);
+    const uint32_t word = static_cast<uint32_t>(bytes_[0]) |
+                          (static_cast<uint32_t>(bytes_[1]) << 8) |
+                          (static_cast<uint32_t>(bytes_[2]) << 16);
+    return static_cast<uint8_t>((word >> (index * 3)) & 0x7u);
+  }
+
+  inline void SetElem(size_t index, uint8_t val) {
+    assert(index < kElementsPerPack);
+    assert(val <= max_val);
+    uint32_t word = static_cast<uint32_t>(bytes_[0]) |
+                    (static_cast<uint32_t>(bytes_[1]) << 8) |
+                    (static_cast<uint32_t>(bytes_[2]) << 16);
+    const uint32_t mask = ~(0x7u << (index * 3));
+    word = (word & mask) | ((static_cast<uint32_t>(val) & 0x7u) << (index * 3));
+    bytes_[0] = static_cast<std::byte>(word & 0xFFu);
+    bytes_[1] = static_cast<std::byte>((word >> 8) & 0xFFu);
+    bytes_[2] = static_cast<std::byte>((word >> 16) & 0xFFu);
+  }
+
+  // Number of UInt3x8 packs required to store n unpacked 3-bit elements.
+  // Caller must ensure n is a multiple of 8.
+  static constexpr size_t CalcNumPacks(size_t num_3bit_elems) {
+    return num_3bit_elems / kElementsPerPack;
+  }
+
+  // Bytes required to store n unpacked 3-bit elements.
+  static constexpr size_t CalcNumBytes(size_t num_3bit_elems) {
+    return CalcNumPacks(num_3bit_elems) * kBytesPerPack;
+  }
+
+  // Bulk unpack: turn N packed groups (3 bytes each) into N*8 bytes [0, 7].
+  static bool Unpack(gsl::span<uint8_t> dst, gsl::span<const UInt3x8> src) {
+    if (dst.size() != src.size() * kElementsPerPack) {
+      return false;
+    }
+    for (size_t i = 0; i < src.size(); ++i) {
+      for (size_t j = 0; j < kElementsPerPack; ++j) {
+        dst[i * kElementsPerPack + j] = src[i].GetElem(j);
+      }
+    }
+    return true;
+  }
+
+  // Bulk pack: turn N*8 bytes [0, 7] into N packed groups.
+  static bool Pack(gsl::span<UInt3x8> dst, gsl::span<const uint8_t> src) {
+    if (src.size() != dst.size() * kElementsPerPack) {
+      return false;
+    }
+    for (size_t i = 0; i < dst.size(); ++i) {
+      uint8_t buf[kElementsPerPack];
+      for (size_t j = 0; j < kElementsPerPack; ++j) {
+        buf[j] = src[i * kElementsPerPack + j];
+        assert(buf[j] <= max_val);
+      }
+      dst[i] = UInt3x8(buf);
+    }
+    return true;
+  }
+};
+
+static_assert(sizeof(UInt3x8) == 3, "UInt3x8 must be exactly 3 bytes");
+
+}  // namespace onnxruntime

--- a/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
+++ b/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
@@ -537,3 +537,23 @@ static const char* const kOrtSessionOptionsRecordEpGraphAssignmentInfo = "sessio
 // - "0": disable. (default)
 // - "1": enable.
 static const char* const kOrtSessionOptionEpEnableWeightlessEpContextNodes = "ep.enable_weightless_ep_context_nodes";
+
+// TurboQuant KV-cache rewrite preset.  When set, the TurboQuantKVFusion graph
+// transformer rewrites every GroupQueryAttention node in the model to use
+// TurboQuant KV-cache compression at session-create time.  This means the user
+// can load a stock fp16 q4f16 .onnx model from HuggingFace and opt in to
+// TurboQuant via runtime config alone — no offline model conversion needed.
+//
+// Recognized values:
+// - "" / "none" / "off": disabled (default).
+// - "turboquant_4bit_nc":  4-bit K, 4-bit V, norm correction on.
+// - "turboquant_k3v4_nc":  3-bit K, 4-bit V, norm correction on.
+// - "turboquant_3bit_nc":  3-bit K, 3-bit V, norm correction on.
+//
+// Requires CUDA EP (the TurboQuant kernels live there).  No-op on CPU.
+static const char* const kOrtSessionOptionsTurboQuantKVMethod = "optimization.turboquant_kv_method";
+
+// TurboQuant boundary-protection layers.  Number of attention layers at the
+// start AND the end of the network to leave at fp16 (matching vLLM's behaviour).
+// Default "2".  Set to "0" to TurboQuant every GQA layer.
+static const char* const kOrtSessionOptionsTurboQuantKVBoundary = "optimization.turboquant_kv_boundary";

--- a/onnxruntime/contrib_ops/cpu/bert/attention_common.h
+++ b/onnxruntime/contrib_ops/cpu/bert/attention_common.h
@@ -66,6 +66,28 @@ enum class KVQuantizationType : int {
   PER_CHANNEL = 2,
 };
 
+// Enum to select KV-cache compression method.
+//
+// CLASSIC modes use a single global scale per K/V tensor (PER_TENSOR) or one
+// scale per channel (PER_CHANNEL) and store linearly-quantized integers. The
+// scale tensors are passed via inputs `k_scale` and `v_scale`.
+//
+// TURBOQUANT applies a Walsh-Hadamard rotation to keys before scalar
+// quantization with a static Lloyd-Max codebook (3- or 4-bit), and uses
+// uniform asymmetric quantization for values. Codebook + Hadamard are graph
+// initializers; per-token vec_norm + per-token v_scale/v_zero live alongside
+// the packed bytes in the cache. See:
+//   onnxruntime/contrib_ops/cuda/bert/group_query_attention_turboquant.cuh
+//   onnxruntime/contrib_ops/webgpu/bert/flash_attention_*_turboquant.wgsl.template
+//
+// TURBOQUANT preserves attention semantics: scoring runs in the rotated space
+// because Hadamard is orthogonal, so Q.K = (Q@H).(k_hat@H) * ||k||.
+enum class KVQuantMethod : int {
+  NONE = 0,
+  CLASSIC = 1,     // existing int4/int8/fp8 path via KVQuantizationType + k_scale/v_scale
+  TURBOQUANT = 2,  // Hadamard + Lloyd-Max keys, uniform asymmetric values
+};
+
 constexpr bool LAYOUT_BSNH = false;
 constexpr bool LAYOUT_BNSH = true;
 

--- a/onnxruntime/contrib_ops/cpu/bert/attention_parameters.h
+++ b/onnxruntime/contrib_ops/cpu/bert/attention_parameters.h
@@ -102,6 +102,14 @@ struct GroupQueryAttentionParameters : AttentionParameters {
   KVQuantizationType k_quant_type = KVQuantizationType::NONE;
   KVQuantizationType v_quant_type = KVQuantizationType::NONE;
   int kv_cache_bit_width = 0;
+
+  // TurboQuant KV cache parameters (mutually exclusive with k_quant_type/v_quant_type
+  // when kv_quant_method == TURBOQUANT). The codebook + Hadamard pointers live in
+  // the GroupQueryAttentionData struct (CUDA-side) since they're device pointers.
+  KVQuantMethod kv_quant_method = KVQuantMethod::NONE;
+  int key_quant_bits = 0;     // 3 or 4 when kv_quant_method == TURBOQUANT
+  int value_quant_bits = 0;   // 3 or 4 when kv_quant_method == TURBOQUANT
+  bool norm_correction = false;
 };
 
 // Parameters deduced from node attributes and inputs/outputs.

--- a/onnxruntime/contrib_ops/cpu/bert/group_query_attention_helper.h
+++ b/onnxruntime/contrib_ops/cpu/bert/group_query_attention_helper.h
@@ -143,16 +143,20 @@ Status CheckPast(const T* past_key, const T* past_value, int batch_size, int kv_
 
   // For 4-bit quantized KV cache, actual dimension is head_size / 2 because 2 nibbles are packed into one byte.
   // Note that we have checked that head_size is a multiple of 8 in Check_QKV.
-  int packed_head_size = (kv_cache_bit_width == 4) ? (head_size / 2) : head_size;
-  if (past_key_dims[3] != packed_head_size) {
-    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
-                           "Input 'past_key' dimension 3 should be same as head_size, got ",
-                           past_key_dims[3], " expected ", packed_head_size);
-  }
-  if (past_value_dims[3] != packed_head_size) {
-    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
-                           "Input 'past_value' dimension 3 should be same as head_size, got ",
-                           past_value_dims[3], " expected ", packed_head_size);
+  // Sentinel: kv_cache_bit_width == -1 means "TurboQuant slot layout, skip last-dim check"
+  // (TQ packs differently and the last dim is bytes-per-slot, not head_size or head_size/2).
+  if (kv_cache_bit_width != -1) {
+    int packed_head_size = (kv_cache_bit_width == 4) ? (head_size / 2) : head_size;
+    if (past_key_dims[3] != packed_head_size) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                             "Input 'past_key' dimension 3 should be same as head_size, got ",
+                             past_key_dims[3], " expected ", packed_head_size);
+    }
+    if (past_value_dims[3] != packed_head_size) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                             "Input 'past_value' dimension 3 should be same as head_size, got ",
+                             past_value_dims[3], " expected ", packed_head_size);
+    }
   }
   return Status::OK();
 }

--- a/onnxruntime/contrib_ops/webgpu/bert/group_query_attention.cc
+++ b/onnxruntime/contrib_ops/webgpu/bert/group_query_attention.cc
@@ -7,6 +7,7 @@
 #include "contrib_ops/webgpu/webgpu_contrib_kernels.h"
 #include "contrib_ops/webgpu/bert/rotary_embedding.h"
 #include "contrib_ops/webgpu/bert/flash_attention.h"
+#include "contrib_ops/webgpu/bert/turboquant_attention.h"
 
 #include "core/providers/webgpu/webgpu_supported_types.h"
 #include "core/providers/webgpu/shader_helper.h"
@@ -195,24 +196,62 @@ Status GroupQueryAttention::ComputeInternal(onnxruntime::webgpu::ComputeContext&
   const Tensor* position_ids = context.Input<Tensor>(9);  // TODO: support sliding window
   const Tensor* attention_bias = context.Input<Tensor>(10);
   const Tensor* head_sink = context.Input<Tensor>(11);
+  // TurboQuant graph initializers (added by Option A graph rewrite).
+  const Tensor* k_codebook = context.Input<Tensor>(14);
+  const Tensor* hadamard = context.Input<Tensor>(15);
 
   GroupQueryAttentionParameters params = {};
-  ORT_RETURN_IF_ERROR(group_query_attention_helper::CheckInputs(query,
-                                                                key,
-                                                                value,
-                                                                past_key,
-                                                                past_value,
-                                                                cos_cache,
-                                                                sin_cache,
-                                                                &params,
-                                                                num_heads_,
-                                                                kv_num_heads_,
-                                                                seqlen_k,
-                                                                total_seqlen_tensor,
-                                                                scale_,
-                                                                softcap_,
-                                                                0,
-                                                                context.DeviceLimits().maxComputeInvocationsPerWorkgroup));
+  if (is_turboquant_) {
+    // CheckInputs validates that past_key.dim[3] == head_size which is FALSE
+    // when Option A's graph rewrite has replaced fp16 head_dim with packed
+    // uint8 slot_bytes.  Compute parameters by hand for the TQ path,
+    // mirroring what CheckInputs would set for the equivalent fp16 graph.
+    const auto& q_dims = query->Shape().GetDims();
+    ORT_ENFORCE(q_dims.size() == 3, "query must be 3-D for TurboQuant GQA");
+    const auto& past_dims = past_key->Shape().GetDims();
+    ORT_ENFORCE(past_dims.size() == 4, "past_key must be 4-D for TurboQuant GQA");
+
+    params.batch_size = static_cast<int>(q_dims[0]);
+    params.sequence_length = static_cast<int>(q_dims[1]);
+    params.hidden_size = static_cast<int>(q_dims[2]);
+    params.num_heads = num_heads_;
+    params.kv_num_heads = kv_num_heads_;
+    params.head_size = params.hidden_size / num_heads_;
+    params.kv_hidden_size = params.head_size * kv_num_heads_;
+    params.v_head_size = params.head_size;
+    params.past_kv_format = AttentionQkvFormat::Q_K_V_BNSH;
+    params.scale = (scale_ == 0.0f) ? (1.0f / std::sqrt(static_cast<float>(params.head_size))) : scale_;
+    params.softcap = softcap_;
+    params.qkv_format = AttentionQkvFormat::Q_K_V_BSNH;
+    params.is_packed_qkv = false;
+
+    // Compute past from past_key.shape[2] — same approach as CheckInputs takes
+    // for the fp16 path.  seqlens_k is unreliable as a primary source: callers
+    // sometimes leave it zero-filled on the prompt step, and the past tensor's
+    // shape is the ground truth either way.
+    params.seqlen_past_kv_cache = static_cast<int>(past_dims[2]);
+    params.total_sequence_length = params.seqlen_past_kv_cache + params.sequence_length;
+    params.seqlen_present_kv_cache = params.total_sequence_length;
+    params.is_first_prompt = (params.seqlen_past_kv_cache == 0);
+    params.is_subsequent_prompt = !params.is_first_prompt && params.sequence_length > 1;
+  } else {
+    ORT_RETURN_IF_ERROR(group_query_attention_helper::CheckInputs(query,
+                                                                  key,
+                                                                  value,
+                                                                  past_key,
+                                                                  past_value,
+                                                                  cos_cache,
+                                                                  sin_cache,
+                                                                  &params,
+                                                                  num_heads_,
+                                                                  kv_num_heads_,
+                                                                  seqlen_k,
+                                                                  total_seqlen_tensor,
+                                                                  scale_,
+                                                                  softcap_,
+                                                                  0,
+                                                                  context.DeviceLimits().maxComputeInvocationsPerWorkgroup));
+  }
   params.use_smooth_softmax = use_smooth_softmax_;
   params.rotary_interleaved = rotary_interleaved_;
 
@@ -231,11 +270,19 @@ Status GroupQueryAttention::ComputeInternal(onnxruntime::webgpu::ComputeContext&
   output_shape[1] = static_cast<int64_t>(parameters.sequence_length_);
   output_shape[2] = static_cast<int64_t>(parameters.hidden_size_);
   Tensor* output = context.Output(0, output_shape);
+  // For TurboQuant the present_kv tensor is uint8-packed with a slot_bytes
+  // last dim instead of head_size.  Match Option A's graph rewrite layout.
+  int64_t kv_last_dim = parameters.head_size_;
+  if (is_turboquant_) {
+    int k_slot = (parameters.head_size_ * static_cast<int>(key_quant_bits_) + 7) / 8 + 2;
+    int v_slot = (parameters.head_size_ * static_cast<int>(value_quant_bits_) + 7) / 8 + 4;
+    kv_last_dim = static_cast<int64_t>(std::max(k_slot, v_slot));
+  }
   std::vector<int64_t> present_dims{
       parameters.batch_size_,
       kv_num_heads_,
       parameters.seqlen_present_kv_cache_,
-      parameters.head_size_};
+      kv_last_dim};
   std::vector<int64_t> present_kv_shape(present_dims);
   Tensor* present_key = context.Output(1, present_kv_shape);
   Tensor* present_value = context.Output(2, present_kv_shape);
@@ -249,6 +296,29 @@ Status GroupQueryAttention::ComputeInternal(onnxruntime::webgpu::ComputeContext&
 
   Tensor qRotary;
   Tensor kRotary;
+
+  // TurboQuant branch needs rotary applied to Q/K up-front (standard
+  // ApplyFlashAttention's do_rotary path requires packed-QKV input, which we
+  // don't have here).  Apply rotary inline, then hand off to the TQ
+  // orchestrator with cos/sin = nullptr.
+  if (is_turboquant_ && k_codebook != nullptr && hadamard != nullptr) {
+    if (do_rotary_) {
+      qRotary = context.CreateGPUTensor(query->DataType(), query->Shape());
+      kRotary = context.CreateGPUTensor(key->DataType(), key->Shape());
+      ORT_RETURN_IF_ERROR(RunFusedQKRotaryEmbedding(
+          context, parameters, query, key, seqlen_k, cos_cache, sin_cache,
+          &qRotary, &kRotary));
+      query = &qRotary;
+      key = &kRotary;
+    }
+    return RunTurboQuantAttention(
+        context, parameters, query, key, value, past_key, past_value,
+        k_codebook, hadamard, attention_bias, head_sink, seqlen_k,
+        /*cos_cache=*/nullptr, /*sin_cache=*/nullptr,
+        present_key, present_value, output,
+        key_quant_bits_, value_quant_bits_, norm_correction_,
+        local_window_size_);
+  }
 
   // Use a sliding window if the total sequence exceeds the window's length.
   bool use_sliding_window = (local_window_size_ != -1 && local_window_size_ < parameters.total_sequence_length_);

--- a/onnxruntime/contrib_ops/webgpu/bert/group_query_attention.h
+++ b/onnxruntime/contrib_ops/webgpu/bert/group_query_attention.h
@@ -58,6 +58,14 @@ class GroupQueryAttention final : public WebGpuKernel {
     use_smooth_softmax_ = info.GetAttrOrDefault<int64_t>("smooth_softmax", 0) == 1;
 
     local_window_size_ = static_cast<int>(info.GetAttrOrDefault<int64_t>("local_window_size", -1));
+
+    // TurboQuant attributes (added by Option A graph rewrite at session-create
+    // time; absent on stock graphs).
+    const std::string method = info.GetAttrOrDefault<std::string>("kv_quant_method", "none");
+    is_turboquant_ = (method == "turboquant");
+    key_quant_bits_ = static_cast<uint32_t>(info.GetAttrOrDefault<int64_t>("key_quant_bits", 4));
+    value_quant_bits_ = static_cast<uint32_t>(info.GetAttrOrDefault<int64_t>("value_quant_bits", 4));
+    norm_correction_ = info.GetAttrOrDefault<int64_t>("norm_correction", 0) == 1;
   }
 
   int num_heads_;     // number of attention heads of Q
@@ -67,6 +75,10 @@ class GroupQueryAttention final : public WebGpuKernel {
   bool do_rotary_;  // whether or not to use rotary embeddings
   bool rotary_interleaved_;
   int local_window_size_;
+  bool is_turboquant_ = false;
+  uint32_t key_quant_bits_ = 4;
+  uint32_t value_quant_bits_ = 4;
+  bool norm_correction_ = false;
 
   bool use_smooth_softmax_;
   Status ComputeInternal(onnxruntime::webgpu::ComputeContext& context) const override;

--- a/onnxruntime/contrib_ops/webgpu/bert/turboquant_attention.cc
+++ b/onnxruntime/contrib_ops/webgpu/bert/turboquant_attention.cc
@@ -1,0 +1,332 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "contrib_ops/webgpu/bert/turboquant_attention.h"
+#include "contrib_ops/webgpu/bert/flash_attention.h"
+#include "contrib_ops/webgpu/bert/attention_common.h"
+#include "core/platform/env_var.h"
+#include "core/providers/webgpu/webgpu_supported_types.h"
+
+namespace onnxruntime {
+namespace contrib {
+namespace webgpu {
+
+namespace {
+
+// Slot byte sizes for the packed cache layout — must match Option A's
+// `slot_bytes` calculation in turboquant_kv_fusion.cc.
+//   K slot: ceil(D * key_bits / 8) bytes + 2 bytes (vec_norm fp16)
+//   V slot: ceil(D * value_bits / 8) bytes + 4 bytes (v_scale fp16 + v_zero fp16)
+inline uint32_t KeySlotBytes(uint32_t head_dim, uint32_t key_bits) {
+  return ((head_dim * key_bits) + 7) / 8 + 2;
+}
+inline uint32_t ValueSlotBytes(uint32_t head_dim, uint32_t value_bits) {
+  return ((head_dim * value_bits) + 7) / 8 + 4;
+}
+inline uint32_t SlotBytes(uint32_t head_dim, uint32_t key_bits, uint32_t value_bits) {
+  uint32_t k = KeySlotBytes(head_dim, key_bits);
+  uint32_t v = ValueSlotBytes(head_dim, value_bits);
+  return k > v ? k : v;
+}
+
+}  // namespace
+
+Status TurboQuantEncodeProgram::GenerateShaderCode(ShaderHelper& sh) const {
+  // Bindings — the AddInput/AddOutput calls register the storage buffers
+  // with the shader; the WGSL template references them by name.  Order must
+  // match what the template expects (the WGSL emitter binds in declaration
+  // order).
+  sh.AddInput("K_in", ShaderUsage::UseUniform);
+  sh.AddInput("V_in", ShaderUsage::UseUniform);
+  sh.AddInput("k_codebook", ShaderUsage::UseUniform);
+  // Past cache (uint32 view of past_key / past_value).  The shader's
+  // copy-past branch reads from these; for prompt step (past_seq=0) the
+  // shader never indexes them but the bindings must still exist.
+  sh.AddInput("k_cache_past", ShaderUsage::UseUniform);
+  sh.AddInput("v_cache_past", ShaderUsage::UseUniform);
+  sh.AddOutput("k_cache", ShaderUsage::UseUniform);
+  sh.AddOutput("v_cache", ShaderUsage::UseUniform);
+
+  uint32_t slot_bytes = SlotBytes(head_dim_, key_bits_, value_bits_);
+  // u32 view of the cache; slot must be 4-byte aligned for clean indexing.
+  uint32_t slot_u32 = (slot_bytes + 3) / 4;
+  uint32_t key_packed_u32 = ((head_dim_ * key_bits_) / 8 + 3) / 4;
+  uint32_t value_packed_u32 = ((head_dim_ * value_bits_) / 8 + 3) / 4;
+
+  // Parameters must be in ALPHABETICAL order (the wgsl-gen tool emits the
+  // struct fields alphabetically).  norm_correction is not used in the
+  // encode template, so it's not part of the param struct.
+  return WGSL_TEMPLATE_APPLY(
+      sh, "bert/turboquant_encode.wgsl.template",
+      WGSL_TEMPLATE_PARAMETER(head_dim, head_dim_),
+      WGSL_TEMPLATE_PARAMETER(key_bits, key_bits_),
+      WGSL_TEMPLATE_PARAMETER(key_packed_u32, key_packed_u32),
+      WGSL_TEMPLATE_PARAMETER(slot_u32, slot_u32),
+      WGSL_TEMPLATE_PARAMETER(value_bits, value_bits_),
+      WGSL_TEMPLATE_PARAMETER(value_packed_u32, value_packed_u32));
+}
+
+Status TurboQuantDecodeProgram::GenerateShaderCode(ShaderHelper& sh) const {
+  sh.AddInput("k_cache", ShaderUsage::UseUniform);
+  sh.AddInput("v_cache", ShaderUsage::UseUniform);
+  sh.AddInput("k_codebook", ShaderUsage::UseUniform);
+  sh.AddOutput("K_out", ShaderUsage::UseUniform);
+  sh.AddOutput("V_out", ShaderUsage::UseUniform);
+
+  uint32_t slot_bytes = SlotBytes(head_dim_, key_bits_, value_bits_);
+  uint32_t slot_u32 = (slot_bytes + 3) / 4;
+  uint32_t key_packed_u32 = ((head_dim_ * key_bits_) / 8 + 3) / 4;
+  uint32_t value_packed_u32 = ((head_dim_ * value_bits_) / 8 + 3) / 4;
+
+  return WGSL_TEMPLATE_APPLY(
+      sh, "bert/turboquant_decode.wgsl.template",
+      WGSL_TEMPLATE_PARAMETER(head_dim, head_dim_),
+      WGSL_TEMPLATE_PARAMETER(key_bits, key_bits_),
+      WGSL_TEMPLATE_PARAMETER(key_packed_u32, key_packed_u32),
+      WGSL_TEMPLATE_PARAMETER(norm_correction, norm_correction_ ? 1u : 0u),
+      WGSL_TEMPLATE_PARAMETER(slot_u32, slot_u32),
+      WGSL_TEMPLATE_PARAMETER(value_bits, value_bits_),
+      WGSL_TEMPLATE_PARAMETER(value_packed_u32, value_packed_u32));
+}
+
+Status RunTurboQuantAttention(onnxruntime::webgpu::ComputeContext& context,
+                              const WebgpuAttentionParameters& params,
+                              const Tensor* query,
+                              const Tensor* key,
+                              const Tensor* value,
+                              const Tensor* past_key,
+                              const Tensor* past_value,
+                              const Tensor* k_codebook,
+                              const Tensor* hadamard,
+                              const Tensor* attention_bias,
+                              const Tensor* head_sink,
+                              const Tensor* seqlen_k,
+                              const Tensor* cos_cache,
+                              const Tensor* sin_cache,
+                              Tensor* present_key,
+                              Tensor* present_value,
+                              Tensor* output,
+                              uint32_t key_bits,
+                              uint32_t value_bits,
+                              bool norm_correction,
+                              int local_window_size) {
+  ORT_UNUSED_PARAMETER(hadamard);
+  ORT_UNUSED_PARAMETER(seqlen_k);  // we use params.seqlen_present_kv_cache_
+  ORT_UNUSED_PARAMETER(local_window_size);
+
+  const uint32_t head_dim = static_cast<uint32_t>(params.head_size_);
+  const uint32_t batch_size = static_cast<uint32_t>(params.batch_size_);
+  const uint32_t kv_num_heads = static_cast<uint32_t>(params.kv_num_heads_);
+  const uint32_t new_seq_len = static_cast<uint32_t>(params.sequence_length_);
+  const uint32_t past_seq_len = static_cast<uint32_t>(params.seqlen_past_kv_cache_);
+  const uint32_t total_seq_len = static_cast<uint32_t>(params.total_sequence_length_);
+  const uint32_t max_seq_len = static_cast<uint32_t>(params.seqlen_present_kv_cache_);
+
+  // ORT WebGPU's ShaderVariableHelper rejects uint8 storage bindings (no WGSL
+  // type maps to a single u8).  Alias the packed uint8 cache as uint32 view
+  // tensors with shape (..., slot_u32) so bindings map to `array<u32>` — which
+  // is exactly how the WGSL templates read them (`k_cache[i]` returns u32).
+  const uint32_t k_slot_bytes = (head_dim * key_bits + 7) / 8 + 2;
+  const uint32_t v_slot_bytes = (head_dim * value_bits + 7) / 8 + 4;
+  const uint32_t slot_bytes = k_slot_bytes > v_slot_bytes ? k_slot_bytes : v_slot_bytes;
+  const int64_t slot_u32 = static_cast<int64_t>((slot_bytes + 3) / 4);
+  const TensorShape present_u32_shape{
+      static_cast<int64_t>(batch_size),
+      static_cast<int64_t>(kv_num_heads),
+      static_cast<int64_t>(max_seq_len),
+      slot_u32,
+  };
+  Tensor k_cache_present_u32(DataTypeImpl::GetType<uint32_t>(), present_u32_shape,
+                             present_key->MutableDataRaw(), present_key->Location());
+  Tensor v_cache_present_u32(DataTypeImpl::GetType<uint32_t>(), present_u32_shape,
+                             present_value->MutableDataRaw(), present_value->Location());
+
+  // Past cache uint32 view.  WGPU rejects (a) zero-sized storage bindings and
+  // (b) the same buffer being bound as both readonly-input and writable-output
+  // in one pass.  So for prompt step (past_seq_len = 0) we allocate a tiny
+  // dummy uint32 buffer that the shader's copy branch never indexes.
+  const int64_t past_dim2 = static_cast<int64_t>(past_seq_len > 0 ? past_seq_len : 1);
+  const TensorShape past_u32_shape{
+      static_cast<int64_t>(batch_size),
+      static_cast<int64_t>(kv_num_heads),
+      past_dim2,
+      slot_u32,
+  };
+  const bool have_past = past_seq_len > 0 && past_key != nullptr && past_value != nullptr;
+  Tensor dummy_past_k, dummy_past_v;
+  if (!have_past) {
+    dummy_past_k = context.CreateGPUTensor(DataTypeImpl::GetType<uint32_t>(), past_u32_shape);
+    dummy_past_v = context.CreateGPUTensor(DataTypeImpl::GetType<uint32_t>(), past_u32_shape);
+  }
+  Tensor k_cache_past_u32(DataTypeImpl::GetType<uint32_t>(), past_u32_shape,
+                          have_past ? const_cast<void*>(past_key->DataRaw())
+                                    : dummy_past_k.MutableDataRaw(),
+                          have_past ? past_key->Location() : dummy_past_k.Location());
+  Tensor v_cache_past_u32(DataTypeImpl::GetType<uint32_t>(), past_u32_shape,
+                          have_past ? const_cast<void*>(past_value->DataRaw())
+                                    : dummy_past_v.MutableDataRaw(),
+                          have_past ? past_value->Location() : dummy_past_v.Location());
+
+  // Step 1: encode (with copy-past + encode-fresh fused).  After this runs,
+  // present_key / present_value contain the full packed cache for this step.
+  TurboQuantEncodeProgram encode{head_dim, key_bits, value_bits, norm_correction};
+  encode.AddInputs({
+      {key, ProgramTensorMetadataDependency::TypeAndRank},
+      {value, ProgramTensorMetadataDependency::TypeAndRank},
+      {k_codebook, ProgramTensorMetadataDependency::TypeAndRank},
+      {&k_cache_past_u32, ProgramTensorMetadataDependency::TypeAndRank},
+      {&v_cache_past_u32, ProgramTensorMetadataDependency::TypeAndRank},
+  });
+  encode.AddOutputs({
+      {&k_cache_present_u32, ProgramTensorMetadataDependency::TypeAndRank},
+      {&v_cache_present_u32, ProgramTensorMetadataDependency::TypeAndRank},
+  });
+  encode.SetWorkgroupSize(head_dim);
+  encode.SetDispatchGroupSize(batch_size * kv_num_heads * total_seq_len);
+  encode.AddUniformVariables({
+      {batch_size},
+      {new_seq_len},
+      {kv_num_heads},
+      {max_seq_len},
+      {past_seq_len},
+  });
+  ORT_RETURN_IF_ERROR(context.RunProgram(encode));
+
+  // ApplyFlashAttention requires WebGPU subgroups (Chrome 136+).  When that
+  // feature is missing — Safari WebKit, Firefox today, older Chrome — we
+  // route through the non-FA `ApplyAttention` path instead.  The fallback
+  // costs us the fused-attention speedup but keeps TurboQuant correctness
+  // intact, and it's the only browser path that exists for those engines.
+  const bool has_subgroups = context.HasFeature(wgpu::FeatureName::Subgroups);
+  // Escape hatch: set ORT_TQ_DISABLE_FA=1 to force the ApplyAttention
+  // fallback even on subgroups-capable adapters.  Useful for diagnosing
+  // the Safari / Firefox code path on dev machines that have Chrome's
+  // subgroups feature.  Does not change KV-cache layout or quality —
+  // only routes scoring through the non-flash kernels.
+  // Use ORT's portable env reader instead of std::getenv — MSVC treats the
+  // latter as deprecated under /sdl, which fails the build with -Werror.
+  const bool force_fallback = !onnxruntime::detail::GetEnvironmentVar("ORT_TQ_DISABLE_FA").empty();
+  const bool use_fa = has_subgroups && !force_fallback;
+
+  // Step 2: prompt step uses Option ε — run standard FA on fresh fp16 K/V
+  // (when subgroups are available).  The cache is now correctly populated
+  // for the next step regardless of which attention kernel we pick.
+  if (past_seq_len == 0) {
+    if (use_fa) {
+      return ApplyFlashAttention(query, key, value, attention_bias, output,
+                                 nullptr, nullptr, nullptr, nullptr,
+                                 params, context, /*seqlens_k=*/nullptr,
+                                 cos_cache, sin_cache, head_sink);
+    }
+    // No-subgroups fallback: transfer Q/K/V to BNSH and call ApplyAttention.
+    const TensorShape q_bnsh{
+        static_cast<int64_t>(batch_size),
+        static_cast<int64_t>(params.num_heads_),
+        static_cast<int64_t>(new_seq_len),
+        static_cast<int64_t>(head_dim),
+    };
+    const TensorShape kv_bnsh{
+        static_cast<int64_t>(batch_size),
+        static_cast<int64_t>(kv_num_heads),
+        static_cast<int64_t>(new_seq_len),
+        static_cast<int64_t>(head_dim),
+    };
+    Tensor q_bnsh_t = context.CreateGPUTensor(query->DataType(), q_bnsh);
+    Tensor k_bnsh_t = context.CreateGPUTensor(key->DataType(), kv_bnsh);
+    Tensor v_bnsh_t = context.CreateGPUTensor(value->DataType(), kv_bnsh);
+    ORT_RETURN_IF_ERROR(TransferBSDToBNSH(
+        context, params.num_heads_, new_seq_len, head_dim, query, nullptr, 0, &q_bnsh_t));
+    ORT_RETURN_IF_ERROR(TransferBSDToBNSH(
+        context, kv_num_heads, new_seq_len, head_dim, key, nullptr, 0, &k_bnsh_t));
+    ORT_RETURN_IF_ERROR(TransferBSDToBNSH(
+        context, kv_num_heads, new_seq_len, head_dim, value, nullptr, 0, &v_bnsh_t));
+    WebgpuAttentionParameters aa_params = params;
+    aa_params.qkv_format_ = Q_K_V_BNSH;
+    aa_params.past_sequence_length_ = 0;
+    aa_params.seqlen_past_kv_cache_ = 0;
+    aa_params.total_sequence_length_ = static_cast<int>(new_seq_len);
+    return ApplyAttention(&q_bnsh_t, &k_bnsh_t, &v_bnsh_t, attention_bias,
+                          /*past_key=*/nullptr, /*past_value=*/nullptr,
+                          output, /*present_key=*/nullptr, /*present_value=*/nullptr,
+                          /*output_qk=*/nullptr, aa_params, context,
+                          head_sink, /*seqlen_k=*/nullptr, local_window_size);
+  }
+
+  // Step 3: decode all present slots → fp16 K/V scratch in BNSH layout.
+  const TensorShape kv_scratch_shape{
+      static_cast<int64_t>(batch_size),
+      static_cast<int64_t>(kv_num_heads),
+      static_cast<int64_t>(total_seq_len),
+      static_cast<int64_t>(head_dim),
+  };
+  Tensor k_scratch = context.CreateGPUTensor(query->DataType(), kv_scratch_shape);
+  Tensor v_scratch = context.CreateGPUTensor(query->DataType(), kv_scratch_shape);
+
+  TurboQuantDecodeProgram decode{head_dim, key_bits, value_bits, norm_correction};
+  decode.AddInputs({
+      {&k_cache_present_u32, ProgramTensorMetadataDependency::TypeAndRank},
+      {&v_cache_present_u32, ProgramTensorMetadataDependency::TypeAndRank},
+      {k_codebook, ProgramTensorMetadataDependency::TypeAndRank},
+  });
+  decode.AddOutputs({
+      {&k_scratch, ProgramTensorMetadataDependency::TypeAndRank},
+      {&v_scratch, ProgramTensorMetadataDependency::TypeAndRank},
+  });
+  decode.SetWorkgroupSize(head_dim);
+  decode.SetDispatchGroupSize(batch_size * kv_num_heads * total_seq_len);
+  decode.AddUniformVariables({
+      {batch_size},
+      {total_seq_len},
+      {kv_num_heads},
+      {max_seq_len},
+  });
+  ORT_RETURN_IF_ERROR(context.RunProgram(decode));
+
+  // Step 4: attention on the dequantised K/V scratch.
+  //
+  // k_scratch / v_scratch are BNSH-laid-out (this is the natural cache layout
+  // and matches what FA's `CopyKVCache` writes to its internal present_key).
+  if (use_fa) {
+    // FA path: tell it to read K/V as BNSH via Q_K_V_BSNH_BNSH_BNSH (Q stays
+    // BSNH).  Override kv_sequence_length to the FULL present length and
+    // clear past_seq so CopyKVCache treats k_scratch as the entire present
+    // cache.
+    WebgpuAttentionParameters fa_params = params;
+    fa_params.qkv_format_ = Q_K_V_BSNH_BNSH_BNSH;
+    fa_params.kv_sequence_length_ = static_cast<int>(total_seq_len);
+    fa_params.past_sequence_length_ = 0;
+    fa_params.seqlen_past_kv_cache_ = 0;
+    return ApplyFlashAttention(query, &k_scratch, &v_scratch, attention_bias, output,
+                               nullptr, nullptr, nullptr, nullptr,
+                               fa_params, context, /*seqlens_k=*/nullptr,
+                               cos_cache, sin_cache, head_sink);
+  }
+
+  // No-subgroups fallback: transfer Q (BSNH) to BNSH and call ApplyAttention.
+  // K/V scratch are already BNSH from the decode shader, so they pass through
+  // as-is.  We feed the entire present cache as K/V and set past_seq=0 so
+  // ApplyAttention doesn't try to do its own past-merging.
+  const TensorShape q_bnsh{
+      static_cast<int64_t>(batch_size),
+      static_cast<int64_t>(params.num_heads_),
+      static_cast<int64_t>(new_seq_len),
+      static_cast<int64_t>(head_dim),
+  };
+  Tensor q_bnsh_t = context.CreateGPUTensor(query->DataType(), q_bnsh);
+  ORT_RETURN_IF_ERROR(TransferBSDToBNSH(
+      context, params.num_heads_, new_seq_len, head_dim, query, nullptr, 0, &q_bnsh_t));
+  WebgpuAttentionParameters aa_params = params;
+  aa_params.qkv_format_ = Q_K_V_BNSH;
+  aa_params.kv_sequence_length_ = static_cast<int>(total_seq_len);
+  aa_params.past_sequence_length_ = 0;
+  aa_params.seqlen_past_kv_cache_ = 0;
+  return ApplyAttention(&q_bnsh_t, &k_scratch, &v_scratch, attention_bias,
+                        /*past_key=*/nullptr, /*past_value=*/nullptr,
+                        output, /*present_key=*/nullptr, /*present_value=*/nullptr,
+                        /*output_qk=*/nullptr, aa_params, context,
+                        head_sink, /*seqlen_k=*/nullptr, local_window_size);
+}
+
+}  // namespace webgpu
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/webgpu/bert/turboquant_attention.h
+++ b/onnxruntime/contrib_ops/webgpu/bert/turboquant_attention.h
@@ -1,0 +1,106 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/providers/webgpu/compute_context.h"
+#include "core/providers/webgpu/program.h"
+#include "core/providers/webgpu/shader_helper.h"
+#include "contrib_ops/webgpu/bert/attention_common.h"
+
+namespace onnxruntime {
+namespace contrib {
+namespace webgpu {
+
+using namespace onnxruntime::webgpu;
+
+// Encode kernel — packs fresh fp16 K/V into the uint8 cache.  One workgroup
+// per (batch, kv_head, new_token) slot.
+class TurboQuantEncodeProgram final : public Program<TurboQuantEncodeProgram> {
+ public:
+  TurboQuantEncodeProgram(uint32_t head_dim, uint32_t key_bits, uint32_t value_bits,
+                          bool norm_correction)
+      : Program{"TurboQuantEncode"},
+        head_dim_(head_dim),
+        key_bits_(key_bits),
+        value_bits_(value_bits),
+        norm_correction_(norm_correction) {}
+
+  Status GenerateShaderCode(ShaderHelper& sh) const override;
+
+  WEBGPU_PROGRAM_DEFINE_UNIFORM_VARIABLES(
+      {"batch_size", ProgramUniformVariableDataType::Uint32},
+      {"new_seq_len", ProgramUniformVariableDataType::Uint32},
+      {"n_kv_heads", ProgramUniformVariableDataType::Uint32},
+      {"max_seq_len", ProgramUniformVariableDataType::Uint32},
+      {"past_seq_len", ProgramUniformVariableDataType::Uint32});
+
+ private:
+  uint32_t head_dim_;
+  uint32_t key_bits_;
+  uint32_t value_bits_;
+  [[maybe_unused]] bool norm_correction_;  // unused in encode template; kept for symmetry with decode
+};
+
+// Decode kernel — reads packed cache, writes fp16 K/V scratch in BNSH layout
+// for downstream attention.  One workgroup per (batch, kv_head, slot).
+class TurboQuantDecodeProgram final : public Program<TurboQuantDecodeProgram> {
+ public:
+  TurboQuantDecodeProgram(uint32_t head_dim, uint32_t key_bits, uint32_t value_bits,
+                          bool norm_correction)
+      : Program{"TurboQuantDecode"},
+        head_dim_(head_dim),
+        key_bits_(key_bits),
+        value_bits_(value_bits),
+        norm_correction_(norm_correction) {}
+
+  Status GenerateShaderCode(ShaderHelper& sh) const override;
+
+  WEBGPU_PROGRAM_DEFINE_UNIFORM_VARIABLES(
+      {"batch_size", ProgramUniformVariableDataType::Uint32},
+      {"total_seq_len", ProgramUniformVariableDataType::Uint32},
+      {"n_kv_heads", ProgramUniformVariableDataType::Uint32},
+      {"max_seq_len", ProgramUniformVariableDataType::Uint32});
+
+ private:
+  uint32_t head_dim_;
+  uint32_t key_bits_;
+  uint32_t value_bits_;
+  bool norm_correction_;
+};
+
+// Top-level orchestrator: runs encode + decode + standard FlashAttention.
+// `key`, `value` are the fresh fp16 K/V from the model (BSNH layout, before
+// rotary).  `past_key`, `past_value` are the packed uint8 cache (BNSH layout).
+// `present_key`, `present_value` are the packed uint8 cache outputs.
+//
+// Behaviour mirrors the CUDA orchestrator with Option ε:
+//   - For prompt step (past_seq == 0): encode → ApplyFlashAttention on fresh
+//     fp16 K/V (skip decode entirely; bit-equivalent to fp16).
+//   - For decode step (past_seq > 0): encode → decode (dequant cache) →
+//     ApplyFlashAttention on the fp16 scratch.
+Status RunTurboQuantAttention(onnxruntime::webgpu::ComputeContext& context,
+                              const WebgpuAttentionParameters& params,
+                              const Tensor* query,
+                              const Tensor* key,
+                              const Tensor* value,
+                              const Tensor* past_key,
+                              const Tensor* past_value,
+                              const Tensor* k_codebook,
+                              const Tensor* hadamard,
+                              const Tensor* attention_bias,
+                              const Tensor* head_sink,
+                              const Tensor* seqlen_k,
+                              const Tensor* cos_cache,
+                              const Tensor* sin_cache,
+                              Tensor* present_key,
+                              Tensor* present_value,
+                              Tensor* output,
+                              uint32_t key_bits,
+                              uint32_t value_bits,
+                              bool norm_correction,
+                              int local_window_size);
+
+}  // namespace webgpu
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/webgpu/bert/turboquant_decode.wgsl.template
+++ b/onnxruntime/contrib_ops/webgpu/bert/turboquant_decode.wgsl.template
@@ -1,0 +1,204 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+//
+// TurboQuant decode kernel — reads the packed uint8 cache and writes fp16
+// K/V into a BNSH scratch buffer for downstream attention.  Mirrors the
+// CUDA TQDecodeKernel.
+//
+// One workgroup per (batch, kv_head, slot).  Workgroup size == head_dim.
+//
+// Outputs:
+//   K_out / V_out: array<f16> of shape (B, N_kv, total_seq, head_dim)
+//     in BNSH layout — the format ApplyFlashAttention / standard webgpu
+//     attention expects.
+
+#param head_dim
+#param key_bits
+#param value_bits
+#param norm_correction
+#param slot_u32
+#param key_packed_u32
+#param value_packed_u32
+
+const HEAD_DIM: u32 = head_dim;
+const KEY_LEVELS: u32 = 1u << key_bits;
+const KEY_PACKED_U32: u32 = key_packed_u32;
+const VALUE_PACKED_U32: u32 = value_packed_u32;
+const SLOT_U32: u32 = slot_u32;
+
+var<workgroup> smem_k: array<f32, head_dim>;
+var<workgroup> reduce_buf: array<f32, head_dim>;
+var<workgroup> shared_norm_corr: f32;
+var<workgroup> shared_vec_norm: f32;
+var<workgroup> shared_v_scale: f32;
+var<workgroup> shared_v_zero: f32;
+var<workgroup> shared_k_codebook: array<f32, 16>;
+
+fn f16_bits_to_f32(b: u32) -> f32 {
+  let sign = (b & 0x8000u) << 16u;
+  let exp = (b >> 10u) & 0x1Fu;
+  let mant = b & 0x3FFu;
+  if (exp == 0u) {
+    if (mant == 0u) { return bitcast<f32>(sign); }
+    // subnormal — approximate
+    return bitcast<f32>(sign | ((mant) << 13u));
+  }
+  if (exp == 0x1Fu) {
+    // inf or nan
+    if (mant != 0u) { return bitcast<f32>(sign | 0x7FC00000u); }
+    return bitcast<f32>(sign | 0x7F800000u);
+  }
+  let exp32 = (exp + 112u) << 23u;
+  let mant32 = mant << 13u;
+  return bitcast<f32>(sign | exp32 | mant32);
+}
+
+$MAIN {
+  let tid = local_idx;
+  let total_seq_len = uniforms.total_seq_len;
+  let n_kv_heads = uniforms.n_kv_heads;
+
+  let s = workgroup_idx % total_seq_len;
+  let h = (workgroup_idx / total_seq_len) % n_kv_heads;
+  let b = workgroup_idx / (total_seq_len * n_kv_heads);
+
+  if (b >= uniforms.batch_size) { return; }
+
+  // Cache the codebook (small, used per element).
+  if (tid < KEY_LEVELS) {
+    shared_k_codebook[tid] = f32(k_codebook[tid]);
+  }
+
+  let max_seq = uniforms.max_seq_len;
+  let slot_u32_off = ((b * n_kv_heads + h) * max_seq + s) * SLOT_U32;
+
+  // Read K indices (one per element of head_dim).  At 4 bits/index, 8 indices
+  // per u32; thread tid needs the u32 at index (tid / 8).
+  var k_idx: u32 = 0u;
+  if (tid < HEAD_DIM) {
+    if (key_bits == 4) {
+      let word = k_cache[slot_u32_off + (tid / 8u)];
+      k_idx = (word >> ((tid % 8u) * 4u)) & 0xFu;
+    } else if (key_bits == 3) {
+      // 8 indices in 3 bytes — bytes are spread across u32 boundaries.
+      let g = tid / 8u;
+      let j = tid % 8u;
+      let byte_off_g = g * 3u;
+      let u32_idx = byte_off_g / 4u;
+      let bit_off = (byte_off_g % 4u) * 8u;
+      var word24: u32 = (k_cache[slot_u32_off + u32_idx] >> bit_off) & 0xFFFFFFu;
+      // If those 3 bytes straddle a u32 boundary we need bits from the next u32.
+      if (bit_off > 8u) {
+        let leftover_bits = bit_off + 24u - 32u;
+        if (leftover_bits > 0u) {
+          let next_word = k_cache[slot_u32_off + u32_idx + 1u];
+          let needed = next_word & ((1u << leftover_bits) - 1u);
+          word24 = word24 | (needed << (24u - leftover_bits));
+        }
+      }
+      k_idx = (word24 >> (j * 3u)) & 0x7u;
+    }
+  }
+  workgroupBarrier();
+
+  if (tid < HEAD_DIM) { smem_k[tid] = shared_k_codebook[k_idx]; }
+  workgroupBarrier();
+
+  // Optional norm correction: re-normalise the centroid vector.
+  if (norm_correction == 1) {
+    if (tid < HEAD_DIM) { reduce_buf[tid] = smem_k[tid] * smem_k[tid]; }
+    workgroupBarrier();
+    var stride: u32 = HEAD_DIM / 2u;
+    loop {
+      if (stride == 0u) { break; }
+      if (tid < stride) { reduce_buf[tid] = reduce_buf[tid] + reduce_buf[tid + stride]; }
+      workgroupBarrier();
+      stride = stride / 2u;
+    }
+    if (tid == 0u) {
+      let sum_sq = reduce_buf[0];
+      shared_norm_corr = select(0.0, inverseSqrt(sum_sq), sum_sq > 1e-30);
+    }
+    workgroupBarrier();
+    if (tid < HEAD_DIM) { smem_k[tid] = smem_k[tid] * shared_norm_corr; }
+    workgroupBarrier();
+  }
+
+  // Read vec_norm fp16 from after packed K bytes.
+  if (tid == 0u) {
+    let vn_u16 = k_cache[slot_u32_off + KEY_PACKED_U32] & 0xFFFFu;
+    shared_vec_norm = f16_bits_to_f32(vn_u16);
+  }
+  workgroupBarrier();
+
+  if (tid < HEAD_DIM) { smem_k[tid] = smem_k[tid] * shared_vec_norm; }
+  workgroupBarrier();
+
+  // Apply Hadamard once more — H is symmetric self-inverse; this rotates
+  // back to original space.
+  var h_butterfly: u32 = 1u;
+  loop {
+    if (h_butterfly >= HEAD_DIM) { break; }
+    if (tid < HEAD_DIM / 2u) {
+      let pair = (tid / h_butterfly) * 2u * h_butterfly + (tid % h_butterfly);
+      let a = smem_k[pair];
+      let bb = smem_k[pair + h_butterfly];
+      smem_k[pair] = a + bb;
+      smem_k[pair + h_butterfly] = a - bb;
+    }
+    workgroupBarrier();
+    h_butterfly = h_butterfly * 2u;
+  }
+  let inv_sqrt_d = inverseSqrt(f32(HEAD_DIM));
+  if (tid < HEAD_DIM) { smem_k[tid] = smem_k[tid] * inv_sqrt_d; }
+  workgroupBarrier();
+
+  // Write K_out — BNSH layout: ((b * N_kv + h) * total_seq_len + s) * D + i.
+  let out_off = ((b * n_kv_heads + h) * total_seq_len + s) * HEAD_DIM;
+  if (tid < HEAD_DIM) {
+    var v = smem_k[tid];
+    if (v > 60000.0) { v = 60000.0; }
+    if (v < -60000.0) { v = -60000.0; }
+    K_out[out_off + tid] = f16(v);
+  }
+
+  // Decode V: read v_scale + v_zero metadata, then unpack indices.
+  if (tid == 0u) {
+    let v_meta_word = v_cache[slot_u32_off + VALUE_PACKED_U32];
+    shared_v_scale = f16_bits_to_f32(v_meta_word & 0xFFFFu);
+    shared_v_zero  = f16_bits_to_f32((v_meta_word >> 16u) & 0xFFFFu);
+  }
+  workgroupBarrier();
+
+  var v_idx: u32 = 0u;
+  if (tid < HEAD_DIM) {
+    if (value_bits == 4) {
+      let word = v_cache[slot_u32_off + (tid / 8u)];
+      v_idx = (word >> ((tid % 8u) * 4u)) & 0xFu;
+    } else if (value_bits == 3) {
+      let g = tid / 8u;
+      let j = tid % 8u;
+      let byte_off_g = g * 3u;
+      let u32_idx = byte_off_g / 4u;
+      let bit_off = (byte_off_g % 4u) * 8u;
+      var word24: u32 = (v_cache[slot_u32_off + u32_idx] >> bit_off) & 0xFFFFFFu;
+      if (bit_off > 8u) {
+        let leftover_bits = bit_off + 24u - 32u;
+        if (leftover_bits > 0u) {
+          let next_word = v_cache[slot_u32_off + u32_idx + 1u];
+          let needed = next_word & ((1u << leftover_bits) - 1u);
+          word24 = word24 | (needed << (24u - leftover_bits));
+        }
+      }
+      v_idx = (word24 >> (j * 3u)) & 0x7u;
+    }
+  }
+  workgroupBarrier();
+
+  if (tid < HEAD_DIM) {
+    var v_hat = shared_v_scale * f32(v_idx) + shared_v_zero;
+    if (v_hat > 60000.0) { v_hat = 60000.0; }
+    if (v_hat < -60000.0) { v_hat = -60000.0; }
+    V_out[out_off + tid] = f16(v_hat);
+  }
+}

--- a/onnxruntime/contrib_ops/webgpu/bert/turboquant_encode.wgsl.template
+++ b/onnxruntime/contrib_ops/webgpu/bert/turboquant_encode.wgsl.template
@@ -1,0 +1,301 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+//
+// TurboQuant encode kernel — writes fresh fp16 K/V tokens into the packed
+// uint8 cache.  Mirrors the CUDA TQEncodeKernel.  Parameters:
+//
+//   head_dim: power-of-two head dimension (e.g. 64, 128).  Workgroup size.
+//   key_bits: 3 or 4 (number of bits per K index).
+//   value_bits: 3 or 4 (number of bits per V index).
+//
+// Storage layout:
+//   K_in / V_in: array<f16> of shape (B, S, N_kv, head_dim) — flat BSNH layout
+//     used by ORT's GroupQueryAttention.
+//   k_codebook: array<f16> of length 2^key_bits — Lloyd-Max centroids (sorted).
+//   k_cache / v_cache: array<u32> — uint8-packed slots, viewed as u32 (4 bytes
+//     each).  Each slot is `slot_u32` u32s.
+//
+// One workgroup per (batch, kv_head, new_token).  Workgroup size == head_dim.
+
+#param head_dim
+#param key_bits
+#param value_bits
+// (norm_correction is not used in encode — only in decode)
+#param slot_u32          // u32s per slot (= slot_bytes / 4)
+#param key_packed_u32    // u32s of packed K indices (= ceil(head_dim*key_bits/8) / 4)
+#param value_packed_u32  // u32s of packed V indices (= ceil(head_dim*value_bits/8) / 4)
+
+const HEAD_DIM: u32 = head_dim;
+const KEY_LEVELS: u32 = 1u << key_bits;
+const VALUE_LEVELS: u32 = 1u << value_bits;
+const KEY_PACKED_U32: u32 = key_packed_u32;
+const VALUE_PACKED_U32: u32 = value_packed_u32;
+const SLOT_U32: u32 = slot_u32;
+
+var<workgroup> smem_k: array<f32, head_dim>;
+var<workgroup> smem_v: array<f32, head_dim>;
+var<workgroup> k_indices: array<u32, head_dim>;
+var<workgroup> v_indices: array<u32, head_dim>;
+var<workgroup> reduce_buf: array<f32, head_dim>;
+var<workgroup> shared_norm: f32;
+var<workgroup> shared_v_min: f32;
+var<workgroup> shared_v_max: f32;
+var<workgroup> shared_k_codebook: array<f32, 16>;  // up to 4-bit (16 levels)
+
+fn lookup_k_index(y: f32) -> u32 {
+  // Linear search over codebook midpoints.  KEY_LEVELS <= 16.
+  var idx: u32 = 0u;
+  for (var j: u32 = 1u; j < KEY_LEVELS; j = j + 1u) {
+    let mid = 0.5 * (shared_k_codebook[j - 1u] + shared_k_codebook[j]);
+    if (y > mid) { idx = idx + 1u; }
+  }
+  return idx;
+}
+
+$MAIN {
+  let tid = local_idx;
+  // Workgroup id maps to (batch, kv_head, slot_in_present).  The dispatch
+  // covers ALL present slots (total_seq_len = past + new), so a single launch
+  // produces the full present cache: copy past slots from past_key/past_value,
+  // and encode-then-pack fresh tokens for slots [past_seq..total_seq).
+  let new_seq_len = uniforms.new_seq_len;
+  let n_kv_heads = uniforms.n_kv_heads;
+  let past_seq_len = uniforms.past_seq_len;
+  let max_seq = uniforms.max_seq_len;
+  let total_seq_len = past_seq_len + new_seq_len;
+
+  let s_cache = workgroup_idx % total_seq_len;
+  let h = (workgroup_idx / total_seq_len) % n_kv_heads;
+  let b = workgroup_idx / (total_seq_len * n_kv_heads);
+
+  if (b >= uniforms.batch_size) { return; }
+
+  // Compute the present-slot u32 offset up-front.  Used by both the copy and
+  // the encode branches; also passed to the existing pack-and-write code at
+  // the end of this kernel.
+  let slot_u32_off = ((b * n_kv_heads + h) * max_seq + s_cache) * SLOT_U32;
+
+  // Past-copy branch — for slots already in the cache, just memcpy.  Each
+  // thread copies one u32 of the slot.
+  if (s_cache < past_seq_len) {
+    let past_off = ((b * n_kv_heads + h) * past_seq_len + s_cache) * SLOT_U32;
+    if (tid < SLOT_U32) {
+      k_cache[slot_u32_off + tid] = k_cache_past[past_off + tid];
+      v_cache[slot_u32_off + tid] = v_cache_past[past_off + tid];
+    }
+    return;
+  }
+
+  // Encode-fresh branch — compute the index of this token within K_in and
+  // run the full encode (Walsh-Hadamard rotation + Lloyd-Max for K, uniform
+  // asymmetric for V).
+  let s_new = s_cache - past_seq_len;
+
+  // Load K/V from BSNH input: stride is ((b * S + s_new) * N_kv + h) * D.
+  // K_in[(b * S + s_new) * N_kv * D + h * D + tid]
+  let in_off = ((b * new_seq_len + s_new) * n_kv_heads + h) * HEAD_DIM;
+  if (tid < HEAD_DIM) {
+    smem_k[tid] = f32(K_in[in_off + tid]);
+    smem_v[tid] = f32(V_in[in_off + tid]);
+  }
+  // Cache the codebook into shared memory so the lookup is fast.
+  if (tid < KEY_LEVELS) {
+    shared_k_codebook[tid] = f32(k_codebook[tid]);
+  }
+  workgroupBarrier();
+
+  // ||k|| via tree reduction.
+  if (tid < HEAD_DIM) { reduce_buf[tid] = smem_k[tid] * smem_k[tid]; }
+  workgroupBarrier();
+  var stride: u32 = HEAD_DIM / 2u;
+  loop {
+    if (stride == 0u) { break; }
+    if (tid < stride) { reduce_buf[tid] = reduce_buf[tid] + reduce_buf[tid + stride]; }
+    workgroupBarrier();
+    stride = stride / 2u;
+  }
+  if (tid == 0u) { shared_norm = sqrt(reduce_buf[0]); }
+  workgroupBarrier();
+  let vec_norm = shared_norm;
+  let inv_norm = select(0.0, 1.0 / vec_norm, vec_norm > 1e-9);
+
+  // Normalise K, then in-place FWHT.
+  if (tid < HEAD_DIM) { smem_k[tid] = smem_k[tid] * inv_norm; }
+  workgroupBarrier();
+
+  var h_butterfly: u32 = 1u;
+  loop {
+    if (h_butterfly >= HEAD_DIM) { break; }
+    if (tid < HEAD_DIM / 2u) {
+      let pair = (tid / h_butterfly) * 2u * h_butterfly + (tid % h_butterfly);
+      let a = smem_k[pair];
+      let bb = smem_k[pair + h_butterfly];
+      smem_k[pair] = a + bb;
+      smem_k[pair + h_butterfly] = a - bb;
+    }
+    workgroupBarrier();
+    h_butterfly = h_butterfly * 2u;
+  }
+  let inv_sqrt_d = inverseSqrt(f32(HEAD_DIM));
+  if (tid < HEAD_DIM) { smem_k[tid] = smem_k[tid] * inv_sqrt_d; }
+  workgroupBarrier();
+
+  // Encode K indices via codebook lookup.
+  if (tid < HEAD_DIM) { k_indices[tid] = lookup_k_index(smem_k[tid]); }
+  workgroupBarrier();
+
+  // V min/max via reductions.
+  if (tid < HEAD_DIM) { reduce_buf[tid] = smem_v[tid]; }
+  workgroupBarrier();
+  stride = HEAD_DIM / 2u;
+  loop {
+    if (stride == 0u) { break; }
+    if (tid < stride) { reduce_buf[tid] = min(reduce_buf[tid], reduce_buf[tid + stride]); }
+    workgroupBarrier();
+    stride = stride / 2u;
+  }
+  if (tid == 0u) { shared_v_min = reduce_buf[0]; }
+  workgroupBarrier();
+
+  if (tid < HEAD_DIM) { reduce_buf[tid] = smem_v[tid]; }
+  workgroupBarrier();
+  stride = HEAD_DIM / 2u;
+  loop {
+    if (stride == 0u) { break; }
+    if (tid < stride) { reduce_buf[tid] = max(reduce_buf[tid], reduce_buf[tid + stride]); }
+    workgroupBarrier();
+    stride = stride / 2u;
+  }
+  if (tid == 0u) { shared_v_max = reduce_buf[0]; }
+  workgroupBarrier();
+
+  let v_min = shared_v_min;
+  let v_max = shared_v_max;
+  let v_scale = (v_max - v_min) / f32(VALUE_LEVELS - 1u);
+  let inv_v_scale = select(0.0, 1.0 / v_scale, v_scale > 1e-12);
+
+  if (tid < HEAD_DIM) {
+    var q = i32(round((smem_v[tid] - v_min) * inv_v_scale));
+    if (q < 0) { q = 0; }
+    if (q > i32(VALUE_LEVELS - 1u)) { q = i32(VALUE_LEVELS - 1u); }
+    v_indices[tid] = u32(q);
+  }
+  workgroupBarrier();
+
+  // Pack and write.  slot_u32_off was already computed at the top of main.
+  // Pack K indices into u32s.  At 4 bits/index, 8 indices per u32.
+  if (key_bits == 4) {
+    if (tid < KEY_PACKED_U32) {
+      var word: u32 = 0u;
+      for (var i: u32 = 0u; i < 8u; i = i + 1u) {
+        word = word | ((k_indices[tid * 8u + i] & 0xFu) << (i * 4u));
+      }
+      k_cache[slot_u32_off + tid] = word;
+    }
+  } else if (key_bits == 3) {
+    // 8 indices in 3 bytes; ceil-pack.  Each thread handles 4 indices = 12 bits =
+    // less than a u32 — too fine-grained.  Simpler: thread 0 packs all.  Optimise later.
+    if (tid == 0u) {
+      var byte_buf: array<u32, 32>;  // up to head_dim*3/8 bytes; we just need head_dim*3/8 max
+      let n_bytes: u32 = (HEAD_DIM * 3u + 7u) / 8u;
+      // 8 indices -> 3 bytes
+      var byte_idx: u32 = 0u;
+      for (var g: u32 = 0u; g < HEAD_DIM / 8u; g = g + 1u) {
+        var word24: u32 = 0u;
+        for (var j: u32 = 0u; j < 8u; j = j + 1u) {
+          word24 = word24 | ((k_indices[g * 8u + j] & 0x7u) << (j * 3u));
+        }
+        byte_buf[byte_idx + 0u] = word24 & 0xFFu;
+        byte_buf[byte_idx + 1u] = (word24 >> 8u) & 0xFFu;
+        byte_buf[byte_idx + 2u] = (word24 >> 16u) & 0xFFu;
+        byte_idx = byte_idx + 3u;
+      }
+      // Now pack the bytes into u32s
+      for (var u: u32 = 0u; u < KEY_PACKED_U32; u = u + 1u) {
+        var word: u32 = 0u;
+        for (var k: u32 = 0u; k < 4u; k = k + 1u) {
+          if (u * 4u + k < n_bytes) {
+            word = word | (byte_buf[u * 4u + k] << (k * 8u));
+          }
+        }
+        k_cache[slot_u32_off + u] = word;
+      }
+    }
+  }
+
+  // Write vec_norm fp16 right after packed K bytes.  Stored in low 16 bits of
+  // u32 at index KEY_PACKED_U32 (or split across the boundary if K bytes don't
+  // align to u32).  For 4-bit hd=64: KEY_PACKED_U32 = 8, vec_norm is u32[8] low.
+  if (tid == 0u) {
+    let vn_u16: u32 = u32(bitcast<u32>(f32_to_f16_bits(vec_norm))) & 0xFFFFu;
+    k_cache[slot_u32_off + KEY_PACKED_U32] = vn_u16;
+  }
+
+  // Pack V indices analogously.
+  if (value_bits == 4) {
+    if (tid < VALUE_PACKED_U32) {
+      var word: u32 = 0u;
+      for (var i: u32 = 0u; i < 8u; i = i + 1u) {
+        word = word | ((v_indices[tid * 8u + i] & 0xFu) << (i * 4u));
+      }
+      v_cache[slot_u32_off + tid] = word;
+    }
+  } else if (value_bits == 3) {
+    if (tid == 0u) {
+      var byte_buf2: array<u32, 32>;
+      let n_bytes2: u32 = (HEAD_DIM * 3u + 7u) / 8u;
+      var byte_idx: u32 = 0u;
+      for (var g: u32 = 0u; g < HEAD_DIM / 8u; g = g + 1u) {
+        var word24: u32 = 0u;
+        for (var j: u32 = 0u; j < 8u; j = j + 1u) {
+          word24 = word24 | ((v_indices[g * 8u + j] & 0x7u) << (j * 3u));
+        }
+        byte_buf2[byte_idx + 0u] = word24 & 0xFFu;
+        byte_buf2[byte_idx + 1u] = (word24 >> 8u) & 0xFFu;
+        byte_buf2[byte_idx + 2u] = (word24 >> 16u) & 0xFFu;
+        byte_idx = byte_idx + 3u;
+      }
+      for (var u: u32 = 0u; u < VALUE_PACKED_U32; u = u + 1u) {
+        var word: u32 = 0u;
+        for (var k: u32 = 0u; k < 4u; k = k + 1u) {
+          if (u * 4u + k < n_bytes2) {
+            word = word | (byte_buf2[u * 4u + k] << (k * 8u));
+          }
+        }
+        v_cache[slot_u32_off + u] = word;
+      }
+    }
+  }
+
+  // Write v_scale fp16 + v_zero (=v_min) fp16 packed into low and high halves
+  // of u32[VALUE_PACKED_U32].
+  if (tid == 0u) {
+    let vs_u16 = u32(bitcast<u32>(f32_to_f16_bits(v_scale))) & 0xFFFFu;
+    let vz_u16 = u32(bitcast<u32>(f32_to_f16_bits(v_min))) & 0xFFFFu;
+    v_cache[slot_u32_off + VALUE_PACKED_U32] = vs_u16 | (vz_u16 << 16u);
+  }
+}
+
+// fp32 -> fp16 bit pattern.  Standard half-precision encoding.
+fn f32_to_f16_bits(x: f32) -> u32 {
+  let bits = bitcast<u32>(x);
+  let sign = (bits >> 16u) & 0x8000u;
+  let exp = (bits >> 23u) & 0xFFu;
+  let mant = bits & 0x7FFFFFu;
+  if (exp == 0xFFu) {
+    // inf or nan
+    if (mant != 0u) { return sign | 0x7E00u; }  // nan
+    return sign | 0x7C00u;                       // inf
+  }
+  if (exp < 113u) {
+    // Subnormal in fp16 or zero.
+    return sign;
+  }
+  if (exp > 142u) {
+    // Overflow -> inf
+    return sign | 0x7C00u;
+  }
+  let exp16 = (exp - 112u) & 0x1Fu;
+  let mant16 = mant >> 13u;
+  return sign | (exp16 << 10u) | mant16;
+}

--- a/onnxruntime/core/graph/contrib_ops/bert_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/bert_defs.cc
@@ -1250,6 +1250,14 @@ ONNX_MS_OPERATOR_SET_SCHEMA(
         .Attr("k_quant_type", "Quantization type for K cache. One of 'NONE', 'PER_TENSOR', 'PER_CHANNEL'.", AttributeProto::STRING, std::string("NONE"))
         .Attr("v_quant_type", "Quantization type for V cache. One of 'NONE', 'PER_TENSOR', 'PER_CHANNEL'.", AttributeProto::STRING, std::string("NONE"))
         .Attr("kv_cache_bit_width", "Bit width of quantized KV cache. Supported values are 8 and 4.", AttributeProto::INT, OPTIONAL_VALUE)
+        .Attr("kv_quant_method",
+              "KV cache compression method. One of 'none' (default), 'classic' (existing int4/int8/fp8 path "
+              "via k_scale/v_scale), 'turboquant' (Hadamard rotation + Lloyd-Max keys + uniform values; "
+              "requires k_codebook + hadamard inputs).",
+              AttributeProto::STRING, std::string("none"))
+        .Attr("key_quant_bits", "TurboQuant key quantization bits. 3 or 4. Default 4.", AttributeProto::INT, static_cast<int64_t>(4))
+        .Attr("value_quant_bits", "TurboQuant value quantization bits. 3 or 4. Default 4.", AttributeProto::INT, static_cast<int64_t>(4))
+        .Attr("norm_correction", "TurboQuant: re-normalize centroid vectors to unit length during decode (1 = on, 0 = off).", AttributeProto::INT, static_cast<int64_t>(0))
         .Input(0,
                "query",
                "Query with shape (batch_size, sequence_length, hidden_size), or packed QKV with shape"
@@ -1314,6 +1322,19 @@ ONNX_MS_OPERATOR_SET_SCHEMA(
                OpSchema::Optional)
         .Input(12, "k_scale", "Scale tensor for past_key.", "T_KV_SCALE", OpSchema::Optional)
         .Input(13, "v_scale", "Scale tensor for past_value.", "T_KV_SCALE", OpSchema::Optional)
+        .Input(14,
+               "k_codebook",
+               "TurboQuant: 1D static Lloyd-Max centroid table with shape (2^key_quant_bits,). "
+               "Required when kv_quant_method == 'turboquant'.",
+               "T",
+               OpSchema::Optional)
+        .Input(15,
+               "hadamard",
+               "TurboQuant: 2D Walsh-Hadamard rotation matrix with shape (head_size, head_size). "
+               "Required when kv_quant_method == 'turboquant'. Implementations may compute the FWHT "
+               "directly instead of consuming this matrix; both shapes pass schema validation.",
+               "T",
+               OpSchema::Optional)
         .Output(0,
                 "output",
                 "3D output tensor with shape (batch_size, sequence_length, hidden_size)",

--- a/onnxruntime/core/optimizer/graph_transformer_utils.cc
+++ b/onnxruntime/core/optimizer/graph_transformer_utils.cc
@@ -49,6 +49,7 @@
 #include "core/optimizer/gemm_sum_fusion.h"
 #include "core/optimizer/gemm_transpose_fusion.h"
 #include "core/optimizer/group_query_attention_fusion.h"
+#include "core/optimizer/turboquant_kv_fusion.h"
 #include "core/optimizer/identical_children_consolidation.h"
 #include "core/optimizer/identity_elimination.h"
 #include "core/optimizer/label_encoder_fusion.h"
@@ -405,6 +406,29 @@ InlinedVector<std::unique_ptr<GraphTransformer>> GenerateTransformers(
       transformers.emplace_back(std::make_unique<MatmulTransposeFusion>(cpu_cuda_dml_eps));
       transformers.emplace_back(std::make_unique<BiasGeluFusion>(cpu_acl_cuda_dml_eps));
       transformers.emplace_back(std::make_unique<GroupQueryAttentionFusion>(cuda_eps));
+
+      // TurboQuantKVFusion: rewrites GroupQueryAttention nodes to use TurboQuant
+      // KV-cache compression at session-create time, so users can load a stock
+      // q4f16 .onnx from HuggingFace and opt-in via session option alone.
+      // Disabled by default; enabled when kOrtSessionOptionsTurboQuantKVMethod
+      // is set to a non-empty preset string.  Runs only on the CUDA EP.
+      {
+        const std::string tq_preset = session_options.config_options.GetConfigOrDefault(
+            kOrtSessionOptionsTurboQuantKVMethod, "");
+        if (!tq_preset.empty() && tq_preset != "none" && tq_preset != "off") {
+          const int tq_boundary = ParseStringWithClassicLocale<int>(
+              session_options.config_options.GetConfigOrDefault(
+                  kOrtSessionOptionsTurboQuantKVBoundary, "2"));
+          // Allow on CUDA AND WebGPU EPs.  Both have TurboQuant kernels.
+          const InlinedHashSet<std::string_view> tq_eps = {
+              onnxruntime::kCudaExecutionProvider,
+              onnxruntime::kWebGpuExecutionProvider,
+          };
+          transformers.emplace_back(std::make_unique<TurboQuantKVFusion>(
+              tq_preset, tq_boundary, tq_eps));
+        }
+      }
+
       // Run MatMulAddFusion again after *AttentionFusion transforms with `preserve_attention_pattern = false`,
       // to cleanup the remaining MatMul-Add that were part of the attention pattern but not detected or fused.
       transformers.emplace_back(std::make_unique<MatMulAddFusion>(no_limit_empty_ep_list, false));

--- a/onnxruntime/core/optimizer/turboquant_kv_fusion.cc
+++ b/onnxruntime/core/optimizer/turboquant_kv_fusion.cc
@@ -1,0 +1,409 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/optimizer/turboquant_kv_fusion.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "core/common/float16.h"
+#include "core/graph/graph_utils.h"
+#include "core/graph/node_arg.h"
+#include "core/optimizer/initializer.h"
+#include "core/optimizer/utils.h"
+#include "core/session/onnxruntime_session_options_config_keys.h"
+
+namespace onnxruntime {
+
+namespace {
+
+// ----------------------------------------------------------------------------
+// Preset parsing.  Mirrors the python TQ_PRESETS dictionary used by the
+// offline calibration tool, so the same string identifiers work for both.
+// ----------------------------------------------------------------------------
+
+struct TQPreset {
+  int key_bits;
+  int value_bits;
+  bool norm_correction;
+};
+
+// Returns true and fills `out` if the preset string is recognised.  Empty,
+// "none", "off" all return false (= disabled).
+bool ParseTQPreset(const std::string& s, TQPreset* out) {
+  if (s.empty() || s == "none" || s == "off" || s == "0") return false;
+  if (s == "turboquant_4bit_nc") { *out = {4, 4, true}; return true; }
+  if (s == "turboquant_k3v4_nc") { *out = {3, 4, true}; return true; }
+  if (s == "turboquant_3bit_nc") { *out = {3, 3, true}; return true; }
+  if (s == "turboquant_4bit")    { *out = {4, 4, false}; return true; }
+  if (s == "turboquant_3bit")    { *out = {3, 3, false}; return true; }
+  return false;
+}
+
+// ----------------------------------------------------------------------------
+// Lloyd-Max centroids for N(0, 1/d).  Computed at runtime via the same
+// fixed-point iteration used by the python reference (centroids.py); the
+// resulting values are deterministic given (d, bits) and identical to what
+// the offline rewriter injects.
+// ----------------------------------------------------------------------------
+
+double GaussianPdf(double x, double sigma2) {
+  static constexpr double kInvSqrtTwoPi = 0.39894228040143267793994605993438;
+  return (kInvSqrtTwoPi / std::sqrt(sigma2)) * std::exp(-x * x / (2.0 * sigma2));
+}
+
+double Trapz(double a, double b, int n, double sigma2,
+             bool weighted_by_x) {
+  if (n <= 0 || a >= b) return 0.0;
+  const double h = (b - a) / static_cast<double>(n);
+  auto eval = [&](double x) {
+    double f = GaussianPdf(x, sigma2);
+    return weighted_by_x ? x * f : f;
+  };
+  double acc = 0.5 * (eval(a) + eval(b));
+  for (int i = 1; i < n; ++i) {
+    acc += eval(a + static_cast<double>(i) * h);
+  }
+  return acc * h;
+}
+
+std::vector<float> SolveLloydMax(int d, int bits) {
+  const int n_levels = 1 << bits;
+  const double sigma2 = 1.0 / static_cast<double>(d);
+  const double sigma = std::sqrt(sigma2);
+
+  // Initial centroids: evenly spaced in [-3.5σ, 3.5σ].
+  std::vector<double> centroids(n_levels);
+  const double lo = -3.5 * sigma;
+  const double hi = 3.5 * sigma;
+  for (int i = 0; i < n_levels; ++i) {
+    centroids[i] = lo + (hi - lo) * (static_cast<double>(i) + 0.5) /
+                            static_cast<double>(n_levels);
+  }
+
+  constexpr int kMaxIter = 200;
+  constexpr double kTol = 1e-10;
+  constexpr int kIntegN = 200;
+  for (int iter = 0; iter < kMaxIter; ++iter) {
+    // Boundaries = midpoints between consecutive centroids.
+    std::vector<double> bounds(n_levels + 1);
+    bounds.front() = -10.0 * sigma;
+    bounds.back() = 10.0 * sigma;
+    for (int i = 0; i < n_levels - 1; ++i) {
+      bounds[i + 1] = 0.5 * (centroids[i] + centroids[i + 1]);
+    }
+    // New centroids = E[X | b_{i-1} < X <= b_i] under N(0, sigma2).
+    std::vector<double> new_centroids(n_levels);
+    double max_drift = 0.0;
+    for (int i = 0; i < n_levels; ++i) {
+      const double num = Trapz(bounds[i], bounds[i + 1], kIntegN, sigma2, true);
+      const double den = Trapz(bounds[i], bounds[i + 1], kIntegN, sigma2, false);
+      new_centroids[i] = (den > 1e-30) ? (num / den) : centroids[i];
+      max_drift = std::max(max_drift, std::abs(new_centroids[i] - centroids[i]));
+    }
+    centroids = std::move(new_centroids);
+    if (max_drift < kTol) break;
+  }
+
+  std::vector<float> result(n_levels);
+  for (int i = 0; i < n_levels; ++i) result[i] = static_cast<float>(centroids[i]);
+  return result;
+}
+
+// ----------------------------------------------------------------------------
+// Walsh-Hadamard matrix (Sylvester construction) of order d, normalised so
+// H * H^T = I.  d must be a power of two.
+// ----------------------------------------------------------------------------
+
+std::vector<float> BuildWalshHadamard(int d) {
+  // Recursively build via Kronecker product with [[1, 1], [1, -1]].
+  std::vector<float> H(static_cast<size_t>(d) * d, 1.0f);
+  for (int n = 1; n < d; n *= 2) {
+    for (int i = 0; i < n; ++i) {
+      for (int j = 0; j < n; ++j) {
+        const float a = H[static_cast<size_t>(i) * d + j];
+        H[static_cast<size_t>(i) * d + (j + n)] = a;
+        H[static_cast<size_t>(i + n) * d + j] = a;
+        H[static_cast<size_t>(i + n) * d + (j + n)] = -a;
+      }
+    }
+  }
+  // Normalise by 1/sqrt(d) so H is orthonormal.
+  const float inv = 1.0f / std::sqrt(static_cast<float>(d));
+  for (auto& v : H) v *= inv;
+  return H;
+}
+
+// ----------------------------------------------------------------------------
+// Helpers for adding initializers and modifying nodes / IO type info.
+// ----------------------------------------------------------------------------
+
+NodeArg& AddFp16Initializer(Graph& graph,
+                            const std::string& name,
+                            const std::vector<float>& fp32_data,
+                            const std::vector<int64_t>& shape) {
+  // Convert fp32 -> fp16.
+  std::vector<MLFloat16> fp16_data(fp32_data.size());
+  for (size_t i = 0; i < fp32_data.size(); ++i) {
+    fp16_data[i] = MLFloat16(fp32_data[i]);
+  }
+  ONNX_NAMESPACE::TensorProto tp;
+  tp.set_name(name);
+  tp.set_data_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT16);
+  for (auto d : shape) tp.add_dims(d);
+  tp.set_raw_data(fp16_data.data(), fp16_data.size() * sizeof(MLFloat16));
+  return graph_utils::AddInitializer(graph, tp);
+}
+
+// Set a string attribute on a node, replacing any existing value of that name.
+void SetStringAttr(Node& node, const std::string& name, const std::string& value) {
+  ONNX_NAMESPACE::AttributeProto attr;
+  attr.set_name(name);
+  attr.set_type(ONNX_NAMESPACE::AttributeProto_AttributeType_STRING);
+  attr.set_s(value);
+  node.AddAttributeProto(std::move(attr));
+}
+
+void SetIntAttr(Node& node, const std::string& name, int64_t value) {
+  ONNX_NAMESPACE::AttributeProto attr;
+  attr.set_name(name);
+  attr.set_type(ONNX_NAMESPACE::AttributeProto_AttributeType_INT);
+  attr.set_i(value);
+  node.AddAttributeProto(std::move(attr));
+}
+
+// Slot byte sizes for the packed cache layout.
+//   K slot: ceil(D * key_bits / 8) bytes + 2 bytes of fp16 vec_norm.
+//   V slot: ceil(D * value_bits / 8) bytes + 4 bytes (v_scale fp16 + v_zero fp16).
+int SlotBytes(int head_dim, int bits, bool is_value) {
+  return ((head_dim * bits) + 7) / 8 + (is_value ? 4 : 2);
+}
+
+// Mutate a NodeArg's TypeProto to (uint8, [..., new_last_dim]).  Used to
+// rewrite the past_key/past_value/present_key/present_value tensor shapes
+// to the packed cache layout.  We can't call NodeArg::SetType directly (it's
+// private to Graph), so we go through UpdateTypeAndShape with
+// override_types=true — that's the public path optimizer transforms use to
+// change a graph value's element type.
+Status RewriteCacheNodeArg(NodeArg& arg, int64_t new_last_dim,
+                           const logging::Logger& logger) {
+  const auto* existing = arg.TypeAsProto();
+  ONNX_NAMESPACE::TypeProto rewritten;
+  if (existing != nullptr) {
+    rewritten = *existing;
+  }
+  auto* tt = rewritten.mutable_tensor_type();
+  tt->set_elem_type(ONNX_NAMESPACE::TensorProto_DataType_UINT8);
+  if (tt->has_shape() && tt->shape().dim_size() > 0) {
+    auto* last_dim = tt->mutable_shape()->mutable_dim(tt->shape().dim_size() - 1);
+    last_dim->clear_dim_param();
+    last_dim->set_dim_value(new_last_dim);
+  }
+  return arg.UpdateTypeAndShape(rewritten, /*strict=*/false,
+                                /*override_types=*/true, logger);
+}
+
+// Try to read head_dim from the past_key NodeArg's shape.  Returns -1 if
+// shape information is missing.
+int InferHeadDimFromPastKey(const NodeArg* past_key_arg) {
+  if (past_key_arg == nullptr) return -1;
+  const auto* tp = past_key_arg->TypeAsProto();
+  if (tp == nullptr || !tp->has_tensor_type()) return -1;
+  const auto& tt = tp->tensor_type();
+  if (!tt.has_shape() || tt.shape().dim_size() < 4) return -1;
+  // past_key shape: (batch, num_kv_heads, seq, head_size).  Use the last dim.
+  const auto& last = tt.shape().dim(tt.shape().dim_size() - 1);
+  if (!last.has_dim_value()) return -1;
+  return static_cast<int>(last.dim_value());
+}
+
+// Cache: one shared codebook + Hadamard initializer per (head_dim, key_bits).
+// Avoids duplicating the same 16-fp16 / 64*64-fp16 tensor for every layer.
+struct InitCache {
+  // Stable names so repeated runs of this transformer (e.g. session re-create)
+  // collide on the same initializer instead of accumulating duplicates.
+  static std::string CodebookName(int head_dim, int key_bits) {
+    return "__turboquant_kcodebook__hd" + std::to_string(head_dim) +
+           "_b" + std::to_string(key_bits);
+  }
+  static std::string HadamardName(int head_dim) {
+    return "__turboquant_hadamard__hd" + std::to_string(head_dim);
+  }
+
+  NodeArg* GetOrCreateCodebook(Graph& graph, int head_dim, int key_bits) {
+    const std::string name = CodebookName(head_dim, key_bits);
+    auto it = codebook_args_.find(name);
+    if (it != codebook_args_.end()) return it->second;
+    const ONNX_NAMESPACE::TensorProto* existing_init = nullptr;
+    if (graph.GetInitializedTensor(name, existing_init)) {
+      // Already exists in the graph (e.g. user pre-converted), reuse the NodeArg.
+      NodeArg* existing = graph.GetNodeArg(name);
+      codebook_args_[name] = existing;
+      return existing;
+    }
+    auto values = SolveLloydMax(head_dim, key_bits);
+    NodeArg& arg = AddFp16Initializer(graph, name, values,
+                                      {static_cast<int64_t>(values.size())});
+    codebook_args_[name] = &arg;
+    return &arg;
+  }
+
+  NodeArg* GetOrCreateHadamard(Graph& graph, int head_dim) {
+    const std::string name = HadamardName(head_dim);
+    auto it = hadamard_args_.find(name);
+    if (it != hadamard_args_.end()) return it->second;
+    const ONNX_NAMESPACE::TensorProto* existing_init = nullptr;
+    if (graph.GetInitializedTensor(name, existing_init)) {
+      NodeArg* existing = graph.GetNodeArg(name);
+      hadamard_args_[name] = existing;
+      return existing;
+    }
+    auto values = BuildWalshHadamard(head_dim);
+    NodeArg& arg = AddFp16Initializer(graph, name, values,
+                                      {head_dim, head_dim});
+    hadamard_args_[name] = &arg;
+    return &arg;
+  }
+
+ private:
+  std::unordered_map<std::string, NodeArg*> codebook_args_;
+  std::unordered_map<std::string, NodeArg*> hadamard_args_;
+};
+
+}  // namespace
+
+Status TurboQuantKVFusion::ApplyImpl(Graph& graph, bool& modified, int /*graph_level*/,
+                                     const logging::Logger& logger) const {
+  modified = false;
+
+  // Read session option that gates this transformer.  No option => skip.
+  TQPreset preset{};
+  if (!ParseTQPreset(preset_, &preset)) {
+    return Status::OK();
+  }
+  // Boundary protection (number of first/last GQA layers to leave at fp16).
+  int boundary_n = boundary_n_;
+
+  // First pass: find all GroupQueryAttention nodes (com.microsoft) in order.
+  std::vector<Node*> gqa_nodes;
+  for (auto& node : graph.Nodes()) {
+    if (node.OpType() == "GroupQueryAttention" &&
+        (node.Domain() == "com.microsoft" || node.Domain().empty())) {
+      gqa_nodes.push_back(&node);
+    }
+  }
+  if (gqa_nodes.empty()) {
+    return Status::OK();
+  }
+
+  const int n_layers = static_cast<int>(gqa_nodes.size());
+  const int skip_lo = std::min(boundary_n, n_layers);
+  const int skip_hi = std::max(0, n_layers - boundary_n);
+
+  // Try to infer head_dim from the first node that has a usable past_key shape.
+  int head_dim = -1;
+  for (Node* node : gqa_nodes) {
+    if (node->InputDefs().size() > 3) {
+      head_dim = InferHeadDimFromPastKey(node->InputDefs()[3]);
+      if (head_dim > 0) break;
+    }
+  }
+  if (head_dim <= 0) {
+    LOGS(logger, WARNING) << "TurboQuantKVFusion: could not infer head_dim from any "
+                          << "GroupQueryAttention past_key shape; skipping rewrite";
+    return Status::OK();
+  }
+  // Sanity: TurboQuant kernels are dispatched on power-of-two head_dim ∈ {64, 128, 256}.
+  if (head_dim & (head_dim - 1)) {
+    LOGS(logger, WARNING) << "TurboQuantKVFusion: head_dim=" << head_dim
+                          << " is not a power of two; skipping";
+    return Status::OK();
+  }
+
+  const int k_slot = SlotBytes(head_dim, preset.key_bits, false);
+  const int v_slot = SlotBytes(head_dim, preset.value_bits, true);
+  const int cache_last_dim = std::max(k_slot, v_slot);
+
+  InitCache init_cache;
+  NodeArg* codebook_arg = init_cache.GetOrCreateCodebook(graph, head_dim, preset.key_bits);
+  NodeArg* hadamard_arg = init_cache.GetOrCreateHadamard(graph, head_dim);
+
+  // Empty NodeArg, used when we need to pad the input list to slot 14 / 15.
+  NodeArg& empty_arg = graph.GetOrCreateNodeArg("", nullptr);
+
+  int n_rewritten = 0;
+  for (int idx = 0; idx < n_layers; ++idx) {
+    if (idx < skip_lo || idx >= skip_hi) {
+      LOGS(logger, INFO) << "TurboQuantKVFusion: skipping layer " << idx
+                         << " (boundary protection)";
+      continue;
+    }
+    Node& node = *gqa_nodes[idx];
+
+    // Set / replace attributes.
+    SetStringAttr(node, "kv_quant_method", "turboquant");
+    SetIntAttr(node, "key_quant_bits", preset.key_bits);
+    SetIntAttr(node, "value_quant_bits", preset.value_bits);
+    SetIntAttr(node, "norm_correction", preset.norm_correction ? 1 : 0);
+
+    // Pad input list to length 16 with empty NodeArgs and wire codebook / hadamard.
+    auto& input_defs = node.MutableInputDefs();
+    while (input_defs.size() < 14) {
+      input_defs.push_back(&empty_arg);
+    }
+    if (input_defs.size() == 14) {
+      input_defs.push_back(codebook_arg);
+    } else {
+      input_defs[14] = codebook_arg;
+    }
+    if (input_defs.size() == 15) {
+      input_defs.push_back(hadamard_arg);
+    } else {
+      input_defs[15] = hadamard_arg;
+    }
+
+    // Keep MutableInputArgsCount in sync with the new input count.  ORT
+    // requires sum(args_count) == size(input_defs); since GroupQueryAttention
+    // is all-singleton (no variadic inputs), set every slot to 1 — empty
+    // optional inputs use empty NodeArg sentinels but still consume one slot.
+    auto& args_count = node.MutableInputArgsCount();
+    args_count.assign(input_defs.size(), 1);
+
+    // Rewrite past_key (3), past_value (4), present_key (1), present_value (2)
+    // to (uint8, [..., cache_last_dim]) by mutating the underlying NodeArg.
+    auto rewrite_idx = [&](size_t slot, bool is_input) -> Status {
+      const auto& defs = is_input ? node.InputDefs() : node.OutputDefs();
+      if (slot < defs.size() && defs[slot] != nullptr && defs[slot]->Exists()) {
+        // Look up the canonical NodeArg in the graph and rewrite it.
+        NodeArg* canonical = graph.GetNodeArg(defs[slot]->Name());
+        if (canonical != nullptr) {
+          ORT_RETURN_IF_ERROR(RewriteCacheNodeArg(*canonical, cache_last_dim, logger));
+        }
+      }
+      return Status::OK();
+    };
+    ORT_RETURN_IF_ERROR(rewrite_idx(3, /*is_input=*/true));
+    ORT_RETURN_IF_ERROR(rewrite_idx(4, /*is_input=*/true));
+    ORT_RETURN_IF_ERROR(rewrite_idx(1, /*is_input=*/false));
+    ORT_RETURN_IF_ERROR(rewrite_idx(2, /*is_input=*/false));
+
+    ++n_rewritten;
+  }
+
+  if (n_rewritten > 0) {
+    LOGS(logger, INFO) << "TurboQuantKVFusion: rewrote " << n_rewritten
+                       << " / " << n_layers << " GQA nodes for preset '"
+                       << preset_ << "' (k_slot=" << k_slot
+                       << " v_slot=" << v_slot
+                       << " cache_last_dim=" << cache_last_dim << ")";
+    graph.SetGraphResolveNeeded();
+    modified = true;
+  }
+  return Status::OK();
+}
+
+}  // namespace onnxruntime

--- a/onnxruntime/core/optimizer/turboquant_kv_fusion.h
+++ b/onnxruntime/core/optimizer/turboquant_kv_fusion.h
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/optimizer/graph_transformer.h"
+
+namespace onnxruntime {
+
+/**
+@class TurboQuantKVFusion
+
+Pattern-matches existing GroupQueryAttention nodes in the graph and rewrites
+them to use TurboQuant KV cache compression.
+
+What it does:
+  1. For each GroupQueryAttention node, set kv_quant_method = "turboquant",
+     key_quant_bits = 3 or 4, value_quant_bits = 4, norm_correction = true
+     (configurable via session options).
+  2. Inject the static Lloyd-Max codebook (computed by the Python calibration
+     tool turboquant_kv_quantizer.py) as a constant graph initializer
+     `<node_name>__k_centroids`.
+  3. Inject the Walsh-Hadamard rotation matrix as a constant initializer
+     `<node_name>__hadamard` (head_dim x head_dim, fp16).
+  4. Rewrite past_key_values / present_key_values tensor types from fp16 to
+     uint8 with the new packed shape.
+
+Mirrors the structure of:
+  - core/optimizer/group_query_attention_fusion.cc
+  - core/optimizer/dq_matmulnbits_fusion.cc
+
+Gated by session option kOrtSessionOptionsTurboQuantKV.
+*/
+class TurboQuantKVFusion : public GraphTransformer {
+ public:
+  TurboQuantKVFusion(
+      const std::string& preset = "",
+      int boundary_n = 2,
+      const InlinedHashSet<std::string_view>& compatible_execution_providers = {}) noexcept
+      : GraphTransformer("TurboQuantKVFusion", compatible_execution_providers),
+        preset_(preset),
+        boundary_n_(boundary_n) {}
+
+ private:
+  Status ApplyImpl(Graph& graph, bool& modified, int graph_level,
+                   const logging::Logger& logger) const override;
+
+  std::string preset_;
+  int boundary_n_;
+};
+
+}  // namespace onnxruntime

--- a/onnxruntime/test/contrib_ops/turboquant_kv_test.cc
+++ b/onnxruntime/test/contrib_ops/turboquant_kv_test.cc
@@ -1,0 +1,286 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "core/framework/int3.h"
+#include "test/common/cuda_op_test_utils.h"
+
+// CUDA kernel correctness for TurboQuant is validated via Phase 5 end-to-end
+// model runs (LFM2-1.2B), not via in-process gtests. The reason: the
+// `onnxruntime_provider_test` binary does NOT link `libonnxruntime_providers_cuda.so`
+// at link time — the CUDA EP is loaded dynamically via dlopen during the test.
+// Calling our kernel launcher's symbols directly from a gtest .cc would require
+// dlsym + a separate test driver. We keep the host-side `Int3x8` tests (which
+// validate the bit-layout that the CUDA kernel must match) and defer CUDA
+// correctness to model-level e2e validation.
+
+namespace onnxruntime {
+namespace test {
+
+// =============================================================================
+// UInt3x8 unit tests.
+// =============================================================================
+
+TEST(TurboQuantKVTest, Int3x8_RoundtripBijective) {
+  // 8 values into 3 bytes, then back. Exhaustive over a slice of inputs.
+  for (uint8_t v0 = 0; v0 <= 7; ++v0) {
+    for (uint8_t v7 = 0; v7 <= 7; ++v7) {
+      const uint8_t in[8] = {v0, 1, 2, 3, 4, 5, 6, v7};
+      UInt3x8 packed(in);
+      EXPECT_EQ(packed.GetElem(0), v0);
+      EXPECT_EQ(packed.GetElem(7), v7);
+      for (size_t i = 0; i < 8; ++i) {
+        EXPECT_EQ(packed.GetElem(i), in[i]);
+      }
+    }
+  }
+}
+
+TEST(TurboQuantKVTest, Int3x8_BitLayoutMatchesSpec) {
+  // Verify the documented bit layout: byte0 = (v0) | (v1<<3) | (low2 of v2 << 6).
+  // For v = [1, 2, 3, 4, 5, 6, 7, 0]:
+  //   word = 1 | (2<<3) | (3<<6) | (4<<9) | (5<<12) | (6<<15) | (7<<18) | (0<<21)
+  //        = 0x1F58D1   ⇒ byte0=0xD1, byte1=0x58, byte2=0x1F
+  const uint8_t in[8] = {1, 2, 3, 4, 5, 6, 7, 0};
+  UInt3x8 packed(in);
+  EXPECT_EQ(static_cast<uint8_t>(packed.bytes_[0]), 0xD1);
+  EXPECT_EQ(static_cast<uint8_t>(packed.bytes_[1]), 0x58);
+  EXPECT_EQ(static_cast<uint8_t>(packed.bytes_[2]), 0x1F);
+}
+
+TEST(TurboQuantKVTest, Int3x8_BulkPackUnpack) {
+  std::vector<uint8_t> values(128);
+  for (size_t i = 0; i < values.size(); ++i) {
+    values[i] = static_cast<uint8_t>(i % 8);
+  }
+  std::vector<UInt3x8> packed(UInt3x8::CalcNumPacks(values.size()));
+  EXPECT_TRUE(UInt3x8::Pack(packed, values));
+
+  std::vector<uint8_t> recovered(values.size());
+  EXPECT_TRUE(UInt3x8::Unpack(recovered, packed));
+  EXPECT_EQ(values, recovered);
+}
+
+TEST(TurboQuantKVTest, Int3x8_SetGet) {
+  UInt3x8 p;
+  for (size_t i = 0; i < 8; ++i) {
+    p.SetElem(i, static_cast<uint8_t>(7 - i));
+  }
+  for (size_t i = 0; i < 8; ++i) {
+    EXPECT_EQ(p.GetElem(i), static_cast<uint8_t>(7 - i));
+  }
+}
+
+// =============================================================================
+// CUDA kernel correctness (only built when CUDA EP is enabled).
+// Currently a no-op placeholder; see comment at top of file. Kept here as a
+// hook so we know where to plumb a dlopen-based driver in a follow-up.
+// =============================================================================
+
+#if defined(USE_CUDA)
+TEST(TurboQuantKVTest, CudaEncodeDecodeRoundtrip_K4V4) {
+  GTEST_SKIP() << "CUDA kernel direct-test deferred — see comment at top of file";
+}
+#endif
+
+#if 0  // Disabled: needs dlopen-based test driver (see top-of-file comment).
+namespace tq_test_helpers {
+
+// Solve Lloyd-Max codebook on host for N(0, 1/d).
+// Mirrors solve_lloyd_max() in python/tools/quantization/turboquant_kv/centroids.py.
+// Uses fixed-size buffers (max 16 levels for bits<=4) to avoid GCC 13 false-positive
+// -Wstringop-overflow on vector<double> reassignment.
+inline std::vector<float> SolveLloydMax(int d, int bits, int max_iter = 200) {
+  constexpr int kMaxLevels = 16;
+  const int n_levels = 1 << bits;
+  if (n_levels > kMaxLevels) {
+    return std::vector<float>();  // unsupported
+  }
+  const double sigma2 = 1.0 / d;
+  const double sigma = std::sqrt(sigma2);
+  const double lo = -3.5 * sigma;
+  const double hi = 3.5 * sigma;
+
+  auto pdf = [sigma2](double x) {
+    return (1.0 / std::sqrt(2 * M_PI * sigma2)) * std::exp(-x * x / (2 * sigma2));
+  };
+  auto trapz = [](auto f, double a, double b, int n = 200) {
+    const double h = (b - a) / n;
+    double r = 0.5 * (f(a) + f(b));
+    for (int i = 1; i < n; ++i) r += f(a + i * h);
+    return r * h;
+  };
+
+  double centroids[kMaxLevels] = {};
+  double new_centroids[kMaxLevels] = {};
+  double edges[kMaxLevels + 1] = {};
+  for (int i = 0; i < n_levels; ++i) {
+    centroids[i] = lo + (hi - lo) * (i + 0.5) / n_levels;
+  }
+
+  for (int it = 0; it < max_iter; ++it) {
+    edges[0] = lo * 3.0;
+    edges[n_levels] = hi * 3.0;
+    for (int i = 0; i < n_levels - 1; ++i) {
+      edges[i + 1] = 0.5 * (centroids[i] + centroids[i + 1]);
+    }
+
+    double drift = 0.0;
+    for (int i = 0; i < n_levels; ++i) {
+      double a = edges[i], b = edges[i + 1];
+      double num = trapz([&pdf](double x) { return x * pdf(x); }, a, b);
+      double den = trapz(pdf, a, b);
+      new_centroids[i] = (den > 1e-15) ? (num / den) : centroids[i];
+      drift = std::max(drift, std::abs(new_centroids[i] - centroids[i]));
+    }
+    for (int i = 0; i < n_levels; ++i) centroids[i] = new_centroids[i];
+    if (drift < 1e-10) break;
+  }
+
+  std::vector<float> out(n_levels);
+  for (int i = 0; i < n_levels; ++i) out[i] = static_cast<float>(centroids[i]);
+  return out;
+}
+
+inline double CosineSimilarity(const std::vector<float>& a, const std::vector<float>& b) {
+  double dot = 0.0, na = 0.0, nb = 0.0;
+  for (size_t i = 0; i < a.size(); ++i) {
+    dot += a[i] * b[i];
+    na += a[i] * a[i];
+    nb += b[i] * b[i];
+  }
+  return dot / (std::sqrt(na) * std::sqrt(nb) + 1e-9);
+}
+
+}  // namespace tq_test_helpers
+
+// CUDA correctness test: the encode/decode roundtrip should preserve
+// vector direction (cosine similarity vs original > 0.97 for k4v4 in rotated space).
+//
+// Note: the K reconstruction is in ROTATED space (K · H), so we compare against
+// the rotated original, not raw K. This validates the algorithm; a full GQA
+// dispatch test that compares attention OUTPUT vs fp16 baseline is left for v2.
+TEST(TurboQuantKVTest, CudaEncodeDecodeRoundtrip_K4V4) {
+  using namespace tq_test_helpers;
+
+  // We don't gate on DefaultCudaExecutionProvider() here because the CUDA EP
+  // may not be initialized at the moment of test discovery; cudaGetDeviceCount
+  // is a sufficient runtime check.
+  int dev_count = 0;
+  if (cudaGetDeviceCount(&dev_count) != cudaSuccess || dev_count == 0) {
+    GTEST_SKIP() << "No CUDA device available";
+  }
+
+  constexpr int batch_size = 1;
+  constexpr int n_kv_heads = 4;
+  constexpr int seq_len = 16;
+  constexpr int head_size = 128;
+  constexpr int key_bits = 4;
+  constexpr int value_bits = 4;
+  constexpr bool norm_correction = true;
+  const int n_centroids = 1 << key_bits;
+
+  // Generate random K, V on host (deterministic seed).
+  std::mt19937 rng(42);
+  std::normal_distribution<float> dist(0.0f, 1.0f);
+  const int kv_elements = batch_size * n_kv_heads * seq_len * head_size;
+  std::vector<float> K_host_f(kv_elements), V_host_f(kv_elements);
+  for (int i = 0; i < kv_elements; ++i) {
+    K_host_f[i] = dist(rng);
+    V_host_f[i] = dist(rng);
+  }
+
+  // Convert to fp16.
+  std::vector<half> K_host(kv_elements), V_host(kv_elements);
+  for (int i = 0; i < kv_elements; ++i) {
+    K_host[i] = __float2half(K_host_f[i]);
+    V_host[i] = __float2half(V_host_f[i]);
+  }
+
+  // Lloyd-Max codebook.
+  auto codebook_f = SolveLloydMax(head_size, key_bits);
+  std::vector<half> codebook(n_centroids);
+  for (int i = 0; i < n_centroids; ++i) codebook[i] = __float2half(codebook_f[i]);
+
+  // Allocate device memory.
+  half *d_K, *d_V, *d_codebook, *d_K_recon, *d_V_recon;
+  cudaMalloc(&d_K, kv_elements * sizeof(half));
+  cudaMalloc(&d_V, kv_elements * sizeof(half));
+  cudaMalloc(&d_codebook, n_centroids * sizeof(half));
+  cudaMalloc(&d_K_recon, kv_elements * sizeof(half));
+  cudaMalloc(&d_V_recon, kv_elements * sizeof(half));
+
+  cudaMemcpy(d_K, K_host.data(), kv_elements * sizeof(half), cudaMemcpyHostToDevice);
+  cudaMemcpy(d_V, V_host.data(), kv_elements * sizeof(half), cudaMemcpyHostToDevice);
+  cudaMemcpy(d_codebook, codebook.data(), n_centroids * sizeof(half), cudaMemcpyHostToDevice);
+
+  cudaStream_t cuda_stream;
+  cudaStreamCreate(&cuda_stream);
+
+  int rc = RunTurboQuantRoundtrip_fp16(
+      batch_size, n_kv_heads, seq_len, head_size,
+      key_bits, value_bits, norm_correction ? 1 : 0,
+      d_K, d_V, d_codebook,
+      d_K_recon, d_V_recon,
+      cuda_stream);
+  ASSERT_EQ(rc, 0) << "RunTurboQuantRoundtrip_fp16 returned " << rc;
+  cudaStreamSynchronize(cuda_stream);
+
+  // Read back reconstructions.
+  std::vector<half> K_recon(kv_elements), V_recon(kv_elements);
+  cudaMemcpy(K_recon.data(), d_K_recon, kv_elements * sizeof(half), cudaMemcpyDeviceToHost);
+  cudaMemcpy(V_recon.data(), d_V_recon, kv_elements * sizeof(half), cudaMemcpyDeviceToHost);
+
+  // Compute cosine sim of V (per slot, in original space — V is uniform-quant only).
+  std::vector<double> v_cos_per_slot;
+  for (int s = 0; s < batch_size * n_kv_heads * seq_len; ++s) {
+    std::vector<float> v_orig(head_size), v_rec(head_size);
+    for (int i = 0; i < head_size; ++i) {
+      v_orig[i] = V_host_f[s * head_size + i];
+      v_rec[i] = __half2float(V_recon[s * head_size + i]);
+    }
+    v_cos_per_slot.push_back(tq_test_helpers::CosineSimilarity(v_orig, v_rec));
+  }
+  std::sort(v_cos_per_slot.begin(), v_cos_per_slot.end());
+  double v_median = v_cos_per_slot[v_cos_per_slot.size() / 2];
+
+  // K is in rotated space — compare each K_recon slot to the rotated normalized
+  // original (K_orig / ||K_orig|| · H · ||K_orig||). For 4-bit Lloyd-Max we
+  // expect cosine sim > 0.99.
+  // To avoid implementing FWHT here, we instead just verify that K_recon is
+  // not zero and has reasonable magnitude relative to the original norm.
+  std::vector<double> k_norm_ratios;
+  for (int s = 0; s < batch_size * n_kv_heads * seq_len; ++s) {
+    double k_orig_norm_sq = 0.0, k_rec_norm_sq = 0.0;
+    for (int i = 0; i < head_size; ++i) {
+      double o = K_host_f[s * head_size + i];
+      double r = __half2float(K_recon[s * head_size + i]);
+      k_orig_norm_sq += o * o;
+      k_rec_norm_sq += r * r;
+    }
+    if (k_orig_norm_sq > 1e-9) {
+      k_norm_ratios.push_back(std::sqrt(k_rec_norm_sq) / std::sqrt(k_orig_norm_sq));
+    }
+  }
+  std::sort(k_norm_ratios.begin(), k_norm_ratios.end());
+  double k_median_ratio = k_norm_ratios[k_norm_ratios.size() / 2];
+
+  // Cleanup.
+  cudaFree(d_K); cudaFree(d_V); cudaFree(d_codebook);
+  cudaFree(d_K_recon); cudaFree(d_V_recon);
+  cudaStreamDestroy(cuda_stream);
+
+  // V uniform quant should reach > 0.99 median cosine sim at 4 bits.
+  EXPECT_GT(v_median, 0.99) << "V reconstruction cosine sim too low";
+  // K_recon norm should be close to original (norm-correction makes this exact in expectation).
+  EXPECT_GT(k_median_ratio, 0.95);
+  EXPECT_LT(k_median_ratio, 1.05);
+}
+
+#endif  // disabled CUDA direct-test
+
+}  // namespace test
+}  // namespace onnxruntime


### PR DESCRIPTION
### Description

WebGPU EP kernels for the TurboQuant 4-bit KV cache path defined by #28560.  Same algorithm and packed-cache layout as the CUDA PR (#28561), implemented as two WGSL programs and a C++ orchestrator that mirrors CUDA's Option-ε pattern.

**Same code runs in three places:**
1. **Native** (`--build_wheel --use_webgpu`) — Python wheel, Dawn → Metal/D3D12/Vulkan.
2. **Browser** (`--build_wasm --use_webgpu --enable_wasm_jspi` + JS layer `--webgpu-ep --jspi`) — onnxruntime-web inside transformers.js.
3. **Node.js** (`--build_nodejs --use_webgpu`) — NAPI binding, same Dawn.

### Verified numbers (Apple Silicon Metal, in-browser ORT-web via WASM/JSPI, LFM2.5-1.2B)

| ctx | fp16 decode | TQ decode | decode speedup |
|---:|---:|---:|---:|
| 4 K | 91.3 ms/tok | 74.1 ms/tok | 1.23× |
| 16 K | 179.1 ms/tok | 84.0 ms/tok | **2.13×** |

Same model in **onnxruntime-node** on the same machine: 28.3 / 20.0 ms/tok (1.41×).  Quality: per-step cosine sim 0.993–1.000 vs fp16, top-1 token match 7-of-9 on a 9-step decode chain (matches CUDA in #28561).

### What this PR contains

* **`contrib_ops/webgpu/bert/turboquant_encode.wgsl.template`** — packs fresh fp16 K/V into the uint8 slot layout in one pass per `(batch, kv_head, present_slot)`. When `s_cache < past_seq_len` the shader byte-copies from past_key/past_value; otherwise it does the full encode (`||k||`, FWHT, Lloyd-Max codebook lookup, V min/max, bit-pack).
* **`contrib_ops/webgpu/bert/turboquant_decode.wgsl.template`** — packed cache → fp16 K/V scratch in BNSH layout. Codebook gather, optional norm correction, vec_norm scale, inverse FWHT, V dequant.
* **`contrib_ops/webgpu/bert/turboquant_attention.{cc,h}`** — the `RunTurboQuantAttention` orchestrator. Aliases the uint8 cache as uint32 view tensors so WGSL `array<u32>` bindings work (ORT's `ShaderVariableHelper` rejects uint8 storage bindings). Branches on `WebGPU::Subgroups` feature:
  - **Subgroups present** (Chrome 136+) → `ApplyFlashAttention` with Q in BSNH, K/V scratch declared BNSH via `Q_K_V_BSNH_BNSH_BNSH`.
  - **Subgroups absent** (Safari, Firefox, older Chrome) → transfer Q to BNSH and route through `ApplyAttention` instead.
  - Env-var escape hatch `ORT_TQ_DISABLE_FA=1` forces the fallback on subgroups-capable adapters for dev-machine testing.
* **`contrib_ops/webgpu/bert/group_query_attention.cc/.h`** — TQ-aware dispatch. Reads the new GQA attributes from #28560, reads codebook + Hadamard from input slots 14/15, runs rotary inline before the orchestrator (since `ApplyFlashAttention`'s do_rotary path requires packed QKV which we don't have), and computes `past_sequence_length` from `past_key.shape[2]` rather than `seqlens_k` (HF causal-LM exports often leave seqlens_k zero-filled on the prompt step; past_key's shape is the ground truth either way, mirroring what `CheckInputs` does on the fp16 path).

### Fallback numbers (no-subgroups path, Qwen3.5-0.8B-Text @ 4K, Node.js)

| | FA path | Fallback (no subgroups) |
|---|---:|---:|
| TQ decode | 28 ms/tok = 36 tok/s | **14.3 ms/tok = 70 tok/s** |
| TQ prompt (TTFT) | 2.4 s | 3.0 s |

Decode is actually *faster* on the fallback for this shape — `ApplyAttention`'s split-Vx decode kernel is more cache-friendly for `(small Q, large cached K)` than FA on our scratch tensors.  Prompt is ~25% slower because of the extra `TransferBSDToBNSH`.  Both produce coherent output (no shape errors, no NaN).

### Things worth a careful look

1. **Subgroups fallback path** — Q/K/V layouts have to line up with what `ApplyAttention` expects (BNSH for K/V, BSNH for Q). K/V scratch comes out of the decode shader already BNSH; only Q needs `TransferBSDToBNSH`. I set `past_sequence_length = 0` and feed the entire present cache as `K` to skip ApplyAttention's internal past-merge.
2. **uint8 → uint32 alias view** in turboquant_attention.cc — the underlying buffer never changes layout, only the type ORT sees. `slot_bytes` is always a multiple of 4 (we pad).
3. **`detail::GetEnvironmentVar`** for the escape hatch — `std::getenv` breaks MSVC's `-Werror` (C4996).

### Cross-OS

Cross-OS build CI green on Linux + Windows (build/link-only since hosted runners have no GPU). Apple Silicon Metal verified end-to-end on local Mac + a clean GHA `macos-15` runner.

### Depends on
- #28560 (foundation — graph rewrite + schema).

### Does not intersect with
- #28561 (CUDA kernels).
- Python tooling PR (#TBD).