### PR TITLE
Fix WebGPU GatherBlockQuantized dispatch failure for empty indices

### DIFF
--- a/onnxruntime/contrib_ops/webgpu/quantization/gather_block_quantized.cc
+++ b/onnxruntime/contrib_ops/webgpu/quantization/gather_block_quantized.cc
@@ -260,6 +260,10 @@ Status GatherBlockQuantized::ComputeInternal(ComputeContext& context) const {
   int64_t output_size = output_shape.Size();
   auto* output_tensor = context.Output(0, output_shape);
 
+  if (output_size == 0) {
+    return Status::OK();
+  }
+
   // For the 2-bit zero-point path we need to address the packed byte using the scale row index
   // and the within-row quantize-axis index (not the flat scales offset, which crosses row
   // boundaries when scale_qaxis_dim isn't a multiple of the packing factor). To keep the shader

--- a/onnxruntime/test/contrib_ops/gather_block_quantized_op_test.cc
+++ b/onnxruntime/test/contrib_ops/gather_block_quantized_op_test.cc
@@ -759,6 +759,27 @@ TEST(GatherBlockQuantizedOpTest, WebGpu_GatherAxis0NoZeroPoints_2Bits_Uint8) {
                                                 /*block_size=*/16, /*bits=*/2, output, output_shape);
 }
 
+TEST(GatherBlockQuantizedOpTest, WebGpu_EmptyIndices_8Bits_Uint8) {
+  // An empty indices tensor produces an empty output. The kernel must not dispatch a
+  // (0, 1, 1) workgroup in that case. See issue #28772.
+  std::vector<uint8_t> data(2 * 16, 128);
+  std::vector<int64_t> data_shape = {2, 16};
+  std::vector<int32_t> indices = {};
+  std::vector<int64_t> indices_shape = {0};
+  std::vector<float> scales = {1.0f, 2.0f};
+  std::vector<int64_t> scales_shape = {2, 1};
+
+  std::vector<float> output = {};
+  std::vector<int64_t> output_shape = {0, 16};
+
+  std::vector<uint8_t> zero_points = {};
+  std::vector<int64_t> zero_points_shape = {};
+  RunGatherBlockQuantizedWebGpu<float, int32_t>(data, data_shape, indices, indices_shape, scales, scales_shape,
+                                                zero_points, zero_points_shape,
+                                                /*gather_axis=*/0, /*quantize_axis=*/1,
+                                                /*block_size=*/16, /*bits=*/8, output, output_shape);
+}
+
 TEST(GatherBlockQuantizedOpTest, WebGpu_InvalidIndices_2Bits_Uint8) {
   auto pack4 = [](int v0, int v1, int v2, int v3) -> uint8_t {
     auto enc = [](int v) { return static_cast<uint8_t>((v + 2) & 0x3); };


### PR DESCRIPTION
### Description
`GatherBlockQuantized` on WebGPU computes the dispatch size as `ceil(output_size / 64)`, which is 0 when the gather output is empty (e.g. an empty indices tensor), and `NormalizeDispatchGroupSize` rejects the (0, 1, 1) dispatch. Return early for an empty output instead, matching other WebGPU kernels.

Adds `GatherBlockQuantizedOpTest.WebGpu_EmptyIndices_8Bits_Uint8`.

### Motivation and Context
Fixes #28772.