### PR TITLE
[CUDA] Add decode (M=1) GEMV fast path to MatMul

### DIFF
--- a/onnxruntime/core/providers/cuda/math/matmul.cc
+++ b/onnxruntime/core/providers/cuda/math/matmul.cc
@@ -5,12 +5,22 @@
 
 #include "core/providers/cuda/shared_inc/fpgeneric.h"
 #include "core/providers/cuda/cuda_allocator.h"
+#include "core/providers/cuda/cuda_type_conversion.h"
+#include "core/providers/cuda/math/matmul_gemv.h"
 #ifndef BUILD_CUDA_EP_AS_PLUGIN
 #include "core/providers/cuda/tunable/math/matmul.h"
 #endif
 
 namespace onnxruntime {
 namespace cuda {
+
+// GEMV decode fast path is only beneficial for small N (cuBLAS GEMM tiles win
+// for large N) and a reasonably large K (enough reduction work to amortize the
+// launch). Engaged only for fp16/bf16 constant weights at M==1.
+namespace {
+constexpr int64_t kGemvMaxN = 1024;
+constexpr int64_t kGemvMinK = 256;
+}  // namespace
 
 #define REGISTER_KERNEL_TYPED(T)                                  \
   ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(                        \
@@ -91,6 +101,40 @@ static bool CanUseStridedBatchedGemm(const TensorShape& left_shape, const Tensor
 }
 
 template <typename T>
+Status MatMul<T>::PrePack(const Tensor& tensor, int input_idx, AllocatorPtr alloc,
+                          /*out*/ bool& is_packed,
+                          /*out*/ PrePackedWeights* /*prepacked_weights*/) {
+  is_packed = false;
+  // Only the constant weight B (input 1), fp16/bf16, used as a plain [K, N]
+  // matrix (no transpose), is eligible. We keep is_packed == false so the
+  // original B tensor remains available for the cuBLAS path when M > 1.
+  if constexpr (std::is_same_v<T, MLFloat16> || std::is_same_v<T, BFloat16>) {
+    if (input_idx == 1 && !trans_B_ && !trans_batch_b_) {
+      const auto& shape = tensor.Shape();
+      if (shape.NumDimensions() == 2) {
+        const int64_t k = shape[0];
+        const int64_t n = shape[1];
+        if (n >= 1 && n <= kGemvMaxN && k >= kGemvMinK) {
+          using CudaT = typename OrtToCudaType<T>::type;
+          cudaStream_t stream = cudaStreamLegacy;  // PrePack runs at init, outside any capture.
+          const size_t bytes = static_cast<size_t>(n) * static_cast<size_t>(k) * sizeof(CudaT);
+          gemv_b_transposed_ = IAllocator::MakeUniquePtr<void>(alloc, bytes, true);
+          TransposeForGemv<CudaT>(stream,
+                                  reinterpret_cast<CudaT*>(gemv_b_transposed_.get()),
+                                  reinterpret_cast<const CudaT*>(tensor.Data<T>()),
+                                  static_cast<int>(k), static_cast<int>(n));
+          CUDA_RETURN_IF_ERROR(cudaStreamSynchronize(stream));
+          gemv_n_ = n;
+          gemv_k_ = k;
+          gemv_enabled_ = true;
+        }
+      }
+    }
+  }
+  return Status::OK();
+}
+
+template <typename T>
 Status MatMul<T>::ComputeInternal(OpKernelContext* ctx) const {
   const Tensor* left_X = ctx->Input<Tensor>(0);
   const Tensor* right_X = ctx->Input<Tensor>(1);
@@ -121,6 +165,22 @@ Status MatMul<T>::ComputeInternal(OpKernelContext* ctx) const {
     using CudaT = typename ToCudaType<T>::MappedType;
     Fill<CudaT>(Stream(ctx), reinterpret_cast<CudaT*>(Y->MutableData<T>()), CudaT(0.f), narrow<int64_t>(output_size));
     return Status::OK();
+  }
+
+  // Decode (M==1) GEMV fast path: a single custom kernel beats cuBLAS's split-K
+  // dot + reduce for a small constant fp16/bf16 weight. Falls through to cuBLAS
+  // for M > 1, transposed A, or batched GEMM.
+  if constexpr (std::is_same_v<T, MLFloat16> || std::is_same_v<T, BFloat16>) {
+    if (gemv_enabled_ && !trans_a && helper.M() == 1 && helper.OutputOffsets().size() == 1 &&
+        helper.N() == gemv_n_ && helper.K() == gemv_k_) {
+      using CudaT = typename OrtToCudaType<T>::type;
+      MatMulGemvM1<CudaT>(Stream(ctx),
+                          reinterpret_cast<CudaT*>(Y->MutableData<T>()),
+                          reinterpret_cast<const CudaT*>(left_X->Data<T>()),
+                          reinterpret_cast<const CudaT*>(gemv_b_transposed_.get()),
+                          static_cast<int>(helper.N()), static_cast<int>(helper.K()), alpha_);
+      return Status::OK();
+    }
   }
 
 #ifndef BUILD_CUDA_EP_AS_PLUGIN

--- a/onnxruntime/core/providers/cuda/math/matmul.h
+++ b/onnxruntime/core/providers/cuda/math/matmul.h
@@ -24,12 +24,26 @@ class MatMul final : public CudaKernel {
   Status ComputeInternal(OpKernelContext* context) const override;
   Status ComputeDefault(OpKernelContext* context, MatMulComputeHelper& helper) const;
 
+  Status PrePack(const Tensor& tensor, int input_idx, AllocatorPtr alloc,
+                 /*out*/ bool& is_packed,
+                 /*out*/ PrePackedWeights* prepacked_weights) override;
+
  private:
   const float alpha_;
   const bool trans_A_;
   const bool trans_B_;
   const bool trans_batch_a_;
   const bool trans_batch_b_;
+
+  // Decode (M==1) GEMV fast path: a transposed [N, K] copy of a small constant
+  // fp16/bf16 weight is built once in PrePack so ComputeInternal can dispatch a
+  // single-kernel GEMV instead of cuBLAS's split-K + reduce. The original B
+  // input is left intact (is_packed stays false) so the M>1 cuBLAS path still
+  // works.
+  IAllocatorUniquePtr<void> gemv_b_transposed_;
+  bool gemv_enabled_ = false;
+  int64_t gemv_n_ = 0;
+  int64_t gemv_k_ = 0;
 };
 
 template <typename T>

--- a/onnxruntime/core/providers/cuda/math/matmul_gemv.cu
+++ b/onnxruntime/core/providers/cuda/math/matmul_gemv.cu
@@ -75,8 +75,8 @@ void MatMulGemvM1(cudaStream_t stream, T* y, const T* a, const T* b_transposed,
   GemvM1Kernel<T, THREADS><<<n, THREADS, 0, stream>>>(y, a, b_transposed, n, k, alpha);
 }
 
-#define INSTANTIATE_GEMV(T)                                                                   \
-  template void TransposeForGemv<T>(cudaStream_t, T*, const T*, int, int);                     \
+#define INSTANTIATE_GEMV(T)                                                \
+  template void TransposeForGemv<T>(cudaStream_t, T*, const T*, int, int); \
   template void MatMulGemvM1<T>(cudaStream_t, T*, const T*, const T*, int, int, float)
 
 INSTANTIATE_GEMV(OrtToCudaType<MLFloat16>::type);

--- a/onnxruntime/core/providers/cuda/math/matmul_gemv.cu
+++ b/onnxruntime/core/providers/cuda/math/matmul_gemv.cu
@@ -1,0 +1,88 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/cuda/math/matmul_gemv.h"
+
+#include <cuda_fp16.h>
+#include <cuda_bf16.h>
+#include "core/providers/cuda/cuda_type_conversion.h"
+
+namespace onnxruntime {
+namespace cuda {
+
+namespace {
+
+// Tile transpose: dst[c, r] = src[r, c]. src is [rows, cols], dst is [cols, rows].
+template <typename T, int TILE>
+__global__ void TransposeKernel(T* __restrict__ dst, const T* __restrict__ src, int rows, int cols) {
+  __shared__ T tile[TILE][TILE + 1];
+  int r = blockIdx.y * TILE + threadIdx.y;
+  int c = blockIdx.x * TILE + threadIdx.x;
+  if (r < rows && c < cols) {
+    tile[threadIdx.y][threadIdx.x] = src[static_cast<int64_t>(r) * cols + c];
+  }
+  __syncthreads();
+  int rt = blockIdx.x * TILE + threadIdx.y;  // transposed row index (into cols)
+  int ct = blockIdx.y * TILE + threadIdx.x;  // transposed col index (into rows)
+  if (rt < cols && ct < rows) {
+    dst[static_cast<int64_t>(rt) * rows + ct] = tile[threadIdx.x][threadIdx.y];
+  }
+}
+
+// One block per output column n. Threads split K, reduce in shared, write Y[n].
+// Bt is [N, K] row-major: row n (length K) is contiguous, so the per-step reads
+// across threads are coalesced.
+template <typename T, int THREADS>
+__global__ void GemvM1Kernel(T* __restrict__ y, const T* __restrict__ a,
+                             const T* __restrict__ b_transposed, int n, int k, float alpha) {
+  const int col = blockIdx.x;
+  if (col >= n) return;
+  const int tid = threadIdx.x;
+  const T* b_row = b_transposed + static_cast<int64_t>(col) * k;
+
+  float acc = 0.0f;
+  for (int i = tid; i < k; i += THREADS) {
+    acc += static_cast<float>(a[i]) * static_cast<float>(b_row[i]);
+  }
+
+  __shared__ float sh[THREADS];
+  sh[tid] = acc;
+  __syncthreads();
+#pragma unroll
+  for (int s = THREADS / 2; s > 0; s >>= 1) {
+    if (tid < s) sh[tid] += sh[tid + s];
+    __syncthreads();
+  }
+  if (tid == 0) {
+    y[col] = static_cast<T>(alpha * sh[0]);
+  }
+}
+
+}  // namespace
+
+template <typename T>
+void TransposeForGemv(cudaStream_t stream, T* dst, const T* src, int rows, int cols) {
+  constexpr int TILE = 32;
+  dim3 block(TILE, TILE);
+  dim3 grid((cols + TILE - 1) / TILE, (rows + TILE - 1) / TILE);
+  TransposeKernel<T, TILE><<<grid, block, 0, stream>>>(dst, src, rows, cols);
+}
+
+template <typename T>
+void MatMulGemvM1(cudaStream_t stream, T* y, const T* a, const T* b_transposed,
+                  int n, int k, float alpha) {
+  constexpr int THREADS = 128;
+  GemvM1Kernel<T, THREADS><<<n, THREADS, 0, stream>>>(y, a, b_transposed, n, k, alpha);
+}
+
+#define INSTANTIATE_GEMV(T)                                                                   \
+  template void TransposeForGemv<T>(cudaStream_t, T*, const T*, int, int);                     \
+  template void MatMulGemvM1<T>(cudaStream_t, T*, const T*, const T*, int, int, float)
+
+INSTANTIATE_GEMV(OrtToCudaType<MLFloat16>::type);
+INSTANTIATE_GEMV(OrtToCudaType<BFloat16>::type);
+
+#undef INSTANTIATE_GEMV
+
+}  // namespace cuda
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cuda/math/matmul_gemv.h
+++ b/onnxruntime/core/providers/cuda/math/matmul_gemv.h
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <cuda_runtime.h>
+#include "core/providers/cuda/shared_inc/cuda_utils.h"
+
+namespace onnxruntime {
+namespace cuda {
+
+// Decode-oriented GEMV fast path for MatMul: Y[1, N] = alpha * A[1, K] * B[K, N].
+//
+// At decode (M == 1) a plain fp16/bf16 MatMul with a constant weight is a memory
+// bound GEMV. cuBLAS dispatches a split-K path (a `dot_kernel` followed by a
+// separate `reduce_1Block_kernel`) -- two launches for one tiny GEMV. A single
+// custom kernel that assigns one thread block per output column, splitting K
+// across the block and reducing once, is ~2x faster on small N.
+//
+// The kernel reads the weight in a transposed [N, K] layout (row `n` contiguous)
+// so consecutive threads access consecutive addresses (coalesced). The caller
+// produces that layout once via TransposeForGemv during PrePack.
+
+// Transpose a row-major [rows, cols] matrix into [cols, rows] (row-major).
+template <typename T>
+void TransposeForGemv(cudaStream_t stream, T* dst, const T* src, int rows, int cols);
+
+// Compute Y[n] = alpha * sum_k A[k] * Bt[n, k] for n in [0, N), Bt is [N, K].
+// Accumulation is done in fp32 to match cuBLAS's fp32-compute fp16 GEMM.
+template <typename T>
+void MatMulGemvM1(cudaStream_t stream, T* y, const T* a, const T* b_transposed,
+                  int n, int k, float alpha);
+
+}  // namespace cuda
+}  // namespace onnxruntime

--- a/onnxruntime/test/providers/cpu/math/matmul_test.cc
+++ b/onnxruntime/test/providers/cpu/math/matmul_test.cc
@@ -520,6 +520,57 @@ TEST(MathOpTest, MatMul_Float16) {
 }
 #endif
 
+#ifdef USE_CUDA
+// Exercises the CUDA MatMul decode (M==1) GEMV fast path: a constant fp16 weight
+// with K >= 256 and small N is prepacked (transposed) and run by a custom GEMV
+// kernel. The non-constant variant takes the cuBLAS path; both must match.
+TEST(MathOpTest, MatMul_Float16_GemvDecode) {
+  int min_cuda_architecture = 530;
+  if (!HasCudaEnvironment(min_cuda_architecture)) {
+    LOGS_DEFAULT(WARNING) << "Hardware NOT support FP16";
+    return;
+  }
+
+  constexpr int K = 2048;
+  constexpr int N = 256;
+  std::vector<float> A(K), B(static_cast<size_t>(K) * N);
+  for (int k = 0; k < K; ++k) {
+    A[k] = 0.05f * std::sin(0.013f * k);
+  }
+  for (int i = 0; i < K * N; ++i) {
+    B[i] = 0.05f * std::cos(0.017f * i);
+  }
+
+  std::vector<float> Y(N, 0.0f);
+  for (int n = 0; n < N; ++n) {
+    float sum = 0.0f;
+    for (int k = 0; k < K; ++k) {
+      sum += A[k] * B[k * N + n];
+    }
+    Y[n] = sum;
+  }
+
+  std::vector<MLFloat16> f_A(A.size()), f_B(B.size()), f_Y(Y.size());
+  ConvertFloatToMLFloat16(A.data(), f_A.data(), static_cast<int>(A.size()));
+  ConvertFloatToMLFloat16(B.data(), f_B.data(), static_cast<int>(B.size()));
+  ConvertFloatToMLFloat16(Y.data(), f_Y.data(), static_cast<int>(Y.size()));
+
+  auto run_test = [&](bool B_is_constant) {
+    OpTester test("MatMul", 14);
+    test.AddInput<MLFloat16>("A", {1, K}, f_A);
+    test.AddInput<MLFloat16>("B", {K, N}, f_B, B_is_constant);
+    test.AddOutput<MLFloat16>("Y", {1, N}, f_Y);
+    // fp16 accumulation tolerance over K=2048 reductions.
+    test.SetOutputAbsErr("Y", 1.0f);
+    std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+    execution_providers.emplace_back(DefaultCudaExecutionProvider());
+    test.ConfigEps(std::move(execution_providers)).RunWithConfig();
+  };
+  run_test(true);   // constant B -> GEMV fast path
+  run_test(false);  // non-constant B -> cuBLAS path
+}
+#endif
+
 #if defined(USE_CUDA) || defined(USE_DNNL)
 TEST(MathOpTest, MatMul_bfloat16) {
 #ifdef USE_CUDA


### PR DESCRIPTION
### Description

Adds a decode-oriented (`M == 1`) GEMV fast path to the CUDA `MatMul` op. At decode a plain
fp16/bf16 `MatMul` with a constant weight is a memory-bound GEMV; cuBLAS dispatches a
split-K path (a `dot_kernel` followed by a separate `reduce_1Block_kernel`) — two launches
for one tiny GEMV. A single custom kernel that prepacks the constant weight (transposed for
coalescing) and assigns one block per output column is ~2× faster.

### Motivation

Profiling decode of a hybrid linear-attention + MoE model (Qwen3-Next / Qwen3.6) showed the
MoE router-gate `MatMul` nodes (`[1, 2048] × [2048, 256]` and a `[2048, 1]` projection,
fp16) spending ~350 µs/token across the model. They are plain `MatMul` ops that ORT routes
to cuBLAS, which selects a 496-way split-K (`dot_kernel`) + separate `reduce_1Block_kernel`
— two kernels for one small `M = 1` GEMV.

A microbench of `[1, 2048] × [2048, 256]` fp16 showed:

| Variant | µs/call | vs cuBLAS |
|---|---|---|
| cuBLAS `Hgemm` (split-K dot + reduce) | 7.11 | 1.0× |
| custom GEMV, weight row-major `[K, N]` (strided) | 7.45 | 0.96× |
| custom GEMV, weight **transposed `[N, K]`** (coalesced) | **3.65** | **1.95×** |

The row-major variant ties cuBLAS — the coalesced transposed layout is what wins, so the
weight is transposed once during `PrePack`.

### Key Changes

| File | Change |
|---|---|
| `core/providers/cuda/math/matmul_gemv.{h,cu}` | New `GemvM1Kernel` (one block per output column, splits K across the block, single block-reduce, fp32 accumulation) + a tiled `TransposeForGemv` helper. Instantiated for fp16/bf16 only. |
| `core/providers/cuda/math/matmul.{h,cc}` | `PrePack` transposes an eligible constant B into an `[N, K]` buffer; `ComputeInternal` dispatches the GEMV at `M == 1`. |
| `test/providers/cpu/math/matmul_test.cc` | `MatMul_Float16_GemvDecode` parity test. |

Eligibility (all required): input is the **constant** weight B (initializer, input 1),
dtype fp16/bf16, used as a plain 2-D `[K, N]` matrix (no `transB`/`transBatchB`),
`N ≤ 1024`, `K ≥ 256`. `is_packed` is left **false** so the original B tensor stays
available — at `M > 1` (and for transposed A, batched GEMM, or non-eligible shapes) the
kernel falls through to the existing cuBLAS path unchanged.

### Performance

End-to-end on Qwen3.6-35B-A3B (H200, INT4, single-sequence decode, CUDA graph on):

- The router-gate cuBLAS kernels (`nvjet` 207 + `dot_kernel` 73 + `reduce_1Block` 72 =
  ~352 µs/token) are replaced by a single `GemvM1Kernel` (~192 µs/token).
- Total GPU busy 5.25 → 5.10 ms/token.
- Decode throughput **154.8 → 158.3 tok/s (+2.3%)**.

### Testing

`MatMul_Float16_GemvDecode` exercises both paths (constant-B fast path and non-constant-B
cuBLAS path) against a reference; fp32 accumulation matches cuBLAS's fp32-compute fp16 GEMM.

```
./onnxruntime_provider_test --gtest_filter='MathOpTest.MatMul*:*FusedMatMul*'
```

All 36 `MatMul` / `FusedMatMul` tests pass.

### Motivation and Context

Decode-throughput optimization for fp16/bf16 models with small constant-weight projections
(e.g. MoE router gates). No public API change; numerics are preserved and all non-eligible
shapes keep the existing cuBLAS behavior.
