### PR TITLE
EPContext sample helper follow-ups + compiled-model encryption design doc

### DIFF
--- a/docs/design/Compiled_Model_Encryption.md
+++ b/docs/design/Compiled_Model_Encryption.md
@@ -1,0 +1,678 @@
+# Compiled Model Encryption
+
+## Overview
+
+This document describes how an application can generate an *encrypted* compiled model and later load
+it for inference, with **all encryption/decryption performed by the application**. ONNX Runtime (ORT)
+and the execution providers (EPs) never write plaintext to disk on the application's behalf and never
+hold the encryption keys.
+
+The piece that makes this possible for **EPContext binary data** — the compiled kernels/engines an EP
+emits when embed mode is disabled (e.g. a serialized TensorRT engine or a QNN context binary) — is a
+pair of application-supplied **named-buffer I/O callbacks** plus a small EP-facing configuration
+handle. That mechanism, together with a reference helper for EP authors, was added in
+[microsoft/onnxruntime#28624](https://github.com/microsoft/onnxruntime/pull/28624) and refined in
+[microsoft/onnxruntime#29294](https://github.com/microsoft/onnxruntime/pull/29294).
+
+The model-level and initializer-level hooks that this feature builds on (the compiled-model write
+callback, the per-initializer location callback, in-memory external initializers, and EPContext embed
+mode) are **pre-existing** ORT compile/session APIs and are described here only for context.
+
+> **Note:** The public API added by these PRs is **experimental** — it is resolved by name/version
+> through the `Ort::Experimental` function-pointer table (see [Experimental_C_API.md](Experimental_C_API.md)),
+> not exposed as members of the stable `OrtApi` struct. All entries below are available since
+> `ORT_API_VERSION` 28.
+
+## Background
+
+A model is composed of the following "model assets":
+
+- ONNX model file
+- External initializer files referenced from the ONNX model
+- EPContext node binary data (embedded in the model, or stored in external files, for compiled models)
+
+ORT already supports model compilation via the compilation API (`OrtCompileApi`). These pre-existing
+APIs let an application:
+
+- Provide an input model from a buffer (`ModelCompilationOptions_SetInputModelFromBuffer`), allowing
+  the application to decrypt the model before handing it to ORT.
+- Stream out compiled ONNX model bytes via a write callback
+  (`ModelCompilationOptions_SetOutputModelWriteFunc`), enabling the application to encrypt the output.
+- Control per-initializer storage via a callback
+  (`ModelCompilationOptions_SetOutputModelGetInitializerLocationFunc`), enabling the application to
+  encrypt and store initializers externally.
+
+For loading and inference, ORT lets an application inject external initializer files from an in-memory
+buffer (`AddExternalInitializersFromFilesInMemory`), so the application can decrypt initializer files
+and hand the bytes to the session.
+
+### Current Gaps (addressed by #28624 / #29294)
+
+- **Compilation:** there was no hook to intercept EPContext binary data writes when embed mode is
+  disabled — the EP wrote the context binary directly to a file, defeating application-side encryption.
+- **Load:** there was no way to supply decrypted EPContext binary data to the EP without writing
+  plaintext to disk and without double-buffering.
+
+## Requirements
+
+- **No unencrypted data on disk.** All encryption/decryption happens in memory, in the application;
+  ORT and the EPs never persist plaintext on the application's behalf.
+- **Minimize peak memory.** Avoid double-buffering (app buffer + ORT copy). Prefer a read callback
+  that lets the application allocate the output directly via an ORT-provided allocator (1× peak).
+- **Reuse existing API patterns.** A write callback for the compile side and a read callback (with an
+  ORT-provided allocator) for the load side. Keep the callbacks generic ("named buffer") so the
+  contract can be reused for other named payloads.
+- **Minimize EP / plugin API changes.** No changes to the `OrtEp` struct or the `Compile()` signature.
+  Encryption is application-controlled, not ORT- or EP-controlled.
+- **Backward compatible.** EPs that ignore the new APIs, and applications that register no callbacks,
+  behave exactly as before.
+
+## Assumptions
+
+- Uncompiled model assets are originally encrypted.
+- The uncompiled model may have a mix of embedded initializers and initializers stored in external
+  (encrypted) files.
+- The application knows the location of all model assets (both uncompiled and compiled).
+- Just-in-time (JIT) compilation is used, with a requirement that no unencrypted assets are written to
+  disk during compilation.
+- The original uncompiled model is encrypted and must be decrypted during JIT compilation.
+- Compiled models may have EPContext nodes with embedded binary data or binary data stored in
+  encrypted external files.
+
+## Approaches Considered
+
+### Where encryption lives
+
+**A. Application-controlled I/O callbacks (chosen).** The application supplies read/write callbacks;
+ORT and the EPs route EPContext binary data through them and never handle keys or plaintext on disk.
+
+- Pros: keys and crypto never enter ORT; the application can encrypt, compress, or redirect to cloud
+  storage; no crypto dependency is added to ORT.
+- Cons: the application must implement and register the callbacks; the contract (allocator ownership,
+  state lifetime and thread-safety) must be documented carefully.
+
+**B. ORT- or EP-managed encryption.** ORT (or each EP) encrypts/decrypts using a key handed to it.
+
+- Pros: less application code for the common case.
+- Cons: ORT/EPs would own key material and a crypto implementation (large surface, policy and
+  compliance burden) and would be inflexible for cloud/compression use cases. Rejected.
+
+**C. Filesystem / OS-level encryption.** Rely on an encrypted volume.
+
+- Pros: no ORT changes.
+- Cons: does not satisfy "no unencrypted data on disk" for JIT flows (plaintext transits the
+  filesystem) and is outside the application's per-asset control. Rejected.
+
+### How the EP obtains the callbacks
+
+**A. Getter-based `OrtEpContextConfig` + reference helper (chosen).** The application registers
+callbacks on the session/compile options; the EP extracts an opaque `OrtEpContextConfig` in
+`CreateEp()` and pulls the callback/state via `OrtEpApi` accessors. The "callback if present, else
+file I/O" logic and untrusted-name hardening live in the sample `ep_context_data_utils` helper.
+
+- Pros: zero `OrtEp` struct changes; the opaque handle can gain fields later without breaking EPs; the
+  fallback/validation policy can evolve in sample code without an ABI commitment.
+- Cons: EPs must copy/adapt the helper (it is not ABI); slightly more EP code than a single ORT call.
+
+**B. ORT-implemented `OrtEpApi::Read/WriteEpContextData` utility (proposed, not shipped).** ORT owns a
+function that performs the callback-or-disk fallback internally.
+
+- Pros: a single call for the EP; consistent fallback behavior across EPs.
+- Cons: bakes path-resolution and fallback policy into the ABI (hard to iterate on) and grows the
+  stable surface. Deferred in favor of a sample helper — see [Rejected Alternatives](#rejected-alternatives).
+
+**C. Change the `OrtEp` struct / `Compile()` signature.** Pass the callbacks/config directly to the EP.
+
+- Pros: explicit.
+- Cons: breaks the EP ABI and every existing EP. Rejected.
+
+### Read-side memory model
+
+**A. Read callback allocates via the ORT allocator; `EpContextData` adopts it (chosen).** Peak memory
+is 1× — only the final buffer exists.
+
+**B. Callback returns its own buffer and ORT copies into a `std::vector`.** Simpler ownership, but 2×
+peak for potentially multi-GB engine/context binaries. Retained only as the `std::vector` convenience
+overload for callers that want an owned vector and can afford one copy.
+
+### EPContext storage
+
+**Embed (`embed = true`)** keeps EPContext bytes inside the model, encrypted with the model bytes — no
+EPContext-specific callback is needed; this is simplest when the model stays under the 2 GB protobuf
+limit. **External (`embed = false`)** stores the bytes in separate files and is the case that requires
+the write/read callbacks. Both are supported; embed is recommended first when size permits.
+
+## Named-Buffer I/O Callbacks
+
+The callbacks are intentionally generic ("named buffer") so the same contract can be reused for other
+named payloads in the future; today they are used for EPContext binary data. Each invocation is
+synchronous, and ORT does not serialize invocations made by different EP instances or worker threads.
+
+### `OrtWriteNamedBufferFunc`
+
+Called during compilation to write named binary data. `name` identifies which EPContext binary is
+being written so the application can choose a storage location. The application's implementation can
+process the data in any way (e.g. encrypt and store, upload to cloud storage, or compress) before
+persisting it.
+
+Each invocation represents one complete write for `name`; the signature carries no offset or
+final-chunk marker, so any chunked ordering/completion contract must be defined by the invoking EP.
+Current EPContext use should prefer a single invocation per EPContext binary unless the EP documents
+chunking semantics.
+
+```c
+typedef OrtStatus*(ORT_API_CALL* OrtWriteNamedBufferFunc)(_In_ void* state,
+                                                          _In_ const char* name,
+                                                          _In_ const void* buffer,
+                                                          _In_ size_t buffer_num_bytes);
+```
+
+### `OrtReadNamedBufferFunc`
+
+Called during session load to obtain named binary data. ORT provides an allocator so the application
+can allocate the output buffer directly, avoiding double-buffering. The application reads, processes
+(e.g. decrypts, decompresses, downloads), allocates via the provided allocator, fills the buffer, and
+returns. Peak memory for the payload is 1× (only the final buffer exists).
+
+```c
+typedef OrtStatus*(ORT_API_CALL* OrtReadNamedBufferFunc)(_In_ void* state,
+                                                         _In_ const char* name,
+                                                         _In_ OrtAllocator* allocator,
+                                                         _Outptr_ void** buffer,
+                                                         _Out_ size_t* data_size);
+```
+
+Both callbacks return `OrtStatus*` (nullptr on success; use `CreateStatus` on failure). The `state`
+pointer is opaque and owned by the application, which must keep it valid — and synchronize it if it
+can be used concurrently — for as long as an EP might invoke the callback.
+
+## Registering the Callbacks (Application Side)
+
+### Read callback — `OrtApi_SessionOptions_SetEpContextDataReadFunc`
+
+Registers the read callback on the session options. Reading happens at session load, so this is
+configured on `OrtSessionOptions`. Passing `NULL` for `read_func` clears any previously set callback
+(and its state).
+
+```c
+ORT_EXPERIMENTAL_API(28, OrtStatusPtr, OrtApi_SessionOptions_SetEpContextDataReadFunc,
+                     _Inout_ OrtSessionOptions* options,
+                     _In_opt_ OrtReadNamedBufferFunc read_func,
+                     _In_opt_ void* state);
+```
+
+### Write callback — `OrtCompileApi_ModelCompilationOptions_SetEpContextDataWriteFunc`
+
+Registers the write callback used during compilation when embed mode is disabled. Writing happens only
+at compile time, so this is configured on `OrtModelCompilationOptions`. It may be used together with
+`ModelCompilationOptions_SetEpContextBinaryInformation`, whose binary information still describes the
+compiled-model/output location EPs use to generate stable logical names or as a file-fallback
+location. Passing `NULL` for `write_func` clears any previously set callback (and its state).
+
+```c
+ORT_EXPERIMENTAL_API(28, OrtStatusPtr, OrtCompileApi_ModelCompilationOptions_SetEpContextDataWriteFunc,
+                     _In_ OrtModelCompilationOptions* model_compile_options,
+                     _In_opt_ OrtWriteNamedBufferFunc write_func,
+                     _In_opt_ void* state);
+```
+
+## EP-Facing: `OrtEpContextConfig` and Accessors
+
+### `OrtEpContextConfig` (opaque handle)
+
+An opaque handle that holds ORT's copy of the EPContext callback function pointers and their opaque
+state, extracted from an `OrtSessionOptions` instance. It **does not** own the application-provided
+state — the application remains responsible for keeping that state valid and synchronized. The EP
+creates the handle during `CreateEp()` (while the session options are still valid) and releases it in
+its destructor.
+
+> The originally-proposed *typed EP-context generation-option accessors* (embed mode, file path, node
+> name prefix, weightless flag, etc.) are **not** part of this implementation. `OrtEpContextConfig`
+> currently carries only the I/O callbacks and their state. See [Open Questions](#open-questions).
+
+### Extract / release — `OrtEpApi_SessionOptions_GetEpContextConfig` / `OrtEpApi_ReleaseEpContextConfig`
+
+```c
+// Extract the EPContext configuration (callbacks + state) from session options. On success *config is
+// a non-NULL handle that must be released with OrtEpApi_ReleaseEpContextConfig; on failure *config is
+// left unmodified. Call during CreateEp() while session_options is valid; store the handle for Compile().
+ORT_EXPERIMENTAL_API(28, OrtStatusPtr, OrtEpApi_SessionOptions_GetEpContextConfig,
+                     _In_ const OrtSessionOptions* session_options,
+                     _Outptr_ OrtEpContextConfig** config);
+
+// Release the handle. May be NULL.
+ORT_EXPERIMENTAL_API(28, void, OrtEpApi_ReleaseEpContextConfig,
+                     _Frees_ptr_opt_ OrtEpContextConfig* config);
+```
+
+### Retrieve callbacks — `OrtEpApi_EpContextConfig_GetEpContextData{Read,Write}Func`
+
+The EP pulls the registered callback (and its state) out of the config. If none was registered,
+`*func` and `*state` are set to `NULL`, and the EP should use its own normal disk read/write path.
+
+```c
+ORT_EXPERIMENTAL_API(28, OrtStatusPtr, OrtEpApi_EpContextConfig_GetEpContextDataReadFunc,
+                     _In_ const OrtEpContextConfig* config,
+                     _Out_ OrtReadNamedBufferFunc* read_func,
+                     _Out_ void** state);
+
+ORT_EXPERIMENTAL_API(28, OrtStatusPtr, OrtEpApi_EpContextConfig_GetEpContextDataWriteFunc,
+                     _In_ const OrtEpContextConfig* config,
+                     _Out_ OrtWriteNamedBufferFunc* write_func,
+                     _Out_ void** state);
+```
+
+### C++ convenience wrapper — `Ort::Experimental::EpContextConfig`
+
+A move-only RAII wrapper (in `onnxruntime_experimental_cxx_api.h`) that owns the handle and exposes the
+callback accessors. Typical EP usage: construct from the session options during `CreateEp()`, keep the
+wrapper for the EP's lifetime, and query the callbacks via `GetReadFunc()` / `GetWriteFunc()`.
+
+```cpp
+namespace Ort::Experimental {
+class EpContextConfig {
+ public:
+  explicit EpContextConfig(std::nullptr_t) noexcept;
+  explicit EpContextConfig(const SessionOptions& session_options);
+  explicit EpContextConfig(ConstSessionOptions session_options);   // extracts via GetEpContextConfig
+
+  EpContextConfig(EpContextConfig&&) noexcept;                     // move-only
+  EpContextConfig& operator=(EpContextConfig&&) noexcept;
+
+  OrtEpContextConfig* get() const noexcept;
+  explicit operator bool() const noexcept;
+  OrtEpContextConfig* release() noexcept;
+  void reset() noexcept;                                           // releases via OrtEpApi_ReleaseEpContextConfig
+
+  void GetReadFunc(OrtReadNamedBufferFunc& read_func, void*& state) const;
+  void GetWriteFunc(OrtWriteNamedBufferFunc& write_func, void*& state) const;
+};
+}  // namespace Ort::Experimental
+```
+
+## Reference Helper: `ep_context_data_utils` (sample, not ABI)
+
+Location: `onnxruntime/test/autoep/library/ep_context_data_utils.h`. This is **sample/reference code**
+for EP authors, shared by the example plugin EP and its tests. It is intentionally **outside the ORT C
+and EP ABI**; EPs are expected to copy and adapt it. It wraps the "use the callback if present,
+otherwise fall back to file I/O" pattern and hardens untrusted, model-derived names. Production EPs
+should additionally apply their own sandboxing, size limits, and path policies.
+
+### `EpContextData` — zero-copy owning buffer (#29294)
+
+A move-only RAII owner for the bytes returned by a read. On the callback path it **adopts** the
+allocator-provided buffer directly (no copy) and frees it via the same allocator on destruction; on the
+file-fallback path it owns a `std::vector` read straight from disk. Either way the bytes are accessed
+through `data()` / `size()` without an extra copy. Ownership is transferred into the object **only on
+success**, so it stays empty on any error path.
+
+```cpp
+class EpContextData {
+ public:
+  const char* data() const noexcept;   // valid until destroyed/reassigned; may be null only when empty
+  size_t size() const noexcept;
+  bool empty() const noexcept;
+  // move-only; frees the adopted allocator buffer (if any) on destruction
+};
+```
+
+### Read with file fallback
+
+```cpp
+// Zero-copy: if the config carries a read callback it is invoked with the ORT allocator and the
+// returned buffer is adopted by `out`; otherwise the file is read (resolved against the model dir).
+OrtStatus* ReadEpContextData(const OrtApi& api, const OrtEpContextConfig* config,
+                             const char* file_name, const OrtGraph* graph, EpContextData& out);
+
+// std::vector<char> convenience wrapper around the above (file path reads straight into `data`; the
+// callback path reads zero-copy and then copies once). `data` is cleared first; empty on failure.
+OrtStatus* ReadEpContextDataWithFileFallback(const OrtApi& api, const OrtEpContextConfig* config,
+                                             const char* file_name, const OrtGraph* graph,
+                                             std::vector<char>& data);
+```
+
+### Write with file fallback
+
+```cpp
+// If the config carries a write callback it is invoked with `file_name`; otherwise the bytes are
+// written to a file. An overload takes a separate `fallback_file_name` for the on-disk path.
+OrtStatus* WriteEpContextDataWithFileFallback(const OrtApi& api, const OrtEpContextConfig* config,
+                                              const char* file_name, const OrtGraph* graph,
+                                              const void* buffer, size_t buffer_size);
+```
+
+### Untrusted name handling (#28624 + #29294)
+
+The helper distinguishes trust based on the `OrtGraph*`:
+
+- **Logical (callback-namespace) names** written into the model are validated with
+  `ValidateEpContextDataName`: reject absolute/rooted paths, reject `..` traversal
+  (`ContainsPathTraversal`), and reject directory-like names (empty leaf, `.`, or a `..` leaf).
+- **Model-derived file names** (`graph != nullptr`, i.e. read from an EPContext node's
+  `ep_cache_context` attribute) are joined with the model directory, canonicalized with
+  `std::filesystem::weakly_canonical` (resolving `.` / `..` and symlinks), and accepted **only if the
+  resolved path stays within the model directory** (`IsResolvedPathWithinBase`). A benign `a/b/../file`
+  is accepted; anything escaping the model directory — including via a symlink — is rejected.
+- **Trusted callers** (`graph == nullptr`) own the path and may pass an absolute path or one containing
+  `..`; there is no model directory to contain against, so no traversal check is applied there.
+
+## Application Flows
+
+### Flow 1: JIT Compilation (Encrypt Compiled Model)
+
+```text
+┌─────────────────────────────────────────────────────────────────┐
+│ Application                                                       │
+│                                                                   │
+│  1. Create OrtSessionOptions                                      │
+│  2. Decrypt external initializer files into buffers               │
+│  3. Inject via AddExternalInitializersFromFilesInMemory           │
+│  4. Create OrtModelCompilationOptions from session options        │
+│  5. Decrypt ONNX model into buffer                                │
+│  6. ModelCompilationOptions_SetInputModelFromBuffer(buffer)       │
+│  7. ModelCompilationOptions_SetOutputModelWriteFunc(encrypt_cb)   │
+│  8. ModelCompilationOptions_SetOutputModelGetInitializerLocation… │
+│  9. ModelCompilationOptions_SetEpContextEmbedMode(true|false)     │
+│ 10. [If embed=false]                                              │
+│     ModelCompilationOptions_SetEpContextDataWriteFunc(write_cb)   │
+│ 11. CompileModel(...)                                             │
+│                                                                   │
+│  During CompileModel:                                             │
+│  ├─ ORT calls the model write callback with compiled ONNX chunks  │
+│  ├─ ORT calls the initializer-location callback per initializer   │
+│  └─ [If embed=false]                                              │
+│     ├─ EP extracts OrtEpContextConfig in CreateEp()               │
+│     ├─ ORT calls ep->Compile(...)                                 │
+│     │  Inside EP's Compile():                                     │
+│     │  ├─ EP generates compiled binary (e.g., a TRT engine)       │
+│     │  ├─ EP calls ep_context_data_utils::WriteEpContextData…     │
+│     │  │     (api, config, name, graph, data, size)               │
+│     │  └─ helper pulls write_cb from config and invokes it        │
+│     │     → app encrypts and stores the data                      │
+│                                                                   │
+│  After CompileModel: all assets are encrypted on disk/storage     │
+└───────────────────────────────────────────────────────────────────┘
+```
+
+#### Step-by-step
+
+1. Create `OrtSessionOptions` and configure the desired execution providers.
+2. Decrypt external initializer files into memory buffers.
+3. Inject initializers via `OrtApi::AddExternalInitializersFromFilesInMemory` (copies buffers). Release
+   app-side buffers after this call.
+4. Create `OrtModelCompilationOptions` from the session options via
+   `OrtCompileApi::CreateModelCompilationOptionsFromSessionOptions`.
+5. Decrypt the uncompiled ONNX model into a memory buffer.
+6. Set the input model buffer via `OrtCompileApi::ModelCompilationOptions_SetInputModelFromBuffer`.
+7. Set the model write callback via `OrtCompileApi::ModelCompilationOptions_SetOutputModelWriteFunc`.
+   ORT calls it with chunks of compiled ONNX bytes; the app encrypts and writes them.
+8. Set the initializer location callback via
+   `OrtCompileApi::ModelCompilationOptions_SetOutputModelGetInitializerLocationFunc`. Per initializer,
+   the app can:
+   - Embed it in the ONNX model (return `new_external_info = NULL`); it is encrypted with the model
+     bytes via the model write callback.
+   - Store it externally: encrypt and write the initializer, then return an `OrtExternalInitializerInfo`
+     pointing to the file.
+
+   > Note: ONNX files cannot exceed 2 GB due to protobuf limitations. Large initializers should be
+   > stored externally.
+9. Set the EPContext embed mode via `OrtCompileApi::ModelCompilationOptions_SetEpContextEmbedMode`.
+   - `embed = true`: EPContext binary data is stored inside the `ep_cache_context` attribute of
+     EPContext nodes and is encrypted with the model bytes. No additional API is needed.
+   - `embed = false`: EPContext binary data is stored in external files. Proceed to step 10.
+10. _(If `embed = false`)_ Register the write callback **(new in #28624)** via
+    `OrtCompileApi::ModelCompilationOptions_SetEpContextDataWriteFunc`. ORT stores it in the session
+    options; when the EP calls `OrtEpApi_SessionOptions_GetEpContextConfig` during `CreateEp()`, the
+    write callback is carried by the returned `OrtEpContextConfig`. During `Compile()`, when the EP
+    produces compiled binary data (e.g. a serialized TensorRT engine), it writes it through the config
+    (directly via `OrtEpApi_EpContextConfig_GetEpContextDataWriteFunc`, or via the
+    `ep_context_data_utils::WriteEpContextDataWithFileFallback` helper) instead of writing to disk. The
+    `name` parameter lets the application distinguish multiple EPContext binaries (one per compiled
+    subgraph).
+11. Compile the model via `OrtCompileApi::CompileModel`. After this call, all compiled model assets are
+    generated and encrypted.
+
+### Flow 2: Load, Decrypt, and Run Inference
+
+```text
+┌─────────────────────────────────────────────────────────────────┐
+│ Application                                                       │
+│                                                                   │
+│  1. Create OrtSessionOptions                                      │
+│  2. Decrypt external initializer files into buffers               │
+│  3. Inject via AddExternalInitializersFromFilesInMemory           │
+│  4. [If embed=false]                                              │
+│     SessionOptions_SetEpContextDataReadFunc(decrypt_read_cb)      │
+│  5. Decrypt compiled ONNX model into buffer                       │
+│  6. CreateSessionFromArray(buffer, ...)                           │
+│                                                                   │
+│  During session initialization:                                   │
+│  ├─ EP extracts OrtEpContextConfig in CreateEp()                  │
+│  │   → EP stores the handle (e.g. Ort::Experimental::EpContext…)  │
+│  ├─ ORT calls ep->Compile(...)                                    │
+│  │  Inside EP's Compile():                                        │
+│  │  ├─ EP hits an EPContext node with an external file reference  │
+│  │  ├─ EP calls ep_context_data_utils::ReadEpContextData(         │
+│  │  │     api, config, name, graph, ep_context_data)              │
+│  │  ├─ helper pulls read_cb from config and invokes it:           │
+│  │  │   read_cb(state, name, allocator, &buf, &size)              │
+│  │  │   → app reads, decrypts, allocates via ORT allocator        │
+│  │  └─ EP deserializes from ep_context_data.data()/size()         │
+│  │                                                                │
+│  7. Run inference                                                 │
+└───────────────────────────────────────────────────────────────────┘
+```
+
+#### Step-by-step
+
+1. Create `OrtSessionOptions` and configure the desired execution providers.
+2. Decrypt external initializer files into memory buffers.
+3. Inject initializers via `OrtApi::AddExternalInitializersFromFilesInMemory` (copies buffers). Release
+   app-side buffers after this call.
+4. _(If `embed = false`)_ Register the read callback **(new in #28624)** via
+   `OrtApi::SessionOptions_SetEpContextDataReadFunc`. When invoked, the callback receives an
+   ORT-provided allocator; the application:
+   1. Reads the source data (e.g. from encrypted storage, cloud, a compressed file).
+   2. Processes it as needed (e.g. decrypts, decompresses).
+   3. Allocates a buffer using the ORT allocator.
+   4. Writes the output into the buffer and returns it.
+
+   > This eliminates double-buffering. Peak memory for EPContext data is 1× (only the final buffer
+   > exists).
+5. Decrypt the compiled ONNX model into a memory buffer.
+6. Create the session via `OrtApi::CreateSessionFromArray` with the decrypted model buffer. During
+   session initialization, for each EP:
+   - The EP calls `OrtEpApi_SessionOptions_GetEpContextConfig` during `CreateEp()` (while session
+     options are still valid) and stores the returned `OrtEpContextConfig` handle (typically wrapped in
+     `Ort::Experimental::EpContextConfig`).
+   - ORT calls `ep->Compile(...)`.
+   - When the EP encounters an EPContext node with an external file reference, it reads the data through
+     the config — via `ep_context_data_utils::ReadEpContextData(api, config, name, graph, out)` (or by
+     pulling the callback with `OrtEpApi_EpContextConfig_GetEpContextDataReadFunc`). If no read callback
+     is present, the helper falls back to reading the file from the model directory.
+   - The EP releases the config (RAII wrapper does this in its destructor).
+7. Run inference as usual.
+
+## Memory Usage Analysis
+
+| Asset | Compilation Peak | Load Peak |
+| --- | --- | --- |
+| ONNX model | 1× (app decrypts into buffer, streams out via write callback) | 1× (app decrypts into buffer for `CreateSessionFromArray`) |
+| External initializers | 2× during inject (`AddExternalInitializersFromFilesInMemory` copies) | 2× during inject (same API, same copy behavior) |
+| EPContext binary (embed=true) | Included in ONNX model bytes | Included in ONNX model bytes |
+| EPContext binary (embed=false) | Streaming (near 0×) via write callback | **1×** via read callback (app allocates with the ORT allocator; `EpContextData` adopts it) |
+
+### Notes on Memory
+
+- External initializers still use the existing `AddExternalInitializersFromFilesInMemory` API, which
+  copies buffers (2× peak). A future optimization could add a read-callback variant for initializers,
+  matching the EPContext pattern.
+- EPContext binary data can be large (hundreds of MB to GBs for TensorRT engines, QNN context
+  binaries). The read-callback + `EpContextData` approach is specifically designed to avoid
+  double-buffering here.
+- Embed mode (`embed = true`) is the simplest path: all binary data flows through the existing model
+  write/read callbacks with no EPContext-specific callback needed. Consider it first if the total model
+  size (including embedded EPContext data) stays within the 2 GB protobuf limit.
+
+## EP Impact
+
+All EPs are plugin EPs that implement the `OrtEp` struct and access ORT functionality through
+`OrtEpApi`. **No changes to the `OrtEp` struct are required** — `OrtEp::Compile()`'s signature is
+unchanged. The feature is realized entirely through:
+
+- `OrtEpApi_SessionOptions_GetEpContextConfig` / `OrtEpApi_ReleaseEpContextConfig` — obtain and release
+  the config handle.
+- `OrtEpApi_EpContextConfig_GetEpContextDataReadFunc` / `...GetEpContextDataWriteFunc` — retrieve the
+  application's callback (and state), or `NULL` if none was registered.
+- The `ep_context_data_utils` reference helper (sample code) — encapsulates the callback-or-file
+  fallback and the untrusted-name hardening.
+
+### Adoption by EPs
+
+- **New EPs:** extract the `OrtEpContextConfig` in `CreateEp()` and store it (e.g. as a
+  `Ort::Experimental::EpContextConfig` member). During `Compile()`, read/write EPContext binaries
+  through the config (directly via the getters, or via the reference helper, which handles the
+  callback-vs-disk fallback transparently). Release the config in the destructor.
+- **Old EPs / no callback registered:** the getters return `NULL`; EPs continue reading/writing files
+  directly. No breakage.
+
+### Example: TensorRT-style EP (Compilation — Writing)
+
+```cpp
+// In the EP's Compile(): write the serialized engine, honoring an app write callback if present.
+nvinfer1::IHostMemory* serialized = trt_engine->serialize();
+
+// ep_context_config_ is an Ort::Experimental::EpContextConfig obtained in CreateEp().
+RETURN_IF_ERROR(ep_context_data_utils::WriteEpContextDataWithFileFallback(
+    ort_api, ep_context_config_.get(),
+    engine_cache_name,   // logical name / file-fallback name
+    graph,               // model graph, for file-fallback path resolution
+    serialized->data(), serialized->size()));
+// No std::ofstream needed — the helper invokes the write callback or writes to disk.
+```
+
+### Example: TensorRT-style EP (Load — Reading)
+
+```cpp
+// In the EP's Compile(): read a cached engine, honoring an app read callback if present.
+ep_context_data_utils::EpContextData ctx;
+RETURN_IF_ERROR(ep_context_data_utils::ReadEpContextData(
+    ort_api, ep_context_config_.get(), ep_cache_context_name, graph, ctx));
+
+engine = runtime->deserializeCudaEngine(ctx.data(), ctx.size());
+// `ctx` frees the adopted allocator buffer (or its owned vector) on destruction — no manual free.
+```
+
+Both examples replace the EP's existing `std::ofstream` / `std::ifstream` code with a single helper
+call that handles both the custom (callback) and standard (disk) cases.
+
+### Backward Compatibility
+
+This is a backward-compatible addition: the new functions are experimental entries resolved by
+name/version, the `OrtEp` struct (EP-implemented) is unchanged, and `OrtEp::Compile()`'s signature is
+unchanged. EPs that do not call the new functions, and applications that register no callbacks, behave
+exactly as before.
+
+## API Summary
+
+New callback typedefs (in `onnxruntime_experimental_c_api.h`):
+
+| API | Location | Purpose |
+| --- | --- | --- |
+| `OrtWriteNamedBufferFunc` | Callback typedef | Write named (EPContext) binary data during compilation |
+| `OrtReadNamedBufferFunc` | Callback typedef | Read/process named data, allocate via the ORT allocator, return the buffer, during load |
+
+New experimental functions (since `ORT_API_VERSION` 28):
+
+| API | Group | Purpose |
+| --- | --- | --- |
+| `OrtApi_SessionOptions_SetEpContextDataReadFunc` | `OrtApi` | Register the read callback on session options (load) |
+| `OrtCompileApi_ModelCompilationOptions_SetEpContextDataWriteFunc` | `OrtCompileApi` | Register the write callback on compile options |
+| `OrtEpApi_SessionOptions_GetEpContextConfig` | `OrtEpApi` | EP extracts the config handle from session options during `CreateEp()` |
+| `OrtEpApi_ReleaseEpContextConfig` | `OrtEpApi` | Release the `OrtEpContextConfig` handle |
+| `OrtEpApi_EpContextConfig_GetEpContextDataReadFunc` | `OrtEpApi` | EP retrieves the read callback + state (or `NULL`) |
+| `OrtEpApi_EpContextConfig_GetEpContextDataWriteFunc` | `OrtEpApi` | EP retrieves the write callback + state (or `NULL`) |
+| `OrtEpContextConfig` | Opaque type | Carries the callbacks + state extracted from session options |
+
+C++ wrapper and reference helper:
+
+| Symbol | Location | Purpose |
+| --- | --- | --- |
+| `Ort::Experimental::EpContextConfig` | `onnxruntime_experimental_cxx_api.h` | RAII wrapper over `OrtEpContextConfig`; `GetReadFunc` / `GetWriteFunc` |
+| `ep_context_data_utils::EpContextData` | `test/autoep/library/ep_context_data_utils.h` (sample) | Zero-copy owning buffer for a read result |
+| `ep_context_data_utils::ReadEpContextData` / `ReadEpContextDataWithFileFallback` | sample | Read via callback or file fallback |
+| `ep_context_data_utils::WriteEpContextDataWithFileFallback` | sample | Write via callback or file fallback |
+
+Pre-existing APIs used (no changes needed):
+
+| API | Location | Purpose |
+| --- | --- | --- |
+| `AddExternalInitializersFromFilesInMemory` | `OrtApi` | Inject decrypted external initializers |
+| `ModelCompilationOptions_SetInputModelFromBuffer` | `OrtCompileApi` | Compile from a decrypted model buffer |
+| `ModelCompilationOptions_SetOutputModelWriteFunc` | `OrtCompileApi` | Stream-encrypt compiled ONNX model bytes |
+| `ModelCompilationOptions_SetOutputModelGetInitializerLocationFunc` | `OrtCompileApi` | Per-initializer embed/external decision + encryption |
+| `ModelCompilationOptions_SetEpContextEmbedMode` | `OrtCompileApi` | Control EPContext binary embedding |
+| `ModelCompilationOptions_SetEpContextBinaryInformation` | `OrtCompileApi` | Describe the compiled-model/output location for stable names / file fallback |
+| `CreateSessionFromArray` | `OrtApi` | Create a session from a decrypted model buffer |
+
+## Internal Wiring
+
+This section is illustrative implementation detail — applications and EPs see only the public APIs
+above.
+
+- **Application → session options.** `SetEpContextDataReadFunc` (on `OrtSessionOptions`) and
+  `SetEpContextDataWriteFunc` (on `OrtModelCompilationOptions`, which forwards into the underlying
+  session options) store the callback function pointer and opaque state.
+- **Session options → `OrtEpContextConfig`.** `OrtEpApi_SessionOptions_GetEpContextConfig` allocates a
+  config handle that holds copies of those callback pointers and state values (it does not own the
+  application state).
+- **`OrtEpContextConfig` → EP.** The EP obtains the handle during `CreateEp()` and keeps it. During
+  `Compile()`, the getters return the stored callback/state; when none was registered, they return
+  `NULL` and the EP (or the reference helper) falls back to disk I/O. The EP releases the handle in its
+  destructor.
+
+## Rejected Alternatives
+
+- **ORT-implemented `OrtEpApi::Read/WriteEpContextData` utility.** The original proposal had ORT expose
+  ABI functions that performed the callback-or-disk fallback and path resolution internally. This was
+  not shipped: it would bake fallback and path-resolution policy into the (experimental/stable) ABI,
+  making the untrusted-name hardening hard to iterate on. Instead, EPs retrieve the raw callback via
+  the config getters and use the sample `ep_context_data_utils` helper (copyable, non-ABI) for the
+  fallback and validation logic.
+- **Typed EP-context generation-option accessors on `OrtEpContextConfig`.** The proposal also floated
+  typed accessors for EP-context generation options (`ep.context_enable`, `ep.context_embed_mode`,
+  `ep.context_file_path`, etc.) that EPs read today as string key/value pairs via
+  `GetSessionConfigEntry`. These PRs implement only the I/O callbacks + state on the config; typed
+  accessors remain a possible future extension (see [Open Questions](#open-questions)).
+- **ORT- or EP-managed encryption** and **filesystem-level encryption** — see
+  [Approaches Considered](#approaches-considered).
+
+## Open Questions
+
+1. **Streaming decryption for external initializers.** `AddExternalInitializersFromFilesInMemory`
+   copies buffers (2× peak). Should a read-callback variant be added for initializers to match the
+   EPContext pattern?
+2. **Streaming decryption for the ONNX model itself.** A `CreateSessionFromReadFunc`-style API could let
+   the application stream-decrypt the ONNX model during session creation, avoiding holding the entire
+   decrypted model in memory. Protobuf supports parsing from a stream, so this is feasible.
+3. **Multiple EPContext binaries per compilation.** The write callback includes a `name` parameter to
+   distinguish multiple EPContext binaries. Should ORT guarantee the ordering of write invocations
+   (e.g. all data for name A before name B)? The current contract prefers a single invocation per name
+   unless the EP documents chunking.
+4. **Thread safety of the read callback.** Each EP gets its own `OrtEpContextConfig`, so the design is
+   thread-safe across EPs by construction. If a single EP calls the read path from multiple threads for
+   different files, the application's callback must itself be thread-safe.
+5. **Typed EP-context generation-option accessors (not implemented).** `OrtEpContextConfig` could also
+   expose the EP-context generation options that EPs read today as string key/value pairs via
+   `GetSessionConfigEntry` (e.g. `ep.context_enable`, `ep.context_embed_mode`, `ep.context_file_path`).
+   These PRs implement only the I/O callbacks; typed accessors remain a possible future extension.
+
+## Appendix: EP-Impact Cases (draft)
+
+Rough case analysis of how compilation settings affect EP changes:
+
+- **Embed mode = 1, internal weights:** no EP changes.
+- **Embed mode = 1, external initializer file:**
+  - No weightless: no EP changes.
+  - Weightless: app sets the encryption callback; ORT writes weights to disk by invoking the callback
+    after the EP's `Compile()` call to EP context; no EP changes.

--- a/docs/design/Compiled_Model_Encryption.md
+++ b/docs/design/Compiled_Model_Encryption.md
@@ -51,7 +51,24 @@ and hand the bytes to the session.
 - **Compilation:** there was no hook to intercept EPContext binary data writes when embed mode is
   disabled — the EP wrote the context binary directly to a file, defeating application-side encryption.
 - **Load:** there was no way to supply decrypted EPContext binary data to the EP without writing
-  plaintext to disk and without double-buffering.
+  plaintext to disk and without double-buffering. Before this feature the EP loaded its EPContext
+  binary by opening the external file itself (e.g. `std::ifstream` on the path stored in the
+  `ep_cache_context` attribute). For an encrypted model that forced two undesirable outcomes:
+  - **Plaintext on disk.** Because the EP reads from a file path, the application had to first decrypt
+    the binary to a temporary plaintext file for the EP to open — directly violating the
+    "no unencrypted data on disk" property this feature exists to preserve. Even a short-lived temp
+    file exposes the decrypted engine/context binary to other processes and to crash/interruption
+    scenarios, and adds extra I/O.
+  - **Double-buffering (2× peak memory).** Even if the application decrypted into memory instead, there
+    was no API to hand that buffer to the EP. The EP would allocate its own buffer and read the bytes
+    in, so the decrypted payload existed twice at once — once in the application's buffer and once in
+    the EP's copy. For EPContext binaries that can be hundreds of MB to several GB (TensorRT engines,
+    QNN / Ryzen AI context binaries), that doubled peak is significant.
+
+  The load-side read callback closes both gaps: the application allocates the final buffer once via the
+  ORT-provided allocator and returns the decrypted bytes directly to the EP — no temporary plaintext
+  file and no second copy (1× peak). See [Named-Buffer I/O Callbacks](#named-buffer-io-callbacks) and
+  [Memory Usage Analysis](#memory-usage-analysis).
 
 ## Requirements
 

--- a/docs/design/Compiled_Model_Encryption.md
+++ b/docs/design/Compiled_Model_Encryption.md
@@ -360,9 +360,9 @@ OrtStatus* WriteEpContextDataWithFileFallback(const OrtApi& api, const OrtEpCont
 
 The helper distinguishes trust based on the `OrtGraph*`:
 
-- **Logical (callback-namespace) names** written into the model are validated with
-  `ValidateEpContextDataName`: reject absolute/rooted paths, reject `..` traversal
-  (`ContainsPathTraversal`), and reject directory-like names (empty leaf, `.`, or a `..` leaf).
+- **Logical (callback-namespace) names** are opaque keys owned by the application's I/O callbacks: they
+  are passed through unmodified and are **not** validated as filesystem paths. Path rules are enforced
+  only where a name is actually used as a path (below), not at authoring time.
 - **Model-derived file names** (`graph != nullptr`, i.e. read from an EPContext node's
   `ep_cache_context` attribute) are joined with the model directory, canonicalized with
   `std::filesystem::weakly_canonical` (resolving `.` / `..` and symlinks), and accepted **only if the

--- a/docs/design/Compiled_Model_Encryption.md
+++ b/docs/design/Compiled_Model_Encryption.md
@@ -377,6 +377,12 @@ The helper distinguishes trust based on the `OrtGraph*`:
   special files — notably a FIFO left inside the model directory, which passes containment and would
   block an `ifstream` open (a cheap DoS). The check is advisory, not a security boundary: the path can
   change between the check and the open (TOCTOU); a race-free variant would inspect the opened handle.
+- **A symlink write target is rejected outright** (`symlink_status`, which inspects the link itself
+  rather than following it). Containment alone does not cover this case: a *dangling* symlink has no
+  target for `weakly_canonical` to resolve, so it stays lexically inside the model directory and passes
+  the containment check, yet an `ofstream` would follow it and create the file wherever it points. A
+  `status`-based test cannot catch it either, because the missing target reports as `not_found` — the
+  same result as the ordinary "new file" case that writes must allow.
 
 ## Application Flows
 
@@ -582,7 +588,7 @@ RETURN_IF_ERROR(ep_context_data_utils::ReadEpContextData(
     ort_api, ep_context_config_.get(), ep_cache_context_name, graph, ctx));
 
 engine = runtime->deserializeCudaEngine(ctx.data(), ctx.size());
-// `ctx` frees the adopted allocator buffer (or its owned vector) on destruction — no manual free.
+// `ctx` frees the adopted allocator buffer on destruction — no manual free.
 ```
 
 Both examples replace the EP's existing `std::ofstream` / `std::ifstream` code with a single helper

--- a/docs/design/Compiled_Model_Encryption.md
+++ b/docs/design/Compiled_Model_Encryption.md
@@ -377,12 +377,15 @@ The helper distinguishes trust based on the `OrtGraph*`:
   special files — notably a FIFO left inside the model directory, which passes containment and would
   block an `ifstream` open (a cheap DoS). The check is advisory, not a security boundary: the path can
   change between the check and the open (TOCTOU); a race-free variant would inspect the opened handle.
-- **A symlink write target is rejected outright** (`symlink_status`, which inspects the link itself
-  rather than following it). Containment alone does not cover this case: a *dangling* symlink has no
-  target for `weakly_canonical` to resolve, so it stays lexically inside the model directory and passes
-  the containment check, yet an `ofstream` would follow it and create the file wherever it points. A
-  `status`-based test cannot catch it either, because the missing target reports as `not_found` — the
-  same result as the ordinary "new file" case that writes must allow.
+- **A symlink write target is rejected** (`symlink_status`, which inspects the link itself rather than
+  following it). This covers what containment cannot: a *dangling* symlink has no target for
+  `weakly_canonical` to resolve, so the link path survives resolution, stays lexically inside the model
+  directory and passes the containment check — yet an `ofstream` would follow it and create the file
+  wherever it points. A `status`-based test cannot catch it either, because the missing target reports
+  as `not_found`, the same result as the ordinary "new file" case that writes must allow. Note the
+  division of labor: a model-relative symlink that *does* resolve is replaced by its target during
+  resolution, so containment is what constrains those writes; this check covers the dangling case and
+  trusted (`graph == nullptr`) paths, which skip resolution altogether.
 
 ## Application Flows
 

--- a/docs/design/Compiled_Model_Encryption.md
+++ b/docs/design/Compiled_Model_Encryption.md
@@ -370,6 +370,13 @@ The helper distinguishes trust based on the `OrtGraph*`:
   is accepted; anything escaping the model directory — including via a symlink — is rejected.
 - **Trusted callers** (`graph == nullptr`) own the path and may pass an absolute path or one containing
   `..`; there is no model directory to contain against, so no traversal check is applied there.
+- **File type** is checked where the path is actually used, not during resolution: a read target must
+  exist and be a regular file (`EnsureRegularFileForRead`), and a write target must be a regular file
+  *if* it already exists (`EnsureRegularFileForWrite`). Both use `std::filesystem::status`, which
+  follows symlinks and so is consistent with the canonicalization above. This rejects directories and
+  special files — notably a FIFO left inside the model directory, which passes containment and would
+  block an `ifstream` open (a cheap DoS). The check is advisory, not a security boundary: the path can
+  change between the check and the open (TOCTOU); a race-free variant would inspect the opened handle.
 
 ## Application Flows
 

--- a/docs/design/Compiled_Model_Encryption.md
+++ b/docs/design/Compiled_Model_Encryption.md
@@ -149,8 +149,8 @@ function that performs the callback-or-disk fallback internally.
 is 1× — only the final buffer exists.
 
 **B. Callback returns its own buffer and ORT copies into a `std::vector`.** Simpler ownership, but 2×
-peak for potentially multi-GB engine/context binaries. Retained only as the `std::vector` convenience
-overload for callers that want an owned vector and can afford one copy.
+peak for potentially multi-GB engine/context binaries. Rejected: `EpContextData` already provides
+convenient zero-copy access, so no separate copy-into-`std::vector` reader is kept.
 
 ### EPContext storage
 
@@ -319,9 +319,10 @@ should additionally apply their own sandboxing, size limits, and path policies.
 
 A move-only RAII owner for the bytes returned by a read. On the callback path it **adopts** the
 allocator-provided buffer directly (no copy) and frees it via the same allocator on destruction; on the
-file-fallback path it owns a `std::vector` read straight from disk. Either way the bytes are accessed
-through `data()` / `size()` without an extra copy. Ownership is transferred into the object **only on
-success**, so it stays empty on any error path.
+file-fallback path it reads straight from disk into a buffer allocated from the same (optionally
+caller-supplied) allocator. Either way the bytes are accessed through `data()` / `size()` without an
+extra copy, and the allocator (which is not owned) must outlive the object. Ownership is transferred
+into the object **only on success**, so it stays empty on any error path.
 
 ```cpp
 class EpContextData {
@@ -336,16 +337,13 @@ class EpContextData {
 ### Read with file fallback
 
 ```cpp
-// Zero-copy: if the config carries a read callback it is invoked with the ORT allocator and the
-// returned buffer is adopted by `out`; otherwise the file is read (resolved against the model dir).
+// Zero-copy: if the config carries a read callback it is invoked with the (optionally caller-supplied)
+// allocator and the returned buffer is adopted by `out`; otherwise the file is read into an allocator-
+// backed buffer (resolved against the model dir). `allocator` is optional (nullptr = ORT default) and is
+// not owned by `out`: it must outlive `out`.
 OrtStatus* ReadEpContextData(const OrtApi& api, const OrtEpContextConfig* config,
-                             const char* file_name, const OrtGraph* graph, EpContextData& out);
-
-// std::vector<char> convenience wrapper around the above (file path reads straight into `data`; the
-// callback path reads zero-copy and then copies once). `data` is cleared first; empty on failure.
-OrtStatus* ReadEpContextDataWithFileFallback(const OrtApi& api, const OrtEpContextConfig* config,
-                                             const char* file_name, const OrtGraph* graph,
-                                             std::vector<char>& data);
+                             const char* file_name, const OrtGraph* graph, EpContextData& out,
+                             OrtAllocator* allocator = nullptr);
 ```
 
 ### Write with file fallback
@@ -617,7 +615,7 @@ C++ wrapper and reference helper:
 | --- | --- | --- |
 | `Ort::Experimental::EpContextConfig` | `onnxruntime_experimental_cxx_api.h` | RAII wrapper over `OrtEpContextConfig`; `GetReadFunc` / `GetWriteFunc` |
 | `ep_context_data_utils::EpContextData` | `test/autoep/library/ep_context_data_utils.h` (sample) | Zero-copy owning buffer for a read result |
-| `ep_context_data_utils::ReadEpContextData` / `ReadEpContextDataWithFileFallback` | sample | Read via callback or file fallback |
+| `ep_context_data_utils::ReadEpContextData` | sample | Read via callback or file fallback into an owning `EpContextData` |
 | `ep_context_data_utils::WriteEpContextDataWithFileFallback` | sample | Write via callback or file fallback |
 
 Pre-existing APIs used (no changes needed):

--- a/onnxruntime/test/autoep/ep_context_data_callbacks.h
+++ b/onnxruntime/test/autoep/ep_context_data_callbacks.h
@@ -22,6 +22,8 @@ struct EpContextDataCallbackState {
   std::string write_file_name;
   std::string read_file_name;
   std::vector<char> payload;
+  // Buffer the read callback allocated, recorded so tests can assert the reader adopted it instead of copying it.
+  void* last_read_buffer = nullptr;
 };
 
 inline OrtStatus* ORT_API_CALL StoreEpContextDataCallback(void* state, const char* file_name, const void* buffer,
@@ -48,6 +50,7 @@ inline OrtStatus* ORT_API_CALL LoadEpContextDataCallback(void* state, const char
 
   *buffer = nullptr;
   *data_size = callback_state->payload.size();
+  callback_state->last_read_buffer = nullptr;
   if (callback_state->payload.empty()) {
     return nullptr;
   }
@@ -57,6 +60,7 @@ inline OrtStatus* ORT_API_CALL LoadEpContextDataCallback(void* state, const char
     return status;
   }
 
+  callback_state->last_read_buffer = *buffer;
   std::copy(callback_state->payload.begin(), callback_state->payload.end(), static_cast<char*>(*buffer));
   return nullptr;
 }

--- a/onnxruntime/test/autoep/ep_context_data_utils_test.cc
+++ b/onnxruntime/test/autoep/ep_context_data_utils_test.cc
@@ -134,8 +134,10 @@ TEST(OrtEpLibrary, EpContextDataUtils_ResolvePathAndInvalidArguments) {
                        ORT_INVALID_ARGUMENT, "EPContext data buffer must not be null for non-empty data");
 
   std::vector<char> data;
+  data.assign({'s', 't', 'a', 'l', 'e'});
   ExpectOrtStatusError(ep_context_data_utils::ReadEpContextDataWithFileFallback(api, nullptr, "", nullptr, data),
                        ORT_INVALID_ARGUMENT, "EPContext data file name must not be empty");
+  EXPECT_TRUE(data.empty());  // cleared up front, even though file_name validation fails
   ExpectOrtStatusError(ep_context_data_utils::WriteEpContextDataWithFileFallback(api, nullptr, "", nullptr, nullptr, 0),
                        ORT_INVALID_ARGUMENT, "EPContext data file name must not be empty");
   ExpectOrtStatusError(ep_context_data_utils::WriteEpContextDataWithFileFallback(

--- a/onnxruntime/test/autoep/ep_context_data_utils_test.cc
+++ b/onnxruntime/test/autoep/ep_context_data_utils_test.cc
@@ -38,6 +38,26 @@ OrtStatus* ORT_API_CALL LoadInvalidEpContextDataCallback(void* state, const char
   return nullptr;
 }
 
+// Allocates a real buffer via the provided allocator and then returns an error status. Used to verify the zero-copy
+// reader frees the callback buffer and leaves the owning buffer empty on a callback error path.
+OrtStatus* ORT_API_CALL LoadFailingAfterAllocEpContextDataCallback(void* state, const char* file_name,
+                                                                   OrtAllocator* allocator, void** buffer,
+                                                                   size_t* data_size) {
+  auto* callback_state = static_cast<EpContextDataCallbackState*>(state);
+  callback_state->read_called = true;
+  callback_state->read_file_name = file_name;
+
+  *buffer = nullptr;
+  *data_size = 0;
+  constexpr size_t kSize = 8;
+  OrtStatus* alloc_status = Ort::GetApi().AllocatorAlloc(allocator, kSize, buffer);
+  if (alloc_status != nullptr) {
+    return alloc_status;
+  }
+  *data_size = kSize;
+  return Ort::GetApi().CreateStatus(ORT_FAIL, "synthetic read failure after allocation");
+}
+
 void ExpectOrtStatusError(OrtStatus* status_ptr, OrtErrorCode expected_code, std::string_view expected_message) {
   Ort::Status status{status_ptr};
   ASSERT_NE(status_ptr, nullptr) << "Expected a failure status, but the API returned nullptr (OK).";
@@ -371,6 +391,23 @@ TEST(OrtEpLibrary, EpContextDataUtils_ReadEpContextDataAdoptsCallbackBufferZeroC
   ASSERT_ORTSTATUS_OK(ep_context_data_utils::ReadEpContextData(
       api, /*ep_context_config=*/nullptr, data_file_name.c_str(), nullptr, file_owned));
   EXPECT_EQ(std::string(file_owned.data(), file_owned.data() + file_owned.size()), payload);
+}
+
+TEST(OrtEpLibrary, EpContextDataUtils_ReadEpContextDataLeavesOutputEmptyOnCallbackError) {
+  const auto& api = Ort::GetApi();
+
+  // A callback that allocates a buffer and then fails: ReadEpContextData must free that buffer (via its internal RAII
+  // guard) and leave the owning buffer empty, since ownership is transferred to `out` only on success.
+  EpContextDataCallbackState read_callback_state;
+  ep_context_data_utils::EpContextData owned;
+  ExpectOrtStatusError(ep_context_data_utils::ReadEpContextData(
+                           api, LoadFailingAfterAllocEpContextDataCallback, &read_callback_state,
+                           "failing_after_alloc_context.bin", nullptr, owned),
+                       ORT_FAIL, "synthetic read failure after allocation");
+  ASSERT_TRUE(read_callback_state.read_called);
+  EXPECT_EQ(read_callback_state.read_file_name, "failing_after_alloc_context.bin");
+  EXPECT_TRUE(owned.empty());
+  EXPECT_EQ(owned.size(), 0u);
 }
 
 }  // namespace test

--- a/onnxruntime/test/autoep/ep_context_data_utils_test.cc
+++ b/onnxruntime/test/autoep/ep_context_data_utils_test.cc
@@ -127,9 +127,10 @@ TEST(OrtEpLibrary, EpContextDataUtils_ResolvePathRejectsUnsafeNames) {
   const auto& api = Ort::GetApi();
   std::filesystem::path data_path;
 
-  ExpectOrtStatusError(ep_context_data_utils::ResolveEpContextDataPath(api, "../escape.ctx", nullptr, data_path),
-                       ORT_INVALID_ARGUMENT, "EPContext data file name must not contain path traversal");
-  EXPECT_TRUE(data_path.empty());
+  // Trusted direct callers (graph == nullptr) own the path: ".." is allowed (there is no model directory to contain
+  // against, and absolute paths are already permitted) and the name is accepted as-is rather than rejected.
+  ASSERT_ORTSTATUS_OK(ep_context_data_utils::ResolveEpContextDataPath(api, "../escape.ctx", nullptr, data_path));
+  EXPECT_FALSE(data_path.empty());
 
 #ifdef _WIN32
   const char* absolute_file_name = "C:\\temp\\escape.ctx";
@@ -151,8 +152,10 @@ TEST(OrtEpLibrary, EpContextDataUtils_ResolvePathRejectsUnsafeNames) {
 #endif
 
   std::vector<char> data;
+  // Trusted (graph == nullptr) reads also allow ".."; the resolver no longer rejects it, so a non-existent target now
+  // surfaces as a normal file-open failure rather than a traversal rejection.
   ExpectOrtStatusError(ep_context_data_utils::ReadEpContextDataFromFile(api, "../escape.ctx", nullptr, data),
-                       ORT_INVALID_ARGUMENT, "EPContext data file name must not contain path traversal");
+                       ORT_FAIL, "Failed to open EPContext data file for read");
   ExpectOrtStatusError(ep_context_data_utils::WriteEpContextDataWithFileFallback(
                            api, nullptr, absolute_file_name, "unused.ctx", nullptr, nullptr, 0),
                        ORT_INVALID_ARGUMENT, "EPContext data file name must not be absolute or rooted");

--- a/onnxruntime/test/autoep/ep_context_data_utils_test.cc
+++ b/onnxruntime/test/autoep/ep_context_data_utils_test.cc
@@ -296,6 +296,14 @@ TEST(OrtEpLibrary, EpContextDataUtils_CallbackFallbackUsesCallbacks) {
   EXPECT_EQ(read_callback_state.read_file_name, "callback_context.bin");
   EXPECT_EQ(data, read_callback_state.payload);
 
+  read_callback_state = {};
+  data.assign({'s', 't', 'a', 'l', 'e'});
+  ASSERT_ORTSTATUS_OK(ep_context_data_utils::ReadEpContextDataWithFileFallback(
+      api, LoadEpContextDataCallback, &read_callback_state, "empty_callback_context.bin", nullptr, data));
+  ASSERT_TRUE(read_callback_state.read_called);
+  EXPECT_EQ(read_callback_state.read_file_name, "empty_callback_context.bin");
+  EXPECT_TRUE(data.empty());
+
   const std::string payload = "callback write payload";
   ASSERT_ORTSTATUS_OK(ep_context_data_utils::WriteEpContextDataWithFileFallback(
       api, StoreEpContextDataCallback, &write_callback_state, "callback_write_context.bin",
@@ -323,12 +331,14 @@ TEST(OrtEpLibrary, EpContextDataUtils_ReadCallbackRejectsNullBufferForNonEmptyPa
   EpContextDataCallbackState read_callback_state;
 
   std::vector<char> data;
+  data.assign({'s', 't', 'a', 'l', 'e'});
   ExpectOrtStatusError(ep_context_data_utils::ReadEpContextDataWithFileFallback(
                            api, LoadInvalidEpContextDataCallback, &read_callback_state,
                            "invalid_callback_context.bin", nullptr, data),
                        ORT_FAIL, "OrtReadNamedBufferFunc returned a null buffer for non-empty EPContext data");
   ASSERT_TRUE(read_callback_state.read_called);
   EXPECT_EQ(read_callback_state.read_file_name, "invalid_callback_context.bin");
+  EXPECT_TRUE(data.empty());
 }
 
 TEST(OrtEpLibrary, EpContextDataUtils_ReadEpContextDataAdoptsCallbackBufferZeroCopy) {

--- a/onnxruntime/test/autoep/ep_context_data_utils_test.cc
+++ b/onnxruntime/test/autoep/ep_context_data_utils_test.cc
@@ -20,6 +20,7 @@
 #include "test/autoep/library/ep_context_data_utils.h"
 #include "test/util/include/api_asserts.h"
 #include "test/util/include/asserts.h"
+#include "test/util/include/test_allocator.h"
 
 namespace onnxruntime {
 namespace test {
@@ -410,6 +411,29 @@ TEST(OrtEpLibrary, EpContextDataUtils_ReadEpContextDataLeavesOutputEmptyOnCallba
   EXPECT_EQ(read_callback_state.read_file_name, "failing_after_alloc_context.bin");
   EXPECT_TRUE(owned.empty());
   EXPECT_EQ(owned.size(), 0u);
+}
+
+TEST(OrtEpLibrary, EpContextDataUtils_ReadEpContextDataUsesCallerSuppliedAllocator) {
+  const auto& api = Ort::GetApi();
+
+  // A caller-supplied allocator is used for the callback output buffer, and the same allocator frees it when the
+  // EpContextData owner is destroyed (matching alloc/free).
+  MockedOrtAllocator allocator;
+  EpContextDataCallbackState read_callback_state;
+  read_callback_state.payload = {'a', 'l', 'l', 'o', 'c', 'a', 't', 'o', 'r'};
+
+  {
+    ep_context_data_utils::EpContextData owned;
+    ASSERT_ORTSTATUS_OK(ep_context_data_utils::ReadEpContextData(
+        api, LoadEpContextDataCallback, &read_callback_state, "caller_allocator_context.bin", nullptr, owned,
+        &allocator));
+    ASSERT_EQ(owned.size(), read_callback_state.payload.size());
+    EXPECT_EQ(std::vector<char>(owned.data(), owned.data() + owned.size()), read_callback_state.payload);
+    // The caller-supplied allocator (not ORT's default) allocated the callback output buffer.
+    EXPECT_GE(allocator.NumAllocations(), static_cast<size_t>(1));
+  }
+  // Destroying `owned` freed the buffer via the same caller-supplied allocator; nothing should leak.
+  allocator.LeakCheck();
 }
 
 }  // namespace test

--- a/onnxruntime/test/autoep/ep_context_data_utils_test.cc
+++ b/onnxruntime/test/autoep/ep_context_data_utils_test.cc
@@ -162,10 +162,15 @@ TEST(OrtEpLibrary, EpContextDataUtils_ResolvePathRejectsUnsafeNames) {
                                                                        empty_model_path_graph.ToExternal(), data_path),
                        ORT_INVALID_ARGUMENT, "requires a model path");
 
-  // A model-derived name that designates a directory ("." or a trailing separator with an empty filename) is
+  // A model-derived name that designates a directory (".", "..", or a trailing separator with an empty filename) is
   // rejected up front, rather than resolving to a directory and failing later with a confusing I/O error.
   ExpectOrtStatusError(ep_context_data_utils::ResolveEpContextDataPath(api, ".", empty_model_path_graph.ToExternal(),
                                                                        data_path),
+                       ORT_INVALID_ARGUMENT, "must refer to a file");
+  // A leaf ".." (e.g. "sub/..") resolves to the parent/model directory; it is rejected here rather than passing the
+  // model-directory containment check and surfacing later as a directory I/O failure.
+  ExpectOrtStatusError(ep_context_data_utils::ResolveEpContextDataPath(api, "sub/..",
+                                                                       empty_model_path_graph.ToExternal(), data_path),
                        ORT_INVALID_ARGUMENT, "must refer to a file");
   ExpectOrtStatusError(ep_context_data_utils::WriteEpContextDataWithFileFallback(
                            api, nullptr, ".", "unused.ctx", nullptr, nullptr, 0),
@@ -321,6 +326,38 @@ TEST(OrtEpLibrary, EpContextDataUtils_ReadCallbackRejectsNullBufferForNonEmptyPa
                        ORT_FAIL, "OrtReadNamedBufferFunc returned a null buffer for non-empty EPContext data");
   ASSERT_TRUE(read_callback_state.read_called);
   EXPECT_EQ(read_callback_state.read_file_name, "invalid_callback_context.bin");
+}
+
+TEST(OrtEpLibrary, EpContextDataUtils_ReadEpContextDataAdoptsCallbackBufferZeroCopy) {
+  const auto& api = Ort::GetApi();
+
+  // Callback path: ReadEpContextData adopts the buffer the callback allocates (no copy into a std::vector) and frees
+  // it via the same allocator when the EpContextData owner is destroyed.
+  EpContextDataCallbackState read_callback_state;
+  read_callback_state.payload = {'z', 'e', 'r', 'o', '-', 'c', 'o', 'p', 'y'};
+  ep_context_data_utils::EpContextData owned;
+  ASSERT_ORTSTATUS_OK(ep_context_data_utils::ReadEpContextData(
+      api, LoadEpContextDataCallback, &read_callback_state, "zero_copy_context.bin", nullptr, owned));
+  ASSERT_TRUE(read_callback_state.read_called);
+  EXPECT_EQ(read_callback_state.read_file_name, "zero_copy_context.bin");
+  ASSERT_EQ(owned.size(), read_callback_state.payload.size());
+  EXPECT_EQ(std::vector<char>(owned.data(), owned.data() + owned.size()), read_callback_state.payload);
+
+  // File-fallback path: with no callback configured, ReadEpContextData reads the file into the owned buffer.
+  const std::filesystem::path test_dir = PrepareTempTestDir("ort_ep_context_data_utils_zero_copy_test");
+  auto cleanup = gsl::finally([&]() { std::filesystem::remove_all(test_dir); });
+
+  const std::string payload = "zero copy file payload";
+  const std::filesystem::path data_path = test_dir / "zero_copy_file.bin";
+  std::string data_file_name;
+  ASSERT_ORTSTATUS_OK(ep_context_data_utils::PathToUtf8String(api, data_path, data_file_name));
+  ASSERT_ORTSTATUS_OK(ep_context_data_utils::WriteEpContextDataToFile(api, data_file_name.c_str(), nullptr,
+                                                                      payload.data(), payload.size()));
+
+  ep_context_data_utils::EpContextData file_owned;
+  ASSERT_ORTSTATUS_OK(ep_context_data_utils::ReadEpContextData(
+      api, /*ep_context_config=*/nullptr, data_file_name.c_str(), nullptr, file_owned));
+  EXPECT_EQ(std::string(file_owned.data(), file_owned.data() + file_owned.size()), payload);
 }
 
 }  // namespace test

--- a/onnxruntime/test/autoep/ep_context_data_utils_test.cc
+++ b/onnxruntime/test/autoep/ep_context_data_utils_test.cc
@@ -188,21 +188,50 @@ TEST(OrtEpLibrary, EpContextDataUtils_ResolvePathRejectsUnsafeNames) {
   ExpectOrtStatusError(ep_context_data_utils::ResolveEpContextDataPath(api, "../escape.ctx",
                                                                        empty_model_path_graph.ToExternal(), data_path),
                        ORT_INVALID_ARGUMENT, "requires a model path");
+}
 
-  // A model-derived name that designates a directory (".", "..", or a trailing separator with an empty filename) is
-  // rejected up front, rather than resolving to a directory and failing later with a confusing I/O error.
-  ExpectOrtStatusError(ep_context_data_utils::ResolveEpContextDataPath(api, ".", empty_model_path_graph.ToExternal(),
-                                                                       data_path),
-                       ORT_INVALID_ARGUMENT, "must refer to a file");
-  // A leaf ".." (e.g. "sub/..") resolves to the parent/model directory; it is rejected here rather than passing the
-  // model-directory containment check and surfacing later as a directory I/O failure.
-  ExpectOrtStatusError(ep_context_data_utils::ResolveEpContextDataPath(api, "sub/..",
-                                                                       empty_model_path_graph.ToExternal(), data_path),
-                       ORT_INVALID_ARGUMENT, "must refer to a file");
-  // A trailing separator leaves an empty leaf ("sub/"), which likewise cannot designate a file.
-  ExpectOrtStatusError(ep_context_data_utils::ResolveEpContextDataPath(api, "sub/",
-                                                                       empty_model_path_graph.ToExternal(), data_path),
-                       ORT_INVALID_ARGUMENT, "must refer to a file");
+TEST(OrtEpLibrary, EpContextDataUtils_RejectsNonRegularFileTargets) {
+  const auto& api = Ort::GetApi();
+  const std::filesystem::path test_dir = PrepareTempTestDir("ort_ep_context_data_utils_regular_file_test");
+  auto cleanup = gsl::finally([&]() { std::filesystem::remove_all(test_dir); });
+
+  const std::filesystem::path model_dir = test_dir / "model_dir";
+  ASSERT_TRUE(std::filesystem::create_directories(model_dir / "subdir"));
+
+  ModelEditorGraph graph;
+  graph.model_path = model_dir / "model.onnx";
+
+  // A model-derived name may resolve to a directory and still pass containment ("subdir/.." resolves to the model
+  // directory itself), so the file-type check - not the resolver - is what rejects it.
+  std::vector<char> data;
+  ExpectOrtStatusError(ep_context_data_utils::ReadEpContextDataFromFile(api, "subdir", graph.ToExternal(), data),
+                       ORT_INVALID_ARGUMENT, "must be a regular file");
+  ExpectOrtStatusError(ep_context_data_utils::ReadEpContextDataFromFile(api, "subdir/..", graph.ToExternal(), data),
+                       ORT_INVALID_ARGUMENT, "must be a regular file");
+
+  // The zero-copy entry point applies the same gate on its file-fallback path.
+  std::string directory_name;
+  ASSERT_ORTSTATUS_OK(ep_context_data_utils::PathToUtf8String(api, model_dir / "subdir", directory_name));
+  ep_context_data_utils::EpContextData directory_read_result;
+  ExpectOrtStatusError(ep_context_data_utils::ReadEpContextData(api, /*ep_context_config=*/nullptr,
+                                                                directory_name.c_str(), nullptr,
+                                                                directory_read_result),
+                       ORT_INVALID_ARGUMENT, "must be a regular file");
+  EXPECT_TRUE(directory_read_result.empty());
+
+  // Writing over an existing directory is rejected up front instead of surfacing as a confusing stream failure.
+  const std::string payload = "regular file payload";
+  ExpectOrtStatusError(ep_context_data_utils::WriteEpContextDataToFile(api, directory_name.c_str(), nullptr,
+                                                                       payload.data(), payload.size()),
+                       ORT_INVALID_ARGUMENT, "must be a regular file");
+
+  // A not-yet-existing target is the normal write case and is still allowed.
+  std::string new_file_name;
+  ASSERT_ORTSTATUS_OK(ep_context_data_utils::PathToUtf8String(api, model_dir / "new_context_data.bin", new_file_name));
+  ASSERT_ORTSTATUS_OK(ep_context_data_utils::WriteEpContextDataToFile(api, new_file_name.c_str(), nullptr,
+                                                                      payload.data(), payload.size()));
+  ASSERT_ORTSTATUS_OK(ep_context_data_utils::ReadEpContextDataFromFile(api, new_file_name.c_str(), nullptr, data));
+  EXPECT_EQ(std::string(data.begin(), data.end()), payload);
 }
 
 TEST(OrtEpLibrary, EpContextDataUtils_ResolvePathRejectsSymlinkEscape) {

--- a/onnxruntime/test/autoep/ep_context_data_utils_test.cc
+++ b/onnxruntime/test/autoep/ep_context_data_utils_test.cc
@@ -9,6 +9,11 @@
 #include <string_view>
 #include <vector>
 
+#if !defined(_WIN32)
+#include <sys/stat.h>
+#include <sys/types.h>
+#endif
+
 #include <gsl/gsl>
 #include <gtest/gtest.h>
 
@@ -232,6 +237,61 @@ TEST(OrtEpLibrary, EpContextDataUtils_RejectsNonRegularFileTargets) {
                                                                       payload.data(), payload.size()));
   ASSERT_ORTSTATUS_OK(ep_context_data_utils::ReadEpContextDataFromFile(api, new_file_name.c_str(), nullptr, data));
   EXPECT_EQ(std::string(data.begin(), data.end()), payload);
+
+#if !defined(_WIN32)
+  // The FIFO case is what motivated the file-type gate: it passes containment and an ifstream open on it blocks
+  // indefinitely, so without the gate this read would hang instead of failing.
+  const std::filesystem::path fifo_path = model_dir / "fifo_context.bin";
+  if (mkfifo(fifo_path.c_str(), 0600) == 0) {
+    ExpectOrtStatusError(ep_context_data_utils::ReadEpContextDataFromFile(api, "fifo_context.bin",
+                                                                          graph.ToExternal(), data),
+                         ORT_INVALID_ARGUMENT, "must be a regular file");
+  }
+#endif
+}
+
+TEST(OrtEpLibrary, EpContextDataUtils_RejectsSymlinkWriteTargets) {
+  const auto& api = Ort::GetApi();
+  const std::filesystem::path test_dir = PrepareTempTestDir("ort_ep_context_data_utils_symlink_write_test");
+  auto cleanup = gsl::finally([&]() { std::filesystem::remove_all(test_dir); });
+
+  const std::filesystem::path model_dir = test_dir / "model_dir";
+  const std::filesystem::path outside_dir = test_dir / "outside_dir";
+  ASSERT_TRUE(std::filesystem::create_directories(model_dir));
+  ASSERT_TRUE(std::filesystem::create_directories(outside_dir));
+
+  ModelEditorGraph graph;
+  graph.model_path = model_dir / "model.onnx";
+
+  // A *dangling* symlink is the dangerous case. weakly_canonical() cannot resolve a target that does not exist yet,
+  // so the link stays lexically inside the model directory and passes containment - but an ofstream would follow it
+  // and create the payload outside. Only a check on the link itself (symlink_status) rejects this.
+  const std::filesystem::path dangling_link = model_dir / "dangling.ctx";
+  const std::filesystem::path escape_target = std::filesystem::path{".."} / outside_dir.filename() / "escaped.ctx";
+  std::error_code symlink_error;
+  std::filesystem::create_symlink(escape_target, dangling_link, symlink_error);
+  if (symlink_error) {
+    GTEST_SKIP() << "Unable to create symlink for write-target test: " << symlink_error.message();
+  }
+
+  const std::string payload = "symlink payload";
+  ExpectOrtStatusError(ep_context_data_utils::WriteEpContextDataToFile(api, "dangling.ctx", graph.ToExternal(),
+                                                                       payload.data(), payload.size()),
+                       ORT_INVALID_ARGUMENT, "must not be a symlink");
+  // The escape is what actually matters: nothing may have been created outside the model directory.
+  EXPECT_FALSE(std::filesystem::exists(outside_dir / "escaped.ctx"));
+
+  // A symlink pointing at an existing regular file inside the model directory is rejected by the same gate, so a
+  // write can never land somewhere other than the path the caller named.
+  ASSERT_ORTSTATUS_OK(ep_context_data_utils::WriteEpContextDataToFile(api, "real.ctx", graph.ToExternal(),
+                                                                      payload.data(), payload.size()));
+  const std::filesystem::path inside_link = model_dir / "inside.ctx";
+  std::filesystem::create_symlink(std::filesystem::path{"real.ctx"}, inside_link, symlink_error);
+  if (!symlink_error) {
+    ExpectOrtStatusError(ep_context_data_utils::WriteEpContextDataToFile(api, "inside.ctx", graph.ToExternal(),
+                                                                         payload.data(), payload.size()),
+                         ORT_INVALID_ARGUMENT, "must not be a symlink");
+  }
 }
 
 TEST(OrtEpLibrary, EpContextDataUtils_ResolvePathRejectsSymlinkEscape) {
@@ -408,6 +468,10 @@ TEST(OrtEpLibrary, EpContextDataUtils_ReadEpContextDataAdoptsCallbackBufferZeroC
   EXPECT_EQ(read_callback_state.read_file_name, "zero_copy_context.bin");
   ASSERT_EQ(owned.size(), read_callback_state.payload.size());
   EXPECT_EQ(std::vector<char>(owned.data(), owned.data() + owned.size()), read_callback_state.payload);
+  // The point of this entry point is adoption, not equality: assert the exact buffer the callback allocated is the
+  // one being handed back. Comparing contents alone would still pass if the reader silently copied.
+  ASSERT_NE(read_callback_state.last_read_buffer, nullptr);
+  EXPECT_EQ(static_cast<const void*>(owned.data()), read_callback_state.last_read_buffer);
 
   // File-fallback path: with no callback configured, ReadEpContextData reads the file into the owned buffer.
   const std::filesystem::path test_dir = PrepareTempTestDir("ort_ep_context_data_utils_zero_copy_test");

--- a/onnxruntime/test/autoep/ep_context_data_utils_test.cc
+++ b/onnxruntime/test/autoep/ep_context_data_utils_test.cc
@@ -165,25 +165,26 @@ TEST(OrtEpLibrary, EpContextDataUtils_ResolvePathRejectsUnsafeNames) {
   ASSERT_ORTSTATUS_OK(ep_context_data_utils::ResolveEpContextDataPath(api, absolute_file_name, nullptr, data_path));
   EXPECT_TRUE(data_path.is_absolute());
 
-#ifdef _WIN32
-  ExpectOrtStatusError(ep_context_data_utils::WriteEpContextDataWithFileFallback(
-                           api, nullptr, drive_relative_file_name, "unused.ctx", nullptr, nullptr, 0),
-                       ORT_INVALID_ARGUMENT, "EPContext data file name must not be absolute or rooted");
-  ExpectOrtStatusError(ep_context_data_utils::WriteEpContextDataWithFileFallback(
-                           api, nullptr, root_relative_file_name, "unused.ctx", nullptr, nullptr, 0),
-                       ORT_INVALID_ARGUMENT, "EPContext data file name must not be absolute or rooted");
-#endif
-
   std::vector<char> data;
   // Trusted (graph == nullptr) reads also allow ".."; the resolver no longer rejects it, so a non-existent target now
   // surfaces as a normal file-open failure rather than a traversal rejection.
   ExpectOrtStatusError(ep_context_data_utils::ReadEpContextDataFromFile(api, "../escape.ctx", nullptr, data),
                        ORT_FAIL, "Failed to open EPContext data file for read");
-  ExpectOrtStatusError(ep_context_data_utils::WriteEpContextDataWithFileFallback(
-                           api, nullptr, absolute_file_name, "unused.ctx", nullptr, nullptr, 0),
-                       ORT_INVALID_ARGUMENT, "EPContext data file name must not be absolute or rooted");
 
   ModelEditorGraph empty_model_path_graph;
+  // Untrusted (model-derived) names must be relative. The resolver is the only place absolute/rooted names are
+  // rejected; the logical write-side name is an opaque callback key and is no longer validated as a path.
+  ExpectOrtStatusError(ep_context_data_utils::ResolveEpContextDataPath(api, absolute_file_name,
+                                                                       empty_model_path_graph.ToExternal(), data_path),
+                       ORT_INVALID_ARGUMENT, "EPContext data file name must not be absolute or rooted");
+#ifdef _WIN32
+  ExpectOrtStatusError(ep_context_data_utils::ResolveEpContextDataPath(api, drive_relative_file_name,
+                                                                       empty_model_path_graph.ToExternal(), data_path),
+                       ORT_INVALID_ARGUMENT, "EPContext data file name must not be absolute or rooted");
+  ExpectOrtStatusError(ep_context_data_utils::ResolveEpContextDataPath(api, root_relative_file_name,
+                                                                       empty_model_path_graph.ToExternal(), data_path),
+                       ORT_INVALID_ARGUMENT, "EPContext data file name must not be absolute or rooted");
+#endif
   ExpectOrtStatusError(ep_context_data_utils::ResolveEpContextDataPath(api, "../escape.ctx",
                                                                        empty_model_path_graph.ToExternal(), data_path),
                        ORT_INVALID_ARGUMENT, "requires a model path");
@@ -198,11 +199,9 @@ TEST(OrtEpLibrary, EpContextDataUtils_ResolvePathRejectsUnsafeNames) {
   ExpectOrtStatusError(ep_context_data_utils::ResolveEpContextDataPath(api, "sub/..",
                                                                        empty_model_path_graph.ToExternal(), data_path),
                        ORT_INVALID_ARGUMENT, "must refer to a file");
-  ExpectOrtStatusError(ep_context_data_utils::WriteEpContextDataWithFileFallback(
-                           api, nullptr, ".", "unused.ctx", nullptr, nullptr, 0),
-                       ORT_INVALID_ARGUMENT, "must refer to a file");
-  ExpectOrtStatusError(ep_context_data_utils::WriteEpContextDataWithFileFallback(
-                           api, nullptr, "sub/", "unused.ctx", nullptr, nullptr, 0),
+  // A trailing separator leaves an empty leaf ("sub/"), which likewise cannot designate a file.
+  ExpectOrtStatusError(ep_context_data_utils::ResolveEpContextDataPath(api, "sub/",
+                                                                       empty_model_path_graph.ToExternal(), data_path),
                        ORT_INVALID_ARGUMENT, "must refer to a file");
 }
 
@@ -272,14 +271,17 @@ TEST(OrtEpLibrary, EpContextDataUtils_FileFallbackReadsAndWrites) {
       api, nullptr, "logical_context_data.bin", fallback_data_file_name.c_str(), nullptr, payload.data(),
       payload.size()));
 
-  const std::filesystem::path unsafe_logical_fallback_path = test_dir / "unsafe_logical_context_data.bin";
-  std::string unsafe_logical_fallback_file_name;
-  ASSERT_ORTSTATUS_OK(ep_context_data_utils::PathToUtf8String(api, unsafe_logical_fallback_path,
-                                                              unsafe_logical_fallback_file_name));
-  ExpectOrtStatusError(ep_context_data_utils::WriteEpContextDataWithFileFallback(
-                           api, nullptr, "../logical_context_data.bin",
-                           unsafe_logical_fallback_file_name.c_str(), nullptr, payload.data(), payload.size()),
-                       ORT_INVALID_ARGUMENT, "EPContext data file name must not contain path traversal");
+  // The logical name is an opaque callback-namespace key, so it is not validated as a filesystem path: even a ".."
+  // name writes normally to the separately resolved fallback target, and never to the traversal location.
+  const std::filesystem::path logical_passthrough_path = test_dir / "logical_passthrough_context_data.bin";
+  std::string logical_passthrough_file_name;
+  ASSERT_ORTSTATUS_OK(ep_context_data_utils::PathToUtf8String(api, logical_passthrough_path,
+                                                              logical_passthrough_file_name));
+  ASSERT_ORTSTATUS_OK(ep_context_data_utils::WriteEpContextDataWithFileFallback(
+      api, nullptr, "../logical_context_data.bin", logical_passthrough_file_name.c_str(), nullptr, payload.data(),
+      payload.size()));
+  EXPECT_TRUE(std::filesystem::exists(logical_passthrough_path));
+  EXPECT_FALSE(std::filesystem::exists(test_dir / ".." / "logical_context_data.bin"));
 
   data.clear();
   ASSERT_ORTSTATUS_OK(ep_context_data_utils::ReadEpContextDataFromFile(api, fallback_data_file_name.c_str(), nullptr,

--- a/onnxruntime/test/autoep/ep_context_data_utils_test.cc
+++ b/onnxruntime/test/autoep/ep_context_data_utils_test.cc
@@ -288,9 +288,10 @@ TEST(OrtEpLibrary, EpContextDataUtils_RejectsSymlinkWriteTargets) {
   ModelEditorGraph graph;
   graph.model_path = model_dir / "model.onnx";
 
-  // A *dangling* symlink is the dangerous case. weakly_canonical() cannot resolve a target that does not exist yet,
-  // so the link stays lexically inside the model directory and passes containment - but an ofstream would follow it
-  // and create the payload outside. Only a check on the link itself (symlink_status) rejects this.
+  // A *dangling* symlink is the dangerous case. weakly_canonical() only canonicalizes the longest existing prefix,
+  // and a dangling link reports as not_found, so the link path itself survives resolution: it stays lexically inside
+  // the model directory and passes containment, yet an ofstream would follow it and create the payload outside.
+  // symlink_status() inspects the link rather than following it, which is what rejects this.
   const std::filesystem::path dangling_link = model_dir / "dangling.ctx";
   const std::filesystem::path escape_target = std::filesystem::path{".."} / outside_dir.filename() / "escaped.ctx";
   std::error_code symlink_error;
@@ -306,14 +307,32 @@ TEST(OrtEpLibrary, EpContextDataUtils_RejectsSymlinkWriteTargets) {
   // The escape is what actually matters: nothing may have been created outside the model directory.
   EXPECT_FALSE(std::filesystem::exists(outside_dir / "escaped.ctx"));
 
-  // A symlink pointing at an existing regular file inside the model directory is rejected by the same gate, so a
-  // write can never land somewhere other than the path the caller named.
+  // A symlink that *does* resolve is handled by containment instead, because weakly_canonical() resolves it before
+  // the write gate sees the path. Pointing outside the model directory is therefore rejected as a containment
+  // failure, not as a symlink - the resolved target is what gets checked.
+  std::string outside_target_name;
+  ASSERT_ORTSTATUS_OK(ep_context_data_utils::PathToUtf8String(api, outside_dir / "target.ctx", outside_target_name));
+  ASSERT_ORTSTATUS_OK(ep_context_data_utils::WriteEpContextDataToFile(api, outside_target_name.c_str(), nullptr,
+                                                                      payload.data(), payload.size()));
+  const std::filesystem::path escaping_link = model_dir / "escaping.ctx";
+  std::filesystem::create_symlink(std::filesystem::path{".."} / outside_dir.filename() / "target.ctx", escaping_link,
+                                  symlink_error);
+  if (!symlink_error) {
+    ExpectOrtStatusError(ep_context_data_utils::WriteEpContextDataToFile(api, "escaping.ctx", graph.ToExternal(),
+                                                                         payload.data(), payload.size()),
+                         ORT_INVALID_ARGUMENT, "within the model directory");
+  }
+
+  // A trusted caller (graph == nullptr) skips resolution entirely, so the write gate is the only thing standing
+  // between the caller and the link - and here it does reject an ordinary, resolvable symlink.
   ASSERT_ORTSTATUS_OK(ep_context_data_utils::WriteEpContextDataToFile(api, "real.ctx", graph.ToExternal(),
                                                                       payload.data(), payload.size()));
   const std::filesystem::path inside_link = model_dir / "inside.ctx";
   std::filesystem::create_symlink(std::filesystem::path{"real.ctx"}, inside_link, symlink_error);
   if (!symlink_error) {
-    ExpectOrtStatusError(ep_context_data_utils::WriteEpContextDataToFile(api, "inside.ctx", graph.ToExternal(),
+    std::string inside_link_name;
+    ASSERT_ORTSTATUS_OK(ep_context_data_utils::PathToUtf8String(api, inside_link, inside_link_name));
+    ExpectOrtStatusError(ep_context_data_utils::WriteEpContextDataToFile(api, inside_link_name.c_str(), nullptr,
                                                                          payload.data(), payload.size()),
                          ORT_INVALID_ARGUMENT, "must not be a symlink");
   }

--- a/onnxruntime/test/autoep/ep_context_data_utils_test.cc
+++ b/onnxruntime/test/autoep/ep_context_data_utils_test.cc
@@ -250,6 +250,31 @@ TEST(OrtEpLibrary, EpContextDataUtils_RejectsNonRegularFileTargets) {
 #endif
 }
 
+TEST(OrtEpLibrary, EpContextDataUtils_ReadWithAllocatorRejectsNullArguments) {
+  const auto& api = Ort::GetApi();
+
+  // This helper takes raw out-pointers rather than references, so a null argument must come back as an OrtStatus*
+  // like every other bad-argument case in the header, not as a crash.
+  void* buffer = nullptr;
+  size_t buffer_size = 0;
+  OrtAllocator* default_allocator = nullptr;
+  ASSERT_ORTSTATUS_OK(api.GetAllocatorWithDefaultOptions(&default_allocator));
+
+  ExpectOrtStatusError(ep_context_data_utils::ReadEpContextDataFromFileWithAllocator(
+                           api, "some_context.bin", nullptr, default_allocator, nullptr, &buffer_size),
+                       ORT_INVALID_ARGUMENT, "non-null out_buffer and out_size");
+  ExpectOrtStatusError(ep_context_data_utils::ReadEpContextDataFromFileWithAllocator(
+                           api, "some_context.bin", nullptr, default_allocator, &buffer, nullptr),
+                       ORT_INVALID_ARGUMENT, "non-null out_buffer and out_size");
+  ExpectOrtStatusError(ep_context_data_utils::ReadEpContextDataFromFileWithAllocator(
+                           api, "some_context.bin", nullptr, nullptr, &buffer, &buffer_size),
+                       ORT_INVALID_ARGUMENT, "non-null allocator");
+
+  // The rejected calls must not have written through the output pointers.
+  EXPECT_EQ(buffer, nullptr);
+  EXPECT_EQ(buffer_size, 0u);
+}
+
 TEST(OrtEpLibrary, EpContextDataUtils_RejectsSymlinkWriteTargets) {
   const auto& api = Ort::GetApi();
   const std::filesystem::path test_dir = PrepareTempTestDir("ort_ep_context_data_utils_symlink_write_test");

--- a/onnxruntime/test/autoep/ep_context_data_utils_test.cc
+++ b/onnxruntime/test/autoep/ep_context_data_utils_test.cc
@@ -134,11 +134,11 @@ TEST(OrtEpLibrary, EpContextDataUtils_ResolvePathAndInvalidArguments) {
                                                                                  nullptr, 1),
                        ORT_INVALID_ARGUMENT, "EPContext data buffer must not be null for non-empty data");
 
-  std::vector<char> data;
-  data.assign({'s', 't', 'a', 'l', 'e'});
-  ExpectOrtStatusError(ep_context_data_utils::ReadEpContextDataWithFileFallback(api, nullptr, "", nullptr, data),
-                       ORT_INVALID_ARGUMENT, "EPContext data file name must not be empty");
-  EXPECT_TRUE(data.empty());  // cleared up front, even though file_name validation fails
+  ep_context_data_utils::EpContextData read_result;
+  ExpectOrtStatusError(
+      ep_context_data_utils::ReadEpContextData(api, /*ep_context_config=*/nullptr, "", nullptr, read_result),
+      ORT_INVALID_ARGUMENT, "EPContext data file name must not be empty");
+  EXPECT_TRUE(read_result.empty());  // reset up front, even though file_name validation fails
   ExpectOrtStatusError(ep_context_data_utils::WriteEpContextDataWithFileFallback(api, nullptr, "", nullptr, nullptr, 0),
                        ORT_INVALID_ARGUMENT, "EPContext data file name must not be empty");
   ExpectOrtStatusError(ep_context_data_utils::WriteEpContextDataWithFileFallback(
@@ -260,10 +260,10 @@ TEST(OrtEpLibrary, EpContextDataUtils_FileFallbackReadsAndWrites) {
   ASSERT_ORTSTATUS_OK(ep_context_data_utils::WriteEpContextDataWithFileFallback(
       api, nullptr, wrapper_data_file_name.c_str(), nullptr, payload.data(), payload.size()));
 
-  data.clear();
-  ASSERT_ORTSTATUS_OK(ep_context_data_utils::ReadEpContextDataWithFileFallback(
-      api, nullptr, wrapper_data_file_name.c_str(), nullptr, data));
-  EXPECT_EQ(std::string(data.begin(), data.end()), payload);
+  ep_context_data_utils::EpContextData wrapper_read_result;
+  ASSERT_ORTSTATUS_OK(ep_context_data_utils::ReadEpContextData(
+      api, /*ep_context_config=*/nullptr, wrapper_data_file_name.c_str(), nullptr, wrapper_read_result));
+  EXPECT_EQ(std::string(wrapper_read_result.data(), wrapper_read_result.data() + wrapper_read_result.size()), payload);
 
   const std::filesystem::path fallback_data_path = test_dir / "fallback_context_data.bin";
   std::string fallback_data_file_name;
@@ -292,10 +292,10 @@ TEST(OrtEpLibrary, EpContextDataUtils_FileFallbackReadsAndWrites) {
   ASSERT_ORTSTATUS_OK(ep_context_data_utils::WriteEpContextDataWithFileFallback(
       api, nullptr, empty_data_file_name.c_str(), nullptr, nullptr, 0));
 
-  data.assign({'s', 't', 'a', 'l', 'e'});
-  ASSERT_ORTSTATUS_OK(ep_context_data_utils::ReadEpContextDataWithFileFallback(
-      api, nullptr, empty_data_file_name.c_str(), nullptr, data));
-  EXPECT_TRUE(data.empty());
+  ep_context_data_utils::EpContextData empty_read_result;
+  ASSERT_ORTSTATUS_OK(ep_context_data_utils::ReadEpContextData(
+      api, /*ep_context_config=*/nullptr, empty_data_file_name.c_str(), nullptr, empty_read_result));
+  EXPECT_TRUE(empty_read_result.empty());
 
   const std::filesystem::path missing_data_path = test_dir / "missing_context_data.bin";
   std::string missing_data_file_name;
@@ -312,20 +312,20 @@ TEST(OrtEpLibrary, EpContextDataUtils_CallbackFallbackUsesCallbacks) {
   read_callback_state.payload = {'c', 'a', 'l', 'l', 'b', 'a', 'c', 'k'};
   EpContextDataCallbackState write_callback_state;
 
-  std::vector<char> data;
-  ASSERT_ORTSTATUS_OK(ep_context_data_utils::ReadEpContextDataWithFileFallback(
-      api, LoadEpContextDataCallback, &read_callback_state, "callback_context.bin", nullptr, data));
+  ep_context_data_utils::EpContextData read_result;
+  ASSERT_ORTSTATUS_OK(ep_context_data_utils::ReadEpContextData(
+      api, LoadEpContextDataCallback, &read_callback_state, "callback_context.bin", nullptr, read_result));
   ASSERT_TRUE(read_callback_state.read_called);
   EXPECT_EQ(read_callback_state.read_file_name, "callback_context.bin");
-  EXPECT_EQ(data, read_callback_state.payload);
+  EXPECT_EQ(std::vector<char>(read_result.data(), read_result.data() + read_result.size()),
+            read_callback_state.payload);
 
   read_callback_state = {};
-  data.assign({'s', 't', 'a', 'l', 'e'});
-  ASSERT_ORTSTATUS_OK(ep_context_data_utils::ReadEpContextDataWithFileFallback(
-      api, LoadEpContextDataCallback, &read_callback_state, "empty_callback_context.bin", nullptr, data));
+  ASSERT_ORTSTATUS_OK(ep_context_data_utils::ReadEpContextData(
+      api, LoadEpContextDataCallback, &read_callback_state, "empty_callback_context.bin", nullptr, read_result));
   ASSERT_TRUE(read_callback_state.read_called);
   EXPECT_EQ(read_callback_state.read_file_name, "empty_callback_context.bin");
-  EXPECT_TRUE(data.empty());
+  EXPECT_TRUE(read_result.empty());
 
   const std::string payload = "callback write payload";
   ASSERT_ORTSTATUS_OK(ep_context_data_utils::WriteEpContextDataWithFileFallback(
@@ -353,15 +353,14 @@ TEST(OrtEpLibrary, EpContextDataUtils_ReadCallbackRejectsNullBufferForNonEmptyPa
 
   EpContextDataCallbackState read_callback_state;
 
-  std::vector<char> data;
-  data.assign({'s', 't', 'a', 'l', 'e'});
-  ExpectOrtStatusError(ep_context_data_utils::ReadEpContextDataWithFileFallback(
+  ep_context_data_utils::EpContextData read_result;
+  ExpectOrtStatusError(ep_context_data_utils::ReadEpContextData(
                            api, LoadInvalidEpContextDataCallback, &read_callback_state,
-                           "invalid_callback_context.bin", nullptr, data),
+                           "invalid_callback_context.bin", nullptr, read_result),
                        ORT_FAIL, "OrtReadNamedBufferFunc returned a null buffer for non-empty EPContext data");
   ASSERT_TRUE(read_callback_state.read_called);
   EXPECT_EQ(read_callback_state.read_file_name, "invalid_callback_context.bin");
-  EXPECT_TRUE(data.empty());
+  EXPECT_TRUE(read_result.empty());
 }
 
 TEST(OrtEpLibrary, EpContextDataUtils_ReadEpContextDataAdoptsCallbackBufferZeroCopy) {

--- a/onnxruntime/test/autoep/library/ep_context_data_utils.h
+++ b/onnxruntime/test/autoep/library/ep_context_data_utils.h
@@ -145,11 +145,13 @@ inline std::string PathToUtf8StringForMessage(const std::filesystem::path& path)
   return status.IsOK() ? utf8_path : std::string{"<path conversion failed>"};
 }
 
-// Lexical check for a ".." component. This is a coarse guard used when there is no filesystem base directory to
-// contain against: logical callback-namespace names and trusted (graph == nullptr) physical paths. It is NOT a
-// containment mechanism: it does not resolve symlinks and it rejects benign cases such as "a/b/c/../file.txt".
-// Filesystem containment against a model directory is done by IsResolvedPathWithinBase() below, which the untrusted
-// (model-relative) resolution path uses.
+// Lexical check for a ".." component. Used only by ValidateEpContextDataName() to reject ".." in the logical
+// callback-namespace name that is written into the EPContext model's ep_cache_context attribute. That logical name is
+// never resolved against a filesystem base, so the model-directory containment check (IsResolvedPathWithinBase()
+// below) cannot apply to it; rejecting ".." up front keeps a generated model from embedding an unsafe relative
+// reference. It is NOT a containment mechanism: it does not resolve symlinks and it rejects benign cases such as
+// "a/b/c/../file.txt". Filesystem containment against a model directory is done by IsResolvedPathWithinBase(), which
+// the untrusted (model-relative) resolution path uses.
 inline bool ContainsPathTraversal(const std::filesystem::path& path) {
   const std::filesystem::path parent_dir{".."};
   for (const auto& component : path) {
@@ -232,8 +234,9 @@ inline OrtStatus* ValidateEpContextDataName(const OrtApi& api, const char* file_
 // Resolves `file_name` to a filesystem path for reading or writing EPContext data (used by both the read path and
 // the write-fallback path).
 //
-// When `graph` is null the caller is trusted and owns the path: `file_name` is returned as-is and may be absolute (a
-// lexical ".." is still rejected as a coarse guard). When `graph` is non-null, `file_name` originates from the
+// When `graph` is null the caller is trusted and owns the path: `file_name` is returned as-is and may be absolute and
+// may contain ".." (there is no model directory to contain against, and absolute paths are already permitted, so no
+// traversal check is applied). When `graph` is non-null, `file_name` originates from the
 // untrusted EPContext model "ep_cache_context" attribute: the graph must have a model path, the name must be
 // relative, and after combining it with the model's directory the result must stay within that directory. Symlinks and
 // ".." are resolved (via weakly_canonical), so a name that escapes the model directory - including through a symlink -
@@ -255,11 +258,11 @@ inline OrtStatus* ResolveEpContextDataPath(const OrtApi& api, const char* file_n
     return api.CreateStatus(ORT_INVALID_ARGUMENT, "EPContext data file name is not a valid path");
   }
 
-  // Trusted direct callers (graph == nullptr) own the path and may pass an absolute physical path.
+  // Trusted direct callers (graph == nullptr) own the path and may pass an absolute physical path, including one with
+  // ".." components. There is no model directory to contain against here, and absolute paths are already allowed, so
+  // no traversal check is applied; the untrusted (model-relative) branch below is the one constrained to the model
+  // directory.
   if (graph == nullptr) {
-    if (ContainsPathTraversal(candidate_path)) {
-      return api.CreateStatus(ORT_INVALID_ARGUMENT, "EPContext data file name must not contain path traversal");
-    }
     data_path = candidate_path;
     return nullptr;
   }

--- a/onnxruntime/test/autoep/library/ep_context_data_utils.h
+++ b/onnxruntime/test/autoep/library/ep_context_data_utils.h
@@ -32,11 +32,13 @@
 // the ORT C and EP ABI and are provided as a reference for EP authors that need to handle external (non-embedded)
 // EPContext binary data.
 //
-// The intended entry points for EP implementers are the ReadEpContextDataWithFileFallback /
-// WriteEpContextDataWithFileFallback overloads: they prefer an application-supplied OrtReadNamedBufferFunc /
-// OrtWriteNamedBufferFunc (carried by OrtEpContextConfig) and fall back to file I/O when no callback is configured.
-// The other functions are lower-level building blocks. Production EPs should additionally apply their own sandboxing,
-// size limits, and path policies; see the per-function notes on how untrusted, model-derived names are treated.
+// The intended entry points for EP implementers are the ReadEpContextData / WriteEpContextDataWithFileFallback
+// overloads: they prefer an application-supplied OrtReadNamedBufferFunc / OrtWriteNamedBufferFunc (carried by
+// OrtEpContextConfig) and fall back to file I/O when no callback is configured. ReadEpContextData returns an owning
+// EpContextData buffer and avoids copying large data; ReadEpContextDataWithFileFallback is a std::vector<char>
+// convenience wrapper around it. The other functions are lower-level building blocks. Production EPs should
+// additionally apply their own sandboxing, size limits, and path policies; see the per-function notes on how
+// untrusted, model-derived names are treated.
 namespace ep_context_data_utils {
 
 #ifdef _WIN32
@@ -163,12 +165,13 @@ inline bool HasAbsoluteOrRootedPath(const std::filesystem::path& path) {
 }
 
 // Returns true if the final component of `path` is empty (e.g., a trailing separator like "sub/") or is the
-// current-directory entry ".", i.e. the name designates a directory rather than a file (".." is handled separately by
-// ContainsPathTraversal()). Such a name resolves to a directory and would only surface later as a confusing file I/O
-// failure, so model-derived names like these are rejected up front.
+// current-directory entry "." or the parent-directory entry "..", i.e. the name designates a directory rather than a
+// file. Such a name resolves to a directory (e.g. "sub/.." resolves to the parent/model directory) and would only
+// surface later as a confusing file I/O failure, so model-derived names like these are rejected up front. A non-leaf
+// ".." anywhere in the path is rejected separately by ContainsPathTraversal() / the model-directory containment check.
 inline bool IsDirectoryOrEmptyName(const std::filesystem::path& path) {
   const std::filesystem::path leaf = path.filename();
-  return leaf.empty() || leaf == std::filesystem::path{"."};
+  return leaf.empty() || leaf == std::filesystem::path{"."} || leaf == std::filesystem::path{".."};
 }
 
 // Returns true if `candidate_full` (a base-relative name already combined with `base`) resolves to a location inside
@@ -348,9 +351,150 @@ inline OrtStatus* WriteEpContextDataToFile(const OrtApi& api, const char* file_n
   return WriteEpContextDataToResolvedFile(api, data_path, buffer, buffer_size);
 }
 
-// Low-level overload that takes the read callback and its opaque state directly. Production EPs should use the
-// overload below that takes an OrtEpContextConfig; this overload exists so unit tests can inject a callback without
-// constructing an OrtEpContextConfig. When `read_func` is null the data is read from a file.
+// Forward declaration so EpContextData can grant the populating read helper access to its internals.
+class EpContextData;
+inline OrtStatus* ReadEpContextData(const OrtApi& api, OrtReadNamedBufferFunc read_func, void* read_state,
+                                    const char* file_name, const OrtGraph* graph, EpContextData& out);
+
+// RAII owner for the bytes returned by an EPContext read, used to avoid copying potentially large data. The
+// app-supplied read-callback path adopts the allocator-provided buffer directly (no copy) and frees it via the same
+// allocator on destruction; the file-fallback path owns the bytes in a std::vector read straight from disk. Either
+// way the bytes are accessed through data()/size() without an extra copy. EPs that handle large EPContext blobs
+// should prefer ReadEpContextData() + EpContextData; the std::vector<char> ReadEpContextDataWithFileFallback()
+// overloads remain as a convenience for callers (e.g. tests) that want an owned vector and can afford one copy.
+class EpContextData {
+ public:
+  EpContextData() = default;
+  ~EpContextData() { FreeAllocatorBuffer(); }
+
+  EpContextData(EpContextData&& other) noexcept { MoveFrom(other); }
+  EpContextData& operator=(EpContextData&& other) noexcept {
+    if (this != &other) {
+      FreeAllocatorBuffer();
+      MoveFrom(other);
+    }
+    return *this;
+  }
+
+  EpContextData(const EpContextData&) = delete;
+  EpContextData& operator=(const EpContextData&) = delete;
+
+  // Pointer to the bytes, owned by this object (valid until it is destroyed or reassigned). May be null only when
+  // size() == 0.
+  const char* data() const noexcept {
+    return buffer_ != nullptr ? static_cast<const char*>(buffer_) : file_bytes_.data();
+  }
+  size_t size() const noexcept { return buffer_ != nullptr ? buffer_size_ : file_bytes_.size(); }
+  bool empty() const noexcept { return size() == 0; }
+
+ private:
+  friend OrtStatus* ReadEpContextData(const OrtApi& api, OrtReadNamedBufferFunc read_func, void* read_state,
+                                      const char* file_name, const OrtGraph* graph, EpContextData& out);
+
+  void FreeAllocatorBuffer() noexcept {
+    if (buffer_ != nullptr && allocator_ != nullptr && api_ != nullptr) {
+      // Best-effort free; release any returned status without throwing (matches the OrtStatus*-based, exception-free
+      // style of these helpers). The default allocator is owned by ORT and must not be released here.
+      Ort::Status free_status{api_->AllocatorFree(allocator_, buffer_)};
+      static_cast<void>(free_status);
+    }
+    api_ = nullptr;
+    allocator_ = nullptr;
+    buffer_ = nullptr;
+    buffer_size_ = 0;
+  }
+
+  void Reset() noexcept {
+    FreeAllocatorBuffer();
+    file_bytes_.clear();
+  }
+
+  void MoveFrom(EpContextData& other) noexcept {
+    api_ = other.api_;
+    allocator_ = other.allocator_;
+    buffer_ = other.buffer_;
+    buffer_size_ = other.buffer_size_;
+    file_bytes_ = std::move(other.file_bytes_);
+    other.api_ = nullptr;
+    other.allocator_ = nullptr;
+    other.buffer_ = nullptr;
+    other.buffer_size_ = 0;
+  }
+
+  const OrtApi* api_ = nullptr;        // Used to free buffer_ (callback path); null otherwise.
+  OrtAllocator* allocator_ = nullptr;  // Allocator that owns buffer_ (callback path); null for the file path.
+  void* buffer_ = nullptr;             // Adopted callback buffer; null when the bytes live in file_bytes_.
+  size_t buffer_size_ = 0;
+  std::vector<char> file_bytes_;  // Owns the bytes on the file-fallback path.
+};
+
+// Zero-copy read: reads EPContext binary data named `file_name` into `out` (reset first). If `read_func` is non-null
+// it is invoked and the buffer it allocates is adopted by `out` (no copy); otherwise the data is read from the file
+// fallback into `out`. See ReadEpContextDataFromFile() for how `graph` governs name resolution. This low-level
+// overload takes the callback directly so tests can inject one; production EPs use the OrtEpContextConfig overload.
+inline OrtStatus* ReadEpContextData(const OrtApi& api, OrtReadNamedBufferFunc read_func, void* read_state,
+                                    const char* file_name, const OrtGraph* graph, EpContextData& out) {
+  out.Reset();
+
+  if (file_name == nullptr || file_name[0] == '\0') {
+    return api.CreateStatus(ORT_INVALID_ARGUMENT, "EPContext data file name must not be empty");
+  }
+
+  if (read_func == nullptr) {
+    // No callback: read the file fallback straight into the owned vector (no extra copy).
+    return ReadEpContextDataFromFile(api, file_name, graph, out.file_bytes_);
+  }
+
+  // Use the C allocator API (not Ort::AllocatorWithDefaultOptions, whose constructor throws) so this OrtStatus*-based
+  // helper stays exception-free. The default allocator is owned by ORT and must not be released here.
+  OrtAllocator* allocator = nullptr;
+  RETURN_IF_ERROR(api.GetAllocatorWithDefaultOptions(&allocator));
+
+  void* ep_context_data = nullptr;
+  size_t ep_context_data_size = 0;
+  OrtStatus* status = read_func(read_state, file_name, allocator, &ep_context_data, &ep_context_data_size);
+  // Adopt whatever the callback allocated so `out` frees it via the allocator on destruction, even on the error paths
+  // below. Ownership transfers without copying the (potentially large) buffer.
+  out.api_ = &api;
+  out.allocator_ = allocator;
+  out.buffer_ = ep_context_data;
+  out.buffer_size_ = ep_context_data_size;
+
+  if (status != nullptr) {
+    return status;
+  }
+
+  if (ep_context_data_size != 0 && ep_context_data == nullptr) {
+    return api.CreateStatus(ORT_FAIL, "OrtReadNamedBufferFunc returned a null buffer for non-empty EPContext data");
+  }
+
+  return nullptr;
+}
+
+// Zero-copy read using the OrtReadNamedBufferFunc carried by `ep_context_config` (if any); otherwise reads the file
+// fallback. See ReadEpContextData() above and ReadEpContextDataFromFile() for `graph` handling.
+inline OrtStatus* ReadEpContextData(const OrtApi& api, const OrtEpContextConfig* ep_context_config,
+                                    const char* file_name, const OrtGraph* graph, EpContextData& out) {
+  OrtReadNamedBufferFunc read_func = nullptr;
+  void* read_state = nullptr;
+  if (ep_context_config != nullptr) {
+    auto get_read_func =
+        Ort::Experimental::Get_OrtEpApi_EpContextConfig_GetEpContextDataReadFunc_SinceV28_Fn(&api);
+    if (get_read_func == nullptr) {
+      return api.CreateStatus(ORT_NOT_IMPLEMENTED,
+                              "OrtEpApi_EpContextConfig_GetEpContextDataReadFunc is not available");
+    }
+    RETURN_IF_ERROR(get_read_func(ep_context_config, &read_func, &read_state));
+  }
+  return ReadEpContextData(api, read_func, read_state, file_name, graph, out);
+}
+
+// std::vector<char> convenience overload that takes the read callback and its opaque state directly. Production EPs
+// should use the OrtEpContextConfig overload below; this overload exists so unit tests can inject a callback without
+// constructing an OrtEpContextConfig. When `read_func` is null the data is read from a file straight into `data` (no
+// extra copy); the callback path reads zero-copy via ReadEpContextData() and then copies once into `data`. EPs
+// handling large data that want to avoid that copy should call ReadEpContextData() and consume the EpContextData
+// buffer directly.
 inline OrtStatus* ReadEpContextDataWithFileFallback(
     const OrtApi& api,
     OrtReadNamedBufferFunc read_func, void* read_state,
@@ -364,37 +508,9 @@ inline OrtStatus* ReadEpContextDataWithFileFallback(
     return ReadEpContextDataFromFile(api, file_name, graph, data);
   }
 
-  // Use the C allocator API (not Ort::AllocatorWithDefaultOptions, whose constructor throws) so this OrtStatus*-based
-  // helper stays exception-free. The default allocator is owned by ORT and must not be released here.
-  OrtAllocator* allocator = nullptr;
-  RETURN_IF_ERROR(api.GetAllocatorWithDefaultOptions(&allocator));
-  void* ep_context_data = nullptr;
-  size_t ep_context_data_size = 0;
-  OrtStatus* status = read_func(read_state, file_name, allocator, &ep_context_data, &ep_context_data_size);
-  auto buffer_deleter = [&api, allocator](void* buffer_to_free) {
-    if (buffer_to_free != nullptr) {
-      // Best-effort free during cleanup; release any returned status without throwing.
-      Ort::Status free_status{api.AllocatorFree(allocator, buffer_to_free)};
-      static_cast<void>(free_status);
-    }
-  };
-  std::unique_ptr<void, decltype(buffer_deleter)> ep_context_data_guard(ep_context_data, buffer_deleter);
-
-  if (status != nullptr) {
-    return status;
-  }
-
-  if (ep_context_data_size != 0 && ep_context_data == nullptr) {
-    return api.CreateStatus(
-        ORT_FAIL, "OrtReadNamedBufferFunc returned a null buffer for non-empty EPContext data");
-  }
-
-  data.clear();
-  if (ep_context_data != nullptr) {
-    const char* ep_context_data_begin = static_cast<const char*>(ep_context_data);
-    data.assign(ep_context_data_begin, ep_context_data_begin + ep_context_data_size);
-  }
-
+  EpContextData owned;
+  RETURN_IF_ERROR(ReadEpContextData(api, read_func, read_state, file_name, graph, owned));
+  data.assign(owned.data(), owned.data() + owned.size());
   return nullptr;
 }
 

--- a/onnxruntime/test/autoep/library/ep_context_data_utils.h
+++ b/onnxruntime/test/autoep/library/ep_context_data_utils.h
@@ -358,7 +358,8 @@ inline OrtStatus* WriteEpContextDataToFile(const OrtApi& api, const char* file_n
 // Forward declaration so EpContextData can grant the populating read helper access to its internals.
 class EpContextData;
 inline OrtStatus* ReadEpContextData(const OrtApi& api, OrtReadNamedBufferFunc read_func, void* read_state,
-                                    const char* file_name, const OrtGraph* graph, EpContextData& out);
+                                    const char* file_name, const OrtGraph* graph, EpContextData& out,
+                                    OrtAllocator* allocator = nullptr);
 
 // RAII owner for the bytes returned by an EPContext read, used to avoid copying potentially large data. The
 // app-supplied read-callback path adopts the allocator-provided buffer directly (no copy) and frees it via the same
@@ -393,7 +394,8 @@ class EpContextData {
 
  private:
   friend OrtStatus* ReadEpContextData(const OrtApi& api, OrtReadNamedBufferFunc read_func, void* read_state,
-                                      const char* file_name, const OrtGraph* graph, EpContextData& out);
+                                      const char* file_name, const OrtGraph* graph, EpContextData& out,
+                                      OrtAllocator* allocator);
 
   void FreeAllocatorBuffer() noexcept {
     if (buffer_ != nullptr && allocator_ != nullptr && api_ != nullptr) {
@@ -434,10 +436,14 @@ class EpContextData {
 
 // Zero-copy read: reads EPContext binary data named `file_name` into `out` (reset first). If `read_func` is non-null
 // it is invoked and the buffer it allocates is adopted by `out` (no copy); otherwise the data is read from the file
-// fallback into `out`. See ReadEpContextDataFromFile() for how `graph` governs name resolution. This low-level
-// overload takes the callback directly so tests can inject one; production EPs use the OrtEpContextConfig overload.
+// fallback into `out`. `allocator` is the allocator handed to the callback for the output buffer; pass nullptr to use
+// ORT's default allocator. Whatever allocator allocates the buffer is stored in `out` and used for the matching free,
+// so a caller may supply its own (e.g. arena/pinned) allocator. See ReadEpContextDataFromFile() for how `graph`
+// governs name resolution. This low-level overload takes the callback directly so tests can inject one; production
+// EPs use the OrtEpContextConfig overload.
 inline OrtStatus* ReadEpContextData(const OrtApi& api, OrtReadNamedBufferFunc read_func, void* read_state,
-                                    const char* file_name, const OrtGraph* graph, EpContextData& out) {
+                                    const char* file_name, const OrtGraph* graph, EpContextData& out,
+                                    OrtAllocator* allocator) {
   out.Reset();
 
   if (file_name == nullptr || file_name[0] == '\0') {
@@ -445,26 +451,31 @@ inline OrtStatus* ReadEpContextData(const OrtApi& api, OrtReadNamedBufferFunc re
   }
 
   if (read_func == nullptr) {
-    // No callback: read the file fallback straight into the owned vector (no extra copy).
+    // No callback: read the file fallback straight into the owned vector (no extra copy). `allocator` is unused on
+    // this path (the bytes live in an owned std::vector).
     return ReadEpContextDataFromFile(api, file_name, graph, out.file_bytes_);
   }
 
+  // Use the caller-provided allocator if any; otherwise ORT's default allocator. Whatever allocates the callback
+  // buffer is also what frees it (stored in `out` for the matching free), so a caller may supply its own allocator.
   // Use the C allocator API (not Ort::AllocatorWithDefaultOptions, whose constructor throws) so this OrtStatus*-based
   // helper stays exception-free. The default allocator is owned by ORT and must not be released here.
-  OrtAllocator* allocator = nullptr;
-  RETURN_IF_ERROR(api.GetAllocatorWithDefaultOptions(&allocator));
+  OrtAllocator* effective_allocator = allocator;
+  if (effective_allocator == nullptr) {
+    RETURN_IF_ERROR(api.GetAllocatorWithDefaultOptions(&effective_allocator));
+  }
 
   void* ep_context_data = nullptr;
   size_t ep_context_data_size = 0;
-  OrtStatus* status = read_func(read_state, file_name, allocator, &ep_context_data, &ep_context_data_size);
+  OrtStatus* status = read_func(read_state, file_name, effective_allocator, &ep_context_data, &ep_context_data_size);
 
-  // Hold any callback-allocated buffer in a local RAII guard so it is freed via the allocator on every error path
-  // below, while `out` stays empty (it was reset above). Ownership is transferred to `out` only on success, matching
-  // the reset-first / bytes-on-success contract and the std::vector overload's empty-on-failure guarantee.
-  auto buffer_deleter = [&api, allocator](void* buffer_to_free) {
+  // Hold any callback-allocated buffer in a local RAII guard so it is freed via the same allocator on every error
+  // path below, while `out` stays empty (it was reset above). Ownership is transferred to `out` only on success,
+  // matching the reset-first / bytes-on-success contract and the std::vector overload's empty-on-failure guarantee.
+  auto buffer_deleter = [&api, effective_allocator](void* buffer_to_free) {
     if (buffer_to_free != nullptr) {
       // Best-effort free; release any returned status without throwing (exception-free OrtStatus* style).
-      Ort::Status free_status{api.AllocatorFree(allocator, buffer_to_free)};
+      Ort::Status free_status{api.AllocatorFree(effective_allocator, buffer_to_free)};
       static_cast<void>(free_status);
     }
   };
@@ -478,9 +489,9 @@ inline OrtStatus* ReadEpContextData(const OrtApi& api, OrtReadNamedBufferFunc re
     return api.CreateStatus(ORT_FAIL, "OrtReadNamedBufferFunc returned a null buffer for non-empty EPContext data");
   }
 
-  // Success: transfer ownership of the callback buffer to `out` (no copy).
+  // Success: transfer ownership of the callback buffer to `out` (no copy); `out` frees it via the same allocator.
   out.api_ = &api;
-  out.allocator_ = allocator;
+  out.allocator_ = effective_allocator;
   out.buffer_ = buffer_guard.release();
   out.buffer_size_ = ep_context_data_size;
 
@@ -488,9 +499,11 @@ inline OrtStatus* ReadEpContextData(const OrtApi& api, OrtReadNamedBufferFunc re
 }
 
 // Zero-copy read using the OrtReadNamedBufferFunc carried by `ep_context_config` (if any); otherwise reads the file
-// fallback. See ReadEpContextData() above and ReadEpContextDataFromFile() for `graph` handling.
+// fallback. `allocator` is forwarded to the callback for the output buffer (nullptr = ORT's default allocator) and is
+// used for the matching free. See ReadEpContextData() above and ReadEpContextDataFromFile() for `graph` handling.
 inline OrtStatus* ReadEpContextData(const OrtApi& api, const OrtEpContextConfig* ep_context_config,
-                                    const char* file_name, const OrtGraph* graph, EpContextData& out) {
+                                    const char* file_name, const OrtGraph* graph, EpContextData& out,
+                                    OrtAllocator* allocator = nullptr) {
   OrtReadNamedBufferFunc read_func = nullptr;
   void* read_state = nullptr;
   if (ep_context_config != nullptr) {
@@ -502,7 +515,7 @@ inline OrtStatus* ReadEpContextData(const OrtApi& api, const OrtEpContextConfig*
     }
     RETURN_IF_ERROR(get_read_func(ep_context_config, &read_func, &read_state));
   }
-  return ReadEpContextData(api, read_func, read_state, file_name, graph, out);
+  return ReadEpContextData(api, read_func, read_state, file_name, graph, out, allocator);
 }
 
 // std::vector<char> convenience overload that takes the read callback and its opaque state directly. Production EPs

--- a/onnxruntime/test/autoep/library/ep_context_data_utils.h
+++ b/onnxruntime/test/autoep/library/ep_context_data_utils.h
@@ -170,7 +170,8 @@ inline bool HasAbsoluteOrRootedPath(const std::filesystem::path& path) {
 // current-directory entry "." or the parent-directory entry "..", i.e. the name designates a directory rather than a
 // file. Such a name resolves to a directory (e.g. "sub/.." resolves to the parent/model directory) and would only
 // surface later as a confusing file I/O failure, so model-derived names like these are rejected up front. A non-leaf
-// ".." anywhere in the path is rejected separately by ContainsPathTraversal() / the model-directory containment check.
+// ".." in a logical callback-namespace name is rejected by ContainsPathTraversal(); in model-relative filesystem
+// names it is canonicalized and accepted only if the resolved path stays within the model directory.
 inline bool IsDirectoryOrEmptyName(const std::filesystem::path& path) {
   const std::filesystem::path leaf = path.filename();
   return leaf.empty() || leaf == std::filesystem::path{"."} || leaf == std::filesystem::path{".."};
@@ -511,16 +512,22 @@ inline OrtStatus* ReadEpContextDataWithFileFallback(
     return ReadEpContextDataFromFile(api, file_name, graph, data);
   }
 
+  // Clear up front so `data` is empty on any error path below and for an empty callback payload; assign only when the
+  // adopted buffer is non-empty (avoids pointer arithmetic on a possibly-null empty buffer).
+  data.clear();
   EpContextData owned;
   RETURN_IF_ERROR(ReadEpContextData(api, read_func, read_state, file_name, graph, owned));
-  data.assign(owned.data(), owned.data() + owned.size());
+  if (!owned.empty()) {
+    data.assign(owned.data(), owned.data() + owned.size());
+  }
   return nullptr;
 }
 
 // Reads EPContext binary data named `file_name`. If the session configured an OrtReadNamedBufferFunc (carried by
 // `ep_context_config`), it is used; otherwise the data is read from a file. When `graph` is non-null it is the
-// EPContext model graph: untrusted absolute/rooted/traversal names are rejected and relative names are resolved
-// against the model directory. Pass `graph == nullptr` only for trusted callers supplying a physical path. `data` is
+// EPContext model graph: untrusted absolute/rooted names are rejected and relative names are resolved against the
+// model directory, with canonicalization/containment handling any ".." components. Pass `graph == nullptr` only for
+// trusted callers supplying a physical path. `data` is
 // cleared first and receives the bytes on success.
 inline OrtStatus* ReadEpContextDataWithFileFallback(
     const OrtApi& api,

--- a/onnxruntime/test/autoep/library/ep_context_data_utils.h
+++ b/onnxruntime/test/autoep/library/ep_context_data_utils.h
@@ -516,6 +516,10 @@ inline OrtStatus* ReadEpContextDataWithFileFallback(
     OrtReadNamedBufferFunc read_func, void* read_state,
     const char* file_name, const OrtGraph* graph,
     std::vector<char>& data) {
+  // Clear first so `data` is empty on every error path (including an invalid file_name) and for an empty callback
+  // payload, matching the reset-first / empty-on-failure contract of the EpContextData overload.
+  data.clear();
+
   if (file_name == nullptr || file_name[0] == '\0') {
     return api.CreateStatus(ORT_INVALID_ARGUMENT, "EPContext data file name must not be empty");
   }
@@ -524,11 +528,9 @@ inline OrtStatus* ReadEpContextDataWithFileFallback(
     return ReadEpContextDataFromFile(api, file_name, graph, data);
   }
 
-  // Clear up front so `data` is empty on any error path below and for an empty callback payload; assign only when the
-  // adopted buffer is non-empty (avoids pointer arithmetic on a possibly-null empty buffer).
-  data.clear();
   EpContextData owned;
   RETURN_IF_ERROR(ReadEpContextData(api, read_func, read_state, file_name, graph, owned));
+  // Assign only when non-empty to avoid pointer arithmetic on a possibly-null empty buffer.
   if (!owned.empty()) {
     data.assign(owned.data(), owned.data() + owned.size());
   }

--- a/onnxruntime/test/autoep/library/ep_context_data_utils.h
+++ b/onnxruntime/test/autoep/library/ep_context_data_utils.h
@@ -374,7 +374,7 @@ class EpContextData {
   EpContextData(EpContextData&& other) noexcept { MoveFrom(other); }
   EpContextData& operator=(EpContextData&& other) noexcept {
     if (this != &other) {
-      FreeAllocatorBuffer();
+      Reset();
       MoveFrom(other);
     }
     return *this;
@@ -457,12 +457,18 @@ inline OrtStatus* ReadEpContextData(const OrtApi& api, OrtReadNamedBufferFunc re
   void* ep_context_data = nullptr;
   size_t ep_context_data_size = 0;
   OrtStatus* status = read_func(read_state, file_name, allocator, &ep_context_data, &ep_context_data_size);
-  // Adopt whatever the callback allocated so `out` frees it via the allocator on destruction, even on the error paths
-  // below. Ownership transfers without copying the (potentially large) buffer.
-  out.api_ = &api;
-  out.allocator_ = allocator;
-  out.buffer_ = ep_context_data;
-  out.buffer_size_ = ep_context_data_size;
+
+  // Hold any callback-allocated buffer in a local RAII guard so it is freed via the allocator on every error path
+  // below, while `out` stays empty (it was reset above). Ownership is transferred to `out` only on success, matching
+  // the reset-first / bytes-on-success contract and the std::vector overload's empty-on-failure guarantee.
+  auto buffer_deleter = [&api, allocator](void* buffer_to_free) {
+    if (buffer_to_free != nullptr) {
+      // Best-effort free; release any returned status without throwing (exception-free OrtStatus* style).
+      Ort::Status free_status{api.AllocatorFree(allocator, buffer_to_free)};
+      static_cast<void>(free_status);
+    }
+  };
+  std::unique_ptr<void, decltype(buffer_deleter)> buffer_guard(ep_context_data, buffer_deleter);
 
   if (status != nullptr) {
     return status;
@@ -471,6 +477,12 @@ inline OrtStatus* ReadEpContextData(const OrtApi& api, OrtReadNamedBufferFunc re
   if (ep_context_data_size != 0 && ep_context_data == nullptr) {
     return api.CreateStatus(ORT_FAIL, "OrtReadNamedBufferFunc returned a null buffer for non-empty EPContext data");
   }
+
+  // Success: transfer ownership of the callback buffer to `out` (no copy).
+  out.api_ = &api;
+  out.allocator_ = allocator;
+  out.buffer_ = buffer_guard.release();
+  out.buffer_size_ = ep_context_data_size;
 
   return nullptr;
 }

--- a/onnxruntime/test/autoep/library/ep_context_data_utils.h
+++ b/onnxruntime/test/autoep/library/ep_context_data_utils.h
@@ -351,9 +351,22 @@ inline OrtStatus* ReadEpContextDataFromFile(const OrtApi& api, const char* file_
 // honored on the file-fallback path just as it is on the callback path. On success `*out_buffer` owns `*out_size`
 // bytes and must be freed by the caller via the same `allocator`; on failure (and for an empty file) `*out_buffer` is
 // null and `*out_size` is 0. `graph` governs name resolution exactly as in ReadEpContextDataFromFile().
+//
+// `allocator`, `out_buffer` and `out_size` must all be non-null. Unlike the other helpers here, which take C++
+// references for their outputs, this one takes raw out-pointers, so it validates them and reports a bad argument as
+// an OrtStatus* rather than dereferencing null.
 inline OrtStatus* ReadEpContextDataFromFileWithAllocator(const OrtApi& api, const char* file_name,
                                                          const OrtGraph* graph, OrtAllocator* allocator,
                                                          void** out_buffer, size_t* out_size) {
+  if (out_buffer == nullptr || out_size == nullptr) {
+    return api.CreateStatus(ORT_INVALID_ARGUMENT,
+                            "EPContext data file read requires non-null out_buffer and out_size pointers");
+  }
+
+  if (allocator == nullptr) {
+    return api.CreateStatus(ORT_INVALID_ARGUMENT, "EPContext data file read requires a non-null allocator");
+  }
+
   *out_buffer = nullptr;
   *out_size = 0;
 

--- a/onnxruntime/test/autoep/library/ep_context_data_utils.h
+++ b/onnxruntime/test/autoep/library/ep_context_data_utils.h
@@ -152,23 +152,6 @@ inline std::string PathToUtf8StringForMessage(const std::filesystem::path& path)
   return status.IsOK() ? utf8_path : std::string{"<path conversion failed>"};
 }
 
-// Lexical check for a ".." component. Used only by ValidateEpContextDataName() to reject ".." in the logical
-// callback-namespace name that is written into the EPContext model's ep_cache_context attribute. That logical name is
-// never resolved against a filesystem base, so the model-directory containment check (IsResolvedPathWithinBase()
-// below) cannot apply to it; rejecting ".." up front keeps a generated model from embedding an unsafe relative
-// reference. It is NOT a containment mechanism: it does not resolve symlinks and it rejects benign cases such as
-// "a/b/c/../file.txt". Filesystem containment against a model directory is done by IsResolvedPathWithinBase(), which
-// the untrusted (model-relative) resolution path uses.
-inline bool ContainsPathTraversal(const std::filesystem::path& path) {
-  const std::filesystem::path parent_dir{".."};
-  for (const auto& component : path) {
-    if (component == parent_dir) {
-      return true;
-    }
-  }
-  return false;
-}
-
 inline bool HasAbsoluteOrRootedPath(const std::filesystem::path& path) {
   return path.is_absolute() || path.has_root_name() || path.has_root_directory();
 }
@@ -178,8 +161,8 @@ inline bool HasAbsoluteOrRootedPath(const std::filesystem::path& path) {
 // NOT stat the filesystem, so a real, existing directory with an ordinary leaf name (e.g. an existing "subdir") is not
 // detected here: it passes this check and is only rejected later when the file fails to open. The purpose is early,
 // clear error messaging for names that can never designate a file; the actual containment guarantee comes from the
-// read-side resolver (IsResolvedPathWithinBase()) plus the eventual file open(). A non-leaf ".." in a logical
-// callback-namespace name is rejected separately by ContainsPathTraversal().
+// read-side resolver (IsResolvedPathWithinBase()) plus the eventual file open(), which also handle non-leaf ".."
+// components via canonicalization rather than a lexical check.
 inline bool HasDirectoryLikeLeaf(const std::filesystem::path& path) {
   const std::filesystem::path leaf = path.filename();
   return leaf.empty() || leaf == std::filesystem::path{"."} || leaf == std::filesystem::path{".."};
@@ -208,36 +191,6 @@ inline bool IsResolvedPathWithinBase(const std::filesystem::path& base, const st
 
   resolved = std::move(candidate_resolved);
   return true;
-}
-
-inline OrtStatus* ValidateEpContextDataName(const OrtApi& api, const char* file_name,
-                                            std::filesystem::path& data_name) {
-  data_name.clear();
-
-  if (file_name == nullptr || file_name[0] == '\0') {
-    return api.CreateStatus(ORT_INVALID_ARGUMENT, "EPContext data file name must not be empty");
-  }
-
-  std::filesystem::path candidate_path;
-  RETURN_IF_ERROR(Utf8Path(api, file_name, candidate_path));
-  if (candidate_path.empty()) {
-    return api.CreateStatus(ORT_INVALID_ARGUMENT, "EPContext data file name is not a valid path");
-  }
-
-  if (HasAbsoluteOrRootedPath(candidate_path)) {
-    return api.CreateStatus(ORT_INVALID_ARGUMENT, "EPContext data file name must not be absolute or rooted");
-  }
-
-  if (ContainsPathTraversal(candidate_path)) {
-    return api.CreateStatus(ORT_INVALID_ARGUMENT, "EPContext data file name must not contain path traversal");
-  }
-
-  if (HasDirectoryLikeLeaf(candidate_path)) {
-    return api.CreateStatus(ORT_INVALID_ARGUMENT, "EPContext data file name must refer to a file, not a directory");
-  }
-
-  data_name = candidate_path;
-  return nullptr;
 }
 
 // Resolves `file_name` to a filesystem path for reading or writing EPContext data (used by both the read path and
@@ -641,17 +594,11 @@ inline OrtStatus* WriteEpContextDataWithFileFallback(
     return api.CreateStatus(ORT_INVALID_ARGUMENT, "EPContext data buffer must not be null for non-empty data");
   }
 
-  // The app-supplied write callback owns its own logical namespace, so file_name is passed through unmodified.
-  // Only the file-fallback path below maps a name onto the filesystem, so it validates the logical name there.
+  // `file_name` is a logical name in the write callback's own namespace, so it is passed through unmodified and is
+  // never validated as a filesystem path. Only `fallback_file_name` below is mapped onto the filesystem.
   if (write_func != nullptr) {
     return write_func(write_state, file_name, buffer, buffer_size);
   }
-
-  // Even when the physical fallback path is supplied separately, `file_name` is the logical name written into the
-  // EPContext model's ep_cache_context attribute. Validate it as a safe relative name so a generated model cannot
-  // contain an unsafe logical reference that later reaches the read-side resolver.
-  std::filesystem::path logical_path;
-  RETURN_IF_ERROR(ValidateEpContextDataName(api, file_name, logical_path));
 
   if (fallback_file_name == nullptr || fallback_file_name[0] == '\0') {
     return api.CreateStatus(ORT_INVALID_ARGUMENT, "EPContext data fallback file name must not be empty");
@@ -703,14 +650,14 @@ inline OrtStatus* WriteEpContextDataWithFileFallback(
 /**
  * \brief Convenience write overload that uses `file_name` as both the logical callback name and the file-fallback path.
  *
- * Because `file_name` doubles as the fallback path, when no callback is configured it must be a safe relative name:
- * this overload validates it and rejects absolute/rooted paths and `..` traversal. To write the file fallback to an
- * absolute physical path (a trusted caller with `graph == nullptr`), use the overload above that takes a separate
- * `fallback_file_name`.
+ * Because `file_name` doubles as the fallback path, when no callback is configured it is resolved by
+ * ResolveEpContextDataPath(): with `graph` non-null it must be relative and must stay within the model directory;
+ * with `graph == nullptr` a trusted caller may supply an absolute physical path. To use a different physical target
+ * than the logical name, use the overload above that takes a separate `fallback_file_name`.
  *
  * \param api The OrtApi.
  * \param ep_context_config EPContext config carrying the optional write callback; may be null (uses the file fallback).
- * \param file_name Logical name and, on the file-fallback path, the (relative) file name to write.
+ * \param file_name Logical name and, on the file-fallback path, the file name to write.
  * \param graph When non-null, resolves `file_name` against the model directory; null denotes a trusted caller.
  * \param buffer The bytes to write; may be null only when `buffer_size` is 0.
  * \param buffer_size Number of bytes to write.

--- a/onnxruntime/test/autoep/library/ep_context_data_utils.h
+++ b/onnxruntime/test/autoep/library/ep_context_data_utils.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <filesystem>
 #include <fstream>
 #include <iterator>
@@ -28,17 +29,23 @@
 #include "plugin_ep_utils.h"
 #include "onnxruntime_experimental_cxx_api.h"
 
-// Sample-only EPContext data helpers shared by the example plugin EP and its tests. These are intentionally outside
-// the ORT C and EP ABI and are provided as a reference for EP authors that need to handle external (non-embedded)
-// EPContext binary data.
-//
-// The intended entry points for EP implementers are the ReadEpContextData / WriteEpContextDataWithFileFallback
-// overloads: they prefer an application-supplied OrtReadNamedBufferFunc / OrtWriteNamedBufferFunc (carried by
-// OrtEpContextConfig) and fall back to file I/O when no callback is configured. ReadEpContextData returns an owning
-// EpContextData buffer and avoids copying large data; ReadEpContextDataWithFileFallback is a std::vector<char>
-// convenience wrapper around it. The other functions are lower-level building blocks. Production EPs should
-// additionally apply their own sandboxing, size limits, and path policies; see the per-function notes on how
-// untrusted, model-derived names are treated.
+/**
+ * \file
+ * \brief Sample-only EPContext data helpers shared by the example plugin EP and its tests.
+ *
+ * These helpers are intentionally outside the ORT C and EP ABI and are provided as a reference for EP authors that
+ * need to handle external (non-embedded) EPContext binary data.
+ *
+ * The intended entry points for EP implementers are:
+ *  - ReadEpContextData(api, config, file_name, graph, out, allocator): reads via an application-supplied
+ *    OrtReadNamedBufferFunc (carried by OrtEpContextConfig) or the file fallback, returning an owning EpContextData
+ *    buffer that avoids copying large data.
+ *  - WriteEpContextDataWithFileFallback(api, config, ...): writes via an application-supplied OrtWriteNamedBufferFunc
+ *    or the file fallback.
+ *
+ * The other functions are lower-level building blocks. Production EPs should additionally apply their own sandboxing,
+ * size limits, and path policies; see the per-function notes on how untrusted, model-derived names are treated.
+ */
 namespace ep_context_data_utils {
 
 #ifdef _WIN32
@@ -166,13 +173,14 @@ inline bool HasAbsoluteOrRootedPath(const std::filesystem::path& path) {
   return path.is_absolute() || path.has_root_name() || path.has_root_directory();
 }
 
-// Returns true if the final component of `path` is empty (e.g., a trailing separator like "sub/") or is the
-// current-directory entry "." or the parent-directory entry "..", i.e. the name designates a directory rather than a
-// file. Such a name resolves to a directory (e.g. "sub/.." resolves to the parent/model directory) and would only
-// surface later as a confusing file I/O failure, so model-derived names like these are rejected up front. A non-leaf
-// ".." in a logical callback-namespace name is rejected by ContainsPathTraversal(); in model-relative filesystem
-// names it is canonicalized and accepted only if the resolved path stays within the model directory.
-inline bool IsDirectoryOrEmptyName(const std::filesystem::path& path) {
+// Lexical (fail-fast) check on the final path component: returns true if the leaf is empty (a trailing separator such
+// as "sub/") or is "." or "..". These leaves lexically denote a directory rather than a concrete file name. This does
+// NOT stat the filesystem, so a real, existing directory with an ordinary leaf name (e.g. an existing "subdir") is not
+// detected here: it passes this check and is only rejected later when the file fails to open. The purpose is early,
+// clear error messaging for names that can never designate a file; the actual containment guarantee comes from the
+// read-side resolver (IsResolvedPathWithinBase()) plus the eventual file open(). A non-leaf ".." in a logical
+// callback-namespace name is rejected separately by ContainsPathTraversal().
+inline bool HasDirectoryLikeLeaf(const std::filesystem::path& path) {
   const std::filesystem::path leaf = path.filename();
   return leaf.empty() || leaf == std::filesystem::path{"."} || leaf == std::filesystem::path{".."};
 }
@@ -224,7 +232,7 @@ inline OrtStatus* ValidateEpContextDataName(const OrtApi& api, const char* file_
     return api.CreateStatus(ORT_INVALID_ARGUMENT, "EPContext data file name must not contain path traversal");
   }
 
-  if (IsDirectoryOrEmptyName(candidate_path)) {
+  if (HasDirectoryLikeLeaf(candidate_path)) {
     return api.CreateStatus(ORT_INVALID_ARGUMENT, "EPContext data file name must refer to a file, not a directory");
   }
 
@@ -273,7 +281,7 @@ inline OrtStatus* ResolveEpContextDataPath(const OrtApi& api, const char* file_n
     return api.CreateStatus(ORT_INVALID_ARGUMENT, "EPContext data file name must not be absolute or rooted");
   }
 
-  if (IsDirectoryOrEmptyName(candidate_path)) {
+  if (HasDirectoryLikeLeaf(candidate_path)) {
     return api.CreateStatus(ORT_INVALID_ARGUMENT, "EPContext data file name must refer to a file, not a directory");
   }
 
@@ -344,6 +352,79 @@ inline OrtStatus* ReadEpContextDataFromFile(const OrtApi& api, const char* file_
   return nullptr;
 }
 
+// Reads the resolved EPContext data file into a buffer allocated from `allocator`, so a caller-supplied allocator is
+// honored on the file-fallback path just as it is on the callback path. On success `*out_buffer` owns `*out_size`
+// bytes and must be freed by the caller via the same `allocator`; on failure (and for an empty file) `*out_buffer` is
+// null and `*out_size` is 0. `graph` governs name resolution exactly as in ReadEpContextDataFromFile().
+inline OrtStatus* ReadEpContextDataFromFileWithAllocator(const OrtApi& api, const char* file_name,
+                                                         const OrtGraph* graph, OrtAllocator* allocator,
+                                                         void** out_buffer, size_t* out_size) {
+  *out_buffer = nullptr;
+  *out_size = 0;
+
+  std::filesystem::path data_path;
+  RETURN_IF_ERROR(ResolveEpContextDataPath(api, file_name, graph, data_path));
+
+  // Open at the end (std::ios::ate) so tellg() reports the byte count; binary mode keeps that count exact.
+  std::ifstream input_stream(data_path, std::ios::binary | std::ios::ate);
+  if (!input_stream) {
+    const std::string message = "Failed to open EPContext data file for read: " +
+                                PathToUtf8StringForMessage(data_path);
+    return api.CreateStatus(ORT_FAIL, message.c_str());
+  }
+
+  const std::streampos end_pos = input_stream.tellg();
+  if (end_pos < 0) {
+    const std::string message = "Failed to determine EPContext data file size: " +
+                                PathToUtf8StringForMessage(data_path);
+    return api.CreateStatus(ORT_FAIL, message.c_str());
+  }
+
+  const auto byte_count_wide = static_cast<std::uintmax_t>(end_pos);
+  if (byte_count_wide > static_cast<std::uintmax_t>(std::numeric_limits<size_t>::max()) ||
+      byte_count_wide > static_cast<std::uintmax_t>(std::numeric_limits<std::streamsize>::max())) {
+    return api.CreateStatus(ORT_INVALID_ARGUMENT, "EPContext data file is too large to read");
+  }
+  const size_t byte_count = static_cast<size_t>(byte_count_wide);
+  if (byte_count == 0) {
+    return nullptr;  // Empty file: leave *out_buffer null / *out_size 0 (no allocation needed).
+  }
+
+  input_stream.seekg(0, std::ios::beg);
+  if (!input_stream) {
+    const std::string message = "Failed to read EPContext data file: " +
+                                PathToUtf8StringForMessage(data_path);
+    return api.CreateStatus(ORT_FAIL, message.c_str());
+  }
+
+  void* buffer = nullptr;
+  RETURN_IF_ERROR(api.AllocatorAlloc(allocator, byte_count, &buffer));
+  if (buffer == nullptr) {
+    return api.CreateStatus(ORT_FAIL, "Allocator returned a null buffer for the EPContext data file read");
+  }
+
+  // Free the freshly allocated buffer via the same allocator on any error path below; release it to the caller on
+  // success. Release any AllocatorFree status without throwing (exception-free OrtStatus* style).
+  auto buffer_deleter = [&api, allocator](void* buffer_to_free) {
+    if (buffer_to_free != nullptr) {
+      Ort::Status free_status{api.AllocatorFree(allocator, buffer_to_free)};
+      static_cast<void>(free_status);
+    }
+  };
+  std::unique_ptr<void, decltype(buffer_deleter)> buffer_guard(buffer, buffer_deleter);
+
+  input_stream.read(static_cast<char*>(buffer), static_cast<std::streamsize>(byte_count));
+  if (!input_stream || static_cast<size_t>(input_stream.gcount()) != byte_count) {
+    const std::string message = "Failed to read EPContext data file: " +
+                                PathToUtf8StringForMessage(data_path);
+    return api.CreateStatus(ORT_FAIL, message.c_str());
+  }
+
+  *out_buffer = buffer_guard.release();
+  *out_size = byte_count;
+  return nullptr;
+}
+
 inline OrtStatus* WriteEpContextDataToFile(const OrtApi& api, const char* file_name, const OrtGraph* graph,
                                            const void* buffer, size_t buffer_size) {
   if (buffer == nullptr && buffer_size != 0) {
@@ -361,12 +442,12 @@ inline OrtStatus* ReadEpContextData(const OrtApi& api, OrtReadNamedBufferFunc re
                                     const char* file_name, const OrtGraph* graph, EpContextData& out,
                                     OrtAllocator* allocator = nullptr);
 
-// RAII owner for the bytes returned by an EPContext read, used to avoid copying potentially large data. The
-// app-supplied read-callback path adopts the allocator-provided buffer directly (no copy) and frees it via the same
-// allocator on destruction; the file-fallback path owns the bytes in a std::vector read straight from disk. Either
-// way the bytes are accessed through data()/size() without an extra copy. EPs that handle large EPContext blobs
-// should prefer ReadEpContextData() + EpContextData; the std::vector<char> ReadEpContextDataWithFileFallback()
-// overloads remain as a convenience for callers (e.g. tests) that want an owned vector and can afford one copy.
+// RAII owner for the bytes returned by an EPContext read, used to avoid copying potentially large data. Both the
+// app-supplied read-callback path and the file-fallback path place the bytes in a buffer obtained from an
+// OrtAllocator: the callback path adopts the buffer the callback allocated, and the file path reads straight into a
+// buffer allocated from the same (optionally caller-supplied) allocator. Either way the bytes are freed via that
+// allocator on destruction and are accessed through data()/size() without an extra copy. EPs that handle large
+// EPContext blobs should prefer ReadEpContextData() + EpContextData.
 class EpContextData {
  public:
   EpContextData() = default;
@@ -386,11 +467,9 @@ class EpContextData {
 
   // Pointer to the bytes, owned by this object (valid until it is destroyed or reassigned). May be null only when
   // size() == 0.
-  const char* data() const noexcept {
-    return buffer_ != nullptr ? static_cast<const char*>(buffer_) : file_bytes_.data();
-  }
-  size_t size() const noexcept { return buffer_ != nullptr ? buffer_size_ : file_bytes_.size(); }
-  bool empty() const noexcept { return size() == 0; }
+  const char* data() const noexcept { return static_cast<const char*>(buffer_); }
+  size_t size() const noexcept { return buffer_size_; }
+  bool empty() const noexcept { return buffer_size_ == 0; }
 
  private:
   friend OrtStatus* ReadEpContextData(const OrtApi& api, OrtReadNamedBufferFunc read_func, void* read_state,
@@ -410,37 +489,39 @@ class EpContextData {
     buffer_size_ = 0;
   }
 
-  void Reset() noexcept {
-    FreeAllocatorBuffer();
-    file_bytes_.clear();
-  }
+  void Reset() noexcept { FreeAllocatorBuffer(); }
 
   void MoveFrom(EpContextData& other) noexcept {
     api_ = other.api_;
     allocator_ = other.allocator_;
     buffer_ = other.buffer_;
     buffer_size_ = other.buffer_size_;
-    file_bytes_ = std::move(other.file_bytes_);
     other.api_ = nullptr;
     other.allocator_ = nullptr;
     other.buffer_ = nullptr;
     other.buffer_size_ = 0;
   }
 
-  const OrtApi* api_ = nullptr;        // Used to free buffer_ (callback path); null otherwise.
-  OrtAllocator* allocator_ = nullptr;  // Allocator that owns buffer_ (callback path); null for the file path.
-  void* buffer_ = nullptr;             // Adopted callback buffer; null when the bytes live in file_bytes_.
-  size_t buffer_size_ = 0;
-  std::vector<char> file_bytes_;  // Owns the bytes on the file-fallback path.
+  const OrtApi* api_ = nullptr;        // Frees buffer_ via allocator_; null when there is no owned buffer.
+  OrtAllocator* allocator_ = nullptr;  // Allocator that owns buffer_ (callback or file path); null when none.
+  void* buffer_ = nullptr;             // Owned bytes (callback buffer or allocator-backed file read); null when empty.
+  size_t buffer_size_ = 0;             // Size of buffer_ in bytes.
 };
 
 // Zero-copy read: reads EPContext binary data named `file_name` into `out` (reset first). If `read_func` is non-null
 // it is invoked and the buffer it allocates is adopted by `out` (no copy); otherwise the data is read from the file
-// fallback into `out`. `allocator` is the allocator handed to the callback for the output buffer; pass nullptr to use
-// ORT's default allocator. Whatever allocator allocates the buffer is stored in `out` and used for the matching free,
-// so a caller may supply its own (e.g. arena/pinned) allocator. See ReadEpContextDataFromFile() for how `graph`
-// governs name resolution. This low-level overload takes the callback directly so tests can inject one; production
-// EPs use the OrtEpContextConfig overload.
+// fallback into a buffer allocated the same way. `allocator` is used for the output buffer on BOTH paths (the
+// callback path hands it to the callback; the file path allocates the read buffer from it); pass nullptr to use ORT's
+// default allocator. Whatever allocator allocates the buffer is stored in `out` and used for the matching free, so a
+// caller may supply its own (e.g. arena/pinned) allocator and it will be honored consistently.
+//
+// Allocator ownership: this function does NOT take ownership of `allocator`. The caller must keep the OrtAllocator
+// alive at least as long as the resulting `out`, because EpContextData frees its buffer via that allocator on
+// destruction. Callers using the C++ API can make this borrowing relationship explicit with a non-owning wrapper such
+// as Ort::UnownedAllocator (passing its underlying OrtAllocator* here).
+//
+// See ReadEpContextDataFromFile() for how `graph` governs name resolution. This low-level overload takes the callback
+// directly so tests can inject one; production EPs use the OrtEpContextConfig overload.
 inline OrtStatus* ReadEpContextData(const OrtApi& api, OrtReadNamedBufferFunc read_func, void* read_state,
                                     const char* file_name, const OrtGraph* graph, EpContextData& out,
                                     OrtAllocator* allocator) {
@@ -450,19 +531,29 @@ inline OrtStatus* ReadEpContextData(const OrtApi& api, OrtReadNamedBufferFunc re
     return api.CreateStatus(ORT_INVALID_ARGUMENT, "EPContext data file name must not be empty");
   }
 
-  if (read_func == nullptr) {
-    // No callback: read the file fallback straight into the owned vector (no extra copy). `allocator` is unused on
-    // this path (the bytes live in an owned std::vector).
-    return ReadEpContextDataFromFile(api, file_name, graph, out.file_bytes_);
-  }
-
-  // Use the caller-provided allocator if any; otherwise ORT's default allocator. Whatever allocates the callback
-  // buffer is also what frees it (stored in `out` for the matching free), so a caller may supply its own allocator.
-  // Use the C allocator API (not Ort::AllocatorWithDefaultOptions, whose constructor throws) so this OrtStatus*-based
-  // helper stays exception-free. The default allocator is owned by ORT and must not be released here.
+  // Use the caller-provided allocator if any; otherwise ORT's default allocator. Whatever allocates the output buffer
+  // is also what frees it (stored in `out` for the matching free), so a caller-supplied allocator is honored on both
+  // the callback and file paths. Use the C allocator API (not Ort::AllocatorWithDefaultOptions, whose constructor
+  // throws) so this OrtStatus*-based helper stays exception-free. The default allocator is owned by ORT and must not
+  // be released here.
   OrtAllocator* effective_allocator = allocator;
   if (effective_allocator == nullptr) {
     RETURN_IF_ERROR(api.GetAllocatorWithDefaultOptions(&effective_allocator));
+  }
+
+  if (read_func == nullptr) {
+    // No callback: read the file fallback into a buffer allocated from `effective_allocator` (so a caller-supplied
+    // allocator is honored here too), then transfer ownership to `out`. The helper frees its own buffer and leaves
+    // the outputs empty on failure, so `out` stays empty (it was reset above).
+    void* file_buffer = nullptr;
+    size_t file_buffer_size = 0;
+    RETURN_IF_ERROR(ReadEpContextDataFromFileWithAllocator(api, file_name, graph, effective_allocator, &file_buffer,
+                                                           &file_buffer_size));
+    out.api_ = &api;
+    out.allocator_ = effective_allocator;
+    out.buffer_ = file_buffer;
+    out.buffer_size_ = file_buffer_size;
+    return nullptr;
   }
 
   void* ep_context_data = nullptr;
@@ -498,9 +589,24 @@ inline OrtStatus* ReadEpContextData(const OrtApi& api, OrtReadNamedBufferFunc re
   return nullptr;
 }
 
-// Zero-copy read using the OrtReadNamedBufferFunc carried by `ep_context_config` (if any); otherwise reads the file
-// fallback. `allocator` is forwarded to the callback for the output buffer (nullptr = ORT's default allocator) and is
-// used for the matching free. See ReadEpContextData() above and ReadEpContextDataFromFile() for `graph` handling.
+/**
+ * \brief Read EPContext binary data into an owning, zero-copy EpContextData buffer (recommended read entry point).
+ *
+ * Reads the EPContext data named `file_name`. If `ep_context_config` carries an application-supplied
+ * OrtReadNamedBufferFunc, that callback is invoked and the buffer it allocates is adopted by `out` without an extra
+ * copy; otherwise the data is read from the file fallback into an allocator-backed buffer.
+ *
+ * \param api The OrtApi.
+ * \param ep_context_config EPContext config carrying the optional read callback; may be null (uses the file fallback).
+ * \param file_name Logical name of the EPContext data: a callback-namespace key, or a file name for the fallback.
+ * \param graph When non-null, the untrusted EPContext model graph. `file_name` must be relative and is resolved
+ *              against the model directory and rejected if it escapes it. Pass null only for trusted callers that
+ *              supply a physical path.
+ * \param out Reset first; receives the bytes on success and is left empty on failure. Access via out.data()/out.size().
+ * \param allocator Optional allocator used for the output buffer on both the callback and file paths; null uses ORT's
+ *                  default allocator. Not owned: it must outlive `out` (see the low-level overload for details).
+ * \return nullptr on success, or an OrtStatus* error owned by the caller.
+ */
 inline OrtStatus* ReadEpContextData(const OrtApi& api, const OrtEpContextConfig* ep_context_config,
                                     const char* file_name, const OrtGraph* graph, EpContextData& out,
                                     OrtAllocator* allocator = nullptr) {
@@ -516,63 +622,6 @@ inline OrtStatus* ReadEpContextData(const OrtApi& api, const OrtEpContextConfig*
     RETURN_IF_ERROR(get_read_func(ep_context_config, &read_func, &read_state));
   }
   return ReadEpContextData(api, read_func, read_state, file_name, graph, out, allocator);
-}
-
-// std::vector<char> convenience overload that takes the read callback and its opaque state directly. Production EPs
-// should use the OrtEpContextConfig overload below; this overload exists so unit tests can inject a callback without
-// constructing an OrtEpContextConfig. When `read_func` is null the data is read from a file straight into `data` (no
-// extra copy); the callback path reads zero-copy via ReadEpContextData() and then copies once into `data`. EPs
-// handling large data that want to avoid that copy should call ReadEpContextData() and consume the EpContextData
-// buffer directly.
-inline OrtStatus* ReadEpContextDataWithFileFallback(
-    const OrtApi& api,
-    OrtReadNamedBufferFunc read_func, void* read_state,
-    const char* file_name, const OrtGraph* graph,
-    std::vector<char>& data) {
-  // Clear first so `data` is empty on every error path (including an invalid file_name) and for an empty callback
-  // payload, matching the reset-first / empty-on-failure contract of the EpContextData overload.
-  data.clear();
-
-  if (file_name == nullptr || file_name[0] == '\0') {
-    return api.CreateStatus(ORT_INVALID_ARGUMENT, "EPContext data file name must not be empty");
-  }
-
-  if (read_func == nullptr) {
-    return ReadEpContextDataFromFile(api, file_name, graph, data);
-  }
-
-  EpContextData owned;
-  RETURN_IF_ERROR(ReadEpContextData(api, read_func, read_state, file_name, graph, owned));
-  // Assign only when non-empty to avoid pointer arithmetic on a possibly-null empty buffer.
-  if (!owned.empty()) {
-    data.assign(owned.data(), owned.data() + owned.size());
-  }
-  return nullptr;
-}
-
-// Reads EPContext binary data named `file_name`. If the session configured an OrtReadNamedBufferFunc (carried by
-// `ep_context_config`), it is used; otherwise the data is read from a file. When `graph` is non-null it is the
-// EPContext model graph: untrusted absolute/rooted names are rejected and relative names are resolved against the
-// model directory, with canonicalization/containment handling any ".." components. Pass `graph == nullptr` only for
-// trusted callers supplying a physical path. `data` is
-// cleared first and receives the bytes on success.
-inline OrtStatus* ReadEpContextDataWithFileFallback(
-    const OrtApi& api,
-    const OrtEpContextConfig* ep_context_config,
-    const char* file_name, const OrtGraph* graph,
-    std::vector<char>& data) {
-  OrtReadNamedBufferFunc read_func = nullptr;
-  void* read_state = nullptr;
-  if (ep_context_config != nullptr) {
-    auto get_read_func =
-        Ort::Experimental::Get_OrtEpApi_EpContextConfig_GetEpContextDataReadFunc_SinceV28_Fn(&api);
-    if (get_read_func == nullptr) {
-      return api.CreateStatus(ORT_NOT_IMPLEMENTED,
-                              "OrtEpApi_EpContextConfig_GetEpContextDataReadFunc is not available");
-    }
-    RETURN_IF_ERROR(get_read_func(ep_context_config, &read_func, &read_state));
-  }
-  return ReadEpContextDataWithFileFallback(api, read_func, read_state, file_name, graph, data);
 }
 
 // Low-level overload that takes the write callback and its opaque state directly. Production EPs should use the
@@ -613,11 +662,23 @@ inline OrtStatus* WriteEpContextDataWithFileFallback(
   return WriteEpContextDataToResolvedFile(api, data_path, buffer, buffer_size);
 }
 
-// Writes EPContext binary data. If the compilation configured an OrtWriteNamedBufferFunc (carried by
-// `ep_context_config`), it is used and `file_name` is passed through unmodified as the logical name. Otherwise the
-// data is written to a file at `fallback_file_name`, which is resolved against the model directory when `graph` is
-// non-null (and rejected if absolute or rooted in that case). `graph == nullptr` denotes a trusted caller that may
-// supply an absolute physical path. `buffer` may be null only when `buffer_size` is 0.
+/**
+ * \brief Write EPContext binary data via an application callback or the file fallback (recommended write entry point).
+ *
+ * If `ep_context_config` carries an application-supplied OrtWriteNamedBufferFunc, it is invoked and `file_name` is
+ * passed through unmodified as the logical name. Otherwise the data is written to a file at `fallback_file_name`.
+ *
+ * \param api The OrtApi.
+ * \param ep_context_config EPContext config carrying the optional write callback; may be null (uses the file fallback).
+ * \param file_name Logical name written into the model / passed to the callback.
+ * \param fallback_file_name File path used only when no write callback is configured; resolved against the model
+ *                           directory when `graph` is non-null (and rejected if absolute or rooted in that case).
+ * \param graph When non-null, resolves `fallback_file_name` against the model directory. `graph == nullptr` denotes a
+ *              trusted caller that may supply an absolute physical path.
+ * \param buffer The bytes to write; may be null only when `buffer_size` is 0.
+ * \param buffer_size Number of bytes to write.
+ * \return nullptr on success, or an OrtStatus* error owned by the caller.
+ */
 inline OrtStatus* WriteEpContextDataWithFileFallback(
     const OrtApi& api,
     const OrtEpContextConfig* ep_context_config,
@@ -639,10 +700,22 @@ inline OrtStatus* WriteEpContextDataWithFileFallback(
                                             buffer_size);
 }
 
-// Convenience overload that uses `file_name` as both the logical callback name and the file-fallback path.
-// Because `file_name` doubles as the fallback path, it must be a safe relative name (this overload validates it and
-// rejects absolute/rooted paths and `..` traversal). To write the file fallback to an absolute physical path (a
-// trusted caller with `graph == nullptr`), use the overload above that takes a separate `fallback_file_name`.
+/**
+ * \brief Convenience write overload that uses `file_name` as both the logical callback name and the file-fallback path.
+ *
+ * Because `file_name` doubles as the fallback path, when no callback is configured it must be a safe relative name:
+ * this overload validates it and rejects absolute/rooted paths and `..` traversal. To write the file fallback to an
+ * absolute physical path (a trusted caller with `graph == nullptr`), use the overload above that takes a separate
+ * `fallback_file_name`.
+ *
+ * \param api The OrtApi.
+ * \param ep_context_config EPContext config carrying the optional write callback; may be null (uses the file fallback).
+ * \param file_name Logical name and, on the file-fallback path, the (relative) file name to write.
+ * \param graph When non-null, resolves `file_name` against the model directory; null denotes a trusted caller.
+ * \param buffer The bytes to write; may be null only when `buffer_size` is 0.
+ * \param buffer_size Number of bytes to write.
+ * \return nullptr on success, or an OrtStatus* error owned by the caller.
+ */
 inline OrtStatus* WriteEpContextDataWithFileFallback(
     const OrtApi& api,
     const OrtEpContextConfig* ep_context_config,

--- a/onnxruntime/test/autoep/library/ep_context_data_utils.h
+++ b/onnxruntime/test/autoep/library/ep_context_data_utils.h
@@ -156,16 +156,44 @@ inline bool HasAbsoluteOrRootedPath(const std::filesystem::path& path) {
   return path.is_absolute() || path.has_root_name() || path.has_root_directory();
 }
 
-// Lexical (fail-fast) check on the final path component: returns true if the leaf is empty (a trailing separator such
-// as "sub/") or is "." or "..". These leaves lexically denote a directory rather than a concrete file name. This does
-// NOT stat the filesystem, so a real, existing directory with an ordinary leaf name (e.g. an existing "subdir") is not
-// detected here: it passes this check and is only rejected later when the file fails to open. The purpose is early,
-// clear error messaging for names that can never designate a file; the actual containment guarantee comes from the
-// read-side resolver (IsResolvedPathWithinBase()) plus the eventual file open(), which also handle non-leaf ".."
-// components via canonicalization rather than a lexical check.
-inline bool HasDirectoryLikeLeaf(const std::filesystem::path& path) {
-  const std::filesystem::path leaf = path.filename();
-  return leaf.empty() || leaf == std::filesystem::path{"."} || leaf == std::filesystem::path{".."};
+// Read gate: the resolved path must exist and be a regular file. status() follows symlinks, matching the
+// canonicalization used for containment. This rejects directories and special files - notably a FIFO, which
+// containment does not catch and which blocks an ifstream open, making it a cheap denial of service. Advisory, not a
+// security boundary: the path can change between this check and the open (TOCTOU).
+inline OrtStatus* EnsureRegularFileForRead(const OrtApi& api, const std::filesystem::path& data_path) {
+  std::error_code ec;
+  const std::filesystem::file_status file_status = std::filesystem::status(data_path, ec);
+  if (ec || !std::filesystem::exists(file_status)) {
+    const std::string message = "Failed to open EPContext data file for read: " +
+                                PathToUtf8StringForMessage(data_path);
+    return api.CreateStatus(ORT_FAIL, message.c_str());
+  }
+
+  if (!std::filesystem::is_regular_file(file_status)) {
+    const std::string message = "EPContext data file must be a regular file: " +
+                                PathToUtf8StringForMessage(data_path);
+    return api.CreateStatus(ORT_INVALID_ARGUMENT, message.c_str());
+  }
+
+  return nullptr;
+}
+
+// Write counterpart: a not-yet-existing target is the normal case and is allowed, but an existing target must be a
+// regular file. Same advisory (TOCTOU) caveat as EnsureRegularFileForRead().
+inline OrtStatus* EnsureRegularFileForWrite(const OrtApi& api, const std::filesystem::path& data_path) {
+  std::error_code ec;
+  const std::filesystem::file_status file_status = std::filesystem::status(data_path, ec);
+  if (ec || !std::filesystem::exists(file_status)) {
+    return nullptr;
+  }
+
+  if (!std::filesystem::is_regular_file(file_status)) {
+    const std::string message = "EPContext data file must be a regular file: " +
+                                PathToUtf8StringForMessage(data_path);
+    return api.CreateStatus(ORT_INVALID_ARGUMENT, message.c_str());
+  }
+
+  return nullptr;
 }
 
 // Returns true if `candidate_full` (a base-relative name already combined with `base`) resolves to a location inside
@@ -203,9 +231,10 @@ inline bool IsResolvedPathWithinBase(const std::filesystem::path& base, const st
 // relative, and after combining it with the model's directory the result must stay within that directory. Symlinks and
 // ".." are resolved (via weakly_canonical), so a name that escapes the model directory - including through a symlink -
 // is rejected.
-// This helper only decides whether a model-derived file name resolves inside the model directory. Production EPs
-// should still choose an application-approved storage root (sandbox), reject special files/locations as appropriate,
-// and cap the number of bytes they will read or write for a single EPContext payload.
+// This helper only decides whether a model-derived file name resolves inside the model directory; the file type is
+// checked by EnsureRegularFileForRead() / EnsureRegularFileForWrite() at the point of use. Production EPs should
+// still choose an application-approved storage root (sandbox) and cap the number of bytes they will read or write for
+// a single EPContext payload.
 inline OrtStatus* ResolveEpContextDataPath(const OrtApi& api, const char* file_name, const OrtGraph* graph,
                                            std::filesystem::path& data_path) {
   data_path.clear();
@@ -234,10 +263,6 @@ inline OrtStatus* ResolveEpContextDataPath(const OrtApi& api, const char* file_n
     return api.CreateStatus(ORT_INVALID_ARGUMENT, "EPContext data file name must not be absolute or rooted");
   }
 
-  if (HasDirectoryLikeLeaf(candidate_path)) {
-    return api.CreateStatus(ORT_INVALID_ARGUMENT, "EPContext data file name must refer to a file, not a directory");
-  }
-
   const ORTCHAR_T* model_path = nullptr;
   RETURN_IF_ERROR(api.Graph_GetModelPath(graph, &model_path));
   if (model_path == nullptr || model_path[0] == 0) {
@@ -258,6 +283,8 @@ inline OrtStatus* ResolveEpContextDataPath(const OrtApi& api, const char* file_n
 
 inline OrtStatus* WriteEpContextDataToResolvedFile(const OrtApi& api, const std::filesystem::path& data_path,
                                                    const void* buffer, size_t buffer_size) {
+  RETURN_IF_ERROR(EnsureRegularFileForWrite(api, data_path));
+
   std::ofstream output_stream(data_path, std::ios::binary);
   if (!output_stream) {
     const std::string message = "Failed to open EPContext data file for write: " +
@@ -287,6 +314,7 @@ inline OrtStatus* ReadEpContextDataFromFile(const OrtApi& api, const char* file_
 
   std::filesystem::path data_path;
   RETURN_IF_ERROR(ResolveEpContextDataPath(api, file_name, graph, data_path));
+  RETURN_IF_ERROR(EnsureRegularFileForRead(api, data_path));
 
   std::ifstream input_stream(data_path, std::ios::binary);
   if (!input_stream) {
@@ -317,6 +345,7 @@ inline OrtStatus* ReadEpContextDataFromFileWithAllocator(const OrtApi& api, cons
 
   std::filesystem::path data_path;
   RETURN_IF_ERROR(ResolveEpContextDataPath(api, file_name, graph, data_path));
+  RETURN_IF_ERROR(EnsureRegularFileForRead(api, data_path));
 
   // Open at the end (std::ios::ate) so tellg() reports the byte count; binary mode keeps that count exact.
   std::ifstream input_stream(data_path, std::ios::binary | std::ios::ate);

--- a/onnxruntime/test/autoep/library/ep_context_data_utils.h
+++ b/onnxruntime/test/autoep/library/ep_context_data_utils.h
@@ -181,11 +181,15 @@ inline OrtStatus* EnsureRegularFileForRead(const OrtApi& api, const std::filesys
 // Write counterpart: a not-yet-existing target is the normal case and is allowed, but an existing target must be a
 // regular file. Same advisory (TOCTOU) caveat as EnsureRegularFileForRead().
 //
-// A symlink leaf is rejected outright, which closes a gap the containment check alone cannot: a *dangling* symlink
-// (one whose target does not exist yet) is not traversed by weakly_canonical(), so it passes containment while
-// pointing outside the model directory, and an ofstream would then follow it and create the target there. Testing
-// the link itself requires symlink_status(), which does not follow links - status() would report the (missing)
-// target as not_found and wave the write through.
+// A symlink leaf is rejected. This closes a gap containment alone cannot: a *dangling* symlink (one whose target
+// does not exist yet) reports as not_found, so weakly_canonical() leaves the link path untouched and it passes
+// containment while pointing outside the model directory - an ofstream would then follow it and create the target
+// there. Detecting that requires symlink_status(), which inspects the link instead of following it; status() would
+// report the missing target as not_found and wave the write through.
+//
+// Note the division of labor: for a model-relative name that resolves, weakly_canonical() has already replaced the
+// link with its target before this runs, so containment is what constrains those writes. This check is what covers
+// the dangling case, and trusted (graph == nullptr) paths, which skip resolution altogether.
 inline OrtStatus* EnsureRegularFileForWrite(const OrtApi& api, const std::filesystem::path& data_path) {
   std::error_code symlink_ec;
   const std::filesystem::file_status link_status = std::filesystem::symlink_status(data_path, symlink_ec);

--- a/onnxruntime/test/autoep/library/ep_context_data_utils.h
+++ b/onnxruntime/test/autoep/library/ep_context_data_utils.h
@@ -180,7 +180,21 @@ inline OrtStatus* EnsureRegularFileForRead(const OrtApi& api, const std::filesys
 
 // Write counterpart: a not-yet-existing target is the normal case and is allowed, but an existing target must be a
 // regular file. Same advisory (TOCTOU) caveat as EnsureRegularFileForRead().
+//
+// A symlink leaf is rejected outright, which closes a gap the containment check alone cannot: a *dangling* symlink
+// (one whose target does not exist yet) is not traversed by weakly_canonical(), so it passes containment while
+// pointing outside the model directory, and an ofstream would then follow it and create the target there. Testing
+// the link itself requires symlink_status(), which does not follow links - status() would report the (missing)
+// target as not_found and wave the write through.
 inline OrtStatus* EnsureRegularFileForWrite(const OrtApi& api, const std::filesystem::path& data_path) {
+  std::error_code symlink_ec;
+  const std::filesystem::file_status link_status = std::filesystem::symlink_status(data_path, symlink_ec);
+  if (!symlink_ec && std::filesystem::is_symlink(link_status)) {
+    const std::string message = "EPContext data file must not be a symlink: " +
+                                PathToUtf8StringForMessage(data_path);
+    return api.CreateStatus(ORT_INVALID_ARGUMENT, message.c_str());
+  }
+
   std::error_code ec;
   const std::filesystem::file_status file_status = std::filesystem::status(data_path, ec);
   if (ec || !std::filesystem::exists(file_status)) {
@@ -453,6 +467,10 @@ class EpContextData {
   size_t size() const noexcept { return buffer_size_; }
   bool empty() const noexcept { return buffer_size_ == 0; }
 
+  // Frees any owned bytes and returns to the empty state. The read entry points call this before doing any work, so
+  // an EpContextData is safe to reuse across reads; callers may also use it to release a large buffer early.
+  void Reset() noexcept { FreeAllocatorBuffer(); }
+
  private:
   friend OrtStatus* ReadEpContextData(const OrtApi& api, OrtReadNamedBufferFunc read_func, void* read_state,
                                       const char* file_name, const OrtGraph* graph, EpContextData& out,
@@ -471,7 +489,15 @@ class EpContextData {
     buffer_size_ = 0;
   }
 
-  void Reset() noexcept { FreeAllocatorBuffer(); }
+  // Takes ownership of `buffer` (allocated from `allocator`, freed via `api`), replacing anything already held.
+  // Used by the read entry point to adopt the callback buffer and the file-fallback buffer through one path.
+  void Adopt(const OrtApi& api, OrtAllocator* allocator, void* buffer, size_t buffer_size) noexcept {
+    FreeAllocatorBuffer();
+    api_ = &api;
+    allocator_ = allocator;
+    buffer_ = buffer;
+    buffer_size_ = buffer_size;
+  }
 
   void MoveFrom(EpContextData& other) noexcept {
     api_ = other.api_;
@@ -531,10 +557,7 @@ inline OrtStatus* ReadEpContextData(const OrtApi& api, OrtReadNamedBufferFunc re
     size_t file_buffer_size = 0;
     RETURN_IF_ERROR(ReadEpContextDataFromFileWithAllocator(api, file_name, graph, effective_allocator, &file_buffer,
                                                            &file_buffer_size));
-    out.api_ = &api;
-    out.allocator_ = effective_allocator;
-    out.buffer_ = file_buffer;
-    out.buffer_size_ = file_buffer_size;
+    out.Adopt(api, effective_allocator, file_buffer, file_buffer_size);
     return nullptr;
   }
 
@@ -563,10 +586,7 @@ inline OrtStatus* ReadEpContextData(const OrtApi& api, OrtReadNamedBufferFunc re
   }
 
   // Success: transfer ownership of the callback buffer to `out` (no copy); `out` frees it via the same allocator.
-  out.api_ = &api;
-  out.allocator_ = effective_allocator;
-  out.buffer_ = buffer_guard.release();
-  out.buffer_size_ = ep_context_data_size;
+  out.Adopt(api, effective_allocator, buffer_guard.release(), ep_context_data_size);
 
   return nullptr;
 }
@@ -581,9 +601,12 @@ inline OrtStatus* ReadEpContextData(const OrtApi& api, OrtReadNamedBufferFunc re
  * \param api The OrtApi.
  * \param ep_context_config EPContext config carrying the optional read callback; may be null (uses the file fallback).
  * \param file_name Logical name of the EPContext data: a callback-namespace key, or a file name for the fallback.
- * \param graph When non-null, the untrusted EPContext model graph. `file_name` must be relative and is resolved
- *              against the model directory and rejected if it escapes it. Pass null only for trusted callers that
- *              supply a physical path.
+ * \param graph Governs name resolution on the FILE-FALLBACK path only. When non-null it is the untrusted EPContext
+ *              model graph, and `file_name` must be relative and must resolve inside the model directory; null
+ *              denotes a trusted caller supplying a physical path. When a read callback is configured, `graph` is
+ *              not consulted at all: `file_name` is forwarded to the callback verbatim as an opaque namespace key,
+ *              so the callback must treat it as untrusted input and must not use it as a filesystem path without
+ *              applying its own validation.
  * \param out Reset first; receives the bytes on success and is left empty on failure. Access via out.data()/out.size().
  * \param allocator Optional allocator used for the output buffer on both the callback and file paths; null uses ORT's
  *                  default allocator. Not owned: it must outlive `out` (see the low-level overload for details).
@@ -592,6 +615,10 @@ inline OrtStatus* ReadEpContextData(const OrtApi& api, OrtReadNamedBufferFunc re
 inline OrtStatus* ReadEpContextData(const OrtApi& api, const OrtEpContextConfig* ep_context_config,
                                     const char* file_name, const OrtGraph* graph, EpContextData& out,
                                     OrtAllocator* allocator = nullptr) {
+  // Reset up front so the documented "empty on failure" contract also holds for the early returns below, which are
+  // reached before the low-level overload (which does its own reset) is ever called.
+  out.Reset();
+
   OrtReadNamedBufferFunc read_func = nullptr;
   void* read_state = nullptr;
   if (ep_context_config != nullptr) {

--- a/onnxruntime/test/autoep/library/example_plugin_ep/ep.cc
+++ b/onnxruntime/test/autoep/library/example_plugin_ep/ep.cc
@@ -424,9 +424,11 @@ OrtStatus* ORT_API_CALL ExampleEp::CompileImpl(_In_ OrtEp* this_ptr, _In_ const 
 
         // This example only exercises the load-side read flow (callback first, file fallback otherwise) to show how
         // an EP retrieves EPContext binary data during compile. A real EP would consume `ep_context_data` (e.g.,
-        // initialize a kernel/engine from it); here it is intentionally read and then discarded.
-        std::vector<char> ep_context_data;
-        RETURN_IF_ERROR(ep_context_data_utils::ReadEpContextDataWithFileFallback(
+        // initialize a kernel/engine from it via ep_context_data.data()/size()); here it is intentionally read and
+        // then discarded. ReadEpContextData returns an owning EpContextData buffer that adopts the callback-provided
+        // memory instead of copying it.
+        ep_context_data_utils::EpContextData ep_context_data;
+        RETURN_IF_ERROR(ep_context_data_utils::ReadEpContextData(
             ep->ort_api, ep->ep_context_config_.get(), ep_cache_context.c_str(), ort_graphs[0],
             ep_context_data));
       }


### PR DESCRIPTION
Follow-up to #28624 (now merged) addressing review comments on the sample-only EPContext helper (`onnxruntime/test/autoep/library/ep_context_data_utils.h`), plus a design doc for the overall feature. Targets `main`.

## Changes

### 1. Reject a leaf `..` in `IsDirectoryOrEmptyName`
`IsDirectoryOrEmptyName()` previously treated only `.` and a trailing separator as directory-like. An untrusted, model-derived name with a leaf `..` (e.g. `sub/..`) would resolve to the parent/model directory and only fail later as a confusing file I/O error. It is now rejected up front. A non-leaf `..` anywhere in the path is still handled by `ContainsPathTraversal()` / the model-directory containment check.

### 2. Avoid the `std::vector<char>` copy on read
The app read-callback path previously copied the allocator-provided buffer into a `std::vector<char>`. Added a move-only `EpContextData` owning buffer plus `ReadEpContextData(...)` overloads:
- **Callback path** adopts the allocator-provided buffer (no copy) and frees it via the same allocator on destruction.
- **File path** reads straight into the owned vector.

The `std::vector<char>` `ReadEpContextDataWithFileFallback(...)` overloads remain as convenience wrappers (file path reads directly into the caller's vector; the callback path delegates to the zero-copy reader and copies once). The example EP now uses the zero-copy `ReadEpContextData` path.

### 3. Drop the coarse path-traversal guard from trusted path resolution
Now that `IsResolvedPathWithinBase()` does real model-directory containment for untrusted model-relative names, the lexical `ContainsPathTraversal()` guard is no longer applied on the trusted `graph == nullptr` branch of `ResolveEpContextDataPath()` — trusted callers already may pass absolute paths and own their paths, so there is no model directory to contain against. `ContainsPathTraversal()` is now used solely by `ValidateEpContextDataName()`, which validates the logical callback-namespace name written into the model `ep_cache_context` attribute (never resolved against a filesystem base). Untrusted model-relative names remain constrained by `IsResolvedPathWithinBase()`.

### 4. Adopt the callback buffer only on success
`ReadEpContextData(...)` now holds any callback-allocated buffer in a local RAII guard and transfers ownership into the `EpContextData` out-parameter **only after** the callback status and `(buffer, size)` validation pass. On any error path the guard frees the buffer and the owner stays empty, matching the reset-first / bytes-on-success contract (and the `std::vector` overload's empty-on-failure guarantee).

### 5. Clear the `std::vector<char>` output before validating `file_name`
The `std::vector<char>` `ReadEpContextDataWithFileFallback(...)` overload now clears `data` at the very top — before the `file_name` null/empty check — so `data` is empty on every error path, consistent with the `EpContextData` overload which resets `out` before argument validation.

### 6. Design doc: `docs/design/Compiled_Model_Encryption.md`
Adds a design document for the application-controlled compiled-model encryption flow that #28624 and this PR implement: the named-buffer read/write callbacks (`OrtReadNamedBufferFunc` / `OrtWriteNamedBufferFunc`), the `OrtEpContextConfig` handle and its `OrtEpApi` accessors, the `Ort::Experimental::EpContextConfig` C++ wrapper, and the `ep_context_data_utils` reference helper. It follows the decision-record layout of `docs/design/Experimental_C_API.md` (Requirements, Approaches Considered, Rejected Alternatives, application flows, memory analysis, API summary, open questions).

## Tests
- `EpContextDataUtils_ReadEpContextDataAdoptsCallbackBufferZeroCopy` — covers the callback-adopt and file paths.
- `EpContextDataUtils_ReadEpContextDataLeavesOutputEmptyOnCallbackError` — a callback that allocates then returns an error leaves the `EpContextData` empty (adopt-on-success).
- `EpContextDataUtils_ResolvePathRejectsUnsafeNames` — added a `sub/..` rejection; updated the two trusted-branch (`graph == nullptr`) `../escape.ctx` assertions to accept the name and surface a normal file-open failure rather than a traversal rejection.
- `EpContextDataUtils_CallbackFallbackUsesCallbacks` — added an empty-callback-payload case; `EpContextDataUtils_ReadCallbackRejectsNullBufferForNonEmptyPayload` — asserts stale output is cleared on a callback failure.
- `EpContextDataUtils_ResolvePathAndInvalidArguments` — asserts a pre-filled vector is cleared when `file_name` is empty.
- Logical-name `..` rejection (`ValidateEpContextDataName`) and the symlink/containment coverage are unchanged.
- Local validation (Windows RelWithDebInfo): `onnxruntime_autoep_test` builds clean; `*EpContextDataUtils*` = 8 passed + 1 skipped (symlink test, expected on Windows).

The three changed C++ files are clang-format clean (the added design doc is Markdown).
