### PR TITLE
Initialize large-head FMHA shared memory per kernel variant

### DIFF
--- a/onnxruntime/contrib_ops/cuda/bert/cutlass_fmha/fmha_launch_template.h
+++ b/onnxruntime/contrib_ops/cuda/bert/cutlass_fmha/fmha_launch_template.h
@@ -233,23 +233,36 @@ void LaunchCutlassFmha(const MemoryEfficientAttentionParams& params) {
     p.window_size = params.local_window_size;
   }
 
-  auto kernel_fn = attention_kernel_batched_impl<Attention>;
-
-  if (params.has_custom_right_padding) {
-    kernel_fn = attention_kernel_batched_impl_right_padding<Attention, queries_per_block>;
-  }
-
   int smem_bytes = sizeof(typename Attention::SharedStorage);
   if (smem_bytes > 0xc000) {
     ORT_ENFORCE(params.sm >= 70, "This kernel requires too much shared memory on this machine!");
-    static bool once = [&]() {
-      cudaFuncSetAttribute(kernel_fn, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_bytes);
-      return true;
-    }();
+    if (params.has_custom_right_padding) {
+      static bool right_padding_once = [&]() {
+        CUDA_CALL_THROW(cudaFuncSetAttribute(
+            attention_kernel_batched_impl_right_padding<Attention, queries_per_block>,
+            cudaFuncAttributeMaxDynamicSharedMemorySize, smem_bytes));
+        return true;
+      }();
+      ORT_UNUSED_PARAMETER(right_padding_once);
+    } else {
+      static bool default_once = [&]() {
+        CUDA_CALL_THROW(cudaFuncSetAttribute(
+            attention_kernel_batched_impl<Attention>,
+            cudaFuncAttributeMaxDynamicSharedMemorySize, smem_bytes));
+        return true;
+      }();
+      ORT_UNUSED_PARAMETER(default_once);
+    }
   }
 
   ORT_ENFORCE(Attention::check_supported(p));
-  kernel_fn<<<p.getBlocksGrid(), p.getThreadsGrid(), smem_bytes, params.stream>>>(p);
+  if (params.has_custom_right_padding) {
+    attention_kernel_batched_impl_right_padding<Attention, queries_per_block>
+        <<<p.getBlocksGrid(), p.getThreadsGrid(), smem_bytes, params.stream>>>(p);
+  } else {
+    attention_kernel_batched_impl<Attention>
+        <<<p.getBlocksGrid(), p.getThreadsGrid(), smem_bytes, params.stream>>>(p);
+  }
 }
 
 template <typename T, typename ArchTag, int queries_per_block, int keys_per_block, int max_head_size>

