### PR TITLE
[CUDA] Optimize QMoE SoftmaxTopK router for small-batch decode

### DIFF
--- a/onnxruntime/contrib_ops/cuda/moe/moe.cc
+++ b/onnxruntime/contrib_ops/cuda/moe/moe.cc
@@ -55,6 +55,9 @@ Status MoE<T>::ComputeInternal(OpKernelContext* context) const {
       1,  //  no quantization so pack size is 1
       is_fused_swiglu,
       0));  // no block-wise quantization for regular MoE
+  ORT_RETURN_IF_NOT(k_ > 0 && k_ <= moe_params.num_experts,
+                    "MoE requires 0 < k <= num_experts, got k=", k_,
+                    " and num_experts=", moe_params.num_experts);
 
   using CudaT = typename OrtToCudaType<T>::type;
 

--- a/onnxruntime/contrib_ops/cuda/moe/moe_quantization.cc
+++ b/onnxruntime/contrib_ops/cuda/moe/moe_quantization.cc
@@ -317,6 +317,9 @@ Status QMoE::ComputeInternal(OpKernelContext* context) const {
       &fc2_shape, fc2_experts_bias_optional, fc2_scales, fc2_zeros,
       nullptr, nullptr, nullptr, nullptr,
       pack_size, is_fused_swiglu, block_size_));
