### PR TITLE
Fix CI: update import convert_tf_models_to_pytorch

### DIFF
--- a/onnxruntime/test/python/transformers/test_convert_tf_models_to_pytorch.py
+++ b/onnxruntime/test/python/transformers/test_convert_tf_models_to_pytorch.py
@@ -1,3 +1,10 @@
+#!/usr/bin/env python
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.  All rights reserved.
+# Licensed under the MIT License.  See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
 import io
 import tarfile
 import zipfile

--- a/onnxruntime/test/python/transformers/test_convert_tf_models_to_pytorch.py
+++ b/onnxruntime/test/python/transformers/test_convert_tf_models_to_pytorch.py
@@ -1,24 +1,16 @@
-import importlib.util
 import io
 import tarfile
 import zipfile
-from pathlib import Path
 
 import pytest
+from parity_utilities import find_transformers_source
 
-# Resolve the module path relative to this file so the test works regardless of CWD.
-MODULE_PATH = (
-    Path(__file__).resolve().parents[4]
-    / "onnxruntime"
-    / "python"
-    / "tools"
-    / "transformers"
-    / "convert_tf_models_to_pytorch.py"
-)
-SPEC = importlib.util.spec_from_file_location("convert_tf_models_to_pytorch", MODULE_PATH)
-assert SPEC is not None and SPEC.loader is not None
-convert_tf_models_to_pytorch = importlib.util.module_from_spec(SPEC)
-SPEC.loader.exec_module(convert_tf_models_to_pytorch)
+# The source module is not copied into the test build output directory, so skip the
+# whole module when it cannot be located instead of failing during collection.
+if find_transformers_source():
+    import convert_tf_models_to_pytorch
+else:
+    pytest.skip("convert_tf_models_to_pytorch.py not found", allow_module_level=True)
 
 
 def test_safe_extract_archive_rejects_tar_path_traversal(tmp_path):

--- a/onnxruntime/test/python/transformers/test_convert_tf_models_to_pytorch.py
+++ b/onnxruntime/test/python/transformers/test_convert_tf_models_to_pytorch.py
@@ -15,9 +15,9 @@ from parity_utilities import find_transformers_source
 # The source module is not copied into the test build output directory, so skip the
 # whole module when it cannot be located instead of failing during collection.
 if find_transformers_source():
-    import convert_tf_models_to_pytorch
+    from convert_tf_models_to_pytorch import safe_extract_archive
 else:
-    pytest.skip("convert_tf_models_to_pytorch.py not found", allow_module_level=True)
+    from onnxruntime.transformers.convert_tf_models_to_pytorch import safe_extract_archive
 
 
 def test_safe_extract_archive_rejects_tar_path_traversal(tmp_path):
@@ -29,7 +29,7 @@ def test_safe_extract_archive_rejects_tar_path_traversal(tmp_path):
         tar_ref.addfile(member, io.BytesIO(data))
 
     with pytest.raises(ValueError, match="outside"):
-        convert_tf_models_to_pytorch.safe_extract_archive(archive_path, tmp_path)
+        safe_extract_archive(archive_path, tmp_path)
 
 
 def test_safe_extract_archive_rejects_zip_path_traversal(tmp_path):
@@ -38,7 +38,7 @@ def test_safe_extract_archive_rejects_zip_path_traversal(tmp_path):
         zip_ref.writestr("../escape.txt", "malicious")
 
     with pytest.raises(ValueError, match="outside"):
-        convert_tf_models_to_pytorch.safe_extract_archive(archive_path, tmp_path)
+        safe_extract_archive(archive_path, tmp_path)
 
 
 def test_safe_extract_archive_rejects_zip_backslash_traversal(tmp_path):
@@ -47,7 +47,7 @@ def test_safe_extract_archive_rejects_zip_backslash_traversal(tmp_path):
         zip_ref.writestr("..\\escape.txt", "malicious")
 
     with pytest.raises(ValueError, match="outside"):
-        convert_tf_models_to_pytorch.safe_extract_archive(archive_path, tmp_path)
+        safe_extract_archive(archive_path, tmp_path)
 
 
 def test_safe_extract_archive_rejects_tar_symlink(tmp_path):
@@ -59,4 +59,4 @@ def test_safe_extract_archive_rejects_tar_symlink(tmp_path):
         tar_ref.addfile(member)
 
     with pytest.raises(ValueError, match="link"):
-        convert_tf_models_to_pytorch.safe_extract_archive(archive_path, tmp_path)
+        safe_extract_archive(archive_path, tmp_path)

--- a/onnxruntime/test/python/transformers/test_convert_tf_models_to_pytorch.py
+++ b/onnxruntime/test/python/transformers/test_convert_tf_models_to_pytorch.py
@@ -12,8 +12,7 @@ import zipfile
 import pytest
 from parity_utilities import find_transformers_source
 
-# The source module is not copied into the test build output directory, so skip the
-# whole module when it cannot be located instead of failing during collection.
+# The source module is not copied into the test build output directory, use a helper function to find it.
 if find_transformers_source():
     from convert_tf_models_to_pytorch import safe_extract_archive
 else:


### PR DESCRIPTION
Update import to use find_transformers_source helper function like other tests.

This fixes CI test failures in transformers tests, where the test script is under build directory, while the import is still in source directory.

