### PR TITLE
Disable OrtEp::ort_version_supported sanity check to work around EPs that don't set it correctly.

### DIFF
--- a/onnxruntime/core/session/plugin_ep/ep_plugin_provider_interfaces.cc
+++ b/onnxruntime/core/session/plugin_ep/ep_plugin_provider_interfaces.cc
@@ -74,12 +74,15 @@ PluginExecutionProviderFactory::CreateProvider(const OrtSessionOptions& session_
 
 // Do some basic checks on `ort_ep` to detect obvious issues early on.
 static Status SanityCheckOrtEp(const OrtEp& ort_ep) {
-  // Plugin EPs were first introduced in ORT 1.22, so we expect at least this API version.
-  constexpr auto kMinAllowedOrtVersionSupported = 22;
+  // NOTE: We disable the API version check as a workaround for EPs that don't set OrtEp::ort_version_supported
+  // correctly. This change should NOT be merged back into main.
 
-  ORT_RETURN_IF_NOT(ort_ep.ort_version_supported >= kMinAllowedOrtVersionSupported,
-                    "OrtEp has invalid ort_version_supported=", ort_ep.ort_version_supported,
-                    " (expected at least ", kMinAllowedOrtVersionSupported, ").");
+  // Plugin EPs were first introduced in ORT 1.22, so we expect at least this API version.
+  // constexpr auto kMinAllowedOrtVersionSupported = 22;
+
+  // ORT_RETURN_IF_NOT(ort_ep.ort_version_supported >= kMinAllowedOrtVersionSupported,
+  //                   "OrtEp has invalid ort_version_supported=", ort_ep.ort_version_supported,
+  //                   " (expected at least ", kMinAllowedOrtVersionSupported, ").");
 
   ORT_RETURN_IF_NOT(ort_ep.GetName != nullptr, "OrtEp has null GetName function pointer.");
 

--- a/onnxruntime/test/framework/ep_plugin_provider_test.cc
+++ b/onnxruntime/test/framework/ep_plugin_provider_test.cc
@@ -298,7 +298,9 @@ TEST(PluginExecutionProviderFactoryTest, CreatePluginExecutionProviderFailsWhenG
   EXPECT_EQ(context.ep_factory.GetReleaseEpCount(), 1);
 }
 
-TEST(PluginExecutionProviderFactoryTest, CreatePluginExecutionProviderFailsForTooLowVersion) {
+// NOTE: We disable the API version check as a workaround for EPs that don't set OrtEp::ort_version_supported
+// correctly. Accordingly, we also disable this test. This change should NOT be merged back into main.
+TEST(PluginExecutionProviderFactoryTest, DISABLED_CreatePluginExecutionProviderFailsForTooLowVersion) {
   test_plugin_ep::CreateProviderTestContext context;
 
   auto ort_ep = std::make_unique<test_plugin_ep::TestOrtEp>();


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Disable OrtEp::ort_version_supported sanity check to work around EPs that don't set it correctly.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

**This is a workaround.**

EPs are expected to correctly set `OrtEp::ort_version_supported` to the version of ORT they support. An ORT-side sanity check was added recently (see https://github.com/microsoft/onnxruntime/pull/28216 and https://github.com/microsoft/onnxruntime/pull/28601). An existing plugin EP doesn't set it correctly (https://github.com/onnxruntime/onnxruntime-qnn/issues/492) and due to release timelines, there may be a version of the plugin EP that fails to load with ORT 1.27 without this workaround.