### PR TITLE
WebGPU: Add indirect dispatch for flash attention graph capture to support Gemma4

### DIFF
--- a/onnxruntime/contrib_ops/webgpu/bert/flash_attention.cc
+++ b/onnxruntime/contrib_ops/webgpu/bert/flash_attention.cc
@@ -160,12 +160,12 @@ Status CopyKVCacheProgram::GenerateShaderCode(ShaderHelper& shader) const {
 }
 
 Status PrepareIndirectDispatchProgram::GenerateShaderCode(ShaderHelper& shader) const {
-  shader.AddInput("seqlen_k", ShaderUsage::None);
+  shader.AddInput("total_sequence_length_input", ShaderUsage::None);
   shader.AddOutput("indirect_buffer", ShaderUsage::None);
   shader.AdditionalImplementation() << kPopulateIndirectDispatchBufferFn;
   shader.MainFunctionBody()
-      << "  let total_seq_length = u32(seqlen_k[0u]) + 1u;\n"
-      << "  let num_total_seq_length_tile = (total_seq_length + uniforms.tile_size - 1u) / uniforms.tile_size;\n"
+      << "  let global_total_seq_length = u32(total_sequence_length_input[0]);\n"
+      << "  let num_total_seq_length_tile = (global_total_seq_length + uniforms.tile_size - 1u) / uniforms.tile_size;\n"
       << "  populate_indirect_dispatch_buffer(num_total_seq_length_tile, uniforms.num_heads * uniforms.num_q_tiles, uniforms.batch_size);\n";
   return Status::OK();
 }
