### PR TITLE
[Python] Document user_data parameter for Session.run_async

### DIFF
--- a/onnxruntime/python/onnxruntime_inference_collection.py
+++ b/onnxruntime/python/onnxruntime_inference_collection.py
@@ -334,8 +334,13 @@ class Session:
 
         :param output_names: name of the outputs
         :param input_feed: dictionary ``{ input_name: input_value }``
-        :param callback: python function that accept array of results, and a status string on error.
-            The callback will be invoked by a cxx thread from ort intra-op threadpool.
+        :param callback: python function that accepts an array of results, a user data object,
+            and a status string on error. The callback will be invoked by a cxx thread from the
+            ort intra-op threadpool.
+        :param user_data: arbitrary Python object forwarded unchanged to ``callback``. Use this to
+            associate per-request state (for example, a request id or a buffer to fill in) with the
+            results that arrive on the callback thread. ONNX Runtime does not inspect or modify
+            this value.
         :param run_options: See :class:`onnxruntime.RunOptions`.
 
         ::
@@ -351,7 +356,7 @@ class Session:
               else:
                 # save results to user_data
 
-            sess.run_async([output_name], {input_name: x}, callback)
+            sess.run_async([output_name], {input_name: x}, callback, MyData())
         """
         self._validate_input(list(input_feed.keys()))
         if not output_names:


### PR DESCRIPTION
Closes #20367. The `user_data` argument has been part of `Session.run_async` since the API was introduced in #16760, but the docstring never described it and the example call dropped it, so users reading `help(sess.run_async)` had to read the pybind layer to figure out what to pass.

This change documents `user_data` as an opaque Python object that ONNX Runtime forwards unchanged to the supplied callback, which matches the actual behavior in `onnxruntime_pybind_state.cc` where the value is stored on the `AsyncResource` and handed back to the callback verbatim. The callback description is also adjusted from "accepts an array of results and a status string" to the three-argument signature the callback already uses (results, user_data, err), so the docstring stops contradicting itself and the existing test in `onnxruntime_test_python.py::test_run_async`.

The example is updated to actually pass a `user_data` argument so that copy-pasting it no longer raises `TypeError: run_async() missing 1 required positional argument`. Documentation only, no behavior or signature change.