### PR TITLE
Validate initializer data length and guard element-count computation in contrib Range shape inference

### DIFF
--- a/onnxruntime/core/graph/contrib_ops/range_schema_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/range_schema_defs.cc
@@ -82,9 +82,10 @@ static int64_t CalcRangeDim(const TensorProto* startShapeInitializer,
   if (delta == 0) {
     fail_shape_inference("delta in Range operator can not be zero!");
   }
-  // Mirror the CPU kernel (core/providers/cpu/generator/range.cc) which clamps empty or
-  // backward ranges to 0 so shape inference does not emit a negative dimension value.
-  double count = ceil((1.0 * (limit - start)) / delta);
+  // Mirror the CPU kernel (core/providers/cpu/generator/range.cc ComputeRange) exactly so the
+  // two paths stay byte-consistent: clamp empty or backward ranges to 0 and promote the
+  // operands to double before the subtraction. Keep this expression identical to the kernel.
+  double count = ceil((static_cast<double>(limit) - static_cast<double>(start)) / static_cast<double>(delta));
   if (!std::isfinite(count)) {
     fail_shape_inference("Range: the computed number of elements is not a finite value.");
   }

--- a/onnxruntime/core/graph/contrib_ops/range_schema_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/range_schema_defs.cc
@@ -44,6 +44,13 @@ int64_t get_data<int64_t>(const TensorProto* shapeInitializer) {
 }
 
 template <>
+int16_t get_data<int16_t>(const TensorProto* shapeInitializer) {
+  // ONNX packs INT16 initializer values into the int32_data repeated field.
+  if (shapeInitializer->int32_data_size() > 0) return static_cast<int16_t>(shapeInitializer->int32_data(0));
+  fail_shape_inference("Can not get shape initializer data!");
+}
+
+template <>
 float get_data<float>(const TensorProto* shapeInitializer) {
   if (shapeInitializer->float_data_size() > 0) return shapeInitializer->float_data(0);
   fail_shape_inference("Can not get shape initializer data!");

--- a/onnxruntime/core/graph/contrib_ops/range_schema_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/range_schema_defs.cc
@@ -88,11 +88,17 @@ static int64_t CalcRangeDim(const TensorProto* startShapeInitializer,
   if (!std::isfinite(count)) {
     fail_shape_inference("Range: the computed number of elements is not a finite value.");
   }
-  int64_t n = static_cast<int64_t>(count);
-  if (n <= 0) {
-    n = 0;
+  // Empty or backward ranges clamp to 0; handle the non-positive case before the cast so a
+  // large-magnitude negative count can never reach (and overflow) the int64 conversion below.
+  if (count <= 0) {
+    return 0;
   }
-  return n;
+  // static_cast<double>(INT64_MAX) rounds up to 2^63 (9223372036854775808.0), which is not
+  // representable as int64_t, so reject any count at or above that boundary before the cast.
+  if (count >= 9223372036854775808.0) {
+    fail_shape_inference("Range: the computed number of elements exceeds the supported range.");
+  }
+  return static_cast<int64_t>(count);
 }
 
 static int64_t CalcResultDim(const TensorProto* startShapeInitializer,

--- a/onnxruntime/core/graph/contrib_ops/range_schema_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/range_schema_defs.cc
@@ -60,6 +60,9 @@ static T GetFirstElement(const TensorProto* shapeInitializer) {
 
   if (utils::HasRawData(*shapeInitializer)) {
     const std::string& bytes = shapeInitializer->raw_data();
+    if (bytes.size() < sizeof(T)) {
+      fail_shape_inference("Range: raw_data size is smaller than the element size for the given data type.");
+    }
     return *reinterpret_cast<const T*>(bytes.c_str());
   }
   return get_data<T>(shapeInitializer);
@@ -75,7 +78,13 @@ static int64_t CalcRangeDim(const TensorProto* startShapeInitializer,
   if (delta == 0) {
     fail_shape_inference("delta in Range operator can not be zero!");
   }
-  return static_cast<int64_t>(ceil((1.0 * (limit - start)) / delta));
+  // Mirror the CPU kernel (core/providers/cpu/generator/range.cc) which clamps empty or
+  // backward ranges to 0 so shape inference does not emit a negative dimension value.
+  int64_t n = static_cast<int64_t>(ceil((1.0 * (limit - start)) / delta));
+  if (n <= 0) {
+    n = 0;
+  }
+  return n;
 }
 
 static int64_t CalcResultDim(const TensorProto* startShapeInitializer,

--- a/onnxruntime/core/graph/contrib_ops/range_schema_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/range_schema_defs.cc
@@ -7,6 +7,7 @@
 #include "core/graph/constants.h"
 #include "core/graph/op.h"
 #include <cmath>
+#include <cstring>
 #include <type_traits>
 
 namespace onnxruntime {
@@ -63,7 +64,10 @@ static T GetFirstElement(const TensorProto* shapeInitializer) {
     if (bytes.size() < sizeof(T)) {
       fail_shape_inference("Range: raw_data size is smaller than the element size for the given data type.");
     }
-    return *reinterpret_cast<const T*>(bytes.c_str());
+    // std::string data is only char-aligned, so copy the bytes into a properly aligned value.
+    T value;
+    std::memcpy(&value, bytes.data(), sizeof(T));
+    return value;
   }
   return get_data<T>(shapeInitializer);
 }
@@ -80,7 +84,11 @@ static int64_t CalcRangeDim(const TensorProto* startShapeInitializer,
   }
   // Mirror the CPU kernel (core/providers/cpu/generator/range.cc) which clamps empty or
   // backward ranges to 0 so shape inference does not emit a negative dimension value.
-  int64_t n = static_cast<int64_t>(ceil((1.0 * (limit - start)) / delta));
+  double count = ceil((1.0 * (limit - start)) / delta);
+  if (!std::isfinite(count)) {
+    fail_shape_inference("Range: the computed number of elements is not a finite value.");
+  }
+  int64_t n = static_cast<int64_t>(count);
   if (n <= 0) {
     n = 0;
   }

--- a/onnxruntime/core/providers/cpu/generator/range.cc
+++ b/onnxruntime/core/providers/cpu/generator/range.cc
@@ -80,7 +80,12 @@ static Status ComputeRange(
   if (delta == T{0}) {
     return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "delta in Range operator can not be zero!");
   }
-  int64_t n = static_cast<int64_t>(ceil((1.0 * (limit - start)) / delta));
+  double count = ceil((1.0 * (limit - start)) / delta);
+  if (!std::isfinite(count)) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                           "Range: the computed number of elements is not a finite value.");
+  }
+  int64_t n = static_cast<int64_t>(count);
   if (n <= 0)
     n = 0;
   TensorShape shape = {n};

--- a/onnxruntime/core/providers/cpu/generator/range.cc
+++ b/onnxruntime/core/providers/cpu/generator/range.cc
@@ -80,7 +80,10 @@ static Status ComputeRange(
   if (delta == T{0}) {
     return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "delta in Range operator can not be zero!");
   }
-  double count = ceil((1.0 * (limit - start)) / delta);
+  // Compute the element count in double, mirroring the shape-inference path
+  // (core/graph/contrib_ops/range_schema_defs.cc CalcRangeDim) exactly. The operands are
+  // promoted to double before the subtraction so integral inputs cannot overflow in T.
+  double count = ceil((static_cast<double>(limit) - static_cast<double>(start)) / static_cast<double>(delta));
   if (!std::isfinite(count)) {
     return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
                            "Range: the computed number of elements is not a finite value.");

--- a/onnxruntime/core/providers/cpu/generator/range.cc
+++ b/onnxruntime/core/providers/cpu/generator/range.cc
@@ -6,10 +6,7 @@
 #include <cmath>
 
 #include "core/providers/op_kernel_type_control.h"
-// TODO: fix the warnings
-#if defined(_MSC_VER) && !defined(__clang__)
-#pragma warning(disable : 26451)
-#endif
+
 namespace onnxruntime {
 
 namespace op_kernel_type_control {

--- a/onnxruntime/core/providers/cpu/generator/range.cc
+++ b/onnxruntime/core/providers/cpu/generator/range.cc
@@ -85,9 +85,18 @@ static Status ComputeRange(
     return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
                            "Range: the computed number of elements is not a finite value.");
   }
-  int64_t n = static_cast<int64_t>(count);
-  if (n <= 0)
-    n = 0;
+  // Empty or backward ranges clamp to 0; handle the non-positive case before the cast so a
+  // large-magnitude negative count can never reach (and overflow) the int64 conversion.
+  int64_t n = 0;
+  if (count > 0) {
+    // static_cast<double>(INT64_MAX) rounds up to 2^63 (9223372036854775808.0), which is not
+    // representable as int64_t, so reject any count at or above that boundary before the cast.
+    if (count >= 9223372036854775808.0) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                             "Range: the computed number of elements exceeds the supported range.");
+    }
+    n = static_cast<int64_t>(count);
+  }
   TensorShape shape = {n};
   T* y = ctx->Output(0, shape)->MutableData<T>();
   for (int64_t i = 0; i < n; ++i) {

--- a/onnxruntime/core/providers/cuda/generator/range.cc
+++ b/onnxruntime/core/providers/cuda/generator/range.cc
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <cmath>
+
 #include "core/providers/shared_library/provider_api.h"
 #include "core/providers/cuda/cuda_common.h"
 #include "range.h"
@@ -87,11 +89,28 @@ static Status ComputeRange(cudaStream_t stream, OpKernelContext* ctx) {
     return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "delta in Range operator can not be zero!");
   }
 
-  double num = (static_cast<double>(limit) - static_cast<double>(start)) / static_cast<double>(delta);
-  int count = static_cast<int>(ceil(num));
-  if (count <= 0)
-    count = 0;
-  TensorShape shape = {static_cast<int64_t>(count)};
+  // Compute the element count in double, mirroring the CPU kernel's guard structure and error
+  // messages (core/providers/cpu/generator/range.cc ComputeRange) and the shape-inference path
+  // (core/graph/contrib_ops/range_schema_defs.cc CalcRangeDim). The operands are
+  // promoted to double before the subtraction so integral inputs cannot overflow in T.
+  double num = ceil((static_cast<double>(limit) - static_cast<double>(start)) / static_cast<double>(delta));
+  if (!std::isfinite(num)) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                           "Range: the computed number of elements is not a finite value.");
+  }
+  // Empty or backward ranges clamp to 0; handle the non-positive case before the cast so a
+  // large-magnitude negative count can never reach (and overflow) the int64 conversion.
+  int64_t count = 0;
+  if (num > 0) {
+    // static_cast<double>(INT64_MAX) rounds up to 2^63 (9223372036854775808.0), which is not
+    // representable as int64_t, so reject any count at or above that boundary before the cast.
+    if (num >= 9223372036854775808.0) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                             "Range: the computed number of elements exceeds the supported range.");
+    }
+    count = static_cast<int64_t>(num);
+  }
+  TensorShape shape = {count};
   T* y = ctx->Output(0, shape)->MutableData<T>();
 
   if (count > 0) {

--- a/onnxruntime/core/providers/cuda/generator/range_impl.cu
+++ b/onnxruntime/core/providers/cuda/generator/range_impl.cu
@@ -13,23 +13,34 @@ namespace onnxruntime {
 namespace cuda {
 
 template <typename T>
-__global__ void RangeKernel(const T start, const T delta, const int count, T* output) {
-  int index = blockIdx.x * blockDim.x + threadIdx.x;
-  if (index < count) {
-    output[index] = start + delta * index;
+__global__ void RangeKernel(const T start, const T delta, const int64_t count, T* output) {
+  // Use a 64-bit grid-stride loop so counts larger than the launch grid (and larger than
+  // INT_MAX) are handled correctly without index truncation or grid-dimension overflow.
+  int64_t index = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  int64_t stride = static_cast<int64_t>(gridDim.x) * blockDim.x;
+  for (int64_t i = index; i < count; i += stride) {
+    output[i] = start + delta * static_cast<T>(i);
   }
 }
 
 template <typename T>
-Status RangeImpl(cudaStream_t stream, const T start, const T delta, const int count, T* output) {
-  constexpr int block_size = 256;
-  int grid_size = (count + block_size - 1) / block_size;
+Status RangeImpl(cudaStream_t stream, const T start, const T delta, const int64_t count, T* output) {
+  if (count <= 0) {
+    return Status::OK();
+  }
+  constexpr int block_size = GridDim::maxThreadsPerBlock;
+  int64_t num_blocks = (count + block_size - 1) / block_size;
+  // CUDA limits the x-dimension of the launch grid to 2^31 - 1 blocks. Cap the grid to that
+  // maximum; the grid-stride loop in RangeKernel covers any remaining elements when the count
+  // requires more blocks than can be launched at once.
+  constexpr int64_t kMaxGridDimX = 2147483647;
+  int grid_size = static_cast<int>(num_blocks < kMaxGridDimX ? num_blocks : kMaxGridDimX);
   RangeKernel<T><<<grid_size, block_size, 0, stream>>>(start, delta, count, output);
   return CUDA_CALL(cudaGetLastError());
 }
 
 #define SPECIALIZED_IMPL(T) \
-  template Status RangeImpl<T>(cudaStream_t stream, const T start, const T delta, const int count, T* output);
+  template Status RangeImpl<T>(cudaStream_t stream, const T start, const T delta, const int64_t count, T* output);
 
 SPECIALIZED_IMPL(int16_t)
 SPECIALIZED_IMPL(int32_t)

--- a/onnxruntime/core/providers/cuda/generator/range_impl.h
+++ b/onnxruntime/core/providers/cuda/generator/range_impl.h
@@ -8,7 +8,7 @@ namespace onnxruntime {
 namespace cuda {
 
 template <typename T>
-Status RangeImpl(cudaStream_t stream, const T start, const T delta, const int count, T* output);
+Status RangeImpl(cudaStream_t stream, const T start, const T delta, const int64_t count, T* output);
 
 }  // namespace cuda
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/cpu/generator/range_test.cc
+++ b/onnxruntime/test/providers/cpu/generator/range_test.cc
@@ -97,12 +97,15 @@ TEST(RangeTest, AlmostSameStartAndLimitHighDelta) {
 #ifndef DISABLE_CONTRIB_OPS
 
 namespace {
-// Describes a single Range input supplied as a graph initializer: its declared dimensions
-// and the exact raw_data bytes. Tests use this to craft both well-formed and truncated
-// initializers (e.g. dims=[0] with empty raw_data) for the contrib Range schema.
+// Describes a single Range input supplied as a graph initializer: its declared dimensions and
+// either the exact raw_data bytes or a typed int32_data payload. Tests use this to craft
+// well-formed, truncated (e.g. dims=[0] with empty raw_data), and typed-field initializers for
+// the contrib Range schema. When int32_data is non-empty it is stored in the typed field instead
+// of raw_data (ONNX packs sub-32-bit int types such as INT16 into int32_data).
 struct RangeInputSpec {
   std::vector<int64_t> dims;
   std::string raw_data;
+  std::vector<int32_t> int32_data;
 };
 
 // Serializes a scalar value to its raw_data byte representation.
@@ -116,14 +119,21 @@ std::string ToRawData(T value) {
 // A correctly-sized scalar initializer (no dims) holding a single value.
 template <typename T>
 RangeInputSpec ScalarInput(T value) {
-  return RangeInputSpec{{}, ToRawData(value)};
+  return RangeInputSpec{{}, ToRawData(value), {}};
 }
 
 // A zero-element initializer (dims=[0]) whose raw_data is empty. The declared size matches
 // the (empty) payload, so initializer size validation accepts it; shape inference, however,
 // still attempts to read the first element.
 RangeInputSpec EmptyInput() {
-  return RangeInputSpec{{0}, std::string{}};
+  return RangeInputSpec{{0}, std::string{}, {}};
+}
+
+// A scalar initializer whose single value is carried in the typed int32_data field. ONNX packs
+// INT16 (and other sub-32-bit int) initializer values into int32_data, so this exercises the
+// typed-field shape-inference path rather than the raw_data path.
+RangeInputSpec Int16TypedInput(int16_t value) {
+  return RangeInputSpec{{}, std::string{}, {static_cast<int32_t>(value)}};
 }
 
 void AddInitializer(ONNX_NAMESPACE::GraphProto* graph, const std::string& name, int data_type,
@@ -134,7 +144,13 @@ void AddInitializer(ONNX_NAMESPACE::GraphProto* graph, const std::string& name, 
   for (int64_t dim : spec.dims) {
     initializer->add_dims(dim);
   }
-  initializer->set_raw_data(spec.raw_data);
+  if (!spec.int32_data.empty()) {
+    for (int32_t value : spec.int32_data) {
+      initializer->add_int32_data(value);
+    }
+  } else {
+    initializer->set_raw_data(spec.raw_data);
+  }
 }
 
 // Builds a single com.microsoft Range node model whose start/limit/delta inputs are supplied
@@ -219,6 +235,20 @@ TEST(RangeTest, ContribOp_ExactSizeRawData_LoadsSuccessfully) {
   const auto status = BuildAndInitializeContribRangeModel(
       ONNX_NAMESPACE::TensorProto_DataType_DOUBLE, ScalarInput(0.0), ScalarInput(5.0),
       ScalarInput(1.0), session_object);
+  ASSERT_STATUS_OK(status);
+  ASSERT_EQ(GetInferredOutputDim(session_object), 5);
+}
+
+// Verifies that shape inference handles an INT16 Range whose initializers store their values in
+// the typed int32_data field (the ONNX packing for INT16) rather than raw_data. This exercises
+// the int16 typed-field path in get_data<int16_t>: start=0, limit=5, delta=1 -> 5 elements.
+TEST(RangeTest, ContribOp_Int16TypedField_InfersDim) {
+  SessionOptions so;
+  so.session_logid = "RangeTest.ContribOp_Int16TypedField_InfersDim";
+  InferenceSession session_object{so, GetEnvironment()};
+  const auto status = BuildAndInitializeContribRangeModel(
+      ONNX_NAMESPACE::TensorProto_DataType_INT16, Int16TypedInput(0), Int16TypedInput(5),
+      Int16TypedInput(1), session_object);
   ASSERT_STATUS_OK(status);
   ASSERT_EQ(GetInferredOutputDim(session_object), 5);
 }

--- a/onnxruntime/test/providers/cpu/generator/range_test.cc
+++ b/onnxruntime/test/providers/cpu/generator/range_test.cc
@@ -1,8 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include "core/graph/constants.h"
+#include "core/session/inference_session.h"
 #include "gtest/gtest.h"
 #include "test/providers/provider_test_utils.h"
+#include "test/test_environment.h"
 
 namespace onnxruntime {
 namespace test {
@@ -87,6 +90,110 @@ TEST(RangeTest, Float_SameStartAndLimit) {
 TEST(RangeTest, AlmostSameStartAndLimitHighDelta) {
   RunTest<float>(2.0f, 2.01f, 1000000.0f, {1}, {2.0f});
 }
+
+#ifndef DISABLE_CONTRIB_OPS
+
+namespace {
+// Adds a scalar double graph initializer whose raw_data is set to the provided bytes.
+// The bytes length is intentionally controllable so tests can supply a truncated payload
+// (shorter than sizeof(double)) to exercise input validation in shape inference.
+void AddDoubleScalarInitializerWithRawData(ONNX_NAMESPACE::GraphProto* graph,
+                                           const std::string& name,
+                                           const std::string& raw_bytes) {
+  auto* initializer = graph->add_initializer();
+  initializer->set_name(name);
+  initializer->set_data_type(ONNX_NAMESPACE::TensorProto_DataType_DOUBLE);
+  initializer->set_raw_data(raw_bytes);
+}
+
+std::string DoubleToRawData(double value) {
+  return std::string(reinterpret_cast<const char*>(&value), sizeof(double));
+}
+
+// Builds a single com.microsoft Range node model whose start/limit/delta inputs are
+// supplied as graph initializers, then loads and initializes it in a session.
+common::Status BuildAndInitializeContribRangeModel(const std::string& start_raw_data,
+                                                    const std::string& limit_raw_data,
+                                                    const std::string& delta_raw_data,
+                                                    InferenceSession& session_object) {
+  ONNX_NAMESPACE::ModelProto model;
+  model.set_ir_version(ONNX_NAMESPACE::Version::IR_VERSION);
+  model.add_opset_import()->set_version(11);
+  auto* ms_opset = model.add_opset_import();
+  ms_opset->set_domain(kMSDomain);
+  ms_opset->set_version(1);
+
+  auto* graph = model.mutable_graph();
+  graph->set_name("ContribRangeGraph");
+
+  AddDoubleScalarInitializerWithRawData(graph, "start", start_raw_data);
+  AddDoubleScalarInitializerWithRawData(graph, "limit", limit_raw_data);
+  AddDoubleScalarInitializerWithRawData(graph, "delta", delta_raw_data);
+
+  auto* output = graph->add_output();
+  output->set_name("Y");
+  output->mutable_type()->mutable_tensor_type()->set_elem_type(ONNX_NAMESPACE::TensorProto_DataType_DOUBLE);
+
+  auto* range_node = graph->add_node();
+  range_node->set_name("Range");
+  range_node->set_op_type("Range");
+  range_node->set_domain(kMSDomain);
+  range_node->add_input("start");
+  range_node->add_input("limit");
+  range_node->add_input("delta");
+  range_node->add_output("Y");
+
+  std::string serialized_model;
+  if (!model.SerializeToString(&serialized_model)) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Failed to serialize test model.");
+  }
+
+  std::stringstream model_stream(serialized_model);
+  ORT_RETURN_IF_ERROR(session_object.Load(model_stream));
+  return session_object.Initialize();
+}
+}  // namespace
+
+// Verifies that Range shape inference rejects an initializer whose raw_data is shorter than
+// the element size for its declared data type, returning a clean failure status instead of
+// reading past the end of the buffer. The model must fail to load/initialize.
+TEST(RangeTest, ContribOp_TruncatedRawData_FailsCleanly) {
+  // 'start' carries fewer bytes than sizeof(double); 'limit'/'delta' are well formed.
+  const std::string truncated_start(sizeof(double) / 2, '\0');
+  SessionOptions so;
+  so.session_logid = "RangeTest.ContribOp_TruncatedRawData_FailsCleanly";
+  InferenceSession session_object{so, GetEnvironment()};
+  const auto status = BuildAndInitializeContribRangeModel(truncated_start,
+                                                          DoubleToRawData(5.0),
+                                                          DoubleToRawData(1.0),
+                                                          session_object);
+  ASSERT_FALSE(status.IsOK());
+}
+
+// Verifies that shape inference clamps an empty/backward range to a zero-sized dimension,
+// matching the CPU kernel behavior, instead of emitting a negative dimension value.
+TEST(RangeTest, ContribOp_BackwardRange_InfersZeroDim) {
+  SessionOptions so;
+  so.session_logid = "RangeTest.ContribOp_BackwardRange_InfersZeroDim";
+  InferenceSession session_object{so, GetEnvironment()};
+  // start > limit with a positive delta yields an empty range.
+  const auto status = BuildAndInitializeContribRangeModel(DoubleToRawData(5.0),
+                                                          DoubleToRawData(0.0),
+                                                          DoubleToRawData(1.0),
+                                                          session_object);
+  ASSERT_STATUS_OK(status);
+
+  const auto outputs = session_object.GetModelOutputs();
+  ASSERT_STATUS_OK(outputs.first);
+  ASSERT_EQ(outputs.second->size(), 1u);
+  const auto* shape = (*outputs.second)[0]->Shape();
+  ASSERT_NE(shape, nullptr);
+  ASSERT_EQ(shape->dim_size(), 1);
+  ASSERT_TRUE(shape->dim(0).has_dim_value());
+  ASSERT_EQ(shape->dim(0).dim_value(), 0);
+}
+
+#endif  // DISABLE_CONTRIB_OPS
 
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/cpu/generator/range_test.cc
+++ b/onnxruntime/test/providers/cpu/generator/range_test.cc
@@ -344,5 +344,58 @@ TEST(RangeTest, ContribOp_CountExceedsInt64Range_FailsCleanly) {
 
 #endif  // DISABLE_CONTRIB_OPS
 
+#ifdef USE_CUDA
+// The following tests exercise the standard onnx-domain Range CUDA kernel with runtime
+// (non-constant) inputs so the element-count guards in the CUDA ComputeRange are evaluated at
+// execution time. They are pinned to the CUDA execution provider and are skipped when a CUDA
+// provider is not available in the current build/runtime. The expected failure messages match
+// the CPU kernel exactly so both paths stay consistent.
+
+// Verifies that the CUDA kernel rejects an element count that exceeds the int64 range.
+TEST(RangeTest, CudaKernel_CountExceedsInt64Range_FailsAtRuntime) {
+  auto cuda_provider = DefaultCudaExecutionProvider();
+  if (cuda_provider == nullptr) {
+    GTEST_SKIP() << "CUDA execution provider is not available.";
+  }
+  OpTester test("Range", 11);
+  test.AddInput<double>("start", {}, {0.0});
+  test.AddInput<double>("limit", {}, {1e19});
+  test.AddInput<double>("delta", {}, {1.0});
+  test.AddOutput<double>("output", {0}, {});
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(std::move(cuda_provider));
+  test.Run(OpTester::ExpectResult::kExpectFailure,
+           "Range: the computed number of elements exceeds the supported range.", {}, nullptr,
+           &execution_providers);
+}
+
+// Verifies that the CUDA kernel rejects a non-finite computed element count (the difference of
+// the two inputs overflows to infinity).
+TEST(RangeTest, CudaKernel_NonFiniteCount_FailsAtRuntime) {
+  auto cuda_provider = DefaultCudaExecutionProvider();
+  if (cuda_provider == nullptr) {
+    GTEST_SKIP() << "CUDA execution provider is not available.";
+  }
+  OpTester test("Range", 11);
+  test.AddInput<double>("start", {}, {-1e308});
+  test.AddInput<double>("limit", {}, {1e308});
+  test.AddInput<double>("delta", {}, {1.0});
+  test.AddOutput<double>("output", {0}, {});
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(std::move(cuda_provider));
+  test.Run(OpTester::ExpectResult::kExpectFailure,
+           "Range: the computed number of elements is not a finite value.", {}, nullptr,
+           &execution_providers);
+}
+
+// Note on large-count coverage: a test that actually materializes a valid count > INT_MAX to
+// prove the int64 launch-path widening is intentionally omitted. OpTester requires a host-side
+// reference output tensor of the same element count, and a value above INT_MAX would need a
+// multi-GB host allocation (and matching device memory), which is impractical and OOM-prone on
+// CI. The int64 widening (count, grid sizing, and the grid-stride kernel index) is instead
+// covered by code review; the two guards above ensure non-finite and >= 2^63 counts are rejected
+// before any launch. A device-level large-count test can be added as a separate, opt-in benchmark.
+#endif  // USE_CUDA
+
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/cpu/generator/range_test.cc
+++ b/onnxruntime/test/providers/cpu/generator/range_test.cc
@@ -8,6 +8,7 @@
 #include "gtest/gtest.h"
 #include "test/providers/provider_test_utils.h"
 #include "test/test_environment.h"
+#include "default_providers.h"
 
 namespace onnxruntime {
 namespace test {
@@ -220,6 +221,40 @@ TEST(RangeTest, ContribOp_ExactSizeRawData_LoadsSuccessfully) {
       ScalarInput(1.0), session_object);
   ASSERT_STATUS_OK(status);
   ASSERT_EQ(GetInferredOutputDim(session_object), 5);
+}
+
+// The following two tests run the contrib Range CPU kernel with runtime (non-constant) inputs.
+// Because the inputs are not initializers, shape inference cannot fold the output length, so
+// the element-count guards in ComputeRange are exercised at execution time rather than at load.
+// They are pinned to the CPU execution provider because the contrib Range kernel is CPU-only.
+
+// Verifies that the kernel rejects an element count that exceeds the int64 range.
+TEST(RangeTest, ContribOp_Kernel_CountExceedsInt64Range_FailsAtRuntime) {
+  OpTester test("Range", 1, kMSDomain);
+  test.AddInput<double>("start", {}, {0.0});
+  test.AddInput<double>("limit", {}, {1e19});
+  test.AddInput<double>("delta", {}, {1.0});
+  test.AddOutput<double>("output", {0}, {});
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(DefaultCpuExecutionProvider());
+  test.Run(OpTester::ExpectResult::kExpectFailure,
+           "Range: the computed number of elements exceeds the supported range.", {}, nullptr,
+           &execution_providers);
+}
+
+// Verifies that the kernel rejects a non-finite computed element count (the difference of the
+// two inputs overflows to infinity).
+TEST(RangeTest, ContribOp_Kernel_NonFiniteCount_FailsAtRuntime) {
+  OpTester test("Range", 1, kMSDomain);
+  test.AddInput<double>("start", {}, {-1e308});
+  test.AddInput<double>("limit", {}, {1e308});
+  test.AddInput<double>("delta", {}, {1.0});
+  test.AddOutput<double>("output", {0}, {});
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(DefaultCpuExecutionProvider());
+  test.Run(OpTester::ExpectResult::kExpectFailure,
+           "Range: the computed number of elements is not a finite value.", {}, nullptr,
+           &execution_providers);
 }
 
 // The following tests exercise failure paths that surface via fail_shape_inference, which

--- a/onnxruntime/test/providers/cpu/generator/range_test.cc
+++ b/onnxruntime/test/providers/cpu/generator/range_test.cc
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <cstring>
+
 #include "core/graph/constants.h"
 #include "core/session/inference_session.h"
 #include "gtest/gtest.h"
@@ -94,28 +96,53 @@ TEST(RangeTest, AlmostSameStartAndLimitHighDelta) {
 #ifndef DISABLE_CONTRIB_OPS
 
 namespace {
-// Adds a scalar double graph initializer whose raw_data is set to the provided bytes.
-// The bytes length is intentionally controllable so tests can supply a truncated payload
-// (shorter than sizeof(double)) to exercise input validation in shape inference.
-void AddDoubleScalarInitializerWithRawData(ONNX_NAMESPACE::GraphProto* graph,
-                                           const std::string& name,
-                                           const std::string& raw_bytes) {
+// Describes a single Range input supplied as a graph initializer: its declared dimensions
+// and the exact raw_data bytes. Tests use this to craft both well-formed and truncated
+// initializers (e.g. dims=[0] with empty raw_data) for the contrib Range schema.
+struct RangeInputSpec {
+  std::vector<int64_t> dims;
+  std::string raw_data;
+};
+
+// Serializes a scalar value to its raw_data byte representation.
+template <typename T>
+std::string ToRawData(T value) {
+  std::string bytes(sizeof(T), '\0');
+  std::memcpy(bytes.data(), &value, sizeof(T));
+  return bytes;
+}
+
+// A correctly-sized scalar initializer (no dims) holding a single value.
+template <typename T>
+RangeInputSpec ScalarInput(T value) {
+  return RangeInputSpec{{}, ToRawData(value)};
+}
+
+// A zero-element initializer (dims=[0]) whose raw_data is empty. The declared size matches
+// the (empty) payload, so initializer size validation accepts it; shape inference, however,
+// still attempts to read the first element.
+RangeInputSpec EmptyInput() {
+  return RangeInputSpec{{0}, std::string{}};
+}
+
+void AddInitializer(ONNX_NAMESPACE::GraphProto* graph, const std::string& name, int data_type,
+                    const RangeInputSpec& spec) {
   auto* initializer = graph->add_initializer();
   initializer->set_name(name);
-  initializer->set_data_type(ONNX_NAMESPACE::TensorProto_DataType_DOUBLE);
-  initializer->set_raw_data(raw_bytes);
+  initializer->set_data_type(data_type);
+  for (int64_t dim : spec.dims) {
+    initializer->add_dims(dim);
+  }
+  initializer->set_raw_data(spec.raw_data);
 }
 
-std::string DoubleToRawData(double value) {
-  return std::string(reinterpret_cast<const char*>(&value), sizeof(double));
-}
-
-// Builds a single com.microsoft Range node model whose start/limit/delta inputs are
-// supplied as graph initializers, then loads and initializes it in a session.
-common::Status BuildAndInitializeContribRangeModel(const std::string& start_raw_data,
-                                                    const std::string& limit_raw_data,
-                                                    const std::string& delta_raw_data,
-                                                    InferenceSession& session_object) {
+// Builds a single com.microsoft Range node model whose start/limit/delta inputs are supplied
+// as graph initializers of the given element type, then loads and initializes it in a session.
+common::Status BuildAndInitializeContribRangeModel(int data_type,
+                                                   const RangeInputSpec& start,
+                                                   const RangeInputSpec& limit,
+                                                   const RangeInputSpec& delta,
+                                                   InferenceSession& session_object) {
   ONNX_NAMESPACE::ModelProto model;
   model.set_ir_version(ONNX_NAMESPACE::Version::IR_VERSION);
   model.add_opset_import()->set_version(11);
@@ -126,13 +153,13 @@ common::Status BuildAndInitializeContribRangeModel(const std::string& start_raw_
   auto* graph = model.mutable_graph();
   graph->set_name("ContribRangeGraph");
 
-  AddDoubleScalarInitializerWithRawData(graph, "start", start_raw_data);
-  AddDoubleScalarInitializerWithRawData(graph, "limit", limit_raw_data);
-  AddDoubleScalarInitializerWithRawData(graph, "delta", delta_raw_data);
+  AddInitializer(graph, "start", data_type, start);
+  AddInitializer(graph, "limit", data_type, limit);
+  AddInitializer(graph, "delta", data_type, delta);
 
   auto* output = graph->add_output();
   output->set_name("Y");
-  output->mutable_type()->mutable_tensor_type()->set_elem_type(ONNX_NAMESPACE::TensorProto_DataType_DOUBLE);
+  output->mutable_type()->mutable_tensor_type()->set_elem_type(data_type);
 
   auto* range_node = graph->add_node();
   range_node->set_name("Range");
@@ -152,23 +179,20 @@ common::Status BuildAndInitializeContribRangeModel(const std::string& start_raw_
   ORT_RETURN_IF_ERROR(session_object.Load(model_stream));
   return session_object.Initialize();
 }
-}  // namespace
 
-// Verifies that Range shape inference rejects an initializer whose raw_data is shorter than
-// the element size for its declared data type, returning a clean failure status instead of
-// reading past the end of the buffer. The model must fail to load/initialize.
-TEST(RangeTest, ContribOp_TruncatedRawData_FailsCleanly) {
-  // 'start' carries fewer bytes than sizeof(double); 'limit'/'delta' are well formed.
-  const std::string truncated_start(sizeof(double) / 2, '\0');
-  SessionOptions so;
-  so.session_logid = "RangeTest.ContribOp_TruncatedRawData_FailsCleanly";
-  InferenceSession session_object{so, GetEnvironment()};
-  const auto status = BuildAndInitializeContribRangeModel(truncated_start,
-                                                          DoubleToRawData(5.0),
-                                                          DoubleToRawData(1.0),
-                                                          session_object);
-  ASSERT_FALSE(status.IsOK());
+// Returns the inferred dim_value of output Y after a successful Initialize, or -1 if absent.
+int64_t GetInferredOutputDim(const InferenceSession& session_object) {
+  const auto outputs = session_object.GetModelOutputs();
+  if (!outputs.first.IsOK() || outputs.second->size() != 1u) {
+    return -1;
+  }
+  const auto* shape = (*outputs.second)[0]->Shape();
+  if (shape == nullptr || shape->dim_size() != 1 || !shape->dim(0).has_dim_value()) {
+    return -1;
+  }
+  return shape->dim(0).dim_value();
 }
+}  // namespace
 
 // Verifies that shape inference clamps an empty/backward range to a zero-sized dimension,
 // matching the CPU kernel behavior, instead of emitting a negative dimension value.
@@ -177,21 +201,99 @@ TEST(RangeTest, ContribOp_BackwardRange_InfersZeroDim) {
   so.session_logid = "RangeTest.ContribOp_BackwardRange_InfersZeroDim";
   InferenceSession session_object{so, GetEnvironment()};
   // start > limit with a positive delta yields an empty range.
-  const auto status = BuildAndInitializeContribRangeModel(DoubleToRawData(5.0),
-                                                          DoubleToRawData(0.0),
-                                                          DoubleToRawData(1.0),
-                                                          session_object);
+  const auto status = BuildAndInitializeContribRangeModel(
+      ONNX_NAMESPACE::TensorProto_DataType_DOUBLE, ScalarInput(5.0), ScalarInput(0.0),
+      ScalarInput(1.0), session_object);
   ASSERT_STATUS_OK(status);
-
-  const auto outputs = session_object.GetModelOutputs();
-  ASSERT_STATUS_OK(outputs.first);
-  ASSERT_EQ(outputs.second->size(), 1u);
-  const auto* shape = (*outputs.second)[0]->Shape();
-  ASSERT_NE(shape, nullptr);
-  ASSERT_EQ(shape->dim_size(), 1);
-  ASSERT_TRUE(shape->dim(0).has_dim_value());
-  ASSERT_EQ(shape->dim(0).dim_value(), 0);
+  ASSERT_EQ(GetInferredOutputDim(session_object), 0);
 }
+
+// Verifies that a correctly-sized raw_data initializer (exactly sizeof(T) bytes) loads
+// successfully and produces the expected inferred dimension, so the length check does not
+// over-reject valid models.
+TEST(RangeTest, ContribOp_ExactSizeRawData_LoadsSuccessfully) {
+  SessionOptions so;
+  so.session_logid = "RangeTest.ContribOp_ExactSizeRawData_LoadsSuccessfully";
+  InferenceSession session_object{so, GetEnvironment()};
+  const auto status = BuildAndInitializeContribRangeModel(
+      ONNX_NAMESPACE::TensorProto_DataType_DOUBLE, ScalarInput(0.0), ScalarInput(5.0),
+      ScalarInput(1.0), session_object);
+  ASSERT_STATUS_OK(status);
+  ASSERT_EQ(GetInferredOutputDim(session_object), 5);
+}
+
+// The following tests exercise failure paths that surface via fail_shape_inference, which
+// reports the error by throwing an inference error. They are excluded from no-exception
+// builds where such a throw would abort rather than yield a failure Status.
+#if !defined(ORT_NO_EXCEPTIONS)
+
+// Verifies that Range shape inference rejects an initializer whose raw_data holds fewer bytes
+// than its declared data type requires (here: a zero-element initializer with empty raw_data,
+// which initializer size validation accepts), returning a clean failure status instead of
+// reading more bytes than the initializer declares. One test per input position.
+TEST(RangeTest, ContribOp_TruncatedStartRawData_FailsCleanly) {
+  SessionOptions so;
+  so.session_logid = "RangeTest.ContribOp_TruncatedStartRawData_FailsCleanly";
+  InferenceSession session_object{so, GetEnvironment()};
+  const auto status = BuildAndInitializeContribRangeModel(
+      ONNX_NAMESPACE::TensorProto_DataType_DOUBLE, EmptyInput(), ScalarInput(5.0),
+      ScalarInput(1.0), session_object);
+  ASSERT_FALSE(status.IsOK());
+}
+
+TEST(RangeTest, ContribOp_TruncatedLimitRawData_FailsCleanly) {
+  SessionOptions so;
+  so.session_logid = "RangeTest.ContribOp_TruncatedLimitRawData_FailsCleanly";
+  InferenceSession session_object{so, GetEnvironment()};
+  const auto status = BuildAndInitializeContribRangeModel(
+      ONNX_NAMESPACE::TensorProto_DataType_DOUBLE, ScalarInput(0.0), EmptyInput(),
+      ScalarInput(1.0), session_object);
+  ASSERT_FALSE(status.IsOK());
+}
+
+TEST(RangeTest, ContribOp_TruncatedDeltaRawData_FailsCleanly) {
+  SessionOptions so;
+  so.session_logid = "RangeTest.ContribOp_TruncatedDeltaRawData_FailsCleanly";
+  InferenceSession session_object{so, GetEnvironment()};
+  const auto status = BuildAndInitializeContribRangeModel(
+      ONNX_NAMESPACE::TensorProto_DataType_DOUBLE, ScalarInput(0.0), ScalarInput(5.0),
+      EmptyInput(), session_object);
+  ASSERT_FALSE(status.IsOK());
+}
+
+// Exercises the length check for different sizeof(T) template instantiations (float, int64).
+TEST(RangeTest, ContribOp_TruncatedFloatRawData_FailsCleanly) {
+  SessionOptions so;
+  so.session_logid = "RangeTest.ContribOp_TruncatedFloatRawData_FailsCleanly";
+  InferenceSession session_object{so, GetEnvironment()};
+  const auto status = BuildAndInitializeContribRangeModel(
+      ONNX_NAMESPACE::TensorProto_DataType_FLOAT, EmptyInput(), ScalarInput(5.0f),
+      ScalarInput(1.0f), session_object);
+  ASSERT_FALSE(status.IsOK());
+}
+
+TEST(RangeTest, ContribOp_TruncatedInt64RawData_FailsCleanly) {
+  SessionOptions so;
+  so.session_logid = "RangeTest.ContribOp_TruncatedInt64RawData_FailsCleanly";
+  InferenceSession session_object{so, GetEnvironment()};
+  const auto status = BuildAndInitializeContribRangeModel(
+      ONNX_NAMESPACE::TensorProto_DataType_INT64, EmptyInput(), ScalarInput<int64_t>(5),
+      ScalarInput<int64_t>(1), session_object);
+  ASSERT_FALSE(status.IsOK());
+}
+
+// Verifies that a zero delta is rejected cleanly by shape inference.
+TEST(RangeTest, ContribOp_ZeroDelta_FailsCleanly) {
+  SessionOptions so;
+  so.session_logid = "RangeTest.ContribOp_ZeroDelta_FailsCleanly";
+  InferenceSession session_object{so, GetEnvironment()};
+  const auto status = BuildAndInitializeContribRangeModel(
+      ONNX_NAMESPACE::TensorProto_DataType_DOUBLE, ScalarInput(0.0), ScalarInput(10.0),
+      ScalarInput(0.0), session_object);
+  ASSERT_FALSE(status.IsOK());
+}
+
+#endif  // !defined(ORT_NO_EXCEPTIONS)
 
 #endif  // DISABLE_CONTRIB_OPS
 

--- a/onnxruntime/test/providers/cpu/generator/range_test.cc
+++ b/onnxruntime/test/providers/cpu/generator/range_test.cc
@@ -293,6 +293,18 @@ TEST(RangeTest, ContribOp_ZeroDelta_FailsCleanly) {
   ASSERT_FALSE(status.IsOK());
 }
 
+// Verifies that a finite element count that exceeds the int64 range is rejected cleanly,
+// rather than reaching an out-of-range conversion (start=0, limit=1e19, delta=1).
+TEST(RangeTest, ContribOp_CountExceedsInt64Range_FailsCleanly) {
+  SessionOptions so;
+  so.session_logid = "RangeTest.ContribOp_CountExceedsInt64Range_FailsCleanly";
+  InferenceSession session_object{so, GetEnvironment()};
+  const auto status = BuildAndInitializeContribRangeModel(
+      ONNX_NAMESPACE::TensorProto_DataType_DOUBLE, ScalarInput(0.0), ScalarInput(1e19),
+      ScalarInput(1.0), session_object);
+  ASSERT_FALSE(status.IsOK());
+}
+
 #endif  // !defined(ORT_NO_EXCEPTIONS)
 
 #endif  // DISABLE_CONTRIB_OPS


### PR DESCRIPTION
### Summary

The `com.microsoft` Range operator's shape-inference helper read a fixed number of bytes from an initializer's `raw_data` without first checking the buffer length, and the element-count computation could pass non-finite or out-of-range values to an `int64` cast. This change adds the missing validations and aligns the shape-inference and CPU kernel paths.

### Changes

- `GetFirstElement` now checks `raw_data` length is at least the element size before reading, and reads via `std::memcpy` into an aligned local.
- `CalcRangeDim` and the CPU kernel `ComputeRange` now reject non-finite computed counts, handle non-positive counts before the `int64` cast, and reject counts that are not representable as `int64` (`>= 2^63`). Both paths use identical messages and semantics.
- The output dimension for empty/backward ranges is clamped to 0 in shape inference to match the kernel.

### Tests

Added contrib Range model-load regression tests in `range_test.cc` covering:
- truncated `raw_data` for `start`, `limit`, and `delta` (double, plus float and int64 element types),
- zero delta,
- a finite-but-too-large element count,
- an exact-size success boundary,
- backward-range zero-dimension inference.

Tests assert on `Status` (safe for no-exception builds) and are guarded by `#ifndef DISABLE_CONTRIB_OPS` (throwing cases additionally by `!defined(ORT_NO_EXCEPTIONS)`). 21/21 `RangeTest` cases pass locally.

### Follow-up

`int16` inputs are currently supported only via `raw_data` (there is no `get_data<int16_t>` specialization for the non-raw-data path); this is left as a separate follow-up.
