### PR TITLE
Validate GatherBlockQuantized inputs (CUDA)

### DIFF
--- a/onnxruntime/contrib_ops/cuda/quantization/gather_block_quantized.cc
+++ b/onnxruntime/contrib_ops/cuda/quantization/gather_block_quantized.cc
@@ -47,6 +47,15 @@ template <typename T1, typename T2, typename Tind>
 GatherBlockQuantized<T1, T2, Tind>::GatherBlockQuantized(const OpKernelInfo& info) : CudaKernel(info) {
   ORT_ENFORCE(info.GetAttr("bits", &bits_).IsOK());
 
+  // bits_ is used as the divisor in 8 / bits_ to derive the uint8 packing factor, so it must
+  // be one of the supported widths. uint8 data packs 4 or 8 bit values; int4/uint4 are 4 bit.
+  if constexpr (std::is_same_v<T1, uint8_t>) {
+    ORT_ENFORCE(bits_ == 4 || bits_ == 8,
+                "GatherBlockQuantized with uint8 data only supports bits == 4 or 8.");
+  } else {
+    ORT_ENFORCE(bits_ == 4, "GatherBlockQuantized with int4/uint4 data only supports bits == 4.");
+  }
+
   block_size_ = info.GetAttrOrDefault<int64_t>("block_size", 0);
   gather_axis_ = info.GetAttrOrDefault<int64_t>("gather_axis", 0);
   quantize_axis_ = info.GetAttrOrDefault<int64_t>("quantize_axis", 0);
@@ -70,6 +79,46 @@ Status GatherBlockQuantized<T1, T2, Tind>::ComputeInternal(OpKernelContext* ctx)
   int64_t indices_rank = static_cast<int64_t>(indices->Shape().NumDimensions());
 
   ORT_ENFORCE(quantize_axis_ == static_cast<int64_t>(data_rank) - 1);
+
+  // block_size is used as a divisor when mapping an element to its quantization block,
+  // so it must be strictly positive (the constructor permits the unset default of 0).
+  ORT_RETURN_IF_NOT(block_size_ > 0, "'block_size' must be greater than 0.");
+
+  // When sub-byte data is packed into uint8_t, the last (quantize) dimension stores
+  // multiple values per stored element. components is the packing factor.
+  uint32_t components = 1;
+  if constexpr (std::is_same_v<T1, uint8_t>) {
+    components = 8 / static_cast<uint32_t>(bits_);
+  }
+
+  // Validate scales shape against data shape, matching the CPU kernel: every dimension
+  // must be equal except the quantize axis, which is divided into block_size blocks.
+  auto scales_shape = scales->Shape().GetDims();
+  ORT_RETURN_IF_NOT(data_rank == static_cast<int64_t>(scales->Shape().NumDimensions()),
+                    "data and scales must have the same rank.");
+  for (size_t i = 0; i < data_shape.size(); ++i) {
+    ORT_RETURN_IF_NOT(static_cast<int64_t>(i) == quantize_axis_
+                          ? (data_shape[i] * components + block_size_ - 1) / block_size_ == scales_shape[i]
+                          : data_shape[i] == scales_shape[i],
+                      "data and scales do not match shapes.");
+  }
+
+  // Validate zero_points shape against scales shape when provided.
+  if (zero_points != nullptr) {
+    auto zero_points_shape = zero_points->Shape().GetDims();
+    ORT_RETURN_IF_NOT(scales->Shape().NumDimensions() == zero_points->Shape().NumDimensions(),
+                      "scales and zero_points must have the same rank.");
+    for (size_t i = 0; i < scales_shape.size(); ++i) {
+      if (components > 1 && static_cast<int64_t>(i) == quantize_axis_) {
+        // For uint8_t with bits < 8, zero_points are packed components per stored element.
+        ORT_RETURN_IF_NOT((scales_shape[i] + components - 1) / components == zero_points_shape[i],
+                          "scales and zero_points shape does not match.");
+      } else {
+        ORT_RETURN_IF_NOT(scales_shape[i] == zero_points_shape[i],
+                          "scales and zero_points must have the same shape.");
+      }
+    }
+  }
 
   TensorShapeVector output_shape;
   output_shape.reserve(data_rank - 1 + indices_rank);
@@ -98,11 +147,8 @@ Status GatherBlockQuantized<T1, T2, Tind>::ComputeInternal(OpKernelContext* ctx)
   }
 
   // Special int4‐in‐uint8 packing tweak: expand the last dim by components
