### PR TITLE
[CPU] Add FP32 GEMV decode kernel for GroupQueryAttention

### DIFF
--- a/docs/contrib_ops/cpu/gqa.md
+++ b/docs/contrib_ops/cpu/gqa.md
@@ -58,7 +58,7 @@ Both the non-quantized and quantized paths have two execution strategies:
 - **Naive (full materialization)**: Computes the full `[S, T]` attention score matrix, applies masking and softmax, then computes the SV product. Simple but memory-intensive for long sequences.
 - **Flash Attention (tiled, online softmax)**: Processes K/V in L2-cache-sized blocks using the online softmax algorithm (Milakov & Gimelshein, 2018). Avoids materializing the full attention matrix, reducing peak memory from O(S×T) to O(S×Bc) per head. Multi-threaded via the MLAS thread pool.
 
-The quantized path uses `MlasFlashAttentionQuantizedKV` (`flashattn_qkv.cpp`); the non-quantized FP32 path uses `MlasFlashAttentionGQA` (`flashattn_gqa.cpp`). Both share the same tiling, masking, and online-softmax structure. The quantized path additionally provides a two-phase flash-decoding strategy for single-token decode; the non-quantized FP32 path is limited to prefill (`sequence_length > 1`) and uses the naive path for decode.
+The quantized path uses `MlasFlashAttentionQuantizedKV` (`flashattn_qkv.cpp`); the non-quantized FP32 path uses `MlasFlashAttentionGQA` (`flashattn_gqa.cpp`). Both share the same tiling, masking, online-softmax, and flash-decoding structure.
 
 The flash path is selected by default when conditions are met (see below). Set `ORT_GQA_DISABLE_FLASH_ATTENTION=1` to force the naive path (applies to both the quantized and non-quantized paths).
 
@@ -213,7 +213,7 @@ The partials buffer is allocated alongside the per-thread scratch in a single al
 
 ## Non-Quantized Flash Attention Path
 
-The non-quantized flash attention path (`MlasFlashAttentionGQA`, in `flashattn_gqa.cpp`) is the FP32-KV-cache counterpart of the quantized path. It is selected for the `float` kernel specialization and reuses the same tiling, online-softmax, and masking structure. Unlike the quantized path, it is limited to prefill / chunked-prefill (`sequence_length > 1`); single-token decode (`sequence_length == 1`) uses the naive path, which is why there is no flash-decoding variant here.
+The non-quantized flash attention path (`MlasFlashAttentionGQA`, in `flashattn_gqa.cpp`) is the FP32-KV-cache counterpart of the quantized path. It is selected for the `float` kernel specialization and reuses the same tiling, online-softmax, masking, and flash-decoding structure.
 
 ### Differences from the Quantized Path
 
@@ -242,7 +242,8 @@ computes a per-q_block bound
 `ir >= kv_causal_limit`, instead of computing and then discarding the masked upper-triangle
 QK/SV GEMMs. This skips roughly half of the QK/SV work for square prefill (S = T) and is the
 main reason the FP32 flash path is faster than naive even at short sequence lengths
-(see the benchmark results below).
+(see the benchmark results below). Decode (q_block of size 1 at the cache tail) attends to all
+KV positions, so the bound equals `total_seqlen` and nothing is skipped.
 
 ### Activation Conditions
 
@@ -250,18 +251,18 @@ The non-quantized flash path is selected when ALL of the following hold:
 
 - The kernel specialization is `float` (FP16 uses the naive path)
 - `ORT_GQA_DISABLE_FLASH_ATTENTION` environment variable is not set (or set to `0`)
-- `sequence_length > 1` (prefill / chunked-prefill; single-token decode uses the naive path)
+- `total_sequence_length > 1`
 - No softcap
 - No smooth softmax
 - No head sink
 - No output QK capture
 - `present_key` and `present_value` are provided
 
-Attention bias, causal masking, local window attention, GQA head grouping (`num_heads != kv_num_heads`), ragged per-batch sequence lengths, and shared past/present buffers are all supported, mirroring the quantized flash path. When any condition is not met, the kernel falls back to the naive full-materialization path.
+Attention bias, causal masking, local window attention, GQA head grouping (`num_heads != kv_num_heads`), ragged per-batch sequence lengths, and shared past/present buffers are all supported for prefill, mirroring the quantized flash path. The non-quantized flash path is currently selected for prefill only (`sequence_length > 1`); single-token decode falls back to the naive full-materialization path (a dedicated decode kernel is added in a follow-up change). When any supported condition is not met, the kernel also falls back to the naive path.
 
-### Block Sizes and Threading
+### Block Sizes, Threading, and Flash Decoding
 
-Block-size selection (`kv_block_size`, `q_block_size`), `(batch, head, q_block)` task partitioning, and the per-thread working buffer layout (`l`, `m`, `scores`, `temp_output`) are identical to the quantized path described above. The only difference is that the per-thread `temp_output` tile is accumulated directly by the SV SGEMM rather than via a fused dequantization. Because this path is prefill-only, it does not include the quantized path's two-phase flash-decoding strategy for single-token decode.
+Block-size selection (`kv_block_size`, `q_block_size`), `(batch, head, q_block)` task partitioning, and the per-thread working buffer layout (`l`, `m`, `scores`, `temp_output`) for prefill are identical to the quantized path described above. The only difference is that the per-thread `temp_output` tile is accumulated directly by the SV SGEMM rather than via a fused dequantization. The two-phase flash-decoding strategy for single-token decode is gated off for the non-quantized path in this PR (decode falls back to naive); it is enabled together with the dedicated decode kernel in a follow-up change.
 
 ## MLAS Dispatch Paths
 
