### PR TITLE
Add session.qdq_strip_activations option for QDQ models

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
+++ b/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
@@ -66,6 +66,15 @@ static const char* const kOrtSessionOptionsDisableQDQConstantFolding =
 // Its default value is "0"
 static const char* const kOrtSessionOptionsDisableDoubleQDQRemover = "session.disable_double_qdq_remover";
 
+// If set to "1", strips activation Q->DQ pairs from QDQ models after compute-op fusions
+// (QLinearMatMul, QLinearConv, etc.) have been applied. This skips QDQ fusion for data-movement ops
+// (Reshape, Transpose, etc.) and removes all remaining activation Q->DQ pairs, allowing unfused ops to
+// run in float precision while preserving quantized compute where fused kernels are available. Also
+// enables DQ -> MatMul/Gemm -> MatMulNBits fusion for patterns that become eligible after activation
+// Q/DQ removal, and constant-folds any remaining weight DQ nodes into float initializers.
+// The default value is "0"
+static const char* const kOrtSessionOptionsQDQStripActivations = "session.qdq_strip_activations";
+
 // If set to "1", enables the removal of QuantizeLinear/DequantizeLinear node pairs once all QDQ handling has been
 // completed. e.g. If after all QDQ handling has completed and we have -> FloatOp -> Q -> DQ -> FloatOp -> the
 // Q -> DQ could potentially be removed. This will provide a performance benefit by avoiding going from float to

--- a/onnxruntime/core/optimizer/graph_transformer_utils.cc
+++ b/onnxruntime/core/optimizer/graph_transformer_utils.cc
@@ -11,6 +11,7 @@
 #include "core/optimizer/matmul_nbits_fusion.h"
 #include "core/optimizer/nhwc_transformer.h"
 #include "core/optimizer/qdq_transformer/qdq_final_cleanup.h"
+#include "core/optimizer/qdq_transformer/qdq_strip_activations_transformer.h"
 #include "core/optimizer/qdq_transformer/selectors_actions/qdq_selector_action_transformer.h"
 #include "core/optimizer/selectors_actions/selector_action_transformer_apply_contexts.h"
 #include "core/session/onnxruntime_session_options_config_keys.h"
@@ -328,6 +329,8 @@ InlinedVector<std::unique_ptr<GraphTransformer>> GenerateTransformers(
 
       const bool enable_quant_qdq_cleanup =
           session_options.config_options.GetConfigOrDefault(kOrtSessionOptionsEnableQuantQDQCleanup, "0") == "1";
+      const bool qdq_strip_activations =
+          session_options.config_options.GetConfigOrDefault(kOrtSessionOptionsQDQStripActivations, "0") == "1";
 #if !defined(DISABLE_CONTRIB_OPS)
       const bool qdq_is_int8_allowed =
           session_options.config_options.GetConfigOrDefault(kOrtSessionOptionsQDQIsInt8Allowed,
@@ -389,7 +392,8 @@ InlinedVector<std::unique_ptr<GraphTransformer>> GenerateTransformers(
                                                                                  SatApplyContextVariant{},
                                                                                  qdq_matmulnbits_accuracy_level,
                                                                                  intra_op_thread_pool,
-                                                                                 qdq_matmulnbits_block_size));
+                                                                                 qdq_matmulnbits_block_size,
+                                                                                 qdq_strip_activations));
       }
 
       transformers.emplace_back(std::make_unique<GemmActivationFusion>(cpu_ep));
@@ -455,6 +459,14 @@ InlinedVector<std::unique_ptr<GraphTransformer>> GenerateTransformers(
           InlinedHashSet<std::string_view>{onnxruntime::kWebGpuExecutionProvider}));
       transformers.emplace_back(std::make_unique<MatMulNBitsQkvFusion>(
           InlinedHashSet<std::string_view>{onnxruntime::kWebGpuExecutionProvider}));
+
+      if (qdq_strip_activations) {
+        transformers.emplace_back(std::make_unique<QDQStripActivationsTransformer>(qdq_matmulnbits_accuracy_level,
+                                                                                   intra_op_thread_pool,
+                                                                                   cpu_execution_provider,
+                                                                                   session_options.config_options,
+                                                                                   qdq_matmulnbits_block_size));
+      }
 
 #endif  // !defined(DISABLE_CONTRIB_OPS)
       // The QDQFinalCleanupTransformer must run AFTER other transformers that fuse Q/DQ nodes. Otherwise, their

