### PR TITLE
[js/webgpu] Add DFT operator

### DIFF
--- a/js/web/docs/webgpu-operators.md
+++ b/js/web/docs/webgpu-operators.md
@@ -34,6 +34,7 @@ Do not modify directly.*
 | Cos | ai.onnx(7+) |  |
 | Cosh | ai.onnx(9+) |  |
 | CumSum | ai.onnx(11-13,14+) |  |
+| DFT | ai.onnx(17-19,20+) |  |
 | DepthToSpace | ai.onnx(11-12,13+); com.ms.internal.nhwc(11-12,13+) |  |
 | DequantizeLinear | ai.onnx(10-12,13-18,19-20,21+) |  |
 | Div | ai.onnx(7-12,13,14+) |  |

--- a/js/web/lib/wasm/jsep/webgpu/op-resolve-rules.ts
+++ b/js/web/lib/wasm/jsep/webgpu/op-resolve-rules.ts
@@ -12,6 +12,7 @@ import { conv, parseConvAttributes } from './ops/conv';
 import { convTranspose, parseConvTransposeAttributes } from './ops/conv-transpose';
 import { cumsum, parseCumSumAttributes } from './ops/cumsum';
 import { depthToSpace, parseDepthToSpaceAttributes } from './ops/depth-to-space';
+import { dft, parseDftAttributes } from './ops/dft';
 import { einsum, parseEinsumAttributes } from './ops/einsum';
 import { expand } from './ops/expand';
 import { fastGelu } from './ops/fast-gelu';
@@ -88,6 +89,7 @@ export const WEBGPU_OP_RESOLVE_RULES: Map<string, OperatorImplementation> = new 
   ['CumSum', [cumsum, parseCumSumAttributes]],
   ['DepthToSpace', [depthToSpace, parseDepthToSpaceAttributes]],
   ['DequantizeLinear', [dequantizeLinear, parseDequantizeLinearAttributes]],
+  ['DFT', [dft, parseDftAttributes]],
   ['Div', [binaryOps.div]],
   ['Einsum', [einsum, parseEinsumAttributes]],
   ['Elu', [unaryOps.elu, unaryOps.parseAlphaAttributes]],

