### PR TITLE
Add Windows ARM64 CUDA plugin package and align CUDA metadata/artifact naming

### DIFF
--- a/cmake/external/cuDNN.cmake
+++ b/cmake/external/cuDNN.cmake
@@ -12,15 +12,17 @@ string(REGEX MATCH "#define CUDNN_MAJOR [1-9]+" macrodef "${cudnn_version_header
 string(REGEX MATCH "[1-9]+" CUDNN_MAJOR_VERSION "${macrodef}")
 
 function(find_cudnn_library NAME)
-    # Since CUDA 13.x, Windows cuDNN import libraries live under an architecture-specific
-    # subdirectory (lib/x64 for win-x64, lib/arm64 for win-arm64). A single cuDNN package
-    # may ship both arches, so only search the subdirectory matching the current target
-    # platform — otherwise find_library could pick the wrong arch (it returns the first
-    # match in PATH_SUFFIXES order).
-    if(onnxruntime_target_platform STREQUAL "ARM64" OR onnxruntime_target_platform STREQUAL "ARM64EC")
-        set(_cudnn_arch_suffixes lib/arm64 lib/${onnxruntime_CUDA_VERSION}/arm64)
-    else()
-        set(_cudnn_arch_suffixes lib/x64 lib/${onnxruntime_CUDA_VERSION}/x64)
+    if(WIN32)
+        # Since CUDA 13.x, Windows cuDNN import libraries live under an architecture-specific
+        # subdirectory (lib/x64 for win-x64, lib/arm64 for win-arm64). A single cuDNN package
+        # may ship both arches, so only search the subdirectory matching the current target
+        # platform — otherwise find_library could pick the wrong arch (it returns the first
+        # match in PATH_SUFFIXES order).
+        if(onnxruntime_target_platform STREQUAL "ARM64" OR onnxruntime_target_platform STREQUAL "ARM64EC")
+            set(_cudnn_arch_suffixes lib/arm64 lib/${onnxruntime_CUDA_VERSION}/arm64)
+        else()
+            set(_cudnn_arch_suffixes lib/x64 lib/${onnxruntime_CUDA_VERSION}/x64)
+        endif()
     endif()
     find_library(
         ${NAME}_LIBRARY ${NAME} "lib${NAME}.so.${CUDNN_MAJOR_VERSION}"

--- a/cmake/external/cuDNN.cmake
+++ b/cmake/external/cuDNN.cmake
@@ -12,10 +12,20 @@ string(REGEX MATCH "#define CUDNN_MAJOR [1-9]+" macrodef "${cudnn_version_header
 string(REGEX MATCH "[1-9]+" CUDNN_MAJOR_VERSION "${macrodef}")
 
 function(find_cudnn_library NAME)
+    # Since CUDA 13.x, Windows cuDNN import libraries live under an architecture-specific
+    # subdirectory (lib/x64 for win-x64, lib/arm64 for win-arm64). A single cuDNN package
+    # may ship both arches, so only search the subdirectory matching the current target
+    # platform — otherwise find_library could pick the wrong arch (it returns the first
+    # match in PATH_SUFFIXES order).
+    if(onnxruntime_target_platform STREQUAL "ARM64" OR onnxruntime_target_platform STREQUAL "ARM64EC")
+        set(_cudnn_arch_suffixes lib/arm64 lib/${onnxruntime_CUDA_VERSION}/arm64)
+    else()
+        set(_cudnn_arch_suffixes lib/x64 lib/${onnxruntime_CUDA_VERSION}/x64)
+    endif()
     find_library(
         ${NAME}_LIBRARY ${NAME} "lib${NAME}.so.${CUDNN_MAJOR_VERSION}"
         HINTS $ENV{CUDNN_PATH} ${CUDNN_PATH} ${Python_SITEARCH}/nvidia/cudnn ${CUDAToolkit_LIBRARY_DIR}
-        PATH_SUFFIXES lib64 lib/x64 lib lib/${onnxruntime_CUDA_VERSION}/x64
+        PATH_SUFFIXES lib64 ${_cudnn_arch_suffixes} lib
         REQUIRED
     )
 

--- a/cmake/external/onnxruntime_external_deps.cmake
+++ b/cmake/external/onnxruntime_external_deps.cmake
@@ -892,10 +892,10 @@ if (onnxruntime_USE_CUDA)
   # On an ARM64 host the suffix is left empty, so find_library() for cudart only looks in
   # "lib64" and never finds <cuda_home>/lib/.../cudart.lib. find_package(CUDAToolkit) then
   # fails with: Could NOT find CUDAToolkit (missing: CUDA_CUDART). Pre-seed the (internal)
-  # search-suffix variables so the toolkit's import libraries are located. We list every
-  # layout NVIDIA ships (lib/x64, lib/arm64, lib) so this works regardless of where the
-  # win-arm64 toolkit places cudart.lib. FindCUDAToolkit unsets these at the end, so this
-  # only affects the search below and is a no-op once CMake gains native WoA support.
+  # search-suffix variables with win-arm64 import-library locations (lib/arm64 and
+  # lib/arm64/stubs) so the toolkit's cudart.lib can be found. FindCUDAToolkit unsets
+  # these at the end, so this only affects the search below and is a no-op once CMake
+  # gains native WoA support.
   if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows" AND CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "ARM64")
     set(_CUDAToolkit_win_search_dirs lib/arm64)
     set(_CUDAToolkit_win_stub_search_dirs lib/arm64/stubs)

--- a/cmake/external/onnxruntime_external_deps.cmake
+++ b/cmake/external/onnxruntime_external_deps.cmake
@@ -880,6 +880,27 @@ endif()
 
 set(onnxruntime_LINK_DIRS)
 if (onnxruntime_USE_CUDA)
+  # Work around a CMake limitation (present through at least CMake 3.31 and current
+  # upstream master) when building natively on a Windows-on-ARM64 host. FindCUDAToolkit
+  # only sets the Windows import-library search suffix when the host is x64:
+  #
+  #   if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
+  #     if(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "AMD64")
+  #       set(_CUDAToolkit_win_search_dirs lib/x64)
+  #       set(_CUDAToolkit_win_stub_search_dirs lib/x64/stubs)
+  #
+  # On an ARM64 host the suffix is left empty, so find_library() for cudart only looks in
+  # "lib64" and never finds <cuda_home>/lib/.../cudart.lib. find_package(CUDAToolkit) then
+  # fails with: Could NOT find CUDAToolkit (missing: CUDA_CUDART). Pre-seed the (internal)
+  # search-suffix variables so the toolkit's import libraries are located. We list every
+  # layout NVIDIA ships (lib/x64, lib/arm64, lib) so this works regardless of where the
+  # win-arm64 toolkit places cudart.lib. FindCUDAToolkit unsets these at the end, so this
+  # only affects the search below and is a no-op once CMake gains native WoA support.
+  if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows" AND CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "ARM64")
+    set(_CUDAToolkit_win_search_dirs lib/arm64)
+    set(_CUDAToolkit_win_stub_search_dirs lib/arm64/stubs)
+  endif()
+
   find_package(CUDAToolkit REQUIRED)
 
   # cuDNN is not needed for minimal CUDA builds (e.g., TensorRT-only builds)

--- a/cmake/onnxruntime_common.cmake
+++ b/cmake/onnxruntime_common.cmake
@@ -94,18 +94,23 @@ else()
          "${ONNXRUNTIME_ROOT}/core/platform/device_discovery_default.cc")
 endif()
 
+# Raw /bigobj is a cl.exe option. Do not apply it to CUDA sources; nvcc treats a
+# standalone /bigobj as an input file on Windows ARM64 CUDA 13.1.
+set(onnxruntime_msvc_bigobj_compile_option
+    "$<$<AND:$<NOT:$<COMPILE_LANGUAGE:ASM_MARMASM>>,$<NOT:$<COMPILE_LANGUAGE:CUDA>>>:/bigobj>")
+
 if(onnxruntime_target_platform STREQUAL "ARM64EC")
     if (MSVC)
         link_directories("$ENV{VCINSTALLDIR}/Tools/MSVC/$ENV{VCToolsVersion}/lib/ARM64EC")
         link_directories("$ENV{VCINSTALLDIR}/Tools/MSVC/$ENV{VCToolsVersion}/ATLMFC/lib/ARM64EC")
         link_libraries(softintrin.lib)
-        add_compile_options("$<$<NOT:$<COMPILE_LANGUAGE:ASM_MARMASM>>:/bigobj>")
+        add_compile_options("${onnxruntime_msvc_bigobj_compile_option}")
     endif()
 endif()
 
 if(onnxruntime_target_platform STREQUAL "ARM64")
     if (MSVC)
-        add_compile_options("$<$<NOT:$<COMPILE_LANGUAGE:ASM_MARMASM>>:/bigobj>")
+        add_compile_options("${onnxruntime_msvc_bigobj_compile_option}")
     endif()
 endif()
 

--- a/cmake/onnxruntime_providers_cuda.cmake
+++ b/cmake/onnxruntime_providers_cuda.cmake
@@ -364,8 +364,9 @@
       target_compile_options(${target} PRIVATE "$<$<COMPILE_LANGUAGE:CXX>:/Zc:preprocessor>")
       target_compile_options(${target} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /Zc:__cplusplus>")
       target_compile_options(${target} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /Zc:preprocessor>")
-      target_compile_options(${target} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /bigobj>")
-      target_compile_options(${target} PRIVATE "$<$<COMPILE_LANGUAGE:CXX>:/bigobj>")
+      # Pass /bigobj to the CUDA host compiler using dash spelling. Raw /bigobj is excluded
+      # from global ARM64 CUDA options in onnxruntime_common.cmake because nvcc parses it as input.
+      target_compile_options(${target} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=-bigobj>")
       # /permissive is required for CUTLASS cute headers and to work around MSVC template resolution
       # issues with abseil headers when compiled through nvcc.
       # See https://github.com/NVIDIA/cutlass/issues/3065
@@ -449,7 +450,7 @@
         target_compile_definitions(${target} PRIVATE COMPILE_HOPPER_TMA_GROUPED_GEMMS)
       endif()
       if (MSVC)
-        target_compile_options(${target} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /bigobj>")
+        # Do NOT add another /bigobj here: the MSVC block above already forwards it to cl.
         target_compile_options(${target} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /wd4172>")
       endif()
     endif()

--- a/cmake/onnxruntime_providers_cuda_plugin.cmake
+++ b/cmake/onnxruntime_providers_cuda_plugin.cmake
@@ -174,7 +174,9 @@ if (MSVC)
         "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /wd4211>"
         "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /Zc:__cplusplus>"
         "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /Zc:preprocessor>"
-        "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /bigobj>"
+        # Pass /bigobj to the CUDA host compiler using dash spelling. Raw /bigobj is excluded
+        # from global ARM64 CUDA options in onnxruntime_common.cmake because nvcc parses it as input.
+        "$<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=-bigobj>"
     )
 
     target_compile_options(onnxruntime_providers_cuda_plugin PRIVATE
@@ -232,7 +234,9 @@ if (MSVC)
             "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /wd4211>"
             "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /Zc:__cplusplus>"
             "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /Zc:preprocessor>"
-            "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /bigobj>"
+            # Pass /bigobj to the CUDA host compiler using dash spelling. Raw /bigobj is excluded
+            # from global ARM64 CUDA options in onnxruntime_common.cmake because nvcc parses it as input.
+            "$<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=-bigobj>"
     )
 endif()
 

--- a/cmake/onnxruntime_providers_cuda_plugin.cmake
+++ b/cmake/onnxruntime_providers_cuda_plugin.cmake
@@ -234,8 +234,9 @@ if (MSVC)
             "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /wd4211>"
             "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /Zc:__cplusplus>"
             "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /Zc:preprocessor>"
-            # Pass /bigobj to the CUDA host compiler using dash spelling. Raw /bigobj is excluded
-            # from global ARM64 CUDA options in onnxruntime_common.cmake because nvcc parses it as input.
+            # Unlike the options explicitly paired with -Xcompiler above, the raw /bigobj inherited
+            # from global compile options is parsed by nvcc as an input file on ARM64. Exclude that raw
+            # option in onnxruntime_common.cmake and forward its dash-spelled equivalent explicitly.
             "$<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=-bigobj>"
     )
 endif()

--- a/cmake/onnxruntime_python.cmake
+++ b/cmake/onnxruntime_python.cmake
@@ -395,10 +395,10 @@ if (WIN32)
         set(_cudnn_arch "x64")
       endif()
       set(CUDNN_SEARCH_PATHS
-        "${onnxruntime_CUDNN_HOME}/bin/cudnn64_*.dll"
         "${onnxruntime_CUDNN_HOME}/bin/${_cudnn_arch}/cudnn64_*.dll"
-        "${onnxruntime_CUDNN_HOME}/bin/${onnxruntime_CUDA_VERSION}/cudnn64_*.dll"
         "${onnxruntime_CUDNN_HOME}/bin/${onnxruntime_CUDA_VERSION}/${_cudnn_arch}/cudnn64_*.dll"
+        "${onnxruntime_CUDNN_HOME}/bin/cudnn64_*.dll"
+        "${onnxruntime_CUDNN_HOME}/bin/${onnxruntime_CUDA_VERSION}/cudnn64_*.dll"
       )
       set(CUDNN_DLL_PATH "")
       foreach(search_path ${CUDNN_SEARCH_PATHS})

--- a/cmake/onnxruntime_python.cmake
+++ b/cmake/onnxruntime_python.cmake
@@ -386,11 +386,19 @@ if (WIN32)
     if(onnxruntime_CUDNN_HOME)
       # may have x64 in the path
       # may have a path with CUDA toolkit version if multiple installed on the machine
+      # Since CUDA 13.x, Windows cuDNN DLLs live under an architecture-specific subdirectory
+      # (bin/x64 for win-x64, bin/arm64 for win-arm64). A single cuDNN package may ship both
+      # arches, so only search the subdirectory matching the current target platform.
+      if(onnxruntime_target_platform STREQUAL "ARM64" OR onnxruntime_target_platform STREQUAL "ARM64EC")
+        set(_cudnn_arch "arm64")
+      else()
+        set(_cudnn_arch "x64")
+      endif()
       set(CUDNN_SEARCH_PATHS
         "${onnxruntime_CUDNN_HOME}/bin/cudnn64_*.dll"
-        "${onnxruntime_CUDNN_HOME}/bin/x64/cudnn64_*.dll"
+        "${onnxruntime_CUDNN_HOME}/bin/${_cudnn_arch}/cudnn64_*.dll"
         "${onnxruntime_CUDNN_HOME}/bin/${onnxruntime_CUDA_VERSION}/cudnn64_*.dll"
-        "${onnxruntime_CUDNN_HOME}/bin/${onnxruntime_CUDA_VERSION}/x64/cudnn64_*.dll"
+        "${onnxruntime_CUDNN_HOME}/bin/${onnxruntime_CUDA_VERSION}/${_cudnn_arch}/cudnn64_*.dll"
       )
       set(CUDNN_DLL_PATH "")
       foreach(search_path ${CUDNN_SEARCH_PATHS})

--- a/onnxruntime/core/providers/cuda/cu_inc/cub.cuh
+++ b/onnxruntime/core/providers/cuda/cu_inc/cub.cuh
@@ -6,14 +6,26 @@
 // Wrapper include for <cub/cub.cuh>.
 
 // Macro definition of `__out` (SAL annotation) conflicts with parameter name `__out` in
-// <CUDA v13.1 directory>/include/cccl/cuda/__ptx/instructions/generated/tcgen05_ld.h.
-// As a workaround, undefine `__out` before including cub/cub.cuh.
+// <CUDA directory>/include/cccl/cuda/__ptx/instructions/generated/tcgen05_ld.h (and the
+// other tcgen05_*.h PTX instruction headers). As a workaround, undefine `__out` before
+// including the CCCL headers.
 #if defined(_MSC_VER)
 #pragma push_macro("__out")
 #undef __out
 // CCCL cub/config.cuh has a #pragma warning(pop) without matching push in CUDA v13.3.
 #pragma warning(push)
 #pragma warning(disable : 4193)
+
+// Depending on the CUDA toolkit version, the CCCL PTX instruction headers are not always
+// reached through <cub/cub.cuh> (e.g. they may be pulled in later by another CUDA header,
+// after the macro has been restored below). Parse the PTX umbrella here, while `__out` is
+// undefined, so those headers are processed safely regardless of include order. Guarded by
+// __has_include so toolkits without <cuda/ptx> are unaffected.
+#if defined(__has_include)
+#if __has_include(<cuda/ptx>)
+#include <cuda/ptx>
+#endif
+#endif
 #endif
 
 #include <cub/cub.cuh>

--- a/plugin-ep-cuda/csharp/Microsoft.ML.OnnxRuntime.EP.Cuda/Microsoft.ML.OnnxRuntime.EP.Cuda.csproj
+++ b/plugin-ep-cuda/csharp/Microsoft.ML.OnnxRuntime.EP.Cuda/Microsoft.ML.OnnxRuntime.EP.Cuda.csproj
@@ -43,6 +43,14 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Include="runtimes\win-arm64\native\**"
+          Pack="true"
+          PackagePath="runtimes/win-arm64/native/"
+          CopyToOutputDirectory="PreserveNewest"
+          Condition="Exists('runtimes\win-arm64\native')" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Include="runtimes\linux-x64\native\**"
           Pack="true"
           PackagePath="runtimes/linux-x64/native/"

--- a/plugin-ep-cuda/csharp/README.md
+++ b/plugin-ep-cuda/csharp/README.md
@@ -78,6 +78,7 @@ Expected layout inside the package:
 ```
 lib/netstandard2.0/Microsoft.ML.OnnxRuntime.EP.Cuda.dll
 runtimes/win-x64/native/onnxruntime_providers_cuda.dll
+runtimes/win-arm64/native/onnxruntime_providers_cuda.dll
 runtimes/linux-x64/native/libonnxruntime_providers_cuda.so
 runtimes/linux-arm64/native/libonnxruntime_providers_cuda.so
 ```
@@ -129,5 +130,6 @@ package, and runs the test app on a GPU agent.
 | RID | Required Files |
 |---|---|
 | `win-x64` | `onnxruntime_providers_cuda.dll` |
+| `win-arm64` | `onnxruntime_providers_cuda.dll` |
 | `linux-x64` | `libonnxruntime_providers_cuda.so` |
 | `linux-arm64` | `libonnxruntime_providers_cuda.so` |

--- a/plugin-ep-cuda/csharp/pack_nuget.py
+++ b/plugin-ep-cuda/csharp/pack_nuget.py
@@ -35,6 +35,7 @@ from pathlib import Path
 # Platform name -> (RID, list of native binary filenames expected in the source dir).
 PLATFORMS: dict[str, tuple[str, tuple[str, ...]]] = {
     "win_x64": ("win-x64", ("onnxruntime_providers_cuda.dll",)),
+    "win_arm64": ("win-arm64", ("onnxruntime_providers_cuda.dll",)),
     "linux_x64": ("linux-x64", ("libonnxruntime_providers_cuda.so",)),
     "linux_aarch64": ("linux-arm64", ("libonnxruntime_providers_cuda.so",)),
 }

--- a/tools/ci_build/github/azure-pipelines/plugin-cuda-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/plugin-cuda-pipeline.yml
@@ -36,10 +36,9 @@ parameters:
   type: boolean
   default: true
 
-# CUDA major.minor series for the build. The exact toolkit minor can differ per platform:
-# win-x64 / linux use CUDA 13.0, while win-arm64 uses CUDA 13.1 (NVIDIA only ships
-# Windows-on-ARM CUDA for 13.x). The option is labeled '13.x' to avoid implying every
-# platform uses 13.0. It is translated to the concrete x64 minor ('13.0') below.
+# CUDA major.minor series for the build. The exact toolkit minor can differ per platform,
+# so the CUDA 13 option uses a major-only label. It is translated to concrete toolkit
+# versions when invoking the packaging stage below.
 - name: cuda_version
   displayName: 'CUDA Version'
   type: string
@@ -136,9 +135,8 @@ extends:
             build_windows_arm64: ${{ parameters.build_windows_arm64 }}
             build_linux_x64: ${{ parameters.build_linux_x64 }}
             build_linux_aarch64: ${{ parameters.build_linux_aarch64 }}
-            # Translate the UI label '13.x' to the concrete x64 toolkit minor '13.0'.
-            # win-arm64 overrides this with arm64_cuda_version (13.1) inside the win stage.
             cuda_version: ${{ replace(parameters.cuda_version, '13.x', '13.0') }}
+            arm64_cuda_version: '13.1'
             package_type: ${{ parameters.package_type }}
             version_file: ${{ variables.epVersionFile }}
             cmake_build_type: ${{ parameters.cmake_build_type }}

--- a/tools/ci_build/github/azure-pipelines/plugin-cuda-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/plugin-cuda-pipeline.yml
@@ -21,23 +21,32 @@ parameters:
   type: boolean
   default: true
 
+- name: build_windows_arm64
+  displayName: 'Build Windows ARM64 (CUDA 13.x only)'
+  type: boolean
+  default: true
+
 - name: build_linux_x64
   displayName: 'Build Linux x64'
   type: boolean
   default: true
 
 - name: build_linux_aarch64
-  displayName: 'Build Linux aarch64 (CUDA 13.0 only)'
+  displayName: 'Build Linux aarch64 (CUDA 13.x only)'
   type: boolean
-  default: false
+  default: true
 
+# CUDA major.minor series for the build. The exact toolkit minor can differ per platform:
+# win-x64 / linux use CUDA 13.0, while win-arm64 uses CUDA 13.1 (NVIDIA only ships
+# Windows-on-ARM CUDA for 13.x). The option is labeled '13.x' to avoid implying every
+# platform uses 13.0. It is translated to the concrete x64 minor ('13.0') below.
 - name: cuda_version
   displayName: 'CUDA Version'
   type: string
-  default: '12.8'
+  default: '13.x'
   values:
   - '12.8'
-  - '13.0'
+  - '13.x'
 
 - name: package_type
   displayName: 'Package Type'
@@ -64,9 +73,9 @@ variables:
   # Non-dev package versions (release, RC) must use Release build type
   - name: invalidBuildTypeConfig
     value: ${{ and(ne(parameters.package_type, 'dev'), ne(parameters.cmake_build_type, 'Release')) }}
-  # aarch64 is only available for CUDA 13.0
+  # aarch64 is only available for CUDA 13.x
   - name: invalidAArch64Config
-    value: ${{ and(eq(parameters.build_linux_aarch64, true), ne(parameters.cuda_version, '13.0')) }}
+    value: ${{ and(eq(parameters.build_linux_aarch64, true), ne(parameters.cuda_version, '13.x')) }}
 
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
@@ -117,25 +126,30 @@ extends:
                 displayName: 'ERROR: Non-dev package version requires Release build type'
             - ${{ if eq(variables['invalidAArch64Config'], 'True') }}:
               - script: |
-                  echo "##vso[task.logissue type=error]Linux aarch64 build is only available for CUDA 13.0."
+                  echo "##vso[task.logissue type=error]Linux aarch64 build is only available for CUDA 13.x."
                   exit 1
-                displayName: 'ERROR: aarch64 requires CUDA 13.0'
+                displayName: 'ERROR: aarch64 requires CUDA 13.x'
       - ${{ else }}:
         - template: stages/plugin-cuda-packaging-stage.yml
           parameters:
             build_windows_x64: ${{ parameters.build_windows_x64 }}
+            build_windows_arm64: ${{ parameters.build_windows_arm64 }}
             build_linux_x64: ${{ parameters.build_linux_x64 }}
             build_linux_aarch64: ${{ parameters.build_linux_aarch64 }}
-            cuda_version: ${{ parameters.cuda_version }}
+            # Translate the UI label '13.x' to the concrete x64 toolkit minor '13.0'.
+            # win-arm64 overrides this with arm64_cuda_version (13.1) inside the win stage.
+            cuda_version: ${{ replace(parameters.cuda_version, '13.x', '13.0') }}
             package_type: ${{ parameters.package_type }}
             version_file: ${{ variables.epVersionFile }}
             cmake_build_type: ${{ parameters.cmake_build_type }}
             ${{ if eq(parameters.cuda_version, '12.8') }}:
               python_package_name: 'onnxruntime-ep-cuda12'
               docker_base_image: 'onnxruntimebuildcache.azurecr.io/internal/azureml/onnxruntime/build/cuda12_x64_almalinux8_gcc14:20251017.1'
-              cmake_cuda_archs: '61-real;75-real;86-real;89-real;120-real;120-virtual'
-            ${{ if eq(parameters.cuda_version, '13.0') }}:
+              cmake_x64_cuda_archs: '61-real;75-real;86-real;89-real;120-real;120-virtual'
+              cmake_arm64_cuda_archs: '61-real;75-real;86-real;89-real;120-real;120-virtual'
+            ${{ if eq(parameters.cuda_version, '13.x') }}:
               python_package_name: 'onnxruntime-ep-cuda13'
               docker_base_image: 'onnxruntimebuildcache.azurecr.io/internal/azureml/onnxruntime/build/cuda13_x64_almalinux8_gcc14:20251107.1'
               docker_base_image_aarch64: 'onnxruntimebuildcache.azurecr.io/public/azureml/onnxruntime_build_cuda13_aarch64_almalinux9_gcc14:20260323.1'
-              cmake_cuda_archs: '75-real;80-real;86-real;89-real;90-real;100-real;120-real;120-virtual'
+              cmake_x64_cuda_archs: '75-real;80-real;86-real;89-real;90-real;120-real;120-virtual'
+              cmake_arm64_cuda_archs: '110-real;120-real;121-real;120-virtual'

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-cuda-nuget-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-cuda-nuget-packaging-stage.yml
@@ -17,6 +17,7 @@ parameters:
   type: object
   default:
     win_x64: false
+    win_arm64: false
     linux_x64: false
     linux_aarch64: false
 
@@ -26,6 +27,8 @@ stages:
   dependsOn:
   - ${{ if eq(parameters.platforms.win_x64, true) }}:
     - Win_plugin_cuda_x64_Build
+  - ${{ if eq(parameters.platforms.win_arm64, true) }}:
+    - Win_plugin_cuda_arm64_Build
   - ${{ if eq(parameters.platforms.linux_x64, true) }}:
     - Linux_plugin_cuda_x64
   - ${{ if eq(parameters.platforms.linux_aarch64, true) }}:
@@ -81,6 +84,13 @@ stages:
           artifactName: cuda_plugin_win_x64
           targetPath: '$(Build.BinariesDirectory)\artifacts\win_x64'
 
+    - ${{ if eq(parameters.platforms.win_arm64, true) }}:
+      - task: DownloadPipelineArtifact@2
+        displayName: 'Download win-arm64 artifacts'
+        inputs:
+          artifactName: cuda_plugin_win_arm64
+          targetPath: '$(Build.BinariesDirectory)\artifacts\win_arm64'
+
     - ${{ if eq(parameters.platforms.linux_x64, true) }}:
       - task: DownloadPipelineArtifact@2
         displayName: 'Download linux-x64 artifacts'
@@ -111,6 +121,7 @@ stages:
           # time and resolve to a boolean value 'True' or 'False'. Compare case-insensitively.
           platforms_enabled = {
               "win_x64":        "${{ parameters.platforms.win_x64 }}".lower() == "true",
+              "win_arm64":      "${{ parameters.platforms.win_arm64 }}".lower() == "true",
               "linux_x64":      "${{ parameters.platforms.linux_x64 }}".lower() == "true",
               "linux_aarch64":  "${{ parameters.platforms.linux_aarch64 }}".lower() == "true",
           }

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-cuda-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-cuda-packaging-stage.yml
@@ -24,6 +24,11 @@ parameters:
   displayName: 'CUDA Version'
   default: '12.8'
 
+- name: arm64_cuda_version
+  type: string
+  displayName: 'Windows ARM64 CUDA Version'
+  default: '13.1'
+
 - name: package_type
   displayName: 'Package Type'
   type: string
@@ -120,10 +125,14 @@ stages:
             $metadata = [ordered]@{
               cuda_version = '${{ parameters.cuda_version }}'
               cuda_version_no_dot = '${{ replace(parameters.cuda_version, '.', '') }}'
+              cuda_version_win_x64 = '${{ parameters.cuda_version }}'
+              cuda_version_win_x64_no_dot = '${{ replace(parameters.cuda_version, '.', '') }}'
+              cuda_version_win_arm64 = '${{ parameters.arm64_cuda_version }}'
+              cuda_version_win_arm64_no_dot = '${{ replace(parameters.arm64_cuda_version, '.', '') }}'
               docker_base_image_linux_x64 = '${{ parameters.docker_base_image }}'
               python_artifact_linux_x64 = 'cuda_plugin_python_linux_x64_cuda${{ replace(parameters.cuda_version, '.', '') }}'
               python_artifact_win_x64 = 'cuda_plugin_python_win_x64_cuda${{ replace(parameters.cuda_version, '.', '') }}'
-              python_artifact_win_arm64 = 'cuda_plugin_python_win_arm64_cuda${{ replace(parameters.cuda_version, '.', '') }}'
+              python_artifact_win_arm64 = 'cuda_plugin_python_win_arm64_cuda${{ replace(parameters.arm64_cuda_version, '.', '') }}'
               nuget_artifact = 'cuda_plugin_nuget'
             }
 
@@ -150,6 +159,7 @@ stages:
         parameters:
           arch: 'arm64'
           cuda_version: ${{ parameters.cuda_version }}
+          arm64_cuda_version: ${{ parameters.arm64_cuda_version }}
           cmake_cuda_archs: ${{ parameters.cmake_arm64_cuda_archs }}
           package_version: ${{ parameters.package_type }}
           version_file: ${{ parameters.version_file }}

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-cuda-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-cuda-packaging-stage.yml
@@ -4,6 +4,11 @@ parameters:
   type: boolean
   default: true
 
+- name: build_windows_arm64
+  displayName: 'Build Windows ARM64'
+  type: boolean
+  default: false
+
 - name: build_linux_x64
   displayName: 'Build Linux x64'
   type: boolean
@@ -51,10 +56,15 @@ parameters:
   displayName: 'Linux aarch64 docker base image'
   default: ''
 
-- name: cmake_cuda_archs
+- name: cmake_x64_cuda_archs
   type: string
-  displayName: 'CMAKE_CUDA_ARCHITECTURES'
+  displayName: 'CMAKE_CUDA_ARCHITECTURES for x64'
   default: '61-real;75-real;86-real;89-real;120-real;120-virtual'
+
+- name: cmake_arm64_cuda_archs
+  type: string
+  displayName: 'CMAKE_CUDA_ARCHITECTURES for ARM64'
+  default: '110-real;120-real;121-real;120-virtual'
 
 - name: python_version
   type: string
@@ -113,6 +123,7 @@ stages:
               docker_base_image_linux_x64 = '${{ parameters.docker_base_image }}'
               python_artifact_linux_x64 = 'cuda_plugin_python_linux_x64_cuda${{ replace(parameters.cuda_version, '.', '') }}'
               python_artifact_win_x64 = 'cuda_plugin_python_win_x64_cuda${{ replace(parameters.cuda_version, '.', '') }}'
+              python_artifact_win_arm64 = 'cuda_plugin_python_win_arm64_cuda${{ replace(parameters.cuda_version, '.', '') }}'
               nuget_artifact = 'cuda_plugin_nuget'
             }
 
@@ -125,8 +136,21 @@ stages:
     - ${{ if eq(parameters.build_windows_x64, true) }}:
       - template: plugin-win-cuda-stage.yml
         parameters:
+          arch: 'x64'
           cuda_version: ${{ parameters.cuda_version }}
-          cmake_cuda_archs: ${{ parameters.cmake_cuda_archs }}
+          cmake_cuda_archs: ${{ parameters.cmake_x64_cuda_archs }}
+          package_version: ${{ parameters.package_type }}
+          version_file: ${{ parameters.version_file }}
+          python_package_name: ${{ parameters.python_package_name }}
+          cmake_build_type: ${{ parameters.cmake_build_type }}
+
+    # Windows ARM64
+    - ${{ if eq(parameters.build_windows_arm64, true) }}:
+      - template: plugin-win-cuda-stage.yml
+        parameters:
+          arch: 'arm64'
+          cuda_version: ${{ parameters.cuda_version }}
+          cmake_cuda_archs: ${{ parameters.cmake_arm64_cuda_archs }}
           package_version: ${{ parameters.package_type }}
           version_file: ${{ parameters.version_file }}
           python_package_name: ${{ parameters.python_package_name }}
@@ -140,7 +164,7 @@ stages:
           arch: 'x64'
           machine_pool: 'onnxruntime-Ubuntu2404-AMD-CPU'
           cuda_version: ${{ parameters.cuda_version }}
-          cmake_cuda_archs: ${{ parameters.cmake_cuda_archs }}
+          cmake_cuda_archs: ${{ parameters.cmake_x64_cuda_archs }}
           package_version: ${{ parameters.package_type }}
           version_file: ${{ parameters.version_file }}
           python_package_name: ${{ parameters.python_package_name }}
@@ -150,7 +174,7 @@ stages:
           docker_python_exe_path: ${{ parameters.docker_python_exe_path }}
           artifact_name: cuda_plugin_linux_x64
 
-    # Linux aarch64 (CUDA 13.0 only)
+    # Linux aarch64 (CUDA 13.x only)
     - ${{ if eq(parameters.build_linux_aarch64, true) }}:
       - template: plugin-linux-cuda-stage.yml
         parameters:
@@ -158,7 +182,7 @@ stages:
           arch: 'aarch64'
           machine_pool: 'onnxruntime-linux-ARM64-CPU-2019'
           cuda_version: ${{ parameters.cuda_version }}
-          cmake_cuda_archs: ${{ parameters.cmake_cuda_archs }}
+          cmake_cuda_archs: ${{ parameters.cmake_arm64_cuda_archs }}
           package_version: ${{ parameters.package_type }}
           version_file: ${{ parameters.version_file }}
           python_package_name: ${{ parameters.python_package_name }}
@@ -176,23 +200,23 @@ stages:
         DoEsrp: true
         platforms:
           win_x64: ${{ parameters.build_windows_x64 }}
+          win_arm64: ${{ parameters.build_windows_arm64 }}
           linux_x64: ${{ parameters.build_linux_x64 }}
           linux_aarch64: ${{ parameters.build_linux_aarch64 }}
 
     # Create zip packages for Foundry Local consumption.
-    - ${{ if or(eq(parameters.build_windows_x64, true), eq(parameters.build_linux_x64, true)) }}:
+    - ${{ if or(eq(parameters.build_windows_x64, true), eq(parameters.build_windows_arm64, true), eq(parameters.build_linux_x64, true), eq(parameters.build_linux_aarch64, true)) }}:
       - stage: Package_Foundry_Local_CUDA_Zips
         displayName: 'Package Foundry Local CUDA Plugin-EP Zips'
         dependsOn:
           - ${{ if eq(parameters.build_windows_x64, true) }}:
             - Win_plugin_cuda_x64_Build
+          - ${{ if eq(parameters.build_windows_arm64, true) }}:
+            - Win_plugin_cuda_arm64_Build
           - ${{ if eq(parameters.build_linux_x64, true) }}:
             - Linux_plugin_cuda_x64
-          # TODO: win-arm64 and linux-aarch64 are still being developed.
-          # - ${{ if eq(parameters.build_windows_arm64, true) }}:
-          #   - Win_plugin_cuda_arm64_Build
-          # - ${{ if eq(parameters.build_linux_aarch64, true) }}:
-          #   - Linux_plugin_cuda_aarch64
+          - ${{ if eq(parameters.build_linux_aarch64, true) }}:
+            - Linux_plugin_cuda_aarch64
           # NOTE: macOS arm64 (Apple Silicon) does not have CUDA support since
           # Apple devices do not use Nvidia GPUs.
         jobs:
@@ -222,6 +246,13 @@ stages:
                 artifactName: cuda_plugin_win_x64
                 targetPath: $(Build.SourcesDirectory)/cuda-plugin-win-x64
 
+          - ${{ if eq(parameters.build_windows_arm64, true) }}:
+            - task: DownloadPipelineArtifact@2
+              displayName: 'Download cuda_plugin_win_arm64'
+              inputs:
+                artifactName: cuda_plugin_win_arm64
+                targetPath: $(Build.SourcesDirectory)/cuda-plugin-win-arm64
+
           - ${{ if eq(parameters.build_linux_x64, true) }}:
             - task: DownloadPipelineArtifact@2
               displayName: 'Download cuda_plugin_linux_x64'
@@ -229,20 +260,12 @@ stages:
                 artifactName: cuda_plugin_linux_x64
                 targetPath: $(Build.SourcesDirectory)/cuda-plugin-linux-x64
 
-          # TODO: win-arm64 and linux-aarch64 are still being developed.
-          # - ${{ if eq(parameters.build_windows_arm64, true) }}:
-          #   - task: DownloadPipelineArtifact@2
-          #     displayName: 'Download cuda_plugin_win_arm64'
-          #     inputs:
-          #       artifactName: cuda_plugin_win_arm64
-          #       targetPath: $(Build.SourcesDirectory)/cuda-plugin-win-arm64
-
-          # - ${{ if eq(parameters.build_linux_aarch64, true) }}:
-          #   - task: DownloadPipelineArtifact@2
-          #     displayName: 'Download cuda_plugin_linux_aarch64'
-          #     inputs:
-          #       artifactName: cuda_plugin_linux_aarch64
-          #       targetPath: $(Build.SourcesDirectory)/cuda-plugin-linux-aarch64
+          - ${{ if eq(parameters.build_linux_aarch64, true) }}:
+            - task: DownloadPipelineArtifact@2
+              displayName: 'Download cuda_plugin_linux_aarch64'
+              inputs:
+                artifactName: cuda_plugin_linux_aarch64
+                targetPath: $(Build.SourcesDirectory)/cuda-plugin-linux-aarch64
 
           - task: PowerShell@2
             displayName: 'Create version.json and zip packages for each platform'
@@ -261,10 +284,9 @@ stages:
                 # NOTE: macOS arm64 (Apple Silicon) is excluded — no CUDA support since Apple devices do not use Nvidia GPUs.
                 $platforms = @(
                   @{ name = 'win-x64';        dir = '$(Build.SourcesDirectory)/cuda-plugin-win-x64' },
-                  @{ name = 'linux-x64';      dir = '$(Build.SourcesDirectory)/cuda-plugin-linux-x64' }
-                  # TODO: win-arm64 and linux-aarch64 are still being developed.
-                  # @{ name = 'win-arm64';      dir = '$(Build.SourcesDirectory)/cuda-plugin-win-arm64' },
-                  # @{ name = 'linux-aarch64';  dir = '$(Build.SourcesDirectory)/cuda-plugin-linux-aarch64' }
+                  @{ name = 'win-arm64';      dir = '$(Build.SourcesDirectory)/cuda-plugin-win-arm64' },
+                  @{ name = 'linux-x64';      dir = '$(Build.SourcesDirectory)/cuda-plugin-linux-x64' },
+                  @{ name = 'linux-aarch64';  dir = '$(Build.SourcesDirectory)/cuda-plugin-linux-aarch64' }
                 )
 
                 $resolvedVersion = $null

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-win-cuda-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-win-cuda-stage.yml
@@ -1,4 +1,11 @@
 parameters:
+- name: arch
+  type: string
+  default: x64
+  values:
+  - x64
+  - arm64
+
 - name: package_version
   type: string
   default: dev
@@ -23,6 +30,16 @@ parameters:
   type: string
   default: '12.8'
 
+# win-arm64 uses a separate CUDA toolkit and cuDNN build than win-x64. NVIDIA only
+# ships Windows-on-ARM CUDA for 13.x, hosted under a 'win-arm64/' blob path prefix.
+- name: arm64_cuda_version
+  type: string
+  default: '13.1'
+
+- name: arm64_cudnn_folder
+  type: string
+  default: '9.24.0.17_cuda13'
+
 - name: python_package_name
   type: string
 
@@ -31,16 +48,23 @@ parameters:
   default: '61-real;75-real;86-real;89-real;120-real;120-virtual'
 
 stages:
-  - stage: Win_plugin_cuda_x64_Build
+  - stage: Win_plugin_cuda_${{ parameters.arch }}_Build
     dependsOn: []
     jobs:
-    - job: Win_plugin_cuda_x64_Build
+    - job: Win_plugin_cuda_${{ parameters.arch }}_Build
       timeoutInMinutes: 360
       workspace:
         clean: all
       pool:
-        name: onnxruntime-Win-CPU-VS2022-Latest
-        os: windows
+        ${{ if eq(parameters.arch, 'arm64') }}:
+          name: onnxruntime-qnn-windows-vs-2022-arm64
+          os: windows
+          hostArchitecture: Arm64
+          demands:
+            - Agent.Version -equals 4.264.2
+        ${{ else }}:
+          name: onnxruntime-Win-CPU-VS2022-Latest
+          os: windows
       templateContext:
         sdl:
           codeSignValidation:
@@ -54,7 +78,7 @@ stages:
         outputs:
         - output: pipelineArtifact
           targetPath: $(Build.ArtifactStagingDirectory)
-          artifactName: cuda_plugin_win_x64
+          artifactName: cuda_plugin_win_${{ parameters.arch }}
       variables:
       - template: ../templates/common-variables.yml
       - name: GRADLE_OPTS
@@ -68,7 +92,7 @@ stages:
 
       - template: ../templates/setup-build-tools.yml
         parameters:
-          host_cpu_arch: 'x64'
+          host_cpu_arch: ${{ parameters.arch }}
           python_version: ${{ parameters.python_version }}
 
       - template: ../templates/set-nightly-build-option-variable-step.yml
@@ -85,26 +109,46 @@ stages:
         env:
           TMPDIR: "$(Agent.TempDirectory)"
 
-      - task: AzureCLI@2
-        displayName: 'Download CUDA SDK v${{ parameters.cuda_version }}'
-        inputs:
-          azureSubscription: AIInfraBuildOnnxRuntimeOSS
-          scriptType: 'batch'
-          scriptLocation: 'inlineScript'
-          inlineScript: |
-            set AZCOPY_AUTO_LOGIN_TYPE=AZCLI
-            azcopy.exe cp --recursive https://lotusscus.blob.core.windows.net/models/cuda_sdk/v${{ parameters.cuda_version }} "$(Agent.TempDirectory)"
+      # CUDA SDK download. win-x64 toolkits live at cuda_sdk/v<ver>; win-arm64 toolkits
+      # live at cuda_sdk/win-arm64/v<ver> (NVIDIA Windows-on-ARM CUDA is 13.x only).
+      - ${{ if ne(parameters.arch, 'arm64') }}:
+        - task: AzureCLI@2
+          displayName: 'Download CUDA SDK v${{ parameters.cuda_version }}'
+          inputs:
+            azureSubscription: AIInfraBuildOnnxRuntimeOSS
+            scriptType: 'batch'
+            scriptLocation: 'inlineScript'
+            inlineScript: |
+              set AZCOPY_AUTO_LOGIN_TYPE=AZCLI
+              azcopy.exe cp --recursive https://lotusscus.blob.core.windows.net/models/cuda_sdk/v${{ parameters.cuda_version }} "$(Agent.TempDirectory)"
 
-      # Since CUDA 13.0, CUDA DLLs are in bin\x64 folder instead of bin folder for Windows.
-      - powershell: |
-          Write-Host "Adding CUDA to PATH"
-          Write-Host "##vso[task.prependpath]$env:AGENT_TEMPDIRECTORY\v${{ parameters.cuda_version }}\bin"
-          Write-Host "##vso[task.prependpath]$env:AGENT_TEMPDIRECTORY\v${{ parameters.cuda_version }}\bin\x64"
-          Write-Host "##vso[task.prependpath]$env:AGENT_TEMPDIRECTORY\v${{ parameters.cuda_version }}\extras\CUPTI\lib64"
-        displayName: 'Add CUDA to PATH'
+        # Since CUDA 13.0, CUDA DLLs are in bin\x64 folder instead of bin folder for Windows.
+        - powershell: |
+            Write-Host "Adding CUDA to PATH"
+            Write-Host "##vso[task.prependpath]$env:AGENT_TEMPDIRECTORY\v${{ parameters.cuda_version }}\bin"
+            Write-Host "##vso[task.prependpath]$env:AGENT_TEMPDIRECTORY\v${{ parameters.cuda_version }}\bin\x64"
+            Write-Host "##vso[task.prependpath]$env:AGENT_TEMPDIRECTORY\v${{ parameters.cuda_version }}\extras\CUPTI\lib64"
+          displayName: 'Add CUDA to PATH'
 
-      # Download cuDNN separately for CUDA 13.0
-      - ${{ if eq(parameters.cuda_version, '13.0') }}:
+      - ${{ else }}:
+        # The win-arm64 agents (onnxruntime-qnn-windows-vs-2022-arm64) do not have the Azure
+        # CLI installed, so the AzureCLI@2 task cannot be used here (it fails with "Azure CLI
+        # 2.x is not installed on this machine"). azcopy is on PATH and can read this storage
+        # account directly, matching the QNN SDK download in
+        # templates/jobs/download_win_qnn_sdk.yml.
+        - powershell: |
+            azcopy.exe cp --recursive https://lotusscus.blob.core.windows.net/models/cuda_sdk/win-arm64/v${{ parameters.arm64_cuda_version }} "$(Agent.TempDirectory)"
+          displayName: 'Download CUDA SDK win-arm64 v${{ parameters.arm64_cuda_version }}'
+
+        - powershell: |
+            Write-Host "Adding CUDA to PATH"
+            Write-Host "##vso[task.prependpath]$env:AGENT_TEMPDIRECTORY\v${{ parameters.arm64_cuda_version }}\bin"
+            Write-Host "##vso[task.prependpath]$env:AGENT_TEMPDIRECTORY\v${{ parameters.arm64_cuda_version }}\bin\arm64"
+            Write-Host "##vso[task.prependpath]$env:AGENT_TEMPDIRECTORY\v${{ parameters.arm64_cuda_version }}\extras\CUPTI\lib64"
+          displayName: 'Add CUDA to PATH'
+
+      # Download cuDNN separately for CUDA 13.0 (win-x64)
+      - ${{ if and(ne(parameters.arch, 'arm64'), eq(parameters.cuda_version, '13.0')) }}:
         - task: AzureCLI@2
           displayName: 'Download cuDNN for CUDA 13.0'
           inputs:
@@ -115,8 +159,16 @@ stages:
               set AZCOPY_AUTO_LOGIN_TYPE=AZCLI
               azcopy.exe cp --recursive https://lotusscus.blob.core.windows.net/models/cudnn_sdk/$(cuda13_cudnn_folder) "$(Agent.TempDirectory)"
 
-      # CUDA 12.x build (no separate cuDNN)
-      - ${{ if ne(parameters.cuda_version, '13.0') }}:
+      # Download cuDNN for win-arm64 (hosted under cudnn_sdk/win-arm64/<folder>).
+      # Uses azcopy directly because the win-arm64 agents do not have the Azure CLI installed
+      # (see the CUDA SDK download step above).
+      - ${{ if eq(parameters.arch, 'arm64') }}:
+        - powershell: |
+            azcopy.exe cp --recursive https://lotusscus.blob.core.windows.net/models/cudnn_sdk/win-arm64/${{ parameters.arm64_cudnn_folder }} "$(Agent.TempDirectory)"
+          displayName: 'Download cuDNN for win-arm64 (${{ parameters.arm64_cudnn_folder }})'
+
+      # CUDA 12.x build (no separate cuDNN). win-x64 only — win-arm64 always uses CUDA 13.x.
+      - ${{ if and(ne(parameters.arch, 'arm64'), ne(parameters.cuda_version, '13.0')) }}:
         - task: PythonScript@0
           displayName: 'Build CUDA Plugin (CUDA ${{ parameters.cuda_version }})'
           inputs:
@@ -143,8 +195,8 @@ stages:
               $(TelemetryOption)
             workingDirectory: '$(Build.BinariesDirectory)'
 
-      # CUDA 13.0 build (separate cuDNN folder)
-      - ${{ if eq(parameters.cuda_version, '13.0') }}:
+      # CUDA 13.0 build (separate cuDNN folder). win-x64 only — win-arm64 handled below.
+      - ${{ if and(ne(parameters.arch, 'arm64'), eq(parameters.cuda_version, '13.0')) }}:
         - task: PythonScript@0
           displayName: 'Build CUDA Plugin (CUDA ${{ parameters.cuda_version }})'
           inputs:
@@ -165,6 +217,36 @@ stages:
               --use_cuda
               --cuda_home="$(Agent.TempDirectory)\v${{ parameters.cuda_version }}"
               --cudnn_home="$(Agent.TempDirectory)\$(cuda13_cudnn_folder)"
+              --skip_tests
+              --cmake_extra_defines CMAKE_CUDA_ARCHITECTURES="${{ parameters.cmake_cuda_archs }}"
+              --cmake_extra_defines onnxruntime_BUILD_CUDA_EP_AS_PLUGIN=ON
+              --cmake_extra_defines $(PluginEpVersionDefine)
+              $(TelemetryOption)
+            workingDirectory: '$(Build.BinariesDirectory)'
+
+      # win-arm64 build (CUDA 13.x with a separate cuDNN folder). Runs natively on the
+      # ARM64 agent, so build.py auto-selects the ARM64 toolset (-A ARM64).
+      - ${{ if eq(parameters.arch, 'arm64') }}:
+        - task: PythonScript@0
+          displayName: 'Build CUDA Plugin (win-arm64 CUDA ${{ parameters.arm64_cuda_version }})'
+          inputs:
+            scriptPath: '$(Build.SourcesDirectory)\tools\ci_build\build.py'
+            arguments: >-
+              --config ${{ parameters.cmake_build_type }}
+              --build_dir $(Build.BinariesDirectory)
+              --skip_submodule_sync
+              --cmake_generator "$(VSGenerator)"
+              --parallel
+              --nvcc_threads 1
+              --flash_nvcc_threads 1
+              --use_vcpkg
+              --use_vcpkg_ms_internal_asset_cache
+              --use_binskim_compliant_compile_flags
+              --update
+              --build
+              --use_cuda
+              --cuda_home="$(Agent.TempDirectory)\v${{ parameters.arm64_cuda_version }}"
+              --cudnn_home="$(Agent.TempDirectory)\${{ parameters.arm64_cudnn_folder }}"
               --skip_tests
               --cmake_extra_defines CMAKE_CUDA_ARCHITECTURES="${{ parameters.cmake_cuda_archs }}"
               --cmake_extra_defines onnxruntime_BUILD_CUDA_EP_AS_PLUGIN=ON
@@ -203,19 +285,26 @@ stages:
           type nul > "$(Build.ArtifactStagingDirectory)\version\$(PluginPackageVersion)"
         displayName: 'Create version marker file'
 
-    - job: Win_plugin_cuda_x64_Python_Package
-      dependsOn: Win_plugin_cuda_x64_Build
+    - job: Win_plugin_cuda_${{ parameters.arch }}_Python_Package
+      dependsOn: Win_plugin_cuda_${{ parameters.arch }}_Build
       timeoutInMinutes: 30
       workspace:
         clean: all
       pool:
-        name: onnxruntime-Win-CPU-VS2022-Latest
-        os: windows
+        ${{ if eq(parameters.arch, 'arm64') }}:
+          name: onnxruntime-qnn-windows-vs-2022-arm64
+          os: windows
+          hostArchitecture: Arm64
+          demands:
+            - Agent.Version -equals 4.264.2
+        ${{ else }}:
+          name: onnxruntime-Win-CPU-VS2022-Latest
+          os: windows
       templateContext:
         outputs:
         - output: pipelineArtifact
           targetPath: '$(Build.ArtifactStagingDirectory)\python'
-          artifactName: cuda_plugin_python_win_x64_cuda${{ replace(parameters.cuda_version, '.', '') }}
+          artifactName: cuda_plugin_python_win_${{ parameters.arch }}_cuda${{ replace(parameters.cuda_version, '.', '') }}
       variables:
       - template: ../templates/common-variables.yml
       steps:
@@ -225,7 +314,7 @@ stages:
 
       - template: ../templates/setup-build-tools.yml
         parameters:
-          host_cpu_arch: 'x64'
+          host_cpu_arch: ${{ parameters.arch }}
           python_version: ${{ parameters.python_version }}
 
       - template: ../templates/set-nightly-build-option-variable-step.yml
@@ -239,7 +328,7 @@ stages:
       - task: DownloadPipelineArtifact@2
         displayName: 'Download plugin build artifacts'
         inputs:
-          artifactName: cuda_plugin_win_x64
+          artifactName: cuda_plugin_win_${{ parameters.arch }}
           targetPath: '$(Build.BinariesDirectory)\plugin_artifacts'
 
       - task: PowerShell@2

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-win-cuda-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-win-cuda-stage.yml
@@ -331,15 +331,11 @@ stages:
           artifactName: cuda_plugin_win_${{ parameters.arch }}
           targetPath: '$(Build.BinariesDirectory)\plugin_artifacts'
 
-      - task: PowerShell@2
+      - powershell: |
+          python -m pip install -r "$(Build.SourcesDirectory)\plugin-ep-cuda\python\requirements-build-wheel.txt"
+          python "$(Build.SourcesDirectory)\plugin-ep-cuda\python\build_wheel.py" `
+            --binary_dir "$(Build.BinariesDirectory)\plugin_artifacts\bin" `
+            --version "$(PluginPythonPackageVersion)" `
+            --package_name "${{ parameters.python_package_name }}" `
+            --output_dir "$(Build.ArtifactStagingDirectory)\python"
         displayName: 'Build Python wheel'
-        inputs:
-          targetType: inline
-          pwsh: true
-          script: |
-            python -m pip install -r "$(Build.SourcesDirectory)\plugin-ep-cuda\python\requirements-build-wheel.txt"
-            python "$(Build.SourcesDirectory)\plugin-ep-cuda\python\build_wheel.py" `
-              --binary_dir "$(Build.BinariesDirectory)\plugin_artifacts\bin" `
-              --version "$(PluginPythonPackageVersion)" `
-              --package_name "${{ parameters.python_package_name }}" `
-              --output_dir "$(Build.ArtifactStagingDirectory)\python"

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-win-cuda-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-win-cuda-stage.yml
@@ -304,7 +304,10 @@ stages:
         outputs:
         - output: pipelineArtifact
           targetPath: '$(Build.ArtifactStagingDirectory)\python'
-          artifactName: cuda_plugin_python_win_${{ parameters.arch }}_cuda${{ replace(parameters.cuda_version, '.', '') }}
+          ${{ if eq(parameters.arch, 'arm64') }}:
+            artifactName: cuda_plugin_python_win_arm64_cuda${{ replace(parameters.arm64_cuda_version, '.', '') }}
+          ${{ else }}:
+            artifactName: cuda_plugin_python_win_x64_cuda${{ replace(parameters.cuda_version, '.', '') }}
       variables:
       - template: ../templates/common-variables.yml
       steps:

--- a/tools/ci_build/github/azure-pipelines/templates/read-cuda-plugin-metadata-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/read-cuda-plugin-metadata-steps.yml
@@ -21,9 +21,14 @@ steps:
       $requiredProperties = @(
         'cuda_version',
         'cuda_version_no_dot',
+        'cuda_version_win_x64',
+        'cuda_version_win_x64_no_dot',
+        'cuda_version_win_arm64',
+        'cuda_version_win_arm64_no_dot',
         'docker_base_image_linux_x64',
         'python_artifact_linux_x64',
         'python_artifact_win_x64',
+        'python_artifact_win_arm64',
         'nuget_artifact'
       )
 
@@ -35,11 +40,18 @@ steps:
 
       Write-Host "Detected CUDA version: $($metadata.cuda_version)"
       Write-Host "Linux Python artifact: $($metadata.python_artifact_linux_x64)"
-      Write-Host "Windows Python artifact: $($metadata.python_artifact_win_x64)"
+      Write-Host "Windows x64 Python artifact: $($metadata.python_artifact_win_x64)"
+      Write-Host "Windows ARM64 Python artifact: $($metadata.python_artifact_win_arm64)"
 
       Write-Host "##vso[task.setvariable variable=CudaVersion]$($metadata.cuda_version)"
       Write-Host "##vso[task.setvariable variable=CudaVersionNoDot]$($metadata.cuda_version_no_dot)"
+      Write-Host "##vso[task.setvariable variable=CudaVersionWinX64]$($metadata.cuda_version_win_x64)"
+      Write-Host "##vso[task.setvariable variable=CudaVersionWinX64NoDot]$($metadata.cuda_version_win_x64_no_dot)"
+      Write-Host "##vso[task.setvariable variable=CudaVersionWinArm64]$($metadata.cuda_version_win_arm64)"
+      Write-Host "##vso[task.setvariable variable=CudaVersionWinArm64NoDot]$($metadata.cuda_version_win_arm64_no_dot)"
       Write-Host "##vso[task.setvariable variable=CudaDockerBaseImage]$($metadata.docker_base_image_linux_x64)"
       Write-Host "##vso[task.setvariable variable=CudaPluginPythonLinuxArtifactName]$($metadata.python_artifact_linux_x64)"
       Write-Host "##vso[task.setvariable variable=CudaPluginPythonWinArtifactName]$($metadata.python_artifact_win_x64)"
+      Write-Host "##vso[task.setvariable variable=CudaPluginPythonWinX64ArtifactName]$($metadata.python_artifact_win_x64)"
+      Write-Host "##vso[task.setvariable variable=CudaPluginPythonWinArm64ArtifactName]$($metadata.python_artifact_win_arm64)"
       Write-Host "##vso[task.setvariable variable=CudaPluginNuGetArtifactName]$($metadata.nuget_artifact)"


### PR DESCRIPTION
### Description
This PR adds Windows ARM64 support to CUDA plugin packaging and updates related build/packaging logic for correctness and consistency across architectures.

In response to review feedback, it also:
- Corrects CMake comments to match actual Windows ARM64 CUDA toolkit search behavior.
- Prioritizes architecture-specific cuDNN DLL search paths before generic fallback paths.
- Aligns Windows ARM64 Python artifact naming with the ARM64 CUDA toolkit version.
- Extends packaging metadata with per-platform CUDA version fields (including win-arm64) and updates metadata-reading template validation/exports accordingly.


### Motivation and Context
Windows ARM64 CUDA plugin packaging requires architecture-aware handling for toolkit/cuDNN discovery and artifact metadata.  
These updates prevent cross-architecture ambiguity (especially for CUDA 13.x win-arm64 vs x64), improve downstream artifact selection reliability, and keep metadata semantics consistent with produced artifacts.