### PR TITLE
Add rotary embedding onnx domain support

### DIFF
--- a/onnxruntime/core/optimizer/group_query_attention_fusion.cc
+++ b/onnxruntime/core/optimizer/group_query_attention_fusion.cc
@@ -289,20 +289,17 @@ static bool TryGetRotaryEmbeddingArgs(Node& rotary_node, RotaryEmbeddingArgs& ar
   }
 
   auto& input_defs = rotary_node.MutableInputDefs();
-  if (rotary_node.Domain() == kMSDomain) {
-    // com.microsoft.RotaryEmbedding inputs:
-    //   input, position_ids, cos_cache, sin_cache
-    if (input_defs.size() < 4 || !NodeArgExists(input_defs[1]) || !NodeArgExists(input_defs[2]) ||
-        !NodeArgExists(input_defs[3])) {
-      return false;
-    }
-    args.position_ids_arg = input_defs[1];
-    args.cos_cache_arg = input_defs[2];
-    args.sin_cache_arg = input_defs[3];
-    return true;
+  // com.microsoft.RotaryEmbedding inputs:
+  //   input, position_ids, cos_cache, sin_cache
+  if (input_defs.size() < 4 || !NodeArgExists(input_defs[1]) || !NodeArgExists(input_defs[2]) ||
+      !NodeArgExists(input_defs[3])) {
+    return false;
   }
 
-  return false;
+  args.position_ids_arg = input_defs[1];
+  args.cos_cache_arg = input_defs[2];
+  args.sin_cache_arg = input_defs[3];
+  return true;
 }
 
 static void FusePreGQANodes(Graph& graph, Node* q_node, Node* k_node, Node* v_node, Node* rotary_node_1, Node* rotary_node_2, Node* new_node, NodeArg& new_node_output_arg) {
@@ -578,6 +575,9 @@ Status GroupQueryAttentionFusion::ApplyImpl(
         cos_cache_arg,
         sin_cache_arg};
     if (position_ids_arg != nullptr) {
+      // During prefill, GQA treats position_ids[0] as a shared base and derives each token's
+      // position as base + sequence index. This fusion therefore assumes the MS-domain
+      // RotaryEmbedding inputs use contiguous positions with the same base for every batch.
       gqa_input_defs.push_back(position_ids_arg);
     }
 

--- a/onnxruntime/core/optimizer/group_query_attention_fusion.cc
+++ b/onnxruntime/core/optimizer/group_query_attention_fusion.cc
@@ -248,6 +248,37 @@ static bool CheckIfAnyOfRequiredGQANodesDoesNotExist(Node* rotary_node_1, Node* 
   return rotary_node_1 == nullptr || rotary_node_2 == nullptr || q_node == nullptr || k_node == nullptr || v_node == nullptr;
 }
 
+static bool TryGetRotaryEmbeddingCacheArgs(Node& rotary_node, NodeArg*& cos_cache_arg, NodeArg*& sin_cache_arg) {
+  if (rotary_node.OpType() != "RotaryEmbedding") {
+    return false;
+  }
+
+  auto& input_defs = rotary_node.MutableInputDefs();
+  if (rotary_node.Domain() == kMSDomain) {
+    // com.microsoft.RotaryEmbedding inputs:
+    //   input, position_ids, cos_cache, sin_cache
+    if (input_defs.size() < 4) {
+      return false;
+    }
+    cos_cache_arg = input_defs[2];
+    sin_cache_arg = input_defs[3];
+    return true;
+  }
+
+  if (rotary_node.Domain() == kOnnxDomain) {
+    // ONNX RotaryEmbedding inputs:
+    //   X, cos_cache, sin_cache, optional position_ids
+    if (input_defs.size() < 3) {
+      return false;
+    }
+    cos_cache_arg = input_defs[1];
+    sin_cache_arg = input_defs[2];
+    return true;
+  }
+
+  return false;
+}
+
 static void FusePreGQANodes(Graph& graph, Node* q_node, Node* k_node, Node* v_node, Node* rotary_node_1, Node* rotary_node_2, Node* new_node, NodeArg& new_node_output_arg) {
   graph_utils::MoveAllNodeInputEdges(graph, *q_node, *new_node);
 
@@ -334,7 +365,9 @@ Status GroupQueryAttentionFusion::ApplyImpl(
     for (auto pre_gqa_node = node.InputNodesBegin(); pre_gqa_node != node.InputNodesEnd(); ++pre_gqa_node) {
       Node& rotary_or_v_node = *graph.GetNode(pre_gqa_node->Index());
 
-      if (rotary_or_v_node.OpType() == "RotaryEmbedding") {
+      NodeArg* rotary_cos_cache_arg = nullptr;
+      NodeArg* rotary_sin_cache_arg = nullptr;
+      if (TryGetRotaryEmbeddingCacheArgs(rotary_or_v_node, rotary_cos_cache_arg, rotary_sin_cache_arg)) {
         if (!rotary_node_1) {
           rotary_node_1 = &rotary_or_v_node;
         } else {
@@ -358,18 +391,19 @@ Status GroupQueryAttentionFusion::ApplyImpl(
         }
 
         if (cos_cache_arg == nullptr) {
-          cos_cache_arg = rotary_or_v_node.MutableInputDefs()[2];
+          cos_cache_arg = rotary_cos_cache_arg;
         }
 
         if (sin_cache_arg == nullptr) {
-          sin_cache_arg = rotary_or_v_node.MutableInputDefs()[3];
+          sin_cache_arg = rotary_sin_cache_arg;
         }
       } else if (rotary_or_v_node.OpType() == "MatMulNBits" || rotary_or_v_node.OpType() == "MatMul") {
         v_node = &rotary_or_v_node;
       }
     }
 
-    if (CheckIfAnyOfRequiredGQANodesDoesNotExist(rotary_node_1, rotary_node_2, q_node, k_node, v_node)) {
+    if (CheckIfAnyOfRequiredGQANodesDoesNotExist(rotary_node_1, rotary_node_2, q_node, k_node, v_node) ||
+        cos_cache_arg == nullptr || sin_cache_arg == nullptr) {
       // Some of the required pre-GQA nodes required for fusion were not retrieved,
       // this can be expected if the model has extra nodes in between MatMuls and rotary embeddings.
       continue;

--- a/onnxruntime/core/optimizer/group_query_attention_fusion.cc
+++ b/onnxruntime/core/optimizer/group_query_attention_fusion.cc
@@ -270,7 +270,15 @@ static bool TryGetRotaryEmbeddingArgs(Node& rotary_node, RotaryEmbeddingArgs& ar
     return false;
   }
 
-  if (rotary_node.Domain() != kMSDomain && rotary_node.Domain() != kOnnxDomain) {
+  if (rotary_node.Domain() == kOnnxDomain) {
+    // Skip ONNX RotaryEmbedding for this fusion. With explicit position_ids it consumes the full
+    // [batch_size, sequence_length] tensor, while fused GQA currently uses prompt-time base-offset
+    // semantics. Without position_ids it uses 3D per-batch caches, which are also incompatible
+    // with GroupQueryAttention's 2D rotary cache inputs.
+    return false;
+  }
+
+  if (rotary_node.Domain() != kMSDomain) {
     return false;
   }
 
@@ -291,21 +299,6 @@ static bool TryGetRotaryEmbeddingArgs(Node& rotary_node, RotaryEmbeddingArgs& ar
     args.position_ids_arg = input_defs[1];
     args.cos_cache_arg = input_defs[2];
     args.sin_cache_arg = input_defs[3];
-    return true;
-  }
-
-  if (rotary_node.Domain() == kOnnxDomain) {
-    // ONNX RotaryEmbedding inputs:
-    //   X, cos_cache, sin_cache, optional position_ids
-    // If position_ids is omitted, ONNX RotaryEmbedding uses 3D per-batch caches, which are
-    // incompatible with GroupQueryAttention's 2D rotary cache inputs.
-    if (input_defs.size() < 4 || !NodeArgExists(input_defs[1]) || !NodeArgExists(input_defs[2]) ||
-        !NodeArgExists(input_defs[3])) {
-      return false;
-    }
-    args.cos_cache_arg = input_defs[1];
-    args.sin_cache_arg = input_defs[2];
-    args.position_ids_arg = input_defs[3];
     return true;
   }
 

--- a/onnxruntime/core/optimizer/group_query_attention_fusion.cc
+++ b/onnxruntime/core/optimizer/group_query_attention_fusion.cc
@@ -248,7 +248,14 @@ static bool CheckIfAnyOfRequiredGQANodesDoesNotExist(Node* rotary_node_1, Node* 
   return rotary_node_1 == nullptr || rotary_node_2 == nullptr || q_node == nullptr || k_node == nullptr || v_node == nullptr;
 }
 
-static bool TryGetRotaryEmbeddingCacheArgs(Node& rotary_node, NodeArg*& cos_cache_arg, NodeArg*& sin_cache_arg) {
+static bool NodeArgExists(const NodeArg* node_arg) {
+  return node_arg != nullptr && node_arg->Exists();
+}
+
+static bool TryGetRotaryEmbeddingArgs(Node& rotary_node,
+                                      NodeArg*& cos_cache_arg,
+                                      NodeArg*& sin_cache_arg,
+                                      NodeArg*& position_ids_arg) {
   if (rotary_node.OpType() != "RotaryEmbedding") {
     return false;
   }
@@ -257,7 +264,7 @@ static bool TryGetRotaryEmbeddingCacheArgs(Node& rotary_node, NodeArg*& cos_cach
   if (rotary_node.Domain() == kMSDomain) {
     // com.microsoft.RotaryEmbedding inputs:
     //   input, position_ids, cos_cache, sin_cache
-    if (input_defs.size() < 4) {
+    if (input_defs.size() < 4 || !NodeArgExists(input_defs[2]) || !NodeArgExists(input_defs[3])) {
       return false;
     }
     cos_cache_arg = input_defs[2];
@@ -268,11 +275,15 @@ static bool TryGetRotaryEmbeddingCacheArgs(Node& rotary_node, NodeArg*& cos_cach
   if (rotary_node.Domain() == kOnnxDomain) {
     // ONNX RotaryEmbedding inputs:
     //   X, cos_cache, sin_cache, optional position_ids
-    if (input_defs.size() < 3) {
+    // If position_ids is omitted, ONNX RotaryEmbedding uses 3D per-batch caches, which are
+    // incompatible with GroupQueryAttention's 2D rotary cache inputs.
+    if (input_defs.size() < 4 || !NodeArgExists(input_defs[1]) || !NodeArgExists(input_defs[2]) ||
+        !NodeArgExists(input_defs[3])) {
       return false;
     }
     cos_cache_arg = input_defs[1];
     sin_cache_arg = input_defs[2];
+    position_ids_arg = input_defs[3];
     return true;
   }
 
@@ -349,6 +360,9 @@ Status GroupQueryAttentionFusion::ApplyImpl(
 
     NodeArg* cos_cache_arg = nullptr;
     NodeArg* sin_cache_arg = nullptr;
+    NodeArg* position_ids_arg = nullptr;
+    bool position_ids_arg_set = false;
+    bool position_ids_arg_mismatch = false;
     NodeArg* past_key_values_key_arg = node.MutableInputDefs()[3];
     NodeArg* past_key_values_value_arg = node.MutableInputDefs()[4];
     NodeArg* seqlens_k = node.MutableInputDefs()[5];
@@ -367,7 +381,11 @@ Status GroupQueryAttentionFusion::ApplyImpl(
 
       NodeArg* rotary_cos_cache_arg = nullptr;
       NodeArg* rotary_sin_cache_arg = nullptr;
-      if (TryGetRotaryEmbeddingCacheArgs(rotary_or_v_node, rotary_cos_cache_arg, rotary_sin_cache_arg)) {
+      NodeArg* rotary_position_ids_arg = nullptr;
+      if (TryGetRotaryEmbeddingArgs(rotary_or_v_node,
+                                    rotary_cos_cache_arg,
+                                    rotary_sin_cache_arg,
+                                    rotary_position_ids_arg)) {
         if (!rotary_node_1) {
           rotary_node_1 = &rotary_or_v_node;
         } else {
@@ -397,12 +415,20 @@ Status GroupQueryAttentionFusion::ApplyImpl(
         if (sin_cache_arg == nullptr) {
           sin_cache_arg = rotary_sin_cache_arg;
         }
+
+        if (!position_ids_arg_set) {
+          position_ids_arg = rotary_position_ids_arg;
+          position_ids_arg_set = true;
+        } else if (position_ids_arg != rotary_position_ids_arg) {
+          position_ids_arg_mismatch = true;
+        }
       } else if (rotary_or_v_node.OpType() == "MatMulNBits" || rotary_or_v_node.OpType() == "MatMul") {
         v_node = &rotary_or_v_node;
       }
     }
 
-    if (CheckIfAnyOfRequiredGQANodesDoesNotExist(rotary_node_1, rotary_node_2, q_node, k_node, v_node) ||
+    if (position_ids_arg_mismatch ||
+        CheckIfAnyOfRequiredGQANodesDoesNotExist(rotary_node_1, rotary_node_2, q_node, k_node, v_node) ||
         cos_cache_arg == nullptr || sin_cache_arg == nullptr) {
       // Some of the required pre-GQA nodes required for fusion were not retrieved,
       // this can be expected if the model has extra nodes in between MatMuls and rotary embeddings.
@@ -527,7 +553,7 @@ Status GroupQueryAttentionFusion::ApplyImpl(
     std::string empty_name;
     auto& empty_node_arg = graph.GetOrCreateNodeArg(empty_name, nullptr);
 
-    const std::array gqa_input_defs{
+    std::vector<NodeArg*> gqa_input_defs{
         &matmul_or_nbits_output,
         &empty_node_arg,
         &empty_node_arg,
@@ -537,10 +563,16 @@ Status GroupQueryAttentionFusion::ApplyImpl(
         total_seq_len,
         cos_cache_arg,
         sin_cache_arg};
+    if (position_ids_arg != nullptr) {
+      gqa_input_defs.push_back(position_ids_arg);
+    }
 
     auto& gqa_input_args = node.MutableInputArgsCount();
     gqa_input_args[7] = 1;
     gqa_input_args[8] = 1;
+    if (position_ids_arg != nullptr) {
+      gqa_input_args[9] = 1;
+    }
 
     // Switch GQA input defs from unfused into the fused form.
     auto& gqa_node_input_defs = node.MutableInputDefs();

--- a/onnxruntime/core/optimizer/group_query_attention_fusion.cc
+++ b/onnxruntime/core/optimizer/group_query_attention_fusion.cc
@@ -252,11 +252,31 @@ static bool NodeArgExists(const NodeArg* node_arg) {
   return node_arg != nullptr && node_arg->Exists();
 }
 
-static bool TryGetRotaryEmbeddingArgs(Node& rotary_node,
-                                      NodeArg*& cos_cache_arg,
-                                      NodeArg*& sin_cache_arg,
-                                      NodeArg*& position_ids_arg) {
+struct RotaryEmbeddingArgs {
+  NodeArg* cos_cache_arg = nullptr;
+  NodeArg* sin_cache_arg = nullptr;
+  NodeArg* position_ids_arg = nullptr;
+  int64_t interleaved = 0;
+  int64_t rotary_embedding_dim = 0;
+};
+
+static int64_t GetIntAttributeOrDefault(const Node& node, const std::string& attr_name, int64_t default_value) {
+  const auto* attr = graph_utils::GetNodeAttribute(node, attr_name);
+  return attr != nullptr ? attr->i() : default_value;
+}
+
+static bool TryGetRotaryEmbeddingArgs(Node& rotary_node, RotaryEmbeddingArgs& args) {
   if (rotary_node.OpType() != "RotaryEmbedding") {
+    return false;
+  }
+
+  if (rotary_node.Domain() != kMSDomain && rotary_node.Domain() != kOnnxDomain) {
+    return false;
+  }
+
+  args.interleaved = GetIntAttributeOrDefault(rotary_node, "interleaved", 0);
+  args.rotary_embedding_dim = GetIntAttributeOrDefault(rotary_node, "rotary_embedding_dim", 0);
+  if ((args.interleaved != 0 && args.interleaved != 1) || args.rotary_embedding_dim < 0) {
     return false;
   }
 
@@ -264,11 +284,13 @@ static bool TryGetRotaryEmbeddingArgs(Node& rotary_node,
   if (rotary_node.Domain() == kMSDomain) {
     // com.microsoft.RotaryEmbedding inputs:
     //   input, position_ids, cos_cache, sin_cache
-    if (input_defs.size() < 4 || !NodeArgExists(input_defs[2]) || !NodeArgExists(input_defs[3])) {
+    if (input_defs.size() < 4 || !NodeArgExists(input_defs[1]) || !NodeArgExists(input_defs[2]) ||
+        !NodeArgExists(input_defs[3])) {
       return false;
     }
-    cos_cache_arg = input_defs[2];
-    sin_cache_arg = input_defs[3];
+    args.position_ids_arg = input_defs[1];
+    args.cos_cache_arg = input_defs[2];
+    args.sin_cache_arg = input_defs[3];
     return true;
   }
 
@@ -281,9 +303,9 @@ static bool TryGetRotaryEmbeddingArgs(Node& rotary_node,
         !NodeArgExists(input_defs[3])) {
       return false;
     }
-    cos_cache_arg = input_defs[1];
-    sin_cache_arg = input_defs[2];
-    position_ids_arg = input_defs[3];
+    args.cos_cache_arg = input_defs[1];
+    args.sin_cache_arg = input_defs[2];
+    args.position_ids_arg = input_defs[3];
     return true;
   }
 
@@ -361,8 +383,10 @@ Status GroupQueryAttentionFusion::ApplyImpl(
     NodeArg* cos_cache_arg = nullptr;
     NodeArg* sin_cache_arg = nullptr;
     NodeArg* position_ids_arg = nullptr;
-    bool position_ids_arg_set = false;
-    bool position_ids_arg_mismatch = false;
+    int64_t rotary_interleaved = 0;
+    int64_t rotary_embedding_dim = 0;
+    bool rotary_args_set = false;
+    bool rotary_args_mismatch = false;
     NodeArg* past_key_values_key_arg = node.MutableInputDefs()[3];
     NodeArg* past_key_values_value_arg = node.MutableInputDefs()[4];
     NodeArg* seqlens_k = node.MutableInputDefs()[5];
@@ -379,13 +403,8 @@ Status GroupQueryAttentionFusion::ApplyImpl(
     for (auto pre_gqa_node = node.InputNodesBegin(); pre_gqa_node != node.InputNodesEnd(); ++pre_gqa_node) {
       Node& rotary_or_v_node = *graph.GetNode(pre_gqa_node->Index());
 
-      NodeArg* rotary_cos_cache_arg = nullptr;
-      NodeArg* rotary_sin_cache_arg = nullptr;
-      NodeArg* rotary_position_ids_arg = nullptr;
-      if (TryGetRotaryEmbeddingArgs(rotary_or_v_node,
-                                    rotary_cos_cache_arg,
-                                    rotary_sin_cache_arg,
-                                    rotary_position_ids_arg)) {
+      RotaryEmbeddingArgs rotary_args;
+      if (TryGetRotaryEmbeddingArgs(rotary_or_v_node, rotary_args)) {
         if (!rotary_node_1) {
           rotary_node_1 = &rotary_or_v_node;
         } else {
@@ -408,26 +427,26 @@ Status GroupQueryAttentionFusion::ApplyImpl(
           }
         }
 
-        if (cos_cache_arg == nullptr) {
-          cos_cache_arg = rotary_cos_cache_arg;
-        }
-
-        if (sin_cache_arg == nullptr) {
-          sin_cache_arg = rotary_sin_cache_arg;
-        }
-
-        if (!position_ids_arg_set) {
-          position_ids_arg = rotary_position_ids_arg;
-          position_ids_arg_set = true;
-        } else if (position_ids_arg != rotary_position_ids_arg) {
-          position_ids_arg_mismatch = true;
+        if (!rotary_args_set) {
+          cos_cache_arg = rotary_args.cos_cache_arg;
+          sin_cache_arg = rotary_args.sin_cache_arg;
+          position_ids_arg = rotary_args.position_ids_arg;
+          rotary_interleaved = rotary_args.interleaved;
+          rotary_embedding_dim = rotary_args.rotary_embedding_dim;
+          rotary_args_set = true;
+        } else if (cos_cache_arg != rotary_args.cos_cache_arg ||
+                   sin_cache_arg != rotary_args.sin_cache_arg ||
+                   position_ids_arg != rotary_args.position_ids_arg ||
+                   rotary_interleaved != rotary_args.interleaved ||
+                   rotary_embedding_dim != rotary_args.rotary_embedding_dim) {
+          rotary_args_mismatch = true;
         }
       } else if (rotary_or_v_node.OpType() == "MatMulNBits" || rotary_or_v_node.OpType() == "MatMul") {
         v_node = &rotary_or_v_node;
       }
     }
 
-    if (position_ids_arg_mismatch ||
+    if (rotary_args_mismatch ||
         CheckIfAnyOfRequiredGQANodesDoesNotExist(rotary_node_1, rotary_node_2, q_node, k_node, v_node) ||
         cos_cache_arg == nullptr || sin_cache_arg == nullptr) {
       // Some of the required pre-GQA nodes required for fusion were not retrieved,
@@ -549,6 +568,8 @@ Status GroupQueryAttentionFusion::ApplyImpl(
     FusePreGQANodes(graph, q_node, k_node, v_node, rotary_node_1, rotary_node_2, mat_mul_or_n_bits_new_node, matmul_or_nbits_output);
 
     node.GetMutableAttributes()["do_rotary"] = ONNX_NAMESPACE::MakeAttribute("do_rotary", static_cast<int64_t>(1));
+    node.GetMutableAttributes()["rotary_interleaved"] =
+        ONNX_NAMESPACE::MakeAttribute("rotary_interleaved", rotary_interleaved);
 
     std::string empty_name;
     auto& empty_node_arg = graph.GetOrCreateNodeArg(empty_name, nullptr);

--- a/onnxruntime/test/optimizer/graph_transform_test_layernorm.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test_layernorm.cc
@@ -607,11 +607,17 @@ static void TestGQAFusion(const std::basic_string<ORTCHAR_T>& file_path, int mat
   ASSERT_TRUE(op_to_count["com.microsoft.GroupQueryAttention"] == 1);
 }
 
-static void BuildOnnxRotaryEmbeddingGQAFusionGraph(ModelTestBuilder& builder,
-                                                   bool include_position_ids,
-                                                   int64_t q_interleaved = 0,
-                                                   int64_t k_interleaved = 0,
-                                                   int64_t rotary_embedding_dim = 0) {
+enum class RotaryEmbeddingDomain {
+  kOnnx,
+  kMS,
+};
+
+static void BuildRotaryEmbeddingGQAFusionGraph(ModelTestBuilder& builder,
+                                               RotaryEmbeddingDomain rotary_domain,
+                                               bool include_position_ids,
+                                               int64_t q_interleaved = 0,
+                                               int64_t k_interleaved = 0,
+                                               int64_t rotary_embedding_dim = 0) {
   constexpr int64_t batch_size = 1;
   constexpr int64_t sequence_length = 2;
   constexpr int64_t input_hidden_size = 8;
@@ -657,18 +663,27 @@ static void BuildOnnxRotaryEmbeddingGQAFusionGraph(ModelTestBuilder& builder,
   NodeArg* k_rotary_out =
       builder.MakeIntermediate<MLFloat16>(std::vector<int64_t>{batch_size, sequence_length, kv_hidden_size});
 
-  std::vector<NodeArg*> q_rotary_inputs{q_matmul_out, cos_cache, sin_cache};
-  std::vector<NodeArg*> k_rotary_inputs{k_matmul_out, cos_cache, sin_cache};
-  if (position_ids != nullptr) {
-    q_rotary_inputs.push_back(position_ids);
-    k_rotary_inputs.push_back(position_ids);
+  std::vector<NodeArg*> q_rotary_inputs;
+  std::vector<NodeArg*> k_rotary_inputs;
+  const char* rotary_domain_name =
+      rotary_domain == RotaryEmbeddingDomain::kMS ? kMSDomain : kOnnxDomain;
+  if (rotary_domain == RotaryEmbeddingDomain::kMS) {
+    q_rotary_inputs = {q_matmul_out, position_ids, cos_cache, sin_cache};
+    k_rotary_inputs = {k_matmul_out, position_ids, cos_cache, sin_cache};
+  } else {
+    q_rotary_inputs = {q_matmul_out, cos_cache, sin_cache};
+    k_rotary_inputs = {k_matmul_out, cos_cache, sin_cache};
+    if (position_ids != nullptr) {
+      q_rotary_inputs.push_back(position_ids);
+      k_rotary_inputs.push_back(position_ids);
+    }
   }
 
-  Node& q_rotary = builder.AddNode("RotaryEmbedding", q_rotary_inputs, {q_rotary_out}, kOnnxDomain);
+  Node& q_rotary = builder.AddNode("RotaryEmbedding", q_rotary_inputs, {q_rotary_out}, rotary_domain_name);
   q_rotary.AddAttribute("num_heads", num_heads);
   q_rotary.AddAttribute("interleaved", q_interleaved);
   q_rotary.AddAttribute("rotary_embedding_dim", rotary_embedding_dim);
-  Node& k_rotary = builder.AddNode("RotaryEmbedding", k_rotary_inputs, {k_rotary_out}, kOnnxDomain);
+  Node& k_rotary = builder.AddNode("RotaryEmbedding", k_rotary_inputs, {k_rotary_out}, rotary_domain_name);
   k_rotary.AddAttribute("num_heads", kv_num_heads);
   k_rotary.AddAttribute("interleaved", k_interleaved);
   k_rotary.AddAttribute("rotary_embedding_dim", rotary_embedding_dim);
@@ -706,6 +721,32 @@ static Status CheckOnnxRotaryEmbeddingGQANotFused(Graph& graph) {
     const auto& attrs = node.GetAttributes();
     auto do_rotary_attr = attrs.find("do_rotary");
     TEST_RETURN_IF_NOT(do_rotary_attr == attrs.end() || do_rotary_attr->second.i() == 0);
+  }
+
+  return Status::OK();
+}
+
+static Status CheckMsRotaryEmbeddingGQAFused(Graph& graph, int64_t expected_interleaved) {
+  const auto op_to_count = CountOpsInGraph(graph);
+  TEST_RETURN_IF_NOT(OpCount(op_to_count, "com.microsoft.RotaryEmbedding") == 0);
+  TEST_RETURN_IF_NOT(OpCount(op_to_count, "MatMul") == 1);
+  TEST_RETURN_IF_NOT(OpCount(op_to_count, "com.microsoft.GroupQueryAttention") == 1);
+
+  for (const Node& node : graph.Nodes()) {
+    if (node.OpType() != "GroupQueryAttention") {
+      continue;
+    }
+
+    const auto& input_defs = node.InputDefs();
+    TEST_RETURN_IF_NOT(input_defs.size() == 10);
+    TEST_RETURN_IF_NOT(input_defs[9] != nullptr && input_defs[9]->Exists());
+
+    const auto& attrs = node.GetAttributes();
+    const auto do_rotary_attr = attrs.find("do_rotary");
+    TEST_RETURN_IF_NOT(do_rotary_attr != attrs.end() && do_rotary_attr->second.i() == 1);
+    const auto interleaved_attr = attrs.find("rotary_interleaved");
+    TEST_RETURN_IF_NOT(interleaved_attr != attrs.end() &&
+                       interleaved_attr->second.i() == expected_interleaved);
   }
 
   return Status::OK();
@@ -902,7 +943,7 @@ TEST_F(GraphTransformationTests, GroupQueryAttentionFusionTest) {
 
 TEST_F(GraphTransformationTests, GroupQueryAttentionFusionSkipsOnnxRotaryEmbeddingTest) {
   auto build_test_case = [](ModelTestBuilder& builder) {
-    BuildOnnxRotaryEmbeddingGQAFusionGraph(builder, true);
+    BuildRotaryEmbeddingGQAFusionGraph(builder, RotaryEmbeddingDomain::kOnnx, true);
   };
 
   ASSERT_STATUS_OK(TestGraphTransformer(build_test_case, 23, *logger_,
@@ -913,7 +954,7 @@ TEST_F(GraphTransformationTests, GroupQueryAttentionFusionSkipsOnnxRotaryEmbeddi
 
 TEST_F(GraphTransformationTests, GroupQueryAttentionFusionSkipsOnnxRotaryEmbeddingInterleavedTest) {
   auto build_test_case = [](ModelTestBuilder& builder) {
-    BuildOnnxRotaryEmbeddingGQAFusionGraph(builder, true, 1, 1);
+    BuildRotaryEmbeddingGQAFusionGraph(builder, RotaryEmbeddingDomain::kOnnx, true, 1, 1);
   };
 
   ASSERT_STATUS_OK(TestGraphTransformer(build_test_case, 23, *logger_,
@@ -924,7 +965,7 @@ TEST_F(GraphTransformationTests, GroupQueryAttentionFusionSkipsOnnxRotaryEmbeddi
 
 TEST_F(GraphTransformationTests, GroupQueryAttentionFusionSkipsOnnxRotaryEmbeddingPartialRotaryTest) {
   auto build_test_case = [](ModelTestBuilder& builder) {
-    BuildOnnxRotaryEmbeddingGQAFusionGraph(builder, true, 0, 0, 16);
+    BuildRotaryEmbeddingGQAFusionGraph(builder, RotaryEmbeddingDomain::kOnnx, true, 0, 0, 16);
   };
 
   ASSERT_STATUS_OK(TestGraphTransformer(build_test_case, 23, *logger_,
@@ -935,7 +976,7 @@ TEST_F(GraphTransformationTests, GroupQueryAttentionFusionSkipsOnnxRotaryEmbeddi
 
 TEST_F(GraphTransformationTests, GroupQueryAttentionFusionOnnxRotaryEmbeddingInterleavedMismatchTest) {
   auto build_test_case = [](ModelTestBuilder& builder) {
-    BuildOnnxRotaryEmbeddingGQAFusionGraph(builder, true, 0, 1);
+    BuildRotaryEmbeddingGQAFusionGraph(builder, RotaryEmbeddingDomain::kOnnx, true, 0, 1);
   };
 
   ASSERT_STATUS_OK(TestGraphTransformer(build_test_case, 23, *logger_,
@@ -946,13 +987,27 @@ TEST_F(GraphTransformationTests, GroupQueryAttentionFusionOnnxRotaryEmbeddingInt
 
 TEST_F(GraphTransformationTests, GroupQueryAttentionFusionOnnxRotaryEmbeddingNoPositionIdsTest) {
   auto build_test_case = [](ModelTestBuilder& builder) {
-    BuildOnnxRotaryEmbeddingGQAFusionGraph(builder, false);
+    BuildRotaryEmbeddingGQAFusionGraph(builder, RotaryEmbeddingDomain::kOnnx, false);
   };
 
   ASSERT_STATUS_OK(TestGraphTransformer(build_test_case, 23, *logger_,
                                         std::make_unique<GroupQueryAttentionFusion>(),
                                         TransformerLevel::Level2, 3, nullptr,
                                         CheckOnnxRotaryEmbeddingGQANotFused));
+}
+
+TEST_F(GraphTransformationTests, GroupQueryAttentionFusionMsRotaryEmbeddingForwardsPositionIdsTest) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    BuildRotaryEmbeddingGQAFusionGraph(builder, RotaryEmbeddingDomain::kMS, true, 1, 1);
+  };
+  auto check_fused_graph = [](Graph& graph) {
+    return CheckMsRotaryEmbeddingGQAFused(graph, 1);
+  };
+
+  ASSERT_STATUS_OK(TestGraphTransformer(build_test_case, 23, *logger_,
+                                        std::make_unique<GroupQueryAttentionFusion>(),
+                                        TransformerLevel::Level2, 3, nullptr,
+                                        check_fused_graph));
 }
 
 TEST_F(GraphTransformationTests, SkipLayerNormFusionWithCastTest) {

--- a/onnxruntime/test/optimizer/graph_transform_test_layernorm.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test_layernorm.cc
@@ -607,6 +607,127 @@ static void TestGQAFusion(const std::basic_string<ORTCHAR_T>& file_path, int mat
   ASSERT_TRUE(op_to_count["com.microsoft.GroupQueryAttention"] == 1);
 }
 
+static void BuildOnnxRotaryEmbeddingGQAFusionGraph(ModelTestBuilder& builder, bool include_position_ids) {
+  constexpr int64_t batch_size = 1;
+  constexpr int64_t sequence_length = 2;
+  constexpr int64_t input_hidden_size = 8;
+  constexpr int64_t num_heads = 2;
+  constexpr int64_t kv_num_heads = 1;
+  constexpr int64_t head_size = 16;
+  constexpr int64_t q_hidden_size = num_heads * head_size;
+  constexpr int64_t kv_hidden_size = kv_num_heads * head_size;
+  constexpr int64_t max_sequence_length = 8;
+  constexpr int64_t half_rotary_dim = head_size / 2;
+
+  auto make_weight = [&builder](int64_t rows, int64_t cols, float value) {
+    return builder.MakeInitializer<MLFloat16>(
+        {rows, cols}, std::vector<MLFloat16>(static_cast<size_t>(rows * cols), MLFloat16(value)));
+  };
+
+  NodeArg* input = builder.MakeInput<MLFloat16>({{batch_size, sequence_length, input_hidden_size}});
+  NodeArg* q_weight = make_weight(input_hidden_size, q_hidden_size, 0.5f);
+  NodeArg* k_weight = make_weight(input_hidden_size, kv_hidden_size, 0.25f);
+  NodeArg* v_weight = make_weight(input_hidden_size, kv_hidden_size, 0.125f);
+
+  NodeArg* q_matmul_out =
+      builder.MakeIntermediate<MLFloat16>(std::vector<int64_t>{batch_size, sequence_length, q_hidden_size});
+  NodeArg* k_matmul_out =
+      builder.MakeIntermediate<MLFloat16>(std::vector<int64_t>{batch_size, sequence_length, kv_hidden_size});
+  NodeArg* v_matmul_out =
+      builder.MakeIntermediate<MLFloat16>(std::vector<int64_t>{batch_size, sequence_length, kv_hidden_size});
+  builder.AddNode("MatMul", {input, q_weight}, {q_matmul_out});
+  builder.AddNode("MatMul", {input, k_weight}, {k_matmul_out});
+  builder.AddNode("MatMul", {input, v_weight}, {v_matmul_out});
+
+  const std::vector<int64_t> cache_shape = include_position_ids
+                                               ? std::vector<int64_t>{max_sequence_length, half_rotary_dim}
+                                               : std::vector<int64_t>{batch_size, sequence_length, half_rotary_dim};
+  NodeArg* cos_cache = builder.MakeInput<MLFloat16>(cache_shape);
+  NodeArg* sin_cache = builder.MakeInput<MLFloat16>(cache_shape);
+  NodeArg* position_ids = include_position_ids
+                              ? builder.MakeInput<int64_t>({{batch_size, sequence_length}})
+                              : nullptr;
+
+  NodeArg* q_rotary_out =
+      builder.MakeIntermediate<MLFloat16>(std::vector<int64_t>{batch_size, sequence_length, q_hidden_size});
+  NodeArg* k_rotary_out =
+      builder.MakeIntermediate<MLFloat16>(std::vector<int64_t>{batch_size, sequence_length, kv_hidden_size});
+
+  std::vector<NodeArg*> q_rotary_inputs{q_matmul_out, cos_cache, sin_cache};
+  std::vector<NodeArg*> k_rotary_inputs{k_matmul_out, cos_cache, sin_cache};
+  if (position_ids != nullptr) {
+    q_rotary_inputs.push_back(position_ids);
+    k_rotary_inputs.push_back(position_ids);
+  }
+
+  Node& q_rotary = builder.AddNode("RotaryEmbedding", q_rotary_inputs, {q_rotary_out}, kOnnxDomain);
+  q_rotary.AddAttribute("num_heads", num_heads);
+  Node& k_rotary = builder.AddNode("RotaryEmbedding", k_rotary_inputs, {k_rotary_out}, kOnnxDomain);
+  k_rotary.AddAttribute("num_heads", kv_num_heads);
+
+  NodeArg* past_key =
+      builder.MakeInput<MLFloat16>({{batch_size, kv_num_heads, max_sequence_length, head_size}});
+  NodeArg* past_value =
+      builder.MakeInput<MLFloat16>({{batch_size, kv_num_heads, max_sequence_length, head_size}});
+  NodeArg* seqlens_k = builder.MakeInput<int32_t>({{batch_size}});
+  NodeArg* total_sequence_length = builder.MakeInput<int32_t>({{1}});
+  NodeArg* gqa_output =
+      builder.MakeOutput<MLFloat16>(std::vector<int64_t>{batch_size, sequence_length, q_hidden_size});
+
+  Node& gqa = builder.AddNode("GroupQueryAttention",
+                              {q_rotary_out, k_rotary_out, v_matmul_out, past_key, past_value,
+                               seqlens_k, total_sequence_length},
+                              {gqa_output},
+                              kMSDomain);
+  gqa.AddAttribute("num_heads", num_heads);
+  gqa.AddAttribute("kv_num_heads", kv_num_heads);
+}
+
+static Status CheckOnnxRotaryEmbeddingGQAFused(Graph& graph) {
+  const auto op_to_count = CountOpsInGraph(graph);
+  TEST_RETURN_IF_NOT(OpCount(op_to_count, "RotaryEmbedding") == 0);
+  TEST_RETURN_IF_NOT(OpCount(op_to_count, "MatMul") == 1);
+  TEST_RETURN_IF_NOT(OpCount(op_to_count, "com.microsoft.GroupQueryAttention") == 1);
+
+  for (const Node& node : graph.Nodes()) {
+    if (node.OpType() != "GroupQueryAttention") {
+      continue;
+    }
+
+    TEST_RETURN_IF_NOT(node.InputDefs().size() == 10);
+    TEST_RETURN_IF_NOT(node.InputDefs()[7] != nullptr && node.InputDefs()[7]->Exists());
+    TEST_RETURN_IF_NOT(node.InputDefs()[8] != nullptr && node.InputDefs()[8]->Exists());
+    TEST_RETURN_IF_NOT(node.InputDefs()[9] != nullptr && node.InputDefs()[9]->Exists());
+
+    const auto& attrs = node.GetAttributes();
+    auto do_rotary_attr = attrs.find("do_rotary");
+    TEST_RETURN_IF_NOT(do_rotary_attr != attrs.end());
+    TEST_RETURN_IF_NOT(do_rotary_attr->second.i() == 1);
+  }
+
+  return Status::OK();
+}
+
+static Status CheckOnnxRotaryEmbeddingGQANotFused(Graph& graph) {
+  const auto op_to_count = CountOpsInGraph(graph);
+  TEST_RETURN_IF_NOT(OpCount(op_to_count, "RotaryEmbedding") == 2);
+  TEST_RETURN_IF_NOT(OpCount(op_to_count, "MatMul") == 3);
+  TEST_RETURN_IF_NOT(OpCount(op_to_count, "com.microsoft.GroupQueryAttention") == 1);
+
+  for (const Node& node : graph.Nodes()) {
+    if (node.OpType() != "GroupQueryAttention") {
+      continue;
+    }
+
+    TEST_RETURN_IF_NOT(node.InputDefs().size() == 7);
+    const auto& attrs = node.GetAttributes();
+    auto do_rotary_attr = attrs.find("do_rotary");
+    TEST_RETURN_IF_NOT(do_rotary_attr == attrs.end() || do_rotary_attr->second.i() == 0);
+  }
+
+  return Status::OK();
+}
+
 static void TestSkipLayerNormFusion(const std::basic_string<ORTCHAR_T>& file_path, int add_count, int ln_count,
                                     int skip_ln_count, int cast_count, logging::Logger* logger) {
   std::shared_ptr<Model> p_model;
@@ -794,6 +915,28 @@ TEST_F(GraphTransformationTests, GroupQueryAttentionFusionTest) {
   TestGQAFusion(MODEL_FOLDER "fusion/gqa_fusion_quantized_simple.onnx", 1, 0, logger_.get());
   TestGQAFusion(MODEL_FOLDER "fusion/gqa_fusion_different_head_sizes.onnx", 0, 1, logger_.get());
   TestGQAFusion(MODEL_FOLDER "fusion/gqa_fusion_quantized_different_head_sizes.onnx", 1, 0, logger_.get());
+}
+
+TEST_F(GraphTransformationTests, GroupQueryAttentionFusionOnnxRotaryEmbeddingTest) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    BuildOnnxRotaryEmbeddingGQAFusionGraph(builder, true);
+  };
+
+  ASSERT_STATUS_OK(TestGraphTransformer(build_test_case, 23, *logger_,
+                                        std::make_unique<GroupQueryAttentionFusion>(),
+                                        TransformerLevel::Level2, 3, nullptr,
+                                        CheckOnnxRotaryEmbeddingGQAFused));
+}
+
+TEST_F(GraphTransformationTests, GroupQueryAttentionFusionOnnxRotaryEmbeddingNoPositionIdsTest) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    BuildOnnxRotaryEmbeddingGQAFusionGraph(builder, false);
+  };
+
+  ASSERT_STATUS_OK(TestGraphTransformer(build_test_case, 23, *logger_,
+                                        std::make_unique<GroupQueryAttentionFusion>(),
+                                        TransformerLevel::Level2, 3, nullptr,
+                                        CheckOnnxRotaryEmbeddingGQANotFused));
 }
 
 TEST_F(GraphTransformationTests, SkipLayerNormFusionWithCastTest) {

--- a/onnxruntime/test/optimizer/graph_transform_test_layernorm.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test_layernorm.cc
@@ -691,39 +691,6 @@ static void BuildOnnxRotaryEmbeddingGQAFusionGraph(ModelTestBuilder& builder,
   gqa.AddAttribute("kv_num_heads", kv_num_heads);
 }
 
-static Status CheckOnnxRotaryEmbeddingGQAFusedWithInterleaved(Graph& graph, int64_t expected_rotary_interleaved) {
-  const auto op_to_count = CountOpsInGraph(graph);
-  TEST_RETURN_IF_NOT(OpCount(op_to_count, "RotaryEmbedding") == 0);
-  TEST_RETURN_IF_NOT(OpCount(op_to_count, "MatMul") == 1);
-  TEST_RETURN_IF_NOT(OpCount(op_to_count, "com.microsoft.GroupQueryAttention") == 1);
-
-  for (const Node& node : graph.Nodes()) {
-    if (node.OpType() != "GroupQueryAttention") {
-      continue;
-    }
-
-    TEST_RETURN_IF_NOT(node.InputDefs().size() == 10);
-    TEST_RETURN_IF_NOT(node.InputDefs()[7] != nullptr && node.InputDefs()[7]->Exists());
-    TEST_RETURN_IF_NOT(node.InputDefs()[8] != nullptr && node.InputDefs()[8]->Exists());
-    TEST_RETURN_IF_NOT(node.InputDefs()[9] != nullptr && node.InputDefs()[9]->Exists());
-
-    const auto& attrs = node.GetAttributes();
-    auto do_rotary_attr = attrs.find("do_rotary");
-    TEST_RETURN_IF_NOT(do_rotary_attr != attrs.end());
-    TEST_RETURN_IF_NOT(do_rotary_attr->second.i() == 1);
-
-    auto rotary_interleaved_attr = attrs.find("rotary_interleaved");
-    TEST_RETURN_IF_NOT(rotary_interleaved_attr != attrs.end());
-    TEST_RETURN_IF_NOT(rotary_interleaved_attr->second.i() == expected_rotary_interleaved);
-  }
-
-  return Status::OK();
-}
-
-static Status CheckOnnxRotaryEmbeddingGQAFused(Graph& graph) {
-  return CheckOnnxRotaryEmbeddingGQAFusedWithInterleaved(graph, 0);
-}
-
 static Status CheckOnnxRotaryEmbeddingGQANotFused(Graph& graph) {
   const auto op_to_count = CountOpsInGraph(graph);
   TEST_RETURN_IF_NOT(OpCount(op_to_count, "RotaryEmbedding") == 2);
@@ -933,7 +900,7 @@ TEST_F(GraphTransformationTests, GroupQueryAttentionFusionTest) {
   TestGQAFusion(MODEL_FOLDER "fusion/gqa_fusion_quantized_different_head_sizes.onnx", 1, 0, logger_.get());
 }
 
-TEST_F(GraphTransformationTests, GroupQueryAttentionFusionOnnxRotaryEmbeddingTest) {
+TEST_F(GraphTransformationTests, GroupQueryAttentionFusionSkipsOnnxRotaryEmbeddingTest) {
   auto build_test_case = [](ModelTestBuilder& builder) {
     BuildOnnxRotaryEmbeddingGQAFusionGraph(builder, true);
   };
@@ -941,25 +908,21 @@ TEST_F(GraphTransformationTests, GroupQueryAttentionFusionOnnxRotaryEmbeddingTes
   ASSERT_STATUS_OK(TestGraphTransformer(build_test_case, 23, *logger_,
                                         std::make_unique<GroupQueryAttentionFusion>(),
                                         TransformerLevel::Level2, 3, nullptr,
-                                        CheckOnnxRotaryEmbeddingGQAFused));
+                                        CheckOnnxRotaryEmbeddingGQANotFused));
 }
 
-TEST_F(GraphTransformationTests, GroupQueryAttentionFusionOnnxRotaryEmbeddingInterleavedTest) {
+TEST_F(GraphTransformationTests, GroupQueryAttentionFusionSkipsOnnxRotaryEmbeddingInterleavedTest) {
   auto build_test_case = [](ModelTestBuilder& builder) {
     BuildOnnxRotaryEmbeddingGQAFusionGraph(builder, true, 1, 1);
-  };
-
-  auto post_graph_checker = [](Graph& graph) {
-    return CheckOnnxRotaryEmbeddingGQAFusedWithInterleaved(graph, 1);
   };
 
   ASSERT_STATUS_OK(TestGraphTransformer(build_test_case, 23, *logger_,
                                         std::make_unique<GroupQueryAttentionFusion>(),
                                         TransformerLevel::Level2, 3, nullptr,
-                                        post_graph_checker));
+                                        CheckOnnxRotaryEmbeddingGQANotFused));
 }
 
-TEST_F(GraphTransformationTests, GroupQueryAttentionFusionOnnxRotaryEmbeddingPartialRotaryTest) {
+TEST_F(GraphTransformationTests, GroupQueryAttentionFusionSkipsOnnxRotaryEmbeddingPartialRotaryTest) {
   auto build_test_case = [](ModelTestBuilder& builder) {
     BuildOnnxRotaryEmbeddingGQAFusionGraph(builder, true, 0, 0, 16);
   };
@@ -967,7 +930,7 @@ TEST_F(GraphTransformationTests, GroupQueryAttentionFusionOnnxRotaryEmbeddingPar
   ASSERT_STATUS_OK(TestGraphTransformer(build_test_case, 23, *logger_,
                                         std::make_unique<GroupQueryAttentionFusion>(),
                                         TransformerLevel::Level2, 3, nullptr,
-                                        CheckOnnxRotaryEmbeddingGQAFused));
+                                        CheckOnnxRotaryEmbeddingGQANotFused));
 }
 
 TEST_F(GraphTransformationTests, GroupQueryAttentionFusionOnnxRotaryEmbeddingInterleavedMismatchTest) {

--- a/onnxruntime/test/optimizer/graph_transform_test_layernorm.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test_layernorm.cc
@@ -607,17 +607,21 @@ static void TestGQAFusion(const std::basic_string<ORTCHAR_T>& file_path, int mat
   ASSERT_TRUE(op_to_count["com.microsoft.GroupQueryAttention"] == 1);
 }
 
-static void BuildOnnxRotaryEmbeddingGQAFusionGraph(ModelTestBuilder& builder, bool include_position_ids) {
+static void BuildOnnxRotaryEmbeddingGQAFusionGraph(ModelTestBuilder& builder,
+                                                   bool include_position_ids,
+                                                   int64_t q_interleaved = 0,
+                                                   int64_t k_interleaved = 0,
+                                                   int64_t rotary_embedding_dim = 0) {
   constexpr int64_t batch_size = 1;
   constexpr int64_t sequence_length = 2;
   constexpr int64_t input_hidden_size = 8;
   constexpr int64_t num_heads = 2;
   constexpr int64_t kv_num_heads = 1;
-  constexpr int64_t head_size = 16;
-  constexpr int64_t q_hidden_size = num_heads * head_size;
-  constexpr int64_t kv_hidden_size = kv_num_heads * head_size;
+  const int64_t head_size = rotary_embedding_dim == 0 ? 16 : 32;
+  const int64_t q_hidden_size = num_heads * head_size;
+  const int64_t kv_hidden_size = kv_num_heads * head_size;
   constexpr int64_t max_sequence_length = 8;
-  constexpr int64_t half_rotary_dim = head_size / 2;
+  const int64_t half_rotary_dim = (rotary_embedding_dim == 0 ? head_size : rotary_embedding_dim) / 2;
 
   auto make_weight = [&builder](int64_t rows, int64_t cols, float value) {
     return builder.MakeInitializer<MLFloat16>(
@@ -662,8 +666,12 @@ static void BuildOnnxRotaryEmbeddingGQAFusionGraph(ModelTestBuilder& builder, bo
 
   Node& q_rotary = builder.AddNode("RotaryEmbedding", q_rotary_inputs, {q_rotary_out}, kOnnxDomain);
   q_rotary.AddAttribute("num_heads", num_heads);
+  q_rotary.AddAttribute("interleaved", q_interleaved);
+  q_rotary.AddAttribute("rotary_embedding_dim", rotary_embedding_dim);
   Node& k_rotary = builder.AddNode("RotaryEmbedding", k_rotary_inputs, {k_rotary_out}, kOnnxDomain);
   k_rotary.AddAttribute("num_heads", kv_num_heads);
+  k_rotary.AddAttribute("interleaved", k_interleaved);
+  k_rotary.AddAttribute("rotary_embedding_dim", rotary_embedding_dim);
 
   NodeArg* past_key =
       builder.MakeInput<MLFloat16>({{batch_size, kv_num_heads, max_sequence_length, head_size}});
@@ -683,7 +691,7 @@ static void BuildOnnxRotaryEmbeddingGQAFusionGraph(ModelTestBuilder& builder, bo
   gqa.AddAttribute("kv_num_heads", kv_num_heads);
 }
 
-static Status CheckOnnxRotaryEmbeddingGQAFused(Graph& graph) {
+static Status CheckOnnxRotaryEmbeddingGQAFusedWithInterleaved(Graph& graph, int64_t expected_rotary_interleaved) {
   const auto op_to_count = CountOpsInGraph(graph);
   TEST_RETURN_IF_NOT(OpCount(op_to_count, "RotaryEmbedding") == 0);
   TEST_RETURN_IF_NOT(OpCount(op_to_count, "MatMul") == 1);
@@ -703,9 +711,17 @@ static Status CheckOnnxRotaryEmbeddingGQAFused(Graph& graph) {
     auto do_rotary_attr = attrs.find("do_rotary");
     TEST_RETURN_IF_NOT(do_rotary_attr != attrs.end());
     TEST_RETURN_IF_NOT(do_rotary_attr->second.i() == 1);
+
+    auto rotary_interleaved_attr = attrs.find("rotary_interleaved");
+    TEST_RETURN_IF_NOT(rotary_interleaved_attr != attrs.end());
+    TEST_RETURN_IF_NOT(rotary_interleaved_attr->second.i() == expected_rotary_interleaved);
   }
 
   return Status::OK();
+}
+
+static Status CheckOnnxRotaryEmbeddingGQAFused(Graph& graph) {
+  return CheckOnnxRotaryEmbeddingGQAFusedWithInterleaved(graph, 0);
 }
 
 static Status CheckOnnxRotaryEmbeddingGQANotFused(Graph& graph) {
@@ -926,6 +942,43 @@ TEST_F(GraphTransformationTests, GroupQueryAttentionFusionOnnxRotaryEmbeddingTes
                                         std::make_unique<GroupQueryAttentionFusion>(),
                                         TransformerLevel::Level2, 3, nullptr,
                                         CheckOnnxRotaryEmbeddingGQAFused));
+}
+
+TEST_F(GraphTransformationTests, GroupQueryAttentionFusionOnnxRotaryEmbeddingInterleavedTest) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    BuildOnnxRotaryEmbeddingGQAFusionGraph(builder, true, 1, 1);
+  };
+
+  auto post_graph_checker = [](Graph& graph) {
+    return CheckOnnxRotaryEmbeddingGQAFusedWithInterleaved(graph, 1);
+  };
+
+  ASSERT_STATUS_OK(TestGraphTransformer(build_test_case, 23, *logger_,
+                                        std::make_unique<GroupQueryAttentionFusion>(),
+                                        TransformerLevel::Level2, 3, nullptr,
+                                        post_graph_checker));
+}
+
+TEST_F(GraphTransformationTests, GroupQueryAttentionFusionOnnxRotaryEmbeddingPartialRotaryTest) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    BuildOnnxRotaryEmbeddingGQAFusionGraph(builder, true, 0, 0, 16);
+  };
+
+  ASSERT_STATUS_OK(TestGraphTransformer(build_test_case, 23, *logger_,
+                                        std::make_unique<GroupQueryAttentionFusion>(),
+                                        TransformerLevel::Level2, 3, nullptr,
+                                        CheckOnnxRotaryEmbeddingGQAFused));
+}
+
+TEST_F(GraphTransformationTests, GroupQueryAttentionFusionOnnxRotaryEmbeddingInterleavedMismatchTest) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    BuildOnnxRotaryEmbeddingGQAFusionGraph(builder, true, 0, 1);
+  };
+
+  ASSERT_STATUS_OK(TestGraphTransformer(build_test_case, 23, *logger_,
+                                        std::make_unique<GroupQueryAttentionFusion>(),
+                                        TransformerLevel::Level2, 3, nullptr,
+                                        CheckOnnxRotaryEmbeddingGQANotFused));
 }
 
 TEST_F(GraphTransformationTests, GroupQueryAttentionFusionOnnxRotaryEmbeddingNoPositionIdsTest) {


### PR DESCRIPTION
### Description
Mobius exports standard ONNX rotary embedding op. Adding support for this.



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


