### PR TITLE
[VitisAI] Recognize native-endian in-memory address tag in process_ext_address

### DIFF
--- a/onnxruntime/core/providers/vitisai/imp/tensor_proto.cc
+++ b/onnxruntime/core/providers/vitisai/imp/tensor_proto.cc
@@ -31,7 +31,17 @@ gsl::span<const char> process_ext_address(const ONNX_NAMESPACE::TensorProto& ten
         // checksum = (size_t)std::strtoull(data.mutable_value()->data(), &end, 10);
       }
     }
-    if (file == "*/_ORT_MEM_ADDR_/*") {
+    // ORT marks initializers whose data lives in an in-process memory buffer
+    // (e.g. weights moved out of the TensorProto during graph optimization) with
+    // one of two sentinels in the 'location' field. The original little-endian
+    // tag is still emitted for some paths, but newer ORT defaults to the
+    // native-endian tag (see TensorToTensorProto / kTensorProtoNativeEndianMemoryAddressTag).
+    // Both encode the buffer address in the 'offset' field; on little-endian
+    // hosts (the only platform this EP targets) the bytes are identical, so we
+    // decode them the same way. Recognizing only the little-endian tag would let
+    // native-endian-tagged initializers slip through model_clone and trip ORT's
+    // "in-memory address marker not allowed in a model protobuf" check.
+    if (file == "*/_ORT_MEM_ADDR_/*" || file == "*/_ORT_NATIVE_ENDIAN_MEM_ADDR_/*") {
       auto addr = reinterpret_cast<const char*>(offset);
       return {addr, size};
     }


### PR DESCRIPTION
### Description

`vaip::process_ext_address` (in the VitisAI EP) decodes the in-memory
"external data" address marker that ORT plants on initializers whose data lives
in an in-process buffer. It only matched the little-endian tag
`"*/_ORT_MEM_ADDR_/*"` (`kTensorProtoLittleEndianMemoryAddressTag`). This PR
makes it also recognize the native-endian tag
`"*/_ORT_NATIVE_ENDIAN_MEM_ADDR_/*"` (`kTensorProtoNativeEndianMemoryAddressTag`).

```cpp
if (file == "*/_ORT_MEM_ADDR_/*" || file == "*/_ORT_NATIVE_ENDIAN_MEM_ADDR_/*") {
  auto addr = reinterpret_cast<const char*>(offset);
  return {addr, size};
}
```

### Motivation and Context

Two existing changes combined to break VitisAI model compilation:

1. #27404 split the single in-memory marker into a little-endian and a
   native-endian variant, and switched `TensorToTensorProto(use_tensor_buffer=true)`
   to emit the **native-endian** tag by default. Both `HasExternalDataInMemory`
   and the data readers treat the two tags equivalently.

2. #28709 added an explicit `ORT_ENFORCE(!utils::HasExternalDataInMemory(tensor), ...)`
   in `Graph::Graph`, rejecting any in-memory address marker found in a
   deserialized model protobuf.

Because `process_ext_address` still only recognized the little-endian tag,
in-memory initializers (e.g. quantized weights moved out of the `TensorProto`
during graph optimization) are no longer detected in `vaip::model_clone`. They
fall through to the verbatim-copy branch and the native-endian marker is carried
into the cloned model proto. When ORT then constructs the cloned `Graph`, the
new enforce fires and aborts compilation:

```
Initializer 'onnx::Conv_1575_quantized' references an ORT in-memory address
marker, which is not allowed in a model protobuf.
```

This regression is observed on 1.27.0, where both changes are present (1.25.x /
1.26.x have the native-endian tag but not the enforce, so the marker leaked
silently without crashing).

Both tags encode the buffer address in the `offset` field; on little-endian
hosts (the only platform this EP targets) the byte layout is identical, so they
are decoded the same way. Recognizing both tags restores the previous behavior
of converting these initializers into a lightweight reference inside
`model_clone`, so the in-memory marker never reaches `Graph::Graph`.
