### PR TITLE
Model package: fold external_data into session options and remove legacy directory load path

### DIFF
--- a/onnxruntime/core/session/model_package/README.md
+++ b/onnxruntime/core/session/model_package/README.md
@@ -45,8 +45,10 @@ optional, but in practice `model_file` is required to load a session.
 ```jsonc
 {
   "model_file":       "model.onnx",
-  "external_data":    "weights",
-  "session_options":  { "session.intra_op_thread_count": "4" },
+  "session_options":  {
+    "session.intra_op_thread_count": "4",
+    "session.model_external_initializers_file_folder_path": "weights"
+  },
   "provider_options": { "device_id": "0" }
 }
 ```
@@ -54,8 +56,7 @@ optional, but in practice `model_file` is required to load a session.
 | Field              | Type   | Required | Notes |
 | ------------------ | ------ | -------- | ----- |
 | `model_file`       | string | yes (for session) | Path to the model file inside the variant. Resolved via `ModelPackage_ResolveStringRef`, anchored at the variant directory. Accepts relative paths, absolute paths or `..` segments (installed layout only), and `sha256:<hex>[/sub/path]` for shared-asset content. |
-| `external_data`    | string | no       | Folder containing the model's external-initializers blobs. Wired into the session as ORT's external-initializers folder hint. Same resolution rules as `model_file`. |
-| `session_options`  | object | no       | Map of `string -> string`. Merged on top of a fresh `OrtSessionOptions` when the caller passes `session_options == NULL` to `CreateSession`. Ignored when the caller supplies their own `OrtSessionOptions`. |
+| `session_options`  | object | no       | Map of `string -> string`. Merged on top of a fresh `OrtSessionOptions` when the caller passes `session_options == NULL` to `CreateSession`. Values of path-valued keys (see `IsModelPackagePathSessionOption`, e.g. `session.model_external_initializers_file_folder_path`, `ep.context_file_path`) are resolved with the same rules as `model_file` at parse time. Those path-valued keys are also applied on the advanced path if the caller did not set them (see below). |
 | `provider_options` | object | no       | Map of `string -> string`. Merged into the variant's EP provider options on the default path. Ignored when the caller supplies their own `OrtSessionOptions`. |
 
 #### Inline vs external
@@ -130,16 +131,22 @@ provider list it should use. Two paths:
 
 - **`session_options != NULL` (advanced).** ORT uses the caller-supplied
   `OrtSessionOptions` as-is. The manifest's `session_options` and
