### PR TITLE
Harden QMoE against integer overflow and partial K tiles

### DIFF
--- a/docs/contrib_ops/cuda/moe_qmoe.md
+++ b/docs/contrib_ops/cuda/moe_qmoe.md
@@ -536,6 +536,15 @@ The operator supports three fusion modes via the `swiglu_fusion` attribute:
 | 1 (interleaved) | `fc1`, `fc2` | `[Gate_0, Value_0, Gate_1, Value_1, …]` — `[E, 2×inter, hidden]` | GPT-OSS layout. |
 | 2 (block) | `fc1`, `fc2` | `[Gate_0…Gate_N | Value_0…Value_N]` — `[E, 2×inter, hidden]` | Concatenated halves; Llama/Gemma layout. |
 
+> **Backward-compatibility remap (`swiglu_fusion=0` + SwiGLU)**: The published gpt-oss-20b
+> model before June 2025 uses **interleaved** SwiGLU layout but `swiglu_fusion` attribute to `0`.
+> To keep those models working, when `activation_type="swiglu"` and `swiglu_fusion=0`,
+> the CUDA op treats the FC1 weights as interleaved (i.e. as if `swiglu_fusion=1`):
+> unconditionally for **QMoE** (which never has a separate `fc3`).
+> A one-time warning is logged. Consequently a SwiGLU model that genuinely intended the
+> non-interleaved split must provide a separate `fc3` (standard MoE) rather than rely on
+> `swiglu_fusion=0`. New exporters should set `swiglu_fusion` explicitly.
+
 > **CPU note**: The CPU MoE/QMoE implementation only supports the **interleaved**
 > SwiGLU layout (`swiglu_fusion=1`). The concatenated layout (`swiglu_fusion=2`)
 > throws `ORT_NOT_IMPLEMENTED` on CPU; use the CUDA EP for concatenated SwiGLU.

--- a/docs/contrib_ops/cuda/qmoe_gemv_experiments.md
+++ b/docs/contrib_ops/cuda/qmoe_gemv_experiments.md
@@ -2,6 +2,11 @@
 
 This file records QMoE INT4/INT8 GEMV profiling results so future kernel and dispatch changes can be compared against a stable baseline.
 
+> **Note**: These are **point-in-time** measurements captured on the specific GPU, driver, CUDA
+> toolkit, and ORT build noted in each section header. Treat the numbers as a historical baseline
+> for regression comparison, not as current performance guidance — re-run the benchmark script on
+> your own hardware before drawing conclusions.
+
 ## 2026-06-12 Baseline: SM90, Warmup 5, Repeat 100
 
 ### Setup