@@ -522,14 +522,11 @@ Status ApplyFlashAttention(const Tensor* Q, const Tensor* K, const Tensor* V, co
   Tensor* indirect_buffer_ptr = nullptr;
   Tensor indirect_buffer;
 
-  // Prepare indirect dispatch buffer for split-reduce path when CPU-side
-  // total_sequence_length is unusable for dispatch sizing:
-  //   - past_present_share_buffer layers: when graph capture is enabled,
-  //     total_sequence_length_ may be 0 (GPU-based seqlen_k), so the indirect
-  //     buffer computes dispatch sizes on GPU. Static KV cache (past_present_share_buffer_)
-  //     is guaranteed by GQA's ORT_ENFORCE when graph capture is enabled.
-  //   - kv_empty layers: no KV tokens are appended, so total_sequence_length_ is always 0;
-  //     using it directly would produce dispatch(0) and skip attention entirely.
+  // Prepare indirect dispatch buffer for split-reduce path with static KV cache.
+  // When graph capture is enabled, total_sequence_length_ may be 0 (GPU-based
+  // seqlen_k), so the indirect buffer computes dispatch sizes on GPU.
+  // Static KV cache (past_present_share_buffer_) is guaranteed by GQA's
+  // ORT_ENFORCE when graph capture is enabled.
   const bool use_indirect_dispatch = seqlen_k != nullptr &&
                                      total_seqlen != nullptr &&
                                      context.IsGraphCaptureEnabled();
@@ -562,11 +559,13 @@ Status ApplyFlashAttention(const Tensor* Q, const Tensor* K, const Tensor* V, co
       present_value = const_cast<Tensor*>(past_value);
     }
 
-    // CopyKVCache normally prepares the indirect buffer. Since we skip CopyKVCache
-    // for kv_empty layers, we must prepare it here.
+    // CopyKVCache normally prepares the indirect dispatch buffer. For kv_empty layers
+    // CopyKVCache is skipped, so we prepare it here. Only needed under graph capture
+    // because that is when total_seqlen is GPU-resident and CPU-side dispatch sizing
+    // is unavailable.
     if (use_indirect_dispatch) {
       PrepareIndirectDispatchProgram program;
-      program.AddInput({seqlen_k, ProgramTensorMetadataDependency::None});
+      program.AddInput({total_seqlen, ProgramTensorMetadataDependency::None});
       program.AddOutput({indirect_buffer_ptr, ProgramTensorMetadataDependency::None});
       program.SetDispatchGroupSize(1)
           .SetWorkgroupSize(1)

--- a/onnxruntime/contrib_ops/webgpu/bert/flash_attention.cc
+++ b/onnxruntime/contrib_ops/webgpu/bert/flash_attention.cc
@@ -52,14 +52,14 @@ fn populate_indirect_dispatch_buffer(x: u32, y: u32, z: u32) {
 }
 )";
 
-// Emits kNormalizeDispatchGroupSizeFn into AdditionalImplementation and appends the two
-// WGSL lines that compute num_total_seq_length_tile and call normalize_dispatch_group_size.
+// Emits kPopulateIndirectDispatchBufferFn into AdditionalImplementation and appends the two
+// WGSL lines that compute num_total_seq_length_tile and call populate_indirect_dispatch_buffer.
 // `total_seq_len_expr` is the WGSL expression that evaluates to the total sequence length.
 static void AppendNormalizeDispatchShader(ShaderHelper& shader, std::string_view total_seq_len_expr) {
-  shader.AdditionalImplementation() << kNormalizeDispatchGroupSizeFn;
+  shader.AdditionalImplementation() << kPopulateIndirectDispatchBufferFn;
   shader.MainFunctionBody()
       << "  let num_total_seq_length_tile = (" << total_seq_len_expr << " + uniforms.tile_size - 1u) / uniforms.tile_size;\n"
-      << "  normalize_dispatch_group_size(num_total_seq_length_tile, uniforms.num_heads * uniforms.num_q_tiles, uniforms.batch_size);\n";
+      << "  populate_indirect_dispatch_buffer(num_total_seq_length_tile, uniforms.num_heads * uniforms.num_q_tiles, uniforms.batch_size);\n";
 }
 
 Status SplitPackedQKVWithRotaryEmbeddingAndCopyKVProgram::GenerateShaderCode(ShaderHelper& sh) const {

--- a/onnxruntime/contrib_ops/webgpu/bert/flash_attention.cc
+++ b/onnxruntime/contrib_ops/webgpu/bert/flash_attention.cc
@@ -52,16 +52,6 @@ fn populate_indirect_dispatch_buffer(x: u32, y: u32, z: u32) {
 }
 )";
 
-// Emits kPopulateIndirectDispatchBufferFn into AdditionalImplementation and appends the two
-// WGSL lines that compute num_total_seq_length_tile and call populate_indirect_dispatch_buffer.
-// `total_seq_len_expr` is the WGSL expression that evaluates to the total sequence length.
-static void AppendPopulateIndirectDispatchShader(ShaderHelper& shader, std::string_view total_seq_len_expr) {
-  shader.AdditionalImplementation() << kPopulateIndirectDispatchBufferFn;
-  shader.MainFunctionBody()
-      << "  let num_total_seq_length_tile = (" << total_seq_len_expr << " + uniforms.tile_size - 1u) / uniforms.tile_size;\n"
-      << "  populate_indirect_dispatch_buffer(num_total_seq_length_tile, uniforms.num_heads * uniforms.num_q_tiles, uniforms.batch_size);\n";
-}
-
 Status SplitPackedQKVWithRotaryEmbeddingAndCopyKVProgram::GenerateShaderCode(ShaderHelper& sh) const {
   const auto& packed_qkv = sh.AddInput("packed_qkv", ShaderUsage::UseUniform);
   const auto& seqlens = sh.AddInput("seqlens", ShaderUsage::UseUniform);
@@ -172,8 +162,11 @@ Status CopyKVCacheProgram::GenerateShaderCode(ShaderHelper& shader) const {
 Status PrepareIndirectDispatchProgram::GenerateShaderCode(ShaderHelper& shader) const {
   shader.AddInput("seqlen_k", ShaderUsage::None);
   shader.AddOutput("indirect_buffer", ShaderUsage::None);
-  shader.MainFunctionBody() << "  let total_seq_length = u32(seqlen_k[0u]) + 1u;\n";
-  AppendPopulateIndirectDispatchShader(shader, "total_seq_length");
+  shader.AdditionalImplementation() << kPopulateIndirectDispatchBufferFn;
+  shader.MainFunctionBody()
+      << "  let total_seq_length = u32(seqlen_k[0u]) + 1u;\n"
+      << "  let num_total_seq_length_tile = (total_seq_length + uniforms.tile_size - 1u) / uniforms.tile_size;\n"
+      << "  populate_indirect_dispatch_buffer(num_total_seq_length_tile, uniforms.num_heads * uniforms.num_q_tiles, uniforms.batch_size);\n";
   return Status::OK();
 }
 

--- a/onnxruntime/contrib_ops/webgpu/bert/flash_attention.cc
+++ b/onnxruntime/contrib_ops/webgpu/bert/flash_attention.cc
@@ -529,10 +529,12 @@ Status ApplyFlashAttention(const Tensor* Q, const Tensor* K, const Tensor* V, co
   Tensor* indirect_buffer_ptr = nullptr;
   Tensor indirect_buffer;
 
-  // Prepare indirect dispatch buffer for the split-reduce path when the CPU-side
+  // Prepare indirect dispatch buffer for split-reduce path when CPU-side
   // total_sequence_length is unusable for dispatch sizing:
-  //   - past_present_share_buffer layers: graph capture keeps seqlen_k GPU-resident, so
-  //     total_sequence_length_ is 0 on CPU and the true value must be read from the GPU tensor.
+  //   - past_present_share_buffer layers: when graph capture is enabled,
+  //     total_sequence_length_ may be 0 (GPU-based seqlen_k), so the indirect
+  //     buffer computes dispatch sizes on GPU. Static KV cache (past_present_share_buffer_)
+  //     is guaranteed by GQA's ORT_ENFORCE when graph capture is enabled.
   //   - kv_empty layers: no KV tokens are appended, so total_sequence_length_ is always 0;
   //     using it directly would produce dispatch(0) and skip attention entirely.
   const bool use_indirect_dispatch = seqlen_k != nullptr &&

--- a/onnxruntime/contrib_ops/webgpu/bert/flash_attention.cc
+++ b/onnxruntime/contrib_ops/webgpu/bert/flash_attention.cc
@@ -52,6 +52,16 @@ fn populate_indirect_dispatch_buffer(x: u32, y: u32, z: u32) {
 }
 )";
 
+// Emits kNormalizeDispatchGroupSizeFn into AdditionalImplementation and appends the two
+// WGSL lines that compute num_total_seq_length_tile and call normalize_dispatch_group_size.
+// `total_seq_len_expr` is the WGSL expression that evaluates to the total sequence length.
+static void AppendNormalizeDispatchShader(ShaderHelper& shader, std::string_view total_seq_len_expr) {
+  shader.AdditionalImplementation() << kNormalizeDispatchGroupSizeFn;
+  shader.MainFunctionBody()
+      << "  let num_total_seq_length_tile = (" << total_seq_len_expr << " + uniforms.tile_size - 1u) / uniforms.tile_size;\n"
+      << "  normalize_dispatch_group_size(num_total_seq_length_tile, uniforms.num_heads * uniforms.num_q_tiles, uniforms.batch_size);\n";
+}
+
 Status SplitPackedQKVWithRotaryEmbeddingAndCopyKVProgram::GenerateShaderCode(ShaderHelper& sh) const {
   const auto& packed_qkv = sh.AddInput("packed_qkv", ShaderUsage::UseUniform);
   const auto& seqlens = sh.AddInput("seqlens", ShaderUsage::UseUniform);
@@ -162,10 +172,8 @@ Status CopyKVCacheProgram::GenerateShaderCode(ShaderHelper& shader) const {
 Status PrepareIndirectDispatchProgram::GenerateShaderCode(ShaderHelper& shader) const {
   shader.AddInput("seqlen_k", ShaderUsage::None);
   shader.AddOutput("indirect_buffer", ShaderUsage::None);
-  shader.AdditionalImplementation() << kNormalizeDispatchGroupSizeFn;
-  shader.MainFunctionBody() << "  let total_seq_length = u32(seqlen_k[0u]) + 1u;\n"
-                            << "  let num_total_seq_length_tile = (total_seq_length + uniforms.tile_size - 1u) / uniforms.tile_size;\n"
-                            << "  normalize_dispatch_group_size(num_total_seq_length_tile, uniforms.num_heads * uniforms.num_q_tiles, uniforms.batch_size);\n";
+  shader.MainFunctionBody() << "  let total_seq_length = u32(seqlen_k[0u]) + 1u;\n";
+  AppendNormalizeDispatchShader(shader, "total_seq_length");
   return Status::OK();
 }
 

--- a/onnxruntime/contrib_ops/webgpu/bert/flash_attention.cc
+++ b/onnxruntime/contrib_ops/webgpu/bert/flash_attention.cc
@@ -159,6 +159,16 @@ Status CopyKVCacheProgram::GenerateShaderCode(ShaderHelper& shader) const {
   return Status::OK();
 }
 
+Status PrepareIndirectDispatchProgram::GenerateShaderCode(ShaderHelper& shader) const {
+  shader.AddInput("seqlen_k", ShaderUsage::None);
+  shader.AddOutput("indirect_buffer", ShaderUsage::None);
+  shader.AdditionalImplementation() << kNormalizeDispatchGroupSizeFn;
+  shader.MainFunctionBody() << "  let total_seq_length = u32(seqlen_k[0u]) + 1u;\n"
+                            << "  let num_total_seq_length_tile = (total_seq_length + uniforms.tile_size - 1u) / uniforms.tile_size;\n"
+                            << "  normalize_dispatch_group_size(num_total_seq_length_tile, uniforms.num_heads * uniforms.num_q_tiles, uniforms.batch_size);\n";
+  return Status::OK();
+}
+
 Status CopyKVCache(onnxruntime::webgpu::ComputeContext& context, const WebgpuAttentionParameters& parameters,
                    const Tensor* K, const Tensor* past_key, Tensor* present_key,
                    const Tensor* V, const Tensor* past_value, Tensor* present_value,
@@ -511,11 +521,12 @@ Status ApplyFlashAttention(const Tensor* Q, const Tensor* K, const Tensor* V, co
   Tensor* indirect_buffer_ptr = nullptr;
   Tensor indirect_buffer;
 
-  // Prepare indirect dispatch buffer for split-reduce path with static KV cache.
-  // When graph capture is enabled, total_sequence_length_ may be 0 (GPU-based
-  // seqlen_k), so the indirect buffer computes dispatch sizes on GPU.
-  // Static KV cache (past_present_share_buffer_) is guaranteed by GQA's
-  // ORT_ENFORCE when graph capture is enabled.
+  // Prepare indirect dispatch buffer for the split-reduce path when the CPU-side
+  // total_sequence_length is unusable for dispatch sizing:
+  //   - past_present_share_buffer layers: graph capture keeps seqlen_k GPU-resident, so
+  //     total_sequence_length_ is 0 on CPU and the true value must be read from the GPU tensor.
+  //   - kv_empty layers: no KV tokens are appended, so total_sequence_length_ is always 0;
+  //     using it directly would produce dispatch(0) and skip attention entirely.
   const bool use_indirect_dispatch = seqlen_k != nullptr &&
                                      total_seqlen != nullptr &&
                                      context.IsGraphCaptureEnabled();
@@ -546,6 +557,21 @@ Status ApplyFlashAttention(const Tensor* Q, const Tensor* K, const Tensor* V, co
       // and CopyKVCache is skipped when kv_empty, so no writes occur through these pointers.
       present_key = const_cast<Tensor*>(past_key);
       present_value = const_cast<Tensor*>(past_value);
+    }
+
+    // CopyKVCache normally prepares the indirect buffer. Since we skip CopyKVCache
+    // for kv_empty layers, we must prepare it here.
+    if (use_indirect_dispatch) {
+      PrepareIndirectDispatchProgram program;
+      program.AddInput({seqlen_k, ProgramTensorMetadataDependency::None});
+      program.AddOutput({indirect_buffer_ptr, ProgramTensorMetadataDependency::None});
+      program.SetDispatchGroupSize(1)
+          .SetWorkgroupSize(1)
+          .AddUniformVariables({{tile_size},
+                                {static_cast<uint32_t>(parameters.num_heads_)},
+                                {num_q_tiles},
+                                {static_cast<uint32_t>(parameters.batch_size_)}});
+      ORT_RETURN_IF_ERROR(context.RunProgram(program));
     }
   }
 

--- a/onnxruntime/contrib_ops/webgpu/bert/flash_attention.cc
+++ b/onnxruntime/contrib_ops/webgpu/bert/flash_attention.cc
@@ -55,7 +55,7 @@ fn populate_indirect_dispatch_buffer(x: u32, y: u32, z: u32) {
 // Emits kPopulateIndirectDispatchBufferFn into AdditionalImplementation and appends the two
 // WGSL lines that compute num_total_seq_length_tile and call populate_indirect_dispatch_buffer.
 // `total_seq_len_expr` is the WGSL expression that evaluates to the total sequence length.
-static void AppendNormalizeDispatchShader(ShaderHelper& shader, std::string_view total_seq_len_expr) {
+static void AppendPopulateIndirectDispatchShader(ShaderHelper& shader, std::string_view total_seq_len_expr) {
   shader.AdditionalImplementation() << kPopulateIndirectDispatchBufferFn;
   shader.MainFunctionBody()
       << "  let num_total_seq_length_tile = (" << total_seq_len_expr << " + uniforms.tile_size - 1u) / uniforms.tile_size;\n"
@@ -173,7 +173,7 @@ Status PrepareIndirectDispatchProgram::GenerateShaderCode(ShaderHelper& shader) 
   shader.AddInput("seqlen_k", ShaderUsage::None);
   shader.AddOutput("indirect_buffer", ShaderUsage::None);
   shader.MainFunctionBody() << "  let total_seq_length = u32(seqlen_k[0u]) + 1u;\n";
-  AppendNormalizeDispatchShader(shader, "total_seq_length");
+  AppendPopulateIndirectDispatchShader(shader, "total_seq_length");
   return Status::OK();
 }
 

--- a/onnxruntime/contrib_ops/webgpu/bert/flash_attention.h
+++ b/onnxruntime/contrib_ops/webgpu/bert/flash_attention.h
@@ -70,6 +70,20 @@ class CopyKVCacheProgram final : public Program<CopyKVCacheProgram> {
   bool use_seqlen_k_;
 };
 
+class PrepareIndirectDispatchProgram final : public Program<PrepareIndirectDispatchProgram> {
+ public:
+  PrepareIndirectDispatchProgram()
+      : Program{"PrepareIndirectDispatch"} {}
+
+  Status GenerateShaderCode(ShaderHelper& sh) const override;
+
+  WEBGPU_PROGRAM_DEFINE_UNIFORM_VARIABLES(
+      {"tile_size", ProgramUniformVariableDataType::Uint32},
+      {"num_heads", ProgramUniformVariableDataType::Uint32},
+      {"num_q_tiles", ProgramUniformVariableDataType::Uint32},
+      {"batch_size", ProgramUniformVariableDataType::Uint32});
+};
+
 class FlashAttentionProgram final : public Program<FlashAttentionProgram> {
  public:
   FlashAttentionProgram(const std::string& kernel_name,

--- a/onnxruntime/contrib_ops/webgpu/bert/group_query_attention.cc
+++ b/onnxruntime/contrib_ops/webgpu/bert/group_query_attention.cc
@@ -353,7 +353,13 @@ Status GroupQueryAttention::ComputeInternal(onnxruntime::webgpu::ComputeContext&
                                           past_value->DataRaw() == present_value->DataRaw();
 
   ORT_ENFORCE(parameters.total_sequence_length_ <= parameters.seqlen_present_kv_cache_, "Total sequence length cannot be greater than the existing KV cache length.");
-  ORT_ENFORCE(!context.IsGraphCaptureEnabled() || parameters.past_present_share_buffer_,
+  // kv_sequence_length==0 fast path: K/V inputs are empty (shared KV layer).
+  // Skip all K/V processing; only apply RoPE to Q if needed.
+  // Use past_key/past_value directly as the KV context.
+  const bool kv_empty = (parameters.kv_sequence_length_ == 0);
+  // kv_empty layers (e.g. Gemma4 layers 15-34) reuse KV from another layer so
+  // past/present cannot share the same buffer — exempt them from this check.
+  ORT_ENFORCE(!context.IsGraphCaptureEnabled() || kv_empty || parameters.past_present_share_buffer_,
               "Graph capture requires past/present KV cache to share the same buffer (static KV cache).");
 
   Tensor qSplit;
@@ -362,11 +368,6 @@ Status GroupQueryAttention::ComputeInternal(onnxruntime::webgpu::ComputeContext&
 
   Tensor qRotary;
   Tensor kRotary;
-
-  // kv_sequence_length==0 fast path: K/V inputs are empty (shared KV layer).
-  // Skip all K/V processing; only apply RoPE to Q if needed.
-  // Use past_key/past_value directly as the KV context.
-  const bool kv_empty = (parameters.kv_sequence_length_ == 0);
 
   // Use a sliding window if the total sequence exceeds the window's length.
   bool use_sliding_window = (local_window_size_ != -1 && local_window_size_ < parameters.total_sequence_length_);

--- a/onnxruntime/test/contrib_ops/group_query_attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/group_query_attention_op_test.cc
@@ -15,6 +15,7 @@
 #include "test/util/include/default_providers.h"
 #ifdef USE_WEBGPU
 #include "core/providers/webgpu/webgpu_provider_options.h"
+#include "core/session/onnxruntime_run_options_config_keys.h"
 #endif
 
 namespace onnxruntime {
@@ -3160,77 +3161,15 @@ TEST(GroupQueryAttentionTest, WebGPU_TurboQuant_RejectsNonPowerOf2HeadSize) {
              {}, nullptr, &execution_providers);
 }
 
-// ---------------------------------------------------------------------------
-// kv_empty WebGPU tests
-//
 // kv_empty is triggered when key/value have sequence_length=0 (Gemma4 shared-KV
-// layers where KV is reused from another layer's cache). The WebGPU kernel
-// aliases present to past and runs flash attention directly against past_key/value.
-// Correctness is verified by cross-checking against the CPU reference path.
-// ---------------------------------------------------------------------------
-
-// WebGPU: kv_empty decode (q_seq=1, past_seq=8).
-// Exercises the kv_empty branch in ApplyFlashAttention for a short past.
-TEST(GroupQueryAttentionTest, WebGPU_SharedKV_KvEmpty_Decode) {
-  auto webgpu_ep = DefaultWebGpuExecutionProvider();
-  if (!webgpu_ep) {
-    GTEST_SKIP() << "WebGPU EP not available";
-  }
-
-  constexpr int batch_size = 1;
-  constexpr int q_seq_len = 1;
-  constexpr int past_seq_len = 8;
-  constexpr int num_heads = 2;
-  constexpr int kv_num_heads = 1;
-  constexpr int head_size = 8;
-  constexpr int hidden_size = num_heads * head_size;
-  constexpr int kv_hidden_size = kv_num_heads * head_size;
-
-  std::vector<float> query_data(batch_size * q_seq_len * hidden_size);
-  std::vector<float> past_key_data(batch_size * kv_num_heads * past_seq_len * head_size);
-  std::vector<float> past_value_data(batch_size * kv_num_heads * past_seq_len * head_size);
-  for (size_t i = 0; i < query_data.size(); i++) query_data[i] = 0.1f * static_cast<float>(i % 7 + 1);
-  for (size_t i = 0; i < past_key_data.size(); i++) past_key_data[i] = 0.2f * static_cast<float>(i % 5 + 1);
-  for (size_t i = 0; i < past_value_data.size(); i++) past_value_data[i] = 0.3f * static_cast<float>(i % 3 + 1);
-
-  // WebGPU run: kv_empty path — present is aliased to past, flash attention
-  // runs directly against past_key/value.
-  OpTester webgpu_tester("GroupQueryAttention", 1, onnxruntime::kMSDomain);
-  webgpu_tester.AddAttribute<int64_t>("num_heads", static_cast<int64_t>(num_heads));
-  webgpu_tester.AddAttribute<int64_t>("kv_num_heads", static_cast<int64_t>(kv_num_heads));
-  webgpu_tester.AddInput<float>("query", {batch_size, q_seq_len, hidden_size}, query_data);
-  webgpu_tester.AddInput<float>("key", {batch_size, 0, kv_hidden_size}, {});    // kv_empty
-  webgpu_tester.AddInput<float>("value", {batch_size, 0, kv_hidden_size}, {});  // kv_empty
-  webgpu_tester.AddInput<float>("past_key", {batch_size, kv_num_heads, past_seq_len, head_size}, past_key_data);
-  webgpu_tester.AddInput<float>("past_value", {batch_size, kv_num_heads, past_seq_len, head_size}, past_value_data);
-  webgpu_tester.AddInput<int32_t>("seqlens_k", {batch_size}, {static_cast<int32_t>(past_seq_len - 1)});
-  webgpu_tester.AddInput<int32_t>("total_sequence_length", {1}, {past_seq_len});
-  webgpu_tester.AddOptionalInputEdge<float>();    // cos_cache
-  webgpu_tester.AddOptionalInputEdge<float>();    // sin_cache
-  webgpu_tester.AddOptionalInputEdge<int64_t>();  // position_ids
-  webgpu_tester.AddOptionalInputEdge<float>();    // attention_bias
-  webgpu_tester.AddOptionalInputEdge<float>();    // head_sink
-  const int output_size = batch_size * q_seq_len * hidden_size;
-  webgpu_tester.AddOutput<float>("output", {batch_size, q_seq_len, hidden_size}, std::vector<float>(output_size, 0.0f));
-  webgpu_tester.SetOutputTolerance(1e6f);
-  std::vector<std::unique_ptr<IExecutionProvider>> webgpu_eps;
-  webgpu_eps.push_back(std::move(webgpu_ep));
-  webgpu_tester.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &webgpu_eps);
-  const float* webgpu_out = webgpu_tester.GetFetches()[0].Get<Tensor>().Data<float>();
-  std::vector<float> webgpu_output(webgpu_out, webgpu_out + output_size);
-
-  // CPU reference: use real total_sequence_length so CPU path is correct.
-  auto cpu_output = RunGQASharedKV(
-      batch_size, q_seq_len, past_seq_len, query_data, past_key_data, past_value_data,
-      num_heads, kv_num_heads, head_size, GqaTargetEp::kCpu);
-
-  ExpectOutputsMatch(webgpu_output, cpu_output, 0.05f, "SharedKV_KvEmpty_Decode_WebGPU_vs_CPU");
-}
-
-// WebGPU: kv_empty decode with larger past (past_seq=32, exercises tile boundary).
-// past_seq_len=32 crosses the tile size threshold, exercising multi-tile flash attention.
-TEST(GroupQueryAttentionTest, WebGPU_SharedKV_KvEmpty_LargerPast) {
-  auto webgpu_ep = DefaultWebGpuExecutionProvider();
+// layers where KV is reused from another layer's cache). Under graph capture,
+// total_seqlen is GPU-resident so dispatch sizes must be computed on GPU via
+// PrepareIndirectDispatchProgram.
+TEST(GroupQueryAttentionTest, WebGPU_SharedKVLayers_IndirectDispatchForGraphCapture) {
+  ConfigOptions config_options{};
+  ORT_THROW_IF_ERROR(config_options.AddConfigEntry(webgpu::options::kEnableGraphCapture,
+                                                   webgpu::options::kEnableGraphCapture_ON));
+  auto webgpu_ep = WebGpuExecutionProviderWithOptions(config_options);
   if (!webgpu_ep) {
     GTEST_SKIP() << "WebGPU EP not available";
   }
@@ -3269,9 +3208,13 @@ TEST(GroupQueryAttentionTest, WebGPU_SharedKV_KvEmpty_LargerPast) {
   const int output_size = batch_size * q_seq_len * hidden_size;
   webgpu_tester.AddOutput<float>("output", {batch_size, q_seq_len, hidden_size}, std::vector<float>(output_size, 0.0f));
   webgpu_tester.SetOutputTolerance(1e6f);
+  // gpu_graph_id=-1 keeps IsGraphCaptureEnabled()=true (exercising the indirect dispatch
+  // code path) without triggering actual Dawn command capture/replay.
+  RunOptions run_options;
+  ORT_THROW_IF_ERROR(run_options.config_options.AddConfigEntry(kOrtRunOptionsConfigCudaGraphAnnotation, "-1"));
   std::vector<std::unique_ptr<IExecutionProvider>> webgpu_eps;
   webgpu_eps.push_back(std::move(webgpu_ep));
-  webgpu_tester.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &webgpu_eps);
+  webgpu_tester.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, &run_options, &webgpu_eps);
   const float* webgpu_out = webgpu_tester.GetFetches()[0].Get<Tensor>().Data<float>();
   std::vector<float> webgpu_output(webgpu_out, webgpu_out + output_size);
 
@@ -3279,7 +3222,7 @@ TEST(GroupQueryAttentionTest, WebGPU_SharedKV_KvEmpty_LargerPast) {
       batch_size, q_seq_len, past_seq_len, query_data, past_key_data, past_value_data,
       num_heads, kv_num_heads, head_size, GqaTargetEp::kCpu);
 
-  ExpectOutputsMatch(webgpu_output, cpu_output, 0.05f, "SharedKV_KvEmpty_LargerPast_WebGPU_vs_CPU");
+  ExpectOutputsMatch(webgpu_output, cpu_output, 0.05f, "SharedKVLayers_IndirectDispatchForGraphCapture_vs_CPU");
 }
 
 // --- Success paths: TurboQuant with flash attention at various K sizes ---

--- a/onnxruntime/test/contrib_ops/group_query_attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/group_query_attention_op_test.cc
@@ -3228,7 +3228,7 @@ TEST(GroupQueryAttentionTest, WebGPU_SharedKV_IndirectDispatch_Decode) {
   // CPU reference: use real total_sequence_length so CPU path is correct.
   auto cpu_output = RunGQASharedKV(
       batch_size, q_seq_len, past_seq_len, query_data, past_key_data, past_value_data,
-      num_heads, kv_num_heads, head_size, /*use_cuda=*/false, /*use_webgpu=*/false);
+      num_heads, kv_num_heads, head_size, GqaTargetEp::kCpu);
 
   ExpectOutputsMatch(webgpu_output, cpu_output, 0.05f, "SharedKV_IndirectDispatch_Decode_WebGPU_vs_CPU");
 }
@@ -3287,7 +3287,7 @@ TEST(GroupQueryAttentionTest, WebGPU_SharedKV_IndirectDispatch_LargerPast) {
 
   auto cpu_output = RunGQASharedKV(
       batch_size, q_seq_len, past_seq_len, query_data, past_key_data, past_value_data,
-      num_heads, kv_num_heads, head_size, /*use_cuda=*/false, /*use_webgpu=*/false);
+      num_heads, kv_num_heads, head_size, GqaTargetEp::kCpu);
 
   ExpectOutputsMatch(webgpu_output, cpu_output, 0.05f, "SharedKV_IndirectDispatch_LargerPast_WebGPU_vs_CPU");
 }

--- a/onnxruntime/test/contrib_ops/group_query_attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/group_query_attention_op_test.cc
@@ -3161,19 +3161,17 @@ TEST(GroupQueryAttentionTest, WebGPU_TurboQuant_RejectsNonPowerOf2HeadSize) {
 }
 
 // ---------------------------------------------------------------------------
-// Indirect dispatch tests (PrepareIndirectDispatchProgram)
+// kv_empty WebGPU tests
 //
-// These tests pass total_sequence_length=0 to trigger the kv_empty indirect
-// dispatch path: use_seqlen_k=true so seqlen_k tensor is used on the GPU, and
-// use_indirect_dispatch=true so PrepareIndirectDispatchProgram sizes the flash-
-// attention dispatch from the GPU-resident seqlen_k value instead of the zero
-// CPU value. Correctness is verified by cross-checking against CPU with the
-// real total.
+// kv_empty is triggered when key/value have sequence_length=0 (Gemma4 shared-KV
+// layers where KV is reused from another layer's cache). The WebGPU kernel
+// aliases present to past and runs flash attention directly against past_key/value.
+// Correctness is verified by cross-checking against the CPU reference path.
 // ---------------------------------------------------------------------------
 
-// WebGPU: kv_empty + total_sequence_length=0, decode (q_seq=1).
-// Exercises PrepareIndirectDispatchProgram for the kv_empty indirect dispatch path.
-TEST(GroupQueryAttentionTest, WebGPU_SharedKV_IndirectDispatch_Decode) {
+// WebGPU: kv_empty decode (q_seq=1, past_seq=8).
+// Exercises the kv_empty branch in ApplyFlashAttention for a short past.
+TEST(GroupQueryAttentionTest, WebGPU_SharedKV_KvEmpty_Decode) {
   auto webgpu_ep = DefaultWebGpuExecutionProvider();
   if (!webgpu_ep) {
     GTEST_SKIP() << "WebGPU EP not available";
@@ -3195,24 +3193,23 @@ TEST(GroupQueryAttentionTest, WebGPU_SharedKV_IndirectDispatch_Decode) {
   for (size_t i = 0; i < past_key_data.size(); i++) past_key_data[i] = 0.2f * static_cast<float>(i % 5 + 1);
   for (size_t i = 0; i < past_value_data.size(); i++) past_value_data[i] = 0.3f * static_cast<float>(i % 3 + 1);
 
-  // WebGPU run: total_sequence_length=0 forces use_seqlen_k=true and
-  // use_indirect_dispatch=true; PrepareIndirectDispatchProgram sizes the
-  // dispatch from seqlen_k[0] on the GPU rather than the zero CPU value.
+  // WebGPU run: kv_empty path — present is aliased to past, flash attention
+  // runs directly against past_key/value.
   OpTester webgpu_tester("GroupQueryAttention", 1, onnxruntime::kMSDomain);
   webgpu_tester.AddAttribute<int64_t>("num_heads", static_cast<int64_t>(num_heads));
   webgpu_tester.AddAttribute<int64_t>("kv_num_heads", static_cast<int64_t>(kv_num_heads));
   webgpu_tester.AddInput<float>("query", {batch_size, q_seq_len, hidden_size}, query_data);
-  webgpu_tester.AddInput<float>("key", {batch_size, 0, kv_hidden_size}, {});
-  webgpu_tester.AddInput<float>("value", {batch_size, 0, kv_hidden_size}, {});
+  webgpu_tester.AddInput<float>("key", {batch_size, 0, kv_hidden_size}, {});    // kv_empty
+  webgpu_tester.AddInput<float>("value", {batch_size, 0, kv_hidden_size}, {});  // kv_empty
   webgpu_tester.AddInput<float>("past_key", {batch_size, kv_num_heads, past_seq_len, head_size}, past_key_data);
   webgpu_tester.AddInput<float>("past_value", {batch_size, kv_num_heads, past_seq_len, head_size}, past_value_data);
   webgpu_tester.AddInput<int32_t>("seqlens_k", {batch_size}, {static_cast<int32_t>(past_seq_len - 1)});
-  webgpu_tester.AddInput<int32_t>("total_sequence_length", {1}, {0});  // 0 → indirect dispatch path
-  webgpu_tester.AddOptionalInputEdge<float>();                         // cos_cache
-  webgpu_tester.AddOptionalInputEdge<float>();                         // sin_cache
-  webgpu_tester.AddOptionalInputEdge<int64_t>();                       // position_ids
-  webgpu_tester.AddOptionalInputEdge<float>();                         // attention_bias
-  webgpu_tester.AddOptionalInputEdge<float>();                         // head_sink
+  webgpu_tester.AddInput<int32_t>("total_sequence_length", {1}, {past_seq_len});
+  webgpu_tester.AddOptionalInputEdge<float>();    // cos_cache
+  webgpu_tester.AddOptionalInputEdge<float>();    // sin_cache
+  webgpu_tester.AddOptionalInputEdge<int64_t>();  // position_ids
+  webgpu_tester.AddOptionalInputEdge<float>();    // attention_bias
+  webgpu_tester.AddOptionalInputEdge<float>();    // head_sink
   const int output_size = batch_size * q_seq_len * hidden_size;
   const int present_size = batch_size * kv_num_heads * past_seq_len * head_size;
   webgpu_tester.AddOutput<float>("output", {batch_size, q_seq_len, hidden_size}, std::vector<float>(output_size, 0.0f));
@@ -3230,13 +3227,12 @@ TEST(GroupQueryAttentionTest, WebGPU_SharedKV_IndirectDispatch_Decode) {
       batch_size, q_seq_len, past_seq_len, query_data, past_key_data, past_value_data,
       num_heads, kv_num_heads, head_size, GqaTargetEp::kCpu);
 
-  ExpectOutputsMatch(webgpu_output, cpu_output, 0.05f, "SharedKV_IndirectDispatch_Decode_WebGPU_vs_CPU");
+  ExpectOutputsMatch(webgpu_output, cpu_output, 0.05f, "SharedKV_KvEmpty_Decode_WebGPU_vs_CPU");
 }
 
-// WebGPU: kv_empty + total_sequence_length=0, larger past (exercises tile boundary).
-// past_seq_len=32 ensures num_total_seq_length_tile > 1, validating the tile
-// count arithmetic in PrepareIndirectDispatchProgram more thoroughly.
-TEST(GroupQueryAttentionTest, WebGPU_SharedKV_IndirectDispatch_LargerPast) {
+// WebGPU: kv_empty decode with larger past (past_seq=32, exercises tile boundary).
+// past_seq_len=32 crosses the tile size threshold, exercising multi-tile flash attention.
+TEST(GroupQueryAttentionTest, WebGPU_SharedKV_KvEmpty_LargerPast) {
   auto webgpu_ep = DefaultWebGpuExecutionProvider();
   if (!webgpu_ep) {
     GTEST_SKIP() << "WebGPU EP not available";
@@ -3262,17 +3258,17 @@ TEST(GroupQueryAttentionTest, WebGPU_SharedKV_IndirectDispatch_LargerPast) {
   webgpu_tester.AddAttribute<int64_t>("num_heads", static_cast<int64_t>(num_heads));
   webgpu_tester.AddAttribute<int64_t>("kv_num_heads", static_cast<int64_t>(kv_num_heads));
   webgpu_tester.AddInput<float>("query", {batch_size, q_seq_len, hidden_size}, query_data);
-  webgpu_tester.AddInput<float>("key", {batch_size, 0, kv_hidden_size}, {});
-  webgpu_tester.AddInput<float>("value", {batch_size, 0, kv_hidden_size}, {});
+  webgpu_tester.AddInput<float>("key", {batch_size, 0, kv_hidden_size}, {});    // kv_empty
+  webgpu_tester.AddInput<float>("value", {batch_size, 0, kv_hidden_size}, {});  // kv_empty
   webgpu_tester.AddInput<float>("past_key", {batch_size, kv_num_heads, past_seq_len, head_size}, past_key_data);
   webgpu_tester.AddInput<float>("past_value", {batch_size, kv_num_heads, past_seq_len, head_size}, past_value_data);
   webgpu_tester.AddInput<int32_t>("seqlens_k", {batch_size}, {static_cast<int32_t>(past_seq_len - 1)});
-  webgpu_tester.AddInput<int32_t>("total_sequence_length", {1}, {0});  // 0 → indirect dispatch path
-  webgpu_tester.AddOptionalInputEdge<float>();                         // cos_cache
-  webgpu_tester.AddOptionalInputEdge<float>();                         // sin_cache
-  webgpu_tester.AddOptionalInputEdge<int64_t>();                       // position_ids
-  webgpu_tester.AddOptionalInputEdge<float>();                         // attention_bias
-  webgpu_tester.AddOptionalInputEdge<float>();                         // head_sink
+  webgpu_tester.AddInput<int32_t>("total_sequence_length", {1}, {past_seq_len});
+  webgpu_tester.AddOptionalInputEdge<float>();    // cos_cache
+  webgpu_tester.AddOptionalInputEdge<float>();    // sin_cache
+  webgpu_tester.AddOptionalInputEdge<int64_t>();  // position_ids
+  webgpu_tester.AddOptionalInputEdge<float>();    // attention_bias
+  webgpu_tester.AddOptionalInputEdge<float>();    // head_sink
   const int output_size = batch_size * q_seq_len * hidden_size;
   const int present_size = batch_size * kv_num_heads * past_seq_len * head_size;
   webgpu_tester.AddOutput<float>("output", {batch_size, q_seq_len, hidden_size}, std::vector<float>(output_size, 0.0f));
@@ -3289,7 +3285,7 @@ TEST(GroupQueryAttentionTest, WebGPU_SharedKV_IndirectDispatch_LargerPast) {
       batch_size, q_seq_len, past_seq_len, query_data, past_key_data, past_value_data,
       num_heads, kv_num_heads, head_size, GqaTargetEp::kCpu);
 
-  ExpectOutputsMatch(webgpu_output, cpu_output, 0.05f, "SharedKV_IndirectDispatch_LargerPast_WebGPU_vs_CPU");
+  ExpectOutputsMatch(webgpu_output, cpu_output, 0.05f, "SharedKV_KvEmpty_LargerPast_WebGPU_vs_CPU");
 }
 
 // --- Success paths: TurboQuant with flash attention at various K sizes ---

--- a/onnxruntime/test/contrib_ops/group_query_attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/group_query_attention_op_test.cc
@@ -3211,13 +3211,10 @@ TEST(GroupQueryAttentionTest, WebGPU_SharedKV_KvEmpty_Decode) {
   webgpu_tester.AddOptionalInputEdge<float>();    // attention_bias
   webgpu_tester.AddOptionalInputEdge<float>();    // head_sink
   const int output_size = batch_size * q_seq_len * hidden_size;
-  const int present_size = batch_size * kv_num_heads * past_seq_len * head_size;
   webgpu_tester.AddOutput<float>("output", {batch_size, q_seq_len, hidden_size}, std::vector<float>(output_size, 0.0f));
-  webgpu_tester.AddOutput<float>("present_key", {batch_size, kv_num_heads, past_seq_len, head_size}, std::vector<float>(present_size, 0.0f));
-  webgpu_tester.AddOutput<float>("present_value", {batch_size, kv_num_heads, past_seq_len, head_size}, std::vector<float>(present_size, 0.0f));
   webgpu_tester.SetOutputTolerance(1e6f);
   std::vector<std::unique_ptr<IExecutionProvider>> webgpu_eps;
-  webgpu_eps.push_back(DefaultWebGpuExecutionProvider());
+  webgpu_eps.push_back(std::move(webgpu_ep));
   webgpu_tester.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &webgpu_eps);
   const float* webgpu_out = webgpu_tester.GetFetches()[0].Get<Tensor>().Data<float>();
   std::vector<float> webgpu_output(webgpu_out, webgpu_out + output_size);
@@ -3270,13 +3267,10 @@ TEST(GroupQueryAttentionTest, WebGPU_SharedKV_KvEmpty_LargerPast) {
   webgpu_tester.AddOptionalInputEdge<float>();    // attention_bias
   webgpu_tester.AddOptionalInputEdge<float>();    // head_sink
   const int output_size = batch_size * q_seq_len * hidden_size;
-  const int present_size = batch_size * kv_num_heads * past_seq_len * head_size;
   webgpu_tester.AddOutput<float>("output", {batch_size, q_seq_len, hidden_size}, std::vector<float>(output_size, 0.0f));
-  webgpu_tester.AddOutput<float>("present_key", {batch_size, kv_num_heads, past_seq_len, head_size}, std::vector<float>(present_size, 0.0f));
-  webgpu_tester.AddOutput<float>("present_value", {batch_size, kv_num_heads, past_seq_len, head_size}, std::vector<float>(present_size, 0.0f));
   webgpu_tester.SetOutputTolerance(1e6f);
   std::vector<std::unique_ptr<IExecutionProvider>> webgpu_eps;
-  webgpu_eps.push_back(DefaultWebGpuExecutionProvider());
+  webgpu_eps.push_back(std::move(webgpu_ep));
   webgpu_tester.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &webgpu_eps);
   const float* webgpu_out = webgpu_tester.GetFetches()[0].Get<Tensor>().Data<float>();
   std::vector<float> webgpu_output(webgpu_out, webgpu_out + output_size);

--- a/onnxruntime/test/contrib_ops/group_query_attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/group_query_attention_op_test.cc
@@ -14,8 +14,12 @@
 #include "test/providers/provider_test_utils.h"
 #include "test/util/include/default_providers.h"
 #ifdef USE_WEBGPU
+#include "core/graph/model.h"
 #include "core/providers/webgpu/webgpu_provider_options.h"
-#include "core/session/onnxruntime_run_options_config_keys.h"
+#include "core/session/inference_session.h"
+#include "core/session/IOBinding.h"
+#include "test/test_environment.h"
+#include "test/unittest_util/framework_test_utils.h"
 #endif
 
 namespace onnxruntime {
@@ -2563,6 +2567,175 @@ TEST(GroupQueryAttentionTest, WebGPU_SharedKV_SlidingWindow) {
   tester.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
 }
 
+// WebGPU graph capture test for kv_empty (Gemma4 shared-KV) layers.
+//
+// When graph capture is enabled, total_seqlen is GPU-resident and
+// PrepareIndirectDispatchProgram must compute dispatch sizes on GPU.
+// This test exercises the full ORT graph capture path by allocating all
+// inputs as GPU tensors via IOBinding, running capture then replay, and
+// verifying the replay output matches the CPU reference.
+TEST(GroupQueryAttentionTest, WebGPU_SharedKV_IndirectDispatchForGraphCapture) {
+#ifdef USE_WEBGPU
+  constexpr int batch_size = 1;
+  constexpr int q_seq_len = 1;
+  constexpr int past_seq_len = 32;
+  constexpr int num_heads = 2;
+  constexpr int kv_num_heads = 1;
+  constexpr int head_size = 8;
+  constexpr int hidden_size = num_heads * head_size;
+  constexpr int kv_hidden_size = kv_num_heads * head_size;
+
+  // Build a GQA model directly using the Graph API so graph inputs are
+  // properly declared (OpTester::BuildModel doesn't call graph.Resolve or
+  // SetInputs, producing a proto that InferenceSession::Load rejects).
+  std::unique_ptr<onnxruntime::Model> p_model;
+  {
+    std::unordered_map<std::string, int> domain_to_version;
+    domain_to_version[kOnnxDomain] = 17;
+    domain_to_version[kMSDomain] = 1;
+    p_model = std::make_unique<onnxruntime::Model>(
+        "gqa_gc_test", true, ModelMetaData(), PathString(),
+        IOnnxRuntimeOpSchemaRegistryList(), domain_to_version,
+        std::vector<ONNX_NAMESPACE::FunctionProto>{},
+        DefaultLoggingManager().DefaultLogger(),
+        ModelOptions(true, true));
+    onnxruntime::Graph& graph = p_model->MainGraph();
+
+    ONNX_NAMESPACE::TypeProto tp_float, tp_int32;
+    tp_float.mutable_tensor_type()->set_elem_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+    tp_int32.mutable_tensor_type()->set_elem_type(ONNX_NAMESPACE::TensorProto_DataType_INT32);
+
+    std::vector<onnxruntime::NodeArg*> in_defs = {
+        &graph.GetOrCreateNodeArg("query", &tp_float),
+        &graph.GetOrCreateNodeArg("key", &tp_float),
+        &graph.GetOrCreateNodeArg("value", &tp_float),
+        &graph.GetOrCreateNodeArg("past_key", &tp_float),
+        &graph.GetOrCreateNodeArg("past_value", &tp_float),
+        &graph.GetOrCreateNodeArg("seqlens_k", &tp_int32),
+        &graph.GetOrCreateNodeArg("total_sequence_length", &tp_int32),
+        // optional inputs 8-12 are absent — use empty NodeArgs
+        &graph.GetOrCreateNodeArg("", nullptr),
+        &graph.GetOrCreateNodeArg("", nullptr),
+        &graph.GetOrCreateNodeArg("", nullptr),
+        &graph.GetOrCreateNodeArg("", nullptr),
+        &graph.GetOrCreateNodeArg("", nullptr),
+    };
+    std::vector<onnxruntime::NodeArg*> out_defs = {
+        &graph.GetOrCreateNodeArg("output", &tp_float),
+    };
+
+    auto& node = graph.AddNode("gqa", "GroupQueryAttention", "GQA",
+                               in_defs, out_defs, nullptr, kMSDomain);
+    node.AddAttribute("num_heads", static_cast<int64_t>(num_heads));
+    node.AddAttribute("kv_num_heads", static_cast<int64_t>(kv_num_heads));
+
+    ORT_THROW_IF_ERROR(graph.Resolve());
+  }
+
+  std::string model_data;
+  p_model->ToProto().SerializeToString(&model_data);
+
+  // Create InferenceSession with graph capture EP.
+  SessionOptions so;
+  InferenceSession session{so, GetEnvironment()};
+  ConfigOptions config_options{};
+  ORT_THROW_IF_ERROR(config_options.AddConfigEntry(webgpu::options::kEnableGraphCapture,
+                                                   webgpu::options::kEnableGraphCapture_ON));
+  auto webgpu_ep = WebGpuExecutionProviderWithOptions(config_options);
+  if (!webgpu_ep) {
+    GTEST_SKIP() << "WebGPU EP not available";
+  }
+  IExecutionProvider* ep_ptr = webgpu_ep.get();
+  ORT_THROW_IF_ERROR(session.RegisterExecutionProvider(std::move(webgpu_ep)));
+  std::istringstream model_stream(model_data);
+  ORT_THROW_IF_ERROR(session.Load(model_stream));
+  ORT_THROW_IF_ERROR(session.Initialize());
+
+  // Get GPU allocator from session.
+  OrtMemoryInfo gpu_mem_info(WEBGPU_BUFFER, OrtAllocatorType::OrtDeviceAllocator,
+                             OrtDevice(OrtDevice::GPU, OrtDevice::MemType::DEFAULT, OrtDevice::VendorIds::NONE, 0));
+  auto gpu_alloc = session.GetAllocator(gpu_mem_info);
+  AllocatorPtr cpu_alloc = TestCPUExecutionProvider()->CreatePreferredAllocators()[0];
+
+  // Prepare test data.
+  std::vector<float> query_data(batch_size * q_seq_len * hidden_size);
+  std::vector<float> past_key_data(batch_size * kv_num_heads * past_seq_len * head_size);
+  std::vector<float> past_value_data(batch_size * kv_num_heads * past_seq_len * head_size);
+  for (size_t i = 0; i < query_data.size(); i++) query_data[i] = 0.1f * static_cast<float>(i % 7 + 1);
+  for (size_t i = 0; i < past_key_data.size(); i++) past_key_data[i] = 0.2f * static_cast<float>(i % 5 + 1);
+  for (size_t i = 0; i < past_value_data.size(); i++) past_value_data[i] = 0.3f * static_cast<float>(i % 3 + 1);
+
+  // Helper: create GPU OrtValue by copying from CPU data (data may be nullptr for zero-size tensors).
+  auto make_gpu_value = [&](const void* data, MLDataType dtype, TensorShape shape) -> OrtValue {
+    Tensor gpu_tensor(dtype, shape, gpu_alloc);
+    if (data != nullptr && shape.Size() > 0) {
+      Tensor cpu_tensor(dtype, shape, const_cast<void*>(data), cpu_alloc->Info());
+      ORT_THROW_IF_ERROR(ep_ptr->GetDataTransfer()->CopyTensor(cpu_tensor, gpu_tensor));
+    }
+    OrtValue val;
+    Tensor::InitOrtValue(std::move(gpu_tensor), val);
+    return val;
+  };
+
+  auto q_val = make_gpu_value(query_data.data(), DataTypeImpl::GetType<float>(),
+                              TensorShape{batch_size, q_seq_len, hidden_size});
+  auto key_val = make_gpu_value(nullptr, DataTypeImpl::GetType<float>(),
+                                TensorShape{batch_size, 0, kv_hidden_size});
+  auto value_val = make_gpu_value(nullptr, DataTypeImpl::GetType<float>(),
+                                  TensorShape{batch_size, 0, kv_hidden_size});
+  auto pk_val = make_gpu_value(past_key_data.data(), DataTypeImpl::GetType<float>(),
+                               TensorShape{batch_size, kv_num_heads, past_seq_len, head_size});
+  auto pv_val = make_gpu_value(past_value_data.data(), DataTypeImpl::GetType<float>(),
+                               TensorShape{batch_size, kv_num_heads, past_seq_len, head_size});
+  std::vector<int32_t> seqlens_k_data = {past_seq_len - 1};
+  auto sk_val = make_gpu_value(seqlens_k_data.data(), DataTypeImpl::GetType<int32_t>(),
+                               TensorShape{batch_size});
+  std::vector<int32_t> total_seqlen_data = {past_seq_len};
+  auto ts_val = make_gpu_value(total_seqlen_data.data(), DataTypeImpl::GetType<int32_t>(),
+                               TensorShape{1});
+
+  // Preallocate GPU output.
+  Tensor gpu_out_tensor(DataTypeImpl::GetType<float>(),
+                        TensorShape{batch_size, q_seq_len, hidden_size}, gpu_alloc);
+  OrtValue out_val;
+  Tensor::InitOrtValue(std::move(gpu_out_tensor), out_val);
+
+  // Bind inputs and output.
+  std::unique_ptr<IOBinding> io_binding;
+  ORT_THROW_IF_ERROR(session.NewIOBinding(&io_binding));
+  ORT_THROW_IF_ERROR(io_binding->BindInput("query", q_val));
+  ORT_THROW_IF_ERROR(io_binding->BindInput("key", key_val));
+  ORT_THROW_IF_ERROR(io_binding->BindInput("value", value_val));
+  ORT_THROW_IF_ERROR(io_binding->BindInput("past_key", pk_val));
+  ORT_THROW_IF_ERROR(io_binding->BindInput("past_value", pv_val));
+  ORT_THROW_IF_ERROR(io_binding->BindInput("seqlens_k", sk_val));
+  ORT_THROW_IF_ERROR(io_binding->BindInput("total_sequence_length", ts_val));
+  ORT_THROW_IF_ERROR(io_binding->BindOutput("output", out_val));
+  ORT_THROW_IF_ERROR(io_binding->SynchronizeInputs());
+
+  // Run 1: capture.
+  RunOptions run_options;
+  ORT_THROW_IF_ERROR(session.Run(run_options, *io_binding));
+
+  // Run 2: replay.
+  ORT_THROW_IF_ERROR(session.Run(run_options, *io_binding));
+
+  // Copy output GPU -> CPU and compare to CPU reference.
+  const int output_size = batch_size * q_seq_len * hidden_size;
+  auto& gpu_out = io_binding->GetOutputs()[0].Get<Tensor>();
+  Tensor cpu_out_tensor(DataTypeImpl::GetType<float>(), gpu_out.Shape(), cpu_alloc);
+  ORT_THROW_IF_ERROR(ep_ptr->GetDataTransfer()->CopyTensor(gpu_out, cpu_out_tensor));
+  std::vector<float> webgpu_output(cpu_out_tensor.Data<float>(),
+                                   cpu_out_tensor.Data<float>() + output_size);
+
+  auto cpu_output = RunGQASharedKV(
+      batch_size, q_seq_len, past_seq_len, query_data, past_key_data, past_value_data,
+      num_heads, kv_num_heads, head_size, GqaTargetEp::kCpu);
+
+  ExpectOutputsMatch(webgpu_output, cpu_output, 0.05f, "SharedKV_IndirectDispatchForGraphCapture_vs_CPU");
+#endif
+}
+
 // ---------------------------------------------------------------------------
 // Batched right-padded packed-QKV prefill with do_rotary.
 //
@@ -3159,70 +3332,6 @@ TEST(GroupQueryAttentionTest, WebGPU_TurboQuant_RejectsNonPowerOf2HeadSize) {
   tester.Run(OpTester::ExpectResult::kExpectFailure,
              "KV cache quantization requires head_size >= 8 and a power of 2",
              {}, nullptr, &execution_providers);
-}
-
-// kv_empty is triggered when key/value have sequence_length=0 (Gemma4 shared-KV
-// layers where KV is reused from another layer's cache). Under graph capture,
-// total_seqlen is GPU-resident so dispatch sizes must be computed on GPU via
-// PrepareIndirectDispatchProgram.
-TEST(GroupQueryAttentionTest, WebGPU_SharedKVLayers_IndirectDispatchForGraphCapture) {
-  ConfigOptions config_options{};
-  ORT_THROW_IF_ERROR(config_options.AddConfigEntry(webgpu::options::kEnableGraphCapture,
-                                                   webgpu::options::kEnableGraphCapture_ON));
-  auto webgpu_ep = WebGpuExecutionProviderWithOptions(config_options);
-  if (!webgpu_ep) {
-    GTEST_SKIP() << "WebGPU EP not available";
-  }
-
-  constexpr int batch_size = 1;
-  constexpr int q_seq_len = 1;
-  constexpr int past_seq_len = 32;
-  constexpr int num_heads = 2;
-  constexpr int kv_num_heads = 1;
-  constexpr int head_size = 8;
-  constexpr int hidden_size = num_heads * head_size;
-  constexpr int kv_hidden_size = kv_num_heads * head_size;
-
-  std::vector<float> query_data(batch_size * q_seq_len * hidden_size);
-  std::vector<float> past_key_data(batch_size * kv_num_heads * past_seq_len * head_size);
-  std::vector<float> past_value_data(batch_size * kv_num_heads * past_seq_len * head_size);
-  for (size_t i = 0; i < query_data.size(); i++) query_data[i] = 0.1f * static_cast<float>(i % 7 + 1);
-  for (size_t i = 0; i < past_key_data.size(); i++) past_key_data[i] = 0.2f * static_cast<float>(i % 5 + 1);
-  for (size_t i = 0; i < past_value_data.size(); i++) past_value_data[i] = 0.3f * static_cast<float>(i % 3 + 1);
-
-  OpTester webgpu_tester("GroupQueryAttention", 1, onnxruntime::kMSDomain);
-  webgpu_tester.AddAttribute<int64_t>("num_heads", static_cast<int64_t>(num_heads));
-  webgpu_tester.AddAttribute<int64_t>("kv_num_heads", static_cast<int64_t>(kv_num_heads));
-  webgpu_tester.AddInput<float>("query", {batch_size, q_seq_len, hidden_size}, query_data);
-  webgpu_tester.AddInput<float>("key", {batch_size, 0, kv_hidden_size}, {});    // kv_empty
-  webgpu_tester.AddInput<float>("value", {batch_size, 0, kv_hidden_size}, {});  // kv_empty
-  webgpu_tester.AddInput<float>("past_key", {batch_size, kv_num_heads, past_seq_len, head_size}, past_key_data);
-  webgpu_tester.AddInput<float>("past_value", {batch_size, kv_num_heads, past_seq_len, head_size}, past_value_data);
-  webgpu_tester.AddInput<int32_t>("seqlens_k", {batch_size}, {static_cast<int32_t>(past_seq_len - 1)});
-  webgpu_tester.AddInput<int32_t>("total_sequence_length", {1}, {past_seq_len});
-  webgpu_tester.AddOptionalInputEdge<float>();    // cos_cache
-  webgpu_tester.AddOptionalInputEdge<float>();    // sin_cache
-  webgpu_tester.AddOptionalInputEdge<int64_t>();  // position_ids
-  webgpu_tester.AddOptionalInputEdge<float>();    // attention_bias
-  webgpu_tester.AddOptionalInputEdge<float>();    // head_sink
-  const int output_size = batch_size * q_seq_len * hidden_size;
-  webgpu_tester.AddOutput<float>("output", {batch_size, q_seq_len, hidden_size}, std::vector<float>(output_size, 0.0f));
-  webgpu_tester.SetOutputTolerance(1e6f);
-  // gpu_graph_id=-1 keeps IsGraphCaptureEnabled()=true (exercising the indirect dispatch
-  // code path) without triggering actual Dawn command capture/replay.
-  RunOptions run_options;
-  ORT_THROW_IF_ERROR(run_options.config_options.AddConfigEntry(kOrtRunOptionsConfigCudaGraphAnnotation, "-1"));
-  std::vector<std::unique_ptr<IExecutionProvider>> webgpu_eps;
-  webgpu_eps.push_back(std::move(webgpu_ep));
-  webgpu_tester.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, &run_options, &webgpu_eps);
-  const float* webgpu_out = webgpu_tester.GetFetches()[0].Get<Tensor>().Data<float>();
-  std::vector<float> webgpu_output(webgpu_out, webgpu_out + output_size);
-
-  auto cpu_output = RunGQASharedKV(
-      batch_size, q_seq_len, past_seq_len, query_data, past_key_data, past_value_data,
-      num_heads, kv_num_heads, head_size, GqaTargetEp::kCpu);
-
-  ExpectOutputsMatch(webgpu_output, cpu_output, 0.05f, "SharedKVLayers_IndirectDispatchForGraphCapture_vs_CPU");
 }
 
 // --- Success paths: TurboQuant with flash attention at various K sizes ---

--- a/onnxruntime/test/contrib_ops/group_query_attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/group_query_attention_op_test.cc
@@ -2657,7 +2657,7 @@ TEST(GroupQueryAttentionTest, WebGPU_SharedKV_IndirectDispatchForGraphCapture) {
   auto gpu_alloc = session.GetAllocator(gpu_mem_info);
   AllocatorPtr cpu_alloc = TestCPUExecutionProvider()->CreatePreferredAllocators()[0];
 
-  // Prepare test data.
+  // Capture-run input data (set A).
   std::vector<float> query_data(batch_size * q_seq_len * hidden_size);
   std::vector<float> past_key_data(batch_size * kv_num_heads * past_seq_len * head_size);
   std::vector<float> past_value_data(batch_size * kv_num_heads * past_seq_len * head_size);
@@ -2665,7 +2665,15 @@ TEST(GroupQueryAttentionTest, WebGPU_SharedKV_IndirectDispatchForGraphCapture) {
   for (size_t i = 0; i < past_key_data.size(); i++) past_key_data[i] = 0.2f * static_cast<float>(i % 5 + 1);
   for (size_t i = 0; i < past_value_data.size(); i++) past_value_data[i] = 0.3f * static_cast<float>(i % 3 + 1);
 
-  // Helper: create GPU OrtValue by copying from CPU data (data may be nullptr for zero-size tensors).
+  // Replay-run input data (set B) — different values to verify replay actually uses new data.
+  std::vector<float> query_data2(batch_size * q_seq_len * hidden_size);
+  std::vector<float> past_key_data2(batch_size * kv_num_heads * past_seq_len * head_size);
+  std::vector<float> past_value_data2(batch_size * kv_num_heads * past_seq_len * head_size);
+  for (size_t i = 0; i < query_data2.size(); i++) query_data2[i] = 0.5f * static_cast<float>(i % 11 + 1);
+  for (size_t i = 0; i < past_key_data2.size(); i++) past_key_data2[i] = 0.4f * static_cast<float>(i % 7 + 1);
+  for (size_t i = 0; i < past_value_data2.size(); i++) past_value_data2[i] = 0.6f * static_cast<float>(i % 4 + 1);
+
+  // Helper: create GPU OrtValue by copying from CPU data (nullptr = zero-size tensor).
   auto make_gpu_value = [&](const void* data, MLDataType dtype, TensorShape shape) -> OrtValue {
     Tensor gpu_tensor(dtype, shape, gpu_alloc);
     if (data != nullptr && shape.Size() > 0) {
@@ -2675,6 +2683,15 @@ TEST(GroupQueryAttentionTest, WebGPU_SharedKV_IndirectDispatchForGraphCapture) {
     OrtValue val;
     Tensor::InitOrtValue(std::move(gpu_tensor), val);
     return val;
+  };
+
+  // Helper: overwrite an existing GPU tensor's data in-place from CPU (same buffer, new values).
+  // Under graph capture the WGPUBuffer pointer is baked in; rebinding is not allowed.
+  auto update_gpu_value = [&](const OrtValue& gpu_val, const void* data, MLDataType dtype, TensorShape shape) {
+    if (shape.Size() > 0) {
+      Tensor cpu_tensor(dtype, shape, const_cast<void*>(data), cpu_alloc->Info());
+      ORT_THROW_IF_ERROR(ep_ptr->GetDataTransfer()->CopyTensor(cpu_tensor, const_cast<Tensor&>(gpu_val.Get<Tensor>())));
+    }
   };
 
   auto q_val = make_gpu_value(query_data.data(), DataTypeImpl::GetType<float>(),
@@ -2717,10 +2734,18 @@ TEST(GroupQueryAttentionTest, WebGPU_SharedKV_IndirectDispatchForGraphCapture) {
   RunOptions run_options;
   ORT_THROW_IF_ERROR(session.Run(run_options, *io_binding));
 
-  // Run 2: replay.
+  // Run 2: replay with different inputs (set B) written into the same GPU buffers.
+  // Rebinding is not allowed under graph capture — the WGPUBuffer pointers are baked
+  // in at capture time, so new data must be copied into the existing buffers.
+  update_gpu_value(q_val, query_data2.data(), DataTypeImpl::GetType<float>(),
+                   TensorShape{batch_size, q_seq_len, hidden_size});
+  update_gpu_value(pk_val, past_key_data2.data(), DataTypeImpl::GetType<float>(),
+                   TensorShape{batch_size, kv_num_heads, past_seq_len, head_size});
+  update_gpu_value(pv_val, past_value_data2.data(), DataTypeImpl::GetType<float>(),
+                   TensorShape{batch_size, kv_num_heads, past_seq_len, head_size});
   ORT_THROW_IF_ERROR(session.Run(run_options, *io_binding));
 
-  // Copy output GPU -> CPU and compare to CPU reference.
+  // Copy replay output GPU -> CPU and compare against CPU reference for set B.
   const int output_size = batch_size * q_seq_len * hidden_size;
   auto& gpu_out = io_binding->GetOutputs()[0].Get<Tensor>();
   Tensor cpu_out_tensor(DataTypeImpl::GetType<float>(), gpu_out.Shape(), cpu_alloc);
@@ -2729,7 +2754,7 @@ TEST(GroupQueryAttentionTest, WebGPU_SharedKV_IndirectDispatchForGraphCapture) {
                                    cpu_out_tensor.Data<float>() + output_size);
 
   auto cpu_output = RunGQASharedKV(
-      batch_size, q_seq_len, past_seq_len, query_data, past_key_data, past_value_data,
+      batch_size, q_seq_len, past_seq_len, query_data2, past_key_data2, past_value_data2,
       num_heads, kv_num_heads, head_size, GqaTargetEp::kCpu);
 
   ExpectOutputsMatch(webgpu_output, cpu_output, 0.05f, "SharedKV_IndirectDispatchForGraphCapture_vs_CPU");

--- a/onnxruntime/test/contrib_ops/group_query_attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/group_query_attention_op_test.cc
@@ -2822,8 +2822,7 @@ TEST(GroupQueryAttentionTest, BatchedRightPaddedRotaryPrefill_CUDA) {
   RunBatchedRightPaddedRotaryPrefillForEP(GqaTargetEp::kCuda);
 }
 
-TEST(GroupQueryAttentionTest, BatchedRightPaddedRotaryPrefill_WebGPU) {
-  auto webgpu_ep = DefaultWebGpuExecutionProvider();
+TEST(GroupQueryAttentionTest, BatchedRightPaddedRotaryPrefill_WebGPU) {  auto webgpu_ep = DefaultWebGpuExecutionProvider();
   if (!webgpu_ep) {
     GTEST_SKIP() << "WebGPU EP not available";
   }
@@ -3158,6 +3157,138 @@ TEST(GroupQueryAttentionTest, WebGPU_TurboQuant_RejectsNonPowerOf2HeadSize) {
   tester.Run(OpTester::ExpectResult::kExpectFailure,
              "KV cache quantization requires head_size >= 8 and a power of 2",
              {}, nullptr, &execution_providers);
+}
+
+// ---------------------------------------------------------------------------
+// Indirect dispatch tests (PrepareIndirectDispatchProgram)
+//
+// These tests pass total_sequence_length=0 to trigger the kv_empty indirect
+// dispatch path: use_seqlen_k=true so seqlen_k tensor is used on the GPU, and
+// use_indirect_dispatch=true so PrepareIndirectDispatchProgram sizes the flash-
+// attention dispatch from the GPU-resident seqlen_k value instead of the zero
+// CPU value. Correctness is verified by cross-checking against CPU with the
+// real total.
+// ---------------------------------------------------------------------------
+
+// WebGPU: kv_empty + total_sequence_length=0, decode (q_seq=1).
+// Exercises PrepareIndirectDispatchProgram for the kv_empty indirect dispatch path.
+TEST(GroupQueryAttentionTest, WebGPU_SharedKV_IndirectDispatch_Decode) {
+  auto webgpu_ep = DefaultWebGpuExecutionProvider();
+  if (!webgpu_ep) {
+    GTEST_SKIP() << "WebGPU EP not available";
+  }
+
+  constexpr int batch_size = 1;
+  constexpr int q_seq_len = 1;
+  constexpr int past_seq_len = 8;
+  constexpr int num_heads = 2;
+  constexpr int kv_num_heads = 1;
+  constexpr int head_size = 8;
+  constexpr int hidden_size = num_heads * head_size;
+  constexpr int kv_hidden_size = kv_num_heads * head_size;
+
+  std::vector<float> query_data(batch_size * q_seq_len * hidden_size);
+  std::vector<float> past_key_data(batch_size * kv_num_heads * past_seq_len * head_size);
+  std::vector<float> past_value_data(batch_size * kv_num_heads * past_seq_len * head_size);
+  for (size_t i = 0; i < query_data.size(); i++) query_data[i] = 0.1f * static_cast<float>(i % 7 + 1);
+  for (size_t i = 0; i < past_key_data.size(); i++) past_key_data[i] = 0.2f * static_cast<float>(i % 5 + 1);
+  for (size_t i = 0; i < past_value_data.size(); i++) past_value_data[i] = 0.3f * static_cast<float>(i % 3 + 1);
+
+  // WebGPU run: total_sequence_length=0 forces use_seqlen_k=true and
+  // use_indirect_dispatch=true; PrepareIndirectDispatchProgram sizes the
+  // dispatch from seqlen_k[0] on the GPU rather than the zero CPU value.
+  OpTester webgpu_tester("GroupQueryAttention", 1, onnxruntime::kMSDomain);
+  webgpu_tester.AddAttribute<int64_t>("num_heads", static_cast<int64_t>(num_heads));
+  webgpu_tester.AddAttribute<int64_t>("kv_num_heads", static_cast<int64_t>(kv_num_heads));
+  webgpu_tester.AddInput<float>("query", {batch_size, q_seq_len, hidden_size}, query_data);
+  webgpu_tester.AddInput<float>("key", {batch_size, 0, kv_hidden_size}, {});
+  webgpu_tester.AddInput<float>("value", {batch_size, 0, kv_hidden_size}, {});
+  webgpu_tester.AddInput<float>("past_key", {batch_size, kv_num_heads, past_seq_len, head_size}, past_key_data);
+  webgpu_tester.AddInput<float>("past_value", {batch_size, kv_num_heads, past_seq_len, head_size}, past_value_data);
+  webgpu_tester.AddInput<int32_t>("seqlens_k", {batch_size}, {static_cast<int32_t>(past_seq_len - 1)});
+  webgpu_tester.AddInput<int32_t>("total_sequence_length", {1}, {0});  // 0 → indirect dispatch path
+  webgpu_tester.AddOptionalInputEdge<float>();    // cos_cache
+  webgpu_tester.AddOptionalInputEdge<float>();    // sin_cache
+  webgpu_tester.AddOptionalInputEdge<int64_t>();  // position_ids
+  webgpu_tester.AddOptionalInputEdge<float>();    // attention_bias
+  webgpu_tester.AddOptionalInputEdge<float>();    // head_sink
+  const int output_size = batch_size * q_seq_len * hidden_size;
+  const int present_size = batch_size * kv_num_heads * past_seq_len * head_size;
+  webgpu_tester.AddOutput<float>("output", {batch_size, q_seq_len, hidden_size}, std::vector<float>(output_size, 0.0f));
+  webgpu_tester.AddOutput<float>("present_key", {batch_size, kv_num_heads, past_seq_len, head_size}, std::vector<float>(present_size, 0.0f));
+  webgpu_tester.AddOutput<float>("present_value", {batch_size, kv_num_heads, past_seq_len, head_size}, std::vector<float>(present_size, 0.0f));
+  webgpu_tester.SetOutputTolerance(1e6f);
+  std::vector<std::unique_ptr<IExecutionProvider>> webgpu_eps;
+  webgpu_eps.push_back(DefaultWebGpuExecutionProvider());
+  webgpu_tester.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &webgpu_eps);
+  const float* webgpu_out = webgpu_tester.GetFetches()[0].Get<Tensor>().Data<float>();
+  std::vector<float> webgpu_output(webgpu_out, webgpu_out + output_size);
+
+  // CPU reference: use real total_sequence_length so CPU path is correct.
+  auto cpu_output = RunGQASharedKV(
+      batch_size, q_seq_len, past_seq_len, query_data, past_key_data, past_value_data,
+      num_heads, kv_num_heads, head_size, /*use_cuda=*/false, /*use_webgpu=*/false);
+
+  ExpectOutputsMatch(webgpu_output, cpu_output, 0.05f, "SharedKV_IndirectDispatch_Decode_WebGPU_vs_CPU");
+}
+
+// WebGPU: kv_empty + total_sequence_length=0, larger past (exercises tile boundary).
+// past_seq_len=32 ensures num_total_seq_length_tile > 1, validating the tile
+// count arithmetic in PrepareIndirectDispatchProgram more thoroughly.
+TEST(GroupQueryAttentionTest, WebGPU_SharedKV_IndirectDispatch_LargerPast) {
+  auto webgpu_ep = DefaultWebGpuExecutionProvider();
+  if (!webgpu_ep) {
+    GTEST_SKIP() << "WebGPU EP not available";
+  }
+
+  constexpr int batch_size = 1;
+  constexpr int q_seq_len = 1;
+  constexpr int past_seq_len = 32;
+  constexpr int num_heads = 2;
+  constexpr int kv_num_heads = 1;
+  constexpr int head_size = 8;
+  constexpr int hidden_size = num_heads * head_size;
+  constexpr int kv_hidden_size = kv_num_heads * head_size;
+
+  std::vector<float> query_data(batch_size * q_seq_len * hidden_size);
+  std::vector<float> past_key_data(batch_size * kv_num_heads * past_seq_len * head_size);
+  std::vector<float> past_value_data(batch_size * kv_num_heads * past_seq_len * head_size);
+  for (size_t i = 0; i < query_data.size(); i++) query_data[i] = 0.1f * static_cast<float>(i % 7 + 1);
+  for (size_t i = 0; i < past_key_data.size(); i++) past_key_data[i] = 0.2f * static_cast<float>(i % 5 + 1);
+  for (size_t i = 0; i < past_value_data.size(); i++) past_value_data[i] = 0.3f * static_cast<float>(i % 3 + 1);
+
+  OpTester webgpu_tester("GroupQueryAttention", 1, onnxruntime::kMSDomain);
+  webgpu_tester.AddAttribute<int64_t>("num_heads", static_cast<int64_t>(num_heads));
+  webgpu_tester.AddAttribute<int64_t>("kv_num_heads", static_cast<int64_t>(kv_num_heads));
+  webgpu_tester.AddInput<float>("query", {batch_size, q_seq_len, hidden_size}, query_data);
+  webgpu_tester.AddInput<float>("key", {batch_size, 0, kv_hidden_size}, {});
+  webgpu_tester.AddInput<float>("value", {batch_size, 0, kv_hidden_size}, {});
+  webgpu_tester.AddInput<float>("past_key", {batch_size, kv_num_heads, past_seq_len, head_size}, past_key_data);
+  webgpu_tester.AddInput<float>("past_value", {batch_size, kv_num_heads, past_seq_len, head_size}, past_value_data);
+  webgpu_tester.AddInput<int32_t>("seqlens_k", {batch_size}, {static_cast<int32_t>(past_seq_len - 1)});
+  webgpu_tester.AddInput<int32_t>("total_sequence_length", {1}, {0});  // 0 → indirect dispatch path
+  webgpu_tester.AddOptionalInputEdge<float>();    // cos_cache
+  webgpu_tester.AddOptionalInputEdge<float>();    // sin_cache
+  webgpu_tester.AddOptionalInputEdge<int64_t>();  // position_ids
+  webgpu_tester.AddOptionalInputEdge<float>();    // attention_bias
+  webgpu_tester.AddOptionalInputEdge<float>();    // head_sink
+  const int output_size = batch_size * q_seq_len * hidden_size;
+  const int present_size = batch_size * kv_num_heads * past_seq_len * head_size;
+  webgpu_tester.AddOutput<float>("output", {batch_size, q_seq_len, hidden_size}, std::vector<float>(output_size, 0.0f));
+  webgpu_tester.AddOutput<float>("present_key", {batch_size, kv_num_heads, past_seq_len, head_size}, std::vector<float>(present_size, 0.0f));
+  webgpu_tester.AddOutput<float>("present_value", {batch_size, kv_num_heads, past_seq_len, head_size}, std::vector<float>(present_size, 0.0f));
+  webgpu_tester.SetOutputTolerance(1e6f);
+  std::vector<std::unique_ptr<IExecutionProvider>> webgpu_eps;
+  webgpu_eps.push_back(DefaultWebGpuExecutionProvider());
+  webgpu_tester.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &webgpu_eps);
+  const float* webgpu_out = webgpu_tester.GetFetches()[0].Get<Tensor>().Data<float>();
+  std::vector<float> webgpu_output(webgpu_out, webgpu_out + output_size);
+
+  auto cpu_output = RunGQASharedKV(
+      batch_size, q_seq_len, past_seq_len, query_data, past_key_data, past_value_data,
+      num_heads, kv_num_heads, head_size, /*use_cuda=*/false, /*use_webgpu=*/false);
+
+  ExpectOutputsMatch(webgpu_output, cpu_output, 0.05f, "SharedKV_IndirectDispatch_LargerPast_WebGPU_vs_CPU");
 }
 
 // --- Success paths: TurboQuant with flash attention at various K sizes ---

--- a/onnxruntime/test/contrib_ops/group_query_attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/group_query_attention_op_test.cc
@@ -2822,7 +2822,8 @@ TEST(GroupQueryAttentionTest, BatchedRightPaddedRotaryPrefill_CUDA) {
   RunBatchedRightPaddedRotaryPrefillForEP(GqaTargetEp::kCuda);
 }
 
-TEST(GroupQueryAttentionTest, BatchedRightPaddedRotaryPrefill_WebGPU) {  auto webgpu_ep = DefaultWebGpuExecutionProvider();
+TEST(GroupQueryAttentionTest, BatchedRightPaddedRotaryPrefill_WebGPU) {
+  auto webgpu_ep = DefaultWebGpuExecutionProvider();
   if (!webgpu_ep) {
     GTEST_SKIP() << "WebGPU EP not available";
   }
@@ -3207,11 +3208,11 @@ TEST(GroupQueryAttentionTest, WebGPU_SharedKV_IndirectDispatch_Decode) {
   webgpu_tester.AddInput<float>("past_value", {batch_size, kv_num_heads, past_seq_len, head_size}, past_value_data);
   webgpu_tester.AddInput<int32_t>("seqlens_k", {batch_size}, {static_cast<int32_t>(past_seq_len - 1)});
   webgpu_tester.AddInput<int32_t>("total_sequence_length", {1}, {0});  // 0 → indirect dispatch path
-  webgpu_tester.AddOptionalInputEdge<float>();    // cos_cache
-  webgpu_tester.AddOptionalInputEdge<float>();    // sin_cache
-  webgpu_tester.AddOptionalInputEdge<int64_t>();  // position_ids
-  webgpu_tester.AddOptionalInputEdge<float>();    // attention_bias
-  webgpu_tester.AddOptionalInputEdge<float>();    // head_sink
+  webgpu_tester.AddOptionalInputEdge<float>();                         // cos_cache
+  webgpu_tester.AddOptionalInputEdge<float>();                         // sin_cache
+  webgpu_tester.AddOptionalInputEdge<int64_t>();                       // position_ids
+  webgpu_tester.AddOptionalInputEdge<float>();                         // attention_bias
+  webgpu_tester.AddOptionalInputEdge<float>();                         // head_sink
   const int output_size = batch_size * q_seq_len * hidden_size;
   const int present_size = batch_size * kv_num_heads * past_seq_len * head_size;
   webgpu_tester.AddOutput<float>("output", {batch_size, q_seq_len, hidden_size}, std::vector<float>(output_size, 0.0f));
@@ -3267,11 +3268,11 @@ TEST(GroupQueryAttentionTest, WebGPU_SharedKV_IndirectDispatch_LargerPast) {
   webgpu_tester.AddInput<float>("past_value", {batch_size, kv_num_heads, past_seq_len, head_size}, past_value_data);
   webgpu_tester.AddInput<int32_t>("seqlens_k", {batch_size}, {static_cast<int32_t>(past_seq_len - 1)});
   webgpu_tester.AddInput<int32_t>("total_sequence_length", {1}, {0});  // 0 → indirect dispatch path
-  webgpu_tester.AddOptionalInputEdge<float>();    // cos_cache
-  webgpu_tester.AddOptionalInputEdge<float>();    // sin_cache
-  webgpu_tester.AddOptionalInputEdge<int64_t>();  // position_ids
-  webgpu_tester.AddOptionalInputEdge<float>();    // attention_bias
-  webgpu_tester.AddOptionalInputEdge<float>();    // head_sink
+  webgpu_tester.AddOptionalInputEdge<float>();                         // cos_cache
+  webgpu_tester.AddOptionalInputEdge<float>();                         // sin_cache
+  webgpu_tester.AddOptionalInputEdge<int64_t>();                       // position_ids
+  webgpu_tester.AddOptionalInputEdge<float>();                         // attention_bias
+  webgpu_tester.AddOptionalInputEdge<float>();                         // head_sink
   const int output_size = batch_size * q_seq_len * hidden_size;
   const int present_size = batch_size * kv_num_heads * past_seq_len * head_size;
   webgpu_tester.AddOutput<float>("output", {batch_size, q_seq_len, hidden_size}, std::vector<float>(output_size, 0.0f));

--- a/onnxruntime/test/contrib_ops/group_query_attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/group_query_attention_op_test.cc
@@ -2567,6 +2567,7 @@ TEST(GroupQueryAttentionTest, WebGPU_SharedKV_SlidingWindow) {
   tester.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
 }
 
+#ifdef USE_WEBGPU
 // WebGPU graph capture test for kv_empty (Gemma4 shared-KV) layers.
 //
 // When graph capture is enabled, total_seqlen is GPU-resident and
@@ -2575,7 +2576,6 @@ TEST(GroupQueryAttentionTest, WebGPU_SharedKV_SlidingWindow) {
 // inputs as GPU tensors via IOBinding, running capture then replay, and
 // verifying the replay output matches the CPU reference.
 TEST(GroupQueryAttentionTest, WebGPU_SharedKV_IndirectDispatchForGraphCapture) {
-#ifdef USE_WEBGPU
   constexpr int batch_size = 1;
   constexpr int q_seq_len = 1;
   constexpr int past_seq_len = 32;
@@ -2758,8 +2758,8 @@ TEST(GroupQueryAttentionTest, WebGPU_SharedKV_IndirectDispatchForGraphCapture) {
       num_heads, kv_num_heads, head_size, GqaTargetEp::kCpu);
 
   ExpectOutputsMatch(webgpu_output, cpu_output, 0.05f, "SharedKV_IndirectDispatchForGraphCapture_vs_CPU");
-#endif
 }
+#endif  // USE_WEBGPU
 
 // ---------------------------------------------------------------------------
 // Batched right-padded packed-QKV prefill with do_rotary.


### PR DESCRIPTION
## Summary
This adds indirect dispatch support for WebGPU flash attention to enable graph capture for Gemma4. When graph capture is on, \`total_seqlen\` is GPU-resident and cannot be read on the CPU, so dispatch group sizes must be computed on GPU.

CopyKVCache normally prepares the indirect dispatch buffer as a side effect. For Gemma4 kv_empty layers (shared KV layers that skip CopyKVCache), a dedicated \`PrepareIndirectDispatchProgram\` fills the indirect buffer instead — avoiding \`dispatch(0)\` crashes.

- Adds \`PrepareIndirectDispatchProgram\`: a single-thread GPU kernel that reads \`total_sequence_length_input[0]\` and writes 3 x uint32 dispatch dims to \`indirect_buffer\`, matching the logic in \`CopyKVCacheProgram\`
- \`use_indirect_dispatch\` is gated on \`context.IsGraphCaptureEnabled()\` — indirect dispatch is only needed when \`total_seqlen\` is GPU-resident; when graph capture is off, CPU-side dispatch sizing works correctly even for kv_empty layers
- \`PrepareIndirectDispatchProgram\` takes \`total_sequence_length_input\` (the global max, batch-safe) rather than \`seqlen_k\` (per-batch index 0, unsafe for batch > 1)

## Changes
- \`flash_attention.cc\`:
  - New \`PrepareIndirectDispatchProgram::GenerateShaderCode\`: reads \`total_sequence_length_input[0]\`, computes tile count, calls \`populate_indirect_dispatch_buffer\` — identical logic to \`CopyKVCacheProgram\`'s indirect dispatch block
  - \`use_indirect_dispatch\` gated on \`seqlen_k != nullptr && total_seqlen != nullptr && context.IsGraphCaptureEnabled()\`
  - kv_empty path calls \`PrepareIndirectDispatchProgram\` when \`use_indirect_dispatch\` is true (i.e., under graph capture)
- \`flash_attention.h\`: Added \`PrepareIndirectDispatchProgram\` class declaration

## Test plan
- [x] Verified with Gemma4 INT4 model: ~95-105 tok/s with GC=ON vs ~75 tok/s with GC=OFF
- [x] Tested multiple prompts (short/long) with graph capture enabled — no crashes, correct output
- [x] Verified warmup (capture run) followed by replay produces consistent results
- [x] Unit test: \`WebGPU_SharedKV_IndirectDispatchForGraphCapture\` — exercises the full ORT graph capture simulation path end-to-end:
  - Model built via the Graph API (opset 17) with all GQA inputs declared as proper graph inputs
  - All inputs allocated as GPU-resident tensors via \`InferenceSession::GetAllocator\` + \`IOBinding\`; \`total_seqlen\` is a real \`WGPUBuffer\` so \`PrepareIndirectDispatchProgram\` reads it from GPU
  - WebGPU EP registered with \`kEnableGraphCapture=ON\`; first \`Run\` captures, second \`Run\` replays
  - Replay output copied GPU→CPU and compared against a CPU reference to verify correctness
  - Covers the kv_empty branch specifically: \`key\`/\`value\` have \`sequence_length=0\`, triggering the \`PrepareIndirectDispatchProgram\` code path (CopyKVCache is skipped for kv_empty layers)