### PR TITLE
MoE CUDA: plumb SwiGLU schema attributes to kernel

### DIFF
--- a/onnxruntime/contrib_ops/cuda/collective/sharded_moe.cc
+++ b/onnxruntime/contrib_ops/cuda/collective/sharded_moe.cc
@@ -86,7 +86,11 @@ Status ShardedMoE<T>::ComputeInternal(OpKernelContext* context) const {
                                                                      activation_type_,
                                                                      fc3_experts_weights_optional != nullptr,
                                                                      normalize_routing_weights_,
-                                                                     use_sparse_mixer_);
+                                                                     use_sparse_mixer_,
+                                                                     activation_alpha_,
+                                                                     activation_beta_,
+                                                                     swiglu_limit_,
+                                                                     swiglu_fusion_ == 1);
 
   size_t ws_size = moe_runner.getWorkspaceSize(
       static_cast<size_t>(moe_params.num_rows), static_cast<size_t>(moe_params.hidden_size),

--- a/onnxruntime/contrib_ops/cuda/moe/ft_moe/moe_kernel.cu
+++ b/onnxruntime/contrib_ops/cuda/moe/ft_moe/moe_kernel.cu
@@ -48,9 +48,13 @@ static constexpr int WARP_SIZE = 32;
 //   dim = x.shape[-1]
 //   x = x.view(-1, dim // 2, 2)
 //   x_glu, x_linear = x[..., 0], x[..., 1]
-//   y = x_glu * torch.sigmoid(alpha * x_glu) * (x_linear + 1)
-template <typename T, bool HasLimit>
-__global__ void swiglu_kernel_interleaved(T* output, T const* input, int intermediate_size, int num_rows, float alpha, float limit) {
+//   y = x_glu * torch.sigmoid(alpha * x_glu) * (x_linear + beta)
+// Interleaved version. Set ``has_limit=false`` (or pass ``limit <= 0``)
+// to skip clamping; ``beta`` controls the additive bias on the linear
+// branch (1.0 for GPT-OSS-style SwiGLU, 0.0 for standard SwiGLU).
+template <typename T>
+__global__ void swiglu_kernel_interleaved(T* output, T const* input, int intermediate_size, int num_rows,
+                                          float alpha, float beta, float limit, bool has_limit) {
   int const row = blockIdx.x;
   if (row >= num_rows) {
     return;
@@ -63,7 +67,7 @@ __global__ void swiglu_kernel_interleaved(T* output, T const* input, int interme
     float glu = static_cast<float>(row_input[2 * i]);
     float linear = static_cast<float>(row_input[2 * i + 1]);
 
-    if constexpr (HasLimit) {
+    if (has_limit) {
       glu = fminf(glu, limit);
       linear = fminf(fmaxf(linear, -limit), limit);
     }
@@ -72,13 +76,14 @@ __global__ void swiglu_kernel_interleaved(T* output, T const* input, int interme
     float sigmoid_out = 1.f / (1.f + expf(-sigmoid_arg));
 
     float swish_out = glu * sigmoid_out;
-    row_output[i] = static_cast<T>(swish_out * (linear + 1.f));
+    row_output[i] = static_cast<T>(swish_out * (linear + beta));
   }
 }
 
 // Non interleaved version of SwiGLU kernel, which splits each row into two chunks of same size.
-template <typename T, bool HasLimit>
-__global__ void swiglu_kernel_chunked(T* output, T const* input, int intermediate_size, int num_rows, float alpha, float limit) {
+template <typename T>
+__global__ void swiglu_kernel_chunked(T* output, T const* input, int intermediate_size, int num_rows,
+                                      float alpha, float beta, float limit, bool has_limit) {
   int const row = blockIdx.x;
   if (row >= num_rows) {
     return;
@@ -91,7 +96,7 @@ __global__ void swiglu_kernel_chunked(T* output, T const* input, int intermediat
     float glu = static_cast<float>(row_input[i]);
     float linear = static_cast<float>(row_input[i + intermediate_size]);
 
-    if constexpr (HasLimit) {
+    if (has_limit) {
       glu = fminf(glu, limit);
       linear = fminf(fmaxf(linear, -limit), limit);
     }
@@ -100,25 +105,29 @@ __global__ void swiglu_kernel_chunked(T* output, T const* input, int intermediat
     float sigmoid_out = 1.f / (1.f + expf(-sigmoid_arg));
 
     float swish_out = glu * sigmoid_out;
-    row_output[i] = static_cast<T>(swish_out * (linear + 1.f));
+    row_output[i] = static_cast<T>(swish_out * (linear + beta));
   }
 }
 
-template <typename T, bool IsInterLeaved, bool HasLimit>
-void invokeSwiGLU(T* output, T const* input, int intermediate_size, int num_rows, float alpha, float limit, cudaStream_t stream) {
+template <typename T>
+void invokeSwiGLU(T* output, T const* input, int intermediate_size, int num_rows,
+                  float alpha, float beta, float limit, bool interleaved, cudaStream_t stream) {
   if (num_rows == 0) {
     return;
   }
+  const bool has_limit = limit > 0.f;
   dim3 block(std::min(intermediate_size, 1024));
   dim3 grid(num_rows);
 
   DUMP_TENSOR_INIT();
   DUMP_TENSOR("swiglu input", input, num_rows, 2 * intermediate_size);
 
-  if constexpr (IsInterLeaved) {
-    swiglu_kernel_interleaved<T, HasLimit><<<grid, block, 0, stream>>>(output, input, intermediate_size, num_rows, alpha, limit);
+  if (interleaved) {
+    swiglu_kernel_interleaved<T><<<grid, block, 0, stream>>>(
+        output, input, intermediate_size, num_rows, alpha, beta, limit, has_limit);
   } else {
-    swiglu_kernel_chunked<T, HasLimit><<<grid, block, 0, stream>>>(output, input, intermediate_size, num_rows, alpha, limit);
+    swiglu_kernel_chunked<T><<<grid, block, 0, stream>>>(
+        output, input, intermediate_size, num_rows, alpha, beta, limit, has_limit);
   }
 
   DUMP_TENSOR("swiglu output", output, num_rows, intermediate_size);
@@ -748,13 +757,19 @@ __global__ void dispatch_activations_kernel(int64_t* total_rows_before_expert, i
 
 template <typename T, typename WeightType, typename Enable>
 CutlassMoeFCRunner<T, WeightType, Enable>::CutlassMoeFCRunner(int sm_version, ActivationType activation_type, bool has_fc3,
-                                                              bool normalize_routing_weights, bool use_sparse_mixer)
+                                                              bool normalize_routing_weights, bool use_sparse_mixer,
+                                                              float swiglu_alpha, float swiglu_beta,
+                                                              float swiglu_limit, bool swiglu_interleaved)
     : activation_type_(activation_type),
       has_fc3_(has_fc3),
       total_past_rows_(0),
       total_covered_rows_(0),
       normalize_routing_weights_(normalize_routing_weights),
-      use_sparse_mixer_(use_sparse_mixer) {
+      use_sparse_mixer_(use_sparse_mixer),
+      swiglu_alpha_(swiglu_alpha),
+      swiglu_beta_(swiglu_beta),
+      swiglu_limit_(swiglu_limit),
+      swiglu_interleaved_(swiglu_interleaved) {
   moe_gemm_runner_.initialize(sm_version);
 }
 
@@ -1034,17 +1049,15 @@ void CutlassMoeFCRunner<T, WeightType, Enable>::run_moe_fc(
         ActivationType::Identity,
         stream);
 
-    constexpr bool swiglu_interleaved = true;
-    constexpr bool swiglu_has_limit = true;
-    constexpr float swiglu_alpha = 1.702f;
-    constexpr float swiglu_limit = 7.0f;
-    invokeSwiGLU<T, swiglu_interleaved, swiglu_has_limit>(
+    invokeSwiGLU<T>(
         swiglu_output_buffer + total_past_rows_ * inter_size,
         gemm1_output_buffer + total_past_rows_ * 2 * inter_size,
         inter_size,
         static_cast<int>(total_covered_rows_),
-        swiglu_alpha,
-        swiglu_limit,
+        swiglu_alpha_,
+        swiglu_beta_,
+        swiglu_limit_,
+        swiglu_interleaved_,
         stream);
 
     moe_gemm_runner_.moe_gemm(
@@ -1370,7 +1383,7 @@ template void finalize_moe_routing_kernelLauncher(const half*, half*, const half
 template void finalize_moe_routing_kernelLauncher(const __nv_bfloat16*, __nv_bfloat16*, const __nv_bfloat16*,
                                                   const __nv_bfloat16*, const int*, const int*, int, int, int, cudaStream_t);
 
-template void invokeSwiGLU<float, true, true>(float*, float const*, int, int, float, float, cudaStream_t);
-template void invokeSwiGLU<half, true, true>(half*, half const*, int, int, float, float, cudaStream_t);
+template void invokeSwiGLU<float>(float*, float const*, int, int, float, float, float, bool, cudaStream_t);
+template void invokeSwiGLU<half>(half*, half const*, int, int, float, float, float, bool, cudaStream_t);
 
 }  // namespace ort_fastertransformer

--- a/onnxruntime/contrib_ops/cuda/moe/ft_moe/moe_kernel.h
+++ b/onnxruntime/contrib_ops/cuda/moe/ft_moe/moe_kernel.h
@@ -56,8 +56,9 @@ void topk_gating_softmax_kernelLauncher(const T* input, const bool* finished, T*
                                         int* indices, int* source_row, int num_rows, int num_experts, int k,
                                         bool normalize_routing_weights, bool use_sparse_mixer, cudaStream_t stream);
 
-template <typename T, bool interleaved>
-void invokeSwiGLU(T* output, T const* input, int intermediate_size, int num_rows, float swiglu_alpha, cudaStream_t stream);
+template <typename T>
+void invokeSwiGLU(T* output, T const* input, int intermediate_size, int num_rows,
+                  float alpha, float beta, float limit, bool interleaved, cudaStream_t stream);
 
 class CubKeyValueSorter {
  public:
@@ -112,7 +113,10 @@ template <typename T,          /*The type used for activations/scales/compute*/
           typename Enable = void>
 class CutlassMoeFCRunner {
  public:
-  CutlassMoeFCRunner(int sm_version, ActivationType activation_type, bool has_fc3, bool normalize_routing_weights, bool use_sparse_mixer);
+  CutlassMoeFCRunner(int sm_version, ActivationType activation_type, bool has_fc3,
+                     bool normalize_routing_weights, bool use_sparse_mixer,
+                     float swiglu_alpha = 1.702f, float swiglu_beta = 1.0f,
+                     float swiglu_limit = 7.0f, bool swiglu_interleaved = true);
 
   size_t getWorkspaceSize(size_t num_rows, size_t hidden_size, size_t inter_size, size_t num_experts, size_t k);
 
@@ -167,6 +171,13 @@ class CutlassMoeFCRunner {
   bool has_fc3_;
   bool normalize_routing_weights_;
   bool use_sparse_mixer_;
+
+  // SwiGLU activation parameters. Defaults match the legacy
+  // hardcoded GPT-OSS values.
+  float swiglu_alpha_;
+  float swiglu_beta_;
+  float swiglu_limit_;
+  bool swiglu_interleaved_;
 
   // Cuda events
   contrib::cuda::AutoDestoryCudaEvent cuda_event_;

--- a/onnxruntime/contrib_ops/cuda/moe/moe.cc
+++ b/onnxruntime/contrib_ops/cuda/moe/moe.cc
@@ -56,7 +56,11 @@ Status MoE<T>::ComputeInternal(OpKernelContext* context) const {
                                                                      activation_type_,
                                                                      fc3_experts_weights_optional != nullptr,
                                                                      normalize_routing_weights_,
-                                                                     use_sparse_mixer_);
+                                                                     use_sparse_mixer_,
+                                                                     activation_alpha_,
+                                                                     activation_beta_,
+                                                                     swiglu_limit_,
+                                                                     swiglu_fusion_ == 1);
 
   size_t ws_size = moe_runner.getWorkspaceSize(
       static_cast<size_t>(moe_params.num_rows), static_cast<size_t>(moe_params.hidden_size),

--- a/onnxruntime/contrib_ops/cuda/moe/moe_base.h
+++ b/onnxruntime/contrib_ops/cuda/moe/moe_base.h
@@ -40,12 +40,34 @@ class MoEBase {
     if (use_sparse_mixer_) {
       ORT_ENFORCE(k_ == 2, "Sparse mixer only supports k=2");
     }
+
+    // Parse SwiGLU-specific attributes. Defaults match the historical
+    // hardcoded GPT-OSS values so that existing models continue to
+    // produce the same output.
+    //   swiglu_fusion = 1 : interleaved (gate, up, gate, up, ...)
+    //   swiglu_fusion = 2 : chunked     (gate..., up...)
+    //   activation_alpha  : multiplier applied to the gate before sigmoid
+    //   activation_beta   : bias added to the up branch (linear + beta)
+    //   swiglu_limit      : clamp range for gate (max) and up (±limit);
+    //                       a non-positive value disables clamping.
+    swiglu_fusion_ = op_kernel_info.GetAttrOrDefault<int64_t>("swiglu_fusion", 1);
+    activation_alpha_ = op_kernel_info.GetAttrOrDefault<float>("activation_alpha", 1.702f);
+    activation_beta_ = op_kernel_info.GetAttrOrDefault<float>("activation_beta", 1.0f);
+    swiglu_limit_ = op_kernel_info.GetAttrOrDefault<float>("swiglu_limit", 7.0f);
+    if (activation_type_ == ort_fastertransformer::ActivationType::SwiGLU) {
+      ORT_ENFORCE(swiglu_fusion_ == 1 || swiglu_fusion_ == 2,
+                  "swiglu_fusion must be 1 (interleaved) or 2 (chunked); got ", swiglu_fusion_);
+    }
   }
 
   bool normalize_routing_weights_;
   bool use_sparse_mixer_;
   int64_t k_;
   ort_fastertransformer::ActivationType activation_type_;
+  int64_t swiglu_fusion_;
+  float activation_alpha_;
+  float activation_beta_;
+  float swiglu_limit_;
 };
 
 }  // namespace cuda

--- a/onnxruntime/contrib_ops/cuda/quantization/moe_quantization.cc
+++ b/onnxruntime/contrib_ops/cuda/quantization/moe_quantization.cc
@@ -65,7 +65,11 @@ Status QMoE<T>::QuantizedMoEImpl(OpKernelContext* context,
                                                                            activation_type_,
                                                                            fc3_experts_weights_optional != nullptr,
                                                                            normalize_routing_weights_,
-                                                                           use_sparse_mixer_);
+                                                                           use_sparse_mixer_,
+                                                                           activation_alpha_,
+                                                                           activation_beta_,
+                                                                           swiglu_limit_,
+                                                                           swiglu_fusion_ == 1);
 
   size_t ws_size = moe_runner.getWorkspaceSize(
       static_cast<size_t>(moe_params.num_rows), static_cast<size_t>(moe_params.hidden_size),


### PR DESCRIPTION
Fixes #28738.

## Problem

The `com.microsoft::MoE` schema declares these SwiGLU-related attributes:

- `swiglu_fusion` — 1 for interleaved (gate, up, gate, up, …), 2 for chunked (gate…, up…)
- `activation_alpha` — multiplier on the gate before sigmoid
- `activation_beta` — additive bias on the linear/up branch (`linear + beta`)
- `swiglu_limit` — clamp range for both branches

…but the CUDA kernel **hardcodes** the GPT-OSS values (`alpha=1.702`, `beta=1.0`, `limit=7.0`, interleaved) and silently ignores whatever the user sets:

https://github.com/microsoft/onnxruntime/blob/main/onnxruntime/contrib_ops/cuda/moe/ft_moe/moe_kernel.cu#L1037-L1048

This silently produces incorrect output for any model using **standard** SwiGLU semantics (`y = silu(gate) * up`, no `+1` bias, no clipping, alpha=1) — e.g. Gemma 4 26B-A4B. The mobius issue at https://github.com/microsoft/onnxruntime-genai/issues/2062 traces back to this.

## Changes

- **`cuda/moe/moe_base.h`** — parse the four schema attributes. Defaults match the legacy hardcoded GPT-OSS values, so existing callers see no behavior change.
- **`cuda/moe/ft_moe/moe_kernel.{h,cu}`** — refactor `invokeSwiGLU` to take `alpha`, `beta`, `limit`, `interleaved` as runtime arguments. `HasLimit` template param becomes a runtime `has_limit = limit > 0` check. The `+1.f` bias on the linear branch becomes `+ beta`. Dispatch to `swiglu_kernel_chunked` when `swiglu_fusion=2` (the chunked kernel existed but was unreachable).
- **`CutlassMoeFCRunner`** ctor gains four optional SwiGLU parameters (defaulting to legacy GPT-OSS values) and stores them on the runner.
- **`moe.cc`, `collective/sharded_moe.cc`, `quantization/moe_quantization.cc`** — plumb the parsed attributes into the runner.

## Validation

Built and ran a standalone correctness harness on H200 (sm_90, fp32) comparing the refactored kernel to the original hardcoded one across a mixed-distribution input that exercises clamping:

| Configuration | Result |
|---|---|
| GPT-OSS defaults (`alpha=1.702, beta=1.0, limit=7.0`, interleaved) | **0/32 mismatches** vs original kernel (bit-identical) |
| Standard SwiGLU (`alpha=1.0, beta=0.0, limit=0` → `has_limit=false`) | **0/32 mismatches** vs CPU-computed `silu(gate) * linear` |

I attempted a full `onnxruntime_providers_cuda` build locally but the system CUDA 13.2 toolkit hits a pre-existing cccl header bug (`cub/device/device_transform.cuh:44` global-qualification syntax error) on many unrelated `.cu` files. That failure is environmental, not from this change — `nvcc -c` on the refactored kernel succeeds standalone.

Please run CUDA CI to confirm.

## Migration / backwards compatibility

- Existing models that don't set the SwiGLU attributes get GPT-OSS defaults → no behavior change.
- Existing C++ callers of `CutlassMoeFCRunner(sm, type, has_fc3, normalize, sparse_mixer)` keep working because the four new constructor parameters have defaults.