### PR TITLE
Fix CPU LSTM input validation and refactor ValidateInputs to frontends

### DIFF
--- a/onnxruntime/contrib_ops/cpu/quantization/dynamic_quantize_lstm.cc
+++ b/onnxruntime/contrib_ops/cpu/quantization/dynamic_quantize_lstm.cc
@@ -164,13 +164,35 @@ Status DynamicQuantizeLSTM::UseSharedPrePackedBuffers(std::vector<BufferUniquePt
   }
 
 Status DynamicQuantizeLSTM::Compute(OpKernelContext* context) const {
+  ORT_RETURN_IF_ERROR(ValidateInputs(*context));
+  const Tensor& X = *context->Input<Tensor>(0);
+  const auto& X_shape = X.Shape();
+
   // weights. [num_directions, input_size, 4*hidden_size]
   const Tensor* W = packed_W_.buffer_ ? nullptr : context->Input<Tensor>(1);
-  // recurrence weights. [num_directionshidden_size, 4*hidden_size]
+  // recurrence weights. [num_directions, hidden_size, 4*hidden_size]
   const Tensor* R = packed_R_.buffer_ ? nullptr : context->Input<Tensor>(2);
 
   const auto& W_shape = (W != nullptr) ? W->Shape() : packed_W_.shape_;
   const auto& R_shape = (R != nullptr) ? R->Shape() : packed_R_.shape_;
+
+  if (W_shape.NumDimensions() != 3 ||
+      W_shape[0] != num_directions_ ||
+      W_shape[2] != static_cast<int64_t>(hidden_size_) * 4 ||
+      W_shape[1] != X_shape[2]) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Input W must have shape {",
+                           num_directions_, ",", X_shape[2], ",", 4, "*", hidden_size_,
+                           "}. Actual:", W_shape);
+  }
+
+  if (R_shape.NumDimensions() != 3 ||
+      R_shape[0] != num_directions_ ||
+      R_shape[1] != hidden_size_ ||
+      R_shape[2] != static_cast<int64_t>(hidden_size_) * 4) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Input R must have shape {",
+                           num_directions_, ",", hidden_size_, ",", 4, "*", hidden_size_,
+                           "}. Actual:", R_shape);
+  }
 
   const Tensor* w_scale = context->Input<Tensor>(8);
   const Tensor* w_zp = context->Input<Tensor>(9);

