### PR TITLE
Implement Name Based partitioning and update documents

### DIFF
--- a/docs/annotated_partitioning/PartitioningWithAnnotationsAndMemoryConstraints.md
+++ b/docs/annotated_partitioning/PartitioningWithAnnotationsAndMemoryConstraints.md
@@ -178,6 +178,42 @@ Nodes that do not match any rule fall through to the normal EP capability-based 
 
 > **Note — Annotations vs. actual placement:** An annotation expresses a *preference*, not a guarantee. If the target EP does not have a registered kernel for a node (for example, a particular data-type / opset-version combination is not implemented in the CUDA EP), that node will not be placed on the requested device. Instead it falls through to the next EP in the provider list that can handle it.
 
+### Name-Based Layer Assignment (No Model Modification)
+
+For models that already have structured node names (most HuggingFace exports, ONNX models produced by PyTorch, etc.), you can skip the annotation step entirely. The session option `session.name_based_layer_assignment` performs **substring matching** directly against `Node::Name()`:
+
+```
+device1(pattern1, pattern2, ...); device2(pattern3, pattern4, ...)
+```
+
+- **Substring matching:** A pattern matches if it appears *anywhere* in the node name. For example, `layers.0/` matches `/model/layers.0/self_attn/q_proj/MatMul`.
+- **Longest match wins:** When multiple patterns match the same node name, the longest pattern takes priority. For example, `layers.10/` wins over `layers.1/` for a node named `/model/layers.10/...`.
+- **No `=` prefix:** The exact-match qualifier (`=`) from annotation-based syntax is not supported. All patterns are treated as substrings.
+- **Same device designators:** The device portion uses the same device designators as `session.layer_assignment_settings` (see table above).
+
+```python
+import onnxruntime as ort
+
+opts = ort.SessionOptions()
+
+# Assign layers 0–7 to GPU, layers 8–15 to CPU based on node names
+opts.add_session_config_entry(
+    "session.name_based_layer_assignment",
+    "gpu(layers.0/, layers.1/, layers.2/, layers.3/, layers.4/, layers.5/, layers.6/, layers.7/); "
+    "cpu(layers.8/, layers.9/, layers.10/, layers.11/, layers.12/, layers.13/, layers.14/, layers.15/)"
+)
+
+session = ort.InferenceSession("model.onnx", opts,
+                               providers=["CUDAExecutionProvider", "CPUExecutionProvider"])
+```
+
+**Tips for writing patterns:**
+- Include the trailing `/` in layer patterns (e.g., `layers.1/` instead of `layers.1`) to avoid `layers.1` accidentally matching `layers.10`, `layers.11`, etc.
+- Use [Netron](https://netron.app/) to inspect your model's node names and identify suitable substrings.
+- Nodes that do not match any pattern fall through to normal EP capability-based assignment (typically CPU).
+
+**Combining with annotation-based matching:** Both `session.layer_assignment_settings` and `session.name_based_layer_assignment` can be set simultaneously. Annotation-based matching takes priority — if a node has a `layer_ann` metadata property that matches an annotation rule, that assignment is used. Name-based matching acts as a fallback for nodes without annotation matches.
+
 ## Capacity-Aware Partitioning (implemented for CUDA)
 
 When running models on a CUDA GPU with limited memory, you can set a memory budget so ONNX Runtime stops assigning nodes to the CUDA EP once the estimated memory consumption reaches the limit. Nodes are considered in topological order and assignment halts at the first node that would exceed the budget — ONNX Runtime does not search ahead for smaller nodes that might still fit. Remaining nodes are then eligible for assignment by the subsequent EPs in the session's provider list (often CPU, but not necessarily).
@@ -292,26 +328,29 @@ EPs that prefer the NHWC data layout — for example, the CUDA EP when it is cre
 
 Because the first-pass tags are tentative, ONNX Runtime does **not** commit any memory budget for them. The budget is committed only for the nodes that survive the second pass; the cost of a node that is dropped is never counted against the memory limit. This keeps the accumulated memory estimate accurate when `prefer_nhwc` is combined with `session.resource_cuda_partitioning_settings`, so a dropped node does not consume phantom budget that could prematurely halt assignment of later nodes.
 
-## Combining Both Features
-Layer annotations and capacity-aware partitioning can be used together. When both are configured:
-- Layer annotations provide the initial node-to-device mapping.
+## Combining Features
+Layer annotations, name-based assignment, and capacity-aware partitioning can be used together in any combination. When multiple are configured:
+- Annotation-based matching (`session.layer_assignment_settings`) has highest priority.
+- Name-based matching (`session.name_based_layer_assignment`) provides fallback for nodes without annotation matches.
 - The capacity-aware partitioner enforces the memory budget, potentially overriding assignments that would exceed the GPU memory limit.
 
-This combination gives you fine-grained control: use annotations to express logical model structure, and let the memory budget act as a safety net.
+This combination gives you fine-grained control: use annotations or name patterns to express logical model structure, and let the memory budget act as a safety net.
 
 ```python
 opts = ort.SessionOptions()
 
+# Name-based assignment (no model modification needed)
 opts.add_session_config_entry(
-    "session.layer_assignment_settings",
-    "gpu(encoder, decoder); cpu(=postprocess)"
+    "session.name_based_layer_assignment",
+    "gpu(layers.0/, layers.1/, layers.2/, layers.3/); cpu(layers.4/, layers.5/, layers.6/, layers.7/)"
 )
 
+# Memory budget as a safety net
 opts.add_session_config_entry(
     "session.resource_cuda_partitioning_settings",
     "4194304,node_memory_stats.csv"
 )
 
-session = ort.InferenceSession("model_annotated.onnx", opts,
+session = ort.InferenceSession("model.onnx", opts,
                                providers=["CUDAExecutionProvider", "CPUExecutionProvider"])
 ```

--- a/docs/annotated_partitioning/PartitioningWithAnnotationsAndMemoryConstraints.md
+++ b/docs/annotated_partitioning/PartitioningWithAnnotationsAndMemoryConstraints.md
@@ -212,7 +212,9 @@ session = ort.InferenceSession("model.onnx", opts,
 - Use [Netron](https://netron.app/) to inspect your model's node names and identify suitable substrings.
 - Nodes that do not match any pattern fall through to normal EP capability-based assignment (typically CPU).
 
-**Combining with annotation-based matching:** Both `session.layer_assignment_settings` and `session.name_based_layer_assignment` can be set simultaneously. Annotation-based matching takes priority — if a node has a `layer_ann` metadata property that matches an annotation rule, that assignment is used. Name-based matching acts as a fallback for nodes without annotation matches.
+**Mutual exclusivity with annotation-based matching:** The `session.name_based_layer_assignment` and `session.layer_assignment_settings` options are **mutually exclusive** — setting both will return an error. Use annotation-based matching for models that carry explicit `layer_ann` metadata annotations, or name-based matching for unmodified models with structured node names. If you need fine-grained exceptions (e.g., force one specific node to CPU), add the node's name pattern to the name-based config instead of mixing the two approaches.
+
+**No subgraph inheritance:** Unlike annotation-based matching (where unannotated subgraph nodes inherit their parent's device assignment), name-based matching treats every node independently. Since node names are dense (virtually every node has a name encoding its structural position), inheritance is unnecessary — each node matches on its own name.
 
 ## Capacity-Aware Partitioning (implemented for CUDA)
 
@@ -329,12 +331,13 @@ EPs that prefer the NHWC data layout — for example, the CUDA EP when it is cre
 Because the first-pass tags are tentative, ONNX Runtime does **not** commit any memory budget for them. The budget is committed only for the nodes that survive the second pass; the cost of a node that is dropped is never counted against the memory limit. This keeps the accumulated memory estimate accurate when `prefer_nhwc` is combined with `session.resource_cuda_partitioning_settings`, so a dropped node does not consume phantom budget that could prematurely halt assignment of later nodes.
 
 ## Combining Features
-Layer annotations, name-based assignment, and capacity-aware partitioning can be used together in any combination. When multiple are configured:
-- Annotation-based matching (`session.layer_assignment_settings`) has highest priority.
-- Name-based matching (`session.name_based_layer_assignment`) provides fallback for nodes without annotation matches.
+Layer annotations OR name-based assignment can be combined with capacity-aware partitioning. Note that annotation-based and name-based matching are **mutually exclusive** — you cannot use both simultaneously.
+
+When a layer assignment option (either annotation-based or name-based) is configured together with the capacity-aware partitioner:
+- The layer assignment option expresses the desired device placement.
 - The capacity-aware partitioner enforces the memory budget, potentially overriding assignments that would exceed the GPU memory limit.
 
-This combination gives you fine-grained control: use annotations or name patterns to express logical model structure, and let the memory budget act as a safety net.
+This gives you fine-grained control: use annotations or name patterns to express logical model structure, and let the memory budget act as a safety net.
 
 ```python
 opts = ort.SessionOptions()

--- a/docs/annotated_partitioning/PartitioningWithAnnotationsAndMemoryConstraints.md
+++ b/docs/annotated_partitioning/PartitioningWithAnnotationsAndMemoryConstraints.md
@@ -188,7 +188,7 @@ device1(pattern1, pattern2, ...); device2(pattern3, pattern4, ...)
 
 - **Substring matching:** A pattern matches if it appears *anywhere* in the node name. For example, `layers.0/` matches `/model/layers.0/self_attn/q_proj/MatMul`.
 - **Longest match wins:** When multiple patterns match the same node name, the longest pattern takes priority. For example, `layers.10/` wins over `layers.1/` for a node named `/model/layers.10/...`.
-- **No `=` prefix:** The exact-match qualifier (`=`) from annotation-based syntax is not supported. All patterns are treated as substrings.
+- **No `=` prefix:** The exact-match qualifier (`=`) from annotation-based syntax is rejected with an error. All patterns are treated as substrings.
 - **Same device designators:** The device portion uses the same device designators as `session.layer_assignment_settings` (see table above).
 
 ```python

--- a/docs/annotated_partitioning/cuda_kernel_workspace_inventory.md
+++ b/docs/annotated_partitioning/cuda_kernel_workspace_inventory.md
@@ -1,0 +1,432 @@
+# CUDA Kernel Workspace Buffer Inventory
+
+This document catalogs all CUDA kernels in ONNX Runtime that allocate temporary/workspace buffers via `GetScratchBuffer` or `GetTransientScratchBuffer`. For each kernel, it identifies what information is needed to compute the workspace size and whether that information is available at `GetCapability()` time (for the workspace estimation function design).
+
+## Classification Key
+
+| Symbol | Meaning |
+|--------|---------|
+| ✅ | Fully determinable from shapes + attributes + device properties |
+| ✅* | Determinable via cuDNN/cuBLAS API call (needs handle, available on EP) |
+| ⚠️ | Requires profiling/tactic selection (deterministic but costly at planning time) |
+
+---
+
+## Core CUDA Providers (`onnxruntime/core/providers/cuda/`)
+
+### 1. Attention (LLM — Opset 23/24)
+
+**File:** `llm/attention.cc`
+
+**Buffers allocated:**
+| Buffer | Size formula | Depends on |
+|--------|--------------|-----------|
+| `softmax_lse_buffer` | `B * S_q * num_heads * sizeof(float)` | shapes |
+| `softmax_lse_accum_buffer` | From `get_num_splits_and_buffer_sizes()` | shapes + `multiProcessorCount` |
+| `out_accum_buffer` | From `get_num_splits_and_buffer_sizes()` | shapes + `multiProcessorCount` |
+| `q_bsnh_buffer` | `B * S_q * num_heads * head_size * element_size` | shapes + dtype |
+| `out_bsnh_buffer` | Same as Q | shapes + dtype |
+| `k_bsnh_buffer` / `v_bsnh_buffer` | `B * S_kv * num_kv_heads * head_size * element_size` | shapes + dtype |
+| `seqlens_k_buffer` | `B * sizeof(int)` | batch size |
+| `past_seqlens_buffer` | `B * sizeof(int)` | batch size |
+| `k_expand_buffer` / `v_expand_buffer` | `B * num_heads * S_kv * head_size * element_size` (GQA expansion) | shapes + dtype |
+| `converted_mask_buffer` | `B * S_q * S_kv * sizeof(float)` | shapes |
+| `present_k_scratch` / `present_v_scratch` | present KV cache size | shapes |
+| `workspace_buffer` (math attention) | `B * S_q * num_heads * sizeof(float)` | shapes |
+
+**What's needed to compute:** Input shapes, `num_heads` attribute, `head_size`, dtype, `device_prop.multiProcessorCount`.
+
+**Static determinability:** ✅ All pure arithmetic on shapes + device SM count.
+
+---
+
+### 2. Conv (cuDNN Frontend)
+
+**File:** `nn/conv.cc`, `nn/conv.h`
+
+**Buffers allocated:**
+| Buffer | Size formula | Depends on |
+|--------|--------------|-----------|
+| `workspace` | `s_.cudnn_fe_graph->get_workspace_size()` | cuDNN plan selection |
+| `memory_for_cudnn_conv_results` (Conv8 only) | `y_dims_with_adjusted_pads.Size() * element_size` | output shape + padding |
+
+**What's needed to compute:** Input shapes (NCHW), weight shapes, pads/strides/dilations attributes, cuDNN handle (for `build_plans()`).
+
+**Static determinability:** ✅* — Requires calling `build_plans(handle)` with `HEUR_MODE_A`. The handle is on the EP. All tensor shapes and conv params come from node attributes.
+
+**Note:** `GetTransientScratchBuffer` (32MB) used for algorithm search in Conv8 — this is a one-time cost during first Compute, not a per-run workspace.
+
+---
+
+### 3. ConvTranspose
+
+**File:** `nn/conv_transpose.h`, `nn/conv_transpose_8.h`
+
+**Buffers allocated:**
+| Buffer | Size formula | Depends on |
+|--------|--------------|-----------|
+| `workspace` | `s_.workspace_bytes` (from cuDNN FE or algo selection) | Same as Conv |
+| `AlgoSearchWorkspaceSize` (Conv8 path) | 32MB constant | N/A |
+
+**Static determinability:** ✅* — Same as Conv.
+
+---
+
+### 4. DeformConv
+
+**File:** `nn/deform_conv.cc`
+
+**Buffers allocated:**
+| Buffer | Size formula | Depends on |
+|--------|--------------|-----------|
+| `col_buffer` | `C * kernel_size * col_stride * sizeof(T)` where `col_stride = n_parallel_imgs * output_image_size` | Input shapes, kernel_size, `device_prop.totalGlobalMem` (for chunk sizing) |
+
+**What's needed:** Input shape (N,C,H,W), kernel dims, output_image_size, `totalGlobalMem` (determines `n_parallel_imgs` via `GetNParallelImgs`).
+
+**Static determinability:** ✅ — Pure arithmetic on shapes + device memory size.
+
+---
+
+### 5. BatchNorm
+
+**File:** `nn/batch_norm.cc`
+
+**Buffers allocated:**
+| Buffer | Size formula | Depends on |
+|--------|--------------|-----------|
+| `f_scale`, `f_B`, `f_mean`, `f_var` | `C * sizeof(float)` each | Channel dim (shape[1] or shape[3]) |
+
+**What's needed:** Channel dimension `C` from input shape.
+
+**Static determinability:** ✅ — Trivial: `4 * C * sizeof(float)`.
+
+---
+
+### 6. InstanceNorm
+
+**File:** `nn/instance_norm.cc`
+
+**Buffers allocated:**
+| Buffer | Size formula | Depends on |
+|--------|--------------|-----------|
+| `mean`, `variance` | `N * C * sizeof(T)` | Batch × channels |
+| `unused_scale`, `unused_bias` | `N * C * sizeof(T)` | Same |
+| `scale_data_fp32`, `bias_data_fp32` | `C * sizeof(float)` (if fp16) | Channel dim + dtype |
+
+**What's needed:** Input shape (N, C), dtype.
+
+**Static determinability:** ✅ — Pure arithmetic on shapes.
+
+---
+
+### 7. Dropout
+
+**File:** `nn/dropout.cc`
+
+**Buffers allocated:**
+| Buffer | Size formula | Depends on |
+|--------|--------------|-----------|
+| mask buffer | `element_count * sizeof(bool)` or `element_count / 16 * sizeof(BitmaskElementType)` | Input element count, bitmask mode |
+
+**Static determinability:** ✅ — Input element count.
+
+---
+
+### 8. Reduction Ops (ReduceSum, ReduceMax, ReduceMean, etc.)
+
+**File:** `reduction/reduction_ops.cc`
+
+**Buffers allocated:**
+| Buffer | Size formula | Depends on |
+|--------|--------------|-----------|
+| `workspace_cuda` | `cudnnGetReductionWorkspaceSize()` | cuDNN handle, input/output tensor descriptors |
+| `indices_cuda` | `cudnnGetReductionIndicesSize()` | Same |
+| `temp_X` | `input_count * sizeof(float)` (type cast) | Input size |
+| `input_data_buffer` | `input_count * sizeof(T)` (for `calculate_sqt_`) | Input size |
+| `exp_result_buffer` | `input_count * sizeof(T)` (for `log_sum_exp_`) | Input size |
+| `log_sum_result_buffer` | `output_count * sizeof(T)` | Output size |
+| `temp_output` | `output_count * sizeof(float)` | Output size |
+
+**What's needed:** Input/output shapes, reduction axes, op variant (LogSumExp, L2, etc.), cuDNN handle.
+
+**Static determinability:** ✅* — cuDNN workspace query needs handle + tensor descriptors (constructible from shapes).
+
+---
+
+### 9. RNN (LSTM/GRU)
+
+**File:** `rnn/cudnn_rnn_base.cc`
+
+**Buffers allocated:**
+| Buffer | Size formula | Depends on |
+|--------|--------------|-----------|
+| `workspace_cuda` | `cudnnGetRNNTempSpaceSizes(fwdInference)` | RNN descriptor, seq_length, batch_size |
+| `reservespace_cuda` | `cudnnGetRNNTempSpaceSizes(training)` | Same |
+| `reorganized_w_data` | `w_size * sizeof(T)` | hidden_size, num_layers, input_size, direction |
+| `x_reversed_data` | `seq_length * batch_size * input_size * sizeof(T)` | Shapes (bidirectional case) |
+| `y_alloc_data` | `output_size * sizeof(T)` | Shapes |
+| `state_buffer_` | RNN state size from cuDNN | cuDNN descriptor |
+
+**What's needed:** seq_length, batch_size, input_size, hidden_size, num_layers, direction attribute, cuDNN handle.
+
+**Static determinability:** ✅* — cuDNN API queries, all inputs available from node attributes/shapes.
+
+---
+
+### 10. TopK
+
+**File:** `math/topk_impl.cuh`
+
+**Buffers allocated:**
+| Buffer | Size formula | Depends on |
+|--------|--------------|-----------|
+| `input_key_buffer` | `dimension * sizeof(T)` | Last-axis dimension |
+| `output_key_buffer` | `dimension * sizeof(T)` | Same |
+| `input_value_buffer` | `dimension * sizeof(int64_t)` | Same |
+| `output_value_buffer` | `dimension * sizeof(int64_t)` | Same |
+| `temp_storage_buffer` | From `cub::DeviceRadixSort::SortPairs` query | dimension |
+
+**What's needed:** Dimension (last axis size), k, dtype.
+
+**Static determinability:** ✅ — CUB temp storage query is deterministic given size.
+
+---
+
+### 11. MatMulInteger
+
+**File:** `math/matmul_integer.cc`
+
+**Buffers allocated:**
+| Buffer | Size formula | Depends on |
+|--------|--------------|-----------|
+| `a_row_buf` | `(output_size / N) * sizeof(int32_t)` | M dimension |
+| `b_col_buf` | `(output_size / M) * sizeof(int32_t)` | N dimension |
+
+**What's needed:** M, N dimensions from MatMul shapes.
+
+**Static determinability:** ✅ — Pure arithmetic.
+
+---
+
+### 12. IntegerGemm (int8 alignment padding)
+
+**File:** `integer_gemm.cc`
+
+**Buffers allocated:**
+| Buffer | Size formula | Depends on |
+|--------|--------------|-----------|
+| `a_padded` | `m * roundoff(lda, 32) * sizeof(int8_t)` (only if lda not 32-aligned) | M, K dims |
+| `b_padded` | `k * roundoff(ldb, 32) * sizeof(int8_t)` (only if ldb not 32-aligned) | K, N dims |
+
+**What's needed:** M, K, N dimensions + alignment check.
+
+**Static determinability:** ✅ — Pure arithmetic.
+
+---
+
+### 13. Compress
+
+**File:** `tensor/compress.cc`
+
+**Buffers allocated:**
+| Buffer | Size formula | Depends on |
+|--------|--------------|-----------|
+| `condition_cumulative_sum_buffer` | `valid_condition_length * sizeof(int32_t)` | Condition tensor size |
+| `temp_buffer` | CUB `DeviceScan::InclusiveSum` temp storage | Condition size |
+
+**Static determinability:** ✅ — Condition shape determines everything.
+
+---
+
+### 14. GatherND
+
+**File:** `tensor/gather_nd.cc`
+
+**Buffers allocated:**
+| Buffer | Size formula | Depends on |
+|--------|--------------|-----------|
+| `sizes_from_slice_dims_buffer` | `num_slice_dims * sizeof(int64_t)` | Indices shape |
+| `input_slice_offsets_buffer` | `num_slices * sizeof(int64_t)` | Indices shape[:-1] product |
+
+**Static determinability:** ✅ — Indices shape.
+
+---
+
+### 15. NonZero
+
+**File:** `tensor/nonzero_op.cc`
+
+**Buffers allocated:**
+| Buffer | Size formula | Depends on |
+|--------|--------------|-----------|
+| `prefix_buffer` | `number_of_blocks * sizeof(int)` | Input element count / block_size |
+| `temp_buffer` | CUB temp storage | Input element count |
+
+**Static determinability:** ✅ — Input element count.
+
+---
+
+### 16. Upsample/Resize
+
+**File:** `tensor/upsample.cc`
+
+**Buffers allocated:**
+| Buffer | Size formula | Depends on |
+|--------|--------------|-----------|
+| temp buffer (via lambda) | Varies by resize mode | Input/output shapes, mode |
+| `dims_mapping_buffer` | `temp_buffer_size` (coordinate mapping) | Output shape |
+
+**Static determinability:** ✅ — Input/output shapes + mode attribute.
+
+---
+
+### 17. NonMaxSuppression
+
+**File:** `object_detection/non_max_suppression.cc`
+
+**Buffers allocated:**
+| Buffer | Size formula | Depends on |
+|--------|--------------|-----------|
+| Various (via lambda) | Determined by CUB DeviceSelect internals | num_boxes, num_classes |
+
+**What's needed:** boxes shape (num_batches, num_boxes, 4), scores shape.
+
+**Static determinability:** ✅ — CUB queries are deterministic given sizes.
+
+---
+
+## Contrib CUDA Operators (`onnxruntime/contrib_ops/cuda/`)
+
+### 18. Attention / MultiHeadAttention (Contrib)
+
+**File:** `bert/attention.cc`, `bert/multihead_attention.cc`
+
+**Buffers:** Uses `GetAttentionWorkspaceSize()` helper function.
+
+**Size formula:** Depends on attention algorithm (Flash, MemoryEfficient, FusedRunner, Default):
+- Flash: `qkv_size` (Q+K+V projection)
+- MemoryEfficient: `qkv_size + output_accum (float)`
+- Default (unfused): `qkv_size + 2 * attention_scratch_size`
+
+**What's needed:** B, S_q, S_kv, num_heads, head_size, dtype, which attention algorithm is selected.
+
+**Static determinability:** ✅ — Algorithm selection depends on shapes + SM version (available from device_prop).
+
+---
+
+### 19. MOE (Mixture of Experts)
+
+**File:** `moe/moe.cc`, `moe/moe_quantization.cc`
+
+**Buffers allocated:**
+| Buffer | Size formula | Depends on |
+|--------|--------------|-----------|
+| `workspace` | `moe_runner->getWorkspaceSize(num_rows, hidden, inter, experts, k)` | Shapes + tactic |
+| `expert_scales` | `num_rows * k * sizeof(float)` | Shapes |
+| `expert_indices` | `num_rows * k * sizeof(int)` | Shapes |
+| `permutation_row_map` | `num_rows * k * sizeof(int)` | Shapes |
+
+**What's needed:** num_rows, hidden_size, inter_size, num_experts, k, activation_type, SM version, selected tactic.
+
+**Static determinability:** ⚠️ — `getWorkspaceSize()` depends on profiled best tactic (CUTLASS config). Could use worst-case across tactics as upper bound.
+
+---
+
+### 20. MatMulNBits (Quantized MatMul)
+
+**File:** `quantization/matmul_nbits.cc`
+
+**Buffers allocated:**
+| Buffer | Size formula | Depends on |
+|--------|--------------|-----------|
+| `workspace_buffer` | `weightOnlyGemmRunner_->getWorkspaceSize(m, n, k)` | Dims + tactic |
+| `packed_transposed_weight_space` | `packed_weight_bytes` (transient) | Weight shape |
+| `permutation_map_buffer` | `32 * sizeof(int32_t)` (transient) | Constant |
+
+**What's needed:** M, N, K dimensions, quantization bits, SM version.
+
+**Static determinability:** ⚠️ — Runner workspace depends on profiled tactic. Could use upper bound.
+
+---
+
+### 21. fpA_intB GEMM (FP×INT quantized)
+
+**File:** `llm/fpA_intB_gemm/`
+
+**Buffers:** `virtual size_t getWorkspaceSize(m, n, k)`.
+
+**What's needed:** M, N, K + CUTLASS template specialization.
+
+**Static determinability:** ⚠️ — Depends on selected CUTLASS config/tactic.
+
+---
+
+### 22. Inverse (Matrix Inversion)
+
+**File:** `inverse.cc`
+
+**Buffers allocated:**
+| Buffer | Size formula | Depends on |
+|--------|--------------|-----------|
+| `input_workspace` | `input_count * sizeof(T)` | Matrix dimensions |
+| `matrix_ptrs` | `n_batches * sizeof(T*)` | Batch count |
+| `output_ptrs` | `n_batches * sizeof(T*)` | Batch count |
+| `ml_float_output` | `input_count * sizeof(float)` (if fp16→fp32) | Dims + dtype |
+
+**Static determinability:** ✅ — Pure arithmetic on matrix dimensions.
+
+---
+
+### 23. Generation (Beam Search / Sampling)
+
+**File:** `transformers/generation_device_helper.cc`
+
+**Buffers:** Various pinned + device buffers for beam state.
+
+**What's needed:** batch_size, beam_width, max_length, vocab_size.
+
+**Static determinability:** ✅ — All from session/model config.
+
+---
+
+## Summary: Coverage Analysis
+
+### Workspace estimation approach validation
+
+| Category | # Kernels | Estimation feasibility | Notes |
+|----------|-----------|----------------------|-------|
+| **Shapes only** | 12 | ✅ Exact, trivial | BatchNorm, InstanceNorm, Dropout, TopK, MatMulInteger, IntegerGemm, Compress, GatherND, NonZero, Upsample, Inverse, Generation |
+| **Shapes + device properties** | 3 | ✅ Exact | Attention (SM count), DeformConv (totalGlobalMem), Contrib Attention (SM version) |
+| **Shapes + cuDNN/cuBLAS handle** | 4 | ✅* Exact via API query | Conv, ConvTranspose, Reduction, RNN |
+| **Shapes + tactic profiling** | 3 | ⚠️ Upper bound only | MOE, MatMulNBits, fpA_intB_GEMM |
+
+### Key takeaways
+
+1. **~75% of kernels** (19/25) can produce **exact** workspace estimates at `GetCapability()` time using only shapes + attributes + device properties (+ cuDNN handle for API queries).
+
+2. **~12% of kernels** (3/25) require tactic profiling (CUTLASS/CUB autotuning). For these, options are:
+   - Use worst-case workspace across all tactics (safe upper bound)
+   - Run tactic selection eagerly at estimation time (expensive but exact)
+   - Accept 1.5x multiplier for these few kernels
+
+3. **The cuDNN handle requirement** affects only 4 kernel types (Conv, ConvTranspose, Reduction, RNN). All are standard cuDNN API queries that are fast and deterministic given the handle + tensor descriptors.
+
+4. **No kernel requires actual GPU execution** to determine workspace size — even tactic-based kernels select tactics via CPU-side profiling/heuristics, not by running GPU code.
+
+5. **Largest workspace consumers** in practice:
+   - **Attention** (Flash): dominates in LLM workloads. Exact estimation possible.
+   - **Conv** (cuDNN): dominates in vision workloads. Exact via `build_plans()`.
+   - **MOE**: significant in MoE models. Upper bound via worst-case tactic.
+
+### What the estimation function needs access to (API requirements):
+
+| Access needed | How accessed | Kernels that require it |
+|---------------|-------------|------------------------|
+| `Node_GetInputShape()` | OrtEpApi (generic) | All 25 kernels |
+| `Node_GetAttributeInt/Ints()` | OrtEpApi (generic) | Conv, Attention, RNN, MOE |
+| `device_prop.multiProcessorCount` | Cast `OrtEp*` to concrete EP type | Attention, DeformConv |
+| `device_prop.totalGlobalMem` | Cast `OrtEp*` to concrete EP type | DeformConv |
+| cuDNN handle | Cast `OrtEp*` to concrete EP type | Conv, ConvTranspose, Reduction, RNN |
+| Tactic profiler state (or worst-case constant) | Cast `OrtEp*` to concrete EP type | MOE, MatMulNBits, fpA_intB |
+
+**API surface:** Only `Node_GetInputShape` and `Node_GetAttributeInt/Ints` need to be added to `OrtEpApi` (generic, EP-agnostic). All device-specific state (cuDNN handles, device properties, profiler state) is accessed by casting `OrtEp*` to the EP's concrete type — no public API needed since the estimation function is EP-specific code.

--- a/docs/annotated_partitioning/future_directions_constrained_env.md
+++ b/docs/annotated_partitioning/future_directions_constrained_env.md
@@ -79,8 +79,6 @@ A config like `gpu(layers.0, layers.1, ..., layers.15); cpu(layers.16, ..., laye
 ### Risks / Open Questions
 
 - **Name stability**: Node names aren't guaranteed stable across exports. Mitigated by prefix/substring matching rather than exact names.
-- **Unnamed nodes / nodes created by graph transformers**: See detailed analysis below.
-- **Subgraph nodes**: Control flow (If/Loop) subgraph nodes may have different naming conventions.
 
 ### Handling Nodes Created by Graph Transformers
 
@@ -129,6 +127,18 @@ For models with fully static shapes (common in transformer inference with fixed 
 Additionally, by knowing exact memory requirements before execution begins, ORT can **minimize the chance of running into OOM** — if the total memory needed exceeds device capacity, the session can fail at `Initialize()` time with a clear error rather than crashing mid-inference with an opaque allocation failure.
 
 This brings ORT's allocation efficiency on par with specialized runtimes like llama.cpp, while retaining ORT's generality for arbitrary model architectures.
+
+### Dynamic Shapes in Transformer Models
+
+Nearly all transformer models are *exported* with dynamic batch + sequence_length — this is the default in PyTorch `torch.onnx.export`, Hugging Face Optimum, and Olive. However, for constrained deployment the picture is different:
+
+- **Fixed-shape re-export is standard for edge/embedded:** batch=1, seq_len=128 (or a few discrete lengths like 128/256/512). This is standard practice for TensorRT, CoreML, and QNN deployments.
+- **LLM serving keeps shapes dynamic** (variable prompts, KV-cache growth). But these are typically high-VRAM scenarios (A100/H100), not constrained environments.
+- **Vision transformers** (ViT, DINO, etc.) have fixed patch sequences — only batch is dynamic, and fixing batch=1 yields fully static shapes.
+
+**Implication for pre-allocation:** The target audience of `pre_allocate_execution_buffers` — embedded, edge, single-model-per-device — typically *can* use static shapes. Models are re-exported with fixed dimensions as part of the deployment pipeline. The dynamic-shape case (LLM serving with variable seq_len) lives in a different deployment tier where VRAM budget is less critical than throughput and the arena allocator handles repeated allocations efficiently.
+
+**Implication for workspace estimation:** Even with dynamic shapes, `EstimateWorkspace` (Level 1) and `DeclareWorkspaceRequirements` (Level 2) remain valuable for *budget decisions* — they can use worst-case shapes (max batch, max seq_len from model config) to determine how many nodes fit on the device. The estimate doesn't need to match runtime exactly; it needs to be conservative enough to avoid OOM.
 
 ### Reference: What llama.cpp Does
 
@@ -232,7 +242,7 @@ Since partitioning is decided once at `Initialize()` time and all required devic
 
 **Why this matters:** The goal is not to fail gracefully — it's to **avoid failure entirely**. Today, models either OOM on device or trigger heavy VRAM thrashing on Windows. The partitioning must be conservative enough to prevent this, while accurate enough to maximize GPU utilization.
 
-**Solution: Two-level estimation with post-assignment verification and tail-trim**
+**Solution: Two-level estimation with post-assignment verification**
 
 **Level 1 — Static workspace estimation function (at partitioning time):**
 
@@ -314,7 +324,7 @@ Status Attention::DeclareWorkspaceRequirements(span<const TensorShape> shapes,
 
 Both call the same `ComputeAttentionWorkspace()` — producing **identical results**. The estimation function gets device properties from the EP; the kernel method gets them from its stored EP reference. Same data, same computation, same answer.
 
-**For cuDNN-based ops**, the estimation function can also be precise — it calls `build_plans()` using the EP's handle and the node's shapes/attributes. The Level 2 tail-trim remains as a safety net for any edge cases (e.g., cuDNN returning different results due to driver version differences between planning and execution).
+**For cuDNN-based ops**, the estimation function can also be precise — it calls `build_plans()` using the EP's handle and the node's shapes/attributes. Level 2 re-check serves as a diagnostic safety net — if the post-fusion total exceeds the budget, a warning is logged indicating that the Level 1 estimate was too optimistic (e.g., cuDNN returning different workspace sizes due to driver version differences or fusion changing the algorithm selection).
 
 **KernelCreateInfo and registration macros:**
 
@@ -329,18 +339,85 @@ struct KernelCreateInfo {
 };
 ```
 
-The existing `ONNX_OPERATOR_TYPED_KERNEL_EX` macro doesn't need changes — it produces `KernelCreateInfo` via `BuildKernelCreateInfo<>()`. The estimation function can be set separately after construction, or a new macro variant can be introduced:
+The existing `ONNX_OPERATOR_TYPED_KERNEL_EX` macro doesn't need changes — it produces `KernelCreateInfo` via `BuildKernelCreateInfo<>()`. A new macro variant adds the estimation function for kernels that implement it:
 
 ```cpp
-// Option: set via a builder-style extension after BuildKernelCreateInfo:
-auto info = BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(...)>();
-info.workspace_estimate_func = &EstimateAttentionWorkspace;
-
-// Option: new macro that includes the estimation function:
-// (only for kernels that implement estimation — opt-in)
+// New macro: ONNX_OPERATOR_TYPED_KERNEL_EX_WITH_ESTIMATE
+// Same as ONNX_OPERATOR_TYPED_KERNEL_EX but also registers a workspace estimation function.
+#define ONNX_OPERATOR_TYPED_KERNEL_EX_WITH_ESTIMATE(                                          \
+    name, domain, ver, type, provider, builder, estimate_fn, ...)                             \
+  class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(provider, domain, ver, type, name);             \
+  template <>                                                                                 \
+  KernelCreateInfo                                                                            \
+  BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(                                \
+      provider, domain, ver, type, name)>() {                                                 \
+    return KernelCreateInfo(                                                                  \
+        builder.SetName(#name)                                                                \
+            .SetDomain(domain)                                                                \
+            .SinceVersion(ver)                                                                \
+            .Provider(provider)                                                               \
+            .Build(),                                                                         \
+        static_cast<KernelCreatePtrFn>(                                                       \
+            [](FuncManager&, const OpKernelInfo& info,                                        \
+               std::unique_ptr<OpKernel>& out) -> Status {                                    \
+              out = std::make_unique<__VA_ARGS__>(info);                                       \
+              return Status::OK();                                                            \
+            }),                                                                               \
+        estimate_fn);                                                                         \
+  }
 ```
 
-No existing macros need modification — this is purely additive.
+This requires a new `KernelCreateInfo` constructor overload:
+
+```cpp
+struct KernelCreateInfo {
+  std::unique_ptr<KernelDef> kernel_def;
+  KernelCreateFn kernel_create_func;
+  OrtKernelWorkspaceEstimateFunc workspace_estimate_func;  // NEW — may be nullptr
+  Status status;
+
+  // Existing constructor (unchanged — sets workspace_estimate_func to nullptr):
+  KernelCreateInfo(std::unique_ptr<KernelDef> definition,
+                   KernelCreateFn create_func)
+      : kernel_def(std::move(definition)),
+        kernel_create_func(create_func),
+        workspace_estimate_func(nullptr) {}
+
+  // New constructor with estimation function:
+  KernelCreateInfo(std::unique_ptr<KernelDef> definition,
+                   KernelCreateFn create_func,
+                   OrtKernelWorkspaceEstimateFunc estimate_func)
+      : kernel_def(std::move(definition)),
+        kernel_create_func(create_func),
+        workspace_estimate_func(estimate_func) {}
+
+  KernelCreateInfo(KernelCreateInfo&& other) noexcept
+      : kernel_def(std::move(other.kernel_def)),
+        kernel_create_func(std::move(other.kernel_create_func)),
+        workspace_estimate_func(other.workspace_estimate_func) {}
+
+  KernelCreateInfo() = default;
+};
+```
+
+**Usage example** (registering a CUDA Attention kernel with estimation):
+
+```cpp
+// In cuda_contrib_kernels.cc:
+ONNX_OPERATOR_TYPED_KERNEL_EX_WITH_ESTIMATE(
+    Attention,                            // name
+    kMSDomain,                            // domain
+    1,                                    // ver
+    float,                                // type
+    kCudaExecutionProvider,               // provider
+    KernelDefBuilder()                    // builder
+        .TypeConstraint("T", DataTypeImpl::GetTensorType<float>())
+        .InputMemoryType(OrtMemTypeCPUInput, {3, 4}),
+    &cuda::EstimateAttentionWorkspace,    // estimate_fn  ← NEW argument
+    cuda::Attention<float>);              // kernel class (__VA_ARGS__)
+```
+
+Kernels without estimation continue using `ONNX_OPERATOR_TYPED_KERNEL_EX` unchanged — their `workspace_estimate_func` is `nullptr`, and the budget logic applies the 1.5x multiplier as today. The migration is opt-in, kernel by kernel.
 
 **Integration with GetCapability and the resource budget:**
 
@@ -480,48 +557,66 @@ This produces the **exact same result** as the kernel would compute during `Decl
 
 **Why no public API for device properties or library handles:** The estimation function is registered BY the EP for ITS kernels — it's EP-specific code running in the EP's own DLL. It can safely cast `OrtEp*` to its concrete type (e.g., `CudaEp*`) to access device_prop, cuDNN handles, etc. This is the same pattern kernels already use: `static_cast<const CUDAExecutionProvider*>(info.GetExecutionProvider())->GetDeviceProp()`. No generic `Ep_GetCudnnHandle` or `Ep_GetDeviceIntProperty` API is needed — that would be CUDA-specific pollution of the universal EP interface.
 
-**Level 2 — Verification and diagnostics (after kernel creation):**
+**Level 2 — Post-fusion budget re-check (before InsertCast and MemcpyTransformer):**
 
-After EP assignment and kernel creation, during `FinalizeSessionState()`:
+The `TransformGraph()` pipeline has a natural insertion point after EP-specific optimizers but before the transformers that bake in EP boundaries:
 
-1. Call `DeclareWorkspaceRequirements()` on all kernel instances → get exact workspace sizes.
-2. Compute actual total memory: initializers + peak activations + peak workspace.
-3. If actual total ≤ budget → proceed normally (log confirmation at verbose level).
-4. If actual total > budget → **log a warning** with the overrun amount and the nodes contributing most workspace. Do NOT attempt to reassign nodes.
+```
+L1 optimizers → Partition (GetCapability) → L2/L3 EP-specific optimizers → [HERE] → InsertCastTransformer → L4 → MemcpyTransformer
+```
 
-**What does `DeclareWorkspaceRequirements()` have that `EstimateWorkspace()` doesn't?**
+At `[HERE]`:
+- Nodes are assigned to EPs ✓
+- EP-specific fusions (ConvRelu, FusedMatMul, etc.) have already been applied ✓
+- The graph reflects the *actual* ops that will become kernels ✓
+- Cast nodes have NOT been inserted yet ✓ (no fp16↔fp32 casts at boundaries)
+- Memcpy nodes have NOT been inserted yet ✓ (boundaries can still move)
+- Kernels do NOT exist yet ✗ (cannot call `DeclareWorkspaceRequirements`)
 
-Both run during static initialization (not runtime). Both have access to static shapes, node attributes, and the EP's device state. In the common case, they should produce **identical answers** — they call the same shared helper with the same inputs. The design intentionally makes them equivalent.
+**Why before InsertCastTransformer:** The InsertCastTransformer inserts fp16↔fp32 Cast nodes at EP boundaries where input/output types don't match. If we offload nodes *after* Cast insertion, we'd leave orphaned Cast nodes at the old boundary and need new ones at the new boundary — similar to the MemcpyTransformer problem. By running before both, any Cast and Memcpy nodes are inserted at the final (post-offload) boundaries.
 
-However, `DeclareWorkspaceRequirements()` runs *after* one additional pipeline stage that can (in narrow cases) change what a node looks like:
+Since kernels don't exist, we call the **same `EstimateWorkspace()` functions** from Level 1 — but now on the post-fusion graph. This eliminates the only meaningful gap between Level 1 and Level 2: fused ops that didn't exist at `GetCapability()` time now have their own estimation functions registered alongside their kernel definitions.
 
-1. **EP-specific graph transforms (Level 2/3 optimizers):** These run *after* `GetCapability()` partitions the graph. They can fuse adjacent nodes within an EP's subgraph (e.g., Conv+Relu → ConvRelu, MatMul+Add → FusedMatMul). The fused node is a *different op* than the original — its workspace may differ from the sum of the parts. The estimation function at Level 1 was called on the pre-fusion nodes; `DeclareWorkspaceRequirements()` is called on the post-fusion kernel.
+**Algorithm:**
 
-2. **Kernel constructor decisions:** The constructor has access to the full `OpKernelInfo` including all inputs, attributes, and EP state simultaneously. Some kernels select between code paths based on complex multi-factor heuristics (e.g., "use flash path if head_size ≤ 128 AND sm ≥ 80 AND no causal mask" vs "use unfused path otherwise"). The estimation function must replicate this logic exactly — a bug there would cause divergence.
+1. For each node assigned to the constrained EP, look up its `OrtKernelWorkspaceEstimateFunc` from the kernel registry (same registry that will later be used to create the kernel).
+2. Call the estimation function on the (possibly fused) node → get workspace.
+3. Re-run the budget check: `base_cost + workspace` for all assigned nodes.
+4. If total ≤ budget → proceed to InsertCastTransformer/MemcpyTransformer normally.
+5. If total > budget → **log a warning** and proceed. Do NOT attempt to offload nodes.
 
-**In practice, divergence is rare because:**
-- Fused ops (case 1) typically don't exist in the kernel registry at Level 1 — they're created by the fusion transformer itself, which knows their workspace needs. The estimation function for a fused op would be registered alongside the fused kernel.
-- Constructor logic (case 2) is the same arithmetic the estimation function replicates.
+**Why warn-only (no runtime offload):**
 
-**The honest assessment:** For well-written estimation functions operating on models with static shapes, Level 2 should agree with Level 1 100% of the time. Level 2's value is purely as a **development-time assertion** — catching bugs in estimation functions during testing, not as a production safety net.
+The earlier design attempted tail-node offloading at this stage — walking backward through GPU-assigned nodes and reassigning them to CPU. In practice, this is problematic:
 
-**Why we cannot reassign nodes at this stage:**
+- **For bf16/fp16 models** (the dominant constrained-VRAM use case): CPU EP lacks kernels for most bf16/fp16 compute ops (MatMul, Attention, LayerNorm). The offload loop would hit a non-offloadable node almost immediately and accomplish nothing.
+- **For fp32 CNN models** (where CPU *could* handle offloaded ops): The performance cost of GPU→CPU→GPU data transfers typically outweighs the memory benefit of offloading a few tail nodes.
+- **Complexity vs value**: Offload logic (type checking, contiguous-tail constraint, boundary correctness) adds significant code for a feature that rarely fires and rarely helps.
 
-The MemcpyTransformer (which inserts data-copy nodes at EP boundaries) runs during graph transformation — well before `FinalizeSessionState()`. By the time kernels exist and exact workspace is known, the graph already has Memcpy nodes baked in at the original partition boundaries. Reassigning tail nodes to CPU would require:
-- Removing the now-incorrect Memcpy nodes at the old boundary
-- Inserting new Memcpy nodes at the new boundary
-- Re-running shape inference on affected subgraphs
-- Re-creating kernels for the moved nodes under a different EP
+The correct fix for a Level 2 budget overrun is to **improve Level 1 accuracy** — make the estimation functions precise enough that post-fusion re-check merely confirms (not corrects) the budget. Level 2 serves as a **diagnostic safety net**: if the warning fires, it indicates the Level 1 estimate was too optimistic, and the estimation function for the offending kernel(s) should be improved.
 
-This is effectively re-running a portion of `Initialize()` — not a simple post-hoc trim. The complexity and fragility of partial re-partitioning at this stage makes it impractical.
+```cpp
+// Pseudo-code in TransformGraph, after L2/L3, before InsertCastTransformer:
+if (level2_total > budget) {
+    size_t overrun = level2_total - budget;
+    LOGS(logger, WARNING)
+        << "Post-fusion budget re-check: EP '" << ep_type
+        << "' exceeds memory budget by " << overrun << " bytes. "
+        << "Level 1 estimation was too optimistic. "
+        << "Consider improving workspace estimation for fused ops. "
+        << "Proceeding — runtime OOM may occur.";
+}
+```
 
-**Design philosophy: get it right in Level 1.**
+This keeps the pipeline simple: Level 2 is purely observational (re-check + warn), not interventional. If the warning fires in testing, the developer improves the relevant `EstimateWorkspace()` function. In production, the budget was validated at Level 1 and Level 2 divergence should be rare.
 
-The estimation functions demonstrated above (Attention, Conv) produce **exact** workspace sizes using the same logic and data the kernel will use. For 75% of workspace-consuming kernels, shapes alone determine workspace (pure arithmetic). For another 16%, the cuDNN heuristic planner gives exact answers. The remaining ~12% (MOE, MatMulNBits) use upper-bound estimates that are tight.
+**Why Level 2 exists separately from Level 1:**
 
-Given this precision, Level 2 serves as a **diagnostic check**, not a correction mechanism:
-- If the estimate matches → confirms the system is working correctly.
-- If the estimate under-shot → the warning alerts the developer that a particular kernel's estimation function needs improvement. This is a bug to fix in the estimation function, not a runtime recovery scenario.
+Level 1 (during `GetCapability()`) operates on the **pre-fusion** graph. It estimates workspace for the original unfused nodes (Conv, Relu separately). Level 2 operates on the **post-fusion** graph (ConvRelu as a single node). The two can diverge when:
+- A fused op's workspace differs from the sum of its parts (common — fusion often reduces workspace)
+- Level 2/3 optimizers add or remove nodes (e.g., constant folding eliminates a node entirely)
+
+For most LLM models (which are repetitive transformer blocks with minimal fusion opportunity), Level 1 and Level 2 will agree. Level 2 matters more for CNN models with heavy fusion (Conv+BN+Relu patterns).
 
 **When static shapes are unavailable:**
 
@@ -832,17 +927,71 @@ Workspace pre-allocation follows the same model:
 
 **Note on CUDA:** In practice, concurrent `Run()` on the same CUDA session is uncommon (users don't typically do this). But the design should remain thread-safe by following the same per-run buffer pattern.
 
+**Single-thread pre-allocation mode (eliminating runtime OOM):**
+
+Even with workspace planning, the per-`Run()` buffer allocation can still OOM if device memory is fragmented or consumed by other processes since `Initialize()`. For constrained environments, this is the last remaining point of failure.
+
+Most constrained-environment users run **single-threaded inference** — one `Run()` at a time. ORT already has a concurrent-run counter (`InferenceSession::current_num_runs_`). If the session is configured to disallow concurrency, the execution buffer (which includes workspace slots) can be **allocated once at initialization and reused for every `Run()` call**:
+
+```cpp
+session_options.AddConfigEntry("session.pre_allocate_execution_buffers", "1");
+```
+
+When enabled:
+1. After `FinalizeSessionState()` computes the memory pattern (including workspace offsets from `DeclareWorkspaceRequirements`), allocate the peak buffer once: `IAllocator::Alloc(peak_size)` per EP.
+2. Store the pre-allocated buffer pointer on `SessionState`.
+3. Each `Run()` reuses the same buffer — no allocation, no OOM possible.
+4. Enforce `max_concurrent_runs = 1`: if a second `Run()` arrives, fail fast.
+
+```cpp
+if (pre_allocate_mode_ && current_num_runs_.fetch_add(1) > 0) {
+    current_num_runs_.fetch_sub(1);
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
+        "Concurrent Run() not allowed with pre-allocated execution buffers.");
+}
+```
+
+**What this guarantees:** If `Initialize()` succeeds, `Run()` cannot OOM — all device memory (weights + intermediates + workspace) is already resident. The budget at partition time accounts for all three: `budget ≥ weights_on_device + peak_execution_buffer`.
+
+**What already exists:** `MemoryPattern` computation is done, `MemoryPatternGroup::GetPeakAllocSize()` gives peak size, `current_num_runs_` counter exists, per-EP allocators exist. The `ExecutionFrame` already uses offset-based placement into a contiguous block — the change is to not free/reallocate that block between calls.
+
+**Scope:** Single-threaded only. For concurrent inference, multiple buffers are needed (defeating the guarantee).
+
+**Interaction with dynamic shapes:** `pre_allocate_execution_buffers` is fundamentally a **static-shape-only** feature. With dynamic shapes, `ExecutionFrame` must allocate buffers on every `Run()` because activation tensor sizes are unknown until the input arrives — there is no way to pre-compute a total buffer size at `Initialize()` time. Even if some kernels' workspace slots are shape-independent, the activation portion (which typically dominates) still requires per-`Run()` allocation, so the OOM-elimination guarantee cannot hold.
+
+Furthermore, the arena allocator already handles repeated allocations efficiently (same-size blocks are recycled without syscalls), so pre-allocating just the workspace portion while leaving activations dynamic would add complexity for negligible gain.
+
+**Summary:** For dynamic-shape models, the value of `DeclareWorkspaceRequirements` is in **budget estimation** (Level 1/Level 2, using worst-case or max-batch sizes to decide how many nodes fit on the device), not in runtime pre-allocation.
+
 **Planning flow (during FinalizeSessionState):**
 
 1. For each kernel in the execution plan (when shapes are static), call `DeclareWorkspaceRequirements()` with the inferred input shapes.
 2. Record `{NodeIndex, slot_id} → size_bytes` in the execution plan.
 3. Run liveness analysis: workspace for node N is live only during step N's execution.
 4. Compute offsets (same algorithm as activation patterns) → yields `peak_workspace_size` and per-slot offsets.
-5. Store workspace pattern in `SessionState` (like memory patterns).
+5. Store workspace pattern as a **separate `WorkspacePattern`** in `SessionState`.
+
+**Why workspace buffers are separate from `MemoryPattern` (activations):**
+
+Although the offset planning algorithm is the same (liveness → assign offsets → compute peak), workspace buffers differ in allocation and retrieval:
+
+| Aspect | MemoryPattern (activations) | WorkspacePattern |
+|--------|---------------------------|------------------|
+| **Addressing** | `MLValueIndex` — framework-assigned, part of graph IR | `(NodeIndex, slot_id)` — kernel-defined, opaque to framework |
+| **Who queries** | Framework automatically when creating output `OrtValue`s | Kernel explicitly via `GetPreallocatedWorkspace(slot_id)` |
+| **Lifetime** | Multi-step — output lives until its last consumer executes | Single-step — live only during the owning kernel's step |
+| **What's returned** | An `OrtValue` (typed tensor with shape metadata) | Raw `void*` — kernel interprets the bytes internally |
+| **Graph visibility** | Framework manages these as edges between nodes | Invisible to graph — internal scratch memory |
+| **Size determination** | Inferred from output shape × element_size | Declared by kernel (may be unrelated to any tensor shape) |
+
+Concretely, this means:
+- `WorkspacePattern` is a new class (not reusing `MemoryPatternGroup`) with its own lookup: `GetOffset(NodeIndex, slot_id) → {offset, size}`.
+- The workspace buffer is allocated separately from the activation buffer. They could share physical memory (workspace is always single-step, so it never overlaps with itself across steps), but keeping them separate simplifies accounting and makes budget tracking unambiguous: `peak_total = peak_activations + peak_workspace`.
+- In pre-allocation mode, both buffers are allocated once at init. In normal mode, both are allocated per-`Run()` from the arena. But they remain distinct allocations with distinct query paths.
 
 **Per-Run retrieval (during Compute):**
 
-Each `ExecutionFrame` allocates a workspace buffer of `peak_workspace_size` via `Reserve()` and provides offset-based access:
+Each `ExecutionFrame` allocates a workspace buffer of `peak_workspace_size` via the EP's allocator and provides offset-based access through a dedicated query interface (not the existing OrtValue/MLValue machinery):
 
 **Alternative A: Transparent fallback in GetScratchBuffer**
 
@@ -1024,14 +1173,30 @@ A minimal custom executable (CLI tool) serves three purposes:
 
 | Concern | Status | Notes |
 |---------|--------|-------|
-| Tokenizer | External dependency | ORT core has no tokenizer. Options: link sentencepiece, use onnxruntime-extensions, or bundle minimal BPE |
+| Tokenizer | Reuse from ORT Extensions | See tokenizer strategy below |
 | KV cache rotation | Straightforward | Pre-allocate `(batch, heads, max_seq, head_dim)`, feed `past_key_values` outputs back as inputs each step |
 | Decode loop | Trivial | Run session → extract logits → sample token → repeat |
 | Model format | Constraint | Requires decoder-style ONNX export with explicit KV cache I/O (HuggingFace optimum exports provide this) |
 | Partitioning | This design | Direction 1 + `IResourceAccountant` |
 | Static allocation | Phase A+B | Fixed `max_seq_len` makes all decode-phase shapes static |
 
-The executable would be ~500–1000 LOC (excluding tokenizer): configure session options, set up KV cache tensors, run the generate loop. The tokenizer is the only non-trivial external dependency.
+**Tokenizer strategy — borrowing from ORT Extensions:**
+
+[ORT Extensions](https://github.com/microsoft/onnxruntime-extensions) already implements production-quality tokenizers in C++:
+- **BPE** (GPT-2, LLaMA-3, Phi, Mistral) — `onnxruntime_extensions/tokenizer/bpe_tokenizer.cc`
+- **SentencePiece** (LLaMA-1/2, T5, mT5) — wraps the SentencePiece C++ library
+- **WordPiece** (BERT, DistilBERT) — `onnxruntime_extensions/tokenizer/wordpiece_tokenizer.cc`
+
+For the custom executable, we can **extract the tokenizer C++ code directly** from ORT Extensions rather than taking a full dependency on the extensions DLL. The tokenizer logic is self-contained: it reads a vocabulary/merge file, applies the algorithm (BPE merge loop, SentencePiece unigram, or WordPiece greedy match), and produces token IDs. No ONNX graph execution is involved.
+
+**Practical approach:**
+1. Copy the relevant tokenizer source files (BPE tokenizer is ~500 LOC + vocab loading) into the demo executable's source tree.
+2. Strip the ORT Extensions custom-op registration wrapper — keep only the core `Encode(string) → vector<int>` and `Decode(vector<int>) → string` logic.
+3. Load the tokenizer model file (e.g., `tokenizer.json` from HuggingFace, or `tokenizer.model` for SentencePiece) at startup alongside the ONNX model.
+
+This gives us a battle-tested tokenizer with no additional runtime dependency — just a few source files compiled into the executable. The code is already Apache-2.0 licensed (same as ORT).
+
+The executable would be ~500–1000 LOC (excluding tokenizer): configure session options, set up KV cache tensors, run the generate loop. With the borrowed tokenizer code, the total grows to ~1500–2000 LOC but remains self-contained with zero external dependencies beyond ORT itself.
 
 ---
 

--- a/docs/annotated_partitioning/future_directions_constrained_env.md
+++ b/docs/annotated_partitioning/future_directions_constrained_env.md
@@ -56,7 +56,7 @@ A config like `gpu(layers.0, layers.1, ..., layers.15); cpu(layers.16, ..., laye
    - Keeps the existing parser/grammar unchanged (reuse the `device(pattern1, pattern2, ...); ...` syntax)
    - Uses a **new `SubstringMatcher`** (not the existing trie-based `LayeringRuleMatcher`) for the actual matching
    - Makes intent explicit — users opt into name-based matching deliberately
-   - Both options can coexist (annotation-based takes priority if both match a node)
+   - The two options are **mutually exclusive** — setting both returns an error
    - No risk of breaking existing annotation-based workflows
 
 3. **Build index at load time.** During `InferenceSession::Initialize()`, after graph is loaded but before partitioning:
@@ -136,22 +136,27 @@ Without it, `layers.1` (a substring of `layers.10`, `layers.11`, ..., `layers.19
 
 **Integration with `LayeringIndex`:**
 
-`LayeringIndex` currently owns a `LayeringRuleMatcher`. For name-based mode, it would own a `SubstringMatcher` instead (or additionally, if both annotation-based and name-based configs are present). The `ProcessGraph` method gains a branch:
+`LayeringIndex` owns either a `LayeringRuleMatcher` (annotation mode) or a `SubstringMatcher` (name-based mode) — the two are mutually exclusive. The `ProcessGraph` method branches based on which mode is active:
 
 ```cpp
-void LayeringIndex::ProcessGraph(const Graph& graph) {
+void LayeringIndex::ProcessGraph(const Graph& graph, std::optional<size_t> parent_layer_id) {
   for (const auto& node : graph.Nodes()) {
     std::optional<size_t> matched_rule_idx;
 
-    // Annotation-based matching (existing, higher priority)
-    const std::string& annotation = node.GetLayeringAnnotation();
-    if (!annotation.empty()) {
-      matched_rule_idx = matcher_.Match(annotation);
-    }
-
-    // Name-based matching (new, fallback if no annotation match)
-    if (!matched_rule_idx && substring_matcher_) {
+    if (substring_matcher_) {
+      // Name-based mode: substring match against node name, no inheritance.
+      // Node names are dense, so each node is matched independently.
       matched_rule_idx = substring_matcher_->Match(node.Name());
+    } else {
+      // Annotation-based mode: prefix/exact match against metadata,
+      // with subgraph inheritance for unannotated nodes.
+      const std::string& annotation = node.GetLayeringAnnotation();
+      if (!annotation.empty()) {
+        matched_rule_idx = matcher_.Match(annotation);
+      }
+      if (!matched_rule_idx && parent_layer_id) {
+        matched_rule_idx = parent_layer_id;
+      }
     }
 
     if (matched_rule_idx) {
@@ -161,7 +166,9 @@ void LayeringIndex::ProcessGraph(const Graph& graph) {
 }
 ```
 
-This preserves annotation-based priority (if a node has both an annotation and a matching name pattern, annotation wins) while enabling name-based matching for unannotated models.
+**Why mutual exclusivity (not priority/fallback):**
+
+The two modes have fundamentally different inheritance semantics. Annotations are sparse — nodes without annotations inherit from their subgraph parent to maintain device consistency. Names are dense — virtually every node has a name, so inheritance is unnecessary and would incorrectly override name-based matches in subgraphs. Making the modes mutually exclusive keeps the semantics simple and predictable.
 
 ### Advantages
 

--- a/docs/annotated_partitioning/future_directions_constrained_env.md
+++ b/docs/annotated_partitioning/future_directions_constrained_env.md
@@ -120,16 +120,25 @@ new_node.SetExecutionProviderType(original_node.GetExecutionProviderType());
 
 ---
 
-## Direction 2: Static Shape Pre-allocation (ollama/llama.cpp Style)
+## Direction 2: Minimize Allocations for Static-Shape Models
 
-### What ollama Does
+### Goal
 
-llama.cpp (and by extension ollama) exploits that transformer inference has **fully deterministic memory usage**:
+For models with fully static shapes (common in transformer inference with fixed batch/sequence dimensions), ORT should minimize or eliminate runtime memory allocations. When all tensor shapes are known at `Initialize()` time, the runtime can pre-compute exact memory requirements and pre-allocate everything upfront — no arena overhead, no per-`Run()` allocation calls, deterministic memory usage.
+
+Additionally, by knowing exact memory requirements before execution begins, ORT can **minimize the chance of running into OOM** — if the total memory needed exceeds device capacity, the session can fail at `Initialize()` time with a clear error rather than crashing mid-inference with an opaque allocation failure.
+
+This brings ORT's allocation efficiency on par with specialized runtimes like llama.cpp, while retaining ORT's generality for arbitrary model architectures.
+
+### Reference: What llama.cpp Does
+
+llama.cpp exploits that transformer inference has **fully deterministic memory usage**:
 - All weight tensors are known at load time
 - KV cache is pre-allocated for max sequence length
 - Intermediate activation buffers have shapes determined by `(batch, seq_len, hidden_dim)` — all known in advance
+- Workspace/temp buffers are known per-op and pre-planned
 
-This means the runtime can compute **exactly** how much memory each layer needs before running, enabling precise layer-by-layer offloading decisions.
+This means the runtime computes **exactly** how much memory is needed before running — zero allocation calls during inference.
 
 ### What ORT Already Does
 
@@ -166,7 +175,7 @@ This provides stream-aware pooling managed by the CUDA driver, with less memory 
 
 **Note on actual memory consumption:** While these give exact logical tensor sizes, actual device memory will be rounded up to page/alignment boundaries — either per allocation or for a single large buffer. The reported sizes are a lower bound; real usage includes alignment overhead.
 
-It applies a **1.5x safety multiplier** to account for unknowable temp/workspace allocations. This multiplier exists because temp buffer sizes are discovered only at runtime — no kernel declares its workspace needs in advance.
+It applies a **1.5x safety multiplier** to account for unknowable temp/workspace allocations. This multiplier exists because temp buffer sizes are discovered only at runtime — no kernel declares its workspace needs in advance. **For static-shape models where `DeclareWorkspaceRequirements` (Phase A below) has been implemented for all relevant kernels, this multiplier becomes unnecessary and should be bypassed** — exact workspace sizes are known at planning time, eliminating the need for a safety margin.
 
 **Per-node accounting (not per-layer)**: `IResourceAccountant` tracks costs at the node/subgraph level — `nodes_costs` in `IndexedSubGraph` is for accounting after an EP claims nodes (single nodes or fused groups), not for layering. It has no concept of "layer" as defined by the layering index.
 
@@ -201,9 +210,19 @@ To eliminate both the multiplier and arena waste for temp buffers, two problems 
 | Pre-allocated activation buffers | Yes — fixed slots | Yes — memory patterns with liveness reuse | ✓ Already exists for static shapes |
 | Workspace pre-computation | Yes — known per op | No — kernels discover at runtime | Need `DeclareWorkspaceRequirements()` on kernels |
 | Workspace outside arena | Yes — part of static plan | No — `GetScratchBuffer()` uses arena | Need to include workspace in memory pattern plan |
-| Zero-copy weight transfer | mmap + `cudaMemcpy` per layer | EP-managed transfers during initialization | Relevant only for Phase D (prefetch/offload pipeline) — see below |
+| Zero-copy weight transfer | mmap + `cudaMemcpy` at load per layer | mmap + `cudaMemcpy` at load per partition | ✓ Same model — not a gap |
 
-**Note on "zero-copy device transfer":** In llama.cpp, model weights are memory-mapped (`mmap`) from disk, and individual layers are streamed to GPU via `cudaMemcpy`/`cudaMemcpyAsync` on demand — the CPU never allocates a separate copy, it reads directly from the mmap'd file into GPU memory. In ORT today, initializers are deserialized from protobuf into host memory, then copied to device during session state finalization — all upfront, not on-demand per layer. "Zero-copy" here refers to eliminating the intermediate host allocation: mapping weights directly from file to device. This is primarily relevant for the prefetch/offload pipeline (Phase D) where layers are streamed to GPU during execution rather than all loaded at once.
+**Note on weight transfer:** Both llama.cpp and ORT use the same approach: **static partitioning at load time, no dynamic weight swapping during inference.**
+
+- **llama.cpp**: User sets `-ngl N` (number of GPU layers). At load time, those N layers' weights are `cudaMemcpy`'d from mmap'd file to GPU. Remaining layers stay in host memory. No runtime swapping — this is performant because there is zero weight transfer overhead during token generation.
+- **ORT (with constrained partitioning)**: The layering index + `IResourceAccountant` determines which nodes run on GPU. At `Initialize()` time, only those nodes' initializers are copied to device from mmap'd external data. Remaining weights stay in host memory.
+
+**Best practice for constrained environments:** Model weights should be stored as **external data on disk** (not embedded in protobuf). This ensures:
+1. ORT memory-maps the file — minimal host memory overhead during loading.
+2. Only GPU-partitioned nodes' weights are copied to device — no OOM as long as partitioning respects the budget.
+3. CPU-partitioned nodes' weights remain accessible via mmap without requiring a separate host allocation.
+
+Since partitioning is decided once at `Initialize()` time and all required device weights are resident before `Run()`, there is no need for dynamic layer loading/offloading during inference.
 
 ### How to Approach
 
@@ -317,6 +336,102 @@ Pro: Clear separation, no ambiguity about ownership. Con: Kernels need explicit 
 
 **Buffer strategy:** Workspace offsets can share the activation buffer (liveness doesn't overlap — workspace is live only during its step, activations may span steps). Alternatively, a separate workspace buffer is simpler initially and easier to account for in memory limits.
 
+##### EP Plugin C ABI Surface for Workspace Pre-declaration
+
+In the plugin architecture, `DeclareWorkspaceRequirements` crosses the C ABI boundary. This section defines the concrete API additions.
+
+**Declaration side — new optional function pointer on `OrtKernelImpl`:**
+
+```c
+// Added to OrtKernelImpl (optional, like PrePackWeight):
+ORT_API2_STATUS(DeclareWorkspaceRequirements,
+    _In_ OrtKernelImpl* this_ptr,
+    _In_reads_(num_inputs) const int64_t* const* input_shapes,   // shape per input
+    _In_reads_(num_inputs) const size_t* input_shape_ranks,      // rank per input
+    _In_ size_t num_inputs,
+    _Out_writes_all_(max_slots) OrtWorkspaceSlot* slots,         // pre-allocated by ORT
+    _In_ size_t max_slots,                                        // capacity (e.g., 8)
+    _Out_ size_t* num_slots);                                     // actual count filled
+
+// Slot descriptor (C struct, no inheritance):
+typedef struct OrtWorkspaceSlot {
+  int slot_id;          // Kernel-defined, stable identifier (0, 1, 2, ...)
+  size_t size_bytes;    // Required size for this slot
+} OrtWorkspaceSlot;
+```
+
+If `DeclareWorkspaceRequirements` is NULL on the `OrtKernelImpl`, ORT skips the kernel during workspace planning (falls back to arena at runtime).
+
+**Retrieval side — new function in `OrtEpApi`:**
+
+```c
+// Added to OrtEpApi (called by plugin kernels during Compute):
+ORT_API2_STATUS(KernelContext_GetPreallocatedWorkspace,
+    _In_ const OrtKernelContext* context,
+    _In_ int slot_id,
+    _Outptr_result_maybenull_ void** buffer);   // NULL if not pre-planned
+```
+
+Returns a pointer into the pre-allocated workspace buffer at the offset computed during planning. Returns NULL if no workspace was pre-planned for this kernel+slot (dynamic shapes, or kernel didn't declare). The pointer is valid for the duration of the `Compute()` call.
+
+**Slot ID provisioning — how kernels define unique slot_ids:**
+
+Slot IDs are **kernel-author-defined constants**, not dynamically allocated. Each kernel class defines its slots as an enum or set of constants in its implementation:
+
+```cpp
+// Example: CUDA Attention kernel (inside the plugin DLL)
+namespace cuda {
+class AttentionKernel : public OrtKernelImplBase {
+  // Slot IDs are private constants — stable across versions, used as array indices
+  static constexpr size_t kSlotQTranspose = 0;
+  static constexpr size_t kSlotKTranspose = 1;
+  static constexpr size_t kSlotVTranspose = 2;
+  static constexpr size_t kSlotSoftmaxWorkspace = 3;
+  static constexpr size_t kNumSlots = 4;
+
+  OrtStatus* DeclareWorkspaceRequirements(...) override {
+    slots[kSlotQTranspose] = {kSlotQTranspose, batch * heads * seq * head_dim * sizeof(half)};
+    slots[kSlotKTranspose] = {kSlotKTranspose, batch * heads * seq * head_dim * sizeof(half)};
+    slots[kSlotVTranspose] = {kSlotVTranspose, batch * heads * seq * head_dim * sizeof(half)};
+    slots[kSlotSoftmaxWorkspace] = {kSlotSoftmaxWorkspace, cudnn_workspace_size};
+    *num_slots = kNumSlots;
+    return nullptr;
+  }
+
+  OrtStatus* Compute(OrtKernelContext* ctx) override {
+    void* q_buf = nullptr;
+    // Uses pre-planned workspace if available, falls back to arena otherwise
+    api_->KernelContext_GetScratchBuffer(ctx, kSlotQTranspose, q_transpose_size, &q_buf);
+    // ... use q_buf ...
+  }
+};
+}  // namespace cuda
+```
+
+**Key design properties:**
+
+| Property | Design Choice | Rationale |
+|----------|--------------|-----------|
+| Slot ID scope | Per kernel *instance* (node) | Same kernel class on different nodes gets separate buffers; ORT disambiguates via `(NodeIndex, slot_id)` |
+| Slot ID assignment | Static constants in kernel code | No registry, no runtime allocation, no cross-kernel coordination needed |
+| Slot ID range | `[0, max_slots)` — small integers | Simple array indexing in the offset plan; `max_slots` = 8 is generous for any single kernel |
+| Uniqueness guarantee | Kernel author's responsibility | Same convention as `input_index` in `PrePackWeight` — the kernel knows its own buffer layout |
+| Stability across versions | Expected (like enum values) | Slot IDs are internal to the kernel; not exposed to users or other kernels |
+
+**Where state lives:**
+
+| State | Location | Lifetime |
+|-------|----------|----------|
+| Slot definitions (id + size) | Returned by `DeclareWorkspaceRequirements` → stored in `ExecutionPlan` | Session lifetime (computed once at `Initialize()`) |
+| Offset map `{(NodeIndex, slot_id) → offset}` | `SessionState::workspace_pattern_` (new field, analogous to `mem_patterns_`) | Session lifetime (shared, read-only) |
+| Peak workspace size per EP/device | `SessionState::workspace_pattern_` | Session lifetime |
+| Actual workspace buffer | `ExecutionFrame` (allocated per-`Run()` via `Reserve()`) | Single `Run()` invocation |
+
+**No global slot registry needed.** Unlike input indices which are defined by the ONNX op schema, slot IDs are entirely internal to the kernel implementation. Two different kernel classes can both use `slot_id=0` without conflict — the framework always qualifies with `NodeIndex`. This means:
+- No coordination between kernel authors
+- No registration step during plugin initialization
+- No versioning concerns (IDs never cross the plugin boundary as semantic values)
+
 #### Phase B: Eliminate Arena for Static-Shape Models
 
 Once workspace is pre-declared, **all** allocations for a static-shape model are known at `Initialize()` time:
@@ -331,45 +446,39 @@ At this point, the BFC arena serves no purpose for the main execution path. The 
 
 Runtime temp buffers from ops that don't implement `DeclareWorkspaceRequirements()` can still fall back to a small arena.
 
-#### Phase C: Automatic Partitioning with Memory Budget
+### Custom Executable: Purpose and Scope
 
-Combine Phase A + Direction 1:
+A minimal custom executable (CLI tool) serves three purposes:
 
-```
-# User specifies only the budget, ORT figures out the split:
-session.resource_cuda_partitioning_settings = "memory_limit=6GB"
-```
+1. **Code example and test bed.** Demonstrates how to configure and exercise the constrained-environment features (name-based partitioning, memory budgets, static allocation mode) end-to-end using the ORT C/C++ API. Acts as a living integration test that exercises the full pipeline without depending on GenAI or external frameworks.
 
-Flow:
-1. Load model, run shape inference for target input shapes
-2. Compute per-layer memory requirements
-3. Greedily assign layers to GPU until budget exhausted
-4. Remaining layers → CPU
-5. Optionally: overlap CPU compute with GPU→CPU transfers (pipeline)
+2. **Interactive LLM demo (llama.cpp-style UX).** Loads a transformer ONNX model, manages the decode loop (prompt → KV cache → token sampling → output), and interacts with the user via stdin/stdout. This showcases ORT's ability to run large models on constrained hardware with the same user experience as llama.cpp — but backed by ORT's general-purpose runtime.
 
-#### Phase D: Layer Prefetch/Offload Pipeline
+3. **Primitive GenAI replacement for testing.** For the narrow case of single-model, single-user, greedy/top-k text generation, the executable can replace GenAI as a simpler alternative that doesn't pull in the full GenAI dependency. It is **not** a production replacement for GenAI (no batching, no beam search, no speculative decoding) — it is a minimal harness for validating that the partitioning and memory features work correctly on real models.
 
-For models that don't fit in GPU at all, but where layer-sequential execution allows streaming:
+**What the executable handles (application-level):**
+- Token encode/decode (via sentencepiece or tokenizers library)
+- KV cache allocation and rotation (fixed max sequence length)
+- Autoregressive decode loop (feed output token back as next input)
+- Session configuration: name-based layer assignment, memory budget, static shapes
 
-1. While GPU executes layer N, prefetch layer N+1 weights from CPU→GPU
-2. After layer N completes, offload its weights back (or discard if not needed for backward)
-3. This requires explicit memory management and CUDA stream orchestration
+**What ORT handles (session-level, no executable changes needed):**
+- Graph partitioning across devices (Direction 1 + `IResourceAccountant`)
+- Static memory pre-allocation (Phase A + B)
+- Kernel execution, data transfers, stream synchronization
 
-ORT's existing `Stream` infrastructure in the framework could support this, but would need:
-- A "layer executor" that knows the sequential dependency chain
-- Explicit prefetch scheduling (similar to how `MemoryOptimizer` in training handles activation offload)
+**Feasibility: no fundamental ORT blockers.** The existing session API (`CreateSession` → `Run` with named I/O) is sufficient for an autoregressive decode loop. KV cache management is feeding output tensors back as inputs — the same pattern GenAI uses over the same C API.
 
-### What's Achievable Without a Custom Executable
+| Concern | Status | Notes |
+|---------|--------|-------|
+| Tokenizer | External dependency | ORT core has no tokenizer. Options: link sentencepiece, use onnxruntime-extensions, or bundle minimal BPE |
+| KV cache rotation | Straightforward | Pre-allocate `(batch, heads, max_seq, head_dim)`, feed `past_key_values` outputs back as inputs each step |
+| Decode loop | Trivial | Run session → extract logits → sample token → repeat |
+| Model format | Constraint | Requires decoder-style ONNX export with explicit KV cache I/O (HuggingFace optimum exports provide this) |
+| Partitioning | This design | Direction 1 + `IResourceAccountant` |
+| Static allocation | Phase A+B | Fixed `max_seq_len` makes all decode-phase shapes static |
 
-Unlike llama.cpp which is a monolithic binary, ORT can achieve most of this within the existing session API:
-
-- **Static buffer pre-allocation**: Extend `SessionOptions` with a "static allocation mode" flag + input shape hints
-- **Automatic layer splitting**: Combine name-based matching + memory planning in `Initialize()`
-- **Prefetch pipeline**: Implement as an execution strategy in `SequentialExecutor` when model is detected as layer-sequential
-
-What you **cannot** easily do without a custom executable:
-- Continuous batching / speculative decoding (requires application-level scheduling)
-- Dynamic KV cache management (though GenAI already handles this)
+The executable would be ~500–1000 LOC (excluding tokenizer): configure session options, set up KV cache tensors, run the generate loop. The tokenizer is the only non-trivial external dependency.
 
 ---
 

--- a/docs/annotated_partitioning/future_directions_constrained_env.md
+++ b/docs/annotated_partitioning/future_directions_constrained_env.md
@@ -26,53 +26,147 @@ A config like `gpu(layers.0, layers.1, ..., layers.15); cpu(layers.16, ..., laye
 
 ### How to Approach
 
-1. **Extend `LayeringRuleMatcher` to operate on node names directly.** Today the matcher looks at `node.GetMetadata("layer_ann")`. Add a parallel path that runs the same prefix/substring matching against `node.Name()`. This is a small change — the trie infrastructure already exists.
+1. **Add a new `SubstringMatcher` for node-name matching.** Today the `LayeringRuleMatcher` supports exact match and prefix match (via a trie that walks from position 0 of the input string). Neither mode works for node names: a node named `/model/layers.5/self_attn/q_proj/MatMul` does not *start with* `layers.5` — the identifying substring appears in the middle. Name-based matching fundamentally requires **substring** search. The existing trie infrastructure is irrelevant here — a new, simpler matching approach is needed (see "Substring Matching Implementation" below).
 
-2. **Config via a separate session option (same syntax).** Rather than introducing a new qualifier into the existing `kOrtSessionOptionsLayerAssignmentSettings` syntax, add a parallel session option that uses **the same `device(prefix1, prefix2, ...); ...` grammar** but matches against `Node::Name()` instead of node metadata:
+2. **Config via a separate session option (same grammar, different matcher).** Rather than introducing a new qualifier into the existing `kOrtSessionOptionsLayerAssignmentSettings` syntax, add a parallel session option that uses **the same `device(pattern1, pattern2, ...); ...` grammar** but performs **substring matching** against `Node::Name()` instead of prefix/exact matching against node metadata:
 
    ```cpp
    // Existing (annotation-based, matches node metadata 'layer_ann'):
    static const char* const kOrtSessionOptionsLayerAssignmentSettings =
        "session.layer_assignment_settings";
 
-   // NEW (name-based, matches Node::Name() via substring/prefix):
+   // NEW (name-based, matches Node::Name() via substring):
    static const char* const kOrtSessionOptionsNameBasedLayerAssignment =
        "session.name_based_layer_assignment";
    ```
 
-   Usage stays identical — only the matching target differs:
+   Usage stays identical — only the matching target and algorithm differ:
    ```
-   # Annotation-based (existing):
+   # Annotation-based (existing, prefix/exact match against node metadata):
    session.layer_assignment_settings = "cuda(encoder_layer, attention); cpu(embed)"
 
-   # Name-based (new, same syntax):
-   session.name_based_layer_assignment = "cuda(layers.0, layers.1); cpu(layers.16)"
+   # Name-based (new, substring match against Node::Name()):
+   session.name_based_layer_assignment = "cuda(layers.0/, layers.1/); cpu(layers.16/)"
 
    # Range expressions (future extension, not currently supported):
    session.name_based_layer_assignment = "cuda(layers.[0-15]); cpu(layers.[16-31])"
    ```
 
    This approach:
-   - Keeps the existing parser/grammar unchanged (reuse `LayeringRuleMatcher`)
+   - Keeps the existing parser/grammar unchanged (reuse the `device(pattern1, pattern2, ...); ...` syntax)
+   - Uses a **new `SubstringMatcher`** (not the existing trie-based `LayeringRuleMatcher`) for the actual matching
    - Makes intent explicit — users opt into name-based matching deliberately
    - Both options can coexist (annotation-based takes priority if both match a node)
    - No risk of breaking existing annotation-based workflows
 
 3. **Build index at load time.** During `InferenceSession::Initialize()`, after graph is loaded but before partitioning:
    - If config contains name-based rules, iterate all nodes once
-   - Build `NodeIndex → RuleIndex` map using substring/prefix matching on `Node::Name()`
+   - Build `NodeIndex → RuleIndex` map using substring matching on `Node::Name()`
    - Feed this into the existing `LayeringIndex` infrastructure (same downstream flow)
 
-4. **Range expressions (future extension).** The current `LayeringRuleMatcher` supports only exact match (`=prefix`) and prefix match. It does **not** support range syntax today. For transformer models with numbered layers, a future extension could add range support:
+4. **Range expressions (future extension).** The config grammar does **not** support range syntax today. For transformer models with numbered layers, a future extension could add range support:
    ```
    cuda(layers.[0-15]); cpu(layers.[16-31])
    ```
    This would avoid enumerating 32+ layer prefixes manually, but requires new parsing logic. Until then, users must enumerate each layer prefix explicitly or use a broad prefix like `layers.` that captures all layers for a single device.
 
+### Substring Matching Implementation
+
+The existing `LayeringRuleMatcher` uses a **trie** for prefix matching — it walks the input string from position 0 and checks if any trie path matches a prefix of the input. This only works when the pattern appears at the **start** of the matched string.
+
+For node names, patterns appear in the **middle**:
+```
+Pattern:    "layers.5"
+Node name:  "/model/layers.5/self_attn/q_proj/MatMul"
+                    ^^^^^^^^ — match at position 7, not position 0
+```
+
+The trie is useless here. A new `SubstringMatcher` class is needed.
+
+#### Design: Flat vector + `std::string::find`
+
+The simplest correct approach:
+
+```cpp
+class SubstringMatcher {
+ public:
+  explicit SubstringMatcher(const LayeringRules& rules);
+
+  /// Returns the index of the best matching rule for the given node name.
+  /// "Best" = longest pattern that appears as a substring in the name.
+  std::optional<size_t> Match(std::string_view node_name) const;
+
+ private:
+  // Sorted by pattern length descending — longest patterns checked first.
+  // First match wins (longest-match priority).
+  struct PatternEntry {
+    std::string pattern;
+    size_t rule_index;
+  };
+  InlinedVector<PatternEntry> patterns_;  // sorted longest-first
+};
+```
+
+**Match algorithm:**
+```cpp
+std::optional<size_t> SubstringMatcher::Match(std::string_view node_name) const {
+  for (const auto& entry : patterns_) {
+    if (node_name.find(entry.pattern) != std::string_view::npos) {
+      return entry.rule_index;
+    }
+  }
+  return std::nullopt;
+}
+```
+
+**Why longest-match-first ordering:**
+
+Without it, `layers.1` (a substring of `layers.10`, `layers.11`, ..., `layers.19`) would incorrectly match nodes from layers 10–19. By checking longer patterns first, `layers.10` matches before `layers.1` gets a chance. Users should include the path separator for unambiguous matching: `layers.1/` won't match `layers.10/...`.
+
+**Performance:** With ~64 patterns and node names < 200 chars, this is O(P × N) per node where P = number of patterns and N = name length. Total cost for a 1000-node model: ~64 × 200 × 1000 = ~12M character comparisons. This completes in microseconds on modern hardware and runs only once during `Initialize()`. No optimization (Aho-Corasick, etc.) is warranted.
+
+**Priority semantics:**
+
+| Scenario | Behavior |
+|----------|----------|
+| Single match | Return that rule's index |
+| Multiple matches (different lengths) | Longest pattern wins |
+| Multiple matches (same length, different rules) | First rule in config order wins (stable sort by length, preserving config order as tiebreaker) |
+| No match | Return `nullopt` → node goes to fallback EP (CPU) |
+
+**Integration with `LayeringIndex`:**
+
+`LayeringIndex` currently owns a `LayeringRuleMatcher`. For name-based mode, it would own a `SubstringMatcher` instead (or additionally, if both annotation-based and name-based configs are present). The `ProcessGraph` method gains a branch:
+
+```cpp
+void LayeringIndex::ProcessGraph(const Graph& graph) {
+  for (const auto& node : graph.Nodes()) {
+    std::optional<size_t> matched_rule_idx;
+
+    // Annotation-based matching (existing, higher priority)
+    const std::string& annotation = node.GetLayeringAnnotation();
+    if (!annotation.empty()) {
+      matched_rule_idx = matcher_.Match(annotation);
+    }
+
+    // Name-based matching (new, fallback if no annotation match)
+    if (!matched_rule_idx && substring_matcher_) {
+      matched_rule_idx = substring_matcher_->Match(node.Name());
+    }
+
+    if (matched_rule_idx) {
+      node_to_layering_index_[node.Index()] = *matched_rule_idx;
+    }
+  }
+}
+```
+
+This preserves annotation-based priority (if a node has both an annotation and a matching name pattern, annotation wins) while enabling name-based matching for unannotated models.
+
 ### Advantages
 
 - **Zero model modification** — works with any model that has structured naming
-- **Reuses existing partitioning infrastructure** — only the index-building step changes
+- **Reuses existing partitioning infrastructure** — only the index-building and matching steps change
 - **User-friendly** — users can inspect node names with Netron and write rules directly
 - **Composable with resource accounting** — can combine name-based assignment with memory budgets
 

--- a/docs/annotated_partitioning/future_directions_constrained_env.md
+++ b/docs/annotated_partitioning/future_directions_constrained_env.md
@@ -1298,10 +1298,10 @@ The executable would be ~500–1000 LOC (excluding tokenizer): configure session
 
 ```
 Near-term (low effort, high value):
-├── 1. Name-based matching in LayeringRuleMatcher
-│     - Add 'name:' prefix qualifier to config syntax
-│     - Match against Node::Name() instead of metadata
-│     - Support range expressions for numbered layers
+├── 1. Name-based matching via session.name_based_layer_assignment  [DONE]
+│     - Separate session option with substring matching against Node::Name()
+│     - SubstringMatcher with longest-match-wins priority
+│     - Annotation-based matching takes precedence when both are configured
 │
 ├── 2. Precise per-node memory estimation
 │     - Static workspace estimation functions registered per kernel type

--- a/docs/annotated_partitioning/future_directions_constrained_env.md
+++ b/docs/annotated_partitioning/future_directions_constrained_env.md
@@ -226,6 +226,559 @@ Since partitioning is decided once at `Initialize()` time and all required devic
 
 ### How to Approach
 
+#### The Chicken-and-Egg Problem: Workspace Estimation vs EP Assignment
+
+**Problem statement:** To make precise memory budget decisions during `GetCapability()`, `IResourceAccountant` needs workspace sizes per node. But workspace sizes come from kernels, which don't exist until *after* EP assignment (kernels are created during `Compile()`/session state finalization — same reason `PrePack` happens late). At decision time, you can't ask a kernel that doesn't exist yet.
+
+**Why this matters:** The goal is not to fail gracefully — it's to **avoid failure entirely**. Today, models either OOM on device or trigger heavy VRAM thrashing on Windows. The partitioning must be conservative enough to prevent this, while accurate enough to maximize GPU utilization.
+
+**Solution: Two-level estimation with post-assignment verification and tail-trim**
+
+**Level 1 — Static workspace estimation function (at partitioning time):**
+
+When a kernel is registered (via `KernelRegistry_AddKernel`), optionally provide a **static estimation function** — a class-level function that takes node info and returns a conservative workspace estimate without needing a kernel instance:
+
+```c
+// Registered alongside the kernel definition in KernelRegistry_AddKernel:
+typedef OrtStatus*(ORT_API_CALL* OrtKernelWorkspaceEstimateFunc)(
+    _In_ const OrtEpApi* api,          // for querying node attributes/shapes/device props
+    _In_ const OrtNode* node,          // the specific node being evaluated
+    _In_ const OrtEp* ep,              // EP instance (for device properties like SM count)
+    _Out_ size_t* estimated_workspace_bytes);
+```
+
+The function uses `api->Node_GetAttribute*()` and `api->Node_GetInputShape()` to access the node's attributes and input shapes, and `api->Ep_GetDeviceProperty()` for GPU hardware properties — everything needed to compute workspace without a kernel instance.
+
+**Can the estimate be precise (not just conservative)?**
+
+Depends on the kernel:
+
+| Kernel | Workspace depends on | Available at GetCapability()? | Precise estimate? |
+|--------|---------------------|-------------------------------|-------------------|
+| **Attention (Flash)** | shapes + `num_heads` attr + `device_prop.multiProcessorCount` | ✓ All available (EP has device_prop) | **YES — exact** |
+| **Conv (cuDNN)** | cuDNN `build_plans(handle)` with tensor shapes + conv params | ✓ EP has handle; shapes/attrs available from node | **YES — exact** (with `HEUR_MODE_A`) |
+| **GEMM/MatMul** | No workspace | N/A | N/A (returns 0) |
+
+For **attention**, workspace is determined by `get_num_splits_and_buffer_sizes()` which is pure arithmetic given `(batch, seq, heads, head_size, multiProcessorCount)`. The EP already has `multiProcessorCount` from `cudaGetDeviceProperties()` which runs during EP construction (before `GetCapability()`). So the estimate can be **exact**.
+
+For **cuDNN-based ops** (Conv), the workspace depends on which algorithm cuDNN selects via `build_plans(handle)`. However, a cuDNN handle is just a lightweight context object (`cudnnCreate` + `cudnnSetStream`) — the EP already owns one from construction time. With static shapes, all inputs to `build_plans()` are known: tensor dimensions, conv parameters (from node attributes), and the handle. The `CUDNN_HEUR_MODE_A` (fast heuristic) used by ORT is essentially a lookup + arithmetic — not actual GPU profiling. So the estimation function **can call `build_plans()` and get the exact workspace size**. This makes Conv estimates **precise too**.
+
+The reason `build_plans()` currently runs during first `Compute()` is historical: ORT didn't have a pre-execution workspace declaration phase, and shapes weren't known until runtime. With static shapes and the estimation function pattern, this computation can move earlier.
+
+The estimation function accesses the handle by casting `OrtEp*` to the EP's concrete type (safe because the function is EP-specific code registered by that EP):
+
+```cpp
+auto* cuda_ep = static_cast<const CudaEp*>(ep);  // plugin path
+cudnnHandle_t handle = cuda_ep->GetCudnnHandle();
+```
+
+**Can it be the same function as DeclareWorkspaceRequirements?**
+
+Not the same function pointer (different signatures — one has a kernel instance, one doesn't). But the **core computation logic can be a shared static helper** called from both:
+
+```cpp
+// Shared static helper (no instance needed):
+static size_t ComputeAttentionWorkspace(int batch, int seq, int heads,
+                                         int head_size, int num_SMs) {
+    auto [num_splits, slse_size, o_size] = flash::get_num_splits_and_buffer_sizes(
+        batch, seq, seq, heads, head_size, num_SMs);
+    return flash::get_softmax_lse_size(seq, batch, heads) + slse_size + o_size;
+}
+
+// Estimation function (no kernel instance — called during GetCapability):
+OrtStatus* EstimateAttentionWorkspace(const OrtEpApi* api, const OrtNode* node,
+                                       const OrtEp* ep, size_t* out) {
+    const int64_t* shape; size_t rank;
+    api->Node_GetInputShape(node, 0, &shape, &rank);
+    int64_t num_heads;
+    api->Node_GetAttributeInt(node, "num_heads", &num_heads);
+
+    // EP-specific: cast to concrete type to access device properties
+    auto* cuda_ep = static_cast<const CudaEp*>(ep);
+    int num_SMs = cuda_ep->GetDeviceProp().multiProcessorCount;
+
+    *out = ComputeAttentionWorkspace(shape[0], shape[1], num_heads, shape[3], num_SMs);
+    return nullptr;
+}
+
+// DeclareWorkspaceRequirements (has kernel instance — called during FinalizeSessionState):
+Status Attention::DeclareWorkspaceRequirements(span<const TensorShape> shapes,
+                                               InlinedVector<WorkspaceRequirement>& reqs) {
+    int num_SMs = GetDeviceProp().multiProcessorCount;
+    size_t total = ComputeAttentionWorkspace(
+        shapes[0][0], shapes[0][1], num_heads_, head_size_, num_SMs);
+    reqs.push_back({total, kSlotFlashWorkspace});
+    return Status::OK();
+}
+```
+
+Both call the same `ComputeAttentionWorkspace()` — producing **identical results**. The estimation function gets device properties from the EP; the kernel method gets them from its stored EP reference. Same data, same computation, same answer.
+
+**For cuDNN-based ops**, the estimation function can also be precise — it calls `build_plans()` using the EP's handle and the node's shapes/attributes. The Level 2 tail-trim remains as a safety net for any edge cases (e.g., cuDNN returning different results due to driver version differences between planning and execution).
+
+**KernelCreateInfo and registration macros:**
+
+Today `KernelCreateInfo` contains `{kernel_def, kernel_create_func, status}`. To add the estimation function:
+
+```cpp
+struct KernelCreateInfo {
+  std::unique_ptr<KernelDef> kernel_def;
+  KernelCreateFn kernel_create_func;
+  OrtKernelWorkspaceEstimateFunc workspace_estimate_func;  // NEW — may be nullptr
+  Status status;
+};
+```
+
+The existing `ONNX_OPERATOR_TYPED_KERNEL_EX` macro doesn't need changes — it produces `KernelCreateInfo` via `BuildKernelCreateInfo<>()`. The estimation function can be set separately after construction, or a new macro variant can be introduced:
+
+```cpp
+// Option: set via a builder-style extension after BuildKernelCreateInfo:
+auto info = BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(...)>();
+info.workspace_estimate_func = &EstimateAttentionWorkspace;
+
+// Option: new macro that includes the estimation function:
+// (only for kernels that implement estimation — opt-in)
+```
+
+No existing macros need modification — this is purely additive.
+
+**Integration with GetCapability and the resource budget:**
+
+The estimation function is called during budget enforcement — by the EP directly (in-tree) or by the host bridge (plugin). The result is combined with the base cost from `IResourceAccountant`.
+
+**Multiplier handling — non-member helper approach:**
+
+`ComputeResourceCount()` currently applies a 1.5x multiplier to approximate workspace for kernels without estimation functions. With precise workspace estimates available, the multiplier must be skipped. Rather than changing `ComputeResourceCount()`'s signature, we move the multiplier out and into a non-member helper that encapsulates the budget decision:
+
+```cpp
+// Non-member helper (e.g., in resource_accountant_helpers.h):
+// Called by both in-tree GetCapability and the plugin host bridge.
+ResourceCount ComputeNodeCostForBudget(
+    IResourceAccountant& accountant,
+    const Node& node,
+    std::optional<ResourceCount> workspace_estimate) {
+  // ComputeResourceCount returns base cost: outputs + initializers (dedup'd)
+  // NO multiplier — multiplier is now applied here when needed
+  ResourceCount base_cost = accountant.ComputeResourceCount(node);
+
+  if (workspace_estimate.has_value()) {
+    // Precise workspace known — add it directly, no multiplier
+    return AddResourceCounts(base_cost, *workspace_estimate);
+  }
+  // No workspace estimate — apply heuristic multiplier (1.5x)
+  return ApplyWorkspaceHeuristic(base_cost);
+}
+
+// Multiplier as an explicit utility:
+ResourceCount ApplyWorkspaceHeuristic(ResourceCount base) {
+  size_t bytes = std::get<0>(base);
+  return ResourceCount{static_cast<size_t>(bytes * 1.5)};
+}
+```
+
+**Design rationale:**
+- `ComputeResourceCount()` signature is **unchanged** — it returns the raw base cost (outputs + initializers with dedup). The 1.5x multiplier moves out of the accountant into this helper.
+- The helper is the **single decision point** for both code paths (in-tree and plugin host bridge). No duplicated logic.
+- `ApplyWorkspaceHeuristic()` makes the multiplier explicit and testable. It can be adjusted (e.g., per-EP or per-op-type) without changing any interface.
+- The helper integrates naturally with the existing budget check pattern:
+
+```cpp
+// Usage in GetCapability (both paths):
+auto total_cost = ComputeNodeCostForBudget(*accountant, node, workspace_estimate);
+auto would_be_consumed = AddResourceCounts(consumed, total_cost);
+
+if (has_budget && ResourceCountExceeds(would_be_consumed, budget)) {
+    accountant->SetStopAssignment();
+    break;
+}
+
+consumed = would_be_consumed;
+sub_graph->SetAccountant(accountant);
+sub_graph->AppendNodeCost(total_cost);
+```
+
+**Why this is clean with committed/uncommitted weights:**
+
+- **Weight dedup is unaffected.** `ComputeResourceCount()` handles pending/committed weight tracking internally. The workspace estimate is purely additive — it's not a weight, so it doesn't participate in dedup.
+- **`AppendNodeCost()` stores the combined total.** When `AccountForNode()` runs later (during `TryAssignNodes()`), it adds the stored cost (base + workspace) to `consumed_amount` and commits the weights. The workspace portion just inflates the per-node cost.
+- **`CommitWeightsForNode()` only touches initializers.** Workspace is a separate addend, not tracked in weight sets.
+- **`ResetForNewPass()` is fine.** The workspace estimate is stateless — recomputed fresh from node shapes each call, no state to carry across passes.
+
+If no estimation function is registered for a kernel, the helper applies the 1.5x multiplier as today (unchanged behavior).
+
+**Example estimation function (CUDA Conv):**
+
+```cpp
+OrtStatus* EstimateConvWorkspace(const OrtEpApi* api, const OrtNode* node,
+                                  const OrtEp* ep, size_t* out) {
+    // Get input shape (X: NCHW)
+    const int64_t* x_shape = nullptr;
+    size_t x_rank = 0;
+    OrtStatus* status = api->Node_GetInputShape(node, 0, &x_shape, &x_rank);
+    if (status) return status;
+    if (x_rank < 3) {
+        return api->CreateStatus(ORT_INVALID_ARGUMENT,
+                                 "Conv: input X must be at least rank 3");
+    }
+
+    // Get weight shape (W: [M, C/group, kH, kW, ...])
+    const int64_t* w_shape = nullptr;
+    size_t w_rank = 0;
+    status = api->Node_GetInputShape(node, 1, &w_shape, &w_rank);
+    if (status) return status;
+    if (w_rank != x_rank) {
+        return api->CreateStatus(ORT_INVALID_ARGUMENT,
+                                 "Conv: weight rank must match input rank");
+    }
+
+    // Get conv attributes (all optional — defaults to empty/zeros per ONNX spec)
+    const int64_t* pads = nullptr;
+    size_t pads_count = 0;
+    status = api->Node_GetAttributeInts(node, "pads", &pads, &pads_count);
+    if (status) return status;  // distinguishes "not present" (OK + nullptr) from error
+
+    const int64_t* strides = nullptr;
+    size_t strides_count = 0;
+    status = api->Node_GetAttributeInts(node, "strides", &strides, &strides_count);
+    if (status) return status;
+
+    const int64_t* dilations = nullptr;
+    size_t dilations_count = 0;
+    status = api->Node_GetAttributeInts(node, "dilations", &dilations, &dilations_count);
+    if (status) return status;
+
+    // EP-specific: cast to concrete type to access cuDNN handle
+    auto* cuda_ep = static_cast<const CudaEp*>(ep);
+    cudnnHandle_t handle = cuda_ep->GetCudnnHandle();
+    if (!handle) {
+        return api->CreateStatus(ORT_RUNTIME_EXCEPTION,
+                                 "Conv: cuDNN handle not available on EP");
+    }
+
+    // Build cuDNN frontend graph and query workspace
+    // (same logic as CreateCudnnFeExecutionPlan but without storing state)
+    auto graph = BuildConvFrontendGraph(x_shape, x_rank, w_shape, w_rank,
+                                         pads, pads_count, strides, strides_count,
+                                         dilations, dilations_count);
+    if (!graph) {
+        return api->CreateStatus(ORT_RUNTIME_EXCEPTION,
+                                 "Conv: failed to build cuDNN frontend graph");
+    }
+
+    auto plan_status = graph->build_plans(handle, cudnn_frontend::BuildPlanPolicy_t::HEURISTICS_ONLY);
+    if (plan_status) {
+        return api->CreateStatus(ORT_RUNTIME_EXCEPTION,
+                                 plan_status.get_message());
+    }
+
+    *out = graph->get_workspace_size();
+    return nullptr;  // success
+}
+```
+
+This produces the **exact same result** as the kernel would compute during `DeclareWorkspaceRequirements` — same handle, same shapes, same algorithm selection. The shared logic is the cuDNN frontend graph construction.
+
+**Why no public API for device properties or library handles:** The estimation function is registered BY the EP for ITS kernels — it's EP-specific code running in the EP's own DLL. It can safely cast `OrtEp*` to its concrete type (e.g., `CudaEp*`) to access device_prop, cuDNN handles, etc. This is the same pattern kernels already use: `static_cast<const CUDAExecutionProvider*>(info.GetExecutionProvider())->GetDeviceProp()`. No generic `Ep_GetCudnnHandle` or `Ep_GetDeviceIntProperty` API is needed — that would be CUDA-specific pollution of the universal EP interface.
+
+**Level 2 — Verification and diagnostics (after kernel creation):**
+
+After EP assignment and kernel creation, during `FinalizeSessionState()`:
+
+1. Call `DeclareWorkspaceRequirements()` on all kernel instances → get exact workspace sizes.
+2. Compute actual total memory: initializers + peak activations + peak workspace.
+3. If actual total ≤ budget → proceed normally (log confirmation at verbose level).
+4. If actual total > budget → **log a warning** with the overrun amount and the nodes contributing most workspace. Do NOT attempt to reassign nodes.
+
+**What does `DeclareWorkspaceRequirements()` have that `EstimateWorkspace()` doesn't?**
+
+Both run during static initialization (not runtime). Both have access to static shapes, node attributes, and the EP's device state. In the common case, they should produce **identical answers** — they call the same shared helper with the same inputs. The design intentionally makes them equivalent.
+
+However, `DeclareWorkspaceRequirements()` runs *after* one additional pipeline stage that can (in narrow cases) change what a node looks like:
+
+1. **EP-specific graph transforms (Level 2/3 optimizers):** These run *after* `GetCapability()` partitions the graph. They can fuse adjacent nodes within an EP's subgraph (e.g., Conv+Relu → ConvRelu, MatMul+Add → FusedMatMul). The fused node is a *different op* than the original — its workspace may differ from the sum of the parts. The estimation function at Level 1 was called on the pre-fusion nodes; `DeclareWorkspaceRequirements()` is called on the post-fusion kernel.
+
+2. **Kernel constructor decisions:** The constructor has access to the full `OpKernelInfo` including all inputs, attributes, and EP state simultaneously. Some kernels select between code paths based on complex multi-factor heuristics (e.g., "use flash path if head_size ≤ 128 AND sm ≥ 80 AND no causal mask" vs "use unfused path otherwise"). The estimation function must replicate this logic exactly — a bug there would cause divergence.
+
+**In practice, divergence is rare because:**
+- Fused ops (case 1) typically don't exist in the kernel registry at Level 1 — they're created by the fusion transformer itself, which knows their workspace needs. The estimation function for a fused op would be registered alongside the fused kernel.
+- Constructor logic (case 2) is the same arithmetic the estimation function replicates.
+
+**The honest assessment:** For well-written estimation functions operating on models with static shapes, Level 2 should agree with Level 1 100% of the time. Level 2's value is purely as a **development-time assertion** — catching bugs in estimation functions during testing, not as a production safety net.
+
+**Why we cannot reassign nodes at this stage:**
+
+The MemcpyTransformer (which inserts data-copy nodes at EP boundaries) runs during graph transformation — well before `FinalizeSessionState()`. By the time kernels exist and exact workspace is known, the graph already has Memcpy nodes baked in at the original partition boundaries. Reassigning tail nodes to CPU would require:
+- Removing the now-incorrect Memcpy nodes at the old boundary
+- Inserting new Memcpy nodes at the new boundary
+- Re-running shape inference on affected subgraphs
+- Re-creating kernels for the moved nodes under a different EP
+
+This is effectively re-running a portion of `Initialize()` — not a simple post-hoc trim. The complexity and fragility of partial re-partitioning at this stage makes it impractical.
+
+**Design philosophy: get it right in Level 1.**
+
+The estimation functions demonstrated above (Attention, Conv) produce **exact** workspace sizes using the same logic and data the kernel will use. For 75% of workspace-consuming kernels, shapes alone determine workspace (pure arithmetic). For another 16%, the cuDNN heuristic planner gives exact answers. The remaining ~12% (MOE, MatMulNBits) use upper-bound estimates that are tight.
+
+Given this precision, Level 2 serves as a **diagnostic check**, not a correction mechanism:
+- If the estimate matches → confirms the system is working correctly.
+- If the estimate under-shot → the warning alerts the developer that a particular kernel's estimation function needs improvement. This is a bug to fix in the estimation function, not a runtime recovery scenario.
+
+**When static shapes are unavailable:**
+
+If the model has dynamic shapes, the estimation function cannot compute workspace (shapes are unknown at `GetCapability()` time). In this case:
+- The estimation function returns a failure status or a sentinel value indicating "unknown."
+- `ComputeNodeCostForBudget()` falls back to the 1.5x heuristic multiplier on base cost.
+- The user may need to **tune the memory budget by trial and error** — setting a conservative budget and adjusting based on observed OOM or under-utilization. This is analogous to llama.cpp's `-ngl` flag: the user picks a layer count and adjusts based on whether it fits.
+- A future extension could accept user-provided "typical shape hints" (e.g., `max_batch=4, max_seq=2048`) to enable estimation even for dynamic-shape models, but this is out of scope for the initial design.
+
+**Plugin C ABI for Level 1:**
+
+```c
+// Workspace estimation function type (no kernel instance needed):
+typedef OrtStatus*(ORT_API_CALL* OrtKernelWorkspaceEstimateFunc)(
+    _In_ const OrtEpApi* api,
+    _In_ const OrtNode* node,
+    _In_ const OrtEp* ep,
+    _Out_ size_t* estimated_workspace_bytes);
+
+// Extension to KernelRegistry_AddKernel in OrtEpApi:
+ORT_API2_STATUS(KernelRegistry_AddKernelV2,
+    _Inout_ OrtKernelRegistry* registry,
+    _In_ const OrtKernelDef* kernel_def,
+    _In_ OrtKernelCreateFunc create_func,
+    _In_opt_ void* create_func_state,
+    _In_opt_ OrtKernelWorkspaceEstimateFunc workspace_estimate_func);  // NEW — may be NULL
+```
+
+**Required OrtEpApi additions for the estimation function to query node info:**
+
+```c
+// Query input shape from a node's NodeArg (populated by shape inference):
+ORT_API2_STATUS(Node_GetInputShape,
+    _In_ const OrtNode* node,
+    _In_ size_t input_index,
+    _Outptr_result_maybenull_ const int64_t** shape,  // NULL if dynamic
+    _Out_ size_t* rank);
+
+// Query integer attribute from a node:
+ORT_API2_STATUS(Node_GetAttributeInt,
+    _In_ const OrtNode* node,
+    _In_ const char* attr_name,
+    _Out_ int64_t* value);
+
+// Query integer array attribute:
+ORT_API2_STATUS(Node_GetAttributeInts,
+    _In_ const OrtNode* node,
+    _In_ const char* attr_name,
+    _Outptr_ const int64_t** values,
+    _Out_ size_t* count);
+```
+
+**Device properties and library handles** (cuDNN, cuBLAS, etc.) are accessed by casting `OrtEp*` to the EP's concrete type inside the estimation function — no public API needed (see examples above).
+
+---
+
+### Implementation Across Kernel Types and GetCapability Paths
+
+ORT has **three distinct kernel authoring scenarios** and **two GetCapability architectures**. The workspace estimation and declaration APIs must work correctly in each combination.
+
+#### Three Kernel Types
+
+| Type | Description | Registration mechanism | Examples |
+|------|-------------|----------------------|----------|
+| **In-tree** | C++ kernels compiled into the ORT binary | `BuildKernelCreateInfo<>()` via macros (`ONNX_OPERATOR_TYPED_KERNEL_EX`) | All CPU kernels, legacy CUDA EP kernels |
+| **Plugin (shared source)** | Same C++ source as in-tree, compiled into EP plugin DLL, uses adapter layer | `KernelRegistry_AddKernel` C ABI, with `CudaKernelAdapter<T>` bridging | CUDA EP plugin kernels |
+| **Pure ABI** | Kernels written directly against the C ABI (`OrtKernelImpl`) | `KernelRegistry_AddKernel` C ABI, `OrtKernelImpl` function pointers | Third-party EP plugin kernels |
+
+#### Two GetCapability Architectures
+
+| Architecture | Resource budgeting location | Workspace estimation call site |
+|-------------|---------------------------|-------------------------------|
+| **In-tree** | Inside `CUDAExecutionProvider::GetCapability()` — EP owns the loop, calls `resource_accountant->ComputeResourceCount(node)`, makes accept/reject decisions | EP calls estimation function directly in its loop |
+| **Plugin bridge** | In `PluginExecutionProvider::GetCapability()` (the C++ host wrapper) — plugin EP only proposes candidates, host does budgeting after plugin returns | Host calls estimation function during budget enforcement |
+
+**Critical difference:** In the plugin path, the plugin's `GetCapabilityImpl` returns a list of "I support these nodes" without resource checks. The **host bridge** (`ep_plugin_provider_interfaces.cc`) then iterates those nodes in topological order, calls `resource_accountant->ComputeResourceCount(node)` for each, and enforces the budget — halting assignment when the threshold is exceeded. The plugin never sees the accountant directly.
+
+#### Implementation: `OrtKernelWorkspaceEstimateFunc` (Level 1 — at partitioning time)
+
+**In-tree path:**
+
+```cpp
+// In CUDAExecutionProvider::GetCapability() loop (in-tree only):
+const KernelCreateInfo* kci = kernel_lookup.LookUpKernel(node);
+std::optional<size_t> workspace_estimate;
+if (kci && kci->workspace_estimate_func) {
+    size_t ws = 0;
+    // In-tree: pass IExecutionProvider* — func casts to CUDAExecutionProvider*
+    kci->workspace_estimate_func(this, node, &ws);
+    workspace_estimate = ws;
+}
+// Use non-member helper for budget decision:
+auto total_cost = ComputeNodeCostForBudget(*resource_accountant, node, workspace_estimate);
+// ... budget check with total_cost ...
+```
+
+The estimation function for in-tree kernels is a static member function. It casts the EP pointer to `CUDAExecutionProvider*` to access `GetDeviceProp()` and `PerThreadDefaultCudnnHandle()` — exactly the same pattern kernels already use.
+
+**Plugin bridge path:**
+
+```cpp
+// In PluginExecutionProvider::GetCapability() host-side budget loop
+// (ep_plugin_provider_interfaces.cc):
+for (const auto& node_grouping : api_graph_support_info.node_groupings) {
+    const Node& internal_node = node_grouping.nodes[0]->GetInternalNode();
+
+    // Look up workspace estimate function from kernel registry
+    const KernelCreateInfo* kci = kernel_lookup.LookUpKernel(internal_node);
+    std::optional<size_t> workspace_estimate;
+    if (kci && kci->workspace_estimate_func) {
+        size_t ws = 0;
+        // Plugin path: registered via KernelRegistry_AddKernelV2
+        // Function casts OrtEp* to its concrete type internally
+        OrtStatus* est_status = kci->workspace_estimate_func(
+            &ep_api_, ep_node->ToExternal(), ort_ep_.get(), &ws);
+        if (est_status) { OrtApis::ReleaseStatus(est_status); }
+        else { workspace_estimate = ws; }
+    }
+
+    // Same non-member helper as in-tree:
+    auto total_cost = ComputeNodeCostForBudget(*resource_accountant, internal_node,
+                                               workspace_estimate);
+    // ... budget check with total_cost ...
+}
+```
+
+**Pure ABI path (third-party EP):**
+
+Same as plugin bridge — the estimation function is registered via `KernelRegistry_AddKernelV2` and called by the host during budget enforcement. The kernel author provides the function pointer at registration time:
+
+```c
+// Third-party EP kernel registration:
+OrtStatus* MyConvEstimate(const OrtEpApi* api, const OrtNode* node,
+                           const OrtEp* ep, size_t* out) {
+    // Cast to concrete EP type to access device-specific state:
+    auto* my_ep = static_cast<const MyGpuEp*>(ep);
+    // ... compute workspace from node shapes + my_ep->device_properties ...
+}
+
+// During EP's RegisterKernels callback:
+ep_api->KernelRegistry_AddKernelV2(registry, conv_kernel_def, CreateConvKernel,
+                                    /*state=*/nullptr, &MyConvEstimate);
+```
+
+#### Implementation: `DeclareWorkspaceRequirements` (Level 2 — after kernel creation)
+
+**In-tree path:**
+
+Straightforward — add a virtual method to `OpKernel`:
+
+```cpp
+// In include/onnxruntime/core/framework/op_kernel.h:
+[[nodiscard]] virtual Status DeclareWorkspaceRequirements(
+    gsl::span<const TensorShape> input_shapes,
+    InlinedVector<WorkspaceRequirement>& requirements) const {
+  return Status::OK();  // Default: no workspace declared
+}
+```
+
+In-tree kernels override this just like they override `PrePack()`. Called during `FinalizeSessionState()` after kernel instances exist.
+
+**Plugin (shared source) path:**
+
+The `CudaKernelAdapter<T>` already bridges virtual calls to the underlying kernel class. The adapter forwards `DeclareWorkspaceRequirements` to the underlying kernel's implementation:
+
+```cpp
+// In cuda_kernel_adapter.h — adapter already forwards PrePack similarly:
+Status DeclareWorkspaceRequirements(
+    gsl::span<const TensorShape> input_shapes,
+    InlinedVector<WorkspaceRequirement>& requirements) const override {
+  // The underlying kernel class (compiled in the plugin DLL) implements this directly.
+  // CudaKernelAdapter<T> inherits from T, so T::DeclareWorkspaceRequirements is accessible.
+  return T::DeclareWorkspaceRequirements(input_shapes, requirements);
+}
+```
+
+Since plugin shared-source kernels ARE the same C++ class (just compiled in a different DLL), they implement `DeclareWorkspaceRequirements` as a regular virtual override — no ABI translation needed.
+
+**Pure ABI path (third-party EP):**
+
+Add an optional function pointer to `OrtKernelImpl`:
+
+```c
+// In onnxruntime_ep_c_api.h, extend OrtKernelImpl:
+struct OrtKernelImpl {
+  // ... existing fields (Compute, Release, PrePackWeight, ...) ...
+
+  // NEW — optional workspace declaration (ORT >= 1.XX):
+  ORT_API2_STATUS(DeclareWorkspaceRequirements,
+      _In_ OrtKernelImpl* this_ptr,
+      _In_ const int64_t* const* input_shapes,  // array of shape arrays
+      _In_ const size_t* input_ranks,            // rank of each input
+      _In_ size_t num_inputs,
+      _Out_ OrtWorkspaceRequirement** requirements,  // allocated by kernel
+      _Out_ size_t* num_requirements);
+};
+```
+
+The `PluginEpOpKernel` adapter (in `ep_kernel_registration.cc`) bridges this to the virtual call:
+
+```cpp
+// In PluginEpOpKernel:
+Status DeclareWorkspaceRequirements(
+    gsl::span<const TensorShape> input_shapes,
+    InlinedVector<WorkspaceRequirement>& requirements) const override {
+  // Version guard (same pattern as PrePack):
+  if (kernel_impl_->ort_version_supported < XX ||
+      kernel_impl_->DeclareWorkspaceRequirements == nullptr) {
+    return Status::OK();  // No declaration — fall back to arena
+  }
+
+  // Convert TensorShape spans to C arrays
+  InlinedVector<const int64_t*> shape_ptrs;
+  InlinedVector<size_t> ranks;
+  for (const auto& shape : input_shapes) {
+    shape_ptrs.push_back(shape.GetDims().data());
+    ranks.push_back(shape.NumDimensions());
+  }
+
+  OrtWorkspaceRequirement* reqs = nullptr;
+  size_t num_reqs = 0;
+  ORT_RETURN_IF_ERROR(ToStatusAndRelease(
+      kernel_impl_->DeclareWorkspaceRequirements(
+          kernel_impl_, shape_ptrs.data(), ranks.data(),
+          shape_ptrs.size(), &reqs, &num_reqs)));
+
+  // Convert C results to C++ vector
+  for (size_t i = 0; i < num_reqs; ++i) {
+    requirements.push_back({reqs[i].size_bytes, reqs[i].slot_id});
+  }
+  // Free C allocation (kernel used OrtAllocator or static buffer)
+  return Status::OK();
+}
+```
+
+#### Summary: Where Each Piece Lives
+
+| Component | In-tree | Plugin (shared source) | Pure ABI |
+|-----------|---------|----------------------|----------|
+| **Workspace estimation func** | Static member on kernel class; stored in `KernelCreateInfo::workspace_estimate_func` | Same static function, registered via `KernelRegistry_AddKernelV2` | C function pointer, registered via `KernelRegistry_AddKernelV2` |
+| **Who calls estimation** | EP's `GetCapability()` loop via `ComputeNodeCostForBudget()` helper | Host bridge via same `ComputeNodeCostForBudget()` helper | Host bridge (same) |
+| **DeclareWorkspaceRequirements** | Virtual override on `OpKernel` | Virtual override (same C++ class in plugin DLL) | `OrtKernelImpl::DeclareWorkspaceRequirements` function pointer → `PluginEpOpKernel` adapter |
+| **Who calls DeclareWorkspace** | `FinalizeSessionState()` | `FinalizeSessionState()` (same) | `FinalizeSessionState()` via adapter |
+| **Device property access** | `static_cast<CUDAExecutionProvider*>(ep)->GetDeviceProp()` | `static_cast<const CudaEp*>(ep)->GetDeviceProp()` | `static_cast<const MyEp*>(ep)->GetDeviceProps()` |
+| **cuDNN handle access** | `static_cast<CUDAExecutionProvider*>(ep)->PerThreadDefaultCudnnHandle()` | `static_cast<const CudaEp*>(ep)->GetCudnnHandle()` | N/A (EP-specific) |
+
+#### Key Design Principle
+
+The **estimation function** signature differs between in-tree and plugin paths:
+
+- **In-tree:** `static size_t EstimateWorkspace(const IExecutionProvider* ep, const Node& node)` — C++ types, direct EP access
+- **Plugin/ABI:** `OrtStatus* EstimateWorkspace(const OrtEpApi*, const OrtNode*, const OrtEp*, size_t*)` — C ABI, opaque types
+
+But both compute the same result. For shared-source kernels (compiled both in-tree and as plugin), a single static helper function (e.g., `ComputeAttentionWorkspace()`) is called from both wrappers — ensuring the estimate is identical regardless of build configuration.
+
+---
+
 #### Phase A: Workspace Pre-declaration (`DeclareWorkspaceRequirements`)
 
 The core missing piece. Today no kernel declares its temp buffer needs before `Compute()`. To close this gap, introduce a method on `OpKernel` that returns workspace descriptors — each with a size and a key for later retrieval.
@@ -491,9 +1044,10 @@ Near-term (low effort, high value):
 │     - Match against Node::Name() instead of metadata
 │     - Support range expressions for numbered layers
 │
-├── 2. Precise memory estimation for static-shape models
-│     - Run shape inference during Initialize() when shapes are known
-│     - Compute exact per-layer memory in IResourceAccountant
+├── 2. Precise per-node memory estimation
+│     - Static workspace estimation functions registered per kernel type
+│     - IResourceAccountant uses exact output sizes + workspace estimates
+│     - Eliminates 1.5x multiplier for kernels with estimation functions
 │
 Mid-term (medium effort):
 ├── 3. Auto-partitioning with memory budget only

--- a/docs/annotated_partitioning/future_directions_constrained_env.md
+++ b/docs/annotated_partitioning/future_directions_constrained_env.md
@@ -269,11 +269,7 @@ Before discussing gaps, it's important to note what ORT already provides:
 
 **Note on arena and temp buffer reuse:** While the BFC arena wastes memory due to chunk granularity, it does provide **automatic reuse** for temp buffers during sequential execution — subsequent kernels reuse the same arena memory for their scratch needs without actual device allocations.
 
-**CUDA mempool as an alternative:** ORT already supports replacing the BFC arena with native CUDA memory pools (`cudaMallocFromPoolAsync`), enabled via:
-```cpp
-session_options.add_session_config_entry("ep.cudaexecutionprovider.arena.use_cuda_mempool", "1");
-```
-This provides stream-aware pooling managed by the CUDA driver, with less memory waste than BFC. Since `GetScratchBuffer()` uses the same device allocator as activations (resolved via `SessionState::GetAllocator(device)` — keyed by `OrtDevice` only, not by purpose), enabling mempool automatically benefits temp buffers too. A separate temp-only allocator would require architectural changes to `AllocatorMap` (currently not feasible without significant refactoring).
+**CUDA mempool as an alternative:** ORT supports replacing the BFC arena with native CUDA memory pools (`cudaMallocFromPoolAsync`). This is enabled via the EP-scoped arena configuration key `arena.use_cuda_mempool` (e.g., `"ep.cudapluginexecutionprovider.arena.use_cuda_mempool" = "1"` in session config). This provides stream-aware pooling managed by the CUDA driver, with less memory waste than BFC. Since `GetScratchBuffer()` uses the same device allocator as activations (resolved via `SessionState::GetAllocator(device)` — keyed by `OrtDevice` only, not by purpose), enabling mempool automatically benefits temp buffers too. A separate temp-only allocator would require architectural changes to `AllocatorMap` (currently not feasible without significant refactoring).
 
 **Pre-allocated space for temp buffers (alternative approach):** If workspace sizes can be pre-computed (see Phase A below), temp buffers could be served from the same pre-allocated memory pattern buffer used for activations. Since workspace is live only during its kernel's execution, it participates naturally in liveness-based offset planning — no arena needed at all. This is the more principled solution: solve the workspace size problem first, then temp memory becomes part of the static plan.
 
@@ -1032,11 +1028,9 @@ Workspace pre-allocation follows the same model:
 
 Even with workspace planning, the per-`Run()` buffer allocation can still OOM if device memory is fragmented or consumed by other processes since `Initialize()`. For constrained environments, this is the last remaining point of failure.
 
-Most constrained-environment users run **single-threaded inference** — one `Run()` at a time. ORT already has a concurrent-run counter (`InferenceSession::current_num_runs_`). If the session is configured to disallow concurrency, the execution buffer (which includes workspace slots) can be **allocated once at initialization and reused for every `Run()` call**:
+Most constrained-environment users run **single-threaded inference** — one `Run()` at a time. ORT already has a concurrent-run counter (`InferenceSession::current_num_runs_`). If the session is configured to disallow concurrency, the execution buffer (which includes workspace slots) can be **allocated once at initialization and reused for every `Run()` call**.
 
-```cpp
-session_options.AddConfigEntry("session.pre_allocate_execution_buffers", "1");
-```
+**Proposed** (not currently implemented): a session option such as `session.pre_allocate_execution_buffers = "1"` would enable this behavior.
 
 When enabled:
 1. After `FinalizeSessionState()` computes the memory pattern (including workspace offsets from `DeclareWorkspaceRequirements`), allocate the peak buffer once: `IAllocator::Alloc(peak_size)` per EP.

--- a/docs/annotated_partitioning/future_directions_constrained_env.md
+++ b/docs/annotated_partitioning/future_directions_constrained_env.md
@@ -202,7 +202,7 @@ So if the original node was `/model/layers.5/self_attn/q_proj/MatMul`, the fused
 **Edge cases to handle:**
 1. **Generic names** (e.g., `"Attention"` without incorporating the original name): Some fusions create nodes with generic names that don't contain layer-identifying substrings. In general, name-based partitioning can only be used when node names contain representative strings suitable for layer matching. Two options exist:
    - **Annotation fallback**: Use annotation-based assignment for these nodes, or update the transformer to follow the derivative naming convention.
-   - **Exact-match rule**: If the user is willing to assign *all* nodes with a given generic name to the same device, they can add an exact-match rule (e.g., `cuda(=Attention)`). This works without annotations, but applies uniformly — all nodes matching that name go to the specified device.
+   - **Substring rule**: Add a substring pattern (e.g., `cuda(Attention)`) to assign all nodes whose name contains `Attention`. Note that name-based assignment does not support the '=' exact-match qualifier — all patterns are substrings.
 2. **Multiple source nodes**: When a fusion merges N nodes from potentially different layers, the resulting name typically uses one of them as the base. If the merged nodes span layer boundaries, the fused node will match whichever layer the chosen base name belongs to. This mirrors annotation-based behavior (annotation is copied from one source node).
 
 **Recommendation:** No special machinery needed for pre-partitioning transformers. The derivative naming convention already preserves matchability. Document this as a convention that transformer authors should follow: always pass an original node's name as the base to `GenerateNodeName()`.
@@ -1308,7 +1308,7 @@ Near-term (low effort, high value):
 ├── 1. Name-based matching via session.name_based_layer_assignment  [DONE]
 │     - Separate session option with substring matching against Node::Name()
 │     - SubstringMatcher with longest-match-wins priority
-│     - Annotation-based matching takes precedence when both are configured
+│     - Mutually exclusive with annotation-based matching (setting both options returns INVALID_ARGUMENT)
 │
 ├── 2. Precise per-node memory estimation
 │     - Static workspace estimation functions registered per kernel type

--- a/docs/annotated_partitioning/future_directions_constrained_env.md
+++ b/docs/annotated_partitioning/future_directions_constrained_env.md
@@ -1,0 +1,415 @@
+# Future Directions: Constrained Environment Partitioning
+
+## Context
+
+Today's annotation-based partitioning requires each node to carry a `layer_ann` metadata property. The `LayeringIndex` matches these annotations against user-supplied rules (prefix trie + exact match) to assign nodes to devices. The `IResourceAccountant` optionally enforces memory budgets.
+
+The goal: make ORT as easy to use as ollama for running large models on machines with limited GPU memory — automatic or near-automatic layer offloading without requiring model producers to annotate every node.
+
+---
+
+## Direction 1: Name-Based Substring Matching (No Annotation Step)
+
+### Idea
+
+Skip the annotation metadata entirely. Instead, match directly against **node names** using substrings/patterns from the configuration. MS Foundry models (and most HuggingFace exports) already encode layer structure in node names:
+
+```
+/model/layers.0/self_attn/q_proj/MatMul
+/model/layers.0/self_attn/k_proj/MatMul
+/model/layers.15/mlp/gate_proj/MatMul
+/model/embed_tokens/Gather
+/model/norm/LayerNormalization
+```
+
+A config like `gpu(layers.0, layers.1, ..., layers.15); cpu(layers.16, ..., layers.31)` would partition without any model modification.
+
+### How to Approach
+
+1. **Extend `LayeringRuleMatcher` to operate on node names directly.** Today the matcher looks at `node.GetMetadata("layer_ann")`. Add a parallel path that runs the same prefix/substring matching against `node.Name()`. This is a small change — the trie infrastructure already exists.
+
+2. **Config via a separate session option (same syntax).** Rather than introducing a new qualifier into the existing `kOrtSessionOptionsLayerAssignmentSettings` syntax, add a parallel session option that uses **the same `device(prefix1, prefix2, ...); ...` grammar** but matches against `Node::Name()` instead of node metadata:
+
+   ```cpp
+   // Existing (annotation-based, matches node metadata 'layer_ann'):
+   static const char* const kOrtSessionOptionsLayerAssignmentSettings =
+       "session.layer_assignment_settings";
+
+   // NEW (name-based, matches Node::Name() via substring/prefix):
+   static const char* const kOrtSessionOptionsNameBasedLayerAssignment =
+       "session.name_based_layer_assignment";
+   ```
+
+   Usage stays identical — only the matching target differs:
+   ```
+   # Annotation-based (existing):
+   session.layer_assignment_settings = "cuda(encoder_layer, attention); cpu(embed)"
+
+   # Name-based (new, same syntax):
+   session.name_based_layer_assignment = "cuda(layers.0, layers.1); cpu(layers.16)"
+
+   # Range expressions (future extension, not currently supported):
+   session.name_based_layer_assignment = "cuda(layers.[0-15]); cpu(layers.[16-31])"
+   ```
+
+   This approach:
+   - Keeps the existing parser/grammar unchanged (reuse `LayeringRuleMatcher`)
+   - Makes intent explicit — users opt into name-based matching deliberately
+   - Both options can coexist (annotation-based takes priority if both match a node)
+   - No risk of breaking existing annotation-based workflows
+
+3. **Build index at load time.** During `InferenceSession::Initialize()`, after graph is loaded but before partitioning:
+   - If config contains name-based rules, iterate all nodes once
+   - Build `NodeIndex → RuleIndex` map using substring/prefix matching on `Node::Name()`
+   - Feed this into the existing `LayeringIndex` infrastructure (same downstream flow)
+
+4. **Range expressions (future extension).** The current `LayeringRuleMatcher` supports only exact match (`=prefix`) and prefix match. It does **not** support range syntax today. For transformer models with numbered layers, a future extension could add range support:
+   ```
+   cuda(layers.[0-15]); cpu(layers.[16-31])
+   ```
+   This would avoid enumerating 32+ layer prefixes manually, but requires new parsing logic. Until then, users must enumerate each layer prefix explicitly or use a broad prefix like `layers.` that captures all layers for a single device.
+
+### Advantages
+
+- **Zero model modification** — works with any model that has structured naming
+- **Reuses existing partitioning infrastructure** — only the index-building step changes
+- **User-friendly** — users can inspect node names with Netron and write rules directly
+- **Composable with resource accounting** — can combine name-based assignment with memory budgets
+
+### Risks / Open Questions
+
+- **Name stability**: Node names aren't guaranteed stable across exports. Mitigated by prefix/substring matching rather than exact names.
+- **Unnamed nodes / nodes created by graph transformers**: See detailed analysis below.
+- **Subgraph nodes**: Control flow (If/Loop) subgraph nodes may have different naming conventions.
+
+### Handling Nodes Created by Graph Transformers
+
+#### Pre-partitioning transformers (Level 1)
+
+Level 1 optimizers run **before** partitioning. With annotation-based matching, these transformers propagate annotations to new nodes via the `AddNode(..., annotation_source)` overload, which copies `GetLayeringAnnotation()` from an original node. The name-based approach needs an analogous story.
+
+**Key insight: new node names ARE derivative of original names.** Verified in the codebase:
+
+- `Graph::GenerateNodeName(base_name)` takes a base string and ensures uniqueness by appending `_token_<N>` only on collision.
+- Transformers construct the base name from original node(s):
+  - `layer_norm_fusion.cc`: `GenerateNodeName(mul_node.Name() + "/LayerNormFusion/")`
+  - `matmul_add_fusion.cc`: `GenerateNodeName(matmul_node.Name() + "/MatMulAddFusion")`
+  - `attention_fusion.cc`: `GenerateNodeName("Attention")` ← **exception — generic name**
+
+So if the original node was `/model/layers.5/self_attn/q_proj/MatMul`, the fused node typically becomes something like `/model/layers.5/self_attn/q_proj/MatMul/MatMulAddFusion` — which still contains the original layer prefix and will match substring rules like `layers.5`.
+
+**This means name-based matching is naturally robust to pre-partitioning fusions** — no explicit annotation-copying step is needed, because the substring match against the derivative name still hits the same rules. This is actually **simpler** than the annotation-based approach.
+
+**Edge cases to handle:**
+1. **Generic names** (e.g., `"Attention"` without incorporating the original name): Some fusions create nodes with generic names that don't contain layer-identifying substrings. In general, name-based partitioning can only be used when node names contain representative strings suitable for layer matching. Two options exist:
+   - **Annotation fallback**: Use annotation-based assignment for these nodes, or update the transformer to follow the derivative naming convention.
+   - **Exact-match rule**: If the user is willing to assign *all* nodes with a given generic name to the same device, they can add an exact-match rule (e.g., `cuda(=Attention)`). This works without annotations, but applies uniformly — all nodes matching that name go to the specified device.
+2. **Multiple source nodes**: When a fusion merges N nodes from potentially different layers, the resulting name typically uses one of them as the base. If the merged nodes span layer boundaries, the fused node will match whichever layer the chosen base name belongs to. This mirrors annotation-based behavior (annotation is copied from one source node).
+
+**Recommendation:** No special machinery needed for pre-partitioning transformers. The derivative naming convention already preserves matchability. Document this as a convention that transformer authors should follow: always pass an original node's name as the base to `GenerateNodeName()`.
+
+#### Post-partitioning transformers (Level 2+)
+
+Level 2+ optimizers run **after** partitioning, when EP assignments have already been made. These transformers already copy the EP assignment from original nodes:
+
+```cpp
+new_node.SetExecutionProviderType(original_node.GetExecutionProviderType());
+```
+
+**No action needed for name-based matching here.** By the time Level 2+ transformers run, partitioning is complete. The node names are irrelevant — only the EP assignment matters, and that's already propagated correctly.
+
+---
+
+## Direction 2: Static Shape Pre-allocation (ollama/llama.cpp Style)
+
+### What ollama Does
+
+llama.cpp (and by extension ollama) exploits that transformer inference has **fully deterministic memory usage**:
+- All weight tensors are known at load time
+- KV cache is pre-allocated for max sequence length
+- Intermediate activation buffers have shapes determined by `(batch, seq_len, hidden_dim)` — all known in advance
+
+This means the runtime can compute **exactly** how much memory each layer needs before running, enabling precise layer-by-layer offloading decisions.
+
+### What ORT Already Does
+
+Before discussing gaps, it's important to note what ORT already provides:
+
+- **Shape inference runs during `Initialize()`** — specifically during `graph.Resolve()` after graph optimizations but before memory planning. Shape info is populated on all `NodeArg` objects.
+- **Memory pattern pre-allocation** — When `EnableMemPattern` is set and shapes are static, `TensorAllocatorWithMemPattern` computes exact allocation offsets/sizes via `OrtValuePatternPlanner`, then pre-allocates a single large buffer per device via `Reserve()` (bypasses arena, calls device allocator directly). Intermediate buffers are reused based on liveness analysis.
+- **Initializers can bypass arena** — When `use_device_allocator_for_initializers` is set, initializers are loaded via `Reserve()` (direct device allocation) during session state finalization, bypassing the arena's binning/coalescing logic. Without this option, initializers allocate through the arena like any other buffer.
+- **BFC Arena** — Best-Fit-with-Coalescing allocator provides fast (O(log n)) sub-allocation. Allocations are cheap, but it suffers from memory waste due to power-of-two growth and chunk granularity.
+
+**What's already outside the arena:**
+- Initializers → `Reserve()` (direct device allocator)
+- Memory pattern buffers (activations) → `Reserve()` (direct device allocator)
+
+**What's still arena-allocated:**
+- **Runtime temp/workspace buffers** — kernels call `GetScratchBuffer<T>()` during `Compute()`, which allocates from the device allocator (arena by default). These are ephemeral (freed when kernel completes) and their sizes are only known at execution time.
+
+**Note on arena and temp buffer reuse:** While the BFC arena wastes memory due to chunk granularity, it does provide **automatic reuse** for temp buffers during sequential execution — subsequent kernels reuse the same arena memory for their scratch needs without actual device allocations.
+
+**CUDA mempool as an alternative:** ORT already supports replacing the BFC arena with native CUDA memory pools (`cudaMallocFromPoolAsync`), enabled via:
+```cpp
+session_options.add_session_config_entry("ep.cudaexecutionprovider.arena.use_cuda_mempool", "1");
+```
+This provides stream-aware pooling managed by the CUDA driver, with less memory waste than BFC. Since `GetScratchBuffer()` uses the same device allocator as activations (resolved via `SessionState::GetAllocator(device)` — keyed by `OrtDevice` only, not by purpose), enabling mempool automatically benefits temp buffers too. A separate temp-only allocator would require architectural changes to `AllocatorMap` (currently not feasible without significant refactoring).
+
+**Pre-allocated space for temp buffers (alternative approach):** If workspace sizes can be pre-computed (see Phase A below), temp buffers could be served from the same pre-allocated memory pattern buffer used for activations. Since workspace is live only during its kernel's execution, it participates naturally in liveness-based offset planning — no arena needed at all. This is the more principled solution: solve the workspace size problem first, then temp memory becomes part of the static plan.
+
+### IResourceAccountant Precision
+
+`IResourceAccountant::ComputeResourceCount()` already returns **exact sizes when shapes are static**:
+- Initializer sizes: exact via `GetSizeInBytesFromTensorProto()`
+- Output tensor sizes: exact when all dimensions are known via `GetSizeInBytesFromTensorTypeProto()`
+- Weight deduplication: tracked via `pending_weights_`/`committed_weights_` to avoid double-counting
+
+**Note on actual memory consumption:** While these give exact logical tensor sizes, actual device memory will be rounded up to page/alignment boundaries — either per allocation or for a single large buffer. The reported sizes are a lower bound; real usage includes alignment overhead.
+
+It applies a **1.5x safety multiplier** to account for unknowable temp/workspace allocations. This multiplier exists because temp buffer sizes are discovered only at runtime — no kernel declares its workspace needs in advance.
+
+**Per-node accounting (not per-layer)**: `IResourceAccountant` tracks costs at the node/subgraph level — `nodes_costs` in `IndexedSubGraph` is for accounting after an EP claims nodes (single nodes or fused groups), not for layering. It has no concept of "layer" as defined by the layering index.
+
+**Do we need per-layer aggregation?** Likely not as a first-class feature in `IResourceAccountant`.
+
+The current budget enforcement cuts off EP placement at the individual node level — once the cumulative budget is exceeded, subsequent nodes are rejected regardless of layer boundaries. **This is intentional**: atomic rollback of already-placed nodes within a layer was explicitly rejected during the previous implementation phase due to complexity and because it would require re-running `GetCapability()` with different node sets.
+
+The layering index already controls the *order* in which nodes are presented to the EP (layer by layer), so in practice the budget cutoff tends to land near layer boundaries. If exact layer-boundary cuts are desired in the future, it would need to be a separate mechanism (e.g., pre-computing per-layer costs and making accept/reject decisions at the layer level before calling `GetCapability()`), not a change to the accountant.
+
+For debugging/UX purposes, per-layer summaries can be computed externally by summing node costs grouped by their layer annotation — no accountant changes needed.
+
+### The Remaining Gap: Runtime Temp Buffers
+
+The 1.5x multiplier and arena waste both stem from the same root cause: **kernels allocate workspace at runtime without prior declaration.**
+
+Examples of how workspace sizes are determined:
+- **cuDNN Convolution**: Workspace depends on algorithm selection (`cudnn_fe_graph->get_workspace_size()`)
+- **cuDNN RNN**: Queries cuDNN at runtime (`cudnnGetRNNTempSpaceSizes()`)
+- **Attention kernels**: Computed from runtime parameters (`batch_size * seq_len * num_heads * head_size`)
+
+The `SequentialExecutionPlan` tracks only activation tensors and initializers — workspace buffers are ephemeral and never planned statically. There is no `GetWorkspaceSize()` virtual method on `OpKernel`.
+
+To eliminate both the multiplier and arena waste for temp buffers, two problems must be solved:
+1. **Learn temp buffer sizes in advance** — e.g., a `DeclareWorkspaceRequirements(shapes)` method on kernels, queryable during `Initialize()` when shapes are static
+2. **Allocate temp buffers outside the arena** — once sizes are known, include them in the memory pattern plan alongside activations
+
+### What ORT Is Missing
+
+| Capability | llama.cpp | ORT Today | Gap |
+|-----------|-----------|-----------|-----|
+| Static memory plan | Yes — computed at load | Yes — `MemoryPatternGroup` + `Reserve()` | ✓ Activations + initializers already bypass arena |
+| Pre-allocated activation buffers | Yes — fixed slots | Yes — memory patterns with liveness reuse | ✓ Already exists for static shapes |
+| Workspace pre-computation | Yes — known per op | No — kernels discover at runtime | Need `DeclareWorkspaceRequirements()` on kernels |
+| Workspace outside arena | Yes — part of static plan | No — `GetScratchBuffer()` uses arena | Need to include workspace in memory pattern plan |
+| Zero-copy weight transfer | mmap + `cudaMemcpy` per layer | EP-managed transfers during initialization | Relevant only for Phase D (prefetch/offload pipeline) — see below |
+
+**Note on "zero-copy device transfer":** In llama.cpp, model weights are memory-mapped (`mmap`) from disk, and individual layers are streamed to GPU via `cudaMemcpy`/`cudaMemcpyAsync` on demand — the CPU never allocates a separate copy, it reads directly from the mmap'd file into GPU memory. In ORT today, initializers are deserialized from protobuf into host memory, then copied to device during session state finalization — all upfront, not on-demand per layer. "Zero-copy" here refers to eliminating the intermediate host allocation: mapping weights directly from file to device. This is primarily relevant for the prefetch/offload pipeline (Phase D) where layers are streamed to GPU during execution rather than all loaded at once.
+
+### How to Approach
+
+#### Phase A: Workspace Pre-declaration (`DeclareWorkspaceRequirements`)
+
+The core missing piece. Today no kernel declares its temp buffer needs before `Compute()`. To close this gap, introduce a method on `OpKernel` that returns workspace descriptors — each with a size and a key for later retrieval.
+
+**Analogy to PrePack:** This mechanism is similar to the existing `PrePack()` pattern — both are called once during session state finalization (not during `Run()`), both store results that are reused across all subsequent runs. `PrePack()` pre-processes weight data; `DeclareWorkspaceRequirements()` pre-computes workspace layout.
+
+**Interface:**
+
+```cpp
+struct WorkspaceRequirement {
+  size_t size_bytes;        // Size of this workspace buffer
+  int slot_id;             // Kernel-defined slot identifier (0, 1, 2, ...)
+                           // Unique within a single kernel instance
+};
+
+// Optional override on OpKernel (called during FinalizeSessionState):
+virtual Status DeclareWorkspaceRequirements(
+    gsl::span<const TensorShape> input_shapes,
+    InlinedVector<WorkspaceRequirement>& requirements) const {
+  return Status::OK();  // Default: no declaration (fall back to arena)
+}
+```
+
+A kernel can declare multiple workspace slots (e.g., attention needs separate Q transpose buffer, output buffer, seqlens buffer). The `slot_id` is defined by the kernel author and is stable across calls — it identifies *which* buffer within that kernel's logic.
+
+**Key constraint:** Multiple nodes may use the same kernel class. Each node instance gets its own set of workspace slots. The unique key for retrieval is `(NodeIndex, slot_id)` — the framework supplies `NodeIndex`, the kernel supplies `slot_id`.
+
+**Memory reuse via liveness-based offset planning:**
+
+Workspace buffers are live only during their kernel's execution step. This means workspaces from non-overlapping steps can share the same physical memory — exactly the same liveness analysis already used for activation tensors. The offset planner assigns overlapping offsets to workspaces whose liveness intervals don't intersect:
+
+```
+Step 0: Node A workspace (slots 0,1) → offsets [0, 4096]
+Step 1: Node B workspace (slot 0)    → offset [0]  ← reuses Node A's memory
+Step 2: Node C workspace (slots 0,1) → offsets [0, 8192]  ← reuses again
+```
+
+Peak workspace memory = max over all steps of (sum of workspace slots for that step), not the sum of all workspaces across all nodes.
+
+**Concurrency model (multiple concurrent `Run()` calls):**
+
+The existing memory pattern system already handles this correctly:
+- The **pattern** (offset/size map) is computed once during `Initialize()` and cached in `SessionState` — shared, read-only.
+- The **actual buffer** is allocated per-`Run()` by each `ExecutionFrame` using the pattern as a blueprint.
+- Each concurrent `Run()` gets its own `ExecutionFrame` with its own workspace buffer — no sharing, no synchronization needed.
+
+Workspace pre-allocation follows the same model:
+- `DeclareWorkspaceRequirements()` is called during `FinalizeSessionState()` → produces a workspace offset plan (shared, immutable).
+- Each `Run()` allocates a workspace buffer of `peak_workspace_size` bytes and uses offsets from the plan.
+- Concurrent runs each get their own buffer — safe without locks.
+
+**Note on CUDA:** In practice, concurrent `Run()` on the same CUDA session is uncommon (users don't typically do this). But the design should remain thread-safe by following the same per-run buffer pattern.
+
+**Planning flow (during FinalizeSessionState):**
+
+1. For each kernel in the execution plan (when shapes are static), call `DeclareWorkspaceRequirements()` with the inferred input shapes.
+2. Record `{NodeIndex, slot_id} → size_bytes` in the execution plan.
+3. Run liveness analysis: workspace for node N is live only during step N's execution.
+4. Compute offsets (same algorithm as activation patterns) → yields `peak_workspace_size` and per-slot offsets.
+5. Store workspace pattern in `SessionState` (like memory patterns).
+
+**Per-Run retrieval (during Compute):**
+
+Each `ExecutionFrame` allocates a workspace buffer of `peak_workspace_size` via `Reserve()` and provides offset-based access:
+
+**Alternative A: Transparent fallback in GetScratchBuffer**
+
+Modify `GetScratchBuffer<T>(slot_id, size, stream)` to check for a pre-planned buffer first:
+
+```cpp
+template <typename T>
+IAllocatorUniquePtr<T> GetScratchBuffer(int slot_id, size_t count_or_bytes, Stream* stream) const {
+  // Check if workspace was pre-planned for this node + slot
+  void* preallocated = context_.GetPreallocatedWorkspace(slot_id);
+  if (preallocated) {
+    // Return non-owning pointer (buffer lifetime managed by the frame)
+    return IAllocatorUniquePtr<T>(static_cast<T*>(preallocated), [](T*){});
+  }
+  // Fall back to arena (dynamic shapes, or DeclareWorkspaceRequirements not implemented)
+  return IAllocator::MakeUniquePtr<T>(allocator_, count_or_bytes, false, stream);
+}
+```
+
+Pro: Minimal kernel code changes — just add `slot_id` parameter. Con: Overloads `GetScratchBuffer` semantics; non-owning vs owning pointer distinction is subtle.
+
+**Alternative B: Separate retrieval path**
+
+Keep `GetScratchBuffer()` unchanged for arena allocation. Add a new method:
+
+```cpp
+// In OpKernelContext:
+void* GetPreallocatedWorkspace(int slot_id) const;
+// Returns nullptr if not pre-planned → kernel must call GetScratchBuffer() instead
+
+// Kernel usage:
+void* ws = context->GetPreallocatedWorkspace(0);
+if (!ws) {
+  scratch_buffer_ = GetScratchBuffer<void>(workspace_size, stream);
+  ws = scratch_buffer_.get();
+}
+```
+
+Pro: Clear separation, no ambiguity about ownership. Con: Kernels need explicit fallback logic (but this is a one-time pattern per kernel).
+
+**Compatibility with dynamic shapes:** Both alternatives are opt-in. If `DeclareWorkspaceRequirements()` is not overridden or returns empty (dynamic shapes), everything falls back to `GetScratchBuffer()` → arena, exactly as today. Same kernel binary works for both static and dynamic models.
+
+**Incremental adoption:** Start with the highest-impact ops (attention, convolution, GEMM) which account for the majority of workspace. Less common ops continue using the arena with a reduced safety multiplier in `IResourceAccountant`.
+
+**Buffer strategy:** Workspace offsets can share the activation buffer (liveness doesn't overlap — workspace is live only during its step, activations may span steps). Alternatively, a separate workspace buffer is simpler initially and easier to account for in memory limits.
+
+#### Phase B: Eliminate Arena for Static-Shape Models
+
+Once workspace is pre-declared, **all** allocations for a static-shape model are known at `Initialize()` time:
+- Initializers → already `Reserve()` (done)
+- Activations → already memory-pattern `Reserve()` (done)
+- Workspace → new, via Phase A
+
+At this point, the BFC arena serves no purpose for the main execution path. The session could:
+1. Pre-allocate exact memory per device (sum of pattern peak + workspace peak)
+2. Use offset-based addressing for all buffers
+3. Disable the arena entirely for this session (save memory waste from chunk granularity)
+
+Runtime temp buffers from ops that don't implement `DeclareWorkspaceRequirements()` can still fall back to a small arena.
+
+#### Phase C: Automatic Partitioning with Memory Budget
+
+Combine Phase A + Direction 1:
+
+```
+# User specifies only the budget, ORT figures out the split:
+session.resource_cuda_partitioning_settings = "memory_limit=6GB"
+```
+
+Flow:
+1. Load model, run shape inference for target input shapes
+2. Compute per-layer memory requirements
+3. Greedily assign layers to GPU until budget exhausted
+4. Remaining layers → CPU
+5. Optionally: overlap CPU compute with GPU→CPU transfers (pipeline)
+
+#### Phase D: Layer Prefetch/Offload Pipeline
+
+For models that don't fit in GPU at all, but where layer-sequential execution allows streaming:
+
+1. While GPU executes layer N, prefetch layer N+1 weights from CPU→GPU
+2. After layer N completes, offload its weights back (or discard if not needed for backward)
+3. This requires explicit memory management and CUDA stream orchestration
+
+ORT's existing `Stream` infrastructure in the framework could support this, but would need:
+- A "layer executor" that knows the sequential dependency chain
+- Explicit prefetch scheduling (similar to how `MemoryOptimizer` in training handles activation offload)
+
+### What's Achievable Without a Custom Executable
+
+Unlike llama.cpp which is a monolithic binary, ORT can achieve most of this within the existing session API:
+
+- **Static buffer pre-allocation**: Extend `SessionOptions` with a "static allocation mode" flag + input shape hints
+- **Automatic layer splitting**: Combine name-based matching + memory planning in `Initialize()`
+- **Prefetch pipeline**: Implement as an execution strategy in `SequentialExecutor` when model is detected as layer-sequential
+
+What you **cannot** easily do without a custom executable:
+- Continuous batching / speculative decoding (requires application-level scheduling)
+- Dynamic KV cache management (though GenAI already handles this)
+
+---
+
+## Recommended Roadmap
+
+```
+Near-term (low effort, high value):
+├── 1. Name-based matching in LayeringRuleMatcher
+│     - Add 'name:' prefix qualifier to config syntax
+│     - Match against Node::Name() instead of metadata
+│     - Support range expressions for numbered layers
+│
+├── 2. Precise memory estimation for static-shape models
+│     - Run shape inference during Initialize() when shapes are known
+│     - Compute exact per-layer memory in IResourceAccountant
+│
+Mid-term (medium effort):
+├── 3. Auto-partitioning with memory budget only
+│     - User specifies "6GB GPU budget"
+│     - ORT computes optimal layer split automatically
+│     - Combines (1) + (2)
+│
+├── 4. Static allocation mode
+│     - Pre-allocate all buffers when shapes are known
+│     - Eliminate per-Run() allocation overhead
+│
+Long-term (high effort, ollama-parity):
+├── 5. Layer prefetch pipeline
+│     - Stream weights CPU↔GPU during execution
+│     - Enables running models larger than GPU memory
+│
+└── 6. Integration with GenAI
+      - KV cache-aware memory planning
+      - Continuous batching + layer offload coordination
+```
+
+---
+
+## Key Insight
+
+The fundamental difference between ORT and llama.cpp for this use case is **generality vs specialization**. llama.cpp knows it's running a transformer with sequential layers. ORT handles arbitrary graphs. The trick is to **detect** when a model is transformer-like (sequential layers, static shapes) and engage a specialized execution path — without losing generality for other model types.
+
+Direction 1 (name-based matching) is the lowest-friction win: it makes the existing annotation system accessible without model modification. Direction 2 (static pre-allocation + auto-splitting) is what closes the gap with ollama but requires more infrastructure work, particularly around shape-aware memory planning at partition time.

--- a/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
+++ b/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
@@ -427,8 +427,11 @@ static const char* const kOrtSessionOptionsLayerAssignmentSettings = "session.la
 /// The '=' prefix (exact match) from the annotation-based grammar is rejected with an error
 /// — all patterns are treated as substrings.
 /// Longest matching pattern wins when multiple patterns match the same node name.
-/// If both this option and kOrtSessionOptionsLayerAssignmentSettings are set,
-/// annotation-based matching takes priority for nodes that have annotations.
+/// No subgraph inheritance is applied — each node is matched independently by its name.
+///
+/// MUTUALLY EXCLUSIVE with kOrtSessionOptionsLayerAssignmentSettings. Setting both returns
+/// INVALID_ARGUMENT. Use annotation-based matching for models with explicit layer annotations,
+/// or name-based matching for models with structured node names (HuggingFace, PyTorch exports).
 /// </summary>
 static const char* const kOrtSessionOptionsNameBasedLayerAssignment = "session.name_based_layer_assignment";
 

--- a/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
+++ b/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
@@ -424,7 +424,7 @@ static const char* const kOrtSessionOptionsLayerAssignmentSettings = "session.la
 /// Name-based layer assignment. Uses the same device(pattern1, pattern2, ...); ... grammar
 /// as kOrtSessionOptionsLayerAssignmentSettings but performs SUBSTRING matching against
 /// Node::Name() instead of prefix/exact matching against node metadata annotations.
-/// The '=' prefix (exact match) from the annotation-based grammar is NOT supported here
+/// The '=' prefix (exact match) from the annotation-based grammar is rejected with an error
 /// — all patterns are treated as substrings.
 /// Longest matching pattern wins when multiple patterns match the same node name.
 /// If both this option and kOrtSessionOptionsLayerAssignmentSettings are set,

--- a/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
+++ b/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
@@ -420,6 +420,18 @@ static const char* const kOrtSessionOptionsResourceCudaPartitioningSettings =
 /// </summary>
 static const char* const kOrtSessionOptionsLayerAssignmentSettings = "session.layer_assignment_settings";
 
+/// <summary>
+/// Name-based layer assignment. Uses the same device(pattern1, pattern2, ...); ... grammar
+/// as kOrtSessionOptionsLayerAssignmentSettings but performs SUBSTRING matching against
+/// Node::Name() instead of prefix/exact matching against node metadata annotations.
+/// The '=' prefix (exact match) from the annotation-based grammar is NOT supported here
+/// — all patterns are treated as substrings.
+/// Longest matching pattern wins when multiple patterns match the same node name.
+/// If both this option and kOrtSessionOptionsLayerAssignmentSettings are set,
+/// annotation-based matching takes priority for nodes that have annotations.
+/// </summary>
+static const char* const kOrtSessionOptionsNameBasedLayerAssignment = "session.name_based_layer_assignment";
+
 // Enable EP context feature to dump the partitioned graph which includes the EP context into Onnx file.
 // The dumped Onnx model with EP context can be used for future inference to avoid the EP graph partitioning/compile overhead.
 // "0": disable. (default)

--- a/onnxruntime/core/framework/layering_annotations.cc
+++ b/onnxruntime/core/framework/layering_annotations.cc
@@ -13,6 +13,7 @@
 #include "core/framework/execution_providers.h"
 #include "core/graph/graph.h"
 
+#include <algorithm>
 #include <limits>
 
 namespace onnxruntime {
@@ -335,28 +336,50 @@ LayeringIndex LayeringIndex::Create(const Graph& graph,
                                     EpNameToLayeringIndices ep_map,
                                     LayeringIndexToEpName rule_map,
                                     LayeringRules layering_rules) {
-  // 1. Create LayeringIndex instance with pre-computed maps
   LayeringIndex index(std::move(layering_rules), std::move(ep_map), std::move(rule_map));
-
-  // 2. Traverse the graph and index nodes
   index.ProcessGraph(graph, std::nullopt);
+  return index;
+}
 
+LayeringIndex LayeringIndex::Create(const Graph& graph,
+                                    EpNameToLayeringIndices ep_map,
+                                    LayeringIndexToEpName rule_map,
+                                    LayeringRules layering_rules,
+                                    SubstringMatcher substring_matcher) {
+  LayeringIndex index(std::move(layering_rules), std::move(ep_map), std::move(rule_map), std::move(substring_matcher));
+  index.ProcessGraph(graph, std::nullopt);
   return index;
 }
 
 Status LayeringIndex::Create(const Graph& graph,
                              const std::string& config_string,
+                             const std::string& name_based_config_string,
                              gsl::span<const OrtEpDevice* const> ep_devices,
                              const ExecutionProviders& ep_providers,
                              const logging::Logger& logger,
                              std::optional<LayeringIndex>& layering_index) {
+  // Parse annotation-based rules
   LayeringRules rules;
-  ORT_RETURN_IF_ERROR(LayeringRules::FromConfigString(config_string, rules));
+  if (!config_string.empty()) {
+    ORT_RETURN_IF_ERROR(LayeringRules::FromConfigString(config_string, rules));
+    LOGS(logger, INFO) << "Parsed " << rules.rules.size() << " annotation-based layering rules from config.";
+  }
 
-  LOGS(logger, INFO) << "Parsed " << rules.rules.size() << " layering rules from config.";
+  // Parse name-based rules
+  LayeringRules name_rules;
+  if (!name_based_config_string.empty()) {
+    ORT_RETURN_IF_ERROR(LayeringRules::FromConfigString(name_based_config_string, name_rules));
+    LOGS(logger, INFO) << "Parsed " << name_rules.rules.size() << " name-based layering rules from config.";
+  }
+
+  // Merge both rule sets: annotation-based rules first (lower indices = higher priority in ProcessGraph),
+  // then name-based rules appended. The SubstringMatcher will operate on name-based rules only.
+  const size_t annotation_rule_count = rules.rules.size();
+  for (auto& nr : name_rules.rules) {
+    rules.rules.push_back(std::move(nr));
+  }
 
   if (rules.rules.empty()) {
-    // Return no index indicating no layering
     layering_index.reset();
     return Status::OK();
   }
@@ -384,9 +407,6 @@ Status LayeringIndex::Create(const Graph& graph,
     if (matched_ep) {
       const std::string& ep_type = *matched_ep;
       ep_map[ep_type].insert(i);
-      // Ensure 1:1 mapping from rule index to EP type
-      // Note: A rule index refers to a unique entry in LayeringRules::rules vector.
-      // So 'i' is unique.
       rule_map[i] = ep_type;
       matched_rule_count++;
       LOGS(logger, VERBOSE) << "Layering Rule " << i << " (" << rule.device << " -> " << rule.annotation
@@ -402,7 +422,22 @@ Status LayeringIndex::Create(const Graph& graph,
   LOGS(logger, INFO) << "LayeringIndex created. Matched " << matched_rule_count
                      << " out of " << rules.rules.size() << " rules to available Execution Providers.";
 
-  layering_index = LayeringIndex::Create(graph, std::move(ep_map), std::move(rule_map), std::move(rules));
+  // Build SubstringMatcher from name-based rules only (indices offset by annotation_rule_count)
+  std::optional<SubstringMatcher> substring_matcher;
+  if (annotation_rule_count < rules.rules.size()) {
+    // Create a LayeringRules containing only the name-based portion
+    // SubstringMatcher stores rule indices offset to align with the merged rules vector
+    LayeringRules name_only_rules;
+    for (size_t i = annotation_rule_count; i < rules.rules.size(); ++i) {
+      name_only_rules.rules.push_back(rules.rules[i]);
+    }
+    substring_matcher.emplace(name_only_rules, annotation_rule_count);
+  }
+
+  // Create LayeringIndex with the merged rules
+  LayeringIndex index(std::move(rules), std::move(ep_map), std::move(rule_map), std::move(substring_matcher));
+  index.ProcessGraph(graph, std::nullopt);
+  layering_index = std::move(index);
   return Status::OK();
 }
 
@@ -423,11 +458,16 @@ void LayeringIndex::ProcessGraph(const Graph& graph, std::optional<size_t> paren
   for (auto& node : graph.Nodes()) {
     std::optional<size_t> matched_rule_idx = std::nullopt;
 
-    // 4. For every node query its annotation
+    // 4. For every node query its annotation (prefix/exact match)
     const std::string& annotation = node.GetLayeringAnnotation();
     if (!annotation.empty()) {
       // If it has an annotation try to match it
       matched_rule_idx = matcher_.Match(annotation);
+    }
+
+    // 4b. If no annotation match, try substring matching against node name
+    if (!matched_rule_idx && substring_matcher_) {
+      matched_rule_idx = substring_matcher_->Match(node.Name());
     }
 
     // 5. If node has no annotation, inherit from subgraph parent node
@@ -542,6 +582,30 @@ void LayeringRuleMatcher::UpdateBestMatch(std::optional<size_t>& current_best, s
   if (!current_best || candidate < *current_best) {
     current_best = candidate;
   }
+}
+
+SubstringMatcher::SubstringMatcher(const LayeringRules& rules, size_t rule_index_offset) {
+  for (size_t i = 0; i < rules.rules.size(); ++i) {
+    const auto& rule = rules.rules[i];
+    if (!rule.annotation.empty()) {
+      patterns_.push_back({rule.annotation, i + rule_index_offset});
+    }
+  }
+  // Sort by pattern length descending (longest first).
+  // Stable sort preserves config order as tiebreaker for same-length patterns.
+  std::stable_sort(patterns_.begin(), patterns_.end(),
+                   [](const PatternEntry& a, const PatternEntry& b) {
+                     return a.pattern.size() > b.pattern.size();
+                   });
+}
+
+std::optional<size_t> SubstringMatcher::Match(std::string_view node_name) const {
+  for (const auto& entry : patterns_) {
+    if (node_name.find(entry.pattern) != std::string_view::npos) {
+      return entry.rule_index;
+    }
+  }
+  return std::nullopt;
 }
 
 std::optional<std::reference_wrapper<const InlinedHashSet<size_t>>>

--- a/onnxruntime/core/framework/layering_annotations.cc
+++ b/onnxruntime/core/framework/layering_annotations.cc
@@ -91,10 +91,8 @@ common::Status LayeringRules::FromConfigString(const std::string& config_value, 
   return common::Status::OK();
 }
 
-LayeringRuleMatcher::LayeringRuleMatcher(const LayeringRules& rules, std::optional<size_t> annotation_rule_count) {
-  const size_t limit = annotation_rule_count.has_value() ? std::min(*annotation_rule_count, rules.rules.size())
-                                                         : rules.rules.size();
-  for (size_t i = 0; i < limit; ++i) {
+LayeringRuleMatcher::LayeringRuleMatcher(const LayeringRules& rules) {
+  for (size_t i = 0; i < rules.rules.size(); ++i) {
     const auto& rule = rules.rules[i];
     ORT_ENFORCE(!rule.annotation.empty(), "Layering rule annotation cannot be empty");
     if (rule.prefix_match) {
@@ -347,10 +345,9 @@ LayeringIndex LayeringIndex::Create(const Graph& graph,
                                     EpNameToLayeringIndices ep_map,
                                     LayeringIndexToEpName rule_map,
                                     LayeringRules layering_rules,
-                                    SubstringMatcher substring_matcher,
-                                    std::optional<size_t> annotation_rule_count) {
+                                    SubstringMatcher substring_matcher) {
   LayeringIndex index(std::move(layering_rules), std::move(ep_map), std::move(rule_map),
-                      std::move(substring_matcher), annotation_rule_count);
+                      std::move(substring_matcher));
   index.ProcessGraph(graph, std::nullopt);
   return index;
 }
@@ -362,32 +359,36 @@ Status LayeringIndex::Create(const Graph& graph,
                              const ExecutionProviders& ep_providers,
                              const logging::Logger& logger,
                              std::optional<LayeringIndex>& layering_index) {
-  // Parse annotation-based rules
+  // Annotation-based and name-based layer assignment are mutually exclusive.
+  if (!config_string.empty() && !name_based_config_string.empty()) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                           "Cannot set both 'session.layer_assignment_settings' and "
+                           "'session.name_based_layer_assignment'. These options are mutually exclusive. "
+                           "Use annotation-based matching for models with explicit layer annotations, "
+                           "or name-based matching for models with structured node names.");
+  }
+
+  const bool is_name_based = !name_based_config_string.empty();
+  const std::string& active_config = is_name_based ? name_based_config_string : config_string;
+
   LayeringRules rules;
-  if (!config_string.empty()) {
-    ORT_RETURN_IF_ERROR(LayeringRules::FromConfigString(config_string, rules));
-    LOGS(logger, INFO) << "Parsed " << rules.rules.size() << " annotation-based layering rules from config.";
-  }
+  if (!active_config.empty()) {
+    ORT_RETURN_IF_ERROR(LayeringRules::FromConfigString(active_config, rules));
 
-  // Parse name-based rules
-  LayeringRules name_rules;
-  if (!name_based_config_string.empty()) {
-    ORT_RETURN_IF_ERROR(LayeringRules::FromConfigString(name_based_config_string, name_rules));
-    // Reject '=' (exact-match qualifier) in name-based rules — all patterns must be substrings
-    for (const auto& rule : name_rules.rules) {
-      ORT_RETURN_IF(!rule.prefix_match,
-                    "Name-based layer assignment does not support the '=' (exact-match) qualifier. "
-                    "All patterns are treated as substrings. Remove the '=' prefix from pattern: '",
-                    rule.annotation, "'");
+    if (is_name_based) {
+      // Reject '=' (exact-match qualifier) in name-based rules — all patterns must be substrings
+      for (const auto& rule : rules.rules) {
+        if (!rule.prefix_match) {
+          return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                                 "Name-based layer assignment does not support the '=' (exact-match) qualifier. "
+                                 "All patterns are treated as substrings. Remove the '=' prefix from pattern: '",
+                                 rule.annotation, "'");
+        }
+      }
+      LOGS(logger, INFO) << "Parsed " << rules.rules.size() << " name-based layering rules from config.";
+    } else {
+      LOGS(logger, INFO) << "Parsed " << rules.rules.size() << " annotation-based layering rules from config.";
     }
-    LOGS(logger, INFO) << "Parsed " << name_rules.rules.size() << " name-based layering rules from config.";
-  }
-
-  // Merge both rule sets: annotation-based rules first (lower indices = higher priority in ProcessGraph),
-  // then name-based rules appended. The SubstringMatcher will operate on name-based rules only.
-  const size_t annotation_rule_count = rules.rules.size();
-  for (auto& nr : name_rules.rules) {
-    rules.rules.push_back(std::move(nr));
   }
 
   if (rules.rules.empty()) {
@@ -433,21 +434,15 @@ Status LayeringIndex::Create(const Graph& graph,
   LOGS(logger, INFO) << "LayeringIndex created. Matched " << matched_rule_count
                      << " out of " << rules.rules.size() << " rules to available Execution Providers.";
 
-  // Build SubstringMatcher from name-based rules only (indices offset by annotation_rule_count)
+  // Build SubstringMatcher for name-based mode
   std::optional<SubstringMatcher> substring_matcher;
-  if (annotation_rule_count < rules.rules.size()) {
-    // Create a LayeringRules containing only the name-based portion
-    // SubstringMatcher stores rule indices offset to align with the merged rules vector
-    LayeringRules name_only_rules;
-    for (size_t i = annotation_rule_count; i < rules.rules.size(); ++i) {
-      name_only_rules.rules.push_back(rules.rules[i]);
-    }
-    substring_matcher.emplace(name_only_rules, annotation_rule_count);
+  if (is_name_based) {
+    substring_matcher.emplace(rules);
   }
 
-  // Create LayeringIndex with the merged rules
+  // Create LayeringIndex — annotation mode uses matcher_ only, name-based uses substring_matcher_ only
   LayeringIndex index(std::move(rules), std::move(ep_map), std::move(rule_map),
-                      std::move(substring_matcher), annotation_rule_count);
+                      std::move(substring_matcher));
   index.ProcessGraph(graph, std::nullopt);
   layering_index = std::move(index);
   return Status::OK();
@@ -470,21 +465,23 @@ void LayeringIndex::ProcessGraph(const Graph& graph, std::optional<size_t> paren
   for (auto& node : graph.Nodes()) {
     std::optional<size_t> matched_rule_idx = std::nullopt;
 
-    // 4. For every node query its annotation (prefix/exact match)
-    const std::string& annotation = node.GetLayeringAnnotation();
-    if (!annotation.empty()) {
-      // If it has an annotation try to match it
-      matched_rule_idx = matcher_.Match(annotation);
-    }
-
-    // 4b. If no annotation match, try substring matching against node name
-    if (!matched_rule_idx && substring_matcher_) {
+    if (substring_matcher_) {
+      // Name-based mode: substring matching against node name, no inheritance.
+      // Node names are dense (virtually every node has one), so inheritance is
+      // unnecessary — each node is matched independently by its own name.
       matched_rule_idx = substring_matcher_->Match(node.Name());
-    }
+    } else {
+      // Annotation-based mode: prefix/exact match against metadata annotation,
+      // with subgraph inheritance for unannotated nodes.
+      const std::string& annotation = node.GetLayeringAnnotation();
+      if (!annotation.empty()) {
+        matched_rule_idx = matcher_.Match(annotation);
+      }
 
-    // 5. If node has no annotation, inherit from subgraph parent node
-    if (!matched_rule_idx && parent_layer_id) {
-      matched_rule_idx = parent_layer_id;
+      // Inherit from subgraph parent node if no annotation match
+      if (!matched_rule_idx && parent_layer_id) {
+        matched_rule_idx = parent_layer_id;
+      }
     }
 
     // Record assignment if we have a match
@@ -539,15 +536,15 @@ void LayeringIndex::Update(const Graph& graph, gsl::span<const NodeIndex> nodes)
 
     std::optional<size_t> matched_rule_idx;
 
-    // Try annotation-based matching first (higher priority)
-    const std::string& annotation = node->GetLayeringAnnotation();
-    if (!annotation.empty()) {
-      matched_rule_idx = matcher_.Match(annotation);
-    }
-
-    // Fallback to substring matching against node name
-    if (!matched_rule_idx && substring_matcher_) {
+    if (substring_matcher_) {
+      // Name-based mode: substring match against node name
       matched_rule_idx = substring_matcher_->Match(node->Name());
+    } else {
+      // Annotation-based mode: prefix/exact match against metadata
+      const std::string& annotation = node->GetLayeringAnnotation();
+      if (!annotation.empty()) {
+        matched_rule_idx = matcher_.Match(annotation);
+      }
     }
 
     if (matched_rule_idx) {
@@ -604,11 +601,11 @@ void LayeringRuleMatcher::UpdateBestMatch(std::optional<size_t>& current_best, s
   }
 }
 
-SubstringMatcher::SubstringMatcher(const LayeringRules& rules, size_t name_rules_start_index) {
+SubstringMatcher::SubstringMatcher(const LayeringRules& rules) {
   for (size_t i = 0; i < rules.rules.size(); ++i) {
     const auto& rule = rules.rules[i];
     if (!rule.annotation.empty()) {
-      patterns_.push_back({rule.annotation, i + name_rules_start_index});
+      patterns_.push_back({rule.annotation, i});
     }
   }
   // Sort by pattern length descending (longest first).

--- a/onnxruntime/core/framework/layering_annotations.cc
+++ b/onnxruntime/core/framework/layering_annotations.cc
@@ -346,8 +346,10 @@ LayeringIndex LayeringIndex::Create(const Graph& graph,
                                     EpNameToLayeringIndices ep_map,
                                     LayeringIndexToEpName rule_map,
                                     LayeringRules layering_rules,
-                                    SubstringMatcher substring_matcher) {
-  LayeringIndex index(std::move(layering_rules), std::move(ep_map), std::move(rule_map), std::move(substring_matcher));
+                                    SubstringMatcher substring_matcher,
+                                    size_t annotation_rule_count) {
+  LayeringIndex index(std::move(layering_rules), std::move(ep_map), std::move(rule_map),
+                      std::move(substring_matcher), annotation_rule_count);
   index.ProcessGraph(graph, std::nullopt);
   return index;
 }

--- a/onnxruntime/core/framework/layering_annotations.cc
+++ b/onnxruntime/core/framework/layering_annotations.cc
@@ -91,8 +91,9 @@ common::Status LayeringRules::FromConfigString(const std::string& config_value, 
   return common::Status::OK();
 }
 
-LayeringRuleMatcher::LayeringRuleMatcher(const LayeringRules& rules, size_t rule_count) {
-  const size_t limit = (rule_count == 0) ? rules.rules.size() : std::min(rule_count, rules.rules.size());
+LayeringRuleMatcher::LayeringRuleMatcher(const LayeringRules& rules, std::optional<size_t> annotation_rule_count) {
+  const size_t limit = annotation_rule_count.has_value() ? std::min(*annotation_rule_count, rules.rules.size())
+                                                         : rules.rules.size();
   for (size_t i = 0; i < limit; ++i) {
     const auto& rule = rules.rules[i];
     ORT_ENFORCE(!rule.annotation.empty(), "Layering rule annotation cannot be empty");
@@ -347,7 +348,7 @@ LayeringIndex LayeringIndex::Create(const Graph& graph,
                                     LayeringIndexToEpName rule_map,
                                     LayeringRules layering_rules,
                                     SubstringMatcher substring_matcher,
-                                    size_t annotation_rule_count) {
+                                    std::optional<size_t> annotation_rule_count) {
   LayeringIndex index(std::move(layering_rules), std::move(ep_map), std::move(rule_map),
                       std::move(substring_matcher), annotation_rule_count);
   index.ProcessGraph(graph, std::nullopt);
@@ -603,11 +604,11 @@ void LayeringRuleMatcher::UpdateBestMatch(std::optional<size_t>& current_best, s
   }
 }
 
-SubstringMatcher::SubstringMatcher(const LayeringRules& rules, size_t rule_index_offset) {
+SubstringMatcher::SubstringMatcher(const LayeringRules& rules, size_t name_rules_start_index) {
   for (size_t i = 0; i < rules.rules.size(); ++i) {
     const auto& rule = rules.rules[i];
     if (!rule.annotation.empty()) {
-      patterns_.push_back({rule.annotation, i + rule_index_offset});
+      patterns_.push_back({rule.annotation, i + name_rules_start_index});
     }
   }
   // Sort by pattern length descending (longest first).

--- a/onnxruntime/core/framework/layering_annotations.cc
+++ b/onnxruntime/core/framework/layering_annotations.cc
@@ -91,8 +91,9 @@ common::Status LayeringRules::FromConfigString(const std::string& config_value, 
   return common::Status::OK();
 }
 
-LayeringRuleMatcher::LayeringRuleMatcher(const LayeringRules& rules) {
-  for (size_t i = 0; i < rules.rules.size(); ++i) {
+LayeringRuleMatcher::LayeringRuleMatcher(const LayeringRules& rules, size_t rule_count) {
+  const size_t limit = (rule_count == 0) ? rules.rules.size() : std::min(rule_count, rules.rules.size());
+  for (size_t i = 0; i < limit; ++i) {
     const auto& rule = rules.rules[i];
     ORT_ENFORCE(!rule.annotation.empty(), "Layering rule annotation cannot be empty");
     if (rule.prefix_match) {
@@ -369,6 +370,13 @@ Status LayeringIndex::Create(const Graph& graph,
   LayeringRules name_rules;
   if (!name_based_config_string.empty()) {
     ORT_RETURN_IF_ERROR(LayeringRules::FromConfigString(name_based_config_string, name_rules));
+    // Reject '=' (exact-match qualifier) in name-based rules — all patterns must be substrings
+    for (const auto& rule : name_rules.rules) {
+      ORT_RETURN_IF(!rule.prefix_match,
+                    "Name-based layer assignment does not support the '=' (exact-match) qualifier. "
+                    "All patterns are treated as substrings. Remove the '=' prefix from pattern: '",
+                    rule.annotation, "'");
+    }
     LOGS(logger, INFO) << "Parsed " << name_rules.rules.size() << " name-based layering rules from config.";
   }
 
@@ -435,7 +443,8 @@ Status LayeringIndex::Create(const Graph& graph,
   }
 
   // Create LayeringIndex with the merged rules
-  LayeringIndex index(std::move(rules), std::move(ep_map), std::move(rule_map), std::move(substring_matcher));
+  LayeringIndex index(std::move(rules), std::move(ep_map), std::move(rule_map),
+                      std::move(substring_matcher), annotation_rule_count);
   index.ProcessGraph(graph, std::nullopt);
   layering_index = std::move(index);
   return Status::OK();
@@ -525,28 +534,36 @@ void LayeringIndex::Update(const Graph& graph, gsl::span<const NodeIndex> nodes)
       continue;
     }
 
+    std::optional<size_t> matched_rule_idx;
+
+    // Try annotation-based matching first (higher priority)
     const std::string& annotation = node->GetLayeringAnnotation();
     if (!annotation.empty()) {
-      auto matched_rule_idx = matcher_.Match(annotation);
+      matched_rule_idx = matcher_.Match(annotation);
+    }
 
-      if (matched_rule_idx) {
-        const size_t rule_idx = *matched_rule_idx;
+    // Fallback to substring matching against node name
+    if (!matched_rule_idx && substring_matcher_) {
+      matched_rule_idx = substring_matcher_->Match(node->Name());
+    }
 
-        // Only assign if this rule maps to a valid EP in our configuration
-        if (layering_index_to_ep_name_.count(rule_idx)) {
-          // Check if already assigned to a DIFFERENT rule, if so clean up old mapping
-          auto prev_assign = current_graph_index.node_to_layering_index_.find(node_index);
-          if (prev_assign != current_graph_index.node_to_layering_index_.end()) {
-            size_t old_rule = prev_assign->second;
-            if (old_rule != rule_idx) {
-              current_graph_index.layer_to_node_ids_[old_rule].erase(node_index);
-            }
+    if (matched_rule_idx) {
+      const size_t rule_idx = *matched_rule_idx;
+
+      // Only assign if this rule maps to a valid EP in our configuration
+      if (layering_index_to_ep_name_.count(rule_idx)) {
+        // Check if already assigned to a DIFFERENT rule, if so clean up old mapping
+        auto prev_assign = current_graph_index.node_to_layering_index_.find(node_index);
+        if (prev_assign != current_graph_index.node_to_layering_index_.end()) {
+          size_t old_rule = prev_assign->second;
+          if (old_rule != rule_idx) {
+            current_graph_index.layer_to_node_ids_[old_rule].erase(node_index);
           }
-
-          ORT_IGNORE_RETURN_VALUE(current_graph_index.node_to_layering_index_.insert_or_assign(node_index, rule_idx));
-          ORT_IGNORE_RETURN_VALUE(current_graph_index.layer_to_node_ids_[rule_idx].insert(node_index));
-          was_updated = true;
         }
+
+        ORT_IGNORE_RETURN_VALUE(current_graph_index.node_to_layering_index_.insert_or_assign(node_index, rule_idx));
+        ORT_IGNORE_RETURN_VALUE(current_graph_index.layer_to_node_ids_[rule_idx].insert(node_index));
+        was_updated = true;
       }
     }
   }

--- a/onnxruntime/core/framework/layering_annotations.h
+++ b/onnxruntime/core/framework/layering_annotations.h
@@ -11,6 +11,7 @@
 #include "core/common/logging/logging.h"
 #include "gsl/gsl"
 #include <string>
+#include <string_view>
 #include <vector>
 #include <optional>
 #include <memory>
@@ -83,6 +84,36 @@ class LayeringRuleMatcher {
   void UpdateBestMatch(std::optional<size_t>& current_best, size_t candidate) const;
 };
 
+/// <summary>
+/// Performs substring matching against node names. Unlike LayeringRuleMatcher (which does
+/// prefix/exact matching from position 0), this matches patterns appearing anywhere in the
+/// input string. Longest matching pattern wins.
+/// </summary>
+class SubstringMatcher {
+ public:
+  /// <param name="rules">The rules whose annotations become substring patterns.
+  ///   The '=' prefix (exact match) qualifier is ignored — all patterns are substrings.</param>
+  /// <param name="rule_index_offset">Offset added to each pattern's local index to produce the
+  ///   global rule index in the merged LayeringRules vector.</param>
+  explicit SubstringMatcher(const LayeringRules& rules, size_t rule_index_offset = 0);
+
+  /// <summary>
+  /// Returns the index of the best matching rule for the given node name.
+  /// "Best" = longest pattern that appears as a substring in the name.
+  /// </summary>
+  /// <param name="node_name">the node's name to match against</param>
+  /// <returns>index of the matching LayeringRule if a substring match is found</returns>
+  std::optional<size_t> Match(std::string_view node_name) const;
+
+ private:
+  struct PatternEntry {
+    std::string pattern;
+    size_t rule_index;
+  };
+  // Sorted by pattern length descending. First match wins (longest-match priority).
+  InlinedVector<PatternEntry> patterns_;
+};
+
 namespace EpLayeringMatcher {
 /// <summary>
 /// Matches a list of available OrtEpDevices against the device string specified in the LayerAnnotation.
@@ -126,11 +157,22 @@ class LayeringIndex {
                               LayeringRules layering_rules);
 
   /// <summary>
+  /// Creates a fully initialized LayeringIndex with an optional SubstringMatcher for name-based matching.
+  /// </summary>
+  static LayeringIndex Create(const Graph& graph,
+                              EpNameToLayeringIndices ep_map,
+                              LayeringIndexToEpName rule_map,
+                              LayeringRules layering_rules,
+                              SubstringMatcher substring_matcher);
+
+  /// <summary>
   /// Factory method that creates a LayeringIndex by parsing configuration, matching rules against
   /// available devices/providers, and indexing the graph.
   /// </summary>
   /// <param name="graph">The graph to index.</param>
-  /// <param name="config_string">The configuration string containing layering rules.</param>
+  /// <param name="config_string">The annotation-based configuration string (prefix/exact match on metadata).</param>
+  /// <param name="name_based_config_string">The name-based configuration string (substring match on Node::Name()).
+  ///              May be empty if name-based matching is not configured.</param>
   /// <param name="ep_devices">Available OrtEpDevices to match rules against.</param>
   /// <param name="ep_providers">Available ExecutionProviders to match rules against (fallback).</param>
   /// <param name="logger">Logger for reporting information/errors.</param>
@@ -139,6 +181,7 @@ class LayeringIndex {
   /// <returns>Status indicating success or failure.</returns>
   static Status Create(const Graph& graph,
                        const std::string& config_string,
+                       const std::string& name_based_config_string,
                        gsl::span<const OrtEpDevice* const> ep_devices,
                        const ExecutionProviders& ep_providers,
                        const logging::Logger& logger,
@@ -192,11 +235,17 @@ class LayeringIndex {
     LayerIndexToNodes layer_to_node_ids_;
   };
 
-  LayeringIndex(LayeringRules layering_rules, EpNameToLayeringIndices ep_name_to_layering_indices, LayeringIndexToEpName layering_index_to_ep_name)
+  LayeringIndex(LayeringRules layering_rules, EpNameToLayeringIndices ep_name_to_layering_indices,
+                LayeringIndexToEpName layering_index_to_ep_name,
+                std::optional<SubstringMatcher> substring_matcher = std::nullopt)
       : rules_(std::move(layering_rules)),
         matcher_(rules_),
         ep_name_to_layering_indices_(std::move(ep_name_to_layering_indices)),
-        layering_index_to_ep_name_(std::move(layering_index_to_ep_name)) {}
+        layering_index_to_ep_name_(std::move(layering_index_to_ep_name)),
+        substring_matcher_(std::move(substring_matcher)) {}
+
+  // Optional substring matcher for name-based layer assignment
+  std::optional<SubstringMatcher> substring_matcher_;
 
   // Graph and sub-graphs mapping to their indices
   InlinedHashMap<const Graph*, GraphLayeringIndex> graph_index_;

--- a/onnxruntime/core/framework/layering_annotations.h
+++ b/onnxruntime/core/framework/layering_annotations.h
@@ -58,7 +58,11 @@ struct LayeringRules {
 /// </summary>
 class LayeringRuleMatcher {
  public:
-  explicit LayeringRuleMatcher(const LayeringRules& rules);
+  /// <param name="rules">The full set of layering rules.</param>
+  /// <param name="rule_count">Number of rules to index (from the beginning). If 0 or omitted,
+  ///   all rules are indexed. Use this to scope the matcher to annotation-based rules only
+  ///   when name-based rules are appended to the same vector.</param>
+  explicit LayeringRuleMatcher(const LayeringRules& rules, size_t rule_count = 0);
 
   /// <summary>
   /// The method returns the index of the best matching rule for the given annotation
@@ -237,9 +241,10 @@ class LayeringIndex {
 
   LayeringIndex(LayeringRules layering_rules, EpNameToLayeringIndices ep_name_to_layering_indices,
                 LayeringIndexToEpName layering_index_to_ep_name,
-                std::optional<SubstringMatcher> substring_matcher = std::nullopt)
+                std::optional<SubstringMatcher> substring_matcher = std::nullopt,
+                size_t annotation_rule_count = 0)
       : rules_(std::move(layering_rules)),
-        matcher_(rules_),
+        matcher_(rules_, annotation_rule_count),
         ep_name_to_layering_indices_(std::move(ep_name_to_layering_indices)),
         layering_index_to_ep_name_(std::move(layering_index_to_ep_name)),
         substring_matcher_(std::move(substring_matcher)) {}

--- a/onnxruntime/core/framework/layering_annotations.h
+++ b/onnxruntime/core/framework/layering_annotations.h
@@ -163,11 +163,15 @@ class LayeringIndex {
   /// <summary>
   /// Creates a fully initialized LayeringIndex with an optional SubstringMatcher for name-based matching.
   /// </summary>
+  /// <param name="annotation_rule_count">Number of rules (from the start of layering_rules) that are
+  ///   annotation-based. The annotation matcher will only index these rules. Rules beyond this index
+  ///   are name-based and matched exclusively via substring_matcher against Node::Name().</param>
   static LayeringIndex Create(const Graph& graph,
                               EpNameToLayeringIndices ep_map,
                               LayeringIndexToEpName rule_map,
                               LayeringRules layering_rules,
-                              SubstringMatcher substring_matcher);
+                              SubstringMatcher substring_matcher,
+                              size_t annotation_rule_count = 0);
 
   /// <summary>
   /// Factory method that creates a LayeringIndex by parsing configuration, matching rules against

--- a/onnxruntime/core/framework/layering_annotations.h
+++ b/onnxruntime/core/framework/layering_annotations.h
@@ -58,11 +58,15 @@ struct LayeringRules {
 /// </summary>
 class LayeringRuleMatcher {
  public:
-  /// <param name="rules">The full set of layering rules.</param>
-  /// <param name="rule_count">Number of rules to index (from the beginning). If 0 or omitted,
-  ///   all rules are indexed. Use this to scope the matcher to annotation-based rules only
-  ///   when name-based rules are appended to the same vector.</param>
-  explicit LayeringRuleMatcher(const LayeringRules& rules, size_t rule_count = 0);
+  /// <param name="rules">The full set of layering rules (may include appended name-based rules).</param>
+  /// <param name="annotation_rule_count">Number of annotation-based rules to index (from the beginning
+  ///   of the rules vector). If nullopt or omitted, all rules are indexed.
+  ///   If 0, no rules are indexed (disables annotation matching entirely).
+  ///   When name-based rules are appended after annotation rules in the same vector,
+  ///   pass the count of annotation rules so name-based patterns are excluded from
+  ///   the prefix/exact-match trie.</param>
+  explicit LayeringRuleMatcher(const LayeringRules& rules,
+                               std::optional<size_t> annotation_rule_count = std::nullopt);
 
   /// <summary>
   /// The method returns the index of the best matching rule for the given annotation
@@ -96,10 +100,14 @@ class LayeringRuleMatcher {
 class SubstringMatcher {
  public:
   /// <param name="rules">The rules whose annotations become substring patterns.
-  ///   The '=' prefix (exact match) qualifier is ignored — all patterns are substrings.</param>
-  /// <param name="rule_index_offset">Offset added to each pattern's local index to produce the
-  ///   global rule index in the merged LayeringRules vector.</param>
-  explicit SubstringMatcher(const LayeringRules& rules, size_t rule_index_offset = 0);
+  ///   The '=' prefix (exact match) qualifier is rejected during config parsing — all patterns
+  ///   must be substrings.</param>
+  /// <param name="name_rules_start_index">The starting index of these name-based rules within the
+  ///   merged rules vector. When name-based rules are appended after annotation-based rules,
+  ///   this equals the count of annotation rules. For example, if there are 3 annotation rules
+  ///   followed by 2 name-based rules, pass name_rules_start_index=3 so that Match() returns
+  ///   3 or 4 (the correct merged-vector positions) instead of 0 or 1.</param>
+  explicit SubstringMatcher(const LayeringRules& rules, size_t name_rules_start_index = 0);
 
   /// <summary>
   /// Returns the index of the best matching rule for the given node name.
@@ -171,7 +179,7 @@ class LayeringIndex {
                               LayeringIndexToEpName rule_map,
                               LayeringRules layering_rules,
                               SubstringMatcher substring_matcher,
-                              size_t annotation_rule_count = 0);
+                              std::optional<size_t> annotation_rule_count = std::nullopt);
 
   /// <summary>
   /// Factory method that creates a LayeringIndex by parsing configuration, matching rules against
@@ -246,7 +254,7 @@ class LayeringIndex {
   LayeringIndex(LayeringRules layering_rules, EpNameToLayeringIndices ep_name_to_layering_indices,
                 LayeringIndexToEpName layering_index_to_ep_name,
                 std::optional<SubstringMatcher> substring_matcher = std::nullopt,
-                size_t annotation_rule_count = 0)
+                std::optional<size_t> annotation_rule_count = std::nullopt)
       : rules_(std::move(layering_rules)),
         matcher_(rules_, annotation_rule_count),
         ep_name_to_layering_indices_(std::move(ep_name_to_layering_indices)),

--- a/onnxruntime/core/framework/layering_annotations.h
+++ b/onnxruntime/core/framework/layering_annotations.h
@@ -58,15 +58,8 @@ struct LayeringRules {
 /// </summary>
 class LayeringRuleMatcher {
  public:
-  /// <param name="rules">The full set of layering rules (may include appended name-based rules).</param>
-  /// <param name="annotation_rule_count">Number of annotation-based rules to index (from the beginning
-  ///   of the rules vector). If nullopt or omitted, all rules are indexed.
-  ///   If 0, no rules are indexed (disables annotation matching entirely).
-  ///   When name-based rules are appended after annotation rules in the same vector,
-  ///   pass the count of annotation rules so name-based patterns are excluded from
-  ///   the prefix/exact-match trie.</param>
-  explicit LayeringRuleMatcher(const LayeringRules& rules,
-                               std::optional<size_t> annotation_rule_count = std::nullopt);
+  /// <param name="rules">The annotation-based layering rules to index.</param>
+  explicit LayeringRuleMatcher(const LayeringRules& rules);
 
   /// <summary>
   /// The method returns the index of the best matching rule for the given annotation
@@ -102,12 +95,7 @@ class SubstringMatcher {
   /// <param name="rules">The rules whose annotations become substring patterns.
   ///   The '=' prefix (exact match) qualifier is rejected during config parsing — all patterns
   ///   must be substrings.</param>
-  /// <param name="name_rules_start_index">The starting index of these name-based rules within the
-  ///   merged rules vector. When name-based rules are appended after annotation-based rules,
-  ///   this equals the count of annotation rules. For example, if there are 3 annotation rules
-  ///   followed by 2 name-based rules, pass name_rules_start_index=3 so that Match() returns
-  ///   3 or 4 (the correct merged-vector positions) instead of 0 or 1.</param>
-  explicit SubstringMatcher(const LayeringRules& rules, size_t name_rules_start_index = 0);
+  explicit SubstringMatcher(const LayeringRules& rules);
 
   /// <summary>
   /// Returns the index of the best matching rule for the given node name.
@@ -169,21 +157,19 @@ class LayeringIndex {
                               LayeringRules layering_rules);
 
   /// <summary>
-  /// Creates a fully initialized LayeringIndex with an optional SubstringMatcher for name-based matching.
+  /// Creates a fully initialized LayeringIndex with a SubstringMatcher for name-based matching.
+  /// In this mode, annotation matching is disabled and no subgraph inheritance is applied.
   /// </summary>
-  /// <param name="annotation_rule_count">Number of rules (from the start of layering_rules) that are
-  ///   annotation-based. The annotation matcher will only index these rules. Rules beyond this index
-  ///   are name-based and matched exclusively via substring_matcher against Node::Name().</param>
   static LayeringIndex Create(const Graph& graph,
                               EpNameToLayeringIndices ep_map,
                               LayeringIndexToEpName rule_map,
                               LayeringRules layering_rules,
-                              SubstringMatcher substring_matcher,
-                              std::optional<size_t> annotation_rule_count = std::nullopt);
+                              SubstringMatcher substring_matcher);
 
   /// <summary>
   /// Factory method that creates a LayeringIndex by parsing configuration, matching rules against
   /// available devices/providers, and indexing the graph.
+  /// Annotation-based and name-based options are mutually exclusive — setting both returns an error.
   /// </summary>
   /// <param name="graph">The graph to index.</param>
   /// <param name="config_string">The annotation-based configuration string (prefix/exact match on metadata).</param>
@@ -253,10 +239,9 @@ class LayeringIndex {
 
   LayeringIndex(LayeringRules layering_rules, EpNameToLayeringIndices ep_name_to_layering_indices,
                 LayeringIndexToEpName layering_index_to_ep_name,
-                std::optional<SubstringMatcher> substring_matcher = std::nullopt,
-                std::optional<size_t> annotation_rule_count = std::nullopt)
+                std::optional<SubstringMatcher> substring_matcher = std::nullopt)
       : rules_(std::move(layering_rules)),
-        matcher_(rules_, annotation_rule_count),
+        matcher_(rules_),
         ep_name_to_layering_indices_(std::move(ep_name_to_layering_indices)),
         layering_index_to_ep_name_(std::move(layering_index_to_ep_name)),
         substring_matcher_(std::move(substring_matcher)) {}

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -1651,8 +1651,9 @@ common::Status InferenceSession::TransformGraph(onnxruntime::Graph& graph, bool 
 #if !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
   std::optional<LayeringIndex> layering_index_storage;
   const auto layering_config = session_options_.config_options.GetConfigOrDefault(kOrtSessionOptionsLayerAssignmentSettings, "");
-  if (!layering_config.empty()) {
-    ORT_RETURN_IF_ERROR_SESSIONID_(LayeringIndex::Create(graph, layering_config, {}, execution_providers_,
+  const auto name_based_config = session_options_.config_options.GetConfigOrDefault(kOrtSessionOptionsNameBasedLayerAssignment, "");
+  if (!layering_config.empty() || !name_based_config.empty()) {
+    ORT_RETURN_IF_ERROR_SESSIONID_(LayeringIndex::Create(graph, layering_config, name_based_config, {}, execution_providers_,
                                                          *session_logger_, layering_index_storage));
     if (layering_index_storage) {
       layering_index = &layering_index_storage.value();

--- a/onnxruntime/test/framework/layering_annotations_test.cc
+++ b/onnxruntime/test/framework/layering_annotations_test.cc
@@ -12,6 +12,7 @@
 #include "core/graph/constants.h"
 #include "core/graph/model.h"  // For Model, Graph
 #include "gtest/gtest.h"
+#include "gmock/gmock.h"
 
 #include "test/util/include/asserts.h"
 #include "test/util/include/test_environment.h"
@@ -1860,23 +1861,22 @@ TEST(SubstringMatcherTest, TrailingSlashDisambiguates) {
   }
 }
 
-TEST(SubstringMatcherTest, RuleIndexOffset) {
+TEST(SubstringMatcherTest, BasicRuleIndices) {
   LayeringRules rules;
-  rules.rules.push_back({"gpu", "layers.0/", true});  // Local index 0
-  rules.rules.push_back({"cpu", "embed", true});      // Local index 1
+  rules.rules.push_back({"gpu", "layers.0/", true});  // Index 0
+  rules.rules.push_back({"cpu", "embed", true});      // Index 1
 
-  // Offset by 5 — simulates name-based rules appended after 5 annotation-based rules
-  SubstringMatcher matcher(rules, /*name_rules_start_index=*/5);
+  SubstringMatcher matcher(rules);
 
   {
     auto result = matcher.Match("/model/layers.0/MatMul");
     ASSERT_TRUE(result.has_value());
-    EXPECT_EQ(*result, 5u);  // 0 + offset 5
+    EXPECT_EQ(*result, 0u);
   }
   {
     auto result = matcher.Match("/model/embed_tokens/Gather");
     ASSERT_TRUE(result.has_value());
-    EXPECT_EQ(*result, 6u);  // 1 + offset 5
+    EXPECT_EQ(*result, 1u);
   }
 }
 
@@ -1948,9 +1948,8 @@ TEST(LayeringIndexTest, NameBasedMatchingIntegration) {
   EXPECT_FALSE(assign2.has_value());
 }
 
-TEST(LayeringIndexTest, AnnotationTakesPriorityOverNameBased) {
-  // When a node has both an annotation match AND a name-based match,
-  // the annotation-based assignment must win.
+TEST(LayeringIndexTest, MutualExclusivityRejectsBothConfigs) {
+  // Setting both annotation-based and name-based configs must return INVALID_ARGUMENT.
 
   std::unordered_map<std::string, int> domain_to_version;
   domain_to_version[kOnnxDomain] = 12;
@@ -1961,69 +1960,23 @@ TEST(LayeringIndexTest, AnnotationTakesPriorityOverNameBased) {
 
   ONNX_NAMESPACE::TypeProto type_proto;
   type_proto.mutable_tensor_type()->set_elem_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
-
   NodeArg* input = &graph.GetOrCreateNodeArg("input", &type_proto);
-  NodeArg* mid1 = &graph.GetOrCreateNodeArg("mid1", &type_proto);
-  NodeArg* mid2 = &graph.GetOrCreateNodeArg("mid2", &type_proto);
   NodeArg* output = &graph.GetOrCreateNodeArg("output", &type_proto);
-
-  // node0: has annotation AND a name that matches a name-based pattern
-  Node& node0 = graph.AddNode("/model/layers.0/self_attn/MatMul", "Abs", "", {input}, {mid1});
-  node0.SetLayeringAnnotation("go_to_cpu");  // annotation says CPU
-
-  // node1: has only a name match (no annotation)
-  Node& node1 = graph.AddNode("/model/layers.0/mlp/MatMul", "Abs", "", {mid1}, {mid2});
-
-  // node2: has only an annotation match (name doesn't match any name-based pattern)
-  Node& node2 = graph.AddNode("/model/norm/LayerNorm", "Abs", "", {mid2}, {output});
-  node2.SetLayeringAnnotation("go_to_gpu");
-
+  graph.AddNode("node0", "Abs", "", {input}, {output});
   ASSERT_STATUS_OK(graph.Resolve());
 
-  // Merged rules:
-  //   Index 0: annotation-based "go_to_cpu" (exact match) → CpuEP
-  //   Index 1: annotation-based "go_to_gpu" (exact match) → GpuEP
-  //   Index 2: name-based "layers.0/" (substring) → GpuEP
-  LayeringRules merged_rules;
-  merged_rules.rules.push_back({"cpu", "go_to_cpu", false});  // Index 0, exact match
-  merged_rules.rules.push_back({"gpu", "go_to_gpu", false});  // Index 1, exact match
-  merged_rules.rules.push_back({"gpu", "layers.0/", true});   // Index 2, name-based substring
+  ExecutionProviders providers;
+  std::optional<LayeringIndex> layering_index;
 
-  LayeringIndex::EpNameToLayeringIndices ep_map;
-  ep_map["CpuEP"].insert(0);
-  ep_map["GpuEP"].insert(1);
-  ep_map["GpuEP"].insert(2);
-
-  LayeringIndex::LayeringIndexToEpName rule_map;
-  rule_map[0] = "CpuEP";
-  rule_map[1] = "GpuEP";
-  rule_map[2] = "GpuEP";
-
-  // SubstringMatcher covers only the name-based rule (index 2)
-  LayeringRules name_only_rules;
-  name_only_rules.rules.push_back({"gpu", "layers.0/", true});
-  SubstringMatcher substring_matcher(name_only_rules, /*name_rules_start_index=*/2);
-
-  auto index = LayeringIndex::Create(graph, std::move(ep_map), std::move(rule_map),
-                                     std::move(merged_rules), std::move(substring_matcher),
-                                     /*annotation_rule_count=*/2);
-
-  // node0: annotation "go_to_cpu" matches rule 0 (CpuEP).
-  // Name "layers.0/" also matches rule 2 (GpuEP).
-  // Annotation MUST win → assigned to rule 0 (CpuEP).
-  auto assign0 = index.GetNodeAssignment(graph, node0.Index());
-  ASSERT_TRUE(assign0.has_value());
-  EXPECT_EQ(*assign0, 0u);  // annotation wins: rule 0 (CpuEP), NOT rule 2 (GpuEP)
-
-  // node1: no annotation, name matches "layers.0/" → rule 2 (GpuEP)
-  auto assign1 = index.GetNodeAssignment(graph, node1.Index());
-  ASSERT_TRUE(assign1.has_value());
-  EXPECT_EQ(*assign1, 2u);  // name-based fallback
-
-  // node2: annotation "go_to_gpu" matches rule 1, name doesn't match any name pattern → rule 1
-  auto assign2 = index.GetNodeAssignment(graph, node2.Index());
-  ASSERT_TRUE(assign2.has_value());
-  EXPECT_EQ(*assign2, 1u);  // annotation match only
+  // Both configs set — should fail
+  auto status = LayeringIndex::Create(graph,
+                                      /*config_string=*/"cpu(layer1)",
+                                      /*name_based_config_string=*/"gpu(layers.0/)",
+                                      {}, providers,
+                                      DefaultLoggingManager().DefaultLogger(),
+                                      layering_index);
+  ASSERT_FALSE(status.IsOK());
+  EXPECT_THAT(status.ErrorMessage(), ::testing::HasSubstr("mutually exclusive"));
 }
 
 TEST(LayeringIndexTest, UpdateAppliesSubstringMatcherToNewNodes) {

--- a/onnxruntime/test/framework/layering_annotations_test.cc
+++ b/onnxruntime/test/framework/layering_annotations_test.cc
@@ -2005,7 +2005,8 @@ TEST(LayeringIndexTest, AnnotationTakesPriorityOverNameBased) {
   SubstringMatcher substring_matcher(name_only_rules, /*rule_index_offset=*/2);
 
   auto index = LayeringIndex::Create(graph, std::move(ep_map), std::move(rule_map),
-                                     std::move(merged_rules), std::move(substring_matcher));
+                                     std::move(merged_rules), std::move(substring_matcher),
+                                     /*annotation_rule_count=*/2);
 
   // node0: annotation "go_to_cpu" matches rule 0 (CpuEP).
   // Name "layers.0/" also matches rule 2 (GpuEP).

--- a/onnxruntime/test/framework/layering_annotations_test.cc
+++ b/onnxruntime/test/framework/layering_annotations_test.cc
@@ -2025,6 +2025,70 @@ TEST(LayeringIndexTest, AnnotationTakesPriorityOverNameBased) {
   EXPECT_EQ(*assign2, 1u);  // annotation match only
 }
 
+TEST(LayeringIndexTest, UpdateAppliesSubstringMatcherToNewNodes) {
+  // Verifies that LayeringIndex::Update() applies substring_matcher_ fallback
+  // for new nodes that have no annotation but whose Name() matches a name-based pattern.
+  // This covers the post-layout-transform incremental update path.
+
+  std::unordered_map<std::string, int> domain_to_version;
+  domain_to_version[kOnnxDomain] = 12;
+  Model model("test_model", false, ModelMetaData(), PathString(), IOnnxRuntimeOpSchemaRegistryList(),
+              domain_to_version, std::vector<ONNX_NAMESPACE::FunctionProto>(),
+              DefaultLoggingManager().DefaultLogger());
+  Graph& graph = model.MainGraph();
+
+  ONNX_NAMESPACE::TypeProto type_proto;
+  type_proto.mutable_tensor_type()->set_elem_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+
+  // Initial graph with one node assigned via name-based matching
+  NodeArg* input = &graph.GetOrCreateNodeArg("input", &type_proto);
+  NodeArg* mid = &graph.GetOrCreateNodeArg("mid", &type_proto);
+  NodeArg* output = &graph.GetOrCreateNodeArg("output", &type_proto);
+
+  graph.AddNode("/model/layers.0/self_attn/MatMul", "Abs", "", {input}, {mid});
+  graph.AddNode("/model/norm/LayerNorm", "Abs", "", {mid}, {output});
+
+  ASSERT_STATUS_OK(graph.Resolve());
+
+  // Name-based rules: layers.0/ -> gpu (index 0)
+  LayeringRules name_rules;
+  name_rules.rules.push_back({"gpu", "layers.0/", true});
+
+  LayeringIndex::EpNameToLayeringIndices ep_map;
+  ep_map["GpuEP"].insert(0);
+  LayeringIndex::LayeringIndexToEpName rule_map;
+  rule_map[0] = "GpuEP";
+
+  SubstringMatcher substring_matcher(name_rules);
+  auto index = LayeringIndex::Create(graph, std::move(ep_map), std::move(rule_map),
+                                     std::move(name_rules), std::move(substring_matcher));
+
+  // Simulate layout transform adding new nodes with structured names
+  NodeArg* new_out1 = &graph.GetOrCreateNodeArg("new_out1", &type_proto);
+  NodeArg* new_out2 = &graph.GetOrCreateNodeArg("new_out2", &type_proto);
+
+  // New node whose name matches "layers.0/" pattern
+  Node& new_matching = graph.AddNode("/model/layers.0/self_attn/Transpose", "Abs", "", {output}, {new_out1});
+
+  // New node whose name does NOT match any pattern
+  Node& new_unmatched = graph.AddNode("/model/lm_head/MatMul", "Abs", "", {new_out1}, {new_out2});
+
+  ASSERT_STATUS_OK(graph.Resolve());
+
+  // Call Update() with the new nodes (the incremental path)
+  std::vector<NodeIndex> new_nodes = {new_matching.Index(), new_unmatched.Index()};
+  index.Update(graph, new_nodes);
+
+  // new_matching should be assigned via substring match
+  auto assign_match = index.GetNodeAssignment(graph, new_matching.Index());
+  ASSERT_TRUE(assign_match.has_value());
+  EXPECT_EQ(*assign_match, 0u);
+
+  // new_unmatched should remain unassigned
+  auto assign_no = index.GetNodeAssignment(graph, new_unmatched.Index());
+  EXPECT_FALSE(assign_no.has_value());
+}
+
 }  // namespace test
 }  // namespace onnxruntime
 

--- a/onnxruntime/test/framework/layering_annotations_test.cc
+++ b/onnxruntime/test/framework/layering_annotations_test.cc
@@ -1866,7 +1866,7 @@ TEST(SubstringMatcherTest, RuleIndexOffset) {
   rules.rules.push_back({"cpu", "embed", true});      // Local index 1
 
   // Offset by 5 — simulates name-based rules appended after 5 annotation-based rules
-  SubstringMatcher matcher(rules, /*rule_index_offset=*/5);
+  SubstringMatcher matcher(rules, /*name_rules_start_index=*/5);
 
   {
     auto result = matcher.Match("/model/layers.0/MatMul");
@@ -2002,7 +2002,7 @@ TEST(LayeringIndexTest, AnnotationTakesPriorityOverNameBased) {
   // SubstringMatcher covers only the name-based rule (index 2)
   LayeringRules name_only_rules;
   name_only_rules.rules.push_back({"gpu", "layers.0/", true});
-  SubstringMatcher substring_matcher(name_only_rules, /*rule_index_offset=*/2);
+  SubstringMatcher substring_matcher(name_only_rules, /*name_rules_start_index=*/2);
 
   auto index = LayeringIndex::Create(graph, std::move(ep_map), std::move(rule_map),
                                      std::move(merged_rules), std::move(substring_matcher),

--- a/onnxruntime/test/framework/layering_annotations_test.cc
+++ b/onnxruntime/test/framework/layering_annotations_test.cc
@@ -1786,6 +1786,245 @@ TEST(LayeringIndexPartitionerTest, MultipleRulesForSameEp) {
   EXPECT_TRUE(found[3]);   // node3 - unassigned
 }
 
+// ===================== SubstringMatcher Tests =====================
+
+TEST(SubstringMatcherTest, BasicSubstringMatch) {
+  LayeringRules rules;
+  rules.rules.push_back({"gpu", "layers.0/", true});     // Index 0
+  rules.rules.push_back({"gpu", "layers.1/", true});     // Index 1
+  rules.rules.push_back({"cpu", "embed_tokens", true});  // Index 2
+
+  SubstringMatcher matcher(rules);
+
+  // Match in the middle of a node name
+  {
+    auto result = matcher.Match("/model/layers.0/self_attn/q_proj/MatMul");
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(*result, 0u);
+  }
+  {
+    auto result = matcher.Match("/model/layers.1/mlp/gate_proj/MatMul");
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(*result, 1u);
+  }
+  {
+    auto result = matcher.Match("/model/embed_tokens/Gather");
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(*result, 2u);
+  }
+  // No match
+  {
+    auto result = matcher.Match("/model/norm/LayerNormalization");
+    EXPECT_FALSE(result.has_value());
+  }
+}
+
+TEST(SubstringMatcherTest, LongestMatchWins) {
+  LayeringRules rules;
+  // Shorter pattern first in config order
+  rules.rules.push_back({"cpu", "layers.1", true});   // Index 0 — would match layers.10, layers.11, etc.
+  rules.rules.push_back({"gpu", "layers.10", true});  // Index 1 — longer, should win for layers.10
+
+  SubstringMatcher matcher(rules);
+
+  // "layers.10" is longer — should match even though "layers.1" also appears as a substring
+  {
+    auto result = matcher.Match("/model/layers.10/self_attn/MatMul");
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(*result, 1u);  // layers.10 wins (longer)
+  }
+  // "layers.1/" — only "layers.1" matches (layers.10 does not appear here)
+  {
+    auto result = matcher.Match("/model/layers.1/self_attn/MatMul");
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(*result, 0u);
+  }
+}
+
+TEST(SubstringMatcherTest, TrailingSlashDisambiguates) {
+  LayeringRules rules;
+  rules.rules.push_back({"gpu", "layers.1/", true});   // Index 0 — won't match layers.10/
+  rules.rules.push_back({"cpu", "layers.10/", true});  // Index 1
+
+  SubstringMatcher matcher(rules);
+
+  {
+    auto result = matcher.Match("/model/layers.1/self_attn/MatMul");
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(*result, 0u);
+  }
+  {
+    auto result = matcher.Match("/model/layers.10/self_attn/MatMul");
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(*result, 1u);  // "layers.10/" matches, not "layers.1/"
+  }
+}
+
+TEST(SubstringMatcherTest, RuleIndexOffset) {
+  LayeringRules rules;
+  rules.rules.push_back({"gpu", "layers.0/", true});  // Local index 0
+  rules.rules.push_back({"cpu", "embed", true});      // Local index 1
+
+  // Offset by 5 — simulates name-based rules appended after 5 annotation-based rules
+  SubstringMatcher matcher(rules, /*rule_index_offset=*/5);
+
+  {
+    auto result = matcher.Match("/model/layers.0/MatMul");
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(*result, 5u);  // 0 + offset 5
+  }
+  {
+    auto result = matcher.Match("/model/embed_tokens/Gather");
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(*result, 6u);  // 1 + offset 5
+  }
+}
+
+TEST(SubstringMatcherTest, EmptyNameNoMatch) {
+  LayeringRules rules;
+  rules.rules.push_back({"gpu", "layers.0/", true});
+
+  SubstringMatcher matcher(rules);
+
+  auto result = matcher.Match("");
+  EXPECT_FALSE(result.has_value());
+}
+
+TEST(LayeringIndexTest, NameBasedMatchingIntegration) {
+  // Test that LayeringIndex uses SubstringMatcher for unannotated nodes when configured
+
+  std::unordered_map<std::string, int> domain_to_version;
+  domain_to_version[kOnnxDomain] = 12;
+  Model model("test_model", false, ModelMetaData(), PathString(), IOnnxRuntimeOpSchemaRegistryList(),
+              domain_to_version, std::vector<ONNX_NAMESPACE::FunctionProto>(),
+              DefaultLoggingManager().DefaultLogger());
+  Graph& graph = model.MainGraph();
+
+  ONNX_NAMESPACE::TypeProto type_proto;
+  type_proto.mutable_tensor_type()->set_elem_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+
+  // Create nodes with transformer-style names (no annotations)
+  NodeArg* input = &graph.GetOrCreateNodeArg("input", &type_proto);
+  NodeArg* mid1 = &graph.GetOrCreateNodeArg("mid1", &type_proto);
+  NodeArg* mid2 = &graph.GetOrCreateNodeArg("mid2", &type_proto);
+  NodeArg* output = &graph.GetOrCreateNodeArg("output", &type_proto);
+
+  Node& node0 = graph.AddNode("/model/layers.0/self_attn/MatMul", "Abs", "", {input}, {mid1});
+  Node& node1 = graph.AddNode("/model/layers.1/mlp/MatMul", "Abs", "", {mid1}, {mid2});
+  Node& node2 = graph.AddNode("/model/embed_tokens/Gather", "Abs", "", {mid2}, {output});
+
+  ASSERT_STATUS_OK(graph.Resolve());
+
+  // Build name-based rules for layers.0 -> gpu, layers.1 -> cpu
+  LayeringRules name_rules;
+  name_rules.rules.push_back({"gpu", "layers.0/", true});  // merged index 0
+  name_rules.rules.push_back({"cpu", "layers.1/", true});  // merged index 1
+
+  LayeringIndex::EpNameToLayeringIndices ep_map;
+  ep_map["GpuEP"].insert(0);
+  ep_map["CpuEP"].insert(1);
+
+  LayeringIndex::LayeringIndexToEpName rule_map;
+  rule_map[0] = "GpuEP";
+  rule_map[1] = "CpuEP";
+
+  // Create index with SubstringMatcher
+  SubstringMatcher substring_matcher(name_rules);
+  auto index = LayeringIndex::Create(graph, std::move(ep_map), std::move(rule_map), std::move(name_rules),
+                                     std::move(substring_matcher));
+
+  // Node with "layers.0/" in name → rule 0
+  auto assign0 = index.GetNodeAssignment(graph, node0.Index());
+  ASSERT_TRUE(assign0.has_value());
+  EXPECT_EQ(*assign0, 0u);
+
+  // Node with "layers.1/" in name → rule 1
+  auto assign1 = index.GetNodeAssignment(graph, node1.Index());
+  ASSERT_TRUE(assign1.has_value());
+  EXPECT_EQ(*assign1, 1u);
+
+  // Node with "embed_tokens" — no matching rule → unassigned
+  auto assign2 = index.GetNodeAssignment(graph, node2.Index());
+  EXPECT_FALSE(assign2.has_value());
+}
+
+TEST(LayeringIndexTest, AnnotationTakesPriorityOverNameBased) {
+  // When a node has both an annotation match AND a name-based match,
+  // the annotation-based assignment must win.
+
+  std::unordered_map<std::string, int> domain_to_version;
+  domain_to_version[kOnnxDomain] = 12;
+  Model model("test_model", false, ModelMetaData(), PathString(), IOnnxRuntimeOpSchemaRegistryList(),
+              domain_to_version, std::vector<ONNX_NAMESPACE::FunctionProto>(),
+              DefaultLoggingManager().DefaultLogger());
+  Graph& graph = model.MainGraph();
+
+  ONNX_NAMESPACE::TypeProto type_proto;
+  type_proto.mutable_tensor_type()->set_elem_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+
+  NodeArg* input = &graph.GetOrCreateNodeArg("input", &type_proto);
+  NodeArg* mid1 = &graph.GetOrCreateNodeArg("mid1", &type_proto);
+  NodeArg* mid2 = &graph.GetOrCreateNodeArg("mid2", &type_proto);
+  NodeArg* output = &graph.GetOrCreateNodeArg("output", &type_proto);
+
+  // node0: has annotation AND a name that matches a name-based pattern
+  Node& node0 = graph.AddNode("/model/layers.0/self_attn/MatMul", "Abs", "", {input}, {mid1});
+  node0.SetLayeringAnnotation("go_to_cpu");  // annotation says CPU
+
+  // node1: has only a name match (no annotation)
+  Node& node1 = graph.AddNode("/model/layers.0/mlp/MatMul", "Abs", "", {mid1}, {mid2});
+
+  // node2: has only an annotation match (name doesn't match any name-based pattern)
+  Node& node2 = graph.AddNode("/model/norm/LayerNorm", "Abs", "", {mid2}, {output});
+  node2.SetLayeringAnnotation("go_to_gpu");
+
+  ASSERT_STATUS_OK(graph.Resolve());
+
+  // Merged rules:
+  //   Index 0: annotation-based "go_to_cpu" (exact match) → CpuEP
+  //   Index 1: annotation-based "go_to_gpu" (exact match) → GpuEP
+  //   Index 2: name-based "layers.0/" (substring) → GpuEP
+  LayeringRules merged_rules;
+  merged_rules.rules.push_back({"cpu", "go_to_cpu", false});  // Index 0, exact match
+  merged_rules.rules.push_back({"gpu", "go_to_gpu", false});  // Index 1, exact match
+  merged_rules.rules.push_back({"gpu", "layers.0/", true});   // Index 2, name-based substring
+
+  LayeringIndex::EpNameToLayeringIndices ep_map;
+  ep_map["CpuEP"].insert(0);
+  ep_map["GpuEP"].insert(1);
+  ep_map["GpuEP"].insert(2);
+
+  LayeringIndex::LayeringIndexToEpName rule_map;
+  rule_map[0] = "CpuEP";
+  rule_map[1] = "GpuEP";
+  rule_map[2] = "GpuEP";
+
+  // SubstringMatcher covers only the name-based rule (index 2)
+  LayeringRules name_only_rules;
+  name_only_rules.rules.push_back({"gpu", "layers.0/", true});
+  SubstringMatcher substring_matcher(name_only_rules, /*rule_index_offset=*/2);
+
+  auto index = LayeringIndex::Create(graph, std::move(ep_map), std::move(rule_map),
+                                     std::move(merged_rules), std::move(substring_matcher));
+
+  // node0: annotation "go_to_cpu" matches rule 0 (CpuEP).
+  // Name "layers.0/" also matches rule 2 (GpuEP).
+  // Annotation MUST win → assigned to rule 0 (CpuEP).
+  auto assign0 = index.GetNodeAssignment(graph, node0.Index());
+  ASSERT_TRUE(assign0.has_value());
+  EXPECT_EQ(*assign0, 0u);  // annotation wins: rule 0 (CpuEP), NOT rule 2 (GpuEP)
+
+  // node1: no annotation, name matches "layers.0/" → rule 2 (GpuEP)
+  auto assign1 = index.GetNodeAssignment(graph, node1.Index());
+  ASSERT_TRUE(assign1.has_value());
+  EXPECT_EQ(*assign1, 2u);  // name-based fallback
+
+  // node2: annotation "go_to_gpu" matches rule 1, name doesn't match any name pattern → rule 1
+  auto assign2 = index.GetNodeAssignment(graph, node2.Index());
+  ASSERT_TRUE(assign2.has_value());
+  EXPECT_EQ(*assign2, 1u);  // annotation match only
+}
+
 }  // namespace test
 }  // namespace onnxruntime
 

--- a/onnxruntime/test/framework/session_state_test.cc
+++ b/onnxruntime/test/framework/session_state_test.cc
@@ -497,7 +497,7 @@ void LoadWithResourceAwarePartitioning(const ORTCHAR_T* model_path,
   LayeringIndex* layering_index = nullptr;
   std::optional<LayeringIndex> layering_index_storage;
   if (!layering_config.empty()) {
-    ASSERT_STATUS_OK(LayeringIndex::Create(graph, layering_config, {}, execution_providers,
+    ASSERT_STATUS_OK(LayeringIndex::Create(graph, layering_config, /*name_based_config_string=*/"", {}, execution_providers,
                                            default_logger, layering_index_storage));
     if (layering_index_storage.has_value()) {
       layering_index = &layering_index_storage.value();


### PR DESCRIPTION
This pull request introduces a new "name-based layer assignment" feature for ONNX Runtime, allowing device assignment of model nodes based on substring matching of node names, as an alternative to annotation-based matching. The implementation ensures that name-based and annotation-based assignment modes are mutually exclusive, and updates documentation, configuration keys, and core logic to support this new capability.

**Key changes:**

#### Name-based Layer Assignment Feature

- Added support for a new session option, `session.name_based_layer_assignment`, which enables device assignment using substring matching against node names (rather than metadata annotations). The longest matching pattern wins, and all patterns are treated as substrings (the `=` exact-match qualifier is disallowed in this mode). [[1]](diffhunk://#diff-10b3051b9e36eccfc7ca0f2d44ce78a9980ca573cde0f931ffd1456da2c681daR181-R218) [[2]](diffhunk://#diff-62d211e77c575a2fec6492c9fbfe25743fac9d6d72be7c007e7f6eb8dbecc7e7R423-R437)

- Implemented the `SubstringMatcher` class and integrated it into the `LayeringIndex` logic, enabling efficient substring-based rule matching for node assignment. The matcher sorts patterns by length and returns the first (longest) match. [[1]](diffhunk://#diff-a8f614056d63b5b3325eea1d855afc96550c977c16d8fdba641012a79194b7b5R604-R627) [[2]](diffhunk://#diff-b64b395fbb0afa67dcf493f97493f3df353486c3c8344df89f25df057ca3840fR88-R116)

#### Mutual Exclusivity and API Changes

- Enforced mutual exclusivity between annotation-based (`session.layer_assignment_settings`) and name-based (`session.name_based_layer_assignment`) assignment options. Attempting to set both now results in an error, with clear messaging. [[1]](diffhunk://#diff-a8f614056d63b5b3325eea1d855afc96550c977c16d8fdba641012a79194b7b5L338-L359) [[2]](diffhunk://#diff-b64b395fbb0afa67dcf493f97493f3df353486c3c8344df89f25df057ca3840fR159-R177)

- Updated the `LayeringIndex::Create` API and related logic to accept both configuration strings, select the active mode, and construct the appropriate matcher. [[1]](diffhunk://#diff-a8f614056d63b5b3325eea1d855afc96550c977c16d8fdba641012a79194b7b5L338-L359) [[2]](diffhunk://#diff-b64b395fbb0afa67dcf493f97493f3df353486c3c8344df89f25df057ca3840fR186)

#### Documentation Updates

- Expanded the documentation to describe the new name-based assignment feature, provide usage examples, highlight best practices for pattern writing, and explain the mutual exclusivity and lack of subgraph inheritance in name-based mode. [[1]](diffhunk://#diff-10b3051b9e36eccfc7ca0f2d44ce78a9980ca573cde0f931ffd1456da2c681daR181-R218) [[2]](diffhunk://#diff-10b3051b9e36eccfc7ca0f2d44ce78a9980ca573cde0f931ffd1456da2c681daL295-R357)

#### Core Logic and Maintenance

- Refactored the `LayeringIndex` and related methods to support both matching modes, updating node assignment and update logic to branch appropriately based on the selected mode. [[1]](diffhunk://#diff-a8f614056d63b5b3325eea1d855afc96550c977c16d8fdba641012a79194b7b5L426-R485) [[2]](diffhunk://#diff-a8f614056d63b5b3325eea1d855afc96550c977c16d8fdba641012a79194b7b5R537-R548)

- Added and documented the new configuration key `kOrtSessionOptionsNameBasedLayerAssignment` in the public API headers.

These changes provide a more flexible and user-friendly way to partition models across devices, especially for models with structured node names but lacking explicit annotations.