### PR TITLE
[MLAS] KleidiAI fix igemm regression

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
+++ b/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
@@ -498,6 +498,11 @@ static const char* const kOrtSessionOptionsMlasLutGemm = "mlas.use_lut_gemm";
 // - "1": Disable KleidiAI kernels even if available.
 static const char* const kOrtSessionOptionsMlasDisableKleidiAi = "mlas.disable_kleidiai";
 
+// Override the KleidiAI convolution IGEMM route threshold.
+// The value is a non-negative integer for the maximum allowed output_m * effective_k * filter_count.
+// "0" or unset uses the MLAS default heuristic.
+static const char* const kOrtSessionOptionsMlasKleidiAiConvIgemmMaxWork = "mlas.kleidiai.conv_igemm_max_work";
+
 // When converting DQ + MatMul -> MatMulNBits, the accuracy level of the MatMulNBits is controlled by this option.
 // Refer to MatMulNBits op schema for more details.
 // If not provided, default is 4.

--- a/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
+++ b/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
@@ -498,9 +498,12 @@ static const char* const kOrtSessionOptionsMlasLutGemm = "mlas.use_lut_gemm";
 // - "1": Disable KleidiAI kernels even if available.
 static const char* const kOrtSessionOptionsMlasDisableKleidiAi = "mlas.disable_kleidiai";
 
-// Override the KleidiAI convolution IGEMM route threshold.
-// The value is a non-negative integer for the maximum allowed output_m * effective_k * filter_count.
-// "0" or unset uses the MLAS default heuristic.
+// Power-user tuning option for the Arm® KleidiAI™ SME IGEMM convolution route on Arm64.
+// For 2D convolutions where both SME IGEMM and the MlasGemm SGEMM fallback are valid routes, work is estimated as:
+//  output_h * output_w * input_channels * dilated_kernel_h * dilated_kernel_w * filter_count.
+// Work above this threshold routes through the SGEMM fallback; work at or below it stays on IGEMM.
+// "0" or unset uses the MLAS default heuristic, intended for typical workloads.
+// This option exists for perf experimentation; the default may be retuned in future ORT releases.
 static const char* const kOrtSessionOptionsMlasKleidiAiConvIgemmMaxWork = "mlas.kleidiai.conv_igemm_max_work";
 
 // When converting DQ + MatMul -> MatMulNBits, the accuracy level of the MatMulNBits is controlled by this option.

--- a/onnxruntime/core/mlas/inc/mlas.h
+++ b/onnxruntime/core/mlas/inc/mlas.h
@@ -207,6 +207,7 @@ MlasActivation(
 
 struct MLAS_BACKEND_KERNEL_SELECTOR_CONFIG {
     bool use_kleidiai = true; /**< Flag to use KleidiAI backend kernels if available */
+    size_t kleidiai_conv_igemm_max_work = 0; /**< Optional SME IGEMM route threshold override; 0 uses default */
 };
 
 //

--- a/onnxruntime/core/mlas/lib/convolve.cpp
+++ b/onnxruntime/core/mlas/lib/convolve.cpp
@@ -15,6 +15,9 @@ Abstract:
 --*/
 
 #include "mlasi.h"
+#if defined(USE_KLEIDIAI)
+#include "kleidiai/mlasi_kleidiai.h"
+#endif
 
 //
 // Define the number of working buffer elements required per thread.
@@ -574,6 +577,11 @@ Return Value:
     const size_t FilterCount = Parameters->FilterCount;
     const size_t OutputSize = Parameters->OutputSize;
     const size_t K = Parameters->K;
+    bool use_gemm_batch_override = false;
+#if defined(USE_KLEIDIAI)
+    use_gemm_batch_override =
+        ArmKleidiAI::SelectConvRoute(Parameters) == ArmKleidiAI::ConvRoute::GemmFallback;
+#endif
 
     //
     // Compute the strides to step through slices of the local segment.
@@ -637,9 +645,15 @@ Return Value:
                     SegmentStartN + n, CountN);
             }
 
-            MlasSgemmOperation(CblasNoTrans, CblasNoTrans, FilterCount, CountN,
-                CountK, 1.0f, Filter + k, K, ColumnBuffer, CountN, beta,
-                SegmentOutput, OutputSize);
+            if (use_gemm_batch_override) {
+                MlasGemm(CblasNoTrans, CblasNoTrans, FilterCount, CountN,
+                    CountK, 1.0f, Filter + k, K, ColumnBuffer, CountN, beta,
+                    SegmentOutput, OutputSize, nullptr, Parameters->BackendKernelSelectorConfig);
+            } else {
+                MlasSgemmOperation(CblasNoTrans, CblasNoTrans, FilterCount, CountN,
+                    CountK, 1.0f, Filter + k, K, ColumnBuffer, CountN, beta,
+                    SegmentOutput, OutputSize);
+            }
 
             beta = 1.0f;
         }

--- a/onnxruntime/core/mlas/lib/convolve.cpp
+++ b/onnxruntime/core/mlas/lib/convolve.cpp
@@ -15,9 +15,6 @@ Abstract:
 --*/
 
 #include "mlasi.h"
-#if defined(USE_KLEIDIAI)
-#include "kleidiai/mlasi_kleidiai.h"
-#endif
 
 //
 // Define the number of working buffer elements required per thread.
@@ -577,11 +574,9 @@ Return Value:
     const size_t FilterCount = Parameters->FilterCount;
     const size_t OutputSize = Parameters->OutputSize;
     const size_t K = Parameters->K;
-    bool use_gemm_batch_override = false;
-#if defined(USE_KLEIDIAI)
-    use_gemm_batch_override =
-        ArmKleidiAI::SelectConvRoute(Parameters) == ArmKleidiAI::ConvRoute::GemmFallback;
-#endif
+    bool use_gemm_batch_override =
+        GetMlasPlatform().MlasConvRouteOverride != nullptr &&
+        GetMlasPlatform().MlasConvRouteOverride(Parameters) == MlasConvRouteGemmFallback;
 
     //
     // Compute the strides to step through slices of the local segment.

--- a/onnxruntime/core/mlas/lib/convolve.cpp
+++ b/onnxruntime/core/mlas/lib/convolve.cpp
@@ -574,9 +574,9 @@ Return Value:
     const size_t FilterCount = Parameters->FilterCount;
     const size_t OutputSize = Parameters->OutputSize;
     const size_t K = Parameters->K;
-    bool use_gemm_batch_override =
-        GetMlasPlatform().MlasConvRouteOverride != nullptr &&
-        GetMlasPlatform().MlasConvRouteOverride(Parameters) == MlasConvRouteGemmFallback;
+    const bool use_gemm_batch_override =
+        GetMlasPlatform().MlasConvSGemmRouteOverride != nullptr &&
+        GetMlasPlatform().MlasConvSGemmRouteOverride(Parameters) == MlasConvSGemmRouteDispatch;
 
     //
     // Compute the strides to step through slices of the local segment.
@@ -1394,7 +1394,12 @@ MlasConvSupportsDenseChannelsLast2DFloatKernel(
         return false;
     }
 
