### PR TITLE
 Fix over-copy of packed sub-byte tensors in OrtApi::GetValue

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -5767,9 +5767,13 @@ struct OrtApi {
 
   /** \brief Compute total size in bytes of the tensor data contained in an OrtValue.
    *
-   * Returns the total number of bytes used to store the tensor data. For numeric tensors,
-   * this is sizeof(element_type) * total_element_count. OrtValues that are not tensors or
-   * that are tensors that contain strings will cause an error to be returned.
+   * Returns the total number of bytes used to store the tensor data. For numeric tensors of a
+   * type that occupies at least one byte per element, this is sizeof(element_type) *
+   * total_element_count. For packed sub-byte types (e.g. int4/uint4, which store multiple
+   * elements per byte) it is the actual packed storage size, which is smaller than
+   * sizeof(element_type) * total_element_count. Use this value (not the element count) when
+   * copying or bounds-checking the raw tensor buffer. OrtValues that are not tensors or that are
+   * tensors that contain strings will cause an error to be returned.
    *
    * \param[in] ort_value OrtValue instance containing a tensor
    * \param[out] size The total size of the tensor data in bytes

--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -2067,10 +2067,8 @@ struct TensorTypeAndShapeInfoImpl : Base<T> {
 
   /// Wraps OrtApi::GetTensorShapeElementCount.
   /// Returns the number of logical elements in the tensor (the product of its shape dimensions).
-  /// For packed sub-byte types (e.g. int4/uint4) this is the element count, which is NOT the same
-  /// as the storage size in bytes: multiple elements share a storage byte, so the raw buffer is
-  /// smaller than the element count. Use Ort::Value::GetTensorSizeInBytes() when sizing or bounds-
-  /// checking the raw buffer returned by GetTensorRawData()/GetTensorData<T>().
+  /// Use Ort::Value::GetTensorSizeInBytes() when sizing or bounds-checking the raw buffer returned
+  /// by GetTensorRawData()/GetTensorData<T>().
   size_t GetElementCount() const;
 
   size_t GetDimensionsCount() const;  ///< Wraps OrtApi::GetDimensionsCount

--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -2068,7 +2068,7 @@ struct TensorTypeAndShapeInfoImpl : Base<T> {
   /// Wraps OrtApi::GetTensorShapeElementCount.
   /// Returns the number of logical elements in the tensor (the product of its shape dimensions).
   /// Use Ort::Value::GetTensorSizeInBytes() when sizing or bounds-checking the raw buffer returned
-  /// by GetTensorRawData()/GetTensorData<T>().
+  /// by GetTensorRawData()/GetTensorData\<T\>().
   size_t GetElementCount() const;
 
   size_t GetDimensionsCount() const;  ///< Wraps OrtApi::GetDimensionsCount
@@ -2354,7 +2354,7 @@ struct ConstValueImpl : Base<T> {
   /// sizeof(element_type) * total_element_count. For packed sub-byte types (e.g. int4/uint4)
   /// it is the actual packed storage size, which is smaller than the element count returned by
   /// GetTensorTypeAndShapeInfo().GetElementCount(). Use this value (not the element count) when
-  /// copying or bounds-checking the raw buffer from GetTensorRawData()/GetTensorData<T>().
+  /// copying or bounds-checking the raw buffer from GetTensorRawData()/GetTensorData\<T\>().
   /// </summary>
   /// <returns>The total size of the tensor data in bytes</returns>
   size_t GetTensorSizeInBytes() const;  ///< Wraps OrtApi::GetTensorSizeInBytes

--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -2064,7 +2064,14 @@ struct TensorTypeAndShapeInfoImpl : Base<T> {
   using B::B;
 
   ONNXTensorElementDataType GetElementType() const;  ///< Wraps OrtApi::GetTensorElementType
-  size_t GetElementCount() const;                    ///< Wraps OrtApi::GetTensorShapeElementCount
+
+  /// Wraps OrtApi::GetTensorShapeElementCount.
+  /// Returns the number of logical elements in the tensor (the product of its shape dimensions).
+  /// For packed sub-byte types (e.g. int4/uint4) this is the element count, which is NOT the same
+  /// as the storage size in bytes: multiple elements share a storage byte, so the raw buffer is
+  /// smaller than the element count. Use Ort::Value::GetTensorSizeInBytes() when sizing or bounds-
+  /// checking the raw buffer returned by GetTensorRawData()/GetTensorData<T>().
+  size_t GetElementCount() const;
 
   size_t GetDimensionsCount() const;  ///< Wraps OrtApi::GetDimensionsCount
 
@@ -2345,7 +2352,11 @@ struct ConstValueImpl : Base<T> {
   /// <summary>
   /// Returns the total size of the tensor data in bytes. Throws an exception if the OrtValue
   /// does not contain a tensor or if it contains a tensor that contains strings.
-  /// For numeric tensors, this is sizeof(element_type) * total_element_count.
+  /// For numeric tensors of a type that occupies at least one byte per element, this is
+  /// sizeof(element_type) * total_element_count. For packed sub-byte types (e.g. int4/uint4)
+  /// it is the actual packed storage size, which is smaller than the element count returned by
+  /// GetTensorTypeAndShapeInfo().GetElementCount(). Use this value (not the element count) when
+  /// copying or bounds-checking the raw buffer from GetTensorRawData()/GetTensorData<T>().
   /// </summary>
   /// <returns>The total size of the tensor data in bytes</returns>
   size_t GetTensorSizeInBytes() const;  ///< Wraps OrtApi::GetTensorSizeInBytes

--- a/onnxruntime/core/optimizer/constant_folding.cc
+++ b/onnxruntime/core/optimizer/constant_folding.cc
@@ -267,7 +267,11 @@ static int64_t EstimateUniqueOutputSizeInBytes(const Node& node) {
 
     if (output_idx == 0) {
       // Output 0 has the same (possibly packed sub-byte) element type as the input.
-      total_size += ComputeTensorSizeInBytesForConstantFolding(input_elem_type, input_num_elements);
+      const int64_t output0_size = ComputeTensorSizeInBytesForConstantFolding(input_elem_type, input_num_elements);
+      if (output0_size < 0) {
+        return -1;  // Output 0 size is unknown; treat the whole node's output size as unknown.
+      }
+      total_size += output0_size;
     } else {
       // The remaining Unique outputs are int64 index/count tensors.
       total_size += SafeInt<int64_t>(input_num_elements) * sizeof(int64_t);
@@ -317,18 +321,15 @@ static int64_t EstimateConstantOfShapeOutputSizeInBytes(const Node& node, const 
     num_elements *= dim;
   }
 
-  // Determine the element size of the output. The ONNX spec for ConstantOfShape defaults the
+  // Determine the element type of the output. The ONNX spec for ConstantOfShape defaults the
   // element type to float when the optional 'value' attribute is absent.
-  size_t element_size = sizeof(float);
   auto elem_type = ONNX_NAMESPACE::TensorProto_DataType_FLOAT;
   const auto& attrs = node.GetAttributes();
   auto it = attrs.find("value");
   if (it != attrs.end() && it->second.type() == ONNX_NAMESPACE::AttributeProto::TENSOR) {
     const auto value_elem_type = static_cast<ONNX_NAMESPACE::TensorProto_DataType>(
         it->second.t().data_type());
-    const size_t es = GetElementSizeForConstantFolding(value_elem_type);
-    if (es != 0) {
-      element_size = es;
+    if (GetElementSizeForConstantFolding(value_elem_type) != 0) {
       elem_type = value_elem_type;
     }
   }

--- a/onnxruntime/core/optimizer/constant_folding.cc
+++ b/onnxruntime/core/optimizer/constant_folding.cc
@@ -157,6 +157,35 @@ static size_t GetElementSizeForConstantFolding(ONNX_NAMESPACE::TensorProto_DataT
   return elem_type == ONNX_NAMESPACE::TensorProto_DataType_STRING ? sizeof(std::string) : 0;
 }
 
+// Number of sub-byte elements packed into a single storage byte for packed sub-byte element
+// types (e.g. int4/uint4 pack 2 elements per byte, int2/uint2 pack 4). Returns 1 for all other
+// (>= 1 byte) element types. Keep in sync with the sub-byte types registered in data_types.cc.
+static int64_t GetNumSubElemsPerByteForConstantFolding(ONNX_NAMESPACE::TensorProto_DataType elem_type) {
+  switch (elem_type) {
+    case ONNX_NAMESPACE::TensorProto_DataType_INT4:
+    case ONNX_NAMESPACE::TensorProto_DataType_UINT4:
+    case ONNX_NAMESPACE::TensorProto_DataType_FLOAT4E2M1:
+      return 2;
+    case ONNX_NAMESPACE::TensorProto_DataType_INT2:
+    case ONNX_NAMESPACE::TensorProto_DataType_UINT2:
+      return 4;
+    default:
+      return 1;
+  }
+}
+
+// Computes the packed storage size in bytes for `num_elements` elements of `elem_type`, where
+// `element_size` is the storage size of one packing unit (a byte for sub-byte types). For packed
+// sub-byte types multiple elements share a storage byte, so the size is
+// ceil(num_elements / sub_elems_per_byte) * element_size rather than the naive product, which
+// would overestimate by 2-4x.
+static int64_t ComputeTensorSizeInBytesForConstantFolding(ONNX_NAMESPACE::TensorProto_DataType elem_type,
+                                                          int64_t num_elements, size_t element_size) {
+  const int64_t sub_elems_per_byte = GetNumSubElemsPerByteForConstantFolding(elem_type);
+  const int64_t num_storage_units = (num_elements + (sub_elems_per_byte - 1)) / sub_elems_per_byte;
+  return SafeInt<int64_t>(num_storage_units) * static_cast<int64_t>(element_size);
+}
+
 static int64_t EstimateTensorElementCount(const ONNX_NAMESPACE::TensorShapeProto& shape) {
   SafeInt<int64_t> num_elements = 1;
   for (int i = 0; i < shape.dim_size(); ++i) {
@@ -197,7 +226,7 @@ static int64_t EstimateTensorSizeInBytes(const NodeArg& node_arg) {
     return -1;
   }
 
-  return SafeInt<int64_t>(num_elements) * static_cast<int64_t>(element_size);
+  return ComputeTensorSizeInBytesForConstantFolding(elem_type, num_elements, element_size);
 }
 
 static int64_t EstimateUniqueOutputSizeInBytes(const Node& node) {
@@ -233,8 +262,14 @@ static int64_t EstimateUniqueOutputSizeInBytes(const Node& node) {
       continue;
     }
 
-    const size_t element_size = output_idx == 0 ? input_element_size : sizeof(int64_t);
-    total_size += SafeInt<int64_t>(input_num_elements) * static_cast<int64_t>(element_size);
+    if (output_idx == 0) {
+      // Output 0 has the same (possibly packed sub-byte) element type as the input.
+      total_size += ComputeTensorSizeInBytesForConstantFolding(input_elem_type, input_num_elements,
+                                                               input_element_size);
+    } else {
+      // The remaining Unique outputs are int64 index/count tensors.
+      total_size += SafeInt<int64_t>(input_num_elements) * static_cast<int64_t>(sizeof(int64_t));
+    }
   }
 
   return total_size;
@@ -283,18 +318,20 @@ static int64_t EstimateConstantOfShapeOutputSizeInBytes(const Node& node, const 
   // Determine the element size of the output. The ONNX spec for ConstantOfShape defaults the
   // element type to float when the optional 'value' attribute is absent.
   size_t element_size = sizeof(float);
+  auto elem_type = ONNX_NAMESPACE::TensorProto_DataType_FLOAT;
   const auto& attrs = node.GetAttributes();
   auto it = attrs.find("value");
   if (it != attrs.end() && it->second.type() == ONNX_NAMESPACE::AttributeProto::TENSOR) {
-    const auto elem_type = static_cast<ONNX_NAMESPACE::TensorProto_DataType>(
+    const auto value_elem_type = static_cast<ONNX_NAMESPACE::TensorProto_DataType>(
         it->second.t().data_type());
-    const size_t es = GetElementSizeForConstantFolding(elem_type);
+    const size_t es = GetElementSizeForConstantFolding(value_elem_type);
     if (es != 0) {
       element_size = es;
+      elem_type = value_elem_type;
     }
   }
 
-  return num_elements * static_cast<int64_t>(element_size);
+  return ComputeTensorSizeInBytesForConstantFolding(elem_type, num_elements, element_size);
 }
 
 // Estimate the total output size in bytes for a node using shape inference results.

--- a/onnxruntime/core/optimizer/constant_folding.cc
+++ b/onnxruntime/core/optimizer/constant_folding.cc
@@ -10,6 +10,7 @@
 #include "core/graph/graph_utils.h"
 #include "core/optimizer/optimizer_execution_frame.h"
 #include "core/framework/op_kernel.h"
+#include "core/framework/tensor.h"
 #include "core/framework/tensorprotoutils.h"
 #include "core/session/onnxruntime_session_options_config_keys.h"
 #include "core/common/safeint.h"
@@ -148,6 +149,15 @@ static Status ConstantFoldIfNode(Graph& graph, Node& if_node, const logging::Log
 static constexpr int64_t kDefaultConstantFoldingMaxOutputSizeInBytes = 1024 * 1024 * 1024;
 
 static size_t GetElementSizeForConstantFolding(ONNX_NAMESPACE::TensorProto_DataType elem_type) {
+  // Complex types are excluded: ORT's tensor type system (DataTypeImpl::TensorTypeFromONNXEnum)
+  // does not support them, so we cannot size them via Tensor::CalculateTensorStorageSize().
+  // Returning 0 makes callers treat the size as unknown instead of attempting an unsupported
+  // conversion.
+  if (elem_type == ONNX_NAMESPACE::TensorProto_DataType_COMPLEX64 ||
+      elem_type == ONNX_NAMESPACE::TensorProto_DataType_COMPLEX128) {
+    return 0;
+  }
+
   const size_t element_size = utils::GetElementSizeOfTensor(elem_type);
   if (element_size != 0) {
     return element_size;
@@ -157,33 +167,26 @@ static size_t GetElementSizeForConstantFolding(ONNX_NAMESPACE::TensorProto_DataT
   return elem_type == ONNX_NAMESPACE::TensorProto_DataType_STRING ? sizeof(std::string) : 0;
 }
 
-// Number of sub-byte elements packed into a single storage byte for packed sub-byte element
-// types (e.g. int4/uint4 pack 2 elements per byte, int2/uint2 pack 4). Returns 1 for all other
-// (>= 1 byte) element types. Keep in sync with the sub-byte types registered in data_types.cc.
-static int64_t GetNumSubElemsPerByteForConstantFolding(ONNX_NAMESPACE::TensorProto_DataType elem_type) {
-  switch (elem_type) {
-    case ONNX_NAMESPACE::TensorProto_DataType_INT4:
-    case ONNX_NAMESPACE::TensorProto_DataType_UINT4:
-    case ONNX_NAMESPACE::TensorProto_DataType_FLOAT4E2M1:
-      return 2;
-    case ONNX_NAMESPACE::TensorProto_DataType_INT2:
-    case ONNX_NAMESPACE::TensorProto_DataType_UINT2:
-      return 4;
-    default:
-      return 1;
-  }
-}
-
-// Computes the packed storage size in bytes for `num_elements` elements of `elem_type`, where
-// `element_size` is the storage size of one packing unit (a byte for sub-byte types). For packed
-// sub-byte types multiple elements share a storage byte, so the size is
-// ceil(num_elements / sub_elems_per_byte) * element_size rather than the naive product, which
-// would overestimate by 2-4x.
+// Computes the packed storage size in bytes for `num_elements` elements of `elem_type`.
+// Delegates to Tensor::CalculateTensorStorageSize() so the sub-byte packing math (e.g. int4/uint4
+// pack 2 elements per byte, int2/uint2 pack 4) lives in a single place and does not have to be kept
+// in sync here. Returns -1 if the element type is not a recognized tensor element type or the
+// computed size cannot be represented.
 static int64_t ComputeTensorSizeInBytesForConstantFolding(ONNX_NAMESPACE::TensorProto_DataType elem_type,
-                                                          int64_t num_elements, size_t element_size) {
-  const int64_t sub_elems_per_byte = GetNumSubElemsPerByteForConstantFolding(elem_type);
-  const int64_t num_storage_units = (num_elements + (sub_elems_per_byte - 1)) / sub_elems_per_byte;
-  return SafeInt<int64_t>(num_storage_units) * static_cast<int64_t>(element_size);
+                                                          int64_t num_elements) {
+  if (GetElementSizeForConstantFolding(elem_type) == 0) {
+    return -1;  // Unknown element type.
+  }
+
+  const MLDataType elt_type = DataTypeImpl::TensorTypeFromONNXEnum(elem_type)->GetElementType();
+  size_t storage_size = 0;
+  const Status status =
+      Tensor::CalculateTensorStorageSize(elt_type, TensorShape({num_elements}), /*alignment*/ 0, storage_size);
+  if (!status.IsOK() || storage_size > static_cast<size_t>(std::numeric_limits<int64_t>::max())) {
+    return -1;
+  }
+
+  return static_cast<int64_t>(storage_size);
 }
 
 static int64_t EstimateTensorElementCount(const ONNX_NAMESPACE::TensorShapeProto& shape) {
@@ -226,7 +229,7 @@ static int64_t EstimateTensorSizeInBytes(const NodeArg& node_arg) {
     return -1;
   }
 
-  return ComputeTensorSizeInBytesForConstantFolding(elem_type, num_elements, element_size);
+  return ComputeTensorSizeInBytesForConstantFolding(elem_type, num_elements);
 }
 
 static int64_t EstimateUniqueOutputSizeInBytes(const Node& node) {
@@ -264,11 +267,10 @@ static int64_t EstimateUniqueOutputSizeInBytes(const Node& node) {
 
     if (output_idx == 0) {
       // Output 0 has the same (possibly packed sub-byte) element type as the input.
-      total_size += ComputeTensorSizeInBytesForConstantFolding(input_elem_type, input_num_elements,
-                                                               input_element_size);
+      total_size += ComputeTensorSizeInBytesForConstantFolding(input_elem_type, input_num_elements);
     } else {
       // The remaining Unique outputs are int64 index/count tensors.
-      total_size += SafeInt<int64_t>(input_num_elements) * static_cast<int64_t>(sizeof(int64_t));
+      total_size += SafeInt<int64_t>(input_num_elements) * sizeof(int64_t);
     }
   }
 
@@ -331,7 +333,7 @@ static int64_t EstimateConstantOfShapeOutputSizeInBytes(const Node& node, const 
     }
   }
 
