### PR TITLE
Fix Conv shape inference OOB read for mismatched weight spatial rank

### DIFF
--- a/cmake/patches/onnx/onnx.patch
+++ b/cmake/patches/onnx/onnx.patch
@@ -74,7 +74,39 @@ diff --git a/onnx/defs/nn/old.cc b/onnx/defs/nn/old.cc
 index a6a8a83..153da87 100644
 --- a/onnx/defs/nn/old.cc
 +++ b/onnx/defs/nn/old.cc
-@@ -4026,7 +4026,6 @@ ONNX_OPERATOR_SET_SCHEMA(
+@@ -179,10 +179,14 @@
+        return;
+      }
+      kernel_shape.push_back(second_input_shape.dim(i).dim_value());
+    }
+  }
++  if (kernel_shape.size() != n_input_dims) {
++    fail_shape_inference("Attribute kernel_shape has incorrect size");
++  }
++
+ 
+   std::vector<int64_t> effective_kernel_shape = kernel_shape;
+   for (size_t i = 0; i < kernel_shape.size(); i++) {
+     // accounting for dilation, how big is the kernel in this dimension
+     effective_kernel_shape[i] = (effective_kernel_shape[i] - 1) * dilations[i] + 1;
+@@ -1988,10 +1992,14 @@
+        return;
+      }
+      kernel_shape.push_back(second_input_shape.dim(i).dim_value());
+    }
+  }
++  if (kernel_shape.size() != n_input_dims) {
++    fail_shape_inference("Attribute kernel_shape has incorrect size");
++  }
++
+ 
+   std::vector<int64_t> effective_kernel_shape = kernel_shape;
+   for (size_t i = 0; i < kernel_shape.size(); i++) {
+     // accounting for dilation, how big is the kernel in this dimension
+     effective_kernel_shape[i] = (effective_kernel_shape[i] - 1) * dilations[i] + 1;
+@@ -4024,11 +4032,10 @@
+ 
+ ONNX_OPERATOR_SET_SCHEMA(
      GroupNormalization,
      18,
      OpSchema()
@@ -82,3 +114,5 @@ index a6a8a83..153da87 100644
          .SetDoc(GroupNormalization_ver18_doc)
          .Attr("epsilon", "The epsilon value to use to avoid division by zero.", AttributeProto::FLOAT, 1e-5f)
          .Attr(
+             "num_groups",
+             "The number of groups of channels. It should be a divisor of the number of channels `C`.",

--- a/onnxruntime/test/framework/inference_session_test.cc
+++ b/onnxruntime/test/framework/inference_session_test.cc
@@ -1213,6 +1213,50 @@ TEST(InferenceSessionTests, TestOptionalInputs) {
   }
 }
 
+static std::string BuildConvModelWithMismatchedWeightSpatialRankBytes(int64_t opset_version) {
+  ONNX_NAMESPACE::ModelProto model;
+  model.set_ir_version(ONNX_NAMESPACE::Version::IR_VERSION);
+
+  auto* opset = model.add_opset_import();
+  opset->set_domain(onnxruntime::kOnnxDomain);
+  opset->set_version(opset_version);
+
+  auto* graph = model.mutable_graph();
+  graph->set_name("conv_mismatched_weight_spatial_rank");
+
+  auto add_tensor_value_info = [](ONNX_NAMESPACE::ValueInfoProto* value_info,
+                                  const char* name,
+                                  const std::vector<int64_t>& dims) {
+    value_info->set_name(name);
+    auto* type = value_info->mutable_type()->mutable_tensor_type();
+    type->set_elem_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+    auto* shape = type->mutable_shape();
+    for (int64_t dim : dims) {
+      shape->add_dim()->set_dim_value(dim);
+    }
+  };
+
+  add_tensor_value_info(graph->add_input(), "X", {1, 1, 4, 4});
+  add_tensor_value_info(graph->add_input(), "W", {1, 1, 3, 3, 3});
+
+  auto* output = graph->add_output();
+  output->set_name("Y");
+  output->mutable_type()->mutable_tensor_type()->set_elem_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+
+  auto* node = graph->add_node();
+  node->set_name("Conv_0");
+  node->set_op_type("Conv");
+  node->set_domain(onnxruntime::kOnnxDomain);
+  node->add_input("X");
+  node->add_input("W");
+  node->add_output("Y");
+
+  std::string model_data;
+  const bool serialized = model.SerializeToString(&model_data);
+  EXPECT_TRUE(serialized);
+  return model_data;
+}
+
 static void CreateFuseOpModel(const PathString& model_file_name) {
   onnxruntime::Model model("graph_1", false, ModelMetaData(), PathString(), IOnnxRuntimeOpSchemaRegistryList(),
                            {{kOnnxDomain, 12}}, {}, DefaultLoggingManager().DefaultLogger());
@@ -2954,6 +2998,30 @@ TEST(InferenceSessionTests, InterThreadPoolWithDenormalAsZero) {
   VerifyThreadPoolWithDenormalAsZero(session2.GetInterOpThreadPoolToUse(), false);
 }
 #endif
+
+#ifndef ORT_NO_EXCEPTIONS
+TEST(InferenceSessionTests, ConvLoadRejectsWeightSpatialRankMismatchOpset11) {
+  const std::string model_data = BuildConvModelWithMismatchedWeightSpatialRankBytes(11);
+  std::stringstream model_stream(model_data);
+
+  SessionOptions so;
+  so.session_logid = "InferenceSessionTests.ConvLoadRejectsWeightSpatialRankMismatchOpset11";
+  InferenceSession session{so, GetEnvironment()};
+
+  ASSERT_STATUS_NOT_OK_AND_HAS_SUBSTR(session.Load(model_stream), "Attribute kernel_shape has incorrect size");
+}
+
+TEST(InferenceSessionTests, ConvLoadRejectsWeightSpatialRankMismatchOpset1) {
+  const std::string model_data = BuildConvModelWithMismatchedWeightSpatialRankBytes(1);
+  std::stringstream model_stream(model_data);
+
+  SessionOptions so;
+  so.session_logid = "InferenceSessionTests.ConvLoadRejectsWeightSpatialRankMismatchOpset1";
+  InferenceSession session{so, GetEnvironment()};
+
+  ASSERT_STATUS_NOT_OK_AND_HAS_SUBSTR(session.Load(model_stream), "Attribute kernel_shape has incorrect size");
+}
+#endif  // !ORT_NO_EXCEPTIONS
 
 TEST(InferenceSessionTests, BadDataTypeInInitializerIsHandled) {
   // model has an initializer with a bogus data type. Graph ctor should detect and throw.


### PR DESCRIPTION
Related to #28731 

## Description
Fixes an out-of-bounds read in Conv shape inference when `kernel_shape` inferred from weight rank does not match input spatial rank.

The issue is in ONNX shape inference code used by ORT during model load, and can be triggered by malformed Conv models where:
- input rank implies `n_input_dims = N`
- weight rank implies `kernel_shape.size() > N`

## Changes
- Updated `cmake/patches/onnx/onnx.patch`:
  - Added `kernel_shape.size() == n_input_dims` validation in:
    - `convPoolShapeInference_opset19`
    - `convPoolShapeInference1`
- Added regression tests in `onnxruntime/test/framework/inference_session_test.cc`:
  - `InferenceSessionTests.ConvLoadRejectsWeightSpatialRankMismatchOpset11`
  - `InferenceSessionTests.ConvLoadRejectsWeightSpatialRankMismatchOpset1`
- Tests build malformed models in-memory and verify `InferenceSession::Load()` fails with shape-inference error instead of hitting UB.

## Validation
- Verified ONNX patch applies cleanly to ONNX `v1.21.0` with ORT patch flags:
  - `patch --dry-run --binary --ignore-whitespace -p1`
- Added focused regression coverage for both opset paths (legacy + opset19 helper path).

## Risk
Low.
- Behavior changes only for invalid/malformed models.
- Valid models are unaffected.
