### PR TITLE
[CoreML EP] Add Not builder

### DIFF
--- a/onnxruntime/core/providers/coreml/builders/impl/not_op_builder.cc
+++ b/onnxruntime/core/providers/coreml/builders/impl/not_op_builder.cc
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/coreml/builders/impl/base_op_builder.h"
+#include "core/providers/coreml/builders/impl/builder_utils.h"
+#include "core/providers/coreml/builders/model_builder.h"
+#include "core/providers/coreml/builders/op_builder_factory.h"
+#include "core/providers/shared/utils/utils.h"
+
+namespace onnxruntime {
+namespace coreml {
+
+// Elementwise unary logical op. ONNX Not -> CoreML ML Program 'logical_not'.
+class NotOpBuilder : public BaseOpBuilder {
+  Status AddToModelBuilderImpl(ModelBuilder& model_builder, const Node& node,
+                               const logging::Logger& logger) const override;
+
+  bool IsOpSupportedImpl(const Node& node, const OpBuilderInputParams& input_params,
+                         const logging::Logger& logger) const override;
+
+  bool HasSupportedInputsImpl(const Node& node, const OpBuilderInputParams& input_params,
+                              const logging::Logger& logger) const override;
+
+  bool SupportsMLProgram() const override { return true; }
+};
+
+Status NotOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, const Node& node,
+                                           const logging::Logger& /*logger*/) const {
+  using namespace CoreML::Specification::MILSpec;
+  const auto& input_defs = node.InputDefs();
+
+  // https://apple.github.io/coremltools/source/coremltools.converters.mil.mil.ops.defs.html#coremltools.converters.mil.mil.ops.defs.iOS15.elementwise_unary.logical_not
+  std::unique_ptr<Operation> op = model_builder.CreateOperation(node, "logical_not");
+  AddOperationInput(*op, "x", input_defs[0]->Name());
+  AddOperationOutput(*op, *node.OutputDefs()[0]);
+  model_builder.AddOperation(std::move(op));
+  return Status::OK();
+}
+
+bool NotOpBuilder::IsOpSupportedImpl(const Node& node, const OpBuilderInputParams& input_params,
+                                     const logging::Logger& logger) const {
+  if (!input_params.create_mlprogram) {
+    LOGS(logger, VERBOSE) << node.OpType() << " is only supported for the ML Program format.";
+    return false;
+  }
+  return true;
+}
+
+bool NotOpBuilder::HasSupportedInputsImpl(const Node& node, const OpBuilderInputParams& /*input_params*/,
+                                          const logging::Logger& logger) const {
+  const auto& input_defs = node.InputDefs();
+  int32_t x_type = 0;
+  if (!GetType(*input_defs[0], x_type, logger)) {
+    return false;
+  }
+
+  // ONNX Not takes a bool input; CoreML logical_not likewise operates on bool tensors.
+  if (x_type != ONNX_NAMESPACE::TensorProto_DataType_BOOL) {
+    LOGS(logger, VERBOSE) << node.OpType() << ": input must be bool. Got type: " << x_type;
+    return false;
+  }
+  return true;
+}
+
+void CreateNotOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations) {
+  op_registrations.builders.push_back(std::make_unique<NotOpBuilder>());
+  op_registrations.op_builder_map.emplace(op_type, op_registrations.builders.back().get());
+}
+
+}  // namespace coreml
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/coreml/builders/op_builder_factory.cc
+++ b/onnxruntime/core/providers/coreml/builders/op_builder_factory.cc
@@ -84,6 +84,7 @@ static OpBuilderRegistrations CreateOpBuilderRegistrations() {
   CreateIdentityOpBuilder("Identity", op_registrations);
   CreateLRNOpBuilder("LRN", op_registrations);
   CreateGemmOpBuilder("MatMul", op_registrations);
+  CreateNotOpBuilder("Not", op_registrations);
   CreatePadOpBuilder("Pad", op_registrations);
   CreateReshapeOpBuilder("Reshape", op_registrations);
   CreateResizeOpBuilder("Resize", op_registrations);

--- a/onnxruntime/core/providers/coreml/builders/op_builder_factory.h
+++ b/onnxruntime/core/providers/coreml/builders/op_builder_factory.h
@@ -34,6 +34,7 @@ void CreateGemmOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_
 void CreateGridSampleOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateIdentityOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateLRNOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
+void CreateNotOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreatePadOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreatePoolOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateReductionOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);

--- a/onnxruntime/test/providers/coreml/coreml_basic_test.cc
+++ b/onnxruntime/test/providers/coreml/coreml_basic_test.cc
@@ -3349,6 +3349,73 @@ TEST(CoreMLExecutionProviderTest, GatherScalarIndicesRank5DataNotSupported) {
   TestModelLoad(model_span, MakeCoreMLExecutionProvider("MLProgram"), ExpectedEPNodeAssignment::None);
 }
 