--- a/onnxruntime/core/optimizer/qdq_transformer/qdq_strip_activations_transformer.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/qdq_strip_activations_transformer.cc
@@ -1,0 +1,217 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/optimizer/qdq_transformer/qdq_strip_activations_transformer.h"
+
+#include <vector>
+
+#include "core/graph/constants.h"
+#include "core/graph/graph_utils.h"
+#include "core/graph/graph_viewer.h"
+#include "core/optimizer/constant_folding.h"
+#include "core/optimizer/qdq_transformer/qdq_util.h"
+
+#if !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
+#include "core/optimizer/qdq_transformer/selectors_actions/qdq_actions.h"
+#include "core/optimizer/qdq_transformer/selectors_actions/qdq_selectors.h"
+#include "core/optimizer/selectors_actions/helpers.h"
+#endif
+
+namespace onnxruntime {
+
+namespace {
+
+// Remove a Q->DQ pair by bypassing both nodes and connecting Q's input source directly to DQ's downstream
+// consumers. Handles graph outputs. Returns true if the pair was removed.
+// This handles Q -> multiple DQ (each DQ with single consumer), following the pattern in qdq_final_cleanup.cc.
+bool RemoveQDQPair(Graph& graph, Node& q_node, const logging::Logger& logger) {
+  if (!QDQ::MatchQNode(q_node) || q_node.GetOutputEdgesCount() < 1) {
+    return false;
+  }
+
+  // Collect all DQ consumers of Q.
+  std::vector<Node*> dq_nodes;
+  for (auto it = q_node.OutputNodesBegin(); it != q_node.OutputNodesEnd(); ++it) {
+    dq_nodes.push_back(graph.GetNode(it->Index()));
+  }
+
+  const auto get_constant_initializer = [&graph](const std::string& initializer_name) {
+    return graph.GetConstantInitializer(initializer_name, true);
+  };
+
+  // Validate: ALL consumers must be DQ nodes with matching scale/zp, each with <= 1 non-graph-output consumer.
+  for (auto* dq_node : dq_nodes) {
+    if (dq_node == nullptr || !QDQ::MatchDQNode(*dq_node)) {
+      return false;
+    }
+
+    if (!QDQ::IsQDQPairSupported(graph, q_node, *dq_node, get_constant_initializer,
+                                 graph.ModelPath(), false)) {
+      return false;
+    }
+
+    const bool produces_graph_output = graph.NodeProducesGraphOutput(*dq_node);
+    const auto output_edges_count = dq_node->GetOutputEdgesCount();
+
+    // DQ must have exactly 1 consumer, or be a graph output with no consumers.
+    if (produces_graph_output && output_edges_count != 0) {
+      return false;
+    }
+    if (!produces_graph_output && output_edges_count != 1) {
+      return false;
+    }
+  }
+
+  LOGS(logger, VERBOSE) << "QDQStripActivationsTransformer: removing Q node \"" << q_node.Name()
+                        << "\" with " << dq_nodes.size() << " DQ consumer(s)";
+
+  // Get Q's input edge info (source node or initializer/graph input) and remove the src->Q edge upfront,
+  // before processing DQ nodes. This must happen before any modifications to src_node.output_defs
+  // (e.g., in the graph-output case) which would cause a NodeArg mismatch in RemoveEdge.
+  NodeIndex src_node_idx = 0;
+  int src_arg_idx = -1;
+  if (q_node.GetInputEdgesCount() == 1) {
+    const Node::EdgeEnd& input_edge = *q_node.InputEdgesBegin();
+    src_node_idx = input_edge.GetNode().Index();
+    src_arg_idx = input_edge.GetSrcArgIndex();
+    graph.RemoveEdge(src_node_idx, q_node.Index(), src_arg_idx, 0);
+  }
+
+  // Process each DQ node.
+  for (auto* dq_node_ptr : dq_nodes) {
+    Node& dq_node = *dq_node_ptr;
+    const bool produces_graph_output = graph.NodeProducesGraphOutput(dq_node);
+
+    // Remove edge: Q -> DQ.
+    graph.RemoveEdge(q_node.Index(), dq_node.Index(), 0, 0);
+
+    if (!produces_graph_output) {
+      // Get downstream consumer of DQ.
+      const Node::EdgeEnd& output_edge = *dq_node.OutputEdgesBegin();
+      NodeIndex downstream_idx = output_edge.GetNode().Index();
+      int downstream_arg_idx = output_edge.GetDstArgIndex();
+
+      // Remove edge: DQ -> downstream.
+      graph.RemoveEdge(dq_node.Index(), downstream_idx, 0, downstream_arg_idx);
+
+      // Rewire: downstream now gets Q's input.
+      Node& downstream_node = *graph.GetNode(downstream_idx);
+      downstream_node.MutableInputDefs()[downstream_arg_idx] = q_node.MutableInputDefs()[0];
+
+      // Add edge from Q's source to downstream (if Q's input came from a node).
+      if (src_arg_idx >= 0) {
+        graph.AddEdge(src_node_idx, downstream_idx, src_arg_idx, downstream_arg_idx);
+      }
+    } else {
+      // DQ produces a graph output.
+      NodeArg* graph_output_nodearg = dq_node.MutableOutputDefs()[0];
+      if (src_arg_idx >= 0 && dq_nodes.size() == 1) {
+        // Update source node to produce the graph output.
+        Node& src_node = *graph.GetNode(src_node_idx);
+        src_node.MutableOutputDefs()[src_arg_idx] = graph_output_nodearg;
+      } else {
+        // Add Identity to connect graph input/initializer to graph output.
+        Node& id_node = graph.AddNode(graph.GenerateNodeName("QDQStripActivationsTransformer"),
+                                      "Identity", "", {q_node.MutableInputDefs()[0]}, {graph_output_nodearg});
+        id_node.SetExecutionProviderType(dq_node.GetExecutionProviderType());
+      }
+    }
+
+    graph.RemoveNode(dq_node.Index());
+  }
+
+  // Q node has no edges remaining (src->Q removed upfront, Q->DQ removed in loop).
+  graph.RemoveNode(q_node.Index());
+
+  return true;
+}
+
+}  // namespace
+
+Status QDQStripActivationsTransformer::ApplyImpl(Graph& graph, bool& modified, int graph_level,
+                                                 const logging::Logger& logger) const {
+  GraphViewer graph_viewer(graph);
+  const auto& node_topology_list = graph_viewer.GetNodesInTopologicalOrder();
+
+  // Sub-pass A: Remove all adjacent Q->DQ pairs.
+  for (auto node_index : node_topology_list) {
+    auto* node_ptr = graph.GetNode(node_index);
+    if (node_ptr == nullptr) {
+      continue;
+    }
+
+    ORT_RETURN_IF_ERROR(Recurse(*node_ptr, modified, graph_level, logger));
+
+    if (QDQ::MatchQNode(*node_ptr)) {
+      if (RemoveQDQPair(graph, *node_ptr, logger)) {
+        modified = true;
+      }
+    }
+  }
+
+#if !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
+  // Sub-pass B: MatMulNBits fusion for newly eligible patterns.
+  // After Q->DQ removal, DQ -> MatMul / Gemm patterns may now be eligible.
+  // Re-get topological order since graph was modified.
+  if (modified) {
+    // Resolve graph after sub-pass A modifications so selectors/actions see consistent type/shape info.
+    ORT_RETURN_IF_ERROR(graph.Resolve());
+
+    GraphViewer updated_viewer(graph);
+    const auto& updated_topology = updated_viewer.GetNodesInTopologicalOrder();
+
+    // Use the same EP list as DQMatMulToMatMulNBitsRules in QDQSelectorActionTransformer.
+    std::vector<const char*> compatible_eps = {kCpuExecutionProvider, kCudaExecutionProvider,
+                                               kDmlExecutionProvider, ""};
+    QDQ::DQMatMulToMatMulNBitsSelector dq_matmul_selector(compatible_eps);
+    QDQ::DQMatMulToMatMulNBitsAction dq_matmul_action(qdq_matmulnbits_accuracy_level_,
+                                                      intra_op_thread_pool_,
+                                                      qdq_matmulnbits_block_size_);
+
+    // Safe to iterate a snapshot of node indices while mutating: removed nodes return nullptr (skipped
+    // below), and new MatMulNBits nodes aren't in the original list. The selectors only inspect node
+    // neighbors, not the viewer's cached topological order.
+    for (auto node_index : updated_topology) {
+      auto* node_ptr = graph.GetNode(node_index);
+      if (node_ptr == nullptr || (node_ptr->OpType() != "MatMul" && node_ptr->OpType() != "Gemm")) {
+        continue;
+      }
+
+      auto selection = dq_matmul_selector.Select(updated_viewer, *node_ptr);
+      if (selection.has_value()) {
+        NodesToOptimize nto(graph, *selection);
+        if (nto.IsValid()) {
+          auto status = dq_matmul_action.Run(graph, nto);
+          if (status.IsOK()) {
+            modified = true;
+            continue;
+          }
+          LOGS(logger, WARNING) << "QDQStripActivationsTransformer: DQMatMulToMatMulNBits action failed: "
+                                << status.ErrorMessage();
+        }
+      }
+    }
+  }
+#endif  // !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
+
+  // Sub-pass C: Constant-fold remaining weight DQ nodes.
+  // After activation Q->DQ removal, weight DQ nodes on constant initializers can be folded into float
+  // tensors so ops run directly on float weights.
+  if (modified) {
+    // Resolve graph first: sub-passes A and B may have added new nodes (Identity, MatMulNBits) whose
+    // Op() schemas are not yet set. ConstantFolding calls UpdateShapeInference which dereferences
+    // node.Op() — this would crash on unresolved nodes.
+    ORT_RETURN_IF_ERROR(graph.Resolve());
+
+    ConstantFolding constant_folding(cpu_execution_provider_,
+                                     /*skip_dequantize_linear=*/false,
+                                     config_options_);
+    bool cf_modified = false;
+    ORT_RETURN_IF_ERROR(constant_folding.Apply(graph, cf_modified, logger));
+    modified |= cf_modified;
+  }
+
+  return Status::OK();
+}
+
+}  // namespace onnxruntime

--- a/onnxruntime/core/optimizer/qdq_transformer/qdq_strip_activations_transformer.h
+++ b/onnxruntime/core/optimizer/qdq_transformer/qdq_strip_activations_transformer.h
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/common/common.h"
+#include "core/framework/execution_provider.h"
+#include "core/optimizer/graph_transformer.h"
+#include "core/platform/threadpool.h"
+#include "core/session/onnxruntime_session_options_config_keys.h"
+
+namespace onnxruntime {
+
+/**
+@Class QDQStripActivationsTransformer
+
+Strips activation Q->DQ pairs left over after compute-op QDQ fusions (e.g., QLinearMatMul,
+QLinearConv) have been applied by QDQSelectorActionTransformer.
+
+The activations themselves were never stored in quantized form — the Q->DQ wrappers are an
+authoring artifact of QDQ models. Removing them lets unfused ops run in float precision while
+preserving quantized compute where fused kernels are available.
+
+This is intended for fully QDQ models where we want unfused ops to run in float precision.
+It works best when DropQDQNodesRules/SplitQDQRules are skipped (via
+session.qdq_strip_activations="1"), so that data-movement ops keep their Q/DQ wrappers, making
+all Q->DQ pairs directly adjacent.
+
+Sub-passes:
+  A) Remove all adjacent Q->DQ pairs where all of Q's consumers are DQ nodes with matching
+     scale/zp, and each such DQ has exactly one output edge (unless that edge goes directly
+     to a graph output).
+  B) Fuse newly eligible DQ -> MatMul / Gemm patterns into MatMulNBits.
+  C) Constant-fold remaining weight DQ nodes on constant initializers into float tensors.
+*/
+class QDQStripActivationsTransformer : public GraphTransformer {
+ public:
+  QDQStripActivationsTransformer(int64_t qdq_matmulnbits_accuracy_level,
+                                 concurrency::ThreadPool* intra_op_thread_pool,
+                                 const IExecutionProvider& cpu_execution_provider,
+                                 const ConfigOptions& config_options,
+                                 int64_t qdq_matmulnbits_block_size = 0)
+      : GraphTransformer("QDQStripActivationsTransformer"),
+        qdq_matmulnbits_accuracy_level_(qdq_matmulnbits_accuracy_level),
+        intra_op_thread_pool_(intra_op_thread_pool),
+        cpu_execution_provider_(cpu_execution_provider),
+        config_options_(config_options),
+        qdq_matmulnbits_block_size_(qdq_matmulnbits_block_size) {}
+
+ private:
+  Status ApplyImpl(Graph& graph, bool& modified, int graph_level,
+                   const logging::Logger& logger) const override;
+
+  int64_t qdq_matmulnbits_accuracy_level_;
+  concurrency::ThreadPool* intra_op_thread_pool_;
+  const IExecutionProvider& cpu_execution_provider_;
+  const ConfigOptions& config_options_;
+  int64_t qdq_matmulnbits_block_size_;
+};
+
+}  // namespace onnxruntime

