### PR TITLE
Add explicit CUDA version suffix to GPU release artifacts

### DIFF
--- a/tools/ci_build/github/azure-pipelines/stages/nuget-linux-cuda-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/nuget-linux-cuda-packaging-stage.yml
@@ -214,8 +214,10 @@ stages:
         script: |
           docker run -e SYSTEM_COLLECTIONURI --gpus all -e CFLAGS="-Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fstack-protector-strong -fstack-clash-protection -fcf-protection -O3 -Wl,--strip-all" -e CXXFLAGS="-Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fstack-protector-strong -fstack-clash-protection -fcf-protection -O3 -Wl,--strip-all" -e NVIDIA_VISIBLE_DEVICES=all --rm --volume /data/models:/data/models --volume $(Build.SourcesDirectory):/src_dir \
           --volume $(Build.ArtifactStagingDirectory):/artifact_src -e NIGHTLY_BUILD onnxruntimecuda${{ variables.CUDA_VERSION_MAJOR }}xtrt86build \
-          /src_dir/onnxruntime-inference-examples/c_cxx/squeezenet/run_capi_application.sh -o /src_dir/onnxruntime -p /artifact_src/onnxruntime-linux-x64-gpu_cuda$(CUDA_VERSION_MAJOR)-$(OnnxRuntimeVersion).tgz -w /src_dir/onnxruntime-inference-examples/c_cxx/squeezenet
+          /src_dir/onnxruntime-inference-examples/c_cxx/squeezenet/run_capi_application.sh -o /src_dir/onnxruntime -p /artifact_src/onnxruntime-linux-x64-gpu_cuda${CUDA_VERSION_MAJOR}-$(OnnxRuntimeVersion).tgz -w /src_dir/onnxruntime-inference-examples/c_cxx/squeezenet
         workingDirectory: '$(Build.ArtifactStagingDirectory)'
+      env:
+        CUDA_VERSION_MAJOR: $(CUDA_VERSION_MAJOR)
 
     - task: 1ES.PublishPipelineArtifact@1
       inputs:

--- a/tools/ci_build/github/azure-pipelines/stages/nuget-linux-cuda-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/nuget-linux-cuda-packaging-stage.yml
@@ -183,23 +183,23 @@ stages:
       displayName: 'Shell Script'
       inputs:
         scriptPath: 'onnxruntime/tools/ci_build/github/linux/extract_and_bundle_gpu_package.sh'
-        args: '-a $(Build.BinariesDirectory)/tgz-artifacts'
+        args: '-a $(Build.BinariesDirectory)/tgz-artifacts -c $(CUDA_VERSION_MAJOR)'
         workingDirectory: '$(Build.BinariesDirectory)/tgz-artifacts'
 
     - task: ArchiveFiles@2
       inputs:
-        rootFolderOrFile: '$(Build.BinariesDirectory)/tgz-artifacts/onnxruntime-linux-x64-gpu'
+        rootFolderOrFile: '$(Build.BinariesDirectory)/tgz-artifacts/onnxruntime-linux-x64-gpu_cuda$(CUDA_VERSION_MAJOR)'
         includeRootFolder: false
         archiveType: 'tar' # Options: zip, 7z, tar, wim
         tarCompression: 'gz'
-        archiveFile: '$(Build.ArtifactStagingDirectory)/onnxruntime-linux-x64-gpu-$(OnnxRuntimeVersion).tgz'
+        archiveFile: '$(Build.ArtifactStagingDirectory)/onnxruntime-linux-x64-gpu_cuda$(CUDA_VERSION_MAJOR)-$(OnnxRuntimeVersion).tgz'
         replaceExistingArchive: true
 
     - template: ../templates/validate-package.yml
       parameters:
         PackageType: 'tarball'
         PackagePath: '$(Build.ArtifactStagingDirectory)'
-        PackageName: 'onnxruntime-linux-x64-gpu-$(OnnxRuntimeVersion).tgz'
+        PackageName: 'onnxruntime-linux-x64-gpu_cuda$(CUDA_VERSION_MAJOR)-$(OnnxRuntimeVersion).tgz'
         ScriptPath: '$(Build.SourcesDirectory)/onnxruntime/tools/nuget/validate_package.py'
         PlatformsSupported: 'linux-x64'
         VerifyNugetSigning: false
