### PR TITLE
Fix build failure from direct ONNX schema include in layernorm optimizer tests

### DIFF
--- a/onnxruntime/test/optimizer/graph_transform_test_layernorm.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test_layernorm.cc
@@ -9,7 +9,7 @@
 
 #include "gtest/gtest.h"
 
-#include "onnx/defs/schema.h"
+#include "core/graph/onnx_protobuf.h"
 
 #include "core/graph/graph_utils.h"
 #include "core/graph/graph_viewer.h"


### PR DESCRIPTION
### Description

This fixes a macOS AppleClang build failure in `onnxruntime_test_all` caused by directly including ONNX’s `onnx/defs/schema.h` from `graph_transform_test_layernorm.cc`.

With the macOS arm64 CI build, ORT enables `-Wshorten-64-to-32` and treats warnings as errors. ONNX’s schema header pulls in protobuf v21.12 headers, and protobuf’s `google/protobuf/parse_context.h` emits several `-Wshorten-64-to-32` diagnostics under AppleClang. Because the test file included `onnx/defs/schema.h` directly, it bypassed ORT’s existing `core/graph/onnx_protobuf.h` wrapper, which already suppresses this known protobuf warning around ONNX/protobuf includes.

The fix is to include/use the existing ORT ONNX protobuf wrapper instead of directly including `onnx/defs/schema.h`.

### Repro

On macOS arm64 with AppleClang/Xcode, run:

```bash
./build.sh \
  --config "${ORT_BUILD_CONFIG:-Release}" \
  --use_xcode \
  --apple_sysroot macosx \
  --build_shared_lib \
  --parallel \
  --skip_tests \
  --osx_arch arm64 \
  --apple_deploy_target 14 \
  --cmake_generator Ninja
```

A faster targeted repro is:

```bash
python3 tools/ci_build/build.py \
  --config Release \
  --use_xcode \
  --apple_sysroot macosx \
  --build_shared_lib \
  --parallel \
  --skip_tests \
  --osx_arch arm64 \
  --apple_deploy_target 14 \
  --cmake_generator Ninja \
  --build_dir build/repro_ci \
  --update --build \
  --target onnxruntime_test_all
```

Before this fix, the build fails compiling:

```text
onnxruntime/test/optimizer/graph_transform_test_layernorm.cc
```

with errors like:

```text
google/protobuf/parse_context.h:328:47: error: implicit conversion loses integer precision: 'long' to 'int' [-Werror,-Wshorten-64-to-32]
  int chunk_size = buffer_end_ + kSlopBytes - ptr;
```

### Root cause

`graph_transform_test_layernorm.cc` directly included:

```cpp
#include "onnx/defs/schema.h"
```

This exposed protobuf v21.12 headers to ORT’s normal AppleClang warning policy:

- `-Wshorten-64-to-32` is enabled
- warnings are treated as errors
- protobuf v21.12 emits known `-Wshorten-64-to-32` warnings in `parse_context.h`

ORT already has `core/graph/onnx_protobuf.h`, which wraps ONNX/protobuf includes with the appropriate diagnostic suppression. The direct ONNX include bypassed that wrapper.

### Summary of fix

Replace the direct ONNX schema include in `graph_transform_test_layernorm.cc` with ORT’s existing ONNX protobuf wrapper include, so protobuf headers are included under the existing warning suppression.

### Validation

Validated locally on macOS arm64 / Xcode 16.4 / AppleClang 17 with:

```bash
python3 tools/ci_build/build.py \
  --config Release \
  --use_xcode \
  --apple_sysroot macosx \
  --build_shared_lib \
  --parallel \
  --skip_tests \
  --osx_arch arm64 \
  --apple_deploy_target 14 \
  --cmake_generator Ninja \
  --build_dir build/repro_ci \
  --build \
  --target onnxruntime_test_all
```

and then the broader build step:

```bash
python3 tools/ci_build/build.py \
  --config Release \
  --use_xcode \
  --apple_sysroot macosx \
  --build_shared_lib \
  --parallel \
  --skip_tests \
  --osx_arch arm64 \
  --apple_deploy_target 14 \
  --cmake_generator Ninja \
  --build_dir build/repro_ci \
  --build
```

Both completed successfully after the fix.