### PR TITLE
Add 2-bit quantization support to WebGPU GatherBlockQuantized operator

### DIFF
--- a/onnxruntime/contrib_ops/webgpu/moe/qmoe.h
+++ b/onnxruntime/contrib_ops/webgpu/moe/qmoe.h
@@ -20,8 +20,8 @@ class QMoE final : public MoE {
  public:
   QMoE(const OpKernelInfo& info) : MoE(info) {
     ORT_ENFORCE(info.GetAttr<int64_t>("expert_weight_bits", &expert_weight_bits_).IsOK());
-    ORT_ENFORCE(expert_weight_bits_ == 8 || expert_weight_bits_ == 4,
-                "expert_weight_bits must be 4 or 8, but got ", expert_weight_bits_);
+    ORT_ENFORCE(expert_weight_bits_ == 8 || expert_weight_bits_ == 4 || expert_weight_bits_ == 2,
+                "expert_weight_bits must be 2, 4, or 8, but got ", expert_weight_bits_);
     block_size_ = static_cast<int>(info.GetAttrOrDefault<int64_t>("block_size", 0));
   }
 

--- a/onnxruntime/contrib_ops/webgpu/quantization/gather_block_quantized.cc
+++ b/onnxruntime/contrib_ops/webgpu/quantization/gather_block_quantized.cc
@@ -74,6 +74,10 @@ Status GatherBlockQuantizedProgram::GenerateShaderCode(ShaderHelper& shader) con
         << "  let byte_in_word_2b = byte_idx_2b % 4;\n"
         << "  let unpacked_bytes_2b = " << unpack << "(u32(packed_word_2b));\n"
         << "  var quantized_data = (unpacked_bytes_2b[byte_in_word_2b] >> bit_shift_2b) & 0x3;\n";
+    if (is_signed_) {
+      shader.MainFunctionBody()
+          << "  if((quantized_data & 0x2) != 0) { quantized_data = quantized_data - 4 ;};\n";
+    }
   } else if (is_4bit) {
     shader.MainFunctionBody()
         << "  let data_index = data_offset % 8;\n"
@@ -149,8 +153,13 @@ Status GatherBlockQuantizedProgram::GenerateShaderCode(ShaderHelper& shader) con
           << "  var zero_point = zero_point_vec[zero_point_index];\n";
     }
     if (is_signed_) {
-      shader.MainFunctionBody()
-          << "  if((zero_point & 0x8) != 0) { zero_point = zero_point - 16 ;};\n";
+      if (is_2bit) {
+        shader.MainFunctionBody()
+            << "  if((zero_point & 0x2) != 0) { zero_point = zero_point - 4 ;};\n";
+      } else if (is_4bit) {
+        shader.MainFunctionBody()
+            << "  if((zero_point & 0x8) != 0) { zero_point = zero_point - 16 ;};\n";
+      }
     }
   }
   shader.MainFunctionBody()


### PR DESCRIPTION
## Description
Adds 2‑bit quantization support to two WebGPU operators:
- `GatherBlockQuantized`: Handles signed 2‑bit quantized data (2's complement, range [-2, 1]) and 2‑bit zero points (including when the packed zero point dimension isn't a multiple of 4). Follows the same patterns as the existing CPU implementation and includes WebGPU‑specific test coverage.
- `QMoE`: Extends the constructor to accept `expert_weight_bits_ == 2`.

## Motivation and Context
Resolves #28895! INT2 quantization is a hot research/industry topic for LLM serving, and this support enables using 2‑bit quantized weights with both WebGPU's GatherBlockQuantized and QMoE operators!