@@ -214,10 +214,10 @@ stages:
         script: |
           docker run -e SYSTEM_COLLECTIONURI --gpus all -e CFLAGS="-Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fstack-protector-strong -fstack-clash-protection -fcf-protection -O3 -Wl,--strip-all" -e CXXFLAGS="-Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fstack-protector-strong -fstack-clash-protection -fcf-protection -O3 -Wl,--strip-all" -e NVIDIA_VISIBLE_DEVICES=all --rm --volume /data/models:/data/models --volume $(Build.SourcesDirectory):/src_dir \
           --volume $(Build.ArtifactStagingDirectory):/artifact_src -e NIGHTLY_BUILD onnxruntimecuda${{ variables.CUDA_VERSION_MAJOR }}xtrt86build \
-          /src_dir/onnxruntime-inference-examples/c_cxx/squeezenet/run_capi_application.sh -o /src_dir/onnxruntime -p /artifact_src/onnxruntime-linux-x64-gpu-$(OnnxRuntimeVersion).tgz -w /src_dir/onnxruntime-inference-examples/c_cxx/squeezenet
+          /src_dir/onnxruntime-inference-examples/c_cxx/squeezenet/run_capi_application.sh -o /src_dir/onnxruntime -p /artifact_src/onnxruntime-linux-x64-gpu_cuda$(CUDA_VERSION_MAJOR)-$(OnnxRuntimeVersion).tgz -w /src_dir/onnxruntime-inference-examples/c_cxx/squeezenet
         workingDirectory: '$(Build.ArtifactStagingDirectory)'
 
     - task: 1ES.PublishPipelineArtifact@1
       inputs:
         targetPath: '$(Build.ArtifactStagingDirectory)'
-        artifactName: 'onnxruntime-linux-x64-gpu'
+        artifactName: 'onnxruntime-linux-x64-gpu_cuda$(CUDA_VERSION_MAJOR)'

--- a/tools/ci_build/github/azure-pipelines/stages/nuget-win-cuda-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/nuget-win-cuda-packaging-stage.yml
@@ -122,6 +122,10 @@ stages:
     variables:
       CUDA_MODULE_LOADINGL: 'LAZY'
       GRADLE_OPTS: '-Dorg.gradle.daemon=false'
+      ${{ if eq(parameters.CudaVersion, '13.0') }}:
+        CUDA_VERSION_MAJOR: '13'
+      ${{ if eq(parameters.CudaVersion, '12.8') }}:
+        CUDA_VERSION_MAJOR: '12'
     steps:
     - checkout: self                           # due to checkout multiple repos, the root directory is $(Build.SourcesDirectory)/onnxruntime
     - checkout: onnxruntime-inference-examples # due to checkout multiple repos, the root directory is $(Build.SourcesDirectory)/onnxruntime-inference-examples
@@ -181,14 +185,14 @@ stages:
       displayName: 'Copy zip file to: $(Build.ArtifactStagingDirectory)'
       inputs:
         SourceFolder: '$(Build.BinariesDirectory)\zip-artifacts'
-        Contents: 'onnxruntime-win-x64-gpu-*.zip'
+        Contents: 'onnxruntime-win-x64-gpu_cuda*-*.zip'
         TargetFolder: '$(Build.ArtifactStagingDirectory)'
 
     - template: ../templates/validate-package.yml
       parameters:
         PackageType: 'zip'
         PackagePath: '$(Build.ArtifactStagingDirectory)'
-        PackageName: 'onnxruntime-win-x64-gpu-$(OnnxRuntimeVersion).zip'
+        PackageName: 'onnxruntime-win-x64-gpu_cuda$(CUDA_VERSION_MAJOR)-$(OnnxRuntimeVersion).zip'
         ScriptPath: '$(Build.SourcesDirectory)\onnxruntime\tools\nuget\validate_package.py'
         PlatformsSupported: 'win-x64'
         VerifyNugetSigning: false
@@ -200,11 +204,11 @@ stages:
       condition: and(succeeded(), ne(${{parameters.CudaVersion}}, '13.0'))
       inputs:
         filename: $(Build.SourcesDirectory)\onnxruntime-inference-examples\c_cxx\squeezenet\run_capi_application.bat
-        arguments: $(Build.SourcesDirectory)\onnxruntime $(Build.ArtifactStagingDirectory)\onnxruntime-win-x64-gpu-$(OnnxRuntimeVersion).zip $(Build.SourcesDirectory)\onnxruntime-inference-examples\c_cxx\squeezenet
+        arguments: $(Build.SourcesDirectory)\onnxruntime $(Build.ArtifactStagingDirectory)\onnxruntime-win-x64-gpu_cuda$(CUDA_VERSION_MAJOR)-$(OnnxRuntimeVersion).zip $(Build.SourcesDirectory)\onnxruntime-inference-examples\c_cxx\squeezenet
         workingFolder: '$(Build.ArtifactStagingDirectory)'
 
     - task: 1ES.PublishPipelineArtifact@1
       displayName: 'Publish Pipeline Combined GPU Package Artifact'
       inputs:
