### PR TITLE
fix: support Expo 55 in ORT RN Expo config plugin

### DIFF
--- a/js/react_native/app.plugin.js
+++ b/js/react_native/app.plugin.js
@@ -4,6 +4,14 @@ const pkg = require('onnxruntime-react-native/package.json');
 const path = require('path');
 const fs = require('fs');
 
+// Expo SDK 55+ bare template uses ExpoReactHostFactory instead of ReactNativeHostWrapper.
+function isExpoSdk55OrAbove(config) {
+  const major = config.sdkVersion ? parseInt(String(config.sdkVersion).split('.')[0], 10) : -1;
+  if (!Number.isNaN(major)) {
+    return major >= 55;
+  }
+}
+
 const withOrt = (config) => {
   // Add build dependency to gradle file
   config = configPlugin.withAppBuildGradle(config, (config) => {
@@ -35,14 +43,26 @@ const withOrt = (config) => {
         offset: 0,
         comment: '//',
       }).contents;
-      config.modResults.contents = generateCode.mergeContents({
-        src: config.modResults.contents,
-        newSrc: '      add(OnnxruntimePackage())',
-        tag: 'onnxruntime-react-native-package',
-        anchor: /override fun getPackages\(\)/,
-        offset: 2,
-        comment: '//',
-      }).contents;
+      const packageRegistration = isExpoSdk55OrAbove(config)
+        ? // Expo 55+ path
+          generateCode.mergeContents({
+            src: config.modResults.contents,
+            newSrc: '          add(OnnxruntimePackage())',
+            tag: 'onnxruntime-react-native-package',
+            anchor: /PackageList\(this\)\.packages\.apply\s*\{/,
+            offset: 1,
+            comment: '//',
+          })
+        : // Expo < 55 path
+          generateCode.mergeContents({
+            src: config.modResults.contents,
+            newSrc: '              add(OnnxruntimePackage())',
+            tag: 'onnxruntime-react-native-package',
+            anchor: /override fun getPackages\(\)/,
+            offset: 2,
+            comment: '//',
+          });
+      config.modResults.contents = packageRegistration.contents;
     } else if (lang === 'java') {
       config.modResults.contents = generateCode.mergeContents({
         src: config.modResults.contents,
@@ -56,7 +76,7 @@ const withOrt = (config) => {
         if (/return\s+new PackageList\(this\)\.getPackages\(\);/.test(config.modResults.contents)) {
           config.modResults.contents = config.modResults.contents.replace(
             /(\s*)return\s+new PackageList\(this\)\.getPackages\(\);/,
-            '$1List<ReactPackage> packages = new PackageList(this).getPackages();\n$1packages.add(new OnnxruntimePackage());\n$1return packages;',
+            '$1List<ReactPackage> packages = new PackageList(this).getPackages();\n$1packages.add(new OnnxruntimePackage());\n$1return packages;'
           );
         } else {
           config.modResults.contents = generateCode.mergeContents({


### PR DESCRIPTION
### Description
This PR adds a conditionally-switched logic for establishing the insertion point registering the ORT RN native module for Expo < 55 (`ReactNativeHostWrapper`) and Expo >= 55 (`ExpoReactHostFactory.getDefaultReactHost`) in the Expo config plugin's main application code manipulation logic.

Below are example artifacts after modifications by the ORT RN Expo config plugin for:
<details>
<summary>Expo 54</summary>

```
package com.anonymous.myapp

// @generated begin onnxruntime-react-native-import - expo prebuild (DO NOT MODIFY) sync-4543d7f2625243dfdef886002e5bf12df91957f2
import ai.onnxruntime.reactnative.OnnxruntimePackage
// @generated end onnxruntime-react-native-import
import android.app.Application
import android.content.res.Configuration

import com.facebook.react.PackageList
import com.facebook.react.ReactApplication
import com.facebook.react.ReactNativeApplicationEntryPoint.loadReactNative
import com.facebook.react.ReactNativeHost
import com.facebook.react.ReactPackage
import com.facebook.react.ReactHost
import com.facebook.react.common.ReleaseLevel
import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint
import com.facebook.react.defaults.DefaultReactNativeHost

import expo.modules.ApplicationLifecycleDispatcher
import expo.modules.ReactNativeHostWrapper

class MainApplication : Application(), ReactApplication {

  override val reactNativeHost: ReactNativeHost = ReactNativeHostWrapper(
      this,
      object : DefaultReactNativeHost(this) {
        override fun getPackages(): List<ReactPackage> =
            PackageList(this).packages.apply {
// @generated begin onnxruntime-react-native-package - expo prebuild (DO NOT MODIFY) sync-25da176d9e9c766ec723838ae4be361b632bb7b3
              add(OnnxruntimePackage())
// @generated end onnxruntime-react-native-package
              // Packages that cannot be autolinked yet can be added manually here, for example:
              // add(MyReactNativePackage())
            }

          override fun getJSMainModuleName(): String = ".expo/.virtual-metro-entry"

          override fun getUseDeveloperSupport(): Boolean = BuildConfig.DEBUG

          override val isNewArchEnabled: Boolean = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED
      }
  )
```

</details>

<details>
<summary>Expo 55</summary>

```
package com.anonymous.expoapp

// @generated begin onnxruntime-react-native-import - expo prebuild (DO NOT MODIFY) sync-4543d7f2625243dfdef886002e5bf12df91957f2
import ai.onnxruntime.reactnative.OnnxruntimePackage
// @generated end onnxruntime-react-native-import
import android.app.Application
import android.content.res.Configuration

import com.facebook.react.PackageList
import com.facebook.react.ReactApplication
import com.facebook.react.ReactNativeApplicationEntryPoint.loadReactNative
import com.facebook.react.ReactPackage
import com.facebook.react.ReactHost
import com.facebook.react.common.ReleaseLevel
import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint

import expo.modules.ApplicationLifecycleDispatcher
import expo.modules.ExpoReactHostFactory

class MainApplication : Application(), ReactApplication {

  override val reactHost: ReactHost by lazy {
    ExpoReactHostFactory.getDefaultReactHost(
      context = applicationContext,
      packageList =
        PackageList(this).packages.apply {
// @generated begin onnxruntime-react-native-package - expo prebuild (DO NOT MODIFY) sync-a88c2d7d7f009e4e421e13cf3649dd1245afdb53
          add(OnnxruntimePackage())
// @generated end onnxruntime-react-native-package
          // Packages that cannot be autolinked yet can be added manually here, for example:
          // add(MyReactNativePackage())
        }
    )
  }
```
</details>

### Motivation and Context
Fixes #28657 by adding an insertion point path for Expo 55+.