### PR TITLE
Fix path traversal in TensorRT EP RefitEngine

### DIFF
--- a/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.cc
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.cc
@@ -2264,7 +2264,6 @@ NvExecutionProvider::GetCapability(const GraphViewer& graph,
  */
 common::Status NvExecutionProvider::RefitEngine(std::string onnx_model_filename,
                                                 std::string& onnx_model_folder_path,
-                                                bool path_check,
                                                 const void* onnx_model_bytestream,
                                                 size_t onnx_model_bytestream_size,
                                                 const void* onnx_external_data_bytestream,
@@ -2285,7 +2284,7 @@ common::Status NvExecutionProvider::RefitEngine(std::string onnx_model_filename,
                              "Please use provide an ONNX bytestream to enable refitting the weightless engine.");
     } else {
       // Validate that the ONNX model path does not escape the model directory.
-      if (path_check && !onnx_model_filename.empty()) {
+      if (!onnx_model_filename.empty()) {
         ORT_RETURN_IF_ERROR(utils::ValidateExternalDataPathFromDir(
             std::filesystem::path(onnx_model_folder_path), std::filesystem::path(onnx_model_filename)));
       }
@@ -3052,9 +3051,12 @@ Status NvExecutionProvider::CreateNodeComputeInfoFromGraph(const GraphViewer& gr
 
   if (weight_stripped_engine_refit_) {
     LOGS_DEFAULT(VERBOSE) << "[NvTensorRTRTX EP] Refit engine from main ONNX file after engine build";
-    auto status = RefitEngine(model_path_,
-                              onnx_model_folder_path_,
-                              false /* path check for security */,
+    std::filesystem::path model_fs_path(model_path_);
+    std::string refit_folder = onnx_model_folder_path_.empty()
+                                   ? model_fs_path.parent_path().string()
+                                   : onnx_model_folder_path_;
+    auto status = RefitEngine(model_fs_path.filename().string(),
+                              refit_folder,
                               onnx_model_bytestream_,
                               onnx_model_bytestream_size_,
                               onnx_external_data_bytestream_,

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.h
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.h
@@ -344,7 +344,6 @@ class NvExecutionProvider : public IExecutionProvider {
 
   static common::Status RefitEngine(std::string onnx_model_filename,
                                     std::string& onnx_model_folder_path,
-                                    bool path_check,
                                     const void* onnx_model_bytestream,
                                     size_t onnx_model_bytestream_size,
                                     const void* onnx_external_data_bytestream,

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/onnx_ctx_model_helper.cc
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/onnx_ctx_model_helper.cc
@@ -317,8 +317,6 @@ Status TensorRTCacheModelHandler::GetEpContextFromGraph(const Node& node) {
   auto& attrs = node.GetAttributes();
 
   const int64_t embed_mode = attrs.at(EMBED_MODE).i();
-  // Only make path checks if model not provided as byte buffer
-  bool make_secure_path_checks = ep_context_model_path_.empty();
 
   if (embed_mode) {
     // Get engine from byte stream.
@@ -335,7 +333,6 @@ Status TensorRTCacheModelHandler::GetEpContextFromGraph(const Node& node) {
       const std::string onnx_model_filename = attrs.at(ONNX_MODEL_FILENAME).s();
       auto status = NvExecutionProvider::RefitEngine(onnx_model_filename,
                                                      onnx_model_folder_path_,
-                                                     make_secure_path_checks,
                                                      onnx_model_bytestream_,
                                                      onnx_model_bytestream_size_,
                                                      onnx_external_data_bytestream_,
@@ -389,7 +386,6 @@ Status TensorRTCacheModelHandler::GetEpContextFromGraph(const Node& node) {
       std::string weight_stripped_engine_cache = engine_cache_path.string();
       auto status = NvExecutionProvider::RefitEngine(onnx_model_filename,
                                                      onnx_model_folder_path_,
-                                                     make_secure_path_checks,
                                                      onnx_model_bytestream_,
                                                      onnx_model_bytestream_size_,
                                                      onnx_external_data_bytestream_,

--- a/onnxruntime/core/providers/tensorrt/onnx_ctx_model_helper.cc
+++ b/onnxruntime/core/providers/tensorrt/onnx_ctx_model_helper.cc
@@ -287,8 +287,6 @@ Status TensorRTCacheModelHandler::GetEpContextFromGraph(const GraphViewer& graph
   auto& attrs = node->GetAttributes();
 
   const int64_t embed_mode = attrs.at(EMBED_MODE).i();
-  // Only make path checks if model not provided as byte buffer
-  bool make_secure_path_checks = !GetModelPath(graph_viewer).empty();
 
   if (embed_mode) {
     // Get engine from byte stream.
@@ -307,7 +305,6 @@ Status TensorRTCacheModelHandler::GetEpContextFromGraph(const GraphViewer& graph
       auto status = TensorrtExecutionProvider::RefitEngine(onnx_model_filename,
                                                            onnx_model_folder_path_,
                                                            placeholder,
-                                                           make_secure_path_checks,
                                                            onnx_model_bytestream_,
                                                            onnx_model_bytestream_size_,
                                                            onnx_external_data_bytestream_,
@@ -372,7 +369,6 @@ Status TensorRTCacheModelHandler::GetEpContextFromGraph(const GraphViewer& graph
       auto status = TensorrtExecutionProvider::RefitEngine(onnx_model_filename,
                                                            onnx_model_folder_path_,
                                                            weight_stripped_engine_cache,
-                                                           make_secure_path_checks,
                                                            onnx_model_bytestream_,
                                                            onnx_model_bytestream_size_,
                                                            onnx_external_data_bytestream_,

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -2873,7 +2873,6 @@ TensorrtExecutionProvider::GetCapability(const GraphViewer& graph,
 common::Status TensorrtExecutionProvider::RefitEngine(std::string onnx_model_filename,
                                                       std::string& onnx_model_folder_path,
                                                       std::string& weight_stripped_engine_cath_path,
-                                                      bool path_check,
                                                       const void* onnx_model_bytestream,
                                                       size_t onnx_model_bytestream_size,
                                                       const void* onnx_external_data_bytestream,
@@ -2897,7 +2896,7 @@ common::Status TensorrtExecutionProvider::RefitEngine(std::string onnx_model_fil
                              "When providing a bytestream during session initialization, it should also be set as trt_onnx_bytes_stream");
     } else {
       // Validate that the ONNX model path does not escape the model directory.
-      if (path_check && !onnx_model_filename.empty()) {
+      if (!onnx_model_filename.empty()) {
         ORT_RETURN_IF_ERROR(utils::ValidateExternalDataPathFromDir(
             std::filesystem::path(onnx_model_folder_path), std::filesystem::path(onnx_model_filename)));
       }
@@ -3709,10 +3708,13 @@ Status TensorrtExecutionProvider::CreateNodeComputeInfoFromGraph(const GraphView
 
     if (weight_stripped_engine_refit_) {
       LOGS_DEFAULT(VERBOSE) << "[TensorRT EP] Refit engine from main ONNX file after engine build";
-      auto status = RefitEngine(model_path_,
-                                onnx_model_folder_path_,
+      std::filesystem::path model_fs_path(model_path_);
+      std::string refit_folder = onnx_model_folder_path_.empty()
+                                     ? model_fs_path.parent_path().string()
+                                     : onnx_model_folder_path_;
+      auto status = RefitEngine(model_fs_path.filename().string(),
+                                refit_folder,
                                 engine_cache_path,
-                                false /* path check for security */,
                                 onnx_model_bytestream_,
                                 onnx_model_bytestream_size_,
                                 onnx_external_data_bytestream_,
@@ -4204,10 +4206,13 @@ Status TensorrtExecutionProvider::CreateNodeComputeInfoFromGraph(const GraphView
       context_update = true;
 
       if (weight_stripped_engine_refit_) {
-        auto status = RefitEngine(model_path_,
-                                  onnx_model_folder_path_,
+        std::filesystem::path model_fs_path(model_path_);
+        std::string refit_folder = onnx_model_folder_path_.empty()
+                                       ? model_fs_path.parent_path().string()
+                                       : onnx_model_folder_path_;
+        auto status = RefitEngine(model_fs_path.filename().string(),
+                                  refit_folder,
                                   engine_cache_path,
-                                  false /* path check for security */,
                                   onnx_model_bytestream_,
                                   onnx_model_bytestream_size_,
                                   onnx_external_data_bytestream_,

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.h
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.h
@@ -315,7 +315,6 @@ class TensorrtExecutionProvider : public IExecutionProvider {
   static common::Status RefitEngine(std::string onnx_model_filename,
                                     std::string& onnx_model_folder_path,
                                     std::string& weight_stripped_engine_cath_path,
-                                    bool path_check,
                                     const void* onnx_model_bytestream,
                                     size_t onnx_model_bytestream_size,
                                     const void* onnx_external_data_bytestream,


### PR DESCRIPTION
## Summary

Fix a path traversal vulnerability in the TensorRT and NvTensorRTRTX Execution Providers' `RefitEngine()` function. Path validation was deliberately disabled at production call sites, allowing malicious ONNX models to potentially read arbitrary files when weight-stripped engine refitting is active.

## Problem

`RefitEngine()` accepted a `path_check` parameter that controlled whether path traversal validation was performed. All non-EPContext call sites passed `false`, completely bypassing security checks. Additionally, the NvTensorRTRTX `onnx_ctx_model_helper.cc` had **inverted** logic (`ep_context_model_path_.empty()` instead of `!...empty()`), which disabled path checks when loading from files -- the exact case where validation is most needed.

An attacker could craft a malicious ONNX model with a traversal path in the `ONNX_MODEL_FILENAME` attribute (e.g. `../../../etc/passwd`) to cause the runtime to read arbitrary filesystem paths during engine refitting.

## Fix

- **Remove the `path_check` parameter** from `RefitEngine()` in both TensorRT EP and NvTensorRTRTX EP -- path validation via `ValidateExternalDataPathFromDir()` is now unconditional
- **At internal call sites**, extract just the filename from `model_path_` and derive the folder path so validation can verify directory containment (`model_path_` is a full absolute path from `graph.ModelPath()`, which would be rejected by the validator as-is)
- **Remove `make_secure_path_checks`** variable from both `onnx_ctx_model_helper.cc` files (no longer needed since validation is always on)

## Files Changed

- `onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.h` -- remove `path_check` parameter
- `onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc` -- always validate, fix call sites
- `onnxruntime/core/providers/tensorrt/onnx_ctx_model_helper.cc` -- remove now-unused variable and argument
- `onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.h` -- remove `path_check` parameter
- `onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.cc` -- always validate, fix call site
- `onnxruntime/core/providers/nv_tensorrt_rtx/onnx_ctx_model_helper.cc` -- remove inverted-logic variable and argument