### PR TITLE
[WebNN EP] Fix scale/zero_point rank for per-axis QDQ on last axis

### DIFF
--- a/onnxruntime/core/providers/webnn/builders/impl/qdq_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/qdq_op_builder.cc
@@ -85,10 +85,10 @@ Status QDQOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
     }
   }
 
-  // For per-axis quantization/dequantization and axis is not equal to input_rank - 1,
-  // we need to reshape the scale and zero_point tensors to make them broadcastable with the input tensor.
-  if (scale_shape.size() == 1 && input_rank > 1 &&
-      block_size == 0 && axis != static_cast<int32_t>(input_rank - 1)) {
+  // For per-axis quantization/dequantization, the scale is 1-D.
+  // WebNN requires the scale and zero_point tensors to have the same rank as the input tensor.
+  // We need to reshape them to make them broadcastable with the input tensor.
+  if (scale_shape.size() == 1 && input_rank > 1 && block_size == 0) {
     // Insert ones before and after the axis dimension for broadcasting of scale tensor.
     std::vector<uint32_t> target_shape{SafeInt<uint32_t>(input_shape[axis])};
     target_shape.insert(target_shape.begin(), axis, 1);


### PR DESCRIPTION
For per-axis QuantizeLinear/DequantizeLinear, the scale and zero_point tensors are 1-D. WebNN's quantizeLinear/dequantizeLinear requires them to have the same rank as the input (it broadcasts per-dimension and does not left-pad ranks). The reshape was skipped when the quantization axis was the last dimension, leaving a rank-1 scale against a higher-rank input and triggering "the rank of scale is not equal to the rank of input".

Drop the `axis != input_rank - 1` guard so the reshape runs for all per-axis cases; the existing math already yields the correct shape (e.g. input [512, 1024], scale [1024], axis 1 -> scale [1, 1024]).