-  if constexpr (std::is_same_v<T1, uint8_t>) {
-    uint32_t components = 8 / static_cast<int>(bits_);
-    if (components > 1) {
-      output_shape.back() *= components;
-    }
+  if (components > 1) {
+    output_shape.back() *= components;
   }
 
   Tensor* output = ctx->Output(0, TensorShape(output_shape));
@@ -123,11 +169,8 @@ Status GatherBlockQuantized<T1, T2, Tind>::ComputeInternal(OpKernelContext* ctx)
   // after_gather_dim has to be adjusted to match
   // the unpacked output dims for correct kernel indexing
   int64_t after_gather_dim_unpacked = after_gather_dim;
-  if constexpr (std::is_same_v<T1, uint8_t>) {
-    uint32_t components = 8 / static_cast<int>(bits_);
-    if (components > 1) {
-      after_gather_dim_unpacked *= components;
-    }
+  if (components > 1) {
+    after_gather_dim_unpacked *= components;
   }
 
   GatherBlockQuantizedParam param;
@@ -139,6 +182,12 @@ Status GatherBlockQuantized<T1, T2, Tind>::ComputeInternal(OpKernelContext* ctx)
   param.block_size = block_size_;
   param.gather_axis = gather_axis_;
   param.N = N;
+
+  // Device flag the kernel sets when a gathered index is outside the valid range.
+  // It is initialized to 0 and read back after the launch to surface a clean status.
+  auto index_out_of_bounds = GetScratchBuffer<int>(1, ctx->GetComputeStream());
+  CUDA_RETURN_IF_ERROR(cudaMemsetAsync(index_out_of_bounds.get(), 0, sizeof(int), param.stream));
+  param.index_out_of_bounds = index_out_of_bounds.get();
 
   const auto dequantized_type = scales->GetElementType();
   if (dequantized_type == ONNX_NAMESPACE::TensorProto_DataType_FLOAT) {
@@ -153,6 +202,23 @@ Status GatherBlockQuantized<T1, T2, Tind>::ComputeInternal(OpKernelContext* ctx)
     const auto* scales_ptr = static_cast<const BFloat16*>(scales->DataRaw());
     auto* output_ptr = static_cast<BFloat16*>(output->MutableDataRaw());
     LaunchGatherBlockQuantizedKernel(data_ptr, indices_ptr, scales_ptr, zero_points_ptr, output_ptr, param);
+  }
+
+  auto host_index_out_of_bounds = AllocateBufferOnCPUPinned<int>(1);
+  // The device-side bounds check and kernel early-return above always run, so memory
+  // safety does not depend on the host readback below. The readback only upgrades a
+  // silently incorrect result into a clean error, and it requires a device-to-host copy
+  // plus a stream synchronize. Both are illegal while the stream is being captured for a
+  // CUDA graph, so skip the readback during capture and let the device-side guard stand.
+  cudaStreamCaptureStatus capture_status = cudaStreamCaptureStatusNone;
+  CUDA_RETURN_IF_ERROR(cudaStreamIsCapturing(param.stream, &capture_status));
+  if (capture_status == cudaStreamCaptureStatusNone) {
+    CUDA_RETURN_IF_ERROR(cudaMemcpyAsync(host_index_out_of_bounds.get(), index_out_of_bounds.get(), sizeof(int),
+                                         cudaMemcpyDeviceToHost, param.stream));
+    CUDA_RETURN_IF_ERROR(cudaStreamSynchronize(param.stream));
+    ORT_RETURN_IF(*host_index_out_of_bounds.get() != 0,
+                  "indices element out of data bounds. Each index must be within the inclusive range [",
+                  -param.gather_axis_dim, ", ", param.gather_axis_dim - 1, "].");
   }
 
   return Status::OK();

--- a/onnxruntime/contrib_ops/cuda/quantization/gather_block_quantized.cu
+++ b/onnxruntime/contrib_ops/cuda/quantization/gather_block_quantized.cu
@@ -44,7 +44,8 @@ __global__ void GatherBlockQuantizedKernel(
     int64_t block_size,
     int64_t gather_axis,
     int64_t N,
-    bool sign) {
+    bool sign,
+    int* index_out_of_bounds) {
   int64_t out_idx = blockDim.x * blockIdx.x + threadIdx.x;
   if (out_idx >= N) return;
 
@@ -53,6 +54,18 @@ __global__ void GatherBlockQuantizedKernel(
   int64_t idx_after = out_idx % after_gather_dim;
   int64_t idx = (out_idx % (after_gather_dim * ind_dim)) / after_gather_dim;
   int64_t idx_at_g = indices[idx];
+
+  // Validate the gathered index and normalize negatives, mirroring the CPU kernel.
+  // A negative index counts from the end of the gather axis; anything outside
+  // [-gather_axis_dim, gather_axis_dim) is reported via the device error flag.
+  if (idx_at_g < -gather_axis_dim || idx_at_g >= gather_axis_dim) {
+    *index_out_of_bounds = 1;
+    return;
+  }
+  if (idx_at_g < 0) {
+    idx_at_g += gather_axis_dim;
+  }
+
   int64_t in_idx = idx_before * gather_axis_dim * after_gather_dim + idx_at_g * after_gather_dim + idx_after;
 
   int64_t block_id = in_idx / block_size;
@@ -81,8 +94,10 @@ void LaunchGatherBlockQuantizedKernel(const T1* data,
   int blocksPerGrid = (int)(ceil(static_cast<float>(param.N) / GridDim::maxThreadsPerBlock));
   bool sign = std::is_same<T1, Int4x2>::value;
 
-  GatherBlockQuantizedKernel<<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0, param.stream>>>(data, indices, scales, zero_points, output,
-                                                                                              param.after_gather_dim, param.gather_axis_dim, param.ind_dim, param.bits, param.block_size, param.gather_axis, param.N, sign);
+  GatherBlockQuantizedKernel<<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0, param.stream>>>(
+      data, indices, scales, zero_points, output,
+      param.after_gather_dim, param.gather_axis_dim, param.ind_dim, param.bits, param.block_size,
+      param.gather_axis, param.N, sign, param.index_out_of_bounds);
 }
 
 template void LaunchGatherBlockQuantizedKernel<uint8_t, float, int32_t>(const uint8_t*, const int32_t*, const float*, const uint8_t*, float*, GatherBlockQuantizedParam);

--- a/onnxruntime/contrib_ops/cuda/quantization/gather_block_quantized.cuh
+++ b/onnxruntime/contrib_ops/cuda/quantization/gather_block_quantized.cuh
@@ -19,6 +19,10 @@ struct GatherBlockQuantizedParam {
   int64_t block_size;
   int64_t gather_axis;
   int64_t N;
+  // Device buffer of a single int. The kernel sets it to 1 if any gathered index
+  // is outside the valid range [-gather_axis_dim, gather_axis_dim). The host reads
+  // it back after the launch and returns an error status when it is set.
+  int* index_out_of_bounds;
 };
 
 template <typename T1, typename T2, typename Tind>

--- a/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
@@ -4072,8 +4072,10 @@ GatherBlockQuantized is a Gather with data quantized. It is similar to Gather (h
         if (quantize_axis < -r || quantize_axis >= r) {
           fail_shape_inference("quantize_axis must be in [-r, r-1]");
         }
-        if (block_size < 0) {
-          fail_shape_inference("block_size must be non-negative");
+        if (block_size <= 0) {
+          // block_size is used as a divisor below when relating data and scales shapes,
+          // so it must be strictly positive.
+          fail_shape_inference("block_size must be greater than 0");
         }
 
         gather_axis = (gather_axis + r) % r;

--- a/onnxruntime/test/contrib_ops/gather_block_quantized_op_test.cc
+++ b/onnxruntime/test/contrib_ops/gather_block_quantized_op_test.cc
@@ -375,6 +375,12 @@ TEST(GatherBlockQuantizedOpTest, UnsupportedTypes) {
 }
 #endif
 
+// Runs GatherBlockQuantized with inputs that are expected to be rejected (no zero_points).
+// Parameters:
+//   gather_axis   - value for the "gather_axis" attribute
+//   quantize_axis - value for the "quantize_axis" attribute
+//   block_size    - value for the "block_size" attribute
+//   bits          - value for the "bits" attribute (default 4)
 template <typename T1, typename T2, typename Tind>
 void Test_Fail_WithoutZeroPoints(int64_t gather_axis,
                                  int64_t quantize_axis,
@@ -504,6 +510,44 @@ TEST(GatherBlockQuantizedOpTest, InvalidIndices) {
   Test_InvalidIndices_WithZeroPoints<UInt4x2, float, int32_t>();
   Test_InvalidIndices_WithZeroPoints<Int4x2, float, int32_t>();
   Test_InvalidIndices_WithZeroPoints<uint8_t, float, int32_t>();
+}
+#endif
+
+#ifdef USE_CUDA
+// The CUDA EP validates quantization-parameter shapes on the host and gathered-index
+// bounds on the device. These cases mirror the CPU coverage above but run on the CUDA
+// EP, which previously skipped these checks. They fall back to the CPU EP (which rejects
+// the same inputs) when no CUDA device is present.
+TEST(GatherBlockQuantizedOpTest, CudaShapeMismatch) {
+  Test_ShapeMismatch_WithZeroPoints<UInt4x2, float, int32_t>();
+  Test_ShapeMismatch_WithZeroPoints<Int4x2, float, int32_t>();
+  Test_ShapeMismatch_WithZeroPoints<uint8_t, float, int32_t>();
+}
+
+TEST(GatherBlockQuantizedOpTest, CudaInvalidIndices) {
+  Test_InvalidIndices_WithZeroPoints<UInt4x2, float, int32_t>();
+  Test_InvalidIndices_WithZeroPoints<Int4x2, float, int32_t>();
+  Test_InvalidIndices_WithZeroPoints<uint8_t, float, int32_t>();
+}
+
+// block_size == 0 is an invalid divisor for relating data and scales shapes, so shape
+// inference rejects it with fail_shape_inference during Graph::Resolve.
+TEST(GatherBlockQuantizedOpTest, CudaInvalidBlockSizeZero) {
+  Test_Fail_WithoutZeroPoints<UInt4x2, float, int32_t>(/*gather_axis=*/0, /*quantize_axis=*/2, /*block_size=*/0);
+  Test_Fail_WithoutZeroPoints<Int4x2, float, int32_t>(/*gather_axis=*/0, /*quantize_axis=*/2, /*block_size=*/0);
+  Test_Fail_WithoutZeroPoints<uint8_t, float, int32_t>(/*gather_axis=*/0, /*quantize_axis=*/2, /*block_size=*/0);
+}
+
+// uint8 data supports bits in {4, 8} and int4/uint4 supports bits == 4 on CUDA; other
+// values are rejected by the constructor before the 8 / bits division that derives the
+// uint8 packing factor.
+TEST(GatherBlockQuantizedOpTest, CudaUnsupportedBits) {
+  Test_Fail_WithoutZeroPoints<UInt4x2, float, int32_t>(
+      /*gather_axis=*/0, /*quantize_axis=*/2, /*block_size=*/16, /*bits=*/3);
+  Test_Fail_WithoutZeroPoints<Int4x2, float, int32_t>(
+      /*gather_axis=*/0, /*quantize_axis=*/2, /*block_size=*/16, /*bits=*/8);
+  Test_Fail_WithoutZeroPoints<uint8_t, float, int32_t>(
+      /*gather_axis=*/0, /*quantize_axis=*/2, /*block_size=*/16, /*bits=*/3);
 }
 #endif
 


### PR DESCRIPTION
The CUDA GatherBlockQuantized implementation validates its inputs so malformed inputs are rejected with clear diagnostics instead of being used directly, bringing the CUDA path in line with the CPU implementation:

- Validates the `data`/`scales`/`zero_points` shape compatibility (matching rank, the per-axis block relationship between `data` and `scales`, and `scales`/`zero_points` consistency).
- Rejects a non-positive `block_size` at both the kernel and the GatherBlockQuantized shape-inference function, where it is used as a divisor when relating the `data` and `scales` shapes; this avoids a divide error during `Graph::Resolve`.
- Guards the supported per-dtype bit-widths.
- Bounds-checks/normalizes gather index values against the data extent on the device and surfaces an out-of-range index as a non-OK status from the host (no silent clamp). The host error-flag readback is skipped while a CUDA graph is being captured so graph capture remains supported.

Adds expect-failure tests for these cases; they follow this file's existing convention for the CUDA-only cases.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
