### PR TITLE
Avoid small MatMul batch parameter heap allocations

### DIFF
--- a/onnxruntime/core/providers/cpu/math/matmul.cc
+++ b/onnxruntime/core/providers/cpu/math/matmul.cc
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include "core/providers/cpu/math/matmul.h"
+#include "core/common/inlined_containers.h"
 #include "core/providers/cpu/math/gemm_matmul_common.h"
 #include "core/providers/cpu/math/matmul_helper.h"
 #include "core/util/math.h"
@@ -329,39 +330,57 @@ Status MatMul<float>::Compute(OpKernelContext* ctx) const {
   }
 
   if (can_use_fastmath_sbgemm) {
-    std::vector<MLAS_SBGEMM_DATA_PARAMS> data(max_len);
-    for (size_t i = 0; i < max_len; i++) {
-      data[i].BIsfp32 = !(bool(packed_b_));
-      data[i].AIsfp32 = true;
-      data[i].A = a_data + helper.LeftOffsets()[i];
-      data[i].lda = lda;
-      data[i].B = data[i].BIsfp32 ? b_data + helper.RightOffsets()[i] : (float*)packed_b_.get();
-      data[i].ldb = ldb;
-      data[i].C = y_data + helper.OutputOffsets()[i];
-      data[i].ldc = N;
-      data[i].Bias = nullptr;
-      data[i].OutputProcessor = nullptr;
-      data[i].BIsPacked = static_cast<bool>(packed_b_);
+    auto gemm_batch = [&](auto& data) {
+      for (size_t i = 0; i < max_len; i++) {
+        data[i].BIsfp32 = !(bool(packed_b_));
+        data[i].AIsfp32 = true;
+        data[i].A = a_data + helper.LeftOffsets()[i];
+        data[i].lda = lda;
+        data[i].B = data[i].BIsfp32 ? b_data + helper.RightOffsets()[i] : (float*)packed_b_.get();
+        data[i].ldb = ldb;
+        data[i].C = y_data + helper.OutputOffsets()[i];
+        data[i].ldc = N;
+        data[i].Bias = nullptr;
+        data[i].OutputProcessor = nullptr;
+        data[i].BIsPacked = static_cast<bool>(packed_b_);
+      }
+      MlasSBGemmBatch(trans_a ? CblasTrans : CblasNoTrans, trans_b ? CblasTrans : CblasNoTrans,
+                      M, N, K, max_len, data.data(), thread_pool, &mlas_backend_kernel_selector_config_);
+    };
+
+    if (max_len <= 2) {
+      InlinedVector<MLAS_SBGEMM_DATA_PARAMS, 2> data(max_len);
+      gemm_batch(data);
+    } else {
+      std::vector<MLAS_SBGEMM_DATA_PARAMS> data(max_len);
+      gemm_batch(data);
     }
-    MlasSBGemmBatch(trans_a ? CblasTrans : CblasNoTrans, trans_b ? CblasTrans : CblasNoTrans,
-                    M, N, K, max_len, data.data(), thread_pool, &mlas_backend_kernel_selector_config_);
   } else
 #endif
   {
-    std::vector<MLAS_SGEMM_DATA_PARAMS> data(max_len);
-    for (size_t i = 0; i < max_len; i++) {
-      data[i].BIsPacked = bool(packed_b_);
-      data[i].A = a_data + helper.LeftOffsets()[i];
-      data[i].lda = lda;
-      data[i].B = data[i].BIsPacked ? (float*)packed_b_.get() : b_data + helper.RightOffsets()[i];
-      data[i].ldb = ldb;
-      data[i].C = y_data + helper.OutputOffsets()[i];
-      data[i].ldc = N;
-      data[i].alpha = alpha_attr_;
-      data[i].beta = 0.0f;
+    auto gemm_batch = [&](auto& data) {
+      for (size_t i = 0; i < max_len; i++) {
+        data[i].BIsPacked = bool(packed_b_);
+        data[i].A = a_data + helper.LeftOffsets()[i];
+        data[i].lda = lda;
+        data[i].B = data[i].BIsPacked ? (float*)packed_b_.get() : b_data + helper.RightOffsets()[i];
+        data[i].ldb = ldb;
+        data[i].C = y_data + helper.OutputOffsets()[i];
+        data[i].ldc = N;
+        data[i].alpha = alpha_attr_;
+        data[i].beta = 0.0f;
+      }
+      MlasGemmBatch(trans_a ? CblasTrans : CblasNoTrans, trans_b ? CblasTrans : CblasNoTrans,
+                    M, N, K, data.data(), max_len, thread_pool, &mlas_backend_kernel_selector_config_);
+    };
+
+    if (max_len <= 2) {
+      InlinedVector<MLAS_SGEMM_DATA_PARAMS, 2> data(max_len);
+      gemm_batch(data);
+    } else {
+      std::vector<MLAS_SGEMM_DATA_PARAMS> data(max_len);
+      gemm_batch(data);
     }
-    MlasGemmBatch(trans_a ? CblasTrans : CblasNoTrans, trans_b ? CblasTrans : CblasNoTrans,
-                  M, N, K, data.data(), max_len, thread_pool, &mlas_backend_kernel_selector_config_);
   }
   return Status::OK();
 }

--- a/onnxruntime/core/providers/cpu/math/matmul.cc
+++ b/onnxruntime/core/providers/cpu/math/matmul.cc
@@ -316,8 +316,9 @@ Status MatMul<float>::Compute(OpKernelContext* ctx) const {
   const size_t K = static_cast<size_t>(helper.K());
   const size_t lda = helper.Lda(trans_a);
   const size_t ldb = helper.Ldb(trans_b);
-  // Small batches use stack-backed InlinedVector storage (no per-Compute() heap
-  // allocation); larger batches fall back to std::vector. Shared by both paths below.
+  // When Abseil is enabled (the default), small batches use stack-backed InlinedVector
+  // storage to avoid a per-Compute() heap allocation; larger batches use std::vector.
+  // (Under DISABLE_ABSEIL, InlinedVector is std::vector, so this is a no-op.)
   constexpr size_t kInlineBatchCutoff = 2;
 #if defined(__aarch64__) && defined(__linux__)
   const bool can_use_fastmath_sbgemm = CanUseFastMathModeSBGemm(N, K);

--- a/onnxruntime/core/providers/cpu/math/matmul.cc
+++ b/onnxruntime/core/providers/cpu/math/matmul.cc
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 #include "core/providers/cpu/math/matmul.h"
-#include "core/common/inlined_containers.h"
+#include "core/common/inlined_containers_fwd.h"
 #include "core/providers/cpu/math/gemm_matmul_common.h"
 #include "core/providers/cpu/math/matmul_helper.h"
 #include "core/util/math.h"
@@ -316,6 +316,9 @@ Status MatMul<float>::Compute(OpKernelContext* ctx) const {
   const size_t K = static_cast<size_t>(helper.K());
   const size_t lda = helper.Lda(trans_a);
   const size_t ldb = helper.Ldb(trans_b);
+  // Small batches use stack-backed InlinedVector storage (no per-Compute() heap
+  // allocation); larger batches fall back to std::vector. Shared by both paths below.
+  constexpr size_t kInlineBatchCutoff = 2;
 #if defined(__aarch64__) && defined(__linux__)
   const bool can_use_fastmath_sbgemm = CanUseFastMathModeSBGemm(N, K);
   if (packed_b_) {
@@ -348,8 +351,8 @@ Status MatMul<float>::Compute(OpKernelContext* ctx) const {
                       M, N, K, max_len, data.data(), thread_pool, &mlas_backend_kernel_selector_config_);
     };
 
-    if (max_len <= 2) {
-      InlinedVector<MLAS_SBGEMM_DATA_PARAMS, 2> data(max_len);
+    if (max_len <= kInlineBatchCutoff) {
+      InlinedVector<MLAS_SBGEMM_DATA_PARAMS, kInlineBatchCutoff> data(max_len);
       gemm_batch(data);
     } else {
       std::vector<MLAS_SBGEMM_DATA_PARAMS> data(max_len);
@@ -374,8 +377,8 @@ Status MatMul<float>::Compute(OpKernelContext* ctx) const {
                     M, N, K, data.data(), max_len, thread_pool, &mlas_backend_kernel_selector_config_);
     };
 
-    if (max_len <= 2) {
-      InlinedVector<MLAS_SGEMM_DATA_PARAMS, 2> data(max_len);
+    if (max_len <= kInlineBatchCutoff) {
+      InlinedVector<MLAS_SGEMM_DATA_PARAMS, kInlineBatchCutoff> data(max_len);
       gemm_batch(data);
     } else {
       std::vector<MLAS_SGEMM_DATA_PARAMS> data(max_len);


### PR DESCRIPTION
### Description

Reduce per-call heap allocation overhead in the CPU `MatMul<float>` kernel for the small batched-GEMM case.

`MatMul<float>::Compute()` builds an array of MLAS batch-parameter structs before calling `MlasGemmBatch` / `MlasSBGemmBatch`. Previously this always used `std::vector`, so even the common single-GEMM path performed one heap allocation per `Compute()` call.

This change uses stack-backed `InlinedVector` storage when `helper.OutputOffsets().size() <= 2`, and keeps the existing `std::vector` path for larger batches:

- `MLAS_SGEMM_DATA_PARAMS` and `MLAS_SBGEMM_DATA_PARAMS` (aarch64/Linux fast-math path) both use `InlinedVector<..., 2>` for `max_len <= 2`.
- Larger batches fall back to `std::vector`, preserving prior behavior (and avoiding the `InlinedVector` overflow path, which I measured to regress for larger batches).

The struct is ~64 bytes and trivially copyable, so the net effect is removing exactly **one `malloc`/`free` pair per `Compute()` call** in the small-batch case.

### Motivation and Context

Many real CPU MatMul shapes flatten to `helper.OutputOffsets().size() == 1`. `MatMulComputeHelper` special-cases an activation × 2D-weight matrix into a single GEMM (offsets `{0}`), so shapes like the following all hit `max_len == 1`:

```text
[M, K] x [K, N]
[B, S, K] x [K, N]
[B, H, S, K] x [K, N]
```

These appear in transformer projections, MLP layers, and classifier heads. Removing a heap allocation from that path is a small, low-risk latency improvement.

### Performance Measurements

Measured on Windows (MSVC, `RelWithDebInfo`) with `onnxruntime_perf_test`, using 256-node **square** MatMul chains (`[N,N]·[N,N]`, which flatten to `max_len == 1` — the case this PR optimizes). 5 trials each; medians shown. `per-node saving` = `(base_p50 − opt_p50) / 256`.

| N | base avg (ms) | opt avg (ms) | base p50 (µs) | opt p50 (µs) | per-node saving |
|---:|---:|---:|---:|---:|---:|
| 1 | 0.178246 | 0.177635 | 159.7 | 153.4 | 24.6 ns |
| 8 | 0.189659 | 0.182407 | 167.7 | 158.4 | 36.3 ns |
| 16 | 0.209381 | 0.194601 | 178.4 | 168.4 | 39.1 ns |
| 32 | 0.307178 | 0.293141 | 279.4 | 269.7 | 37.9 ns |
| 64 | 1.389432 | 1.362902 | 1371.2 | 1333.6 | 146.9 ns |
| 128 | 3.403018 | 3.145609 | 3305.9 | 3123.3 | 713.3 ns |

**Interpretation (honest scope):**

- The benefit is a **fixed ~36–39 ns per `Compute()` call**, clearly and consistently visible at N=8/16/32 — exactly one `malloc`/`free` pair removed.
- Because the saving is fixed, its true contribution shrinks as the GEMM grows: ~5–6% at N≤16, ~3.5% at N=32, but **well under 1% for N≥64**.
- The larger apparent deltas at N=64/128 (147 ns / 713 ns per node) exceed what a fixed allocation can account for and are dominated by threaded-GEMM run-to-run variance (the baseline/optimized ranges overlap), so they should **not** be read as a real ~5% win.

In short: this is a targeted micro-optimization that helps **tiny-GEMM-heavy** CPU workloads; for mainstream MatMul sizes the effect is below the measurement noise floor. It is intentionally low-risk rather than a broad throughput win.

### Validation

- Built `onnxruntime_perf_test` separately for the baseline (`std::vector`) and optimized (`InlinedVector`) code for an apples-to-apples comparison.
- Built `onnxruntime_provider_test` with the final change.
- Focused MatMul tests pass:

```text
onnxruntime_provider_test.exe --gtest_filter=*MatMul*
[==========] 430 tests from 16 test suites ran.
[  PASSED  ] 430 tests.
YOU HAVE 1 DISABLED TEST
```
