### PR TITLE
Fix: Add CMake package files to Windows artifact #28468

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/c-api-artifacts-package-and-publish-steps-windows.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-artifacts-package-and-publish-steps-windows.yml
@@ -1,7 +1,14 @@
 # --------------------------------------------------------------
 # Template: Package and publish Windows C-API artifacts.
 # Expects a "cmake --install" tree under $(Build.BinariesDirectory)\installed.
-# Produces a versioned .zip containing DLLs, libs, headers, CMake files, and docs.
+# Produces a versioned .zip containing DLLs, libs, headers, CMake package
+# files, and docs.
+#
+# Note: Runtime DLLs are placed under lib/ (not bin/) to align with the
+#       patched CMake target files. The installed include/onnxruntime/
+#       hierarchy is flattened so public headers sit directly under
+#       include/, e.g. include/onnxruntime_c_api.h rather than
+#       include/onnxruntime/onnxruntime_c_api.h.
 # --------------------------------------------------------------
 
 parameters:
@@ -62,7 +69,7 @@ steps:
           if errorlevel 1 (
             echo ERROR: cmake --install failed
             exit /b 1
-          )    
+          )
 
     # Publish symbols to Microsoft symbol server for main/rel-* branches
     - ${{ if or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/rel-'))}}:
@@ -175,7 +182,8 @@ steps:
         script: |
           set INSTALLED=$(Build.BinariesDirectory)\installed
           set ARTIFACT=$(Build.BinariesDirectory)\${{parameters.artifactName}}
-          
+          set RAWBUILD=$(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}
+
           if exist %ARTIFACT% (
             rmdir /S /Q %ARTIFACT%
           )
@@ -195,7 +203,7 @@ steps:
             echo "Removed .exe files from lib\"
           )
 
-          REM Optional- CUDA provider – copy extra headers
+          REM Optional- CUDA provider - copy extra headers
           if exist "%INSTALLED%\bin\onnxruntime_providers_cuda.dll" (
             echo "CUDA provider present"
             if not exist "%ARTIFACT%\include\core\providers\cuda" (
@@ -207,31 +215,83 @@ steps:
             copy "$(Build.SourcesDirectory)\include\onnxruntime\core\providers\cuda\cuda_resource.h"  "%ARTIFACT%\include\core\providers\cuda"
           )
 
-          REM If TRT is disabled, remove its binaries from the artifact
+          REM Optional- WebGPU dependencies (staged into build output, not installed by CMake)
+          if exist "%RAWBUILD%\dxcompiler.dll" (
+            echo "WebGPU dxcompiler.dll present"
+            copy "%RAWBUILD%\dxcompiler.dll" "%ARTIFACT%\lib"
+          )
+          if exist "%RAWBUILD%\dxil.dll" (
+            echo "WebGPU dxil.dll present"
+            copy "%RAWBUILD%\dxil.dll" "%ARTIFACT%\lib"
+          )
+
+          REM Optional- QNN dependencies (staged into build output, not installed by CMake)
+          REM Gate checks raw build output, NOT installed\bin, because the QNN provider DLL
+          REM and its SDK runtime dependencies are not covered by any CMake install() rule.
+          if exist "%RAWBUILD%\onnxruntime_providers_qnn.dll" (
+            echo "QNN provider present - copying QNN SDK runtime DLLs and license"
+            if exist "%RAWBUILD%\libQnnHtp*.so" (
+              copy "%RAWBUILD%\libQnnHtp*.so" "%ARTIFACT%\lib" /Y
+            )
+            if exist "%RAWBUILD%\libqnnhtp*.cat" (
+              copy "%RAWBUILD%\libqnnhtp*.cat" "%ARTIFACT%\lib" /Y
+            )
+            if exist "%RAWBUILD%\QnnCpu.dll" (
+              copy "%RAWBUILD%\QnnCpu.dll" "%ARTIFACT%\lib"
+            )
+            if exist "%RAWBUILD%\QnnGpu.dll" (
+              copy "%RAWBUILD%\QnnGpu.dll" "%ARTIFACT%\lib"
+            )
+            if exist "%RAWBUILD%\QnnHtp.dll" (
+              copy "%RAWBUILD%\QnnHtp.dll" "%ARTIFACT%\lib"
+            )
+            if exist "%RAWBUILD%\QnnHtpPrepare.dll" (
+              copy "%RAWBUILD%\QnnHtpPrepare.dll" "%ARTIFACT%\lib"
+            )
+            if exist "%RAWBUILD%\QnnHtpV68Stub.dll" (
+              copy "%RAWBUILD%\QnnHtpV68Stub.dll" "%ARTIFACT%\lib"
+            )
+            if exist "%RAWBUILD%\QnnHtpV73Stub.dll" (
+              copy "%RAWBUILD%\QnnHtpV73Stub.dll" "%ARTIFACT%\lib"
+            )
+            if exist "%RAWBUILD%\QnnHtpV81Stub.dll" (
+              copy "%RAWBUILD%\QnnHtpV81Stub.dll" "%ARTIFACT%\lib"
+            )
+            if exist "%RAWBUILD%\QnnSaver.dll" (
+              copy "%RAWBUILD%\QnnSaver.dll" "%ARTIFACT%\lib"
+            )
+            if exist "%RAWBUILD%\QnnSystem.dll" (
+              copy "%RAWBUILD%\QnnSystem.dll" "%ARTIFACT%\lib"
+            )
+            if exist "%RAWBUILD%\Qualcomm_LICENSE.pdf" (
+              copy "%RAWBUILD%\Qualcomm_LICENSE.pdf" "%ARTIFACT%"
+            )
+          )
+
+          REM Copy PDB files for debugging from raw build output.
+          REM NOTE: this must run BEFORE the TRT-disabled cleanup below, otherwise the
+          REM wildcard onnxruntime_providers_*.pdb copy will re-introduce the TensorRT
+          REM pdb that the cleanup step is about to delete.
+          if exist "%RAWBUILD%\onnxruntime.pdb" (
+            copy "%RAWBUILD%\onnxruntime.pdb" "%ARTIFACT%\lib"
+          )
+
+          if exist "%RAWBUILD%\onnxruntime_providers_*.pdb" (
+            copy "%RAWBUILD%\onnxruntime_providers_*.pdb" "%ARTIFACT%\lib"
+          )
+
+          REM If TRT is disabled, remove its binaries from the artifact.
+          REM Must run AFTER the pdb copy above so the deletion is not undone.
           if /I "${{ parameters.trtEnabled }}"=="false" (
             if exist "%ARTIFACT%\lib\onnxruntime_providers_tensorrt.dll" del "%ARTIFACT%\lib\onnxruntime_providers_tensorrt.dll"
             if exist "%ARTIFACT%\lib\onnxruntime_providers_tensorrt.lib" del "%ARTIFACT%\lib\onnxruntime_providers_tensorrt.lib"
             if exist "%ARTIFACT%\lib\onnxruntime_providers_tensorrt.pdb" del "%ARTIFACT%\lib\onnxruntime_providers_tensorrt.pdb"
           )
 
-          REM Optional- QNN provider – include its license
-          if exist "%INSTALLED%\bin\onnxruntime_providers_qnn.dll" (
-            if exist "$(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\Qualcomm_LICENSE.pdf" (
-              copy "$(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\Qualcomm_LICENSE.pdf" "%ARTIFACT%"
-            )
-          )
-
-          REM Copy PDB files for debugging
-          if exist "$(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime.pdb" (
-            copy "$(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime.pdb" "%ARTIFACT%\lib"
-          )
-
-          if exist "$(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_*.pdb" (
-            copy "$(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_*.pdb" "%ARTIFACT%\lib"
-          )
-
           REM Training API headers (if built)
-          copy "$(Build.SourcesDirectory)\orttraining\orttraining\training_api\include\onnxruntime_training*.h" "%ARTIFACT%\include"
+          if exist "$(Build.SourcesDirectory)\orttraining\orttraining\training_api\include\onnxruntime_training*.h" (
+            copy "$(Build.SourcesDirectory)\orttraining\orttraining\training_api\include\onnxruntime_training*.h" "%ARTIFACT%\include"
+          )
 
           REM Docs and License -> root\
           copy "$(Build.SourcesDirectory)\README.md"             "%ARTIFACT%\README.md"
@@ -247,7 +307,114 @@ steps:
 
         workingDirectory: '$(Build.BinariesDirectory)'
 
-    # Code signing (ESRP) – only when requested
+    # Verify the final artifact contains only intended ORT public content
+    - task: PowerShell@2
+      displayName: 'Verify artifact contains only intended ORT public headers and libraries'
+      inputs:
+        targetType: 'inline'
+        script: |
+          $artifactDir = "$(Build.BinariesDirectory)\${{parameters.artifactName}}"
+          $includeDir = Join-Path $artifactDir "include"
+          $libDir     = Join-Path $artifactDir "lib"
+
+          # ---------- Include directory ----------
+          if (Test-Path $includeDir) {
+              # Allow only these top-level directories (ORT public header roots).
+              # Note: 'onnxruntime' is deliberately NOT allowed because the flatten
+              # step earlier in this template should have already removed it.
+              $allowedIncludeDirs = @('core', 'cuda', 'training')
+              $unexpectedDirs = Get-ChildItem -Path $includeDir -Directory | Where-Object {
+                  $_.Name -notin $allowedIncludeDirs
+              }
+              if ($unexpectedDirs) {
+                  Write-Host "##vso[task.logissue type=error]Unexpected directories in include/: $($unexpectedDirs.Name -join ', ')"
+                  exit 1
+              }
+
+              # Reject any loose files directly under include/ (headers should be in subdirs)
+              $looseFiles = Get-ChildItem -Path $includeDir -File
+              if ($looseFiles) {
+                  Write-Host "##vso[task.logissue type=error]Loose files found directly under include/: $($looseFiles.Name -join ', ')"
+                  exit 1
+              }
+          }
+
+          # ---------- Library directory ----------
+          if (Test-Path $libDir) {
+              # Only these file extensions are expected in lib/
+              $allowedExtensions = @('.dll', '.lib', '.pdb', '.so', '.cat')
+              $badFiles = Get-ChildItem -Path $libDir -File | Where-Object {
+                  $ext = [System.IO.Path]::GetExtension($_.Name).ToLowerInvariant()
+                  $ext -notin $allowedExtensions
+              }
+              if ($badFiles) {
+                  Write-Host "##vso[task.logissue type=error]Unexpected file types in lib/: $($badFiles.Name -join ', ')"
+                  exit 1
+              }
+
+              # Reject any static library (.lib / .a) that does not start with 'onnxruntime' (or 'libonnxruntime')
+              $badStatic = Get-ChildItem -Path $libDir -File | Where-Object {
+                  $ext = [System.IO.Path]::GetExtension($_.Name).ToLowerInvariant()
+                  ($ext -in @('.lib', '.a')) -and ($_.Name -notmatch '^(lib)?onnxruntime.*\.(lib|a)$')
+              }
+              if ($badStatic) {
+                  Write-Host "##vso[task.logissue type=error]Unexpected static libraries: $($badStatic.Name -join ', ')"
+                  exit 1
+              }
+
+              # Reject any file name that matches known third-party dependency names,
+              # even if it has an otherwise-allowed extension. ORT's own files (which
+              # all start with "onnxruntime") are explicitly excluded first so this
+              # cannot false-positive on, e.g., onnxruntime.dll.
+              # NOTE: update this list if ONNX Runtime adds new bundled third-party
+              # dependencies whose install() rules could land files in lib/.
+              $thirdPartyPatterns = @('protobuf', 'absl', 're2', 'nsync', 'gtest', 'benchmark', '^onnx\.', '^onnx_test')
+              $thirdPartyFiles = Get-ChildItem -Path $libDir -File | Where-Object {
+                  $name = $_.BaseName.ToLowerInvariant()
+                  if ($name -match '^(lib)?onnxruntime') { return $false }
+                  ($thirdPartyPatterns | Where-Object { $name -match $_ }) -ne $null
+              }
+              if ($thirdPartyFiles) {
+                  Write-Host "##vso[task.logissue type=error]Files resembling third-party libraries: $($thirdPartyFiles.Name -join ', ')"
+                  exit 1
+              }
+
+              # The only allowed subdirectory in lib/ is 'cmake'
+              $badDirs = Get-ChildItem -Path $libDir -Directory | Where-Object { $_.Name -ne 'cmake' }
+              if ($badDirs) {
+                  Write-Host "##vso[task.logissue type=error]Unexpected subdirectories in lib/: $($badDirs.Name -join ', ')"
+                  exit 1
+              }
+
+              # ---------- cmake subdirectory ----------
+              $cmakeDir = Join-Path $libDir 'cmake'
+              if (Test-Path $cmakeDir) {
+                  # Only onnxruntime*.cmake files and the onnxruntime/ subfolder are allowed
+                  $badCmakeFiles = Get-ChildItem -Path $cmakeDir -File | Where-Object {
+                      $_.Name -notmatch '^onnxruntime.*\.cmake$'
+                  }
+                  if ($badCmakeFiles) {
+                      Write-Host "##vso[task.logissue type=error]Unexpected .cmake files: $($badCmakeFiles.Name -join ', ')"
+                      exit 1
+                  }
+
+                  # If there is an onnxruntime subdir, allow it (it contains the actual CMake targets)
+                  $onnxruntimeCmakeDir = Join-Path $cmakeDir 'onnxruntime'
+                  if (Test-Path $onnxruntimeCmakeDir) {
+                      $badOnnxFiles = Get-ChildItem -Path $onnxruntimeCmakeDir -File | Where-Object {
+                          $_.Name -notmatch '^onnxruntime.*\.cmake$'
+                      }
+                      if ($badOnnxFiles) {
+                          Write-Host "##vso[task.logissue type=error]Unexpected files in cmake/onnxruntime/: $($badOnnxFiles.Name -join ', ')"
+                          exit 1
+                      }
+                  }
+              }
+          }
+
+          Write-Host "Verification passed: only ORT public headers and libraries found."
+
+    # Code signing (ESRP) - only when requested
     - ${{ if eq(parameters.DoEsrp, true) }}:
       - template: win-esrp-dll.yml
         parameters:

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-artifacts-package-and-publish-steps-windows.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-artifacts-package-and-publish-steps-windows.yml
@@ -40,11 +40,35 @@ parameters:
   default: false
 
 steps:
+
+    # Verify that the CMake build tree is present before install
+    - task: CmdLine@2
+      displayName: 'Verify CMake build tree location'
+      inputs:
+        script: |
+          if not exist "$(Build.BinariesDirectory)\${{parameters.buildConfig}}\CMakeCache.txt" (
+            echo ERROR: CMakeCache.txt not found at $(Build.BinariesDirectory)\${{parameters.buildConfig}}
+            echo This means the --install step below is pointed at the wrong directory.
+            exit /b 1
+          )
+          echo "Confirmed CMake build tree at $(Build.BinariesDirectory)\${{parameters.buildConfig}}"
+
+    # Run cmake --install to populate the "installed" tree used for packaging
+    - task: CmdLine@2
+      displayName: 'CMake install'
+      inputs:
+        script: |
+          cmake --install "$(Build.BinariesDirectory)\${{parameters.buildConfig}}" --config ${{parameters.buildConfig}} --prefix "$(Build.BinariesDirectory)\installed"
+          if errorlevel 1 (
+            echo ERROR: cmake --install failed
+            exit /b 1
+          )    
+
     # Publish symbols to Microsoft symbol server for main/rel-* branches
-    - ${{if or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/rel-'))}}:
+    - ${{ if or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/rel-'))}}:
       - template: publish-symbolrequestprod-api.yml
         parameters:
-          ${{if eq(variables['Build.SourceBranch'], 'refs/heads/main')}}:
+          ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main')}}:
             symbolExpiryTime: 60
           includePublicSymbolServer: true
           symbolsArtifactName: ${{parameters.artifactNameNoVersionString}}
@@ -158,7 +182,7 @@ steps:
           mkdir %ARTIFACT%
 
           REM Copy DLLs (runtime) and all lib/ contents (libs, cmake, pdbs) into artifact\lib
-          xcopy /E /I /Y "%INSTALLED%\bin\*.dll"     "%ARTIFACT%\lib"
+          xcopy /I /Y "%INSTALLED%\bin\*.dll"    "%ARTIFACT%\lib"
           xcopy /E /I /Y "%INSTALLED%\lib\*"     "%ARTIFACT%\lib"
           REM Copy flattened headers into artifact\include
           xcopy /E /I /Y "%INSTALLED%\include\*" "%ARTIFACT%\include"

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-artifacts-package-and-publish-steps-windows.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-artifacts-package-and-publish-steps-windows.yml
@@ -1,4 +1,8 @@
-# sets up common build tools for the windows build machines before build
+# --------------------------------------------------------------
+# Template: Package and publish Windows C-API artifacts.
+# Expects a "cmake --install" tree under $(Build.BinariesDirectory)\installed.
+# Produces a versioned .zip containing DLLs, libs, headers, CMake files, and docs.
+# --------------------------------------------------------------
 
 parameters:
 - name: DoEsrp
@@ -36,6 +40,7 @@ parameters:
   default: false
 
 steps:
+    # Publish symbols to Microsoft symbol server for main/rel-* branches
     - ${{if or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/rel-'))}}:
       - template: publish-symbolrequestprod-api.yml
         parameters:
@@ -50,227 +55,200 @@ steps:
             $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime.pdb
             $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_*.pdb
 
+    # Validate that cmake --install produced all required files
+    - task: CmdLine@2
+      displayName: 'Validate CMake install output'
+      inputs:
+        script: |
+          if not exist "$(Build.BinariesDirectory)\installed\bin\onnxruntime.dll" (
+            echo ERROR: installed\bin\onnxruntime.dll not found. Did the cmake --install step run?
+            exit /b 1
+          )
 
+          if not exist "$(Build.BinariesDirectory)\installed\lib\cmake\onnxruntime\onnxruntimeConfig.cmake" (
+            echo ERROR: onnxruntimeConfig.cmake not found in installed tree
+            exit /b 1
+          )
+
+          if not exist "$(Build.BinariesDirectory)\installed\lib\cmake\onnxruntime\onnxruntimeConfigVersion.cmake" (
+            echo ERROR: onnxruntimeConfigVersion.cmake not found in installed tree
+            exit /b 1
+          )
+
+          if not exist "$(Build.BinariesDirectory)\installed\lib\cmake\onnxruntime\onnxruntimeTargets.cmake" (
+            echo ERROR: onnxruntimeTargets.cmake not found in installed tree. install(EXPORT) may not have run.
+            exit /b 1
+          )
+
+          echo "CMake install output validated successfully"
+
+    # Flatten include/onnxruntime -> include/ and patch CMake target files to reference lib/ for .dll
+    - task: PowerShell@2
+      displayName: 'Flatten include directory and patch generated CMake Targets files'
+      inputs:
+        targetType: 'inline'
+        script: |
+          $installed = "$(Build.BinariesDirectory)\installed"
+          $nestedInclude = Join-Path $installed "include\onnxruntime"
+          $flatInclude = Join-Path $installed "include"
+
+          if (Test-Path $nestedInclude) {
+            Write-Host "Flattening $nestedInclude into $flatInclude"
+            Get-ChildItem -Path $nestedInclude | Move-Item -Destination $flatInclude -Force
+            Remove-Item -Path $nestedInclude -Recurse -Force
+          } else {
+            Write-Host "##vso[task.logissue type=warning]Expected nested include dir not found: $nestedInclude"
+          }
+
+          $cmakeDir = Join-Path $installed "lib\cmake\onnxruntime"
+          $targetFiles = Get-ChildItem -Path $cmakeDir -Filter "onnxruntimeTargets*.cmake" -ErrorAction SilentlyContinue
+
+          if (-not $targetFiles) {
+            Write-Host "##vso[task.logissue type=error]No onnxruntimeTargets*.cmake files found to patch in $cmakeDir"
+            exit 1
+          }
+
+          foreach ($file in $targetFiles) {
+              Write-Host "Patching $($file.FullName)"
+              $content = Get-Content -Path $file.FullName -Raw
+
+              # Remove nested 'include/onnxruntime' from prefix
+              $content = $content -replace '(\$\{_IMPORT_PREFIX\}/include)/onnxruntime', '$1'
+
+              # Change DLL location from bin/ to lib/
+              $content = $content -replace '\$\{_IMPORT_PREFIX\}/bin/', '${_IMPORT_PREFIX}/lib/'
+
+              Set-Content -Path $file.FullName -Value $content -NoNewline
+          }
+
+          # Verify that patches succeeded
+          $stillNested = Select-String `
+              -Path (Join-Path $cmakeDir "onnxruntimeTargets*.cmake") `
+              -Pattern 'include/onnxruntime' `
+              -ErrorAction SilentlyContinue
+
+          $stillBin = Select-String `
+              -Path (Join-Path $cmakeDir "onnxruntimeTargets*.cmake") `
+              -Pattern '\$\{_IMPORT_PREFIX\}/bin/' `
+              -ErrorAction SilentlyContinue
+
+          if ($stillNested) {
+              Write-Host "##vso[task.logissue type=error]include/onnxruntime reference still present"
+              exit 1
+          }
+
+          if ($stillBin) {
+              Write-Host "##vso[task.logissue type=error]bin DLL reference still present"
+              exit 1
+          }
+
+          Write-Host "Include directory flattened and CMake Targets files patched successfully"
+
+    # Assemble the final artifact directory by copying from the installed tree
     - task: CmdLine@2
       displayName: 'Copy build artifacts for zipping'
       inputs:
         script: |
+          set INSTALLED=$(Build.BinariesDirectory)\installed
+          set ARTIFACT=$(Build.BinariesDirectory)\${{parameters.artifactName}}
           
-          if not exist $(Build.BinariesDirectory)\${{parameters.artifactName}} (
-            mkdir $(Build.BinariesDirectory)\${{parameters.artifactName}}
+          if exist %ARTIFACT% (
+            rmdir /S /Q %ARTIFACT%
           )
-          
-          if not exist $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin (
-            mkdir $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
-          )
-          
-          if not exist $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib (
-            mkdir $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib
-          )
-          
-          if not exist $(Build.BinariesDirectory)\${{parameters.artifactName}}\include\onnxruntime (
-            mkdir $(Build.BinariesDirectory)\${{parameters.artifactName}}\include\onnxruntime
-          )
-          
-          if not exist $(Build.BinariesDirectory)\${{parameters.artifactName}}\include\onnxruntime\core (
-            mkdir $(Build.BinariesDirectory)\${{parameters.artifactName}}\include\onnxruntime\core
-          )
-          
-          if not exist $(Build.BinariesDirectory)\${{parameters.artifactName}}\include\onnxruntime\core\providers (
-            mkdir $(Build.BinariesDirectory)\${{parameters.artifactName}}\include\onnxruntime\core\providers
-          )
-         
-          if not exist $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib\cmake (
-            mkdir $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib\cmake
-          )
-          
-          if not exist $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib\cmake\onnxruntime (
-           mkdir $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib\cmake\onnxruntime
+          mkdir %ARTIFACT%
+
+          REM Copy DLLs (runtime) and all lib/ contents (libs, cmake, pdbs) into artifact\lib
+          xcopy /E /I /Y "%INSTALLED%\bin\*.dll"     "%ARTIFACT%\lib"
+          xcopy /E /I /Y "%INSTALLED%\lib\*"     "%ARTIFACT%\lib"
+          REM Copy flattened headers into artifact\include
+          xcopy /E /I /Y "%INSTALLED%\include\*" "%ARTIFACT%\include"
+
+          echo "Copied installed tree into artifact directory"
+
+          REM Remove any stray .exe files from lib (they belong elsewhere)
+          if exist "%ARTIFACT%\lib\*.exe" (
+            del /Q "%ARTIFACT%\lib\*.exe"
+            echo "Removed .exe files from lib\"
           )
 
-          if exist $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_cuda.dll (
-            echo "cuda context headers copied"
-            mkdir $(Build.BinariesDirectory)\${{parameters.artifactName}}\include\onnxruntime\core\providers\cuda
-            copy $(Build.SourcesDirectory)\include\onnxruntime\core\providers\resource.h $(Build.BinariesDirectory)\${{parameters.artifactName}}\include\onnxruntime\core\providers
-            copy $(Build.SourcesDirectory)\include\onnxruntime\core\providers\custom_op_context.h $(Build.BinariesDirectory)\${{parameters.artifactName}}\include\onnxruntime\core\providers
-            copy $(Build.SourcesDirectory)\include\onnxruntime\core\providers\cuda\cuda_context.h $(Build.BinariesDirectory)\${{parameters.artifactName}}\include\onnxruntime\core\providers\cuda
-            copy $(Build.SourcesDirectory)\include\onnxruntime\core\providers\cuda\cuda_resource.h $(Build.BinariesDirectory)\${{parameters.artifactName}}\include\onnxruntime\core\providers\cuda
-          )
-
-          echo "Directories created"
-
-          REM Core ORT DLL -> bin\,  LIB/PDB -> lib\ 
-          copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime.dll          $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
-          copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime.lib          $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib
-          copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime.pdb          $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib
-
-          REM Providers Shared DLL -> bin\,  LIB/PDB -> lib\ 
-          copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_shared.dll     $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
-          copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_shared.lib     $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib
-          copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_shared.pdb     $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib
-
-          REM CUDA EP DLL -> bin\,  LIB/PDB -> lib\ 
-          if exist $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_cuda.dll (
-            copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_cuda.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
-          )
-
-          if exist $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_cuda.lib (
-            copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_cuda.lib $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib
-          )
-
-          if exist $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_cuda.pdb (
-            copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_cuda.pdb $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib
-          )
-
-          REM WebGPU DLLs -> bin\ 
-          if exist $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\dxcompiler.dll (
-            copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\dxcompiler.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
-          )
-
-          if exist $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\dxil.dll (
-            copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\dxil.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
-          )
-
-          REM QNN DLLs -> bin\ 
-          if exist $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_qnn.dll (
-            copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_qnn.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
-            
-            if exist $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\libQnnHtp*.so (
-              copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\libQnnHtp*.so $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin /Y
+          REM Optional- CUDA provider – copy extra headers
+          if exist "%INSTALLED%\bin\onnxruntime_providers_cuda.dll" (
+            echo "CUDA provider present"
+            if not exist "%ARTIFACT%\include\core\providers\cuda" (
+              mkdir "%ARTIFACT%\include\core\providers\cuda"
             )
-
-            if exist $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\libqnnhtp*.cat (
-              copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\libqnnhtp*.cat $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin /Y
-            )
-
-            if exist $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\QnnCpu.dll (
-              copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\QnnCpu.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
-            )
-
-            if exist $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\QnnGpu.dll (
-              copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\QnnGpu.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
-            )
-
-            if exist $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\QnnHtp.dll (
-              copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\QnnHtp.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
-            )
-
-            if exist $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\QnnHtpPrepare.dll (
-              copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\QnnHtpPrepare.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
-            )
-
-            if exist $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\QnnHtpV68Stub.dll (
-              copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\QnnHtpV68Stub.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
-            )
-
-            if exist $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\QnnHtpV73Stub.dll (
-              copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\QnnHtpV73Stub.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
-            )
-
-            if exist $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\QnnHtpV81Stub.dll (
-              copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\QnnHtpV81Stub.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
-            )
-
-            if exist $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\QnnSaver.dll (
-              copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\QnnSaver.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
-            )
-
-            if exist $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\QnnSystem.dll (
-              copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\QnnSystem.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
-            )
-
-            if exist $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\Qualcomm_LICENSE.pdf (
-              copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\Qualcomm_LICENSE.pdf $(Build.BinariesDirectory)\${{parameters.artifactName}}
-            )            
+            copy "$(Build.SourcesDirectory)\include\onnxruntime\core\providers\resource.h"            "%ARTIFACT%\include\core\providers"
+            copy "$(Build.SourcesDirectory)\include\onnxruntime\core\providers\custom_op_context.h"   "%ARTIFACT%\include\core\providers"
+            copy "$(Build.SourcesDirectory)\include\onnxruntime\core\providers\cuda\cuda_context.h"   "%ARTIFACT%\include\core\providers\cuda"
+            copy "$(Build.SourcesDirectory)\include\onnxruntime\core\providers\cuda\cuda_resource.h"  "%ARTIFACT%\include\core\providers\cuda"
           )
 
+          REM If TRT is disabled, remove its binaries from the artifact
+          if /I "${{ parameters.trtEnabled }}"=="false" (
+            if exist "%ARTIFACT%\lib\onnxruntime_providers_tensorrt.dll" del "%ARTIFACT%\lib\onnxruntime_providers_tensorrt.dll"
+            if exist "%ARTIFACT%\lib\onnxruntime_providers_tensorrt.lib" del "%ARTIFACT%\lib\onnxruntime_providers_tensorrt.lib"
+            if exist "%ARTIFACT%\lib\onnxruntime_providers_tensorrt.pdb" del "%ARTIFACT%\lib\onnxruntime_providers_tensorrt.pdb"
+          )
 
-          REM TensorRT EP DLL -> bin\,  LIB/PDB -> lib\ 
-          if /I "${{ parameters.trtEnabled }}"=="true" (
-            if exist $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_tensorrt.dll (
-              copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_tensorrt.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
-            )
-
-            if exist $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_tensorrt.lib (
-              copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_tensorrt.lib $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib
-            )
-
-            if exist $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_tensorrt.pdb (
-              copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_tensorrt.pdb $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib
+          REM Optional- QNN provider – include its license
+          if exist "%INSTALLED%\bin\onnxruntime_providers_qnn.dll" (
+            if exist "$(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\Qualcomm_LICENSE.pdf" (
+              copy "$(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\Qualcomm_LICENSE.pdf" "%ARTIFACT%"
             )
           )
 
-          REM Headers (flat into include\onnxruntime) 
-          copy $(Build.SourcesDirectory)\include\onnxruntime\core\session\onnxruntime_*.h              $(Build.BinariesDirectory)\${{parameters.artifactName}}\include\onnxruntime
-          copy $(Build.SourcesDirectory)\include\onnxruntime\core\framework\provider_options.h         $(Build.BinariesDirectory)\${{parameters.artifactName}}\include\onnxruntime
-          copy $(Build.SourcesDirectory)\include\onnxruntime\core\providers\cpu\cpu_provider_factory.h $(Build.BinariesDirectory)\${{parameters.artifactName}}\include\onnxruntime
-          copy $(Build.SourcesDirectory)\orttraining\orttraining\training_api\include\onnxruntime_training*.h $(Build.BinariesDirectory)\${{parameters.artifactName}}\include\onnxruntime
-
-          REM Docs and License -> root\ 
-          copy $(Build.SourcesDirectory)\README.md             $(Build.BinariesDirectory)\${{parameters.artifactName}}\README.md
-          copy $(Build.SourcesDirectory)\docs\Privacy.md       $(Build.BinariesDirectory)\${{parameters.artifactName}}\Privacy.md
-          copy $(Build.SourcesDirectory)\LICENSE               $(Build.BinariesDirectory)\${{parameters.artifactName}}\LICENSE
-          copy $(Build.SourcesDirectory)\ThirdPartyNotices.txt $(Build.BinariesDirectory)\${{parameters.artifactName}}\ThirdPartyNotices.txt
-          copy $(Build.SourcesDirectory)\VERSION_NUMBER        $(Build.BinariesDirectory)\${{parameters.artifactName}}\VERSION_NUMBER
-
-          @echo ${{parameters.commitId}} > $(Build.BinariesDirectory)\${{parameters.artifactName}}\GIT_COMMIT_ID
-
-          REM CMake Package Files -> lib\cmake\onnxruntime\ 
-          if not exist "$(Build.BinariesDirectory)\${{parameters.buildConfig}}\onnxruntimeConfig.cmake" (
-            echo ERROR: onnxruntimeConfig.cmake not found
-            exit /b 1
+          REM Copy PDB files for debugging
+          if exist "$(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime.pdb" (
+            copy "$(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime.pdb" "%ARTIFACT%\lib"
           )
 
-          if not exist "$(Build.BinariesDirectory)\${{parameters.buildConfig}}\onnxruntimeConfigVersion.cmake" (
-            echo ERROR: onnxruntimeConfigVersion.cmake not found
-            exit /b 1
+          if exist "$(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_*.pdb" (
+            copy "$(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_*.pdb" "%ARTIFACT%\lib"
           )
 
-          copy "$(Build.BinariesDirectory)\${{parameters.buildConfig}}\onnxruntimeConfig.cmake" ^
-               "$(Build.BinariesDirectory)\${{parameters.artifactName}}\lib\cmake\onnxruntime"
+          REM Training API headers (if built)
+          copy "$(Build.SourcesDirectory)\orttraining\orttraining\training_api\include\onnxruntime_training*.h" "%ARTIFACT%\include"
 
-          copy "$(Build.BinariesDirectory)\${{parameters.buildConfig}}\onnxruntimeConfigVersion.cmake" ^
-               "$(Build.BinariesDirectory)\${{parameters.artifactName}}\lib\cmake\onnxruntime"
+          REM Docs and License -> root\
+          copy "$(Build.SourcesDirectory)\README.md"             "%ARTIFACT%\README.md"
+          copy "$(Build.SourcesDirectory)\docs\Privacy.md"       "%ARTIFACT%\Privacy.md"
+          copy "$(Build.SourcesDirectory)\LICENSE"               "%ARTIFACT%\LICENSE"
+          copy "$(Build.SourcesDirectory)\ThirdPartyNotices.txt" "%ARTIFACT%\ThirdPartyNotices.txt"
+          copy "$(Build.SourcesDirectory)\VERSION_NUMBER"        "%ARTIFACT%\VERSION_NUMBER"
 
-          for /d %%D in ("$(Build.BinariesDirectory)\${{parameters.buildConfig}}\CMakeFiles\Export\*") do (
-              if exist "%%D\onnxruntimeTargets.cmake" (
-                  copy "%%D\onnxruntimeTargets.cmake" ^
-                       "$(Build.BinariesDirectory)\${{parameters.artifactName}}\lib\cmake\onnxruntime"
-              )
-              if exist "%%D\onnxruntimeTargets-release.cmake" (
-                  copy "%%D\onnxruntimeTargets-release.cmake" ^
-                       "$(Build.BinariesDirectory)\${{parameters.artifactName}}\lib\cmake\onnxruntime"
-              )
-              if exist "%%D\onnxruntimeTargets-relwithdebinfo.cmake" (
-                  copy "%%D\onnxruntimeTargets-relwithdebinfo.cmake" ^
-                       "$(Build.BinariesDirectory)\${{parameters.artifactName}}\lib\cmake\onnxruntime"
-              )
-          )
+          REM Record the Git commit hash
+          @echo ${{parameters.commitId}} > "%ARTIFACT%\GIT_COMMIT_ID"
 
-        workingDirectory: '$(Build.BinariesDirectory)\${{parameters.buildConfig}}'
+          echo "Directories and files finalized"
 
+        workingDirectory: '$(Build.BinariesDirectory)'
+
+    # Code signing (ESRP) – only when requested
     - ${{ if eq(parameters.DoEsrp, true) }}:
       - template: win-esrp-dll.yml
         parameters:
           FolderPath: '$(Build.BinariesDirectory)\${{parameters.artifactName}}'
           DisplayName: 'ESRP - Sign Native dlls'
           DoEsrp: ${{parameters.DoEsrp}}
-          Pattern: '*.dll,*.exe'
+          Pattern: '*.dll'
 
+    # Remove temporary signing summaries
     - task: DeleteFiles@1
       displayName: 'Delete CodeSignSummary*.md'
       inputs:
         SourceFolder: '$(Build.BinariesDirectory)\${{parameters.artifactName}}'
         Contents: 'CodeSignSummary*.md'
 
+    # Create final .zip archive
     - task: ArchiveFiles@2
       inputs:
         rootFolderOrFile: '$(Build.BinariesDirectory)\${{parameters.artifactName}}'
         includeRootFolder: true
-        archiveType: 'zip' # Options: zip, 7z, tar, wim
+        archiveType: 'zip'
         archiveFile: '$(Build.ArtifactStagingDirectory)\${{parameters.artifactName}}.zip'
         replaceExistingArchive: true
 
+    # Optionally publish the staging directory itself as a pipeline artifact
     - ${{ if parameters.publishArtifactStagingDirectory }}:
       - task: 1ES.PublishPipelineArtifact@1
         inputs:

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-artifacts-package-and-publish-steps-windows.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-artifacts-package-and-publish-steps-windows.yml
@@ -203,6 +203,9 @@ steps:
             echo "Removed .exe files from lib\"
           )
 
+          REM Copying provider_options.h file into include directory
+          copy "$(Build.SourcesDirectory)\include\onnxruntime\core\framework\provider_options.h" "%ARTIFACT%\include"
+
           REM Optional- CUDA provider - copy extra headers
           if exist "%INSTALLED%\bin\onnxruntime_providers_cuda.dll" (
             echo "CUDA provider present"
@@ -319,9 +322,6 @@ steps:
 
           # ---------- Include directory ----------
           if (Test-Path $includeDir) {
-              # Allow only these top-level directories (ORT public header roots).
-              # Note: 'onnxruntime' is deliberately NOT allowed because the flatten
-              # step earlier in this template should have already removed it.
               $allowedIncludeDirs = @('core', 'cuda', 'training')
               $unexpectedDirs = Get-ChildItem -Path $includeDir -Directory | Where-Object {
                   $_.Name -notin $allowedIncludeDirs
@@ -330,13 +330,16 @@ steps:
                   Write-Host "##vso[task.logissue type=error]Unexpected directories in include/: $($unexpectedDirs.Name -join ', ')"
                   exit 1
               }
-
-              # Reject any loose files directly under include/ (headers should be in subdirs)
-              $looseFiles = Get-ChildItem -Path $includeDir -File
+              # Allow loose files directly under include/ that are ORT's own public/training headers
+              $allowedLooseHeaderPattern = '^(onnxruntime.*\.h|provider_options\.h)$'
+              $looseFiles = Get-ChildItem -Path $includeDir -File | Where-Object {
+                  $_.Name -notmatch $allowedLooseHeaderPattern
+              }
               if ($looseFiles) {
-                  Write-Host "##vso[task.logissue type=error]Loose files found directly under include/: $($looseFiles.Name -join ', ')"
+                  Write-Host "##vso[task.logissue type=error]Unexpected loose files found directly under include/: $($looseFiles.Name -join ', ')"
                   exit 1
               }
+
           }
 
           # ---------- Library directory ----------

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-artifacts-package-and-publish-steps-windows.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-artifacts-package-and-publish-steps-windows.yml
@@ -55,14 +55,38 @@ steps:
       displayName: 'Copy build artifacts for zipping'
       inputs:
         script: |
-          mkdir $(Build.BinariesDirectory)\${{parameters.artifactName}}
-          mkdir $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
-          mkdir $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib
-          mkdir $(Build.BinariesDirectory)\${{parameters.artifactName}}\include\onnxruntime
-          mkdir $(Build.BinariesDirectory)\${{parameters.artifactName}}\include\onnxruntime\core
-          mkdir $(Build.BinariesDirectory)\${{parameters.artifactName}}\include\onnxruntime\core\providers
-          mkdir $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib\cmake
-          mkdir $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib\cmake\onnxruntime
+          
+          if not exist $(Build.BinariesDirectory)\${{parameters.artifactName}} (
+            mkdir $(Build.BinariesDirectory)\${{parameters.artifactName}}
+          )
+          
+          if not exist $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin (
+            mkdir $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
+          )
+          
+          if not exist $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib (
+            mkdir $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib
+          )
+          
+          if not exist $(Build.BinariesDirectory)\${{parameters.artifactName}}\include\onnxruntime (
+            mkdir $(Build.BinariesDirectory)\${{parameters.artifactName}}\include\onnxruntime
+          )
+          
+          if not exist $(Build.BinariesDirectory)\${{parameters.artifactName}}\include\onnxruntime\core (
+            mkdir $(Build.BinariesDirectory)\${{parameters.artifactName}}\include\onnxruntime\core
+          )
+          
+          if not exist $(Build.BinariesDirectory)\${{parameters.artifactName}}\include\onnxruntime\core\providers (
+            mkdir $(Build.BinariesDirectory)\${{parameters.artifactName}}\include\onnxruntime\core\providers
+          )
+         
+          if not exist $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib\cmake (
+            mkdir $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib\cmake
+          )
+          
+          if not exist $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib\cmake\onnxruntime (
+           mkdir $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib\cmake\onnxruntime
+          )
 
           if exist $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_cuda.dll (
             echo "cuda context headers copied"
@@ -75,22 +99,17 @@ steps:
 
           echo "Directories created"
 
-          # Core ORT DLL → bin\,  LIB/PDB → lib\ 
+          REM Core ORT DLL -> bin\,  LIB/PDB -> lib\ 
           copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime.dll          $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
           copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime.lib          $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib
           copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime.pdb          $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib
 
-          # Providers Shared DLL → bin\,  LIB/PDB → lib\ 
+          REM Providers Shared DLL -> bin\,  LIB/PDB -> lib\ 
           copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_shared.dll     $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
           copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_shared.lib     $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib
           copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_shared.pdb     $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib
 
-          # onnx_test_runner.exe → bin\ 
-          if exist $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnx_test_runner.exe (
-            copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnx_test_runner.exe     $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
-          )
-
-         # CUDA EP DLL → bin\,  LIB/PDB → lib\ 
+          REM CUDA EP DLL -> bin\,  LIB/PDB -> lib\ 
           if exist $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_cuda.dll (
             copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_cuda.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
           )
@@ -103,7 +122,7 @@ steps:
             copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_cuda.pdb $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib
           )
 
-          # WebGPU DLLs → bin\ 
+          REM WebGPU DLLs -> bin\ 
           if exist $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\dxcompiler.dll (
             copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\dxcompiler.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
           )
@@ -112,7 +131,7 @@ steps:
             copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\dxil.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
           )
 
-          # QNN DLLs → bin\ 
+          REM QNN DLLs -> bin\ 
           if exist $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_qnn.dll (
             copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_qnn.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
             
@@ -166,7 +185,7 @@ steps:
           )
 
 
-         # TensorRT EP DLL → bin\,  LIB/PDB → lib\ 
+          REM TensorRT EP DLL -> bin\,  LIB/PDB -> lib\ 
           if /I "${{ parameters.trtEnabled }}"=="true" (
             if exist $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_tensorrt.dll (
               copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_tensorrt.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
@@ -181,13 +200,13 @@ steps:
             )
           )
 
-          # Headers (flat into include\) 
+          REM Headers (flat into include\onnxruntime) 
           copy $(Build.SourcesDirectory)\include\onnxruntime\core\session\onnxruntime_*.h              $(Build.BinariesDirectory)\${{parameters.artifactName}}\include\onnxruntime
           copy $(Build.SourcesDirectory)\include\onnxruntime\core\framework\provider_options.h         $(Build.BinariesDirectory)\${{parameters.artifactName}}\include\onnxruntime
           copy $(Build.SourcesDirectory)\include\onnxruntime\core\providers\cpu\cpu_provider_factory.h $(Build.BinariesDirectory)\${{parameters.artifactName}}\include\onnxruntime
           copy $(Build.SourcesDirectory)\orttraining\orttraining\training_api\include\onnxruntime_training*.h $(Build.BinariesDirectory)\${{parameters.artifactName}}\include\onnxruntime
 
-          # Docs and License → root\ 
+          REM Docs and License -> root\ 
           copy $(Build.SourcesDirectory)\README.md             $(Build.BinariesDirectory)\${{parameters.artifactName}}\README.md
           copy $(Build.SourcesDirectory)\docs\Privacy.md       $(Build.BinariesDirectory)\${{parameters.artifactName}}\Privacy.md
           copy $(Build.SourcesDirectory)\LICENSE               $(Build.BinariesDirectory)\${{parameters.artifactName}}\LICENSE
@@ -196,12 +215,24 @@ steps:
 
           @echo ${{parameters.commitId}} > $(Build.BinariesDirectory)\${{parameters.artifactName}}\GIT_COMMIT_ID
 
-          # CMake Package Files → lib\cmake\onnxruntime\ 
-          copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\onnxruntimeConfig.cmake $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib\cmake\onnxruntime
+          REM CMake Package Files -> lib\cmake\onnxruntime\ 
+          if not exist "$(Build.BinariesDirectory)\${{parameters.buildConfig}}\onnxruntimeConfig.cmake" (
+            echo ERROR: onnxruntimeConfig.cmake not found
+            exit /b 1
+          )
 
-          copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\onnxruntimeConfigVersion.cmake $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib\cmake\onnxruntime
+          if not exist "$(Build.BinariesDirectory)\${{parameters.buildConfig}}\onnxruntimeConfigVersion.cmake" (
+            echo ERROR: onnxruntimeConfigVersion.cmake not found
+            exit /b 1
+          )
 
-          for /d %%D in ($(Build.BinariesDirectory)\${{parameters.buildConfig}}\CMakeFiles\Export\*) do (
+          copy "$(Build.BinariesDirectory)\${{parameters.buildConfig}}\onnxruntimeConfig.cmake" ^
+               "$(Build.BinariesDirectory)\${{parameters.artifactName}}\lib\cmake\onnxruntime"
+
+          copy "$(Build.BinariesDirectory)\${{parameters.buildConfig}}\onnxruntimeConfigVersion.cmake" ^
+               "$(Build.BinariesDirectory)\${{parameters.artifactName}}\lib\cmake\onnxruntime"
+
+          for /d %%D in ("$(Build.BinariesDirectory)\${{parameters.buildConfig}}\CMakeFiles\Export\*") do (
               if exist "%%D\onnxruntimeTargets.cmake" (
                   copy "%%D\onnxruntimeTargets.cmake" ^
                        "$(Build.BinariesDirectory)\${{parameters.artifactName}}\lib\cmake\onnxruntime"

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-artifacts-package-and-publish-steps-windows.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-artifacts-package-and-publish-steps-windows.yml
@@ -75,20 +75,22 @@ steps:
 
           echo "Directories created"
 
-          REM ── Core ORT DLL → bin\,  LIB/PDB → lib\ ─────────────────────
+          # Core ORT DLL → bin\,  LIB/PDB → lib\ 
           copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime.dll          $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
           copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime.lib          $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib
           copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime.pdb          $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib
 
-          REM ── Providers Shared DLL → bin\,  LIB/PDB → lib\ ─────────────
+          # Providers Shared DLL → bin\,  LIB/PDB → lib\ 
           copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_shared.dll     $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
           copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_shared.lib     $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib
           copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_shared.pdb     $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib
 
-          REM ── onnx_test_runner.exe → bin\ ────────────────────────────────
-          copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnx_test_runner.exe     $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
+          # onnx_test_runner.exe → bin\ 
+          if exist $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnx_test_runner.exe (
+            copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnx_test_runner.exe     $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
+          )
 
-          REM ── CUDA EP DLL → bin\,  LIB/PDB → lib\ ──────────────────────
+         # CUDA EP DLL → bin\,  LIB/PDB → lib\ 
           if exist $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_cuda.dll (
             copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_cuda.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
           )
@@ -101,7 +103,7 @@ steps:
             copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_cuda.pdb $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib
           )
 
-          REM ── WebGPU DLLs → bin\ ─────────────────────────────────────────
+          # WebGPU DLLs → bin\ 
           if exist $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\dxcompiler.dll (
             copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\dxcompiler.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
           )
@@ -110,25 +112,61 @@ steps:
             copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\dxil.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
           )
 
-          REM ── QNN DLLs → bin\ ────────────────────────────────────────────
+          # QNN DLLs → bin\ 
           if exist $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_qnn.dll (
             copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_qnn.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
-            copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\libQnnHtp*.so $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin /Y
-            copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\libqnnhtp*.cat $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin /Y
-            copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\QnnCpu.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
-            copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\QnnGpu.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
-            copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\QnnHtp.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
-            copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\QnnHtpPrepare.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
-            copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\QnnHtpV68Stub.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
-            copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\QnnHtpV73Stub.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
-            copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\QnnHtpV81Stub.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
-            copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\QnnSaver.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
-            copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\QnnSystem.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
-            copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\Qualcomm_LICENSE.pdf $(Build.BinariesDirectory)\${{parameters.artifactName}}
+            
+            if exist $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\libQnnHtp*.so (
+              copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\libQnnHtp*.so $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin /Y
+            )
+
+            if exist $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\libqnnhtp*.cat (
+              copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\libqnnhtp*.cat $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin /Y
+            )
+
+            if exist $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\QnnCpu.dll (
+              copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\QnnCpu.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
+            )
+
+            if exist $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\QnnGpu.dll (
+              copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\QnnGpu.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
+            )
+
+            if exist $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\QnnHtp.dll (
+              copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\QnnHtp.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
+            )
+
+            if exist $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\QnnHtpPrepare.dll (
+              copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\QnnHtpPrepare.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
+            )
+
+            if exist $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\QnnHtpV68Stub.dll (
+              copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\QnnHtpV68Stub.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
+            )
+
+            if exist $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\QnnHtpV73Stub.dll (
+              copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\QnnHtpV73Stub.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
+            )
+
+            if exist $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\QnnHtpV81Stub.dll (
+              copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\QnnHtpV81Stub.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
+            )
+
+            if exist $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\QnnSaver.dll (
+              copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\QnnSaver.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
+            )
+
+            if exist $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\QnnSystem.dll (
+              copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\QnnSystem.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
+            )
+
+            if exist $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\Qualcomm_LICENSE.pdf (
+              copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\Qualcomm_LICENSE.pdf $(Build.BinariesDirectory)\${{parameters.artifactName}}
+            )            
           )
 
 
-          REM ── TensorRT EP DLL → bin\,  LIB/PDB → lib\ ──────────────────
+         # TensorRT EP DLL → bin\,  LIB/PDB → lib\ 
           if /I "${{ parameters.trtEnabled }}"=="true" (
             if exist $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_tensorrt.dll (
               copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_tensorrt.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
@@ -143,21 +181,22 @@ steps:
             )
           )
 
-          REM ── Headers (flat into include\) ───────────────────────────────
+          # Headers (flat into include\) 
           copy $(Build.SourcesDirectory)\include\onnxruntime\core\session\onnxruntime_*.h              $(Build.BinariesDirectory)\${{parameters.artifactName}}\include\onnxruntime
           copy $(Build.SourcesDirectory)\include\onnxruntime\core\framework\provider_options.h         $(Build.BinariesDirectory)\${{parameters.artifactName}}\include\onnxruntime
           copy $(Build.SourcesDirectory)\include\onnxruntime\core\providers\cpu\cpu_provider_factory.h $(Build.BinariesDirectory)\${{parameters.artifactName}}\include\onnxruntime
           copy $(Build.SourcesDirectory)\orttraining\orttraining\training_api\include\onnxruntime_training*.h $(Build.BinariesDirectory)\${{parameters.artifactName}}\include\onnxruntime
 
-          REM ── Docs and License → root\ ───────────────────────────────────
+          # Docs and License → root\ 
           copy $(Build.SourcesDirectory)\README.md             $(Build.BinariesDirectory)\${{parameters.artifactName}}\README.md
           copy $(Build.SourcesDirectory)\docs\Privacy.md       $(Build.BinariesDirectory)\${{parameters.artifactName}}\Privacy.md
           copy $(Build.SourcesDirectory)\LICENSE               $(Build.BinariesDirectory)\${{parameters.artifactName}}\LICENSE
           copy $(Build.SourcesDirectory)\ThirdPartyNotices.txt $(Build.BinariesDirectory)\${{parameters.artifactName}}\ThirdPartyNotices.txt
           copy $(Build.SourcesDirectory)\VERSION_NUMBER        $(Build.BinariesDirectory)\${{parameters.artifactName}}\VERSION_NUMBER
+
           @echo ${{parameters.commitId}} > $(Build.BinariesDirectory)\${{parameters.artifactName}}\GIT_COMMIT_ID
 
-          REM ── CMake Package Files → lib\cmake\onnxruntime\ ──────────────
+          # CMake Package Files → lib\cmake\onnxruntime\ 
           copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\onnxruntimeConfig.cmake $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib\cmake\onnxruntime
 
           copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\onnxruntimeConfigVersion.cmake $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib\cmake\onnxruntime

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-artifacts-package-and-publish-steps-windows.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-artifacts-package-and-publish-steps-windows.yml
@@ -56,65 +56,126 @@ steps:
       inputs:
         script: |
           mkdir $(Build.BinariesDirectory)\${{parameters.artifactName}}
+          mkdir $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
           mkdir $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib
-          mkdir $(Build.BinariesDirectory)\${{parameters.artifactName}}\include
+          mkdir $(Build.BinariesDirectory)\${{parameters.artifactName}}\include\onnxruntime
+          mkdir $(Build.BinariesDirectory)\${{parameters.artifactName}}\include\onnxruntime\core
+          mkdir $(Build.BinariesDirectory)\${{parameters.artifactName}}\include\onnxruntime\core\providers
+          mkdir $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib\cmake
+          mkdir $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib\cmake\onnxruntime
 
           if exist $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_cuda.dll (
             echo "cuda context headers copied"
-            mkdir $(Build.BinariesDirectory)\${{parameters.artifactName}}\include\core\providers\cuda
-            copy $(Build.SourcesDirectory)\include\onnxruntime\core\providers\resource.h $(Build.BinariesDirectory)\${{parameters.artifactName}}\include\core\providers
-            copy $(Build.SourcesDirectory)\include\onnxruntime\core\providers\custom_op_context.h $(Build.BinariesDirectory)\${{parameters.artifactName}}\include\core\providers
-            copy $(Build.SourcesDirectory)\include\onnxruntime\core\providers\cuda\cuda_context.h $(Build.BinariesDirectory)\${{parameters.artifactName}}\include\core\providers\cuda
-            copy $(Build.SourcesDirectory)\include\onnxruntime\core\providers\cuda\cuda_resource.h $(Build.BinariesDirectory)\${{parameters.artifactName}}\include\core\providers\cuda
+            mkdir $(Build.BinariesDirectory)\${{parameters.artifactName}}\include\onnxruntime\core\providers\cuda
+            copy $(Build.SourcesDirectory)\include\onnxruntime\core\providers\resource.h $(Build.BinariesDirectory)\${{parameters.artifactName}}\include\onnxruntime\core\providers
+            copy $(Build.SourcesDirectory)\include\onnxruntime\core\providers\custom_op_context.h $(Build.BinariesDirectory)\${{parameters.artifactName}}\include\onnxruntime\core\providers
+            copy $(Build.SourcesDirectory)\include\onnxruntime\core\providers\cuda\cuda_context.h $(Build.BinariesDirectory)\${{parameters.artifactName}}\include\onnxruntime\core\providers\cuda
+            copy $(Build.SourcesDirectory)\include\onnxruntime\core\providers\cuda\cuda_resource.h $(Build.BinariesDirectory)\${{parameters.artifactName}}\include\onnxruntime\core\providers\cuda
           )
 
           echo "Directories created"
-          copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib
-          copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_shared.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib
-          copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_shared.lib $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib
-          copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_shared.pdb $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib
-          copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_cuda.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib
-          copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_cuda.pdb $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib
-          copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_cuda.lib $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib
 
-          # Copy WebGPU dependencies if required
-          copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\dxcompiler.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib
-          copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\dxil.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib
+          REM ── Core ORT DLL → bin\,  LIB/PDB → lib\ ─────────────────────
+          copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime.dll          $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
+          copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime.lib          $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib
+          copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime.pdb          $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib
 
-          # Copy QNN dependencies if required
-          copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_qnn.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib
-          copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\libQnnHtp*.so $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib /Y
-          copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\libqnnhtp*.cat $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib /Y
-          copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\QnnCpu.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib
-          copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\QnnGpu.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib
-          copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\QnnHtp.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib
-          copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\QnnHtpPrepare.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib
-          copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\QnnHtpV68Stub.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib
-          copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\QnnHtpV73Stub.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib
-          copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\QnnHtpV81Stub.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib
-          copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\QnnSaver.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib
-          copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\QnnSystem.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib
-          copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\Qualcomm_LICENSE.pdf $(Build.BinariesDirectory)\${{parameters.artifactName}}
+          REM ── Providers Shared DLL → bin\,  LIB/PDB → lib\ ─────────────
+          copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_shared.dll     $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
+          copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_shared.lib     $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib
+          copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_shared.pdb     $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib
 
-          # copy trt ep libraries only when trt ep is enabled
-          copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_tensorrt.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib
-          copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_tensorrt.pdb $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib
-          copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_tensorrt.lib $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib
+          REM ── onnx_test_runner.exe → bin\ ────────────────────────────────
+          copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnx_test_runner.exe     $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
 
-          copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime.pdb $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib
-          copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime.lib $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib
-          copy $(Build.SourcesDirectory)\include\onnxruntime\core\session\onnxruntime_*.h  $(Build.BinariesDirectory)\${{parameters.artifactName}}\include
-          copy $(Build.SourcesDirectory)\include\onnxruntime\core\framework\provider_options.h  $(Build.BinariesDirectory)\${{parameters.artifactName}}\include
-          copy $(Build.SourcesDirectory)\include\onnxruntime\core\providers\cpu\cpu_provider_factory.h  $(Build.BinariesDirectory)\${{parameters.artifactName}}\include
-          copy $(Build.SourcesDirectory)\orttraining\orttraining\training_api\include\onnxruntime_training*.h  $(Build.BinariesDirectory)\${{parameters.artifactName}}\include
+          REM ── CUDA EP DLL → bin\,  LIB/PDB → lib\ ──────────────────────
+          if exist $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_cuda.dll (
+            copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_cuda.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
+          )
 
-          REM copy the README, license and TPN
-          copy $(Build.SourcesDirectory)\README.md $(Build.BinariesDirectory)\${{parameters.artifactName}}\README.md
-          copy $(Build.SourcesDirectory)\docs\Privacy.md $(Build.BinariesDirectory)\${{parameters.artifactName}}\Privacy.md
-          copy $(Build.SourcesDirectory)\LICENSE $(Build.BinariesDirectory)\${{parameters.artifactName}}\LICENSE
+          if exist $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_cuda.lib (
+            copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_cuda.lib $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib
+          )
+
+          if exist $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_cuda.pdb (
+            copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_cuda.pdb $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib
+          )
+
+          REM ── WebGPU DLLs → bin\ ─────────────────────────────────────────
+          if exist $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\dxcompiler.dll (
+            copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\dxcompiler.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
+          )
+
+          if exist $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\dxil.dll (
+            copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\dxil.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
+          )
+
+          REM ── QNN DLLs → bin\ ────────────────────────────────────────────
+          if exist $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_qnn.dll (
+            copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_qnn.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
+            copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\libQnnHtp*.so $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin /Y
+            copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\libqnnhtp*.cat $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin /Y
+            copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\QnnCpu.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
+            copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\QnnGpu.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
+            copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\QnnHtp.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
+            copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\QnnHtpPrepare.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
+            copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\QnnHtpV68Stub.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
+            copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\QnnHtpV73Stub.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
+            copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\QnnHtpV81Stub.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
+            copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\QnnSaver.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
+            copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\QnnSystem.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
+            copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\Qualcomm_LICENSE.pdf $(Build.BinariesDirectory)\${{parameters.artifactName}}
+          )
+
+
+          REM ── TensorRT EP DLL → bin\,  LIB/PDB → lib\ ──────────────────
+          if /I "${{ parameters.trtEnabled }}"=="true" (
+            if exist $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_tensorrt.dll (
+              copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_tensorrt.dll $(Build.BinariesDirectory)\${{parameters.artifactName}}\bin
+            )
+
+            if exist $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_tensorrt.lib (
+              copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_tensorrt.lib $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib
+            )
+
+            if exist $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_tensorrt.pdb (
+              copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\${{parameters.buildConfig}}\onnxruntime_providers_tensorrt.pdb $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib
+            )
+          )
+
+          REM ── Headers (flat into include\) ───────────────────────────────
+          copy $(Build.SourcesDirectory)\include\onnxruntime\core\session\onnxruntime_*.h              $(Build.BinariesDirectory)\${{parameters.artifactName}}\include\onnxruntime
+          copy $(Build.SourcesDirectory)\include\onnxruntime\core\framework\provider_options.h         $(Build.BinariesDirectory)\${{parameters.artifactName}}\include\onnxruntime
+          copy $(Build.SourcesDirectory)\include\onnxruntime\core\providers\cpu\cpu_provider_factory.h $(Build.BinariesDirectory)\${{parameters.artifactName}}\include\onnxruntime
+          copy $(Build.SourcesDirectory)\orttraining\orttraining\training_api\include\onnxruntime_training*.h $(Build.BinariesDirectory)\${{parameters.artifactName}}\include\onnxruntime
+
+          REM ── Docs and License → root\ ───────────────────────────────────
+          copy $(Build.SourcesDirectory)\README.md             $(Build.BinariesDirectory)\${{parameters.artifactName}}\README.md
+          copy $(Build.SourcesDirectory)\docs\Privacy.md       $(Build.BinariesDirectory)\${{parameters.artifactName}}\Privacy.md
+          copy $(Build.SourcesDirectory)\LICENSE               $(Build.BinariesDirectory)\${{parameters.artifactName}}\LICENSE
           copy $(Build.SourcesDirectory)\ThirdPartyNotices.txt $(Build.BinariesDirectory)\${{parameters.artifactName}}\ThirdPartyNotices.txt
-          copy $(Build.SourcesDirectory)\VERSION_NUMBER $(Build.BinariesDirectory)\${{parameters.artifactName}}\VERSION_NUMBER
+          copy $(Build.SourcesDirectory)\VERSION_NUMBER        $(Build.BinariesDirectory)\${{parameters.artifactName}}\VERSION_NUMBER
           @echo ${{parameters.commitId}} > $(Build.BinariesDirectory)\${{parameters.artifactName}}\GIT_COMMIT_ID
+
+          REM ── CMake Package Files → lib\cmake\onnxruntime\ ──────────────
+          copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\onnxruntimeConfig.cmake $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib\cmake\onnxruntime
+
+          copy $(Build.BinariesDirectory)\${{parameters.buildConfig}}\onnxruntimeConfigVersion.cmake $(Build.BinariesDirectory)\${{parameters.artifactName}}\lib\cmake\onnxruntime
+
+          for /d %%D in ($(Build.BinariesDirectory)\${{parameters.buildConfig}}\CMakeFiles\Export\*) do (
+              if exist "%%D\onnxruntimeTargets.cmake" (
+                  copy "%%D\onnxruntimeTargets.cmake" ^
+                       "$(Build.BinariesDirectory)\${{parameters.artifactName}}\lib\cmake\onnxruntime"
+              )
+              if exist "%%D\onnxruntimeTargets-release.cmake" (
+                  copy "%%D\onnxruntimeTargets-release.cmake" ^
+                       "$(Build.BinariesDirectory)\${{parameters.artifactName}}\lib\cmake\onnxruntime"
+              )
+              if exist "%%D\onnxruntimeTargets-relwithdebinfo.cmake" (
+                  copy "%%D\onnxruntimeTargets-relwithdebinfo.cmake" ^
+                       "$(Build.BinariesDirectory)\${{parameters.artifactName}}\lib\cmake\onnxruntime"
+              )
+          )
 
         workingDirectory: '$(Build.BinariesDirectory)\${{parameters.buildConfig}}'
 

--- a/tools/ci_build/github/azure-pipelines/templates/win-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-ci.yml
@@ -1,3 +1,9 @@
+# --------------------------------------------------------------
+# Main Windows CI stage: builds ONNX Runtime, runs tests,
+# performs CMake install, and packages C-API (and optionally Java/Node.js) artifacts.
+# Triggered as part of the overall CI pipeline.
+# --------------------------------------------------------------
+
 parameters:
 - name: DoCompliance
   displayName: Run Compliance Tasks?
@@ -120,15 +126,17 @@ stages:
           enabled: true
           scanOutputDirectoryOnly: true
       outputs:
+      # Main C-API artifact (the .zip)
       - output: pipelineArtifact
         targetPath: $(Build.ArtifactStagingDirectory)
         artifactName: 'onnxruntime${{ parameters.artifact_name_suffix }}-win-${{ parameters.packageName }}'
 
+      # Java binaries (if built)
       - ${{ if eq(parameters.buildJava, 'true') }}:
         - output: pipelineArtifact
           targetPath: $(Build.BinariesDirectory)\onnxruntime-java-win-${{ parameters.msbuildPlatform }}
           artifactName: 'drop-onnxruntime-java-win-${{ parameters.packageName }}${{parameters.artifact_name_suffix}}'
-      # GPU build has two jobs. This is the first one.
+      # GPU build stages test artifacts for later GPU testing
       - ${{ if contains(parameters.ort_build_pool_name, 'GPU') }}:
           - output: pipelineArtifact
             targetPath: $(Agent.TempDirectory)/RelWithDebInfo
@@ -148,14 +156,17 @@ stages:
       timeoutInMinutes: 360
 
     steps:
+      # 1. Source checkout
       - checkout: self
         clean: true
         submodules: none
 
+      # 2. Install build tools (VS, CMake, etc.)
       - template: setup-build-tools.yml
         parameters:
           host_cpu_arch: 'x64'
 
+      # 3. Optional: Java JDK
       - ${{ if eq(parameters['buildJava'], 'true') }}:
         - task: JavaToolInstaller@0
           inputs:
@@ -163,6 +174,7 @@ stages:
             jdkArchitectureOption: ${{ parameters.buildArch }}
             jdkSourceOption: 'PreInstalled'
 
+      # 4. Optional: Download GPU libraries (CUDA, TRT)
       - ${{ if ne(parameters.CudaVersion, '') }}:
         - template: jobs/download_win_gpu_library.yml
           parameters:
@@ -173,10 +185,13 @@ stages:
               DownloadCUDA: true
               DownloadTRT: true
 
+      # 5. Set version variables (e.g., OnnxRuntimeVersion, commit hash)
       - template: set-version-number-variables-step.yml
 
+      # 6. Install Python dependencies for build scripts
       - script: python -m pip install -r $(Build.SourcesDirectory)\tools\ci_build\github\windows\python\requirements.txt
 
+      # 7. Assemble common build arguments
       - template: set-variable.yml
         parameters:
           name: commonBuildPyArgs
@@ -198,6 +213,7 @@ stages:
             $(timeoutParameter)
             $(buildJavaParameter)
 
+      # 8. Build (special handling for arm64x, otherwise generic)
       - ${{ if eq(parameters.msbuildPlatform, 'arm64x') }}:
         - template: build-win-arm64x-steps.yml
           parameters:
@@ -212,7 +228,7 @@ stages:
             arguments: '$(commonBuildPyArgs) --build_dir $(Build.BinariesDirectory)'
             workingDirectory: '$(Build.BinariesDirectory)'
 
-      # For CPU job, tests are run in the same machine as building
+      # 9. Java build (if enabled)
       - ${{ if eq(parameters.buildJava, 'true') }}:
         - template: setup-maven.yml
         - template: make_java_win_binaries.yml
@@ -223,7 +239,7 @@ stages:
             PreReleaseVersionSuffixNumber: ${{ parameters.PreReleaseVersionSuffixNumber }}
             buildOnly: true
 
-        # All GPU builds will be tested in the next stage with GPU machine
+      # 10. Run tests (on CPU) or stage test binaries for later GPU runs
       - ${{ if contains(parameters.ort_build_pool_name, 'CPU') }}:
         - task: PythonScript@0
           displayName: 'test'
@@ -233,6 +249,7 @@ stages:
             arguments: '--config RelWithDebInfo --use_binskim_compliant_compile_flags --enable_lto --disable_rtti --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --build_shared_lib --test --cmake_generator "$(VSGenerator)" --enable_onnx_tests  $(TelemetryOption) ${{ parameters.buildparameter }}'
             workingDirectory: '$(Build.BinariesDirectory)'
       - ${{ else }}:
+        # For GPU builds, copy necessary test files to a temporary location for later execution
         - powershell: |
             New-Item $(Agent.TempDirectory)/RelWithDebInfo -Force -ItemType Directory
             Copy-Item -Path "$(Build.BinariesDirectory)/RelWithDebInfo/CTestTestfile.cmake" -Destination $(Agent.TempDirectory)/RelWithDebInfo/ -Force
@@ -254,12 +271,37 @@ stages:
             displayName: 'Copy java pad and folder for java test'
             workingDirectory: '$(Build.BinariesDirectory)'
 
+      # 11. List built DLLs for debugging
       - script: |
           dir *.dll
           mkdir $(Build.ArtifactStagingDirectory)\testdata
         workingDirectory: '$(Build.BinariesDirectory)/RelWithDebInfo/RelWithDebInfo'
         displayName: 'List built DLLs'
 
+      # Verify that the CMake build tree is present before install
+      - task: CmdLine@2
+        displayName: 'Verify CMake build tree location'
+        inputs:
+          script: |
+            if not exist "$(Build.BinariesDirectory)\RelWithDebInfo\CMakeCache.txt" (
+              echo ERROR: CMakeCache.txt not found at $(Build.BinariesDirectory)\RelWithDebInfo
+              echo This means the --install step below is pointed at the wrong directory.
+              exit /b 1
+            )
+            echo "Confirmed CMake build tree at $(Build.BinariesDirectory)\RelWithDebInfo"
+
+      # Run cmake --install to populate the "installed" tree used for packaging
+      - task: CmdLine@2
+        displayName: 'CMake install'
+        inputs:
+          script: |
+            cmake --install "$(Build.BinariesDirectory)\RelWithDebInfo" --config RelWithDebInfo --prefix "$(Build.BinariesDirectory)\installed"
+            if errorlevel 1 (
+              echo ERROR: cmake --install failed
+              exit /b 1
+            )
+
+      # 12. Package the C-API artifact using the dedicated template
       - template: c-api-artifacts-package-and-publish-steps-windows.yml
         parameters:
           buildConfig: RelWithDebInfo
@@ -268,6 +310,7 @@ stages:
           commitId: $(OnnxRuntimeGitCommitHash)
           DoEsrp: ${{ parameters.DoEsrp }}
 
+      # 13. Optional: Node.js bindings packaging
       - ${{ if eq(parameters.buildNodejs, true) }}:
         - template: nodejs-artifacts-package-and-publish-steps-windows.yml
           parameters:
@@ -275,6 +318,7 @@ stages:
             artifactName: 'drop-onnxruntime-nodejs-win-${{ parameters.packageName }}${{ parameters.artifact_name_suffix }}'
             DoEsrp: ${{ parameters.DoEsrp }}
 
+      # 14. Copy custom operator library (for testing) if x64
       - task: CopyFiles@2
         displayName: 'Copy custom_op_library to: $(Build.ArtifactStagingDirectory)'
         condition: and(succeeded(), eq('${{ parameters.packageName}}', 'x64'))

--- a/tools/ci_build/github/azure-pipelines/templates/win-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/win-ci.yml
@@ -278,29 +278,6 @@ stages:
         workingDirectory: '$(Build.BinariesDirectory)/RelWithDebInfo/RelWithDebInfo'
         displayName: 'List built DLLs'
 
-      # Verify that the CMake build tree is present before install
-      - task: CmdLine@2
-        displayName: 'Verify CMake build tree location'
-        inputs:
-          script: |
-            if not exist "$(Build.BinariesDirectory)\RelWithDebInfo\CMakeCache.txt" (
-              echo ERROR: CMakeCache.txt not found at $(Build.BinariesDirectory)\RelWithDebInfo
-              echo This means the --install step below is pointed at the wrong directory.
-              exit /b 1
-            )
-            echo "Confirmed CMake build tree at $(Build.BinariesDirectory)\RelWithDebInfo"
-
-      # Run cmake --install to populate the "installed" tree used for packaging
-      - task: CmdLine@2
-        displayName: 'CMake install'
-        inputs:
-          script: |
-            cmake --install "$(Build.BinariesDirectory)\RelWithDebInfo" --config RelWithDebInfo --prefix "$(Build.BinariesDirectory)\installed"
-            if errorlevel 1 (
-              echo ERROR: cmake --install failed
-              exit /b 1
-            )
-
       # 12. Package the C-API artifact using the dedicated template
       - template: c-api-artifacts-package-and-publish-steps-windows.yml
         parameters:

--- a/tools/ci_build/github/windows/bundle_dlls_gpu.bat
+++ b/tools/ci_build/github/windows/bundle_dlls_gpu.bat
@@ -7,16 +7,15 @@ FOR /R %%i IN (*.zip) do (
    set filename=%%~ni
    IF "!filename:~20,3!"=="gpu" (
        mkdir !filename!\lib
-       mkdir !filename!\bin 
-       move onnxruntime-win-x64-tensorrt\bin\onnxruntime_providers_tensorrt.dll !filename!\bin\onnxruntime_providers_tensorrt.dll
+       move onnxruntime-win-x64-tensorrt\lib\onnxruntime_providers_tensorrt.dll !filename!\lib\onnxruntime_providers_tensorrt.dll
        move onnxruntime-win-x64-tensorrt\lib\onnxruntime_providers_tensorrt.lib !filename!\lib\onnxruntime_providers_tensorrt.lib
        move onnxruntime-win-x64-tensorrt\lib\onnxruntime_providers_tensorrt.pdb !filename!\lib\onnxruntime_providers_tensorrt.pdb
-       move onnxruntime-win-x64-tensorrt\bin\onnxruntime_providers_shared.dll !filename!\bin\onnxruntime_providers_shared.dll
+       move onnxruntime-win-x64-tensorrt\lib\onnxruntime_providers_shared.dll !filename!\lib\onnxruntime_providers_shared.dll
        move onnxruntime-win-x64-tensorrt\lib\onnxruntime_providers_shared.lib !filename!\lib\onnxruntime_providers_shared.lib
        move onnxruntime-win-x64-tensorrt\lib\onnxruntime_providers_shared.pdb !filename!\lib\onnxruntime_providers_shared.pdb
-       move onnxruntime-win-x64-tensorrt\bin\onnxruntime.dll !filename!\bin\onnxruntime.dll
+       move onnxruntime-win-x64-tensorrt\lib\onnxruntime.dll !filename!\lib\onnxruntime.dll
        move onnxruntime-win-x64-tensorrt\lib\onnxruntime.lib !filename!\lib\onnxruntime.lib
        move onnxruntime-win-x64-tensorrt\lib\onnxruntime.pdb !filename!\lib\onnxruntime.pdb
-       7z a %%~ni.zip !filename!\bin !filename!\lib
+       7z a %%~ni.zip !filename!\lib
    )
 )

--- a/tools/ci_build/github/windows/bundle_dlls_gpu.bat
+++ b/tools/ci_build/github/windows/bundle_dlls_gpu.bat
@@ -7,15 +7,16 @@ FOR /R %%i IN (*.zip) do (
    set filename=%%~ni
    IF "!filename:~20,3!"=="gpu" (
        mkdir !filename!\lib
-       move onnxruntime-win-x64-tensorrt\lib\onnxruntime_providers_tensorrt.dll !filename!\lib\onnxruntime_providers_tensorrt.dll
+       mkdir !filename!\bin 
+       move onnxruntime-win-x64-tensorrt\bin\onnxruntime_providers_tensorrt.dll !filename!\bin\onnxruntime_providers_tensorrt.dll
        move onnxruntime-win-x64-tensorrt\lib\onnxruntime_providers_tensorrt.lib !filename!\lib\onnxruntime_providers_tensorrt.lib
        move onnxruntime-win-x64-tensorrt\lib\onnxruntime_providers_tensorrt.pdb !filename!\lib\onnxruntime_providers_tensorrt.pdb
-       move onnxruntime-win-x64-tensorrt\lib\onnxruntime_providers_shared.dll !filename!\lib\onnxruntime_providers_shared.dll
+       move onnxruntime-win-x64-tensorrt\bin\onnxruntime_providers_shared.dll !filename!\bin\onnxruntime_providers_shared.dll
        move onnxruntime-win-x64-tensorrt\lib\onnxruntime_providers_shared.lib !filename!\lib\onnxruntime_providers_shared.lib
        move onnxruntime-win-x64-tensorrt\lib\onnxruntime_providers_shared.pdb !filename!\lib\onnxruntime_providers_shared.pdb
-       move onnxruntime-win-x64-tensorrt\lib\onnxruntime.dll !filename!\lib\onnxruntime.dll
+       move onnxruntime-win-x64-tensorrt\bin\onnxruntime.dll !filename!\bin\onnxruntime.dll
        move onnxruntime-win-x64-tensorrt\lib\onnxruntime.lib !filename!\lib\onnxruntime.lib
        move onnxruntime-win-x64-tensorrt\lib\onnxruntime.pdb !filename!\lib\onnxruntime.pdb
-       7z a  %%~ni.zip !filename!\lib
+       7z a %%~ni.zip !filename!\bin !filename!\lib
    )
 )


### PR DESCRIPTION
## Description
Fixes #28468

The Windows C-API artifact package was missing the CMake package metadata required for downstream CMake consumers. As a result, projects using the packaged artifact could not integrate ONNX Runtime through `find_package()`.

In addition, the packaging script assumed the presence of optional provider binaries (CUDA, TensorRT, WebGPU, QNN), which could cause incomplete artifacts when those components were built but had no corresponding `install()` rule, or packaging failures when they weren't built at all.

## Root Cause

The Windows artifact packaging template (`c-api-artifacts-package-and-publish-steps-windows.yml`) did not:

- Run `cmake --install`, so it never generated or packaged the exported CMake config/target files needed by `find_package()`.
- Flatten the installed `include/onnxruntime/` hierarchy to match the flat `include/` layout ONNX Runtime's own headers and existing consumers expect.
- Safely handle optional execution provider artifacts (CUDA, TensorRT) or third-party runtime dependencies (WebGPU's `dxcompiler.dll`/`dxil.dll`, the QNN SDK's runtime DLLs) that are staged into the raw build output but are not covered by any CMake `install()` rule.

## Changes Made

**Modified:** `tools/ci_build/github/azure-pipelines/templates/c-api-artifacts-package-and-publish-steps-windows.yml`

### CMake Package Support
- Added a `cmake --install` step that populates an `installed/` tree under `$(Build.BinariesDirectory)`, including:
  - `onnxruntimeConfig.cmake`
  - `onnxruntimeConfigVersion.cmake`
  - `onnxruntimeTargets.cmake` (and per-configuration variants, e.g. `onnxruntimeTargets-relwithdebinfo.cmake`, when generated)
- Added a validation step that fails fast if any of the above files are missing from the installed tree, so a broken `install(EXPORT)` is caught immediately rather than producing a silently incomplete zip.
- Added a flatten step that moves `installed/include/onnxruntime/*` up to `installed/include/` and removes the now-empty nested folder, then patches the generated `onnxruntimeTargets*.cmake` files so their `${_IMPORT_PREFIX}/include/onnxruntime` and `${_IMPORT_PREFIX}/bin/` references point at the flattened `include/` and `lib/` paths used in the final artifact. The patch step verifies its own output and fails the build if either old-style reference is still present afterward.
- Copies the generated CMake package files into `lib/cmake/onnxruntime/` in the final artifact.

### Optional / Third-Party Component Handling
- CUDA provider: copies the extra public headers (`resource.h`, `custom_op_context.h`, `cuda_context.h`, `cuda_resource.h`) when `onnxruntime_providers_cuda.dll` is present.
- TensorRT: existing `trtEnabled` parameter now also strips the TensorRT `.pdb` (in addition to `.dll`/`.lib`) when disabled, run *after* the PDB copy step so the cleanup isn't undone by a later wildcard copy.
- WebGPU: copies `dxcompiler.dll` / `dxil.dll` from the raw build output when present. These are staged by custom build commands and have no `install()` rule, so they would otherwise be silently dropped now that packaging is `cmake --install`-driven.
- QNN: copies the full set of Qualcomm QNN SDK runtime DLLs/`.so`/`.cat` files and the SDK license PDF from the raw build output when `onnxruntime_providers_qnn.dll` is present. This is required by `qnn-ep-win.yml`, which calls this template to produce the `onnxruntime-win-arm64x-qnn` archive — without this, that archive would ship without its QNN runtime dependencies.
- Added a packaging-time verification step that inspects the assembled `include/` and `lib/` directories and fails the build if it finds anything that isn't an expected ORT-owned file (headers outside the known `core`/`cuda`/`training` roots, loose files directly under `include/`, non-ORT static libraries, or files matching known third-party dependency name patterns such as `protobuf`, `absl`, `re2`). This guards against `cmake --install` pulling in headers/libs from bundled third-party dependencies (protobuf, abseil, etc.), since `cmake --install` runs every `install()` rule in the build tree, not just ONNX Runtime's own targets.

## Expected Artifact Structure

```
onnxruntime-win-x64-<version>/
│   LICENSE
│   Privacy.md
│   README.md
│   ThirdPartyNotices.txt
│   VERSION_NUMBER
│
├───include
│   │   onnxruntime_c_api.h
│   └───core
│       └───providers
│           │   custom_op_context.h
│           │   resource.h
│
└───lib
    │   onnxruntime.dll
    │   onnxruntime.lib
    │   onnxruntime.pdb
    │   onnxruntime_providers_shared.dll
    │   onnxruntime_providers_shared.lib
    │   onnxruntime_providers_shared.pdb
    │
    └───cmake
        └───onnxruntime
            │   onnxruntimeConfig.cmake
            │   onnxruntimeConfigVersion.cmake
            │   onnxruntimeTargets-relwithdebinfo.cmake
            │   onnxruntimeTargets.cmake
```

## Type of Change

- [x] Bug fix
- [x] Build/CI change