### PR TITLE
Harden CropAndResize against malformed crop_size tensors

### DIFF
--- a/onnxruntime/contrib_ops/cpu/crop_and_resize.cc
+++ b/onnxruntime/contrib_ops/cpu/crop_and_resize.cc
@@ -200,7 +200,14 @@ Status CropAndResize<T>::Compute(OpKernelContext* context) const {
   // validate crop_size
   if (crop_size_dims.NumDimensions() != 1) {
     return Status(common::ONNXRUNTIME, common::INVALID_ARGUMENT,
-                  "Number of dimensions for crop size should be exactly 1");
+                  std::string("crop_size must be a 1-D tensor; got rank ") +
+                      std::to_string(crop_size_dims.NumDimensions()));
+  }
+
+  if (crop_size_dims.Size() != 2) {
+    return Status(common::ONNXRUNTIME, common::INVALID_ARGUMENT,
+                  std::string("crop_size input tensor must have exactly 2 elements; got ") +
+                      std::to_string(crop_size_dims.Size()));
   }
 
   auto channels = x_dims[1];

--- a/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
@@ -2847,6 +2847,11 @@ ONNX_MS_OPERATOR_SET_SCHEMA(CropAndResize, 1,
                                   if (crop_size_shape.dim_size() != 1) {
                                     fail_shape_inference("crop_size shape input tensor has wrong dimension");
                                   }
+                                  if (crop_size_shape.dim(0).has_dim_value() &&
+                                      crop_size_shape.dim(0).dim_value() != 2) {
+                                    fail_shape_inference("crop_size input tensor must have exactly 2 elements; got ",
+                                                         crop_size_shape.dim(0).dim_value());
+                                  }
                                 })
                                 .SetDoc(R"DOC(
         Extracts crops from the input image tensor and resizes them using bilinear sampling or nearest neighbor sampling

--- a/onnxruntime/test/contrib_ops/crop_and_resize_op_test.cc
+++ b/onnxruntime/test/contrib_ops/crop_and_resize_op_test.cc
@@ -92,8 +92,8 @@ TEST(CropAndResizeTest, CropAndResizeRejectsMalformedCropSize) {
   test_with_three_elements.AddOutput<float>("output", {1, 1, 1, 1}, {0.0f});
 
   test_with_three_elements.Run(OpTester::ExpectResult::kExpectFailure,
-                                "[ShapeInferenceError] crop_size input tensor must have exactly 2 elements; got 3",
-                                {kTensorrtExecutionProvider});
+                               "[ShapeInferenceError] crop_size input tensor must have exactly 2 elements; got 3",
+                               {kTensorrtExecutionProvider});
 }
 
 TEST(CropAndResizeTest, CropAndResize_1133) {

--- a/onnxruntime/test/contrib_ops/crop_and_resize_op_test.cc
+++ b/onnxruntime/test/contrib_ops/crop_and_resize_op_test.cc
@@ -72,6 +72,30 @@ TEST(CropAndResizeTest, CropAndResize_1222) {
   test2.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
 }
 
+TEST(CropAndResizeTest, CropAndResizeRejectsMalformedCropSize) {
+  OpTester test("CropAndResize", 1, onnxruntime::kMSDomain);
+  test.AddInput<float>("X", {1, 1, 2, 2}, {1.1f, 2.2f, 3.3f, 4.4f});
+  test.AddInput<float>("rois", {1, 4}, {0.0f, 0.0f, 1.0f, 1.0f});
+  test.AddInput<int32_t>("batch_indices", {1}, {0});
+  test.AddInput<int32_t>("crop_size", {1}, {2});
+  test.AddOutput<float>("output", {1, 1, 1, 1}, {0.0f});
+
+  test.Run(OpTester::ExpectResult::kExpectFailure,
+           "[ShapeInferenceError] crop_size input tensor must have exactly 2 elements; got 1",
+           {kTensorrtExecutionProvider});
+
+  OpTester test_with_three_elements("CropAndResize", 1, onnxruntime::kMSDomain);
+  test_with_three_elements.AddInput<float>("X", {1, 1, 2, 2}, {1.1f, 2.2f, 3.3f, 4.4f});
+  test_with_three_elements.AddInput<float>("rois", {1, 4}, {0.0f, 0.0f, 1.0f, 1.0f});
+  test_with_three_elements.AddInput<int32_t>("batch_indices", {1}, {0});
+  test_with_three_elements.AddInput<int32_t>("crop_size", {3}, {2, 2, 2});
+  test_with_three_elements.AddOutput<float>("output", {1, 1, 1, 1}, {0.0f});
+
+  test_with_three_elements.Run(OpTester::ExpectResult::kExpectFailure,
+                                "[ShapeInferenceError] crop_size input tensor must have exactly 2 elements; got 3",
+                                {kTensorrtExecutionProvider});
+}
+
 TEST(CropAndResizeTest, CropAndResize_1133) {
   OpTester test1("CropAndResize", 1, onnxruntime::kMSDomain);
   test1.AddInput<float>("X", {1, 1, 3, 3}, {1.1f, 2.2f, 3.3f, 4.4f, 5.5f, 6.6f, 7.7f, 8.8f, 9.9f});


### PR DESCRIPTION
## Description

This PR closes a validation gap in the Microsoft CropAndResize contrib op by rejecting malformed `crop_size` tensors before runtime can read past the end of the array. The fix improves safety for invalid models and preserves existing behavior for valid inputs.

## Summary of Changes

### Validation and safety

| File | Change |
|------|--------|
| `onnxruntime/contrib_ops/cpu/crop_and_resize.cc` | Added explicit runtime validation to ensure `crop_size` is a 1-D tensor with exactly 2 elements before indexing `crop_size_data[1]`. |
| `onnxruntime/core/graph/contrib_ops/contrib_defs.cc` | Added shape-inference validation so malformed `crop_size` shapes are rejected during model resolution when the size is known. |

### Regression coverage

- Added provider-test coverage in `onnxruntime/test/contrib_ops/crop_and_resize_op_test.cc` for malformed `crop_size` inputs of length 1 and 3, confirming they fail validation instead of reaching the runtime path.

## Testing

Verified locally with:

- `cmake --build build/Linux/Release --target onnxruntime_provider_test -j2`
- `cd build/Linux/Release && ./onnxruntime_provider_test --gtest_filter='CropAndResizeTest.*'`

Result: 5 tests ran, 5 passed.

## Motivation and Context

The root cause was that the runtime path only checked the rank of `crop_size`, not its element count. A rank-1 tensor with fewer than 2 elements could still reach `crop_size_data[1]`, which created an out-of-bounds read path and exposed adjacent heap bytes. This fix addresses both runtime execution and model-loading/shape-inference validation to close the vulnerability path end to end.

## Checklist

- [x] Tests added/updated
- [x] No breaking changes
- [x] CI passes (verified locally via provider test suite)
