### PR TITLE
[CoreML EP] Add Equal builder

### DIFF
--- a/onnxruntime/core/providers/coreml/builders/impl/equal_op_builder.cc
+++ b/onnxruntime/core/providers/coreml/builders/impl/equal_op_builder.cc
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/coreml/builders/impl/base_op_builder.h"
+#include "core/providers/coreml/builders/impl/builder_utils.h"
+#include "core/providers/coreml/builders/model_builder.h"
+#include "core/providers/coreml/builders/op_builder_factory.h"
+#include "core/providers/shared/utils/utils.h"
+
+namespace onnxruntime {
+namespace coreml {
+
+// ONNX Equal(x, y) -> CoreML ML Program 'equal'. Produces a bool tensor.
+class EqualOpBuilder : public BaseOpBuilder {
+  Status AddToModelBuilderImpl(ModelBuilder& model_builder, const Node& node,
+                               const logging::Logger& logger) const override;
+
+  bool IsOpSupportedImpl(const Node& node, const OpBuilderInputParams& input_params,
+                         const logging::Logger& logger) const override;
+
+  bool HasSupportedInputsImpl(const Node& node, const OpBuilderInputParams& input_params,
+                              const logging::Logger& logger) const override;
+
+  bool SupportsMLProgram() const override { return true; }
+};
+
+Status EqualOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, const Node& node,
+                                             const logging::Logger& /*logger*/) const {
+  using namespace CoreML::Specification::MILSpec;
+  const auto& input_defs = node.InputDefs();
+
+  // https://apple.github.io/coremltools/source/coremltools.converters.mil.mil.ops.defs.html#coremltools.converters.mil.mil.ops.defs.iOS15.elementwise_binary.equal
+  std::unique_ptr<Operation> op = model_builder.CreateOperation(node, "equal");
+  AddOperationInput(*op, "x", input_defs[0]->Name());
+  AddOperationInput(*op, "y", input_defs[1]->Name());
+  AddOperationOutput(*op, *node.OutputDefs()[0]);
+  model_builder.AddOperation(std::move(op));
+  return Status::OK();
+}
+
+bool EqualOpBuilder::IsOpSupportedImpl(const Node& node, const OpBuilderInputParams& input_params,
+                                       const logging::Logger& logger) const {
+  if (!input_params.create_mlprogram) {
+    LOGS(logger, VERBOSE) << node.OpType() << " is only supported for the ML Program format.";
+    return false;
+  }
+  return true;
+}
+
+bool EqualOpBuilder::HasSupportedInputsImpl(const Node& node, const OpBuilderInputParams& /*input_params*/,
+                                            const logging::Logger& logger) const {
+  const auto& input_defs = node.InputDefs();
+  int32_t x_type = 0, y_type = 0;
+  if (!GetType(*input_defs[0], x_type, logger) || !GetType(*input_defs[1], y_type, logger)) {
+    return false;
+  }
+
+  // ONNX Equal requires both inputs share a type. CoreML 'equal' supports
+  // float/fp16/int32/bool. (int64 is unrepresentable in the CoreML partition,
+  // since CoreML tensors are int32 at the boundary.)
+  auto is_supported_data_type = [](int32_t type) {
+    return type == ONNX_NAMESPACE::TensorProto_DataType_FLOAT ||
+           type == ONNX_NAMESPACE::TensorProto_DataType_FLOAT16 ||
+           type == ONNX_NAMESPACE::TensorProto_DataType_INT32 ||
+           type == ONNX_NAMESPACE::TensorProto_DataType_BOOL;
+  };
+  if (!is_supported_data_type(x_type) || x_type != y_type) {
+    LOGS(logger, VERBOSE) << node.OpType() << ": both inputs must share a supported type. Got: "
+                          << x_type << ", " << y_type;
+    return false;
+  }
+  return true;
+}
+
+void CreateEqualOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations) {
+  op_registrations.builders.push_back(std::make_unique<EqualOpBuilder>());
+  op_registrations.op_builder_map.emplace(op_type, op_registrations.builders.back().get());
+}
+
+}  // namespace coreml
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/coreml/builders/op_builder_factory.cc
+++ b/onnxruntime/core/providers/coreml/builders/op_builder_factory.cc
@@ -76,6 +76,7 @@ static OpBuilderRegistrations CreateOpBuilderRegistrations() {
   CreateConvOpBuilder("Conv", op_registrations);
   CreateConvTransposeOpBuilder("ConvTranspose", op_registrations);
   CreateDepthToSpaceOpBuilder("DepthToSpace", op_registrations);
+  CreateEqualOpBuilder("Equal", op_registrations);
   CreateFlattenOpBuilder("Flatten", op_registrations);
   CreateGatherOpBuilder("Gather", op_registrations);
   CreateGatherNDOpBuilder("GatherND", op_registrations);

--- a/onnxruntime/core/providers/coreml/builders/op_builder_factory.h
+++ b/onnxruntime/core/providers/coreml/builders/op_builder_factory.h
@@ -27,6 +27,7 @@ void CreateConcatOpBuilder(const std::string& op_type, OpBuilderRegistrations& o
 void CreateConvOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateConvTransposeOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateDepthToSpaceOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
+void CreateEqualOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateFlattenOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateGatherOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateGatherNDOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);

--- a/onnxruntime/test/providers/coreml/coreml_basic_test.cc
+++ b/onnxruntime/test/providers/coreml/coreml_basic_test.cc
@@ -3349,6 +3349,79 @@ TEST(CoreMLExecutionProviderTest, GatherScalarIndicesRank5DataNotSupported) {
   TestModelLoad(model_span, MakeCoreMLExecutionProvider("MLProgram"), ExpectedEPNodeAssignment::None);
 }
 
+namespace {
+// X(float graph input) Equal Y(const) -> bool cmp -> Cast(float) -> output.
+// The bool output of Equal stays internal -- CoreML partitions cannot expose
+// bool I/O, so the trailing Cast brings it back to float for the partition
+// boundary.
+std::string MakeEqualModelData() {
+  onnxruntime::Model model("equal_test", false, DefaultLoggingManager().DefaultLogger());
+  auto& graph = model.MainGraph();
+
+  auto make_type = [](int32_t elem_type) {
+    ONNX_NAMESPACE::TypeProto t;
+    t.mutable_tensor_type()->set_elem_type(elem_type);
+    for (int64_t d : {1, 4}) t.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(d);
+    return t;
+  };
+  const auto float_type = make_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+  const auto bool_type = make_type(ONNX_NAMESPACE::TensorProto_DataType_BOOL);
+
+  auto& x = graph.GetOrCreateNodeArg("X", &float_type);
+  auto& y = graph.GetOrCreateNodeArg("Y", &float_type);
+  auto& cmp = graph.GetOrCreateNodeArg("Cmp", &bool_type);
+  auto& out = graph.GetOrCreateNodeArg("Out", &float_type);
+
+  ONNX_NAMESPACE::TensorProto y_init;
+  y_init.set_name("Y");
+  y_init.set_data_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+  y_init.add_dims(1);
+  y_init.add_dims(4);
+  for (float v : {1.0f, 2.0f, 3.0f, 4.0f}) y_init.add_float_data(v);
+  graph.AddInitializedTensor(y_init);
+
+  graph.AddNode("eq", "Equal", "equal", {&x, &y}, {&cmp});
+  auto& cast = graph.AddNode("cast", "Cast", "bool -> float", {&cmp}, {&out});
+  cast.AddAttribute("to", static_cast<int64_t>(ONNX_NAMESPACE::TensorProto_DataType_FLOAT));
+
+  ORT_THROW_IF_ERROR(graph.Resolve());
+  std::string model_data;
+  model.ToProto().SerializeToString(&model_data);
+  return model_data;
+}
+}  // namespace
+
+// Equal is lowered to the ML Program 'equal' op.
+TEST(CoreMLExecutionProviderTest, Equal_MLProgram) {
+  const std::string model_data = MakeEqualModelData();
+  gsl::span<const std::byte> model_span{reinterpret_cast<const std::byte*>(model_data.data()),
+                                        model_data.size()};
+
+#if defined(__APPLE__)
+  std::vector<int64_t> dims = {1, 4};
+  OrtValue x_val;
+  CreateMLValue<float>(CPUAllocator::DefaultInstance(), dims, {1.0f, 0.0f, 3.0f, 0.0f}, &x_val);
+  NameMLValMap feeds;
+  feeds.insert(std::make_pair("X", x_val));
+
+  EPVerificationParams params{};
+  params.ep_node_assignment = ExpectedEPNodeAssignment::All;
+  RunAndVerifyOutputsWithEP(model_span, CurrentTestName(),
+                            MakeCoreMLExecutionProvider("MLProgram"), feeds, params);
+#else
+  TestModelLoad(model_span, MakeCoreMLExecutionProvider("MLProgram"), ExpectedEPNodeAssignment::All);
+#endif
+}
+
+// Equal only has an ML Program lowering; on the NeuralNetwork format the
+// graph falls back to CPU.
+TEST(CoreMLExecutionProviderTest, EqualNeuralNetworkNotSupported) {
+  const std::string model_data = MakeEqualModelData();
+  gsl::span<const std::byte> model_span{reinterpret_cast<const std::byte*>(model_data.data()),
+                                        model_data.size()};
+  TestModelLoad(model_span, MakeCoreMLExecutionProvider(), ExpectedEPNodeAssignment::None);
+}
+
 #endif  // !(ORT_MINIMAL_BUILD)
 }  // namespace test
 }  // namespace onnxruntime

