### PR TITLE
Fix out-of-bounds error

### DIFF
--- a/onnxruntime/contrib_ops/cpu/transformers/logits_processor.cc
+++ b/onnxruntime/contrib_ops/cpu/transformers/logits_processor.cc
@@ -48,7 +48,11 @@ void RepetitionPenaltyLogitsProcessor<T>::Process(const ISequences* sequences,
       unique_word_ids.insert(word_id);
     }
 
+    const int vocab_size = next_token_scores.vocab_size;
     for (const int32_t word_id : unique_word_ids) {
+      if (word_id < 0 || word_id >= vocab_size) {
+        continue;
+      }
       T score = beam_token_scores[word_id];
 
       // If score < 0, then repetition penalty > 1.0 has to multiplied to reduce the previous token probability,
@@ -89,7 +93,11 @@ void NoRepeatNGramLogitsProcessor<T>::Process(const ISequences* sequences,
       }
     }
 
+    const int vocab_size = next_token_scores.vocab_size;
     for (const int32_t word_id : blocked_word_ids) {
+      if (word_id < 0 || word_id >= vocab_size) {
+        continue;
+      }
       beam_token_scores[word_id] = std::numeric_limits<T>::lowest();
     }
   }

--- a/onnxruntime/contrib_ops/cpu/transformers/logits_processor.h
+++ b/onnxruntime/contrib_ops/cpu/transformers/logits_processor.h
@@ -28,7 +28,9 @@ struct NextTokenScores {
   }
 
   void SetScore(int token_id, T score) {
-    assert(token_id >= 0 && token_id < vocab_size);
+    if (token_id < 0 || token_id >= vocab_size) {
+      return;
+    }
     for (int i = 0; i < batch_beam_size; i++) {
       scores[static_cast<gsl::index>(i) * vocab_size + token_id] = score;
     }


### PR DESCRIPTION
This pull request introduces important safety checks to prevent out-of-bounds access in the logits processing code for transformers. The main updates ensure that token IDs are validated against the vocabulary size before being used, which improves robustness and prevents potential crashes.

**Safety and robustness improvements:**

* Added bounds checking for token IDs in the `RepetitionPenaltyLogitsProcessor<T>::Process` method to ensure only valid IDs are used when accessing `beam_token_scores`.
* Added bounds checking for token IDs in the `NoRepeatNGramLogitsProcessor<T>::Process` method to prevent out-of-bounds writes to `beam_token_scores`.
* Updated the `NextTokenScores::SetScore` method to return early if the provided `token_id` is out of bounds, replacing the previous assert with a safe check.