### PR TITLE
[WebGPU] Make max_num_pending_dispatches configurable

### DIFF
--- a/onnxruntime/core/providers/webgpu/webgpu_context.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.cc
@@ -41,6 +41,8 @@ namespace webgpu {
 
 void WebGpuContext::Initialize(const WebGpuContextConfig& config) {
   std::call_once(init_flag_, [this, &config]() {
+    max_num_pending_dispatches_ = config.max_num_pending_dispatches;
+
     if (device_ == nullptr) {
       // Create wgpu::Adapter
       wgpu::RequestAdapterOptions req_adapter_options = {};
@@ -174,6 +176,16 @@ void WebGpuContext::Initialize(const WebGpuContextConfig& config) {
       query_type_ = TimestampQueryType::None;
     }
   });
+
+  if (max_num_pending_dispatches_ != config.max_num_pending_dispatches) {
+    LOGS_DEFAULT(WARNING)
+        << "WebGPU context is already initialized with "
+        << "maxNumPendingDispatches="
+        << max_num_pending_dispatches_
+        << ". Requested value "
+        << config.max_num_pending_dispatches
+        << " will be ignored.";
+  }
 }
 
 Status WebGpuContext::Wait(wgpu::Future f) {

--- a/onnxruntime/core/providers/webgpu/webgpu_context.h
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.h
@@ -97,6 +97,7 @@ struct WebGpuContextConfig {
   };
   bool validation_mode_explicitly_set{false};
   bool preserve_device{false};
+  uint32_t max_num_pending_dispatches{16};
   uint64_t max_storage_buffer_binding_size{0};
   WebGpuBufferCacheConfig buffer_cache_config{};
   int power_preference{static_cast<int>(WGPUPowerPreference_HighPerformance)};
@@ -348,7 +349,7 @@ class WebGpuContext final {
   std::unique_ptr<ProgramManager> program_mgr_;
 
   uint32_t num_pending_dispatches_ = 0;
-  const uint32_t max_num_pending_dispatches_ = 16;
+  uint32_t max_num_pending_dispatches_ = 16;
 
   std::unique_ptr<SplitKConfig> split_k_config_;
 

--- a/onnxruntime/core/providers/webgpu/webgpu_provider_factory.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_provider_factory.cc
@@ -199,6 +199,30 @@ WebGpuContextConfig ParseWebGpuContextConfig(const ConfigOptions& config_options
         "Invalid maxStorageBufferBindingSize value: ", max_storage_buffer_binding_size_str);
   }
 
+  std::string max_num_pending_dispatches_str;
+  if (config_options.TryGetConfigEntry(
+          kMaxNumPendingDispatches,
+          max_num_pending_dispatches_str)) {
+    ORT_ENFORCE(
+        std::errc{} ==
+            std::from_chars(
+                max_num_pending_dispatches_str.data(),
+                max_num_pending_dispatches_str.data() +
+                    max_num_pending_dispatches_str.size(),
+                config.max_num_pending_dispatches)
+                .ec,
+        "Invalid maxNumPendingDispatches value: ",
+        max_num_pending_dispatches_str);
+    ORT_ENFORCE(
+        config.max_num_pending_dispatches > 0,
+        "maxNumPendingDispatches must be greater than 0");
+    // Practical cap to avoid excessive query buffer sizing and
+    // unpredictable memory/performance behavior.
+    ORT_ENFORCE(
+        config.max_num_pending_dispatches <= 4096,
+        "maxNumPendingDispatches must be less than or equal to 4096");
+  }
+
   LOGS_DEFAULT(VERBOSE) << "WebGPU EP Device ID: " << config.context_id;
   LOGS_DEFAULT(VERBOSE) << "WebGPU EP WGPUInstance: " << reinterpret_cast<size_t>(config.instance);
   LOGS_DEFAULT(VERBOSE) << "WebGPU EP WGPUDevice: " << reinterpret_cast<size_t>(config.device);
@@ -206,6 +230,7 @@ WebGpuContextConfig ParseWebGpuContextConfig(const ConfigOptions& config_options
   LOGS_DEFAULT(VERBOSE) << "WebGPU EP ValidationMode: " << config.validation_mode;
   LOGS_DEFAULT(VERBOSE) << "WebGPU EP PreserveDevice: " << config.preserve_device;
   LOGS_DEFAULT(VERBOSE) << "WebGPU EP max storage buffer binding size: " << config.max_storage_buffer_binding_size;
+  LOGS_DEFAULT(VERBOSE) << "WebGPU EP max pending dispatches: " << config.max_num_pending_dispatches;
 
   // buffer cache modes
   auto parse_buffer_cache_mode = [&config_options](const std::string& config_entry_str,

--- a/onnxruntime/core/providers/webgpu/webgpu_provider_options.h
+++ b/onnxruntime/core/providers/webgpu/webgpu_provider_options.h
@@ -36,6 +36,9 @@ constexpr const char* kEnablePIXCapture = "ep.webgpuexecutionprovider.enablePIXC
 constexpr const char* kPreserveDevice = "ep.webgpuexecutionprovider.preserveDevice";
 
 constexpr const char* kMaxStorageBufferBindingSize = "ep.webgpuexecutionprovider.maxStorageBufferBindingSize";
+// Valid range: 1-4096. Larger values are rejected to avoid excessive
+// query buffer sizing and unpredictable memory/performance behavior.
+constexpr const char* kMaxNumPendingDispatches = "ep.webgpuexecutionprovider.maxNumPendingDispatches";
 
 // The following are the possible values for the provider options.
 

--- a/onnxruntime/test/providers/cpu/tensor/expand_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/expand_test.cc
@@ -186,6 +186,27 @@ TEST(ExpandOpTest, Expand_3x1x3x1_int64_webgpu) {
   test.ConfigEp(std::move(provider))
       .RunWithConfig();
 }
+
+TEST(ExpandOpTest, Expand_3x3_int64_webgpu_max_num_pending_dispatches) {
+  OpTester test("Expand", 8);
+
+  test.AddInput<int64_t>("data_0", {1}, {1});
+  test.AddInput<int64_t>("data_1", {2}, {3, 3});
+
+  test.AddOutput<int64_t>("result", {3, 3},
+                          {1, 1, 1,
+                           1, 1, 1,
+                           1, 1, 1});
+
+  ConfigOptions config_options{};
+  ASSERT_STATUS_OK(config_options.AddConfigEntry(webgpu::options::kEnableInt64, "1"));
+  ASSERT_STATUS_OK(config_options.AddConfigEntry(webgpu::options::kMaxNumPendingDispatches, "32"));
+
+  auto provider = WebGpuExecutionProviderWithOptions(config_options);
+
+  test.ConfigEp(std::move(provider))
+      .RunWithConfig();
+}
 #endif
 
 TEST(ExpandOpTest, Expand_3x3_float16) {


### PR DESCRIPTION
### Description

Adds support for configuring the WebGPU execution provider's maximum number of pending dispatches via a provider option.

Previously, `WebGpuContext::max_num_pending_dispatches_` was hardcoded to `16`. This change introduces a new WebGPU provider option:

`ep.webgpuexecutionprovider.maxNumPendingDispatches`

The value is parsed into `WebGpuContextConfig` and applied during `WebGpuContext` initialization, while preserving the existing default value of `16`.

A WebGPU execution test was also added to verify that the new provider option can be supplied successfully and that execution proceeds correctly with a custom value.

### Testing

* Built ONNX Runtime with WebGPU enabled.

* Ran:
  * `ExpandOpTest.Expand_3x3_int64_webgpu_max_num_pending_dispatches`
  * `ExpandOpTest.*webgpu*`

* All tests passed.


### Motivation and Context

Fixes #28613.

Some devices may achieve better inference performance with a different pending dispatch limit. This change makes the existing hardcoded value configurable without changing the default behavior.