### PR TITLE
[MLAS][KleidiAI] Integrate Depthwise 3x3 Conv Kernel

### DIFF
--- a/cmake/onnxruntime_mlas.cmake
+++ b/cmake/onnxruntime_mlas.cmake
@@ -320,6 +320,7 @@ function(setup_kleidiai)
     ${MLAS_SRC_DIR}/kleidiai/sbgemm_kleidiai.cpp
     ${MLAS_SRC_DIR}/kleidiai/convolve_kleidiai.cpp
     ${MLAS_SRC_DIR}/kleidiai/qgemm_kleidiai.cpp
+    ${MLAS_SRC_DIR}/kleidiai/dw_conv_kleidiai.cpp
   )
   target_link_libraries(onnxruntime_mlas PRIVATE kleidiai)
   list(APPEND onnxruntime_EXTERNAL_LIBRARIES kleidiai)

--- a/cmake/onnxruntime_mlas.cmake
+++ b/cmake/onnxruntime_mlas.cmake
@@ -367,6 +367,7 @@ function(setup_kleidiai)
     ${MLAS_SRC_DIR}/kleidiai/convolve_kleidiai.cpp
     ${MLAS_SRC_DIR}/kleidiai/qgemm_kleidiai.cpp
     ${MLAS_SRC_DIR}/kleidiai/qnbitgemm_kleidiai.cpp
+    ${MLAS_SRC_DIR}/kleidiai/dw_conv_kleidiai.cpp
   )
   target_link_libraries(onnxruntime_mlas PRIVATE kleidiai)
   list(APPEND onnxruntime_EXTERNAL_LIBRARIES kleidiai)

--- a/onnxruntime/core/mlas/lib/convolve.cpp
+++ b/onnxruntime/core/mlas/lib/convolve.cpp
@@ -1351,6 +1351,9 @@ static constexpr size_t ComputeChannelsLastConvOutSize(size_t input, size_t kern
 
     return 0;
 }
+
+constexpr size_t kKleidiAIDepthwiseRowsPerTile = 4;
+constexpr size_t kKleidiAIDepthwiseColsPerTile = 4;
 #endif
 
 }  // namespace
@@ -1453,22 +1456,46 @@ MlasConvSupportsDepthwiseChannelsLast2DFloatKernel(
     MLAS_UNREFERENCED_PARAMETER(Beta);
     return false;
 #else
-    MLAS_UNREFERENCED_PARAMETER(Dimensions);
-    MLAS_UNREFERENCED_PARAMETER(BatchCount);
-    MLAS_UNREFERENCED_PARAMETER(GroupCount);
-    MLAS_UNREFERENCED_PARAMETER(InputChannelsPerGroup);
-    MLAS_UNREFERENCED_PARAMETER(InputShape);
-    MLAS_UNREFERENCED_PARAMETER(KernelShape);
-    MLAS_UNREFERENCED_PARAMETER(DilationShape);
-    MLAS_UNREFERENCED_PARAMETER(Padding);
-    MLAS_UNREFERENCED_PARAMETER(StrideShape);
-    MLAS_UNREFERENCED_PARAMETER(FilterCount);
-    MLAS_UNREFERENCED_PARAMETER(Beta);
+    if (GetMlasPlatform().MlasConvPrepareOverride == nullptr ||
+        GetMlasPlatform().MlasConvOverride == nullptr) {
+        return false;
+    }
 
-    // TODO: enable only for shapes supported by the dedicated
-    // depthwise kernel. Until then, keep depthwise/grouped convolutions out of
-    // the Arm® KleidiAI™ NHWC path.
-    return false;
+    if (!MLAS_CPUIDINFO::GetCPUIDInfo().HasArm_SME2()) {
+        return false;
+    }
+
+    if (Dimensions != 2 || BatchCount != 1 || Beta != 0.0f || GroupCount == 0) {
+        return false;
+    }
+
+    if (InputChannelsPerGroup != 1 || FilterCount != 1) {
+        return false;
+    }
+
+    if (KernelShape[0] != 3 || KernelShape[1] != 3) {
+        return false;
+    }
+
+    if (StrideShape[0] != 1 || StrideShape[1] != 1) {
+        return false;
+    }
+
+    if (DilationShape[0] != 1 || DilationShape[1] != 1) {
+        return false;
+    }
+
+    const bool zero_padding = Padding[0] == 0 && Padding[1] == 0 && Padding[2] == 0 && Padding[3] == 0;
+    const bool unit_padding = Padding[0] == 1 && Padding[1] == 1 && Padding[2] == 1 && Padding[3] == 1;
+    if (!zero_padding && !unit_padding) {
+        return false;
+    }
+
+    const size_t output_h =
+        ComputeChannelsLastConvOutSize(InputShape[0], KernelShape[0], Padding[0], StrideShape[0]);
+    const size_t output_w =
+        ComputeChannelsLastConvOutSize(InputShape[1], KernelShape[1], Padding[1], StrideShape[1]);
+    return output_h >= kKleidiAIDepthwiseRowsPerTile && output_w >= kKleidiAIDepthwiseColsPerTile;
 #endif
 }
 

--- a/onnxruntime/core/mlas/lib/convolve.cpp
+++ b/onnxruntime/core/mlas/lib/convolve.cpp
@@ -1348,6 +1348,9 @@ static constexpr size_t ComputeChannelsLastConvOutSize(size_t input, size_t kern
 
     return 0;
 }
+
+constexpr size_t kKleidiAIDepthwiseRowsPerTile = 4;
+constexpr size_t kKleidiAIDepthwiseColsPerTile = 4;
 #endif
 
 }  // namespace
@@ -1450,22 +1453,46 @@ MlasConvSupportsDepthwiseChannelsLast2DFloatKernel(
     MLAS_UNREFERENCED_PARAMETER(Beta);
     return false;
 #else
-    MLAS_UNREFERENCED_PARAMETER(Dimensions);
-    MLAS_UNREFERENCED_PARAMETER(BatchCount);
-    MLAS_UNREFERENCED_PARAMETER(GroupCount);
-    MLAS_UNREFERENCED_PARAMETER(InputChannelsPerGroup);
-    MLAS_UNREFERENCED_PARAMETER(InputShape);
-    MLAS_UNREFERENCED_PARAMETER(KernelShape);
-    MLAS_UNREFERENCED_PARAMETER(DilationShape);
-    MLAS_UNREFERENCED_PARAMETER(Padding);
-    MLAS_UNREFERENCED_PARAMETER(StrideShape);
-    MLAS_UNREFERENCED_PARAMETER(FilterCount);
-    MLAS_UNREFERENCED_PARAMETER(Beta);
+    if (GetMlasPlatform().MlasConvPrepareOverride == nullptr ||
+        GetMlasPlatform().MlasConvOverride == nullptr) {
+        return false;
+    }
 
-    // TODO: enable only for shapes supported by the dedicated
-    // depthwise kernel. Until then, keep depthwise/grouped convolutions out of
-    // the Arm® KleidiAI™ NHWC path.
-    return false;
+    if (!MLAS_CPUIDINFO::GetCPUIDInfo().HasArm_SME2()) {
+        return false;
+    }
+
+    if (Dimensions != 2 || BatchCount != 1 || Beta != 0.0f || GroupCount == 0) {
+        return false;
+    }
+
+    if (InputChannelsPerGroup != 1 || FilterCount != 1) {
+        return false;
+    }
+
+    if (KernelShape[0] != 3 || KernelShape[1] != 3) {
+        return false;
+    }
+
+    if (StrideShape[0] != 1 || StrideShape[1] != 1) {
+        return false;
+    }
+
+    if (DilationShape[0] != 1 || DilationShape[1] != 1) {
+        return false;
+    }
+
+    const bool zero_padding = Padding[0] == 0 && Padding[1] == 0 && Padding[2] == 0 && Padding[3] == 0;
+    const bool unit_padding = Padding[0] == 1 && Padding[1] == 1 && Padding[2] == 1 && Padding[3] == 1;
+    if (!zero_padding && !unit_padding) {
+        return false;
+    }
+
+    const size_t output_h =
+        ComputeChannelsLastConvOutSize(InputShape[0], KernelShape[0], Padding[0], StrideShape[0]);
+    const size_t output_w =
+        ComputeChannelsLastConvOutSize(InputShape[1], KernelShape[1], Padding[1], StrideShape[1]);
+    return output_h >= kKleidiAIDepthwiseRowsPerTile && output_w >= kKleidiAIDepthwiseColsPerTile;
 #endif
 }
 

--- a/onnxruntime/core/mlas/lib/convolve.cpp
+++ b/onnxruntime/core/mlas/lib/convolve.cpp
@@ -15,6 +15,9 @@ Abstract:
 --*/
 
 #include "mlasi.h"
+#if defined(USE_KLEIDIAI) && defined(MLAS_TARGET_ARM64)
+#include "kleidiai/mlasi_kleidiai.h"
+#endif
 #if defined(BUILD_MLAS_NO_ONNXRUNTIME)
 // Standalone MLAS builds don't have access to the ORT-internal SafeInt
 // wrapper; fall back to the SafeInt.hpp header directly (its default
@@ -1352,8 +1355,6 @@ static constexpr size_t ComputeChannelsLastConvOutSize(size_t input, size_t kern
     return 0;
 }
 
-constexpr size_t kKleidiAIDepthwiseRowsPerTile = 4;
-constexpr size_t kKleidiAIDepthwiseColsPerTile = 4;
 #endif
 
 }  // namespace
@@ -1461,41 +1462,27 @@ MlasConvSupportsDepthwiseChannelsLast2DFloatKernel(
         return false;
     }
 
