### PR TITLE
Add 10 contributor onboarding playbooks

### DIFF
--- a/docs/Contributor_Playbooks_Plan.md
+++ b/docs/Contributor_Playbooks_Plan.md
@@ -31,6 +31,7 @@ The following playbooks have been drafted:
 6. [06 Adding a Contrib Operator](playbooks/06-adding-a-contrib-operator.md)
 7. [07 Graph Optimizations and Fusion Passes](playbooks/07-graph-optimizations-and-fusion-passes.md)
 8. [08 Execution Provider Implementation](playbooks/08-execution-provider-implementation.md)
+9. [09 Memory Management, Allocators, and Data Movement](playbooks/09-memory-management-allocators-and-data-movement.md)
 
 ## Proposed Playbooks
 

--- a/docs/Contributor_Playbooks_Plan.md
+++ b/docs/Contributor_Playbooks_Plan.md
@@ -27,6 +27,7 @@ The first three playbooks have been drafted:
 2. [02 Build, Test, and Debug Locally](playbooks/02-build-test-and-debug-locally.md)
 3. [03 First PR and Environment Setup](playbooks/03-first-pr-and-environment-setup.md)
 4. [04 Session Lifecycle from Load to Run](playbooks/04-session-lifecycle-from-load-to-run.md)
+5. [05 Adding or Changing a Kernel](playbooks/05-adding-or-changing-a-kernel.md)
 
 ## Proposed Playbooks
 

--- a/docs/Contributor_Playbooks_Plan.md
+++ b/docs/Contributor_Playbooks_Plan.md
@@ -28,6 +28,7 @@ The first three playbooks have been drafted:
 3. [03 First PR and Environment Setup](playbooks/03-first-pr-and-environment-setup.md)
 4. [04 Session Lifecycle from Load to Run](playbooks/04-session-lifecycle-from-load-to-run.md)
 5. [05 Adding or Changing a Kernel](playbooks/05-adding-or-changing-a-kernel.md)
+6. [06 Adding a Contrib Operator](playbooks/06-adding-a-contrib-operator.md)
 
 ## Proposed Playbooks
 

--- a/docs/Contributor_Playbooks_Plan.md
+++ b/docs/Contributor_Playbooks_Plan.md
@@ -1,0 +1,222 @@
+# Contributor Playbooks Plan
+
+This document lays out a proposed set of 10 playbooks for new contributors to ONNX Runtime. The goal is to turn the repo’s scattered reference material into a guided learning path that starts with low-risk changes and builds toward deeper subsystems.
+
+The current repo already has one true playbook: [ExecutionProvider_Playbook.md](ExecutionProvider_Playbook.md). The rest of the guidance is spread across reference docs such as [CONTRIBUTING.md](../CONTRIBUTING.md), [PR_Guidelines.md](PR_Guidelines.md), [Coding_Conventions_and_Standards.md](Coding_Conventions_and_Standards.md), [Model_Test.md](Model_Test.md), and [C_API_Guidelines.md](C_API_Guidelines.md).
+
+## Intended Learning Order
+
+The playbooks should be written in this sequence so that each one builds on the previous one:
+
+1. Repo map and architecture overview
+2. Build, test, and debug locally
+3. First PR and environment setup
+4. Session lifecycle from load to run
+5. Adding or changing a kernel
+6. Adding a contrib operator
+7. Graph optimizations and fusion passes
+8. Execution provider implementation
+9. Memory management, allocators, and data movement
+10. Python and C API binding extension
+
+## Draft Status
+
+The first three playbooks have been drafted:
+
+1. [01 Repo Map and Architecture Overview](playbooks/01-repo-map-and-architecture-overview.md)
+2. [02 Build, Test, and Debug Locally](playbooks/02-build-test-and-debug-locally.md)
+3. [03 First PR and Environment Setup](playbooks/03-first-pr-and-environment-setup.md)
+
+## Proposed Playbooks
+
+### 1. Repo map and architecture overview
+
+Purpose: explain how the major pieces of ORT fit together before a contributor touches code.
+
+Should cover:
+
+- model loading, graph IR, optimization, partitioning, and execution
+- top-level directories and what lives in each one
+- where contributors should look for inference, training, and bindings work
+
+Starter references:
+
+- `onnxruntime/core/`
+- `onnxruntime/test/`
+- `orttraining/`
+- `csharp/`, `java/`, `js/`, `objectivec/`, `rust/`
+
+### 2. Build, test, and debug locally
+
+Purpose: make the everyday developer loop predictable and reproducible.
+
+Should cover:
+
+- the recommended build entry points on each platform
+- selecting targeted tests instead of full-suite runs
+- common debugging workflows for kernel and graph issues
+- how to use the existing test infrastructure effectively
+
+Starter references:
+
+- `build.sh`
+- `build.bat`
+- [Model_Test.md](Model_Test.md)
+
+### 3. First PR and environment setup
+
+Purpose: help a new contributor get from a fresh clone to a small, reviewable pull request.
+
+Should cover:
+
+- cloning the repo and setting up prerequisites
+- choosing a good first issue or a safe small task
+- running the smallest useful build and test loop
+- preparing a PR that follows the repo’s conventions
+
+Starter references:
+
+- [CONTRIBUTING.md](../CONTRIBUTING.md)
+- [PR_Guidelines.md](PR_Guidelines.md)
+- [Coding_Conventions_and_Standards.md](Coding_Conventions_and_Standards.md)
+
+### 4. Session lifecycle from load to run
+
+Purpose: show how ORT turns a model into an executable session.
+
+Should cover:
+
+- the `Load()` to `Initialize()` to `Run()` flow
+- graph optimization and partitioning checkpoints
+- how session options affect execution
+- where execution providers and kernels enter the flow
+
+Starter references:
+
+- `onnxruntime/core/session/`
+- `onnxruntime/core/graph/`
+- `onnxruntime/core/optimizer/`
+
+### 5. Adding or changing a kernel
+
+Purpose: teach the smallest meaningful execution change that still touches ORT internals.
+
+Should cover:
+
+- how kernel registration works
+- CPU vs provider-specific kernel structure
+- shape/type validation and error reporting
+- adding tests for correctness and edge cases
+
+Starter references:
+
+- `onnxruntime/core/framework/`
+- `onnxruntime/core/providers/`
+- `onnxruntime/test/providers/`
+
+### 6. Adding a contrib operator
+
+Purpose: show how to introduce a `com.microsoft` operator and keep it maintainable.
+
+Should cover:
+
+- schema definition and registration
+- kernel implementations across providers as needed
+- documentation and test coverage expectations
+- compatibility concerns for a non-standard op
+
+Starter references:
+
+- [ContribOperators.md](ContribOperators.md)
+- `onnxruntime/contrib_ops/`
+
+### 7. Graph optimizations and fusion passes
+
+Purpose: help a contributor understand how ORT rewrites graphs before execution.
+
+Should cover:
+
+- pattern matching and transformation basics
+- when to fuse nodes and when not to
+- how to keep optimizer behavior conservative and deterministic
+- how to validate rewrites with focused tests
+
+Starter references:
+
+- `onnxruntime/core/optimizer/`
+- `onnxruntime/core/graph/`
+
+### 8. Execution provider implementation
+
+Purpose: expand the existing playbook into a newcomer-friendly path from scaffold to first supported op.
+
+Should cover:
+
+- provider skeleton, factory wiring, and build integration
+- capability discovery and partitioning
+- allocators, memory info, and data movement
+- runtime registration and tests
+
+Starter references:
+
+- [ExecutionProvider_Playbook.md](ExecutionProvider_Playbook.md)
+- `onnxruntime/core/providers/`
+- `docs/cuda_plugin_ep/QUICK_START.md`
+
+### 9. Memory management, allocators, and data movement
+
+Purpose: explain the performance- and correctness-critical memory layer.
+
+Should cover:
+
+- allocator types and lifetime rules
+- device, pinned, and read-only memory concepts
+- transfer paths across execution providers
+- common failure modes and how to test them
+
+Starter references:
+
+- `onnxruntime/core/framework/`
+- `onnxruntime/core/providers/`
+
+### 10. Python and C API binding extension
+
+Purpose: show how a C++ or session-level feature is exposed to Python and the public C API.
+
+Should cover:
+
+- where the public C API lives
+- how Python bindings map onto the C API and core runtime
+- compatibility and versioning constraints for exported APIs
+- tests for binding and option propagation
+
+Starter references:
+
+- [C_API_Guidelines.md](C_API_Guidelines.md)
+- `include/onnxruntime/core/session/onnxruntime_c_api.h`
+- `onnxruntime/python/`
+
+## Suggested Writing Rule
+
+Each playbook should be practical and task-oriented:
+
+- start with a short outcome statement
+- list the repo files or subsystems the reader should open first
+- walk through a minimal implementation path
+- include a small test plan and common failure modes
+- end with a checklist the contributor can use before opening a PR
+
+## What Makes These 10 Useful
+
+Together, the set covers the main contributor journeys in ORT:
+
+- first-time contribution
+- core runtime concepts
+- local development and debugging
+- operator and kernel work
+- graph transformation work
+- execution provider work
+- memory and performance concerns
+- public API and binding work
+
+That gives new contributors a path from “I can build the repo” to “I can safely modify a core subsystem.”

