### PR TITLE
checks to handle oob writes based on seqlens_k

### DIFF
--- a/onnxruntime/contrib_ops/webgpu/bert/flash_attention.cc
+++ b/onnxruntime/contrib_ops/webgpu/bert/flash_attention.cc
@@ -74,11 +74,12 @@ Status CopyKVCacheProgram::GenerateShaderCode(ShaderHelper& shader) const {
                                "  let num_head_id = output_indices[1];\n"
                                "  let batch = output_indices[0];\n";
   if (use_seqlen_k_) {
-    shader.MainFunctionBody() << "  let total_seq_length = u32(seqlen_k[0u]) + 1u;\n";
+    shader.MainFunctionBody() << "  let raw_total_seq_length = u32(seqlen_k[0u]) + 1u;\n"
+                              << "  let total_seq_length = min(max(raw_total_seq_length, uniforms.kv_sequence_length), uniforms.present_sequence_length);\n";
   } else {
     shader.MainFunctionBody() << "  let total_seq_length = uniforms.total_sequence_length;\n";
   }
-  shader.MainFunctionBody() << "  let past_sequence_length = total_seq_length - uniforms.kv_sequence_length;\n";
+  shader.MainFunctionBody() << "  let past_sequence_length = select(0u, total_seq_length - uniforms.kv_sequence_length, total_seq_length >= uniforms.kv_sequence_length);\n";
   if (past_present_share_buffer_) {
     shader.MainFunctionBody() << "  let present_offset = " << present_key.IndicesToOffset("present_key_indices_t(batch, num_head_id, past_sequence_length + sequence_id, head_size_id)") << ";\n";
   } else {
@@ -175,6 +176,7 @@ Status CopyKVCache(onnxruntime::webgpu::ComputeContext& context, const WebgpuAtt
       .AddUniformVariables({{static_cast<uint32_t>(copy_size)},
                             {static_cast<uint32_t>(parameters.total_sequence_length_)},
                             {static_cast<uint32_t>(parameters.kv_sequence_length_)},
+                            {gsl::narrow_cast<uint32_t>(present_key->Shape()[2])},
                             {tile_size},
                             {static_cast<uint32_t>(parameters.num_heads_)}});
 

--- a/onnxruntime/contrib_ops/webgpu/bert/flash_attention.h
+++ b/onnxruntime/contrib_ops/webgpu/bert/flash_attention.h
@@ -55,6 +55,7 @@ class CopyKVCacheProgram final : public Program<CopyKVCacheProgram> {
   WEBGPU_PROGRAM_DEFINE_UNIFORM_VARIABLES({"copy_size", ProgramUniformVariableDataType::Uint32},
                                           {"total_sequence_length", ProgramUniformVariableDataType::Uint32},
                                           {"kv_sequence_length", ProgramUniformVariableDataType::Uint32},
+                                          {"present_sequence_length", ProgramUniformVariableDataType::Uint32},
                                           {"tile_size", ProgramUniformVariableDataType::Uint32},
                                           {"num_heads", ProgramUniformVariableDataType::Uint32});
 

--- a/onnxruntime/contrib_ops/webgpu/bert/flash_attention.wgsl.template
+++ b/onnxruntime/contrib_ops/webgpu/bert/flash_attention.wgsl.template
@@ -18,7 +18,7 @@ const num_heads : u32 = qkv_num_heads;
 #if use_seqlen_k
 // When graph capture is enabled, total_sequence_length is read from GPU buffer
 fn get_total_sequence_length() -> u32 {
-  return u32(seqlens_k[0]) + 1u;
+  return min(max(u32(seqlens_k[0]) + 1u, uniforms.new_sequence_length), uniforms.present_sequence_length);
 }
 #else
 // When graph capture is disabled, total_sequence_length comes from uniforms

--- a/onnxruntime/contrib_ops/webgpu/bert/flash_attention_decode_qkt.wgsl.template
+++ b/onnxruntime/contrib_ops/webgpu/bert/flash_attention_decode_qkt.wgsl.template
@@ -60,7 +60,7 @@ $MAIN {
   let local_row = u32(local_idx / tile_size_k_vec);
   let local_col = local_idx % tile_size_k_vec;
 #if use_indirect_dispatch
-  let total_sequence_length = u32(seqlens_k[0]) + 1u;
+  let total_sequence_length = min(max(u32(seqlens_k[0]) + 1u, 1u), uniforms.present_sequence_length);
 #else
   let total_sequence_length = uniforms.total_sequence_length;
 #endif

--- a/onnxruntime/contrib_ops/webgpu/bert/flash_attention_decode_split_vx.wgsl.template
+++ b/onnxruntime/contrib_ops/webgpu/bert/flash_attention_decode_split_vx.wgsl.template
@@ -43,7 +43,7 @@ $MAIN {
   let local_row = u32(local_idx / tile_size_k_vec);
   let local_col = local_idx % tile_size_k_vec;
   #if use_indirect_dispatch
-  let total_sequence_length = u32(seqlens_k[0]) + 1u;
+  let total_sequence_length = min(max(u32(seqlens_k[0]) + 1u, 1u), uniforms.present_sequence_length);
   #else
   let total_sequence_length = uniforms.total_sequence_length;
   #endif

--- a/onnxruntime/contrib_ops/webgpu/bert/flash_attention_decode_vx_reduce.wgsl.template
+++ b/onnxruntime/contrib_ops/webgpu/bert/flash_attention_decode_vx_reduce.wgsl.template
@@ -29,7 +29,7 @@ $MAIN {
   let local_row = u32(local_idx / tile_size);
   let local_col = local_idx % tile_size;
   #if use_indirect_dispatch
-  let total_sequence_length = u32(seqlens_k[0]) + 1u;
+  let total_sequence_length = min(max(u32(seqlens_k[0]) + 1u, 1u), uniforms.num_present_sequence_length_tile * seq_tile_size);
   let num_total_seq_length_tile = (total_sequence_length + seq_tile_size - 1) / seq_tile_size;
   #else
   let num_total_seq_length_tile = uniforms.num_total_seq_length_tile;

--- a/onnxruntime/contrib_ops/webgpu/bert/split_packed_qkv_with_rotary_embedding.wgsl.template
+++ b/onnxruntime/contrib_ops/webgpu/bert/split_packed_qkv_with_rotary_embedding.wgsl.template
@@ -37,9 +37,9 @@ $MAIN {
 #else
     let base_position = 0u;
 #endif
+    let max_rotary_position = uniforms.cos_cache_shape[0];
+    let valid_rotary_position = base_position < max_rotary_position && position_id < max_rotary_position - base_position;
     // Process a rotary pair (i, j)
-    let cos_v = cos_cache.getByIndices(vec2<u32>(base_position + position_id, in_head_idx));
-    let sin_v = sin_cache.getByIndices(vec2<u32>(base_position + position_id, in_head_idx));
 
     // Calculate actual indices in the head for i and j
 #if interleaved
@@ -56,8 +56,14 @@ $MAIN {
     let q_j_offset = q_base + idx_j;
     let q_i = packed_qkv.getByOffset(q_i_offset);
     let q_j = packed_qkv.getByOffset(q_j_offset);
-    let q_re = q_i * cos_v - q_j * sin_v;
-    let q_im = q_i * sin_v + q_j * cos_v;
+    var q_re = q_i;
+    var q_im = q_j;
+    if (valid_rotary_position) {
+      let cos_v = cos_cache.getByIndices(vec2<u32>(base_position + position_id, in_head_idx));
+      let sin_v = sin_cache.getByIndices(vec2<u32>(base_position + position_id, in_head_idx));
+      q_re = q_i * cos_v - q_j * sin_v;
+      q_im = q_i * sin_v + q_j * cos_v;
+    }
     query.setByIndices(vec3<u32>(batch_idx, seq_idx, head_idx * uniforms.head_size + idx_i), q_re);
     query.setByIndices(vec3<u32>(batch_idx, seq_idx, head_idx * uniforms.head_size + idx_j), q_im);
 
@@ -68,8 +74,14 @@ $MAIN {
       let k_j_offset = k_base + idx_j;
       let k_i = packed_qkv.getByOffset(k_i_offset);
       let k_j = packed_qkv.getByOffset(k_j_offset);
-      let k_re = k_i * cos_v - k_j * sin_v;
-      let k_im = k_i * sin_v + k_j * cos_v;
+      var k_re = k_i;
+      var k_im = k_j;
+      if (valid_rotary_position) {
+        let cos_v = cos_cache.getByIndices(vec2<u32>(base_position + position_id, in_head_idx));
+        let sin_v = sin_cache.getByIndices(vec2<u32>(base_position + position_id, in_head_idx));
+        k_re = k_i * cos_v - k_j * sin_v;
+        k_im = k_i * sin_v + k_j * cos_v;
+      }
       key.setByIndices(vec3<u32>(batch_idx, seq_idx, head_idx * uniforms.head_size + idx_i), k_re);
       key.setByIndices(vec3<u32>(batch_idx, seq_idx, head_idx * uniforms.head_size + idx_j), k_im);
 

--- a/onnxruntime/contrib_ops/webgpu/bert/split_packed_qkv_with_rotary_embedding_and_copykv.wgsl.template
+++ b/onnxruntime/contrib_ops/webgpu/bert/split_packed_qkv_with_rotary_embedding_and_copykv.wgsl.template
@@ -28,17 +28,20 @@ $MAIN {
 
   // Calculate position_id (needed for rotary embedding)
   let seqlen_i = seqlens.getByOffset(batch_idx);
-  let seqlen = u32(seqlen_i);
-  let total_seqlen = seqlen + 1u;
+  let raw_total_seqlen = u32(seqlen_i) + 1u;
+  let total_seqlen = min(max(raw_total_seqlen, uniforms.sequence_length), uniforms.present_sequence_length);
 
   let past_seqlen = total_seqlen - uniforms.sequence_length;
   // `position_id` is used to get cos/sin cache and also as the time step index in present_key/present_value
   let position_id = past_seqlen + seq_idx;
+  let valid_cache_position = raw_total_seqlen >= uniforms.sequence_length && raw_total_seqlen <= uniforms.present_sequence_length;
 #if use_multi_rotary_cache_concat
   let base_position = select(0u, multi_rotary_cache_concat_offset, total_seqlen > multi_rotary_cache_concat_offset);
 #else
   let base_position = 0u;
 #endif
+  let max_rotary_position = uniforms.cos_cache_shape[0];
+  let valid_rotary_position = base_position < max_rotary_position && position_id < max_rotary_position - base_position;
 
 #if prepare_indirect_dispatch
   // Prepare indirect dispatch buffer for thread 0
@@ -52,9 +55,6 @@ $MAIN {
 
   if (in_head_idx < uniforms.half_rotary_dim) {
     // Process a rotary pair (i, j)
-    let cos_v = cos_cache.getByIndices(vec2<u32>(base_position + position_id, in_head_idx));
-    let sin_v = sin_cache.getByIndices(vec2<u32>(base_position + position_id, in_head_idx));
-
     // Calculate actual indices in the head for i and j
 #if interleaved
     let idx_i = in_head_idx + in_head_idx;
@@ -70,20 +70,32 @@ $MAIN {
     let q_j_offset = q_base + idx_j;
     let q_i = packed_qkv.getByOffset(q_i_offset);
     let q_j = packed_qkv.getByOffset(q_j_offset);
-    let q_re = q_i * cos_v - q_j * sin_v;
-    let q_im = q_i * sin_v + q_j * cos_v;
+    var q_re = q_i;
+    var q_im = q_j;
+    if (valid_rotary_position) {
+      let cos_v = cos_cache.getByIndices(vec2<u32>(base_position + position_id, in_head_idx));
+      let sin_v = sin_cache.getByIndices(vec2<u32>(base_position + position_id, in_head_idx));
+      q_re = q_i * cos_v - q_j * sin_v;
+      q_im = q_i * sin_v + q_j * cos_v;
+    }
     query.setByIndices(vec3<u32>(batch_idx, seq_idx, head_idx * uniforms.head_size + idx_i), q_re);
     query.setByIndices(vec3<u32>(batch_idx, seq_idx, head_idx * uniforms.head_size + idx_j), q_im);
 
     // Process K and V pairs if within kv_num_heads
-    if (head_idx < uniforms.kv_num_heads) {
+    if (head_idx < uniforms.kv_num_heads && valid_cache_position) {
       let k_base = base_offset + uniforms.hidden_size + head_idx * uniforms.head_size;
       let k_i_offset = k_base + idx_i;
       let k_j_offset = k_base + idx_j;
       let k_i = packed_qkv.getByOffset(k_i_offset);
       let k_j = packed_qkv.getByOffset(k_j_offset);
-      let k_re = k_i * cos_v - k_j * sin_v;
-      let k_im = k_i * sin_v + k_j * cos_v;
+      var k_re = k_i;
+      var k_im = k_j;
+      if (valid_rotary_position) {
+        let cos_v = cos_cache.getByIndices(vec2<u32>(base_position + position_id, in_head_idx));
+        let sin_v = sin_cache.getByIndices(vec2<u32>(base_position + position_id, in_head_idx));
+        k_re = k_i * cos_v - k_j * sin_v;
+        k_im = k_i * sin_v + k_j * cos_v;
+      }
       // Write K directly to present_key cache
       present_key.setByIndices(vec4<u32>(batch_idx, head_idx, position_id, idx_i), k_re);
       present_key.setByIndices(vec4<u32>(batch_idx, head_idx, position_id, idx_j), k_im);
@@ -105,7 +117,7 @@ $MAIN {
     query.setByIndices(vec3<u32>(batch_idx, seq_idx, head_idx * uniforms.head_size + actual_idx), q_data);
 
     // Copy K and V if within kv_num_heads directly to present cache
-    if (head_idx < uniforms.kv_num_heads) {
+    if (head_idx < uniforms.kv_num_heads && valid_cache_position) {
       let k_offset = base_offset + uniforms.hidden_size + head_idx * uniforms.head_size + actual_idx;
       let k_data = packed_qkv.getByOffset(k_offset);
       present_key.setByIndices(vec4<u32>(batch_idx, head_idx, position_id, actual_idx), k_data);


### PR DESCRIPTION
WebGPU GroupQueryAttention kernel reads the int32 element values of the seqlens_k input tensor (input#5) inside the WGSL shader and uses them directly to derive position_id, which becomes the sequence index of present_key.setByIndices / present_value.setByIndices. CheckInputs validates only the shape of seqlens_k. Handle the case where iff formed values on seqlens_k can result in oob writes.