--- a/onnxruntime/core/optimizer/qdq_transformer/selectors_actions/qdq_selector_action_transformer.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/selectors_actions/qdq_selector_action_transformer.cc
@@ -376,10 +376,16 @@ SelectorActionRegistry CreateSelectorActionRegistry(
     bool is_int8_allowed,
     int64_t qdq_matmulnbits_accuracy_level,
     concurrency::ThreadPool* intra_op_thread_pool,
-    int64_t qdq_matmulnbits_block_size) {
+    int64_t qdq_matmulnbits_block_size,
+    bool skip_data_movement_qdq_rules) {
   SelectorActionRegistry qdq_selector_action_registry;
-  SplitQDQRules(qdq_selector_action_registry);
-  DropQDQNodesRules(qdq_selector_action_registry);
+  // Data-movement QDQ rules (Split, Reshape/Transpose/Squeeze/... drop) are skipped when the caller
+  // intends to strip activation Q/DQ later: keeping the Q/DQ wrappers around data-movement ops
+  // ensures all remaining Q->DQ pairs are directly adjacent and removable in one pass.
+  if (!skip_data_movement_qdq_rules) {
+    SplitQDQRules(qdq_selector_action_registry);
+    DropQDQNodesRules(qdq_selector_action_registry);
+  }
   DropDQNodesRules(qdq_selector_action_registry);
   UnaryOpQDQRules(qdq_selector_action_registry);
   BinaryOpQDQRules(qdq_selector_action_registry);
@@ -403,12 +409,14 @@ QDQSelectorActionTransformer::QDQSelectorActionTransformer(
     const SatApplyContextVariant& apply_context,
     int64_t qdq_matmulnbits_accuracy_level,
     concurrency::ThreadPool* intra_op_thread_pool,
-    int64_t qdq_matmulnbits_block_size)
+    int64_t qdq_matmulnbits_block_size,
+    bool skip_data_movement_qdq_rules)
     : SelectorActionTransformer{
           "QDQSelectorActionTransformer",
           CreateSelectorActionRegistry(is_int8_allowed, qdq_matmulnbits_accuracy_level,
                                        intra_op_thread_pool,
-                                       qdq_matmulnbits_block_size),
+                                       qdq_matmulnbits_block_size,
+                                       skip_data_movement_qdq_rules),
           apply_context,
           // this transformer is compatible with CPU, DML, ACL and CUDA EP.
           // There is further EP control on the rule level.

--- a/onnxruntime/core/optimizer/qdq_transformer/selectors_actions/qdq_selector_action_transformer.h
+++ b/onnxruntime/core/optimizer/qdq_transformer/selectors_actions/qdq_selector_action_transformer.h
@@ -30,7 +30,8 @@ class QDQSelectorActionTransformer : public SelectorActionTransformer {
                                const SatApplyContextVariant& apply_context = {},
                                int64_t qdq_matmulnbits_accuracy_level = 4,
                                concurrency::ThreadPool* intra_op_thread_pool = nullptr,
-                               int64_t qdq_matmulnbits_block_size = 0);
+                               int64_t qdq_matmulnbits_block_size = 0,
+                               bool skip_data_movement_qdq_rules = false);
 };
 
 }  // namespace onnxruntime