--- a/tools/ci_build/github/apple/coreml_supported_mlprogram_ops.md
+++ b/tools/ci_build/github/apple/coreml_supported_mlprogram_ops.md
@@ -16,6 +16,7 @@ Keep in sync with doco generated from /docs/execution-providers/CoreML-Execution
 |ai.onnx:Ceil||
 |ai.onnx:Div||
 |ai.onnx:Elu||
+|ai.onnx:Equal|Inputs must share dtype (fp32/fp16/int32/bool); output is bool. MLProgram only.|
 |ai.onnx:Erf||
 |ai.onnx:Exp||
 |ai.onnx:GatherND|batch_dims must be 0.|


### PR DESCRIPTION
Lowers ONNX Equal to the iOS15 MIL `equal` op. Both inputs must share a
supported dtype (fp32, fp16, int32, bool). The output is bool, which cannot
sit on a CoreML partition boundary, so the meaningful test is Equal followed
by a Cast(bool->float) that brings the comparison back to a representable
boundary type. Mirrors the same internal-bool pattern used by Where in
#28597 and the And/Not work.

ML-Program-only; IsOpSupportedImpl rejects it on the NeuralNetwork format
so the graph falls back to CPU.

Tests (coreml_basic_test.cc):
- Equal_MLProgram: X(float input) Equal Y(const) -> Cast(float) runs fully
  on CoreML and matches CPU.
- EqualNeuralNetworkNotSupported: same graph falls back on NeuralNetwork.

Doc: coreml_supported_mlprogram_ops.md lists Equal.



🤖 Generated with [Claude Code](https://claude.com/claude-code)
