### PR TITLE
C# RunAsync: Pin the raw IntPtr[] arrays inside CallbackHost

### DIFF
--- a/csharp/src/Microsoft.ML.OnnxRuntime/InferenceSession.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/InferenceSession.shared.cs
@@ -1132,6 +1132,7 @@ namespace Microsoft.ML.OnnxRuntime
             }
             finally
             {
+                host.UnpinArrays();
                 hostHdl.Free();
             }
         }
@@ -1156,6 +1157,11 @@ namespace Microsoft.ML.OnnxRuntime
             public IntPtr[] rawOutputNames { get; }
             public IntPtr[] rawOutputValues { get; }
 
+            private readonly GCHandle _pinnedInputNames;
+            private readonly GCHandle _pinnedInputValues;
+            private readonly GCHandle _pinnedOutputNames;
+            private readonly GCHandle _pinnedOutputValues;
+
             public CallbackHost(InferenceSession session,
                                 IReadOnlyCollection<string> cbInputNames,
                                 IReadOnlyCollection<OrtValue> cbinputValues,
@@ -1175,6 +1181,19 @@ namespace Microsoft.ML.OnnxRuntime
 
                 rawOutputNames = LookupUtf8Names(outputNames, n => n, session.LookupOutputMetadata);
                 rawOutputValues = outputValues.Select(v => v.Handle).ToArray();
+
+                _pinnedInputNames = GCHandle.Alloc(rawInputNames, GCHandleType.Pinned);
+                _pinnedInputValues = GCHandle.Alloc(rawInputValues, GCHandleType.Pinned);
+                _pinnedOutputNames = GCHandle.Alloc(rawOutputNames, GCHandleType.Pinned);
+                _pinnedOutputValues = GCHandle.Alloc(rawOutputValues, GCHandleType.Pinned);
+            }
+
+            internal void UnpinArrays()
+            {
+                _pinnedInputNames.Free();
+                _pinnedInputValues.Free();
+                _pinnedOutputNames.Free();
+                _pinnedOutputValues.Free();
             }
         }
 
@@ -1186,7 +1205,7 @@ namespace Microsoft.ML.OnnxRuntime
                                       UserCallbackDelegate callback)
         {
             CallbackHost host = new CallbackHost(this, inputNames, inputValues, outputNames, outputValues, callback);
-            var host_hdl = GCHandle.Alloc(host, GCHandleType.Pinned);
+            var host_hdl = GCHandle.Alloc(host, GCHandleType.Normal);
 
             try
             {
@@ -1205,6 +1224,7 @@ namespace Microsoft.ML.OnnxRuntime
             }
             catch (OnnxRuntimeException)
             {
+                host.UnpinArrays();
                 host_hdl.Free();
                 throw;
             }

--- a/csharp/src/Microsoft.ML.OnnxRuntime/InferenceSession.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/InferenceSession.shared.cs
@@ -1186,7 +1186,7 @@ namespace Microsoft.ML.OnnxRuntime
                                       UserCallbackDelegate callback)
         {
             CallbackHost host = new CallbackHost(this, inputNames, inputValues, outputNames, outputValues, callback);
-            var host_hdl = GCHandle.Alloc(host, GCHandleType.Normal);
+            var host_hdl = GCHandle.Alloc(host, GCHandleType.Pinned);
 
             try
             {


### PR DESCRIPTION
### Description
Pin the raw IntPtr[] arrays inside CallbackHost to prevent GC from moving them while native OrtRunAsync holds raw pointers to them.



### Motivation and Context
InferenceSession.RunAsync rarely and randomly fails with access violation.  
```
Faulting module name: onnxruntime.dll, version: 1.26.26.508, time stamp: 0x69fdf731 
Exception code: 0xc0000005
Fault offset: 0x0000000000092274
```
OrtRunAsync submits async GPU work and returns immediately. Native ORT holds raw pointers to rawInputNames, rawInputValues, rawOutputNames, rawOutputValues for the duration of the async operation. GCHandle.Normal on CallbackHost prevents collection but not compaction, so GC can move the IntPtr[] arrays, leaving native ORT with stale pointers.

CallbackHost cannot be pinned directly because it holds non-blittable managed references. Instead, CallbackHost pins each IntPtr[] array separately in its constructor (IntPtr is blittable) and UnpinArrays() frees them in OrtCallback.finally alongside the existing hostHdl.Free().


