### PR TITLE
WebGPU: enable INT64 for Equal/Sub/Where/ReduceSum under enable_int64 flag to support Gemma4

### DIFF
--- a/onnxruntime/core/providers/webgpu/math/binary_elementwise_ops.cc
+++ b/onnxruntime/core/providers/webgpu/math/binary_elementwise_ops.cc
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <memory>
+
 #include "core/providers/common.h"
 #include "core/providers/webgpu/math/binary_elementwise_ops.h"
 #include "core/providers/webgpu/math/binary_elementwise_broadcast_utils.h"

--- a/onnxruntime/core/providers/webgpu/math/binary_elementwise_ops.cc
+++ b/onnxruntime/core/providers/webgpu/math/binary_elementwise_ops.cc
@@ -20,7 +20,7 @@ Status BinaryElementwiseProgram::GenerateShaderCode(ShaderHelper& shader) const 
 
   const bool a_is_bool = Inputs()[0].var_type == ProgramVariableDataType::Boolx4;
   const bool b_is_bool = Inputs()[1].var_type == ProgramVariableDataType::Boolx4;
-  const bool is_bool_output = Outputs()[0].var_type == ProgramVariableDataType::Boolx4;
+  const bool is_int64_output = is_int64_ && Outputs()[0].var_type != ProgramVariableDataType::Boolx4;
 
   shader.AdditionalImplementation() << additional_impl_;
 
@@ -29,56 +29,30 @@ Status BinaryElementwiseProgram::GenerateShaderCode(ShaderHelper& shader) const 
   // check whether can use element-wise mode.
   // If either A or B is scalar, or A and B have the same shape, element-wise mode can be used.
   // In element-wise mode, no indices calculation is needed.
-  const bool can_use_element_wise_mode = is_lhs_scalar_ || is_rhs_scalar_ || !is_broadcast_;
-  // INT64 with bool output (e.g. Equal) requires special handling: the output is packed 4-per-u32
-  // (Boolx4) but inputs are i32 per element (component=1). Each thread reads 4 consecutive input
-  // elements and packs the comparison results into one u32, with bounds guards for non-div-4 sizes.
-  // The non-scalar broadcast case (shapes differ, neither input scalar) falls through to the
-  // standard broadcast path below, which handles component=1 INT64 via vec4<i32>==vec4<i32>.
-  if (is_int64_ && is_bool_output && can_use_element_wise_mode) {
-    auto get_a = [&](const std::string& idx) {
-      return is_lhs_scalar_ ? a.GetByOffset("0") : a.GetByOffset(idx);
-    };
-    auto get_b = [&](const std::string& idx) {
-      return is_rhs_scalar_ ? b.GetByOffset("0") : b.GetByOffset(idx);
-    };
-    // Each thread processes 4 output bool elements packed into one u32.
-    // INT64 inputs are stored element-by-element (component=1), so we must guard
-    // lanes 1-3 against out-of-bounds reads when the tensor size is not a multiple of 4.
-    shader.MainFunctionBody()
-        << "let base = global_idx * 4u;\n"
-        << "let n = uniforms.element_count;\n"
-        << "let r0 = " << get_a("base") << " == " << get_b("base") << ";\n"
-        << "var r1 = false; var r2 = false; var r3 = false;\n"
-        << "if (base + 1u < n) { r1 = " << get_a("base + 1u") << " == " << get_b("base + 1u") << "; }\n"
-        << "if (base + 2u < n) { r2 = " << get_a("base + 2u") << " == " << get_b("base + 2u") << "; }\n"
-        << "if (base + 3u < n) { r3 = " << get_a("base + 3u") << " == " << get_b("base + 3u") << "; }\n"
-        << "let r = vec4<bool>(r0, r1, r2, r3);\n";
-    shader.MainFunctionBody() << c.SetByOffset("global_idx", "r");
-    return Status::OK();
-  }
-
-  // Same shape or scalar: read inputs at the flat output index, no broadcast index calculation.
-  if (can_use_element_wise_mode) {
+  if (is_lhs_scalar_ || is_rhs_scalar_ || !is_broadcast_) {
     // get A data
-    if (is_lhs_scalar_) {
-      if (is_int64_) {
-        // For INT64 with component=1, input_a_element_t is i32; GetByOffset already returns i32.
-        shader.MainFunctionBody() << "let a = " << a.GetByOffset("0") << ";\n";
-      } else {
-        shader.MainFunctionBody() << "let a = input_a_value_t(" << a.GetByOffset("0") << ".x);\n";
-      }
+    if (is_int64_) {
+      // INT64 inputs have component=1; read 4 individual elements into vec4 for uniform processing.
+      shader.MainFunctionBody() << "let a = vec4<input_a_value_t>("
+                                << a.GetByOffset(is_lhs_scalar_ ? "0" : "global_idx * 4u") << ", "
+                                << a.GetByOffset(is_lhs_scalar_ ? "0" : "global_idx * 4u + 1u") << ", "
+                                << a.GetByOffset(is_lhs_scalar_ ? "0" : "global_idx * 4u + 2u") << ", "
+                                << a.GetByOffset(is_lhs_scalar_ ? "0" : "global_idx * 4u + 3u") << ");\n";
+    } else if (is_lhs_scalar_) {
+      shader.MainFunctionBody() << "let a = input_a_value_t(" << a.GetByOffset("0") << ".x);\n";
     } else {
       shader.MainFunctionBody() << "let a = " << a.GetByOffset("global_idx") << ";\n";
     }
 
     // get B data
-    if (is_rhs_scalar_) {
-      if (is_int64_) {
-        shader.MainFunctionBody() << "let b = " << b.GetByOffset("0") << ";\n";
-      } else {
-        shader.MainFunctionBody() << "let b = input_b_value_t(" << b.GetByOffset("0") << ".x);\n";
-      }
+    if (is_int64_) {
+      shader.MainFunctionBody() << "let b = vec4<input_b_value_t>("
+                                << b.GetByOffset(is_rhs_scalar_ ? "0" : "global_idx * 4u") << ", "
+                                << b.GetByOffset(is_rhs_scalar_ ? "0" : "global_idx * 4u + 1u") << ", "
+                                << b.GetByOffset(is_rhs_scalar_ ? "0" : "global_idx * 4u + 2u") << ", "
+                                << b.GetByOffset(is_rhs_scalar_ ? "0" : "global_idx * 4u + 3u") << ");\n";
+    } else if (is_rhs_scalar_) {
+      shader.MainFunctionBody() << "let b = input_b_value_t(" << b.GetByOffset("0") << ".x);\n";
     } else {
       shader.MainFunctionBody() << "let b = " << b.GetByOffset("global_idx") << ";\n";
     }
@@ -115,8 +89,6 @@ Status BinaryElementwiseProgram::GenerateShaderCode(ShaderHelper& shader) const 
       }
     } else {
       // In broadcast mode, each element of the vec4 value of A and B will be loaded separately to calculate the output value.
-      // This path is also used by INT64 broadcast (component=1): each GetByOffset returns one i32 element,
-      // and the expression (e.g. vec4<i32>==vec4<i32>) produces correct vec4<bool> results.
       shader.MainFunctionBody() << "var outputIndices = " << c_indices.OffsetToIndices("global_idx * 4") << ";\n"
                                 << "let offset_a0 = " << a_indices.BroadcastedIndicesToOffset("outputIndices", c_indices) << ";\n"
                                 << "let offset_b0 = " << b_indices.BroadcastedIndicesToOffset("outputIndices", c_indices) << ";\n"
@@ -161,7 +133,18 @@ Status BinaryElementwiseProgram::GenerateShaderCode(ShaderHelper& shader) const 
     }
   }
 
-  shader.MainFunctionBody() << c.SetByOffset("global_idx", expression_);
+  if (is_int64_output) {
+    // INT64 output (component=1): write each component of the vec4 result individually.
+    shader.MainFunctionBody()
+        << "let result = " << expression_ << ";\n"
+        << "let n = uniforms.element_count;\n"
+        << c.SetByOffset("global_idx * 4u", "result[0]") << "\n"
+        << "if (global_idx * 4u + 1u < n) { " << c.SetByOffset("global_idx * 4u + 1u", "result[1]") << " }\n"
+        << "if (global_idx * 4u + 2u < n) { " << c.SetByOffset("global_idx * 4u + 2u", "result[2]") << " }\n"
+        << "if (global_idx * 4u + 3u < n) { " << c.SetByOffset("global_idx * 4u + 3u", "result[3]") << " }\n";
+  } else {
+    shader.MainFunctionBody() << c.SetByOffset("global_idx", expression_);
+  }
   return Status::OK();
 }
 
@@ -217,9 +200,9 @@ Status BinaryElementwise::ComputeInternal(ComputeContext& context) const {
   }
 
   bool is_output_int64 = output_tensor->GetElementType() == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64;
-  uint32_t vec_size = is_output_int64 ? onnxruntime::narrow<uint32_t>(size)
-                                      : onnxruntime::narrow<uint32_t>((size + 3) / 4);
+  uint32_t vec_size = onnxruntime::narrow<uint32_t>((size + 3) / 4);
   int output_component = is_output_int64 ? 1 : 4;
+  uint32_t output_size = is_output_int64 ? onnxruntime::narrow<uint32_t>(size) : vec_size;
 
   std::string additional_impl;
   if (get_additional_impl_) {
@@ -242,7 +225,7 @@ Status BinaryElementwise::ComputeInternal(ComputeContext& context) const {
           {static_cast<uint32_t>(vec_size)},
           {static_cast<uint32_t>(size)},
       })