--- a/docs/Contributor_Playbooks_Plan.md
+++ b/docs/Contributor_Playbooks_Plan.md
@@ -32,6 +32,7 @@ The following playbooks have been drafted:
 7. [07 Graph Optimizations and Fusion Passes](playbooks/07-graph-optimizations-and-fusion-passes.md)
 8. [08 Execution Provider Implementation](playbooks/08-execution-provider-implementation.md)
 9. [09 Memory Management, Allocators, and Data Movement](playbooks/09-memory-management-allocators-and-data-movement.md)
+10. [10 Python and C API Binding Extension](playbooks/10-python-and-c-api-binding-extension.md)
 
 ## Proposed Playbooks
 

--- a/docs/Contributor_Playbooks_Plan.md
+++ b/docs/Contributor_Playbooks_Plan.md
@@ -21,7 +21,7 @@ The playbooks should be written in this sequence so that each one builds on the 
 
 ## Draft Status
 
-The first three playbooks have been drafted:
+The following playbooks have been drafted:
 
 1. [01 Repo Map and Architecture Overview](playbooks/01-repo-map-and-architecture-overview.md)
 2. [02 Build, Test, and Debug Locally](playbooks/02-build-test-and-debug-locally.md)
@@ -29,6 +29,7 @@ The first three playbooks have been drafted:
 4. [04 Session Lifecycle from Load to Run](playbooks/04-session-lifecycle-from-load-to-run.md)
 5. [05 Adding or Changing a Kernel](playbooks/05-adding-or-changing-a-kernel.md)
 6. [06 Adding a Contrib Operator](playbooks/06-adding-a-contrib-operator.md)
+7. [07 Graph Optimizations and Fusion Passes](playbooks/07-graph-optimizations-and-fusion-passes.md)
 
 ## Proposed Playbooks
 

--- a/docs/Contributor_Playbooks_Plan.md
+++ b/docs/Contributor_Playbooks_Plan.md
@@ -30,6 +30,7 @@ The following playbooks have been drafted:
 5. [05 Adding or Changing a Kernel](playbooks/05-adding-or-changing-a-kernel.md)
 6. [06 Adding a Contrib Operator](playbooks/06-adding-a-contrib-operator.md)
 7. [07 Graph Optimizations and Fusion Passes](playbooks/07-graph-optimizations-and-fusion-passes.md)
+8. [08 Execution Provider Implementation](playbooks/08-execution-provider-implementation.md)
 
 ## Proposed Playbooks
 

--- a/docs/Contributor_Playbooks_Plan.md
+++ b/docs/Contributor_Playbooks_Plan.md
@@ -26,6 +26,7 @@ The first three playbooks have been drafted:
 1. [01 Repo Map and Architecture Overview](playbooks/01-repo-map-and-architecture-overview.md)
 2. [02 Build, Test, and Debug Locally](playbooks/02-build-test-and-debug-locally.md)
 3. [03 First PR and Environment Setup](playbooks/03-first-pr-and-environment-setup.md)
+4. [04 Session Lifecycle from Load to Run](playbooks/04-session-lifecycle-from-load-to-run.md)
 
 ## Proposed Playbooks
 

--- a/docs/playbooks/01-repo-map-and-architecture-overview.md
+++ b/docs/playbooks/01-repo-map-and-architecture-overview.md
@@ -1,0 +1,88 @@
+# Playbook 01: Repo Map and Architecture Overview
+
+## Outcome
+
+By the end of this playbook, you will understand where major subsystems live, how inference flows through ONNX Runtime, and where to start reading code for common contribution types.
+
+## Start Here
+
+- [README.md](../../README.md)
+- [CONTRIBUTING.md](../../CONTRIBUTING.md)
+- [docs/Coding_Conventions_and_Standards.md](../Coding_Conventions_and_Standards.md)
+- [AGENTS.md](../../AGENTS.md)
+
+## Core Runtime Mental Model
+
+ONNX Runtime inference pipeline:
+
+1. Load model
+2. Build graph
+3. Optimize graph
+4. Partition across execution providers
+5. Execute kernels
+
+Use this model as your map when navigating code.
+
+## Top-Level Repo Areas
+
+- [onnxruntime/core](../../onnxruntime/core): graph, optimizer, session, runtime framework, execution providers
+- [onnxruntime/test](../../onnxruntime/test): C++ tests, provider tests, model tests
+- [onnxruntime/contrib_ops](../../onnxruntime/contrib_ops): non-standard operators and registrations
+- [orttraining](../../orttraining): training-specific runtime code
+- [include](../../include): public headers, including C API
+- [docs](../): contributor and design references
+- [csharp](../../csharp), [java](../../java), [js](../../js), [objectivec](../../objectivec), [rust](../../rust): language bindings
+
+## Core Layers and Entry Points
+
+Session and execution:
+
+- [onnxruntime/core/session/inference_session.h](../../onnxruntime/core/session/inference_session.h)
+- [onnxruntime/core/session/inference_session.cc](../../onnxruntime/core/session/inference_session.cc)
+
+Graph model and traversal:
+
+- [onnxruntime/core/graph](../../onnxruntime/core/graph)
+
+Optimization framework:
+
+- [onnxruntime/core/optimizer/graph_transformer.cc](../../onnxruntime/core/optimizer/graph_transformer.cc)
+- [onnxruntime/core/optimizer/rule_based_graph_transformer.cc](../../onnxruntime/core/optimizer/rule_based_graph_transformer.cc)
+
+Execution providers:
+
+- [onnxruntime/core/providers](../../onnxruntime/core/providers)
+
+Provider and kernel tests:
+
+- [onnxruntime/test/providers](../../onnxruntime/test/providers)
+
+ONNX model test runner:
+
+- [onnxruntime/test/onnx/main.cc](../../onnxruntime/test/onnx/main.cc)
+
+## Contribution Path to Code Area
+
+- If you are fixing model load or run behavior: start in session and graph folders.
+- If you are adding graph rewrites: start in optimizer and related tests.
+- If you are adding kernel support: start in providers and provider tests.
+- If you are exposing new public APIs: start in include and C API docs.
+
+## 45-Minute Code Reading Exercise
+
+1. Open [onnxruntime/core/session/inference_session.h](../../onnxruntime/core/session/inference_session.h) and locate load, initialize, and run declarations.
+2. Open [onnxruntime/core/session/inference_session.cc](../../onnxruntime/core/session/inference_session.cc) and follow the high-level call flow.
+3. Open one optimizer pass such as [onnxruntime/core/optimizer/conv_activation_fusion.cc](../../onnxruntime/core/optimizer/conv_activation_fusion.cc) to understand rewrite style.
+4. Open a provider test directory such as [onnxruntime/test/providers/cpu](../../onnxruntime/test/providers/cpu) and inspect test naming and utilities.
+
+## Common Failure Modes
+
+- Reading files without a pipeline map: you lose context quickly.
+- Starting in provider code before understanding session lifecycle.
+- Attempting broad changes before finding existing tests in the same area.
+
+## Exit Checklist
+
+- [ ] You can describe the load to execute pipeline in your own words.
+- [ ] You know where graph, optimizer, session, provider, and tests live.
+- [ ] You identified one likely code area for your first code contribution.