--- a/onnxruntime/test/optimizer/qdq_strip_activations_transformer_test.cc
+++ b/onnxruntime/test/optimizer/qdq_strip_activations_transformer_test.cc
@@ -1,0 +1,611 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/framework/int4.h"
+#include "core/graph/model.h"
+#include "core/graph/node_attr_utils.h"
+#include "core/optimizer/qdq_transformer/qdq_strip_activations_transformer.h"
+#include "core/optimizer/qdq_transformer/selectors_actions/qdq_selector_action_transformer.h"
+#include "core/session/onnxruntime_session_options_config_keys.h"
+
+#include "test/test_environment.h"
+#include "test/unittest_util/framework_test_utils.h"
+#include "test/util/include/asserts.h"
+#include "test/util/include/inference_session_wrapper.h"
+
+#include "gtest/gtest.h"
+#include "test/unittest_util/graph_transform_test_builder.h"
+#include "test/unittest_util/qdq_test_utils.h"
+
+#if !defined(DISABLE_CONTRIB_OPS)
+
+namespace onnxruntime {
+namespace test {
+
+// Use scale=0.008 with zp=128 for uint8 to cover the [-1, 1] input range without clipping.
+// Range: [-128*0.008, 127*0.008] = [-1.024, 1.016]. Max rounding error = 0.004.
+constexpr float kTestScale = 0.008f;
+constexpr uint8_t kTestZp = 128;
+constexpr float kTestTolerance = 0.005f;
+
+// For int8: scale=0.008, zp=0 covers [-128*0.008, 127*0.008] = [-1.024, 1.016]
+constexpr int8_t kTestZpInt8 = 0;
+
+// Test: Simple Q->DQ pair removed by QDQStripActivationsTransformer
+// Graph: Input -> Q -> DQ -> Relu -> Output
+// Expected: Input -> Relu -> Output (Q and DQ removed)
+TEST(QDQStripActivationsTransformerTests, RemoveSimpleQDQPair) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    auto* input_arg = builder.MakeInput<float>({1, 4, 8}, -1.f, 1.f);
+    auto* output_arg = builder.MakeOutput();
+
+    auto* q_output = builder.MakeIntermediate();
+    auto* dq_output = builder.MakeIntermediate();
+    builder.AddQuantizeLinearNode<uint8_t>(input_arg, kTestScale, kTestZp, q_output);
+    builder.AddDequantizeLinearNode<uint8_t>(q_output, kTestScale, kTestZp, dq_output);
+
+    builder.AddNode("Relu", {dq_output}, {output_arg});
+  };
+
+  auto check_graph = [](InferenceSessionWrapper& session) {
+    auto op_to_count = CountOpsInGraph(session.GetGraph());
+    EXPECT_EQ(op_to_count["QuantizeLinear"], 0);
+    EXPECT_EQ(op_to_count["DequantizeLinear"], 0);
+    EXPECT_EQ(op_to_count["Relu"], 1);
+  };
+
+  auto add_session_options = [](SessionOptions& so) {
+    ASSERT_STATUS_OK(so.config_options.AddConfigEntry(kOrtSessionOptionsQDQStripActivations, "1"));
+  };
+
+  TransformerTester(build_test_case,
+                    check_graph,
+                    TransformerLevel::Level1,
+                    TransformerLevel::Level2,
+                    21 /*opset_version*/,
+                    kTestTolerance,
+                    0.0f,
+                    nullptr, add_session_options);
+}
+
+// Test: Q with multiple DQ consumers all get removed
+// Graph: Input -> Q -> DQ1 -> Relu -> Out1
+//                   -> DQ2 -> Sigmoid -> Out2
+// Expected: Input -> Relu -> Out1, Input -> Sigmoid -> Out2
+TEST(QDQStripActivationsTransformerTests, RemoveQDQPairMultipleDQConsumers) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    auto* input_arg = builder.MakeInput<float>({1, 4, 8}, -1.f, 1.f);
+    auto* output1 = builder.MakeOutput();
+    auto* output2 = builder.MakeOutput();
+
+    auto* q_output = builder.MakeIntermediate();
+    builder.AddQuantizeLinearNode<uint8_t>(input_arg, kTestScale, kTestZp, q_output);
+
+    auto* dq1_output = builder.MakeIntermediate();
+    builder.AddDequantizeLinearNode<uint8_t>(q_output, kTestScale, kTestZp, dq1_output);
+    builder.AddNode("Relu", {dq1_output}, {output1});
+
+    auto* dq2_output = builder.MakeIntermediate();
+    builder.AddDequantizeLinearNode<uint8_t>(q_output, kTestScale, kTestZp, dq2_output);
+    builder.AddNode("Sigmoid", {dq2_output}, {output2});
+  };
+
+  auto check_graph = [](InferenceSessionWrapper& session) {
+    auto op_to_count = CountOpsInGraph(session.GetGraph());
+    EXPECT_EQ(op_to_count["QuantizeLinear"], 0);
+    EXPECT_EQ(op_to_count["DequantizeLinear"], 0);
+    EXPECT_EQ(op_to_count["Relu"], 1);
+    EXPECT_EQ(op_to_count["Sigmoid"], 1);
+  };
+
+  auto add_session_options = [](SessionOptions& so) {
+    ASSERT_STATUS_OK(so.config_options.AddConfigEntry(kOrtSessionOptionsQDQStripActivations, "1"));
+  };
+
+  TransformerTester(build_test_case,
+                    check_graph,
+                    TransformerLevel::Level1,
+                    TransformerLevel::Level2,
+                    21 /*opset_version*/,
+                    kTestTolerance,
+                    0.0f,
+                    nullptr, add_session_options);
+}
+
+// Test: Q->DQ pair not removed when scale/zp mismatch
+TEST(QDQStripActivationsTransformerTests, NoRemovalOnScaleMismatch) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    auto* input_arg = builder.MakeInput<float>({1, 4, 8}, -1.f, 1.f);
+    auto* output_arg = builder.MakeOutput();
+
+    auto* q_output = builder.MakeIntermediate();
+    auto* dq_output = builder.MakeIntermediate();
+    builder.AddQuantizeLinearNode<uint8_t>(input_arg, kTestScale, kTestZp, q_output);
+    builder.AddDequantizeLinearNode<uint8_t>(q_output, 0.009f, kTestZp, dq_output);
+
+    builder.AddNode("Relu", {dq_output}, {output_arg});
+  };
+
+  auto check_graph = [](InferenceSessionWrapper& session) {
+    auto op_to_count = CountOpsInGraph(session.GetGraph());
+    EXPECT_EQ(op_to_count["QuantizeLinear"], 1);
+    EXPECT_EQ(op_to_count["DequantizeLinear"], 1);
+    EXPECT_EQ(op_to_count["Relu"], 1);
+  };
+
+  auto add_session_options = [](SessionOptions& so) {
+    ASSERT_STATUS_OK(so.config_options.AddConfigEntry(kOrtSessionOptionsQDQStripActivations, "1"));
+  };
+
+  TransformerTester(build_test_case,
+                    check_graph,
+                    TransformerLevel::Level1,
+                    TransformerLevel::Level2,
+                    21 /*opset_version*/,
+                    1.0f,
+                    1.0f,
+                    nullptr, add_session_options);
+}
+
+// Test: Option disabled - no Q->DQ removal
+TEST(QDQStripActivationsTransformerTests, OptionDisabledNoRemoval) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    auto* input_arg = builder.MakeInput<float>({1, 4, 8}, -1.f, 1.f);
+    auto* output_arg = builder.MakeOutput();
+
+    auto* q_output = builder.MakeIntermediate();
+    auto* dq_output = builder.MakeIntermediate();
+    builder.AddQuantizeLinearNode<uint8_t>(input_arg, kTestScale, kTestZp, q_output);
+    builder.AddDequantizeLinearNode<uint8_t>(q_output, kTestScale, kTestZp, dq_output);
+
+    builder.AddNode("Relu", {dq_output}, {output_arg});
+  };
+
+  auto check_graph = [](InferenceSessionWrapper& session) {
+    auto op_to_count = CountOpsInGraph(session.GetGraph());
+    EXPECT_EQ(op_to_count["Relu"], 1);
+    // Without kOrtSessionOptionsQDQStripActivations, our transformer doesn't run.
+    // With enable_quant_qdq_cleanup defaulting to "0", Q->DQ nodes should remain.
+    EXPECT_EQ(op_to_count["QuantizeLinear"], 1);
+    EXPECT_EQ(op_to_count["DequantizeLinear"], 1);
+  };
+
+  TransformerTester(build_test_case,
+                    check_graph,
+                    TransformerLevel::Level1,
+                    TransformerLevel::Level2,
+                    21 /*opset_version*/);
+}
+
+// Test: DQ producing graph output - handled via Identity node
+// Graph: Input -> Q -> DQ -> (graph output)
+TEST(QDQStripActivationsTransformerTests, RemoveQDQPairWithGraphOutput) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    auto* input_arg = builder.MakeInput<float>({1, 4, 8}, -1.f, 1.f);
+
+    auto* q_output = builder.MakeIntermediate();
+    auto* dq_output = builder.MakeOutput();
+    builder.AddQuantizeLinearNode<uint8_t>(input_arg, kTestScale, kTestZp, q_output);
+    builder.AddDequantizeLinearNode<uint8_t>(q_output, kTestScale, kTestZp, dq_output);
+  };
+
+  auto check_graph = [](InferenceSessionWrapper& session) {
+    auto op_to_count = CountOpsInGraph(session.GetGraph());
+    EXPECT_EQ(op_to_count["QuantizeLinear"], 0);
+    EXPECT_EQ(op_to_count["DequantizeLinear"], 0);
+  };
+
+  auto add_session_options = [](SessionOptions& so) {
+    ASSERT_STATUS_OK(so.config_options.AddConfigEntry(kOrtSessionOptionsQDQStripActivations, "1"));
+  };
+
+  TransformerTester(build_test_case,
+                    check_graph,
+                    TransformerLevel::Level1,
+                    TransformerLevel::Level2,
+                    21 /*opset_version*/,
+                    kTestTolerance,
+                    0.0f,
+                    nullptr, add_session_options);
+}
+
+// Test: Multiple chained Q->DQ pairs all removed
+// Graph: Input -> Q -> DQ -> Relu -> Q -> DQ -> Sigmoid -> Output
+// Expected: Input -> Relu -> Sigmoid -> Output
+TEST(QDQStripActivationsTransformerTests, RemoveMultipleChainedQDQPairs) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    auto* input_arg = builder.MakeInput<float>({1, 4, 8}, -1.f, 1.f);
+    auto* output_arg = builder.MakeOutput();
+
+    auto* q1 = builder.MakeIntermediate();
+    auto* dq1 = builder.MakeIntermediate();
+    builder.AddQuantizeLinearNode<uint8_t>(input_arg, kTestScale, kTestZp, q1);
+    builder.AddDequantizeLinearNode<uint8_t>(q1, kTestScale, kTestZp, dq1);
+
+    auto* relu_out = builder.MakeIntermediate();
+    builder.AddNode("Relu", {dq1}, {relu_out});
+
+    auto* q2 = builder.MakeIntermediate();
+    auto* dq2 = builder.MakeIntermediate();
+    builder.AddQuantizeLinearNode<uint8_t>(relu_out, kTestScale, kTestZp, q2);
+    builder.AddDequantizeLinearNode<uint8_t>(q2, kTestScale, kTestZp, dq2);
+
+    builder.AddNode("Sigmoid", {dq2}, {output_arg});
+  };
+
+  auto check_graph = [](InferenceSessionWrapper& session) {
+    auto op_to_count = CountOpsInGraph(session.GetGraph());
+    EXPECT_EQ(op_to_count["QuantizeLinear"], 0);
+    EXPECT_EQ(op_to_count["DequantizeLinear"], 0);
+    EXPECT_EQ(op_to_count["Relu"], 1);
+    EXPECT_EQ(op_to_count["Sigmoid"], 1);
+  };
+
+  auto add_session_options = [](SessionOptions& so) {
+    ASSERT_STATUS_OK(so.config_options.AddConfigEntry(kOrtSessionOptionsQDQStripActivations, "1"));
+  };
+
+  TransformerTester(build_test_case,
+                    check_graph,
+                    TransformerLevel::Level1,
+                    TransformerLevel::Level2,
+                    21 /*opset_version*/,
+                    kTestTolerance,
+                    0.0f,
+                    nullptr, add_session_options);
+}
+
+// Test: int8_t Q->DQ pair removed
+TEST(QDQStripActivationsTransformerTests, RemoveInt8QDQPair) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    auto* input_arg = builder.MakeInput<float>({1, 4, 8}, -1.f, 1.f);
+    auto* output_arg = builder.MakeOutput();
+
+    auto* q_output = builder.MakeIntermediate();
+    auto* dq_output = builder.MakeIntermediate();
+    builder.AddQuantizeLinearNode<int8_t>(input_arg, kTestScale, kTestZpInt8, q_output);
+    builder.AddDequantizeLinearNode<int8_t>(q_output, kTestScale, kTestZpInt8, dq_output);
+
+    builder.AddNode("Relu", {dq_output}, {output_arg});
+  };
+
+  auto check_graph = [](InferenceSessionWrapper& session) {
+    auto op_to_count = CountOpsInGraph(session.GetGraph());
+    EXPECT_EQ(op_to_count["QuantizeLinear"], 0);
+    EXPECT_EQ(op_to_count["DequantizeLinear"], 0);
+    EXPECT_EQ(op_to_count["Relu"], 1);
+  };
+
+  auto add_session_options = [](SessionOptions& so) {
+    ASSERT_STATUS_OK(so.config_options.AddConfigEntry(kOrtSessionOptionsQDQStripActivations, "1"));
+  };
+
+  TransformerTester(build_test_case,
+                    check_graph,
+                    TransformerLevel::Level1,
+                    TransformerLevel::Level2,
+                    21 /*opset_version*/,
+                    kTestTolerance,
+                    0.0f,
+                    nullptr, add_session_options);
+}
+
+// Test: With qdq_strip_activations, data-movement ops keep Q/DQ adjacent so removal works.
+// Graph: Input -> Q -> DQ -> Reshape -> Q -> DQ -> Relu -> Output
+// With our option: DropQDQNodesRules skipped, Q->DQ pairs around Reshape stay adjacent,
+//   and our transformer removes them.
+TEST(QDQStripActivationsTransformerTests, SkipDataMovementRules) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    auto* input_arg = builder.MakeInput<float>({1, 3, 2, 2}, -1.f, 1.f);
+    auto* output_arg = builder.MakeOutput();
+
+    auto* q1 = builder.MakeIntermediate();
+    auto* dq1 = builder.MakeIntermediate();
+    builder.AddQuantizeLinearNode<uint8_t>(input_arg, kTestScale, kTestZp, q1);
+    builder.AddDequantizeLinearNode<uint8_t>(q1, kTestScale, kTestZp, dq1);
+
+    auto* reshape_shape = builder.Make1DInitializer<int64_t>({1, 12});
+    auto* reshape_out = builder.MakeIntermediate();
+    builder.AddNode("Reshape", {dq1, reshape_shape}, {reshape_out});
+
+    auto* q2 = builder.MakeIntermediate();
+    auto* dq2 = builder.MakeIntermediate();
+    builder.AddQuantizeLinearNode<uint8_t>(reshape_out, kTestScale, kTestZp, q2);
+    builder.AddDequantizeLinearNode<uint8_t>(q2, kTestScale, kTestZp, dq2);
+
+    builder.AddNode("Relu", {dq2}, {output_arg});
+  };
+
+  auto check_graph = [](InferenceSessionWrapper& session) {
+    auto op_to_count = CountOpsInGraph(session.GetGraph());
+    EXPECT_EQ(op_to_count["QuantizeLinear"], 0);
+    EXPECT_EQ(op_to_count["DequantizeLinear"], 0);
+    EXPECT_EQ(op_to_count["Reshape"], 1);
+    EXPECT_EQ(op_to_count["Relu"], 1);
+  };
+
+  auto add_session_options = [](SessionOptions& so) {
+    ASSERT_STATUS_OK(so.config_options.AddConfigEntry(kOrtSessionOptionsQDQStripActivations, "1"));
+  };
+
+  TransformerTester(build_test_case,
+                    check_graph,
+                    TransformerLevel::Level1,
+                    TransformerLevel::Level2,
+                    21 /*opset_version*/,
+                    kTestTolerance,
+                    0.0f,
+                    nullptr, add_session_options);
+}
+
+// Test: Conv with QDQ is fused into QLinearConv by Level1, while surrounding
+// activation Q->DQ pairs are removed by our Level2 transformer.
+// Graph: Input -> Q -> DQ -> Conv(QDQ weight) -> Q -> DQ -> Q -> DQ -> Identity -> Output
+// After Level1: Input -> Q -> QLinearConv -> DQ -> Q -> DQ -> Identity -> Output
+// After Level2: Input -> Q -> QLinearConv -> DQ -> Identity -> Output
+TEST(QDQStripActivationsTransformerTests, ConvQDQFusionWithActivationRemoval) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    auto* input_arg = builder.MakeInput<float>({1, 3, 8, 8}, -1.f, 1.f);
+    auto* output_arg = builder.MakeOutput();
+
+    // Input Q -> DQ pair (consumed by Conv QDQ fusion)
+    constexpr float conv_input_scale = 0.04f;
+    constexpr uint8_t conv_input_zp = 128;
+    auto* dq_conv_input = AddQDQNodePair<uint8_t>(builder, input_arg, conv_input_scale, conv_input_zp);
+
+    // Weight: constant uint8 initializer + DQ
+    auto* weight = builder.MakeInitializer<uint8_t>({16, 3, 3, 3}, uint8_t(0), uint8_t(255));
+    auto* dq_w_output = builder.MakeIntermediate();
+    builder.AddDequantizeLinearNode<uint8_t>(weight, 0.03f, uint8_t(118), dq_w_output);
+
+    // Conv
+    auto* conv_output = builder.MakeIntermediate();
+    builder.AddNode("Conv", {dq_conv_input, dq_w_output}, {conv_output});
+
+    // Conv output Q -> DQ pair (Q consumed by Conv fusion, DQ remains to dequantize QLinearConv output)
+    constexpr float conv_output_scale = 0.039f;
+    constexpr uint8_t conv_output_zp = 135;
+    auto* q_conv_out = builder.MakeIntermediate();
+    auto* dq_conv_out = builder.MakeIntermediate();
+    builder.AddQuantizeLinearNode<uint8_t>(conv_output, conv_output_scale, conv_output_zp, q_conv_out);
+    builder.AddDequantizeLinearNode<uint8_t>(q_conv_out, conv_output_scale, conv_output_zp, dq_conv_out);
+
+    // Activation Q -> DQ pair (removed by our transformer).
+    // Scale=0.05 with zp=128 gives representable range [-6.4, 6.35] which covers
+    // the full Conv output range of [-5.265, 4.68] from DQ(0.039, 135).
+    constexpr float act_scale = 0.05f;
+    constexpr uint8_t act_zp = 128;
+    auto* q_final = builder.MakeIntermediate();
+    auto* dq_final = builder.MakeIntermediate();
+    builder.AddQuantizeLinearNode<uint8_t>(dq_conv_out, act_scale, act_zp, q_final);
+    builder.AddDequantizeLinearNode<uint8_t>(q_final, act_scale, act_zp, dq_final);
+
+    builder.AddNode("Identity", {dq_final}, {output_arg});
+  };
+
+  auto check_graph = [](InferenceSessionWrapper& session) {
+    auto op_to_count = CountOpsInGraph(session.GetGraph());
+    // Conv should be fused to QLinearConv by Level1 QDQSelectorActionTransformer
+    EXPECT_EQ(op_to_count["QLinearConv"], 1);
+    EXPECT_EQ(op_to_count["Conv"], 0);
+    // Q_input remains (feeds QLinearConv), DQ_conv_out remains (dequantizes QLinearConv output)
+    // Q_final and DQ_final removed by our transformer
+    EXPECT_EQ(op_to_count["QuantizeLinear"], 1);
+    EXPECT_EQ(op_to_count["DequantizeLinear"], 1);
+  };
+
+  auto add_session_options = [](SessionOptions& so) {
+    ASSERT_STATUS_OK(so.config_options.AddConfigEntry(kOrtSessionOptionsQDQStripActivations, "1"));
+  };
+
+  TransformerTester(build_test_case,
+                    check_graph,
+                    TransformerLevel::Level1,
+                    TransformerLevel::Level2,
+                    21 /*opset_version*/,
+                    0.04f /*per_sample_tolerance*/,
+                    0.04f /*relative_per_sample_tolerance*/,
+                    nullptr, add_session_options);
+}
+
+// Test: Activation Q->DQ removal enables DQ(blockwise)->MatMul fusion to MatMulNBits.
+// At Level1, the MatMul has 2 DQ inputs (activation DQ + weight DQ), so DQMatMulNodeGroupSelector
+// rejects it (requires exactly 1 DQ). Our Level2 transformer removes the activation Q->DQ (Sub-pass A),
+// then Sub-pass B sees DQ(blockwise weight)->MatMul with 1 DQ and fuses it to MatMulNBits.
+//
+// Graph: Input -> Q -> DQ -> MatMul(DQ_blockwise(int4 weight)) -> Q -> DQ -> Identity -> Output
+// After Level2: Input -> MatMulNBits -> Identity -> Output
+TEST(QDQStripActivationsTransformerTests, MatMulNBitsWithActivationRemoval) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    constexpr int64_t K = 64;
+    constexpr int64_t N = 32;
+    constexpr int64_t block_size = 32;
+    constexpr int64_t num_blocks = (K + block_size - 1) / block_size;  // 2
+
+    auto* input_arg = builder.MakeInput<float>({1, K}, -1.f, 1.f);
+    auto* output_arg = builder.MakeOutput();
+
+    // Input activation Q -> DQ pair (removed by Sub-pass A)
+    auto* q_input = builder.MakeIntermediate();
+    auto* dq_act_output = builder.MakeIntermediate();
+    builder.AddQuantizeLinearNode<uint8_t>(input_arg, kTestScale, kTestZp, q_input);
+    builder.AddDequantizeLinearNode<uint8_t>(q_input, kTestScale, kTestZp, dq_act_output);
+
+    // Blockwise DQ for int4 weight (fused with MatMul to MatMulNBits by Sub-pass B)
+    auto* weight_arg = builder.MakeInitializer<Int4x2>({K, N}, Int4x2(Int4x2::min_val, 0),
+                                                       Int4x2(Int4x2::max_val, 0));
+    auto* scale_arg = builder.MakeInitializer<float>({num_blocks, N}, 0.5f, 2.0f);
+    auto* zp_arg = builder.MakeInitializer<Int4x2>({num_blocks, N}, Int4x2(0, 0), Int4x2(2, 0));
+
+    auto* dq_weight_output = builder.MakeIntermediate();
+    NodeAttributes dq_attrs;
+    utils::SetNodeAttribute(utils::MakeAttribute("axis", static_cast<int64_t>(0)), dq_attrs);
+    utils::SetNodeAttribute(utils::MakeAttribute("block_size", block_size), dq_attrs);
+    builder.AddNode("DequantizeLinear", {weight_arg, scale_arg, zp_arg}, {dq_weight_output}, "", &dq_attrs);
+
+    // MatMul with activation (input A) and blockwise-dequantized weight (input B)
+    auto* matmul_output = builder.MakeIntermediate();
+    builder.AddNode("MatMul", {dq_act_output, dq_weight_output}, {matmul_output});
+
+    // Output activation Q -> DQ pair (removed by Sub-pass A).
+    // MatMul output range can be large (K=64 * weight range), so use a wide scale.
+    // Scale=8.0 with zp=128 covers [-1024, 1016].
+    constexpr float output_scale = 8.0f;
+    auto* q_output = builder.MakeIntermediate();
+    auto* dq_output = builder.MakeIntermediate();
+    builder.AddQuantizeLinearNode<uint8_t>(matmul_output, output_scale, kTestZp, q_output);
+    builder.AddDequantizeLinearNode<uint8_t>(q_output, output_scale, kTestZp, dq_output);
+
+    builder.AddNode("Identity", {dq_output}, {output_arg});
+  };
+
+  auto check_graph = [](InferenceSessionWrapper& session) {
+    auto op_to_count = CountOpsInGraph(session.GetGraph());
+    // Both activation Q->DQ pairs removed, DQ(blockwise)->MatMul fused to MatMulNBits
+    EXPECT_EQ(op_to_count["com.microsoft.MatMulNBits"], 1);
+    EXPECT_EQ(op_to_count["MatMul"], 0);
+    EXPECT_EQ(op_to_count["QuantizeLinear"], 0);
+    EXPECT_EQ(op_to_count["DequantizeLinear"], 0);
+  };
+
+  auto add_session_options = [](SessionOptions& so) {
+    ASSERT_STATUS_OK(so.config_options.AddConfigEntry(kOrtSessionOptionsQDQStripActivations, "1"));
+  };
+
+  TransformerTester(build_test_case,
+                    check_graph,
+                    TransformerLevel::Level1,
+                    TransformerLevel::Level2,
+                    21 /*opset_version*/,
+                    5.0f /*per_sample_tolerance - output Q->DQ rounding error up to scale/2=4*/,
+                    5.0f /*relative_per_sample_tolerance*/,
+                    nullptr, add_session_options);
+}
+
+// Test: Weight DQ on constant initializer is constant-folded (Sub-pass C)
+// Graph: Input -> Q -> DQ -> Add(DQ(int8 weight constant)) -> Output
+// Expected: Input -> Add(float weight) -> Output (activation Q->DQ removed, weight DQ constant-folded)
+TEST(QDQStripActivationsTransformerTests, WeightDQConstantFolding) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    auto* input_arg = builder.MakeInput<float>({1, 4, 8}, -1.f, 1.f);
+    auto* output_arg = builder.MakeOutput();
+
+    // Activation Q->DQ on input
+    auto* q_output = builder.MakeIntermediate();
+    auto* dq_output = builder.MakeIntermediate();
+    builder.AddQuantizeLinearNode<uint8_t>(input_arg, kTestScale, kTestZp, q_output);
+    builder.AddDequantizeLinearNode<uint8_t>(q_output, kTestScale, kTestZp, dq_output);
+
+    // Weight: int8 constant initializer with DQ (per-tensor, not blockwise)
+    auto* weight_init = builder.MakeInitializer<int8_t>({1, 4, 8}, -64, 64);
+    constexpr float weight_scale = 0.01f;
+    constexpr int8_t weight_zp = 0;
+    auto* weight_dq_output = builder.MakeIntermediate();
+    builder.AddDequantizeLinearNode<int8_t>(weight_init, weight_scale, weight_zp, weight_dq_output);
+
+    // Add: activation + weight
+    builder.AddNode("Add", {dq_output, weight_dq_output}, {output_arg});
+  };
+
+  auto check_graph = [](InferenceSessionWrapper& session) {
+    auto op_to_count = CountOpsInGraph(session.GetGraph());
+    // Activation Q->DQ removed (Sub-pass A)
+    EXPECT_EQ(op_to_count["QuantizeLinear"], 0);
+    // Weight DQ constant-folded (Sub-pass C)
+    EXPECT_EQ(op_to_count["DequantizeLinear"], 0);
+    EXPECT_EQ(op_to_count["Add"], 1);
+  };
+
+  auto add_session_options = [](SessionOptions& so) {
+    ASSERT_STATUS_OK(so.config_options.AddConfigEntry(kOrtSessionOptionsQDQStripActivations, "1"));
+  };
+
+  TransformerTester(build_test_case,
+                    check_graph,
+                    TransformerLevel::Level1,
+                    TransformerLevel::Level2,
+                    21 /*opset_version*/,
+                    kTestTolerance,
+                    0.0f,
+                    nullptr, add_session_options);
+}
+
+// Test: Gemm with activation Q->DQ, uint8 weight DQ, and int32 bias DQ
+// Full QDQ quantization commonly use this pattern: all inputs are quantized,
+// with the activation as uint16, weight as uint8, and bias as int32.
+// GemmQDQRules rejects uint16 activations (16-bit not allowed), so the Gemm stays
+// unfused in pass 1. After activation Q->DQ removal (Sub-pass A), the remaining
+// DQ(uint8 weight)->Gemm with DQ(int32 bias) should be fused to MatMulNBits (Sub-pass B).
+// Graph before: Input -> Q(u16) -> DQ(u16) -> Gemm(DQ(u8 weight), DQ(i32 bias)) -> Q(u16) -> DQ(u16) -> Output
+// Expected:     Input -> MatMulNBits(bias) -> Output
+TEST(QDQStripActivationsTransformerTests, GemmWithInt32BiasDQ) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    constexpr int64_t K = 64;
+    constexpr int64_t N = 32;
+    constexpr float act_scale = 0.00002f;  // uint16 covers [-0.655, 1.311] with zp=32768
+    constexpr uint16_t act_zp = 32768;
+
+    auto* input_arg = builder.MakeInput<float>({1, K}, -0.5f, 0.5f);
+    auto* output_arg = builder.MakeOutput();
+
+    // Input activation Q -> DQ pair using uint16 (removed by Sub-pass A)
+    // uint16 is rejected by GemmQDQRules so Gemm stays unfused in first pass.
+    auto* q_input = builder.MakeIntermediate();
+    auto* dq_act_output = builder.MakeIntermediate();
+    builder.AddQuantizeLinearNode<uint16_t>(input_arg, act_scale, act_zp, q_input);
+    builder.AddDequantizeLinearNode<uint16_t>(q_input, act_scale, act_zp, dq_act_output);
+
+    // Per-channel DQ for uint8 weight (axis=1, scale shape [N])
+    auto* weight_arg = builder.MakeInitializer<uint8_t>({K, N}, static_cast<uint8_t>(0), static_cast<uint8_t>(255));
+    auto* dq_weight_output = builder.MakeIntermediate();
+    std::vector<float> weight_scales(static_cast<size_t>(N), 0.03f);
+    std::vector<uint8_t> weight_zps(static_cast<size_t>(N), static_cast<uint8_t>(128));
+    builder.AddDequantizeLinearNode<uint8_t>(weight_arg, weight_scales, weight_zps, dq_weight_output);
+
+    // Bias DQ: int32 quantized bias -> float (common in QNN quantization)
+    auto* bias_quantized = builder.MakeInitializer<int32_t>({N}, static_cast<int32_t>(-1000), static_cast<int32_t>(1000));
+    auto* bias_dq_output = builder.MakeIntermediate();
+    builder.AddDequantizeLinearNode<int32_t>(bias_quantized, 0.0001f, static_cast<int32_t>(0), bias_dq_output);
+
+    // Gemm with activation, weight, and bias
+    auto* gemm_output = builder.MakeIntermediate();
+    builder.AddNode("Gemm", {dq_act_output, dq_weight_output, bias_dq_output}, {gemm_output});
+
+    // Output activation Q -> DQ pair using uint16 (removed by Sub-pass A)
+    constexpr float output_scale = 0.1f;
+    auto* q_output = builder.MakeIntermediate();
+    auto* dq_output = builder.MakeIntermediate();
+    builder.AddQuantizeLinearNode<uint16_t>(gemm_output, output_scale, act_zp, q_output);
+    builder.AddDequantizeLinearNode<uint16_t>(q_output, output_scale, act_zp, dq_output);
+
+    builder.AddNode("Identity", {dq_output}, {output_arg});
+  };
+
+  auto check_graph = [](InferenceSessionWrapper& session) {
+    auto op_to_count = CountOpsInGraph(session.GetGraph());
+    // Gemm fused to MatMulNBits, activation Q->DQ pairs removed
+    EXPECT_EQ(op_to_count["com.microsoft.MatMulNBits"], 1);
+    EXPECT_EQ(op_to_count["Gemm"], 0);
+    EXPECT_EQ(op_to_count["QuantizeLinear"], 0);
+    // Bias DQ constant-folded by Sub-pass C (constant int32 initializer)
+    EXPECT_EQ(op_to_count["DequantizeLinear"], 0);
+  };
+
+  auto add_session_options = [](SessionOptions& so) {
+    ASSERT_STATUS_OK(so.config_options.AddConfigEntry(kOrtSessionOptionsQDQStripActivations, "1"));
+  };
+
+  TransformerTester(build_test_case,
+                    check_graph,
+                    TransformerLevel::Level1,
+                    TransformerLevel::Level2,
+                    21 /*opset_version*/,
+                    5.0f /*per_sample_tolerance - output Q->DQ rounding error up to scale/2=4*/,
+                    5.0f /*relative_per_sample_tolerance*/,
+                    nullptr, add_session_options);
+}
+
+}  // namespace test
+}  // namespace onnxruntime
+
+#endif  // !defined(DISABLE_CONTRIB_OPS)