--- a/js/web/lib/wasm/jsep/webgpu/ops/dft.ts
+++ b/js/web/lib/wasm/jsep/webgpu/ops/dft.ts
@@ -1,0 +1,380 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { DataType } from '../../../wasm-common';
+import { TensorView } from '../../tensor-view';
+import { ShapeUtil } from '../../util';
+import { AttributeWithCacheKey, createAttributeWithCacheKey } from '../attribute-with-cache-key';
+import { ComputeContext, ProgramInfo, ProgramUniform } from '../types';
+
+import { inputVariable, outputVariable, ShaderHelper, tensorTypeToWsglValueType } from './common';
+
+// ONNX DFT (opset 17-20): a 1-D transform along `axis`, with the innermost dimension holding the real/imaginary
+// parts (1 for real input, 2 for complex). Forward is unnormalized, inverse is scaled by 1/N — matching the CPU
+// kernel core/providers/cpu/signal/dft.cc. 5-smooth lengths use a shared-memory mixed-radix (2/3/4/5) Stockham
+// FFT (one transform per workgroup); other lengths fall back to a direct O(N^2) DFT (the CPU kernel uses
+// Bluestein chirp-z there, which would restore O(N log N) if the fallback ever becomes hot).
+
+export interface DftAttributes extends AttributeWithCacheKey {
+  readonly axis: number;
+  readonly inverse: number;
+  readonly onesided: number;
+}
+
+const WORKGROUP_SIZE = 256;
+const MAX_SHARED_MEMORY_LENGTH = 512;
+const TWO_PI = 2 * Math.PI;
+
+const factorizeToRadices = (length: number): number[] | undefined => {
+  const radices: number[] = [];
+  let remaining = length;
+  for (const radix of [4, 2, 3, 5]) {
+    while (remaining % radix === 0) {
+      radices.push(radix);
+      remaining /= radix;
+    }
+  }
+  return remaining === 1 ? radices : undefined;
+};
+
+const wgslFloat = (value: number): string => {
+  const text = value.toPrecision(9);
+  return /[.eE]/.test(text) ? text : `${text}.0`;
+};
+
+// One radix-`radix` Stockham stage: reads the `subTransform`-sized partial transforms from `readOffset` and
+// writes the combined transforms to the other half of the ping-pong buffer, with twiddles baked in.
+const stageCode = (radix: number, subTransform: number, length: number, readOffset: number, sign: number): string => {
+  const butterflies = length / radix;
+  const writeOffset = MAX_SHARED_MEMORY_LENGTH - readOffset;
+  const out = (k: number): string => `smem[${writeOffset}u + base + ${k * subTransform}u]`;
+  let code = `  for (var t = local_idx; t < ${butterflies}u; t += ${WORKGROUP_SIZE}u) {\n`;
+  code += `    let twiddleIndex = t % ${subTransform}u;\n    let angleUnit = f32(twiddleIndex);\n`;
+  code += `    var leg: array<vec2<f32>, 5>;\n`;
+  for (let j = 0; j < radix; j++) {
+    const source = `${readOffset}u + t + ${j * butterflies}u`;
+    if (j === 0) {
+      code += `    leg[0] = smem[${source}];\n`;
+    } else {
+      const twiddle = (sign * TWO_PI * j) / (radix * subTransform);
+      code += `    { let a = ${wgslFloat(twiddle)} * angleUnit; leg[${j}] = cmul(smem[${source}], vec2<f32>(cos(a), sin(a))); }\n`;
+    }
+  }
+  code += `    let base = (t / ${subTransform}u) * ${subTransform * radix}u + twiddleIndex;\n`;
+  if (radix === 2) {
+    code += `    ${out(0)} = leg[0] + leg[1];\n    ${out(1)} = leg[0] - leg[1];\n`;
+  } else if (radix === 4) {
+    const rotate = sign < 0 ? 'vec2<f32>(oddDiff.y, -oddDiff.x)' : 'vec2<f32>(-oddDiff.y, oddDiff.x)';
+    code += `    let evenSum = leg[0] + leg[2]; let evenDiff = leg[0] - leg[2];\n`;
+    code += `    let oddSum = leg[1] + leg[3]; let oddDiff = leg[1] - leg[3];\n`;
+    code += `    let oddRot = ${rotate};\n`;
+    code += `    ${out(0)} = evenSum + oddSum;\n    ${out(1)} = evenDiff + oddRot;\n`;
+    code += `    ${out(2)} = evenSum - oddSum;\n    ${out(3)} = evenDiff - oddRot;\n`;
+  } else {
+    for (let k = 0; k < radix; k++) {
+      const terms = ['leg[0]'];
+      for (let j = 1; j < radix; j++) {
+        const angle = (sign * TWO_PI * (j * k)) / radix;
+        const c = wgslFloat(Math.cos(angle));
+        const s = wgslFloat(Math.sin(angle));
+        terms.push(`vec2<f32>(leg[${j}].x*${c} - leg[${j}].y*${s}, leg[${j}].x*${s} + leg[${j}].y*${c})`);
+      }
+      code += `    ${out(k)} = ${terms.join(' + ')};\n`;
+    }
+  }
+  return `${code}  }\n  workgroupBarrier();\n`;
+};
+
+const fftStages = (radices: number[], length: number, sign: number): { code: string; resultOffset: number } => {
+  let code = '';
+  let subTransform = 1;
+  let readOffset = 0;
+  for (const radix of radices) {
+    code += stageCode(radix, subTransform, length, readOffset, sign);
+    subTransform *= radix;
+    readOffset = MAX_SHARED_MEMORY_LENGTH - readOffset;
+  }
+  return { code, resultOffset: readOffset };
+};
+
+interface DftPlan {
+  dataType: number;
+  outputDims: number[];
+  length: number; // transform length N, after any dft_length / IRFFT resize
+  signalLength: number;
+  inner: number; // transforms packed between the axis and the innermost (complex) dimension
+  batch: number;
+  inputComponents: number;
+  outputComponents: number;
+  outputLength: number;
+  inverse: boolean;
+  onesided: boolean;
+}
+
+const computeDftPlan = (
+  input: TensorView,
+  fftAxis: number,
+  inverse: boolean,
+  onesided: boolean,
+  dftLength: number | undefined,
+): DftPlan => {
+  const dims = input.dims;
+  const rank = dims.length;
+  const inputComponents = dims[rank - 1];
+  const signalLength = dims[fftAxis];
+  let length = inverse && onesided ? (signalLength - 1) * 2 : signalLength;
+  if (dftLength !== undefined) {
+    length = dftLength;
+  }
+  const outputComponents = inverse && onesided ? 1 : 2;
+  const outputLength = onesided && !inverse ? Math.floor(length / 2) + 1 : length;
+  const outputDims = dims.slice();
+  outputDims[fftAxis] = outputLength;
+  outputDims[rank - 1] = outputComponents;
+  let inner = 1;
+  for (let d = fftAxis + 1; d < rank - 1; d++) {
+    inner *= dims[d];
+  }
+  const batch = ShapeUtil.size(dims) / inputComponents / signalLength;
+  return {
+    dataType: input.dataType,
+    outputDims,
+    length,
+    signalLength,
+    inner,
+    batch,
+    inputComponents,
+    outputComponents,
+    outputLength,
+    inverse,
+    onesided,
+  };
+};
+
+// Only the values that change the emitted code go into the cache key; the addressing dimensions
+// (signalLength/inner/outputLength/batch) are passed as uniforms so shaders are reused across shapes.
+const programHint = (plan: DftPlan, path: string): string =>
+  [path, plan.length, plan.inputComponents, plan.outputComponents, plan.inverse, plan.onesided].join(';');
+
+const programUniforms = (plan: DftPlan): ProgramUniform[] => [
+  { type: DataType.uint32, data: plan.batch },
+  { type: DataType.uint32, data: plan.signalLength },
+  { type: DataType.uint32, data: plan.inner },
+  { type: DataType.uint32, data: plan.outputLength },
+];
+
+const declareDftUniforms = (
+  shaderHelper: ShaderHelper,
+  x: ReturnType<typeof inputVariable>,
+  y: ReturnType<typeof outputVariable>,
+): string =>
+  shaderHelper
+    .registerUniform('batch', 'u32')
+    .registerUniform('signalLength', 'u32')
+    .registerUniform('inner', 'u32')
+    .registerUniform('outputLength', 'u32')
+    .declareVariables(x, y);
+
+const createFftProgramInfo = (plan: DftPlan): ProgramInfo => {
+  const { dataType, length, inputComponents, outputComponents, inverse, onesided } = plan;
+  const valueType = tensorTypeToWsglValueType(dataType);
+  const sign = inverse ? 1 : -1;
+  const scale = inverse ? 1 / length : 1;
+  const radices = factorizeToRadices(length)!;
+
+  const getShaderSource = (shaderHelper: ShaderHelper): string => {
+    const x = inputVariable('x', dataType, [1]);
+    const y = outputVariable('y', dataType, [1]);
+    const readSample = (indexExpr: string): string => {
+      const offset = `inBase + (${indexExpr}) * uniforms.inner * ${inputComponents}u`;
+      const real = `f32(${x.getByOffset(offset)})`;
+      const imag = inputComponents === 2 ? `f32(${x.getByOffset(`${offset} + 1u`)})` : '0.0';
+      return `vec2<f32>(${real}, ${imag})`;
+    };
+
+    let load: string;
+    if (inverse && onesided) {
+      const conjugateEnd = length % 2 === 0 ? 'uniforms.signalLength - 1u' : 'uniforms.signalLength';
+      load = `
+    for (var i = local_idx; i < uniforms.signalLength; i += ${WORKGROUP_SIZE}u) {
+      smem[i] = ${readSample('i')};
+    }
+    workgroupBarrier();
+    for (var k = local_idx + 1u; k < ${conjugateEnd}; k += ${WORKGROUP_SIZE}u) {
+      let h = smem[k];
+      smem[${length}u - k] = vec2<f32>(h.x, -h.y);
+    }
+    workgroupBarrier();`;
+    } else {
+      load = `
+    let loadCount = min(uniforms.signalLength, ${length}u);
+    for (var i = local_idx; i < ${length}u; i += ${WORKGROUP_SIZE}u) {
+      if (i < loadCount) { smem[i] = ${readSample('i')}; } else { smem[i] = vec2<f32>(0.0); }
+    }
+    workgroupBarrier();`;
+    }
+
+    const { code: stages, resultOffset } = fftStages(radices, length, sign);
+    const scaled = scale === 1 ? `smem[${resultOffset}u + i]` : `smem[${resultOffset}u + i] * ${wgslFloat(scale)}`;
+    const storeImag = outputComponents === 2 ? y.setByOffset('off + 1u', `${valueType}(v.y)`) : '';
+
+    return `
+  ${declareDftUniforms(shaderHelper, x, y)}
+  var<workgroup> smem: array<vec2<f32>, ${2 * MAX_SHARED_MEMORY_LENGTH}>;
+  fn cmul(a: vec2<f32>, b: vec2<f32>) -> vec2<f32> {
+    return vec2<f32>(a.x * b.x - a.y * b.y, a.x * b.y + a.y * b.x);
+  }
+  ${shaderHelper.mainStart(WORKGROUP_SIZE)}
+    let row = workgroup_index;
+    if (row >= uniforms.batch) { return; }
+    let outer = row / uniforms.inner;
+    let within = row % uniforms.inner;
+    let inBase = (outer * uniforms.signalLength * uniforms.inner + within) * ${inputComponents}u;
+    let outBase = (outer * uniforms.outputLength * uniforms.inner + within) * ${outputComponents}u;
+    ${load}
+${stages}    for (var i = local_idx; i < uniforms.outputLength; i += ${WORKGROUP_SIZE}u) {
+      let v = ${scaled};
+      let off = outBase + i * uniforms.inner * ${outputComponents}u;
+      ${y.setByOffset('off', `${valueType}(v.x)`)}
+      ${storeImag}
+    }
+  }`;
+  };
+
+  return {
+    name: 'DFT',
+    shaderCache: { hint: programHint(plan, 'fft'), inputDependencies: ['type'] },
+    getShaderSource,
+    getRunData: () => ({
+      outputs: [{ dims: plan.outputDims, dataType }],
+      programUniforms: programUniforms(plan),
+      dispatchGroup: { x: plan.batch },
+    }),
+  };
+};
+
+// Direct O(N^2) DFT for lengths the shared-memory FFT cannot take (non 5-smooth, or beyond the workgroup
+// budget). One workgroup per transform; each output bin sums over the input samples read from global memory.
+const createDirectDftProgramInfo = (plan: DftPlan): ProgramInfo => {
+  const { dataType, length, inputComponents, outputComponents, inverse, onesided } = plan;
+  const valueType = tensorTypeToWsglValueType(dataType);
+  const sign = inverse ? 1 : -1;
+  const scale = inverse ? 1 / length : 1;
+
+  const getShaderSource = (shaderHelper: ShaderHelper): string => {
+    const x = inputVariable('x', dataType, [1]);
+    const y = outputVariable('y', dataType, [1]);
+    const readSample = (indexExpr: string): string => {
+      const offset = `inBase + (${indexExpr}) * uniforms.inner * ${inputComponents}u`;
+      const real = `f32(${x.getByOffset(offset)})`;
+      const imag = inputComponents === 2 ? `f32(${x.getByOffset(`${offset} + 1u`)})` : '0.0';
+      return `vec2<f32>(${real}, ${imag})`;
+    };
+
+    // For IRFFT the spectrum is the Hermitian extension of the half-spectrum input.
+    const spectrum =
+      inverse && onesided
+        ? `fn spectrum(inBase: u32, k: u32) -> vec2<f32> {
+    if (k < uniforms.signalLength) { return ${readSample('k')}; }
+    let h = ${readSample(`${length}u - k`)};
+    return vec2<f32>(h.x, -h.y);
+  }`
+        : `fn spectrum(inBase: u32, n: u32) -> vec2<f32> {
+    if (n < uniforms.signalLength) { return ${readSample('n')}; }
+    return vec2<f32>(0.0, 0.0);
+  }`;
+
+    // knMod tracks (k*n) mod length via addition, so the twiddle index never overflows u32 at large N.
+    const accumulate = `
+      let angle = ${wgslFloat(sign * TWO_PI)} * f32(knMod) / ${wgslFloat(length)};
+      acc += cmul(spectrum(inBase, n), vec2<f32>(cos(angle), sin(angle)));
+      knMod += k;
+      if (knMod >= ${length}u) { knMod -= ${length}u; }`;
+    const storeImag = outputComponents === 2 ? y.setByOffset('off + 1u', `${valueType}(v.y)`) : '';
+    const scaled = scale === 1 ? 'acc' : `acc * ${wgslFloat(scale)}`;
+
+    return `
+  ${declareDftUniforms(shaderHelper, x, y)}
+  fn cmul(a: vec2<f32>, b: vec2<f32>) -> vec2<f32> {
+    return vec2<f32>(a.x * b.x - a.y * b.y, a.x * b.y + a.y * b.x);
+  }
+  ${spectrum}
+  ${shaderHelper.mainStart(WORKGROUP_SIZE)}
+    let row = workgroup_index;
+    if (row >= uniforms.batch) { return; }
+    let outer = row / uniforms.inner;
+    let within = row % uniforms.inner;
+    let inBase = (outer * uniforms.signalLength * uniforms.inner + within) * ${inputComponents}u;
+    let outBase = (outer * uniforms.outputLength * uniforms.inner + within) * ${outputComponents}u;
+    for (var k = local_idx; k < uniforms.outputLength; k += ${WORKGROUP_SIZE}u) {
+      var acc = vec2<f32>(0.0, 0.0);
+      var knMod = 0u;
+      for (var n = 0u; n < ${length}u; n++) {${accumulate}
+      }
+      let v = ${scaled};
+      let off = outBase + k * uniforms.inner * ${outputComponents}u;
+      ${y.setByOffset('off', `${valueType}(v.x)`)}
+      ${storeImag}
+    }
+  }`;
+  };
+
+  return {
+    name: 'DFT',
+    shaderCache: { hint: programHint(plan, 'direct'), inputDependencies: ['type'] },
+    getShaderSource,
+    getRunData: () => ({
+      outputs: [{ dims: plan.outputDims, dataType }],
+      programUniforms: programUniforms(plan),
+      dispatchGroup: { x: plan.batch },
+    }),
+  };
+};
+
+const readScalar = (tensor: TensorView | undefined): number | undefined => {
+  if (!tensor || ShapeUtil.size(tensor.dims) === 0) {
+    return undefined;
+  }
+  return tensor.dataType === DataType.int32 ? tensor.getInt32Array()[0] : Number(tensor.getBigInt64Array()[0]);
+};
+
+const validateInputs = (inputs: readonly TensorView[]): void => {
+  if (!inputs || inputs.length < 1) {
+    throw new Error('DFT requires at least 1 input.');
+  }
+  const complex = inputs[0].dims[inputs[0].dims.length - 1];
+  if (complex !== 1 && complex !== 2) {
+    throw new Error("DFT input's innermost dimension must be 1 (real) or 2 (complex).");
+  }
+};
+
+export const dft = (context: ComputeContext, attributes: DftAttributes): void => {
+  validateInputs(context.inputs);
+  const input = context.inputs[0];
+  const rank = input.dims.length;
+  const inverse = attributes.inverse !== 0;
+  const onesided = attributes.onesided !== 0;
+
+  // opset 20 passes dft_length (input 1) and axis (input 2) as scalar tensors; opset 17-19 use the axis
+  // attribute. Both are read on the CPU, so only the signal is uploaded to the GPU.
+  const dftLength = readScalar(context.inputs[1]);
+  const fftAxis = ShapeUtil.normalizeAxis(readScalar(context.inputs[2]) ?? attributes.axis, rank);
+  if (fftAxis === rank - 1) {
+    throw new Error('DFT axis must refer to a signal dimension, not the innermost (real/imaginary) dimension.');
+  }
+  if (inverse && onesided && input.dims[rank - 1] !== 2) {
+    throw new Error('Inverse one-sided DFT (IRFFT) requires complex-valued input (innermost dimension 2).');
+  }
+
+  const plan = computeDftPlan(input, fftAxis, inverse, onesided, dftLength);
+  const useSharedMemoryFft = plan.length <= MAX_SHARED_MEMORY_LENGTH && factorizeToRadices(plan.length) !== undefined;
+  const programInfo = useSharedMemoryFft ? createFftProgramInfo(plan) : createDirectDftProgramInfo(plan);
+  context.compute(programInfo, { inputs: [0] });
+};
+
+export const parseDftAttributes = (attributes: Record<string, unknown>): DftAttributes =>
+  createAttributeWithCacheKey({
+    axis: (attributes.axis as number) ?? 1,
+    inverse: (attributes.inverse as number) ?? 0,
+    onesided: (attributes.onesided as number) ?? 0,
+  });

