### PR TITLE
[CoreML EP] Add Mod builder

### DIFF
--- a/onnxruntime/core/providers/coreml/builders/impl/mod_op_builder.cc
+++ b/onnxruntime/core/providers/coreml/builders/impl/mod_op_builder.cc
@@ -1,0 +1,90 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/coreml/builders/impl/base_op_builder.h"
+#include "core/providers/coreml/builders/impl/builder_utils.h"
+#include "core/providers/coreml/builders/model_builder.h"
+#include "core/providers/coreml/builders/op_builder_factory.h"
+#include "core/providers/shared/utils/utils.h"
+
+namespace onnxruntime {
+namespace coreml {
+
+// ONNX Mod(x, y) with attribute fmod=0 -> CoreML ML Program 'mod'. Both
+// implement floor-mod semantics (sign follows the divisor / Python % style).
+// We reject fmod=1 (C-style truncated remainder, sign follows the dividend)
+// because the iOS15 MIL ops set has no native fmod and decomposing it would
+// require trunc + mul + sub, which is not worth the complexity for now.
+class ModOpBuilder : public BaseOpBuilder {
+  Status AddToModelBuilderImpl(ModelBuilder& model_builder, const Node& node,
+                               const logging::Logger& logger) const override;
+
+  bool IsOpSupportedImpl(const Node& node, const OpBuilderInputParams& input_params,
+                         const logging::Logger& logger) const override;
+
+  bool HasSupportedInputsImpl(const Node& node, const OpBuilderInputParams& input_params,
+                              const logging::Logger& logger) const override;
+
+  bool SupportsMLProgram() const override { return true; }
+};
+
+Status ModOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, const Node& node,
+                                           const logging::Logger& /*logger*/) const {
+  using namespace CoreML::Specification::MILSpec;
+  const auto& input_defs = node.InputDefs();
+
+  // https://apple.github.io/coremltools/source/coremltools.converters.mil.mil.ops.defs.html#coremltools.converters.mil.mil.ops.defs.iOS15.elementwise_binary.mod
+  std::unique_ptr<Operation> op = model_builder.CreateOperation(node, "mod");
+  AddOperationInput(*op, "x", input_defs[0]->Name());
+  AddOperationInput(*op, "y", input_defs[1]->Name());
+  AddOperationOutput(*op, *node.OutputDefs()[0]);
+  model_builder.AddOperation(std::move(op));
+  return Status::OK();
+}
+
+bool ModOpBuilder::IsOpSupportedImpl(const Node& node, const OpBuilderInputParams& input_params,
+                                     const logging::Logger& logger) const {
+  if (!input_params.create_mlprogram) {
+    LOGS(logger, VERBOSE) << node.OpType() << " is only supported for the ML Program format.";
+    return false;
+  }
+
+  NodeAttrHelper helper(node);
+  const auto fmod = helper.Get("fmod", static_cast<int64_t>(0));
+  if (fmod != 0) {
+    // ONNX fmod=1 is C-style truncated remainder; MIL 'mod' is floor mod, so
+    // the semantics don't match. Fall back to CPU.
+    LOGS(logger, VERBOSE) << node.OpType() << " with fmod=1 (C-style remainder) is not supported.";
+    return false;
+  }
+  return true;
+}
+
+bool ModOpBuilder::HasSupportedInputsImpl(const Node& node, const OpBuilderInputParams& /*input_params*/,
+                                          const logging::Logger& logger) const {
+  const auto& input_defs = node.InputDefs();
+  int32_t x_type = 0, y_type = 0;
+  if (!GetType(*input_defs[0], x_type, logger) || !GetType(*input_defs[1], y_type, logger)) {
+    return false;
+  }
+  // ONNX Mod requires both inputs share a type. MIL 'mod' supports int32/fp16/fp32.
+  auto is_supported_data_type = [](int32_t type) {
+    return type == ONNX_NAMESPACE::TensorProto_DataType_INT32 ||
+           type == ONNX_NAMESPACE::TensorProto_DataType_FLOAT ||
+           type == ONNX_NAMESPACE::TensorProto_DataType_FLOAT16;
+  };
+  if (!is_supported_data_type(x_type) || x_type != y_type) {
+    LOGS(logger, VERBOSE) << node.OpType() << ": both inputs must share a supported type. Got: "
+                          << x_type << ", " << y_type;
+    return false;
+  }
+  return true;
+}
+
+void CreateModOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations) {
+  op_registrations.builders.push_back(std::make_unique<ModOpBuilder>());
+  op_registrations.op_builder_map.emplace(op_type, op_registrations.builders.back().get());
+}
+
+}  // namespace coreml
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/coreml/builders/op_builder_factory.cc
+++ b/onnxruntime/core/providers/coreml/builders/op_builder_factory.cc
@@ -84,6 +84,7 @@ static OpBuilderRegistrations CreateOpBuilderRegistrations() {
   CreateIdentityOpBuilder("Identity", op_registrations);
   CreateLRNOpBuilder("LRN", op_registrations);
   CreateGemmOpBuilder("MatMul", op_registrations);
+  CreateModOpBuilder("Mod", op_registrations);
   CreatePadOpBuilder("Pad", op_registrations);
   CreateReshapeOpBuilder("Reshape", op_registrations);
   CreateResizeOpBuilder("Resize", op_registrations);

--- a/onnxruntime/core/providers/coreml/builders/op_builder_factory.h
+++ b/onnxruntime/core/providers/coreml/builders/op_builder_factory.h
@@ -34,6 +34,7 @@ void CreateGemmOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_
 void CreateGridSampleOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateIdentityOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateLRNOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
+void CreateModOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreatePadOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreatePoolOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateReductionOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);

