### PR TITLE
[CUDA] Chunked dequant+GEMM in MatMulNBits to reduce peak GPU memory for large N

### DIFF
--- a/onnxruntime/contrib_ops/cuda/quantization/matmul_nbits.cc
+++ b/onnxruntime/contrib_ops/cuda/quantization/matmul_nbits.cc
@@ -394,8 +394,22 @@ Status MatMulNBits<T>::ComputeInternal(OpKernelContext* ctx) const {
   }
 
   int64_t K_padded = (K_ + block_size_ - 1) / block_size_ * block_size_;
-  IAllocatorUniquePtr<T> b_data_ptr = this->template GetScratchBuffer<T>(N_ * K_padded, this->GetComputeStream(ctx));
+
+  // Determine if chunked dequant will be used (large N with column-wise quantization)
+  constexpr int64_t kChunkTargetRows = 32768;
+  const int64_t scratch_bytes = N_ * K_padded * static_cast<int64_t>(sizeof(T));
+  const bool will_use_chunked = (scratch_bytes > 256 * 1024 * 1024) &&
+                                (N_ > kChunkTargetRows * 2) &&
+                                column_wise_quant_blk_ &&
+                                (reorder_idx_data == nullptr);
+
+  // Allocate scratch: full size normally, chunk size if chunked path will be used
+  const int64_t scratch_n = will_use_chunked ? kChunkTargetRows : N_;
+  IAllocatorUniquePtr<T> b_data_ptr = this->template GetScratchBuffer<T>(scratch_n * K_padded, this->GetComputeStream(ctx));
   auto* b_data = b_data_ptr.get();
