### PR TITLE
[Pipeline] Fix CUDA Python packaging pipeline

### DIFF
--- a/onnxruntime/test/python/onnxruntime_test_python_iobinding.py
+++ b/onnxruntime/test/python/onnxruntime_test_python_iobinding.py
@@ -8,7 +8,6 @@ import numpy as np
 from helper import get_name
 from numpy.testing import assert_almost_equal
 from onnx import TensorProto, helper
-from onnx.defs import onnx_opset_version
 
 import onnxruntime as onnxrt
 from onnxruntime.capi._pybind_state import OrtDevice as C_OrtDevice  # pylint: disable=E0611
@@ -19,6 +18,11 @@ test_params = [
     ("cuda", "CUDAExecutionProvider", C_OrtDevice.cuda),
     ("dml", "DmlExecutionProvider", C_OrtDevice.dml),
 ]
+
+# Highest ai.onnx opset that has been *released* by the installed onnx package.
+# Avoid onnx.defs.onnx_opset_version(), which returns the in-development next opset
+# (ORT's loader rejects un-released opsets unless ALLOW_RELEASED_ONNX_OPSET_ONLY=0).
+_LAST_RELEASED_AI_ONNX_OPSET = max(v for (d, v) in helper.OP_SET_ID_VERSION_MAP if d == "ai.onnx")
 
 
 class TestIOBinding(unittest.TestCase):
@@ -74,7 +78,7 @@ class TestIOBinding(unittest.TestCase):
                 if execution_provider not in onnxrt.get_available_providers():
                     self.skipTest(f"Skipping on {device.upper()}.")
 
-                opset = onnx_opset_version()
+                opset = _LAST_RELEASED_AI_ONNX_OPSET
                 devices = [
                     (
                         C_OrtDevice(C_OrtDevice.cpu(), C_OrtDevice.default_memory(), 0),
@@ -143,7 +147,7 @@ class TestIOBinding(unittest.TestCase):
                             assert_almost_equal(x, y)
 
     def test_bind_onnx_types_supported_by_numpy(self):
-        opset = onnx_opset_version()
+        opset = _LAST_RELEASED_AI_ONNX_OPSET
         devices = [
             (
                 C_OrtDevice(C_OrtDevice.cpu(), C_OrtDevice.default_memory(), 0),
@@ -200,7 +204,7 @@ class TestIOBinding(unittest.TestCase):
         except ImportError:
             self.skipTest("Skipping since PyTorch is not installed.")
 
-        opset = onnx_opset_version()
+        opset = _LAST_RELEASED_AI_ONNX_OPSET
         devices = [
             (
                 C_OrtDevice(C_OrtDevice.cpu(), C_OrtDevice.default_memory(), 0),

--- a/onnxruntime/test/python/onnxruntime_test_python_nv_tensorrt_rtx_ep_tests.py
+++ b/onnxruntime/test/python/onnxruntime_test_python_nv_tensorrt_rtx_ep_tests.py
@@ -12,12 +12,16 @@ from autoep_helper import AutoEpTestCase
 from helper import get_name
 from numpy.testing import assert_almost_equal
 from onnx import TensorProto, helper
-from onnx.defs import onnx_opset_version
 
 import onnxruntime as onnxrt
 from onnxruntime.capi._pybind_state import OrtDevice as C_OrtDevice
 from onnxruntime.capi._pybind_state import OrtValue as C_OrtValue
 from onnxruntime.capi._pybind_state import OrtValueVector, SessionIOBinding
+
+# Highest ai.onnx opset that has been *released* by the installed onnx package.
+# Avoid onnx.defs.onnx_opset_version(), which returns the in-development next opset
+# (ORT's loader rejects un-released opsets unless ALLOW_RELEASED_ONNX_OPSET_ONLY=0).
+_LAST_RELEASED_AI_ONNX_OPSET = max(v for (d, v) in helper.OP_SET_ID_VERSION_MAP if d == "ai.onnx")
 
 
 class TestNvTensorRTRTXAutoEP(AutoEpTestCase):
@@ -357,7 +361,7 @@ class TestNvTensorRTRTXAutoEP(AutoEpTestCase):
         sess_options = onnxrt.SessionOptions()
         sess_options.set_provider_selection_policy(onnxrt.OrtExecutionProviderDevicePolicy.PREFER_GPU)
         self.assertTrue(sess_options.has_providers())
-        opset = onnx_opset_version()
+        opset = _LAST_RELEASED_AI_ONNX_OPSET
         device = C_OrtDevice(C_OrtDevice.cuda(), C_OrtDevice.default_memory(), 0)
 
         for dtype in [
@@ -422,7 +426,7 @@ class TestNvTensorRTRTXAutoEP(AutoEpTestCase):
         sess_options = onnxrt.SessionOptions()
         sess_options.set_provider_selection_policy(onnxrt.OrtExecutionProviderDevicePolicy.PREFER_GPU)
         self.assertTrue(sess_options.has_providers())
-        opset = onnx_opset_version()
+        opset = _LAST_RELEASED_AI_ONNX_OPSET
 
         for dtype in [
             torch.float32,


### PR DESCRIPTION
### Description
The ONNX 1.22 release is returning 27 with the API `onnx_opset_version()` and this is the latest "in development" opset in ONNX and not the released opset version. This breaks tests in ORT as there is a validation check. So adjust the tests so that the test models are stamped with the latest release opset version.


### Motivation and Context
Fix packaging pipeline break

Successful run - https://aiinfra.visualstudio.com/Lotus/_build/results?buildId=1277057&view=results

