### PR TITLE
[QNN-EP] add gather handler for transpose optimizer

### DIFF
--- a/onnxruntime/core/optimizer/transpose_optimization/onnx_transpose_optimization.cc
+++ b/onnxruntime/core/optimizer/transpose_optimization/onnx_transpose_optimization.cc
@@ -2239,6 +2239,53 @@ static bool HandleSlice(HandlerArgs& args) {
 
 constexpr HandlerInfo slice_handler = {&FirstInput, &HandleSlice};
 
+// Pushes a Transpose past a Gather, but only for the scalar-indices case (indices is a 0-D
+// constant). Why so narrow:
+//   - General Gather output rank is `data.rank - 1 + indices.rank`. Computing the post-rewrite
+//     output perm correctly for arbitrary indices.rank is fiddly and easy to get wrong without
+//     a dedicated test rig. Scalar-indices is structurally identical to Squeeze along the
+//     gathered axis, which we already trust.
+//   - Requiring a constant indices tensor lets us read its rank from .Shape().empty(); a dynamic
+//     indices input has no statically-known rank in general, so we can't decide if we're in the
+//     scalar case at compile time.
+// Only the `data` input is transposable here (FirstInput selector); `indices` are positions,
+// not values to be permuted.
+static bool HandleGather(HandlerArgs& args) {
+  size_t rank = args.perm.size();
+
+  int64_t axis = args.node.GetAttributeIntDefault("axis", 0);
+  if (!NormalizeAndValidateAxis(axis, rank)) {
+    return false;
+  }
+
+  // Indices must be a constant whose shape is exactly [] (0-D scalar). Bail otherwise -- the
+  // general rank case isn't handled by this handler.
+  auto inputs = args.node.Inputs();
+  if (inputs.size() < 2) {
+    return false;
+  }
+  std::unique_ptr<api::TensorRef> indices_const = args.ctx.graph.GetConstant(inputs[1]);
+  if (indices_const == nullptr) {
+    return false;
+  }
+  if (!indices_const->Shape().empty()) {
+    return false;
+  }
+
+  // Remap axis under the input perm: the user's `Gather(axis=k)` on the transposed data is
+  // equivalent to gathering along original-data axis perm[k]. Output rank drops by 1, exactly
+  // the Squeeze case along axis perm[k].
+  int64_t new_axis = args.perm[gsl::narrow_cast<size_t>(axis)];
+  args.node.SetAttributeInt("axis", new_axis);
+
+  TransposeFirstInput(args.ctx, args.node, args.perm_inv);
+  std::vector<int64_t> new_axes{new_axis};
+  TransposeOutputs(args.ctx, args.node, SqueezePerm(new_axes, args.perm));
+  return true;
+}
+
+constexpr HandlerInfo gather_handler = {&FirstInput, &HandleGather};
+
 static bool HandleTile(HandlerArgs& args) {
   size_t rank = args.perm.size();
   std::vector<int64_t> perm_shape{gsl::narrow_cast<int64_t>(rank)};
@@ -2632,6 +2679,7 @@ static const std::unordered_map<std::string_view, const HandlerInfo&> handler_ma
     {"Squeeze", squeeze_handler},
     {"Unsqueeze", unsqueeze_handler},
     {"Slice", slice_handler},
+    {"Gather", gather_handler},
     {"Tile", tile_handler},
 
     {"Softmax", soft_hard_max_handler},

--- a/onnxruntime/test/optimizer/transpose_optimizer_test.cc
+++ b/onnxruntime/test/optimizer/transpose_optimizer_test.cc
@@ -2445,7 +2445,7 @@ TEST(TransposeOptimizerTests, TestGatherRank1IndicesNoOpt) {
 TEST(TransposeOptimizerTests, TestGatherNonconstIndicesNoOpt) {
   auto build_test_case_1 = [&](ModelTestBuilder& builder) {
     auto* input0_arg = builder.MakeInput<float>({2, 4, 6, 5}, 0.0, 1.0);
-    auto* indices_arg = MakeInput<int64_t>(builder, {{}}, {}, {2});  // graph input, not initializer
+    auto* indices_arg = MakeInput<int64_t>(builder, std::vector<int64_t>{}, {}, {2});  // graph input, not initializer
     auto* transpose_1_out_0 = builder.MakeIntermediate();
     auto* gather_1_out_0 = builder.MakeIntermediate();
     auto* transpose_2_out_0 = builder.MakeOutput();

--- a/onnxruntime/test/optimizer/transpose_optimizer_test.cc
+++ b/onnxruntime/test/optimizer/transpose_optimizer_test.cc
@@ -2377,12 +2377,9 @@ TEST(TransposeOptimizerTests, TestGatherScalarIndices) {
                     /*opset_version*/ {13, 18, 23});
 }
 
-// Negative axis: ONNX Gather permits axis in [-r, r-1]. NormalizeAndValidateAxis must convert
-// to a non-negative value before the perm-remap. perm[3] = 2, so the rewritten Gather should
-// run on axis 2. SqueezePerm({2},[0,3,1,2]) = [0,1,?] — work it out:
-//   removed={2}; is_removed=[F,F,T,F]; axes_map=[0,1,_,2]; perm=[0,3,1,2]
-//   walk: 0->0; 3->2; 1->1; 2 removed (skip)  =>  [0, 2, 1]
-// User's downstream Transpose [0,2,1] cancels the rewrite-emitted [0,2,1], cost=0.
+// Negative axis: ONNX Gather permits axis in [-r, r-1]. The handler must normalize the axis
+// before remapping under perm. Here axis=-1 on a rank-4 input means axis 3, and perm[3]=2.
+// The rewrite cancels the user's downstream Transpose, so the final graph has zero transpose cost.
 TEST(TransposeOptimizerTests, TestGatherNegativeAxis) {
   auto build_test_case_1 = [&](ModelTestBuilder& builder) {
     auto* input0_arg = builder.MakeInput<float>({2, 4, 6, 5}, 0.0, 1.0);
@@ -2431,7 +2428,24 @@ TEST(TransposeOptimizerTests, TestGatherRank1IndicesNoOpt) {
   };
 
   auto check_optimized_graph_1 = [&](InferenceSessionWrapper& session) {
-    ORT_UNUSED_PARAMETER(session);
+    const auto op_to_count = CountOpsInGraph(session.GetGraph());
+    EXPECT_EQ(op_to_count.at("Transpose"), 2);
+    EXPECT_EQ(op_to_count.at("Gather"), 1);
+
+    // Assert the Transpose perms are unchanged — guards against in-place attribute mutation
+    // or node-swap that would preserve op counts but alter the graph.
+    std::vector<std::vector<int64_t>> transpose_perms;
+    for (const auto& node : session.GetGraph().Nodes()) {
+      if (node.OpType() != "Transpose") continue;
+      const auto& attrs = node.GetAttributes();
+      auto it = attrs.find("perm");
+      ASSERT_TRUE(it != attrs.end());
+      ASSERT_EQ(it->second.type(), ONNX_NAMESPACE::AttributeProto_AttributeType_INTS);
+      transpose_perms.emplace_back(it->second.ints().begin(), it->second.ints().end());
+    }
+    std::sort(transpose_perms.begin(), transpose_perms.end());
+    std::vector<std::vector<int64_t>> expected{{0, 1, 3, 2}, {0, 3, 1, 2}};
+    EXPECT_EQ(transpose_perms, expected);
   };
 
   TransformerTester(build_test_case_1,
@@ -2459,7 +2473,24 @@ TEST(TransposeOptimizerTests, TestGatherNonconstIndicesNoOpt) {
   };
 
   auto check_optimized_graph_1 = [&](InferenceSessionWrapper& session) {
-    ORT_UNUSED_PARAMETER(session);
+    const auto op_to_count = CountOpsInGraph(session.GetGraph());
+    EXPECT_EQ(op_to_count.at("Transpose"), 2);
+    EXPECT_EQ(op_to_count.at("Gather"), 1);
+
+    // Assert the Transpose perms are unchanged — guards against in-place attribute mutation
+    // or node-swap that would preserve op counts but alter the graph.
+    std::vector<std::vector<int64_t>> transpose_perms;
+    for (const auto& node : session.GetGraph().Nodes()) {
+      if (node.OpType() != "Transpose") continue;
+      const auto& attrs = node.GetAttributes();
+      auto it = attrs.find("perm");
+      ASSERT_TRUE(it != attrs.end());
+      ASSERT_EQ(it->second.type(), ONNX_NAMESPACE::AttributeProto_AttributeType_INTS);
+      transpose_perms.emplace_back(it->second.ints().begin(), it->second.ints().end());
+    }
+    std::sort(transpose_perms.begin(), transpose_perms.end());
+    std::vector<std::vector<int64_t>> expected{{0, 2, 1}, {0, 3, 1, 2}};
+    EXPECT_EQ(transpose_perms, expected);
   };
 
   TransformerTester(build_test_case_1,

--- a/onnxruntime/test/optimizer/transpose_optimizer_test.cc
+++ b/onnxruntime/test/optimizer/transpose_optimizer_test.cc
@@ -2334,6 +2334,141 @@ TEST(TransposeOptimizerTests, TestSliceDefaultAxesNonconstStartsUnknownLengthInt
                     /*opset_version*/ {15, 18, 23});
 }
 
+// Gather with a 0-D constant indices tensor: rank decreases by one along the gathered axis,
+// structurally identical to Squeeze. The handler should push the leading Transpose past Gather,
+// remap axis under perm, and emit a SqueezePerm on the output. The user's downstream Transpose
+// then composes with the rewrite-emitted one and both cancel.
+//
+//   input{2,4,6,5} -> Transpose(perm=[0,3,1,2]) -> {2,5,4,6}
+//                  -> Gather(axis=2, scalar idx) -> {2,5,6}
+//                  -> Transpose(perm=[0,2,1])   -> {2,6,5}    (graph output)
+//
+// After push:
+//   input -> Gather(axis=perm[2]=1, scalar) -> {2,6,5}
+//         -> Transpose(SqueezePerm({1},[0,3,1,2])=[0,2,1])    <- rewrite-emitted
+//         -> Transpose([0,2,1])                                <- user-supplied
+// The two trailing Transposes compose to identity and the optimizer eliminates them, so the
+// surviving graph has zero transposes.
+TEST(TransposeOptimizerTests, TestGatherScalarIndices) {
+  auto build_test_case_1 = [&](ModelTestBuilder& builder) {
+    auto* input0_arg = builder.MakeInput<float>({2, 4, 6, 5}, 0.0, 1.0);
+    auto* indices_const = builder.MakeScalarInitializer<int64_t>(2);
+    auto* transpose_1_out_0 = builder.MakeIntermediate();
+    auto* gather_1_out_0 = builder.MakeIntermediate();
+    auto* transpose_2_out_0 = builder.MakeOutput();
+
+    auto& transpose_1 = builder.AddNode("Transpose", {input0_arg}, {transpose_1_out_0});
+    transpose_1.AddAttribute("perm", std::vector<int64_t>{0, 3, 1, 2});
+    auto& gather_1 = builder.AddNode("Gather", {transpose_1_out_0, indices_const}, {gather_1_out_0});
+    gather_1.AddAttribute("axis", static_cast<int64_t>(2));
+    auto& transpose_2 = builder.AddNode("Transpose", {gather_1_out_0}, {transpose_2_out_0});
+    transpose_2.AddAttribute("perm", std::vector<int64_t>{0, 2, 1});
+  };
+
+  auto check_optimized_graph_1 = [&](InferenceSessionWrapper& session) {
+    int transpose_cost = EstimateTransposeCost(session.GetGraph());
+    EXPECT_EQ(transpose_cost, 0);
+  };
+
+  TransformerTester(build_test_case_1,
+                    check_optimized_graph_1,
+                    TransformerLevel::Default,
+                    TransformerLevel::Level1,
+                    /*opset_version*/ {13, 18, 23});
+}
+
+// Negative axis: ONNX Gather permits axis in [-r, r-1]. NormalizeAndValidateAxis must convert
+// to a non-negative value before the perm-remap. perm[3] = 2, so the rewritten Gather should
+// run on axis 2. SqueezePerm({2},[0,3,1,2]) = [0,1,?] — work it out:
+//   removed={2}; is_removed=[F,F,T,F]; axes_map=[0,1,_,2]; perm=[0,3,1,2]
+//   walk: 0->0; 3->2; 1->1; 2 removed (skip)  =>  [0, 2, 1]
+// User's downstream Transpose [0,2,1] cancels the rewrite-emitted [0,2,1], cost=0.
+TEST(TransposeOptimizerTests, TestGatherNegativeAxis) {
+  auto build_test_case_1 = [&](ModelTestBuilder& builder) {
+    auto* input0_arg = builder.MakeInput<float>({2, 4, 6, 5}, 0.0, 1.0);
+    auto* indices_const = builder.MakeScalarInitializer<int64_t>(0);
+    auto* transpose_1_out_0 = builder.MakeIntermediate();
+    auto* gather_1_out_0 = builder.MakeIntermediate();
+    auto* transpose_2_out_0 = builder.MakeOutput();
+
+    auto& transpose_1 = builder.AddNode("Transpose", {input0_arg}, {transpose_1_out_0});
+    transpose_1.AddAttribute("perm", std::vector<int64_t>{0, 3, 1, 2});
+    auto& gather_1 = builder.AddNode("Gather", {transpose_1_out_0, indices_const}, {gather_1_out_0});
+    gather_1.AddAttribute("axis", static_cast<int64_t>(-1));  // last axis = 3 in 4D, perm[3]=2
+    auto& transpose_2 = builder.AddNode("Transpose", {gather_1_out_0}, {transpose_2_out_0});
+    transpose_2.AddAttribute("perm", std::vector<int64_t>{0, 2, 1});
+  };
+
+  auto check_optimized_graph_1 = [&](InferenceSessionWrapper& session) {
+    int transpose_cost = EstimateTransposeCost(session.GetGraph());
+    EXPECT_EQ(transpose_cost, 0);
+  };
+
+  TransformerTester(build_test_case_1,
+                    check_optimized_graph_1,
+                    TransformerLevel::Default,
+                    TransformerLevel::Level1,
+                    /*opset_version*/ {13, 18, 23});
+}
+
+// Rank-1 indices (even of length 1) preserve the gathered axis in the output, so the rewrite
+// is NOT a Squeeze-style rank reduction. The handler should refuse and leave the original
+// transposes in place.
+TEST(TransposeOptimizerTests, TestGatherRank1IndicesNoOpt) {
+  auto build_test_case_1 = [&](ModelTestBuilder& builder) {
+    auto* input0_arg = builder.MakeInput<float>({2, 4, 6, 5}, 0.0, 1.0);
+    auto* indices_const = builder.MakeInitializer<int64_t>({1}, {2});  // rank-1, NOT scalar
+    auto* transpose_1_out_0 = builder.MakeIntermediate();
+    auto* gather_1_out_0 = builder.MakeIntermediate();
+    auto* transpose_2_out_0 = builder.MakeOutput();
+
+    auto& transpose_1 = builder.AddNode("Transpose", {input0_arg}, {transpose_1_out_0});
+    transpose_1.AddAttribute("perm", std::vector<int64_t>{0, 3, 1, 2});
+    auto& gather_1 = builder.AddNode("Gather", {transpose_1_out_0, indices_const}, {gather_1_out_0});
+    gather_1.AddAttribute("axis", static_cast<int64_t>(2));
+    auto& transpose_2 = builder.AddNode("Transpose", {gather_1_out_0}, {transpose_2_out_0});
+    transpose_2.AddAttribute("perm", std::vector<int64_t>{0, 1, 3, 2});
+  };
+
+  auto check_optimized_graph_1 = [&](InferenceSessionWrapper& session) {
+    ORT_UNUSED_PARAMETER(session);
+  };
+
+  TransformerTester(build_test_case_1,
+                    check_optimized_graph_1,
+                    TransformerLevel::Default,
+                    TransformerLevel::Level1,
+                    /*opset_version*/ {13, 18, 23});
+}
+
+// Dynamic (non-constant) indices: handler can't read the rank statically, so it bails.
+TEST(TransposeOptimizerTests, TestGatherNonconstIndicesNoOpt) {
+  auto build_test_case_1 = [&](ModelTestBuilder& builder) {
+    auto* input0_arg = builder.MakeInput<float>({2, 4, 6, 5}, 0.0, 1.0);
+    auto* indices_arg = MakeInput<int64_t>(builder, {{}}, {}, {2});  // graph input, not initializer
+    auto* transpose_1_out_0 = builder.MakeIntermediate();
+    auto* gather_1_out_0 = builder.MakeIntermediate();
+    auto* transpose_2_out_0 = builder.MakeOutput();
+
+    auto& transpose_1 = builder.AddNode("Transpose", {input0_arg}, {transpose_1_out_0});
+    transpose_1.AddAttribute("perm", std::vector<int64_t>{0, 3, 1, 2});
+    auto& gather_1 = builder.AddNode("Gather", {transpose_1_out_0, indices_arg}, {gather_1_out_0});
+    gather_1.AddAttribute("axis", static_cast<int64_t>(2));
+    auto& transpose_2 = builder.AddNode("Transpose", {gather_1_out_0}, {transpose_2_out_0});
+    transpose_2.AddAttribute("perm", std::vector<int64_t>{0, 2, 1});
+  };
+
+  auto check_optimized_graph_1 = [&](InferenceSessionWrapper& session) {
+    ORT_UNUSED_PARAMETER(session);
+  };
+
+  TransformerTester(build_test_case_1,
+                    check_optimized_graph_1,
+                    TransformerLevel::Default,
+                    TransformerLevel::Level1,
+                    /*opset_version*/ {13, 18, 23});
+}
+
 TEST(TransposeOptimizerTests, TestTile) {
   auto build_test_case_1 = [&](ModelTestBuilder& builder) {
     auto* input0_arg = MakeInput<float>(builder, {{2, -1, 6, 3}}, {2, 4, 6, 3}, 0.0, 1.0);


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Gather is missing from the transpose optimizer's handler map. This PR adds HandleGather, which pushes a Transpose past a Gather so the
  transpose can cancel or fuse with neighboring transposes.

  The rewrite is:

  `data -> Transpose(perm) -> Gather(axis=k, indices=scalar_const)`

  becomes

  `data -> Gather(axis=perm[k], indices=scalar_const) -> Transpose(SqueezePerm({perm[k]}, perm))`

  Scope is intentionally narrow — only the scalar (0-D) constant-indices case, which is structurally identical to a Squeeze along the gathered axis and reuses SqueezePerm for the post-rewrite output perm. Non-scalar or non-constant indices are left untouched. The  framework's DefaultCostCheck still gates the rewrite on profitability, so unprofitable cases are rejected before the handler runs.

 Tests added in transpose_optimizer_test.cc cover the positive scalar-indices case, negative-axis normalization, rank-1-indices  fall-through, and dynamic-indices fall-through.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

We've observed that the Transpose → Gather → Transpose pattern produces sub-optimal inference performance on the QNN EP. With this
  handler in place, the surrounding transposes can fold or cancel, eliminating layout-conversion overhead around Gather.

