### PR TITLE
[CoreML EP] Add Range builder

### DIFF
--- a/onnxruntime/core/providers/coreml/builders/impl/range_op_builder.cc
+++ b/onnxruntime/core/providers/coreml/builders/impl/range_op_builder.cc
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/coreml/builders/impl/base_op_builder.h"
+#include "core/providers/coreml/builders/impl/builder_utils.h"
+#include "core/providers/coreml/builders/model_builder.h"
+#include "core/providers/coreml/builders/op_builder_factory.h"
+#include "core/providers/shared/utils/utils.h"
+
+namespace onnxruntime {
+namespace coreml {
+
+// ONNX Range(start, limit, delta) -> CoreML ML Program 'range_1d'. All three
+// inputs are scalar tensors of the same dtype; produces a 1-D tensor of the
+// generated range values.
+class RangeOpBuilder : public BaseOpBuilder {
+  Status AddToModelBuilderImpl(ModelBuilder& model_builder, const Node& node,
+                               const logging::Logger& logger) const override;
+
+  bool IsOpSupportedImpl(const Node& node, const OpBuilderInputParams& input_params,
+                         const logging::Logger& logger) const override;
+
+  bool HasSupportedInputsImpl(const Node& node, const OpBuilderInputParams& input_params,
+                              const logging::Logger& logger) const override;
+
+  bool SupportsMLProgram() const override { return true; }
+};
+
+Status RangeOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, const Node& node,
+                                             const logging::Logger& /*logger*/) const {
+  using namespace CoreML::Specification::MILSpec;
+  const auto& input_defs = node.InputDefs();
+
+  // https://apple.github.io/coremltools/source/coremltools.converters.mil.mil.ops.defs.html#coremltools.converters.mil.mil.ops.defs.iOS15.tensor_operation.range_1d
+  // range_1d(end, start, step) -> tensor<[(end - start) / step], T>
+  // ONNX Range is (start, limit, delta) -> remap accordingly.
+  std::unique_ptr<Operation> op = model_builder.CreateOperation(node, "range_1d");
+  AddOperationInput(*op, "end", input_defs[1]->Name());    // ONNX 'limit'
+  AddOperationInput(*op, "start", input_defs[0]->Name());  // ONNX 'start'
+  AddOperationInput(*op, "step", input_defs[2]->Name());   // ONNX 'delta'
+  AddOperationOutput(*op, *node.OutputDefs()[0]);
+  model_builder.AddOperation(std::move(op));
+  return Status::OK();
+}
+
+bool RangeOpBuilder::IsOpSupportedImpl(const Node& node, const OpBuilderInputParams& input_params,
+                                       const logging::Logger& logger) const {
+  if (!input_params.create_mlprogram) {
+    LOGS(logger, VERBOSE) << node.OpType() << " is only supported for the ML Program format.";
+    return false;
+  }
+  return true;
+}
+
+bool RangeOpBuilder::HasSupportedInputsImpl(const Node& node, const OpBuilderInputParams& /*input_params*/,
+                                            const logging::Logger& logger) const {
+  const auto& input_defs = node.InputDefs();
+  int32_t start_type = 0;
+  if (!GetType(*input_defs[0], start_type, logger)) {
+    return false;
+  }
+  // MIL range_1d supports int32, fp16, fp32.
+  // ONNX uses int64 for integer ranges; treated as int32 inside the CoreML partition.
+  if (start_type != ONNX_NAMESPACE::TensorProto_DataType_INT32 &&
+      start_type != ONNX_NAMESPACE::TensorProto_DataType_INT64 &&
+      start_type != ONNX_NAMESPACE::TensorProto_DataType_FLOAT &&
+      start_type != ONNX_NAMESPACE::TensorProto_DataType_FLOAT16) {
+    LOGS(logger, VERBOSE) << node.OpType() << ": input dtype " << start_type << " not supported.";
+    return false;
+  }
+  return true;
+}
+
+void CreateRangeOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations) {
+  op_registrations.builders.push_back(std::make_unique<RangeOpBuilder>());
+  op_registrations.op_builder_map.emplace(op_type, op_registrations.builders.back().get());
+}
+
+}  // namespace coreml
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/coreml/builders/op_builder_factory.cc
+++ b/onnxruntime/core/providers/coreml/builders/op_builder_factory.cc
@@ -85,6 +85,7 @@ static OpBuilderRegistrations CreateOpBuilderRegistrations() {
   CreateLRNOpBuilder("LRN", op_registrations);
   CreateGemmOpBuilder("MatMul", op_registrations);
   CreatePadOpBuilder("Pad", op_registrations);
+  CreateRangeOpBuilder("Range", op_registrations);
   CreateReshapeOpBuilder("Reshape", op_registrations);
   CreateResizeOpBuilder("Resize", op_registrations);
   CreateShapeOpBuilder("Shape", op_registrations);

--- a/onnxruntime/core/providers/coreml/builders/op_builder_factory.h
+++ b/onnxruntime/core/providers/coreml/builders/op_builder_factory.h
@@ -48,6 +48,7 @@ void CreateTileOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_
 void CreateTransposeOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateUnaryOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateQuickGeluOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
+void CreateRangeOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 
 }  // namespace coreml
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/coreml/coreml_basic_test.cc
+++ b/onnxruntime/test/providers/coreml/coreml_basic_test.cc
@@ -3349,6 +3349,70 @@ TEST(CoreMLExecutionProviderTest, GatherScalarIndicesRank5DataNotSupported) {
   TestModelLoad(model_span, MakeCoreMLExecutionProvider("MLProgram"), ExpectedEPNodeAssignment::None);
 }
 
