### PR TITLE
Move `OrtEp` sanity checks to plugin EP creation and remove check for `OrtEp::ort_version_supported` upper bound

### DIFF
--- a/onnxruntime/core/session/plugin_ep/ep_kernel_registration.cc
+++ b/onnxruntime/core/session/plugin_ep/ep_kernel_registration.cc
@@ -207,23 +207,6 @@ class PluginEpOpKernel final : public controlflow::IControlFlowKernel {
 Status PluginEpOpKernel::Create(FuncManager& /*fn_manager*/, const OpKernelInfo& info,
                                 OrtKernelCreateFunc kernel_create_func, void* kernel_create_func_state,
                                 /*out*/ std::unique_ptr<PluginEpOpKernel>& op_kernel) {
-  const auto* ep = info.GetExecutionProvider();
-  ORT_ENFORCE(ep != nullptr, "IExecutionProvider* retrieved from OpKernelInfo should never be nullptr");
-  const auto* ort_ep = ep->GetOrtEp();
-  ORT_ENFORCE(ort_ep != nullptr, "GetOrtEp() returned nullptr for EP '", ep->Type(), "'");
-
-  // Sanity-check the OrtEp to detect corruption early (e.g., garbage pointer from vtable mismatch).
-  ORT_ENFORCE(ort_ep->ort_version_supported > 0 && ort_ep->ort_version_supported <= ORT_API_VERSION,
-              "OrtEp for '", ep->Type(), "' has invalid ort_version_supported=", ort_ep->ort_version_supported,
-              " (expected 1..", ORT_API_VERSION, "). Possible pointer corruption or stale plugin DLL.");
-  ORT_ENFORCE(ort_ep->GetName != nullptr,
-              "OrtEp for '", ep->Type(), "' has null GetName function pointer. Possible pointer corruption.");
-  const char* ort_ep_name = ort_ep->GetName(ort_ep);
-  ORT_ENFORCE(ort_ep_name != nullptr && ep->Type() == ort_ep_name,
-              "OrtEp::GetName() returned '", (ort_ep_name ? ort_ep_name : "<null>"),
-              "' but IExecutionProvider::Type() is '", ep->Type(),
-              "'. Possible pointer corruption or EP mismatch.");
-
   // OpKernel's constructor *copies* the OpKernelInfo.
   // Therefore, must create the OpKernel instance immediately so that we can pass the actual OpKernelInfo
   // to the plugin EP's kernel creation function.
@@ -235,6 +218,8 @@ Status PluginEpOpKernel::Create(FuncManager& /*fn_manager*/, const OpKernelInfo&
 
   const auto& op_type = info.node().OpType();
   const auto& node_name = info.node().Name();
+  const auto* ep = info.GetExecutionProvider();
+  ORT_ENFORCE(ep != nullptr, "IExecutionProvider* retrieved from OpKernelInfo should never be nullptr");
   const auto& ep_name = ep->Type();
 
   // Do some basic checks for the OrtKernelImpl provided by the EP. Other checks for missing function implementations

--- a/onnxruntime/core/session/plugin_ep/ep_plugin_provider_interfaces.cc
+++ b/onnxruntime/core/session/plugin_ep/ep_plugin_provider_interfaces.cc
@@ -72,23 +72,43 @@ PluginExecutionProviderFactory::CreateProvider(const OrtSessionOptions& session_
   return plugin_ep;
 }
 
+// Do some basic checks on `ort_ep` to detect obvious issues early on.
+static Status SanityCheckOrtEp(const OrtEp& ort_ep) {
+  // Plugin EPs were first introduced in ORT 1.22, so we expect at least this API version.
+  constexpr auto kMinAllowedOrtVersionSupported = 22;
+
+  ORT_RETURN_IF_NOT(ort_ep.ort_version_supported >= kMinAllowedOrtVersionSupported,
+                    "OrtEp has invalid ort_version_supported=", ort_ep.ort_version_supported,
+                    " (expected at least ", kMinAllowedOrtVersionSupported, ").");
+
+  ORT_RETURN_IF_NOT(ort_ep.GetName != nullptr, "OrtEp has null GetName function pointer.");
+
+  ORT_RETURN_IF_NOT(ort_ep.GetName(&ort_ep) != nullptr, "OrtEp's GetName function returned null.");
+
+  return Status::OK();
+}
+
 Status PluginExecutionProviderFactory::CreatePluginExecutionProvider(
     const OrtSessionOptions& session_options,
     const OrtLogger& logger,
     /*out*/ std::unique_ptr<PluginExecutionProvider>& plugin_ep) {
   plugin_ep = nullptr;
-  OrtEp* ort_ep = nullptr;
+  OrtEp* ort_ep_raw = nullptr;
 
   ORT_RETURN_IF_ERROR(ToStatusAndRelease(ep_factory_.CreateEp(&ep_factory_, hardware_devices_.data(),
                                                               ep_metadata_.data(), hardware_devices_.size(),
-                                                              &session_options, &logger, &ort_ep)));
-  ORT_RETURN_IF(ort_ep == nullptr, "OrtEpFactory::CreateEp() for '", ep_factory_.GetName(&ep_factory_),
+                                                              &session_options, &logger, &ort_ep_raw)));
+  ORT_RETURN_IF(ort_ep_raw == nullptr, "OrtEpFactory::CreateEp() for '", ep_factory_.GetName(&ep_factory_),
                 "' returned a NULL OrtEp instance");
+
+  auto ort_ep = UniqueOrtEp(ort_ep_raw, OrtEpDeleter(ep_factory_));
+
+  ORT_RETURN_IF_ERROR(SanityCheckOrtEp(*ort_ep));
 
   std::shared_ptr<KernelRegistry> kernel_registry;
   ORT_RETURN_IF_ERROR(GetPluginEpKernelRegistry(*ort_ep, kernel_registry));
 
-  plugin_ep = std::make_unique<PluginExecutionProvider>(UniqueOrtEp(ort_ep, OrtEpDeleter(ep_factory_)),
+  plugin_ep = std::make_unique<PluginExecutionProvider>(std::move(ort_ep),
                                                         session_options, ep_factory_, devices_,
                                                         kernel_registry,
                                                         *logger.ToInternal());

--- a/onnxruntime/test/framework/ep_plugin_provider_test.cc
+++ b/onnxruntime/test/framework/ep_plugin_provider_test.cc
@@ -296,7 +296,7 @@ TEST(PluginExecutionProviderFactoryTest, CreatePluginExecutionProviderAcceptsHig
   test_plugin_ep::CreateProviderTestContext context;
 
   auto ort_ep = std::make_unique<test_plugin_ep::TestOrtEp>();
-  ort_ep->ort_version_supported = 999;
+  ort_ep->ort_version_supported = ORT_API_VERSION + 1;
   context.ep_factory.SetNextEp(std::move(ort_ep));
 
   std::unique_ptr<PluginExecutionProvider> plugin_ep;

--- a/onnxruntime/test/framework/ep_plugin_provider_test.cc
+++ b/onnxruntime/test/framework/ep_plugin_provider_test.cc
@@ -100,16 +100,23 @@ std::unique_ptr<OrtHardwareDevice> MakeTestOrtHardwareDevice(OrtHardwareDeviceTy
 }
 
 std::unique_ptr<OrtEpDevice> MakeTestOrtEpDevice(const OrtHardwareDevice* hardware_device,
-                                                 const OrtMemoryInfo* device_memory_info = nullptr,
-                                                 const OrtMemoryInfo* host_accessible_memory_info = nullptr) {
+                                                 OrtEpFactory& ep_factory,
+                                                 const OrtMemoryInfo* device_memory_info,
+                                                 const OrtMemoryInfo* host_accessible_memory_info) {
   auto ep_device = std::make_unique<OrtEpDevice>();
   ep_device->ep_name = "TestOrtEp";
   ep_device->ep_vendor = "Contoso";
   ep_device->device = hardware_device;
-  ep_device->ep_factory = &g_test_ort_ep_factory;
+  ep_device->ep_factory = &ep_factory;
   ep_device->device_memory_info = device_memory_info;
   ep_device->host_accessible_memory_info = host_accessible_memory_info;
   return ep_device;
+}
+
+std::unique_ptr<OrtEpDevice> MakeTestOrtEpDevice(const OrtHardwareDevice* hardware_device,
+                                                 const OrtMemoryInfo* device_memory_info = nullptr,
+                                                 const OrtMemoryInfo* host_accessible_memory_info = nullptr) {
+  return MakeTestOrtEpDevice(hardware_device, g_test_ort_ep_factory, device_memory_info, host_accessible_memory_info);
 }
 
 OrtDevice MakeTestOrtDevice(OrtDevice::DeviceType device_type, OrtDevice::MemoryType memory_type) {
@@ -162,7 +169,146 @@ class MockKernelLookup : public IExecutionProvider::IKernelLookup {
   LookUpKernelFunc lookup_ = nullptr;
 };
 
+const OrtLogger& GetDefaultOrtLogger() {
+  const auto& logger = DefaultLoggingManager().DefaultLogger();
+  return *reinterpret_cast<const OrtLogger*>(&logger);
+}
+
+// Test OrtEpFactory that creates a caller-provided OrtEp and tracks ReleaseEp calls.
+// Used to test PluginExecutionProviderFactory creation and sanity-check behavior.
+struct TestOrtEpFactoryForCreateProvider : ::OrtEpFactory {
+  TestOrtEpFactoryForCreateProvider() : ::OrtEpFactory{} {
+    ort_version_supported = ORT_API_VERSION;
+    GetName = GetNameImpl;
+    CreateEp = CreateEpImpl;
+    ReleaseEp = ReleaseEpImpl;
+  }
+
+  void SetNextEp(std::unique_ptr<TestOrtEp> ep) {
+    next_ep_ = std::move(ep);
+  }
+
+  static const char* ORT_API_CALL GetNameImpl(const OrtEpFactory* /*this_ptr*/) noexcept {
+    return "TestOrtEp";
+  }
+
+  static OrtStatus* ORT_API_CALL CreateEpImpl(OrtEpFactory* this_ptr,
+                                              const OrtHardwareDevice* const* /*hw_devices*/,
+                                              const OrtKeyValuePairs* const* /*ep_metadata*/,
+                                              size_t /*num_devices*/,
+                                              const OrtSessionOptions* /*session_options*/,
+                                              const OrtLogger* /*logger*/,
+                                              OrtEp** ep_out) noexcept {
+    auto& self = *static_cast<TestOrtEpFactoryForCreateProvider*>(this_ptr);
+    *ep_out = self.next_ep_.release();
+    return nullptr;
+  }
+
+  static void ORT_API_CALL ReleaseEpImpl(OrtEpFactory* this_ptr, OrtEp* ep) noexcept {
+    auto& self = *static_cast<TestOrtEpFactoryForCreateProvider*>(this_ptr);
+    ++self.release_ep_count_;
+    delete static_cast<TestOrtEp*>(ep);
+  }
+
+  int GetReleaseEpCount() const {
+    return release_ep_count_;
+  }
+
+ private:
+  int release_ep_count_ = 0;
+  std::unique_ptr<TestOrtEp> next_ep_;
+};
+
+// Test context for PluginExecutionProviderFactory creation tests.
+struct CreateProviderTestContext {
+  CreateProviderTestContext()
+      : hw_device(MakeTestOrtHardwareDevice(OrtHardwareDeviceType_CPU)),
+        ep_device(MakeTestOrtEpDevice(hw_device.get(), ep_factory,
+                                      /*device_memory_info*/ nullptr,
+                                      /*host_accessible_memory_info*/ nullptr)),
+        ep_devices{ep_device.get()},
+        provider_factory(ep_factory, ep_devices) {
+  }
+
+  Status Create(std::unique_ptr<PluginExecutionProvider>& plugin_ep_out) {
+    Ort::SessionOptions session_options;
+    return provider_factory.CreatePluginExecutionProvider(*static_cast<const OrtSessionOptions*>(session_options),
+                                                          GetDefaultOrtLogger(), plugin_ep_out);
+  }
+
+  TestOrtEpFactoryForCreateProvider ep_factory;
+  std::unique_ptr<OrtHardwareDevice> hw_device;
+  std::unique_ptr<OrtEpDevice> ep_device;
+  std::vector<const OrtEpDevice*> ep_devices;
+  PluginExecutionProviderFactory provider_factory;
+};
+
 }  // namespace test_plugin_ep
+
+TEST(PluginExecutionProviderFactoryTest, CreatePluginExecutionProviderFailsWithNullGetNamePointer) {
+  test_plugin_ep::CreateProviderTestContext context;
+
+  auto ort_ep = std::make_unique<test_plugin_ep::TestOrtEp>();
+  ort_ep->GetName = nullptr;
+  context.ep_factory.SetNextEp(std::move(ort_ep));
+
+  std::unique_ptr<PluginExecutionProvider> plugin_ep;
+  const Status status = context.Create(plugin_ep);
+
+  ASSERT_FALSE(status.IsOK());
+  EXPECT_THAT(status.ErrorMessage(), ::testing::HasSubstr("null GetName function pointer"));
+  EXPECT_EQ(context.ep_factory.GetReleaseEpCount(), 1);
+}
+
+TEST(PluginExecutionProviderFactoryTest, CreatePluginExecutionProviderFailsWhenGetNameReturnsNull) {
+  test_plugin_ep::CreateProviderTestContext context;
+
+  auto ort_ep = std::make_unique<test_plugin_ep::TestOrtEp>();
+  ort_ep->GetName = [](const OrtEp* /*this_ptr*/) noexcept -> const char* {
+    return nullptr;
+  };
+  context.ep_factory.SetNextEp(std::move(ort_ep));
+
+  std::unique_ptr<PluginExecutionProvider> plugin_ep;
+  const Status status = context.Create(plugin_ep);
+
+  ASSERT_FALSE(status.IsOK());
+  EXPECT_THAT(status.ErrorMessage(), ::testing::HasSubstr("GetName function returned null"));
+  EXPECT_EQ(context.ep_factory.GetReleaseEpCount(), 1);
+}
+
+TEST(PluginExecutionProviderFactoryTest, CreatePluginExecutionProviderFailsForTooLowVersion) {
+  test_plugin_ep::CreateProviderTestContext context;
+
+  auto ort_ep = std::make_unique<test_plugin_ep::TestOrtEp>();
+  ort_ep->ort_version_supported = 0;
+  context.ep_factory.SetNextEp(std::move(ort_ep));
+
+  std::unique_ptr<PluginExecutionProvider> plugin_ep;
+  const Status status = context.Create(plugin_ep);
+
+  ASSERT_FALSE(status.IsOK());
+  EXPECT_THAT(status.ErrorMessage(), ::testing::HasSubstr("invalid ort_version_supported"));
+  EXPECT_EQ(context.ep_factory.GetReleaseEpCount(), 1);
+}
+
+TEST(PluginExecutionProviderFactoryTest, CreatePluginExecutionProviderAcceptsHighVersion) {
+  test_plugin_ep::CreateProviderTestContext context;
+
+  auto ort_ep = std::make_unique<test_plugin_ep::TestOrtEp>();
+  ort_ep->ort_version_supported = 999;
+  context.ep_factory.SetNextEp(std::move(ort_ep));
+
+  std::unique_ptr<PluginExecutionProvider> plugin_ep;
+
+  ASSERT_STATUS_OK(context.Create(plugin_ep));
+  ASSERT_NE(plugin_ep, nullptr);
+
+  EXPECT_EQ(context.ep_factory.GetReleaseEpCount(), 0);
+
+  plugin_ep.reset();
+  EXPECT_EQ(context.ep_factory.GetReleaseEpCount(), 1);
+}
 
 TEST(PluginExecutionProviderTest, GetPreferredLayout) {
   auto [ep, ort_ep] = test_plugin_ep::MakeTestOrtEp();


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

- Move OrtEp sanity checks from op kernel creation to EP creation.
- Remove check for upper bound of OrtEp::ort_version_supported.
- Add tests covering sanity checks. 

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Revert rejection of `OrtEp` instances that specify a version in `ort_version_supported` larger than ORT's `ORT_API_VERSION`. The guidance is for plugin EPs to set it to the `ORT_API_VERSION` value from their ORT header, but plugin EPs may optionally support earlier versions of ORT as well.