### PR TITLE
Upgrade to Xcode 26

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -38,7 +38,7 @@ jobs:
           XCODE_DEVELOPER_DIR="/Applications/Xcode_${{ env.XCODE_VERSION }}.app/Contents/Developer"
           sudo xcode-select --switch "${XCODE_DEVELOPER_DIR}"
 
-      - name: (CPU, CoreML, XNNPACK EPs) Build onnxruntime for iOS x86_64 and run tests using simulator
+      - name: (CPU, CoreML, XNNPACK EPs) Build onnxruntime for iOS and run tests using simulator
         shell: bash
         run: |
           python3 ${{ github.workspace }}/tools/ci_build/build.py \
@@ -49,7 +49,7 @@ jobs:
             --use_xnnpack \
             --ios \
             --apple_sysroot iphonesimulator \
-            --osx_arch x86_64 \
+            --osx_arch arm64 \
             --apple_deploy_target=15.1 \
             --use_xcode \
             --config RelWithDebInfo \

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   iOS_CI_on_Mac:
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -61,5 +61,5 @@ jobs:
 
     timeout-minutes: 150
     env:
-      XCODE_VERSION: 15.3.0
-      IOS_SIMULATOR_RUNTIME_VERSION: 17.4
+      XCODE_VERSION: 26.3
+      IOS_SIMULATOR_RUNTIME_VERSION: 26.2

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -23,10 +23,12 @@ jobs:
     uses: ./.github/workflows/macos-ci-build-and-test-workflow.yml
     with:
       # Only build arm64 for CPU
+      # Also run a Release build on Xcode 26.3 for new-toolchain coverage.
       matrix_include: >-
         [
           {"machine": "arm64", "target": "arm64", "build_config": "Debug"},
-          {"machine": "arm64", "target": "arm64", "build_config": "Release"}
+          {"machine": "arm64", "target": "arm64", "build_config": "Release"},
+          {"machine": "arm64", "target": "arm64", "build_config": "Release", "xcode_version": "26.3"}
         ]
       python_version: "3.14"
 

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -23,12 +23,12 @@ jobs:
     uses: ./.github/workflows/macos-ci-build-and-test-workflow.yml
     with:
       # Only build arm64 for CPU
-      # Also run a Release build on Xcode 26.3 for new-toolchain coverage.
+      # Also run a Release build on Xcode 16 for legacy-toolchain coverage.
       matrix_include: >-
         [
           {"machine": "arm64", "target": "arm64", "build_config": "Debug"},
           {"machine": "arm64", "target": "arm64", "build_config": "Release"},
-          {"machine": "arm64", "target": "arm64", "build_config": "Release", "xcode_version": "26.3"}
+          {"machine": "arm64", "target": "arm64", "build_config": "Release", "xcode_version": "16"}
         ]
       python_version: "3.14"
 
@@ -71,8 +71,8 @@ jobs:
     runs-on: macos-15
 
     env:
-      xcode_version: 16.4
-      simulator_runtime_version: 18.5
+      xcode_version: 26.3
+      simulator_runtime_version: 26.2
 
     strategy:
       matrix:

--- a/.github/workflows/macos-ci-build-and-test-workflow.yml
+++ b/.github/workflows/macos-ci-build-and-test-workflow.yml
@@ -50,7 +50,7 @@ jobs:
 
     # "macos-15" is an arm64 image.
     # see also: https://github.com/actions/runner-images/blob/main/README.md
-    runs-on: macos-15
+    runs-on: ${{ matrix.machine == 'x86_64' && 'macos-15-intel' || 'macos-15' }}
     env:
       build_flags: >
         --build_dir ./build
@@ -70,9 +70,8 @@ jobs:
         --config ${{ matrix.build_config }}
         --osx_arch ${{ matrix.target }}
 
-      # xCode version needs to match the "runs-on" configuration.
-      # A matrix entry may override the Xcode version via "xcode_version";
-      # otherwise fall back to the default.
+      # A matrix entry may override the Xcode version via "xcode_version"; otherwise fall back to the default.
+      # The Xcode version needs to be present on the image specified in the "runs-on" configuration.
       xcode_version: ${{ matrix.xcode_version || '26.3' }}
 
     steps:

