### PR TITLE
[WebGPU] Graph capture support for KV-shared decoder models

### DIFF
--- a/onnxruntime/contrib_ops/webgpu/bert/flash_attention.cc
+++ b/onnxruntime/contrib_ops/webgpu/bert/flash_attention.cc
@@ -79,6 +79,34 @@ Status SplitPackedQKVWithRotaryEmbeddingAndCopyKVProgram::GenerateShaderCode(Sha
                              WGSL_TEMPLATE_VARIABLE(sin_cache, sin_cache));
 }
 
+Status PrepareIndirectDispatchProgram::GenerateShaderCode(ShaderHelper& shader) const {
+  shader.AddInput("seqlen_k", ShaderUsage::None);
+  shader.AddOutput("indirect_buffer", ShaderUsage::None);
+  shader.MainFunctionBody() << "  if (global_idx == 0u) {\n"
+                            << "    let total_seq_length = u32(seqlen_k[0u]) + 1u;\n"
+                            << "    let num_total_seq_length_tile = (total_seq_length + uniforms.tile_size - 1u) / uniforms.tile_size;\n"
+                            << "    indirect_buffer[0] = num_total_seq_length_tile;\n"
+                            << "    indirect_buffer[1] = uniforms.num_heads;\n"
+                            << "    indirect_buffer[2] = 1u;\n"
+                            << "  }\n";
+  return Status::OK();
+}
+
+Status PrepareIndirectDispatch(onnxruntime::webgpu::ComputeContext& context,
+                               const WebgpuAttentionParameters& parameters,
+                               const Tensor* seqlen_k,
+                               Tensor* indirect_buffer,
+                               uint32_t tile_size) {
+  PrepareIndirectDispatchProgram program{};
+  program.AddInput({seqlen_k, ProgramTensorMetadataDependency::None});
+  program.AddOutput({indirect_buffer, ProgramTensorMetadataDependency::None});
+  program.SetDispatchGroupSize(1)
+      .SetWorkgroupSize(1)
+      .AddUniformVariables({{tile_size},
+                            {static_cast<uint32_t>(parameters.num_heads_)}});
+  return context.RunProgram(program);
+}
+
 Status CopyKVCacheProgram::GenerateShaderCode(ShaderHelper& shader) const {
   // Expectations are
   //    qkv have same number of heads and hidden dimension (head size).
@@ -450,12 +478,20 @@ Status ApplyFlashAttention(const Tensor* Q, const Tensor* K, const Tensor* V, co
   Tensor* indirect_buffer_ptr = nullptr;
   Tensor indirect_buffer;
 
-  // Prepare indirect dispatch buffer for split-reduce path with static KV cache.
-  // When graph capture is enabled, total_sequence_length_ may be 0 (GPU-based
-  // seqlen_k), so the indirect buffer computes dispatch sizes on GPU.
-  const bool use_indirect_dispatch = parameters.past_present_share_buffer_ &&
+  // Prepare indirect dispatch buffer for decode path.
+  // Required when total_sequence_length is unknown at dispatch time:
+  //   1) Graph capture is on: total_seq_len varies across iterations of the captured graph.
+  //   2) total_sequence_length is GPU-resident (sentinel 0): any model that computes
+  //      seqlens_k inside the ONNX graph, regardless of GC state.
+  // The dispatch requires either static KV cache (past_present_share_buffer_) or kv_empty
+  // (KV-shared layer where past_key aliases another layer's present cache).
+  const bool decode_needs_indirect = context.IsGraphCaptureEnabled() ||
+                                     parameters.total_sequence_length_ == 0;
+  const bool use_indirect_dispatch = parameters.sequence_length_ == 1 &&
                                      seqlen_k != nullptr &&
-                                     context.IsGraphCaptureEnabled();
+                                     decode_needs_indirect &&
+                                     (parameters.past_present_share_buffer_ ||
+                                      (kv_empty && past_key != nullptr && past_value != nullptr));
   if (use_indirect_dispatch) {
     const TensorShape indirect_buffer_shape{3};  // 3 uint32 values for dispatch dimensions
     indirect_buffer = context.CreateGPUTensor(DataTypeImpl::GetType<uint32_t>(), indirect_buffer_shape);
@@ -480,6 +516,11 @@ Status ApplyFlashAttention(const Tensor* Q, const Tensor* K, const Tensor* V, co
       // and CopyKVCache is skipped when kv_empty, so no writes occur through these pointers.
       present_key = const_cast<Tensor*>(past_key);
       present_value = const_cast<Tensor*>(past_value);
+    }
+    // Populate indirect dispatch buffer for the decode kernels (CopyKVCache normally does this,
+    // but it's skipped for kv_empty layers).
+    if (use_indirect_dispatch) {
+      ORT_RETURN_IF_ERROR(PrepareIndirectDispatch(context, parameters, seqlen_k, indirect_buffer_ptr, tile_size));
     }
   } else if (do_rotary) {
     ORT_ENFORCE(parameters.is_packed_qkv_, "Fused SplitPackedQKVWithRotaryEmbeddingAndCopyKV requires packed QKV input.");

--- a/onnxruntime/contrib_ops/webgpu/bert/flash_attention.h
+++ b/onnxruntime/contrib_ops/webgpu/bert/flash_attention.h
@@ -45,6 +45,16 @@ class SplitPackedQKVWithRotaryEmbeddingAndCopyKVProgram final : public Program<S
   const uint32_t multi_rotary_cache_concat_offset_;
 };
 
+class PrepareIndirectDispatchProgram final : public Program<PrepareIndirectDispatchProgram> {
+ public:
+  PrepareIndirectDispatchProgram() : Program{"PrepareIndirectDispatch"} {}
+
+  Status GenerateShaderCode(ShaderHelper& sh) const override;
+
+  WEBGPU_PROGRAM_DEFINE_UNIFORM_VARIABLES({"tile_size", ProgramUniformVariableDataType::Uint32},
+                                          {"num_heads", ProgramUniformVariableDataType::Uint32});
+};
+
 class CopyKVCacheProgram final : public Program<CopyKVCacheProgram> {
  public:
   CopyKVCacheProgram(const std::string& kernel_name, bool has_past, bool kv_BNSH, bool past_present_share_buffer,

--- a/onnxruntime/core/providers/webgpu/generator/constant_of_shape.cc
+++ b/onnxruntime/core/providers/webgpu/generator/constant_of_shape.cc
@@ -1,0 +1,110 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/webgpu/generator/constant_of_shape.h"
+#include "core/providers/webgpu/shader_helper.h"
+
+namespace onnxruntime {
+namespace webgpu {
+
+Status ConstantOfShapeProgram::GenerateShaderCode(ShaderHelper& sh) const {
+  const auto& output = sh.AddOutput("output", ShaderUsage::UseUniform | ShaderUsage::UseValueTypeAlias);
+
+  sh.MainFunctionBody() << sh.GuardAgainstOutOfBoundsWorkgroupSizes("uniforms.output_size")
+                        << "  " << output.SetByOffset("global_idx", "bitcast<output_value_t>(uniforms.value)");
+
+  return Status::OK();
+}
+
+Status ConstantOfShape::ComputeInternal(ComputeContext& context) const {
+  Tensor* output_tensor = nullptr;
+  ORT_RETURN_IF_ERROR(PrepareCompute(&context, &output_tensor));
+
+  const auto output_size = output_tensor->Shape().Size();
+  if (output_size == 0) {
+    return Status::OK();
+  }
+
+  uint32_t value_u32 = 0;
+  const void* value_ptr = GetValuePtr();
+  if (value_ptr != nullptr) {
+    std::memcpy(&value_u32, value_ptr, std::min(sizeof(uint32_t), static_cast<size_t>(output_tensor->DataType()->Size())));
+  }
+
+  ConstantOfShapeProgram program;
+  program.AddOutput({output_tensor, ProgramTensorMetadataDependency::Type})
+      .SetDispatchGroupSize((static_cast<uint32_t>(output_size) + WORKGROUP_SIZE - 1) / WORKGROUP_SIZE)
+      .AddUniformVariables({
+          static_cast<uint32_t>(output_size),
+          value_u32,
+      });
+
+  return context.RunProgram(program);
+}
+
+namespace {
+
+std::vector<MLDataType> GetConstantOfShapeTypeConstraints(bool enable_int64) {
+  auto types = std::vector<MLDataType>{
+      DataTypeImpl::GetTensorType<float>(),
+      DataTypeImpl::GetTensorType<MLFloat16>(),
+      DataTypeImpl::GetTensorType<int32_t>(),
+      DataTypeImpl::GetTensorType<uint8_t>(),
+      DataTypeImpl::GetTensorType<int8_t>(),
+      DataTypeImpl::GetTensorType<bool>(),
+  };
+  if (enable_int64) {
+    types.push_back(DataTypeImpl::GetTensorType<int64_t>());
+  }
+  return types;
+}
+
+KernelCreatePtrFn GetConstantOfShapeKernelCreateFn() {
+  return [](FuncManager&, const OpKernelInfo& info, std::unique_ptr<OpKernel>& out) -> Status {
+    out = std::make_unique<ConstantOfShape>(info);
+    return Status::OK();
+  };
+}
+
+template <int StartVersion, int EndVersion>
+KernelCreateInfo CreateConstantOfShapeVersionedKernelInfo(bool enable_int64) {
+  return {
+      KernelDefBuilder()
+          .SetName("ConstantOfShape")
+          .SetDomain(kOnnxDomain)
+          .SinceVersion(StartVersion, EndVersion)
+          .Provider(kWebGpuExecutionProvider)
+          .TypeConstraint("T1", DataTypeImpl::GetTensorType<int64_t>())
+          .TypeConstraint("T2", GetConstantOfShapeTypeConstraints(enable_int64))
+          .InputMemoryType(OrtMemTypeCPU, 0)
+          .Build(),
+      GetConstantOfShapeKernelCreateFn()};
+}
+
+template <int SinceVersion>
+KernelCreateInfo CreateConstantOfShapeKernelInfo(bool enable_int64) {
+  return {
+      KernelDefBuilder()
+          .SetName("ConstantOfShape")
+          .SetDomain(kOnnxDomain)
+          .SinceVersion(SinceVersion)
+          .Provider(kWebGpuExecutionProvider)
+          .TypeConstraint("T1", DataTypeImpl::GetTensorType<int64_t>())
+          .TypeConstraint("T2", GetConstantOfShapeTypeConstraints(enable_int64))
+          .InputMemoryType(OrtMemTypeCPU, 0)
+          .Build(),
+      GetConstantOfShapeKernelCreateFn()};
+}
+
+}  // namespace
+
+void RegisterConstantOfShapeKernels(KernelRegistry& kernel_registry, bool enable_int64) {
+  ORT_THROW_IF_ERROR(kernel_registry.Register(CreateConstantOfShapeVersionedKernelInfo<9, 19>(enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry.Register(CreateConstantOfShapeVersionedKernelInfo<20, 20>(enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry.Register(CreateConstantOfShapeVersionedKernelInfo<21, 22>(enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry.Register(CreateConstantOfShapeVersionedKernelInfo<23, 23>(enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry.Register(CreateConstantOfShapeKernelInfo<24>(enable_int64)));
+}
+
+}  // namespace webgpu
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/webgpu/generator/constant_of_shape.h
+++ b/onnxruntime/core/providers/webgpu/generator/constant_of_shape.h
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/framework/kernel_registry.h"
+#include "core/providers/webgpu/program.h"
+#include "core/providers/webgpu/webgpu_kernel.h"
+#include "core/providers/cpu/generator/constant_of_shape_base.h"
+
+namespace onnxruntime {
+namespace webgpu {
+
+class ConstantOfShapeProgram final : public Program<ConstantOfShapeProgram> {
+ public:
+  ConstantOfShapeProgram() : Program{"ConstantOfShape"} {}
+
+  Status GenerateShaderCode(ShaderHelper& sh) const override;
+
+  WEBGPU_PROGRAM_DEFINE_UNIFORM_VARIABLES({"output_size", ProgramUniformVariableDataType::Uint32},
+                                          {"value", ProgramUniformVariableDataType::Uint32});
+};
+
+class ConstantOfShape final : public WebGpuKernel, public ConstantOfShapeBase<> {
+ public:
+  explicit ConstantOfShape(const OpKernelInfo& info) : WebGpuKernel(info), ConstantOfShapeBase<>(info) {}
+
+  Status ComputeInternal(ComputeContext& context) const override;
+};
+
+void RegisterConstantOfShapeKernels(KernelRegistry& kernel_registry, bool enable_int64);
+
+}  // namespace webgpu
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
@@ -32,6 +32,7 @@
 #include "core/providers/webgpu/tensor/cast.h"
 #include "core/providers/webgpu/tensor/expand.h"
 #include "core/providers/webgpu/tensor/grid_sample.h"
+#include "core/providers/webgpu/generator/constant_of_shape.h"
 #include "core/providers/webgpu/generator/range.h"
 #include "core/providers/webgpu/tensor/unsqueeze.h"
 
@@ -478,6 +479,9 @@ std::unique_ptr<KernelRegistry> RegisterKernels(bool enable_graph_capture, bool 
 
   // Register Range kernels with conditional int64 support
   RegisterRangeKernels(*kernel_registry, enable_int64);
+
+  // Register ConstantOfShape kernels with conditional int64 support
+  RegisterConstantOfShapeKernels(*kernel_registry, enable_int64);
 
   // Register Unsqueeze kernels with conditional int64 support
   ORT_THROW_IF_ERROR(kernel_registry->Register(CreateUnsqueezeVersionedKernelInfo<1, 10>(enable_int64)));


### PR DESCRIPTION
## Summary

Two changes required for WebGPU graph capture to work on models with KV-shared layers (e.g. Gemma4), independent of how the model was built (works with both `enable_webgpu_graph=true` and without):

- **ConstantOfShape WebGPU kernel** — KV-shared layers emit ConstantOfShape to create zero-filled tensors. Without a WebGPU kernel, these fall back to CPU, flooding the captured graph with MemcpyFromHost. Registered opset-by-opset (9, 20, 21, 23, 24) to match ONNX spec changes.
- **PrepareIndirectDispatch for kv_empty layers** — KV-shared layers skip CopyKVCache (no new K/V), which normally populates the indirect dispatch buffer. A single-thread shader fills it from `seqlen_k[0]+1` when CopyKVCache is skipped under graph capture. Also widens the indirect dispatch predicate to cover GPU-resident `total_sequence_length` (sentinel 0).

## Test plan

- [ ] CI passes (build + existing WebGPU tests)
- [ ] Verify ConstantOfShape kernel handles float/int32/int64 and zero-element outputs
- [ ] Verify PrepareIndirectDispatch fires correctly for kv_empty decode under GC
- [ ] E2e test with Gemma4 model built with `enable_webgpu_graph=true` (pending genai builder support)

🤖 Generated with [Claude Code](https://claude.com/claude-code)