--- a/onnxruntime/test/optimizer/qdq_strip_activations_transformer_test.cc
+++ b/onnxruntime/test/optimizer/qdq_strip_activations_transformer_test.cc
@@ -31,6 +31,50 @@ constexpr float kTestTolerance = 0.005f;
 // For int8: scale=0.008, zp=0 covers [-128*0.008, 127*0.008] = [-1.024, 1.016]
 constexpr int8_t kTestZpInt8 = 0;
 
+// Lightweight transform test: builds model, creates a single InferenceSession,
+// runs Load + Initialize (which applies all graph transformers), then invokes
+// check_transformed_graph on the resulting session.
+//
+// Unlike TransformerTester, this skips the baseline session and Run() calls,
+// roughly halving the per-test memory footprint. This matters for ASan CI jobs
+// that run dozens of tests in a single process and are close to the memory
+// budget. Use for tests that only need to verify post-transform graph structure;
+// keep numerically-sensitive integration tests on TransformerTester so the
+// transformed graph still produces correct outputs.
+static void CheckTransformedGraphOnly(
+    const std::function<void(ModelTestBuilder&)>& build_test_case,
+    const std::function<void(InferenceSessionWrapper&)>& check_transformed_graph,
+    int opset_version,
+    bool enable_strip_activations) {
+  std::unordered_map<std::string, int> domain_to_version;
+  domain_to_version[kOnnxDomain] = opset_version;
+  domain_to_version[kMSDomain] = 1;
+  Model model("QDQStripActivationsTest", false, ModelMetaData(), PathString(),
+              IOnnxRuntimeOpSchemaRegistryList(), domain_to_version, {},
+              DefaultLoggingManager().DefaultLogger());
+  Graph& graph = model.MainGraph();
+  ModelTestBuilder helper(graph);
+  build_test_case(helper);
+  helper.SetGraphOutputs();
+  ASSERT_STATUS_OK(graph.Resolve());
+
+  std::string model_data;
+  model.ToProto().SerializeToString(&model_data);
+
+  SessionOptions session_options;
+  session_options.graph_optimization_level = TransformerLevel::Level2;
+  if (enable_strip_activations) {
+    ASSERT_STATUS_OK(session_options.config_options.AddConfigEntry(
+        kOrtSessionOptionsQDQStripActivations, "1"));
+  }
+  InferenceSessionWrapper session{session_options, GetEnvironment()};
+  ASSERT_STATUS_OK(session.Load(model_data.data(), static_cast<int>(model_data.size())));
+  ASSERT_STATUS_OK(session.Initialize());
+  if (check_transformed_graph) {
+    check_transformed_graph(session);
+  }
+}
+
 // Test: Simple Q->DQ pair removed by QDQStripActivationsTransformer
 // Graph: Input -> Q -> DQ -> Relu -> Output
 // Expected: Input -> Relu -> Output (Q and DQ removed)
