### PR TITLE
fix(ci): use subprocess for Triton compile helpers

### DIFF
--- a/tools/ci_build/compile_triton.py
+++ b/tools/ci_build/compile_triton.py
@@ -12,6 +12,13 @@ import subprocess
 import triton
 
 
+def _run_subprocess(command, out_dir, action, output_path):
+    try:
+        subprocess.run(command, cwd=out_dir, check=True)
+    except (subprocess.CalledProcessError, OSError) as exc:
+        raise RuntimeError(f"{action} failed for '{output_path}': {' '.join(command)}: {exc}") from exc
+
+
 def compile(function_table, out_dir):
     def compile_one(func, sig, **kwargs):
         ret = triton.compile(func, signature=sig, **kwargs)
@@ -61,28 +68,24 @@ def compile(function_table, out_dir):
 def convert_lib_to_obj(lib_file, out_dir):
     obj_file = lib_file.split(".")[0] + ".o"
     command = ["objcopy", "-I", "binary", "-O", "elf64-x86-64", "-B", "i386:x86-64", lib_file, obj_file]
+    output_path = os.path.join(out_dir, obj_file)
 
-    try:
-        subprocess.run(command, cwd=out_dir, check=True)
-    except subprocess.CalledProcessError as exc:
-        raise RuntimeError(f"exec convert command: {' '.join(command)} failed.") from exc
+    _run_subprocess(command, out_dir, "objcopy", output_path)
 
-    if not os.path.exists(os.path.join(out_dir, obj_file)):
-        raise RuntimeError(f"the output file not exist, after exec comamnd: {' '.join(command)}")
+    if not os.path.exists(output_path):
+        raise RuntimeError(f"objcopy did not create the expected output file '{output_path}'.")
 
     return obj_file
 
 
 def archive_obj_files(obj_files, out_dir, out_obj_file):
     command = ["ar", "rcs", out_obj_file, *obj_files]
+    output_path = os.path.join(out_dir, out_obj_file)
 
-    try:
-        subprocess.run(command, cwd=out_dir, check=True)
-    except subprocess.CalledProcessError as exc:
-        raise RuntimeError(f"exec convert command: {' '.join(command)} failed.") from exc
+    _run_subprocess(command, out_dir, "ar", output_path)
 
-    if not os.path.exists(os.path.join(out_dir, out_obj_file)):
-        raise RuntimeError(f"the output file not exist, after exec comamnd: {' '.join(command)}")
+    if not os.path.exists(output_path):
+        raise RuntimeError(f"ar did not create the expected output archive '{output_path}'.")
 
 
 def convert_and_save(metadata, header_file, out_dir, out_obj_file):

--- a/tools/ci_build/compile_triton.py
+++ b/tools/ci_build/compile_triton.py
@@ -7,6 +7,7 @@ import argparse
 import importlib.util
 import os
 import shutil
+import subprocess
 
 import triton
 
@@ -59,28 +60,29 @@ def compile(function_table, out_dir):
 
 def convert_lib_to_obj(lib_file, out_dir):
     obj_file = lib_file.split(".")[0] + ".o"
-    command = f"cd {out_dir}; objcopy -I binary -O elf64-x86-64 -B i386:x86-64 {lib_file} {obj_file}; cd -"
-    ret = os.system(command)
+    command = ["objcopy", "-I", "binary", "-O", "elf64-x86-64", "-B", "i386:x86-64", lib_file, obj_file]
 
-    if ret != 0:
-        raise Exception(f"exec convert command: {command} failed.")
-    # check file exist
-    if not os.path.exists(f"{out_dir}/{obj_file}"):
-        raise Exception(f"the output file not exist, after exec comamnd: {command}")
+    try:
+        subprocess.run(command, cwd=out_dir, check=True)
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError(f"exec convert command: {' '.join(command)} failed.") from exc
+
+    if not os.path.exists(os.path.join(out_dir, obj_file)):
+        raise RuntimeError(f"the output file not exist, after exec comamnd: {' '.join(command)}")
 
     return obj_file
 
 
 def archive_obj_files(obj_files, out_dir, out_obj_file):
-    obj_files = " ".join(obj_files)
-    command = f"cd {out_dir}; ar rcs {out_obj_file} {obj_files}; cd -"
-    ret = os.system(command)
+    command = ["ar", "rcs", out_obj_file, *obj_files]
 
