### PR TITLE
Restore the original ModelAPI semantics

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -7803,11 +7803,15 @@ struct OrtModelEditorApi {
 
   /** \brief Add an initializer to the OrtGraph
    *
-   * The OrtGraph takes ownership of the OrtValue and the caller must NOT call OrtApi::ReleaseValue on it.
-   * Internally ORT moves the tensor data into the graph's storage (the underlying buffer is reference-counted
-   * via shared_ptr, so this is cheap) and destroys the caller's OrtValue wrapper on success. Any deleter
-   * bound to the OrtValue (e.g., via OrtApi::CreateTensorWithDataAndDeleterAsOrtValue) will fire exactly once
-   * when the graph's copy of the OrtValue is destroyed.
+   * The OrtGraph takes ownership of the OrtValue. On success ORT internally calls
+   * OrtApi::ReleaseValue on the caller's wrapper, so `ort_value` is no longer a valid pointer
+   * after this call returns successfully — do NOT call OrtApi::ReleaseValue on it or otherwise
+   * dereference it. On failure ownership is NOT transferred and the caller remains
+   * responsible for releasing `ort_value`.
+   *
+   * Internally the tensor data is reference-counted via shared_ptr, so the move is cheap.
+   * Any deleter bound to the OrtValue (e.g., via OrtApi::CreateTensorWithDataAndDeleterAsOrtValue)
+   * will fire exactly once when the graph's copy of the OrtValue is destroyed.
    *
    * If the OrtValue was created with a user-provided buffer (e.g., OrtApi::CreateTensorWithDataAsOrtValue),
    * that buffer must remain valid for the duration of the inference session.

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -7803,8 +7803,12 @@ struct OrtModelEditorApi {
 
   /** \brief Add an initializer to the OrtGraph
    *
-   * ORT will copy the OrtValue wrapper internally. The caller retains ownership of the OrtValue and should
-   * release it with OrtApi::ReleaseValue when done. Note that the underlying data buffer is not copied.
+   * The OrtGraph takes ownership of the OrtValue and the caller must NOT call OrtApi::ReleaseValue on it.
+   * Internally ORT moves the tensor data into the graph's storage (the underlying buffer is reference-counted
+   * via shared_ptr, so this is cheap) and destroys the caller's OrtValue wrapper on success. Any deleter
+   * bound to the OrtValue (e.g., via OrtApi::CreateTensorWithDataAndDeleterAsOrtValue) will fire exactly once
+   * when the graph's copy of the OrtValue is destroyed.
+   *
    * If the OrtValue was created with a user-provided buffer (e.g., OrtApi::CreateTensorWithDataAsOrtValue),
    * that buffer must remain valid for the duration of the inference session.
    *
@@ -7843,7 +7847,7 @@ struct OrtModelEditorApi {
    * \since Version 1.22.
    */
   ORT_API2_STATUS(AddInitializerToGraph, _Inout_ OrtGraph* graph, _In_ const char* name,
-                  _In_ const OrtValue* ort_value, bool data_is_external);
+                  _Inout_ OrtValue* ort_value, bool data_is_external);
 
   /** \brief Add an OrtNode to an OrtGraph
    *

--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -3626,7 +3626,9 @@ struct GraphImpl : ConstGraphImpl<T> {
   // <Wraps GetModelEditorApi().SetGraphOutputs()
   void SetOutputs(std::vector<ValueInfo>& outputs);
   // <Wraps GetModelEditorApi().AddInitializerToGraph()
-  void AddInitializer(const std::string& name, Value& initializer, bool data_is_external);  // Graph takes ownership of OrtValue
+  // On success the Value is emptied (released to the graph) and becomes equivalent to a default-constructed Value.
+  // On error ownership is retained by the caller.
+  void AddInitializer(const std::string& name, Value& initializer, bool data_is_external);
   // <Wraps GetModelEditorApi().AddNodeToGraph()
   void AddNode(Node& node);  // Graph takes ownership of Node
 #endif                       // !defined(ORT_MINIMAL_BUILD)

--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -3626,7 +3626,7 @@ struct GraphImpl : ConstGraphImpl<T> {
   // <Wraps GetModelEditorApi().SetGraphOutputs()
   void SetOutputs(std::vector<ValueInfo>& outputs);
   // <Wraps GetModelEditorApi().AddInitializerToGraph()
-  void AddInitializer(const std::string& name, const Value& initializer, bool data_is_external);  // Graph copies the OrtValue internally
+  void AddInitializer(const std::string& name, Value& initializer, bool data_is_external);  // Graph takes ownership of OrtValue
   // <Wraps GetModelEditorApi().AddNodeToGraph()
   void AddNode(Node& node);  // Graph takes ownership of Node
 #endif                       // !defined(ORT_MINIMAL_BUILD)

--- a/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
@@ -4041,9 +4041,10 @@ inline void GraphImpl<T>::SetOutputs(std::vector<ValueInfo>& outputs) {
 }
 
 template <typename T>
-inline void GraphImpl<T>::AddInitializer(const std::string& name, const Value& initializer, bool data_is_external) {
-  // Graph copies the OrtValue internally. Caller retains ownership of initializer.
+inline void GraphImpl<T>::AddInitializer(const std::string& name, Value& initializer, bool data_is_external) {
+  // Graph takes ownership of `initializer`. On error the ownership is not transferred.
   ThrowOnError(GetModelEditorApi().AddInitializerToGraph(this->p_, name.c_str(), initializer, data_is_external));
+  initializer.release();
 }
 
 template <typename T>

--- a/onnxruntime/core/session/model_editor_api.h
+++ b/onnxruntime/core/session/model_editor_api.h
@@ -34,7 +34,7 @@ ORT_API_STATUS_IMPL(SetGraphInputs, _In_ OrtGraph* graph,
 ORT_API_STATUS_IMPL(SetGraphOutputs, _In_ OrtGraph* graph,
                     _In_reads_(outputs_len) _In_ OrtValueInfo** outputs, _In_ size_t outputs_len);
 ORT_API_STATUS_IMPL(AddInitializerToGraph, _In_ OrtGraph* graph, _In_ const char* name,
-                    _In_ const OrtValue* ort_value,
+                    _Inout_ OrtValue* ort_value,
                     bool data_is_external);
 ORT_API_STATUS_IMPL(AddNodeToGraph, _In_ OrtGraph* graph, _Inout_ OrtNode* node);
 

--- a/onnxruntime/core/session/model_editor_c_api.cc
+++ b/onnxruntime/core/session/model_editor_c_api.cc
@@ -291,15 +291,23 @@ ORT_API_STATUS_IMPL(OrtModelEditorAPI::AddInitializerToGraph, _In_ OrtGraph* ort
     }
   }
 
-  // Copy the OrtValue into the graph's storage (cheap: bumps the inner shared_ptr refcount
-  // for the tensor data) and then delete the caller's wrapper. This restores the original
-  // ownership-transfer contract documented for this API: callers may release()/hand off the
-  // raw OrtValue* and must NOT call ReleaseValue afterwards. Dropping the caller's wrapper
-  // here ensures any deleter bound to the OrtValue (e.g. via CreateTensorWithDataAndDeleter)
-  // fires exactly once when the graph's copy is destroyed.
+  // Move the OrtValue into the graph's storage and destroy the caller's wrapper via
+  // OrtApis::ReleaseValue. This restores the original ownership-transfer contract documented
+  // for this API: the caller hands off the raw OrtValue* and must NOT call ReleaseValue on it
+  // afterwards. Any deleter bound to the OrtValue (e.g. via CreateTensorWithDataAndDeleterAsOrtValue)
+  // fires exactly once when the graph's copy of the OrtValue is destroyed.
+  //
+  // Strong exception guarantee: try_emplace below is the only step that can throw (key string
+  // allocation / map rehash). If it throws, *ort_value is untouched and ownership has not been
+  // transferred, so the caller remains responsible for releasing it. The subsequent move-assign
+  // and ReleaseValue are noexcept.
+  static_assert(std::is_nothrow_move_assignable_v<OrtValue>,
+                "Strong exception guarantee for AddInitializerToGraph relies on noexcept move-assign of OrtValue.");
+
   auto& m = data_is_external ? graph->external_initializers : graph->initializers;
-  auto [it, inserted] = m.emplace(name, *ort_value);
+  auto [it, inserted] = m.try_emplace(name);
   ORT_ENFORCE(inserted, "Unexpected duplicate name after validation. This is a bug.");
+  it->second = std::move(*ort_value);
   OrtApis::ReleaseValue(ort_value);
 
   return nullptr;

--- a/onnxruntime/core/session/model_editor_c_api.cc
+++ b/onnxruntime/core/session/model_editor_c_api.cc
@@ -239,7 +239,7 @@ ORT_API_STATUS_IMPL(OrtModelEditorAPI::SetGraphOutputs, _In_ OrtGraph* ort_graph
 }
 
 ORT_API_STATUS_IMPL(OrtModelEditorAPI::AddInitializerToGraph, _In_ OrtGraph* ort_graph, _In_ const char* name,
-                    _In_ const OrtValue* ort_value, bool data_is_external) {
+                    _Inout_ OrtValue* ort_value, bool data_is_external) {
   API_IMPL_BEGIN
   if (name == nullptr || *name == '\0') {
     return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, "name cannot be null or empty string");
@@ -291,9 +291,16 @@ ORT_API_STATUS_IMPL(OrtModelEditorAPI::AddInitializerToGraph, _In_ OrtGraph* ort
     }
   }
 
+  // Copy the OrtValue into the graph's storage (cheap: bumps the inner shared_ptr refcount
+  // for the tensor data) and then delete the caller's wrapper. This restores the original
+  // ownership-transfer contract documented for this API: callers may release()/hand off the
+  // raw OrtValue* and must NOT call ReleaseValue afterwards. Dropping the caller's wrapper
+  // here ensures any deleter bound to the OrtValue (e.g. via CreateTensorWithDataAndDeleter)
+  // fires exactly once when the graph's copy is destroyed.
   auto& m = data_is_external ? graph->external_initializers : graph->initializers;
   auto [it, inserted] = m.emplace(name, *ort_value);
   ORT_ENFORCE(inserted, "Unexpected duplicate name after validation. This is a bug.");
+  OrtApis::ReleaseValue(ort_value);
 
   return nullptr;
   API_IMPL_END

--- a/onnxruntime/test/shared_lib/test_model_builder_api.cc
+++ b/onnxruntime/test/shared_lib/test_model_builder_api.cc
@@ -235,7 +235,7 @@ TEST(ModelEditorAPITest, Basic_CApi) {
                                                      &y_tensor));
 
     Ort::ThrowOnError(model_editor_api.AddInitializerToGraph(graph, "Y", y_tensor, /*data is external*/ true));
