### PR TITLE
Fix FP8 (FLOAT8E4M3FN) quantization scale using wrong reference distribution

### DIFF
--- a/onnxruntime/python/tools/quantization/quant_utils.py
+++ b/onnxruntime/python/tools/quantization/quant_utils.py
@@ -378,7 +378,7 @@ def compute_scale_zp_float8(element_type, std):
             from ml_dtypes import float8_e4m3fn  # noqa: PLC0415
 
             zp_dtype = float8_e4m3fn
-            all_values = [float(i) for i in range(256)]
+            all_values = numpy.arange(256, dtype=numpy.uint8).view(float8_e4m3fn).astype(numpy.float32)
             values = numpy.array(
                 [f for f in all_values if not numpy.isnan(f) and not numpy.isinf(f)], dtype=numpy.float32
             )

--- a/onnxruntime/test/python/quantization/test_quant_util.py
+++ b/onnxruntime/test/python/quantization/test_quant_util.py
@@ -17,6 +17,7 @@ from onnx import TensorProto, helper, numpy_helper
 from onnxruntime.quantization.quant_utils import (
     QuantType,
     compute_scale_zp,
+    compute_scale_zp_float8,
     load_model_with_shape_infer,
     model_has_infer_metadata,
     pack_bytes_to_4bit,
@@ -82,6 +83,16 @@ class TestQuantUtil(unittest.TestCase):
             _compute_scale_zp(0.0, 0.0, -32768, 32767, numpy.int16, symmetric=True, min_real_range=0.0001),
             [0, 0.0002 / 65535],
         )
+
+    def test_compute_scale_zp_float8(self):
+        # The FLOAT8E4M3FN reference distribution must be the 254 finite float8
+        # values (std ~= 100.0577), not the integers 0..255 (std ~= 73.9). With
+        # std=1 the scale is therefore 1 / 100.0577, not 1 / 73.9.
+        zero, scale = compute_scale_zp_float8(TensorProto.FLOAT8E4M3FN, numpy.float32(1.0))
+        numpy.testing.assert_allclose(float(scale), 1.0 / 100.05772, rtol=1e-5)
+        # Scale is linear in the input std.
+        _, scale2 = compute_scale_zp_float8(TensorProto.FLOAT8E4M3FN, numpy.float32(2.0))
+        numpy.testing.assert_allclose(float(scale2), 2.0 / 100.05772, rtol=1e-5)
 
     def test_load_external_model(self):
         input_name = "input"


### PR DESCRIPTION
## Problem

`compute_scale_zp_float8` (in `onnxruntime/python/tools/quantization/quant_utils.py`) computes the FP8 quantization scale as `scale = std_data / std_f8`, where `std_f8` is the standard deviation of the representable `FLOAT8E4M3FN` values. It built that reference distribution as:

```python
all_values = [float(i) for i in range(256)]
```

That's the integers `0.0 .. 255.0` — **not** the float8 values. It should reinterpret each of the 256 byte patterns as a `float8_e4m3fn` value (the finite set spanning `-448..448`). This is a regression from the ONNX 1.19 integration that removed `onnx.numpy_helper.float8e4m3_to_float32` (the prior code was `[float8e4m3_to_float32(i) for i in range(256)]`); the repo's own reference notebook `docs/python/notebooks/quantization_f8.ipynb` still documents the correct algorithm.

Effect: `std_f8` is computed as **73.90** instead of **100.06**, so every FP8 scale is **~35% too large**, degrading FP8-quantized model accuracy. The path is live — called from `onnx_quantizer.py` and `qdq_quantizer.py`.

## Reproduction (real function)

```python
compute_scale_zp_float8(TensorProto.FLOAT8E4M3FN, numpy.float32(1.0))
# before: scale = 0.01353175   (distribution = 0..255, n=256, std=73.90)
# after:  scale = 0.00999423   (distribution = -448..448, n=254, std=100.06)
```

## Fix

```python
all_values = numpy.arange(256, dtype=numpy.uint8).view(float8_e4m3fn).astype(numpy.float32)
```

The existing `not numpy.isnan(f) and not numpy.isinf(f)` filter then drops the 2 NaN byte patterns, leaving the 254 finite float8 values. `float8_e4m3fn` and `numpy` are already imported.

## Test

Adds `test_compute_scale_zp_float8` to `onnxruntime/test/python/quantization/test_quant_util.py` asserting `scale == std / 100.0577` (and linearity in `std`). It fails on the old code (`std_f8` 73.9) and passes after the fix.