### PR TITLE
Add Execution Provider conformance test suite

### DIFF
--- a/onnxruntime/test/framework/execution_provider_conformance_test.cc
+++ b/onnxruntime/test/framework/execution_provider_conformance_test.cc
@@ -65,7 +65,12 @@ std::vector<EpConformanceParam> GetEpConformanceParams() {
 #ifdef USE_DML
   params.push_back({"Dml", [] { return DefaultDmlExecutionProvider(); }});
 #endif
-#ifdef USE_WEBGPU
+  // Mirror the guard used by base_tester.cc / default_providers.cc: in
+  // ORT_USE_EP_API_ADAPTERS builds DefaultWebGpuExecutionProvider() ORT_ENFORCEs
+  // (aborting the whole test run) when the dynamic plugin EP is initialized to a
+  // different EP, rather than cleanly returning nullptr. Only list the built-in
+  // WebGPU EP when it is not routed through the EP API adapters.
+#if defined(USE_WEBGPU) && !defined(ORT_USE_EP_API_ADAPTERS)
   params.push_back({"WebGpu", [] { return DefaultWebGpuExecutionProvider(); }});
 #endif
 #ifdef USE_XNNPACK

--- a/onnxruntime/test/framework/execution_provider_conformance_test.cc
+++ b/onnxruntime/test/framework/execution_provider_conformance_test.cc
@@ -48,6 +48,7 @@ namespace {
 struct EpConformanceParam {
   std::string name;
   std::function<std::unique_ptr<IExecutionProvider>()> factory;
+  bool expects_plugin_ep = false;
 };
 
 std::vector<EpConformanceParam> GetEpConformanceParams() {
@@ -60,7 +61,11 @@ std::vector<EpConformanceParam> GetEpConformanceParams() {
   params.push_back({"Cpu_NoArena", [] { return DefaultCpuExecutionProvider(/*enable_arena*/ false); }});
 
 #ifdef USE_CUDA
+#if defined(ORT_UNIT_TEST_HAS_CUDA_PLUGIN_EP) && defined(ORT_UNIT_TEST_ENABLE_DYNAMIC_PLUGIN_EP_USAGE)
+  params.push_back({"Cuda", [] { return DefaultCudaExecutionProvider(); }, true});
+#else
   params.push_back({"Cuda", [] { return DefaultCudaExecutionProvider(); }});
+#endif
 #endif
 #ifdef USE_DML
   params.push_back({"Dml", [] { return DefaultDmlExecutionProvider(); }});
@@ -270,15 +275,20 @@ TEST_P(EpConformanceTest, GraphCaptureNodeAssignmentPolicyIsValid) {
       << "GetGraphCaptureNodeAssignmentPolicy() returned an unknown policy value.";
 }
 
-// Invariant: a built-in EP is not a plugin wrapper, so GetOrtEp() returns nullptr.
-// Only a PluginExecutionProvider wrapping an OrtEp reports a backing OrtEp, and
-// every EP exercised by this suite is built-in.
-TEST_P(EpConformanceTest, GetOrtEpIsNullForBuiltInEp) {
+// Invariant: a built-in EP returns no backing OrtEp. A PluginExecutionProvider
+// returns the same non-null backing OrtEp across repeated queries.
+TEST_P(EpConformanceTest, GetOrtEpMatchesProviderKind) {
   auto ep = MakeEp();
   if (!ep) GTEST_SKIP() << GetParam().name << " EP not available in this environment.";
 
-  EXPECT_EQ(ep->GetOrtEp(), nullptr)
-      << "A built-in EP must not report a backing OrtEp (that is reserved for plugin EPs).";
+  const OrtEp* ort_ep = ep->GetOrtEp();
+  if (GetParam().expects_plugin_ep) {
+    ASSERT_NE(ort_ep, nullptr) << "A plugin EP must report its backing OrtEp.";
+    EXPECT_EQ(ep->GetOrtEp(), ort_ep) << "A plugin EP must report a stable backing OrtEp.";
+  } else {
+    EXPECT_EQ(ort_ep, nullptr)
+        << "A built-in EP must not report a backing OrtEp (that is reserved for plugin EPs).";
+  }
 }
 
 // Invariant: GetEpContextNodes() reports no nodes on a freshly constructed EP.

--- a/onnxruntime/test/framework/execution_provider_conformance_test.cc
+++ b/onnxruntime/test/framework/execution_provider_conformance_test.cc
@@ -140,9 +140,11 @@ TEST_P(EpConformanceTest, PreferredAllocatorsAreNonNullAndRepeatable) {
       << "CreatePreferredAllocators() must be repeatable (documented as stateless).";
 }
 
-// Invariant: each preferred allocator hands back usable memory. A non-zero
-// allocation yields a non-null pointer that can be freed. For CPU-accessible
-// memory we additionally verify the buffer is host-writable and readable.
+// Invariant: each CPU-accessible preferred allocator hands back usable memory:
+// a non-zero allocation yields a non-null, host-writable and -readable pointer
+// that can be freed. Device allocators are intentionally excluded here -- their
+// raw Alloc/Free lifecycle is backend-specific (see body) -- and are covered by
+// PreferredAllocatorsAreNonNullAndRepeatable instead.
 TEST_P(EpConformanceTest, PreferredAllocatorsAllocateUsableMemory) {
   auto ep = MakeEp();
   if (!ep) GTEST_SKIP() << GetParam().name << " EP not available in this environment.";
@@ -153,21 +155,36 @@ TEST_P(EpConformanceTest, PreferredAllocatorsAllocateUsableMemory) {
   }
 
   constexpr size_t kBytes = 256;
+  size_t exercised = 0;
   for (const auto& alloc : allocators) {
     ASSERT_NE(alloc, nullptr);
+
+    // Standalone Alloc()/Free() is only a backend-agnostic contract for
+    // CPU-accessible allocators. A device allocator may hand out memory with a
+    // backend-specific lifecycle that this test cannot drive: e.g. the WebGPU
+    // GpuBufferAllocator creates buffers mapped at creation that must be
+    // unmapped through the buffer manager before Free(), so Free()-ing a
+    // freshly allocated buffer throws. Skip such allocators; they are covered
+    // by PreferredAllocatorsAreNonNullAndRepeatable.
+    if (!alloc->Info().device.UsesCpuMemory()) {
+      continue;
+    }
 
     void* p = alloc->Alloc(kBytes);
     ASSERT_NE(p, nullptr) << "Alloc(" << kBytes << ") returned null for allocator on "
                           << alloc->Info().device.ToString();
 
-    // Only host-accessible memory may be touched from the test (CPU) thread.
-    if (alloc->Info().device.UsesCpuMemory()) {
-      std::memset(p, 0xAB, kBytes);
-      const auto* bytes = static_cast<const unsigned char*>(p);
-      EXPECT_EQ(bytes[0], 0xAB);
-      EXPECT_EQ(bytes[kBytes - 1], 0xAB);
-    }
+    std::memset(p, 0xAB, kBytes);
+    const auto* bytes = static_cast<const unsigned char*>(p);
+    EXPECT_EQ(bytes[0], 0xAB);
+    EXPECT_EQ(bytes[kBytes - 1], 0xAB);
     alloc->Free(p);
+    ++exercised;
+  }
+
+  if (exercised == 0) {
+    GTEST_SKIP() << GetParam().name
+                 << " EP exposes no CPU-accessible preferred allocator to exercise.";
   }
 }
 

--- a/onnxruntime/test/framework/execution_provider_conformance_test.cc
+++ b/onnxruntime/test/framework/execution_provider_conformance_test.cc
@@ -1,0 +1,239 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Execution Provider conformance test suite.
+//
+// These parameterized tests encode invariants that EVERY IExecutionProvider
+// implementation is expected to satisfy, independent of the specific hardware
+// backend. They turn the previously-implicit Liskov-substitutability
+// assumptions of the IExecutionProvider contract into enforced, executable
+// checks, so that a new (or modified) EP cannot silently violate the behavior
+// the framework relies on.
+//
+// Adding an EP to the coverage is a single line: append an entry to
+// GetEpConformanceParams() below, guarded by the appropriate USE_* macro. The
+// stored value is a *factory*, not a constructed provider, so:
+//   - No EP is instantiated during static initialization.
+//   - A factory that returns nullptr (EP compiled but unavailable at runtime,
+//     e.g. no GPU present) causes the affected test to be skipped, not failed.
+//
+// Only documented, backend-agnostic contracts are asserted here. Memory that is
+// not CPU-accessible is never dereferenced from the test thread; such checks are
+// guarded by OrtDevice::UsesCpuMemory().
+
+#include <cstring>
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "core/framework/allocator.h"
+#include "core/framework/data_transfer.h"
+#include "core/framework/data_types.h"
+#include "core/framework/execution_provider.h"
+#include "core/framework/tensor.h"
+
+#include "test/util/include/default_providers.h"
+
+namespace onnxruntime {
+namespace test {
+
+namespace {
+
+// One EP under test: a human-readable name (also used as the gtest parameter
+// suffix, so it must be a valid identifier) plus a factory that constructs a
+// fresh provider instance.
+struct EpConformanceParam {
+  std::string name;
+  std::function<std::unique_ptr<IExecutionProvider>()> factory;
+};
+
+std::vector<EpConformanceParam> GetEpConformanceParams() {
+  std::vector<EpConformanceParam> params;
+
+  // CPU is always available. Cover both the arena and non-arena allocator paths
+  // since they are distinct IAllocator implementations with different Alloc/Free
+  // behavior.
+  params.push_back({"Cpu_Arena", [] { return DefaultCpuExecutionProvider(/*enable_arena*/ true); }});
+  params.push_back({"Cpu_NoArena", [] { return DefaultCpuExecutionProvider(/*enable_arena*/ false); }});
+
+#ifdef USE_CUDA
+  params.push_back({"Cuda", [] { return DefaultCudaExecutionProvider(); }});
+#endif
+#ifdef USE_DML
+  params.push_back({"Dml", [] { return DefaultDmlExecutionProvider(); }});
+#endif
+#ifdef USE_WEBGPU
+  params.push_back({"WebGpu", [] { return DefaultWebGpuExecutionProvider(); }});
+#endif
+#ifdef USE_XNNPACK
+  params.push_back({"Xnnpack", [] { return DefaultXnnpackExecutionProvider(); }});
+#endif
+
+  return params;
+}
+
+}  // namespace
+
+class EpConformanceTest : public testing::TestWithParam<EpConformanceParam> {
+ protected:
+  // Construct the EP under test. Returns nullptr when the EP is compiled but not
+  // available in the current environment; callers should GTEST_SKIP() in that case.
+  std::unique_ptr<IExecutionProvider> MakeEp() const { return GetParam().factory(); }
+};
+
+// Invariant: Type() is non-empty and stable -- both across repeated calls on a
+// single instance and across independent instances from the same factory. The
+// framework keys kernel registries and node assignment on this string.
+TEST_P(EpConformanceTest, TypeIsNonEmptyAndStable) {
+  auto ep = MakeEp();
+  if (!ep) GTEST_SKIP() << GetParam().name << " EP not available in this environment.";
+
+  const std::string type = ep->Type();
+  EXPECT_FALSE(type.empty()) << "IExecutionProvider::Type() must not be empty.";
+  EXPECT_EQ(type, ep->Type()) << "Type() must be stable across calls on the same instance.";
+
+  auto ep2 = MakeEp();
+  ASSERT_NE(ep2, nullptr);
+  EXPECT_EQ(type, ep2->Type()) << "Type() must be identical for instances from the same factory.";
+}
+
+// Invariant: GetPreferredLayout() returns one of the defined DataLayout values.
+// Layout transformation dispatches on this, so an out-of-range value is a bug.
+TEST_P(EpConformanceTest, PreferredLayoutIsValid) {
+  auto ep = MakeEp();
+  if (!ep) GTEST_SKIP() << GetParam().name << " EP not available in this environment.";
+
+  const DataLayout layout = ep->GetPreferredLayout();
+  EXPECT_TRUE(layout == DataLayout::NCHW || layout == DataLayout::NHWC)
+      << "GetPreferredLayout() returned an unknown DataLayout value.";
+}
+
+// Invariant: the CPU mem types always map to CPU-accessible memory. The
+// framework's input/output staging copies depend on this for every EP.
+TEST_P(EpConformanceTest, CpuMemTypesMapToCpuAccessibleDevice) {
+  auto ep = MakeEp();
+  if (!ep) GTEST_SKIP() << GetParam().name << " EP not available in this environment.";
+
+  EXPECT_TRUE(ep->GetOrtDeviceByMemType(OrtMemTypeCPUInput).UsesCpuMemory())
+      << "OrtMemTypeCPUInput must map to CPU-accessible memory.";
+  EXPECT_TRUE(ep->GetOrtDeviceByMemType(OrtMemTypeCPUOutput).UsesCpuMemory())
+      << "OrtMemTypeCPUOutput must map to CPU-accessible memory.";
+}
+
+// Invariant: CreatePreferredAllocators() never yields a null allocator and is
+// repeatable. The header documents it as a stateless factory, so a second call
+// must produce an equivalently-sized set.
+TEST_P(EpConformanceTest, PreferredAllocatorsAreNonNullAndRepeatable) {
+  auto ep = MakeEp();
+  if (!ep) GTEST_SKIP() << GetParam().name << " EP not available in this environment.";
+
+  auto allocators = ep->CreatePreferredAllocators();
+  for (const auto& alloc : allocators) {
+    EXPECT_NE(alloc, nullptr) << "CreatePreferredAllocators() must not return null entries.";
+  }
+
+  auto allocators2 = ep->CreatePreferredAllocators();
+  EXPECT_EQ(allocators.size(), allocators2.size())
+      << "CreatePreferredAllocators() must be repeatable (documented as stateless).";
+}
+
+// Invariant: each preferred allocator hands back usable memory. A non-zero
+// allocation yields a non-null pointer that can be freed. For CPU-accessible
+// memory we additionally verify the buffer is host-writable and readable.
+TEST_P(EpConformanceTest, PreferredAllocatorsAllocateUsableMemory) {
+  auto ep = MakeEp();
+  if (!ep) GTEST_SKIP() << GetParam().name << " EP not available in this environment.";
+
+  auto allocators = ep->CreatePreferredAllocators();
+  if (allocators.empty()) {
+    GTEST_SKIP() << GetParam().name << " EP exposes no preferred allocators.";
+  }
+
+  constexpr size_t kBytes = 256;
+  for (const auto& alloc : allocators) {
+    ASSERT_NE(alloc, nullptr);
+
+    void* p = alloc->Alloc(kBytes);
+    ASSERT_NE(p, nullptr) << "Alloc(" << kBytes << ") returned null for allocator on "
+                          << alloc->Info().device.ToString();
+
+    // Only host-accessible memory may be touched from the test (CPU) thread.
+    if (alloc->Info().device.UsesCpuMemory()) {
+      std::memset(p, 0xAB, kBytes);
+      const auto* bytes = static_cast<const unsigned char*>(p);
+      EXPECT_EQ(bytes[0], 0xAB);
+      EXPECT_EQ(bytes[kBytes - 1], 0xAB);
+    }
+    alloc->Free(p);
+  }
+}
+
+// Invariant: GetDataTransfer() is optional (may be null). When provided, and it
+// advertises the ability to copy within a CPU-accessible device, a CopyTensor
+// round-trip must preserve the data exactly.
+TEST_P(EpConformanceTest, DataTransferCpuRoundTripPreservesData) {
+  auto ep = MakeEp();
+  if (!ep) GTEST_SKIP() << GetParam().name << " EP not available in this environment.";
+
+  auto data_transfer = ep->GetDataTransfer();
+  if (!data_transfer) {
+    GTEST_SKIP() << GetParam().name << " EP provides no IDataTransfer (allowed by the contract).";
+  }
+
+  // Host the tensors on a CPU-accessible preferred allocator.
+  AllocatorPtr cpu_alloc;
+  for (auto& alloc : ep->CreatePreferredAllocators()) {
+    if (alloc && alloc->Info().device.UsesCpuMemory()) {
+      cpu_alloc = alloc;
+      break;
+    }
+  }
+  if (!cpu_alloc) {
+    GTEST_SKIP() << GetParam().name << " EP has no CPU-accessible allocator to drive the round-trip.";
+  }
+
+  const OrtDevice& cpu_device = cpu_alloc->Info().device;
+  if (!data_transfer->CanCopy(cpu_device, cpu_device)) {
+    GTEST_SKIP() << GetParam().name << " EP data transfer does not advertise CPU<->CPU copy.";
+  }
+
+  const TensorShape shape({2, 3});
+  Tensor src(DataTypeImpl::GetType<float>(), shape, cpu_alloc);
+  Tensor dst(DataTypeImpl::GetType<float>(), shape, cpu_alloc);
+
+  const float values[] = {1.f, -2.f, 3.5f, 4.f, 5.f, -6.25f};
+  constexpr size_t kNumValues = sizeof(values) / sizeof(values[0]);
+  ASSERT_EQ(static_cast<size_t>(shape.Size()), kNumValues);
+  std::memcpy(src.MutableDataRaw(), values, sizeof(values));
+  std::memset(dst.MutableDataRaw(), 0, sizeof(values));
+
+  ASSERT_TRUE(data_transfer->CopyTensor(src, dst).IsOK()) << "CopyTensor failed for a CPU<->CPU copy.";
+  EXPECT_EQ(std::memcmp(src.DataRaw(), dst.DataRaw(), sizeof(values)), 0)
+      << "A CPU round-trip CopyTensor must preserve data exactly.";
+}
+
+// Invariant: read-only metadata queries are callable and self-consistent on a
+// freshly constructed EP (no session or logger required), and the device-id
+// accessor agrees with GetDevice().
+TEST_P(EpConformanceTest, MetadataQueriesAreCallable) {
+  auto ep = MakeEp();
+  if (!ep) GTEST_SKIP() << GetParam().name << " EP not available in this environment.";
+
+  EXPECT_EQ(ep->GetDeviceId(), ep->GetDevice().Id())
+      << "GetDeviceId() must agree with GetDevice().Id().";
+
+  // These must simply be callable without crashing on a bare EP instance.
+  (void)ep->ConcurrentRunSupported();
+  (void)ep->GetTuningContext();
+  (void)ep->GetOrtDeviceByMemType(OrtMemTypeDefault);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    EpContract, EpConformanceTest, testing::ValuesIn(GetEpConformanceParams()),
+    [](const testing::TestParamInfo<EpConformanceParam>& info) { return info.param.name; });
+
+}  // namespace test
+}  // namespace onnxruntime

--- a/onnxruntime/test/framework/execution_provider_conformance_test.cc
+++ b/onnxruntime/test/framework/execution_provider_conformance_test.cc
@@ -10,6 +10,11 @@
 // checks, so that a new (or modified) EP cannot silently violate the behavior
 // the framework relies on.
 //
+// The invariant checks themselves live in
+// test/util/include/ep_conformance_invariants.h and are shared with the plugin EP
+// suite (test/providers/ep_conformance_plugin_test.cc), which runs the same
+// invariants against a dynamically-loaded plugin EP.
+//
 // Adding an EP to the coverage is a single line: append an entry to
 // GetEpConformanceParams() below, guarded by the appropriate USE_* macro. The
 // stored value is a *factory*, not a constructed provider, so:
@@ -21,7 +26,6 @@
 // not CPU-accessible is never dereferenced from the test thread; such checks are
 // guarded by OrtDevice::UsesCpuMemory().
 
-#include <cstring>
 #include <functional>
 #include <memory>
 #include <string>
@@ -29,13 +33,10 @@
 
 #include "gtest/gtest.h"
 
-#include "core/framework/allocator.h"
-#include "core/framework/data_transfer.h"
-#include "core/framework/data_types.h"
 #include "core/framework/execution_provider.h"
-#include "core/framework/tensor.h"
 
 #include "test/util/include/default_providers.h"
+#include "test/util/include/ep_conformance_invariants.h"
 
 namespace onnxruntime {
 namespace test {
@@ -101,13 +102,7 @@ TEST_P(EpConformanceTest, TypeIsNonEmptyAndStable) {
   auto ep = MakeEp();
   if (!ep) GTEST_SKIP() << GetParam().name << " EP not available in this environment.";
 
-  const std::string type = ep->Type();
-  EXPECT_FALSE(type.empty()) << "IExecutionProvider::Type() must not be empty.";
-  EXPECT_EQ(type, ep->Type()) << "Type() must be stable across calls on the same instance.";
-
-  auto ep2 = MakeEp();
-  ASSERT_NE(ep2, nullptr);
-  EXPECT_EQ(type, ep2->Type()) << "Type() must be identical for instances from the same factory.";
+  ep_conformance::CheckTypeIsNonEmptyAndStable(*ep, [this] { return MakeEp(); }, GetParam().name);
 }
 
 // Invariant: GetPreferredLayout() returns one of the defined DataLayout values.
@@ -116,9 +111,7 @@ TEST_P(EpConformanceTest, PreferredLayoutIsValid) {
   auto ep = MakeEp();
   if (!ep) GTEST_SKIP() << GetParam().name << " EP not available in this environment.";
 
-  const DataLayout layout = ep->GetPreferredLayout();
-  EXPECT_TRUE(layout == DataLayout::NCHW || layout == DataLayout::NHWC)
-      << "GetPreferredLayout() returned an unknown DataLayout value.";
+  ep_conformance::CheckPreferredLayoutIsValid(*ep, GetParam().name);
 }
 
 // Invariant: the CPU mem types always map to CPU-accessible memory. The
@@ -127,10 +120,7 @@ TEST_P(EpConformanceTest, CpuMemTypesMapToCpuAccessibleDevice) {
   auto ep = MakeEp();
   if (!ep) GTEST_SKIP() << GetParam().name << " EP not available in this environment.";
 
-  EXPECT_TRUE(ep->GetOrtDeviceByMemType(OrtMemTypeCPUInput).UsesCpuMemory())
-      << "OrtMemTypeCPUInput must map to CPU-accessible memory.";
-  EXPECT_TRUE(ep->GetOrtDeviceByMemType(OrtMemTypeCPUOutput).UsesCpuMemory())
-      << "OrtMemTypeCPUOutput must map to CPU-accessible memory.";
+  ep_conformance::CheckCpuMemTypesMapToCpuAccessibleDevice(*ep, GetParam().name);
 }
 
 // Invariant: CreatePreferredAllocators() never yields a null allocator and is
@@ -140,14 +130,7 @@ TEST_P(EpConformanceTest, PreferredAllocatorsAreNonNullAndRepeatable) {
   auto ep = MakeEp();
   if (!ep) GTEST_SKIP() << GetParam().name << " EP not available in this environment.";
 
-  auto allocators = ep->CreatePreferredAllocators();
-  for (const auto& alloc : allocators) {
-    EXPECT_NE(alloc, nullptr) << "CreatePreferredAllocators() must not return null entries.";
-  }
-
-  auto allocators2 = ep->CreatePreferredAllocators();
-  EXPECT_EQ(allocators.size(), allocators2.size())
-      << "CreatePreferredAllocators() must be repeatable (documented as stateless).";
+  ep_conformance::CheckPreferredAllocatorsAreNonNullAndRepeatable(*ep, GetParam().name);
 }
 
 // Invariant: each CPU-accessible preferred allocator hands back usable memory:
@@ -159,43 +142,7 @@ TEST_P(EpConformanceTest, PreferredAllocatorsAllocateUsableMemory) {
   auto ep = MakeEp();
   if (!ep) GTEST_SKIP() << GetParam().name << " EP not available in this environment.";
 
-  auto allocators = ep->CreatePreferredAllocators();
-  if (allocators.empty()) {
-    GTEST_SKIP() << GetParam().name << " EP exposes no preferred allocators.";
-  }
-
-  constexpr size_t kBytes = 256;
-  size_t exercised = 0;
-  for (const auto& alloc : allocators) {
-    ASSERT_NE(alloc, nullptr);
-
-    // Standalone Alloc()/Free() is only a backend-agnostic contract for
-    // CPU-accessible allocators. A device allocator may hand out memory with a
-    // backend-specific lifecycle that this test cannot drive: e.g. the WebGPU
-    // GpuBufferAllocator creates buffers mapped at creation that must be
-    // unmapped through the buffer manager before Free(), so Free()-ing a
-    // freshly allocated buffer throws. Skip such allocators; they are covered
-    // by PreferredAllocatorsAreNonNullAndRepeatable.
-    if (!alloc->Info().device.UsesCpuMemory()) {
-      continue;
-    }
-
-    void* p = alloc->Alloc(kBytes);
-    ASSERT_NE(p, nullptr) << "Alloc(" << kBytes << ") returned null for allocator on "
-                          << alloc->Info().device.ToString();
-
-    std::memset(p, 0xAB, kBytes);
-    const auto* bytes = static_cast<const unsigned char*>(p);
-    EXPECT_EQ(bytes[0], 0xAB);
-    EXPECT_EQ(bytes[kBytes - 1], 0xAB);
-    alloc->Free(p);
-    ++exercised;
-  }
-
-  if (exercised == 0) {
-    GTEST_SKIP() << GetParam().name
-                 << " EP exposes no CPU-accessible preferred allocator to exercise.";
-  }
+  ep_conformance::CheckPreferredAllocatorsAllocateUsableMemory(*ep, GetParam().name);
 }
 
 // Invariant: GetDataTransfer() is optional (may be null). When provided, and it
@@ -205,41 +152,7 @@ TEST_P(EpConformanceTest, DataTransferCpuRoundTripPreservesData) {
   auto ep = MakeEp();
   if (!ep) GTEST_SKIP() << GetParam().name << " EP not available in this environment.";
 
-  auto data_transfer = ep->GetDataTransfer();
-  if (!data_transfer) {
-    GTEST_SKIP() << GetParam().name << " EP provides no IDataTransfer (allowed by the contract).";
-  }
-
-  // Host the tensors on a CPU-accessible preferred allocator.
-  AllocatorPtr cpu_alloc;
-  for (auto& alloc : ep->CreatePreferredAllocators()) {
-    if (alloc && alloc->Info().device.UsesCpuMemory()) {
-      cpu_alloc = alloc;
-      break;
-    }
-  }
-  if (!cpu_alloc) {
-    GTEST_SKIP() << GetParam().name << " EP has no CPU-accessible allocator to drive the round-trip.";
-  }
-
-  const OrtDevice& cpu_device = cpu_alloc->Info().device;
-  if (!data_transfer->CanCopy(cpu_device, cpu_device)) {
-    GTEST_SKIP() << GetParam().name << " EP data transfer does not advertise CPU<->CPU copy.";
-  }
-
-  const TensorShape shape({2, 3});
-  Tensor src(DataTypeImpl::GetType<float>(), shape, cpu_alloc);
-  Tensor dst(DataTypeImpl::GetType<float>(), shape, cpu_alloc);
-
-  const float values[] = {1.f, -2.f, 3.5f, 4.f, 5.f, -6.25f};
-  constexpr size_t kNumValues = sizeof(values) / sizeof(values[0]);
-  ASSERT_EQ(static_cast<size_t>(shape.Size()), kNumValues);
-  std::memcpy(src.MutableDataRaw(), values, sizeof(values));
-  std::memset(dst.MutableDataRaw(), 0, sizeof(values));
-
-  ASSERT_TRUE(data_transfer->CopyTensor(src, dst).IsOK()) << "CopyTensor failed for a CPU<->CPU copy.";
-  EXPECT_EQ(std::memcmp(src.DataRaw(), dst.DataRaw(), sizeof(values)), 0)
-      << "A CPU round-trip CopyTensor must preserve data exactly.";
+  ep_conformance::CheckDataTransferCpuRoundTripPreservesData(*ep, GetParam().name);
 }
 
 // Invariant: read-only metadata queries are callable and self-consistent on a
@@ -249,15 +162,7 @@ TEST_P(EpConformanceTest, MetadataQueriesAreCallable) {
   auto ep = MakeEp();
   if (!ep) GTEST_SKIP() << GetParam().name << " EP not available in this environment.";
 
-  EXPECT_EQ(ep->GetDeviceId(), ep->GetDevice().Id())
-      << "GetDeviceId() must agree with GetDevice().Id().";
-
-  // These must simply be callable without crashing on a bare EP instance.
-  (void)ep->ConcurrentRunSupported();
-  (void)ep->GetTuningContext();
-  (void)ep->GetOrtDeviceByMemType(OrtMemTypeDefault);
-  (void)ep->IsGraphCaptureEnabled();
-  (void)ep->ShouldConvertDataLayoutForOp(/*domain*/ "", /*op_type*/ "Conv", ep->GetPreferredLayout());
+  ep_conformance::CheckMetadataQueriesAreCallable(*ep, GetParam().name);
 }
 
 // Invariant: GetGraphCaptureNodeAssignmentPolicy() returns one of the defined
@@ -269,10 +174,7 @@ TEST_P(EpConformanceTest, GraphCaptureNodeAssignmentPolicyIsValid) {
   auto ep = MakeEp();
   if (!ep) GTEST_SKIP() << GetParam().name << " EP not available in this environment.";
 
-  const OrtGraphCaptureNodeAssignmentPolicy policy = ep->GetGraphCaptureNodeAssignmentPolicy();
-  EXPECT_TRUE(policy == OrtGraphCaptureNodeAssignmentPolicy_ALL_NODES_ON_EP ||
-              policy == OrtGraphCaptureNodeAssignmentPolicy_ALLOW_CPU_FOR_SHAPES)
-      << "GetGraphCaptureNodeAssignmentPolicy() returned an unknown policy value.";
+  ep_conformance::CheckGraphCaptureNodeAssignmentPolicyIsValid(*ep, GetParam().name);
 }
 
 // Invariant: a built-in EP returns no backing OrtEp. A PluginExecutionProvider
@@ -281,14 +183,7 @@ TEST_P(EpConformanceTest, GetOrtEpMatchesProviderKind) {
   auto ep = MakeEp();
   if (!ep) GTEST_SKIP() << GetParam().name << " EP not available in this environment.";
 
-  const OrtEp* ort_ep = ep->GetOrtEp();
-  if (GetParam().expects_plugin_ep) {
-    ASSERT_NE(ort_ep, nullptr) << "A plugin EP must report its backing OrtEp.";
-    EXPECT_EQ(ep->GetOrtEp(), ort_ep) << "A plugin EP must report a stable backing OrtEp.";
-  } else {
-    EXPECT_EQ(ort_ep, nullptr)
-        << "A built-in EP must not report a backing OrtEp (that is reserved for plugin EPs).";
-  }
+  ep_conformance::CheckGetOrtEpMatchesProviderKind(*ep, GetParam().expects_plugin_ep, GetParam().name);
 }
 
 // Invariant: GetEpContextNodes() reports no nodes on a freshly constructed EP.
@@ -298,8 +193,7 @@ TEST_P(EpConformanceTest, EpContextNodesEmptyOnFreshEp) {
   auto ep = MakeEp();
   if (!ep) GTEST_SKIP() << GetParam().name << " EP not available in this environment.";
 
-  EXPECT_TRUE(ep->GetEpContextNodes().empty())
-      << "A fresh EP (no compilation performed) must report no EPContext nodes.";
+  ep_conformance::CheckEpContextNodesEmptyOnFreshEp(*ep, GetParam().name);
 }
 
 // Invariant: every preferred allocator reports self-consistent OrtMemoryInfo --
@@ -310,13 +204,7 @@ TEST_P(EpConformanceTest, PreferredAllocatorInfoIsConsistent) {
   auto ep = MakeEp();
   if (!ep) GTEST_SKIP() << GetParam().name << " EP not available in this environment.";
 
-  for (const auto& alloc : ep->CreatePreferredAllocators()) {
-    ASSERT_NE(alloc, nullptr) << "CreatePreferredAllocators() must not return null entries.";
-    const OrtMemoryInfo& info = alloc->Info();
-    EXPECT_FALSE(info.name.empty()) << "Allocator OrtMemoryInfo.name must not be empty.";
-    EXPECT_NE(info.alloc_type, OrtInvalidAllocator)
-        << "Allocator must report a valid OrtAllocatorType (not OrtInvalidAllocator).";
-  }
+  ep_conformance::CheckPreferredAllocatorInfoIsConsistent(*ep, GetParam().name);
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/onnxruntime/test/framework/execution_provider_conformance_test.cc
+++ b/onnxruntime/test/framework/execution_provider_conformance_test.cc
@@ -251,6 +251,62 @@ TEST_P(EpConformanceTest, MetadataQueriesAreCallable) {
   (void)ep->ConcurrentRunSupported();
   (void)ep->GetTuningContext();
   (void)ep->GetOrtDeviceByMemType(OrtMemTypeDefault);
+  (void)ep->IsGraphCaptureEnabled();
+  (void)ep->ShouldConvertDataLayoutForOp(/*domain*/ "", /*op_type*/ "Conv", ep->GetPreferredLayout());
+}
+
+// Invariant: GetGraphCaptureNodeAssignmentPolicy() returns one of the defined
+// OrtGraphCaptureNodeAssignmentPolicy values. The session dispatches on this
+// while validating a graph for capture, so an out-of-range value is a bug.
+// This is a pure query and is valid to call on every EP regardless of whether
+// graph capture is enabled.
+TEST_P(EpConformanceTest, GraphCaptureNodeAssignmentPolicyIsValid) {
+  auto ep = MakeEp();
+  if (!ep) GTEST_SKIP() << GetParam().name << " EP not available in this environment.";
+
+  const OrtGraphCaptureNodeAssignmentPolicy policy = ep->GetGraphCaptureNodeAssignmentPolicy();
+  EXPECT_TRUE(policy == OrtGraphCaptureNodeAssignmentPolicy_ALL_NODES_ON_EP ||
+              policy == OrtGraphCaptureNodeAssignmentPolicy_ALLOW_CPU_FOR_SHAPES)
+      << "GetGraphCaptureNodeAssignmentPolicy() returned an unknown policy value.";
+}
+
+// Invariant: a built-in EP is not a plugin wrapper, so GetOrtEp() returns nullptr.
+// Only a PluginExecutionProvider wrapping an OrtEp reports a backing OrtEp, and
+// every EP exercised by this suite is built-in.
+TEST_P(EpConformanceTest, GetOrtEpIsNullForBuiltInEp) {
+  auto ep = MakeEp();
+  if (!ep) GTEST_SKIP() << GetParam().name << " EP not available in this environment.";
+
+  EXPECT_EQ(ep->GetOrtEp(), nullptr)
+      << "A built-in EP must not report a backing OrtEp (that is reserved for plugin EPs).";
+}
+
+// Invariant: GetEpContextNodes() reports no nodes on a freshly constructed EP.
+// EPs populate this only when generating an EPContext cache model during
+// compilation; with no compilation performed, the documented default is empty.
+TEST_P(EpConformanceTest, EpContextNodesEmptyOnFreshEp) {
+  auto ep = MakeEp();
+  if (!ep) GTEST_SKIP() << GetParam().name << " EP not available in this environment.";
+
+  EXPECT_TRUE(ep->GetEpContextNodes().empty())
+      << "A fresh EP (no compilation performed) must report no EPContext nodes.";
+}
+
+// Invariant: every preferred allocator reports self-consistent OrtMemoryInfo --
+// a non-empty name and a valid allocator type. This metadata keys allocator
+// lookup in the framework, so it must be well-formed for every EP. Only the
+// backend-agnostic fields are checked; the raw memory is not touched here.
+TEST_P(EpConformanceTest, PreferredAllocatorInfoIsConsistent) {
+  auto ep = MakeEp();
+  if (!ep) GTEST_SKIP() << GetParam().name << " EP not available in this environment.";
+
+  for (const auto& alloc : ep->CreatePreferredAllocators()) {
+    ASSERT_NE(alloc, nullptr) << "CreatePreferredAllocators() must not return null entries.";
+    const OrtMemoryInfo& info = alloc->Info();
+    EXPECT_FALSE(info.name.empty()) << "Allocator OrtMemoryInfo.name must not be empty.";
+    EXPECT_NE(info.alloc_type, OrtInvalidAllocator)
+        << "Allocator must report a valid OrtAllocatorType (not OrtInvalidAllocator).";
+  }
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/onnxruntime/test/framework/execution_provider_conformance_test.cc
+++ b/onnxruntime/test/framework/execution_provider_conformance_test.cc
@@ -3,12 +3,17 @@
 
 // Execution Provider conformance test suite.
 //
-// These parameterized tests encode invariants that EVERY IExecutionProvider
+// These parameterized tests encode invariants that every IExecutionProvider
 // implementation is expected to satisfy, independent of the specific hardware
 // backend. They turn the previously-implicit Liskov-substitutability
 // assumptions of the IExecutionProvider contract into enforced, executable
-// checks, so that a new (or modified) EP cannot silently violate the behavior
-// the framework relies on.
+// checks, so that a covered EP cannot silently violate the behavior the
+// framework relies on.
+//
+// Coverage is opt-in per EP: only the providers registered in
+// GetEpConformanceParams() are exercised (currently CPU, plus CUDA, DML, WebGPU
+// and XNNPACK behind their build guards). Listing a provider there extends the
+// guarantee to it; EPs not listed are not checked by this suite.
 //
 // The invariant checks themselves live in
 // test/util/include/ep_conformance_invariants.h and are shared with the plugin EP
@@ -19,13 +24,16 @@
 // GetEpConformanceParams() below, guarded by the appropriate USE_* macro. The
 // stored value is a *factory*, not a constructed provider, so:
 //   - No EP is instantiated during static initialization.
-//   - A factory that returns nullptr (EP compiled but unavailable at runtime,
-//     e.g. no GPU present) causes the affected test to be skipped, not failed.
+//   - An EP that is compiled but unavailable at runtime (e.g. no GPU present)
+//     causes the affected test to be skipped, not failed -- whether its factory
+//     signals that by returning nullptr or by throwing during construction (see
+//     MakeEp()).
 //
 // Only documented, backend-agnostic contracts are asserted here. Memory that is
 // not CPU-accessible is never dereferenced from the test thread; such checks are
 // guarded by OrtDevice::UsesCpuMemory().
 
+#include <exception>
 #include <functional>
 #include <memory>
 #include <string>
@@ -43,9 +51,13 @@ namespace test {
 
 namespace {
 
-// One EP under test: a human-readable name (also used as the gtest parameter
-// suffix, so it must be a valid identifier) plus a factory that constructs a
-// fresh provider instance.
+// One EP under test:
+//   - name: a human-readable label, also used as the gtest parameter suffix, so it
+//     must be a valid identifier.
+//   - factory: constructs a fresh provider instance (see MakeEp()).
+//   - expects_plugin_ep: true iff this EP is plugin-backed, i.e. GetOrtEp() must
+//     return non-null (see CheckGetOrtEpMatchesProviderKind). Built-in EPs leave it
+//     false.
 struct EpConformanceParam {
   std::string name;
   std::function<std::unique_ptr<IExecutionProvider>()> factory;
@@ -63,7 +75,7 @@ std::vector<EpConformanceParam> GetEpConformanceParams() {
 
 #ifdef USE_CUDA
 #if defined(ORT_UNIT_TEST_HAS_CUDA_PLUGIN_EP) && defined(ORT_UNIT_TEST_ENABLE_DYNAMIC_PLUGIN_EP_USAGE)
-  params.push_back({"Cuda", [] { return DefaultCudaExecutionProvider(); }, true});
+  params.push_back({"Cuda", [] { return DefaultCudaExecutionProvider(); }, /*expects_plugin_ep=*/true});
 #else
   params.push_back({"Cuda", [] { return DefaultCudaExecutionProvider(); }});
 #endif
@@ -92,7 +104,20 @@ class EpConformanceTest : public testing::TestWithParam<EpConformanceParam> {
  protected:
   // Construct the EP under test. Returns nullptr when the EP is compiled but not
   // available in the current environment; callers should GTEST_SKIP() in that case.
-  std::unique_ptr<IExecutionProvider> MakeEp() const { return GetParam().factory(); }
+  // Some providers signal unavailability by returning nullptr from their factory;
+  // others (e.g. CUDA, whose constructor calls cudaSetDevice) throw when no device or
+  // driver is present. Both are treated as "unavailable" so the affected test skips
+  // rather than fails; the exception text is logged so a genuine construction
+  // regression stays visible.
+  std::unique_ptr<IExecutionProvider> MakeEp() const {
+    try {
+      return GetParam().factory();
+    } catch (const std::exception& e) {
+      GTEST_LOG_(WARNING) << GetParam().name
+                          << " EP factory threw during construction (treated as unavailable): " << e.what();
+      return nullptr;
+    }
+  }
 };
 
 // Invariant: Type() is non-empty and stable -- both across repeated calls on a
@@ -146,18 +171,18 @@ TEST_P(EpConformanceTest, PreferredAllocatorsAllocateUsableMemory) {
 }
 
 // Invariant: GetDataTransfer() is optional (may be null). When provided, and it
-// advertises the ability to copy within a CPU-accessible device, a CopyTensor
-// round-trip must preserve the data exactly.
-TEST_P(EpConformanceTest, DataTransferCpuRoundTripPreservesData) {
+// advertises the ability to copy within a CPU-accessible device, a CPU-to-CPU
+// CopyTensor must preserve the data exactly.
+TEST_P(EpConformanceTest, DataTransferCpuCopyPreservesData) {
   auto ep = MakeEp();
   if (!ep) GTEST_SKIP() << GetParam().name << " EP not available in this environment.";
 
-  ep_conformance::CheckDataTransferCpuRoundTripPreservesData(*ep, GetParam().name);
+  ep_conformance::CheckDataTransferCpuCopyPreservesData(*ep, GetParam().name);
 }
 
-// Invariant: read-only metadata queries are callable and self-consistent on a
-// freshly constructed EP (no session or logger required), and the device-id
-// accessor agrees with GetDevice().
+// Invariant: read-only metadata queries are callable on a freshly constructed EP (no
+// session or logger required). GetDeviceId() is provider-defined and is not required
+// to equal GetDevice().Id(), so it is only smoke-called.
 TEST_P(EpConformanceTest, MetadataQueriesAreCallable) {
   auto ep = MakeEp();
   if (!ep) GTEST_SKIP() << GetParam().name << " EP not available in this environment.";

--- a/onnxruntime/test/framework/execution_provider_conformance_test.cc
+++ b/onnxruntime/test/framework/execution_provider_conformance_test.cc
@@ -221,9 +221,10 @@ TEST_P(EpConformanceTest, EpContextNodesEmptyOnFreshEp) {
   ep_conformance::CheckEpContextNodesEmptyOnFreshEp(*ep, GetParam().name);
 }
 
-// Invariant: every preferred allocator reports self-consistent OrtMemoryInfo --
-// a non-empty name and a valid allocator type. This metadata keys allocator
-// lookup in the framework, so it must be well-formed for every EP. Only the
+// Invariant: every preferred allocator reports a valid allocator type in its
+// OrtMemoryInfo. This metadata keys allocator lookup in the framework, so it must
+// be well-formed for every EP. The allocator name is intentionally not asserted --
+// an empty OrtMemoryInfo.name is permitted by the contract. Only the
 // backend-agnostic fields are checked; the raw memory is not touched here.
 TEST_P(EpConformanceTest, PreferredAllocatorInfoIsConsistent) {
   auto ep = MakeEp();

--- a/onnxruntime/test/providers/ep_conformance_plugin_test.cc
+++ b/onnxruntime/test/providers/ep_conformance_plugin_test.cc
@@ -1,0 +1,141 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Plugin EP conformance test suite.
+//
+// This suite runs the shared Execution Provider conformance invariants
+// (test/util/include/ep_conformance_invariants.h) against a *plugin* EP -- an
+// OrtEp reached through the PluginExecutionProvider wrapper -- rather than against
+// an in-tree IExecutionProvider implementation. Developing an EP as a plugin (the
+// OrtEp / OrtEpFactory ABI) is the recommended path for external EP authors, so the
+// same Liskov-substitutability contract that the built-in suite
+// (test/framework/execution_provider_conformance_test.cc) enforces for the internal
+// interface is enforced here for the plugin interface.
+//
+// The EP under test is whichever plugin EP the dynamic plugin EP infrastructure was
+// initialized with. That is intentionally open-ended so the suite covers arbitrary
+// plugin EPs:
+//   - the in-repo example plugin EP,
+//   - an ORT-owned EP that has been converted to a plugin (e.g. CUDA or WebGPU
+//     routed through the EP API adapters), or
+//   - any plugin EP specified at runtime via the
+//     ORT_UNIT_TEST_MAIN_DYNAMIC_PLUGIN_EP_CONFIG_JSON[_FILE] environment variables.
+//
+// When the infrastructure is not initialized (no plugin EP configured for this run),
+// MakeEp() returns nullptr and every test cleanly skips.
+
+#include <memory>
+#include <string>
+
+#include "gtest/gtest.h"
+
+#include "core/framework/execution_provider.h"
+
+#include "test/unittest_util/test_dynamic_plugin_ep.h"
+#include "test/util/include/ep_conformance_invariants.h"
+
+#if defined(ORT_UNIT_TEST_ENABLE_DYNAMIC_PLUGIN_EP_USAGE)
+
+namespace onnxruntime {
+namespace test {
+namespace {
+
+namespace dynamic_plugin_ep_infra = onnxruntime::test::dynamic_plugin_ep_infra;
+
+// Fixture that constructs the dynamically-loaded plugin EP under test. A null return
+// means the dynamic plugin EP infrastructure was not initialized for this run, in
+// which case the test skips. Each test is the plugin-interface counterpart of the
+// identically-named test in the built-in EP suite.
+class EpPluginConformanceTest : public ::testing::Test {
+ protected:
+  static std::unique_ptr<IExecutionProvider> MakeEp() { return dynamic_plugin_ep_infra::MakeEp(); }
+
+  // Human-readable label for failure messages: the selected plugin EP's name.
+  static std::string EpLabel() { return dynamic_plugin_ep_infra::GetEpName().value_or(std::string{"PluginEp"}); }
+};
+
+TEST_F(EpPluginConformanceTest, TypeIsNonEmptyAndStable) {
+  auto ep = MakeEp();
+  if (!ep) GTEST_SKIP() << "dynamic plugin EP infrastructure is not initialized.";
+
+  ep_conformance::CheckTypeIsNonEmptyAndStable(
+      *ep, [] { return EpPluginConformanceTest::MakeEp(); }, EpLabel());
+}
+
+TEST_F(EpPluginConformanceTest, PreferredLayoutIsValid) {
+  auto ep = MakeEp();
+  if (!ep) GTEST_SKIP() << "dynamic plugin EP infrastructure is not initialized.";
+
+  ep_conformance::CheckPreferredLayoutIsValid(*ep, EpLabel());
+}
+
+TEST_F(EpPluginConformanceTest, CpuMemTypesMapToCpuAccessibleDevice) {
+  auto ep = MakeEp();
+  if (!ep) GTEST_SKIP() << "dynamic plugin EP infrastructure is not initialized.";
+
+  ep_conformance::CheckCpuMemTypesMapToCpuAccessibleDevice(*ep, EpLabel());
+}
+
+TEST_F(EpPluginConformanceTest, PreferredAllocatorsAreNonNullAndRepeatable) {
+  auto ep = MakeEp();
+  if (!ep) GTEST_SKIP() << "dynamic plugin EP infrastructure is not initialized.";
+
+  ep_conformance::CheckPreferredAllocatorsAreNonNullAndRepeatable(*ep, EpLabel());
+}
+
+TEST_F(EpPluginConformanceTest, PreferredAllocatorsAllocateUsableMemory) {
+  auto ep = MakeEp();
+  if (!ep) GTEST_SKIP() << "dynamic plugin EP infrastructure is not initialized.";
+
+  ep_conformance::CheckPreferredAllocatorsAllocateUsableMemory(*ep, EpLabel());
+}
+
+TEST_F(EpPluginConformanceTest, DataTransferCpuRoundTripPreservesData) {
+  auto ep = MakeEp();
+  if (!ep) GTEST_SKIP() << "dynamic plugin EP infrastructure is not initialized.";
+
+  ep_conformance::CheckDataTransferCpuRoundTripPreservesData(*ep, EpLabel());
+}
+
+TEST_F(EpPluginConformanceTest, MetadataQueriesAreCallable) {
+  auto ep = MakeEp();
+  if (!ep) GTEST_SKIP() << "dynamic plugin EP infrastructure is not initialized.";
+
+  ep_conformance::CheckMetadataQueriesAreCallable(*ep, EpLabel());
+}
+
+TEST_F(EpPluginConformanceTest, GraphCaptureNodeAssignmentPolicyIsValid) {
+  auto ep = MakeEp();
+  if (!ep) GTEST_SKIP() << "dynamic plugin EP infrastructure is not initialized.";
+
+  ep_conformance::CheckGraphCaptureNodeAssignmentPolicyIsValid(*ep, EpLabel());
+}
+
+TEST_F(EpPluginConformanceTest, GetOrtEpMatchesProviderKind) {
+  auto ep = MakeEp();
+  if (!ep) GTEST_SKIP() << "dynamic plugin EP infrastructure is not initialized.";
+
+  // A dynamically-loaded plugin EP is always backed by an OrtEp, so unlike a
+  // built-in EP it must report a stable non-null backing OrtEp.
+  ep_conformance::CheckGetOrtEpMatchesProviderKind(*ep, /*expects_plugin_ep*/ true, EpLabel());
+}
+
+TEST_F(EpPluginConformanceTest, EpContextNodesEmptyOnFreshEp) {
+  auto ep = MakeEp();
+  if (!ep) GTEST_SKIP() << "dynamic plugin EP infrastructure is not initialized.";
+
+  ep_conformance::CheckEpContextNodesEmptyOnFreshEp(*ep, EpLabel());
+}
+
+TEST_F(EpPluginConformanceTest, PreferredAllocatorInfoIsConsistent) {
+  auto ep = MakeEp();
+  if (!ep) GTEST_SKIP() << "dynamic plugin EP infrastructure is not initialized.";
+
+  ep_conformance::CheckPreferredAllocatorInfoIsConsistent(*ep, EpLabel());
+}
+
+}  // namespace
+}  // namespace test
+}  // namespace onnxruntime
+
+#endif  // defined(ORT_UNIT_TEST_ENABLE_DYNAMIC_PLUGIN_EP_USAGE)

--- a/onnxruntime/test/providers/ep_conformance_plugin_test.cc
+++ b/onnxruntime/test/providers/ep_conformance_plugin_test.cc
@@ -31,16 +31,14 @@
 
 #include "core/framework/execution_provider.h"
 
+#if defined(ORT_UNIT_TEST_ENABLE_DYNAMIC_PLUGIN_EP_USAGE)
+
 #include "test/unittest_util/test_dynamic_plugin_ep.h"
 #include "test/util/include/ep_conformance_invariants.h"
-
-#if defined(ORT_UNIT_TEST_ENABLE_DYNAMIC_PLUGIN_EP_USAGE)
 
 namespace onnxruntime {
 namespace test {
 namespace {
-
-namespace dynamic_plugin_ep_infra = onnxruntime::test::dynamic_plugin_ep_infra;
 
 // Fixture that constructs the dynamically-loaded plugin EP under test. A null return
 // means the dynamic plugin EP infrastructure was not initialized for this run, in
@@ -59,7 +57,7 @@ TEST_F(EpPluginConformanceTest, TypeIsNonEmptyAndStable) {
   if (!ep) GTEST_SKIP() << "dynamic plugin EP infrastructure is not initialized.";
 
   ep_conformance::CheckTypeIsNonEmptyAndStable(
-      *ep, [] { return EpPluginConformanceTest::MakeEp(); }, EpLabel());
+      *ep, [] { return MakeEp(); }, EpLabel());
 }
 
 TEST_F(EpPluginConformanceTest, PreferredLayoutIsValid) {
@@ -90,11 +88,11 @@ TEST_F(EpPluginConformanceTest, PreferredAllocatorsAllocateUsableMemory) {
   ep_conformance::CheckPreferredAllocatorsAllocateUsableMemory(*ep, EpLabel());
 }
 
-TEST_F(EpPluginConformanceTest, DataTransferCpuRoundTripPreservesData) {
+TEST_F(EpPluginConformanceTest, DataTransferCpuCopyPreservesData) {
   auto ep = MakeEp();
   if (!ep) GTEST_SKIP() << "dynamic plugin EP infrastructure is not initialized.";
 
-  ep_conformance::CheckDataTransferCpuRoundTripPreservesData(*ep, EpLabel());
+  ep_conformance::CheckDataTransferCpuCopyPreservesData(*ep, EpLabel());
 }
 
 TEST_F(EpPluginConformanceTest, MetadataQueriesAreCallable) {

--- a/onnxruntime/test/util/include/ep_conformance_invariants.h
+++ b/onnxruntime/test/util/include/ep_conformance_invariants.h
@@ -1,0 +1,242 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+// Shared Execution Provider conformance invariants.
+//
+// These free functions encode the backend-agnostic invariants that EVERY
+// execution provider is expected to satisfy. They are the single source of truth
+// shared by two suites so the internal-interface and plugin-interface checks
+// cannot drift apart:
+//   - The built-in EP suite (test/framework/execution_provider_conformance_test.cc)
+//     exercises the in-tree IExecutionProvider implementations.
+//   - The plugin EP suite (test/providers/ep_conformance_plugin_test.cc) exercises a
+//     dynamically-loaded plugin EP -- i.e. an OrtEp reached through the
+//     PluginExecutionProvider wrapper -- which is the recommended path for external
+//     EP authors.
+//
+// Only documented, backend-agnostic contracts are asserted here. Memory that is not
+// CPU-accessible is never dereferenced; such checks are guarded by
+// OrtDevice::UsesCpuMemory().
+//
+// Each function issues gtest expectations/assertions directly. Because some of them
+// call GTEST_SKIP() when a backend-agnostic precondition is not met (e.g. the EP
+// exposes no CPU-accessible allocator), a function must be invoked as the LAST
+// statement of a test body so the skip cleanly ends the test.
+
+#include <cstring>
+#include <functional>
+#include <memory>
+#include <string_view>
+
+#include "gtest/gtest.h"
+
+#include "core/framework/allocator.h"
+#include "core/framework/data_transfer.h"
+#include "core/framework/data_types.h"
+#include "core/framework/execution_provider.h"
+#include "core/framework/tensor.h"
+
+namespace onnxruntime {
+namespace test {
+namespace ep_conformance {
+
+// Factory that constructs a fresh EP instance under test. Used by invariants that
+// need to compare independent instances produced by the same source.
+using MakeEpFn = std::function<std::unique_ptr<IExecutionProvider>()>;
+
+// Invariant: Type() is non-empty and stable -- both across repeated calls on a
+// single instance and across independent instances from the same source. The
+// framework keys kernel registries and node assignment on this string.
+inline void CheckTypeIsNonEmptyAndStable(IExecutionProvider& ep, const MakeEpFn& make_ep, std::string_view label) {
+  const std::string type = ep.Type();
+  EXPECT_FALSE(type.empty()) << label << ": IExecutionProvider::Type() must not be empty.";
+  EXPECT_EQ(type, ep.Type()) << label << ": Type() must be stable across calls on the same instance.";
+
+  auto ep2 = make_ep();
+  ASSERT_NE(ep2, nullptr) << label << ": the EP source must produce a second instance.";
+  EXPECT_EQ(type, ep2->Type()) << label << ": Type() must be identical for instances from the same source.";
+}
+
+// Invariant: GetPreferredLayout() returns one of the defined DataLayout values.
+// Layout transformation dispatches on this, so an out-of-range value is a bug.
+inline void CheckPreferredLayoutIsValid(IExecutionProvider& ep, std::string_view label) {
+  const DataLayout layout = ep.GetPreferredLayout();
+  EXPECT_TRUE(layout == DataLayout::NCHW || layout == DataLayout::NHWC)
+      << label << ": GetPreferredLayout() returned an unknown DataLayout value.";
+}
+
+// Invariant: the CPU mem types always map to CPU-accessible memory. The framework's
+// input/output staging copies depend on this for every EP.
+inline void CheckCpuMemTypesMapToCpuAccessibleDevice(IExecutionProvider& ep, std::string_view label) {
+  EXPECT_TRUE(ep.GetOrtDeviceByMemType(OrtMemTypeCPUInput).UsesCpuMemory())
+      << label << ": OrtMemTypeCPUInput must map to CPU-accessible memory.";
+  EXPECT_TRUE(ep.GetOrtDeviceByMemType(OrtMemTypeCPUOutput).UsesCpuMemory())
+      << label << ": OrtMemTypeCPUOutput must map to CPU-accessible memory.";
+}
+
+// Invariant: CreatePreferredAllocators() never yields a null allocator and is
+// repeatable. The header documents it as a stateless factory, so a second call must
+// produce an equivalently-sized set.
+inline void CheckPreferredAllocatorsAreNonNullAndRepeatable(IExecutionProvider& ep, std::string_view label) {
+  auto allocators = ep.CreatePreferredAllocators();
+  for (const auto& alloc : allocators) {
+    EXPECT_NE(alloc, nullptr) << label << ": CreatePreferredAllocators() must not return null entries.";
+  }
+
+  auto allocators2 = ep.CreatePreferredAllocators();
+  EXPECT_EQ(allocators.size(), allocators2.size())
+      << label << ": CreatePreferredAllocators() must be repeatable (documented as stateless).";
+}
+
+// Invariant: each CPU-accessible preferred allocator hands back usable memory: a
+// non-zero allocation yields a non-null, host-writable and -readable pointer that can
+// be freed. Device allocators are intentionally excluded here -- their raw Alloc/Free
+// lifecycle is backend-specific -- and are covered by
+// CheckPreferredAllocatorsAreNonNullAndRepeatable instead.
+inline void CheckPreferredAllocatorsAllocateUsableMemory(IExecutionProvider& ep, std::string_view label) {
+  auto allocators = ep.CreatePreferredAllocators();
+  if (allocators.empty()) {
+    GTEST_SKIP() << label << " EP exposes no preferred allocators.";
+  }
+
+  constexpr size_t kBytes = 256;
+  size_t exercised = 0;
+  for (const auto& alloc : allocators) {
+    ASSERT_NE(alloc, nullptr);
+
+    // Standalone Alloc()/Free() is only a backend-agnostic contract for
+    // CPU-accessible allocators. A device allocator may hand out memory with a
+    // backend-specific lifecycle that this test cannot drive: e.g. the WebGPU
+    // GpuBufferAllocator creates buffers mapped at creation that must be unmapped
+    // through the buffer manager before Free(), so Free()-ing a freshly allocated
+    // buffer throws. Skip such allocators; they are covered by
+    // CheckPreferredAllocatorsAreNonNullAndRepeatable.
+    if (!alloc->Info().device.UsesCpuMemory()) {
+      continue;
+    }
+
+    void* p = alloc->Alloc(kBytes);
+    ASSERT_NE(p, nullptr) << label << ": Alloc(" << kBytes << ") returned null for allocator on "
+                          << alloc->Info().device.ToString();
+
+    std::memset(p, 0xAB, kBytes);
+    const auto* bytes = static_cast<const unsigned char*>(p);
+    EXPECT_EQ(bytes[0], 0xAB);
+    EXPECT_EQ(bytes[kBytes - 1], 0xAB);
+    alloc->Free(p);
+    ++exercised;
+  }
+
+  if (exercised == 0) {
+    GTEST_SKIP() << label << " EP exposes no CPU-accessible preferred allocator to exercise.";
+  }
+}
+
+// Invariant: GetDataTransfer() is optional (may be null). When provided, and it
+// advertises the ability to copy within a CPU-accessible device, a CopyTensor
+// round-trip must preserve the data exactly.
+inline void CheckDataTransferCpuRoundTripPreservesData(IExecutionProvider& ep, std::string_view label) {
+  auto data_transfer = ep.GetDataTransfer();
+  if (!data_transfer) {
+    GTEST_SKIP() << label << " EP provides no IDataTransfer (allowed by the contract).";
+  }
+
+  // Host the tensors on a CPU-accessible preferred allocator.
+  AllocatorPtr cpu_alloc;
+  for (auto& alloc : ep.CreatePreferredAllocators()) {
+    if (alloc && alloc->Info().device.UsesCpuMemory()) {
+      cpu_alloc = alloc;
+      break;
+    }
+  }
+  if (!cpu_alloc) {
+    GTEST_SKIP() << label << " EP has no CPU-accessible allocator to drive the round-trip.";
+  }
+
+  const OrtDevice& cpu_device = cpu_alloc->Info().device;
+  if (!data_transfer->CanCopy(cpu_device, cpu_device)) {
+    GTEST_SKIP() << label << " EP data transfer does not advertise CPU<->CPU copy.";
+  }
+
+  const TensorShape shape({2, 3});
+  Tensor src(DataTypeImpl::GetType<float>(), shape, cpu_alloc);
+  Tensor dst(DataTypeImpl::GetType<float>(), shape, cpu_alloc);
+
+  const float values[] = {1.f, -2.f, 3.5f, 4.f, 5.f, -6.25f};
+  constexpr size_t kNumValues = sizeof(values) / sizeof(values[0]);
+  ASSERT_EQ(static_cast<size_t>(shape.Size()), kNumValues);
+  std::memcpy(src.MutableDataRaw(), values, sizeof(values));
+  std::memset(dst.MutableDataRaw(), 0, sizeof(values));
+
+  ASSERT_TRUE(data_transfer->CopyTensor(src, dst).IsOK()) << label << ": CopyTensor failed for a CPU<->CPU copy.";
+  EXPECT_EQ(std::memcmp(src.DataRaw(), dst.DataRaw(), sizeof(values)), 0)
+      << label << ": a CPU round-trip CopyTensor must preserve data exactly.";
+}
+
+// Invariant: read-only metadata queries are callable and self-consistent on a
+// freshly constructed EP (no session or logger required), and the device-id accessor
+// agrees with GetDevice().
+inline void CheckMetadataQueriesAreCallable(IExecutionProvider& ep, std::string_view label) {
+  EXPECT_EQ(ep.GetDeviceId(), ep.GetDevice().Id()) << label << ": GetDeviceId() must agree with GetDevice().Id().";
+
+  // These must simply be callable without crashing on a bare EP instance.
+  (void)ep.ConcurrentRunSupported();
+  (void)ep.GetTuningContext();
+  (void)ep.GetOrtDeviceByMemType(OrtMemTypeDefault);
+  (void)ep.IsGraphCaptureEnabled();
+  (void)ep.ShouldConvertDataLayoutForOp(/*domain*/ "", /*op_type*/ "Conv", ep.GetPreferredLayout());
+}
+
+// Invariant: GetGraphCaptureNodeAssignmentPolicy() returns one of the defined
+// OrtGraphCaptureNodeAssignmentPolicy values. The session dispatches on this while
+// validating a graph for capture, so an out-of-range value is a bug. This is a pure
+// query and is valid to call on every EP regardless of whether graph capture is
+// enabled.
+inline void CheckGraphCaptureNodeAssignmentPolicyIsValid(IExecutionProvider& ep, std::string_view label) {
+  const OrtGraphCaptureNodeAssignmentPolicy policy = ep.GetGraphCaptureNodeAssignmentPolicy();
+  EXPECT_TRUE(policy == OrtGraphCaptureNodeAssignmentPolicy_ALL_NODES_ON_EP ||
+              policy == OrtGraphCaptureNodeAssignmentPolicy_ALLOW_CPU_FOR_SHAPES)
+      << label << ": GetGraphCaptureNodeAssignmentPolicy() returned an unknown policy value.";
+}
+
+// Invariant: GetOrtEp() reflects the provider kind. A built-in EP returns no backing
+// OrtEp; a PluginExecutionProvider returns the same non-null backing OrtEp across
+// repeated queries.
+inline void CheckGetOrtEpMatchesProviderKind(IExecutionProvider& ep, bool expects_plugin_ep, std::string_view label) {
+  const OrtEp* ort_ep = ep.GetOrtEp();
+  if (expects_plugin_ep) {
+    ASSERT_NE(ort_ep, nullptr) << label << ": a plugin EP must report its backing OrtEp.";
+    EXPECT_EQ(ep.GetOrtEp(), ort_ep) << label << ": a plugin EP must report a stable backing OrtEp.";
+  } else {
+    EXPECT_EQ(ort_ep, nullptr)
+        << label << ": a built-in EP must not report a backing OrtEp (that is reserved for plugin EPs).";
+  }
+}
+
+// Invariant: GetEpContextNodes() reports no nodes on a freshly constructed EP. EPs
+// populate this only when generating an EPContext cache model during compilation;
+// with no compilation performed, the documented default is empty.
+inline void CheckEpContextNodesEmptyOnFreshEp(IExecutionProvider& ep, std::string_view label) {
+  EXPECT_TRUE(ep.GetEpContextNodes().empty())
+      << label << ": a fresh EP (no compilation performed) must report no EPContext nodes.";
+}
+
+// Invariant: every preferred allocator reports self-consistent OrtMemoryInfo -- a
+// non-empty name and a valid allocator type. This metadata keys allocator lookup in
+// the framework, so it must be well-formed for every EP. Only the backend-agnostic
+// fields are checked; the raw memory is not touched here.
+inline void CheckPreferredAllocatorInfoIsConsistent(IExecutionProvider& ep, std::string_view label) {
+  for (const auto& alloc : ep.CreatePreferredAllocators()) {
+    ASSERT_NE(alloc, nullptr) << label << ": CreatePreferredAllocators() must not return null entries.";
+    const OrtMemoryInfo& info = alloc->Info();
+    EXPECT_FALSE(info.name.empty()) << label << ": allocator OrtMemoryInfo.name must not be empty.";
+    EXPECT_NE(info.alloc_type, OrtInvalidAllocator)
+        << label << ": allocator must report a valid OrtAllocatorType (not OrtInvalidAllocator).";
+  }
+}
+
+}  // namespace ep_conformance
+}  // namespace test
+}  // namespace onnxruntime

--- a/onnxruntime/test/util/include/ep_conformance_invariants.h
+++ b/onnxruntime/test/util/include/ep_conformance_invariants.h
@@ -5,7 +5,7 @@
 
 // Shared Execution Provider conformance invariants.
 //
-// These free functions encode the backend-agnostic invariants that EVERY
+// These free functions encode the backend-agnostic invariants that every
 // execution provider is expected to satisfy. They are the single source of truth
 // shared by two suites so the internal-interface and plugin-interface checks
 // cannot drift apart:
@@ -78,7 +78,8 @@ inline void CheckCpuMemTypesMapToCpuAccessibleDevice(IExecutionProvider& ep, std
 
 // Invariant: CreatePreferredAllocators() never yields a null allocator and is
 // repeatable. The header documents it as a stateless factory, so a second call must
-// produce an equivalently-sized set.
+// produce the same set of allocators -- same count, and the same OrtMemoryInfo per
+// position -- not merely an equally-sized one.
 inline void CheckPreferredAllocatorsAreNonNullAndRepeatable(IExecutionProvider& ep, std::string_view label) {
   auto allocators = ep.CreatePreferredAllocators();
   for (const auto& alloc : allocators) {
@@ -86,8 +87,20 @@ inline void CheckPreferredAllocatorsAreNonNullAndRepeatable(IExecutionProvider& 
   }
 
   auto allocators2 = ep.CreatePreferredAllocators();
-  EXPECT_EQ(allocators.size(), allocators2.size())
+  for (const auto& alloc : allocators2) {
+    EXPECT_NE(alloc, nullptr)
+        << label << ": CreatePreferredAllocators() must not return null entries on a repeat call.";
+  }
+
+  ASSERT_EQ(allocators.size(), allocators2.size())
       << label << ": CreatePreferredAllocators() must be repeatable (documented as stateless).";
+
+  for (size_t i = 0; i < allocators.size(); ++i) {
+    if (!allocators[i] || !allocators2[i]) continue;
+    EXPECT_TRUE(allocators[i]->Info() == allocators2[i]->Info())
+        << label << ": CreatePreferredAllocators() must report stable OrtMemoryInfo across calls ("
+        << allocators[i]->Info().ToString() << " vs " << allocators2[i]->Info().ToString() << ").";
+  }
 }
 
 // Invariant: each CPU-accessible preferred allocator hands back usable memory: a
@@ -95,6 +108,8 @@ inline void CheckPreferredAllocatorsAreNonNullAndRepeatable(IExecutionProvider& 
 // be freed. Device allocators are intentionally excluded here -- their raw Alloc/Free
 // lifecycle is backend-specific -- and are covered by
 // CheckPreferredAllocatorsAreNonNullAndRepeatable instead.
+//
+// May GTEST_SKIP(): invoke as the LAST statement of the test body (see file header).
 inline void CheckPreferredAllocatorsAllocateUsableMemory(IExecutionProvider& ep, std::string_view label) {
   auto allocators = ep.CreatePreferredAllocators();
   if (allocators.empty()) {
@@ -135,9 +150,11 @@ inline void CheckPreferredAllocatorsAllocateUsableMemory(IExecutionProvider& ep,
 }
 
 // Invariant: GetDataTransfer() is optional (may be null). When provided, and it
-// advertises the ability to copy within a CPU-accessible device, a CopyTensor
-// round-trip must preserve the data exactly.
-inline void CheckDataTransferCpuRoundTripPreservesData(IExecutionProvider& ep, std::string_view label) {
+// advertises the ability to copy within a CPU-accessible device, a CPU-to-CPU
+// CopyTensor must preserve the data exactly.
+//
+// May GTEST_SKIP(): invoke as the LAST statement of the test body (see file header).
+inline void CheckDataTransferCpuCopyPreservesData(IExecutionProvider& ep, std::string_view label) {
   auto data_transfer = ep.GetDataTransfer();
   if (!data_transfer) {
     GTEST_SKIP() << label << " EP provides no IDataTransfer (allowed by the contract).";
@@ -152,7 +169,7 @@ inline void CheckDataTransferCpuRoundTripPreservesData(IExecutionProvider& ep, s
     }
   }
   if (!cpu_alloc) {
-    GTEST_SKIP() << label << " EP has no CPU-accessible allocator to drive the round-trip.";
+    GTEST_SKIP() << label << " EP has no CPU-accessible allocator to drive the copy.";
   }
 
   const OrtDevice& cpu_device = cpu_alloc->Info().device;
@@ -172,16 +189,18 @@ inline void CheckDataTransferCpuRoundTripPreservesData(IExecutionProvider& ep, s
 
   ASSERT_TRUE(data_transfer->CopyTensor(src, dst).IsOK()) << label << ": CopyTensor failed for a CPU<->CPU copy.";
   EXPECT_EQ(std::memcmp(src.DataRaw(), dst.DataRaw(), sizeof(values)), 0)
-      << label << ": a CPU round-trip CopyTensor must preserve data exactly.";
+      << label << ": a CPU-to-CPU CopyTensor must preserve data exactly.";
 }
 
-// Invariant: read-only metadata queries are callable and self-consistent on a
-// freshly constructed EP (no session or logger required), and the device-id accessor
-// agrees with GetDevice().
-inline void CheckMetadataQueriesAreCallable(IExecutionProvider& ep, std::string_view label) {
-  EXPECT_EQ(ep.GetDeviceId(), ep.GetDevice().Id()) << label << ": GetDeviceId() must agree with GetDevice().Id().";
-
+// Invariant: read-only metadata queries are callable on a freshly constructed EP (no
+// session or logger required). GetDeviceId() is a provider-defined identifier that is
+// deliberately NOT required to equal GetDevice().Id() -- e.g. WebGPU returns a
+// configurable context id while its OrtDevice id is fixed at 0 -- so it is only
+// smoke-called here, never asserted against GetDevice().
+inline void CheckMetadataQueriesAreCallable(IExecutionProvider& ep, [[maybe_unused]] std::string_view label) {
   // These must simply be callable without crashing on a bare EP instance.
+  (void)ep.GetDeviceId();
+  (void)ep.GetDevice();
   (void)ep.ConcurrentRunSupported();
   (void)ep.GetTuningContext();
   (void)ep.GetOrtDeviceByMemType(OrtMemTypeDefault);
@@ -223,15 +242,16 @@ inline void CheckEpContextNodesEmptyOnFreshEp(IExecutionProvider& ep, std::strin
       << label << ": a fresh EP (no compilation performed) must report no EPContext nodes.";
 }
 
-// Invariant: every preferred allocator reports self-consistent OrtMemoryInfo -- a
-// non-empty name and a valid allocator type. This metadata keys allocator lookup in
-// the framework, so it must be well-formed for every EP. Only the backend-agnostic
-// fields are checked; the raw memory is not touched here.
+// Invariant: every preferred allocator reports a valid allocator type in its
+// OrtMemoryInfo. This metadata keys allocator lookup in the framework, so it must be
+// well-formed for every EP. The allocator name is intentionally NOT asserted: an
+// empty OrtMemoryInfo.name is permitted by the contract, so requiring a non-empty one
+// would over-state it. Only the backend-agnostic fields are checked; the raw memory
+// is not touched here.
 inline void CheckPreferredAllocatorInfoIsConsistent(IExecutionProvider& ep, std::string_view label) {
   for (const auto& alloc : ep.CreatePreferredAllocators()) {
     ASSERT_NE(alloc, nullptr) << label << ": CreatePreferredAllocators() must not return null entries.";
     const OrtMemoryInfo& info = alloc->Info();
-    EXPECT_FALSE(info.name.empty()) << label << ": allocator OrtMemoryInfo.name must not be empty.";
     EXPECT_NE(info.alloc_type, OrtInvalidAllocator)
         << label << ": allocator must report a valid OrtAllocatorType (not OrtInvalidAllocator).";
   }


### PR DESCRIPTION
### Description

Adds shared, executable conformance checks for both ONNX Runtime execution-provider integration paths:

1. **Built-in/in-tree EPs** through the internal `IExecutionProvider` interface.
2. **Out-of-tree plugin EPs** through the public `OrtEp` / `OrtEpFactory` ABI, reached end-to-end via `PluginExecutionProvider` after dynamically loading the plugin library.

The backend-agnostic invariants live in one header and are reused by both suites so their expectations cannot drift apart.

### Files

- `onnxruntime/test/util/include/ep_conformance_invariants.h`
  - Single source of truth for the shared invariant checks.
- `onnxruntime/test/framework/execution_provider_conformance_test.cc`
  - Parameterized built-in EP suite (`EpContract/EpConformanceTest`).
- `onnxruntime/test/providers/ep_conformance_plugin_test.cc`
  - Dynamic plugin suite (`EpPluginConformanceTest`) compiled into `onnxruntime_provider_test`.

### Coverage

The built-in suite always covers the CPU EP in arena and non-arena configurations. CUDA, DML, WebGPU, and XNNPACK are registered behind their build guards. A factory that returns `nullptr` (for example, an EP compiled but unavailable on the current machine) skips the affected test instead of failing.

The plugin suite runs against whichever plugin initializes the existing dynamic-plugin test infrastructure. This includes:

- in-repo example plugin EPs;
- ORT EPs routed through the plugin API adapters, such as CUDA or WebGPU;
- external plugin EPs selected with `ORT_UNIT_TEST_MAIN_DYNAMIC_PLUGIN_EP_CONFIG_JSON` or `ORT_UNIT_TEST_MAIN_DYNAMIC_PLUGIN_EP_CONFIG_JSON_FILE`.

If no plugin is configured, the plugin tests skip cleanly.

### Invariants enforced

1. `Type()` is non-empty and stable across calls and independent instances.
2. `GetPreferredLayout()` returns a defined layout (`NCHW` or `NHWC`).
3. CPU input/output memory types map to CPU-accessible devices.
4. `CreatePreferredAllocators()` returns no null entries and is repeatable.
5. CPU-accessible preferred allocators return usable, writable memory that can be freed.
6. An advertised CPU-to-CPU `IDataTransfer` round trip preserves bytes exactly.
7. Metadata queries are callable on a fresh EP and `GetDeviceId()` agrees with `GetDevice().Id()`.
8. `GetGraphCaptureNodeAssignmentPolicy()` returns a defined policy value.
9. `GetOrtEp()` matches provider kind: built-in EPs return `nullptr`; plugin EPs return a stable, non-null backing `OrtEp`.
10. `GetEpContextNodes()` is empty before any compilation has occurred.
11. Preferred allocators report well-formed `OrtMemoryInfo` (non-empty name and valid allocator type).

Only documented, backend-agnostic behavior is asserted. Non-CPU-accessible memory is never dereferenced by the test thread; backend-specific operations are skipped when their portable preconditions are unavailable.

### Why this change matters

ONNX Runtime relies on more than 20 execution providers being substitutable behind a common framework contract, while external EP authors are expected to implement the public plugin ABI. Previously, the assumptions shared by those paths were implicit: distributed across interface comments, adapter logic, and downstream framework code.

That creates three recurring costs:

- **Contract drift:** an EP can return invalid layout/device/allocator metadata and fail later in an unrelated framework path.
- **External authoring cost:** plugin authors must reverse-engineer the behavior ORT expects beyond function signatures.
- **Regression risk:** changes to allocators, device mapping, data transfer, or the plugin adapter can silently violate a shared assumption.

These suites turn the common baseline into an executable checklist and exercise the plugin ABI through the same adapter path used in production.

### Running against an external plugin EP

Build `onnxruntime_provider_test`, point the dynamic-plugin test infrastructure at the plugin library, and run only the plugin conformance suite. For example:

```bash
export ORT_UNIT_TEST_MAIN_DYNAMIC_PLUGIN_EP_CONFIG_JSON='{
  "ep_library_registration_name": "ExampleExecutionProvider",
  "ep_library_path": "/absolute/path/to/libexample_ep.dylib",
  "selected_ep_name": "ExampleExecutionProvider"
}'

./onnxruntime_provider_test --gtest_filter='EpPluginConformanceTest.*'
```

The registration and selected EP names must match the names exposed by the plugin factory.

### Testing

Local Windows RelWithDebInfo validation:

```text
[==========] 22 tests from 1 test suite ran.
[  PASSED  ] 22 tests.
```

This is 11 shared invariants across the CPU arena and non-arena configurations. Plugin-enabled CI jobs run the same invariant set through the dynamically loaded plugin path; unsupported backend-specific portions skip rather than fail.

External plugin validation on macOS 14 / Apple Silicon:

- Plugin: `onnxruntime-ep-mlx==0.3.0` (`MLXExecutionProvider`, public plugin ABI version 27).
- Test binary: `onnxruntime_provider_test` built from this PR (ORT API version 28).
- Result: [ad hoc MLX validation run](https://github.com/microsoft/onnxruntime/actions/runs/29621769280) completed successfully.

```text
[==========] 11 tests from 1 test suite ran. (37 ms total)
[  PASSED  ] 9 tests.
[  SKIPPED ] 2 tests.
```

The two skips are expected and contract-valid: MLX exposes no preferred allocator to exercise directly and no `IDataTransfer`. All applicable shared invariants passed, including plugin identity/lifetime (`GetOrtEp()`), layout/device metadata, graph-capture policy, and fresh-EP state.

### Relationship to EP capability segregation (#29087)

This PR validates the baseline behavior common to every EP. It intentionally does not infer support for optional capabilities from legacy default virtual methods.

#29087 adds explicit capability-query hooks. If that work lands, capability-specific conformance checks (graph capture, tuning, compilation, and data-layout decisions) can be added only for EPs that advertise the corresponding capability. The PRs remain independent: this suite does not require #29087, and #29087 does not require this suite.
