### PR TITLE
Fix OOB pointer in TensorAt for sub-byte packed types

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -3007,7 +3007,7 @@ struct OrtApi {
    * For example, given a tensor with shape of [3,224,224], a pointer to the element at location [2,150,128] can be retrieved
    *
    * This function only works for numeric type tensors (No strings, etc).
-   * This function does not support sub-byte packed types (e.g., int4). 
+   * This function does not support sub-byte packed types (e.g., int4).
    * This is a no-copy method whose returned pointer is valid until the passed in ::OrtValue is free'd.
    *
    * \param[in] value

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -3007,6 +3007,7 @@ struct OrtApi {
    * For example, given a tensor with shape of [3,224,224], a pointer to the element at location [2,150,128] can be retrieved
    *
    * This function only works for numeric type tensors (No strings, etc).
+   * This function does not support sub-byte packed types (e.g., int4). 
    * This is a no-copy method whose returned pointer is valid until the passed in ::OrtValue is free'd.
    *
    * \param[in] value

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -2540,6 +2540,13 @@ ORT_API_STATUS_IMPL(OrtApis::TensorAt, _Inout_ OrtValue* value, const int64_t* l
     return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, "this API does not support strings");
   }
 
+  const auto* prim_type = tensor->DataType()->AsPrimitiveDataType();
+  if (prim_type != nullptr && prim_type->HasSubElems()) {
+    return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT,
+                                 "this API does not support sub-byte packed types (e.g., int4). "
+                                 "Use OrtValue::GetTensorMutableData and manual unpacking instead.");
+  }
+
   const auto& tensor_shape = tensor->Shape();
   const auto num_dimensions = tensor_shape.NumDimensions();
   if (location_values_count != num_dimensions) {

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -3110,7 +3110,13 @@ TEST(CApiTest, tensor_at_rejects_subbyte_types) {
     std::vector<int64_t> dims = {7};
     Ort::Value tensor = Ort::Value::CreateTensor(info, values.data(), values.size(), dims.data(), dims.size(),
                                                  ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_INT4);
-    ASSERT_THROW(tensor.At<uint8_t>({0}), Ort::Exception);
+    try {
+      tensor.At<uint8_t>({0});
+      FAIL() << "Expected TensorAt to reject int4 sub-byte packed type";
+    } catch (const Ort::Exception& excpt) {
+      EXPECT_EQ(excpt.GetOrtErrorCode(), ORT_INVALID_ARGUMENT);
+      EXPECT_THAT(excpt.what(), testing::HasSubstr("does not support sub-byte packed types"));
+    }
   }
 
   // UInt4: 7 logical elements packed into 4 bytes
@@ -3119,40 +3125,42 @@ TEST(CApiTest, tensor_at_rejects_subbyte_types) {
     std::vector<int64_t> dims = {7};
     Ort::Value tensor = Ort::Value::CreateTensor(info, values.data(), values.size(), dims.data(), dims.size(),
                                                  ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT4);
-    ASSERT_THROW(tensor.At<uint8_t>({0}), Ort::Exception);
+    try {
+      tensor.At<uint8_t>({0});
+      FAIL() << "Expected TensorAt to reject uint4 sub-byte packed type";
+    } catch (const Ort::Exception& excpt) {
+      EXPECT_EQ(excpt.GetOrtErrorCode(), ORT_INVALID_ARGUMENT);
+      EXPECT_THAT(excpt.what(), testing::HasSubstr("does not support sub-byte packed types"));
+    }
   }
 }
 