+
+  // Skip full dequant when chunked path will handle it in the GEMM loop
+  if (!will_use_chunked) {
 
   if (nbits_ == 8) {
     if (column_wise_quant_blk_) {
@@ -483,29 +497,144 @@ Status MatMulNBits<T>::ComputeInternal(OpKernelContext* ctx) const {
     }
   }
 
+  } // end if (!will_use_chunked)
+
   DUMP_TENSOR_D("DeQuantized", b_data, static_cast<int>(N_), static_cast<int>(K_padded));
 
   const CudaT alpha = onnxruntime::cuda::OrtToCudaType<T>::FromFloat(1.f);
   const CudaT zero = onnxruntime::cuda::OrtToCudaType<T>::FromFloat(0.f);
 
   if (helper.OutputOffsets().size() == 1) {
-    CUBLAS_RETURN_IF_ERROR(cublasGemmHelper(
-        GetCublasHandle(ctx),
-        CUBLAS_OP_T,
-        CUBLAS_OP_N,
-        SafeInt<int>(helper.N()),
-        SafeInt<int>(helper.M()),
-        SafeInt<int>(helper.K()),
-        &alpha,
-        reinterpret_cast<const CudaT*>(b_data),
-        SafeInt<int>(K_padded),
-        reinterpret_cast<const CudaT*>(a_data),
-        helper.Lda(transa),
-        &zero,
-        reinterpret_cast<CudaT*>(Y->MutableData<T>()),
-        helper.Ldc(),
-        GetDeviceProp(),
-        UseTF32()));
+    if (will_use_chunked) {
+      // Chunked dequant+GEMM: scratch buffer is already sized for one chunk.
+      const int64_t chunk_n = kChunkTargetRows;
+
+      auto* out_data = reinterpret_cast<CudaT*>(Y->MutableData<T>());
+
+      for (int64_t n_start = 0; n_start < N_; n_start += chunk_n) {
+        const int64_t n_end = std::min(n_start + chunk_n, N_);
+        const int this_chunk = static_cast<int>(n_end - n_start);
+
+        // Dequantize this chunk of N rows
+        if (nbits_ == 8) {
+          if (column_wise_quant_blk_) {
+            const int64_t blocks_per_col = K_padded / block_size_;
+            // blob: [N, K] uint8 — offset by n_start * K
+            const uint8_t* chunk_blob = blob_data + n_start * K_padded;
+            // scales: [N, blocks_per_col] — offset by n_start * blocks_per_col
+            const auto* chunk_scales = reinterpret_cast<const CudaT*>(scales_data) + n_start * blocks_per_col;
+            const void* chunk_zp = nullptr;
+            if (zero_points_data) {
+              if (zero_points && zero_points->IsDataType<T>()) {
+                chunk_zp = reinterpret_cast<const CudaT*>(zero_points_data) + n_start * blocks_per_col;
+              } else {
+                chunk_zp = static_cast<const uint8_t*>(zero_points_data) + n_start * blocks_per_col;
+              }
+            }
+            if (zero_points && zero_points->IsDataType<T>()) {
+              ORT_RETURN_IF_ERROR(Dequantize8Bits(
+                  reinterpret_cast<CudaT*>(b_data),
+                  chunk_blob,
+                  chunk_scales,
+                  static_cast<const CudaT*>(chunk_zp),
+                  nullptr,  // no reorder_idx for chunked path
+                  SafeInt<int>(K_padded),
+                  this_chunk,
+                  SafeInt<int>(block_size_),
+                  stream));
+            } else {
+              ORT_RETURN_IF_ERROR(Dequantize8Bits(
+                  reinterpret_cast<CudaT*>(b_data),
+                  chunk_blob,
+                  chunk_scales,
+                  static_cast<const uint8_t*>(chunk_zp),
+                  nullptr,
+                  SafeInt<int>(K_padded),
+                  this_chunk,
+                  SafeInt<int>(block_size_),
+                  stream));
+            }
+          }
+        } else {
+          // 4-bit chunked path
+          if (column_wise_quant_blk_) {
+            const int64_t blocks_per_col = K_padded / block_size_;
+            const uint8_t* chunk_blob = blob_data + n_start * (K_padded / 2);  // 4-bit: 2 values per byte
+            const auto* chunk_scales = reinterpret_cast<const CudaT*>(scales_data) + n_start * blocks_per_col;
+            const void* chunk_zp = nullptr;
+            if (zero_points_data) {
+              if (zero_points && zero_points->IsDataType<T>()) {
+                chunk_zp = reinterpret_cast<const CudaT*>(zero_points_data) + n_start * blocks_per_col;
+              } else {
+                // 4-bit ZP: packed, offset by n_start * ceil(blocks_per_col / 2)
+                chunk_zp = static_cast<const uint8_t*>(zero_points_data) + n_start * ((blocks_per_col + 1) / 2);
+              }
+            }
+            if (zero_points && zero_points->IsDataType<T>()) {
+              ORT_RETURN_IF_ERROR(Dequantize4Bits(
+                  reinterpret_cast<CudaT*>(b_data),
+                  chunk_blob,
+                  chunk_scales,
+                  static_cast<const CudaT*>(chunk_zp),
+                  nullptr,
+                  SafeInt<int>(K_padded),
+                  this_chunk,
+                  SafeInt<int>(block_size_),
+                  stream));
+            } else {
+              ORT_RETURN_IF_ERROR(Dequantize4Bits(
+                  reinterpret_cast<CudaT*>(b_data),
+                  chunk_blob,
+                  chunk_scales,
+                  static_cast<const uint8_t*>(chunk_zp),
+                  nullptr,
+                  SafeInt<int>(K_padded),
+                  this_chunk,
+                  SafeInt<int>(block_size_),
+                  stream));
+            }
+          }
+        }
+
+        // GEMM for this chunk: C[:, n_start:n_end] = A[M,K] @ B_chunk[chunk_n, K]^T
+        CUBLAS_RETURN_IF_ERROR(cublasGemmHelper(
+            GetCublasHandle(ctx),
+            CUBLAS_OP_T,
+            CUBLAS_OP_N,
+            this_chunk,                                     // n (output columns for this chunk)
+            SafeInt<int>(helper.M()),                       // m
+            SafeInt<int>(helper.K()),                       // k
+            &alpha,
+            reinterpret_cast<const CudaT*>(b_data),        // B_chunk [chunk_n, K_padded]
+            SafeInt<int>(K_padded),
+            reinterpret_cast<const CudaT*>(a_data),         // A [M, K]
+            helper.Lda(transa),
+            &zero,
+            out_data + n_start,                              // C[:, n_start] — strided output
+            SafeInt<int>(helper.Ldc()),                      // ldc = N (full output stride)
+            GetDeviceProp(),
+            UseTF32()));
+      }
+    } else {
+      // Original non-chunked path for small N
+      CUBLAS_RETURN_IF_ERROR(cublasGemmHelper(
+          GetCublasHandle(ctx),
+          CUBLAS_OP_T,
+          CUBLAS_OP_N,
+          SafeInt<int>(helper.N()),
+          SafeInt<int>(helper.M()),
+          SafeInt<int>(helper.K()),
+          &alpha,
+          reinterpret_cast<const CudaT*>(b_data),
+          SafeInt<int>(K_padded),
+          reinterpret_cast<const CudaT*>(a_data),
+          helper.Lda(transa),
+          &zero,
+          reinterpret_cast<CudaT*>(Y->MutableData<T>()),
+          helper.Ldc(),
+          GetDeviceProp(),
+          UseTF32()));
+    }
   }
 
   return Status::OK();

--- a/onnxruntime/contrib_ops/cuda/quantization/matmul_nbits.cc
+++ b/onnxruntime/contrib_ops/cuda/quantization/matmul_nbits.cc
@@ -410,94 +410,93 @@ Status MatMulNBits<T>::ComputeInternal(OpKernelContext* ctx) const {
 
   // Skip full dequant when chunked path will handle it in the GEMM loop
   if (!will_use_chunked) {
-
-  if (nbits_ == 8) {
-    if (column_wise_quant_blk_) {
-      if (reorder_idx) {
-        ORT_ENFORCE(K_padded == reorder_idx->Shape()[0], "K_padded != g_idx->Shape()[0]");
-      }
-      if (zero_points && zero_points->IsDataType<T>()) {
-        ORT_RETURN_IF_ERROR(Dequantize8Bits(
-            reinterpret_cast<CudaT*>(b_data),
-            blob_data,
-            reinterpret_cast<const CudaT*>(scales_data),
-            (const CudaT*)zero_points_data,
-            reorder_idx_data,
-            SafeInt<int>(K_padded),
-            SafeInt<int>(N_),
-            SafeInt<int>(block_size_),
-            stream));
-      } else {
-        ORT_RETURN_IF_ERROR(Dequantize8Bits(
-            reinterpret_cast<CudaT*>(b_data),
-            blob_data,
-            reinterpret_cast<const CudaT*>(scales_data),
-            (const uint8_t*)zero_points_data,
-            reorder_idx_data,
-            SafeInt<int>(K_padded),
-            SafeInt<int>(N_),
-            SafeInt<int>(block_size_),
-            stream));
-      }
-    } else {  // row-wise block
-      ORT_RETURN_IF_ERROR(DequantizeBlockwise8b(
-          reinterpret_cast<CudaT*>(b_data),
-          blob_data,
-          reinterpret_cast<const CudaT*>(scales_data),
-          (const uint8_t*)zero_points_data,
-          SafeInt<int>(block_size_),
-          column_wise_quant_blk_,
-          SafeInt<int>(K_),
-          SafeInt<int>(N_),
-          stream));
-    }
-  } else {  // 4 bits
-    if (column_wise_quant_blk_) {
-      if (reorder_idx) {
-        ORT_ENFORCE(K_padded == reorder_idx->Shape()[0], "K_padded != g_idx->Shape()[0]");
-      }
-      // column-wise block
-      if ((zero_points && zero_points->IsDataType<T>())) {
-        ORT_RETURN_IF_ERROR(Dequantize4Bits(
-            reinterpret_cast<CudaT*>(b_data),
-            blob_data,
-            reinterpret_cast<const CudaT*>(scales_data),
-            (const CudaT*)zero_points_data,
-            reorder_idx_data,
-            SafeInt<int>(K_padded),
-            SafeInt<int>(N_),
-            SafeInt<int>(block_size_),
-            stream));
-      } else {
-        ORT_RETURN_IF_ERROR(Dequantize4Bits(
+    if (nbits_ == 8) {
+      if (column_wise_quant_blk_) {
+        if (reorder_idx) {
+          ORT_ENFORCE(K_padded == reorder_idx->Shape()[0], "K_padded != g_idx->Shape()[0]");
+        }
+        if (zero_points && zero_points->IsDataType<T>()) {
+          ORT_RETURN_IF_ERROR(Dequantize8Bits(
+              reinterpret_cast<CudaT*>(b_data),
+              blob_data,
+              reinterpret_cast<const CudaT*>(scales_data),
+              (const CudaT*)zero_points_data,
+              reorder_idx_data,
+              SafeInt<int>(K_padded),
+              SafeInt<int>(N_),
+              SafeInt<int>(block_size_),
+              stream));
+        } else {
+          ORT_RETURN_IF_ERROR(Dequantize8Bits(
+              reinterpret_cast<CudaT*>(b_data),
+              blob_data,
+              reinterpret_cast<const CudaT*>(scales_data),
+              (const uint8_t*)zero_points_data,
+              reorder_idx_data,
+              SafeInt<int>(K_padded),
+              SafeInt<int>(N_),
+              SafeInt<int>(block_size_),
+              stream));
+        }
+      } else {  // row-wise block
+        ORT_RETURN_IF_ERROR(DequantizeBlockwise8b(
             reinterpret_cast<CudaT*>(b_data),
             blob_data,
             reinterpret_cast<const CudaT*>(scales_data),
             (const uint8_t*)zero_points_data,
-            reorder_idx_data,
-            SafeInt<int>(K_padded),
-            SafeInt<int>(N_),
             SafeInt<int>(block_size_),
+            column_wise_quant_blk_,
+            SafeInt<int>(K_),
+            SafeInt<int>(N_),
             stream));
       }
-    } else {
-      // row-wise block
-      K_padded = K_;
+    } else {  // 4 bits
+      if (column_wise_quant_blk_) {
+        if (reorder_idx) {
+          ORT_ENFORCE(K_padded == reorder_idx->Shape()[0], "K_padded != g_idx->Shape()[0]");
+        }
+        // column-wise block
+        if ((zero_points && zero_points->IsDataType<T>())) {
+          ORT_RETURN_IF_ERROR(Dequantize4Bits(
+              reinterpret_cast<CudaT*>(b_data),
+              blob_data,
+              reinterpret_cast<const CudaT*>(scales_data),
+              (const CudaT*)zero_points_data,
+              reorder_idx_data,
+              SafeInt<int>(K_padded),
+              SafeInt<int>(N_),
+              SafeInt<int>(block_size_),
+              stream));
+        } else {
+          ORT_RETURN_IF_ERROR(Dequantize4Bits(
+              reinterpret_cast<CudaT*>(b_data),
+              blob_data,
+              reinterpret_cast<const CudaT*>(scales_data),
+              (const uint8_t*)zero_points_data,
+              reorder_idx_data,
+              SafeInt<int>(K_padded),
+              SafeInt<int>(N_),
+              SafeInt<int>(block_size_),
+              stream));
+        }
+      } else {
+        // row-wise block
+        K_padded = K_;
 
-      ORT_RETURN_IF_ERROR(DequantizeBlockwise4b(
-          reinterpret_cast<CudaT*>(b_data),
-          blob_data,
-          reinterpret_cast<const CudaT*>(scales_data),
-          (const uint8_t*)zero_points_data,
-          SafeInt<int>(block_size_),
-          column_wise_quant_blk_,
-          SafeInt<int>(K_),
-          SafeInt<int>(N_),
-          stream));
+        ORT_RETURN_IF_ERROR(DequantizeBlockwise4b(
+            reinterpret_cast<CudaT*>(b_data),
+            blob_data,
+            reinterpret_cast<const CudaT*>(scales_data),
+            (const uint8_t*)zero_points_data,
+            SafeInt<int>(block_size_),
+            column_wise_quant_blk_,
+            SafeInt<int>(K_),
+            SafeInt<int>(N_),
+            stream));
+      }
     }
-  }
 
-  } // end if (!will_use_chunked)
+  }  // end if (!will_use_chunked)
 
   DUMP_TENSOR_D("DeQuantized", b_data, static_cast<int>(N_), static_cast<int>(K_padded));
 
@@ -601,17 +600,17 @@ Status MatMulNBits<T>::ComputeInternal(OpKernelContext* ctx) const {
             GetCublasHandle(ctx),
             CUBLAS_OP_T,
             CUBLAS_OP_N,
-            this_chunk,                                     // n (output columns for this chunk)
-            SafeInt<int>(helper.M()),                       // m
-            SafeInt<int>(helper.K()),                       // k
+            this_chunk,                // n (output columns for this chunk)
+            SafeInt<int>(helper.M()),  // m
+            SafeInt<int>(helper.K()),  // k
             &alpha,
-            reinterpret_cast<const CudaT*>(b_data),        // B_chunk [chunk_n, K_padded]
+            reinterpret_cast<const CudaT*>(b_data),  // B_chunk [chunk_n, K_padded]
             SafeInt<int>(K_padded),
-            reinterpret_cast<const CudaT*>(a_data),         // A [M, K]
+            reinterpret_cast<const CudaT*>(a_data),  // A [M, K]
             helper.Lda(transa),
             &zero,
-            out_data + n_start,                              // C[:, n_start] — strided output
-            SafeInt<int>(helper.Ldc()),                      // ldc = N (full output stride)
+            out_data + n_start,          // C[:, n_start] — strided output
+            SafeInt<int>(helper.Ldc()),  // ldc = N (full output stride)
             GetDeviceProp(),
             UseTF32()));
       }

--- a/onnxruntime/contrib_ops/cuda/quantization/matmul_nbits.cc
+++ b/onnxruntime/contrib_ops/cuda/quantization/matmul_nbits.cc
@@ -395,110 +395,108 @@ Status MatMulNBits<T>::ComputeInternal(OpKernelContext* ctx) const {
 
   int64_t K_padded = (K_ + block_size_ - 1) / block_size_ * block_size_;
 
-  // Determine if chunked dequant will be used (large N with column-wise quantization)
-  constexpr int64_t kChunkTargetRows = 32768;
+  // Chunked dequant+GEMM trades peak scratch memory for repeated kernel launches.
+  // Thresholds:
+  //   256 MB  – scratch budget; above this the full N*K_padded buffer would dominate
+  //             device memory and risk OOM on consumer GPUs (8–12 GB).
+  //   N > 2*chunk_target_rows (default 65536) – ensures at least two chunks so the
+  //             overhead of per-chunk cuBLAS calls is amortised.
+  //   chunk_target_rows (default 32768) – chosen so that each dequant+GEMM tile is
+  //             large enough to saturate SMs while keeping scratch ≤ ~128 MB.
+  // Only column-wise quantization without reorder_idx is supported; row-wise layouts
+  // interleave K blocks across N and cannot be sliced along the N axis.
+  const int64_t chunk_target_rows = chunk_target_rows_;
   const int64_t scratch_bytes = N_ * K_padded * static_cast<int64_t>(sizeof(T));
-  const bool will_use_chunked = (scratch_bytes > 256 * 1024 * 1024) &&
-                                (N_ > kChunkTargetRows * 2) &&
-                                column_wise_quant_blk_ &&
-                                (reorder_idx_data == nullptr);
+  const bool will_use_chunked = column_wise_quant_blk_ &&
+                                (reorder_idx_data == nullptr) &&
+                                (force_chunked_ ||
+                                 ((scratch_bytes > 256 * 1024 * 1024) &&
+                                  (N_ > chunk_target_rows * 2)));
 
   // Allocate scratch: full size normally, chunk size if chunked path will be used
-  const int64_t scratch_n = will_use_chunked ? kChunkTargetRows : N_;
+  const int64_t scratch_n = will_use_chunked ? chunk_target_rows : N_;
   IAllocatorUniquePtr<T> b_data_ptr = this->template GetScratchBuffer<T>(scratch_n * K_padded, this->GetComputeStream(ctx));
   auto* b_data = b_data_ptr.get();
 
+  // Column-wise dequant helper: dispatches 8-bit / 4-bit × typed / uint8 zero-points.
+  // Used by both the full-N and chunked paths so the offset math stays in one place.
+  const int64_t blocks_per_col = K_padded / block_size_;
+  auto dequant_column_wise = [&](const uint8_t* chunk_blob,
+                                 const CudaT* chunk_scales,
+                                 const void* chunk_zp,
+                                 const int32_t* chunk_reorder_idx,
+                                 int n_rows) -> Status {
+    if (nbits_ == 8) {
+      if (zero_points && zero_points->IsDataType<T>()) {
+        return Dequantize8Bits(
+            reinterpret_cast<CudaT*>(b_data), chunk_blob, chunk_scales,
+            static_cast<const CudaT*>(chunk_zp), chunk_reorder_idx,
+            SafeInt<int>(K_padded), n_rows, SafeInt<int>(block_size_), stream);
+      } else {
+        return Dequantize8Bits(
+            reinterpret_cast<CudaT*>(b_data), chunk_blob, chunk_scales,
+            static_cast<const uint8_t*>(chunk_zp), chunk_reorder_idx,
+            SafeInt<int>(K_padded), n_rows, SafeInt<int>(block_size_), stream);
+      }
+    } else {
+      if (zero_points && zero_points->IsDataType<T>()) {
+        return Dequantize4Bits(
+            reinterpret_cast<CudaT*>(b_data), chunk_blob, chunk_scales,
+            static_cast<const CudaT*>(chunk_zp), chunk_reorder_idx,
+            SafeInt<int>(K_padded), n_rows, SafeInt<int>(block_size_), stream);
+      } else {
+        return Dequantize4Bits(
+            reinterpret_cast<CudaT*>(b_data), chunk_blob, chunk_scales,
+            static_cast<const uint8_t*>(chunk_zp), chunk_reorder_idx,
+            SafeInt<int>(K_padded), n_rows, SafeInt<int>(block_size_), stream);
+      }
+    }
+  };
+
   // Skip full dequant when chunked path will handle it in the GEMM loop
   if (!will_use_chunked) {
-    if (nbits_ == 8) {
-      if (column_wise_quant_blk_) {
-        if (reorder_idx) {
-          ORT_ENFORCE(K_padded == reorder_idx->Shape()[0], "K_padded != g_idx->Shape()[0]");
-        }
-        if (zero_points && zero_points->IsDataType<T>()) {
-          ORT_RETURN_IF_ERROR(Dequantize8Bits(
-              reinterpret_cast<CudaT*>(b_data),
-              blob_data,
-              reinterpret_cast<const CudaT*>(scales_data),
-              (const CudaT*)zero_points_data,
-              reorder_idx_data,
-              SafeInt<int>(K_padded),
-              SafeInt<int>(N_),
-              SafeInt<int>(block_size_),
-              stream));
-        } else {
-          ORT_RETURN_IF_ERROR(Dequantize8Bits(
-              reinterpret_cast<CudaT*>(b_data),
-              blob_data,
-              reinterpret_cast<const CudaT*>(scales_data),
-              (const uint8_t*)zero_points_data,
-              reorder_idx_data,
-              SafeInt<int>(K_padded),
-              SafeInt<int>(N_),
-              SafeInt<int>(block_size_),
-              stream));
-        }
-      } else {  // row-wise block
-        ORT_RETURN_IF_ERROR(DequantizeBlockwise8b(
-            reinterpret_cast<CudaT*>(b_data),
-            blob_data,
-            reinterpret_cast<const CudaT*>(scales_data),
-            (const uint8_t*)zero_points_data,
-            SafeInt<int>(block_size_),
-            column_wise_quant_blk_,
-            SafeInt<int>(K_),
-            SafeInt<int>(N_),
-            stream));
+    if (column_wise_quant_blk_) {
+      if (reorder_idx) {
+        ORT_ENFORCE(K_padded == reorder_idx->Shape()[0], "K_padded != g_idx->Shape()[0]");
       }
-    } else {  // 4 bits
-      if (column_wise_quant_blk_) {
-        if (reorder_idx) {
-          ORT_ENFORCE(K_padded == reorder_idx->Shape()[0], "K_padded != g_idx->Shape()[0]");
-        }
-        // column-wise block
-        if ((zero_points && zero_points->IsDataType<T>())) {
-          ORT_RETURN_IF_ERROR(Dequantize4Bits(
-              reinterpret_cast<CudaT*>(b_data),
-              blob_data,
-              reinterpret_cast<const CudaT*>(scales_data),
-              (const CudaT*)zero_points_data,
-              reorder_idx_data,
-              SafeInt<int>(K_padded),
-              SafeInt<int>(N_),
-              SafeInt<int>(block_size_),
-              stream));
-        } else {
-          ORT_RETURN_IF_ERROR(Dequantize4Bits(
-              reinterpret_cast<CudaT*>(b_data),
-              blob_data,
-              reinterpret_cast<const CudaT*>(scales_data),
-              (const uint8_t*)zero_points_data,
-              reorder_idx_data,
-              SafeInt<int>(K_padded),
-              SafeInt<int>(N_),
-              SafeInt<int>(block_size_),
-              stream));
-        }
-      } else {
-        // row-wise block
-        K_padded = K_;
-
-        ORT_RETURN_IF_ERROR(DequantizeBlockwise4b(
-            reinterpret_cast<CudaT*>(b_data),
-            blob_data,
-            reinterpret_cast<const CudaT*>(scales_data),
-            (const uint8_t*)zero_points_data,
-            SafeInt<int>(block_size_),
-            column_wise_quant_blk_,
-            SafeInt<int>(K_),
-            SafeInt<int>(N_),
-            stream));
-      }
+      ORT_RETURN_IF_ERROR(dequant_column_wise(
+          blob_data,
+          reinterpret_cast<const CudaT*>(scales_data),
+          zero_points_data,
+          reorder_idx_data,
+          SafeInt<int>(N_)));
+    } else if (nbits_ == 8) {
+      // row-wise block (8-bit)
+      ORT_RETURN_IF_ERROR(DequantizeBlockwise8b(
+          reinterpret_cast<CudaT*>(b_data),
+          blob_data,
+          reinterpret_cast<const CudaT*>(scales_data),
+          (const uint8_t*)zero_points_data,
+          SafeInt<int>(block_size_),
+          column_wise_quant_blk_,
+          SafeInt<int>(K_),
+          SafeInt<int>(N_),
+          stream));
+    } else {
+      // row-wise block (4-bit)
+      K_padded = K_;
+      ORT_RETURN_IF_ERROR(DequantizeBlockwise4b(
+          reinterpret_cast<CudaT*>(b_data),
+          blob_data,
+          reinterpret_cast<const CudaT*>(scales_data),
+          (const uint8_t*)zero_points_data,
+          SafeInt<int>(block_size_),
+          column_wise_quant_blk_,
+          SafeInt<int>(K_),
+          SafeInt<int>(N_),
+          stream));
     }
 
   }  // end if (!will_use_chunked)
 
-  DUMP_TENSOR_D("DeQuantized", b_data, static_cast<int>(N_), static_cast<int>(K_padded));
+  if (!will_use_chunked) {
+    DUMP_TENSOR_D("DeQuantized", b_data, static_cast<int>(N_), static_cast<int>(K_padded));
+  }
 
   const CudaT alpha = onnxruntime::cuda::OrtToCudaType<T>::FromFloat(1.f);
   const CudaT zero = onnxruntime::cuda::OrtToCudaType<T>::FromFloat(0.f);
@@ -506,7 +504,7 @@ Status MatMulNBits<T>::ComputeInternal(OpKernelContext* ctx) const {
   if (helper.OutputOffsets().size() == 1) {
     if (will_use_chunked) {
       // Chunked dequant+GEMM: scratch buffer is already sized for one chunk.
-      const int64_t chunk_n = kChunkTargetRows;
+      const int64_t chunk_n = chunk_target_rows;
 
       auto* out_data = reinterpret_cast<CudaT*>(Y->MutableData<T>());
 
@@ -515,85 +513,30 @@ Status MatMulNBits<T>::ComputeInternal(OpKernelContext* ctx) const {
         const int this_chunk = static_cast<int>(n_end - n_start);
 
         // Dequantize this chunk of N rows
-        if (nbits_ == 8) {
-          if (column_wise_quant_blk_) {
-            const int64_t blocks_per_col = K_padded / block_size_;
-            // blob: [N, K] uint8 — offset by n_start * K
-            const uint8_t* chunk_blob = blob_data + n_start * K_padded;
-            // scales: [N, blocks_per_col] — offset by n_start * blocks_per_col
-            const auto* chunk_scales = reinterpret_cast<const CudaT*>(scales_data) + n_start * blocks_per_col;
-            const void* chunk_zp = nullptr;
-            if (zero_points_data) {
-              if (zero_points && zero_points->IsDataType<T>()) {
-                chunk_zp = reinterpret_cast<const CudaT*>(zero_points_data) + n_start * blocks_per_col;
-              } else {
-                chunk_zp = static_cast<const uint8_t*>(zero_points_data) + n_start * blocks_per_col;
-              }
-            }
-            if (zero_points && zero_points->IsDataType<T>()) {
-              ORT_RETURN_IF_ERROR(Dequantize8Bits(
-                  reinterpret_cast<CudaT*>(b_data),
-                  chunk_blob,
-                  chunk_scales,
-                  static_cast<const CudaT*>(chunk_zp),
-                  nullptr,  // no reorder_idx for chunked path
-                  SafeInt<int>(K_padded),
-                  this_chunk,
-                  SafeInt<int>(block_size_),
-                  stream));
-            } else {
-              ORT_RETURN_IF_ERROR(Dequantize8Bits(
-                  reinterpret_cast<CudaT*>(b_data),
-                  chunk_blob,
-                  chunk_scales,
-                  static_cast<const uint8_t*>(chunk_zp),
-                  nullptr,
-                  SafeInt<int>(K_padded),
-                  this_chunk,
-                  SafeInt<int>(block_size_),
-                  stream));
-            }
-          }
-        } else {
-          // 4-bit chunked path
-          if (column_wise_quant_blk_) {
-            const int64_t blocks_per_col = K_padded / block_size_;
-            const uint8_t* chunk_blob = blob_data + n_start * (K_padded / 2);  // 4-bit: 2 values per byte
-            const auto* chunk_scales = reinterpret_cast<const CudaT*>(scales_data) + n_start * blocks_per_col;
-            const void* chunk_zp = nullptr;
-            if (zero_points_data) {
-              if (zero_points && zero_points->IsDataType<T>()) {
-                chunk_zp = reinterpret_cast<const CudaT*>(zero_points_data) + n_start * blocks_per_col;
-              } else {
-                // 4-bit ZP: packed, offset by n_start * ceil(blocks_per_col / 2)
-                chunk_zp = static_cast<const uint8_t*>(zero_points_data) + n_start * ((blocks_per_col + 1) / 2);
-              }
-            }
-            if (zero_points && zero_points->IsDataType<T>()) {
-              ORT_RETURN_IF_ERROR(Dequantize4Bits(
-                  reinterpret_cast<CudaT*>(b_data),
-                  chunk_blob,
-                  chunk_scales,
-                  static_cast<const CudaT*>(chunk_zp),
-                  nullptr,
-                  SafeInt<int>(K_padded),
-                  this_chunk,
-                  SafeInt<int>(block_size_),
-                  stream));
-            } else {
-              ORT_RETURN_IF_ERROR(Dequantize4Bits(
-                  reinterpret_cast<CudaT*>(b_data),
-                  chunk_blob,
-                  chunk_scales,
-                  static_cast<const uint8_t*>(chunk_zp),
-                  nullptr,
-                  SafeInt<int>(K_padded),
-                  this_chunk,
-                  SafeInt<int>(block_size_),
-                  stream));
-            }
+        // column_wise_quant_blk_ is guaranteed by will_use_chunked; assert to prevent
+        // silent use of uninitialized b_data if the outer guard is ever relaxed.
+        ORT_ENFORCE(column_wise_quant_blk_, "Chunked path requires column-wise quantization blocks");
+
+        // Compute per-chunk pointers into the column-wise-packed weight, scale, and ZP arrays.
+        const uint8_t* chunk_blob = blob_data + n_start * (nbits_ == 8 ? K_padded : K_padded / 2);
+        const auto* chunk_scales = reinterpret_cast<const CudaT*>(scales_data) + n_start * blocks_per_col;
+        const void* chunk_zp = nullptr;
+        if (zero_points_data) {
+          if (zero_points && zero_points->IsDataType<T>()) {
+            chunk_zp = reinterpret_cast<const CudaT*>(zero_points_data) + n_start * blocks_per_col;
+          } else if (nbits_ == 8) {
+            chunk_zp = static_cast<const uint8_t*>(zero_points_data) + n_start * blocks_per_col;
+          } else {
+            // 4-bit ZP: packed, offset by n_start * ceil(blocks_per_col / 2)
+            chunk_zp = static_cast<const uint8_t*>(zero_points_data) + n_start * ((blocks_per_col + 1) / 2);
           }
         }
+        ORT_RETURN_IF_ERROR(dequant_column_wise(
+            chunk_blob, chunk_scales, chunk_zp,
+            nullptr,  // no reorder_idx for chunked path
+            this_chunk));
+
+        DUMP_TENSOR_D("DeQuantized_chunk", b_data, this_chunk, static_cast<int>(K_padded));
 
         // GEMM for this chunk: C[:, n_start:n_end] = A[M,K] @ B_chunk[chunk_n, K]^T
         CUBLAS_RETURN_IF_ERROR(cublasGemmHelper(

--- a/onnxruntime/contrib_ops/cuda/quantization/matmul_nbits.h
+++ b/onnxruntime/contrib_ops/cuda/quantization/matmul_nbits.h
@@ -18,6 +18,13 @@ namespace contrib {
 namespace cuda {
 using namespace onnxruntime::cuda;
 
+// Environment variables to force the chunked dequant+GEMM path for testing.
+// ORT_MATMULNBITS_FORCE_CHUNKED=1 bypasses the scratch-size and min-N guards.
+// ORT_MATMULNBITS_CHUNK_SIZE overrides the default chunk size (32768).
+constexpr const char* kForceChunkedEnvVar = "ORT_MATMULNBITS_FORCE_CHUNKED";
+constexpr const char* kChunkSizeEnvVar = "ORT_MATMULNBITS_CHUNK_SIZE";
+constexpr int64_t kDefaultChunkTargetRows = 32768;
+
 #if USE_FPA_INTB_GEMM
 using onnxruntime::llm::kernels::cutlass_kernels::CutlassFpAIntBGemmRunner;
 using onnxruntime::llm::kernels::weight_only::GemmDims;
@@ -71,6 +78,9 @@ class MatMulNBits final : public CudaKernel {
     }
 #endif
     sm_ = this->GetDeviceProp().major * 10 + this->GetDeviceProp().minor;
+
+    force_chunked_ = ParseEnvironmentVariableWithDefault<int>(kForceChunkedEnvVar, 0) != 0;
+    chunk_target_rows_ = ParseEnvironmentVariableWithDefault<int64_t>(kChunkSizeEnvVar, kDefaultChunkTargetRows);
 
 #if USE_FPA_INTB_GEMM
     if constexpr (std::is_same<T, MLFloat16>::value || std::is_same<T, BFloat16>::value) {
@@ -141,6 +151,8 @@ class MatMulNBits final : public CudaKernel {
   bool has_bias_{false};
   bool has_zero_points_{false};
   bool is_zero_points_scale_same_type_{false};
+  bool force_chunked_{false};
+  int64_t chunk_target_rows_{kDefaultChunkTargetRows};
 
 #if USE_FPA_INTB_GEMM
   bool has_fpA_intB_gemv_{false};

--- a/onnxruntime/contrib_ops/cuda/quantization/matmul_nbits.h
+++ b/onnxruntime/contrib_ops/cuda/quantization/matmul_nbits.h
@@ -81,6 +81,9 @@ class MatMulNBits final : public CudaKernel {
 
     force_chunked_ = ParseEnvironmentVariableWithDefault<int>(kForceChunkedEnvVar, 0) != 0;
     chunk_target_rows_ = ParseEnvironmentVariableWithDefault<int64_t>(kChunkSizeEnvVar, kDefaultChunkTargetRows);
+    if (chunk_target_rows_ < 1) {
+      chunk_target_rows_ = kDefaultChunkTargetRows;
+    }
 
 #if USE_FPA_INTB_GEMM
     if constexpr (std::is_same<T, MLFloat16>::value || std::is_same<T, BFloat16>::value) {

--- a/onnxruntime/test/contrib_ops/matmul_4bits_test.cc
+++ b/onnxruntime/test/contrib_ops/matmul_4bits_test.cc
@@ -826,6 +826,138 @@ TEST(MatMulNBits, BFloat16_Int4_NoZeroPoint) {
     RunTest<BFloat16>(32, 1024, 2048, block_size, has_zeropoint, zp_is_4bit, abs_error);
   }
 }
+
+// Chunked dequant+GEMM path tests.
+// Force the chunked path with a small chunk size to exercise per-chunk pointer
+// arithmetic (blob, scales, zero_points offsets) and strided cuBLAS output
+// with manageable tensor sizes.
+
+TEST(MatMulNBits, Fp16_Int4_Chunked_Uint8ZeroPoint) {
+  constexpr float abs_error = 0.1f;
+
+  ScopedEnvironmentVariables scoped_env_vars{EnvVarMap{
+      {"ORT_MATMULNBITS_FORCE_CHUNKED", "1"},
+      {"ORT_MATMULNBITS_CHUNK_SIZE", "64"}}};
+
+  for (auto block_size : {32, 64, 128}) {
+    for (auto M : {1, 2}) {
+      TestOptions opts{};
+      opts.M = M, opts.N = 256, opts.K = 1024;
+      opts.block_size = block_size;
+      opts.has_zero_point = true;
+      opts.zp_is_4bit = true;
+      opts.output_abs_error = abs_error;
+      opts.output_rel_error = 0.001f;
+      std::vector<std::unique_ptr<IExecutionProvider>> eps;
+      eps.push_back(DefaultCudaExecutionProvider());
+      RunTest<MLFloat16>(opts, std::move(eps));
+    }
+  }
+}
+
+TEST(MatMulNBits, Fp16_Int4_Chunked_Fp16ZeroPoint) {
+  constexpr float abs_error = 0.1f;
+
+  ScopedEnvironmentVariables scoped_env_vars{EnvVarMap{
+      {"ORT_MATMULNBITS_FORCE_CHUNKED", "1"},
+      {"ORT_MATMULNBITS_CHUNK_SIZE", "64"}}};
+
+  for (auto block_size : {32, 64, 128}) {
+    for (auto M : {1, 2}) {
+      TestOptions opts{};
+      opts.M = M, opts.N = 256, opts.K = 1024;
+      opts.block_size = block_size;
+      opts.has_zero_point = true;
+      opts.zp_is_4bit = false;
+      opts.output_abs_error = abs_error;
+      opts.output_rel_error = 0.001f;
+      std::vector<std::unique_ptr<IExecutionProvider>> eps;
+      eps.push_back(DefaultCudaExecutionProvider());
+      RunTest<MLFloat16>(opts, std::move(eps));
+    }
+  }
+}
+
+TEST(MatMulNBits, Fp16_Int4_Chunked_NoZeroPoint) {
+  constexpr float abs_error = 0.1f;
+
+  ScopedEnvironmentVariables scoped_env_vars{EnvVarMap{
+      {"ORT_MATMULNBITS_FORCE_CHUNKED", "1"},
+      {"ORT_MATMULNBITS_CHUNK_SIZE", "64"}}};
+
+  for (auto block_size : {32, 64, 128}) {
+    for (auto M : {1, 2}) {
+      TestOptions opts{};
+      opts.M = M, opts.N = 256, opts.K = 1024;
+      opts.block_size = block_size;
+      opts.has_zero_point = false;
+      opts.zp_is_4bit = true;
+      opts.output_abs_error = abs_error;
+      opts.output_rel_error = 0.001f;
+      std::vector<std::unique_ptr<IExecutionProvider>> eps;
+      eps.push_back(DefaultCudaExecutionProvider());
+      RunTest<MLFloat16>(opts, std::move(eps));
+    }
+  }
+}
+
+TEST(MatMulNBits, BFloat16_Int4_Chunked_Uint8ZeroPoint) {
+  if (!HasCudaEnvironment(800)) {
+    GTEST_SKIP() << "Skipping BFloat16 tests on CUDA < 8.0";
+  }
+
+  constexpr float abs_error = 0.1f;
+  constexpr bool zp_is_4bit = true;
+  constexpr bool has_zeropoint = true;
+
+  ScopedEnvironmentVariables scoped_env_vars{EnvVarMap{
+      {"ORT_MATMULNBITS_FORCE_CHUNKED", "1"},
+      {"ORT_MATMULNBITS_CHUNK_SIZE", "64"}}};
+
+  for (auto block_size : {32, 64, 128}) {
+    for (auto M : {1, 2}) {
+      TestOptions opts{};
+      opts.M = M, opts.N = 256, opts.K = 1024;
+      opts.block_size = block_size;
+      opts.has_zero_point = has_zeropoint;
+      opts.zp_is_4bit = zp_is_4bit;
+      opts.output_abs_error = abs_error;
+      opts.output_rel_error = 0.001f;
+      std::vector<std::unique_ptr<IExecutionProvider>> eps;
+      eps.push_back(DefaultCudaExecutionProvider());
+      RunTest<BFloat16>(opts, std::move(eps));
+    }
+  }
+}
+
+TEST(MatMulNBits, BFloat16_Int4_Chunked_BFloat16ZeroPoint) {
+  if (!HasCudaEnvironment(800)) {
+    GTEST_SKIP() << "Skipping BFloat16 tests on CUDA < 8.0";
+  }
+
+  constexpr float abs_error = 0.1f;
+  constexpr bool zp_is_4bit = false;
+  constexpr bool has_zeropoint = true;
+
+  ScopedEnvironmentVariables scoped_env_vars{EnvVarMap{
+      {"ORT_MATMULNBITS_FORCE_CHUNKED", "1"},
+      {"ORT_MATMULNBITS_CHUNK_SIZE", "64"}}};
+
+  for (auto block_size : {32, 64, 128}) {
+    for (auto M : {1, 2}) {
+      TestOptions opts{};
+      opts.M = M, opts.N = 256, opts.K = 1024;
+      opts.block_size = block_size;
+      opts.has_zero_point = has_zeropoint;
+      opts.zp_is_4bit = zp_is_4bit;
+      opts.output_abs_error = abs_error;
+      opts.output_rel_error = 0.001f;
+      std::vector<std::unique_ptr<IExecutionProvider>> eps;
+      eps.push_back(DefaultCudaExecutionProvider());
+      RunTest<BFloat16>(opts, std::move(eps));
+    }
+  }
+}
 #endif
 
 #endif  // defined(USE_CUDA) || defined(USE_DML)

--- a/onnxruntime/test/contrib_ops/matmul_4bits_test.cc
+++ b/onnxruntime/test/contrib_ops/matmul_4bits_test.cc
@@ -853,6 +853,20 @@ TEST(MatMulNBits, Fp16_Int4_Chunked_Uint8ZeroPoint) {
       RunTest<MLFloat16>(opts, std::move(eps));
     }
   }
+  // Odd blocks_per_col (K=96, block_size=32 → blocks_per_col=3) exercises the
+  // (blocks_per_col + 1) / 2 rounding in the 4-bit packed ZP offset.
+  {
+    TestOptions opts{};
+    opts.M = 1, opts.N = 256, opts.K = 96;
+    opts.block_size = 32;
+    opts.has_zero_point = true;
+    opts.zp_is_4bit = true;
+    opts.output_abs_error = abs_error;
+    opts.output_rel_error = 0.001f;
+    std::vector<std::unique_ptr<IExecutionProvider>> eps;
+    eps.push_back(DefaultCudaExecutionProvider());
+    RunTest<MLFloat16>(opts, std::move(eps));
+  }
 }
 
 TEST(MatMulNBits, Fp16_Int4_Chunked_Fp16ZeroPoint) {
@@ -927,6 +941,20 @@ TEST(MatMulNBits, BFloat16_Int4_Chunked_Uint8ZeroPoint) {
       eps.push_back(DefaultCudaExecutionProvider());
       RunTest<BFloat16>(opts, std::move(eps));
     }
+  }
+  // Odd blocks_per_col (K=96, block_size=32 → blocks_per_col=3) exercises the
+  // (blocks_per_col + 1) / 2 rounding in the 4-bit packed ZP offset.
+  {
+    TestOptions opts{};
+    opts.M = 1, opts.N = 256, opts.K = 96;
+    opts.block_size = 32;
+    opts.has_zero_point = has_zeropoint;
+    opts.zp_is_4bit = zp_is_4bit;
+    opts.output_abs_error = abs_error;
+    opts.output_rel_error = 0.001f;
+    std::vector<std::unique_ptr<IExecutionProvider>> eps;
+    eps.push_back(DefaultCudaExecutionProvider());
+    RunTest<BFloat16>(opts, std::move(eps));
   }
 }
 

--- a/onnxruntime/test/contrib_ops/matmul_8bits_test.cc
+++ b/onnxruntime/test/contrib_ops/matmul_8bits_test.cc
@@ -47,6 +47,7 @@ struct TestOptions8Bits {
   int64_t accuracy_level{0};
 
   bool has_zero_point{false};
+  bool zp_is_typed{false};  // true: zero_points use same type as scales (T); false: uint8
   bool has_g_idx{false};
   bool has_bias{false};
 
@@ -59,6 +60,7 @@ struct TestOptions8Bits {
             << ", block_size:" << opts.block_size
             << ", accuracy_level:" << opts.accuracy_level
             << ", has_zero_point:" << opts.has_zero_point
+            << ", zp_is_typed:" << opts.zp_is_typed
             << ", has_g_idx:" << opts.has_g_idx
             << ", has_bias:" << opts.has_bias;
 }
@@ -167,7 +169,23 @@ void RunTest8Bits(const TestOptions8Bits& opts) {
   }
 
   if (opts.has_zero_point) {
-    test.AddInput<uint8_t>("zero_points", {N, static_cast<int64_t>(q_zp_size_in_bytes) / N}, zp, true);
+    if (opts.zp_is_typed) {
+      // T-typed zero points: convert uint8 zp to float then to T1
+      std::vector<float> zp_f;
+      zp_f.reserve(q_zp_size_in_bytes);
+      for (size_t i = 0; i < zp.size(); i++) {
+        zp_f.push_back(static_cast<float>(zp[i]));
+      }
+      if constexpr (std::is_same_v<T1, float>) {
+        test.AddInput<T1>("zero_points", {N, static_cast<int64_t>(q_zp_size_in_bytes) / N}, zp_f, true);
+      } else if constexpr (std::is_same_v<T1, MLFloat16>) {
+        test.AddInput<T1>("zero_points", {N, static_cast<int64_t>(q_zp_size_in_bytes) / N}, FloatsToMLFloat16s(zp_f), true);
+      } else if constexpr (std::is_same_v<T1, BFloat16>) {
+        test.AddInput<T1>("zero_points", {N, static_cast<int64_t>(q_zp_size_in_bytes) / N}, FloatsToBFloat16s(zp_f), true);
+      }
+    } else {
+      test.AddInput<uint8_t>("zero_points", {N, static_cast<int64_t>(q_zp_size_in_bytes) / N}, zp, true);
+    }
   } else {
     test.AddOptionalInputEdge<uint8_t>();
   }
@@ -523,6 +541,133 @@ TEST(MatMulNBits, BFloat16_Int8_Gemm_Cuda) {
   TestMatMul8BitsTyped<BFloat16, 32, 512, 512, 64>(abs_error, rel_error);
   TestMatMul8BitsTyped<BFloat16, 1, 256, 256, 128>(abs_error, rel_error);
   TestMatMul8BitsTyped<BFloat16, 32, 1024, 1024, 128>(abs_error, rel_error);
+}
+
+// Chunked dequant+GEMM path tests for INT8.
+// Force the chunked path with a small chunk size to exercise per-chunk pointer
+// arithmetic (blob, scales, zero_points offsets) and strided cuBLAS output
+// with manageable tensor sizes.
+
+TEST(MatMulNBits, Fp16_Int8_Chunked_Uint8ZeroPoint) {
+  constexpr float abs_error = 0.1f;
+  constexpr float rel_error = 0.02f;
+
+  ScopedEnvironmentVariables scoped_env_vars{EnvVarMap{
+      {"ORT_MATMULNBITS_FORCE_CHUNKED", "1"},
+      {"ORT_MATMULNBITS_CHUNK_SIZE", "64"}}};
+
+  for (auto block_size : {32, 64, 128}) {
+    TestOptions8Bits opts{};
+    opts.M = 1, opts.N = 256, opts.K = 1024;
+    opts.block_size = block_size;
+    opts.has_zero_point = true;
+    opts.zp_is_typed = false;
+    opts.output_abs_error = abs_error;
+    opts.output_rel_error = rel_error;
+    RunTest8Bits<MLFloat16>(opts);
+
+    opts.M = 2;
+    RunTest8Bits<MLFloat16>(opts);
+  }
+}
+
+TEST(MatMulNBits, Fp16_Int8_Chunked_Fp16ZeroPoint) {
+  constexpr float abs_error = 0.1f;
+  constexpr float rel_error = 0.02f;
+
+  ScopedEnvironmentVariables scoped_env_vars{EnvVarMap{
+      {"ORT_MATMULNBITS_FORCE_CHUNKED", "1"},
+      {"ORT_MATMULNBITS_CHUNK_SIZE", "64"}}};
+
+  for (auto block_size : {32, 64, 128}) {
+    TestOptions8Bits opts{};
+    opts.M = 1, opts.N = 256, opts.K = 1024;
+    opts.block_size = block_size;
+    opts.has_zero_point = true;
+    opts.zp_is_typed = true;
+    opts.output_abs_error = abs_error;
+    opts.output_rel_error = rel_error;
+    RunTest8Bits<MLFloat16>(opts);
+
+    opts.M = 2;
+    RunTest8Bits<MLFloat16>(opts);
+  }
+}
+
+TEST(MatMulNBits, Fp16_Int8_Chunked_NoZeroPoint) {
+  constexpr float abs_error = 0.1f;
+  constexpr float rel_error = 0.02f;
+
+  ScopedEnvironmentVariables scoped_env_vars{EnvVarMap{
+      {"ORT_MATMULNBITS_FORCE_CHUNKED", "1"},
+      {"ORT_MATMULNBITS_CHUNK_SIZE", "64"}}};
+
+  for (auto block_size : {32, 64, 128}) {
+    TestOptions8Bits opts{};
+    opts.M = 1, opts.N = 256, opts.K = 1024;
+    opts.block_size = block_size;
+    opts.has_zero_point = false;
+    opts.output_abs_error = abs_error;
+    opts.output_rel_error = rel_error;
+    RunTest8Bits<MLFloat16>(opts);
+
+    opts.M = 2;
+    RunTest8Bits<MLFloat16>(opts);
+  }
+}
+
+TEST(MatMulNBits, BFloat16_Int8_Chunked_Uint8ZeroPoint) {
+  if (!HasCudaEnvironment(800)) {
+    GTEST_SKIP() << "Skipping BFloat16 tests on CUDA < 8.0";
+  }
+
+  constexpr float abs_error = 0.1f;
+  constexpr float rel_error = 0.02f;
+
+  ScopedEnvironmentVariables scoped_env_vars{EnvVarMap{
+      {"ORT_MATMULNBITS_FORCE_CHUNKED", "1"},
+      {"ORT_MATMULNBITS_CHUNK_SIZE", "64"}}};
+
+  for (auto block_size : {32, 64, 128}) {
+    TestOptions8Bits opts{};
+    opts.M = 1, opts.N = 256, opts.K = 1024;
+    opts.block_size = block_size;
+    opts.has_zero_point = true;
+    opts.zp_is_typed = false;
+    opts.output_abs_error = abs_error;
+    opts.output_rel_error = rel_error;
+    RunTest8Bits<BFloat16>(opts);
+
+    opts.M = 2;
+    RunTest8Bits<BFloat16>(opts);
+  }
+}
+
+TEST(MatMulNBits, BFloat16_Int8_Chunked_BFloat16ZeroPoint) {
+  if (!HasCudaEnvironment(800)) {
+    GTEST_SKIP() << "Skipping BFloat16 tests on CUDA < 8.0";
+  }
+
+  constexpr float abs_error = 0.1f;
+  constexpr float rel_error = 0.02f;
+
+  ScopedEnvironmentVariables scoped_env_vars{EnvVarMap{
+      {"ORT_MATMULNBITS_FORCE_CHUNKED", "1"},
+      {"ORT_MATMULNBITS_CHUNK_SIZE", "64"}}};
+
+  for (auto block_size : {32, 64, 128}) {
+    TestOptions8Bits opts{};
+    opts.M = 1, opts.N = 256, opts.K = 1024;
+    opts.block_size = block_size;
+    opts.has_zero_point = true;
+    opts.zp_is_typed = true;
+    opts.output_abs_error = abs_error;
+    opts.output_rel_error = rel_error;
+    RunTest8Bits<BFloat16>(opts);
+
+    opts.M = 2;
+    RunTest8Bits<BFloat16>(opts);
+  }
 }
 #endif
 


### PR DESCRIPTION
## Description

When `MatMulNBits` dequantizes a large weight matrix (e.g., a 248K×2048 INT8 embed/lm_head), it allocates a scratch buffer for the full FP16 dequantized result before calling cuBLAS GEMM. For models with large vocabularies and tied embeddings, this single allocation can exceed **970 MB**, causing unnecessary peak GPU memory pressure.

This PR introduces a **chunked dequant+GEMM path** that splits the N dimension into 32K-row chunks, dequantizing and computing GEMM one chunk at a time into a strided output. This reduces the scratch buffer from `N × K × sizeof(FP16)` to `32K × K × sizeof(FP16)`.

### Example: Qwen3.5-2B (vocab=248K, hidden=2048, INT8 block_size=32)

| | Before | After |
|---|---|---|
| Scratch buffer | 970 MB | 125 MB |
| Peak net GPU (model) | 3.17 GB | 2.16 GB |

### When the chunked path activates

All four conditions must be true:
1. Scratch buffer would exceed **256 MB**
2. `N > 64K` rows
3. Column-wise quantization (`column_wise_quant_blk_`)
4. No `reorder_idx` (g_idx)

When any condition is false, the original full-dequant path is used unchanged.

### How it works

1. Allocate scratch for one chunk (32K × K) instead of full (N × K)
2. Skip the upfront full dequantization
3. In the GEMM section, loop over N in 32K-row chunks:
   - Dequantize chunk of blob/scales/zero_points into the scratch buffer
   - Call `cublasGemmHelper` with strided output (`out_data + n_start`, `ldc = N`)
4. Supports both INT8 and INT4, with FP16 or uint8 zero points

### What is NOT changed

- No new dependencies or build flags
- No accuracy impact (same dequant kernels, same cuBLAS GEMM)
- No change to the fused `TryMatMulNBits` / `TryMatMul8Bits` fast paths (m=1 decode)
- No change to the `fpA_intB_gemm` PrePack path
- Batched GEMM path (`OutputOffsets().size() > 1`) is unmodified

### Motivation

Models with shared/tied INT8 embeddings (e.g., Qwen3.5, Llama with `shared_embeddings=true`) have a 248K+ row weight matrix for both `embed_tokens` and `lm_head`. The `lm_head` MatMulNBits dequantizes this entire matrix to FP16 during prefill (when `m > 1` and the fused `TryMatMul8Bits` m=1 kernel can't be used). On an 8 GB GPU, the 970 MB scratch buffer alone can push total VRAM over budget.