### PR TITLE
Fix parsing issue with WebGPU testing skill

### DIFF
--- a/.agents/skills/webgpu-local-testing/SKILL.md
+++ b/.agents/skills/webgpu-local-testing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: webgpu-local-testing
-description: Build and run ONNX Runtime WebGPU provider tests on Linux WITHOUT a real GPU, using a software Vulkan adapter (Mesa lavapipe). Use when you need to exercise WebGPU EP kernels off-Mac — the Linux webgpu CI leg is build-only, so software Vulkan is how you actually run WebGPU correctness tests locally. SCOPE: lavapipe only validates host-side enforce/shape bugs and MatMul-free kernels; any graph containing MatMul (including the expanded-Attention node tests) crashes lavapipe and runs ONLY on macOS-arm64 Metal, which is the source of truth for those. Covers install (dnf on Azure Linux), the --use_webgpu build flag, the onnxruntime_provider_test target, VK_ICD_FILENAMES, and the lavapipe MatMul crash gotcha.
+description: "Build and run ONNX Runtime WebGPU provider tests on Linux WITHOUT a real GPU, using a software Vulkan adapter (Mesa lavapipe). Use when you need to exercise WebGPU EP kernels off-Mac — the Linux webgpu CI leg is build-only, so software Vulkan is how you actually run WebGPU correctness tests locally. SCOPE - lavapipe only validates host-side enforce/shape bugs and MatMul-free kernels; any graph containing MatMul (including the expanded-Attention node tests) crashes lavapipe and runs ONLY on macOS-arm64 Metal, which is the source of truth for those. Covers install (dnf on Azure Linux), the --use_webgpu build flag, the onnxruntime_provider_test target, VK_ICD_FILENAMES, and the lavapipe MatMul crash gotcha."
 ---
 
 # Running ONNX Runtime WebGPU Tests Locally on Linux (No GPU)


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
The  webgpu-local-testing skill is failing to load because of invalid YAML in its frontmatter. The unquoated description: value contained colon-space sequences ( SCOPE: lavapipe ,  e.g.: ), and according to Copilot, in YAML a plain (unquoted) scalar can't contain  ": ". The parser reads it as a nested mapping key and aborts with:

 ScannerError: mapping values are not allowed here

 It was the only one of the 8 skills with this pattern, which is why every other skill loaded fine. The fix is to wrap the description value in double quotes and adjust `SCOPE:`  to `SCOPE -` so the colons are treated as literal text. The frontmatter now parses, with both required keys (name, description) intact.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
The Copilot CLI was flagging this skill as failing to load, so this change attempts to resolve that error. 