### PR TITLE
Clarify available EP when InferenceSession providers not supplied

### DIFF
--- a/onnxruntime/python/onnxruntime_inference_collection.py
+++ b/onnxruntime/python/onnxruntime_inference_collection.py
@@ -264,8 +264,10 @@ class Session:
 
         :param providers: Optional sequence of providers in order of decreasing
             precedence. Values can either be provider names or tuples of
-            (provider name, options dict). If not provided, then all available
-            providers are used with the default precedence.
+            (provider name, options dict). If not provided, any providers
+            configured in the session options at construction time are used;
+            if none were configured there either, `CPUExecutionProvider` is
+            used by default. To use other providers, specify them explicitly.
         :param provider_options: Optional sequence of options dicts corresponding
             to the providers listed in 'providers'.
 
@@ -484,8 +486,10 @@ class InferenceSession(Session):
         :param sess_options: Session options.
         :param providers: Optional sequence of providers in order of decreasing
             precedence. Values can either be provider names or tuples of
-            (provider name, options dict). If not provided, then all available
-            providers are used with the default precedence.
+            (provider name, options dict). If not provided, any providers
+            configured in `sess_options` are used; if none are configured there
+            either, `CPUExecutionProvider` is used by default. To use other
+            providers, specify them explicitly.
         :param provider_options: Optional sequence of options dicts corresponding
             to the providers listed in 'providers'.
 

--- a/onnxruntime/python/onnxruntime_inference_collection.py
+++ b/onnxruntime/python/onnxruntime_inference_collection.py
@@ -310,8 +310,10 @@ class Session:
 
         :param providers: Optional sequence of providers in order of decreasing
             precedence. Values can either be provider names or tuples of
-            (provider name, options dict). If not provided, then all available
-            providers are used with the default precedence.
+            (provider name, options dict). If not provided, any providers
+            configured in the session options at construction time are used;
+            if none were configured there either, `CPUExecutionProvider` is
+            used by default. To use other providers, specify them explicitly.
         :param provider_options: Optional sequence of options dicts corresponding
             to the providers listed in 'providers'.
 
@@ -633,8 +635,10 @@ class InferenceSession(Session):
         :param sess_options: Session options.
         :param providers: Optional sequence of providers in order of decreasing
             precedence. Values can either be provider names or tuples of
-            (provider name, options dict). If not provided, then all available
-            providers are used with the default precedence.
+            (provider name, options dict). If not provided, any providers
+            configured in `sess_options` are used; if none are configured there
+            either, `CPUExecutionProvider` is used by default. To use other
+            providers, specify them explicitly.
         :param provider_options: Optional sequence of options dicts corresponding
             to the providers listed in 'providers'.
 

--- a/orttraining/orttraining/python/training/ortmodule/_execution_agent.py
+++ b/orttraining/orttraining/python/training/ortmodule/_execution_agent.py
@@ -28,11 +28,13 @@ class InferenceAgent:
     def __init__(self, path_or_bytes, session_options=None, providers=None, provider_options=None):
         """
         :param path_or_bytes: filename or serialized ONNX or ORT format model in a byte string
-        :param sess_options: session options
+        :param session_options: session options
         :param providers: Optional sequence of providers in order of decreasing
             precedence. Values can either be provider names or tuples of
-            (provider name, options dict). If not provided, then all available
-            providers are used with the default precedence.
+            (provider name, options dict). If not provided, any providers
+            configured in `session_options` are used; if none are configured
+            there either, `CPUExecutionProvider` is used by default. To use
+            other providers, specify them explicitly.
         :param provider_options: Optional sequence of options dicts corresponding
             to the providers listed in 'providers'.
 
@@ -105,11 +107,13 @@ class TrainingAgent:
         :param fw_outputs_device_info: Device info for fetches in forward pass.
         :param bw_fetches_names: Fetch names for backward pass.
         :param bw_outputs_device_info: Device info for fetches in backward pass.
-        :param sess_options: session options
+        :param session_options: session options
         :param providers: Optional sequence of providers in order of decreasing
             precedence. Values can either be provider names or tuples of
-            (provider name, options dict). If not provided, then all available
-            providers are used with the default precedence.
+            (provider name, options dict). If not provided, any providers
+            configured in `session_options` are used; if none are configured there
+            either, `CPUExecutionProvider` is used by default. To use other
+            providers, specify them explicitly.
         :param provider_options: Optional sequence of options dicts corresponding
             to the providers listed in 'providers'.
         :param local_rank: Optional rank of current device, used for memory profiling only.


### PR DESCRIPTION
### Description

This updates the documentation regarding the optional `providers` param when initializing an `InferenceSession` to clarify that when `providers` is not specified it will result in the CPUExecutionProvider being used even though other providers such as DMLExecutionProvider may be available (such as through installation of `onnxruntime-directml`).

### Motivation and Context

This documentation update was originally proposed and reviewed in https://github.com/microsoft/onnxruntime/pull/10115#discussion_r794095704, but the work went stale and was never integrated. I was confused by the current documentation because there appears to be conflicting information. I have issued this PR to get this documentation change integrated to help the next developer that may face this same issue.

#### Existing Documentation Location 1
The specific param documentation for `InferenceSession` which describes that if no provider specified, all available providers are used in the default precedence order.
Published at https://onnxruntime.ai/docs/api/python/api_summary.html#inferencesession
https://github.com/microsoft/onnxruntime/blob/50c951000064aaa46d15c2447bec85b58e98a135/onnxruntime/python/onnxruntime_inference_collection.py#L485-L488

#### Existing Documentation Location 2
This is higher level documentation, that states things differently and says the execution provider must be provided explicitly since ONNX Runtime 1.10 and if `providers` is not specified then it will only use the CPUExecutionProvider.
Published at https://onnxruntime.ai/docs/api/python/api_summary.html#load-and-run-a-model
https://github.com/microsoft/onnxruntime/blob/50c951000064aaa46d15c2447bec85b58e98a135/docs/python/api_summary.rst?plain=1#L42-L45


