### PR TITLE
S390x workflow using qemu

### DIFF
--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -128,3 +128,34 @@ jobs:
       job_identifier: build-linux-arm64-release
     secrets:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # --- s390x Builds ---
+  build-linux-s390x-debug:
+    name: Build Linux s390x Debug
+    uses: ./.github/workflows/reusable_linux_build.yml
+    with:
+      pool_name: "onnxruntime-github-Ubuntu2204-AMD-CPU"
+      build_config: Debug
+      architecture: s390x
+      dockerfile_path: tools/ci_build/github/linux/docker/inference/s390x/python/cpu/Dockerfile
+      docker_image_repo: onnxruntimecpubuildpythons390x
+      # ASan disabled due to excessive runtime (>4hr). Includes wheel build for basic checks.
+      extra_build_flags: '--use_binskim_compliant_compile_flags --build_shared_lib'
+      job_identifier: build-linux-s390x-debug
+    secrets:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build-linux-s390x-release:
+    name: Build Linux s390x Release
+    uses: ./.github/workflows/reusable_linux_build.yml
+    with:
+      pool_name: "onnxruntime-github-Ubuntu2204-AMD-CPU"
+      build_config: Release
+      architecture: s390x
+      dockerfile_path: tools/ci_build/github/linux/docker/inference/s390x/python/cpu/Dockerfile
+      docker_image_repo: onnxruntimecpubuildpythons390x
+      extra_build_flags: '--use_binskim_compliant_compile_flags --build_wheel --cmake_extra_defines onnxruntime_BUILD_BENCHMARKS=ON'
+      python_path_prefix: 'PATH=/opt/python/cp314-cp314/bin:$PATH' # $ needs escaping in single quotes
+      job_identifier: build-linux-s390x-release
+    secrets:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reusable_linux_build.yml
+++ b/.github/workflows/reusable_linux_build.yml
@@ -82,8 +82,15 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Setup QEMU
+        if: inputs.architecture == 's390x'
+        run: |
+          #!/bin/bash
+          set -e -x
+          docker run --rm --privileged docker.io/tonistiigi/binfmt:qemu-v10.0.4-56@sha256:30cc9a4d03765acac9be2ed0afc23af1ad018aed2c28ea4be8c2eb9afe03fbd1 --install s390x
+
       - name: Set up Python ${{ inputs.python_version }}
-        if: inputs.architecture != 'arm64'
+        if: inputs.architecture == 'x64'
         uses: actions/setup-python@v6
         with:
           python-version: ${{ inputs.python_version }}
@@ -124,6 +131,7 @@ jobs:
           execution_providers: ${{ inputs.execution_providers }} # Pass down EP list
           extra_build_flags: ${{ inputs.extra_build_flags }} --use_cache
           python_path_prefix: ${{ inputs.python_path_prefix }}
+          use_vcpkg: ${{ inputs.architecture != 's390x' }}
 
       # ------------- Build Step (Compilation) -------------
       - name: Build ONNX Runtime (${{ inputs.architecture }} / ${{ inputs.build_config }})
@@ -136,6 +144,7 @@ jobs:
           execution_providers: ${{ inputs.execution_providers }} # Pass down EP list
           extra_build_flags: ${{ inputs.extra_build_flags }} --use_cache
           python_path_prefix: ${{ inputs.python_path_prefix }}
+          use_vcpkg: ${{ inputs.architecture != 's390x' }}
 
       # ------------- Test Step -------------
       - name: Test ONNX Runtime (${{ inputs.architecture }} / ${{ inputs.build_config }})
@@ -149,6 +158,7 @@ jobs:
           execution_providers: ${{ inputs.execution_providers }} # Pass down EP list
           extra_build_flags: ${{ inputs.extra_build_flags }} --use_cache
           python_path_prefix: ${{ inputs.python_path_prefix }}
+          use_vcpkg: ${{ inputs.architecture != 's390x' }}
 
       # ------------- Prepare Artifact Step -------------
       - name: Prepare Build Output for Upload
@@ -196,3 +206,10 @@ jobs:
           name: vcpkg-manifest-install-log-${{ inputs.architecture }}-${{ inputs.build_config }}
           path: ${{ runner.temp }}/${{ inputs.build_config }}/${{ inputs.build_config }}/vcpkg-manifest-install.log
           if-no-files-found: ignore
+
+      - name: Clean up QEMU
+        if: always() && inputs.architecture == 's390x'
+        run: |
+          #!/bin/bash
+          set -e -x
+          docker run --rm --privileged docker.io/tonistiigi/binfmt:qemu-v10.0.4-56@sha256:30cc9a4d03765acac9be2ed0afc23af1ad018aed2c28ea4be8c2eb9afe03fbd1 --uninstall s390x