--- a/onnxruntime/core/providers/cpu/rnn/deep_cpu_lstm.cc
+++ b/onnxruntime/core/providers/cpu/rnn/deep_cpu_lstm.cc
@@ -277,10 +277,10 @@ Status DeepCpuLstmOp::UseSharedPrePackedBuffers(std::vector<BufferUniquePtr>& pr
 }
 
 Status DeepCpuLstmOp::Compute(OpKernelContext* context) const {
+  ORT_RETURN_IF_ERROR(ValidateInputs(*context));
   const Tensor& X = *context->Input<Tensor>(0);  // inputs. [seq_length, batch_size, input_size]
 
   Status status;
-  // auto& logger = context->Logger();
 
   if (X.IsDataType<float>()) {
     const Tensor* W = packed_W_.buffer_ ? nullptr : context->Input<Tensor>(1);
@@ -290,6 +290,25 @@ Status DeepCpuLstmOp::Compute(OpKernelContext* context) const {
 
     const auto& W_shape = (W != nullptr) ? W->Shape() : packed_W_.shape_;
     const auto& R_shape = (R != nullptr) ? R->Shape() : packed_R_.shape_;
+    const auto& X_shape = X.Shape();
+
+    if (W_shape.NumDimensions() != 3 ||
+        W_shape[0] != num_directions_ ||
+        W_shape[1] != static_cast<int64_t>(hidden_size_) * 4 ||
+        W_shape[2] != X_shape[2]) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Input W must have shape {",
+                             num_directions_, ",", 4, "*", hidden_size_, ",",
+                             X_shape[2], "}. Actual:", W_shape);
+    }
+
+    if (R_shape.NumDimensions() != 3 ||
+        R_shape[0] != num_directions_ ||
+        R_shape[1] != static_cast<int64_t>(hidden_size_) * 4 ||
+        R_shape[2] != hidden_size_) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Input R must have shape {",
+                             num_directions_, ",", 4, "*", hidden_size_, ",",
+                             hidden_size_, "}. Actual:", R_shape);
+    }
 
     const auto* input_weights = (W != nullptr) ? W->Data<float>() : nullptr;
     const auto* recurrent_weights = (R != nullptr) ? R->Data<float>() : nullptr;

--- a/onnxruntime/core/providers/cpu/rnn/lstm_base.cc
+++ b/onnxruntime/core/providers/cpu/rnn/lstm_base.cc
@@ -44,9 +44,6 @@ Status LSTMBase::ComputeImpl(OpKernelContext& context,
   int batch_size = narrow<int>(X_shape[1]);
   int input_size = narrow<int>(X_shape[2]);
 
-  Status status = ValidateInputs(X, B, sequence_lens, initial_h, initial_c, P);
-  ORT_RETURN_IF_ERROR(status);
-
   // LSTM outputs are optional but must be in the same order
   TensorShape Y_dims{seq_length, num_directions_, batch_size, hidden_size_};
   Tensor* Y = context.Output(/*index*/ 0, Y_dims);
@@ -73,7 +70,7 @@ Status LSTMBase::ComputeImpl(OpKernelContext& context,
   }
 
   AllocatorPtr alloc;
-  status = context.GetTempSpaceAllocator(&alloc);
+  Status status = context.GetTempSpaceAllocator(&alloc);
   ORT_RETURN_IF_ERROR(status);
 
   gsl::span<const InputT> bias = B != nullptr ? B->DataAsSpan<InputT>() : gsl::span<const InputT>();
@@ -177,19 +174,23 @@ Status LSTMBase::ComputeImpl(OpKernelContext& context,
   return Status::OK();
 }
 
-Status LSTMBase::ValidateInputs(const Tensor& X,
-                                const Tensor* B,
-                                const Tensor* sequence_lens,
-                                const Tensor* initial_h,
-                                const Tensor* initial_c,
-                                const Tensor* P) const {
+Status LSTMBase::ValidateInputs(OpKernelContext& context) const {
+  const Tensor& X = *context.Input<Tensor>(0);
+  const Tensor* B = context.Input<Tensor>(3);
+  const Tensor* sequence_lens = context.Input<Tensor>(4);
+  const Tensor* initial_h = context.Input<Tensor>(5);
+  const Tensor* initial_c = context.Input<Tensor>(6);
+  const Tensor* P = context.Input<Tensor>(7);
   auto& X_shape = X.Shape();
+
+  // ONNX shape inference (RNNShapeInference) validates X rank before the kernel
+  // runs during standard model loading. This check is defense-in-depth for
+  // programmatic graph construction or internal paths that bypass shape inference.
+  if (X_shape.NumDimensions() != 3)
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Input X must have 3 dimensions only. Actual:", X_shape);
 
   int64_t seq_length = X_shape[0];
   int64_t batch_size = X_shape[1];
-
-  if (X_shape.NumDimensions() != 3)
-    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Input X must have 3 dimensions only. Actual:", X_shape);
 
   if (B != nullptr) {
     auto& B_shape = B->Shape();

--- a/onnxruntime/core/providers/cpu/rnn/lstm_base.h
+++ b/onnxruntime/core/providers/cpu/rnn/lstm_base.h
@@ -65,12 +65,7 @@ class LSTMBase {
                      const rnn::detail::GemmWeights<WeightT>& R_1,
                      const rnn::detail::GemmWeights<WeightT>& R_2) const;
 
-  Status ValidateInputs(const Tensor& X,
-                        const Tensor* B,
-                        const Tensor* sequence_lens,
-                        const Tensor* initial_h,
-                        const Tensor* initial_c,
-                        const Tensor* P) const;
+  Status ValidateInputs(OpKernelContext& context) const;
 
   rnn::detail::Direction direction_;
   int num_directions_;

--- a/onnxruntime/test/contrib_ops/quantize_lstm_op_test.cc
+++ b/onnxruntime/test/contrib_ops/quantize_lstm_op_test.cc
@@ -350,6 +350,81 @@ static void RunQuantLSTM(int64_t input_size,
                       per_channel, "bidirectional");
 }
 
+static void RunInvalidDynamicQuantLstmShapeTest(const std::vector<int64_t>& W_dims,
+                                                const std::vector<uint8_t>& W_data,
+                                                const std::vector<int64_t>& R_dims,
+                                                const std::vector<uint8_t>& R_data,
+                                                const std::string& expected_error) {
+  constexpr int64_t seq_length = 2;
+  constexpr int64_t batch_size = 1;
+  constexpr int64_t input_size = 1;
+  constexpr int64_t hidden_size = 2;
+  constexpr int64_t num_directions = 1;
+
+  OpTester test("DynamicQuantizeLSTM", 1, onnxruntime::kMSDomain);
+  test.AddAttribute<std::vector<std::string>>("activations", {"sigmoid", "tanh", "tanh"});
+  test.AddAttribute("direction", std::string("forward"));
+  test.AddAttribute("hidden_size", hidden_size);
+  test.AddAttribute<int64_t>("input_forget", 0);
+
+  test.AddInput<float>("X", {seq_length, batch_size, input_size},
+                       std::vector<float>(seq_length * batch_size * input_size, 0.1f));
+  test.AddInput<uint8_t>("W", W_dims, W_data);
+  test.AddInput<uint8_t>("R", R_dims, R_data);
+
+  test.AddOptionalInputEdge<float>();  // B
+  test.AddOptionalInputEdge<int>();    // sequence_lens
+  test.AddOptionalInputEdge<float>();  // initial_h
+  test.AddOptionalInputEdge<float>();  // initial_c
+  test.AddOptionalInputEdge<float>();  // P
+
+  test.AddInput<float>("W_scale", {num_directions}, {1.0f});
+  test.AddInput<uint8_t>("W_zero_point", {num_directions}, {128});
+  test.AddInput<float>("R_scale", {num_directions}, {1.0f});
+  test.AddInput<uint8_t>("R_zero_point", {num_directions}, {128});
+
+  test.AddOutput<float>("Y", {seq_length, num_directions, batch_size, hidden_size},
+                        std::vector<float>(seq_length * num_directions * batch_size * hidden_size, 0.0f));
+
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(DefaultCpuExecutionProvider());
+  test.Run(OpTester::ExpectResult::kExpectFailure, expected_error, {}, nullptr, &execution_providers);
+}
+
+TEST(DynamicQuantLSTMTest, InvalidInputShapes) {
+  constexpr int64_t input_size = 1;
+  constexpr int64_t hidden_size = 2;
+  constexpr int64_t num_directions = 1;
+
+  // DynamicQuantizeLSTM W layout: [num_directions, input_size, 4*hidden_size]
+  const std::vector<int64_t> valid_W_dims = {num_directions, input_size, 4 * hidden_size};
+  const std::vector<uint8_t> valid_W_data(num_directions * input_size * 4 * hidden_size, 128);
+
+  // DynamicQuantizeLSTM R layout: [num_directions, hidden_size, 4*hidden_size]
+  const std::vector<int64_t> valid_R_dims = {num_directions, hidden_size, 4 * hidden_size};
+  const std::vector<uint8_t> valid_R_data(num_directions * hidden_size * 4 * hidden_size, 128);
+
+  RunInvalidDynamicQuantLstmShapeTest({4 * hidden_size, input_size},
+                                      std::vector<uint8_t>(4 * hidden_size * input_size, 128),
+                                      valid_R_dims, valid_R_data,
+                                      "Input W must have shape");
+
+  RunInvalidDynamicQuantLstmShapeTest({num_directions, input_size, 4 * hidden_size - 1},
+                                      std::vector<uint8_t>(num_directions * input_size * (4 * hidden_size - 1), 128),
+                                      valid_R_dims, valid_R_data,
+                                      "Input W must have shape");
+
+  RunInvalidDynamicQuantLstmShapeTest(valid_W_dims, valid_W_data,
+                                      {4 * hidden_size, hidden_size},
+                                      std::vector<uint8_t>(4 * hidden_size * hidden_size, 128),
+                                      "Input R must have shape");
+
+  RunInvalidDynamicQuantLstmShapeTest(valid_W_dims, valid_W_data,
+                                      {num_directions, hidden_size + 1, 4 * hidden_size},
+                                      std::vector<uint8_t>(num_directions * (hidden_size + 1) * 4 * hidden_size, 128),
+                                      "Input R must have shape");
+}
+
 TEST(DynamicQuantLSTMTest, SmallSize) {
   RunQuantLSTM<int8_t>(2, 1, 16);
   RunQuantLSTM<int8_t>(2, 1, 16, true /*per_channel*/);

--- a/onnxruntime/test/providers/cpu/rnn/deep_cpu_lstm_op_test.cc
+++ b/onnxruntime/test/providers/cpu/rnn/deep_cpu_lstm_op_test.cc
@@ -249,7 +249,7 @@ TEST(LSTMTest, InvalidInputShapes) {
                                valid_W_data,
                                valid_R_dims,
                                valid_R_data,
-                               "First input tensor must have rank 3");
+                               "must have rank 3");
 
   RunInvalidLstmInputShapeTest(valid_X_dims,
                                valid_X_data,

--- a/onnxruntime/test/providers/cpu/rnn/deep_cpu_lstm_op_test.cc
+++ b/onnxruntime/test/providers/cpu/rnn/deep_cpu_lstm_op_test.cc
@@ -187,6 +187,103 @@ void SimpleWeightsNoBiasTwoRows(std::string direction,
                 nullptr, nullptr, nullptr, nullptr, seq_lengths, direction, 999.f, /* output_sequence*/ false);
 }
 
+static void RunInvalidLstmInputShapeTest(const std::vector<int64_t>& X_dims,
+                                         const std::vector<float>& X_data,
+                                         const std::vector<int64_t>& W_dims,
+                                         const std::vector<float>& W_data,
+                                         const std::vector<int64_t>& R_dims,
+                                         const std::vector<float>& R_data,
+                                         const std::string& expected_error) {
+  constexpr int64_t seq_length = 2;
+  constexpr int64_t batch_size = 1;
+  constexpr int64_t hidden_size = 2;
+  constexpr int64_t num_directions = 1;
+
+  OpTester test("LSTM");
+  test.AddAttribute<std::vector<string>>("activations", {"sigmoid", "tanh", "tanh"});
+  test.AddAttribute("direction", "forward");
+  test.AddAttribute("hidden_size", hidden_size);
+
+  test.AddInput<float>("X", X_dims, X_data);
+  test.AddInput<float>("W", W_dims, W_data);
+  test.AddInput<float>("R", R_dims, R_data);
+
+  test.AddOptionalInputEdge<float>();  // B
+  test.AddOptionalInputEdge<int>();    // sequence_lens
+  test.AddOptionalInputEdge<float>();  // initial_h
+  test.AddOptionalInputEdge<float>();  // initial_c
+  test.AddOptionalInputEdge<float>();  // P
+
+  std::vector<int64_t> Y_dims = {seq_length, num_directions, batch_size, hidden_size};
+  test.AddOutput<float>("Y", Y_dims, std::vector<float>(seq_length * num_directions * batch_size * hidden_size, 0.0f));
+  test.AddOptionalOutputEdge<float>();  // Y_h
+  test.AddOptionalOutputEdge<float>();  // Y_c
+
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(DefaultCpuExecutionProvider());
+  test.Run(OpTester::ExpectResult::kExpectFailure, expected_error, {}, nullptr, &execution_providers);
+}
+
+TEST(LSTMTest, InvalidInputShapes) {
+  constexpr int64_t seq_length = 2;
+  constexpr int64_t batch_size = 1;
+  constexpr int64_t input_size = 1;
+  constexpr int64_t hidden_size = 2;
+  constexpr int64_t num_directions = 1;
+
+  const std::vector<int64_t> valid_X_dims = {seq_length, batch_size, input_size};
+  const std::vector<float> valid_X_data(seq_length * batch_size * input_size, 0.1f);
+
+  const std::vector<int64_t> valid_W_dims = {num_directions, 4 * hidden_size, input_size};
+  const std::vector<float> valid_W_data(num_directions * 4 * hidden_size * input_size, 0.1f);
+
+  const std::vector<int64_t> valid_R_dims = {num_directions, 4 * hidden_size, hidden_size};
+  const std::vector<float> valid_R_data(num_directions * 4 * hidden_size * hidden_size, 0.1f);
+
+  // X rank is validated by ONNX shape inference (RNNShapeInference) before the
+  // kernel runs, not by ORT kernel code. The expected error string is from the
+  // ONNX library. This sub-case serves as a regression test for that contract.
+  RunInvalidLstmInputShapeTest({seq_length, batch_size},
+                               std::vector<float>(seq_length * batch_size, 0.1f),
+                               valid_W_dims,
+                               valid_W_data,
+                               valid_R_dims,
+                               valid_R_data,
+                               "First input tensor must have rank 3");
+
+  RunInvalidLstmInputShapeTest(valid_X_dims,
+                               valid_X_data,
+                               {4 * hidden_size, input_size},
+                               std::vector<float>(4 * hidden_size * input_size, 0.1f),
+                               valid_R_dims,
+                               valid_R_data,
+                               "Input W must have shape");
+
+  RunInvalidLstmInputShapeTest(valid_X_dims,
+                               valid_X_data,
+                               {num_directions, 4 * hidden_size - 1, input_size},
+                               std::vector<float>(num_directions * (4 * hidden_size - 1) * input_size, 0.1f),
+                               valid_R_dims,
+                               valid_R_data,
+                               "Input W must have shape");
+
+  RunInvalidLstmInputShapeTest(valid_X_dims,
+                               valid_X_data,
+                               valid_W_dims,
+                               valid_W_data,
+                               {4 * hidden_size, hidden_size},
+                               std::vector<float>(4 * hidden_size * hidden_size, 0.1f),
+                               "Input R must have shape");
+
+  RunInvalidLstmInputShapeTest(valid_X_dims,
+                               valid_X_data,
+                               valid_W_dims,
+                               valid_W_data,
+                               {num_directions, 4 * hidden_size, hidden_size + 1},
+                               std::vector<float>(num_directions * 4 * hidden_size * (hidden_size + 1), 0.1f),
+                               "Input R must have shape");
+}
+
 TEST(LSTMTest, ForwardSimpleWeightsNoBiasTwoRows) {
   // TODO: Unskip when fixed #41968513
   if (DefaultDmlExecutionProvider().get() != nullptr) {


### PR DESCRIPTION
## Summary

Follow-up to #27737, which fixed out-of-bounds shape reads in the CUDA LSTM path but explicitly deferred the CPU counterpart. This PR addresses CPU LSTM validation gaps.

---

## Problems fixed

### 1. Structural: validation in the backend instead of the frontend

W's third dimension `input_size` must equal X's third dimension `input_size` at runtime,
Validating W therefore depends on X. Beyond this data dependency,
input validation is not the responsibility of the computation. `ComputeImpl()`
should receive already-validated inputs, not validate them itself.
In addition, `ValidateInputs()` no longer receives six individual tensors from the caller.

### 2. Bug: out-of-bounds dimension reads before rank check

In `ValidateInputs()`, `X.Shape()[0]` and `X.Shape()[1]` were read *before* the `NumDimensions() != 3` guard:

```cpp
// Before — UB on rank < 2
auto& X_shape = X.Shape();
int64_t seq_length = X_shape[0];   // ← read before rank check
int64_t batch_size = X_shape[1];   // ← read before rank check
if (X_shape.NumDimensions() != 3)
  return error;

// After — guard first
if (X_shape.NumDimensions() != 3)
  return error;
int64_t seq_length = X_shape[0];
int64_t batch_size = X_shape[1];
```

This mirrors the fix applied to the CUDA path in #27737.

### 3. Missing: CPU LSTM never validated W or R shapes

Neither `DeepCpuLstmOp::Compute()` nor `DynamicQuantizeLSTM::Compute()` validated W or R shapes.
> `DynamicQuantizeLSTM` uses transposed W and R layouts.
> `[num_directions, input_size, 4*hidden_size]` and `[num_directions, hidden_size, 4*hidden_size]` respectively
> That's why W/R validation cannot be integrated into ValidateInputs()

---

## Changes

| File | Change |
|------|--------|
| `lstm_base.h` | `ValidateInputs()` declaration: `(OpKernelContext& context)` |
| `lstm_base.cc` | 1. `ValidateInputs()` fetches inputs internally.<br> 2. Rank check reordered before dimension reads.<br> 3. call removed from `ComputeImpl` |
| `deep_cpu_lstm.cc` | `ValidateInputs(*context)` + W/R validation called at top of `Compute()` |
| `dynamic_quantize_lstm.cc` | Same; W/R validation added for the first time (transposed W layout: `[num_directions, input_size, 4*hidden_size]`) |
| `deep_cpu_lstm_op_test.cc` | `LSTMTest.InvalidInputShapes`: wrong-rank W, wrong-dim W, wrong-rank R, wrong-dim R; plus X-rank regression test against ONNX shape inference |
| `quantize_lstm_op_test.cc` | `DynamicQuantLSTMTest.InvalidInputShapes`: same four cases for the quantized path |
