### PR TITLE
fix: NodeJS pkging stage needs to use CFS

### DIFF
--- a/tools/ci_build/github/azure-pipelines/stages/nodejs-npm-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/nodejs-npm-packaging-stage.yml
@@ -54,6 +54,8 @@ stages:
     - checkout: self
       submodules: true
 
+    - template: ../templates/setup-feeds-and-python-steps.yml
+
     - script: |
         echo.>>.gitattributes
         echo /js/** text=auto eol=lf>>.gitattributes


### PR DESCRIPTION
### Description

ADO pipeline `Nodejs_Packaging` stage now uses CFS.


### Motivation and Context

It gets network isolated otherwise, and fails.