### PR TITLE
docs: fix dead C_API.md link in Privacy.md

### DIFF
--- a/docs/Privacy.md
+++ b/docs/Privacy.md
@@ -17,5 +17,5 @@ Currently telemetry is only implemented for Windows builds and is turned **ON** 
 The Windows provider uses the [TraceLogging](https://docs.microsoft.com/en-us/windows/win32/tracelogging/trace-logging-about) API for its implementation. This enables ONNX Runtime trace events to be collected by the operating system, and based on user consent, this data may be periodically sent to Microsoft servers following GDPR and privacy regulations for anonymity and data access controls. 
 
 Windows ML and onnxruntime C APIs allow Trace Logging to be turned on/off (see [API pages](../README.md#api-documentation) for details).
-For information on how to enable and disable telemetry, see [C API: Telemetry](./C_API.md#telemetry). 
+For information on how to enable and disable telemetry, see [C API: Telemetry](https://onnxruntime.ai/docs/api/c/struct_ort_api.html#a5906120ee76cca5e8f560e6e8a3fd85c). 
 There are equivalent APIs in the C#, Python, and Java language bindings as well.


### PR DESCRIPTION
### Description

`docs/Privacy.md` links to `./C_API.md#telemetry` for telemetry enable/disable instructions, but `docs/C_API.md` was removed in #6225 (2021) when the C API documentation was migrated to the [onnxruntime.ai docs site](https://onnxruntime.ai/docs). The link has been dead ever since.

This points the link at the canonical Doxygen page for `OrtApi::EnableTelemetryEvents` on the docs site, which is where the equivalent guidance lives today. The pattern matches the existing `docs/FAQ.md` reference to `onnxruntime.ai/docs/api/python/...` for a specific API symbol.

### Motivation and Context

Closes #23701.

The dead link breaks the only pointer in `Privacy.md` to actionable instructions for opting out of Windows telemetry, which is a privacy-relevant gap.