### PR TITLE
Remove unimodule.json so Expo autolinks onnxruntime-react-native

### DIFF
--- a/js/react_native/package.json
+++ b/js/react_native/package.json
@@ -53,7 +53,6 @@
     "onnxruntime-react-native.podspec",
     "app.plugin.js",
     "react-native.config.js",
-    "unimodule.json",
     "!dist/commonjs/*.js.map",
     "!dist/module/*.js.map",
     "!android/.gitignore",

--- a/js/react_native/unimodule.json
+++ b/js/react_native/unimodule.json
@@ -1,4 +1,0 @@
-{
-  "name": "onnxruntime-react-native",
-  "platforms": ["ios", "android"]
-}


### PR DESCRIPTION
### Description

Removes `js/react_native/unimodule.json` and its entry in the npm `files` list.

### Motivation and Context

Fixes #29004 — in Expo projects, importing `onnxruntime-react-native` crashes the app at startup with `[runtime not ready]: TypeError: Cannot read property 'install' of null`.

`expo-modules-autolinking` treats the presence of `unimodule.json` as a marker that the dependency is an Expo module and therefore excludes it from React Native community autolinking (`expo-modules-autolinking react-native-config`). Since the package isn't actually an Expo module, nothing registers it on the Expo side either: `OnnxruntimePackage` never appears in the generated `PackageList.java`, `NativeModules.Onnxruntime` is `null`, and the import-time `Module.install()` call in `binding.js` throws before the app can mount.

The package already ships a `react-native.config.js` with the correct `packageImportPath` / `packageInstance`, so React Native autolinking knows exactly how to register it — the legacy marker file is the only thing preventing that in Expo apps. The file was added in #11556 (May 2022) to help Expo's then-current tooling discover the package; today's tooling interprets it in the opposite way. Bare React Native apps ignore the file entirely, so this change is a no-op for them.

Verified on Expo SDK 56 / React Native 0.85 / onnxruntime-react-native 1.24.3 (Android), by deleting the file from `node_modules` via a pnpm patch:

- before: `npx expo-modules-autolinking react-native-config --json` omits the package; the generated `PackageList.java` has no `OnnxruntimePackage`; the app crashes at startup
- after: the command reports the package with `packageInstance: new OnnxruntimePackage()`; `PackageList.java` registers `ai.onnxruntime.reactnative.OnnxruntimePackage`; the app boots and on-device inference of a 66M-parameter model runs through the JSI binding — without using the `app.plugin.js` config plugin

This is the root cause behind #19510, #26925, and #26796, and it is why the Expo config plugin currently has to inject `OnnxruntimePackage` into `MainApplication` by string manipulation — the part of the plugin that keeps breaking with new Expo SDKs (#28657, #28672). With the marker removed, that `MainApplication` patching becomes unnecessary on Android.

Note for maintainers: apps that currently work around the bug via `app.plugin.js` or a manual `react-native.config.js` entry would register the package twice once autolinking starts working. The config plugin should probably drop its `MainApplication` modification in the same release — happy to extend this PR to do that if you'd like, or keep it minimal as-is.
