### PR TITLE
Remove hard core ORT dependency from CUDA plugin EP packages

### DIFF
--- a/plugin-ep-cuda/README.md
+++ b/plugin-ep-cuda/README.md
@@ -8,8 +8,12 @@ For more information about plugin EPs, see the documentation
 
 ## Contents
 
-- [`MIN_ONNXRUNTIME_VERSION`](MIN_ONNXRUNTIME_VERSION) - Minimum compatible ONNX Runtime version for the Python package.
+- [`MIN_ONNXRUNTIME_VERSION`](MIN_ONNXRUNTIME_VERSION) - Minimum compatible core `onnxruntime` version. Single source
+  of truth shared by all packages built from this directory. The packages do not declare a hard dependency on a
+  specific ONNX Runtime package; instead, this version string is injected into each package's README at build/pack
+  time, and the native plugin EP code validates compatibility at registration time.
 - [`python/`](python/) - Sources and build script for the `onnxruntime-ep-cuda12`/`onnxruntime-ep-cuda13` Python wheels.
+- [`csharp/`](csharp/) - Sources and packaging script for the `Microsoft.ML.OnnxRuntime.EP.Cuda` NuGet package.
 
 ## Usage
 

--- a/plugin-ep-cuda/_packaging_utils.py
+++ b/plugin-ep-cuda/_packaging_utils.py
@@ -1,0 +1,45 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+"""Shared utilities for the CUDA plugin EP packaging scripts. Not a public API."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+# Matches "@var@" template variables.
+_TEMPLATE_VARIABLE_PATTERN = re.compile(r"@(\w+)@")
+
+
+def gen_file_from_template(
+    template_file: Path, output_file: Path, variable_substitutions: dict[str, str], strict: bool = True
+) -> None:
+    """Generate a file from a template by substituting "@var@" markers with provided values.
+
+    If `strict` is True, raises ValueError when the set of "@var@" names found in the template
+    does not match the keys of `variable_substitutions`.
+
+    Note: substituted values are inserted verbatim with no awareness of the target file's syntax.
+    The caller is responsible for any quoting/escaping required by the target format.
+    """
+    content = template_file.read_text(encoding="utf-8")
+
+    variables_in_file: set[str] = set()
+
+    def replace(match: re.Match[str]) -> str:
+        name = match.group(1)
+        variables_in_file.add(name)
+        return variable_substitutions.get(name, match.group(0))
+
+    content = _TEMPLATE_VARIABLE_PATTERN.sub(replace, content)
+
+    if strict and variables_in_file != variable_substitutions.keys():
+        provided = set(variable_substitutions.keys())
+        raise ValueError(
+            f"Template variables and substitution keys do not match for {template_file}. "
+            f"Only in template: {sorted(variables_in_file - provided)}. "
+            f"Only in substitutions: {sorted(provided - variables_in_file)}."
+        )
+
+    output_file.write_text(content, encoding="utf-8")

--- a/plugin-ep-cuda/csharp/Microsoft.ML.OnnxRuntime.EP.Cuda/Microsoft.ML.OnnxRuntime.EP.Cuda.csproj
+++ b/plugin-ep-cuda/csharp/Microsoft.ML.OnnxRuntime.EP.Cuda/Microsoft.ML.OnnxRuntime.EP.Cuda.csproj
@@ -26,28 +26,6 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
-  <!--
-    Minimum required Microsoft.ML.OnnxRuntime version is read from a file (single source
-    of truth, shared with the other plugin EP packages). The path is overridable via
-    -p:OnnxRuntimeMinVersionFile=<absolute path> so callers (e.g. pack_nuget.py, which
-    builds out of a staged copy) can point at the original file in the source tree.
-  -->
-  <PropertyGroup>
-    <OnnxRuntimeMinVersionFile Condition="'$(OnnxRuntimeMinVersionFile)' == ''">$(MSBuildThisFileDirectory)..\..\MIN_ONNXRUNTIME_VERSION</OnnxRuntimeMinVersionFile>
-    <OnnxRuntimeMinVersion Condition="Exists('$(OnnxRuntimeMinVersionFile)')">$([System.IO.File]::ReadAllText('$(OnnxRuntimeMinVersionFile)').Trim())</OnnxRuntimeMinVersion>
-  </PropertyGroup>
-
-  <Target Name="_ValidateOnnxRuntimeMinVersion" BeforeTargets="CollectPackageReferences">
-    <Error Condition="!Exists('$(OnnxRuntimeMinVersionFile)')"
-           Text="OnnxRuntimeMinVersionFile not found: '$(OnnxRuntimeMinVersionFile)'. Set -p:OnnxRuntimeMinVersionFile=&lt;absolute path&gt; or restore the file at the default location." />
-    <Error Condition="'$(OnnxRuntimeMinVersion)' == ''"
-           Text="OnnxRuntimeMinVersion resolved to an empty value from '$(OnnxRuntimeMinVersionFile)'." />
-  </Target>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="$(OnnxRuntimeMinVersion)" />
-  </ItemGroup>
-
   <ItemGroup>
     <!-- Ensure README is included in the package -->
     <None Include="README.md" Pack="true" PackagePath="" />

--- a/plugin-ep-cuda/csharp/Microsoft.ML.OnnxRuntime.EP.Cuda/README.md
+++ b/plugin-ep-cuda/csharp/Microsoft.ML.OnnxRuntime.EP.Cuda/README.md
@@ -2,6 +2,14 @@
 
 CUDA plugin Execution Provider for [ONNX Runtime](https://github.com/microsoft/onnxruntime).
 
+### Prerequisites
+
+This package provides the CUDA plugin EP only. Your project must separately reference an ONNX Runtime
+core package (e.g. `Microsoft.ML.OnnxRuntime`) of version `@min_onnxruntime_version@` or later.
+
+If the referenced ONNX Runtime is incompatible, the plugin EP will report an error when its library is
+registered.
+
 ### Usage
 
 ```csharp
@@ -48,4 +56,4 @@ env.UnregisterExecutionProviderLibrary("cuda_ep");
 
 - NVIDIA GPU with CUDA support
 - CUDA toolkit and cuDNN installed on the system
-- ONNX Runtime 1.26.0 or later
+- ONNX Runtime `@min_onnxruntime_version@` or later

--- a/plugin-ep-cuda/csharp/pack_nuget.py
+++ b/plugin-ep-cuda/csharp/pack_nuget.py
@@ -44,6 +44,10 @@ PROJECT_DIR = SCRIPT_DIR / "Microsoft.ML.OnnxRuntime.EP.Cuda"
 CSPROJ = PROJECT_DIR / "Microsoft.ML.OnnxRuntime.EP.Cuda.csproj"
 MIN_ORT_VERSION_FILE = SCRIPT_DIR.parent / "MIN_ONNXRUNTIME_VERSION"
 
+# Import the shared template helper from _packaging_utils.py in the parent directory.
+sys.path.insert(0, str(SCRIPT_DIR.parent))
+from _packaging_utils import gen_file_from_template  # noqa: E402 (path setup must precede import)
+
 
 class PackError(RuntimeError):
     """Raised for any user-actionable failure during packaging."""
@@ -207,14 +211,12 @@ def stage_binaries(
 def dotnet_common_args(
     staged_csproj: Path,
     args: argparse.Namespace,
-    min_ort_version_file: Path,
 ) -> list[str]:
     common = [
         str(staged_csproj),
         "--configuration",
         args.configuration,
         f"-p:Version={args.version}",
-        f"-p:OnnxRuntimeMinVersionFile={min_ort_version_file}",
     ]
     if args.nuget_config:
         common.extend(["--configfile", str(args.nuget_config)])
@@ -222,10 +224,10 @@ def dotnet_common_args(
     return common
 
 
-def do_build(staged_csproj: Path, staging_dir: Path, args: argparse.Namespace, min_ort_version_file: Path) -> None:
+def do_build(staged_csproj: Path, staging_dir: Path, args: argparse.Namespace) -> None:
     print()
     print(f"Running dotnet build (Version={args.version}, Configuration={args.configuration})...")
-    cmd = ["dotnet", "build", *dotnet_common_args(staged_csproj, args, min_ort_version_file)]
+    cmd = ["dotnet", "build", *dotnet_common_args(staged_csproj, args)]
     print("+ " + " ".join(cmd))
     subprocess.run(cmd, check=True)
 
@@ -242,14 +244,13 @@ def do_pack(
     staged_csproj: Path,
     output_dir: Path,
     args: argparse.Namespace,
-    min_ort_version_file: Path,
 ) -> None:
     print()
     print(f"Running dotnet pack (Version={args.version}, Configuration={args.configuration})...")
     pack_args = [
         "dotnet",
         "pack",
-        *dotnet_common_args(staged_csproj, args, min_ort_version_file),
+        *dotnet_common_args(staged_csproj, args),
         "--output",
         str(output_dir),
     ]
@@ -268,6 +269,21 @@ def do_pack(
         print(f"Produced: {pkg.name} ({pkg.stat().st_size / (1024 * 1024):.2f} MB)")
 
 
+def render_readme(staging_dir: Path, min_ort_version: str) -> None:
+    """Substitute the minimum ORT version into the staged README in place."""
+    readme = staging_dir / "README.md"
+    if not readme.is_file():
+        raise PackError(f"staged README not found: {readme}")
+    try:
+        gen_file_from_template(
+            readme,
+            readme,
+            {"min_onnxruntime_version": min_ort_version},
+        )
+    except ValueError as e:
+        raise PackError(str(e)) from e
+
+
 def run_in_staging(args: argparse.Namespace, staging_dir: Path, min_ort_version_file: Path) -> None:
     staged_csproj = staging_dir / "Microsoft.ML.OnnxRuntime.EP.Cuda.csproj"
     output_dir: Path = args.output_dir
@@ -281,12 +297,16 @@ def run_in_staging(args: argparse.Namespace, staging_dir: Path, min_ort_version_
     else:
         stage_sources(staging_dir)
         stage_binaries(staging_dir, args, required_platforms)
+        min_ort_version = min_ort_version_file.read_text(encoding="utf-8").strip()
+        if not min_ort_version:
+            raise PackError(f"{min_ort_version_file} is empty")
+        render_readme(staging_dir, min_ort_version)
 
     if args.build_only:
-        do_build(staged_csproj, staging_dir, args, min_ort_version_file)
+        do_build(staged_csproj, staging_dir, args)
         return
 
-    do_pack(staged_csproj, output_dir, args, min_ort_version_file)
+    do_pack(staged_csproj, output_dir, args)
 
     print()
     print(f"Done. Output: {output_dir}")

--- a/plugin-ep-cuda/csharp/test/CudaEpNuGetTest/CudaEpNuGetTest.csproj
+++ b/plugin-ep-cuda/csharp/test/CudaEpNuGetTest/CudaEpNuGetTest.csproj
@@ -13,10 +13,18 @@
       a single-package local feed.
     -->
     <OrtCudaPackageVersion Condition="'$(OrtCudaPackageVersion)' == ''">*-*</OrtCudaPackageVersion>
+    <!--
+      Version of the ONNX Runtime core package to test against. CI overrides this with
+      -p:OrtCoreTestVersion=<exact version> to pin the test to a specific version; the floating
+      fallback is for local development.
+    -->
+    <OrtCoreTestVersion Condition="'$(OrtCoreTestVersion)' == ''">*-*</OrtCoreTestVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Microsoft.ML.OnnxRuntime is pulled in transitively via the EP package. -->
+    <!-- The plugin EP package does not declare a hard dependency on a core ORT package, so reference
+         one explicitly here. -->
+    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="$(OrtCoreTestVersion)" />
     <PackageReference Include="Microsoft.ML.OnnxRuntime.EP.Cuda" Version="$(OrtCudaPackageVersion)" />
   </ItemGroup>
 

--- a/plugin-ep-cuda/python/build_wheel.py
+++ b/plugin-ep-cuda/python/build_wheel.py
@@ -13,7 +13,10 @@ from pathlib import Path
 SCRIPT_DIR = Path(__file__).parent
 MIN_ONNXRUNTIME_VERSION_FILE = SCRIPT_DIR.parent / "MIN_ONNXRUNTIME_VERSION"
 
-_TEMPLATE_VARIABLE_PATTERN = re.compile(r"@(\w+)@")
+# Import the shared template helper from _packaging_utils.py in the parent directory.
+sys.path.insert(0, str(SCRIPT_DIR.parent))
+from _packaging_utils import gen_file_from_template  # noqa: E402 (path setup must precede import)
+
 BINARY_PATTERNS = [
     "onnxruntime_providers_cuda_plugin.dll",
     "libonnxruntime_providers_cuda_plugin.so",
@@ -38,27 +41,6 @@ AUDITWHEEL_EXCLUDE = [
 ]
 
 
-def gen_file_from_template(template_file: Path, output_file: Path, variable_substitutions: dict[str, str]) -> None:
-    content = template_file.read_text(encoding="utf-8")
-    variables_in_file: set[str] = set()
-
-    def replace(match: re.Match[str]) -> str:
-        name = match.group(1)
-        variables_in_file.add(name)
-        return variable_substitutions.get(name, match.group(0))
-
-    content = _TEMPLATE_VARIABLE_PATTERN.sub(replace, content)
-    if variables_in_file != variable_substitutions.keys():
-        provided = set(variable_substitutions.keys())
-        raise ValueError(
-            f"Template variables and substitution keys do not match for {template_file}. "
-            f"Only in template: {sorted(variables_in_file - provided)}. "
-            f"Only in substitutions: {sorted(provided - variables_in_file)}."
-        )
-
-    output_file.write_text(content, encoding="utf-8")
-
-
 def prepare_staging_dir(staging_dir: Path, binary_dir: Path, version: str, package_name: str) -> None:
     staging_dir.mkdir(parents=True, exist_ok=True)
     shutil.copy2(SCRIPT_DIR / "setup.py", staging_dir / "setup.py")
@@ -79,10 +61,19 @@ def prepare_staging_dir(staging_dir: Path, binary_dir: Path, version: str, packa
     if not min_ort_version:
         raise ValueError(f"{MIN_ONNXRUNTIME_VERSION_FILE} is empty")
 
+    # Substitute the minimum ORT version into the staged README in place.
+    staged_readme = package_dir / "README.md"
+    gen_file_from_template(
+        staged_readme,
+        staged_readme,
+        {"min_onnxruntime_version": min_ort_version},
+    )
+
+    # Render pyproject.toml from its template
     gen_file_from_template(
         SCRIPT_DIR / "pyproject.toml.in",
         staging_dir / "pyproject.toml",
-        {"package_name": package_name, "version": version, "min_onnxruntime_version": min_ort_version},
+        {"package_name": package_name, "version": version},
     )
 
 

--- a/plugin-ep-cuda/python/onnxruntime_ep_cuda/README.md
+++ b/plugin-ep-cuda/python/onnxruntime_ep_cuda/README.md
@@ -2,6 +2,21 @@
 
 CUDA Execution Provider plugin for ONNX Runtime. Install alongside `onnxruntime` to enable the CUDA plugin EP.
 
+## Prerequisites
+
+This package provides the CUDA plugin EP only. You must separately install an ONNX Runtime package
+(e.g. `onnxruntime`) of version `@min_onnxruntime_version@` or later.
+
+If the installed ONNX Runtime is incompatible, the plugin EP will report an error when its library is
+registered.
+
+## Installation
+
+```bash
+pip install "onnxruntime>=@min_onnxruntime_version@"
+pip install onnxruntime-ep-cuda12  # or onnxruntime-ep-cuda13 for CUDA 13.x
+```
+
 ## Usage
 
 ```python

--- a/plugin-ep-cuda/python/pyproject.toml.in
+++ b/plugin-ep-cuda/python/pyproject.toml.in
@@ -9,9 +9,6 @@ description = "ONNX Runtime CUDA Plugin Execution Provider"
 readme = "onnxruntime_ep_cuda/README.md"
 license = {text = "MIT"}
 requires-python = ">=3.11"
-dependencies = [
-  "onnxruntime>=@min_onnxruntime_version@",
-]
 
 [tool.setuptools.packages.find]
 include = ["onnxruntime_ep_cuda*"]

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-linux-cuda-test-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-linux-cuda-test-stage.yml
@@ -98,9 +98,9 @@ stages:
               ls -la /build/python_wheel/
               exit 1
             fi
-            # --no-deps keeps onnxruntime pinned at the minimum version (the plugin wheel only
-            # requires onnxruntime>=<min>, which is already satisfied by the pinned install above).
-            python3 -m pip install --no-deps \"\$wheel\"
+            # The plugin wheel declares no dependency on a core onnxruntime package, so installing it
+            # leaves the onnxruntime pinned at the minimum version above untouched.
+            python3 -m pip install \"\$wheel\"
             python3 -c \"import onnxruntime; print('Base onnxruntime runtime version:', onnxruntime.__version__)\"
             python3 -u /onnxruntime_src/plugin-ep-cuda/python/test/test_cuda_plugin_ep.py
           "

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-win-cuda-test-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-win-cuda-test-stage.yml
@@ -173,6 +173,13 @@ stages:
         Write-Host "Detected package version: $packageVersion"
         Write-Host "##vso[task.setvariable variable=OrtCudaPackageVersion]$packageVersion"
 
+        # The EP package no longer declares a hard dependency on a core ORT package, so the test
+        # project references one explicitly. Pin it to the minimum supported version.
+        $minOrtVersionFile = "$(Build.SourcesDirectory)\plugin-ep-cuda\MIN_ONNXRUNTIME_VERSION"
+        $minOrtVersion = (Get-Content $minOrtVersionFile -Raw).Trim()
+        Write-Host "Using minimum core ORT version: $minOrtVersion from $minOrtVersionFile"
+        Write-Host "##vso[task.setvariable variable=OrtCoreTestVersion]$minOrtVersion"
+
         # Write a project-level nuget.config that adds ONLY the local feed.
         # NuGet merges this with the repo-root NuGet.config.
         $nugetConfig = "$(Build.SourcesDirectory)\plugin-ep-cuda\csharp\test\CudaEpNuGetTest\nuget.config"
@@ -193,7 +200,8 @@ stages:
         dotnet build `
           "$(CudaTestProject)" `
           --configuration Release `
-          -p:OrtCudaPackageVersion=$(OrtCudaPackageVersion)
+          -p:OrtCudaPackageVersion=$(OrtCudaPackageVersion) `
+          -p:OrtCoreTestVersion=$(OrtCoreTestVersion)
       displayName: 'Build test project'
 
     - pwsh: |


### PR DESCRIPTION
## Description

The CUDA plugin EP packages (`onnxruntime-ep-cuda12`/`onnxruntime-ep-cuda13` wheels and the
`Microsoft.ML.OnnxRuntime.EP.Cuda` NuGet package) currently declare a hard dependency on the core
`onnxruntime` package. That is wrong for `onnxruntime-gpu` users, who would otherwise be forced to pull in
the CPU `onnxruntime`/`Microsoft.ML.OnnxRuntime` package. This change drops the hard dependency from both
packages, documents the core-package prerequisite in the READMEs, and installs/pins the core ORT package
explicitly in CI — mirroring what was done for the WebGPU plugin EP in #28384.

The minimum compatible ORT version remains the single source of truth in
[`plugin-ep-cuda/MIN_ONNXRUNTIME_VERSION`](plugin-ep-cuda/MIN_ONNXRUNTIME_VERSION); it is now injected into
each package's README at build/pack time, and the native plugin EP validates compatibility at registration
time.

## Summary of Changes

### Python wheel

| File | Change |
|------|--------|
| `plugin-ep-cuda/python/pyproject.toml.in` | Removed the `dependencies = ["onnxruntime>=..."]` block. |
| `plugin-ep-cuda/python/build_wheel.py` | Import the shared `gen_file_from_template` helper; render the staged package README with the minimum ORT version; stop injecting the version into `pyproject.toml`. |
| `plugin-ep-cuda/python/onnxruntime_ep_cuda/README.md` | Added a Prerequisites section and an explicit `pip install "onnxruntime>=@min_onnxruntime_version@"` step. |

### C# NuGet package

| File | Change |
|------|--------|
| `plugin-ep-cuda/csharp/Microsoft.ML.OnnxRuntime.EP.Cuda/Microsoft.ML.OnnxRuntime.EP.Cuda.csproj` | Removed the `OnnxRuntimeMinVersion` resolution/validation machinery and the hard `Microsoft.ML.OnnxRuntime` `PackageReference`. |
| `plugin-ep-cuda/csharp/Microsoft.ML.OnnxRuntime.EP.Cuda/README.md` | Added a Prerequisites section and templatized the version requirement. |
| `plugin-ep-cuda/csharp/pack_nuget.py` | Render the staged README via the shared helper; dropped the `-p:OnnxRuntimeMinVersionFile` plumbing from `dotnet build`/`pack`. |

### Shared / docs

| File | Change |
|------|--------|
| `plugin-ep-cuda/_packaging_utils.py` | New shared `gen_file_from_template` helper (matches the WebGPU plugin's utility). |
| `plugin-ep-cuda/README.md` | Documented the no-hard-dependency behavior and the C# package. |

### Tests & CI

| File | Change |
|------|--------|
| `plugin-ep-cuda/csharp/test/CudaEpNuGetTest/CudaEpNuGetTest.csproj` | Reference the core `Microsoft.ML.OnnxRuntime` package explicitly via `$(OrtCoreTestVersion)` (no longer transitively pulled in). |
| `tools/ci_build/github/azure-pipelines/stages/plugin-linux-cuda-test-stage.yml` | Dropped the now-unnecessary `--no-deps` install flag and updated the comment. |
| `tools/ci_build/github/azure-pipelines/stages/plugin-win-cuda-test-stage.yml` | Set `OrtCoreTestVersion` from `MIN_ONNXRUNTIME_VERSION` and pass it to `dotnet build`. |

## Testing

- `python -m ruff check` and `lintrunner` pass on the changed files.
- Python scripts compile (`python -m py_compile`).
- CI: the Linux/Windows CUDA plugin test stages install the core `onnxruntime` package explicitly and verify
  the plugin wheel installs without altering the pinned core version; the NuGet test project references the
  core package explicitly and pins it to the minimum supported version.

## Motivation and Context

Follow-up to PR #28824 (CUDA plugin EP minimum ORT version / version-gated callbacks), kept separate to keep
that PR focused on the version-gating change. Mirrors the WebGPU plugin EP packaging change in #28384. The
CUDA case is stronger: a hard dependency on the CPU `onnxruntime` package is incorrect for `onnxruntime-gpu`
users.

## Checklist

- [x] Tests added/updated (CI test stages and NuGet test project updated)
- [x] Documentation updated (package and top-level READMEs)
- [x] No breaking changes (consumers must now install the core ORT package explicitly, documented in READMEs)
- [ ] CI passes