+  ORT_RETURN_IF_NOT(k_ > 0 && k_ <= moe_params.num_experts,
+                    "QMoE requires 0 < k <= num_experts, got k=", k_,
+                    " and num_experts=", moe_params.num_experts);
 
   if (uses_fp4_weight_scales) {
     constexpr int64_t fp4_block_size = 32;

--- a/onnxruntime/contrib_ops/cuda/moe/qmoe_kernels.cu
+++ b/onnxruntime/contrib_ops/cuda/moe/qmoe_kernels.cu
@@ -261,7 +261,7 @@ __global__ void SoftmaxTopKWarpBitonicKernel(const T* logits, float* topk_scales
 // Warp CUB merge sort softmax + top-k for num_experts <= kBufferSize (64). One
 // warp (32 threads) per block sorts a row's logits held in shared memory. This
 // is the genai-recommended path for sort sizes in (32, 64]. Tie-breaking
-// matches SoftmaxTopKMergeKernel via ScoreIndexGreater.
+// matches SoftmaxTopKMergeKernel via a packed stable sort key.
 template <typename T, int kBufferSize>
 __global__ void SoftmaxTopKWarpMergeKernel(const T* logits, float* topk_scales, int* topk_indices,
                                            int num_rows, int num_experts, int k, bool normalize_scales) {

--- a/onnxruntime/contrib_ops/cuda/moe/qmoe_kernels.cu
+++ b/onnxruntime/contrib_ops/cuda/moe/qmoe_kernels.cu
@@ -6,6 +6,7 @@
 #include "core/common/narrow.h"
 #include "core/providers/cuda/cuda_common.h"
 #include "core/providers/cuda/cu_inc/cub.cuh"
+#include "core/providers/cuda/cu_inc/topk_warp_sort.cuh"
 #include "contrib_ops/cuda/llm/moe_gemm/moe_kernels.h"
 #include <cuda_bf16.h>
 #include <algorithm>
@@ -201,6 +202,131 @@ __global__ void SoftmaxTopKMergeKernel(const T* logits, float* topk_scales, int*
   }
 }
 
+// Warp-bitonic softmax + top-k for num_experts <= 32. Each warp handles one
+// row, with lane `l` owning expert `l`. The whole softmax reduction and the
+// sort are done with warp shuffles (no shared memory). This is the fastest path
+// for tiny expert counts per the onnxruntime-genai top-k benchmark. Tie-breaking
+// (equal scores prefer the lower expert index) matches SoftmaxTopKMergeKernel.
+template <typename T, int kWarpsPerBlock>
+__global__ void SoftmaxTopKWarpBitonicKernel(const T* logits, float* topk_scales, int* topk_indices,
+                                             int num_rows, int num_experts, int k, bool normalize_scales) {
+  constexpr int kWarpSize = onnxruntime::cuda::topk_warp::kWarpSize;
+  const int lane = threadIdx.x;
+  const int row = blockIdx.x * kWarpsPerBlock + threadIdx.y;
+  if (row >= num_rows) return;
+
+  const T* row_logits = logits + static_cast<size_t>(row) * num_experts;
+  const float logit = (lane < num_experts) ? static_cast<float>(row_logits[lane]) : -FLT_MAX;
+
+  // Warp-wide max for numerical stability.
+  float max_val = logit;
+#pragma unroll
+  for (int offset = kWarpSize / 2; offset > 0; offset >>= 1) {
+    max_val = fmaxf(max_val, __shfl_xor_sync(0xFFFFFFFF, max_val, offset));
+  }
+
+  // Warp-wide exp sum (softmax denominator over all experts).
+  float sum_exp = (lane < num_experts) ? expf(logit - max_val) : 0.0f;
+#pragma unroll
+  for (int offset = kWarpSize / 2; offset > 0; offset >>= 1) {
+    sum_exp += __shfl_xor_sync(0xFFFFFFFF, sum_exp, offset);
+  }
+  const float inv_sum = (sum_exp > 0.0f) ? (1.0f / sum_exp) : 0.0f;
+
+  // Sort (logit, expert index) descending; sorting by logit is equivalent to
+  // sorting by softmax probability since the mapping is monotonic.
+  float score = logit;
+  int index = (lane < num_experts) ? lane : INT_MAX;
+  onnxruntime::cuda::topk_warp::WarpBitonicSortDescending(score, index);
+
+  // Lane r now holds the rank-r element. Compute the top-k probabilities.
+  float prob = (lane < k) ? expf(score - max_val) * inv_sum : 0.0f;
+
+  if (normalize_scales) {
+    float scale_sum = prob;
+#pragma unroll
+    for (int offset = kWarpSize / 2; offset > 0; offset >>= 1) {
+      scale_sum += __shfl_xor_sync(0xFFFFFFFF, scale_sum, offset);
+    }
+    const float denom = (scale_sum > 1e-6f) ? scale_sum : 1.0f;
+    prob /= denom;
+  }
+
+  if (lane < k) {
+    topk_scales[static_cast<size_t>(row) * k + lane] = prob;
+    topk_indices[static_cast<size_t>(row) * k + lane] = index;
+  }
+}
+
+// Warp CUB merge sort softmax + top-k for num_experts <= kBufferSize (64). One
+// warp (32 threads) per block sorts a row's logits held in shared memory. This
+// is the genai-recommended path for sort sizes in (32, 64]. Tie-breaking
+// matches SoftmaxTopKMergeKernel via ScoreIndexGreater.
+template <typename T, int kBufferSize>
+__global__ void SoftmaxTopKWarpMergeKernel(const T* logits, float* topk_scales, int* topk_indices,
+                                           int num_rows, int num_experts, int k, bool normalize_scales) {
+  constexpr int kWarpSize = onnxruntime::cuda::topk_warp::kWarpSize;
+  using WarpMergeSorter = onnxruntime::cuda::topk_warp::WarpMergeSorter<kBufferSize>;
+
+  const int row = blockIdx.x;
+  if (row >= num_rows) return;
+  const int lane = threadIdx.x;
+
+  __shared__ float s_scores[kBufferSize];
+  __shared__ int s_indices[kBufferSize];
+  __shared__ typename WarpMergeSorter::TempStorage temp_storage;
+
+  const T* row_logits = logits + static_cast<size_t>(row) * num_experts;
+
+  // Load logits into shared memory and compute the warp-wide max.
+  float local_max = -FLT_MAX;
+  for (int i = lane; i < kBufferSize; i += kWarpSize) {
+    const float v = (i < num_experts) ? static_cast<float>(row_logits[i]) : -FLT_MAX;
+    s_scores[i] = v;
+    s_indices[i] = (i < num_experts) ? i : INT_MAX;
+    local_max = fmaxf(local_max, v);
+  }
+#pragma unroll
+  for (int offset = kWarpSize / 2; offset > 0; offset >>= 1) {
+    local_max = fmaxf(local_max, __shfl_xor_sync(0xFFFFFFFF, local_max, offset));
+  }
+  const float max_val = local_max;
+
+  // Warp-wide exp sum over all experts.
+  float local_sum = 0.0f;
+  for (int i = lane; i < num_experts; i += kWarpSize) {
+    local_sum += expf(s_scores[i] - max_val);
+  }
+#pragma unroll
+  for (int offset = kWarpSize / 2; offset > 0; offset >>= 1) {
+    local_sum += __shfl_xor_sync(0xFFFFFFFF, local_sum, offset);
+  }
+  const float inv_sum = (local_sum > 0.0f) ? (1.0f / local_sum) : 0.0f;
+
+  __syncwarp();
+  WarpMergeSorter::Sort(s_scores, s_indices, temp_storage, num_experts);
+  __syncwarp();
+
+  // s_scores[r]/s_indices[r] now hold the rank-r logit/expert index.
+  float scale_sum = 0.0f;
+  if (normalize_scales) {
+    for (int i = lane; i < k; i += kWarpSize) {
+      scale_sum += expf(s_scores[i] - max_val) * inv_sum;
+    }
+#pragma unroll
+    for (int offset = kWarpSize / 2; offset > 0; offset >>= 1) {
+      scale_sum += __shfl_xor_sync(0xFFFFFFFF, scale_sum, offset);
+    }
+  }
+  const float denom = (normalize_scales && scale_sum > 1e-6f) ? scale_sum : 1.0f;
+
+  for (int i = lane; i < k; i += kWarpSize) {
+    const float prob = expf(s_scores[i] - max_val) * inv_sum;
+    topk_scales[static_cast<size_t>(row) * k + i] = normalize_scales ? (prob / denom) : prob;
+    topk_indices[static_cast<size_t>(row) * k + i] = s_indices[i];
+  }
+}
+
 template <typename T>
 void DispatchSoftmaxTopK(const T* logits, float* topk_scales, int* topk_indices,
                          int num_rows, int num_experts, int k, bool normalize_scales,
@@ -210,7 +336,23 @@ void DispatchSoftmaxTopK(const T* logits, float* topk_scales, int* topk_indices,
   // num_experts. k must fit in s_topk (<= 64).
   const dim3 grid(static_cast<unsigned>(num_rows));
   if (k <= 64 && num_experts <= 1024) {
-    if (num_experts <= 128) {
+    // Tiny expert counts: a single warp sorts a row entirely in registers via
+    // an in-register bitonic sort (no shared memory). Multiple warps per block
+    // process multiple rows for better occupancy.
+    if (num_experts <= onnxruntime::cuda::topk_warp::kWarpBitonicMaxSize) {
+      constexpr int kWarpsPerBlock = 8;
+      const dim3 block(static_cast<unsigned>(onnxruntime::cuda::topk_warp::kWarpSize), kWarpsPerBlock);
+      const dim3 bitonic_grid(static_cast<unsigned>((num_rows + kWarpsPerBlock - 1) / kWarpsPerBlock));
+      SoftmaxTopKWarpBitonicKernel<T, kWarpsPerBlock><<<bitonic_grid, block, 0, stream>>>(
+          logits, topk_scales, topk_indices, num_rows, num_experts, k, normalize_scales);
+      return;
+    } else if (num_experts <= onnxruntime::cuda::topk_warp::kWarpMergeMaxSize) {
+      // Single warp per row sorts up to 64 logits in shared memory (CUB warp
+      // merge sort), the genai-recommended path for sort sizes in (32, 64].
+      SoftmaxTopKWarpMergeKernel<T, 64><<<grid, onnxruntime::cuda::topk_warp::kWarpSize, 0, stream>>>(
+          logits, topk_scales, topk_indices, num_rows, num_experts, k, normalize_scales);
+      return;
+    } else if (num_experts <= 128) {
       SoftmaxTopKMergeKernel<T, 128, 1><<<grid, 128, 0, stream>>>(
           logits, topk_scales, topk_indices, num_rows, num_experts, k, normalize_scales);
       return;

--- a/onnxruntime/contrib_ops/cuda/moe/qmoe_kernels.cu
+++ b/onnxruntime/contrib_ops/cuda/moe/qmoe_kernels.cu
@@ -35,7 +35,7 @@ __device__ __forceinline__ float TopKNormalizeDenom(bool normalize_scales, float
 }
 
 __device__ __forceinline__ float WarpReduceMax(float value) {
-  constexpr int kWarpSize = onnxruntime::cuda::topk_warp::kWarpSize;
+  constexpr int kWarpSize = onnxruntime::cuda::topk::kWarpSize;
 #pragma unroll
   for (int offset = kWarpSize / 2; offset > 0; offset >>= 1) {
     value = fmaxf(value, __shfl_xor_sync(0xFFFFFFFF, value, offset));
@@ -44,7 +44,7 @@ __device__ __forceinline__ float WarpReduceMax(float value) {
 }
 
 __device__ __forceinline__ float WarpReduceSum(float value) {
-  constexpr int kWarpSize = onnxruntime::cuda::topk_warp::kWarpSize;
+  constexpr int kWarpSize = onnxruntime::cuda::topk::kWarpSize;
 #pragma unroll
   for (int offset = kWarpSize / 2; offset > 0; offset >>= 1) {
     value += __shfl_xor_sync(0xFFFFFFFF, value, offset);
@@ -145,22 +145,8 @@ __global__ void SoftmaxTopKKernel(const T* logits, float* topk_scales, int* topk
 // the layout onnxruntime-genai's top-k benchmarks also recommend (CUB block
 // merge) for sort sizes up to ~1024. The capacity (kBlockSize*kItemsPerThread)
 // must be >= num_experts; padding lanes carry -FLT_MAX so they sort to the
-// bottom. Tie-breaking matches the scalar kernel (lower expert index first):
-// each key carries its expert index and the comparator breaks ties on the lower
-// index, so correctness does not rely on cub::BlockMergeSort being a stable sort
-// (it is not).
-struct LogitIndexKey {
-  float logit;
-  int index;
-};
-
-// Order primarily by descending logit, breaking ties by ascending expert index
-// so that equal logits deterministically prefer the lower expert index.
-struct LogitIndexDescending {
-  __device__ bool operator()(const LogitIndexKey& a, const LogitIndexKey& b) const {
-    return a.logit > b.logit || (a.logit == b.logit && a.index < b.index);
-  }
-};
+// bottom. Tie-breaking matches the scalar kernel (lower expert index first) via
+// the same packed stable sort key used by the warp merge path.
 
 template <typename T, int kBlockSize, int kItemsPerThread>
 __global__ void SoftmaxTopKMergeKernel(const T* logits, float* topk_scales, int* topk_indices,
@@ -171,7 +157,7 @@ __global__ void SoftmaxTopKMergeKernel(const T* logits, float* topk_scales, int*
   const T* row_logits = logits + static_cast<size_t>(row) * num_experts;
   const int tid = threadIdx.x;
 
-  using BlockMergeSort = cub::BlockMergeSort<LogitIndexKey, kBlockSize, kItemsPerThread>;
+  using BlockMergeSort = cub::BlockMergeSort<uint64_t, kBlockSize, kItemsPerThread, cub::NullType>;
   using BlockReduce = cub::BlockReduce<float, kBlockSize>;
   __shared__ union {
     typename BlockMergeSort::TempStorage merge;
@@ -181,21 +167,21 @@ __global__ void SoftmaxTopKMergeKernel(const T* logits, float* topk_scales, int*
   __shared__ float s_max;
   __shared__ float s_sum;
 
-  // Load this thread's (logit, expert index) keys in a blocked arrangement:
-  // thread t owns indices [t*ipt, t*ipt+ipt).
-  LogitIndexKey keys[kItemsPerThread];
+  // Load this thread's packed (logit, expert index) keys in a blocked
+  // arrangement: thread t owns indices [t*ipt, t*ipt+ipt).
+  uint64_t keys[kItemsPerThread];
+  float local_max = -FLT_MAX;
 #pragma unroll
   for (int j = 0; j < kItemsPerThread; ++j) {
     const int idx = tid * kItemsPerThread + j;
-    keys[j].logit = (idx < num_experts) ? static_cast<float>(row_logits[idx]) : -FLT_MAX;
-    keys[j].index = (idx < num_experts) ? idx : num_experts;
+    const float logit = (idx < num_experts) ? static_cast<float>(row_logits[idx]) : -FLT_MAX;
+    const int index = (idx < num_experts) ? idx : INT_MAX;
+    keys[j] = onnxruntime::cuda::topk::PackStableSortKey(logit, index);
+    local_max = fmaxf(local_max, logit);
   }
 
   // Softmax denominator over all experts (needed when normalize_scales is false;
   // when true it cancels in the top-k normalization but is still correct).
-  float local_max = -FLT_MAX;
-#pragma unroll
-  for (int j = 0; j < kItemsPerThread; ++j) local_max = fmaxf(local_max, keys[j].logit);
   const float block_max = BlockReduceMax<BlockReduce>(local_max, temp.reduce);
   if (tid == 0) s_max = block_max;
   // Single barrier: publishes s_max to all threads and also separates the two
@@ -207,7 +193,9 @@ __global__ void SoftmaxTopKMergeKernel(const T* logits, float* topk_scales, int*
 #pragma unroll
   for (int j = 0; j < kItemsPerThread; ++j) {
     const int idx = tid * kItemsPerThread + j;
-    if (idx < num_experts) local_sum += expf(keys[j].logit - max_val);
+    if (idx < num_experts) {
+      local_sum += expf(onnxruntime::cuda::topk::UnpackStableSortScore(keys[j]) - max_val);
+    }
   }
   const float block_sum = BlockReduceSum<BlockReduce>(local_sum, temp.reduce);
   if (tid == 0) s_sum = block_sum;
@@ -215,19 +203,21 @@ __global__ void SoftmaxTopKMergeKernel(const T* logits, float* topk_scales, int*
   __syncthreads();
   const float inv_sum = SafeInvSum(s_sum);
 
-  // Sort (logit, index) keys descending (ties broken on lower index). Result
-  // stays in a blocked layout, so sorted rank r lives in thread (r / ipt),
-  // item (r % ipt). Sort() leaves the sorted keys in each thread's registers and
-  // temp.merge is not reused afterwards, so no barrier is needed here; the
-  // shared s_topk writes below are published by the barrier that follows them.
-  BlockMergeSort(temp.merge).Sort(keys, LogitIndexDescending());
+  // Sort packed (logit, index) keys descending. Result stays in a blocked
+  // layout, so sorted rank r lives in thread (r / ipt), item (r % ipt). Sort()
+  // leaves the sorted keys in each thread's registers and temp.merge is not
+  // reused afterwards, so no barrier is needed here; the shared s_topk writes
+  // below are published by the barrier that follows them.
+  BlockMergeSort(temp.merge).Sort(keys, onnxruntime::cuda::topk::Greater<uint64_t>());
 
 #pragma unroll
   for (int j = 0; j < kItemsPerThread; ++j) {
     const int rank = tid * kItemsPerThread + j;
     if (rank < k) {
-      topk_indices[static_cast<size_t>(row) * k + rank] = keys[j].index;
-      s_topk[rank] = SoftmaxScale(keys[j].logit, max_val, inv_sum);
+      const uint64_t key = keys[j];
+      topk_indices[static_cast<size_t>(row) * k + rank] =
+          onnxruntime::cuda::topk::UnpackStableSortIndex(key);
+      s_topk[rank] = SoftmaxScale(onnxruntime::cuda::topk::UnpackStableSortScore(key), max_val, inv_sum);
     }
   }
   __syncthreads();
@@ -269,7 +259,7 @@ __global__ void SoftmaxTopKWarpBitonicKernel(const T* logits, float* topk_scales
   // sorting by softmax probability since the mapping is monotonic.
   float score = logit;
   int index = (lane < num_experts) ? lane : INT_MAX;
-  onnxruntime::cuda::topk_warp::WarpBitonicSortDescending(score, index);
+  onnxruntime::cuda::topk::WarpBitonicSortDescending(score, index);
 
   // Lane r now holds the rank-r element. Compute the top-k probabilities.
   float prob = (lane < k) ? SoftmaxScale(score, max_val, inv_sum) : 0.0f;
@@ -291,8 +281,8 @@ __global__ void SoftmaxTopKWarpBitonicKernel(const T* logits, float* topk_scales
 template <typename T, int kBufferSize>
 __global__ void SoftmaxTopKWarpMergeKernel(const T* logits, float* topk_scales, int* topk_indices,
                                            int num_rows, int num_experts, int k, bool normalize_scales) {
-  constexpr int kWarpSize = onnxruntime::cuda::topk_warp::kWarpSize;
-  using WarpMergeSorter = onnxruntime::cuda::topk_warp::WarpMergeSorter<kBufferSize>;
+  constexpr int kWarpSize = onnxruntime::cuda::topk::kWarpSize;
+  using WarpMergeSorter = onnxruntime::cuda::topk::WarpMergeSorter<kBufferSize>;
 
   const int row = blockIdx.x;
   if (row >= num_rows) return;
@@ -354,17 +344,17 @@ void DispatchSoftmaxTopK(const T* logits, float* topk_scales, int* topk_indices,
     // Tiny expert counts: a single warp sorts a row entirely in registers via
     // an in-register bitonic sort (no shared memory). Multiple warps per block
     // process multiple rows for better occupancy.
-    if (num_experts <= onnxruntime::cuda::topk_warp::kWarpBitonicMaxSize) {
+    if (num_experts <= onnxruntime::cuda::topk::kWarpBitonicMaxSize) {
       constexpr int kWarpsPerBlock = 8;
-      const dim3 block(static_cast<unsigned>(onnxruntime::cuda::topk_warp::kWarpSize), kWarpsPerBlock);
+      const dim3 block(static_cast<unsigned>(onnxruntime::cuda::topk::kWarpSize), kWarpsPerBlock);
       const dim3 bitonic_grid(static_cast<unsigned>((num_rows + kWarpsPerBlock - 1) / kWarpsPerBlock));
       SoftmaxTopKWarpBitonicKernel<T, kWarpsPerBlock><<<bitonic_grid, block, 0, stream>>>(
           logits, topk_scales, topk_indices, num_rows, num_experts, k, normalize_scales);
       return;
-    } else if (num_experts <= onnxruntime::cuda::topk_warp::kWarpMergeMaxSize) {
+    } else if (num_experts <= onnxruntime::cuda::topk::kWarpMergeMaxSize) {
       // Single warp per row sorts up to 64 logits in shared memory (CUB warp
       // merge sort), the genai-recommended path for sort sizes in (32, 64].
-      SoftmaxTopKWarpMergeKernel<T, 64><<<grid, onnxruntime::cuda::topk_warp::kWarpSize, 0, stream>>>(
+      SoftmaxTopKWarpMergeKernel<T, 64><<<grid, onnxruntime::cuda::topk::kWarpSize, 0, stream>>>(
           logits, topk_scales, topk_indices, num_rows, num_experts, k, normalize_scales);
       return;
     } else if (num_experts <= 128) {

--- a/onnxruntime/contrib_ops/cuda/moe/qmoe_kernels.cu
+++ b/onnxruntime/contrib_ops/cuda/moe/qmoe_kernels.cu
@@ -88,115 +88,6 @@ __global__ void SoftmaxTopKKernel(const T* logits, float* topk_scales, int* topk
   }
 }
 
-// Block-per-row softmax + top-k. Each block processes one row using all of its
-// threads with parallel reductions. This is far more efficient than the
-// one-thread-per-row kernel above for the autoregressive-decode case
-// (num_rows == 1), where the latter leaves all but one thread idle and becomes
-// memory-latency-bound on the serial expert scan. Tie-breaking matches the
-// scalar kernel: on equal logits the lower expert index is selected first.
-template <typename T, int kBlockSize>
-__global__ void SoftmaxTopKKernelBlock(const T* logits, float* topk_scales, int* topk_indices,
-                                       int num_rows, int num_experts, int k, bool normalize_scales) {
-  const int row = blockIdx.x;
-  if (row >= num_rows) return;
-
-  const T* row_logits = logits + static_cast<size_t>(row) * num_experts;
-  float* row_scales = topk_scales + static_cast<size_t>(row) * k;
-  int* row_indices = topk_indices + static_cast<size_t>(row) * k;
-
-  const int tid = threadIdx.x;
-
-  __shared__ float s_reduce[kBlockSize];
-  __shared__ int s_idx[kBlockSize];
-  __shared__ int s_chosen[64];  // selected expert indices so far (k <= 64)
-
-  // 1. Block-parallel max over experts (coalesced strided reads).
-  float local_max = -FLT_MAX;
-  for (int i = tid; i < num_experts; i += kBlockSize) {
-    local_max = fmaxf(local_max, static_cast<float>(row_logits[i]));
-  }
-  s_reduce[tid] = local_max;
-  __syncthreads();
-  for (int s = kBlockSize / 2; s > 0; s >>= 1) {
-    if (tid < s) s_reduce[tid] = fmaxf(s_reduce[tid], s_reduce[tid + s]);
-    __syncthreads();
-  }
-  const float max_val = s_reduce[0];
-  __syncthreads();
-
-  // 2. Block-parallel sum of exp.
-  float local_sum = 0.0f;
-  for (int i = tid; i < num_experts; i += kBlockSize) {
-    local_sum += expf(static_cast<float>(row_logits[i]) - max_val);
-  }
-  s_reduce[tid] = local_sum;
-  __syncthreads();
-  for (int s = kBlockSize / 2; s > 0; s >>= 1) {
-    if (tid < s) s_reduce[tid] += s_reduce[tid + s];
-    __syncthreads();
-  }
-  const float sum_exp = s_reduce[0];
-  const float inv_sum = (sum_exp > 0.0f) ? (1.0f / sum_exp) : 0.0f;
-  __syncthreads();
-
-  // 3. Top-k via k rounds of block-wide argmax (k is small). Selecting on the
-  // logit value is equivalent to selecting on the softmax probability since the
-  // softmax is monotonic; the probability is recovered only for the winners.
-  for (int r = 0; r < k; ++r) {
-    float best_val = -FLT_MAX;
-    int best_idx = num_experts;  // larger than any valid index -> lowest-index tie-break
-    for (int i = tid; i < num_experts; i += kBlockSize) {
-      bool taken = false;
-      for (int c = 0; c < r; ++c) {
-        if (s_chosen[c] == i) {
-          taken = true;
-          break;
-        }
-      }
-      if (taken) continue;
-      const float val = static_cast<float>(row_logits[i]);
-      if (val > best_val || (val == best_val && i < best_idx)) {
-        best_val = val;
-        best_idx = i;
-      }
-    }
-    s_reduce[tid] = best_val;
-    s_idx[tid] = best_idx;
-    __syncthreads();
-    for (int s = kBlockSize / 2; s > 0; s >>= 1) {
-      if (tid < s) {
-        const float ov = s_reduce[tid + s];
-        const int oi = s_idx[tid + s];
-        if (ov > s_reduce[tid] || (ov == s_reduce[tid] && oi < s_idx[tid])) {
-          s_reduce[tid] = ov;
-          s_idx[tid] = oi;
-        }
-      }
-      __syncthreads();
-    }
-    if (tid == 0) {
-      const int widx = s_idx[0];
-      s_chosen[r] = widx;
-      row_indices[r] = widx;
-      row_scales[r] = expf(s_reduce[0] - max_val) * inv_sum;
-    }
-    __syncthreads();
-  }
-
-  // 4. Normalize if requested (over the selected top-k probabilities).
-  if (normalize_scales && tid == 0) {
-    float scale_sum = 0.0f;
-    for (int i = 0; i < k; ++i) {
-      scale_sum += row_scales[i];
-    }
-    if (scale_sum > 1e-6f) {
-      for (int i = 0; i < k; ++i) {
-        row_scales[i] /= scale_sum;
-      }
-    }
-  }
-}
-
 // Block-per-row softmax + top-k using a CUB block sort. Each block sorts one
 // row's logits (descending) and reads the first k. A full sort of 256 logits is
 // ~2.5x faster than k rounds of block-argmax on this size (benchmarked), and is
@@ -318,7 +209,7 @@ void DispatchSoftmaxTopK(const T* logits, float* topk_scales, int* topk_indices,
   // (one block fully sorts a row). Pick the smallest capacity that covers
   // num_experts. k must fit in s_topk (<= 64).
   const dim3 grid(static_cast<unsigned>(num_rows));
-  if (k <= 64) {
+  if (k <= 64 && num_experts <= 1024) {
     if (num_experts <= 128) {
       SoftmaxTopKMergeKernel<T, 128, 1><<<grid, 128, 0, stream>>>(
           logits, topk_scales, topk_indices, num_rows, num_experts, k, normalize_scales);
@@ -331,18 +222,13 @@ void DispatchSoftmaxTopK(const T* logits, float* topk_scales, int* topk_indices,
       SoftmaxTopKMergeKernel<T, 128, 4><<<grid, 128, 0, stream>>>(
           logits, topk_scales, topk_indices, num_rows, num_experts, k, normalize_scales);
       return;
-    } else if (num_experts <= 1024) {
+    } else /*if (num_experts <= 1024)*/ {
       SoftmaxTopKMergeKernel<T, 256, 4><<<grid, 256, 0, stream>>>(
           logits, topk_scales, topk_indices, num_rows, num_experts, k, normalize_scales);
       return;
     }
-    // num_experts > 1024: block-argmax kernel handles arbitrary sizes.
-    constexpr int kBlockSize = 256;
-    SoftmaxTopKKernelBlock<T, kBlockSize><<<grid, kBlockSize, 0, stream>>>(
-        logits, topk_scales, topk_indices, num_rows, num_experts, k, normalize_scales);
   } else {
-    // k > 64 is not expected for MoE routing; fall back to the simple
-    // one-thread-per-row kernel which has no k cap.
+    // Fall back to the simple one-thread-per-row kernel.
     const int block = 256;
     const int grid_1d = Compute1DGridSize(num_rows, block);
     SoftmaxTopKKernel<T><<<grid_1d, block, 0, stream>>>(

--- a/onnxruntime/contrib_ops/cuda/moe/qmoe_kernels.cu
+++ b/onnxruntime/contrib_ops/cuda/moe/qmoe_kernels.cu
@@ -20,6 +20,56 @@ int Compute1DGridSize(int num_elements, int block_size) {
   return (num_elements + block_size - 1) / block_size;
 }
 
+constexpr float kTopKNormalizeEpsilon = 1e-6f;
+
+__device__ __forceinline__ float SoftmaxScale(float logit, float max_val, float inv_sum) {
+  return expf(logit - max_val) * inv_sum;
+}
+
+__device__ __forceinline__ float SafeInvSum(float sum) {
+  return (sum > 0.0f) ? (1.0f / sum) : 0.0f;
+}
+
+__device__ __forceinline__ float TopKNormalizeDenom(bool normalize_scales, float scale_sum) {
+  return (normalize_scales && scale_sum > kTopKNormalizeEpsilon) ? scale_sum : 1.0f;
+}
+
+__device__ __forceinline__ float WarpReduceMax(float value) {
+  constexpr int kWarpSize = onnxruntime::cuda::topk_warp::kWarpSize;
+#pragma unroll
+  for (int offset = kWarpSize / 2; offset > 0; offset >>= 1) {
+    value = fmaxf(value, __shfl_xor_sync(0xFFFFFFFF, value, offset));
+  }
+  return value;
+}
+
+__device__ __forceinline__ float WarpReduceSum(float value) {
+  constexpr int kWarpSize = onnxruntime::cuda::topk_warp::kWarpSize;
+#pragma unroll
+  for (int offset = kWarpSize / 2; offset > 0; offset >>= 1) {
+    value += __shfl_xor_sync(0xFFFFFFFF, value, offset);
+  }
+  return value;
+}
+
+template <typename BlockReduce>
+__device__ __forceinline__ float BlockReduceMax(float value, typename BlockReduce::TempStorage& temp_storage) {
+#if CUDART_VERSION >= 12090
+  return BlockReduce(temp_storage).Reduce(value, ::cuda::maximum());
+#else
+  return BlockReduce(temp_storage).Reduce(value, cub::Max());
+#endif
+}
+
+template <typename BlockReduce>
+__device__ __forceinline__ float BlockReduceSum(float value, typename BlockReduce::TempStorage& temp_storage) {
+#if CUDART_VERSION >= 12090
+  return BlockReduce(temp_storage).Reduce(value, ::cuda::std::plus());
+#else
+  return BlockReduce(temp_storage).Reduce(value, cub::Sum());
+#endif
+}
+
 template <typename T>
 __global__ void SoftmaxTopKKernel(const T* logits, float* topk_scales, int* topk_indices,
                                   int num_rows, int num_experts, int k, bool normalize_scales) {
@@ -81,7 +131,7 @@ __global__ void SoftmaxTopKKernel(const T* logits, float* topk_scales, int* topk
     for (int i = 0; i < k; ++i) {
       scale_sum += row_scales[i];
     }
-    if (scale_sum > 1e-6f) {
+    if (scale_sum > kTopKNormalizeEpsilon) {
       for (int i = 0; i < k; ++i) {
         row_scales[i] /= scale_sum;
       }
@@ -146,11 +196,7 @@ __global__ void SoftmaxTopKMergeKernel(const T* logits, float* topk_scales, int*
   float local_max = -FLT_MAX;
 #pragma unroll
   for (int j = 0; j < kItemsPerThread; ++j) local_max = fmaxf(local_max, keys[j].logit);
-#if CUDART_VERSION >= 12090
-  float block_max = BlockReduce(temp.reduce).Reduce(local_max, ::cuda::maximum());
-#else
-  float block_max = BlockReduce(temp.reduce).Reduce(local_max, cub::Max());
-#endif
+  const float block_max = BlockReduceMax<BlockReduce>(local_max, temp.reduce);
   if (tid == 0) s_max = block_max;
   // Single barrier: publishes s_max to all threads and also separates the two
   // BlockReduce uses that share temp.reduce.
@@ -163,15 +209,11 @@ __global__ void SoftmaxTopKMergeKernel(const T* logits, float* topk_scales, int*
     const int idx = tid * kItemsPerThread + j;
     if (idx < num_experts) local_sum += expf(keys[j].logit - max_val);
   }
-#if CUDART_VERSION >= 12090
-  float block_sum = BlockReduce(temp.reduce).Reduce(local_sum, ::cuda::std::plus());
-#else
-  float block_sum = BlockReduce(temp.reduce).Reduce(local_sum, cub::Sum());
-#endif
+  const float block_sum = BlockReduceSum<BlockReduce>(local_sum, temp.reduce);
   if (tid == 0) s_sum = block_sum;
   // Single barrier: publishes s_sum and separates temp.reduce from temp.merge.
   __syncthreads();
-  const float inv_sum = (s_sum > 0.0f) ? (1.0f / s_sum) : 0.0f;
+  const float inv_sum = SafeInvSum(s_sum);
 
   // Sort (logit, index) keys descending (ties broken on lower index). Result
   // stays in a blocked layout, so sorted rank r lives in thread (r / ipt),
@@ -185,7 +227,7 @@ __global__ void SoftmaxTopKMergeKernel(const T* logits, float* topk_scales, int*
     const int rank = tid * kItemsPerThread + j;
     if (rank < k) {
       topk_indices[static_cast<size_t>(row) * k + rank] = keys[j].index;
-      s_topk[rank] = expf(keys[j].logit - max_val) * inv_sum;
+      s_topk[rank] = SoftmaxScale(keys[j].logit, max_val, inv_sum);
     }
   }
   __syncthreads();
@@ -194,7 +236,7 @@ __global__ void SoftmaxTopKMergeKernel(const T* logits, float* topk_scales, int*
     if (normalize_scales) {
       float scale_sum = 0.0f;
       for (int i = 0; i < k; ++i) scale_sum += s_topk[i];
-      const float denom = (scale_sum > 1e-6f) ? scale_sum : 1.0f;
+      const float denom = TopKNormalizeDenom(normalize_scales, scale_sum);
       for (int i = 0; i < k; ++i) topk_scales[static_cast<size_t>(row) * k + i] = s_topk[i] / denom;
     } else {
       for (int i = 0; i < k; ++i) topk_scales[static_cast<size_t>(row) * k + i] = s_topk[i];
@@ -210,7 +252,6 @@ __global__ void SoftmaxTopKMergeKernel(const T* logits, float* topk_scales, int*
 template <typename T, int kWarpsPerBlock>
 __global__ void SoftmaxTopKWarpBitonicKernel(const T* logits, float* topk_scales, int* topk_indices,
                                              int num_rows, int num_experts, int k, bool normalize_scales) {
-  constexpr int kWarpSize = onnxruntime::cuda::topk_warp::kWarpSize;
   const int lane = threadIdx.x;
   const int row = blockIdx.x * kWarpsPerBlock + threadIdx.y;
   if (row >= num_rows) return;
@@ -218,20 +259,11 @@ __global__ void SoftmaxTopKWarpBitonicKernel(const T* logits, float* topk_scales
   const T* row_logits = logits + static_cast<size_t>(row) * num_experts;
   const float logit = (lane < num_experts) ? static_cast<float>(row_logits[lane]) : -FLT_MAX;
 
-  // Warp-wide max for numerical stability.
-  float max_val = logit;
-#pragma unroll
-  for (int offset = kWarpSize / 2; offset > 0; offset >>= 1) {
-    max_val = fmaxf(max_val, __shfl_xor_sync(0xFFFFFFFF, max_val, offset));
-  }
+  const float max_val = WarpReduceMax(logit);
 
   // Warp-wide exp sum (softmax denominator over all experts).
-  float sum_exp = (lane < num_experts) ? expf(logit - max_val) : 0.0f;
-#pragma unroll
-  for (int offset = kWarpSize / 2; offset > 0; offset >>= 1) {
-    sum_exp += __shfl_xor_sync(0xFFFFFFFF, sum_exp, offset);
-  }
-  const float inv_sum = (sum_exp > 0.0f) ? (1.0f / sum_exp) : 0.0f;
+  const float sum_exp = WarpReduceSum((lane < num_experts) ? expf(logit - max_val) : 0.0f);
+  const float inv_sum = SafeInvSum(sum_exp);
 
   // Sort (logit, expert index) descending; sorting by logit is equivalent to
   // sorting by softmax probability since the mapping is monotonic.
@@ -240,16 +272,10 @@ __global__ void SoftmaxTopKWarpBitonicKernel(const T* logits, float* topk_scales
   onnxruntime::cuda::topk_warp::WarpBitonicSortDescending(score, index);
 
   // Lane r now holds the rank-r element. Compute the top-k probabilities.
-  float prob = (lane < k) ? expf(score - max_val) * inv_sum : 0.0f;
+  float prob = (lane < k) ? SoftmaxScale(score, max_val, inv_sum) : 0.0f;
 
   if (normalize_scales) {
-    float scale_sum = prob;
-#pragma unroll
-    for (int offset = kWarpSize / 2; offset > 0; offset >>= 1) {
-      scale_sum += __shfl_xor_sync(0xFFFFFFFF, scale_sum, offset);
-    }
-    const float denom = (scale_sum > 1e-6f) ? scale_sum : 1.0f;
-    prob /= denom;
+    prob /= TopKNormalizeDenom(normalize_scales, WarpReduceSum(prob));
   }
 
   if (lane < k) {
@@ -286,22 +312,14 @@ __global__ void SoftmaxTopKWarpMergeKernel(const T* logits, float* topk_scales, 
     s_indices[i] = (i < num_experts) ? i : INT_MAX;
     local_max = fmaxf(local_max, v);
   }
-#pragma unroll
-  for (int offset = kWarpSize / 2; offset > 0; offset >>= 1) {
-    local_max = fmaxf(local_max, __shfl_xor_sync(0xFFFFFFFF, local_max, offset));
-  }
-  const float max_val = local_max;
+  const float max_val = WarpReduceMax(local_max);
 
   // Warp-wide exp sum over all experts.
   float local_sum = 0.0f;
   for (int i = lane; i < num_experts; i += kWarpSize) {
     local_sum += expf(s_scores[i] - max_val);
   }
-#pragma unroll
-  for (int offset = kWarpSize / 2; offset > 0; offset >>= 1) {
-    local_sum += __shfl_xor_sync(0xFFFFFFFF, local_sum, offset);
-  }
-  const float inv_sum = (local_sum > 0.0f) ? (1.0f / local_sum) : 0.0f;
+  const float inv_sum = SafeInvSum(WarpReduceSum(local_sum));
 
   __syncwarp();
   WarpMergeSorter::Sort(s_scores, s_indices, temp_storage, num_experts);
@@ -311,17 +329,14 @@ __global__ void SoftmaxTopKWarpMergeKernel(const T* logits, float* topk_scales, 
   float scale_sum = 0.0f;
   if (normalize_scales) {
     for (int i = lane; i < k; i += kWarpSize) {
-      scale_sum += expf(s_scores[i] - max_val) * inv_sum;
+      scale_sum += SoftmaxScale(s_scores[i], max_val, inv_sum);
     }
-#pragma unroll
-    for (int offset = kWarpSize / 2; offset > 0; offset >>= 1) {
-      scale_sum += __shfl_xor_sync(0xFFFFFFFF, scale_sum, offset);
-    }
+    scale_sum = WarpReduceSum(scale_sum);
   }
-  const float denom = (normalize_scales && scale_sum > 1e-6f) ? scale_sum : 1.0f;
+  const float denom = TopKNormalizeDenom(normalize_scales, scale_sum);
 
   for (int i = lane; i < k; i += kWarpSize) {
-    const float prob = expf(s_scores[i] - max_val) * inv_sum;
+    const float prob = SoftmaxScale(s_scores[i], max_val, inv_sum);
     topk_scales[static_cast<size_t>(row) * k + i] = normalize_scales ? (prob / denom) : prob;
     topk_indices[static_cast<size_t>(row) * k + i] = s_indices[i];
   }

--- a/onnxruntime/contrib_ops/cuda/moe/qmoe_kernels.cu
+++ b/onnxruntime/contrib_ops/cuda/moe/qmoe_kernels.cu
@@ -203,9 +203,23 @@ __global__ void SoftmaxTopKKernelBlock(const T* logits, float* topk_scales, int*
 // the layout onnxruntime-genai's top-k benchmarks also recommend (CUB block
 // merge) for sort sizes up to ~1024. The capacity (kBlockSize*kItemsPerThread)
 // must be >= num_experts; padding lanes carry -FLT_MAX so they sort to the
-// bottom. Tie-breaking matches the scalar kernel (lower expert index first)
-// because the value carried alongside each key is the expert index and the sort
-// is stable.
+// bottom. Tie-breaking matches the scalar kernel (lower expert index first):
+// each key carries its expert index and the comparator breaks ties on the lower
+// index, so correctness does not rely on cub::BlockMergeSort being a stable sort
+// (it is not).
+struct LogitIndexKey {
+  float logit;
+  int index;
+};
+
+// Order primarily by descending logit, breaking ties by ascending expert index
+// so that equal logits deterministically prefer the lower expert index.
+struct LogitIndexDescending {
+  __device__ bool operator()(const LogitIndexKey& a, const LogitIndexKey& b) const {
+    return a.logit > b.logit || (a.logit == b.logit && a.index < b.index);
+  }
+};
+
 template <typename T, int kBlockSize, int kItemsPerThread>
 __global__ void SoftmaxTopKMergeKernel(const T* logits, float* topk_scales, int* topk_indices,
                                        int num_rows, int num_experts, int k, bool normalize_scales) {
@@ -215,7 +229,7 @@ __global__ void SoftmaxTopKMergeKernel(const T* logits, float* topk_scales, int*
   const T* row_logits = logits + static_cast<size_t>(row) * num_experts;
   const int tid = threadIdx.x;
 
-  using BlockMergeSort = cub::BlockMergeSort<float, kBlockSize, kItemsPerThread, int>;
+  using BlockMergeSort = cub::BlockMergeSort<LogitIndexKey, kBlockSize, kItemsPerThread>;
   using BlockReduce = cub::BlockReduce<float, kBlockSize>;
   __shared__ union {
     typename BlockMergeSort::TempStorage merge;
@@ -225,62 +239,61 @@ __global__ void SoftmaxTopKMergeKernel(const T* logits, float* topk_scales, int*
   __shared__ float s_max;
   __shared__ float s_sum;
 
-  // Load this thread's keys (logits) and values (expert indices) in a blocked
-  // arrangement: thread t owns indices [t*ipt, t*ipt+ipt).
-  float keys[kItemsPerThread];
-  int vals[kItemsPerThread];
+  // Load this thread's (logit, expert index) keys in a blocked arrangement:
+  // thread t owns indices [t*ipt, t*ipt+ipt).
+  LogitIndexKey keys[kItemsPerThread];
 #pragma unroll
   for (int j = 0; j < kItemsPerThread; ++j) {
     const int idx = tid * kItemsPerThread + j;
-    keys[j] = (idx < num_experts) ? static_cast<float>(row_logits[idx]) : -FLT_MAX;
-    vals[j] = (idx < num_experts) ? idx : num_experts;
+    keys[j].logit = (idx < num_experts) ? static_cast<float>(row_logits[idx]) : -FLT_MAX;
+    keys[j].index = (idx < num_experts) ? idx : num_experts;
   }
 
   // Softmax denominator over all experts (needed when normalize_scales is false;
   // when true it cancels in the top-k normalization but is still correct).
   float local_max = -FLT_MAX;
 #pragma unroll
-  for (int j = 0; j < kItemsPerThread; ++j) local_max = fmaxf(local_max, keys[j]);
+  for (int j = 0; j < kItemsPerThread; ++j) local_max = fmaxf(local_max, keys[j].logit);
 #if CUDART_VERSION >= 12090
-  float block_max = BlockReduce(temp.reduce).Reduce(local_max, ::cuda::maximum<float>());
+  float block_max = BlockReduce(temp.reduce).Reduce(local_max, ::cuda::maximum());
 #else
   float block_max = BlockReduce(temp.reduce).Reduce(local_max, cub::Max());
 #endif
   if (tid == 0) s_max = block_max;
+  // Single barrier: publishes s_max to all threads and also separates the two
+  // BlockReduce uses that share temp.reduce.
   __syncthreads();
   const float max_val = s_max;
-  __syncthreads();
 
   float local_sum = 0.0f;
 #pragma unroll
   for (int j = 0; j < kItemsPerThread; ++j) {
     const int idx = tid * kItemsPerThread + j;
-    if (idx < num_experts) local_sum += expf(keys[j] - max_val);
+    if (idx < num_experts) local_sum += expf(keys[j].logit - max_val);
   }
 #if CUDART_VERSION >= 12090
-  float block_sum = BlockReduce(temp.reduce).Reduce(local_sum, ::cuda::std::plus<float>());
+  float block_sum = BlockReduce(temp.reduce).Reduce(local_sum, ::cuda::std::plus());
 #else
   float block_sum = BlockReduce(temp.reduce).Reduce(local_sum, cub::Sum());
 #endif
   if (tid == 0) s_sum = block_sum;
+  // Single barrier: publishes s_sum and separates temp.reduce from temp.merge.
   __syncthreads();
   const float inv_sum = (s_sum > 0.0f) ? (1.0f / s_sum) : 0.0f;
-  __syncthreads();
 
-  // Sort (logit, index) pairs descending. Result stays in a blocked layout, so
-  // sorted rank r lives in thread (r / ipt), item (r % ipt).
-  struct DescendingOp {
-    __device__ bool operator()(const float& a, const float& b) const { return a > b; }
-  };
-  BlockMergeSort(temp.merge).Sort(keys, vals, DescendingOp());
-  __syncthreads();
+  // Sort (logit, index) keys descending (ties broken on lower index). Result
+  // stays in a blocked layout, so sorted rank r lives in thread (r / ipt),
+  // item (r % ipt). Sort() leaves the sorted keys in each thread's registers and
+  // temp.merge is not reused afterwards, so no barrier is needed here; the
+  // shared s_topk writes below are published by the barrier that follows them.
+  BlockMergeSort(temp.merge).Sort(keys, LogitIndexDescending());
 
 #pragma unroll
   for (int j = 0; j < kItemsPerThread; ++j) {
     const int rank = tid * kItemsPerThread + j;
     if (rank < k) {
-      topk_indices[static_cast<size_t>(row) * k + rank] = vals[j];
-      s_topk[rank] = expf(keys[j] - max_val) * inv_sum;
+      topk_indices[static_cast<size_t>(row) * k + rank] = keys[j].index;
+      s_topk[rank] = expf(keys[j].logit - max_val) * inv_sum;
     }
   }
   __syncthreads();

--- a/onnxruntime/contrib_ops/cuda/moe/qmoe_kernels.cu
+++ b/onnxruntime/contrib_ops/cuda/moe/qmoe_kernels.cu
@@ -88,6 +88,255 @@ __global__ void SoftmaxTopKKernel(const T* logits, float* topk_scales, int* topk
   }
 }
 
+// Block-per-row softmax + top-k. Each block processes one row using all of its
+// threads with parallel reductions. This is far more efficient than the
+// one-thread-per-row kernel above for the autoregressive-decode case
+// (num_rows == 1), where the latter leaves all but one thread idle and becomes
+// memory-latency-bound on the serial expert scan. Tie-breaking matches the
+// scalar kernel: on equal logits the lower expert index is selected first.
+template <typename T, int kBlockSize>
+__global__ void SoftmaxTopKKernelBlock(const T* logits, float* topk_scales, int* topk_indices,
+                                       int num_rows, int num_experts, int k, bool normalize_scales) {
+  const int row = blockIdx.x;
+  if (row >= num_rows) return;
+
+  const T* row_logits = logits + static_cast<size_t>(row) * num_experts;
+  float* row_scales = topk_scales + static_cast<size_t>(row) * k;
+  int* row_indices = topk_indices + static_cast<size_t>(row) * k;
+
+  const int tid = threadIdx.x;
+
+  __shared__ float s_reduce[kBlockSize];
+  __shared__ int s_idx[kBlockSize];
+  __shared__ int s_chosen[64];  // selected expert indices so far (k <= 64)
+
+  // 1. Block-parallel max over experts (coalesced strided reads).
+  float local_max = -FLT_MAX;
+  for (int i = tid; i < num_experts; i += kBlockSize) {
+    local_max = fmaxf(local_max, static_cast<float>(row_logits[i]));
+  }
+  s_reduce[tid] = local_max;
+  __syncthreads();
+  for (int s = kBlockSize / 2; s > 0; s >>= 1) {
+    if (tid < s) s_reduce[tid] = fmaxf(s_reduce[tid], s_reduce[tid + s]);
+    __syncthreads();
+  }
+  const float max_val = s_reduce[0];
+  __syncthreads();
+
+  // 2. Block-parallel sum of exp.
+  float local_sum = 0.0f;
+  for (int i = tid; i < num_experts; i += kBlockSize) {
+    local_sum += expf(static_cast<float>(row_logits[i]) - max_val);
+  }
+  s_reduce[tid] = local_sum;
+  __syncthreads();
+  for (int s = kBlockSize / 2; s > 0; s >>= 1) {
+    if (tid < s) s_reduce[tid] += s_reduce[tid + s];
+    __syncthreads();
+  }
+  const float sum_exp = s_reduce[0];
+  const float inv_sum = (sum_exp > 0.0f) ? (1.0f / sum_exp) : 0.0f;
+  __syncthreads();
+
+  // 3. Top-k via k rounds of block-wide argmax (k is small). Selecting on the
+  // logit value is equivalent to selecting on the softmax probability since the
+  // softmax is monotonic; the probability is recovered only for the winners.
+  for (int r = 0; r < k; ++r) {
+    float best_val = -FLT_MAX;
+    int best_idx = num_experts;  // larger than any valid index -> lowest-index tie-break
+    for (int i = tid; i < num_experts; i += kBlockSize) {
+      bool taken = false;
+      for (int c = 0; c < r; ++c) {
+        if (s_chosen[c] == i) {
+          taken = true;
+          break;
+        }
+      }
+      if (taken) continue;
+      const float val = static_cast<float>(row_logits[i]);
+      if (val > best_val || (val == best_val && i < best_idx)) {
+        best_val = val;
+        best_idx = i;
+      }
+    }
+    s_reduce[tid] = best_val;
+    s_idx[tid] = best_idx;
+    __syncthreads();
+    for (int s = kBlockSize / 2; s > 0; s >>= 1) {
+      if (tid < s) {
+        const float ov = s_reduce[tid + s];
+        const int oi = s_idx[tid + s];
+        if (ov > s_reduce[tid] || (ov == s_reduce[tid] && oi < s_idx[tid])) {
+          s_reduce[tid] = ov;
+          s_idx[tid] = oi;
+        }
+      }
+      __syncthreads();
+    }
+    if (tid == 0) {
+      const int widx = s_idx[0];
+      s_chosen[r] = widx;
+      row_indices[r] = widx;
+      row_scales[r] = expf(s_reduce[0] - max_val) * inv_sum;
+    }
+    __syncthreads();
+  }
+
+  // 4. Normalize if requested (over the selected top-k probabilities).
+  if (normalize_scales && tid == 0) {
+    float scale_sum = 0.0f;
+    for (int i = 0; i < k; ++i) {
+      scale_sum += row_scales[i];
+    }
+    if (scale_sum > 1e-6f) {
+      for (int i = 0; i < k; ++i) {
+        row_scales[i] /= scale_sum;
+      }
+    }
+  }
+}
+
+// Block-per-row softmax + top-k using a CUB block sort. Each block sorts one
+// row's logits (descending) and reads the first k. A full sort of 256 logits is
+// ~2.5x faster than k rounds of block-argmax on this size (benchmarked), and is
+// the layout onnxruntime-genai's top-k benchmarks also recommend (CUB block
+// merge) for sort sizes up to ~1024. The capacity (kBlockSize*kItemsPerThread)
+// must be >= num_experts; padding lanes carry -FLT_MAX so they sort to the
+// bottom. Tie-breaking matches the scalar kernel (lower expert index first)
+// because the value carried alongside each key is the expert index and the sort
+// is stable.
+template <typename T, int kBlockSize, int kItemsPerThread>
+__global__ void SoftmaxTopKMergeKernel(const T* logits, float* topk_scales, int* topk_indices,
+                                       int num_rows, int num_experts, int k, bool normalize_scales) {
+  const int row = blockIdx.x;
+  if (row >= num_rows) return;
+
+  const T* row_logits = logits + static_cast<size_t>(row) * num_experts;
+  const int tid = threadIdx.x;
+
+  using BlockMergeSort = cub::BlockMergeSort<float, kBlockSize, kItemsPerThread, int>;
+  using BlockReduce = cub::BlockReduce<float, kBlockSize>;
+  __shared__ union {
+    typename BlockMergeSort::TempStorage merge;
+    typename BlockReduce::TempStorage reduce;
+  } temp;
+  __shared__ float s_topk[64];  // k <= 64
+  __shared__ float s_max;
+  __shared__ float s_sum;
+
+  // Load this thread's keys (logits) and values (expert indices) in a blocked
+  // arrangement: thread t owns indices [t*ipt, t*ipt+ipt).
+  float keys[kItemsPerThread];
+  int vals[kItemsPerThread];
+#pragma unroll
+  for (int j = 0; j < kItemsPerThread; ++j) {
+    const int idx = tid * kItemsPerThread + j;
+    keys[j] = (idx < num_experts) ? static_cast<float>(row_logits[idx]) : -FLT_MAX;
+    vals[j] = (idx < num_experts) ? idx : num_experts;
+  }
+
+  // Softmax denominator over all experts (needed when normalize_scales is false;
+  // when true it cancels in the top-k normalization but is still correct).
+  float local_max = -FLT_MAX;
+#pragma unroll
+  for (int j = 0; j < kItemsPerThread; ++j) local_max = fmaxf(local_max, keys[j]);
+#if CUDART_VERSION >= 12090
+  float block_max = BlockReduce(temp.reduce).Reduce(local_max, ::cuda::maximum<float>());
+#else
+  float block_max = BlockReduce(temp.reduce).Reduce(local_max, cub::Max());
+#endif
+  if (tid == 0) s_max = block_max;
+  __syncthreads();
+  const float max_val = s_max;
+  __syncthreads();
+
+  float local_sum = 0.0f;
+#pragma unroll
+  for (int j = 0; j < kItemsPerThread; ++j) {
+    const int idx = tid * kItemsPerThread + j;
+    if (idx < num_experts) local_sum += expf(keys[j] - max_val);
+  }
+#if CUDART_VERSION >= 12090
+  float block_sum = BlockReduce(temp.reduce).Reduce(local_sum, ::cuda::std::plus<float>());
+#else
+  float block_sum = BlockReduce(temp.reduce).Reduce(local_sum, cub::Sum());
+#endif
+  if (tid == 0) s_sum = block_sum;
+  __syncthreads();
+  const float inv_sum = (s_sum > 0.0f) ? (1.0f / s_sum) : 0.0f;
+  __syncthreads();
+
+  // Sort (logit, index) pairs descending. Result stays in a blocked layout, so
+  // sorted rank r lives in thread (r / ipt), item (r % ipt).
+  struct DescendingOp {
+    __device__ bool operator()(const float& a, const float& b) const { return a > b; }
+  };
+  BlockMergeSort(temp.merge).Sort(keys, vals, DescendingOp());
+  __syncthreads();
+
+#pragma unroll
+  for (int j = 0; j < kItemsPerThread; ++j) {
+    const int rank = tid * kItemsPerThread + j;
+    if (rank < k) {
+      topk_indices[static_cast<size_t>(row) * k + rank] = vals[j];
+      s_topk[rank] = expf(keys[j] - max_val) * inv_sum;
+    }
+  }
+  __syncthreads();
+
+  if (tid == 0) {
+    if (normalize_scales) {
+      float scale_sum = 0.0f;
+      for (int i = 0; i < k; ++i) scale_sum += s_topk[i];
+      const float denom = (scale_sum > 1e-6f) ? scale_sum : 1.0f;
+      for (int i = 0; i < k; ++i) topk_scales[static_cast<size_t>(row) * k + i] = s_topk[i] / denom;
+    } else {
+      for (int i = 0; i < k; ++i) topk_scales[static_cast<size_t>(row) * k + i] = s_topk[i];
+    }
+  }
+}
+
+template <typename T>
+void DispatchSoftmaxTopK(const T* logits, float* topk_scales, int* topk_indices,
+                         int num_rows, int num_experts, int k, bool normalize_scales,
+                         cudaStream_t stream) {
+  // Block-per-row CUB merge sort is the fastest path for the common decode case
+  // (one block fully sorts a row). Pick the smallest capacity that covers
+  // num_experts. k must fit in s_topk (<= 64).
+  const dim3 grid(static_cast<unsigned>(num_rows));
+  if (k <= 64) {
+    if (num_experts <= 128) {
+      SoftmaxTopKMergeKernel<T, 128, 1><<<grid, 128, 0, stream>>>(
+          logits, topk_scales, topk_indices, num_rows, num_experts, k, normalize_scales);
+      return;
+    } else if (num_experts <= 256) {
+      SoftmaxTopKMergeKernel<T, 128, 2><<<grid, 128, 0, stream>>>(
+          logits, topk_scales, topk_indices, num_rows, num_experts, k, normalize_scales);
+      return;
+    } else if (num_experts <= 512) {
+      SoftmaxTopKMergeKernel<T, 128, 4><<<grid, 128, 0, stream>>>(
+          logits, topk_scales, topk_indices, num_rows, num_experts, k, normalize_scales);
+      return;
+    } else if (num_experts <= 1024) {
+      SoftmaxTopKMergeKernel<T, 256, 4><<<grid, 256, 0, stream>>>(
+          logits, topk_scales, topk_indices, num_rows, num_experts, k, normalize_scales);
+      return;
+    }
+    // num_experts > 1024: block-argmax kernel handles arbitrary sizes.
+    constexpr int kBlockSize = 256;
+    SoftmaxTopKKernelBlock<T, kBlockSize><<<grid, kBlockSize, 0, stream>>>(
+        logits, topk_scales, topk_indices, num_rows, num_experts, k, normalize_scales);
+  } else {
+    // k > 64 is not expected for MoE routing; fall back to the simple
+    // one-thread-per-row kernel which has no k cap.
+    const int block = 256;
+    const int grid_1d = Compute1DGridSize(num_rows, block);
+    SoftmaxTopKKernel<T><<<grid_1d, block, 0, stream>>>(
+        logits, topk_scales, topk_indices, num_rows, num_experts, k, normalize_scales);
+  }
+}
+
 void LaunchSoftmaxTopK(
     const float* logits,
     float* topk_scales,
@@ -97,9 +346,7 @@ void LaunchSoftmaxTopK(
     int k,
     bool normalize_scales,
     cudaStream_t stream) {
-  int block = 256;
-  int grid = Compute1DGridSize(num_rows, block);
-  SoftmaxTopKKernel<float><<<grid, block, 0, stream>>>(logits, topk_scales, topk_indices, num_rows, num_experts, k, normalize_scales);
+  DispatchSoftmaxTopK<float>(logits, topk_scales, topk_indices, num_rows, num_experts, k, normalize_scales, stream);
 }
 
 void LaunchSoftmaxTopK(
@@ -111,9 +358,7 @@ void LaunchSoftmaxTopK(
     int k,
     bool normalize_scales,
     cudaStream_t stream) {
-  int block = 256;
-  int grid = Compute1DGridSize(num_rows, block);
-  SoftmaxTopKKernel<half><<<grid, block, 0, stream>>>(logits, topk_scales, topk_indices, num_rows, num_experts, k, normalize_scales);
+  DispatchSoftmaxTopK<half>(logits, topk_scales, topk_indices, num_rows, num_experts, k, normalize_scales, stream);
 }
 
 void LaunchSoftmaxTopK(
@@ -125,9 +370,7 @@ void LaunchSoftmaxTopK(
     int k,
     bool normalize_scales,
     cudaStream_t stream) {
-  int block = 256;
-  int grid = Compute1DGridSize(num_rows, block);
-  SoftmaxTopKKernel<__nv_bfloat16><<<grid, block, 0, stream>>>(logits, topk_scales, topk_indices, num_rows, num_experts, k, normalize_scales);
+  DispatchSoftmaxTopK<__nv_bfloat16>(logits, topk_scales, topk_indices, num_rows, num_experts, k, normalize_scales, stream);
 }
 
 template <typename T>

--- a/onnxruntime/contrib_ops/cuda/moe/qmoe_kernels.cu
+++ b/onnxruntime/contrib_ops/cuda/moe/qmoe_kernels.cu
@@ -23,7 +23,7 @@ int Compute1DGridSize(int num_elements, int block_size) {
 constexpr float kTopKNormalizeEpsilon = 1e-6f;
 
 __device__ __forceinline__ float SoftmaxScale(float logit, float max_val, float inv_sum) {
-  return expf(logit - max_val) * inv_sum;
+  return (inv_sum > 0.0f) ? expf(logit - max_val) * inv_sum : 0.0f;
 }
 
 __device__ __forceinline__ float SafeInvSum(float sum) {
@@ -81,7 +81,7 @@ __global__ void SoftmaxTopKKernel(const T* logits, float* topk_scales, int* topk
   int* row_indices = topk_indices + row * k;
 
   // 1. Find max for numerical stability
-  float max_val = -FLT_MAX;
+  float max_val = onnxruntime::cuda::topk::kNegativeInfinity;
   for (int i = 0; i < num_experts; ++i) {
     float val = static_cast<float>(row_logits[i]);
     if (val > max_val) max_val = val;
@@ -92,6 +92,7 @@ __global__ void SoftmaxTopKKernel(const T* logits, float* topk_scales, int* topk
   for (int i = 0; i < num_experts; ++i) {
     sum_exp += expf(static_cast<float>(row_logits[i]) - max_val);
   }
+  const float inv_sum = SafeInvSum(sum_exp);
 
   // 3. Compute Softmax and find TopK
   // For small k, we can do a simple selection.
@@ -107,7 +108,7 @@ __global__ void SoftmaxTopKKernel(const T* logits, float* topk_scales, int* topk
   }
 
   for (int i = 0; i < num_experts; ++i) {
-    float prob = expf(static_cast<float>(row_logits[i]) - max_val) / sum_exp;
+    float prob = SoftmaxScale(static_cast<float>(row_logits[i]), max_val, inv_sum);
 
     // Insert into top-k logic
     // Simple insertion sort for very small k (e.g. k=2)
@@ -144,9 +145,10 @@ __global__ void SoftmaxTopKKernel(const T* logits, float* topk_scales, int* topk
 // ~2.5x faster than k rounds of block-argmax on this size (benchmarked), and is
 // the layout onnxruntime-genai's top-k benchmarks also recommend (CUB block
 // merge) for sort sizes up to ~1024. The capacity (kBlockSize*kItemsPerThread)
-// must be >= num_experts; padding lanes carry -FLT_MAX so they sort to the
-// bottom. Tie-breaking matches the scalar kernel (lower expert index first) via
-// the same packed stable sort key used by the warp merge path.
+// must be >= num_experts; padding lanes carry (-inf, INT_MAX) so valid -inf
+// expert scores sort ahead of padding. Tie-breaking matches the scalar kernel
+// (lower expert index first) via the same packed stable sort key used by the
+// warp merge path.
 
 template <typename T, int kBlockSize, int kItemsPerThread>
 __global__ void SoftmaxTopKMergeKernel(const T* logits, float* topk_scales, int* topk_indices,
@@ -170,11 +172,12 @@ __global__ void SoftmaxTopKMergeKernel(const T* logits, float* topk_scales, int*
   // Load this thread's packed (logit, expert index) keys in a blocked
   // arrangement: thread t owns indices [t*ipt, t*ipt+ipt).
   uint64_t keys[kItemsPerThread];
-  float local_max = -FLT_MAX;
+  float local_max = onnxruntime::cuda::topk::kNegativeInfinity;
 #pragma unroll
   for (int j = 0; j < kItemsPerThread; ++j) {
     const int idx = tid * kItemsPerThread + j;
-    const float logit = (idx < num_experts) ? static_cast<float>(row_logits[idx]) : -FLT_MAX;
+    const float logit = (idx < num_experts) ? static_cast<float>(row_logits[idx])
+                                            : onnxruntime::cuda::topk::kNegativeInfinity;
     const int index = (idx < num_experts) ? idx : INT_MAX;
     keys[j] = onnxruntime::cuda::topk::PackStableSortKey(logit, index);
     local_max = fmaxf(local_max, logit);
@@ -247,7 +250,8 @@ __global__ void SoftmaxTopKWarpBitonicKernel(const T* logits, float* topk_scales
   if (row >= num_rows) return;
 
   const T* row_logits = logits + static_cast<size_t>(row) * num_experts;
-  const float logit = (lane < num_experts) ? static_cast<float>(row_logits[lane]) : -FLT_MAX;
+  const float logit = (lane < num_experts) ? static_cast<float>(row_logits[lane])
+                                           : onnxruntime::cuda::topk::kNegativeInfinity;
 
   const float max_val = WarpReduceMax(logit);
 
@@ -295,9 +299,10 @@ __global__ void SoftmaxTopKWarpMergeKernel(const T* logits, float* topk_scales, 
   const T* row_logits = logits + static_cast<size_t>(row) * num_experts;
 
   // Load logits into shared memory and compute the warp-wide max.
-  float local_max = -FLT_MAX;
+  float local_max = onnxruntime::cuda::topk::kNegativeInfinity;
   for (int i = lane; i < kBufferSize; i += kWarpSize) {
-    const float v = (i < num_experts) ? static_cast<float>(row_logits[i]) : -FLT_MAX;
+    const float v = (i < num_experts) ? static_cast<float>(row_logits[i])
+                                      : onnxruntime::cuda::topk::kNegativeInfinity;
     s_scores[i] = v;
     s_indices[i] = (i < num_experts) ? i : INT_MAX;
     local_max = fmaxf(local_max, v);
@@ -336,6 +341,10 @@ template <typename T>
 void DispatchSoftmaxTopK(const T* logits, float* topk_scales, int* topk_indices,
                          int num_rows, int num_experts, int k, bool normalize_scales,
                          cudaStream_t stream) {
+  ORT_ENFORCE(k > 0 && k <= num_experts,
+              "SoftmaxTopK requires 0 < k <= num_experts, got k=", k,
+              " and num_experts=", num_experts);
+
   // Block-per-row CUB merge sort is the fastest path for the common decode case
   // (one block fully sorts a row). Pick the smallest capacity that covers
   // num_experts. k must fit in s_topk (<= 64).

--- a/onnxruntime/core/providers/cuda/cu_inc/topk_warp_sort.cuh
+++ b/onnxruntime/core/providers/cuda/cu_inc/topk_warp_sort.cuh
@@ -1,0 +1,160 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Reusable warp-level Top-K sorting primitives for CUDA.
+//
+// These helpers sort (score, index) pairs in descending order. Ties on the
+// score are broken deterministically by preferring the smaller index, matching
+// the tie-breaking used by the onnxruntime-genai Top-K kernels (the
+// `STABLE_TOPK` path in cuda_topk_warp_sort_helper.cuh).
+//
+// Two primitives are provided, mirroring the algorithms that the genai offline
+// benchmark found fastest for small sort sizes:
+//   * WarpBitonicSortDescending : best for sort sizes up to 32. Each lane holds
+//     a single (score, index) pair entirely in registers and exchanges data
+//     via warp shuffles, avoiding shared memory.
+//   * WarpMergeSorter            : best for sort sizes up to 64 (CUB warp merge
+//     sort). A single warp sorts up to `BufferSize` pairs held in shared memory.
+//
+// They are intentionally operator-agnostic so they can be reused outside the
+// MoE Top-K path.
+
+#pragma once
+
+#include <cfloat>
+#include <climits>
+#include <cstdint>
+
+#include "core/providers/cuda/cu_inc/cub.cuh"
+
+namespace onnxruntime {
+namespace cuda {
+namespace topk_warp {
+
+constexpr int kWarpSize = 32;
+
+// Compile-time threshold guidance based on the onnxruntime-genai offline
+// benchmark (NVIDIA H200, CUDA 12.8). Use WarpBitonicSortDescending for sort
+// sizes up to kWarpBitonicMaxSize, and the CUB warp merge sort for sizes up to
+// kWarpMergeMaxSize. Larger sizes should fall back to a block-wide sort.
+constexpr int kWarpBitonicMaxSize = 32;
+constexpr int kWarpMergeMaxSize = 64;
+
+/**
+ * @brief In-register, warp-wide bitonic sort of kWarpSize (32) (score, index)
+ *        pairs, producing a descending order.
+ *
+ * Each lane in the warp contributes exactly one (score, index) pair. After the
+ * call, the warp's pairs are sorted so that lane 0 holds the largest score.
+ * Ties on the score are broken in favor of the smaller index. Data is exchanged
+ * with __shfl_sync, so no shared memory is required.
+ *
+ * Lanes that do not hold a valid element should pass score = -FLT_MAX and
+ * index = INT_MAX so that they sort to the bottom.
+ */
+__device__ inline void WarpBitonicSortDescending(float& score, int& index) {
+  const int lane_id = threadIdx.x % kWarpSize;
+
+  // Build the bitonic sorting network in stages.
+  for (int k = 2; k <= kWarpSize; k <<= 1) {
+    for (int j = k >> 1; j > 0; j >>= 1) {
+      const int paired_lane = lane_id ^ j;
+      const float paired_score = __shfl_sync(0xFFFFFFFF, score, paired_lane);
+      const int paired_index = __shfl_sync(0xFFFFFFFF, index, paired_lane);
+
+      // A standard bitonic network sorts ascending when (lane_id & k) == 0; we
+      // invert the swap condition to produce an overall descending sort.
+      const bool direction = ((lane_id & k) == 0);
+
+      // Tie-break: equal scores prefer the smaller index.
+      const bool is_mine_greater =
+          (score > paired_score) || (score == paired_score && index < paired_index);
+
+      const float s_max = is_mine_greater ? score : paired_score;
+      const int i_max = is_mine_greater ? index : paired_index;
+      const float s_min = is_mine_greater ? paired_score : score;
+      const int i_min = is_mine_greater ? paired_index : index;
+
+      if (direction) {
+        score = (lane_id < paired_lane) ? s_max : s_min;
+        index = (lane_id < paired_lane) ? i_max : i_min;
+      } else {
+        score = (lane_id < paired_lane) ? s_min : s_max;
+        index = (lane_id < paired_lane) ? i_min : i_max;
+      }
+    }
+  }
+}
+
+// Composite key sorted by the CUB warp merge sort. Sorting the (score, index)
+// pair as a single key lets the comparator break ties deterministically without
+// relying on the sort being stable (CUB merge sort is not stable).
+struct ScoreIndex {
+  float score;
+  int index;
+};
+
+// Descending comparator with smaller-index tie-breaking.
+struct ScoreIndexGreater {
+  __device__ __forceinline__ bool operator()(const ScoreIndex& a, const ScoreIndex& b) const {
+    return a.score > b.score || (a.score == b.score && a.index < b.index);
+  }
+};
+
+/**
+ * @brief Single-warp CUB merge sort of up to `BufferSize` (score, index) pairs
+ *        held in shared memory, producing a descending order.
+ *
+ * Only the first warp of the calling block performs work; the caller is
+ * responsible for any __syncthreads() needed before (to publish the shared
+ * memory inputs) and after (to consume the sorted outputs). On return,
+ * smem_scores[r]/smem_indices[r] hold the element of rank r (rank 0 == largest).
+ *
+ * @tparam BufferSize Maximum number of pairs to sort. Must be <= 256.
+ */
+template <int BufferSize>
+struct WarpMergeSorter {
+  static_assert(BufferSize > 0 && BufferSize <= 256, "BufferSize must be in (0, 256].");
+
+  static constexpr int kItemsPerThread = (BufferSize + kWarpSize - 1) / kWarpSize;
+  using SortT = cub::WarpMergeSort<ScoreIndex, kItemsPerThread, kWarpSize>;
+  using TempStorage = typename SortT::TempStorage;
+
+  // num_valid_items elements are read from shared memory; the remainder are
+  // padded with (-FLT_MAX, INT_MAX) so they sort to the bottom.
+  __device__ static void Sort(float* smem_scores, int* smem_indices,
+                              TempStorage& temp_storage, int num_valid_items) {
+    if (threadIdx.x >= kWarpSize) {
+      return;
+    }
+
+    ScoreIndex items[kItemsPerThread];
+#pragma unroll
+    for (int i = 0; i < kItemsPerThread; ++i) {
+      const int idx = threadIdx.x + i * kWarpSize;
+      if (idx < num_valid_items) {
+        items[i].score = smem_scores[idx];
+        items[i].index = smem_indices[idx];
+      } else {
+        items[i].score = -FLT_MAX;
+        items[i].index = INT_MAX;
+      }
+    }
+
+    SortT(temp_storage).Sort(items, ScoreIndexGreater());
+
+    // Blocked write-back: rank r lives at smem[r].
+#pragma unroll
+    for (int i = 0; i < kItemsPerThread; ++i) {
+      const int idx = threadIdx.x * kItemsPerThread + i;
+      if (idx < BufferSize) {
+        smem_scores[idx] = items[i].score;
+        smem_indices[idx] = items[i].index;
+      }
+    }
+  }
+};
+
+}  // namespace topk_warp
+}  // namespace cuda
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cuda/cu_inc/topk_warp_sort.cuh
+++ b/onnxruntime/core/providers/cuda/cu_inc/topk_warp_sort.cuh
@@ -29,7 +29,7 @@
 
 namespace onnxruntime {
 namespace cuda {
-namespace topk_warp {
+namespace topk {
 
 constexpr int kWarpSize = 32;
 
@@ -120,8 +120,9 @@ __device__ __forceinline__ int UnpackStableSortIndex(uint64_t key) {
   return static_cast<int>(UINT_MAX - inverted_index);
 }
 
-struct PackedStableSortKeyGreater {
-  __device__ __forceinline__ bool operator()(uint64_t a, uint64_t b) const {
+template <typename T>
+struct Greater {
+  __device__ __host__ __forceinline__ bool operator()(const T& a, const T& b) const {
     return a > b;
   }
 };
@@ -167,7 +168,7 @@ struct WarpMergeSorter {
       }
     }
 
-    SortT(temp_storage).Sort(items, PackedStableSortKeyGreater());
+    SortT(temp_storage).Sort(items, Greater<uint64_t>());
 
     // Blocked write-back: rank r lives at smem[r].
 #pragma unroll
@@ -181,6 +182,6 @@ struct WarpMergeSorter {
   }
 };
 
-}  // namespace topk_warp
+}  // namespace topk
 }  // namespace cuda
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/cuda/cu_inc/topk_warp_sort.cuh
+++ b/onnxruntime/core/providers/cuda/cu_inc/topk_warp_sort.cuh
@@ -24,6 +24,7 @@
 #include <cfloat>
 #include <climits>
 #include <cstdint>
+#include <limits>
 
 #include "core/providers/cuda/cu_inc/cub.cuh"
 
@@ -39,6 +40,7 @@ constexpr int kWarpSize = 32;
 // kWarpMergeMaxSize. Larger sizes should fall back to a block-wide sort.
 constexpr int kWarpBitonicMaxSize = 32;
 constexpr int kWarpMergeMaxSize = 64;
+constexpr float kNegativeInfinity = -std::numeric_limits<float>::infinity();
 
 __device__ __forceinline__ int LaneId() {
   int lane_id;
@@ -59,8 +61,8 @@ __device__ __forceinline__ int LinearThreadIdInBlock() {
  * Ties on the score are broken in favor of the smaller index. Data is exchanged
  * with __shfl_sync, so no shared memory is required.
  *
- * Lanes that do not hold a valid element should pass score = -FLT_MAX and
- * index = INT_MAX so that they sort to the bottom.
+ * Lanes that do not hold a valid element should pass score = kNegativeInfinity
+ * and index = INT_MAX so that valid -inf scores sort ahead of padding.
  */
 __device__ inline void WarpBitonicSortDescending(float& score, int& index) {
   const int lane_id = LaneId();
@@ -147,7 +149,7 @@ struct WarpMergeSorter {
   using TempStorage = typename SortT::TempStorage;
 
   // num_valid_items elements are read from shared memory; the remainder are
-  // padded with (-FLT_MAX, INT_MAX) so they sort to the bottom.
+  // padded with (kNegativeInfinity, INT_MAX) so valid -inf scores sort ahead of padding.
   __device__ static void Sort(float* smem_scores, int* smem_indices,
                               TempStorage& temp_storage, int num_valid_items) {
     const int thread_id = LinearThreadIdInBlock();
@@ -164,7 +166,7 @@ struct WarpMergeSorter {
       if (idx < num_valid_items) {
         items[i] = PackStableSortKey(smem_scores[idx], smem_indices[idx]);
       } else {
-        items[i] = PackStableSortKey(-FLT_MAX, INT_MAX);
+        items[i] = PackStableSortKey(kNegativeInfinity, INT_MAX);
       }
     }
 

--- a/onnxruntime/core/providers/cuda/cu_inc/topk_warp_sort.cuh
+++ b/onnxruntime/core/providers/cuda/cu_inc/topk_warp_sort.cuh
@@ -96,18 +96,33 @@ __device__ inline void WarpBitonicSortDescending(float& score, int& index) {
   }
 }
 
-// Composite key sorted by the CUB warp merge sort. Sorting the (score, index)
-// pair as a single key lets the comparator break ties deterministically without
-// relying on the sort being stable (CUB merge sort is not stable).
-struct ScoreIndex {
-  float score;
-  int index;
-};
+// Convert a (score, index) pair into a single unsigned integer key. Descending
+// integer order then gives descending float score order, with equal scores
+// preferring the smaller original index. This matches the stable Top-K packing
+// used by onnxruntime-genai while avoiding a compound comparator in CUB.
+__device__ __forceinline__ uint64_t PackStableSortKey(float score, int index) {
+  const uint32_t score_bits = __float_as_uint(score);
+  const uint32_t sortable_score =
+      (score_bits & 0x80000000u) ? (~score_bits) : (score_bits | 0x80000000u);
+  const uint32_t inverted_index = UINT_MAX - static_cast<uint32_t>(index);
+  return (static_cast<uint64_t>(sortable_score) << 32) | inverted_index;
+}
 
-// Descending comparator with smaller-index tie-breaking.
-struct ScoreIndexGreater {
-  __device__ __forceinline__ bool operator()(const ScoreIndex& a, const ScoreIndex& b) const {
-    return a.score > b.score || (a.score == b.score && a.index < b.index);
+__device__ __forceinline__ float UnpackStableSortScore(uint64_t key) {
+  const uint32_t sortable_score = static_cast<uint32_t>(key >> 32);
+  const uint32_t score_bits =
+      (sortable_score & 0x80000000u) ? (sortable_score & 0x7fffffffu) : ~sortable_score;
+  return __uint_as_float(score_bits);
+}
+
+__device__ __forceinline__ int UnpackStableSortIndex(uint64_t key) {
+  const uint32_t inverted_index = static_cast<uint32_t>(key & 0xffffffffu);
+  return static_cast<int>(UINT_MAX - inverted_index);
+}
+
+struct PackedStableSortKeyGreater {
+  __device__ __forceinline__ bool operator()(uint64_t a, uint64_t b) const {
+    return a > b;
   }
 };
 
@@ -127,7 +142,7 @@ struct WarpMergeSorter {
   static_assert(BufferSize > 0 && BufferSize <= 256, "BufferSize must be in (0, 256].");
 
   static constexpr int kItemsPerThread = (BufferSize + kWarpSize - 1) / kWarpSize;
-  using SortT = cub::WarpMergeSort<ScoreIndex, kItemsPerThread, kWarpSize>;
+  using SortT = cub::WarpMergeSort<uint64_t, kItemsPerThread, kWarpSize, cub::NullType>;
   using TempStorage = typename SortT::TempStorage;
 
   // num_valid_items elements are read from shared memory; the remainder are
@@ -141,28 +156,26 @@ struct WarpMergeSorter {
 
     const int lane_id = thread_id;
 
-    ScoreIndex items[kItemsPerThread];
+    uint64_t items[kItemsPerThread];
 #pragma unroll
     for (int i = 0; i < kItemsPerThread; ++i) {
       const int idx = lane_id + i * kWarpSize;
       if (idx < num_valid_items) {
-        items[i].score = smem_scores[idx];
-        items[i].index = smem_indices[idx];
+        items[i] = PackStableSortKey(smem_scores[idx], smem_indices[idx]);
       } else {
-        items[i].score = -FLT_MAX;
-        items[i].index = INT_MAX;
+        items[i] = PackStableSortKey(-FLT_MAX, INT_MAX);
       }
     }
 
-    SortT(temp_storage).Sort(items, ScoreIndexGreater());
+    SortT(temp_storage).Sort(items, PackedStableSortKeyGreater());
 
     // Blocked write-back: rank r lives at smem[r].
 #pragma unroll
     for (int i = 0; i < kItemsPerThread; ++i) {
-  const int idx = lane_id * kItemsPerThread + i;
+      const int idx = lane_id * kItemsPerThread + i;
       if (idx < BufferSize) {
-        smem_scores[idx] = items[i].score;
-        smem_indices[idx] = items[i].index;
+        smem_scores[idx] = UnpackStableSortScore(items[i]);
+        smem_indices[idx] = UnpackStableSortIndex(items[i]);
       }
     }
   }

--- a/onnxruntime/core/providers/cuda/cu_inc/topk_warp_sort.cuh
+++ b/onnxruntime/core/providers/cuda/cu_inc/topk_warp_sort.cuh
@@ -40,6 +40,16 @@ constexpr int kWarpSize = 32;
 constexpr int kWarpBitonicMaxSize = 32;
 constexpr int kWarpMergeMaxSize = 64;
 
+__device__ __forceinline__ int LaneId() {
+  int lane_id;
+  asm volatile("mov.u32 %0, %%laneid;" : "=r"(lane_id));
+  return lane_id;
+}
+
+__device__ __forceinline__ int LinearThreadIdInBlock() {
+  return threadIdx.x + blockDim.x * (threadIdx.y + blockDim.y * threadIdx.z);
+}
+
 /**
  * @brief In-register, warp-wide bitonic sort of kWarpSize (32) (score, index)
  *        pairs, producing a descending order.
@@ -53,7 +63,7 @@ constexpr int kWarpMergeMaxSize = 64;
  * index = INT_MAX so that they sort to the bottom.
  */
 __device__ inline void WarpBitonicSortDescending(float& score, int& index) {
-  const int lane_id = threadIdx.x % kWarpSize;
+  const int lane_id = LaneId();
 
   // Build the bitonic sorting network in stages.
   for (int k = 2; k <= kWarpSize; k <<= 1) {
@@ -124,14 +134,17 @@ struct WarpMergeSorter {
   // padded with (-FLT_MAX, INT_MAX) so they sort to the bottom.
   __device__ static void Sort(float* smem_scores, int* smem_indices,
                               TempStorage& temp_storage, int num_valid_items) {
-    if (threadIdx.x >= kWarpSize) {
+    const int thread_id = LinearThreadIdInBlock();
+    if (thread_id >= kWarpSize) {
       return;
     }
+
+    const int lane_id = thread_id;
 
     ScoreIndex items[kItemsPerThread];
 #pragma unroll
     for (int i = 0; i < kItemsPerThread; ++i) {
-      const int idx = threadIdx.x + i * kWarpSize;
+      const int idx = lane_id + i * kWarpSize;
       if (idx < num_valid_items) {
         items[i].score = smem_scores[idx];
         items[i].index = smem_indices[idx];
@@ -146,7 +159,7 @@ struct WarpMergeSorter {
     // Blocked write-back: rank r lives at smem[r].
 #pragma unroll
     for (int i = 0; i < kItemsPerThread; ++i) {
-      const int idx = threadIdx.x * kItemsPerThread + i;
+  const int idx = lane_id * kItemsPerThread + i;
       if (idx < BufferSize) {
         smem_scores[idx] = items[i].score;
         smem_indices[idx] = items[i].index;

--- a/onnxruntime/test/contrib_ops/cuda_kernels/softmax_topk_kernel_test.cc
+++ b/onnxruntime/test/contrib_ops/cuda_kernels/softmax_topk_kernel_test.cc
@@ -222,6 +222,52 @@ TEST(CUDA_EP_Unittest, SoftmaxTopK_BlockMergeStillMatchesReference) {
   RunSoftmaxTopKTest<float>(num_rows, num_experts, k, true, logits, 1e-6f);
 }
 
+TEST(CUDA_EP_Unittest, SoftmaxTopK_WarpBitonicHandlesNegativeInfinityPadding) {
+  constexpr int num_rows = 2;
+  constexpr int num_experts = 8;
+  constexpr int k = 8;
+  constexpr float neg_inf = -std::numeric_limits<float>::infinity();
+  std::vector<float> logits = {
+      3.0f, neg_inf, 2.0f, neg_inf, 1.0f, neg_inf, 0.0f, neg_inf,
+      neg_inf, 4.0f, neg_inf, neg_inf, 3.0f, neg_inf, neg_inf, 2.0f};
+
+  RunSoftmaxTopKTest<float>(num_rows, num_experts, k, false, logits, 1e-6f);
+}
+
+TEST(CUDA_EP_Unittest, SoftmaxTopK_WarpMergeHandlesNegativeInfinityPadding) {
+  constexpr int num_rows = 2;
+  constexpr int num_experts = 40;
+  constexpr int k = 40;
+  constexpr float neg_inf = -std::numeric_limits<float>::infinity();
+  std::vector<float> logits(static_cast<size_t>(num_rows) * num_experts, neg_inf);
+  for (int expert = 0; expert < 10; ++expert) {
+    logits[expert * 3] = static_cast<float>(expert) * 0.25f;
+    logits[static_cast<size_t>(1) * num_experts + expert * 2] = 3.0f - static_cast<float>(expert) * 0.125f;
+  }
+
+  RunSoftmaxTopKTest<float>(num_rows, num_experts, k, true, logits, 1e-6f);
+}
+
+TEST(CUDA_EP_Unittest, SoftmaxTopK_BlockMergeHandlesNegativeInfinityPadding) {
+  constexpr int num_rows = 2;
+  constexpr int num_experts = 80;
+  constexpr int k = 64;
+  constexpr float neg_inf = -std::numeric_limits<float>::infinity();
+  std::vector<float> logits(static_cast<size_t>(num_rows) * num_experts, neg_inf);
+  for (int expert = 0; expert < 20; ++expert) {
+    logits[expert * 2] = static_cast<float>(expert) * 0.125f;
+    logits[static_cast<size_t>(1) * num_experts + expert * 3] = 5.0f - static_cast<float>(expert) * 0.25f;
+  }
+
+  RunSoftmaxTopKTest<float>(num_rows, num_experts, k, true, logits, 1e-6f);
+}
+
+TEST(CUDA_EP_Unittest, SoftmaxTopK_RejectsKGreaterThanExperts) {
+  EXPECT_THROW(onnxruntime::contrib::cuda::LaunchSoftmaxTopK(
+                   static_cast<const float*>(nullptr), nullptr, nullptr, 1, 8, 9, false, nullptr),
+               OnnxRuntimeException);
+}
+
 }  // namespace
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/contrib_ops/cuda_kernels/softmax_topk_kernel_test.cc
+++ b/onnxruntime/test/contrib_ops/cuda_kernels/softmax_topk_kernel_test.cc
@@ -1,0 +1,227 @@
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+
+#include "contrib_ops/cuda/moe/qmoe_kernels.h"
+#include "core/providers/cuda/cuda_common.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <numeric>
+#include <vector>
+
+namespace onnxruntime {
+namespace test {
+namespace {
+
+struct CudaBuffer {
+  void* data = nullptr;
+  size_t bytes = 0;
+
+  explicit CudaBuffer(size_t size_in_bytes) : bytes(size_in_bytes) {
+    CUDA_CALL_THROW(cudaMalloc(&data, bytes));
+  }
+
+  ~CudaBuffer() {
+    if (data != nullptr) {
+      cudaFree(data);
+    }
+  }
+
+  template <typename T>
+  T* As() {
+    return reinterpret_cast<T*>(data);
+  }
+
+  void CopyFromHost(const void* src) {
+    CUDA_CALL_THROW(cudaMemcpy(data, src, bytes, cudaMemcpyHostToDevice));
+  }
+
+  void CopyToHost(void* dst) const {
+    CUDA_CALL_THROW(cudaMemcpy(dst, data, bytes, cudaMemcpyDeviceToHost));
+  }
+};
+
+struct ExpectedTopK {
+  std::vector<float> scales;
+  std::vector<int> indices;
+};
+
+template <typename T>
+float ToFloat(T value) {
+  return static_cast<float>(value);
+}
+
+template <typename T>
+T FromFloat(float value) {
+  return static_cast<T>(value);
+}
+
+template <typename T>
+ExpectedTopK ReferenceSoftmaxTopK(const std::vector<T>& logits, int num_rows, int num_experts, int k,
+                                  bool normalize_scales) {
+  ExpectedTopK expected;
+  expected.scales.resize(static_cast<size_t>(num_rows) * k);
+  expected.indices.resize(static_cast<size_t>(num_rows) * k);
+
+  for (int row = 0; row < num_rows; ++row) {
+    const T* row_logits = logits.data() + static_cast<size_t>(row) * num_experts;
+    float max_logit = -std::numeric_limits<float>::infinity();
+    for (int expert = 0; expert < num_experts; ++expert) {
+      max_logit = std::max(max_logit, ToFloat(row_logits[expert]));
+    }
+
+    float sum_exp = 0.0f;
+    for (int expert = 0; expert < num_experts; ++expert) {
+      sum_exp += std::exp(ToFloat(row_logits[expert]) - max_logit);
+    }
+
+    std::vector<int> order(num_experts);
+    std::iota(order.begin(), order.end(), 0);
+    std::stable_sort(order.begin(), order.end(), [&](int lhs, int rhs) {
+      const float lhs_logit = ToFloat(row_logits[lhs]);
+      const float rhs_logit = ToFloat(row_logits[rhs]);
+      return lhs_logit > rhs_logit || (lhs_logit == rhs_logit && lhs < rhs);
+    });
+
+    float topk_sum = 0.0f;
+    for (int rank = 0; rank < k; ++rank) {
+      const int expert = order[rank];
+      const float scale = std::exp(ToFloat(row_logits[expert]) - max_logit) / sum_exp;
+      expected.scales[static_cast<size_t>(row) * k + rank] = scale;
+      expected.indices[static_cast<size_t>(row) * k + rank] = expert;
+      topk_sum += scale;
+    }
+
+    if (normalize_scales && topk_sum > 1e-6f) {
+      for (int rank = 0; rank < k; ++rank) {
+        expected.scales[static_cast<size_t>(row) * k + rank] /= topk_sum;
+      }
+    }
+  }
+
+  return expected;
+}
+
+template <typename T>
+void RunSoftmaxTopKTest(int num_rows, int num_experts, int k, bool normalize_scales,
+                        const std::vector<float>& logits_float, float tolerance) {
+  ASSERT_EQ(logits_float.size(), static_cast<size_t>(num_rows) * num_experts);
+
+  std::vector<T> logits(logits_float.size());
+  std::transform(logits_float.begin(), logits_float.end(), logits.begin(), [](float value) {
+    return FromFloat<T>(value);
+  });
+
+  CudaBuffer d_logits(logits.size() * sizeof(T));
+  CudaBuffer d_scales(static_cast<size_t>(num_rows) * k * sizeof(float));
+  CudaBuffer d_indices(static_cast<size_t>(num_rows) * k * sizeof(int));
+  d_logits.CopyFromHost(logits.data());
+
+  cudaStream_t stream = nullptr;
+  CUDA_CALL_THROW(cudaStreamCreate(&stream));
+  onnxruntime::contrib::cuda::LaunchSoftmaxTopK(
+      d_logits.As<T>(), d_scales.As<float>(), d_indices.As<int>(), num_rows, num_experts, k, normalize_scales, stream);
+  CUDA_CALL_THROW(cudaGetLastError());
+  CUDA_CALL_THROW(cudaStreamSynchronize(stream));
+  CUDA_CALL_THROW(cudaStreamDestroy(stream));
+
+  std::vector<float> actual_scales(static_cast<size_t>(num_rows) * k);
+  std::vector<int> actual_indices(static_cast<size_t>(num_rows) * k);
+  d_scales.CopyToHost(actual_scales.data());
+  d_indices.CopyToHost(actual_indices.data());
+
+  const ExpectedTopK expected = ReferenceSoftmaxTopK(logits, num_rows, num_experts, k, normalize_scales);
+  ASSERT_EQ(actual_indices, expected.indices);
+  ASSERT_EQ(actual_scales.size(), expected.scales.size());
+  for (size_t i = 0; i < actual_scales.size(); ++i) {
+    EXPECT_NEAR(actual_scales[i], expected.scales[i], tolerance) << "at flattened top-k index " << i;
+  }
+}
+
+std::vector<float> MakeLogits(int num_rows, int num_experts) {
+  std::vector<float> logits(static_cast<size_t>(num_rows) * num_experts);
+  for (int row = 0; row < num_rows; ++row) {
+    for (int expert = 0; expert < num_experts; ++expert) {
+      const int v = (expert * 17 + row * 11) % 29;
+      logits[static_cast<size_t>(row) * num_experts + expert] = 0.125f * static_cast<float>(v - 14);
+    }
+  }
+  return logits;
+}
+
+TEST(CUDA_EP_Unittest, SoftmaxTopK_WarpBitonicStableTiesFloat) {
+  constexpr int num_rows = 9;
+  constexpr int num_experts = 8;
+  constexpr int k = 4;
+  std::vector<float> logits = {
+      4.0f, 1.0f, 4.0f, 0.0f, 3.0f, 4.0f, -2.0f, 4.0f,
+      -1.0f, 2.0f, 2.0f, 5.0f, 5.0f, 5.0f, 0.5f, -3.0f,
+      0.0f, 0.0f, 0.0f, -1.0f, -1.0f, 2.0f, 2.0f, 2.0f,
+      3.0f, 1.0f, 2.0f, 3.0f, 3.0f, -4.0f, -5.0f, 0.0f,
+      1.5f, 1.5f, 1.0f, 2.0f, 0.0f, 2.0f, 2.0f, -2.0f,
+      -6.0f, -5.0f, -4.0f, -3.0f, -2.0f, -1.0f, 0.0f, 1.0f,
+      7.0f, 7.0f, 6.0f, 6.0f, 5.0f, 5.0f, 4.0f, 4.0f,
+      -1.0f, 8.0f, -1.0f, 8.0f, 3.0f, 8.0f, 2.0f, 1.0f,
+      0.25f, 0.5f, 0.75f, 1.0f, 1.25f, 1.5f, 1.75f, 2.0f};
+
+  RunSoftmaxTopKTest<float>(num_rows, num_experts, k, false, logits, 1e-6f);
+}
+
+TEST(CUDA_EP_Unittest, SoftmaxTopK_WarpBitonicBoundaryNormalizeHalf) {
+  constexpr int num_rows = 10;
+  constexpr int num_experts = 32;
+  constexpr int k = 8;
+  auto logits = MakeLogits(num_rows, num_experts);
+  logits[3 * num_experts + 0] = 6.0f;
+  logits[3 * num_experts + 5] = 6.0f;
+  logits[3 * num_experts + 17] = 6.0f;
+
+  RunSoftmaxTopKTest<half>(num_rows, num_experts, k, true, logits, 2e-3f);
+}
+
+TEST(CUDA_EP_Unittest, SoftmaxTopK_WarpMergeStableTiesFloat) {
+  constexpr int num_rows = 5;
+  constexpr int num_experts = 64;
+  constexpr int k = 8;
+  auto logits = MakeLogits(num_rows, num_experts);
+  for (int expert : {2, 13, 31, 63}) {
+    logits[static_cast<size_t>(1) * num_experts + expert] = 5.0f;
+  }
+  for (int expert : {0, 16, 32, 48}) {
+    logits[static_cast<size_t>(4) * num_experts + expert] = 4.5f;
+  }
+
+  RunSoftmaxTopKTest<float>(num_rows, num_experts, k, false, logits, 1e-6f);
+}
+
+TEST(CUDA_EP_Unittest, SoftmaxTopK_WarpMergeNormalizeBFloat16) {
+  constexpr int num_rows = 6;
+  constexpr int num_experts = 64;
+  constexpr int k = 16;
+  auto logits = MakeLogits(num_rows, num_experts);
+  logits[2 * num_experts + 4] = 7.0f;
+  logits[2 * num_experts + 9] = 7.0f;
+  logits[2 * num_experts + 47] = 7.0f;
+
+  RunSoftmaxTopKTest<__nv_bfloat16>(num_rows, num_experts, k, true, logits, 2e-2f);
+}
+
+TEST(CUDA_EP_Unittest, SoftmaxTopK_BlockMergeStillMatchesReference) {
+  constexpr int num_rows = 4;
+  constexpr int num_experts = 128;
+  constexpr int k = 8;
+  auto logits = MakeLogits(num_rows, num_experts);
+  logits[0] = 9.0f;
+  logits[7] = 9.0f;
+  logits[65] = 9.0f;
+
+  RunSoftmaxTopKTest<float>(num_rows, num_experts, k, true, logits, 1e-6f);
+}
+
+}  // namespace
+}  // namespace test
+}  // namespace onnxruntime


### PR DESCRIPTION
### Description

Optimizes the CUDA QMoE router top-k (`LaunchSoftmaxTopK`) for small-batch / autoregressive decode by replacing the old one-thread-per-row hot path with parallel CUB and warp-level top-k kernels. The dispatch now uses the fastest specialized path for common MoE expert counts while preserving the existing softmax normalization and deterministic lower-index tie-breaking semantics.

This PR also factors the warp-level top-k sorting code into a reusable CUDA helper header and adds direct CUDA-internal tests so the new routing paths are covered independently of higher-level QMoE tests.

### Motivation and Context

The previous router path launched a 256-thread block per row but did all top-k work in a single thread. In decode scenarios such as `num_rows == 1`, that made the router latency-bound on a serial scan of all expert logits and turned `SoftmaxTopKKernel` into a major MoE decode bottleneck.

For a Qwen3-style MoE workload with 256 experts, top-8 routing, and 40 MoE layers, the original router accounted for roughly 50% of decode GPU time. Moving the work to block/warp-parallel kernels removes that bottleneck while keeping the same output ordering and scaling behavior.

### Key Changes

| Area | Change |
|---|---|
| QMoE router dispatch | Adds `DispatchSoftmaxTopK` routing for `k <= 64` and `num_experts <= 1024`, with a fallback to the original scalar kernel for larger or uncommon shapes. |
| Tiny expert counts | Adds `SoftmaxTopKWarpBitonicKernel` for `num_experts <= 32`, using one warp per row and in-register bitonic sorting via warp shuffles. |
| Small expert counts | Adds `SoftmaxTopKWarpMergeKernel` for `32 < num_experts <= 64`, using a single warp and CUB warp merge sort. |
| Larger common MoE counts | Uses `SoftmaxTopKMergeKernel` with CUB block merge sort for `num_experts <= 128`, `256`, `512`, and `1024`. |
| Reusable top-k helpers | Adds `onnxruntime/core/providers/cuda/cu_inc/topk_warp_sort.cuh` with reusable warp bitonic and warp merge sort helpers. |
| Stable tie-breaking | Packs `(score, index)` into a `uint64_t` stable sort key for the CUB merge paths, matching onnxruntime-genai's lower-index tie-breaking and avoiding compound comparators. |
| Softmax cleanup | Factors shared softmax scale, safe reciprocal, top-k normalization, warp reduction, and CUB block reduction helpers to keep the optimized kernels consistent. |
| Tests | Adds CUDA-internal `SoftmaxTopK_*` tests covering warp bitonic, warp merge, block merge, stable ties, normalization, `float`, `half`, and `bfloat16`. |

### Performance

H200 measurements for the target QMoE decode scenario showed the router cost dropping from roughly `5.56 ms/token` to `0.17 ms/token`, improving end-to-end Qwen3.6-35B-A3B INT4 decode throughput from about `80 tok/s` to `113 tok/s`.

Additional profiling of the `32 < num_experts <= 64` warp merge path showed the packed `uint64_t` stable sort key is consistently faster than a `{float, int}` struct comparator on H200:

| Experts | Sort-only packed/struct | Full softmax+top-k packed/struct |
|---:|---:|---:|
| 33 | 0.680x | 0.704x |
| 48 | 0.672x | 0.695x |
| 64 | 0.673x | 0.696x |

### Testing

- `lintrunner -a`
- `ninja onnxruntime_providers_cuda_ut`
- `ninja onnxruntime_provider_test`
- `GTEST_FILTER='CUDA_EP_Unittest.SoftmaxTopK_*' ./onnxruntime_provider_test --gtest_filter='CUDA_EP_Unittest.All'`
- `onnxruntime/test/python/transformers/test_qmoe_cuda.py -k parity` (`44 passed`)
