### PR TITLE
Fix integer overflow in RKNPU implicit bias allocation

### DIFF
--- a/onnxruntime/core/providers/rknpu/onnx_converter.cc
+++ b/onnxruntime/core/providers/rknpu/onnx_converter.cc
@@ -141,17 +141,14 @@ static void* AllocZeroedBias(size_t element_size, uint32_t count) {
   try {
     num_bytes = SafeInt<size_t>(element_size) * count;
   } catch (const std::exception&) {
-    throw std::runtime_error(
-        "RKNPU: implicit bias size overflow (element_size=" +
-        std::to_string(element_size) + ", count=" + std::to_string(count) + ")");
+    ORT_THROW("RKNPU: implicit bias size overflow (element_size=", element_size,
+              ", count=", count, ")");
   }
   void* ptr = malloc(num_bytes);
-  if (ptr == nullptr && num_bytes != 0) {
-    throw std::runtime_error(
-        "RKNPU: failed to allocate " + std::to_string(num_bytes) +
-        " bytes for implicit bias (element_size=" + std::to_string(element_size) +
-        ", count=" + std::to_string(count) + ")");
-  }
+  ORT_ENFORCE(ptr != nullptr || num_bytes == 0,
+              "RKNPU: failed to allocate ", num_bytes,
+              " bytes for implicit bias (element_size=", element_size,
+              ", count=", count, ")");
   if (ptr != nullptr) {
     memset(ptr, 0, num_bytes);
   }

--- a/onnxruntime/core/providers/rknpu/onnx_converter.cc
+++ b/onnxruntime/core/providers/rknpu/onnx_converter.cc
@@ -1,6 +1,7 @@
 // Copyright 2020 rock-chips.com Inc.
 
 #include <fstream>
+#include <limits>
 #include <map>
 #include <numeric>
 #include <string>
@@ -120,6 +121,16 @@ OnnxConverter::CreateRknnTensor(const std::string& name,
   return graph_->CreateTensor(attr, (void*)data);
 }
 
+static uint32_t ToRknpuDim(int64_t dim, const std::string& name) {
+  if (dim < 0 || dim > static_cast<int64_t>(std::numeric_limits<uint32_t>::max())) {
+    throw std::invalid_argument(
+        "RKNPU: tensor dimension out of uint32_t range (name=" + name +
+        ", dim=" + std::to_string(dim) + ")");
+  }
+
+  return static_cast<uint32_t>(dim);
+}
+
 // Allocates a zero-initialized buffer holding `count` elements of `element_size`
 // bytes each, used as an implicit (all-zero) bias when a Conv/Gemm node omits
 // its bias input. A malicious model can specify a weight dimension large enough
@@ -154,7 +165,7 @@ void OnnxConverter::HandleInitializer() {
     const std::string name = tensor.name();
     std::vector<uint32_t> dims;
     for (const auto dim : tensor.dims()) {
-      dims.push_back(static_cast<uint32_t>(dim));
+      dims.push_back(ToRknpuDim(dim, name));
     }
     if (tensor.data_type() == ONNX_NAMESPACE::TensorProto_DataType_FLOAT) {
       const char* ptr = tensor.float_data().empty()
@@ -216,7 +227,7 @@ std::vector<std::shared_ptr<rk::nn::Tensor>> OnnxConverter::GetInputOfOnnxModel(
     for (const auto& dim : input.type().tensor_type().shape().dim()) {
       if (dim.value_case() ==
           ONNX_NAMESPACE::TensorShapeProto_Dimension::kDimValue) {
-        shape.push_back(static_cast<uint32_t>(dim.dim_value()));
+        shape.push_back(ToRknpuDim(dim.dim_value(), input.name()));
       } else {
         throw std::invalid_argument(
             "The input of graph doesn't have dim_value");
@@ -297,7 +308,7 @@ Shaper::Shape GetShape(const ONNX_NAMESPACE::ModelProto& model_proto,
 
       for (const auto& dim : value_info.type().tensor_type().shape().dim()) {
         if (dim.has_dim_value()) {
-          shape.push_back(dim.dim_value());
+          shape.push_back(ToRknpuDim(dim.dim_value(), value_info.name()));
         } else {
           break;
         }
@@ -578,7 +589,7 @@ std::vector<std::vector<int>> OnnxConverter::GetSupportedNodes(
     const std::string name = tensor.name();
     std::vector<uint32_t> dims;
     for (const auto dim : tensor.dims()) {
-      dims.push_back(static_cast<uint32_t>(dim));
+      dims.push_back(ToRknpuDim(dim, name));
     }
     tensor_dims_[name] = dims;
   }

--- a/onnxruntime/core/providers/rknpu/onnx_converter.cc
+++ b/onnxruntime/core/providers/rknpu/onnx_converter.cc
@@ -138,9 +138,10 @@ static uint32_t ToRknpuDim(int64_t dim, const std::string& name) {
 // failure paths report element_size/count (and the byte count) to aid diagnosis.
 static void* AllocZeroedBias(size_t element_size, uint32_t count) {
   size_t num_bytes = 0;
-  try {
+  ORT_TRY {
     num_bytes = SafeInt<size_t>(element_size) * count;
-  } catch (const std::exception&) {
+  }
+  ORT_CATCH(const std::exception&) {
     ORT_THROW("RKNPU: implicit bias size overflow (element_size=", element_size,
               ", count=", count, ")");
   }

--- a/onnxruntime/core/providers/rknpu/onnx_converter.cc
+++ b/onnxruntime/core/providers/rknpu/onnx_converter.cc
@@ -129,11 +129,10 @@ static uint32_t ToRknpuDim(int64_t dim, const std::string& name) {
   return static_cast<uint32_t>(dim);
 }
 
-// Allocates a zero-initialized buffer holding `count` elements of `element_size`
-// bytes each, used as an implicit (all-zero) bias when a Conv/Gemm node omits
-// its bias input. SafeInt throws OnnxRuntimeException if `element_size * count`
-// overflows size_t, guarding against a heap buffer overflow from a malicious
-// weight dimension. std::make_unique zero-initializes and owns the buffer.
+// Allocates a zero-initialized bias buffer for `count` elements of `element_size`
+// bytes, used when a Conv/Gemm node omits its bias input. SafeInt provides
+// overflow-checked size arithmetic (throws on size_t overflow); std::make_unique
+// zero-initializes and owns the buffer.
 static std::unique_ptr<uint8_t[]> AllocZeroedBias(size_t element_size, uint32_t count) {
   const size_t num_bytes = SafeInt<size_t>(element_size) * count;
   return std::make_unique<uint8_t[]>(num_bytes);

--- a/onnxruntime/core/providers/rknpu/onnx_converter.cc
+++ b/onnxruntime/core/providers/rknpu/onnx_converter.cc
@@ -11,6 +11,7 @@
 #include <memory>
 #include <vector>
 #include "core/common/logging/logging.h"
+#include "core/common/safeint.h"
 #include "onnx_converter.h"
 #include "node_attr_helper.h"
 
@@ -117,6 +118,24 @@ OnnxConverter::CreateRknnTensor(const std::string& name,
   attr->qntParamAffineAsymmetric.scale.push_back(scale);
   attr->qntParamSymmetric.scale.push_back(scale);
   return graph_->CreateTensor(attr, (void*)data);
+}
+
+// Allocates a zero-initialized buffer holding `count` elements of `element_size`
+// bytes each, used as an implicit (all-zero) bias when a Conv/Gemm node omits
+// its bias input. A malicious model can specify a weight dimension large enough
+// that `element_size * count` overflows size_t and wraps to a tiny allocation,
+// which would cause a heap buffer overflow when the buffer is later consumed.
+// SafeInt throws on overflow, and the allocation result is null-checked.
+static void* AllocZeroedBias(size_t element_size, uint32_t count) {
+  const size_t num_bytes = SafeInt<size_t>(element_size) * count;
+  void* ptr = malloc(num_bytes);
+  if (ptr == nullptr && num_bytes != 0) {
+    throw std::runtime_error("RKNPU: failed to allocate implicit bias buffer");
+  }
+  if (ptr != nullptr) {
+    memset(ptr, 0, num_bytes);
+  }
+  return ptr;
 }
 
 void OnnxConverter::HandleInitializer() {
@@ -944,8 +963,7 @@ void OnnxConverter::AddLayerConvImpl(const std::string& input,
     }
   } else {
     uint32_t dim = shaper_[weight][0];
-    void* ptr = (void*)malloc(sizeof(float) * dim);
-    memset(ptr, 0, sizeof(float) * dim);
+    void* ptr = AllocZeroedBias(sizeof(float), dim);
     free_list_.push_back(ptr);
 
     std::vector<uint32_t> dims = {dim};
@@ -1053,8 +1071,7 @@ void OnnxConverter::AddLayerQLinearConvImpl(const string& input,
     }
   } else {
     uint32_t dim = shaper_[weight][0];
-    void* ptr = (void*)malloc(sizeof(int32_t) * dim);
-    memset(ptr, 0, sizeof(int32_t) * dim);
+    void* ptr = AllocZeroedBias(sizeof(int32_t), dim);
     free_list_.push_back(ptr);
 
     std::vector<uint32_t> dims = {dim};
@@ -1142,8 +1159,7 @@ void OnnxConverter::AddLayerDepthwiseConvImpl(
     }
   } else {
     uint32_t dim = shaper_[weight][0];
-    void* ptr = (void*)malloc(sizeof(float) * dim);
-    memset(ptr, 0, sizeof(float) * dim);
+    void* ptr = AllocZeroedBias(sizeof(float), dim);
     free_list_.push_back(ptr);
 
     std::vector<uint32_t> dims = {dim};
@@ -1376,8 +1392,7 @@ void OnnxConverter::AddLayerFC(const std::string& input,
     }
   } else {
     uint32_t dim = shaper_[weight][0];
-    void* ptr = (void*)malloc(sizeof(float) * dim);
-    memset(ptr, 0, sizeof(float) * dim);
+    void* ptr = AllocZeroedBias(sizeof(float), dim);
     free_list_.push_back(ptr);
 
     std::vector<uint32_t> dims = {dim};

--- a/onnxruntime/core/providers/rknpu/onnx_converter.cc
+++ b/onnxruntime/core/providers/rknpu/onnx_converter.cc
@@ -11,6 +11,7 @@
 #include <algorithm>
 #include <memory>
 #include <vector>
+#include "core/common/common.h"
 #include "core/common/logging/logging.h"
 #include "core/common/safeint.h"
 #include "onnx_converter.h"
@@ -122,11 +123,8 @@ OnnxConverter::CreateRknnTensor(const std::string& name,
 }
 
 static uint32_t ToRknpuDim(int64_t dim, const std::string& name) {
-  if (dim < 0 || dim > static_cast<int64_t>(std::numeric_limits<uint32_t>::max())) {
-    throw std::invalid_argument(
-        "RKNPU: tensor dimension out of uint32_t range (name=" + name +
-        ", dim=" + std::to_string(dim) + ")");
-  }
+  ORT_ENFORCE(dim >= 0 && dim <= static_cast<int64_t>(std::numeric_limits<uint32_t>::max()),
+              "RKNPU: tensor dimension out of uint32_t range (name=", name, ", dim=", dim, ")");
 
   return static_cast<uint32_t>(dim);
 }

--- a/onnxruntime/core/providers/rknpu/onnx_converter.cc
+++ b/onnxruntime/core/providers/rknpu/onnx_converter.cc
@@ -131,29 +131,12 @@ static uint32_t ToRknpuDim(int64_t dim, const std::string& name) {
 
 // Allocates a zero-initialized buffer holding `count` elements of `element_size`
 // bytes each, used as an implicit (all-zero) bias when a Conv/Gemm node omits
-// its bias input. A malicious model can specify a weight dimension large enough
-// that `element_size * count` overflows size_t and wraps to a tiny allocation,
-// which would cause a heap buffer overflow when the buffer is later consumed.
-// SafeInt throws on overflow, and the allocation result is null-checked. Both
-// failure paths report element_size/count (and the byte count) to aid diagnosis.
-static void* AllocZeroedBias(size_t element_size, uint32_t count) {
-  size_t num_bytes = 0;
-  ORT_TRY {
-    num_bytes = SafeInt<size_t>(element_size) * count;
-  }
-  ORT_CATCH(const std::exception&) {
-    ORT_THROW("RKNPU: implicit bias size overflow (element_size=", element_size,
-              ", count=", count, ")");
-  }
-  void* ptr = malloc(num_bytes);
-  ORT_ENFORCE(ptr != nullptr || num_bytes == 0,
-              "RKNPU: failed to allocate ", num_bytes,
-              " bytes for implicit bias (element_size=", element_size,
-              ", count=", count, ")");
-  if (ptr != nullptr) {
-    memset(ptr, 0, num_bytes);
-  }
-  return ptr;
+// its bias input. SafeInt throws OnnxRuntimeException if `element_size * count`
+// overflows size_t, guarding against a heap buffer overflow from a malicious
+// weight dimension. std::make_unique zero-initializes and owns the buffer.
+static std::unique_ptr<uint8_t[]> AllocZeroedBias(size_t element_size, uint32_t count) {
+  const size_t num_bytes = SafeInt<size_t>(element_size) * count;
+  return std::make_unique<uint8_t[]>(num_bytes);
 }
 
 void OnnxConverter::HandleInitializer() {
@@ -851,9 +834,6 @@ void OnnxConverter::Clear() {
   rk_tensors_.clear();
   shaper_.Clear();
 
-  for (const auto p : free_list_) {
-    if (p) free(p);
-  }
   free_list_.clear();
 }
 
@@ -981,8 +961,8 @@ void OnnxConverter::AddLayerConvImpl(const std::string& input,
     }
   } else {
     uint32_t dim = shaper_[weight][0];
-    void* ptr = AllocZeroedBias(sizeof(float), dim);
-    free_list_.push_back(ptr);
+    free_list_.push_back(AllocZeroedBias(sizeof(float), dim));
+    void* ptr = free_list_.back().get();
 
     std::vector<uint32_t> dims = {dim};
     auto rk_bias = CreateRknnTensor(bias, dims, ptr, rk::nn::TensorRole::CONST);
@@ -1089,8 +1069,8 @@ void OnnxConverter::AddLayerQLinearConvImpl(const string& input,
     }
   } else {
     uint32_t dim = shaper_[weight][0];
-    void* ptr = AllocZeroedBias(sizeof(int32_t), dim);
-    free_list_.push_back(ptr);
+    free_list_.push_back(AllocZeroedBias(sizeof(int32_t), dim));
+    void* ptr = free_list_.back().get();
 
     std::vector<uint32_t> dims = {dim};
     auto rk_bias = CreateRknnTensor(bias, dims, ptr, rk::nn::TensorRole::CONST,
@@ -1177,8 +1157,8 @@ void OnnxConverter::AddLayerDepthwiseConvImpl(
     }
   } else {
     uint32_t dim = shaper_[weight][0];
-    void* ptr = AllocZeroedBias(sizeof(float), dim);
-    free_list_.push_back(ptr);
+    free_list_.push_back(AllocZeroedBias(sizeof(float), dim));
+    void* ptr = free_list_.back().get();
 
     std::vector<uint32_t> dims = {dim};
     auto rk_bias = CreateRknnTensor(bias, dims, ptr, rk::nn::TensorRole::CONST);
@@ -1410,8 +1390,8 @@ void OnnxConverter::AddLayerFC(const std::string& input,
     }
   } else {
     uint32_t dim = shaper_[weight][0];
-    void* ptr = AllocZeroedBias(sizeof(float), dim);
-    free_list_.push_back(ptr);
+    free_list_.push_back(AllocZeroedBias(sizeof(float), dim));
+    void* ptr = free_list_.back().get();
 
     std::vector<uint32_t> dims = {dim};
     auto rk_bias = CreateRknnTensor(bias, dims, ptr, rk::nn::TensorRole::CONST);

--- a/onnxruntime/core/providers/rknpu/onnx_converter.cc
+++ b/onnxruntime/core/providers/rknpu/onnx_converter.cc
@@ -125,12 +125,23 @@ OnnxConverter::CreateRknnTensor(const std::string& name,
 // its bias input. A malicious model can specify a weight dimension large enough
 // that `element_size * count` overflows size_t and wraps to a tiny allocation,
 // which would cause a heap buffer overflow when the buffer is later consumed.
-// SafeInt throws on overflow, and the allocation result is null-checked.
+// SafeInt throws on overflow, and the allocation result is null-checked. Both
+// failure paths report element_size/count (and the byte count) to aid diagnosis.
 static void* AllocZeroedBias(size_t element_size, uint32_t count) {
-  const size_t num_bytes = SafeInt<size_t>(element_size) * count;
+  size_t num_bytes = 0;
+  try {
+    num_bytes = SafeInt<size_t>(element_size) * count;
+  } catch (const std::exception&) {
+    throw std::runtime_error(
+        "RKNPU: implicit bias size overflow (element_size=" +
+        std::to_string(element_size) + ", count=" + std::to_string(count) + ")");
+  }
   void* ptr = malloc(num_bytes);
   if (ptr == nullptr && num_bytes != 0) {
-    throw std::runtime_error("RKNPU: failed to allocate implicit bias buffer");
+    throw std::runtime_error(
+        "RKNPU: failed to allocate " + std::to_string(num_bytes) +
+        " bytes for implicit bias (element_size=" + std::to_string(element_size) +
+        ", count=" + std::to_string(count) + ")");
   }
   if (ptr != nullptr) {
     memset(ptr, 0, num_bytes);

--- a/onnxruntime/core/providers/rknpu/onnx_converter.h
+++ b/onnxruntime/core/providers/rknpu/onnx_converter.h
@@ -63,7 +63,7 @@ class OnnxConverter {
   // for GetSupportedNodes
   std::map<std::string, std::vector<uint32_t>> tensor_dims_;
 
-  std::vector<void*> free_list_;  // remember free
+  std::vector<std::unique_ptr<uint8_t[]>> free_list_;  // owns implicit-bias buffers
 
   std::pair<std::pair<int, ONNX_NAMESPACE::NodeProto>, FuseCode>
   FindActivation(const ONNX_NAMESPACE::ModelProto& model_proto,


### PR DESCRIPTION
### Description

The RKNPU execution provider's ONNX converter creates implicit (all-zero) bias
buffers when a `Conv` / `Gemm` / `QLinearConv` node omits its bias input. The
buffer size was computed as `sizeof(T) * dim` (where `dim` derives from a model
weight's shape) with no overflow check, and the raw allocation was tracked in a
manually-freed `void*` list.

This PR hardens the converter:

- **Dimension validation:** ONNX `int64_t` dimensions are validated (via
  `ORT_ENFORCE` in a new `ToRknpuDim` helper) before being narrowed to the RKNPU
  `uint32_t` shape representation, rejecting negative or out-of-range values.
  This covers all four ingestion points (`HandleInitializer`,
  `GetInputOfOnnxModel`, `GetShape`, `GetSupportedNodes`).
- **Overflow-checked allocation:** all four implicit-bias sites
  (`AddLayerConvImpl`, `AddLayerQLinearConvImpl`, `AddLayerDepthwiseConvImpl`,
  `AddLayerFC`) go through a shared `AllocZeroedBias` helper that computes the
  byte count with `SafeInt<size_t>` (throws on overflow) and returns a
  zero-initialized `std::make_unique<uint8_t[]>` buffer.
- **RAII ownership:** `free_list_` is now
  `std::vector<std::unique_ptr<uint8_t[]>>`, so the bias buffers are freed
  automatically and `Clear()` no longer walks/`free()`s raw pointers.

### Motivation and Context

A malicious ONNX model can provide dimensions that are unsafe for the RKNPU
converter's 32-bit shape representation or for byte-size allocation arithmetic:

- ONNX stores dimensions as `int64_t`, while the RKNPU converter/DDK uses
  `uint32_t` shape values. Silently narrowing a large or negative `int64_t`
  value can produce a misleading `uint32_t` dimension.
- Even after a dimension is represented as `uint32_t`, the original
  `sizeof(T) * dim` could overflow `size_t` on 32-bit RKNPU targets. For example,
  `dim = 0x40000400` makes `sizeof(float) * dim` wrap to **4096 bytes** while the
  created tensor still advertises `dim` elements, which would corrupt the heap
  when the bias is consumed by the driver.
- The original code also passed the `malloc` result to `memset` without a null
  check.

The fix uses `SafeInt<size_t>` (the ORT-standard idiom for memory-size
arithmetic), validates ONNX dimensions before they enter the RKNPU `uint32_t`
shape model, and replaces the manual `malloc`/`free` list with zero-initialized,
RAII-owned `std::make_unique<uint8_t[]>` buffers.

**Validation:** the RKNPU EP requires the Rockchip DDK (`RKNPU_DDK_PATH`) and an
ARM target, so it does not build on a typical x64 dev box and has no GPU-free CI
leg. The change was validated with `clang-format`, `git diff --check`, and a
standalone test against ORT's `SafeInt.hpp`, confirming the guard throws on the
overflowing dimensions (`0x40000400`, `0xFFFFFFFF`) while preserving normal and
zero-dimension behavior.

**Testing:** No unit test is included because the RKNPU EP is not compiled in
any CI leg (it requires the proprietary Rockchip DDK and an ARM target), and the
`ToRknpuDim` / `AllocZeroedBias` helpers have internal (file-`static`) linkage,
so they are not reachable from the gtest suites. The overflow/validation logic
was instead exercised with a standalone test against ORT's `SafeInt.hpp` as
noted above.

