### PR TITLE
Fix `ToOrtStatus` translation of `SYSTEM`-category `Status` error codes

### DIFF
--- a/include/onnxruntime/core/common/status.h
+++ b/include/onnxruntime/core/common/status.h
@@ -125,6 +125,13 @@ constexpr HRESULT StatusCodeToHRESULT(StatusCode status) noexcept {
 }
 #endif
 
+/**
+ * Maps an OS errno value (as carried by a SYSTEM-category Status) to the closest StatusCode.
+ * Translates SYSTEM-category statuses into ONNXRUNTIME-category codes (and OrtErrorCode at the C API boundary).
+ * Unrecognized values map to FAIL.
+ */
+StatusCode StatusCodeFromSystemErrno(int errno_value) noexcept;
+
 class [[nodiscard]] Status {
  public:
   Status() noexcept = default;

--- a/onnxruntime/core/common/status.cc
+++ b/onnxruntime/core/common/status.cc
@@ -12,10 +12,25 @@ limitations under the License.
 // Modifications Copyright (c) Microsoft.
 
 #include "core/common/status.h"
+
+#include <cerrno>
+
 #include "core/common/common.h"
 
 namespace onnxruntime {
 namespace common {
+
+StatusCode StatusCodeFromSystemErrno(int errno_value) noexcept {
+  switch (errno_value) {
+    case ENOENT:
+      return StatusCode::NO_SUCHFILE;
+    case EINVAL:
+      return StatusCode::INVALID_ARGUMENT;
+    default:
+      return StatusCode::FAIL;
+  }
+}
+
 Status::Status(StatusCategory category, int code, const std::string& msg) {
   // state_ will be allocated here causing the status to be treated as a failure
   ORT_ENFORCE(code != static_cast<int>(common::OK));
@@ -56,7 +71,7 @@ std::string Status::ToString() const {
   if (common::SYSTEM == state_->category) {
     result += "SystemError";
     result += " : ";
-    result += std::to_string(errno);
+    result += std::to_string(Code());
   } else if (common::ONNXRUNTIME == state_->category) {
     result += "[ONNXRuntimeError]";
     result += " : ";

--- a/onnxruntime/core/framework/error_code.cc
+++ b/onnxruntime/core/framework/error_code.cc
@@ -80,7 +80,28 @@ _Ret_notnull_ OrtStatus* ToOrtStatus(const Status& st) {
   OrtStatus* p = NewStatus(clen);
   if (p == nullptr)
     return nullptr;
-  p->code = static_cast<OrtErrorCode>(st.Code());
+
+  // Map the status' code to an OrtErrorCode based on its category.
+  // A SYSTEM-category status carries a raw OS errno (unrelated to the StatusCode/OrtErrorCode numbering), so it must
+  // be translated rather than cast directly.
+  // ONNXRUNTIME-category codes map 1:1 onto OrtErrorCode.
+  // NONE is only valid for an OK status, which was handled above.
+  common::StatusCode status_code;
+  switch (st.Category()) {
+    case common::SYSTEM:
+      status_code = common::StatusCodeFromSystemErrno(st.Code());
+      break;
+    case common::ONNXRUNTIME:
+      status_code = static_cast<common::StatusCode>(st.Code());
+      break;
+    default:
+      // Unexpected category. Don't throw across the C API boundary; fall back to a generic failure.
+      assert(false && "Unexpected StatusCategory in ToOrtStatus");
+      status_code = common::StatusCode::FAIL;
+      break;
+  }
+  p->code = static_cast<OrtErrorCode>(status_code);
+
   memcpy(p->msg, st.ErrorMessage().c_str(), clen);
   p->msg[clen] = '\0';
   return p;

--- a/onnxruntime/core/graph/model.cc
+++ b/onnxruntime/core/graph/model.cc
@@ -560,11 +560,11 @@ static Status LoadModelHelper(const T& file_path, Loader loader) {
   Status status = Env::Default().FileOpenRd(file_path, fd);
   if (!status.IsOK()) {
     if (status.Category() == common::SYSTEM) {
-      switch (status.Code()) {
-        case ENOENT:
+      switch (common::StatusCodeFromSystemErrno(status.Code())) {
+        case common::NO_SUCHFILE:
           return ORT_MAKE_STATUS(ONNXRUNTIME, NO_SUCHFILE, "Load model ", ToUTF8String(file_path),
                                  " failed. File doesn't exist");
-        case EINVAL:
+        case common::INVALID_ARGUMENT:
           return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Load model ", ToUTF8String(file_path), " failed");
         default:
           return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "system error number ", status.Code());

--- a/onnxruntime/core/providers/shared_library/provider_host_api.h
+++ b/onnxruntime/core/providers/shared_library/provider_host_api.h
@@ -42,7 +42,7 @@ struct Provider {
                                           const OrtSessionOptions& /*session_options*/,
                                           const OrtLogger& /*logger*/,
                                           std::unique_ptr<IExecutionProvider>& /*ep*/) {
-    return Status(common::StatusCategory::NONE, common::NOT_IMPLEMENTED,
+    return Status(common::StatusCategory::ONNXRUNTIME, common::NOT_IMPLEMENTED,
                   "CreateIExecutionProvider is not implemented for this provider");
   }
 

--- a/onnxruntime/test/common/status_test.cc
+++ b/onnxruntime/test/common/status_test.cc
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/common/status.h"
+
+#include <cerrno>
+#include <string>
+
+#include "gtest/gtest.h"
+
+namespace onnxruntime {
+namespace common {
+namespace test {
+
+// A SYSTEM-category status carries a raw OS errno, which must be mapped to the closest StatusCode.
+// Unrecognized values fall back to FAIL.
+TEST(StatusCodeFromSystemErrnoTest, KnownAndUnknownValues) {
+  EXPECT_EQ(StatusCodeFromSystemErrno(ENOENT), NO_SUCHFILE);
+  EXPECT_EQ(StatusCodeFromSystemErrno(EINVAL), INVALID_ARGUMENT);
+  EXPECT_EQ(StatusCodeFromSystemErrno(EACCES), FAIL);
+}
+
+// ToString() on a SYSTEM-category status must use the status' own stored code, not the live global errno.
+TEST(StatusTest, ToStringWithSystemCategoryUsesStoredCode) {
+  errno = EINVAL;  // Poison the global errno; ToString() must not read it.
+  const Status status(SYSTEM, ENOENT, "open file failed");
+  const std::string text = status.ToString();
+  EXPECT_NE(text.find(std::to_string(ENOENT)), std::string::npos);
+  EXPECT_EQ(text.find(std::to_string(EINVAL)), std::string::npos);
+}
+
+}  // namespace test
+}  // namespace common
+}  // namespace onnxruntime

--- a/onnxruntime/test/common/status_test.cc
+++ b/onnxruntime/test/common/status_test.cc
@@ -6,6 +6,7 @@
 #include <cerrno>
 #include <string>
 
+#include "gsl/gsl"
 #include "gtest/gtest.h"
 
 namespace onnxruntime {
@@ -22,11 +23,11 @@ TEST(StatusCodeFromSystemErrnoTest, KnownAndUnknownValues) {
 
 // ToString() on a SYSTEM-category status must use the status' own stored code, not the live global errno.
 TEST(StatusTest, ToStringWithSystemCategoryUsesStoredCode) {
+  const int saved_errno = errno;
+  auto restore_errno = gsl::finally([saved_errno]() { errno = saved_errno; });
   errno = EINVAL;  // Poison the global errno; ToString() must not read it.
   const Status status(SYSTEM, ENOENT, "open file failed");
-  const std::string text = status.ToString();
-  EXPECT_NE(text.find(std::to_string(ENOENT)), std::string::npos);
-  EXPECT_EQ(text.find(std::to_string(EINVAL)), std::string::npos);
+  EXPECT_EQ(status.ToString(), "SystemError : " + std::to_string(ENOENT));
 }
 
 }  // namespace test

--- a/onnxruntime/test/framework/error_code_test.cc
+++ b/onnxruntime/test/framework/error_code_test.cc
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/framework/error_code_helper.h"
+
+#include <cerrno>
+
+#include "gtest/gtest.h"
+
+#include "core/common/status.h"
+#include "core/session/onnxruntime_cxx_api.h"
+
+namespace onnxruntime {
+namespace test {
+
+namespace {
+// Builds an Ort::Status from the given onnxruntime::Status with onnxruntime::ToOrtStatus().
+Ort::Status AsOrtStatus(const Status& status) {
+  Ort::Status ort_status{ToOrtStatus(status)};
+  return ort_status;
+}
+}  // namespace
+
+// A SYSTEM-category status carries a raw OS errno that must be mapped to a meaningful OrtErrorCode
+// rather than being reinterpreted directly.
+TEST(ToOrtStatusTest, SystemCategoryErrnoIsMapped) {
+  EXPECT_EQ(AsOrtStatus(Status(common::SYSTEM, ENOENT, "no such file")).GetErrorCode(), ORT_NO_SUCHFILE);
+  EXPECT_EQ(AsOrtStatus(Status(common::SYSTEM, EINVAL, "invalid")).GetErrorCode(), ORT_INVALID_ARGUMENT);
+}
+
+// An unrecognized errno falls back to ORT_FAIL instead of producing a bogus / out-of-range code.
+TEST(ToOrtStatusTest, SystemCategoryUnknownErrnoFallsBackToFail) {
+  EXPECT_EQ(AsOrtStatus(Status(common::SYSTEM, EACCES, "permission denied")).GetErrorCode(), ORT_FAIL);
+}
+
+// ONNXRUNTIME-category codes map 1:1 onto OrtErrorCode and must be preserved.
+TEST(ToOrtStatusTest, OnnxRuntimeCategoryCodeIsPreserved) {
+  EXPECT_EQ(AsOrtStatus(Status(common::ONNXRUNTIME, common::NO_SUCHFILE, "missing")).GetErrorCode(), ORT_NO_SUCHFILE);
+  EXPECT_EQ(AsOrtStatus(Status(common::ONNXRUNTIME, common::INVALID_GRAPH, "bad graph")).GetErrorCode(),
+            ORT_INVALID_GRAPH);
+}
+
+// The error message must be carried through unchanged.
+TEST(ToOrtStatusTest, MessageIsPreserved) {
+  auto ort_status = AsOrtStatus(Status(common::SYSTEM, ENOENT, "open file failed"));
+  ASSERT_FALSE(ort_status.IsOK());
+  EXPECT_EQ(ort_status.GetErrorMessage(), "open file failed");
+}
+
+}  // namespace test
+}  // namespace onnxruntime


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Before this change, `ToOrtStatus` cast a `SYSTEM`-category `Status`' raw OS errno directly to `OrtErrorCode`, producing a meaningless (possibly out-of-range) code.

Add a shared `StatusCodeFromSystemErrno` mapper (`ENOENT`->`NO_SUCHFILE`, `EINVAL`->`INVALID_ARGUMENT`, else `FAIL`) and use it in `ToOrtStatus`, which now switches on category and asserts on unexpected values without throwing across the C API boundary.

Also fix `Status::ToString` to print the status' stored code for `SYSTEM` category instead of the live global `errno`, and refactor model.cc's `LoadModelHelper` to reuse the shared mapper while keeping its friendly messages.

Add unit tests for the mapper, `Status::ToString`, and `ToOrtStatus`.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Fix `OrtStatus` error code translation from an `onnxruntime::Status` with non-`ONNXRUNTIME` category.