-  return ComputeTensorSizeInBytesForConstantFolding(elem_type, num_elements, element_size);
+  return ComputeTensorSizeInBytesForConstantFolding(elem_type, num_elements);
 }
 
 // Estimate the total output size in bytes for a node using shape inference results.

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -2018,20 +2018,23 @@ static ORT_STATUS_PTR OrtGetValueImplSeqOfMap(const OrtValue* p_ml_value, int in
 }
 #endif
 
-ORT_STATUS_PTR PopulateTensorWithData(Tensor& tensor, _In_ const void* data_elem, size_t num_elems) {
-  auto len = narrow<size_t>(tensor.Shape().Size());
-  if (num_elems < len) {
-    return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, "input array is too short");
-  }
+// Copies the contents of `data_elem` into `tensor`.
+//
+// Both the element type and the number of elements to copy are derived from `tensor`:
+//   - For numeric tensors, tensor.SizeInBytes() bytes are copied. This is packing-aware,
+//     so sub-byte types (e.g. int4/uint4) copy only their packed storage size rather than
+//     one byte per logical element.
+//   - For string tensors, exactly tensor.Shape().Size() std::string elements are copied.
+//
+// Assumption: `data_elem` points to a buffer that holds at least as many elements as
+// `tensor`'s shape, with a matching element type. All current callers satisfy this because
+// they size the tensor from the same source data.
+ORT_STATUS_PTR PopulateTensorWithData(Tensor& tensor, _In_ const void* data_elem) {
   if (!tensor.IsDataTypeString()) {
-    // Use the tensor's actual storage size in bytes rather than elem_size * num_elems.
-    // For packed sub-byte types (e.g., int4/uint4) multiple elements share a storage byte,
-    // so the naive product over-counts and would over-read the source / overflow the destination.
     memcpy(tensor.MutableDataRaw(), data_elem, tensor.SizeInBytes());
   } else {
+    const auto len = narrow<size_t>(tensor.Shape().Size());
     const std::string* strings = reinterpret_cast<const std::string*>(data_elem);
-    // Copy exactly the tensor's element count (len), not num_elems, to avoid writing past
-    // the destination when the source is larger than the tensor.
     auto str_span = gsl::make_span(strings, len);
     auto* dst = tensor.MutableData<std::string>();
     std::copy(str_span.begin(), str_span.end(), dst);
@@ -2040,9 +2043,9 @@ ORT_STATUS_PTR PopulateTensorWithData(Tensor& tensor, _In_ const void* data_elem
 }
 
 ORT_STATUS_PTR CreateTensorAndPopulate(MLDataType element_type, const int64_t* shape, size_t shape_len,
-                                       const void* data, size_t num_elements, _Inout_ OrtAllocator* allocator, OrtValue& result) {
+                                       const void* data, _Inout_ OrtAllocator* allocator, OrtValue& result) {
   ORT_API_RETURN_IF_ERROR(CreateTensorImpl(element_type, shape, shape_len, allocator, result));
-  ORT_API_RETURN_IF_ERROR(PopulateTensorWithData(*result.GetMutable<Tensor>(), data, num_elements));
+  ORT_API_RETURN_IF_ERROR(PopulateTensorWithData(*result.GetMutable<Tensor>(), data));
   return nullptr;
 }
 
@@ -2060,7 +2063,6 @@ static ORT_STATUS_PTR OrtGetValueImplSeqOfTensors(_In_ const OrtValue* p_ml_valu
   auto result = std::make_unique<OrtValue>();
   ORT_API_RETURN_IF_ERROR(c_api_internal::CreateTensorAndPopulate(one_tensor.DataType(), tensor_shape.GetDims().data(),
                                                                   tensor_shape.NumDimensions(), one_tensor.DataRaw(),
-                                                                  narrow<size_t>(one_tensor.Shape().Size()),
                                                                   allocator, *result));
   *out = result.release();
   return nullptr;
@@ -2108,7 +2110,6 @@ static ORT_STATUS_PTR OrtGetValueImplMapHelper(_In_ const OrtValue* p_ml_value, 
   std::vector<TKey> vec_keys;
   std::vector<TVal> vec_vals;
   const void* data_ptr;
-  size_t data_size;
   MLDataType element_type;
   switch (index) {
     case 0: {  // user is requesting keys
@@ -2116,20 +2117,18 @@ static ORT_STATUS_PTR OrtGetValueImplMapHelper(_In_ const OrtValue* p_ml_value, 
       vec_keys.reserve(static_cast<size_t>(num_kv_pairs));
       std::transform(data.cbegin(), data.cend(), std::back_inserter(vec_keys), [](const auto& k) { return k.first; });
       data_ptr = vec_keys.data();
-      data_size = vec_keys.size();
     } break;
     case 1: {  // user is requesting values
       element_type = DataTypeImpl::TensorTypeFromONNXEnum(GetONNXTensorElementDataType<TVal>())->GetElementType();
       vec_vals.reserve(static_cast<size_t>(num_kv_pairs));
       std::transform(data.cbegin(), data.cend(), std::back_inserter(vec_vals), [](const auto& k) { return k.second; });
       data_ptr = vec_vals.data();
-      data_size = vec_vals.size();
     } break;
     default:
       return OrtApis::CreateStatus(ORT_FAIL, "Invalid index requested for map type.");
   }
   ORT_API_RETURN_IF_ERROR(c_api_internal::CreateTensorAndPopulate(element_type, dims.data(), dims.size(), data_ptr,
-                                                                  data_size, allocator, *result));
+                                                                  allocator, *result));
   *out = result.release();
   return nullptr;
 }

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -2018,19 +2018,21 @@ static ORT_STATUS_PTR OrtGetValueImplSeqOfMap(const OrtValue* p_ml_value, int in
 }
 #endif
 
-ORT_STATUS_PTR PopulateTensorWithData(Tensor& tensor, bool is_string, _In_ const void* data_elem, size_t num_elems) {
+ORT_STATUS_PTR PopulateTensorWithData(Tensor& tensor, _In_ const void* data_elem, size_t num_elems) {
   auto len = narrow<size_t>(tensor.Shape().Size());
   if (num_elems < len) {
     return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, "input array is too short");
   }
-  if (!is_string) {
+  if (!tensor.IsDataTypeString()) {
     // Use the tensor's actual storage size in bytes rather than elem_size * num_elems.
     // For packed sub-byte types (e.g., int4/uint4) multiple elements share a storage byte,
     // so the naive product over-counts and would over-read the source / overflow the destination.
     memcpy(tensor.MutableDataRaw(), data_elem, tensor.SizeInBytes());
   } else {
     const std::string* strings = reinterpret_cast<const std::string*>(data_elem);
-    auto str_span = gsl::make_span(strings, num_elems);
+    // Copy exactly the tensor's element count (len), not num_elems, to avoid writing past
+    // the destination when the source is larger than the tensor.
+    auto str_span = gsl::make_span(strings, len);
     auto* dst = tensor.MutableData<std::string>();
     std::copy(str_span.begin(), str_span.end(), dst);
   }
@@ -2040,8 +2042,7 @@ ORT_STATUS_PTR PopulateTensorWithData(Tensor& tensor, bool is_string, _In_ const
 ORT_STATUS_PTR CreateTensorAndPopulate(MLDataType element_type, const int64_t* shape, size_t shape_len,
                                        const void* data, size_t num_elements, _Inout_ OrtAllocator* allocator, OrtValue& result) {
   ORT_API_RETURN_IF_ERROR(CreateTensorImpl(element_type, shape, shape_len, allocator, result));
-  ORT_API_RETURN_IF_ERROR(PopulateTensorWithData(*result.GetMutable<Tensor>(), utils::IsDataTypeString(element_type),
-                                                 data, num_elements));
+  ORT_API_RETURN_IF_ERROR(PopulateTensorWithData(*result.GetMutable<Tensor>(), data, num_elements));
   return nullptr;
 }
 

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -2018,14 +2018,16 @@ static ORT_STATUS_PTR OrtGetValueImplSeqOfMap(const OrtValue* p_ml_value, int in
 }
 #endif
 
-ORT_STATUS_PTR PopulateTensorWithData(Tensor& tensor, bool is_string, _In_ const void* data_elem, size_t num_elems,
-                                      size_t elem_size) {
+ORT_STATUS_PTR PopulateTensorWithData(Tensor& tensor, bool is_string, _In_ const void* data_elem, size_t num_elems) {
   auto len = narrow<size_t>(tensor.Shape().Size());
   if (num_elems < len) {
     return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, "input array is too short");
   }
   if (!is_string) {
-    memcpy(tensor.MutableDataRaw(), data_elem, elem_size * num_elems);
+    // Use the tensor's actual storage size in bytes rather than elem_size * num_elems.
+    // For packed sub-byte types (e.g., int4/uint4) multiple elements share a storage byte,
+    // so the naive product over-counts and would over-read the source / overflow the destination.
+    memcpy(tensor.MutableDataRaw(), data_elem, tensor.SizeInBytes());
   } else {
     const std::string* strings = reinterpret_cast<const std::string*>(data_elem);
     auto str_span = gsl::make_span(strings, num_elems);
@@ -2039,7 +2041,7 @@ ORT_STATUS_PTR CreateTensorAndPopulate(MLDataType element_type, const int64_t* s
                                        const void* data, size_t num_elements, _Inout_ OrtAllocator* allocator, OrtValue& result) {
   ORT_API_RETURN_IF_ERROR(CreateTensorImpl(element_type, shape, shape_len, allocator, result));
   ORT_API_RETURN_IF_ERROR(PopulateTensorWithData(*result.GetMutable<Tensor>(), utils::IsDataTypeString(element_type),
-                                                 data, num_elements, element_type->Size()));
+                                                 data, num_elements));
   return nullptr;
 }
 

--- a/onnxruntime/test/optimizer/graph_transform_test.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test.cc
@@ -19,6 +19,7 @@
 
 #include "core/common/span_utils.h"
 #include "core/framework/data_types.h"
+#include "core/framework/int4.h"
 #include "core/framework/ort_value.h"
 #include "core/graph/graph_utils.h"
 #include "core/graph/graph_viewer.h"
@@ -1750,6 +1751,76 @@ TEST_F(GraphTransformationTests, ConstantFoldingConstantOfShapeBlockedWhenOutput
                                         std::make_unique<ConstantFolding>(*e.get(), false, config_options),
                                         TransformerLevel::Level1, 1,
                                         pre_graph_checker, post_graph_checker));
+}
+
+// The constant-folding output-size estimate must be packing-aware for sub-byte types.
+// A QuantizeLinear node that produces a packed int4 output stores 2 elements per byte, so its
+// real storage size is ceil(num_elements / 2) bytes. The pre-execution size estimate previously
+// used num_elements * 1 byte, over-counting by ~2x and needlessly blocking folding of sub-byte
+// outputs that actually fit within the configured limit.
+TEST_F(GraphTransformationTests, ConstantFoldingSubByteOutputSizeIsPacked) {
+  // 20000 int4 elements -> 10000 packed bytes of real storage (the old estimate was 20000 bytes).
+  constexpr int64_t kNumElements = 20000;
+
+  auto build_model = [&](ModelTestBuilder& builder) {
+    auto* input_data = builder.MakeInitializer<float>({kNumElements}, -1.0f, 1.0f);
+    auto* output_arg = builder.MakeOutput();
+    builder.AddQuantizeLinearNode<Int4x2>(input_data, 1.0f, Int4x2(0, 0), output_arg);
+  };
+
+  // Case 1: limit (15000 bytes) sits between the packed size (10000) and the old over-estimate
+  // (20000). With the packing-aware estimate the node SHOULD be folded. Under the old estimate
+  // it would have been (incorrectly) skipped.
+  {
+    auto pre_graph_checker = [](Graph& graph) -> Status {
+      auto op_to_count = CountOpsInGraph(graph);
+      TEST_RETURN_IF_NOT(op_to_count["QuantizeLinear"] == 1);
+      return Status::OK();
+    };
+
+    auto post_graph_checker = [](Graph& graph) -> Status {
+      auto op_to_count = CountOpsInGraph(graph);
+      // Real packed size (10000 bytes) is within the 15000 byte limit, so folding proceeds.
+      TEST_RETURN_IF_NOT(op_to_count["QuantizeLinear"] == 0);
+      return Status::OK();
+    };
+
+    std::unique_ptr<CPUExecutionProvider> e = std::make_unique<CPUExecutionProvider>(CPUExecutionProviderInfo());
+    ConfigOptions config_options;
+    ASSERT_STATUS_OK(config_options.AddConfigEntry(
+        kOrtSessionOptionsConstantFoldingMaxOutputSizeInBytes, "15000"));
+
+    ASSERT_STATUS_OK(TestGraphTransformer(build_model, 21, *logger_,
+                                          std::make_unique<ConstantFolding>(*e.get(), false, config_options),
+                                          TransformerLevel::Level1, 1,
+                                          pre_graph_checker, post_graph_checker));
+  }
+
+  // Case 2: limit (5000 bytes) is below even the packed size (10000), so folding is blocked.
+  {
+    auto pre_graph_checker = [](Graph& graph) -> Status {
+      auto op_to_count = CountOpsInGraph(graph);
+      TEST_RETURN_IF_NOT(op_to_count["QuantizeLinear"] == 1);
+      return Status::OK();
+    };
+
+    auto post_graph_checker = [](Graph& graph) -> Status {
+      auto op_to_count = CountOpsInGraph(graph);
+      // Real packed size (10000 bytes) exceeds the 5000 byte limit, so the node is not folded.
+      TEST_RETURN_IF_NOT(op_to_count["QuantizeLinear"] == 1);
+      return Status::OK();
+    };
+
+    std::unique_ptr<CPUExecutionProvider> e = std::make_unique<CPUExecutionProvider>(CPUExecutionProviderInfo());
+    ConfigOptions config_options;
+    ASSERT_STATUS_OK(config_options.AddConfigEntry(
+        kOrtSessionOptionsConstantFoldingMaxOutputSizeInBytes, "5000"));
+
+    ASSERT_STATUS_OK(TestGraphTransformer(build_model, 21, *logger_,
+                                          std::make_unique<ConstantFolding>(*e.get(), false, config_options),
+                                          TransformerLevel::Level1, 1,
+                                          pre_graph_checker, post_graph_checker));
+  }
 }
 
 // Test that small constant folding still works with the size limit.

--- a/onnxruntime/test/shared_lib/test_nontensor_types.cc
+++ b/onnxruntime/test/shared_lib/test_nontensor_types.cc
@@ -305,11 +305,13 @@ TEST(CApiTest, CreateGetSeqSubByteTensors) {
       ASSERT_EQ(tensor_info.GetElementType(), elem_type);
       ASSERT_EQ(tensor_info.GetShape(), dims);
 
-      // Compare the packed bytes directly. GetTensorData<T>() does not support sub-byte
-      // types, so use the raw pointer and the packing-aware byte size.
+      // `out` is a fresh tensor that GetValue() allocated and copied into, so its data is a
+      // distinct buffer from the input `packed` bytes (the input tensors alias `packed`).
+      // Comparing them therefore validates the copy rather than reading the same memory twice.
       const size_t out_bytes = out.GetTensorSizeInBytes();
       ASSERT_EQ(out_bytes, packed.size());
       const auto* ret = static_cast<const uint8_t*>(out.GetTensorRawData());
+      ASSERT_NE(static_cast<const void*>(ret), static_cast<const void*>(packed.data()));
       for (size_t i = 0; i < out_bytes; ++i) {
         ASSERT_EQ(ret[i], packed[i]);
       }

--- a/onnxruntime/test/shared_lib/test_nontensor_types.cc
+++ b/onnxruntime/test/shared_lib/test_nontensor_types.cc
@@ -284,13 +284,13 @@ TEST(CApiTest, CreateGetSeqSubByteTensors) {
   auto default_allocator = std::make_unique<MockedOrtAllocator>();
   Ort::MemoryInfo info("Cpu", OrtDeviceAllocator, 0, OrtMemTypeDefault);
 
-  auto run_for_type = [&](ONNXTensorElementDataType elem_type, const std::array<uint8_t, 4>& packed) {
+  auto run_for_type = [&](ONNXTensorElementDataType elem_type, std::array<uint8_t, 4> packed) {
     const std::vector<int64_t> dims{7};  // 7 4-bit elements -> 4 packed bytes
     constexpr int N = 2;
 
     std::vector<Ort::Value> in;
     for (int i = 0; i < N; ++i) {
-      Ort::Value tensor = Ort::Value::CreateTensor(info, const_cast<uint8_t*>(packed.data()), packed.size(),
+      Ort::Value tensor = Ort::Value::CreateTensor(info, packed.data(), packed.size(),
                                                    dims.data(), dims.size(), elem_type);
       in.push_back(std::move(tensor));
     }
@@ -305,8 +305,12 @@ TEST(CApiTest, CreateGetSeqSubByteTensors) {
       ASSERT_EQ(tensor_info.GetElementType(), elem_type);
       ASSERT_EQ(tensor_info.GetShape(), dims);
 
-      const auto* ret = out.GetTensorData<uint8_t>();
-      for (size_t i = 0; i < packed.size(); ++i) {
+      // Compare the packed bytes directly. GetTensorData<T>() does not support sub-byte
+      // types, so use the raw pointer and the packing-aware byte size.
+      const size_t out_bytes = out.GetTensorSizeInBytes();
+      ASSERT_EQ(out_bytes, packed.size());
+      const auto* ret = static_cast<const uint8_t*>(out.GetTensorRawData());
+      for (size_t i = 0; i < out_bytes; ++i) {
         ASSERT_EQ(ret[i], packed[i]);
       }
     }

--- a/onnxruntime/test/shared_lib/test_nontensor_types.cc
+++ b/onnxruntime/test/shared_lib/test_nontensor_types.cc
@@ -278,12 +278,8 @@ TEST(CApiTest, CreateGetSeqStringTensors) {
   ASSERT_EQ(string_set, std::set<std::string>(std::begin(string_input_data), std::end(string_input_data)));
 }
 
-// Regression test for MSRC 119491: GetValue() on a sequence of packed sub-byte tensors
-// (int4/uint4) must copy only the packed storage bytes. Previously it copied
-// element_type->Size() * logical_element_count bytes, which over-counts ~2x for sub-byte
-// types and caused a heap over-read of the source and overflow of the destination.
-// Uses an odd logical length (7 elements -> ceil(7/2) = 4 packed bytes) to exercise the
-// packing edge. Best run under AddressSanitizer, where the pre-fix overflow is detected.
+// Test - GetValue() on a sequence of packed sub-byte tensors
+// (int4/uint4) must copy only the packed storage bytes.
 TEST(CApiTest, CreateGetSeqSubByteTensors) {
   auto default_allocator = std::make_unique<MockedOrtAllocator>();
   Ort::MemoryInfo info("Cpu", OrtDeviceAllocator, 0, OrtMemTypeDefault);

--- a/onnxruntime/test/shared_lib/test_nontensor_types.cc
+++ b/onnxruntime/test/shared_lib/test_nontensor_types.cc
@@ -4,6 +4,7 @@
 #include <functional>
 #include <iostream>
 #include <set>
+#include <array>
 
 #include "core/common/common.h"
 #include "core/session/onnxruntime_cxx_api.h"
@@ -275,6 +276,50 @@ TEST(CApiTest, CreateGetSeqStringTensors) {
     }
   }
   ASSERT_EQ(string_set, std::set<std::string>(std::begin(string_input_data), std::end(string_input_data)));
+}
+
+// Regression test for MSRC 119491: GetValue() on a sequence of packed sub-byte tensors
+// (int4/uint4) must copy only the packed storage bytes. Previously it copied
+// element_type->Size() * logical_element_count bytes, which over-counts ~2x for sub-byte
+// types and caused a heap over-read of the source and overflow of the destination.
+// Uses an odd logical length (7 elements -> ceil(7/2) = 4 packed bytes) to exercise the
+// packing edge. Best run under AddressSanitizer, where the pre-fix overflow is detected.
+TEST(CApiTest, CreateGetSeqSubByteTensors) {
+  auto default_allocator = std::make_unique<MockedOrtAllocator>();
+  Ort::MemoryInfo info("Cpu", OrtDeviceAllocator, 0, OrtMemTypeDefault);
+
+  auto run_for_type = [&](ONNXTensorElementDataType elem_type, const std::array<uint8_t, 4>& packed) {
+    const std::vector<int64_t> dims{7};  // 7 4-bit elements -> 4 packed bytes
+    constexpr int N = 2;
+
+    std::vector<Ort::Value> in;
+    for (int i = 0; i < N; ++i) {
+      Ort::Value tensor = Ort::Value::CreateTensor(info, const_cast<uint8_t*>(packed.data()), packed.size(),
+                                                   dims.data(), dims.size(), elem_type);
+      in.push_back(std::move(tensor));
+    }
+
+    Ort::Value seq_ort = Ort::Value::CreateSequence(in);
+
+    for (int idx = 0; idx < N; ++idx) {
+      Ort::Value out = seq_ort.GetValue(idx, default_allocator.get());
+
+      auto type_info = out.GetTypeInfo();
+      auto tensor_info = type_info.GetTensorTypeAndShapeInfo();
+      ASSERT_EQ(tensor_info.GetElementType(), elem_type);
+      ASSERT_EQ(tensor_info.GetShape(), dims);
+
+      const auto* ret = out.GetTensorData<uint8_t>();
+      for (size_t i = 0; i < packed.size(); ++i) {
+        ASSERT_EQ(ret[i], packed[i]);
+      }
+    }
+  };
+
+  // {0, 1, 2, 3, -8, 7, 6, pad_0}
+  run_for_type(ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_INT4, {0x10, 0x32, 0x78, 0x06});
+  // {0, 1, 2, 3, 4, 5, 15, pad_0}
+  run_for_type(ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT4, {0x10, 0x32, 0x54, 0x0F});
 }
 
 TEST(CApiTest, TypeInfoSequence) {


### PR DESCRIPTION
 ### Summary
  OrtApi::GetValue on a sequence of tensors copied elements using element_type->Size() * element_count bytes. For packed sub-byte types (INT4/UINT4, two elements per byte) this is ~2× the real storage size, causing a heap over-read of the source and overflow of the destination.

 ### Fix
  In PopulateTensorWithData (onnxruntime/core/session/onnxruntime_c_api.cc), copy the tensor's actual packed size via Tensor::SizeInBytes() instead of element_type->Size() * num_elems, and drop the now-unused elem_size parameter. SizeInBytes() is packing-aware: identical for ≥1-byte types (no behavior change) and correct for sub-byte types.

 ### Testing
   - Added CApiTest.CreateGetSeqSubByteTensors: sequences of INT4/UINT4 tensors with an odd length (7 elements → 4 packed bytes), verifying GetValue() round-trips correctly.
   - Full onnxruntime_shared_lib_test suite passes (185/185); other paths unchanged.
   - Confirmed under AddressSanitizer: the old formula triggers a heap-buffer-overflow, the new one is clean.


