### PR TITLE
[CoreML EP] Add Neg builder

### DIFF
--- a/onnxruntime/core/providers/coreml/builders/impl/neg_op_builder.cc
+++ b/onnxruntime/core/providers/coreml/builders/impl/neg_op_builder.cc
@@ -1,0 +1,82 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/coreml/builders/impl/base_op_builder.h"
+#include "core/providers/coreml/builders/impl/builder_utils.h"
+#include "core/providers/coreml/builders/model_builder.h"
+#include "core/providers/coreml/builders/op_builder_factory.h"
+#include "core/providers/shared/utils/utils.h"
+
+namespace onnxruntime {
+namespace coreml {
+
+// ONNX Neg. The iOS15 MIL op set has no native 'neg', so we lower it as
+// mul(x, -1) with a per-dtype constant.
+class NegOpBuilder : public BaseOpBuilder {
+  Status AddToModelBuilderImpl(ModelBuilder& model_builder, const Node& node,
+                               const logging::Logger& logger) const override;
+
+  bool IsOpSupportedImpl(const Node& node, const OpBuilderInputParams& input_params,
+                         const logging::Logger& logger) const override;
+
+  bool HasSupportedInputsImpl(const Node& node, const OpBuilderInputParams& input_params,
+                              const logging::Logger& logger) const override;
+
+  bool SupportsMLProgram() const override { return true; }
+};
+
+Status NegOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, const Node& node,
+                                           const logging::Logger& /*logger*/) const {
+  using namespace CoreML::Specification::MILSpec;
+  const auto& input_defs = node.InputDefs();
+  const auto input_dtype = input_defs[0]->TypeAsProto()->tensor_type().elem_type();
+
+  std::unique_ptr<Operation> op = model_builder.CreateOperation(node, "mul");
+  AddOperationInput(*op, "x", input_defs[0]->Name());
+  if (input_dtype == ONNX_NAMESPACE::TensorProto_DataType_FLOAT) {
+    AddOperationInput(*op, "y", model_builder.AddScalarConstant(op->type(), "neg_one", -1.0f));
+  } else if (input_dtype == ONNX_NAMESPACE::TensorProto_DataType_FLOAT16) {
+    AddOperationInput(*op, "y", model_builder.AddScalarConstant(op->type(), "neg_one", MLFloat16(-1.0f)));
+  } else if (input_dtype == ONNX_NAMESPACE::TensorProto_DataType_INT32) {
+    AddOperationInput(*op, "y", model_builder.AddScalarConstant(op->type(), "neg_one", static_cast<int32_t>(-1)));
+  } else {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                           "NegOpBuilder::AddToModelBuilderImpl, unsupported dtype: ", input_dtype);
+  }
+  AddOperationOutput(*op, *node.OutputDefs()[0]);
+  model_builder.AddOperation(std::move(op));
+  return Status::OK();
+}
+
+bool NegOpBuilder::IsOpSupportedImpl(const Node& node, const OpBuilderInputParams& input_params,
+                                     const logging::Logger& logger) const {
+  if (!input_params.create_mlprogram) {
+    LOGS(logger, VERBOSE) << node.OpType() << " is only supported for the ML Program format.";
+    return false;
+  }
+  return true;
+}
+
+bool NegOpBuilder::HasSupportedInputsImpl(const Node& node, const OpBuilderInputParams& /*input_params*/,
+                                          const logging::Logger& logger) const {
+  const auto& input_defs = node.InputDefs();
+  int32_t x_type = 0;
+  if (!GetType(*input_defs[0], x_type, logger)) {
+    return false;
+  }
+  if (x_type != ONNX_NAMESPACE::TensorProto_DataType_FLOAT &&
+      x_type != ONNX_NAMESPACE::TensorProto_DataType_FLOAT16 &&
+      x_type != ONNX_NAMESPACE::TensorProto_DataType_INT32) {
+    LOGS(logger, VERBOSE) << node.OpType() << ": input dtype " << x_type << " not supported.";
+    return false;
+  }
+  return true;
+}
+
+void CreateNegOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations) {
+  op_registrations.builders.push_back(std::make_unique<NegOpBuilder>());
+  op_registrations.op_builder_map.emplace(op_type, op_registrations.builders.back().get());
+}
+
+}  // namespace coreml
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/coreml/builders/op_builder_factory.cc
+++ b/onnxruntime/core/providers/coreml/builders/op_builder_factory.cc
@@ -84,6 +84,7 @@ static OpBuilderRegistrations CreateOpBuilderRegistrations() {
   CreateIdentityOpBuilder("Identity", op_registrations);
   CreateLRNOpBuilder("LRN", op_registrations);
   CreateGemmOpBuilder("MatMul", op_registrations);
+  CreateNegOpBuilder("Neg", op_registrations);
   CreatePadOpBuilder("Pad", op_registrations);
   CreateReshapeOpBuilder("Reshape", op_registrations);
   CreateResizeOpBuilder("Resize", op_registrations);

--- a/onnxruntime/core/providers/coreml/builders/op_builder_factory.h
+++ b/onnxruntime/core/providers/coreml/builders/op_builder_factory.h
@@ -34,6 +34,7 @@ void CreateGemmOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_
 void CreateGridSampleOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateIdentityOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateLRNOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
+void CreateNegOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreatePadOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreatePoolOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateReductionOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);

