### PR TITLE
webgpu: Normalize indirect-dispatch buffer in flash attention

### DIFF
--- a/onnxruntime/contrib_ops/webgpu/bert/flash_attention.cc
+++ b/onnxruntime/contrib_ops/webgpu/bert/flash_attention.cc
@@ -16,6 +16,39 @@ namespace onnxruntime {
 namespace contrib {
 namespace webgpu {
 
+// WGSL helper function for writing a normalized indirect dispatch buffer.
+// The host-side dispatch path uses ProgramManager::NormalizeDispatchGroupSize
+// to split a 1D group count into 2D when it exceeds the WebGPU per-dimension
+// limit. The indirect-dispatch path skips that host-side normalization (the
+// dispatch size lives on the GPU), so the same normalization is replicated
+// here. Consumers read `workgroup_idx` from shader_helper which always
+// flattens (x, y, z) into a single linear index, so the (1D vs 2D) split is
+// transparent to consumer shaders.
+//
+// Caller requirement: the calling shader must declare a storage output named
+// exactly `indirect_buffer` of type `array<u32>` (at least 3 elements).
+//
+// Scope: this mirrors only the 2D (sqrt) tier of the host normalizer; the
+// host helper additionally falls back to a 3D (cbrt) layout when the 2D split
+// would also exceed the per-dimension limit. The 2D-only mirror is safe for
+// any total <= ~65535^2 (~4.29B), which covers all expected attention
+// workloads (batch_size * num_heads * num_total_seq_length_tile is far smaller).
+constexpr const char kWriteIndirectDispatchFn[] = R"(
+fn write_indirect_dispatch(total: u32) {
+  let limit = 65535u;  // WebGPU spec maxComputeWorkgroupsPerDimension
+  if (total <= limit) {
+    indirect_buffer[0] = total;
+    indirect_buffer[1] = 1u;
+    indirect_buffer[2] = 1u;
+  } else {
+    let dispatch_avg = u32(ceil(sqrt(f32(total))));
+    indirect_buffer[0] = dispatch_avg;
+    indirect_buffer[1] = dispatch_avg;
+    indirect_buffer[2] = 1u;
+  }
+}
+)";
+
 Status SplitPackedQKVWithRotaryEmbeddingAndCopyKVProgram::GenerateShaderCode(ShaderHelper& sh) const {
   const auto& packed_qkv = sh.AddInput("packed_qkv", ShaderUsage::UseUniform);
   const auto& seqlens = sh.AddInput("seqlens", ShaderUsage::UseUniform);
@@ -28,6 +61,7 @@ Status SplitPackedQKVWithRotaryEmbeddingAndCopyKVProgram::GenerateShaderCode(Sha
 
   if (prepare_indirect_dispatch_) {
     sh.AddOutput("indirect_buffer", ShaderUsage::None);
+    sh.AdditionalImplementation() << kWriteIndirectDispatchFn;
   }
 
   return WGSL_TEMPLATE_APPLY(sh, "bert/split_packed_qkv_with_rotary_embedding_and_copykv.wgsl.template",
@@ -85,15 +119,15 @@ Status CopyKVCacheProgram::GenerateShaderCode(ShaderHelper& shader) const {
     shader.MainFunctionBody() << "  let present_offset = " << present_key.IndicesToOffset("present_key_indices_t(batch, num_head_id, sequence_id, head_size_id)") << ";\n";
   }
 
-  // Add indirect dispatch logic for thread 0
   if (prepare_indirect_dispatch_) {
-    // TODO: Add NormalizeDispatchGroupSize logic here to avoid exceeding max dispatch size.
-    shader.MainFunctionBody() << "  // Prepare indirect dispatch buffer for thread 0\n"
-                              << "  if (global_idx == 0u) {\n"
+    shader.AdditionalImplementation() << kWriteIndirectDispatchFn;
+    // Mirror the direct-dispatch formula at the FlashAttentionDecodeQKT call site:
+    // batch_size * num_heads * num_total_seq_length_tile. batch_size is read from
+    // copy_kv_shape[0], which is set host-side from parameters.batch_size_.
+    shader.MainFunctionBody() << "  if (global_idx == 0u) {\n"
                               << "    let num_total_seq_length_tile = (total_seq_length + uniforms.tile_size - 1u) / uniforms.tile_size;\n"
-                              << "    indirect_buffer[0] = num_total_seq_length_tile;\n"
-                              << "    indirect_buffer[1] = uniforms.num_heads;\n"
-                              << "    indirect_buffer[2] = 1u;\n"
+                              << "    let total = uniforms.copy_kv_shape_shape[0] * uniforms.num_heads * num_total_seq_length_tile;\n"
+                              << "    write_indirect_dispatch(total);\n"
                               << "  }\n\n";
   }
 

--- a/onnxruntime/contrib_ops/webgpu/bert/split_packed_qkv_with_rotary_embedding_and_copykv.wgsl.template
+++ b/onnxruntime/contrib_ops/webgpu/bert/split_packed_qkv_with_rotary_embedding_and_copykv.wgsl.template
@@ -41,12 +41,13 @@ $MAIN {
 #endif
 
 #if prepare_indirect_dispatch
-  // Prepare indirect dispatch buffer for thread 0
   if (global_idx == 0u) {
     let num_total_seq_length_tile = (total_seqlen + uniforms.tile_size - 1u) / uniforms.tile_size;
-    indirect_buffer[0] = num_total_seq_length_tile;
-    indirect_buffer[1] = uniforms.num_heads;
-    indirect_buffer[2] = 1u;
+    // Mirror the direct-dispatch formula at the FlashAttentionDecodeQKT call site:
+    // batch_size * num_heads * num_total_seq_length_tile. batch_size is read from
+    // query_shape[0]; query is shaped (batch_size, sequence_length, hidden_size).
+    let total = uniforms.query_shape[0] * uniforms.num_heads * num_total_seq_length_tile;
+    write_indirect_dispatch(total);
   }
 #endif
 


### PR DESCRIPTION
## Summary

- Add a shared WGSL helper ``write_indirect_dispatch(total)`` that mirrors the host-side ``ProgramManager::NormalizeDispatchGroupSize`` 2D (sqrt) tier on the GPU, and use it from ``CopyKVCacheProgram`` and ``SplitPackedQKVWithRotaryEmbeddingAndCopyKVProgram``.
- Replace the previous inline 3D writes ``[num_total_seq_length_tile, num_heads, 1]`` with a flat ``total = batch_size * num_heads * num_total_seq_length_tile``, structurally matching the direct-dispatch formula at the ``FlashAttentionDecodeQKT`` call site.
- ``batch_size`` is read from existing shape uniforms (``copy_kv_shape[0]`` / ``query_shape[0]``); no new uniform is added.

## Motivation

The host-side dispatch path uses ``ProgramManager::NormalizeDispatchGroupSize`` to split a 1D group count into a 2D layout when it would exceed the WebGPU per-dimension limit (``maxComputeWorkgroupsPerDimension``, 65535 per the spec). The indirect-dispatch path, where the dispatch size is computed on the GPU, skipped this normalization, leaving a ``// TODO: Add NormalizeDispatchGroupSize logic here to avoid exceeding max dispatch size.`` in ``CopyKVCacheProgram``.

The previous inline writes also dropped the ``batch_size`` factor that the direct path uses, which happened to work because today's call sites run with ``batch_size == 1`` but was structurally fragile.

Consumer shaders are unchanged: ``shader_helper`` always flattens ``workgroup_id (x, y, z)`` into a linear ``workgroup_idx``, so the 1D-vs-2D split is transparent to consumers.

## Test plan

- [x] Build: ``cmake --build build/Windows/Release --config Release --target onnxruntime --parallel 4`` — clean
- [x] Lint: ``lintrunner -a`` — no issues
- [x] Correctness on phi4-graph-prune with ``verify_model_correctness.py``: 3/3 queries match reference output (math, factual, math)
- [x] Multi-generator correctness with ``verify_multi_gen.py``: 3 sequential matches + 2 overlapping coherent — PASSED
- [x] 2D-split path exercised under a forced threshold (``let limit = 1u``): same scripts pass, confirming the sqrt split produces a correct indirect dispatch
- [x] Production threshold (``let limit = 65535u``) verified in built and deployed DLL via binary inspection