### PR TITLE
Validate BeamSearch vocab_size against logits width

### DIFF
--- a/onnxruntime/contrib_ops/cpu/transformers/beam_search_parameters.cc
+++ b/onnxruntime/contrib_ops/cpu/transformers/beam_search_parameters.cc
@@ -144,9 +144,13 @@ void BeamSearchParameters::ParseFromInputs(OpKernelContext* context) {
 
 void BeamSearchParameters::SetSubgraphParameters(int vocabulary_size, int heads, int hidden_size_per_head, int layers) {
   // Override vocab_size using the inferred shape from the decoder subgraph ONLY IF
-  // the vocab_size hasn't been explicitly specified by the user (as an attribute of BeamSearch)
+  // the vocab_size hasn't been explicitly specified by the user (as an attribute of BeamSearch).
+  // Reject an explicitly supplied vocab_size that does not match the decoder logits width.
   if (vocab_size == -1 || vocab_size == 0) {
     vocab_size = vocabulary_size;
+  } else if (vocab_size != vocabulary_size) {
+    ORT_THROW("vocab_size attribute (", vocab_size,
+              ") does not match decoder subgraph logits width (", vocabulary_size, ")");
   }
   num_heads = heads;
   head_size = hidden_size_per_head;

--- a/onnxruntime/contrib_ops/cpu/transformers/beam_search_parameters.cc
+++ b/onnxruntime/contrib_ops/cpu/transformers/beam_search_parameters.cc
@@ -145,12 +145,12 @@ void BeamSearchParameters::ParseFromInputs(OpKernelContext* context) {
 void BeamSearchParameters::SetSubgraphParameters(int vocabulary_size, int heads, int hidden_size_per_head, int layers) {
   // Override vocab_size using the inferred shape from the decoder subgraph ONLY IF
   // the vocab_size hasn't been explicitly specified by the user (as an attribute of BeamSearch).
-  // Reject an explicitly supplied vocab_size that does not match the decoder logits width.
+  // Reject an explicitly supplied vocab_size that exceeds the decoder logits width.
   if (vocab_size == -1 || vocab_size == 0) {
     vocab_size = vocabulary_size;
-  } else if (vocab_size != vocabulary_size) {
+  } else if (vocab_size > vocabulary_size) {
     ORT_THROW("vocab_size attribute (", vocab_size,
-              ") does not match decoder subgraph logits width (", vocabulary_size, ")");
+              ") cannot exceed decoder subgraph logits width (", vocabulary_size, ")");
   }
   num_heads = heads;
   head_size = hidden_size_per_head;

--- a/onnxruntime/contrib_ops/cpu/transformers/generation_device_helper.cc
+++ b/onnxruntime/contrib_ops/cpu/transformers/generation_device_helper.cc
@@ -306,9 +306,9 @@ Status ProcessLogits(const OrtValue& logits,                                 // 
   const TensorShape& logits_shape = logits.Get<Tensor>().Shape();
   ORT_ENFORCE(logits_shape.NumDimensions() == 3);
   const auto logits_vocab_size = static_cast<int>(logits_shape[2]);
-  ORT_RETURN_IF_NOT(vocab_size == logits_vocab_size,
+  ORT_RETURN_IF_NOT(vocab_size > 0 && vocab_size <= logits_vocab_size,
                     "BeamSearch: vocab_size attribute (", vocab_size,
-                    ") does not match decoder logits width (", logits_vocab_size, ")");
+                    ") must be positive and not exceed decoder logits width (", logits_vocab_size, ")");
   auto input_length = logits_shape[1];
   auto logits_batch_size = logits_shape[0];
 
@@ -477,9 +477,9 @@ Status GreedySearchProcessLogits(
   const TensorShape& logits_shape = logits.Get<Tensor>().Shape();
   ORT_ENFORCE(logits_shape.NumDimensions() == 3);
   const auto logits_vocab_size = static_cast<int>(logits_shape[2]);
-  ORT_RETURN_IF_NOT(vocab_size == logits_vocab_size,
+  ORT_RETURN_IF_NOT(vocab_size > 0 && vocab_size <= logits_vocab_size,
                     "GreedySearch: vocab_size attribute (", vocab_size,
-                    ") does not match decoder logits width (", logits_vocab_size, ")");
+                    ") must be positive and not exceed decoder logits width (", logits_vocab_size, ")");
   auto input_length = logits_shape[1];
 
   // Get logits for the last token:

--- a/onnxruntime/contrib_ops/cpu/transformers/generation_device_helper.cc
+++ b/onnxruntime/contrib_ops/cpu/transformers/generation_device_helper.cc
@@ -305,6 +305,10 @@ Status ProcessLogits(const OrtValue& logits,                                 // 
   // where input_length equals to parameters_->sequence_length for first subgraph call, and 1 for the remaining calls.
   const TensorShape& logits_shape = logits.Get<Tensor>().Shape();
   ORT_ENFORCE(logits_shape.NumDimensions() == 3);
+  const auto logits_vocab_size = static_cast<int>(logits_shape[2]);
+  ORT_RETURN_IF_NOT(vocab_size == logits_vocab_size,
+                    "BeamSearch: vocab_size attribute (", vocab_size,
+                    ") does not match decoder logits width (", logits_vocab_size, ")");
   auto input_length = logits_shape[1];
   auto logits_batch_size = logits_shape[0];
 
@@ -472,6 +476,10 @@ Status GreedySearchProcessLogits(
   // where input_length equals to parameters_->sequence_length for first subgraph call, and 1 for the remaining calls.
   const TensorShape& logits_shape = logits.Get<Tensor>().Shape();
   ORT_ENFORCE(logits_shape.NumDimensions() == 3);
+  const auto logits_vocab_size = static_cast<int>(logits_shape[2]);
+  ORT_RETURN_IF_NOT(vocab_size == logits_vocab_size,
+                    "GreedySearch: vocab_size attribute (", vocab_size,
+                    ") does not match decoder logits width (", logits_vocab_size, ")");
   auto input_length = logits_shape[1];
 
   // Get logits for the last token:

--- a/onnxruntime/contrib_ops/cuda/transformers/generation_device_helper.cc
+++ b/onnxruntime/contrib_ops/cuda/transformers/generation_device_helper.cc
@@ -362,6 +362,10 @@ Status ProcessLogits(const OrtValue& logits,                                 // 
   // where input_length equals to parameters_->sequence_length for first subgraph call, and 1 for the remaining calls.
   const TensorShape& logits_shape = logits.Get<Tensor>().Shape();
   ORT_ENFORCE(logits_shape.NumDimensions() == 3);
+  const auto logits_vocab_size = static_cast<int>(logits_shape[2]);
+  ORT_RETURN_IF_NOT(vocab_size == logits_vocab_size,
+                    "BeamSearch: vocab_size attribute (", vocab_size,
+                    ") does not match decoder logits width (", logits_vocab_size, ")");
   auto input_length = logits_shape[1];
   auto logits_batch_size = logits_shape[0];
 
@@ -849,6 +853,10 @@ Status GreedySearchProcessLogits(
   // where input_length equals to parameters_->sequence_length for first subgraph call, and 1 for the remaining calls.
   const TensorShape& logits_shape = logits.Get<Tensor>().Shape();
   ORT_ENFORCE(logits_shape.NumDimensions() == 3);
+  const auto logits_vocab_size = static_cast<int>(logits_shape[2]);
+  ORT_RETURN_IF_NOT(vocab_size == logits_vocab_size,
+                    "GreedySearch: vocab_size attribute (", vocab_size,
+                    ") does not match decoder logits width (", logits_vocab_size, ")");
   auto input_length = logits_shape[1];
 
   // NOTE: `padded_vocab_size` MAY be different from `vocab_size`.

--- a/onnxruntime/contrib_ops/cuda/transformers/generation_device_helper.cc
+++ b/onnxruntime/contrib_ops/cuda/transformers/generation_device_helper.cc
@@ -363,9 +363,9 @@ Status ProcessLogits(const OrtValue& logits,                                 // 
   const TensorShape& logits_shape = logits.Get<Tensor>().Shape();
   ORT_ENFORCE(logits_shape.NumDimensions() == 3);
   const auto logits_vocab_size = static_cast<int>(logits_shape[2]);
-  ORT_RETURN_IF_NOT(vocab_size == logits_vocab_size,
+  ORT_RETURN_IF_NOT(vocab_size > 0 && vocab_size <= logits_vocab_size,
                     "BeamSearch: vocab_size attribute (", vocab_size,
-                    ") does not match decoder logits width (", logits_vocab_size, ")");
+                    ") must be positive and not exceed decoder logits width (", logits_vocab_size, ")");
   auto input_length = logits_shape[1];
   auto logits_batch_size = logits_shape[0];
 
@@ -854,9 +854,9 @@ Status GreedySearchProcessLogits(
   const TensorShape& logits_shape = logits.Get<Tensor>().Shape();
   ORT_ENFORCE(logits_shape.NumDimensions() == 3);
   const auto logits_vocab_size = static_cast<int>(logits_shape[2]);
-  ORT_RETURN_IF_NOT(vocab_size == logits_vocab_size,
+  ORT_RETURN_IF_NOT(vocab_size > 0 && vocab_size <= logits_vocab_size,
                     "GreedySearch: vocab_size attribute (", vocab_size,
-                    ") does not match decoder logits width (", logits_vocab_size, ")");
+                    ") must be positive and not exceed decoder logits width (", logits_vocab_size, ")");
   auto input_length = logits_shape[1];
 
   // NOTE: `padded_vocab_size` MAY be different from `vocab_size`.

--- a/onnxruntime/test/contrib_ops/beam_search_test.cc
+++ b/onnxruntime/test/contrib_ops/beam_search_test.cc
@@ -11,6 +11,7 @@
 #include "test/unittest_util/model_tester.h"
 #include "test/util/include/scoped_env_vars.h"
 #include "contrib_ops/cpu/transformers/generation_shared.h"
+#include "contrib_ops/cpu/transformers/beam_search_parameters.h"
 
 #ifdef USE_CUDA
 #include "core/providers/cuda/cuda_provider_options.h"
@@ -20,6 +21,23 @@ extern std::unique_ptr<Ort::Env> ort_env;
 
 namespace onnxruntime {
 namespace test {
+
+TEST(BeamSearchParametersTest, SetSubgraphParametersRejectsMismatchedVocabSize) {
+  contrib::transformers::BeamSearchParameters parameters;
+  parameters.vocab_size = 64;
+
+  EXPECT_THROW(parameters.SetSubgraphParameters(128, 1, 1, 1), OnnxRuntimeException);
+}
+
+TEST(BeamSearchParametersTest, SetSubgraphParametersUsesSubgraphSizeWhenAttributeIsDefault) {
+  contrib::transformers::BeamSearchParameters parameters;
+  parameters.vocab_size = -1;
+
+  parameters.SetSubgraphParameters(128, 2, 4, 6);
+
+  EXPECT_EQ(parameters.vocab_size, 128);
+  EXPECT_EQ(parameters.num_heads, 2);
+}
 
 void RunGptBeamSearchFp32() {
   std::vector<int64_t> input_ids_shape{3, 12};

--- a/onnxruntime/test/contrib_ops/beam_search_test.cc
+++ b/onnxruntime/test/contrib_ops/beam_search_test.cc
@@ -22,11 +22,21 @@ extern std::unique_ptr<Ort::Env> ort_env;
 namespace onnxruntime {
 namespace test {
 
-TEST(BeamSearchParametersTest, SetSubgraphParametersRejectsMismatchedVocabSize) {
+TEST(BeamSearchParametersTest, SetSubgraphParametersRejectsOversizedVocabSize) {
+  contrib::transformers::BeamSearchParameters parameters;
+  parameters.vocab_size = 150;
+
+  EXPECT_THROW(parameters.SetSubgraphParameters(128, 1, 1, 1), OnnxRuntimeException);
+}
+
+TEST(BeamSearchParametersTest, SetSubgraphParametersAllowsPaddedVocabSize) {
   contrib::transformers::BeamSearchParameters parameters;
   parameters.vocab_size = 64;
 
-  EXPECT_THROW(parameters.SetSubgraphParameters(128, 1, 1, 1), OnnxRuntimeException);
+  parameters.SetSubgraphParameters(128, 2, 4, 6);
+
+  EXPECT_EQ(parameters.vocab_size, 64);
+  EXPECT_EQ(parameters.num_heads, 2);
 }
 
 TEST(BeamSearchParametersTest, SetSubgraphParametersUsesSubgraphSizeWhenAttributeIsDefault) {


### PR DESCRIPTION
## Summary

This PR hardens generation-path vocab-size handling by rejecting mismatches between the user-supplied `vocab_size` and the decoder logits width, instead of relying on unsafe span/copy logic.

## Key Changes

- Added session-time validation in the beam-search parameter setup path to reject explicit `vocab_size` values that do not match the decoder subgraph logits width.
- Added runtime validation in CPU and CUDA generation helpers before logits span/copy logic uses `vocab_size`.
- Added regression tests covering mismatch rejection and the default-size inference path.

## Why

A mismatched `vocab_size` could drive generation helpers to read or copy beyond the real logits width. These guards stop that class of out-of-bounds / DoS risk at both setup time and runtime.

## Testing

- `PATH=/home/tlwu/onnxruntime/.venv/bin:$PATH cmake --build . --target onnxruntime_provider_test -j2`
- `./onnxruntime_provider_test --gtest_filter='BeamSearchParametersTest.SetSubgraphParametersRejectsMismatchedVocabSize:BeamSearchTest.*:GreedySearchTest.*'`