--- a/onnxruntime/test/providers/coreml/coreml_basic_test.cc
+++ b/onnxruntime/test/providers/coreml/coreml_basic_test.cc
@@ -3349,6 +3349,86 @@ TEST(CoreMLExecutionProviderTest, GatherScalarIndicesRank5DataNotSupported) {
   TestModelLoad(model_span, MakeCoreMLExecutionProvider("MLProgram"), ExpectedEPNodeAssignment::None);
 }
 
+namespace {
+// X(int32) Mod Y(int32 const) -> int32 output. Used by the Mod tests below.
+// fmod attribute defaults to 0 (floor mod, matches MIL `mod`).
+std::string MakeModModelData(int32_t elem_type, int64_t fmod = 0) {
+  onnxruntime::Model model("mod_test", false, DefaultLoggingManager().DefaultLogger());
+  auto& graph = model.MainGraph();
+
+  ONNX_NAMESPACE::TypeProto t;
+  t.mutable_tensor_type()->set_elem_type(elem_type);
+  for (int64_t d : {1, 4}) t.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(d);
+
+  auto& x = graph.GetOrCreateNodeArg("X", &t);
+  auto& y = graph.GetOrCreateNodeArg("Y", &t);
+  auto& z = graph.GetOrCreateNodeArg("Z", &t);
+
+  ONNX_NAMESPACE::TensorProto y_init;
+  y_init.set_name("Y");
+  y_init.set_data_type(elem_type);
+  y_init.add_dims(1);
+  y_init.add_dims(4);
+  if (elem_type == ONNX_NAMESPACE::TensorProto_DataType_INT32) {
+    for (int32_t v : {3, 3, 3, 3}) y_init.add_int32_data(v);
+  } else {
+    for (float v : {3.0f, 3.0f, 3.0f, 3.0f}) y_init.add_float_data(v);
+  }
+  graph.AddInitializedTensor(y_init);
+
+  auto& mod_node = graph.AddNode("mod", "Mod", "modulo", {&x, &y}, {&z});
+  mod_node.AddAttribute("fmod", fmod);
+
+  ORT_THROW_IF_ERROR(graph.Resolve());
+  std::string model_data;
+  model.ToProto().SerializeToString(&model_data);
+  return model_data;
+}
+}  // namespace
+
+// Mod with fmod=0 (floor mod) is lowered to MIL `mod`.
+TEST(CoreMLExecutionProviderTest, Mod_MLProgram) {
+  const std::string model_data =
+      MakeModModelData(ONNX_NAMESPACE::TensorProto_DataType_INT32);
+  gsl::span<const std::byte> model_span{reinterpret_cast<const std::byte*>(model_data.data()),
+                                        model_data.size()};
+
+#if defined(__APPLE__)
+  std::vector<int64_t> dims = {1, 4};
+  OrtValue x_val;
+  CreateMLValue<int32_t>(CPUAllocator::DefaultInstance(), dims, {7, 8, 9, 10}, &x_val);
+  NameMLValMap feeds;
+  feeds.insert(std::make_pair("X", x_val));
+
+  EPVerificationParams params{};
+  params.ep_node_assignment = ExpectedEPNodeAssignment::All;
+  RunAndVerifyOutputsWithEP(model_span, CurrentTestName(),
+                            MakeCoreMLExecutionProvider("MLProgram"), feeds, params);
+#else
+  TestModelLoad(model_span, MakeCoreMLExecutionProvider("MLProgram"), ExpectedEPNodeAssignment::All);
+#endif
+}
+
+// Mod with fmod=1 (C-style truncated remainder) has different semantics from
+// MIL's floor `mod`, so it must fall back to CPU.
+TEST(CoreMLExecutionProviderTest, ModFmodTrueNotSupported) {
+  const std::string model_data =
+      MakeModModelData(ONNX_NAMESPACE::TensorProto_DataType_FLOAT, /*fmod=*/1);
+  gsl::span<const std::byte> model_span{reinterpret_cast<const std::byte*>(model_data.data()),
+                                        model_data.size()};
+  TestModelLoad(model_span, MakeCoreMLExecutionProvider("MLProgram"), ExpectedEPNodeAssignment::None);
+}
+
+// Mod only has an ML Program lowering; on the NeuralNetwork format it must
+// fall back to CPU.
+TEST(CoreMLExecutionProviderTest, ModNeuralNetworkNotSupported) {
+  const std::string model_data =
+      MakeModModelData(ONNX_NAMESPACE::TensorProto_DataType_INT32);
+  gsl::span<const std::byte> model_span{reinterpret_cast<const std::byte*>(model_data.data()),
+                                        model_data.size()};
+  TestModelLoad(model_span, MakeCoreMLExecutionProvider(), ExpectedEPNodeAssignment::None);
+}
+
 #endif  // !(ORT_MINIMAL_BUILD)
 }  // namespace test
 }  // namespace onnxruntime