@@ -54,18 +98,8 @@ TEST(QDQStripActivationsTransformerTests, RemoveSimpleQDQPair) {
     EXPECT_EQ(op_to_count["Relu"], 1);
   };
 
-  auto add_session_options = [](SessionOptions& so) {
-    ASSERT_STATUS_OK(so.config_options.AddConfigEntry(kOrtSessionOptionsQDQStripActivations, "1"));
-  };
-
-  TransformerTester(build_test_case,
-                    check_graph,
-                    TransformerLevel::Level1,
-                    TransformerLevel::Level2,
-                    21 /*opset_version*/,
-                    kTestTolerance,
-                    0.0f,
-                    nullptr, add_session_options);
+  CheckTransformedGraphOnly(build_test_case, check_graph, 21 /*opset_version*/,
+                            true /*enable_strip_activations*/);
 }
 
 // Test: Q with multiple DQ consumers all get removed
@@ -98,18 +132,8 @@ TEST(QDQStripActivationsTransformerTests, RemoveQDQPairMultipleDQConsumers) {
     EXPECT_EQ(op_to_count["Sigmoid"], 1);
   };
 
-  auto add_session_options = [](SessionOptions& so) {
-    ASSERT_STATUS_OK(so.config_options.AddConfigEntry(kOrtSessionOptionsQDQStripActivations, "1"));
-  };
-
-  TransformerTester(build_test_case,
-                    check_graph,
-                    TransformerLevel::Level1,
-                    TransformerLevel::Level2,
-                    21 /*opset_version*/,
-                    kTestTolerance,
-                    0.0f,
-                    nullptr, add_session_options);
+  CheckTransformedGraphOnly(build_test_case, check_graph, 21 /*opset_version*/,
+                            true /*enable_strip_activations*/);
 }
 
 // Test: Q->DQ pair not removed when scale/zp mismatch