-        artifactName: 'onnxruntime-win-x64-gpu'
+        artifactName: 'onnxruntime-win-x64-gpu_cuda$(CUDA_VERSION_MAJOR)'
         targetPath: '$(Build.ArtifactStagingDirectory)'

--- a/tools/ci_build/github/linux/extract_and_bundle_gpu_package.sh
+++ b/tools/ci_build/github/linux/extract_and_bundle_gpu_package.sh
@@ -6,6 +6,7 @@ do case "${parameter_Option}"
 in
 a) ARTIFACT_DIR=${OPTARG};;
 c) CUDA_MAJOR=${OPTARG};;
+*) echo "Unknown option"; exit 1;;
 esac
 done
 
@@ -14,24 +15,22 @@ if [ -z "$CUDA_MAJOR" ]; then
   exit 1
 fi
 
-EXIT_CODE=1
-
 uname -a
 
-cd $ARTIFACT_DIR
+cd "$ARTIFACT_DIR"
 
-mkdir -p $ARTIFACT_DIR/onnxruntime-linux-x64-tensorrt
-tar zxvf $ARTIFACT_DIR/onnxruntime-linux-x64-tensorrt-*.tgz -C onnxruntime-linux-x64-tensorrt
-rm $ARTIFACT_DIR/onnxruntime-linux-x64-tensorrt-*.tgz
+mkdir -p "$ARTIFACT_DIR"/onnxruntime-linux-x64-tensorrt
+tar zxvf "$ARTIFACT_DIR"/onnxruntime-linux-x64-tensorrt-*.tgz -C onnxruntime-linux-x64-tensorrt
+rm "$ARTIFACT_DIR"/onnxruntime-linux-x64-tensorrt-*.tgz
 
 # Rename cuda directory to gpu_cuda{MAJOR} directory
 GPU_DIR_NAME="onnxruntime-linux-x64-gpu_cuda${CUDA_MAJOR}"