--- a/js/web/lib/wasm/jsep/webgpu/ops/dft.ts
+++ b/js/web/lib/wasm/jsep/webgpu/ops/dft.ts
@@ -354,7 +354,11 @@ const validateInputs = (inputs: readonly TensorView[]): void => {
   if (!inputs || inputs.length < 1) {
     throw new Error('DFT requires at least 1 input.');
   }
-  const complex = inputs[0].dims[inputs[0].dims.length - 1];
+  const dims = inputs[0].dims;
+  if (dims.length < 2) {
+    throw new Error('DFT input must have at least 2 dimensions.');
+  }
+  const complex = dims[dims.length - 1];
   if (complex !== 1 && complex !== 2) {
     throw new Error("DFT input's innermost dimension must be 1 (real) or 2 (complex).");
   }

--- a/js/web/lib/wasm/jsep/webgpu/ops/dft.ts
+++ b/js/web/lib/wasm/jsep/webgpu/ops/dft.ts
@@ -331,11 +331,23 @@ const createDirectDftProgramInfo = (plan: DftPlan): ProgramInfo => {
   };
 };
 
-const readScalar = (tensor: TensorView | undefined): number | undefined => {
-  if (!tensor || ShapeUtil.size(tensor.dims) === 0) {
+const readOptionalScalar = (tensor: TensorView | undefined): number | undefined => {
+  // An omitted optional input crosses the JSEP bridge as a placeholder tensor with an undefined
+  // data type and rank 0, not as `undefined`.
+  if (!tensor || tensor.dataType === DataType.undefined) {
     return undefined;
   }
-  return tensor.dataType === DataType.int32 ? tensor.getInt32Array()[0] : Number(tensor.getBigInt64Array()[0]);
+  if (ShapeUtil.size(tensor.dims) !== 1) {
+    throw new Error('DFT optional scalar inputs must have exactly 1 element.');
+  }
+  if (tensor.dataType === DataType.int32) {
+    return tensor.getInt32Array()[0];
+  }
+  const value = Number(tensor.getBigInt64Array()[0]);
+  if (!Number.isSafeInteger(value)) {
+    throw new Error('DFT optional scalar inputs are out of JavaScript safe integer range.');
+  }
+  return value;
 };
 
 const validateInputs = (inputs: readonly TensorView[]): void => {
@@ -357,8 +369,11 @@ export const dft = (context: ComputeContext, attributes: DftAttributes): void =>
 
   // opset 20 passes dft_length (input 1) and axis (input 2) as scalar tensors; opset 17-19 use the axis
   // attribute. Both are read on the CPU, so only the signal is uploaded to the GPU.
-  const dftLength = readScalar(context.inputs[1]);
-  const fftAxis = ShapeUtil.normalizeAxis(readScalar(context.inputs[2]) ?? attributes.axis, rank);
+  const dftLength = readOptionalScalar(context.inputs[1]);
+  if (dftLength !== undefined && dftLength <= 0) {
+    throw new Error('dft_length must be greater than zero.');
+  }
+  const fftAxis = ShapeUtil.normalizeAxis(readOptionalScalar(context.inputs[2]) ?? attributes.axis, rank);
   if (fftAxis === rank - 1) {
     throw new Error('DFT axis must refer to a signal dimension, not the innermost (real/imaginary) dimension.');
   }
@@ -367,6 +382,9 @@ export const dft = (context: ComputeContext, attributes: DftAttributes): void =>
   }
 
   const plan = computeDftPlan(input, fftAxis, inverse, onesided, dftLength);
+  if (plan.length <= 0) {
+    throw new Error(`Invalid DFT length: ${plan.length}`);
+  }
   const useSharedMemoryFft = plan.length <= MAX_SHARED_MEMORY_LENGTH && factorizeToRadices(plan.length) !== undefined;
   const programInfo = useSharedMemoryFft ? createFftProgramInfo(plan) : createDirectDftProgramInfo(plan);
   context.compute(programInfo, { inputs: [0] });

--- a/js/web/lib/wasm/jsep/webgpu/ops/dft.ts
+++ b/js/web/lib/wasm/jsep/webgpu/ops/dft.ts
@@ -194,10 +194,15 @@ const createFftProgramInfo = (plan: DftPlan): ProgramInfo => {
 
     let load: string;
     if (inverse && onesided) {
-      const conjugateEnd = length % 2 === 0 ? 'uniforms.signalLength - 1u' : 'uniforms.signalLength';
+      // Zero-pad or truncate when dft_length implies a different bin count than the input provides;
+      // the Nyquist bin is only exempt from mirroring when it is actually present.
+      const halfSpectrum = Math.floor(length / 2) + 1;
+      const conjugateEnd =
+        length % 2 === 0 ? `select(provided, provided - 1u, provided == ${halfSpectrum}u)` : 'provided';
       load = `
-    for (var i = local_idx; i < uniforms.signalLength; i += ${WORKGROUP_SIZE}u) {
-      smem[i] = ${readSample('i')};
+    let provided = min(uniforms.signalLength, ${halfSpectrum}u);
+    for (var i = local_idx; i < ${length}u; i += ${WORKGROUP_SIZE}u) {
+      if (i < provided) { smem[i] = ${readSample('i')}; } else { smem[i] = vec2<f32>(0.0); }
     }
     workgroupBarrier();
     for (var k = local_idx + 1u; k < ${conjugateEnd}; k += ${WORKGROUP_SIZE}u) {
@@ -271,13 +276,20 @@ const createDirectDftProgramInfo = (plan: DftPlan): ProgramInfo => {
       return `vec2<f32>(${real}, ${imag})`;
     };
 
-    // For IRFFT the spectrum is the Hermitian extension of the half-spectrum input.
+    // For IRFFT the spectrum is the Hermitian extension of the half-spectrum input, zero-padded or
+    // truncated when dft_length implies a different bin count than the input provides. Reads must
+    // never pass `provided`, or they would land in the adjacent transform's data.
     const spectrum =
       inverse && onesided
         ? `fn spectrum(inBase: u32, k: u32) -> vec2<f32> {
-    if (k < uniforms.signalLength) { return ${readSample('k')}; }
-    let h = ${readSample(`${length}u - k`)};
-    return vec2<f32>(h.x, -h.y);
+    let provided = min(uniforms.signalLength, ${Math.floor(length / 2) + 1}u);
+    if (k < provided) { return ${readSample('k')}; }
+    let m = ${length}u - k;
+    if (m < provided) {
+      let h = ${readSample('m')};
+      return vec2<f32>(h.x, -h.y);
+    }
+    return vec2<f32>(0.0, 0.0);
   }`
         : `fn spectrum(inBase: u32, n: u32) -> vec2<f32> {
     if (n < uniforms.signalLength) { return ${readSample('n')}; }

--- a/js/web/test/data/ops/dft.jsonc
+++ b/js/web/test/data/ops/dft.jsonc
@@ -1,0 +1,169 @@
+[
+  {
+    "name": "DFT forward (axis attribute, opset 17)",
+    "operator": "DFT",
+    "attributes": [{ "name": "axis", "data": 1, "type": "int" }],
+    "opset": { "domain": "", "version": 17 },
+    "cases": [
+      {
+        "name": "complex-to-complex, N = 4",
+        "inputs": [{ "data": [1, 0, 2, -1, 0, 0, -1, 2], "dims": [1, 4, 2], "type": "float32" }],
+        "outputs": [{ "data": [2, 1, -2, -3, 0, -1, 4, 3], "dims": [1, 4, 2], "type": "float32" }]
+      },
+      {
+        "name": "real input, N = 5",
+        "inputs": [{ "data": [1, 2, 3, 4, 5], "dims": [1, 5, 1], "type": "float32" }],
+        "outputs": [
+          {
+            "data": [15, 0, -2.5, 3.440955, -2.5, 0.812299, -2.5, -0.812299, -2.5, -3.440955],
+            "dims": [1, 5, 2],
+            "type": "float32"
+          }
+        ]
+      },
+      {
+        "name": "batched, axis = 1 of [2, 3, 2]",
+        "inputs": [{ "data": [0, 6, 1, 7, 2, 8, 3, 9, 4, 10, 5, 11], "dims": [2, 3, 2], "type": "float32" }],
+        "outputs": [
+          {
+            "data": [
+              3, 21, -2.366025, -0.633975, -0.633975, -2.366025, 12, 30, -2.366025, -0.633975, -0.633975, -2.366025
+            ],
+            "dims": [2, 3, 2],
+            "type": "float32"
+          }
+        ]
+      },
+      {
+        "name": "prime length N = 7 (direct-DFT fallback)",
+        "inputs": [{ "data": [1, 0, 0, 1, 2, -1, 3, 0, -1, 0, 0, -2, 1, 1], "dims": [1, 7, 2], "type": "float32" }],
+        "outputs": [
+          {
+            "data": [
+              6, -1, 0.351438, -0.989017, -0.211363, 7.227886, 0.119137, -5.574572, 1.6828, -1.770242, 0.656405,
+              -2.712157, -1.598418, 4.818102
+            ],
+            "dims": [1, 7, 2],
+            "type": "float32"
+          }
+        ]
+      },
+      {
+        "name": "inner > 1: middle axis of [1, 3, 2, 2] (2-D DFT column pass)",
+        "inputs": [{ "data": [1, 0, 0, 1, 2, 0, 0, 2, 3, 0, 0, 3], "dims": [1, 3, 2, 2], "type": "float32" }],
+        "outputs": [
+          {
+            "data": [6, 0, 0, 6, -1.5, 0.866025, -0.866025, -1.5, -1.5, -0.866025, 0.866025, -1.5],
+            "dims": [1, 3, 2, 2],
+            "type": "float32"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "DFT inverse (opset 17)",
+    "operator": "DFT",
+    "attributes": [
+      { "name": "axis", "data": 1, "type": "int" },
+      { "name": "inverse", "data": 1, "type": "int" }
+    ],
+    "opset": { "domain": "", "version": 17 },
+    "cases": [
+      {
+        "name": "complex-to-complex, N = 4 (1/N normalized)",
+        "inputs": [{ "data": [2, 1, -2, -3, 0, -1, 4, 3], "dims": [1, 4, 2], "type": "float32" }],
+        "outputs": [{ "data": [1, 0, 2, -1, 0, 0, -1, 2], "dims": [1, 4, 2], "type": "float32" }]
+      }
+    ]
+  },
+  {
+    "name": "DFT one-sided forward / RFFT (opset 17)",
+    "operator": "DFT",
+    "attributes": [
+      { "name": "axis", "data": 1, "type": "int" },
+      { "name": "onesided", "data": 1, "type": "int" }
+    ],
+    "opset": { "domain": "", "version": 17 },
+    "cases": [
+      {
+        "name": "real input, N = 6 -> N/2 + 1 = 4 bins",
+        "inputs": [{ "data": [0, 1, 2, 3, 4, 5], "dims": [1, 6, 1], "type": "float32" }],
+        "outputs": [{ "data": [15, 0, -3, 5.196152, -3, 1.732051, -3, 0], "dims": [1, 4, 2], "type": "float32" }]
+      }
+    ]
+  },
+  {
+    "name": "DFT one-sided inverse / IRFFT (opset 17)",
+    "operator": "DFT",
+    "attributes": [
+      { "name": "axis", "data": 1, "type": "int" },
+      { "name": "inverse", "data": 1, "type": "int" },
+      { "name": "onesided", "data": 1, "type": "int" }
+    ],
+    "opset": { "domain": "", "version": 17 },
+    "cases": [
+      {
+        "name": "half spectrum (L = 4) -> full real signal (N = 6)",
+        "inputs": [{ "data": [15, 0, -3, 5.196152, -3, 1.732051, -3, 0], "dims": [1, 4, 2], "type": "float32" }],
+        "outputs": [{ "data": [0, 1, 2, 3, 4, 5], "dims": [1, 6, 1], "type": "float32" }]
+      }
+    ]
+  },
+  {
+    "name": "DFT with dft_length and axis inputs (opset 20)",
+    "operator": "DFT",
+    "opset": { "domain": "", "version": 20 },
+    "cases": [
+      {
+        "name": "complex input N = 5, dft_length = 8 (zero-padded), axis = 1",
+        "inputs": [
+          { "data": [1, 0, 2, 0, 3, 0, 2, 0, 1, 0], "dims": [1, 5, 2], "type": "float32" },
+          { "data": [8], "dims": [], "type": "int64" },
+          { "data": [1], "dims": [], "type": "int64" }
+        ],
+        "outputs": [
+          {
+            "data": [9, 0, 0, -5.828427, -1, 0, 0, 0.171573, 1, 0, 0, -0.171573, -1, 0, 0, 5.828427],
+            "dims": [1, 8, 2],
+            "type": "float32"
+          }
+        ]
+      },
+      {
+        "name": "axis = -2 via input (default), no dft_length",
+        "inputs": [
+          { "data": [1, 0, 2, -1, 0, 0, -1, 2], "dims": [1, 4, 2], "type": "float32" },
+          { "data": [4], "dims": [], "type": "int64" },
+          { "data": [-2], "dims": [], "type": "int64" }
+        ],
+        "outputs": [{ "data": [2, 1, -2, -3, 0, -1, 4, 3], "dims": [1, 4, 2], "type": "float32" }]
+      }
+    ]
+  },
+  {
+    "name": "DFT negative axis attribute (opset 17)",
+    "operator": "DFT",
+    "attributes": [{ "name": "axis", "data": -2, "type": "int" }],
+    "opset": { "domain": "", "version": 17 },
+    "cases": [
+      {
+        "name": "axis = -2 resolves to the signal dimension",
+        "inputs": [{ "data": [1, 0, 2, -1, 0, 0, -1, 2], "dims": [1, 4, 2], "type": "float32" }],
+        "outputs": [{ "data": [2, 1, -2, -3, 0, -1, 4, 3], "dims": [1, 4, 2], "type": "float32" }]
+      }
+    ]
+  },
+  {
+    "name": "DFT opset 20 with axis defaulted (both optional inputs omitted)",
+    "operator": "DFT",
+    "opset": { "domain": "", "version": 20 },
+    "cases": [
+      {
+        "name": "no dft_length, no axis -> default axis -2",
+        "inputs": [{ "data": [1, 0, 2, -1, 0, 0, -1, 2], "dims": [1, 4, 2], "type": "float32" }],
+        "outputs": [{ "data": [2, 1, -2, -3, 0, -1, 4, 3], "dims": [1, 4, 2], "type": "float32" }]
+      }
+    ]
+  }
+]

--- a/js/web/test/suite-test-list.jsonc
+++ b/js/web/test/suite-test-list.jsonc
@@ -1351,6 +1351,7 @@
       "conv1d.jsonc",
       "conv3dncdhw.jsonc",
       "cos.jsonc",
+      "dft.jsonc",
       "div.jsonc",
       "div_int32.jsonc",
       "depth-to-space.jsonc",

--- a/onnxruntime/core/providers/js/js_execution_provider.cc
+++ b/onnxruntime/core/providers/js/js_execution_provider.cc
@@ -254,6 +254,8 @@ class ONNX_OPERATOR_KERNEL_CLASS_NAME(kJsExecutionProvider, kOnnxDomain, 21, Tra
 
 class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kJsExecutionProvider, kOnnxDomain, 11, 12, DepthToSpace);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kJsExecutionProvider, kOnnxDomain, 13, DepthToSpace);
+class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kJsExecutionProvider, kOnnxDomain, 17, 19, DFT);
+class ONNX_OPERATOR_KERNEL_CLASS_NAME(kJsExecutionProvider, kOnnxDomain, 20, DFT);
 class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kJsExecutionProvider, kMSInternalNHWCDomain, 11, 12, DepthToSpace);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kJsExecutionProvider, kMSInternalNHWCDomain, 13, DepthToSpace);
 
@@ -595,6 +597,8 @@ std::unique_ptr<KernelRegistry> RegisterKernels() {
 
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kJsExecutionProvider, kOnnxDomain, 11, 12, DepthToSpace)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kJsExecutionProvider, kOnnxDomain, 13, DepthToSpace)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kJsExecutionProvider, kOnnxDomain, 17, 19, DFT)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kJsExecutionProvider, kOnnxDomain, 20, DFT)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kJsExecutionProvider, kMSInternalNHWCDomain, 11, 12, DepthToSpace)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kJsExecutionProvider, kMSInternalNHWCDomain, 13, DepthToSpace)>,
 