-  `provider_options` are **not** merged. Use this when you need custom EP
-  setup that does not round-trip through string options (shared CUDA
+  `provider_options` are **not** merged, with one exception: path-valued
+  session options (see `IsModelPackagePathSessionOption`) are carried over
+  from the variant for keys the caller did not set, so a model that needs its
+  external-initializers folder still loads. Use this path when you need custom
+  EP setup that does not round-trip through string options (shared CUDA
   streams, shared QNN EP contexts, custom allocators, ...). The
   `OrtSessionOptions` passed earlier to
   `CreateModelPackageOptionsFromSessionOptions` only drives variant
   selection / EP discovery; it is never silently re-applied here.
 
-In both modes, `external_data` from `executor_info["ort"]` is wired in as
-ORT's external-initializers folder hint, so the model file can reference
-weights stored next to (or shared by) the package.
+A variant points ORT at external-initializer weights by setting
+`session.model_external_initializers_file_folder_path` in its
+`session_options` to a folder (relative, absolute, or `sha256:<hex>` shared
+asset). The value is resolved at parse time and overrides the model's own
+directory, so the model file can reference weights stored next to (or shared
+by) the package.
 
 ---
 

--- a/onnxruntime/core/session/model_package/model_package_context.cc
+++ b/onnxruntime/core/session/model_package/model_package_context.cc
@@ -16,6 +16,7 @@
 #include "core/session/model_package/model_package_context.h"
 #include "core/session/model_package/model_package_options.h"
 #include "core/session/model_package/model_package_variant_selector.h"
+#include "core/session/onnxruntime_session_options_config_keys.h"
 #include "core/session/ort_env.h"
 #include "core/session/provider_policy_context.h"
 #include "core/session/utils.h"
@@ -27,6 +28,13 @@
 #include "model_package.h"
 
 namespace onnxruntime {
+
+bool IsModelPackagePathSessionOption(std::string_view key) {
+  // Session-option config keys whose values are path references (sha256:<hex>, relative, or
+  // absolute) that must be resolved against the model package. Add new path-valued keys here.
+  return key == kOrtSessionOptionsModelExternalInitializersFileFolderPath ||
+         key == kOrtSessionOptionEpContextFilePath;
+}
 
 namespace {
 // Deleter for the type-erased model_package handle held by ModelPackageContext.
@@ -350,21 +358,6 @@ Status ModelPackageComponentContext::GetSelectedVariantName(const std::string*& 
   return Status::OK();
 }
 
-Status ModelPackageComponentContext::GetSelectedVariantExternalDataFolder(
-    const std::string*& out_folder) const {
-  out_folder = nullptr;
-  const VariantInfo* selected_variant = nullptr;
-  ORT_RETURN_IF_ERROR(GetSelectedVariantInfo(selected_variant));
-  ORT_RETURN_IF(selected_variant == nullptr,
-                "Selected variant is null for component: ", component_model_name_);
-  if (selected_variant->file.has_value() &&
-      selected_variant->file->external_data_folder_path.has_value() &&
-      !selected_variant->file->external_data_folder_path->empty()) {
-    out_folder = &(*selected_variant->file->external_data_folder_path);
-  }
-  return Status::OK();
-}
-
 ModelPackageContext::ModelPackageContext(const std::filesystem::path& package_root)
     : package_handle_(nullptr, &CloseModelPackageHandle), package_root_(package_root) {
   // Open the package via the model_package C API and keep the handle open for this context's
@@ -493,17 +486,18 @@ ModelPackageContext::ModelPackageContext(const std::filesystem::path& package_ro
         fill_string_map("session_options", ort_file.session_options);
         fill_string_map("provider_options", ort_file.provider_options);
 
-        if (auto it = ort_obj->find("external_data"); it != ort_obj->end()) {
-          if (!it->is_string()) {
-            ORT_THROW("ORT variant configuration: external_data must be a string for variant '",
-                      ort_variant.variant_name, "' in component '", component_name, "'");
+        // Resolve path-valued session options (e.g. the external initializers folder) against the
+        // package so variants can reference shared assets by sha256: URI or relative path.
+        if (ort_file.session_options.has_value()) {
+          for (auto& [key, value] : *ort_file.session_options) {
+            if (!value.empty() && IsModelPackagePathSessionOption(key)) {
+              value = resolve_string_ref(key.c_str(), value, /*must_exist=*/false);
+            }
           }
-          ort_file.external_data_folder_path = resolve_string_ref(
-              "external_data", it->get<std::string>(), /*must_exist=*/false);
         }
 
         if (!ort_file.identifier.empty() || ort_file.session_options.has_value() ||
-            ort_file.provider_options.has_value() || ort_file.external_data_folder_path.has_value()) {
+            ort_file.provider_options.has_value()) {
           ort_variant.file = std::move(ort_file);
         }
       }

--- a/onnxruntime/core/session/model_package/model_package_context.h
+++ b/onnxruntime/core/session/model_package/model_package_context.h
@@ -13,6 +13,7 @@
 #include "core/session/model_package/model_package_variant_selector.h"
 #include <memory>
 #include <optional>
+#include <string_view>
 #include <unordered_map>
 #include <vector>
 

--- a/onnxruntime/core/session/model_package/model_package_context.h
+++ b/onnxruntime/core/session/model_package/model_package_context.h
@@ -36,15 +36,15 @@ struct VariantModelInfo {
   std::string identifier;                 // deterministic id (e.g., filename)
   std::filesystem::path model_file_path;  // resolved path under <component>/<variant>/
 
-  // from variant.json file entry
+  // from variant.json file entry. Values of path-valued session option keys (see
+  // IsModelPackagePathSessionOption) are resolved to absolute paths at parse time.
   std::optional<std::unordered_map<std::string, std::string>> session_options;
   std::optional<std::unordered_map<std::string, std::string>> provider_options;
-
-  // Resolved folder containing the model's external initializer file, when
-  // executor_info.ort.external_data was set (path or sha256: URI). Empty
-  // otherwise. Used as the ORT external-initializers folder hint.
-  std::optional<std::string> external_data_folder_path;
 };
+
+// True if the given ORT session-option config key holds a file/folder path reference that must be
+// resolved against the model package (sha256:<hex>, relative, or absolute) before use.
+bool IsModelPackagePathSessionOption(std::string_view key);
 
 // variant-level info (metadata.json + variant.json)
 struct VariantInfo {
@@ -127,10 +127,6 @@ class ModelPackageComponentContext {
   Status GetSelectedVariantConsumerMetadata(const std::string*& out_json_str) const;
 
   Status GetSelectedVariantName(const std::string*& out_name) const;
-
-  // Returns the resolved external_data folder for the selected variant, or
-  // nullptr-on-success if none was declared. Borrowed from VariantModelInfo.
-  Status GetSelectedVariantExternalDataFolder(const std::string*& out_folder) const;
 
   std::vector<std::unique_ptr<IExecutionProvider>>& MutableProviderList() { return provider_list_; }
   const std::vector<const OrtEpDevice*>& ExecutionDevices() const { return execution_devices_; }

--- a/onnxruntime/core/session/model_package_api.cc
+++ b/onnxruntime/core/session/model_package_api.cc
@@ -355,7 +355,31 @@ ORT_API_STATUS_IMPL(OrtModelPackageApi_CreateSession_SinceV28,
 
     effective_options = &*effective_options_storage;
   } else {
-    effective_options = session_options;
+    // Advanced path: use the caller-supplied options. Still carry over the variant's path-valued
+    // session options (e.g. the external initializers folder the model needs to load), but only
+    // for keys the caller did not set, so an explicit user value wins.
+    gsl::span<const std::string> session_option_keys;
+    gsl::span<const std::string> session_option_values;
+    ORT_API_RETURN_IF_STATUS_NOT_OK(
+        mp_ctx.GetSelectedVariantFileSessionOptions(session_option_keys, session_option_values));
+    ORT_API_RETURN_IF(session_option_keys.size() != session_option_values.size(),
+                      ORT_FAIL, "Session option keys/values size mismatch.");
+
+    effective_options_storage.emplace(*session_options);
+    const auto& existing = effective_options_storage->value.config_options.GetConfigOptionsMap();
+    for (size_t i = 0; i < session_option_keys.size(); ++i) {
+      if (!onnxruntime::IsModelPackagePathSessionOption(session_option_keys[i]) ||
+          existing.count(session_option_keys[i]) != 0) {
+        continue;
+      }
+      OrtStatus* st = OrtApis::AddSessionConfigEntry(&*effective_options_storage,
+                                                     session_option_keys[i].c_str(),
+                                                     session_option_values[i].c_str());
+      if (st != nullptr) {
+        return st;
+      }
+    }
+    effective_options = &*effective_options_storage;
   }
 
   // 3) Create session with the resolved file and effective session options.

--- a/onnxruntime/core/session/utils.cc
+++ b/onnxruntime/core/session/utils.cc
@@ -354,6 +354,15 @@ static OrtStatus* CreateSessionAndLoadModelImpl(_In_ const OrtSessionOptions* op
                                                 _In_opt_ const void* model_data,
                                                 size_t model_data_length,
                                                 std::unique_ptr<onnxruntime::InferenceSession>& sess) {
+  if (model_path != nullptr) {
+    std::error_code ec;
+    if (std::filesystem::is_directory(model_path, ec) && !ec) {
+      return OrtApis::CreateStatus(
+          ORT_INVALID_ARGUMENT,
+          "The model path is a directory. Loading a model package from a directory path is not supported. "
+          "Use the model package API (CreateModelPackageContext, SelectComponent, CreateSession) instead.");
+    }
+  }
   return CreateSessionAndLoadSingleModelImpl(options, env, model_path, model_data, model_data_length, sess);
 }
 

--- a/onnxruntime/core/session/utils.cc
+++ b/onnxruntime/core/session/utils.cc
@@ -347,113 +347,13 @@ static OrtStatus* CreateSessionAndLoadSingleModelImpl(_In_ const OrtSessionOptio
 }
 
 // Internal function that creates an InferenceSession and loads the model.
-// Caller should provide either a model file path, model_data + model_data_length, or a model package directory.
+// Caller should provide either a model file path, or model_data + model_data_length.
 static OrtStatus* CreateSessionAndLoadModelImpl(_In_ const OrtSessionOptions* options,
                                                 const onnxruntime::Environment& env,
                                                 _In_opt_z_ const ORTCHAR_T* model_path,
                                                 _In_opt_ const void* model_data,
                                                 size_t model_data_length,
                                                 std::unique_ptr<onnxruntime::InferenceSession>& sess) {
-  // `model_path` could be a single ONNX file path, an ORT format model path, or a model package directory.
-  const ORTCHAR_T* model_path_to_use = model_path;
-
-  // keep storage alive if ORT selects a model variant.
-  std::filesystem::path selected_model_variant_path;
-
-  if (model_path_to_use != nullptr) {
-    std::error_code ec;
-    std::filesystem::path package_root{model_path_to_use};
-
-    if (std::filesystem::is_directory(package_root, ec) && !ec) {
-#if !defined(ORT_MINIMAL_BUILD)
-      OrtSessionOptions* options_to_use = nullptr;
-      OrtSessionOptions ort_sess_options = options ? *options : OrtSessionOptions();
-      if (options) {
-        options_to_use = &ort_sess_options;
-      }
-
-      std::vector<std::unique_ptr<IExecutionProvider>> provider_list;
-      const bool has_provider_factories = options_to_use != nullptr && !options_to_use->provider_factories.empty();
-      ProviderPolicyContext provider_policy_context;
-      std::vector<const OrtEpDevice*> execution_devices;
-      std::vector<const OrtEpDevice*> devices_selected;
-
-      // Create the IExecutionProvider instances to gather EP name and EP devices.
-      if (has_provider_factories) {
-        for (auto& factory : options_to_use->provider_factories) {
-          auto provider = factory->CreateProvider(*options_to_use, *logging::LoggingManager::DefaultLogger().ToExternal());
-          provider_list.push_back(std::move(provider));
-        }
-      } else if (options_to_use != nullptr && options_to_use->value.ep_selection_policy.enable) {
-        // No model loaded yet, so no model metadata. Pass empty metadata for now.
-        // TODO: Pass metadata from manifest json to delegate policy?
-        OrtKeyValuePairs model_metadata;
-        auto status = provider_policy_context.SelectEpsForModelPackage(env, *options_to_use, model_metadata,
-                                                                       execution_devices, devices_selected,
-                                                                       provider_list);
-        ORT_API_RETURN_IF_STATUS_NOT_OK(status);
-      }
-
-      // Build EP info from finalized providers.
-      std::vector<VariantSelectionEpInfo> ep_infos;
-      ORT_API_RETURN_IF_STATUS_NOT_OK(GetVariantSelectionEpInfo(provider_list, ep_infos));
-
-      ORT_API_RETURN_IF_STATUS_NOT_OK(PrintAvailableAndSelectedEpInfos(env, ep_infos));
-
-      if (ep_infos.empty()) {
-        return OrtApis::CreateStatus(ORT_FAIL,
-                                     "No execution providers were provided or selected. "
-                                     "Check the EP selection policy or explicitly specify EPs.");
-      }
-
-      // Select the most suitable model variant based on EP info and model constraints.
-      ModelPackageContext model_package_context(package_root);
-      const auto& package_info = model_package_context.GetModelPackageInfo();
-      const ComponentInfo* component_info = nullptr;
-
-      if (package_info.components.empty()) {
-        return OrtApis::CreateStatus(ORT_FAIL, "No component models found in the model package.");
-      } else if (package_info.components.size() > 1) {
-        return OrtApis::CreateStatus(ORT_FAIL,
-                                     "Multiple component models found in the model package. "
-                                     "Currently only single component model is supported.");
-      }
-
-      component_info = &package_info.components[0];
-      if (component_info == nullptr) {
-        return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, "Component model not found.");
-      }
-
-      ModelPackageComponentContext component_context(component_info->component_name, *component_info, ep_infos);
-      ORT_API_RETURN_IF_STATUS_NOT_OK(component_context.ResolveVariant());
-      ORT_API_RETURN_IF_STATUS_NOT_OK(component_context.GetSelectedVariantFilePath(selected_model_variant_path));
-      model_path_to_use = selected_model_variant_path.c_str();
-
-      ORT_API_RETURN_IF_ERROR(CreateSessionAndLoadSingleModelImpl(options_to_use, env, model_path_to_use,
-                                                                  model_data, model_data_length, sess));
-
-      // Register execution providers
-      for (auto& provider : provider_list) {
-        if (provider) {
-          ORT_API_RETURN_IF_STATUS_NOT_OK(sess->RegisterExecutionProvider(std::move(provider)));
-        }
-      }
-
-      // Log telemetry for auto EP selection
-      if (!has_provider_factories &&
-          options_to_use != nullptr &&
-          options_to_use->value.ep_selection_policy.enable) {
-        ORT_API_RETURN_IF_STATUS_NOT_OK(provider_policy_context.LogTelemetry(*sess, *options_to_use,
-                                                                             execution_devices, devices_selected));
-      }
-
-#else
-      return OrtApis::CreateStatus(ORT_FAIL, "Model package is not supported in this build.");
-#endif
-      return nullptr;
-    }
-  }
-
   return CreateSessionAndLoadSingleModelImpl(options, env, model_path, model_data, model_data_length, sess);
 }
 

--- a/onnxruntime/core/session/utils.cc
+++ b/onnxruntime/core/session/utils.cc
@@ -981,67 +981,23 @@ OrtStatus* CreateSessionForModelPackage(_In_ const OrtSessionOptions* options,
                                         const std::filesystem::path& selected_model_path,
                                         onnxruntime::ModelPackageComponentContext& model_package_context,
                                         std::unique_ptr<onnxruntime::InferenceSession>& sess) {
-  // When the variant declares an external_data folder (e.g. a shared asset
-  // under <package_root>/shared_assets/sha256-<hex>/) we must switch to
-  // buffer load: ORT only honors session.model_external_initializers_file_folder_path
-  // when model_location_ is empty (see inference_session.cc). The mmap'd
-  // model buffer can be released right after Load; external initializers
-  // are read from the folder hint during Initialize.
-  const std::string* external_data_folder = nullptr;
-  ORT_API_RETURN_IF_STATUS_NOT_OK(
-      model_package_context.GetSelectedVariantExternalDataFolder(external_data_folder));
-
-  std::unique_ptr<OrtSessionOptions> cloned_options;
+  // The model is loaded from selected_model_path. Any path-valued options (e.g. the external
+  // initializers folder via session.model_external_initializers_file_folder_path) were already
+  // resolved and merged into `options` by the caller.
+  std::unique_ptr<OrtSessionOptions> default_options;
   const OrtSessionOptions* options_to_use = options;
-  onnxruntime::Env::MappedMemoryPtr mapped_model;
-  const void* model_data = nullptr;
-  size_t model_data_length = 0;
-
-  if (external_data_folder != nullptr) {
-    cloned_options = options ? std::make_unique<OrtSessionOptions>(*options)
-                             : std::make_unique<OrtSessionOptions>();
-    ORT_API_RETURN_IF_STATUS_NOT_OK(
-        cloned_options->value.config_options.AddConfigEntry(
-            kOrtSessionOptionsModelExternalInitializersFileFolderPath,
-            external_data_folder->c_str()));
-    options_to_use = cloned_options.get();
-
-    size_t model_file_length = 0;
-    ORT_API_RETURN_IF_STATUS_NOT_OK(
-        onnxruntime::Env::Default().GetFileLength(selected_model_path.c_str(), model_file_length));
-    if (model_file_length == 0) {
-      return OrtApis::CreateStatus(
-          ORT_FAIL,
-          ("model_package: selected variant model file is empty: " + selected_model_path.string()).c_str());
-    }
-    ORT_API_RETURN_IF_STATUS_NOT_OK(
-        onnxruntime::Env::Default().MapFileIntoMemory(selected_model_path.c_str(),
-                                                      /*offset=*/0,
-                                                      model_file_length,
-                                                      mapped_model));
-    model_data = mapped_model.get();
-    model_data_length = model_file_length;
-  } else if (options_to_use == nullptr) {
-    // No external_data and caller did not pass options: synthesize a default
-    // OrtSessionOptions so the downstream *options_to_use dereferences are safe.
-    cloned_options = std::make_unique<OrtSessionOptions>();
-    options_to_use = cloned_options.get();
+  if (options_to_use == nullptr) {
+    // Caller did not pass options: synthesize a default OrtSessionOptions so the downstream
+    // *options_to_use dereferences are safe.
+    default_options = std::make_unique<OrtSessionOptions>();
+    options_to_use = default_options.get();
   }
 
-  if (model_data != nullptr) {
-    ORT_API_RETURN_IF_ERROR(CreateSessionAndLoadSingleModelImpl(options_to_use, env,
-                                                                /*model_path*/ nullptr,
-                                                                model_data,
-                                                                model_data_length,
-                                                                sess));
-  } else {
-    ORT_API_RETURN_IF_ERROR(CreateSessionAndLoadSingleModelImpl(options_to_use, env,
-                                                                selected_model_path.c_str(),
-                                                                /*model_data*/ nullptr,
-                                                                /*model_data_length*/ 0,
-                                                                sess));
-  }
-  mapped_model.reset();
+  ORT_API_RETURN_IF_ERROR(CreateSessionAndLoadSingleModelImpl(options_to_use, env,
+                                                              selected_model_path.c_str(),
+                                                              /*model_data*/ nullptr,
+                                                              /*model_data_length*/ 0,
+                                                              sess));
 
   // Providers were created earlier from the original options; rebuild now so
   // any merged variant-specific provider options take effect.

--- a/onnxruntime/test/autoep/test_model_package.cc
+++ b/onnxruntime/test/autoep/test_model_package.cc
@@ -16,6 +16,7 @@
 
 #include "core/session/model_package/model_package_context.h"
 #include "core/session/onnxruntime_experimental_cxx_api.h"
+#include "core/session/onnxruntime_session_options_config_keys.h"
 #include "core/session/abi_devices.h"
 #include "test/autoep/test_autoep_utils.h"
 #include "test/util/include/asserts.h"
@@ -747,6 +748,80 @@ TEST(ModelPackageTest, VariantSessionOptions_DispatchedThroughAddSessionConfigEn
   EXPECT_TRUE(mentions_dispatch) << "error did not mention typed dispatch: " << err_msg;
 
   std::error_code ec;
+  std::filesystem::remove_all(package_root, ec);
+}
+
+// A variant's path-valued session option (the external initializers folder) is resolved against
+// the package (relative -> absolute) at parse time and applied, so the model's external data can
+// live outside the model's own directory.
+TEST(ModelPackageTest, VariantSessionOption_ResolvesExternalInitializersFolder) {
+  const auto package_root = std::filesystem::temp_directory_path() / "ort_mp_ext_ini_resolve";
+  std::vector<VariantSpec> variants;
+  variants.push_back(VariantSpec{
+      "variant_1", "example_ep", "cpu", "", "testdata/conv_qdq_external_ini.onnx", std::unordered_map<std::string, std::string>{
+                                                                                       {kOrtSessionOptionsModelExternalInitializersFileFolderPath, "weights"},
+                                                                                   },
+      {}});
+  BuildPackage(package_root, "model_1", variants);
+
+  // Put the external data file in a subfolder of the variant dir. It can only be found if
+  // "weights" is resolved to <variant_dir>/weights and used to override the model directory.
+  const auto weights_dir = package_root / "model_1" / "variant_1" / "weights";
+  std::error_code ec;
+  std::filesystem::create_directories(weights_dir, ec);
+  ASSERT_FALSE(ec);
+  std::filesystem::copy_file("testdata/conv_qdq_external_ini.bin",
+                             weights_dir / "conv_qdq_external_ini.bin",
+                             std::filesystem::copy_options::overwrite_existing, ec);
+  ASSERT_FALSE(ec);
+
+  RegisteredEpDeviceUniquePtr example_ep;
+  ASSERT_NO_FATAL_FAILURE(Utils::RegisterAndGetExampleEp(*ort_env, Utils::example_ep_info, example_ep));
+  Ort::ConstEpDevice plugin_ep_device(example_ep.get());
+
+  Ort::SessionOptions session_options;
+  std::unordered_map<std::string, std::string> ep_options;
+  session_options.AppendExecutionProvider_V2(*ort_env, {plugin_ep_device}, ep_options);
+
+  const auto& pkg_api = GetModelPackageFns();
+  ASSERT_NE(pkg_api.CreateModelPackageContext, nullptr) << "Model package experimental API is not available";
+
+  auto options_deleter = [&pkg_api](OrtModelPackageOptions* p) { if (p) pkg_api.ReleaseModelPackageOptions(p); };
+  auto context_deleter = [&pkg_api](OrtModelPackageContext* p) { if (p) pkg_api.ReleaseModelPackageContext(p); };
+  auto component_context_deleter = [&pkg_api](OrtModelPackageComponentContext* p) {
+    if (p) pkg_api.ReleaseModelPackageComponentContext(p);
+  };
+  std::unique_ptr<OrtModelPackageOptions, decltype(options_deleter)> mp_opts(nullptr, options_deleter);
+  std::unique_ptr<OrtModelPackageContext, decltype(context_deleter)> ctx(nullptr, context_deleter);
+  std::unique_ptr<OrtModelPackageComponentContext, decltype(component_context_deleter)> comp_ctx(nullptr, component_context_deleter);
+
+  OrtModelPackageOptions* raw_mp_opts = nullptr;
+  ASSERT_ORTSTATUS_OK(pkg_api.CreateModelPackageOptionsFromSessionOptions(*ort_env, session_options, &raw_mp_opts));
+  mp_opts.reset(raw_mp_opts);
+
+  OrtModelPackageContext* raw_ctx = nullptr;
+  ASSERT_ORTSTATUS_OK(pkg_api.CreateModelPackageContext(package_root.c_str(), &raw_ctx));
+  ctx.reset(raw_ctx);
+
+  OrtModelPackageComponentContext* raw_comp_ctx = nullptr;
+  ASSERT_ORTSTATUS_OK(pkg_api.SelectComponent(ctx.get(), "model_1", mp_opts.get(), &raw_comp_ctx));
+  comp_ctx.reset(raw_comp_ctx);
+
+  // nullptr session_options -> metadata-merge (default) path applies the resolved folder option.
+  // Session creation loads the external initializers during Initialize; it succeeds only if the
+  // relative "weights" was resolved and used to override the model directory.
+  OrtSession* raw_session = nullptr;
+  ASSERT_ORTSTATUS_OK(pkg_api.CreateSession(*ort_env, comp_ctx.get(), /*session_options=*/nullptr, &raw_session));
+  ASSERT_NE(raw_session, nullptr);
+  Ort::Session session(raw_session);
+
+  // Advanced path: pass the caller's own session options. The variant's resolved folder option is
+  // still carried over (the caller did not set it), so external initializers still load.
+  OrtSession* raw_session_adv = nullptr;
+  ASSERT_ORTSTATUS_OK(pkg_api.CreateSession(*ort_env, comp_ctx.get(), session_options, &raw_session_adv));
+  ASSERT_NE(raw_session_adv, nullptr);
+  Ort::Session session_adv(raw_session_adv);
+
   std::filesystem::remove_all(package_root, ec);
 }
 

--- a/onnxruntime/test/autoep/test_model_package.cc
+++ b/onnxruntime/test/autoep/test_model_package.cc
@@ -204,6 +204,35 @@ std::filesystem::path BuildTwoVariantPackage(const std::filesystem::path& packag
   return BuildPackage(package_root, "model_1", variants);
 }
 
+// Runs the full experimental OrtModelPackageApi flow for a single-component package and returns the
+// created session: CreateModelPackageOptionsFromSessionOptions -> CreateModelPackageContext ->
+// SelectComponent -> CreateSession. `session_options` drives both variant/EP selection and session
+// creation (advanced path), mirroring how a caller loads a package. Throws on any error.
+Ort::Session CreateSessionFromModelPackage(const std::filesystem::path& package_root,
+                                           const std::string& component_name,
+                                           Ort::SessionOptions& session_options) {
+  const auto& pkg_api = GetModelPackageFns();
+
+  OrtModelPackageOptions* raw_mp_opts = nullptr;
+  Ort::ThrowOnError(pkg_api.CreateModelPackageOptionsFromSessionOptions(*ort_env, session_options, &raw_mp_opts));
+  std::unique_ptr<OrtModelPackageOptions, decltype(pkg_api.ReleaseModelPackageOptions)>
+      mp_opts(raw_mp_opts, pkg_api.ReleaseModelPackageOptions);
+
+  OrtModelPackageContext* raw_ctx = nullptr;
+  Ort::ThrowOnError(pkg_api.CreateModelPackageContext(package_root.c_str(), &raw_ctx));
+  std::unique_ptr<OrtModelPackageContext, decltype(pkg_api.ReleaseModelPackageContext)>
+      ctx(raw_ctx, pkg_api.ReleaseModelPackageContext);
+
+  OrtModelPackageComponentContext* raw_comp_ctx = nullptr;
+  Ort::ThrowOnError(pkg_api.SelectComponent(ctx.get(), component_name.c_str(), mp_opts.get(), &raw_comp_ctx));
+  std::unique_ptr<OrtModelPackageComponentContext, decltype(pkg_api.ReleaseModelPackageComponentContext)>
+      comp_ctx(raw_comp_ctx, pkg_api.ReleaseModelPackageComponentContext);
+
+  OrtSession* raw_session = nullptr;
+  Ort::ThrowOnError(pkg_api.CreateSession(*ort_env, comp_ctx.get(), session_options, &raw_session));
+  return Ort::Session{raw_session};
+}
+
 }  // namespace
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -430,7 +459,7 @@ TEST(ModelPackageTest, LoadModelPackageAndRunInference_PluginEp_AppendV2) {
   std::unordered_map<std::string, std::string> ep_options;
   session_options.AppendExecutionProvider_V2(*ort_env, {plugin_ep_device}, ep_options);
 
-  Ort::Session session(*ort_env, package_root.c_str(), session_options);
+  Ort::Session session = CreateSessionFromModelPackage(package_root, "model_1", session_options);
 
   Ort::MemoryInfo memory_info = Ort::MemoryInfo::CreateCpu(OrtDeviceAllocator, OrtMemTypeCPU);
   std::vector<int64_t> shape = {3, 2};
@@ -468,7 +497,7 @@ TEST(ModelPackageTest, LoadModelPackageAndRunInference_PreferCpu) {
   Ort::SessionOptions session_options;
   session_options.SetEpSelectionPolicy(OrtExecutionProviderDevicePolicy_PREFER_CPU);
 
-  Ort::Session session(*ort_env, package_root.c_str(), session_options);
+  Ort::Session session = CreateSessionFromModelPackage(package_root, "model_1", session_options);
 
   Ort::MemoryInfo memory_info = Ort::MemoryInfo::CreateCpu(OrtDeviceAllocator, OrtMemTypeCPU);
   std::vector<int64_t> shape = {3, 2};
@@ -541,7 +570,7 @@ TEST(ModelPackageTest, CheckCompiledModelCompatibilityInfo) {
   std::unordered_map<std::string, std::string> ep_options;
   session_options.AppendExecutionProvider_V2(*ort_env, {plugin_ep_device}, ep_options);
 
-  Ort::Session session(*ort_env, package_root.c_str(), session_options);
+  Ort::Session session = CreateSessionFromModelPackage(package_root, "model_1", session_options);
 
   std::error_code ec;
   std::filesystem::remove_all(package_root, ec);

--- a/onnxruntime/test/autoep/test_model_package.cc
+++ b/onnxruntime/test/autoep/test_model_package.cc
@@ -520,6 +520,32 @@ TEST(ModelPackageTest, LoadModelPackageAndRunInference_PreferCpu) {
   std::filesystem::remove_all(package_root, ec);
 }
 
+// Passing a directory path to OrtCreateSession is no longer treated as a model package. It must
+// fail with a clear message pointing at the model package API rather than a generic load error.
+TEST(ModelPackageTest, DirectoryPath_FailsWithModelPackageApiHint) {
+  const auto package_root = std::filesystem::temp_directory_path() / "ort_mp_directory_path_rejected";
+  BuildTwoVariantPackage(package_root,
+                         "variant_1", "cpu", "",
+                         "testdata/mul_1.onnx",
+                         "variant_2", "npu", "",
+                         "testdata/mul_16.onnx");
+
+  Ort::SessionOptions session_options;
+  bool threw = false;
+  try {
+    Ort::Session session(*ort_env, package_root.c_str(), session_options);
+  } catch (const Ort::Exception& e) {
+    threw = true;
+    const std::string msg = e.what();
+    EXPECT_NE(msg.find("directory"), std::string::npos) << "unexpected error: " << msg;
+    EXPECT_NE(msg.find("model package API"), std::string::npos) << "unexpected error: " << msg;
+  }
+  EXPECT_TRUE(threw) << "Loading a session from a directory path should fail";
+
+  std::error_code ec;
+  std::filesystem::remove_all(package_root, ec);
+}
+
 TEST(ModelPackageTest, CheckCompiledModelCompatibilityInfo) {
   RegisteredEpDeviceUniquePtr example_ep;
   ASSERT_NO_FATAL_FAILURE(Utils::RegisterAndGetExampleEp(*ort_env, Utils::example_ep_info, example_ep));


### PR DESCRIPTION
### Description

Two changes to the model package flow, enabled by the file-path external initializers support:

**1. Fold `external_data` into `session_options` with path resolution.**
- Path-valued session options (an allowlist: `session.model_external_initializers_file_folder_path` and `ep.context_file_path`) are resolved against the package (`sha256:<hex>`, relative, or absolute) at variant-parse time, using the same rules as `model_file`.
- The dedicated `external_data` variant field and its special session injection are removed; the model is always loaded from the selected variant path.
- On the advanced path (caller supplies their own `OrtSessionOptions`), path-valued options are carried over from the variant for keys the caller did not set, so a model that needs its external-initializers folder still loads.

**2. Remove the legacy directory-based `CreateSession(package_dir)` path.**
- Removes the `is_directory(package_root)` branch in `CreateSessionAndLoadModelImpl`. Model packages are loaded through the experimental `OrtModelPackageApi` (`CreateModelPackageContext` -> `SelectComponent` -> `CreateSession`).
- The three end-to-end tests that exercised the directory path are migrated to the experimental API via a `CreateSessionFromModelPackage` test helper, preserving coverage for factory-based selection, `PREFER_CPU` policy selection, and compiled-model compatibility scoring.

### Motivation and Context

The file-path external initializers folder support (#29459) lets the model package flow drop its workaround of memory-mapping the model and forcing a buffer load: it sets the folder option and loads from the selected variant path directly. Building on that, the dedicated `external_data` field folds into the general session-options mechanism. A variant declares `session.model_external_initializers_file_folder_path` (or other path-valued options) in its `session_options`, and ORT resolves those values against the package at parse time. This removes special-case code and lets other path-valued options such as the EPContext file path be resolved the same way. An allowlist is used rather than value-syntax sniffing because session-option values are arbitrary strings; only known path-valued keys are resolved, so ordinary values pass through untouched.

The legacy directory-based `CreateSession(package_dir)` path was meant to be removed when the experimental `OrtModelPackageApi` landed. It only did variant/EP selection and never merged the variant's `session_options`/`provider_options`, so a package loaded via `Ort::Session(env, dir, so)` silently ignored its manifest session options, inconsistent with the experimental API. Removing it leaves a single, consistent way to load a model package.