--- a/onnxruntime/core/providers/cuda/llm/attention.cc
+++ b/onnxruntime/core/providers/cuda/llm/attention.cc
@@ -1381,12 +1381,6 @@ Status Attention<T>::ComputeInternal(OpKernelContext* context) const {
         // Fall back to unfused attention when they differ.
         (!is_gqa || parameters.head_size == parameters.v_head_size) &&
         (past_key == nullptr || parameters.head_size == parameters.v_head_size) &&
-        // The nonpad_kv_seqlen path uses CUTLASS FMHA custom right-padding.
-        // For large heads this variant can exceed the per-SM dynamic shared
-        // memory opt-in limit on smaller architectures. Let the unified
-        // unfused path handle those cases instead of launching an over-budget
-        // MEA kernel.
-        (nonpad_kv_seqlen == nullptr || parameters.head_size <= 256) &&
         // GQA+MEA requires LaunchUngroup which only has fp16/bf16 instantiations.
         // FP32 GQA must fall through to the unfused path.
         !(is_gqa && std::is_same<T, float>::value);

--- a/onnxruntime/core/providers/cuda/llm/attention.cc
+++ b/onnxruntime/core/providers/cuda/llm/attention.cc
@@ -1381,6 +1381,12 @@ Status Attention<T>::ComputeInternal(OpKernelContext* context) const {
         // Fall back to unfused attention when they differ.
         (!is_gqa || parameters.head_size == parameters.v_head_size) &&
         (past_key == nullptr || parameters.head_size == parameters.v_head_size) &&
+        // The nonpad_kv_seqlen path uses CUTLASS FMHA custom right-padding.
+        // For large heads this variant can exceed the per-SM dynamic shared
+        // memory opt-in limit on smaller architectures. Let the unified
+        // unfused path handle those cases instead of launching an over-budget
+        // MEA kernel.
+        (nonpad_kv_seqlen == nullptr || parameters.head_size <= 256) &&
         // GQA+MEA requires LaunchUngroup which only has fp16/bf16 instantiations.
         // FP32 GQA must fall through to the unfused path.
         !(is_gqa && std::is_same<T, float>::value);

--- a/onnxruntime/test/python/transformers/test_onnx_attention/test_gqa.py
+++ b/onnxruntime/test/python/transformers/test_onnx_attention/test_gqa.py
@@ -1535,13 +1535,34 @@ class TestONNXAttentionGQALargeHeadUnfused(unittest.TestCase):
         self.assertLess(out.float().max().item(), 1.0)
 
 
-@unittest.skipIf(not has_cuda_device(53), "CUDA device not available, skipping large head MEA fallback tests.")
+@unittest.skipIf(not has_cuda_device(53), "CUDA device not available, skipping large head MEA tests.")
 @patch.dict(os.environ, {"ORT_DISABLE_FLASH_ATTENTION": "1", "ORT_DISABLE_MEMORY_EFFICIENT_ATTENTION": "0"})
-class TestONNXAttentionGQALargeHeadNonpadMEAFallback(unittest.TestCase):
-    """head_size=512 with nonpad_kv_seqlen must fall back instead of launching MEA."""
+class TestONNXAttentionGQALargeHeadNonpadMEA(unittest.TestCase):
+    """Large-head normal and right-padding MEA kernels initialize independently."""
 
-    def test_gqa_large_head_nonpad_seqlen_falls_back_from_mea_fp16(self):
-        config = AttentionConfig(
+    def test_gqa_large_head_nonpad_seqlen_after_default_mea_fp16(self):
+        default_config = AttentionConfig(
+            batch_size=2,
+            q_sequence_length=32,
+            kv_sequence_length=32,
+            past_kv_sequence_length=0,
+            q_num_heads=8,
+            kv_num_heads=4,
+            head_size=512,
+            is_causal=0,
+        )
+        parity_check_gqa_prompt(
+            config=default_config,
+            ep="CUDAExecutionProvider",
+            device="cuda",
+            torch_type=torch.float16,
+            ort_type=TensorProto.FLOAT16,
+            causal=False,
+            rtol=rtol["fp16"],
+            atol=atol["fp16"],
+        )
+
+        nonpad_config = AttentionConfig(
             batch_size=2,
             q_sequence_length=32,
             kv_sequence_length=32,
@@ -1555,7 +1576,7 @@ class TestONNXAttentionGQALargeHeadNonpadMEAFallback(unittest.TestCase):
         nonpad_seqlens = torch.tensor([32, 19], dtype=torch.int64, device="cuda")
 
         parity_check_gqa_prompt_with_nonpad_kv_seqlen(
-            config=config,
+            config=nonpad_config,
             nonpad_seqlens=nonpad_seqlens,
             ep="CUDAExecutionProvider",
             device="cuda",

--- a/onnxruntime/test/python/transformers/test_onnx_attention/test_gqa.py
+++ b/onnxruntime/test/python/transformers/test_onnx_attention/test_gqa.py
@@ -1535,6 +1535,37 @@ class TestONNXAttentionGQALargeHeadUnfused(unittest.TestCase):
         self.assertLess(out.float().max().item(), 1.0)
 
 
+@unittest.skipIf(not has_cuda_device(53), "CUDA device not available, skipping large head MEA fallback tests.")
+@patch.dict(os.environ, {"ORT_DISABLE_FLASH_ATTENTION": "1", "ORT_DISABLE_MEMORY_EFFICIENT_ATTENTION": "0"})
+class TestONNXAttentionGQALargeHeadNonpadMEAFallback(unittest.TestCase):
+    """head_size=512 with nonpad_kv_seqlen must fall back instead of launching MEA."""
+
+    def test_gqa_large_head_nonpad_seqlen_falls_back_from_mea_fp16(self):
+        config = AttentionConfig(
+            batch_size=2,
+            q_sequence_length=32,
+            kv_sequence_length=32,
+            past_kv_sequence_length=0,
+            q_num_heads=8,
+            kv_num_heads=4,
+            head_size=512,
+            is_causal=0,
+            has_nonpad_kv_seqlen=True,
+        )
+        nonpad_seqlens = torch.tensor([32, 19], dtype=torch.int64, device="cuda")
+
+        parity_check_gqa_prompt_with_nonpad_kv_seqlen(
+            config=config,
+            nonpad_seqlens=nonpad_seqlens,
+            ep="CUDAExecutionProvider",
+            device="cuda",
+            torch_type=torch.float16,
+            ort_type=TensorProto.FLOAT16,
+            rtol=rtol["fp16"],
+            atol=atol["fp16"],
+        )
+
+
 class TestONNXAttentionGQALargeHeadUnfusedCPU(unittest.TestCase):
     """CPU twin of TestONNXAttentionGQALargeHeadUnfused.
 

--- a/onnxruntime/test/python/transformers/test_onnx_attention/test_gqa.py
+++ b/onnxruntime/test/python/transformers/test_onnx_attention/test_gqa.py
@@ -1541,6 +1541,8 @@ class TestONNXAttentionGQALargeHeadNonpadMEA(unittest.TestCase):
     """Large-head normal and right-padding MEA kernels initialize independently."""
 
     def test_gqa_large_head_nonpad_seqlen_after_default_mea_fp16(self):
+        # Keep this order: the regression requires the default kernel to opt in
+        # first, then verifies that the distinct right-padding kernel does too.
         default_config = AttentionConfig(
             batch_size=2,
             q_sequence_length=32,


### PR DESCRIPTION
### Description

Fixes #28388.

Large-head Memory Efficient Attention kernels require an explicit `cudaFuncAttributeMaxDynamicSharedMemorySize` opt-in when their dynamic shared-memory requirement exceeds `0xc000`. The default batched kernel and the custom right-padding kernel are distinct device functions, but the previous function-local `once` configured only whichever function pointer was selected on the first invocation. If the other variant ran later in the same process, it launched without the required opt-in and failed with excessive shared-memory usage.

This change:

- keeps separate thread-safe initialization state for the default and right-padding kernel variants;
- applies `cudaFuncSetAttribute` to the exact kernel that will launch;
- checks the CUDA API result with `CUDA_CALL_THROW`; and
- launches the matching kernel directly after its own shared-memory initialization.

### Tests

- Added `TestONNXAttentionGQALargeHeadNonpadMEA`, which runs the default large-head MEA kernel first and then the right-padding/nonpad variant in the same process. This ordering reproduces the original process-global initialization bug and verifies that both distinct kernels opt in independently.
- `python3 -m py_compile onnxruntime/test/python/transformers/test_onnx_attention/test_gqa.py`
- `git diff --check`

The targeted CUDA test requires an ONNX Runtime CUDA build and a compatible GPU, so execution is delegated to CI.
