### PR TITLE
[WebGPU] Enable Cast to int64 by default

### DIFF
--- a/onnxruntime/core/providers/webgpu/shader_variable.cc
+++ b/onnxruntime/core/providers/webgpu/shader_variable.cc
@@ -367,7 +367,7 @@ std::string ShaderVariableHelper::GetByOffsetImpl(std::string_view offset) const
   return SS_GET(ss);
 }
 
-std::string ShaderVariableHelper::SetByOffsetImpl(std::string_view offset, std::string_view value) const {
+std::string ShaderVariableHelper::SetByOffsetImpl(std::string_view offset, std::string_view value, bool use_storage_type) const {
   SS(ss, kStringInitialSizeSetByOffsetImpl);
 
   if (usage_ & ShaderUsage::UseSetByOffsetSegments) {
@@ -379,7 +379,13 @@ std::string ShaderVariableHelper::SetByOffsetImpl(std::string_view offset, std::
       ORT_THROW("Invalid type");
       break;
     case onnxruntime::webgpu::ProgramVariableDataType::Int64:
-      ss << name_ << "[" << offset << "]=vec2<u32>(u32(" << value << "), select(0u, 0xFFFFFFFFu, i32(" << value << ") < 0));";
+      if (use_storage_type) {
+        // Value is already storage type (vec2<u32>), use directly
+        ss << name_ << "[" << offset << "]=" << value << ";";
+      } else {
+        // Value is i32, sign-extend to int64 (vec2<u32>)
+        ss << name_ << "[" << offset << "]=vec2<u32>(u32(" << value << "), select(0u, 0xFFFFFFFFu, i32(" << value << ") < 0));";
+      }
       break;
     case onnxruntime::webgpu::ProgramVariableDataType::Uint64:
       ss << name_ << "[" << offset << "]=vec2<u32>(u32(" << value << "), 0u);";

--- a/onnxruntime/core/providers/webgpu/shader_variable.h
+++ b/onnxruntime/core/providers/webgpu/shader_variable.h
@@ -177,8 +177,9 @@ class ShaderVariableHelper : public ShaderIndicesHelper {
   // create a WGSL statement for setting data at the given offset.
   // \param offset: a WGSL expression (u32) representing the offset.
   // \param value: the value ({varname}_value_t) to set.
+  // \param use_storage_type: for int64, if true expects vec2<u32> (storage type) instead of i32.
   template <typename TOffset, typename TValue>
-  inline std::string SetByOffset(TOffset&& offset, TValue&& value) const;
+  inline std::string SetByOffset(TOffset&& offset, TValue&& value, bool use_storage_type = false) const;
 
   // create a WGSL expression ({varname}_value_t) for getting data at the given indices.
   // \param indices: a list of indices values (u32).
@@ -200,7 +201,7 @@ class ShaderVariableHelper : public ShaderIndicesHelper {
   void Impl(OStringStream& ss) const;
 
   std::string GetByOffsetImpl(std::string_view offset) const;
-  std::string SetByOffsetImpl(std::string_view offset, std::string_view value) const;
+  std::string SetByOffsetImpl(std::string_view offset, std::string_view value, bool use_storage_type) const;
   std::string_view StorageType() const;
   std::string_view ValueType() const;
   std::string_view ElementType() const;
@@ -297,8 +298,8 @@ inline std::string ShaderIndicesHelper::IndicesGet(std::string_view indices_var,
 }
 
 template <typename TOffset, typename TValue>
-inline std::string ShaderVariableHelper::SetByOffset(TOffset&& offset, TValue&& value) const {
-  return SetByOffsetImpl(detail::pass_as_string(offset), detail::pass_as_string(value));
+inline std::string ShaderVariableHelper::SetByOffset(TOffset&& offset, TValue&& value, bool use_storage_type) const {
+  return SetByOffsetImpl(detail::pass_as_string(offset), detail::pass_as_string(value), use_storage_type);
 }
 
 template <typename... TIndicesAndValue>

--- a/onnxruntime/core/providers/webgpu/tensor/cast.cc
+++ b/onnxruntime/core/providers/webgpu/tensor/cast.cc
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <array>
+#include <string>
 #include <vector>
 
 #include "core/providers/webgpu/tensor/cast.h"
@@ -19,19 +21,24 @@ Status Cast::ComputeInternal(ComputeContext& context) const {
     return Status::OK();
   }
   bool is_from_int64 = input_tensor->DataType() == DataTypeImpl::GetType<int64_t>();
+  bool is_from_float = input_tensor->DataType() == DataTypeImpl::GetType<float>() ||
+                       input_tensor->DataType() == DataTypeImpl::GetType<MLFloat16>();
+  bool is_from_unsigned = input_tensor->DataType() == DataTypeImpl::GetType<uint32_t>() ||
+                          input_tensor->DataType() == DataTypeImpl::GetType<bool>();
   const int in_components = is_from_int64 ? 1 : 4;
   const int out_components = to_ == ONNX_NAMESPACE::TensorProto_DataType_INT64 ? 1 : 4;
   uint32_t vec_size = onnxruntime::narrow<uint32_t>((size + 3) / 4);
   uint32_t in_vec_size = onnxruntime::narrow<uint32_t>(in_components == 1 ? size : vec_size);
   uint32_t out_vec_size = onnxruntime::narrow<uint32_t>(out_components == 1 ? size : vec_size);
 
-  CastProgram program{to_, is_from_int64};
+  CastProgram program{to_, is_from_int64, is_from_float, is_from_unsigned};
   program
       .AddInput({input_tensor, ProgramTensorMetadataDependency::Type, {in_vec_size}, in_components})
       .AddOutput({output_tensor, ProgramTensorMetadataDependency::None, {out_vec_size}, out_components})
       .SetDispatchGroupSize((vec_size + WORKGROUP_SIZE - 1) / WORKGROUP_SIZE)
       .AddUniformVariables({
           {static_cast<uint32_t>(vec_size)},
+          {static_cast<uint32_t>(size)},
       })
       .CacheHint(std::to_string(to_));
   return context.RunProgram(program);
@@ -64,22 +71,97 @@ Status CastProgram::GenerateShaderCode(ShaderHelper& sh) const {
       ORT_NOT_IMPLEMENTED("Cast to type ", to_, " is not supported.");
   }
 
+  // float32 -> int64 via IEEE 754 bit decomposition:
+  //   - Finite values: truncated toward zero (matches C++ static_cast<int64_t>).
+  //   - Zero/subnormals: 0.
+  //   - Out-of-range, +/-Inf, NaN: saturate by sign to INT64_MAX / INT64_MIN.
+  // Saturation is spec-compliant (ONNX leaves these undefined) but differs from x86 static_cast,
+  // so don't pin a specific NaN->int64 result in cross-EP tests.
+  if (to_ == ONNX_NAMESPACE::TensorProto_DataType_INT64 && is_from_float_) {
+    sh.AdditionalImplementation() << "fn float_to_int64(f: f32) -> vec2<u32> {\n"
+                                     "  let bits = bitcast<u32>(f);\n"
+                                     "  let sign = (bits >> 31u) & 1u;\n"
+                                     "  let biased_exp = (bits >> 23u) & 0xFFu;\n"
+                                     "  let mantissa = bits & 0x7FFFFFu;\n"
+                                     "  if (biased_exp == 0u) {\n"
+                                     "    return vec2<u32>(0u, 0u);\n"
+                                     "  }\n"
+                                     "  if (biased_exp == 255u) {\n"
+                                     "    return select(vec2<u32>(0xFFFFFFFFu, 0x7FFFFFFFu),\n"
+                                     "                  vec2<u32>(0u, 0x80000000u), sign == 1u);\n"
+                                     "  }\n"
+                                     "  let sig = 0x800000u | mantissa;\n"
+                                     "  let exp = i32(biased_exp) - 150;\n"
+                                     "  var low: u32 = 0u;\n"
+                                     "  var high: u32 = 0u;\n"
+                                     "  if (exp >= 40) {\n"
+                                     "    return select(vec2<u32>(0xFFFFFFFFu, 0x7FFFFFFFu),\n"
+                                     "                  vec2<u32>(0u, 0x80000000u), sign == 1u);\n"
+                                     "  } else if (exp >= 32) {\n"
+                                     "    high = sig << u32(exp - 32);\n"
+                                     "  } else if (exp > 0) {\n"
+                                     "    low = sig << u32(exp);\n"
+                                     "    high = sig >> u32(32 - exp);\n"
+                                     "  } else if (exp == 0) {\n"
+                                     "    low = sig;\n"
+                                     "  } else if (exp > -24) {\n"
+                                     "    low = sig >> u32(-exp);\n"
+                                     "  }\n"
+                                     "  if (sign == 1u) {\n"
+                                     "    let carry = select(0u, 1u, low == 0u);\n"
+                                     "    low = ~low + 1u;\n"
+                                     "    high = ~high + carry;\n"
+                                     "  }\n"
+                                     "  return vec2<u32>(low, high);\n"
+                                     "}\n";
+  }
+
   sh.MainFunctionBody() << sh.GuardAgainstOutOfBoundsWorkgroupSizes("uniforms.vec_size");
-  if (is_from_int64_) {
+
+  if (is_from_int64_ && to_ != ONNX_NAMESPACE::TensorProto_DataType_INT64) {
+    // int64 -> non-int64
     sh.MainFunctionBody() << "  let a0 = " << input.GetByOffset("global_idx * 4") << ";\n"
                           << "  let a1 = " << input.GetByOffset("global_idx * 4 + 1") << ";\n"
                           << "  let a2 = " << input.GetByOffset("global_idx * 4 + 2") << ";\n"
                           << "  let a3 = " << input.GetByOffset("global_idx * 4 + 3") << ";\n"
                           << "  let a = vec4<i32>(a0, a1, a2, a3);\n";
+    sh.MainFunctionBody() << output.SetByOffset("global_idx", expression);
+  } else if (to_ == ONNX_NAMESPACE::TensorProto_DataType_INT64) {
+    // cast to int64
+    std::array<std::string, 4> values;
+    constexpr std::array<char, 4> kLanes{'x', 'y', 'z', 'w'};
+    if (is_from_int64_) {
+      // int64 -> int64: straight 64-bit copy of the vec2<u32> (low, high) pair.
+      sh.MainFunctionBody() << "  let base = global_idx * 4u;\n";
+      for (size_t i = 0; i < 4; ++i) {
+        values[i] = MakeStringWithClassicLocale("x[base + ", i, "u]");
+      }
+    } else {
+      sh.MainFunctionBody() << "  let a = " << input.GetByOffset("global_idx") << ";\n"
+                            << "  let base = global_idx * 4u;\n";
+      for (size_t i = 0; i < 4; ++i) {
+        if (is_from_float_) {
+          // float32/float16 -> int64: IEEE 754 bit decomposition. float16 reuses the
+          // float32 helper since every f16 value is exactly representable as f32.
+          values[i] = MakeStringWithClassicLocale("float_to_int64(f32(a.", kLanes[i], "))");
+        } else if (is_from_unsigned_) {
+          // uint32/bool -> int64: zero-extend.
+          values[i] = MakeStringWithClassicLocale("vec2<u32>(u32(a.", kLanes[i], "), 0u)");
+        } else {
+          // int32 -> int64: sign-extend.
+          values[i] = MakeStringWithClassicLocale(
+              "vec2<u32>(u32(a.", kLanes[i], "), select(0u, 0xFFFFFFFFu, i32(a.", kLanes[i], ") < 0))");
+        }
+      }
+    }
+    sh.MainFunctionBody() << "  y[base] = " << values[0] << ";\n";
+    for (size_t i = 1; i < 4; ++i) {
+      sh.MainFunctionBody() << "  if (base + " << i << "u < uniforms.output_size) { y[base + " << i
+                            << "u] = " << values[i] << "; }\n";
+    }
   } else {
+    // generic cast (no int64 involved).
     sh.MainFunctionBody() << "  let a = " << input.GetByOffset("global_idx") << ";\n";
-  }
-  if (to_ == ONNX_NAMESPACE::TensorProto_DataType_INT64) {
-    sh.MainFunctionBody() << output.SetByOffset("global_idx * 4", "a.x") << "\n"
-                          << output.SetByOffset("global_idx * 4 + 1", "a.y") << "\n"
-                          << output.SetByOffset("global_idx * 4 + 2", "a.z") << "\n"
-                          << output.SetByOffset("global_idx * 4 + 3", "a.w") << "\n";
-  } else {
     sh.MainFunctionBody() << output.SetByOffset("global_idx", expression);
   }
 
@@ -88,7 +170,9 @@ Status CastProgram::GenerateShaderCode(ShaderHelper& sh) const {
 
 template <int StartVersion, int EndVersion>
 KernelCreateInfo CreateCastKernelInfo(bool enable_int64) {
-  const auto& type_constraints = GetOpTypeConstraints(enable_int64, true);
+  // Casting to int64 is always supported. Casting *from* int64 (int64 in T1/input) stays guarded by enable_int64.
+  const auto& t1_constraints = GetOpTypeConstraints(/*enable_int64=*/enable_int64, /*enable_bool=*/true);
+  const auto& t2_constraints = GetOpTypeConstraints(/*enable_int64=*/true, /*enable_bool=*/true);
 
   KernelCreatePtrFn kernel_create_fn = [](FuncManager&, const OpKernelInfo& info, std::unique_ptr<OpKernel>& out) -> Status {
     out = std::make_unique<Cast>(info);
@@ -96,27 +180,25 @@ KernelCreateInfo CreateCastKernelInfo(bool enable_int64) {
   };
 
   if constexpr (StartVersion == EndVersion) {
-    // Non-versioned kernel
     return {
         KernelDefBuilder()
             .SetName("Cast")
             .SetDomain(kOnnxDomain)
             .SinceVersion(StartVersion)
             .Provider(kWebGpuExecutionProvider)
-            .TypeConstraint("T1", type_constraints)
-            .TypeConstraint("T2", type_constraints)
+            .TypeConstraint("T1", t1_constraints)
+            .TypeConstraint("T2", t2_constraints)
             .Build(),
         kernel_create_fn};
   } else {
-    // Versioned kernel
     return {
         KernelDefBuilder()
             .SetName("Cast")
             .SetDomain(kOnnxDomain)
             .SinceVersion(StartVersion, EndVersion)
             .Provider(kWebGpuExecutionProvider)
-            .TypeConstraint("T1", type_constraints)
-            .TypeConstraint("T2", type_constraints)
+            .TypeConstraint("T1", t1_constraints)
+            .TypeConstraint("T2", t2_constraints)
             .Build(),
         kernel_create_fn};
   }

--- a/onnxruntime/core/providers/webgpu/tensor/cast.cc
+++ b/onnxruntime/core/providers/webgpu/tensor/cast.cc
@@ -154,6 +154,9 @@ Status CastProgram::GenerateShaderCode(ShaderHelper& sh) const {
         }
       }
     }
+    // Note: Direct array assignment is used here instead of output.SetByOffset() because
+    // the values are already vec2<u32> (64-bit representations), not int32 scalars.
+    // SetByOffset would incorrectly try to convert int32 to int64.
     sh.MainFunctionBody() << "  y[base] = " << values[0] << ";\n";
     for (size_t i = 1; i < 4; ++i) {
       sh.MainFunctionBody() << "  if (base + " << i << "u < uniforms.output_size) { y[base + " << i

--- a/onnxruntime/core/providers/webgpu/tensor/cast.cc
+++ b/onnxruntime/core/providers/webgpu/tensor/cast.cc
@@ -118,8 +118,10 @@ Status CastProgram::GenerateShaderCode(ShaderHelper& sh) const {
 
   sh.MainFunctionBody() << sh.GuardAgainstOutOfBoundsWorkgroupSizes("uniforms.vec_size");
 
-  if (is_from_int64_ && to_ != ONNX_NAMESPACE::TensorProto_DataType_INT64) {
-    // int64 -> non-int64
+  if (is_from_int64_) {
+    // int64 -> any (including int64)
+    // Note: int64 inputs are not enabled by default (requires enable_int64).
+    // This path handles the downcast to 32-bit types.
     // Load lanes 1-3 conditionally to avoid out-of-bounds reads when size % 4 != 0.
     // Lane 0 is always valid due to the workgroup size guard.
     sh.MainFunctionBody() << "  let base = global_idx * 4u;\n"
@@ -132,42 +134,45 @@ Status CastProgram::GenerateShaderCode(ShaderHelper& sh) const {
                             << " = " << input.GetByOffset(MakeStringWithClassicLocale("base + ", i, "u")) << "; }\n";
     }
     sh.MainFunctionBody() << "  let a = vec4<i32>(a0, a1, a2, a3);\n";
-    sh.MainFunctionBody() << output.SetByOffset("global_idx", expression);
-  } else if (to_ == ONNX_NAMESPACE::TensorProto_DataType_INT64) {
-    // cast to int64
-    std::array<std::string, 4> values;
-    constexpr std::array<char, 4> kLanes{'x', 'y', 'z', 'w'};
-    if (is_from_int64_) {
-      // int64 -> int64: straight 64-bit copy of the vec2<u32> (low, high) pair.
-      sh.MainFunctionBody() << "  let base = global_idx * 4u;\n";
-      for (size_t i = 0; i < 4; ++i) {
-        values[i] = MakeStringWithClassicLocale("x[base + ", i, "u]");
+    if (to_ == ONNX_NAMESPACE::TensorProto_DataType_INT64) {
+      // int64 -> int64
+      constexpr std::array<char, 4> kLanes{'x', 'y', 'z', 'w'};
+      sh.MainFunctionBody() << output.SetByOffset("base", "a.x");
+      for (size_t i = 1; i < 4; ++i) {
+        sh.MainFunctionBody() << "  if (base + " << i << "u < uniforms.output_size) { "
+                              << output.SetByOffset(MakeStringWithClassicLocale("base + ", i, "u"),
+                                                    MakeStringWithClassicLocale("a.", kLanes[i]))
+                              << " }\n";
       }
     } else {
-      sh.MainFunctionBody() << "  let a = " << input.GetByOffset("global_idx") << ";\n"
-                            << "  let base = global_idx * 4u;\n";
-      for (size_t i = 0; i < 4; ++i) {
-        if (is_from_float_) {
-          // float32/float16 -> int64: IEEE 754 bit decomposition. float16 reuses the
-          // float32 helper since every f16 value is exactly representable as f32.
-          values[i] = MakeStringWithClassicLocale("float_to_int64(f32(a.", kLanes[i], "))");
-        } else if (is_from_unsigned_) {
-          // uint32/bool -> int64: zero-extend.
-          values[i] = MakeStringWithClassicLocale("vec2<u32>(u32(a.", kLanes[i], "), 0u)");
-        } else {
-          // int32 -> int64: sign-extend.
-          values[i] = MakeStringWithClassicLocale(
-              "vec2<u32>(u32(a.", kLanes[i], "), select(0u, 0xFFFFFFFFu, i32(a.", kLanes[i], ") < 0))");
-        }
+      sh.MainFunctionBody() << output.SetByOffset("global_idx", expression);
+    }
+  } else if (to_ == ONNX_NAMESPACE::TensorProto_DataType_INT64) {
+    // cast to int64 (non-int64 inputs only)
+    std::array<std::string, 4> values;
+    constexpr std::array<char, 4> kLanes{'x', 'y', 'z', 'w'};
+    sh.MainFunctionBody() << "  let a = " << input.GetByOffset("global_idx") << ";\n"
+                          << "  let base = global_idx * 4u;\n";
+    for (size_t i = 0; i < 4; ++i) {
+      if (is_from_float_) {
+        // float32/float16 -> int64: IEEE 754 bit decomposition. float16 reuses the
+        // float32 helper since every f16 value is exactly representable as f32.
+        values[i] = MakeStringWithClassicLocale("float_to_int64(f32(a.", kLanes[i], "))");
+      } else if (is_from_unsigned_) {
+        // uint32/bool -> int64: zero-extend.
+        values[i] = MakeStringWithClassicLocale("vec2<u32>(u32(a.", kLanes[i], "), 0u)");
+      } else {
+        // int32 -> int64: sign-extend.
+        values[i] = MakeStringWithClassicLocale(
+            "vec2<u32>(u32(a.", kLanes[i], "), select(0u, 0xFFFFFFFFu, i32(a.", kLanes[i], ") < 0))");
       }
     }
-    // Note: Direct array assignment is used here instead of output.SetByOffset() because
-    // the values are already vec2<u32> (64-bit representations).
-    // SetByOffset would incorrectly try to convert int32 to int64.
-    sh.MainFunctionBody() << "  y[base] = " << values[0] << ";\n";
+    // Use use_storage_type=true to write vec2<u32> directly.
+    sh.MainFunctionBody() << output.SetByOffset("base", values[0], /*use_storage_type=*/true);
     for (size_t i = 1; i < 4; ++i) {
-      sh.MainFunctionBody() << "  if (base + " << i << "u < uniforms.output_size) { y[base + " << i
-                            << "u] = " << values[i] << "; }\n";
+      sh.MainFunctionBody() << "  if (base + " << i << "u < uniforms.output_size) { "
+                            << output.SetByOffset(MakeStringWithClassicLocale("base + ", i, "u"), values[i], /*use_storage_type=*/true)
+                            << " }\n";
     }
   } else {
     // generic cast (no int64 involved).

--- a/onnxruntime/core/providers/webgpu/tensor/cast.cc
+++ b/onnxruntime/core/providers/webgpu/tensor/cast.cc
@@ -120,11 +120,18 @@ Status CastProgram::GenerateShaderCode(ShaderHelper& sh) const {
 
   if (is_from_int64_ && to_ != ONNX_NAMESPACE::TensorProto_DataType_INT64) {
     // int64 -> non-int64
-    sh.MainFunctionBody() << "  let a0 = " << input.GetByOffset("global_idx * 4") << ";\n"
-                          << "  let a1 = " << input.GetByOffset("global_idx * 4 + 1") << ";\n"
-                          << "  let a2 = " << input.GetByOffset("global_idx * 4 + 2") << ";\n"
-                          << "  let a3 = " << input.GetByOffset("global_idx * 4 + 3") << ";\n"
-                          << "  let a = vec4<i32>(a0, a1, a2, a3);\n";
+    // Load lanes 1-3 conditionally to avoid out-of-bounds reads when size % 4 != 0.
+    // Lane 0 is always valid due to the workgroup size guard.
+    sh.MainFunctionBody() << "  let base = global_idx * 4u;\n"
+                          << "  let a0 = " << input.GetByOffset("base") << ";\n"
+                          << "  var a1: i32 = 0;\n"
+                          << "  var a2: i32 = 0;\n"
+                          << "  var a3: i32 = 0;\n";
+    for (size_t i = 1; i < 4; ++i) {
+      sh.MainFunctionBody() << "  if (base + " << i << "u < uniforms.output_size) { a" << i
+                            << " = " << input.GetByOffset(MakeStringWithClassicLocale("base + ", i, "u")) << "; }\n";
+    }
+    sh.MainFunctionBody() << "  let a = vec4<i32>(a0, a1, a2, a3);\n";
     sh.MainFunctionBody() << output.SetByOffset("global_idx", expression);
   } else if (to_ == ONNX_NAMESPACE::TensorProto_DataType_INT64) {
     // cast to int64
@@ -155,7 +162,7 @@ Status CastProgram::GenerateShaderCode(ShaderHelper& sh) const {
       }
     }
     // Note: Direct array assignment is used here instead of output.SetByOffset() because
-    // the values are already vec2<u32> (64-bit representations), not int32 scalars.
+    // the values are already vec2<u32> (64-bit representations).
     // SetByOffset would incorrectly try to convert int32 to int64.
     sh.MainFunctionBody() << "  y[base] = " << values[0] << ";\n";
     for (size_t i = 1; i < 4; ++i) {

--- a/onnxruntime/core/providers/webgpu/tensor/cast.h
+++ b/onnxruntime/core/providers/webgpu/tensor/cast.h
@@ -12,15 +12,19 @@ namespace webgpu {
 
 class CastProgram final : public Program<CastProgram> {
  public:
-  CastProgram(int32_t to, bool is_from_int64) : Program{"Cast"}, to_{to}, is_from_int64_{is_from_int64} {}
+  CastProgram(int32_t to, bool is_from_int64, bool is_from_float, bool is_from_unsigned)
+      : Program{"Cast"}, to_{to}, is_from_int64_{is_from_int64}, is_from_float_{is_from_float}, is_from_unsigned_{is_from_unsigned} {}
 
   Status GenerateShaderCode(ShaderHelper& sh) const override;
 
-  WEBGPU_PROGRAM_DEFINE_UNIFORM_VARIABLES({"vec_size", ProgramUniformVariableDataType::Uint32});
+  WEBGPU_PROGRAM_DEFINE_UNIFORM_VARIABLES({"vec_size", ProgramUniformVariableDataType::Uint32},
+                                          {"output_size", ProgramUniformVariableDataType::Uint32});
 
  private:
   int32_t to_;
   bool is_from_int64_;
+  bool is_from_float_;
+  bool is_from_unsigned_;
 };
 
 class Cast final : public WebGpuKernel {

--- a/onnxruntime/test/providers/cpu/tensor/cast_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/cast_op_test.cc
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include <cstring>
+#include <limits>
 #include <type_traits>
 
 #include "boost/mp11.hpp"
@@ -3496,6 +3497,261 @@ TEST(CastOpTest, FloatToFloat8E8M0_ExactMax) {
 }
 
 #endif  // !defined(DISABLE_FLOAT8_TYPES)
+
+TEST(CastOpTest, Float32ToInt64_LargeValues) {
+  const std::vector<int64_t> shape{8};
+  const std::vector<float> input = {
+      1099511627776.0f,     // 2^40, exact in f32
+      -1099511627776.0f,    // -2^40, exact in f32
+      140737488355328.0f,   // 2^47, exact in f32
+      -140737488355328.0f,  // -2^47, exact in f32
+      9007199254740992.0f,  // 2^53
+      0.0f,                 // zero
+      1.5f,                 // truncates to 1
+      -1.5f,                // truncates to -1
+  };
+  const std::vector<int64_t> expected = {
+      1099511627776LL,
+      -1099511627776LL,
+      140737488355328LL,
+      -140737488355328LL,
+      static_cast<int64_t>(9007199254740992.0f),
+      0LL,
+      1LL,
+      -1LL,
+  };
+  TestCastOp(gsl::make_span(input), gsl::make_span(expected), shape);
+}
+
+TEST(CastOpTest, Float32ToInt64_PowersOfTwo) {
+  const std::vector<int64_t> shape{4};
+  const std::vector<float> input = {
+      8589934592.0f,   // 2^33
+      17179869184.0f,  // 2^34
+      4294967296.0f,   // 2^32
+      -4294967296.0f,  // -2^32
+  };
+  const std::vector<int64_t> expected = {
+      8589934592LL,
+      17179869184LL,
+      4294967296LL,
+      -4294967296LL,
+  };
+  TestCastOp(gsl::make_span(input), gsl::make_span(expected), shape);
+}
+
+TEST(CastOpTest, Float32ToInt64_VeryLargeValues) {
+  const std::vector<int64_t> shape{8};
+  const std::vector<float> input = {
+      36028797018963968.0f,     // 2^55, boundary into the exp >= 32 branch
+      -36028797018963968.0f,    // -2^55
+      1152921504606846976.0f,   // 2^60
+      -1152921504606846976.0f,  // -2^60
+      4611686018427387904.0f,   // 2^62, largest power of two < 2^63
+      -4611686018427387904.0f,  // -2^62
+      18014398509481984.0f,     // 2^54, last value still in the exp > 0 branch
+      -18014398509481984.0f,    // -2^54
+  };
+  const std::vector<int64_t> expected = {
+      36028797018963968LL,
+      -36028797018963968LL,
+      1152921504606846976LL,
+      -1152921504606846976LL,
+      4611686018427387904LL,
+      -4611686018427387904LL,
+      18014398509481984LL,
+      -18014398509481984LL,
+  };
+  TestCastOp(gsl::make_span(input), gsl::make_span(expected), shape);
+}
+
+TEST(CastOpTest, Float32ToInt64_MantissaBoundary) {
+  const std::vector<int64_t> shape{4};
+  const std::vector<float> input = {
+      8388608.0f,   // 2^23, boundary into the exp == 0 branch
+      8388609.0f,   // 2^23 + 1
+      -8388609.0f,  // -(2^23 + 1)
+      16777215.0f,  // 2^24 - 1, last value before exp > 0
+  };
+  const std::vector<int64_t> expected = {
+      8388608LL,
+      8388609LL,
+      -8388609LL,
+      16777215LL,
+  };
+  TestCastOp(gsl::make_span(input), gsl::make_span(expected), shape);
+}
+
+TEST(CastOpTest, Float32ToInt64_TinyValues) {
+  const std::vector<int64_t> shape{4};
+  const std::vector<float> input = {
+      0.5f,
+      -0.5f,
+      0.999f,
+      1e-20f,  // far below the exp > -24 cutoff -> 0
+  };
+  const std::vector<int64_t> expected = {
+      0LL,
+      0LL,
+      0LL,
+      0LL,
+  };
+  TestCastOp(gsl::make_span(input), gsl::make_span(expected), shape);
+}
+
+TEST(CastOpTest, Float16ToInt64_LargeValues) {
+  const std::vector<int64_t> shape{4};
+  const std::vector<MLFloat16> input = {
+      MLFloat16(32768.0f),   // 2^15, exact in f16
+      MLFloat16(-32768.0f),  // -2^15
+      MLFloat16(65504.0f),   // f16 max finite
+      MLFloat16(-65504.0f),  // f16 min finite
+  };
+  const std::vector<int64_t> expected = {
+      32768LL,
+      -32768LL,
+      65504LL,
+      -65504LL,
+  };
+  TestCastOp(gsl::make_span(input), gsl::make_span(expected), shape);
+}
+
+TEST(CastOpTest, Float32ToInt64_SpecialValues) {
+  // float infinity/NaN -> int64 is undefined behavior in C++.
+  // Only test well-defined conversions here (zero, small values).
+  const std::vector<int64_t> shape{4};
+  const std::vector<float> input = {
+      0.0f,
+      -0.0f,
+      1.0f,
+      -1.0f,
+  };
+  const std::vector<int64_t> expected = {
+      0LL,
+      0LL,
+      1LL,
+      -1LL,
+  };
+  TestCastOp(gsl::make_span(input), gsl::make_span(expected), shape);
+}
+
+TEST(CastOpTest, Int32ToInt64) {
+  // int32 -> int64 must sign-extend
+  const std::vector<int64_t> shape{8};
+  const std::vector<int32_t> input = {
+      0,
+      1,
+      -1,
+      std::numeric_limits<int32_t>::max(),  // 2^31 - 1
+      std::numeric_limits<int32_t>::min(),  // -2^31
+      -12345,
+      32767,
+      -32768,
+  };
+  const std::vector<int64_t> expected = {
+      0LL,
+      1LL,
+      -1LL,
+      2147483647LL,
+      -2147483648LL,
+      -12345LL,
+      32767LL,
+      -32768LL,
+  };
+  TestCastOp(gsl::make_span(input), gsl::make_span(expected), shape);
+}
+
+TEST(CastOpTest, UInt32ToInt64) {
+  // uint32 -> int64 must zero-extend
+  const std::vector<int64_t> shape{8};
+  const std::vector<uint32_t> input = {
+      0u,
+      1u,
+      0x80000000u,                           // 2^31, top bit set
+      std::numeric_limits<uint32_t>::max(),  // 2^32 - 1
+      123456u,
+      0x7FFFFFFFu,  // 2^31 - 1
+      0xFFFFFFFEu,  // 2^32 - 2
+      0xC0000000u,  // 3 * 2^30
+  };
+  const std::vector<int64_t> expected = {
+      0LL,
+      1LL,
+      2147483648LL,
+      4294967295LL,
+      123456LL,
+      2147483647LL,
+      4294967294LL,
+      3221225472LL,
+  };
+  TestCastOp(gsl::make_span(input), gsl::make_span(expected), shape);
+}
+
+TEST(CastOpTest, BoolToInt64) {
+  // bool -> int64 zero-extends to 0 or 1.
+  const std::vector<int64_t> shape{4};
+  const bool bool_input[] = {false, true, true, false};
+  const gsl::span<const bool> bool_input_span(bool_input);
+  const std::vector<int64_t> expected = {
+      0LL,
+      1LL,
+      1LL,
+      0LL,
+  };
+  TestCastOp(bool_input_span, gsl::make_span(expected), shape);
+}
+
+// Regression tests for int64 non-multiple-of-4 element counts.
+// size % 4 == 2
+TEST(CastOpTest, Float32ToInt64_SizeMod4Eq2) {
+  const std::vector<int64_t> shape{2};
+  const std::vector<float> input = {1.5f, -2.5f};
+  const std::vector<int64_t> expected = {1LL, -2LL};
+  TestCastOp(gsl::make_span(input), gsl::make_span(expected), shape);
+}
+
+TEST(CastOpTest, Float32ToInt64_SizeMod4Eq2_Large) {
+  const std::vector<int64_t> shape{6};
+  const std::vector<float> input = {
+      4294967296.0f,   // 2^32
+      -4294967296.0f,  // -2^32
+      8589934592.0f,   // 2^33
+      1.0f,
+      -1.0f,
+      1099511627776.0f,  // 2^40
+  };
+  const std::vector<int64_t> expected = {
+      4294967296LL,
+      -4294967296LL,
+      8589934592LL,
+      1LL,
+      -1LL,
+      1099511627776LL,
+  };
+  TestCastOp(gsl::make_span(input), gsl::make_span(expected), shape);
+}
+
+TEST(CastOpTest, Int32ToInt64_SizeMod4Eq2) {
+  const std::vector<int64_t> shape{2};
+  const std::vector<int32_t> input = {-1, std::numeric_limits<int32_t>::min()};
+  const std::vector<int64_t> expected = {-1LL, -2147483648LL};
+  TestCastOp(gsl::make_span(input), gsl::make_span(expected), shape);
+}
+
+TEST(CastOpTest, UInt32ToInt64_SizeMod4Eq2) {
+  const std::vector<int64_t> shape{2};
+  const std::vector<uint32_t> input = {0x80000000u, std::numeric_limits<uint32_t>::max()};
+  const std::vector<int64_t> expected = {2147483648LL, 4294967295LL};
+  TestCastOp(gsl::make_span(input), gsl::make_span(expected), shape);
+}
+
+// size % 4 == 1
+TEST(CastOpTest, Int32ToInt64_SizeMod4Eq1) {
+  const std::vector<int64_t> shape{5};
+  const std::vector<int32_t> input = {0, -1, 1, std::numeric_limits<int32_t>::min(), 42};
+  const std::vector<int64_t> expected = {0LL, -1LL, 1LL, -2147483648LL, 42LL};
+  TestCastOp(gsl::make_span(input), gsl::make_span(expected), shape);
+}
 
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/cpu/tensor/cast_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/cast_op_test.cc
@@ -64,7 +64,8 @@ void TestCastOp(gsl::span<const SrcType> input,
                 const std::string& expected_failure_string = "",
                 int opset = 21,
                 Saturate saturate = Saturate::None,
-                bool cuda_only = false) {
+                bool cuda_only = false,
+                const std::unordered_set<std::string>& additional_excluded_providers = {}) {
   OpTester test("Cast", opset);
   test.AddAttribute<int64_t>("to", utils::ToTensorProtoElementType<DstType>());
   test.AddInput<SrcType>("input", dimensions, input.data(), input.size());
@@ -84,6 +85,9 @@ void TestCastOp(gsl::span<const SrcType> input,
     // The OpenVINO doesn't support 0 size input
     excluded_provider_types.insert(kOpenVINOExecutionProvider);
   }
+
+  // Add any additional excluded providers
+  excluded_provider_types.insert(additional_excluded_providers.begin(), additional_excluded_providers.end());
 
   if (cuda_only && (excluded_provider_types.count(kCudaExecutionProvider) > 0)) {
     return;
@@ -3684,7 +3688,9 @@ TEST(CastOpTest, UInt32ToInt64) {
       4294967294LL,
       3221225472LL,
   };
-  TestCastOp(gsl::make_span(input), gsl::make_span(expected), shape);
+  // QNN EP doesn't correctly handle UINT_32 to INT_64 cast (sign-extends instead of zero-extends).
+  TestCastOp(gsl::make_span(input), gsl::make_span(expected), shape,
+             OpTester::ExpectResult::kExpectSuccess, "", 21, Saturate::None, false, {kQnnExecutionProvider});
 }
 
 TEST(CastOpTest, BoolToInt64) {
@@ -3742,7 +3748,10 @@ TEST(CastOpTest, UInt32ToInt64_SizeMod4Eq2) {
   const std::vector<int64_t> shape{2};
   const std::vector<uint32_t> input = {0x80000000u, std::numeric_limits<uint32_t>::max()};
   const std::vector<int64_t> expected = {2147483648LL, 4294967295LL};
-  TestCastOp(gsl::make_span(input), gsl::make_span(expected), shape);
+
+  // QNN EP doesn't correctly handle UINT_32 to INT_64 cast (sign-extends instead of zero-extends).
+  TestCastOp(gsl::make_span(input), gsl::make_span(expected), shape,
+             OpTester::ExpectResult::kExpectSuccess, "", 21, Saturate::None, false, {kQnnExecutionProvider});
 }
 
 // size % 4 == 1


### PR DESCRIPTION
### Description
Support casting to int64 from float32 via IEEE-754 bit decomposition.

- Introduce a new `float_to_int64` helper that emits the truncated-toward-zero value in full int64 range.
- `to_` type now always allows int64, regardless of `enable_int64`; casting *from* int64 stays gated by `enable_int64`.
- Adds `cast_op_test.cc` coverage for the newly introduced conversions.

### Motivation and Context
While running the mask-generation vision encoder (`Xenova/sam-vit-base`) on the WebGPU EP via Transformers.js, float32-to-int64 cast nodes fall back to the CPU provider under the default session configuration, because casting to int64 was previously gated behind `enable_int64` flag, introducing host memcpy and synchronization overhead.

Making cast-to-int64 correct across the full int64 range lets it run on the
WebGPU EP by default, keeping these nodes on-device and eliminating the stalls.

### Performance Impact

Measured on the `vision_encoder.onnx` of `Xenova/sam-vit-base` (mask-generation, SAM ViT-base vision encoder) on the
WebGPU EP.

| Platform         | Latency reduction | Speedup |
|------------------|------------------:|--------:|
| Intel Wildcat Lake |            −22.8% |   1.30× |
| Intel Panther Lake |            −17.1% |   1.21× |

This change yields a 1.2–1.3× speedup on the SAM ViT-base vision encoder under default configuration.

