### PR TITLE
Single-source OrtErrorCode values to keep StatusCode in sync

### DIFF
--- a/cmake/onnxruntime.cmake
+++ b/cmake/onnxruntime.cmake
@@ -29,6 +29,7 @@ function(get_c_cxx_api_headers HEADERS_VAR)
     "${REPO_ROOT}/include/onnxruntime/core/session/onnxruntime_env_config_keys.h"
     "${REPO_ROOT}/include/onnxruntime/core/session/onnxruntime_ep_c_api.h"
     "${REPO_ROOT}/include/onnxruntime/core/session/onnxruntime_ep_device_ep_metadata_keys.h"
+    "${REPO_ROOT}/include/onnxruntime/core/session/onnxruntime_error_code.h"
     "${REPO_ROOT}/include/onnxruntime/core/session/onnxruntime_experimental_c_api.h"
     "${REPO_ROOT}/include/onnxruntime/core/session/onnxruntime_experimental_c_api.inc"
     "${REPO_ROOT}/include/onnxruntime/core/session/onnxruntime_float16.h"

--- a/docs/c_cxx/Doxyfile
+++ b/docs/c_cxx/Doxyfile
@@ -946,6 +946,7 @@ WARN_LOGFILE           =
 INPUT                  = ../../include/onnxruntime/core/session/onnxruntime_c_api.h \
                          ../../include/onnxruntime/core/session/onnxruntime_cxx_api.h \
                          ../../include/onnxruntime/core/session/onnxruntime_ep_c_api.h \
+                         ../../include/onnxruntime/core/session/onnxruntime_error_code.h \
                          ../../orttraining/orttraining/training_api/include/onnxruntime_training_c_api.h \
                          ../../orttraining/orttraining/training_api/include/onnxruntime_training_cxx_api.h
 

--- a/include/onnxruntime/core/common/status.h
+++ b/include/onnxruntime/core/common/status.h
@@ -16,9 +16,13 @@ limitations under the License.
 #include <memory>
 #include <ostream>
 #include <string>
+
 #ifdef _WIN32
 #include <winerror.h>
 #endif