-mkdir -p $ARTIFACT_DIR/$GPU_DIR_NAME
-tar zxvf $ARTIFACT_DIR/onnxruntime-linux-x64-cuda-*.tgz -C $GPU_DIR_NAME
-VERSION=`ls $ARTIFACT_DIR/$GPU_DIR_NAME | sed 's/onnxruntime-linux-x64-cuda-//'`
-mv $ARTIFACT_DIR/$GPU_DIR_NAME/* $ARTIFACT_DIR/$GPU_DIR_NAME/${GPU_DIR_NAME}-$VERSION
-rm $ARTIFACT_DIR/onnxruntime-linux-x64-cuda-*.tgz
+mkdir -p "$ARTIFACT_DIR"/"$GPU_DIR_NAME"
+tar zxvf "$ARTIFACT_DIR"/onnxruntime-linux-x64-cuda-*.tgz -C "$GPU_DIR_NAME"
+VERSION=$(find "$ARTIFACT_DIR"/"$GPU_DIR_NAME" -maxdepth 1 -mindepth 1 -printf '%f\n' | sed 's/onnxruntime-linux-x64-cuda-//')
+mv "$ARTIFACT_DIR"/"$GPU_DIR_NAME"/* "$ARTIFACT_DIR"/"$GPU_DIR_NAME"/"${GPU_DIR_NAME}-${VERSION}"
+rm "$ARTIFACT_DIR"/onnxruntime-linux-x64-cuda-*.tgz
 
-cp onnxruntime-linux-x64-tensorrt/*/lib/libonnxruntime.so* $GPU_DIR_NAME/*/lib
-cp onnxruntime-linux-x64-tensorrt/*/lib/libonnxruntime_providers_tensorrt.so $GPU_DIR_NAME/*/lib
-cp onnxruntime-linux-x64-tensorrt/*/lib/libonnxruntime_providers_shared.so $GPU_DIR_NAME/*/lib
+cp onnxruntime-linux-x64-tensorrt/*/lib/libonnxruntime.so* "$GPU_DIR_NAME"/*/lib
+cp onnxruntime-linux-x64-tensorrt/*/lib/libonnxruntime_providers_tensorrt.so "$GPU_DIR_NAME"/*/lib
+cp onnxruntime-linux-x64-tensorrt/*/lib/libonnxruntime_providers_shared.so "$GPU_DIR_NAME"/*/lib

--- a/tools/ci_build/github/linux/extract_and_bundle_gpu_package.sh
+++ b/tools/ci_build/github/linux/extract_and_bundle_gpu_package.sh
@@ -1,30 +1,37 @@
 #!/bin/bash
 set -e -o -x
 
-while getopts a: parameter_Option
+while getopts a:c: parameter_Option
 do case "${parameter_Option}"
 in
 a) ARTIFACT_DIR=${OPTARG};;
+c) CUDA_MAJOR=${OPTARG};;
 esac
 done
+
+if [ -z "$CUDA_MAJOR" ]; then
+  echo "Error: CUDA major version (-c) is required"
+  exit 1
+fi
 
 EXIT_CODE=1
 
 uname -a
 
-cd $ARTIFACT_DIR 
+cd $ARTIFACT_DIR
 
 mkdir -p $ARTIFACT_DIR/onnxruntime-linux-x64-tensorrt
 tar zxvf $ARTIFACT_DIR/onnxruntime-linux-x64-tensorrt-*.tgz -C onnxruntime-linux-x64-tensorrt
 rm $ARTIFACT_DIR/onnxruntime-linux-x64-tensorrt-*.tgz
 
-# Rename cuda directory to gpu directory
-mkdir -p $ARTIFACT_DIR/onnxruntime-linux-x64-gpu
-tar zxvf $ARTIFACT_DIR/onnxruntime-linux-x64-cuda-*.tgz -C onnxruntime-linux-x64-gpu
-VERSION=`ls $ARTIFACT_DIR/onnxruntime-linux-x64-gpu | sed 's/onnxruntime-linux-x64-cuda-//'`
-mv $ARTIFACT_DIR/onnxruntime-linux-x64-gpu/* $ARTIFACT_DIR/onnxruntime-linux-x64-gpu/onnxruntime-linux-x64-gpu-$VERSION
+# Rename cuda directory to gpu_cuda{MAJOR} directory
+GPU_DIR_NAME="onnxruntime-linux-x64-gpu_cuda${CUDA_MAJOR}"
+mkdir -p $ARTIFACT_DIR/$GPU_DIR_NAME
+tar zxvf $ARTIFACT_DIR/onnxruntime-linux-x64-cuda-*.tgz -C $GPU_DIR_NAME
+VERSION=`ls $ARTIFACT_DIR/$GPU_DIR_NAME | sed 's/onnxruntime-linux-x64-cuda-//'`
+mv $ARTIFACT_DIR/$GPU_DIR_NAME/* $ARTIFACT_DIR/$GPU_DIR_NAME/${GPU_DIR_NAME}-$VERSION
 rm $ARTIFACT_DIR/onnxruntime-linux-x64-cuda-*.tgz
 
-cp onnxruntime-linux-x64-tensorrt/*/lib/libonnxruntime.so* onnxruntime-linux-x64-gpu/*/lib
-cp onnxruntime-linux-x64-tensorrt/*/lib/libonnxruntime_providers_tensorrt.so onnxruntime-linux-x64-gpu/*/lib
-cp onnxruntime-linux-x64-tensorrt/*/lib/libonnxruntime_providers_shared.so onnxruntime-linux-x64-gpu/*/lib
+cp onnxruntime-linux-x64-tensorrt/*/lib/libonnxruntime.so* $GPU_DIR_NAME/*/lib
+cp onnxruntime-linux-x64-tensorrt/*/lib/libonnxruntime_providers_tensorrt.so $GPU_DIR_NAME/*/lib
+cp onnxruntime-linux-x64-tensorrt/*/lib/libonnxruntime_providers_shared.so $GPU_DIR_NAME/*/lib

--- a/tools/ci_build/github/windows/extract_zip_files_gpu.ps1
+++ b/tools/ci_build/github/windows/extract_zip_files_gpu.ps1
@@ -1,8 +1,14 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
+$CudaMajor = $Env:CUDA_VERSION_MAJOR
+if (-not $CudaMajor) {
+    Write-Error "CUDA_VERSION_MAJOR environment variable is required"
+    exit 1
+}
+
 # extract *-cuda-*.zip and *-tensorrt-*.zip
-Get-ChildItem $Env:BUILD_BINARIESDIRECTORY\zip-artifacts -Filter *.zip | 
+Get-ChildItem $Env:BUILD_BINARIESDIRECTORY\zip-artifacts -Filter *.zip |
 Foreach-Object {
  $cmd = "7z.exe x $($_.FullName) -y -o$Env:BUILD_BINARIESDIRECTORY\zip-artifacts"
  Write-Output $cmd
@@ -13,13 +19,14 @@ Foreach-Object {
 Get-ChildItem $Env:BUILD_BINARIESDIRECTORY\zip-artifacts | Where-Object { $_.Name -match 'onnxruntime-win-x64-tensorrt-\d{1,}\.\d{1,}\.\d{1,}$' } | Rename-Item -NewName $Env:BUILD_BINARIESDIRECTORY\zip-artifacts\onnxruntime-win-x64-tensorrt
 Remove-Item $Env:BUILD_BINARIESDIRECTORY\zip-artifacts\*.zip
 
-# Rename cuda directory to gpu directory and re-compress it for later use in bundle_dlls_gpu.bat
+# Rename cuda directory to gpu_cuda{MAJOR} directory and re-compress it for later use in bundle_dlls_gpu.bat
 Get-ChildItem $Env:BUILD_BINARIESDIRECTORY\zip-artifacts -Filter *cuda* |
 Foreach-Object {
  $($_.FullName) -match '.*onnxruntime-win-x64-cuda-(.*)'
  $version=$matches[1]
- Rename-Item -Path $($_.FullName) -NewName onnxruntime-win-x64-gpu-$version
- $cmd = "7z.exe a $Env:BUILD_BINARIESDIRECTORY\zip-artifacts\onnxruntime-win-x64-gpu-$version.zip $Env:BUILD_BINARIESDIRECTORY\zip-artifacts\onnxruntime-win-x64-gpu-$version"
+ $gpuName = "onnxruntime-win-x64-gpu_cuda${CudaMajor}-$version"
+ Rename-Item -Path $($_.FullName) -NewName $gpuName
+ $cmd = "7z.exe a $Env:BUILD_BINARIESDIRECTORY\zip-artifacts\${gpuName}.zip $Env:BUILD_BINARIESDIRECTORY\zip-artifacts\${gpuName}"
  Write-Output $cmd
  Invoke-Expression -Command $cmd
 }

--- a/tools/nuget/validate_package.py
+++ b/tools/nuget/validate_package.py
@@ -232,10 +232,7 @@ def validate_tarball(args):
         raise Exception("No packages / more than one packages found in the given path.")
 
     package_name = args.package_name
-    if "-gpu-" in package_name.lower():
-        is_gpu_package = True
-    else:
-        is_gpu_package = False
+    is_gpu_package = "-gpu" in package_name.lower()
 
     package_folder = re.search("(.*)[.].*", package_name).group(1)
 
@@ -266,10 +263,7 @@ def validate_zip(args):
         raise Exception("No packages / more than one packages found in the given path.")
 
     package_name = args.package_name
-    if "-gpu-" in package_name.lower():
-        is_gpu_package = True
-    else:
-        is_gpu_package = False
+    is_gpu_package = "-gpu" in package_name.lower()
 
     package_folder = re.search("(.*)[.].*", package_name).group(1)
 

--- a/tools/nuget/validate_package.py
+++ b/tools/nuget/validate_package.py
@@ -232,7 +232,7 @@ def validate_tarball(args):
         raise Exception("No packages / more than one packages found in the given path.")
 
     package_name = args.package_name
-    is_gpu_package = "-gpu" in package_name.lower()
+    is_gpu_package = "-gpu_cuda" in package_name.lower()
 
     package_folder = re.search("(.*)[.].*", package_name).group(1)
 
@@ -263,7 +263,7 @@ def validate_zip(args):
         raise Exception("No packages / more than one packages found in the given path.")
 
     package_name = args.package_name
-    is_gpu_package = "-gpu" in package_name.lower()
+    is_gpu_package = "-gpu_cuda" in package_name.lower()
 
     package_folder = re.search("(.*)[.].*", package_name).group(1)
 


### PR DESCRIPTION
### Description

For ORT 1.27, GPU release artifacts (zip/tgz) now include an explicit CUDA major version suffix to distinguish between CUDA 12 and CUDA 13 builds.

**Before:** `onnxruntime-linux-x64-gpu-1.27.0.tgz`, `onnxruntime-win-x64-gpu-1.27.0.zip`  
**After:** `onnxruntime-linux-x64-gpu_cuda12-1.27.0.tgz`, `onnxruntime-win-x64-gpu_cuda13-1.27.0.tgz`, etc.



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


