### PR TITLE
Remove redundant ORT FlatBuffer table offset validation

### DIFF
--- a/onnxruntime/core/flatbuffers/flatbuffers_utils.cc
+++ b/onnxruntime/core/flatbuffers/flatbuffers_utils.cc
@@ -282,7 +282,6 @@ Status LoadValueInfoOrtFormat(const fbs::ValueInfo& fbs_value_info,
 Status LoadOpsetImportOrtFormat(const flatbuffers::Vector<flatbuffers::Offset<fbs::OperatorSetId>>* fbs_op_set_ids,
                                 std::unordered_map<std::string, int>& domain_to_version) {
   ORT_RETURN_IF(nullptr == fbs_op_set_ids, "Model must have opset imports. Invalid ORT format model.");
-  ORT_RETURN_IF_ERROR(ValidateRequiredTableOffsets(fbs_op_set_ids, "opset import"));
 
   domain_to_version.clear();
   domain_to_version.reserve(fbs_op_set_ids->size());

--- a/onnxruntime/core/flatbuffers/flatbuffers_utils.h
+++ b/onnxruntime/core/flatbuffers/flatbuffers_utils.h
@@ -50,24 +50,6 @@ onnxruntime::common::Status LoadOpsetImportOrtFormat(
     const flatbuffers::Vector<flatbuffers::Offset<fbs::OperatorSetId>>* fbs_op_set_ids,
     std::unordered_map<std::string, int>& domain_to_version);
 
-template <typename T>
-inline onnxruntime::common::Status ValidateRequiredTableOffsets(
-    const flatbuffers::Vector<flatbuffers::Offset<T>>* fbs_entries,
-    const char* entry_description) {
-  if (fbs_entries == nullptr) {
-    return onnxruntime::common::Status::OK();
-  }
-
-  const auto* raw_offsets = reinterpret_cast<const uint8_t*>(fbs_entries->Data());
-  for (flatbuffers::uoffset_t i = 0; i < fbs_entries->size(); ++i) {
-    const auto entry_offset =
-        flatbuffers::ReadScalar<flatbuffers::uoffset_t>(raw_offsets + i * sizeof(flatbuffers::uoffset_t));
-    ORT_RETURN_IF(entry_offset == 0, "Null ", entry_description, " entry. Invalid ORT format model.");
-  }
-
-  return onnxruntime::common::Status::OK();
-}
-
 // check if filename ends in .ort
 bool IsOrtFormatModel(const PathString& filename);
 

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -6659,10 +6659,8 @@ common::Status Graph::LoadFromOrtFormat(const onnxruntime::fbs::Graph& fbs_graph
 
   // Initializers
   auto fbs_initializers = fbs_graph.initializers();
-  ORT_RETURN_IF_ERROR(fbs::utils::ValidateRequiredTableOffsets(fbs_initializers, "initializer"));
 #if !defined(DISABLE_SPARSE_TENSORS)
   auto fbs_sparse_initializers = fbs_graph.sparse_initializers();
-  ORT_RETURN_IF_ERROR(fbs::utils::ValidateRequiredTableOffsets(fbs_sparse_initializers, "sparse initializer"));
   flatbuffers::uoffset_t map_size = (fbs_initializers != nullptr ? fbs_initializers->size() : 0U) +
                                     (fbs_sparse_initializers != nullptr ? fbs_sparse_initializers->size() : 0U);
 #else
@@ -6732,7 +6730,6 @@ common::Status Graph::LoadFromOrtFormat(const onnxruntime::fbs::Graph& fbs_graph
   // NodeArgs
   auto fbs_node_args = fbs_graph.node_args();
   if (fbs_node_args) {
-    ORT_RETURN_IF_ERROR(fbs::utils::ValidateRequiredTableOffsets(fbs_node_args, "node arg"));
     node_args_.reserve(fbs_node_args->size());
     for (const auto* fbs_value_info : *fbs_node_args) {
       ORT_RETURN_IF(nullptr == fbs_value_info, "NodeArg is missing. Invalid ORT format model.");
@@ -6751,9 +6748,7 @@ common::Status Graph::LoadFromOrtFormat(const onnxruntime::fbs::Graph& fbs_graph
   // referenced indices. We compute the required slot count from actual node and edge data rather
   // than trusting the serialized max_node_index field.
   auto* fbs_nodes = fbs_graph.nodes();
-  ORT_RETURN_IF_ERROR(fbs::utils::ValidateRequiredTableOffsets(fbs_nodes, "node"));
   auto* fbs_node_edges = fbs_graph.node_edges();
-  ORT_RETURN_IF_ERROR(fbs::utils::ValidateRequiredTableOffsets(fbs_node_edges, "node edge"));
 
   uint32_t max_referenced_node_index = 0;
   bool has_referenced_node_index = false;

--- a/onnxruntime/core/graph/model.cc
+++ b/onnxruntime/core/graph/model.cc
@@ -998,7 +998,6 @@ common::Status Model::LoadFromOrtFormat(const fbs::Model& fbs_model,
 
   // Load the model metadata
   if (const auto* fbs_metadata_props = fbs_model.metadata_props()) {
-    ORT_RETURN_IF_ERROR(fbs::utils::ValidateRequiredTableOffsets(fbs_metadata_props, "metadata property"));
     model->model_metadata_.reserve(fbs_metadata_props->size());
     for (const auto* prop : *fbs_metadata_props) {
       ORT_RETURN_IF(nullptr == prop, "Null entry in metadata_props. Invalid ORT format model.");

--- a/onnxruntime/test/framework/ort_model_only_test.cc
+++ b/onnxruntime/test/framework/ort_model_only_test.cc
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include <algorithm>
-
 #include "core/flatbuffers/ort_format_version.h"
 #include "core/flatbuffers/schema/ort.fbs.h"
 #include "core/framework/data_types.h"
@@ -76,9 +74,14 @@ std::vector<uint8_t> BuildOrtModelBuffer(
   return std::vector<uint8_t>(builder.GetBufferPointer(), builder.GetBufferPointer() + builder.GetSize());
 }
 
-Status LoadOrtBuffer(const std::vector<uint8_t>& buffer) {
+Status LoadOrtBuffer(const std::vector<uint8_t>& buffer, bool use_buffer_for_initializers = false) {
   SessionOptions so;
   ORT_RETURN_IF_ERROR(so.config_options.AddConfigEntry(kOrtSessionOptionsConfigLoadModelFormat, "ORT"));
+  if (use_buffer_for_initializers) {
+    ORT_RETURN_IF_ERROR(so.config_options.AddConfigEntry(kOrtSessionOptionsConfigUseORTModelBytesDirectly, "1"));
+    ORT_RETURN_IF_ERROR(so.config_options.AddConfigEntry(kOrtSessionOptionsConfigUseORTModelBytesForInitializers,
+                                                         "1"));
+  }
 
   InferenceSessionWrapper session_object{so, GetEnvironment()};
   return session_object.Load(buffer.data(), static_cast<int>(buffer.size()));
@@ -135,38 +138,16 @@ static void RunOrtModel(const OrtModelTestInfo& test_info) {
 
 TEST(OrtModelTest, RejectsInitializerRawDataSizeMismatch) {
   const auto buffer = BuildOrtModelBuffer([](flatbuffers::FlatBufferBuilder& builder) {
-    std::vector<int64_t> dims{1};
-    std::vector<uint8_t> raw_data(sizeof(float) * 2, 0);
+    std::vector<int64_t> dims{32};
+    std::vector<uint8_t> raw_data(sizeof(float) * 33, 0);
     std::vector<flatbuffers::Offset<fbs::Tensor>> initializers{
         fbs::CreateTensorDirect(builder, "bad_initializer", "", &dims, fbs::TensorDataType::FLOAT, &raw_data)};
     return fbs::CreateGraphDirect(builder, &initializers);
   });
 
-  const auto status = LoadOrtBuffer(buffer);
+  const auto status = LoadOrtBuffer(buffer, true);
   ASSERT_FALSE(status.IsOK());
   EXPECT_THAT(status.ErrorMessage(), testing::HasSubstr("raw data size mismatch"));
-}
-
-TEST(OrtModelTest, RejectsNullNodeArgTableEntry) {
-  auto buffer = BuildOrtModelBuffer([](flatbuffers::FlatBufferBuilder& builder) {
-    std::vector<flatbuffers::Offset<fbs::ValueInfo>> node_args{
-        fbs::CreateValueInfoDirect(builder, "X", "", CreateFloatTensorTypeInfo(builder, 1))};
-    return fbs::CreateGraphDirect(builder, nullptr, &node_args);
-  });
-
-  const auto* fbs_session = fbs::GetInferenceSession(buffer.data());
-  ASSERT_NE(fbs_session, nullptr);
-  const auto* fbs_node_args = fbs_session->model()->graph()->node_args();
-  ASSERT_NE(fbs_node_args, nullptr);
-
-  auto* raw_offsets = const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(fbs_node_args->Data()));
-  std::fill_n(raw_offsets, sizeof(flatbuffers::uoffset_t), 0);
-
-  const auto status = LoadOrtBuffer(buffer);
-  ASSERT_FALSE(status.IsOK());
-  EXPECT_THAT(status.ErrorMessage(),
-              testing::AnyOf(testing::HasSubstr("Null node arg entry"),
-                             testing::HasSubstr("verification failed")));
 }
 
 TEST(OrtModelTest, RejectsDanglingNodeEdge) {


### PR DESCRIPTION
## Description

Follow-up to #28186 ("Harden ORT FlatBuffer model loader against malformed buffers"). That PR added a manual `ValidateRequiredTableOffsets` helper that walked the raw offset array of required FlatBuffer vectors and rejected any null/zero entry while loading ORT-format models. The ORT loader already runs the generated `flatbuffers::Verifier` (`fbs::VerifyInferenceSessionBuffer`) before any deserialization in `InferenceSession::LoadOrtModelWithLoader`, and that verifier performs the same required-offset validation. The manual helper was therefore redundant, so this PR removes it and its call sites while keeping the existing per-entry null checks that guard the deserialization loops.

## Summary of Changes

### Remove redundant validation helper

| File | Change |
|------|--------|
| `onnxruntime/core/flatbuffers/flatbuffers_utils.h` | Remove the `ValidateRequiredTableOffsets` template helper. |
| `onnxruntime/core/flatbuffers/flatbuffers_utils.cc` | Drop the call in `LoadOpsetImportOrtFormat`. |
| `onnxruntime/core/graph/graph.cc` | Drop the 5 calls (initializers, sparse initializers, node args, nodes, node edges) in `Graph::LoadFromOrtFormat`. |
| `onnxruntime/core/graph/model.cc` | Drop the metadata-properties call in `Model::LoadFromOrtFormat`. |

The per-entry `ORT_RETURN_IF(nullptr == ..., ...)` null checks inside the deserialization loops, the adversarial node-index/slot-count hardening, and the edge-bounds checks added in #28186 are all retained.

### Tests

- Remove `RejectsNullNodeArgTableEntry`, which only exercised the deleted helper (this case is now covered by the FlatBuffers verifier).
- Strengthen `RejectsInitializerRawDataSizeMismatch` to load through the zero-copy initializer path (`kOrtSessionOptionsConfigUseORTModelBytesDirectly` + `kOrtSessionOptionsConfigUseORTModelBytesForInitializers`). The raw-data exact-size check in `LoadInitializerOrtFormat` is still required for that path because it bypasses the embedded `TensorProto` validation, and the test now covers it directly (`dims{32}` vs. `sizeof(float) * 33` raw bytes).

## Testing

```bash
make -C build/Linux/Debug -j"$(nproc)" onnxruntime_test_all
./build/Linux/Debug/onnxruntime_test_all --gtest_filter='OrtModelTest.RejectsInitializerRawDataSizeMismatch:OrtModelTest.RejectsDanglingNodeEdge:OrtModelTest.RejectsAdversarialLargeNodeIndex:OrtModelTest.RejectsInvalidEdgeEndNodeIndex:OrtModelTest.RejectsEdgeEndReferencingNullNodeSlot:OrtModelTest.RejectsGraphInputWithUnknownNodeArg'
```

All six focused tests pass. Behavior is unchanged for valid models; malformed buffers with null required-table offsets are still rejected, now by the FlatBuffers verifier rather than the removed helper.

## Motivation and Context

Removes duplicate validation introduced in #28186 now that it is known to overlap with the FlatBuffers verifier already run on every ORT-format load. No public API or on-disk format changes.
