### PR TITLE
[ORT] Extend reshape fusion

### DIFF
--- a/onnxruntime/core/optimizer/reshape_fusion.cc
+++ b/onnxruntime/core/optimizer/reshape_fusion.cc
@@ -132,17 +132,78 @@ static bool Match_Linear_Subgraph_1(Graph& graph, const Node& concat, const Node
   return true;
 }
 
-static bool Match_Shape(Graph& graph, const Node& concat, const Node& shape, const NodeArg& root_input, const logging::Logger& logger) {
+static bool Match_Shape(Graph& graph, const Node& concat, const Node& shape, const NodeArg& root_input,
+                        int64_t expected_gather_index, const logging::Logger& logger) {
   const NodeArg& shape_input = *(shape.InputDefs()[0]);
   if (shape_input.Name() == root_input.Name()) {
+    return true;
+  }
+
+  // Allow a narrow passthrough pattern: input -> GlobalAveragePool -> Reshape, where shape is taken from
+  // the pre-pool input and only batch dim (index 0) is gathered.
+  const Node* root_input_producer = graph.GetProducerNode(root_input.Name());
+  if (root_input_producer != nullptr && root_input_producer->OpType() == "GlobalAveragePool" &&
+      root_input_producer->InputDefs().size() > 0 && root_input_producer->InputDefs()[0] != nullptr &&
+      root_input_producer->InputDefs()[0]->Name() == shape_input.Name() && expected_gather_index == 0) {
     return true;
   }
 
   const ONNX_NAMESPACE::TensorShapeProto* shape_input_shape = shape_input.Shape();
   const ONNX_NAMESPACE::TensorShapeProto* root_input_shape = root_input.Shape();
 
-  if (shape_input_shape != nullptr && root_input_shape != nullptr)
-    return optimizer_utils::CompareShape(*shape_input_shape, *root_input_shape);
+  if (shape_input_shape != nullptr && root_input_shape != nullptr) {
+    // First try the existing static-value comparison.
+    if (optimizer_utils::CompareShape(*shape_input_shape, *root_input_shape)) {
+      return true;
+    }
+    // Also allow matching when both shapes have the same rank and each dimension
+    // is either equal by static value or by matching symbolic dim_param.
+    // This covers cases like position_ids [batch_size, sequence_length] taking
+    // shape from input_ids [batch_size, sequence_length] — same symbolic dims
+    // but no static values.
+    if (shape_input_shape->dim_size() == root_input_shape->dim_size() &&
+        shape_input_shape->dim_size() > 0) {
+      bool all_dims_match = true;
+      for (int i = 0; i < shape_input_shape->dim_size(); ++i) {
+        const auto& dim_a = shape_input_shape->dim(i);
+        const auto& dim_b = root_input_shape->dim(i);
+        if (utils::HasDimValue(dim_a) && utils::HasDimValue(dim_b)) {
+          if (dim_a.dim_value() != dim_b.dim_value()) {
+            all_dims_match = false;
+            break;
+          }
+        } else if (utils::HasDimParam(dim_a) && utils::HasDimParam(dim_b)) {
+          if (dim_a.dim_param() != dim_b.dim_param()) {
+            all_dims_match = false;
+            break;
+          }
+        } else {
+          // One has value, the other has param, or neither has anything — no match.
+          all_dims_match = false;
+          break;
+        }
+      }
+      if (all_dims_match) {
+        return true;
+      }
+    }
+  }
+
+  // Allow match when only the gathered dimension needs to agree.
+  // E.g., Shape extracts batch dim from a pre-projection tensor; that dim is
+  // identical to the batch dim of the post-projection tensor being reshaped.
+  if (shape_input_shape != nullptr && root_input_shape != nullptr &&
+      expected_gather_index < shape_input_shape->dim_size() &&
+      expected_gather_index < root_input_shape->dim_size()) {
+    const auto& dim_a = shape_input_shape->dim(static_cast<int>(expected_gather_index));
+    const auto& dim_b = root_input_shape->dim(static_cast<int>(expected_gather_index));
+    if ((utils::HasDimValue(dim_a) && utils::HasDimValue(dim_b) &&
+         dim_a.dim_value() == dim_b.dim_value()) ||
+        (utils::HasDimParam(dim_a) && utils::HasDimParam(dim_b) &&
+         dim_a.dim_param() == dim_b.dim_param())) {
+      return true;
+    }
+  }
 
   const Node* p_node_before_shape = graph_utils::GetInputNode(shape, 0);
   if (p_node_before_shape == nullptr) {
@@ -188,11 +249,12 @@ bool ReshapeFusion::Match_One_Element_Output_Subgraph_1(Graph& graph, const Node
       return true;
     }
 
-    if (!optimizer_utils::IsInitializerWithExpectedValue(graph, *(gather.InputDefs()[1]), int64_t(shape_value.size()), false)) {
+    const int64_t expected_gather_index = static_cast<int64_t>(shape_value.size());
+    if (!optimizer_utils::IsInitializerWithExpectedValue(graph, *(gather.InputDefs()[1]), expected_gather_index, false)) {
       return false;
     }
 
-    if (!Match_Shape(graph, concat, shape, root_input, logger)) {
+    if (!Match_Shape(graph, concat, shape, root_input, expected_gather_index, logger)) {
       return false;
     }
     return true;
@@ -340,19 +402,23 @@ index corresponding to the index of the argument, or a custom subgraph in which 
 have only one output edge. Note the resulting shape value should contain no more than one
 value of -1.
 
+The Shape node may feed from Sub-graph Root itself, or from a different tensor upstream
+as long as the gathered dimension matches (same static value or same symbolic dim_param)
+between the Shape source and Sub-graph Root.
+
 Before fusion:
-   [Sub-graph    Root]
-    |        /                  \
-    |    Shape                   Shape
-    |       |                      |
-    |    Gather(indices=0)  a[]   Gather(indices=2)  b[] or subgraph
-    |       \              /             /             /
-    |   Unsqueeze         /        Unsqueeze          /
-    |         \          /  ___________/             /
-    |          \        /  / _______________________/
-    |           \      /  / /
-     \            Concat
-      \          /
+   [Sub-graph Root]  [Ancestor of Root or Root itself]
+    |                       /                  \
+    |                   Shape                   Shape
+    |                      |                      |
+    |                   Gather(indices=0)  a[]   Gather(indices=2)  b[] or subgraph
+    |                      \              /             /             /
+    |                  Unsqueeze         /        Unsqueeze          /
+    |                        \          /  ___________/             /
+    |                         \        /  / _______________________/
+    |                          \      /  / /
+     \                           Concat
+      \                         /
          Reshape
 
 After fusion:

--- a/onnxruntime/core/providers/cpu/tensor/reshape_helper.h
+++ b/onnxruntime/core/providers/cpu/tensor/reshape_helper.h
@@ -21,6 +21,8 @@ class ReshapeHelper {
     auto nDims = requested_shape.size();
     ptrdiff_t unknown_dim = -1;
     int64_t size = 1;
+    int64_t size_for_inference = 1;
+    bool has_zero_dim = false;
     for (size_t i = 0; i < nDims; ++i) {
       ORT_ENFORCE(requested_shape[i] >= -1, "A dimension cannot be less than -1, got ", requested_shape[i]);
       if (requested_shape[i] == -1) {
@@ -39,6 +41,11 @@ class ReshapeHelper {
                     ", requested shape:", TensorShape(requested_shape));
         }
         size *= dim;
+        if (dim == 0) {
+          has_zero_dim = true;
+        } else {
+          size_for_inference *= dim;
+        }
       }
     }
 
@@ -46,10 +53,31 @@ class ReshapeHelper {
 
     if (unknown_dim != -1) {
       // calculate unknown dimension
-      ORT_ENFORCE(requested_shape_size != 0 && (input_shape_size % requested_shape_size) == 0,
-                  "The input tensor cannot be reshaped to the requested shape. Input shape:", input_shape,
-                  ", requested shape:", TensorShape(requested_shape));
-      requested_shape[unknown_dim] = input_shape_size / requested_shape_size;
+      if (has_zero_dim) {
+        ORT_ENFORCE(input_shape_size == 0,
+                    "The input tensor cannot be reshaped to the requested shape. Input shape:", input_shape,
+                    ", requested shape:", TensorShape(requested_shape));
+        ORT_ENFORCE(size_for_inference != 0,
+                    "The input tensor cannot be reshaped to the requested shape. Input shape:", input_shape,
+                    ", requested shape:", TensorShape(requested_shape));
+
+        int64_t input_shape_non_zero_size = 1;
+        for (size_t i = 0; i < input_shape.NumDimensions(); ++i) {
+          if (input_shape[i] != 0) {
+            input_shape_non_zero_size *= input_shape[i];
+          }
+        }
+
+        ORT_ENFORCE((input_shape_non_zero_size % size_for_inference) == 0,
+                    "The input tensor cannot be reshaped to the requested shape. Input shape:", input_shape,
+                    ", requested shape:", TensorShape(requested_shape));
+        requested_shape[unknown_dim] = input_shape_non_zero_size / size_for_inference;
+      } else {
+        ORT_ENFORCE(size != 0 && (input_shape_size % size) == 0,
+                    "The input tensor cannot be reshaped to the requested shape. Input shape:", input_shape,
+                    ", requested shape:", TensorShape(requested_shape));
+        requested_shape[unknown_dim] = input_shape_size / size;
+      }
     } else {
       // check if the output shape is valid.
       ORT_ENFORCE(input_shape_size == requested_shape_size,

--- a/onnxruntime/core/providers/cpu/tensor/reshape_helper.h
+++ b/onnxruntime/core/providers/cpu/tensor/reshape_helper.h
@@ -42,8 +42,12 @@ class ReshapeHelper {
         }
         size *= dim;
         if (dim == 0) {
-          has_zero_dim = true;
+          has_zero_dim = allow_zero;
         } else {
+          if (size_for_inference > (std::numeric_limits<int64_t>::max() / dim)) {
+            ORT_THROW("The requested shape has too many elements. Input shape:", input_shape,
+                      ", requested shape:", TensorShape(requested_shape));
+          }
           size_for_inference *= dim;
         }
       }
@@ -64,6 +68,10 @@ class ReshapeHelper {
         int64_t input_shape_non_zero_size = 1;
         for (size_t i = 0; i < input_shape.NumDimensions(); ++i) {
           if (input_shape[i] != 0) {
+            if (input_shape_non_zero_size > (std::numeric_limits<int64_t>::max() / input_shape[i])) {
+              ORT_THROW("The input shape has too many elements. Input shape:", input_shape,
+                        ", requested shape:", TensorShape(requested_shape));
+            }
             input_shape_non_zero_size *= input_shape[i];
           }
         }

--- a/onnxruntime/test/optimizer/graph_transform_test.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test.cc
@@ -8705,6 +8705,164 @@ TEST_F(GraphTransformationTests, ReshapeFusionOpsetTest) {
 }
 #endif
 
+// Test reshape fusion when Shape feeds from a tensor with the same symbolic dim_param names
+// as the reshape root (e.g., position_ids reshaped using Shape from input_ids in Qwen).
+TEST_F(GraphTransformationTests, ReshapeFusionDimParamMatch) {
+  auto build_test_case = [&](ModelTestBuilder& builder) {
+    // input_ids: [batch_size, sequence_length] — symbolic dims
+    auto* input_ids = builder.MakeSymbolicInput<float>({std::string("batch_size"), std::string("sequence_length")});
+    // position_ids: [batch_size, sequence_length] — same symbolic dims
+    auto* position_ids = builder.MakeSymbolicInput<float>({std::string("batch_size"), std::string("sequence_length")});
+
+    auto* shape_out = builder.MakeIntermediate();
+    auto* gather_out = builder.MakeIntermediate();
+    auto* unsqueeze_out = builder.MakeIntermediate();
+    auto* concat_out = builder.MakeIntermediate();
+    auto* out = builder.MakeOutput();
+
+    auto* scalar_int_0 = builder.MakeInitializer<int64_t>({}, {0});
+    auto* unsqueeze_axes = builder.MakeInitializer<int64_t>({1}, {0});
+    auto* const_neg1 = builder.MakeInitializer<int64_t>({1}, {-1});
+
+    // Shape(input_ids) -> Gather(0) -> Unsqueeze -> Concat([unsqueeze, -1]) -> Reshape(position_ids)
+    builder.AddNode("Shape", {input_ids}, {shape_out});
+    builder.AddNode("Gather", {shape_out, scalar_int_0}, {gather_out});
+    builder.AddNode("Unsqueeze", {gather_out, unsqueeze_axes}, {unsqueeze_out});
+    builder.AddNode("Concat", {unsqueeze_out, const_neg1}, {concat_out}).AddAttribute("axis", static_cast<int64_t>(0));
+    builder.AddNode("Reshape", {position_ids, concat_out}, {out});
+  };
+
+  auto pre_graph_checker = [&](Graph& graph) {
+    TEST_RETURN_IF_NOT(CountOpsInGraph(graph)["Shape"] == 1);
+    TEST_RETURN_IF_NOT(CountOpsInGraph(graph)["Gather"] == 1);
+    TEST_RETURN_IF_NOT(CountOpsInGraph(graph)["Unsqueeze"] == 1);
+    TEST_RETURN_IF_NOT(CountOpsInGraph(graph)["Concat"] == 1);
+    TEST_RETURN_IF_NOT(CountOpsInGraph(graph)["Reshape"] == 1);
+    return Status::OK();
+  };
+
+  auto post_graph_checker = [&](Graph& graph) {
+    TEST_RETURN_IF_NOT(CountOpsInGraph(graph)["Shape"] == 0);
+    TEST_RETURN_IF_NOT(CountOpsInGraph(graph)["Gather"] == 0);
+    TEST_RETURN_IF_NOT(CountOpsInGraph(graph)["Unsqueeze"] == 0);
+    TEST_RETURN_IF_NOT(CountOpsInGraph(graph)["Concat"] == 0);
+    TEST_RETURN_IF_NOT(CountOpsInGraph(graph)["Reshape"] == 1);
+    return Status::OK();
+  };
+
+  std::unique_ptr<GraphTransformer> transformer = std::make_unique<ReshapeFusion>();
+  ASSERT_STATUS_OK(TestGraphTransformer(build_test_case, 14, *logger_, std::move(transformer),
+                                        TransformerLevel::Level1, 1, pre_graph_checker, post_graph_checker));
+}
+
+// Test reshape fusion when Shape feeds from a different tensor than the reshape root,
+// but the gathered dimension matches by symbolic dim_param (moondream2 vision encoder pattern:
+// Shape from pre-projection tensor, Reshape on post-projection output).
+TEST_F(GraphTransformationTests, ReshapeFusionCrossTensorDimMatch) {
+  auto build_test_case = [&](ModelTestBuilder& builder) {
+    // pre_proj: [batch_size, seq_len, 768] — pre-projection (layernorm output)
+    auto* pre_proj = builder.MakeSymbolicInput<float>(
+        {std::string("batch_size"), std::string("seq_len"), int64_t(768)});
+    // post_proj: [batch_size, seq_len, 2304] — post-projection (qkv linear output, different last dim)
+    auto* post_proj = builder.MakeSymbolicInput<float>(
+        {std::string("batch_size"), std::string("seq_len"), int64_t(2304)});
+
+    auto* shape_out = builder.MakeIntermediate();
+    auto* gather_out = builder.MakeIntermediate();
+    auto* unsqueeze_out = builder.MakeIntermediate();
+    auto* concat_out = builder.MakeIntermediate();
+    auto* out = builder.MakeOutput();
+
+    auto* scalar_int_0 = builder.MakeInitializer<int64_t>({}, {0});
+    auto* unsqueeze_axes = builder.MakeInitializer<int64_t>({1}, {0});
+    auto* const_neg1 = builder.MakeInitializer<int64_t>({1}, {-1});
+    auto* const_3 = builder.MakeInitializer<int64_t>({1}, {3});
+    auto* const_256 = builder.MakeInitializer<int64_t>({1}, {256});
+
+    // Shape(pre_proj) -> Gather(0) -> Unsqueeze -> Concat([unsqueeze, -1, 3, 256]) -> Reshape(post_proj)
+    builder.AddNode("Shape", {pre_proj}, {shape_out});
+    builder.AddNode("Gather", {shape_out, scalar_int_0}, {gather_out});
+    builder.AddNode("Unsqueeze", {gather_out, unsqueeze_axes}, {unsqueeze_out});
+    builder.AddNode("Concat", {unsqueeze_out, const_neg1, const_3, const_256}, {concat_out})
+        .AddAttribute("axis", static_cast<int64_t>(0));
+    builder.AddNode("Reshape", {post_proj, concat_out}, {out});
+  };
+
+  auto pre_graph_checker = [&](Graph& graph) {
+    TEST_RETURN_IF_NOT(CountOpsInGraph(graph)["Shape"] == 1);
+    TEST_RETURN_IF_NOT(CountOpsInGraph(graph)["Gather"] == 1);
+    TEST_RETURN_IF_NOT(CountOpsInGraph(graph)["Unsqueeze"] == 1);
+    TEST_RETURN_IF_NOT(CountOpsInGraph(graph)["Concat"] == 1);
+    TEST_RETURN_IF_NOT(CountOpsInGraph(graph)["Reshape"] == 1);
+    return Status::OK();
+  };
+
+  auto post_graph_checker = [&](Graph& graph) {
+    TEST_RETURN_IF_NOT(CountOpsInGraph(graph)["Shape"] == 0);
+    TEST_RETURN_IF_NOT(CountOpsInGraph(graph)["Gather"] == 0);
+    TEST_RETURN_IF_NOT(CountOpsInGraph(graph)["Unsqueeze"] == 0);
+    TEST_RETURN_IF_NOT(CountOpsInGraph(graph)["Concat"] == 0);
+    TEST_RETURN_IF_NOT(CountOpsInGraph(graph)["Reshape"] == 1);
+    return Status::OK();
+  };
+
+  std::unique_ptr<GraphTransformer> transformer = std::make_unique<ReshapeFusion>();
+  ASSERT_STATUS_OK(TestGraphTransformer(build_test_case, 14, *logger_, std::move(transformer),
+                                        TransformerLevel::Level1, 1, pre_graph_checker, post_graph_checker));
+}
+
+// Test reshape fusion with GlobalAveragePool passthrough pattern (MobileNetV2):
+// Shape is taken from the pre-pool input, Reshape operates on the pool output,
+// and only batch dim (gather index 0) is extracted.
+TEST_F(GraphTransformationTests, ReshapeFusionGlobalAveragePoolPassthrough) {
+  auto build_test_case = [&](ModelTestBuilder& builder) {
+    auto* input = builder.MakeInput<float>({{1, 1280, 7, 7}});
+    auto* pool_out = builder.MakeIntermediate();
+    auto* shape_out = builder.MakeIntermediate();
+    auto* gather_out = builder.MakeIntermediate();
+    auto* unsqueeze_out = builder.MakeIntermediate();
+    auto* concat_out = builder.MakeIntermediate();
+    auto* out = builder.MakeOutput();
+
+    auto* scalar_int_0 = builder.MakeInitializer<int64_t>({}, {0});
+    auto* unsqueeze_axes = builder.MakeInitializer<int64_t>({1}, {0});
+    auto* const_neg1 = builder.MakeInitializer<int64_t>({1}, {-1});
+
+    // input -> GlobalAveragePool -> pool_out
+    builder.AddNode("GlobalAveragePool", {input}, {pool_out});
+    // Shape(input) -> Gather(0) -> Unsqueeze -> Concat([unsqueeze, -1]) -> Reshape(pool_out)
+    builder.AddNode("Shape", {input}, {shape_out});
+    builder.AddNode("Gather", {shape_out, scalar_int_0}, {gather_out});
+    builder.AddNode("Unsqueeze", {gather_out, unsqueeze_axes}, {unsqueeze_out});
+    builder.AddNode("Concat", {unsqueeze_out, const_neg1}, {concat_out}).AddAttribute("axis", static_cast<int64_t>(0));
+    builder.AddNode("Reshape", {pool_out, concat_out}, {out});
+  };
+
+  auto pre_graph_checker = [&](Graph& graph) {
+    TEST_RETURN_IF_NOT(CountOpsInGraph(graph)["GlobalAveragePool"] == 1);
+    TEST_RETURN_IF_NOT(CountOpsInGraph(graph)["Shape"] == 1);
+    TEST_RETURN_IF_NOT(CountOpsInGraph(graph)["Gather"] == 1);
+    TEST_RETURN_IF_NOT(CountOpsInGraph(graph)["Unsqueeze"] == 1);
+    TEST_RETURN_IF_NOT(CountOpsInGraph(graph)["Concat"] == 1);
+    TEST_RETURN_IF_NOT(CountOpsInGraph(graph)["Reshape"] == 1);
+    return Status::OK();
+  };
+
+  auto post_graph_checker = [&](Graph& graph) {
+    TEST_RETURN_IF_NOT(CountOpsInGraph(graph)["GlobalAveragePool"] == 1);
+    TEST_RETURN_IF_NOT(CountOpsInGraph(graph)["Shape"] == 0);
+    TEST_RETURN_IF_NOT(CountOpsInGraph(graph)["Gather"] == 0);
+    TEST_RETURN_IF_NOT(CountOpsInGraph(graph)["Unsqueeze"] == 0);
+    TEST_RETURN_IF_NOT(CountOpsInGraph(graph)["Concat"] == 0);
+    TEST_RETURN_IF_NOT(CountOpsInGraph(graph)["Reshape"] == 1);
+    return Status::OK();
+  };
+
+  std::unique_ptr<GraphTransformer> transformer = std::make_unique<ReshapeFusion>();
+  ASSERT_STATUS_OK(TestGraphTransformer(build_test_case, 14, *logger_, std::move(transformer),
+                                        TransformerLevel::Level1, 1, pre_graph_checker, post_graph_checker));
+}
+
 TEST_F(GraphTransformationTests, DynamicQuantizeMatMulTest) {
   constexpr const ORTCHAR_T* model_uri = MODEL_FOLDER "fusion/dynamic_quantize_matmul.onnx";
   std::shared_ptr<Model> p_model;

--- a/onnxruntime/test/providers/cpu/tensor/tensor_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/tensor_op_test.cc
@@ -174,6 +174,11 @@ TEST(TensorOpTest, Reshape_EmptyInputWithAllowZero) {
 // Test allowzero=1 with zero dim and unknown dim (-1): infer unknown from non-zero product.
 // Input: {2, 0, 3} (0 elements), shape: {0, -1} → output: {0, 6}
 TEST(TensorOpTest, Reshape_AllowZeroWithZeroDimAndUnknownDim) {
+  // TODO: Unskip when fixed #41968513
+  if (DefaultDmlExecutionProvider().get() != nullptr) {
+    GTEST_SKIP() << "Skipping because of the following error: MLOperatorAuthorImpl.cpp(2100): The parameter is incorrect.";
+  }
+
   OpTester test("Reshape", 14);
 
   test.AddInput<float>("data", {2, 0, 3}, std::vector<float>());
@@ -186,6 +191,11 @@ TEST(TensorOpTest, Reshape_AllowZeroWithZeroDimAndUnknownDim) {
 
 // Test allowzero=1 with zero dim and unknown dim: input {4, 0}, shape {0, 2, -1} → output {0, 2, 2}
 TEST(TensorOpTest, Reshape_AllowZeroWithZeroDimAndUnknownDim2) {
+  // TODO: Unskip when fixed #41968513
+  if (DefaultDmlExecutionProvider().get() != nullptr) {
+    GTEST_SKIP() << "Skipping because of the following error: MLOperatorAuthorImpl.cpp(2100): The parameter is incorrect.";
+  }
+
   OpTester test("Reshape", 14);
 
   test.AddInput<float>("data", {4, 0}, std::vector<float>());
@@ -199,6 +209,11 @@ TEST(TensorOpTest, Reshape_AllowZeroWithZeroDimAndUnknownDim2) {
 // Test allowzero=1 with zero dim, unknown dim, and multi-dim non-zero product.
 // Input: {3, 0, 5} (0 elements), shape: {0, -1} → non-zero product of input is 3*5=15, output: {0, 15}
 TEST(TensorOpTest, Reshape_AllowZeroWithZeroDimAndUnknownDimMultiDim) {
+  // TODO: Unskip when fixed #41968513
+  if (DefaultDmlExecutionProvider().get() != nullptr) {
+    GTEST_SKIP() << "Skipping because of the following error: MLOperatorAuthorImpl.cpp(2100): The parameter is incorrect.";
+  }
+
   OpTester test("Reshape", 14);
 
   test.AddInput<float>("data", {3, 0, 5}, std::vector<float>());

--- a/onnxruntime/test/providers/cpu/tensor/tensor_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/tensor_op_test.cc
@@ -171,6 +171,44 @@ TEST(TensorOpTest, Reshape_EmptyInputWithAllowZero) {
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
 }
 
+// Test allowzero=1 with zero dim and unknown dim (-1): infer unknown from non-zero product.
+// Input: {2, 0, 3} (0 elements), shape: {0, -1} → output: {0, 6}
+TEST(TensorOpTest, Reshape_AllowZeroWithZeroDimAndUnknownDim) {
+  OpTester test("Reshape", 14);
+
+  test.AddInput<float>("data", {2, 0, 3}, std::vector<float>());
+  test.AddInput<int64_t>("shape", {2}, {0, -1});
+  test.AddAttribute<int64_t>("allowzero", 1);
+  test.AddOutput<float>("reshaped", {0, 6}, std::vector<float>());
+  // TensorRT, QNN don't support empty dimension
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kQnnExecutionProvider});
+}
+
+// Test allowzero=1 with zero dim and unknown dim: input {4, 0}, shape {0, 2, -1} → output {0, 2, 2}
+TEST(TensorOpTest, Reshape_AllowZeroWithZeroDimAndUnknownDim2) {
+  OpTester test("Reshape", 14);
+
+  test.AddInput<float>("data", {4, 0}, std::vector<float>());
+  test.AddInput<int64_t>("shape", {3}, {0, 2, -1});
+  test.AddAttribute<int64_t>("allowzero", 1);
+  test.AddOutput<float>("reshaped", {0, 2, 2}, std::vector<float>());
+  // TensorRT, QNN don't support empty dimension
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kQnnExecutionProvider});
+}
+
+// Test allowzero=1 with zero dim, unknown dim, and multi-dim non-zero product.
+// Input: {3, 0, 5} (0 elements), shape: {0, -1} → non-zero product of input is 3*5=15, output: {0, 15}
+TEST(TensorOpTest, Reshape_AllowZeroWithZeroDimAndUnknownDimMultiDim) {
+  OpTester test("Reshape", 14);
+
+  test.AddInput<float>("data", {3, 0, 5}, std::vector<float>());
+  test.AddInput<int64_t>("shape", {2}, {0, -1});
+  test.AddAttribute<int64_t>("allowzero", 1);
+  test.AddOutput<float>("reshaped", {0, 15}, std::vector<float>());
+  // TensorRT, QNN don't support empty dimension
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kQnnExecutionProvider});
+}
+
 TEST(TensorOpTest, Reshape_UnknownDimWithoutAllowZero) {
   OpTester test("Reshape");
 


### PR DESCRIPTION
Enable reshape fusion for models with symbolic (dynamic) dimensions, covering patterns found in MobileNetV2, vision encoders, and SLMs.

Changes:
- Match_Shape: allow dimension matching by symbolic dim_param, not just  static values. Needed for SLMs (e.g. Qwen) where `position_ids` takes `Shape` from `input_ids` — same `dim_param` names, no static values.
- Match_Shape: allow matching when only the gathered dimension agrees between `Shape` source and reshape root. Needed for vision encoders (e.g. moondream2) where `Shape` is taken from pre-projection tensor but `Reshape` operates on post-projection output.
- Match_Shape: add `GlobalAveragePool` passthrough — accept `Shape` from pre-pool input when gathering batch dim. Needed for MobileNetV2.
- ReshapeHelper: handle zero-dim shapes (`allow_zero=true`) by computing unknown dim from non-zero dimension product only. Needed for MobileNetV2 reshape fusion output.
- Add corresponding unit tests.