@@ -133,18 +157,8 @@ TEST(QDQStripActivationsTransformerTests, NoRemovalOnScaleMismatch) {
     EXPECT_EQ(op_to_count["Relu"], 1);
   };
 
-  auto add_session_options = [](SessionOptions& so) {
-    ASSERT_STATUS_OK(so.config_options.AddConfigEntry(kOrtSessionOptionsQDQStripActivations, "1"));
-  };
-
-  TransformerTester(build_test_case,
-                    check_graph,
-                    TransformerLevel::Level1,
-                    TransformerLevel::Level2,
-                    21 /*opset_version*/,
-                    1.0f,
-                    1.0f,
-                    nullptr, add_session_options);
+  CheckTransformedGraphOnly(build_test_case, check_graph, 21 /*opset_version*/,
+                            true /*enable_strip_activations*/);
 }
 
 // Test: Option disabled - no Q->DQ removal
@@ -170,11 +184,8 @@ TEST(QDQStripActivationsTransformerTests, OptionDisabledNoRemoval) {
     EXPECT_EQ(op_to_count["DequantizeLinear"], 1);
   };
 
-  TransformerTester(build_test_case,
-                    check_graph,
-                    TransformerLevel::Level1,
-                    TransformerLevel::Level2,
-                    21 /*opset_version*/);
+  CheckTransformedGraphOnly(build_test_case, check_graph, 21 /*opset_version*/,
+                            false /*enable_strip_activations*/);
 }
 
 // Test: DQ producing graph output - handled via Identity node
@@ -195,18 +206,8 @@ TEST(QDQStripActivationsTransformerTests, RemoveQDQPairWithGraphOutput) {
     EXPECT_EQ(op_to_count["DequantizeLinear"], 0);
   };
 
-  auto add_session_options = [](SessionOptions& so) {
-    ASSERT_STATUS_OK(so.config_options.AddConfigEntry(kOrtSessionOptionsQDQStripActivations, "1"));
-  };
-
-  TransformerTester(build_test_case,
-                    check_graph,
-                    TransformerLevel::Level1,
-                    TransformerLevel::Level2,
-                    21 /*opset_version*/,
-                    kTestTolerance,
-                    0.0f,
-                    nullptr, add_session_options);
+  CheckTransformedGraphOnly(build_test_case, check_graph, 21 /*opset_version*/,
+                            true /*enable_strip_activations*/);
 }
 
 // Test: Multiple chained Q->DQ pairs all removed
@@ -241,18 +242,8 @@ TEST(QDQStripActivationsTransformerTests, RemoveMultipleChainedQDQPairs) {
     EXPECT_EQ(op_to_count["Sigmoid"], 1);
   };
 
