### PR TITLE
Hint GCC >= 12 on aarch64 for bf16/fp16 capability probes

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -673,20 +673,19 @@ else()
   endif()
   check_function_exists(reallocarray HAS_REALLOCARRAY)
   if (NOT APPLE AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten" AND onnxruntime_target_platform STREQUAL "aarch64")
-   # GCC < 12 on aarch64 ships with an assembler that does not accept the
-   # `+bf16` / `+fp16` architecture extensions used below, producing a cryptic
-   # "compiler doesn't support BFLOAT16" failure during the capability probe.
-   # See microsoft/onnxruntime#22837.
-   if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" AND CMAKE_C_COMPILER_VERSION VERSION_LESS 12)
-     message(FATAL_ERROR "GCC >= 12 is required for aarch64 BFloat16/Float16 support. Found GCC ${CMAKE_C_COMPILER_VERSION}.")
-   endif()
    check_cxx_compiler_flag(-march=armv8.2-a+bf16 HAS_ARM64_BFLOAT16)
    if(NOT HAS_ARM64_BFLOAT16)
-     message(FATAL_ERROR  "The compiler doesn't support BFLOAT16!!!")
+     message(FATAL_ERROR "The compiler/assembler does not support the aarch64 +bf16 ISA extension. "
+       "On aarch64 this typically requires GCC >= 12 paired with a sufficiently recent binutils "
+       "(the capability is gated by the assembler, not the compiler alone). "
+       "See https://github.com/microsoft/onnxruntime/issues/22837 for details.")
    endif()
    check_cxx_compiler_flag(-march=armv8.2-a+fp16 HAS_ARM64_FLOAT16)
    if(NOT HAS_ARM64_FLOAT16)
-     message(FATAL_ERROR  "The compiler doesn't support FLOAT16!!!")
+     message(FATAL_ERROR "The compiler/assembler does not support the aarch64 +fp16 ISA extension. "
+       "On aarch64 this typically requires GCC >= 12 paired with a sufficiently recent binutils "
+       "(the capability is gated by the assembler, not the compiler alone). "
+       "See https://github.com/microsoft/onnxruntime/issues/22837 for details.")
    endif()
   endif()
 

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -673,6 +673,13 @@ else()
   endif()
   check_function_exists(reallocarray HAS_REALLOCARRAY)
   if (NOT APPLE AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten" AND onnxruntime_target_platform STREQUAL "aarch64")
+   # GCC < 12 on aarch64 ships with an assembler that does not accept the
+   # `+bf16` / `+fp16` architecture extensions used below, producing a cryptic
+   # "compiler doesn't support BFLOAT16" failure during the capability probe.
+   # See microsoft/onnxruntime#22837.
+   if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" AND CMAKE_C_COMPILER_VERSION VERSION_LESS 12)
+     message(FATAL_ERROR "GCC >= 12 is required for aarch64 BFloat16/Float16 support. Found GCC ${CMAKE_C_COMPILER_VERSION}.")
+   endif()
    check_cxx_compiler_flag(-march=armv8.2-a+bf16 HAS_ARM64_BFLOAT16)
    if(NOT HAS_ARM64_BFLOAT16)
      message(FATAL_ERROR  "The compiler doesn't support BFLOAT16!!!")


### PR DESCRIPTION
## Summary
- Adds an explicit, aarch64-scoped `GCC >= 12` guard immediately before the existing `-march=armv8.2-a+bf16` / `-march=armv8.2-a+fp16` `check_cxx_compiler_flag` probes in `cmake/CMakeLists.txt`.
- The new guard fires with an actionable `FATAL_ERROR` that names the required compiler version and the version that was detected.
- No change to the global GCC 11.1 minimum, and no impact on x86_64, Apple, Emscripten, MSVC, or Clang builds.

## Motivation
On aarch64, GCC versions prior to 12 ship with an assembler that does not accept the `+bf16` / `+fp16` architecture extensions. The existing capability probes therefore fail at configure time with the opaque message `The compiler doesn't support BFLOAT16!!!`, leaving users to guess that a newer toolchain (not just a newer compiler) is required. This is the exact scenario reported on RHEL 9 / GCC 11.

Fixes #22837

## Changes
- `cmake/CMakeLists.txt`: inside the existing `if (NOT APPLE AND NOT Emscripten AND onnxruntime_target_platform STREQUAL "aarch64")` block, add a `CMAKE_C_COMPILER_ID STREQUAL "GNU" AND CMAKE_C_COMPILER_VERSION VERSION_LESS 12` check that emits a descriptive `FATAL_ERROR` naming the required GCC version and the detected version.

## Test Plan
- This is a CMake-only configure-time change; no runtime tests are affected.
- Verified `lintrunner -a` reports no issues on the changed file.
- Existing CI `linux-aarch64` build jobs exercise the unchanged code path on a supported toolchain.
- Manual verification: configuring on aarch64 with GCC < 12 now fails at CMake time with `GCC >= 12 is required for aarch64 BFloat16/Float16 support. Found GCC <version>.`, instead of the previous cryptic `The compiler doesn't support BFLOAT16!!!`.