--- a/docs/playbooks/02-build-test-and-debug-locally.md
+++ b/docs/playbooks/02-build-test-and-debug-locally.md
@@ -1,0 +1,112 @@
+# Playbook 02: Build, Test, and Debug Locally
+
+## Outcome
+
+By the end of this playbook, you will be able to run a fast local edit-build-test-debug loop and scale up only when needed.
+
+## Start Here
+
+- [build.sh](../../build.sh)
+- [build.bat](../../build.bat)
+- [docs/Model_Test.md](../Model_Test.md)
+- [onnxruntime/test/providers](../../onnxruntime/test/providers)
+
+## Build Phases You Need to Know
+
+The build driver supports three phases:
+
+- update: generate or regenerate build files
+- build: compile code
+- test: run tests
+
+First build in a new directory should include update. Incremental builds for existing source changes usually only need build.
+
+## Recommended Local Loops
+
+### Loop A: First local build
+
+Linux or macOS:
+
+```bash
+./build.sh --config RelWithDebInfo --update --build --parallel --skip_tests
+```
+
+Windows:
+
+```powershell
+.\build.bat --config RelWithDebInfo --update --build --parallel --skip_tests
+```
+
+### Loop B: Incremental rebuild while iterating
+
+Linux or macOS:
+
+```bash
+./build.sh --config RelWithDebInfo --build --parallel --skip_tests
+```
+
+Windows:
+
+```powershell
+.\build.bat --config RelWithDebInfo --build --parallel --skip_tests
+```
+
+### Loop C: Run tests only after a successful build
+
+Linux or macOS:
+
+```bash
+./build.sh --config RelWithDebInfo --test
+```
+
+Windows:
+
+```powershell
+.\build.bat --config RelWithDebInfo --test
+```
+
+## Targeted C++ Test Execution
+
+Run tests directly from the build output directory.
+
+Linux example:
+
+```bash
+cd build/Linux/RelWithDebInfo
+./onnxruntime_provider_test --gtest_filter="*Conv*"
+./onnxruntime_test_all --gtest_filter="*Session*"
+```
+
+Windows example:
+
+```powershell
+cd build\Windows\RelWithDebInfo
+.\onnxruntime_provider_test.exe --gtest_filter="*Conv*"
+.\onnxruntime_test_all.exe --gtest_filter="*Session*"
+```
+
+## Model Tests
+
+For ONNX model test data setup and onnx_test_runner options, use [docs/Model_Test.md](../Model_Test.md).
+
+## Practical Debug Workflow
+
+1. Build in RelWithDebInfo while iterating.
+2. Run one focused test with a narrow gtest filter.
+3. Reproduce with deterministic settings when possible.
+4. Add or update a test before changing code if the bug is not already covered.
+5. Re-run the smallest affected test set after each change.
+
+## Common Failure Modes
+
+- Running test binaries from the wrong working directory.
+- Running full test suites too early instead of using targeted filters.
+- Forgetting update phase after changing CMake files or adding new source files.
+- Mixing unrelated fixes while debugging one issue.
+
+## Exit Checklist
+
+- [ ] You can run first build and incremental build loops.
+- [ ] You can run a targeted provider test and a targeted core test.
+- [ ] You can locate and use the model test runner documentation.
+- [ ] You have a repeatable minimal test loop for your current task.

