### PR TITLE
Fix CPU ReverseSequence returning zeros for zero-length sequences

### DIFF
--- a/onnxruntime/core/providers/cpu/tensor/reverse_sequence.cc
+++ b/onnxruntime/core/providers/cpu/tensor/reverse_sequence.cc
@@ -136,10 +136,6 @@ static Status ReverseSequenceImpl(const Tensor& X,
   for (int i = 0; i < batch_size; i++) {
     int64_t seq_len = sequence_lengths[i];
 
-    if (seq_len == 0) {
-      continue;
-    }
-
     if (seq_len > max_seq_len || seq_len < 0) {
       return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Invalid sequence length: ", seq_len,
                              ". Value must be in range [0,", max_seq_len, "]");

--- a/onnxruntime/test/providers/cpu/tensor/reverse_sequence_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/reverse_sequence_test.cc
@@ -156,6 +156,32 @@ TEST(ReverseSequenceTest, InvalidInput) {
   }
 }
 
+TEST(ReverseSequenceTest, ZeroSequenceLength) {
+  // A sequence length of 0 must leave that batch's column unchanged rather than
+  // emitting zeros from the uninitialized output buffer. See issue #28490.
+  OpTester test("ReverseSequence", 10);
+
+  std::vector<float> input = {10, 20, 30,
+                              11, 21, 31,
+                              12, 22, 32,
+                              13, 23, 33,
+                              14, 24, 34};
+  std::vector<int64_t> sequence_lens = {4, 0, 2};
+  std::vector<float> expected_output = {13, 20, 31,
+                                        12, 21, 30,
+                                        11, 22, 32,
+                                        10, 23, 33,
+                                        14, 24, 34};
+
+  test.AddAttribute("batch_axis", int64_t(1));
+  test.AddAttribute("time_axis", int64_t(0));
+
+  test.AddInput<float>("input", {5, 3, 1}, input);
+  test.AddInput<int64_t>("sequence_lens", {3}, sequence_lens);
+  test.AddOutput<float>("Y", {5, 3, 1}, expected_output);
+  test.Run();
+}
+
 TEST(ReverseSequenceTest, BadLength) {
   auto run_test = [](bool use_negative) {
     OpTester test("ReverseSequence", 10);


### PR DESCRIPTION
### Description
`ReverseSequenceImpl` skips a batch with `continue` when `seq_len == 0`, but the output isn't pre-copied from the input, so that column is left as zeros instead of unchanged. Removing the early `continue` lets the existing `[seq_len, max_seq_len)` loop copy the whole column through.

Adds `ReverseSequenceTest.ZeroSequenceLength`.

### Motivation and Context
Fixes #28490. Labelled `[OpenVINO]` but the bug is in the CPU EP.