--- a/onnxruntime/test/providers/coreml/coreml_basic_test.cc
+++ b/onnxruntime/test/providers/coreml/coreml_basic_test.cc
@@ -3349,6 +3349,59 @@ TEST(CoreMLExecutionProviderTest, GatherScalarIndicesRank5DataNotSupported) {
   TestModelLoad(model_span, MakeCoreMLExecutionProvider("MLProgram"), ExpectedEPNodeAssignment::None);
 }
 
+namespace {
+// Float input -> Neg -> float output. Used by the Neg tests below.
+std::string MakeNegModelData(int32_t elem_type) {
+  onnxruntime::Model model("neg_test", false, DefaultLoggingManager().DefaultLogger());
+  auto& graph = model.MainGraph();
+
+  ONNX_NAMESPACE::TypeProto t;
+  t.mutable_tensor_type()->set_elem_type(elem_type);
+  for (int64_t d : {1, 4}) t.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(d);
+
+  auto& x = graph.GetOrCreateNodeArg("X", &t);
+  auto& y = graph.GetOrCreateNodeArg("Y", &t);
+  graph.AddNode("neg", "Neg", "negate", {&x}, {&y});
+
+  ORT_THROW_IF_ERROR(graph.Resolve());
+  std::string model_data;
+  model.ToProto().SerializeToString(&model_data);
+  return model_data;
+}
+}  // namespace
+
+// Neg is lowered to MIL `mul(x, -1)` (the iOS15 MIL op set has no native
+// `neg`); the const -1 is emitted with the input's dtype.
+TEST(CoreMLExecutionProviderTest, Neg_MLProgram) {
+  const std::string model_data = MakeNegModelData(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+  gsl::span<const std::byte> model_span{reinterpret_cast<const std::byte*>(model_data.data()),
+                                        model_data.size()};
+
+#if defined(__APPLE__)
+  std::vector<int64_t> dims = {1, 4};
+  OrtValue x_val;
+  CreateMLValue<float>(CPUAllocator::DefaultInstance(), dims, {1.0f, -2.0f, 0.0f, 3.5f}, &x_val);
+  NameMLValMap feeds;
+  feeds.insert(std::make_pair("X", x_val));
+
+  EPVerificationParams params{};
+  params.ep_node_assignment = ExpectedEPNodeAssignment::All;
+  RunAndVerifyOutputsWithEP(model_span, CurrentTestName(),
+                            MakeCoreMLExecutionProvider("MLProgram"), feeds, params);
+#else
+  TestModelLoad(model_span, MakeCoreMLExecutionProvider("MLProgram"), ExpectedEPNodeAssignment::All);
+#endif
+}
+
+// Neg only has an ML Program lowering; on the NeuralNetwork format it must
+// fall back to CPU.
+TEST(CoreMLExecutionProviderTest, NegNeuralNetworkNotSupported) {
+  const std::string model_data = MakeNegModelData(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+  gsl::span<const std::byte> model_span{reinterpret_cast<const std::byte*>(model_data.data()),
+                                        model_data.size()};
+  TestModelLoad(model_span, MakeCoreMLExecutionProvider(), ExpectedEPNodeAssignment::None);
+}
+
 #endif  // !(ORT_MINIMAL_BUILD)
 }  // namespace test
 }  // namespace onnxruntime

--- a/tools/ci_build/github/apple/coreml_supported_mlprogram_ops.md
+++ b/tools/ci_build/github/apple/coreml_supported_mlprogram_ops.md
@@ -34,6 +34,7 @@ Keep in sync with doco generated from /docs/execution-providers/CoreML-Execution
 |ai.onnx:MaxPool|Only 2D Pool is supported currently. 3D and 5D support can be added if needed.|
 |ai.onnx:Max||
 |ai.onnx:Mul||
+|ai.onnx:Neg|Lowered to MIL `mul(x, -1)`. Supports fp32 / fp16 / int32. MLProgram only.|
 |ai.onnx:Pow|Only supports cases when both inputs are fp32.|
 |ai.onnx:PRelu||
 |ai.onnx:Reciprocal|this ask for a `epislon` (default 1e-4) where onnx don't provide|


### PR DESCRIPTION
Lowers ONNX Neg. The iOS15 MIL op set has no native `neg`, so the lowering
emits `mul(x, -1)` with a per-dtype constant. Supports fp32, fp16, int32.

ML-Program-only; IsOpSupportedImpl rejects Neg on the NeuralNetwork format
so the node falls back to CPU.

Tests (coreml_basic_test.cc):
- Neg_MLProgram: float Neg runs on CoreML and matches CPU.
- NegNeuralNetworkNotSupported: Neg falls back on the NeuralNetwork format.

Doc: coreml_supported_mlprogram_ops.md lists Neg.



🤖 Generated with [Claude Code](https://claude.com/claude-code)
