### PR TITLE
Fix plugin EP test failure when host ORT lacks newer data types

### DIFF
--- a/include/onnxruntime/ep/adapter/kernel_def_builder.h
+++ b/include/onnxruntime/ep/adapter/kernel_def_builder.h
@@ -28,6 +28,20 @@ inline const OrtDataType* GetTensorType(ONNXTensorElementDataType elem_type) {
   return result;
 }
 
+/// <summary>
+/// Gets an OrtMLDataType for a tensor type. Returns nullptr if the host ORT does not support the type.
+/// </summary>
+inline const OrtDataType* TryGetTensorType(ONNXTensorElementDataType elem_type) {
+  const OrtEpApi& ep_api = Ort::GetEpApi();
+  const OrtDataType* result = nullptr;
+
+  Ort::Status status(ep_api.GetTensorDataType(elem_type, &result));
+  if (!status.IsOK()) {
+    return nullptr;
+  }
+  return result;
+}
+
 inline const OrtDataType* MLDataTypeToOrtDataType(MLDataType ml_type) {
   auto tensor_type = ml_type->AsTensorType();
   EP_ENFORCE(tensor_type != nullptr, "EP Kernel registration only supports tensor types.");
@@ -35,6 +49,22 @@ inline const OrtDataType* MLDataTypeToOrtDataType(MLDataType ml_type) {
   auto primitive_type = static_cast<const PrimitiveDataTypeBase*>(elem_type);
   auto onnx_type = static_cast<ONNXTensorElementDataType>(primitive_type->GetDataType());
   return GetTensorType(onnx_type);
+}
+
+/// <summary>
+/// Converts an MLDataType to an OrtDataType. Returns nullptr if the host ORT does not support the type.
+/// This enables forward-compatible plugins to register kernels with type constraints that include newer
+/// data types without failing when loaded into an older host ORT.
+/// </summary>
+inline const OrtDataType* TryMLDataTypeToOrtDataType(MLDataType ml_type) {
+  auto tensor_type = ml_type->AsTensorType();
+  if (tensor_type == nullptr) {
+    return nullptr;
+  }
+  auto elem_type = tensor_type->GetElementType();
+  auto primitive_type = static_cast<const PrimitiveDataTypeBase*>(elem_type);
+  auto onnx_type = static_cast<ONNXTensorElementDataType>(primitive_type->GetDataType());
+  return TryGetTensorType(onnx_type);
 }
 
 /// <summary>
@@ -73,14 +103,24 @@ struct KernelDefBuilder {
     std::vector<const OrtDataType*> ort_types;
     ort_types.reserve(types.size());
     for (const auto& type : types) {
-      ort_types.push_back(MLDataTypeToOrtDataType(type));
+      // Use TryMLDataTypeToOrtDataType to gracefully skip types the host ORT doesn't support.
+      // This allows a newer plugin to load into an older host without failing on unknown types.
+      const OrtDataType* ort_type = TryMLDataTypeToOrtDataType(type);
+      if (ort_type != nullptr) {
+        ort_types.push_back(ort_type);
+      }
     }
-    builder_.AddTypeConstraint(arg_name, ort_types);
+    if (!ort_types.empty()) {
+      builder_.AddTypeConstraint(arg_name, ort_types);
+    }
     return *this;
   }
 
   KernelDefBuilder& TypeConstraint(const char* arg_name, MLDataType type) {
-    builder_.AddTypeConstraint(arg_name, MLDataTypeToOrtDataType(type));
+    const OrtDataType* ort_type = TryMLDataTypeToOrtDataType(type);
+    if (ort_type != nullptr) {
+      builder_.AddTypeConstraint(arg_name, ort_type);
+    }
     return *this;
   }
 

--- a/include/onnxruntime/ep/adapter/kernel_def_builder.h
+++ b/include/onnxruntime/ep/adapter/kernel_def_builder.h
@@ -8,6 +8,7 @@
 #endif
 
 #include <memory>
+#include <vector>
 
 #include "core/framework/data_types.h"
 
@@ -29,7 +30,7 @@ inline const OrtDataType* GetTensorType(ONNXTensorElementDataType elem_type) {
 }
 
 /// <summary>
-/// Gets an OrtMLDataType for a tensor type. Returns nullptr if the host ORT does not support the type.
+/// Gets an OrtDataType for a tensor type. Returns nullptr if the host ORT does not support the type.
 /// </summary>
 inline const OrtDataType* TryGetTensorType(ONNXTensorElementDataType elem_type) {
   const OrtEpApi& ep_api = Ort::GetEpApi();
@@ -37,7 +38,10 @@ inline const OrtDataType* TryGetTensorType(ONNXTensorElementDataType elem_type) 
 
   Ort::Status status(ep_api.GetTensorDataType(elem_type, &result));
   if (!status.IsOK()) {
-    return nullptr;
+    if (status.GetErrorCode() == ORT_INVALID_ARGUMENT || status.GetErrorCode() == ORT_NOT_IMPLEMENTED) {
+      return nullptr;
+    }
+    Ort::ThrowOnError(status);
   }
   return result;
 }
@@ -58,9 +62,7 @@ inline const OrtDataType* MLDataTypeToOrtDataType(MLDataType ml_type) {
 /// </summary>
 inline const OrtDataType* TryMLDataTypeToOrtDataType(MLDataType ml_type) {
   auto tensor_type = ml_type->AsTensorType();
-  if (tensor_type == nullptr) {
-    return nullptr;
-  }
+  EP_ENFORCE(tensor_type != nullptr, "EP Kernel registration only supports tensor types.");
   auto elem_type = tensor_type->GetElementType();
   auto primitive_type = static_cast<const PrimitiveDataTypeBase*>(elem_type);
   auto onnx_type = static_cast<ONNXTensorElementDataType>(primitive_type->GetDataType());
@@ -103,15 +105,15 @@ struct KernelDefBuilder {
     std::vector<const OrtDataType*> ort_types;
     ort_types.reserve(types.size());
     for (const auto& type : types) {
-      // Use TryMLDataTypeToOrtDataType to gracefully skip types the host ORT doesn't support.
-      // This allows a newer plugin to load into an older host without failing on unknown types.
       const OrtDataType* ort_type = TryMLDataTypeToOrtDataType(type);
       if (ort_type != nullptr) {
         ort_types.push_back(ort_type);
       }
     }
-    if (!ort_types.empty()) {
+    if (types.empty() || !ort_types.empty()) {
       builder_.AddTypeConstraint(arg_name, ort_types);
+    } else {
+      valid_ = false;
     }
     return *this;
   }
@@ -120,6 +122,8 @@ struct KernelDefBuilder {
     const OrtDataType* ort_type = TryMLDataTypeToOrtDataType(type);
     if (ort_type != nullptr) {
       builder_.AddTypeConstraint(arg_name, ort_type);
+    } else {
+      valid_ = false;
     }
     return *this;
   }
@@ -174,10 +178,11 @@ struct KernelDefBuilder {
   // assignment externally; the queue id hint is not needed.
   KernelDefBuilder& ExecQueueId(int /*queue_id*/) { return *this; }
 
-  Ort::KernelDef Build() { return builder_.Build(); }
+  Ort::KernelDef Build() { return valid_ ? builder_.Build() : Ort::KernelDef{nullptr}; }
 
  private:
   Ort::KernelDefBuilder builder_;
+  bool valid_ = true;
 };
 
 }  // namespace adapter

--- a/include/onnxruntime/ep/adapter/kernel_registry.h
+++ b/include/onnxruntime/ep/adapter/kernel_registry.h
@@ -35,7 +35,7 @@ struct KernelCreateInfo {
                    KernelCreatePtrFn create_func)
       : kernel_def(std::move(definition)),
         kernel_create_func(create_func) {
-    assert(kernel_def != nullptr);
+    assert(kernel_def == nullptr || kernel_create_func != nullptr);
   }
 
   KernelCreateInfo(KernelCreateInfo&& other) noexcept


### PR DESCRIPTION
### Description

Fix the CUDA plugin EP package test pipeline failure where the plugin is built with the latest code (which includes `float8e8m0` and other newer data types), but the host ORT 1.26 release does not support these types. When the plugin attempts to register kernel type constraints containing unsupported types, `GetTensorDataType` fails and the plugin load crashes.

### Motivation and Context

The plugin EP architecture allows plugins to be built against a newer version of the ONNX Runtime headers while being loaded into an older host ORT. However, the existing `KernelDefBuilder::TypeConstraint` methods call `GetTensorType` (which throws on unsupported types), making it impossible for a forward-compatible plugin to register kernels that include newer data types in their type constraint lists.

### Changes

- Add `TryGetTensorType()` — a non-throwing variant of `GetTensorType()` that returns `nullptr` when the host ORT does not recognize a tensor element type.
- Add `TryMLDataTypeToOrtDataType()` — a non-throwing variant of `MLDataTypeToOrtDataType()` that returns `nullptr` instead of asserting/throwing.
- Update `KernelDefBuilder::TypeConstraint` (both vector and single-type overloads) to use the `Try` variants and gracefully skip unsupported types rather than failing.

### Impact

- Plugins built with newer headers can now load into older host ORT releases without crashing on unknown data types.
- If all types in a constraint list are unsupported, the constraint is simply not registered (the kernel will not match, which is the correct fallback behavior).
- No behavioral change when the host supports all types — the code path is identical to before.