### PR TITLE
[MLAS] Integrate prototype decomposable QGEMM

### DIFF
--- a/cmake/deps.txt
+++ b/cmake/deps.txt
@@ -56,7 +56,7 @@ extensions;https://github.com/microsoft/onnxruntime-extensions/archive/c24b7bab0
 directx_headers;https://github.com/microsoft/DirectX-Headers/archive/refs/tags/v1.613.1.zip;47653509a3371eabb156360f42faf582f314bf2e
 cudnn_frontend;https://github.com/NVIDIA/cudnn-frontend/archive/refs/tags/v1.12.0.zip;7e733cfdc410d777b76122d64232499205589a96
 dawn;https://github.com/google/dawn/archive/ec7b457e5bb1fcec6f59733c4f3dd84d2f885a38.zip;d4d64d1729104b61e654073566f1a376e16cad92
-kleidiai;https://github.com/ARM-software/kleidiai/archive/refs/tags/v1.20.0.tar.gz;6895e72b3d5cf1173358164cb3d64c9d7d33cc84
+kleidiai;https://gitlab.arm.com/kleidi/kleidiai/-/archive/06f9f75b20df8785b60fce624d85f6c7ba819855/kleidiai-06f9f75b20df8785b60fce624d85f6c7ba819855.tar.gz;543d60c1718aaee7c8d6e0c7c4bb6d5492a1230d
 # kleidiai-qmx is pinned to a specific commit as there are no tagged releases. When an appropriate tagged release becomes available,
 # this entry will be updated to use refs/tags/<version> instead of the raw commit hash.
 kleidiai-qmx;https://github.com/qualcomm/kleidiai/archive/2f10c9a8d32f81ffeeb6d4885a29cc35d2b0da87.zip;5e855730a2d69057a569f43dd7532db3b2d2a05c

--- a/onnxruntime/contrib_ops/cpu/quantization/attention_quant.cc
+++ b/onnxruntime/contrib_ops/cpu/quantization/attention_quant.cc
@@ -29,7 +29,7 @@ class QAttention : public OpKernel, public AttentionCPUBase {
                  /*out*/ PrePackedWeights* prepacked_weights) override;
 
   Status UseSharedPrePackedBuffers(std::vector<BufferUniquePtr>& prepacked_buffers,
-                                   gsl::span<const size_t> /*prepacked_buffer_sizes*/,
+                                   gsl::span<const size_t> prepacked_buffer_sizes,
                                    int input_idx,
                                    /*out*/ bool& used_shared_buffers) override;
 