+namespace {
+// Range(start, limit, delta) with int32 scalar graph inputs (so the build
+// has to wire runtime tensors through to MIL `range_1d`'s scalar arguments).
+std::string MakeRangeModelData() {
+  onnxruntime::Model model("range_test", false, DefaultLoggingManager().DefaultLogger());
+  auto& graph = model.MainGraph();
+
+  ONNX_NAMESPACE::TypeProto scalar_int;
+  scalar_int.mutable_tensor_type()->set_elem_type(ONNX_NAMESPACE::TensorProto_DataType_INT32);
+  // scalar = 0 dims; intentionally leave shape empty.
+
+  ONNX_NAMESPACE::TypeProto out_type;
+  out_type.mutable_tensor_type()->set_elem_type(ONNX_NAMESPACE::TensorProto_DataType_INT32);
+  out_type.mutable_tensor_type()->mutable_shape()->add_dim();  // dynamic-length 1D
+
+  auto& s = graph.GetOrCreateNodeArg("start", &scalar_int);
+  auto& l = graph.GetOrCreateNodeArg("limit", &scalar_int);
+  auto& d = graph.GetOrCreateNodeArg("delta", &scalar_int);
+  auto& y = graph.GetOrCreateNodeArg("Y", &out_type);
+  graph.AddNode("range", "Range", "generate range", {&s, &l, &d}, {&y});
+
+  ORT_THROW_IF_ERROR(graph.Resolve());
+  std::string model_data;
+  model.ToProto().SerializeToString(&model_data);
+  return model_data;
+}
+}  // namespace
+
+// Range is lowered to MIL `range_1d`. ONNX (start, limit, delta) -> MIL
+// (end, start, step).
+TEST(CoreMLExecutionProviderTest, Range_MLProgram) {
+  const std::string model_data = MakeRangeModelData();
+  gsl::span<const std::byte> model_span{reinterpret_cast<const std::byte*>(model_data.data()),
+                                        model_data.size()};
+
+#if defined(__APPLE__)
+  std::vector<int64_t> scalar_dims;
+  OrtValue s_val, l_val, d_val;
+  CreateMLValue<int32_t>(CPUAllocator::DefaultInstance(), scalar_dims, {0}, &s_val);
+  CreateMLValue<int32_t>(CPUAllocator::DefaultInstance(), scalar_dims, {6}, &l_val);
+  CreateMLValue<int32_t>(CPUAllocator::DefaultInstance(), scalar_dims, {2}, &d_val);
+  NameMLValMap feeds;
+  feeds.insert(std::make_pair("start", s_val));
+  feeds.insert(std::make_pair("limit", l_val));
+  feeds.insert(std::make_pair("delta", d_val));
+
+  EPVerificationParams params{};
+  params.ep_node_assignment = ExpectedEPNodeAssignment::All;
+  RunAndVerifyOutputsWithEP(model_span, CurrentTestName(),
+                            MakeCoreMLExecutionProvider("MLProgram"), feeds, params);
+#else
+  TestModelLoad(model_span, MakeCoreMLExecutionProvider("MLProgram"), ExpectedEPNodeAssignment::All);
+#endif
+}
+
+// Range only has an ML Program lowering; on the NeuralNetwork format it must
+// fall back to CPU.
+TEST(CoreMLExecutionProviderTest, RangeNeuralNetworkNotSupported) {
+  const std::string model_data = MakeRangeModelData();
+  gsl::span<const std::byte> model_span{reinterpret_cast<const std::byte*>(model_data.data()),
+                                        model_data.size()};
+  TestModelLoad(model_span, MakeCoreMLExecutionProvider(), ExpectedEPNodeAssignment::None);
+}
+
 #endif  // !(ORT_MINIMAL_BUILD)
 }  // namespace test
 }  // namespace onnxruntime

--- a/tools/ci_build/github/apple/coreml_supported_mlprogram_ops.md
+++ b/tools/ci_build/github/apple/coreml_supported_mlprogram_ops.md
@@ -36,6 +36,7 @@ Keep in sync with doco generated from /docs/execution-providers/CoreML-Execution
 |ai.onnx:Mul||
 |ai.onnx:Pow|Only supports cases when both inputs are fp32.|
 |ai.onnx:PRelu||
+|ai.onnx:Range|Lowered to MIL `range_1d`. Inputs (start, limit, delta) are remapped to MIL's (end, start, step). int32/fp16/fp32. MLProgram only.|
 |ai.onnx:Reciprocal|this ask for a `epislon` (default 1e-4) where onnx don't provide|
 |ai.onnx:ReduceSum||
 |ai.onnx:ReduceMean||


### PR DESCRIPTION
Lowers ONNX Range to the iOS15 MIL `range_1d` op. ONNX (start, limit, delta)
is remapped to MIL's (end, start, step) parameter order. Supports int32 (and
int64-treated-as-int32 inside the CoreML partition), fp16, fp32.

ML-Program-only; IsOpSupportedImpl rejects Range on the NeuralNetwork format
so the node falls back to CPU.

Tests (coreml_basic_test.cc):
- Range_MLProgram: Range with int32 scalar graph inputs runs on CoreML and
  matches CPU output.
- RangeNeuralNetworkNotSupported: Range falls back on NeuralNetwork.

Doc: coreml_supported_mlprogram_ops.md lists Range.

Driven by SAM (24 Range nodes in the vision encoder, 6 in the prompt
encoder, all for positional-encoding index generation).



🤖 Generated with [Claude Code](https://claude.com/claude-code)