-    // graph now owns y_tensor
+    y_tensor = nullptr;  // wrapper consumed by the API on success; pointer is no longer valid
 
     if (use_constant_node) {
       // Test that a Constant node is converted to an initializer
@@ -1108,8 +1108,9 @@ TEST(ModelEditorAPITest, AddInitializerToGraph_DuplicateName_Fails) {
   Ort::ThrowOnError(api.CreateTensorAsOrtValue(allocator, dims.data(), dims.size(),
                                                ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &tensor2));
 
-  // First add should succeed: graph takes ownership of tensor1.
+  // First add should succeed: the API consumes tensor1 (calls ReleaseValue on the wrapper).
   ASSERT_ORTSTATUS_OK(model_editor_api.AddInitializerToGraph(graph, "W", tensor1, false));
+  tensor1 = nullptr;  // wrapper consumed by the API; pointer is no longer valid
 
   // Second add with same name should fail. On failure ownership of tensor2 is NOT transferred,
   // so the caller is still responsible for releasing it.
@@ -1117,7 +1118,7 @@ TEST(ModelEditorAPITest, AddInitializerToGraph_DuplicateName_Fails) {
   EXPECT_FALSE(status.IsOK());
   EXPECT_THAT(status.GetErrorMessage(), ::testing::HasSubstr("already been added"));
 
-  // Clean up. tensor1 is owned by the graph (do NOT release). tensor2 is still owned by us.
+  // Cleanup: tensor1 was consumed by the successful add; tensor2 is still owned by us.
   api.ReleaseValue(tensor2);
   api.ReleaseGraph(graph);
 }
@@ -1137,8 +1138,9 @@ TEST(ModelEditorAPITest, AddInitializerToGraph_OwnershipTransferred) {
   Ort::ThrowOnError(api.CreateTensorAsOrtValue(allocator, dims.data(), dims.size(),
                                                ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &tensor));
 
-  // Graph takes ownership; caller must NOT release tensor afterwards.
+  // Graph takes ownership; the API consumes the wrapper on success.
   ASSERT_ORTSTATUS_OK(model_editor_api.AddInitializerToGraph(graph, "W", tensor, false));
+  tensor = nullptr;  // wrapper consumed by the API; caller must NOT call ReleaseValue
 
   api.ReleaseGraph(graph);
 }

--- a/onnxruntime/test/shared_lib/test_model_builder_api.cc
+++ b/onnxruntime/test/shared_lib/test_model_builder_api.cc
@@ -235,7 +235,7 @@ TEST(ModelEditorAPITest, Basic_CApi) {
                                                      &y_tensor));
 
     Ort::ThrowOnError(model_editor_api.AddInitializerToGraph(graph, "Y", y_tensor, /*data is external*/ true));
-    api.ReleaseValue(y_tensor);
+    // graph now owns y_tensor
 
     if (use_constant_node) {
       // Test that a Constant node is converted to an initializer
@@ -1108,21 +1108,21 @@ TEST(ModelEditorAPITest, AddInitializerToGraph_DuplicateName_Fails) {
   Ort::ThrowOnError(api.CreateTensorAsOrtValue(allocator, dims.data(), dims.size(),
                                                ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &tensor2));
 
-  // First add should succeed
+  // First add should succeed: graph takes ownership of tensor1.
   ASSERT_ORTSTATUS_OK(model_editor_api.AddInitializerToGraph(graph, "W", tensor1, false));
 
-  // Second add with same name should fail
+  // Second add with same name should fail. On failure ownership of tensor2 is NOT transferred,
+  // so the caller is still responsible for releasing it.
   Ort::Status status{model_editor_api.AddInitializerToGraph(graph, "W", tensor2, false)};
   EXPECT_FALSE(status.IsOK());
   EXPECT_THAT(status.GetErrorMessage(), ::testing::HasSubstr("already been added"));
 
-  // Clean up — caller retains ownership under copy semantics
-  api.ReleaseValue(tensor1);
+  // Clean up. tensor1 is owned by the graph (do NOT release). tensor2 is still owned by us.
   api.ReleaseValue(tensor2);
   api.ReleaseGraph(graph);
 }
 
-TEST(ModelEditorAPITest, AddInitializerToGraph_SamePointerDifferentName_Succeeds) {
+TEST(ModelEditorAPITest, AddInitializerToGraph_OwnershipTransferred) {
   const auto& api = Ort::GetApi();
   const auto& model_editor_api = Ort::GetModelEditorApi();
 
@@ -1137,12 +1137,9 @@ TEST(ModelEditorAPITest, AddInitializerToGraph_SamePointerDifferentName_Succeeds
   Ort::ThrowOnError(api.CreateTensorAsOrtValue(allocator, dims.data(), dims.size(),
                                                ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &tensor));
 
-  // Both adds succeed — each creates an independent copy sharing the same underlying data
-  ASSERT_ORTSTATUS_OK(model_editor_api.AddInitializerToGraph(graph, "W1", tensor, false));
-  ASSERT_ORTSTATUS_OK(model_editor_api.AddInitializerToGraph(graph, "W2", tensor, false));
+  // Graph takes ownership; caller must NOT release tensor afterwards.
+  ASSERT_ORTSTATUS_OK(model_editor_api.AddInitializerToGraph(graph, "W", tensor, false));
 
-  // Caller retains ownership and releases
-  api.ReleaseValue(tensor);
   api.ReleaseGraph(graph);
 }
 


### PR DESCRIPTION
This pull request updates the ownership semantics for adding initializers to an `OrtGraph` in the ONNX Runtime C and C++ APIs. The main change is that the graph now takes ownership of the `OrtValue` when adding an initializer, and the caller must not release it afterward. The code, documentation, and tests have been updated to reflect this new contract.

**API Ownership Semantics Update**

* Changed the `AddInitializerToGraph` API so that `OrtGraph` takes ownership of the `OrtValue` (previously, the caller retained ownership); updated the parameter type from `const OrtValue*` to `_Inout_ OrtValue*` in both the C and C++ headers, and clarified documentation accordingly. [[1]](diffhunk://#diff-5845a5c76fb64abdc8f0cffe21b37f8da1712674eb3abc4cd87190891be1bd48L7806-R7811) [[2]](diffhunk://#diff-5845a5c76fb64abdc8f0cffe21b37f8da1712674eb3abc4cd87190891be1bd48L7846-R7850) [[3]](diffhunk://#diff-17f64e8b38fcdcd25e90abcabeec4b420956b15fe63868a5d0b270c376bde209L3629-R3629) [[4]](diffhunk://#diff-10e5057aa31f6a2304e858d85889db4cd347ab0f432a80a4e2dd43105a477564L37-R37)

**Implementation Changes**

* Modified the implementation of `AddInitializerToGraph` to move the tensor data into the graph's storage, destroy the caller's `OrtValue` wrapper on success, and ensure deleters are called exactly once. [[1]](diffhunk://#diff-43552e7189339e00e475596a9e0a93a98e9a0e0198170fbb2595071a21eb64e0L242-R242) [[2]](diffhunk://#diff-43552e7189339e00e475596a9e0a93a98e9a0e0198170fbb2595071a21eb64e0R294-R303) [[3]](diffhunk://#diff-cc93f5f9d8078d3d3af14c9bb4c0c59e25a99f3ec75d7772ea20111ed7eb6ddeL4044-R4047)

**Test Updates**

* Updated tests to reflect the new ownership model: callers no longer release `OrtValue` after adding as an initializer, and clarified comments about ownership transfer and error handling. [[1]](diffhunk://#diff-5b35e6af2639393ec7cba56315b51ab9bef864e88ea8eba9bb92a08754a90415L238-R238) [[2]](diffhunk://#diff-5b35e6af2639393ec7cba56315b51ab9bef864e88ea8eba9bb92a08754a90415L1111-R1125) [[3]](diffhunk://#diff-5b35e6af2639393ec7cba56315b51ab9bef864e88ea8eba9bb92a08754a90415L1140-L1145)