### PR TITLE
Encapsulate global random seed in a function

### DIFF
--- a/onnxruntime/core/framework/random_seed.cc
+++ b/onnxruntime/core/framework/random_seed.cc
@@ -9,23 +9,18 @@
 namespace onnxruntime {
 namespace utils {
 
-// "Global initializer calls a non-constexpr function."
-// TODO: Fix the warning. The variable should be put in the environment class.
-#if defined(_MSC_VER) && !defined(__clang__)
-#pragma warning(push)
-#pragma warning(disable : 26426)
-#endif
-static std::atomic<int64_t> g_random_seed(std::chrono::system_clock::now().time_since_epoch().count());
-#if defined(_MSC_VER) && !defined(__clang__)
-#pragma warning(pop)
-#endif
+static std::atomic<int64_t>& GetGlobalRandomSeed() {
+  static std::atomic<int64_t> g_random_seed(
+      std::chrono::system_clock::now().time_since_epoch().count());
+  return g_random_seed;
+}
 
 int64_t GetRandomSeed() {
-  return g_random_seed.load();
+  return GetGlobalRandomSeed().load();
 }
 
 void SetRandomSeed(int64_t seed) {
-  g_random_seed.store(seed);
+  GetGlobalRandomSeed().store(seed);
 
   // Reset default generators.
   RandomGenerator::Default().SetSeed(seed);


### PR DESCRIPTION
Refactor global random seed management to use a function for better encapsulation.

### Description
Convert the file-scope static to a function-local static in `GetGlobalRandomSeed()`, deferring initialization to first use.  No API or behavioral change; all callers use `GetRandomSeed()`/`SetRandomSeed()` which remain identical.



### Motivation and Context
The global `g_random_seed` was initialized via `std::chrono::system_clock::now()` at static construction time. When the ORT DLL is loaded dynamically (e.g., via `LoadLibraryExW` in the fuzzer), this triggers an ASan `initialization-order-fiasco`: ORT's `_GLOBAL__sub_I_random_seed.cc` calls `std::chrono::system_clock::now()` before libc++'s `chrono.cpp` globals (`GetSystemTimeAsFileTimeFunc`) are initialized.


