### PR TITLE
Fix CCCL header-ordering parse error on CUDA 13.x

### DIFF
--- a/onnxruntime/core/providers/cuda/cu_inc/cub.cuh
+++ b/onnxruntime/core/providers/cuda/cu_inc/cub.cuh
@@ -13,6 +13,17 @@
 #undef __out
 #endif
 
+// Workaround for CCCL (CUDA 13.x) header-ordering issue:
+// <cub/device/device_transform.cuh> specializes cuda::proclaims_copyable_arguments,
+// whose primary template lives in <cuda/__functional/address_stability.h>.
+// Under some CUDA 13.x toolkits the cub umbrella reaches device_transform.cuh
+// before address_stability.h, causing a cudafe++ parse error on the
+// specialization (`global qualification of class name is invalid before ':'`).
+// Force the primary template to be visible first.
+#if defined(__CUDACC_VER_MAJOR__) && (__CUDACC_VER_MAJOR__ >= 13)
+#include <cuda/__functional/address_stability.h>
+#endif
+
 #include <cub/cub.cuh>
 
 #if defined(_MSC_VER)


### PR DESCRIPTION
Under CUDA 13.x toolkits the cub umbrella include reaches <cub/device/device_transform.cuh> before
<cuda/__functional/address_stability.h>. The former specializes cuda::proclaims_copyable_arguments, whose primary template is declared in the latter. With CCCL 3.x cudafe++ rejects the specialization with:

  error: global qualification of class name is invalid before ':' token
  struct ::cuda::proclaims_copyable_arguments<...> : ::cuda::std::true_type

The symptom shows up as a build failure in any TU that pulls the cub wrapper from ORT (e.g. contrib_ops/cuda/math/bias_softmax_impl.cu and contrib_ops/cuda/moe/ft_moe/moe_kernel.cu in 1.26.x), under CUDA >= 13.3.

Force-include the address_stability header in the ORT cub wrapper for CUDA >= 13, so the primary template is visible before any cub header specializes it. No runtime behavior change.

### Description
<!-- Describe your changes. -->



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


