### PR TITLE
Address CUDA ReduceL2 negative results and add test coverage

### DIFF
--- a/onnxruntime/core/providers/cpu/reduction/reduction_ops.h
+++ b/onnxruntime/core/providers/cpu/reduction/reduction_ops.h
@@ -17,6 +17,8 @@
 #include "core/providers/cpu/reduction/reduction_kernel_base.h"
 #include "core/common/safeint.h"
 #include <cmath>
+#include <limits>
+#include <type_traits>
 
 namespace onnxruntime {
 
@@ -717,14 +719,67 @@ class ReduceAggregatorProd : public ReduceAggregator<T, T> {
   }
 };
 
+// Saturating absolute value for norm reductions.
+// For signed integer types, abs(MIN_VALUE) overflows because -MIN_VALUE > MAX_VALUE.
+// This returns MAX_VALUE (the closest representable value) instead of invoking UB.
+template <typename T>
+inline T saturating_abs(const T& v) {
+  if constexpr (std::is_signed_v<T> && std::is_integral_v<T>) {
+    if (v == std::numeric_limits<T>::min()) {
+      return std::numeric_limits<T>::max();
+    }
+  }
+  return v > T(0) ? v : -v;
+}
+
 template <typename T>
 class ReduceAggregatorL1 : public ReduceAggregator<T, T> {
+  // For integer types, accumulate sum-of-absolute-values in double to avoid overflow UB.
+  //
+  // Problem: ReduceL1 computes sum(|x_i|). For integer types, the sum can overflow:
+  //   - int32: just 3 elements of value 1,000,000,000 sum to 3×10^9 > INT32_MAX
+  //   - The abs step itself overflows for INT_MIN (handled by saturating_abs)
+  //
+  // Solution: Accumulate in double (range ~1.8e308), then clamp when casting back to T.
+  // For int32 inputs, double accumulation is exact (53-bit mantissa > 32 bits).
+  // For int64 inputs, values > 2^53 lose precision, but the final truncation to int64
+  // makes the error at most ±1.
+  double double_accumulator_ = 0.0;
+
  public:
   inline ReduceAggregatorL1(int64_t N, const T&) : ReduceAggregator<T, T>(N, 0) {}
   inline T aggall(const T* from_data) {
-    return Eigen::Map<const Eigen::Matrix<T, Eigen::Dynamic, 1>>(from_data, onnxruntime::narrow<size_t>(this->N_)).cwiseAbs().sum();
+    if constexpr (std::is_integral_v<T>) {
+      // Accumulate in double to avoid integer overflow during summation.
+      double sum = 0.0;
+      for (size_t i = 0, n = onnxruntime::narrow<size_t>(this->N_); i < n; ++i) {
+        sum += std::abs(static_cast<double>(from_data[i]));
+      }
+      // Saturate to max representable value if the L1-norm exceeds T's range.
+      constexpr double max_val = static_cast<double>(std::numeric_limits<T>::max());
+      if (sum >= max_val) return std::numeric_limits<T>::max();
+      return static_cast<T>(sum);
+    } else {
+      return Eigen::Map<const Eigen::Matrix<T, Eigen::Dynamic, 1>>(from_data, onnxruntime::narrow<size_t>(this->N_)).cwiseAbs().sum();
+    }
   }
-  inline void update(const T& v) { this->accumulator_ += v > 0 ? v : -v; }
+  inline void update(const T& v) {
+    if constexpr (std::is_integral_v<T>) {
+      // Accumulate abs in double to avoid overflow UB.
+      double_accumulator_ += std::abs(static_cast<double>(v));
+    } else {
+      this->accumulator_ += saturating_abs(v);
+    }
+  }
+  inline T get_value() {
+    if constexpr (std::is_integral_v<T>) {
+      constexpr double max_val = static_cast<double>(std::numeric_limits<T>::max());
+      if (double_accumulator_ >= max_val) return std::numeric_limits<T>::max();
+      return static_cast<T>(double_accumulator_);
+    } else {
+      return this->accumulator_;
+    }
+  }
 
   static void fill_for_empty_set(Tensor& output) {
     EigenMap<T>(output).array() = static_cast<T>(0);
@@ -733,13 +788,61 @@ class ReduceAggregatorL1 : public ReduceAggregator<T, T> {
 
 template <typename T>
 class ReduceAggregatorL2 : public ReduceAggregator<T, T> {
+  // For integer types, accumulate sum-of-squares in double to avoid signed overflow UB.
+  //
+  // Problem: ReduceL2 computes sqrt(sum(x_i^2)). For integer types, squaring can overflow:
+  //   - int32: any |v| > 46340 causes v*v > INT32_MAX (signed overflow = UB)
+  //   - int64: any |v| > 3,037,000,499 causes v*v > INT64_MAX
+  //   - INT_MIN: (-2^31)^2 = 2^62 which wraps to 0 in int32, giving sqrt(0) = 0 (wrong)
+  //
+  // Solution: Promote each element to double before squaring. Double has:
+  //   - Range up to ~1.8e308 (sufficient for any sum of int64 squares)
+  //   - 53-bit mantissa: individual int32 squares are exact; int64 values > 2^53 lose
+  //     precision but the final sqrt + truncation makes the error at most ±1 in the result.
+  //
+  // The final cast back to T is clamped to numeric_limits<T>::max() to avoid UB when the
+  // L2-norm exceeds the representable range (e.g., ReduceL2([INT_MIN]) ≈ 2^31 > INT32_MAX).
+  double double_accumulator_ = 0.0;
+
  public:
   inline ReduceAggregatorL2(int64_t N, const T&) : ReduceAggregator<T, T>(N, 0) {}
   inline T aggall(const T* from_data) {
-    return Eigen::Map<const Eigen::Matrix<T, Eigen::Dynamic, 1>>(from_data, onnxruntime::narrow<size_t>(this->N_)).norm();
+    if constexpr (std::is_integral_v<T>) {
+      // Accumulate in double to avoid integer overflow during squaring.
+      double sum = 0.0;
+      for (size_t i = 0, n = onnxruntime::narrow<size_t>(this->N_); i < n; ++i) {
+        double dv = static_cast<double>(from_data[i]);
+        sum += dv * dv;
+      }
+      double result = std::sqrt(sum);
+      // Saturate to max representable value if the norm exceeds T's range.
+      constexpr double max_val = static_cast<double>(std::numeric_limits<T>::max());
+      if (result >= max_val) return std::numeric_limits<T>::max();
+      return static_cast<T>(result);
+    } else {
+      return Eigen::Map<const Eigen::Matrix<T, Eigen::Dynamic, 1>>(from_data, onnxruntime::narrow<size_t>(this->N_)).norm();
+    }
   }
-  inline void update(const T& v) { this->accumulator_ += v * v; }
-  inline T get_value() { return reduce_sqrt<T>(this->accumulator_); }
+  inline void update(const T& v) {
+    if constexpr (std::is_integral_v<T>) {
+      // Square in double to avoid integer overflow UB.
+      double dv = static_cast<double>(v);
+      double_accumulator_ += dv * dv;
+    } else {
+      this->accumulator_ += v * v;
+    }
+  }
+  inline T get_value() {
+    if constexpr (std::is_integral_v<T>) {
+      double result = std::sqrt(double_accumulator_);
+      // Saturate to max representable value to avoid UB when casting back to integer.
+      constexpr double max_val = static_cast<double>(std::numeric_limits<T>::max());
+      if (result >= max_val) return std::numeric_limits<T>::max();
+      return static_cast<T>(result);
+    } else {
+      return reduce_sqrt<T>(this->accumulator_);
+    }
+  }
   static void fill_for_empty_set(Tensor& output) {
     EigenMap<T>(output).array() = static_cast<T>(0);
   }

--- a/onnxruntime/core/providers/cpu/reduction/reduction_ops.h
+++ b/onnxruntime/core/providers/cpu/reduction/reduction_ops.h
@@ -822,9 +822,11 @@ class ReduceAggregatorL2 : public ReduceAggregator<T, T> {
   //   - Range up to ~1.8e308 (sufficient for any sum of int64 squares). The accumulator
   //     cannot overflow to infinity: even summing INT64_MAX^2 for every element would
   //     require > 2.1e270 elements — physically impossible.
-  //   - 53-bit mantissa: int32 squares fit in 62 bits (max 46340^2 < 2^31), well within
-  //     double's 53-bit exact range, so naive accumulation is exact. Kahan summation
-  //     is unnecessary for int32 and would only add overhead.
+  //   - 53-bit mantissa: int32 values are exactly representable in double, but their
+  //     squares can require up to 62 bits (e.g., (2^31-1)^2 ≈ 2^62). For |v| > 2^26,
+  //     v*v exceeds 2^53 and loses precision. However, this is at most 1 ULP of error
+  //     per element — far better than integer overflow. Kahan summation is omitted for
+  //     int32 since the per-element squaring dominates error, not accumulation.
   //   - For int64, values > 2^53 lose precision in both squaring and accumulation.
   //     Kahan compensated summation is used for types >= 64 bits to reduce accumulation
   //     error from O(N) to O(1) ULPs (squaring precision loss remains inherent).

--- a/onnxruntime/core/providers/cpu/reduction/reduction_ops.h
+++ b/onnxruntime/core/providers/cpu/reduction/reduction_ops.h
@@ -741,19 +741,35 @@ class ReduceAggregatorL1 : public ReduceAggregator<T, T> {
   //   - The abs step itself overflows for INT_MIN (handled by saturating_abs)
   //
   // Solution: Accumulate in double (range ~1.8e308), then clamp when casting back to T.
-  // For int32 inputs, double accumulation is exact (53-bit mantissa > 32 bits).
-  // For int64 inputs, values > 2^53 lose precision, but the final truncation to int64
-  // makes the error at most ±1.
+  // The double accumulator cannot overflow to infinity: even summing INT64_MAX for every
+  // element, overflow requires > 1.9e289 elements — physically impossible.
+  // For int32 inputs, double accumulation is exact: |x_i| fits in 31 bits, and double's
+  // 53-bit mantissa can represent sums exactly up to 2^53 (~4.5 million max-magnitude
+  // elements). Kahan summation is unnecessary and would only add overhead.
+  // For int64 inputs, values > 2^53 and large reductions may lose precision when
+  // accumulated in double. Kahan compensated summation is used for types >= 64 bits
+  // to reduce accumulation error from O(N) to O(1) ULPs.
   double double_accumulator_ = 0.0;
+  double kahan_compensation_ = 0.0;  // Kahan compensation term for int64+
 
  public:
   inline ReduceAggregatorL1(int64_t N, const T&) : ReduceAggregator<T, T>(N, 0) {}
   inline T aggall(const T* from_data) {
     if constexpr (std::is_integral_v<T>) {
-      // Accumulate in double to avoid integer overflow during summation.
       double sum = 0.0;
-      for (size_t i = 0, n = onnxruntime::narrow<size_t>(this->N_); i < n; ++i) {
-        sum += std::abs(static_cast<double>(from_data[i]));
+      if constexpr (sizeof(T) >= sizeof(int64_t)) {
+        // Kahan compensated summation for int64+ to minimize precision loss.
+        double comp = 0.0;
+        for (size_t i = 0, n = onnxruntime::narrow<size_t>(this->N_); i < n; ++i) {
+          double y = std::abs(static_cast<double>(from_data[i])) - comp;
+          double t = sum + y;
+          comp = (t - sum) - y;
+          sum = t;
+        }
+      } else {
+        for (size_t i = 0, n = onnxruntime::narrow<size_t>(this->N_); i < n; ++i) {
+          sum += std::abs(static_cast<double>(from_data[i]));
+        }
       }
       // Saturate to max representable value if the L1-norm exceeds T's range.
       constexpr double max_val = static_cast<double>(std::numeric_limits<T>::max());
@@ -765,8 +781,15 @@ class ReduceAggregatorL1 : public ReduceAggregator<T, T> {
   }
   inline void update(const T& v) {
     if constexpr (std::is_integral_v<T>) {
-      // Accumulate abs in double to avoid overflow UB.
-      double_accumulator_ += std::abs(static_cast<double>(v));
+      if constexpr (sizeof(T) >= sizeof(int64_t)) {
+        // Kahan compensated summation for int64+.
+        double y = std::abs(static_cast<double>(v)) - kahan_compensation_;
+        double t = double_accumulator_ + y;
+        kahan_compensation_ = (t - double_accumulator_) - y;
+        double_accumulator_ = t;
+      } else {
+        double_accumulator_ += std::abs(static_cast<double>(v));
+      }
     } else {
       this->accumulator_ += saturating_abs(v);
     }
@@ -796,23 +819,41 @@ class ReduceAggregatorL2 : public ReduceAggregator<T, T> {
   //   - INT_MIN: (-2^31)^2 = 2^62 which wraps to 0 in int32, giving sqrt(0) = 0 (wrong)
   //
   // Solution: Promote each element to double before squaring. Double has:
-  //   - Range up to ~1.8e308 (sufficient for any sum of int64 squares)
-  //   - 53-bit mantissa: individual int32 squares are exact; int64 values > 2^53 lose
-  //     precision but the final sqrt + truncation makes the error at most ±1 in the result.
+  //   - Range up to ~1.8e308 (sufficient for any sum of int64 squares). The accumulator
+  //     cannot overflow to infinity: even summing INT64_MAX^2 for every element would
+  //     require > 2.1e270 elements — physically impossible.
+  //   - 53-bit mantissa: int32 squares fit in 62 bits (max 46340^2 < 2^31), well within
+  //     double's 53-bit exact range, so naive accumulation is exact. Kahan summation
+  //     is unnecessary for int32 and would only add overhead.
+  //   - For int64, values > 2^53 lose precision in both squaring and accumulation.
+  //     Kahan compensated summation is used for types >= 64 bits to reduce accumulation
+  //     error from O(N) to O(1) ULPs (squaring precision loss remains inherent).
   //
   // The final cast back to T is clamped to numeric_limits<T>::max() to avoid UB when the
   // L2-norm exceeds the representable range (e.g., ReduceL2([INT_MIN]) ≈ 2^31 > INT32_MAX).
   double double_accumulator_ = 0.0;
+  double kahan_compensation_ = 0.0;  // Kahan compensation term for int64+
 
  public:
   inline ReduceAggregatorL2(int64_t N, const T&) : ReduceAggregator<T, T>(N, 0) {}
   inline T aggall(const T* from_data) {
     if constexpr (std::is_integral_v<T>) {
-      // Accumulate in double to avoid integer overflow during squaring.
       double sum = 0.0;
-      for (size_t i = 0, n = onnxruntime::narrow<size_t>(this->N_); i < n; ++i) {
-        double dv = static_cast<double>(from_data[i]);
-        sum += dv * dv;
+      if constexpr (sizeof(T) >= sizeof(int64_t)) {
+        // Kahan compensated summation for int64+ to minimize precision loss.
+        double comp = 0.0;
+        for (size_t i = 0, n = onnxruntime::narrow<size_t>(this->N_); i < n; ++i) {
+          double dv = static_cast<double>(from_data[i]);
+          double y = dv * dv - comp;
+          double t = sum + y;
+          comp = (t - sum) - y;
+          sum = t;
+        }
+      } else {
+        for (size_t i = 0, n = onnxruntime::narrow<size_t>(this->N_); i < n; ++i) {
+          double dv = static_cast<double>(from_data[i]);
+          sum += dv * dv;
+        }
       }
       double result = std::sqrt(sum);
       // Saturate to max representable value if the norm exceeds T's range.
@@ -825,9 +866,16 @@ class ReduceAggregatorL2 : public ReduceAggregator<T, T> {
   }
   inline void update(const T& v) {
     if constexpr (std::is_integral_v<T>) {
-      // Square in double to avoid integer overflow UB.
       double dv = static_cast<double>(v);
-      double_accumulator_ += dv * dv;
+      if constexpr (sizeof(T) >= sizeof(int64_t)) {
+        // Kahan compensated summation for int64+.
+        double y = dv * dv - kahan_compensation_;
+        double t = double_accumulator_ + y;
+        kahan_compensation_ = (t - double_accumulator_) - y;
+        double_accumulator_ = t;
+      } else {
+        double_accumulator_ += dv * dv;
+      }
     } else {
       this->accumulator_ += v * v;
     }

--- a/onnxruntime/core/providers/cpu/reduction/reduction_ops.h
+++ b/onnxruntime/core/providers/cpu/reduction/reduction_ops.h
@@ -4,6 +4,10 @@
 #ifndef CORE_PROVIDERS_CPU_REDUCTION_OPS_H
 #define CORE_PROVIDERS_CPU_REDUCTION_OPS_H
 
+#include <cmath>
+#include <limits>
+#include <type_traits>
+
 #ifndef SHARED_PROVIDER
 #include "core/common/common.h"
 #include "core/common/optional.h"
@@ -16,9 +20,6 @@
 #include "core/platform/threadpool.h"
 #include "core/providers/cpu/reduction/reduction_kernel_base.h"
 #include "core/common/safeint.h"
-#include <cmath>
-#include <limits>
-#include <type_traits>
 
 namespace onnxruntime {
 

--- a/onnxruntime/core/providers/cuda/reduction/reduction_functions.cu
+++ b/onnxruntime/core/providers/cuda/reduction/reduction_functions.cu
@@ -549,12 +549,18 @@ void Impl_SaturatingAbs(cudaStream_t stream, const T* input_data, T* output_data
   UnaryElementWiseImpl(stream, input_data, output_data, OP_SaturatingAbs<T>(), count);
 }
 
-// Explicit instantiations for types registered for ReduceL1/L2 on CUDA.
+// Explicit instantiations for types used by ReduceL1/L2 on CUDA.
+// The SPECIALIZED_REDUCEKERNEL_COMPUTEIMPL macro expands for int32_t, int64_t, int8_t, uint8_t.
+// Even though ReduceL1/L2 aren't registered for int64/int8/uint8, the runtime check
+// on cudnn_reduce_op causes the compiler to emit the call, so the linker needs symbols.
 template void Impl_SaturatingAbs<float>(cudaStream_t, const float*, float*, size_t);
 template void Impl_SaturatingAbs<double>(cudaStream_t, const double*, double*, size_t);
 template void Impl_SaturatingAbs<half>(cudaStream_t, const half*, half*, size_t);
 template void Impl_SaturatingAbs<BFloat16>(cudaStream_t, const BFloat16*, BFloat16*, size_t);
 template void Impl_SaturatingAbs<int32_t>(cudaStream_t, const int32_t*, int32_t*, size_t);
+template void Impl_SaturatingAbs<int64_t>(cudaStream_t, const int64_t*, int64_t*, size_t);
+template void Impl_SaturatingAbs<int8_t>(cudaStream_t, const int8_t*, int8_t*, size_t);
+template void Impl_SaturatingAbs<uint8_t>(cudaStream_t, const uint8_t*, uint8_t*, size_t);
 
 }  // namespace cuda
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/cuda/reduction/reduction_functions.cu
+++ b/onnxruntime/core/providers/cuda/reduction/reduction_functions.cu
@@ -4,6 +4,8 @@
 #include "core/providers/cuda/reduction/reduction_functions.h"
 
 #include <algorithm>
+#include <limits>
+#include <type_traits>
 
 #include <cuda.h>
 #include <cuda_fp16.h>

--- a/onnxruntime/core/providers/cuda/reduction/reduction_functions.cu
+++ b/onnxruntime/core/providers/cuda/reduction/reduction_functions.cu
@@ -549,6 +549,35 @@ void Impl_SaturatingAbs(cudaStream_t stream, const T* input_data, T* output_data
   UnaryElementWiseImpl(stream, input_data, output_data, OP_SaturatingAbs<T>(), count);
 }
 
+/**
+ * Saturating cast from double to integer type T.
+ *
+ * A plain C++ cast from double to an integer type is undefined behavior when the value
+ * exceeds the integer's representable range (C++ standard [conv.fpint]/1). While some
+ * CUDA compiler/PTX combinations may produce saturating behavior in practice, this is
+ * NOT guaranteed by the CUDA specification. This functor explicitly clamps the double
+ * to [numeric_limits<T>::min(), numeric_limits<T>::max()] before casting, making the
+ * result well-defined and matching the CPU side's explicit clamping logic.
+ */
+template <typename T>
+struct OP_SaturatingCastFromDouble {
+  __device__ __inline__ T operator()(const double& a) const {
+    constexpr double t_max = static_cast<double>(std::numeric_limits<T>::max());
+    constexpr double t_min = static_cast<double>(std::numeric_limits<T>::min());
+    if (a >= t_max) return std::numeric_limits<T>::max();
+    if (a <= t_min) return std::numeric_limits<T>::min();
+    // NaN: neither >= t_max nor <= t_min, falls through to cast.
+    // static_cast<T>(NaN) is UB in C++, but cuDNN reductions on finite inputs
+    // cannot produce NaN for norm/sum operations, so this path is unreachable.
+    return static_cast<T>(a);
+  }
+};
+
+template <typename T>
+void Impl_SaturatingCastFromDouble(cudaStream_t stream, const double* input_data, T* output_data, size_t count) {
+  UnaryElementWiseImpl(stream, input_data, output_data, OP_SaturatingCastFromDouble<T>(), count);
+}
+
 // Explicit instantiations for types used by ReduceL1/L2 on CUDA.
 // The SPECIALIZED_REDUCEKERNEL_COMPUTEIMPL macro expands for int32_t, int64_t, int8_t, uint8_t.
 // Even though ReduceL1/L2 aren't registered for int64/int8/uint8, the runtime check
@@ -561,6 +590,11 @@ template void Impl_SaturatingAbs<int32_t>(cudaStream_t, const int32_t*, int32_t*
 template void Impl_SaturatingAbs<int64_t>(cudaStream_t, const int64_t*, int64_t*, size_t);
 template void Impl_SaturatingAbs<int8_t>(cudaStream_t, const int8_t*, int8_t*, size_t);
 template void Impl_SaturatingAbs<uint8_t>(cudaStream_t, const uint8_t*, uint8_t*, size_t);
+
+template void Impl_SaturatingCastFromDouble<int32_t>(cudaStream_t, const double*, int32_t*, size_t);
+template void Impl_SaturatingCastFromDouble<int64_t>(cudaStream_t, const double*, int64_t*, size_t);
+template void Impl_SaturatingCastFromDouble<int8_t>(cudaStream_t, const double*, int8_t*, size_t);
+template void Impl_SaturatingCastFromDouble<uint8_t>(cudaStream_t, const double*, uint8_t*, size_t);
 
 }  // namespace cuda
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/cuda/reduction/reduction_functions.cu
+++ b/onnxruntime/core/providers/cuda/reduction/reduction_functions.cu
@@ -513,3 +513,48 @@ INSTANTIATE_REDUCE_MATRIX_COLUMNS(BFloat16);
 
 }  // namespace cuda
 }  // namespace onnxruntime
+
+// =============================================================================
+// Saturating absolute value for norm no-op reductions.
+//
+// When reducing a singleton axis (input_count == output_count), the cuDNN
+// workaround copies data directly. For NORM1/NORM2 the result must be
+// non-negative. The standard _Abs(a) uses `a > 0 ? a : -a` which is undefined
+// behavior for the minimum value of signed types (e.g., INT32_MIN) because
+// -INT32_MIN overflows int32.
+//
+// This saturating variant clamps the result to numeric_limits<T>::max() when
+// the true absolute value is unrepresentable. This is mathematically the
+// closest value within the type's range.
+// =============================================================================
+namespace onnxruntime {
+namespace cuda {
+
+template <typename T>
+struct OP_SaturatingAbs {
+  __device__ __inline__ T operator()(const T& a) const {
+    if constexpr (std::is_signed_v<T> && std::is_integral_v<T>) {
+      // For the minimum value of a signed type, -a overflows.
+      // Saturate to max representable value instead.
+      if (a == std::numeric_limits<T>::min()) {
+        return std::numeric_limits<T>::max();
+      }
+    }
+    return a > T(0) ? a : -a;
+  }
+};
+
+template <typename T>
+void Impl_SaturatingAbs(cudaStream_t stream, const T* input_data, T* output_data, size_t count) {
+  UnaryElementWiseImpl(stream, input_data, output_data, OP_SaturatingAbs<T>(), count);
+}
+
+// Explicit instantiations for types registered for ReduceL1/L2 on CUDA.
+template void Impl_SaturatingAbs<float>(cudaStream_t, const float*, float*, size_t);
+template void Impl_SaturatingAbs<double>(cudaStream_t, const double*, double*, size_t);
+template void Impl_SaturatingAbs<half>(cudaStream_t, const half*, half*, size_t);
+template void Impl_SaturatingAbs<BFloat16>(cudaStream_t, const BFloat16*, BFloat16*, size_t);
+template void Impl_SaturatingAbs<int32_t>(cudaStream_t, const int32_t*, int32_t*, size_t);
+
+}  // namespace cuda
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cuda/reduction/reduction_functions.h
+++ b/onnxruntime/core/providers/cuda/reduction/reduction_functions.h
@@ -117,5 +117,16 @@ void UnaryDiv(cudaStream_t stream, const T* input, T* output, T denominator, siz
 template <typename T>
 void Impl_SaturatingAbs(cudaStream_t stream, const T* input_data, T* output_data, size_t count);
 
+/**
+ * Saturating cast from double to integer type T.
+ *
+ * Clamps the double value to [numeric_limits<T>::min(), numeric_limits<T>::max()] before
+ * casting to T. This avoids undefined behavior from out-of-range float-to-integer conversions
+ * (C++ standard [conv.fpint]/1) and provides well-defined saturation semantics matching
+ * the CPU reduction's explicit clamping logic.
+ */
+template <typename T>
+void Impl_SaturatingCastFromDouble(cudaStream_t stream, const double* input_data, T* output_data, size_t count);
+
 }  // namespace cuda
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/cuda/reduction/reduction_functions.h
+++ b/onnxruntime/core/providers/cuda/reduction/reduction_functions.h
@@ -107,5 +107,15 @@ Status reduce_matrix_columns(cudaStream_t stream, const TIn* input, TOut* output
 template <typename T>
 void UnaryDiv(cudaStream_t stream, const T* input, T* output, T denominator, size_t count);
 
+/**
+ * Saturating absolute value for norm no-op reductions.
+ *
+ * Unlike Impl_Abs, this handles the minimum value of signed integer types
+ * (e.g., INT32_MIN) by saturating to numeric_limits<T>::max() instead of
+ * invoking undefined behavior via signed overflow.
+ */
+template <typename T>
+void Impl_SaturatingAbs(cudaStream_t stream, const T* input_data, T* output_data, size_t count);
+
 }  // namespace cuda
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/cuda/reduction/reduction_ops.cc
+++ b/onnxruntime/core/providers/cuda/reduction/reduction_ops.cc
@@ -206,9 +206,14 @@ Status ReduceKernel<allow_multi_axes>::ReduceKernelShared(
           &one, input_tensor, input_data,
           &zero, output_tensor, reinterpret_cast<CudaT*>(Y)));
     } else {
-      // cudnnReduceTensor for ReduceSum has issue if input and output has same size, we just need to copy the data for this case
+      // cudnnReduceTensor for ReduceSum has issue if input and output has same size, we just need to copy the data
+      // for this case. This happens when the input is Scalar.
       if (input_count == output_count) {
-        if (reinterpret_cast<const void*>(Y) != reinterpret_cast<const void*>(X)) {
+        // For norm ops the single-element result must still be non-negative.
+        if (cudnn_reduce_op == CUDNN_REDUCE_TENSOR_NORM1 || cudnn_reduce_op == CUDNN_REDUCE_TENSOR_NORM2) {
+          Impl_Abs<CudaT>(cuda_stream, reinterpret_cast<const CudaT*>(X),
+                          reinterpret_cast<CudaT*>(Y), input_count);
+        } else if (reinterpret_cast<const void*>(Y) != reinterpret_cast<const void*>(X)) {
           CUDA_RETURN_IF_ERROR(cudaMemcpyAsync(Y, X, input_count * sizeof(T), cudaMemcpyDeviceToDevice, cuda_stream));
         }
       } else {
@@ -589,10 +594,16 @@ Status ReduceComputeCore(const AllocatorPtr& gpu_allocator, const CudaKernel* ke
             &zero, output_tensor, p_output));
       }
     } else {
-      // cudnnReduceTensor for ReduceSum has issue if input and output has same size, we just need to copy the data for this case
+      // cudnnReduceTensor for ReduceSum has issue if input and output has same size, we just need to copy the data
+      // for this case.
       if (input_count == output_count) {
-        if (output.MutableData<T>() != input.Data<T>()) {
-          CUDA_RETURN_IF_ERROR(cudaMemcpyAsync(output.MutableData<T>(), input.Data<T>(), input_count * sizeof(T), cudaMemcpyDeviceToDevice, stream));
+        // For norm ops the single-element result must still be non-negative.
+        if (cudnn_reduce_op == CUDNN_REDUCE_TENSOR_NORM1 || cudnn_reduce_op == CUDNN_REDUCE_TENSOR_NORM2) {
+          Impl_Abs<CudaT>(stream, reinterpret_cast<const CudaT*>(input.Data<T>()),
+                          reinterpret_cast<CudaT*>(output.MutableData<T>()), input_count);
+        } else if (output.MutableData<T>() != input.Data<T>()) {
+          CUDA_RETURN_IF_ERROR(cudaMemcpyAsync(output.MutableData<T>(), input.Data<T>(),
+                                               input_count * sizeof(T), cudaMemcpyDeviceToDevice, stream));
         }
       } else {
         if (temp_X) {
@@ -775,7 +786,11 @@ Status ReduceKernel<allow_multi_axes>::ComputeImpl(OpKernelContext* ctx, cudnnRe
     }                                                                                                                     \
                                                                                                                           \
     if (input_count == output_count) {                                                                                    \
-      if (Y->MutableData<T>() != X->Data<T>()) {                                                                          \
+      /* For no-op reductions where element count is unchanged, L1/L2 must still apply norm semantics. */                 \
+      if (cudnn_reduce_op == CUDNN_REDUCE_TENSOR_NORM1 || cudnn_reduce_op == CUDNN_REDUCE_TENSOR_NORM2) {                 \
+        Impl_Abs<CudaT>(Stream(ctx), reinterpret_cast<const CudaT*>(X->Data<T>()),                                        \
+                        reinterpret_cast<CudaT*>(Y->MutableData<T>()), input_count);                                      \
+      } else if (Y->MutableData<T>() != X->Data<T>()) {                                                                   \
         CUDA_RETURN_IF_ERROR(cudaMemcpyAsync(Y->MutableData<T>(), X->Data<T>(),                                           \
                                              input_count * sizeof(T), cudaMemcpyDeviceToDevice, Stream(ctx)));            \
       }                                                                                                                   \

--- a/onnxruntime/core/providers/cuda/reduction/reduction_ops.cc
+++ b/onnxruntime/core/providers/cuda/reduction/reduction_ops.cc
@@ -8,6 +8,7 @@
 #include "core/providers/cuda/math/binary_elementwise_ops_impl.h"
 #include "core/providers/cuda/math/binary_elementwise_ops.h"
 #include "core/providers/cuda/math/unary_elementwise_ops_impl.h"
+#include "core/providers/cuda/reduction/reduction_functions.h"
 #ifdef ENABLE_TRAINING
 #include "contrib_ops/cpu/aten_ops/aten_op.h"
 #endif
@@ -206,13 +207,13 @@ Status ReduceKernel<allow_multi_axes>::ReduceKernelShared(
           &one, input_tensor, input_data,
           &zero, output_tensor, reinterpret_cast<CudaT*>(Y)));
     } else {
-      // cudnnReduceTensor for ReduceSum has issue if input and output has same size, we just need to copy the data
-      // for this case. This happens when the input is Scalar.
+      // cudnnReduceTensor has issues if input and output have the same size. This happens when the input is a
+      // scalar or when a singleton axis (dim == 1) is reduced, making the reduction a no-op.
       if (input_count == output_count) {
-        // For norm ops the single-element result must still be non-negative.
+        // For norm ops the result must still be non-negative (|x| for single-element no-op reductions).
         if (cudnn_reduce_op == CUDNN_REDUCE_TENSOR_NORM1 || cudnn_reduce_op == CUDNN_REDUCE_TENSOR_NORM2) {
-          Impl_Abs<CudaT>(cuda_stream, reinterpret_cast<const CudaT*>(X),
-                          reinterpret_cast<CudaT*>(Y), input_count);
+          Impl_SaturatingAbs<CudaT>(cuda_stream, reinterpret_cast<const CudaT*>(X),
+                                    reinterpret_cast<CudaT*>(Y), input_count);
         } else if (reinterpret_cast<const void*>(Y) != reinterpret_cast<const void*>(X)) {
           CUDA_RETURN_IF_ERROR(cudaMemcpyAsync(Y, X, input_count * sizeof(T), cudaMemcpyDeviceToDevice, cuda_stream));
         }
@@ -594,13 +595,13 @@ Status ReduceComputeCore(const AllocatorPtr& gpu_allocator, const CudaKernel* ke
             &zero, output_tensor, p_output));
       }
     } else {
-      // cudnnReduceTensor for ReduceSum has issue if input and output has same size, we just need to copy the data
-      // for this case.
+      // cudnnReduceTensor has issues if input and output have the same size. This happens when the input is a
+      // scalar or when a singleton axis (dim == 1) is reduced, making the reduction a no-op.
       if (input_count == output_count) {
-        // For norm ops the single-element result must still be non-negative.
+        // For norm ops the result must still be non-negative (|x| for single-element no-op reductions).
         if (cudnn_reduce_op == CUDNN_REDUCE_TENSOR_NORM1 || cudnn_reduce_op == CUDNN_REDUCE_TENSOR_NORM2) {
-          Impl_Abs<CudaT>(stream, reinterpret_cast<const CudaT*>(input.Data<T>()),
-                          reinterpret_cast<CudaT*>(output.MutableData<T>()), input_count);
+          Impl_SaturatingAbs<CudaT>(stream, reinterpret_cast<const CudaT*>(input.Data<T>()),
+                                    reinterpret_cast<CudaT*>(output.MutableData<T>()), input_count);
         } else if (output.MutableData<T>() != input.Data<T>()) {
           CUDA_RETURN_IF_ERROR(cudaMemcpyAsync(output.MutableData<T>(), input.Data<T>(),
                                                input_count * sizeof(T), cudaMemcpyDeviceToDevice, stream));
@@ -788,8 +789,8 @@ Status ReduceKernel<allow_multi_axes>::ComputeImpl(OpKernelContext* ctx, cudnnRe
     if (input_count == output_count) {                                                                                    \
       /* For no-op reductions where element count is unchanged, L1/L2 must still apply norm semantics. */                 \
       if (cudnn_reduce_op == CUDNN_REDUCE_TENSOR_NORM1 || cudnn_reduce_op == CUDNN_REDUCE_TENSOR_NORM2) {                 \
-        Impl_Abs<CudaT>(Stream(ctx), reinterpret_cast<const CudaT*>(X->Data<T>()),                                        \
-                        reinterpret_cast<CudaT*>(Y->MutableData<T>()), input_count);                                      \
+        Impl_SaturatingAbs<CudaT>(Stream(ctx), reinterpret_cast<const CudaT*>(X->Data<T>()),                              \
+                                  reinterpret_cast<CudaT*>(Y->MutableData<T>()), input_count);                            \
       } else if (Y->MutableData<T>() != X->Data<T>()) {                                                                   \
         CUDA_RETURN_IF_ERROR(cudaMemcpyAsync(Y->MutableData<T>(), X->Data<T>(),                                           \
                                              input_count * sizeof(T), cudaMemcpyDeviceToDevice, Stream(ctx)));            \

--- a/onnxruntime/core/providers/cuda/reduction/reduction_ops.cc
+++ b/onnxruntime/core/providers/cuda/reduction/reduction_ops.cc
@@ -806,11 +806,13 @@ Status ReduceKernel<allow_multi_axes>::ComputeImpl(OpKernelContext* ctx, cudnnRe
     CudnnTensor output_tensor;                                                                                            \
     CudnnReduceDescriptor reduce_desc;                                                                                    \
                                                                                                                           \
-    /* Use double for integer reductions: 53-bit mantissa makes int32 squaring/summation exact,      */                   \
-    /* and provides much better precision for int64 than float (24-bit mantissa).                     */                  \
-    /* Note: cuDNN handles summation order internally, so Kahan compensation is not applicable here.  */                  \
-    /* For int64 values > 2^53, precision loss during accumulation is inherent to cuDNN's approach.   */                  \
-    /* The double accumulator cannot overflow: even INT64_MAX^2 * N needs > 10^270 elements.         */                   \
+    /* Use double for integer reductions to avoid integer overflow UB and improve precision.       */                     \
+    /* double's 53-bit mantissa: int32 values are exactly representable, but their squares         */                     \
+    /* (up to ~2^62) may exceed 53 bits and lose precision for large values. Still, double         */                     \
+    /* provides vastly better precision than float (24-bit mantissa) for all integer types.        */                     \
+    /* Note: cuDNN handles summation order internally, so Kahan compensation is not applicable.    */                     \
+    /* For int64 values > 2^53, precision loss during accumulation is inherent to cuDNN's design.  */                     \
+    /* The double accumulator cannot overflow: even INT64_MAX^2 * N needs > 10^270 elements.      */                      \
     cudnnDataType_t cudnn_type_X = CUDNN_DATA_DOUBLE;                                                                     \
     IAllocatorUniquePtr<double> temp_X = GetScratchBuffer<double>(input_count, GetComputeStream(ctx));                    \
     Impl_Cast<CudaT, double>(Stream(ctx), reinterpret_cast<const CudaT*>(X->Data<T>()), temp_X.get(), X->Shape().Size()); \
@@ -831,14 +833,11 @@ Status ReduceKernel<allow_multi_axes>::ComputeImpl(OpKernelContext* ctx, cudnnRe
     CUDNN_RETURN_IF_ERROR(cudnnReduceTensor(GetCudnnHandle(ctx), reduce_desc, indices_cuda.get(), indices_bytes,          \
                                             workspace_cuda.get(), workspace_bytes, &one, input_tensor, temp_X.get(),      \
                                             &zero, output_tensor, temp_Y.get()));                                         \
-    /* Cast double result back to integer type. CUDA's PTX cvt instruction (used by             */                        \
-    /* static_cast in device code) provides saturating semantics for float→int conversions:      */                       \
-    /*   - double values > numeric_limits<T>::max() → T_MAX                                     */                        \
-    /*   - double values < numeric_limits<T>::min() → T_MIN                                     */                        \
-    /*   - NaN → 0                                                                              */                        \
-    /* This matches the CPU side's explicit clamping behavior. See PTX ISA docs:                 */                       \
-    /* "For float-to-integer conversions, cvt.sat clips values to the range of the dest type."  */                        \
-    Impl_Cast<double, CudaT>(Stream(ctx), temp_Y.get(), reinterpret_cast<CudaT*>(Y->MutableData<T>()), output_count);     \
+    /* Cast double result back to integer with explicit saturation (clamping to [T_MIN, T_MAX]).    */                    \
+    /* A plain C++ cast from double to int is UB when out of range ([conv.fpint]/1). We use a     */                      \
+    /* dedicated saturating kernel that clamps before casting, matching the CPU's explicit logic.  */                     \
+    Impl_SaturatingCastFromDouble<CudaT>(Stream(ctx), temp_Y.get(),                                                       \
+                                         reinterpret_cast<CudaT*>(Y->MutableData<T>()), output_count);                    \
                                                                                                                           \
     return Status::OK();                                                                                                  \
   }
@@ -847,18 +846,20 @@ Status ReduceKernel<allow_multi_axes>::ComputeImpl(OpKernelContext* ctx, cudnnRe
 // cuDNN does not natively support integer tensor reductions, so the strategy is:
 //   1. Cast integer input → double (device kernel via Impl_Cast)
 //   2. Perform cuDNN reduction in double precision (CUDNN_DATA_DOUBLE)
-//   3. Cast double result → integer (device kernel via Impl_Cast, with PTX saturation)
+//   3. Cast double result → integer (device kernel via Impl_SaturatingCastFromDouble)
 //
 // Why double and not float?
-//   - double (53-bit mantissa) makes int32 arithmetic exact during reduction.
+//   - double avoids integer overflow UB and provides much better precision for all int types.
+//   - int32 values are exactly representable in double; their squares (up to ~2^62) may lose
+//     precision for |v| > 2^26, but this is at most 1 ULP error — far better than overflow.
 //   - float (24-bit mantissa) loses precision for int32 values > 16M and any int64 values.
 //   - For int64 values > 2^53, precision loss remains inherent (same limitation as CPU).
-//   - Memory cost: 2× scratch buffer vs float — acceptable for integer reductions (rare in practice).
+//   - Memory cost: 2× scratch buffer vs float — acceptable for integer reductions (rare).
 //
 // Saturation behavior:
-//   - When the reduction result exceeds the integer type's range (e.g., L2 norm of INT_MIN,
-//     or large summations), CUDA's PTX cvt instruction saturates to T_MAX/T_MIN rather than
-//     wrapping. This matches the CPU's explicit clamping logic.
+//   - Impl_SaturatingCastFromDouble explicitly clamps to [T_MIN, T_MAX] before casting,
+//     avoiding the undefined behavior of out-of-range double→int conversions in C++.
+//   - This matches the CPU's explicit clamping logic in ReduceAggregatorL1/L2.
 SPECIALIZED_REDUCEKERNEL_COMPUTEIMPL(int32_t)
 SPECIALIZED_REDUCEKERNEL_COMPUTEIMPL(int64_t)
 SPECIALIZED_REDUCEKERNEL_COMPUTEIMPL(int8_t)

--- a/onnxruntime/core/providers/cuda/reduction/reduction_ops.cc
+++ b/onnxruntime/core/providers/cuda/reduction/reduction_ops.cc
@@ -806,9 +806,14 @@ Status ReduceKernel<allow_multi_axes>::ComputeImpl(OpKernelContext* ctx, cudnnRe
     CudnnTensor output_tensor;                                                                                            \
     CudnnReduceDescriptor reduce_desc;                                                                                    \
                                                                                                                           \
-    cudnnDataType_t cudnn_type_X = CUDNN_DATA_FLOAT;                                                                      \
-    IAllocatorUniquePtr<float> temp_X = GetScratchBuffer<float>(input_count, GetComputeStream(ctx));                      \
-    Impl_Cast<CudaT, float>(Stream(ctx), reinterpret_cast<const CudaT*>(X->Data<T>()), temp_X.get(), X->Shape().Size());  \
+    /* Use double for integer reductions: 53-bit mantissa makes int32 squaring/summation exact,      */                   \
+    /* and provides much better precision for int64 than float (24-bit mantissa).                     */                  \
+    /* Note: cuDNN handles summation order internally, so Kahan compensation is not applicable here.  */                  \
+    /* For int64 values > 2^53, precision loss during accumulation is inherent to cuDNN's approach.   */                  \
+    /* The double accumulator cannot overflow: even INT64_MAX^2 * N needs > 10^270 elements.         */                   \
+    cudnnDataType_t cudnn_type_X = CUDNN_DATA_DOUBLE;                                                                     \
+    IAllocatorUniquePtr<double> temp_X = GetScratchBuffer<double>(input_count, GetComputeStream(ctx));                    \
+    Impl_Cast<CudaT, double>(Stream(ctx), reinterpret_cast<const CudaT*>(X->Data<T>()), temp_X.get(), X->Shape().Size()); \
                                                                                                                           \
     ORT_RETURN_IF_ERROR(reduce_desc.Set(cudnn_reduce_op, cudnn_type_X, CUDNN_REDUCE_TENSOR_NO_INDICES));                  \
     ORT_RETURN_IF_ERROR(input_tensor.Set(input_dims_cudnn, cudnn_type_X));                                                \
@@ -820,17 +825,40 @@ Status ReduceKernel<allow_multi_axes>::ComputeImpl(OpKernelContext* ctx, cudnnRe
     IAllocatorUniquePtr<void> indices_cuda = GetScratchBuffer<void>(indices_bytes, GetComputeStream(ctx));                \
     IAllocatorUniquePtr<void> workspace_cuda = GetScratchBuffer<void>(workspace_bytes, GetComputeStream(ctx));            \
                                                                                                                           \
-    const auto one = Consts<float>::One;                                                                                  \
-    const auto zero = Consts<float>::Zero;                                                                                \
-    auto temp_Y = GetScratchBuffer<float>(output_count, GetComputeStream(ctx));                                           \
+    const auto one = Consts<double>::One;                                                                                 \
+    const auto zero = Consts<double>::Zero;                                                                               \
+    auto temp_Y = GetScratchBuffer<double>(output_count, GetComputeStream(ctx));                                          \
     CUDNN_RETURN_IF_ERROR(cudnnReduceTensor(GetCudnnHandle(ctx), reduce_desc, indices_cuda.get(), indices_bytes,          \
                                             workspace_cuda.get(), workspace_bytes, &one, input_tensor, temp_X.get(),      \
                                             &zero, output_tensor, temp_Y.get()));                                         \
-    Impl_Cast<float, CudaT>(Stream(ctx), temp_Y.get(), reinterpret_cast<CudaT*>(Y->MutableData<T>()), output_count);      \
+    /* Cast double result back to integer type. CUDA's PTX cvt instruction (used by             */                        \
+    /* static_cast in device code) provides saturating semantics for float→int conversions:      */                       \
+    /*   - double values > numeric_limits<T>::max() → T_MAX                                     */                        \
+    /*   - double values < numeric_limits<T>::min() → T_MIN                                     */                        \
+    /*   - NaN → 0                                                                              */                        \
+    /* This matches the CPU side's explicit clamping behavior. See PTX ISA docs:                 */                       \
+    /* "For float-to-integer conversions, cvt.sat clips values to the range of the dest type."  */                        \
+    Impl_Cast<double, CudaT>(Stream(ctx), temp_Y.get(), reinterpret_cast<CudaT*>(Y->MutableData<T>()), output_count);     \
                                                                                                                           \
     return Status::OK();                                                                                                  \
   }
 
+// Integer reduction specializations.
+// cuDNN does not natively support integer tensor reductions, so the strategy is:
+//   1. Cast integer input → double (device kernel via Impl_Cast)
+//   2. Perform cuDNN reduction in double precision (CUDNN_DATA_DOUBLE)
+//   3. Cast double result → integer (device kernel via Impl_Cast, with PTX saturation)
+//
+// Why double and not float?
+//   - double (53-bit mantissa) makes int32 arithmetic exact during reduction.
+//   - float (24-bit mantissa) loses precision for int32 values > 16M and any int64 values.
+//   - For int64 values > 2^53, precision loss remains inherent (same limitation as CPU).
+//   - Memory cost: 2× scratch buffer vs float — acceptable for integer reductions (rare in practice).
+//
+// Saturation behavior:
+//   - When the reduction result exceeds the integer type's range (e.g., L2 norm of INT_MIN,
+//     or large summations), CUDA's PTX cvt instruction saturates to T_MAX/T_MIN rather than
+//     wrapping. This matches the CPU's explicit clamping logic.
 SPECIALIZED_REDUCEKERNEL_COMPUTEIMPL(int32_t)
 SPECIALIZED_REDUCEKERNEL_COMPUTEIMPL(int64_t)
 SPECIALIZED_REDUCEKERNEL_COMPUTEIMPL(int8_t)

--- a/onnxruntime/test/providers/cpu/reduction/reduction_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/reduction/reduction_ops_test.cc
@@ -600,7 +600,8 @@ TEST(ReductionOpTest, ReduceL2_int32_squaring_overflow) {
   // sqrt(50000^2 + 50000^2) = 50000*sqrt(2) ≈ 70710
   test.AddInput<int32_t>("data", {2}, {50000, 50000});
   test.AddOutput<int32_t>("reduced", {}, {70710});
-  // Both CPU and CUDA use double accumulator, so squaring is exact for int32.
+  // Both CPU and CUDA use double accumulator to avoid integer overflow UB.
+  // For these test values (50000^2 = 2.5e9 < 2^53), squaring is exact in double.
   test.Run(OpTester::ExpectResult::kExpectSuccess, "",
            {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
 }

--- a/onnxruntime/test/providers/cpu/reduction/reduction_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/reduction/reduction_ops_test.cc
@@ -423,6 +423,30 @@ TEST(ReductionOpTest, ReduceL1_int32_keepdims_singleton_axis_negative_input) {
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
 }
 
+// INT_MIN abs is UB in two's complement; saturating_abs should clamp to INT_MAX.
+TEST(ReductionOpTest, ReduceL1_int32_INT_MIN) {
+  OpTester test("ReduceL1");
+  test.AddAttribute("axes", std::vector<int64_t>{0});
+  test.AddAttribute("keepdims", static_cast<int64_t>(0));
+  test.AddInput<int32_t>("data", {1}, {std::numeric_limits<int32_t>::min()});
+  // abs(INT_MIN) overflows; we expect saturation to INT_MAX.
+  test.AddOutput<int32_t>("reduced", {}, {std::numeric_limits<int32_t>::max()});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+}
+
+// Summation overflow: summing large positive values should saturate to INT_MAX rather than wrap.
+TEST(ReductionOpTest, ReduceL1_int32_summation_overflow) {
+  OpTester test("ReduceL1");
+  test.AddAttribute("axes", std::vector<int64_t>{0});
+  test.AddAttribute("keepdims", static_cast<int64_t>(0));
+  // 3 * 1,000,000,000 = 3e9 > INT32_MAX (2,147,483,647)
+  test.AddInput<int32_t>("data", {3}, {1000000000, 1000000000, 1000000000});
+  test.AddOutput<int32_t>("reduced", {}, {std::numeric_limits<int32_t>::max()});
+  // Only CPU handles saturation; CUDA casts to float (loses precision but doesn't overflow).
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "",
+           {kTensorrtExecutionProvider, kCudaExecutionProvider, kRocmExecutionProvider});
+}
+
 TEST(ReductionOpTest, ReduceL2_default_axes_keepdims) {
   OpTester test("ReduceL2");
   test.AddAttribute("keepdims", (int64_t)1);
@@ -552,6 +576,31 @@ TEST(ReductionOpTest, ReduceL2_int32_keepdims_singleton_axis_negative_input) {
   // TensorRT/OpenVINO do not support int32 ReduceL2.
   test.Run(OpTester::ExpectResult::kExpectSuccess, "",
            {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
+}
+
+// INT_MIN: sqrt(INT_MIN^2) overflows; should saturate to INT_MAX.
+TEST(ReductionOpTest, ReduceL2_int32_INT_MIN) {
+  OpTester test("ReduceL2");
+  test.AddAttribute("axes", std::vector<int64_t>{0});
+  test.AddAttribute("keepdims", static_cast<int64_t>(0));
+  test.AddInput<int32_t>("data", {1}, {std::numeric_limits<int32_t>::min()});
+  // sqrt(INT_MIN^2) = |INT_MIN| which overflows int32; saturate to INT_MAX.
+  test.AddOutput<int32_t>("reduced", {}, {std::numeric_limits<int32_t>::max()});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "",
+           {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
+}
+
+// Squaring overflow: large values squared exceed int32 range; double accumulator avoids UB.
+TEST(ReductionOpTest, ReduceL2_int32_squaring_overflow) {
+  OpTester test("ReduceL2");
+  test.AddAttribute("axes", std::vector<int64_t>{0});
+  test.AddAttribute("keepdims", static_cast<int64_t>(0));
+  // sqrt(50000^2 + 50000^2) = 50000*sqrt(2) ≈ 70710
+  test.AddInput<int32_t>("data", {2}, {50000, 50000});
+  test.AddOutput<int32_t>("reduced", {}, {70710});
+  // Only CPU handles this precisely with double accumulator.
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "",
+           {kTensorrtExecutionProvider, kOpenVINOExecutionProvider, kCudaExecutionProvider, kRocmExecutionProvider});
 }
 
 TEST(ReductionOpTest, ReduceL2_keepdims) {

--- a/onnxruntime/test/providers/cpu/reduction/reduction_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/reduction/reduction_ops_test.cc
@@ -347,6 +347,75 @@ TEST(ReductionOpTest, ReduceL10DTensor) {
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
 }
 
+TEST(ReductionOpTest, ReduceL1_int32_singleton_axis_negative_input) {
+  OpTester test("ReduceL1");
+  test.AddAttribute("axes", std::vector<int64_t>{0});
+  test.AddAttribute("keepdims", static_cast<int64_t>(0));
+  test.AddInput<int32_t>("data", {1, 1}, {-4});
+  test.AddOutput<int32_t>("reduced", {1}, {4});
+  // TensorRT does not support int32 ReduceL1.
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+}
+
+TEST(ReductionOpTest, ReduceL1_int64_singleton_axis_negative_input) {
+  OpTester test("ReduceL1");
+  test.AddAttribute("axes", std::vector<int64_t>{0});
+  test.AddAttribute("keepdims", static_cast<int64_t>(0));
+  test.AddInput<int64_t>("data", {1, 1}, {-4});
+  test.AddOutput<int64_t>("reduced", {1}, {4});
+  // TensorRT does not support int64 ReduceL1.
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+}
+
+TEST(ReductionOpTest, ReduceL1_float_singleton_axis_negative_input) {
+  OpTester test("ReduceL1");
+  test.AddAttribute("axes", std::vector<int64_t>{0});
+  test.AddAttribute("keepdims", static_cast<int64_t>(0));
+  test.AddInput<float>("data", {1, 1}, {-4.0f});
+  test.AddOutput<float>("reduced", {1}, {4.0f});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+}
+
+TEST(ReductionOpTest, ReduceL1_double_singleton_axis_negative_input) {
+  OpTester test("ReduceL1");
+  test.AddAttribute("axes", std::vector<int64_t>{0});
+  test.AddAttribute("keepdims", static_cast<int64_t>(0));
+  test.AddInput<double>("data", {1, 1}, {-4.0});
+  test.AddOutput<double>("reduced", {1}, {4.0});
+  // TensorRT does not support double ReduceL1.
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+}
+
+#if defined(USE_CUDA)
+TEST(ReductionOpTest, ReduceL1_half_singleton_axis_negative_input) {
+  OpTester test("ReduceL1");
+  test.AddAttribute("axes", std::vector<int64_t>{0});
+  test.AddAttribute("keepdims", static_cast<int64_t>(0));
+  test.AddInput<MLFloat16>("data", {1, 1}, FloatsToMLFloat16s({-4.0f}));
+  test.AddOutput<MLFloat16>("reduced", {1}, FloatsToMLFloat16s({4.0f}));
+  test.Run();
+}
+#endif
+
+TEST(ReductionOpTest, ReduceL1_float_multi_element_all_negative) {
+  OpTester test("ReduceL1");
+  test.AddAttribute("axes", std::vector<int64_t>{0});
+  test.AddAttribute("keepdims", static_cast<int64_t>(0));
+  test.AddInput<float>("data", {3, 2}, {-1.0f, -2.0f, -3.0f, -4.0f, -5.0f, -6.0f});
+  test.AddOutput<float>("reduced", {2}, {9.0f, 12.0f});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+}
+
+TEST(ReductionOpTest, ReduceL1_int32_keepdims_singleton_axis_negative_input) {
+  OpTester test("ReduceL1");
+  test.AddAttribute("axes", std::vector<int64_t>{0});
+  test.AddAttribute("keepdims", static_cast<int64_t>(1));
+  test.AddInput<int32_t>("data", {1, 2}, {-3, -7});
+  test.AddOutput<int32_t>("reduced", {1, 2}, {3, 7});
+  // TensorRT does not support int32 ReduceL1.
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+}
+
 TEST(ReductionOpTest, ReduceL2_default_axes_keepdims) {
   OpTester test("ReduceL2");
   test.AddAttribute("keepdims", (int64_t)1);
@@ -404,6 +473,78 @@ TEST(ReductionOpTest, ReduceL2_do_not_keepdims_2) {
                        {1.0f, 2.0f, 3.0f});
   test.AddOutput<float>("reduced", {}, {3.741657387f});
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});  // TensorRT: full reduce without keepDimensions is not supported with explicit batch
+}
+
+TEST(ReductionOpTest, ReduceL2_singleton_axis_negative_input) {
+  OpTester test("ReduceL2");
+  test.AddAttribute("axes", std::vector<int64_t>{0});
+  test.AddAttribute("keepdims", static_cast<int64_t>(0));
+  test.AddInput<float>("data", {1, 1}, {-4.0f});
+  test.AddOutput<float>("reduced", {1}, {4.0f});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+}
+
+TEST(ReductionOpTest, ReduceL2_double_singleton_axis_negative_input) {
+  OpTester test("ReduceL2");
+  test.AddAttribute("axes", std::vector<int64_t>{0});
+  test.AddAttribute("keepdims", static_cast<int64_t>(0));
+  test.AddInput<double>("data", {1, 1}, {-4.0});
+  test.AddOutput<double>("reduced", {1}, {4.0});
+  // TensorRT does not support double ReduceL2.
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+}
+
+TEST(ReductionOpTest, ReduceL2_int32_singleton_axis_negative_input) {
+  OpTester test("ReduceL2");
+  test.AddAttribute("axes", std::vector<int64_t>{0});
+  test.AddAttribute("keepdims", static_cast<int64_t>(0));
+  test.AddInput<int32_t>("data", {1, 1}, {-4});
+  test.AddOutput<int32_t>("reduced", {1}, {4});
+  // TensorRT/OpenVINO do not support int32 ReduceL2.
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "",
+           {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
+}
+
+#if defined(USE_CUDA)
+TEST(ReductionOpTest, ReduceL2_half_singleton_axis_negative_input) {
+  OpTester test("ReduceL2");
+  test.AddAttribute("axes", std::vector<int64_t>{0});
+  test.AddAttribute("keepdims", static_cast<int64_t>(0));
+  test.AddInput<MLFloat16>("data", {1, 1}, FloatsToMLFloat16s({-4.0f}));
+  test.AddOutput<MLFloat16>("reduced", {1}, FloatsToMLFloat16s({4.0f}));
+  test.Run();
+}
+#endif
+
+TEST(ReductionOpTest, ReduceL2_float_multi_element_all_negative) {
+  OpTester test("ReduceL2");
+  test.AddAttribute("axes", std::vector<int64_t>{0});
+  test.AddAttribute("keepdims", static_cast<int64_t>(0));
+  // sqrt((-1)^2 + (-3)^2 + (-5)^2) = sqrt(35) ≈ 5.916
+  // sqrt((-2)^2 + (-4)^2 + (-6)^2) = sqrt(56) ≈ 7.483
+  test.AddInput<float>("data", {3, 2}, {-1.0f, -2.0f, -3.0f, -4.0f, -5.0f, -6.0f});
+  test.AddOutput<float>("reduced", {2}, {5.91607978f, 7.48331477f});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+}
+
+TEST(ReductionOpTest, ReduceL2_float_keepdims_singleton_axis_negative_input) {
+  OpTester test("ReduceL2");
+  test.AddAttribute("axes", std::vector<int64_t>{0});
+  test.AddAttribute("keepdims", static_cast<int64_t>(1));
+  test.AddInput<float>("data", {1, 2}, {-3.0f, -7.0f});
+  test.AddOutput<float>("reduced", {1, 2}, {3.0f, 7.0f});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+}
+
+TEST(ReductionOpTest, ReduceL2_int32_keepdims_singleton_axis_negative_input) {
+  OpTester test("ReduceL2");
+  test.AddAttribute("axes", std::vector<int64_t>{0});
+  test.AddAttribute("keepdims", static_cast<int64_t>(1));
+  test.AddInput<int32_t>("data", {1, 2}, {-3, -7});
+  test.AddOutput<int32_t>("reduced", {1, 2}, {3, 7});
+  // TensorRT/OpenVINO do not support int32 ReduceL2.
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "",
+           {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
 }
 
 TEST(ReductionOpTest, ReduceL2_keepdims) {

--- a/onnxruntime/test/providers/cpu/reduction/reduction_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/reduction/reduction_ops_test.cc
@@ -347,6 +347,13 @@ TEST(ReductionOpTest, ReduceL10DTensor) {
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
 }
 
+TEST(ReductionOpTest, ReduceL1_0DTensor_negative_input) {
+  OpTester test("ReduceL1");
+  test.AddInput<float>("data", {}, {-3.0f});
+  test.AddOutput<float>("reduced", {}, {3.0f});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+}
+
 TEST(ReductionOpTest, ReduceL1_int32_singleton_axis_negative_input) {
   OpTester test("ReduceL1");
   test.AddAttribute("axes", std::vector<int64_t>{0});
@@ -665,6 +672,13 @@ TEST(ReductionOpTest, ReduceL20DTensor) {
   OpTester test("ReduceL2");
   test.AddInput<float>("data", {}, {2});
   test.AddOutput<float>("reduced", {}, {2});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+}
+
+TEST(ReductionOpTest, ReduceL2_0DTensor_negative_input) {
+  OpTester test("ReduceL2");
+  test.AddInput<float>("data", {}, {-5.0f});
+  test.AddOutput<float>("reduced", {}, {5.0f});
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
 }
 

--- a/onnxruntime/test/providers/cpu/reduction/reduction_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/reduction/reduction_ops_test.cc
@@ -431,7 +431,9 @@ TEST(ReductionOpTest, ReduceL1_int32_INT_MIN) {
   test.AddInput<int32_t>("data", {1}, {std::numeric_limits<int32_t>::min()});
   // abs(INT_MIN) overflows; we expect saturation to INT_MAX.
   test.AddOutput<int32_t>("reduced", {}, {std::numeric_limits<int32_t>::max()});
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+  // Exclude EPs that may not implement the CPU's saturating INT_MIN behavior.
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "",
+           {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
 }
 
 // Summation overflow: summing large positive values should saturate to INT_MAX rather than wrap.
@@ -442,9 +444,9 @@ TEST(ReductionOpTest, ReduceL1_int32_summation_overflow) {
   // 3 * 1,000,000,000 = 3e9 > INT32_MAX (2,147,483,647)
   test.AddInput<int32_t>("data", {3}, {1000000000, 1000000000, 1000000000});
   test.AddOutput<int32_t>("reduced", {}, {std::numeric_limits<int32_t>::max()});
-  // Only CPU handles saturation; CUDA casts to float (loses precision but doesn't overflow).
+  // CUDA now uses double accumulation (same as CPU), so saturation matches.
   test.Run(OpTester::ExpectResult::kExpectSuccess, "",
-           {kTensorrtExecutionProvider, kCudaExecutionProvider, kRocmExecutionProvider});
+           {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
 }
 
 TEST(ReductionOpTest, ReduceL2_default_axes_keepdims) {
@@ -598,9 +600,9 @@ TEST(ReductionOpTest, ReduceL2_int32_squaring_overflow) {
   // sqrt(50000^2 + 50000^2) = 50000*sqrt(2) ≈ 70710
   test.AddInput<int32_t>("data", {2}, {50000, 50000});
   test.AddOutput<int32_t>("reduced", {}, {70710});
-  // Only CPU handles this precisely with double accumulator.
+  // Both CPU and CUDA use double accumulator, so squaring is exact for int32.
   test.Run(OpTester::ExpectResult::kExpectSuccess, "",
-           {kTensorrtExecutionProvider, kOpenVINOExecutionProvider, kCudaExecutionProvider, kRocmExecutionProvider});
+           {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
 }
 
 TEST(ReductionOpTest, ReduceL2_keepdims) {

--- a/onnxruntime/test/providers/cpu/reduction/reduction_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/reduction/reduction_ops_test.cc
@@ -433,7 +433,7 @@ TEST(ReductionOpTest, ReduceL1_int32_INT_MIN) {
   test.AddOutput<int32_t>("reduced", {}, {std::numeric_limits<int32_t>::max()});
   // Exclude EPs that may not implement the CPU's saturating INT_MIN behavior.
   test.Run(OpTester::ExpectResult::kExpectSuccess, "",
-           {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
+           {kTensorrtExecutionProvider, kOpenVINOExecutionProvider, kDmlExecutionProvider, kWebGpuExecutionProvider});
 }
 
 // Summation overflow: summing large positive values should saturate to INT_MAX rather than wrap.
@@ -446,7 +446,7 @@ TEST(ReductionOpTest, ReduceL1_int32_summation_overflow) {
   test.AddOutput<int32_t>("reduced", {}, {std::numeric_limits<int32_t>::max()});
   // CUDA now uses double accumulation (same as CPU), so saturation matches.
   test.Run(OpTester::ExpectResult::kExpectSuccess, "",
-           {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
+           {kTensorrtExecutionProvider, kOpenVINOExecutionProvider, kDmlExecutionProvider, kWebGpuExecutionProvider});
 }
 
 TEST(ReductionOpTest, ReduceL2_default_axes_keepdims) {
@@ -589,7 +589,7 @@ TEST(ReductionOpTest, ReduceL2_int32_INT_MIN) {
   // sqrt(INT_MIN^2) = |INT_MIN| which overflows int32; saturate to INT_MAX.
   test.AddOutput<int32_t>("reduced", {}, {std::numeric_limits<int32_t>::max()});
   test.Run(OpTester::ExpectResult::kExpectSuccess, "",
-           {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
+           {kTensorrtExecutionProvider, kOpenVINOExecutionProvider, kDmlExecutionProvider, kWebGpuExecutionProvider});
 }
 
 // Squaring overflow: large values squared exceed int32 range; double accumulator avoids UB.
@@ -603,7 +603,7 @@ TEST(ReductionOpTest, ReduceL2_int32_squaring_overflow) {
   // Both CPU and CUDA use double accumulator to avoid integer overflow UB.
   // For these test values (50000^2 = 2.5e9 < 2^53), squaring is exact in double.
   test.Run(OpTester::ExpectResult::kExpectSuccess, "",
-           {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
+           {kTensorrtExecutionProvider, kOpenVINOExecutionProvider, kDmlExecutionProvider, kWebGpuExecutionProvider});
 }
 
 TEST(ReductionOpTest, ReduceL2_keepdims) {


### PR DESCRIPTION
This pull request significantly improves the numerical correctness and robustness of L1 and L2 reduction operations (norms) for integer types on both CPU and CUDA backends. The main changes address integer overflow, undefined behavior, and precision loss in norm calculations, especially for edge cases like minimum representable integers and large accumulations. The changes also ensure consistency between CPU and CUDA implementations, and add detailed documentation for future maintainability.

**Numerical correctness and overflow handling for integer norm reductions:**

* On CPU, L1 and L2 reductions (`ReduceAggregatorL1` and `ReduceAggregatorL2` in `reduction_ops.h`) now accumulate in double precision to avoid integer overflow and undefined behavior, with Kahan summation for int64+ to minimize precision loss. Results are clamped to the maximum representable value to prevent overflow. [[1]](diffhunk://#diff-ca0c9224442a3c46251b0fb7326aacc1469bdee20ab409b930556f439d560015R722-R805) [[2]](diffhunk://#diff-ca0c9224442a3c46251b0fb7326aacc1469bdee20ab409b930556f439d560015R814-R893)
* Introduced a `saturating_abs` function on CPU and a device-side `Impl_SaturatingAbs` kernel on CUDA to safely compute the absolute value for signed integer types, clamping to `max()` if `abs(min())` would overflow. [[1]](diffhunk://#diff-ca0c9224442a3c46251b0fb7326aacc1469bdee20ab409b930556f439d560015R722-R805) [[2]](diffhunk://#diff-f7138acd21464814d1793c9d334bee07d0cbe69719691e67efe3b2e23e4d06c7R516-R566) [[3]](diffhunk://#diff-945ab1deb57e1ff44b790cb2054537c252e23b7c7c374f44da66475361910abdR110-R119)

**CUDA backend improvements and consistency:**

* For integer reductions on CUDA, the input is cast to double before reduction, and the result is cast back to integer with saturating semantics (using PTX `cvt.sat`), matching the CPU's explicit clamping. This avoids precision loss and undefined behavior.
* For no-op reductions (where input and output counts are equal), norm operations now use the saturating absolute value kernel to ensure non-negative results, even for edge-case values like `INT_MIN`. [[1]](diffhunk://#diff-ee5316fc3898058f70e942d9a84de36be4c7da09f144633a2504236430d5d033L209-R217) [[2]](diffhunk://#diff-ee5316fc3898058f70e942d9a84de36be4c7da09f144633a2504236430d5d033L592-R607) [[3]](diffhunk://#diff-ee5316fc3898058f70e942d9a84de36be4c7da09f144633a2504236430d5d033L778-R794)

**Documentation and maintainability:**

* Added detailed comments explaining the rationale and numerical properties of the new implementations, including why double precision is used, the limitations of float, and the behavior for large reductions and edge cases. [[1]](diffhunk://#diff-ca0c9224442a3c46251b0fb7326aacc1469bdee20ab409b930556f439d560015R722-R805) [[2]](diffhunk://#diff-ca0c9224442a3c46251b0fb7326aacc1469bdee20ab409b930556f439d560015R814-R893) [[3]](diffhunk://#diff-f7138acd21464814d1793c9d334bee07d0cbe69719691e67efe3b2e23e4d06c7R516-R566) [[4]](diffhunk://#diff-ee5316fc3898058f70e942d9a84de36be4c7da09f144633a2504236430d5d033L807-R861)

These changes make norm reductions for integer types safe, mathematically correct, and consistent across CPU and CUDA, even for extreme or previously problematic inputs.