+
+#include "core/session/onnxruntime_error_code.h"
+
 namespace onnxruntime {
 namespace common {
 
@@ -31,24 +35,25 @@ enum StatusCategory {
 /**
  * Error code for ONNXRuntime.
  *
- * These values must stay in sync with the public C API OrtErrorCode enum values.
+ * The values are derived from the public C API OrtErrorCode enum so the enum values will match.
+ * If a new OrtErrorCode value is introduced, a corresponding value should also be added here.
  */
 enum StatusCode {
-  OK = 0,
-  FAIL = 1,
-  INVALID_ARGUMENT = 2,
-  NO_SUCHFILE = 3,
-  NO_MODEL = 4,
-  ENGINE_ERROR = 5,
-  RUNTIME_EXCEPTION = 6,
-  INVALID_PROTOBUF = 7,
-  MODEL_LOADED = 8,
-  NOT_IMPLEMENTED = 9,
-  INVALID_GRAPH = 10,
-  EP_FAIL = 11,
-  MODEL_LOAD_CANCELED = 12,
-  MODEL_REQUIRES_COMPILATION = 13,
-  NOT_FOUND = 14,
+  OK = ORT_OK,
+  FAIL = ORT_FAIL,
+  INVALID_ARGUMENT = ORT_INVALID_ARGUMENT,
+  NO_SUCHFILE = ORT_NO_SUCHFILE,
+  NO_MODEL = ORT_NO_MODEL,
+  ENGINE_ERROR = ORT_ENGINE_ERROR,
+  RUNTIME_EXCEPTION = ORT_RUNTIME_EXCEPTION,
+  INVALID_PROTOBUF = ORT_INVALID_PROTOBUF,
+  MODEL_LOADED = ORT_MODEL_LOADED,
+  NOT_IMPLEMENTED = ORT_NOT_IMPLEMENTED,
+  INVALID_GRAPH = ORT_INVALID_GRAPH,
+  EP_FAIL = ORT_EP_FAIL,
+  MODEL_LOAD_CANCELED = ORT_MODEL_LOAD_CANCELED,
+  MODEL_REQUIRES_COMPILATION = ORT_MODEL_REQUIRES_COMPILATION,
+  NOT_FOUND = ORT_NOT_FOUND,
 };
 
 constexpr const char* StatusCodeToString(StatusCode status) noexcept {

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -34,6 +34,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "onnxruntime_error_code.h"
+
 /** \brief The API version defined in this header
  *
  * This value is used by some API functions to behave as this version of the header expects.
@@ -262,79 +264,6 @@ typedef enum OrtLoggingLevel {
   ORT_LOGGING_LEVEL_ERROR,    ///< Error messages.
   ORT_LOGGING_LEVEL_FATAL,    ///< Fatal error messages (most severe).
 } OrtLoggingLevel;
-
-/** \brief Error codes reported by ONNX Runtime.
- *
- * The error code associated with an ::OrtStatus.
- */
-typedef enum OrtErrorCode {
-  /**
-   * Success. No error occurred.
-   */
-  ORT_OK,
-  /**
-   * Generic failure that does not map to a more specific error code. Consult the error message for details.
-   */
-  ORT_FAIL,
-  /**
-   * A caller-supplied argument was invalid (e.g. NULL pointer, out-of-range value, mismatched shape/rank, or bad
-   * configuration).
-   */
-  ORT_INVALID_ARGUMENT,
-  /**
-   * A required file (such as a model file) does not exist.
-   */
-  ORT_NO_SUCHFILE,
-  /**
-   * Legacy/unused but retained for ABI compatibility. Historically returned when a model could not be found by name in
-   * the ONNX Runtime Server (removed in 2022).
-   */
-  ORT_NO_MODEL,
-  /**
-   * A hardware accelerator or backend engine reported a failure (e.g. a device crash or other device-level error).
-   */
-  ORT_ENGINE_ERROR,
-  /**
-   * A generic runtime exception was caught. The error message is the primary source of detail.
-   */
-  ORT_RUNTIME_EXCEPTION,
-  /**
-   * Protobuf parsing or serialization failed.
-   */
-  ORT_INVALID_PROTOBUF,
-  /**
-   * Invalid session state for the requested operation. Despite the name, this code does not mean "success, model
-   * loaded"; it is returned when the session is in the wrong state for the requested call (e.g. a model is already
-   * loaded, the session is already initialized, or no model has been loaded yet). The name is historical and is
-   * retained for ABI compatibility; consult the error message for the specific condition.
-   */
-  ORT_MODEL_LOADED,
-  /**
-   * The requested functionality is not implemented in this build.
-   */
-  ORT_NOT_IMPLEMENTED,
-  /**
-   * The model graph is structurally invalid (e.g. recursive function definitions, invalid tensor dimensions, or
-   * malformed nodes).
-   */
-  ORT_INVALID_GRAPH,
-  /**
-   * An execution provider reported a generic failure.
-   */
-  ORT_EP_FAIL,
-  /**
-   * Model loading or session initialization was canceled at the caller's request.
-   */
-  ORT_MODEL_LOAD_CANCELED,
-  /**
-   * The model requires compilation by an execution provider, but compilation was disabled via session options.
-   */
-  ORT_MODEL_REQUIRES_COMPILATION,
-  /**
-   * A requested resource could not be found.
-   */
-  ORT_NOT_FOUND,
-} OrtErrorCode;
 
 typedef enum OrtOpAttrType {
   ORT_OP_ATTR_UNDEFINED = 0,

--- a/include/onnxruntime/core/session/onnxruntime_error_code.h
+++ b/include/onnxruntime/core/session/onnxruntime_error_code.h
@@ -1,0 +1,92 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+/** \addtogroup Global
+ * ONNX Runtime C API
+ * @{
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** \brief Error codes reported by ONNX Runtime.
+ *
+ * The error code associated with an ::OrtStatus.
+ */
+typedef enum OrtErrorCode {
+  /**
+   * Success. No error occurred.
+   */
+  ORT_OK,
+  /**
+   * Generic failure that does not map to a more specific error code. Consult the error message for details.
+   */
+  ORT_FAIL,
+  /**
+   * A caller-supplied argument was invalid (e.g. NULL pointer, out-of-range value, mismatched shape/rank, or bad
+   * configuration).
+   */
+  ORT_INVALID_ARGUMENT,
+  /**
+   * A required file (such as a model file) does not exist.
+   */
+  ORT_NO_SUCHFILE,
+  /**
+   * Legacy/unused but retained for ABI compatibility. Historically returned when a model could not be found by name in
+   * the ONNX Runtime Server (removed in 2022).
+   */
+  ORT_NO_MODEL,
+  /**
+   * A hardware accelerator or backend engine reported a failure (e.g. a device crash or other device-level error).
+   */
+  ORT_ENGINE_ERROR,
+  /**
+   * A generic runtime exception was caught. The error message is the primary source of detail.
+   */
+  ORT_RUNTIME_EXCEPTION,
+  /**
+   * Protobuf parsing or serialization failed.
+   */
+  ORT_INVALID_PROTOBUF,
+  /**
+   * Invalid session state for the requested operation. Despite the name, this code does not mean "success, model
+   * loaded"; it is returned when the session is in the wrong state for the requested call (e.g. a model is already
+   * loaded, the session is already initialized, or no model has been loaded yet). The name is historical and is
+   * retained for ABI compatibility; consult the error message for the specific condition.
+   */
+  ORT_MODEL_LOADED,
+  /**
+   * The requested functionality is not implemented in this build.
+   */
+  ORT_NOT_IMPLEMENTED,
+  /**
+   * The model graph is structurally invalid (e.g. recursive function definitions, invalid tensor dimensions, or
+   * malformed nodes).
+   */
+  ORT_INVALID_GRAPH,
+  /**
+   * An execution provider reported a generic failure.
+   */
+  ORT_EP_FAIL,
+  /**
+   * Model loading or session initialization was canceled at the caller's request.
+   */
+  ORT_MODEL_LOAD_CANCELED,
+  /**
+   * The model requires compilation by an execution provider, but compilation was disabled via session options.
+   */
+  ORT_MODEL_REQUIRES_COMPILATION,
+  /**
+   * A requested resource could not be found.
+   */
+  ORT_NOT_FOUND,
+} OrtErrorCode;
+
+#ifdef __cplusplus
+}
+#endif
+
+/// @}


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Extract the public C API OrtErrorCode enum into its own header (onnxruntime_error_code.h) and define onnxruntime::common::StatusCode enumerators in terms of the ORT_* constants (e.g. OK = ORT_OK). This makes the public C API enum the single source of truth for error code values so the public and internal enums cannot drift out of sync, without requiring any call-site changes to the existing static_cast bridges.

Add the new header to the C/C++ API install list (cmake/onnxruntime.cmake) and to the Doxygen INPUT list (docs/c_cxx/Doxyfile).

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

`OrtErrorCode` may be added to in the future. This change makes it easier to keep the internal enum in sync.

Follow up to https://github.com/microsoft/onnxruntime/pull/29018#discussion_r3405250002