--- a/onnxruntime/contrib_ops/cuda/llm/cutlass_extensions/gemm/threadblock/dq_mma_base.h
+++ b/onnxruntime/contrib_ops/cuda/llm/cutlass_extensions/gemm/threadblock/dq_mma_base.h
@@ -69,6 +69,10 @@ class DqMmaBase {
   static_assert(DequantOp != WeightOnlyQuantOp::UNDEFINED, "");
 
   static constexpr int kMinFinegrainedGroupSize = 32;
+  // Sized for the smallest supported fine-grained group size (32): a CTA K-tile of Shape::kK spans
+  // up to Shape::kK / 32 scale rows. Larger group sizes (64/128) consume fewer rows per stage and
+  // therefore leave part of this reservation unused -- a deliberate worst-case sizing so the same
+  // pipeline storage works for every supported group size. Keep this >= the largest rows-per-stage.
   static constexpr int kFinegrainedScaleRowsPerStage = Shape::kK / kMinFinegrainedGroupSize;
   // Finegrained scales get streamed in via cp.async.
   static constexpr int ScalebiasStages = isFinegrained(DequantOp) ? Stages * kFinegrainedScaleRowsPerStage : 1;

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemv.cu
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemv.cu
@@ -4,11 +4,14 @@
 #include "contrib_ops/cuda/llm/moe_gemm/moe_gemv.h"
 
 #include <cuda_fp16.h>
-#include <cstdlib>
 #include <type_traits>
 
 #include "core/common/common.h"
 #include "contrib_ops/cuda/llm/fpA_intB_gemv/dispatcher.h"
+// Include env_var_utils.h after dispatcher.h: dispatcher.h transitively pulls in provider_api.h,
+// which defines SHARED_PROVIDER. That guard suppresses env_var_utils.h's own logging.h include and
+// avoids redefining CREATE_MESSAGE / LOGS_CATEGORY (which would fail under -Werror).
+#include "core/platform/env_var_utils.h"
 
 namespace onnxruntime::llm {
 namespace kernels {
@@ -398,10 +401,9 @@ struct TypeTag {
 // fp32. Honored only for fp16 activations (bf16 always accumulates in fp32). Set
 // ORT_MOE_GEMV_FP16_ACCUM=1 to measure the perf/accuracy tradeoff of 16-bit accumulation.
 inline bool MoeGemvUseFp16Accum() {
-  static bool const enabled = []() {
-    char const* v = std::getenv("ORT_MOE_GEMV_FP16_ACCUM");
-    return v != nullptr && v[0] == '1';
-  }();
+  // Parsed once via ORT's environment helper (consistent parsing/thread-safety across platforms).
+  static bool const enabled =
+      onnxruntime::ParseEnvironmentVariableWithDefault<int>("ORT_MOE_GEMV_FP16_ACCUM", 0) == 1;
   return enabled;
 }
 

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemv.cu
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemv.cu
@@ -443,6 +443,16 @@ bool is_moe_gemv_supported(int sm, int64_t expanded_num_rows, int64_t n, int64_t
   if (interleaved_k % step_k != 0) {
     return false;
   }
+
+  // The interleaved kernel reads K in whole tiles of kTileSizeK (64). Each group of participating
+  // threads covers one kTileSizeK-wide K tile via sub-offsets {0, kTileSizeK/2, ...}; the per-thread
+  // activation iterator unconditionally loads StepK elements at real_offset_k. When k is not a multiple
+  // of kTileSizeK the final partial tile makes the upper-half threads read past the valid k range of the
+  // activation row (e.g. k=32 reads act[..32..63]), yielding garbage/NaN. Require complete K tiles.
+  if (k % kTileSizeK != 0) {
+    return false;
+  }
+
   return true;
 }
 

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_kernels.cu
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_kernels.cu
@@ -77,10 +77,9 @@ namespace onnxruntime::llm::kernels::cutlass_kernels {
 // Master switch for the symmetric INT MoE GEMV fast path. Enabled by default;
 // set ORT_DISABLE_MOE_GEMV=1 to fall back to the CUTLASS grouped GEMM.
 inline bool MoeGemvDisabledByEnv() {
-  static bool const disabled = []() {
-    char const* v = std::getenv("ORT_DISABLE_MOE_GEMV");
-    return v != nullptr && v[0] == '1';
-  }();
+  // Parsed once via ORT's environment helper (consistent parsing/thread-safety across platforms).
+  static bool const disabled =
+      onnxruntime::ParseEnvironmentVariableWithDefault<int>("ORT_DISABLE_MOE_GEMV", 0) == 1;
   return disabled;
 }
 
@@ -2470,7 +2469,8 @@ void CutlassMoeFCRunner<T, WeightType, OutputType, InputType, ScaleBiasType, Ena
         activation_params, stream);
 
     // Run the GEMM with activation function overridden with `Identity`, we do the activation separately.
-    // Fast path: int4 per-channel MoE GEMV for small expanded-row counts (e.g. batch-1 decode).
+    // Fast path: symmetric INT4/INT8 (per-column or block-wise) MoE GEMV for small expanded-row counts
+    // (e.g. batch-1 decode).
     bool const fc1_did_gemv = fc1_did_fused_gemv || tryLaunchMoeGemvIntSymmetric<T, WeightType, ScaleBiasType>(
                                                         input, fc1_expert_weights,
                                                         quant_params.groupwise.group_size > 0
@@ -2573,7 +2573,8 @@ void CutlassMoeFCRunner<T, WeightType, OutputType, InputType, ScaleBiasType, Ena
 
   ActivationParameters activation_params;  // Here assume gemm2 has no activation
                                            // Note: expanded_num_rows, to check this value, it's greater than num_rows * num_experts_per_node
-                                           // Fast path: int4 per-channel MoE GEMV (no bias here; fc2 bias applied in finalizeMoeRouting).
+                                           // Fast path: symmetric INT4/INT8 (per-column or block-wise) MoE GEMV
+                                           // (no bias here; fc2 bias applied in finalizeMoeRouting).
                                            // Keep the decode GEMV path single-EP until token-drop/all-to-all
                                            // cases are profiled and validated.
   bool const fc2_did_gemv = tryLaunchMoeGemvIntSymmetric<T, WeightType, ScaleBiasType>(

--- a/onnxruntime/contrib_ops/cuda/moe/moe.cc
+++ b/onnxruntime/contrib_ops/cuda/moe/moe.cc
@@ -184,11 +184,13 @@ Status MoE<T>::ComputeInternal(OpKernelContext* context) const {
       static_cast<size_t>(moe_params.inter_size), static_cast<size_t>(moe_params.num_experts), static_cast<size_t>(k_),
       kernel_activation_type, parallelism_config, use_awq);
 
-  // Scratch buffer for workspace + expert_scales + expert_indices + permutation_map
-  size_t scales_bytes = moe_params.num_rows * k_ * sizeof(float);
-  size_t indices_bytes = moe_params.num_rows * k_ * sizeof(int);
-  size_t permutation_bytes = moe_params.num_rows * k_ * sizeof(int);
-  size_t total_scratch_bytes = ws_size + scales_bytes + indices_bytes + permutation_bytes;
+  // Scratch buffer for workspace + expert_scales + expert_indices + permutation_map.
+  // Use checked arithmetic: these byte counts derive adjacent pointer offsets inside one allocation.
+  size_t expanded_rows = SafeInt<size_t>(moe_params.num_rows) * SafeInt<size_t>(k_);
+  size_t scales_bytes = expanded_rows * sizeof(float);
+  size_t indices_bytes = expanded_rows * sizeof(int);
+  size_t permutation_bytes = expanded_rows * sizeof(int);
+  size_t total_scratch_bytes = SafeInt<size_t>(ws_size) + scales_bytes + indices_bytes + permutation_bytes;
 
   auto work_space = GetScratchBuffer<void>(total_scratch_bytes, stream_obj);
   char* workspace_ptr = reinterpret_cast<char*>(work_space.get());

--- a/onnxruntime/contrib_ops/cuda/moe/moe_quantization.cc
+++ b/onnxruntime/contrib_ops/cuda/moe/moe_quantization.cc
@@ -344,6 +344,22 @@ Status QMoE::ComputeInternal(OpKernelContext* context) const {
                     "QMoE requires 0 < k <= num_experts, got k=", k_,
                     " and num_experts=", moe_params.num_experts);
 
+  // The INT4/INT8 weight-only path stores B in the column-interleaved layout (ColumnMajorTileInterleave),
+  // whose CUTLASS pitchlinear iterators require the GEMM reduction dim K to be a whole multiple of the
+  // interleave tile (kInterleaveKTile == 64 for fp16/bf16 activations). For the two MoE GEMMs the
+  // reduction dims are fc1.K == hidden_size and fc2.K == inter_size. A partial final K tile is read past
+  // the valid range and silently yields garbage/NaN (the single-matrix fpA_intB GEMM throws on this; the
+  // grouped MoE GEMM and the decode GEMV have no such guard), so reject it up front with a clear error.
+  if (quant_type_ == "int") {
+    constexpr int64_t kInterleaveKTile = 64;
+    ORT_RETURN_IF_NOT(moe_params.hidden_size % kInterleaveKTile == 0,
+                      "QMoE int weight-only quantization requires hidden_size to be a multiple of ",
+                      kInterleaveKTile, " (the interleaved-weight K tile), got hidden_size=", moe_params.hidden_size, ".");
+    ORT_RETURN_IF_NOT(moe_params.inter_size % kInterleaveKTile == 0,
+                      "QMoE int weight-only quantization requires inter_size to be a multiple of ",
+                      kInterleaveKTile, " (the interleaved-weight K tile), got inter_size=", moe_params.inter_size, ".");
+  }
+
   if (uses_fp4_weight_scales) {
     constexpr int64_t fp4_block_size = 32;
     const int64_t fc1_out_size = is_fused_swiglu ? moe_params.inter_size * 2 : moe_params.inter_size;

--- a/onnxruntime/contrib_ops/cuda/moe/moe_quantization.cc
+++ b/onnxruntime/contrib_ops/cuda/moe/moe_quantization.cc
@@ -518,13 +518,15 @@ Status QMoE::ComputeInternal(OpKernelContext* context) const {
   }
   // Lock released — concurrent QMoE inferences can now run prep work in parallel.
 
-  // Scratch buffer for workspace + expert_scales + expert_indices
+  // Scratch buffer for workspace + expert_scales + expert_indices + permutation_map.
+  // Use checked arithmetic: these byte counts derive adjacent pointer offsets inside one allocation.
   // expert_scales: num_rows * k * sizeof(float)
   // expert_indices: num_rows * k * sizeof(int)
-  size_t scales_bytes = moe_params.num_rows * k_ * sizeof(float);
-  size_t indices_bytes = moe_params.num_rows * k_ * sizeof(int);
-  size_t permutation_bytes = moe_params.num_rows * k_ * sizeof(int);
-  size_t total_scratch_bytes = workspace_size + scales_bytes + indices_bytes + permutation_bytes;
+  size_t expanded_rows = SafeInt<size_t>(moe_params.num_rows) * SafeInt<size_t>(k_);
+  size_t scales_bytes = expanded_rows * sizeof(float);
+  size_t indices_bytes = expanded_rows * sizeof(int);
+  size_t permutation_bytes = expanded_rows * sizeof(int);
+  size_t total_scratch_bytes = SafeInt<size_t>(workspace_size) + scales_bytes + indices_bytes + permutation_bytes;
 
   auto work_space = GetScratchBuffer<void>(total_scratch_bytes, GetComputeStream(context));
   char* workspace_ptr = reinterpret_cast<char*>(work_space.get());

--- a/onnxruntime/test/python/transformers/test_qmoe_cuda.py
+++ b/onnxruntime/test/python/transformers/test_qmoe_cuda.py
@@ -1104,8 +1104,14 @@ class SparseMoeBlockORTHelper(nn.Module):
                 use_quant=True,  # Always use QMoE
                 quant_bits=self.quant_bits,
                 # We use swiglu_fusion=1 (fused and interleaved) based on the kernel implementation.
-                # This matches the behavior of the Cutlass/MLAS kernels used in ORT.
-                swiglu_fusion=getattr(self, "swiglu_fusion", 0),
+                # This matches the behavior of the Cutlass/MLAS kernels used in ORT. Tests may set
+                # onnx_swiglu_fusion_override to emit a different attribute value (e.g. 0) while keeping
+                # the interleaved weight layout, to exercise the kernel's backward-compat remap.
+                swiglu_fusion=(
+                    self.onnx_swiglu_fusion_override
+                    if getattr(self, "onnx_swiglu_fusion_override", None) is not None
+                    else getattr(self, "swiglu_fusion", 0)
+                ),
                 block_size=self.block_size,  # Add block_size for block-wise quantization
             )
         except Exception as e:
@@ -1901,6 +1907,35 @@ class TestSwigluQMoE(unittest.TestCase):
         self.assertEqual(torch_result.shape, expected_shape)
         self.assertFalse(torch.isnan(torch_result).any())
         self.assertFalse(torch.isinf(torch_result).any())
+
+        swiglu_moe.parity_check()
+
+    def test_swiglu_qmoe_fusion0_remap_parity(self):
+        # Backward-compat regression: the published gpt-oss-20b model emits no swiglu_fusion attribute
+        # (defaulting to 0) but stores FC1 in the interleaved SwiGLU layout. The CUDA QMoE op remaps
+        # swiglu_fusion=0 -> 1 for SwiGLU activation. Here we build an interleaved block, emit
+        # swiglu_fusion=0 in the ONNX graph, and verify parity still holds against the interleaved
+        # reference. Without the remap this would compute the wrong (non-interleaved) result.
+        torch.manual_seed(1234)
+        numpy.random.seed(1234)
+
+        config = SwigluMoeConfig(hidden_size=128, intermediate_size=256, num_local_experts=4, num_experts_per_token=2)
+
+        swiglu_moe = SwigluMoEBlock(
+            config,
+            batch_size=1,
+            sequence_length=32,
+            quant_bits=4,
+            onnx_dtype=TensorProto.FLOAT16,
+            use_asymmetric_quant=False,
+        )
+        # Keep the interleaved reference and weight layout (swiglu_fusion == 1) but emit swiglu_fusion=0
+        # in the ONNX attribute so the op's backward-compatibility remap path is exercised.
+        self.assertEqual(swiglu_moe.swiglu_fusion, 1)
+        swiglu_moe.onnx_swiglu_fusion_override = 0
+
+        hidden_states = torch.randn(1, 32, config.hidden_size).to(device).to(torch.float16)
+        _ = swiglu_moe.forward(hidden_states)
 
         swiglu_moe.parity_check()
 

--- a/onnxruntime/test/python/transformers/test_qmoe_cuda.py
+++ b/onnxruntime/test/python/transformers/test_qmoe_cuda.py
@@ -1939,6 +1939,35 @@ class TestSwigluQMoE(unittest.TestCase):
 
         swiglu_moe.parity_check()
 
+    def test_swiglu_qmoe_int_partial_ktile_rejected(self):
+        # NaN-hardening regression: the INT4/INT8 weight-only path stores B in the column-interleaved
+        # layout, whose CUTLASS K iterator requires each GEMM reduction dim to be a whole multiple of the
+        # 64-element interleave tile (fc1.K == hidden_size, fc2.K == inter_size). A partial final K tile
+        # is read past the valid range and silently produces garbage/NaN. QMoE now rejects such shapes up
+        # front with a clear error instead of computing wrong results. Here inter_size 544 (== 17*32) is
+        # block-quant valid (block_size=32) but 544 % 64 == 32, so the op must raise.
+        torch.manual_seed(4321)
+        numpy.random.seed(4321)
+
+        config = SwigluMoeConfig(hidden_size=512, intermediate_size=544, num_local_experts=4, num_experts_per_token=2)
+
+        swiglu_moe = SwigluMoEBlock(
+            config,
+            batch_size=1,
+            sequence_length=1,
+            quant_bits=8,
+            onnx_dtype=TensorProto.FLOAT16,
+            block_size=32,
+            use_asymmetric_quant=False,
+        )
+
+        # Build the ONNX model + session (the interleaved-layout guard fires at run time in
+        # ComputeInternal, not during session creation), then assert the run is rejected.
+        self.assertTrue(swiglu_moe.recreate_onnx_model())
+        hidden_states = torch.randn(1, 1, config.hidden_size).to(device).to(torch.float16)
+        with self.assertRaisesRegex(Exception, "inter_size to be a multiple of 64"):
+            swiglu_moe.ort_forward(hidden_states)
+
     @parameterized.expand(swiglu_test_cases)
     def test_swiglu_qmoe_parity_bf16(self, batch_size, sequence_length, quant_bits):
         base_seed = 1500
@@ -2781,7 +2810,9 @@ class TestQMoEIntPrePackSmoke(unittest.TestCase):
         self.assertLess(numpy.abs(out).max(), 10.0, "Output magnitude is implausibly large")
 
     def test_int4_swiglu_interleaved_small(self):
-        self._run_one(hidden_size=64, inter_size=32, num_experts=4, top_k=2, swiglu_fusion=1, batch_size=8)
+        # inter_size must be a multiple of 64 (the interleaved-weight K tile) for the INT path; a
+        # partial final K tile is now rejected up front by QMoE's hardening check.
+        self._run_one(hidden_size=64, inter_size=64, num_experts=4, top_k=2, swiglu_fusion=1, batch_size=8)
 
     def test_int4_swiglu_interleaved_medium(self):
         self._run_one(hidden_size=128, inter_size=64, num_experts=8, top_k=2, swiglu_fusion=1, batch_size=16)


### PR DESCRIPTION
## Description

The symmetric INT4/INT8 MoE decode GEMV could emit `NaN`/garbage when a GEMM
reduction dimension was not a whole multiple of the 64-element interleaved-weight
K tile (e.g. `intermediate_size` such as 544). The interleaved weight layout's
CUTLASS K iterator reads K in whole tiles of 64; a partial final tile makes
threads read past the valid activation range. This PR fixes the decode GEMV
selection gate to reject such shapes, adds an explicit up-front validation in the
QMoE op so the grouped GEMM path fails with a clear error instead of silently
producing wrong results, and folds in several QMoE review-feedback cleanups
(checked size arithmetic, env-var parsing, and documentation).

## Summary of Changes

### NaN fix and hardening (INT weight-only path)

| File | Change |
|------|--------|
| `onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemv.cu` | `is_moe_gemv_supported` now rejects `k % kTileSizeK != 0` (64), so the decode GEMV is not selected for a partial final K tile and the path falls back to the grouped GEMM. |
| `onnxruntime/contrib_ops/cuda/moe/moe_quantization.cc` | Added an up-front guard for `quant_type == "int"`: `hidden_size` (fc1.K) and `inter_size` (fc2.K) must be multiples of 64 (the interleaved-weight K tile); otherwise return `INVALID_ARGUMENT` with a clear message instead of computing garbage. |

### Review-feedback cleanups

| File | Change |
|------|--------|
| `onnxruntime/contrib_ops/cuda/moe/moe.cc` | Use `SafeInt<size_t>` for scratch byte-count arithmetic (expanded rows × element sizes) feeding a single allocation. |
| `onnxruntime/contrib_ops/cuda/moe/moe_quantization.cc` | Same `SafeInt<size_t>` scratch-size hardening. |
| `onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemv.cu` | Parse `ORT_MOE_GEMV_FP16_ACCUM` via `ParseEnvironmentVariableWithDefault<int>`; include `env_var_utils.h` after `dispatcher.h` (SHARED_PROVIDER guard ordering, documented inline). |
| `onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_kernels.cu` | Parse `ORT_DISABLE_MOE_GEMV` via the same helper; clarify fast-path comments (symmetric INT4/INT8, per-column or block-wise). |
| `onnxruntime/contrib_ops/cuda/llm/cutlass_extensions/gemm/threadblock/dq_mma_base.h` | Comment explaining the worst-case sizing of `kFinegrainedScaleRowsPerStage` for the smallest fine-grained group size. |

### Documentation

| File | Change |
|------|--------|
| `docs/contrib_ops/cuda/moe_qmoe.md` | Document the `swiglu_fusion=0` + SwiGLU backward-compatibility remap (gpt-oss-20b interleaved layout) and the one-time warning. |
| `docs/contrib_ops/cuda/qmoe_gemv_experiments.md` | Note that recorded numbers are point-in-time baselines tied to the listed GPU/driver/CUDA/ORT build. |

## Testing

- `python -m pytest onnxruntime/test/python/transformers/test_qmoe_cuda.py -k "gemv or swiglu or block or PrePack or prepack"` — 84 passed, 6 skipped on H200 (sm90).
- New `TestSwigluQMoE::test_swiglu_qmoe_int_partial_ktile_rejected` builds an `inter_size=544` (= 17×32, partial 64 tile) INT8 SwiGLU QMoE and asserts the run raises `"inter_size to be a multiple of 64"`.
- New `TestSwigluQMoE::test_swiglu_qmoe_fusion0_remap_parity` exercises the `swiglu_fusion=0` → interleaved remap parity.
- `TestQMoEIntPrePackSmoke::test_int4_swiglu_interleaved_small` bumped from `inter_size=32` (a now-rejected partial K tile) to `64`.
- `ORT_ENABLE_FP4_GEMV=1 python -m pytest onnxruntime/test/python/transformers/test_qmoe_fp4_cuda.py` — no failures (the new guard is scoped to `quant_type == "int"`, so FP4/FP8 are unaffected).
- `lintrunner` clean on the changed C++ and Python files.

## Motivation and Context

The interleaved column-major weight layout (`ColumnMajorTileInterleave<64, …>`)
requires the GEMM reduction dim K to be a whole multiple of `ThreadblockK` (64
for fp16/bf16 activations). The single-matrix `fpA_intB` GEMM already throws on
this, but the grouped MoE GEMM and the decode GEMV had no equivalent guard and
silently produced `NaN`/garbage. This PR closes that gap at the QMoE boundary
(clear error) and in the GEMV dispatch gate (safe fallback). No supported,
64-aligned shape changes behavior.

## Checklist

- [x] Tests added/updated
- [x] Documentation updated (if applicable)
- [x] No breaking changes (rejected shapes were already producing incorrect output)
- [ ] CI passes