-      .AddOutput({output_tensor, ProgramTensorMetadataDependency::Type, {vec_size}, output_component});
+      .AddOutput({output_tensor, ProgramTensorMetadataDependency::Type, {output_size}, output_component});
 
   if (is_lhs_scalar || is_rhs_scalar || !is_broadcast) {
     // Mode Element-wise

--- a/onnxruntime/core/providers/webgpu/math/binary_elementwise_ops.cc
+++ b/onnxruntime/core/providers/webgpu/math/binary_elementwise_ops.cc
@@ -29,14 +29,23 @@ Status BinaryElementwiseProgram::GenerateShaderCode(ShaderHelper& shader) const 
   if (is_lhs_scalar_ || is_rhs_scalar_ || !is_broadcast_) {
     // get A data
     if (is_lhs_scalar_) {
-      shader.MainFunctionBody() << "let a = input_a_value_t(" << a.GetByOffset("0") << ".x);\n";
+      if (is_int64_) {
+        // For INT64 with component=1, input_a_element_t is i32; GetByOffset already returns i32.
+        shader.MainFunctionBody() << "let a = " << a.GetByOffset("0") << ";\n";
+      } else {
+        shader.MainFunctionBody() << "let a = input_a_value_t(" << a.GetByOffset("0") << ".x);\n";
+      }
     } else {
       shader.MainFunctionBody() << "let a = " << a.GetByOffset("global_idx") << ";\n";
     }
 
     // get B data
     if (is_rhs_scalar_) {
-      shader.MainFunctionBody() << "let b = input_b_value_t(" << b.GetByOffset("0") << ".x);\n";
+      if (is_int64_) {
+        shader.MainFunctionBody() << "let b = " << b.GetByOffset("0") << ";\n";
+      } else {
+        shader.MainFunctionBody() << "let b = input_b_value_t(" << b.GetByOffset("0") << ".x);\n";
+      }
     } else {
       shader.MainFunctionBody() << "let b = " << b.GetByOffset("global_idx") << ";\n";
     }
@@ -145,12 +154,17 @@ Status BinaryElementwise::ComputeInternal(ComputeContext& context) const {
   bool is_lhs_bool = lhs_tensor->GetElementType() == ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL;
   bool is_rhs_bool = rhs_tensor->GetElementType() == ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL;
 
-  bool vectorize = is_lhs_scalar || is_rhs_scalar || !is_broadcast;
+  // INT64 has no vec4 representation in WebGPU (stored as vec2<u32>), so disable vectorization.
+  bool is_lhs_int64 = lhs_tensor->GetElementType() == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64;
+  bool is_rhs_int64 = rhs_tensor->GetElementType() == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64;
+  bool is_int64 = is_lhs_int64 || is_rhs_int64;
+
+  bool vectorize = !is_int64 && (is_lhs_scalar || is_rhs_scalar || !is_broadcast);
   bool a_last_dim_divisible_by_4 = false;
   bool b_last_dim_divisible_by_4 = false;
   bool shared_dimension_divisible_by_4 = false;
   size_t num_shared_dimension = 0;
-  if (!vectorize) {
+  if (!is_int64 && !vectorize) {
     // check whether vectorize can be enabled
     a_last_dim_divisible_by_4 = lhs_shape.NumDimensions() > 0 && lhs_shape[lhs_shape.NumDimensions() - 1] % 4 == 0;
     b_last_dim_divisible_by_4 = rhs_shape.NumDimensions() > 0 && rhs_shape[rhs_shape.NumDimensions() - 1] % 4 == 0;
@@ -167,7 +181,10 @@ Status BinaryElementwise::ComputeInternal(ComputeContext& context) const {
     }
   }
 
-  uint32_t vec_size = onnxruntime::narrow<uint32_t>((size + 3) / 4);
+  bool is_output_int64 = output_tensor->GetElementType() == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64;
+  uint32_t vec_size = is_output_int64 ? onnxruntime::narrow<uint32_t>(size)
+                                      : onnxruntime::narrow<uint32_t>((size + 3) / 4);
+  int output_component = is_output_int64 ? 1 : 4;
 
   std::string additional_impl;
   if (get_additional_impl_) {
@@ -182,20 +199,21 @@ Status BinaryElementwise::ComputeInternal(ComputeContext& context) const {
                                    is_rhs_scalar,
                                    shared_dimension_divisible_by_4 || a_last_dim_divisible_by_4,
                                    shared_dimension_divisible_by_4 || b_last_dim_divisible_by_4,
-                                   vectorize};
+                                   vectorize,
+                                   is_int64};
   program
       .SetDispatchGroupSize((vec_size + WORKGROUP_SIZE - 1) / WORKGROUP_SIZE)
       .AddUniformVariables({
           {static_cast<uint32_t>(vec_size)},
       })
-      .AddOutput({output_tensor, ProgramTensorMetadataDependency::Type, {vec_size}, 4});
+      .AddOutput({output_tensor, ProgramTensorMetadataDependency::Type, {vec_size}, output_component});
 
-  if (is_lhs_scalar || is_rhs_scalar || !is_broadcast) {
-    // Mode Element-wise
+  if (is_int64 || is_lhs_scalar || is_rhs_scalar || !is_broadcast) {
+    // Mode Element-wise (also used for INT64 which has no vec4 representation)
     // cache hint: "E{is_a_scalar}{is_b_scalar}"
     program
-        .AddInputs({{lhs_tensor, ProgramTensorMetadataDependency::Type, ProgramInput::Flatten, 4},
-                    {rhs_tensor, ProgramTensorMetadataDependency::Type, ProgramInput::Flatten, 4}})
+        .AddInputs({{lhs_tensor, ProgramTensorMetadataDependency::Type, ProgramInput::Flatten, is_int64 ? 1 : 4},
+                    {rhs_tensor, ProgramTensorMetadataDependency::Type, ProgramInput::Flatten, is_int64 ? 1 : 4}})
         .CacheHint("E" + std::to_string(is_lhs_scalar) + std::to_string(is_rhs_scalar));
   } else if (vectorize) {
     // reshape the dims to merge the shared dimension if available

--- a/onnxruntime/core/providers/webgpu/math/binary_elementwise_ops.cc
+++ b/onnxruntime/core/providers/webgpu/math/binary_elementwise_ops.cc
@@ -307,6 +307,9 @@ WEBGPU_BINARY_KERNEL(Mul, 14, Mul, WebGpuSupportedNumberTypes())
 
 WEBGPU_BINARY_IMPL(Sub, "a - b")
 
+// NOTE: int64 arithmetic in the WebGPU shader operates on the low 32 bits only (i32 element type).
+// Values outside the int32 range [-2^31, 2^31-1] will produce incorrect results.
+// This matches the same limitation documented in Range and is acceptable for token-position workloads.
 template <int StartVersion, int EndVersion>
 KernelCreateInfo CreateSubVersionedKernelInfo(bool enable_int64) {
   const auto& type_constraints = GetOpTypeConstraints(enable_int64, false);
@@ -386,6 +389,8 @@ WEBGPU_BINARY_KERNEL_2(Pow, 15, Pow, WebGpuSupportedNumberTypes(), WebGpuSupport
 
 WEBGPU_BINARY_IMPL(Equal, "vec4<u32>(vec4<input_a_element_t>(a) == vec4<input_b_element_t>(b))")
 
+// NOTE: int64 comparison in the WebGPU shader uses i32 element type (low 32 bits only).
+// Values outside the int32 range will produce incorrect results.
 template <int StartVersion, int EndVersion>
 KernelCreateInfo CreateEqualVersionedKernelInfo(bool enable_int64) {
   const auto& type_constraints = GetOpTypeConstraints(enable_int64, false);

--- a/onnxruntime/core/providers/webgpu/math/binary_elementwise_ops.cc
+++ b/onnxruntime/core/providers/webgpu/math/binary_elementwise_ops.cc
@@ -20,7 +20,6 @@ Status BinaryElementwiseProgram::GenerateShaderCode(ShaderHelper& shader) const 
 
   const bool a_is_bool = Inputs()[0].var_type == ProgramVariableDataType::Boolx4;
   const bool b_is_bool = Inputs()[1].var_type == ProgramVariableDataType::Boolx4;
-  const bool is_int64_output = is_int64_ && Outputs()[0].var_type != ProgramVariableDataType::Boolx4;
 
   shader.AdditionalImplementation() << additional_impl_;
 
@@ -30,31 +29,41 @@ Status BinaryElementwiseProgram::GenerateShaderCode(ShaderHelper& shader) const 
   // If either A or B is scalar, or A and B have the same shape, element-wise mode can be used.
   // In element-wise mode, no indices calculation is needed.
   if (is_lhs_scalar_ || is_rhs_scalar_ || !is_broadcast_) {
-    // get A data
-    if (is_int64_) {
+    if (is_int64_input_) {
       // INT64 inputs have component=1; read 4 individual elements into vec4 for uniform processing.
-      shader.MainFunctionBody() << "let a = vec4<input_a_value_t>("
-                                << a.GetByOffset(is_lhs_scalar_ ? "0" : "global_idx * 4u") << ", "
-                                << a.GetByOffset(is_lhs_scalar_ ? "0" : "global_idx * 4u + 1u") << ", "
-                                << a.GetByOffset(is_lhs_scalar_ ? "0" : "global_idx * 4u + 2u") << ", "
-                                << a.GetByOffset(is_lhs_scalar_ ? "0" : "global_idx * 4u + 3u") << ");\n";
-    } else if (is_lhs_scalar_) {
-      shader.MainFunctionBody() << "let a = input_a_value_t(" << a.GetByOffset("0") << ".x);\n";
+      // Guard lanes 1-3 against OOB reads when size is not divisible by 4.
+      const auto a_offset = [&](const std::string& idx) {
+        return is_lhs_scalar_ ? a.GetByOffset("0") : a.GetByOffset(idx);
+      };
+      const auto b_offset = [&](const std::string& idx) {
+        return is_rhs_scalar_ ? b.GetByOffset("0") : b.GetByOffset(idx);
+      };
+      shader.MainFunctionBody()
+          << "let base = global_idx * 4u;\n"
+          << "let n = uniforms.element_count;\n"
+          << "var a0 = " << a_offset("base") << ";\n"
+          << "var b0 = " << b_offset("base") << ";\n"
+          << "var a1 = input_a_value_t(0); var a2 = input_a_value_t(0); var a3 = input_a_value_t(0);\n"
+          << "var b1 = input_b_value_t(0); var b2 = input_b_value_t(0); var b3 = input_b_value_t(0);\n"
+          << "if (base + 1u < n) { a1 = " << a_offset("base + 1u") << "; b1 = " << b_offset("base + 1u") << "; }\n"
+          << "if (base + 2u < n) { a2 = " << a_offset("base + 2u") << "; b2 = " << b_offset("base + 2u") << "; }\n"
+          << "if (base + 3u < n) { a3 = " << a_offset("base + 3u") << "; b3 = " << b_offset("base + 3u") << "; }\n"
+          << "let a = vec4<input_a_value_t>(a0, a1, a2, a3);\n"
+          << "let b = vec4<input_b_value_t>(b0, b1, b2, b3);\n";
     } else {
-      shader.MainFunctionBody() << "let a = " << a.GetByOffset("global_idx") << ";\n";
-    }
+      // get A data
+      if (is_lhs_scalar_) {
+        shader.MainFunctionBody() << "let a = input_a_value_t(" << a.GetByOffset("0") << ".x);\n";
+      } else {
+        shader.MainFunctionBody() << "let a = " << a.GetByOffset("global_idx") << ";\n";
+      }
 
-    // get B data
-    if (is_int64_) {
-      shader.MainFunctionBody() << "let b = vec4<input_b_value_t>("
-                                << b.GetByOffset(is_rhs_scalar_ ? "0" : "global_idx * 4u") << ", "
-                                << b.GetByOffset(is_rhs_scalar_ ? "0" : "global_idx * 4u + 1u") << ", "
-                                << b.GetByOffset(is_rhs_scalar_ ? "0" : "global_idx * 4u + 2u") << ", "
-                                << b.GetByOffset(is_rhs_scalar_ ? "0" : "global_idx * 4u + 3u") << ");\n";
-    } else if (is_rhs_scalar_) {
-      shader.MainFunctionBody() << "let b = input_b_value_t(" << b.GetByOffset("0") << ".x);\n";
-    } else {
-      shader.MainFunctionBody() << "let b = " << b.GetByOffset("global_idx") << ";\n";
+      // get B data
+      if (is_rhs_scalar_) {
+        shader.MainFunctionBody() << "let b = input_b_value_t(" << b.GetByOffset("0") << ".x);\n";
+      } else {
+        shader.MainFunctionBody() << "let b = " << b.GetByOffset("global_idx") << ";\n";
+      }
     }
   } else {
     const auto& c_indices = shader.AddIndices("bcast_indices");
@@ -133,7 +142,7 @@ Status BinaryElementwiseProgram::GenerateShaderCode(ShaderHelper& shader) const 
     }
   }
 
-  if (is_int64_output) {
+  if (is_int64_output_) {
     // INT64 output (component=1): write each component of the vec4 result individually.
     shader.MainFunctionBody()
         << "let result = " << expression_ << ";\n"
@@ -175,14 +184,14 @@ Status BinaryElementwise::ComputeInternal(ComputeContext& context) const {
   // INT64 has no vec4 representation in WebGPU (stored as vec2<u32>), so disable vectorization.
   bool is_lhs_int64 = lhs_tensor->GetElementType() == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64;
   bool is_rhs_int64 = rhs_tensor->GetElementType() == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64;
-  bool is_int64 = is_lhs_int64 || is_rhs_int64;
+  bool is_int64_input = is_lhs_int64 || is_rhs_int64;
 
-  bool vectorize = !is_int64 && (is_lhs_scalar || is_rhs_scalar || !is_broadcast);
+  bool vectorize = !is_int64_input && (is_lhs_scalar || is_rhs_scalar || !is_broadcast);
   bool a_last_dim_divisible_by_4 = false;
   bool b_last_dim_divisible_by_4 = false;
   bool shared_dimension_divisible_by_4 = false;
   size_t num_shared_dimension = 0;
-  if (!is_int64 && !vectorize) {
+  if (!is_int64_input && !vectorize) {
     // check whether vectorize can be enabled
     a_last_dim_divisible_by_4 = lhs_shape.NumDimensions() > 0 && lhs_shape[lhs_shape.NumDimensions() - 1] % 4 == 0;
     b_last_dim_divisible_by_4 = rhs_shape.NumDimensions() > 0 && rhs_shape[rhs_shape.NumDimensions() - 1] % 4 == 0;
@@ -199,10 +208,10 @@ Status BinaryElementwise::ComputeInternal(ComputeContext& context) const {
     }
   }
 
-  bool is_output_int64 = output_tensor->GetElementType() == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64;
+  bool is_int64_output = output_tensor->GetElementType() == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64;
   uint32_t vec_size = onnxruntime::narrow<uint32_t>((size + 3) / 4);
-  int output_component = is_output_int64 ? 1 : 4;
-  uint32_t output_size = is_output_int64 ? onnxruntime::narrow<uint32_t>(size) : vec_size;
+  int output_component = is_int64_output ? 1 : 4;
+  uint32_t output_size = is_int64_output ? onnxruntime::narrow<uint32_t>(size) : vec_size;
 
   std::string additional_impl;
   if (get_additional_impl_) {
@@ -218,7 +227,8 @@ Status BinaryElementwise::ComputeInternal(ComputeContext& context) const {
                                    shared_dimension_divisible_by_4 || a_last_dim_divisible_by_4,
                                    shared_dimension_divisible_by_4 || b_last_dim_divisible_by_4,
                                    vectorize,
-                                   is_int64};
+                                   is_int64_input,
+                                   is_int64_output};
   program
       .SetDispatchGroupSize((vec_size + WORKGROUP_SIZE - 1) / WORKGROUP_SIZE)
       .AddUniformVariables({
@@ -231,8 +241,8 @@ Status BinaryElementwise::ComputeInternal(ComputeContext& context) const {
     // Mode Element-wise
     // cache hint: "E{is_a_scalar}{is_b_scalar}"
     program
-        .AddInputs({{lhs_tensor, ProgramTensorMetadataDependency::Type, ProgramInput::Flatten, is_int64 ? 1 : 4},
-                    {rhs_tensor, ProgramTensorMetadataDependency::Type, ProgramInput::Flatten, is_int64 ? 1 : 4}})
+        .AddInputs({{lhs_tensor, ProgramTensorMetadataDependency::Type, ProgramInput::Flatten, is_int64_input ? 1 : 4},
+                    {rhs_tensor, ProgramTensorMetadataDependency::Type, ProgramInput::Flatten, is_int64_input ? 1 : 4}})
         .CacheHint("E" + std::to_string(is_lhs_scalar) + std::to_string(is_rhs_scalar));
   } else if (vectorize) {
     // reshape the dims to merge the shared dimension if available

--- a/onnxruntime/core/providers/webgpu/math/binary_elementwise_ops.cc
+++ b/onnxruntime/core/providers/webgpu/math/binary_elementwise_ops.cc
@@ -38,13 +38,18 @@ Status BinaryElementwiseProgram::GenerateShaderCode(ShaderHelper& shader) const 
       auto get_b = [&](const std::string& idx) {
         return is_rhs_scalar_ ? b.GetByOffset("0") : b.GetByOffset(idx);
       };
+      // Each thread processes 4 output bool elements packed into one u32.
+      // INT64 inputs are stored element-by-element (component=1), so we must guard
+      // lanes 1-3 against out-of-bounds reads when the tensor size is not a multiple of 4.
       shader.MainFunctionBody()
           << "let base = global_idx * 4u;\n"
-          << "let r = vec4<bool>("
-          << get_a("base") << " == " << get_b("base") << ", "
-          << get_a("base + 1u") << " == " << get_b("base + 1u") << ", "
-          << get_a("base + 2u") << " == " << get_b("base + 2u") << ", "
-          << get_a("base + 3u") << " == " << get_b("base + 3u") << ");\n";
+          << "let n = uniforms.element_count;\n"
+          << "let r0 = " << get_a("base") << " == " << get_b("base") << ";\n"
+          << "var r1 = false; var r2 = false; var r3 = false;\n"
+          << "if (base + 1u < n) { r1 = " << get_a("base + 1u") << " == " << get_b("base + 1u") << "; }\n"
+          << "if (base + 2u < n) { r2 = " << get_a("base + 2u") << " == " << get_b("base + 2u") << "; }\n"
+          << "if (base + 3u < n) { r3 = " << get_a("base + 3u") << " == " << get_b("base + 3u") << "; }\n"
+          << "let r = vec4<bool>(r0, r1, r2, r3);\n";
       shader.MainFunctionBody() << c.SetByOffset("global_idx", "r");
       return Status::OK();
     }
@@ -227,6 +232,7 @@ Status BinaryElementwise::ComputeInternal(ComputeContext& context) const {
       .SetDispatchGroupSize((vec_size + WORKGROUP_SIZE - 1) / WORKGROUP_SIZE)
       .AddUniformVariables({
           {static_cast<uint32_t>(vec_size)},
+          {static_cast<uint32_t>(size)},
       })
       .AddOutput({output_tensor, ProgramTensorMetadataDependency::Type, {vec_size}, output_component});
 

--- a/onnxruntime/core/providers/webgpu/math/binary_elementwise_ops.cc
+++ b/onnxruntime/core/providers/webgpu/math/binary_elementwise_ops.cc
@@ -115,6 +115,8 @@ Status BinaryElementwiseProgram::GenerateShaderCode(ShaderHelper& shader) const 
       }
     } else {
       // In broadcast mode, each element of the vec4 value of A and B will be loaded separately to calculate the output value.
+      // This path is also used by INT64 broadcast (component=1): each GetByOffset returns one i32 element,
+      // and the expression (e.g. vec4<i32>==vec4<i32>) produces correct vec4<bool> results.
       shader.MainFunctionBody() << "var outputIndices = " << c_indices.OffsetToIndices("global_idx * 4") << ";\n"
                                 << "let offset_a0 = " << a_indices.BroadcastedIndicesToOffset("outputIndices", c_indices) << ";\n"
                                 << "let offset_b0 = " << b_indices.BroadcastedIndicesToOffset("outputIndices", c_indices) << ";\n"

--- a/onnxruntime/core/providers/webgpu/math/binary_elementwise_ops.cc
+++ b/onnxruntime/core/providers/webgpu/math/binary_elementwise_ops.cc
@@ -7,6 +7,7 @@
 #include "core/providers/webgpu/shader_helper.h"
 #include "core/providers/webgpu/string_macros.h"
 #include "core/providers/webgpu/webgpu_supported_types.h"
+#include "core/providers/webgpu/webgpu_execution_provider.h"
 
 namespace onnxruntime {
 namespace webgpu {
@@ -306,9 +307,44 @@ WEBGPU_BINARY_VERSIONED_KERNEL(Mul, 13, 13, Mul, WebGpuSupportedNumberTypes())
 WEBGPU_BINARY_KERNEL(Mul, 14, Mul, WebGpuSupportedNumberTypes())
 
 WEBGPU_BINARY_IMPL(Sub, "a - b")
-WEBGPU_BINARY_VERSIONED_KERNEL(Sub, 7, 12, Sub, WebGpuSupportedNumberTypes())
-WEBGPU_BINARY_VERSIONED_KERNEL(Sub, 13, 13, Sub, WebGpuSupportedNumberTypes())
-WEBGPU_BINARY_KERNEL(Sub, 14, Sub, WebGpuSupportedNumberTypes())
+
+template <int StartVersion, int EndVersion>
+KernelCreateInfo CreateSubVersionedKernelInfo(bool enable_int64) {
+  const auto& type_constraints = GetOpTypeConstraints(enable_int64, false);
+  KernelCreatePtrFn kernel_create_fn = [](FuncManager&, const OpKernelInfo& info, std::unique_ptr<OpKernel>& out) -> Status {
+    out = std::make_unique<Sub>(info);
+    return Status::OK();
+  };
+  return {KernelDefBuilder()
+              .SetName("Sub")
+              .SetDomain(kOnnxDomain)
+              .SinceVersion(StartVersion, EndVersion)
+              .Provider(kWebGpuExecutionProvider)
+              .TypeConstraint("T", type_constraints)
+              .Build(),
+          kernel_create_fn};
+}
+
+template <int SinceVersion>
+KernelCreateInfo CreateSubKernelInfo(bool enable_int64) {
+  const auto& type_constraints = GetOpTypeConstraints(enable_int64, false);
+  KernelCreatePtrFn kernel_create_fn = [](FuncManager&, const OpKernelInfo& info, std::unique_ptr<OpKernel>& out) -> Status {
+    out = std::make_unique<Sub>(info);
+    return Status::OK();
+  };
+  return {KernelDefBuilder()
+              .SetName("Sub")
+              .SetDomain(kOnnxDomain)
+              .SinceVersion(SinceVersion)
+              .Provider(kWebGpuExecutionProvider)
+              .TypeConstraint("T", type_constraints)
+              .Build(),
+          kernel_create_fn};
+}
+
+template KernelCreateInfo CreateSubVersionedKernelInfo<7, 12>(bool);
+template KernelCreateInfo CreateSubVersionedKernelInfo<13, 13>(bool);
+template KernelCreateInfo CreateSubKernelInfo<14>(bool);
 
 std::string GetPowImpl(int lhs_element_type, int /* rhs_element_type */) {
   SS(s, 1024);
@@ -350,10 +386,45 @@ WEBGPU_BINARY_VERSIONED_KERNEL_2(Pow, 13, 14, Pow, WebGpuSupportedNumberTypes(),
 WEBGPU_BINARY_KERNEL_2(Pow, 15, Pow, WebGpuSupportedNumberTypes(), WebGpuSupportedNumberTypes())
 
 WEBGPU_BINARY_IMPL(Equal, "vec4<u32>(vec4<input_a_element_t>(a) == vec4<input_b_element_t>(b))")
-WEBGPU_BINARY_VERSIONED_KERNEL(Equal, 7, 10, Equal, WebGpuSupportedNumberTypes())
-WEBGPU_BINARY_VERSIONED_KERNEL(Equal, 11, 12, Equal, WebGpuSupportedNumberTypes())
-WEBGPU_BINARY_VERSIONED_KERNEL(Equal, 13, 18, Equal, WebGpuSupportedNumberTypes())
-WEBGPU_BINARY_KERNEL(Equal, 19, Equal, WebGpuSupportedNumberTypes())
+
+template <int StartVersion, int EndVersion>
+KernelCreateInfo CreateEqualVersionedKernelInfo(bool enable_int64) {
+  const auto& type_constraints = GetOpTypeConstraints(enable_int64, false);
+  KernelCreatePtrFn kernel_create_fn = [](FuncManager&, const OpKernelInfo& info, std::unique_ptr<OpKernel>& out) -> Status {
+    out = std::make_unique<Equal>(info);
+    return Status::OK();
+  };
+  return {KernelDefBuilder()
+              .SetName("Equal")
+              .SetDomain(kOnnxDomain)
+              .SinceVersion(StartVersion, EndVersion)
+              .Provider(kWebGpuExecutionProvider)
+              .TypeConstraint("T", type_constraints)
+              .Build(),
+          kernel_create_fn};
+}
+
+template <int SinceVersion>
+KernelCreateInfo CreateEqualKernelInfo(bool enable_int64) {
+  const auto& type_constraints = GetOpTypeConstraints(enable_int64, false);
+  KernelCreatePtrFn kernel_create_fn = [](FuncManager&, const OpKernelInfo& info, std::unique_ptr<OpKernel>& out) -> Status {
+    out = std::make_unique<Equal>(info);
+    return Status::OK();
+  };
+  return {KernelDefBuilder()
+              .SetName("Equal")
+              .SetDomain(kOnnxDomain)
+              .SinceVersion(SinceVersion)
+              .Provider(kWebGpuExecutionProvider)
+              .TypeConstraint("T", type_constraints)
+              .Build(),
+          kernel_create_fn};
+}
+
+template KernelCreateInfo CreateEqualVersionedKernelInfo<7, 10>(bool);
+template KernelCreateInfo CreateEqualVersionedKernelInfo<11, 12>(bool);
+template KernelCreateInfo CreateEqualVersionedKernelInfo<13, 18>(bool);
+template KernelCreateInfo CreateEqualKernelInfo<19>(bool);
 
 WEBGPU_BINARY_IMPL(Greater, "vec4<u32>(vec4<input_a_element_t>(a) > vec4<input_b_element_t>(b))")
 WEBGPU_BINARY_VERSIONED_KERNEL(Greater, 7, 8, Greater, WebGpuSupportedNumberTypes())

--- a/onnxruntime/core/providers/webgpu/math/binary_elementwise_ops.cc
+++ b/onnxruntime/core/providers/webgpu/math/binary_elementwise_ops.cc
@@ -26,7 +26,29 @@ Status BinaryElementwiseProgram::GenerateShaderCode(ShaderHelper& shader) const 
   // check whether can use element-wise mode.
   // If either A or B is scalar, or A and B have the same shape, element-wise mode can be used.
   // In element-wise mode, no indices calculation is needed.
+  const bool is_bool_output = Outputs()[0].var_type == ProgramVariableDataType::Boolx4;
+
   if (is_lhs_scalar_ || is_rhs_scalar_ || !is_broadcast_) {
+    // INT64 inputs with bool output: output is packed 4-per-u32, but inputs are scalar i32 per element.
+    // Read 4 consecutive elements per thread and pack them together.
+    if (is_int64_ && is_bool_output) {
+      auto get_a = [&](const std::string& idx) {
+        return is_lhs_scalar_ ? a.GetByOffset("0") : a.GetByOffset(idx);
+      };
+      auto get_b = [&](const std::string& idx) {
+        return is_rhs_scalar_ ? b.GetByOffset("0") : b.GetByOffset(idx);
+      };
+      shader.MainFunctionBody()
+          << "let base = global_idx * 4u;\n"
+          << "let r = vec4<bool>("
+          << get_a("base") << " == " << get_b("base") << ", "
+          << get_a("base + 1u") << " == " << get_b("base + 1u") << ", "
+          << get_a("base + 2u") << " == " << get_b("base + 2u") << ", "
+          << get_a("base + 3u") << " == " << get_b("base + 3u") << ");\n";
+      shader.MainFunctionBody() << c.SetByOffset("global_idx", "r");
+      return Status::OK();
+    }
+
     // get A data
     if (is_lhs_scalar_) {
       if (is_int64_) {

--- a/onnxruntime/core/providers/webgpu/math/binary_elementwise_ops.cc
+++ b/onnxruntime/core/providers/webgpu/math/binary_elementwise_ops.cc
@@ -7,7 +7,6 @@
 #include "core/providers/webgpu/shader_helper.h"
 #include "core/providers/webgpu/string_macros.h"
 #include "core/providers/webgpu/webgpu_supported_types.h"
-#include "core/providers/webgpu/webgpu_execution_provider.h"
 
 namespace onnxruntime {
 namespace webgpu {

--- a/onnxruntime/core/providers/webgpu/math/binary_elementwise_ops.cc
+++ b/onnxruntime/core/providers/webgpu/math/binary_elementwise_ops.cc
@@ -146,11 +146,11 @@ Status BinaryElementwiseProgram::GenerateShaderCode(ShaderHelper& shader) const 
     // INT64 output (component=1): write each component of the vec4 result individually.
     shader.MainFunctionBody()
         << "let result = " << expression_ << ";\n"
-        << "let n = uniforms.element_count;\n"
+        << "let output_size = uniforms.element_count;\n"
         << c.SetByOffset("global_idx * 4u", "result[0]") << "\n"
-        << "if (global_idx * 4u + 1u < n) { " << c.SetByOffset("global_idx * 4u + 1u", "result[1]") << " }\n"
-        << "if (global_idx * 4u + 2u < n) { " << c.SetByOffset("global_idx * 4u + 2u", "result[2]") << " }\n"
-        << "if (global_idx * 4u + 3u < n) { " << c.SetByOffset("global_idx * 4u + 3u", "result[3]") << " }\n";
+        << "if (global_idx * 4u + 1u < output_size) { " << c.SetByOffset("global_idx * 4u + 1u", "result[1]") << " }\n"
+        << "if (global_idx * 4u + 2u < output_size) { " << c.SetByOffset("global_idx * 4u + 2u", "result[2]") << " }\n"
+        << "if (global_idx * 4u + 3u < output_size) { " << c.SetByOffset("global_idx * 4u + 3u", "result[3]") << " }\n";
   } else {
     shader.MainFunctionBody() << c.SetByOffset("global_idx", expression_);
   }

--- a/onnxruntime/core/providers/webgpu/math/binary_elementwise_ops.cc
+++ b/onnxruntime/core/providers/webgpu/math/binary_elementwise_ops.cc
@@ -20,6 +20,7 @@ Status BinaryElementwiseProgram::GenerateShaderCode(ShaderHelper& shader) const 
 
   const bool a_is_bool = Inputs()[0].var_type == ProgramVariableDataType::Boolx4;
   const bool b_is_bool = Inputs()[1].var_type == ProgramVariableDataType::Boolx4;
+  const bool is_bool_output = Outputs()[0].var_type == ProgramVariableDataType::Boolx4;
 
   shader.AdditionalImplementation() << additional_impl_;
 
@@ -28,34 +29,37 @@ Status BinaryElementwiseProgram::GenerateShaderCode(ShaderHelper& shader) const 
   // check whether can use element-wise mode.
   // If either A or B is scalar, or A and B have the same shape, element-wise mode can be used.
   // In element-wise mode, no indices calculation is needed.
-  const bool is_bool_output = Outputs()[0].var_type == ProgramVariableDataType::Boolx4;
+  const bool can_use_element_wise_mode = is_lhs_scalar_ || is_rhs_scalar_ || !is_broadcast_;
+  // INT64 with bool output (e.g. Equal) requires special handling: the output is packed 4-per-u32
+  // (Boolx4) but inputs are i32 per element (component=1). Each thread reads 4 consecutive input
+  // elements and packs the comparison results into one u32, with bounds guards for non-div-4 sizes.
+  // The non-scalar broadcast case (shapes differ, neither input scalar) falls through to the
+  // standard broadcast path below, which handles component=1 INT64 via vec4<i32>==vec4<i32>.
+  if (is_int64_ && is_bool_output && can_use_element_wise_mode) {
+    auto get_a = [&](const std::string& idx) {
+      return is_lhs_scalar_ ? a.GetByOffset("0") : a.GetByOffset(idx);
+    };
+    auto get_b = [&](const std::string& idx) {
+      return is_rhs_scalar_ ? b.GetByOffset("0") : b.GetByOffset(idx);
+    };
+    // Each thread processes 4 output bool elements packed into one u32.
+    // INT64 inputs are stored element-by-element (component=1), so we must guard
+    // lanes 1-3 against out-of-bounds reads when the tensor size is not a multiple of 4.
+    shader.MainFunctionBody()
+        << "let base = global_idx * 4u;\n"
+        << "let n = uniforms.element_count;\n"
+        << "let r0 = " << get_a("base") << " == " << get_b("base") << ";\n"
+        << "var r1 = false; var r2 = false; var r3 = false;\n"
+        << "if (base + 1u < n) { r1 = " << get_a("base + 1u") << " == " << get_b("base + 1u") << "; }\n"
+        << "if (base + 2u < n) { r2 = " << get_a("base + 2u") << " == " << get_b("base + 2u") << "; }\n"
+        << "if (base + 3u < n) { r3 = " << get_a("base + 3u") << " == " << get_b("base + 3u") << "; }\n"
+        << "let r = vec4<bool>(r0, r1, r2, r3);\n";
+    shader.MainFunctionBody() << c.SetByOffset("global_idx", "r");
+    return Status::OK();
+  }
 
-  if (is_lhs_scalar_ || is_rhs_scalar_ || !is_broadcast_) {
-    // INT64 inputs with bool output: output is packed 4-per-u32, but inputs are scalar i32 per element.
-    // Read 4 consecutive elements per thread and pack them together.
-    if (is_int64_ && is_bool_output) {
-      auto get_a = [&](const std::string& idx) {
-        return is_lhs_scalar_ ? a.GetByOffset("0") : a.GetByOffset(idx);
-      };
-      auto get_b = [&](const std::string& idx) {
-        return is_rhs_scalar_ ? b.GetByOffset("0") : b.GetByOffset(idx);
-      };
-      // Each thread processes 4 output bool elements packed into one u32.
-      // INT64 inputs are stored element-by-element (component=1), so we must guard
-      // lanes 1-3 against out-of-bounds reads when the tensor size is not a multiple of 4.
-      shader.MainFunctionBody()
-          << "let base = global_idx * 4u;\n"
-          << "let n = uniforms.element_count;\n"
-          << "let r0 = " << get_a("base") << " == " << get_b("base") << ";\n"
-          << "var r1 = false; var r2 = false; var r3 = false;\n"
-          << "if (base + 1u < n) { r1 = " << get_a("base + 1u") << " == " << get_b("base + 1u") << "; }\n"
-          << "if (base + 2u < n) { r2 = " << get_a("base + 2u") << " == " << get_b("base + 2u") << "; }\n"
-          << "if (base + 3u < n) { r3 = " << get_a("base + 3u") << " == " << get_b("base + 3u") << "; }\n"
-          << "let r = vec4<bool>(r0, r1, r2, r3);\n";
-      shader.MainFunctionBody() << c.SetByOffset("global_idx", "r");
-      return Status::OK();
-    }
-
+  // Same shape or scalar: read inputs at the flat output index, no broadcast index calculation.
+  if (can_use_element_wise_mode) {
     // get A data
     if (is_lhs_scalar_) {
       if (is_int64_) {
@@ -238,8 +242,8 @@ Status BinaryElementwise::ComputeInternal(ComputeContext& context) const {
       })
       .AddOutput({output_tensor, ProgramTensorMetadataDependency::Type, {vec_size}, output_component});
 
-  if (is_int64 || is_lhs_scalar || is_rhs_scalar || !is_broadcast) {
-    // Mode Element-wise (also used for INT64 which has no vec4 representation)
+  if (is_lhs_scalar || is_rhs_scalar || !is_broadcast) {
+    // Mode Element-wise
     // cache hint: "E{is_a_scalar}{is_b_scalar}"
     program
         .AddInputs({{lhs_tensor, ProgramTensorMetadataDependency::Type, ProgramInput::Flatten, is_int64 ? 1 : 4},

--- a/onnxruntime/core/providers/webgpu/math/binary_elementwise_ops.cc
+++ b/onnxruntime/core/providers/webgpu/math/binary_elementwise_ops.cc
@@ -25,6 +25,13 @@ Status BinaryElementwiseProgram::GenerateShaderCode(ShaderHelper& shader) const 
 
   shader.MainFunctionBody() << shader.GuardAgainstOutOfBoundsWorkgroupSizes("uniforms.vec_size");
 
+  if (is_int64_input_ || is_int64_output_) {
+    // INT64 input or output (component=1): declare shared base and element_count for use in the shader.
+    shader.MainFunctionBody()
+        << "let base = global_idx * 4u;\n"
+        << "let element_count = uniforms.element_count;\n";
+  }
+
   // check whether can use element-wise mode.
   // If either A or B is scalar, or A and B have the same shape, element-wise mode can be used.
   // In element-wise mode, no indices calculation is needed.
@@ -39,15 +46,13 @@ Status BinaryElementwiseProgram::GenerateShaderCode(ShaderHelper& shader) const 
         return is_rhs_scalar_ ? b.GetByOffset("0") : b.GetByOffset(idx);
       };
       shader.MainFunctionBody()
-          << "let base = global_idx * 4u;\n"
-          << "let n = uniforms.element_count;\n"
           << "var a0 = " << a_offset("base") << ";\n"
           << "var b0 = " << b_offset("base") << ";\n"
           << "var a1 = input_a_value_t(0); var a2 = input_a_value_t(0); var a3 = input_a_value_t(0);\n"
           << "var b1 = input_b_value_t(0); var b2 = input_b_value_t(0); var b3 = input_b_value_t(0);\n"
-          << "if (base + 1u < n) { a1 = " << a_offset("base + 1u") << "; b1 = " << b_offset("base + 1u") << "; }\n"
-          << "if (base + 2u < n) { a2 = " << a_offset("base + 2u") << "; b2 = " << b_offset("base + 2u") << "; }\n"
-          << "if (base + 3u < n) { a3 = " << a_offset("base + 3u") << "; b3 = " << b_offset("base + 3u") << "; }\n"
+          << "if (base + 1u < element_count) { a1 = " << a_offset("base + 1u") << "; b1 = " << b_offset("base + 1u") << "; }\n"
+          << "if (base + 2u < element_count) { a2 = " << a_offset("base + 2u") << "; b2 = " << b_offset("base + 2u") << "; }\n"
+          << "if (base + 3u < element_count) { a3 = " << a_offset("base + 3u") << "; b3 = " << b_offset("base + 3u") << "; }\n"
           << "let a = vec4<input_a_value_t>(a0, a1, a2, a3);\n"
           << "let b = vec4<input_b_value_t>(b0, b1, b2, b3);\n";
     } else {
@@ -146,11 +151,10 @@ Status BinaryElementwiseProgram::GenerateShaderCode(ShaderHelper& shader) const 
     // INT64 output (component=1): write each component of the vec4 result individually.
     shader.MainFunctionBody()
         << "let result = " << expression_ << ";\n"
-        << "let output_size = uniforms.element_count;\n"
-        << c.SetByOffset("global_idx * 4u", "result[0]") << "\n"
-        << "if (global_idx * 4u + 1u < output_size) { " << c.SetByOffset("global_idx * 4u + 1u", "result[1]") << " }\n"
-        << "if (global_idx * 4u + 2u < output_size) { " << c.SetByOffset("global_idx * 4u + 2u", "result[2]") << " }\n"
-        << "if (global_idx * 4u + 3u < output_size) { " << c.SetByOffset("global_idx * 4u + 3u", "result[3]") << " }\n";
+        << c.SetByOffset("base", "result[0]") << "\n"
+        << "if (base + 1u < element_count) { " << c.SetByOffset("base + 1u", "result[1]") << " }\n"
+        << "if (base + 2u < element_count) { " << c.SetByOffset("base + 2u", "result[2]") << " }\n"
+        << "if (base + 3u < element_count) { " << c.SetByOffset("base + 3u", "result[3]") << " }\n";
   } else {
     shader.MainFunctionBody() << c.SetByOffset("global_idx", expression_);
   }

--- a/onnxruntime/core/providers/webgpu/math/binary_elementwise_ops.h
+++ b/onnxruntime/core/providers/webgpu/math/binary_elementwise_ops.h
@@ -20,15 +20,17 @@ class BinaryElementwiseProgram final : public Program<BinaryElementwiseProgram> 
                            const bool is_rhs_scalar,
                            const bool is_lhs_use_4_components,
                            const bool is_rhs_use_4_components,
-                           const bool vectorize) : Program{kernel_name},
-                                                   expression_{expression},
-                                                   additional_impl_{additional_impl},
-                                                   is_broadcast_{is_broadcast},
-                                                   is_lhs_scalar_{is_lhs_scalar},
-                                                   is_rhs_scalar_{is_rhs_scalar},
-                                                   is_lhs_use_4_components_{is_lhs_use_4_components},
-                                                   is_rhs_use_4_components_{is_rhs_use_4_components},
-                                                   vectorize_{vectorize} {}
+                           const bool vectorize,
+                           const bool is_int64 = false) : Program{kernel_name},
+                                                          expression_{expression},
+                                                          additional_impl_{additional_impl},
+                                                          is_broadcast_{is_broadcast},
+                                                          is_lhs_scalar_{is_lhs_scalar},
+                                                          is_rhs_scalar_{is_rhs_scalar},
+                                                          is_lhs_use_4_components_{is_lhs_use_4_components},
+                                                          is_rhs_use_4_components_{is_rhs_use_4_components},
+                                                          vectorize_{vectorize},
+                                                          is_int64_{is_int64} {}
 
   Status GenerateShaderCode(ShaderHelper& sh) const override;
 
@@ -43,6 +45,7 @@ class BinaryElementwiseProgram final : public Program<BinaryElementwiseProgram> 
   bool is_lhs_use_4_components_;
   bool is_rhs_use_4_components_;
   bool vectorize_;
+  bool is_int64_;
 };
 
 class BinaryElementwise : public WebGpuKernel {

--- a/onnxruntime/core/providers/webgpu/math/binary_elementwise_ops.h
+++ b/onnxruntime/core/providers/webgpu/math/binary_elementwise_ops.h
@@ -21,16 +21,18 @@ class BinaryElementwiseProgram final : public Program<BinaryElementwiseProgram> 
                            const bool is_lhs_use_4_components,
                            const bool is_rhs_use_4_components,
                            const bool vectorize,
-                           const bool is_int64 = false) : Program{kernel_name},
-                                                          expression_{expression},
-                                                          additional_impl_{additional_impl},
-                                                          is_broadcast_{is_broadcast},
-                                                          is_lhs_scalar_{is_lhs_scalar},
-                                                          is_rhs_scalar_{is_rhs_scalar},
-                                                          is_lhs_use_4_components_{is_lhs_use_4_components},
-                                                          is_rhs_use_4_components_{is_rhs_use_4_components},
-                                                          vectorize_{vectorize},
-                                                          is_int64_{is_int64} {}
+                           const bool is_int64_input = false,
+                           const bool is_int64_output = false) : Program{kernel_name},
+                                                                 expression_{expression},
+                                                                 additional_impl_{additional_impl},
+                                                                 is_broadcast_{is_broadcast},
+                                                                 is_lhs_scalar_{is_lhs_scalar},
+                                                                 is_rhs_scalar_{is_rhs_scalar},
+                                                                 is_lhs_use_4_components_{is_lhs_use_4_components},
+                                                                 is_rhs_use_4_components_{is_rhs_use_4_components},
+                                                                 vectorize_{vectorize},
+                                                                 is_int64_input_{is_int64_input},
+                                                                 is_int64_output_{is_int64_output} {}
 
   Status GenerateShaderCode(ShaderHelper& sh) const override;
 
@@ -46,7 +48,8 @@ class BinaryElementwiseProgram final : public Program<BinaryElementwiseProgram> 
   bool is_lhs_use_4_components_;
   bool is_rhs_use_4_components_;
   bool vectorize_;
-  bool is_int64_;
+  bool is_int64_input_;
+  bool is_int64_output_;
 };
 
 class BinaryElementwise : public WebGpuKernel {

--- a/onnxruntime/core/providers/webgpu/math/binary_elementwise_ops.h
+++ b/onnxruntime/core/providers/webgpu/math/binary_elementwise_ops.h
@@ -34,7 +34,8 @@ class BinaryElementwiseProgram final : public Program<BinaryElementwiseProgram> 
 
   Status GenerateShaderCode(ShaderHelper& sh) const override;
 
-  WEBGPU_PROGRAM_DEFINE_UNIFORM_VARIABLES({"vec_size", ProgramUniformVariableDataType::Uint32});
+  WEBGPU_PROGRAM_DEFINE_UNIFORM_VARIABLES({"vec_size", ProgramUniformVariableDataType::Uint32},
+                                          {"element_count", ProgramUniformVariableDataType::Uint32});
 
  private:
   std::string_view expression_;

--- a/onnxruntime/core/providers/webgpu/math/binary_elementwise_ops.h
+++ b/onnxruntime/core/providers/webgpu/math/binary_elementwise_ops.h
@@ -66,5 +66,16 @@ class BinaryElementwise : public WebGpuKernel {
   const GetAdditionalImplementationFunction get_additional_impl_;
 };
 
+// Factory functions for ops with conditional int64 support (registered via RegisterKernels).
+template <int StartVersion, int EndVersion>
+KernelCreateInfo CreateEqualVersionedKernelInfo(bool enable_int64);
+template <int SinceVersion>
+KernelCreateInfo CreateEqualKernelInfo(bool enable_int64);
+
+template <int StartVersion, int EndVersion>
+KernelCreateInfo CreateSubVersionedKernelInfo(bool enable_int64);
+template <int SinceVersion>
+KernelCreateInfo CreateSubKernelInfo(bool enable_int64);
+
 }  // namespace webgpu
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/webgpu/reduction/reduction_ops.cc
+++ b/onnxruntime/core/providers/webgpu/reduction/reduction_ops.cc
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include "core/providers/webgpu/reduction/reduction_ops.h"
+#include <memory>
 #include <sstream>
 #include "core/framework/data_transfer_manager.h"
 #include "core/providers/webgpu/data_transfer.h"

--- a/onnxruntime/core/providers/webgpu/reduction/reduction_ops.cc
+++ b/onnxruntime/core/providers/webgpu/reduction/reduction_ops.cc
@@ -325,12 +325,6 @@ template <bool allow_multi_axes>
 Status ReduceKernel<allow_multi_axes>::ComputeInternal(ComputeContext& context) const {
   const auto* input_tensor = context.Input(0);
   ORT_RETURN_IF_ERROR(CheckInput(input_tensor));
-  // INT64 must use component=1 (WebGPU has no native i64 vector type).
-  // ToProgramVariableDataType(INT64, 4) returns InvalidType today — if a future change
-  // adds Int64x4, this assert fires and the shader must be updated for vectorized INT64.
-  ORT_ENFORCE(ToProgramVariableDataType(ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64, 4) == ProgramVariableDataType::InvalidType,
-              "INT64 reduction requires component=1. If Int64x4 is now supported, update the reduction "
-              "shader to handle vectorized INT64 before removing this check.");
   InlinedVector<uint32_t> input_axes;
   bool add_suffix = name_ == "ArgMax" || name_ == "ArgMin";
   ReduceOpType reduce_op_type = StringToReduceOp(name_ + std::string((select_last_index_ != 0 && add_suffix) ? "_select_last_index" : ""));

--- a/onnxruntime/core/providers/webgpu/reduction/reduction_ops.cc
+++ b/onnxruntime/core/providers/webgpu/reduction/reduction_ops.cc
@@ -325,12 +325,12 @@ template <bool allow_multi_axes>
 Status ReduceKernel<allow_multi_axes>::ComputeInternal(ComputeContext& context) const {
   const auto* input_tensor = context.Input(0);
   ORT_RETURN_IF_ERROR(CheckInput(input_tensor));
-  // INT64 inputs require component=1 in the shader (WebGPU has no native i64 vector type).
-  // The programs below use AddInput with default component=1. Guard here so that any future
-  // refactor adding vectorization is caught before it silently produces wrong results for INT64.
-  ORT_ENFORCE(input_tensor->GetElementType() != ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64 ||
-                  NumberOfComponents(ToProgramVariableDataType(ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64, 1)) == 1,
-              "INT64 ReduceSum requires component=1 since WebGPU has no native 64-bit vector type.");
+  // INT64 must use component=1 (WebGPU has no native i64 vector type).
+  // ToProgramVariableDataType(INT64, 4) returns InvalidType today — if a future change
+  // adds Int64x4, this assert fires and the shader must be updated for vectorized INT64.
+  ORT_ENFORCE(ToProgramVariableDataType(ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64, 4) == ProgramVariableDataType::InvalidType,
+              "INT64 reduction requires component=1. If Int64x4 is now supported, update the reduction "
+              "shader to handle vectorized INT64 before removing this check.");
   InlinedVector<uint32_t> input_axes;
   bool add_suffix = name_ == "ArgMax" || name_ == "ArgMin";
   ReduceOpType reduce_op_type = StringToReduceOp(name_ + std::string((select_last_index_ != 0 && add_suffix) ? "_select_last_index" : ""));

--- a/onnxruntime/core/providers/webgpu/reduction/reduction_ops.cc
+++ b/onnxruntime/core/providers/webgpu/reduction/reduction_ops.cc
@@ -325,6 +325,12 @@ template <bool allow_multi_axes>
 Status ReduceKernel<allow_multi_axes>::ComputeInternal(ComputeContext& context) const {
   const auto* input_tensor = context.Input(0);
   ORT_RETURN_IF_ERROR(CheckInput(input_tensor));
+  // INT64 inputs require component=1 in the shader (WebGPU has no native i64 vector type).
+  // The programs below use AddInput with default component=1. Guard here so that any future
+  // refactor adding vectorization is caught before it silently produces wrong results for INT64.
+  ORT_ENFORCE(input_tensor->GetElementType() != ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64 ||
+                  NumberOfComponents(ToProgramVariableDataType(ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64, 1)) == 1,
+              "INT64 ReduceSum requires component=1 since WebGPU has no native 64-bit vector type.");
   InlinedVector<uint32_t> input_axes;
   bool add_suffix = name_ == "ArgMax" || name_ == "ArgMin";
   ReduceOpType reduce_op_type = StringToReduceOp(name_ + std::string((select_last_index_ != 0 && add_suffix) ? "_select_last_index" : ""));

--- a/onnxruntime/core/providers/webgpu/reduction/reduction_ops.cc
+++ b/onnxruntime/core/providers/webgpu/reduction/reduction_ops.cc
@@ -60,6 +60,8 @@ REGISTER_REDUCE_KERNEL(ReduceMin, 20);
 
 // ReduceSum: versions 1-12 use axes as attribute; version 13+ uses axes as a CPU input tensor.
 // Factory functions allow conditional int64 support on the T type constraint.
+// NOTE: int64 reduction in the WebGPU shader uses i32 (low 32 bits only); values outside
+// the int32 range will produce incorrect results — same limitation as Range.
 template <int StartVersion, int EndVersion>
 KernelCreateInfo CreateReduceSumVersionedKernelInfo(bool enable_int64) {
   const auto& type_constraints = GetOpTypeConstraints(enable_int64, false);

--- a/onnxruntime/core/providers/webgpu/reduction/reduction_ops.cc
+++ b/onnxruntime/core/providers/webgpu/reduction/reduction_ops.cc
@@ -8,7 +8,6 @@
 #include "core/providers/webgpu/shader_helper.h"
 #include "core/providers/webgpu/webgpu_supported_types.h"
 #include "core/providers/webgpu/tensor/transpose.h"
-#include "core/providers/webgpu/webgpu_execution_provider.h"
 
 namespace onnxruntime {
 namespace webgpu {
@@ -68,7 +67,7 @@ KernelCreateInfo CreateReduceSumVersionedKernelInfo(bool enable_int64) {
     out = std::make_unique<ReduceSum>(info);
     return Status::OK();
   };
-  return {(*KernelDefBuilder::Create())
+  return {KernelDefBuilder()
               .SetName("ReduceSum")
               .SetDomain(kOnnxDomain)
               .SinceVersion(StartVersion, EndVersion)
@@ -85,7 +84,7 @@ KernelCreateInfo CreateReduceSumKernelInfo(bool enable_int64) {
     out = std::make_unique<ReduceSum>(info);
     return Status::OK();
   };
-  return {(*KernelDefBuilder::Create())
+  return {KernelDefBuilder()
               .SetName("ReduceSum")
               .SetDomain(kOnnxDomain)
               .SinceVersion(SinceVersion)

--- a/onnxruntime/core/providers/webgpu/reduction/reduction_ops.cc
+++ b/onnxruntime/core/providers/webgpu/reduction/reduction_ops.cc
@@ -8,6 +8,7 @@
 #include "core/providers/webgpu/shader_helper.h"
 #include "core/providers/webgpu/webgpu_supported_types.h"
 #include "core/providers/webgpu/tensor/transpose.h"
+#include "core/providers/webgpu/webgpu_execution_provider.h"
 
 namespace onnxruntime {
 namespace webgpu {
@@ -58,9 +59,46 @@ REGISTER_REDUCE_VERSIONED_KERNEL(ReduceMin, 13, 17);
 REGISTER_REDUCE_VERSIONED_KERNEL_WITH_AXIS_IN_INPUT(ReduceMin, 18, 19);
 REGISTER_REDUCE_KERNEL(ReduceMin, 20);
 
-REGISTER_REDUCE_VERSIONED_KERNEL(ReduceSum, 1, 10);
-REGISTER_REDUCE_VERSIONED_KERNEL(ReduceSum, 11, 12);
-REGISTER_REDUCE_KERNEL(ReduceSum, 13);
+// ReduceSum: versions 1-12 use axes as attribute; version 13+ uses axes as a CPU input tensor.
+// Factory functions allow conditional int64 support on the T type constraint.
+template <int StartVersion, int EndVersion>
+KernelCreateInfo CreateReduceSumVersionedKernelInfo(bool enable_int64) {
+  const auto& type_constraints = GetOpTypeConstraints(enable_int64, false);
+  KernelCreatePtrFn kernel_create_fn = [](FuncManager&, const OpKernelInfo& info, std::unique_ptr<OpKernel>& out) -> Status {
+    out = std::make_unique<ReduceSum>(info);
+    return Status::OK();
+  };
+  return {(*KernelDefBuilder::Create())
+              .SetName("ReduceSum")
+              .SetDomain(kOnnxDomain)
+              .SinceVersion(StartVersion, EndVersion)
+              .Provider(kWebGpuExecutionProvider)
+              .TypeConstraint("T", type_constraints)
+              .Build(),
+          kernel_create_fn};
+}
+
+template <int SinceVersion>
+KernelCreateInfo CreateReduceSumKernelInfo(bool enable_int64) {
+  const auto& type_constraints = GetOpTypeConstraints(enable_int64, false);
+  KernelCreatePtrFn kernel_create_fn = [](FuncManager&, const OpKernelInfo& info, std::unique_ptr<OpKernel>& out) -> Status {
+    out = std::make_unique<ReduceSum>(info);
+    return Status::OK();
+  };
+  return {(*KernelDefBuilder::Create())
+              .SetName("ReduceSum")
+              .SetDomain(kOnnxDomain)
+              .SinceVersion(SinceVersion)
+              .Provider(kWebGpuExecutionProvider)
+              .TypeConstraint("T", type_constraints)
+              .InputMemoryType(OrtMemTypeCPUInput, 1)
+              .Build(),
+          kernel_create_fn};
+}
+
+template KernelCreateInfo CreateReduceSumVersionedKernelInfo<1, 10>(bool);
+template KernelCreateInfo CreateReduceSumVersionedKernelInfo<11, 12>(bool);
+template KernelCreateInfo CreateReduceSumKernelInfo<13>(bool);
 
 REGISTER_REDUCE_VERSIONED_KERNEL(ReduceProd, 1, 10);
 REGISTER_REDUCE_VERSIONED_KERNEL(ReduceProd, 11, 12);

--- a/onnxruntime/core/providers/webgpu/reduction/reduction_ops.h
+++ b/onnxruntime/core/providers/webgpu/reduction/reduction_ops.h
@@ -160,5 +160,11 @@ class ArgMax final : public ReduceKernel<false> {
   ArgMax(const OpKernelInfo& info) : ReduceKernel<false>(info, "ArgMax", true) {}
 };
 
+// Factory functions for ReduceSum with conditional int64 support (registered via RegisterKernels).
+template <int StartVersion, int EndVersion>
+KernelCreateInfo CreateReduceSumVersionedKernelInfo(bool enable_int64);
+template <int SinceVersion>
+KernelCreateInfo CreateReduceSumKernelInfo(bool enable_int64);
+
 }  // namespace webgpu
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/webgpu/tensor/where.cc
+++ b/onnxruntime/core/providers/webgpu/tensor/where.cc
@@ -5,6 +5,8 @@
 #include "core/providers/webgpu/tensor/where.h"
 #include "core/providers/cpu/tensor/utils.h"
 #include "core/providers/webgpu/shader_helper.h"
+#include "core/providers/webgpu/webgpu_supported_types.h"
+#include "core/providers/webgpu/webgpu_execution_provider.h"
 
 namespace onnxruntime {
 namespace webgpu {
@@ -156,37 +158,64 @@ Status Where::ComputeInternal(ComputeContext& context) const {
 }
 
 namespace {
-const std::vector<MLDataType>& WhereOpTypeConstraints() {
+const std::vector<MLDataType>& WhereOpTypeConstraints(bool enable_int64 = false) {
   // currently support boolean, integer and float types that explicitly allowed in WGSL:
   // https://gpuweb.github.io/gpuweb/wgsl/#plain-types-section
   //
-  static std::vector<MLDataType> types{
+  static std::vector<MLDataType> base_types{
       DataTypeImpl::GetTensorType<MLFloat16>(),
       DataTypeImpl::GetTensorType<float>(),
       DataTypeImpl::GetTensorType<int32_t>(),
       DataTypeImpl::GetTensorType<uint32_t>(),
       DataTypeImpl::GetTensorType<bool>()};
-  return types;
+  if (enable_int64) {
+    static std::vector<MLDataType> types_with_int64 = []() {
+      auto types = base_types;
+      types.push_back(DataTypeImpl::GetTensorType<int64_t>());
+      return types;
+    }();
+    return types_with_int64;
+  }
+  return base_types;
 }
 }  // namespace
 
-ONNX_OPERATOR_VERSIONED_KERNEL_EX(
-    Where,
-    kOnnxDomain,
-    9, 15,
-    kWebGpuExecutionProvider,
-    (*KernelDefBuilder::Create())
-        .TypeConstraint("T", WhereOpTypeConstraints()),
-    Where);
+template <int StartVersion, int EndVersion>
+KernelCreateInfo CreateWhereVersionedKernelInfo(bool enable_int64) {
+  const auto& type_constraints = WhereOpTypeConstraints(enable_int64);
+  KernelCreatePtrFn kernel_create_fn = [](FuncManager&, const OpKernelInfo& info, std::unique_ptr<OpKernel>& out) -> Status {
+    out = std::make_unique<Where>(info);
+    return Status::OK();
+  };
+  return {(*KernelDefBuilder::Create())
+              .SetName("Where")
+              .SetDomain(kOnnxDomain)
+              .SinceVersion(StartVersion, EndVersion)
+              .Provider(kWebGpuExecutionProvider)
+              .TypeConstraint("T", type_constraints)
+              .Build(),
+          kernel_create_fn};
+}
 
-ONNX_OPERATOR_KERNEL_EX(
-    Where,
-    kOnnxDomain,
-    16,
-    kWebGpuExecutionProvider,
-    (*KernelDefBuilder::Create())
-        .TypeConstraint("T", WhereOpTypeConstraints()),
-    Where);
+template <int SinceVersion>
+KernelCreateInfo CreateWhereKernelInfo(bool enable_int64) {
+  const auto& type_constraints = WhereOpTypeConstraints(enable_int64);
+  KernelCreatePtrFn kernel_create_fn = [](FuncManager&, const OpKernelInfo& info, std::unique_ptr<OpKernel>& out) -> Status {
+    out = std::make_unique<Where>(info);
+    return Status::OK();
+  };
+  return {(*KernelDefBuilder::Create())
+              .SetName("Where")
+              .SetDomain(kOnnxDomain)
+              .SinceVersion(SinceVersion)
+              .Provider(kWebGpuExecutionProvider)
+              .TypeConstraint("T", type_constraints)
+              .Build(),
+          kernel_create_fn};
+}
+
+template KernelCreateInfo CreateWhereVersionedKernelInfo<9, 15>(bool);
+template KernelCreateInfo CreateWhereKernelInfo<16>(bool);
 
 }  // namespace webgpu
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/webgpu/tensor/where.cc
+++ b/onnxruntime/core/providers/webgpu/tensor/where.cc
@@ -66,10 +66,28 @@ Status WhereProgram::GenerateShaderCode(ShaderHelper& shader) const {
     return absl::StrCat("select(", b, ", ", a, ", ", c, ")");
   };
 
-  if (!is_broadcast_) {
+  if (!is_broadcast_ && !is_int64_) {
     shader.MainFunctionBody() << output.SetByOffset(
         "global_idx",
         expression(a_input.GetByOffset("global_idx"), b_input.GetByOffset("global_idx"), c_input.GetByOffset("global_idx")));
+
+  } else if (is_int64_) {
+    // INT64: no vec4; process one element per thread using direct storage access.
+    // Handles both broadcast and non-broadcast (BroadcastedIndicesToOffset returns global_idx for matching shapes).
+    const auto& c_indices = shader.AddIndices("c_indices");
+    const auto& a_indices = shader.AddIndices("a_indices");
+    const auto& b_indices = shader.AddIndices("b_indices");
+    const auto& output_indices = shader.AddIndices("output_indices");
+
+    shader.MainFunctionBody()
+        << "let output_idx = " << output_indices.OffsetToIndices("global_idx") << ";\n"
+        << "let offset_a = " << a_indices.BroadcastedIndicesToOffset("output_idx", output_indices) << ";\n"
+        << "let offset_b = " << b_indices.BroadcastedIndicesToOffset("output_idx", output_indices) << ";\n"
+        << "let offset_c = " << c_indices.BroadcastedIndicesToOffset("output_idx", output_indices) << ";\n"
+        << "let cond = bool(c_data[offset_c / 4u] & (0xffu << (u32(offset_c % 4u) * 8u)));\n"
+        << "let a_val = a_data[offset_a];\n"
+        << "let b_val = b_data[offset_b];\n"
+        << "output_data[global_idx] = select(b_val, a_val, cond);\n";
 
   } else {
     const auto& c_indices = shader.AddIndices("c_indices");
@@ -131,22 +149,26 @@ Status Where::ComputeInternal(ComputeContext& context) const {
     return Status::OK();
   }
 
-  constexpr int component = 4;
-  uint32_t vec_size = onnxruntime::narrow<uint32_t>((output_shape.Size() + 3) / component);
+  bool is_int64 = x_tensor->GetElementType() == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64 ||
+                  y_tensor->GetElementType() == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64;
+  const int component = is_int64 ? 1 : 4;
+  uint32_t vec_size = is_int64
+                          ? onnxruntime::narrow<uint32_t>(output_shape.Size())
+                          : onnxruntime::narrow<uint32_t>((output_shape.Size() + 3) / component);
   const auto is_broadcast = !(x_shape == y_shape &&
                               y_shape == cond_shape);
-  WhereProgram program{is_broadcast};
+  WhereProgram program{is_broadcast, is_int64};
   program
-      .CacheHint(is_broadcast)
+      .CacheHint(is_broadcast, is_int64)
       .SetDispatchGroupSize((vec_size + WORKGROUP_SIZE - 1) / WORKGROUP_SIZE)
       .AddInputs({{cond_tensor, ProgramTensorMetadataDependency::Type, {(cond_shape.Size() + 3) / 4}, 4},
-                  {x_tensor, ProgramTensorMetadataDependency::Type, {(x_shape.Size() + 3) / 4}, 4},
-                  {y_tensor, ProgramTensorMetadataDependency::Type, {(y_shape.Size() + 3) / 4}, 4}})
-      .AddOutput({output_tensor, ProgramTensorMetadataDependency::Type, {vec_size}, 4})
+                  {x_tensor, ProgramTensorMetadataDependency::Type, {is_int64 ? x_shape.Size() : (x_shape.Size() + 3) / 4}, component},
+                  {y_tensor, ProgramTensorMetadataDependency::Type, {is_int64 ? y_shape.Size() : (y_shape.Size() + 3) / 4}, component}})
+      .AddOutput({output_tensor, ProgramTensorMetadataDependency::Type, {vec_size}, component})
       .AddUniformVariables({
           {static_cast<uint32_t>(vec_size)},
       });
-  if (is_broadcast) {
+  if (is_broadcast || is_int64) {
     program
         .AddIndices(cond_shape)
         .AddIndices(x_shape)

--- a/onnxruntime/core/providers/webgpu/tensor/where.cc
+++ b/onnxruntime/core/providers/webgpu/tensor/where.cc
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <memory>
+
 #include "core/common/inlined_containers.h"
 #include "core/providers/webgpu/tensor/where.h"
 #include "core/providers/cpu/tensor/utils.h"
@@ -85,9 +87,9 @@ Status WhereProgram::GenerateShaderCode(ShaderHelper& shader) const {
         << "let offset_b = " << b_indices.BroadcastedIndicesToOffset("output_idx", output_indices) << ";\n"
         << "let offset_c = " << c_indices.BroadcastedIndicesToOffset("output_idx", output_indices) << ";\n"
         << "let cond = bool(c_data[offset_c / 4u] & (0xffu << (u32(offset_c % 4u) * 8u)));\n"
-        << "let a_val = a_data[offset_a];\n"
-        << "let b_val = b_data[offset_b];\n"
-        << "output_data[global_idx] = select(b_val, a_val, cond);\n";
+        << "let a_val = " << a_input.GetByOffset("offset_a") << ";\n"
+        << "let b_val = " << b_input.GetByOffset("offset_b") << ";\n";
+    shader.MainFunctionBody() << output.SetByOffset("global_idx", "select(b_val, a_val, cond)");
 
   } else {
     const auto& c_indices = shader.AddIndices("c_indices");

--- a/onnxruntime/core/providers/webgpu/tensor/where.cc
+++ b/onnxruntime/core/providers/webgpu/tensor/where.cc
@@ -91,7 +91,7 @@ Status WhereProgram::GenerateShaderCode(ShaderHelper& shader) const {
         << "let offset_a = " << a_indices.BroadcastedIndicesToOffset("output_idx", output_indices) << ";\n"
         << "let offset_b = " << b_indices.BroadcastedIndicesToOffset("output_idx", output_indices) << ";\n"
         << "let offset_c = " << c_indices.BroadcastedIndicesToOffset("output_idx", output_indices) << ";\n"
-        << "let cond = bool(c_data[offset_c / 4u] & (0xffu << (u32(offset_c % 4u) * 8u)));\n"
+        << "let cond = " << c_input.GetByOffset("offset_c / 4") << "[offset_c % 4];\n"
         << "let a_val = " << a_input.GetByOffset("offset_a") << ";\n"
         << "let b_val = " << b_input.GetByOffset("offset_b") << ";\n";
     shader.MainFunctionBody() << output.SetByOffset("global_idx", "select(b_val, a_val, cond)");

--- a/onnxruntime/core/providers/webgpu/tensor/where.cc
+++ b/onnxruntime/core/providers/webgpu/tensor/where.cc
@@ -68,6 +68,10 @@ Status WhereProgram::GenerateShaderCode(ShaderHelper& shader) const {
     return absl::StrCat("select(", b, ", ", a, ", ", c, ")");
   };
 
+  // Fast path: no-broadcast, non-INT64. One thread handles 4 elements (vec4); global_idx is a
+  // vec4 index and c_input.GetByOffset reads a full packed-bool u32 directly.
+  // INT64 is excluded because its layout is element-per-thread (component=1, vec_size=output_size),
+  // so the condition byte must be extracted with the packed-bool logic in the is_int64_ branch below.
   if (!is_broadcast_ && !is_int64_) {
     shader.MainFunctionBody() << output.SetByOffset(
         "global_idx",

--- a/onnxruntime/core/providers/webgpu/tensor/where.cc
+++ b/onnxruntime/core/providers/webgpu/tensor/where.cc
@@ -68,10 +68,11 @@ Status WhereProgram::GenerateShaderCode(ShaderHelper& shader) const {
     return absl::StrCat("select(", b, ", ", a, ", ", c, ")");
   };
 
-  // Fast path: no-broadcast, non-INT64. One thread handles 4 elements (vec4); global_idx is a
-  // vec4 index and c_input.GetByOffset reads a full packed-bool u32 directly.
-  // INT64 is excluded because its layout is element-per-thread (component=1, vec_size=output_size),
-  // so the condition byte must be extracted with the packed-bool logic in the is_int64_ branch below.
+  // Fast path: no-broadcast, non-INT64. global_idx is a vec4 index (vec_size = output_size/4),
+  // and c_input.GetByOffset reads a full packed-bool u32 as vec4<bool> directly.
+  // INT64 is excluded because vec_size = output_size (one thread per element), so global_idx is
+  // an element index — c_input.GetByOffset would read the wrong condition word. The is_int64_
+  // branch below extracts the correct condition bit via offset_c / 4u and byte masking.
   if (!is_broadcast_ && !is_int64_) {
     shader.MainFunctionBody() << output.SetByOffset(
         "global_idx",

--- a/onnxruntime/core/providers/webgpu/tensor/where.cc
+++ b/onnxruntime/core/providers/webgpu/tensor/where.cc
@@ -6,7 +6,6 @@
 #include "core/providers/cpu/tensor/utils.h"
 #include "core/providers/webgpu/shader_helper.h"
 #include "core/providers/webgpu/webgpu_supported_types.h"
-#include "core/providers/webgpu/webgpu_execution_provider.h"
 
 namespace onnxruntime {
 namespace webgpu {
@@ -157,37 +156,14 @@ Status Where::ComputeInternal(ComputeContext& context) const {
   return context.RunProgram(program);
 }
 
-namespace {
-const std::vector<MLDataType>& WhereOpTypeConstraints(bool enable_int64 = false) {
-  // currently support boolean, integer and float types that explicitly allowed in WGSL:
-  // https://gpuweb.github.io/gpuweb/wgsl/#plain-types-section
-  //
-  static std::vector<MLDataType> base_types{
-      DataTypeImpl::GetTensorType<MLFloat16>(),
-      DataTypeImpl::GetTensorType<float>(),
-      DataTypeImpl::GetTensorType<int32_t>(),
-      DataTypeImpl::GetTensorType<uint32_t>(),
-      DataTypeImpl::GetTensorType<bool>()};
-  if (enable_int64) {
-    static std::vector<MLDataType> types_with_int64 = []() {
-      auto types = base_types;
-      types.push_back(DataTypeImpl::GetTensorType<int64_t>());
-      return types;
-    }();
-    return types_with_int64;
-  }
-  return base_types;
-}
-}  // namespace
-
 template <int StartVersion, int EndVersion>
 KernelCreateInfo CreateWhereVersionedKernelInfo(bool enable_int64) {
-  const auto& type_constraints = WhereOpTypeConstraints(enable_int64);
+  const auto& type_constraints = GetOpTypeConstraints(enable_int64, /*enable_bool=*/true);
   KernelCreatePtrFn kernel_create_fn = [](FuncManager&, const OpKernelInfo& info, std::unique_ptr<OpKernel>& out) -> Status {
     out = std::make_unique<Where>(info);
     return Status::OK();
   };
-  return {(*KernelDefBuilder::Create())
+  return {KernelDefBuilder()
               .SetName("Where")
               .SetDomain(kOnnxDomain)
               .SinceVersion(StartVersion, EndVersion)
@@ -199,12 +175,12 @@ KernelCreateInfo CreateWhereVersionedKernelInfo(bool enable_int64) {
 
 template <int SinceVersion>
 KernelCreateInfo CreateWhereKernelInfo(bool enable_int64) {
-  const auto& type_constraints = WhereOpTypeConstraints(enable_int64);
+  const auto& type_constraints = GetOpTypeConstraints(enable_int64, /*enable_bool=*/true);
   KernelCreatePtrFn kernel_create_fn = [](FuncManager&, const OpKernelInfo& info, std::unique_ptr<OpKernel>& out) -> Status {
     out = std::make_unique<Where>(info);
     return Status::OK();
   };
-  return {(*KernelDefBuilder::Create())
+  return {KernelDefBuilder()
               .SetName("Where")
               .SetDomain(kOnnxDomain)
               .SinceVersion(SinceVersion)

--- a/onnxruntime/core/providers/webgpu/tensor/where.h
+++ b/onnxruntime/core/providers/webgpu/tensor/where.h
@@ -31,5 +31,11 @@ class Where final : public WebGpuKernel {
   Status ComputeInternal(ComputeContext& context) const override;
 };
 
+// Factory functions for conditional int64 support (registered via RegisterKernels).
+template <int StartVersion, int EndVersion>
+KernelCreateInfo CreateWhereVersionedKernelInfo(bool enable_int64);
+template <int SinceVersion>
+KernelCreateInfo CreateWhereKernelInfo(bool enable_int64);
+
 }  // namespace webgpu
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/webgpu/tensor/where.h
+++ b/onnxruntime/core/providers/webgpu/tensor/where.h
@@ -13,7 +13,7 @@ namespace webgpu {
 
 class WhereProgram final : public Program<WhereProgram> {
  public:
-  WhereProgram(bool is_broadcast) : Program{"Where"}, is_broadcast_{is_broadcast} {
+  WhereProgram(bool is_broadcast, bool is_int64 = false) : Program{"Where"}, is_broadcast_{is_broadcast}, is_int64_{is_int64} {
   }
 
   Status GenerateShaderCode(ShaderHelper& sh) const override;
@@ -21,6 +21,7 @@ class WhereProgram final : public Program<WhereProgram> {
 
  private:
   const bool is_broadcast_;
+  const bool is_int64_;
 };
 
 class Where final : public WebGpuKernel {

--- a/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
@@ -34,6 +34,9 @@
 #include "core/providers/webgpu/tensor/grid_sample.h"
 #include "core/providers/webgpu/generator/range.h"
 #include "core/providers/webgpu/tensor/unsqueeze.h"
+#include "core/providers/webgpu/math/binary_elementwise_ops.h"
+#include "core/providers/webgpu/tensor/where.h"
+#include "core/providers/webgpu/reduction/reduction_ops.h"
 
 namespace onnxruntime {
 
@@ -158,9 +161,7 @@ static const BuildKernelCreateInfoFn build_kernel_create_info_function_table[] =
     KERNEL_CREATE_INFO_VERSIONED(7, 12, Add),
     KERNEL_CREATE_INFO_VERSIONED(13, 13, Add),
     KERNEL_CREATE_INFO(14, Add),
-    KERNEL_CREATE_INFO_VERSIONED(7, 12, Sub),
-    KERNEL_CREATE_INFO_VERSIONED(13, 13, Sub),
-    KERNEL_CREATE_INFO(14, Sub),
+    // Sub: registered via RegisterKernels with conditional int64 support
     KERNEL_CREATE_INFO_VERSIONED(7, 12, Mul),
     KERNEL_CREATE_INFO_VERSIONED(13, 13, Mul),
     KERNEL_CREATE_INFO(14, Mul),
@@ -171,10 +172,7 @@ static const BuildKernelCreateInfoFn build_kernel_create_info_function_table[] =
     KERNEL_CREATE_INFO_VERSIONED(12, 12, Pow),
     KERNEL_CREATE_INFO_VERSIONED(13, 14, Pow),
     KERNEL_CREATE_INFO(15, Pow),
-    KERNEL_CREATE_INFO_VERSIONED(7, 10, Equal),
-    KERNEL_CREATE_INFO_VERSIONED(11, 12, Equal),
-    KERNEL_CREATE_INFO_VERSIONED(13, 18, Equal),
-    KERNEL_CREATE_INFO(19, Equal),
+    // Equal: registered via RegisterKernels with conditional int64 support
     KERNEL_CREATE_INFO_VERSIONED(7, 8, Greater),
     KERNEL_CREATE_INFO_VERSIONED(9, 12, Greater),
     KERNEL_CREATE_INFO(13, Greater),
@@ -243,9 +241,7 @@ static const BuildKernelCreateInfoFn build_kernel_create_info_function_table[] =
     BuildKernelCreateInfo<class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 13, 17, ReduceProd)>,
     BuildKernelCreateInfo<class ONNX_OPERATOR_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 18, ReduceProd)>,
 
-    BuildKernelCreateInfo<class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 1, 10, ReduceSum)>,
-    BuildKernelCreateInfo<class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 11, 12, ReduceSum)>,
-    BuildKernelCreateInfo<class ONNX_OPERATOR_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 13, ReduceSum)>,
+    // ReduceSum: registered via RegisterKernels with conditional int64 support
 
     BuildKernelCreateInfo<class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 1, 10, ReduceL1)>,
     BuildKernelCreateInfo<class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 11, 12, ReduceL1)>,
@@ -272,8 +268,7 @@ static const BuildKernelCreateInfoFn build_kernel_create_info_function_table[] =
     BuildKernelCreateInfo<class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 13, 17, ReduceLogSumExp)>,
     BuildKernelCreateInfo<class ONNX_OPERATOR_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 18, ReduceLogSumExp)>,
 
-    KERNEL_CREATE_INFO_VERSIONED(9, 15, Where),
-    KERNEL_CREATE_INFO(16, Where),
+    // Where: registered via RegisterKernels with conditional int64 support
 
     BuildKernelCreateInfo<class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 1, 12, Transpose)>,
     BuildKernelCreateInfo<class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 13, 20, Transpose)>,
@@ -491,6 +486,26 @@ std::unique_ptr<KernelRegistry> RegisterKernels(bool enable_graph_capture, bool 
   // Register Expand kernels with conditional int64 support
   ORT_THROW_IF_ERROR(kernel_registry->Register(CreateExpandVersionedKernelInfo<8, 12>(enable_int64)));
   ORT_THROW_IF_ERROR(kernel_registry->Register(CreateExpandKernelInfo<13>(enable_int64)));
+
+  // Register Equal kernels with conditional int64 support
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateEqualVersionedKernelInfo<7, 10>(enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateEqualVersionedKernelInfo<11, 12>(enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateEqualVersionedKernelInfo<13, 18>(enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateEqualKernelInfo<19>(enable_int64)));
+
+  // Register Sub kernels with conditional int64 support
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateSubVersionedKernelInfo<7, 12>(enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateSubVersionedKernelInfo<13, 13>(enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateSubKernelInfo<14>(enable_int64)));
+
+  // Register Where kernels with conditional int64 support
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateWhereVersionedKernelInfo<9, 15>(enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateWhereKernelInfo<16>(enable_int64)));
+
+  // Register ReduceSum kernels with conditional int64 support
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateReduceSumVersionedKernelInfo<1, 10>(enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateReduceSumVersionedKernelInfo<11, 12>(enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateReduceSumKernelInfo<13>(enable_int64)));
 
 #ifndef DISABLE_CONTRIB_OPS
   Status status = ::onnxruntime::contrib::webgpu::RegisterWebGpuContribKernels(*kernel_registry, enable_graph_capture);

--- a/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
@@ -5069,9 +5069,9 @@ TEST(MathOpTest, Sub_int64_webgpu) {
 
 TEST(MathOpTest, Equal_int64_webgpu) {
   OpTester test("Equal", 13);
-  test.AddInput<int64_t>("A", {4}, {1, 0, -1, -1});
-  test.AddInput<int64_t>("B", {4}, {1, 1, 2, -1});
-  test.AddOutput<bool>("C", {4}, {true, false, false, true});
+  test.AddInput<int64_t>("A", {5}, {1, 0, -1, -1, 3});
+  test.AddInput<int64_t>("B", {5}, {1, 1, 2, -1, 3});
+  test.AddOutput<bool>("C", {5}, {true, false, false, true, true});
   ConfigOptions config_options{};
   ASSERT_STATUS_OK(config_options.AddConfigEntry(webgpu::options::kEnableInt64, "1"));
   auto provider = WebGpuExecutionProviderWithOptions(config_options);

--- a/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
@@ -5080,6 +5080,58 @@ TEST(MathOpTest, Sub_webgpu_int64_broadcast) {
       .RunWithConfig();
 }
 
+// Size divisible by 4: catches future vec4 optimizations that might break INT64.
+TEST(MathOpTest, Sub_webgpu_int64_size_div4) {
+  OpTester test("Sub", 14);
+  test.AddInput<int64_t>("A", {8}, {10, 20, 30, 40, 50, 60, 70, 80});
+  test.AddInput<int64_t>("B", {8}, {1, 2, 3, 4, 5, 6, 7, 8});
+  test.AddOutput<int64_t>("C", {8}, {9, 18, 27, 36, 45, 54, 63, 72});
+  ConfigOptions config_options{};
+  ASSERT_STATUS_OK(config_options.AddConfigEntry(webgpu::options::kEnableInt64, "1"));
+  auto provider = WebGpuExecutionProviderWithOptions(config_options);
+  test.ConfigEp(std::move(provider))
+      .RunWithConfig();
+}
+
+// Scalar LHS: exercises is_lhs_scalar_ path for INT64 Sub.
+TEST(MathOpTest, Sub_webgpu_int64_lhs_scalar) {
+  OpTester test("Sub", 14);
+  test.AddInput<int64_t>("A", {1}, {100});
+  test.AddInput<int64_t>("B", {5}, {1, 2, 3, 4, 5});
+  test.AddOutput<int64_t>("C", {5}, {99, 98, 97, 96, 95});
+  ConfigOptions config_options{};
+  ASSERT_STATUS_OK(config_options.AddConfigEntry(webgpu::options::kEnableInt64, "1"));
+  auto provider = WebGpuExecutionProviderWithOptions(config_options);
+  test.ConfigEp(std::move(provider))
+      .RunWithConfig();
+}
+
+// Scalar RHS: exercises is_rhs_scalar_ path for INT64 Sub.
+TEST(MathOpTest, Sub_webgpu_int64_rhs_scalar) {
+  OpTester test("Sub", 14);
+  test.AddInput<int64_t>("A", {5}, {10, 20, 30, 40, 50});
+  test.AddInput<int64_t>("B", {1}, {7});
+  test.AddOutput<int64_t>("C", {5}, {3, 13, 23, 33, 43});
+  ConfigOptions config_options{};
+  ASSERT_STATUS_OK(config_options.AddConfigEntry(webgpu::options::kEnableInt64, "1"));
+  auto provider = WebGpuExecutionProviderWithOptions(config_options);
+  test.ConfigEp(std::move(provider))
+      .RunWithConfig();
+}
+
+// Shape broadcast, size divisible by 4: A [1,4] broadcasts against B [2,4] -> output [2,4].
+TEST(MathOpTest, Sub_webgpu_int64_broadcast_size_div4) {
+  OpTester test("Sub", 14);
+  test.AddInput<int64_t>("A", {1, 4}, {10, 20, 30, 40});
+  test.AddInput<int64_t>("B", {2, 4}, {1, 2, 3, 4, 5, 6, 7, 8});
+  test.AddOutput<int64_t>("C", {2, 4}, {9, 18, 27, 36, 5, 14, 23, 32});
+  ConfigOptions config_options{};
+  ASSERT_STATUS_OK(config_options.AddConfigEntry(webgpu::options::kEnableInt64, "1"));
+  auto provider = WebGpuExecutionProviderWithOptions(config_options);
+  test.ConfigEp(std::move(provider))
+      .RunWithConfig();
+}
+
 TEST(MathOpTest, Equal_webgpu_int64) {
   OpTester test("Equal", 13);
   test.AddInput<int64_t>("A", {5}, {1, 0, -1, -1, 3});

--- a/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
@@ -23,6 +23,7 @@
 // and adds no link dependency on the webgpu provider library (which is not linked into
 // onnxruntime_provider_test in every build configuration, e.g. the plugin build). See issue #28969.
 #include "core/providers/webgpu/math/binary_elementwise_broadcast_utils.h"
+#include "core/providers/webgpu/webgpu_provider_options.h"
 #endif
 
 namespace onnxruntime {
@@ -5052,6 +5053,32 @@ TEST(MathOpTest, BitwiseNot_uint8) {
   test.AddOutput<uint8_t>("Y", dims, {254, 251, 250, 252});
   test.Run();
 }
+
+#ifdef USE_WEBGPU
+TEST(MathOpTest, Sub_int64_webgpu) {
+  OpTester test("Sub", 14);
+  test.AddInput<int64_t>("A", {4}, {10, 5, -3, 0});
+  test.AddInput<int64_t>("B", {4}, {3, 5, 1, -7});
+  test.AddOutput<int64_t>("C", {4}, {7, 0, -4, 7});
+  ConfigOptions config_options{};
+  ASSERT_STATUS_OK(config_options.AddConfigEntry(webgpu::options::kEnableInt64, "1"));
+  auto provider = WebGpuExecutionProviderWithOptions(config_options);
+  test.ConfigEp(std::move(provider))
+      .RunWithConfig();
+}
+
+TEST(MathOpTest, Equal_int64_webgpu) {
+  OpTester test("Equal", 13);
+  test.AddInput<int64_t>("A", {4}, {1, 0, -1, -1});
+  test.AddInput<int64_t>("B", {4}, {1, 1, 2, -1});
+  test.AddOutput<bool>("C", {4}, {true, false, false, true});
+  ConfigOptions config_options{};
+  ASSERT_STATUS_OK(config_options.AddConfigEntry(webgpu::options::kEnableInt64, "1"));
+  auto provider = WebGpuExecutionProviderWithOptions(config_options);
+  test.ConfigEp(std::move(provider))
+      .RunWithConfig();
+}
+#endif
 
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
@@ -5055,7 +5055,7 @@ TEST(MathOpTest, BitwiseNot_uint8) {
 }
 
 #ifdef USE_WEBGPU
-TEST(MathOpTest, Sub_int64_webgpu) {
+TEST(MathOpTest, Sub_webgpu_int64) {
   OpTester test("Sub", 14);
   test.AddInput<int64_t>("A", {4}, {10, 5, -3, 0});
   test.AddInput<int64_t>("B", {4}, {3, 5, 1, -7});
@@ -5067,11 +5067,78 @@ TEST(MathOpTest, Sub_int64_webgpu) {
       .RunWithConfig();
 }
 
-TEST(MathOpTest, Equal_int64_webgpu) {
+TEST(MathOpTest, Equal_webgpu_int64) {
   OpTester test("Equal", 13);
   test.AddInput<int64_t>("A", {5}, {1, 0, -1, -1, 3});
   test.AddInput<int64_t>("B", {5}, {1, 1, 2, -1, 3});
   test.AddOutput<bool>("C", {5}, {true, false, false, true, true});
+  ConfigOptions config_options{};
+  ASSERT_STATUS_OK(config_options.AddConfigEntry(webgpu::options::kEnableInt64, "1"));
+  auto provider = WebGpuExecutionProviderWithOptions(config_options);
+  test.ConfigEp(std::move(provider))
+      .RunWithConfig();
+}
+
+// Size divisible by 4: exercises the packed-bool path without tail padding.
+TEST(MathOpTest, Equal_webgpu_int64_size_div4) {
+  OpTester test("Equal", 13);
+  test.AddInput<int64_t>("A", {8}, {1, 2, 3, 4, 5, 6, 7, 8});
+  test.AddInput<int64_t>("B", {8}, {1, 0, 3, 0, 5, 0, 7, 0});
+  test.AddOutput<bool>("C", {8}, {true, false, true, false, true, false, true, false});
+  ConfigOptions config_options{};
+  ASSERT_STATUS_OK(config_options.AddConfigEntry(webgpu::options::kEnableInt64, "1"));
+  auto provider = WebGpuExecutionProviderWithOptions(config_options);
+  test.ConfigEp(std::move(provider))
+      .RunWithConfig();
+}
+
+// Scalar LHS: lhs is a scalar, rhs is a vector; exercises is_lhs_scalar_ path.
+TEST(MathOpTest, Equal_webgpu_int64_lhs_scalar) {
+  OpTester test("Equal", 13);
+  test.AddInput<int64_t>("A", {1}, {3});
+  test.AddInput<int64_t>("B", {5}, {1, 2, 3, 4, 3});
+  test.AddOutput<bool>("C", {5}, {false, false, true, false, true});
+  ConfigOptions config_options{};
+  ASSERT_STATUS_OK(config_options.AddConfigEntry(webgpu::options::kEnableInt64, "1"));
+  auto provider = WebGpuExecutionProviderWithOptions(config_options);
+  test.ConfigEp(std::move(provider))
+      .RunWithConfig();
+}
+
+// Scalar RHS: rhs is a scalar, lhs is a vector; exercises is_rhs_scalar_ path.
+TEST(MathOpTest, Equal_webgpu_int64_rhs_scalar) {
+  OpTester test("Equal", 13);
+  test.AddInput<int64_t>("A", {5}, {1, 2, 3, 4, 3});
+  test.AddInput<int64_t>("B", {1}, {3});
+  test.AddOutput<bool>("C", {5}, {false, false, true, false, true});
+  ConfigOptions config_options{};
+  ASSERT_STATUS_OK(config_options.AddConfigEntry(webgpu::options::kEnableInt64, "1"));
+  auto provider = WebGpuExecutionProviderWithOptions(config_options);
+  test.ConfigEp(std::move(provider))
+      .RunWithConfig();
+}
+
+// Shape broadcast, size not divisible by 4: A [1,3] broadcasts against B [2,3] -> output [2,3].
+// Exercises the INT64 broadcast path with tail padding in the packed-bool output.
+TEST(MathOpTest, Equal_webgpu_int64_broadcast) {
+  OpTester test("Equal", 13);
+  test.AddInput<int64_t>("A", {1, 3}, {1, 2, 3});
+  test.AddInput<int64_t>("B", {2, 3}, {1, 0, 3, 1, 2, 3});
+  test.AddOutput<bool>("C", {2, 3}, {true, false, true, true, true, true});
+  ConfigOptions config_options{};
+  ASSERT_STATUS_OK(config_options.AddConfigEntry(webgpu::options::kEnableInt64, "1"));
+  auto provider = WebGpuExecutionProviderWithOptions(config_options);
+  test.ConfigEp(std::move(provider))
+      .RunWithConfig();
+}
+
+// Shape broadcast, size divisible by 4: A [1,4] broadcasts against B [2,4] -> output [2,4].
+// Exercises the INT64 broadcast path without tail padding.
+TEST(MathOpTest, Equal_webgpu_int64_broadcast_size_div4) {
+  OpTester test("Equal", 13);
+  test.AddInput<int64_t>("A", {1, 4}, {1, 2, 3, 4});
+  test.AddInput<int64_t>("B", {2, 4}, {1, 0, 3, 0, 1, 2, 3, 4});
+  test.AddOutput<bool>("C", {2, 4}, {true, false, true, false, true, true, true, true});
   ConfigOptions config_options{};
   ASSERT_STATUS_OK(config_options.AddConfigEntry(webgpu::options::kEnableInt64, "1"));
   auto provider = WebGpuExecutionProviderWithOptions(config_options);

--- a/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
@@ -5067,6 +5067,19 @@ TEST(MathOpTest, Sub_webgpu_int64) {
       .RunWithConfig();
 }
 
+// INT64 Sub with broadcast: A [1,3] broadcasts against B [2,3] -> output [2,3].
+TEST(MathOpTest, Sub_webgpu_int64_broadcast) {
+  OpTester test("Sub", 14);
+  test.AddInput<int64_t>("A", {1, 3}, {10, 20, 30});
+  test.AddInput<int64_t>("B", {2, 3}, {1, 2, 3, 4, 5, 6});
+  test.AddOutput<int64_t>("C", {2, 3}, {9, 18, 27, 6, 15, 24});
+  ConfigOptions config_options{};
+  ASSERT_STATUS_OK(config_options.AddConfigEntry(webgpu::options::kEnableInt64, "1"));
+  auto provider = WebGpuExecutionProviderWithOptions(config_options);
+  test.ConfigEp(std::move(provider))
+      .RunWithConfig();
+}
+
 TEST(MathOpTest, Equal_webgpu_int64) {
   OpTester test("Equal", 13);
   test.AddInput<int64_t>("A", {5}, {1, 0, -1, -1, 3});

--- a/onnxruntime/test/providers/cpu/reduction/reduction_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/reduction/reduction_ops_test.cc
@@ -7000,7 +7000,7 @@ TEST(ReductionOpTest, ReduceSum_int64_webgpu) {
   OpTester test("ReduceSum", 13);
   test.AddInput<int64_t>("data", {3}, {10, 20, 30});
   test.AddInput<int64_t>("axes", {1}, {0}, true);
-  test.AddOutput<int64_t>("reduced", {}, {60});
+  test.AddOutput<int64_t>("reduced", {1}, {60});
   ConfigOptions config_options{};
   ASSERT_STATUS_OK(config_options.AddConfigEntry(webgpu::options::kEnableInt64, "1"));
   auto provider = WebGpuExecutionProviderWithOptions(config_options);

--- a/onnxruntime/test/providers/cpu/reduction/reduction_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/reduction/reduction_ops_test.cc
@@ -13,6 +13,10 @@
 #include "core/providers/cpu/reduction/reduction_ops.h"
 #include "test/util/include/default_providers.h"
 
+#ifdef USE_WEBGPU
+#include "core/providers/webgpu/webgpu_provider_options.h"
+#endif
+
 namespace onnxruntime {
 namespace test {
 
@@ -6990,6 +6994,20 @@ TEST(ReductionOpTest, ReduceProd_EmptySet_DefaultAxes_KeepDims) {
             kMIGraphXExecutionProvider, kOpenVINOExecutionProvider, kQnnExecutionProvider,
             kTensorrtExecutionProvider, kWebGpuExecutionProvider});
 }
+
+#ifdef USE_WEBGPU
+TEST(ReductionOpTest, ReduceSum_int64_webgpu) {
+  OpTester test("ReduceSum", 13);
+  test.AddInput<int64_t>("data", {3}, {10, 20, 30});
+  test.AddInput<int64_t>("axes", {1}, {0}, true);
+  test.AddOutput<int64_t>("reduced", {}, {60});
+  ConfigOptions config_options{};
+  ASSERT_STATUS_OK(config_options.AddConfigEntry(webgpu::options::kEnableInt64, "1"));
+  auto provider = WebGpuExecutionProviderWithOptions(config_options);
+  test.ConfigEp(std::move(provider))
+      .RunWithConfig();
+}
+#endif
 
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/cpu/reduction/reduction_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/reduction/reduction_ops_test.cc
@@ -6996,11 +6996,24 @@ TEST(ReductionOpTest, ReduceProd_EmptySet_DefaultAxes_KeepDims) {
 }
 
 #ifdef USE_WEBGPU
-TEST(ReductionOpTest, ReduceSum_int64_webgpu) {
+TEST(ReductionOpTest, ReduceSum_WebGpu_EnableInt64) {
   OpTester test("ReduceSum", 13);
   test.AddInput<int64_t>("data", {3}, {10, 20, 30});
   test.AddInput<int64_t>("axes", {1}, {0}, true);
   test.AddOutput<int64_t>("reduced", {1}, {60});
+  ConfigOptions config_options{};
+  ASSERT_STATUS_OK(config_options.AddConfigEntry(webgpu::options::kEnableInt64, "1"));
+  auto provider = WebGpuExecutionProviderWithOptions(config_options);
+  test.ConfigEp(std::move(provider))
+      .RunWithConfig();
+}
+
+// Size divisible by 4: catches issues if the shader is ever accidentally vectorized for INT64.
+TEST(ReductionOpTest, ReduceSum_WebGpu_EnableInt64_SizeDiv4) {
+  OpTester test("ReduceSum", 13);
+  test.AddInput<int64_t>("data", {4}, {10, 20, 30, 40});
+  test.AddInput<int64_t>("axes", {1}, {0}, true);
+  test.AddOutput<int64_t>("reduced", {1}, {100});
   ConfigOptions config_options{};
   ASSERT_STATUS_OK(config_options.AddConfigEntry(webgpu::options::kEnableInt64, "1"));
   auto provider = WebGpuExecutionProviderWithOptions(config_options);

--- a/onnxruntime/test/providers/cpu/tensor/where_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/where_op_test.cc
@@ -7,6 +7,11 @@
 
 #include "test/providers/provider_test_utils.h"
 
+#ifdef USE_WEBGPU
+#include "test/util/include/default_providers.h"
+#include "core/providers/webgpu/webgpu_provider_options.h"
+#endif
+
 namespace onnxruntime {
 namespace test {
 
@@ -145,6 +150,21 @@ TEST(WhereOpTest, BroadcastWithScalar) {
 
   test.Run();
 }
+
+#ifdef USE_WEBGPU
+TEST(WhereOpTest, Where_int64_webgpu) {
+  OpTester test{kOpName, kOpVersion};
+  test.AddInput<bool>("condition", {4}, {true, false, true, false});
+  test.AddInput<int64_t>("X", {4}, {10, 20, 30, 40});
+  test.AddInput<int64_t>("Y", {4}, {1, 2, 3, 4});
+  test.AddOutput<int64_t>("output", {4}, {10, 2, 30, 4});
+  ConfigOptions config_options{};
+  ASSERT_STATUS_OK(config_options.AddConfigEntry(webgpu::options::kEnableInt64, "1"));
+  auto provider = WebGpuExecutionProviderWithOptions(config_options);
+  test.ConfigEp(std::move(provider))
+      .RunWithConfig();
+}
+#endif
 
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/cpu/tensor/where_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/where_op_test.cc
@@ -152,12 +152,29 @@ TEST(WhereOpTest, BroadcastWithScalar) {
 }
 
 #ifdef USE_WEBGPU
-TEST(WhereOpTest, Where_int64_webgpu) {
+// Non-broadcast: all inputs have the same shape. Exercises the is_int64_ non-broadcast path.
+TEST(WhereOpTest, EnableWebGpuInt64) {
   OpTester test{kOpName, kOpVersion};
   test.AddInput<bool>("condition", {4}, {true, false, true, false});
   test.AddInput<int64_t>("X", {4}, {10, 20, 30, 40});
   test.AddInput<int64_t>("Y", {4}, {1, 2, 3, 4});
   test.AddOutput<int64_t>("output", {4}, {10, 2, 30, 4});
+  ConfigOptions config_options{};
+  ASSERT_STATUS_OK(config_options.AddConfigEntry(webgpu::options::kEnableInt64, "1"));
+  auto provider = WebGpuExecutionProviderWithOptions(config_options);
+  test.ConfigEp(std::move(provider))
+      .RunWithConfig();
+}
+
+// Broadcast: condition [1,4] broadcasts over X/Y [2,4]. Exercises the is_int64_ broadcast path
+// where BroadcastedIndicesToOffset computes a different source offset per output element.
+TEST(WhereOpTest, EnableBroadcastWebGpuInt64) {
+  // condition [1,4] broadcasts against X [2,4] and Y [2,4] -> output [2,4]
+  OpTester test{kOpName, kOpVersion};
+  test.AddInput<bool>("condition", {1, 4}, {true, false, true, false});
+  test.AddInput<int64_t>("X", {2, 4}, {10, 20, 30, 40, 50, 60, 70, 80});
+  test.AddInput<int64_t>("Y", {2, 4}, {1, 2, 3, 4, 5, 6, 7, 8});
+  test.AddOutput<int64_t>("output", {2, 4}, {10, 2, 30, 4, 50, 6, 70, 8});
   ConfigOptions config_options{};
   ASSERT_STATUS_OK(config_options.AddConfigEntry(webgpu::options::kEnableInt64, "1"));
   auto provider = WebGpuExecutionProviderWithOptions(config_options);


### PR DESCRIPTION
## Summary

These four ops were forcing CPU fallback when inputs were INT64, preventing WebGPU graph capture. Converted from static macro registration to the factory function pattern (same as Cast/Unsqueeze/Expand/Range) so INT64 type constraints are included when `enable_int64=true`.

`enable_int64` is always `true` when `enable_graph_capture=true` — `GetKernelRegistry` calls `RegisterKernels(true, true)` unconditionally in that path — so this fix has no effect on the default (non-graph-capture) execution path.

## Changed ops

| Op | Versions |
|---|---|
| `Equal` | 7–10, 11–12, 13–18, 19+ |
| `Sub` | 7–12, 13, 14+ |
| `Where` | 9–15, 16+ |
| `ReduceSum` | 1–10, 11–12, 13+ |

## Approach

Each op follows the established factory function pattern:

- `CreateXVersionedKernelInfo<Start, End>(bool enable_int64)` / `CreateXKernelInfo<Since>(bool enable_int64)`
- Removed from static `build_kernel_create_info_function_table[]`
- Registered in `RegisterKernels()` alongside Cast/Unsqueeze/Expand/Range

`ReduceSum` version 13+ retains `InputMemoryType(OrtMemTypeCPUInput, 1)` (axes input must be on CPU) — unchanged from the original registration.

`Where` factory functions delegate to `GetOpTypeConstraints(enable_int64, /*enable_bool=*/true)` rather than a local duplicate type list. All three files (`where.cc`, `binary_elementwise_ops.cc`, `reduction_ops.cc`) use stack-allocated `KernelDefBuilder()` consistent with other WebGPU factory functions, and drop the unused `webgpu_execution_provider.h` include.

## Runtime fixes for INT64 inference

`BinaryElementwise` (`Sub`, `Equal`) and `Where` required additional shader-level fixes to correctly handle INT64 tensors at inference time:

- **Vectorization disabled for INT64**: INT64 is stored as `vec2<u32>` (8 bytes/element) and has no vec4 representation. Vectorization is now disabled when either input is INT64, and `component=1` is used for correct buffer binding.
- **Correct dispatch size**: `vec_size` is computed as element count (not rounded-up vec4 count) for INT64 outputs.
- **Scalar input path**: The scalar broadcast path no longer applies an extra `.x` dereference on top of `GetByOffset`, which already extracts the `i32` element for INT64.
- **Where non-broadcast path**: Non-broadcast INT64 `Where` now uses the element-per-thread shader path instead of the vec4 fast path that would truncate values to i32.
- **Cache key**: `is_int64` is included in the `Where` cache hint, preventing float and INT64 shaders from incorrectly sharing a cached entry.
- **Shape indices for INT64**: Shape indices are registered for non-broadcast INT64 `Where` so `BroadcastedIndicesToOffset` has the required helpers available.
- **Equal INT64 with bool output**: The element-wise path now explicitly reads 4 consecutive INT64 elements per thread and packs them into a `vec4<bool>` before writing to the bool output buffer. Previously, only element 0 was read and broadcast across all 4 positions of the comparison, giving wrong results.

## Testing

- All 1174 nodes of a Gemma4 WebGPU decoder model assigned to `WebGpuExecutionProvider` (previously ~20 nodes fell back to CPU due to INT64 Equal/Sub/Where/ReduceSum)
- End-to-end graph capture inference: ~87 tok/s on Gemma4-E2B-it INT4
- `USE_WEBGPU`-guarded unit tests added for all four ops with `kEnableInt64=1`: `Sub_int64_webgpu`, `Equal_int64_webgpu`, `Where_int64_webgpu`, `ReduceSum_int64_webgpu`

## Related

- Indirect dispatch fix (prerequisite for graph capture): #29236
- https://github.com/onnxruntime/mobius/pull/380