### PR TITLE
[Node.js] Follow HTTP 3xx redirects in onnxruntime-node install scripts

### DIFF
--- a/js/node/script/install-utils.js
+++ b/js/node/script/install-utils.js
@@ -15,16 +15,46 @@ const REDIRECT_STATUS_CODES = [301, 302, 303, 307, 308];
 
 async function downloadFile(url, dest) {
   return new Promise((resolve, reject) => {
+    let settled = false;
+    const cleanup = () => {
+      try {
+        fs.unlinkSync(dest);
+      } catch {
+        // ignore if the file was never created or already removed
+      }
+    };
+    const fail = (err) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      file.destroy();
+      cleanup();
+      reject(err);
+    };
+    const succeed = () => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      resolve();
+    };
+
     const file = fs.createWriteStream(dest);
+    // Attach the error handler immediately so that stream creation failures
+    // (e.g. ENOENT or permission errors) reject the promise instead of
+    // crashing the install with an unhandled 'error' event.
+    file.on('error', (err) => {
+      fail(err);
+    });
+
     const doRequest = (currentUrl, redirectsLeft) => {
       https
         .get(currentUrl, (res) => {
           if (REDIRECT_STATUS_CODES.includes(res.statusCode) && res.headers.location) {
             res.resume();
             if (redirectsLeft <= 0) {
-              file.close();
-              fs.unlinkSync(dest);
-              reject(new Error(`Failed to download from ${url}. Too many redirects (>${MAX_REDIRECTS}).`));
+              fail(new Error(`Failed to download from ${url}. Too many redirects (>${MAX_REDIRECTS}).`));
               return;
             }
             const nextUrl = new URL(res.headers.location, currentUrl).toString();
@@ -32,25 +62,20 @@ async function downloadFile(url, dest) {
             return;
           }
           if (res.statusCode !== 200) {
-            file.close();
-            fs.unlinkSync(dest);
-            reject(new Error(`Failed to download from ${url}. HTTP status code = ${res.statusCode}`));
+            res.resume();
+            fail(new Error(`Failed to download from ${url}. HTTP status code = ${res.statusCode}`));
             return;
           }
 
-          res.pipe(file);
           file.on('finish', () => {
-            file.close();
-            resolve();
+            file.close(() => {
+              succeed();
+            });
           });
-          file.on('error', (err) => {
-            fs.unlinkSync(dest);
-            reject(err);
-          });
+          res.pipe(file);
         })
         .on('error', (err) => {
-          fs.unlinkSync(dest);
-          reject(err);
+          fail(err);
         });
     };
     doRequest(url, MAX_REDIRECTS);
@@ -66,7 +91,8 @@ async function downloadJson(url) {
           const contentType = res.headers['content-type'];
 
           if (!statusCode) {
-            reject(new Error('No response statud code from server.'));
+            res.resume();
+            reject(new Error('No response status code from server.'));
             return;
           }
           if (REDIRECT_STATUS_CODES.includes(statusCode) && res.headers.location) {
@@ -80,13 +106,16 @@ async function downloadJson(url) {
             return;
           }
           if (statusCode >= 400 && statusCode < 500) {
+            res.resume();
             resolve(null);
             return;
           } else if (statusCode !== 200) {
+            res.resume();
             reject(new Error(`Failed to download build list. HTTP status code = ${statusCode}`));
             return;
           }
           if (!contentType || !/^application\/json/.test(contentType)) {
+            res.resume();
             reject(new Error(`unexpected content type: ${contentType}`));
             return;
           }

--- a/js/node/script/install-utils.js
+++ b/js/node/script/install-utils.js
@@ -10,76 +10,107 @@ const path = require('path');
 const os = require('os');
 const AdmZip = require('adm-zip'); // Use adm-zip instead of spawn
 
+const MAX_REDIRECTS = 5;
+const REDIRECT_STATUS_CODES = [301, 302, 303, 307, 308];
+
 async function downloadFile(url, dest) {
   return new Promise((resolve, reject) => {
     const file = fs.createWriteStream(dest);
-    https
-      .get(url, (res) => {
-        if (res.statusCode !== 200) {
-          file.close();
-          fs.unlinkSync(dest);
-          reject(new Error(`Failed to download from ${url}. HTTP status code = ${res.statusCode}`));
-          return;
-        }
+    const doRequest = (currentUrl, redirectsLeft) => {
+      https
+        .get(currentUrl, (res) => {
+          if (REDIRECT_STATUS_CODES.includes(res.statusCode) && res.headers.location) {
+            res.resume();
+            if (redirectsLeft <= 0) {
+              file.close();
+              fs.unlinkSync(dest);
+              reject(new Error(`Failed to download from ${url}. Too many redirects (>${MAX_REDIRECTS}).`));
+              return;
+            }
+            const nextUrl = new URL(res.headers.location, currentUrl).toString();
+            doRequest(nextUrl, redirectsLeft - 1);
+            return;
+          }
+          if (res.statusCode !== 200) {
+            file.close();
+            fs.unlinkSync(dest);
+            reject(new Error(`Failed to download from ${url}. HTTP status code = ${res.statusCode}`));
+            return;
+          }
 
-        res.pipe(file);
-        file.on('finish', () => {
-          file.close();
-          resolve();
-        });
-        file.on('error', (err) => {
+          res.pipe(file);
+          file.on('finish', () => {
+            file.close();
+            resolve();
+          });
+          file.on('error', (err) => {
+            fs.unlinkSync(dest);
+            reject(err);
+          });
+        })
+        .on('error', (err) => {
           fs.unlinkSync(dest);
           reject(err);
         });
-      })
-      .on('error', (err) => {
-        fs.unlinkSync(dest);
-        reject(err);
-      });
+    };
+    doRequest(url, MAX_REDIRECTS);
   });
 }
 
 async function downloadJson(url) {
   return new Promise((resolve, reject) => {
-    https
-      .get(url, (res) => {
-        const { statusCode } = res;
-        const contentType = res.headers['content-type'];
+    const doRequest = (currentUrl, redirectsLeft) => {
+      https
+        .get(currentUrl, (res) => {
+          const { statusCode } = res;
+          const contentType = res.headers['content-type'];
 
-        if (!statusCode) {
-          reject(new Error('No response statud code from server.'));
-          return;
-        }
-        if (statusCode >= 400 && statusCode < 500) {
-          resolve(null);
-          return;
-        } else if (statusCode !== 200) {
-          reject(new Error(`Failed to download build list. HTTP status code = ${statusCode}`));
-          return;
-        }
-        if (!contentType || !/^application\/json/.test(contentType)) {
-          reject(new Error(`unexpected content type: ${contentType}`));
-          return;
-        }
-        res.setEncoding('utf8');
-        let rawData = '';
-        res.on('data', (chunk) => {
-          rawData += chunk;
-        });
-        res.on('end', () => {
-          try {
-            resolve(JSON.parse(rawData));
-          } catch (e) {
-            reject(e);
+          if (!statusCode) {
+            reject(new Error('No response statud code from server.'));
+            return;
           }
-        });
-        res.on('error', (err) => {
+          if (REDIRECT_STATUS_CODES.includes(statusCode) && res.headers.location) {
+            res.resume();
+            if (redirectsLeft <= 0) {
+              reject(new Error(`Failed to download build list. Too many redirects (>${MAX_REDIRECTS}).`));
+              return;
+            }
+            const nextUrl = new URL(res.headers.location, currentUrl).toString();
+            doRequest(nextUrl, redirectsLeft - 1);
+            return;
+          }
+          if (statusCode >= 400 && statusCode < 500) {
+            resolve(null);
+            return;
+          } else if (statusCode !== 200) {
+            reject(new Error(`Failed to download build list. HTTP status code = ${statusCode}`));
+            return;
+          }
+          if (!contentType || !/^application\/json/.test(contentType)) {
+            reject(new Error(`unexpected content type: ${contentType}`));
+            return;
+          }
+          res.setEncoding('utf8');
+          let rawData = '';
+          res.on('data', (chunk) => {
+            rawData += chunk;
+          });
+          res.on('end', () => {
+            try {
+              resolve(JSON.parse(rawData));
+            } catch (e) {
+              reject(e);
+            }
+          });
+          res.on('error', (err) => {
+            reject(err);
+          });
+        })
+        .on('error', (err) => {
           reject(err);
         });
-      })
-      .on('error', (err) => {
-        reject(err);
-      });
+    };
+    doRequest(url, MAX_REDIRECTS);
   });
 }
 


### PR DESCRIPTION
### Description

`js/node/script/install-utils.js` previously treated any non-200 response as a fatal error, so an HTTP 301/302/303/307/308 redirect on a metadata or artifact URL aborted `npm install onnxruntime-node` with messages like:

```
Error: Failed to download build list. HTTP status code = 302
```

The NuGet Server API documents that requests may return 301/302 and clients are expected to follow the `Location` header. This is currently being observed in the wild against `https://api.nuget.org/v3/index.json`, which 302s to a regional mirror.

### Fix

Both `downloadFile()` and `downloadJson()` now:

- detect 301/302/303/307/308 with a non-empty `Location` header,
- resolve the next URL via `new URL(res.headers.location, currentUrl)` (handles both absolute and relative `Location` values),
- recurse through an inner `doRequest(currentUrl, redirectsLeft)` helper,
- cap redirect depth at 5 and surface a clear error if the cap is exceeded.

Existing 200 / 4xx / non-redirect-non-200 paths are unchanged, so no other behavior regresses.

### Motivation and Context

Fixes #28265
Fixes #28393

Both reporters independently observed the same root cause (Linux/WSL2 hitting a 302 from the NuGet index endpoint) and proposed essentially the same fix. This PR implements it.