-    if (!MLAS_CPUIDINFO::GetCPUIDInfo().HasArm_SME2()) {
+    if (Dimensions != 2) {
         return false;
     }
 
-    if (Dimensions != 2 || BatchCount != 1 || Beta != 0.0f || GroupCount == 0) {
-        return false;
+    MLAS_CONV_PARAMETERS parameters{};
+    parameters.Dimensions = Dimensions;
+    parameters.BatchCount = BatchCount;
+    parameters.GroupCount = GroupCount;
+    parameters.InputChannels = InputChannelsPerGroup;
+    parameters.FilterCount = FilterCount;
+    parameters.Beta = Beta;
+    for (size_t dim = 0; dim < Dimensions; ++dim) {
+        parameters.InputShape[dim] = InputShape[dim];
+        parameters.KernelShape[dim] = KernelShape[dim];
+        parameters.DilationShape[dim] = DilationShape[dim];
+        parameters.Padding[dim] = Padding[dim];
+        parameters.Padding[dim + Dimensions] = Padding[dim + Dimensions];
+        parameters.StrideShape[dim] = StrideShape[dim];
     }
 
-    if (InputChannelsPerGroup != 1 || FilterCount != 1) {
-        return false;
-    }
-
-    if (KernelShape[0] != 3 || KernelShape[1] != 3) {
-        return false;
-    }
-
-    if (StrideShape[0] != 1 || StrideShape[1] != 1) {
-        return false;
-    }
-
-    if (DilationShape[0] != 1 || DilationShape[1] != 1) {
-        return false;
-    }
-
-    const bool zero_padding = Padding[0] == 0 && Padding[1] == 0 && Padding[2] == 0 && Padding[3] == 0;
-    const bool unit_padding = Padding[0] == 1 && Padding[1] == 1 && Padding[2] == 1 && Padding[3] == 1;
-    if (!zero_padding && !unit_padding) {
-        return false;
-    }
-
-    const size_t output_h =
-        ComputeChannelsLastConvOutSize(InputShape[0], KernelShape[0], Padding[0], StrideShape[0]);
-    const size_t output_w =
-        ComputeChannelsLastConvOutSize(InputShape[1], KernelShape[1], Padding[1], StrideShape[1]);
-    return output_h >= kKleidiAIDepthwiseRowsPerTile && output_w >= kKleidiAIDepthwiseColsPerTile;
+    return ArmKleidiAI::DepthwiseConvKleidiAISupported(&parameters);
 #endif
 }
 

--- a/onnxruntime/core/mlas/lib/kai_ukernel_interface.cpp
+++ b/onnxruntime/core/mlas/lib/kai_ukernel_interface.cpp
@@ -40,6 +40,8 @@
 #include "kai/ukernels/matmul/matmul_clamp_f32_f32_f32p/kai_matmul_clamp_f32_f32_f32p2vlx1b_1x16vl_sme2_mla.h"
 //   IMATMUL
 #include "kai/ukernels/matmul/imatmul_clamp_f32_f32p_f32p/kai_imatmul_clamp_f32_f32p2vlx1_f32p2vlx1b_2vlx2vl_sme2_mopa.h"
+//   DWCONV
+#include "kai/ukernels/dwconv/dwconv_f32_f32_f32p/kai_dwconv_clamp_f32_f32_f32p1vlx1b_3x3_s1_4xc_sme2_mla.h"
 
 #if defined(ENABLE_QMX_KERNELS)
 // QMX kernels (optional)
@@ -232,6 +234,9 @@ const KaiF32IMatmulKernel imatmul_conv_sme2 =
 const KaiBF16SBgemmKernel sbgemm_gemm_sme2 =
     KAI_WRAP_UKERNEL_RUN_MATMUL_11(matmul_clamp_f32_bf16p2vlx2_bf16p2vlx2_2vlx2vl_sme2_mopa);
 
+const KaiF32DepthwiseConvKernel dwconv_sme2 =
+    KAI_WRAP_UKERNEL_RUN_DWCONV_PLANAR_4(dwconv_clamp_f32_f32_f32p1vlx1b_3x3_s1_4xc_sme2_mla);
+
 #if defined(ENABLE_QMX_KERNELS)
 const KaiF32IMatmulKernel imatmul_conv_qmx =
     KAI_WRAP_UKERNEL_RUN_IMATMUL_PACKED_7(imatmul_clamp_f32_f32p2vlx1_f32p2vlx1b_2vlx2vl_qmx_mopa);
@@ -371,4 +376,9 @@ const KaiDynamicQGemmKernel& GetKleidiAIQGemmUKernel() {
 const KaiBF16SBgemmKernel& GetKleidiAISBGemmUKernel() {
     // Currently only SME2 variant exists for bfloat16/SBGEMM kernel
     return sbgemm_gemm_sme2;
+}
+
+const KaiF32DepthwiseConvKernel& GetKleidiAIDepthwiseConvUKernel() {
+    // Currently only an SME2 variant exists for FP32 depthwise convolution.
+    return dwconv_sme2;
 }

--- a/onnxruntime/core/mlas/lib/kai_ukernel_interface.h
+++ b/onnxruntime/core/mlas/lib/kai_ukernel_interface.h
@@ -18,13 +18,18 @@
 
 #include "kai/ukernels/matmul/imatmul_clamp_f32_f32p_f32p/kai_imatmul_clamp_f32_f32p_f32p_interface.h"
 
+#include "kai/ukernels/dwconv/dwconv_f32_f32_f32p/kai_dwconv_clamp_f32_f32_f32p_interface.h"
+
 // Wrapper type that carries a stable "name" alongside the KAI ukernel interface.
 // This avoids needing to infer which underlying microkernel was selected from a function pointer.
 template <typename UkernelFn>
-struct KaiMatmulKernel {
+struct KaiKernel {
     const char* name;
     UkernelFn ukernel;
 };
+
+template <typename UkernelFn>
+using KaiMatmulKernel = KaiKernel<UkernelFn>;
 
 // Wrapper for FP32 GEMM kernels where both LHS and RHS are pre-packed (common SGEMM path).
 using KaiF32SgemmKernel = KaiMatmulKernel<kai_matmul_clamp_f32_f32p_f32p_ukernel>;
@@ -42,6 +47,9 @@ using KaiDynamicQGemmKernel = KaiMatmulKernel<kai_matmul_clamp_f32_qai8dxp_qsi8c
 using KaiF32IMatmulKernel = KaiMatmulKernel<kai_imatmul_clamp_f32_f32p_f32p_ukernel>;
 
 using KaiBF16SBgemmKernel = KaiMatmulKernel<kai_matmul_clamp_f32_bf16p_bf16p_ukernel>;
+
+// Wrapper for FP32 planar depthwise convolution kernels.
+using KaiF32DepthwiseConvKernel = KaiKernel<kai_dwconv_clamp_f32_f32_f32p_planar_ukernel>;
 
 // Returns the selected Qnbit GEMM ukernel based on runtime CPU capabilities.
 const KaiQnbitGemmKernel& GetKleidiAIGemmUKernel();
@@ -63,3 +71,6 @@ const KaiF32IMatmulKernel& GetKleidiAIF32IMatmulUKernel();
 
 // Returns the selected BF16 SBGEMM ukernel used by the KleidiAI based on runtime CPU capabilities.
 const KaiBF16SBgemmKernel& GetKleidiAISBGemmUKernel();
+
+// Returns the selected FP32 depthwise convolution ukernel based on runtime CPU capabilities.
+const KaiF32DepthwiseConvKernel& GetKleidiAIDepthwiseConvUKernel();

--- a/onnxruntime/core/mlas/lib/kleidiai/convolve_kleidiai.cpp
+++ b/onnxruntime/core/mlas/lib/kleidiai/convolve_kleidiai.cpp
@@ -123,7 +123,17 @@ static size_t ComputeMlasWorkingBufferSize(const size_t co,
     return m * co;
 }
 
-static bool CheckCapabilitiesSme(const MLAS_CONV_PARAMETERS* Parameters) {
+static bool CheckIgemmRouteCapabilities(const MLAS_CONV_PARAMETERS* Parameters,
+                                         const ArmKleidiAI::ConvRouteSelection& route_selection) {
+    if (route_selection.route != ArmKleidiAI::ConvRoute::IGemm) {
+        if (route_selection.route == ArmKleidiAI::ConvRoute::SGemmFallback) {
+            KLEIDIAI_DEBUG_LOG("CheckIgemmRouteCapabilities returning false to prefer SGEMM-backed conv path.");
+        } else {
+            KLEIDIAI_DEBUG_LOG("CheckIgemmRouteCapabilities returning false on non-IGEMM route.");
+        }
+        return false;
+    }
+
     // Grouped support in this override is only implemented for channels-last
     // layout. The generic grouped path still assumes contiguous per-group CHW.
     if (Parameters->GroupCount > 1 && !Parameters->ChannelsLast) {
@@ -141,35 +151,24 @@ static bool CheckCapabilitiesSme(const MLAS_CONV_PARAMETERS* Parameters) {
             Parameters->StrideShape,
             Parameters->FilterCount,
             Parameters->Beta)) {
-        KLEIDIAI_DEBUG_LOG("CheckCapabilitiesSme returning false on shared capability checks.");
+        KLEIDIAI_DEBUG_LOG("CheckIgemmRouteCapabilities returning false on shared capability checks.");
         return false;
     }
 
-    const auto route_selection = ArmKleidiAI::SelectConvRoute(Parameters);
-    const auto route = route_selection.route;
+    // ensure LHS packed buffer size is non-zero
+    const size_t d_kh = route_selection.effective_kernel_h;
+    const size_t d_kw = route_selection.effective_kernel_w;
+    const size_t m_step = imatmul_conv.ukernel.get_m_step();
 
-    if (route == ArmKleidiAI::ConvRoute::IGemm) {
-        // ensure LHS packed buffer size is non-zero
-        const size_t d_kh = route_selection.effective_kernel_h;
-        const size_t d_kw = route_selection.effective_kernel_w;
-        const size_t m_step = imatmul_conv.ukernel.get_m_step();
+    const size_t bytes_per_m_step = kai_get_lhs_packed_size_lhs_imatmul_pack_x32p2vlx1_x32p_sme(
+        m_step, d_kh * d_kw, Parameters->InputChannels);
 
-        const size_t bytes_per_m_step = kai_get_lhs_packed_size_lhs_imatmul_pack_x32p2vlx1_x32p_sme(
-            m_step, d_kh * d_kw, Parameters->InputChannels);
-
-        if (bytes_per_m_step == 0) {
-            KLEIDIAI_DEBUG_LOG("CheckCapabilitiesSME returning false on zero LHS packed size");
-            return false;
-        }
-        return true;
+    if (bytes_per_m_step == 0) {
+        KLEIDIAI_DEBUG_LOG("CheckIgemmRouteCapabilities returning false on zero LHS packed size");
+        return false;
     }
 
-    if (route == ArmKleidiAI::ConvRoute::SGemmFallback) {
-        KLEIDIAI_DEBUG_LOG("CheckCapabilitiesSme returning false to prefer SGEMM-backed conv path.");
-    } else {
-        KLEIDIAI_DEBUG_LOG("CheckCapabilitiesSme returning false on functional or optimization checks.");
-    }
-    return false;
+    return true;
 }
 
 //General purpose axis swapping
@@ -758,7 +757,13 @@ ArmKleidiAI::MlasConvPrepare(MLAS_CONV_PARAMETERS* Parameters,
 
     Parameters->ThreadCount = MlasGetMaximumThreadCount(ThreadPool);
 
-    if(!CheckCapabilitiesSme(Parameters)){
+    const auto route_selection = ArmKleidiAI::SelectConvRoute(Parameters);
+    if (route_selection.route == ArmKleidiAI::ConvRoute::Depthwise) {
+        *WorkingBufferSize = 0;
+        return true;
+    }
+
+    if (!CheckIgemmRouteCapabilities(Parameters, route_selection)) {
         return false;
     }
 
@@ -790,26 +795,59 @@ ArmKleidiAI::MlasConv(
         return false;
     }
 
-    if(!CheckCapabilitiesSme(Parameters)){
-        // Fallback to Default Mlas
-        return false;
-    };
-    ConvolveSme(Parameters->FilterCount, Parameters->InputChannels,          // channel out, in
-                Parameters->InputShape[0], Parameters->InputShape[1],         // image dimensions
-                Parameters->KernelShape[0], Parameters->KernelShape[1],      // kernel dimensions
-                Parameters->StrideShape[0], Parameters->StrideShape[1],      // kernel stride dimensions
-                Parameters->DilationShape[0], Parameters->DilationShape[1],  // kernel dilation
-                Parameters->Padding[0],                                      // image padding
-                Parameters->GroupCount,                                      // filter groups
-                Filter, Bias,
-                reinterpret_cast<const std::byte*>(Parameters->PackedFilter),
-                Parameters->PackedFilterGroupStride,
-                Input, Output, WorkingBuffer, Parameters->ChannelsLast, ThreadPool);
+    const auto route_selection = ArmKleidiAI::SelectConvRoute(Parameters);
 
-    const bool grouped_channels_last = Parameters->ChannelsLast && Parameters->GroupCount > 1;
-    const size_t activation_rows = grouped_channels_last ? Parameters->OutputSize : Parameters->FilterCount;
-    const size_t activation_cols =
-        grouped_channels_last ? Parameters->GroupCount * Parameters->FilterCount : Parameters->OutputSize;
-    MlasActivation(Parameters->Activation, Output, nullptr, activation_rows, activation_cols, activation_cols);
-    return true;
+    if (route_selection.route == ArmKleidiAI::ConvRoute::Depthwise) {
+        if (DepthwiseConvKleidiAI(Parameters->BatchCount,
+                                  Parameters->InputShape[0],
+                                  Parameters->InputShape[1],
+                                  Parameters->GroupCount * Parameters->InputChannels,
+                                  Parameters->KernelShape[0],
+                                  Parameters->KernelShape[1],
+                                  Parameters->Padding[0],
+                                  Parameters->Padding[1],
+                                  Parameters->Padding[2],
+                                  Parameters->Padding[3],
+                                  Parameters->ChannelsLast,
+                                  Input,
+                                  Filter,
+                                  Bias,
+                                  Output,
+                                  -std::numeric_limits<float>::max(),
+                                  std::numeric_limits<float>::max())) {
+            const size_t activation_rows = Parameters->ChannelsLast
+                                               ? Parameters->OutputSize
+                                               : Parameters->GroupCount * Parameters->FilterCount;
+            const size_t activation_cols = Parameters->ChannelsLast
+                                               ? Parameters->GroupCount * Parameters->FilterCount
+                                               : Parameters->OutputSize;
+            MlasActivation(Parameters->Activation, Output, nullptr, activation_rows, activation_cols, activation_cols);
+            return true;
+        }
+
+        return false;
+    }
+
+    if (CheckIgemmRouteCapabilities(Parameters, route_selection)) {
+        ConvolveSme(Parameters->FilterCount, Parameters->InputChannels,          // channel out, in
+                    Parameters->InputShape[0], Parameters->InputShape[1],         // image dimensions
+                    Parameters->KernelShape[0], Parameters->KernelShape[1],      // kernel dimensions
+                    Parameters->StrideShape[0], Parameters->StrideShape[1],      // kernel stride dimensions
+                    Parameters->DilationShape[0], Parameters->DilationShape[1],  // kernel dilation
+                    Parameters->Padding[0],                                      // image padding
+                    Parameters->GroupCount,                                      // filter groups
+                    Filter, Bias,
+                    reinterpret_cast<const std::byte*>(Parameters->PackedFilter),
+                    Parameters->PackedFilterGroupStride,
+                    Input, Output, WorkingBuffer, Parameters->ChannelsLast, ThreadPool);
+
+        const bool grouped_channels_last = Parameters->ChannelsLast && Parameters->GroupCount > 1;
+        const size_t activation_rows = grouped_channels_last ? Parameters->OutputSize : Parameters->FilterCount;
+        const size_t activation_cols =
+            grouped_channels_last ? Parameters->GroupCount * Parameters->FilterCount : Parameters->OutputSize;
+        MlasActivation(Parameters->Activation, Output, nullptr, activation_rows, activation_cols, activation_cols);
+        return true;
+    }
+
+    return false;
 }

--- a/onnxruntime/core/mlas/lib/kleidiai/convolve_kleidiai.cpp
+++ b/onnxruntime/core/mlas/lib/kleidiai/convolve_kleidiai.cpp
@@ -123,7 +123,17 @@ static size_t ComputeMlasWorkingBufferSize(const size_t co,
     return m * co;
 }
 
-static bool CheckCapabilitiesSme(const MLAS_CONV_PARAMETERS* Parameters) {
+static bool CheckIgemmRouteCapabilities(const MLAS_CONV_PARAMETERS* Parameters,
+                                         const ArmKleidiAI::ConvRouteSelection& route_selection) {
+    if (route_selection.route != ArmKleidiAI::ConvRoute::IGemm) {
+        if (route_selection.route == ArmKleidiAI::ConvRoute::SGemmFallback) {
+            KLEIDIAI_DEBUG_LOG("CheckIgemmRouteCapabilities returning false to prefer SGEMM-backed conv path.");
+        } else {
+            KLEIDIAI_DEBUG_LOG("CheckIgemmRouteCapabilities returning false on non-IGEMM route.");
+        }
+        return false;
+    }
+
     // Grouped support in this override is only implemented for channels-last
     // layout. The generic grouped path still assumes contiguous per-group CHW.
     if (Parameters->GroupCount > 1 && !Parameters->ChannelsLast) {
@@ -141,35 +151,24 @@ static bool CheckCapabilitiesSme(const MLAS_CONV_PARAMETERS* Parameters) {
             Parameters->StrideShape,
             Parameters->FilterCount,
             Parameters->Beta)) {
-        KLEIDIAI_DEBUG_LOG("CheckCapabilitiesSme returning false on shared capability checks.");
+        KLEIDIAI_DEBUG_LOG("CheckIgemmRouteCapabilities returning false on shared capability checks.");
         return false;
     }
 
-    const auto route_selection = ArmKleidiAI::SelectConvRoute(Parameters);
-    const auto route = route_selection.route;
+    // ensure LHS packed buffer size is non-zero
+    const size_t d_kh = route_selection.effective_kernel_h;
+    const size_t d_kw = route_selection.effective_kernel_w;
+    const size_t m_step = imatmul_conv.ukernel.get_m_step();
 
-    if (route == ArmKleidiAI::ConvRoute::IGemm) {
-        // ensure LHS packed buffer size is non-zero
-        const size_t d_kh = route_selection.effective_kernel_h;
-        const size_t d_kw = route_selection.effective_kernel_w;
-        const size_t m_step = imatmul_conv.ukernel.get_m_step();
+    const size_t bytes_per_m_step = kai_get_lhs_packed_size_lhs_imatmul_pack_x32p2vlx1_x32p_sme(
+        m_step, d_kh * d_kw, Parameters->InputChannels);
 
-        const size_t bytes_per_m_step = kai_get_lhs_packed_size_lhs_imatmul_pack_x32p2vlx1_x32p_sme(
-            m_step, d_kh * d_kw, Parameters->InputChannels);
-
-        if (bytes_per_m_step == 0) {
-            KLEIDIAI_DEBUG_LOG("CheckCapabilitiesSME returning false on zero LHS packed size");
-            return false;
-        }
-        return true;
+    if (bytes_per_m_step == 0) {
+        KLEIDIAI_DEBUG_LOG("CheckIgemmRouteCapabilities returning false on zero LHS packed size");
+        return false;
     }
 
-    if (route == ArmKleidiAI::ConvRoute::SGemmFallback) {
-        KLEIDIAI_DEBUG_LOG("CheckCapabilitiesSme returning false to prefer SGEMM-backed conv path.");
-    } else {
-        KLEIDIAI_DEBUG_LOG("CheckCapabilitiesSme returning false on functional or optimization checks.");
-    }
-    return false;
+    return true;
 }
 
 //General purpose axis swapping
@@ -759,7 +758,13 @@ ArmKleidiAI::MlasConvPrepare(MLAS_CONV_PARAMETERS* Parameters,
 
     Parameters->ThreadCount = MlasGetMaximumThreadCount(ThreadPool);
 
-    if(!CheckCapabilitiesSme(Parameters)){
+    const auto route_selection = ArmKleidiAI::SelectConvRoute(Parameters);
+    if (route_selection.route == ArmKleidiAI::ConvRoute::Depthwise) {
+        *WorkingBufferSize = 0;
+        return true;
+    }
+
+    if (!CheckIgemmRouteCapabilities(Parameters, route_selection)) {
         return false;
     }
 
@@ -791,26 +796,59 @@ ArmKleidiAI::MlasConv(
         return false;
     }
 
-    if(!CheckCapabilitiesSme(Parameters)){
-        // Fallback to Default Mlas
-        return false;
-    };
-    ConvolveSme(Parameters->FilterCount, Parameters->InputChannels,          // channel out, in
-                Parameters->InputShape[0], Parameters->InputShape[1],         // image dimensions
-                Parameters->KernelShape[0], Parameters->KernelShape[1],      // kernel dimensions
-                Parameters->StrideShape[0], Parameters->StrideShape[1],      // kernel stride dimensions
-                Parameters->DilationShape[0], Parameters->DilationShape[1],  // kernel dilation
-                Parameters->Padding[0],                                      // image padding
-                Parameters->GroupCount,                                      // filter groups
-                Filter, Bias,
-                reinterpret_cast<const std::byte*>(Parameters->PackedFilter),
-                Parameters->PackedFilterGroupStride,
-                Input, Output, WorkingBuffer, Parameters->ChannelsLast, ThreadPool);
+    const auto route_selection = ArmKleidiAI::SelectConvRoute(Parameters);
 
-    const bool grouped_channels_last = Parameters->ChannelsLast && Parameters->GroupCount > 1;
-    const size_t activation_rows = grouped_channels_last ? Parameters->OutputSize : Parameters->FilterCount;
-    const size_t activation_cols =
-        grouped_channels_last ? Parameters->GroupCount * Parameters->FilterCount : Parameters->OutputSize;
-    MlasActivation(Parameters->Activation, Output, nullptr, activation_rows, activation_cols, activation_cols);
-    return true;
+    if (route_selection.route == ArmKleidiAI::ConvRoute::Depthwise) {
+        if (DepthwiseConvKleidiAI(Parameters->BatchCount,
+                                  Parameters->InputShape[0],
+                                  Parameters->InputShape[1],
+                                  Parameters->GroupCount * Parameters->InputChannels,
+                                  Parameters->KernelShape[0],
+                                  Parameters->KernelShape[1],
+                                  Parameters->Padding[0],
+                                  Parameters->Padding[1],
+                                  Parameters->Padding[2],
+                                  Parameters->Padding[3],
+                                  Parameters->ChannelsLast,
+                                  Input,
+                                  Filter,
+                                  Bias,
+                                  Output,
+                                  -std::numeric_limits<float>::max(),
+                                  std::numeric_limits<float>::max())) {
+            const size_t activation_rows = Parameters->ChannelsLast
+                                               ? Parameters->OutputSize
+                                               : Parameters->GroupCount * Parameters->FilterCount;
+            const size_t activation_cols = Parameters->ChannelsLast
+                                               ? Parameters->GroupCount * Parameters->FilterCount
+                                               : Parameters->OutputSize;
+            MlasActivation(Parameters->Activation, Output, nullptr, activation_rows, activation_cols, activation_cols);
+            return true;
+        }
+
+        return false;
+    }
+
+    if (CheckIgemmRouteCapabilities(Parameters, route_selection)) {
+        ConvolveSme(Parameters->FilterCount, Parameters->InputChannels,          // channel out, in
+                    Parameters->InputShape[0], Parameters->InputShape[1],         // image dimensions
+                    Parameters->KernelShape[0], Parameters->KernelShape[1],      // kernel dimensions
+                    Parameters->StrideShape[0], Parameters->StrideShape[1],      // kernel stride dimensions
+                    Parameters->DilationShape[0], Parameters->DilationShape[1],  // kernel dilation
+                    Parameters->Padding[0],                                      // image padding
+                    Parameters->GroupCount,                                      // filter groups
+                    Filter, Bias,
+                    reinterpret_cast<const std::byte*>(Parameters->PackedFilter),
+                    Parameters->PackedFilterGroupStride,
+                    Input, Output, WorkingBuffer, Parameters->ChannelsLast, ThreadPool);
+
+        const bool grouped_channels_last = Parameters->ChannelsLast && Parameters->GroupCount > 1;
+        const size_t activation_rows = grouped_channels_last ? Parameters->OutputSize : Parameters->FilterCount;
+        const size_t activation_cols =
+            grouped_channels_last ? Parameters->GroupCount * Parameters->FilterCount : Parameters->OutputSize;
+        MlasActivation(Parameters->Activation, Output, nullptr, activation_rows, activation_cols, activation_cols);
+        return true;
+    }
+
+    return false;
 }

--- a/onnxruntime/core/mlas/lib/kleidiai/dw_conv_kleidiai.cpp
+++ b/onnxruntime/core/mlas/lib/kleidiai/dw_conv_kleidiai.cpp
@@ -1,0 +1,333 @@
+//
+// SPDX-FileCopyrightText: Copyright 2025-2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+//
+// SPDX-License-Identifier: MIT
+//
+
+#include "mlasi_kleidiai.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <vector>
+
+#include "kai_ukernel_interface.h"
+
+#include "kai/ukernels/dwconv/pack/kai_rhs_dwconv_pack_x32p1vlx1b_x32_x32_sme.h"
+
+const KaiF32DepthwiseConvKernel& dwconv = GetKleidiAIDepthwiseConvUKernel();
+
+namespace ArmKleidiAI {
+namespace {
+
+struct DwconvTlsBuffers {
+    std::vector<float> feature_map_nhwc;
+    std::vector<float> weights_hwcn;
+    std::vector<std::byte> weights_packed;
+    std::vector<float> nhwc_out;
+    std::vector<float> bias_fallback;
+};
+
+thread_local DwconvTlsBuffers g_dwconv_tls;
+
+constexpr size_t kDwconvColsPerTile = 4;
+
+static void ConvertNchwToNhwc(const float* src,
+                              float* dst,
+                              size_t batches,
+                              size_t channels,
+                              size_t height,
+                              size_t width) {
+    const size_t src_stride_n = channels * height * width;
+    const size_t src_stride_c = height * width;
+    const size_t src_stride_h = width;
+    const size_t dst_stride_n = height * width * channels;
+    const size_t dst_stride_h = width * channels;
+    const size_t dst_stride_w = channels;
+
+    for (size_t n = 0; n < batches; ++n) {
+        for (size_t h = 0; h < height; ++h) {
+            for (size_t w = 0; w < width; ++w) {
+                for (size_t c = 0; c < channels; ++c) {
+                    const size_t src_index = n * src_stride_n + c * src_stride_c + h * src_stride_h + w;
+                    const size_t dst_index = n * dst_stride_n + h * dst_stride_h + w * dst_stride_w + c;
+                    dst[dst_index] = src[src_index];
+                }
+            }
+        }
+    }
+}
+
+static void ConvertNhwcToNchw(const float* src,
+                              float* dst,
+                              size_t batches,
+                              size_t channels,
+                              size_t height,
+                              size_t width) {
+    const size_t dst_stride_n = channels * height * width;
+    const size_t dst_stride_c = height * width;
+    const size_t dst_stride_h = width;
+    const size_t src_stride_n = height * width * channels;
+    const size_t src_stride_h = width * channels;
+    const size_t src_stride_w = channels;
+
+    for (size_t n = 0; n < batches; ++n) {
+        for (size_t c = 0; c < channels; ++c) {
+            for (size_t h = 0; h < height; ++h) {
+                for (size_t w = 0; w < width; ++w) {
+                    const size_t src_index = n * src_stride_n + h * src_stride_h + w * src_stride_w + c;
+                    const size_t dst_index = n * dst_stride_n + c * dst_stride_c + h * dst_stride_h + w;
+                    dst[dst_index] = src[src_index];
+                }
+            }
+        }
+    }
+}
+
+static void ConvertDepthwiseWeightsToHwcn(const float* src,
+                                          float* dst,
+                                          size_t channels,
+                                          size_t filter_height,
+                                          size_t filter_width) {
+    const size_t kernel_size = filter_height * filter_width;
+    for (size_t c = 0; c < channels; ++c) {
+        const float* channel_weights = src + c * kernel_size;
+        for (size_t kh = 0; kh < filter_height; ++kh) {
+            for (size_t kw = 0; kw < filter_width; ++kw) {
+                const size_t dst_index = (kh * filter_width + kw) * channels + c;
+                dst[dst_index] = channel_weights[kh * filter_width + kw];
+            }
+        }
+    }
+}
+
+static bool TryComputeDepthwiseOutputShape(size_t in_height,
+                                           size_t in_width,
+                                           size_t filter_height,
+                                           size_t filter_width,
+                                           size_t pad_top,
+                                           size_t pad_left,
+                                           size_t pad_bottom,
+                                           size_t pad_right,
+                                           size_t& out_height,
+                                           size_t& out_width) {
+    const size_t padded_height = in_height + pad_top + pad_bottom;
+    const size_t padded_width = in_width + pad_left + pad_right;
+
+    if (padded_height < filter_height || padded_width < filter_width) {
+        return false;
+    }
+
+    out_height = padded_height + 1 - filter_height;
+    out_width = padded_width + 1 - filter_width;
+    return true;
+}
+
+}  // namespace
+
+bool
+MLASCALL
+DepthwiseConvKleidiAISupported(const MLAS_CONV_PARAMETERS* Parameters) {
+    if (Parameters == nullptr) {
+        return false;
+    }
+
+    if (!UseSME2) {
+        return false;
+    }
+
+    if (Parameters->BackendKernelSelectorConfig && !Parameters->BackendKernelSelectorConfig->use_kleidiai) {
+        return false;
+    }
+
+    if (Parameters->Dimensions != 2) {
+        return false;
+    }
+
+    // The current direct kernel path processes a single batch at a time.
+    if (Parameters->BatchCount != 1) {
+        return false;
+    }
+
+    if (Parameters->Beta != 0.0f) {
+        return false;
+    }
+
+    // Depthwise convolution with multiplier 1: one input channel and one filter per group.
+    if (Parameters->InputChannels != 1 || Parameters->FilterCount != 1) {
+        return false;
+    }
+
+    // Kernel specialization is 3x3 with unit stride and dilation.
+    if (Parameters->KernelShape[0] != 3 || Parameters->KernelShape[1] != 3) {
+        return false;
+    }
+
+    if (Parameters->StrideShape[0] != 1 || Parameters->StrideShape[1] != 1) {
+        return false;
+    }
+
+    if (Parameters->DilationShape[0] != 1 || Parameters->DilationShape[1] != 1) {
+        return false;
+    }
+
+    const bool zero_padding = Parameters->Padding[0] == 0 && Parameters->Padding[1] == 0 &&
+                              Parameters->Padding[2] == 0 && Parameters->Padding[3] == 0;
+    const bool unit_padding = Parameters->Padding[0] == 1 && Parameters->Padding[1] == 1 &&
+                              Parameters->Padding[2] == 1 && Parameters->Padding[3] == 1;
+    if (!zero_padding && !unit_padding) {
+        return false;
+    }
+
+    size_t out_height = 0;
+    size_t out_width = 0;
+    if (!TryComputeDepthwiseOutputShape(Parameters->InputShape[0],
+                                        Parameters->InputShape[1],
+                                        Parameters->KernelShape[0],
+                                        Parameters->KernelShape[1],
+                                        Parameters->Padding[0],
+                                        Parameters->Padding[1],
+                                        Parameters->Padding[2],
+                                        Parameters->Padding[3],
+                                        out_height,
+                                        out_width)) {
+        return false;
+    }
+
+    return out_height >= dwconv.ukernel.get_m_step() && out_width >= kDwconvColsPerTile;
+}
+
+bool
+MLASCALL
+DepthwiseConvKleidiAI(size_t batches,
+                      size_t in_height,
+                      size_t in_width,
+                      size_t channels,
+                      size_t filter_height,
+                      size_t filter_width,
+                      size_t pad_top,
+                      size_t pad_left,
+                      size_t pad_bottom,
+                      size_t pad_right,
+                      bool channels_last,
+                      const float* feature_map,
+                      const float* weights,
+                      const float* bias,
+                      float* out,
+                      float clamp_min,
+                      float clamp_max) {
+    if (!UseSME2 || feature_map == nullptr || weights == nullptr || out == nullptr) {
+        return false;
+    }
+
+    if (batches != 1 || channels == 0) {
+        return false;
+    }
+
+    size_t out_height = 0;
+    size_t out_width = 0;
+    if (!TryComputeDepthwiseOutputShape(in_height,
+                                        in_width,
+                                        filter_height,
+                                        filter_width,
+                                        pad_top,
+                                        pad_left,
+                                        pad_bottom,
+                                        pad_right,
+                                        out_height,
+                                        out_width)) {
+        return false;
+    }
+
+    const size_t rows_handled = dwconv.ukernel.get_m_step();
+    if (out_height < rows_handled || out_width < kDwconvColsPerTile) {
+        return false;
+    }
+
+    auto& tls = g_dwconv_tls;
+
+    const float* feature_map_nhwc = feature_map;
+    if (!channels_last) {
+        const size_t input_size = batches * in_height * in_width * channels;
+        tls.feature_map_nhwc.resize(input_size);
+        ConvertNchwToNhwc(feature_map, tls.feature_map_nhwc.data(), batches, channels, in_height, in_width);
+        feature_map_nhwc = tls.feature_map_nhwc.data();
+    }
+
+    const size_t weights_size = filter_height * filter_width * channels;
+    tls.weights_hwcn.resize(weights_size);
+    ConvertDepthwiseWeightsToHwcn(weights, tls.weights_hwcn.data(), channels, filter_height, filter_width);
+
+    const float* bias_data = bias;
+    if (bias_data == nullptr) {
+        tls.bias_fallback.assign(channels, 0.0f);
+        bias_data = tls.bias_fallback.data();
+    }
+
+    const size_t packed_size_bytes =
+        kai_rhs_get_dst_size_dwconv_pack_x32p1vlx1b_x32_x32_sme(filter_height, filter_width, channels);
+    tls.weights_packed.resize(packed_size_bytes);
+    KLEIDIAI_KERNEL_LOG("kai_run_rhs_dwconv_pack_x32p1vlx1b_x32_x32_sme"
+                        << " filter_height=" << filter_height << " filter_width=" << filter_width
+                        << " channels=" << channels);
+    kai_run_rhs_dwconv_pack_x32p1vlx1b_x32_x32_sme(filter_height,
+                                                   filter_width,
+                                                   filter_height,
+                                                   filter_width,
+                                                   channels,
+                                                   tls.weights_hwcn.data(),
+                                                   bias_data,
+                                                   tls.weights_packed.data());
+
+    float* nhwc_out = out;
+    if (!channels_last) {
+        const size_t output_size = batches * out_height * out_width * channels;
+        tls.nhwc_out.assign(output_size, 0.0f);
+        nhwc_out = tls.nhwc_out.data();
+    }
+
+    const size_t in_row_stride_elements = in_width * channels;
+    const size_t out_row_stride_elements = out_width * channels;
+    for (size_t out_row = 0; out_row < out_height; out_row += rows_handled) {
+        const ptrdiff_t start_in_row = static_cast<ptrdiff_t>(out_row) - static_cast<ptrdiff_t>(pad_top);
+        const size_t kernel_pad_top = start_in_row < 0 ? static_cast<size_t>(-start_in_row) : 0;
+        const size_t in_row = start_in_row < 0 ? 0 : static_cast<size_t>(start_in_row);
+
+        const size_t rows_to_process = std::min(rows_handled, out_height - out_row);
+        size_t valid_input_rows = 0;
+        if (in_row < in_height) {
+            const size_t max_rows_available = in_height - in_row;
+            const size_t needed_rows = filter_height + rows_to_process - 1;
+            valid_input_rows = std::min(max_rows_available, needed_rows);
+        }
+
+        const float* inptr = feature_map_nhwc + in_row * in_row_stride_elements;
+        float* outptr = nhwc_out + out_row * out_row_stride_elements;
+
+        KLEIDIAI_KERNEL_LOG(dwconv.name
+                            << " valid_input_rows=" << valid_input_rows
+                            << " valid_dst_rows=" << rows_to_process
+                            << " pad_left=" << pad_left << " pad_top=" << kernel_pad_top);
+        dwconv.ukernel.run_dwconv(inptr,
+                                  tls.weights_packed.data(),
+                                  outptr,
+                                  in_row_stride_elements * sizeof(float),
+                                  channels * sizeof(float),
+                                  out_row_stride_elements * sizeof(float),
+                                  channels * sizeof(float),
+                                  valid_input_rows,
+                                  rows_to_process,
+                                  pad_left,
+                                  kernel_pad_top,
+                                  0.0f,
+                                  clamp_min,
+                                  clamp_max);
+    }
+
+    if (!channels_last) {
+        ConvertNhwcToNchw(nhwc_out, out, batches, channels, out_height, out_width);
+    }
+
+    return true;
+}
+
+}  // namespace ArmKleidiAI

--- a/onnxruntime/core/mlas/lib/kleidiai/dw_conv_kleidiai.cpp
+++ b/onnxruntime/core/mlas/lib/kleidiai/dw_conv_kleidiai.cpp
@@ -14,10 +14,10 @@
 
 #include "kai/ukernels/dwconv/pack/kai_rhs_dwconv_pack_x32p1vlx1b_x32_x32_sme.h"
 
-const KaiF32DepthwiseConvKernel& dwconv = GetKleidiAIDepthwiseConvUKernel();
-
 namespace ArmKleidiAI {
 namespace {
+
+const KaiF32DepthwiseConvKernel& dwconv = GetKleidiAIDepthwiseConvUKernel();
 
 struct DwconvTlsBuffers {
     std::vector<float> feature_map_nhwc;
@@ -25,6 +25,22 @@ struct DwconvTlsBuffers {
     std::vector<std::byte> weights_packed;
     std::vector<float> nhwc_out;
     std::vector<float> bias_fallback;
+
+    void ReleaseLargeBuffers() {
+        ArmKleidiAI::MlasShrinkKleidiAIScratchIfTooLarge(feature_map_nhwc);
+        ArmKleidiAI::MlasShrinkKleidiAIScratchIfTooLarge(weights_hwcn);
+        ArmKleidiAI::MlasShrinkKleidiAIScratchIfTooLarge(weights_packed);
+        ArmKleidiAI::MlasShrinkKleidiAIScratchIfTooLarge(nhwc_out);
+        ArmKleidiAI::MlasShrinkKleidiAIScratchIfTooLarge(bias_fallback);
+    }
+};
+
+struct ScopedKaiDwconvTlsCleanup {
+    DwconvTlsBuffers& buffers;
+
+    ~ScopedKaiDwconvTlsCleanup() {
+        buffers.ReleaseLargeBuffers();
+    }
 };
 
 thread_local DwconvTlsBuffers g_dwconv_tls;
@@ -139,7 +155,7 @@ DepthwiseConvKleidiAISupported(const MLAS_CONV_PARAMETERS* Parameters) {
         return false;
     }
 
-    if (Parameters->Dimensions != 2) {
+    if (Parameters->Dimensions != 2 || Parameters->GroupCount == 0) {
         return false;
     }
 
@@ -219,7 +235,7 @@ DepthwiseConvKleidiAI(size_t batches,
         return false;
     }
 
-    if (batches != 1 || channels == 0) {
+    if (batches != 1 || channels == 0 || filter_height != 3 || filter_width != 3) {
         return false;
     }
 
@@ -244,6 +260,7 @@ DepthwiseConvKleidiAI(size_t batches,
     }
 
     auto& tls = g_dwconv_tls;
+    ScopedKaiDwconvTlsCleanup cleanup{tls};
 
     const float* feature_map_nhwc = feature_map;
     if (!channels_last) {

--- a/onnxruntime/core/mlas/lib/kleidiai/kai_ukernel_interface.cpp
+++ b/onnxruntime/core/mlas/lib/kleidiai/kai_ukernel_interface.cpp
@@ -54,6 +54,8 @@
 // FP16 HGEMM kernels
 #include "kai/ukernels/matmul/matmul_clamp_f16_f16_f16p/kai_matmul_clamp_f16_f16_f16p2vlx2b_1x8vl_sme_mla.h"
 #include "kai/ukernels/matmul/matmul_clamp_f16_f16_f16p/kai_matmul_clamp_f16_f16_f16p2vlx2b_1x16vl_sme2_dot.h"
+//   DWCONV
+#include "kai/ukernels/dwconv/dwconv_f32_f32_f32p/kai_dwconv_clamp_f32_f32_f32p1vlx1b_3x3_s1_4xc_sme2_mla.h"
 
 #if defined(ENABLE_QMX_KERNELS)
 // QMX kernels (optional)
@@ -305,6 +307,9 @@ const KaiF16IMatmulKernel imatmul_f16_conv_sme2 =
 const KaiBF16SBgemmKernel sbgemm_gemm_sme2 =
     KAI_WRAP_UKERNEL_RUN_MATMUL_11(matmul_clamp_f32_bf16p2vlx2_bf16p2vlx2_2vlx2vl_sme2_mopa);
 
+const KaiF32DepthwiseConvKernel dwconv_sme2 =
+    KAI_WRAP_UKERNEL_RUN_DWCONV_PLANAR_4(dwconv_clamp_f32_f32_f32p1vlx1b_3x3_s1_4xc_sme2_mla);
+
 #if defined(ENABLE_QMX_KERNELS)
 const KaiF32IMatmulKernel imatmul_conv_qmx =
     KAI_WRAP_UKERNEL_RUN_IMATMUL_PACKED_7(imatmul_clamp_f32_f32p2vlx1_f32p2vlx1b_2vlx2vl_qmx_mopa);
@@ -492,4 +497,9 @@ const KaiF16HgemmKernel& GetKleidiAIHgemmUKernel() {
     } else {
         return hgemm_sme;
     }
+}
+
+const KaiF32DepthwiseConvKernel& GetKleidiAIDepthwiseConvUKernel() {
+    // Currently only an SME2 variant exists for FP32 depthwise convolution.
+    return dwconv_sme2;
 }

--- a/onnxruntime/core/mlas/lib/kleidiai/kai_ukernel_interface.h
+++ b/onnxruntime/core/mlas/lib/kleidiai/kai_ukernel_interface.h
@@ -24,13 +24,20 @@
 
 #include "kai/ukernels/matmul/matmul_clamp_f16_f16_f16p/kai_matmul_clamp_f16_f16_f16p_interface.h"
 
+#include "kai/ukernels/dwconv/dwconv_f32_f32_f32p/kai_dwconv_clamp_f32_f32_f32p_interface.h"
+
 // Wrapper type that carries a stable "name" alongside the KAI ukernel interface.
 // This avoids needing to infer which underlying microkernel was selected from a function pointer.
 template <typename UkernelFn>
-struct KaiMatmulKernel {
+struct KaiKernel {
     const char* name;
     UkernelFn ukernel;
 };
+
+using KaiF32DepthwiseConvKernel = KaiKernel<kai_dwconv_clamp_f32_f32_f32p_planar_ukernel>;
+
+template <typename UkernelFn>
+using KaiMatmulKernel = KaiKernel<UkernelFn>;
 
 enum class KaiQ4RhsPackLayout {
     SymmetricNxK,
@@ -104,3 +111,5 @@ const KaiBF16SBgemmKernel& GetKleidiAISBGemmUKernel();
 
 // Returns the selected FP16 HGEMM ukernel based on runtime CPU capabilities.
 const KaiF16HgemmKernel& GetKleidiAIHgemmUKernel();
+// Returns the selected FP32 depthwise convolution ukernel based on runtime CPU capabilities.
+const KaiF32DepthwiseConvKernel& GetKleidiAIDepthwiseConvUKernel();

--- a/onnxruntime/core/mlas/lib/kleidiai/mlasi_kleidiai.h
+++ b/onnxruntime/core/mlas/lib/kleidiai/mlasi_kleidiai.h
@@ -56,9 +56,16 @@ inline const bool UseSME2 = MLAS_CPUIDINFO::GetCPUIDInfo().HasArm_SME2();
 inline const bool UseSME = MLAS_CPUIDINFO::GetCPUIDInfo().HasArm_SME();
 inline const std::string_view vendor_name = MLAS_CPUIDINFO::GetCPUIDInfo().GetCPUVendor();
 
+bool
+MLASCALL
+DepthwiseConvKleidiAISupported(
+    const MLAS_CONV_PARAMETERS* Parameters
+    );
+
 // Selects the convolution route for Arm® KleidiAI™
 enum class ConvRoute {
     NoKleidiAi,    // decline the conv, caller runs unchanged
+    Depthwise,     // handle the whole conv via SME2 depthwise kernel
     IGemm,         // handle the whole conv via SME IGEMM kernel
     SGemmFallback, // decline IGEMM, but still route the per-segment SGEMM slices through MlasGemm
                    // so that the Arm® KleidiAI™ SGEMM backend override can pick them up
@@ -115,6 +122,12 @@ inline ConvRouteSelection SelectConvRoute(const MLAS_CONV_PARAMETERS* Parameters
         (Parameters->Padding[0] != Parameters->Padding[2]) ||
         (Parameters->Padding[0] != Parameters->Padding[3])) {
         return ConvRouteSelection{};
+    }
+
+    if (Parameters->InputChannels == 1 && Parameters->FilterCount == 1) {
+        return DepthwiseConvKleidiAISupported(Parameters)
+            ? ConvRouteSelection{ConvRoute::Depthwise, Parameters->KernelShape[0], Parameters->KernelShape[1]}
+            : ConvRouteSelection{};
     }
 
     size_t effective_kernel_h;
@@ -336,6 +349,28 @@ MlasConv(
     float* WorkingBuffer,
     float* Output,
     MLAS_THREADPOOL* ThreadPool
+    );
+
+bool
+MLASCALL
+DepthwiseConvKleidiAI(
+    size_t batches,
+    size_t in_height,
+    size_t in_width,
+    size_t channels,
+    size_t filter_height,
+    size_t filter_width,
+    size_t pad_top,
+    size_t pad_left,
+    size_t pad_bottom,
+    size_t pad_right,
+    bool channels_last,
+    const float* feature_map,
+    const float* weights,
+    const float* bias,
+    float* out,
+    float clamp_min,
+    float clamp_max
     );
 
 size_t

--- a/onnxruntime/core/mlas/lib/kleidiai/mlasi_kleidiai.h
+++ b/onnxruntime/core/mlas/lib/kleidiai/mlasi_kleidiai.h
@@ -68,9 +68,16 @@ inline const bool UseSME2 = MLAS_CPUIDINFO::GetCPUIDInfo().HasArm_SME2();
 inline const bool UseSME = MLAS_CPUIDINFO::GetCPUIDInfo().HasArm_SME();
 inline const std::string_view vendor_name = MLAS_CPUIDINFO::GetCPUIDInfo().GetCPUVendor();
 
+bool
+MLASCALL
+DepthwiseConvKleidiAISupported(
+    const MLAS_CONV_PARAMETERS* Parameters
+    );
+
 // Selects the convolution route for Arm® KleidiAI™
 enum class ConvRoute {
     NoKleidiAi,    // decline the conv, caller runs unchanged
+    Depthwise,     // handle the whole conv via SME2 depthwise kernel
     IGemm,         // handle the whole conv via SME IGEMM kernel
     SGemmFallback, // decline IGEMM, but still route the per-segment SGEMM slices through MlasGemm
                    // so that the Arm® KleidiAI™ SGEMM backend override can pick them up
@@ -127,6 +134,12 @@ inline ConvRouteSelection SelectConvRoute(const MLAS_CONV_PARAMETERS* Parameters
         (Parameters->Padding[0] != Parameters->Padding[2]) ||
         (Parameters->Padding[0] != Parameters->Padding[3])) {
         return ConvRouteSelection{};
+    }
+
+    if (Parameters->InputChannels == 1 && Parameters->FilterCount == 1) {
+        return DepthwiseConvKleidiAISupported(Parameters)
+            ? ConvRouteSelection{ConvRoute::Depthwise, Parameters->KernelShape[0], Parameters->KernelShape[1]}
+            : ConvRouteSelection{};
     }
 
     size_t effective_kernel_h;
@@ -425,6 +438,28 @@ MlasConv(
     float* WorkingBuffer,
     float* Output,
     MLAS_THREADPOOL* ThreadPool
+    );
+
+bool
+MLASCALL
+DepthwiseConvKleidiAI(
+    size_t batches,
+    size_t in_height,
+    size_t in_width,
+    size_t channels,
+    size_t filter_height,
+    size_t filter_width,
+    size_t pad_top,
+    size_t pad_left,
+    size_t pad_bottom,
+    size_t pad_right,
+    bool channels_last,
+    const float* feature_map,
+    const float* weights,
+    const float* bias,
+    float* out,
+    float clamp_min,
+    float clamp_max
     );
 
 size_t

--- a/onnxruntime/core/optimizer/nhwc_transformer.cc
+++ b/onnxruntime/core/optimizer/nhwc_transformer.cc
@@ -207,12 +207,14 @@ bool FloatNhwcWrapperFilter(const onnx_transpose_optimization::api::GraphRef& gr
   std::array<size_t, 2> strides{1, 1};
   std::array<size_t, 4> pads{};
   size_t batch_count = 0;
+  size_t input_channels_per_group = 0;
   size_t total_filter_count = 0;
 
   if (!TryGetDimValueAsSizeT(*input_shape, 0, batch_count) ||
       !TryGetDimValueAsSizeT(*input_shape, 2, input_spatial_shape[0]) ||
       !TryGetDimValueAsSizeT(*input_shape, 3, input_spatial_shape[1]) ||
       !TryGetDimValueAsSizeT(*weight_shape, 0, total_filter_count) ||
+      !TryGetDimValueAsSizeT(*weight_shape, 1, input_channels_per_group) ||
       !TryGetDimValueAsSizeT(*weight_shape, 2, kernel_spatial_shape[0]) ||
       !TryGetDimValueAsSizeT(*weight_shape, 3, kernel_spatial_shape[1])) {
     return false;
@@ -249,11 +251,6 @@ bool FloatNhwcWrapperFilter(const onnx_transpose_optimization::api::GraphRef& gr
           filter_count,
           /*Beta*/ 0.0f)) {
     return true;
-  }
-
-  size_t input_channels_per_group = 0;
-  if (!TryGetDimValueAsSizeT(*weight_shape, 1, input_channels_per_group)) {
-    return false;
   }
 
   return MlasConvSupportsDepthwiseChannelsLast2DFloatKernel(

--- a/onnxruntime/test/mlas/unittest/test_dwconv_kleidiai.cpp
+++ b/onnxruntime/test/mlas/unittest/test_dwconv_kleidiai.cpp
@@ -1,0 +1,305 @@
+//
+// SPDX-FileCopyrightText: Copyright 2025-2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+//
+// SPDX-License-Identifier: MIT
+//
+
+#if defined(USE_KLEIDIAI) && !defined(_MSC_VER)
+
+#include "test_util.h"
+#include "core/mlas/lib/kleidiai/mlasi_kleidiai.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <limits>
+#include <random>
+#include <vector>
+
+namespace {
+
+void ConvertNchwToNhwc(const float* src,
+                       float* dst,
+                       size_t batches,
+                       size_t channels,
+                       size_t height,
+                       size_t width) {
+  const size_t src_stride_n = channels * height * width;
+  const size_t src_stride_c = height * width;
+  const size_t src_stride_h = width;
+  const size_t dst_stride_n = height * width * channels;
+  const size_t dst_stride_h = width * channels;
+  const size_t dst_stride_w = channels;
+
+  for (size_t n = 0; n < batches; ++n) {
+    for (size_t h = 0; h < height; ++h) {
+      for (size_t w = 0; w < width; ++w) {
+        for (size_t c = 0; c < channels; ++c) {
+          const size_t src_index = n * src_stride_n + c * src_stride_c + h * src_stride_h + w;
+          const size_t dst_index = n * dst_stride_n + h * dst_stride_h + w * dst_stride_w + c;
+          dst[dst_index] = src[src_index];
+        }
+      }
+    }
+  }
+}
+
+void DepthwiseReferenceNchw(const float* input,
+                            const float* weights,
+                            const float* bias,
+                            size_t batches,
+                            size_t channels,
+                            size_t in_height,
+                            size_t in_width,
+                            size_t filter_height,
+                            size_t filter_width,
+                            size_t pad_top,
+                            size_t pad_left,
+                            size_t pad_bottom,
+                            size_t pad_right,
+                            float clamp_min,
+                            float clamp_max,
+                            float* output) {
+  const size_t out_height = in_height + pad_top + pad_bottom + 1 - filter_height;
+  const size_t out_width = in_width + pad_left + pad_right + 1 - filter_width;
+
+  for (size_t b = 0; b < batches; ++b) {
+    for (size_t c = 0; c < channels; ++c) {
+      for (size_t oh = 0; oh < out_height; ++oh) {
+        for (size_t ow = 0; ow < out_width; ++ow) {
+          float acc = bias != nullptr ? bias[c] : 0.0f;
+          for (size_t kh = 0; kh < filter_height; ++kh) {
+            const int in_y = static_cast<int>(oh) + static_cast<int>(kh) - static_cast<int>(pad_top);
+            if (in_y < 0 || in_y >= static_cast<int>(in_height)) {
+              continue;
+            }
+            for (size_t kw = 0; kw < filter_width; ++kw) {
+              const int in_x = static_cast<int>(ow) + static_cast<int>(kw) - static_cast<int>(pad_left);
+              if (in_x < 0 || in_x >= static_cast<int>(in_width)) {
+                continue;
+              }
+              const size_t input_idx =
+                  (((b * channels) + c) * in_height + static_cast<size_t>(in_y)) * in_width +
+                  static_cast<size_t>(in_x);
+              const size_t weight_idx = (c * filter_height + kh) * filter_width + kw;
+              acc += input[input_idx] * weights[weight_idx];
+            }
+          }
+          const size_t output_idx = (((b * channels) + c) * out_height + oh) * out_width + ow;
+          output[output_idx] = std::clamp(acc, clamp_min, clamp_max);
+        }
+      }
+    }
+  }
+}
+
+void RunDepthwiseConvCase(size_t channels, size_t in_height, size_t in_width, size_t padding, bool channels_last) {
+  if (!MLAS_CPUIDINFO::GetCPUIDInfo().HasArm_SME2()) {
+    GTEST_SKIP() << "DepthwiseConvKleidiAI requires ARM64 SME2. Skipping test.";
+  }
+
+  constexpr size_t batches = 1;
+  constexpr size_t filter_height = 3;
+  constexpr size_t filter_width = 3;
+
+  const size_t pad_top = padding;
+  const size_t pad_left = padding;
+  const size_t pad_bottom = padding;
+  const size_t pad_right = padding;
+
+  const size_t input_size = batches * channels * in_height * in_width;
+  const size_t weights_size = channels * filter_height * filter_width;
+  const size_t out_height = in_height + pad_top + pad_bottom + 1 - filter_height;
+  const size_t out_width = in_width + pad_left + pad_right + 1 - filter_width;
+  const size_t output_size = batches * channels * out_height * out_width;
+
+  std::vector<float> input(input_size);
+  std::vector<float> weights(weights_size);
+  std::vector<float> bias(channels);
+  std::vector<float> input_nhwc(input_size);
+  std::vector<float> expected(output_size);
+  std::vector<float> expected_nhwc(output_size);
+  std::vector<float> output(output_size, std::numeric_limits<float>::quiet_NaN());
+
+  std::mt19937 rng(static_cast<uint32_t>(channels * 131 + in_height * 17 + padding));
+  std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
+
+  auto fill_buffer = [&](std::vector<float>& buffer) {
+    for (float& v : buffer) {
+      v = dist(rng);
+    }
+  };
+
+  fill_buffer(input);
+  fill_buffer(weights);
+  fill_buffer(bias);
+
+  const float clamp_min = -std::numeric_limits<float>::max();
+  const float clamp_max = std::numeric_limits<float>::max();
+
+  DepthwiseReferenceNchw(input.data(),
+                         weights.data(),
+                         bias.data(),
+                         batches,
+                         channels,
+                         in_height,
+                         in_width,
+                         filter_height,
+                         filter_width,
+                         pad_top,
+                         pad_left,
+                         pad_bottom,
+                         pad_right,
+                         clamp_min,
+                         clamp_max,
+                         expected.data());
+
+  ConvertNchwToNhwc(input.data(), input_nhwc.data(), batches, channels, in_height, in_width);
+  ConvertNchwToNhwc(expected.data(), expected_nhwc.data(), batches, channels, out_height, out_width);
+
+  const float* input_data = channels_last ? input_nhwc.data() : input.data();
+  const float* expected_data = channels_last ? expected_nhwc.data() : expected.data();
+
+  const bool status = ArmKleidiAI::DepthwiseConvKleidiAI(batches,
+                                                         in_height,
+                                                         in_width,
+                                                         channels,
+                                                         filter_height,
+                                                         filter_width,
+                                                         pad_top,
+                                                         pad_left,
+                                                         pad_bottom,
+                                                         pad_right,
+                                                         channels_last,
+                                                         input_data,
+                                                         weights.data(),
+                                                         bias.data(),
+                                                         output.data(),
+                                                         clamp_min,
+                                                         clamp_max);
+  ASSERT_TRUE(status);
+
+  for (size_t i = 0; i < output_size; ++i) {
+    EXPECT_NEAR(expected_data[i], output[i], 1e-4f) << "Mismatch at element " << i;
+  }
+}
+
+void RunMlasConvChannelsLastCase(size_t channels, size_t in_height, size_t in_width, size_t padding) {
+  if (!MLAS_CPUIDINFO::GetCPUIDInfo().HasArm_SME2()) {
+    GTEST_SKIP() << "DepthwiseConvKleidiAI requires ARM64 SME2. Skipping test.";
+  }
+
+  constexpr size_t batches = 1;
+  constexpr size_t filter_height = 3;
+  constexpr size_t filter_width = 3;
+  constexpr size_t filter_count = 1;
+
+  const size_t out_height = in_height + padding + padding + 1 - filter_height;
+  const size_t out_width = in_width + padding + padding + 1 - filter_width;
+  const size_t input_size = batches * channels * in_height * in_width;
+  const size_t output_size = batches * channels * out_height * out_width;
+
+  std::vector<float> input(input_size);
+  std::vector<float> input_nhwc(input_size);
+  std::vector<float> weights(channels * filter_height * filter_width);
+  std::vector<float> bias(channels);
+  std::vector<float> expected(output_size);
+  std::vector<float> expected_nhwc(output_size);
+  std::vector<float> output(output_size, std::numeric_limits<float>::quiet_NaN());
+
+  std::mt19937 rng(static_cast<uint32_t>(channels * 197 + in_width * 23 + padding));
+  std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
+  for (float& v : input) {
+    v = dist(rng);
+  }
+  for (float& v : weights) {
+    v = dist(rng);
+  }
+  for (float& v : bias) {
+    v = dist(rng);
+  }
+
+  DepthwiseReferenceNchw(input.data(),
+                         weights.data(),
+                         bias.data(),
+                         batches,
+                         channels,
+                         in_height,
+                         in_width,
+                         filter_height,
+                         filter_width,
+                         padding,
+                         padding,
+                         padding,
+                         padding,
+                         -std::numeric_limits<float>::max(),
+                         std::numeric_limits<float>::max(),
+                         expected.data());
+  ConvertNchwToNhwc(input.data(), input_nhwc.data(), batches, channels, in_height, in_width);
+  ConvertNchwToNhwc(expected.data(), expected_nhwc.data(), batches, channels, out_height, out_width);
+
+  const int64_t input_shape[] = {static_cast<int64_t>(in_height), static_cast<int64_t>(in_width)};
+  const int64_t kernel_shape[] = {static_cast<int64_t>(filter_height), static_cast<int64_t>(filter_width)};
+  const int64_t dilation_shape[] = {1, 1};
+  const int64_t pads[] = {static_cast<int64_t>(padding), static_cast<int64_t>(padding),
+                          static_cast<int64_t>(padding), static_cast<int64_t>(padding)};
+  const int64_t strides[] = {1, 1};
+  const int64_t output_shape[] = {static_cast<int64_t>(out_height), static_cast<int64_t>(out_width)};
+  MLAS_ACTIVATION activation;
+  activation.ActivationKind = MlasIdentityActivation;
+
+  MLAS_CONV_PARAMETERS parameters{};
+  size_t working_buffer_size = 0;
+  MlasConvPrepare(&parameters,
+                  2,
+                  batches,
+                  channels,
+                  1,
+                  input_shape,
+                  kernel_shape,
+                  dilation_shape,
+                  pads,
+                  strides,
+                  output_shape,
+                  filter_count,
+                  &activation,
+                  &working_buffer_size,
+                  true,
+                  0.0f,
+                  nullptr);
+  std::vector<float> working_buffer(working_buffer_size);
+  MlasConv(&parameters,
+           input_nhwc.data(),
+           weights.data(),
+           bias.data(),
+           working_buffer.data(),
+           output.data(),
+           nullptr);
+
+  for (size_t i = 0; i < output_size; ++i) {
+    EXPECT_NEAR(expected_nhwc[i], output[i], 1e-4f) << "Mismatch at element " << i;
+  }
+}
+
+}  // namespace
+
+TEST(MlasKleidiDepthwiseTest, ZeroPaddingNchw) {
+  RunDepthwiseConvCase(/*channels=*/32, /*in_height=*/8, /*in_width=*/8, /*padding=*/0, /*channels_last=*/false);
+}
+
+TEST(MlasKleidiDepthwiseTest, UnitPaddingNchw) {
+  RunDepthwiseConvCase(/*channels=*/32, /*in_height=*/8, /*in_width=*/8, /*padding=*/1, /*channels_last=*/false);
+}
+
+TEST(MlasKleidiDepthwiseTest, ZeroPaddingNhwc) {
+  RunDepthwiseConvCase(/*channels=*/32, /*in_height=*/8, /*in_width=*/8, /*padding=*/0, /*channels_last=*/true);
+}
+
+TEST(MlasKleidiDepthwiseTest, UnitPaddingNhwc) {
+  RunDepthwiseConvCase(/*channels=*/32, /*in_height=*/8, /*in_width=*/8, /*padding=*/1, /*channels_last=*/true);
+}
+
+TEST(MlasKleidiDepthwiseTest, MlasConvChannelsLast) {
+  RunMlasConvChannelsLastCase(/*channels=*/32, /*in_height=*/8, /*in_width=*/8, /*padding=*/1);
+}
+
+#endif  // defined(USE_KLEIDIAI) && !defined(_MSC_VER)

--- a/onnxruntime/test/mlas/unittest/test_dwconv_kleidiai.cpp
+++ b/onnxruntime/test/mlas/unittest/test_dwconv_kleidiai.cpp
@@ -302,4 +302,31 @@ TEST(MlasKleidiDepthwiseTest, MlasConvChannelsLast) {
   RunMlasConvChannelsLastCase(/*channels=*/32, /*in_height=*/8, /*in_width=*/8, /*padding=*/1);
 }
 
+TEST(MlasKleidiDepthwiseTest, RejectsNon3x3Filters) {
+  if (!MLAS_CPUIDINFO::GetCPUIDInfo().HasArm_SME2()) {
+    GTEST_SKIP() << "DepthwiseConvKleidiAI requires ARM64 SME2. Skipping test.";
+  }
+
+  constexpr size_t batches = 1;
+  constexpr size_t in_height = 8;
+  constexpr size_t in_width = 8;
+  constexpr size_t channels = 32;
+
+  std::vector<float> input(batches * in_height * in_width * channels);
+  std::vector<float> weights(channels * 3 * 3);
+  std::vector<float> bias(channels);
+  std::vector<float> output(batches * in_height * in_width * channels);
+
+  EXPECT_FALSE(ArmKleidiAI::DepthwiseConvKleidiAI(
+      batches, in_height, in_width, channels, /*filter_height=*/2, /*filter_width=*/3,
+      /*pad_top=*/0, /*pad_left=*/0, /*pad_bottom=*/0, /*pad_right=*/0, /*channels_last=*/true,
+      input.data(), weights.data(), bias.data(), output.data(),
+      -std::numeric_limits<float>::max(), std::numeric_limits<float>::max()));
+  EXPECT_FALSE(ArmKleidiAI::DepthwiseConvKleidiAI(
+      batches, in_height, in_width, channels, /*filter_height=*/3, /*filter_width=*/2,
+      /*pad_top=*/0, /*pad_left=*/0, /*pad_bottom=*/0, /*pad_right=*/0, /*channels_last=*/true,
+      input.data(), weights.data(), bias.data(), output.data(),
+      -std::numeric_limits<float>::max(), std::numeric_limits<float>::max()));
+}
+
 #endif  // defined(USE_KLEIDIAI) && !defined(_MSC_VER)


### PR DESCRIPTION
### Description
This PR adds a Arm® KleidiAI™ backed f32 depthwise convolution path in MLAS and wires it into the CPU/KleidiAI convolution routing flow.
The new path targets eligible depthwise convolutions using the KleidiAI SME2 depthwise ukernel. It is integrated as a first-class KleidiAI convolution route so depthwise dispatch is handled consistently with the existing IGEMM / SGEMM fallback routing.
### Changes

- Added a new KleidiAI f32 depthwise convolution implementation:
  - `onnxruntime/core/mlas/lib/kleidiai/dw_conv_kleidiai.cpp`
- Added depthwise ukernel plumbing through the KleidiAI ukernel interface.
- Added CMake integration for the new depthwise source.
- Added support checks for the new depthwise path.
- Integrated depthwise selection into the KleidiAI conv routing model via `ConvRoute::Depthwise`.
- Updated KleidiAI conv prepare/dispatch to route through:
  - `Depthwise`
  - `IGemm`
  - `SGemmFallback`
  - `NoKleidiAi`
- Updated NHWC transform gating so f32 Conv/FusedConv can be transformed when either dense or depthwise KleidiAI channels-last support is available.
- Added MLAS unit test coverage for the KleidiAI depthwise convolution path.

### Supported depthwise shape envelope

The current KleidiAI depthwise route supports f32 depthwise convolution with:

- 2D convolution
- batch size 1
- depthwise multiplier 1
- `3x3` kernel
- stride 1
- dilation 1
- all-zero padding or all-one padding
- SME2 availability
- sufficient output dimensions for the KleidiAI tile shape

The implementation handles NHWC directly and can fall back to internal NCHW to NHWC conversion when needed.


### Example Performance Results

| Model | No KleidiAI | KleidiAI no DW | KleidiAI + DW | KleidiAI + DW vs No KleidiAI | KleidiAI + DW vs KleidiAI no DW | Latency reduction vs no DW |
|---|---:|---:|---:|---:|---:|---:|
| `mobilenet_v1_f32.onnx` | 12.778 ms | 4.567 ms | 3.996 ms | 3.20x faster | 1.14x faster | 12.5% |
| `mobilenetv1_ssd_f32.onnx` | 29.348 ms | 9.326 ms | 8.538 ms | 3.44x faster | 1.09x faster | 8.5% |
| `retinaface_f32.onnx` | 70.761 ms | 41.540 ms | 37.511 ms | 1.89x faster | 1.11x faster | 9.7% |
| `deeplabv3_mobilenetv2_f32.onnx` | 119.709 ms | 49.899 ms | 49.398 ms | 2.42x faster | 1.01x faster | 1.0% |
| `de_efficientnetlitev3_f32.onnx` | 134.750 ms | 40.252 ms | 38.543 ms | 3.50x faster | 1.04x faster | 4.2% |