-// Regression: TensorAt still works correctly for normal (non-sub-byte) types.
-TEST(CApiTest, tensor_at_normal_types_still_work) {
+// TensorAt provides direct element access for normal (non-sub-byte) types.
+TEST(CApiTest, tensor_at_with_data_float) {
   Ort::MemoryInfo info("Cpu", OrtDeviceAllocator, 0, OrtMemTypeDefault);
+  std::vector<float> values = {1.0f, 2.0f, 3.0f, 4.0f};
+  std::vector<int64_t> dims = {4};
+  Ort::Value tensor = Ort::Value::CreateTensor<float>(info, values.data(), values.size(), dims.data(), dims.size());
+  ASSERT_EQ(1.0f, tensor.At<float>({0}));
+  ASSERT_EQ(4.0f, tensor.At<float>({3}));
+}
 
-  // float
-  {
-    std::vector<float> values = {1.0f, 2.0f, 3.0f, 4.0f};
-    std::vector<int64_t> dims = {4};
-    Ort::Value tensor = Ort::Value::CreateTensor<float>(info, values.data(), values.size(), dims.data(), dims.size());
-    ASSERT_EQ(1.0f, tensor.At<float>({0}));
-    ASSERT_EQ(4.0f, tensor.At<float>({3}));
-  }
+TEST(CApiTest, tensor_at_with_data_int32) {
+  Ort::MemoryInfo info("Cpu", OrtDeviceAllocator, 0, OrtMemTypeDefault);
+  std::vector<int32_t> values = {10, 20, 30};
+  std::vector<int64_t> dims = {3};
+  Ort::Value tensor = Ort::Value::CreateTensor<int32_t>(info, values.data(), values.size(), dims.data(), dims.size());
+  ASSERT_EQ(10, tensor.At<int32_t>({0}));
+  ASSERT_EQ(30, tensor.At<int32_t>({2}));
+}
 
-  // int32_t
-  {
-    std::vector<int32_t> values = {10, 20, 30};
-    std::vector<int64_t> dims = {3};
-    Ort::Value tensor = Ort::Value::CreateTensor<int32_t>(info, values.data(), values.size(), dims.data(), dims.size());
-    ASSERT_EQ(10, tensor.At<int32_t>({0}));
-    ASSERT_EQ(30, tensor.At<int32_t>({2}));
-  }
-
-  // int8_t
-  {
-    std::vector<int8_t> values = {-1, 0, 1, 127};
-    std::vector<int64_t> dims = {4};
-    Ort::Value tensor = Ort::Value::CreateTensor<int8_t>(info, values.data(), values.size(), dims.data(), dims.size());
-    ASSERT_EQ(-1, tensor.At<int8_t>({0}));
-    ASSERT_EQ(127, tensor.At<int8_t>({3}));
-  }
+TEST(CApiTest, tensor_at_with_data_int8) {
+  Ort::MemoryInfo info("Cpu", OrtDeviceAllocator, 0, OrtMemTypeDefault);
+  std::vector<int8_t> values = {-1, 0, 1, 127};
+  std::vector<int64_t> dims = {4};
+  Ort::Value tensor = Ort::Value::CreateTensor<int8_t>(info, values.data(), values.size(), dims.data(), dims.size());
+  ASSERT_EQ(-1, tensor.At<int8_t>({0}));
+  ASSERT_EQ(127, tensor.At<int8_t>({3}));
 }
 
 // Test that TensorAt bounds checking still rejects out-of-range indices for normal types.

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -3163,7 +3163,7 @@ TEST(CApiTest, tensor_at_with_data_int8) {
   ASSERT_EQ(127, tensor.At<int8_t>({3}));
 }
 
-// Test that TensorAt bounds checking still rejects out-of-range indices for normal types.
+// Test that TensorAt bounds checking rejects out-of-range indices for normal types.
 TEST(CApiTest, tensor_at_bounds_check) {
   Ort::MemoryInfo info("Cpu", OrtDeviceAllocator, 0, OrtMemTypeDefault);
 

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -3123,6 +3123,60 @@ TEST(CApiTest, tensor_at_rejects_subbyte_types) {
   }
 }
 
+// Regression: TensorAt still works correctly for normal (non-sub-byte) types.
+TEST(CApiTest, tensor_at_normal_types_still_work) {
+  Ort::MemoryInfo info("Cpu", OrtDeviceAllocator, 0, OrtMemTypeDefault);
+
+  // float
+  {
+    std::vector<float> values = {1.0f, 2.0f, 3.0f, 4.0f};
+    std::vector<int64_t> dims = {4};
+    Ort::Value tensor = Ort::Value::CreateTensor<float>(info, values.data(), values.size(), dims.data(), dims.size());
+    ASSERT_EQ(1.0f, tensor.At<float>({0}));
+    ASSERT_EQ(4.0f, tensor.At<float>({3}));
+  }
+
+  // int32_t
+  {
+    std::vector<int32_t> values = {10, 20, 30};
+    std::vector<int64_t> dims = {3};
+    Ort::Value tensor = Ort::Value::CreateTensor<int32_t>(info, values.data(), values.size(), dims.data(), dims.size());
+    ASSERT_EQ(10, tensor.At<int32_t>({0}));
+    ASSERT_EQ(30, tensor.At<int32_t>({2}));
+  }
+
+  // int8_t
+  {
+    std::vector<int8_t> values = {-1, 0, 1, 127};
+    std::vector<int64_t> dims = {4};
+    Ort::Value tensor = Ort::Value::CreateTensor<int8_t>(info, values.data(), values.size(), dims.data(), dims.size());
+    ASSERT_EQ(-1, tensor.At<int8_t>({0}));
+    ASSERT_EQ(127, tensor.At<int8_t>({3}));
+  }
+}
+
+// Test that TensorAt bounds checking still rejects out-of-range indices for normal types.
+TEST(CApiTest, tensor_at_bounds_check) {
+  Ort::MemoryInfo info("Cpu", OrtDeviceAllocator, 0, OrtMemTypeDefault);
+
+  std::vector<float> values = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
+  std::vector<int64_t> dims = {2, 3};
+  Ort::Value tensor = Ort::Value::CreateTensor<float>(info, values.data(), values.size(), dims.data(), dims.size());
+
+  // Valid access works
+  ASSERT_EQ(1.0f, tensor.At<float>({0, 0}));
+  ASSERT_EQ(6.0f, tensor.At<float>({1, 2}));
+
+  // Out-of-range indices throw
+  ASSERT_THROW(tensor.At<float>({2, 0}), Ort::Exception);   // row out of range
+  ASSERT_THROW(tensor.At<float>({0, 3}), Ort::Exception);   // col out of range
+  ASSERT_THROW(tensor.At<float>({-1, 0}), Ort::Exception);  // negative index
+
+  // Wrong number of dimensions throws
+  ASSERT_THROW(tensor.At<float>({0}), Ort::Exception);
+  ASSERT_THROW(tensor.At<float>({0, 0, 0}), Ort::Exception);
+}
+
 TEST(CApiTest, access_tensor_data_elements) {
   /**
    * Create a 2x3 data blob that looks like:

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -3079,9 +3079,6 @@ TEST(CApiTest, create_tensor_with_data_int4) {
   auto query_dims = tensor_info.GetShape();
   ASSERT_EQ(query_dims, dims);
   ASSERT_EQ(tensor_info.GetElementType(), ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_INT4);
-
-  uint8_t pair_2 = tensor.At<uint8_t>({2});
-  ASSERT_EQ(values[2], pair_2);
 }
 
 // Test creating an Ort::Value with UINT4 data.
@@ -3101,9 +3098,29 @@ TEST(CApiTest, create_tensor_with_data_uint4) {
   auto query_dims = tensor_info.GetShape();
   ASSERT_EQ(query_dims, dims);
   ASSERT_EQ(tensor_info.GetElementType(), ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT4);
+}
 
-  uint8_t pair_2 = tensor.At<uint8_t>({2});
-  ASSERT_EQ(values[2], pair_2);
+// Test that TensorAt rejects sub-byte packed types to prevent OOB pointer returns.
+TEST(CApiTest, tensor_at_rejects_subbyte_types) {
+  Ort::MemoryInfo info("Cpu", OrtDeviceAllocator, 0, OrtMemTypeDefault);
+
+  // Int4: 7 logical elements packed into 4 bytes
+  {
+    std::array<uint8_t, 4> values = {0x10, 0x32, 0x78, 0x06};
+    std::vector<int64_t> dims = {7};
+    Ort::Value tensor = Ort::Value::CreateTensor(info, values.data(), values.size(), dims.data(), dims.size(),
+                                                 ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_INT4);
+    ASSERT_THROW(tensor.At<uint8_t>({0}), Ort::Exception);
+  }
+
+  // UInt4: 7 logical elements packed into 4 bytes
+  {
+    std::array<uint8_t, 4> values = {0x10, 0x32, 0x54, 0x0F};
+    std::vector<int64_t> dims = {7};
+    Ort::Value tensor = Ort::Value::CreateTensor(info, values.data(), values.size(), dims.data(), dims.size(),
+                                                 ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT4);
+    ASSERT_THROW(tensor.At<uint8_t>({0}), Ort::Exception);
+  }
 }
 
 TEST(CApiTest, access_tensor_data_elements) {

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -3175,14 +3175,24 @@ TEST(CApiTest, tensor_at_bounds_check) {
   ASSERT_EQ(1.0f, tensor.At<float>({0, 0}));
   ASSERT_EQ(6.0f, tensor.At<float>({1, 2}));
 
+  auto expect_at_throws = [&tensor](const std::vector<int64_t>& location, const std::string& expected_message) {
+    try {
+      tensor.At<float>(location);
+      FAIL() << "Expected TensorAt to throw for the given location";
+    } catch (const Ort::Exception& excpt) {
+      EXPECT_EQ(excpt.GetOrtErrorCode(), ORT_INVALID_ARGUMENT);
+      EXPECT_THAT(excpt.what(), testing::HasSubstr(expected_message));
+    }
+  };
+
   // Out-of-range indices throw
-  ASSERT_THROW(tensor.At<float>({2, 0}), Ort::Exception);   // row out of range
-  ASSERT_THROW(tensor.At<float>({0, 3}), Ort::Exception);   // col out of range
-  ASSERT_THROW(tensor.At<float>({-1, 0}), Ort::Exception);  // negative index
+  expect_at_throws({2, 0}, "invalid location range");   // row out of range
+  expect_at_throws({0, 3}, "invalid location range");   // col out of range
+  expect_at_throws({-1, 0}, "invalid location range");  // negative index
 
   // Wrong number of dimensions throws
-  ASSERT_THROW(tensor.At<float>({0}), Ort::Exception);
-  ASSERT_THROW(tensor.At<float>({0, 0, 0}), Ort::Exception);
+  expect_at_throws({0}, "location dimensions do not match shape size");
+  expect_at_throws({0, 0, 0}, "location dimensions do not match shape size");
 }
 
 TEST(CApiTest, access_tensor_data_elements) {


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Reject sub-byte packed types with appropriate error message. The TensorAt API returns a void*, it fundamentally cannot point to a sub-byte element. The fix is to reject sub-byte types at the API boundary, similar to how strings are rejected. Tests have been updated to reflect the changes. 


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
TensorAt computed pointer offsets using logical element indices but Size() returns the byte size of the packed storage unit (1 byte for Int4x2/UInt4x2 which holds 2 elements). This caused out-of-bounds pointer returns when element indices exceeded the actual buffer size.

The API fundamentally cannot return a pointer to a sub-byte element, so reject sub-byte packed types with an appropriate error message, similar to how strings are already rejected.