--- a/onnxruntime/core/providers/js/operators/dft.cc
+++ b/onnxruntime/core/providers/js/operators/dft.cc
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/js/js_kernel.h"
+#include "dft.h"
+
+namespace onnxruntime {
+namespace js {
+
+ONNX_OPERATOR_VERSIONED_KERNEL_EX(
+    DFT,
+    kOnnxDomain,
+    17, 19,
+    kJsExecutionProvider,
+    KernelDefBuilder()
+        .TypeConstraint("T1", DataTypeImpl::GetTensorType<float>())
+        .TypeConstraint("T2", BuildKernelDefConstraintsFromTypeList<TypeList<int32_t, int64_t>>())
+        .InputMemoryType(OrtMemTypeCPU, 1),  // dft_length
+    DFT);
+
+ONNX_OPERATOR_KERNEL_EX(
+    DFT,
+    kOnnxDomain,
+    20,
+    kJsExecutionProvider,
+    KernelDefBuilder()
+        .TypeConstraint("T1", DataTypeImpl::GetTensorType<float>())
+        .TypeConstraint("T2", BuildKernelDefConstraintsFromTypeList<TypeList<int32_t, int64_t>>())
+        .InputMemoryType(OrtMemTypeCPU, 1)   // dft_length
+        .InputMemoryType(OrtMemTypeCPU, 2),  // axis
+    DFT);
+
+}  // namespace js
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/js/operators/dft.h
+++ b/onnxruntime/core/providers/js/operators/dft.h
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/providers/js/js_kernel.h"
+
+namespace onnxruntime {
+namespace js {
+
+class DFT final : public JsKernel {
+ public:
+  DFT(const OpKernelInfo& info) : JsKernel(info) {
+    // opset 20 turned axis into an input (default -2); before that it's an attribute (default 1).
+    int64_t axis = info.node().SinceVersion() < 20 ? info.GetAttrOrDefault<int64_t>("axis", 1) : -2;
+    int64_t inverse = info.GetAttrOrDefault<int64_t>("inverse", 0);
+    int64_t onesided = info.GetAttrOrDefault<int64_t>("onesided", 0);
+    JSEP_INIT_KERNEL_ATTRIBUTE(DFT, ({
+                                 "axis" : $1,
+                                 "inverse" : $2,
+                                 "onesided" : $3
+                               }),
+                               static_cast<int32_t>(axis),
+                               static_cast<int32_t>(inverse),
+                               static_cast<int32_t>(onesided));
+  }
+};
+
+}  // namespace js
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/webgpu/math/dft.cc
+++ b/onnxruntime/core/providers/webgpu/math/dft.cc
@@ -1,0 +1,370 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/webgpu/math/dft.h"
+
+#include <cmath>
+#include <iomanip>
+#include <limits>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "core/providers/common.h"
+#include "core/providers/webgpu/shader_helper.h"
+#include "core/providers/webgpu/webgpu_supported_types.h"
+
+namespace onnxruntime {
+namespace webgpu {
+
+// ONNX DFT (opset 17-20): a 1-D transform along `axis`, with the innermost dimension holding the
+// real/imaginary parts (1 for real input, 2 for complex). Forward is unnormalized, inverse is scaled
+// by 1/N -- matching the CPU kernel core/providers/cpu/signal/dft.cc. 5-smooth lengths use a
+// shared-memory mixed-radix (2/3/4/5) Stockham FFT (one transform per workgroup); other lengths fall
+// back to a direct O(N^2) DFT (the CPU kernel uses Bluestein chirp-z there, which would restore
+// O(N log N) if the fallback ever becomes hot).
+
+ONNX_OPERATOR_VERSIONED_KERNEL_EX(
+    DFT,
+    kOnnxDomain,
+    17, 19,
+    kWebGpuExecutionProvider,
+    (*KernelDefBuilder::Create())
+        .TypeConstraint("T1", WebGpuSupportedFloatTypes())
+        .TypeConstraint("T2", {DataTypeImpl::GetTensorType<int32_t>(),
+                               DataTypeImpl::GetTensorType<int64_t>()})
+        .InputMemoryType(OrtMemTypeCPU, 1),
+    DFT);
+
+ONNX_OPERATOR_KERNEL_EX(
+    DFT,
+    kOnnxDomain,
+    20,
+    kWebGpuExecutionProvider,
+    (*KernelDefBuilder::Create())
+        .TypeConstraint("T1", WebGpuSupportedFloatTypes())
+        .TypeConstraint("T2", {DataTypeImpl::GetTensorType<int32_t>(),
+                               DataTypeImpl::GetTensorType<int64_t>()})
+        .InputMemoryType(OrtMemTypeCPU, 1)
+        .InputMemoryType(OrtMemTypeCPU, 2),
+    DFT);
+
+static constexpr uint32_t kDftWorkgroupSize = 256;
+static constexpr uint32_t kDftMaxSharedMemoryLength = 512;
+static constexpr double kTwoPi = 6.283185307179586476925286766559;
+
+static bool FactorizeToRadices(uint32_t length, std::vector<uint32_t>& radices) {
+  uint32_t remaining = length;
+  for (uint32_t radix : {4u, 2u, 3u, 5u}) {
+    while (remaining % radix == 0) {
+      radices.push_back(radix);
+      remaining /= radix;
+    }
+  }
+  return remaining == 1;
+}
+
+static std::string WgslFloat(double value) {
+  std::ostringstream oss;
+  oss << std::scientific << std::setprecision(9) << value;
+  return oss.str();
+}
+
+// One radix-`radix` Stockham stage: reads the `sub_transform`-sized partial transforms from
+// `read_offset` and writes the combined transforms to the other half of the ping-pong buffer,
+// with twiddles baked in.
+static void EmitFftStage(OStringStream& os, uint32_t radix, uint32_t sub_transform, uint32_t length,
+                         uint32_t read_offset, int sign) {
+  const uint32_t butterflies = length / radix;
+  const uint32_t write_offset = kDftMaxSharedMemoryLength - read_offset;
+  auto out = [&](uint32_t k) {
+    return "smem[" + std::to_string(write_offset) + "u + base + " + std::to_string(k * sub_transform) + "u]";
+  };
+  os << "  for (var t = local_idx; t < " << butterflies << "u; t += " << kDftWorkgroupSize << "u) {\n"
+     << "    let twiddle_index = t % " << sub_transform << "u;\n"
+     << "    let angle_unit = f32(twiddle_index);\n"
+     << "    var leg: array<vec2<f32>, 5>;\n";
+  for (uint32_t j = 0; j < radix; ++j) {
+    const std::string source = std::to_string(read_offset) + "u + t + " + std::to_string(j * butterflies) + "u";
+    if (j == 0) {
+      os << "    leg[0] = smem[" << source << "];\n";
+    } else {
+      const double twiddle = (sign * kTwoPi * j) / (radix * sub_transform);
+      os << "    { let a = " << WgslFloat(twiddle) << " * angle_unit; leg[" << j
+         << "] = cmul(smem[" << source << "], vec2<f32>(cos(a), sin(a))); }\n";
+    }
+  }
+  os << "    let base = (t / " << sub_transform << "u) * " << sub_transform * radix << "u + twiddle_index;\n";
+  if (radix == 2) {
+    os << "    " << out(0) << " = leg[0] + leg[1];\n"
+       << "    " << out(1) << " = leg[0] - leg[1];\n";
+  } else if (radix == 4) {
+    const std::string rotate = sign < 0 ? "vec2<f32>(odd_diff.y, -odd_diff.x)" : "vec2<f32>(-odd_diff.y, odd_diff.x)";
+    os << "    let even_sum = leg[0] + leg[2]; let even_diff = leg[0] - leg[2];\n"
+       << "    let odd_sum = leg[1] + leg[3]; let odd_diff = leg[1] - leg[3];\n"
+       << "    let odd_rot = " << rotate << ";\n"
+       << "    " << out(0) << " = even_sum + odd_sum;\n"
+       << "    " << out(1) << " = even_diff + odd_rot;\n"
+       << "    " << out(2) << " = even_sum - odd_sum;\n"
+       << "    " << out(3) << " = even_diff - odd_rot;\n";
+  } else {
+    for (uint32_t k = 0; k < radix; ++k) {
+      os << "    " << out(k) << " = leg[0]";
+      for (uint32_t j = 1; j < radix; ++j) {
+        const double angle = (sign * kTwoPi * (j * k)) / radix;
+        const std::string c = WgslFloat(std::cos(angle));
+        const std::string s = WgslFloat(std::sin(angle));
+        os << " + vec2<f32>(leg[" << j << "].x*" << c << " - leg[" << j << "].y*" << s
+           << ", leg[" << j << "].x*" << s << " + leg[" << j << "].y*" << c << ")";
+      }
+      os << ";\n";
+    }
+  }
+  os << "  }\n"
+     << "  workgroupBarrier();\n";
+}
+
+Status DFTProgram::GenerateShaderCode(ShaderHelper& shader) const {
+  const auto& input = shader.AddInput("x", ShaderUsage::UseUniform);
+  const auto& output = shader.AddOutput("output", ShaderUsage::UseUniform | ShaderUsage::UseElementTypeAlias);
+
+  const int sign = is_inverse_ ? 1 : -1;
+  const double scale = is_inverse_ ? 1.0 / length_ : 1.0;
+
+  std::vector<uint32_t> radices;
+  ORT_RETURN_IF_NOT(FactorizeToRadices(length_, radices), "DFT length ", length_, " is not 5-smooth.");
+
+  shader.AdditionalImplementation()
+      << "var<workgroup> smem: array<vec2<f32>, " << 2 * kDftMaxSharedMemoryLength << ">;\n"
+      << "fn cmul(a: vec2<f32>, b: vec2<f32>) -> vec2<f32> {\n"
+      << "  return vec2<f32>(a.x * b.x - a.y * b.y, a.x * b.y + a.y * b.x);\n"
+      << "}\n";
+
+  auto read_sample = [&](const std::string& index) {
+    const std::string offset = "in_base + (" + index + ") * uniforms.inner * " + std::to_string(input_components_) + "u";
+    const std::string real = "f32(" + input.GetByOffset(offset) + ")";
+    const std::string imag = input_components_ == 2 ? "f32(" + input.GetByOffset(offset + " + 1u") + ")" : "0.0";
+    return "vec2<f32>(" + real + ", " + imag + ")";
+  };
+
+  shader.MainFunctionBody()
+      << "let row = workgroup_idx;\n"
+      << "if (row >= uniforms.batch) { return; }\n"
+      << "let outer = row / uniforms.inner;\n"
+      << "let within = row % uniforms.inner;\n"
+      << "let in_base = (outer * uniforms.signal_length * uniforms.inner + within) * " << input_components_ << "u;\n"
+      << "let out_base = (outer * uniforms.output_length * uniforms.inner + within) * " << output_components_ << "u;\n";
+
+  if (is_inverse_ && is_onesided_) {
+    // For IRFFT the spectrum is the Hermitian extension of the half-spectrum input.
+    const std::string conjugate_end = length_ % 2 == 0 ? "uniforms.signal_length - 1u" : "uniforms.signal_length";
+    shader.MainFunctionBody()
+        << "for (var i = local_idx; i < uniforms.signal_length; i += " << kDftWorkgroupSize << "u) {\n"
+        << "  smem[i] = " << read_sample("i") << ";\n"
+        << "}\n"
+        << "workgroupBarrier();\n"
+        << "for (var k = local_idx + 1u; k < " << conjugate_end << "; k += " << kDftWorkgroupSize << "u) {\n"
+        << "  let h = smem[k];\n"
+        << "  smem[" << length_ << "u - k] = vec2<f32>(h.x, -h.y);\n"
+        << "}\n"
+        << "workgroupBarrier();\n";
+  } else {
+    shader.MainFunctionBody()
+        << "let load_count = min(uniforms.signal_length, " << length_ << "u);\n"
+        << "for (var i = local_idx; i < " << length_ << "u; i += " << kDftWorkgroupSize << "u) {\n"
+        << "  if (i < load_count) { smem[i] = " << read_sample("i") << "; } else { smem[i] = vec2<f32>(0.0); }\n"
+        << "}\n"
+        << "workgroupBarrier();\n";
+  }
+
+  uint32_t sub_transform = 1;
+  uint32_t read_offset = 0;
+  for (uint32_t radix : radices) {
+    EmitFftStage(shader.MainFunctionBody(), radix, sub_transform, length_, read_offset, sign);
+    sub_transform *= radix;
+    read_offset = kDftMaxSharedMemoryLength - read_offset;
+  }
+
+  const std::string scaled = scale == 1.0
+                                 ? "smem[" + std::to_string(read_offset) + "u + i]"
+                                 : "smem[" + std::to_string(read_offset) + "u + i] * " + WgslFloat(scale);
+  shader.MainFunctionBody()
+      << "for (var i = local_idx; i < uniforms.output_length; i += " << kDftWorkgroupSize << "u) {\n"
+      << "  let v = " << scaled << ";\n"
+      << "  let off = out_base + i * uniforms.inner * " << output_components_ << "u;\n"
+      << "  " << output.SetByOffset("off", "output_element_t(v.x)") << "\n";
+  if (output_components_ == 2) {
+    shader.MainFunctionBody()
+        << "  " << output.SetByOffset("off + 1u", "output_element_t(v.y)") << "\n";
+  }
+  shader.MainFunctionBody() << "}\n";
+
+  return Status::OK();
+}
+
+Status DFTDirectProgram::GenerateShaderCode(ShaderHelper& shader) const {
+  const auto& input = shader.AddInput("x", ShaderUsage::UseUniform);
+  const auto& output = shader.AddOutput("output", ShaderUsage::UseUniform | ShaderUsage::UseElementTypeAlias);
+
+  const int sign = is_inverse_ ? 1 : -1;
+  const double scale = is_inverse_ ? 1.0 / length_ : 1.0;
+
+  auto read_sample = [&](const std::string& index) {
+    const std::string offset = "in_base + (" + index + ") * uniforms.inner * " + std::to_string(input_components_) + "u";
+    const std::string real = "f32(" + input.GetByOffset(offset) + ")";
+    const std::string imag = input_components_ == 2 ? "f32(" + input.GetByOffset(offset + " + 1u") + ")" : "0.0";
+    return "vec2<f32>(" + real + ", " + imag + ")";
+  };
+
+  shader.AdditionalImplementation()
+      << "fn cmul(a: vec2<f32>, b: vec2<f32>) -> vec2<f32> {\n"
+      << "  return vec2<f32>(a.x * b.x - a.y * b.y, a.x * b.y + a.y * b.x);\n"
+      << "}\n";
+  if (is_inverse_ && is_onesided_) {
+    // For IRFFT the spectrum is the Hermitian extension of the half-spectrum input.
+    shader.AdditionalImplementation()
+        << "fn spectrum(in_base: u32, k: u32) -> vec2<f32> {\n"
+        << "  if (k < uniforms.signal_length) { return " << read_sample("k") << "; }\n"
+        << "  let h = " << read_sample(std::to_string(length_) + "u - k") << ";\n"
+        << "  return vec2<f32>(h.x, -h.y);\n"
+        << "}\n";
+  } else {
+    shader.AdditionalImplementation()
+        << "fn spectrum(in_base: u32, n: u32) -> vec2<f32> {\n"
+        << "  if (n < uniforms.signal_length) { return " << read_sample("n") << "; }\n"
+        << "  return vec2<f32>(0.0, 0.0);\n"
+        << "}\n";
+  }
+
+  const std::string scaled = scale == 1.0 ? "acc" : "acc * " + WgslFloat(scale);
+  shader.MainFunctionBody()
+      << "let row = workgroup_idx;\n"
+      << "if (row >= uniforms.batch) { return; }\n"
+      << "let outer = row / uniforms.inner;\n"
+      << "let within = row % uniforms.inner;\n"
+      << "let in_base = (outer * uniforms.signal_length * uniforms.inner + within) * " << input_components_ << "u;\n"
+      << "let out_base = (outer * uniforms.output_length * uniforms.inner + within) * " << output_components_ << "u;\n"
+      << "for (var k = local_idx; k < uniforms.output_length; k += " << kDftWorkgroupSize << "u) {\n"
+      << "  var acc = vec2<f32>(0.0, 0.0);\n"
+      // kn_mod tracks (k*n) mod length via addition, so the twiddle index never overflows u32 at large N.
+      << "  var kn_mod = 0u;\n"
+      << "  for (var n = 0u; n < " << length_ << "u; n++) {\n"
+      << "    let angle = " << WgslFloat(sign * kTwoPi) << " * f32(kn_mod) / " << WgslFloat(static_cast<double>(length_)) << ";\n"
+      << "    acc += cmul(spectrum(in_base, n), vec2<f32>(cos(angle), sin(angle)));\n"
+      << "    kn_mod += k;\n"
+      << "    if (kn_mod >= " << length_ << "u) { kn_mod -= " << length_ << "u; }\n"
+      << "  }\n"
+      << "  let v = " << scaled << ";\n"
+      << "  let off = out_base + k * uniforms.inner * " << output_components_ << "u;\n"
+      << "  " << output.SetByOffset("off", "output_element_t(v.x)") << "\n";
+  if (output_components_ == 2) {
+    shader.MainFunctionBody()
+        << "  " << output.SetByOffset("off + 1u", "output_element_t(v.y)") << "\n";
+  }
+  shader.MainFunctionBody() << "}\n";
+
+  return Status::OK();
+}
+
+static bool TryReadScalar(const Tensor* tensor, int64_t& value) {
+  if (tensor == nullptr || tensor->Shape().Size() == 0) {
+    return false;
+  }
+  if (tensor->DataType() == DataTypeImpl::GetType<int64_t>()) {
+    value = tensor->Data<int64_t>()[0];
+  } else {
+    value = static_cast<int64_t>(tensor->Data<int32_t>()[0]);
+  }
+  return true;
+}
+
+Status DFT::ComputeInternal(ComputeContext& context) const {
+  const auto* input_tensor = context.Input(0);
+  const TensorShape& input_shape = input_tensor->Shape();
+  const int64_t rank = static_cast<int64_t>(input_shape.NumDimensions());
+  ORT_RETURN_IF(rank < 2, "DFT input must have at least 2 dimensions.");
+
+  const int64_t input_components = input_shape[onnxruntime::narrow<size_t>(rank - 1)];
+  ORT_RETURN_IF(input_components != 1 && input_components != 2,
+                "DFT input's innermost dimension must be 1 (real) or 2 (complex).");
+
+  int64_t axis = axis_;
+  if (opset_ >= 20 && context.InputCount() > 2) {
+    TryReadScalar(context.Input(2), axis);
+  }
+  axis = HandleNegativeAxis(axis, rank);
+  ORT_RETURN_IF(axis == rank - 1,
+                "DFT axis must refer to a signal dimension, not the innermost (real/imaginary) dimension.");
+  ORT_RETURN_IF(is_inverse_ && is_onesided_ && input_components != 2,
+                "Inverse one-sided DFT (IRFFT) requires complex-valued input (innermost dimension 2).");
+
+  const int64_t signal_length = input_shape[onnxruntime::narrow<size_t>(axis)];
+  int64_t length = is_inverse_ && is_onesided_ ? (signal_length - 1) * 2 : signal_length;
+  if (context.InputCount() > 1) {
+    TryReadScalar(context.Input(1), length);
+  }
+  ORT_RETURN_IF(length < 0 || length > std::numeric_limits<uint32_t>::max(), "Invalid DFT length: ", length);
+
+  const int64_t output_components = is_inverse_ && is_onesided_ ? 1 : 2;
+  const int64_t output_length = is_onesided_ && !is_inverse_ ? length / 2 + 1 : length;
+
+  TensorShape output_shape = input_shape;
+  output_shape[onnxruntime::narrow<size_t>(axis)] = output_length;
+  output_shape[onnxruntime::narrow<size_t>(rank - 1)] = output_components;
+  auto* output_tensor = context.Output(0, output_shape);
+  if (output_shape.Size() == 0) {
+    return Status::OK();
+  }
+
+  // Transforms packed between the axis and the innermost (real/imaginary) dimension.
+  int64_t inner = 1;
+  for (int64_t d = axis + 1; d < rank - 1; ++d) {
+    inner *= input_shape[onnxruntime::narrow<size_t>(d)];
+  }
+  int64_t batch = 1;
+  for (int64_t d = 0; d < rank - 1; ++d) {
+    if (d != axis) {
+      batch *= input_shape[onnxruntime::narrow<size_t>(d)];
+    }
+  }
+
+  const uint32_t transform_length = static_cast<uint32_t>(length);
+  std::vector<uint32_t> radices;
+  const bool use_shared_memory_fft =
+      transform_length <= kDftMaxSharedMemoryLength && FactorizeToRadices(transform_length, radices);
+
+  if (use_shared_memory_fft) {
+    DFTProgram program{transform_length, static_cast<uint32_t>(input_components),
+                       static_cast<uint32_t>(output_components), is_inverse_, is_onesided_};
+    program
+        .AddInputs({{input_tensor, ProgramTensorMetadataDependency::Type}})
+        .AddOutputs({{output_tensor, ProgramTensorMetadataDependency::Type}})
+        .CacheHint(std::to_string(transform_length), std::to_string(input_components),
+                   std::to_string(output_components), std::to_string(is_inverse_), std::to_string(is_onesided_))
+        .SetWorkgroupSize(kDftWorkgroupSize)
+        .SetDispatchGroupSize(static_cast<uint32_t>(batch))
+        .AddUniformVariables({{static_cast<uint32_t>(batch)},
+                              {static_cast<uint32_t>(signal_length)},
+                              {static_cast<uint32_t>(inner)},
+                              {static_cast<uint32_t>(output_length)}});
+    return context.RunProgram(program);
+  }
+
+  DFTDirectProgram program{transform_length, static_cast<uint32_t>(input_components),
+                           static_cast<uint32_t>(output_components), is_inverse_, is_onesided_};
+  program
+      .AddInputs({{input_tensor, ProgramTensorMetadataDependency::Type}})
+      .AddOutputs({{output_tensor, ProgramTensorMetadataDependency::Type}})
+      .CacheHint(std::to_string(transform_length), std::to_string(input_components),
+                 std::to_string(output_components), std::to_string(is_inverse_), std::to_string(is_onesided_))
+      .SetWorkgroupSize(kDftWorkgroupSize)
+      .SetDispatchGroupSize(static_cast<uint32_t>(batch))
+      .AddUniformVariables({{static_cast<uint32_t>(batch)},
+                            {static_cast<uint32_t>(signal_length)},
+                            {static_cast<uint32_t>(inner)},
+                            {static_cast<uint32_t>(output_length)}});
+  return context.RunProgram(program);
+}
+
+}  // namespace webgpu
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/webgpu/math/dft.cc
+++ b/onnxruntime/core/providers/webgpu/math/dft.cc
@@ -266,16 +266,17 @@ Status DFTDirectProgram::GenerateShaderCode(ShaderHelper& shader) const {
   return Status::OK();
 }
 
-static bool TryReadScalar(const Tensor* tensor, int64_t& value) {
-  if (tensor == nullptr || tensor->Shape().Size() == 0) {
-    return false;
+static Status ReadOptionalScalar(const Tensor* tensor, const char* name, int64_t& value) {
+  if (tensor == nullptr) {
+    return Status::OK();
   }
+  ORT_RETURN_IF_NOT(tensor->Shape().IsScalar(), name, " must be a scalar value.");
   if (tensor->DataType() == DataTypeImpl::GetType<int64_t>()) {
     value = tensor->Data<int64_t>()[0];
   } else {
     value = static_cast<int64_t>(tensor->Data<int32_t>()[0]);
   }
-  return true;
+  return Status::OK();
 }
 
 Status DFT::ComputeInternal(ComputeContext& context) const {
@@ -290,7 +291,7 @@ Status DFT::ComputeInternal(ComputeContext& context) const {
 
   int64_t axis = axis_;
   if (opset_ >= 20 && context.InputCount() > 2) {
-    TryReadScalar(context.Input(2), axis);
+    ORT_RETURN_IF_ERROR(ReadOptionalScalar(context.Input(2), "axis", axis));
   }
   axis = HandleNegativeAxis(axis, rank);
   ORT_RETURN_IF(axis == rank - 1,
@@ -301,7 +302,7 @@ Status DFT::ComputeInternal(ComputeContext& context) const {
   const int64_t signal_length = input_shape[onnxruntime::narrow<size_t>(axis)];
   int64_t length = is_inverse_ && is_onesided_ ? (signal_length - 1) * 2 : signal_length;
   if (context.InputCount() > 1) {
-    TryReadScalar(context.Input(1), length);
+    ORT_RETURN_IF_ERROR(ReadOptionalScalar(context.Input(1), "dft_length", length));
   }
   ORT_RETURN_IF(length < 0 || length > std::numeric_limits<uint32_t>::max(), "Invalid DFT length: ", length);
 

--- a/onnxruntime/core/providers/webgpu/math/dft.cc
+++ b/onnxruntime/core/providers/webgpu/math/dft.cc
@@ -156,11 +156,18 @@ Status DFTProgram::GenerateShaderCode(ShaderHelper& shader) const {
       << "let out_base = (outer * uniforms.output_length * uniforms.inner + within) * " << output_components_ << "u;\n";
 
   if (is_inverse_ && is_onesided_) {
-    // For IRFFT the spectrum is the Hermitian extension of the half-spectrum input.
-    const std::string conjugate_end = length_ % 2 == 0 ? "uniforms.signal_length - 1u" : "uniforms.signal_length";
+    // For IRFFT the spectrum is the Hermitian extension of the half-spectrum input, zero-padded or
+    // truncated when dft_length implies a different bin count than the input provides. The Nyquist
+    // bin is only exempt from mirroring when it is actually present.
+    const uint32_t half_spectrum = length_ / 2 + 1;
+    const std::string conjugate_end =
+        length_ % 2 == 0
+            ? "select(provided, provided - 1u, provided == " + std::to_string(half_spectrum) + "u)"
+            : "provided";
     shader.MainFunctionBody()
-        << "for (var i = local_idx; i < uniforms.signal_length; i += " << kDftWorkgroupSize << "u) {\n"
-        << "  smem[i] = " << read_sample("i") << ";\n"
+        << "let provided = min(uniforms.signal_length, " << half_spectrum << "u);\n"
+        << "for (var i = local_idx; i < " << length_ << "u; i += " << kDftWorkgroupSize << "u) {\n"
+        << "  if (i < provided) { smem[i] = " << read_sample("i") << "; } else { smem[i] = vec2<f32>(0.0); }\n"
         << "}\n"
         << "workgroupBarrier();\n"
         << "for (var k = local_idx + 1u; k < " << conjugate_end << "; k += " << kDftWorkgroupSize << "u) {\n"
@@ -221,12 +228,20 @@ Status DFTDirectProgram::GenerateShaderCode(ShaderHelper& shader) const {
       << "  return vec2<f32>(a.x * b.x - a.y * b.y, a.x * b.y + a.y * b.x);\n"
       << "}\n";
   if (is_inverse_ && is_onesided_) {
-    // For IRFFT the spectrum is the Hermitian extension of the half-spectrum input.
+    // For IRFFT the spectrum is the Hermitian extension of the half-spectrum input, zero-padded or
+    // truncated when dft_length implies a different bin count than the input provides. Reads must
+    // never pass `provided`, or they would land in the adjacent transform's data.
+    const uint32_t half_spectrum = length_ / 2 + 1;
     shader.AdditionalImplementation()
         << "fn spectrum(in_base: u32, k: u32) -> vec2<f32> {\n"
-        << "  if (k < uniforms.signal_length) { return " << read_sample("k") << "; }\n"
-        << "  let h = " << read_sample(std::to_string(length_) + "u - k") << ";\n"
-        << "  return vec2<f32>(h.x, -h.y);\n"
+        << "  let provided = min(uniforms.signal_length, " << half_spectrum << "u);\n"
+        << "  if (k < provided) { return " << read_sample("k") << "; }\n"
+        << "  let m = " << length_ << "u - k;\n"
+        << "  if (m < provided) {\n"
+        << "    let h = " << read_sample("m") << ";\n"
+        << "    return vec2<f32>(h.x, -h.y);\n"
+        << "  }\n"
+        << "  return vec2<f32>(0.0, 0.0);\n"
         << "}\n";
   } else {
     shader.AdditionalImplementation()

--- a/onnxruntime/core/providers/webgpu/math/dft.cc
+++ b/onnxruntime/core/providers/webgpu/math/dft.cc
@@ -301,8 +301,9 @@ Status DFT::ComputeInternal(ComputeContext& context) const {
 
   const int64_t signal_length = input_shape[onnxruntime::narrow<size_t>(axis)];
   int64_t length = is_inverse_ && is_onesided_ ? (signal_length - 1) * 2 : signal_length;
-  if (context.InputCount() > 1) {
+  if (context.InputCount() > 1 && context.Input(1) != nullptr) {
     ORT_RETURN_IF_ERROR(ReadOptionalScalar(context.Input(1), "dft_length", length));
+    ORT_RETURN_IF(length <= 0, "dft_length must be greater than zero.");
   }
   ORT_RETURN_IF(length < 0 || length > std::numeric_limits<uint32_t>::max(), "Invalid DFT length: ", length);
 

--- a/onnxruntime/core/providers/webgpu/math/dft.h
+++ b/onnxruntime/core/providers/webgpu/math/dft.h
@@ -1,0 +1,88 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/providers/webgpu/webgpu_kernel.h"
+#include "core/providers/webgpu/program.h"
+
+namespace onnxruntime {
+namespace webgpu {
+
+// Shared-memory mixed-radix (2/3/4/5) Stockham FFT: one transform per workgroup, O(N log N).
+// Used when the transform length is 5-smooth and fits in workgroup memory.
+class DFTProgram final : public Program<DFTProgram> {
+ public:
+  DFTProgram(uint32_t length, uint32_t input_components, uint32_t output_components, bool is_inverse, bool is_onesided)
+      : Program{"DFT"},
+        length_{length},
+        input_components_{input_components},
+        output_components_{output_components},
+        is_inverse_{is_inverse},
+        is_onesided_{is_onesided} {}
+
+  Status GenerateShaderCode(ShaderHelper& sh) const override;
+
+  WEBGPU_PROGRAM_DEFINE_UNIFORM_VARIABLES(
+      {"batch", ProgramUniformVariableDataType::Uint32},
+      {"signal_length", ProgramUniformVariableDataType::Uint32},
+      {"inner", ProgramUniformVariableDataType::Uint32},
+      {"output_length", ProgramUniformVariableDataType::Uint32});
+
+ private:
+  uint32_t length_;
+  uint32_t input_components_;
+  uint32_t output_components_;
+  bool is_inverse_;
+  bool is_onesided_;
+};
+
+// Direct O(N^2) DFT for lengths the shared-memory FFT cannot take (non 5-smooth, or beyond the
+// workgroup memory budget). One workgroup per transform; each output bin sums over the input samples.
+class DFTDirectProgram final : public Program<DFTDirectProgram> {
+ public:
+  DFTDirectProgram(uint32_t length, uint32_t input_components, uint32_t output_components, bool is_inverse, bool is_onesided)
+      : Program{"DFTDirect"},
+        length_{length},
+        input_components_{input_components},
+        output_components_{output_components},
+        is_inverse_{is_inverse},
+        is_onesided_{is_onesided} {}
+
+  Status GenerateShaderCode(ShaderHelper& sh) const override;
+
+  WEBGPU_PROGRAM_DEFINE_UNIFORM_VARIABLES(
+      {"batch", ProgramUniformVariableDataType::Uint32},
+      {"signal_length", ProgramUniformVariableDataType::Uint32},
+      {"inner", ProgramUniformVariableDataType::Uint32},
+      {"output_length", ProgramUniformVariableDataType::Uint32});
+
+ private:
+  uint32_t length_;
+  uint32_t input_components_;
+  uint32_t output_components_;
+  bool is_inverse_;
+  bool is_onesided_;
+};
+
+class DFT final : public WebGpuKernel {
+ public:
+  DFT(const OpKernelInfo& info) : WebGpuKernel{info} {
+    opset_ = info.node().SinceVersion();
+    is_onesided_ = info.GetAttrOrDefault<int64_t>("onesided", 0) != 0;
+    is_inverse_ = info.GetAttrOrDefault<int64_t>("inverse", 0) != 0;
+    // Opset 20 moves axis from an attribute to input 2; -2 is its spec default.
+    axis_ = opset_ < 20 ? info.GetAttrOrDefault<int64_t>("axis", 1) : -2;
+  }
+
+  Status ComputeInternal(ComputeContext& context) const override;
+
+ private:
+  int64_t axis_;
+  bool is_onesided_;
+  bool is_inverse_;
+  int opset_;
+};
+
+}  // namespace webgpu
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
@@ -443,6 +443,9 @@ static const BuildKernelCreateInfoFn build_kernel_create_info_function_table[] =
     BuildKernelCreateInfo<class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 11, 13, CumSum)>,
     BuildKernelCreateInfo<class ONNX_OPERATOR_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 14, CumSum)>,
 
+    KERNEL_CREATE_INFO_VERSIONED(17, 19, DFT),
+    KERNEL_CREATE_INFO(20, DFT),
+
     KERNEL_CREATE_INFO_VERSIONED(1, 9, TopK),
     KERNEL_CREATE_INFO_VERSIONED(10, 10, TopK),
     KERNEL_CREATE_INFO_VERSIONED(11, 23, TopK),

--- a/onnxruntime/test/providers/cpu/signal/signal_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/signal/signal_ops_test.cc
@@ -535,6 +535,76 @@ TEST(SignalOpsTest, DFT20_RFFT_IRFFT_roundtrip) {
   TestRFFTIRFFTRoundTrip(kOpsetVersion20);
 }
 
+// Length 7 is prime, exercising the non-radix code paths (Bluestein on CPU, direct DFT on GPU EPs).
+static void TestPrimeLengthDFTFloat(bool onesided, int since_version) {
+  OpTester test("DFT", since_version);
+
+  vector<int64_t> shape = {1, 7, 1};
+  vector<float> input = {1, 2, 3, 4, 5, 6, 7};
+
+  vector<int64_t> output_shape = {1, onesided ? 4 : 7, 2};
+  vector<float> expected_output = {28.00000f, 0.00000f, -3.50000f, 7.26782f,
+                                   -3.50000f, 2.79116f, -3.50000f, 0.79885f};
+  if (!onesided) {
+    expected_output.insert(expected_output.end(),
+                           {-3.50000f, -0.79885f, -3.50000f, -2.79116f, -3.50000f, -7.26782f});
+  }
+
+  test.AddInput<float>("input", shape, input);
+  if (since_version == 20) {
+    test.AddInput<int64_t>("dft_length", {}, {7});
+    test.AddInput<int64_t>("axis", {}, {1});
+  }
+  test.AddAttribute<int64_t>("onesided", static_cast<int64_t>(onesided));
+  test.AddOutput<float>("output", output_shape, expected_output);
+  test.SetOutputAbsErr("output", 0.0002f);
+  test.ConfigExcludeEps({kDmlExecutionProvider});
+  test.RunWithConfig();
+}
+
+TEST(SignalOpsTest, DFT17_Float_prime_length) { TestPrimeLengthDFTFloat(false, kMinOpsetVersion); }
+
+TEST(SignalOpsTest, DFT20_Float_prime_length) { TestPrimeLengthDFTFloat(false, kOpsetVersion20); }
+
+TEST(SignalOpsTest, DFT17_Float_prime_length_onesided) { TestPrimeLengthDFTFloat(true, kMinOpsetVersion); }
+
+TEST(SignalOpsTest, DFT20_Float_prime_length_onesided) { TestPrimeLengthDFTFloat(true, kOpsetVersion20); }
+
+// dft_length longer than the signal zero-pads before the transform; padding to 8 stays on radix
+// paths while padding to 7 lands on the non-radix fallback.
+static void TestZeroPaddedDFTFloat(int64_t dft_length, int since_version) {
+  OpTester test("DFT", since_version);
+
+  vector<int64_t> shape = {1, 5, 1};
+  vector<float> input = {1, 2, 3, 4, 5};
+
+  const vector<float> expected_padded_to_8 = {
+      15.00000f, 0.00000f, -5.41421f, -7.24264f, 3.00000f, 2.00000f, -2.58579f, -1.24264f,
+      3.00000f, 0.00000f, -2.58579f, 1.24264f, 3.00000f, -2.00000f, -5.41421f, 7.24264f};
+  const vector<float> expected_padded_to_7 = {
+      15.00000f, 0.00000f, -6.52930f, -4.05456f, 3.46346f, -1.43004f, -0.93416f, 2.45265f,
+      -0.93416f, -2.45265f, 3.46346f, 1.43004f, -6.52930f, 4.05456f};
+  const vector<float>& expected_output = dft_length == 8 ? expected_padded_to_8 : expected_padded_to_7;
+
+  test.AddInput<float>("input", shape, input);
+  test.AddInput<int64_t>("dft_length", {}, {dft_length});
+  if (since_version == 20) {
+    test.AddInput<int64_t>("axis", {}, {1});
+  }
+  test.AddOutput<float>("output", {1, dft_length, 2}, expected_output);
+  test.SetOutputAbsErr("output", 0.0002f);
+  test.ConfigExcludeEps({kDmlExecutionProvider});
+  test.RunWithConfig();
+}
+
+TEST(SignalOpsTest, DFT17_Float_zero_padded_radix2) { TestZeroPaddedDFTFloat(8, kMinOpsetVersion); }
+
+TEST(SignalOpsTest, DFT20_Float_zero_padded_radix2) { TestZeroPaddedDFTFloat(8, kOpsetVersion20); }
+
+TEST(SignalOpsTest, DFT17_Float_zero_padded_prime) { TestZeroPaddedDFTFloat(7, kMinOpsetVersion); }
+
+TEST(SignalOpsTest, DFT20_Float_zero_padded_prime) { TestZeroPaddedDFTFloat(7, kOpsetVersion20); }
+
 // Test 2D complex input (single 1D signal without batch dimension)
 static void TestDFT2DComplex(int since_version) {
   OpTester test("DFT", since_version);

--- a/onnxruntime/test/providers/cpu/signal/signal_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/signal/signal_ops_test.cc
@@ -605,6 +605,34 @@ TEST(SignalOpsTest, DFT17_Float_zero_padded_prime) { TestZeroPaddedDFTFloat(7, k
 
 TEST(SignalOpsTest, DFT20_Float_zero_padded_prime) { TestZeroPaddedDFTFloat(7, kOpsetVersion20); }
 
+// Runs only against EPs that register DFT for float16 (the CPU kernel is float/double only).
+// Kernels accumulate in float32 internally, so the tolerance covers float16 output quantization.
+static void TestRadix2DFTFloat16(int since_version) {
+  OpTester test("DFT", since_version);
+
+  vector<int64_t> shape = {1, 8, 1};
+  vector<int64_t> output_shape = {1, 8, 2};
+
+  vector<float> input = {1, 2, 3, 4, 5, 6, 7, 8};
+  vector<float> expected_output = {36.000f, 0.000f, -4.000f, 9.65685f, -4.000f, 4.000f, -4.000f, 1.65685f,
+                                   -4.000f, 0.000f, -4.000f, -1.65685f, -4.000f, -4.000f, -4.000f, -9.65685f};
+
+  test.AddInput<MLFloat16>("input", shape, ToFloat16(input));
+  if (since_version == 20) {
+    test.AddInput<int64_t>("dft_length", {}, {8});
+    test.AddInput<int64_t>("axis", {}, {1});
+  }
+  test.AddOutput<MLFloat16>("output", output_shape, ToFloat16(expected_output));
+  test.SetOutputAbsErr("output", 0.05f);
+  test.ConfigExcludeEps({kDmlExecutionProvider});
+  test.RunWithConfig();
+}
+
+TEST(SignalOpsTest, DFT17_Float16_radix2) { TestRadix2DFTFloat16(kMinOpsetVersion); }
+
+TEST(SignalOpsTest, DFT20_Float16_radix2) { TestRadix2DFTFloat16(kOpsetVersion20); }
+
+
 // Test 2D complex input (single 1D signal without batch dimension)
 static void TestDFT2DComplex(int since_version) {
   OpTester test("DFT", since_version);

--- a/onnxruntime/test/providers/cpu/signal/signal_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/signal/signal_ops_test.cc
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 #include <functional>
+#include <string>
+#include <unordered_set>
 #include <vector>
 
 #include "gtest/gtest.h"
@@ -632,6 +634,59 @@ TEST(SignalOpsTest, DFT17_Float16_radix2) { TestRadix2DFTFloat16(kMinOpsetVersio
 
 TEST(SignalOpsTest, DFT20_Float16_radix2) { TestRadix2DFTFloat16(kOpsetVersion20); }
 
+// dft_length can imply a different half-spectrum bin count (floor(dft_length/2) + 1) than the
+// IRFFT input provides; missing bins are treated as zero and extra bins are ignored. The CPU
+// kernel implements these semantics on its Bluestein path but not yet on its radix-2 path, so
+// radix-2 length cases exclude the CPU EP until that is fixed.
+static void TestIRFFTSpectrumLengthMismatchFloat(const vector<float>& input, int64_t input_bins,
+                                                 int64_t dft_length, const vector<float>& expected_output,
+                                                 int since_version, bool exclude_cpu) {
+  OpTester test("DFT", since_version);
+
+  test.AddInput<float>("input", {1, input_bins, 2}, input);
+  test.AddInput<int64_t>("dft_length", {}, {dft_length});
+  if (since_version == 20) {
+    test.AddInput<int64_t>("axis", {}, {1});
+  }
+  test.AddAttribute<int64_t>("onesided", static_cast<int64_t>(true));
+  test.AddAttribute<int64_t>("inverse", static_cast<int64_t>(true));
+  test.AddOutput<float>("output", {1, dft_length, 1}, expected_output);
+  test.SetOutputAbsErr("output", 0.001f);
+  std::unordered_set<std::string> excluded_providers{kDmlExecutionProvider};
+  if (exclude_cpu) {
+    excluded_providers.insert(kCpuExecutionProvider);
+  }
+  test.ConfigExcludeEps(excluded_providers);
+  test.RunWithConfig();
+}
+
+TEST(SignalOpsTest, DFT17_IRFFT_underprovided_spectrum_radix2) {
+  TestIRFFTSpectrumLengthMismatchFloat(
+      {1, 0, 2, 1, 3, -2}, 3, 8,
+      {1.375000f, 0.801777f, -0.875000f, -0.905330f, 0.375000f, 0.448223f, -0.375000f, 0.155330f},
+      kMinOpsetVersion, /*exclude_cpu=*/true);
+}
+
+TEST(SignalOpsTest, DFT20_IRFFT_underprovided_spectrum_radix2) {
+  TestIRFFTSpectrumLengthMismatchFloat(
+      {1, 0, 2, 1, 3, -2}, 3, 8,
+      {1.375000f, 0.801777f, -0.875000f, -0.905330f, 0.375000f, 0.448223f, -0.375000f, 0.155330f},
+      kOpsetVersion20, /*exclude_cpu=*/true);
+}
+
+TEST(SignalOpsTest, DFT20_IRFFT_underprovided_spectrum_prime) {
+  TestIRFFTSpectrumLengthMismatchFloat(
+      {1, 0, 2, 1, 3, -2}, 3, 7,
+      {1.571429f, 0.642126f, -1.283041f, -0.408290f, 0.733165f, -0.230072f, -0.025316f},
+      kOpsetVersion20, /*exclude_cpu=*/false);
+}
+
+TEST(SignalOpsTest, DFT20_IRFFT_overprovided_spectrum_radix2) {
+  TestIRFFTSpectrumLengthMismatchFloat(
+      {1, 0, 2, 1, 3, -2, 4, 0.5f, -1, 0, 5, 5, 6, -6}, 7, 8,
+      {2.250000f, 0.131282f, -0.875000f, -0.161612f, -0.750000f, 1.368718f, -0.625000f, -0.338388f},
+      kOpsetVersion20, /*exclude_cpu=*/true);
+}
 
 // Test 2D complex input (single 1D signal without batch dimension)
 static void TestDFT2DComplex(int since_version) {

--- a/onnxruntime/test/providers/cpu/signal/signal_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/signal/signal_ops_test.cc
@@ -641,6 +641,10 @@ TEST(SignalOpsTest, DFT20_Float16_radix2) { TestRadix2DFTFloat16(kOpsetVersion20
 static void TestIRFFTSpectrumLengthMismatchFloat(const vector<float>& input, int64_t input_bins,
                                                  int64_t dft_length, const vector<float>& expected_output,
                                                  int since_version, bool exclude_cpu) {
+  if (exclude_cpu && nullptr == DefaultWebGpuExecutionProvider().get()) {
+    GTEST_SKIP() << "Test requires the WebGPU execution provider when the CPU radix-2 path is excluded.";
+  }
+
   OpTester test("DFT", since_version);
 
   test.AddInput<float>("input", {1, input_bins, 2}, input);


### PR DESCRIPTION
### Description

Implements the `DFT` operator (opset 17–20) for the WebGPU (JSEP) execution provider: a batched shared-memory mixed-radix (2/3/4/5) Stockham FFT, with an O(N^2) direct-DFT fallback for non-5-smooth lengths. Handles real/complex input, forward/inverse (1/N-normalized), one-sided RFFT and one-sided-inverse IRFFT, and the opset-20 `dft_length`/`axis` tensor inputs — matching the semantics of the CPU kernel in `core/providers/cpu/signal/dft.cc`.

### Motivation and Context

The WebGPU EP had no DFT/FFT kernel, so spectral and audio-preprocessing models fall back to a slow path (#20997). This adds it to the JSEP EP. The op test suite was extended to cover the WebGPU backend; I also verified the kernel against ORT's CPU DFT on real WebGPU across the forward, inverse, RFFT, and IRFFT paths. As with other `onnxruntime-web` op PRs, CI is the source of truth for the full web build.

Closes #20997