### PR TITLE
Update protobuf to mitigate CVE-2026-0994

### DIFF
--- a/tools/ci_build/github/linux/docker/scripts/manylinux/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/manylinux/requirements.txt
@@ -4,7 +4,7 @@ mypy
 pytest
 setuptools>=68.2.2
 wheel
-protobuf==6.33.0
+protobuf==6.33.5
 sympy==1.14
 flatbuffers
 neural-compressor>=2.2.1


### PR DESCRIPTION
One more reference to 6.33.0 that was missed.

CVE-2026-0994
Upgrade protobuf from 6.33.0 to 6.33.5 to fix the vulnerability.