### PR TITLE
Fix thread-pool param self-assignment and dedupe schema registration in session_state_test

### DIFF
--- a/onnxruntime/test/framework/session_state_test.cc
+++ b/onnxruntime/test/framework/session_state_test.cc
@@ -854,6 +854,9 @@ TEST_P(SessionStatePrepackingTest, PrePackingTest) {
   PrepackingTestParam test_param = GetParam();
 
   OrtThreadPoolParams to{};
+  // Use a small, fixed intra-op pool size to keep thread/memory overhead low (e.g., under ASan)
+  // while still exercising the non-null threadpool path.
+  to.thread_pool_size = 2;
   auto tp = concurrency::CreateThreadPool(&onnxruntime::Env::Default(), to, concurrency::ThreadPoolType::INTRA_OP);
   RegisterPrePackingTestSchemaOnce();
 
@@ -930,6 +933,8 @@ class SessionStateTestSharedInitalizersWithPrePacking : public ::testing::Test {
 
   void SetUp() override {
     OrtThreadPoolParams to{};
+    // Use a small, fixed intra-op pool size to keep thread/memory overhead low (e.g., under ASan).
+    to.thread_pool_size = 2;
     tp = concurrency::CreateThreadPool(&onnxruntime::Env::Default(), to, concurrency::ThreadPoolType::INTRA_OP);
     RegisterPrePackingTestSchemaOnce();
 

--- a/onnxruntime/test/framework/session_state_test.cc
+++ b/onnxruntime/test/framework/session_state_test.cc
@@ -3,6 +3,7 @@
 
 #include <fstream>
 #include <iostream>
+#include <mutex>
 #include <absl/base/config.h>
 
 #include "asserts.h"
@@ -141,7 +142,7 @@ class TestOpKernel : public OpKernel {
 class SessionStateAddGetKernelTest : public testing::TestWithParam<int> {};
 
 TEST_P(SessionStateAddGetKernelTest, AddGetKernelTest) {
-  OrtThreadPoolParams to;
+  OrtThreadPoolParams to{};
   to.thread_pool_size = GetParam();
   auto tp = concurrency::CreateThreadPool(&onnxruntime::Env::Default(), to, concurrency::ThreadPoolType::INTRA_OP);
   ONNX_OPERATOR_SCHEMA(Variable)
@@ -231,8 +232,8 @@ class SessionStateTestP : public testing::TestWithParam<TestParam> {};
 // Test that we separate out constant and non-constant initializers correctly
 TEST_P(SessionStateTestP, TestInitializerProcessing) {
   const TestParam& param = GetParam();
-  OrtThreadPoolParams to;
-  to.thread_pool_size = to.thread_pool_size;
+  OrtThreadPoolParams to{};
+  to.thread_pool_size = param.thread_count;
   auto tp = concurrency::CreateThreadPool(&onnxruntime::Env::Default(), to, concurrency::ThreadPoolType::INTRA_OP);
 
   std::basic_ostringstream<ORTCHAR_T> oss;
@@ -471,7 +472,7 @@ void LoadWithResourceAwarePartitioning(const ORTCHAR_T* model_path,
   Graph& graph = model->MainGraph();
   ASSERT_STATUS_OK(graph.Resolve());
 
-  OrtThreadPoolParams to;
+  OrtThreadPoolParams to{};
   to.thread_pool_size = 1;
   auto tp = concurrency::CreateThreadPool(&onnxruntime::Env::Default(), to, concurrency::ThreadPoolType::INTRA_OP);
 
@@ -833,17 +834,28 @@ struct PrepackingTestParam {
   bool test_prepacking;
 };
 
+namespace {
+// The PrePackingTest schema is registered into the global ONNX schema registry. Register it only
+// once to avoid duplicate-registration warnings when multiple tests/fixtures run in the same process.
+void RegisterPrePackingTestSchemaOnce() {
+  static std::once_flag pre_packing_schema_registered;
+  std::call_once(pre_packing_schema_registered, []() {
+    ONNX_OPERATOR_SCHEMA(PrePackingTest)
+        .SetDoc("Faking Node for PrePacking")
+        .Input(0, "Input_0", "input 0", "tensor(float)")
+        .Input(1, "Input_1", "input 1", "tensor(float)")
+        .Output(0, "output_0", "docstr for output_0.", "tensor(float)");
+  });
+}
+}  // namespace
+
 class SessionStatePrepackingTest : public testing::TestWithParam<PrepackingTestParam> {};
 TEST_P(SessionStatePrepackingTest, PrePackingTest) {
   PrepackingTestParam test_param = GetParam();
 
-  OrtThreadPoolParams to;
+  OrtThreadPoolParams to{};
   auto tp = concurrency::CreateThreadPool(&onnxruntime::Env::Default(), to, concurrency::ThreadPoolType::INTRA_OP);
-  ONNX_OPERATOR_SCHEMA(PrePackingTest)
-      .SetDoc("Faking Node for PrePacking")
-      .Input(0, "Input_0", "input 0", "tensor(float)")
-      .Input(1, "Input_1", "input 1", "tensor(float)")
-      .Output(0, "output_0", "docstr for output_0.", "tensor(float)");
+  RegisterPrePackingTestSchemaOnce();
 
   ExecutionProviders execution_providers;
   auto cpu_execution_provider = std::make_unique<CPUExecutionProvider>(CPUExecutionProviderInfo(false));
@@ -917,13 +929,9 @@ class SessionStateTestSharedInitalizersWithPrePacking : public ::testing::Test {
   std::unique_ptr<concurrency::ThreadPool> tp;
 
   void SetUp() override {
-    OrtThreadPoolParams to;
+    OrtThreadPoolParams to{};
     tp = concurrency::CreateThreadPool(&onnxruntime::Env::Default(), to, concurrency::ThreadPoolType::INTRA_OP);
-    ONNX_OPERATOR_SCHEMA(PrePackingTest)
-        .SetDoc("Faking Node for PrePacking")
-        .Input(0, "Input_0", "input 0", "tensor(float)")
-        .Input(1, "Input_1", "input 1", "tensor(float)")
-        .Output(0, "output_0", "docstr for output_0.", "tensor(float)");
+    RegisterPrePackingTestSchemaOnce();
 
     auto cpu_execution_provider = std::make_unique<CPUExecutionProvider>(CPUExecutionProviderInfo(false));
     ASSERT_STATUS_OK(execution_providers.Add(kCpuExecutionProvider, std::move(cpu_execution_provider)));


### PR DESCRIPTION
## Description

Fixes a latent bug and reduces unnecessary resource usage in `session_state_test.cc`.

### Thread-pool parameter initialization

`SessionStateTestP.TestInitializerProcessing` contained a self-assignment that silently dropped the test's intended thread count:

```cpp
OrtThreadPoolParams to;
to.thread_pool_size = to.thread_pool_size;  // no-op: leaves thread_pool_size = 0
```

`thread_pool_size = 0` means "use all physical cores (or half the logical cores)". Across the 8 parametrized instances this spins up large intra-op thread pools regardless of the `thread_count` parameter, adding avoidable thread/memory overhead — which is especially costly under the AddressSanitizer build.

This PR:
- Corrects the assignment to use the intended parameter: `to.thread_pool_size = param.thread_count;`
- Value-initializes all local `OrtThreadPoolParams` instances (`OrtThreadPoolParams to{};`) for consistency and to avoid relying on implicit defaults.

### Deduplicate schema registration

`PrePackingTest` was registered into the global ONNX schema registry in two places (`SessionStatePrepackingTest` and the `SessionStateTestSharedInitalizersWithPrePacking` fixture), producing duplicate-registration warnings when both run in the same process. The registration is now centralized behind a `std::call_once` helper so the schema is registered exactly once.

## Motivation and Context

While investigating an ASan `onnxruntime_test_all` OOM, `SessionStatePrepackingTest` showed up as the abort site (the process-wide ASan allocator aborts in whichever test is allocating when the limit is hit). The dominant memory driver was addressed separately in #28797 (QDQ Gemm transformer tests). This PR cleans up the genuine, independent issues found in `session_state_test.cc` during that investigation: the self-assignment bug and the duplicate schema registration.

## Testing

All affected tests pass locally (RelWithDebInfo):

```
[==========] 19 tests from 4 test suites ran.
[  PASSED  ] 19 tests.
```

Covers `SessionStateTestP`, `SessionStatePrepackingTest`, `SessionStateAddGetKernelTest`, and `SessionStateTestSharedInitalizersWithPrePacking`.
