### PR TITLE
[web] Fix use-after-free of model buffer with use_ort_model_bytes_for_initializers

### DIFF
--- a/js/web/lib/wasm/wasm-core-impl.ts
+++ b/js/web/lib/wasm/wasm-core-impl.ts
@@ -225,6 +225,10 @@ type IOBindingState = {
 
 /**
  *  tuple elements are: InferenceSession ID; inputNamesUTF8Encoded; outputNamesUTF8Encoded; bindingState
+ *
+ *  modelDataOffsetToFree is the WASM heap offset of the model data buffer that must be kept alive for the entire
+ *  session lifetime (e.g. when `use_ort_model_bytes_for_initializers` makes the initializer tensors point directly
+ *  into it) and freed in releaseSession(). It is 0 when the buffer was already freed right after createSession().
  */
 type SessionMetadata = [
   inferenceSessionId: number,
@@ -233,6 +237,7 @@ type SessionMetadata = [
   bindingState: IOBindingState | null,
   enableGraphCapture: boolean,
   inputOutputBound: boolean,
+  modelDataOffsetToFree: number,
 ];
 
 const activeSessions = new Map<number, SessionMetadata>();
@@ -348,6 +353,7 @@ export const createSession = async (
   let sessionOptionsHandle = 0;
   let ioBindingHandle = 0;
   let allocs: number[] = [];
+  let modelDataOffsetToFree = 0;
   const inputNamesUTF8Encoded = [];
   const outputNamesUTF8Encoded = [];
 
@@ -492,6 +498,13 @@ export const createSession = async (
       };
     }
 
+    if (
+      (options?.extra?.session as Record<string, unknown> | undefined)?.use_ort_model_bytes_for_initializers === '1'
+    ) {
+      // hand ownership of the model data buffer to the session; releaseSession() will free it.
+      modelDataOffsetToFree = modelDataOffset;
+    }
+
     activeSessions.set(sessionHandle, [
       sessionHandle,
       inputNamesUTF8Encoded,
@@ -499,6 +512,7 @@ export const createSession = async (
       bindingState,
       enableGraphCapture,
       false,
+      modelDataOffsetToFree,
     ]);
     return [sessionHandle, inputNames, outputNames, inputMetadata, outputMetadata];
   } catch (e) {
@@ -518,7 +532,10 @@ export const createSession = async (
     }
     throw e;
   } finally {
-    wasm._free(modelDataOffset);
+    // skip only when ownership was handed to the session above; the session frees it in releaseSession().
+    if (modelDataOffsetToFree === 0) {
+      wasm._free(modelDataOffset);
+    }
     if (sessionOptionsHandle !== 0) {
       if (wasm._OrtReleaseSessionOptions(sessionOptionsHandle) !== 0) {
         checkLastError("Can't release session options.");
@@ -537,7 +554,15 @@ export const releaseSession = (sessionId: number): void => {
   if (!session) {
     throw new Error(`cannot release session. invalid session id: ${sessionId}`);
   }
-  const [sessionHandle, inputNamesUTF8Encoded, outputNamesUTF8Encoded, ioBindingState, enableGraphCapture] = session;
+  const [
+    sessionHandle,
+    inputNamesUTF8Encoded,
+    outputNamesUTF8Encoded,
+    ioBindingState,
+    enableGraphCapture,
+    ,
+    modelDataOffsetToFree,
+  ] = session;
 
   if (ioBindingState) {
     if (enableGraphCapture) {
@@ -558,6 +583,10 @@ export const releaseSession = (sessionId: number): void => {
   outputNamesUTF8Encoded.forEach((buf) => wasm._OrtFree(buf));
   if (wasm._OrtReleaseSession(sessionHandle) !== 0) {
     checkLastError("Can't release session.");
+  }
+  // free the model data buffer that was kept alive for the session's in-place initializers, if any.
+  if (modelDataOffsetToFree !== 0) {
+    wasm._free(modelDataOffsetToFree);
   }
   activeSessions.delete(sessionId);
 };
@@ -715,6 +744,7 @@ export const run = async (
   const ioBindingState = session[3];
   const enableGraphCapture = session[4];
   const inputOutputBound = session[5];
+  const modelDataOffsetToFree = session[6];
 
   const inputCount = inputIndices.length;
   const outputCount = outputIndices.length;
@@ -825,6 +855,7 @@ export const run = async (
         ioBindingState,
         enableGraphCapture,
         true,
+        modelDataOffsetToFree,
       ]);
     }
 
@@ -1064,6 +1095,7 @@ export const run = async (
         ioBindingState,
         enableGraphCapture,
         false,
+        modelDataOffsetToFree,
       ]);
     }
     // Wait for all output tensor data to be downloaded.


### PR DESCRIPTION
### Description

Seeing inference result becomes garbage when optimizing memory footprints as suggested by https://onnxruntime.ai/docs/performance/model-optimizations/ort-format-models.html#load-ort-format-model-from-an-in-memory-byte-array.

```
      const opts: OrtSessionOptions = {
        executionProviders: ['wasm'],
        extra: {
          session: {
            use_ort_model_bytes_directly: '1',
            use_ort_model_bytes_for_initializers: '1',
            disable_prepacking: '1',
          },
        },
      }
```

The root cause is that `createSession()` copies the model data into a WASM heap buffer (`modelDataOffset`) and unconditionally `_free()`s it in its `finally` block, right after the session is built. That is safe by default, where ORT copies every weight initializer into separate session-owned memory.

But when `session.use_ort_model_bytes_for_initializers` is set, the initializer tensors point *directly* into that buffer instead of being copied, so freeing it after creation is a use-after-free: later allocations overwrite the weights and inference produces garbage.

This PR makes the buffer a per-session resource, freed alongside the input/ output name buffers that `releaseSession()` already cleans up:

- `SessionMetadata` gains a `modelDataOffsetToFree` field (0 when there is nothing to defer).
- When the option is set, `createSession()` stores `modelDataOffset` in that field and the `finally` skips the free; the error path leaves the field 0 so the buffer is still freed and never leaks.
- `releaseSession()` frees the stored offset after `_OrtReleaseSession()`.
- The two `activeSessions.set()` rebuilds in `run()` preserve the field so it survives IO-binding updates.

Default sessions (no option) are unaffected: the buffer is still freed immediately in `createSession()`.

### Motivation and Context
Fixes #19491. `use_ort_model_bytes_for_initializers` avoids a full second copy of the weights in the WASM heap (measured ~halved steady memory for an int4 model), but is unusable on web until the buffer outlives session creation. Web is the only platform that both allocates and frees this buffer internally; native APIs leave ownership with the caller, who keeps it alive for the session lifetime.

Verified manually in a browser: with the option set, inference now produces correct output and steady WASM memory drops as expected, and sessions create/run/release without crashing.
