### PR TITLE
Fix simplified layer norm fp16 overflow

### DIFF
--- a/onnxruntime/contrib_ops/cuda/bert/layer_norm.cuh
+++ b/onnxruntime/contrib_ops/cuda/bert/layer_norm.cuh
@@ -27,6 +27,7 @@ limitations under the License.
 #include <cuda_fp16.h>
 #include <cuda_bf16.h>
 #include <cublas_v2.h>
+#include <cub/cub.cuh>
 
 using namespace onnxruntime::cuda;
 using namespace cub;
@@ -74,43 +75,62 @@ struct KeyValuePairSum {
                                                                const cub::KeyValuePair<float, float>& b) {
     return cub::KeyValuePair<float, float>(a.key + b.key, a.value + b.value);
   }
+
+  __device__ inline cub::KeyValuePair<half, half> operator()(const cub::KeyValuePair<half, half>& a,
+                                                             const cub::KeyValuePair<half, half>& b) {
+    const half2 a2 = __halves2half2(a.key, a.value);
+    const half2 b2 = __halves2half2(b.key, b.value);
+    const half2 res = AddHalf2(a2, b2);
+    return cub::KeyValuePair<half, half>(__low2half(res), __high2half(res));
+  }
+
+  __device__ inline cub::KeyValuePair<half2, half2> operator()(const cub::KeyValuePair<half2, half2>& a,
+                                                               const cub::KeyValuePair<half2, half2>& b) {
+    return cub::KeyValuePair<half2, half2>(AddHalf2(a.key, b.key), AddHalf2(a.value, b.value));
+  }
+
+  __device__ inline cub::KeyValuePair<nv_bfloat16, nv_bfloat16> operator()(const cub::KeyValuePair<nv_bfloat16, nv_bfloat16>& a,
+                                                                           const cub::KeyValuePair<nv_bfloat16, nv_bfloat16>& b) {
+    const nv_bfloat162 a2 = __halves2bfloat162(a.key, a.value);
+    const nv_bfloat162 b2 = __halves2bfloat162(b.key, b.value);
+    const nv_bfloat162 res = AddHalf2(a2, b2);
+    return cub::KeyValuePair<nv_bfloat16, nv_bfloat16>(__low2bfloat16(res), __high2bfloat16(res));
+  }
 };
 
 template <typename T, int TPB>
 __device__ inline void LayerNorm(
-    const cub::KeyValuePair<float, float>& thread_data, const int ld, const int offset, const T* beta,
-    const T* gamma, const float epsilon, T* output) {
+    const cub::KeyValuePair<T, T>& thread_data, const int ld, const int offset, const T* beta,
+    const T* gamma, const T epsilon, T* output) {
   // Assuming thread_data is already divided by ld
-  // Uses fp32 accumulation for mean/variance to avoid overflow in fp16/bf16.
 
-  using BlockReduce = cub::BlockReduce<cub::KeyValuePair<float, float>, TPB>;
+  using BlockReduce = cub::BlockReduce<cub::KeyValuePair<T, T>, TPB>;
   __shared__ typename BlockReduce::TempStorage temp_storage;
-  __shared__ float mu;      // mean
-  __shared__ float rsigma;  // 1 / std.dev.
+  __shared__ T mu;      // mean
+  __shared__ T rsigma;  // 1 / std.dev.
 
   KeyValuePairSum pair_sum;
   const auto sum_kv = BlockReduce(temp_storage).Reduce(thread_data, pair_sum);
 
   if (threadIdx.x == 0) {
     mu = sum_kv.key;
-    rsigma = rsqrtf(sum_kv.value - mu * mu + epsilon);
+    rsigma = Rsqrt(sum_kv.value - mu * mu + epsilon);
   }
   __syncthreads();
 
   for (int i = threadIdx.x; i < ld; i += TPB) {
     const int idx = offset + i;
-    const float val = static_cast<float>(output[idx]);
-    const float g = static_cast<float>(gamma[i]);
-    const float b = (nullptr == beta) ? 0.f : static_cast<float>(beta[i]);
-    output[idx] = static_cast<T>(g * (val - mu) * rsigma + b);
+    const T val = output[idx];
+    const T g(gamma[i]);
+    const T b = (nullptr == beta) ? (T)0 : beta[i];
+    output[idx] = g * (val - mu) * rsigma + b;
   }
 }
 
 template <typename T, int TPB>
 __device__ inline void SimplifiedLayerNorm(
-    const float& thread_data, const int ld, const int offset, const T* gamma, const float epsilon, T* output) {
+    const float& thread_data, const int ld, const int offset, const T* gamma, const T epsilon, T* output) {
   // Assuming thread_data is already divided by ld
-  // Uses fp32 accumulation to avoid overflow in fp16/bf16.
 
   using BlockReduce = cub::BlockReduce<float, TPB>;
   __shared__ typename BlockReduce::TempStorage temp_storage;
@@ -119,7 +139,7 @@ __device__ inline void SimplifiedLayerNorm(
   const float sum = BlockReduce(temp_storage).Sum(thread_data);
 
   if (threadIdx.x == 0) {
-    rsigma = rsqrtf(sum + epsilon);
+    rsigma = Rsqrt(sum + static_cast<float>(epsilon));
   }
   __syncthreads();
 
@@ -132,22 +152,20 @@ __device__ inline void SimplifiedLayerNorm(
 }
 
 template <typename T, int TPB, int ILP>
-__device__ inline void LayerNormSmall(const T* input_v, const cub::KeyValuePair<float, float>& thread_data,
+__device__ inline void LayerNormSmall(const T* input_v, const cub::KeyValuePair<T, T>& thread_data,
                                       const int ld, const int idx, const T* beta, const T* gamma,
-                                      const float epsilon, T* output) {
+                                      const T epsilon, T* output) {
   // Assuming thread_data is already divided by ld
   // Small settings: the block covers the leading dimension TPB >= ld. The input
   // value is available in a register
-  // Uses fp32 accumulation for mean/variance to avoid overflow in fp16/bf16.
   using VecT = aligned_vector<T, ILP>;
-  using BlockReduce = cub::BlockReduce<cub::KeyValuePair<float, float>, TPB>;
+  using BlockReduce = cub::BlockReduce<cub::KeyValuePair<T, T>, TPB>;
   __shared__ typename BlockReduce::TempStorage temp_storage;
-  __shared__ float mu;      // mean
-  __shared__ float rsigma;  // 1 / std.dev.
-  T gamma_v[ILP], output_v[ILP];
+  __shared__ T mu;      // mean
+  __shared__ T rsigma;  // 1 / std.dev.
+  T beta_v[ILP], gamma_v[ILP], output_v[ILP];
 
   const bool is_valid = ILP * threadIdx.x < ld;
-  T beta_v[ILP];
   if (is_valid) {
     if (beta != nullptr) {
       VecT* beta_val = reinterpret_cast<VecT*>(&beta_v);
@@ -159,21 +177,20 @@ __device__ inline void LayerNormSmall(const T* input_v, const cub::KeyValuePair<
   }
 
   KeyValuePairSum pair_sum;
-  const cub::KeyValuePair<float, float> sum_kv = BlockReduce(temp_storage).Reduce(thread_data, pair_sum);
+  const cub::KeyValuePair<T, T> sum_kv = BlockReduce(temp_storage).Reduce(thread_data, pair_sum);
 
   if (threadIdx.x == 0) {
     mu = sum_kv.key;
-    rsigma = rsqrtf(sum_kv.value - mu * mu + epsilon);
+    rsigma = Rsqrt(sum_kv.value - mu * mu + epsilon);
   }
   __syncthreads();
 
   if (is_valid) {
 #pragma unroll
     for (int i = 0; i < ILP; i++) {
-      const float in_f = static_cast<float>(input_v[i]);
-      const float g_f = static_cast<float>(gamma_v[i]);
-      const float b_f = (beta != nullptr) ? static_cast<float>(beta_v[i]) : 0.f;
-      output_v[i] = static_cast<T>(g_f * (in_f - mu) * rsigma + b_f);
+      output_v[i] = (beta != nullptr)
+                        ? gamma_v[i] * (input_v[i] - mu) * rsigma + beta_v[i]
+                        : gamma_v[i] * (input_v[i] - mu) * rsigma;
     }
 
     VecT* output_val = reinterpret_cast<VecT*>(&output_v);
@@ -183,11 +200,10 @@ __device__ inline void LayerNormSmall(const T* input_v, const cub::KeyValuePair<
 
 template <typename T, int TPB, int ILP>
 __device__ inline void SimplifiedLayerNormSmall(const T* input_v, const float& thread_data, const int ld, const int idx,
-                                                const T* gamma, const float epsilon, T* output) {
+                                                const T* gamma, const T epsilon, T* output) {
   // Assuming thread_data is already divided by ld
   // Small settings: the block covers the leading dimension TPB >= ld. The input
   // value is available in a register
-  // Uses fp32 accumulation to avoid overflow in fp16/bf16.
   using VecT = aligned_vector<T, ILP>;
   using BlockReduce = cub::BlockReduce<float, TPB>;
   __shared__ typename BlockReduce::TempStorage temp_storage;
@@ -205,16 +221,14 @@ __device__ inline void SimplifiedLayerNormSmall(const T* input_v, const float& t
   const float sum = BlockReduce(temp_storage).Sum(thread_data);
 
   if (threadIdx.x == 0) {
-    rsigma = rsqrtf(sum + epsilon);
+    rsigma = Rsqrt(sum + static_cast<float>(epsilon));
   }
   __syncthreads();
 
   if (is_valid) {
 #pragma unroll
     for (int i = 0; i < ILP; i++) {
-      const float in_f = static_cast<float>(input_v[i]);
-      const float g_f = static_cast<float>(gamma_v[i]);
-      output_v[i] = static_cast<T>(g_f * in_f * rsigma);
+      output_v[i] = static_cast<T>(static_cast<float>(gamma_v[i]) * static_cast<float>(input_v[i]) * rsigma);
     }
 
     VecT* output_val = reinterpret_cast<VecT*>(&output_v);

--- a/onnxruntime/contrib_ops/cuda/bert/skip_layer_norm_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/skip_layer_norm_impl.cu
@@ -37,6 +37,24 @@ namespace contrib {
 namespace cuda {
 
 namespace {
+template <typename T>
+T maybe2half(float x);
+
+template <>
+float maybe2half(float x) {
+  return x;
+}
+
+template <>
+half maybe2half(float x) {
+  return __float2half_rn(x);
+}
+
+template <>
+nv_bfloat16 maybe2half(float x) {
+  return __float2bfloat16_rn(x);
+}
+
 // Using only power of 2 numbers will lead to waste of compute for same size such as 768, which is a very common case
 // in BERT. Ideally we can step by wrap_size * num_unroll, but listing too many steps will cause long compile time.
 constexpr int kSizes[] = {128, 320, 384, 640, 768, 1024, 1280, 2048, 4096, 5120, 8192};
@@ -72,16 +90,16 @@ bool CanVectorized(void* output, void* sum_output, const void* input, const void
 
 template <typename T, unsigned TPB, bool Simplified>
 __global__ void SkipLayerNormKernel(
-    T* output, T* sum_output, const T* input, const T* skip, const T* bias, const T* gamma, const T* beta,
-    float epsilon, const int ld, int skip_size) {
-  const float reverse_ld = 1.f / ld;
+    T* output, T* sum_output, const T* input, const T* skip, const T* bias, const T* gamma, const T* beta, T epsilon,
+    const int ld, int skip_size) {
+  const T reverse_ld = T(1.f / ld);
   const int offset = blockIdx.x * ld;
   const bool has_bias = (bias != nullptr);
 
   // Reduce sum of x and x^2, and the results are divided by ld.
-  // Uses fp32 accumulation to avoid overflow in fp16/bf16.
   KeyValuePairSum pair_sum;
-  cub::KeyValuePair<float, float> thread_data(0.f, 0.f);
+  cub::KeyValuePair<T, T> thread_data(0, 0);
+  float thread_data_simplified = 0.0f;
 
   for (int i = threadIdx.x; i < ld; i += TPB) {
     const int idx = offset + i;
@@ -92,9 +110,13 @@ __global__ void SkipLayerNormKernel(
     }
     val += skip[idx % skip_size];
 
-    const float val_f = static_cast<float>(val);
-    const float rldval = reverse_ld * val_f;
-    thread_data = pair_sum(thread_data, cub::KeyValuePair<float, float>(rldval, rldval * val_f));
+    const T rldval = reverse_ld * val;
+    thread_data = pair_sum(thread_data, cub::KeyValuePair<T, T>(rldval, rldval * val));
+
+    if (Simplified) {
+      float val_f = static_cast<float>(val);
+      thread_data_simplified += static_cast<float>(reverse_ld) * val_f * val_f;
+    }
 
     if (sum_output != nullptr) {
       sum_output[idx] = val;
@@ -104,7 +126,7 @@ __global__ void SkipLayerNormKernel(
   }
 
   if (Simplified) {
-    SimplifiedLayerNorm<T, TPB>(thread_data.value, ld, offset, gamma, epsilon, output);
+    SimplifiedLayerNorm<T, TPB>(thread_data_simplified, ld, offset, gamma, epsilon, output);
     return;
   }
   LayerNorm<T, TPB>(thread_data, ld, offset, beta, gamma, epsilon, output);
@@ -113,15 +135,16 @@ __global__ void SkipLayerNormKernel(
 // Vectorized kernel
 template <typename T, unsigned TPB, int ILP, bool Simplified>
 __global__ void SkipLayerNormKernelSmall(
-    T* output, T* sum_output, const T* input, const T* skip, const T* bias, const T* gamma, const T* beta,
-    float epsilon, int ld, int skip_size) {
-  const float rld = 1.f / ld;
+    T* output, T* sum_output, const T* input, const T* skip, const T* bias, const T* gamma, const T* beta, T epsilon,
+    int ld, int skip_size) {
+  const T rld = T(1.f / ld);
   const int idx = blockIdx.x * ld + threadIdx.x * ILP;
 
   using VecT = aligned_vector<T, ILP>;
   T sum_v[ILP];
 
-  cub::KeyValuePair<float, float> thread_data(0.f, 0.f);
+  cub::KeyValuePair<T, T> thread_data(T(0.f), T(0.f));
+  float thread_data_simplified = 0.0f;
 
   if (ILP * threadIdx.x < ld) {  // load data under this guard to avoid reading out-of-bounds
     T skip_v[ILP], bias_v[ILP];
@@ -139,8 +162,9 @@ __global__ void SkipLayerNormKernelSmall(
       *bias_val = *reinterpret_cast<const VecT*>(&bias[threadIdx.x * ILP]);
     }
 
-    float rldval_sum = 0.f;
-    float rldvalsq_sum = 0.f;
+    T rldval_sum = T(0.f);
+    T rldvalsq_sum = T(0.f);
+    float rldvalsq_sum_f = 0.0f;
     const bool has_sum_output = (sum_output != nullptr);
 
 #pragma unroll
@@ -150,21 +174,26 @@ __global__ void SkipLayerNormKernelSmall(
       }
       sum_v[i] += skip_v[i];
 
-      const float val_f = static_cast<float>(sum_v[i]);
-      const float rldval = rld * val_f;
+      const T rldval = rld * sum_v[i];
       rldval_sum += rldval;
-      rldvalsq_sum += rldval * val_f;
+      rldvalsq_sum += rldval * sum_v[i];
+
+      if (Simplified) {
+        float val_f = static_cast<float>(sum_v[i]);
+        rldvalsq_sum_f += static_cast<float>(rld) * val_f * val_f;
+      }
     }
 
     if (has_sum_output) {
       *(reinterpret_cast<VecT*>(&sum_output[idx])) = *reinterpret_cast<VecT*>(&sum_v);
     }
 
-    thread_data = cub::KeyValuePair<float, float>(rldval_sum, rldvalsq_sum);
+    thread_data = cub::KeyValuePair<T, T>(rldval_sum, rldvalsq_sum);
+    thread_data_simplified = rldvalsq_sum_f;
   }
 
   if (Simplified) {
-    SimplifiedLayerNormSmall<T, TPB, ILP>(sum_v, thread_data.value, ld, idx, gamma, epsilon, output);
+    SimplifiedLayerNormSmall<T, TPB, ILP>(sum_v, thread_data_simplified, ld, idx, gamma, epsilon, output);
     return;
   }
   LayerNormSmall<T, TPB, ILP>(sum_v, thread_data, ld, idx, beta, gamma, epsilon, output);
@@ -188,11 +217,11 @@ void LaunchSkipLayerNormKernel(
 
 #define LAUNCH_SKIP_LAYER_NORM_KERNEL_SMALL(num_unroll)                                                  \
   SkipLayerNormKernelSmall<T, block_size, num_unroll, Simplified><<<grid_size, block_size, 0, stream>>>( \
-      output, sum_output, input, skip, bias, gamma, beta, epsilon, ld, skip_size)
+      output, sum_output, input, skip, bias, gamma, beta, maybe2half<T>(epsilon), ld, skip_size)
 
 #define LAUNCH_SKIP_LAYER_NORM_KERNEL()                                                 \
   SkipLayerNormKernel<T, block_size, Simplified><<<grid_size, block_size, 0, stream>>>( \
-      output, sum_output, input, skip, bias, gamma, beta, epsilon, ld, skip_size)
+      output, sum_output, input, skip, bias, gamma, beta, maybe2half<T>(epsilon), ld, skip_size)
 
 #define CASE_NEXT_SIZE(next_size_value)                                         \
   case next_size_value: {                                                       \


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
This PR resolves a critical numerical stability bug in the `SkipSimplifiedLayerNormalization` CUDA kernel when operating under `float16` (FP16) precision.

To prevent variance overflow during FP16 reduction, this change upgrades the precision of the intermediate reduction variables to `float` (FP32) within the non-strict simplified layer normalization paths:
1. **Precision Upgrade in Kernel Helpers (`layer_norm.cuh`)**: Modified the simplified variance reduction loops to accumulate intermediate squared states using `float` instead of `half` (via `cub::BlockReduce<float, TPB>`).
2. **Precision Upgrade in Host/Device Implementations (`skip_layer_norm_impl.cu`)**: Updated the shared memory allocation and thread-local data registers to use `float` for tracking the sum-of-squares.

This maintains FP16 inputs/outputs and retains high performance while guaranteeing numerical stability during reduction, achieving parity with the CPU EP and the strict-mode CUDA kernels.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
**Fixes #29034**

When executing transformer architectures in FP16 mode, input activations with large magnitudes (e.g., maximum absolute values > 7600, common in deep layer activations, scaling factors, or specific outlier features) can cause the variance calculation inside `SkipSimplifiedLayerNormalization` to overflow silently.

Because the maximum representable value for FP16 is $65504$, accumulating squared activations for a hidden dimension (e.g., $hidden\_size = 768$ or $1024$) easily exceeds this limit. In the existing non-strict kernels, this results in an overflow to infinity ($\infty$), producing `NaN` or silent all-zero outputs without throwing a runtime exception or crash. This is particularly problematic in production (e.g., `openai/privacy-filter` deployments), where the PII detection can silently fail by outputting zero logits.

By upgrading the intermediate accumulation to FP32, the numerical bounds are dramatically increased, fully eliminating the overflow risk for these models.
