### PR TITLE
[WebGPU] Fix profiling timestamp alignment with ORT profiler

### DIFF
--- a/onnxruntime/core/providers/webgpu/webgpu_context.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.cc
@@ -633,12 +633,15 @@ void WebGpuContext::WriteTimestamp(uint32_t query_index) {
   compute_pass_encoder.WriteTimestamp(query_set_, query_index);
 }
 
-void WebGpuContext::StartProfiling() {
+void WebGpuContext::StartProfiling(TimePoint profiling_start_time) {
   if (query_type_ == TimestampQueryType::None) {
     return;
   }
 
   is_profiling_ = true;
+  profiling_start_time_ = profiling_start_time;
+  gpu_timestamp_offset_ = 0;
+  profiling_first_submit_cpu_offset_us_ = -1;
 
   const uint32_t query_count = max_num_pending_dispatches_ * 2;
 
@@ -662,6 +665,10 @@ void WebGpuContext::StartProfiling() {
 
 void WebGpuContext::CollectProfilingData(profiling::Events& events) {
   if (!pending_queries_.empty()) {
+    int64_t cpu_offset_us = profiling_first_submit_cpu_offset_us_ > 0
+                                ? profiling_first_submit_cpu_offset_us_
+                                : 0;
+
     for (const auto& pending_query : pending_queries_) {
       const auto& pending_kernels = pending_query.kernels;
       const auto& query_read_buffer = pending_query.query_buffer;
@@ -690,7 +697,6 @@ void WebGpuContext::CollectProfilingData(profiling::Events& events) {
 
         if (gpu_timestamp_offset_ == 0) {
           gpu_timestamp_offset_ = mapped_data[i * 2];
-          // TODO: apply CPU-GPU time offset so that timestamps are aligned
         }
         uint64_t start_time = mapped_data[i * 2] - gpu_timestamp_offset_;
         uint64_t end_time = mapped_data[i * 2 + 1] - gpu_timestamp_offset_;
@@ -704,7 +710,7 @@ void WebGpuContext::CollectProfilingData(profiling::Events& events) {
                                      -1,
                                      -1,
                                      pending_kernel_info.name,
-                                     static_cast<int64_t>(std::round(start_time / 1000.0)),
+                                     static_cast<int64_t>(std::round(start_time / 1000.0)) + cpu_offset_us,
                                      static_cast<int64_t>(std::round((end_time - start_time) / 1000.0)),
                                      event_args);
         events.emplace_back(std::move(event));
@@ -769,6 +775,10 @@ void WebGpuContext::Flush(const webgpu::BufferManager& buffer_mgr) {
     ORT_ENFORCE(num_pending_dispatches_ == pending_kernels_.size(),
                 "Number of pending dispatches (", num_pending_dispatches_,
                 ") does not match pending kernels size (", pending_kernels_.size(), ")");
+
+    if (profiling_first_submit_cpu_offset_us_ < 0) {
+      profiling_first_submit_cpu_offset_us_ = TimeDiffMicroSeconds(profiling_start_time_);
+    }
 
     uint32_t query_count = num_pending_dispatches_ * 2;
     current_command_encoder_.ResolveQuerySet(

--- a/onnxruntime/core/providers/webgpu/webgpu_context.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.cc
@@ -633,13 +633,15 @@ void WebGpuContext::WriteTimestamp(uint32_t query_index) {
   compute_pass_encoder.WriteTimestamp(query_set_, query_index);
 }
 
-void WebGpuContext::StartProfiling(TimePoint profiling_start_time) {
+void WebGpuContext::StartProfiling() {
   if (query_type_ == TimestampQueryType::None) {
     return;
   }
 
   is_profiling_ = true;
-  profiling_start_time_ = profiling_start_time;
+  // profiling_start_time_ is supplied separately via SetProfilingStartTime, which is
+  // driven by WebGpuProfiler::StartProfiling and carries the ORT profiler's CPU time
+  // base for both session-level and run-level profiling.
   gpu_timestamp_offset_ = 0;
   profiling_first_submit_cpu_offset_us_ = -1;
 
@@ -665,6 +667,9 @@ void WebGpuContext::StartProfiling(TimePoint profiling_start_time) {
 
 void WebGpuContext::CollectProfilingData(profiling::Events& events) {
   if (!pending_queries_.empty()) {
+    // Shift GPU timestamps (which start from 0 at the first submit) onto the ORT
+    // profiler's CPU timeline by adding the CPU elapsed time from profiling_start_time_
+    // to that first submit. This keeps GPU events aligned with ORT CPU events.
     int64_t cpu_offset_us = profiling_first_submit_cpu_offset_us_ > 0
                                 ? profiling_first_submit_cpu_offset_us_
                                 : 0;
@@ -776,6 +781,8 @@ void WebGpuContext::Flush(const webgpu::BufferManager& buffer_mgr) {
                 "Number of pending dispatches (", num_pending_dispatches_,
                 ") does not match pending kernels size (", pending_kernels_.size(), ")");
 
+    // Capture the CPU elapsed time from the ORT profiler's start to this first submit.
+    // Used in CollectProfilingData to offset GPU timestamps onto the ORT CPU timeline.
     if (profiling_first_submit_cpu_offset_us_ < 0) {
       profiling_first_submit_cpu_offset_us_ = TimeDiffMicroSeconds(profiling_start_time_);
     }

--- a/onnxruntime/core/providers/webgpu/webgpu_context.h
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.h
@@ -240,7 +240,12 @@ class WebGpuContext final {
     return *split_k_config_;
   }
 
-  void StartProfiling(TimePoint profiling_start_time = std::chrono::high_resolution_clock::now());
+  // Set the CPU time base (ORT profiler's profiling_start_time) used to align GPU
+  // timestamps with ORT CPU events. Pushed in by WebGpuProfiler::StartProfiling, which
+  // is the only place that receives the framework's profiling start time for both
+  // session-level and run-level profiling.
+  void SetProfilingStartTime(TimePoint profiling_start_time) { profiling_start_time_ = profiling_start_time; }
+  void StartProfiling();
   // Collect pending GPU profiling data into the given events vector.
   void CollectProfilingData(profiling::Events& events);
   // Collect pending GPU profiling data into the shared events_ vector (run-level).
@@ -364,7 +369,11 @@ class WebGpuContext final {
   std::vector<PendingQueryInfo> pending_queries_;
 
   uint64_t gpu_timestamp_offset_ = 0;
+  // ORT profiler's CPU time base, set via SetProfilingStartTime; GPU timestamps are
+  // aligned to it. See SetProfilingStartTime.
   TimePoint profiling_start_time_;
+  // CPU elapsed time (us) from profiling_start_time_ to the first GPU submit, applied
+  // as an offset to GPU timestamps in CollectProfilingData. -1 until the first submit.
   int64_t profiling_first_submit_cpu_offset_us_ = -1;
   bool is_profiling_ = false;
   // Shared GPU profiling events for run-level profiling.

--- a/onnxruntime/core/providers/webgpu/webgpu_context.h
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.h
@@ -240,7 +240,7 @@ class WebGpuContext final {
     return *split_k_config_;
   }
 
-  void StartProfiling();
+  void StartProfiling(TimePoint profiling_start_time = std::chrono::high_resolution_clock::now());
   // Collect pending GPU profiling data into the given events vector.
   void CollectProfilingData(profiling::Events& events);
   // Collect pending GPU profiling data into the shared events_ vector (run-level).
@@ -364,6 +364,8 @@ class WebGpuContext final {
   std::vector<PendingQueryInfo> pending_queries_;
 
   uint64_t gpu_timestamp_offset_ = 0;
+  TimePoint profiling_start_time_;
+  int64_t profiling_first_submit_cpu_offset_us_ = -1;
   bool is_profiling_ = false;
   // Shared GPU profiling events for run-level profiling.
   profiling::Events events_;

--- a/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
@@ -779,7 +779,9 @@ Status WebGpuExecutionProvider::OnRunStart(const onnxruntime::RunOptions& run_op
   }
 
   // Start profiling if session-level or run-level profiling is enabled
-  if (run_options.enable_profiling || (session_profiler_ && session_profiler_->Enabled())) {
+  if (session_profiler_ && session_profiler_->Enabled()) {
+    context_.StartProfiling(session_profiler_->ProfilingStartTime());
+  } else if (run_options.enable_profiling) {
     context_.StartProfiling();
   }
 
@@ -869,7 +871,7 @@ Status WebGpuExecutionProvider::ReplayGraph(int graph_annotation_id, bool /*sync
   ORT_ENFORCE(IsGraphCaptured(graph_annotation_id));
   // TODO: enable profiling in run level
   if (session_profiler_ && session_profiler_->Enabled()) {
-    context_.StartProfiling();
+    context_.StartProfiling(session_profiler_->ProfilingStartTime());
   }
   context_.Replay(captured_graphs_.at(graph_annotation_id), *per_graph_buffer_mgrs_.at(graph_annotation_id));
   if (session_profiler_ && session_profiler_->Enabled()) {

--- a/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
@@ -778,10 +778,10 @@ Status WebGpuExecutionProvider::OnRunStart(const onnxruntime::RunOptions& run_op
     context_.PushErrorScope();
   }
 
-  // Start profiling if session-level or run-level profiling is enabled
-  if (session_profiler_ && session_profiler_->Enabled()) {
-    context_.StartProfiling(session_profiler_->ProfilingStartTime());
-  } else if (run_options.enable_profiling) {
+  // Start profiling if session-level or run-level profiling is enabled. The CPU time
+  // base used to align GPU timestamps is pushed into the context by
+  // WebGpuProfiler::StartProfiling, so no timepoint is threaded through here.
+  if ((session_profiler_ && session_profiler_->Enabled()) || run_options.enable_profiling) {
     context_.StartProfiling();
   }
 
@@ -871,7 +871,7 @@ Status WebGpuExecutionProvider::ReplayGraph(int graph_annotation_id, bool /*sync
   ORT_ENFORCE(IsGraphCaptured(graph_annotation_id));
   // TODO: enable profiling in run level
   if (session_profiler_ && session_profiler_->Enabled()) {
-    context_.StartProfiling(session_profiler_->ProfilingStartTime());
+    context_.StartProfiling();
   }
   context_.Replay(captured_graphs_.at(graph_annotation_id), *per_graph_buffer_mgrs_.at(graph_annotation_id));
   if (session_profiler_ && session_profiler_->Enabled()) {

--- a/onnxruntime/core/providers/webgpu/webgpu_profiler.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_profiler.cc
@@ -11,8 +11,9 @@ namespace webgpu {
 
 WebGpuProfiler::WebGpuProfiler(WebGpuContext& context) : context_{context} {}
 
-Status WebGpuProfiler::StartProfiling(TimePoint) {
+Status WebGpuProfiler::StartProfiling(TimePoint profiling_start_time) {
   enabled_ = true;
+  profiling_start_time_ = profiling_start_time;
   return Status::OK();
 }
 

--- a/onnxruntime/core/providers/webgpu/webgpu_profiler.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_profiler.cc
@@ -13,7 +13,11 @@ WebGpuProfiler::WebGpuProfiler(WebGpuContext& context) : context_{context} {}
 
 Status WebGpuProfiler::StartProfiling(TimePoint profiling_start_time) {
   enabled_ = true;
-  profiling_start_time_ = profiling_start_time;
+  // Push the ORT profiler's CPU time base into the context so GPU timestamps align
+  // with ORT CPU events. This is the only hook that receives the framework's
+  // profiling_start_time for both session-level and run-level profiling; for run-level
+  // profiling the WebGpuProfiler is a temporary that OnRunStart cannot reach directly.
+  context_.SetProfilingStartTime(profiling_start_time);
   return Status::OK();
 }
 

--- a/onnxruntime/core/providers/webgpu/webgpu_profiler.h
+++ b/onnxruntime/core/providers/webgpu/webgpu_profiler.h
@@ -22,6 +22,7 @@ class WebGpuProfiler final : public onnxruntime::profiling::EpProfiler {
   void Stop(uint64_t, const profiling::EventRecord&) override {
   }
   inline bool Enabled() const { return enabled_; }
+  inline TimePoint ProfilingStartTime() const { return profiling_start_time_; }
   // GPU events collected during session-level profiling.
   profiling::Events& GpuEvents() {
     is_session_level_ = true;
@@ -32,6 +33,7 @@ class WebGpuProfiler final : public onnxruntime::profiling::EpProfiler {
   WebGpuContext& context_;
   bool enabled_{false};
   bool is_session_level_{false};
+  TimePoint profiling_start_time_;
   profiling::Events gpu_events_;
 };
 

--- a/onnxruntime/core/providers/webgpu/webgpu_profiler.h
+++ b/onnxruntime/core/providers/webgpu/webgpu_profiler.h
@@ -22,7 +22,6 @@ class WebGpuProfiler final : public onnxruntime::profiling::EpProfiler {
   void Stop(uint64_t, const profiling::EventRecord&) override {
   }
   inline bool Enabled() const { return enabled_; }
-  inline TimePoint ProfilingStartTime() const { return profiling_start_time_; }
   // GPU events collected during session-level profiling.
   profiling::Events& GpuEvents() {
     is_session_level_ = true;
@@ -33,7 +32,6 @@ class WebGpuProfiler final : public onnxruntime::profiling::EpProfiler {
   WebGpuContext& context_;
   bool enabled_{false};
   bool is_session_level_{false};
-  TimePoint profiling_start_time_;
   profiling::Events gpu_events_;
 };
 


### PR DESCRIPTION
### Description
Add CPU time offset to WebGPU GPU profiling timestamps so they align with the ORT profiler's time base (microseconds since profiling start). Previously GPU events started from 0, causing misalignment in trace viewers.


### Motivation and Context
See above.

