### PR TITLE
Fix extended minimal builds with the Core ML EP

### DIFF
--- a/include/onnxruntime/core/graph/graph.h
+++ b/include/onnxruntime/core/graph/graph.h
@@ -1455,10 +1455,6 @@ class Graph {  // NOLINT(clang-analyzer-optin.performance.Padding): preserve exi
     SetInputs(AsSpan(inputs));
   }
 
-  const Model& GetModel() const {
-    return owning_model_;
-  }
-
   const logging::Logger& GetLogger() const {
     return logger_;
   }
@@ -1476,6 +1472,10 @@ class Graph {  // NOLINT(clang-analyzer-optin.performance.Padding): preserve exi
 #endif  // !defined(ORT_MINIMAL_BUILD)
 
 #if !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
+  const Model& GetModel() const {
+    return owning_model_;
+  }
+
   /** Sets the type of a NodeArg, replacing existing type/shape if any */
   void SetNodeArgType(NodeArg& arg, const ONNX_NAMESPACE::TypeProto& type_proto);
 


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Enables `GetModel()` in extended minimal builds.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Fixes https://github.com/microsoft/onnxruntime/issues/29386/. Extended minimal builds with the Core ML Execution Provider fail because getting the model metadata in coreml_execution_provider.cc on L63 requires Graph::GetModel(), which is only available in full (non-minimal) builds.