### PR TITLE
[GH 28654] Address keidiai security issue

### DIFF
--- a/onnxruntime/core/mlas/lib/kleidiai/convolve_kleidiai.cpp
+++ b/onnxruntime/core/mlas/lib/kleidiai/convolve_kleidiai.cpp
@@ -447,6 +447,9 @@ static std::unique_ptr<std::byte[]> LhsPackImageDataSme(const size_t ci, const s
 
     const auto lhs_size = kai_get_lhs_packed_size_lhs_imatmul_pack_x32p2vlx1_x32p_sme(m,kh*kw,ci);
     auto lhs = std::make_unique<std::byte[]>(lhs_size);
+    // Some ukernel packing paths may not overwrite every byte in the packed buffer for partial tiles.
+    // Start from a deterministic zero state so stale heap contents cannot influence later math.
+    std::fill_n(lhs.get(), lhs_size, std::byte{0});
 
     std::unique_ptr<float[]> nhwc_holder;
     const float* activation_src = nullptr;

--- a/onnxruntime/test/mlas/unittest/test_conv2d.h
+++ b/onnxruntime/test/mlas/unittest/test_conv2d.h
@@ -716,12 +716,16 @@ class MlasConv2DTest : public MlasTestBase {
     //
     // This sequence forces pad-buffer growth by running a smaller-CI convolution followed by a larger-CI
     // convolution (with padding to ensure pad pointers are used), then runs the smaller-CI convolution again.
+    // Execute both orders to validate that results are stable regardless of invocation order.
     // Repeat a few times to increase the likelihood of triggering a reallocation and verify the path.
     //
     for (int i = 0; i < 4; ++i) {
       Test(1, 1, 64, 11, 11, 32, 3, 3, 1, 1, 1, 1, 1, 1, 1, 1);   // smaller CI
       Test(1, 1, 320, 11, 11, 32, 3, 3, 1, 1, 1, 1, 1, 1, 1, 1);  // larger CI forces pad buffer growth
       Test(1, 1, 64, 11, 11, 32, 3, 3, 1, 1, 1, 1, 1, 1, 1, 1);   // sanity: back to smaller CI after growth
+
+      Test(1, 1, 320, 11, 11, 32, 3, 3, 1, 1, 1, 1, 1, 1, 1, 1);  // reversed order start
+      Test(1, 1, 64, 11, 11, 32, 3, 3, 1, 1, 1, 1, 1, 1, 1, 1);   // reversed order end
     }
   }
 


### PR DESCRIPTION
This pull request improves the reliability and determinism of convolution kernel packing and expands the convolution unit test coverage to ensure buffer management is robust against allocation and reuse issues.

**Reliability and determinism improvements:**

* In `convolve_kleidiai.cpp`, the packed buffer for the LHS (left-hand side) image data is now explicitly zero-initialized before use, ensuring that any stale heap data does not affect computations, especially in cases where some packing paths may not overwrite every byte.

**Testing and validation enhancements:**

* In `test_conv2d.h`, the convolution buffer growth test is expanded to run both increasing and decreasing input channel (CI) orders, validating that the results remain stable regardless of invocation sequence and increasing the chances of catching buffer reuse or reallocation bugs.