### PR TITLE
[js/web] Forward WebGPU EP buffer cache mode options from JS

### DIFF
--- a/js/common/lib/inference-session.ts
+++ b/js/common/lib/inference-session.ts
@@ -273,6 +273,47 @@ export declare namespace InferenceSession {
     validationMode?: 'disabled' | 'wgpuOnly' | 'basic' | 'full';
 
     /**
+     * Specify the cache mode for storage buffers.
+     * - 'disabled': Disable buffer cache. Buffers are destroyed when no longer in use.
+     * - 'lazyRelease': Buffers are released lazily, at the end of the current run.
+     * - 'simple': Released buffers are cached and reused only for requests of the exact same size.
+     * - 'bucket': Released buffers are cached and reused using predefined size buckets. This is the default mode.
+     *
+     * For static-shape models, 'simple' may reduce GPU memory usage, because exact-size buffers are reused across
+     * runs instead of allocating new bucket-sized buffers.
+     *
+     * @default 'bucket'
+     */
+    storageBufferCacheMode?: 'disabled' | 'lazyRelease' | 'simple' | 'bucket';
+
+    /**
+     * Specify the cache mode for uniform buffers.
+     *
+     * See {@link storageBufferCacheMode} for a description of the available modes.
+     *
+     * @default 'simple'
+     */
+    uniformBufferCacheMode?: 'disabled' | 'lazyRelease' | 'simple' | 'bucket';
+
+    /**
+     * Specify the cache mode for query resolve buffers.
+     *
+     * See {@link storageBufferCacheMode} for a description of the available modes.
+     *
+     * @default 'disabled'
+     */
+    queryResolveBufferCacheMode?: 'disabled' | 'lazyRelease' | 'simple' | 'bucket';
+
+    /**
+     * Specify the cache mode for buffers not covered by the other buffer cache mode options.
+     *
+     * See {@link storageBufferCacheMode} for a description of the available modes.
+     *
+     * @default 'disabled'
+     */
+    defaultBufferCacheMode?: 'disabled' | 'lazyRelease' | 'simple' | 'bucket';
+
+    /**
      * Specify an optional WebGPU device to be used by the WebGPU execution provider.
      */
     device?: TryGetGlobalType<'GPUDevice'>;

--- a/js/web/lib/wasm/session-options.ts
+++ b/js/web/lib/wasm/session-options.ts
@@ -138,6 +138,22 @@ const setExecutionProviders = async (
             if (webgpuOptions.validationMode) {
               appendEpOption(epOptions, 'validationMode', webgpuOptions.validationMode, allocs);
             }
+
+            // set buffer cache modes
+            for (const key of [
+              'storageBufferCacheMode',
+              'uniformBufferCacheMode',
+              'queryResolveBufferCacheMode',
+              'defaultBufferCacheMode',
+            ] as const) {
+              const mode = webgpuOptions[key];
+              if (mode) {
+                if (mode !== 'disabled' && mode !== 'lazyRelease' && mode !== 'simple' && mode !== 'bucket') {
+                  throw new Error(`${key} must be one of 'disabled', 'lazyRelease', 'simple' or 'bucket': ${mode}`);
+                }
+                appendEpOption(epOptions, key, mode, allocs);
+              }
+            }
           }
 
           const info = getInstance().webgpuRegisterDevice!(customDevice);

--- a/onnxruntime/core/providers/webgpu/buffer_manager.cc
+++ b/onnxruntime/core/providers/webgpu/buffer_manager.cc
@@ -487,12 +487,12 @@ std::ostream& operator<<(std::ostream& os, BufferCacheMode mode) {
   return os;
 }
 
-BufferManager::BufferManager(WebGpuContext& context, BufferCacheMode storage_buffer_cache_mode, BufferCacheMode uniform_buffer_cache_mode, BufferCacheMode query_resolve_buffer_cache_mode)
+BufferManager::BufferManager(WebGpuContext& context, BufferCacheMode storage_buffer_cache_mode, BufferCacheMode uniform_buffer_cache_mode, BufferCacheMode query_resolve_buffer_cache_mode, BufferCacheMode default_buffer_cache_mode)
     : context_{context},
       storage_cache_{CreateBufferCacheManager(storage_buffer_cache_mode)},
       uniform_cache_{CreateBufferCacheManager(uniform_buffer_cache_mode)},
       query_resolve_cache_{CreateBufferCacheManager(query_resolve_buffer_cache_mode)},
-      default_cache_{CreateBufferCacheManager(BufferCacheMode::Disabled)} {
+      default_cache_{CreateBufferCacheManager(default_buffer_cache_mode)} {
 }
 
 void BufferManager::Upload(void* src, WGPUBuffer dst, size_t size) const {
@@ -632,8 +632,8 @@ IBufferCacheManager& BufferManager::GetCacheManager(WGPUBuffer buffer) const {
   return GetCacheManager(usage);
 }
 
-std::unique_ptr<BufferManager> BufferManagerFactory::Create(WebGpuContext& context, BufferCacheMode storage_buffer_cache_mode, BufferCacheMode uniform_buffer_cache_mode, BufferCacheMode query_resolve_buffer_cache_mode) {
-  return std::make_unique<BufferManager>(context, storage_buffer_cache_mode, uniform_buffer_cache_mode, query_resolve_buffer_cache_mode);
+std::unique_ptr<BufferManager> BufferManagerFactory::Create(WebGpuContext& context, BufferCacheMode storage_buffer_cache_mode, BufferCacheMode uniform_buffer_cache_mode, BufferCacheMode query_resolve_buffer_cache_mode, BufferCacheMode default_buffer_cache_mode) {
+  return std::make_unique<BufferManager>(context, storage_buffer_cache_mode, uniform_buffer_cache_mode, query_resolve_buffer_cache_mode, default_buffer_cache_mode);
 }
 
 }  // namespace webgpu

--- a/onnxruntime/core/providers/webgpu/buffer_manager.h
+++ b/onnxruntime/core/providers/webgpu/buffer_manager.h
@@ -87,7 +87,7 @@ class IBufferCacheManager {
 //
 class BufferManager {
  public:
-  BufferManager(WebGpuContext& context, BufferCacheMode storage_buffer_cache_mode, BufferCacheMode uniform_buffer_cache_mode, BufferCacheMode query_resolve_buffer_cache_mode);
+  BufferManager(WebGpuContext& context, BufferCacheMode storage_buffer_cache_mode, BufferCacheMode uniform_buffer_cache_mode, BufferCacheMode query_resolve_buffer_cache_mode, BufferCacheMode default_buffer_cache_mode);
   void Upload(void* src, WGPUBuffer dst, size_t size) const;
   void MemCpy(WGPUBuffer src, WGPUBuffer dst, size_t size) const;
   WGPUBuffer Create(size_t size, wgpu::BufferUsage usage) const;
@@ -114,7 +114,7 @@ class BufferManager {
 
 class BufferManagerFactory {
  public:
-  static std::unique_ptr<BufferManager> Create(WebGpuContext& context, BufferCacheMode storage_buffer_cache_mode, BufferCacheMode uniform_buffer_cache_mode, BufferCacheMode query_resolve_buffer_cache_mode);
+  static std::unique_ptr<BufferManager> Create(WebGpuContext& context, BufferCacheMode storage_buffer_cache_mode, BufferCacheMode uniform_buffer_cache_mode, BufferCacheMode query_resolve_buffer_cache_mode, BufferCacheMode default_buffer_cache_mode);
 
  private:
   BufferManagerFactory() {}

--- a/onnxruntime/core/providers/webgpu/webgpu_context.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.cc
@@ -148,12 +148,14 @@ void WebGpuContext::Initialize(const WebGpuContextConfig& config) {
     buffer_mgr_ = BufferManagerFactory::Create(*this,
                                                config.buffer_cache_config.storage.mode,
                                                config.buffer_cache_config.uniform.mode,
-                                               config.buffer_cache_config.query_resolve.mode);
+                                               config.buffer_cache_config.query_resolve.mode,
+                                               config.buffer_cache_config.default_entry.mode);
 
     // create initializer buffer manager.
     initializer_buffer_mgr_ = BufferManagerFactory::Create(*this,
                                                            BufferCacheMode::LazyRelease,
                                                            BufferCacheMode::LazyRelease,
+                                                           BufferCacheMode::Disabled,
                                                            BufferCacheMode::Disabled);
 
     // create program manager

--- a/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
@@ -802,6 +802,7 @@ Status WebGpuExecutionProvider::OnRunStart(const onnxruntime::RunOptions& run_op
             context_,
             webgpu::BufferCacheMode::Graph,
             webgpu::BufferCacheMode::GraphSimple,
+            webgpu::BufferCacheMode::Disabled,
             webgpu::BufferCacheMode::Disabled);
         if (session_buffer_pool_) {
           session_buffer_pool_->SeedInto(*it->second);


### PR DESCRIPTION
### Description
The native WebGPU EP already supports the buffer cache mode options (`ep.webgpuexecutionprovider.storageBufferCacheMode` and friends), but onnxruntime-web never forwarded them from `executionProviders`, so they were unreachable from JS. This adds `storageBufferCacheMode`, `uniformBufferCacheMode`, `queryResolveBufferCacheMode` and `defaultBufferCacheMode` to `WebGpuExecutionProviderOption` and forwards them to the EP the same way `validationMode` is forwarded today, with the values validated against the set the native side accepts. The options ride the existing `SessionOptionsAppendExecutionProvider` path, which prefixes each key into exactly the config entry the EP reads, so no native changes are needed.

### Motivation and Context
Fixes #29016. For static shape models, `storageBufferCacheMode: 'simple'` reuses exact size buffers across runs instead of allocating new bucket sized ones, which the issue's repro shows cutting peak WebGPU memory by about 27 percent. Verified locally with tsc builds of js/common and js/web, prettier and eslint, the js/common unit tests, and type level checks that the new options compile and invalid values are rejected.
