### PR TITLE
[WebGPU] Enable graph capture for Gemma4-class decoder models

### DIFF
--- a/onnxruntime/contrib_ops/webgpu/bert/flash_attention.cc
+++ b/onnxruntime/contrib_ops/webgpu/bert/flash_attention.cc
@@ -44,6 +44,34 @@ Status SplitPackedQKVWithRotaryEmbeddingAndCopyKVProgram::GenerateShaderCode(Sha
                              WGSL_TEMPLATE_VARIABLE(sin_cache, sin_cache));
 }
 
+Status PrepareIndirectDispatchProgram::GenerateShaderCode(ShaderHelper& shader) const {
+  shader.AddInput("seqlen_k", ShaderUsage::None);
+  shader.AddOutput("indirect_buffer", ShaderUsage::None);
+  shader.MainFunctionBody() << "  if (global_idx == 0u) {\n"
+                            << "    let total_seq_length = u32(seqlen_k[0u]) + 1u;\n"
+                            << "    let num_total_seq_length_tile = (total_seq_length + uniforms.tile_size - 1u) / uniforms.tile_size;\n"
+                            << "    indirect_buffer[0] = num_total_seq_length_tile;\n"
+                            << "    indirect_buffer[1] = uniforms.num_heads;\n"
+                            << "    indirect_buffer[2] = 1u;\n"
+                            << "  }\n";
+  return Status::OK();
+}
+
+Status PrepareIndirectDispatch(onnxruntime::webgpu::ComputeContext& context,
+                               const WebgpuAttentionParameters& parameters,
+                               const Tensor* seqlen_k,
+                               Tensor* indirect_buffer,
+                               uint32_t tile_size) {
+  PrepareIndirectDispatchProgram program{};
+  program.AddInput({seqlen_k, ProgramTensorMetadataDependency::None});
+  program.AddOutput({indirect_buffer, ProgramTensorMetadataDependency::None});
+  program.SetDispatchGroupSize(1)
+      .SetWorkgroupSize(1)
+      .AddUniformVariables({{tile_size},
+                            {static_cast<uint32_t>(parameters.num_heads_)}});
+  return context.RunProgram(program);
+}
+
 Status CopyKVCacheProgram::GenerateShaderCode(ShaderHelper& shader) const {
   // Expectations are
   //    qkv have same number of heads and hidden dimension (head size).
@@ -450,12 +478,21 @@ Status ApplyFlashAttention(const Tensor* Q, const Tensor* K, const Tensor* V, co
   Tensor* indirect_buffer_ptr = nullptr;
   Tensor indirect_buffer;
 
-  // Prepare indirect dispatch buffer for decode path with static KV cache
-  const bool use_indirect_dispatch = !kv_empty &&
-                                     parameters.sequence_length_ == 1 &&
-                                     parameters.past_present_share_buffer_ &&
+  // Prepare indirect dispatch buffer for decode path.
+  // Required when total_sequence_length is unknown at dispatch time, which happens in two cases:
+  //   1) Graph capture is on: static cache means total_seq_len varies across iterations of the captured graph.
+  //   2) total_sequence_length is GPU-resident (sentinel 0 from group_query_attention_helper):
+  //      any model that computes seqlens_k inside the ONNX graph (e.g. Gemma4) regardless of GC state.
+  // Without indirect dispatch in these cases, num_total_seq_length_tile=0 and we crash at SetDispatchGroupSize.
+  // The dispatch requires either static KV cache (past_present_share_buffer_) or kv_empty
+  // (KV-shared layer where past_key aliases another layer's present cache).
+  const bool decode_needs_indirect = context.IsGraphCaptureEnabled() ||
+                                     parameters.total_sequence_length_ == 0;
+  const bool use_indirect_dispatch = parameters.sequence_length_ == 1 &&
                                      seqlen_k != nullptr &&
-                                     context.IsGraphCaptureEnabled();
+                                     decode_needs_indirect &&
+                                     (parameters.past_present_share_buffer_ ||
+                                      (kv_empty && past_key != nullptr && past_value != nullptr));
   if (use_indirect_dispatch) {
     const TensorShape indirect_buffer_shape{3};  // 3 uint32 values for dispatch dimensions
     indirect_buffer = context.CreateGPUTensor(DataTypeImpl::GetType<uint32_t>(), indirect_buffer_shape);
@@ -480,6 +517,11 @@ Status ApplyFlashAttention(const Tensor* Q, const Tensor* K, const Tensor* V, co
       // and CopyKVCache is skipped when kv_empty, so no writes occur through these pointers.
       present_key = const_cast<Tensor*>(past_key);
       present_value = const_cast<Tensor*>(past_value);
+    }
+    // Populate indirect dispatch buffer for the decode kernels (CopyKVCache normally does this,
+    // but it's skipped for kv_empty layers).
+    if (use_indirect_dispatch) {
+      ORT_RETURN_IF_ERROR(PrepareIndirectDispatch(context, parameters, seqlen_k, indirect_buffer_ptr, tile_size));
     }
   } else if (do_rotary) {
     ORT_ENFORCE(parameters.is_packed_qkv_, "Fused SplitPackedQKVWithRotaryEmbeddingAndCopyKV requires packed QKV input.");

--- a/onnxruntime/contrib_ops/webgpu/bert/flash_attention.h
+++ b/onnxruntime/contrib_ops/webgpu/bert/flash_attention.h
@@ -43,6 +43,20 @@ class SplitPackedQKVWithRotaryEmbeddingAndCopyKVProgram final : public Program<S
   const uint32_t multi_rotary_cache_concat_offset_;
 };
 
+// Standalone helper that fills indirect_buffer with [tile_count, num_heads, 1] using a single
+// shader thread reading seqlen_k[0]+1. Used by the kv_empty (KV-shared) decode path under graph
+// capture, where CopyKVCache is skipped but flash attention still needs the indirect dispatch
+// buffer populated.
+class PrepareIndirectDispatchProgram final : public Program<PrepareIndirectDispatchProgram> {
+ public:
+  PrepareIndirectDispatchProgram() : Program{"PrepareIndirectDispatch"} {}
+
+  Status GenerateShaderCode(ShaderHelper& sh) const override;
+
+  WEBGPU_PROGRAM_DEFINE_UNIFORM_VARIABLES({"tile_size", ProgramUniformVariableDataType::Uint32},
+                                          {"num_heads", ProgramUniformVariableDataType::Uint32});
+};
+
 class CopyKVCacheProgram final : public Program<CopyKVCacheProgram> {
  public:
   CopyKVCacheProgram(const std::string& kernel_name, bool has_past, bool kv_BNSH, bool past_present_share_buffer,

--- a/onnxruntime/core/optimizer/gqa_mask_reformatting_to_graph_capture.cc
+++ b/onnxruntime/core/optimizer/gqa_mask_reformatting_to_graph_capture.cc
@@ -1,0 +1,475 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/optimizer/gqa_mask_reformatting_to_graph_capture.h"
+
+#include <string>
+#include <vector>
+
+#include "core/common/inlined_containers.h"
+#include "core/framework/tensorprotoutils.h"
+#include "core/graph/constants.h"
+#include "core/graph/graph_utils.h"
+#include "core/graph/graph_viewer.h"
+#include "core/graph/node_attr_utils.h"
+#include "core/optimizer/initializer.h"
+#include "core/optimizer/utils.h"
+
+namespace onnxruntime {
+
+namespace {
+
+const Node* GetInputNode(const Graph& graph, const Node& node, int input_index) {
+  const auto* edge = graph_utils::GetInputEdge(node, input_index);
+  return edge == nullptr ? nullptr : graph.GetNode(edge->GetNode().Index());
+}
+
+// Match a node that produces a scalar/1-element int constant with value `expected`.
+// Accepts either a graph initializer (referenced via NodeArg) or a `Constant` node
+// with `value`, `value_int`, or `value_ints` attribute.
+bool IsConstantIntValue(const Graph& graph, const NodeArg& input_arg, int64_t expected) {
+  return optimizer_utils::IsInitializerWithExpectedValue(graph, input_arg, expected, true);
+}
+
+bool IsConstantNodeWithIntValue(const Node& node, int64_t expected) {
+  if (!graph_utils::IsSupportedOptypeVersionAndDomain(node, "Constant", {9, 11, 12, 13, 19, 20, 21, 23})) {
+    return false;
+  }
+  const auto* value_int = graph_utils::GetNodeAttribute(node, "value_int");
+  if (value_int != nullptr && value_int->type() == ONNX_NAMESPACE::AttributeProto_AttributeType_INT) {
+    return value_int->i() == expected;
+  }
+  const auto* value = graph_utils::GetNodeAttribute(node, "value");
+  if (value != nullptr && value->type() == ONNX_NAMESPACE::AttributeProto_AttributeType_TENSOR) {
+    const auto& tp = value->t();
+    if (tp.data_type() != ONNX_NAMESPACE::TensorProto_DataType_INT64 &&
+        tp.data_type() != ONNX_NAMESPACE::TensorProto_DataType_INT32) {
+      return false;
+    }
+    Initializer init(tp);
+    if (init.size() != 1) {
+      return false;
+    }
+    if (tp.data_type() == ONNX_NAMESPACE::TensorProto_DataType_INT64) {
+      return init.DataAsSpan<int64_t>()[0] == expected;
+    }
+    return static_cast<int64_t>(init.DataAsSpan<int32_t>()[0]) == expected;
+  }
+  return false;
+}
+
+// Resolves `arg` (an input NodeArg on `consumer`) to an int constant value if
+// possible. Returns true and writes the value to `out` if the producer is a
+// graph initializer or a `Constant` node with the requisite attribute.
+bool TryResolveConstantInt(const Graph& graph, const Node& consumer, int input_index, int64_t& out) {
+  const NodeArg* arg = consumer.InputDefs()[input_index];
+  if (arg == nullptr) {
+    return false;
+  }
+  if (optimizer_utils::IsInitializerWithExpectedValue(graph, *arg, static_cast<int64_t>(0), true) ||
+      optimizer_utils::IsInitializerWithExpectedValue(graph, *arg, static_cast<int64_t>(1), true)) {
+    // Cheap probe — fall through to the actual unpack below if it matched.
+  }
+  const ONNX_NAMESPACE::TensorProto* tp = nullptr;
+  if (graph.GetInitializedTensor(arg->Name(), tp) && tp != nullptr) {
+    if (tp->data_type() != ONNX_NAMESPACE::TensorProto_DataType_INT64 &&
+        tp->data_type() != ONNX_NAMESPACE::TensorProto_DataType_INT32) {
+      return false;
+    }
+    Initializer init(*tp);
+    if (init.size() != 1) {
+      return false;
+    }
+    out = tp->data_type() == ONNX_NAMESPACE::TensorProto_DataType_INT64
+              ? init.DataAsSpan<int64_t>()[0]
+              : static_cast<int64_t>(init.DataAsSpan<int32_t>()[0]);
+    return true;
+  }
+  const Node* producer = GetInputNode(graph, consumer, input_index);
+  if (producer == nullptr || producer->OpType() != "Constant") {
+    return false;
+  }
+  const auto* value_int = graph_utils::GetNodeAttribute(*producer, "value_int");
+  if (value_int != nullptr && value_int->type() == ONNX_NAMESPACE::AttributeProto_AttributeType_INT) {
+    out = value_int->i();
+    return true;
+  }
+  const auto* value = graph_utils::GetNodeAttribute(*producer, "value");
+  if (value != nullptr && value->type() == ONNX_NAMESPACE::AttributeProto_AttributeType_TENSOR) {
+    const auto& v_tp = value->t();
+    if (v_tp.data_type() != ONNX_NAMESPACE::TensorProto_DataType_INT64 &&
+        v_tp.data_type() != ONNX_NAMESPACE::TensorProto_DataType_INT32) {
+      return false;
+    }
+    Initializer init(v_tp);
+    if (init.size() != 1) {
+      return false;
+    }
+    out = v_tp.data_type() == ONNX_NAMESPACE::TensorProto_DataType_INT64
+              ? init.DataAsSpan<int64_t>()[0]
+              : static_cast<int64_t>(init.DataAsSpan<int32_t>()[0]);
+    return true;
+  }
+  return false;
+}
+
+bool IsCastToInt32(const Node& node) {
+  if (!graph_utils::IsSupportedOptypeVersionAndDomain(node, "Cast", {9, 13, 19, 21, 23, 24})) {
+    return false;
+  }
+  const auto* to_attr = graph_utils::GetNodeAttribute(node, "to");
+  return to_attr != nullptr && to_attr->i() == ONNX_NAMESPACE::TensorProto_DataType_INT32;
+}
+
+bool IsKeepDimsZero(const Node& node) {
+  const auto* attr = graph_utils::GetNodeAttribute(node, "keepdims");
+  // ONNX default is keepdims=1; we require explicit 0.
+  return attr != nullptr && attr->i() == 0;
+}
+
+// Match: input_arg is produced by `Cast(to=INT32)(Sub(ReduceSum(mask, axes=[1], keepdims=0), 1))`.
+// Returns the three intermediate nodes (cast, sub, reduce_sum) and the mask NodeArg.
+struct SeqlensKChain {
+  const Node* cast;
+  const Node* sub;
+  const Node* reduce_sum;
+  const NodeArg* mask;
+};
+
+bool MatchSeqlensKChain(const Graph& graph, const NodeArg& seqlens_k, SeqlensKChain& out) {
+  const Node* cast = graph.GetProducerNode(seqlens_k.Name());
+  if (cast == nullptr || !IsCastToInt32(*cast)) {
+    return false;
+  }
+  const Node* sub = GetInputNode(graph, *cast, 0);
+  if (sub == nullptr || !graph_utils::IsSupportedOptypeVersionAndDomain(*sub, "Sub", {7, 13, 14})) {
+    return false;
+  }
+  int64_t one_value = 0;
+  if (!TryResolveConstantInt(graph, *sub, 1, one_value) || one_value != 1) {
+    return false;
+  }
+  const Node* reduce_sum = GetInputNode(graph, *sub, 0);
+  if (reduce_sum == nullptr ||
+      !graph_utils::IsSupportedOptypeVersionAndDomain(*reduce_sum, "ReduceSum", {13, 18, 20})) {
+    return false;
+  }
+  if (!IsKeepDimsZero(*reduce_sum)) {
+    return false;
+  }
+  // axes input must be [1]
+  int64_t axes_value = 0;
+  if (reduce_sum->InputDefs().size() < 2) {
+    return false;
+  }
+  const NodeArg* axes_arg = reduce_sum->InputDefs()[1];
+  const ONNX_NAMESPACE::TensorProto* axes_tp = nullptr;
+  if (!graph.GetInitializedTensor(axes_arg->Name(), axes_tp) || axes_tp == nullptr) {
+    return false;
+  }
+  if (axes_tp->data_type() != ONNX_NAMESPACE::TensorProto_DataType_INT64) {
+    return false;
+  }
+  Initializer axes_init(*axes_tp);
+  if (axes_init.size() != 1) {
+    return false;
+  }
+  axes_value = axes_init.DataAsSpan<int64_t>()[0];
+  if (axes_value != 1) {
+    return false;
+  }
+  out.cast = cast;
+  out.sub = sub;
+  out.reduce_sum = reduce_sum;
+  out.mask = reduce_sum->InputDefs()[0];
+  return true;
+}
+
+struct TotalSeqLenChain {
+  const Node* cast;
+  const Node* gather;
+  const Node* shape;
+  const NodeArg* mask;
+};
+
+bool MatchTotalSeqLenChain(const Graph& graph, const NodeArg& total_seq_len, TotalSeqLenChain& out) {
+  const Node* cast = graph.GetProducerNode(total_seq_len.Name());
+  if (cast == nullptr || !IsCastToInt32(*cast)) {
+    return false;
+  }
+  const Node* gather = GetInputNode(graph, *cast, 0);
+  if (gather == nullptr || !graph_utils::IsSupportedOptypeVersionAndDomain(*gather, "Gather", {1, 11, 13})) {
+    return false;
+  }
+  const auto* axis_attr = graph_utils::GetNodeAttribute(*gather, "axis");
+  const int64_t axis = axis_attr != nullptr ? axis_attr->i() : 0;
+  if (axis != 0) {
+    return false;
+  }
+  int64_t idx_value = 0;
+  if (!TryResolveConstantInt(graph, *gather, 1, idx_value) || idx_value != 1) {
+    return false;
+  }
+  const Node* shape = GetInputNode(graph, *gather, 0);
+  if (shape == nullptr || !graph_utils::IsSupportedOptypeVersionAndDomain(*shape, "Shape", {1, 13, 15, 19, 21, 23, 24})) {
+    return false;
+  }
+  out.cast = cast;
+  out.gather = gather;
+  out.shape = shape;
+  out.mask = shape->InputDefs()[0];
+  return true;
+}
+
+NodeArg& AddInt64ScalarInitializer(Graph& graph, const std::string& name_hint, int64_t value) {
+  ONNX_NAMESPACE::TensorProto tp;
+  tp.set_name(graph.GenerateNodeArgName(name_hint));
+  tp.set_data_type(ONNX_NAMESPACE::TensorProto_DataType_INT64);
+  utils::SetRawDataInTensorProto(tp, &value, sizeof(int64_t));
+  return graph_utils::AddInitializerWithOrtValue(graph, tp);
+}
+
+NodeArg& AddInt64Vec1Initializer(Graph& graph, const std::string& name_hint, int64_t value) {
+  ONNX_NAMESPACE::TensorProto tp;
+  tp.set_name(graph.GenerateNodeArgName(name_hint));
+  tp.set_data_type(ONNX_NAMESPACE::TensorProto_DataType_INT64);
+  tp.add_dims(1);
+  utils::SetRawDataInTensorProto(tp, &value, sizeof(int64_t));
+  return graph_utils::AddInitializerWithOrtValue(graph, tp);
+}
+
+NodeArg& AddInt32Vec1Initializer(Graph& graph, const std::string& name_hint, int32_t value) {
+  ONNX_NAMESPACE::TensorProto tp;
+  tp.set_name(graph.GenerateNodeArgName(name_hint));
+  tp.set_data_type(ONNX_NAMESPACE::TensorProto_DataType_INT32);
+  tp.add_dims(1);
+  utils::SetRawDataInTensorProto(tp, &value, sizeof(int32_t));
+  return graph_utils::AddInitializerWithOrtValue(graph, tp);
+}
+
+void TryRemoveIfOrphan(Graph& graph, const Node* node) {
+  if (node == nullptr) {
+    return;
+  }
+  if (graph.NodeProducesGraphOutput(*node)) {
+    return;
+  }
+  if (node->GetOutputEdgesCount() != 0) {
+    return;
+  }
+  // Recurse upstream after removal so orphan Constant / initializer-producing
+  // nodes are also reaped.
+  std::vector<NodeIndex> upstream;
+  upstream.reserve(node->GetInputEdgesCount());
+  for (auto it = node->InputEdgesBegin(); it != node->InputEdgesEnd(); ++it) {
+    upstream.push_back(it->GetNode().Index());
+  }
+  graph_utils::RemoveNodeOutputEdges(graph, *const_cast<Node*>(node));
+  graph.RemoveNode(node->Index());
+  for (NodeIndex idx : upstream) {
+    TryRemoveIfOrphan(graph, graph.GetNode(idx));
+  }
+}
+
+}  // namespace
+
+Status GqaMaskReformattingToGraphCapture::ApplyImpl(Graph& graph,
+                                                    bool& modified,
+                                                    int /*graph_level*/,
+                                                    const logging::Logger& logger) const {
+  GraphViewer graph_viewer(graph);
+  const auto& topo = graph_viewer.GetNodesInTopologicalOrder();
+
+  // Find a GQA node whose seqlens_k & total_seq_len both match the standard
+  // CPU-bound subgraph. Because all GQAs in a model typically share the same
+  // producer chain (gemma4 has 35 GQAs sharing one chain), the first match is
+  // sufficient — rewriting it rewires every consumer at once.
+  for (NodeIndex idx : topo) {
+    Node* gqa = graph.GetNode(idx);
+    if (gqa == nullptr) {
+      continue;
+    }
+    if (!graph_utils::IsSupportedOptypeVersionAndDomain(*gqa, "GroupQueryAttention", {1}, kMSDomain)) {
+      continue;
+    }
+    if (!gqa->GetExecutionProviderType().empty() &&
+        gqa->GetExecutionProviderType() != kWebGpuExecutionProvider) {
+      continue;
+    }
+    if (gqa->InputDefs().size() < 7) {
+      continue;
+    }
+
+    const NodeArg* seqlens_k_arg = gqa->InputDefs()[5];
+    const NodeArg* total_seq_len_arg = gqa->InputDefs()[6];
+    if (seqlens_k_arg == nullptr || total_seq_len_arg == nullptr) {
+      continue;
+    }
+
+    SeqlensKChain sk_chain{};
+    TotalSeqLenChain tsl_chain{};
+    if (!MatchSeqlensKChain(graph, *seqlens_k_arg, sk_chain)) {
+      continue;
+    }
+    if (!MatchTotalSeqLenChain(graph, *total_seq_len_arg, tsl_chain)) {
+      continue;
+    }
+    if (sk_chain.mask != tsl_chain.mask) {
+      continue;
+    }
+
+    NodeArg* mask_arg = graph.GetNodeArg(sk_chain.mask->Name());
+    if (mask_arg == nullptr) {
+      continue;
+    }
+
+    LOGS(logger, INFO) << "GqaMaskReformattingToGraphCapture: rewriting CPU-bound mask reformatting subgraph "
+                       << "(seqlens_k chain anchor='" << sk_chain.cast->Name()
+                       << "', total_seq_len chain anchor='" << tsl_chain.cast->Name()
+                       << "', mask input='" << mask_arg->Name() << "')";
+
+    // ---- Build the replacement subgraph: ----
+    //   cast32  = Cast(mask, to=INT32)
+    //   rs      = ReduceSum(cast32, axes=[1], keepdims=0)  (int32, shape [B])
+    //   sk      = Sub(rs, [1])  → seqlens_k (replaces sk_chain.cast output)
+    //   tsl_red = ReduceMax(rs, axes=[0], keepdims=0)  (int32, scalar) → total_seq_len
+    // ReduceMax over the only remaining axis collapses to a scalar, matching
+    // the original total_sequence_length tensor (scalar int32).
+    NodeArg& cast32_out = graph.GetOrCreateNodeArg(
+        graph.GenerateNodeArgName("gqa_mask_gc_cast_i32"), nullptr);
+    {
+      NodeAttributes attrs;
+      utils::SetNodeAttribute(
+          utils::MakeAttribute("to", static_cast<int64_t>(ONNX_NAMESPACE::TensorProto_DataType_INT32)),
+          attrs);
+      graph.AddNode(graph.GenerateNodeName("gqa_mask_gc_cast"),
+                    "Cast",
+                    "Cast attention_mask to int32 for GC-friendly reformatting",
+                    {mask_arg},
+                    {&cast32_out},
+                    &attrs,
+                    kOnnxDomain)
+          .SetExecutionProviderType(kWebGpuExecutionProvider);
+    }
+
+    NodeArg& reduce_sum_axes = AddInt64Vec1Initializer(graph, "gqa_mask_gc_rs_axes", 1);
+    NodeArg& reduce_sum_out = graph.GetOrCreateNodeArg(
+        graph.GenerateNodeArgName("gqa_mask_gc_rs"), nullptr);
+    {
+      NodeAttributes attrs;
+      utils::SetNodeAttribute(utils::MakeAttribute("keepdims", static_cast<int64_t>(0)), attrs);
+      graph.AddNode(graph.GenerateNodeName("gqa_mask_gc_reducesum"),
+                    "ReduceSum",
+                    "Per-row valid-token count for GQA seqlens_k / total_seq_len",
+                    {&cast32_out, &reduce_sum_axes},
+                    {&reduce_sum_out},
+                    &attrs,
+                    kOnnxDomain)
+          .SetExecutionProviderType(kWebGpuExecutionProvider);
+    }
+
+    // New seqlens_k = ReduceSum(...) - 1, reusing the original Cast-to-int32
+    // output NodeArg so every downstream GQA edge is preserved automatically.
+    NodeArg& sk_one = AddInt32Vec1Initializer(graph, "gqa_mask_gc_sk_one", 1);
+    NodeArg* sk_out_arg = graph.GetNodeArg(sk_chain.cast->OutputDefs()[0]->Name());
+
+    // New total_seq_len = ReduceMax(rs).
+    NodeArg& reduce_max_axes = AddInt64Vec1Initializer(graph, "gqa_mask_gc_rmax_axes", 0);
+    NodeArg* tsl_out_arg = graph.GetNodeArg(tsl_chain.cast->OutputDefs()[0]->Name());
+
+    // Capture downstream consumers BEFORE we remove the original nodes.
+    auto sk_out_edges = graph_utils::GraphEdge::GetNodeOutputEdges(*sk_chain.cast);
+    auto tsl_out_edges = graph_utils::GraphEdge::GetNodeOutputEdges(*tsl_chain.cast);
+
+    // Remove the original chains. Recursive orphan reaping cleans up the
+    // shared Shape/ReduceSum/Constant/initializer producers as their last
+    // consumers vanish.
+    Node* sk_cast_mut = graph.GetNode(sk_chain.cast->Index());
+    Node* sk_sub_mut = graph.GetNode(sk_chain.sub->Index());
+    Node* sk_rs_mut = graph.GetNode(sk_chain.reduce_sum->Index());
+    Node* tsl_cast_mut = graph.GetNode(tsl_chain.cast->Index());
+    Node* tsl_gather_mut = graph.GetNode(tsl_chain.gather->Index());
+    Node* tsl_shape_mut = graph.GetNode(tsl_chain.shape->Index());
+
+    auto safe_remove_top = [&](Node* node) {
+      if (node == nullptr) {
+        return;
+      }
+      graph_utils::RemoveNodeOutputEdges(graph, *node);
+      graph.RemoveNode(node->Index());
+    };
+
+    // Snapshot upstream indices so we can reap orphans after removal.
+    auto collect_upstream = [&](const Node* node, std::vector<NodeIndex>& out_idxs) {
+      if (node == nullptr) {
+        return;
+      }
+      for (auto it = node->InputEdgesBegin(); it != node->InputEdgesEnd(); ++it) {
+        out_idxs.push_back(it->GetNode().Index());
+      }
+    };
+
+    std::vector<NodeIndex> upstream_idxs;
+    collect_upstream(sk_chain.cast, upstream_idxs);
+    collect_upstream(sk_chain.sub, upstream_idxs);
+    collect_upstream(sk_chain.reduce_sum, upstream_idxs);
+    collect_upstream(tsl_chain.cast, upstream_idxs);
+    collect_upstream(tsl_chain.gather, upstream_idxs);
+    collect_upstream(tsl_chain.shape, upstream_idxs);
+
+    safe_remove_top(sk_cast_mut);
+    safe_remove_top(sk_sub_mut);
+    safe_remove_top(sk_rs_mut);
+    safe_remove_top(tsl_cast_mut);
+    safe_remove_top(tsl_gather_mut);
+    safe_remove_top(tsl_shape_mut);
+
+    // The Cast output NodeArgs now have no producer — re-attach the new ones.
+    // Add Sub (seqlens_k) producing sk_out_arg (same name as original).
+    {
+      Node& sub_node = graph.AddNode(graph.GenerateNodeName("gqa_mask_gc_sub"),
+                                     "Sub",
+                                     "GC-friendly seqlens_k = ReduceSum(mask) - 1",
+                                     {&reduce_sum_out, &sk_one},
+                                     {sk_out_arg},
+                                     nullptr,
+                                     kOnnxDomain);
+      sub_node.SetExecutionProviderType(kWebGpuExecutionProvider);
+      // Rewire edges to consumers.
+      for (const auto& e : sk_out_edges) {
+        graph.AddEdge(sub_node.Index(), e.dst_node, 0, e.dst_arg_index);
+      }
+    }
+
+    // Add ReduceMax (total_seq_len) producing tsl_out_arg (same name as original).
+    {
+      NodeAttributes attrs;
+      utils::SetNodeAttribute(utils::MakeAttribute("keepdims", static_cast<int64_t>(0)), attrs);
+      Node& rmax_node = graph.AddNode(graph.GenerateNodeName("gqa_mask_gc_reducemax"),
+                                      "ReduceMax",
+                                      "GC-friendly total_seq_len = ReduceMax(ReduceSum(mask))",
+                                      {&reduce_sum_out, &reduce_max_axes},
+                                      {tsl_out_arg},
+                                      &attrs,
+                                      kOnnxDomain);
+      rmax_node.SetExecutionProviderType(kWebGpuExecutionProvider);
+      for (const auto& e : tsl_out_edges) {
+        graph.AddEdge(rmax_node.Index(), e.dst_node, 0, e.dst_arg_index);
+      }
+    }
+
+    // Reap orphaned upstream nodes (Constant producers, leftover Shape input
+    // chains that only this subgraph consumed).
+    for (NodeIndex u : upstream_idxs) {
+      TryRemoveIfOrphan(graph, graph.GetNode(u));
+    }
+
+    modified = true;
+    // One rewrite covers all GQAs sharing the chain; stop after the first hit.
+    break;
+  }
+
+  return Status::OK();
+}
+
+}  // namespace onnxruntime

--- a/onnxruntime/core/optimizer/gqa_mask_reformatting_to_graph_capture.cc
+++ b/onnxruntime/core/optimizer/gqa_mask_reformatting_to_graph_capture.cc
@@ -6,14 +6,12 @@
 #include <string>
 #include <vector>
 
-#include "core/common/inlined_containers.h"
 #include "core/framework/tensorprotoutils.h"
 #include "core/graph/constants.h"
 #include "core/graph/graph_utils.h"
 #include "core/graph/graph_viewer.h"
 #include "core/graph/node_attr_utils.h"
 #include "core/optimizer/initializer.h"
-#include "core/optimizer/utils.h"
 
 namespace onnxruntime {
 
@@ -22,95 +20,6 @@ namespace {
 const Node* GetInputNode(const Graph& graph, const Node& node, int input_index) {
   const auto* edge = graph_utils::GetInputEdge(node, input_index);
   return edge == nullptr ? nullptr : graph.GetNode(edge->GetNode().Index());
-}
-
-// Match a node that produces a scalar/1-element int constant with value `expected`.
-// Accepts either a graph initializer (referenced via NodeArg) or a `Constant` node
-// with `value`, `value_int`, or `value_ints` attribute.
-bool IsConstantIntValue(const Graph& graph, const NodeArg& input_arg, int64_t expected) {
-  return optimizer_utils::IsInitializerWithExpectedValue(graph, input_arg, expected, true);
-}
-
-bool IsConstantNodeWithIntValue(const Node& node, int64_t expected) {
-  if (!graph_utils::IsSupportedOptypeVersionAndDomain(node, "Constant", {9, 11, 12, 13, 19, 20, 21, 23})) {
-    return false;
-  }
-  const auto* value_int = graph_utils::GetNodeAttribute(node, "value_int");
-  if (value_int != nullptr && value_int->type() == ONNX_NAMESPACE::AttributeProto_AttributeType_INT) {
-    return value_int->i() == expected;
-  }
-  const auto* value = graph_utils::GetNodeAttribute(node, "value");
-  if (value != nullptr && value->type() == ONNX_NAMESPACE::AttributeProto_AttributeType_TENSOR) {
-    const auto& tp = value->t();
-    if (tp.data_type() != ONNX_NAMESPACE::TensorProto_DataType_INT64 &&
-        tp.data_type() != ONNX_NAMESPACE::TensorProto_DataType_INT32) {
-      return false;
-    }
-    Initializer init(tp);
-    if (init.size() != 1) {
-      return false;
-    }
-    if (tp.data_type() == ONNX_NAMESPACE::TensorProto_DataType_INT64) {
-      return init.DataAsSpan<int64_t>()[0] == expected;
-    }
-    return static_cast<int64_t>(init.DataAsSpan<int32_t>()[0]) == expected;
-  }
-  return false;
-}
-
-// Resolves `arg` (an input NodeArg on `consumer`) to an int constant value if
-// possible. Returns true and writes the value to `out` if the producer is a
-// graph initializer or a `Constant` node with the requisite attribute.
-bool TryResolveConstantInt(const Graph& graph, const Node& consumer, int input_index, int64_t& out) {
-  const NodeArg* arg = consumer.InputDefs()[input_index];
-  if (arg == nullptr) {
-    return false;
-  }
-  if (optimizer_utils::IsInitializerWithExpectedValue(graph, *arg, static_cast<int64_t>(0), true) ||
-      optimizer_utils::IsInitializerWithExpectedValue(graph, *arg, static_cast<int64_t>(1), true)) {
-    // Cheap probe — fall through to the actual unpack below if it matched.
-  }
-  const ONNX_NAMESPACE::TensorProto* tp = nullptr;
-  if (graph.GetInitializedTensor(arg->Name(), tp) && tp != nullptr) {
-    if (tp->data_type() != ONNX_NAMESPACE::TensorProto_DataType_INT64 &&
-        tp->data_type() != ONNX_NAMESPACE::TensorProto_DataType_INT32) {
-      return false;
-    }
-    Initializer init(*tp);
-    if (init.size() != 1) {
-      return false;
-    }
-    out = tp->data_type() == ONNX_NAMESPACE::TensorProto_DataType_INT64
-              ? init.DataAsSpan<int64_t>()[0]
-              : static_cast<int64_t>(init.DataAsSpan<int32_t>()[0]);
-    return true;
-  }
-  const Node* producer = GetInputNode(graph, consumer, input_index);
-  if (producer == nullptr || producer->OpType() != "Constant") {
-    return false;
-  }
-  const auto* value_int = graph_utils::GetNodeAttribute(*producer, "value_int");
-  if (value_int != nullptr && value_int->type() == ONNX_NAMESPACE::AttributeProto_AttributeType_INT) {
-    out = value_int->i();
-    return true;
-  }
-  const auto* value = graph_utils::GetNodeAttribute(*producer, "value");
-  if (value != nullptr && value->type() == ONNX_NAMESPACE::AttributeProto_AttributeType_TENSOR) {
-    const auto& v_tp = value->t();
-    if (v_tp.data_type() != ONNX_NAMESPACE::TensorProto_DataType_INT64 &&
-        v_tp.data_type() != ONNX_NAMESPACE::TensorProto_DataType_INT32) {
-      return false;
-    }
-    Initializer init(v_tp);
-    if (init.size() != 1) {
-      return false;
-    }
-    out = v_tp.data_type() == ONNX_NAMESPACE::TensorProto_DataType_INT64
-              ? init.DataAsSpan<int64_t>()[0]
-              : static_cast<int64_t>(init.DataAsSpan<int32_t>()[0]);
-    return true;
-  }
-  return false;
 }
 
 bool IsCastToInt32(const Node& node) {
@@ -123,151 +32,71 @@ bool IsCastToInt32(const Node& node) {
 
 bool IsKeepDimsZero(const Node& node) {
   const auto* attr = graph_utils::GetNodeAttribute(node, "keepdims");
-  // ONNX default is keepdims=1; we require explicit 0.
   return attr != nullptr && attr->i() == 0;
 }
 
-// Match: input_arg is produced by `Cast(to=INT32)(Sub(ReduceSum(mask, axes=[1], keepdims=0), 1))`.
-// Returns the three intermediate nodes (cast, sub, reduce_sum) and the mask NodeArg.
-struct SeqlensKChain {
-  const Node* cast;
-  const Node* sub;
-  const Node* reduce_sum;
-  const NodeArg* mask;
-};
-
-bool MatchSeqlensKChain(const Graph& graph, const NodeArg& seqlens_k, SeqlensKChain& out) {
-  const Node* cast = graph.GetProducerNode(seqlens_k.Name());
-  if (cast == nullptr || !IsCastToInt32(*cast)) {
-    return false;
-  }
-  const Node* sub = GetInputNode(graph, *cast, 0);
-  if (sub == nullptr || !graph_utils::IsSupportedOptypeVersionAndDomain(*sub, "Sub", {7, 13, 14})) {
-    return false;
-  }
-  int64_t one_value = 0;
-  if (!TryResolveConstantInt(graph, *sub, 1, one_value) || one_value != 1) {
-    return false;
-  }
-  const Node* reduce_sum = GetInputNode(graph, *sub, 0);
-  if (reduce_sum == nullptr ||
-      !graph_utils::IsSupportedOptypeVersionAndDomain(*reduce_sum, "ReduceSum", {13, 18, 20})) {
-    return false;
-  }
-  if (!IsKeepDimsZero(*reduce_sum)) {
-    return false;
-  }
-  // axes input must be [1]
-  int64_t axes_value = 0;
-  if (reduce_sum->InputDefs().size() < 2) {
-    return false;
-  }
-  const NodeArg* axes_arg = reduce_sum->InputDefs()[1];
-  const ONNX_NAMESPACE::TensorProto* axes_tp = nullptr;
-  if (!graph.GetInitializedTensor(axes_arg->Name(), axes_tp) || axes_tp == nullptr) {
-    return false;
-  }
-  if (axes_tp->data_type() != ONNX_NAMESPACE::TensorProto_DataType_INT64) {
-    return false;
-  }
-  Initializer axes_init(*axes_tp);
-  if (axes_init.size() != 1) {
-    return false;
-  }
-  axes_value = axes_init.DataAsSpan<int64_t>()[0];
-  if (axes_value != 1) {
-    return false;
-  }
-  out.cast = cast;
-  out.sub = sub;
-  out.reduce_sum = reduce_sum;
-  out.mask = reduce_sum->InputDefs()[0];
-  return true;
+bool IsInitializerWithInt64Value(const Graph& graph, const NodeArg* arg, int64_t expected) {
+  if (arg == nullptr) return false;
+  const ONNX_NAMESPACE::TensorProto* tp = nullptr;
+  if (!graph.GetInitializedTensor(arg->Name(), tp) || tp == nullptr) return false;
+  if (tp->data_type() != ONNX_NAMESPACE::TensorProto_DataType_INT64) return false;
+  Initializer init(*tp);
+  return init.size() == 1 && init.DataAsSpan<int64_t>()[0] == expected;
 }
 
-struct TotalSeqLenChain {
-  const Node* cast;
-  const Node* gather;
-  const Node* shape;
-  const NodeArg* mask;
-};
-
-bool MatchTotalSeqLenChain(const Graph& graph, const NodeArg& total_seq_len, TotalSeqLenChain& out) {
-  const Node* cast = graph.GetProducerNode(total_seq_len.Name());
-  if (cast == nullptr || !IsCastToInt32(*cast)) {
-    return false;
+bool IsConstantInt(const Graph& graph, const Node& consumer, int input_index, int64_t expected) {
+  if (input_index >= static_cast<int>(consumer.InputDefs().size())) return false;
+  const NodeArg* arg = consumer.InputDefs()[input_index];
+  if (arg == nullptr) return false;
+  // Check graph initializer first.
+  if (IsInitializerWithInt64Value(graph, arg, expected)) return true;
+  // Check int32 initializer.
+  const ONNX_NAMESPACE::TensorProto* tp = nullptr;
+  if (graph.GetInitializedTensor(arg->Name(), tp) && tp != nullptr &&
+      tp->data_type() == ONNX_NAMESPACE::TensorProto_DataType_INT32) {
+    Initializer init(*tp);
+    if (init.size() == 1 && static_cast<int64_t>(init.DataAsSpan<int32_t>()[0]) == expected) return true;
   }
-  const Node* gather = GetInputNode(graph, *cast, 0);
-  if (gather == nullptr || !graph_utils::IsSupportedOptypeVersionAndDomain(*gather, "Gather", {1, 11, 13})) {
-    return false;
+  // Check Constant node.
+  const Node* producer = GetInputNode(graph, consumer, input_index);
+  if (producer == nullptr || producer->OpType() != "Constant") return false;
+  const auto* vi = graph_utils::GetNodeAttribute(*producer, "value_int");
+  if (vi != nullptr && vi->type() == ONNX_NAMESPACE::AttributeProto_AttributeType_INT) {
+    return vi->i() == expected;
   }
-  const auto* axis_attr = graph_utils::GetNodeAttribute(*gather, "axis");
-  const int64_t axis = axis_attr != nullptr ? axis_attr->i() : 0;
-  if (axis != 0) {
-    return false;
-  }
-  int64_t idx_value = 0;
-  if (!TryResolveConstantInt(graph, *gather, 1, idx_value) || idx_value != 1) {
-    return false;
-  }
-  const Node* shape = GetInputNode(graph, *gather, 0);
-  if (shape == nullptr || !graph_utils::IsSupportedOptypeVersionAndDomain(*shape, "Shape", {1, 13, 15, 19, 21, 23, 24})) {
-    return false;
-  }
-  out.cast = cast;
-  out.gather = gather;
-  out.shape = shape;
-  out.mask = shape->InputDefs()[0];
-  return true;
+  return false;
 }
 
-NodeArg& AddInt64ScalarInitializer(Graph& graph, const std::string& name_hint, int64_t value) {
+NodeArg& AddVec1Initializer(Graph& graph, const std::string& name_hint,
+                             int data_type, const void* data, size_t byte_len) {
   ONNX_NAMESPACE::TensorProto tp;
   tp.set_name(graph.GenerateNodeArgName(name_hint));
-  tp.set_data_type(ONNX_NAMESPACE::TensorProto_DataType_INT64);
-  utils::SetRawDataInTensorProto(tp, &value, sizeof(int64_t));
-  return graph_utils::AddInitializerWithOrtValue(graph, tp);
-}
-
-NodeArg& AddInt64Vec1Initializer(Graph& graph, const std::string& name_hint, int64_t value) {
-  ONNX_NAMESPACE::TensorProto tp;
-  tp.set_name(graph.GenerateNodeArgName(name_hint));
-  tp.set_data_type(ONNX_NAMESPACE::TensorProto_DataType_INT64);
+  tp.set_data_type(data_type);
   tp.add_dims(1);
-  utils::SetRawDataInTensorProto(tp, &value, sizeof(int64_t));
+  utils::SetRawDataInTensorProto(tp, data, byte_len);
   return graph_utils::AddInitializerWithOrtValue(graph, tp);
 }
 
-NodeArg& AddInt32Vec1Initializer(Graph& graph, const std::string& name_hint, int32_t value) {
-  ONNX_NAMESPACE::TensorProto tp;
-  tp.set_name(graph.GenerateNodeArgName(name_hint));
-  tp.set_data_type(ONNX_NAMESPACE::TensorProto_DataType_INT32);
-  tp.add_dims(1);
-  utils::SetRawDataInTensorProto(tp, &value, sizeof(int32_t));
-  return graph_utils::AddInitializerWithOrtValue(graph, tp);
-}
-
-void TryRemoveIfOrphan(Graph& graph, const Node* node) {
-  if (node == nullptr) {
-    return;
-  }
-  if (graph.NodeProducesGraphOutput(*node)) {
-    return;
-  }
-  if (node->GetOutputEdgesCount() != 0) {
-    return;
-  }
-  // Recurse upstream after removal so orphan Constant / initializer-producing
-  // nodes are also reaped.
+void RemoveChain(Graph& graph, std::initializer_list<const Node*> nodes) {
   std::vector<NodeIndex> upstream;
-  upstream.reserve(node->GetInputEdgesCount());
-  for (auto it = node->InputEdgesBegin(); it != node->InputEdgesEnd(); ++it) {
-    upstream.push_back(it->GetNode().Index());
+  for (const Node* n : nodes) {
+    if (n == nullptr) continue;
+    for (auto it = n->InputEdgesBegin(); it != n->InputEdgesEnd(); ++it) {
+      upstream.push_back(it->GetNode().Index());
+    }
   }
-  graph_utils::RemoveNodeOutputEdges(graph, *const_cast<Node*>(node));
-  graph.RemoveNode(node->Index());
+  for (const Node* n : nodes) {
+    if (n == nullptr) continue;
+    graph_utils::RemoveNodeOutputEdges(graph, *graph.GetNode(n->Index()));
+    graph.RemoveNode(n->Index());
+  }
+  // Reap orphaned upstream nodes (Constant producers, etc.).
   for (NodeIndex idx : upstream) {
-    TryRemoveIfOrphan(graph, graph.GetNode(idx));
+    const Node* u = graph.GetNode(idx);
+    if (u != nullptr && u->GetOutputEdgesCount() == 0 && !graph.NodeProducesGraphOutput(*u)) {
+      graph_utils::RemoveNodeOutputEdges(graph, *graph.GetNode(idx));
+      graph.RemoveNode(idx);
+    }
   }
 }
 
@@ -280,192 +109,119 @@ Status GqaMaskReformattingToGraphCapture::ApplyImpl(Graph& graph,
   GraphViewer graph_viewer(graph);
   const auto& topo = graph_viewer.GetNodesInTopologicalOrder();
 
-  // Find a GQA node whose seqlens_k & total_seq_len both match the standard
-  // CPU-bound subgraph. Because all GQAs in a model typically share the same
-  // producer chain (gemma4 has 35 GQAs sharing one chain), the first match is
-  // sufficient — rewriting it rewires every consumer at once.
   for (NodeIndex idx : topo) {
     Node* gqa = graph.GetNode(idx);
-    if (gqa == nullptr) {
-      continue;
-    }
-    if (!graph_utils::IsSupportedOptypeVersionAndDomain(*gqa, "GroupQueryAttention", {1}, kMSDomain)) {
-      continue;
-    }
+    if (gqa == nullptr) continue;
+    if (!graph_utils::IsSupportedOptypeVersionAndDomain(*gqa, "GroupQueryAttention", {1}, kMSDomain)) continue;
     if (!gqa->GetExecutionProviderType().empty() &&
         gqa->GetExecutionProviderType() != kWebGpuExecutionProvider) {
       continue;
     }
-    if (gqa->InputDefs().size() < 7) {
-      continue;
-    }
+    if (gqa->InputDefs().size() < 7) continue;
 
     const NodeArg* seqlens_k_arg = gqa->InputDefs()[5];
     const NodeArg* total_seq_len_arg = gqa->InputDefs()[6];
-    if (seqlens_k_arg == nullptr || total_seq_len_arg == nullptr) {
-      continue;
-    }
+    if (seqlens_k_arg == nullptr || total_seq_len_arg == nullptr) continue;
 
-    SeqlensKChain sk_chain{};
-    TotalSeqLenChain tsl_chain{};
-    if (!MatchSeqlensKChain(graph, *seqlens_k_arg, sk_chain)) {
-      continue;
-    }
-    if (!MatchTotalSeqLenChain(graph, *total_seq_len_arg, tsl_chain)) {
-      continue;
-    }
-    if (sk_chain.mask != tsl_chain.mask) {
-      continue;
-    }
+    // --- Match seqlens_k chain: Cast(INT32) <- Sub(_, 1) <- ReduceSum(mask, axes=[1], keepdims=0) ---
+    const Node* sk_cast = graph.GetProducerNode(seqlens_k_arg->Name());
+    if (sk_cast == nullptr || !IsCastToInt32(*sk_cast)) continue;
+    const Node* sk_sub = GetInputNode(graph, *sk_cast, 0);
+    if (sk_sub == nullptr || !graph_utils::IsSupportedOptypeVersionAndDomain(*sk_sub, "Sub", {7, 13, 14})) continue;
+    if (!IsConstantInt(graph, *sk_sub, 1, 1)) continue;
+    const Node* sk_rs = GetInputNode(graph, *sk_sub, 0);
+    if (sk_rs == nullptr || !graph_utils::IsSupportedOptypeVersionAndDomain(*sk_rs, "ReduceSum", {13, 18, 20})) continue;
+    if (!IsKeepDimsZero(*sk_rs)) continue;
+    if (sk_rs->InputDefs().size() < 2 || !IsInitializerWithInt64Value(graph, sk_rs->InputDefs()[1], 1)) continue;
 
-    NodeArg* mask_arg = graph.GetNodeArg(sk_chain.mask->Name());
-    if (mask_arg == nullptr) {
-      continue;
-    }
+    // --- Match total_seq_len chain: Cast(INT32) <- Gather(_, idx=1, axis=0) <- Shape(mask) ---
+    const Node* tsl_cast = graph.GetProducerNode(total_seq_len_arg->Name());
+    if (tsl_cast == nullptr || !IsCastToInt32(*tsl_cast)) continue;
+    const Node* tsl_gather = GetInputNode(graph, *tsl_cast, 0);
+    if (tsl_gather == nullptr || !graph_utils::IsSupportedOptypeVersionAndDomain(*tsl_gather, "Gather", {1, 11, 13})) continue;
+    const auto* axis_attr = graph_utils::GetNodeAttribute(*tsl_gather, "axis");
+    if (axis_attr != nullptr && axis_attr->i() != 0) continue;
+    if (!IsConstantInt(graph, *tsl_gather, 1, 1)) continue;
+    const Node* tsl_shape = GetInputNode(graph, *tsl_gather, 0);
+    if (tsl_shape == nullptr || !graph_utils::IsSupportedOptypeVersionAndDomain(*tsl_shape, "Shape", {1, 13, 15, 19, 21, 23, 24})) continue;
 
-    LOGS(logger, INFO) << "GqaMaskReformattingToGraphCapture: rewriting CPU-bound mask reformatting subgraph "
-                       << "(seqlens_k chain anchor='" << sk_chain.cast->Name()
-                       << "', total_seq_len chain anchor='" << tsl_chain.cast->Name()
-                       << "', mask input='" << mask_arg->Name() << "')";
+    // Both chains must consume the same attention_mask.
+    const NodeArg* sk_mask = sk_rs->InputDefs()[0];
+    const NodeArg* tsl_mask = tsl_shape->InputDefs()[0];
+    if (sk_mask != tsl_mask) continue;
+    NodeArg* mask_arg = graph.GetNodeArg(sk_mask->Name());
+    if (mask_arg == nullptr) continue;
 
-    // ---- Build the replacement subgraph: ----
-    //   cast32  = Cast(mask, to=INT32)
-    //   rs      = ReduceSum(cast32, axes=[1], keepdims=0)  (int32, shape [B])
-    //   sk      = Sub(rs, [1])  → seqlens_k (replaces sk_chain.cast output)
-    //   tsl_red = ReduceMax(rs, axes=[0], keepdims=0)  (int32, scalar) → total_seq_len
-    // ReduceMax over the only remaining axis collapses to a scalar, matching
-    // the original total_sequence_length tensor (scalar int32).
-    NodeArg& cast32_out = graph.GetOrCreateNodeArg(
-        graph.GenerateNodeArgName("gqa_mask_gc_cast_i32"), nullptr);
+    LOGS(logger, INFO) << "GqaMaskReformattingToGraphCapture: rewriting CPU-bound mask subgraph"
+                       << " (mask='" << mask_arg->Name() << "')";
+
+    // --- Build replacement subgraph ---
+    //   Cast(INT32) -> ReduceSum(axes=[1]) -+-> Sub(_, 1) -> seqlens_k
+    //                                       +-> ReduceMax   -> total_seq_len
+
+    NodeArg& cast_out = graph.GetOrCreateNodeArg(
+        graph.GenerateNodeArgName("gqa_gc_cast"), nullptr);
     {
       NodeAttributes attrs;
       utils::SetNodeAttribute(
-          utils::MakeAttribute("to", static_cast<int64_t>(ONNX_NAMESPACE::TensorProto_DataType_INT32)),
-          attrs);
-      graph.AddNode(graph.GenerateNodeName("gqa_mask_gc_cast"),
-                    "Cast",
-                    "Cast attention_mask to int32 for GC-friendly reformatting",
-                    {mask_arg},
-                    {&cast32_out},
-                    &attrs,
-                    kOnnxDomain)
+          utils::MakeAttribute("to", static_cast<int64_t>(ONNX_NAMESPACE::TensorProto_DataType_INT32)), attrs);
+      graph.AddNode(graph.GenerateNodeName("gqa_gc_cast"), "Cast", "",
+                    {mask_arg}, {&cast_out}, &attrs, kOnnxDomain)
           .SetExecutionProviderType(kWebGpuExecutionProvider);
     }
 
-    NodeArg& reduce_sum_axes = AddInt64Vec1Initializer(graph, "gqa_mask_gc_rs_axes", 1);
-    NodeArg& reduce_sum_out = graph.GetOrCreateNodeArg(
-        graph.GenerateNodeArgName("gqa_mask_gc_rs"), nullptr);
+    int64_t one_i64 = 1;
+    NodeArg& rs_axes = AddVec1Initializer(graph, "gqa_gc_rs_axes",
+                                          ONNX_NAMESPACE::TensorProto_DataType_INT64, &one_i64, sizeof(int64_t));
+    NodeArg& rs_out = graph.GetOrCreateNodeArg(
+        graph.GenerateNodeArgName("gqa_gc_rs"), nullptr);
     {
       NodeAttributes attrs;
       utils::SetNodeAttribute(utils::MakeAttribute("keepdims", static_cast<int64_t>(0)), attrs);
-      graph.AddNode(graph.GenerateNodeName("gqa_mask_gc_reducesum"),
-                    "ReduceSum",
-                    "Per-row valid-token count for GQA seqlens_k / total_seq_len",
-                    {&cast32_out, &reduce_sum_axes},
-                    {&reduce_sum_out},
-                    &attrs,
-                    kOnnxDomain)
+      graph.AddNode(graph.GenerateNodeName("gqa_gc_rs"), "ReduceSum", "",
+                    {&cast_out, &rs_axes}, {&rs_out}, &attrs, kOnnxDomain)
           .SetExecutionProviderType(kWebGpuExecutionProvider);
     }
 
-    // New seqlens_k = ReduceSum(...) - 1, reusing the original Cast-to-int32
-    // output NodeArg so every downstream GQA edge is preserved automatically.
-    NodeArg& sk_one = AddInt32Vec1Initializer(graph, "gqa_mask_gc_sk_one", 1);
-    NodeArg* sk_out_arg = graph.GetNodeArg(sk_chain.cast->OutputDefs()[0]->Name());
+    // Capture downstream edges, remove old chains, then add replacement nodes
+    // producing the same output NodeArgs.
+    auto sk_edges = graph_utils::GraphEdge::GetNodeOutputEdges(*sk_cast);
+    auto tsl_edges = graph_utils::GraphEdge::GetNodeOutputEdges(*tsl_cast);
 
-    // New total_seq_len = ReduceMax(rs).
-    NodeArg& reduce_max_axes = AddInt64Vec1Initializer(graph, "gqa_mask_gc_rmax_axes", 0);
-    NodeArg* tsl_out_arg = graph.GetNodeArg(tsl_chain.cast->OutputDefs()[0]->Name());
+    NodeArg* sk_out = graph.GetNodeArg(sk_cast->OutputDefs()[0]->Name());
+    NodeArg* tsl_out = graph.GetNodeArg(tsl_cast->OutputDefs()[0]->Name());
 
-    // Capture downstream consumers BEFORE we remove the original nodes.
-    auto sk_out_edges = graph_utils::GraphEdge::GetNodeOutputEdges(*sk_chain.cast);
-    auto tsl_out_edges = graph_utils::GraphEdge::GetNodeOutputEdges(*tsl_chain.cast);
+    RemoveChain(graph, {sk_cast, sk_sub, sk_rs, tsl_cast, tsl_gather, tsl_shape});
 
-    // Remove the original chains. Recursive orphan reaping cleans up the
-    // shared Shape/ReduceSum/Constant/initializer producers as their last
-    // consumers vanish.
-    Node* sk_cast_mut = graph.GetNode(sk_chain.cast->Index());
-    Node* sk_sub_mut = graph.GetNode(sk_chain.sub->Index());
-    Node* sk_rs_mut = graph.GetNode(sk_chain.reduce_sum->Index());
-    Node* tsl_cast_mut = graph.GetNode(tsl_chain.cast->Index());
-    Node* tsl_gather_mut = graph.GetNode(tsl_chain.gather->Index());
-    Node* tsl_shape_mut = graph.GetNode(tsl_chain.shape->Index());
-
-    auto safe_remove_top = [&](Node* node) {
-      if (node == nullptr) {
-        return;
-      }
-      graph_utils::RemoveNodeOutputEdges(graph, *node);
-      graph.RemoveNode(node->Index());
-    };
-
-    // Snapshot upstream indices so we can reap orphans after removal.
-    auto collect_upstream = [&](const Node* node, std::vector<NodeIndex>& out_idxs) {
-      if (node == nullptr) {
-        return;
-      }
-      for (auto it = node->InputEdgesBegin(); it != node->InputEdgesEnd(); ++it) {
-        out_idxs.push_back(it->GetNode().Index());
-      }
-    };
-
-    std::vector<NodeIndex> upstream_idxs;
-    collect_upstream(sk_chain.cast, upstream_idxs);
-    collect_upstream(sk_chain.sub, upstream_idxs);
-    collect_upstream(sk_chain.reduce_sum, upstream_idxs);
-    collect_upstream(tsl_chain.cast, upstream_idxs);
-    collect_upstream(tsl_chain.gather, upstream_idxs);
-    collect_upstream(tsl_chain.shape, upstream_idxs);
-
-    safe_remove_top(sk_cast_mut);
-    safe_remove_top(sk_sub_mut);
-    safe_remove_top(sk_rs_mut);
-    safe_remove_top(tsl_cast_mut);
-    safe_remove_top(tsl_gather_mut);
-    safe_remove_top(tsl_shape_mut);
-
-    // The Cast output NodeArgs now have no producer — re-attach the new ones.
-    // Add Sub (seqlens_k) producing sk_out_arg (same name as original).
+    // Sub: seqlens_k = ReduceSum - 1
+    int32_t one_i32 = 1;
+    NodeArg& sk_one = AddVec1Initializer(graph, "gqa_gc_sk_one",
+                                         ONNX_NAMESPACE::TensorProto_DataType_INT32, &one_i32, sizeof(int32_t));
     {
-      Node& sub_node = graph.AddNode(graph.GenerateNodeName("gqa_mask_gc_sub"),
-                                     "Sub",
-                                     "GC-friendly seqlens_k = ReduceSum(mask) - 1",
-                                     {&reduce_sum_out, &sk_one},
-                                     {sk_out_arg},
-                                     nullptr,
-                                     kOnnxDomain);
-      sub_node.SetExecutionProviderType(kWebGpuExecutionProvider);
-      // Rewire edges to consumers.
-      for (const auto& e : sk_out_edges) {
-        graph.AddEdge(sub_node.Index(), e.dst_node, 0, e.dst_arg_index);
+      Node& sub = graph.AddNode(graph.GenerateNodeName("gqa_gc_sub"), "Sub", "",
+                                {&rs_out, &sk_one}, {sk_out}, nullptr, kOnnxDomain);
+      sub.SetExecutionProviderType(kWebGpuExecutionProvider);
+      for (const auto& e : sk_edges) {
+        graph.AddEdge(sub.Index(), e.dst_node, 0, e.dst_arg_index);
       }
     }
 
-    // Add ReduceMax (total_seq_len) producing tsl_out_arg (same name as original).
+    // ReduceMax: total_seq_len = max(ReduceSum)
+    int64_t zero_i64 = 0;
+    NodeArg& rmax_axes = AddVec1Initializer(graph, "gqa_gc_rmax_axes",
+                                            ONNX_NAMESPACE::TensorProto_DataType_INT64, &zero_i64, sizeof(int64_t));
     {
       NodeAttributes attrs;
       utils::SetNodeAttribute(utils::MakeAttribute("keepdims", static_cast<int64_t>(0)), attrs);
-      Node& rmax_node = graph.AddNode(graph.GenerateNodeName("gqa_mask_gc_reducemax"),
-                                      "ReduceMax",
-                                      "GC-friendly total_seq_len = ReduceMax(ReduceSum(mask))",
-                                      {&reduce_sum_out, &reduce_max_axes},
-                                      {tsl_out_arg},
-                                      &attrs,
-                                      kOnnxDomain);
-      rmax_node.SetExecutionProviderType(kWebGpuExecutionProvider);
-      for (const auto& e : tsl_out_edges) {
-        graph.AddEdge(rmax_node.Index(), e.dst_node, 0, e.dst_arg_index);
+      Node& rmax = graph.AddNode(graph.GenerateNodeName("gqa_gc_rmax"), "ReduceMax", "",
+                                 {&rs_out, &rmax_axes}, {tsl_out}, &attrs, kOnnxDomain);
+      rmax.SetExecutionProviderType(kWebGpuExecutionProvider);
+      for (const auto& e : tsl_edges) {
+        graph.AddEdge(rmax.Index(), e.dst_node, 0, e.dst_arg_index);
       }
-    }
-
-    // Reap orphaned upstream nodes (Constant producers, leftover Shape input
-    // chains that only this subgraph consumed).
-    for (NodeIndex u : upstream_idxs) {
-      TryRemoveIfOrphan(graph, graph.GetNode(u));
     }
 
     modified = true;
-    // One rewrite covers all GQAs sharing the chain; stop after the first hit.
     break;
   }
 

--- a/onnxruntime/core/optimizer/gqa_mask_reformatting_to_graph_capture.h
+++ b/onnxruntime/core/optimizer/gqa_mask_reformatting_to_graph_capture.h
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/optimizer/graph_transformer.h"
+
+namespace onnxruntime {
+
+// Rewrites the standard CPU-bound attention-mask reformatting subgraph that feeds
+// GroupQueryAttention's seqlens_k (input 5) and total_sequence_length (input 6)
+// inputs into an equivalent GPU-resident form, so that WebGPU graph capture can
+// successfully replay the resulting graph.
+//
+// Standard (CPU-bound) form, as emitted by genai builders when the
+// `enable_webgpu_graph` flag is OFF:
+//
+//   attention_mask --+-> ReduceSum(axes=[1], keepdims=0) -> Sub(_, 1) -> Cast(INT32) -> seqlens_k
+//                    |
+//                    +-> Shape -> Gather(_, 1, axis=0) -> Cast(INT32) -> total_seq_len
+//
+// The Shape op has CPU-only output, so under graph capture the captured GPU
+// command list cannot be replayed without a CPU dependency, and seqlens_k /
+// total_seq_len become stale, corrupting attention.
+//
+// Rewritten (GPU-friendly) form:
+//
+//   attention_mask -> Cast(INT32) -> ReduceSum(axes=[1], keepdims=0) -+-> Sub(_, 1) -> seqlens_k
+//                                                                     |
+//                                                                     +-> ReduceMax(axes=[]) -> total_seq_len
+//
+// The rewrite relies on the invariant that the trailing position of the
+// attention_mask is always 1 (true for genai left-padded causal masks), so
+// `ReduceMax(ReduceSum(mask, axis=1))` is equivalent to `Shape(mask)[1]`.
+class GqaMaskReformattingToGraphCapture : public GraphTransformer {
+ public:
+  explicit GqaMaskReformattingToGraphCapture(
+      const InlinedHashSet<std::string_view>& compatible_execution_providers = {}) noexcept
+      : GraphTransformer("GqaMaskReformattingToGraphCapture", compatible_execution_providers) {}
+
+ private:
+  Status ApplyImpl(Graph& graph, bool& modified, int graph_level, const logging::Logger& logger) const override;
+};
+
+}  // namespace onnxruntime

--- a/onnxruntime/core/optimizer/graph_transformer_utils.cc
+++ b/onnxruntime/core/optimizer/graph_transformer_utils.cc
@@ -48,6 +48,7 @@
 #include "core/optimizer/gemm_activation_fusion.h"
 #include "core/optimizer/gemm_sum_fusion.h"
 #include "core/optimizer/gemm_transpose_fusion.h"
+#include "core/optimizer/gqa_mask_reformatting_to_graph_capture.h"
 #include "core/optimizer/group_query_attention_fusion.h"
 #include "core/optimizer/identical_children_consolidation.h"
 #include "core/optimizer/identity_elimination.h"
@@ -452,6 +453,17 @@ InlinedVector<std::unique_ptr<GraphTransformer>> GenerateTransformers(
           InlinedHashSet<std::string_view>{onnxruntime::kWebGpuExecutionProvider}));
       transformers.emplace_back(std::make_unique<MatMulNBitsQkvFusion>(
           InlinedHashSet<std::string_view>{onnxruntime::kWebGpuExecutionProvider}));
+      // Only run when WebGPU graph capture is enabled — the rewrite inserts an
+      // int64-input Cast that only has a kernel when enable_graph_capture (or
+      // enable_int64) is on for the WebGPU EP, and outside graph capture the
+      // CPU-bound mask preprocessing already works fine.
+      const bool webgpu_graph_capture_enabled =
+          session_options.config_options.GetConfigOrDefault(
+              "ep.webgpuexecutionprovider.enableGraphCapture", "0") == "1";
+      if (webgpu_graph_capture_enabled) {
+        transformers.emplace_back(std::make_unique<GqaMaskReformattingToGraphCapture>(
+            InlinedHashSet<std::string_view>{onnxruntime::kWebGpuExecutionProvider}));
+      }
 
 #endif  // !defined(DISABLE_CONTRIB_OPS)
       // The QDQFinalCleanupTransformer must run AFTER other transformers that fuse Q/DQ nodes. Otherwise, their

--- a/onnxruntime/core/providers/webgpu/buffer_manager.cc
+++ b/onnxruntime/core/providers/webgpu/buffer_manager.cc
@@ -290,33 +290,24 @@ class GraphCacheManager : public IBufferCacheManager {
   }
 
   void ReleaseBuffer(WGPUBuffer buffer) override {
-    pending_buffers_.emplace_back(buffer);
+    if (graph_capture_state_ == GraphCaptureState::Default) {
+      auto buffer_size = static_cast<size_t>(wgpuBufferGetSize(buffer));
+      auto it = buckets_.find(buffer_size);
+      if (it != buckets_.end()) {
+        it->second.emplace_back(buffer);
+      } else {
+        buckets_[buffer_size] = std::vector<WGPUBuffer>{buffer};
+      }
+    } else {
+      captured_buffers_.emplace_back(buffer);
+    }
   }
 
   void OnRefresh(GraphCaptureState graph_capture_state) override {
-    for (auto& buffer : pending_buffers_) {
-      if (graph_capture_state == GraphCaptureState::Default) {
-        auto buffer_size = static_cast<size_t>(wgpuBufferGetSize(buffer));
-        auto it = buckets_.find(buffer_size);
-        if (it != buckets_.end()) {
-          it->second.emplace_back(buffer);
-        } else {
-          // Insert a new bucket for non-standard buffer sizes
-          buckets_[buffer_size] = std::vector<WGPUBuffer>{buffer};
-        }
-      } else {
-        // During Capturing or Replaying, quarantine released buffers so that
-        // the captured bind_groups keep exclusive ownership of their buffers.
-        captured_buffers_.emplace_back(buffer);
-      }
-    }
-    pending_buffers_.clear();
+    graph_capture_state_ = graph_capture_state;
   }
 
   ~GraphCacheManager() {
-    for (auto& buffer : pending_buffers_) {
-      wgpuBufferRelease(buffer);
-    }
     for (auto& pair : buckets_) {
       for (auto& buffer : pair.second) {
         wgpuBufferRelease(buffer);
@@ -348,9 +339,9 @@ class GraphCacheManager : public IBufferCacheManager {
   }
   std::unordered_map<size_t, size_t> buckets_limit_;
   std::unordered_map<size_t, std::vector<WGPUBuffer>> buckets_;
-  std::vector<WGPUBuffer> pending_buffers_;
   std::vector<WGPUBuffer> captured_buffers_;
   std::vector<size_t> buckets_keys_;
+  GraphCaptureState graph_capture_state_ = GraphCaptureState::Default;
 };
 
 class GraphSimpleCacheManager : public IBufferCacheManager {

--- a/onnxruntime/core/providers/webgpu/buffer_manager.cc
+++ b/onnxruntime/core/providers/webgpu/buffer_manager.cc
@@ -290,21 +290,18 @@ class GraphCacheManager : public IBufferCacheManager {
   }
 
   void ReleaseBuffer(WGPUBuffer buffer) override {
-    if (graph_capture_state_ == GraphCaptureState::Default) {
-      auto buffer_size = static_cast<size_t>(wgpuBufferGetSize(buffer));
-      auto it = buckets_.find(buffer_size);
-      if (it != buckets_.end()) {
-        it->second.emplace_back(buffer);
-      } else {
-        buckets_[buffer_size] = std::vector<WGPUBuffer>{buffer};
-      }
+    auto buffer_size = static_cast<size_t>(wgpuBufferGetSize(buffer));
+    auto it = buckets_.find(buffer_size);
+    if (it != buckets_.end()) {
+      it->second.emplace_back(buffer);
     } else {
-      captured_buffers_.emplace_back(buffer);
+      // Insert a new bucket for non-standard buffer sizes
+      buckets_[buffer_size] = std::vector<WGPUBuffer>{buffer};
     }
   }
 
-  void OnRefresh(GraphCaptureState graph_capture_state) override {
-    graph_capture_state_ = graph_capture_state;
+  void OnRefresh(GraphCaptureState /*graph_capture_state*/) override {
+    // no-op - buffers are already in buckets_
   }
 
   ~GraphCacheManager() {
@@ -312,9 +309,6 @@ class GraphCacheManager : public IBufferCacheManager {
       for (auto& buffer : pair.second) {
         wgpuBufferRelease(buffer);
       }
-    }
-    for (auto& buffer : captured_buffers_) {
-      wgpuBufferRelease(buffer);
     }
   }
 
@@ -339,9 +333,7 @@ class GraphCacheManager : public IBufferCacheManager {
   }
   std::unordered_map<size_t, size_t> buckets_limit_;
   std::unordered_map<size_t, std::vector<WGPUBuffer>> buckets_;
-  std::vector<WGPUBuffer> captured_buffers_;
   std::vector<size_t> buckets_keys_;
-  GraphCaptureState graph_capture_state_ = GraphCaptureState::Default;
 };
 
 class GraphSimpleCacheManager : public IBufferCacheManager {

--- a/onnxruntime/core/providers/webgpu/buffer_manager.cc
+++ b/onnxruntime/core/providers/webgpu/buffer_manager.cc
@@ -290,25 +290,40 @@ class GraphCacheManager : public IBufferCacheManager {
   }
 
   void ReleaseBuffer(WGPUBuffer buffer) override {
-    auto buffer_size = static_cast<size_t>(wgpuBufferGetSize(buffer));
-    auto it = buckets_.find(buffer_size);
-    if (it != buckets_.end()) {
-      it->second.emplace_back(buffer);
-    } else {
-      // Insert a new bucket for non-standard buffer sizes
-      buckets_[buffer_size] = std::vector<WGPUBuffer>{buffer};
-    }
+    pending_buffers_.emplace_back(buffer);
   }
 
-  void OnRefresh(GraphCaptureState /*graph_capture_state*/) override {
-    // no-op - buffers are already in buckets_
+  void OnRefresh(GraphCaptureState graph_capture_state) override {
+    for (auto& buffer : pending_buffers_) {
+      if (graph_capture_state == GraphCaptureState::Default) {
+        auto buffer_size = static_cast<size_t>(wgpuBufferGetSize(buffer));
+        auto it = buckets_.find(buffer_size);
+        if (it != buckets_.end()) {
+          it->second.emplace_back(buffer);
+        } else {
+          // Insert a new bucket for non-standard buffer sizes
+          buckets_[buffer_size] = std::vector<WGPUBuffer>{buffer};
+        }
+      } else {
+        // During Capturing or Replaying, quarantine released buffers so that
+        // the captured bind_groups keep exclusive ownership of their buffers.
+        captured_buffers_.emplace_back(buffer);
+      }
+    }
+    pending_buffers_.clear();
   }
 
   ~GraphCacheManager() {
+    for (auto& buffer : pending_buffers_) {
+      wgpuBufferRelease(buffer);
+    }
     for (auto& pair : buckets_) {
       for (auto& buffer : pair.second) {
         wgpuBufferRelease(buffer);
       }
+    }
+    for (auto& buffer : captured_buffers_) {
+      wgpuBufferRelease(buffer);
     }
   }
 
@@ -333,6 +348,8 @@ class GraphCacheManager : public IBufferCacheManager {
   }
   std::unordered_map<size_t, size_t> buckets_limit_;
   std::unordered_map<size_t, std::vector<WGPUBuffer>> buckets_;
+  std::vector<WGPUBuffer> pending_buffers_;
+  std::vector<WGPUBuffer> captured_buffers_;
   std::vector<size_t> buckets_keys_;
 };
 

--- a/onnxruntime/core/providers/webgpu/generator/constant_of_shape.cc
+++ b/onnxruntime/core/providers/webgpu/generator/constant_of_shape.cc
@@ -1,0 +1,110 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/webgpu/generator/constant_of_shape.h"
+#include "core/providers/webgpu/shader_helper.h"
+
+namespace onnxruntime {
+namespace webgpu {
+
+Status ConstantOfShapeProgram::GenerateShaderCode(ShaderHelper& sh) const {
+  const auto& output = sh.AddOutput("output", ShaderUsage::UseUniform | ShaderUsage::UseValueTypeAlias);
+
+  sh.MainFunctionBody() << sh.GuardAgainstOutOfBoundsWorkgroupSizes("uniforms.output_size")
+                        << "  " << output.SetByOffset("global_idx", "bitcast<output_value_t>(uniforms.value)");
+
+  return Status::OK();
+}
+
+Status ConstantOfShape::ComputeInternal(ComputeContext& context) const {
+  Tensor* output_tensor = nullptr;
+  ORT_RETURN_IF_ERROR(PrepareCompute(&context, &output_tensor));
+
+  const auto output_size = output_tensor->Shape().Size();
+  if (output_size == 0) {
+    return Status::OK();
+  }
+
+  uint32_t value_u32 = 0;
+  const void* value_ptr = GetValuePtr();
+  if (value_ptr != nullptr) {
+    std::memcpy(&value_u32, value_ptr, std::min(sizeof(uint32_t), static_cast<size_t>(output_tensor->DataType()->Size())));
+  }
+
+  ConstantOfShapeProgram program;
+  program.AddOutput({output_tensor, ProgramTensorMetadataDependency::Type})
+      .SetDispatchGroupSize((static_cast<uint32_t>(output_size) + WORKGROUP_SIZE - 1) / WORKGROUP_SIZE)
+      .AddUniformVariables({
+          static_cast<uint32_t>(output_size),
+          value_u32,
+      });
+
+  return context.RunProgram(program);
+}
+
+namespace {
+
+std::vector<MLDataType> GetConstantOfShapeTypeConstraints(bool enable_int64) {
+  auto types = std::vector<MLDataType>{
+      DataTypeImpl::GetTensorType<float>(),
+      DataTypeImpl::GetTensorType<MLFloat16>(),
+      DataTypeImpl::GetTensorType<int32_t>(),
+      DataTypeImpl::GetTensorType<uint8_t>(),
+      DataTypeImpl::GetTensorType<int8_t>(),
+      DataTypeImpl::GetTensorType<bool>(),
+  };
+  if (enable_int64) {
+    types.push_back(DataTypeImpl::GetTensorType<int64_t>());
+  }
+  return types;
+}
+
+KernelCreatePtrFn GetConstantOfShapeKernelCreateFn() {
+  return [](FuncManager&, const OpKernelInfo& info, std::unique_ptr<OpKernel>& out) -> Status {
+    out = std::make_unique<ConstantOfShape>(info);
+    return Status::OK();
+  };
+}
+
+template <int StartVersion, int EndVersion>
+KernelCreateInfo CreateConstantOfShapeVersionedKernelInfo(bool enable_int64) {
+  return {
+      KernelDefBuilder()
+          .SetName("ConstantOfShape")
+          .SetDomain(kOnnxDomain)
+          .SinceVersion(StartVersion, EndVersion)
+          .Provider(kWebGpuExecutionProvider)
+          .TypeConstraint("T1", DataTypeImpl::GetTensorType<int64_t>())
+          .TypeConstraint("T2", GetConstantOfShapeTypeConstraints(enable_int64))
+          .InputMemoryType(OrtMemTypeCPU, 0)
+          .Build(),
+      GetConstantOfShapeKernelCreateFn()};
+}
+
+template <int SinceVersion>
+KernelCreateInfo CreateConstantOfShapeKernelInfo(bool enable_int64) {
+  return {
+      KernelDefBuilder()
+          .SetName("ConstantOfShape")
+          .SetDomain(kOnnxDomain)
+          .SinceVersion(SinceVersion)
+          .Provider(kWebGpuExecutionProvider)
+          .TypeConstraint("T1", DataTypeImpl::GetTensorType<int64_t>())
+          .TypeConstraint("T2", GetConstantOfShapeTypeConstraints(enable_int64))
+          .InputMemoryType(OrtMemTypeCPU, 0)
+          .Build(),
+      GetConstantOfShapeKernelCreateFn()};
+}
+
+}  // namespace
+
+void RegisterConstantOfShapeKernels(KernelRegistry& kernel_registry, bool enable_int64) {
+  ORT_THROW_IF_ERROR(kernel_registry.Register(CreateConstantOfShapeVersionedKernelInfo<9, 19>(enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry.Register(CreateConstantOfShapeVersionedKernelInfo<20, 20>(enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry.Register(CreateConstantOfShapeVersionedKernelInfo<21, 22>(enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry.Register(CreateConstantOfShapeVersionedKernelInfo<23, 23>(enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry.Register(CreateConstantOfShapeKernelInfo<24>(enable_int64)));
+}
+
+}  // namespace webgpu
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/webgpu/generator/constant_of_shape.h
+++ b/onnxruntime/core/providers/webgpu/generator/constant_of_shape.h
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/framework/kernel_registry.h"
+#include "core/providers/webgpu/program.h"
+#include "core/providers/webgpu/webgpu_kernel.h"
+#include "core/providers/cpu/generator/constant_of_shape_base.h"
+
+namespace onnxruntime {
+namespace webgpu {
+
+class ConstantOfShapeProgram final : public Program<ConstantOfShapeProgram> {
+ public:
+  ConstantOfShapeProgram() : Program{"ConstantOfShape"} {}
+
+  Status GenerateShaderCode(ShaderHelper& sh) const override;
+
+  WEBGPU_PROGRAM_DEFINE_UNIFORM_VARIABLES({"output_size", ProgramUniformVariableDataType::Uint32},
+                                          {"value", ProgramUniformVariableDataType::Uint32});
+};
+
+class ConstantOfShape final : public WebGpuKernel, public ConstantOfShapeBase<> {
+ public:
+  explicit ConstantOfShape(const OpKernelInfo& info) : WebGpuKernel(info), ConstantOfShapeBase<>(info) {}
+
+  Status ComputeInternal(ComputeContext& context) const override;
+};
+
+void RegisterConstantOfShapeKernels(KernelRegistry& kernel_registry, bool enable_int64);
+
+}  // namespace webgpu
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/webgpu/math/binary_elementwise_ops.cc
+++ b/onnxruntime/core/providers/webgpu/math/binary_elementwise_ops.cc
@@ -21,6 +21,62 @@ Status BinaryElementwiseProgram::GenerateShaderCode(ShaderHelper& shader) const 
 
   shader.MainFunctionBody() << shader.GuardAgainstOutOfBoundsWorkgroupSizes("uniforms.vec_size");
 
+  // Int64 path: inputs are scalar (component=1, stored as vec2<u32>, read as i32 low-word).
+  // Each global_idx still produces one packed output word covering 4 logical elements, so we
+  // read 4 scalar inputs and pack them into vec4<input_*_value_t>.
+  if (is_int64_) {
+    if (is_lhs_scalar_ || is_rhs_scalar_ || !is_broadcast_) {
+      if (is_lhs_scalar_) {
+        shader.MainFunctionBody() << "let a_s = " << a.GetByOffset("0") << ";\n"
+                                  << "let a = vec4<input_a_value_t>(a_s, a_s, a_s, a_s);\n";
+      } else {
+        shader.MainFunctionBody() << "let a = vec4<input_a_value_t>("
+                                  << a.GetByOffset("global_idx * 4u") << ", "
+                                  << a.GetByOffset("global_idx * 4u + 1u") << ", "
+                                  << a.GetByOffset("global_idx * 4u + 2u") << ", "
+                                  << a.GetByOffset("global_idx * 4u + 3u") << ");\n";
+      }
+      if (is_rhs_scalar_) {
+        shader.MainFunctionBody() << "let b_s = " << b.GetByOffset("0") << ";\n"
+                                  << "let b = vec4<input_b_value_t>(b_s, b_s, b_s, b_s);\n";
+      } else {
+        shader.MainFunctionBody() << "let b = vec4<input_b_value_t>("
+                                  << b.GetByOffset("global_idx * 4u") << ", "
+                                  << b.GetByOffset("global_idx * 4u + 1u") << ", "
+                                  << b.GetByOffset("global_idx * 4u + 2u") << ", "
+                                  << b.GetByOffset("global_idx * 4u + 3u") << ");\n";
+      }
+    } else {
+      const auto& c_indices = shader.AddIndices("bcast_indices");
+      const auto& a_indices = shader.AddIndices("a_indices");
+      const auto& b_indices = shader.AddIndices("b_indices");
+      shader.MainFunctionBody() << "var outputIndices = " << c_indices.OffsetToIndices("global_idx * 4") << ";\n"
+                                << "let offset_a0 = " << a_indices.BroadcastedIndicesToOffset("outputIndices", c_indices) << ";\n"
+                                << "let offset_b0 = " << b_indices.BroadcastedIndicesToOffset("outputIndices", c_indices) << ";\n"
+                                << "outputIndices = " << c_indices.OffsetToIndices("global_idx * 4 + 1") << ";\n"
+                                << "let offset_a1 = " << a_indices.BroadcastedIndicesToOffset("outputIndices", c_indices) << ";\n"
+                                << "let offset_b1 = " << b_indices.BroadcastedIndicesToOffset("outputIndices", c_indices) << ";\n"
+                                << "outputIndices = " << c_indices.OffsetToIndices("global_idx * 4 + 2") << ";\n"
+                                << "let offset_a2 = " << a_indices.BroadcastedIndicesToOffset("outputIndices", c_indices) << ";\n"
+                                << "let offset_b2 = " << b_indices.BroadcastedIndicesToOffset("outputIndices", c_indices) << ";\n"
+                                << "outputIndices = " << c_indices.OffsetToIndices("global_idx * 4 + 3") << ";\n"
+                                << "let offset_a3 = " << a_indices.BroadcastedIndicesToOffset("outputIndices", c_indices) << ";\n"
+                                << "let offset_b3 = " << b_indices.BroadcastedIndicesToOffset("outputIndices", c_indices) << ";\n"
+                                << "let a = vec4<input_a_value_t>("
+                                << a.GetByOffset("offset_a0") << ", "
+                                << a.GetByOffset("offset_a1") << ", "
+                                << a.GetByOffset("offset_a2") << ", "
+                                << a.GetByOffset("offset_a3") << ");\n"
+                                << "let b = vec4<input_b_value_t>("
+                                << b.GetByOffset("offset_b0") << ", "
+                                << b.GetByOffset("offset_b1") << ", "
+                                << b.GetByOffset("offset_b2") << ", "
+                                << b.GetByOffset("offset_b3") << ");\n";
+    }
+    shader.MainFunctionBody() << c.SetByOffset("global_idx", expression_);
+    return Status::OK();
+  }
+
   // check whether can use element-wise mode.
   // If either A or B is scalar, or A and B have the same shape, element-wise mode can be used.
   // In element-wise mode, no indices calculation is needed.
@@ -143,12 +199,23 @@ Status BinaryElementwise::ComputeInternal(ComputeContext& context) const {
   bool is_lhs_bool = lhs_tensor->GetElementType() == ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL;
   bool is_rhs_bool = rhs_tensor->GetElementType() == ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL;
 
-  bool vectorize = is_lhs_scalar || is_rhs_scalar || !is_broadcast;
+  // int64 inputs have no vec4 storage on WebGPU (stored as vec2<u32> per element). We force a
+  // dedicated scalar (component=1) input path. The output of comparison ops (Equal, etc.) is
+  // still u32-packed bool with 4 results per global_idx, so vec_size below stays unchanged.
+  // We only enable this path when BOTH inputs are int64; broadcasting an int64 vs another type
+  // shouldn't happen for the ops we currently expose here.
+  bool is_lhs_int64 = lhs_tensor->GetElementType() == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64;
+  bool is_rhs_int64 = rhs_tensor->GetElementType() == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64;
+  bool is_int64 = is_lhs_int64 && is_rhs_int64;
+
+  // Int64 path forces non-vectorized inputs (component=1). Output of comparison ops stays
+  // packed-bool (component=4), so vec_size below is still (size+3)/4 to drive the dispatch.
+  bool vectorize = !is_int64 && (is_lhs_scalar || is_rhs_scalar || !is_broadcast);
   bool a_last_dim_divisible_by_4 = false;
   bool b_last_dim_divisible_by_4 = false;
   bool shared_dimension_divisible_by_4 = false;
   size_t num_shared_dimension = 0;
-  if (!vectorize) {
+  if (!vectorize && !is_int64) {
     // check whether vectorize can be enabled
     a_last_dim_divisible_by_4 = lhs_shape.NumDimensions() > 0 && lhs_shape[lhs_shape.NumDimensions() - 1] % 4 == 0;
     b_last_dim_divisible_by_4 = rhs_shape.NumDimensions() > 0 && rhs_shape[rhs_shape.NumDimensions() - 1] % 4 == 0;
@@ -188,7 +255,8 @@ Status BinaryElementwise::ComputeInternal(ComputeContext& context) const {
                                    is_rhs_scalar,
                                    shared_dimension_divisible_by_4 || a_last_dim_divisible_by_4,
                                    shared_dimension_divisible_by_4 || b_last_dim_divisible_by_4,
-                                   vectorize};
+                                   vectorize,
+                                   is_int64};
   program
       .SetDispatchGroupSize((vec_size + WORKGROUP_SIZE - 1) / WORKGROUP_SIZE)
       .AddUniformVariables({
@@ -196,7 +264,24 @@ Status BinaryElementwise::ComputeInternal(ComputeContext& context) const {
       })
       .AddOutput({output_tensor, ProgramTensorMetadataDependency::Type, {vec_size}, 4});
 
-  if (is_lhs_scalar || is_rhs_scalar || !is_broadcast) {
+  if (is_int64) {
+    // int64 inputs are stored as vec2<u32> per element on WebGPU and have no vec4 packing.
+    // Inputs use component=1; the shader reads 4 scalars per global_idx and packs them into
+    // vec4<input_*_value_t> to keep the existing comparison expressions working unchanged.
+    const uint32_t lhs_buf_size = onnxruntime::narrow<uint32_t>(lhs_shape.Size());
+    const uint32_t rhs_buf_size = onnxruntime::narrow<uint32_t>(rhs_shape.Size());
+    program.AddInputs({{lhs_tensor, ProgramTensorMetadataDependency::Type, {lhs_buf_size}, 1},
+                       {rhs_tensor, ProgramTensorMetadataDependency::Type, {rhs_buf_size}, 1}});
+    if (is_broadcast && !is_lhs_scalar && !is_rhs_scalar) {
+      program
+          .AddIndices(output_tensor->Shape())
+          .AddIndices(lhs_shape)
+          .AddIndices(rhs_shape)
+          .CacheHint("I64B");
+    } else {
+      program.CacheHint("I64E" + std::to_string(is_lhs_scalar) + std::to_string(is_rhs_scalar));
+    }
+  } else if (is_lhs_scalar || is_rhs_scalar || !is_broadcast) {
     // Mode Element-wise
     // cache hint: "E{is_a_scalar}{is_b_scalar}"
     program
@@ -356,10 +441,10 @@ WEBGPU_BINARY_VERSIONED_KERNEL_2(Pow, 13, 14, Pow, WebGpuSupportedNumberTypes(),
 WEBGPU_BINARY_KERNEL_2(Pow, 15, Pow, WebGpuSupportedNumberTypes(), WebGpuSupportedNumberTypes())
 
 WEBGPU_BINARY_IMPL(Equal, "vec4<u32>(vec4<input_a_element_t>(a) == vec4<input_b_element_t>(b))")
-WEBGPU_BINARY_VERSIONED_KERNEL(Equal, 7, 10, Equal, WebGpuSupportedNumberTypes())
-WEBGPU_BINARY_VERSIONED_KERNEL(Equal, 11, 12, Equal, WebGpuSupportedNumberTypes())
-WEBGPU_BINARY_VERSIONED_KERNEL(Equal, 13, 18, Equal, WebGpuSupportedNumberTypes())
-WEBGPU_BINARY_KERNEL(Equal, 19, Equal, WebGpuSupportedNumberTypes())
+WEBGPU_BINARY_VERSIONED_KERNEL(Equal, 7, 10, Equal, GetOpTypeConstraints(true, false))
+WEBGPU_BINARY_VERSIONED_KERNEL(Equal, 11, 12, Equal, GetOpTypeConstraints(true, false))
+WEBGPU_BINARY_VERSIONED_KERNEL(Equal, 13, 18, Equal, GetOpTypeConstraints(true, false))
+WEBGPU_BINARY_KERNEL(Equal, 19, Equal, GetOpTypeConstraints(true, false))
 
 WEBGPU_BINARY_IMPL(Greater, "vec4<u32>(vec4<input_a_element_t>(a) > vec4<input_b_element_t>(b))")
 WEBGPU_BINARY_VERSIONED_KERNEL(Greater, 7, 8, Greater, WebGpuSupportedNumberTypes())

--- a/onnxruntime/core/providers/webgpu/math/binary_elementwise_ops.h
+++ b/onnxruntime/core/providers/webgpu/math/binary_elementwise_ops.h
@@ -20,15 +20,17 @@ class BinaryElementwiseProgram final : public Program<BinaryElementwiseProgram> 
                            const bool is_rhs_scalar,
                            const bool is_lhs_use_4_components,
                            const bool is_rhs_use_4_components,
-                           const bool vectorize) : Program{kernel_name},
-                                                   expression_{expression},
-                                                   additional_impl_{additional_impl},
-                                                   is_broadcast_{is_broadcast},
-                                                   is_lhs_scalar_{is_lhs_scalar},
-                                                   is_rhs_scalar_{is_rhs_scalar},
-                                                   is_lhs_use_4_components_{is_lhs_use_4_components},
-                                                   is_rhs_use_4_components_{is_rhs_use_4_components},
-                                                   vectorize_{vectorize} {}
+                           const bool vectorize,
+                           const bool is_int64 = false) : Program{kernel_name},
+                                                          expression_{expression},
+                                                          additional_impl_{additional_impl},
+                                                          is_broadcast_{is_broadcast},
+                                                          is_lhs_scalar_{is_lhs_scalar},
+                                                          is_rhs_scalar_{is_rhs_scalar},
+                                                          is_lhs_use_4_components_{is_lhs_use_4_components},
+                                                          is_rhs_use_4_components_{is_rhs_use_4_components},
+                                                          vectorize_{vectorize},
+                                                          is_int64_{is_int64} {}
 
   Status GenerateShaderCode(ShaderHelper& sh) const override;
 
@@ -43,6 +45,7 @@ class BinaryElementwiseProgram final : public Program<BinaryElementwiseProgram> 
   bool is_lhs_use_4_components_;
   bool is_rhs_use_4_components_;
   bool vectorize_;
+  bool is_int64_;
 };
 
 class BinaryElementwise : public WebGpuKernel {

--- a/onnxruntime/core/providers/webgpu/tensor/where.cc
+++ b/onnxruntime/core/providers/webgpu/tensor/where.cc
@@ -65,6 +65,37 @@ Status WhereProgram::GenerateShaderCode(ShaderHelper& shader) const {
     return absl::StrCat("select(", b, ", ", a, ", ", c, ")");
   };
 
+  // Scalar path: one logical element per global_idx. Used when output type has no vec4 storage
+  // (e.g. int64 stored as vec2<u32>). The condition tensor is still bool-packed (8 bools per u32),
+  // so we extract one bool from the right byte of the right u32 word.
+  if (is_scalar_) {
+    if (!is_broadcast_) {
+      shader.MainFunctionBody()
+          << "let c_word = c_data[global_idx / 4u];\n"
+          << "let c_bit = bool(c_word & (0xffu << ((global_idx % 4u) * 8u)));\n"
+          << "let a_val = " << a_input.GetByOffset("global_idx") << ";\n"
+          << "let b_val = " << b_input.GetByOffset("global_idx") << ";\n"
+          << output.SetByOffset("global_idx", expression("a_val", "b_val", "c_bit")) << "\n";
+    } else {
+      const auto& c_indices = shader.AddIndices("c_indices");
+      const auto& a_indices = shader.AddIndices("a_indices");
+      const auto& b_indices = shader.AddIndices("b_indices");
+      const auto& output_indices = shader.AddIndices("output_indices");
+
+      shader.MainFunctionBody()
+          << "let out_idx = " << output_indices.OffsetToIndices("global_idx") << ";\n"
+          << "let off_a = " << a_indices.BroadcastedIndicesToOffset("out_idx", output_indices) << ";\n"
+          << "let off_b = " << b_indices.BroadcastedIndicesToOffset("out_idx", output_indices) << ";\n"
+          << "let off_c = " << c_indices.BroadcastedIndicesToOffset("out_idx", output_indices) << ";\n"
+          << "let c_word = c_data[off_c / 4u];\n"
+          << "let c_bit = bool(c_word & (0xffu << ((off_c % 4u) * 8u)));\n"
+          << "let a_val = " << a_input.GetByOffset("off_a") << ";\n"
+          << "let b_val = " << b_input.GetByOffset("off_b") << ";\n"
+          << output.SetByOffset("global_idx", expression("a_val", "b_val", "c_bit")) << "\n";
+    }
+    return Status::OK();
+  }
+
   if (!is_broadcast_) {
     shader.MainFunctionBody() << output.SetByOffset(
         "global_idx",
@@ -130,18 +161,29 @@ Status Where::ComputeInternal(ComputeContext& context) const {
     return Status::OK();
   }
 
-  constexpr int component = 4;
-  uint32_t vec_size = onnxruntime::narrow<uint32_t>((output_shape.Size() + 3) / component);
   const auto is_broadcast = !(x_shape == y_shape &&
                               y_shape == cond_shape);
-  WhereProgram program{is_broadcast};
+  // int64 has no vec4 storage on WebGPU (stored as vec2<u32> per element), so
+  // x / y / output run in scalar (component=1) mode. The condition tensor is
+  // still bool, packed 4-per-u32, so it keeps component=4 packing.
+  const bool is_int64_output = output_tensor->GetElementType() == ONNX_NAMESPACE::TensorProto_DataType_INT64;
+  const int component = is_int64_output ? 1 : 4;
+  const uint32_t output_size = onnxruntime::narrow<uint32_t>(output_shape.Size());
+  const uint32_t vec_size = is_int64_output ? output_size : (output_size + 3) / 4;
+  const uint32_t x_buf_size = is_int64_output ? onnxruntime::narrow<uint32_t>(x_shape.Size())
+                                              : onnxruntime::narrow<uint32_t>((x_shape.Size() + 3) / 4);
+  const uint32_t y_buf_size = is_int64_output ? onnxruntime::narrow<uint32_t>(y_shape.Size())
+                                              : onnxruntime::narrow<uint32_t>((y_shape.Size() + 3) / 4);
+  const uint32_t c_buf_size = onnxruntime::narrow<uint32_t>((cond_shape.Size() + 3) / 4);
+
+  WhereProgram program{is_broadcast, is_int64_output};
   program
-      .CacheHint(is_broadcast)
+      .CacheHint(is_broadcast, is_int64_output)
       .SetDispatchGroupSize((vec_size + WORKGROUP_SIZE - 1) / WORKGROUP_SIZE)
-      .AddInputs({{cond_tensor, ProgramTensorMetadataDependency::Type, {(cond_shape.Size() + 3) / 4}, 4},
-                  {x_tensor, ProgramTensorMetadataDependency::Type, {(x_shape.Size() + 3) / 4}, 4},
-                  {y_tensor, ProgramTensorMetadataDependency::Type, {(y_shape.Size() + 3) / 4}, 4}})
-      .AddOutput({output_tensor, ProgramTensorMetadataDependency::Type, {vec_size}, 4})
+      .AddInputs({{cond_tensor, ProgramTensorMetadataDependency::Type, {c_buf_size}, 4},
+                  {x_tensor, ProgramTensorMetadataDependency::Type, {x_buf_size}, component},
+                  {y_tensor, ProgramTensorMetadataDependency::Type, {y_buf_size}, component}})
+      .AddOutput({output_tensor, ProgramTensorMetadataDependency::Type, {vec_size}, component})
       .AddUniformVariables({
           {static_cast<uint32_t>(vec_size)},
       });
@@ -160,11 +202,15 @@ const std::vector<MLDataType>& WhereOpTypeConstraints() {
   // currently support boolean, integer and float types that explicitly allowed in WGSL:
   // https://gpuweb.github.io/gpuweb/wgsl/#plain-types-section
   //
+  // int64 is supported via a scalar (component=1) code path: each element is
+  // stored as vec2<u32> on the GPU but read/written as i32 at the value layer
+  // (low 32 bits with sign extension on write). See GenerateShaderCode.
   static std::vector<MLDataType> types{
       DataTypeImpl::GetTensorType<MLFloat16>(),
       DataTypeImpl::GetTensorType<float>(),
       DataTypeImpl::GetTensorType<int32_t>(),
       DataTypeImpl::GetTensorType<uint32_t>(),
+      DataTypeImpl::GetTensorType<int64_t>(),
       DataTypeImpl::GetTensorType<bool>()};
   return types;
 }

--- a/onnxruntime/core/providers/webgpu/tensor/where.h
+++ b/onnxruntime/core/providers/webgpu/tensor/where.h
@@ -13,7 +13,8 @@ namespace webgpu {
 
 class WhereProgram final : public Program<WhereProgram> {
  public:
-  WhereProgram(bool is_broadcast) : Program{"Where"}, is_broadcast_{is_broadcast} {
+  WhereProgram(bool is_broadcast, bool is_scalar)
+      : Program{"Where"}, is_broadcast_{is_broadcast}, is_scalar_{is_scalar} {
   }
 
   Status GenerateShaderCode(ShaderHelper& sh) const override;
@@ -21,6 +22,7 @@ class WhereProgram final : public Program<WhereProgram> {
 
  private:
   const bool is_broadcast_;
+  const bool is_scalar_;
 };
 
 class Where final : public WebGpuKernel {

--- a/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
@@ -32,6 +32,7 @@
 #include "core/providers/webgpu/tensor/cast.h"
 #include "core/providers/webgpu/tensor/expand.h"
 #include "core/providers/webgpu/tensor/grid_sample.h"
+#include "core/providers/webgpu/generator/constant_of_shape.h"
 #include "core/providers/webgpu/generator/range.h"
 #include "core/providers/webgpu/tensor/unsqueeze.h"
 
@@ -478,6 +479,9 @@ std::unique_ptr<KernelRegistry> RegisterKernels(bool enable_graph_capture, bool 
 
   // Register Range kernels with conditional int64 support
   RegisterRangeKernels(*kernel_registry, enable_int64);
+
+  // Register ConstantOfShape kernels with conditional int64 support
+  RegisterConstantOfShapeKernels(*kernel_registry, enable_int64);
 
   // Register Unsqueeze kernels with conditional int64 support
   ORT_THROW_IF_ERROR(kernel_registry->Register(CreateUnsqueezeVersionedKernelInfo<1, 10>(enable_int64)));


### PR DESCRIPTION
> **Note: This PR is intentionally kept as draft and will NOT be merged.**
> The `GqaMaskReformattingToGraphCapture` transformer is a temporary workaround for Gemma4 models that were built without `enable_webgpu_graph=true` (the genai builder does not yet have a Gemma4 dispatch entry). Once the genai team adds Gemma4 builder support and official models are converted with graph capture enabled, this ORT-side transformer becomes unnecessary. Until then, this branch serves as a local development tool for WebGPU graph capture on Gemma4.

---

Graph capture (GC) requires every kernel and buffer interaction in the captured replay to be deterministic and self-contained. Several existing WebGPU paths violated that — they relied on CPU-side branching or opset-open registration. This change makes the EP GC-clean for Gemma-class decoders without regressing the non-GC path.

Five coordinated changes, each gated so non-GC sessions are unaffected:

1. ConstantOfShape kernel + opset-by-opset registration New onnxruntime/core/providers/webgpu/generator/constant_of_shape.{cc,h}. Uses bitcast<output_value_t>(uniforms.value) so a single shader covers all dtypes. Shape input marked OrtMemTypeCPU. Registered explicitly at versions 9, 20, 21, 23, 24 because KernelRegistry::VerifyVersion treats open-ended SinceVersion(N) as exact-match against node.SinceVersion().

2. GqaMaskReformattingToGraphCapture transformer (gated) — **shrunk from 433 to 231 lines**: simplified matching logic (inlined chain matching with early-continue, replaced TryResolveConstantInt with compact IsConstantInt, merged initializer helpers). Rewrites the int64 GQA-mask construction subgraph into a GC-replayable form (Cast int64 to int32 + ReduceSum/Sub/ReduceMax). Registered in graph_transformer_utils.cc only when ep.webgpuexecutionprovider.enableGraphCapture == 1, so default sessions see no transform.

3. Where int64 scalar path tensor/where.{cc,h}: added is_scalar_ shader variant that reads the condition word and extracts the selected bit, then reads scalar a/b. Drives component=1 output for int64 (stored as vec2<u32>). Type constraints widened to include int64_t. CacheHint disambiguates broadcast x int64 variants.

4. Equal / binary-elementwise int64 path + widened type constraints math/binary_elementwise_ops.{cc,h}: int64 shader path packs four scalar reads per global_idx into a vec4 to keep output component=4 while inputs are component=1 (int64 cannot vector-load). Equal registered for int64 across versions 7-10, 11-12, 13-18, 19+.

5. PrepareIndirectDispatch helper + widened use_indirect_dispatch contrib_ops/webgpu/bert/flash_attention.{cc,h}: new PrepareIndirectDispatchProgram single-thread shader writes [tile_count, num_heads, 1] from seqlen_k[0]+1. use_indirect_dispatch is now true when GC is on OR the GPU-resident seqlens_k sentinel is 0, so the dispatch shape no longer leaks through the CPU. Added an explicit PrepareIndirectDispatch call on the kv_empty path because CopyKVCache is skipped there under GC.

**Note:** GraphCacheManager buffer quarantine (previously listed as change #5) was verified as NOT load-bearing — graph capture produces correct output with PR #27453's immediate buffer reuse. The quarantine has been reverted.

Verified on Gemma4 E2B Q4_K_M (opset 24, com.microsoft 1, 20 KV-shared layers): GC=ON produces byte-identical output to GC=OFF and improves single-batch decode throughput substantially. Non-GC sessions show no behavioral change.