--- a/tools/ci_build/github/linux/docker/inference/s390x/python/cpu/Dockerfile
+++ b/tools/ci_build/github/linux/docker/inference/s390x/python/cpu/Dockerfile
@@ -1,0 +1,11 @@
+ARG BASEIMAGE=quay.io/pypa/manylinux_2_28_s390x:latest
+FROM --platform=linux/s390x $BASEIMAGE
+
+ADD scripts /tmp/scripts
+RUN cd /tmp/scripts && /tmp/scripts/install_centos.sh && /tmp/scripts/install_deps.sh && rm -rf /tmp/scripts
+
+ARG BUILD_UID=1001
+ARG BUILD_USER=onnxruntimedev
+RUN adduser --uid $BUILD_UID $BUILD_USER
+WORKDIR /home/$BUILD_USER
+USER $BUILD_USER

--- a/tools/ci_build/github/linux/docker/inference/s390x/python/cpu/scripts/install_centos.sh
+++ b/tools/ci_build/github/linux/docker/inference/s390x/python/cpu/scripts/install_centos.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+os_major_version=$(tr -dc '0-9.' </etc/redhat-release | cut -d \. -f1)
+
+echo "installing for os major version : $os_major_version"
+dnf install -y glibc-langpack-\* which redhat-lsb-core expat-devel tar unzip zlib-devel make bzip2 bzip2-devel perl-IPC-Cmd openssl-devel wget ninja-build curl zip
+
+if ! command -v ccache &>/dev/null; then
+  dnf install -y ccache
+fi
+
+# last cmake release before 4.0.0
+pipx install --force cmake==3.31.10

--- a/tools/ci_build/github/linux/docker/inference/s390x/python/cpu/scripts/install_deps.sh
+++ b/tools/ci_build/github/linux/docker/inference/s390x/python/cpu/scripts/install_deps.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e -x
+pushd .
+PYTHON_EXES=("/opt/python/cp311-cp311/bin/python3.11" "/opt/python/cp312-cp312/bin/python3.12" "/opt/python/cp313-cp313/bin/python3.13" "/opt/python/cp313-cp313t/bin/python3.13" "/opt/python/cp314-cp314/bin/python3.14" "/opt/python/cp314-cp314t/bin/python3.14")
+CURRENT_DIR=$(pwd)
+if ! [ -x "$(command -v protoc)" ]; then
+  $CURRENT_DIR/install_protobuf.sh
+fi
+popd
+export ONNX_ML=1
+export CMAKE_ARGS="-DONNX_BUILD_PYTHON=ON -DONNX_GEN_PB_TYPE_STUBS=ON -DONNX_WERROR=OFF"
+
+for PYTHON_EXE in "${PYTHON_EXES[@]}"
+do
+  ${PYTHON_EXE} -m pip install -r requirements.txt
+done

