### PR TITLE
Add boundary checks for input validation

### DIFF
--- a/onnxruntime/contrib_ops/cpu/bert/multihead_attention_helper.h
+++ b/onnxruntime/contrib_ops/cpu/bert/multihead_attention_helper.h
@@ -177,6 +177,12 @@ Status CheckPast(const T* past_key, const T* past_value, const T* past_seq_len,
           "past_sequence_length tensor must be of one element when past_present_share_buffer is set");
     }
     past_sequence_length = *((*past_seq_len).template Data<int32_t>());
+    if (past_sequence_length < 0 || past_sequence_length >= max_sequence_length) {
+      return ORT_MAKE_STATUS(
+          ONNXRUNTIME, INVALID_ARGUMENT,
+          "past_sequence_length must be non-negative and less than max_sequence_length (",
+          max_sequence_length, "), got ", past_sequence_length);
+    }
   }
   return Status::OK();
 }


### PR DESCRIPTION
This pull request introduces an important input validation in the `multihead_attention_helper.h` file to ensure the integrity of the `past_sequence_length` parameter. The main change is an additional check that validates the value of `past_sequence_length` to prevent invalid or out-of-bounds values.

**Input validation improvements:**

* Added a check to ensure that `past_sequence_length` is non-negative and less than `max_sequence_length`, returning an error status if the condition is not met in `Status CheckPast` in `onnxruntime/contrib_ops/cpu/bert/multihead_attention_helper.h`.