### PR TITLE
Add `tools/python/compile_contributors.py` `--paths` option

### DIFF
--- a/tools/python/compile_contributors.py
+++ b/tools/python/compile_contributors.py
@@ -11,9 +11,14 @@ Description:
 
 Usage:
     python compile_contributors.py [--base <base_branch>] [--target <target_branch>] [--dir <output_dir>]
+                                   [--paths <path> [<path> ...]]
 
 Example:
     python compile_contributors.py --base origin/rel-1.23.2 --target origin/rel-1.24.1 --dir rel-1.24.1_report
+
+    # Limit to commits that touch specific directories (e.g. for a per-component release note):
+    python compile_contributors.py --base origin/main~500 --target origin/main \
+        --paths onnxruntime/core/providers/webgpu onnxruntime/contrib_ops/webgpu plugin-ep-webgpu
 
 Outputs:
     - detail.csv: Detailed breakdown of PRs, authors, and commit links.
@@ -314,6 +319,19 @@ def main():
     parser.add_argument("--target", default="origin/rel-1.24.1", help="Target branch/commit to compare to")
     parser.add_argument("--dir", default="contributors", help="Output directory for reports and logs")
     parser.add_argument("--scan-depth", type=int, default=200, help="Depth to scan base/meta-PRs for deduplication")
+    parser.add_argument(
+        "--paths",
+        nargs="+",
+        default=None,
+        metavar="PATH",
+        help=(
+            "Optional list of paths (git pathspec) to limit history to. "
+            "Only commits that touch one of these paths are considered. "
+            "Note: when a 'Cherry-pick round' meta-PR is included because at "
+            "least one of its cherry-picks touched these paths, all its "
+            "sub-PRs are still expanded regardless of paths."
+        ),
+    )
     args = parser.parse_args()
 
     # Early validation
@@ -324,6 +342,9 @@ def main():
     branch_target = args.target
     output_dir = args.dir
     scan_depth = args.scan_depth
+    # Build a pathspec suffix (e.g. ["--", "onnxruntime/core/providers/webgpu", ...]) once,
+    # so it can be appended to each `git log` invocation below.
+    paths_args = (["--", *args.paths]) if args.paths else []
 
     if not os.path.exists(output_dir):
         os.makedirs(output_dir)
@@ -331,10 +352,12 @@ def main():
     logs_path = os.path.join(output_dir, "logs.txt")
     with open(logs_path, "w", encoding="utf-8") as log_file:
         log_event(f"Starting comparison: {branch_base} -> {branch_target}", log_file)
+        if args.paths:
+            log_event(f"Limiting history to paths: {args.paths}", log_file)
 
         # 1. Fetch base branch PRs (scan depth controlled by scan_depth)
         log_event(f"Fetching base branch history for {branch_base} (last {scan_depth})...", log_file)
-        log_base = run_command(["git", "log", branch_base, "-n", str(scan_depth), "--oneline"])
+        log_base = run_command(["git", "log", branch_base, "-n", str(scan_depth), "--oneline", *paths_args])
         if log_base is None:
             log_event(
                 f"Error: Could not fetch history for base ref '{branch_base}'. Please check if the ref exists.",
@@ -348,7 +371,7 @@ def main():
         # 2. Fetch target branch PRs (only those not in base)
         log_event(f"Fetching target branch history: {branch_base}..{branch_target}...", log_file)
         # Using A..B syntax for git log
-        log_target = run_command(["git", "log", f"{branch_base}..{branch_target}", "--oneline"])
+        log_target = run_command(["git", "log", f"{branch_base}..{branch_target}", "--oneline", *paths_args])
         if log_target is None:
             log_event(
                 f"Error: Could not fetch history for range '{branch_base}..{branch_target}'. Please check if the refs exist.",

--- a/tools/python/compile_contributors.py
+++ b/tools/python/compile_contributors.py
@@ -16,9 +16,10 @@ Usage:
 Example:
     python compile_contributors.py --base origin/rel-1.23.2 --target origin/rel-1.24.1 --dir rel-1.24.1_report
 
-    # Limit to commits that touch specific directories (e.g. for a per-component release note):
+    # Limit to commits that touch selected areas (replace with your paths):
+    # Using git pathspec syntax, ":(top)" anchors each path at repository root.
     python compile_contributors.py --base origin/main~500 --target origin/main \
-        --paths onnxruntime/core/providers/webgpu onnxruntime/contrib_ops/webgpu plugin-ep-webgpu
+        --paths ":(top)path/to/component_a" ":(top)path/to/component_b"
 
 Outputs:
     - detail.csv: Detailed breakdown of PRs, authors, and commit links.


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Add a new `--paths` option to `compile_contributors.py` to limit git history queries using pathspecs.

Apply the path filter to both base and target git log collection and log the active path filter in logs.txt.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Allow `compile_contributors.py` to be used for releases where relevant changes are largely limited to a subset of the codebase. E.g., we can limit the paths to WebGPU EP-related files for the WebGPU plugin EP release.