-  auto add_session_options = [](SessionOptions& so) {
-    ASSERT_STATUS_OK(so.config_options.AddConfigEntry(kOrtSessionOptionsQDQStripActivations, "1"));
-  };
-
-  TransformerTester(build_test_case,
-                    check_graph,
-                    TransformerLevel::Level1,
-                    TransformerLevel::Level2,
-                    21 /*opset_version*/,
-                    kTestTolerance,
-                    0.0f,
-                    nullptr, add_session_options);
+  CheckTransformedGraphOnly(build_test_case, check_graph, 21 /*opset_version*/,
+                            true /*enable_strip_activations*/);
 }
 
 // Test: int8_t Q->DQ pair removed
@@ -276,18 +267,8 @@ TEST(QDQStripActivationsTransformerTests, RemoveInt8QDQPair) {
     EXPECT_EQ(op_to_count["Relu"], 1);
   };
 
-  auto add_session_options = [](SessionOptions& so) {
-    ASSERT_STATUS_OK(so.config_options.AddConfigEntry(kOrtSessionOptionsQDQStripActivations, "1"));
-  };
-
-  TransformerTester(build_test_case,
-                    check_graph,
-                    TransformerLevel::Level1,
-                    TransformerLevel::Level2,
-                    21 /*opset_version*/,
-                    kTestTolerance,
-                    0.0f,
-                    nullptr, add_session_options);
+  CheckTransformedGraphOnly(build_test_case, check_graph, 21 /*opset_version*/,
+                            true /*enable_strip_activations*/);
 }
 
 // Test: With qdq_strip_activations, data-movement ops keep Q/DQ adjacent so removal works.
@@ -324,18 +305,8 @@ TEST(QDQStripActivationsTransformerTests, SkipDataMovementRules) {
     EXPECT_EQ(op_to_count["Relu"], 1);
   };
 
-  auto add_session_options = [](SessionOptions& so) {
-    ASSERT_STATUS_OK(so.config_options.AddConfigEntry(kOrtSessionOptionsQDQStripActivations, "1"));
-  };
-
-  TransformerTester(build_test_case,
-                    check_graph,
-                    TransformerLevel::Level1,
-                    TransformerLevel::Level2,
-                    21 /*opset_version*/,
-                    kTestTolerance,
-                    0.0f,
-                    nullptr, add_session_options);
+  CheckTransformedGraphOnly(build_test_case, check_graph, 21 /*opset_version*/,
+                            true /*enable_strip_activations*/);
 }
 
 // Test: Conv with QDQ is fused into QLinearConv by Level1, while surrounding


### PR DESCRIPTION
### Description

Adds a new session option `session.qdq_strip_activations` for fully-QDQ models that want
unfused ops to run in float while keeping quantized compute (`QLinearMatMul`,
`QLinearConv`, `MatMulNBits`, …) where fused kernels exist.

When set to `"1"`, two things happen:

1. **`QDQSelectorActionTransformer` skips data-movement QDQ fusion rules**
   (`SplitQDQRules` + `DropQDQNodesRules`). Reshape / Transpose / Squeeze / Unsqueeze /
   Flatten / Expand / Gather / Slice / Tile / Resize / MaxPool / etc. keep their Q/DQ
   wrappers instead of being rewritten to operate on int8 directly. This guarantees
   every remaining Q→DQ pair is *directly adjacent* in the graph.

2. A new **`QDQStripActivationsTransformer`** runs after `MatMulNBitsFusion` and applies
   three sub-passes:
   - **A. Strip adjacent Q→DQ pairs.** For every Q whose consumers are all matching DQ
     nodes (same scale/zp via `QDQ::IsQDQPairSupported`), bypass both nodes and rewire
     Q's source directly to DQ's downstream consumers. Handles single-DQ, fan-out (Q→
     multi-DQ each with one consumer), and graph-output cases (inserts Identity where
     needed). Modeled on `qdq_final_cleanup.cc`.
   - **B. Retry `DQMatMulToMatMulNBits` fusion.** Patterns of the form
     `DQ(quantized weight) → MatMul/Gemm` that were previously blocked by an activation
     DQ on input A become eligible after sub-pass A. Reuses the existing
     `DQMatMulToMatMulNBitsSelector` / `DQMatMulToMatMulNBitsAction` with the same EP
     filter (`CPU`, `CUDA`, `DML`).
   - **C. Constant-fold remaining weight DQ.** `DQ(constant int initializer) → float`
     is folded so unfused float ops can read the dequantized weights directly. Runs the
     existing `ConstantFolding` transformer with `skip_dequantize_linear=false`.

The transformer is gated by `!defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)`
and `!defined(DISABLE_CONTRIB_OPS)` so it matches the conditions of the existing
`DQMatMulToMatMulNBits` machinery it reuses. The session option defaults to `"0"` — no
behavior change for any existing user.

#### Key design decision: skipping `DropQDQNodesRules` / `SplitQDQRules`

The original goal was a single-pass strip of activation Q→DQ. Doing that *without*
skipping data-movement QDQ fusion would require non-trivial BFS through chains of
`DQ → Reshape → Q → DQ → Transpose → Q → DQ → …` to find non-adjacent pairs. By
skipping those two rule families, the Q/DQ wrappers stay in place and every Q→DQ that
needs removal is directly adjacent — a simple linear scan suffices.

This trades the "data-movement op runs on int8" path away. The tradeoff per data-movement
op (`… → Q → DQ → ReshapeLike → Q → DQ → …`):

| Surrounding nodes | Existing (`DropQDQNodes`) | New (`qdq_strip_activations`) | Winner |
|---|---|---|---|
| float producer + float consumer | `Q → Reshape → DQ` (2 extra ops) | `Reshape` (0 extra) | **strip** |
| int8 producer, float consumer | `int8 → Reshape → DQ` (1 extra) | `int8 → DQ → Reshape` (1 extra) | tie |
| float producer, int8 consumer | `Q → Reshape → int8` (1 extra) | `Reshape → Q → int8` (1 extra) | tie |
| int8 producer + int8 consumer | `Reshape` (0 extra) | `DQ → Reshape → Q` (2 extra) | existing |

Workloads targeted by this option are "mostly float activations, with a handful of
fused quantized compute kernels" — i.e. row 1 dominates. Workloads where most
activations should stay quantized end-to-end should leave the option off and continue
using the existing pipeline.

The transformer itself is not EP-filtered (sub-pass A is a generic graph rewrite), but
sub-pass B inherits the existing `{CPU, CUDA, DML, ""}` EP filter from
`DQMatMulToMatMulNBitsSelector`. WebGPU / JS are not covered because the underlying
fusion does not currently target them.

### Motivation and Context

Fully-QDQ models have every op wrapped in `Q → DQ`. ORT's existing options can fuse
quantized compute (`disable_quant_qdq="0"`, default) or strip *all* Q/DQ
(`enable_quant_qdq_cleanup="1"`), but no combination can produce "fuse what's
fuseable + drop activation Q/DQ everywhere else", because:

- `disable_quant_qdq="1"` skips the entire QDQ pipeline, losing `QLinearMatMul` /
  `QLinearConv`.
- `enable_quant_qdq_cleanup="1"` runs `QDQFinalCleanupTransformer`, which can't remove
  `Q → DQ` when the DQ has multiple consumers (and `EnsureUniqueDQForNodeUnit` is
  skipped when `disable_quant_qdq="1"`, so this case is common).
- Neither handles non-adjacent Q/DQ pairs across `DQ → Reshape → Q` chains.
- Neither makes `DQ(quantized weight) → MatMul` patterns visible to the
  `DQMatMulToMatMulNBits` fusion when an activation DQ blocks them.

This option fills that gap and unblocks `MatMulNBits` weight-only-quantized compute on
QDQ models that previously couldn't reach it.

### Tests

New: `onnxruntime/test/optimizer/qdq_strip_activations_transformer_test.cc` —
12 unit tests under `QDQStripActivationsTransformerTests` covering:

- Simple Q→DQ removal (uint8 and int8)
- Q→multi-DQ fan-out
- Scale/zp mismatch (no removal)
- Option-disabled behavior (no removal, no behavior change)
- Q→DQ pair where DQ is a graph output (Identity insertion)
- Chained Q→DQ pairs
- Data-movement op behavior with the rules skipped
- End-to-end Conv + activation Q/DQ stripping
- End-to-end `MatMulNBits` fusion via the new transformer's sub-pass B
- Weight DQ constant folding via sub-pass C
- Gemm with int32 bias DQ

All pass on a CPU-only Release build. Existing test suites unaffected:

- 154 `QDQTransformerTests` — all pass.
- 53 `*MatMulNBits*` graph-transformation tests — all pass.

Lintrunner clean on the modified/added files.
