### PR TITLE
Fix Whisper genai_config context_length using wrong config attribute

### DIFF
--- a/onnxruntime/python/tools/transformers/models/whisper/whisper_helper.py
+++ b/onnxruntime/python/tools/transformers/models/whisper/whisper_helper.py
@@ -525,10 +525,13 @@ class WhisperHelper:
             f.write(audio_processor_json)
 
         provider_options = [] if "cpu" in provider else [{f"{provider}": {}}]
+        # Prefer max_target_positions (always 448 for Whisper) over max_length,
+        # which may not exist on WhisperConfig and fall back to a wrong default (20).
+        context_length = getattr(config, "max_target_positions", None) or config.max_length
         genai_config = {
             "model": {
                 "bos_token_id": config.bos_token_id,
-                "context_length": config.max_length,
+                "context_length": context_length,
                 "decoder": {
                     "session_options": {
                         "log_id": "onnxruntime-genai",
@@ -581,7 +584,7 @@ class WhisperHelper:
                 "do_sample": False,
                 "early_stopping": True,
                 "length_penalty": 1.0,
-                "max_length": config.max_length,
+                "max_length": context_length,
                 "min_length": 0,
                 "no_repeat_ngram_size": 0,
                 "num_beams": 1,


### PR DESCRIPTION
## Description

`WhisperConfig` does not have a `max_length` attribute. Accessing `config.max_length` falls back to the `PretrainedConfig` default (20) in some transformers versions, causing a runtime error:

```
RuntimeError: max_length (448) cannot be greater than model context_length (20)
```

## Fix

Use `config.max_target_positions` (always 448 for all Whisper variants) instead of `config.max_length` for both `context_length` and `search.max_length` in the generated `genai_config.json`.

## Testing

Verified that `max_target_positions` is correctly set to 448 for whisper-tiny, whisper-medium, and whisper-large-v3-turbo.