### PR TITLE
Add 2-bit quantization support to WebGPU GatherBlockQuantized operator

### DIFF
--- a/onnxruntime/contrib_ops/webgpu/quantization/gather_block_quantized.cc
+++ b/onnxruntime/contrib_ops/webgpu/quantization/gather_block_quantized.cc
@@ -74,6 +74,10 @@ Status GatherBlockQuantizedProgram::GenerateShaderCode(ShaderHelper& shader) con
         << "  let byte_in_word_2b = byte_idx_2b % 4;\n"
         << "  let unpacked_bytes_2b = " << unpack << "(u32(packed_word_2b));\n"
         << "  var quantized_data = (unpacked_bytes_2b[byte_in_word_2b] >> bit_shift_2b) & 0x3;\n";
+    if (is_signed_) {
+      shader.MainFunctionBody()
+          << "  if((quantized_data & 0x2) != 0) { quantized_data = quantized_data - 4 ;};\n";
+    }
   } else if (is_4bit) {
     shader.MainFunctionBody()
         << "  let data_index = data_offset % 8;\n"
@@ -149,8 +153,13 @@ Status GatherBlockQuantizedProgram::GenerateShaderCode(ShaderHelper& shader) con
           << "  var zero_point = zero_point_vec[zero_point_index];\n";
     }
     if (is_signed_) {
-      shader.MainFunctionBody()
-          << "  if((zero_point & 0x8) != 0) { zero_point = zero_point - 16 ;};\n";
+      if (is_2bit) {
+        shader.MainFunctionBody()
+            << "  if((zero_point & 0x2) != 0) { zero_point = zero_point - 4 ;};\n";
+      } else if (is_4bit) {
+        shader.MainFunctionBody()
+            << "  if((zero_point & 0x8) != 0) { zero_point = zero_point - 16 ;};\n";
+      }
     }
   }
   shader.MainFunctionBody()


### PR DESCRIPTION
Adds complete 2‑bit quantization support to the WebGPU GatherBlockQuantized operator. The implementation includes:

1. Sign‑extension logic for 2‑bit signed quantized values
2. Sign‑extension logic for 2‑bit signed zero points
3. Maintains full backward compatibility with existing 4‑bit and 8‑bit support
### Motivation and Context
This change addresses GitHub issue #28895: "Add 2‑bit quantization support to the WebGPU GatherBlockQuantized operator". The existing codebase had partial 2‑bit support but was missing sign‑extension, which is critical for correct dequantization of signed 2‑bit values (range [-2, 1]).

