### PR TITLE
Add INT4 per-channel MoE GEMV fast path for batch-1 decode (GPT-OSS-20B)

### DIFF
--- a/docs/contrib_ops/cuda/moe_qmoe.md
+++ b/docs/contrib_ops/cuda/moe_qmoe.md
@@ -182,7 +182,7 @@ under [onnxruntime/contrib_ops/cuda/llm/moe_gemm/](onnxruntime/contrib_ops/cuda/
 
 | Path | CUTLASS class | Used for | SM range |
 |------|---------------|----------|----------|
-| **MoE GEMV fast path** | `fpA_intB_gemv`-based custom kernel | INT4 per-channel W4A16 with FP16/BF16 activations and small expanded row counts | SM80+ |
+| **MoE GEMV fast path** | `fpA_intB_gemv`-based custom kernel | INT4 per-channel W4A16 with FP16 activations and true decode row counts | SM80+ |
 | **Ampere GemmGrouped** | `cutlass::gemm::kernel::GemmGrouped` | INT4/INT8 W*A16, FP8 W8A16 dequant fallback, FP32 | SM75–SM89, plus all mixed-input on SM90/SM120 |
 | **TMA Warp-Specialized (mixed-input)** | `CollectiveBuilderMixedInput` | Same-type FP16×FP16 / BF16×BF16, native MXFP4 W4A16 | SM90 (same-type), SM120 (FP4 W4A16) |
 | **Block-Scaled Tensor Op** | `OpClassBlockScaledTensorOp` | Native FP8×MXFP4 (`wfp4afp8`) | SM100+ (Blackwell) |
@@ -190,12 +190,16 @@ under [onnxruntime/contrib_ops/cuda/llm/moe_gemm/](onnxruntime/contrib_ops/cuda/
 The MoE GEMV fast path is selected before the Ampere grouped GEMM for INT4
 per-channel QMoE when all of the following are true:
 
-- activation/output dtype is FP16 or BF16;
+- activation/output dtype is FP16;
 - weights are INT4 and scales/biases use the same dtype as the activation;
 - `block_size <= 0` (per-output-channel scales, no group-wise scales or zero-points);
-- `expanded_num_rows = num_tokens * top_k` is in `(0, 64]`;
+- `expanded_num_rows = num_tokens * top_k` is in `(0, 2]`;
+- `N >= 1024` and `K >= 1024`;
 - `N` is divisible by 32 for the INT4 column-interleaved tile, and `K` satisfies
   the kernel step alignment.
+
+BF16 and broader row-count coverage currently stay on grouped GEMM until profile
+data shows an end-to-end GEMV win.
 
 Set `ORT_DISABLE_MOE_GEMV=1` before process start to force the grouped GEMM
 fallback for debugging, benchmarking, or bisecting numerical differences. The
@@ -853,7 +857,7 @@ follow-up work in the order below so each step has an isolated benchmark signal.
 |----------|-----------|------------------|----------------------|------------|
 | P0 | Establish a benchmark baseline | Prevent regressions and tune cutoffs with data | Add a focused microbenchmark or perf-test mode that sweeps `num_tokens`, `top_k`, `hidden_size`, `inter_size`, dtype, and SM. Always run with GEMV on and with `ORT_DISABLE_MOE_GEMV=1`. | Report latency and speedup for SM80/SM89/SM90/SM100/SM120 where available; keep QMoE parity tests green. |
 | P1 | Avoid repeated row-to-expert scans | Reduces per-block overhead, especially when `N` has many tiles | Either materialize `permuted_row_to_expert` during the prologue or launch GEMV by expert ranges so each block already knows its expert. Keep the existing prefix-offset scan as fallback until the new map is available for all prologue paths. | Compare kernel time for `expanded_num_rows` in `{1, 2, 4, 8, 16, 32, 64}` and `N` in typical FC1/FC2 sizes. |
-| P1 | Tune tile shapes and dispatch threshold | Better occupancy/throughput across model dimensions | Benchmark `CtaN`, thread count, and max `expanded_num_rows` alternatives. The current cutoff (`<=64`) should become data-driven per architecture or at least per broad SM family. | GEMV should win over grouped GEMM at the selected threshold for both FC1 and FC2 shapes. |
+| P1 | Tune tile shapes and dispatch threshold | Better occupancy/throughput across model dimensions | Benchmark `CtaN`, thread count, and max `expanded_num_rows` alternatives. The current conservative cutoff (`expanded_num_rows <= 2`, FP16, `N/K >= 1024`) should stay data-driven per architecture or at least per broad SM family. | GEMV should win over grouped GEMM at the selected threshold for both FC1 and FC2 shapes. |
 | P2 | Fuse FC1 gated activation for SwiGLU | Saves one global write/read of the FC1 intermediate and one activation launch | Add a gated GEMV epilogue for `swiglu_fusion=1/2` that writes post-gated `[expanded_rows, inter_size]`. Preserve the existing unfused activation path for non-SwiGLU and unsupported parameter combinations. | Add targeted interleaved and block SwiGLU INT4 per-channel decode tests; benchmark FC1 end-to-end latency. |
 | P2 | Fuse FC2 finalize/scatter for decode | Reduces FC2 output traffic and launch overhead | Add an FC2 GEMV variant that applies routing weights and accumulates directly into final output for small rows. This likely needs access to `permuted_row_to_unpermuted_row` and `token_topk_unpermuted_scales`. | Compare full MoE latency, not just GEMV kernel time, because finalize launch removal is the main benefit. |
 | P3 | Broaden dtype/quant coverage only if profitable | Avoids extra maintenance for rarely faster paths | Evaluate INT8 per-channel and selected group-wise INT4 cases after the INT4 per-channel path is tuned. Group-wise support needs scale loads indexed by K group and zero-point handling, so it should be justified by benchmark data. | Require parity coverage for each new mode and benchmark wins over grouped GEMM. |
@@ -861,6 +865,31 @@ follow-up work in the order below so each step has an isolated benchmark signal.
 Keep the debug switch (`ORT_DISABLE_MOE_GEMV`) until all planned fast paths have
 independent coverage and benchmark data. It is useful for A/B testing, fallback
 validation, and bisecting numerical or performance regressions.
+
+The initial P0 profiling hook is
+[profile_qmoe_gemv.sh](../../../onnxruntime/test/python/transformers/profile_qmoe_gemv.sh).
+It profiles GEMV and the grouped-GEMM fallback in separate sequential `nsys`
+runs, which avoids overlapping Python workers on the same GPU and keeps the
+cached `ORT_DISABLE_MOE_GEMV` value fixed before the CUDA kernel path is first
+used:
+
+```bash
+onnxruntime/test/python/transformers/profile_qmoe_gemv.sh \
+  --case m1_top2_fp16_128x256 --warmup 5 --repeat 100
+```
+
+For model-size sweeps, pass explicit shape arguments such as
+`--hidden-size 1024 --intermediate-size 4096 --num-experts 8 --top-k 2`.
+Use `--list-cases` to show named benchmark cases, including FP16 model-size
+decode cases for GPT-OSS-20B, Qwen3.6-35B-A3B (shared expert ignored), and
+Gemma-4-26B-A4B.
+
+Record comparable profile runs in [qmoe_gemv_exp.md](qmoe_gemv_exp.md).
+
+For a quick smoke run without `nsys`, set `ORT_QMOE_GEMV_BENCHMARK=1` and run
+`TestQMoEGemvBenchmark` directly. Select one case with
+`ORT_QMOE_GEMV_BENCHMARK_CASE=<case-name>` and compare fallback mode by running
+again with `ORT_DISABLE_MOE_GEMV=1`.
 
 ---
 

--- a/docs/contrib_ops/cuda/moe_qmoe.md
+++ b/docs/contrib_ops/cuda/moe_qmoe.md
@@ -871,6 +871,14 @@ fallback when the map is unavailable. Initial SM90 actual-model profiles are
 recorded in [qmoe_gemv_exp.md](qmoe_gemv_exp.md). Follow-up P1 tile probes
 kept the existing `CtaN=8, Threads=128` shape after `CtaN=16`, `Threads=64`,
 and a map-specialized launch all failed to improve the measured GEMV kernels.
+The first fusion experiment, FC1 interleaved SwiGLU inside the INT4 per-channel
+GEMV epilogue, is implemented for the profiled FP16 path. It supports
+`swiglu_fusion == 1` with scalar or per-expert alpha/beta/limit parameters and
+falls back to the unfused GEMV-plus-activation path for unsupported dtype,
+quantization, or activation modes. On SM90 actual-model profiles it improved
+GPT-OSS-20B from `0.0721` ms to `0.0681` ms and Gemma-4-26B-A4B from `0.0610`
+ms to `0.0580` ms; Qwen3.6-35B-A3B remains routed to grouped GEMM by the
+current 512-wide intermediate-size guard.
 
 Keep the debug switch (`ORT_DISABLE_MOE_GEMV`) until all planned fast paths have
 independent coverage and benchmark data. It is useful for A/B testing, fallback

--- a/docs/contrib_ops/cuda/moe_qmoe.md
+++ b/docs/contrib_ops/cuda/moe_qmoe.md
@@ -864,6 +864,12 @@ follow-up work in the order below so each step has an isolated benchmark signal.
 | P2 | Fuse FC2 finalize/scatter for decode | Reduces FC2 output traffic and launch overhead | Add an FC2 GEMV variant that applies routing weights and accumulates directly into final output for small rows. This likely needs access to `permuted_row_to_unpermuted_row` and `token_topk_unpermuted_scales`. | Compare full MoE latency, not just GEMV kernel time, because finalize launch removal is the main benefit. |
 | P3 | Broaden dtype/quant coverage only if profitable | Avoids extra maintenance for rarely faster paths | Evaluate INT8 per-channel and selected group-wise INT4 cases after the INT4 per-channel path is tuned. Group-wise support needs scale loads indexed by K group and zero-point handling, so it should be justified by benchmark data. | Require parity coverage for each new mode and benchmark wins over grouped GEMM. |
 
+Status: the P1 row-to-expert scan item is implemented by materializing the local
+expert id in `permuted_token_selected_experts` during both prologue paths and
+passing that map to the GEMV kernels. GEMV keeps the prefix-offset scan as a
+fallback when the map is unavailable. Initial SM90 actual-model profiles are
+recorded in [qmoe_gemv_exp.md](qmoe_gemv_exp.md).
+
 Keep the debug switch (`ORT_DISABLE_MOE_GEMV`) until all planned fast paths have
 independent coverage and benchmark data. It is useful for A/B testing, fallback
 validation, and bisecting numerical or performance regressions.

--- a/docs/contrib_ops/cuda/moe_qmoe.md
+++ b/docs/contrib_ops/cuda/moe_qmoe.md
@@ -24,6 +24,7 @@ and have been significantly modified for ONNX Runtime — see
 10. [FP8 (W8A16) Details](#10-fp8-w8a16-details)
 11. [WFP4AFP8 Details](#11-wfp4afp8-details)
 12. [Future / Deferred Modes](#12-future--deferred-modes)
+  - [12.1 MoE GEMV Improvement Plan](#121-moe-gemv-improvement-plan)
 13. [Testing](#13-testing)
 14. [Build Configuration](#14-build-configuration)
 15. [Limitations & Known Issues](#15-limitations--known-issues)
@@ -174,15 +175,31 @@ values that require them are rejected at construction time:
 
 ## 4. Architecture Dispatch & Kernel Paths
 
-The runner selects between three CUTLASS kernel families at runtime. The choice is
+The runner selects between three CUTLASS kernel families and one small-row GEMV
+fast path at runtime. The choice is
 made by `CutlassMoeFCRunner::supportsTmaWarpSpecialized()` and the dispatch headers
 under [onnxruntime/contrib_ops/cuda/llm/moe_gemm/](onnxruntime/contrib_ops/cuda/llm/moe_gemm/).
 
 | Path | CUTLASS class | Used for | SM range |
 |------|---------------|----------|----------|
+| **MoE GEMV fast path** | `fpA_intB_gemv`-based custom kernel | INT4 per-channel W4A16 with FP16/BF16 activations and small expanded row counts | SM80+ |
 | **Ampere GemmGrouped** | `cutlass::gemm::kernel::GemmGrouped` | INT4/INT8 W*A16, FP8 W8A16 dequant fallback, FP32 | SM75–SM89, plus all mixed-input on SM90/SM120 |
 | **TMA Warp-Specialized (mixed-input)** | `CollectiveBuilderMixedInput` | Same-type FP16×FP16 / BF16×BF16, native MXFP4 W4A16 | SM90 (same-type), SM120 (FP4 W4A16) |
 | **Block-Scaled Tensor Op** | `OpClassBlockScaledTensorOp` | Native FP8×MXFP4 (`wfp4afp8`) | SM100+ (Blackwell) |
+
+The MoE GEMV fast path is selected before the Ampere grouped GEMM for INT4
+per-channel QMoE when all of the following are true:
+
+- activation/output dtype is FP16 or BF16;
+- weights are INT4 and scales/biases use the same dtype as the activation;
+- `block_size <= 0` (per-output-channel scales, no group-wise scales or zero-points);
+- `expanded_num_rows = num_tokens * top_k` is in `(0, 64]`;
+- `N` is divisible by 32 for the INT4 column-interleaved tile, and `K` satisfies
+  the kernel step alignment.
+
+Set `ORT_DISABLE_MOE_GEMV=1` before process start to force the grouped GEMM
+fallback for debugging, benchmarking, or bisecting numerical differences. The
+switch is cached on first use.
 
 ### 4.1 Per-mode dispatch matrix
 
@@ -288,6 +305,10 @@ INT4 packing layout within a byte: `[high_nibble | low_nibble] = [elt_1 | elt_0]
 Each INT4 element is in `[-8, 7]` (signed) before bias, `[0, 15]` after the +8 bias.
 
 #### Preprocessing pipeline (offline, `pack_weights_for_cuda_mixed_gemm`)
+
+INT MoE/QMoE CUDA kernels, including the small-row MoE GEMV path, consume the
+SM80 `ColumnMajorTileInterleave<64, 4>` layout. Pack INT4/INT8 MoE weights with
+the SM80 target layout even when the runtime GPU is Hopper or newer.
 
 1. **Input layout**: `[N, K]` per expert (Out × In), 2 elements per byte for INT4.
 2. **Transpose & signed conversion**:
@@ -821,6 +842,25 @@ software dequant of the mixed-input path.
 
 The schema reserves the necessary input slots (18–21) so adding these modes
 will not change the operator interface.
+
+### 12.1 MoE GEMV Improvement Plan
+
+The INT4 per-channel MoE GEMV path targets decode-sized workloads where launch
+overhead and global-memory traffic dominate grouped GEMM efficiency. Track
+follow-up work in the order below so each step has an isolated benchmark signal.
+
+| Priority | Work item | Expected benefit | Implementation notes | Validation |
+|----------|-----------|------------------|----------------------|------------|
+| P0 | Establish a benchmark baseline | Prevent regressions and tune cutoffs with data | Add a focused microbenchmark or perf-test mode that sweeps `num_tokens`, `top_k`, `hidden_size`, `inter_size`, dtype, and SM. Always run with GEMV on and with `ORT_DISABLE_MOE_GEMV=1`. | Report latency and speedup for SM80/SM89/SM90/SM100/SM120 where available; keep QMoE parity tests green. |
+| P1 | Avoid repeated row-to-expert scans | Reduces per-block overhead, especially when `N` has many tiles | Either materialize `permuted_row_to_expert` during the prologue or launch GEMV by expert ranges so each block already knows its expert. Keep the existing prefix-offset scan as fallback until the new map is available for all prologue paths. | Compare kernel time for `expanded_num_rows` in `{1, 2, 4, 8, 16, 32, 64}` and `N` in typical FC1/FC2 sizes. |
+| P1 | Tune tile shapes and dispatch threshold | Better occupancy/throughput across model dimensions | Benchmark `CtaN`, thread count, and max `expanded_num_rows` alternatives. The current cutoff (`<=64`) should become data-driven per architecture or at least per broad SM family. | GEMV should win over grouped GEMM at the selected threshold for both FC1 and FC2 shapes. |
+| P2 | Fuse FC1 gated activation for SwiGLU | Saves one global write/read of the FC1 intermediate and one activation launch | Add a gated GEMV epilogue for `swiglu_fusion=1/2` that writes post-gated `[expanded_rows, inter_size]`. Preserve the existing unfused activation path for non-SwiGLU and unsupported parameter combinations. | Add targeted interleaved and block SwiGLU INT4 per-channel decode tests; benchmark FC1 end-to-end latency. |
+| P2 | Fuse FC2 finalize/scatter for decode | Reduces FC2 output traffic and launch overhead | Add an FC2 GEMV variant that applies routing weights and accumulates directly into final output for small rows. This likely needs access to `permuted_row_to_unpermuted_row` and `token_topk_unpermuted_scales`. | Compare full MoE latency, not just GEMV kernel time, because finalize launch removal is the main benefit. |
+| P3 | Broaden dtype/quant coverage only if profitable | Avoids extra maintenance for rarely faster paths | Evaluate INT8 per-channel and selected group-wise INT4 cases after the INT4 per-channel path is tuned. Group-wise support needs scale loads indexed by K group and zero-point handling, so it should be justified by benchmark data. | Require parity coverage for each new mode and benchmark wins over grouped GEMM. |
+
+Keep the debug switch (`ORT_DISABLE_MOE_GEMV`) until all planned fast paths have
+independent coverage and benchmark data. It is useful for A/B testing, fallback
+validation, and bisecting numerical or performance regressions.
 
 ---
 

--- a/docs/contrib_ops/cuda/moe_qmoe.md
+++ b/docs/contrib_ops/cuda/moe_qmoe.md
@@ -882,10 +882,12 @@ current 512-wide intermediate-size guard.
 For GPT-OSS-20B, a naive FC2 GEMV-plus-finalize fused kernel was rejected after
 profiling because it serialized the four top-k expert GEMVs inside each CTA.
 A smaller one-row finalize specialization is kept for `num_rows == 1` and
-`top_k <= 4`; it preserves the existing FC2 GEMV parallelism and only caches the
-one-token routing metadata in shared memory. The measured benefit is kernel-local
-and modest, so the next substantial GPT-OSS opportunity is likely a different
-FC2 design that preserves top-k parallelism while reducing finalize traffic.
+`top_k <= 4`; it preserves the existing FC2 GEMV parallelism, caches the
+one-token routing metadata in shared memory, and dispatches exact top-k
+specializations so GPT-OSS top-k 4 is compile-time unrolled. The measured
+benefit is still modest, so the next substantial GPT-OSS opportunity is likely a
+different FC2 design that preserves top-k parallelism while reducing finalize
+traffic.
 
 Keep the debug switch (`ORT_DISABLE_MOE_GEMV`) until all planned fast paths have
 independent coverage and benchmark data. It is useful for A/B testing, fallback

--- a/docs/contrib_ops/cuda/moe_qmoe.md
+++ b/docs/contrib_ops/cuda/moe_qmoe.md
@@ -879,6 +879,13 @@ quantization, or activation modes. On SM90 actual-model profiles it improved
 GPT-OSS-20B from `0.0721` ms to `0.0681` ms and Gemma-4-26B-A4B from `0.0610`
 ms to `0.0580` ms; Qwen3.6-35B-A3B remains routed to grouped GEMM by the
 current 512-wide intermediate-size guard.
+For GPT-OSS-20B, a naive FC2 GEMV-plus-finalize fused kernel was rejected after
+profiling because it serialized the four top-k expert GEMVs inside each CTA.
+A smaller one-row finalize specialization is kept for `num_rows == 1` and
+`top_k <= 4`; it preserves the existing FC2 GEMV parallelism and only caches the
+one-token routing metadata in shared memory. The measured benefit is kernel-local
+and modest, so the next substantial GPT-OSS opportunity is likely a different
+FC2 design that preserves top-k parallelism while reducing finalize traffic.
 
 Keep the debug switch (`ORT_DISABLE_MOE_GEMV`) until all planned fast paths have
 independent coverage and benchmark data. It is useful for A/B testing, fallback

--- a/docs/contrib_ops/cuda/moe_qmoe.md
+++ b/docs/contrib_ops/cuda/moe_qmoe.md
@@ -868,7 +868,9 @@ Status: the P1 row-to-expert scan item is implemented by materializing the local
 expert id in `permuted_token_selected_experts` during both prologue paths and
 passing that map to the GEMV kernels. GEMV keeps the prefix-offset scan as a
 fallback when the map is unavailable. Initial SM90 actual-model profiles are
-recorded in [qmoe_gemv_exp.md](qmoe_gemv_exp.md).
+recorded in [qmoe_gemv_exp.md](qmoe_gemv_exp.md). Follow-up P1 tile probes
+kept the existing `CtaN=8, Threads=128` shape after `CtaN=16`, `Threads=64`,
+and a map-specialized launch all failed to improve the measured GEMV kernels.
 
 Keep the debug switch (`ORT_DISABLE_MOE_GEMV`) until all planned fast paths have
 independent coverage and benchmark data. It is useful for A/B testing, fallback

--- a/docs/contrib_ops/cuda/moe_qmoe.md
+++ b/docs/contrib_ops/cuda/moe_qmoe.md
@@ -193,13 +193,15 @@ per-channel QMoE when all of the following are true:
 - activation/output dtype is FP16;
 - weights are INT4 and scales/biases use the same dtype as the activation;
 - `block_size <= 0` (per-output-channel scales, no group-wise scales or zero-points);
-- `expanded_num_rows = num_tokens * top_k` is in `(0, 2]`;
-- `N >= 1024` and `K >= 1024`;
+- `expanded_num_rows = num_tokens * top_k` is in `(0, 8]`;
+- `N >= 512` and `K >= 512`;
+- if `expanded_num_rows > 4`, the logical MoE intermediate size is at least 704
+  and the GEMV call dimensions satisfy `N >= 704` and `K >= 704`;
 - `N` is divisible by 32 for the INT4 column-interleaved tile, and `K` satisfies
   the kernel step alignment.
 
-BF16 and broader row-count coverage currently stay on grouped GEMM until profile
-data shows an end-to-end GEMV win.
+BF16 and broader row-count or smaller-dimension coverage currently stay on
+grouped GEMM until profile data shows an end-to-end GEMV win.
 
 Set `ORT_DISABLE_MOE_GEMV=1` before process start to force the grouped GEMM
 fallback for debugging, benchmarking, or bisecting numerical differences. The
@@ -857,7 +859,7 @@ follow-up work in the order below so each step has an isolated benchmark signal.
 |----------|-----------|------------------|----------------------|------------|
 | P0 | Establish a benchmark baseline | Prevent regressions and tune cutoffs with data | Add a focused microbenchmark or perf-test mode that sweeps `num_tokens`, `top_k`, `hidden_size`, `inter_size`, dtype, and SM. Always run with GEMV on and with `ORT_DISABLE_MOE_GEMV=1`. | Report latency and speedup for SM80/SM89/SM90/SM100/SM120 where available; keep QMoE parity tests green. |
 | P1 | Avoid repeated row-to-expert scans | Reduces per-block overhead, especially when `N` has many tiles | Either materialize `permuted_row_to_expert` during the prologue or launch GEMV by expert ranges so each block already knows its expert. Keep the existing prefix-offset scan as fallback until the new map is available for all prologue paths. | Compare kernel time for `expanded_num_rows` in `{1, 2, 4, 8, 16, 32, 64}` and `N` in typical FC1/FC2 sizes. |
-| P1 | Tune tile shapes and dispatch threshold | Better occupancy/throughput across model dimensions | Benchmark `CtaN`, thread count, and max `expanded_num_rows` alternatives. The current conservative cutoff (`expanded_num_rows <= 2`, FP16, `N/K >= 1024`) should stay data-driven per architecture or at least per broad SM family. | GEMV should win over grouped GEMM at the selected threshold for both FC1 and FC2 shapes. |
+| P1 | Tune tile shapes and dispatch threshold | Better occupancy/throughput across model dimensions | Benchmark `CtaN`, thread count, and max `expanded_num_rows` alternatives. The current model-profiled cutoff (`expanded_num_rows <= 8`, FP16, `N/K >= 512`, and logical intermediate size plus GEMV call dimensions at least 704 when `expanded_num_rows > 4`) should stay data-driven per architecture or at least per broad SM family. | GEMV should win over grouped GEMM at the selected threshold for both FC1 and FC2 shapes. |
 | P2 | Fuse FC1 gated activation for SwiGLU | Saves one global write/read of the FC1 intermediate and one activation launch | Add a gated GEMV epilogue for `swiglu_fusion=1/2` that writes post-gated `[expanded_rows, inter_size]`. Preserve the existing unfused activation path for non-SwiGLU and unsupported parameter combinations. | Add targeted interleaved and block SwiGLU INT4 per-channel decode tests; benchmark FC1 end-to-end latency. |
 | P2 | Fuse FC2 finalize/scatter for decode | Reduces FC2 output traffic and launch overhead | Add an FC2 GEMV variant that applies routing weights and accumulates directly into final output for small rows. This likely needs access to `permuted_row_to_unpermuted_row` and `token_topk_unpermuted_scales`. | Compare full MoE latency, not just GEMV kernel time, because finalize launch removal is the main benefit. |
 | P3 | Broaden dtype/quant coverage only if profitable | Avoids extra maintenance for rarely faster paths | Evaluate INT8 per-channel and selected group-wise INT4 cases after the INT4 per-channel path is tuned. Group-wise support needs scale loads indexed by K group and zero-point handling, so it should be justified by benchmark data. | Require parity coverage for each new mode and benchmark wins over grouped GEMM. |

--- a/docs/contrib_ops/cuda/qmoe_gemv_exp.md
+++ b/docs/contrib_ops/cuda/qmoe_gemv_exp.md
@@ -1,0 +1,147 @@
+# QMoE GEMV Profiling Experiments
+
+This file records QMoE INT4 per-channel GEMV profiling results so future kernel and dispatch changes can be compared against a stable baseline.
+
+## 2026-06-12 Baseline: SM90, Warmup 5, Repeat 100
+
+### Setup
+
+- Machine/GPU: local CUDA machine, SM90 reported by `torch.cuda.get_device_capability()`.
+- ONNX Runtime build: `/home/tianlei/onnxruntime/build/cu130/Release`.
+- Python: `/home/tianlei/onnxruntime/.venv_cu130/bin/python`.
+- Nsight Systems: `/home/tianlei/cuda13.0/bin/nsys`.
+- Benchmark script: `onnxruntime/test/python/transformers/profile_qmoe_gemv.sh`.
+- Warmup: 5 ORT runs before the measured `benchmark` NVTX range.
+- Repeat: 100 measured ORT runs inside the `benchmark` NVTX range.
+- Common shape settings: hidden size 128, intermediate size 256, 4 experts, top-k 2, INT4 symmetric per-channel weights, SwiGLU interleaved activation.
+- Profile log: `/tmp/qmoe_gemv_warmup5_r100.log`.
+- Nsight artifacts: `/tmp/qmoe_gemv_<case>_warmup5_r100_{gemv,gemm}.{nsys-rep,sqlite}`.
+
+Command template:
+
+```bash
+pushd /tmp >/dev/null
+PATH=/home/tianlei/cuda13.0/bin:$PATH \
+PYTHONPATH=/home/tianlei/onnxruntime/build/cu130/Release:/home/tianlei/onnxruntime/onnxruntime/test/python/transformers \
+/home/tianlei/onnxruntime/onnxruntime/test/python/transformers/profile_qmoe_gemv.sh \
+  --python /home/tianlei/onnxruntime/.venv_cu130/bin/python \
+  --case <case-name> --warmup 5 --repeat 100 \
+  -o /tmp/qmoe_gemv_<case-name>_warmup5_r100
+popd >/dev/null
+```
+
+Parse command used for kernel-level comparisons:
+
+```bash
+python onnxruntime/test/python/transformers/parse_nsys.py \
+  /tmp/qmoe_gemv_<case>_warmup5_r100_<mode>.sqlite \
+  --nvtx-range benchmark --pattern '%'
+```
+
+`--pattern '%'` is important for fallback runs because the grouped-GEMM compute kernels are named as CUTLASS kernels and are not shown by the default parser pattern.
+
+### End-To-End ORT Loop Timing
+
+Lower is better. `GEMV/GEMM` compares the host-observed average latency printed by `profile_qmoe_gemv.py`.
+
+| Case | Tokens | Expanded rows | DType | GEMV ms | GEMM fallback ms | GEMV/GEMM | Result |
+|------|--------|---------------|-------|---------|------------------|-----------|--------|
+| `m1_top2_fp16_128x256` | 1 | 2 | FP16 | 0.0967 | 0.0706 | 1.37x | GEMV slower |
+| `m4_top2_fp16_128x256` | 4 | 8 | FP16 | 0.1372 | 0.0705 | 1.94x | GEMV slower |
+| `m8_top2_fp16_128x256` | 8 | 16 | FP16 | 0.1381 | 0.0702 | 1.97x | GEMV slower |
+| `m1_top2_bf16_128x256` | 1 | 2 | BF16 | 0.0972 | 0.0706 | 1.38x | GEMV slower |
+
+### Primary Compute Kernel Timing
+
+Values are average kernel duration in microseconds inside the measured NVTX range. GEMV has two compute kernels per ORT run in these cases, corresponding to the two MoE FC stages. GEMM fallback has two grouped-GEMM kernels per ORT run, except `m8_top2_fp16_128x256` appears as one aggregated CUTLASS kernel row with 200 calls.
+
+| Case | GEMV compute avg us | GEMM compute avg us | Notes |
+|------|---------------------|---------------------|-------|
+| `m1_top2_fp16_128x256` | 2.82, 2.56 | 3.98, 3.44 | GEMV compute kernels are faster, but total ORT loop is slower. |
+| `m4_top2_fp16_128x256` | 3.01, 2.74 | 3.72, 3.42 | GEMV compute kernels are faster, but total ORT loop is slower. |
+| `m8_top2_fp16_128x256` | 3.09, 2.75 | 3.55 aggregated over 200 calls | GEMV compute kernels are faster per call, but total ORT loop is slower. |
+| `m1_top2_bf16_128x256` | 2.84, 2.61 | 4.22, 3.49 | GEMV compute kernels are faster, but total ORT loop is slower. |
+
+### Observations
+
+- With explicit warmup and `nsys` NVTX filtering, the host-observed ORT loop latency is not aligned with the earlier low-repeat smoke numbers that suggested a GEMV win. This warmed baseline shows grouped GEMM fallback faster for these small 128x256 cases.
+- Kernel-only compute timing still shows the custom GEMV compute kernels faster than grouped GEMM compute kernels. The end-to-end loss likely comes from non-compute overhead around the GEMV path, dispatch/prologue behavior, extra launches, or measurement sensitivity at very small latencies.
+- The default `parse_nsys.py` kernel filter can hide fallback CUTLASS grouped-GEMM kernels. Use `--pattern '%'` for GEMV-vs-GEMM profile comparisons.
+- This baseline strengthens the P1/P2 work items: avoid repeated row-to-expert scans, tune tile/threshold decisions with data, and consider fusing FC1 activation or FC2 finalize/scatter before expanding GEMV coverage.
+
+### Next Experiments
+
+- Sweep larger realistic FC dimensions, especially model-like hidden/intermediate sizes, because this baseline only covers 128x256 test-sized shapes.
+- Sweep expanded rows `{1, 2, 4, 8, 16, 32, 64}` while keeping shape and dtype fixed.
+- Capture CUDA API timing inside the `benchmark` range to identify host-side synchronization or launch overhead differences.
+- Record per-architecture results for SM80/SM89/SM90/SM100/SM120 when available.
+
+## 2026-06-12 Larger Shape Sweep: SM90, 1024x4096, Warmup 5, Repeat 100
+
+### Setup
+
+- Same environment as the baseline section.
+- Custom profiler arguments were used instead of named cases.
+- Common shape settings: hidden size 1024, intermediate size 4096, 8 experts, top-k 2, INT4 symmetric per-channel weights, SwiGLU interleaved activation.
+- Profile log: `/tmp/qmoe_gemv_1024x4096_e8_warmup5_r100.log`.
+- Nsight artifacts: `/tmp/qmoe_gemv_custom_<case>_1024x4096_e8_warmup5_r100_{gemv,gemm}.{nsys-rep,sqlite}`.
+
+Command template:
+
+```bash
+pushd /tmp >/dev/null
+PATH=/home/tianlei/cuda13.0/bin:$PATH \
+PYTHONPATH=/home/tianlei/onnxruntime/build/cu130/Release:/home/tianlei/onnxruntime/onnxruntime/test/python/transformers \
+/home/tianlei/onnxruntime/onnxruntime/test/python/transformers/profile_qmoe_gemv.sh \
+  --python /home/tianlei/onnxruntime/.venv_cu130/bin/python \
+  --batch-size 1 --sequence-length <m> \
+  --hidden-size 1024 --intermediate-size 4096 \
+  --num-experts 8 --top-k 2 --dtype FLOAT16 \
+  --warmup 5 --repeat 100 \
+  -o /tmp/qmoe_gemv_custom_m<m>_top2_float16_1024x4096_e8_warmup5_r100
+popd >/dev/null
+```
+
+### End-To-End ORT Loop Timing
+
+Lower is better. `GEMV/GEMM` compares the host-observed average latency printed by `profile_qmoe_gemv.py`.
+
+| Case | Tokens | Expanded rows | DType | GEMV ms | GEMM fallback ms | GEMV/GEMM | Result |
+|------|--------|---------------|-------|---------|------------------|-----------|--------|
+| `custom_m1_top2_float16_1024x4096_e8` | 1 | 2 | FP16 | 0.0622 | 0.0811 | 0.77x | GEMV faster |
+| `custom_m4_top2_float16_1024x4096_e8` | 4 | 8 | FP16 | 0.1542 | 0.0873 | 1.77x | GEMV slower |
+| `custom_m8_top2_float16_1024x4096_e8` | 8 | 16 | FP16 | 0.2083 | 0.0976 | 2.13x | GEMV slower |
+| `custom_m1_top2_bfloat16_1024x4096_e8` | 1 | 2 | BF16 | 0.2144 | 0.0844 | 2.54x | GEMV slower |
+
+### Primary Compute Kernel Timing
+
+Values are average kernel duration in microseconds inside the measured NVTX range.
+
+| Case | GEMV compute avg us | GEMM compute avg us | Notes |
+|------|---------------------|---------------------|-------|
+| `custom_m1_top2_float16_1024x4096_e8` | 6.78, 4.70 | 14.61, 8.55 | GEMV wins both compute and end-to-end. |
+| `custom_m4_top2_float16_1024x4096_e8` | 12.05, 10.00 | 16.56, 12.71 | GEMV compute is faster, but total ORT loop is slower. |
+| `custom_m8_top2_float16_1024x4096_e8` | 23.19, 13.50 | 26.34, 14.29 | GEMV compute advantage narrows and end-to-end latency is worse. |
+| `custom_m1_top2_bfloat16_1024x4096_e8` | 6.99, 4.69 | 12.86 aggregated over 200 calls | BF16 GEMV is much slower end-to-end despite comparable compute-kernel timing. |
+
+### Observations
+
+- FP16 GEMV shows a real end-to-end win for single-token decode at 1024x4096, unlike the tiny 128x256 test shape.
+- The previous broad `expanded_num_rows <= 64` dispatch threshold was too optimistic on SM90 for this shape. At expanded rows 8 and 16, grouped GEMM fallback is faster end-to-end.
+- BF16 needs separate treatment. The single-token BF16 point is much slower with GEMV even though the raw GEMV kernels are not obviously bad.
+- The initial P1 dispatch cutoff is therefore conservative: FP16 only, `expanded_num_rows <= 2`, and `N/K >= 1024`. Collect more model-size points around expanded rows 2, 4, 8, and 16 before enabling GEMV beyond true single-token decode.
+
+## 2026-06-12 Post-Threshold Dispatch Smoke: SM90, Warmup 1, Repeat 2
+
+### Setup
+
+- Same build and Python environment as above, after syncing the rebuilt CUDA provider into the Python package `capi` directory.
+- Nsight Systems profiles used the measured `benchmark` NVTX range and counted kernels matching `%moe_gemv%`.
+- These runs validate routing only; repeat count is too small for performance comparison.
+
+| Case | Expanded rows | DType | Expected route | `moe_gemv` calls in benchmark | Result |
+|------|---------------|-------|----------------|--------------------------------|--------|
+| `m1_top2_fp16_128x256` | 2 | FP16 | grouped GEMM fallback (`N/K < 1024`) | 0 | Passed |
+| `custom_m1_top2_float16_1024x4096_e8` | 2 | FP16 | GEMV | 4 | Passed |
+| `custom_m4_top2_float16_1024x4096_e8` | 8 | FP16 | grouped GEMM fallback (`expanded_num_rows > 2`) | 0 | Passed |
+| `custom_m1_top2_bfloat16_1024x4096_e8` | 2 | BF16 | grouped GEMM fallback (FP16-only GEMV gate) | 0 | Passed |

--- a/docs/contrib_ops/cuda/qmoe_gemv_exp.md
+++ b/docs/contrib_ops/cuda/qmoe_gemv_exp.md
@@ -415,7 +415,9 @@ vector element.
 | Variant | Enabled ms | FC1 GEMV avg us | FC2 GEMV avg us | Finalize avg us | Result |
 |---------|------------|-----------------|-----------------|-----------------|--------|
 | FC1 fused baseline | 0.0681 | 13.93 | 10.11 | ~5.65 | Baseline for comparison. |
-| one-row finalize specialization | 0.0681 | 13.98 | 10.09 | 5.50 | Keep; small finalize-kernel win, end-to-end neutral within noise. |
+| one-row finalize specialization | 0.0681 | 13.98 | 10.09 | 5.50 | Kept as first step; small finalize-kernel win, end-to-end neutral within noise. |
+| static top-k one-row specialization | 0.0671 | 13.93 | 10.01 | 5.00 | Keep; top-k 4 compile-time unroll improves finalize and gives the best GPT-OSS enabled latency so far. |
+| static top-k with 128 threads | 0.0684 | 13.82 | 10.24 | 6.48 | Reject; smaller block underutilizes the 2880-wide output. |
 
 ### Correctness
 
@@ -434,4 +436,5 @@ vector element.
   carefully bounded numerical change.
 - The current one-row finalize specialization is intentionally small: it is useful
   for GPT-style single-token decode and does not alter routing for larger batches
-  or top-k 8 models.
+  or top-k 8 models. Dispatching exact top-k specializations is worthwhile for
+  GPT-OSS top-k 4; reducing the one-row block from 256 to 128 threads is not.

--- a/docs/contrib_ops/cuda/qmoe_gemv_exp.md
+++ b/docs/contrib_ops/cuda/qmoe_gemv_exp.md
@@ -145,3 +145,78 @@ Values are average kernel duration in microseconds inside the measured NVTX rang
 | `custom_m1_top2_float16_1024x4096_e8` | 2 | FP16 | GEMV | 4 | Passed |
 | `custom_m4_top2_float16_1024x4096_e8` | 8 | FP16 | grouped GEMM fallback (`expanded_num_rows > 2`) | 0 | Passed |
 | `custom_m1_top2_bfloat16_1024x4096_e8` | 2 | BF16 | grouped GEMM fallback (FP16-only GEMV gate) | 0 | Passed |
+
+## 2026-06-12 Actual Model Dimensions: SM90, FP16, Warmup 5, Repeat 20
+
+### Setup
+
+- Same build and Python environment as above.
+- Nsight Systems profiles used the measured `benchmark` NVTX range.
+- Enabled mode leaves `ORT_DISABLE_MOE_GEMV` unset. Fallback mode sets `ORT_DISABLE_MOE_GEMV=1`.
+- Nsight artifacts: `/tmp/qmoe_actual_<case>_warmup5_r20_{enabled,gemm}.{nsys-rep,sqlite}`.
+- Summary log: `/tmp/qmoe_actual_model_dims_fp16_warmup5_r20_summary.txt`.
+
+Model dimensions came from the Hugging Face configs below. Qwen's shared expert
+is ignored in this benchmark.
+
+| Model case | Source dimensions | Tokens | Expanded rows | Enabled ms | Fallback ms | `moe_gemv` calls in enabled profile | Route |
+|------------|-------------------|--------|---------------|------------|-------------|--------------------------------------|-------|
+| `gpt_oss_20b_m1_top4_fp16_2880x2880_e32` | `hidden_size=2880`, `intermediate_size=2880`, `num_local_experts=32`, `top_k=4` | 1 | 4 | 0.0909 | 0.0944 | 0 | grouped GEMM fallback |
+| `qwen3_6_35b_a3b_m1_top8_fp16_2048x512_e256` | `hidden_size=2048`, `moe_intermediate_size=512`, `num_experts=256`, `top_k=8` | 1 | 8 | 0.0744 | 0.0743 | 0 | grouped GEMM fallback |
+| `gemma4_26b_a4b_m1_top8_fp16_2816x704_e128` | `hidden_size=2816`, `moe_intermediate_size=704`, `num_experts=128`, `top_k=8` | 1 | 8 | 0.0819 | 0.0820 | 0 | grouped GEMM fallback |
+
+### Observations
+
+- The actual single-token top-k values for these models produce expanded rows 4
+  or 8, so they intentionally stay on grouped GEMM under the current
+  `expanded_num_rows <= 2` GEMV gate.
+- Enabled and forced-fallback timings are nearly identical, and the enabled
+  profiles contain zero custom `moe_gemv` kernels, confirming the dispatch route.
+- These profiles establish the current grouped-GEMM baseline for actual model
+  dimensions. Future GEMV work for model-realistic top-k needs targeted row-count
+  improvements before expanding the dispatch gate.
+
+## 2026-06-12 Actual Model Dimensions With Relaxed GEMV Gate: SM90, FP16, Warmup 5, Repeat 100
+
+### Setup
+
+- Same build and Python environment as above.
+- Dispatch was temporarily relaxed to `expanded_num_rows <= 8` and `N/K >= 512`
+  to force GEMV coverage for GPT-OSS-20B, Qwen3.6-35B-A3B, and Gemma-4-26B-A4B
+  FP16 model-size cases.
+- Nsight artifacts: `/tmp/qmoe_actual_<case>_relaxed_warmup5_r100_{enabled,gemm}.{nsys-rep,sqlite}`.
+- Summary log: `/tmp/qmoe_actual_model_dims_fp16_relaxed_warmup5_r100_summary.txt`.
+
+| Model case | Expanded rows | Enabled route | Enabled ms | Fallback ms | GEMV/GEMM | GEMV calls | Primary enabled compute avg us | Primary fallback compute avg us | Decision |
+|------------|---------------|---------------|------------|-------------|-----------|------------|--------------------------------|---------------------------------|----------|
+| `gpt_oss_20b_m1_top4_fp16_2880x2880_e32` | 4 | GEMV | 0.0760 | 0.0905 | 0.84x | 200 | 15.35, 11.94 | 20.11, 18.48 | Keep GEMV candidate |
+| `qwen3_6_35b_a3b_m1_top8_fp16_2048x512_e256` | 8 | GEMV | 0.0865 | 0.0707 | 1.22x | 200 | 20.37, 18.77 | 10.33 aggregated over 200 calls | Reject current GEMV gate |
+| `gemma4_26b_a4b_m1_top8_fp16_2816x704_e128` | 8 | GEMV | 0.0745 | 0.0801 | 0.93x | 200 | 14.61, 11.85 | 13.58 aggregated over 200 calls | Keep GEMV candidate |
+
+### Observations
+
+- GPT-OSS-20B benefits from GEMV at expanded rows 4 with square 2880x2880 FC
+  dimensions.
+- Gemma-4-26B-A4B shows a smaller but positive end-to-end win at expanded rows 8
+  with 2816x704 / 704x2816 FC dimensions.
+- Qwen3.6-35B-A3B regresses with the current GEMV kernel at expanded rows 8 and
+  2048x512 / 512x2048 FC dimensions. The primary GEMV kernels are slower than
+  grouped GEMM for this 512-wide MoE hidden size.
+- Based on this pass, the dispatch gate should keep `expanded_num_rows <= 8` and
+  `N/K >= 512`, but require the logical MoE intermediate size and each GEMV call
+  dimension to be at least 704 when `expanded_num_rows > 4`. The logical
+  intermediate-size check is needed because Qwen's gated FC1 has `N=1024` even
+  though the MoE hidden size is 512. This keeps GPT-OSS and Gemma enabled while
+  routing the measured Qwen regression to grouped GEMM. A future autotuner could
+  replace this hand cutoff.
+
+### Final Route Check After Logical Intermediate-Size Guard
+
+After adding the logical intermediate-size guard, short Nsight profiles with
+warmup 1 and repeat 2 confirmed the intended final routing:
+
+| Model case | Expected route | `moe_gemv` calls in benchmark | Result |
+|------------|----------------|--------------------------------|--------|
+| `gpt_oss_20b_m1_top4_fp16_2880x2880_e32` | GEMV | 4 | Passed |
+| `qwen3_6_35b_a3b_m1_top8_fp16_2048x512_e256` | grouped GEMM fallback | 0 | Passed |
+| `gemma4_26b_a4b_m1_top8_fp16_2816x704_e128` | GEMV | 4 | Passed |

--- a/docs/contrib_ops/cuda/qmoe_gemv_exp.md
+++ b/docs/contrib_ops/cuda/qmoe_gemv_exp.md
@@ -265,3 +265,55 @@ range. The two GEMV compute rows correspond to FC1 and FC2.
 - Qwen remains routed to grouped GEMM by the logical-intermediate-size guard. A
   quick enabled-mode smoke run reported valid output for
   `qwen3_6_35b_a3b_m1_top8_fp16_2048x512_e256`.
+
+## 2026-06-12 P1 Tile-Shape Probe: SM90, FP16, Warmup 5, Repeat 100
+
+### Setup
+
+- Same build and Python environment as above.
+- Goal: test the next P1 tile-shape knobs against the actual model-size cases
+  that route to GEMV after the row-to-expert map optimization.
+- Variants tested:
+  - `CtaN=16, Threads=128`: halves the number of N-tile CTAs.
+  - `CtaN=8, Threads=64`: reduces threads per CTA while preserving the N tile.
+  - `CtaN=8, Threads=128` with a map-specialized launch: splits direct-map and
+    prefix-scan kernels so the common direct-map path avoids the runtime branch.
+- Nsight artifacts:
+  `/tmp/qmoe_actual_*_ctan16_warmup5_r100_{gemv,gemm}.{nsys-rep,sqlite}`,
+  `/tmp/qmoe_actual_*_threads64_warmup5_r100_{gemv,gemm}.{nsys-rep,sqlite}`,
+  and `/tmp/qmoe_actual_*_specialized_map_warmup5_r100_{gemv,gemm}.{nsys-rep,sqlite}`.
+
+### End-To-End ORT Loop Timing
+
+| Variant | Model case | Enabled ms | Fallback ms | Result |
+|---------|------------|------------|-------------|--------|
+| `CtaN=16, Threads=128` | `gpt_oss_20b_m1_top4_fp16_2880x2880_e32` | 0.0852 | 0.0872 | Reject |
+| `CtaN=16, Threads=128` | `gemma4_26b_a4b_m1_top8_fp16_2816x704_e128` | 0.0644 | 0.0791 | Reject |
+| `CtaN=8, Threads=64` | `gpt_oss_20b_m1_top4_fp16_2880x2880_e32` | 0.0832 | 0.0993 | Reject |
+| `CtaN=8, Threads=64` | `gemma4_26b_a4b_m1_top8_fp16_2816x704_e128` | 0.0645 | 0.0799 | Reject |
+| map-specialized launch | `gpt_oss_20b_m1_top4_fp16_2880x2880_e32` | 0.0726 | 0.0909 | Reject, neutral/slightly worse kernels |
+| map-specialized launch | `gemma4_26b_a4b_m1_top8_fp16_2816x704_e128` | 0.0600 | 0.0790 | Reject, neutral/slightly worse kernels |
+
+### Primary GEMV Compute Kernel Timing
+
+Values are average kernel duration in microseconds inside the measured NVTX
+range. Previous best is the row-to-expert map build with `CtaN=8, Threads=128`:
+GPT `13.69, 10.22` us and Gemma `7.17, 4.56` us.
+
+| Variant | GPT GEMV avg us | Gemma GEMV avg us | Decision |
+|---------|-----------------|-------------------|----------|
+| `CtaN=16, Threads=128` | 19.48, 17.52 | 11.07, 5.65 | Wider N tile is slower for both models. |
+| `CtaN=8, Threads=64` | 18.77, 16.78 | 11.09, 5.09 | Fewer threads are slower for both models. |
+| map-specialized launch | 14.00, 10.10 | 7.25, 4.62 | No clear kernel win; keep the simpler launch. |
+
+### Observations
+
+- The existing `CtaN=8, Threads=128` tile remains the best measured choice for
+  the current SM90 actual-model cases.
+- Halving N tiles with `CtaN=16` reduced CTA count but lost too much per-CTA
+  efficiency.
+- `Threads=64` did not help the 704-wide Gemma case and significantly hurt the
+  larger GPT-OSS case.
+- The direct-map branch in the current kernel is not a visible bottleneck after
+  the row-to-expert map optimization, so the extra specialized launch variants
+  are not worth the additional code size.

--- a/docs/contrib_ops/cuda/qmoe_gemv_exp.md
+++ b/docs/contrib_ops/cuda/qmoe_gemv_exp.md
@@ -377,3 +377,61 @@ range. The fused GEMV compute rows correspond to fused FC1 and unfused FC2.
 - The FC2 finalize/scatter fusion remains a larger but riskier opportunity. It
   can remove another launch, but it needs a design that preserves the current
   float accumulation behavior across top-k experts.
+
+## 2026-06-13 GPT-OSS FC2 / Finalize Follow-Up: SM90, FP16, Warmup 5, Repeat 100
+
+### Setup
+
+- Same build and Python environment as above.
+- Target case: `gpt_oss_20b_m1_top4_fp16_2880x2880_e32`.
+- Goal: find remaining GPT-OSS-specific opportunity after FC1 interleaved SwiGLU
+  fusion. The prior profile had FC1 GEMV around `13.93` us, FC2 GEMV around
+  `10.11` us, and finalize around `5.65` us.
+- Nsight artifacts:
+  `/tmp/ort_qmoe_profile/qmoe_fc2_finalize_fused_gpt_{gemv,gemm}.{nsys-rep,sqlite}`
+  for the rejected fused-FC2 prototype and
+  `/tmp/ort_qmoe_profile/qmoe_finalize_onerow_gpt_{gemv,gemm}.{nsys-rep,sqlite}`
+  for the retained one-row finalize specialization.
+
+### Rejected Prototype: FC2 GEMV + Finalize Fusion
+
+The prototype assigned one CTA to each original token and N tile, then looped
+over the token's top-k experts inside that CTA. It avoided atomics and preserved
+the top-k accumulation order, but it also serialized the four GPT-OSS FC2 GEMVs
+that previously ran as separate expanded-row CTAs.
+
+| Variant | Enabled ms | Fused FC2/finalize avg us | Decision |
+|---------|------------|---------------------------|----------|
+| FC2 GEMV + finalize fusion | 0.0848 | 33.21 | Reject; removed from code. |
+
+### Retained Prototype: One-Row Finalize Specialization
+
+The retained change keeps the existing FC2 GEMV kernel and only specializes
+`finalizeMoeRoutingKernelLauncher` for `num_rows == 1` and `top_k <= 4`. The
+specialized kernel caches `unpermuted_row_to_permuted_row`, expert ids, and
+routing scales once in shared memory instead of reloading them for every output
+vector element.
+
+| Variant | Enabled ms | FC1 GEMV avg us | FC2 GEMV avg us | Finalize avg us | Result |
+|---------|------------|-----------------|-----------------|-----------------|--------|
+| FC1 fused baseline | 0.0681 | 13.93 | 10.11 | ~5.65 | Baseline for comparison. |
+| one-row finalize specialization | 0.0681 | 13.98 | 10.09 | 5.50 | Keep; small finalize-kernel win, end-to-end neutral within noise. |
+
+### Correctness
+
+- Large enough FP16 INT4 SwiGLU top-k 4 parity case
+  (`hidden_size=1024`, `intermediate_size=1024`, `num_experts=8`, `top_k=4`) had
+  max absolute difference `0.0006104` before the helper's parity check and
+  `0.000732` in the built-in parity check.
+
+### Observations
+
+- GPT-OSS still has room around FC2 and finalize, but a simple single-CTA
+  FC2/finalize fusion is the wrong shape because it gives up expanded-row
+  parallelism.
+- A viable future FC2/finalize design likely needs to preserve parallelism across
+  top-k experts and N tiles, then reduce partial results without atomics or with
+  carefully bounded numerical change.
+- The current one-row finalize specialization is intentionally small: it is useful
+  for GPT-style single-token decode and does not alter routing for larger batches
+  or top-k 8 models.

--- a/docs/contrib_ops/cuda/qmoe_gemv_exp.md
+++ b/docs/contrib_ops/cuda/qmoe_gemv_exp.md
@@ -220,3 +220,48 @@ warmup 1 and repeat 2 confirmed the intended final routing:
 | `gpt_oss_20b_m1_top4_fp16_2880x2880_e32` | GEMV | 4 | Passed |
 | `qwen3_6_35b_a3b_m1_top8_fp16_2048x512_e256` | grouped GEMM fallback | 0 | Passed |
 | `gemma4_26b_a4b_m1_top8_fp16_2816x704_e128` | GEMV | 4 | Passed |
+
+## 2026-06-13 P1 Row-To-Expert Map: SM90, FP16, Warmup 5, Repeat 100
+
+### Setup
+
+- Same build and Python environment as above.
+- Change under test: the prologue now writes the local expert id for each
+  permuted row into `permuted_token_selected_experts`, and the INT4
+  per-channel MoE GEMV kernel uses that direct row-to-expert map instead of
+  scanning `expert_first_token_offset` in every N-tile CTA. The prefix-offset
+  scan remains as a fallback when no map is passed.
+- Nsight artifacts:
+  `/tmp/qmoe_actual_gpt_oss_20b_p1_row_expert_warmup5_r100_{gemv,gemm}.{nsys-rep,sqlite}`
+  and
+  `/tmp/qmoe_actual_gemma4_26b_p1_row_expert_warmup5_r100_{gemv,gemm}.{nsys-rep,sqlite}`.
+- Summary logs:
+  `/tmp/qmoe_actual_gpt_oss_20b_p1_row_expert_warmup5_r100.log` and
+  `/tmp/qmoe_actual_gemma4_26b_p1_row_expert_warmup5_r100.log`.
+
+### End-To-End ORT Loop Timing
+
+| Model case | Expanded rows | Enabled route | Enabled ms | Fallback ms | GEMV/GEMM | GEMV calls | Result |
+|------------|---------------|---------------|------------|-------------|-----------|------------|--------|
+| `gpt_oss_20b_m1_top4_fp16_2880x2880_e32` | 4 | GEMV | 0.0721 | 0.0941 | 0.77x | 200 | GEMV faster |
+| `gemma4_26b_a4b_m1_top8_fp16_2816x704_e128` | 8 | GEMV | 0.0610 | 0.0795 | 0.77x | 200 | GEMV faster |
+
+### Primary Compute Kernel Timing
+
+Values are average kernel duration in microseconds inside the measured NVTX
+range. The two GEMV compute rows correspond to FC1 and FC2.
+
+| Model case | GEMV compute avg us | Fallback compute avg us | Previous GEMV compute avg us | Notes |
+|------------|---------------------|-------------------------|------------------------------|-------|
+| `gpt_oss_20b_m1_top4_fp16_2880x2880_e32` | 13.69, 10.22 | 20.32, 18.55 | 15.35, 11.94 | Direct map reduces GEMV kernel time by about 11% and 14% versus the relaxed-gate baseline. |
+| `gemma4_26b_a4b_m1_top8_fp16_2816x704_e128` | 7.17, 4.56 | 18.82, 7.99 | 14.61, 11.85 | Direct map removes a large per-tile scan cost at top-k 8 for this 704-wide case. |
+
+### Observations
+
+- The P1 row-to-expert map improves both actual-model GEMV candidates without
+  changing the dispatch policy.
+- The improvement is largest for Gemma, where expanded rows 8 and many N tiles
+  made the repeated prefix scan particularly visible.
+- Qwen remains routed to grouped GEMM by the logical-intermediate-size guard. A
+  quick enabled-mode smoke run reported valid output for
+  `qwen3_6_35b_a3b_m1_top8_fp16_2048x512_e256`.

--- a/docs/contrib_ops/cuda/qmoe_gemv_exp.md
+++ b/docs/contrib_ops/cuda/qmoe_gemv_exp.md
@@ -317,3 +317,63 @@ GPT `13.69, 10.22` us and Gemma `7.17, 4.56` us.
 - The direct-map branch in the current kernel is not a visible bottleneck after
   the row-to-expert map optimization, so the extra specialized launch variants
   are not worth the additional code size.
+
+## 2026-06-13 FC1 Interleaved SwiGLU Fusion: SM90, FP16, Warmup 5, Repeat 100
+
+### Setup
+
+- Same build and Python environment as above.
+- Change under test: FC1 INT4 per-channel GEMV has an interleaved SwiGLU epilogue
+  for the profiled FP16 path. It computes adjacent gate/linear FC1 columns,
+  applies the existing `alpha=1.702`, `beta=1.0`, `limit=7.0` SwiGLU formula,
+  and writes post-activation `[expanded_rows, inter_size]` directly to the FC2
+  input buffer.
+- The unfused GEMV plus `doGatedActivationKernel` path remains the fallback for
+  non-FP16, non-INT4-per-channel, groupwise quantization, non-interleaved
+  activations, and shapes rejected by the existing GEMV dispatch policy.
+- Nsight artifacts:
+  `/tmp/ort_qmoe_profile/qmoe_swiglu_fused_gpt_{gemv,gemm}.{nsys-rep,sqlite}`,
+  `/tmp/ort_qmoe_profile/qmoe_swiglu_fused_gemma_{gemv,gemm}.{nsys-rep,sqlite}`,
+  and `/tmp/ort_qmoe_profile/qmoe_swiglu_fused_qwen_{gemv,gemm}.{nsys-rep,sqlite}`.
+
+### Correctness
+
+- Focused QMoE GEMV smoke:
+  `TestQMoEGemvBenchmark::test_decode_latency` passed.
+- Large enough FP16 INT4 SwiGLU parity case to exercise the fused path
+  (`hidden_size=1024`, `intermediate_size=512`, `num_experts=4`, `top_k=2`) had
+  max absolute difference `0.0009766` before the helper's parity check and
+  `0.000893` in the built-in parity check.
+
+### End-To-End ORT Loop Timing
+
+Lower is better. Previous best is the P1 row-to-expert map build with the same
+`CtaN=8, Threads=128` tile shape.
+
+| Model case | Expanded rows | Enabled route | Fused GEMV ms | Previous best GEMV ms | Fallback ms | Result |
+|------------|---------------|---------------|---------------|-----------------------|-------------|--------|
+| `gpt_oss_20b_m1_top4_fp16_2880x2880_e32` | 4 | GEMV | 0.0681 | 0.0721 | 0.1013 | GEMV faster; fusion improves enabled path by about 5.5%. |
+| `gemma4_26b_a4b_m1_top8_fp16_2816x704_e128` | 8 | GEMV | 0.0580 | 0.0610 | 0.0811 | GEMV faster; fusion improves enabled path by about 4.9%. |
+| `qwen3_6_35b_a3b_m1_top8_fp16_2048x512_e256` | 8 | grouped GEMM fallback | 0.0706 | N/A | 0.0710 | No custom GEMV kernels; route unchanged by fusion. |
+
+### Primary Kernel Timing
+
+Values are average kernel duration in microseconds inside the measured NVTX
+range. The fused GEMV compute rows correspond to fused FC1 and unfused FC2.
+
+| Model case | Fused GEMV compute avg us | Previous best GEMV compute avg us | Removed activation avg us from fallback profile | Notes |
+|------------|---------------------------|-----------------------------------|-----------------------------------------------|-------|
+| `gpt_oss_20b_m1_top4_fp16_2880x2880_e32` | 13.93, 10.11 | 13.69, 10.22 | 3.23 | FC1 GEMV is slightly slower due to the fused epilogue, but removing the activation launch gives a net end-to-end win. |
+| `gemma4_26b_a4b_m1_top8_fp16_2816x704_e128` | 8.30, 4.57 | 7.17, 4.56 | 1.82 | The fused epilogue costs more for the small FC1 tile, but still beats the separate activation launch end-to-end. |
+| `qwen3_6_35b_a3b_m1_top8_fp16_2048x512_e256` | N/A | N/A | 1.76 | The 512-wide intermediate-size guard keeps Qwen on grouped GEMM. |
+
+### Observations
+
+- FC1 interleaved SwiGLU fusion is a modest but real win for the two actual-model
+  cases that already route to GEMV.
+- The win comes from launch and memory-traffic removal, not from faster FC1
+  compute. The fused FC1 kernel is slightly slower than the prior FC1 GEMV
+  kernel, so this optimization should stay narrowly gated to the measured path.
+- The FC2 finalize/scatter fusion remains a larger but riskier opportunity. It
+  can remove another launch, but it needs a design that preserves the current
+  float accumulation behavior across top-k experts.

--- a/docs/contrib_ops/cuda/qmoe_gemv_experiments.md
+++ b/docs/contrib_ops/cuda/qmoe_gemv_experiments.md
@@ -7,9 +7,9 @@ This file records QMoE INT4 per-channel GEMV profiling results so future kernel 
 ### Setup
 
 - Machine/GPU: local CUDA machine, SM90 reported by `torch.cuda.get_device_capability()`.
-- ONNX Runtime build: `/home/tianlei/onnxruntime/build/cu130/Release`.
-- Python: `/home/tianlei/onnxruntime/.venv_cu130/bin/python`.
-- Nsight Systems: `/home/tianlei/cuda13.0/bin/nsys`.
+- ONNX Runtime build: `~/onnxruntime/build/cu130/Release`.
+- Python: `~/onnxruntime/.venv/bin/python`.
+- Nsight Systems: `~/cuda13.0/bin/nsys`.
 - Benchmark script: `onnxruntime/test/python/transformers/profile_qmoe_gemv.sh`.
 - Warmup: 5 ORT runs before the measured `benchmark` NVTX range.
 - Repeat: 100 measured ORT runs inside the `benchmark` NVTX range.
@@ -21,10 +21,10 @@ Command template:
 
 ```bash
 pushd /tmp >/dev/null
-PATH=/home/tianlei/cuda13.0/bin:$PATH \
-PYTHONPATH=/home/tianlei/onnxruntime/build/cu130/Release:/home/tianlei/onnxruntime/onnxruntime/test/python/transformers \
-/home/tianlei/onnxruntime/onnxruntime/test/python/transformers/profile_qmoe_gemv.sh \
-  --python /home/tianlei/onnxruntime/.venv_cu130/bin/python \
+PATH=~/cuda13.0/bin:$PATH \
+PYTHONPATH=~/onnxruntime/build/cu130/Release:~/onnxruntime/onnxruntime/test/python/transformers \
+~/onnxruntime/onnxruntime/test/python/transformers/profile_qmoe_gemv.sh \
+  --python ~/onnxruntime/.venv/bin/python \
   --case <case-name> --warmup 5 --repeat 100 \
   -o /tmp/qmoe_gemv_<case-name>_warmup5_r100
 popd >/dev/null
@@ -90,10 +90,10 @@ Command template:
 
 ```bash
 pushd /tmp >/dev/null
-PATH=/home/tianlei/cuda13.0/bin:$PATH \
-PYTHONPATH=/home/tianlei/onnxruntime/build/cu130/Release:/home/tianlei/onnxruntime/onnxruntime/test/python/transformers \
-/home/tianlei/onnxruntime/onnxruntime/test/python/transformers/profile_qmoe_gemv.sh \
-  --python /home/tianlei/onnxruntime/.venv_cu130/bin/python \
+PATH=~/cuda13.0/bin:$PATH \
+PYTHONPATH=~/onnxruntime/build/cu130/Release:~/onnxruntime/onnxruntime/test/python/transformers \
+~/onnxruntime/onnxruntime/test/python/transformers/profile_qmoe_gemv.sh \
+  --python ~/onnxruntime/.venv/bin/python \
   --batch-size 1 --sequence-length <m> \
   --hidden-size 1024 --intermediate-size 4096 \
   --num-experts 8 --top-k 2 --dtype FLOAT16 \
@@ -438,3 +438,70 @@ vector element.
   for GPT-style single-token decode and does not alter routing for larger batches
   or top-k 8 models. Dispatching exact top-k specializations is worthwhile for
   GPT-OSS top-k 4; reducing the one-row block from 256 to 128 threads is not.
+
+## 2026-06-13 GenAI End-To-End Throughput: GPT-OSS-20B INT4, SM90 (H200), Batch 1
+
+### Setup
+
+- Measures full ONNX Runtime GenAI token-generation throughput, not isolated
+  kernel time, so it captures the real end-to-end impact of the MoE GEMV path.
+- GPU: single H200 (SM90), `CUDA_VISIBLE_DEVICES=1` on an otherwise idle GPU.
+  GPU 0 was busy with another job during early runs and produced corrupted
+  numbers, so all results below use an idle GPU.
+- ONNX Runtime build: `~/onnxruntime/build/cu130/Release` (branch
+  `tlw/rel-1.27.0_qmoe_update`), CUDA 13.0, `CMAKE_CUDA_ARCHITECTURES=89;90`.
+- ONNX Runtime GenAI: `0.14.0-dev`, venv `~/.venv_src_8f0278c` (Python 3.14).
+- Model: `gpt-oss-20b` INT4 per-channel,
+  `~/models/gpt-oss-20b/cuda/cuda-int4-kquant-block-32-mixed/`
+  (`hidden=inter=2880`, 32 experts, top-k 4, SwiGLU interleaved). Single-token
+  decode expands to 4 rows per step, which routes to the INT4 per-channel GEMV.
+- Three configurations compared:
+  - **Cutlass baseline (grouped GEMM)**: GEMV disabled via
+    `ORT_DISABLE_MOE_GEMV=1`, so FC1/FC2 use the cutlass grouped-GEMM path.
+  - **GEMV (final)**: default build with the INT4 per-channel MoE GEMV fast path,
+    including the row-to-expert map, FC1 interleaved SwiGLU fusion, and static
+    top-k one-row finalize specialization.
+  - **FT baseline**: FasterTransformer MoE kernel used in ORT 1.26 (or ORT GenAI 0.14.1) reference token-generation throughput for the same model and prompt lengths.
+- Correctness: both GEMV-enabled and `ORT_DISABLE_MOE_GEMV=1` produce identical
+  correct output ("Paris is the capital of France.") for the sanity prompt, and
+  the Nsight trace confirms `moe_gemv_kernel` executes for FC1 and FC2.
+
+Command template (run once per configuration):
+
+```bash
+cd ~/onnxruntime-genai/benchmark/python
+source ~/.venv_src_8f0278c/bin/activate
+export LD_LIBRARY_PATH=~/cuda13.0/lib64:~/cudnn9.19_cuda13/lib:$LD_LIBRARY_PATH
+# Add ORT_DISABLE_MOE_GEMV=1 for the cutlass baseline.
+CUDA_VISIBLE_DEVICES=1 python benchmark_e2e.py \
+  -i ~/models/gpt-oss-20b/cuda/cuda-int4-kquant-block-32-mixed/ \
+  -b 1 -l 128,1024,2048 -g 256 -r 10 -w 2 \
+  --use_random_tokens --chat_template '{input}' \
+  -pm 1 -e cuda -mn gpt-oss-20b -pr int4 -o results_gptoss/<name>.csv
+```
+
+### Token-Generation Throughput
+
+Higher is better. Values are average token-generation throughput in tokens per
+second (tps) for batch size 1, 256 generated tokens, 10 repeats, 2 warmups.
+
+| Prompt length | Cutlass baseline (gemm) tps | GEMV (final) tps | FT baseline tps | GEMV vs cutlass | GEMV vs FT |
+|---------------|-----------------------------|------------------|-----------------|-----------------|------------|
+| 128 | 248.9 | 288.0 | 265.2 | +15.7% | +8.6% |
+| 1024 | 237.8 | 272.2 | 252.9 | +14.5% | +7.6% |
+| 2048 | 231.3 | 265.0 | 245.6 | +14.6% | +7.9% |
+
+### Observations
+
+- The final MoE GEMV path beats both the cutlass grouped-GEMM baseline and the
+  FasterTransformer 0.14.1 reference at every measured prompt length.
+- Versus the cutlass grouped-GEMM baseline, GEMV improves end-to-end
+  token-generation throughput by roughly 15% across prompt lengths.
+- Versus the FT 0.14.1 baseline, GEMV is about 8% faster, meeting the goal of
+  outperforming FasterTransformer for GPT-OSS-20B single-token decode.
+- These end-to-end gains are consistent with the kernel-level wins recorded in
+  the row-to-expert map, FC1 interleaved SwiGLU fusion, and static top-k finalize
+  sections above.
+- Always confirm the benchmark GPU is idle (`nvidia-smi`) before recording
+  numbers; contention on a shared GPU inflates sampling latency and corrupts the
+  throughput measurement.

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemm_profiler.cc
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemm_profiler.cc
@@ -7,6 +7,7 @@
 #include "contrib_ops/cuda/llm/moe_gemm/moe_gemm_kernels.h"
 
 #include <functional>
+#include <limits>
 #include <memory>
 
 namespace onnxruntime::llm::kernels::cutlass_kernels {
@@ -127,33 +128,85 @@ std::optional<MoeGemmProfiler::Config> MoeGemmProfiler::runProfiling(int maxM, M
   return best_config;
 }
 
-void MoeGemmProfiler::profileTactics(CutlassMoeFCRunnerInterface* runner, nvinfer::DataType dtype,
+void MoeGemmProfiler::profileTactics(CutlassMoeFCRunnerInterface* runner,
                                      weight_only::GemmDims const& dims, MoeGemmId const& gemmId) {
   ORT_LLM_LOG_ENTRY();
-  // Check if already cached
-  (void)dtype;
-  auto it = config_cache_.find(gemmId);
-  if (it != config_cache_.end()) {
-    return;  // Already profiled
+
+  // Profile per M bucket: decode (small M) and prefill (large M) prefer different tile shapes,
+  // so cache a separate best config for each bucket instead of a single shape-only config.
+  int const bucket = bucketM(dims.maxM);
+  auto& bucket_map = config_cache_[gemmId];
+  if (bucket_map.find(bucket) != bucket_map.end()) {
+    return;  // Already profiled for this (GemmId, M bucket).
   }
 
   // Initialize backend with correct types
   initBackend(runner, gemmId);
 
-  // Run profiling
-  int maxM = static_cast<int>(dims.maxM);
-  auto result = runProfiling(maxM, gemmId);
+  // Run profiling at the bucket's representative M.
+  auto result = runProfiling(bucket, gemmId);
 
-  // Cache result
-  config_cache_[gemmId] = result;
+  // Cache result for this bucket
+  bucket_map[bucket] = result;
+}
+
+int MoeGemmProfiler::bucketM(int64_t m) {
+  // Snap M up to the next power of two so a handful of buckets cover the full range. M=1 (the
+  // common batch-1 decode case) gets its own bucket and therefore its own decode-tuned tactic.
+  if (m <= 1) {
+    return 1;
+  }
+  constexpr int64_t kMaxBucket = 8192;
+  if (m >= kMaxBucket) {
+    return static_cast<int>(kMaxBucket);
+  }
+  int64_t bucket = 1;
+  while (bucket < m) {
+    bucket <<= 1;
+  }
+  return static_cast<int>(bucket);
 }
 
 std::optional<MoeGemmProfiler::Config> MoeGemmProfiler::getBestConfig(int m, MoeGemmId const& id) const {
   ORT_LLM_LOG_ENTRY();
-  (void)m;  // M is already factored into profiling
   auto it = config_cache_.find(id);
-  if (it != config_cache_.end()) {
-    return it->second;
+  if (it == config_cache_.end()) {
+    return std::nullopt;
+  }
+  auto const& bucket_map = it->second;
+  int const bucket = bucketM(m);
+
+  // Exact bucket profiled: use it.
+  auto exact = bucket_map.find(bucket);
+  if (exact != bucket_map.end()) {
+    return exact->second;
+  }
+
+  // Not profiled for this exact bucket. Fall back to the nearest profiled bucket: prefer the
+  // smallest profiled bucket >= requested (tuned for at least this much work), otherwise the
+  // largest profiled bucket below it.
+  std::optional<Config> best_ge;
+  int best_ge_bucket = std::numeric_limits<int>::max();
+  std::optional<Config> best_lt;
+  int best_lt_bucket = -1;
+  for (auto const& kv : bucket_map) {
+    if (kv.first >= bucket) {
+      if (kv.first < best_ge_bucket) {
+        best_ge_bucket = kv.first;
+        best_ge = kv.second;
+      }
+    } else {
+      if (kv.first > best_lt_bucket) {
+        best_lt_bucket = kv.first;
+        best_lt = kv.second;
+      }
+    }
+  }
+  if (best_ge_bucket != std::numeric_limits<int>::max()) {
+    return best_ge;
+  }
+  if (best_lt_bucket >= 0) {
+    return best_lt;
   }
   return std::nullopt;
 }

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemm_profiler.h
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemm_profiler.h
@@ -90,12 +90,21 @@ class MoeGemmProfiler {
     sm_ = sm;
   }
 
-  // Profile tactics for a GEMM problem using GemmProfilerBackend
-  void profileTactics(CutlassMoeFCRunnerInterface* runner, onnxruntime::llm::nvinfer::DataType dtype,
+  // Profile tactics for a GEMM problem using GemmProfilerBackend.
+  // Profiles (and caches) the best config for the M bucket that contains dims.maxM. The first
+  // call for a new (GemmId, M-bucket) pair runs the profiler; subsequent calls return immediately.
+  // The data/weight types are taken from gemmId, so no separate dtype argument is needed.
+  void profileTactics(CutlassMoeFCRunnerInterface* runner,
                       weight_only::GemmDims const& dims, MoeGemmId const& gemmId);
 
-  // Get best config for a given M and GemmId
+  // Get best config for a given M and GemmId. Selects the config profiled for the M bucket that
+  // contains m, so small-M (decode) GEMMs use a decode-tuned tile instead of a prefill-tuned one.
   std::optional<Config> getBestConfig(int m, MoeGemmId const& id) const;
+
+  // Snap a row count M to a representative profiling bucket. Decode (small M) and prefill
+  // (large M) favor very different CUTLASS tile shapes, so we keep a separate best config per
+  // bucket rather than reusing a single shape-only config. Buckets are powers of two.
+  static int bucketM(int64_t m);
 
  private:
   // Initialize backend for profiling
@@ -108,8 +117,8 @@ class MoeGemmProfiler {
   GemmProfilerBackend backend_;
   CutlassMoeFCRunnerInterface* runner_{nullptr};
 
-  // Cached results: (M, GemmId) -> best config
-  mutable std::unordered_map<MoeGemmId, std::optional<Config>, MoeGemmIdHash> config_cache_;
+  // Cached results: GemmId -> (M bucket -> best config)
+  mutable std::unordered_map<MoeGemmId, std::unordered_map<int, std::optional<Config>>, MoeGemmIdHash> config_cache_;
 
   // Profiler parameters
   int num_experts_{0};

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemv.cu
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemv.cu
@@ -133,12 +133,17 @@ static constexpr int kThreads = 128;
 // int4 ColumnMajorInterleave (Sm80) tile width along N.
 static constexpr int kTileSizeK = 64;
 static constexpr int kInt4Interleave = 128 * 8 / (kTileSizeK * 4);  // = 4
+static constexpr int64_t kMaxProfiledExpandedRows = 2;
+static constexpr int64_t kMinProfiledProblemDim = 1024;
 
 bool is_moe_gemv_supported(int sm, int64_t expanded_num_rows, int64_t n, int64_t k) {
   if (sm < 80) {
     return false;
   }
-  if (expanded_num_rows <= 0 || expanded_num_rows > 64) {
+  if (expanded_num_rows <= 0 || expanded_num_rows > kMaxProfiledExpandedRows) {
+    return false;
+  }
+  if (n < kMinProfiledProblemDim || k < kMinProfiledProblemDim) {
     return false;
   }
   // n must tile evenly; k must tile evenly into StepK (32 for int4) along interleaved-K.

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemv.cu
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemv.cu
@@ -395,7 +395,6 @@ template void launch_moe_gemv_int4_per_channel<__nv_bfloat16>(__nv_bfloat16 cons
 template void launch_moe_gemv_int4_per_channel_interleaved_swiglu<half>(
     half const*, uint8_t const*, half const*, half const*, half*, int64_t const*, int const*, int, int64_t,
     int64_t, int64_t, int, cutlass_kernels::ActivationParams, cudaStream_t);
-
 }  // namespace moe_gemv
 }  // namespace kernels
 }  // namespace onnxruntime::llm

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemv.cu
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemv.cu
@@ -1,0 +1,195 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "contrib_ops/cuda/llm/moe_gemm/moe_gemv.h"
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+
+#include "core/common/common.h"
+#include "contrib_ops/cuda/llm/fpA_intB_gemv/dispatcher.h"
+
+namespace onnxruntime::llm {
+namespace kernels {
+namespace fpA_intB_gemv {
+
+// MoE batched GEMV kernel. One thread-block (CtaM = 1 row) processes a single
+// expanded row; the row's expert determines the weight/scale/bias base pointers.
+// Mirrors the dense fpA_intB_gemv `kernel<>` body for GroupSize=0 (per-channel),
+// EnableActScale=false, EnableZero=false, ApplyAlphaInAdvance=false.
+template <typename Details, int CtaN, int Threads, bool EnableBias,
+          typename TypeA = typename Details::TypeDetailsA::Type>
+__global__ void moe_gemv_kernel(TypeA* act, uint8_t* weight, TypeA* scales, TypeA* bias, TypeA* out,
+                                int64_t const* expert_first_token_offset, int num_experts,
+                                int64_t weight_expert_stride, int n, int k) {
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 750))
+  using AccessTypeA = typename Details::AccessTypeA;
+  using AccessTypeW = typename Details::AccessTypeW;
+
+  static constexpr bool Mandatory = true;
+  static constexpr int CtaM = 1;
+  static constexpr int StepK = Details::kStepK;
+  static constexpr int CtaK = StepK * Threads;
+  static_assert(CtaN % 2 == 0);
+
+  int const row = blockIdx.x;
+
+  // Resolve the expert owning this permuted row via a small linear scan over the
+  // monotonically increasing offsets (num_experts is small, value broadcasts).
+  int expert = 0;
+#pragma unroll 1
+  for (int e = 0; e < num_experts; ++e) {
+    if (row >= static_cast<int>(expert_first_token_offset[e + 1])) {
+      expert = e + 1;
+    } else {
+      break;
+    }
+  }
+
+  weight += expert * weight_expert_stride;
+  scales += static_cast<int64_t>(expert) * n;
+  if constexpr (EnableBias) {
+    bias += static_cast<int64_t>(expert) * n;
+  }
+
+  int const origin_k = k, interleaved_k = k * Details::kInterleave;
+
+  int const tile_id_m = row, tile_id_n = blockIdx.y, tid = threadIdx.x;
+  int const offset_m = tile_id_m * CtaM, interleaved_offset_n = tile_id_n * CtaN;
+  int const real_offset_n = interleaved_offset_n * Details::kInterleave +
+                            ((tid * StepK / Details::LayoutDetails::kTileSize) % Details::kInterleave);
+  int const real_offset_k =
+      (tid * StepK / (Details::kInterleave * Details::LayoutDetails::kTileSize)) * Details::LayoutDetails::kTileSize +
+      ((tid * StepK) % Details::LayoutDetails::kTileSize);
+
+  GMemIterator<Mandatory, AccessTypeA, CtaM, Details::kAccessNumA, TypeA> act_iterator(
+      act, offset_m * origin_k + real_offset_k, CtaK / Details::kInterleave, origin_k);
+  GMemIterator<Mandatory, AccessTypeW, CtaN, Details::kAccessNumW, uint8_t> weight_iterator(
+      weight, (interleaved_offset_n * interleaved_k + tid * StepK) / Details::kElemsPerByteW,
+      CtaK / Details::kElemsPerByteW, interleaved_k / Details::kElemsPerByteW);
+  // Per-channel scales: constant along K (step 0), indexed by output column.
+  GMemIterator<Mandatory, TypeA, CtaN, 1, TypeA> scales_iterator(scales, real_offset_n, 0, Details::kInterleave);
+
+  out += offset_m * n + tile_id_n * CtaN * Details::kInterleave;
+  if constexpr (EnableBias) {
+    bias += tile_id_n * CtaN * Details::kInterleave;
+  }
+
+  TypeA tile_acc[CtaM * CtaN];
+  fill<CtaM * CtaN>(tile_acc, static_cast<TypeA>(0.f));
+
+  TypeA vec_scale[CtaN];
+#pragma unroll
+  for (int i = 0; i < CtaN; ++i) {
+    scales_iterator.load(vec_scale + i, 0, i);
+  }
+
+  for (int idx_k = tid * StepK, iter = 0; idx_k < interleaved_k; idx_k += CtaK, ++iter) {
+    TypeA tile_a[StepK], tile_w[StepK], tile_w_pack2[CtaN * StepK];
+    uint8_t tile_w_quantized[StepK / Details::kElemsPerByteW];
+#pragma unroll
+    for (int i = 0; i < CtaN; ++i) {
+      weight_iterator.load(tile_w_quantized, iter, i);
+      dequantize<Details, 1, StepK, false, false>(tile_w, tile_w_quantized, vec_scale + i, nullptr, 1.0f);
+      pack_to_vec2<Details, StepK>(tile_w_pack2, tile_w, i);
+    }
+#pragma unroll
+    for (int i = 0; i < CtaM; ++i) {
+      act_iterator.load(tile_a, iter, i);
+      mma<Details, 1, CtaN, StepK>(tile_acc + i * CtaN, tile_w_pack2, tile_a);
+    }
+  }
+  epilogue<Details, CtaM, CtaN, Threads, EnableBias, false>(out, n, tile_acc, bias, 1.0f);
+#endif
+}
+
+template <typename Details, int CtaN, int Threads, typename TypeA>
+static void launch_moe_gemv(TypeA* act, uint8_t* weight, TypeA* scales, TypeA* bias, TypeA* out,
+                            int64_t const* expert_first_token_offset, int num_experts, int64_t expanded_num_rows,
+                            int64_t n, int64_t k, cudaStream_t stream) {
+  int64_t const weight_expert_stride = n * k / Details::kElemsPerByteW;
+  dim3 grid(static_cast<unsigned>(expanded_num_rows), static_cast<unsigned>(n / (CtaN * Details::kInterleave)));
+  dim3 block(Threads);
+  if (bias != nullptr) {
+    moe_gemv_kernel<Details, CtaN, Threads, true><<<grid, block, 0, stream>>>(
+        act, weight, scales, bias, out, expert_first_token_offset, num_experts, weight_expert_stride,
+        static_cast<int>(n), static_cast<int>(k));
+  } else {
+    moe_gemv_kernel<Details, CtaN, Threads, false><<<grid, block, 0, stream>>>(
+        act, weight, scales, bias, out, expert_first_token_offset, num_experts, weight_expert_stride,
+        static_cast<int>(n), static_cast<int>(k));
+  }
+}
+
+}  // namespace fpA_intB_gemv
+
+namespace moe_gemv {
+
+namespace fiv = onnxruntime::llm::kernels::fpA_intB_gemv;
+
+// CtaN/Threads match the dense per-channel (EnableZero=false) m-tile config.
+static constexpr int kCtaN = 8;
+static constexpr int kThreads = 128;
+// int4 ColumnMajorInterleave (Sm80) tile width along N.
+static constexpr int kTileSizeK = 64;
+static constexpr int kInt4Interleave = 128 * 8 / (kTileSizeK * 4);  // = 4
+
+bool is_moe_gemv_supported(int sm, int64_t expanded_num_rows, int64_t n, int64_t k) {
+  if (sm < 80) {
+    return false;
+  }
+  if (expanded_num_rows <= 0 || expanded_num_rows > 64) {
+    return false;
+  }
+  // n must tile evenly; k must tile evenly into StepK (32 for int4) along interleaved-K.
+  if (n % (kCtaN * kInt4Interleave) != 0) {
+    return false;
+  }
+  int64_t const interleaved_k = k * kInt4Interleave;
+  int const step_k = 128 / 4;  // kStepK for int4
+  if (interleaved_k % step_k != 0) {
+    return false;
+  }
+  return true;
+}
+
+template <typename T>
+struct DetailsForT;
+
+template <>
+struct DetailsForT<half> {
+  using Details = fiv::KernelDetails<fiv::FP16DetailsA, fiv::Int4DetailsW, fiv::ColumnMajorInterleaved, true, kTileSizeK>;
+  using TypeA = half;
+};
+
+template <>
+struct DetailsForT<__nv_bfloat16> {
+  using Details = fiv::KernelDetails<fiv::BF16DetailsA, fiv::Int4DetailsW, fiv::ColumnMajorInterleaved, true, kTileSizeK>;
+  using TypeA = __nv_bfloat16;
+};
+
+template <typename T>
+void launch_moe_gemv_int4_per_channel(T const* act, uint8_t const* weight, T const* scales, T const* bias, T* out,
+                                      int64_t const* expert_first_token_offset, int num_experts,
+                                      int64_t expanded_num_rows, int64_t n, int64_t k, int sm, cudaStream_t stream) {
+  ORT_UNUSED_PARAMETER(sm);
+  using Details = typename DetailsForT<T>::Details;
+  using TypeA = typename DetailsForT<T>::TypeA;
+  fiv::launch_moe_gemv<Details, kCtaN, kThreads, TypeA>(
+      const_cast<TypeA*>(reinterpret_cast<TypeA const*>(act)),
+      const_cast<uint8_t*>(weight),
+      const_cast<TypeA*>(reinterpret_cast<TypeA const*>(scales)),
+      const_cast<TypeA*>(reinterpret_cast<TypeA const*>(bias)),
+      reinterpret_cast<TypeA*>(out),
+      expert_first_token_offset, num_experts, expanded_num_rows, n, k, stream);
+}
+
+template void launch_moe_gemv_int4_per_channel<half>(half const*, uint8_t const*, half const*, half const*, half*,
+                                                     int64_t const*, int, int64_t, int64_t, int64_t, int, cudaStream_t);
+template void launch_moe_gemv_int4_per_channel<__nv_bfloat16>(__nv_bfloat16 const*, uint8_t const*, __nv_bfloat16 const*,
+                                                              __nv_bfloat16 const*, __nv_bfloat16*, int64_t const*, int,
+                                                              int64_t, int64_t, int64_t, int, cudaStream_t);
+
+}  // namespace moe_gemv
+}  // namespace kernels
+}  // namespace onnxruntime::llm

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemv.cu
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemv.cu
@@ -20,7 +20,8 @@ namespace fpA_intB_gemv {
 template <typename Details, int CtaN, int Threads, bool EnableBias,
           typename TypeA = typename Details::TypeDetailsA::Type>
 __global__ void moe_gemv_kernel(TypeA* act, uint8_t* weight, TypeA* scales, TypeA* bias, TypeA* out,
-                                int64_t const* expert_first_token_offset, int num_experts,
+                                int64_t const* expert_first_token_offset, int const* permuted_row_to_expert,
+                                int num_experts,
                                 int64_t weight_expert_stride, int n, int k) {
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 750))
   using AccessTypeA = typename Details::AccessTypeA;
@@ -34,16 +35,18 @@ __global__ void moe_gemv_kernel(TypeA* act, uint8_t* weight, TypeA* scales, Type
 
   int const row = blockIdx.x;
 
-  // Resolve the expert owning this permuted row via a small linear scan over the
-  // monotonically increasing offsets (num_experts is small, value broadcasts).
-  int expert = 0;
+  int expert = permuted_row_to_expert != nullptr ? permuted_row_to_expert[row] : 0;
+  // Fallback path for prologues that have not materialized the row-to-expert map.
 #pragma unroll 1
-  for (int e = 0; e < num_experts; ++e) {
+  for (int e = 0; e < num_experts && permuted_row_to_expert == nullptr; ++e) {
     if (row >= static_cast<int>(expert_first_token_offset[e + 1])) {
       expert = e + 1;
-    } else {
-      break;
+      continue;
     }
+    break;
+  }
+  if (expert < 0 || expert >= num_experts) {
+    return;
   }
 
   weight += expert * weight_expert_stride;
@@ -105,18 +108,19 @@ __global__ void moe_gemv_kernel(TypeA* act, uint8_t* weight, TypeA* scales, Type
 
 template <typename Details, int CtaN, int Threads, typename TypeA>
 static void launch_moe_gemv(TypeA* act, uint8_t* weight, TypeA* scales, TypeA* bias, TypeA* out,
-                            int64_t const* expert_first_token_offset, int num_experts, int64_t expanded_num_rows,
-                            int64_t n, int64_t k, cudaStream_t stream) {
+                            int64_t const* expert_first_token_offset, int const* permuted_row_to_expert,
+                            int num_experts, int64_t expanded_num_rows, int64_t n, int64_t k,
+                            cudaStream_t stream) {
   int64_t const weight_expert_stride = n * k / Details::kElemsPerByteW;
   dim3 grid(static_cast<unsigned>(expanded_num_rows), static_cast<unsigned>(n / (CtaN * Details::kInterleave)));
   dim3 block(Threads);
   if (bias != nullptr) {
     moe_gemv_kernel<Details, CtaN, Threads, true><<<grid, block, 0, stream>>>(
-        act, weight, scales, bias, out, expert_first_token_offset, num_experts, weight_expert_stride,
+        act, weight, scales, bias, out, expert_first_token_offset, permuted_row_to_expert, num_experts, weight_expert_stride,
         static_cast<int>(n), static_cast<int>(k));
   } else {
     moe_gemv_kernel<Details, CtaN, Threads, false><<<grid, block, 0, stream>>>(
-        act, weight, scales, bias, out, expert_first_token_offset, num_experts, weight_expert_stride,
+        act, weight, scales, bias, out, expert_first_token_offset, permuted_row_to_expert, num_experts, weight_expert_stride,
         static_cast<int>(n), static_cast<int>(k));
   }
 }
@@ -180,7 +184,8 @@ struct DetailsForT<__nv_bfloat16> {
 
 template <typename T>
 void launch_moe_gemv_int4_per_channel(T const* act, uint8_t const* weight, T const* scales, T const* bias, T* out,
-                                      int64_t const* expert_first_token_offset, int num_experts,
+                                      int64_t const* expert_first_token_offset, int const* permuted_row_to_expert,
+                                      int num_experts,
                                       int64_t expanded_num_rows, int64_t n, int64_t k, int sm, cudaStream_t stream) {
   ORT_UNUSED_PARAMETER(sm);
   using Details = typename DetailsForT<T>::Details;
@@ -191,14 +196,16 @@ void launch_moe_gemv_int4_per_channel(T const* act, uint8_t const* weight, T con
       const_cast<TypeA*>(reinterpret_cast<TypeA const*>(scales)),
       const_cast<TypeA*>(reinterpret_cast<TypeA const*>(bias)),
       reinterpret_cast<TypeA*>(out),
-      expert_first_token_offset, num_experts, expanded_num_rows, n, k, stream);
+      expert_first_token_offset, permuted_row_to_expert, num_experts, expanded_num_rows, n, k, stream);
 }
 
 template void launch_moe_gemv_int4_per_channel<half>(half const*, uint8_t const*, half const*, half const*, half*,
-                                                     int64_t const*, int, int64_t, int64_t, int64_t, int, cudaStream_t);
+                                                     int64_t const*, int const*, int, int64_t, int64_t, int64_t,
+                                                     int, cudaStream_t);
 template void launch_moe_gemv_int4_per_channel<__nv_bfloat16>(__nv_bfloat16 const*, uint8_t const*, __nv_bfloat16 const*,
-                                                              __nv_bfloat16 const*, __nv_bfloat16*, int64_t const*, int,
-                                                              int64_t, int64_t, int64_t, int, cudaStream_t);
+                                                              __nv_bfloat16 const*, __nv_bfloat16*, int64_t const*,
+                                                              int const*, int, int64_t, int64_t, int64_t, int,
+                                                              cudaStream_t);
 
 }  // namespace moe_gemv
 }  // namespace kernels

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemv.cu
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemv.cu
@@ -133,8 +133,9 @@ static constexpr int kThreads = 128;
 // int4 ColumnMajorInterleave (Sm80) tile width along N.
 static constexpr int kTileSizeK = 64;
 static constexpr int kInt4Interleave = 128 * 8 / (kTileSizeK * 4);  // = 4
-static constexpr int64_t kMaxProfiledExpandedRows = 2;
-static constexpr int64_t kMinProfiledProblemDim = 1024;
+static constexpr int64_t kMaxProfiledExpandedRows = 8;
+static constexpr int64_t kMinProfiledProblemDim = 512;
+static constexpr int64_t kMinProfiledProblemDimForExpandedRowsAbove4 = 704;
 
 bool is_moe_gemv_supported(int sm, int64_t expanded_num_rows, int64_t n, int64_t k) {
   if (sm < 80) {
@@ -144,6 +145,10 @@ bool is_moe_gemv_supported(int sm, int64_t expanded_num_rows, int64_t n, int64_t
     return false;
   }
   if (n < kMinProfiledProblemDim || k < kMinProfiledProblemDim) {
+    return false;
+  }
+  if (expanded_num_rows > 4 &&
+      (n < kMinProfiledProblemDimForExpandedRowsAbove4 || k < kMinProfiledProblemDimForExpandedRowsAbove4)) {
     return false;
   }
   // n must tile evenly; k must tile evenly into StepK (32 for int4) along interleaved-K.

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemv.cu
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemv.cu
@@ -106,6 +106,152 @@ __global__ void moe_gemv_kernel(TypeA* act, uint8_t* weight, TypeA* scales, Type
 #endif
 }
 
+template <typename Details, int CtaM, int CtaN, int Threads, bool EnableBias,
+          typename TypeA = typename Details::TypeDetailsA::Type>
+__device__ __forceinline__ void swiglu_epilogue(void* out, void* tile_acc, void* bias,
+                                                cutlass_kernels::ActivationParams activation_params) {
+  static constexpr int Interleave = Details::kInterleave;
+  static constexpr int ThreadsPerInterleavedTile = Details::kThreadsPerInterleavedTile;
+  static constexpr int WarpSize = Details::kWarpSize;
+  static constexpr int WarpNum = Threads / WarpSize;
+  static constexpr int RawCols = CtaN * Interleave;
+  static_assert(CtaM == 1);
+  static_assert(RawCols % 2 == 0);
+  static_assert(Threads % WarpSize == 0);
+
+  __shared__ float shmem[CtaM * CtaN * Interleave * WarpNum];
+  int tid = threadIdx.x;
+  int warp_id = tid / WarpSize, lane_id = tid % WarpSize;
+#pragma unroll
+  for (int n = 0; n < CtaN; ++n) {
+    float v = static_cast<float>(reinterpret_cast<TypeA*>(tile_acc)[n]);
+    v = warp_reduce_sum<Interleave, ThreadsPerInterleavedTile>(v);
+    if (lane_id < Interleave * ThreadsPerInterleavedTile && lane_id % ThreadsPerInterleavedTile == 0) {
+      shmem[warp_id * RawCols + n * Interleave + lane_id / ThreadsPerInterleavedTile] = v;
+    }
+  }
+  __syncthreads();
+
+#pragma unroll
+  for (int pair = tid; pair < RawCols / 2; pair += Threads) {
+    int const gate_idx = pair * 2;
+    int const linear_idx = gate_idx + 1;
+    float gate = 0.f;
+    float linear = 0.f;
+#pragma unroll
+    for (int warp = 0; warp < WarpNum; ++warp) {
+      gate += shmem[warp * RawCols + gate_idx];
+      linear += shmem[warp * RawCols + linear_idx];
+    }
+    if constexpr (EnableBias) {
+      gate += static_cast<float>(reinterpret_cast<TypeA*>(bias)[gate_idx]);
+      linear += static_cast<float>(reinterpret_cast<TypeA*>(bias)[linear_idx]);
+    }
+    if (isfinite(activation_params.limit)) {
+      gate = fminf(gate, activation_params.limit);
+      linear = fminf(fmaxf(linear, -activation_params.limit), activation_params.limit);
+    }
+    linear += activation_params.beta;
+    float const sigmoid = 1.0f / (1.0f + expf(-activation_params.alpha * gate));
+    reinterpret_cast<TypeA*>(out)[pair] = static_cast<TypeA>(gate * sigmoid * linear);
+  }
+}
+
+template <typename Details, int CtaN, int Threads, bool EnableBias,
+          typename TypeA = typename Details::TypeDetailsA::Type>
+__global__ void moe_gemv_interleaved_swiglu_kernel(
+    TypeA* act, uint8_t* weight, TypeA* scales, TypeA* bias, TypeA* out,
+    int64_t const* expert_first_token_offset, int const* permuted_row_to_expert, int num_experts,
+    int64_t weight_expert_stride, int inter_size, int k, cutlass_kernels::ActivationParams activation_params) {
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 750))
+  using AccessTypeA = typename Details::AccessTypeA;
+  using AccessTypeW = typename Details::AccessTypeW;
+
+  static constexpr bool Mandatory = true;
+  static constexpr int CtaM = 1;
+  static constexpr int StepK = Details::kStepK;
+  static constexpr int CtaK = StepK * Threads;
+  static_assert(CtaN % 2 == 0);
+
+  int const row = blockIdx.x;
+
+  int expert = permuted_row_to_expert != nullptr ? permuted_row_to_expert[row] : 0;
+#pragma unroll 1
+  for (int e = 0; e < num_experts && permuted_row_to_expert == nullptr; ++e) {
+    if (row >= static_cast<int>(expert_first_token_offset[e + 1])) {
+      expert = e + 1;
+      continue;
+    }
+    break;
+  }
+  if (expert < 0 || expert >= num_experts) {
+    return;
+  }
+
+  float const* alpha = activation_params.swiglu_alpha;
+  float const* beta = activation_params.swiglu_beta;
+  float const* limit = activation_params.swiglu_limit;
+  activation_params.alpha = alpha ? alpha[expert] : activation_params.alpha;
+  activation_params.beta = beta ? beta[expert] : activation_params.beta;
+  activation_params.limit = limit ? limit[expert] : activation_params.limit;
+
+  int const n = inter_size * 2;
+  weight += expert * weight_expert_stride;
+  scales += static_cast<int64_t>(expert) * n;
+  if constexpr (EnableBias) {
+    bias += static_cast<int64_t>(expert) * n;
+  }
+
+  int const origin_k = k, interleaved_k = k * Details::kInterleave;
+
+  int const tile_id_m = row, tile_id_n = blockIdx.y, tid = threadIdx.x;
+  int const offset_m = tile_id_m * CtaM, interleaved_offset_n = tile_id_n * CtaN;
+  int const real_offset_n = interleaved_offset_n * Details::kInterleave +
+                            ((tid * StepK / Details::LayoutDetails::kTileSize) % Details::kInterleave);
+  int const real_offset_k =
+      (tid * StepK / (Details::kInterleave * Details::LayoutDetails::kTileSize)) * Details::LayoutDetails::kTileSize +
+      ((tid * StepK) % Details::LayoutDetails::kTileSize);
+
+  GMemIterator<Mandatory, AccessTypeA, CtaM, Details::kAccessNumA, TypeA> act_iterator(
+      act, offset_m * origin_k + real_offset_k, CtaK / Details::kInterleave, origin_k);
+  GMemIterator<Mandatory, AccessTypeW, CtaN, Details::kAccessNumW, uint8_t> weight_iterator(
+      weight, (interleaved_offset_n * interleaved_k + tid * StepK) / Details::kElemsPerByteW,
+      CtaK / Details::kElemsPerByteW, interleaved_k / Details::kElemsPerByteW);
+  GMemIterator<Mandatory, TypeA, CtaN, 1, TypeA> scales_iterator(scales, real_offset_n, 0, Details::kInterleave);
+
+  out += offset_m * inter_size + tile_id_n * CtaN * Details::kInterleave / 2;
+  if constexpr (EnableBias) {
+    bias += tile_id_n * CtaN * Details::kInterleave;
+  }
+
+  TypeA tile_acc[CtaM * CtaN];
+  fill<CtaM * CtaN>(tile_acc, static_cast<TypeA>(0.f));
+
+  TypeA vec_scale[CtaN];
+#pragma unroll
+  for (int i = 0; i < CtaN; ++i) {
+    scales_iterator.load(vec_scale + i, 0, i);
+  }
+
+  for (int idx_k = tid * StepK, iter = 0; idx_k < interleaved_k; idx_k += CtaK, ++iter) {
+    TypeA tile_a[StepK], tile_w[StepK], tile_w_pack2[CtaN * StepK];
+    uint8_t tile_w_quantized[StepK / Details::kElemsPerByteW];
+#pragma unroll
+    for (int i = 0; i < CtaN; ++i) {
+      weight_iterator.load(tile_w_quantized, iter, i);
+      dequantize<Details, 1, StepK, false, false>(tile_w, tile_w_quantized, vec_scale + i, nullptr, 1.0f);
+      pack_to_vec2<Details, StepK>(tile_w_pack2, tile_w, i);
+    }
+#pragma unroll
+    for (int i = 0; i < CtaM; ++i) {
+      act_iterator.load(tile_a, iter, i);
+      mma<Details, 1, CtaN, StepK>(tile_acc + i * CtaN, tile_w_pack2, tile_a);
+    }
+  }
+  swiglu_epilogue<Details, CtaM, CtaN, Threads, EnableBias>(out, tile_acc, bias, activation_params);
+#endif
+}
+
 template <typename Details, int CtaN, int Threads, typename TypeA>
 static void launch_moe_gemv(TypeA* act, uint8_t* weight, TypeA* scales, TypeA* bias, TypeA* out,
                             int64_t const* expert_first_token_offset, int const* permuted_row_to_expert,
@@ -122,6 +268,27 @@ static void launch_moe_gemv(TypeA* act, uint8_t* weight, TypeA* scales, TypeA* b
     moe_gemv_kernel<Details, CtaN, Threads, false><<<grid, block, 0, stream>>>(
         act, weight, scales, bias, out, expert_first_token_offset, permuted_row_to_expert, num_experts,
         weight_expert_stride, static_cast<int>(n), static_cast<int>(k));
+  }
+}
+
+template <typename Details, int CtaN, int Threads, typename TypeA>
+static void launch_moe_gemv_interleaved_swiglu(
+    TypeA* act, uint8_t* weight, TypeA* scales, TypeA* bias, TypeA* out,
+    int64_t const* expert_first_token_offset, int const* permuted_row_to_expert, int num_experts,
+    int64_t expanded_num_rows, int64_t inter_size, int64_t k,
+    cutlass_kernels::ActivationParams activation_params, cudaStream_t stream) {
+  int64_t const n = inter_size * 2;
+  int64_t const weight_expert_stride = n * k / Details::kElemsPerByteW;
+  dim3 grid(static_cast<unsigned>(expanded_num_rows), static_cast<unsigned>(n / (CtaN * Details::kInterleave)));
+  dim3 block(Threads);
+  if (bias != nullptr) {
+    moe_gemv_interleaved_swiglu_kernel<Details, CtaN, Threads, true><<<grid, block, 0, stream>>>(
+        act, weight, scales, bias, out, expert_first_token_offset, permuted_row_to_expert, num_experts,
+        weight_expert_stride, static_cast<int>(inter_size), static_cast<int>(k), activation_params);
+  } else {
+    moe_gemv_interleaved_swiglu_kernel<Details, CtaN, Threads, false><<<grid, block, 0, stream>>>(
+        act, weight, scales, bias, out, expert_first_token_offset, permuted_row_to_expert, num_experts,
+        weight_expert_stride, static_cast<int>(inter_size), static_cast<int>(k), activation_params);
   }
 }
 
@@ -199,6 +366,25 @@ void launch_moe_gemv_int4_per_channel(T const* act, uint8_t const* weight, T con
       expert_first_token_offset, permuted_row_to_expert, num_experts, expanded_num_rows, n, k, stream);
 }
 
+template <typename T>
+void launch_moe_gemv_int4_per_channel_interleaved_swiglu(
+    T const* act, uint8_t const* weight, T const* scales, T const* bias, T* out,
+    int64_t const* expert_first_token_offset, int const* permuted_row_to_expert, int num_experts,
+    int64_t expanded_num_rows, int64_t inter_size, int64_t k, int sm,
+    cutlass_kernels::ActivationParams activation_params, cudaStream_t stream) {
+  ORT_UNUSED_PARAMETER(sm);
+  using Details = typename DetailsForT<T>::Details;
+  using TypeA = typename DetailsForT<T>::TypeA;
+  fiv::launch_moe_gemv_interleaved_swiglu<Details, kCtaN, kThreads, TypeA>(
+      const_cast<TypeA*>(reinterpret_cast<TypeA const*>(act)),
+      const_cast<uint8_t*>(weight),
+      const_cast<TypeA*>(reinterpret_cast<TypeA const*>(scales)),
+      const_cast<TypeA*>(reinterpret_cast<TypeA const*>(bias)),
+      reinterpret_cast<TypeA*>(out),
+      expert_first_token_offset, permuted_row_to_expert, num_experts, expanded_num_rows, inter_size, k,
+      activation_params, stream);
+}
+
 template void launch_moe_gemv_int4_per_channel<half>(half const*, uint8_t const*, half const*, half const*, half*,
                                                      int64_t const*, int const*, int, int64_t, int64_t, int64_t,
                                                      int, cudaStream_t);
@@ -206,6 +392,9 @@ template void launch_moe_gemv_int4_per_channel<__nv_bfloat16>(__nv_bfloat16 cons
                                                               __nv_bfloat16 const*, __nv_bfloat16*, int64_t const*,
                                                               int const*, int, int64_t, int64_t, int64_t, int,
                                                               cudaStream_t);
+template void launch_moe_gemv_int4_per_channel_interleaved_swiglu<half>(
+    half const*, uint8_t const*, half const*, half const*, half*, int64_t const*, int const*, int, int64_t,
+    int64_t, int64_t, int, cutlass_kernels::ActivationParams, cudaStream_t);
 
 }  // namespace moe_gemv
 }  // namespace kernels

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemv.cu
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemv.cu
@@ -116,12 +116,12 @@ static void launch_moe_gemv(TypeA* act, uint8_t* weight, TypeA* scales, TypeA* b
   dim3 block(Threads);
   if (bias != nullptr) {
     moe_gemv_kernel<Details, CtaN, Threads, true><<<grid, block, 0, stream>>>(
-        act, weight, scales, bias, out, expert_first_token_offset, permuted_row_to_expert, num_experts, weight_expert_stride,
-        static_cast<int>(n), static_cast<int>(k));
+        act, weight, scales, bias, out, expert_first_token_offset, permuted_row_to_expert, num_experts,
+        weight_expert_stride, static_cast<int>(n), static_cast<int>(k));
   } else {
     moe_gemv_kernel<Details, CtaN, Threads, false><<<grid, block, 0, stream>>>(
-        act, weight, scales, bias, out, expert_first_token_offset, permuted_row_to_expert, num_experts, weight_expert_stride,
-        static_cast<int>(n), static_cast<int>(k));
+        act, weight, scales, bias, out, expert_first_token_offset, permuted_row_to_expert, num_experts,
+        weight_expert_stride, static_cast<int>(n), static_cast<int>(k));
   }
 }
 

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemv.h
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemv.h
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Batched GEMV fast path for int4 weight-only per-channel MoE at small expanded
+// row counts (e.g. batch-1 decode with top_k experts). Each expanded row is a
+// single token-expert pair; one thread-block handles one row and offsets the
+// weight/scale/bias pointers by that row's expert. Reuses the device-side math
+// (layout, dequantize, mma, epilogue) from the dense fpA_intB_gemv kernel.
+
+#pragma once
+
+#include <cstdint>
+#include <cuda_runtime.h>
+
+namespace onnxruntime::llm {
+namespace kernels {
+namespace moe_gemv {
+
+// Returns true if the batched MoE GEMV fast path supports this problem shape.
+// Requirements: int4 per-channel weights, half/bf16 activations, sm >= 80,
+// small expanded_num_rows, and n divisible by the kernel tile width.
+bool is_moe_gemv_supported(int sm, int64_t expanded_num_rows, int64_t n, int64_t k);
+
+// Launches the int4 per-channel MoE GEMV.
+//   act:      [expanded_num_rows, k]  permuted activations (row-major)
+//   weight:   [num_experts, k, n] packed int4 in Sm80 ColumnMajorInterleave layout (uint8)
+//   scales:   [num_experts, n] per-channel scales (T)
+//   bias:     [num_experts, n] per-expert bias (T) or nullptr
+//   out:      [expanded_num_rows, n] (row-major)
+//   expert_first_token_offset: [num_experts + 1] prefix offsets of permuted rows
+// T is half or __nv_bfloat16.
+template <typename T>
+void launch_moe_gemv_int4_per_channel(
+    T const* act, uint8_t const* weight, T const* scales, T const* bias, T* out,
+    int64_t const* expert_first_token_offset, int num_experts, int64_t expanded_num_rows,
+    int64_t n, int64_t k, int sm, cudaStream_t stream);
+
+}  // namespace moe_gemv
+}  // namespace kernels
+}  // namespace onnxruntime::llm

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemv.h
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemv.h
@@ -12,6 +12,8 @@
 #include <cstdint>
 #include <cuda_runtime.h>
 
+#include "contrib_ops/cuda/llm/moe_gemm/common.h"
+
 namespace onnxruntime::llm {
 namespace kernels {
 namespace moe_gemv {
@@ -35,6 +37,17 @@ void launch_moe_gemv_int4_per_channel(
     T const* act, uint8_t const* weight, T const* scales, T const* bias, T* out,
     int64_t const* expert_first_token_offset, int const* permuted_row_to_expert, int num_experts, int64_t expanded_num_rows,
     int64_t n, int64_t k, int sm, cudaStream_t stream);
+
+// Launches the int4 per-channel MoE GEMV and fuses interleaved SwiGLU activation.
+//   weight/scales/bias use raw FC1 output width [num_experts, k, 2 * inter_size]
+//   out is post-activation [expanded_num_rows, inter_size]
+// Only interleaved SwiGLU layout (`swiglu_fusion == 1`) is supported.
+template <typename T>
+void launch_moe_gemv_int4_per_channel_interleaved_swiglu(
+    T const* act, uint8_t const* weight, T const* scales, T const* bias, T* out,
+    int64_t const* expert_first_token_offset, int const* permuted_row_to_expert, int num_experts, int64_t expanded_num_rows,
+    int64_t inter_size, int64_t k, int sm, cutlass_kernels::ActivationParams activation_params,
+    cudaStream_t stream);
 
 }  // namespace moe_gemv
 }  // namespace kernels

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemv.h
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemv.h
@@ -28,11 +28,12 @@ bool is_moe_gemv_supported(int sm, int64_t expanded_num_rows, int64_t n, int64_t
 //   bias:     [num_experts, n] per-expert bias (T) or nullptr
 //   out:      [expanded_num_rows, n] (row-major)
 //   expert_first_token_offset: [num_experts + 1] prefix offsets of permuted rows
+//   permuted_row_to_expert: [expanded_num_rows] local expert id for each permuted row, or nullptr to scan offsets
 // T is half or __nv_bfloat16.
 template <typename T>
 void launch_moe_gemv_int4_per_channel(
     T const* act, uint8_t const* weight, T const* scales, T const* bias, T* out,
-    int64_t const* expert_first_token_offset, int num_experts, int64_t expanded_num_rows,
+    int64_t const* expert_first_token_offset, int const* permuted_row_to_expert, int num_experts, int64_t expanded_num_rows,
     int64_t n, int64_t k, int sm, cudaStream_t stream);
 
 }  // namespace moe_gemv

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_kernels.cu
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_kernels.cu
@@ -133,6 +133,53 @@ bool tryLaunchMoeGemvInt4PerChannel(T const* input, WeightType const* weights, S
   }
 }
 
+template <typename T, typename WeightType, typename ScaleBiasType>
+bool tryLaunchMoeGemvInt4PerChannelInterleavedSwiGLU(
+    T const* input, WeightType const* weights, ScaleBiasType const* scales, ScaleBiasType const* biases, T* output,
+    int64_t const* expert_first_token_offset, int num_experts_per_node, int const* permuted_row_to_expert,
+    int64_t expanded_num_rows, int64_t inter_size, int64_t k, int sm, int group_size,
+    bool disabled, cutlass_kernels::ActivationParams activation_params, cudaStream_t stream) {
+  if constexpr (std::is_same_v<WeightType, cutlass::uint4b_t> &&
+                std::is_same_v<T, half> && std::is_same_v<ScaleBiasType, T>) {
+    if (disabled || MoeGemvDisabledByEnv() || group_size > 0) {
+      return false;
+    }
+    if (activation_params.swiglu_fusion != 1) {
+      return false;
+    }
+    if (activation_params.activation_type != ActivationType::Swiglu &&
+        activation_params.activation_type != ActivationType::SwigluBias) {
+      return false;
+    }
+    int64_t const n = inter_size * 2;
+    if (!onnxruntime::llm::kernels::moe_gemv::is_moe_gemv_supported(sm, expanded_num_rows, n, k)) {
+      return false;
+    }
+    onnxruntime::llm::kernels::moe_gemv::launch_moe_gemv_int4_per_channel_interleaved_swiglu<T>(
+        input, reinterpret_cast<uint8_t const*>(weights), scales, biases, output, expert_first_token_offset,
+        permuted_row_to_expert, num_experts_per_node, expanded_num_rows, inter_size, k, sm, activation_params, stream);
+    return true;
+  } else {
+    (void)input;
+    (void)weights;
+    (void)scales;
+    (void)biases;
+    (void)output;
+    (void)expert_first_token_offset;
+    (void)num_experts_per_node;
+    (void)permuted_row_to_expert;
+    (void)expanded_num_rows;
+    (void)inter_size;
+    (void)k;
+    (void)sm;
+    (void)group_size;
+    (void)disabled;
+    (void)activation_params;
+    (void)stream;
+    return false;
+  }
+}
+
 /**
  * Takes the input maps and prepares the expanded maps for min latency
  * @param num_active_experts_per_node: Number of active experts on current node
@@ -2277,20 +2324,32 @@ void CutlassMoeFCRunner<T, WeightType, OutputType, InputType, ScaleBiasType, Ena
       alpha_scale_ptr_array = computeFP8DequantScale(
           alpha_scale_ptr_array, num_experts_per_node, quant_params.groupwise.fc1.alpha, stream);
     }
-    // Run the GEMM with activation function overridden with `Identity`, we do the activation separately
-    // Fast path: int4 per-channel MoE GEMV for small expanded-row counts (e.g. batch-1 decode).
-    bool const fc1_did_gemv = tryLaunchMoeGemvInt4PerChannel<T, WeightType, ScaleBiasType>(
+    bool const fc1_did_fused_gemv = tryLaunchMoeGemvInt4PerChannelInterleavedSwiGLU<T, WeightType, ScaleBiasType>(
         input, fc1_expert_weights,
         quant_params.groupwise.group_size > 0
             ? static_cast<ScaleBiasType const*>(quant_params.groupwise.fc1.weight_scales)
             : fc1_int_scales,
-        fc1_expert_biases, static_cast<T*>(intermediate_result), expert_first_token_offset, num_experts_per_node,
-        permuted_row_to_expert, expanded_num_rows, /*n=*/static_cast<int64_t>(fc1_out_size), /*k=*/hidden_size,
-        onnxruntime::llm::common::getSMVersion(),
-        quant_params.groupwise.group_size,
+        fc1_expert_biases, output, expert_first_token_offset, num_experts_per_node,
+        permuted_row_to_expert, expanded_num_rows, inter_size, hidden_size,
+        onnxruntime::llm::common::getSMVersion(), quant_params.groupwise.group_size,
         /*disabled=*/use_ampere_activation_fusion || !bias_is_broadcast ||
             MoeGemvRejectedByProfiledInterSize(expanded_num_rows, inter_size),
-        stream);
+        activation_params, stream);
+
+    // Run the GEMM with activation function overridden with `Identity`, we do the activation separately.
+    // Fast path: int4 per-channel MoE GEMV for small expanded-row counts (e.g. batch-1 decode).
+    bool const fc1_did_gemv = fc1_did_fused_gemv || tryLaunchMoeGemvInt4PerChannel<T, WeightType, ScaleBiasType>(
+                                                        input, fc1_expert_weights,
+                                                        quant_params.groupwise.group_size > 0
+                                                            ? static_cast<ScaleBiasType const*>(quant_params.groupwise.fc1.weight_scales)
+                                                            : fc1_int_scales,
+                                                        fc1_expert_biases, static_cast<T*>(intermediate_result), expert_first_token_offset, num_experts_per_node,
+                                                        permuted_row_to_expert, expanded_num_rows, /*n=*/static_cast<int64_t>(fc1_out_size), /*k=*/hidden_size,
+                                                        onnxruntime::llm::common::getSMVersion(),
+                                                        quant_params.groupwise.group_size,
+                                                        /*disabled=*/use_ampere_activation_fusion || !bias_is_broadcast ||
+                                                            MoeGemvRejectedByProfiledInterSize(expanded_num_rows, inter_size),
+                                                        stream);
     if (!fc1_did_gemv) {
       auto universal_input = GroupedGemmInput<T, WeightType, OutputType, OutputType>{input,
                                                                                      total_tokens_including_expert, fc1_expert_weights,
@@ -2311,7 +2370,7 @@ void CutlassMoeFCRunner<T, WeightType, OutputType, InputType, ScaleBiasType, Ena
 
     sync_check_cuda_error(stream);
 
-    if (!use_ampere_activation_fusion) {
+    if (!use_ampere_activation_fusion && !fc1_did_fused_gemv) {
       using GatedActOutputType = std::conditional_t<use_w4afp8, ScaleBiasType, T>;
       if (is_gated_activation) {
         doGatedActivation<GatedActOutputType, UnfusedGemmOutputType>(

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_kernels.cu
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_kernels.cu
@@ -98,7 +98,8 @@ template <typename T, typename WeightType, typename ScaleBiasType>
 bool tryLaunchMoeGemvInt4PerChannel(T const* input, WeightType const* weights, ScaleBiasType const* scales,
                                     ScaleBiasType const* biases, T* output,
                                     int64_t const* expert_first_token_offset, int num_experts_per_node,
-                                    int64_t expanded_num_rows, int64_t n, int64_t k, int sm, int group_size,
+                                    int const* permuted_row_to_expert, int64_t expanded_num_rows,
+                                    int64_t n, int64_t k, int sm, int group_size,
                                     bool disabled, cudaStream_t stream) {
   if constexpr (std::is_same_v<WeightType, cutlass::uint4b_t> &&
                 std::is_same_v<T, half> && std::is_same_v<ScaleBiasType, T>) {
@@ -110,7 +111,7 @@ bool tryLaunchMoeGemvInt4PerChannel(T const* input, WeightType const* weights, S
     }
     onnxruntime::llm::kernels::moe_gemv::launch_moe_gemv_int4_per_channel<T>(
         input, reinterpret_cast<uint8_t const*>(weights), scales, biases, output, expert_first_token_offset,
-        num_experts_per_node, expanded_num_rows, n, k, sm, stream);
+        permuted_row_to_expert, num_experts_per_node, expanded_num_rows, n, k, sm, stream);
     return true;
   } else {
     (void)input;
@@ -120,6 +121,7 @@ bool tryLaunchMoeGemvInt4PerChannel(T const* input, WeightType const* weights, S
     (void)output;
     (void)expert_first_token_offset;
     (void)num_experts_per_node;
+    (void)permuted_row_to_expert;
     (void)expanded_num_rows;
     (void)n;
     (void)k;
@@ -332,6 +334,7 @@ void buildMinLatencyActiveExpertMaps(int* num_active_experts_per_node, float* ex
 template <int BLOCK_SIZE, int EXPERTS_PER_TOKEN, int LOG2_NUM_EXPERTS>
 __global__ void fusedBuildExpertMapsSortFirstTokenKernel(int const* const token_selected_experts,
                                                          int* const permuted_row_to_unpermuted_row, int* const unpermuted_row_to_permuted_row,
+                                                         int* const permuted_token_selected_experts,
                                                          int64_t* const expert_first_token_offset, int64_t const num_tokens, int const experts_per_token,
                                                          int const start_expert, int const end_expert, int const num_experts_per_node) {
   // Only using block wise collective so we can only have one block
@@ -402,6 +405,7 @@ __global__ void fusedBuildExpertMapsSortFirstTokenKernel(int const* const token_
       int const permuted_row = local_token_permuted_indices[i];
       permuted_row_to_unpermuted_row[permuted_row] = unpermuted_row;
       unpermuted_row_to_permuted_row[unpermuted_row] = permuted_row;
+      permuted_token_selected_experts[permuted_row] = local_token_selected_experts[i];
     }
   }
 
@@ -416,7 +420,8 @@ __global__ void fusedBuildExpertMapsSortFirstTokenKernel(int const* const token_
 
 template <int BLOCK_SIZE, int EXPERTS_PER_TOKEN, int LOG2_NUM_EXPERTS>
 bool fusedBuildExpertMapsSortFirstTokenDispatch(int const* token_selected_experts, int* permuted_row_to_unpermuted_row,
-                                                int* unpermuted_row_to_permuted_row, int64_t* expert_first_token_offset, int64_t const num_tokens,
+                                                int* unpermuted_row_to_permuted_row, int* permuted_token_selected_experts,
+                                                int64_t* expert_first_token_offset, int64_t const num_tokens,
                                                 int const num_experts_per_node, int const experts_per_token, int const start_expert, int const end_expert,
                                                 cudaStream_t stream) {
   ORT_ENFORCE(num_experts_per_node == (end_expert - start_expert),
@@ -454,15 +459,17 @@ bool fusedBuildExpertMapsSortFirstTokenDispatch(int const* token_selected_expert
 
   CUDA_CALL_THROW(cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, shared_size));
   CUDA_CALL_THROW(cudaLaunchKernelEx(&config, kernel, token_selected_experts, permuted_row_to_unpermuted_row,
-                                     unpermuted_row_to_permuted_row, expert_first_token_offset, num_tokens, experts_per_token, start_expert,
-                                     end_expert, num_experts_per_node));
+                                     unpermuted_row_to_permuted_row, permuted_token_selected_experts,
+                                     expert_first_token_offset, num_tokens, experts_per_token, start_expert, end_expert,
+                                     num_experts_per_node));
 
   return true;
 }
 
 template <int EXPERTS_PER_TOKEN, int LOG2_NUM_EXPERTS>
 bool fusedBuildExpertMapsSortFirstTokenBlockSize(int const* token_selected_experts, int* permuted_row_to_unpermuted_row,
-                                                 int* unpermuted_row_to_permuted_row, int64_t* expert_first_token_offset, int64_t const num_tokens,
+                                                 int* unpermuted_row_to_permuted_row, int* permuted_token_selected_experts,
+                                                 int64_t* expert_first_token_offset, int64_t const num_tokens,
                                                  int const num_experts_per_node, int const experts_per_token, int const start_expert, int const end_expert,
                                                  cudaStream_t stream) {
   int const block_size = num_tokens;
@@ -481,13 +488,14 @@ bool fusedBuildExpertMapsSortFirstTokenBlockSize(int const* token_selected_exper
   }
 
   return func(token_selected_experts, permuted_row_to_unpermuted_row, unpermuted_row_to_permuted_row,
-              expert_first_token_offset, num_tokens, num_experts_per_node, experts_per_token, start_expert, end_expert,
-              stream);
+              permuted_token_selected_experts, expert_first_token_offset, num_tokens, num_experts_per_node,
+              experts_per_token, start_expert, end_expert, stream);
 }
 
 template <int LOG2_NUM_EXPERTS>
 bool fusedBuildExpertMapsSortFirstTokenBlockSize(int const* token_selected_experts, int* permuted_row_to_unpermuted_row,
-                                                 int* unpermuted_row_to_permuted_row, int64_t* expert_first_token_offset, int64_t const num_tokens,
+                                                 int* unpermuted_row_to_permuted_row, int* permuted_token_selected_experts,
+                                                 int64_t* expert_first_token_offset, int64_t const num_tokens,
                                                  int const num_experts_per_node, int const experts_per_token, int const start_expert, int const end_expert,
                                                  cudaStream_t stream) {
   auto func = &fusedBuildExpertMapsSortFirstTokenBlockSize<1, LOG2_NUM_EXPERTS>;
@@ -518,12 +526,13 @@ bool fusedBuildExpertMapsSortFirstTokenBlockSize(int const* token_selected_exper
     }
   }
   return func(token_selected_experts, permuted_row_to_unpermuted_row, unpermuted_row_to_permuted_row,
-              expert_first_token_offset, num_tokens, num_experts_per_node, experts_per_token, start_expert, end_expert,
-              stream);
+              permuted_token_selected_experts, expert_first_token_offset, num_tokens, num_experts_per_node,
+              experts_per_token, start_expert, end_expert, stream);
 }
 
 bool fusedBuildExpertMapsSortFirstToken(int const* token_selected_experts, int* permuted_row_to_unpermuted_row,
-                                        int* unpermuted_row_to_permuted_row, int64_t* expert_first_token_offset, int64_t const num_tokens,
+                                        int* unpermuted_row_to_permuted_row, int* permuted_token_selected_experts,
+                                        int64_t* expert_first_token_offset, int64_t const num_tokens,
                                         int const num_experts_per_node, int const experts_per_token, int const start_expert, int const end_expert,
                                         cudaStream_t stream) {
   // We need enough bits to represent [0, num_experts_per_node+1] (inclusive) i.e. num_experts_per_node + 2 values
@@ -537,8 +546,9 @@ bool fusedBuildExpertMapsSortFirstToken(int const* token_selected_experts, int* 
                             &fusedBuildExpertMapsSortFirstTokenBlockSize<8>, &fusedBuildExpertMapsSortFirstTokenBlockSize<9>};
 
     return funcs[expert_log - 1](token_selected_experts, permuted_row_to_unpermuted_row,
-                                 unpermuted_row_to_permuted_row, expert_first_token_offset, num_tokens, num_experts_per_node,
-                                 experts_per_token, start_expert, end_expert, stream);
+                                 unpermuted_row_to_permuted_row, permuted_token_selected_experts,
+                                 expert_first_token_offset, num_tokens, num_experts_per_node, experts_per_token,
+                                 start_expert, end_expert, stream);
   }
   ORT_LLM_LOG_DEBUG(onnxruntime::MakeString("Experts per node ", num_experts_per_node, " does not have supported fused moe prologues"));
   return false;
@@ -2149,7 +2159,8 @@ void CutlassMoeFCRunner<T, WeightType, OutputType, InputType, ScaleBiasType, Ena
     TmaWarpSpecializedGroupedGemmInput::ElementSF* fc2_fp4_act_flat, QuantParams quant_params, int64_t const num_rows,
     int64_t const expanded_num_rows, int64_t const hidden_size, int64_t const inter_size,
     int const num_experts_per_node, ActivationType fc1_activation_type, float const** alpha_scale_ptr_array,
-    bool bias_is_broadcast, cudaStream_t stream, cutlass_extensions::CutlassGemmConfig config,
+    int const* permuted_row_to_expert, bool bias_is_broadcast,
+    cudaStream_t stream, cutlass_extensions::CutlassGemmConfig config,
     ActivationParameters activation_params) {
   bool const using_tma_ws_gemm1 = gemm_runner.isTmaWarpSpecialized(config);
   bool const is_gated_activation = isGatedActivation(fc1_activation_type);
@@ -2274,7 +2285,7 @@ void CutlassMoeFCRunner<T, WeightType, OutputType, InputType, ScaleBiasType, Ena
             ? static_cast<ScaleBiasType const*>(quant_params.groupwise.fc1.weight_scales)
             : fc1_int_scales,
         fc1_expert_biases, static_cast<T*>(intermediate_result), expert_first_token_offset, num_experts_per_node,
-        expanded_num_rows, /*n=*/static_cast<int64_t>(fc1_out_size), /*k=*/hidden_size,
+        permuted_row_to_expert, expanded_num_rows, /*n=*/static_cast<int64_t>(fc1_out_size), /*k=*/hidden_size,
         onnxruntime::llm::common::getSMVersion(),
         quant_params.groupwise.group_size,
         /*disabled=*/use_ampere_activation_fusion || !bias_is_broadcast ||
@@ -2334,6 +2345,7 @@ void CutlassMoeFCRunner<T, WeightType, OutputType, InputType, ScaleBiasType, Ena
     int const* const token_selected_experts, int64_t const* const num_valid_tokens_ptr, int64_t const num_rows,
     int64_t const expanded_num_rows, int64_t const hidden_size, int64_t const inter_size,
     int const num_experts_per_node, int64_t const k, float const** alpha_scale_ptr_array,
+    int const* permuted_row_to_expert,
     cudaStream_t stream, MOEParallelismConfig parallelism_config,
     cutlass_extensions::CutlassGemmConfig config) {
   int64_t const* total_tokens_including_expert = expert_first_token_offset + 1;
@@ -2373,7 +2385,7 @@ void CutlassMoeFCRunner<T, WeightType, OutputType, InputType, ScaleBiasType, Ena
           ? static_cast<ScaleBiasType const*>(quant_params.groupwise.fc2.weight_scales)
           : fc2_int_scales,
       /*biases*/ nullptr, static_cast<T*>(gemm_output), expert_first_token_offset, num_experts_per_node,
-      expanded_num_rows, /*n=*/hidden_size, /*k=*/inter_size, onnxruntime::llm::common::getSMVersion(),
+      permuted_row_to_expert, expanded_num_rows, /*n=*/hidden_size, /*k=*/inter_size, onnxruntime::llm::common::getSMVersion(),
       quant_params.groupwise.group_size,
       /*disabled=*/using_tma_ws_gemm2 || MoeGemvRejectedByProfiledInterSize(expanded_num_rows, inter_size), stream);
   if (!fc2_did_gemv) {
@@ -2546,8 +2558,10 @@ void CutlassMoeFCRunner<T, WeightType, OutputType, InputType, ScaleBiasType, Ena
     if (!use_w4afp8) {
       // WAR: fusedBuildExpertMapsSortFirstToken kernel will lead to illegal memory access for W4AFP8
       fused_prologue_result = fusedBuildExpertMapsSortFirstToken(token_selected_experts,
-                                                                 permuted_row_to_unpermuted_row_, unpermuted_row_to_permuted_row, expert_first_token_offset_, num_rows,
-                                                                 num_experts_per_node, experts_per_token, start_expert, end_expert, stream);
+                                                                 permuted_row_to_unpermuted_row_, unpermuted_row_to_permuted_row,
+                                                                 permuted_token_selected_experts_, expert_first_token_offset_, num_rows,
+                                                                 num_experts_per_node, experts_per_token, start_expert, end_expert,
+                                                                 stream);
     }
 
     if (!fused_prologue_result) {
@@ -2587,7 +2601,8 @@ void CutlassMoeFCRunner<T, WeightType, OutputType, InputType, ScaleBiasType, Ena
                 expert_first_token_offset_, gemm1_tma_ws_input, fc1_expert_weights, fc1_expert_biases, num_valid_tokens_ptr,
                 fc1_int_scales, fc1_fp8_dequant, use_wfp4afp8 ? fc2_wfp4afp8_quant_scale : fc2_fp8_quant,
                 fc1_fp4_act_scale_, fc2_fp4_act_scale_, quant_params, num_rows, expanded_num_rows, hidden_size, inter_size,
-                num_experts_per_node, fc1_activation_type, alpha_scale_ptr_array_fc1_, /*bias_is_broadcast=*/true, stream, *gemm1_config_,
+                num_experts_per_node, fc1_activation_type, alpha_scale_ptr_array_fc1_, permuted_token_selected_experts_,
+                /*bias_is_broadcast=*/true, stream, *gemm1_config_,
                 activation_params);
     sync_check_cuda_error(stream);
 
@@ -2599,7 +2614,7 @@ void CutlassMoeFCRunner<T, WeightType, OutputType, InputType, ScaleBiasType, Ena
                 fc2_fp8_dequant, fc2_fp4_act_scale_, quant_params, token_topk_unpermuted_scales,
                 permuted_token_final_scales_, unpermuted_row_to_permuted_row, permuted_row_to_unpermuted_row_,
                 token_selected_experts, num_valid_tokens_ptr, num_rows, expanded_num_rows, hidden_size, inter_size,
-                num_experts_per_node, experts_per_token, alpha_scale_ptr_array_fc2_, stream,
+                num_experts_per_node, experts_per_token, alpha_scale_ptr_array_fc2_, permuted_token_selected_experts_, stream,
                 parallelism_config, *gemm2_config_);
     sync_check_cuda_error(stream);
   }

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_kernels.cu
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_kernels.cu
@@ -84,6 +84,12 @@ inline bool MoeGemvDisabledByEnv() {
   return disabled;
 }
 
+inline bool MoeGemvRejectedByProfiledInterSize(int64_t expanded_num_rows, int64_t inter_size) {
+  static constexpr int64_t kMaxRowsForSmallInterSize = 4;
+  static constexpr int64_t kMinInterSizeForTop8 = 704;
+  return expanded_num_rows > kMaxRowsForSmallInterSize && inter_size < kMinInterSizeForTop8;
+}
+
 // Attempts the batched int4 per-channel MoE GEMV. Returns true if it ran (output
 // written), false if the configuration is unsupported and the caller must fall
 // back to the grouped GEMM. Compiles to a no-op (returns false) for any type
@@ -2271,7 +2277,9 @@ void CutlassMoeFCRunner<T, WeightType, OutputType, InputType, ScaleBiasType, Ena
         expanded_num_rows, /*n=*/static_cast<int64_t>(fc1_out_size), /*k=*/hidden_size,
         onnxruntime::llm::common::getSMVersion(),
         quant_params.groupwise.group_size,
-        /*disabled=*/use_ampere_activation_fusion || !bias_is_broadcast, stream);
+        /*disabled=*/use_ampere_activation_fusion || !bias_is_broadcast ||
+            MoeGemvRejectedByProfiledInterSize(expanded_num_rows, inter_size),
+        stream);
     if (!fc1_did_gemv) {
       auto universal_input = GroupedGemmInput<T, WeightType, OutputType, OutputType>{input,
                                                                                      total_tokens_including_expert, fc1_expert_weights,
@@ -2367,7 +2375,7 @@ void CutlassMoeFCRunner<T, WeightType, OutputType, InputType, ScaleBiasType, Ena
       /*biases*/ nullptr, static_cast<T*>(gemm_output), expert_first_token_offset, num_experts_per_node,
       expanded_num_rows, /*n=*/hidden_size, /*k=*/inter_size, onnxruntime::llm::common::getSMVersion(),
       quant_params.groupwise.group_size,
-      /*disabled=*/using_tma_ws_gemm2, stream);
+      /*disabled=*/using_tma_ws_gemm2 || MoeGemvRejectedByProfiledInterSize(expanded_num_rows, inter_size), stream);
   if (!fc2_did_gemv) {
     auto universal_input = GroupedGemmInput<T, WeightType, OutputType, OutputType>{input, total_tokens_including_expert,
                                                                                    fc2_expert_weights,

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_kernels.cu
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_kernels.cu
@@ -1632,24 +1632,24 @@ __global__ void finalizeMoeRoutingKernel(GemmOutputType const* expanded_permuted
 #endif
 }
 
-template <typename OutputType, class GemmOutputType, class ScaleBiasType, ScaleMode SCALE_MODE, int MaxExpertsPerToken>
+template <typename OutputType, class GemmOutputType, class ScaleBiasType, ScaleMode SCALE_MODE, int ExpertsPerToken>
 __global__ void finalizeMoeRoutingOneRowKernel(GemmOutputType const* expanded_permuted_rows,
                                                OutputType* reduced_unpermuted_output, ScaleBiasType const* bias, float const* scales,
                                                int const* unpermuted_row_to_permuted_row, int const* token_selected_experts,
-                                               int64_t const orig_cols, int64_t const experts_per_token,
-                                               int const num_experts_per_node, int const start_expert_id) {
+                                               int64_t const orig_cols, int const num_experts_per_node,
+                                               int const start_expert_id) {
   assert(orig_cols % 4 == 0);
-  assert(experts_per_token <= MaxExpertsPerToken);
+  static_assert(ExpertsPerToken > 0 && ExpertsPerToken <= 4);
 
   // Load 128-bits per thread, according to the smallest data type we read/write
   constexpr int64_t FINALIZE_ELEM_PER_THREAD = 128 / std::min(sizeof_bits<OutputType>::value, sizeof_bits<GemmOutputType>::value);
 
-  __shared__ int expanded_permuted_rows_for_topk[MaxExpertsPerToken];
-  __shared__ int expert_ids_for_topk[MaxExpertsPerToken];
-  __shared__ float row_scales_for_topk[MaxExpertsPerToken];
+  __shared__ int expanded_permuted_rows_for_topk[ExpertsPerToken];
+  __shared__ int expert_ids_for_topk[ExpertsPerToken];
+  __shared__ float row_scales_for_topk[ExpertsPerToken];
 
   int const tid = threadIdx.x;
-  if (tid < experts_per_token) {
+  if (tid < ExpertsPerToken) {
     int const expert_id = token_selected_experts[tid] - start_expert_id;
     expert_ids_for_topk[tid] = expert_id;
     expanded_permuted_rows_for_topk[tid] =
@@ -1677,7 +1677,8 @@ __global__ void finalizeMoeRoutingOneRowKernel(GemmOutputType const* expanded_pe
   for (int elem_index = start_offset; elem_index < num_elems_in_col; elem_index += stride) {
     ComputeElem thread_output;
     thread_output.fill(0);
-    for (int k_idx = 0; k_idx < experts_per_token; ++k_idx) {
+#pragma unroll
+    for (int k_idx = 0; k_idx < ExpertsPerToken; ++k_idx) {
       int const expanded_permuted_row = expanded_permuted_rows_for_topk[k_idx];
       if (expanded_permuted_row < 0) {
         continue;
@@ -1833,12 +1834,30 @@ void finalizeMoeRoutingKernelLauncher(GemmOutputType const* expanded_permuted_ro
     config.gridDim = blocks;
     config.blockDim = threads;
     if (num_rows == 1 && experts_per_token > 0 && experts_per_token <= 4) {
-      auto func = final_scales
-                      ? &finalizeMoeRoutingOneRowKernel<OutputType, GemmOutputType, ScaleBiasType, ScaleMode::DEFAULT, 4>
-                      : &finalizeMoeRoutingOneRowKernel<OutputType, GemmOutputType, ScaleBiasType, ScaleMode::NO_SCALE, 4>;
-      cudaLaunchKernelEx(&config, func, expanded_permuted_rows, reduced_unpermuted_output, bias_ptr, final_scales,
-                         unpermuted_row_to_permuted_row, token_selected_experts, cols, experts_per_token,
-                         num_experts_per_node_int, start_expert_id);
+#define LAUNCH_FINALIZE_ONE_ROW(EXPERTS_PER_TOKEN)                                                                                        \
+  do {                                                                                                                                    \
+    auto func = final_scales                                                                                                              \
+                    ? &finalizeMoeRoutingOneRowKernel<OutputType, GemmOutputType, ScaleBiasType, ScaleMode::DEFAULT, EXPERTS_PER_TOKEN>   \
+                    : &finalizeMoeRoutingOneRowKernel<OutputType, GemmOutputType, ScaleBiasType, ScaleMode::NO_SCALE, EXPERTS_PER_TOKEN>; \
+    cudaLaunchKernelEx(&config, func, expanded_permuted_rows, reduced_unpermuted_output, bias_ptr, final_scales,                          \
+                       unpermuted_row_to_permuted_row, token_selected_experts, cols, num_experts_per_node_int, start_expert_id);          \
+  } while (0)
+
+      switch (experts_per_token) {
+        case 1:
+          LAUNCH_FINALIZE_ONE_ROW(1);
+          break;
+        case 2:
+          LAUNCH_FINALIZE_ONE_ROW(2);
+          break;
+        case 3:
+          LAUNCH_FINALIZE_ONE_ROW(3);
+          break;
+        default:
+          LAUNCH_FINALIZE_ONE_ROW(4);
+          break;
+      }
+#undef LAUNCH_FINALIZE_ONE_ROW
     } else {
       auto func = final_scales
                       ? &finalizeMoeRoutingKernel<OutputType, GemmOutputType, ScaleBiasType, ScaleMode::DEFAULT>

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_kernels.cu
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_kernels.cu
@@ -87,7 +87,7 @@ inline bool MoeGemvDisabledByEnv() {
 // Attempts the batched int4 per-channel MoE GEMV. Returns true if it ran (output
 // written), false if the configuration is unsupported and the caller must fall
 // back to the grouped GEMM. Compiles to a no-op (returns false) for any type
-// combination other than (half|bf16 activations, uint4b_t weights, ScaleBias==T).
+// combination other than (half activations, uint4b_t weights, ScaleBias==T).
 template <typename T, typename WeightType, typename ScaleBiasType>
 bool tryLaunchMoeGemvInt4PerChannel(T const* input, WeightType const* weights, ScaleBiasType const* scales,
                                     ScaleBiasType const* biases, T* output,
@@ -95,8 +95,7 @@ bool tryLaunchMoeGemvInt4PerChannel(T const* input, WeightType const* weights, S
                                     int64_t expanded_num_rows, int64_t n, int64_t k, int sm, int group_size,
                                     bool disabled, cudaStream_t stream) {
   if constexpr (std::is_same_v<WeightType, cutlass::uint4b_t> &&
-                (std::is_same_v<T, half> || std::is_same_v<T, __nv_bfloat16>) &&
-                std::is_same_v<ScaleBiasType, T>) {
+                std::is_same_v<T, half> && std::is_same_v<ScaleBiasType, T>) {
     if (disabled || MoeGemvDisabledByEnv() || group_size > 0) {
       return false;
     }

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_kernels.cu
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_kernels.cu
@@ -1632,6 +1632,76 @@ __global__ void finalizeMoeRoutingKernel(GemmOutputType const* expanded_permuted
 #endif
 }
 
+template <typename OutputType, class GemmOutputType, class ScaleBiasType, ScaleMode SCALE_MODE, int MaxExpertsPerToken>
+__global__ void finalizeMoeRoutingOneRowKernel(GemmOutputType const* expanded_permuted_rows,
+                                               OutputType* reduced_unpermuted_output, ScaleBiasType const* bias, float const* scales,
+                                               int const* unpermuted_row_to_permuted_row, int const* token_selected_experts,
+                                               int64_t const orig_cols, int64_t const experts_per_token,
+                                               int const num_experts_per_node, int const start_expert_id) {
+  assert(orig_cols % 4 == 0);
+  assert(experts_per_token <= MaxExpertsPerToken);
+
+  // Load 128-bits per thread, according to the smallest data type we read/write
+  constexpr int64_t FINALIZE_ELEM_PER_THREAD = 128 / std::min(sizeof_bits<OutputType>::value, sizeof_bits<GemmOutputType>::value);
+
+  __shared__ int expanded_permuted_rows_for_topk[MaxExpertsPerToken];
+  __shared__ int expert_ids_for_topk[MaxExpertsPerToken];
+  __shared__ float row_scales_for_topk[MaxExpertsPerToken];
+
+  int const tid = threadIdx.x;
+  if (tid < experts_per_token) {
+    int const expert_id = token_selected_experts[tid] - start_expert_id;
+    expert_ids_for_topk[tid] = expert_id;
+    expanded_permuted_rows_for_topk[tid] =
+        (expert_id >= 0 && expert_id < num_experts_per_node) ? unpermuted_row_to_permuted_row[tid] : -1;
+    row_scales_for_topk[tid] = (SCALE_MODE == ScaleMode::NO_SCALE) ? 1.f : scales[tid];
+  }
+  __syncthreads();
+
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+  asm volatile("griddepcontrol.wait;");
+#endif
+
+  int64_t const start_offset = tid;
+  int64_t const stride = FINALIZE_THREADS_PER_BLOCK;
+  int64_t const num_elems_in_col = orig_cols / FINALIZE_ELEM_PER_THREAD;
+
+  using BiasElem = cutlass::Array<ScaleBiasType, FINALIZE_ELEM_PER_THREAD>;
+  using InputElem = cutlass::Array<GemmOutputType, FINALIZE_ELEM_PER_THREAD>;
+  using OutputElem = cutlass::Array<OutputType, FINALIZE_ELEM_PER_THREAD>;
+  using ComputeElem = cutlass::Array<float, FINALIZE_ELEM_PER_THREAD>;
+  auto const* bias_v = reinterpret_cast<BiasElem const*>(bias);
+  auto const* expanded_permuted_rows_v = reinterpret_cast<InputElem const*>(expanded_permuted_rows);
+  auto* reduced_row_ptr_v = reinterpret_cast<OutputElem*>(reduced_unpermuted_output);
+
+  for (int elem_index = start_offset; elem_index < num_elems_in_col; elem_index += stride) {
+    ComputeElem thread_output;
+    thread_output.fill(0);
+    for (int k_idx = 0; k_idx < experts_per_token; ++k_idx) {
+      int const expanded_permuted_row = expanded_permuted_rows_for_topk[k_idx];
+      if (expanded_permuted_row < 0) {
+        continue;
+      }
+
+      auto const* expanded_permuted_rows_row_ptr = expanded_permuted_rows_v + expanded_permuted_row * num_elems_in_col;
+
+      ComputeElem expert_result = arrayConvert<InputElem, ComputeElem>(expanded_permuted_rows_row_ptr[elem_index]);
+      if (bias) {
+        auto const* bias_ptr = bias_v + expert_ids_for_topk[k_idx] * num_elems_in_col;
+        expert_result = expert_result + arrayConvert<BiasElem, ComputeElem>(bias_ptr[elem_index]);
+      }
+
+      thread_output = thread_output + row_scales_for_topk[k_idx] * expert_result;
+    }
+
+    OutputElem output_elem = arrayConvert<ComputeElem, OutputElem>(thread_output);
+    reduced_row_ptr_v[elem_index] = output_elem;
+  }
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+  asm volatile("griddepcontrol.launch_dependents;");
+#endif
+}
+
 // Final kernel to unpermute and scale
 // This kernel unpermutes the original data, does the k-way reduction and performs the final skip connection.
 template <typename OutputType, class GemmOutputType, class ScaleBiasType, ScaleMode SCALE_MODE>
@@ -1762,12 +1832,21 @@ void finalizeMoeRoutingKernelLauncher(GemmOutputType const* expanded_permuted_ro
     int64_t const threads = FINALIZE_THREADS_PER_BLOCK;
     config.gridDim = blocks;
     config.blockDim = threads;
-    auto func = final_scales
-                    ? &finalizeMoeRoutingKernel<OutputType, GemmOutputType, ScaleBiasType, ScaleMode::DEFAULT>
-                    : &finalizeMoeRoutingKernel<OutputType, GemmOutputType, ScaleBiasType, ScaleMode::NO_SCALE>;
-    cudaLaunchKernelEx(&config, func, expanded_permuted_rows, reduced_unpermuted_output, bias_ptr, final_scales,
-                       unpermuted_row_to_permuted_row, token_selected_experts, cols, experts_per_token, num_experts_per_node_int,
-                       start_expert_id);
+    if (num_rows == 1 && experts_per_token > 0 && experts_per_token <= 4) {
+      auto func = final_scales
+                      ? &finalizeMoeRoutingOneRowKernel<OutputType, GemmOutputType, ScaleBiasType, ScaleMode::DEFAULT, 4>
+                      : &finalizeMoeRoutingOneRowKernel<OutputType, GemmOutputType, ScaleBiasType, ScaleMode::NO_SCALE, 4>;
+      cudaLaunchKernelEx(&config, func, expanded_permuted_rows, reduced_unpermuted_output, bias_ptr, final_scales,
+                         unpermuted_row_to_permuted_row, token_selected_experts, cols, experts_per_token,
+                         num_experts_per_node_int, start_expert_id);
+    } else {
+      auto func = final_scales
+                      ? &finalizeMoeRoutingKernel<OutputType, GemmOutputType, ScaleBiasType, ScaleMode::DEFAULT>
+                      : &finalizeMoeRoutingKernel<OutputType, GemmOutputType, ScaleBiasType, ScaleMode::NO_SCALE>;
+      cudaLaunchKernelEx(&config, func, expanded_permuted_rows, reduced_unpermuted_output, bias_ptr, final_scales,
+                         unpermuted_row_to_permuted_row, token_selected_experts, cols, experts_per_token, num_experts_per_node_int,
+                         start_expert_id);
+    }
   }
 }
 
@@ -2436,8 +2515,8 @@ void CutlassMoeFCRunner<T, WeightType, OutputType, InputType, ScaleBiasType, Ena
   }
 
   ActivationParameters activation_params;  // Here assume gemm2 has no activation
-  // Note: expanded_num_rows, to check this value, it's greater than num_rows * num_experts_per_node
-  // Fast path: int4 per-channel MoE GEMV (no bias here; fc2 bias applied in finalizeMoeRouting).
+                                           // Note: expanded_num_rows, to check this value, it's greater than num_rows * num_experts_per_node
+                                           // Fast path: int4 per-channel MoE GEMV (no bias here; fc2 bias applied in finalizeMoeRouting).
   bool const fc2_did_gemv = tryLaunchMoeGemvInt4PerChannel<T, WeightType, ScaleBiasType>(
       input, fc2_expert_weights,
       quant_params.groupwise.group_size > 0

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_kernels.cu
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_kernels.cu
@@ -15,6 +15,7 @@
  */
 
 #include <algorithm>
+#include <cstdlib>
 #include <cuda.h>
 #include <cuda_fp16.h>
 #include <float.h>
@@ -60,6 +61,7 @@
 #include "contrib_ops/cuda/llm/kernels/quantization.cuh"
 #include "contrib_ops/cuda/llm/moe_gemm/common.h"
 #include "contrib_ops/cuda/llm/moe_gemm/moe_kernels.h"
+#include "contrib_ops/cuda/llm/moe_gemm/moe_gemv.h"
 #include "contrib_ops/cuda/llm/moe_gemm/moe_util_kernels.h"
 #include "contrib_ops/cuda/llm/moe_gemm/moe_gemm_activation_kernels.cuh"
 #include "contrib_ops/cuda/llm/moe_gemm/moe_gemm_utils.cuh"
@@ -71,6 +73,59 @@ using namespace onnxruntime::llm::kernels;
 using namespace onnxruntime::llm::common;
 
 namespace onnxruntime::llm::kernels::cutlass_kernels {
+
+// Master switch for the int4 per-channel MoE GEMV fast path. Enabled by default;
+// set ORT_DISABLE_MOE_GEMV=1 to fall back to the CUTLASS grouped GEMM.
+inline bool MoeGemvDisabledByEnv() {
+  static bool const disabled = []() {
+    char const* v = std::getenv("ORT_DISABLE_MOE_GEMV");
+    return v != nullptr && v[0] == '1';
+  }();
+  return disabled;
+}
+
+// Attempts the batched int4 per-channel MoE GEMV. Returns true if it ran (output
+// written), false if the configuration is unsupported and the caller must fall
+// back to the grouped GEMM. Compiles to a no-op (returns false) for any type
+// combination other than (half|bf16 activations, uint4b_t weights, ScaleBias==T).
+template <typename T, typename WeightType, typename ScaleBiasType>
+bool tryLaunchMoeGemvInt4PerChannel(T const* input, WeightType const* weights, ScaleBiasType const* scales,
+                                    ScaleBiasType const* biases, T* output,
+                                    int64_t const* expert_first_token_offset, int num_experts_per_node,
+                                    int64_t expanded_num_rows, int64_t n, int64_t k, int sm, int group_size,
+                                    bool disabled, cudaStream_t stream) {
+  if constexpr (std::is_same_v<WeightType, cutlass::uint4b_t> &&
+                (std::is_same_v<T, half> || std::is_same_v<T, __nv_bfloat16>) &&
+                std::is_same_v<ScaleBiasType, T>) {
+    if (disabled || MoeGemvDisabledByEnv() || group_size > 0) {
+      return false;
+    }
+    if (!onnxruntime::llm::kernels::moe_gemv::is_moe_gemv_supported(sm, expanded_num_rows, n, k)) {
+      return false;
+    }
+    onnxruntime::llm::kernels::moe_gemv::launch_moe_gemv_int4_per_channel<T>(
+        input, reinterpret_cast<uint8_t const*>(weights), scales, biases, output, expert_first_token_offset,
+        num_experts_per_node, expanded_num_rows, n, k, sm, stream);
+    return true;
+  } else {
+    (void)input;
+    (void)weights;
+    (void)scales;
+    (void)biases;
+    (void)output;
+    (void)expert_first_token_offset;
+    (void)num_experts_per_node;
+    (void)expanded_num_rows;
+    (void)n;
+    (void)k;
+    (void)sm;
+    (void)group_size;
+    (void)disabled;
+    (void)stream;
+    return false;
+  }
+}
+
 /**
  * Takes the input maps and prepares the expanded maps for min latency
  * @param num_active_experts_per_node: Number of active experts on current node
@@ -2207,21 +2262,34 @@ void CutlassMoeFCRunner<T, WeightType, OutputType, InputType, ScaleBiasType, Ena
           alpha_scale_ptr_array, num_experts_per_node, quant_params.groupwise.fc1.alpha, stream);
     }
     // Run the GEMM with activation function overridden with `Identity`, we do the activation separately
-    auto universal_input = GroupedGemmInput<T, WeightType, OutputType, OutputType>{input,
-                                                                                   total_tokens_including_expert, fc1_expert_weights,
-                                                                                   /*scales*/ quant_params.groupwise.group_size > 0
-                                                                                       ? static_cast<ScaleBiasType const*>(quant_params.groupwise.fc1.weight_scales)
-                                                                                       : fc1_int_scales,
-                                                                                   /*zeros*/ quant_params.groupwise.group_size > 0
-                                                                                       ? static_cast<ScaleBiasType const*>(quant_params.groupwise.fc1.weight_zeros)
-                                                                                       : nullptr,
-                                                                                   fc1_expert_biases, static_cast<OutputType*>(use_ampere_activation_fusion ? output : intermediate_result),
-                                                                                   alpha_scale_ptr_array, /*occupancy*/ nullptr,
-                                                                                   use_ampere_activation_fusion ? fc1_activation_type : ActivationType::Identity, expanded_num_rows,
-                                                                                   /*N*/ int64_t(fc1_out_size),
-                                                                                   /*K*/ hidden_size, num_experts_per_node, quant_params.groupwise.group_size, bias_is_broadcast,
-                                                                                   use_ampere_activation_fusion, stream, activation_params, config};
-    gemm_runner.moeGemmBiasAct(universal_input, TmaWarpSpecializedGroupedGemmInput{});
+    // Fast path: int4 per-channel MoE GEMV for small expanded-row counts (e.g. batch-1 decode).
+    bool const fc1_did_gemv = tryLaunchMoeGemvInt4PerChannel<T, WeightType, ScaleBiasType>(
+        input, fc1_expert_weights,
+        quant_params.groupwise.group_size > 0
+            ? static_cast<ScaleBiasType const*>(quant_params.groupwise.fc1.weight_scales)
+            : fc1_int_scales,
+        fc1_expert_biases, static_cast<T*>(intermediate_result), expert_first_token_offset, num_experts_per_node,
+        expanded_num_rows, /*n=*/static_cast<int64_t>(fc1_out_size), /*k=*/hidden_size,
+        onnxruntime::llm::common::getSMVersion(),
+        quant_params.groupwise.group_size,
+        /*disabled=*/use_ampere_activation_fusion || !bias_is_broadcast, stream);
+    if (!fc1_did_gemv) {
+      auto universal_input = GroupedGemmInput<T, WeightType, OutputType, OutputType>{input,
+                                                                                     total_tokens_including_expert, fc1_expert_weights,
+                                                                                     /*scales*/ quant_params.groupwise.group_size > 0
+                                                                                         ? static_cast<ScaleBiasType const*>(quant_params.groupwise.fc1.weight_scales)
+                                                                                         : fc1_int_scales,
+                                                                                     /*zeros*/ quant_params.groupwise.group_size > 0
+                                                                                         ? static_cast<ScaleBiasType const*>(quant_params.groupwise.fc1.weight_zeros)
+                                                                                         : nullptr,
+                                                                                     fc1_expert_biases, static_cast<OutputType*>(use_ampere_activation_fusion ? output : intermediate_result),
+                                                                                     alpha_scale_ptr_array, /*occupancy*/ nullptr,
+                                                                                     use_ampere_activation_fusion ? fc1_activation_type : ActivationType::Identity, expanded_num_rows,
+                                                                                     /*N*/ int64_t(fc1_out_size),
+                                                                                     /*K*/ hidden_size, num_experts_per_node, quant_params.groupwise.group_size, bias_is_broadcast,
+                                                                                     use_ampere_activation_fusion, stream, activation_params, config};
+      gemm_runner.moeGemmBiasAct(universal_input, TmaWarpSpecializedGroupedGemmInput{});
+    }
 
     sync_check_cuda_error(stream);
 
@@ -2291,26 +2359,38 @@ void CutlassMoeFCRunner<T, WeightType, OutputType, InputType, ScaleBiasType, Ena
 
   ActivationParameters activation_params;  // Here assume gemm2 has no activation
   // Note: expanded_num_rows, to check this value, it's greater than num_rows * num_experts_per_node
-  auto universal_input = GroupedGemmInput<T, WeightType, OutputType, OutputType>{input, total_tokens_including_expert,
-                                                                                 fc2_expert_weights,
-                                                                                 quant_params.groupwise.group_size > 0
-                                                                                     ? static_cast<ScaleBiasType const*>(quant_params.groupwise.fc2.weight_scales)
-                                                                                     : fc2_int_scales,
-                                                                                 quant_params.groupwise.group_size > 0
-                                                                                     ? static_cast<ScaleBiasType const*>(quant_params.groupwise.fc2.weight_zeros)
-                                                                                     : nullptr,
-                                                                                 nullptr, static_cast<OutputType*>(gemm_output),
-                                                                                 alpha_scale_ptr_array, /*occupancy*/ nullptr, ActivationType::Identity, expanded_num_rows,
-                                                                                 /*N*/ hidden_size,
-                                                                                 /*K*/ inter_size,
-                                                                                 num_experts_per_node,
-                                                                                 quant_params.groupwise.group_size,
-                                                                                 /*bias_is_broadcast*/ false,
-                                                                                 /*use_fused_moe*/ false,
-                                                                                 stream,
-                                                                                 activation_params,
-                                                                                 config};
-  gemm_runner.moeGemmBiasAct(universal_input, tma_ws_input);
+  // Fast path: int4 per-channel MoE GEMV (no bias here; fc2 bias applied in finalizeMoeRouting).
+  bool const fc2_did_gemv = tryLaunchMoeGemvInt4PerChannel<T, WeightType, ScaleBiasType>(
+      input, fc2_expert_weights,
+      quant_params.groupwise.group_size > 0
+          ? static_cast<ScaleBiasType const*>(quant_params.groupwise.fc2.weight_scales)
+          : fc2_int_scales,
+      /*biases*/ nullptr, static_cast<T*>(gemm_output), expert_first_token_offset, num_experts_per_node,
+      expanded_num_rows, /*n=*/hidden_size, /*k=*/inter_size, onnxruntime::llm::common::getSMVersion(),
+      quant_params.groupwise.group_size,
+      /*disabled=*/using_tma_ws_gemm2, stream);
+  if (!fc2_did_gemv) {
+    auto universal_input = GroupedGemmInput<T, WeightType, OutputType, OutputType>{input, total_tokens_including_expert,
+                                                                                   fc2_expert_weights,
+                                                                                   quant_params.groupwise.group_size > 0
+                                                                                       ? static_cast<ScaleBiasType const*>(quant_params.groupwise.fc2.weight_scales)
+                                                                                       : fc2_int_scales,
+                                                                                   quant_params.groupwise.group_size > 0
+                                                                                       ? static_cast<ScaleBiasType const*>(quant_params.groupwise.fc2.weight_zeros)
+                                                                                       : nullptr,
+                                                                                   nullptr, static_cast<OutputType*>(gemm_output),
+                                                                                   alpha_scale_ptr_array, /*occupancy*/ nullptr, ActivationType::Identity, expanded_num_rows,
+                                                                                   /*N*/ hidden_size,
+                                                                                   /*K*/ inter_size,
+                                                                                   num_experts_per_node,
+                                                                                   quant_params.groupwise.group_size,
+                                                                                   /*bias_is_broadcast*/ false,
+                                                                                   /*use_fused_moe*/ false,
+                                                                                   stream,
+                                                                                   activation_params,
+                                                                                   config};
+    gemm_runner.moeGemmBiasAct(universal_input, tma_ws_input);
+  }
   sync_check_cuda_error(stream);
 
   bool has_different_output_type_ampere = (use_w4afp8 || use_fp8) && !using_tma_ws_gemm2;

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_kernels.h
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_kernels.h
@@ -434,7 +434,8 @@ class CutlassMoeFCRunner : public CutlassMoeFCRunnerInterface {
                     TmaWarpSpecializedGroupedGemmInput::ElementSF* fc2_fp4_act_flat, QuantParams quant_params,
                     int64_t const num_rows, int64_t const expanded_num_rows, int64_t const hidden_size, int64_t const inter_size,
                     int const num_experts_per_node, ActivationType fc1_activation_type, float const** alpha_scale_ptr_array,
-                    bool bias_is_broadcast, cudaStream_t stream, cutlass_extensions::CutlassGemmConfig config,
+                    int const* permuted_row_to_expert, bool bias_is_broadcast,
+                    cudaStream_t stream, cutlass_extensions::CutlassGemmConfig config,
                     ActivationParameters activation_params);
 
   static void gemm2(MoeGemmRunner<T, WeightType, OutputType, ScaleBiasType>& gemm_runner,
@@ -449,6 +450,7 @@ class CutlassMoeFCRunner : public CutlassMoeFCRunnerInterface {
                     int64_t const* const num_valid_tokens_ptr, int64_t const num_rows, int64_t const expanded_num_rows,
                     int64_t const hidden_size, int64_t const inter_size, int const num_experts_per_node,
                     int64_t const experts_per_token, float const** alpha_scale_ptr_array,
+                    int const* permuted_row_to_expert,
                     cudaStream_t stream, MOEParallelismConfig parallelism_config,
                     cutlass_extensions::CutlassGemmConfig config);
 
@@ -469,7 +471,7 @@ class CutlassMoeFCRunner : public CutlassMoeFCRunnerInterface {
                        static_cast<WeightType const*>(fc1_expert_weights), static_cast<ScaleBiasType const*>(fc1_expert_biases),
                        num_valid_tokens_ptr, static_cast<ScaleBiasType const*>(fc1_int_scales), fc1_fp8_dequant, fc2_fp8_quant,
                        fc1_fp4_act_flat, fc2_fp4_act_flat, quant_params, num_rows, expanded_num_rows, hidden_size, inter_size,
-                       num_experts_per_node, fc1_activation_type, alpha_scale_ptr_array, bias_is_broadcast, stream, config,
+                       num_experts_per_node, fc1_activation_type, alpha_scale_ptr_array, nullptr, bias_is_broadcast, stream, config,
                        activation_params);
   }
 
@@ -491,7 +493,7 @@ class CutlassMoeFCRunner : public CutlassMoeFCRunnerInterface {
                        static_cast<ScaleBiasType const*>(fc2_int_scales), fc2_fp8_dequant, fc2_fp4_act_flat, quant_params,
                        token_topk_unpermuted_scales, token_topk_permuted_scales, unpermuted_row_to_permuted_row,
                        permuted_row_to_unpermuted_row, token_selected_experts, num_valid_tokens_ptr, num_rows, expanded_num_rows,
-                       hidden_size, inter_size, num_experts_per_node, experts_per_token, alpha_scale_ptr_array,
+                       hidden_size, inter_size, num_experts_per_node, experts_per_token, alpha_scale_ptr_array, nullptr,
                        stream, parallelism_config, config);
   }
 

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_util_kernels.h
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_util_kernels.h
@@ -40,8 +40,9 @@ namespace cutlass_kernels {
 // These kernels are used in moeUtilOp.cpp
 int64_t computeNumTokensPerBlock(int64_t const num_tokens, int64_t const num_experts_per_node);
 
-bool fusedBuildExpertMapsSortFirstToken(int const* token_selected_experts, int* unpermuted_token_selected_experts,
-                                        int* permuted_source_token_ids, int64_t* expert_first_token_offset, int64_t const num_tokens,
+bool fusedBuildExpertMapsSortFirstToken(int const* token_selected_experts, int* permuted_row_to_unpermuted_row,
+                                        int* unpermuted_row_to_permuted_row, int* permuted_token_selected_experts,
+                                        int64_t* expert_first_token_offset, int64_t const num_tokens,
                                         int const num_experts_per_node, int const experts_per_token, int const start_expert, int const end_expert,
                                         cudaStream_t stream);
 

--- a/onnxruntime/contrib_ops/cuda/moe/moe.cc
+++ b/onnxruntime/contrib_ops/cuda/moe/moe.cc
@@ -42,8 +42,20 @@ Status MoE<T>::ComputeInternal(OpKernelContext* context) const {
   const Tensor* fc3_experts_bias_optional = context->Input<Tensor>(7);
 
   using onnxruntime::llm::kernels::cutlass_kernels::ActivationType;
+
+  // Backward compatibility: the published gpt-oss-20b model (and any model exported by ORT < 1.27)
+  // hard-coded the interleaved SwiGLU fusion layout and did not emit a swiglu_fusion attribute, so it
+  // falls back to the default of 0 ("not fused"). When the activation is SwiGLU, swiglu_fusion is 0,
+  // and there is no separate FC3 weight, the gate and value projections are actually pre-fused into FC1
+  // (interleaved layout). Treat this as swiglu_fusion == 1 so those legacy models keep working.
+  int swiglu_fusion = swiglu_fusion_;
+  if (activation_type_ == ActivationType::Swiglu && swiglu_fusion == 0 &&
+      fc3_experts_weights_optional == nullptr) {
+    swiglu_fusion = 1;
+  }
+
   bool is_fused_swiglu = (activation_type_ == ActivationType::Swiglu) &&
-                         (swiglu_fusion_ != 0) &&
+                         (swiglu_fusion != 0) &&
                          (fc3_experts_weights_optional == nullptr);
 
   MoEParameters moe_params;
@@ -301,7 +313,7 @@ Status MoE<T>::ComputeInternal(OpKernelContext* context) const {
         onnxruntime::llm::kernels::cutlass_kernels::ActivationParams params(kernel_activation_type);
         params.alpha = activation_alpha_;
         params.beta = activation_beta_;
-        params.swiglu_fusion = swiglu_fusion_;
+        params.swiglu_fusion = swiglu_fusion;
         params.limit = swiglu_limit_;
         return params;
       }(),

--- a/onnxruntime/contrib_ops/cuda/moe/moe.cc
+++ b/onnxruntime/contrib_ops/cuda/moe/moe.cc
@@ -133,23 +133,23 @@ Status MoE<T>::ComputeInternal(OpKernelContext* context) const {
 
     // GEMM 1
     MoeGemmId id1(static_cast<int>(moe_params.inter_size), static_cast<int>(moe_params.hidden_size), dtype, MoeGemmId::GemmType::Gemm1);
-    if (mGemmId1 != id1) {
-      mGemmId1 = id1;
+    {
+      // profileTactics caches per (GemmId, M bucket); calling it every forward lets decode
+      // (small M) and prefill (large M) each profile and select their own best tile shape.
       GemmDims dims(static_cast<int64_t>(moe_params.num_rows), static_cast<int64_t>(moe_params.num_rows),
                     static_cast<int64_t>(moe_params.inter_size), static_cast<int64_t>(moe_params.hidden_size));
-      mGemmProfiler.profileTactics(&moe_runner, dtype, dims, id1);
+      mGemmProfiler.profileTactics(&moe_runner, dims, id1);
     }
-    auto config1 = mGemmProfiler.getBestConfig(static_cast<int>(moe_params.num_rows), mGemmId1);
+    auto config1 = mGemmProfiler.getBestConfig(static_cast<int>(moe_params.num_rows), id1);
 
     // GEMM 2
     MoeGemmId id2(static_cast<int>(moe_params.hidden_size), static_cast<int>(moe_params.inter_size), dtype, MoeGemmId::GemmType::Gemm2);
-    if (mGemmId2 != id2) {
-      mGemmId2 = id2;
+    {
       GemmDims dims(static_cast<int64_t>(moe_params.num_rows), static_cast<int64_t>(moe_params.num_rows),
                     static_cast<int64_t>(moe_params.hidden_size), static_cast<int64_t>(moe_params.inter_size));
-      mGemmProfiler.profileTactics(&moe_runner, dtype, dims, id2);
+      mGemmProfiler.profileTactics(&moe_runner, dims, id2);
     }
-    auto config2 = mGemmProfiler.getBestConfig(static_cast<int>(moe_params.num_rows), mGemmId2);
+    auto config2 = mGemmProfiler.getBestConfig(static_cast<int>(moe_params.num_rows), id2);
 
     moe_runner.setTactic(config1, config2);
   }

--- a/onnxruntime/contrib_ops/cuda/moe/moe.h
+++ b/onnxruntime/contrib_ops/cuda/moe/moe.h
@@ -24,8 +24,6 @@ class MoE final : public CudaKernel, public MoEBase {
 
  private:
   mutable onnxruntime::llm::kernels::cutlass_kernels::MoeGemmProfiler mGemmProfiler;
-  mutable onnxruntime::llm::kernels::cutlass_kernels::MoeGemmId mGemmId1;
-  mutable onnxruntime::llm::kernels::cutlass_kernels::MoeGemmId mGemmId2;
   mutable std::mutex mGemmProfilerMutex;
 };
 

--- a/onnxruntime/contrib_ops/cuda/moe/moe_quantization.cc
+++ b/onnxruntime/contrib_ops/cuda/moe/moe_quantization.cc
@@ -211,6 +211,17 @@ Status QMoE::ComputeInternal(OpKernelContext* context) const {
               "QMoE in CUDA execution provider does not support separate fc3_experts_weights. "
               "Gate and up projection weights must be pre-concatenated into fc1.");
 
+  // Backward compatibility: the published gpt-oss-20b model (and any model exported by ORT < 1.27)
+  // hard-coded the interleaved SwiGLU fusion layout and did not emit a swiglu_fusion attribute, so it
+  // falls back to the default of 0 ("not fused"). QMoE never has a separate FC3 (enforced above), so a
+  // SwiGLU activation with swiglu_fusion == 0 means the gate and value projections are actually pre-fused
+  // into FC1 (interleaved layout). Treat this as swiglu_fusion == 1 so those legacy models keep working.
+  int swiglu_fusion = swiglu_fusion_;
+  if (activation_type_ == onnxruntime::llm::kernels::cutlass_kernels::ActivationType::Swiglu &&
+      swiglu_fusion == 0) {
+    swiglu_fusion = 1;
+  }
+
   const Tensor* fc1_zeros = packed_fc1_bias_ ? nullptr : context->Input<Tensor>(11);
   const Tensor* fc2_zeros = packed_fc2_bias_ ? nullptr : context->Input<Tensor>(12);
 
@@ -931,7 +942,7 @@ Status QMoE::ComputeInternal(OpKernelContext* context) const {
           onnxruntime::llm::kernels::cutlass_kernels::ActivationParams params(activation_type_);
           params.alpha = activation_alpha_;
           params.beta = activation_beta_;
-          params.swiglu_fusion = swiglu_fusion_;
+          params.swiglu_fusion = swiglu_fusion;
           params.limit = swiglu_limit_;
           return params;
         }(),

--- a/onnxruntime/contrib_ops/cuda/moe/moe_quantization.cc
+++ b/onnxruntime/contrib_ops/cuda/moe/moe_quantization.cc
@@ -413,23 +413,23 @@ Status QMoE::ComputeInternal(OpKernelContext* context) const {
 
       // GEMM 1: N=fc1_out_size (doubled for gated), K=hidden_size
       MoeGemmId id1(static_cast<int>(fc1_out_size), static_cast<int>(moe_params.hidden_size), dtype, wtype, MoeGemmId::GemmType::Gemm1);
-      if (mGemmId1 != id1) {
-        mGemmId1 = id1;
+      {
+        // profileTactics caches per (GemmId, M bucket); calling it every forward lets decode
+        // (small M) and prefill (large M) each profile and select their own best tile shape.
         GemmDims dims(static_cast<int64_t>(moe_params.num_rows), static_cast<int64_t>(moe_params.num_rows),
                       fc1_out_size, static_cast<int64_t>(moe_params.hidden_size));
-        mGemmProfiler.profileTactics(m_moe_runner.get(), dtype, dims, id1);
+        mGemmProfiler.profileTactics(m_moe_runner.get(), dims, id1);
       }
-      config1 = mGemmProfiler.getBestConfig(static_cast<int>(moe_params.num_rows), mGemmId1);
+      config1 = mGemmProfiler.getBestConfig(static_cast<int>(moe_params.num_rows), id1);
 
       // GEMM 2
       MoeGemmId id2(static_cast<int>(moe_params.hidden_size), static_cast<int>(moe_params.inter_size), dtype, wtype, MoeGemmId::GemmType::Gemm2);
-      if (mGemmId2 != id2) {
-        mGemmId2 = id2;
+      {
         GemmDims dims(static_cast<int64_t>(moe_params.num_rows), static_cast<int64_t>(moe_params.num_rows),
                       static_cast<int64_t>(moe_params.hidden_size), static_cast<int64_t>(moe_params.inter_size));
-        mGemmProfiler.profileTactics(m_moe_runner.get(), dtype, dims, id2);
+        mGemmProfiler.profileTactics(m_moe_runner.get(), dims, id2);
       }
-      config2 = mGemmProfiler.getBestConfig(static_cast<int>(moe_params.num_rows), mGemmId2);
+      config2 = mGemmProfiler.getBestConfig(static_cast<int>(moe_params.num_rows), id2);
 
       m_moe_runner->setTactic(config1, config2);
     }

--- a/onnxruntime/contrib_ops/cuda/moe/moe_quantization.h
+++ b/onnxruntime/contrib_ops/cuda/moe/moe_quantization.h
@@ -75,8 +75,6 @@ class QMoE final : public CudaKernel, public MoEBase {
   IAllocatorUniquePtr<void> packed_fc2_act_scale_;
 
   mutable onnxruntime::llm::kernels::cutlass_kernels::MoeGemmProfiler mGemmProfiler;
-  mutable onnxruntime::llm::kernels::cutlass_kernels::MoeGemmId mGemmId1;
-  mutable onnxruntime::llm::kernels::cutlass_kernels::MoeGemmId mGemmId2;
   mutable std::mutex mGemmProfilerMutex;
 };
 

--- a/onnxruntime/test/python/transformers/profile_qmoe_gemv.py
+++ b/onnxruntime/test/python/transformers/profile_qmoe_gemv.py
@@ -1,0 +1,106 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.  All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
+"""
+Profiling script for the CUDA QMoE INT4 per-channel GEMV decode path.
+
+Usage:
+  python profile_qmoe_gemv.py --case m1_top2_fp16_128x256 --warmup 5 --repeat 100
+
+  nsys profile -t cuda,nvtx -o qmoe_gemv --export=sqlite \
+      python profile_qmoe_gemv.py --case m1_top2_fp16_128x256 --warmup 5 --repeat 100
+  python parse_nsys.py qmoe_gemv.sqlite --nvtx-range benchmark
+"""
+
+import argparse
+import json
+import os
+
+import torch
+from test_qmoe_cuda import (
+    _QMOE_GEMV_BENCHMARK_RESULT_PREFIX,
+    _qmoe_gemv_benchmark_case,
+    _qmoe_gemv_benchmark_cases,
+    run_qmoe_gemv_benchmark,
+)
+
+
+def _custom_case_from_args(args):
+    case = dict(_qmoe_gemv_benchmark_case(args.case))
+    custom_fields = {
+        "batch_size": args.batch_size,
+        "sequence_length": args.sequence_length,
+        "hidden_size": args.hidden_size,
+        "intermediate_size": args.intermediate_size,
+        "num_experts": args.num_experts,
+        "top_k": args.top_k,
+        "onnx_dtype": args.dtype,
+    }
+    case.update({key: value for key, value in custom_fields.items() if value is not None})
+
+    if any(value is not None for value in custom_fields.values()):
+        case["name"] = (
+            f"custom_m{case['batch_size'] * case['sequence_length']}_top{case['top_k']}_"
+            f"{case['onnx_dtype'].lower()}_{case['hidden_size']}x{case['intermediate_size']}_"
+            f"e{case['num_experts']}"
+        )
+
+    return case
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Profile CUDA QMoE INT4 per-channel GEMV decode")
+    parser.add_argument("--case", default="m1_top2_fp16_128x256", help="Benchmark case name")
+    parser.add_argument("--list-cases", action="store_true", help="List available benchmark case names and exit")
+    parser.add_argument("--batch-size", type=int, help="Override batch size")
+    parser.add_argument("--sequence-length", type=int, help="Override sequence length")
+    parser.add_argument("--hidden-size", type=int, help="Override hidden size")
+    parser.add_argument("--intermediate-size", type=int, help="Override intermediate size")
+    parser.add_argument("--num-experts", type=int, help="Override number of experts")
+    parser.add_argument("--top-k", type=int, help="Override top-k experts per token")
+    parser.add_argument("--dtype", choices=["FLOAT16", "BFLOAT16"], help="Override ONNX dtype")
+    parser.add_argument("--warmup", type=int, default=5, help="Warmup iterations before the benchmark NVTX range")
+    parser.add_argument("--repeat", type=int, default=100, help="Benchmark iterations")
+    parser.add_argument(
+        "--disable-gemv",
+        action="store_true",
+        help="Run the grouped GEMM fallback by setting ORT_DISABLE_MOE_GEMV=1 before session creation",
+    )
+    parser.add_argument(
+        "--nvtx",
+        action="store_true",
+        help="Wrap the measured loop in an NVTX range named 'benchmark'",
+    )
+    args = parser.parse_args()
+
+    if args.list_cases:
+        for case in _qmoe_gemv_benchmark_cases():
+            print(case["name"])
+        return
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required for QMoE GEMV profiling")
+
+    os.environ["ORT_QMOE_GEMV_BENCHMARK_REPEATS"] = str(max(1, args.repeat))
+    os.environ["ORT_QMOE_GEMV_BENCHMARK_WARMUP"] = str(max(0, args.warmup))
+    if args.nvtx:
+        os.environ["ORT_QMOE_GEMV_BENCHMARK_NVTX"] = "1"
+    else:
+        os.environ.pop("ORT_QMOE_GEMV_BENCHMARK_NVTX", None)
+
+    if args.disable_gemv:
+        os.environ["ORT_DISABLE_MOE_GEMV"] = "1"
+    else:
+        os.environ.pop("ORT_DISABLE_MOE_GEMV", None)
+
+    result = run_qmoe_gemv_benchmark(_custom_case_from_args(args))
+    if result["has_invalid_output"]:
+        raise RuntimeError("QMoE GEMV profiling produced NaN or Inf output")
+
+    print(_QMOE_GEMV_BENCHMARK_RESULT_PREFIX + json.dumps(result, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/onnxruntime/test/python/transformers/profile_qmoe_gemv.sh
+++ b/onnxruntime/test/python/transformers/profile_qmoe_gemv.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.  All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+#
+# Profile the CUDA QMoE INT4 per-channel GEMV decode path with nsys.
+#
+# Usage:
+#   ./profile_qmoe_gemv.sh
+#   ./profile_qmoe_gemv.sh --list-cases
+#   ./profile_qmoe_gemv.sh --case m8_top2_fp16_128x256 --warmup 5 --repeat 200
+#   ./profile_qmoe_gemv.sh --case gpt_oss_20b_m1_top4_fp16_2880x2880_e32 --warmup 5 --repeat 100
+#   ./profile_qmoe_gemv.sh --batch-size 1 --sequence-length 1 --hidden-size 2880 --intermediate-size 2880 --num-experts 32 --top-k 4
+#   CUDA_VISIBLE_DEVICES=1 ./profile_qmoe_gemv.sh -o /tmp/qmoe_gemv
+#
+
+set -e
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CASE="m1_top2_fp16_128x256"
+WARMUP=5
+REPEAT=100
+OUTPUT_NAME="qmoe_gemv_profile"
+PY="${PYTHON:-python}"
+EXTRA_ARGS=()
+LIST_CASES=0
+
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --case)
+            CASE="$2"
+            shift
+            ;;
+        --list-cases)
+            LIST_CASES=1
+            ;;
+        --batch-size|--sequence-length|--hidden-size|--intermediate-size|--num-experts|--top-k|--dtype)
+            EXTRA_ARGS+=("$1" "$2")
+            shift
+            ;;
+        --repeat)
+            REPEAT="$2"
+            shift
+            ;;
+        --warmup)
+            WARMUP="$2"
+            shift
+            ;;
+        --python)
+            PY="$2"
+            shift
+            ;;
+        -o|--output)
+            OUTPUT_NAME="$2"
+            shift
+            ;;
+        *)
+            echo "Unknown option: $1"
+            echo "Usage: $0 [--list-cases] [--case NAME] [--batch-size N] [--sequence-length N] [--hidden-size N] [--intermediate-size N] [--num-experts N] [--top-k N] [--dtype FLOAT16|BFLOAT16] [--warmup N] [--repeat N] [--python PYTHON] [-o NAME]"
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+if [[ "${LIST_CASES}" -eq 1 ]]; then
+    "${PY}" "${SCRIPT_DIR}/profile_qmoe_gemv.py" --list-cases
+    exit 0
+fi
+
+if ! command -v nsys >/dev/null; then
+    echo "Error: nsys not found. Install NVIDIA Nsight Systems or add it to PATH."
+    exit 1
+fi
+
+HAVE_NVTX=0
+if "${PY}" -c "import nvtx" 2>/dev/null; then
+    HAVE_NVTX=1
+else
+    echo "Note: 'nvtx' package not installed. NVTX range markers will be disabled."
+    echo "      Install with: pip install nvtx"
+    echo "      Falling back to --skip-first to exclude warmup-like first calls."
+fi
+
+echo ""
+echo "========================================"
+echo "  Profiling: CUDA QMoE GEMV"
+echo "========================================"
+echo "Case:   ${CASE}"
+echo "Warmup: ${WARMUP}"
+echo "Repeat: ${REPEAT}"
+echo "Python: ${PY}"
+if [[ -n "${CUDA_VISIBLE_DEVICES:-}" ]]; then
+    echo "CUDA_VISIBLE_DEVICES: ${CUDA_VISIBLE_DEVICES}"
+fi
+if [[ "${#EXTRA_ARGS[@]}" -gt 0 ]]; then
+    echo "Custom args: ${EXTRA_ARGS[*]}"
+fi
+
+profile_one() {
+    local mode="$1"
+    local disable_arg=""
+    local base="${OUTPUT_NAME}_${mode}"
+    if [[ "${mode}" == "gemm" ]]; then
+        disable_arg="--disable-gemv"
+    fi
+
+    echo ""
+    echo "---- Profiling ${mode} ----"
+    rm -f "${base}.nsys-rep" "${base}.sqlite"
+    nsys profile -t cuda,nvtx --force-overwrite true -o "${base}" --export=sqlite \
+        "${PY}" "${SCRIPT_DIR}/profile_qmoe_gemv.py" \
+            --case "${CASE}" "${EXTRA_ARGS[@]}" --warmup "${WARMUP}" --repeat "${REPEAT}" --nvtx ${disable_arg}
+
+    echo ""
+    echo "---- Kernel results (${mode}) ----"
+    if [[ "${HAVE_NVTX}" -eq 1 ]]; then
+        "${PY}" "${SCRIPT_DIR}/parse_nsys.py" "${base}.sqlite" --nvtx-range benchmark
+    else
+        "${PY}" "${SCRIPT_DIR}/parse_nsys.py" "${base}.sqlite" --skip-first 1
+    fi
+}
+
+profile_one gemv
+profile_one gemm
+
+echo ""
+echo "Done."

--- a/onnxruntime/test/python/transformers/test_moe_cuda.py
+++ b/onnxruntime/test/python/transformers/test_moe_cuda.py
@@ -21,12 +21,12 @@ import torch
 import torch.nn.functional as F
 from cuda_plugin_ep_helper import get_cuda_provider_name
 from onnx import TensorProto, helper
+from onnxruntime.capi import _pybind_state as _quantize
 from parameterized import parameterized
 from torch import nn
 
 import onnxruntime
 from onnxruntime import InferenceSession, SessionOptions
-from onnxruntime.capi import _pybind_state as _quantize
 
 # Reduces number of tests to run for faster pipeline checks
 pipeline_mode = os.getenv("PIPELINE_MODE", "1") == "1"
@@ -152,7 +152,8 @@ def quant_dequant(weights, is_4_bit_quantization: bool = True):
         q_weight_reshaped = q_weight.reshape(n, -1)
 
         # Pack weights for CUDA mixed-gemm kernel (FpA_IntB format), and qMoE kernel uses the same format.
-        processed_q_weight = _quantize.pack_weights_for_cuda_mixed_gemm(q_weight_reshaped, n, k, 4)
+        # INT MoE/QMoE kernels consume the SM80 column-interleaved layout, including on newer GPUs.
+        processed_q_weight = _quantize.pack_weights_for_cuda_mixed_gemm(q_weight_reshaped, n, k, 4, 80)
 
         # So we need to DEQUANTIZE back to get `result`.
         # scale is [n, block_per_k]
@@ -233,7 +234,8 @@ def quant_dequant(weights, is_4_bit_quantization: bool = True):
 
         q_weight_reshaped = q_weight.reshape(n, -1)
         # Pack weights for CUDA mixed-gemm kernel (FpA_IntB format)
-        processed_q_weight = _quantize.pack_weights_for_cuda_mixed_gemm(q_weight_reshaped, n, k, 8)
+        # INT MoE/QMoE kernels consume the SM80 column-interleaved layout, including on newer GPUs.
+        processed_q_weight = _quantize.pack_weights_for_cuda_mixed_gemm(q_weight_reshaped, n, k, 8, 80)
 
         # Dequantize for reference
         # (q - 128) * scale if using 128 offset? or (q) * scale if symmetric around 0?
@@ -1520,7 +1522,7 @@ class TestPhiMoE(unittest.TestCase):
 phi3_qmoe_test_cases = list(
     itertools.product(
         [1, 4],  # batch_size
-        [1, 8],  # sequence_length
+        [1, 8],  # sequence_length; keeps expanded rows <= 64 to exercise the INT4 MoE GEMV path
         [TensorProto.FLOAT16],  # onnx type, None mean fp32 for bits = 0, fp16 for bits > 0
         [True],  # normalize_routing_weights
     )

--- a/onnxruntime/test/python/transformers/test_moe_cuda.py
+++ b/onnxruntime/test/python/transformers/test_moe_cuda.py
@@ -21,12 +21,12 @@ import torch
 import torch.nn.functional as F
 from cuda_plugin_ep_helper import get_cuda_provider_name
 from onnx import TensorProto, helper
-from onnxruntime.capi import _pybind_state as _quantize
 from parameterized import parameterized
 from torch import nn
 
 import onnxruntime
 from onnxruntime import InferenceSession, SessionOptions
+from onnxruntime.capi import _pybind_state as _quantize
 
 # Reduces number of tests to run for faster pipeline checks
 pipeline_mode = os.getenv("PIPELINE_MODE", "1") == "1"

--- a/onnxruntime/test/python/transformers/test_qmoe_cuda.py
+++ b/onnxruntime/test/python/transformers/test_qmoe_cuda.py
@@ -18,9 +18,12 @@
 # while maintaining computational efficiency.
 # --------------------------------------------------------------------------
 import copy
+import json
+import os
 import time
 import unittest
 from collections import OrderedDict
+from contextlib import nullcontext
 
 import numpy
 import torch
@@ -32,6 +35,14 @@ from parameterized import parameterized
 from torch import nn
 
 import onnxruntime
+
+try:
+    import nvtx
+
+    has_nvtx = True
+except ImportError:
+    has_nvtx = False
+    nvtx = None
 
 try:
     from onnx import TensorProto
@@ -80,6 +91,17 @@ if torch.cuda.is_available():
     ort_provider = ["CUDAExecutionProvider"]
 else:
     ort_provider = ["CPUExecutionProvider"]
+
+
+def _qmoe_benchmark_nvtx_range(name="benchmark", color="green"):
+    if os.getenv("ORT_QMOE_GEMV_BENCHMARK_NVTX") != "1":
+        return nullcontext()
+
+    if not has_nvtx:
+        return nullcontext()
+
+    return nvtx.annotate(name, color=color)
+
 
 torch.manual_seed(42)
 numpy.random.seed(42)
@@ -324,6 +346,25 @@ def quant_dequant(weights, is_4_bit_quantization: bool = True, asymmetric: bool 
         scale, quantized_storage, dequantized, zero_point_storage
     """
     block_size = weights.shape[1]
+    if is_4_bit_quantization and not asymmetric and block_size > 256:
+        n, k = weights.shape
+        weights_float = weights.detach().float()
+        scale = weights_float.abs().amax(dim=1, keepdim=True) / 7.0
+        scale = torch.clamp(scale, min=torch.finfo(torch.float32).eps)
+        q_weight = torch.clamp(torch.round(weights_float / scale), -8, 7).to(torch.int16) + 8
+        q_weight = q_weight.to(torch.uint8).contiguous()
+        q_low = q_weight[:, 0::2]
+        q_high = q_weight[:, 1::2]
+        if q_high.shape[1] < q_low.shape[1]:
+            q_high = F.pad(q_high, (0, 1))
+        q_packed = q_low | (q_high << 4)
+        processed_q_weight = _pybind.pack_weights_for_cuda_mixed_gemm(q_packed.cpu().numpy(), n, k, 4, 80)
+        processed_q_weight_torch = (
+            torch.from_numpy(processed_q_weight).reshape(k, n // 2).to(weights.device).view(torch.uint8)
+        )
+        dequantized = (q_weight.to(weights.dtype) - 8.0) * scale.to(weights.device).to(weights.dtype)
+        return scale.to(weights.device).to(torch.float16), processed_q_weight_torch, dequantized, None
+
     return quant_dequant_blockwise(weights, block_size, is_4_bit_quantization, asymmetric)
 
 
@@ -892,14 +933,25 @@ class SparseMoeBlockORTHelper(nn.Module):
             print("DEBUG: ORT inference completed successfully")
 
         if enable_performance_test:
-            repeat = 100
-            s = time.time()
-            for _ in range(repeat):
-                iobinding.synchronize_inputs()
-                self.ort_sess.run_with_iobinding(iobinding)
-                iobinding.synchronize_outputs()
-            e = time.time()
+            warmup = max(0, int(os.getenv("ORT_QMOE_GEMV_BENCHMARK_WARMUP", "5")))
+            repeat = max(1, int(os.getenv("ORT_QMOE_GEMV_BENCHMARK_REPEATS", "100")))
+            with _qmoe_benchmark_nvtx_range("warmup", "yellow"):
+                for _ in range(warmup):
+                    iobinding.synchronize_inputs()
+                    self.ort_sess.run_with_iobinding(iobinding)
+                    iobinding.synchronize_outputs()
+
+            with _qmoe_benchmark_nvtx_range("benchmark", "green"):
+                torch.cuda.synchronize()
+                s = time.perf_counter()
+                for _ in range(repeat):
+                    iobinding.synchronize_inputs()
+                    self.ort_sess.run_with_iobinding(iobinding)
+                    iobinding.synchronize_outputs()
+                torch.cuda.synchronize()
+                e = time.perf_counter()
             time_ms = (e - s) / repeat * 1000
+            self.last_ort_latency_ms = time_ms
             is_swiglu = hasattr(self, "use_swiglu") and self.use_swiglu
             is_interleaved = getattr(self, "swiglu_fusion", 0) == 1
             act_type = f"SwiGLU(interleaved={is_interleaved})" if is_swiglu else "SiLU"
@@ -1902,6 +1954,148 @@ class TestSwigluQMoEBf16(unittest.TestCase):
         self.assertFalse(torch.isinf(torch_result).any())
 
         swiglu_moe.parity_check()
+
+
+_QMOE_GEMV_BENCHMARK_RESULT_PREFIX = "QMOE_GEMV_BENCHMARK_RESULT "
+
+
+def _qmoe_gemv_benchmark_cases():
+    return [
+        {
+            "name": "m1_top2_fp16_128x256",
+            "batch_size": 1,
+            "sequence_length": 1,
+            "hidden_size": 128,
+            "intermediate_size": 256,
+            "num_experts": 4,
+            "top_k": 2,
+            "onnx_dtype": "FLOAT16",
+        },
+        {
+            "name": "m4_top2_fp16_128x256",
+            "batch_size": 1,
+            "sequence_length": 4,
+            "hidden_size": 128,
+            "intermediate_size": 256,
+            "num_experts": 4,
+            "top_k": 2,
+            "onnx_dtype": "FLOAT16",
+        },
+        {
+            "name": "m8_top2_fp16_128x256",
+            "batch_size": 1,
+            "sequence_length": 8,
+            "hidden_size": 128,
+            "intermediate_size": 256,
+            "num_experts": 4,
+            "top_k": 2,
+            "onnx_dtype": "FLOAT16",
+        },
+        {
+            "name": "m1_top2_bf16_128x256",
+            "batch_size": 1,
+            "sequence_length": 1,
+            "hidden_size": 128,
+            "intermediate_size": 256,
+            "num_experts": 4,
+            "top_k": 2,
+            "onnx_dtype": "BFLOAT16",
+        },
+        {
+            "name": "gpt_oss_20b_m1_top4_fp16_2880x2880_e32",
+            "batch_size": 1,
+            "sequence_length": 1,
+            "hidden_size": 2880,
+            "intermediate_size": 2880,
+            "num_experts": 32,
+            "top_k": 4,
+            "onnx_dtype": "FLOAT16",
+        },
+        {
+            "name": "qwen3_6_35b_a3b_m1_top8_fp16_2048x512_e256",
+            "batch_size": 1,
+            "sequence_length": 1,
+            "hidden_size": 2048,
+            "intermediate_size": 512,
+            "num_experts": 256,
+            "top_k": 8,
+            "onnx_dtype": "FLOAT16",
+        },
+        {
+            "name": "gemma4_26b_a4b_m1_top8_fp16_2816x704_e128",
+            "batch_size": 1,
+            "sequence_length": 1,
+            "hidden_size": 2816,
+            "intermediate_size": 704,
+            "num_experts": 128,
+            "top_k": 8,
+            "onnx_dtype": "FLOAT16",
+        },
+    ]
+
+
+def _qmoe_gemv_benchmark_case(case_name):
+    for case in _qmoe_gemv_benchmark_cases():
+        if case["name"] == case_name:
+            return case
+
+    case_names = ", ".join(case["name"] for case in _qmoe_gemv_benchmark_cases())
+    raise ValueError(f"Unknown QMoE GEMV benchmark case '{case_name}'. Available cases: {case_names}")
+
+
+def run_qmoe_gemv_benchmark(case):
+    seed = 4242
+    torch.manual_seed(seed)
+    numpy.random.seed(seed)
+
+    onnx_dtype = getattr(TensorProto, case["onnx_dtype"])
+    torch_dtype = onnx_to_torch_type_map[onnx_dtype]
+    config = PhiMoEConfig(
+        hidden_size=case["hidden_size"],
+        intermediate_size=case["intermediate_size"],
+        num_local_experts=case["num_experts"],
+        num_experts_per_tok=case["top_k"],
+    )
+    qmoe = PhiMoESparseMoeBlock(
+        config,
+        batch_size=case["batch_size"],
+        sequence_length=case["sequence_length"],
+        quant_bits=4,
+        onnx_dtype=onnx_dtype,
+        use_asymmetric_quant=False,
+    )
+    hidden_states = torch.randn(
+        case["batch_size"], case["sequence_length"], case["hidden_size"], device=device, dtype=torch_dtype
+    )
+    output = qmoe.ort_forward(hidden_states, enable_performance_test=True)
+
+    return {
+        "case": case["name"],
+        "disable_gemv": os.getenv("ORT_DISABLE_MOE_GEMV") == "1",
+        "expanded_num_rows": case["batch_size"] * case["sequence_length"] * case["top_k"],
+        "has_invalid_output": bool(torch.isnan(output).any() or torch.isinf(output).any()),
+        "latency_ms": qmoe.last_ort_latency_ms,
+        "sm": torch.cuda.get_device_capability()[0] * 10 + torch.cuda.get_device_capability()[1],
+    }
+
+
+def run_qmoe_gemv_benchmark_case(case_name=None):
+    case = _qmoe_gemv_benchmark_case(
+        case_name or os.getenv("ORT_QMOE_GEMV_BENCHMARK_CASE", _qmoe_gemv_benchmark_cases()[0]["name"])
+    )
+    return run_qmoe_gemv_benchmark(case)
+
+
+@unittest.skipIf(not torch.cuda.is_available(), "skipping QMoE GEMV benchmark since it requires CUDA.")
+@unittest.skipIf(
+    os.getenv("ORT_QMOE_GEMV_BENCHMARK") != "1",
+    "Set ORT_QMOE_GEMV_BENCHMARK=1 to run the opt-in QMoE GEMV benchmark.",
+)
+class TestQMoEGemvBenchmark(unittest.TestCase):
+    def test_decode_latency(self):
+        result = run_qmoe_gemv_benchmark_case()
+        self.assertFalse(result["has_invalid_output"])
+        print(_QMOE_GEMV_BENCHMARK_RESULT_PREFIX + json.dumps(result, sort_keys=True))
 
 
 @unittest.skipIf(True, "Skipping QMoE benchmark tests")

--- a/onnxruntime/test/python/transformers/test_qmoe_cuda.py
+++ b/onnxruntime/test/python/transformers/test_qmoe_cuda.py
@@ -27,11 +27,11 @@ import torch
 import torch.nn.functional as F
 from cuda_plugin_ep_helper import resolve_cuda_plugin_ep
 from onnx import helper
+from onnxruntime.capi import _pybind_state as _pybind
 from parameterized import parameterized
 from torch import nn
 
 import onnxruntime
-from onnxruntime.capi import _pybind_state as _pybind
 
 try:
     from onnx import TensorProto
@@ -1186,7 +1186,7 @@ class SparseMoeBlockORTHelper(nn.Module):
         dtype_str = ort_dtype_name_map[self.onnx_dtype]
         tolerance_key = f"{dtype_str}:{self.quant_bits}"
         if tolerance_key in ort_dtype_quant_bits_tolerance_map:
-            base_atol, rtol = ort_dtype_quant_bits_tolerance_map[tolerance_key]
+            base_atol, _rtol = ort_dtype_quant_bits_tolerance_map[tolerance_key]
 
             # Increase tolerance for asymmetric quantization due to different computation path
             if self.use_asymmetric_quant:
@@ -1460,6 +1460,7 @@ class PhiMoESparseMoeBlock(SparseMoeBlockORTHelper):
 
 # Define test cases for different MoE types
 phi3_test_cases = [
+    (1, 1, 4),  # decode-sized INT4 per-channel path exercises the MoE GEMV fast path
     (1, 32, 4),
     (1, 32, 8),
     (2, 16, 4),

--- a/onnxruntime/test/python/transformers/test_qmoe_cuda.py
+++ b/onnxruntime/test/python/transformers/test_qmoe_cuda.py
@@ -30,11 +30,11 @@ import torch
 import torch.nn.functional as F
 from cuda_plugin_ep_helper import resolve_cuda_plugin_ep
 from onnx import helper
-from onnxruntime.capi import _pybind_state as _pybind
 from parameterized import parameterized
 from torch import nn
 
 import onnxruntime
+from onnxruntime.capi import _pybind_state as _pybind
 
 try:
     import nvtx


### PR DESCRIPTION
## Summary

Adds an INT4 per-channel **MoE GEMV fast path** for single-token (batch-1) decode of MoE models such as GPT-OSS-20B, replacing the CUTLASS grouped-GEMM path when the expanded row count is small. On an H200 (SM90) this improves end-to-end GPT-OSS-20B INT4 token-generation throughput by roughly **15% over the CUTLASS grouped-GEMM baseline** and about **8% over the FasterTransformer 0.14.1 reference** across prompt lengths 128/1024/2048, while producing bit-faithful output.

## Motivation

At batch-1 decode each token expands to `top_k` rows (4 for GPT-OSS-20B), so the MoE FC1/FC2 GEMMs are extremely skinny. The CUTLASS grouped GEMM is built for throughput on larger M and leaves the decode path memory-bound and underutilized. A dedicated weight-only INT4 GEMV with per-expert dispatch is a better fit for this regime and closes the gap to (and surpasses) FasterTransformer for GPT-OSS-20B.

## Key Changes

### New MoE GEMV kernel
| File | Change |
|---|---|
| `contrib_ops/cuda/llm/moe_gemm/moe_gemv.h` | Public interface: `is_moe_gemv_supported` dispatch predicate and `launch_moe_gemv_int4_per_channel<T>` launcher. |
| `contrib_ops/cuda/llm/moe_gemm/moe_gemv.cu` | INT4 per-channel batched GEMV (FP16/BF16). One CTA per expanded row × N-tile; per-expert weight/scale/bias offsets via a direct row-to-expert map (prefix-offset scan fallback). FC1 has an interleaved SwiGLU-fused epilogue; a static top-k one-row finalize specialization is used for FC2 routing. |

### Runner wiring and profiler
| File | Change |
|---|---|
| `contrib_ops/cuda/llm/moe_gemm/moe_kernels.cu` / `.h` | Branch FC1 and FC2 to the GEMV fast path when supported; fall back to grouped GEMM otherwise. `ORT_DISABLE_MOE_GEMV=1` forces the grouped-GEMM path for A/B testing. |
| `contrib_ops/cuda/llm/moe_gemm/moe_gemm_profiler.cc` / `.h`, `moe_util_kernels.h` | Use M (token count) in the MoE GEMM profiler so the tactic selection reflects the decode shape. |

### Backward-compatible SwiGLU fusion
| File | Change |
|---|---|
| `contrib_ops/cuda/moe/moe.cc`, `moe_quantization.cc` (+ `.h`) | Treat `swiglu_fusion == 0` with no separate FC3 as interleaved fusion (`== 1`). The published GPT-OSS-20B model (and any model exported by ORT < 1.27) hard-coded the interleaved layout and emits no `swiglu_fusion` attribute, so it defaults to 0; those weights are pre-fused into FC1 and must be treated as fusion mode 1. |

### Tests, profiling, and docs
| File | Change |
|---|---|
| `test/python/transformers/profile_qmoe_gemv.py` / `.sh` | Standalone QMoE GEMV profiling harness (NVTX-ranged, GEMV-vs-grouped-GEMM kernel comparison). |
| `test/python/transformers/test_qmoe_cuda.py`, `test_moe_cuda.py` | QMoE GEMV decode-latency/parity coverage and import tidy-ups. |
| `docs/contrib_ops/cuda/qmoe_gemv_experiments.md` | Full experiment log: kernel-level sweeps, dispatch-gate tuning, and the GenAI end-to-end throughput comparison (CUTLASS baseline / GEMV final / FT baseline). |
| `docs/contrib_ops/cuda/moe_qmoe.md` | QMoE doc updates. |

## Results (GPT-OSS-20B INT4, H200/SM90, batch 1)

Token-generation throughput (tps, higher is better):

| Prompt length | CUTLASS baseline (gemm) | GEMV (final) | FT 0.14.1 | GEMV vs cutlass | GEMV vs FT |
|---|---|---|---|---|---|
| 128 | 248.9 | 288.0 | 265.2 | +15.7% | +8.6% |
| 1024 | 237.8 | 272.2 | 252.9 | +14.5% | +7.6% |
| 2048 | 231.3 | 265.0 | 245.6 | +14.6% | +7.9% |

## Correctness

- GEMV-enabled and `ORT_DISABLE_MOE_GEMV=1` (grouped GEMM) produce identical, correct output for the GPT-OSS-20B sanity prompt; Nsight traces confirm `moe_gemv_kernel` runs for FC1 and FC2.
- FP16 INT4 SwiGLU parity cases pass with max absolute difference ~1e-3 against the reference.

## Testing Notes

- Build: `bash .env/cuda_130.sh --build` (CUDA 13.0, `CMAKE_CUDA_ARCHITECTURES=89;90`).
- Kernel profiling: `onnxruntime/test/python/transformers/profile_qmoe_gemv.sh`.
- End-to-end: GenAI `benchmark_e2e.py` on GPT-OSS-20B INT4, batch 1, prompt lengths 128/1024/2048. Run on an idle GPU — shared-GPU contention corrupts the decode-latency measurement.
- A/B check: compare default vs `ORT_DISABLE_MOE_GEMV=1` for both throughput and output parity.

> Note: opened as a draft — a few commits (`record tile experiments`, `clean up`, `adjust reject`) are exploratory and may be squashed/reworded before review.