-    if (Padding[0] != Padding[2] || Padding[1] != Padding[3]) {
+    // The channels-last float convolution path is only implemented by the Arm® KleidiAI™
+    // SME conv override, which currently uses a single padding value in its LHS indirection table.
+    // Require uniform padding until separate H/W padding is supported there.
+    if (Padding[0] != Padding[2] ||
+        Padding[1] != Padding[3] ||
+        Padding[0] != Padding[1]) {
         return false;
     }
 

--- a/onnxruntime/core/mlas/lib/kleidiai/convolve_kleidiai.cpp
+++ b/onnxruntime/core/mlas/lib/kleidiai/convolve_kleidiai.cpp
@@ -146,6 +146,18 @@ static bool CheckCapabilitiesSme(const MLAS_CONV_PARAMETERS* Parameters) {
     const auto route = ArmKleidiAI::SelectConvRoute(Parameters);
 
     if (route == ArmKleidiAI::ConvRoute::Igemm) {
+        // ensure LHS packed buffer size is non-zero
+        const size_t d_kh = ComputeKernelSize(Parameters->DilationShape[0], Parameters->KernelShape[0]);
+        const size_t d_kw = ComputeKernelSize(Parameters->DilationShape[1], Parameters->KernelShape[1]);
+        const size_t m_step = imatmul_conv.ukernel.get_m_step();
+
+        const size_t bytes_per_m_step = kai_get_lhs_packed_size_lhs_imatmul_pack_x32p2vlx1_x32p_sme(
+            m_step, d_kh * d_kw, Parameters->InputChannels);
+
+        if (bytes_per_m_step == 0) {
+            KLEIDIAI_DEBUG_LOG("CheckCapabilitiesSME returning false on zero LHS packed size");
+            return false;
+        }
         return true;
     }
 
@@ -599,6 +611,8 @@ static void ConvolveSme(const size_t co, //channels out
             // Query the packed LHS buffer size for exactly one m_step block.
             const size_t bytes_per_m_step = kai_get_lhs_packed_size_lhs_imatmul_pack_x32p2vlx1_x32p_sme(
                 m_step, d_kh * d_kw, ci);
+            ORT_ENFORCE(bytes_per_m_step != 0,
+                        "KleidiAI LHS packed size must be non-zero.");
 
             // Determine how many rows we can pack in one chunk.
             size_t m_chunk = std::max<size_t>(m_step, MAX_LHS_CHUNK_BYTES / bytes_per_m_step * m_step);

--- a/onnxruntime/core/mlas/lib/kleidiai/convolve_kleidiai.cpp
+++ b/onnxruntime/core/mlas/lib/kleidiai/convolve_kleidiai.cpp
@@ -24,8 +24,9 @@
 
 const KaiF32IMatmulKernel& imatmul_conv = GetKleidiAIF32IMatmulUKernel();
 
-// Maximum temporary buffer size (in bytes) for KleidiAI LHS packing.
-constexpr size_t MAX_LHS_CHUNK_BYTES = 2097152;
+// Hard cap of 2 MiB on temporary LHS packing chunks, intended to keep tiles
+// reasonably cache-friendly and to avoid oversized temporary buffers
+constexpr size_t MAX_LHS_CHUNK_BYTES = 2 * 1024 * 1024;
 
 // Left-hand-side (input indirection) cache key
 struct LhsCacheKey {
@@ -142,7 +143,18 @@ static bool CheckCapabilitiesSme(const MLAS_CONV_PARAMETERS* Parameters) {
         return false;
     }
 
-    return true;
+    const auto route = ArmKleidiAI::SelectConvRoute(Parameters);
+
+    if (route == ArmKleidiAI::ConvRoute::Igemm) {
+        return true;
+    }
+
+    if (route == ArmKleidiAI::ConvRoute::GemmFallback) {
+        KLEIDIAI_DEBUG_LOG("CheckCapabilitiesSme returning false to prefer SGEMM-backed conv path.");
+    } else {
+        KLEIDIAI_DEBUG_LOG("CheckCapabilitiesSme returning false on functional or optimization checks.");
+    }
+    return false;
 }
 
 //General purpose axis swapping

--- a/onnxruntime/core/mlas/lib/kleidiai/convolve_kleidiai.cpp
+++ b/onnxruntime/core/mlas/lib/kleidiai/convolve_kleidiai.cpp
@@ -24,9 +24,11 @@
 
 const KaiF32IMatmulKernel& imatmul_conv = GetKleidiAIF32IMatmulUKernel();
 
-// Hard cap of 2 MiB on temporary LHS packing chunks, intended to keep tiles
-// reasonably cache-friendly and to avoid oversized temporary buffers
-constexpr size_t MAX_LHS_CHUNK_BYTES = 2 * 1024 * 1024;
+// Bound for the per-thread packed LHS scratch buffer used by the chunked IGEMM path.
+// This is a heuristic budget (chosen because 2 MiB is a common L2 cache size) which limits
+// temporary memory growth while keeping chunks large enough to be worth the KAI packing overhead.
+// If one m_step block already exceeds the budget, processing is done one m_step at a time.
+constexpr size_t kMaxLhsPackedChunkBytes = 2 * 1024 * 1024;
 
 // Left-hand-side (input indirection) cache key
 struct LhsCacheKey {
@@ -143,12 +145,13 @@ static bool CheckCapabilitiesSme(const MLAS_CONV_PARAMETERS* Parameters) {
         return false;
     }
 
-    const auto route = ArmKleidiAI::SelectConvRoute(Parameters);
+    const auto route_selection = ArmKleidiAI::SelectConvRoute(Parameters);
+    const auto route = route_selection.route;
 
     if (route == ArmKleidiAI::ConvRoute::Igemm) {
         // ensure LHS packed buffer size is non-zero
-        const size_t d_kh = ComputeKernelSize(Parameters->DilationShape[0], Parameters->KernelShape[0]);
-        const size_t d_kw = ComputeKernelSize(Parameters->DilationShape[1], Parameters->KernelShape[1]);
+        const size_t d_kh = route_selection.effective_kernel_h;
+        const size_t d_kw = route_selection.effective_kernel_w;
         const size_t m_step = imatmul_conv.ukernel.get_m_step();
 
         const size_t bytes_per_m_step = kai_get_lhs_packed_size_lhs_imatmul_pack_x32p2vlx1_x32p_sme(
@@ -502,7 +505,8 @@ static void ConvolveSme(const size_t co, //channels out
                         bool input_is_channels_last,
                         MLAS_THREADPOOL* ThreadPool) {
 
-    //compute corrected dimensions of dilated kernel
+    //dilation expands the logical kernel shape; RHS packing masks the inserted unused weights.
+    //this way, compute corrected dimensions of dilated kernel
     const auto d_kh = ComputeKernelSize(dilationh, kh);
     const auto d_kw = ComputeKernelSize(dilationw, kw);
 
@@ -513,6 +517,12 @@ static void ConvolveSme(const size_t co, //channels out
     size_t n_step = imatmul_conv.ukernel.get_n_step();
     size_t m_step = imatmul_conv.ukernel.get_m_step();
 
+    // Query the packed LHS buffer size for exactly one m_step block.
+    const size_t bytes_per_m_step = kai_get_lhs_packed_size_lhs_imatmul_pack_x32p2vlx1_x32p_sme(
+        m_step, d_kh * d_kw, ci);
+    // Sanity check to ensure data passed to the function is valid and won't cause a zero division error.
+    assert(bytes_per_m_step != 0);
+
     // tile iteration dimensions
     std::array<size_t,3> dim;
     dim[0] = 1;                          // B
@@ -520,11 +530,11 @@ static void ConvolveSme(const size_t co, //channels out
     dim[2] = MlasDivRoundup(co, n_step); // N
 
     //Minimize the kernel call count for the number of available threads
-    auto RequiredTiles = std::min(static_cast<size_t>(MlasGetMaximumThreadCount(ThreadPool)), dim[0]*dim[1]*dim[2]);
+    auto required_tiles = std::min(static_cast<size_t>(MlasGetMaximumThreadCount(ThreadPool)), dim[0]*dim[1]*dim[2]);
 
     //scale required tiles over available tile processors
-    dim[1] = MlasDivRoundup(RequiredTiles * dim[1], dim[1] * dim[2]);
-    dim[2] = MlasDivRoundup(RequiredTiles * dim[2], dim[1] * dim[2]);
+    dim[1] = MlasDivRoundup(required_tiles * dim[1], dim[1] * dim[2]);
+    dim[2] = MlasDivRoundup(required_tiles * dim[2], dim[1] * dim[2]);
 
     //compute new step sizes
     size_t m_tile_step = m_step * MlasDivRoundup(MlasDivRoundup(m, dim[1]), m_step);
@@ -596,7 +606,7 @@ static void ConvolveSme(const size_t co, //channels out
             const size_t rhs_packed_offset =
                 imatmul_conv.ukernel.get_rhs_packed_offset(n_idx * n_tile_step, d_kh * d_kw, ci);
 
-            auto BTile = reinterpret_cast<const void*>(
+            auto b_tile = reinterpret_cast<const void*>(
                 rhs_data + rhs_packed_offset
             );
 
@@ -608,14 +618,10 @@ static void ConvolveSme(const size_t co, //channels out
             // Actual number of rows in this tile (may be smaller for the last tile)
             size_t tile_m_size = std::min(m_tile_step, m - tile_m_start);
 
-            // Query the packed LHS buffer size for exactly one m_step block.
-            const size_t bytes_per_m_step = kai_get_lhs_packed_size_lhs_imatmul_pack_x32p2vlx1_x32p_sme(
-                m_step, d_kh * d_kw, ci);
-            ORT_ENFORCE(bytes_per_m_step != 0,
-                        "KleidiAI LHS packed size must be non-zero.");
-
             // Determine how many rows we can pack in one chunk.
-            size_t m_chunk = std::max<size_t>(m_step, MAX_LHS_CHUNK_BYTES / bytes_per_m_step * m_step);
+            const size_t max_m_step_chunks = kMaxLhsPackedChunkBytes / bytes_per_m_step;
+            // If bytes_per_m_step exceeds kMaxLhsPackedChunkBytes, process m_step at a time
+            size_t m_chunk = max_m_step_chunks == 0 ? m_step : m_step * max_m_step_chunks;
 
             // Do not exceed the number of rows available in this tile
             m_chunk = std::min<size_t>(tile_m_size, m_chunk);
@@ -624,29 +630,33 @@ static void ConvolveSme(const size_t co, //channels out
             const size_t lhs_buffer_bytes = kai_get_lhs_packed_size_lhs_imatmul_pack_x32p2vlx1_x32p_sme(
                 m_chunk, d_kh * d_kw, ci);
 
-            // Allocate a single reusable buffer for LHS packing
-            auto lhs = std::make_unique<std::byte[]>(lhs_buffer_bytes);
+            // Thread-local grow-only reusable buffer for LHS packing
+            thread_local std::vector<std::byte> lhs_buffer;
+            if (lhs_buffer.size() < lhs_buffer_bytes) {
+                lhs_buffer.resize(lhs_buffer_bytes);
+            }
+            auto* lhs = lhs_buffer.data();
 
             // Interpret the packed LHS buffer as the input A tile
             // for the matrix multiplication kernel.
-            auto ATile = reinterpret_cast<const float*>(lhs.get());
+            auto a_tile = reinterpret_cast<const float*>(lhs);
 
             for (size_t m_base = 0; m_base < tile_m_size; m_base += m_chunk) {
                 // Actual number of rows processed in this iteration.
                 // The last chunk may be smaller than m_chunk.
                 const size_t tile_size_m = std::min(m_chunk, tile_m_size - m_base);
 
-                // Pack TileSizeM rows of the LHS matrix into a temporary buffer.
+                // Pack tile_size_m rows of the LHS matrix into a temporary buffer.
                 kai_run_lhs_imatmul_pack_x32p2vlx1_x32p_sme(tile_size_m,
                                                             d_kh * d_kw,
                                                             ci,
                                                             lhs_ptrs.get() + (tile_m_start + m_base) * d_kh * d_kw,
                                                             reinterpret_cast<size_t>(activation_src),
                                                             reinterpret_cast<const void*>(pad_data),
-                                                            lhs.get());
+                                                            lhs);
 
                 // Get result tile, C
-                auto CTile = &reinterpret_cast<std::byte*>(result)[
+                auto c_tile = &reinterpret_cast<std::byte*>(result)[
                     (tile_m_start + m_base) * co * sizeof(float) +
                     n_idx * n_tile_step * sizeof(float)];
 
@@ -654,8 +664,8 @@ static void ConvolveSme(const size_t co, //channels out
                     << " M=" << tile_size_m << " N=" << tile_size_n
                     << " k_chunk_count=" << (d_kh * d_kw) << " k_chunk_length=" << ci);
 
-                imatmul_conv.ukernel.run_imatmul(tile_size_m, tile_size_n, d_kh * d_kw, ci, ATile, BTile,
-                                                 CTile, co * sizeof(float), -std::numeric_limits<float>::max(),
+                imatmul_conv.ukernel.run_imatmul(tile_size_m, tile_size_n, d_kh * d_kw, ci, a_tile, b_tile,
+                                                 c_tile, co * sizeof(float), -std::numeric_limits<float>::max(),
                                                  std::numeric_limits<float>::max());
             }
         });

--- a/onnxruntime/core/mlas/lib/kleidiai/convolve_kleidiai.cpp
+++ b/onnxruntime/core/mlas/lib/kleidiai/convolve_kleidiai.cpp
@@ -24,6 +24,8 @@
 
 const KaiF32IMatmulKernel& imatmul_conv = GetKleidiAIF32IMatmulUKernel();
 
+// Maximum temporary buffer size (in bytes) for KleidiAI LHS packing.
+constexpr size_t MAX_LHS_CHUNK_BYTES = 2097152;
 
 // Left-hand-side (input indirection) cache key
 struct LhsCacheKey {
@@ -267,37 +269,6 @@ static std::unique_ptr<float[]> NChwToNhwc(const size_t n,
     return t;
 }
 
-static void MultiThreadedLHSPackSme(MLAS_THREADPOOL* ThreadPool, const size_t ci, const size_t m, const size_t kh,
-                                    const size_t kw, const void * const* lhs_ptrs, std::byte* lhs_data,
-                                    const float* in_data,
-                                    const float* pad_ptr) {
-    size_t m_step = imatmul_conv.ukernel.get_m_step();
-
-    // Minimize the kernel call count for the number of available threads
-    auto RequiredTiles = MlasDivRoundup(m, m_step);
-    auto MaxTiles = std::min(static_cast<size_t>(MlasGetMaximumThreadCount(ThreadPool)), RequiredTiles);
-    m_step *= MlasDivRoundup(RequiredTiles, MaxTiles);
-    RequiredTiles = MlasDivRoundup(m, m_step);
-
-    MlasTrySimpleParallel(ThreadPool, static_cast<ptrdiff_t>(RequiredTiles), [&](ptrdiff_t tid) {
-
-        auto m_idx = static_cast<size_t>(tid) * m_step;
-        auto offset = kai_get_lhs_packed_offset_lhs_imatmul_pack_x32p2vlx1_x32p_sme(m_idx,kh*kw,ci);
-
-        KLEIDIAI_KERNEL_LOG("kai_run_lhs_imatmul_pack_x32p2vlx1_x32p_sme"
-                            << " M=" << (m < (m_idx + m_step) ? m - m_idx : m_step)
-                            << " k_chunk_count=" << (kh * kw)
-                            << " k_chunk_length=" << ci);
-        kai_run_lhs_imatmul_pack_x32p2vlx1_x32p_sme(
-            m < (m_idx + m_step) ? m - m_idx : m_step, kh * kw, ci,
-            lhs_ptrs + m_idx * kh * kw,
-            reinterpret_cast<size_t>(in_data),
-            reinterpret_cast<const void*>(pad_ptr),
-            lhs_data + offset
-        );
-    });
-}
-
 size_t
 MLASCALL
 ArmKleidiAI::MlasConvSymmetricChannelsLast2DFloatPackWSize(
@@ -434,61 +405,26 @@ static std::shared_ptr<const void*[]> LhsPtrFill(const size_t ci, const size_t i
     return lhs_ptrs;
 }
 
-static std::unique_ptr<std::byte[]> LhsPackImageDataSme(const size_t ci, const size_t ih, const size_t iw,
-                                                        const size_t kh, const size_t kw, const size_t sh,
-                                                        const size_t sw, const size_t padding, const float* in,
-                                                        bool input_is_channels_last,
-                                                        MLAS_THREADPOOL* ThreadPool)
-{
+static const float* GetOrCreatePadDataSme(const size_t ci) {
     size_t padsize = 256;
-    if(ci > padsize)
-    {
-        // figure out how many blocks needed to correctly fill padding
-        padsize = ((ci + padsize - 1) / padsize) * padsize;
+    if (ci > padsize) {
+        padsize = MlasDivRoundup(ci, padsize) * padsize;
     }
 
     // pad_ptr must be at least 'ci' floats for padding pixels.
-    // Using a thread_local grow-only buffer to avoid cross-thread interference and ensure sizing is correct.
-    //
-    // The pad buffer contents are always zero. Since the buffer is grow-only and never written with non-zero data,
-    // we only need to zero-initialize newly-grown elements.
+    // The buffer is grow-only and zero-initializes newly-grown elements.
     thread_local std::vector<float> pad_ptr;
-
     if (pad_ptr.size() < padsize) {
         pad_ptr.resize(padsize, 0.f);
     }
 
-    //create lhs in format required for imatmul
-    const auto m = ComputeConvOutSize(ih, kh, padding, sh) * ComputeConvOutSize(iw, kw, padding, sw);
+    return pad_ptr.data();
+}
 
-    const auto lhs_size = kai_get_lhs_packed_size_lhs_imatmul_pack_x32p2vlx1_x32p_sme(m,kh*kw,ci);
-    auto lhs = std::make_unique<std::byte[]>(lhs_size);
-
-    std::unique_ptr<float[]> nhwc_holder;
-    const float* activation_src = nullptr;
-    if (input_is_channels_last) {
-        activation_src = in;
-    } else {
-        nhwc_holder = NChwToNhwc(1, ci, ih, iw, in, 1, 1, false, ThreadPool);
-        activation_src = nhwc_holder.get();
-    }
-
-    // Cache of computed lhs ptr offsets. thread_local to prevent interference from parallel sessions.
-    //
-    // Entries include pointers to the pad buffer for out-of-bounds pixels, so we must not reuse entries after the
-    // pad buffer is reallocated. To avoid clearing the entire cache, we group caches by pad buffer identity and
-    // invalidate only the old group when the pad buffer moves.
-    using LhsPtrsCache = std::unordered_map<LhsCacheKey, std::shared_ptr<const void*[]>>;
-    thread_local std::unordered_map<const float*, LhsPtrsCache> lhs_ptrs_cache_by_pad;
-
-    // If pad_ptr moved (vector reallocation), drop only the old group to avoid accumulating unreachable entries.
-    thread_local const float* last_pad_ptr = nullptr;
-    const float* cur_pad_ptr = pad_ptr.data();
-    if (last_pad_ptr != nullptr && last_pad_ptr != cur_pad_ptr) {
-        lhs_ptrs_cache_by_pad.erase(last_pad_ptr);
-    }
-    last_pad_ptr = cur_pad_ptr;
-
+static std::shared_ptr<const void*[]> GetOrCreateLhsPtrTableSme(const size_t ci, const size_t ih, const size_t iw,
+                                                                const size_t kh, const size_t kw, const size_t sh,
+                                                                const size_t sw, const size_t padding, const float* pad_ptr) {
+    // LhsPtrFill stores geometry offsets only; the current input base is supplied when packing.
     LhsCacheKey key = {
         ci, ih, iw,
         padding, sh, sw,
@@ -496,19 +432,28 @@ static std::unique_ptr<std::byte[]> LhsPackImageDataSme(const size_t ci, const s
         1, 1
     };
 
+    // Setting up LHS ptr cache and tracking value of last passed pad_ptr
+    using LhsPtrsCache = std::unordered_map<LhsCacheKey, std::shared_ptr<const void*[]>>;
+    thread_local std::unordered_map<const float*, LhsPtrsCache> lhs_ptrs_cache_by_pad;
+    thread_local const float* last_pad_ptr = nullptr;
+
+    // If pad_ptr moved (vector reallocation), drop only the old group to avoid accumulating unreachable entries.
+    const float* cur_pad_ptr = pad_ptr;
+    if (last_pad_ptr != nullptr && last_pad_ptr != cur_pad_ptr) {
+        lhs_ptrs_cache_by_pad.erase(last_pad_ptr);
+    }
+    last_pad_ptr = cur_pad_ptr;
+
     auto& lhs_ptrs_cache = lhs_ptrs_cache_by_pad[cur_pad_ptr];
 
     std::shared_ptr<const void*[]> lhs_ptrs;
     if (auto found = lhs_ptrs_cache.find(key); found != lhs_ptrs_cache.end()) {
         lhs_ptrs = found->second;
     } else {
-        lhs_ptrs = LhsPtrFill(ci, ih, iw, kh, kw, sh, sw, padding, &pad_ptr[0]);
+        lhs_ptrs = LhsPtrFill(ci, ih, iw, kh, kw, sh, sw, padding, pad_ptr);
         lhs_ptrs_cache[key] = lhs_ptrs;
     }
-
-    MultiThreadedLHSPackSme(ThreadPool, ci, m, kh, kw, &lhs_ptrs[0], &lhs[0], activation_src, &pad_ptr[0]);
-
-    return lhs;
+    return lhs_ptrs;
 }
 
 static void ConvolveSme(const size_t co, //channels out
@@ -533,7 +478,6 @@ static void ConvolveSme(const size_t co, //channels out
                         bool input_is_channels_last,
                         MLAS_THREADPOOL* ThreadPool) {
 
-    //RhsPackWeightsBiasSme() - to perform dilation increases kernel size and masks unused weights
     //compute corrected dimensions of dilated kernel
     const auto d_kh = ComputeKernelSize(dilationh, kh);
     const auto d_kw = ComputeKernelSize(dilationw, kw);
@@ -559,12 +503,12 @@ static void ConvolveSme(const size_t co, //channels out
     dim[2] = MlasDivRoundup(RequiredTiles * dim[2], dim[1] * dim[2]);
 
     //compute new step sizes
-    m_step *= MlasDivRoundup(MlasDivRoundup(m, dim[1]), m_step);
-    n_step *= MlasDivRoundup(MlasDivRoundup(co, dim[2]), n_step);
+    size_t m_tile_step = m_step * MlasDivRoundup(MlasDivRoundup(m, dim[1]), m_step);
+    size_t n_tile_step = n_step * MlasDivRoundup(MlasDivRoundup(co, dim[2]), n_step);
 
     //update tile iterations
-    dim[1] = MlasDivRoundup(m, m_step);
-    dim[2] = MlasDivRoundup(co, n_step);
+    dim[1] = MlasDivRoundup(m, m_tile_step);
+    dim[2] = MlasDivRoundup(co, n_tile_step);
 
     const bool grouped_channels_last = input_is_channels_last && groups > 1;
     const size_t input_channels_total = ci * groups;
@@ -592,10 +536,17 @@ static void ConvolveSme(const size_t co, //channels out
             result = tmp_mlas_aligned;
         }
 
-        auto lhs = LhsPackImageDataSme(ci, ih, iw, d_kh, d_kw, sh, sw, padding,
-                                      input_group,
-                                      input_is_channels_last,
-                                      ThreadPool);
+        // LHS packing data
+        const float* pad_data = GetOrCreatePadDataSme(ci);
+        std::unique_ptr<float[]> nhwc_holder;
+        const float* activation_src = input_group;
+        if (!input_is_channels_last) {
+            nhwc_holder = NChwToNhwc(1, ci, ih, iw, input_group, 1, 1, false, ThreadPool);
+            activation_src = nhwc_holder.get();
+        }
+        auto lhs_ptrs = GetOrCreateLhsPtrTableSme(ci, ih, iw, d_kh, d_kw, sh, sw, padding, pad_data);
+
+        // RHS packing data
         const std::byte* rhs_data = packed_rhs ? packed_rhs + g * packed_rhs_group_stride : nullptr;
         std::unique_ptr<std::byte[]> rhs_storage;
         if (rhs_data == nullptr) {
@@ -614,40 +565,73 @@ static void ConvolveSme(const size_t co, //channels out
         MlasTrySimpleParallel(ThreadPool, static_cast<ptrdiff_t>(dim[0] * dim[1] * dim[2]), [&](ptrdiff_t tid) {
             //compute B,M,N index from iteration index
             //ptrdiff_t BIdx = tid / (dim[1] * dim[2]);
-            ptrdiff_t MIdx = (tid % (dim[1] * dim[2])) / dim[2];
-            ptrdiff_t NIdx = (tid % (dim[1] * dim[2])) % dim[2];
+            const size_t m_idx = static_cast<size_t>((tid % (dim[1] * dim[2])) / dim[2]);
+            const size_t n_idx = static_cast<size_t>((tid % (dim[1] * dim[2])) % dim[2]);
 
             // Get rhs tile, B
             const size_t rhs_packed_offset =
-                imatmul_conv.ukernel.get_rhs_packed_offset(NIdx * n_step, d_kh * d_kw, ci);
+                imatmul_conv.ukernel.get_rhs_packed_offset(n_idx * n_tile_step, d_kh * d_kw, ci);
 
             auto BTile = reinterpret_cast<const void*>(
                 rhs_data + rhs_packed_offset
             );
 
-            // Get lhs tile, A
-            const size_t lhs_packed_offset =
-                imatmul_conv.ukernel.get_lhs_packed_offset(MIdx * m_step, d_kh * d_kw, ci);
+            // Calculate lhs tile chunks
+            auto tile_size_n = (n_idx + 1) * n_tile_step > co ? (co - n_idx * n_tile_step) : n_tile_step;
 
-            auto ATile = reinterpret_cast<const float*>(
-                reinterpret_cast<const std::byte*>(lhs.get()) + lhs_packed_offset
-            );
+            // Compute the starting row index of the current M tile
+            size_t tile_m_start = m_idx * m_tile_step;
+            // Actual number of rows in this tile (may be smaller for the last tile)
+            size_t tile_m_size = std::min(m_tile_step, m - tile_m_start);
 
-            auto TileSizeM = (MIdx + 1) * m_step > m ? (m - MIdx * m_step) : m_step;
-            auto TileSizeN = (NIdx + 1) * n_step > co ? (co - NIdx * n_step) : n_step;
+            // Query the packed LHS buffer size for exactly one m_step block.
+            const size_t bytes_per_m_step = kai_get_lhs_packed_size_lhs_imatmul_pack_x32p2vlx1_x32p_sme(
+                m_step, d_kh * d_kw, ci);
 
-            // Get result tile, C
-            auto CTile = &reinterpret_cast<std::byte*>(result)[
-                MIdx * m_step * co * sizeof(float) +
-                NIdx * n_step * sizeof(float)];
+            // Determine how many rows we can pack in one chunk.
+            size_t m_chunk = std::max<size_t>(m_step, MAX_LHS_CHUNK_BYTES / bytes_per_m_step * m_step);
 
-            KLEIDIAI_KERNEL_LOG(imatmul_conv.name
-                                << " M=" << TileSizeM << " N=" << TileSizeN
-                                << " k_chunk_count=" << (d_kh * d_kw) << " k_chunk_length=" << ci);
-            imatmul_conv.ukernel.run_imatmul(
-                TileSizeM, TileSizeN, d_kh * d_kw, ci, ATile, BTile, CTile, co * sizeof(float),
-                -std::numeric_limits<float>::max(), std::numeric_limits<float>::max()
-            );
+            // Do not exceed the number of rows available in this tile
+            m_chunk = std::min<size_t>(tile_m_size, m_chunk);
+
+            // Compute the exact packed buffer size for m_chunk rows.
+            const size_t lhs_buffer_bytes = kai_get_lhs_packed_size_lhs_imatmul_pack_x32p2vlx1_x32p_sme(
+                m_chunk, d_kh * d_kw, ci);
+
+            // Allocate a single reusable buffer for LHS packing
+            auto lhs = std::make_unique<std::byte[]>(lhs_buffer_bytes);
+
+            // Interpret the packed LHS buffer as the input A tile
+            // for the matrix multiplication kernel.
+            auto ATile = reinterpret_cast<const float*>(lhs.get());
+
+            for (size_t m_base = 0; m_base < tile_m_size; m_base += m_chunk) {
+                // Actual number of rows processed in this iteration.
+                // The last chunk may be smaller than m_chunk.
+                const size_t tile_size_m = std::min(m_chunk, tile_m_size - m_base);
+
+                // Pack TileSizeM rows of the LHS matrix into a temporary buffer.
+                kai_run_lhs_imatmul_pack_x32p2vlx1_x32p_sme(tile_size_m,
+                                                            d_kh * d_kw,
+                                                            ci,
+                                                            lhs_ptrs.get() + (tile_m_start + m_base) * d_kh * d_kw,
+                                                            reinterpret_cast<size_t>(activation_src),
+                                                            reinterpret_cast<const void*>(pad_data),
+                                                            lhs.get());
+
+                // Get result tile, C
+                auto CTile = &reinterpret_cast<std::byte*>(result)[
+                    (tile_m_start + m_base) * co * sizeof(float) +
+                    n_idx * n_tile_step * sizeof(float)];
+
+                KLEIDIAI_KERNEL_LOG(imatmul_conv.name
+                    << " M=" << tile_size_m << " N=" << tile_size_n
+                    << " k_chunk_count=" << (d_kh * d_kw) << " k_chunk_length=" << ci);
+
+                imatmul_conv.ukernel.run_imatmul(tile_size_m, tile_size_n, d_kh * d_kw, ci, ATile, BTile,
+                                                 CTile, co * sizeof(float), -std::numeric_limits<float>::max(),
+                                                 std::numeric_limits<float>::max());
+            }
         });
 
         if (grouped_channels_last) {

--- a/onnxruntime/core/mlas/lib/kleidiai/convolve_kleidiai.cpp
+++ b/onnxruntime/core/mlas/lib/kleidiai/convolve_kleidiai.cpp
@@ -148,7 +148,7 @@ static bool CheckCapabilitiesSme(const MLAS_CONV_PARAMETERS* Parameters) {
     const auto route_selection = ArmKleidiAI::SelectConvRoute(Parameters);
     const auto route = route_selection.route;
 
-    if (route == ArmKleidiAI::ConvRoute::Igemm) {
+    if (route == ArmKleidiAI::ConvRoute::IGemm) {
         // ensure LHS packed buffer size is non-zero
         const size_t d_kh = route_selection.effective_kernel_h;
         const size_t d_kw = route_selection.effective_kernel_w;
@@ -164,7 +164,7 @@ static bool CheckCapabilitiesSme(const MLAS_CONV_PARAMETERS* Parameters) {
         return true;
     }
 
-    if (route == ArmKleidiAI::ConvRoute::GemmFallback) {
+    if (route == ArmKleidiAI::ConvRoute::SGemmFallback) {
         KLEIDIAI_DEBUG_LOG("CheckCapabilitiesSme returning false to prefer SGEMM-backed conv path.");
     } else {
         KLEIDIAI_DEBUG_LOG("CheckCapabilitiesSme returning false on functional or optimization checks.");

--- a/onnxruntime/core/mlas/lib/kleidiai/mlasi_kleidiai.h
+++ b/onnxruntime/core/mlas/lib/kleidiai/mlasi_kleidiai.h
@@ -56,6 +56,65 @@ inline const bool UseSME2 = MLAS_CPUIDINFO::GetCPUIDInfo().HasArm_SME2();
 inline const bool UseSME = MLAS_CPUIDINFO::GetCPUIDInfo().HasArm_SME();
 inline const std::string_view vendor_name = MLAS_CPUIDINFO::GetCPUIDInfo().GetCPUVendor();
 
+enum class ConvRoute {
+    None,
+    Igemm,
+    GemmFallback,
+};
+
+inline constexpr size_t ConvIgemmMaxWork = 1000000ULL;
+
+inline constexpr size_t ComputeDilatedKernelSize(size_t dilation, size_t kernel) {
+    return (dilation * kernel) - (dilation - 1);
+}
+
+inline constexpr size_t ComputeConvOutputSize(size_t input, size_t kernel, size_t padding, size_t stride) {
+    if (stride > 0 && (input + 2 * padding) >= kernel) {
+        return (((input - kernel) + (2 * padding)) / stride) + 1;
+    }
+
+    return 0;
+}
+
+inline ConvRoute SelectConvRoute(const MLAS_CONV_PARAMETERS* Parameters) {
+    if ((Parameters->Dimensions != 2) ||
+        (Parameters->BatchCount != 1) ||
+        (Parameters->Beta != 0.f) ||
+        (Parameters->Padding[0] != Parameters->Padding[1]) ||
+        (Parameters->Padding[0] != Parameters->Padding[2]) ||
+        (Parameters->Padding[0] != Parameters->Padding[3])) {
+        return ConvRoute::None;
+    }
+
+    const auto effective_kernel_h =
+        ComputeDilatedKernelSize(Parameters->DilationShape[0], Parameters->KernelShape[0]);
+    const auto effective_kernel_w =
+        ComputeDilatedKernelSize(Parameters->DilationShape[1], Parameters->KernelShape[1]);
+    const auto output_m =
+        ComputeConvOutputSize(Parameters->InputShape[0], effective_kernel_h, Parameters->Padding[0], Parameters->StrideShape[0]) *
+        ComputeConvOutputSize(Parameters->InputShape[1], effective_kernel_w, Parameters->Padding[1], Parameters->StrideShape[1]);
+
+    if (output_m == 0) {
+        return ConvRoute::None;
+    }
+
+    const auto filter_count = Parameters->FilterCount;
+    if (filter_count == 1 || Parameters->KernelShape[0] < 3 || Parameters->KernelShape[1] < 3) {
+        return ConvRoute::None;
+    }
+
+    const auto effective_k = Parameters->InputChannels * effective_kernel_h * effective_kernel_w;
+    if(effective_k == 0 || filter_count == 0) {
+        return ConvRoute::None;
+    }
+
+    const auto igemm_max_output_m = (ConvIgemmMaxWork / effective_k / filter_count);
+    if (output_m > igemm_max_output_m) {
+        return ConvRoute::GemmFallback;
+    }
+    return ConvRoute::Igemm;
+}
+
 // Buffer packing routines.
 //
 size_t

--- a/onnxruntime/core/mlas/lib/kleidiai/mlasi_kleidiai.h
+++ b/onnxruntime/core/mlas/lib/kleidiai/mlasi_kleidiai.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include "../mlasi.h"
-#include <iostream>
 
 // Fix to ensure compatibility with MSVC build
 #if defined(_MSC_VER)
@@ -25,6 +24,7 @@
 #endif
 
 #if KLEIDIAI_DEBUG_LOGGING ||KLEIDIAI_KERNEL_LOGGING
+#include <iostream>
 #define KLEIDIAI_LOG(tag, msg) \
     do { \
         std::cout << "[KLEIDIAI " << tag << "]: " << __FILE__ << " : " << __LINE__ << " : " << msg << std::endl; \
@@ -49,6 +49,9 @@
     #define KLEIDIAI_KERNEL_LOG(msg)
 #endif
 
+// Forward declaration since the function is used in this file, implementation is at the bottom of the file
+inline bool mul_overflow_size_t_builtin(size_t a, size_t b, size_t* out);
+
 namespace ArmKleidiAI {
 
 // By default we should try for SME2 first before falling back to SME.
@@ -64,16 +67,39 @@ enum class ConvRoute {
 
 inline constexpr size_t ConvIgemmMaxWork = 1000000ULL;
 
-inline constexpr size_t ComputeDilatedKernelSize(size_t dilation, size_t kernel) {
-    return (dilation * kernel) - (dilation - 1);
+inline bool TryComputeDilatedKernelSize(size_t dilation, size_t kernel, size_t* result) {
+    if (dilation == 0 || kernel == 0) return false;
+
+    // using formula: dilated_kernel_size = dilation * (kernel - 1) + 1
+    size_t scaled_kernel;
+    if (mul_overflow_size_t_builtin(kernel - 1, dilation, &scaled_kernel)) return false;
+
+    if (scaled_kernel == SIZE_MAX) return false;
+
+    *result = scaled_kernel + 1;
+    return true;
 }
 
-inline constexpr size_t ComputeConvOutputSize(size_t input, size_t kernel, size_t padding, size_t stride) {
-    if (stride > 0 && (input + 2 * padding) >= kernel) {
-        return (((input - kernel) + (2 * padding)) / stride) + 1;
-    }
+inline bool TryComputeConvOutputSize(size_t input, size_t kernel, size_t padding, size_t stride, size_t* result) {
+    *result = 0;
 
-    return 0;
+    // not an arithmetic overflow, return true but with result 0
+    if (stride == 0) return true;
+
+    size_t double_padding;
+    if (mul_overflow_size_t_builtin(padding, 2, &double_padding)) return false;
+
+    if (double_padding > (SIZE_MAX - input)) return false;
+    const size_t padded_input = double_padding + input;
+
+    // not an overflow but rather mismatched params, return true with result 0
+    if (padded_input < kernel) return true;
+
+    // using formula: output_size = ((2*padding + input - kernel) / stride) + 1
+    const size_t output_minus_one = (padded_input - kernel) / stride;
+    if (output_minus_one == SIZE_MAX) return false;
+    *result = output_minus_one + 1;
+    return true;
 }
 
 inline ConvRoute SelectConvRoute(const MLAS_CONV_PARAMETERS* Parameters) {
@@ -86,13 +112,29 @@ inline ConvRoute SelectConvRoute(const MLAS_CONV_PARAMETERS* Parameters) {
         return ConvRoute::None;
     }
 
-    const auto effective_kernel_h =
-        ComputeDilatedKernelSize(Parameters->DilationShape[0], Parameters->KernelShape[0]);
-    const auto effective_kernel_w =
-        ComputeDilatedKernelSize(Parameters->DilationShape[1], Parameters->KernelShape[1]);
-    const auto output_m =
-        ComputeConvOutputSize(Parameters->InputShape[0], effective_kernel_h, Parameters->Padding[0], Parameters->StrideShape[0]) *
-        ComputeConvOutputSize(Parameters->InputShape[1], effective_kernel_w, Parameters->Padding[1], Parameters->StrideShape[1]);
+    size_t effective_kernel_h;
+    size_t effective_kernel_w;
+    if (!TryComputeDilatedKernelSize(Parameters->DilationShape[0], Parameters->KernelShape[0], &effective_kernel_h) ||
+        !TryComputeDilatedKernelSize(Parameters->DilationShape[1], Parameters->KernelShape[1], &effective_kernel_w)) {
+        return ConvRoute::None;
+    }
+
+    size_t output_m;
+    size_t output_h_size;
+    size_t output_w_size;
+    if (!TryComputeConvOutputSize(Parameters->InputShape[0],
+                                  effective_kernel_h,
+                                  Parameters->Padding[0],
+                                  Parameters->StrideShape[0],
+                                  &output_h_size) ||
+        !TryComputeConvOutputSize(Parameters->InputShape[1],
+                                  effective_kernel_w,
+                                  Parameters->Padding[1],
+                                  Parameters->StrideShape[1],
+                                  &output_w_size) ||
+        mul_overflow_size_t_builtin(output_h_size, output_w_size, &output_m)) {
+        return ConvRoute::None;
+    }
 
     if (output_m == 0) {
         return ConvRoute::None;
@@ -103,8 +145,12 @@ inline ConvRoute SelectConvRoute(const MLAS_CONV_PARAMETERS* Parameters) {
         return ConvRoute::None;
     }
 
-    const auto effective_k = Parameters->InputChannels * effective_kernel_h * effective_kernel_w;
-    if(effective_k == 0 || filter_count == 0) {
+    size_t effective_k;
+    if (mul_overflow_size_t_builtin(Parameters->InputChannels, effective_kernel_h, &effective_k) ||
+        mul_overflow_size_t_builtin(effective_k, effective_kernel_w, &effective_k)) {
+        return ConvRoute::None;
+    }
+    if (effective_k == 0 || filter_count == 0) {
         return ConvRoute::None;
     }
 

--- a/onnxruntime/core/mlas/lib/kleidiai/mlasi_kleidiai.h
+++ b/onnxruntime/core/mlas/lib/kleidiai/mlasi_kleidiai.h
@@ -56,14 +56,16 @@ inline const bool UseSME2 = MLAS_CPUIDINFO::GetCPUIDInfo().HasArm_SME2();
 inline const bool UseSME = MLAS_CPUIDINFO::GetCPUIDInfo().HasArm_SME();
 inline const std::string_view vendor_name = MLAS_CPUIDINFO::GetCPUIDInfo().GetCPUVendor();
 
+// Selects the convolution route for Arm® KleidiAI™
 enum class ConvRoute {
-    None, // Do not override the caller's default convolution path.
-    Igemm,
-    GemmFallback,
+    NoKleidiAi,    // decline the conv, caller runs unchanged
+    IGemm,         // handle the whole conv via SME IGEMM kernel
+    SGemmFallback, // decline IGEMM, but still route the per-segment SGEMM slices through MlasGemm
+                   // so that the Arm® KleidiAI™ SGEMM backend override can pick them up
 };
 
 struct ConvRouteSelection {
-    ConvRoute route = ConvRoute::None;
+    ConvRoute route = ConvRoute::NoKleidiAi;
     size_t effective_kernel_h = 0;
     size_t effective_kernel_w = 0;
 };
@@ -167,7 +169,7 @@ inline ConvRouteSelection SelectConvRoute(const MLAS_CONV_PARAMETERS* Parameters
     if (MlasMultiplyOverflowsSizeT(output_m, effective_k, &total_work) ||
         MlasMultiplyOverflowsSizeT(total_work, filter_count, &total_work)) {
         // Total work calculation overflow means total work is too large, fall back
-        return ConvRouteSelection{ConvRoute::GemmFallback, effective_kernel_h, effective_kernel_w};
+        return ConvRouteSelection{ConvRoute::SGemmFallback, effective_kernel_h, effective_kernel_w};
     }
 
     const size_t conv_igemm_max_work =
@@ -176,10 +178,10 @@ inline ConvRouteSelection SelectConvRoute(const MLAS_CONV_PARAMETERS* Parameters
             ? Parameters->BackendKernelSelectorConfig->kleidiai_conv_igemm_max_work
             : ConvIgemmMaxWorkDefault;
     if (total_work > conv_igemm_max_work) {
-        return ConvRouteSelection{ConvRoute::GemmFallback, effective_kernel_h, effective_kernel_w};
+        return ConvRouteSelection{ConvRoute::SGemmFallback, effective_kernel_h, effective_kernel_w};
     }
 
-    return ConvRouteSelection{ConvRoute::Igemm, effective_kernel_h, effective_kernel_w};
+    return ConvRouteSelection{ConvRoute::IGemm, effective_kernel_h, effective_kernel_w};
 }
 
 // Buffer packing routines.
@@ -351,17 +353,17 @@ MlasConvSymmetricChannelsLast2DFloatPackW(
     MLAS_THREADPOOL* ThreadPool
     );
 
-inline MLAS_CONV_ROUTE
+inline MLAS_CONV_SGEMM_ROUTE
 MLASCALL
-MlasConvRoute(const MLAS_CONV_PARAMETERS* Parameters) {
+MlasConvSGemmRoute(const MLAS_CONV_PARAMETERS* Parameters) {
     if (Parameters->BackendKernelSelectorConfig &&
         !Parameters->BackendKernelSelectorConfig->use_kleidiai) {
-        return MlasConvRouteDefault;
+        return MlasConvSGemmRouteDirect;
     }
 
-    return ArmKleidiAI::SelectConvRoute(Parameters).route == ArmKleidiAI::ConvRoute::GemmFallback
-        ? MlasConvRouteGemmFallback
-        : MlasConvRouteDefault;
+    return ArmKleidiAI::SelectConvRoute(Parameters).route == ArmKleidiAI::ConvRoute::SGemmFallback
+        ? MlasConvSGemmRouteDispatch
+        : MlasConvSGemmRouteDirect;
 }
 }
 

--- a/onnxruntime/core/mlas/lib/kleidiai/mlasi_kleidiai.h
+++ b/onnxruntime/core/mlas/lib/kleidiai/mlasi_kleidiai.h
@@ -49,9 +49,6 @@
     #define KLEIDIAI_KERNEL_LOG(msg)
 #endif
 
-// Forward declaration since the function is used in this file, implementation is at the bottom of the file
-inline bool mul_overflow_size_t_builtin(size_t a, size_t b, size_t* out);
-
 namespace ArmKleidiAI {
 
 // By default we should try for SME2 first before falling back to SME.
@@ -60,19 +57,28 @@ inline const bool UseSME = MLAS_CPUIDINFO::GetCPUIDInfo().HasArm_SME();
 inline const std::string_view vendor_name = MLAS_CPUIDINFO::GetCPUIDInfo().GetCPUVendor();
 
 enum class ConvRoute {
-    None,
+    None, // Do not override the caller's default convolution path.
     Igemm,
     GemmFallback,
 };
 
-inline constexpr size_t ConvIgemmMaxWork = 1000000ULL;
+struct ConvRouteSelection {
+    ConvRoute route = ConvRoute::None;
+    size_t effective_kernel_h = 0;
+    size_t effective_kernel_w = 0;
+};
+
+// Heuristic default for SME IGEMM selection. Work is estimated as
+// output_m * effective_k * filter_count; larger workloads use the SGEMM-backed
+// fallback to avoid IGEMM packing overhead on large effective-k convolutions.
+inline constexpr size_t ConvIgemmMaxWorkDefault = 1'000'000ULL;
 
 inline bool TryComputeDilatedKernelSize(size_t dilation, size_t kernel, size_t* result) {
     if (dilation == 0 || kernel == 0) return false;
 
     // using formula: dilated_kernel_size = dilation * (kernel - 1) + 1
     size_t scaled_kernel;
-    if (mul_overflow_size_t_builtin(kernel - 1, dilation, &scaled_kernel)) return false;
+    if (MlasMultiplyOverflowsSizeT(kernel - 1, dilation, &scaled_kernel)) return false;
 
     if (scaled_kernel == SIZE_MAX) return false;
 
@@ -81,19 +87,16 @@ inline bool TryComputeDilatedKernelSize(size_t dilation, size_t kernel, size_t* 
 }
 
 inline bool TryComputeConvOutputSize(size_t input, size_t kernel, size_t padding, size_t stride, size_t* result) {
-    *result = 0;
 
-    // not an arithmetic overflow, return true but with result 0
-    if (stride == 0) return true;
+    if (stride == 0) return false;
 
     size_t double_padding;
-    if (mul_overflow_size_t_builtin(padding, 2, &double_padding)) return false;
+    if (MlasMultiplyOverflowsSizeT(padding, 2, &double_padding)) return false;
 
     if (double_padding > (SIZE_MAX - input)) return false;
     const size_t padded_input = double_padding + input;
 
-    // not an overflow but rather mismatched params, return true with result 0
-    if (padded_input < kernel) return true;
+    if (padded_input < kernel) return false;
 
     // using formula: output_size = ((2*padding + input - kernel) / stride) + 1
     const size_t output_minus_one = (padded_input - kernel) / stride;
@@ -102,21 +105,21 @@ inline bool TryComputeConvOutputSize(size_t input, size_t kernel, size_t padding
     return true;
 }
 
-inline ConvRoute SelectConvRoute(const MLAS_CONV_PARAMETERS* Parameters) {
+inline ConvRouteSelection SelectConvRoute(const MLAS_CONV_PARAMETERS* Parameters) {
     if ((Parameters->Dimensions != 2) ||
         (Parameters->BatchCount != 1) ||
         (Parameters->Beta != 0.f) ||
         (Parameters->Padding[0] != Parameters->Padding[1]) ||
         (Parameters->Padding[0] != Parameters->Padding[2]) ||
         (Parameters->Padding[0] != Parameters->Padding[3])) {
-        return ConvRoute::None;
+        return ConvRouteSelection{};
     }
 
     size_t effective_kernel_h;
     size_t effective_kernel_w;
     if (!TryComputeDilatedKernelSize(Parameters->DilationShape[0], Parameters->KernelShape[0], &effective_kernel_h) ||
         !TryComputeDilatedKernelSize(Parameters->DilationShape[1], Parameters->KernelShape[1], &effective_kernel_w)) {
-        return ConvRoute::None;
+        return ConvRouteSelection{};
     }
 
     size_t output_m;
@@ -132,33 +135,51 @@ inline ConvRoute SelectConvRoute(const MLAS_CONV_PARAMETERS* Parameters) {
                                   Parameters->Padding[1],
                                   Parameters->StrideShape[1],
                                   &output_w_size) ||
-        mul_overflow_size_t_builtin(output_h_size, output_w_size, &output_m)) {
-        return ConvRoute::None;
+        MlasMultiplyOverflowsSizeT(output_h_size, output_w_size, &output_m)) {
+        return ConvRouteSelection{};
     }
 
     if (output_m == 0) {
-        return ConvRoute::None;
+        return ConvRouteSelection{};
     }
 
     const auto filter_count = Parameters->FilterCount;
-    if (filter_count == 1 || Parameters->KernelShape[0] < 3 || Parameters->KernelShape[1] < 3) {
-        return ConvRoute::None;
+    if (filter_count == 1) {
+        // Single-output-channel convolutions do not fill the SME IGEMM N tile efficiently,
+        // so defer to the default convolution route.
+        return ConvRouteSelection{};
+    }
+
+    if (Parameters->KernelShape[0] < 3 || Parameters->KernelShape[1] < 3) {
+        return ConvRouteSelection{};
     }
 
     size_t effective_k;
-    if (mul_overflow_size_t_builtin(Parameters->InputChannels, effective_kernel_h, &effective_k) ||
-        mul_overflow_size_t_builtin(effective_k, effective_kernel_w, &effective_k)) {
-        return ConvRoute::None;
+    if (MlasMultiplyOverflowsSizeT(Parameters->InputChannels, effective_kernel_h, &effective_k) ||
+        MlasMultiplyOverflowsSizeT(effective_k, effective_kernel_w, &effective_k)) {
+        return ConvRouteSelection{};
     }
     if (effective_k == 0 || filter_count == 0) {
-        return ConvRoute::None;
+        return ConvRouteSelection{};
     }
 
-    const auto igemm_max_output_m = (ConvIgemmMaxWork / effective_k / filter_count);
-    if (output_m > igemm_max_output_m) {
-        return ConvRoute::GemmFallback;
+    size_t total_work;
+    if (MlasMultiplyOverflowsSizeT(output_m, effective_k, &total_work) ||
+        MlasMultiplyOverflowsSizeT(total_work, filter_count, &total_work)) {
+        // Total work calculation overflow means total work is too large, fall back
+        return ConvRouteSelection{ConvRoute::GemmFallback, effective_kernel_h, effective_kernel_w};
     }
-    return ConvRoute::Igemm;
+
+    const size_t conv_igemm_max_work =
+        Parameters->BackendKernelSelectorConfig != nullptr &&
+        Parameters->BackendKernelSelectorConfig->kleidiai_conv_igemm_max_work != 0
+            ? Parameters->BackendKernelSelectorConfig->kleidiai_conv_igemm_max_work
+            : ConvIgemmMaxWorkDefault;
+    if (total_work > conv_igemm_max_work) {
+        return ConvRouteSelection{ConvRoute::GemmFallback, effective_kernel_h, effective_kernel_w};
+    }
+
+    return ConvRouteSelection{ConvRoute::Igemm, effective_kernel_h, effective_kernel_w};
 }
 
 // Buffer packing routines.
@@ -329,38 +350,18 @@ MlasConvSymmetricChannelsLast2DFloatPackW(
     size_t PackedFilterGroupStride,
     MLAS_THREADPOOL* ThreadPool
     );
+
+inline MLAS_CONV_ROUTE
+MLASCALL
+MlasConvRoute(const MLAS_CONV_PARAMETERS* Parameters) {
+    if (Parameters->BackendKernelSelectorConfig &&
+        !Parameters->BackendKernelSelectorConfig->use_kleidiai) {
+        return MlasConvRouteDefault;
+    }
+
+    return ArmKleidiAI::SelectConvRoute(Parameters).route == ArmKleidiAI::ConvRoute::GemmFallback
+        ? MlasConvRouteGemmFallback
+        : MlasConvRouteDefault;
+}
 }
 
-/*++
-
-Routine Description:
-
-    This routine determines if a wraparound will occur when multiplying two size_t variables
-    Uses __builtin_mul_overflow if available on the current system and if not falls back
-    to a default implementation to check this wraparound.
-
-Arguments:
-
-    a - Supplies the first number to be muliplied.
-
-    b - Supplies the second number to be muliplied.
-
-    out - pointer to a size_t which acts as the return value in success cases.
-
-Return Value:
-
-    Returns false if the operation was successful
-    Returns true if wraparound of size_t was detected
-
---*/
-inline bool mul_overflow_size_t_builtin(size_t a, size_t b, size_t* out) {
-#if defined(__has_builtin)
-#  if __has_builtin(__builtin_mul_overflow)
-    return __builtin_mul_overflow(a, b, out);
-#  endif
-#endif
-    // Fallback to manual check if builtin not available
-    if (b != 0 && a > SIZE_MAX / b) return true;
-    if (out) *out = a * b;
-    return false;
-}

--- a/onnxruntime/core/mlas/lib/kleidiai/mlasi_kleidiai.h
+++ b/onnxruntime/core/mlas/lib/kleidiai/mlasi_kleidiai.h
@@ -145,14 +145,12 @@ inline ConvRouteSelection SelectConvRoute(const MLAS_CONV_PARAMETERS* Parameters
         return ConvRouteSelection{};
     }
 
-    const auto filter_count = Parameters->FilterCount;
-    if (filter_count == 1) {
-        // Single-output-channel convolutions do not fill the SME IGEMM N tile efficiently,
-        // so defer to the default convolution route.
+    if (Parameters->KernelShape[0] < 3 || Parameters->KernelShape[1] < 3) {
         return ConvRouteSelection{};
     }
 
-    if (Parameters->KernelShape[0] < 3 || Parameters->KernelShape[1] < 3) {
+    const auto filter_count = Parameters->FilterCount;
+    if (filter_count == 0) {
         return ConvRouteSelection{};
     }
 
@@ -161,7 +159,18 @@ inline ConvRouteSelection SelectConvRoute(const MLAS_CONV_PARAMETERS* Parameters
         MlasMultiplyOverflowsSizeT(effective_k, effective_kernel_w, &effective_k)) {
         return ConvRouteSelection{};
     }
-    if (effective_k == 0 || filter_count == 0) {
+    if (effective_k == 0) {
+        return ConvRouteSelection{};
+    }
+
+    // Currently, the fallback routes assume NCHW layout, so keep valid NHWC convolutions on IGEMM
+    if (Parameters->ChannelsLast) {
+        return ConvRouteSelection{ConvRoute::IGemm, effective_kernel_h, effective_kernel_w};
+    }
+
+    if (filter_count == 1) {
+        // Single-output-channel convolutions do not fill the SME IGEMM N tile efficiently,
+        // so defer to the default convolution route.
         return ConvRouteSelection{};
     }
 

--- a/onnxruntime/core/mlas/lib/kleidiai/sbgemm_kleidiai.cpp
+++ b/onnxruntime/core/mlas/lib/kleidiai/sbgemm_kleidiai.cpp
@@ -279,7 +279,7 @@ Return Value:
     LhsPackedStride = kai_get_lhs_packed_size_lhs_pack_bf16p2vlx2_f32_sme(M, K, mr, kr, sr);
 
     size_t lhs_resize = 0;
-    if (mul_overflow_size_t_builtin(LhsPackedStride, BatchSize, &lhs_resize))
+    if (MlasMultiplyOverflowsSizeT(LhsPackedStride, BatchSize, &lhs_resize))
     {
         // size_t wraparound detected for LhsPackedStride, fallback to MLAS
         return false;
@@ -304,7 +304,7 @@ Return Value:
         // Multithread pack lhs and rhs
         RhsPackedStride = ArmKleidiAI::MlasSBGemmPackBSize(TransA, TransB, N, K);
         size_t rhs_resize = 0;
-        if (mul_overflow_size_t_builtin(RhsPackedStride, BatchSize, &rhs_resize))
+        if (MlasMultiplyOverflowsSizeT(RhsPackedStride, BatchSize, &rhs_resize))
         {
             // size_t wraparound detected for RhsPackedStride, fallback to MLAS
             return false;
@@ -354,7 +354,7 @@ Return Value:
     // Pre-check maximum tile size to avoid per-iteration overflow inside the parallel loop.
     // Any TileSizeM/TileSizeN used below will be <= m_step/n_step respectively.
     size_t max_tile_elems = 0;
-    if (mul_overflow_size_t_builtin(m_step, n_step, &max_tile_elems)) {
+    if (MlasMultiplyOverflowsSizeT(m_step, n_step, &max_tile_elems)) {
         // size_t wraparound detected for tile size, fallback to MLAS
         return false;
     }

--- a/onnxruntime/core/mlas/lib/kleidiai/sgemm_kleidiai.cpp
+++ b/onnxruntime/core/mlas/lib/kleidiai/sgemm_kleidiai.cpp
@@ -542,7 +542,7 @@ Return Value:
     LhsPackedStride = kai_get_lhs_packed_size_lhs_pack_f32p2vlx1_f32_sme(M, K, mr, kr, sr);
 
     size_t lhs_resize = 0;
-    if(mul_overflow_size_t_builtin(LhsPackedStride, BatchSize, &lhs_resize))
+    if(MlasMultiplyOverflowsSizeT(LhsPackedStride, BatchSize, &lhs_resize))
     {
         // size_t wraparound detected for LhsPackedStride, fallback to MLAS
         return false;
@@ -568,7 +568,7 @@ Return Value:
         // Multithread pack lhs and rhs
         RhsPackedStride = ArmKleidiAI::MlasGemmPackBSize(TransA, TransB, N, K);
         size_t rhs_resize = 0;
-        if (mul_overflow_size_t_builtin(RhsPackedStride, BatchSize, &rhs_resize))
+        if (MlasMultiplyOverflowsSizeT(RhsPackedStride, BatchSize, &rhs_resize))
         {
             // size_t wraparound detected for RhsPackedStride, fallback to MLAS
             return false;
@@ -616,7 +616,7 @@ Return Value:
     // Pre-check maximum tile size to avoid per-iteration overflow inside the parallel loop.
     // Any TileSizeM/TileSizeN used below will be <= m_step/n_step respectively.
     size_t max_tile_elems = 0;
-    if (mul_overflow_size_t_builtin(m_step, n_step, &max_tile_elems)) {
+    if (MlasMultiplyOverflowsSizeT(m_step, n_step, &max_tile_elems)) {
         // size_t wraparound detected for tile size, fallback to MLAS
         return false;
     }

--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -119,6 +119,33 @@ Abstract:
 
 #define MLAS_UNREFERENCED_PARAMETER(parameter) ((void)(parameter))
 
+//
+// Reports whether multiplying two size_t values would overflow.
+//
+
+MLAS_FORCEINLINE
+bool
+MlasMultiplyOverflowsSizeT(
+    size_t a,
+    size_t b,
+    size_t* out
+    )
+{
+#if defined(__has_builtin)
+#if __has_builtin(__builtin_mul_overflow)
+    size_t result;
+    return __builtin_mul_overflow(a, b, out != nullptr ? out : &result);
+#endif
+#endif
+    if (b != 0 && a > std::numeric_limits<size_t>::max() / b) {
+        return true;
+    }
+    if (out != nullptr) {
+        *out = a * b;
+    }
+    return false;
+}
+
 #ifdef MLAS_NO_EXCEPTION
 
 MLAS_FORCEINLINE void
@@ -891,6 +918,18 @@ bool
     MLAS_THREADPOOL* ThreadPool
     );
 
+enum MLAS_CONV_ROUTE {
+    MlasConvRouteDefault,
+    MlasConvRouteGemmFallback,
+};
+
+typedef
+MLAS_CONV_ROUTE
+(MLASCALL MLAS_CONV_ROUTE_OVERRIDE)(
+    const MLAS_CONV_PARAMETERS* Parameters
+    );
+
+
 typedef
 bool
 (MLASCALL MLAS_SGEMM_BATCH_OVERRIDE)(
@@ -1520,6 +1559,7 @@ struct MLAS_PLATFORM {
     // MLAS Conv overrides
     MLAS_CONV_PREPARE_FLOAT_OVERRIDE* MlasConvPrepareOverride = nullptr;
     MLAS_CONV_FLOAT_OVERRIDE* MlasConvOverride = nullptr;
+    MLAS_CONV_ROUTE_OVERRIDE* MlasConvRouteOverride = nullptr;
 #if defined(__aarch64__) && defined(__linux__)
     // SBGemm overrides
     MLAS_SBGEMM_BATCH_OVERRIDE* MlasSBGemmBatchOverride = nullptr;

--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -918,14 +918,14 @@ bool
     MLAS_THREADPOOL* ThreadPool
     );
 
-enum MLAS_CONV_ROUTE {
-    MlasConvRouteDefault,
-    MlasConvRouteGemmFallback,
+enum MLAS_CONV_SGEMM_ROUTE {
+    MlasConvSGemmRouteDirect,   // call MlasSgemmOperation directly
+    MlasConvSGemmRouteDispatch, // call MlasGemm so backend SGEMM overrides may be selected
 };
 
 typedef
-MLAS_CONV_ROUTE
-(MLASCALL MLAS_CONV_ROUTE_OVERRIDE)(
+MLAS_CONV_SGEMM_ROUTE
+(MLASCALL MLAS_CONV_SGEMM_ROUTE_OVERRIDE)(
     const MLAS_CONV_PARAMETERS* Parameters
     );
 
@@ -1559,7 +1559,7 @@ struct MLAS_PLATFORM {
     // MLAS Conv overrides
     MLAS_CONV_PREPARE_FLOAT_OVERRIDE* MlasConvPrepareOverride = nullptr;
     MLAS_CONV_FLOAT_OVERRIDE* MlasConvOverride = nullptr;
-    MLAS_CONV_ROUTE_OVERRIDE* MlasConvRouteOverride = nullptr;
+    MLAS_CONV_SGEMM_ROUTE_OVERRIDE* MlasConvSGemmRouteOverride = nullptr;
 #if defined(__aarch64__) && defined(__linux__)
     // SBGemm overrides
     MLAS_SBGEMM_BATCH_OVERRIDE* MlasSBGemmBatchOverride = nullptr;

--- a/onnxruntime/core/mlas/lib/platform.cpp
+++ b/onnxruntime/core/mlas/lib/platform.cpp
@@ -713,7 +713,7 @@ Return Value:
         this->MlasDynamicQGemmPackBOverride = ArmKleidiAI::MlasDynamicQGemmPackB;
         this->MlasConvPrepareOverride = ArmKleidiAI::MlasConvPrepare;
         this->MlasConvOverride = ArmKleidiAI::MlasConv;
-        this->MlasConvRouteOverride = ArmKleidiAI::MlasConvRoute;
+        this->MlasConvSGemmRouteOverride = ArmKleidiAI::MlasConvSGemmRoute;
 #if defined(__aarch64__) && defined(__linux__)
         // Currently only an SME2 variant of SBGEMM exists
         if (ArmKleidiAI::UseSME2){

--- a/onnxruntime/core/mlas/lib/platform.cpp
+++ b/onnxruntime/core/mlas/lib/platform.cpp
@@ -713,6 +713,7 @@ Return Value:
         this->MlasDynamicQGemmPackBOverride = ArmKleidiAI::MlasDynamicQGemmPackB;
         this->MlasConvPrepareOverride = ArmKleidiAI::MlasConvPrepare;
         this->MlasConvOverride = ArmKleidiAI::MlasConv;
+        this->MlasConvRouteOverride = ArmKleidiAI::MlasConvRoute;
 #if defined(__aarch64__) && defined(__linux__)
         // Currently only an SME2 variant of SBGEMM exists
         if (ArmKleidiAI::UseSME2){

--- a/onnxruntime/core/providers/cpu/mlas_backend_kernel_selector_config_utils.h
+++ b/onnxruntime/core/providers/cpu/mlas_backend_kernel_selector_config_utils.h
@@ -19,12 +19,12 @@ inline void SetupMlasBackendKernelSelectorFromConfigOptions(MLAS_BACKEND_KERNEL_
                                                             const ConfigOptions& config_options) {
   config.use_kleidiai = config_options.GetConfigOrDefault(kOrtSessionOptionsMlasDisableKleidiAi, "0") != "1";
 
-  std::string conv_igemm_max_work;
-  if (config_options.TryGetConfigEntry(kOrtSessionOptionsMlasKleidiAiConvIgemmMaxWork, conv_igemm_max_work)) {
-    ORT_ENFORCE(TryParseStringWithClassicLocale<size_t>(conv_igemm_max_work,
+  if (auto conv_igemm_max_work =
+          config_options.GetConfigEntry(kOrtSessionOptionsMlasKleidiAiConvIgemmMaxWork)) {
+    ORT_ENFORCE(TryParseStringWithClassicLocale<size_t>(*conv_igemm_max_work,
                                                         config.kleidiai_conv_igemm_max_work),
                 "Invalid value for ", kOrtSessionOptionsMlasKleidiAiConvIgemmMaxWork,
-                ": ", conv_igemm_max_work, ". Expected a non-negative integer.");
+                ": ", *conv_igemm_max_work, ". Expected a non-negative integer.");
   }
 }
 

--- a/onnxruntime/core/providers/cpu/mlas_backend_kernel_selector_config_utils.h
+++ b/onnxruntime/core/providers/cpu/mlas_backend_kernel_selector_config_utils.h
@@ -11,12 +11,21 @@
 
 #include "core/session/onnxruntime_session_options_config_keys.h"
 #include "core/mlas/inc/mlas.h"
+#include "core/common/parse_string.h"
 
 namespace onnxruntime {
 
 inline void SetupMlasBackendKernelSelectorFromConfigOptions(MLAS_BACKEND_KERNEL_SELECTOR_CONFIG& config,
                                                             const ConfigOptions& config_options) {
   config.use_kleidiai = config_options.GetConfigOrDefault(kOrtSessionOptionsMlasDisableKleidiAi, "0") != "1";
+
+  std::string conv_igemm_max_work;
+  if (config_options.TryGetConfigEntry(kOrtSessionOptionsMlasKleidiAiConvIgemmMaxWork, conv_igemm_max_work)) {
+    ORT_ENFORCE(TryParseStringWithClassicLocale<size_t>(conv_igemm_max_work,
+                                                        config.kleidiai_conv_igemm_max_work),
+                "Invalid value for ", kOrtSessionOptionsMlasKleidiAiConvIgemmMaxWork,
+                ": ", conv_igemm_max_work, ". Expected a non-negative integer.");
+  }
 }
 
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/cpu/cpu_execution_provider_test.cc
+++ b/onnxruntime/test/providers/cpu/cpu_execution_provider_test.cc
@@ -33,5 +33,34 @@ TEST(CPUExecutionProviderTest, MlasBackendKernelSelectorCanDisableKleidiAi) {
 
   EXPECT_FALSE(config.use_kleidiai);
 }
+
+TEST(CPUExecutionProviderTest, MlasBackendKernelSelectorParsesKleidiAiConvIgemmMaxWork) {
+  MLAS_BACKEND_KERNEL_SELECTOR_CONFIG config;
+  ConfigOptions config_options;
+  const Status add_config_status = config_options.AddConfigEntry(kOrtSessionOptionsMlasKleidiAiConvIgemmMaxWork, "1234567");
+  ASSERT_TRUE(add_config_status.IsOK()) << add_config_status.ErrorMessage();
+
+  SetupMlasBackendKernelSelectorFromConfigOptions(config, config_options);
+
+  EXPECT_EQ(config.kleidiai_conv_igemm_max_work, 1234567u);
+}
+
+TEST(CPUExecutionProviderTest, MlasBackendKernelSelectorRejectsInvalidKleidiAiConvIgemmMaxWork) {
+  MLAS_BACKEND_KERNEL_SELECTOR_CONFIG config;
+  ConfigOptions config_options;
+  const Status add_config_status = config_options.AddConfigEntry(kOrtSessionOptionsMlasKleidiAiConvIgemmMaxWork, "Not a Number");
+  ASSERT_TRUE(add_config_status.IsOK()) << add_config_status.ErrorMessage();
+
+  try {
+    SetupMlasBackendKernelSelectorFromConfigOptions(config, config_options);
+    FAIL() << "Expected invalid " << kOrtSessionOptionsMlasKleidiAiConvIgemmMaxWork << " to throw.";
+  } catch (const OnnxRuntimeException& e) {
+    const std::string message = e.what();
+    EXPECT_NE(message.find(kOrtSessionOptionsMlasKleidiAiConvIgemmMaxWork), std::string::npos);
+    EXPECT_NE(message.find("Not a Number"), std::string::npos);
+    EXPECT_NE(message.find("Expected a non-negative integer."), std::string::npos);
+  }
+}
+
 }  // namespace test
 }  // namespace onnxruntime


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

This PR fixes a convolution performance regression affecting some OCR models with large-kernel convolutions when the KleidiAI SME IGEMM convolution path is selected. 

The change has 2 parts:
1. updates to the KleidiAI IGEMM LHS packing to pack rows in bounded chunks instead of packing the full LHS buffer up front, which reduces memory usage and improves cache locality for large convolutions,
2. a new route selection function `ArmKleidiAI::SelectConvRoute` that decides between `Igemm`, `GemmFallback` and `None` based on convolution parameters and a workload size-based heuristic.

The function `CheckCapabilitiesSme` runs `SelectConvRoute` and only returns true if the selected route is `Igemm`. The patch also adds a standard GEMM fallback to the `ConvRoute` possibilities, and runs `MlasGemm` if said fallback is selected. If the function selects `None`, then the convolution falls back to `MlasSgemmOperation`.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Fixes #27633.