### PR TITLE
Fix STFT complex input frame offsets

### DIFF
--- a/onnxruntime/core/providers/cpu/signal/dft.cc
+++ b/onnxruntime/core/providers/cpu/signal/dft.cc
@@ -7,6 +7,7 @@
 #include <complex>
 #include <functional>
 #include <limits>
+#include <type_traits>
 #include <vector>
 #include <core/common/safeint.h>
 
@@ -532,6 +533,7 @@ static Status short_time_fourier_transform(OpKernelContext* ctx, bool is_oneside
   // Get signal
   const auto* signal = ctx->Input<Tensor>(0);
   const auto frame_step = signal::get_scalar_value_from_tensor<int64_t>(ctx->Input<Tensor>(1));
+  ORT_RETURN_IF_NOT(frame_step > 0, "frame_step must be greater than zero.");
   const auto* window = ctx->Input<Tensor>(2);
   const auto* frame_length_tensor = ctx->Input<Tensor>(3);
 
@@ -592,12 +594,16 @@ static Status short_time_fourier_transform(OpKernelContext* ctx, bool is_oneside
   Tensor b_fft, chirp;
   InlinedVector<std::complex<T>> V;
   InlinedVector<std::complex<T>> temp_output;
+  const int64_t signal_frame_step_components = std::is_same<T, U>::value ? signal_components : 1;
 
   // Run each dft of each batch as if it was a real-valued batch size 1 dft operation
   for (int64_t batch_idx = 0; batch_idx < batch_size; batch_idx++) {
     for (int64_t i = 0; i < n_dfts; i++) {
+      const auto frame_start = i * frame_step;
+      ORT_RETURN_IF_NOT(frame_start <= signal_size - window_size, "STFT input frame is out of bounds.");
       auto input_frame_begin =
-          signal_data + (batch_idx * signal_size * signal_components) + (i * frame_step * signal_components);
+          signal_data + (batch_idx * signal_size * signal_frame_step_components) +
+          (frame_start * signal_frame_step_components);
 
       auto output_frame_begin = Y_data + (batch_idx * n_dfts * dft_output_size * output_components) +
                                 (i * dft_output_size * output_components);

--- a/onnxruntime/core/providers/cpu/signal/dft.cc
+++ b/onnxruntime/core/providers/cpu/signal/dft.cc
@@ -7,7 +7,6 @@
 #include <complex>
 #include <functional>
 #include <limits>
-#include <type_traits>
 #include <vector>
 #include <core/common/safeint.h>
 
@@ -525,9 +524,9 @@ template <typename T, typename U>
 static Status short_time_fourier_transform(OpKernelContext* ctx, bool is_onesided, bool /*inverse*/) {
   // Attr("onesided"): default = 1
   // Input(0, "signal") type = T1
-  // Input(1, "frame_length") type = T2
+  // Input(1, "frame_step") type = T2
   // Input(2, "window") type = T1, optional
-  // Input(3, "frame_step") type = T2
+  // Input(3, "frame_length") type = T2
   // Output(0, "output") type = T1
 
   // Get signal
@@ -594,16 +593,15 @@ static Status short_time_fourier_transform(OpKernelContext* ctx, bool is_oneside
   Tensor b_fft, chirp;
   InlinedVector<std::complex<T>> V;
   InlinedVector<std::complex<T>> temp_output;
-  const int64_t signal_frame_step_components = std::is_same<T, U>::value ? signal_components : 1;
 
   // Run each dft of each batch as if it was a real-valued batch size 1 dft operation
   for (int64_t batch_idx = 0; batch_idx < batch_size; batch_idx++) {
     for (int64_t i = 0; i < n_dfts; i++) {
       const auto frame_start = i * frame_step;
+      // Defensive check before creating a non-owning tensor view. n_dfts derivation should keep this in bounds.
       ORT_RETURN_IF_NOT(frame_start <= signal_size - window_size, "STFT input frame is out of bounds.");
-      auto input_frame_begin =
-          signal_data + (batch_idx * signal_size * signal_frame_step_components) +
-          (frame_start * signal_frame_step_components);
+      // signal_data is U*, so one increment advances one input sample, including both lanes for complex input.
+      auto input_frame_begin = signal_data + (batch_idx * signal_size) + frame_start;
 
       auto output_frame_begin = Y_data + (batch_idx * n_dfts * dft_output_size * output_components) +
                                 (i * dft_output_size * output_components);
@@ -625,9 +623,9 @@ static Status short_time_fourier_transform(OpKernelContext* ctx, bool is_oneside
 Status STFT::Compute(OpKernelContext* ctx) const {
   // Attr("onesided"): default = 1
   // Input(0, "signal") type = T1
-  // Input(1, "frame_length") type = T2
+  // Input(1, "frame_step") type = T2
   // Input(2, "window") type = T1, optional
-  // Input(3, "frame_step") type = T2
+  // Input(3, "frame_length") type = T2
   // Output(0, "output") type = T1
 
   // Get signal shape

--- a/onnxruntime/test/providers/cpu/signal/signal_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/signal/signal_ops_test.cc
@@ -256,7 +256,8 @@ TEST(SignalOpsTest, STFTFrameStepMustBePositive) {
   TestSTFTInvalidFrameStep(-1);
 }
 
-TEST(SignalOpsTest, STFTFloatComplexInputBatched) {
+template <typename T>
+static void TestSTFTComplexInputBatched() {
   OpTester test("STFT", kMinOpsetVersion);
   test.AddAttribute<int64_t>("onesided", static_cast<int64_t>(false));
 
@@ -269,32 +270,41 @@ TEST(SignalOpsTest, STFTFloatComplexInputBatched) {
   constexpr int64_t dft_output_size = frame_length;
   constexpr int64_t output_components = 2;
 
-  vector<float> signal(batch_size * signal_size * signal_components, 0.f);
+  vector<T> signal(batch_size * signal_size * signal_components, static_cast<T>(0));
   for (int64_t batch_idx = 0; batch_idx < batch_size; ++batch_idx) {
-    const float signal_value = batch_idx == 0 ? 1.f : 99.f;
+    const T signal_value = batch_idx == 0 ? static_cast<T>(1) : static_cast<T>(99);
     for (int64_t sample_idx = 0; sample_idx < signal_size; ++sample_idx) {
       signal[(batch_idx * signal_size + sample_idx) * signal_components] = signal_value;
     }
   }
 
-  test.AddInput<float>("signal", {batch_size, signal_size, signal_components}, signal);
+  test.AddInput<T>("signal", {batch_size, signal_size, signal_components}, signal);
   test.AddInput<int64_t>("frame_step", {}, {frame_step});
-  test.AddOptionalInputEdge<float>();
+  test.AddOptionalInputEdge<T>();
   test.AddInput<int64_t>("frame_length", {}, {frame_length});
 
   vector<int64_t> output_shape = {batch_size, n_dfts, dft_output_size, output_components};
-  vector<float> expected_output(batch_size * n_dfts * dft_output_size * output_components, 0.f);
+  vector<T> expected_output(batch_size * n_dfts * dft_output_size * output_components, static_cast<T>(0));
   for (int64_t batch_idx = 0; batch_idx < batch_size; ++batch_idx) {
-    const float dc_value = (batch_idx == 0 ? 1.f : 99.f) * frame_length;
+    const T dc_value = (batch_idx == 0 ? static_cast<T>(1) : static_cast<T>(99)) * static_cast<T>(frame_length);
     for (int64_t frame_idx = 0; frame_idx < n_dfts; ++frame_idx) {
       expected_output[((batch_idx * n_dfts + frame_idx) * dft_output_size) * output_components] = dc_value;
     }
   }
 
-  test.AddOutput<float>("output", output_shape, expected_output);
+  test.AddOutput<T>("output", output_shape, expected_output);
   test.SetOutputAbsErr("output", 0.001f);
+  // DML does not consistently match these CPU STFT validation/regression paths in Windows GPU CI.
   test.ConfigExcludeEps({kDmlExecutionProvider});
   test.RunWithConfig();
+}
+
+TEST(SignalOpsTest, STFTFloatComplexInputBatched) {
+  TestSTFTComplexInputBatched<float>();
+}
+
+TEST(SignalOpsTest, STFTDoubleComplexInputBatched) {
+  TestSTFTComplexInputBatched<double>();
 }
 
 TEST(SignalOpsTest, HannWindowFloat) {

--- a/onnxruntime/test/providers/cpu/signal/signal_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/signal/signal_ops_test.cc
@@ -233,6 +233,67 @@ TEST(SignalOpsTest, STFTFloat) {
   test.Run();
 }
 
+static void TestSTFTInvalidFrameStep(int64_t frame_step) {
+  OpTester test("STFT", kMinOpsetVersion);
+
+  vector<float> signal(64, 1);
+  test.AddInput<float>("signal", {1, 64, 1}, signal);
+  test.AddInput<int64_t>("frame_step", {}, {frame_step});
+  vector<float> window(16, 1);
+  test.AddInput<float>("window", {16}, window);
+  test.AddInput<int64_t>("frame_length", {}, {16});
+
+  vector<int64_t> output_shape = {1, 7, 9, 2};
+  vector<float> expected_output(1 * 7 * 9 * 2, 0.f);
+  test.AddOutput<float>("output", output_shape, expected_output);
+  test.Run(OpTester::ExpectResult::kExpectFailure, "frame_step must be greater than zero");
+}
+
+TEST(SignalOpsTest, STFTFrameStepMustBePositive) {
+  TestSTFTInvalidFrameStep(0);
+  TestSTFTInvalidFrameStep(-1);
+}
+
+TEST(SignalOpsTest, STFTFloatComplexInputBatched) {
+  OpTester test("STFT", kMinOpsetVersion);
+  test.AddAttribute<int64_t>("onesided", static_cast<int64_t>(false));
+
+  constexpr int64_t batch_size = 2;
+  constexpr int64_t signal_size = 128;
+  constexpr int64_t signal_components = 2;
+  constexpr int64_t frame_length = 32;
+  constexpr int64_t frame_step = 16;
+  constexpr int64_t n_dfts = 7;
+  constexpr int64_t dft_output_size = frame_length;
+  constexpr int64_t output_components = 2;
+
+  vector<float> signal(batch_size * signal_size * signal_components, 0.f);
+  for (int64_t batch_idx = 0; batch_idx < batch_size; ++batch_idx) {
+    const float signal_value = batch_idx == 0 ? 1.f : 99.f;
+    for (int64_t sample_idx = 0; sample_idx < signal_size; ++sample_idx) {
+      signal[(batch_idx * signal_size + sample_idx) * signal_components] = signal_value;
+    }
+  }
+
+  test.AddInput<float>("signal", {batch_size, signal_size, signal_components}, signal);
+  test.AddInput<int64_t>("frame_step", {}, {frame_step});
+  test.AddOptionalInputEdge<float>();
+  test.AddInput<int64_t>("frame_length", {}, {frame_length});
+
+  vector<int64_t> output_shape = {batch_size, n_dfts, dft_output_size, output_components};
+  vector<float> expected_output(batch_size * n_dfts * dft_output_size * output_components, 0.f);
+  for (int64_t batch_idx = 0; batch_idx < batch_size; ++batch_idx) {
+    const float dc_value = (batch_idx == 0 ? 1.f : 99.f) * frame_length;
+    for (int64_t frame_idx = 0; frame_idx < n_dfts; ++frame_idx) {
+      expected_output[((batch_idx * n_dfts + frame_idx) * dft_output_size) * output_components] = dc_value;
+    }
+  }
+
+  test.AddOutput<float>("output", output_shape, expected_output);
+  test.SetOutputAbsErr("output", 0.001f);
+  test.Run();
+}
+
 TEST(SignalOpsTest, HannWindowFloat) {
   OpTester test("HannWindow", kMinOpsetVersion);
 

--- a/onnxruntime/test/providers/cpu/signal/signal_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/signal/signal_ops_test.cc
@@ -246,7 +246,9 @@ static void TestSTFTInvalidFrameStep(int64_t frame_step) {
   vector<int64_t> output_shape = {1, 7, 9, 2};
   vector<float> expected_output(1 * 7 * 9 * 2, 0.f);
   test.AddOutput<float>("output", output_shape, expected_output);
-  test.Run(OpTester::ExpectResult::kExpectFailure, "frame_step must be greater than zero");
+  test.Config(OpTester::ExpectResult::kExpectFailure, "frame_step must be greater than zero");
+  test.ConfigExcludeEps({kDmlExecutionProvider});
+  test.RunWithConfig();
 }
 
 TEST(SignalOpsTest, STFTFrameStepMustBePositive) {
@@ -291,7 +293,8 @@ TEST(SignalOpsTest, STFTFloatComplexInputBatched) {
 
   test.AddOutput<float>("output", output_shape, expected_output);
   test.SetOutputAbsErr("output", 0.001f);
-  test.Run();
+  test.ConfigExcludeEps({kDmlExecutionProvider});
+  test.RunWithConfig();
 }
 
 TEST(SignalOpsTest, HannWindowFloat) {


### PR DESCRIPTION
### Description
Fix STFT frame pointer arithmetic for complex-valued input so frame starts are computed in input samples, not trailing real/imag components. Since the frame view pointer is `U*`, one pointer increment advances one full real or complex sample.

Also add validation that `frame_step` is positive and keep a defensive bounds check before creating non-owning tensor views.

Review feedback addressed: simplified the frame pointer arithmetic, fixed the swapped STFT input comments, documented the defensive bounds check, and added double-complex regression coverage. The new STFT validation/regression tests exclude `kDmlExecutionProvider` because these CPU STFT validation/regression paths do not consistently match DirectML behavior in Windows GPU CI.

### Motivation and Context
For complex input shaped `[batch_size, signal_length, 2]`, pointer increments already advance by one real/imag pair. Multiplying frame offsets by `signal_components == 2` again can advance past the valid frame start, allowing later frames to read across batches or beyond the input allocation.

### Testing
- `git diff --check -- onnxruntime/core/providers/cpu/signal/dft.cc onnxruntime/test/providers/cpu/signal/signal_ops_test.cc`
- `.\.venv\Scripts\python.exe tools\ci_build\build.py --config RelWithDebInfo --build --parallel --target onnxruntime_provider_test --build_dir build\Windows`
- `.\onnxruntime_provider_test.exe --gtest_filter="SignalOpsTest.STFTFloat:SignalOpsTest.STFTFrameStepMustBePositive:SignalOpsTest.STFTFloatComplexInputBatched:SignalOpsTest.STFTDoubleComplexInputBatched"` from `build\Windows\RelWithDebInfo\RelWithDebInfo`