### PR TITLE
Fix initializer load for in-memory external data

### DIFF
--- a/onnxruntime/core/optimizer/initializer.cc
+++ b/onnxruntime/core/optimizer/initializer.cc
@@ -72,10 +72,6 @@ Initializer::Initializer(const Graph& graph, const ONNX_NAMESPACE::TensorProto& 
       data_ = GetTensor(ort_value_);
       return;
     }
-#if !defined(__wasm__)
-    ORT_ENFORCE(!model_path.empty(),
-                "model_path must not be empty. Ensure that a path is provided when the model is created or loaded.");
-#endif
   }
 
   Tensor tensor;

--- a/onnxruntime/test/optimizer/initializer_test.cc
+++ b/onnxruntime/test/optimizer/initializer_test.cc
@@ -17,6 +17,11 @@
 #include "test/util/include/asserts.h"
 #include "test/util/include/file_util.h"
 
+#include "core/framework/data_types.h"
+#include "core/framework/tensor.h"
+#include "core/graph/model.h"
+#include "test/test_environment.h"
+
 namespace onnxruntime {
 namespace test {
 #if !defined(__wasm__)
@@ -268,6 +273,27 @@ TEST(OptimizerInitializerTest, DataField) {
   TestInitializerDataField<BFloat16>();
   TestInitializerDataField<float>();
   TestInitializerDataField<double>();
+}
+
+// An in-memory external-data initializer with no registered OrtValue must load without a model_path.
+TEST(OptimizerInitializerTest, InMemoryExternalDataWithoutOrtValueOrModelPath) {
+  std::vector<float> backing(64);  // 256 bytes > kSmallTensorExternalDataThreshold
+  std::iota(backing.begin(), backing.end(), 1.0f);
+
+  Tensor src(DataTypeImpl::GetType<float>(), TensorShape({static_cast<int64_t>(backing.size())}),
+             backing.data(), CPUAllocator::DefaultInstance()->Info());
+  auto tensor_proto = utils::TensorToTensorProto(src, "in_memory_init", /*use_tensor_buffer=*/true);
+  ASSERT_TRUE(utils::HasExternalDataInMemory(tensor_proto));
+
+  Model model("InMemoryExternalDataInitializer", false, DefaultLoggingManager().DefaultLogger());
+  const Graph& graph = model.MainGraph();
+  const Initializer init(graph, tensor_proto, std::filesystem::path{}, /*check_outer_scope=*/false);
+
+  ASSERT_EQ(init.size(), backing.size());
+  const auto values = init.DataAsSpan<float>();
+  for (size_t i = 0; i < backing.size(); ++i) {
+    EXPECT_EQ(values[i], backing[i]) << "Mismatch at index " << i;
+  }
 }
 
 }  // namespace test


### PR DESCRIPTION
### Description
The `Initializer(graph, …)` constructor wrongly required a `model_path` for an initializer with in-memory external data when its `OrtValue` wasn't registered. It now loads the data from memory via `CreateTensorFromTensorProto`, matching the other constructor.

### Motivation and Context
Fixes #28267. A model loaded from bytes via `CreateSessionFromArray` failed with `model_path must not be empty`; loading the same model from a file worked.