--- a/tools/ci_build/github/apple/coreml_supported_mlprogram_ops.md
+++ b/tools/ci_build/github/apple/coreml_supported_mlprogram_ops.md
@@ -33,6 +33,7 @@ Keep in sync with doco generated from /docs/execution-providers/CoreML-Execution
 |ai.onnx:MatMul|Only support for transA == 0, alpha == 1.0 and beta == 1.0 is currently implemented.|
 |ai.onnx:MaxPool|Only 2D Pool is supported currently. 3D and 5D support can be added if needed.|
 |ai.onnx:Max||
+|ai.onnx:Mod|`fmod` attribute must be 0 (floor mod). fp32/fp16/int32. MLProgram only.|
 |ai.onnx:Mul||
 |ai.onnx:Pow|Only supports cases when both inputs are fp32.|
 |ai.onnx:PRelu||


### PR DESCRIPTION
Lowers ONNX Mod with the default fmod=0 (floor mod / Python % semantics) to
the iOS15 MIL `mod` op. fmod=1 (C-style truncated remainder, sign follows
dividend) is rejected since MIL's `mod` is floor-only; such nodes fall back
to CPU rather than producing wrong results.

ML-Program-only; IsOpSupportedImpl rejects Mod on the NeuralNetwork format.

Tests (coreml_basic_test.cc):
- Mod_MLProgram: int32 Mod with fmod=0 runs on CoreML and matches CPU.
- ModFmodTrueNotSupported: Mod with fmod=1 falls back (semantic mismatch).
- ModNeuralNetworkNotSupported: Mod falls back on NeuralNetwork.

Doc: coreml_supported_mlprogram_ops.md lists Mod with the fmod=0 caveat.

Driven by SAM vision_encoder, which has 32 Mod nodes (positional-encoding
index wraparound), all with fmod=0.



🤖 Generated with [Claude Code](https://claude.com/claude-code)
