### PR TITLE
Avoid optional requests import in TF converter

### DIFF
--- a/onnxruntime/python/tools/transformers/convert_tf_models_to_pytorch.py
+++ b/onnxruntime/python/tools/transformers/convert_tf_models_to_pytorch.py
@@ -8,8 +8,6 @@ import os
 import tarfile
 import zipfile
 
-import requests
-
 TFMODELS = {
     "bert-base-uncased": (
         "bert",
@@ -57,6 +55,8 @@ TFMODELS = {
 
 
 def download_compressed_file(tf_ckpt_url, ckpt_dir):
+    import requests  # noqa: PLC0415
+
     r = requests.get(tf_ckpt_url)
     compressed_file_name = tf_ckpt_url.split("/")[-1]
     compressed_file_dir = os.path.join(ckpt_dir, compressed_file_name)
@@ -159,6 +159,8 @@ def download_tf_checkpoint(model_name, tf_models_dir="tf_models"):
         return get_ckpt_prefix_path(ckpt_dir)
 
     else:
+        import requests  # noqa: PLC0415
+
         for filename in [
             "checkpoint",
             "model.ckpt.data-00000-of-00001",


### PR DESCRIPTION
### Description
Move the `requests` imports in `convert_tf_models_to_pytorch.py` into the two download paths that actually use them (`download_compressed_file` and the non-archive path in `download_tf_checkpoint`). This lets the archive-extraction tests import the module without requiring `requests` to be installed.

### Motivation
The transformer conversion tests import the converter module at pytest **collection** time (`from convert_tf_models_to_pytorch import safe_extract_archive`) purely to exercise `safe_extract_archive`. However, `requests` is **not** a declared dependency of the transformers tests — `onnxruntime/python/tools/transformers/requirements.txt` lists `onnx`, `numpy`, `transformers`, `torch`, etc., but not `requests` (it is normally present only transitively via `transformers`).

When `requests` is absent, the module-level `import requests` raises `ModuleNotFoundError` at collection time, which fails the `safe_extract_archive` traversal/symlink tests even though those tests never touch the download paths that use `requests`. Deferring the import into the download functions decouples the archive-safety tests from this undeclared optional dependency.

Note: this is about dependency *availability*, not import speed — importing `requests` is cheap (its own module code is ~1 ms; the full transitive tree is a one-time ~0.25 s cold, mostly stdlib). Adding `requests` to the transformers test requirements would be an equivalent fix; the lazy import is just the smaller, more localized change.

### Testing
- Reproduced the original failure in a venv without `requests`: importing the module raises `ModuleNotFoundError: No module named 'requests'`. After moving the imports, `safe_extract_archive` imports and runs without `requests`.
- Direct `safe_extract_archive` tar/zip traversal checks passed with `.\.venv\Scripts\python.exe`.
- `.\.venv\Scripts\python.exe -m pytest onnxruntime\test\python\transformers\test_convert_tf_models_to_pytorch.py -q` was attempted locally but collection requires `torch`, which is not installed in this venv.