--- a/tools/ci_build/github/linux/docker/inference/s390x/python/cpu/scripts/install_protobuf.sh
+++ b/tools/ci_build/github/linux/docker/inference/s390x/python/cpu/scripts/install_protobuf.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+set -e -x
+
+INSTALL_PREFIX='/usr'
+DEP_FILE_PATH='/tmp/scripts/deps.txt'
+while getopts "p:d:" parameter_Option
+do case "${parameter_Option}"
+in
+p) INSTALL_PREFIX=${OPTARG};;
+d) DEP_FILE_PATH=${OPTARG};;
+esac
+done
+
+
+
+EXTRA_CMAKE_ARGS="-DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_CXX_STANDARD=20"
+
+case "$(uname -s)" in
+   Darwin*)
+     echo 'Building ONNX Runtime on Mac OS X'
+     EXTRA_CMAKE_ARGS="$EXTRA_CMAKE_ARGS -DCMAKE_OSX_ARCHITECTURES=x86_64;arm64"
+     GCC_PATH=$(which clang)
+     GPLUSPLUS_PATH=$(which clang++)
+     ;;
+   Linux*)
+     SYS_LONG_BIT=$(getconf LONG_BIT)
+     DISTRIBUTOR=$(lsb_release -i -s)
+
+     if [[ ("$DISTRIBUTOR" = "CentOS" || "$DISTRIBUTOR" = "RedHatEnterprise") && $SYS_LONG_BIT = "64" ]]; then
+       LIBDIR="lib64"
+     else
+       LIBDIR="lib"
+     fi
+     EXTRA_CMAKE_ARGS="$EXTRA_CMAKE_ARGS -DCMAKE_INSTALL_LIBDIR=$LIBDIR"
+     # Depending on how the compiler has been configured when it was built, sometimes "gcc -dumpversion" shows the full version.
+     GCC_VERSION=$(gcc -dumpversion | cut -d . -f 1)
+     #-fstack-clash-protection prevents attacks based on an overlapping heap and stack.
+     if [ "$GCC_VERSION" -ge 8 ]; then
+        CFLAGS="$CFLAGS -fstack-clash-protection"
+        CXXFLAGS="$CXXFLAGS -fstack-clash-protection"
+     fi
+     ARCH=$(uname -m)
+     GCC_PATH=$(which gcc)
+     GPLUSPLUS_PATH=$(which g++)
+     if [ "$ARCH" == "x86_64" ] && [ "$GCC_VERSION" -ge 9 ]; then
+        CFLAGS="$CFLAGS -fcf-protection"
+        CXXFLAGS="$CXXFLAGS -fcf-protection"
+     fi
+     export CFLAGS
+     export CXXFLAGS
+     ;;
+  *)
+    exit 1
+esac
+mkdir -p "$INSTALL_PREFIX"
+
+if [ -x "$(command -v ninja)" ]; then
+  EXTRA_CMAKE_ARGS="$EXTRA_CMAKE_ARGS -G Ninja"
+fi
+echo "Installing abseil ..."
+pushd .
+absl_url=$(grep '^abseil_cpp' "$DEP_FILE_PATH" | cut -d ';' -f 2 )
+if [[ "$absl_url" = https* ]]; then
+  absl_url=$(echo $absl_url | sed 's/\.zip$/\.tar.gz/')
+  curl -sSL --retry 5 --retry-delay 10 --create-dirs --fail -L -o absl_src.tar.gz $absl_url
+  mkdir abseil
+  cd abseil
+  tar -zxf ../absl_src.tar.gz --strip=1
+else
+  cp $absl_url absl_src.zip
+  unzip absl_src.zip
+  cd */
+fi
+
+CC=$GCC_PATH CXX=$GPLUSPLUS_PATH  cmake "."  "-DABSL_PROPAGATE_CXX_STD=ON" "-DCMAKE_BUILD_TYPE=Release" "-DBUILD_TESTING=OFF" "-DABSL_USE_EXTERNAL_GOOGLETEST=ON" "-DCMAKE_PREFIX_PATH=$INSTALL_PREFIX" "-DCMAKE_INSTALL_PREFIX=$INSTALL_PREFIX" $EXTRA_CMAKE_ARGS
+if [ -x "$(command -v ninja)" ]; then
+  ninja
+  ninja install
+else
+  make -j$(getconf _NPROCESSORS_ONLN)
+  make install
+fi
+popd
+
+pushd .
+echo "Installing protobuf ..."
+protobuf_url=$(grep '^protobuf' $DEP_FILE_PATH | cut -d ';' -f 2 )
+if [[ "$protobuf_url" = https* ]]; then
+  protobuf_url=$(echo "$protobuf_url" | sed 's/\.zip$/\.tar.gz/')
+  curl -sSL --retry 5 --retry-delay 10 --create-dirs --fail -L -o protobuf_src.tar.gz "$protobuf_url"
+  mkdir protobuf
+  cd protobuf
+  tar -zxf ../protobuf_src.tar.gz --strip=1
+else
+  cp $protobuf_url protobuf_src.zip
+  unzip protobuf_src.zip
+  cd protobuf-*
+fi
+
+CC=$GCC_PATH CXX=$GPLUSPLUS_PATH cmake . "-DCMAKE_INSTALL_PREFIX=$INSTALL_PREFIX" -DCMAKE_POSITION_INDEPENDENT_CODE=ON -Dprotobuf_BUILD_TESTS=OFF -DCMAKE_BUILD_TYPE=Release -Dprotobuf_WITH_ZLIB_DEFAULT=OFF -Dprotobuf_BUILD_SHARED_LIBS=OFF "-DCMAKE_PREFIX_PATH=$INSTALL_PREFIX" $EXTRA_CMAKE_ARGS -Dprotobuf_ABSL_PROVIDER=package
+if [ -x "$(command -v ninja)" ]; then
+  ninja
+  ninja install
+else
+  make -j$(getconf _NPROCESSORS_ONLN)
+  make install
+fi
+popd

--- a/tools/ci_build/github/linux/docker/inference/s390x/python/cpu/scripts/requirements.txt
+++ b/tools/ci_build/github/linux/docker/inference/s390x/python/cpu/scripts/requirements.txt
@@ -1,0 +1,10 @@
+numpy==2.2.6; python_version < "3.11"
+numpy==2.4.2; python_version >= "3.11"
+mypy
+pytest
+setuptools>=68.2.2
+wheel
+protobuf==4.25.8
+sympy==1.14
+flatbuffers
+onnx==1.20.1


### PR DESCRIPTION
### Description
This PR adds docker image and necessary scripts, as well as github workflow file to run build and tests for s390x using qemu. IIRC docker image and scripts are based on aarch64 files.


### Motivation and Context
This change would allow easier detection of s390x-specific issues in future.

The change was tested locally using https://github.com/nektos/act, but not everything was possible to get tested that way.
This PR also depends on https://github.com/microsoft/onnxruntime-github-actions/pull/19 and needs to get `microsoft/onnxruntime-github-actions/run-build-script-in-docker` references updated to ones containing changes from mentioned PR to work.