+namespace {
+// int64 X -> Cast(bool) -> Not -> Cast(float). Wrap the bool tensor between
+// int<->bool Casts -- CoreML partitions cannot have bool I/O, so the bool
+// stays internal. Mirrors the And test scaffolding from PR #28597.
+std::string MakeNotChainModelData() {
+  onnxruntime::Model model("not_test", false, DefaultLoggingManager().DefaultLogger());
+  auto& graph = model.MainGraph();
+
+  auto make_type = [](int32_t elem_type) {
+    ONNX_NAMESPACE::TypeProto t;
+    t.mutable_tensor_type()->set_elem_type(elem_type);
+    for (int64_t d : {1, 4}) t.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(d);
+    return t;
+  };
+  const auto int64_type = make_type(ONNX_NAMESPACE::TensorProto_DataType_INT64);
+  const auto bool_type = make_type(ONNX_NAMESPACE::TensorProto_DataType_BOOL);
+  const auto float_type = make_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+
+  auto& x = graph.GetOrCreateNodeArg("X", &int64_type);
+  auto& b = graph.GetOrCreateNodeArg("B", &bool_type);
+  auto& n = graph.GetOrCreateNodeArg("N", &bool_type);
+  auto& y = graph.GetOrCreateNodeArg("Y", &float_type);
+
+  auto& cast_b = graph.AddNode("cast_b", "Cast", "int64 -> bool", {&x}, {&b});
+  cast_b.AddAttribute("to", static_cast<int64_t>(ONNX_NAMESPACE::TensorProto_DataType_BOOL));
+  graph.AddNode("not", "Not", "logical not", {&b}, {&n});
+  auto& cast_y = graph.AddNode("cast_y", "Cast", "bool -> float", {&n}, {&y});
+  cast_y.AddAttribute("to", static_cast<int64_t>(ONNX_NAMESPACE::TensorProto_DataType_FLOAT));
+
+  ORT_THROW_IF_ERROR(graph.Resolve());
+  std::string model_data;
+  model.ToProto().SerializeToString(&model_data);
+  return model_data;
+}
+}  // namespace
+
+// Not is lowered to the ML Program 'logical_not' op.
+TEST(CoreMLExecutionProviderTest, Not_MLProgram) {
+  const std::string model_data = MakeNotChainModelData();
+  gsl::span<const std::byte> model_span{reinterpret_cast<const std::byte*>(model_data.data()),
+                                        model_data.size()};
+
+#if defined(__APPLE__)
+  std::vector<int64_t> dims = {1, 4};
+  OrtValue x_val;
+  CreateMLValue<int64_t>(CPUAllocator::DefaultInstance(), dims, {1, 0, 1, 0}, &x_val);
+  NameMLValMap feeds;
+  feeds.insert(std::make_pair("X", x_val));
+
+  EPVerificationParams params{};
+  params.ep_node_assignment = ExpectedEPNodeAssignment::All;
+  RunAndVerifyOutputsWithEP(model_span, CurrentTestName(),
+                            MakeCoreMLExecutionProvider("MLProgram"), feeds, params);
+#else
+  TestModelLoad(model_span, MakeCoreMLExecutionProvider("MLProgram"), ExpectedEPNodeAssignment::All);
+#endif
+}
+
+// Not only has an ML Program lowering ('logical_not'); on the NeuralNetwork
+// format the chain falls back to CPU.
+TEST(CoreMLExecutionProviderTest, NotNeuralNetworkNotSupported) {
+  const std::string model_data = MakeNotChainModelData();
+  gsl::span<const std::byte> model_span{reinterpret_cast<const std::byte*>(model_data.data()),
+                                        model_data.size()};
+  TestModelLoad(model_span, MakeCoreMLExecutionProvider(), ExpectedEPNodeAssignment::None);
+}
+
 #endif  // !(ORT_MINIMAL_BUILD)
 }  // namespace test
 }  // namespace onnxruntime

--- a/tools/ci_build/github/apple/coreml_supported_mlprogram_ops.md
+++ b/tools/ci_build/github/apple/coreml_supported_mlprogram_ops.md
@@ -34,6 +34,7 @@ Keep in sync with doco generated from /docs/execution-providers/CoreML-Execution
 |ai.onnx:MaxPool|Only 2D Pool is supported currently. 3D and 5D support can be added if needed.|
 |ai.onnx:Max||
 |ai.onnx:Mul||
+|ai.onnx:Not|Input/output are bool; lowered to MIL `logical_not`. MLProgram only.|
 |ai.onnx:Pow|Only supports cases when both inputs are fp32.|
 |ai.onnx:PRelu||
 |ai.onnx:Reciprocal|this ask for a `epislon` (default 1e-4) where onnx don't provide|


### PR DESCRIPTION
Lowers ONNX Not to the iOS15 MIL `logical_not` op. Bool-only input/output,
ML-Program-only (the NeuralNetwork format has no equivalent unary), so
IsOpSupportedImpl rejects it on NeuralNetwork and the node falls back to CPU.

Stacked on top of cast-bool: a bool Not cannot sit on a CoreML partition
boundary, so the meaningful test sandwiches it between int<->bool Casts
(the bool stays internal). Mirrors the And test scaffolding from #28597.

Tests (coreml_basic_test.cc):
- Not_MLProgram: int64 -> Cast(bool) -> Not -> Cast(float) runs fully on
  CoreML and matches CPU.
- NotNeuralNetworkNotSupported: the chain falls back on the NeuralNetwork
  format.

Doc: coreml_supported_mlprogram_ops.md lists Not.



🤖 Generated with [Claude Code](https://claude.com/claude-code)