--- a/.github/workflows/macos-ci-build-and-test-workflow.yml
+++ b/.github/workflows/macos-ci-build-and-test-workflow.yml
@@ -48,9 +48,9 @@ jobs:
         #
         include: ${{ fromJSON(inputs.matrix_include) }}
 
-    # "macos-13" is a x86_64 image, and "macos-15" is an arm64 image.
+    # "macos-15" is an arm64 image.
     # see also: https://github.com/actions/runner-images/blob/main/README.md
-    runs-on: ${{ matrix.machine == 'x86_64' && 'macos-13' || 'macos-15' }}
+    runs-on: macos-15
     env:
       build_flags: >
         --build_dir ./build
@@ -71,7 +71,9 @@ jobs:
         --osx_arch ${{ matrix.target }}
 
       # xCode version needs to match the "runs-on" configuration.
-      xcode_version: ${{ matrix.machine == 'x86_64' && '14.3.1' || '16' }}
+      # A matrix entry may override the Xcode version via "xcode_version";
+      # otherwise fall back to the default.
+      xcode_version: ${{ matrix.xcode_version || '16' }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/macos-ci-build-and-test-workflow.yml
+++ b/.github/workflows/macos-ci-build-and-test-workflow.yml
@@ -73,7 +73,7 @@ jobs:
       # xCode version needs to match the "runs-on" configuration.
       # A matrix entry may override the Xcode version via "xcode_version";
       # otherwise fall back to the default.
-      xcode_version: ${{ matrix.xcode_version || '16' }}
+      xcode_version: ${{ matrix.xcode_version || '26.3' }}
 
     steps:
       - name: Checkout code

--- a/cmake/onnxruntime.cmake
+++ b/cmake/onnxruntime.cmake
@@ -402,14 +402,18 @@ if(onnxruntime_BUILD_APPLE_FRAMEWORK)
         # vs. onnxruntime/providers/core/cpu/math/element_wise_ops.o)
         # In that case, using 'ar ARGS -x' to extract the .o files from .a lib would possibly cause duplicate naming files being overwritten
         # and lead to missing undefined symbol error in the generated binary.
-        # So we use the below python script as a sanity check to do a recursive find of all .o files in ${CUR_TARGET_CMAKE_SOURCE_LIB_DIR}
+        # So we use the below python script as a sanity check to do a recursive find of all .o files in ${CUR_TARGET_OBJECT_DIR}
         # and verifies that matches the content of the .a, and then copy from the source dir.
         # TODO: The copying action here isn't really necessary. For future fix, consider using the script extracts from the ar with the rename to potentially
         # make both maccatalyst and other builds do the same thing.
-        set(CUR_TARGET_CMAKE_SOURCE_LIB_DIR ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/${_LIB}.dir)
+
+        # Use the target's own BINARY_DIR: targets added via add_subdirectory (e.g. model_package) put their
+        # objects under a nested CMakeFiles/<lib>.dir, not one directly under CMAKE_CURRENT_BINARY_DIR.
+        get_target_property(_LIB_BINARY_DIR ${_LIB} BINARY_DIR)
+        set(CUR_TARGET_OBJECT_DIR ${_LIB_BINARY_DIR}/CMakeFiles/${_LIB}.dir)
         add_custom_command(TARGET onnxruntime POST_BUILD
                           COMMAND /usr/bin/ar -t $<TARGET_FILE:${_LIB}> | grep "\.o$"  > ${_LIB}.object_file_list.txt
-                          COMMAND ${CMAKE_COMMAND} -E env python3 ${CMAKE_CURRENT_SOURCE_DIR}/maccatalyst_prepare_objects_for_prelink.py ${CUR_TARGET_CMAKE_SOURCE_LIB_DIR} ${CUR_STATIC_LIB_OBJ_DIR} ${CUR_STATIC_LIB_OBJ_DIR}/${_LIB}.object_file_list.txt
+                          COMMAND ${CMAKE_COMMAND} -E env python3 ${CMAKE_CURRENT_SOURCE_DIR}/maccatalyst_prepare_objects_for_prelink.py ${CUR_TARGET_OBJECT_DIR} ${CUR_STATIC_LIB_OBJ_DIR} ${CUR_STATIC_LIB_OBJ_DIR}/${_LIB}.object_file_list.txt
                           WORKING_DIRECTORY ${CUR_STATIC_LIB_OBJ_DIR})
       else()
         add_custom_command(TARGET onnxruntime POST_BUILD

--- a/cmake/patches/xnnpack/AddEmscriptenAndIosSupport.patch
+++ b/cmake/patches/xnnpack/AddEmscriptenAndIosSupport.patch
@@ -40,7 +40,23 @@ index 94bcad92e3..be7dfe95fd 100644
    SET_PROPERTY(SOURCE ${ALL_MICROKERNEL_SRCS} APPEND_STRING PROPERTY COMPILE_FLAGS " -marm ")
 -  SET_PROPERTY(SOURCE ${ALL_ARMSIMD32_MICROKERNEL_SRCS} APPEND_STRING PROPERTY COMPILE_FLAGS " -march=armv6 -mfpu=vfp -munaligned-access ")
 +  # set this to armv7-a to workaround build issue. we don't target armv6 so it shouldn't matter
-+  SET_PROPERTY(SOURCE ${ALL_ARMSIMD32_MICROKERNEL_SRCS} APPEND_STRING PROPERTY COMPILE_FLAGS " -march=armv7-a -mfpu=vfp -munaligned-access ") 
++  SET_PROPERTY(SOURCE ${ALL_ARMSIMD32_MICROKERNEL_SRCS} APPEND_STRING PROPERTY COMPILE_FLAGS " -march=armv7-a -mfpu=vfp -munaligned-access ")
    SET_PROPERTY(SOURCE ${ALL_NEON_MICROKERNEL_SRCS} APPEND_STRING PROPERTY COMPILE_FLAGS " -march=armv7-a -mfpu=neon ")
    SET_PROPERTY(SOURCE ${ALL_NEONFP16_MICROKERNEL_SRCS} APPEND_STRING PROPERTY COMPILE_FLAGS " -march=armv7-a -mfpu=neon-fp16 ")
    # GCC requires -mfp16-format=ieee to define __fp16 type, but Clang doesn't support this option at all.
+@@ -1038,7 +1047,14 @@ IF(XNNPACK_TARGET_PROCESSOR MATCHES "^x86(_64)?$")
+         SET_PROPERTY(SOURCE ${ALL_MICROKERNEL_SRCS} APPEND_STRING PROPERTY COMPILE_FLAGS " -fomit-frame-pointer ")
+       ENDIF()
+     ENDIF()
+-    SET_PROPERTY(SOURCE ${ALL_SSE_MICROKERNEL_SRCS} APPEND_STRING PROPERTY COMPILE_FLAGS " -msse -mno-sse2 ")
++    # ORT: x86_64 always has SSE2, and the iOS 18+/macOS 15+ SDK <math.h> declares
++    # _Float16 (which clang supports only with SSE2). Building the SSE microkernels with
++    # -mno-sse2 then breaks the system math module precompile on Apple x86_64; keep SSE2.
++    IF(APPLE AND XNNPACK_TARGET_PROCESSOR STREQUAL "x86_64")
++      SET_PROPERTY(SOURCE ${ALL_SSE_MICROKERNEL_SRCS} APPEND_STRING PROPERTY COMPILE_FLAGS " -msse2 -mno-sse3 ")
++    ELSE()
++      SET_PROPERTY(SOURCE ${ALL_SSE_MICROKERNEL_SRCS} APPEND_STRING PROPERTY COMPILE_FLAGS " -msse -mno-sse2 ")
++    ENDIF()
+     SET_PROPERTY(SOURCE ${ALL_SSE2_MICROKERNEL_SRCS} APPEND_STRING PROPERTY COMPILE_FLAGS " -msse2 -mno-sse3 ")
+     SET_PROPERTY(SOURCE ${ALL_SSSE3_MICROKERNEL_SRCS} APPEND_STRING PROPERTY COMPILE_FLAGS " -mssse3 -mno-sse4.1 ")
+     SET_PROPERTY(SOURCE ${ALL_SSE41_MICROKERNEL_SRCS} APPEND_STRING PROPERTY COMPILE_FLAGS " -msse4.1 -mno-sse4.2 ")

--- a/tools/ci_build/github/apple/default_full_ios_framework_build_settings.json
+++ b/tools/ci_build/github/apple/default_full_ios_framework_build_settings.json
@@ -19,8 +19,7 @@
             "--use_coreml",
             "--skip_tests",
             "--no_kleidiai",
-            "--cmake_extra_defines=onnxruntime_BUILD_UNIT_TESTS=OFF",
-            "--cmake_extra_defines=CMAKE_POLICY_VERSION_MINIMUM=3.5"
+            "--cmake_extra_defines=onnxruntime_BUILD_UNIT_TESTS=OFF"
         ],
         "iphoneos": [
             "--ios",

--- a/tools/ci_build/github/apple/default_full_ios_framework_build_settings.json
+++ b/tools/ci_build/github/apple/default_full_ios_framework_build_settings.json
@@ -19,7 +19,8 @@
             "--use_coreml",
             "--skip_tests",
             "--no_kleidiai",
-            "--cmake_extra_defines=onnxruntime_BUILD_UNIT_TESTS=OFF"
+            "--cmake_extra_defines=onnxruntime_BUILD_UNIT_TESTS=OFF",
+            "--cmake_extra_defines=CMAKE_POLICY_VERSION_MINIMUM=3.5"
         ],
         "iphoneos": [
             "--ios",

--- a/tools/ci_build/github/azure-pipelines/mac-ios-packaging-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/mac-ios-packaging-pipeline.yml
@@ -67,5 +67,5 @@ extends:
     - template: templates/stages/mac-ios-packaging-build-stage.yml
       parameters:
         buildType: ${{ parameters.buildType }}
-        xcodeVersion: "16.4"
-        iosSimulatorRuntimeVersion: "18.5"
+        xcodeVersion: "26.3"
+        iosSimulatorRuntimeVersion: "26.2"

--- a/tools/ci_build/github/azure-pipelines/post-merge-jobs.yml
+++ b/tools/ci_build/github/azure-pipelines/post-merge-jobs.yml
@@ -436,6 +436,8 @@ stages:
         architecture: 'x64'
 
     - template: templates/use-xcode-version.yml
+      parameters:
+        xcodeVersion: 15.3.0
 
     - script: |
         pip install -r tools/ci_build/github/apple/ios_packaging/requirements.txt

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-mac-webgpu-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-mac-webgpu-stage.yml
@@ -43,8 +43,6 @@ stages:
       submodules: none
 
     - template: ../templates/use-xcode-version.yml
-      parameters:
-        xcodeVersion: '16.4'
 
     - template: ../templates/setup-build-tools.yml
       parameters:

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
@@ -110,7 +110,7 @@ stages:
       name: AcesShared
       os: macOS
       demands:
-      - ImageOverride -equals ACES_VM_SharedPool_Sequoia
+      - ImageOverride -equals ACES_VM_SharedPool_Tahoe
 
     timeoutInMinutes: 300
     steps:

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
@@ -132,13 +132,18 @@ stages:
         python3 tools/ci_build/github/apple/build_apple_framework.py \
           --build_dir "$(Build.BinariesDirectory)/ios_framework" \
           tools/ci_build/github/apple/default_full_ios_framework_build_settings.json
+      displayName: "Build Apple xcframework"
+
+    - script: |
+        set -e -x
         mkdir $(Build.BinariesDirectory)/artifacts
         pushd $(Build.BinariesDirectory)/ios_framework/framework_out
         zip -vry $(Build.BinariesDirectory)/artifacts/onnxruntime_ios_xcframework.$(OnnxRuntimeVersion).zip \
           onnxruntime.xcframework
-        cp xcframework_info.json $(Build.BinariesDirectory)/artifacts/xcframework_info.json
         popd
-      displayName: "Build Apple xcframework"
+        cp $(Build.BinariesDirectory)/ios_framework/xcframework_info.json \
+          $(Build.BinariesDirectory)/artifacts/xcframework_info.json
+      displayName: "Stage artifacts"
 
     - task: 1ES.PublishPipelineArtifact@1
       inputs:

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
@@ -110,7 +110,7 @@ stages:
       name: AcesShared
       os: macOS
       demands:
-      - ImageOverride -equals ACES_VM_SharedPool_Tahoe
+      - ImageOverride -equals ACES_VM_SharedPool_Sequoia
 
     timeoutInMinutes: 300
     steps:

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
@@ -136,23 +136,39 @@ stages:
 
     - script: |
         set -e -x
-        mkdir $(Build.BinariesDirectory)/artifacts
+
+        # Stage onnxruntime.xcframework as artifact.
+        mkdir -p $(Build.BinariesDirectory)/artifacts/xcframework
+
         pushd $(Build.BinariesDirectory)/ios_framework/framework_out
-        zip -vry $(Build.BinariesDirectory)/artifacts/onnxruntime_ios_xcframework.$(OnnxRuntimeVersion).zip \
+        zip -vry $(Build.BinariesDirectory)/artifacts/xcframework/onnxruntime_ios_xcframework.$(OnnxRuntimeVersion).zip \
           onnxruntime.xcframework
         popd
-        cp $(Build.BinariesDirectory)/ios_framework/xcframework_info.json \
-          $(Build.BinariesDirectory)/artifacts/xcframework_info.json
+
+        # Stage framework_out and xcframework_info.json as test artifact.
+        # Note: framework_out has another copy of onnxruntime.xcframework. This duplication is simpler than
+        # reconstructing the test files from two separate pipeline artifacts.
+        mkdir -p $(Build.BinariesDirectory)/artifacts/test
+
+        pushd $(Build.BinariesDirectory)/ios_framework
+        zip -vry $(Build.BinariesDirectory)/artifacts/test/test_files.zip \
+          framework_out xcframework_info.json
+        popd
       displayName: "Stage artifacts"
 
     - task: 1ES.PublishPipelineArtifact@1
       inputs:
-        targetPath: '$(Build.BinariesDirectory)/artifacts'
+        targetPath: '$(Build.BinariesDirectory)/artifacts/xcframework'
         artifactName: 'onnxruntime-ios-full-xcframework'
 
-  # Run the framework test on a Microsoft-hosted macOS image, which has the required iOS simulator
-  # runtime. The build above stays on the faster ACES pool; only this lighter test job uses the
-  # hosted image. It consumes the xcframework artifact published by the build job.
+    - task: 1ES.PublishPipelineArtifact@1
+      inputs:
+        targetPath: '$(Build.BinariesDirectory)/artifacts/test'
+        artifactName: 'onnxruntime-ios-full-xcframework-test'
+
+  # Run the framework test on a Microsoft-hosted macOS image, which has the required iOS simulator runtime.
+  # The build above stays on the faster ACES pool; only this lighter test job uses the hosted image.
+  # It consumes the onnxruntime-ios-full-xcframework-test artifact published by the build job.
   - job: iOS_Full_xcframework_test
     dependsOn: iOS_Full_xcframework
     workspace:
@@ -165,8 +181,8 @@ stages:
     templateContext:
       inputs:
       - input: pipelineArtifact
-        artifactName: 'onnxruntime-ios-full-xcframework'
-        targetPath: '$(Build.BinariesDirectory)/xcframework_artifact'
+        artifactName: 'onnxruntime-ios-full-xcframework-test'
+        targetPath: '$(Build.BinariesDirectory)/artifacts/test'
     steps:
     - checkout: self
 
@@ -180,15 +196,13 @@ stages:
 
     - script: |
         set -e -x
-        mkdir -p "$(Build.BinariesDirectory)/xcframework_out"
-        unzip -q "$(Build.BinariesDirectory)"/xcframework_artifact/onnxruntime_ios_xcframework.*.zip \
-          -d "$(Build.BinariesDirectory)/xcframework_out"
-      displayName: "Extract xcframework artifact"
+        unzip "$(Build.BinariesDirectory)/artifacts/test/test_files.zip" -d "$(Build.BinariesDirectory)"
+      displayName: "Extract test files"
 
     - script: |
         python3 tools/ci_build/github/apple/test_apple_packages.py \
-          --framework_info_file "$(Build.BinariesDirectory)/xcframework_artifact/xcframework_info.json" \
-          --c_framework_dir "$(Build.BinariesDirectory)/xcframework_out" \
+          --framework_info_file "$(Build.BinariesDirectory)/xcframework_info.json" \
+          --c_framework_dir "$(Build.BinariesDirectory)/framework_out" \
           --skip_macos_test \
           --mac_catalyst_enabled
       displayName: "Test Apple framework"

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
@@ -117,8 +117,6 @@ stages:
     - template: set-version-number-variables-step.yml
 
     - template: use-xcode-version.yml
-      parameters:
-        xcodeVersion: 16.4
 
     - template: setup-build-tools.yml
       parameters:

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
@@ -134,6 +134,11 @@ stages:
         popd
       displayName: "Build Apple xcframework"
 
+    - task: 1ES.PublishPipelineArtifact@1
+      inputs:
+        targetPath: '$(Build.BinariesDirectory)/artifacts'
+        artifactName: 'onnxruntime-ios-full-xcframework'
+
     - script: |
         python3 tools/ci_build/github/apple/test_apple_packages.py \
           --framework_info_file "$(Build.BinariesDirectory)/ios_framework/xcframework_info.json" \
@@ -141,11 +146,6 @@ stages:
           --skip_macos_test \
           --mac_catalyst_enabled
       displayName: "Test Apple framework"
-
-    - task: 1ES.PublishPipelineArtifact@1
-      inputs:
-        targetPath: '$(Build.BinariesDirectory)/artifacts'
-        artifactName: 'onnxruntime-ios-full-xcframework'
 
 - template: win-ci.yml
   parameters:

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
@@ -150,10 +150,45 @@ stages:
         targetPath: '$(Build.BinariesDirectory)/artifacts'
         artifactName: 'onnxruntime-ios-full-xcframework'
 
+  # Run the framework test on a Microsoft-hosted macOS image, which has the required iOS simulator
+  # runtime. The build above stays on the faster ACES pool; only this lighter test job uses the
+  # hosted image. It consumes the xcframework artifact published by the build job.
+  - job: iOS_Full_xcframework_test
+    dependsOn: iOS_Full_xcframework
+    workspace:
+      clean: all
+    pool:
+      name: "Azure Pipelines"
+      image: "macOS-15"
+      os: macOS
+    timeoutInMinutes: 90
+    templateContext:
+      inputs:
+      - input: pipelineArtifact
+        artifactName: 'onnxruntime-ios-full-xcframework'
+        targetPath: '$(Build.BinariesDirectory)/xcframework_artifact'
+    steps:
+    - checkout: self
+
+    - template: use-xcode-version.yml
+      parameters:
+        xcodeVersion: ${{ variables.xcodeVersion }}
+
+    - template: setup-build-tools.yml
+      parameters:
+        host_cpu_arch: arm64
+
+    - script: |
+        set -e -x
+        mkdir -p "$(Build.BinariesDirectory)/xcframework_out"
+        unzip -q "$(Build.BinariesDirectory)"/xcframework_artifact/onnxruntime_ios_xcframework.*.zip \
+          -d "$(Build.BinariesDirectory)/xcframework_out"
+      displayName: "Extract xcframework artifact"
+
     - script: |
         python3 tools/ci_build/github/apple/test_apple_packages.py \
-          --framework_info_file "$(Build.BinariesDirectory)/ios_framework/xcframework_info.json" \
-          --c_framework_dir "$(Build.BinariesDirectory)/ios_framework/framework_out" \
+          --framework_info_file "$(Build.BinariesDirectory)/xcframework_artifact/xcframework_info.json" \
+          --c_framework_dir "$(Build.BinariesDirectory)/xcframework_out" \
           --skip_macos_test \
           --mac_catalyst_enabled
       displayName: "Test Apple framework"

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
@@ -131,6 +131,7 @@ stages:
         pushd $(Build.BinariesDirectory)/ios_framework/framework_out
         zip -vry $(Build.BinariesDirectory)/artifacts/onnxruntime_ios_xcframework.$(OnnxRuntimeVersion).zip \
           onnxruntime.xcframework
+        cp xcframework_info.json $(Build.BinariesDirectory)/artifacts/xcframework_info.json
         popd
       displayName: "Build Apple xcframework"
 

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
@@ -102,6 +102,9 @@ stages:
 
 - stage: iOS_Full_xcframework
   dependsOn: []
+  variables:
+    xcodeVersion: "26.3"
+    iosSimulatorRuntimeVersion: "26.2"
   jobs:
   - job: iOS_Full_xcframework
     workspace:
@@ -117,6 +120,8 @@ stages:
     - template: set-version-number-variables-step.yml
 
     - template: use-xcode-version.yml
+      parameters:
+        xcodeVersion: ${{ variables.xcodeVersion }}
 
     - template: setup-build-tools.yml
       parameters:
@@ -147,6 +152,8 @@ stages:
           --skip_macos_test \
           --mac_catalyst_enabled
       displayName: "Test Apple framework"
+      env:
+        ORT_GET_SIMULATOR_DEVICE_INFO_REQUESTED_RUNTIME_VERSION: ${{ variables.iosSimulatorRuntimeVersion }}
 
 - template: win-ci.yml
   parameters:

--- a/tools/ci_build/github/azure-pipelines/templates/mac-cpu-packing-jobs.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/mac-cpu-packing-jobs.yml
@@ -32,8 +32,6 @@ jobs:
     submodules: none
 
   - template: use-xcode-version.yml
-    parameters:
-      xcodeVersion: 16.4
 
   - template: setup-build-tools.yml
     parameters:

--- a/tools/ci_build/github/azure-pipelines/templates/py-macos.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-macos.yml
@@ -4,7 +4,7 @@ parameters:
 
 - name: python_version
   type: string
-  
+
 - name: cmake_build_type
   type: string
   default: 'Release'
@@ -37,16 +37,13 @@ jobs:
   variables:
   - name: MACOSX_DEPLOYMENT_TARGET
     value: '14.0'
-        
+
   steps:
   - checkout: self
     clean: true
     submodules: none
 
   - template: use-xcode-version.yml
-    parameters:
-      xcodeVersion: '16.4'
-
 
   - template: setup-build-tools.yml
     parameters:

--- a/tools/ci_build/github/azure-pipelines/templates/react-native-ci.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/react-native-ci.yml
@@ -68,8 +68,6 @@ stages:
       runCodesignValidationInjection: false
     steps:
     - template: use-xcode-version.yml
-      parameters:
-        xcodeVersion: 16.4
 
     - template: setup-build-tools.yml
       parameters:
@@ -112,8 +110,6 @@ stages:
         TargetPath: '$(Build.BinariesDirectory)/ios_pod'
 
     - template: use-xcode-version.yml
-      parameters:
-        xcodeVersion: 16.4
 
     - task: NodeTool@0
       inputs:

--- a/tools/ci_build/github/azure-pipelines/templates/use-xcode-version.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/use-xcode-version.yml
@@ -3,7 +3,7 @@
 parameters:
 - name: xcodeVersion
   type: string
-  default: "15.3.0"
+  default: "26.3"
 
 steps:
 - bash: |


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Update most Apple pipelines to use Xcode 26. Keep a build on Xcode 16 for coverage of the older toolchain.

Other fixes:
- Patch XNNPACK to fix an iphonesimulator x86_64 build error with the newer iphonesimulator SDK.
- Fix issue where object files were not copied from the right location for the Mac Catalyst static framework build.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Upgrade to a newer Xcode version. Xcode 16 is no longer available on some build images.