### PR TITLE
Bump protobufjs from 7.6.0 to 7.6.3 in /js/node

### DIFF
--- a/js/node/package-lock.json
+++ b/js/node/package-lock.json
@@ -74,9 +74,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
@@ -648,9 +648,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.0.tgz",
-      "integrity": "sha512-LtESOsMPTZgyYtwxhvdgdjGL0HmXEaRA/hVD6sol4zA60hVXXXP/SGmxnqDbgGE8gy7pYex7cym+5vYPcmaXBQ==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.3.tgz",
+      "integrity": "sha512-+k0vdJKNdW+Vu+dYe8tZA/VvQb6XKNWexC6URwBFXxNnjLJz9nQJCemGyNgRAWD+B7+nGNc9qMPGwcD7s4nzUw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
@@ -658,7 +658,7 @@
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
         "@protobufjs/codegen": "^2.0.5",
-        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/eventemitter": "^1.1.1",
         "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
         "@protobufjs/inquire": "^1.1.2",


### PR DESCRIPTION
### Description
Bumps the protobufjs lockfile entry used by onnxruntime-node from 7.6.0 to 7.6.3. The lockfile also updates @protobufjs/eventemitter from 1.1.0 to 1.1.1, matching protobufjs 7.6.3 dependency metadata.

No package.json range change is needed because the existing ^7.2.4 range already permits 7.6.3.

### Motivation and Context
[GHSA-f38q-mgvj-vph7 / CVE-2026-54269](https://github.com/advisories/GHSA-f38q-mgvj-vph7) reports that protobufjs versions <=7.6.2 are affected by schema-derived names that can shadow runtime-significant properties and make affected processing paths unusable. Version 7.6.3 is the patched 7.x release.

PR #29061 already updated /js/web to protobufjs 7.6.3, but /js/node/package-lock.json still pinned protobufjs 7.6.0. This change brings the Node.js package lockfile in line with the patched version.

Validation:
- 
pm ci in js/node
- 
pm run prepare in js/node
- 
pm audit --json in js/node returned 0 vulnerabilities
- 
pm ls protobufjs @protobufjs/eventemitter --depth=0 shows protobufjs@7.6.3
- Loaded ./test/ort-schema/protobuf/onnx.js with protobufjs/minimal


pm test was attempted. It prepared the Node.js test data and then stopped because the local tree does not have the native binding js/node/bin/napi-v6/win32/x64/onnxruntime_binding.node; this requires a local native build and is unrelated to the protobufjs lockfile update.