### PR TITLE
Fix incorrect string tensor creation in test

### DIFF
--- a/onnxruntime/test/shared_lib/test_nontensor_types.cc
+++ b/onnxruntime/test/shared_lib/test_nontensor_types.cc
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <array>
 #include <functional>
 #include <iostream>
 #include <set>
@@ -102,13 +103,13 @@ TEST(CApiTest, CreateGetVectorOfMapsStringFloat) {  // support zipmap output typ
   constexpr int64_t NUM_KV_PAIRS = 4;
   std::vector<Ort::Value> in;
   const char* keys_arr[NUM_KV_PAIRS] = {"abc", "def", "ghi", "jkl"};
-  std::vector<std::string> keys{keys_arr, keys_arr + NUM_KV_PAIRS};
-  std::vector<int64_t> dims = {NUM_KV_PAIRS};
-  std::vector<float> values{3.0f, 1.0f, 2.f, 0.f};
+  std::array<int64_t, 1> dims = {NUM_KV_PAIRS};
+  std::array<float, NUM_KV_PAIRS> values{3.0f, 1.0f, 2.f, 0.f};
   for (size_t i = 0; i < N; ++i) {
     // create key tensor
-    Ort::Value keys_tensor = Ort::Value::CreateTensor(info, keys.data(), keys.size() * sizeof(std::string),
-                                                      dims.data(), dims.size(), ONNX_TENSOR_ELEMENT_DATA_TYPE_STRING);
+    Ort::Value keys_tensor = Ort::Value::CreateTensor(Ort::AllocatorWithDefaultOptions(), dims.data(), dims.size(),
+                                                      ONNX_TENSOR_ELEMENT_DATA_TYPE_STRING);
+    keys_tensor.FillStringTensor(keys_arr, NUM_KV_PAIRS);
     // create value tensor
     Ort::Value values_tensor = Ort::Value::CreateTensor(info, values.data(), values.size() * sizeof(float),
                                                         dims.data(), dims.size(), ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT);
@@ -147,7 +148,7 @@ TEST(CApiTest, CreateGetVectorOfMapsStringFloat) {  // support zipmap output typ
       std::string stemp(s + start, count);
       keys_ret.insert(stemp);
     }
-    ASSERT_EQ(keys_ret, std::set<std::string>(std::begin(keys), std::end(keys)));
+    ASSERT_EQ(keys_ret, std::set<std::string>(std::begin(keys_arr), std::end(keys_arr)));
 
     // second fetch the values
     Ort::Value values_ort = map_out.GetValue(1, default_allocator.get());


### PR DESCRIPTION
This pull request refactors the `CreateGetVectorOfMapsStringFloat` test in `test_nontensor_types.cc` to improve type safety and clarity by switching from `std::vector` to `std::array` for fixed-size data and updating tensor creation logic. The changes also fix the string comparison to use the correct array.

**Test improvements and type safety:**

* Replaced `std::vector` with `std::array` for `dims` and `values` variables, making the code safer and more efficient for fixed-size data.
* Updated the creation of the string tensor by using `Ort::AllocatorWithDefaultOptions()` and filling the tensor with `FillStringTensor`, aligning with best practices for string tensor creation.

**Test correctness:**

* Fixed the assertion to compare against `keys_arr` instead of the undefined `keys` vector, ensuring the test checks the correct set of keys.

**Header inclusion:**

* Added `#include <array>` at the top of the file to support the use of `std::array`.