### PR TITLE
Fix brew install applesimutils failure by trusting wix/brew tap

### DIFF
--- a/.github/workflows/react_native.yml
+++ b/.github/workflows/react_native.yml
@@ -256,6 +256,7 @@ jobs:
           set -e -x
           npm install -g detox-cli
           brew tap wix/brew
+          brew trust wix/brew
           brew install applesimutils
           npm ci
         working-directory: ${{ github.workspace }}/js

--- a/tools/ci_build/github/azure-pipelines/templates/react-native-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/react-native-ci.yml
@@ -123,6 +123,7 @@ stages:
 
     - script: |
         brew tap wix/brew
+        brew trust wix/brew
         brew install applesimutils
       displayName: Install applesimutils
 


### PR DESCRIPTION
Newer Homebrew versions refuse to load formulae from untrusted third-party taps. This adds `brew trust wix/brew` after tapping to allow the subsequent `brew install applesimutils` to succeed in React Native CI.

**Changes:**
- `.github/workflows/react_native.yml`
- `tools/ci_build/github/azure-pipelines/templates/react-native-ci.yml`