-    if ret != 0:
-        raise Exception(f"exec convert command: {command} failed.")
-    # check file exist
-    if not os.path.exists(f"{out_dir}/{out_obj_file}"):
-        raise Exception(f"the output file not exist, after exec comamnd: {command}")
+    try:
+        subprocess.run(command, cwd=out_dir, check=True)
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError(f"exec convert command: {' '.join(command)} failed.") from exc
+
+    if not os.path.exists(os.path.join(out_dir, out_obj_file)):
+        raise RuntimeError(f"the output file not exist, after exec comamnd: {' '.join(command)}")
 
 
 def convert_and_save(metadata, header_file, out_dir, out_obj_file):
@@ -133,10 +135,10 @@ const _TritonKernelInfo kernel_infos[] = {{
 
 def main(args):
     out_obj_file = args.obj_file
-    out_dir = os.path.dirname(out_obj_file)
+    out_dir = os.path.dirname(out_obj_file) or "."
     out_obj_file = os.path.basename(out_obj_file)
     if not os.path.exists(out_dir):
-        os.mkdir(out_dir)
+        os.makedirs(out_dir, exist_ok=True)
 
     metadata = []
     print("[triton kernel] start compile triton kernel.")

--- a/tools/ci_build/test_compile_triton.py
+++ b/tools/ci_build/test_compile_triton.py
@@ -4,7 +4,6 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
-from unittest import mock
 
 MODULE_PATH = Path(__file__).with_name("compile_triton.py")
 
@@ -29,8 +28,8 @@ class CompileTritonCommandExecutionTest(unittest.TestCase):
             Path(tmp_dir, obj_file).write_text("", encoding="utf-8")
 
             with (
-                mock.patch.object(self.module.os, "system", return_value=0) as mock_system,
-                mock.patch(
+                unittest.mock.patch.object(self.module.os, "system", return_value=0) as mock_system,
+                unittest.mock.patch(
                     "subprocess.run", return_value=subprocess.CompletedProcess(args=[], returncode=0)
                 ) as mock_run,
             ):
@@ -56,8 +55,8 @@ class CompileTritonCommandExecutionTest(unittest.TestCase):
                 Path(tmp_dir, name).write_text("", encoding="utf-8")
 
             with (
-                mock.patch.object(self.module.os, "system", return_value=0) as mock_system,
-                mock.patch(
+                unittest.mock.patch.object(self.module.os, "system", return_value=0) as mock_system,
+                unittest.mock.patch(
                     "subprocess.run", return_value=subprocess.CompletedProcess(args=[], returncode=0)
                 ) as mock_run,
             ):

--- a/tools/ci_build/test_compile_triton.py
+++ b/tools/ci_build/test_compile_triton.py
@@ -1,0 +1,76 @@
+import importlib.util
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+MODULE_PATH = Path(__file__).with_name("compile_triton.py")
+
+
+def load_compile_triton_module():
+    spec = importlib.util.spec_from_file_location("compile_triton_under_test", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class CompileTritonCommandExecutionTest(unittest.TestCase):
+    def setUp(self):
+        self.module = load_compile_triton_module()
+
+    def test_convert_lib_to_obj_uses_subprocess_run(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            lib_file = "kernel.cubin"
+            obj_file = "kernel.o"
+            Path(tmp_dir, lib_file).write_text("binary-data", encoding="utf-8")
+            Path(tmp_dir, obj_file).write_text("", encoding="utf-8")
+
+            with (
+                mock.patch.object(self.module.os, "system", return_value=0) as mock_system,
+                mock.patch(
+                    "subprocess.run", return_value=subprocess.CompletedProcess(args=[], returncode=0)
+                ) as mock_run,
+            ):
+                result = self.module.convert_lib_to_obj(lib_file, tmp_dir)
+
+            self.assertEqual(result, obj_file)
+            mock_system.assert_not_called()
+            mock_run.assert_called_once()
+            command = mock_run.call_args.args[0]
+            kwargs = mock_run.call_args.kwargs
+            self.assertEqual(
+                command,
+                ["objcopy", "-I", "binary", "-O", "elf64-x86-64", "-B", "i386:x86-64", lib_file, obj_file],
+            )
+            self.assertEqual(kwargs["cwd"], tmp_dir)
+            self.assertTrue(kwargs["check"])
+
+    def test_archive_obj_files_uses_subprocess_run(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            out_obj_file = "triton_kernel.a"
+            obj_files = ["kernel_0.o", "kernel_1.o"]
+            for name in [*obj_files, out_obj_file]:
+                Path(tmp_dir, name).write_text("", encoding="utf-8")
+
+            with (
+                mock.patch.object(self.module.os, "system", return_value=0) as mock_system,
+                mock.patch(
+                    "subprocess.run", return_value=subprocess.CompletedProcess(args=[], returncode=0)
+                ) as mock_run,
+            ):
+                self.module.archive_obj_files(obj_files, tmp_dir, out_obj_file)
+
+            mock_system.assert_not_called()
+            mock_run.assert_called_once()
+            command = mock_run.call_args.args[0]
+            kwargs = mock_run.call_args.kwargs
+            self.assertEqual(command, ["ar", "rcs", out_obj_file, *obj_files])
+            self.assertEqual(kwargs["cwd"], tmp_dir)
+            self.assertTrue(kwargs["check"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/ci_build/test_compile_triton.py
+++ b/tools/ci_build/test_compile_triton.py
@@ -2,17 +2,21 @@ import importlib.util
 import subprocess
 import sys
 import tempfile
+import types
 import unittest
+import unittest.mock
 from pathlib import Path
 
 MODULE_PATH = Path(__file__).with_name("compile_triton.py")
 
 
 def load_compile_triton_module():
-    spec = importlib.util.spec_from_file_location("compile_triton_under_test", MODULE_PATH)
-    module = importlib.util.module_from_spec(spec)
-    sys.modules[spec.name] = module
-    spec.loader.exec_module(module)
+    fake_triton = types.SimpleNamespace()
+    with unittest.mock.patch.dict(sys.modules, {"triton": fake_triton}):
+        spec = importlib.util.spec_from_file_location("compile_triton_under_test", MODULE_PATH)
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
     return module
 
 
@@ -69,6 +73,38 @@ class CompileTritonCommandExecutionTest(unittest.TestCase):
             self.assertEqual(command, ["ar", "rcs", out_obj_file, *obj_files])
             self.assertEqual(kwargs["cwd"], tmp_dir)
             self.assertTrue(kwargs["check"])
+
+    def test_convert_lib_to_obj_surfaces_subprocess_errors(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            lib_file = "kernel.cubin"
+            Path(tmp_dir, lib_file).write_text("binary-data", encoding="utf-8")
+
+            with (
+                unittest.mock.patch(
+                    "subprocess.run",
+                    side_effect=subprocess.CalledProcessError(1, ["objcopy"]),
+                ) as mock_run,
+                self.assertRaisesRegex(RuntimeError, "objcopy.*kernel.o"),
+            ):
+                self.module.convert_lib_to_obj(lib_file, tmp_dir)
+
+            mock_run.assert_called_once()
+
+    def test_archive_obj_files_surfaces_os_errors(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            out_obj_file = "triton_kernel.a"
+            obj_files = ["kernel_0.o", "kernel_1.o"]
+
+            with (
+                unittest.mock.patch(
+                    "subprocess.run",
+                    side_effect=FileNotFoundError("ar not found"),
+                ) as mock_run,
+                self.assertRaisesRegex(RuntimeError, "ar.*ar not found"),
+            ):
+                self.module.archive_obj_files(obj_files, tmp_dir, out_obj_file)
+
+            mock_run.assert_called_once()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

This PR replaces shell-based command execution in the Triton compile helper with `subprocess.run()`, and adds regression tests to lock in that behavior.

## Key Changes

- Switched `tools/ci_build/compile_triton.py` to use `subprocess.run()` for `objcopy` and `ar` execution instead of `os.system()`.
- Added `tools/ci_build/test_compile_triton.py` to verify the helper functions invoke subprocess-based command execution and preserve the expected working directory and error handling.
- Hardened directory handling in the Triton compile path so the output directory is created safely with `os.makedirs(..., exist_ok=True)`.

## Why

The previous shell-based implementation was fragile and harder to test. Using `subprocess.run()` makes the command execution path explicit, easier to validate, and safer for CI and cross-platform invocation.

## Testing

- `source .venv/bin/activate && python -m unittest tools.ci_build.test_compile_triton`
- `source .venv/bin/activate && lintrunner -a`
