### PR TITLE
Fix copy-paste typos in DynamicQuantizeLSTM zero-point and scale validation

### DIFF
--- a/onnxruntime/contrib_ops/cpu/quantization/dynamic_quantize_lstm.cc
+++ b/onnxruntime/contrib_ops/cpu/quantization/dynamic_quantize_lstm.cc
@@ -178,14 +178,14 @@ Status DynamicQuantizeLSTM::Compute(OpKernelContext* context) const {
   const Tensor* r_zp = context->Input<Tensor>(11);
 
   const TensorShape& W_zp_shape = w_zp->Shape();
-  const TensorShape& R_zp_shape = w_zp->Shape();
+  const TensorShape& R_zp_shape = r_zp->Shape();
   const TensorShape& W_scale_shape = w_scale->Shape();
   const TensorShape& R_scale_shape = r_scale->Shape();
 
   WeightCheck(W_zp_shape, W_zero_point);
   WeightCheck(R_zp_shape, R_zero_point);
   WeightCheck(W_scale_shape, W_scale);
-  WeightCheck(W_scale_shape, R_scale);
+  WeightCheck(R_scale_shape, R_scale);
 
   const bool is_W_signed = (W != nullptr) ? W->IsDataType<int8_t>() : is_W_signed_;
   const bool is_R_signed = (R != nullptr) ? R->IsDataType<int8_t>() : is_R_signed_;


### PR DESCRIPTION
### Description

Two copy-paste typos in  DynamicQuantizeLSTM::Compute  ( dynamic_quantize_lstm.cc ) cause the recurrence-weight zero-point and scale to be validated against the wrong tensor's shape:

1. L181:  R_zp_shape = w_zp->Shape()  →  r_zp->Shape() .  ZeroPointCheck  then iterates  w_zp 's element count over the smaller  r_zp  tensor, reading past it (OOB read).
2. L188:  WeightCheck(W_scale_shape, R_scale)  →  WeightCheck(R_scale_shape, R_scale) . The recurrence scale shape is validated against the input scale shape instead of its own.



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


