### PR TITLE
Fix Erf NaN preservation on x86_64 FMA3 path

### DIFF
--- a/onnxruntime/core/mlas/lib/amd64/ErfKernelFma3.asm
+++ b/onnxruntime/core/mlas/lib/amd64/ErfKernelFma3.asm
@@ -159,10 +159,10 @@ LComputeErf4x8Loop:
         vmovups YMMWORD PTR ErfKernelFrame.ErfBuffer0[rsp+96],ymm7
 
         vbroadcastss ymm8,ErfConstants.ErfSMALL_P0[rax]
-        vminps  ymm0,ymm0,ymm14                 ; force abs value in range
-        vminps  ymm1,ymm1,ymm14
-        vminps  ymm2,ymm2,ymm14
-        vminps  ymm3,ymm3,ymm14
+        vminps  ymm0,ymm14,ymm0                 ; clamp abs value in range; input in src2 preserves NaN (issue #28462)
+        vminps  ymm1,ymm14,ymm1
+        vminps  ymm2,ymm14,ymm2
+        vminps  ymm3,ymm14,ymm3
         vmovaps ymm9,ymm8
         vmovaps ymm10,ymm8
         vmovaps ymm11,ymm8
@@ -427,7 +427,7 @@ LErfProcess1x8:
         vmovups YMMWORD PTR ErfKernelFrame.ErfBuffer0[rsp],ymm4
 
         vbroadcastss ymm8,ErfConstants.ErfSMALL_P0[rax]
-        vminps  ymm0,ymm0,ymm14                 ; force abs value in range
+        vminps  ymm0,ymm14,ymm0                 ; clamp abs value in range; input in src2 preserves NaN (issue #28462)
 
         vbroadcastss ymm15,ErfConstants.ErfSMALL_P1[rax]
         vmulps  ymm4,ymm0,ymm0                  ; vs0 (square)

--- a/onnxruntime/core/mlas/lib/x86_64/ErfKernelFma3.S
+++ b/onnxruntime/core/mlas/lib/x86_64/ErfKernelFma3.S
@@ -121,10 +121,10 @@ C_UNDERSCORE(MlasErfKernelFma3):
         vmovups YMMWORD PTR ErfBuffer0[rsp+96],ymm7
 
         vbroadcastss ymm8,ErfSMALL_P0[rax]
-        vminps  ymm0,ymm0,ymm14                 # force abs value in range
-        vminps  ymm1,ymm1,ymm14
-        vminps  ymm2,ymm2,ymm14
-        vminps  ymm3,ymm3,ymm14
+        vminps  ymm0,ymm14,ymm0                 # clamp abs value in range; input in src2 preserves NaN (issue #28462)
+        vminps  ymm1,ymm14,ymm1
+        vminps  ymm2,ymm14,ymm2
+        vminps  ymm3,ymm14,ymm3
         vmovaps ymm9,ymm8
         vmovaps ymm10,ymm8
         vmovaps ymm11,ymm8
@@ -390,7 +390,7 @@ C_UNDERSCORE(MlasErfKernelFma3):
         vmovups YMMWORD PTR ErfBuffer0[rsp],ymm4
 
         vbroadcastss ymm8,ErfSMALL_P0[rax]
-        vminps  ymm0,ymm0,ymm14                 # force abs value in range
+        vminps  ymm0,ymm14,ymm0                 # clamp abs value in range; input in src2 preserves NaN (issue #28462)
 
         vbroadcastss ymm15,ErfSMALL_P1[rax]
         vmulps  ymm4,ymm0,ymm0                  # vs0 (square)

--- a/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
@@ -4232,6 +4232,29 @@ TEST(MathOpTest, ErfMoreData) {
   test.Run();
 }
 
+TEST(MathOpTest, ErfNaN) {
+  // Regression for #28462: NaN inputs were clamped to 1.0 on the FMA3 path.
+  OpTester test("Erf", 9);
+  constexpr float qnan = std::numeric_limits<float>::quiet_NaN();
+  constexpr int64_t size = 36;
+  std::vector<int64_t> dims{size};
+  std::vector<float> inputs(size);
+  std::vector<float> outputs(size);
+  for (int64_t i = 0; i < size; ++i) {
+    if (i % 5 == 0) {
+      inputs[i] = qnan;
+      outputs[i] = qnan;
+    } else {
+      const float v = 0.1f * static_cast<float>(i - size / 2);
+      inputs[i] = v;
+      outputs[i] = std::erf(v);
+    }
+  }
+  test.AddInput<float>("A", dims, inputs);
+  test.AddOutput<float>("B", dims, outputs);
+  test.Run();
+}
+
 TEST(MathOpTest, ErfCheckMultiThreadDataChunking) {
   OpTester test("Erf", 9);
   static constexpr int64_t size = 100;


### PR DESCRIPTION
### Description
Swap the operand order of `vminps` in the FMA3 Erf kernel (both
`x86_64/ErfKernelFma3.S` GAS and `amd64/ErfKernelFma3.asm` MASM,
5 instructions each) so the input sits in src2. `VMINPS` returns
its src2 operand when either input is NaN, so this is what lets
NaN propagate through the kernel.

Adds `MathOpTest.ErfNaN` regression test (36 elements — covers
both the 4×8 main loop and the 1×8 tail).

### Motivation and Context
Fixes #28462. The FMA3 kernel had the input in src1, so a NaN
input became the clamping constant (3.925f) and the polynomial
then produced ~1.0. The C++ scalar / SSE2 / NEON / SVE paths
already preserve NaN — only the FMA3 asm needed fixing.