### PR TITLE
Fixed failing KleidiAI NHWC unit tests

### DIFF
--- a/onnxruntime/test/optimizer/nhwc_transformer_test.cc
+++ b/onnxruntime/test/optimizer/nhwc_transformer_test.cc
@@ -447,12 +447,22 @@ TEST(NhwcTransformerTests, ConvFloat_UsesNhwcOnlyWithKleidi) {
 
   auto check_nhwc_graph = [&](InferenceSessionWrapper& session) {
     auto op_to_count = CountOpsInGraph(session.GetGraph());
-    // Only validate NhwcFusedConv graph shape if that path was selected
-    if (op_to_count["com.microsoft.NhwcFusedConv"] == 0) {
+
+    const bool kleidi_supported = HasFloatNhwcNoTransposeSupport({1, 8, 7, 7}, {16, 8, 3, 3}, {1, 1, 1, 1});
+    const int nhwc_count = op_to_count["com.microsoft.NhwcFusedConv"];
+
+    // Other Level 3 layout optimizers may consume the Conv node in the graph before NhwcTransformer.
+    // If NHWC is selected, validate that it's only used with Arm® KleidiAI™ support and that
+    // the expected transpose-boundary graph shape is produced. Otherwise, don't validate the graph shape.
+    if (nhwc_count == 0) {
+      // When the Arm® KleidiAI™ NHWC Conv path is available but no NHWC ops were produced,
+      // ensure that some other optimiser run and consumed the Conv node instead
+      EXPECT_TRUE(!kleidi_supported || op_to_count["Conv"] == 0);
       return;
     }
-    EXPECT_TRUE(HasFloatNhwcNoTransposeSupport({1, 8, 7, 7}, {16, 8, 3, 3}, {1, 1, 1, 1}));
-    EXPECT_EQ(op_to_count["com.microsoft.NhwcFusedConv"], 1);
+
+    EXPECT_TRUE(kleidi_supported);
+    EXPECT_EQ(nhwc_count, 1);
     EXPECT_EQ(op_to_count["Transpose"], 2);
   };
 
@@ -517,15 +527,26 @@ TEST(NhwcTransformerTests, FusedConvFloat_UsesNhwcOnlyWithKleidi) {
 
   auto check_nhwc_graph = [&](InferenceSessionWrapper& session) {
     auto op_to_count = CountOpsInGraph(session.GetGraph());
-    // Only validate NhwcFusedConv graph shape if that path was selected
-    if (op_to_count["com.microsoft.NhwcFusedConv"] == 0) {
+
+    const bool kleidi_supported = HasFloatNhwcNoTransposeSupport({1, 8, 7, 7}, {16, 8, 3, 3}, {1, 1, 1, 1}, {1, 1});
+    const int nhwc_count = op_to_count["com.microsoft.NhwcFusedConv"];
+
+    // Other Level 3 layout optimizers may consume the FusedConv node in the graph before NhwcTransformer.
+    // If NHWC is selected, validate that it's only used with Arm® KleidiAI™ support and that
+    // the expected transpose-boundary graph shape is produced. Otherwise, don't validate the graph shape.
+    if (nhwc_count == 0) {
+      // When the Arm® KleidiAI™ NHWC Conv path is available but no NHWC ops were produced,
+      // ensure that some other optimiser run and consumed the FusedConv node instead
+      EXPECT_TRUE(!kleidi_supported || op_to_count["com.microsoft.FusedConv"] == 0);
       return;
     }
-    EXPECT_TRUE(HasFloatNhwcNoTransposeSupport({1, 8, 7, 7}, {16, 8, 3, 3}, {1, 1, 1, 1}, {1, 1}));
-    EXPECT_EQ(op_to_count["com.microsoft.NhwcFusedConv"], 1);
+
+    EXPECT_TRUE(kleidi_supported);
+    EXPECT_EQ(nhwc_count, 1);
     EXPECT_EQ(op_to_count["Transpose"], 2);
   };
 
+  // Different optimizer paths can change accumulation order, so allow a slightly larger absolute tolerance
   TransformerTester(build_test_case,
                     check_nhwc_graph,
                     TransformerLevel::Level2,

--- a/onnxruntime/test/optimizer/nhwc_transformer_test.cc
+++ b/onnxruntime/test/optimizer/nhwc_transformer_test.cc
@@ -546,13 +546,14 @@ TEST(NhwcTransformerTests, FusedConvFloat_UsesNhwcOnlyWithKleidi) {
     EXPECT_EQ(op_to_count["Transpose"], 2);
   };
 
-  // Different optimizer paths can change accumulation order, so allow a slightly larger absolute tolerance
+  // This compares a Level 3 layout-optimized FusedConv+Relu path with the Level 2 baseline, which can use a different FP accumulation order.
+  // The NCHWc-selected path showed deterministic FP rounding drift just over 1e-6, so use a slightly wider but still narrow margin.
   TransformerTester(build_test_case,
                     check_nhwc_graph,
                     TransformerLevel::Level2,
                     TransformerLevel::Level3,
                     /*opset_version*/ 12,
-                    /*per_sample_tolerance*/ 2e-6,
+                    /*per_sample_tolerance*/ 1.25e-6,
                     /*relative_per_sample_tolerance*/ 1e-6);
 }
 

--- a/onnxruntime/test/optimizer/nhwc_transformer_test.cc
+++ b/onnxruntime/test/optimizer/nhwc_transformer_test.cc
@@ -447,11 +447,13 @@ TEST(NhwcTransformerTests, ConvFloat_UsesNhwcOnlyWithKleidi) {
 
   auto check_nhwc_graph = [&](InferenceSessionWrapper& session) {
     auto op_to_count = CountOpsInGraph(session.GetGraph());
-    const bool expect_nhwc = HasFloatNhwcNoTransposeSupport({1, 8, 7, 7}, {16, 8, 3, 3}, {1, 1, 1, 1});
-    const int expected_nhwc_fused_conv = expect_nhwc ? 1 : 0;
-    const int expected_transposes = expect_nhwc ? 2 : 0;
-    EXPECT_EQ(op_to_count["com.microsoft.NhwcFusedConv"], expected_nhwc_fused_conv);
-    EXPECT_EQ(op_to_count["Transpose"], expected_transposes);
+    // Only validate NhwcFusedConv graph shape if that path was selected
+    if (op_to_count["com.microsoft.NhwcFusedConv"] == 0) {
+      return;
+    }
+    EXPECT_TRUE(HasFloatNhwcNoTransposeSupport({1, 8, 7, 7}, {16, 8, 3, 3}, {1, 1, 1, 1}));
+    EXPECT_EQ(op_to_count["com.microsoft.NhwcFusedConv"], 1);
+    EXPECT_EQ(op_to_count["Transpose"], 2);
   };
 
   TransformerTester(build_test_case,
@@ -515,12 +517,13 @@ TEST(NhwcTransformerTests, FusedConvFloat_UsesNhwcOnlyWithKleidi) {
 
   auto check_nhwc_graph = [&](InferenceSessionWrapper& session) {
     auto op_to_count = CountOpsInGraph(session.GetGraph());
-    const bool expect_nhwc = HasFloatNhwcNoTransposeSupport(
-        {1, 8, 7, 7}, {16, 8, 3, 3}, {1, 1, 1, 1}, {1, 1});
-    const int expected_nhwc_fused_conv = expect_nhwc ? 1 : 0;
-    const int expected_transposes = expect_nhwc ? 2 : 0;
-    EXPECT_EQ(op_to_count["com.microsoft.NhwcFusedConv"], expected_nhwc_fused_conv);
-    EXPECT_EQ(op_to_count["Transpose"], expected_transposes);
+    // Only validate NhwcFusedConv graph shape if that path was selected
+    if (op_to_count["com.microsoft.NhwcFusedConv"] == 0) {
+      return;
+    }
+    EXPECT_TRUE(HasFloatNhwcNoTransposeSupport({1, 8, 7, 7}, {16, 8, 3, 3}, {1, 1, 1, 1}, {1, 1}));
+    EXPECT_EQ(op_to_count["com.microsoft.NhwcFusedConv"], 1);
+    EXPECT_EQ(op_to_count["Transpose"], 2);
   };
 
   TransformerTester(build_test_case,
@@ -528,7 +531,7 @@ TEST(NhwcTransformerTests, FusedConvFloat_UsesNhwcOnlyWithKleidi) {
                     TransformerLevel::Level2,
                     TransformerLevel::Level3,
                     /*opset_version*/ 12,
-                    /*per_sample_tolerance*/ 1e-6,
+                    /*per_sample_tolerance*/ 2e-6,
                     /*relative_per_sample_tolerance*/ 1e-6);
 }
 

--- a/onnxruntime/test/optimizer/nhwc_transformer_test.cc
+++ b/onnxruntime/test/optimizer/nhwc_transformer_test.cc
@@ -456,7 +456,7 @@ TEST(NhwcTransformerTests, ConvFloat_UsesNhwcOnlyWithKleidi) {
     // the expected transpose-boundary graph shape is produced. Otherwise, don't validate the graph shape.
     if (nhwc_count == 0) {
       // When the Arm® KleidiAI™ NHWC Conv path is available but no NHWC ops were produced,
-      // ensure that some other optimiser run and consumed the Conv node instead
+      // ensure that some other optimizer ran and consumed the Conv node instead
       EXPECT_TRUE(!kleidi_supported || op_to_count["Conv"] == 0);
       return;
     }
@@ -536,7 +536,7 @@ TEST(NhwcTransformerTests, FusedConvFloat_UsesNhwcOnlyWithKleidi) {
     // the expected transpose-boundary graph shape is produced. Otherwise, don't validate the graph shape.
     if (nhwc_count == 0) {
       // When the Arm® KleidiAI™ NHWC Conv path is available but no NHWC ops were produced,
-      // ensure that some other optimiser run and consumed the FusedConv node instead
+      // ensure that some other optimizer ran and consumed the FusedConv node instead
       EXPECT_TRUE(!kleidi_supported || op_to_count["com.microsoft.FusedConv"] == 0);
       return;
     }


### PR DESCRIPTION
### Description

The current tests in the `NhwcTransformerTests` suite `ConvFloat_UsesNhwcOnlyWithKleidi` and `FusedConvFloat_UsesNhwcOnlyWithKleidi` assumed that whenever KleidiAI NHWC float-conv support is available, the test graph must be rewritten to `com.microsoft.NhwcFusedConv`.

That assumption is not valid when ONNX Runtime is built with `--enable_arm_neon_nchwc`. In that cofiguration, the Level 3 NCHWc transformer is registered before the NHWC transformer, so the NCHWc rewrite can be selected instead. The optimiser priority is intentional, so these tests shouldn't require NHWC to be chosen over NCHWc.

This change keeps the existing optimiser ordering and instead updates the assertions in the 2 tests. If the NHWC path is selected, the tests still validate the expected `NhwcFusedConv` graph shape and verify that the path is only used when KleidiAI NHWC support is available. If another valid layout optimisation is selected first, the tests no longer fail just because the `NhwcFusedConv` op isn't generated.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

This change fixes the 2 mentioned unit tests which fail when ONNX Runtime is built and tested with `--enable_arm_neon_nchwc`.