### PR TITLE
Fix DropQDQ not dropping Q/DQ around opset-22 MaxPool

### DIFF
--- a/onnxruntime/core/optimizer/qdq_transformer/selectors_actions/qdq_selector_action_transformer.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/selectors_actions/qdq_selector_action_transformer.cc
@@ -86,7 +86,7 @@ void DropQDQNodesRules(SelectorActionRegistry& qdq_selector_action_registry) {
   std::unique_ptr<NodeSelector> selector_no_16bit_and_positive_scale =
       std::make_unique<QDQ::DropQDQNodesSelector>(false, true, false, providers);
   qdq_selector_action_registry.RegisterSelectorAndAction(drop_action_no_int16_and_positive_scale_name,
-                                                         {{"MaxPool", {12}},
+                                                         {{"MaxPool", {12, 22}},
                                                           {"ReduceMax", {}},
                                                           {"ReduceMin", {}}},
                                                          std::move(selector_no_16bit_and_positive_scale),

--- a/onnxruntime/core/optimizer/qdq_transformer/selectors_actions/shared/utils.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/selectors_actions/shared/utils.cc
@@ -52,7 +52,7 @@ static const OpVersionsAndSelector::OpVersionsMap GetMiscOpVersionsMap() {
           {"Expand", {}},
           {"Flatten", {}},
           {"Transpose", {}},
-          {"MaxPool", {12}},
+          {"MaxPool", {12, 22}},
           {"Resize", {}},
           {"Squeeze", {}},
           {"Unsqueeze", {}},

--- a/onnxruntime/test/optimizer/qdq_transformer_test.cc
+++ b/onnxruntime/test/optimizer/qdq_transformer_test.cc
@@ -1104,6 +1104,28 @@ TEST(QDQTransformerTests, MaxpoolDontDropQDQForNegativeScale) {
   RunMaxPoolNegativeScaleDropQDQTestCase<uint16_t>();
 }
 
+// Q/DQ around a MaxPool must still be dropped for the opset-22 MaxPool schema, not only MaxPool-12.
+TEST(QDQTransformerTests, MaxpoolDropQDQOpset22) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    auto* input_arg = builder.MakeInput<uint8_t>({1, 17, 17, 3}, 0, 255);
+    auto* dq_output = builder.MakeIntermediate();
+    auto* maxpool_output = builder.MakeIntermediate();
+
+    builder.AddDequantizeLinearNode<uint8_t>(input_arg, 0.003f, 128, dq_output);
+    builder.AddNode("MaxPool", {dq_output}, {maxpool_output}).AddAttribute("kernel_shape", std::vector<int64_t>{2, 2});
+    builder.AddQuantizeLinearNode<uint8_t>(maxpool_output, 0.003f, 128, builder.MakeOutput());
+  };
+
+  auto check_graph = [](InferenceSessionWrapper& session) {
+    auto op_to_count = CountOpsInGraph(session.GetGraph());
+    EXPECT_EQ(op_to_count["MaxPool"], 1);
+    EXPECT_EQ(op_to_count["QuantizeLinear"], 0);
+    EXPECT_EQ(op_to_count["DequantizeLinear"], 0);
+  };
+
+  TransformerTester(build_test_case, check_graph, TransformerLevel::Level1, TransformerLevel::Level2, 22);
+}
+
 // Runs a test case that checks if Q/DQ nodes are dropped from DQ -> (Un)Squeeze -> Q.
 template <typename QuantType>
 static void RunSqueezeUnsqueezeDropQDQTestCase(const std::string& squeeze_type,


### PR DESCRIPTION
### Description

ONNX added a `MaxPool-22` schema, but the DropQDQ selectors still matched only `MaxPool-12`, so the `DequantizeLinear` / `QuantizeLinear` around an opset-22 `MaxPool` were no longer dropped. This updates both DropQDQ selector op-version maps to `{12, 22}`, matching the QDQ propagation pass. (`MaxPool` stays pinned to integer-capable versions ≥ 12.)

### Motivation and Context

Fixes #28770. Models that optimized to full integer at opset ≤ 21 regressed at opset 22+, blocking users from upgrading their opset.
