### PR TITLE
Fix: Accept 'CPU' as a valid provider name in SessionOptionsAppendExecutionProvider

### DIFF
--- a/onnxruntime/core/session/provider_registration.cc
+++ b/onnxruntime/core/session/provider_registration.cc
@@ -89,7 +89,6 @@ ORT_API_STATUS_IMPL(OrtApis::SessionOptionsAppendExecutionProvider,
   API_IMPL_BEGIN
   enum class EpID {
     INVALID = 0,
-    CPU,
     DML,
     QNN,
     OpenVINO,
@@ -102,7 +101,8 @@ ORT_API_STATUS_IMPL(OrtApis::SessionOptionsAppendExecutionProvider,
     VitisAI,
     CoreML,
     NvTensorRtRtx,  // TensorRt EP for RTX GPUs.
-    MIGraphX
+    MIGraphX,
+    CPU
   };
 
   struct EpToAppend {
@@ -112,7 +112,6 @@ ORT_API_STATUS_IMPL(OrtApis::SessionOptionsAppendExecutionProvider,
   };
 
   static std::array<EpToAppend, 14> supported_eps = {
-      EpToAppend{EpID::CPU, "CPU", kCpuExecutionProvider},
       EpToAppend{EpID::DML, "DML", kDmlExecutionProvider},
       EpToAppend{EpID::QNN, "QNN", kQnnExecutionProvider},
       EpToAppend{EpID::OpenVINO, "OpenVINO", kOpenVINOExecutionProvider},
@@ -125,7 +124,8 @@ ORT_API_STATUS_IMPL(OrtApis::SessionOptionsAppendExecutionProvider,
       EpToAppend{EpID::VitisAI, "VitisAI", kVitisAIExecutionProvider},
       EpToAppend{EpID::CoreML, "CoreML", kCoreMLExecutionProvider},
       EpToAppend{EpID::NvTensorRtRtx, "NvTensorRtRtx", kNvTensorRTRTXExecutionProvider},
-      EpToAppend{EpID::MIGraphX, "MIGraphX", kMIGraphXExecutionProvider}};
+      EpToAppend{EpID::MIGraphX, "MIGraphX", kMIGraphXExecutionProvider},
+      EpToAppend{EpID::CPU, "CPU", kCpuExecutionProvider}};
 
   ProviderOptions provider_options;
   OrtStatus* status = ParseProviderOptions(provider_options_keys,

--- a/onnxruntime/core/session/provider_registration.cc
+++ b/onnxruntime/core/session/provider_registration.cc
@@ -89,6 +89,7 @@ ORT_API_STATUS_IMPL(OrtApis::SessionOptionsAppendExecutionProvider,
   API_IMPL_BEGIN
   enum class EpID {
     INVALID = 0,
+    CPU,
     DML,
     QNN,
     OpenVINO,
@@ -110,7 +111,8 @@ ORT_API_STATUS_IMPL(OrtApis::SessionOptionsAppendExecutionProvider,
     const char* canonical_name = nullptr;
   };
 
-  static std::array<EpToAppend, 13> supported_eps = {
+  static std::array<EpToAppend, 14> supported_eps = {
+      EpToAppend{EpID::CPU, "CPU", kCpuExecutionProvider},
       EpToAppend{EpID::DML, "DML", kDmlExecutionProvider},
       EpToAppend{EpID::QNN, "QNN", kQnnExecutionProvider},
       EpToAppend{EpID::OpenVINO, "OpenVINO", kOpenVINOExecutionProvider},
@@ -197,6 +199,11 @@ ORT_API_STATUS_IMPL(OrtApis::SessionOptionsAppendExecutionProvider,
                                                                              ep_to_append.canonical_name));
 
   switch (ep_to_append.id) {
+    case EpID::CPU: {
+      // CPU EP is always available by default. Accept the name as valid but do nothing,
+      // since the CPU EP is implicitly registered in every session.
+      break;
+    }
     case EpID::DML: {
 #if defined(USE_DML)
       options->provider_factories.push_back(


### PR DESCRIPTION
### Description
Adds 'CPU'/'CPUExecutionProvider' to the supported provider names whitelist in `SessionOptionsAppendExecutionProvider`. The CPU case is handled as a no-op since the CPU EP is always implicitly registered.

### Motivation and Context
The refactoring in #24433 introduced a strict whitelist of supported provider names but omitted 'CPU'. This caused a regression where explicitly appending the CPU provider (which was previously accepted) now throws:

```
RuntimeError: Unknown provider name 'CPU'. Currently supported values are 'DML'/'DmlExecutionProvider', ...
```

This breaks downstream consumers like onnxruntime-genai that call `AppendExecutionProvider('cpu')` when users request CPU execution. The issue was introduced in ORT builds after April 2025 and surfaces in onnxruntime-genai-winml >= 0.13.1.

### Changes
- Added `CPU` to the `EpID` enum
- Added `EpToAppend{EpID::CPU, 'CPU', kCpuExecutionProvider}` to the `supported_eps` array
- Added a `case EpID::CPU:` no-op handler in the switch statement