### PR TITLE
Model package: security, correctness, and session creation simplification

### DIFF
--- a/onnxruntime/core/session/model_package/model_package_context.cc
+++ b/onnxruntime/core/session/model_package/model_package_context.cc
@@ -13,6 +13,8 @@
 
 #include "core/common/logging/logging.h"
 #include "core/framework/error_code_helper.h"
+#include "core/graph/constants.h"
+#include "core/providers/providers.h"
 #include "core/session/model_package/model_package_context.h"
 #include "core/session/model_package/model_package_descriptor_parser.h"
 #include "core/session/model_package/model_package_options.h"
@@ -60,14 +62,11 @@ ModelPackageComponentContext::ModelPackageComponentContext(const std::string& co
                                                            const ModelPackageOptions& options)
     : component_model_name_(component_name),
       component_model_info_(component_model_info),
-      session_options_(options.SessionOptions()),
       owned_ep_infos_(options.EpInfos()),
       execution_devices_(options.ExecutionDevices()),
       devices_selected_(options.DevicesSelected()),
       from_policy_(options.FromPolicy()) {
-  // Copy the provider list from options so we own it.
-  // This avoids UAF if the external ModelPackageOptions handle is released
-  // before this component context.
+  // Move providers from options so we own them for the first session creation.
   auto& src_providers = options.MutableProviderList();
   provider_list_.reserve(src_providers.size());
   for (auto& p : src_providers) {
@@ -325,27 +324,24 @@ Status ModelPackageComponentContext::RebuildProviderListForSession(
     const Environment& env, const OrtSessionOptions& effective_options) {
   provider_list_.clear();
 
-  const bool has_provider_factories = !effective_options.provider_factories.empty();
-
-  if (has_provider_factories) {
-    const auto& logger = *logging::LoggingManager::DefaultLogger().ToExternal();
-    for (auto& factory : effective_options.provider_factories) {
-      provider_list_.push_back(factory->CreateProvider(effective_options, logger));
-    }
+  if (owned_ep_infos_.empty()) {
     return Status::OK();
   }
 
-  // Policy path: reconstruct providers from the already-selected EP devices.
-  if (from_policy_ && !devices_selected_.empty()) {
-    std::unique_ptr<IExecutionProviderFactory> provider_factory;
-    ORT_RETURN_IF_ERROR(CreateIExecutionProviderFactoryForEpDevices(
-        env,
-        gsl::span<const OrtEpDevice* const>(devices_selected_.data(), devices_selected_.size()),
-        provider_factory));
-
-    const auto& logger = *logging::LoggingManager::DefaultLogger().ToExternal();
-    provider_list_.push_back(provider_factory->CreateProvider(effective_options, logger));
+  const auto& ep_info = owned_ep_infos_[0];
+  if (ep_info.ep_name == kCpuExecutionProvider || ep_info.ep_devices.empty()) {
+    // CPU is built-in; no provider to register.
+    return Status::OK();
   }
+
+  std::unique_ptr<IExecutionProviderFactory> provider_factory;
+  ORT_RETURN_IF_ERROR(CreateIExecutionProviderFactoryForEpDevices(
+      env,
+      gsl::span<const OrtEpDevice* const>(ep_info.ep_devices.data(), ep_info.ep_devices.size()),
+      provider_factory));
+
+  const auto& logger = *logging::LoggingManager::DefaultLogger().ToExternal();
+  provider_list_.push_back(provider_factory->CreateProvider(effective_options, logger));
 
   return Status::OK();
 }

--- a/onnxruntime/core/session/model_package/model_package_context.cc
+++ b/onnxruntime/core/session/model_package/model_package_context.cc
@@ -57,10 +57,24 @@ Status FillOptionCachesFromMap(
 
 ModelPackageComponentContext::ModelPackageComponentContext(const std::string& component_name,
                                                            const ComponentInfo& component_model_info,
-                                                           const ModelPackageOptions* options)
+                                                           const ModelPackageOptions& options)
     : component_model_name_(component_name),
       component_model_info_(component_model_info),
-      options_(options) {
+      session_options_(options.SessionOptions()),
+      owned_ep_infos_(options.EpInfos()),
+      execution_devices_(options.ExecutionDevices()),
+      devices_selected_(options.DevicesSelected()),
+      from_policy_(options.FromPolicy()) {
+  // Copy the provider list from options so we own it.
+  // This avoids UAF if the external ModelPackageOptions handle is released
+  // before this component context.
+  auto& src_providers = options.MutableProviderList();
+  provider_list_.reserve(src_providers.size());
+  for (auto& p : src_providers) {
+    provider_list_.push_back(std::move(p));
+  }
+  // Point the span at our owned copy.
+  ep_infos_ = gsl::span<const VariantSelectionEpInfo>(owned_ep_infos_);
 }
 
 ModelPackageComponentContext::ModelPackageComponentContext(const std::string& component_name,
@@ -72,20 +86,11 @@ ModelPackageComponentContext::ModelPackageComponentContext(const std::string& co
 }
 
 Status ModelPackageComponentContext::ResolveVariant() {
-  if (!ep_infos_.empty()) {
-    return ResolveVariantImpl(ep_infos_);
-  }
+  ORT_RETURN_IF(ep_infos_.empty(),
+                "ModelPackageComponentContext::ResolveVariant requires non-empty ep_infos "
+                "(from ModelPackageOptions or explicit span).");
 
-  ORT_RETURN_IF(options_ == nullptr,
-                "ModelPackageComponentContext::ResolveVariant requires non-null ModelPackageOptions "
-                "or non-empty ep_infos.");
-
-  // Mirror resolved EP runtime state from options.
-  execution_devices_ = options_->ExecutionDevices();
-  devices_selected_ = options_->DevicesSelected();
-  from_policy_ = options_->FromPolicy();
-
-  return ResolveVariantImpl(options_->EpInfos());
+  return ResolveVariantImpl(ep_infos_);
 }
 
 Status ModelPackageComponentContext::ResolveVariantImpl(gsl::span<const VariantSelectionEpInfo> ep_infos) {
@@ -262,9 +267,87 @@ Status ModelPackageComponentContext::GetSelectedVariantFileProviderOptions(size_
                                  out_values);
 }
 
-std::vector<std::unique_ptr<IExecutionProvider>>& ModelPackageComponentContext::MutableProviderList() {
-  ORT_ENFORCE(options_ != nullptr, "ModelPackageComponentContext has no associated ModelPackageOptions.");
-  return options_->MutableProviderList();
+namespace {
+void BuildPtrCache(gsl::span<const std::string> strings,
+                   std::vector<const char*>& ptrs_cache,
+                   const char* const*& out_ptrs, size_t& out_count) {
+  ptrs_cache.clear();
+  ptrs_cache.reserve(strings.size());
+  for (const auto& s : strings) {
+    ptrs_cache.push_back(s.c_str());
+  }
+  out_count = ptrs_cache.size();
+  out_ptrs = ptrs_cache.empty() ? nullptr : ptrs_cache.data();
+}
+}  // namespace
+
+Status ModelPackageComponentContext::GetSelectedVariantFileSessionOptionPtrs(
+    size_t file_idx,
+    const char* const*& out_keys,
+    const char* const*& out_values,
+    size_t& out_count) const {
+  out_keys = nullptr;
+  out_values = nullptr;
+  out_count = 0;
+
+  gsl::span<const std::string> keys;
+  gsl::span<const std::string> values;
+  ORT_RETURN_IF_ERROR(GetSelectedVariantFileSessionOptions(file_idx, keys, values));
+  ORT_RETURN_IF(keys.size() != values.size(), "Session options keys/values size mismatch.");
+
+  BuildPtrCache(keys, file_session_option_key_ptrs_cache_[file_idx], out_keys, out_count);
+  size_t dummy;
+  BuildPtrCache(values, file_session_option_value_ptrs_cache_[file_idx], out_values, dummy);
+  return Status::OK();
+}
+
+Status ModelPackageComponentContext::GetSelectedVariantFileProviderOptionPtrs(
+    size_t file_idx,
+    const char* const*& out_keys,
+    const char* const*& out_values,
+    size_t& out_count) const {
+  out_keys = nullptr;
+  out_values = nullptr;
+  out_count = 0;
+
+  gsl::span<const std::string> keys;
+  gsl::span<const std::string> values;
+  ORT_RETURN_IF_ERROR(GetSelectedVariantFileProviderOptions(file_idx, keys, values));
+  ORT_RETURN_IF(keys.size() != values.size(), "Provider options keys/values size mismatch.");
+
+  BuildPtrCache(keys, file_provider_option_key_ptrs_cache_[file_idx], out_keys, out_count);
+  size_t dummy;
+  BuildPtrCache(values, file_provider_option_value_ptrs_cache_[file_idx], out_values, dummy);
+  return Status::OK();
+}
+
+Status ModelPackageComponentContext::RebuildProviderListForSession(
+    const Environment& env, const OrtSessionOptions& effective_options) {
+  provider_list_.clear();
+
+  const bool has_provider_factories = !effective_options.provider_factories.empty();
+
+  if (has_provider_factories) {
+    const auto& logger = *logging::LoggingManager::DefaultLogger().ToExternal();
+    for (auto& factory : effective_options.provider_factories) {
+      provider_list_.push_back(factory->CreateProvider(effective_options, logger));
+    }
+    return Status::OK();
+  }
+
+  // Policy path: reconstruct providers from the already-selected EP devices.
+  if (from_policy_ && !devices_selected_.empty()) {
+    std::unique_ptr<IExecutionProviderFactory> provider_factory;
+    ORT_RETURN_IF_ERROR(CreateIExecutionProviderFactoryForEpDevices(
+        env,
+        gsl::span<const OrtEpDevice* const>(devices_selected_.data(), devices_selected_.size()),
+        provider_factory));
+
+    const auto& logger = *logging::LoggingManager::DefaultLogger().ToExternal();
+    provider_list_.push_back(provider_factory->CreateProvider(effective_options, logger));
+  }
+
+  return Status::OK();
 }
 
 Status ModelPackageComponentContext::GetSelectedVariantConsumerMetadata(const std::string*& out_json_str) const {
@@ -286,21 +369,6 @@ Status ModelPackageComponentContext::GetSelectedVariantConsumerMetadata(const st
 
   out_json_str = &consumer_metadata_cache_;
   return Status::OK();
-}
-
-const std::vector<const OrtEpDevice*>& ModelPackageComponentContext::ExecutionDevices() const {
-  ORT_ENFORCE(options_ != nullptr, "ModelPackageComponentContext has no associated ModelPackageOptions.");
-  return options_->ExecutionDevices();
-}
-
-const std::vector<const OrtEpDevice*>& ModelPackageComponentContext::DevicesSelected() const {
-  ORT_ENFORCE(options_ != nullptr, "ModelPackageComponentContext has no associated ModelPackageOptions.");
-  return options_->DevicesSelected();
-}
-
-bool ModelPackageComponentContext::IsFromPolicy() const {
-  ORT_ENFORCE(options_ != nullptr, "ModelPackageComponentContext has no associated ModelPackageOptions.");
-  return options_->FromPolicy();
 }
 
 ModelPackageContext::ModelPackageContext(const std::filesystem::path& package_root) {
@@ -348,6 +416,33 @@ Status ModelPackageContext::GetComponentNames(gsl::span<const std::string>& out_
   out_names = gsl::span<const std::string>(component_names_cache_.data(),
                                            component_names_cache_.size());
   return Status::OK();
+}
+
+void ModelPackageContext::GetComponentNamePtrs(const char* const*& out_ptrs, size_t& out_count) const {
+  if (component_name_ptrs_cache_.empty() && !component_names_cache_.empty()) {
+    component_name_ptrs_cache_.reserve(component_names_cache_.size());
+    for (const auto& s : component_names_cache_) {
+      component_name_ptrs_cache_.push_back(s.c_str());
+    }
+  }
+  out_count = component_name_ptrs_cache_.size();
+  out_ptrs = component_name_ptrs_cache_.empty() ? nullptr : component_name_ptrs_cache_.data();
+}
+
+void ModelPackageContext::GetVariantNamePtrs(const std::string& component_name,
+                                             const char* const*& out_ptrs, size_t& out_count) const {
+  // Ensure variant name strings are cached first.
+  gsl::span<const std::string> variant_names;
+  (void)GetVariantNames(component_name, variant_names);
+
+  auto& ptrs = variant_name_ptrs_cache_[component_name];
+  ptrs.clear();
+  ptrs.reserve(variant_names.size());
+  for (const auto& s : variant_names) {
+    ptrs.push_back(s.c_str());
+  }
+  out_count = ptrs.size();
+  out_ptrs = ptrs.empty() ? nullptr : ptrs.data();
 }
 
 Status ModelPackageContext::GetVariantCount(const std::string& component_name, size_t& out_count) const {

--- a/onnxruntime/core/session/model_package/model_package_context.h
+++ b/onnxruntime/core/session/model_package/model_package_context.h
@@ -96,14 +96,6 @@ class ModelPackageComponentContext {
     return component_model_info_.variants;
   }
 
-  // Returns the session options snapshot used for this component.
-  // Only valid after construction with ModelPackageOptions (not ep_infos span).
-  const OrtSessionOptions* SessionOptions() const noexcept {
-    return session_options_ ? &*session_options_ : nullptr;
-  }
-
-  bool HasOptions() const noexcept { return session_options_.has_value(); }
-
   Status GetSelectedVariantFilePaths(gsl::span<const std::filesystem::path>& out_file_paths) const;
 
   Status GetSelectedVariantFolderPath(const std::filesystem::path*& out_folder_path) const;
@@ -149,9 +141,6 @@ class ModelPackageComponentContext {
   std::string component_model_name_;
   ComponentInfo component_model_info_{};
 
-  // Owned snapshot of the options state, copied during construction to avoid
-  // lifetime coupling with the external ModelPackageOptions handle.
-  std::optional<OrtSessionOptions> session_options_{};
   gsl::span<const VariantSelectionEpInfo> ep_infos_{};  // non-owning EP intent when options are not used
   std::vector<VariantSelectionEpInfo> owned_ep_infos_{};  // owned copy when constructed from ModelPackageOptions
   std::vector<std::unique_ptr<IExecutionProvider>> provider_list_{};

--- a/onnxruntime/core/session/model_package/model_package_context.h
+++ b/onnxruntime/core/session/model_package/model_package_context.h
@@ -84,7 +84,7 @@ class ModelPackageComponentContext {
  public:
   explicit ModelPackageComponentContext(const std::string& component_name,
                                         const ComponentInfo& component_model_info,
-                                        const ModelPackageOptions* options);
+                                        const ModelPackageOptions& options);
 
   explicit ModelPackageComponentContext(const std::string& component_name,
                                         const ComponentInfo& component_model_info,
@@ -96,9 +96,13 @@ class ModelPackageComponentContext {
     return component_model_info_.variants;
   }
 
-  const ModelPackageOptions* Options() const noexcept {
-    return options_;
+  // Returns the session options snapshot used for this component.
+  // Only valid after construction with ModelPackageOptions (not ep_infos span).
+  const OrtSessionOptions* SessionOptions() const noexcept {
+    return session_options_ ? &*session_options_ : nullptr;
   }
+
+  bool HasOptions() const noexcept { return session_options_.has_value(); }
 
   Status GetSelectedVariantFilePaths(gsl::span<const std::filesystem::path>& out_file_paths) const;
 
@@ -118,19 +122,38 @@ class ModelPackageComponentContext {
   // Returns the consumer_metadata JSON object (from variant.json) serialized to a string for the
   // selected variant. Returns an empty string if the variant did not declare consumer_metadata.
   // Pointer lifetime is owned by this context.
+
+  // C API helpers: return const char* pointer arrays with context-owned lifetime.
+  Status GetSelectedVariantFileSessionOptionPtrs(size_t file_idx,
+                                                  const char* const*& out_keys,
+                                                  const char* const*& out_values,
+                                                  size_t& out_count) const;
+  Status GetSelectedVariantFileProviderOptionPtrs(size_t file_idx,
+                                                   const char* const*& out_keys,
+                                                   const char* const*& out_values,
+                                                   size_t& out_count) const;
+
   Status GetSelectedVariantConsumerMetadata(const std::string*& out_json_str) const;
 
-  std::vector<std::unique_ptr<IExecutionProvider>>& MutableProviderList();
-  const std::vector<const OrtEpDevice*>& ExecutionDevices() const;
-  const std::vector<const OrtEpDevice*>& DevicesSelected() const;
-  bool IsFromPolicy() const;
+  std::vector<std::unique_ptr<IExecutionProvider>>& MutableProviderList() { return provider_list_; }
+  const std::vector<const OrtEpDevice*>& ExecutionDevices() const { return execution_devices_; }
+  const std::vector<const OrtEpDevice*>& DevicesSelected() const { return devices_selected_; }
+  bool IsFromPolicy() const { return from_policy_; }
+
+  // Rebuild the provider list for a new session creation call (providers are consumed/moved
+  // when registered, so they must be rebuilt for each session).
+  // Uses the provided session options for provider creation (should include merged provider options).
+  Status RebuildProviderListForSession(const Environment& env, const OrtSessionOptions& effective_options);
 
  private:
   std::string component_model_name_;
   ComponentInfo component_model_info_{};
 
-  const ModelPackageOptions* options_{};                // non-owning, immutable config source for EP intent
-  gsl::span<const VariantSelectionEpInfo> ep_infos_{};  // non-owning EP intent when options_ is not used
+  // Owned snapshot of the options state, copied during construction to avoid
+  // lifetime coupling with the external ModelPackageOptions handle.
+  std::optional<OrtSessionOptions> session_options_{};
+  gsl::span<const VariantSelectionEpInfo> ep_infos_{};  // non-owning EP intent when options are not used
+  std::vector<VariantSelectionEpInfo> owned_ep_infos_{};  // owned copy when constructed from ModelPackageOptions
   std::vector<std::unique_ptr<IExecutionProvider>> provider_list_{};
 
   // optional runtime state mirrors (if needed by callers)
@@ -148,6 +171,12 @@ class ModelPackageComponentContext {
   mutable std::unordered_map<size_t, std::vector<std::string>> file_id_to_provider_option_keys_cache_{};
   mutable std::unordered_map<size_t, std::vector<std::string>> file_id_to_provider_option_values_cache_{};
 
+  // C API pointer caches for session/provider options, owned by context for stable lifetime.
+  mutable std::unordered_map<size_t, std::vector<const char*>> file_session_option_key_ptrs_cache_{};
+  mutable std::unordered_map<size_t, std::vector<const char*>> file_session_option_value_ptrs_cache_{};
+  mutable std::unordered_map<size_t, std::vector<const char*>> file_provider_option_key_ptrs_cache_{};
+  mutable std::unordered_map<size_t, std::vector<const char*>> file_provider_option_value_ptrs_cache_{};
+
   Status ResolveVariantImpl(gsl::span<const VariantSelectionEpInfo> ep_infos);
   Status GetSelectedVariantInfo(const VariantInfo*& out_variant) const;
 };
@@ -158,6 +187,11 @@ class ModelPackageContext {
 
   size_t GetComponentCount() const noexcept;
   Status GetComponentNames(gsl::span<const std::string>& out_names) const;
+
+  // C API helpers: return const char* pointer arrays with context-owned lifetime.
+  void GetComponentNamePtrs(const char* const*& out_ptrs, size_t& out_count) const;
+  void GetVariantNamePtrs(const std::string& component_name,
+                          const char* const*& out_ptrs, size_t& out_count) const;
 
   Status GetVariantCount(const std::string& component_name, size_t& out_count) const;
   Status GetVariantNames(const std::string& component_name,
@@ -190,6 +224,10 @@ class ModelPackageContext {
   std::vector<std::string> component_names_cache_{};
   mutable std::unordered_map<std::string, std::vector<std::string>> component_to_variant_names_cache_{};
   mutable std::unordered_map<std::string, std::vector<std::string>> variant_to_file_identifiers_cache_{};
+
+  // C API pointer caches: owned by the context so their lifetime matches the documented contract.
+  mutable std::vector<const char*> component_name_ptrs_cache_{};
+  mutable std::unordered_map<std::string, std::vector<const char*>> variant_name_ptrs_cache_{};
 };
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/session/model_package/model_package_descriptor_parser.cc
+++ b/onnxruntime/core/session/model_package/model_package_descriptor_parser.cc
@@ -117,7 +117,12 @@ void from_json(const json& j, EpCompatibilitySchema& c) {
     throw std::invalid_argument(MakeString("\"", kEpKey, "\" must be a non-empty string."));
   }
 
-  if (j.contains(kDeviceKey) && j[kDeviceKey].is_string()) c.device = j[kDeviceKey].get<std::string>();
+  if (j.contains(kDeviceKey) && !j[kDeviceKey].is_null()) {
+    if (!j[kDeviceKey].is_string()) {
+      throw std::invalid_argument(MakeString("\"", kDeviceKey, "\" must be a string when present."));
+    }
+    c.device = j[kDeviceKey].get<std::string>();
+  }
   c.compatibility_string = ParseCompatibilityString(j, kCompatibilityStringKey);
 }
 
@@ -163,6 +168,16 @@ void from_json(const json& j, ComponentSchema& m) {
   }
 
   m.variants = j.at(kVariantsKey).get<std::unordered_map<std::string, VariantSchema>>();
+}
+
+// Parse variants while preserving JSON declaration order for deterministic tie-breaking.
+std::vector<std::pair<std::string, VariantSchema>> ParseVariantsInOrder(const json& variants_obj) {
+  std::vector<std::pair<std::string, VariantSchema>> result;
+  result.reserve(variants_obj.size());
+  for (auto it = variants_obj.begin(); it != variants_obj.end(); ++it) {
+    result.emplace_back(it.key(), it.value().get<VariantSchema>());
+  }
+  return result;
 }
 
 Status FindSingleOnnxFile(const std::filesystem::path& search_dir,
@@ -238,6 +253,59 @@ std::string BuildModelInfoLogString(const VariantInfo& variant) {
   return oss.str();
 }
 
+// Validate that a path segment (component name, variant name, filename) does not contain
+// path traversal sequences or represent an absolute path.
+Status ValidatePathSegment(const std::string& segment, const char* segment_type) {
+  if (segment.empty()) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                           segment_type, " must not be empty.");
+  }
+
+  // Reject absolute paths
+  if (std::filesystem::path(segment).is_absolute()) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                           segment_type, " must not be an absolute path: '", segment, "'.");
+  }
+
+  // Reject .. components
+  for (const auto& part : std::filesystem::path(segment)) {
+    if (part == "..") {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                             segment_type, " must not contain '..' path components: '", segment, "'.");
+    }
+  }
+
+  return Status::OK();
+}
+
+// Validate that a resolved path is confined to the expected root directory.
+Status ValidatePathConfinement(const std::filesystem::path& resolved_path,
+                               const std::filesystem::path& root,
+                               const char* description) {
+  // Use lexical normalization to collapse ".." without resolving symlinks.
+  // This catches path-traversal attacks while allowing symlinked files inside the tree.
+  auto normal_root = root.lexically_normal();
+  auto normal_path = resolved_path.lexically_normal();
+
+  auto root_str = normal_root.string();
+  auto path_str = normal_path.string();
+
+  // Ensure the resolved path starts with the root path.
+  if (path_str.size() < root_str.size() ||
+      path_str.compare(0, root_str.size(), root_str) != 0 ||
+      (path_str.size() > root_str.size() && path_str[root_str.size()] != std::filesystem::path::preferred_separator
+#ifndef _WIN32
+       && path_str[root_str.size()] != '/'
+#endif
+       )) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                           description, " resolves outside the package root. Path: '",
+                           resolved_path.string(), "', Root: '", root.string(), "'.");
+  }
+
+  return Status::OK();
+}
+
 void LogParsedVariants(const logging::Logger& logger,
                        const std::vector<VariantInfo>& variants) {
   for (const auto& v : variants) {
@@ -309,9 +377,9 @@ Status ModelPackageDescriptorParser::ParseVariantsFromComponent(
                            component_name);
   }
 
-  std::unordered_map<std::string, VariantSchema> variants;
+  std::vector<std::pair<std::string, VariantSchema>> variants;
   ORT_TRY {
-    variants = variants_obj->get<std::unordered_map<std::string, VariantSchema>>();
+    variants = ParseVariantsInOrder(*variants_obj);
   }
   ORT_CATCH(const std::exception& ex) {
     return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
@@ -320,7 +388,9 @@ Status ModelPackageDescriptorParser::ParseVariantsFromComponent(
   }
 
   for (const auto& [variant_name, variant] : variants) {
+    ORT_RETURN_IF_ERROR(ValidatePathSegment(variant_name, "Variant name"));
     const std::filesystem::path variant_root = component_model_root / variant_name;
+    ORT_RETURN_IF_ERROR(ValidatePathConfinement(variant_root, component_model_root, "Variant directory"));
     const std::filesystem::path variant_descriptor_path = variant_root / kVariantDescriptorFileName;
 
     if (!std::filesystem::exists(variant_descriptor_path)) {
@@ -365,6 +435,8 @@ Status ModelPackageDescriptorParser::ParseVariantsFromComponent(
 
     for (const auto& file_schema : variant_metadata_schema.files) {
       const std::string identifier = file_schema.filename;  // deterministic identifier in v2 schema
+      ORT_RETURN_IF_ERROR(ValidatePathSegment(identifier, "File name"));
+
       if (!identifiers_seen.insert(identifier).second) {
         return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
                                "Duplicate file identifier '", identifier,
@@ -372,6 +444,7 @@ Status ModelPackageDescriptorParser::ParseVariantsFromComponent(
       }
 
       const std::filesystem::path candidate_path = variant_root / file_schema.filename;
+      ORT_RETURN_IF_ERROR(ValidatePathConfinement(candidate_path, variant_root, "Variant file path"));
       if (!std::filesystem::exists(candidate_path)) {
         return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
                                "Variant '", variant_name, "', file '", file_schema.filename,
@@ -521,7 +594,9 @@ Status ModelPackageDescriptorParser::ParseVariantsFromPackageRoot(
   }
 
   for (const auto& component_name : component_model_names) {
+    ORT_RETURN_IF_ERROR(ValidatePathSegment(component_name, "Component name"));
     const auto component_model_root = package_root / "models" / component_name;
+    ORT_RETURN_IF_ERROR(ValidatePathConfinement(component_model_root, package_root, "Component directory"));
 
     if (has_components &&
         (!std::filesystem::exists(component_model_root) || !std::filesystem::is_directory(component_model_root))) {

--- a/onnxruntime/core/session/model_package/model_package_options.cc
+++ b/onnxruntime/core/session/model_package/model_package_options.cc
@@ -34,6 +34,7 @@ void ModelPackageOptions::ResolveEpSelection(const Environment& env,
     for (auto& factory : session_options.provider_factories) {
       provider_list_.push_back(factory->CreateProvider(session_options, logger));
     }
+    ORT_THROW_IF_ERROR(GetVariantSelectionEpInfo(provider_list_, ep_infos_));
   } else if (from_policy_) {
     OrtKeyValuePairs model_metadata;
     ProviderPolicyContext provider_policy_context;
@@ -41,9 +42,12 @@ void ModelPackageOptions::ResolveEpSelection(const Environment& env,
     ORT_THROW_IF_ERROR(provider_policy_context.SelectEpsForModelPackage(
         env, mutable_session_options, model_metadata,
         execution_devices_, devices_selected_, provider_list_));
+    ORT_THROW_IF_ERROR(GetVariantSelectionEpInfo(provider_list_, ep_infos_));
+  } else {
+    // No explicit providers and no policy: default to CPU for variant selection.
+    ep_infos_.push_back(VariantSelectionEpInfo{});
+    ep_infos_.back().ep_name = kCpuExecutionProvider;
   }
-
-  ORT_THROW_IF_ERROR(GetVariantSelectionEpInfo(provider_list_, ep_infos_));
 
   ORT_THROW_IF_ERROR(PrintAvailableAndSelectedEpInfos(env, ep_infos_));
 }

--- a/onnxruntime/core/session/model_package/model_package_options.cc
+++ b/onnxruntime/core/session/model_package/model_package_options.cc
@@ -15,14 +15,14 @@
 namespace onnxruntime {
 
 ModelPackageOptions::ModelPackageOptions(const Environment& env,
-                                         const OrtSessionOptions& session_options)
-    : session_options_(session_options) {
-  ResolveEpSelection(env);
+                                         const OrtSessionOptions& session_options) {
+  ResolveEpSelection(env, session_options);
 }
 
-void ModelPackageOptions::ResolveEpSelection(const Environment& env) {
-  const bool has_provider_factories = !session_options_.provider_factories.empty();
-  from_policy_ = !has_provider_factories && session_options_.value.ep_selection_policy.enable;
+void ModelPackageOptions::ResolveEpSelection(const Environment& env,
+                                              const OrtSessionOptions& session_options) {
+  const bool has_provider_factories = !session_options.provider_factories.empty();
+  from_policy_ = !has_provider_factories && session_options.value.ep_selection_policy.enable;
 
   provider_list_.clear();
   execution_devices_.clear();
@@ -31,13 +31,13 @@ void ModelPackageOptions::ResolveEpSelection(const Environment& env) {
 
   if (has_provider_factories) {
     const auto& logger = *logging::LoggingManager::DefaultLogger().ToExternal();
-    for (auto& factory : session_options_.provider_factories) {
-      provider_list_.push_back(factory->CreateProvider(session_options_, logger));
+    for (auto& factory : session_options.provider_factories) {
+      provider_list_.push_back(factory->CreateProvider(session_options, logger));
     }
   } else if (from_policy_) {
     OrtKeyValuePairs model_metadata;
     ProviderPolicyContext provider_policy_context;
-    OrtSessionOptions mutable_session_options = session_options_;
+    OrtSessionOptions mutable_session_options = session_options;
     ORT_THROW_IF_ERROR(provider_policy_context.SelectEpsForModelPackage(
         env, mutable_session_options, model_metadata,
         execution_devices_, devices_selected_, provider_list_));
@@ -45,44 +45,31 @@ void ModelPackageOptions::ResolveEpSelection(const Environment& env) {
 
   ORT_THROW_IF_ERROR(GetVariantSelectionEpInfo(provider_list_, ep_infos_));
 
-  // If no EPs were captured (no explicit providers and no policy), default to CPU.
-  // This allows model packages with CPUExecutionProvider variants to be selected.
-  if (ep_infos_.empty()) {
-    ep_infos_.push_back(VariantSelectionEpInfo{});
-    ep_infos_.back().ep_name = kCpuExecutionProvider;
-  }
-
   ORT_THROW_IF_ERROR(PrintAvailableAndSelectedEpInfos(env, ep_infos_));
 }
 
-// Rebuild the provider list based on the selected EP devices.
-// The model package context instance (contains the model package options) can be used
-// with multiple session creation calls, and the provider list is consumed (moved) when
-// registering providers to each session, so we need to rebuild it for each session creation.
-Status ModelPackageOptions::RebuildProviderListForSession(const Environment& env) const {
+Status ModelPackageOptions::RebuildProviderListForSession(const Environment& env,
+                                                          const OrtSessionOptions& effective_options) const {
   provider_list_.clear();
 
-  const bool has_provider_factories = !session_options_.provider_factories.empty();
-
-  if (has_provider_factories) {
-    const auto& logger = *logging::LoggingManager::DefaultLogger().ToExternal();
-    for (auto& factory : session_options_.provider_factories) {
-      provider_list_.push_back(factory->CreateProvider(session_options_, logger));
-    }
+  if (ep_infos_.empty()) {
     return Status::OK();
   }
 
-  // Policy path: reconstruct providers from the already-selected EP devices.
-  if (from_policy_ && !devices_selected_.empty()) {
-    std::unique_ptr<IExecutionProviderFactory> provider_factory;
-    ORT_RETURN_IF_ERROR(CreateIExecutionProviderFactoryForEpDevices(
-        env,
-        gsl::span<const OrtEpDevice* const>(devices_selected_.data(), devices_selected_.size()),
-        provider_factory));
-
-    const auto& logger = *logging::LoggingManager::DefaultLogger().ToExternal();
-    provider_list_.push_back(provider_factory->CreateProvider(session_options_, logger));
+  const auto& ep_info = ep_infos_[0];
+  if (ep_info.ep_name == kCpuExecutionProvider || ep_info.ep_devices.empty()) {
+    // CPU is built-in; no provider to register.
+    return Status::OK();
   }
+
+  std::unique_ptr<IExecutionProviderFactory> provider_factory;
+  ORT_RETURN_IF_ERROR(CreateIExecutionProviderFactoryForEpDevices(
+      env,
+      gsl::span<const OrtEpDevice* const>(ep_info.ep_devices.data(), ep_info.ep_devices.size()),
+      provider_factory));
+
+  const auto& logger = *logging::LoggingManager::DefaultLogger().ToExternal();
+  provider_list_.push_back(provider_factory->CreateProvider(effective_options, logger));
 
   return Status::OK();
 }

--- a/onnxruntime/core/session/model_package/model_package_options.h
+++ b/onnxruntime/core/session/model_package/model_package_options.h
@@ -19,9 +19,8 @@ class ModelPackageOptions {
  public:
   ModelPackageOptions(const Environment& env, const OrtSessionOptions& session_options);
 
-  const OrtSessionOptions& SessionOptions() const noexcept { return session_options_; }
-
-  Status RebuildProviderListForSession(const Environment& env) const;
+  Status RebuildProviderListForSession(const Environment& env,
+                                        const OrtSessionOptions& effective_options) const;
 
   // Resolved state accessors
   std::vector<std::unique_ptr<IExecutionProvider>>& MutableProviderList() const noexcept { return provider_list_; }
@@ -32,9 +31,7 @@ class ModelPackageOptions {
   bool FromPolicy() const noexcept { return from_policy_; }
 
  private:
-  void ResolveEpSelection(const Environment& env);
-
-  OrtSessionOptions session_options_;
+  void ResolveEpSelection(const Environment& env, const OrtSessionOptions& session_options);
 
   // might needs to be rebuilt per session creation, as it becomes empty
   // after consumed by RegisterExecutionProvider(std::move(...)).

--- a/onnxruntime/core/session/model_package/model_package_variant_selector.cc
+++ b/onnxruntime/core/session/model_package/model_package_variant_selector.cc
@@ -125,9 +125,12 @@ VariantMatchResult MatchVariantForEp(VariantInfo& variant, const VariantSelectio
     bool device_ok = !ec.device.has_value() || ec.device->empty();
     std::vector<const OrtHardwareDevice*> constraint_devices = ep_info.hardware_devices;
 
-    if (ep_info.hardware_devices.empty()) {
-      device_ok = true;
-    } else if (!device_ok) {
+    if (!device_ok) {
+      // If the EP exposes no hardware devices but the variant declares a device constraint,
+      // we cannot verify the constraint, so treat it as non-matching.
+      if (ep_info.hardware_devices.empty()) {
+        continue;
+      }
       if (const auto* matched_hd = FindMatchingHardwareDevice(*ec.device, ep_info.hardware_devices)) {
         device_ok = true;
         constraint_devices = {matched_hd};
@@ -246,6 +249,34 @@ Status VariantSelector::SelectVariant(const ModelPackageComponentContext& contex
     if (best_index.has_value()) {
       selected_variant = std::move(variants[*best_index]);
       selected_variant->selected_ep_compatibility_index = best_ec_index;
+      return Status::OK();
+    }
+
+    // CPU fallback: if the primary EP didn't match any variant, try the remaining EPs in order.
+    // This handles common fallback chains like [CUDA, CPU] where no CUDA variant exists.
+    for (size_t ep_idx = 1; ep_idx < ep_infos.size(); ++ep_idx) {
+      best_score = std::numeric_limits<int>::min();
+      best_index.reset();
+      best_ec_index.reset();
+
+      for (size_t i = 0, end = variants.size(); i < end; ++i) {
+        VariantMatchResult m = MatchVariantForEp(variants[i], ep_infos[ep_idx]);
+        if (!m.matched) continue;
+        if (!best_index.has_value() || m.score > best_score) {
+          best_score = m.score;
+          best_index = i;
+          best_ec_index = m.selected_ep_compatibility_index;
+        }
+      }
+
+      if (best_index.has_value()) {
+        LOGS_DEFAULT(INFO) << "Primary EP '" << ep_infos[0].ep_name
+                           << "' did not match any variant; fell back to EP '"
+                           << ep_infos[ep_idx].ep_name << "'.";
+        selected_variant = std::move(variants[*best_index]);
+        selected_variant->selected_ep_compatibility_index = best_ec_index;
+        return Status::OK();
+      }
     }
   }
 

--- a/onnxruntime/core/session/model_package_api.cc
+++ b/onnxruntime/core/session/model_package_api.cc
@@ -15,22 +15,6 @@
 #include "core/session/model_package/model_package_options.h"
 #include "core/session/utils.h"
 
-namespace {
-void BuildCStringArray(gsl::span<const std::string> in,
-                       std::vector<const char*>& cache,
-                       const char* const** out,
-                       size_t* out_count) {
-  cache.clear();
-  cache.reserve(in.size());
-  for (const auto& s : in) {
-    cache.push_back(s.c_str());
-  }
-
-  *out_count = in.size();
-  *out = cache.empty() ? nullptr : cache.data();
-}
-
-}  // namespace
 #endif
 
 using namespace onnxruntime;
@@ -137,8 +121,11 @@ ORT_API_STATUS_IMPL(OrtModelPackageAPI::ModelPackage_GetComponentNames,
   ORT_API_RETURN_IF_STATUS_NOT_OK(
       reinterpret_cast<const onnxruntime::ModelPackageContext*>(ctx)->GetComponentNames(names));
 
-  static thread_local std::vector<const char*> name_ptrs;
-  BuildCStringArray(names, name_ptrs, out_names, out_count);
+  const char* const* ptrs = nullptr;
+  size_t count = 0;
+  reinterpret_cast<const onnxruntime::ModelPackageContext*>(ctx)->GetComponentNamePtrs(ptrs, count);
+  *out_names = ptrs;
+  *out_count = count;
   return nullptr;
 #else
   ORT_UNUSED_PARAMETER(ctx);
@@ -187,8 +174,11 @@ ORT_API_STATUS_IMPL(OrtModelPackageAPI::ModelPackage_GetVariantNames,
   ORT_API_RETURN_IF_STATUS_NOT_OK(
       reinterpret_cast<const onnxruntime::ModelPackageContext*>(ctx)->GetVariantNames(component_name, variant_names));
 
-  static thread_local std::vector<const char*> variant_name_ptrs;
-  BuildCStringArray(variant_names, variant_name_ptrs, out_variant_names, out_count);
+  const char* const* ptrs = nullptr;
+  size_t count = 0;
+  reinterpret_cast<const onnxruntime::ModelPackageContext*>(ctx)->GetVariantNamePtrs(component_name, ptrs, count);
+  *out_variant_names = ptrs;
+  *out_count = count;
   return nullptr;
 #else
   ORT_UNUSED_PARAMETER(ctx);
@@ -229,7 +219,7 @@ ORT_API_STATUS_IMPL(OrtModelPackageAPI::SelectComponent,
   }
 
   auto cix = std::make_unique<onnxruntime::ModelPackageComponentContext>(
-      component_name, *component_info, cxx_options);
+      component_name, *component_info, *cxx_options);
 
   ORT_API_RETURN_IF_STATUS_NOT_OK(cix->ResolveVariant());
 
@@ -353,28 +343,17 @@ ORT_API_STATUS_IMPL(OrtModelPackageAPI::ModelPackageComponent_GetSelectedVariant
           file_idx, keys, values));
 
   ORT_API_RETURN_IF(keys.size() != values.size(), ORT_FAIL, "Session options keys/values size mismatch.");
-  *num_entries = keys.size();
 
-  if (*num_entries == 0) {
-    *option_keys = nullptr;
-    *option_values = nullptr;
-  } else {
-    static thread_local std::vector<const char*> key_ptrs;
-    static thread_local std::vector<const char*> value_ptrs;
+  const char* const* key_ptrs_out = nullptr;
+  const char* const* value_ptrs_out = nullptr;
+  size_t count = 0;
+  ORT_API_RETURN_IF_STATUS_NOT_OK(
+      reinterpret_cast<const onnxruntime::ModelPackageComponentContext*>(ctx)->GetSelectedVariantFileSessionOptionPtrs(
+          file_idx, key_ptrs_out, value_ptrs_out, count));
 
-    key_ptrs.clear();
-    value_ptrs.clear();
-    key_ptrs.reserve(keys.size());
-    value_ptrs.reserve(values.size());
-
-    for (size_t i = 0; i < keys.size(); ++i) {
-      key_ptrs.push_back(keys[i].c_str());
-      value_ptrs.push_back(values[i].c_str());
-    }
-
-    *option_keys = key_ptrs.data();
-    *option_values = value_ptrs.data();
-  }
+  *option_keys = key_ptrs_out;
+  *option_values = value_ptrs_out;
+  *num_entries = count;
 
   return nullptr;
 #else
@@ -407,28 +386,17 @@ ORT_API_STATUS_IMPL(OrtModelPackageAPI::ModelPackageComponent_GetSelectedVariant
           file_idx, keys, values));
 
   ORT_API_RETURN_IF(keys.size() != values.size(), ORT_FAIL, "Provider options keys/values size mismatch.");
-  *num_entries = keys.size();
 
-  if (*num_entries == 0) {
-    *option_keys = nullptr;
-    *option_values = nullptr;
-  } else {
-    static thread_local std::vector<const char*> key_ptrs;
-    static thread_local std::vector<const char*> value_ptrs;
+  const char* const* key_ptrs_out = nullptr;
+  const char* const* value_ptrs_out = nullptr;
+  size_t count = 0;
+  ORT_API_RETURN_IF_STATUS_NOT_OK(
+      reinterpret_cast<const onnxruntime::ModelPackageComponentContext*>(ctx)->GetSelectedVariantFileProviderOptionPtrs(
+          file_idx, key_ptrs_out, value_ptrs_out, count));
 
-    key_ptrs.clear();
-    value_ptrs.clear();
-    key_ptrs.reserve(keys.size());
-    value_ptrs.reserve(values.size());
-
-    for (size_t i = 0; i < keys.size(); ++i) {
-      key_ptrs.push_back(keys[i].c_str());
-      value_ptrs.push_back(values[i].c_str());
-    }
-
-    *option_keys = key_ptrs.data();
-    *option_values = value_ptrs.data();
-  }
+  *option_keys = key_ptrs_out;
+  *option_values = value_ptrs_out;
+  *num_entries = count;
 
   return nullptr;
 #else
@@ -455,8 +423,7 @@ ORT_API_STATUS_IMPL(OrtModelPackageAPI::CreateSession,
   }
 
   auto& mp_ctx = *reinterpret_cast<onnxruntime::ModelPackageComponentContext*>(ctx);
-  const auto* mp_ctx_options = mp_ctx.Options();
-  if (mp_ctx_options == nullptr) {
+  if (!mp_ctx.HasOptions()) {
     return OrtApis::CreateStatus(ORT_FAIL, "ModelPackageContext has no associated options.");
   }
 
@@ -476,7 +443,7 @@ ORT_API_STATUS_IMPL(OrtModelPackageAPI::CreateSession,
 
   if (session_options == nullptr) {
     // Important: use copy-constructor, not assignment (operator= is not implemented).
-    effective_options_storage.emplace(mp_ctx_options->SessionOptions());
+    effective_options_storage.emplace(*mp_ctx.SessionOptions());
 
     // Merge variant/file session options into config options.
     gsl::span<const std::string> session_option_keys;

--- a/onnxruntime/core/session/model_package_api.cc
+++ b/onnxruntime/core/session/model_package_api.cc
@@ -423,9 +423,6 @@ ORT_API_STATUS_IMPL(OrtModelPackageAPI::CreateSession,
   }
 
   auto& mp_ctx = *reinterpret_cast<onnxruntime::ModelPackageComponentContext*>(ctx);
-  if (!mp_ctx.HasOptions()) {
-    return OrtApis::CreateStatus(ORT_FAIL, "ModelPackageContext has no associated options.");
-  }
 
   // 1) Get the selected variant model file path.
   //    Note: This API only supports single-file variants. For multi-file variants, the caller
@@ -435,15 +432,17 @@ ORT_API_STATUS_IMPL(OrtModelPackageAPI::CreateSession,
   ORT_API_RETURN_IF_STATUS_NOT_OK(mp_ctx.GetSelectedVariantFilePath(selected_file_path));
 
   // 2) Pick the OrtSessionOptions per precedence rules:
-  //    - session_options == nullptr (default path): use the options captured on the context,
+  //    - session_options == nullptr (default path): start from a clean OrtSessionOptions,
   //      and merge variant-specific session + provider options from the package metadata.
   //    - session_options != nullptr (advanced path): use caller-supplied as-is, no metadata merge.
   const OrtSessionOptions* effective_options = nullptr;
   std::optional<OrtSessionOptions> effective_options_storage;
 
   if (session_options == nullptr) {
-    // Important: use copy-constructor, not assignment (operator= is not implemented).
-    effective_options_storage.emplace(*mp_ctx.SessionOptions());
+    // Start from a clean session options. The only EP-related state comes from
+    // the variant metadata (session options and provider options), not from the
+    // original session options used to create the package options.
+    effective_options_storage.emplace();
 
     // Merge variant/file session options into config options.
     gsl::span<const std::string> session_option_keys;
@@ -455,9 +454,6 @@ ORT_API_STATUS_IMPL(OrtModelPackageAPI::CreateSession,
                       ORT_FAIL, "Session option keys/values size mismatch.");
 
     for (size_t i = 0; i < session_option_keys.size(); ++i) {
-      // Dispatch through OrtApis::AddSessionOption so well-known typed keys (intra_op_num_threads,
-      // graph_optimization_level, ...) hit their dedicated setters; everything else falls through
-      // to AddSessionConfigEntry. See onnxruntime_c_api.h::AddSessionOption for the full table.
       OrtStatus* st = OrtApis::AddSessionOption(&*effective_options_storage,
                                                 session_option_keys[i].c_str(),
                                                 session_option_values[i].c_str());

--- a/onnxruntime/core/session/utils.cc
+++ b/onnxruntime/core/session/utils.cc
@@ -992,8 +992,7 @@ OrtStatus* CreateSessionForModelPackage(_In_ const OrtSessionOptions* options,
                                                               /*model_data_length*/ 0,
                                                               sess));
 
-  const auto* mp_options = model_package_context.Options();
-  if (mp_options == nullptr) {
+  if (!model_package_context.HasOptions()) {
     return OrtApis::CreateStatus(ORT_FAIL, "ModelPackageContext has no associated ModelPackageOptions.");
   }
 
@@ -1008,7 +1007,7 @@ OrtStatus* CreateSessionForModelPackage(_In_ const OrtSessionOptions* options,
                   });
 
   if (!has_all_live_providers) {
-    ORT_API_RETURN_IF_STATUS_NOT_OK(mp_options->RebuildProviderListForSession(env));
+    ORT_API_RETURN_IF_STATUS_NOT_OK(model_package_context.RebuildProviderListForSession(env, *options));
   }
 
   for (auto& provider : provider_list) {

--- a/onnxruntime/core/session/utils.cc
+++ b/onnxruntime/core/session/utils.cc
@@ -924,19 +924,9 @@ Status GetVariantSelectionEpInfo(std::vector<std::unique_ptr<IExecutionProvider>
     return Status::OK();
   }
 
-  // Pick the first non-CPU provider if available; otherwise fall back to the first provider.
-  size_t selected_idx = 0;
-  for (size_t i = 0; i < provider_list.size(); ++i) {
-    const auto& provider = provider_list[i];
-    if (provider && provider->Type() != onnxruntime::kCpuExecutionProvider) {
-      selected_idx = i;
-      break;
-    }
-  }
-
-  auto& provider = provider_list[selected_idx];
-
-  if (provider && provider->Type() == onnxruntime::kCpuExecutionProvider) {
+  // Use the first provider in the list for variant selection.
+  auto& provider = provider_list[0];
+  if (!provider) {
     return Status::OK();
   }
 
@@ -946,6 +936,11 @@ Status GetVariantSelectionEpInfo(std::vector<std::unique_ptr<IExecutionProvider>
   // Add ep name to ep_info
   ep_info.ep_name = provider->Type();
   ORT_ENFORCE(!ep_info.ep_name.empty(), "EP name should have been set at this point.");
+
+  // CPU is built-in and needs no device/factory metadata for variant selection.
+  if (ep_info.ep_name == onnxruntime::kCpuExecutionProvider) {
+    return Status::OK();
+  }
 
   // Add ep devices to ep_info
   auto& ep_devices = provider->GetEpDevices();
@@ -991,10 +986,6 @@ OrtStatus* CreateSessionForModelPackage(_In_ const OrtSessionOptions* options,
                                                               /*model_data*/ nullptr,
                                                               /*model_data_length*/ 0,
                                                               sess));
-
-  if (!model_package_context.HasOptions()) {
-    return OrtApis::CreateStatus(ORT_FAIL, "ModelPackageContext has no associated ModelPackageOptions.");
-  }
 
   auto& provider_list = model_package_context.MutableProviderList();
 


### PR DESCRIPTION
## Summary

This PR addresses security vulnerabilities, correctness bugs, and simplifies the session creation flow for the model package feature.

### Security & correctness fixes
- **Path traversal validation**: Added `ValidatePathSegment` and `ValidatePathConfinement` to prevent directory traversal attacks via malicious package descriptors. Uses `lexically_normal()` (not `weakly_canonical()`) to support symlinked packages.
- **Use-after-free fix**: `ModelPackageComponentContext` now owns all state (EP infos, provider list, devices) copied from `ModelPackageOptions`, eliminating lifetime coupling.
- **Provider options propagation**: Variant provider options are now properly merged into session options and reach EP creation.
- **String lifetime**: Fixed dangling pointer risk in C-string array construction.
- **Variant ordering**: Variants are now evaluated in descriptor order for deterministic selection.
- **Device validation**: Added bounds checking for device index in EP info resolution.
- **CPU fallback**: Added fallback loop in variant selector to try CPU variant when the requested EP has no match.

### Session creation simplification
- **Removed stored `OrtSessionOptions`** from both `ModelPackageOptions` and `ModelPackageComponentContext`. The session options passed to create package options are now only used to extract EP intent (factories, devices, policy) for variant selection.
- **Clean-slate session creation**: `CreateSession` default path starts from a fresh `OrtSessionOptions` populated only with the selected variant's session options and provider options.
- **Simplified `GetVariantSelectionEpInfo`**: Uses the first EP in the provider list directly instead of skipping CPU. Empty provider list defaults to implicit CPU.
- **Unified `RebuildProviderListForSession`**: Both explicit-factory and policy paths now use `CreateIExecutionProviderFactoryForEpDevices` with captured `ep_devices`, eliminating the two-path rebuild logic.
- **Removed `HasOptions()`/`SessionOptions()`** from the component context API.

### Files changed
- `model_package_descriptor_parser.cc`: Path validation functions
- `model_package_context.h/.cc`: Owned state, simplified rebuild
- `model_package_options.h/.cc`: Removed stored session options, simplified EP resolution
- `model_package_api.cc`: Clean-slate session creation
- `model_package_variant_selector.cc`: CPU fallback loop
- `utils.cc`: Simplified EP info extraction

### Testing
- Verified with CPU-only and CUDA model packages (single and multi-variant)
- E2E notebook tests pass for both ORT and GenAI integration