### PR TITLE
Update protobuf version to 6.33.5

### DIFF
--- a/tools/ci_build/github/linux/docker/inference/aarch64/python/cpu/scripts/requirements.txt
+++ b/tools/ci_build/github/linux/docker/inference/aarch64/python/cpu/scripts/requirements.txt
@@ -4,7 +4,7 @@ mypy
 pytest
 setuptools>=68.2.2
 wheel
-protobuf==4.25.8
+protobuf==5.29.6
 sympy==1.14
 flatbuffers
 onnx==1.21.0

--- a/tools/ci_build/github/linux/docker/scripts/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/requirements.txt
@@ -8,7 +8,7 @@ wheel==0.45.1
 argparse
 sympy==1.14
 flatbuffers
-protobuf==6.33.0
+protobuf==6.33.5
 packaging
 onnxscript==0.6.2
 onnx-ir==0.1.16

--- a/tools/ci_build/github/windows/python/requirements.txt
+++ b/tools/ci_build/github/windows/python/requirements.txt
@@ -4,7 +4,7 @@ mypy
 pytest
 setuptools>=68.2.2
 wheel
-protobuf==6.33.0
+protobuf==6.33.5
 sympy==1.14
 flatbuffers
 psutil

--- a/tools/ci_build/requirements/transformers-test/requirements.txt
+++ b/tools/ci_build/requirements/transformers-test/requirements.txt
@@ -1,7 +1,7 @@
 # packages used by transformers python unittest
 packaging
 # protobuf and numpy is same as tools/ci_build/github/linux/docker/scripts/manylinux/requirements.txt
-protobuf==6.33.0
+protobuf==6.33.5
 numpy==2.2.6; python_version < "3.11"
 numpy==2.4.2; python_version >= "3.11"
 torch==2.10.0


### PR DESCRIPTION
### Description
We have internal alerts asking to update protobuf version in response to CVE-2026-0994.

The alert asks 
tools/ci_build/github/linux/docker/inference/aarch64/python/cpu/scripts/requirements.txt
to be updated to 5.29.6
while the rest are asked to be set to 6.33.5.
