### PR TITLE
[CUDA] Enable XQA by default for FP16/BF16 GQA

### DIFF
--- a/cmake/patches/abseil/absl_cuda_warnings.patch
+++ b/cmake/patches/abseil/absl_cuda_warnings.patch
@@ -1,8 +1,8 @@
 diff --git a/absl/hash/internal/hash.h b/absl/hash/internal/hash.h
 index 1234567..abcdefg 100644
---- a/absl/hash/internal/hash.h
-+++ b/absl/hash/internal/hash.h
-@@ -477,7 +477,7 @@ H AbslHashValue(H hash_state, T (&)[N]) {
+--- a/absl/hash/internal/hash.h	2026-06-14 09:18:51.688331018 +0000
++++ b/absl/hash/internal/hash.h	2026-06-14 09:18:51.693331114 +0000
+@@ -478,7 +478,7 @@
  template <typename H, typename T, size_t N>
  H AbslHashValue(H hash_state, T (&)[N]) {
    static_assert(
@@ -11,7 +11,7 @@ index 1234567..abcdefg 100644
        "Hashing C arrays is not allowed. For string literals, wrap the literal "
        "in absl::string_view(). To hash the array contents, use "
        "absl::MakeSpan() or make the array an std::array. To hash the array "
-@@ -1265,7 +1265,7 @@ class ABSL_DLL MixingHashState : public HashStateBase<MixingHashState> {
+@@ -1265,7 +1265,7 @@
    }
 
   private:
@@ -22,9 +22,9 @@ index 1234567..abcdefg 100644
                                                            WeaklyMixedInteger);
 diff --git a/absl/hash/hash.h b/absl/hash/hash.h
 index 1234567..abcdefg 100644
---- a/absl/hash/hash.h
-+++ b/absl/hash/hash.h
-@@ -333,7 +333,8 @@ class HashState : public hash_internal::HashStateBase<HashState> {
+--- a/absl/hash/hash.h	2026-06-14 09:18:51.688331018 +0000
++++ b/absl/hash/hash.h	2026-06-14 09:18:51.697331190 +0000
+@@ -332,7 +332,8 @@
        absl::enable_if_t<
            std::is_base_of<hash_internal::HashStateBase<T>, T>::value, int> = 0>
    static HashState Create(T* state) {
@@ -34,7 +34,7 @@ index 1234567..abcdefg 100644
      s.Init(state);
      return s;
    }
-@@ -368,7 +369,7 @@ class HashState : public hash_internal::HashStateBase<HashState> {
+@@ -368,7 +369,7 @@
   private:
    HashState() = default;
 
@@ -45,9 +45,9 @@ index 1234567..abcdefg 100644
    template <typename T>
 diff --git a/absl/container/internal/raw_hash_set.h b/absl/container/internal/raw_hash_set.h
 index 1234567..abcdefg 100644
---- a/absl/container/internal/raw_hash_set.h
-+++ b/absl/container/internal/raw_hash_set.h
-@@ -464,7 +464,7 @@ inline uint16_t NextSeed() {
+--- a/absl/container/internal/raw_hash_set.h	2026-06-14 09:18:51.688331018 +0000
++++ b/absl/container/internal/raw_hash_set.h	2026-06-14 09:18:51.699331228 +0000
+@@ -465,7 +465,7 @@
  inline uint16_t NextSeed() {
    static_assert(PerTableSeed::kBitCount == 16);
    thread_local uint16_t seed =
@@ -56,3 +56,16 @@ index 1234567..abcdefg 100644
    seed += uint16_t{0xad53};
    return seed;
  }
+diff --git a/absl/container/internal/common.h b/absl/container/internal/common.h
+index 1234567..abcdefg 100644
+--- a/absl/container/internal/common.h	2026-06-14 09:18:51.688331018 +0000
++++ b/absl/container/internal/common.h	2026-06-14 09:18:51.701331266 +0000
+@@ -59,7 +59,7 @@
+ template <class T>
+ struct IfRRef {
+   template <class Other>
+-  using AddPtr = Other;
++  using AddPtr = std::enable_if_t<true, Other>;
+ };
+
+ template <class T>

--- a/cmake/patches/abseil/absl_cuda_warnings.patch
+++ b/cmake/patches/abseil/absl_cuda_warnings.patch
@@ -1,8 +1,8 @@
 diff --git a/absl/hash/internal/hash.h b/absl/hash/internal/hash.h
 index 1234567..abcdefg 100644
---- a/absl/hash/internal/hash.h	2026-06-14 09:18:51.688331018 +0000
-+++ b/absl/hash/internal/hash.h	2026-06-14 09:18:51.693331114 +0000
-@@ -478,7 +478,7 @@
+--- a/absl/hash/internal/hash.h
++++ b/absl/hash/internal/hash.h
+@@ -477,7 +477,7 @@ H AbslHashValue(H hash_state, T (&)[N]) {
  template <typename H, typename T, size_t N>
  H AbslHashValue(H hash_state, T (&)[N]) {
    static_assert(
@@ -11,7 +11,7 @@ index 1234567..abcdefg 100644
        "Hashing C arrays is not allowed. For string literals, wrap the literal "
        "in absl::string_view(). To hash the array contents, use "
        "absl::MakeSpan() or make the array an std::array. To hash the array "
-@@ -1265,7 +1265,7 @@
+@@ -1265,7 +1265,7 @@ class ABSL_DLL MixingHashState : public HashStateBase<MixingHashState> {
    }
 
   private:
@@ -22,9 +22,9 @@ index 1234567..abcdefg 100644
                                                            WeaklyMixedInteger);
 diff --git a/absl/hash/hash.h b/absl/hash/hash.h
 index 1234567..abcdefg 100644
---- a/absl/hash/hash.h	2026-06-14 09:18:51.688331018 +0000
-+++ b/absl/hash/hash.h	2026-06-14 09:18:51.697331190 +0000
-@@ -332,7 +332,8 @@
+--- a/absl/hash/hash.h
++++ b/absl/hash/hash.h
+@@ -333,7 +333,8 @@ class HashState : public hash_internal::HashStateBase<HashState> {
        absl::enable_if_t<
            std::is_base_of<hash_internal::HashStateBase<T>, T>::value, int> = 0>
    static HashState Create(T* state) {
@@ -34,7 +34,7 @@ index 1234567..abcdefg 100644
      s.Init(state);
      return s;
    }
-@@ -368,7 +369,7 @@
+@@ -368,7 +369,7 @@ class HashState : public hash_internal::HashStateBase<HashState> {
   private:
    HashState() = default;
 
@@ -45,9 +45,9 @@ index 1234567..abcdefg 100644
    template <typename T>
 diff --git a/absl/container/internal/raw_hash_set.h b/absl/container/internal/raw_hash_set.h
 index 1234567..abcdefg 100644
---- a/absl/container/internal/raw_hash_set.h	2026-06-14 09:18:51.688331018 +0000
-+++ b/absl/container/internal/raw_hash_set.h	2026-06-14 09:18:51.699331228 +0000
-@@ -465,7 +465,7 @@
+--- a/absl/container/internal/raw_hash_set.h
++++ b/absl/container/internal/raw_hash_set.h
+@@ -464,7 +464,7 @@ inline uint16_t NextSeed() {
  inline uint16_t NextSeed() {
    static_assert(PerTableSeed::kBitCount == 16);
    thread_local uint16_t seed =
@@ -56,16 +56,3 @@ index 1234567..abcdefg 100644
    seed += uint16_t{0xad53};
    return seed;
  }
-diff --git a/absl/container/internal/common.h b/absl/container/internal/common.h
-index 1234567..abcdefg 100644
---- a/absl/container/internal/common.h	2026-06-14 09:18:51.688331018 +0000
-+++ b/absl/container/internal/common.h	2026-06-14 09:18:51.701331266 +0000
-@@ -59,7 +59,7 @@
- template <class T>
- struct IfRRef {
-   template <class Other>
--  using AddPtr = Other;
-+  using AddPtr = std::enable_if_t<true, Other>;
- };
-
- template <class T>

--- a/onnxruntime/contrib_ops/cuda/bert/group_query_attention.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/group_query_attention.cc
@@ -110,15 +110,9 @@ GroupQueryAttention<T, U>::GroupQueryAttention(const OpKernelInfo& info)
   v_quant_type_ = StringToKVQuantizationType(info.GetAttrOrDefault<std::string>("v_quant_type", "NONE"));
   kv_cache_bit_width_ = static_cast<int>(info.GetAttrOrDefault<int64_t>("kv_cache_bit_width", 0));
 
-  bool is_quantized = (k_quant_type_ != KVQuantizationType::NONE || v_quant_type_ != KVQuantizationType::NONE);
-  // XQA enablement:
-  //  - An explicit ORT_ENABLE_XQA overrides everything (1 = on, 0 = off, including the head_sink default-on path).
-  //  - When unset, XQA defaults on for both quantized and non-quantized fp16/bf16 paths.
   constexpr bool kIsFp16OrBf16 = std::is_same_v<T, MLFloat16> || std::is_same_v<T, BFloat16>;
-  const int xqa_env = ParseEnvironmentVariableWithDefault<int>("ORT_ENABLE_XQA", -1);  // -1 means unset
-  xqa_force_disabled_ = (xqa_env == 0);
-  const int effective_enable_xqa = (xqa_env == -1) ? 1 : xqa_env;
-  enable_xqa_ = kIsFp16OrBf16 && (effective_enable_xqa != 0);
+  // XQA defaults on for fp16/bf16; ORT_ENABLE_XQA=0 disables it explicitly.
+  enable_xqa_ = kIsFp16OrBf16 && (ParseEnvironmentVariableWithDefault<int>("ORT_ENABLE_XQA", 1) != 0);
 
   kernel_options_ = this->GetAttentionKernelOptions();
 
@@ -397,12 +391,8 @@ Status GroupQueryAttention<T, U>::ComputeInternal(OpKernelContext* context) cons
   // 7. No local window attention (global attention only).
   const bool use_xqa_attention_sinks = head_sink != nullptr && !is_inputs_quantized;
   const bool is_xqa_smooth_softmax_supported = !parameters.use_smooth_softmax || use_xqa_attention_sinks;
-  // XQA is enabled by default (enable_xqa_=true when ORT_ENABLE_XQA is unset).
-  // An explicit ORT_ENABLE_XQA=0 (xqa_force_disabled_) overrides everything and turns XQA off entirely.
-  // Ineligible shapes/group sizes fall back via data.use_xqa below.
-  constexpr bool kIsFp16OrBf16 = std::is_same_v<T, MLFloat16> || std::is_same_v<T, BFloat16>;
-  const bool xqa_enabled_for_run = !xqa_force_disabled_ && enable_xqa_;
-  if (xqa_enabled_for_run &&
+  // XQA is enabled when enable_xqa_=true; ineligible shapes/group sizes fall back via data.use_xqa below.
+  if (enable_xqa_ &&
       (device_prop.major >= 8) &&
       !parameters.is_first_prompt &&
       parameters.sequence_length == 1 &&

--- a/onnxruntime/contrib_ops/cuda/bert/group_query_attention.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/group_query_attention.cc
@@ -397,13 +397,11 @@ Status GroupQueryAttention<T, U>::ComputeInternal(OpKernelContext* context) cons
   // 7. No local window attention (global attention only).
   const bool use_xqa_attention_sinks = head_sink != nullptr && !is_inputs_quantized;
   const bool is_xqa_smooth_softmax_supported = !parameters.use_smooth_softmax || use_xqa_attention_sinks;
-  // XQA is opt-in for the non-quantized path (ORT_ENABLE_XQA), but a head_sink (attention sink) input
-  // signals a GPT-OSS style decode model that benefits from XQA, so enable it by default in that case.
-  // An explicit ORT_ENABLE_XQA=0 (xqa_force_disabled_) still wins and turns XQA off entirely.
-  // The dtype guard mirrors enable_xqa_ (XQA only supports fp16/bf16); ineligible cases fall back below.
+  // XQA is enabled by default (enable_xqa_=true when ORT_ENABLE_XQA is unset).
+  // An explicit ORT_ENABLE_XQA=0 (xqa_force_disabled_) overrides everything and turns XQA off entirely.
+  // Ineligible shapes/group sizes fall back via data.use_xqa below.
   constexpr bool kIsFp16OrBf16 = std::is_same_v<T, MLFloat16> || std::is_same_v<T, BFloat16>;
-  const bool xqa_enabled_for_run =
-      !xqa_force_disabled_ && (enable_xqa_ || (kIsFp16OrBf16 && use_xqa_attention_sinks));
+  const bool xqa_enabled_for_run = !xqa_force_disabled_ && enable_xqa_;
   if (xqa_enabled_for_run &&
       (device_prop.major >= 8) &&
       !parameters.is_first_prompt &&

--- a/onnxruntime/contrib_ops/cuda/bert/group_query_attention.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/group_query_attention.cc
@@ -113,12 +113,11 @@ GroupQueryAttention<T, U>::GroupQueryAttention(const OpKernelInfo& info)
   bool is_quantized = (k_quant_type_ != KVQuantizationType::NONE || v_quant_type_ != KVQuantizationType::NONE);
   // XQA enablement:
   //  - An explicit ORT_ENABLE_XQA overrides everything (1 = on, 0 = off, including the head_sink default-on path).
-  //  - When unset, XQA defaults on for the quantized KV cache path and off for the non-quantized path
-  //    (the non-quantized head_sink decode path is additionally enabled per-Run in ComputeInternal).
+  //  - When unset, XQA defaults on for both quantized and non-quantized fp16/bf16 paths.
   constexpr bool kIsFp16OrBf16 = std::is_same_v<T, MLFloat16> || std::is_same_v<T, BFloat16>;
   const int xqa_env = ParseEnvironmentVariableWithDefault<int>("ORT_ENABLE_XQA", -1);  // -1 means unset
   xqa_force_disabled_ = (xqa_env == 0);
-  const int effective_enable_xqa = (xqa_env == -1) ? (is_quantized ? 1 : 0) : xqa_env;
+  const int effective_enable_xqa = (xqa_env == -1) ? 1 : xqa_env;
   enable_xqa_ = kIsFp16OrBf16 && (effective_enable_xqa != 0);
 
   kernel_options_ = this->GetAttentionKernelOptions();
@@ -437,7 +436,8 @@ Status GroupQueryAttention<T, U>::ComputeInternal(OpKernelContext* context) cons
 
     bool is_non_quantized_supported = !is_inputs_quantized &&
                                       (parameters.head_size == 256 || parameters.head_size == 128 || parameters.head_size == 64) &&
-                                      (64 % group_size == 0);
+                                      (group_size == 1 || group_size == 2 || group_size == 4 || group_size == 5 ||
+                                       group_size == 8 || group_size == 16 || group_size == 32);
 
     data.use_xqa = (is_non_quantized_supported || is_int8_quantized_supported || is_fp8_quantized_supported);
 

--- a/onnxruntime/contrib_ops/cuda/bert/group_query_attention.h
+++ b/onnxruntime/contrib_ops/cuda/bert/group_query_attention.h
@@ -38,7 +38,7 @@ class GroupQueryAttention final : public CudaKernel {
   bool disable_flash_attention_;
   bool disable_memory_efficient_attention_;
   bool disable_flash_decode_;
-  bool enable_xqa_;  // True when ORT_ENABLE_XQA != 0 (default: on) and T is fp16/bf16.
+  bool enable_xqa_;                         // True when ORT_ENABLE_XQA != 0 (default: on) and T is fp16/bf16.
   bool enable_cudnn_flash_attention_;       // cuDNN SDPA explicitly enabled (env / sdpa_kernel)
   bool auto_enable_cudnn_flash_attention_;  // auto-prefer cuDNN SDPA on SM>=90 when no explicit kernel pinned
 

--- a/onnxruntime/contrib_ops/cuda/bert/group_query_attention.h
+++ b/onnxruntime/contrib_ops/cuda/bert/group_query_attention.h
@@ -38,8 +38,7 @@ class GroupQueryAttention final : public CudaKernel {
   bool disable_flash_attention_;
   bool disable_memory_efficient_attention_;
   bool disable_flash_decode_;
-  bool enable_xqa_;
-  bool xqa_force_disabled_;                 // True when ORT_ENABLE_XQA=0 is explicitly set (overrides default-on paths).
+  bool enable_xqa_;  // True when ORT_ENABLE_XQA != 0 (default: on) and T is fp16/bf16.
   bool enable_cudnn_flash_attention_;       // cuDNN SDPA explicitly enabled (env / sdpa_kernel)
   bool auto_enable_cudnn_flash_attention_;  // auto-prefer cuDNN SDPA on SM>=90 when no explicit kernel pinned
 

--- a/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_loader_bf16_impl.cuh
+++ b/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_loader_bf16_impl.cuh
@@ -72,6 +72,14 @@ namespace HEAD_DIM_NAMESPACE {
 #undef GRP_SIZE
 #undef M_TILESIZE
 
+#define NAMESPACE_NAME grp5_bf16
+#define GRP_SIZE 5
+#define M_TILESIZE 8
+#include "xqa_impl_gen.cuh"
+#undef NAMESPACE_NAME
+#undef GRP_SIZE
+#undef M_TILESIZE
+
 #define NAMESPACE_NAME grp8_bf16
 #define GRP_SIZE 8
 #define M_TILESIZE 8
@@ -215,6 +223,8 @@ Status LaunchXQAKernelImpl<__nv_bfloat16>(
       return grp2_bf16::Launch<__nv_bfloat16>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size);
     case 4:
       return grp4_bf16::Launch<__nv_bfloat16>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size);
+    case 5:
+      return grp5_bf16::Launch<__nv_bfloat16>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size);
     case 8:
       return grp8_bf16::Launch<__nv_bfloat16>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size);
     case 16:
@@ -222,7 +232,7 @@ Status LaunchXQAKernelImpl<__nv_bfloat16>(
     case 32:
       return grp32_bf16::Launch<__nv_bfloat16>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size);
     default:
-      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "XQA supports group_size 1, 2, 4, 8, 16, 32. Input has ", group_size);
+      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "XQA supports group_size 1, 2, 4, 5, 8, 16, 32. Input has ", group_size);
   }
 }
 

--- a/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_loader_fp16_impl.cuh
+++ b/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_loader_fp16_impl.cuh
@@ -72,6 +72,14 @@ namespace HEAD_DIM_NAMESPACE {
 #undef GRP_SIZE
 #undef M_TILESIZE
 
+#define NAMESPACE_NAME grp5_fp16
+#define GRP_SIZE 5
+#define M_TILESIZE 8
+#include "xqa_impl_gen.cuh"
+#undef NAMESPACE_NAME
+#undef GRP_SIZE
+#undef M_TILESIZE
+
 #define NAMESPACE_NAME grp8_fp16
 #define GRP_SIZE 8
 #define M_TILESIZE 8
@@ -197,6 +205,8 @@ Status LaunchXQAKernelImpl(
       return grp2_fp16::Launch<T>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size);
     case 4:
       return grp4_fp16::Launch<T>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size);
+    case 5:
+      return grp5_fp16::Launch<T>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size);
     case 8:
       return grp8_fp16::Launch<T>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size);
     case 16:
@@ -204,7 +214,7 @@ Status LaunchXQAKernelImpl(
     case 32:
       return grp32_fp16::Launch<T>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size);
     default:
-      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "XQA supports group_size 1, 2, 4, 8, 16, 32. Input has ", group_size);
+      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "XQA supports group_size 1, 2, 4, 5, 8, 16, 32. Input has ", group_size);
   }
 }
 

--- a/onnxruntime/test/python/transformers/benchmark_gqa.py
+++ b/onnxruntime/test/python/transformers/benchmark_gqa.py
@@ -259,6 +259,7 @@ def run_performance_test(
     # Note: some models use bf16.
     # We use fp16/bf16 for all models in this test.
     configures = [
+        (40, 128, 8, 8192, None, "Qwen3-14B"),
         (32, 128, 8, 8192, None, "Llama3-8B"),
         (64, 128, 8, 8192, None, "Llama3-70B"),
         (32, 128, 8, 32768, 4096, "Mistral-7B-v0.1"),

--- a/onnxruntime/test/python/transformers/test_gqa.py
+++ b/onnxruntime/test/python/transformers/test_gqa.py
@@ -2371,9 +2371,9 @@ def gqa_xqa_head_sink_test_cases():
     # Non-quantized global decode with a head_sink (attention sink) input.
     # These configs exercise the XQA attention-sink path added for GPT-OSS style models:
     # seq_len=1, shared KV buffer, no softcap, no local window, head_size in {64, 128},
-    # and 64 % group_size == 0.
+    # and group_size in {1, 2, 4, 5, 8, 16, 32}.
     for torch_type, ort_type in [(torch.float16, TensorProto.FLOAT16), (torch.bfloat16, TensorProto.BFLOAT16)]:
-        for group_size in [1, 4, 8]:
+        for group_size in [1, 4, 5, 8]:
             for head_size in [64, 128]:
                 for rotary in [False, True]:
                     kv_num_heads = 4

--- a/onnxruntime/test/python/transformers/test_gqa.py
+++ b/onnxruntime/test/python/transformers/test_gqa.py
@@ -2435,8 +2435,8 @@ class TestXQAHeadSinkParity(unittest.TestCase):
     """Verify the non-quantized XQA attention-sink (head_sink) decode path matches the reference."""
 
     def setUp(self):
-        # XQA is enabled by default when a head_sink input is present, so this path is exercised
-        # without ORT_ENABLE_XQA. Clear it (saving the previous value) to test the real default.
+        # XQA is enabled by default for fp16/bf16 (ORT_ENABLE_XQA defaults to 1).
+        # Pop any override so we exercise the real default behavior.
         self._prev_enable_xqa = os.environ.pop("ORT_ENABLE_XQA", None)
 
     def tearDown(self):


### PR DESCRIPTION
### Description

Enable XQA by default for non-quantized FP16/BF16 GQA. XQA is a TensorRT-LLM-derived fused decode kernel (`seq_len=1`) that also fuses RoPE + KV-append into a single pass. Requires SM80+, shared KV buffer, no softcap.

Also add `group_size=5` XQA support (e.g. Qwen3-14B: 40 Q-heads / 8 KV-heads) for the Qwen series.


#### Affected models

| Model | group_size | Before | After |
|---|---|---|---|
| Qwen3-8B | 4 | FlashDecode (opt-in XQA) | XQA default |
| Qwen3-14B | 5 | No XQA | XQA default |
| Qwen2-72B | 8 | FlashDecode (opt-in XQA) | XQA default |
| Qwen2-7B | 7 | No XQA | No XQA (unsupported tile width) |

### Performance Result

repro:
```
LD_PRELOAD=/usr/local/cuda-12.8/lib64/libcudart.so.12 \
  LD_LIBRARY_PATH=/usr/local/cuda-12.8/lib64:/workspace/onnxruntime/.venv/lib/python3.12/site-packages/nvidia/cudnn/lib \
  PYTHONPATH=build/Release:onnxruntime/test/python/transformers \
  python onnxruntime/test/python/transformers/benchmark_gqa.py
```

Benchmark: Qwen3-14B (40Q/8KV heads, head_dim=128, fp16, batch=1, SM80, CUDA12.8)

| past_seq_len | XQA off | XQA on | Speedup |
|---|---|---|---|
| 256 | 0.124 ms | 0.092 ms | 1.30× |
| 512 | 0.122 ms | 0.089 ms | 1.33× |
| 1024 | 0.133 ms | 0.094 ms | 1.42× |
| 2048 | 0.136 ms | 0.095 ms | 1.43× |
| 4096 | 0.152 ms | 0.103 ms | 1.42× |
| 8191 | 0.182 ms | 0.116 ms | 1.57× |

Speedup grows with context length (1.30× → 1.57×). No regression in the prompt/prefill path.

### Testing

- `pytest onnxruntime/test/python/transformers/test_gqa.py -v`
- `ORT_ENABLE_XQA=0 pytest onnxruntime/test/python/transformers/test_gqa.py -v` (opt-out smoke test)
