### PR TITLE
Segregate IExecutionProvider optional capabilities into mix-in interfaces

### DIFF
--- a/include/onnxruntime/core/framework/execution_provider.h
+++ b/include/onnxruntime/core/framework/execution_provider.h
@@ -74,6 +74,7 @@ enum class DataLayout {
 // Segregated optional-capability mix-in interfaces. See execution_provider_capabilities.h.
 class IGraphCaptureCapability;
 class ITuningCapability;
+class IDataLayoutCapability;
 class ICompileCapability;
 
 class IExecutionProvider {
@@ -485,6 +486,9 @@ class IExecutionProvider {
 
   /** Return this EP's TunableOp tuning capability, or nullptr if unsupported. */
   virtual ITuningCapability* GetTuningCapability() const noexcept { return nullptr; }
+
+  /** Return this EP's data-layout preference capability, or nullptr if unsupported. */
+  virtual IDataLayoutCapability* GetDataLayoutCapability() const noexcept { return nullptr; }
 
 #if !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
   /** Return this EP's subgraph-compilation capability, or nullptr if unsupported. */

--- a/include/onnxruntime/core/framework/execution_provider.h
+++ b/include/onnxruntime/core/framework/execution_provider.h
@@ -71,6 +71,11 @@ enum class DataLayout {
   Default = NCHW,
 };
 
+// Segregated optional-capability mix-in interfaces. See execution_provider_capabilities.h.
+class IGraphCaptureCapability;
+class ITuningCapability;
+class ICompileCapability;
+
 class IExecutionProvider {
  protected:
   IExecutionProvider(const std::string& type)
@@ -466,6 +471,25 @@ class IExecutionProvider {
   virtual const OrtEp* GetOrtEp() const {
     return nullptr;
   }
+
+  // --- Segregated optional-capability query hooks (Interface Segregation) ---
+  // Each hook returns a pointer to a narrow capability mix-in (defined in
+  // execution_provider_capabilities.h) when this EP supports the corresponding
+  // optional capability, or nullptr otherwise. They let callers depend only on
+  // the capability they need instead of the full IExecutionProvider surface.
+  // The legacy per-capability virtuals above are retained for compatibility;
+  // EPs and callers can migrate to these hooks incrementally.
+
+  /** Return this EP's graph-capture/replay capability, or nullptr if unsupported. */
+  virtual IGraphCaptureCapability* GetGraphCaptureCapability() noexcept { return nullptr; }
+
+  /** Return this EP's TunableOp tuning capability, or nullptr if unsupported. */
+  virtual ITuningCapability* GetTuningCapability() const noexcept { return nullptr; }
+
+#if !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
+  /** Return this EP's subgraph-compilation capability, or nullptr if unsupported. */
+  virtual ICompileCapability* GetCompileCapability() noexcept { return nullptr; }
+#endif
 
  private:
   const std::string type_;

--- a/include/onnxruntime/core/framework/execution_provider.h
+++ b/include/onnxruntime/core/framework/execution_provider.h
@@ -481,14 +481,20 @@ class IExecutionProvider {
   // The legacy per-capability virtuals above are retained for compatibility;
   // EPs and callers can migrate to these hooks incrementally.
 
-  /** Return this EP's graph-capture/replay capability, or nullptr if unsupported. */
+  /** Return this EP's graph-capture/replay capability, or nullptr if unsupported.
+      Non-const because the capability exposes mutating operations (graph replay/release). */
   virtual IGraphCaptureCapability* GetGraphCaptureCapability() noexcept { return nullptr; }
 
-  /** Return this EP's TunableOp tuning capability, or nullptr if unsupported. */
-  virtual ITuningCapability* GetTuningCapability() const noexcept { return nullptr; }
+  /** Return this EP's TunableOp tuning capability, or nullptr if unsupported.
+      Non-const by design: acquiring the tuning capability is part of the mutating
+      execution path -- tuning records state through the returned ITuningContext --
+      so it is intentionally not exposed as a const, read-only query. */
+  virtual ITuningCapability* GetTuningCapability() noexcept { return nullptr; }
 
-  /** Return this EP's data-layout preference capability, or nullptr if unsupported. */
-  virtual IDataLayoutCapability* GetDataLayoutCapability() const noexcept { return nullptr; }
+  /** Return this EP's data-layout preference capability, or nullptr if unsupported.
+      Const and returning a const pointer: data-layout preference is a read-only
+      query, so it must not permit mutating the EP through a const reference. */
+  virtual const IDataLayoutCapability* GetDataLayoutCapability() const noexcept { return nullptr; }
 
 #if !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
   /** Return this EP's subgraph-compilation capability, or nullptr if unsupported. */

--- a/include/onnxruntime/core/framework/execution_provider.h
+++ b/include/onnxruntime/core/framework/execution_provider.h
@@ -283,6 +283,10 @@ class IExecutionProvider {
   /**
      Indicate whether graph capture/replay (for example, CUDA graph capture) is
      enabled for the provider.
+
+     See also IGraphCaptureCapability / GetGraphCaptureCapability() in
+     execution_provider_capabilities.h, the segregated mix-in that groups this and
+     the other graph-capture methods below.
    */
   virtual bool IsGraphCaptureEnabled() const { return false; }
 
@@ -367,6 +371,9 @@ class IExecutionProvider {
 
            Do NOT cache the GraphViewer in FusedNodeAndGraph.filtered_graph in any of the NodeComputeInfo functions
            as it is only valid for the duration of the call to Compile.
+
+           See also ICompileCapability / GetCompileCapability() in
+           execution_provider_capabilities.h, the segregated mix-in that groups the compilation methods.
   */
   virtual common::Status Compile(const std::vector<FusedNodeAndGraph>& fused_nodes_and_graphs,
                                  std::vector<NodeComputeInfo>& node_compute_funcs);
@@ -408,6 +415,13 @@ class IExecutionProvider {
     return {};
   }
 
+  /**
+     Return the data layout preferred by this EP.
+
+     See also IDataLayoutCapability / GetDataLayoutCapability() in
+     execution_provider_capabilities.h, the segregated mix-in that groups
+     GetPreferredLayout() and ShouldConvertDataLayoutForOp().
+   */
   virtual DataLayout GetPreferredLayout() const {
     // EPs which prefer a different layout should override to return their preferred layout.
     return DataLayout::Default;
@@ -434,6 +448,9 @@ class IExecutionProvider {
 
   /**
    * Return the tuning context which holds all TunableOp state.
+   *
+   * See also ITuningCapability / GetTuningCapability() in
+   * execution_provider_capabilities.h, the segregated mix-in.
    */
   virtual ITuningContext* GetTuningContext() const {
     return nullptr;
@@ -486,10 +503,12 @@ class IExecutionProvider {
   virtual IGraphCaptureCapability* GetGraphCaptureCapability() noexcept { return nullptr; }
 
   /** Return this EP's TunableOp tuning capability, or nullptr if unsupported.
-      Non-const by design: acquiring the tuning capability is part of the mutating
-      execution path -- tuning records state through the returned ITuningContext --
-      so it is intentionally not exposed as a const, read-only query. */
-  virtual ITuningCapability* GetTuningCapability() noexcept { return nullptr; }
+      Const and returning a const pointer, mirroring the legacy GetTuningContext()
+      const: ITuningCapability exposes only the read-only GetTuningContext() const,
+      so acquiring it is a const query that stays callable on a const
+      IExecutionProvider&. Tuning state is still recorded through the returned
+      ITuningContext, not by mutating the EP. */
+  virtual const ITuningCapability* GetTuningCapability() const noexcept { return nullptr; }
 
   /** Return this EP's data-layout preference capability, or nullptr if unsupported.
       Const and returning a const pointer: data-layout preference is a read-only

--- a/include/onnxruntime/core/framework/execution_provider_capabilities.h
+++ b/include/onnxruntime/core/framework/execution_provider_capabilities.h
@@ -3,7 +3,9 @@
 
 #pragma once
 
+#include <optional>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "core/common/status.h"
@@ -74,6 +76,32 @@ class ITuningCapability {
 
   /** Return the tuning context which holds all TunableOp state. */
   virtual ITuningContext* GetTuningContext() const = 0;
+};
+
+/**
+ * Data-layout preference capability.
+ *
+ * Only a subset of EPs prefer a non-default (non-NCHW) data layout. Such an EP
+ * advertises its preferred layout and decides, per op, whether ORT should
+ * convert an associated node's data layout during layout transformation. The
+ * two methods are coupled: ShouldConvertDataLayoutForOp is driven by the
+ * preferred layout reported by GetPreferredLayout.
+ */
+class IDataLayoutCapability {
+ public:
+  virtual ~IDataLayoutCapability() = default;
+
+  /** Return the data layout preferred by this EP. */
+  virtual DataLayout GetPreferredLayout() const = 0;
+
+  /**
+   * Decide whether an op (with the given `domain` and `op_type`) should have its
+   * data layout converted to `target_data_layout`. Return std::nullopt to leave
+   * the decision to ORT.
+   */
+  virtual std::optional<bool> ShouldConvertDataLayoutForOp(std::string_view domain,
+                                                           std::string_view op_type,
+                                                           DataLayout target_data_layout) const = 0;
 };
 
 #if !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)

--- a/include/onnxruntime/core/framework/execution_provider_capabilities.h
+++ b/include/onnxruntime/core/framework/execution_provider_capabilities.h
@@ -1,0 +1,107 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "core/common/status.h"
+#include "core/framework/execution_provider.h"
+
+namespace onnxruntime {
+
+class GraphViewer;
+
+/**
+ * Segregated optional-capability interfaces for IExecutionProvider.
+ *
+ * Motivation (Interface Segregation Principle):
+ * IExecutionProvider historically carries a large number of defaulted virtual
+ * methods, many of which represent optional capabilities relevant to only a
+ * subset of execution providers -- graph capture/replay (e.g. CUDA graphs),
+ * ahead-of-time/just-in-time compilation of fused subgraphs, and TunableOp
+ * tuning. Bundling them on the base couples every EP and every caller to the
+ * union of all capabilities.
+ *
+ * Each mix-in below groups one such cluster behind a narrow interface. An EP
+ * that supports a capability implements the corresponding mix-in and returns it
+ * from the matching IExecutionProvider::Get*Capability() query hook; callers
+ * depend only on the mix-in they actually use.
+ *
+ * This is additive and non-breaking: the legacy per-capability virtuals on
+ * IExecutionProvider remain in place, so existing EPs and callers are
+ * unaffected. EPs and callers can migrate to the segregated interfaces
+ * incrementally, and a cluster's legacy virtuals can be removed from the base
+ * once all of its implementers and callers have moved over.
+ */
+
+/**
+ * Graph capture / replay capability (e.g. CUDA graphs).
+ *
+ * Method signatures mirror the corresponding legacy IExecutionProvider virtuals
+ * so that a migrating EP can satisfy both with a single set of definitions.
+ */
+class IGraphCaptureCapability {
+ public:
+  virtual ~IGraphCaptureCapability() = default;
+
+  /** Indicate whether graph capture/replay is enabled for the provider. */
+  virtual bool IsGraphCaptureEnabled() const = 0;
+
+  /** Indicate whether the graph for the given annotation id has been captured and instantiated. */
+  virtual bool IsGraphCaptured(int graph_annotation_id) const = 0;
+
+  /**
+   * Run the instantiated graph.
+   * @param sync If true, synchronize the device/stream after replay before returning.
+   */
+  virtual common::Status ReplayGraph(int graph_annotation_id, bool sync = true) = 0;
+
+  /** Release a previously captured graph and its associated resources. */
+  virtual common::Status ReleaseCapturedGraph(int graph_annotation_id) = 0;
+
+  /** Get the node assignment validation policy to apply when graph capture is enabled. */
+  virtual OrtGraphCaptureNodeAssignmentPolicy GetGraphCaptureNodeAssignmentPolicy() const = 0;
+};
+
+/**
+ * TunableOp tuning capability.
+ */
+class ITuningCapability {
+ public:
+  virtual ~ITuningCapability() = default;
+
+  /** Return the tuning context which holds all TunableOp state. */
+  virtual ITuningContext* GetTuningContext() const = 0;
+};
+
+#if !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
+/**
+ * Subgraph-compilation capability.
+ *
+ * Mirrors the legacy compilation virtuals, which are likewise only available
+ * outside a (non-extended) minimal build.
+ */
+class ICompileCapability {
+ public:
+  virtual ~ICompileCapability() = default;
+
+  /**
+   * Given a collection of fused Nodes and the respective GraphViewer instance for the nodes that were
+   * fused, return create_state/compute/release_state func for each node.
+   */
+  virtual common::Status Compile(const std::vector<IExecutionProvider::FusedNodeAndGraph>& fused_nodes_and_graphs,
+                                 std::vector<NodeComputeInfo>& node_compute_funcs) = 0;
+
+  /** Get the compatibility info for a compiled model. */
+  virtual std::string GetCompiledModelCompatibilityInfo(const GraphViewer& graph_viewer) const = 0;
+
+  /** Validate the compatibility of a compiled model with this execution provider. */
+  virtual common::Status ValidateCompiledModelCompatibilityInfo(
+      const std::string& compatibility_info,
+      OrtCompiledModelCompatibility& model_compatibility) const = 0;
+};
+#endif  // !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
+
+}  // namespace onnxruntime

--- a/include/onnxruntime/core/framework/execution_provider_capabilities.h
+++ b/include/onnxruntime/core/framework/execution_provider_capabilities.h
@@ -22,9 +22,10 @@ class GraphViewer;
  * IExecutionProvider historically carries a large number of defaulted virtual
  * methods, many of which represent optional capabilities relevant to only a
  * subset of execution providers -- graph capture/replay (e.g. CUDA graphs),
- * ahead-of-time/just-in-time compilation of fused subgraphs, and TunableOp
- * tuning. Bundling them on the base couples every EP and every caller to the
- * union of all capabilities.
+ * data-layout preference for layout-sensitive EPs (e.g. NHWC), ahead-of-time/
+ * just-in-time compilation of fused subgraphs, and TunableOp tuning. Bundling
+ * them on the base couples every EP and every caller to the union of all
+ * capabilities.
  *
  * Each mix-in below groups one such cluster behind a narrow interface. An EP
  * that supports a capability implements the corresponding mix-in and returns it
@@ -57,10 +58,20 @@ class IGraphCaptureCapability {
   /**
    * Run the instantiated graph.
    * @param sync If true, synchronize the device/stream after replay before returning.
+   *             The default (true) must stay equal to IExecutionProvider::ReplayGraph's
+   *             default: a default argument binds by the static type of the call
+   *             expression, so the two declarations must agree to behave identically
+   *             regardless of which one a caller sees.
    */
   virtual common::Status ReplayGraph(int graph_annotation_id, bool sync = true) = 0;
 
-  /** Release a previously captured graph and its associated resources. */
+  /**
+   * Release a previously captured graph and its associated resources.
+   *
+   * Thread safety: for EPs where ConcurrentRunSupported() returns true, this may be
+   * called concurrently with Run(), and the EP is responsible for its own
+   * synchronization; for non-concurrent EPs the session serializes the calls.
+   */
   virtual common::Status ReleaseCapturedGraph(int graph_annotation_id) = 0;
 
   /** Get the node assignment validation policy to apply when graph capture is enabled. */
@@ -69,6 +80,12 @@ class IGraphCaptureCapability {
 
 /**
  * TunableOp tuning capability.
+ *
+ * Mirrors the legacy IExecutionProvider::GetTuningContext(), which is a const,
+ * read-only accessor: the capability hands out the tuning context but does not
+ * mutate the EP, so the matching GetTuningCapability() query hook is likewise a
+ * const query. Tuning state is recorded through the returned ITuningContext, not
+ * by mutating the EP.
  */
 class ITuningCapability {
  public:
@@ -118,6 +135,9 @@ class ICompileCapability {
   /**
    * Given a collection of fused Nodes and the respective GraphViewer instance for the nodes that were
    * fused, return create_state/compute/release_state func for each node.
+   *
+   * Do NOT cache the GraphViewer in FusedNodeAndGraph.filtered_graph in any of the NodeComputeInfo
+   * functions, as it is only valid for the duration of the call to Compile.
    */
   virtual common::Status Compile(const std::vector<IExecutionProvider::FusedNodeAndGraph>& fused_nodes_and_graphs,
                                  std::vector<NodeComputeInfo>& node_compute_funcs) = 0;

--- a/onnxruntime/test/framework/execution_provider_capabilities_test.cc
+++ b/onnxruntime/test/framework/execution_provider_capabilities_test.cc
@@ -60,21 +60,15 @@ class TuningEp : public IExecutionProvider, public ITuningCapability {
  public:
   TuningEp() : IExecutionProvider(kFakeEpType) {}
 
-  ITuningCapability* GetTuningCapability() const noexcept override {
-    return const_cast<TuningEp*>(this);
-  }
+  // Non-const hook (matches the base signature): returns the mix-in subobject
+  // directly, with no const_cast.
+  ITuningCapability* GetTuningCapability() noexcept override { return this; }
 
-  // ITuningCapability. Returns nullptr (no real tuning state); a call counter
-  // proves the call is routed to the concrete implementation through the mix-in.
-  ITuningContext* GetTuningContext() const override {
-    ++tuning_query_count_;
-    return nullptr;
-  }
-
-  int tuning_query_count() const { return tuning_query_count_; }
-
- private:
-  mutable int tuning_query_count_ = 0;
+  // ITuningCapability::GetTuningContext() is pure virtual, so a successful call
+  // necessarily dispatches to this override -- that alone proves routing through
+  // the mix-in, with no mutable call-counter needed. A fake EP holds no real
+  // tuning state, so it reports a null context.
+  ITuningContext* GetTuningContext() const override { return nullptr; }
 };
 
 // An EP that supports only a data-layout preference.
@@ -82,9 +76,9 @@ class DataLayoutEp : public IExecutionProvider, public IDataLayoutCapability {
  public:
   DataLayoutEp() : IExecutionProvider(kFakeEpType) {}
 
-  IDataLayoutCapability* GetDataLayoutCapability() const noexcept override {
-    return const_cast<DataLayoutEp*>(this);
-  }
+  // Const hook returning a const pointer: no const_cast, returns the mix-in
+  // subobject directly.
+  const IDataLayoutCapability* GetDataLayoutCapability() const noexcept override { return this; }
 
   // IDataLayoutCapability
   DataLayout GetPreferredLayout() const override { return DataLayout::NHWC; }
@@ -145,9 +139,7 @@ class GraphCaptureAndDataLayoutEp : public IExecutionProvider,
   GraphCaptureAndDataLayoutEp() : IExecutionProvider(kFakeEpType) {}
 
   IGraphCaptureCapability* GetGraphCaptureCapability() noexcept override { return this; }
-  IDataLayoutCapability* GetDataLayoutCapability() const noexcept override {
-    return const_cast<GraphCaptureAndDataLayoutEp*>(this);
-  }
+  const IDataLayoutCapability* GetDataLayoutCapability() const noexcept override { return this; }
 
   // IGraphCaptureCapability
   bool IsGraphCaptureEnabled() const override { return true; }
@@ -207,7 +199,7 @@ TEST(ExecutionProviderCapabilitiesTest, DataLayoutCapabilityIsQueryableAndUsable
   DataLayoutEp ep;
   IExecutionProvider& base = ep;
 
-  IDataLayoutCapability* dl = base.GetDataLayoutCapability();
+  const IDataLayoutCapability* dl = base.GetDataLayoutCapability();
   ASSERT_NE(dl, nullptr) << "EP advertising a data-layout preference must return a non-null capability.";
 
   EXPECT_EQ(dl->GetPreferredLayout(), DataLayout::NHWC);
@@ -229,8 +221,9 @@ TEST(ExecutionProviderCapabilitiesTest, TuningCapabilityIsQueryableAndUsable) {
   ITuningCapability* tc = base.GetTuningCapability();
   ASSERT_NE(tc, nullptr) << "EP advertising tuning must return a non-null capability.";
 
+  // GetTuningContext() is pure virtual on the mix-in, so reaching this concrete
+  // (null-context) result proves the call routed through the mix-in.
   EXPECT_EQ(tc->GetTuningContext(), nullptr);
-  EXPECT_EQ(ep.tuning_query_count(), 1) << "GetTuningContext must reach the concrete implementation.";
 }
 
 #if !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
@@ -297,7 +290,7 @@ TEST(ExecutionProviderCapabilitiesTest, MultipleCapabilitiesCoexist) {
   IExecutionProvider& base = ep;
 
   IGraphCaptureCapability* gc = base.GetGraphCaptureCapability();
-  IDataLayoutCapability* dl = base.GetDataLayoutCapability();
+  const IDataLayoutCapability* dl = base.GetDataLayoutCapability();
   ASSERT_NE(gc, nullptr);
   ASSERT_NE(dl, nullptr);
 

--- a/onnxruntime/test/framework/execution_provider_capabilities_test.cc
+++ b/onnxruntime/test/framework/execution_provider_capabilities_test.cc
@@ -64,9 +64,17 @@ class TuningEp : public IExecutionProvider, public ITuningCapability {
     return const_cast<TuningEp*>(this);
   }
 
-  // ITuningCapability. Returns nullptr (no real tuning state) -- the test only
-  // needs to prove the call path is reachable through the mix-in.
-  ITuningContext* GetTuningContext() const override { return nullptr; }
+  // ITuningCapability. Returns nullptr (no real tuning state); a call counter
+  // proves the call is routed to the concrete implementation through the mix-in.
+  ITuningContext* GetTuningContext() const override {
+    ++tuning_query_count_;
+    return nullptr;
+  }
+
+  int tuning_query_count() const { return tuning_query_count_; }
+
+ private:
+  mutable int tuning_query_count_ = 0;
 };
 
 // An EP that supports only a data-layout preference.
@@ -86,6 +94,74 @@ class DataLayoutEp : public IExecutionProvider, public IDataLayoutCapability {
     if (target_data_layout == DataLayout::NHWC && op_type == "Conv") {
       return true;
     }
+    return std::nullopt;
+  }
+};
+
+#if !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
+// An EP that supports only subgraph compilation. Call markers prove the calls
+// route to the concrete implementation through the mix-in.
+class CompileEp : public IExecutionProvider, public ICompileCapability {
+ public:
+  CompileEp() : IExecutionProvider(kFakeEpType) {}
+
+  ICompileCapability* GetCompileCapability() noexcept override { return this; }
+
+  // ICompileCapability
+  common::Status Compile(const std::vector<IExecutionProvider::FusedNodeAndGraph>& fused_nodes_and_graphs,
+                         std::vector<NodeComputeInfo>& /*node_compute_funcs*/) override {
+    last_fused_count_ = fused_nodes_and_graphs.size();
+    ++compile_call_count_;
+    return Status::OK();
+  }
+  std::string GetCompiledModelCompatibilityInfo(const GraphViewer& /*graph_viewer*/) const override {
+    return kCompatInfo;
+  }
+  common::Status ValidateCompiledModelCompatibilityInfo(
+      const std::string& compatibility_info,
+      OrtCompiledModelCompatibility& model_compatibility) const override {
+    model_compatibility = (compatibility_info == kCompatInfo)
+                              ? OrtCompiledModelCompatibility_EP_SUPPORTED_OPTIMAL
+                              : OrtCompiledModelCompatibility_EP_UNSUPPORTED;
+    return Status::OK();
+  }
+
+  static constexpr const char* kCompatInfo = "fake-compat-v1";
+  int compile_call_count() const { return compile_call_count_; }
+  size_t last_fused_count() const { return last_fused_count_; }
+
+ private:
+  int compile_call_count_ = 0;
+  size_t last_fused_count_ = 0;
+};
+#endif  // !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
+
+// An EP that implements two capabilities at once. Used to verify the hooks
+// return the correct, independent mix-in subobjects under multiple inheritance.
+class GraphCaptureAndDataLayoutEp : public IExecutionProvider,
+                                    public IGraphCaptureCapability,
+                                    public IDataLayoutCapability {
+ public:
+  GraphCaptureAndDataLayoutEp() : IExecutionProvider(kFakeEpType) {}
+
+  IGraphCaptureCapability* GetGraphCaptureCapability() noexcept override { return this; }
+  IDataLayoutCapability* GetDataLayoutCapability() const noexcept override {
+    return const_cast<GraphCaptureAndDataLayoutEp*>(this);
+  }
+
+  // IGraphCaptureCapability
+  bool IsGraphCaptureEnabled() const override { return true; }
+  bool IsGraphCaptured(int /*graph_annotation_id*/) const override { return false; }
+  common::Status ReplayGraph(int /*graph_annotation_id*/, bool /*sync*/) override { return Status::OK(); }
+  common::Status ReleaseCapturedGraph(int /*graph_annotation_id*/) override { return Status::OK(); }
+  OrtGraphCaptureNodeAssignmentPolicy GetGraphCaptureNodeAssignmentPolicy() const override {
+    return OrtGraphCaptureNodeAssignmentPolicy_ALL_NODES_ON_EP;
+  }
+
+  // IDataLayoutCapability
+  DataLayout GetPreferredLayout() const override { return DataLayout::NHWC; }
+  std::optional<bool> ShouldConvertDataLayoutForOp(std::string_view /*domain*/, std::string_view /*op_type*/,
+                                                   DataLayout /*target_data_layout*/) const override {
     return std::nullopt;
   }
 };
@@ -144,6 +220,44 @@ TEST(ExecutionProviderCapabilitiesTest, DataLayoutCapabilityIsQueryableAndUsable
   EXPECT_FALSE(dl->ShouldConvertDataLayoutForOp("", "Add", DataLayout::NHWC).has_value());
 }
 
+// An EP that supports tuning is queryable through the base interface, and the
+// call routes to the concrete implementation through the narrow mix-in.
+TEST(ExecutionProviderCapabilitiesTest, TuningCapabilityIsQueryableAndUsable) {
+  TuningEp ep;
+  IExecutionProvider& base = ep;
+
+  ITuningCapability* tc = base.GetTuningCapability();
+  ASSERT_NE(tc, nullptr) << "EP advertising tuning must return a non-null capability.";
+
+  EXPECT_EQ(tc->GetTuningContext(), nullptr);
+  EXPECT_EQ(ep.tuning_query_count(), 1) << "GetTuningContext must reach the concrete implementation.";
+}
+
+#if !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
+// An EP that supports subgraph compilation is queryable through the base
+// interface and usable through the narrow mix-in.
+TEST(ExecutionProviderCapabilitiesTest, CompileCapabilityIsQueryableAndUsable) {
+  CompileEp ep;
+  IExecutionProvider& base = ep;
+
+  ICompileCapability* compile = base.GetCompileCapability();
+  ASSERT_NE(compile, nullptr) << "EP advertising compilation must return a non-null capability.";
+
+  std::vector<NodeComputeInfo> node_compute_funcs;
+  ASSERT_TRUE(compile->Compile(/*fused_nodes_and_graphs*/ {}, node_compute_funcs).IsOK());
+  EXPECT_EQ(ep.compile_call_count(), 1) << "Compile must reach the concrete implementation.";
+  EXPECT_EQ(ep.last_fused_count(), 0u);
+
+  OrtCompiledModelCompatibility match = OrtCompiledModelCompatibility_EP_NOT_APPLICABLE;
+  ASSERT_TRUE(compile->ValidateCompiledModelCompatibilityInfo(CompileEp::kCompatInfo, match).IsOK());
+  EXPECT_EQ(match, OrtCompiledModelCompatibility_EP_SUPPORTED_OPTIMAL);
+
+  OrtCompiledModelCompatibility mismatch = OrtCompiledModelCompatibility_EP_NOT_APPLICABLE;
+  ASSERT_TRUE(compile->ValidateCompiledModelCompatibilityInfo("other", mismatch).IsOK());
+  EXPECT_EQ(mismatch, OrtCompiledModelCompatibility_EP_UNSUPPORTED);
+}
+#endif  // !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
+
 // Capabilities are independent: an EP that implements only graph capture must
 // not be mistaken for supporting tuning or compilation, and vice versa.
 TEST(ExecutionProviderCapabilitiesTest, CapabilitiesAreIndependent) {
@@ -161,12 +275,41 @@ TEST(ExecutionProviderCapabilitiesTest, CapabilitiesAreIndependent) {
   EXPECT_NE(tuning_base.GetTuningCapability(), nullptr);
   EXPECT_EQ(tuning_base.GetGraphCaptureCapability(), nullptr);
   EXPECT_EQ(tuning_base.GetDataLayoutCapability(), nullptr);
+#if !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
+  EXPECT_EQ(tuning_base.GetCompileCapability(), nullptr);
+#endif
 
   DataLayoutEp data_layout_ep;
   IExecutionProvider& data_layout_base = data_layout_ep;
   EXPECT_NE(data_layout_base.GetDataLayoutCapability(), nullptr);
   EXPECT_EQ(data_layout_base.GetGraphCaptureCapability(), nullptr);
   EXPECT_EQ(data_layout_base.GetTuningCapability(), nullptr);
+#if !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
+  EXPECT_EQ(data_layout_base.GetCompileCapability(), nullptr);
+#endif
+}
+
+// A single EP may implement multiple capabilities at once. Each hook must return
+// the correct mix-in subobject (correct multiple-inheritance dispatch), and the
+// unimplemented capabilities must remain null.
+TEST(ExecutionProviderCapabilitiesTest, MultipleCapabilitiesCoexist) {
+  GraphCaptureAndDataLayoutEp ep;
+  IExecutionProvider& base = ep;
+
+  IGraphCaptureCapability* gc = base.GetGraphCaptureCapability();
+  IDataLayoutCapability* dl = base.GetDataLayoutCapability();
+  ASSERT_NE(gc, nullptr);
+  ASSERT_NE(dl, nullptr);
+
+  // Each hook routes to the correct subobject.
+  EXPECT_TRUE(gc->IsGraphCaptureEnabled());
+  EXPECT_EQ(dl->GetPreferredLayout(), DataLayout::NHWC);
+
+  // Unimplemented capabilities remain null.
+  EXPECT_EQ(base.GetTuningCapability(), nullptr);
+#if !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
+  EXPECT_EQ(base.GetCompileCapability(), nullptr);
+#endif
 }
 
 }  // namespace test

--- a/onnxruntime/test/framework/execution_provider_capabilities_test.cc
+++ b/onnxruntime/test/framework/execution_provider_capabilities_test.cc
@@ -1,0 +1,124 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Unit tests for the segregated optional-capability interfaces on
+// IExecutionProvider (see core/framework/execution_provider_capabilities.h).
+//
+// These exercise the capability-query mechanism with lightweight fake EPs and
+// run entirely on CPU -- they require no GPU/NPU backend.
+
+#include <memory>
+
+#include "gtest/gtest.h"
+
+#include "core/framework/execution_provider.h"
+#include "core/framework/execution_provider_capabilities.h"
+
+namespace onnxruntime {
+namespace test {
+
+namespace {
+
+constexpr const char* kFakeEpType = "FakeCapabilityEp";
+
+// An EP that supports no optional capability. Every query hook should return the
+// base-class default of nullptr.
+class PlainEp : public IExecutionProvider {
+ public:
+  PlainEp() : IExecutionProvider(kFakeEpType) {}
+};
+
+// An EP that supports graph capture, implemented via the segregated mix-in and
+// surfaced through the GetGraphCaptureCapability() query hook.
+class GraphCaptureEp : public IExecutionProvider, public IGraphCaptureCapability {
+ public:
+  GraphCaptureEp() : IExecutionProvider(kFakeEpType) {}
+
+  IGraphCaptureCapability* GetGraphCaptureCapability() noexcept override { return this; }
+
+  // IGraphCaptureCapability
+  bool IsGraphCaptureEnabled() const override { return true; }
+  bool IsGraphCaptured(int graph_annotation_id) const override { return graph_annotation_id == kCapturedId; }
+  common::Status ReplayGraph(int /*graph_annotation_id*/, bool /*sync*/) override {
+    ++replay_count_;
+    return Status::OK();
+  }
+  common::Status ReleaseCapturedGraph(int /*graph_annotation_id*/) override { return Status::OK(); }
+  OrtGraphCaptureNodeAssignmentPolicy GetGraphCaptureNodeAssignmentPolicy() const override {
+    return OrtGraphCaptureNodeAssignmentPolicy_ALLOW_CPU_FOR_SHAPES;
+  }
+
+  static constexpr int kCapturedId = 7;
+  int replay_count() const { return replay_count_; }
+
+ private:
+  int replay_count_ = 0;
+};
+
+// An EP that supports only tuning.
+class TuningEp : public IExecutionProvider, public ITuningCapability {
+ public:
+  TuningEp() : IExecutionProvider(kFakeEpType) {}
+
+  ITuningCapability* GetTuningCapability() const noexcept override {
+    return const_cast<TuningEp*>(this);
+  }
+
+  // ITuningCapability. Returns nullptr (no real tuning state) -- the test only
+  // needs to prove the call path is reachable through the mix-in.
+  ITuningContext* GetTuningContext() const override { return nullptr; }
+};
+
+}  // namespace
+
+// A capability-less EP returns nullptr from every query hook.
+TEST(ExecutionProviderCapabilitiesTest, UnsupportedCapabilitiesReturnNull) {
+  PlainEp ep;
+  IExecutionProvider& base = ep;
+
+  EXPECT_EQ(base.GetGraphCaptureCapability(), nullptr);
+  EXPECT_EQ(base.GetTuningCapability(), nullptr);
+#if !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
+  EXPECT_EQ(base.GetCompileCapability(), nullptr);
+#endif
+}
+
+// An EP that supports graph capture is queryable through the base interface and
+// usable through the narrow mix-in.
+TEST(ExecutionProviderCapabilitiesTest, GraphCaptureCapabilityIsQueryableAndUsable) {
+  GraphCaptureEp ep;
+  IExecutionProvider& base = ep;
+
+  IGraphCaptureCapability* gc = base.GetGraphCaptureCapability();
+  ASSERT_NE(gc, nullptr) << "EP advertising graph capture must return a non-null capability.";
+
+  EXPECT_TRUE(gc->IsGraphCaptureEnabled());
+  EXPECT_TRUE(gc->IsGraphCaptured(GraphCaptureEp::kCapturedId));
+  EXPECT_FALSE(gc->IsGraphCaptured(GraphCaptureEp::kCapturedId + 1));
+  EXPECT_EQ(gc->GetGraphCaptureNodeAssignmentPolicy(),
+            OrtGraphCaptureNodeAssignmentPolicy_ALLOW_CPU_FOR_SHAPES);
+
+  ASSERT_TRUE(gc->ReplayGraph(GraphCaptureEp::kCapturedId, /*sync*/ true).IsOK());
+  EXPECT_TRUE(gc->ReleaseCapturedGraph(GraphCaptureEp::kCapturedId).IsOK());
+  EXPECT_EQ(ep.replay_count(), 1) << "Replay must reach the concrete implementation.";
+}
+
+// Capabilities are independent: an EP that implements only graph capture must
+// not be mistaken for supporting tuning or compilation, and vice versa.
+TEST(ExecutionProviderCapabilitiesTest, CapabilitiesAreIndependent) {
+  GraphCaptureEp graph_ep;
+  IExecutionProvider& graph_base = graph_ep;
+  EXPECT_NE(graph_base.GetGraphCaptureCapability(), nullptr);
+  EXPECT_EQ(graph_base.GetTuningCapability(), nullptr);
+#if !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
+  EXPECT_EQ(graph_base.GetCompileCapability(), nullptr);
+#endif
+
+  TuningEp tuning_ep;
+  IExecutionProvider& tuning_base = tuning_ep;
+  EXPECT_NE(tuning_base.GetTuningCapability(), nullptr);
+  EXPECT_EQ(tuning_base.GetGraphCaptureCapability(), nullptr);
+}
+
+}  // namespace test
+}  // namespace onnxruntime

--- a/onnxruntime/test/framework/execution_provider_capabilities_test.cc
+++ b/onnxruntime/test/framework/execution_provider_capabilities_test.cc
@@ -69,6 +69,27 @@ class TuningEp : public IExecutionProvider, public ITuningCapability {
   ITuningContext* GetTuningContext() const override { return nullptr; }
 };
 
+// An EP that supports only a data-layout preference.
+class DataLayoutEp : public IExecutionProvider, public IDataLayoutCapability {
+ public:
+  DataLayoutEp() : IExecutionProvider(kFakeEpType) {}
+
+  IDataLayoutCapability* GetDataLayoutCapability() const noexcept override {
+    return const_cast<DataLayoutEp*>(this);
+  }
+
+  // IDataLayoutCapability
+  DataLayout GetPreferredLayout() const override { return DataLayout::NHWC; }
+  std::optional<bool> ShouldConvertDataLayoutForOp(std::string_view /*domain*/,
+                                                   std::string_view op_type,
+                                                   DataLayout target_data_layout) const override {
+    if (target_data_layout == DataLayout::NHWC && op_type == "Conv") {
+      return true;
+    }
+    return std::nullopt;
+  }
+};
+
 }  // namespace
 
 // A capability-less EP returns nullptr from every query hook.
@@ -78,6 +99,7 @@ TEST(ExecutionProviderCapabilitiesTest, UnsupportedCapabilitiesReturnNull) {
 
   EXPECT_EQ(base.GetGraphCaptureCapability(), nullptr);
   EXPECT_EQ(base.GetTuningCapability(), nullptr);
+  EXPECT_EQ(base.GetDataLayoutCapability(), nullptr);
 #if !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
   EXPECT_EQ(base.GetCompileCapability(), nullptr);
 #endif
@@ -103,6 +125,25 @@ TEST(ExecutionProviderCapabilitiesTest, GraphCaptureCapabilityIsQueryableAndUsab
   EXPECT_EQ(ep.replay_count(), 1) << "Replay must reach the concrete implementation.";
 }
 
+// An EP that supports a data-layout preference is queryable through the base
+// interface and usable through the narrow mix-in.
+TEST(ExecutionProviderCapabilitiesTest, DataLayoutCapabilityIsQueryableAndUsable) {
+  DataLayoutEp ep;
+  IExecutionProvider& base = ep;
+
+  IDataLayoutCapability* dl = base.GetDataLayoutCapability();
+  ASSERT_NE(dl, nullptr) << "EP advertising a data-layout preference must return a non-null capability.";
+
+  EXPECT_EQ(dl->GetPreferredLayout(), DataLayout::NHWC);
+
+  const std::optional<bool> conv_decision = dl->ShouldConvertDataLayoutForOp("", "Conv", DataLayout::NHWC);
+  ASSERT_TRUE(conv_decision.has_value());
+  EXPECT_TRUE(*conv_decision);
+
+  // An op the EP has no opinion on leaves the decision to ORT (std::nullopt).
+  EXPECT_FALSE(dl->ShouldConvertDataLayoutForOp("", "Add", DataLayout::NHWC).has_value());
+}
+
 // Capabilities are independent: an EP that implements only graph capture must
 // not be mistaken for supporting tuning or compilation, and vice versa.
 TEST(ExecutionProviderCapabilitiesTest, CapabilitiesAreIndependent) {
@@ -110,6 +151,7 @@ TEST(ExecutionProviderCapabilitiesTest, CapabilitiesAreIndependent) {
   IExecutionProvider& graph_base = graph_ep;
   EXPECT_NE(graph_base.GetGraphCaptureCapability(), nullptr);
   EXPECT_EQ(graph_base.GetTuningCapability(), nullptr);
+  EXPECT_EQ(graph_base.GetDataLayoutCapability(), nullptr);
 #if !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
   EXPECT_EQ(graph_base.GetCompileCapability(), nullptr);
 #endif
@@ -118,6 +160,13 @@ TEST(ExecutionProviderCapabilitiesTest, CapabilitiesAreIndependent) {
   IExecutionProvider& tuning_base = tuning_ep;
   EXPECT_NE(tuning_base.GetTuningCapability(), nullptr);
   EXPECT_EQ(tuning_base.GetGraphCaptureCapability(), nullptr);
+  EXPECT_EQ(tuning_base.GetDataLayoutCapability(), nullptr);
+
+  DataLayoutEp data_layout_ep;
+  IExecutionProvider& data_layout_base = data_layout_ep;
+  EXPECT_NE(data_layout_base.GetDataLayoutCapability(), nullptr);
+  EXPECT_EQ(data_layout_base.GetGraphCaptureCapability(), nullptr);
+  EXPECT_EQ(data_layout_base.GetTuningCapability(), nullptr);
 }
 
 }  // namespace test

--- a/onnxruntime/test/framework/execution_provider_capabilities_test.cc
+++ b/onnxruntime/test/framework/execution_provider_capabilities_test.cc
@@ -7,7 +7,7 @@
 // These exercise the capability-query mechanism with lightweight fake EPs and
 // run entirely on CPU -- they require no GPU/NPU backend.
 
-#include <memory>
+#include <type_traits>
 
 #include "gtest/gtest.h"
 
@@ -18,6 +18,67 @@ namespace onnxruntime {
 namespace test {
 
 namespace {
+
+// --- Compile-time signature-drift guard (Interface Segregation contract) ---
+//
+// Each capability mix-in method must keep the SAME signature as the legacy
+// IExecutionProvider virtual it mirrors. That identity is what lets a migrating
+// EP satisfy both the mix-in's pure virtual and the base's legacy virtual with a
+// single override. The drift danger is asymmetric: a mismatch on the *pure*
+// mix-in side is a hard compile error (safe), but a mismatch that leaves the
+// *non-pure* legacy virtual un-overridden compiles silently and splits the two
+// into separate vtable slots. These asserts turn that silent split into a build
+// failure. (Default arguments are not part of a function's type, so ReplayGraph's
+// `sync` default is guarded by a comment at its declaration instead.)
+template <typename M>
+struct MemberSignature;
+template <typename R, typename C, typename... Args>
+struct MemberSignature<R (C::*)(Args...)> {
+  using type = R(Args...);
+};
+template <typename R, typename C, typename... Args>
+struct MemberSignature<R (C::*)(Args...) const> {
+  using type = R(Args...) const;
+};
+template <typename MixinMethod, typename BaseMethod>
+inline constexpr bool kSameSignature =
+    std::is_same_v<typename MemberSignature<MixinMethod>::type, typename MemberSignature<BaseMethod>::type>;
+
+static_assert(kSameSignature<decltype(&IGraphCaptureCapability::IsGraphCaptureEnabled),
+                             decltype(&IExecutionProvider::IsGraphCaptureEnabled)>,
+              "IGraphCaptureCapability::IsGraphCaptureEnabled must mirror IExecutionProvider's.");
+static_assert(kSameSignature<decltype(&IGraphCaptureCapability::IsGraphCaptured),
+                             decltype(&IExecutionProvider::IsGraphCaptured)>,
+              "IGraphCaptureCapability::IsGraphCaptured must mirror IExecutionProvider's.");
+static_assert(kSameSignature<decltype(&IGraphCaptureCapability::ReplayGraph),
+                             decltype(&IExecutionProvider::ReplayGraph)>,
+              "IGraphCaptureCapability::ReplayGraph must mirror IExecutionProvider's.");
+static_assert(kSameSignature<decltype(&IGraphCaptureCapability::ReleaseCapturedGraph),
+                             decltype(&IExecutionProvider::ReleaseCapturedGraph)>,
+              "IGraphCaptureCapability::ReleaseCapturedGraph must mirror IExecutionProvider's.");
+static_assert(kSameSignature<decltype(&IGraphCaptureCapability::GetGraphCaptureNodeAssignmentPolicy),
+                             decltype(&IExecutionProvider::GetGraphCaptureNodeAssignmentPolicy)>,
+              "IGraphCaptureCapability::GetGraphCaptureNodeAssignmentPolicy must mirror IExecutionProvider's.");
+static_assert(kSameSignature<decltype(&ITuningCapability::GetTuningContext),
+                             decltype(&IExecutionProvider::GetTuningContext)>,
+              "ITuningCapability::GetTuningContext must mirror IExecutionProvider's.");
+static_assert(kSameSignature<decltype(&IDataLayoutCapability::GetPreferredLayout),
+                             decltype(&IExecutionProvider::GetPreferredLayout)>,
+              "IDataLayoutCapability::GetPreferredLayout must mirror IExecutionProvider's.");
+static_assert(kSameSignature<decltype(&IDataLayoutCapability::ShouldConvertDataLayoutForOp),
+                             decltype(&IExecutionProvider::ShouldConvertDataLayoutForOp)>,
+              "IDataLayoutCapability::ShouldConvertDataLayoutForOp must mirror IExecutionProvider's.");
+#if !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
+static_assert(kSameSignature<decltype(&ICompileCapability::Compile),
+                             decltype(&IExecutionProvider::Compile)>,
+              "ICompileCapability::Compile must mirror IExecutionProvider's.");
+static_assert(kSameSignature<decltype(&ICompileCapability::GetCompiledModelCompatibilityInfo),
+                             decltype(&IExecutionProvider::GetCompiledModelCompatibilityInfo)>,
+              "ICompileCapability::GetCompiledModelCompatibilityInfo must mirror IExecutionProvider's.");
+static_assert(kSameSignature<decltype(&ICompileCapability::ValidateCompiledModelCompatibilityInfo),
+                             decltype(&IExecutionProvider::ValidateCompiledModelCompatibilityInfo)>,
+              "ICompileCapability::ValidateCompiledModelCompatibilityInfo must mirror IExecutionProvider's.");
+#endif  // !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
 
 constexpr const char* kFakeEpType = "FakeCapabilityEp";
 
@@ -60,9 +121,9 @@ class TuningEp : public IExecutionProvider, public ITuningCapability {
  public:
   TuningEp() : IExecutionProvider(kFakeEpType) {}
 
-  // Non-const hook (matches the base signature): returns the mix-in subobject
-  // directly, with no const_cast.
-  ITuningCapability* GetTuningCapability() noexcept override { return this; }
+  // Const hook returning a const pointer (matches the base signature): returns
+  // the mix-in subobject directly, with no const_cast.
+  const ITuningCapability* GetTuningCapability() const noexcept override { return this; }
 
   // ITuningCapability::GetTuningContext() is pure virtual, so a successful call
   // necessarily dispatches to this override -- that alone proves routing through
@@ -218,8 +279,12 @@ TEST(ExecutionProviderCapabilitiesTest, TuningCapabilityIsQueryableAndUsable) {
   TuningEp ep;
   IExecutionProvider& base = ep;
 
-  ITuningCapability* tc = base.GetTuningCapability();
+  const ITuningCapability* tc = base.GetTuningCapability();
   ASSERT_NE(tc, nullptr) << "EP advertising tuning must return a non-null capability.";
+
+  // The hook returns this EP's own ITuningCapability subobject (correct pointer
+  // adjustment under multiple inheritance), not some unrelated instance.
+  EXPECT_EQ(tc, static_cast<const ITuningCapability*>(&ep));
 
   // GetTuningContext() is pure virtual on the mix-in, so reaching this concrete
   // (null-context) result proves the call routed through the mix-in.


### PR DESCRIPTION
### What this PR does

Introduces narrow, optional-capability **mix-in interfaces** for execution providers in a new header `core/framework/execution_provider_capabilities.h`, plus matching `Get*Capability()` query hooks on `IExecutionProvider` that return the capability pointer when supported and `nullptr` otherwise.

| Mix-in | Grouped methods | Query hook |
|---|---|---|
| `IGraphCaptureCapability` | `IsGraphCaptureEnabled`, `IsGraphCaptured`, `ReplayGraph`, `ReleaseCapturedGraph`, `GetGraphCaptureNodeAssignmentPolicy` | `GetGraphCaptureCapability()` |
| `ITuningCapability` | `GetTuningContext` | `GetTuningCapability()` |
| `IDataLayoutCapability` | `GetPreferredLayout`, `ShouldConvertDataLayoutForOp` | `GetDataLayoutCapability()` |
| `ICompileCapability` *(non-minimal / extended-minimal build)* | `Compile`, `GetCompiledModelCompatibilityInfo`, `ValidateCompiledModelCompatibilityInfo` | `GetCompileCapability()` |

### What this PR is — and is not

This is a **structural / readability refactor**, not a runtime optimization. To set expectations honestly:

- **No memory or performance gain is claimed.** Object layout actually gains an extra vtable per implemented mix-in. The cost is negligible, but it is a cost, not a saving — so the justification is API design, not throughput.
- The value is **explicit, typed capability detection**. Today an optional capability is a defaulted no-op virtual on the base, so "does this EP support X?" is unanswerable — every caller can call it on every EP and silently get a default. With a query hook, support becomes a first-class question: `if (auto* c = ep->GetGraphCaptureCapability()) { ... }`.
- It **lowers the cost of authoring/reviewing an EP**: a capability is declared in one narrow interface, and a new (or plugin) EP author sees a focused per-capability contract instead of the full `IExecutionProvider` surface.

### Why bundling on the base is worth addressing

`IExecutionProvider` is the most widely implemented interface in ORT and has accumulated many defaulted virtuals for capabilities only a subset of EPs implement (CUDA-graph capture, TunableOp tuning, subgraph compilation, non-default data layout). Bundling them on the base couples every EP and every caller to the union of all capabilities. Segregating each cluster behind a queryable mix-in is a step toward an `IExecutionProvider` whose base surface is the contract *every* EP must satisfy, with optional behavior expressed à la carte.

### Const-correctness (addresses review feedback)

The hooks are now split by whether acquiring the capability is a read-only query or part of the mutating path, which removes the earlier `const_cast` / `mutable` workarounds:

- `GetDataLayoutCapability() const` returns a **`const IDataLayoutCapability*`**. Data-layout preference is purely read-only (`GetPreferredLayout` / `ShouldConvertDataLayoutForOp` are `const`), so it must not allow mutating an EP through a const reference. Implementations `return this;` from a const method with **no `const_cast`**.
- `GetGraphCaptureCapability()`, `GetTuningCapability()`, and `GetCompileCapability()` are **non-const** and return non-const pointers, because those capabilities expose mutating operations (graph replay/release, tuning state recorded through `ITuningContext`, subgraph compilation). Acquiring them is honestly part of the mutating execution path, not a const query.

As a result there is no `const_cast` in any implementation or test, and the test fakes no longer need a `mutable` call-counter — `ITuningCapability::GetTuningContext()` is pure virtual, so reaching the concrete result already proves the call routed through the mix-in.

### Compatibility

Purely additive and non-breaking:

- The legacy per-capability virtuals on `IExecutionProvider` remain in place; existing EPs and callers are unaffected.
- The hooks default to `nullptr`; an EP opts in only by implementing a mix-in.
- Migration is incremental; a cluster's legacy virtuals can be removed from the base **only after** all of its implementers and callers have moved over.

### Follow-up (intentionally not in this PR)

Slimming the base for the cleanest cluster — data layout — is a deliberate, separate change. `GetPreferredLayout()` / `ShouldConvertDataLayoutForOp()` are overridden by ~9 EPs (CUDA, QNN, NNAPI, XNNPACK, WebGPU, WebNN, JS, the plugin bridge, and the internal-testing EP) and called from `graph_partitioner.cc` and `layout_transformation.cc`. Migrating all implementers and callers and then deleting the base virtuals is the end-to-end "before/after" that demonstrates the coupling reduction — but it touches several EPs that are not built in a CPU-only configuration, so it is kept out of this infrastructure-only PR to keep this change reviewable and independently verifiable.

### Tests

`onnxruntime/test/framework/execution_provider_capabilities_test.cc` exercises the hooks with lightweight CPU-only fake EPs:

- a capability-less EP returns `nullptr` from every hook;
- each capability is independently queryable and routes through its mix-in;
- capabilities are independent (implementing one does not imply another);
- multiple capabilities coexist on one EP with correct multiple-inheritance dispatch;
- the const data-layout hook yields a usable `const` capability with no casts.