--- a/docs/playbooks/03-first-pr-and-environment-setup.md
+++ b/docs/playbooks/03-first-pr-and-environment-setup.md
@@ -1,0 +1,130 @@
+# Playbook 03: First PR and Environment Setup
+
+## Outcome
+
+By the end of this playbook, you will be able to set up a local development environment, make a small change, run targeted validation, and open a reviewable pull request.
+
+This playbook assumes you have already worked through [Playbook 01](01-repo-map-and-architecture-overview.md) and [Playbook 02](02-build-test-and-debug-locally.md).
+
+## Start Here
+
+- [CONTRIBUTING.md](../../CONTRIBUTING.md)
+- [PR_Guidelines.md](../PR_Guidelines.md)
+- [Coding_Conventions_and_Standards.md](../Coding_Conventions_and_Standards.md)
+
+## Prerequisites
+
+- GitHub account and a fork of the ONNX Runtime repo
+- C++ toolchain for your platform
+- Python 3 for build scripts and tests
+
+## Step 1: Clone and prepare your branch
+
+```bash
+git clone https://github.com/<your-user>/onnxruntime.git
+cd onnxruntime
+git remote add upstream https://github.com/microsoft/onnxruntime.git
+git fetch upstream
+git checkout -b <short-feature-branch-name>
+```
+
+## Step 2: Create and activate a Python virtual environment
+
+Linux or macOS:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip
+```
+
+Windows PowerShell:
+
+```powershell
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
+python -m pip install --upgrade pip
+```
+
+## Step 3: Pick a small, low-risk change
+
+Use one of these patterns for a first PR:
+
+- a focused test improvement under [onnxruntime/test](../../onnxruntime/test)
+- a small documentation fix under [docs](../)
+- a narrow bug fix in one file with one corresponding test
+
+Keep your first PR tight. The guideline in [PR_Guidelines.md](../PR_Guidelines.md) recommends small PRs that are easy to review.
+
+## Step 4: Build with a minimal local loop
+
+First run in a new build directory:
+
+Linux or macOS:
+
+```bash
+./build.sh --config RelWithDebInfo --update --build --parallel --skip_tests
+```
+
+Windows:
+
+```powershell
+.\build.bat --config RelWithDebInfo --update --build --parallel --skip_tests
+```
+
+If you only changed existing source files after this point, you can usually skip update:
+
+Linux or macOS:
+
+```bash
+./build.sh --config RelWithDebInfo --build --parallel --skip_tests
+```
+
+Windows:
+
+```powershell
+.\build.bat --config RelWithDebInfo --build --parallel --skip_tests
+```
+
+## Step 5: Run targeted tests first
+
+Run only tests related to your change before any broad test pass.
+
+Linux example:
+
+```bash
+cd build/Linux/RelWithDebInfo
+./onnxruntime_test_all --gtest_filter="*YourArea*"
+```
+
+Windows example:
+
+```powershell
+cd build\Windows\RelWithDebInfo
+.\onnxruntime_test_all.exe --gtest_filter="*YourArea*"
+```
+
+For model-level tests, see [Model_Test.md](../Model_Test.md).
+
+## Step 6: Prepare and open the PR
+
+Before opening your PR:
+
+- write a clear PR description with motivation
+- include test evidence in the PR description
+- keep cosmetic changes separate from functional changes
+- ensure comments from reviewers are resolved explicitly
+
+## Common Failure Modes
+
+- Build fails after adding files: rerun with update phase enabled.
+- Tests not found in build output: verify config and platform path under build.
+- PR too broad: split into smaller PRs with one intent each.
+
+## Ready-to-Submit Checklist
+
+- [ ] Scope is small and focused
+- [ ] Local build passes on at least one environment
+- [ ] Relevant tests pass locally
+- [ ] PR description explains motivation and validation
+- [ ] No unrelated refactors bundled into the change

--- a/docs/playbooks/04-session-lifecycle-from-load-to-run.md
+++ b/docs/playbooks/04-session-lifecycle-from-load-to-run.md
@@ -1,0 +1,145 @@
+# Playbook 04: Session Lifecycle from Load to Run
+
+## Outcome
+
+By the end of this playbook, you will be able to trace how ONNX Runtime turns a model into an executable session and identify where to debug or modify behavior in the `Load`, `Initialize`, and `Run` phases.
+
+This playbook assumes you have already completed [Playbook 01](01-repo-map-and-architecture-overview.md) and [Playbook 02](02-build-test-and-debug-locally.md).
+
+## Start Here
+
+- [onnxruntime/core/session/inference_session.h](../../onnxruntime/core/session/inference_session.h)
+- [onnxruntime/core/session/inference_session.cc](../../onnxruntime/core/session/inference_session.cc)
+- [onnxruntime/core/graph](../../onnxruntime/core/graph)
+- [onnxruntime/core/optimizer](../../onnxruntime/core/optimizer)
+
+## Mental Model
+
+The session lifecycle is easiest to understand in three phases:
+
+1. `Load`: construct or deserialize the in-memory model representation.
+2. `Initialize`: register providers, transform and partition the graph, build session state, and finalize kernels.
+3. `Run`: validate feeds and fetches, prepare execution state, and execute the graph.
+
+If you are debugging a behavior change, locate the earliest phase where the state first becomes wrong.
+
+## Phase 1: Load
+
+Primary entry points:
+
+- [onnxruntime/core/session/inference_session.h](../../onnxruntime/core/session/inference_session.h)
+- [onnxruntime/core/session/inference_session.cc](../../onnxruntime/core/session/inference_session.cc)
+
+Key things that happen during `Load`:
+
+- model format is selected as ONNX or ORT format
+- model bytes, stream, or path are converted into an in-memory `Model`
+- custom schemas and interop domains may be registered before the model is finalized
+- strict shape/type inference and external initializer options are applied
+
+What to inspect when debugging `Load`:
+
+- whether the input is treated as ONNX or ORT format
+- whether model parsing or protobuf loading fails
+- whether external initializer settings or custom schema registration changes behavior
+
+## Phase 2: Initialize
+
+Primary entry point:
+
+- [onnxruntime/core/session/inference_session.cc](../../onnxruntime/core/session/inference_session.cc)
+
+`Initialize()` is the main session-construction phase. Important checkpoints are:
+
+1. Verify a model has been loaded.
+2. Ensure a CPU execution provider exists, adding the default CPU EP if needed.
+3. Create `SessionState`.
+4. Register kernel registries from execution providers.
+5. Add predefined graph transformers.
+6. Run `TransformGraph()`.
+7. Call `graph.Resolve()`.
+8. Finalize session state with `FinalizeSessionState()`.
+9. Resolve memory-pattern flags and mark the session initialized.
+
+This is the phase where most contributor-facing runtime decisions are made.
+
+## What `TransformGraph()` Does
+
+The `TransformGraph()` flow in [onnxruntime/core/session/inference_session.cc](../../onnxruntime/core/session/inference_session.cc) is especially important because it connects graph rewriting with execution provider assignment.
+
+High-level order:
+
+1. inline functions ahead of time
+2. normalize QDQ structure when needed
+3. apply level 0 and level 1 graph optimizations
+4. partition the graph based on execution provider capabilities
+5. run level 2 and level 3 optimizations, possibly in a loop
+6. insert cast nodes
+7. run level 4 optimizations
+8. insert copy nodes
+
+This order matters. If you change a graph transform or provider capability rule, verify which stage is supposed to own that behavior.
+
+## Phase 3: Run
+
+Primary entry points:
+
+- [onnxruntime/core/session/inference_session.h](../../onnxruntime/core/session/inference_session.h)
+- [onnxruntime/core/session/inference_session.cc](../../onnxruntime/core/session/inference_session.cc)
+
+The public `Run()` overloads funnel into `RunImpl()`.
+
+Key things that happen during `RunImpl()`:
+
+- optional per-run profiling is configured
+- run-level graph capture settings are checked
+- session initialization is validated
+- inputs and requested outputs are validated
+- feeds/fetches bookkeeping is created
+- execution providers receive `OnRunStart()` callbacks
+- the graph is executed through `utils::ExecuteGraph(...)`
+- execution providers receive `OnRunEnd()` callbacks
+- optional cleanup and memory-arena shrinkage are performed
+
+If you are debugging inference-time failures, this is the best place to separate:
+
+- input validation issues
+- execution-provider startup/shutdown issues
+- actual kernel execution failures
+- stream cleanup or graph capture issues
+
+## Code Reading Path
+
+Follow this sequence when learning the pipeline:
+
+1. Read the `Load`, `Initialize`, and `Run` declarations in [onnxruntime/core/session/inference_session.h](../../onnxruntime/core/session/inference_session.h).
+2. Read the `Load` implementations in [onnxruntime/core/session/inference_session.cc](../../onnxruntime/core/session/inference_session.cc).
+3. Read `Initialize()` in [onnxruntime/core/session/inference_session.cc](../../onnxruntime/core/session/inference_session.cc).
+4. Read `TransformGraph()` in [onnxruntime/core/session/inference_session.cc](../../onnxruntime/core/session/inference_session.cc).
+5. Read `RunImpl()` in [onnxruntime/core/session/inference_session.cc](../../onnxruntime/core/session/inference_session.cc).
+
+Do not start by reading all call sites. The core behavior is controlled here.
+
+## Practical Debugging Recipe
+
+Use this sequence when a model behaves differently than expected:
+
+1. Confirm whether the issue appears during model load, session initialization, or execution.
+2. Add or run the smallest test that reproduces the issue.
+3. If the graph looks wrong before execution, inspect `TransformGraph()` and `graph.Resolve()`.
+4. If the graph is correct but execution is wrong, inspect provider callbacks and `utils::ExecuteGraph(...)`.
+5. If behavior depends on provider assignment, verify partitioning and inserted copy nodes.
+
+## Common Failure Modes
+
+- Registering execution providers or graph transformers after `Initialize()` and expecting them to take effect.
+- Debugging kernel output before checking whether graph partitioning already changed the graph.
+- Treating a load-time parse failure like a run-time execution failure.
+- Missing the difference between ORT format model loading and ONNX model loading.
+
+## Exit Checklist
+
+- [ ] You can explain what work belongs to `Load`, `Initialize`, and `Run`.
+- [ ] You know that `TransformGraph()` is the main bridge between graph optimization and provider partitioning.
+- [ ] You know where `SessionState` is created and finalized.
+- [ ] You have a debugging strategy for locating issues in the correct session phase.

--- a/docs/playbooks/05-adding-or-changing-a-kernel.md
+++ b/docs/playbooks/05-adding-or-changing-a-kernel.md
@@ -1,0 +1,159 @@
+# Playbook 05: Adding or Changing a Kernel
+
+## Outcome
+
+By the end of this playbook, you will be able to trace an operator from kernel registration to compute logic to tests, and make a focused kernel change with the right validation loop.
+
+This playbook assumes you have already completed [Playbook 02](02-build-test-and-debug-locally.md) and [Playbook 04](04-session-lifecycle-from-load-to-run.md).
+
+## Start Here
+
+- [onnxruntime/core/providers/cpu/math/element_wise_ops.cc](../../onnxruntime/core/providers/cpu/math/element_wise_ops.cc)
+- [onnxruntime/core/providers/cpu/math/element_wise_ops.h](../../onnxruntime/core/providers/cpu/math/element_wise_ops.h)
+- [onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc](../../onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc)
+- [onnxruntime/test/providers/provider_test_utils.h](../../onnxruntime/test/providers/provider_test_utils.h)
+
+## Pick the Smallest Real Example
+
+For a first kernel-oriented change, use an existing CPU math kernel such as `Add` as your reference path.
+
+That path is useful because it shows all three layers clearly:
+
+1. registration macros in [onnxruntime/core/providers/cpu/math/element_wise_ops.cc](../../onnxruntime/core/providers/cpu/math/element_wise_ops.cc)
+2. kernel class declarations in [onnxruntime/core/providers/cpu/math/element_wise_ops.h](../../onnxruntime/core/providers/cpu/math/element_wise_ops.h)
+3. behavioral tests in [onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc](../../onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc)
+
+## Mental Model
+
+Most kernel work falls into one of these categories:
+
+- add support for a new type or opset in an existing operator
+- fix correctness for shapes, broadcasting, attributes, or edge cases
+- add a provider-specific implementation for an existing operator
+- add validation or error handling for unsupported input cases
+
+Do not start with provider-wide registry plumbing. Start at one operator and follow its owning files.
+
+## Step 1: Locate registration
+
+In [onnxruntime/core/providers/cpu/math/element_wise_ops.cc](../../onnxruntime/core/providers/cpu/math/element_wise_ops.cc), look for the operator registration macros.
+
+For `Add`, the file shows:
+
+- versioned registrations for opsets 7 to 13
+- non-versioned registrations for opset 14+
+- one registration per supported type
+
+That tells you three things immediately:
+
+- which opsets are handled separately
+- which types are supported
+- which kernel class is instantiated for each registration
+
+If your change is only about registration coverage, this file may be the only source change you need.
+
+## Step 2: Find the kernel class
+
+In [onnxruntime/core/providers/cpu/math/element_wise_ops.h](../../onnxruntime/core/providers/cpu/math/element_wise_ops.h), find the kernel class declaration.
+
+For `Add`, the core shape is:
+
+- `template <typename T> class Add final : public OpKernel`
+- constructor for any one-time setup
+- `Status Compute(OpKernelContext* context) const override`
+
+This is the boundary between registration and runtime behavior.
+
+When changing kernel behavior, identify first whether the logic belongs in:
+
+- constructor-time validation
+- `Compute()` input/output handling
+- shared helper or functor code used by multiple kernels
+
+## Step 3: Check neighboring kernels before editing
+
+Before changing code, inspect one nearby operator that solves a similar problem.
+
+Good examples in [onnxruntime/core/providers/cpu/math/element_wise_ops.h](../../onnxruntime/core/providers/cpu/math/element_wise_ops.h):
+
+- `Div` for constructor-time validation of constant integer divisors
+- unary elementwise kernels for functor-based implementations
+
+This helps you match local style and avoid inventing a one-off pattern.
+
+## Step 4: Add or adjust tests first when possible
+
+Use [onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc](../../onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc) as the main example.
+
+The `Add` tests already cover:
+
+- multiple scalar and tensor types
+- broadcasting shapes
+- zero-dimension behavior
+- provider-specific exclusions when relevant
+
+Use [onnxruntime/test/providers/provider_test_utils.h](../../onnxruntime/test/providers/provider_test_utils.h) and `OpTester` for targeted kernel tests.
+
+Typical pattern:
+
+```cpp
+OpTester test("Add", 14);
+test.AddInput<int32_t>("A", {3}, {1, 2, 3});
+test.AddInput<int32_t>("B", {3}, {4, 5, 6});
+test.AddOutput<int32_t>("C", {3}, {5, 7, 9});
+test.Run();
+```
+
+If the bug is already reproduced by an existing test, use that as your focused validation loop.
+
+## Step 5: Make the smallest kernel change
+
+Prefer the narrowest change that matches the failure mode:
+
+- missing type support: update registration and add tests for the new type
+- wrong broadcast behavior: change compute logic and add one focused broadcast regression test
+- invalid input handling: add or tighten validation and test the failure message
+- provider-specific difference: limit the change to the relevant provider directory and tests
+
+Do not widen into unrelated ops while you are still validating the first kernel change.
+
+## Step 6: Run focused validation immediately
+
+After the first substantive edit, run the smallest test slice that can falsify the change.
+
+Typical targeted loop from the build directory:
+
+Linux:
+
+```bash
+./onnxruntime_provider_test --gtest_filter="*MathOpTest*Add*"
+```
+
+Windows:
+
+```powershell
+.\onnxruntime_provider_test.exe --gtest_filter="*MathOpTest*Add*"
+```
+
+If your change is narrower than all `Add` tests, use an even tighter filter based on the specific test name you added.
+
+## How to Decide Where a Kernel Change Belongs
+
+- If the operator is already listed and routed, start in the kernel source file, not provider initialization code.
+- If the operator is not claimed at all, start in registration.
+- If execution reaches the kernel but results are wrong, start in `Compute()` or shared helpers.
+- If only one provider is affected, stay inside that provider’s directory until proven otherwise.
+
+## Common Failure Modes
+
+- Editing a kernel implementation when the real issue is missing registration for an opset or type.
+- Adding a broad test when one small `OpTester` case would isolate the problem faster.
+- Changing multiple operators in the same file before validating the first one.
+- Forgetting that provider-specific tests may need exclusions or provider-specific execution setup.
+
+## Exit Checklist
+
+- [ ] You can point to the registration macro for the operator you changed.
+- [ ] You know where the kernel class and `Compute()` implementation live.
+- [ ] You added or updated a focused test near existing operator tests.
+- [ ] You ran the narrowest possible test filter after the change.

--- a/docs/playbooks/06-adding-a-contrib-operator.md
+++ b/docs/playbooks/06-adding-a-contrib-operator.md
@@ -1,0 +1,160 @@
+# Playbook 06: Adding a Contrib Operator
+
+## Outcome
+
+By the end of this playbook, you will be able to add a `com.microsoft` contrib operator by defining its schema, wiring at least one kernel, registering it with the target execution provider, and validating it with focused tests.
+
+This playbook assumes you have already completed [Playbook 04](04-session-lifecycle-from-load-to-run.md) and [Playbook 05](05-adding-or-changing-a-kernel.md).
+
+## Start Here
+
+- [docs/ContribOperators.md](../ContribOperators.md)
+- [onnxruntime/core/graph/contrib_ops/contrib_defs.cc](../../onnxruntime/core/graph/contrib_ops/contrib_defs.cc)
+- [onnxruntime/contrib_ops/cpu/cpu_contrib_kernels.cc](../../onnxruntime/contrib_ops/cpu/cpu_contrib_kernels.cc)
+- [onnxruntime/test/contrib_ops](../../onnxruntime/test/contrib_ops)
+
+## Pick a Small Reference Path
+
+For learning the contrib flow, two small operators are useful references:
+
+- `SampleOp` for the smallest schema-to-kernel-to-test path
+- `ExpandDims` for a slightly richer example with shape inference and negative tests
+
+Those paths cover the key authoring layers without the complexity of transformer or quantization operators.
+
+## Mental Model
+
+A contrib operator usually adds four distinct things:
+
+1. schema and shape inference in `core/graph/contrib_ops`
+2. kernel class and compute logic in `onnxruntime/contrib_ops/<provider>`
+3. provider kernel table registration
+4. focused tests under `onnxruntime/test/contrib_ops`
+
+If one of those layers is missing, the operator may compile but still fail to load, register, infer shapes, or execute.
+
+## Step 1: Define the schema
+
+Add the operator schema in [onnxruntime/core/graph/contrib_ops/contrib_defs.cc](../../onnxruntime/core/graph/contrib_ops/contrib_defs.cc) using `ONNX_MS_OPERATOR_SET_SCHEMA(...)`.
+
+Reference examples:
+
+- `SampleOp` for a minimal pass-through schema
+- `ExpandDims` for type constraints plus custom shape inference
+
+Your schema should define:
+
+- operator name and version
+- inputs and outputs
+- attributes
+- type constraints
+- shape inference behavior when possible
+- operator documentation
+
+This is the source of truth that feeds generated docs such as [docs/ContribOperators.md](../ContribOperators.md).
+
+## Step 2: Add the kernel implementation
+
+Add the provider-specific kernel in the appropriate contrib provider folder.
+
+CPU references:
+
+- [onnxruntime/contrib_ops/cpu/sample.cc](../../onnxruntime/contrib_ops/cpu/sample.cc)
+- [onnxruntime/contrib_ops/cpu/sample.h](../../onnxruntime/contrib_ops/cpu/sample.h)
+- [onnxruntime/contrib_ops/cpu/expand_dims.cc](../../onnxruntime/contrib_ops/cpu/expand_dims.cc)
+- [onnxruntime/contrib_ops/cpu/expand_dims.h](../../onnxruntime/contrib_ops/cpu/expand_dims.h)
+
+For a simple CPU contrib op, this usually means:
+
+- define an `OpKernel` subclass in a header
+- implement `Compute()` behavior
+- register the kernel with `ONNX_CPU_OPERATOR_*_MS_KERNEL(...)`
+
+Keep the first provider implementation conservative. Get one provider working correctly before expanding to CUDA, WebGPU, JS, or others.
+
+## Step 3: Register the kernel in the provider table
+
+Provider-level contrib registration is not complete until the kernel is added to the provider kernel table.
+
+For CPU, update [onnxruntime/contrib_ops/cpu/cpu_contrib_kernels.cc](../../onnxruntime/contrib_ops/cpu/cpu_contrib_kernels.cc).
+
+Typical work includes:
+
+- forward declaration of the kernel class macro instantiation
+- adding `BuildKernelCreateInfo<...>` in the function table
+
+Use `SampleOp` and `ExpandDims` as the minimal examples of this wiring.
+
+If you skip this step, the kernel may exist in source but never become available to the runtime.
+
+## Step 4: Add focused tests
+
+Add tests in [onnxruntime/test/contrib_ops](../../onnxruntime/test/contrib_ops).
+
+Reference examples:
+
+- [onnxruntime/test/contrib_ops/sample_op_test.cc](../../onnxruntime/test/contrib_ops/sample_op_test.cc)
+- [onnxruntime/test/contrib_ops/expand_dims_test.cc](../../onnxruntime/test/contrib_ops/expand_dims_test.cc)
+
+Good first-test coverage includes:
+
+- one basic success case
+- shape-sensitive behavior if applicable
+- invalid input or attribute failures
+- provider-specific restrictions only if they are part of the contract
+
+Use `OpTester` for focused operator validation.
+
+## Step 5: Keep schema and kernel responsibilities separate
+
+Use this split consistently:
+
+- schema file owns contract, types, attributes, docs, and shape inference
+- kernel file owns runtime computation and input validation during execution
+- provider kernel table owns discoverability by that provider
+- tests own executable specification of expected behavior
+
+If shape inference can fail before runtime, prefer to encode it in the schema. If a runtime value must be checked during execution, handle it in the kernel.
+
+## Step 6: Validate with the narrowest test slice
+
+After the first substantive edit, run the smallest relevant contrib-op test slice.
+
+Typical targeted loop from the build directory:
+
+Linux:
+
+```bash
+./onnxruntime_test_all --gtest_filter="*ExpandDims*:*SampleOp*"
+```
+
+Windows:
+
+```powershell
+.\onnxruntime_test_all.exe --gtest_filter="*ExpandDims*:*SampleOp*"
+```
+
+If you add a new test file or test name, narrow the filter further to the exact operator.
+
+## Design Rules for a New Contrib Op
+
+- start with one provider unless multiple providers are essential
+- keep version `1` unless you are intentionally versioning the contrib contract
+- write shape inference when it is deterministic and cheap
+- add negative tests for invalid axes, shapes, or attributes when those are part of the contract
+- avoid overfitting the operator to one model if the behavior is meant to be reusable
+
+## Common Failure Modes
+
+- adding the schema but forgetting provider kernel table registration
+- adding the kernel but not the schema, which makes model load or shape inference fail
+- putting runtime-only validation into shape inference, or vice versa
+- creating a contrib op when an ONNX standard op or existing contrib op already covers the need
+- forgetting that [docs/ContribOperators.md](../ContribOperators.md) is generated and should not be edited directly
+
+## Exit Checklist
+
+- [ ] The schema exists in `core/graph/contrib_ops` with doc, type constraints, and shape inference as appropriate.
+- [ ] At least one provider kernel exists and is registered in that provider’s contrib kernel table.
+- [ ] Focused tests exist under `onnxruntime/test/contrib_ops`.
+- [ ] You validated the smallest possible contrib-op test slice locally.

--- a/docs/playbooks/07-graph-optimizations-and-fusion-passes.md
+++ b/docs/playbooks/07-graph-optimizations-and-fusion-passes.md
@@ -1,0 +1,150 @@
+# Playbook 07: Graph Optimizations and Fusion Passes
+
+## Outcome
+
+By the end of this playbook, you will be able to add or modify a graph optimization pass, reason about where it runs in the optimizer pipeline, and validate correctness with targeted transformer tests.
+
+This playbook assumes you have already completed [Playbook 04](04-session-lifecycle-from-load-to-run.md) and [Playbook 05](05-adding-or-changing-a-kernel.md).
+
+## Start Here
+
+- [onnxruntime/core/optimizer/graph_transformer.cc](../../onnxruntime/core/optimizer/graph_transformer.cc)
+- [onnxruntime/core/optimizer/rule_based_graph_transformer.cc](../../onnxruntime/core/optimizer/rule_based_graph_transformer.cc)
+- [onnxruntime/core/optimizer/conv_add_fusion.cc](../../onnxruntime/core/optimizer/conv_add_fusion.cc)
+- [onnxruntime/core/optimizer/gather_fusion.cc](../../onnxruntime/core/optimizer/gather_fusion.cc)
+- [onnxruntime/test/optimizer/graph_transform_test.cc](../../onnxruntime/test/optimizer/graph_transform_test.cc)
+
+## Mental Model
+
+Graph optimization in ONNX Runtime is a sequence of transformer passes that rewrite the graph before execution.
+
+There are two common pass styles:
+
+- rule-based passes that check a local pattern and rewrite one region
+- graph-wide passes that scan topology and perform broader rewrites
+
+Every pass should be conservative. If constraints are not proven, do not rewrite.
+
+## Where Optimizations Run
+
+The core execution contract is in [onnxruntime/core/optimizer/graph_transformer.cc](../../onnxruntime/core/optimizer/graph_transformer.cc):
+
+- `GraphTransformer::Apply(...)` calls `ApplyImpl(...)`
+- if the graph was modified, `graph.Resolve()` is called to restore graph validity for subsequent passes
+
+This means your pass can assume a valid graph at entry and must leave a graph that can be resolved after modification.
+
+Rule dispatch behavior is in [onnxruntime/core/optimizer/rule_based_graph_transformer.cc](../../onnxruntime/core/optimizer/rule_based_graph_transformer.cc):
+
+- rules are registered per op type or as any-op rules
+- rules run in topological order
+- if a rule removes the current node, rule application for that node stops
+- subgraphs are processed recursively
+
+## Concrete Fusion Pattern: Conv + Add
+
+Use [onnxruntime/core/optimizer/conv_add_fusion.cc](../../onnxruntime/core/optimizer/conv_add_fusion.cc) as a template for local pattern fusion.
+
+The pass structure is:
+
+1. `SatisfyCondition(...)` guards the rewrite using strict checks.
+2. `Apply(...)` constructs replacement initializer state and rewires nodes.
+3. `FinalizeNodeFusion(...)` transfers edges and removes the old node.
+
+Important guard ideas in this pass:
+
+- op type, opset, and domain checks
+- constant initializer requirements
+- execution provider compatibility checks
+- output and edge shape expectations
+- graph output safety checks
+
+Use this pattern when your fusion replaces a short operator chain with a semantically equivalent compact form.
+
+## Concrete Graph-Wide Pattern: Gather or Slice to Split
+
+Use [onnxruntime/core/optimizer/gather_fusion.cc](../../onnxruntime/core/optimizer/gather_fusion.cc) as a template for topology-scanning rewrites.
+
+The pass demonstrates:
+
+- opset gating to avoid schema mismatches
+- helper functions for axis and initializer decoding
+- coverage checks to ensure rewrites are complete and non-overlapping
+- ordered output reconstruction and node replacement
+
+This style is appropriate when a rewrite depends on relationships among multiple consumer nodes and not just one immediate neighbor.
+
+## Step-by-Step Workflow for a New Optimization
+
+1. Pick one existing pass that is structurally similar to your intended rewrite.
+2. Write exact rewrite preconditions first.
+3. Implement the rewrite with explicit graph utility calls.
+4. Preserve execution-provider boundaries unless cross-provider rewrite is explicitly safe.
+5. Validate graph outputs and node ownership before removing nodes.
+6. Add tests that prove both positive and negative behavior.
+
+If preconditions are complex, encode them in helper functions so the rewrite body stays readable.
+
+## Test Strategy
+
+Primary test harness references:
+
+- [onnxruntime/test/optimizer/graph_transform_test.cc](../../onnxruntime/test/optimizer/graph_transform_test.cc)
+- [onnxruntime/test/optimizer/rule_based_graph_transformer_test.cc](../../onnxruntime/test/optimizer/rule_based_graph_transformer_test.cc)
+
+Common test pattern in `graph_transform_test.cc`:
+
+- load a small model
+- count key ops before transformation
+- register transformer in `GraphTransformerManager`
+- apply at a target transformer level
+- assert post-transform op counts and structure
+
+For each new optimization, include:
+
+- one positive test where rewrite must occur
+- one negative test where rewrite must not occur
+- one safety test for an edge case (graph output, provider mismatch, unsupported shape, or unsupported opset)
+
+## Fast Local Validation Loop
+
+Run targeted optimizer tests first from the build output directory:
+
+Linux:
+
+```bash
+./onnxruntime_test_all --gtest_filter="*GraphTransformationTests*:*RuleBasedGraphTransformer*"
+```
+
+Windows:
+
+```powershell
+.\onnxruntime_test_all.exe --gtest_filter="*GraphTransformationTests*:*RuleBasedGraphTransformer*"
+```
+
+Then narrow further to your specific test names when iterating.
+
+## Design Rules for Safe Rewrites
+
+- do not rewrite across execution-provider boundaries unless explicitly safe
+- require constants and shapes only when they are proven
+- avoid introducing non-deterministic rewrite behavior
+- avoid relying on exporter quirks unless guarded by explicit checks
+- keep rewrite semantics identical to the original subgraph
+
+When in doubt, skip the optimization and preserve correctness.
+
+## Common Failure Modes
+
+- over-permissive conditions that rewrite unsupported patterns
+- removing nodes that still feed graph outputs or surviving nodes
+- missing `graph.Resolve()` expectations after modifications
+- assuming one opset behavior while test models use another
+- missing negative tests that prevent future regressions
+
+## Exit Checklist
+
+- [ ] The optimization has explicit and conservative precondition checks.
+- [ ] Rewrite logic preserves graph semantics and provider constraints.
+- [ ] Positive and negative tests exist in optimizer test suites.
+- [ ] You validated with targeted optimizer test filters locally.

--- a/docs/playbooks/08-execution-provider-implementation.md
+++ b/docs/playbooks/08-execution-provider-implementation.md
@@ -1,0 +1,132 @@
+# Playbook 08: Execution Provider Implementation
+
+## Outcome
+
+By the end of this playbook, you will be able to start an execution provider implementation plan, choose between in-tree and plugin paths, and complete a minimal first-op bring-up with focused validation.
+
+This playbook uses [docs/ExecutionProvider_Playbook.md](../ExecutionProvider_Playbook.md) as the primary deep-dive source and adapts it into the contributor learning sequence.
+
+## Start Here
+
+- [docs/ExecutionProvider_Playbook.md](../ExecutionProvider_Playbook.md)
+- [onnxruntime/core/providers](../../onnxruntime/core/providers)
+- [onnxruntime/test/autoep](../../onnxruntime/test/autoep)
+- [docs/cuda_plugin_ep/QUICK_START.md](../cuda_plugin_ep/QUICK_START.md)
+
+## First Decision: In-Tree or Plugin
+
+Follow this rule early:
+
+- choose in-tree if the provider is intended to ship and evolve inside ORT source builds
+- choose plugin if the provider needs independent versioning and runtime registration
+
+Reference path for plugin scaffolding:
+
+- [onnxruntime/test/autoep/library/example_plugin_ep](../../onnxruntime/test/autoep/library/example_plugin_ep)
+
+Do not start coding until this choice is explicit because it affects build wiring, API surface, and tests.
+
+## EP Responsibilities Checklist
+
+Any EP path should eventually cover:
+
+1. device discovery and capability filtering
+2. graph partitioning via `GetCapability`
+3. execution path via kernel registry or compile callbacks
+4. allocator and memory info handling
+5. data transfer and optional stream synchronization
+6. provider options and session integration
+7. registration, correctness, and regression tests
+
+Treat missing items as planned milestones, not optional details.
+
+## Suggested Milestones for New Contributors
+
+### Milestone 1: Skeleton + Build Wiring
+
+- compile a minimal EP skeleton
+- wire factory and options scaffolding
+- confirm session can construct or register the EP
+
+### Milestone 2: Capability + One Op
+
+- implement conservative `GetCapability`
+- claim one operator pattern only
+- avoid broad claims until execution path is proven
+
+### Milestone 3: Execution Path
+
+- kernel registry path: register one working kernel
+- compile path: return one valid compiled partition path
+- confirm fallback behavior for unsupported nodes
+
+### Milestone 4: Tests + Hardening
+
+- add positive and negative partitioning tests
+- add one execution correctness test against CPU baseline
+- validate error handling for invalid options and unsupported cases
+
+Use the full EP playbook for extended milestones after these core steps.
+
+## Practical Path A: In-Tree EP
+
+For in-tree EP work, use [docs/ExecutionProvider_Playbook.md](../ExecutionProvider_Playbook.md) sections on Path A as the implementation guide and keep this contributor flow:
+
+1. start with provider skeleton and factory creator
+2. wire CMake for provider build inclusion
+3. add minimal capability logic
+4. add first executable kernel or compile callback
+5. add tests under provider test directories
+
+If your first PR is too broad, split by milestone.
+
+## Practical Path B: Plugin EP
+
+For plugin EP work, start from the example plugin implementation:
+
+- [onnxruntime/test/autoep/library/example_plugin_ep/example_plugin_ep.cc](../../onnxruntime/test/autoep/library/example_plugin_ep/example_plugin_ep.cc)
+- [onnxruntime/test/autoep/library/example_plugin_ep/ep_factory.cc](../../onnxruntime/test/autoep/library/example_plugin_ep/ep_factory.cc)
+- [onnxruntime/test/autoep/library/example_plugin_ep/ep.cc](../../onnxruntime/test/autoep/library/example_plugin_ep/ep.cc)
+
+Then validate registration and device selection flow with:
+
+- [onnxruntime/test/autoep/test_registration.cc](../../onnxruntime/test/autoep/test_registration.cc)
+- [onnxruntime/test/autoep/test_selection.cc](../../onnxruntime/test/autoep/test_selection.cc)
+
+Use [docs/cuda_plugin_ep/QUICK_START.md](../cuda_plugin_ep/QUICK_START.md) for runtime registration mechanics.
+
+## First-Op Bring-Up Rules
+
+- support one op, one dtype, one simple shape pattern first
+- validate against CPU EP outputs before adding features
+- keep `GetCapability` deterministic and conservative
+- do not expose allocator or stream features until behavior is correct
+
+This minimizes debugging surface and makes regressions easier to isolate.
+
+## Test Strategy
+
+Use focused tests for the stage you are implementing:
+
+- registration and factory tests
+- capability and partitioning tests
+- execution correctness tests
+- fallback tests for unsupported patterns
+
+For plugin EPs, start from existing autoep test patterns in [onnxruntime/test/autoep](../../onnxruntime/test/autoep).
+
+## Common Failure Modes
+
+- over-claiming nodes in `GetCapability` before execution path is complete
+- forgetting to add provider kernel table wiring after implementing kernels
+- exposing allocator infos that allocator creation code cannot satisfy
+- missing lifecycle pairing for created runtime resources
+- bundling build wiring, partitioning logic, and execution behavior into one unreviewable PR
+
+## Exit Checklist
+
+- [ ] EP path choice (in-tree or plugin) is explicit and documented.
+- [ ] Minimal skeleton builds and registers successfully.
+- [ ] One-op capability and execution path works end-to-end.
+- [ ] Focused tests cover registration, partitioning, and correctness.
+- [ ] Unsupported cases fall back cleanly with actionable errors.

--- a/docs/playbooks/09-memory-management-allocators-and-data-movement.md
+++ b/docs/playbooks/09-memory-management-allocators-and-data-movement.md
@@ -1,0 +1,142 @@
+# Playbook 09: Memory Management, Allocators, and Data Movement
+
+## Outcome
+
+By the end of this playbook, you will be able to reason about allocator selection, tensor placement, and cross-device copies in ONNX Runtime, and debug common memory-transfer issues with focused tests.
+
+This playbook assumes you have already completed [Playbook 04](04-session-lifecycle-from-load-to-run.md), [Playbook 05](05-adding-or-changing-a-kernel.md), and [Playbook 08](08-execution-provider-implementation.md).
+
+## Start Here
+
+- [include/onnxruntime/core/framework/allocator.h](../../include/onnxruntime/core/framework/allocator.h)
+- [onnxruntime/core/framework/session_state.h](../../onnxruntime/core/framework/session_state.h)
+- [onnxruntime/core/framework/data_transfer_manager.h](../../onnxruntime/core/framework/data_transfer_manager.h)
+- [onnxruntime/core/framework/data_transfer_utils.h](../../onnxruntime/core/framework/data_transfer_utils.h)
+- [onnxruntime/test/providers/memcpy_test.cc](../../onnxruntime/test/providers/memcpy_test.cc)
+- [onnxruntime/test/providers/io_binding_test.cc](../../onnxruntime/test/providers/io_binding_test.cc)
+
+## Mental Model
+
+Memory behavior in ORT is the interaction of three layers:
+
+1. allocator layer: where buffers are allocated and freed
+2. session state layer: which allocators are available for each device and memory type
+3. data transfer layer: how tensors move between devices and memory locations
+
+If outputs are wrong, slow, or failing only on some providers, check which layer is responsible before changing code.
+
+## Allocator Fundamentals
+
+In [include/onnxruntime/core/framework/allocator.h](../../include/onnxruntime/core/framework/allocator.h), `IAllocator` defines allocation contracts, including stream-aware allocation support and memory-size safety helpers.
+
+Important concepts to track:
+
+- `OrtMemoryInfo` and `OrtDevice` identify allocator location and semantics
+- arena behavior can be configured via `OrtArenaCfg`
+- stream-aware allocators can use `AllocOnStream(...)`
+- allocation size arithmetic should be overflow-safe
+
+When implementing or modifying allocator usage, preserve these contracts first and optimize second.
+
+## SessionState as the Allocation Router
+
+In [onnxruntime/core/framework/session_state.h](../../onnxruntime/core/framework/session_state.h), `SessionState` owns allocator maps and exposes:
+
+- `GetAllocator(const OrtMemoryInfo&)`
+- `GetAllocator(const OrtDevice&)`
+- `GetInitializerAllocator(...)`
+- memory pattern controls and execution-plan integration
+
+This is the primary place where runtime code resolves “which allocator should this tensor use?”
+
+When debugging placement issues, verify allocator lookup in session state before investigating kernel logic.
+
+## Data Transfer Responsibilities
+
+In [onnxruntime/core/framework/data_transfer_manager.h](../../onnxruntime/core/framework/data_transfer_manager.h), `DataTransferManager` coordinates registered `IDataTransfer` implementations and exposes:
+
+- synchronous and async tensor copy operations
+- sparse tensor copy paths
+- source/destination device routing
+
+In [onnxruntime/core/framework/data_transfer_utils.h](../../onnxruntime/core/framework/data_transfer_utils.h), helper utilities wrap safe tensor copies to raw spans and typed spans.
+
+If tensors are on different devices, correctness depends on this layer, not just allocator correctness.
+
+## Runtime Flow Touchpoints
+
+From session lifecycle code in [onnxruntime/core/session/inference_session.cc](../../onnxruntime/core/session/inference_session.cc):
+
+- session options include memory pattern controls
+- `FinalizeSessionState(...)` builds execution-time allocation state
+- memory-pattern flags are resolved across graph and subgraphs
+- allocator retrieval happens during feed/fetch and run paths
+
+This is why memory bugs can appear only after initialization completes, even when load succeeded.
+
+## Practical Debugging Path
+
+Use this sequence for memory or copy issues:
+
+1. confirm source and destination tensor devices and memory info
+2. confirm allocator lookup through session state
+3. confirm the expected data transfer implementation exists for that device pair
+4. reproduce with minimal I/O binding or memcpy-style tests
+5. only then inspect kernel-side assumptions
+
+Do not start by changing kernel code when the failure mode suggests allocator or transfer misrouting.
+
+## Test References
+
+Use these tests as concrete patterns:
+
+- [onnxruntime/test/providers/memcpy_test.cc](../../onnxruntime/test/providers/memcpy_test.cc): session-state allocator and copy path validation
+- [onnxruntime/test/providers/io_binding_test.cc](../../onnxruntime/test/providers/io_binding_test.cc): binding inputs/outputs across CPU/GPU and explicit transfer behavior
+
+For provider work, add targeted tests that cover:
+
+- expected allocator selection for outputs
+- CPU <-> device transfer correctness
+- preallocated output behavior
+- fallback and synchronization semantics
+
+## Fast Validation Loop
+
+From build output directory, run focused tests first:
+
+Linux:
+
+```bash
+./onnxruntime_test_all --gtest_filter="*MemcpyTest*:*IOBinding*"
+```
+
+Windows:
+
+```powershell
+.\onnxruntime_test_all.exe --gtest_filter="*MemcpyTest*:*IOBinding*"
+```
+
+Narrow further to your exact test names while iterating.
+
+## Design Rules
+
+- keep allocator and transfer concerns separate from kernel math logic
+- choose allocator by explicit device and memory info, not by assumptions
+- only advertise provider memory capabilities you can satisfy
+- make stream and synchronization behavior explicit in tests
+- keep first fixes minimal and observable
+
+## Common Failure Modes
+
+- allocating on CPU and assuming implicit device transfer will happen
+- using the wrong memory info for bound outputs
+- missing or incorrect transfer registration for a device pair
+- exposing stream-aware behavior without synchronization guarantees
+- debugging execution outputs without first validating copy semantics
+
+## Exit Checklist
+
+- [ ] You can identify allocator selection points for the failing path.
+- [ ] You can identify source and destination devices for each tensor copy.
+- [ ] You validated copy and binding behavior with focused tests.
+- [ ] Your change preserves allocator and transfer contracts across providers.

--- a/docs/playbooks/10-python-and-c-api-binding-extension.md
+++ b/docs/playbooks/10-python-and-c-api-binding-extension.md
@@ -1,0 +1,140 @@
+# Playbook 10: Python and C API Binding Extension
+
+## Outcome
+
+By the end of this playbook, you will be able to add or extend a runtime feature across the public C API and Python bindings, while preserving API compatibility and validating behavior with focused tests.
+
+This playbook assumes you have already completed [Playbook 03](03-first-pr-and-environment-setup.md), [Playbook 04](04-session-lifecycle-from-load-to-run.md), and [Playbook 08](08-execution-provider-implementation.md).
+
+## Start Here
+
+- [docs/C_API_Guidelines.md](../C_API_Guidelines.md)
+- [include/onnxruntime/core/session/onnxruntime_c_api.h](../../include/onnxruntime/core/session/onnxruntime_c_api.h)
+- [onnxruntime/python/onnxruntime_pybind_state.cc](../../onnxruntime/python/onnxruntime_pybind_state.cc)
+- [onnxruntime/test/python/onnxruntime_test_python.py](../../onnxruntime/test/python/onnxruntime_test_python.py)
+
+## Mental Model
+
+Binding work should follow a strict layer order:
+
+1. C API contract definition and compatibility
+2. runtime implementation behind that API
+3. Python binding exposure
+4. Python tests validating behavior and error handling
+
+Skipping this order causes drift where Python appears to expose behavior that is not stable in the underlying public API.
+
+## C API First
+
+Use [docs/C_API_Guidelines.md](../C_API_Guidelines.md) as the authoritative checklist.
+
+Key requirements when adding API surface:
+
+- proper API documentation comments and UTF-8 string expectations
+- correct API macros and calling convention
+- `OrtStatus*` error contract (`nullptr` on success)
+- no exception leakage across C/C++ boundaries
+- no out-parameter mutation on failure
+- allocator parameters for APIs that allocate memory
+
+For table-based APIs, append new entries in version-safe order to preserve backward compatibility.
+
+## Where to Add or Update C API Surface
+
+Primary header:
+
+- [include/onnxruntime/core/session/onnxruntime_c_api.h](../../include/onnxruntime/core/session/onnxruntime_c_api.h)
+
+Typical examples to study include `SessionOptions`, `RunOptions`, and EP append/configuration APIs.
+
+When extending existing behavior, prefer evolving option-based APIs where possible instead of introducing avoidable new top-level API calls.
+
+## Python Binding Layer
+
+Primary binding file:
+
+- [onnxruntime/python/onnxruntime_pybind_state.cc](../../onnxruntime/python/onnxruntime_pybind_state.cc)
+
+In this file you can trace:
+
+- Python `SessionOptions` exposure and property mapping
+- provider and EP option wiring
+- helper methods that map Python calls to C/C++ runtime calls
+
+For many extensions, the practical work is:
+
+1. expose a new property or method in pybind
+2. map to existing or newly added C/C++ runtime behavior
+3. preserve existing defaults and failure semantics
+
+Keep Python naming consistent with existing API style.
+
+## Typical Change Paths
+
+### Path A: Add a new configurable session option
+
+1. add or extend C API/session option support
+2. wire option into runtime behavior
+3. expose in Python `SessionOptions`
+4. add Python tests for default, custom value, and invalid value
+
+### Path B: Add a run-time option
+
+1. add C/C++ `RunOptions` support
+2. plumb value into run path
+3. expose through Python run options or run call parameters
+4. add tests proving per-run override behavior
+
+### Path C: Add binding-only helper for existing runtime capability
+
+1. confirm stable existing runtime/C API behavior
+2. add pybind helper wrapper
+3. add focused Python tests without changing runtime semantics
+
+## Test Strategy
+
+Primary Python test anchor:
+
+- [onnxruntime/test/python/onnxruntime_test_python.py](../../onnxruntime/test/python/onnxruntime_test_python.py)
+
+Add focused tests that verify:
+
+- default behavior unchanged
+- new value changes behavior as intended
+- invalid input returns clear failure
+- provider interactions remain compatible
+
+If a change affects specific EP behavior, add EP-gated tests that only run when that provider is available.
+
+## Fast Validation Loop
+
+Run targeted Python tests first:
+
+```bash
+python -m pytest onnxruntime/test/python/onnxruntime_test_python.py -k "session or providers or run_options"
+```
+
+Narrow to exact test names while iterating.
+
+## Design Rules
+
+- treat the C API as the compatibility boundary
+- keep Python wrappers thin and explicit
+- avoid silently changing default behavior
+- preserve error message clarity for caller debugging
+- add tests before broad refactors
+
+## Common Failure Modes
+
+- adding Python exposure without stable C API/runtime support
+- breaking table ordering or compatibility for C API additions
+- leaking C++ exceptions through C boundaries
+- changing defaults in Python wrappers without migration guidance
+- writing only positive tests and missing invalid-input coverage
+
+## Exit Checklist
+
+- [ ] C API contract is documented and compatibility-safe.
+- [ ] Runtime implementation and C API semantics match.
+- [ ] Python binding exposes the feature with consistent naming and defaults.
+- [ ] Focused Python tests cover success and failure behavior.


### PR DESCRIPTION
## Summary
This PR adds a complete 10-playbook onboarding path for new ONNX Runtime contributors, moving from codebase orientation through advanced contribution workflows.

## What is included
- Adds and indexes ten contributor playbooks under docs/playbooks.
- Establishes a suggested learning order in the plan document.
- Provides practical, repo-grounded workflows for:
  - architecture orientation
  - local build/test/debug loops
  - first PR flow
  - session lifecycle tracing
  - kernel contribution
  - contrib operator contribution
  - graph optimization/fusion work
  - execution provider implementation
  - memory/allocator/data movement debugging
  - Python and C API binding extension

## Files changed
- docs/Contributor_Playbooks_Plan.md
- docs/playbooks/01-repo-map-and-architecture-overview.md
- docs/playbooks/02-build-test-and-debug-locally.md
- docs/playbooks/03-first-pr-and-environment-setup.md
- docs/playbooks/04-session-lifecycle-from-load-to-run.md
- docs/playbooks/05-adding-or-changing-a-kernel.md
- docs/playbooks/06-adding-a-contrib-operator.md
- docs/playbooks/07-graph-optimizations-and-fusion-passes.md
- docs/playbooks/08-execution-provider-implementation.md
- docs/playbooks/09-memory-management-allocators-and-data-movement.md
- docs/playbooks/10-python-and-c-api-binding-extension.md

## Commit sequence
- 615a91ba3b Add initial contributor playbooks
- 62dbdd2279 Add session lifecycle playbook
- dbd176423d Add kernel contribution playbook
- d558e40baf Add contrib operator playbook
- 727a35c877 Add graph optimization playbook
- c42c3aeca2 Add execution provider playbook
- a783e144eb Add memory and data movement playbook
- 7f72e42bb9 Add Python and C API binding playbook

## Validation
- Documentation-only change.
- Internal links and ordering were reviewed during authoring.
