### PR TITLE
Fix XNNPACK Clip/Relu fusion when the producer output has other consumers

### DIFF
--- a/onnxruntime/core/providers/xnnpack/detail/node_support_checker.cc
+++ b/onnxruntime/core/providers/xnnpack/detail/node_support_checker.cc
@@ -39,6 +39,12 @@ using FuseCheckerFn = std::function<const NodeUnit*(
     const GraphViewer& graph,
     const std::unordered_map<const Node*, const NodeUnit*>& supported_node_unit_map)>;
 
+bool HasOnlyActivationConsumer(const Node& producer, const Node& activation, const GraphViewer& graph) {
+  return !graph.NodeProducesGraphOutput(producer) &&
+         producer.GetOutputEdgesCount() == 1 &&
+         producer.OutputEdgesBegin()->GetNode().Index() == activation.Index();
+}
+
 const NodeUnit* ClipReluChecker(const NodeUnit& node_unit,
                                 const GraphViewer& graph,
                                 const std::unordered_map<const Node*, const NodeUnit*>& supported_node_unit_map) {
@@ -58,6 +64,10 @@ const NodeUnit* ClipReluChecker(const NodeUnit& node_unit,
         input0.Domain() != kMSInternalNHWCDomain ||
         (node_to_be_fuse.count(input0.OpType()) == 0) ||
         supported_node_unit_map.at(&input0)->UnitType() == NodeUnit::Type::QDQGroup) {
+      break;
+    }
+
+    if (!HasOnlyActivationConsumer(input0, node, graph)) {
       break;
     }
 

--- a/onnxruntime/test/providers/xnnpack/xnnpack_basic_test.cc
+++ b/onnxruntime/test/providers/xnnpack/xnnpack_basic_test.cc
@@ -205,6 +205,25 @@ static void RunModelTest(
                             helper.feeds_, params);
 }
 
+TEST(XnnpackEP, TestPoolReluFusionRejectedWithSideConsumer) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    auto* input_arg = builder.MakeInput<float>({1, 3, 8, 8}, -1.f, 1.f);
+    auto* pool_output = builder.MakeIntermediate();
+    auto* relu_output = builder.MakeIntermediate();
+    auto* output_arg = builder.MakeOutput();
+
+    Node& pool_node = builder.AddNode("MaxPool", {input_arg}, {pool_output});
+    pool_node.AddAttribute("kernel_shape", std::vector<int64_t>{3, 3});
+    pool_node.AddAttribute("pads", std::vector<int64_t>{1, 1, 1, 1});
+    pool_node.AddAttribute("strides", std::vector<int64_t>{1, 1});
+
+    builder.AddNode("Relu", {pool_output}, {relu_output});
+    builder.AddNode("Add", {pool_output, relu_output}, {output_arg});
+  };
+
+  RunModelTest(build_test_case, "xnnpack_pool_relu_fanout");
+}
+
 static void RunModelTestWithPath(const ORTCHAR_T* ort_model_path, const char* graph_name,
                                  std::function<void(const Graph&)> graph_verifier = nullptr,
                                  float abs_err_tolerance = .2f) {

--- a/onnxruntime/test/providers/xnnpack/xnnpack_basic_test.cc
+++ b/onnxruntime/test/providers/xnnpack/xnnpack_basic_test.cc
@@ -221,7 +221,23 @@ TEST(XnnpackEP, TestPoolReluFusionRejectedWithSideConsumer) {
     builder.AddNode("Add", {pool_output, relu_output}, {output_arg});
   };
 
-  RunModelTest(build_test_case, "xnnpack_pool_relu_fanout");
+  // the fusion must be rejected: Relu should remain as a standalone node on the CPU EP
+  std::function<void(const Graph&)> verify = [](const Graph& graph) {
+    int num_relu = 0;
+    for (const auto& node : graph.Nodes()) {
+      if (node.OpType() == "Relu") {
+        ++num_relu;
+        EXPECT_EQ(node.GetExecutionProviderType(), kCpuExecutionProvider)
+            << "Relu should not have been taken by the XNNPACK EP";
+      }
+    }
+    EXPECT_EQ(num_relu, 1) << "Relu should not have been fused with MaxPool";
+  };
+
+  EPVerificationParams params;
+  params.graph_verifier = &verify;
+
+  RunModelTest(build_test_case, "xnnpack_pool_relu_fanout", params);
 }
 
 static void RunModelTestWithPath(const ORTCHAR_T* ort_model_path, const char* graph_name,


### PR DESCRIPTION
### Description
`ClipReluChecker` fuses Conv/MaxPool/AveragePool with a following Clip/Relu without checking other consumers of the producer output. The fused node only exposes the activation output, so a side consumer (or graph output) of the pre-activation value is left dangling and session creation fails with `Invalid model. Node input '...' is not a graph input, initializer, or output of a previous node`. Reject the fusion in that case.

Adds `XnnpackEP.TestPoolReluFusionRejectedWithSideConsumer`.

### Motivation and Context
Fixes #28543, fixes #28544.