@@ -102,7 +102,8 @@ Status QAttention<T>::PrePack(const Tensor& weights, int input_idx, AllocatorPtr
   memset(packed_weights_data, 0, packed_weights_data_size);
 
   for (size_t i = 0; i < loop_len; i++) {
-    MlasGemmPackB(head_size, input_hidden_size, weights_data, hidden_size_x3, false /*AIsSigned*/, weights_is_signed_, packed_weights_data);
+    MlasGemmPackB(head_size, input_hidden_size, weights_data, hidden_size_x3, false /*AIsSigned*/, weights_is_signed_, packed_weights_data,
+                  &mlas_backend_kernel_selector_config_);
     packed_weights_data += packed_weights_size_;
     weights_data += head_size;
   }
@@ -119,7 +120,7 @@ Status QAttention<T>::PrePack(const Tensor& weights, int input_idx, AllocatorPtr
 
 template <typename T>
 Status QAttention<T>::UseSharedPrePackedBuffers(std::vector<BufferUniquePtr>& prepacked_buffers,
-                                                gsl::span<const size_t> /*prepacked_buffer_sizes*/,
+                                                gsl::span<const size_t> prepacked_buffer_sizes,
                                                 int input_idx,
                                                 /*out*/ bool& used_shared_buffers) {
   if (1 != input_idx) {
@@ -128,6 +129,21 @@ Status QAttention<T>::UseSharedPrePackedBuffers(std::vector<BufferUniquePtr>& pr
 
   used_shared_buffers = true;
   packed_weights_ = std::move(prepacked_buffers[0]);
+
+  if (!prepacked_buffer_sizes.empty() && weight_shape_.NumDimensions() == 2) {
+    const auto& weights_dims = weight_shape_.GetDims();
+    const size_t hidden_size_x3 = narrow<size_t>(weights_dims[1]);
+    const size_t hidden_size = hidden_size_x3 / 3;
+    if (num_heads_ > 0 && hidden_size != 0 && hidden_size_x3 == 3 * hidden_size &&
+        hidden_size % static_cast<size_t>(num_heads_) == 0) {
+      const size_t num_heads = static_cast<size_t>(num_heads_);
+      const size_t loop_len = SafeInt<size_t>(3) * num_heads;
+
+      if (prepacked_buffer_sizes[0] % loop_len == 0) {
+        packed_weights_size_ = prepacked_buffer_sizes[0] / loop_len;
+      }
+    }
+  }
 
   return Status::OK();
 }
@@ -311,7 +327,7 @@ Status QAttention<T>::Compute(OpKernelContext* context) const {
       gemm_params.OutputProcessor = &(scale_bias_procs[i]);
     }
 
-    MlasGemmBatch(gemm_shape, gemm_data_vec.data(), loop_len, tp);
+    MlasGemmBatch(gemm_shape, gemm_data_vec.data(), loop_len, tp, &mlas_backend_kernel_selector_config_);
   }
 
   // Compute the attention score and apply the score to V

--- a/onnxruntime/contrib_ops/cpu/quantization/dynamic_quantize_lstm.cc
+++ b/onnxruntime/contrib_ops/cpu/quantization/dynamic_quantize_lstm.cc
@@ -77,7 +77,7 @@ Status DynamicQuantizeLSTM::TryPackWeights(const Tensor& weights, PackedWeights&
 
   const auto* weights_data = static_cast<const uint8_t*>(weights.DataRaw());
   for (int i = 0; i < num_directions_; i++) {
-    MlasGemmPackB(N, K, weights_data, N, false /*AIsSigned*/, is_weight_signed, packed_weights_data);
+    MlasGemmPackB(N, K, weights_data, N, false /*AIsSigned*/, is_weight_signed, packed_weights_data, &mlas_backend_kernel_selector_config_);
     packed_weights_data = static_cast<uint8_t*>(packed_weights_data) + packed_weights_size;
     weights_data += N * K;
   }

--- a/onnxruntime/contrib_ops/cpu/quantization/dynamic_quantize_matmul.cc
+++ b/onnxruntime/contrib_ops/cpu/quantization/dynamic_quantize_matmul.cc
@@ -158,7 +158,8 @@ Status MatMulIntegerToFloatBase::ComputeCommon(OpKernelContext* ctx,
     params.ldc = gemm_shape.N;
   }
 
-  MlasGemmBatch(gemm_shape, gemm_data_vec.data(), num_gemms, ctx->GetOperatorThreadPool());
+  MlasGemmBatch(gemm_shape, gemm_data_vec.data(), num_gemms, ctx->GetOperatorThreadPool(),
+                &mlas_backend_kernel_selector_config_);
 
   return Status::OK();
 }
@@ -297,18 +298,28 @@ Status DynamicQuantizeMatMul::Compute(OpKernelContext* ctx) const {
     gemm_shape.K = static_cast<size_t>(helper.K());
 
     const size_t num_gemms = helper.OutputOffsets().size();
-    std::vector<MLAS_GEMM_DYN_QUANT_DATA_PARAMS> gemm_data_vec(num_gemms);
+    if (num_gemms == 1) {
+      MLAS_GEMM_DYN_QUANT_DATA_PARAMS gemm_data{};
+      gemm_data.A = a_data + helper.LeftOffsets()[0];
+      gemm_data.lda = gemm_shape.K;
+      gemm_data.PackedB = packed_b_.get();
+      gemm_data.C = y_data + helper.OutputOffsets()[0];
+      gemm_data.ldc = gemm_shape.N;
+      MlasDynamicQGemm(gemm_shape, &gemm_data, ctx->GetOperatorThreadPool(), &mlas_backend_kernel_selector_config_);
+    } else {
+      std::vector<MLAS_GEMM_DYN_QUANT_DATA_PARAMS> gemm_data_vec(num_gemms);
 
-    for (size_t gemm_idx = 0; gemm_idx < num_gemms; gemm_idx++) {
-      auto& params = gemm_data_vec[gemm_idx];
-      params.A = a_data + helper.LeftOffsets()[gemm_idx];
-      params.lda = gemm_shape.K;
-      params.PackedB = packed_b_.get();
-      params.C = y_data + helper.OutputOffsets()[gemm_idx];
-      params.ldc = gemm_shape.N;
+      for (size_t gemm_idx = 0; gemm_idx < num_gemms; gemm_idx++) {
+        auto& params = gemm_data_vec[gemm_idx];
+        params.A = a_data + helper.LeftOffsets()[gemm_idx];
+        params.lda = gemm_shape.K;
+        params.PackedB = packed_b_.get();
+        params.C = y_data + helper.OutputOffsets()[gemm_idx];
+        params.ldc = gemm_shape.N;
+      }
+
+      MlasDynamicQGemmBatch(gemm_shape, gemm_data_vec.data(), num_gemms, ctx->GetOperatorThreadPool(), &mlas_backend_kernel_selector_config_);
     }
-
-    MlasDynamicQGemmBatch(gemm_shape, gemm_data_vec.data(), num_gemms, ctx->GetOperatorThreadPool(), &mlas_backend_kernel_selector_config_);
     // This evaluates to true if bias data was not provided as constant data for prepacking stage
     if (!dynamic_quant_mlas_bias_data_was_packed_) {
       if (ctx->Input<Tensor>(IN_BIAS) != nullptr) {

--- a/onnxruntime/contrib_ops/cpu/quantization/dynamic_quantize_matmul.cc
+++ b/onnxruntime/contrib_ops/cpu/quantization/dynamic_quantize_matmul.cc
@@ -223,6 +223,8 @@ class MatMulIntegerToFloat final : public MatMulIntegerToFloatBase {
  protected:
   int GetBIdx() const override { return IN_B; }
 
+  int GetAZeroPointIdx() const override { return IN_A_ZERO_POINT; }
+
  private:
   // a scale and b scale may be switched in fusion stage because of lack of shape information.
   // Fix them up before computation.
@@ -246,6 +248,8 @@ Status DynamicQuantizeMatMul::Compute(OpKernelContext* ctx) const {
     uint8_t a_zero_point;
     GetQuantizationParameter(a_data, num_of_elements, a_scale, a_zero_point, ctx->GetOperatorThreadPool());
 
+    bool is_b_scale_supported = IsBQuantParamSupported(b_scale_tensor->Shape(), b ? b->Shape() : b_shape_);
+
     AllocatorPtr allocator;
     ORT_RETURN_IF_ERROR(ctx->GetTempSpaceAllocator(&allocator));
     uint8_t* a_data_quant = static_cast<uint8_t*>(allocator->Alloc(SafeInt<size_t>(num_of_elements) * sizeof(uint8_t)));
@@ -253,7 +257,6 @@ Status DynamicQuantizeMatMul::Compute(OpKernelContext* ctx) const {
 
     ParQuantizeLinearStd(a_data, a_data_quant, narrow<size_t>(num_of_elements), a_scale, a_zero_point, ctx->GetOperatorThreadPool());
 
-    bool is_b_scale_supported = IsBQuantParamSupported(b_scale_tensor->Shape(), b ? b->Shape() : b_shape_);
     const bool is_a_signed = false;
     ORT_RETURN_IF_ERROR(ComputeCommon(
         ctx,
@@ -298,6 +301,7 @@ Status DynamicQuantizeMatMul::Compute(OpKernelContext* ctx) const {
     gemm_shape.K = static_cast<size_t>(helper.K());
 
     const size_t num_gemms = helper.OutputOffsets().size();
+
     if (num_gemms == 1) {
       MLAS_GEMM_DYN_QUANT_DATA_PARAMS gemm_data{};
       gemm_data.A = a_data + helper.LeftOffsets()[0];
@@ -320,6 +324,7 @@ Status DynamicQuantizeMatMul::Compute(OpKernelContext* ctx) const {
 
       MlasDynamicQGemmBatch(gemm_shape, gemm_data_vec.data(), num_gemms, ctx->GetOperatorThreadPool(), &mlas_backend_kernel_selector_config_);
     }
+
     // This evaluates to true if bias data was not provided as constant data for prepacking stage
     if (!dynamic_quant_mlas_bias_data_was_packed_) {
       if (ctx->Input<Tensor>(IN_BIAS) != nullptr) {
@@ -327,14 +332,13 @@ Status DynamicQuantizeMatMul::Compute(OpKernelContext* ctx) const {
         ORT_RETURN_IF_NOT(bias_t->Shape().Size() == static_cast<int64_t>(gemm_shape.N),
                           "bias tensor's element count must equal B's last dimension (",
                           gemm_shape.N, "), but got ", bias_t->Shape().Size());
-        const auto biases = std::vector<float>(&bias_t->Data<float>()[0],
-                                               &bias_t->Data<float>()[gemm_shape.N]);
+        const float* biases = bias_t->Data<float>();
 
         // deferred adding of bias
         for (size_t gemm_idx = 0; gemm_idx < num_gemms; gemm_idx++) {
           float* MxN = y_data + helper.OutputOffsets()[gemm_idx];
           for (auto l = gemm_shape.M; l > 0; --l) {
-            MlasEltwiseAdd<float>(MxN, biases.data(), MxN, gemm_shape.N);
+            MlasEltwiseAdd<float>(MxN, biases, MxN, gemm_shape.N);
             MxN += gemm_shape.N;
           }
         }

--- a/onnxruntime/contrib_ops/cpu/quantization/quant_gemm.cc
+++ b/onnxruntime/contrib_ops/cpu/quantization/quant_gemm.cc
@@ -119,6 +119,10 @@ class QGemm : protected GemmBase, public MatMulIntegerBase {
     return IN_B;
   }
 
+  int GetAZeroPointIdx() const override {
+    return IN_A_ZERO_POINT;
+  }
+
   virtual bool IsBTransposed() const override {
     return trans_B_ == CblasTrans;
   }

--- a/onnxruntime/core/mlas/inc/mlas.h
+++ b/onnxruntime/core/mlas/inc/mlas.h
@@ -537,8 +537,19 @@ enum class MLAS_QGEMM_OUTPUT_MODE {
     AccumulateMode, // accumulate to the output buffer
 };
 
+class MLAS_QGEMM_SCALE_BIAS_OUTPUT_PROCESSOR;
+
 class MLAS_QGEMM_OUTPUT_PROCESSOR {
 public:
+    // Allows backend overrides to recognize and fuse ScaleBias processing
+    // without requiring RTTI. Other output processor types return nullptr.
+    virtual
+    const MLAS_QGEMM_SCALE_BIAS_OUTPUT_PROCESSOR*
+    AsScaleBiasOutputProcessor() const
+    {
+        return nullptr;
+    }
+
     virtual
     void
     Process(
@@ -569,6 +580,48 @@ public:
             OutputMode_(Mode),
             QuantGran_(QuantGran)
     {
+    }
+
+    const MLAS_QGEMM_SCALE_BIAS_OUTPUT_PROCESSOR*
+    AsScaleBiasOutputProcessor() const override
+    {
+        return this;
+    }
+
+    float*
+    Output() const
+    {
+        return Output_;
+    }
+
+    size_t
+    LeadingDimensionOutput() const
+    {
+        return LeadingDimensionOutput_;
+    }
+
+    const float*
+    Scale() const
+    {
+        return Scale_;
+    }
+
+    const float*
+    Bias() const
+    {
+        return Bias_;
+    }
+
+    MLAS_QGEMM_OUTPUT_MODE
+    OutputMode() const
+    {
+        return OutputMode_;
+    }
+
+    MLAS_QUANTIZATION_GRANULARITY
+    QuantGranularity() const
+    {
+        return QuantGran_;
     }
 
     void
@@ -643,6 +696,9 @@ struct MLAS_GEMM_QUANT_DATA_PARAMS {
  * @param [IN]  DataParams   Array of data descriptors for the matrices.
  * @param [IN]  BatchN       Size of the parameters array, also number of multiplications to perform
  * @param [IN]  ThreadPool   optional thread pool for parallel processing
+ * @param [IN]  BackendKernelSelectorConfig Supplies the backend kernel selector
+ *                                           configuration options, else nullptr if the
+ *                                           default configuration should be used.
  */
 void
 MLASCALL
@@ -650,7 +706,8 @@ MlasGemmBatch(
     const MLAS_GEMM_QUANT_SHAPE_PARAMS& Shape,
     const MLAS_GEMM_QUANT_DATA_PARAMS* DataParams,
     const size_t BatchN,
-    MLAS_THREADPOOL* ThreadPool
+    MLAS_THREADPOOL* ThreadPool,
+    const MLAS_BACKEND_KERNEL_SELECTOR_CONFIG* BackendKernelSelectorConfig = nullptr
     );
 
 inline
@@ -658,9 +715,10 @@ void
 MlasGemm(
     const MLAS_GEMM_QUANT_SHAPE_PARAMS &Shape,
     const MLAS_GEMM_QUANT_DATA_PARAMS &DataParams,
-    MLAS_THREADPOOL *ThreadPool)
+    MLAS_THREADPOOL *ThreadPool,
+    const MLAS_BACKEND_KERNEL_SELECTOR_CONFIG* BackendKernelSelectorConfig = nullptr)
 {
-    MlasGemmBatch(Shape, &DataParams, 1, ThreadPool);
+    MlasGemmBatch(Shape, &DataParams, 1, ThreadPool, BackendKernelSelectorConfig);
 }
 
 /**
@@ -818,7 +876,8 @@ MlasGemmPackB(
     size_t ldb,
     bool AIsSigned,
     bool BIsSigned,
-    void* PackedB
+    void* PackedB,
+    const MLAS_BACKEND_KERNEL_SELECTOR_CONFIG* BackendKernelSelectorConfig = nullptr
     );
 
 /**

--- a/onnxruntime/core/mlas/inc/mlas.h
+++ b/onnxruntime/core/mlas/inc/mlas.h
@@ -880,6 +880,20 @@ MlasGemmPackB(
     const MLAS_BACKEND_KERNEL_SELECTOR_CONFIG* BackendKernelSelectorConfig = nullptr
     );
 
+void
+MLASCALL
+MlasGemmPackB(
+    size_t N,
+    size_t K,
+    const uint8_t* B,
+    size_t ldb,
+    bool AIsSigned,
+    bool BIsSigned,
+    void* PackedB,
+    const MLAS_BACKEND_KERNEL_SELECTOR_CONFIG* BackendKernelSelectorConfig,
+    const uint8_t* ZeroPointA
+    );
+
 /**
  * @brief For symmetric quantized GEMM, returns size of the
  *        packing buffer needed for right hand side

--- a/onnxruntime/core/mlas/lib/kleidiai/mlasi_kleidiai.h
+++ b/onnxruntime/core/mlas/lib/kleidiai/mlasi_kleidiai.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "../mlasi.h"
+#include "core/mlas/inc/mlas.h"
 #include <iostream>
 
 // Fix to ensure compatibility with MSVC build
@@ -103,6 +104,37 @@ MlasGemmBatch(
     const MLAS_SGEMM_DATA_PARAMS* Data,
     size_t BatchSize,
     MLAS_THREADPOOL* ThreadPool
+    );
+
+// QGEMM override
+bool
+MLASCALL
+MlasGemmBatch(
+    const MLAS_GEMM_QUANT_SHAPE_PARAMS& Shape,
+    const MLAS_GEMM_QUANT_DATA_PARAMS* DataParams,
+    const size_t BatchN,
+    MLAS_THREADPOOL* ThreadPool
+    );
+
+size_t
+MLASCALL
+MlasQGemmPackBSize(
+    size_t N,
+    size_t K,
+    bool AIsSigned,
+    bool BIsSigned
+    );
+
+bool
+MLASCALL
+MlasQGemmPackB(
+    size_t N,
+    size_t K,
+    const uint8_t* B,
+    size_t ldb,
+    bool AIsSigned,
+    bool BIsSigned,
+    void* PackedB
     );
 
 #if defined(__aarch64__) && defined(__linux__)

--- a/onnxruntime/core/mlas/lib/kleidiai/mlasi_kleidiai.h
+++ b/onnxruntime/core/mlas/lib/kleidiai/mlasi_kleidiai.h
@@ -134,7 +134,8 @@ MlasQGemmPackB(
     size_t ldb,
     bool AIsSigned,
     bool BIsSigned,
-    void* PackedB
+    void* PackedB,
+    const uint8_t* ZeroPointA
     );
 
 #if defined(__aarch64__) && defined(__linux__)

--- a/onnxruntime/core/mlas/lib/kleidiai/qgemm_kleidiai.cpp
+++ b/onnxruntime/core/mlas/lib/kleidiai/qgemm_kleidiai.cpp
@@ -4,11 +4,16 @@
 // SPDX-License-Identifier: MIT
 //
 
-
-
 #include <array>
+#include <algorithm>
 #include <cstddef>
+#include <cstdint>
+#include <limits>
 #include <vector>
+
+#include "kai/ukernels/matmul/kai_matmul.h"
+#include "kai/ukernels/matmul/kai_matmul_pack_lhs.h"
+#include "kai/ukernels/matmul/kai_matmul_pack_rhs.h"
 
 #include "mlasi_kleidiai.h"
 
@@ -16,6 +21,9 @@
 
 #include "kai/ukernels/matmul/pack/kai_lhs_quant_pack_qai8dxp_f32.h"
 #include "kai/ukernels/matmul/pack/kai_rhs_pack_kxn_qsi8cxp_qsi8cx_neon.h"
+
+namespace ArmKleidiAI {
+namespace {
 
 // Thread-local reusable buffers to reduce allocation overhead across tiles.
 struct KaiTlsBuffersQgemm {
@@ -26,7 +34,594 @@ static thread_local KaiTlsBuffersQgemm g_kai_tls_qgemm;
 
 const KaiDynamicQGemmKernel qgemm_gemm = GetKleidiAIQGemmUKernel();
 
-// Matmul with float output of dynamic-quantized A and symmetric-quantized B.
+struct KaiTlsBuffersQgemmInteger {
+    std::vector<uint8_t> lhs_unsigned;
+    std::vector<uint8_t> rhs_unsigned;
+    std::vector<std::byte> lhs_packed;
+    std::vector<std::byte> rhs_packed;
+    std::vector<int32_t> acc_row_bias;
+    std::vector<int32_t> acc_col_bias;
+    std::vector<int32_t> zero_acc_row_bias;
+    std::vector<int32_t> zero_acc_col_bias;
+    std::vector<float> zero_col_bias;
+};
+static thread_local KaiTlsBuffersQgemmInteger g_kai_tls_qgemm_int;
+
+const kai_matmul_pack_lhs_uker_api qgemm_int_lhs_pack = kai_matmul_pack_lhs_mxk_x8p4vsx4_x8_sme();
+const kai_matmul_pack_rhs_uker_api qgemm_int_rhs_pack = kai_matmul_pack_rhs_kxn_x8p4vsx4_x8_sme();
+const kai_matmul_uker_api qgemm_int_i32 = kai_matmul_i32_u8p4vsx4_u8p4vsx4_i32_i32_8vsx8vs_sme2_mopa();
+const kai_matmul_uker_api qgemm_int_f32 = kai_matmul_clamp_f32_u8p4vsx4_u8p4vsx4_i32_i32_f32_f32_8vsx8vs_sme2_mopa();
+
+static int32_t
+AdjustedZeroPoint(uint8_t zero_point, bool is_signed) {
+    return is_signed ? static_cast<int32_t>(zero_point ^ 0x80) : static_cast<int32_t>(zero_point);
+}
+
+template <typename T>
+static void
+EnsureVectorSize(std::vector<T>& buffer, size_t size) {
+    if (buffer.size() < size) {
+        buffer.resize(size);
+    }
+}
+
+template <typename T>
+static T*
+EnsureZeroVectorSize(std::vector<T>& buffer, size_t size) {
+    if (buffer.size() < size) {
+        buffer.resize(size, T{});
+    }
+    return buffer.data();
+}
+
+static bool
+CheckedAddSize(size_t a, size_t b, size_t* out) {
+    if (a > std::numeric_limits<size_t>::max() - b) {
+        return false;
+    }
+    *out = a + b;
+    return true;
+}
+
+static bool
+CheckedAlignUp(size_t value, size_t alignment, size_t* out) {
+    if (alignment == 0) {
+        *out = value;
+        return true;
+    }
+
+    size_t rounded = 0;
+    if (!CheckedAddSize(value, alignment - 1, &rounded)) {
+        return false;
+    }
+
+    *out = rounded & ~(alignment - 1);
+    return true;
+}
+
+static bool
+PackedBColumnSumsSize(size_t n, size_t* size) {
+    size_t bytes = 0;
+    if (mul_overflow_size_t_builtin(n, sizeof(int32_t), &bytes)) {
+        return false;
+    }
+    return CheckedAlignUp(bytes, MlasGetPreferredBufferAlignment(), size);
+}
+
+static int32_t*
+PackedBColumnSums(void* packed_b) {
+    return reinterpret_cast<int32_t*>(packed_b);
+}
+
+static const int32_t*
+PackedBColumnSums(const void* packed_b) {
+    return reinterpret_cast<const int32_t*>(packed_b);
+}
+
+static void*
+PackedBData(void* packed_b, size_t n) {
+    size_t column_sums_size = 0;
+    if (!PackedBColumnSumsSize(n, &column_sums_size)) {
+        return nullptr;
+    }
+    return static_cast<std::byte*>(packed_b) + column_sums_size;
+}
+
+static const void*
+PackedBData(const void* packed_b, size_t n) {
+    size_t column_sums_size = 0;
+    if (!PackedBColumnSumsSize(n, &column_sums_size)) {
+        return nullptr;
+    }
+    return static_cast<const std::byte*>(packed_b) + column_sums_size;
+}
+
+template <bool LhsIsSigned, bool RhsIsSigned, bool OutputFloat>
+static bool
+GemmBatch(
+    const MLAS_GEMM_QUANT_SHAPE_PARAMS& Shape,
+    const MLAS_GEMM_QUANT_DATA_PARAMS* DataParams,
+    size_t BatchN
+) {
+    const size_t m = Shape.M;
+    const size_t n = Shape.N;
+    const size_t k = Shape.K;
+
+    if (!UseSME2) {
+        return false;
+    }
+    if (DataParams == nullptr) {
+        return false;
+    }
+    if (m == 0 || n == 0 || k == 0 || BatchN == 0) {
+        return true;
+    }
+
+    for (size_t i = 0; i < BatchN; ++i) {
+        const auto& p = DataParams[i];
+
+        if (p.PerColumnZeroPoints) {
+            return false;
+        }
+        if (p.A == nullptr || p.B == nullptr) {
+            return false;
+        }
+
+        const MLAS_QGEMM_SCALE_BIAS_OUTPUT_PROCESSOR* scale_bias_processor = nullptr;
+        if constexpr (OutputFloat) {
+            if (p.OutputProcessor == nullptr) {
+                return false;
+            }
+
+            scale_bias_processor = p.OutputProcessor->AsScaleBiasOutputProcessor();
+            if (scale_bias_processor == nullptr) {
+                return false;
+            }
+            if (scale_bias_processor->OutputMode() != MLAS_QGEMM_OUTPUT_MODE::ZeroMode) {
+                return false;
+            }
+            if (scale_bias_processor->QuantGranularity() != MLAS_QUANTIZATION_GRANULARITY::PerMatrix) {
+                return false;
+            }
+            if (scale_bias_processor->Scale() == nullptr) {
+                return false;
+            }
+            if (scale_bias_processor->Output() == nullptr) {
+                return false;
+            }
+        } else {
+            if (p.C == nullptr) {
+                return false;
+            }
+            if (p.OutputProcessor != nullptr) {
+                return false;
+            }
+        }
+
+        const void* lhs_qdata = static_cast<const void*>(p.A);
+        size_t lhs_stride = p.lda * sizeof(uint8_t);
+        int32_t zpA = AdjustedZeroPoint(p.ZeroPointA, LhsIsSigned);
+        if constexpr (LhsIsSigned) {
+            size_t lhs_unsigned_size = 0;
+            if (mul_overflow_size_t_builtin(m, k, &lhs_unsigned_size)) {
+                return false;
+            }
+            EnsureVectorSize(g_kai_tls_qgemm_int.lhs_unsigned, lhs_unsigned_size);
+
+            const uint8_t* src = p.A;
+            uint8_t* dst = g_kai_tls_qgemm_int.lhs_unsigned.data();
+            for (size_t row = 0; row < m; ++row) {
+                for (size_t col = 0; col < k; ++col) {
+                    dst[col] = src[col] ^ 0x80;
+                }
+                src += p.lda;
+                dst += k;
+            }
+
+            lhs_qdata = static_cast<const void*>(g_kai_tls_qgemm_int.lhs_unsigned.data());
+            lhs_stride = k * sizeof(uint8_t);
+        }
+
+        const bool rhs_is_packed = p.BIsPacked;
+        const void* rhs_qdata = static_cast<const void*>(p.B);
+        size_t rhs_stride = p.ldb * sizeof(uint8_t);
+        const uint8_t zero_point_b = p.ZeroPointB ? p.ZeroPointB[0] : uint8_t{0};
+        const int32_t zpB = AdjustedZeroPoint(zero_point_b, RhsIsSigned);
+        if constexpr (RhsIsSigned) {
+            if (!rhs_is_packed) {
+                size_t rhs_unsigned_size = 0;
+                if (mul_overflow_size_t_builtin(k, n, &rhs_unsigned_size)) {
+                    return false;
+                }
+                EnsureVectorSize(g_kai_tls_qgemm_int.rhs_unsigned, rhs_unsigned_size);
+
+                const uint8_t* src = static_cast<const uint8_t*>(p.B);
+                uint8_t* dst = g_kai_tls_qgemm_int.rhs_unsigned.data();
+                for (size_t row = 0; row < k; ++row) {
+                    for (size_t col = 0; col < n; ++col) {
+                        dst[col] = src[col] ^ 0x80;
+                    }
+                    src += p.ldb;
+                    dst += n;
+                }
+
+                rhs_qdata = static_cast<const void*>(g_kai_tls_qgemm_int.rhs_unsigned.data());
+                rhs_stride = n * sizeof(uint8_t);
+            }
+        }
+
+        const void* acc_row_bias = nullptr;
+        if (zpB == 0) {
+            acc_row_bias = EnsureZeroVectorSize(g_kai_tls_qgemm_int.zero_acc_row_bias, m);
+        } else {
+            EnsureVectorSize(g_kai_tls_qgemm_int.acc_row_bias, m);
+            for (size_t row = 0; row < m; ++row) {
+                const uint8_t* lhs_row = static_cast<const uint8_t*>(lhs_qdata) + row * lhs_stride;
+                int64_t row_sum = 0;
+                for (size_t col = 0; col < k; ++col) {
+                    row_sum += lhs_row[col];
+                }
+                g_kai_tls_qgemm_int.acc_row_bias[row] =
+                    static_cast<int32_t>(-static_cast<int64_t>(zpB) * (row_sum - static_cast<int64_t>(k) * zpA));
+            }
+            acc_row_bias = g_kai_tls_qgemm_int.acc_row_bias.data();
+        }
+
+        const void* acc_col_bias = nullptr;
+        if (zpA == 0) {
+            acc_col_bias = EnsureZeroVectorSize(g_kai_tls_qgemm_int.zero_acc_col_bias, n);
+        } else if (rhs_is_packed) {
+            EnsureVectorSize(g_kai_tls_qgemm_int.acc_col_bias, n);
+            const int32_t* rhs_col_sums = PackedBColumnSums(p.B);
+            for (size_t col = 0; col < n; ++col) {
+                g_kai_tls_qgemm_int.acc_col_bias[col] = static_cast<int32_t>(-static_cast<int64_t>(zpA) * rhs_col_sums[col]);
+            }
+            acc_col_bias = g_kai_tls_qgemm_int.acc_col_bias.data();
+        } else {
+            EnsureVectorSize(g_kai_tls_qgemm_int.acc_col_bias, n);
+            for (size_t col = 0; col < n; ++col) {
+                const uint8_t* rhs_col = static_cast<const uint8_t*>(rhs_qdata) + col;
+                int64_t col_sum = 0;
+                for (size_t row = 0; row < k; ++row) {
+                    col_sum += rhs_col[row * rhs_stride];
+                }
+                g_kai_tls_qgemm_int.acc_col_bias[col] = static_cast<int32_t>(-static_cast<int64_t>(zpA) * col_sum);
+            }
+            acc_col_bias = g_kai_tls_qgemm_int.acc_col_bias.data();
+        }
+
+        const kai_matmul_pack_lhs_uker_config lhs_pack_config{};
+        const kai_matmul_pack_lhs_uker_lhs_packed_dim_args lhs_packed_shape{m, k};
+        const auto lhs_packed_stride =
+            qgemm_int_lhs_pack.get_lhs_packed_stride(&lhs_pack_config, &lhs_packed_shape);
+        const size_t lhs_packed_size =
+            qgemm_int_lhs_pack.get_lhs_packed_size(&lhs_pack_config, &lhs_packed_shape, &lhs_packed_stride);
+        EnsureVectorSize(g_kai_tls_qgemm_int.lhs_packed, lhs_packed_size);
+
+        kai_matmul_pack_lhs_uker_args lhs_pack_args{};
+        lhs_pack_args.shape.m = m;
+        lhs_pack_args.shape.k = k;
+        lhs_pack_args.operand.lhs.ptr = lhs_qdata;
+        lhs_pack_args.operand.lhs.stride.m = lhs_stride;
+        lhs_pack_args.operand.lhs_packed.ptr = g_kai_tls_qgemm_int.lhs_packed.data();
+        lhs_pack_args.operand.lhs_packed.stride = lhs_packed_stride;
+        KLEIDIAI_KERNEL_LOG("kai_matmul_pack_lhs_mxk_x8p4vsx4_x8_sme"
+                            << " Batch=" << i << " M=" << m << " K=" << k);
+        qgemm_int_lhs_pack.run(&lhs_pack_config, &lhs_pack_args);
+
+        const kai_matmul_pack_rhs_uker_config rhs_pack_config{};
+        const kai_matmul_pack_rhs_uker_rhs_packed_dim_args rhs_packed_shape{n, k};
+        const auto rhs_packed_stride =
+            qgemm_int_rhs_pack.get_rhs_packed_stride(&rhs_pack_config, &rhs_packed_shape);
+        const void* rhs_packed_data = nullptr;
+        if (rhs_is_packed) {
+            rhs_packed_data = PackedBData(p.B, n);
+            if (rhs_packed_data == nullptr) {
+                return false;
+            }
+        } else {
+            const size_t rhs_packed_size =
+                qgemm_int_rhs_pack.get_rhs_packed_size(&rhs_pack_config, &rhs_packed_shape, &rhs_packed_stride);
+            EnsureVectorSize(g_kai_tls_qgemm_int.rhs_packed, rhs_packed_size);
+
+            kai_matmul_pack_rhs_uker_args rhs_pack_args{};
+            rhs_pack_args.shape.n = n;
+            rhs_pack_args.shape.k = k;
+            rhs_pack_args.operand.rhs.ptr = rhs_qdata;
+            rhs_pack_args.operand.rhs.stride.n = sizeof(uint8_t);
+            rhs_pack_args.operand.rhs.stride.k = rhs_stride;
+            rhs_pack_args.operand.rhs_packed.ptr = g_kai_tls_qgemm_int.rhs_packed.data();
+            rhs_pack_args.operand.rhs_packed.stride = rhs_packed_stride;
+            rhs_pack_args.operand.bias_n.ptr = nullptr;
+            KLEIDIAI_KERNEL_LOG("kai_matmul_pack_rhs_kxn_x8p4vsx4_x8_sme"
+                                << " Batch=" << i << " N=" << n << " K=" << k);
+            qgemm_int_rhs_pack.run(&rhs_pack_config, &rhs_pack_args);
+            rhs_packed_data = g_kai_tls_qgemm_int.rhs_packed.data();
+        }
+
+        const void* scale = nullptr;
+        const void* scale_bias_n = nullptr;
+        void* dst = nullptr;
+        size_t dst_stride = 0;
+        float clamp_min = std::numeric_limits<float>::lowest();
+        float clamp_max = std::numeric_limits<float>::max();
+        if constexpr (OutputFloat) {
+            scale = scale_bias_processor->Scale();
+            if (scale_bias_processor->Bias() != nullptr) {
+                scale_bias_n = scale_bias_processor->Bias();
+            } else {
+                scale_bias_n = EnsureZeroVectorSize(g_kai_tls_qgemm_int.zero_col_bias, n);
+            }
+            dst = static_cast<void*>(scale_bias_processor->Output());
+            if (mul_overflow_size_t_builtin(scale_bias_processor->LeadingDimensionOutput(), sizeof(float), &dst_stride)) {
+                return false;
+            }
+        } else {
+            dst = static_cast<void*>(p.C);
+            if (mul_overflow_size_t_builtin(p.ldc, sizeof(int32_t), &dst_stride)) {
+                return false;
+            }
+        }
+
+        const kai_matmul_uker_config matmul_config{};
+        const kai_matmul_uker_api& matmul = OutputFloat ? qgemm_int_f32 : qgemm_int_i32;
+        kai_matmul_uker_args matmul_args{};
+        matmul_args.flags = OutputFloat ? KAI_MATMUL_UKER_FLAGS_ARGS_CLAMP : 0;
+        matmul_args.shape.m = m;
+        matmul_args.shape.n = n;
+        matmul_args.shape.k = k;
+        matmul_args.operand.lhs.ptr = g_kai_tls_qgemm_int.lhs_packed.data();
+        matmul_args.operand.lhs.stride.m = lhs_packed_stride.m;
+        matmul_args.operand.rhs.ptr = rhs_packed_data;
+        matmul_args.operand.rhs.stride.n = rhs_packed_stride.n;
+        matmul_args.operand.dst.ptr = dst;
+        matmul_args.operand.dst.stride.m = dst_stride;
+        matmul_args.operand.bias.acc_bias_m.ptr = acc_row_bias;
+        matmul_args.operand.bias.acc_bias_n.ptr = acc_col_bias;
+        if constexpr (OutputFloat) {
+            matmul_args.operand.scale.acc_scale_global.ptr = scale;
+            matmul_args.operand.bias.scale_bias_n.ptr = scale_bias_n;
+            matmul_args.activation.clamp.min_ptr = &clamp_min;
+            matmul_args.activation.clamp.max_ptr = &clamp_max;
+        }
+        if constexpr (OutputFloat) {
+            KLEIDIAI_KERNEL_LOG("kai_matmul_clamp_f32_u8p4vsx4_u8p4vsx4_i32_i32_f32_f32_8vsx8vs_sme2_mopa"
+                                << " Batch=" << i << " M=" << m << " N=" << n << " K=" << k);
+        } else {
+            KLEIDIAI_KERNEL_LOG("kai_matmul_i32_u8p4vsx4_u8p4vsx4_i32_i32_8vsx8vs_sme2_mopa"
+                                << " Batch=" << i << " M=" << m << " N=" << n << " K=" << k);
+        }
+        matmul.run(&matmul_config, &matmul_args);
+    }
+
+    return true;
+}
+
+static bool
+GemmBatchU8U8ToI32(
+    const MLAS_GEMM_QUANT_SHAPE_PARAMS& Shape,
+    const MLAS_GEMM_QUANT_DATA_PARAMS* DataParams,
+    size_t BatchN
+) {
+    return GemmBatch<false, false, false>(Shape, DataParams, BatchN);
+}
+
+static bool
+GemmBatchU8I8ToI32(
+    const MLAS_GEMM_QUANT_SHAPE_PARAMS& Shape,
+    const MLAS_GEMM_QUANT_DATA_PARAMS* DataParams,
+    size_t BatchN
+) {
+    return GemmBatch<false, true, false>(Shape, DataParams, BatchN);
+}
+
+static bool
+GemmBatchI8U8ToI32(
+    const MLAS_GEMM_QUANT_SHAPE_PARAMS& Shape,
+    const MLAS_GEMM_QUANT_DATA_PARAMS* DataParams,
+    size_t BatchN
+) {
+    return GemmBatch<true, false, false>(Shape, DataParams, BatchN);
+}
+
+static bool
+GemmBatchI8I8ToI32(
+    const MLAS_GEMM_QUANT_SHAPE_PARAMS& Shape,
+    const MLAS_GEMM_QUANT_DATA_PARAMS* DataParams,
+    size_t BatchN
+) {
+    return GemmBatch<true, true, false>(Shape, DataParams, BatchN);
+}
+
+static bool
+GemmBatchU8U8ToF32(
+    const MLAS_GEMM_QUANT_SHAPE_PARAMS& Shape,
+    const MLAS_GEMM_QUANT_DATA_PARAMS* DataParams,
+    size_t BatchN
+) {
+    return GemmBatch<false, false, true>(Shape, DataParams, BatchN);
+}
+
+static bool
+GemmBatchU8I8ToF32(
+    const MLAS_GEMM_QUANT_SHAPE_PARAMS& Shape,
+    const MLAS_GEMM_QUANT_DATA_PARAMS* DataParams,
+    size_t BatchN
+) {
+    return GemmBatch<false, true, true>(Shape, DataParams, BatchN);
+}
+
+static bool
+GemmBatchI8U8ToF32(
+    const MLAS_GEMM_QUANT_SHAPE_PARAMS& Shape,
+    const MLAS_GEMM_QUANT_DATA_PARAMS* DataParams,
+    size_t BatchN
+) {
+    return GemmBatch<true, false, true>(Shape, DataParams, BatchN);
+}
+
+static bool
+GemmBatchI8I8ToF32(
+    const MLAS_GEMM_QUANT_SHAPE_PARAMS& Shape,
+    const MLAS_GEMM_QUANT_DATA_PARAMS* DataParams,
+    size_t BatchN
+) {
+    return GemmBatch<true, true, true>(Shape, DataParams, BatchN);
+}
+
+} // namespace
+} // namespace ArmKleidiAI
+
+bool
+MLASCALL
+ArmKleidiAI::MlasGemmBatch(
+    const MLAS_GEMM_QUANT_SHAPE_PARAMS& Shape,
+    const MLAS_GEMM_QUANT_DATA_PARAMS* DataParams,
+    const size_t BatchN,
+    MLAS_THREADPOOL* /*ThreadPool*/
+) {
+    // Implement all unpacked {u8, i8} x {u8, i8} -> i32 variants here.
+    if (Shape.IsAccumulateMode) {
+        return false;
+    }
+    if (BatchN > 0 && DataParams[0].OutputProcessor != nullptr) {
+        if (Shape.AIsSigned) {
+            return Shape.BIsSigned
+                ? GemmBatchI8I8ToF32(Shape, DataParams, BatchN)
+                : GemmBatchI8U8ToF32(Shape, DataParams, BatchN);
+        } else {
+            return Shape.BIsSigned
+                ? GemmBatchU8I8ToF32(Shape, DataParams, BatchN)
+                : GemmBatchU8U8ToF32(Shape, DataParams, BatchN);
+        }
+    }
+    if (Shape.AIsSigned) {
+        return Shape.BIsSigned
+            ? GemmBatchI8I8ToI32(Shape, DataParams, BatchN)
+            : GemmBatchI8U8ToI32(Shape, DataParams, BatchN);
+    } else {
+        return Shape.BIsSigned
+            ? GemmBatchU8I8ToI32(Shape, DataParams, BatchN)
+            : GemmBatchU8U8ToI32(Shape, DataParams, BatchN);
+    }
+}
+
+size_t
+MLASCALL
+ArmKleidiAI::MlasQGemmPackBSize(
+    size_t N,
+    size_t K,
+    bool AIsSigned,
+    bool BIsSigned
+) {
+    MLAS_UNREFERENCED_PARAMETER(AIsSigned);
+    MLAS_UNREFERENCED_PARAMETER(BIsSigned);
+
+    if (!UseSME2 || N == 0 || K == 0) {
+        return 0;
+    }
+
+    size_t column_sums_size = 0;
+    if (!PackedBColumnSumsSize(N, &column_sums_size)) {
+        return 0;
+    }
+
+    size_t rhs_elements = 0;
+    if (mul_overflow_size_t_builtin(N, K, &rhs_elements)) {
+        return 0;
+    }
+
+    const kai_matmul_pack_rhs_uker_config rhs_pack_config{};
+    const kai_matmul_pack_rhs_uker_rhs_packed_dim_args rhs_packed_shape{N, K};
+    const auto rhs_packed_stride =
+        qgemm_int_rhs_pack.get_rhs_packed_stride(&rhs_pack_config, &rhs_packed_shape);
+    const size_t rhs_packed_size =
+        qgemm_int_rhs_pack.get_rhs_packed_size(&rhs_pack_config, &rhs_packed_shape, &rhs_packed_stride);
+
+    size_t total_size = 0;
+    if (!CheckedAddSize(column_sums_size, rhs_packed_size, &total_size)) {
+        return 0;
+    }
+
+    return total_size;
+}
+
+bool
+MLASCALL
+ArmKleidiAI::MlasQGemmPackB(
+    size_t N,
+    size_t K,
+    const uint8_t* B,
+    size_t ldb,
+    bool AIsSigned,
+    bool BIsSigned,
+    void* PackedB
+) {
+    MLAS_UNREFERENCED_PARAMETER(AIsSigned);
+
+    if (ArmKleidiAI::MlasQGemmPackBSize(N, K, AIsSigned, BIsSigned) == 0 || B == nullptr || PackedB == nullptr) {
+        return false;
+    }
+
+    int32_t* rhs_col_sums = PackedBColumnSums(PackedB);
+    std::fill_n(rhs_col_sums, N, int32_t{0});
+
+    const void* rhs_qdata = static_cast<const void*>(B);
+    size_t rhs_stride = ldb * sizeof(uint8_t);
+    std::vector<uint8_t> rhs_unsigned;
+
+    if (BIsSigned) {
+        size_t rhs_unsigned_size = 0;
+        if (mul_overflow_size_t_builtin(N, K, &rhs_unsigned_size)) {
+            return false;
+        }
+        rhs_unsigned.resize(rhs_unsigned_size);
+
+        const uint8_t* src = B;
+        uint8_t* dst = rhs_unsigned.data();
+        for (size_t row = 0; row < K; ++row) {
+            for (size_t col = 0; col < N; ++col) {
+                const uint8_t value = src[col] ^ 0x80;
+                dst[col] = value;
+                rhs_col_sums[col] += value;
+            }
+            src += ldb;
+            dst += N;
+        }
+
+        rhs_qdata = static_cast<const void*>(rhs_unsigned.data());
+        rhs_stride = N * sizeof(uint8_t);
+    } else {
+        const uint8_t* src = B;
+        for (size_t row = 0; row < K; ++row) {
+            for (size_t col = 0; col < N; ++col) {
+                rhs_col_sums[col] += src[col];
+            }
+            src += ldb;
+        }
+    }
+
+    const kai_matmul_pack_rhs_uker_config rhs_pack_config{};
+    const kai_matmul_pack_rhs_uker_rhs_packed_dim_args rhs_packed_shape{N, K};
+    const auto rhs_packed_stride =
+        qgemm_int_rhs_pack.get_rhs_packed_stride(&rhs_pack_config, &rhs_packed_shape);
+
+    kai_matmul_pack_rhs_uker_args rhs_pack_args{};
+    rhs_pack_args.shape.n = N;
+    rhs_pack_args.shape.k = K;
+    rhs_pack_args.operand.rhs.ptr = rhs_qdata;
+    rhs_pack_args.operand.rhs.stride.n = sizeof(uint8_t);
+    rhs_pack_args.operand.rhs.stride.k = rhs_stride;
+    rhs_pack_args.operand.rhs_packed.ptr = PackedBData(PackedB, N);
+    rhs_pack_args.operand.rhs_packed.stride = rhs_packed_stride;
+    rhs_pack_args.operand.bias_n.ptr = nullptr;
+
+    KLEIDIAI_KERNEL_LOG("kai_matmul_pack_rhs_kxn_x8p4vsx4_x8_sme"
+                        << " N=" << N << " K=" << K << " packed=1");
+    qgemm_int_rhs_pack.run(&rhs_pack_config, &rhs_pack_args);
+
+    return true;
+}
 
 size_t
 MLASCALL
@@ -151,19 +746,11 @@ ArmKleidiAI::MlasDynamicQGemmBatch(
     const size_t LhsPackedStride = kai_get_lhs_packed_size_lhs_quant_pack_qai8dxp_f32(Shape.M, Shape.K, mr, kr, sr);
     std::byte* LhsPackedData = nullptr;
 
-    if (g_kai_tls_qgemm.lhs_packed.capacity() < LhsPackedStride * BatchSize) {
-
-        g_kai_tls_qgemm.lhs_packed.reserve(LhsPackedStride * BatchSize);
-    }
-    g_kai_tls_qgemm.lhs_packed.resize(LhsPackedStride * BatchSize);
+    EnsureVectorSize(g_kai_tls_qgemm.lhs_packed, LhsPackedStride * BatchSize);
     LhsPackedData = g_kai_tls_qgemm.lhs_packed.data();
 
     // Per-batch table of LHS base pointers.
-    if (g_kai_tls_qgemm.lhs_base_table.capacity() < BatchSize) {
-
-        g_kai_tls_qgemm.lhs_base_table.reserve(BatchSize);
-    }
-    g_kai_tls_qgemm.lhs_base_table.resize(BatchSize);
+    EnsureVectorSize(g_kai_tls_qgemm.lhs_base_table, BatchSize);
     // Capture the shared batch table pointer so worker threads use the same backing storage.
     const std::byte** tls_lhs_base = g_kai_tls_qgemm.lhs_base_table.data();
     // B batches require no packing.
@@ -217,7 +804,7 @@ ArmKleidiAI::MlasDynamicQGemmBatch(
         auto BTile = reinterpret_cast<const void*>(B_base + rhs_packed_offset);
 
         // Get lhs tile, A
-        const size_t lhs_packed_offset =qgemm_gemm.ukernel.get_lhs_packed_offset(MIdx * m_step, Shape.K);
+        const size_t lhs_packed_offset = qgemm_gemm.ukernel.get_lhs_packed_offset(MIdx * m_step, Shape.K);
 
         const std::byte* A_base = tls_lhs_base[BIdx]; // LhsPackedData + LhsPackedStride * BIdx; OR DataParams[batch_idx].Workspace;
         auto ATile = reinterpret_cast<const std::byte*>(A_base + lhs_packed_offset);
@@ -230,7 +817,7 @@ ArmKleidiAI::MlasDynamicQGemmBatch(
         MIdx * m_step * DataParams[BIdx].ldc * sizeof(float) +
         NIdx * n_step * sizeof(float)
         );
-
+        
         KLEIDIAI_KERNEL_LOG(qgemm_gemm.name
                             << " M=" << TileSizeM << " N=" << TileSizeN << " K=" << Shape.K);
         qgemm_gemm.ukernel.run_matmul(

--- a/onnxruntime/core/mlas/lib/kleidiai/qgemm_kleidiai.cpp
+++ b/onnxruntime/core/mlas/lib/kleidiai/qgemm_kleidiai.cpp
@@ -33,6 +33,32 @@ struct KaiTlsBuffersQgemm {
 static thread_local KaiTlsBuffersQgemm g_kai_tls_qgemm;
 
 const KaiDynamicQGemmKernel qgemm_gemm = GetKleidiAIQGemmUKernel();
+constexpr int32_t kPackedBAccColBiasInvalidZeroPointA = -1;
+
+constexpr size_t kStaticQgemmMTileByteLimit = 128 * 1024;
+constexpr size_t kDynamicQgemmNTileByteLimit = 128 * 1024;
+
+static size_t
+CapStepByPackedBytes(size_t step, size_t base_step, size_t base_packed_bytes, size_t byte_limit) {
+    if (byte_limit == 0 || base_step == 0 || base_packed_bytes == 0 || step <= base_step) {
+        return step;
+    }
+
+    const size_t max_blocks = std::max<size_t>(size_t{1}, byte_limit / base_packed_bytes);
+
+    size_t capped_step = 0;
+    if (mul_overflow_size_t_builtin(base_step, max_blocks, &capped_step)) {
+        return step;
+    }
+
+    return std::min(step, capped_step);
+}
+
+static size_t
+CapDynamicQgemmNStepByPackedRhs(size_t n_step, size_t base_n_step, size_t k, size_t byte_limit) {
+    return CapStepByPackedBytes(
+        n_step, base_n_step, qgemm_gemm.ukernel.get_rhs_packed_offset(base_n_step, k), byte_limit);
+}
 
 struct KaiTlsBuffersQgemmInteger {
     std::vector<uint8_t> lhs_unsigned;
@@ -108,6 +134,21 @@ PackedBColumnSumsSize(size_t n, size_t* size) {
     return CheckedAlignUp(bytes, MlasGetPreferredBufferAlignment(), size);
 }
 
+static bool
+PackedBAccColBiasSize(size_t n, size_t* size) {
+    size_t elements = 0;
+    if (!CheckedAddSize(n, 1, &elements)) {
+        return false;
+    }
+
+    size_t bytes = 0;
+    if (mul_overflow_size_t_builtin(elements, sizeof(int32_t), &bytes)) {
+        return false;
+    }
+
+    return CheckedAlignUp(bytes, MlasGetPreferredBufferAlignment(), size);
+}
+
 static int32_t*
 PackedBColumnSums(void* packed_b) {
     return reinterpret_cast<int32_t*>(packed_b);
@@ -118,13 +159,49 @@ PackedBColumnSums(const void* packed_b) {
     return reinterpret_cast<const int32_t*>(packed_b);
 }
 
+static int32_t*
+PackedBAccColBias(void* packed_b, size_t n) {
+    size_t column_sums_size = 0;
+    if (!PackedBColumnSumsSize(n, &column_sums_size)) {
+        return nullptr;
+    }
+
+    return reinterpret_cast<int32_t*>(static_cast<std::byte*>(packed_b) + column_sums_size);
+}
+
+static const int32_t*
+PackedBAccColBias(const void* packed_b, size_t n) {
+    size_t column_sums_size = 0;
+    if (!PackedBColumnSumsSize(n, &column_sums_size)) {
+        return nullptr;
+    }
+
+    return reinterpret_cast<const int32_t*>(static_cast<const std::byte*>(packed_b) + column_sums_size);
+}
+
+static const int32_t*
+PackedBAccColBiasData(const void* packed_b, size_t n, int32_t zero_point_a) {
+    const int32_t* acc_col_bias = PackedBAccColBias(packed_b, n);
+    if (acc_col_bias == nullptr || acc_col_bias[0] != zero_point_a) {
+        return nullptr;
+    }
+
+    return acc_col_bias + 1;
+}
+
 static void*
 PackedBData(void* packed_b, size_t n) {
     size_t column_sums_size = 0;
     if (!PackedBColumnSumsSize(n, &column_sums_size)) {
         return nullptr;
     }
-    return static_cast<std::byte*>(packed_b) + column_sums_size;
+
+    size_t acc_col_bias_size = 0;
+    if (!PackedBAccColBiasSize(n, &acc_col_bias_size)) {
+        return nullptr;
+    }
+
+    return static_cast<std::byte*>(packed_b) + column_sums_size + acc_col_bias_size;
 }
 
 static const void*
@@ -133,7 +210,13 @@ PackedBData(const void* packed_b, size_t n) {
     if (!PackedBColumnSumsSize(n, &column_sums_size)) {
         return nullptr;
     }
-    return static_cast<const std::byte*>(packed_b) + column_sums_size;
+
+    size_t acc_col_bias_size = 0;
+    if (!PackedBAccColBiasSize(n, &acc_col_bias_size)) {
+        return nullptr;
+    }
+
+    return static_cast<const std::byte*>(packed_b) + column_sums_size + acc_col_bias_size;
 }
 
 template <bool LhsIsSigned, bool RhsIsSigned, bool OutputFloat>
@@ -271,12 +354,17 @@ GemmBatch(
         if (zpA == 0) {
             acc_col_bias = EnsureZeroVectorSize(g_kai_tls_qgemm_int.zero_acc_col_bias, n);
         } else if (rhs_is_packed) {
-            EnsureVectorSize(g_kai_tls_qgemm_int.acc_col_bias, n);
-            const int32_t* rhs_col_sums = PackedBColumnSums(p.B);
-            for (size_t col = 0; col < n; ++col) {
-                g_kai_tls_qgemm_int.acc_col_bias[col] = static_cast<int32_t>(-static_cast<int64_t>(zpA) * rhs_col_sums[col]);
+            const int32_t* packed_acc_col_bias = PackedBAccColBiasData(p.B, n, zpA);
+            if (packed_acc_col_bias != nullptr) {
+                acc_col_bias = packed_acc_col_bias;
+            } else {
+                EnsureVectorSize(g_kai_tls_qgemm_int.acc_col_bias, n);
+                const int32_t* rhs_col_sums = PackedBColumnSums(p.B);
+                for (size_t col = 0; col < n; ++col) {
+                    g_kai_tls_qgemm_int.acc_col_bias[col] = static_cast<int32_t>(-static_cast<int64_t>(zpA) * rhs_col_sums[col]);
+                }
+                acc_col_bias = g_kai_tls_qgemm_int.acc_col_bias.data();
             }
-            acc_col_bias = g_kai_tls_qgemm_int.acc_col_bias.data();
         } else {
             EnsureVectorSize(g_kai_tls_qgemm_int.acc_col_bias, n);
             for (size_t col = 0; col < n; ++col) {
@@ -291,29 +379,20 @@ GemmBatch(
         }
 
         const kai_matmul_pack_lhs_uker_config lhs_pack_config{};
-        const kai_matmul_pack_lhs_uker_lhs_packed_dim_args lhs_packed_shape{m, k};
+        const auto lhs_pack_step = qgemm_int_lhs_pack.get_step(&lhs_pack_config);
+        const size_t lhs_base_m_step = lhs_pack_step.m == 0 ? m : lhs_pack_step.m;
+        const kai_matmul_pack_lhs_uker_lhs_packed_dim_args lhs_packed_shape{lhs_base_m_step, k};
         const auto lhs_packed_stride =
             qgemm_int_lhs_pack.get_lhs_packed_stride(&lhs_pack_config, &lhs_packed_shape);
-        const size_t lhs_packed_size =
-            qgemm_int_lhs_pack.get_lhs_packed_size(&lhs_pack_config, &lhs_packed_shape, &lhs_packed_stride);
-        EnsureVectorSize(g_kai_tls_qgemm_int.lhs_packed, lhs_packed_size);
-
-        kai_matmul_pack_lhs_uker_args lhs_pack_args{};
-        lhs_pack_args.shape.m = m;
-        lhs_pack_args.shape.k = k;
-        lhs_pack_args.operand.lhs.ptr = lhs_qdata;
-        lhs_pack_args.operand.lhs.stride.m = lhs_stride;
-        lhs_pack_args.operand.lhs_packed.ptr = g_kai_tls_qgemm_int.lhs_packed.data();
-        lhs_pack_args.operand.lhs_packed.stride = lhs_packed_stride;
-        KLEIDIAI_KERNEL_LOG("kai_matmul_pack_lhs_mxk_x8p4vsx4_x8_sme"
-                            << " Batch=" << i << " M=" << m << " K=" << k);
-        qgemm_int_lhs_pack.run(&lhs_pack_config, &lhs_pack_args);
+        const size_t m_tile_step =
+            CapStepByPackedBytes(m, lhs_base_m_step, lhs_packed_stride.m, kStaticQgemmMTileByteLimit);
 
         const kai_matmul_pack_rhs_uker_config rhs_pack_config{};
         const kai_matmul_pack_rhs_uker_rhs_packed_dim_args rhs_packed_shape{n, k};
         const auto rhs_packed_stride =
             qgemm_int_rhs_pack.get_rhs_packed_stride(&rhs_pack_config, &rhs_packed_shape);
         const void* rhs_packed_data = nullptr;
+
         if (rhs_is_packed) {
             rhs_packed_data = PackedBData(p.B, n);
             if (rhs_packed_data == nullptr) {
@@ -365,33 +444,54 @@ GemmBatch(
 
         const kai_matmul_uker_config matmul_config{};
         const kai_matmul_uker_api& matmul = OutputFloat ? qgemm_int_f32 : qgemm_int_i32;
-        kai_matmul_uker_args matmul_args{};
-        matmul_args.flags = OutputFloat ? KAI_MATMUL_UKER_FLAGS_ARGS_CLAMP : 0;
-        matmul_args.shape.m = m;
-        matmul_args.shape.n = n;
-        matmul_args.shape.k = k;
-        matmul_args.operand.lhs.ptr = g_kai_tls_qgemm_int.lhs_packed.data();
-        matmul_args.operand.lhs.stride.m = lhs_packed_stride.m;
-        matmul_args.operand.rhs.ptr = rhs_packed_data;
-        matmul_args.operand.rhs.stride.n = rhs_packed_stride.n;
-        matmul_args.operand.dst.ptr = dst;
-        matmul_args.operand.dst.stride.m = dst_stride;
-        matmul_args.operand.bias.acc_bias_m.ptr = acc_row_bias;
-        matmul_args.operand.bias.acc_bias_n.ptr = acc_col_bias;
-        if constexpr (OutputFloat) {
-            matmul_args.operand.scale.acc_scale_global.ptr = scale;
-            matmul_args.operand.bias.scale_bias_n.ptr = scale_bias_n;
-            matmul_args.activation.clamp.min_ptr = &clamp_min;
-            matmul_args.activation.clamp.max_ptr = &clamp_max;
+
+        for (size_t m_start = 0; m_start < m; m_start += m_tile_step) {
+            const size_t m_tile = std::min(m - m_start, m_tile_step);
+            const kai_matmul_pack_lhs_uker_lhs_packed_dim_args lhs_tile_packed_shape{m_tile, k};
+            const size_t lhs_packed_size =
+                qgemm_int_lhs_pack.get_lhs_packed_size(&lhs_pack_config, &lhs_tile_packed_shape, &lhs_packed_stride);
+            EnsureVectorSize(g_kai_tls_qgemm_int.lhs_packed, lhs_packed_size);
+
+            kai_matmul_pack_lhs_uker_args lhs_pack_args{};
+            lhs_pack_args.shape.m = m_tile;
+            lhs_pack_args.shape.k = k;
+            lhs_pack_args.operand.lhs.ptr = static_cast<const uint8_t*>(lhs_qdata) + m_start * lhs_stride;
+            lhs_pack_args.operand.lhs.stride.m = lhs_stride;
+            lhs_pack_args.operand.lhs_packed.ptr = g_kai_tls_qgemm_int.lhs_packed.data();
+            lhs_pack_args.operand.lhs_packed.stride = lhs_packed_stride;
+            KLEIDIAI_KERNEL_LOG("kai_matmul_pack_lhs_mxk_x8p4vsx4_x8_sme"
+                                << " Batch=" << i << " M=" << m_tile << " K=" << k);
+            qgemm_int_lhs_pack.run(&lhs_pack_config, &lhs_pack_args);
+
+            kai_matmul_uker_args matmul_args{};
+            matmul_args.flags = OutputFloat ? KAI_MATMUL_UKER_FLAGS_ARGS_CLAMP : 0;
+            matmul_args.shape.m = m_tile;
+            matmul_args.shape.n = n;
+            matmul_args.shape.k = k;
+            matmul_args.operand.lhs.ptr = g_kai_tls_qgemm_int.lhs_packed.data();
+            matmul_args.operand.lhs.stride.m = lhs_packed_stride.m;
+            matmul_args.operand.rhs.ptr = rhs_packed_data;
+            matmul_args.operand.rhs.stride.n = rhs_packed_stride.n;
+            matmul_args.operand.dst.ptr = static_cast<std::byte*>(dst) + m_start * dst_stride;
+            matmul_args.operand.dst.stride.m = dst_stride;
+            matmul_args.operand.bias.acc_bias_m.ptr =
+                static_cast<const int32_t*>(acc_row_bias) + m_start;
+            matmul_args.operand.bias.acc_bias_n.ptr = acc_col_bias;
+            if constexpr (OutputFloat) {
+                matmul_args.operand.scale.acc_scale_global.ptr = scale;
+                matmul_args.operand.bias.scale_bias_n.ptr = scale_bias_n;
+                matmul_args.activation.clamp.min_ptr = &clamp_min;
+                matmul_args.activation.clamp.max_ptr = &clamp_max;
+            }
+            if constexpr (OutputFloat) {
+                KLEIDIAI_KERNEL_LOG("kai_matmul_clamp_f32_u8p4vsx4_u8p4vsx4_i32_i32_f32_f32_8vsx8vs_sme2_mopa"
+                                    << " Batch=" << i << " M=" << m_tile << " N=" << n << " K=" << k);
+            } else {
+                KLEIDIAI_KERNEL_LOG("kai_matmul_i32_u8p4vsx4_u8p4vsx4_i32_i32_8vsx8vs_sme2_mopa"
+                                    << " Batch=" << i << " M=" << m_tile << " N=" << n << " K=" << k);
+            }
+            matmul.run(&matmul_config, &matmul_args);
         }
-        if constexpr (OutputFloat) {
-            KLEIDIAI_KERNEL_LOG("kai_matmul_clamp_f32_u8p4vsx4_u8p4vsx4_i32_i32_f32_f32_8vsx8vs_sme2_mopa"
-                                << " Batch=" << i << " M=" << m << " N=" << n << " K=" << k);
-        } else {
-            KLEIDIAI_KERNEL_LOG("kai_matmul_i32_u8p4vsx4_u8p4vsx4_i32_i32_8vsx8vs_sme2_mopa"
-                                << " Batch=" << i << " M=" << m << " N=" << n << " K=" << k);
-        }
-        matmul.run(&matmul_config, &matmul_args);
     }
 
     return true;
@@ -526,6 +626,11 @@ ArmKleidiAI::MlasQGemmPackBSize(
         return 0;
     }
 
+    size_t acc_col_bias_size = 0;
+    if (!PackedBAccColBiasSize(N, &acc_col_bias_size)) {
+        return 0;
+    }
+
     size_t rhs_elements = 0;
     if (mul_overflow_size_t_builtin(N, K, &rhs_elements)) {
         return 0;
@@ -542,6 +647,9 @@ ArmKleidiAI::MlasQGemmPackBSize(
     if (!CheckedAddSize(column_sums_size, rhs_packed_size, &total_size)) {
         return 0;
     }
+    if (!CheckedAddSize(total_size, acc_col_bias_size, &total_size)) {
+        return 0;
+    }
 
     return total_size;
 }
@@ -555,16 +663,20 @@ ArmKleidiAI::MlasQGemmPackB(
     size_t ldb,
     bool AIsSigned,
     bool BIsSigned,
-    void* PackedB
+    void* PackedB,
+    const uint8_t* ZeroPointA
 ) {
-    MLAS_UNREFERENCED_PARAMETER(AIsSigned);
-
     if (ArmKleidiAI::MlasQGemmPackBSize(N, K, AIsSigned, BIsSigned) == 0 || B == nullptr || PackedB == nullptr) {
         return false;
     }
 
     int32_t* rhs_col_sums = PackedBColumnSums(PackedB);
     std::fill_n(rhs_col_sums, N, int32_t{0});
+    int32_t* cached_acc_col_bias = PackedBAccColBias(PackedB, N);
+    if (cached_acc_col_bias == nullptr) {
+        return false;
+    }
+    cached_acc_col_bias[0] = kPackedBAccColBiasInvalidZeroPointA;
 
     const void* rhs_qdata = static_cast<const void*>(B);
     size_t rhs_stride = ldb * sizeof(uint8_t);
@@ -598,6 +710,14 @@ ArmKleidiAI::MlasQGemmPackB(
                 rhs_col_sums[col] += src[col];
             }
             src += ldb;
+        }
+    }
+
+    if (ZeroPointA != nullptr) {
+        const int32_t zpA = AdjustedZeroPoint(*ZeroPointA, AIsSigned);
+        cached_acc_col_bias[0] = zpA;
+        for (size_t col = 0; col < N; ++col) {
+            cached_acc_col_bias[col + 1] = static_cast<int32_t>(-static_cast<int64_t>(zpA) * rhs_col_sums[col]);
         }
     }
 
@@ -706,6 +826,7 @@ ArmKleidiAI::MlasDynamicQGemmBatch(
 
     size_t m_step = qgemm_gemm.ukernel.get_m_step();
     size_t n_step = qgemm_gemm.ukernel.get_n_step();
+    const size_t base_n_step = n_step;
 
     if (BatchSize == 0 || Shape.M == 0 || Shape.N == 0 || Shape.K == 0) {
         return;
@@ -753,6 +874,7 @@ ArmKleidiAI::MlasDynamicQGemmBatch(
     EnsureVectorSize(g_kai_tls_qgemm.lhs_base_table, BatchSize);
     // Capture the shared batch table pointer so worker threads use the same backing storage.
     const std::byte** tls_lhs_base = g_kai_tls_qgemm.lhs_base_table.data();
+
     // B batches require no packing.
     // We have already decided the matmul variant we are using before having values for M, N, and K.
     MlasTrySimpleParallel(ThreadPool, BatchSize, [&](ptrdiff_t batch_idx) {
@@ -785,6 +907,8 @@ ArmKleidiAI::MlasDynamicQGemmBatch(
     // Compute new step sizes.
     m_step *= MlasDivRoundup(MlasDivRoundup(Shape.M, dim[1]), m_step);
     n_step *= MlasDivRoundup(MlasDivRoundup(Shape.N, dim[2]), n_step);
+
+    n_step = CapDynamicQgemmNStepByPackedRhs(n_step, base_n_step, Shape.K, kDynamicQgemmNTileByteLimit);
 
     // Update tile iterations.
     dim[1] = MlasDivRoundup(Shape.M, m_step);

--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -979,6 +979,13 @@ bool
     void* PackedB);
 #endif
 
+typedef bool (MLASCALL MLAS_QGEMM_BATCH_OVERRIDE)(
+    const MLAS_GEMM_QUANT_SHAPE_PARAMS& Shape,
+    const MLAS_GEMM_QUANT_DATA_PARAMS* DataParams,
+    const size_t BatchN,
+    MLAS_THREADPOOL* ThreadPool
+);
+
 extern "C" {
 
 #if defined(MLAS_TARGET_AMD64_IX86)
@@ -1502,15 +1509,14 @@ struct MLAS_PLATFORM {
     bool Avx512Supported_ = false;
     bool ArmNeonIsQuantActivationsUnsigned = false;
 
-    // MLAS SGemm overrides
+    // MLAS override hooks
     MLAS_SGEMM_BATCH_OVERRIDE* MlasSGemmBatchOverride = nullptr;
     MLAS_SGEMM_PACK_B_SIZE_OVERRIDE* MlasSGemmPackBSizeOverride = nullptr;
     MLAS_SGEMM_PACK_B_OVERRIDE* MlasSGemmPackBOverride = nullptr;
-    // MLAS Dynamic QGemm overrides
     MLAS_DYNAMIC_QGEMM_BATCH_OVERRIDE* MlasDynamicQGemmBatchOverride = nullptr;
     MLAS_DYNAMIC_QGEMM_PACK_B_SIZE_OVERRIDE* MlasDynamicQGemmPackBSizeOverride = nullptr;
     MLAS_DYNAMIC_QGEMM_PACK_B_OVERRIDE* MlasDynamicQGemmPackBOverride = nullptr;
-    // MLAS Conv overrides
+    MLAS_QGEMM_BATCH_OVERRIDE* MlasQGemmBatchOverride = nullptr;
     MLAS_CONV_PREPARE_FLOAT_OVERRIDE* MlasConvPrepareOverride = nullptr;
     MLAS_CONV_FLOAT_OVERRIDE* MlasConvOverride = nullptr;
 #if defined(__aarch64__) && defined(__linux__)

--- a/onnxruntime/core/mlas/lib/platform.cpp
+++ b/onnxruntime/core/mlas/lib/platform.cpp
@@ -693,6 +693,7 @@ Return Value:
         this->MlasDynamicQGemmBatchOverride = ArmKleidiAI::MlasDynamicQGemmBatch;
         this->MlasDynamicQGemmPackBSizeOverride = ArmKleidiAI::MlasDynamicQGemmPackBSize;
         this->MlasDynamicQGemmPackBOverride = ArmKleidiAI::MlasDynamicQGemmPackB;
+        this->MlasQGemmBatchOverride = ArmKleidiAI::MlasGemmBatch;
         this->MlasConvPrepareOverride = ArmKleidiAI::MlasConvPrepare;
         this->MlasConvOverride = ArmKleidiAI::MlasConv;
 #if defined(__aarch64__) && defined(__linux__)

--- a/onnxruntime/core/mlas/lib/qgemm.cpp
+++ b/onnxruntime/core/mlas/lib/qgemm.cpp
@@ -15,6 +15,7 @@ Abstract:
 
 --*/
 #include <cassert>
+#include <vector>
 #include "core/mlas/lib/mlasi.h"
 #include "qgemm.h"
 
@@ -125,6 +126,33 @@ MlasQgemmGetKernelOutputCnt(
     return int32_t(dispatch->StrideM);
 }
 
+static size_t
+MlasGemmQuantPackBBaseSize(
+    size_t N,
+    size_t K,
+    bool AIsSigned,
+    bool BIsSigned
+    )
+{
+    const auto* GemmQuantDispatch = MlasGemmQuantGetDispatch(AIsSigned, BIsSigned);
+
+    const size_t PackedK = GemmQuantDispatch->PackedK;
+    const size_t PackedStrideK = GemmQuantDispatch->PackedStrideK;
+
+    if (PackedStrideK == 0) {
+        return 0;
+    }
+
+    const size_t AlignedN =
+        (N + MLAS_QGEMM_STRIDEN_THREAD_ALIGN - 1) & ~(MLAS_QGEMM_STRIDEN_THREAD_ALIGN - 1);
+    const size_t AlignedK = (K + PackedK - 1) & ~(PackedK - 1);
+
+    const size_t BytesRequired =
+        (AlignedN * sizeof(int32_t)) + (AlignedN * AlignedK * sizeof(uint8_t));
+    const size_t BufferAlignment = MlasGetPreferredBufferAlignment();
+    return (BytesRequired + BufferAlignment - 1) & ~(BufferAlignment - 1);
+}
+
 #if defined(_MSC_VER) && !defined(__clang__)
 #pragma warning(push)
 // VC++ suggests we can attempt to make 'MlasBitsOfFp32' constexpr, but it is not valid.
@@ -137,8 +165,43 @@ MlasGemmBatch(
     const MLAS_GEMM_QUANT_SHAPE_PARAMS& Shape,
     const MLAS_GEMM_QUANT_DATA_PARAMS* DataParams,
     const size_t BatchN,
-    MLAS_THREADPOOL* ThreadPool)
+    MLAS_THREADPOOL* ThreadPool,
+    const MLAS_BACKEND_KERNEL_SELECTOR_CONFIG* BackendKernelSelectorConfig)
 {
+    bool has_packed_b = false;
+    for (size_t i = 0; i < BatchN; ++i) {
+        has_packed_b = has_packed_b || DataParams[i].BIsPacked;
+    }
+
+    // Override (for example, backend-specific packed-B appendix).
+    if ((!BackendKernelSelectorConfig || BackendKernelSelectorConfig->use_kleidiai) &&
+        GetMlasPlatform().MlasQGemmBatchOverride != nullptr) {
+        const MLAS_GEMM_QUANT_DATA_PARAMS* override_data = DataParams;
+        std::vector<MLAS_GEMM_QUANT_DATA_PARAMS> adjusted_data;
+        bool can_try_override = true;
+        if (has_packed_b) {
+            const size_t packed_b_base_size =
+                MlasGemmQuantPackBBaseSize(Shape.N, Shape.K, Shape.AIsSigned, Shape.BIsSigned);
+            if (packed_b_base_size == 0) {
+                can_try_override = false;
+            } else {
+                adjusted_data.assign(DataParams, DataParams + BatchN);
+                for (size_t i = 0; i < BatchN; ++i) {
+                    if (adjusted_data[i].BIsPacked) {
+                        adjusted_data[i].B =
+                            static_cast<const uint8_t*>(adjusted_data[i].B) + packed_b_base_size;
+                    }
+                }
+                override_data = adjusted_data.data();
+            }
+        }
+
+        if (can_try_override &&
+            GetMlasPlatform().MlasQGemmBatchOverride(Shape, override_data, BatchN, ThreadPool)) {
+            return;
+        }
+    }
+
     const size_t M = Shape.M;
     const size_t N = Shape.N;
     const size_t K = Shape.K;
@@ -406,41 +469,20 @@ Return Value:
 
 --*/
 {
-    //
-    // Retrieve the packing parameters.
-    //
-
-    const auto* GemmQuantDispatch = MlasGemmQuantGetDispatch(AIsSigned, BIsSigned);
-
-    size_t PackedK = GemmQuantDispatch->PackedK;
-    size_t PackedStrideK = GemmQuantDispatch->PackedStrideK;
-
-    if (PackedStrideK == 0) {
+    size_t PackedBytesRequired = MlasGemmQuantPackBBaseSize(N, K, AIsSigned, BIsSigned);
+    if (PackedBytesRequired == 0) {
         return 0;
     }
 
-    //
-    // Compute the number of bytes required to hold the packed buffer.
-    //
-
-    const size_t AlignedN =
-        (N + MLAS_QGEMM_STRIDEN_THREAD_ALIGN - 1) & ~(MLAS_QGEMM_STRIDEN_THREAD_ALIGN - 1);
-    const size_t AlignedK = (K + PackedK - 1) & ~(PackedK - 1);
-
-    const size_t BytesRequired =
-        (AlignedN * sizeof(int32_t)) + (AlignedN * AlignedK * sizeof(uint8_t));
-    const size_t BufferAlignment = MlasGetPreferredBufferAlignment();
-    const size_t AlignedBytesRequired = (BytesRequired + BufferAlignment - 1) &
-        ~(BufferAlignment - 1);
-    // If this gemm B argument is used in a dynamically quantized gemm operation we can optimize for
-    // this use case. Concat both packed representations for later decision. This allows for cases later
-    // where we still have the prepack at the cost of some memory otherwise we can use the qgemm quantization
-    // for better performance
-    if (MlasIsDynamicQGemmAvailable(BackendKernelSelectorConfig)) {
-        return AlignedBytesRequired + MlasDynamicQgemmPackBSize(N, K, BackendKernelSelectorConfig);
-    } else {
-        return AlignedBytesRequired;
+#if defined(USE_KLEIDIAI)
+    if (!BackendKernelSelectorConfig || BackendKernelSelectorConfig->use_kleidiai) {
+        PackedBytesRequired += ArmKleidiAI::MlasQGemmPackBSize(N, K, AIsSigned, BIsSigned);
     }
+#else
+    MLAS_UNREFERENCED_PARAMETER(BackendKernelSelectorConfig);
+#endif
+
+    return PackedBytesRequired;
 }
 
 void
@@ -483,7 +525,8 @@ MlasGemmPackB(
     size_t ldb,
     bool AIsSigned,
     bool BIsSigned,
-    void* PackedB
+    void* PackedB,
+    const MLAS_BACKEND_KERNEL_SELECTOR_CONFIG* BackendKernelSelectorConfig
     )
 /*++
 
@@ -513,6 +556,9 @@ Return Value:
 
 --*/
 {
+    void* PackedBBase = PackedB;
+    const uint8_t* BBase = B;
+    const size_t BasePackedBSize = MlasGemmQuantPackBBaseSize(N, K, AIsSigned, BIsSigned);
 
     //
     // Retrieve the packing parameters.
@@ -576,6 +622,18 @@ Return Value:
         PackedB = (uint8_t*)PackedB + AlignedN * AlignedK;
         B += ldb * CountK;
     }
+
+#if defined(USE_KLEIDIAI)
+    if (!BackendKernelSelectorConfig || BackendKernelSelectorConfig->use_kleidiai) {
+        void* KleidiPackedB = static_cast<uint8_t*>(PackedBBase) + BasePackedBSize;
+        ArmKleidiAI::MlasQGemmPackB(N, K, BBase, ldb, AIsSigned, BIsSigned, KleidiPackedB);
+    }
+#else
+    MLAS_UNREFERENCED_PARAMETER(BackendKernelSelectorConfig);
+    MLAS_UNREFERENCED_PARAMETER(PackedBBase);
+    MLAS_UNREFERENCED_PARAMETER(BBase);
+    MLAS_UNREFERENCED_PARAMETER(BasePackedBSize);
+#endif
 }
 
 #if defined(_MSC_VER) && !defined(__clang__)

--- a/onnxruntime/core/mlas/lib/qgemm.cpp
+++ b/onnxruntime/core/mlas/lib/qgemm.cpp
@@ -15,6 +15,7 @@ Abstract:
 
 --*/
 #include <cassert>
+#include <limits>
 #include <vector>
 #include "core/mlas/lib/mlasi.h"
 #include "qgemm.h"
@@ -153,6 +154,24 @@ MlasGemmQuantPackBBaseSize(
     return (BytesRequired + BufferAlignment - 1) & ~(BufferAlignment - 1);
 }
 
+#if defined(USE_KLEIDIAI)
+static size_t
+MlasGemmQuantPackBAppendixSize(
+    size_t N,
+    size_t K,
+    bool AIsSigned,
+    bool BIsSigned,
+    const MLAS_BACKEND_KERNEL_SELECTOR_CONFIG* BackendKernelSelectorConfig
+    )
+{
+    if (BackendKernelSelectorConfig && !BackendKernelSelectorConfig->use_kleidiai) {
+        return 0;
+    }
+
+    return ArmKleidiAI::MlasQGemmPackBSize(N, K, AIsSigned, BIsSigned);
+}
+#endif
+
 #if defined(_MSC_VER) && !defined(__clang__)
 #pragma warning(push)
 // VC++ suggests we can attempt to make 'MlasBitsOfFp32' constexpr, but it is not valid.
@@ -180,9 +199,11 @@ MlasGemmBatch(
         std::vector<MLAS_GEMM_QUANT_DATA_PARAMS> adjusted_data;
         bool can_try_override = true;
         if (has_packed_b) {
+            const size_t packed_b_appendix_size =
+                MlasGemmQuantPackBAppendixSize(Shape.N, Shape.K, Shape.AIsSigned, Shape.BIsSigned, BackendKernelSelectorConfig);
             const size_t packed_b_base_size =
                 MlasGemmQuantPackBBaseSize(Shape.N, Shape.K, Shape.AIsSigned, Shape.BIsSigned);
-            if (packed_b_base_size == 0) {
+            if (packed_b_base_size == 0 || packed_b_appendix_size == 0) {
                 can_try_override = false;
             } else {
                 adjusted_data.assign(DataParams, DataParams + BatchN);
@@ -475,9 +496,12 @@ Return Value:
     }
 
 #if defined(USE_KLEIDIAI)
-    if (!BackendKernelSelectorConfig || BackendKernelSelectorConfig->use_kleidiai) {
-        PackedBytesRequired += ArmKleidiAI::MlasQGemmPackBSize(N, K, AIsSigned, BIsSigned);
+    const size_t PackedBAppendixBytesRequired =
+        MlasGemmQuantPackBAppendixSize(N, K, AIsSigned, BIsSigned, BackendKernelSelectorConfig);
+    if (PackedBAppendixBytesRequired > std::numeric_limits<size_t>::max() - PackedBytesRequired) {
+        return 0;
     }
+    PackedBytesRequired += PackedBAppendixBytesRequired;
 #else
     MLAS_UNREFERENCED_PARAMETER(BackendKernelSelectorConfig);
 #endif
@@ -527,6 +551,23 @@ MlasGemmPackB(
     bool BIsSigned,
     void* PackedB,
     const MLAS_BACKEND_KERNEL_SELECTOR_CONFIG* BackendKernelSelectorConfig
+    )
+{
+    MlasGemmPackB(N, K, B, ldb, AIsSigned, BIsSigned, PackedB, BackendKernelSelectorConfig, nullptr);
+}
+
+void
+MLASCALL
+MlasGemmPackB(
+    size_t N,
+    size_t K,
+    const uint8_t* B,
+    size_t ldb,
+    bool AIsSigned,
+    bool BIsSigned,
+    void* PackedB,
+    const MLAS_BACKEND_KERNEL_SELECTOR_CONFIG* BackendKernelSelectorConfig,
+    const uint8_t* ZeroPointA
     )
 /*++
 
@@ -624,12 +665,15 @@ Return Value:
     }
 
 #if defined(USE_KLEIDIAI)
-    if (!BackendKernelSelectorConfig || BackendKernelSelectorConfig->use_kleidiai) {
-        void* KleidiPackedB = static_cast<uint8_t*>(PackedBBase) + BasePackedBSize;
-        ArmKleidiAI::MlasQGemmPackB(N, K, BBase, ldb, AIsSigned, BIsSigned, KleidiPackedB);
+    const size_t PackedBAppendixBytesRequired =
+        MlasGemmQuantPackBAppendixSize(N, K, AIsSigned, BIsSigned, BackendKernelSelectorConfig);
+    if (PackedBAppendixBytesRequired != 0) {
+        void* PackedBAppendix = static_cast<uint8_t*>(PackedBBase) + BasePackedBSize;
+        ArmKleidiAI::MlasQGemmPackB(N, K, BBase, ldb, AIsSigned, BIsSigned, PackedBAppendix, ZeroPointA);
     }
 #else
     MLAS_UNREFERENCED_PARAMETER(BackendKernelSelectorConfig);
+    MLAS_UNREFERENCED_PARAMETER(ZeroPointA);
     MLAS_UNREFERENCED_PARAMETER(PackedBBase);
     MLAS_UNREFERENCED_PARAMETER(BBase);
     MLAS_UNREFERENCED_PARAMETER(BasePackedBSize);

--- a/onnxruntime/core/mlas/lib/qgemm.cpp
+++ b/onnxruntime/core/mlas/lib/qgemm.cpp
@@ -187,6 +187,7 @@ MlasGemmBatch(
     MLAS_THREADPOOL* ThreadPool,
     const MLAS_BACKEND_KERNEL_SELECTOR_CONFIG* BackendKernelSelectorConfig)
 {
+#if defined(USE_KLEIDIAI)
     bool has_packed_b = false;
     for (size_t i = 0; i < BatchN; ++i) {
         has_packed_b = has_packed_b || DataParams[i].BIsPacked;
@@ -222,6 +223,9 @@ MlasGemmBatch(
             return;
         }
     }
+#else
+    MLAS_UNREFERENCED_PARAMETER(BackendKernelSelectorConfig);
+#endif
 
     const size_t M = Shape.M;
     const size_t N = Shape.N;

--- a/onnxruntime/core/providers/cpu/quantization/conv_integer.cc
+++ b/onnxruntime/core/providers/cpu/quantization/conv_integer.cc
@@ -5,6 +5,7 @@
 #include "core/providers/cpu/nn/conv_attributes.h"
 #include "core/common/safeint.h"
 #include "core/providers/common.h"
+#include "core/providers/cpu/mlas_backend_kernel_selector_config_utils.h"
 #include "core/util/math.h"
 #include "core/util/math_cpuonly.h"
 #include "core/util/qmath.h"
@@ -15,11 +16,14 @@ using ConvPadVector = ConvAttributes::ConvPadVector;
 
 class ConvInteger : public OpKernel {
  public:
-  explicit ConvInteger(const OpKernelInfo& info) : OpKernel(info), conv_attrs_(info) {}
+  explicit ConvInteger(const OpKernelInfo& info) : OpKernel(info), conv_attrs_(info) {
+    SetupMlasBackendKernelSelectorFromConfigOptions(mlas_backend_kernel_selector_config_, info.GetConfigOptions());
+  }
 
   Status Compute(OpKernelContext* context) const override;
 
   ConvAttributes conv_attrs_;
+  MLAS_BACKEND_KERNEL_SELECTOR_CONFIG mlas_backend_kernel_selector_config_;
 };
 
 ONNX_OPERATOR_KERNEL_EX(
@@ -120,7 +124,51 @@ Status ConvInteger::Compute(OpKernelContext* context) const {
   for (int image_id = 0; image_id < N; ++image_id) {
     for (int group_id = 0; group_id < conv_attrs_.group; ++group_id) {
       if (col_buffer_data != nullptr) {
-        if (kernel_rank == 2) {
+        if (kernel_rank == 1 && !X_is_signed) {
+          // Fast-path 1D im2col for unsigned input, NCHW layout, group=1.
+          // Falls back to the generic implementation for grouped convolutions.
+          if (conv_attrs_.group == 1) {
+            const int64_t C_per_group = C / conv_attrs_.group;
+            const int64_t in_w = input_shape[0];
+            const int64_t out_w = output_shape[0];
+            const int64_t k_w = static_cast<int64_t>(kernel_shape[0]);
+            const int64_t dilation_w = static_cast<int64_t>(dilations[0]);
+            const int64_t stride_w = static_cast<int64_t>(strides[0]);
+            const int64_t pad_left = static_cast<int64_t>(pads[0]);
+
+            uint8_t* col = col_buffer_data;
+
+            // For each channel and kernel position, write one row of length out_w.
+            // Row index: c*k_w + kw
+            for (int64_t c = 0; c < C_per_group; ++c) {
+              const uint8_t* x_c = Xdata + c * in_w;
+
+              for (int64_t kw = 0; kw < k_w; ++kw) {
+                const int64_t base_x = kw * dilation_w - pad_left;
+                uint8_t* dst_row = col + (c * k_w + kw) * out_w;
+
+                for (int64_t ow = 0; ow < out_w; ++ow) {
+                  const int64_t x = base_x + ow * stride_w;
+                  dst_row[ow] = (static_cast<uint64_t>(x) < static_cast<uint64_t>(in_w)) ? x_c[x] : input_offset;
+                }
+              }
+            }
+          } else {
+            math::Im2col<uint8_t, StorageOrder::NCHW>()(
+                Xdata,
+                input_shape.GetDims().data(),
+                output_shape.GetDims().data(),
+                kernel_dim,
+                kernel_shape.data(),
+                strides.data(),
+                dilations.data(),
+                pads.data(),
+                static_cast<int>(kernel_rank),
+                col_buffer_data,
+                false,
+                input_offset);
+          }
+        } else if (kernel_rank == 2) {
           if (X_is_signed) {
             math::Im2col<int8_t, StorageOrder::NCHW>()(
                 reinterpret_cast<const int8_t*>(Xdata),
@@ -208,7 +256,7 @@ Status ConvInteger::Compute(OpKernelContext* context) const {
       gemm_params.C = Ydata;
       gemm_params.ldc = static_cast<size_t>(output_image_size);
 
-      MlasGemm(gemm_shape, gemm_params, thread_pool);
+      MlasGemm(gemm_shape, gemm_params, thread_pool, &mlas_backend_kernel_selector_config_);
 
       Xdata += X_offset;
       Ydata += Y_offset;

--- a/onnxruntime/core/providers/cpu/quantization/matmul_integer.cc
+++ b/onnxruntime/core/providers/cpu/quantization/matmul_integer.cc
@@ -120,7 +120,8 @@ Status MatMulInteger::Compute(OpKernelContext* ctx) const {
     gemm_params.B = b_data + helper.RightOffsets()[batch];
     gemm_params.C = y_data + helper.OutputOffsets()[batch];
   }
-  MlasGemmBatch(gemm_shape, gemm_data_vec.data(), batch_size, ctx->GetOperatorThreadPool());
+  MlasGemmBatch(gemm_shape, gemm_data_vec.data(), batch_size, ctx->GetOperatorThreadPool(),
+                &mlas_backend_kernel_selector_config_);
 
   return Status::OK();
 }

--- a/onnxruntime/core/providers/cpu/quantization/matmul_integer.cc
+++ b/onnxruntime/core/providers/cpu/quantization/matmul_integer.cc
@@ -26,6 +26,8 @@ class MatMulInteger final : public MatMulIntegerBase {
 
  protected:
   int GetBIdx() const override { return IN_B; }
+
+  int GetAZeroPointIdx() const override { return IN_A_ZERO_POINT; }
 };
 
 ONNX_OPERATOR_TYPED_KERNEL_EX(

--- a/onnxruntime/core/providers/cpu/quantization/matmul_integer_base.h
+++ b/onnxruntime/core/providers/cpu/quantization/matmul_integer_base.h
@@ -66,6 +66,7 @@ class MatMulIntegerBase : public OpKernel {
       // buffer memory and we don not want it uninitialized and generate different hashes
       // if and when we try to cache this pre-packed buffer for sharing between sessions.
       memset(packed_b_.get(), 0, packed_b_size);
+#if defined(USE_KLEIDIAI)
       const uint8_t* a_zero_point = nullptr;
       const int a_zero_point_idx = GetAZeroPointIdx();
       if (a_zero_point_idx >= 0) {
@@ -77,6 +78,10 @@ class MatMulIntegerBase : public OpKernel {
 
       MlasGemmPackB(N, K, b_data, N, a_is_signed, b_is_signed_, packed_b_.get(),
                     &mlas_backend_kernel_selector_config_, a_zero_point);
+#else
+      MlasGemmPackB(N, K, b_data, N, a_is_signed, b_is_signed_, packed_b_.get(),
+                    &mlas_backend_kernel_selector_config_);
+#endif
 
       bool share_prepacked_weights = (prepacked_weights != nullptr);
       if (share_prepacked_weights) {

--- a/onnxruntime/core/providers/cpu/quantization/matmul_integer_base.h
+++ b/onnxruntime/core/providers/cpu/quantization/matmul_integer_base.h
@@ -66,7 +66,7 @@ class MatMulIntegerBase : public OpKernel {
       // buffer memory and we don not want it uninitialized and generate different hashes
       // if and when we try to cache this pre-packed buffer for sharing between sessions.
       memset(packed_b_.get(), 0, packed_b_size);
-      MlasGemmPackB(N, K, b_data, N, a_is_signed, b_is_signed_, packed_b_.get());
+      MlasGemmPackB(N, K, b_data, N, a_is_signed, b_is_signed_, packed_b_.get(), &mlas_backend_kernel_selector_config_);
 
       bool share_prepacked_weights = (prepacked_weights != nullptr);
       if (share_prepacked_weights) {

--- a/onnxruntime/core/providers/cpu/quantization/matmul_integer_base.h
+++ b/onnxruntime/core/providers/cpu/quantization/matmul_integer_base.h
@@ -66,7 +66,17 @@ class MatMulIntegerBase : public OpKernel {
       // buffer memory and we don not want it uninitialized and generate different hashes
       // if and when we try to cache this pre-packed buffer for sharing between sessions.
       memset(packed_b_.get(), 0, packed_b_size);
-      MlasGemmPackB(N, K, b_data, N, a_is_signed, b_is_signed_, packed_b_.get(), &mlas_backend_kernel_selector_config_);
+      const uint8_t* a_zero_point = nullptr;
+      const int a_zero_point_idx = GetAZeroPointIdx();
+      if (a_zero_point_idx >= 0) {
+        const Tensor* a_zero_point_tensor = GetConstantInputTensor(a_zero_point_idx);
+        if (a_zero_point_tensor != nullptr && IsScalarOr1ElementVector(a_zero_point_tensor)) {
+          a_zero_point = static_cast<const uint8_t*>(a_zero_point_tensor->DataRaw());
+        }
+      }
+
+      MlasGemmPackB(N, K, b_data, N, a_is_signed, b_is_signed_, packed_b_.get(),
+                    &mlas_backend_kernel_selector_config_, a_zero_point);
 
       bool share_prepacked_weights = (prepacked_weights != nullptr);
       if (share_prepacked_weights) {
@@ -99,6 +109,10 @@ class MatMulIntegerBase : public OpKernel {
    */
   virtual int GetAIdx() const { return 0; }
   virtual int GetBIdx() const = 0;
+
+  virtual int GetAZeroPointIdx() const {
+    return -1;
+  }
 
   virtual bool IsBTransposed() const {
     return false;
@@ -244,18 +258,24 @@ class MatMulIntegerBase : public OpKernel {
     packed_b_ = IAllocator::MakeUniquePtr<void>(alloc, packed_b_size, true);
     memset(packed_b_.get(), 0, packed_b_size);
 
-    const auto scales = static_cast<size_t>(ctx.scale->Shape().Size()) == ctx.N
-                            ? std::vector<float>(&ctx.scale->Data<float>()[0],
-                                                 &ctx.scale->Data<float>()[ctx.N])
-                            : std::vector<float>(ctx.N, ctx.scale->Data<float>()[0]);
+    const float* scales = ctx.scale->Data<float>();
+    std::vector<float> expanded_scales;
+    if (static_cast<size_t>(ctx.scale->Shape().Size()) != ctx.N) {
+      expanded_scales.assign(ctx.N, scales[0]);
+      scales = expanded_scales.data();
+    }
 
-    const auto biases = ctx.bias != nullptr
-                            ? std::vector<float>(&ctx.bias->Data<float>()[0],
-                                                 &ctx.bias->Data<float>()[ctx.N])
-                            : std::vector<float>(ctx.N, 0.f);
+    const float* biases = nullptr;
+    std::vector<float> zero_biases;
+    if (ctx.bias != nullptr) {
+      biases = ctx.bias->Data<float>();
+    } else {
+      zero_biases.assign(ctx.N, 0.f);
+      biases = zero_biases.data();
+    }
 
     MlasDynamicQgemmPackB(ctx.N, ctx.K, reinterpret_cast<const int8_t*>(ctx.b_data),
-                          scales.data(), biases.data(), packed_b_.get(), &mlas_backend_kernel_selector_config_);
+                          scales, biases, packed_b_.get(), &mlas_backend_kernel_selector_config_);
 
     if (prepacked_weights != nullptr) {
       prepacked_weights->buffers_.push_back(std::move(packed_b_));

--- a/onnxruntime/core/providers/cpu/quantization/qlinearconv.cc
+++ b/onnxruntime/core/providers/cpu/quantization/qlinearconv.cc
@@ -30,7 +30,7 @@ class QLinearConv : public OpKernel {
                  /*out*/ PrePackedWeights* prepacked_weights) override;
 
   Status UseSharedPrePackedBuffers(std::vector<BufferUniquePtr>& prepacked_buffers,
-                                   gsl::span<const size_t> /*prepacked_buffer_sizes*/,
+                                   gsl::span<const size_t> prepacked_buffer_sizes,
                                    int input_idx,
                                    /*out*/ bool& used_shared_buffers) override;
 
@@ -455,7 +455,8 @@ Status QLinearConv<ActType>::PrePack(const Tensor& tensor, int input_idx, Alloca
                       group_output_channels,
                       std::is_same<ActType, int8_t>::value,
                       is_W_signed_,
-                      packed_W);
+                      packed_W,
+                      &mlas_backend_kernel_selector_config_);
         packed_W += packed_W_size_;
         Wdata += W_offset;
       }
@@ -499,7 +500,7 @@ Status QLinearConv<ActType>::PrePack(const Tensor& tensor, int input_idx, Alloca
 
 template <typename ActType>
 Status QLinearConv<ActType>::UseSharedPrePackedBuffers(std::vector<BufferUniquePtr>& prepacked_buffers,
-                                                       gsl::span<const size_t> /*prepacked_buffer_sizes*/,
+                                                       gsl::span<const size_t> prepacked_buffer_sizes,
                                                        int input_idx,
                                                        /*out*/ bool& used_shared_buffers) {
   if (input_idx != 3) {
@@ -510,6 +511,14 @@ Status QLinearConv<ActType>::UseSharedPrePackedBuffers(std::vector<BufferUniqueP
 
   if (prepacked_buffers.size() == 1) {  // This means that only packed_W_ exists
     packed_W_buffer_ = std::move(prepacked_buffers[0]);
+
+    if (!prepacked_buffer_sizes.empty() && W_shape_.NumDimensions() > 2 && W_shape_[0] > 0 &&
+        conv_attrs_.group > 0 && W_shape_[0] % conv_attrs_.group == 0) {
+      const size_t group_count = static_cast<size_t>(conv_attrs_.group);
+      if (prepacked_buffer_sizes[0] % group_count == 0) {
+        packed_W_size_ = prepacked_buffer_sizes[0] / group_count;
+      }
+    }
   } else if (prepacked_buffers.size() == 2) {  // This means that only reordered_W_ exists
     // Enforce that the first "placeholder" buffer is nullptr
     ORT_ENFORCE(prepacked_buffers[0].get() == nullptr);
@@ -978,7 +987,7 @@ Status QLinearConv<ActType>::Compute(OpKernelContext* context) const {
             gemm_params.C = worker_gemm_output + group_id * group_output_channels;
             gemm_params.ldc = static_cast<size_t>(M);
 
-            MlasGemm(gemm_shape, gemm_params, nullptr);
+            MlasGemm(gemm_shape, gemm_params, nullptr, &mlas_backend_kernel_selector_config_);
           }
         }
       }

--- a/onnxruntime/core/providers/cpu/quantization/quantize_linear_matmul.cc
+++ b/onnxruntime/core/providers/cpu/quantization/quantize_linear_matmul.cc
@@ -169,7 +169,8 @@ Status QLinearMatMul::Compute(OpKernelContext* ctx) const {
     gemm_params[i].OutputProcessor = &(requant_procs[i]);
   }
 
-  MlasGemmBatch(gemm_shape, gemm_params.data(), num_gemms, ctx->GetOperatorThreadPool());
+  MlasGemmBatch(gemm_shape, gemm_params.data(), num_gemms, ctx->GetOperatorThreadPool(),
+                &mlas_backend_kernel_selector_config_);
 
   return Status::OK();
 }

--- a/onnxruntime/core/providers/cpu/rnn/rnn_helpers.cc
+++ b/onnxruntime/core/providers/cpu/rnn/rnn_helpers.cc
@@ -259,8 +259,6 @@ void ComputeGemm(const int M,
                  int32_t* quantize_agg_C_buffer,
                  concurrency::ThreadPool* thread_pool,
                  const MLAS_BACKEND_KERNEL_SELECTOR_CONFIG* mlas_backend_kernel_selector_config) {
-  ORT_UNUSED_PARAMETER(mlas_backend_kernel_selector_config);
-
   // validate all the inputs
   // need to use the lda/ldb/ldc strides which should be >= the columns for the span
   ORT_ENFORCE(A + (M * K) <= A_end);
@@ -313,7 +311,7 @@ void ComputeGemm(const int M,
   gemm_params.ldc = ld_C_buffer;
   gemm_params.OutputProcessor = &output_processor;
 
-  MlasGemm(gemm_shape, gemm_params, thread_pool);
+  MlasGemm(gemm_shape, gemm_params, thread_pool, mlas_backend_kernel_selector_config);
 }
 
 namespace deepcpu {


### PR DESCRIPTION
## Summary
 This change integrates Arm® KleidiAI™ prototype decomposable QGEMM kernels into the MLAS quantized GEMM path, enabling backend-selected acceleration for quantized CPU operators on supported Arm SME2
  platforms.

  The patch adds a new MLAS QGEMM override hook, threads MLAS_BACKEND_KERNEL_SELECTOR_CONFIG through quantized GEMM packing and execution call sites, and implements KleidiAI-backed {u8,i8} x {u8,i8} QGEMM
  paths for both int32 accumulation output and fused float ScaleBias output.
  ## Key Changes

  - Updates the KleidiAI dependency to a prototype Arm GitLab commit containing decomposable GEMM kernel support.
  - Adds an MLAS QGEMM backend override path alongside the existing SGEMM and DynamicQGEMM override mechanisms.
  - Extends MlasGemmBatch, MlasGemm, and MlasGemmPackB to accept backend kernel selector configuration.
  - Implements KleidiAI SME2 QGEMM support for:
      - u8 x u8 -> i32
      - u8 x i8 -> i32
      - i8 x u8 -> i32
      - i8 x i8 -> i32
      - Corresponding fused ScaleBias -> f32 variants
  - Adds packed-B support for the KleidiAI QGEMM path by appending a backend-specific packed representation after the base MLAS packed buffer.
  - Adds output processor introspection so backend overrides can detect and fuse MLAS_QGEMM_SCALE_BIAS_OUTPUT_PROCESSOR without RTTI.
  - Propagates backend selector configuration through quantized CPU operators including:
      - MatMulInteger
      - QLinearMatMul
      - QLinearConv
      - ConvInteger
      - quantized attention
      - dynamic quantized matmul/LSTM
      - RNN helper GEMM paths
  - Restores packed weight size metadata when shared prepacked buffers are reused by QAttention and QLinearConv.
  - Adds a 1D unsigned ConvInteger im2col fast path.
  - Optimizes single-GEMM DynamicQuantizeMatMul execution by calling MlasDynamicQGemm directly instead of the batch API.