@@ -513,13 +514,13 @@ offsets the intrinsic per-KV-block online-softmax overhead (running max/exp/outp
 The same advantage holds single-threaded (1.4\u20131.8x at threads=1), confirming the gain is
 algorithmic rather than purely from threading.
 
-#### Decode (S = 1, token generation)
+#### Latency — Decode (S = 1, token generation)
 
-Single-token decode (`sequence_length == 1`) is **not** handled by the FP32 flash path; it falls
-back to the naive path. Decode produces only a `[1, total_sequence_length]` score row per head,
-so there is nothing to tile away, and the extra online-softmax bookkeeping made the flash kernel
-slower and noisier in practice. Restricting the flash path to prefill (`sequence_length > 1`) keeps
-the consistent prefill win without regressing decode.
+Single-token decode (`sequence_length == 1`) currently falls back to the naive path for the
+non-quantized FP32 cache: the flash path is gated on `sequence_length > 1` (prefill only),
+because routing the tiny `1 × T × H` decode work through the tiled SGEMM kernel pays
+per-block GEMM setup overhead with no tiling reuse benefit. A dedicated FP32 decode kernel
+is added in a follow-up change.
 ## Current CPU Limitations
 
 The current CPU GroupQueryAttention implementation has a few important limitations:

--- a/docs/contrib_ops/cpu/gqa.md
+++ b/docs/contrib_ops/cpu/gqa.md
@@ -258,11 +258,45 @@ The non-quantized flash path is selected when ALL of the following hold:
 - No output QK capture
 - `present_key` and `present_value` are provided
 
-Attention bias, causal masking, local window attention, GQA head grouping (`num_heads != kv_num_heads`), ragged per-batch sequence lengths, and shared past/present buffers are all supported for prefill, mirroring the quantized flash path. The non-quantized flash path is currently selected for prefill only (`sequence_length > 1`); single-token decode falls back to the naive full-materialization path (a dedicated decode kernel is added in a follow-up change). When any supported condition is not met, the kernel also falls back to the naive path.
+Attention bias, causal masking, local window attention, GQA head grouping (`num_heads != kv_num_heads`), ragged per-batch sequence lengths, shared past/present buffers, and flash decoding are all supported, mirroring the quantized flash path. When any condition is not met, the kernel falls back to the naive full-materialization path.
 
 ### Block Sizes, Threading, and Flash Decoding
 
-Block-size selection (`kv_block_size`, `q_block_size`), `(batch, head, q_block)` task partitioning, and the per-thread working buffer layout (`l`, `m`, `scores`, `temp_output`) for prefill are identical to the quantized path described above. The only difference is that the per-thread `temp_output` tile is accumulated directly by the SV SGEMM rather than via a fused dequantization. The two-phase flash-decoding strategy for single-token decode is gated off for the non-quantized path in this PR (decode falls back to naive); it is enabled together with the dedicated decode kernel in a follow-up change.
+Block-size selection (`kv_block_size`, `q_block_size`), `(batch, head, q_block)` task partitioning, the per-thread working buffer layout (`l`, `m`, `scores`, `temp_output`), and the two-phase flash-decoding strategy for single-token decode are identical to the quantized path described above. The only difference is that the per-thread `temp_output` tile is accumulated directly by the SV SGEMM rather than via a fused dequantization.
+
+#### Decode uses a dedicated GEMV kernel (`sequence_length == 1`)
+
+The tiled online-softmax SGEMM kernel (`MlasFlashAttentionGQAThreaded`) is used **only for
+prefill** (`sequence_length > 1`), where each KV tile is reused across the `q_block_size`
+query rows and tiling delivers real cache-locality and SGEMM packing benefits.
+
+For single-token decode the query tile has `M = 1`, so every K/V element is streamed
+exactly once with no reuse across query rows. Tiling provides **no** cache-locality
+benefit, and routing the `1 × T × H` work through `MlasSgemmOperation` pays the SGEMM
+B-packing/setup cost on every call — which previously made the flash decode path *slower*
+than the naive path (≈0.4–0.6x) for short-to-medium total sequence lengths.
+
+Decode is therefore handled by a dedicated GEMV kernel (`MlasGQADecodeGQAThreaded`),
+dispatched whenever `sequence_length == 1` and flash decoding is not active. It
+parallelizes over `(batch, head)` and, per head, computes the attention directly with two
+matrix-vector products and a two-pass softmax:
+
+- **QK GEMV** — `scores[t] = scale · dot(q, K[t])` for `t ∈ [0, total_seqlen)`.
+- two-pass softmax over `scores` using the dispatched `ReduceMaximumF32Kernel` /
+  `ComputeSumExpF32Kernel` helpers.
+- **SV GEMV** — `out[h] = Σ_t probs[t] · V[t][h]`, then normalize by `1/Σ probs`.
+
+Both GEMV helpers (`MlasGQADecodeQK`, `MlasGQADecodeSV`) live in the baseline-ISA MLAS
+translation unit, so their inner loops use independent accumulator lanes / map-style
+updates that vectorize under SSE2 without `-ffast-math`. Decode needs no causal mask (the
+single new token is the most recent position and attends to every cached token); only
+optional local-window masking and additive attention bias are applied. The kernel streams
+K and V exactly once each, so it is memory-bandwidth bound.
+
+The two-phase flash-decoding path (active when `batch × heads < threads`, KV partitioned
+across idle threads) now also uses these GEMV helpers for its per-chunk QK and SV products
+instead of `M = 1` SGEMM calls, removing the same packing overhead.
+
 
 ## MLAS Dispatch Paths
 
@@ -516,11 +550,29 @@ algorithmic rather than purely from threading.
 
 #### Latency — Decode (S = 1, token generation)
 
-Single-token decode (`sequence_length == 1`) currently falls back to the naive path for the
-non-quantized FP32 cache: the flash path is gated on `sequence_length > 1` (prefill only),
-because routing the tiny `1 × T × H` decode work through the tiled SGEMM kernel pays
-per-block GEMM setup overhead with no tiling reuse benefit. A dedicated FP32 decode kernel
-is added in a follow-up change.
+For single-token decode at this head configuration (`batch\u00d7heads = 16 > threads = 8`, so
+flash decoding KV-partitioning is not active), the workload per `Run` is tiny (a `1 × T × H`
+GEMV pair per head) and operator-level latency is dominated by fixed per-`Run` overhead
+(session dispatch, KV-cache concatenation), so operator-level measurements on the EPYC dev
+box are extremely noisy. The numbers below come from a min-of-many-repeats MLAS-path harness
+to suppress that jitter.
+
+| Total Seqlen | Naive (ms) | Flash (ms) | Speedup |
+|---:|---:|---:|---:|
+| 513  | 0.50 | 0.42 | ~1.0\u20131.2x (noisy) |
+| 1025 | 0.78 | 0.69 | ~1.0\u20131.1x (noisy) |
+| 2049 | 1.89 | 1.73 | ~1.0\u20131.1x (noisy) |
+| 4097 | 6.1  | 4.5  | 1.35\u20131.5x |
+
+Decode is now handled by the dedicated GEMV kernel (`MlasGQADecodeGQAThreaded`) instead of
+the prefill tiling kernel; see *Decode uses a dedicated GEMV kernel* above. Replacing the
+per-head `M = 1` `MlasSgemmOperation` QK/SV calls with direct GEMVs removes the SGEMM
+B-packing overhead that previously made flash decode noticeably **slower** than naive
+(measured ≈0.4\u20130.6x across all lengths before the change). Flash decode is now at parity
+for short/medium sequences (where the work is memory-bandwidth bound and overhead-dominated)
+and consistently ahead for long contexts (T≥4097, ~1.4\u20131.5x) where the streamed
+single-pass KV access wins. Short decode remains overhead-bound rather than algorithm-bound,
+so it is not the target of the prefill-oriented causal early-termination optimization.
 ## Current CPU Limitations
 
 The current CPU GroupQueryAttention implementation has a few important limitations:

--- a/onnxruntime/contrib_ops/cpu/bert/gqa_attention_base.h
+++ b/onnxruntime/contrib_ops/cpu/bert/gqa_attention_base.h
@@ -1091,15 +1091,42 @@ class GQAAttentionBase {
     int thread_count = concurrency::ThreadPool::DegreeOfParallelism(tp);
     thread_count = std::max(thread_count, 1);
 
-    // Per-thread scratch: l + m + scores[q_block_size * kv_block_size] + temp_output[q_block_size * head_size]
-    const size_t buffer_size_per_thread =
-        (SafeInt<size_t>(q_block_size) * 2 +              // l + m
-         SafeInt<size_t>(q_block_size) * kv_block_size +  // scores
-         SafeInt<size_t>(q_block_size) * head_size) *     // temp_output
-        sizeof(float);
-    size_t total_buffer_bytes = SafeInt<size_t>(buffer_size_per_thread) * thread_count;
+    // Flash decoding: for decode (sequence_length==1), partition KV across threads
+    // to improve parallelism when batch*heads < thread_count.
+    const int kv_chunk_count = (max_total_seqlen + kv_block_size - 1) / kv_block_size;
+    const bool use_flash_decoding = (sequence_length == 1 &&
+                                     batch_size * num_heads_ < thread_count &&
+                                     kv_chunk_count > 1);
+
+    size_t buffer_size_per_thread;
+    size_t partials_buffer_bytes = 0;
+    if (use_flash_decoding) {
+      // Flash decoding: per-thread scratch only needs scores[kv_block_size]
+      buffer_size_per_thread = SafeInt<size_t>(kv_block_size) * sizeof(float);
+      // Partials: [batch * num_heads * kv_chunk_count * (2 + head_size)] floats
+      partials_buffer_bytes = SafeInt<size_t>(batch_size) * num_heads_ *
+                              kv_chunk_count * (2 + head_size) * sizeof(float);
+    } else if (sequence_length == 1) {
+      // Decode (GEMV kernel, no Q/KV tiling): per-thread scratch holds the full
+      // score row scores[total_seqlen] plus a temp output accumulator[head_size].
+      buffer_size_per_thread =
+          (SafeInt<size_t>(max_total_seqlen) + head_size) * sizeof(float);
+    } else {
+      buffer_size_per_thread =
+          (SafeInt<size_t>(q_block_size) * 2 +              // l + m
+           SafeInt<size_t>(q_block_size) * kv_block_size +  // scores
+           SafeInt<size_t>(q_block_size) * head_size) *     // temp_output
+          sizeof(float);
+    }
+    size_t total_buffer_bytes = SafeInt<size_t>(buffer_size_per_thread) * thread_count + partials_buffer_bytes;
     auto flash_buffer_alloc = allocator->Alloc(total_buffer_bytes);
     BufferUniquePtr flash_buffer(flash_buffer_alloc, BufferDeleter(allocator));
+
+    // Partials buffer is placed after per-thread scratch
+    float* partials_ptr = use_flash_decoding
+                              ? reinterpret_cast<float*>(reinterpret_cast<char*>(flash_buffer_alloc) +
+                                                         buffer_size_per_thread * thread_count)
+                              : nullptr;
 
     const float scale = scale_ == 0.0f ? 1.0f / sqrt(static_cast<float>(head_size)) : scale_;
 
@@ -1133,6 +1160,8 @@ class GQAAttentionBase {
       args.attention_bias_seqlen_stride = attention_bias_seqlen_stride;
       args.attention_bias_broadcast_batch = attention_bias_broadcast_batch;
       args.attention_bias_broadcast_head = attention_bias_broadcast_head;
+      args.flash_decoding_partials = partials_ptr;
+      args.kv_chunk_count = kv_chunk_count;
 
       MlasFlashAttentionGQA(&args, tp);
     } else {
@@ -1185,6 +1214,8 @@ class GQAAttentionBase {
         args.attention_bias_seqlen_stride = attention_bias_seqlen_stride;
         args.attention_bias_broadcast_batch = true;  // batch offset handled above
         args.attention_bias_broadcast_head = attention_bias_broadcast_head;
+        args.flash_decoding_partials = nullptr;  // per-batch doesn't use flash decoding
+        args.kv_chunk_count = 0;
 
         MlasFlashAttentionGQA(&args, tp);
       }

--- a/onnxruntime/contrib_ops/cpu/bert/gqa_attention_base.h
+++ b/onnxruntime/contrib_ops/cpu/bert/gqa_attention_base.h
@@ -1092,9 +1092,15 @@ class GQAAttentionBase {
     thread_count = std::max(thread_count, 1);
 
     // Flash decoding: for decode (sequence_length==1), partition KV across threads
-    // to improve parallelism when batch*heads < thread_count.
+    // to improve parallelism when batch*heads < thread_count. This KV-split is only
+    // wired into the unified kernel (common_past_seqlen >= 0); the ragged/per-batch
+    // fallback runs the single-pass decode kernel instead, which needs a larger
+    // per-thread scratch (scores[total_seqlen] + temp_output[head_size]). Gating on
+    // common_past_seqlen >= 0 keeps the per-thread buffer sizing below consistent
+    // with the kernel that actually runs.
     const int kv_chunk_count = (max_total_seqlen + kv_block_size - 1) / kv_block_size;
     const bool use_flash_decoding = (sequence_length == 1 &&
+                                     common_past_seqlen >= 0 &&
                                      batch_size * num_heads_ < thread_count &&
                                      kv_chunk_count > 1);
 

--- a/onnxruntime/contrib_ops/cpu/bert/group_query_attention.cc
+++ b/onnxruntime/contrib_ops/cpu/bert/group_query_attention.cc
@@ -349,16 +349,12 @@ Status GroupQueryAttention<T>::Compute(OpKernelContext* context) const {
   // naive path when an unsupported feature is requested (softcap, smooth softmax,
   // head sink, or QK output).
   //
-  // The flash path is currently used for prefill only (sequence_length > 1). Single-token
-  // decode (sequence_length == 1) falls back to the naive path; a dedicated decode kernel
-  // is added in a follow-up change.
+  // Prefill (sequence_length > 1) uses the tiled kernel; single-token decode
+  // (sequence_length == 1 with total_sequence_length > 1) uses the dedicated GEMV
+  // decode kernel. Both are reached when total_sequence_length > 1.
   if constexpr (std::is_same_v<T, float>) {
-    // Restrict the flash path to prefill / chunked-prefill (query length > 1). Single-token
-    // decode (sequence_length == 1) has no flash benefit: the naive score matrix is only
-    // [1, total_sequence_length] per head, so there is nothing to tile away, and the extra
-    // online-softmax bookkeeping makes it slower in practice.
     const bool use_flash = !disable_gqa_flash_ &&
-                           parameters.sequence_length > 1 &&
+                           parameters.total_sequence_length > 1 &&
                            softcap_ == 0.0f &&
                            !use_smooth_softmax_ &&
                            head_sink_data == nullptr &&

--- a/onnxruntime/contrib_ops/cpu/bert/group_query_attention.cc
+++ b/onnxruntime/contrib_ops/cpu/bert/group_query_attention.cc
@@ -348,6 +348,10 @@ Status GroupQueryAttention<T>::Compute(OpKernelContext* context) const {
   // kernel to avoid materializing the full attention score matrix. Falls back to the
   // naive path when an unsupported feature is requested (softcap, smooth softmax,
   // head sink, or QK output).
+  //
+  // The flash path is currently used for prefill only (sequence_length > 1). Single-token
+  // decode (sequence_length == 1) falls back to the naive path; a dedicated decode kernel
+  // is added in a follow-up change.
   if constexpr (std::is_same_v<T, float>) {
     // Restrict the flash path to prefill / chunked-prefill (query length > 1). Single-token
     // decode (sequence_length == 1) has no flash benefit: the naive score matrix is only

--- a/onnxruntime/core/mlas/inc/mlas.h
+++ b/onnxruntime/core/mlas/inc/mlas.h
@@ -2302,9 +2302,9 @@ MlasFlashAttention(
 //
 // Adapts the online-softmax tiled algorithm to operate on an FP32 present
 // K/V cache laid out as BNSH ([batch, kv_num_heads, seqlen_present, head_size]).
-// Supports GQA head grouping, causal masking, local window attention, and
-// additive attention bias. Intended for prefill / chunked-prefill
-// (sequence_length > 1).
+// Supports GQA head grouping, causal masking, local window attention,
+// additive attention bias, and an optional flash-decoding split over the KV
+// sequence dimension for the single-token decode case.
 //
 struct MlasFlashAttentionGQAArgs {
     int batch_size;
@@ -2320,7 +2320,7 @@ struct MlasFlashAttentionGQAArgs {
     int kv_block_size;        // key/value tile size (Bc)
     float scale;              // QK scaling factor
     int thread_count;         // number of partitions / threads
-    float* buffer;            // per-thread scratch
+    float* buffer;            // per-thread scratch (+ optional flash-decoding partials)
     size_t buffer_size_per_thread;
 
     const float* query;       // [batch, num_heads, sequence_length, head_size] BNSH
@@ -2334,6 +2334,12 @@ struct MlasFlashAttentionGQAArgs {
     int attention_bias_seqlen_stride;
     bool attention_bias_broadcast_batch;
     bool attention_bias_broadcast_head;
+
+    // Flash decoding (sequence_length == 1): partition KV across threads.
+    // Set flash_decoding_partials != nullptr to enable; otherwise the standard
+    // per-(batch, head, q_block) partitioning is used.
+    float* flash_decoding_partials;
+    int kv_chunk_count;
 };
 
 /**

--- a/onnxruntime/core/mlas/lib/flashattn_gqa.cpp
+++ b/onnxruntime/core/mlas/lib/flashattn_gqa.cpp
@@ -17,8 +17,8 @@ Abstract:
     an FP32 present K/V cache laid out as BNSH
     ([batch, kv_num_heads, seqlen_present, head_size]) and to support GQA head
     grouping (num_heads % kv_num_heads == 0), causal masking, local window
-    attention, and additive attention bias. Intended for prefill /
-    chunked-prefill (sequence_length > 1).
+    attention, additive attention bias, and an optional flash-decoding split
+    over the KV sequence dimension for single-token decode.
 
     QK^T and S*V use the single-threaded SGEMM primitive MlasSgemmOperation;
     the outer parallelism is provided by MlasExecuteThreaded.
@@ -31,6 +31,71 @@ Abstract:
 #include <limits>
 
 #include "mlasi.h"
+
+//
+// Decode (sequence_length == 1) GEMV helpers.
+//
+// With a single query token the QK^T and S*V products degenerate into
+// matrix-vector products. Computing them directly streams the K and V cache
+// exactly once and avoids the SGEMM B-packing overhead that otherwise dominates
+// the tiny M = 1 GEMMs. These helpers live in the baseline-ISA MLAS translation
+// unit, so the inner loops are written with independent accumulator lanes and a
+// map-style update so the compiler can vectorize them without -ffast-math
+// (which would be required to reassociate a plain scalar float reduction).
+//
+
+// QK^T GEMV: scores[t] = scale * dot(q[0..H), K[t*H .. t*H+H))  for t in [0, n_kv).
+static void
+MlasGQADecodeQK(
+    const float* q,
+    const float* k_cache,
+    std::ptrdiff_t n_kv,
+    std::ptrdiff_t head_size,
+    float scale,
+    float* scores
+)
+{
+    constexpr std::ptrdiff_t kLanes = 8;
+    for (std::ptrdiff_t t = 0; t < n_kv; ++t) {
+        const float* krow = k_cache + t * head_size;
+        float acc[kLanes] = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
+        std::ptrdiff_t h = 0;
+        for (; h + kLanes <= head_size; h += kLanes) {
+            for (std::ptrdiff_t j = 0; j < kLanes; ++j) {
+                acc[j] += q[h + j] * krow[h + j];
+            }
+        }
+        float sum = ((acc[0] + acc[1]) + (acc[2] + acc[3])) +
+                    ((acc[4] + acc[5]) + (acc[6] + acc[7]));
+        for (; h < head_size; ++h) {
+            sum += q[h] * krow[h];
+        }
+        scores[t] = sum * scale;
+    }
+}
+
+// S*V GEMV (accumulate): out[h] = sum_t probs[t] * V[t*H + h]  for h in [0, head_size).
+// `out` is overwritten (initialized to zero) before accumulation.
+static void
+MlasGQADecodeSV(
+    const float* probs,
+    const float* v_cache,
+    std::ptrdiff_t n_kv,
+    std::ptrdiff_t head_size,
+    float* out
+)
+{
+    for (std::ptrdiff_t h = 0; h < head_size; ++h) {
+        out[h] = 0.0f;
+    }
+    for (std::ptrdiff_t t = 0; t < n_kv; ++t) {
+        const float p = probs[t];
+        const float* vrow = v_cache + t * head_size;
+        for (std::ptrdiff_t h = 0; h < head_size; ++h) {
+            out[h] += p * vrow[h];
+        }
+    }
+}
 
 void
 MlasFlashAttentionGQAThreaded(
@@ -294,6 +359,415 @@ MlasFlashAttentionGQAThreaded(
     }
 }
 
+//
+// Flash Decoding: Phase 1 - parallel partial attention over (batch, head, kv_chunk).
+// Each task computes attention for one KV chunk and stores (m, l, partial_output)
+// into the partials buffer.
+//
+void
+MlasFlashDecodingGQAThreaded(
+    void* argptr,
+    std::ptrdiff_t thread_id
+)
+{
+    const MlasFlashAttentionGQAArgs* args =
+        reinterpret_cast<MlasFlashAttentionGQAArgs*>(argptr);
+
+    const ptrdiff_t kv_block_size = static_cast<ptrdiff_t>(args->kv_block_size);
+    const ptrdiff_t batch_size = static_cast<ptrdiff_t>(args->batch_size);
+    const ptrdiff_t num_heads = static_cast<ptrdiff_t>(args->num_heads);
+    const ptrdiff_t kv_num_heads = static_cast<ptrdiff_t>(args->kv_num_heads);
+    const ptrdiff_t total_seqlen = static_cast<ptrdiff_t>(args->total_seqlen);
+    const ptrdiff_t head_size = static_cast<ptrdiff_t>(args->head_size);
+    const ptrdiff_t past_seqlen = static_cast<ptrdiff_t>(args->past_seqlen);
+    const ptrdiff_t local_window_size = static_cast<ptrdiff_t>(args->local_window_size);
+    const float scale = args->scale;
+
+    float* buffer = args->buffer;
+    const ptrdiff_t buffer_size_per_thread = static_cast<ptrdiff_t>(args->buffer_size_per_thread);
+    const ptrdiff_t thread_count = static_cast<ptrdiff_t>(args->thread_count);
+
+    const size_t kv_num_heads_factor = static_cast<size_t>(num_heads / kv_num_heads);
+    const size_t kv_head_stride =
+        static_cast<size_t>(args->seqlen_present_kv) * static_cast<size_t>(head_size);
+
+    const ptrdiff_t kv_chunk_count = static_cast<ptrdiff_t>(args->kv_chunk_count);
+    // Partials layout per entry: [m, l, output[head_size]]
+    const ptrdiff_t partial_stride = 2 + head_size;
+
+#if defined(MLAS_TARGET_AMD64) || defined(MLAS_TARGET_LARCH64)
+    auto&& mlas_platform = GetMlasPlatform();
+#endif
+
+    // Total tasks: (batch, head, kv_chunk)
+    const ptrdiff_t total_task_count = batch_size * num_heads * kv_chunk_count;
+
+    ptrdiff_t task_start = 0;
+    ptrdiff_t task_end = 0;
+    ptrdiff_t quotient = total_task_count / thread_count;
+    ptrdiff_t remainder = total_task_count % thread_count;
+    if (thread_id < remainder) {
+        task_start = (quotient + 1) * thread_id;
+        task_end = task_start + quotient + 1;
+    } else {
+        task_start = quotient * thread_id + remainder;
+        task_end = task_start + quotient;
+    }
+
+    for (ptrdiff_t task_index = task_start; task_index < task_end; ++task_index) {
+        // Decompose task_index into (batch_idx, head_idx, kv_chunk_idx)
+        ptrdiff_t tmp = task_index;
+        ptrdiff_t kv_chunk_idx = tmp % kv_chunk_count;
+        tmp /= kv_chunk_count;
+        ptrdiff_t head_idx = tmp % num_heads;
+        ptrdiff_t batch_idx = tmp / num_heads;
+
+        // Per-thread scratch buffer: just scores[kv_block_size]
+        char* buffer_ptr = reinterpret_cast<char*>(buffer) + thread_id * buffer_size_per_thread;
+        float* scores = reinterpret_cast<float*>(buffer_ptr);
+
+        // KV block range for this chunk
+        const ptrdiff_t ir = kv_chunk_idx * kv_block_size;
+        const size_t row_size_kv = static_cast<size_t>(std::min(kv_block_size, total_seqlen - ir));
+
+        // Determine KV head index for GQA head sharing
+        const size_t kv_head_idx = static_cast<size_t>(head_idx) / kv_num_heads_factor;
+
+        // K/V cache pointers
+        const size_t kv_batch_head_offset =
+            (static_cast<size_t>(batch_idx) * static_cast<size_t>(kv_num_heads) + kv_head_idx) *
+            kv_head_stride;
+        const float* k_cache_head = args->k_cache + kv_batch_head_offset;
+        const float* v_cache_head = args->v_cache + kv_batch_head_offset;
+
+        // Q pointer: layout [batch, num_heads, 1, head_size] (sequence_length=1).
+        // The batch stride is supplied separately to support packed-QKV input.
+        const float* q_ptr = args->query +
+            static_cast<size_t>(batch_idx) * args->q_batch_stride +
+            static_cast<size_t>(head_idx) * static_cast<size_t>(head_size);
+
+        // Step 1: QK^T GEMV for this KV chunk (M = 1)
+        const float* k_block = k_cache_head + static_cast<size_t>(ir) * static_cast<size_t>(head_size);
+        MlasGQADecodeQK(q_ptr, k_block, static_cast<std::ptrdiff_t>(row_size_kv), head_size, scale, scores);
+
+        // Step 1b: Apply attention bias if present
+        if (args->attention_bias != nullptr) {
+            const ptrdiff_t bias_seqlen_stride =
+                static_cast<ptrdiff_t>(args->attention_bias_seqlen_stride);
+            const ptrdiff_t bias_matrix_size = bias_seqlen_stride;  // S=1
+            // The bias tensor has shape [batch|1, num_heads|1, S, T]; the batch stride
+            // uses the actual head extent (1 when the head dim is broadcast).
+            const ptrdiff_t bias_head_extent =
+                args->attention_bias_broadcast_head ? 1 : static_cast<ptrdiff_t>(num_heads);
+            ptrdiff_t bias_offset = 0;
+            if (!args->attention_bias_broadcast_batch) {
+                bias_offset += static_cast<ptrdiff_t>(batch_idx) *
+                               bias_head_extent * bias_matrix_size;
+            }
+            if (!args->attention_bias_broadcast_head) {
+                bias_offset += static_cast<ptrdiff_t>(head_idx) * bias_matrix_size;
+            }
+            const float* bias_row = args->attention_bias + bias_offset + ir;
+            for (ptrdiff_t jcol = 0; jcol < static_cast<ptrdiff_t>(row_size_kv); ++jcol) {
+                scores[jcol] += bias_row[jcol];
+            }
+        }
+
+        // Step 2: Apply causal mask
+        const ptrdiff_t global_q_pos = past_seqlen;  // sequence_length=1, q_idx=0
+        const ptrdiff_t causal_limit = global_q_pos + 1;
+        for (ptrdiff_t jcol = 0; jcol < static_cast<ptrdiff_t>(row_size_kv); ++jcol) {
+            ptrdiff_t kv_pos = ir + jcol;
+            if (kv_pos >= causal_limit) {
+                scores[jcol] = std::numeric_limits<float>::lowest();
+            }
+        }
+
+        // Apply local window masking if enabled
+        if (local_window_size >= 0) {
+            const ptrdiff_t window_start =
+                (causal_limit > local_window_size) ? (causal_limit - local_window_size) : 0;
+            for (ptrdiff_t jcol = 0; jcol < static_cast<ptrdiff_t>(row_size_kv); ++jcol) {
+                ptrdiff_t kv_pos = ir + jcol;
+                if (kv_pos < window_start) {
+                    scores[jcol] = std::numeric_limits<float>::lowest();
+                }
+            }
+        }
+
+        // Step 3: Compute local softmax statistics (m, l) and exp scores
+#if defined(MLAS_TARGET_AMD64) || defined(MLAS_TARGET_LARCH64)
+        float rowmax = mlas_platform.ReduceMaximumF32Kernel(scores, row_size_kv);
+#else
+        float rowmax = MlasReduceMaximumF32Kernel(scores, row_size_kv);
+#endif
+
+        // Pointer to this task's partial in the partials buffer
+        const ptrdiff_t partial_index =
+            (batch_idx * num_heads + head_idx) * kv_chunk_count + kv_chunk_idx;
+        float* partial = args->flash_decoding_partials + partial_index * partial_stride;
+        float* partial_m = partial;
+        float* partial_l = partial + 1;
+        float* partial_output = partial + 2;
+
+        if (rowmax == std::numeric_limits<float>::lowest()) {
+            // Entire chunk is masked: store sentinel
+            *partial_m = std::numeric_limits<float>::lowest();
+            *partial_l = 0.0f;
+            memset(partial_output, 0, static_cast<size_t>(head_size) * sizeof(float));
+            continue;
+        }
+
+        *partial_m = rowmax;
+        float negmax = -rowmax;
+#if defined(MLAS_TARGET_AMD64)
+        float rowsum = mlas_platform.ComputeSumExpF32Kernel(scores, scores, row_size_kv, &negmax);
+#else
+        float rowsum = MlasComputeSumExpF32Kernel(scores, scores, row_size_kv, &negmax);
+#endif
+        *partial_l = rowsum;
+
+        // Step 4: S_exp * V_block -> partial_output (M = 1)
+        const float* v_block = v_cache_head + static_cast<size_t>(ir) * static_cast<size_t>(head_size);
+        MlasGQADecodeSV(scores, v_block, static_cast<std::ptrdiff_t>(row_size_kv), head_size, partial_output);
+    }
+}
+
+//
+// Flash Decoding: Phase 2 - reduce partials for each (batch, head) into final output.
+//
+void
+MlasFlashDecodingGQAReduceThreaded(
+    void* argptr,
+    std::ptrdiff_t thread_id
+)
+{
+    const MlasFlashAttentionGQAArgs* args =
+        reinterpret_cast<MlasFlashAttentionGQAArgs*>(argptr);
+
+    const ptrdiff_t batch_size = static_cast<ptrdiff_t>(args->batch_size);
+    const ptrdiff_t num_heads = static_cast<ptrdiff_t>(args->num_heads);
+    const ptrdiff_t head_size = static_cast<ptrdiff_t>(args->head_size);
+    const ptrdiff_t kv_chunk_count = static_cast<ptrdiff_t>(args->kv_chunk_count);
+    const ptrdiff_t thread_count = static_cast<ptrdiff_t>(args->thread_count);
+    const ptrdiff_t partial_stride = 2 + head_size;
+
+    // Total reduction tasks: one per (batch, head)
+    const ptrdiff_t total_task_count = batch_size * num_heads;
+
+    ptrdiff_t task_start = 0;
+    ptrdiff_t task_end = 0;
+    ptrdiff_t quotient = total_task_count / thread_count;
+    ptrdiff_t remainder = total_task_count % thread_count;
+    if (thread_id < remainder) {
+        task_start = (quotient + 1) * thread_id;
+        task_end = task_start + quotient + 1;
+    } else {
+        task_start = quotient * thread_id + remainder;
+        task_end = task_start + quotient;
+    }
+
+    for (ptrdiff_t task_index = task_start; task_index < task_end; ++task_index) {
+        ptrdiff_t head_idx = task_index % num_heads;
+        ptrdiff_t batch_idx = task_index / num_heads;
+
+        // Pointer to this (batch, head)'s partials: kv_chunk_count entries
+        const float* partials_base = args->flash_decoding_partials +
+            task_index * kv_chunk_count * partial_stride;
+
+        // Find global max across all chunks
+        float global_m = std::numeric_limits<float>::lowest();
+        for (ptrdiff_t c = 0; c < kv_chunk_count; ++c) {
+            float chunk_m = partials_base[c * partial_stride];
+            global_m = std::max(global_m, chunk_m);
+        }
+
+        // Output layout: [batch, sequence_length=1, num_heads, head_size]
+        float* output_ptr = args->output +
+            static_cast<size_t>(batch_idx) * static_cast<size_t>(num_heads) * static_cast<size_t>(head_size) +
+            static_cast<size_t>(head_idx) * static_cast<size_t>(head_size);
+
+        // If all chunks are masked, output zeros
+        if (global_m == std::numeric_limits<float>::lowest()) {
+            memset(output_ptr, 0, static_cast<size_t>(head_size) * sizeof(float));
+            continue;
+        }
+
+        // Accumulate rescaled outputs and l values
+        float global_l = 0.0f;
+        memset(output_ptr, 0, static_cast<size_t>(head_size) * sizeof(float));
+
+        for (ptrdiff_t c = 0; c < kv_chunk_count; ++c) {
+            const float* partial = partials_base + c * partial_stride;
+            float chunk_m = partial[0];
+            float chunk_l = partial[1];
+            const float* chunk_output = partial + 2;
+
+            if (chunk_l <= 0.0f) {
+                continue;  // masked chunk contributes nothing
+            }
+
+            float rescale = std::exp(chunk_m - global_m);
+            global_l += rescale * chunk_l;
+
+            // partial_output = S_exp * V where sum(S_exp) = l_c (unnormalized).
+            // Rescale by exp(m_c - global_m) to align all chunks to the same max.
+            for (ptrdiff_t i = 0; i < head_size; ++i) {
+                output_ptr[i] += rescale * chunk_output[i];
+            }
+        }
+
+        // output = sum_c(rescale_c * partial_output_c) / global_l
+        float inv_l = (global_l > 0.0f) ? (1.0f / global_l) : 0.0f;
+        for (ptrdiff_t i = 0; i < head_size; ++i) {
+            output_ptr[i] *= inv_l;
+        }
+    }
+}
+
+//
+// Decode kernel for sequence_length == 1 without KV-split (batch * heads >=
+// thread_count). Parallelizes over (batch, head); each task attends the single
+// query token to the whole KV cache with a pair of GEMVs and a two-pass softmax.
+// Decode needs no causal masking (the single new token is the most recent
+// position and attends to every cached token); only optional local-window
+// masking and additive bias are applied.
+//
+void
+MlasGQADecodeGQAThreaded(
+    void* argptr,
+    std::ptrdiff_t thread_id
+)
+{
+    const MlasFlashAttentionGQAArgs* args =
+        reinterpret_cast<MlasFlashAttentionGQAArgs*>(argptr);
+
+    const ptrdiff_t batch_size = static_cast<ptrdiff_t>(args->batch_size);
+    const ptrdiff_t num_heads = static_cast<ptrdiff_t>(args->num_heads);
+    const ptrdiff_t kv_num_heads = static_cast<ptrdiff_t>(args->kv_num_heads);
+    const ptrdiff_t total_seqlen = static_cast<ptrdiff_t>(args->total_seqlen);
+    const ptrdiff_t head_size = static_cast<ptrdiff_t>(args->head_size);
+    const ptrdiff_t local_window_size = static_cast<ptrdiff_t>(args->local_window_size);
+    const float scale = args->scale;
+
+    float* buffer = args->buffer;
+    const ptrdiff_t buffer_size_per_thread = static_cast<ptrdiff_t>(args->buffer_size_per_thread);
+    const ptrdiff_t thread_count = static_cast<ptrdiff_t>(args->thread_count);
+
+    const size_t kv_num_heads_factor = static_cast<size_t>(num_heads / kv_num_heads);
+    const size_t kv_head_stride =
+        static_cast<size_t>(args->seqlen_present_kv) * static_cast<size_t>(head_size);
+
+#if defined(MLAS_TARGET_AMD64) || defined(MLAS_TARGET_LARCH64)
+    auto&& mlas_platform = GetMlasPlatform();
+#endif
+
+    // One task per (batch, head).
+    const ptrdiff_t total_task_count = batch_size * num_heads;
+
+    ptrdiff_t task_start = 0;
+    ptrdiff_t task_end = 0;
+    ptrdiff_t quotient = total_task_count / thread_count;
+    ptrdiff_t remainder = total_task_count % thread_count;
+    if (thread_id < remainder) {
+        task_start = (quotient + 1) * thread_id;
+        task_end = task_start + quotient + 1;
+    } else {
+        task_start = quotient * thread_id + remainder;
+        task_end = task_start + quotient;
+    }
+
+    // Local-window low bound: decode can attend to KV positions [window_start, total_seqlen).
+    // causal_limit == past_seqlen + 1 == total_seqlen for the single new token.
+    const ptrdiff_t window_start =
+        (local_window_size >= 0 && total_seqlen > local_window_size) ? (total_seqlen - local_window_size) : 0;
+
+    // Per-thread scratch: scores[total_seqlen] followed by temp_output[head_size].
+    char* buffer_ptr = reinterpret_cast<char*>(buffer) + thread_id * buffer_size_per_thread;
+    float* scores = reinterpret_cast<float*>(buffer_ptr);
+    float* temp_output = scores + total_seqlen;
+
+    for (ptrdiff_t task_index = task_start; task_index < task_end; ++task_index) {
+        const ptrdiff_t head_idx = task_index % num_heads;
+        const ptrdiff_t batch_idx = task_index / num_heads;
+
+        // KV head index for GQA head sharing.
+        const size_t kv_head_idx = static_cast<size_t>(head_idx) / kv_num_heads_factor;
+        const size_t kv_batch_head_offset =
+            (static_cast<size_t>(batch_idx) * static_cast<size_t>(kv_num_heads) + kv_head_idx) *
+            kv_head_stride;
+        const float* k_cache_head = args->k_cache + kv_batch_head_offset;
+        const float* v_cache_head = args->v_cache + kv_batch_head_offset;
+
+        // Q pointer: layout [batch, num_heads, 1, head_size]; batch stride supplied
+        // separately to support packed-QKV input.
+        const float* q_ptr = args->query +
+            static_cast<size_t>(batch_idx) * args->q_batch_stride +
+            static_cast<size_t>(head_idx) * static_cast<size_t>(head_size);
+
+        // Step 1: QK^T GEMV -> scores[0..T)
+        MlasGQADecodeQK(q_ptr, k_cache_head, total_seqlen, head_size, scale, scores);
+
+        // Step 1b: additive attention bias (shape [batch|1, num_heads|1, S=1, T]).
+        if (args->attention_bias != nullptr) {
+            const ptrdiff_t bias_matrix_size =
+                static_cast<ptrdiff_t>(args->attention_bias_seqlen_stride);  // S == 1
+            const ptrdiff_t bias_head_extent =
+                args->attention_bias_broadcast_head ? 1 : static_cast<ptrdiff_t>(num_heads);
+            ptrdiff_t bias_offset = 0;
+            if (!args->attention_bias_broadcast_batch) {
+                bias_offset += static_cast<ptrdiff_t>(batch_idx) * bias_head_extent * bias_matrix_size;
+            }
+            if (!args->attention_bias_broadcast_head) {
+                bias_offset += static_cast<ptrdiff_t>(head_idx) * bias_matrix_size;
+            }
+            const float* bias_row = args->attention_bias + bias_offset;
+            for (ptrdiff_t t = 0; t < total_seqlen; ++t) {
+                scores[t] += bias_row[t];
+            }
+        }
+
+        // Step 2: local-window masking (no causal mask needed for decode).
+        if (window_start > 0) {
+            for (ptrdiff_t t = 0; t < window_start; ++t) {
+                scores[t] = std::numeric_limits<float>::lowest();
+            }
+        }
+
+        // Step 3: softmax over scores[0..T).
+#if defined(MLAS_TARGET_AMD64) || defined(MLAS_TARGET_LARCH64)
+        float rowmax = mlas_platform.ReduceMaximumF32Kernel(scores, total_seqlen);
+#else
+        float rowmax = MlasReduceMaximumF32Kernel(scores, total_seqlen);
+#endif
+
+        // Output layout: [batch, sequence_length=1, num_heads, head_size]
+        float* output_ptr = args->output +
+            (static_cast<size_t>(batch_idx) * static_cast<size_t>(num_heads) +
+             static_cast<size_t>(head_idx)) * static_cast<size_t>(head_size);
+
+        if (rowmax == std::numeric_limits<float>::lowest()) {
+            memset(output_ptr, 0, static_cast<size_t>(head_size) * sizeof(float));
+            continue;
+        }
+
+        float negmax = -rowmax;
+#if defined(MLAS_TARGET_AMD64)
+        float rowsum = mlas_platform.ComputeSumExpF32Kernel(scores, scores, total_seqlen, &negmax);
+#else
+        float rowsum = MlasComputeSumExpF32Kernel(scores, scores, total_seqlen, &negmax);
+#endif
+
+        // Step 4: S_exp * V GEMV -> temp_output, then normalize by 1/l.
+        MlasGQADecodeSV(scores, v_cache_head, total_seqlen, head_size, temp_output);
+
+        const float inv_l = (rowsum > 0.0f) ? (1.0f / rowsum) : 0.0f;
+        for (ptrdiff_t h = 0; h < head_size; ++h) {
+            output_ptr[h] = temp_output[h] * inv_l;
+        }
+    }
+}
+
 void
 MLASCALL
 MlasFlashAttentionGQA(
@@ -301,10 +775,41 @@ MlasFlashAttentionGQA(
     MLAS_THREADPOOL* ThreadPool
 )
 {
-    MlasExecuteThreaded(
-        MlasFlashAttentionGQAThreaded,
-        static_cast<void*>(args),
-        static_cast<std::ptrdiff_t>(args->thread_count),
-        ThreadPool
-    );
+    if (args->sequence_length == 1) {
+        // Decode: M = 1, use the GEMV kernels (no SGEMM packing overhead).
+        if (args->flash_decoding_partials != nullptr) {
+            // Flash decoding: two-phase approach when KV is partitioned across threads.
+            // Phase 1: parallel partial computation over (batch, head, kv_chunk).
+            MlasExecuteThreaded(
+                MlasFlashDecodingGQAThreaded,
+                static_cast<void*>(args),
+                static_cast<std::ptrdiff_t>(args->thread_count),
+                ThreadPool
+            );
+            // Phase 2: reduce partials into final output (parallel over batch*heads).
+            MlasExecuteThreaded(
+                MlasFlashDecodingGQAReduceThreaded,
+                static_cast<void*>(args),
+                static_cast<std::ptrdiff_t>(args->thread_count),
+                ThreadPool
+            );
+        } else {
+            // Single-pass decode parallelized over (batch, head).
+            MlasExecuteThreaded(
+                MlasGQADecodeGQAThreaded,
+                static_cast<void*>(args),
+                static_cast<std::ptrdiff_t>(args->thread_count),
+                ThreadPool
+            );
+        }
+    } else {
+        // Prefill (sequence_length > 1): tiled online-softmax SGEMM kernel.
+        MlasExecuteThreaded(
+            MlasFlashAttentionGQAThreaded,
+            static_cast<void*>(args),
+            static_cast<std::ptrdiff_t>(args->thread_count),
+            ThreadPool
+        );
+    }
 }
+

--- a/onnxruntime/core/mlas/lib/flashattn_gqa.cpp
+++ b/onnxruntime/core/mlas/lib/flashattn_gqa.cpp
@@ -20,8 +20,11 @@ Abstract:
     attention, additive attention bias, and an optional flash-decoding split
     over the KV sequence dimension for single-token decode.
 
-    QK^T and S*V use the single-threaded SGEMM primitive MlasSgemmOperation;
-    the outer parallelism is provided by MlasExecuteThreaded.
+    For multi-token prefill (sequence_length > 1) QK^T and S*V use the
+    single-threaded SGEMM primitive MlasSgemmOperation. For single-token decode
+    (sequence_length == 1, including the flash-decoding KV split) the M == 1
+    GEMVs use the local MlasGQADecodeQK / MlasGQADecodeSV helpers to avoid SGEMM
+    packing overhead. The outer parallelism is provided by MlasExecuteThreaded.
 
 --*/
 

--- a/onnxruntime/test/python/transformers/test_gqa_cpu.py
+++ b/onnxruntime/test/python/transformers/test_gqa_cpu.py
@@ -19,6 +19,7 @@ import numpy
 import torch
 from bert_padding import pad_input, unpad_input
 from einops import rearrange, repeat
+from env_var_helper import scoped_env_var
 from onnx import TensorProto, helper
 
 from onnxruntime import InferenceSession, OrtValue, SessionOptions
@@ -2644,6 +2645,69 @@ class TestGQA(unittest.TestCase):
             pos_ids_attn_bias,
             qk_output,
         )
+
+    def test_gqa_decode_flash_vs_naive_parity(self):
+        # The FP32 flash gate enables the dedicated GEMV decode kernel (and the
+        # flash-decoding KV-split reduction) for sequence_length == 1 with
+        # total_sequence_length > 1. Run the same decode configs against the
+        # reference twice: once with the flash path enabled (default) and once
+        # with it disabled via ORT_GQA_DISABLE_FLASH_ATTENTION=1 (naive path).
+        # If both paths match the reference, the decode kernel and KV-split
+        # reduction are correct -- including the bias and local-window cases.
+        print("-------- TEST GQA DECODE FLASH VS NAIVE PARITY ---------")
+
+        # FP32 only: the GEMV decode kernel and flash gate are float-only.
+        torch_type = torch.float32
+        numpy_type = numpy.float32
+        ort_type = TensorProto.FLOAT
+        rtol = 1e-3
+        atol = 1e-3
+
+        batches = [1, 3]
+        # (sequence_length == 1) decode. Include a long KV length so that the
+        # flash-decoding KV-split path (kv_chunk_count > 1) is exercised.
+        seqs = [(1, 128), (1, 2048)]
+        num_h = [(9, 3)]
+        h_sizes = [64, 128]
+
+        # "0" keeps the flash path enabled; "1" forces the naive path. Reseed per
+        # phase so both paths are validated against the reference on identical
+        # inputs, independent of test execution order.
+        for env_value in ["0", "1"]:
+            with scoped_env_var("ORT_GQA_DISABLE_FLASH_ATTENTION", env_value):
+                print(f"  flash {'disabled (naive path)' if env_value == '1' else 'enabled'}")
+                random.seed(69)
+                torch.manual_seed(69)
+                for b in batches:
+                    for s, s2 in seqs:
+                        for n, n2 in num_h:
+                            for h in h_sizes:
+                                for local in [False, True]:
+                                    for has_attn in [False, True]:
+                                        config = Config(
+                                            b,
+                                            s,
+                                            s2,
+                                            0,
+                                            n,
+                                            n2,
+                                            h,
+                                            False,
+                                            has_attn,
+                                            False,
+                                            QKOutputType.NO_OUTPUT,
+                                        )
+                                        all_close = parity_check_gqa_past(
+                                            config,
+                                            torch_type=torch_type,
+                                            numpy_type=numpy_type,
+                                            ort_type=ort_type,
+                                            local=local,
+                                            past_format=Formats.BNSH,
+                                            rtol=rtol,
+                                            atol=atol,
+                                        )
+                                        self.assertTrue(all_close)
 
     def test_gqa_interactive_one_batch(self):
         print("-------- TEST GQA INTERACTIVE ---------")


### PR DESCRIPTION
### Description

PR1 https://github.com/microsoft/onnxruntime/pull/28962 adds flash attention for **prefill**, and removed flash decoding. This PR will add optimized kernel for **single-token decode**, which will be faster than other kernels including flash decoding.

This PR builds on the prefill-only flash attention change and additionally introduces a dedicated decode kernel.

#### What's included
- **Decode (GEMV) kernel** — A dedicated single-token decode kernel (`MlasGQADecodeGQAThreaded`) for `sequence_length == 1`, parallelized over (batch, head) with a two-pass softmax, using GEMV (`acc[8]`-lane dot product / AXPY) helpers instead of per-block M=1 SGEMM calls. This fixes the per-block SGEMM decode regression.
- The FP32 flash gate (`group_query_attention.cc`) is enabled for `total_sequence_length > 1`, routing prefill to the tiled kernel and decode to the GEMV kernel.
- The quantized KV-cache path is unchanged (FP32-only scope).

#### Results (AMD EPYC 7763, AVX2, 8 threads)
- **Decode:** correctness ~1e-8 vs naive; long-context decode ~1.0–1.5x (T = 4097 ~1.3–1.5x).

### Motivation and Context

The naive GQA path materializes the full score matrix, which is memory-bound for long sequences. Flash attention reduces memory traffic for prefill, and the GEMV decode kernel avoids SGEMM overhead for the M=1 decode case.

### Testing

- Built with `--compile_no_warning_as_error`.
- Correctness verified against the naive path for both prefill and decode (max abs diff ~1e-8).
- Benchmarked via `benchmark_gqa_cpu_flash.py`.
