### PR TITLE
Detach C++ node tests from ONNX on-disk data/node artifacts (onnx#7959) + retiring equivalence proof + corpus-collapse tripwire

### DIFF
--- a/.agents/skills/onnx-opset-bump-checklist/SKILL.md
+++ b/.agents/skills/onnx-opset-bump-checklist/SKILL.md
@@ -38,7 +38,7 @@ B/C/D can be validated). Throughout this section, bold letters in parentheses (e
 ### Group A — version plumbing (always required, mechanical)
 | File | Note |
 |---|---|
-| `cmake/deps.txt` (`onnx;` line) | archive URL + **SHA1 of the `.zip`** (see §2) |
+| `cmake/deps.txt` (`onnx;` line) | archive URL + **SHA1 of the `.zip`** (see §2). ⚠️ Before advancing this pin, verify the target commit still ships `onnx/backend/test/data/node/` — see gotcha **p** (#7959 deletes the on-disk node-test corpus → silent-green CI). |
 | `cmake/external/onnx` (submodule) | `git -C cmake/external/onnx fetch && git -C cmake/external/onnx reset --hard <sha> && git add cmake/external/onnx` |
 | `cmake/vcpkg-ports/onnx/vcpkg.json` | `version-semver`; reset `port-version` to 0 on a real version bump |
 | `cmake/vcpkg-ports/onnx/portfile.cmake` | `REF` + **SHA512 of the `.tar.gz`** (see §2). RC = bare commit as `REF`; formal = `REF "v${VERSION}"` |
@@ -369,6 +369,98 @@ the legs you remember to touch and leaves the default-strict legs red. Precedent
 branch: `38f17243b` (GatherToSlice), generalized to all `*CurrentOpset` fusion tests.
 Annotate each call site with a one-line WHY + the tracking issue so it can be removed once
 the opset is released (#28966).
+
+**(p) A future onnx commit may DELETE the on-disk node-test corpus — a SILENT-GREEN C++ bump landmine.**
+ORT's **C++** node-test coverage depends on ONNX **shipping pre-generated `.pb` artifacts
+inside the pinned archive**: `onnx_test_runner` reads `model.onnx` + `test_data_set_*/*.pb`
+from `_deps/onnx-src/onnx/backend/test/data/node/<test>/` (the FetchContent archive pinned by
+the **SHA1 on the `onnx;` line of `cmake/deps.txt` ~L40** — *not* the `cmake/external/onnx`
+submodule, which only the QNN CI `.../node` path uses). **ONNX PR [onnx/onnx#7959] "Remove
+node test artifacts" deletes that entire on-disk corpus** (~2992+ files) **and removes the
+`cmd_tools.py generate-data` node path**, replacing both with a **Python-only, in-memory**
+flow (`loader.load_node_model_tests()` → `runner.run_node()`, `model_dir=None`, nothing
+written to disk). Naming / directory layout / `.pb` format are **unchanged — the files are
+simply gone.**
+- **⚠️ The C++ failure is SILENT, not loud.** Because names/layout/format don't change, the
+  C++ skip contracts (`GetBrokenTests` / `immutable_broken_tests` in `TestCase.cc` +
+  `main.cc`, names *without* the `test_` prefix) **don't throw or mismatch** — their target
+  paths just cease to exist. An empty `data/node` yields **ZERO** collected cases; the
+  runner's directory BFS finds nothing, `ctest`/`add_test` **exit 0**, and
+  `onnx_test_runner -e cuda .../node/<test>` prints nothing and **returns success.** C++
+  node-test **kernel guarding evaporates behind a GREEN CI with no failure signal** —
+  strictly worse than a hard break.
+- **The Python leg SURVIVES automatically — do not conflate it.** `onnx_backend_test_series.py`
+  does **zero** `.pb`/`model.onnx` disk I/O: it subclasses `onnx.backend.test.runner.Runner`
+  and delegates discovery+execution to the **installed pip `onnx`** package, whose base
+  `_add_model_test` already branches on `model_dir is None` → in-memory. ORT's only override
+  is a rtol/atol injector (`onnx_backend_test_series.py:60-71`), field-agnostic, no disk. So
+  the name-keyed **Python** contracts (`onnx_backend_test_series_filters.jsonc` `^test_`
+  regexes, `onnx_backend_test_series_overrides.jsonc` atol) keep resolving against the pip
+  package's in-memory tests and stay valid. **The mitigation surface is C++-only.** (Residual
+  Python risk is only if #7959 changes the public subclass contract — `Runner.__init__` /
+  `_add_model_test` / `assert_similar_outputs` sig / `TestCase` field names.)
+- **Guardrail — verify the corpus survives BEFORE advancing the `cmake/deps.txt` pin.** As of
+  this writing #7959 is **OPEN + CONFLICTING** (no onnx pin includes it yet), so this is
+  latent, not active. When re-pinning, confirm the target commit still ships the on-disk tree:
+  ```bash
+  # Does the target onnx commit/tag still contain the on-disk node-test corpus?
+  gh api "repos/onnx/onnx/contents/onnx/backend/test/data/node?ref=<target-commit-or-tag>" \
+    --jq 'length'      # >0 = corpus present (safe) ; 404 = DELETED (see #7959) -> STOP
+  # note: the contents API caps directory listings at 1000 entries (~1799 dirs exist today),
+  # so 'length' returns 1000, not the true count — fine here since we only test >0 vs 404.
+  # For an exact count use the git trees API instead:
+  #   gh api "repos/onnx/onnx/git/trees/<target-sha>?recursive=1" --jq '[.tree[].path | select(startswith("onnx/backend/test/data/node/"))] | length'
+  # Or on a materialized archive/worktree:
+  ls _deps/onnx-src/onnx/backend/test/data/node | head   # empty => the landmine has landed
+  ```
+- **Mitigation if a bump is forced onto a #7959 commit (C++ leg only):** ORT must **own
+  node-test materialization** — a CMake `add_custom_command` (gated on
+  `onnxruntime_BUILD_UNIT_TESTS`) that imports the ONNX Python case generators (**confirmed
+  byte-identical / untouched by #7959** — `onnx/backend/test/case/node/*.py`'s `export.*` +
+  `expect(...)` remain; #7959 removes only the serialized `.pb` output, not the source) via
+  `load_node_model_tests()`, and re-serializes each `_NodeTestCase` back to the on-disk
+  `model.onnx` + `test_data_set_*/{input,output}_N.pb` layout the C++ loader expects (exact
+  serialization detail below — **not** `from_array`-only). Then repoint the C++ consumers
+  (runner arg + QNN CI `.../node` path). This also collapses the 3-independent-onnx-pins /
+  dual-skip-list tangle into one materialized copy. **Reference implementation already exists — vendor it, do not
+  re-derive.** Vendor the ~85-line node branch of `onnx/backend/test/cmd_tools.py:generate_data`
+  (`cmd_tools.py:64-110` — the very disk-writer #7959 removes) into a build-time script:
+  - **Entry point: `collect_testcases(op_type=None)`** — pass `op_type=None` **explicitly**
+    to collect ALL ops (it is a required positional; a real `op_type` silently returns a
+    1-op subset — another silent-undercount path). It **self-calls `import_recursive`
+    internally** (`onnx/backend/test/case/node/__init__.py:417`), so one call both populates
+    and returns `_NodeTestCases` — no separate import step, no empty-list footgun.
+  - **Per `TestCase`**: write `case.model.SerializeToString()` → `model.onnx`, and serialize
+    each input/output into `test_data_set_0/{input,output}_j.pb` using the reference's
+    **4-branch dispatch on `graph.input[j].type`** — `numpy_helper.from_dict` (map) /
+    `from_list` (sequence) / `from_optional` (optional) / `from_array`-or-`SerializeToString`
+    (tensor). **Do NOT hand-simplify to `from_array`-only** — that silently mis-serializes
+    every Sequence/Map/Optional node test (`SequenceInsert`, `Optional*`, some Loop/Scan
+    fixtures). Dir name = `case.name` (already carries the `test_` prefix). Positional binding
+    is by the same `j` as the model's `graph.input`, so any `len(inputs) != len(graph.input)`
+    mismatch IndexErrors at BUILD time (fail-loud, never a bad corpus).
+  - **MANDATORY version parity (correctness, not just hygiene).** `expect()` stamps each
+    `model.onnx`'s `opset_import`/IR from the **compiled onnx RUNTIME's** C++ schema registry
+    (`get_schema(op_type, domain).since_version`, `case/node/__init__.py:311-319`), *not* the
+    `.py` case source. So the shim MUST run under an installed onnx wheel whose
+    `onnx.__version__` **==** the `cmake/deps.txt` pin, **hard-asserted as its first line**
+    (`assert onnx.__version__ == <deps-derived>`) — a mismatched wheel bakes the WRONG opset
+    into `model.onnx` = silent corpus drift. Make this structural by **deriving the 6 CI
+    `requirements.txt` `onnx==` pins FROM `cmake/deps.txt`** so wheel==archive by construction
+    (this is also what keeps the *Python* leg testing the pinned version). Under that parity
+    the installed wheel's `case/node/*.py` are byte-identical to the archive's, so the shim
+    uses the installed wheel directly — no `_deps/onnx-src` source plumbing needed.
+  - Also **assert `len(_NodeTestCases) > 0`** at shim start — fail the build on an empty
+    materialization (the build-time twin of the runtime tripwire below).
+- **Min-count TRIPWIRE (mitigation 0 — highest ROI, cause-AGNOSTIC, do this regardless of
+  #7959).** The deepest problem is that corpus absence is **silent-green**, so assert a floor
+  on discovered node-test count in **both** harnesses: C++ at `onnx/main.cc:937` right after
+  `LoadTests` populates the vector — `ORT_ENFORCE(tests.size() >= floor, ...)` (add a
+  `--min_cases N` flag); Python in `onnx_backend_test_series.py` after `create_backend_test()`
+  asserting a floor on `len(backend_test.test_cases)`. This converts *any* future
+  corpus-absence regression (#7959, a bad archive, broken FetchContent, an over-matching
+  filter) from an invisible pass into a **loud red** — the single highest-leverage, lowest-cost
+  change here.
 
 ## 5. Build & validate locally
 

--- a/.agents/skills/onnx-opset-bump-checklist/SKILL.md
+++ b/.agents/skills/onnx-opset-bump-checklist/SKILL.md
@@ -377,7 +377,9 @@ inside the pinned archive**: `onnx_test_runner` reads `model.onnx` + `test_data_
 from `_deps/onnx-src/onnx/backend/test/data/node/<test>/` (the FetchContent archive pinned by
 the **SHA1 on the `onnx;` line of `cmake/deps.txt` ~L40** — *not* the `cmake/external/onnx`
 submodule, which only the QNN CI `.../node` path uses). **ONNX PR [onnx/onnx#7959] "Remove
-node test artifacts" deletes that entire on-disk corpus** (~2992+ files) **and removes the
+node test artifacts" deletes that entire on-disk corpus** (~2992+ files) — it targets onnx
+master, so the first affected release is expected to be **onnx 1.23** (one past the current
+1.22 pin), consistent with the JS `NOTE(#7959)` "onnx >= 1.23" caveat — **and removes the
 `cmd_tools.py generate-data` node path**, replacing both with a **Python-only, in-memory**
 flow (`loader.load_node_model_tests()` → `runner.run_node()`, `model_dir=None`, nothing
 written to disk). Naming / directory layout / `.pb` format are **unchanged — the files are

--- a/.agents/skills/onnx-opset-bump-checklist/SKILL.md
+++ b/.agents/skills/onnx-opset-bump-checklist/SKILL.md
@@ -46,6 +46,7 @@ B/C/D can be validated). Throughout this section, bold letters in parentheses (e
 | `cmake/patches/onnx/onnx.patch` | rebase to the new source (see §3) |
 | `cmake/vcpkg-ports/onnx/fix-dependency-protobuf.patch`, `fix-cmakelists.patch` | re-`diff` only if they fail to apply |
 | **The 7 `requirements.txt` files** with `onnx==X.Y.Z` | `onnxruntime/test/python/requirements.txt`; `tools/ci_build/github/linux/python/requirements.txt`; `tools/ci_build/github/windows/python/requirements.txt`; `tools/ci_build/github/linux/docker/scripts/{requirements.txt,manylinux/requirements.txt,lort/requirements.txt}`; `tools/ci_build/github/linux/docker/inference/aarch64/python/cpu/scripts/requirements.txt`. Confirm with `git grep -n "onnx==<OLD>"` (e.g. `onnx==1.21`) — grep the **old** pin you are replacing, not bare `onnx==1`. ⚠️ **Do NOT bump all matches.** `git grep -n "onnx==1"` also lists 3 transformers-model files — `onnxruntime/python/tools/transformers/models/{llama,phi2,stable_diffusion}/requirements.txt` — that are **intentionally frozen at `onnx==1.18.0`**. Leave those alone; only the 7 CI files above get the new pin. |
+| **The 4 QNN/android CI yaml with an INLINE `onnx==X.Y.Z` pip pin** (node-test materialization legs — NOT covered by the `requirements.txt` grep above) | `tools/ci_build/github/azure-pipelines/linux-qnn-ci-pipeline.yml`; `tools/ci_build/github/azure-pipelines/win-qnn-arm64-ci-pipeline.yml`; `tools/ci_build/github/azure-pipelines/android-arm64-v8a-QNN-crosscompile-ci-pipeline.yml`; `.github/workflows/windows_qnn_x64.yml`. Each has a `pip install onnx==X.Y.Z "numpy==...; ..."` step feeding the `onnxruntime_MATERIALIZE_ONNX_NODE_TESTS` gate (see gotcha **p**); the pin must be bumped in lockstep with `cmake/deps.txt`. Confirm with `git grep -n "onnx==<OLD>" -- '*.yml'`. (These are inline, not `-r requirements.txt`, by design — pulling the full requirements would drag heavy unrelated test deps onto the QNN legs.) |
 
 ### Group B — opset enablement
 | File | Change |
@@ -461,6 +462,15 @@ simply gone.**
   corpus-absence regression (#7959, a bad archive, broken FetchContent, an over-matching
   filter) from an invisible pass into a **loud red** — the single highest-leverage, lowest-cost
   change here.
+- **Other on-disk node-test consumers to repoint when #7959 lands (track, don't lose).** Beyond the
+  C++ `onnx_test_runner` + QNN `.../node` path, three more consumers read the ONNX on-disk
+  node-test data and will break/skip silently once #7959 deletes it — repoint/update each in the
+  same bump: **`csharp/test/Microsoft.ML.OnnxRuntime.EndToEndTests/runtest.sh`** (C# backend test
+  runner pointed at the node dir), **`js/scripts/prepare-onnx-node-tests.ts`** (the JS/web test
+  harness that stages the node corpus), and **`docs/python/conf.py`** (Sphinx doc build that
+  references the node-test data). None are
+  covered by the C++ materialization mitigation above; each needs its own repoint to the
+  materialized tree (or removal) when the corpus source disappears.
 
 ## 5. Build & validate locally
 

--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -77,6 +77,10 @@ jobs:
       architecture: x64
       dockerfile_path: tools/ci_build/github/linux/docker/Dockerfile.manylinux2_28_cpu
       docker_image_repo: onnxruntimecpubuildpythonx64
+      # MATERIALIZE=ON needs no explicit pre-build pip install on this leg: the manylinux cp314
+      # image already ships onnx==1.22.0 + numpy==2.4.2 (the exact gate pins) via its
+      # requirements.txt (install_deps.sh installs it into cp311-cp314). Intentional, not an
+      # omission -- unlike the QNN/android legs which run on bare agents and pip-install the pins.
       extra_build_flags: '--use_binskim_compliant_compile_flags --build_wheel --build_nuget --enable_transformers_tool_test --cmake_extra_defines onnxruntime_BUILD_BENCHMARKS=ON --cmake_extra_defines onnxruntime_MATERIALIZE_ONNX_NODE_TESTS=ON'
       python_path_prefix: 'PATH=/opt/python/cp314-cp314/bin:$PATH' # $ needs escaping in single quotes
       job_identifier: build-linux-x64-release-py314

--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -77,7 +77,7 @@ jobs:
       architecture: x64
       dockerfile_path: tools/ci_build/github/linux/docker/Dockerfile.manylinux2_28_cpu
       docker_image_repo: onnxruntimecpubuildpythonx64
-      extra_build_flags: '--use_binskim_compliant_compile_flags --build_wheel --build_nuget --enable_transformers_tool_test --cmake_extra_defines onnxruntime_BUILD_BENCHMARKS=ON'
+      extra_build_flags: '--use_binskim_compliant_compile_flags --build_wheel --build_nuget --enable_transformers_tool_test --cmake_extra_defines onnxruntime_BUILD_BENCHMARKS=ON --cmake_extra_defines onnxruntime_MATERIALIZE_ONNX_NODE_TESTS=ON'
       python_path_prefix: 'PATH=/opt/python/cp314-cp314/bin:$PATH' # $ needs escaping in single quotes
       job_identifier: build-linux-x64-release-py314
     secrets:

--- a/.github/workflows/windows_qnn_x64.yml
+++ b/.github/workflows/windows_qnn_x64.yml
@@ -43,6 +43,14 @@ jobs:
           python-version: '3.12'
           architecture: x64
 
+      # onnx (pinned to cmake/deps.txt) + numpy (pinned to requirements.txt, python-conditional)
+      # are required at configure time by the onnxruntime_MATERIALIZE_ONNX_NODE_TESTS gate, which
+      # regenerates the onnx node-test corpus into the build tree (onnx_node_tests\node) for
+      # onnx_test_runner. The numpy markers self-select the same pin the CMake gate asserts.
+      - name: Install onnx for node-test materialization
+        shell: cmd
+        run: python -m pip install onnx==1.22.0 "numpy==2.2.6; python_version<'3.11'" "numpy==2.4.2; python_version>='3.11'"
+
       - name: Locate vcvarsall and Setup Env
         uses: ./.github/actions/locate-vcvarsall-and-setup-env
         with:
@@ -72,7 +80,10 @@ jobs:
         shell: cmd
         working-directory: ${{ runner.temp }}\build\RelWithDebInfo\RelWithDebInfo
         run: |
-          .\onnx_test_runner -j 1 -e qnn -i "backend_path|%QNN_SDK_ROOT%\lib\x86_64-windows-msvc\QnnCpu.dll" ${{ github.workspace }}\cmake\external\onnx\onnx\backend\test\data\node
+          rem onnx#7959 collapse sentinel: -m 1 fails loud if 0 node tests are collected (e.g. a
+          rem MATERIALIZE=OFF leg still running this dir). Low value (not the 1500 build floor)
+          rem because -e qnn legitimately reduces the set to ~1529; strict count enforced at build via --min-cases.
+          .\onnx_test_runner -j 1 -m 1 -e qnn -i "backend_path|%QNN_SDK_ROOT%\lib\x86_64-windows-msvc\QnnCpu.dll" ${{ runner.temp }}\build\RelWithDebInfo\onnx_node_tests\node
 
       - name: Run float32 model tests
         shell: cmd

--- a/.github/workflows/windows_qnn_x64.yml
+++ b/.github/workflows/windows_qnn_x64.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Build and Test
         shell: cmd
         run: |
-          python ${{ github.workspace }}\tools\ci_build\build.py --config RelWithDebInfo --build_dir ${{ runner.temp }}\build --cmake_generator "Visual Studio 17 2022" --build_java --build_shared_lib --use_qnn ${{ matrix.QnnLibKind }} --qnn_home %QNN_SDK_ROOT% --use_binskim_compliant_compile_flags --update --build --test --enable_onnx_tests --parallel
+          python ${{ github.workspace }}\tools\ci_build\build.py --config RelWithDebInfo --build_dir ${{ runner.temp }}\build --cmake_generator "Visual Studio 17 2022" --build_java --build_shared_lib --use_qnn ${{ matrix.QnnLibKind }} --qnn_home %QNN_SDK_ROOT% --use_binskim_compliant_compile_flags --cmake_extra_defines onnxruntime_MATERIALIZE_ONNX_NODE_TESTS=ON --update --build --test --enable_onnx_tests --parallel
 
       - name: Run ONNX Tests
         shell: cmd

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -96,6 +96,14 @@ option(onnxruntime_USE_ARM_NEON_NCHWC "Build with ARM Neon NCHWc kernels in MLAS
 option(onnxruntime_USE_KLEIDIAI "Build with KleidiAI integration in MLAS" OFF)
 option(onnxruntime_USE_QMX_KLEIDIAI_COEXIST "Build with QMX and Arm KLEIDIAI libraries" OFF)
 option(onnxruntime_BUILD_UNIT_TESTS "Build ONNXRuntime unit tests" ON)
+# When ON (default), materialize the ONNX node-test corpus from ONNX's Python generators into the
+# build tree at configure/build time, instead of depending on the on-disk corpus shipped in the
+# ONNX source archive. This detaches ORT from ONNX PR #7959 (which deletes onnx/backend/test/data/node).
+# Requires a Python interpreter with onnx (== cmake/deps.txt pin) and numpy installed; the configure
+# step FAILS LOUDLY with an actionable message if they are missing (it does NOT silently skip).
+cmake_dependent_option(onnxruntime_MATERIALIZE_ONNX_NODE_TESTS
+  "Materialize the ONNX node-test corpus into the build tree (needs onnx+numpy)." ON
+  "onnxruntime_BUILD_UNIT_TESTS;NOT onnxruntime_REDUCED_OPS_BUILD;NOT onnxruntime_MINIMAL_BUILD" OFF)
 option(onnxruntime_BUILD_CSHARP "Build C# library" OFF)
 option(onnxruntime_BUILD_OBJC "Build Objective-C library" OFF)
 option(onnxruntime_USE_PREINSTALLED_EIGEN "Use pre-installed EIGEN. Need to provide eigen_SOURCE_PATH if turn this on." OFF)

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -96,13 +96,22 @@ option(onnxruntime_USE_ARM_NEON_NCHWC "Build with ARM Neon NCHWc kernels in MLAS
 option(onnxruntime_USE_KLEIDIAI "Build with KleidiAI integration in MLAS" OFF)
 option(onnxruntime_USE_QMX_KLEIDIAI_COEXIST "Build with QMX and Arm KLEIDIAI libraries" OFF)
 option(onnxruntime_BUILD_UNIT_TESTS "Build ONNXRuntime unit tests" ON)
-# When ON (default), materialize the ONNX node-test corpus from ONNX's Python generators into the
-# build tree at configure/build time, instead of depending on the on-disk corpus shipped in the
-# ONNX source archive. This detaches ORT from ONNX PR #7959 (which deletes onnx/backend/test/data/node).
-# Requires a Python interpreter with onnx (== cmake/deps.txt pin) and numpy installed; the configure
-# step FAILS LOUDLY with an actionable message if they are missing (it does NOT silently skip).
+# Materialize the ONNX node-test corpus from ONNX's Python generators into the build tree at
+# configure/build time, instead of depending on the on-disk corpus shipped in the ONNX source
+# archive. This detaches ORT from ONNX PR #7959 (which deletes onnx/backend/test/data/node).
+#
+# Defaults OFF -- it is an explicit opt-in, enabled only on CI legs that (a) install the pinned
+# onnx + numpy pre-build and (b) actually consume the materialized node corpus (the QNN legs and
+# one Linux CPU leg that runs the equivalence + materialized-node ctests), via
+# `--cmake_extra_defines onnxruntime_MATERIALIZE_ONNX_NODE_TESTS=ON`. Legs that leave it OFF keep
+# their pre-existing behavior (node tests are read from the FetchContent'd ONNX source tree, which
+# still ships data/node on the pinned version), so the default is a zero-regression no-op today.
+#
+# When explicitly set ON, the configure step FAILS LOUDLY if onnx/numpy are missing or off-pin
+# (it does NOT silently skip) -- the loud contract is preserved exactly where materialization is
+# requested. On reduced/minimal builds the dependent condition forces it OFF regardless.
 cmake_dependent_option(onnxruntime_MATERIALIZE_ONNX_NODE_TESTS
-  "Materialize the ONNX node-test corpus into the build tree (needs onnx+numpy)." ON
+  "Materialize the ONNX node-test corpus into the build tree (opt-in; needs onnx+numpy)." OFF
   "onnxruntime_BUILD_UNIT_TESTS;NOT onnxruntime_REDUCED_OPS_BUILD;NOT onnxruntime_MINIMAL_BUILD" OFF)
 option(onnxruntime_BUILD_CSHARP "Build C# library" OFF)
 option(onnxruntime_BUILD_OBJC "Build Objective-C library" OFF)

--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -1541,7 +1541,7 @@ if (NOT onnxruntime_ENABLE_TRAINING_TORCH_INTEROP)
     # onnx version pin: derive from the archive URL in cmake/deps.txt (single source of truth).
     string(REGEX MATCH "v([0-9]+\\.[0-9]+\\.[0-9]+)" _onnx_url_ver "${DEP_URL_onnx}")
     if(CMAKE_MATCH_1)
-      set(ONNX_PINNED_VERSION ${CMAKE_MATCH_1})
+      set(_onnx_pinned_version ${CMAKE_MATCH_1})
     else()
       message(FATAL_ERROR "Could not parse the pinned onnx version from DEP_URL_onnx='${DEP_URL_onnx}' "
         "(expected a vX.Y.Z tag). Fix cmake/deps.txt or this regex.")
@@ -1568,15 +1568,34 @@ if (NOT onnxruntime_ENABLE_TRAINING_TORCH_INTEROP)
     if(NOT _onnx_rc EQUAL 0)
       message(FATAL_ERROR
         "onnxruntime_MATERIALIZE_ONNX_NODE_TESTS=ON but 'import onnx' failed for ${Python_EXECUTABLE}.\n"
-        "  Fix: pip install onnx==${ONNX_PINNED_VERSION} numpy\n"
+        "  Fix: pip install onnx==${_onnx_pinned_version} numpy\n"
         "  OR reconfigure with -Donnxruntime_MATERIALIZE_ONNX_NODE_TESTS=OFF (node-test coverage will be dropped).\n"
         "  Details: ${_onnx_err}")
     endif()
-    if(NOT _onnx_ver STREQUAL ONNX_PINNED_VERSION)
+    # onnx version gate: HARD FAIL on a genuine mismatch, but RC / pre-release AWARE.
+    # ONNX's opset-bump workflow ships wheels like 1.23.0rc1 or 1.23.0.dev20240101 whose
+    # COMPILED opset registry already matches the formal 1.23.0 tag, so we compare on the
+    # RELEASE BASE (major.minor.micro) rather than the raw string. This mirrors
+    # materialize_onnx_node_tests.py::_release_base EXACTLY (regex ^(\d+)\.(\d+)\.(\d+), with a
+    # raw-string fallback when there is no leading X.Y.Z) so the cmake and Python layers agree:
+    # an rcN/.devN wheel of the pinned tag passes, while a real major/minor/micro mismatch
+    # (e.g. 1.21.x, or 1.23.0 when pinned at 1.22.0) still FATALs. Both sides are normalized;
+    # _onnx_pinned_version is already a clean X.Y.Z (parsed from the deps.txt vX.Y.Z tag), so
+    # normalizing it is a no-op kept only for symmetry with the Python two-sided compare.
+    string(REGEX MATCH "^[0-9]+\\.[0-9]+\\.[0-9]+" _onnx_ver_base "${_onnx_ver}")
+    if(_onnx_ver_base STREQUAL "")
+      set(_onnx_ver_base "${_onnx_ver}")
+    endif()
+    string(REGEX MATCH "^[0-9]+\\.[0-9]+\\.[0-9]+" _onnx_pin_base "${_onnx_pinned_version}")
+    if(_onnx_pin_base STREQUAL "")
+      set(_onnx_pin_base "${_onnx_pinned_version}")
+    endif()
+    if(NOT _onnx_ver_base STREQUAL _onnx_pin_base)
       message(FATAL_ERROR
-        "onnx ${_onnx_ver} != pinned ${ONNX_PINNED_VERSION} (cmake/deps.txt). "
-        "A mismatched wheel bakes the wrong opset/IR into the materialized corpus (silent drift).\n"
-        "  Fix: pip install onnx==${ONNX_PINNED_VERSION}")
+        "onnx ${_onnx_ver} (release base ${_onnx_ver_base}) != pinned ${_onnx_pinned_version} "
+        "(cmake/deps.txt). A mismatched wheel bakes the wrong opset/IR into the materialized "
+        "corpus (silent drift).\n"
+        "  Fix: pip install onnx==${_onnx_pinned_version}")
     endif()
 
     # numpy version: assert the build's numpy equals the CI-pinned numpy (the SAME pin the QNN
@@ -1591,9 +1610,9 @@ if (NOT onnxruntime_ENABLE_TRAINING_TORCH_INTEROP)
     # Passing the pin (not the tautological installed value) is what makes the materializer's
     # --expected-numpy-version assert meaningful. Both import failure AND mismatch FAIL LOUD.
     if(Python_VERSION VERSION_LESS 3.11)
-      set(NUMPY_PINNED_VERSION 2.2.6)
+      set(_numpy_pinned_version 2.2.6)
     else()
-      set(NUMPY_PINNED_VERSION 2.4.2)
+      set(_numpy_pinned_version 2.4.2)
     endif()
     execute_process(
       COMMAND ${Python_EXECUTABLE} -c "import numpy,sys; sys.stdout.write(numpy.__version__)"
@@ -1601,22 +1620,22 @@ if (NOT onnxruntime_ENABLE_TRAINING_TORCH_INTEROP)
     if(NOT _np_rc EQUAL 0)
       message(FATAL_ERROR
         "onnxruntime_MATERIALIZE_ONNX_NODE_TESTS=ON but 'import numpy' failed for ${Python_EXECUTABLE}.\n"
-        "  Fix: pip install numpy==${NUMPY_PINNED_VERSION}\n"
+        "  Fix: pip install numpy==${_numpy_pinned_version}\n"
         "  OR reconfigure with -Donnxruntime_MATERIALIZE_ONNX_NODE_TESTS=OFF.\n"
         "  Details: ${_np_err}")
     endif()
-    if(NOT _np_ver STREQUAL NUMPY_PINNED_VERSION)
+    if(NOT _np_ver STREQUAL _numpy_pinned_version)
       message(FATAL_ERROR
-        "numpy ${_np_ver} != pinned ${NUMPY_PINNED_VERSION} (requirements.txt, for Python "
+        "numpy ${_np_ver} != pinned ${_numpy_pinned_version} (requirements.txt, for Python "
         "${Python_VERSION}). The materialized corpus must be reproduced under the pinned numpy so "
         "the equivalence oracle stays within its <=4-ULP band.\n"
-        "  Fix: pip install numpy==${NUMPY_PINNED_VERSION}\n"
+        "  Fix: pip install numpy==${_numpy_pinned_version}\n"
         "  OR reconfigure with -Donnxruntime_MATERIALIZE_ONNX_NODE_TESTS=OFF.")
     endif()
 
     set(_materialize_script ${REPO_ROOT}/tools/python/materialize_onnx_node_tests.py)
-    set(ORT_MATERIALIZED_NODE_ROOT ${CMAKE_BINARY_DIR}/onnx_node_tests)
-    set(ORT_MATERIALIZED_NODE_DIR  ${ORT_MATERIALIZED_NODE_ROOT}/node)
+    set(_materialized_node_root ${CMAKE_BINARY_DIR}/onnx_node_tests)
+    set(_materialized_node_dir  ${_materialized_node_root}/node)
     # Single shared floor for the "silently-empty/undersized materialization" guard. Kept in
     # lockstep with the other floor sites (all must move together if raised):
     #   * MIN_NODE_CASES in onnxruntime/test/python/onnx_node_test_equivalence_test.py
@@ -1628,19 +1647,19 @@ if (NOT onnxruntime_ENABLE_TRAINING_TORCH_INTEROP)
     set(ORT_ONNX_NODE_MIN_CASES 1500)
 
     add_custom_command(
-      OUTPUT  ${ORT_MATERIALIZED_NODE_ROOT}/.stamp
-      COMMAND ${CMAKE_COMMAND} -E make_directory ${ORT_MATERIALIZED_NODE_ROOT}
+      OUTPUT  ${_materialized_node_root}/.stamp
+      COMMAND ${CMAKE_COMMAND} -E make_directory ${_materialized_node_root}
       COMMAND ${Python_EXECUTABLE} ${_materialize_script}
-                --out ${ORT_MATERIALIZED_NODE_ROOT}
-                --expected-onnx-version ${ONNX_PINNED_VERSION}
-                --expected-numpy-version ${NUMPY_PINNED_VERSION}
+                --out ${_materialized_node_root}
+                --expected-onnx-version ${_onnx_pinned_version}
+                --expected-numpy-version ${_numpy_pinned_version}
                 --min-cases ${ORT_ONNX_NODE_MIN_CASES}
-                --stamp ${ORT_MATERIALIZED_NODE_ROOT}/.stamp
+                --stamp ${_materialized_node_root}/.stamp
       DEPENDS ${_materialize_script} ${REPO_ROOT}/cmake/deps.txt
-      COMMENT "Materializing ONNX node-test corpus -> ${ORT_MATERIALIZED_NODE_DIR}"
+      COMMENT "Materializing ONNX node-test corpus -> ${_materialized_node_dir}"
       VERBATIM)
     add_custom_target(onnx_node_tests_materialized ALL
-      DEPENDS ${ORT_MATERIALIZED_NODE_ROOT}/.stamp)
+      DEPENDS ${_materialized_node_root}/.stamp)
 
     if (NOT onnxruntime_REDUCED_OPS_BUILD)
       # First-class ctest over the materialized node corpus (the durable replacement for the
@@ -1650,7 +1669,7 @@ if (NOT onnxruntime_ENABLE_TRAINING_TORCH_INTEROP)
       # near-zero coverage (onnx_test_runner skips non-existent dirs). Single-sourced with the
       # build-time --min-cases via ORT_ONNX_NODE_MIN_CASES.
       add_test(NAME onnx_test_node_materialized
-        COMMAND onnx_test_runner -m ${ORT_ONNX_NODE_MIN_CASES} ${ORT_MATERIALIZED_NODE_DIR})
+        COMMAND onnx_test_runner -m ${ORT_ONNX_NODE_MIN_CASES} ${_materialized_node_dir})
       set_tests_properties(onnx_test_node_materialized PROPERTIES DEPENDS onnx_node_tests_materialized)
 
       # Equivalence oracle: while pinned BELOW #7959 the on-disk corpus still ships in the archive,
@@ -1662,9 +1681,9 @@ if (NOT onnxruntime_ENABLE_TRAINING_TORCH_INTEROP)
         add_test(NAME onnx_node_tests_equivalence
           COMMAND ${Python_EXECUTABLE} ${REPO_ROOT}/tools/python/compare_node_test_corpora.py
                   --oracle       ${_onnx_disk_node}
-                  --materialized ${ORT_MATERIALIZED_NODE_DIR}
-                  --expected-onnx-version  ${ONNX_PINNED_VERSION}
-                  --expected-numpy-version ${NUMPY_PINNED_VERSION}
+                  --materialized ${_materialized_node_dir}
+                  --expected-onnx-version  ${_onnx_pinned_version}
+                  --expected-numpy-version ${_numpy_pinned_version}
                   --min-cases ${ORT_ONNX_NODE_MIN_CASES})
         set_tests_properties(onnx_node_tests_equivalence PROPERTIES DEPENDS onnx_node_tests_materialized)
       else()

--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -1523,6 +1523,156 @@ if (NOT onnxruntime_ENABLE_TRAINING_TORCH_INTEROP)
       COMMAND onnx_test_runner ${onnx_SOURCE_DIR}/onnx/backend/test/data/pytorch-operator)
   endif()
 
+  # ---------------------------------------------------------------------------
+  # Materialized ONNX node-test corpus.
+  #
+  # ONNX PR #7959 deletes the on-disk node-test corpus (onnx/backend/test/data/node) from the ONNX
+  # source archive, leaving only the in-memory Python generators. To detach ORT from that on-disk
+  # artifact, we regenerate the corpus from ONNX's own generators into the build tree and point the
+  # C++ onnx_test_runner consumers (this ctest + QNN CI) at the materialized copy.
+  #
+  # Gated on onnxruntime_MATERIALIZE_ONNX_NODE_TESTS (default ON under BUILD_UNIT_TESTS). The gate
+  # FAILS LOUDLY at configure time if Python/onnx/numpy are missing or mismatched -- it never
+  # silently skips, because a silent skip would recreate the exact "green CI with zero node tests"
+  # coverage gap this feature exists to close.
+  # ---------------------------------------------------------------------------
+  if (onnxruntime_MATERIALIZE_ONNX_NODE_TESTS AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
+    # onnx version pin: derive from the archive URL in cmake/deps.txt (single source of truth).
+    string(REGEX MATCH "v([0-9]+\\.[0-9]+\\.[0-9]+)" _onnx_url_ver "${DEP_URL_onnx}")
+    if(CMAKE_MATCH_1)
+      set(ONNX_PINNED_VERSION ${CMAKE_MATCH_1})
+    else()
+      message(FATAL_ERROR "Could not parse the pinned onnx version from DEP_URL_onnx='${DEP_URL_onnx}' "
+        "(expected a vX.Y.Z tag). Fix cmake/deps.txt or this regex.")
+    endif()
+
+    # Python interpreter is not guaranteed for static test-only builds (the top-level
+    # find_package(Python) in cmake/CMakeLists.txt is gated on BUILD_SHARED_LIB OR ENABLE_PYTHON).
+    #
+    # Guard on Python_VERSION, NOT Python_EXECUTABLE: Python_EXECUTABLE is a CACHE variable that
+    # persists across reconfigures, whereas Python_VERSION is a normal variable re-derived only when
+    # find_package actually runs. On any second `cmake` pass in an existing build dir, a cached
+    # Python_EXECUTABLE would skip find_package and leave Python_VERSION EMPTY -- and the
+    # numpy-pin-by-version selection below (`Python_VERSION VERSION_LESS 3.11`) treats empty as 0,
+    # silently picking the < 3.11 pin regardless of the real interpreter. Keying the guard on
+    # Python_VERSION forces find_package to repopulate the version before that selection every pass.
+    if(NOT Python_VERSION)
+      find_package(Python 3.10 COMPONENTS Interpreter REQUIRED)
+    endif()
+
+    # Configure-time fail-loud gate: onnx present and at the pinned version?
+    execute_process(
+      COMMAND ${Python_EXECUTABLE} -c "import onnx,sys; sys.stdout.write(onnx.__version__)"
+      RESULT_VARIABLE _onnx_rc OUTPUT_VARIABLE _onnx_ver ERROR_VARIABLE _onnx_err)
+    if(NOT _onnx_rc EQUAL 0)
+      message(FATAL_ERROR
+        "onnxruntime_MATERIALIZE_ONNX_NODE_TESTS=ON but 'import onnx' failed for ${Python_EXECUTABLE}.\n"
+        "  Fix: pip install onnx==${ONNX_PINNED_VERSION} numpy\n"
+        "  OR reconfigure with -Donnxruntime_MATERIALIZE_ONNX_NODE_TESTS=OFF (node-test coverage will be dropped).\n"
+        "  Details: ${_onnx_err}")
+    endif()
+    if(NOT _onnx_ver STREQUAL ONNX_PINNED_VERSION)
+      message(FATAL_ERROR
+        "onnx ${_onnx_ver} != pinned ${ONNX_PINNED_VERSION} (cmake/deps.txt). "
+        "A mismatched wheel bakes the wrong opset/IR into the materialized corpus (silent drift).\n"
+        "  Fix: pip install onnx==${ONNX_PINNED_VERSION}")
+    endif()
+
+    # numpy version: assert the build's numpy equals the CI-pinned numpy (the SAME pin the QNN
+    # legs install and that the ONNX corpus reproduction is validated under). Kept in sync with
+    # tools/ci_build/github/linux/docker/scripts/requirements.txt (python-conditional):
+    #   numpy==2.2.6 ; python_version <  "3.11"
+    #   numpy==2.4.2 ; python_version >= "3.11"
+    # The version ASSERT (installed == pin) and the equivalence ctest's <=4-ULP output band are
+    # SEPARATE guards: the assert catches env drift (wrong/unexpected numpy) at CONFIGURE time with
+    # a clear, early message; the ULP band separately absorbs the residual float drift between the
+    # pinned numpy and the numpy the archived ONNX release used to recompute reference outputs.
+    # Passing the pin (not the tautological installed value) is what makes the materializer's
+    # --expected-numpy-version assert meaningful. Both import failure AND mismatch FAIL LOUD.
+    if(Python_VERSION VERSION_LESS 3.11)
+      set(NUMPY_PINNED_VERSION 2.2.6)
+    else()
+      set(NUMPY_PINNED_VERSION 2.4.2)
+    endif()
+    execute_process(
+      COMMAND ${Python_EXECUTABLE} -c "import numpy,sys; sys.stdout.write(numpy.__version__)"
+      RESULT_VARIABLE _np_rc OUTPUT_VARIABLE _np_ver ERROR_VARIABLE _np_err)
+    if(NOT _np_rc EQUAL 0)
+      message(FATAL_ERROR
+        "onnxruntime_MATERIALIZE_ONNX_NODE_TESTS=ON but 'import numpy' failed for ${Python_EXECUTABLE}.\n"
+        "  Fix: pip install numpy==${NUMPY_PINNED_VERSION}\n"
+        "  OR reconfigure with -Donnxruntime_MATERIALIZE_ONNX_NODE_TESTS=OFF.\n"
+        "  Details: ${_np_err}")
+    endif()
+    if(NOT _np_ver STREQUAL NUMPY_PINNED_VERSION)
+      message(FATAL_ERROR
+        "numpy ${_np_ver} != pinned ${NUMPY_PINNED_VERSION} (requirements.txt, for Python "
+        "${Python_VERSION}). The materialized corpus must be reproduced under the pinned numpy so "
+        "the equivalence oracle stays within its <=4-ULP band.\n"
+        "  Fix: pip install numpy==${NUMPY_PINNED_VERSION}\n"
+        "  OR reconfigure with -Donnxruntime_MATERIALIZE_ONNX_NODE_TESTS=OFF.")
+    endif()
+
+    set(_materialize_script ${REPO_ROOT}/tools/python/materialize_onnx_node_tests.py)
+    set(ORT_MATERIALIZED_NODE_ROOT ${CMAKE_BINARY_DIR}/onnx_node_tests)
+    set(ORT_MATERIALIZED_NODE_DIR  ${ORT_MATERIALIZED_NODE_ROOT}/node)
+    # Single shared floor for the "silently-empty/undersized materialization" guard. Kept in
+    # lockstep with the other floor sites (all must move together if raised):
+    #   * MIN_NODE_CASES in onnxruntime/test/python/onnx_node_test_equivalence_test.py
+    #   * MIN_NODE_CASES in onnxruntime/test/python/onnx_backend_test_series.py
+    #   * onnx_test_runner -m (the C++ consumption-point tripwire, wired below)
+    # Today's corpus is ~1799 node cases; 1500 is a conservative floor that survives normal opset
+    # churn but fails loud on a catastrophic under-generation. Passed to the build-time materialize
+    # step (build fails loud), the node ctest (-m, consumption-point), AND the equivalence ctest.
+    set(ORT_ONNX_NODE_MIN_CASES 1500)
+
+    add_custom_command(
+      OUTPUT  ${ORT_MATERIALIZED_NODE_ROOT}/.stamp
+      COMMAND ${CMAKE_COMMAND} -E make_directory ${ORT_MATERIALIZED_NODE_ROOT}
+      COMMAND ${Python_EXECUTABLE} ${_materialize_script}
+                --out ${ORT_MATERIALIZED_NODE_ROOT}
+                --expected-onnx-version ${ONNX_PINNED_VERSION}
+                --expected-numpy-version ${NUMPY_PINNED_VERSION}
+                --min-cases ${ORT_ONNX_NODE_MIN_CASES}
+                --stamp ${ORT_MATERIALIZED_NODE_ROOT}/.stamp
+      DEPENDS ${_materialize_script} ${REPO_ROOT}/cmake/deps.txt
+      COMMENT "Materializing ONNX node-test corpus -> ${ORT_MATERIALIZED_NODE_DIR}"
+      VERBATIM)
+    add_custom_target(onnx_node_tests_materialized ALL
+      DEPENDS ${ORT_MATERIALIZED_NODE_ROOT}/.stamp)
+
+    if (NOT onnxruntime_REDUCED_OPS_BUILD)
+      # First-class ctest over the materialized node corpus (the durable replacement for the
+      # on-disk corpus; previously node tests were only run via the Python series + QNN CI).
+      # -m enforces the case-count floor at CONSUMPTION (the runner's tally), so a silently
+      # empty/partial/truncated materialized tree fails loud instead of exiting green with
+      # near-zero coverage (onnx_test_runner skips non-existent dirs). Single-sourced with the
+      # build-time --min-cases via ORT_ONNX_NODE_MIN_CASES.
+      add_test(NAME onnx_test_node_materialized
+        COMMAND onnx_test_runner -m ${ORT_ONNX_NODE_MIN_CASES} ${ORT_MATERIALIZED_NODE_DIR})
+      set_tests_properties(onnx_test_node_materialized PROPERTIES DEPENDS onnx_node_tests_materialized)
+
+      # Equivalence oracle: while pinned BELOW #7959 the on-disk corpus still ships in the archive,
+      # so we byte-compare the materialized copy against it. Gated on if(EXISTS ...) at CONFIGURE
+      # time, so the test simply stops being registered (clean auto-retirement, no perpetual skip,
+      # no red CI) once the pin advances past #7959 and the oracle disappears.
+      set(_onnx_disk_node ${onnx_SOURCE_DIR}/onnx/backend/test/data/node)
+      if(EXISTS ${_onnx_disk_node})
+        add_test(NAME onnx_node_tests_equivalence
+          COMMAND ${Python_EXECUTABLE} ${REPO_ROOT}/tools/python/compare_node_test_corpora.py
+                  --oracle       ${_onnx_disk_node}
+                  --materialized ${ORT_MATERIALIZED_NODE_DIR}
+                  --expected-onnx-version  ${ONNX_PINNED_VERSION}
+                  --expected-numpy-version ${NUMPY_PINNED_VERSION}
+                  --min-cases ${ORT_ONNX_NODE_MIN_CASES})
+        set_tests_properties(onnx_node_tests_equivalence PROPERTIES DEPENDS onnx_node_tests_materialized)
+      else()
+        message(STATUS "ONNX on-disk node corpus absent (post-#7959 pin) -- equivalence oracle "
+          "retired; skipping onnx_node_tests_equivalence.")
+      endif()
+    endif()
+  endif()
+
   if (CMAKE_SYSTEM_NAME STREQUAL "Android")
       list(APPEND android_shared_libs log android)
   endif()

--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -1531,7 +1531,8 @@ if (NOT onnxruntime_ENABLE_TRAINING_TORCH_INTEROP)
   # artifact, we regenerate the corpus from ONNX's own generators into the build tree and point the
   # C++ onnx_test_runner consumers (this ctest + QNN CI) at the materialized copy.
   #
-  # Gated on onnxruntime_MATERIALIZE_ONNX_NODE_TESTS (default ON under BUILD_UNIT_TESTS). The gate
+  # Gated on onnxruntime_MATERIALIZE_ONNX_NODE_TESTS (opt-in; default OFF -- enabled explicitly on
+  # the provisioned CI legs via --cmake_extra_defines). When ON, the gate
   # FAILS LOUDLY at configure time if Python/onnx/numpy are missing or mismatched -- it never
   # silently skips, because a silent skip would recreate the exact "green CI with zero node tests"
   # coverage gap this feature exists to close.

--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -1636,14 +1636,24 @@ if (NOT onnxruntime_ENABLE_TRAINING_TORCH_INTEROP)
     set(_materialize_script ${REPO_ROOT}/tools/python/materialize_onnx_node_tests.py)
     set(_materialized_node_root ${CMAKE_BINARY_DIR}/onnx_node_tests)
     set(_materialized_node_dir  ${_materialized_node_root}/node)
-    # Single shared floor for the "silently-empty/undersized materialization" guard. Kept in
-    # lockstep with the other floor sites (all must move together if raised):
+    # Single shared floor VALUE for the "silently-empty/undersized materialization" guard. Wired to
+    # three consumption sites; all use the same 1500 literal, but they DO NOT all count the same
+    # population -- the floor is one stable value, not a claim that the counts are identical:
     #   * MIN_NODE_CASES in onnxruntime/test/python/onnx_node_test_equivalence_test.py
-    #   * MIN_NODE_CASES in onnxruntime/test/python/onnx_backend_test_series.py
-    #   * onnx_test_runner -m (the C++ consumption-point tripwire, wired below)
-    # Today's corpus is ~1799 node cases; 1500 is a conservative floor that survives normal opset
-    # churn but fails loud on a catastrophic under-generation. Passed to the build-time materialize
-    # step (build fails loud), the node ctest (-m, consumption-point), AND the equivalence ctest.
+    #   * MIN_NODE_CASES in onnxruntime/test/python/onnx_backend_test_series.py -- the PRE-exclude
+    #     population (counted in the base runner's _add_model_test, BEFORE backend_test.exclude()
+    #     drops filtered cases), i.e. the full materialized case count.
+    #   * onnx_test_runner -m (the C++ consumption-point tripwire, wired below) -- checked against
+    #     tests.size() in main.cc, which is the POST-skip COLLECTED count: LoadTests (TestCase.cc)
+    #     already `continue`s past broken/disabled/no-test-data/training-domain cases before they
+    #     reach that tally, so the C++ population is the Python one MINUS the CPU skip set.
+    # These two populations are INTENTIONALLY different; 1500 is a single conservative floor that
+    # clears both today by a wide margin: ~1799 collected minus a handful of CPU skips (~5:
+    # convinteger + 4 dft_*) is ~1794, still >> 1500 (~17% headroom on the smaller C++ count). 1500
+    # is a STABLE floor, not a moving target -- it does not track the corpus size. If the CPU
+    # broken/skip set ever grew past that margin, the C++ `-m` floor would red-fail LOUDLY (the safe
+    # direction) -- never a silent pass. Passed to the build-time materialize step (build fails
+    # loud), the node ctest (-m, consumption-point), AND the equivalence ctest.
     set(ORT_ONNX_NODE_MIN_CASES 1500)
 
     add_custom_command(

--- a/docs/python/conf.py
+++ b/docs/python/conf.py
@@ -121,7 +121,7 @@ def setup(app):
     if not os.path.exists(dest):
         import urllib.request  # noqa: PLC0415
 
-        url = "https://raw.githubusercontent.com/onnx/onnx/master/onnx/backend/test/data/node/test_sigmoid/model.onnx"
+        url = "https://raw.githubusercontent.com/onnx/onnx/v1.22.0/onnx/backend/test/data/node/test_sigmoid/model.onnx"
         urllib.request.urlretrieve(url, dest)
     loc = os.path.split(dest)[-1]
     if not os.path.exists(loc):

--- a/docs/python/examples/plot_load_and_predict.py
+++ b/docs/python/examples/plot_load_and_predict.py
@@ -19,7 +19,7 @@ from onnxruntime.datasets import get_example
 
 #########################
 # Let's load a very simple model.
-# The model is available on github `onnx...test_sigmoid <https://github.com/onnx/onnx/blob/main/onnx/backend/test/data/node/test_sigmoid>`_.
+# The model is available on github `onnx...test_sigmoid <https://github.com/onnx/onnx/blob/v1.22.0/onnx/backend/test/data/node/test_sigmoid>`_.
 
 example1 = get_example("sigmoid.onnx")
 sess = rt.InferenceSession(example1, providers=rt.get_available_providers())

--- a/onnxruntime/test/onnx/TestCase.cc
+++ b/onnxruntime/test/onnx/TestCase.cc
@@ -958,6 +958,19 @@ std::unique_ptr<std::set<BrokenTest>> GetBrokenTests(const std::string& provider
       {"cast_UINT4_to_FLOAT", "Skipped until onnxruntime/cmake/external/onnx points to onnx 1.19 which should include @onnx/onnx/pull/7074"},
       {"cast_UINT4_to_FLOAT16", "Skipped until onnxruntime/cmake/external/onnx points to onnx 1.19 which should include @onnx/onnx/pull/7074"},
       {"cast_UINT4_to_UINT8", "Skipped until onnxruntime/cmake/external/onnx points to onnx 1.19 which should include @onnx/onnx/pull/7074"},
+      // onnx#7959: the materialized node corpus now runs on the CPU EP via the
+      // onnx_test_node_materialized ctest (previously the C++ node runner was QNN-only). ORT has
+      // no per-channel-quantization ConvInteger support on any EP -- the CPU kernel throws and
+      // CUDA has no ConvInteger kernel at all -- so skip it globally here, mirroring the
+      // provider-agnostic exclusion in onnx_backend_test_series_filters.jsonc.
+      {"convinteger_with_padding", "ORT does not support per-channel quantization for ConvInteger (onnx#7959; mirrors onnx_backend_test_series_filters.jsonc global exclusion)"},
+      // onnx#7959 (same CPU-materialized-node-runner exposure as convinteger above): ORT's DFT
+      // kernel does not implement IRFFT (inverse real FFT) -- a known global conformance gap,
+      // provider-agnostically excluded in onnx_backend_test_series_filters.jsonc. Skip globally.
+      {"dft_irfft", "ORT DFT kernel does not implement IRFFT (onnx#7959; mirrors onnx_backend_test_series_filters.jsonc global exclusion)"},
+      {"dft_irfft_opset19", "ORT DFT kernel does not implement IRFFT (onnx#7959; mirrors onnx_backend_test_series_filters.jsonc global exclusion)"},
+      {"dft_rfft", "ORT DFT kernel does not implement IRFFT (onnx#7959; mirrors onnx_backend_test_series_filters.jsonc global exclusion)"},
+      {"dft_rfft_opset19", "ORT DFT kernel does not implement IRFFT (onnx#7959; mirrors onnx_backend_test_series_filters.jsonc global exclusion)"},
       // Spec-leading: PR #28379 fixed CPU Attention to match the corrected
       // scale -> softcap -> bias/mask -> softmax ordering established by
       // onnx/onnx#7867 (softcap before mask) and onnx/onnx#7913
@@ -1567,12 +1580,9 @@ std::unique_ptr<std::set<BrokenTest>> GetBrokenTests(const std::string& provider
     // Fails since ONNX==1.20.0
     broken_tests->insert({"attention_4d_with_past_and_present_qk_matmul_bias_3d_mask_causal_expanded", "unknown version"});
     broken_tests->insert({"attention_4d_with_past_and_present_qk_matmul_bias_4d_mask_causal_expanded", "unknown version"});
-    broken_tests->insert({"convinteger_with_padding", "unknown version"});
-    // Fails since ONNX==1.21.0
-    broken_tests->insert({"dft_irfft", "unknown version"});
-    broken_tests->insert({"dft_irfft_opset19", "unknown version"});
-    broken_tests->insert({"dft_rfft", "unknown version"});
-    broken_tests->insert({"dft_rfft_opset19", "unknown version"});
+    // Note: dft_irfft/dft_irfft_opset19/dft_rfft/dft_rfft_opset19 (previously listed here as
+    // "Fails since ONNX==1.21.0") are now in the common GetBrokenTests initializer above, since
+    // the CPU-materialized node runner (onnx#7959) exposes the same global IRFFT conformance gap.
     broken_tests->insert({"bitcast_bool_to_uint8", "ORT BitCast kernel does not register bool type"});
   }
 

--- a/onnxruntime/test/onnx/TestCase.cc
+++ b/onnxruntime/test/onnx/TestCase.cc
@@ -964,13 +964,16 @@ std::unique_ptr<std::set<BrokenTest>> GetBrokenTests(const std::string& provider
       // CUDA has no ConvInteger kernel at all -- so skip it globally here, mirroring the
       // provider-agnostic exclusion in onnx_backend_test_series_filters.jsonc.
       {"convinteger_with_padding", "ORT does not support per-channel quantization for ConvInteger (onnx#7959; mirrors onnx_backend_test_series_filters.jsonc global exclusion)"},
-      // onnx#7959 (same CPU-materialized-node-runner exposure as convinteger above): ORT's DFT
-      // kernel does not implement IRFFT (inverse real FFT) -- a known global conformance gap,
-      // provider-agnostically excluded in onnx_backend_test_series_filters.jsonc. Skip globally.
-      {"dft_irfft", "ORT DFT kernel does not implement IRFFT (onnx#7959; mirrors onnx_backend_test_series_filters.jsonc global exclusion)"},
-      {"dft_irfft_opset19", "ORT DFT kernel does not implement IRFFT (onnx#7959; mirrors onnx_backend_test_series_filters.jsonc global exclusion)"},
-      {"dft_rfft", "ORT DFT kernel does not implement IRFFT (onnx#7959; mirrors onnx_backend_test_series_filters.jsonc global exclusion)"},
-      {"dft_rfft_opset19", "ORT DFT kernel does not implement IRFFT (onnx#7959; mirrors onnx_backend_test_series_filters.jsonc global exclusion)"},
+      // onnx#7959 (same CPU-materialized-node-runner exposure as convinteger above): the ORT DFT
+      // rfft/irfft outputs are numerically near-correct but a few near-zero elements exceed the
+      // runner's tight ~1e-5 absolute tolerance (platform-dependent FFT roundoff: passes on Windows
+      // CPU, fails on Linux CPU by <=~1.6e-4). This mirrors the pre-existing GLOBAL exclusion of
+      // these same 4 tests in onnx_backend_test_series_filters.jsonc ("current_failing_tests"), so
+      // the C++ materialized runner stays at parity with the python conformance suite's pass set.
+      {"dft_irfft", "DFT rfft/irfft near-zero elements exceed the tight abs tolerance (onnx#7959; parity with onnx_backend_test_series_filters.jsonc global exclusion)"},
+      {"dft_irfft_opset19", "DFT rfft/irfft near-zero elements exceed the tight abs tolerance (onnx#7959; parity with onnx_backend_test_series_filters.jsonc global exclusion)"},
+      {"dft_rfft", "DFT rfft/irfft near-zero elements exceed the tight abs tolerance (onnx#7959; parity with onnx_backend_test_series_filters.jsonc global exclusion)"},
+      {"dft_rfft_opset19", "DFT rfft/irfft near-zero elements exceed the tight abs tolerance (onnx#7959; parity with onnx_backend_test_series_filters.jsonc global exclusion)"},
       // Spec-leading: PR #28379 fixed CPU Attention to match the corrected
       // scale -> softcap -> bias/mask -> softmax ordering established by
       // onnx/onnx#7867 (softcap before mask) and onnx/onnx#7913
@@ -1582,7 +1585,8 @@ std::unique_ptr<std::set<BrokenTest>> GetBrokenTests(const std::string& provider
     broken_tests->insert({"attention_4d_with_past_and_present_qk_matmul_bias_4d_mask_causal_expanded", "unknown version"});
     // Note: dft_irfft/dft_irfft_opset19/dft_rfft/dft_rfft_opset19 (previously listed here as
     // "Fails since ONNX==1.21.0") are now in the common GetBrokenTests initializer above, since
-    // the CPU-materialized node runner (onnx#7959) exposes the same global IRFFT conformance gap.
+    // the CPU-materialized node runner (onnx#7959) exposes the same marginal FFT precision failure
+    // that onnx_backend_test_series_filters.jsonc already excludes globally.
     broken_tests->insert({"bitcast_bool_to_uint8", "ORT BitCast kernel does not register bool type"});
   }
 

--- a/onnxruntime/test/onnx/main.cc
+++ b/onnxruntime/test/onnx/main.cc
@@ -52,6 +52,8 @@ void usage() {
       "\t-M : Disable memory pattern\n"
       "\t-c [runs]: Specifies the number of Session::Run() to invoke simultaneously for each model.\n"
       "\t-r [repeat]: Specifies the number of times to repeat\n"
+      "\t-m [min_tests]: Fail if fewer than this many test cases are collected (0 = no floor, the "
+      "default). Guards against a silently empty/partial/truncated test tree.\n"
       "\t-I [inference_mode]: Use inference mode. Save the inference result and skip the output value comparison.\n"
       "\t-v: verbose\n"
       "\t-n [test_case_name]: Specifies a single test case to run.\n"
@@ -236,6 +238,7 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
   double atol = 1e-5;
   double rtol = 1e-5;
   int device_id = 0;
+  int min_tests = 0;  // -m: fail if fewer than this many test cases are collected (0 = no floor).
   GraphOptimizationLevel graph_optimization_level = ORT_ENABLE_ALL;
   bool user_graph_optimization_level_set = false;
   bool set_denormal_as_zero = false;
@@ -251,7 +254,7 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
   bool pause = false;
   {
     int ch;
-    while ((ch = getopt(argc, argv, ORT_TSTR("Ac:hj:IMn:r:e:t:a:xvo:d:C:i:pzfb"))) != -1) {
+    while ((ch = getopt(argc, argv, ORT_TSTR("Ac:hj:IMm:n:r:e:t:a:xvo:d:C:i:pzfb"))) != -1) {
       switch (ch) {
         case 'A':
           enable_cpu_mem_arena = false;
@@ -285,6 +288,13 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
           break;
         case 'M':
           enable_mem_pattern = false;
+          break;
+        case 'm':
+          min_tests = static_cast<int>(OrtStrtol<PATH_CHAR_TYPE>(optarg, nullptr));
+          if (min_tests < 0) {
+            usage();
+            return -1;
+          }
           break;
         case 'n':
           // run only some whitelisted tests
@@ -945,6 +955,22 @@ select from 'TF8', 'TF16', 'UINT8', 'FLOAT', 'ITENSOR'. \n)");
                 owned_tests.push_back(std::move(l));
               });
 
+    // Consumption-point floor (opt-in via -m). LoadTests silently skips non-existent/empty dirs
+    // (TestCase.cc: `if (!exists) continue`), so an empty/partial/truncated test tree would
+    // otherwise run to a green exit with near-zero coverage. This fires for a materialized node
+    // corpus that failed to generate, a truncated artifact copy (from a separate download/copy
+    // stage), a stale stamp masking a partial tree, and the post-#7959 state where the
+    // equivalence oracle has retired and nothing else re-anchors the count.
+    if (min_tests > 0 && tests.size() < static_cast<size_t>(min_tests)) {
+      fprintf(stderr,
+              "FATAL: node test corpus collapsed -- onnx_test_runner collected %zu test case(s) "
+              "from the given data root(s), but -m required at least %d. See onnx-opset-bump-checklist "
+              "gotcha (p): onnx#7959 deletes the on-disk node-test corpus and corpus absence is "
+              "otherwise SILENT-GREEN. A silently empty/partial/truncated test tree would report "
+              "success with near-zero coverage.\n",
+              tests.size(), min_tests);
+      return -1;
+    }
     auto tp = TestEnv::CreateThreadPool(Env::Default());
     TestEnv test_env(env, sf, tp.get(), std::move(tests), stat, inference_mode);
     Status st = test_env.Run(p_models, concurrent_session_runs, repeat_count);

--- a/onnxruntime/test/python/onnx_backend_test_series.py
+++ b/onnxruntime/test/python/onnx_backend_test_series.py
@@ -20,6 +20,13 @@ import onnxruntime.backend as backend  # pylint: disable=consider-using-from-imp
 
 pytest_plugins = ("onnx.backend.test.report",)
 
+# Minimum number of ONNX "node" test cases that must be discovered on disk. This is the Python-leg
+# twin of the C++ onnx_test_runner -m floor and the CMake ORT_ONNX_NODE_MIN_CASES gate; all three
+# MUST move in lockstep if the floor is ever raised. It guards against the node corpus silently
+# disappearing (e.g. post-onnx#7959 when the bundled node/ data is removed, leaving this series to
+# quietly lose node coverage). Today's corpus is ~1799 cases; 1500 leaves ~17% headroom.
+MIN_NODE_CASES = 1500
+
 
 class OrtBackendTest(onnx.backend.test.runner.Runner):
     """ONNX test runner with ORT-specific behavior."""
@@ -32,6 +39,9 @@ class OrtBackendTest(onnx.backend.test.runner.Runner):
     ):
         self._rtol_overrides = rtol_overrides
         self._atol_overrides = atol_overrides
+        # Counts "node"-kind test cases discovered on disk. Set before super().__init__ because the
+        # base Runner scans the data dirs (calling _add_model_test) during construction.
+        self._node_case_count = 0
 
         super().__init__(backend, parent_module=__name__)
 
@@ -67,6 +77,9 @@ class OrtBackendTest(onnx.backend.test.runner.Runner):
             attrs = vars(model_test)
         attrs["rtol"] = self._rtol_overrides[model_test.name]
         attrs["atol"] = self._atol_overrides[model_test.name]
+
+        if kind == "node":
+            self._node_case_count += 1
 
         super()._add_model_test(onnx.backend.test.case.test_case.TestCase(**attrs), kind)
 
@@ -116,6 +129,17 @@ def create_backend_test(test_name=None):
     atol_overrides.update(overrides["atol_overrides"])
 
     backend_test = OrtBackendTest(rtol_overrides, atol_overrides)
+
+    # Consumption-point floor (full runs only; a targeted -t/test_name run intentionally collects a
+    # subset). Fires if the node corpus failed to materialize or has otherwise silently shrunk.
+    if not test_name and backend_test._node_case_count < MIN_NODE_CASES:
+        raise RuntimeError(
+            f"Node test corpus collapsed -- discovered only {backend_test._node_case_count} ONNX "
+            f"'node' test case(s), but at least {MIN_NODE_CASES} are required. See "
+            f"onnx-opset-bump-checklist gotcha (p): onnx#7959 removes the on-disk node-test corpus "
+            f"and corpus absence is otherwise silent-green. The corpus appears missing, empty, or "
+            f"truncated (e.g. #7959 landed and no materialized corpus replaced it)."
+        )
 
     # Type not supported
     backend_test.exclude(r"(FLOAT16)")

--- a/onnxruntime/test/python/onnx_backend_test_series.py
+++ b/onnxruntime/test/python/onnx_backend_test_series.py
@@ -40,7 +40,9 @@ class OrtBackendTest(onnx.backend.test.runner.Runner):
         self._rtol_overrides = rtol_overrides
         self._atol_overrides = atol_overrides
         # Counts "node"-kind test cases discovered on disk. Set before super().__init__ because the
-        # base Runner scans the data dirs (calling _add_model_test) during construction.
+        # base Runner scans the data dirs (calling _add_model_test) during construction. NOTE: onnx's
+        # Runner passes the *capitalized* category label ("Node"), not the lowercase load kind, so the
+        # match below is case-insensitive.
         self._node_case_count = 0
 
         super().__init__(backend, parent_module=__name__)
@@ -78,7 +80,7 @@ class OrtBackendTest(onnx.backend.test.runner.Runner):
         attrs["rtol"] = self._rtol_overrides[model_test.name]
         attrs["atol"] = self._atol_overrides[model_test.name]
 
-        if kind == "node":
+        if kind.lower() == "node":
             self._node_case_count += 1
 
         super()._add_model_test(onnx.backend.test.case.test_case.TestCase(**attrs), kind)

--- a/onnxruntime/test/python/onnx_node_test_equivalence_test.py
+++ b/onnxruntime/test/python/onnx_node_test_equivalence_test.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+"""Retiring equivalence test for materialize_onnx_node_tests.py.
+
+Proves the build-time-materialized node-test tree is byte-identical to ONNX's
+still-present on-disk golden corpus (``.../onnx/backend/test/data/node``).
+
+Two complementary equivalence guards exist -- this is one of them; they are NOT
+redundant (different failure modes, different CI legs):
+
+  * THIS unittest -- materializes FRESH into a tmpdir and byte-compares vs the
+    oracle. Validates MATERIALIZER / GENERATOR-LOGIC correctness in isolation,
+    with NO C++ build required, so it runs in the Python test legs and as a fast
+    local dev check. It also carries the Python-side min-count floor
+    (``MIN_NODE_CASES``) -- the Python twin of the C++ runtime tripwire.
+  * The ``onnx_node_tests_equivalence`` CTEST (``compare_node_test_corpora.py``)
+    -- byte-compares the oracle vs the ACTUAL build-tree artifact that
+    ``onnx_test_runner`` consumes. Validates ARTIFACT INTEGRITY end-to-end
+    (catches CMake wiring drift, stale/partial artifacts) in the C++ build legs.
+
+Both auto-retire together when the oracle vanishes post-#7959.
+
+This test is an ORACLE-DEPENDENT guard: it can only certify equivalence while
+the on-disk corpus exists. Once ONNX PR onnx/onnx#7959 lands (deleting that
+corpus), the oracle is gone and this test AUTO-SKIPS -- the materializer then
+becomes the sole source of the node tree, and the permanent min-count tripwire
+(in the C++ runner + the Python backend series) takes over as the cause-agnostic
+backstop.
+
+Version parity: the materialized model.onnx opset/IR is stamped from the
+compiled onnx schema registry, so this test asserts the installed onnx equals
+the ``cmake/deps.txt`` pin (compared on the release base, so a pre-release rcN/.dev
+wheel of the pinned tag is accepted). numpy parity is NOT asserted -- the core
+treats numpy as an informational soft-warning, and recomputed float outputs that
+differ by within a small ULP band are accepted as Class A numpy-gen skew.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+import tempfile
+import unittest
+
+# Make the sibling materializer importable regardless of CWD.
+_TOOLS_PYTHON = os.path.normpath(os.path.join(os.path.dirname(__file__), "..", "..", "..", "tools", "python"))
+if _TOOLS_PYTHON not in sys.path:
+    sys.path.insert(0, _TOOLS_PYTHON)
+
+import materialize_onnx_node_tests as mat  # noqa: E402
+
+# A conservative floor: today's corpus is ~1799 node cases. The floor exists so a
+# silently-empty/undersized materialization fails loud rather than shipping green.
+MIN_NODE_CASES = 1500
+
+
+def _repo_root() -> str:
+    return os.path.normpath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+
+
+def _expected_onnx_version() -> str | None:
+    """Parse the onnx pin (archive tag) from cmake/deps.txt."""
+    deps = os.path.join(_repo_root(), "cmake", "deps.txt")
+    if not os.path.isfile(deps):
+        return None
+    with open(deps) as f:
+        for line in f:
+            if line.startswith("onnx;"):
+                m = re.search(r"/tags/v([0-9]+\.[0-9]+\.[0-9]+)\.zip", line)
+                if m:
+                    return m.group(1)
+    return None
+
+
+def _find_oracle_node_dir() -> str | None:
+    """Locate the on-disk ONNX node corpus (the oracle), if present.
+
+    Search order: the FetchContent build tree (_deps/onnx-src), an env override,
+    then the installed onnx wheel's bundled data. Returns None if the corpus is
+    gone (post-#7959) -> the test auto-skips.
+    """
+    candidates = []
+    env = os.environ.get("ORT_ONNX_NODE_ORACLE_DIR")
+    if env:
+        candidates.append(env)
+    root = _repo_root()
+    # Candidate build-tree oracle locations mirror the ORT convention
+    # build/<Platform>/<Config> layout from tools/ci_build (Platform in
+    # {Linux,Windows,MacOS}, Config in {Debug,Release,RelWithDebInfo,MinSizeRel};
+    # "" covers a flat build/).
+    for build in ("build", "build/Linux", "build/Windows", "build/MacOS"):
+        for cfg in ("Debug", "Release", "RelWithDebInfo", "MinSizeRel", ""):
+            candidates.append(
+                os.path.join(
+                    root,
+                    build,
+                    cfg,
+                    "_deps",
+                    "onnx-src",
+                    "onnx",
+                    "backend",
+                    "test",
+                    "data",
+                    "node",
+                )
+            )
+    try:
+        import onnx.backend.test  # noqa: PLC0415
+
+        candidates.append(os.path.join(os.path.dirname(onnx.backend.test.__file__), "data", "node"))
+    except Exception:
+        pass
+    for c in candidates:
+        if c and os.path.isdir(c) and any(n.startswith("test_") for n in os.listdir(c)):
+            return c
+    return None
+
+
+class NodeTestEquivalence(unittest.TestCase):
+    def test_materialized_equals_on_disk_oracle(self) -> None:
+        oracle = _find_oracle_node_dir()
+        if oracle is None:
+            self.skipTest(
+                "on-disk ONNX node corpus (oracle) not found -- either not built yet, "
+                "or onnx#7959 landed and the corpus was removed. Equivalence oracle "
+                "retired; the materializer + min-count tripwire are now the guard."
+            )
+
+        expected_onnx = _expected_onnx_version()
+        try:
+            import onnx  # noqa: PLC0415
+        except ImportError as exc:  # pragma: no cover
+            self.skipTest(f"onnx not importable: {exc}")
+
+        if expected_onnx and mat._release_base(onnx.__version__) != mat._release_base(expected_onnx):
+            self.skipTest(
+                f"installed onnx=={onnx.__version__} != cmake/deps.txt pin "
+                f"{expected_onnx}; cannot certify equivalence under version skew. "
+                f"Install the pinned onnx to run this check. (A pre-release rcN/.dev "
+                f"of the same release base is accepted.)"
+            )
+
+        with tempfile.TemporaryDirectory(prefix="ort_node_mat_") as tmp:
+            # numpy parity is intentionally NOT asserted here: the core treats it as
+            # an informational soft-warning, and this test validates generator LOGIC
+            # (not corpus-gen numpy identity), so pass expected_numpy=None.
+            written = mat.materialize(
+                tmp,
+                expected_onnx=onnx.__version__,
+                expected_numpy=None,
+                min_cases=MIN_NODE_CASES,
+            )
+            self.assertGreaterEqual(
+                len(written),
+                MIN_NODE_CASES,
+                f"materialized only {len(written)} node cases (< {MIN_NODE_CASES})",
+            )
+            # compare_to_oracle raises MaterializeError (Class B) on any structural
+            # mismatch; Class A small-ULP float drift is accepted + warned.
+            try:
+                mat.compare_to_oracle(
+                    tmp,
+                    os.path.dirname(oracle),  # parent of .../node
+                    min_cases=MIN_NODE_CASES,
+                )
+            except mat.MaterializeError as exc:
+                self.fail(str(exc))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/onnxruntime/test/python/onnx_node_test_equivalence_test.py
+++ b/onnxruntime/test/python/onnx_node_test_equivalence_test.py
@@ -111,7 +111,10 @@ def _find_oracle_node_dir() -> str | None:
         import onnx.backend.test  # noqa: PLC0415
 
         candidates.append(os.path.join(os.path.dirname(onnx.backend.test.__file__), "data", "node"))
-    except Exception:
+    except ImportError:
+        # onnx (or its backend.test data package) isn't importable in this env, so
+        # the installed-wheel oracle location simply doesn't contribute a candidate.
+        # Other candidate sources (env override, build tree) still apply.
         pass
     for c in candidates:
         if c and os.path.isdir(c) and any(n.startswith("test_") for n in os.listdir(c)):

--- a/onnxruntime/test/testdata/onnx_backend_test_series_filters.jsonc
+++ b/onnxruntime/test/testdata/onnx_backend_test_series_filters.jsonc
@@ -380,9 +380,11 @@
         "^test_quantizelinear_uint4",
         // topk uint64 is not implemented in ORT yet.
         "^test_top_k_uint64",
-        // ORT DFT kernel does not implement IRFFT (inverse real FFT) — it always outputs
-        // complex (last dim=2) which is wrong for IRFFT. These ONNX backend tests were
-        // added in onnx commit ee910d0e4 for DFT-20 spec clarification.
+        // ORT DFT rfft/irfft outputs are numerically near-correct but a few
+        // near-zero elements exceed the runner's tight ~1e-5 absolute tolerance
+        // (platform-dependent FFT roundoff: passes on Windows CPU, fails on Linux
+        // CPU by <=~1.6e-4). Mirrors onnxruntime/test/onnx/TestCase.cc so the C++
+        // materialized runner stays at parity with this python conformance suite.
         "^test_dft_rfft",
         "^test_dft_irfft",
         "^test_dft_rfft_opset19",

--- a/tools/ci_build/github/azure-pipelines/android-arm64-v8a-QNN-crosscompile-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/android-arm64-v8a-QNN-crosscompile-ci-pipeline.yml
@@ -62,7 +62,7 @@ jobs:
   # (build_qnn/Release/onnx_node_tests/node) consumed below. The numpy markers self-select the
   # same pin the CMake gate asserts.
   - script: |
-      python3 -m pip install onnx==1.22.0 "numpy==2.2.6; python_version<'3.11'" "numpy==2.4.2; python_version>='3.11'"
+      python3 -m pip install --user onnx==1.22.0 "numpy==2.2.6; python_version<'3.11'" "numpy==2.4.2; python_version>='3.11'"
     displayName: Install onnx for node-test materialization
 
   - script: |

--- a/tools/ci_build/github/azure-pipelines/android-arm64-v8a-QNN-crosscompile-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/android-arm64-v8a-QNN-crosscompile-ci-pipeline.yml
@@ -80,6 +80,7 @@ jobs:
         --use_qnn static_lib \
         --qnn_home $(QnnSDKRootDir) \
         --cmake_generator=Ninja \
+        --cmake_extra_defines onnxruntime_MATERIALIZE_ONNX_NODE_TESTS=ON \
         --skip_tests
     displayName: Build QNN EP
 

--- a/tools/ci_build/github/azure-pipelines/android-arm64-v8a-QNN-crosscompile-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/android-arm64-v8a-QNN-crosscompile-ci-pipeline.yml
@@ -61,6 +61,10 @@ jobs:
   # which regenerates the onnx node-test corpus into the build tree
   # (build_qnn/Release/onnx_node_tests/node) consumed below. The numpy markers self-select the
   # same pin the CMake gate asserts.
+  # --user: this leg runs on a bare non-root Ubuntu agent (system python3, no venv); a plain
+  # install would write /usr/local/bin/f2py -> Permission denied. --user targets ~/.local for the
+  # same agent user, which the configure-time `import onnx` (same python3) resolves. (The two
+  # Windows QNN legs omit --user: their Python Scripts dir is writable.)
   - script: |
       python3 -m pip install --user onnx==1.22.0 "numpy==2.2.6; python_version<'3.11'" "numpy==2.4.2; python_version>='3.11'"
     displayName: Install onnx for node-test materialization

--- a/tools/ci_build/github/azure-pipelines/android-arm64-v8a-QNN-crosscompile-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/android-arm64-v8a-QNN-crosscompile-ci-pipeline.yml
@@ -56,6 +56,15 @@ jobs:
     parameters:
       QnnSDKVersion: ${{ parameters.QnnSdk }}
 
+  # onnx (pinned to cmake/deps.txt) + numpy (pinned to requirements.txt, python-conditional) are
+  # required on the HOST at configure time by the onnxruntime_MATERIALIZE_ONNX_NODE_TESTS gate,
+  # which regenerates the onnx node-test corpus into the build tree
+  # (build_qnn/Release/onnx_node_tests/node) consumed below. The numpy markers self-select the
+  # same pin the CMake gate asserts.
+  - script: |
+      python3 -m pip install onnx==1.22.0 "numpy==2.2.6; python_version<'3.11'" "numpy==2.4.2; python_version>='3.11'"
+    displayName: Install onnx for node-test materialization
+
   - script: |
       set -e -x
       python3 tools/ci_build/build.py \
@@ -76,7 +85,7 @@ jobs:
 
   - script: |
       mkdir -p build_qnn/Release/testdata/QNN/node_tests
-      cp -r cmake/external/onnx/onnx/backend/test/data/node/test_basic_conv_with_padding build_qnn/Release/testdata/QNN/node_tests
+      cp -r build_qnn/Release/onnx_node_tests/node/test_basic_conv_with_padding build_qnn/Release/testdata/QNN/node_tests
     displayName: Initialize test directories
 
   # This is commented out for now. The emulator runs correctly, onnx_test_runner is executable, and the test passes

--- a/tools/ci_build/github/azure-pipelines/linux-qnn-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-qnn-ci-pipeline.yml
@@ -59,6 +59,15 @@ jobs:
         parameters:
           QnnSDKVersion: ${{ parameters.QnnSdk }}
 
+      # onnx (pinned to cmake/deps.txt) + numpy (pinned to requirements.txt, python-conditional)
+      # are required at configure time by the onnxruntime_MATERIALIZE_ONNX_NODE_TESTS gate, which
+      # regenerates the onnx node-test corpus into the build tree
+      # (build/Release/onnx_node_tests/node) for onnx_test_runner. The numpy markers self-select
+      # the same pin the CMake gate asserts (2.2.6 for py<3.11, 2.4.2 for py>=3.11).
+      - script: |
+          python3 -m pip install onnx==1.22.0 "numpy==2.2.6; python_version<'3.11'" "numpy==2.4.2; python_version>='3.11'"
+        displayName: Install onnx for node-test materialization
+
       - script: |
           python3 tools/ci_build/build.py \
             --build_dir build \
@@ -89,9 +98,13 @@ jobs:
         displayName: Run ONNX tests
         inputs:
           script: |
-            ./build/Release/onnx_test_runner -e qnn \
+            # onnx#7959 collapse sentinel: -m 1 fails loud if 0 node tests are collected
+            # (e.g. a MATERIALIZE=OFF leg still running this dir). Low value (not the 1500
+            # build floor) because -e qnn legitimately reduces the set to ~1529; the strict
+            # count is enforced at build time via --min-cases.
+            ./build/Release/onnx_test_runner -e qnn -m 1 \
               -j 1 -i "backend_path|$(QnnSDKRootDir)/lib/x86_64-linux-clang/libQnnCpu.so" \
-              cmake/external/onnx/onnx/backend/test/data/node
+              build/Release/onnx_node_tests/node
 
       - task: CmdLine@2
         displayName: Run float32 model tests

--- a/tools/ci_build/github/azure-pipelines/linux-qnn-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-qnn-ci-pipeline.yml
@@ -64,6 +64,10 @@ jobs:
       # regenerates the onnx node-test corpus into the build tree
       # (build/Release/onnx_node_tests/node) for onnx_test_runner. The numpy markers self-select
       # the same pin the CMake gate asserts (2.2.6 for py<3.11, 2.4.2 for py>=3.11).
+      # --user: this leg runs on a bare non-root Ubuntu agent (system python3, no venv); a plain
+      # install would write /usr/local/bin/f2py -> Permission denied. --user targets ~/.local for
+      # the same agent user, which the configure-time `import onnx` (same python3) resolves. (The
+      # two Windows QNN legs omit --user: their Python Scripts dir is writable.)
       - script: |
           python3 -m pip install --user onnx==1.22.0 "numpy==2.2.6; python_version<'3.11'" "numpy==2.4.2; python_version>='3.11'"
         displayName: Install onnx for node-test materialization

--- a/tools/ci_build/github/azure-pipelines/linux-qnn-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-qnn-ci-pipeline.yml
@@ -65,7 +65,7 @@ jobs:
       # (build/Release/onnx_node_tests/node) for onnx_test_runner. The numpy markers self-select
       # the same pin the CMake gate asserts (2.2.6 for py<3.11, 2.4.2 for py>=3.11).
       - script: |
-          python3 -m pip install onnx==1.22.0 "numpy==2.2.6; python_version<'3.11'" "numpy==2.4.2; python_version>='3.11'"
+          python3 -m pip install --user onnx==1.22.0 "numpy==2.2.6; python_version<'3.11'" "numpy==2.4.2; python_version>='3.11'"
         displayName: Install onnx for node-test materialization
 
       - script: |

--- a/tools/ci_build/github/azure-pipelines/linux-qnn-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-qnn-ci-pipeline.yml
@@ -78,6 +78,7 @@ jobs:
             --use_qnn $(QnnLibKind) \
             --qnn_home $(QnnSDKRootDir) \
             --cmake_generator=Ninja \
+            --cmake_extra_defines onnxruntime_MATERIALIZE_ONNX_NODE_TESTS=ON \
             --update --build --parallel --use_vcpkg --use_vcpkg_ms_internal_asset_cache
         displayName: Build QNN EP
 

--- a/tools/ci_build/github/azure-pipelines/win-qnn-arm64-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-qnn-arm64-ci-pipeline.yml
@@ -74,6 +74,13 @@ jobs:
       addToPath: true
       architecture: $(buildArch)
 
+  # onnx (pinned to cmake/deps.txt) + numpy (pinned to requirements.txt, python-conditional) are
+  # required at configure time by the onnxruntime_MATERIALIZE_ONNX_NODE_TESTS gate, which
+  # regenerates the onnx node-test corpus into the build tree (onnx_node_tests/node) for
+  # onnx_test_runner. The numpy markers self-select the same pin the CMake gate asserts.
+  - script: python -m pip install onnx==1.22.0 "numpy==2.2.6; python_version<'3.11'" "numpy==2.4.2; python_version>='3.11'"
+    displayName: Install onnx for node-test materialization
+
   - task: NuGetToolInstaller@1
     inputs:
       versionSpec: 6.4.x
@@ -107,7 +114,10 @@ jobs:
     displayName: 'Run unit tests'
 
   - script: |
-     .\$(BuildConfig)\onnx_test_runner -j 1 -v -e qnn -i "backend_path|$(QnnSDKRootDir)\lib\aarch64-windows-msvc\QnnCpu.dll" $(Build.SourcesDirectory)\cmake\external\onnx\onnx\backend\test\data\node
+     rem onnx#7959 collapse sentinel: -m 1 fails loud if 0 node tests are collected (e.g. a
+     rem MATERIALIZE=OFF leg still running this dir). Low value (not the 1500 build floor)
+     rem because -e qnn legitimately reduces the set to ~1529; strict count enforced at build via --min-cases.
+     .\$(BuildConfig)\onnx_test_runner -j 1 -v -m 1 -e qnn -i "backend_path|$(QnnSDKRootDir)\lib\aarch64-windows-msvc\QnnCpu.dll" $(Build.BinariesDirectory)\$(BuildConfig)\onnx_node_tests\node
     workingDirectory: '$(Build.BinariesDirectory)\$(BuildConfig)'
     displayName: 'Run ONNX Tests'
 

--- a/tools/ci_build/github/azure-pipelines/win-qnn-arm64-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/win-qnn-arm64-ci-pipeline.yml
@@ -100,6 +100,7 @@ jobs:
         --build_shared_lib --use_vcpkg --use_vcpkg_ms_internal_asset_cache
         --use_qnn $(QnnLibKind)
         --qnn_home $(QnnSDKRootDir)
+        --cmake_extra_defines onnxruntime_MATERIALIZE_ONNX_NODE_TESTS=ON
         --update --build --parallel $(ExtraQnnBuildArgs)
 
   - script: |

--- a/tools/python/compare_node_test_corpora.py
+++ b/tools/python/compare_node_test_corpora.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+"""Byte-equivalence comparator for ONNX node-test corpora.
+
+This is the CANONICAL, build-wired equivalence check (the ``onnx_node_tests_equivalence``
+ctest invokes it): it compares an ALREADY-materialized node-test tree against the
+on-disk ONNX oracle corpus (``.../onnx/backend/test/data/node``, present only below
+onnx/onnx#7959) WITHOUT regenerating anything, so it validates the exact artifact
+``onnx_test_runner`` consumes and cannot race the build-time materialize step.
+
+It is a thin wrapper over the byte/classifier core in
+``materialize_onnx_node_tests.py`` (``compare_to_oracle``), so there is ZERO logic
+duplication. Two sibling entry points share that same core and are documented as
+aliases of THIS canonical check, not independent implementations:
+  * ``materialize_onnx_node_tests.py --oracle-dir`` -- a dev-convenience one-shot
+    (materialize + compare) for local use.
+  * ``onnxruntime/test/python/onnx_node_test_equivalence_test.py`` -- the Python
+    unittest that materializes fresh into a tmpdir to validate generator LOGIC in
+    isolation (Python CI legs); this script validates ARTIFACT INTEGRITY (C++ legs).
+
+Equivalence relation (see ``compare_to_oracle``):
+  * dir-set equality (both directions),
+  * ``model.onnx`` + ``input_*.pb`` byte-identical (hard-fail on diff),
+  * ``output_*.pb`` byte-identical OR within the Class-A float-ULP band (numpy-gen
+    skew -> logged warning), else hard-fail,
+  * a min-count floor so an empty/undersized tree fails loud.
+
+Exit 0 == equivalent (modulo Class A warnings); exit 1 == Class B structural
+mismatch, onnx version skew, dir-set mismatch, or under the floor.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+# Import the byte/classifier core from the sibling materializer.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import materialize_onnx_node_tests as mat
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Byte-compare a materialized node-test tree against the on-disk ONNX oracle.",
+    )
+    p.add_argument(
+        "--oracle",
+        required=True,
+        help="On-disk ONNX oracle: the data/node dir (or a parent containing node/).",
+    )
+    p.add_argument(
+        "--materialized",
+        required=True,
+        help="Materialized tree: the onnx_node_tests/node dir (or a parent containing node/).",
+    )
+    p.add_argument(
+        "--expected-onnx-version",
+        required=True,
+        help="Assert onnx.__version__ equals this (the cmake/deps.txt pin) before comparing.",
+    )
+    p.add_argument(
+        "--expected-numpy-version",
+        default=None,
+        help="Informational/forensic only: logs a WARNING (never fails) on numpy skew.",
+    )
+    p.add_argument(
+        "--min-cases",
+        type=int,
+        default=1,
+        help="Fail loud if fewer than this many cases are present in the materialized tree.",
+    )
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    try:
+        # Version parity first: a skewed wheel produces confusing Class B noise.
+        mat._check_versions(args.expected_onnx_version, args.expected_numpy_version)
+        mat.compare_to_oracle(
+            args.materialized,
+            args.oracle,
+            min_cases=args.min_cases,
+        )
+    except mat.MaterializeError as exc:
+        print(f"[compare_node_test_corpora] {exc}", file=sys.stderr)
+        return 1
+    print(
+        f"[compare_node_test_corpora] EQUIVALENCE OK: materialized tree "
+        f"{args.materialized} is byte-identical to oracle {args.oracle} "
+        f"(modulo <= {mat._CLASS_A_MAX_ULP} ULP Class A float drift)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/python/compare_node_test_corpora.py
+++ b/tools/python/compare_node_test_corpora.py
@@ -22,7 +22,10 @@ aliases of THIS canonical check, not independent implementations:
 
 Equivalence relation (see ``compare_to_oracle``):
   * dir-set equality (both directions),
-  * ``model.onnx`` + ``input_*.pb`` byte-identical (hard-fail on diff),
+  * ``model.onnx`` + ``input_*.pb`` byte-identical (hard-fail on diff), EXCEPT
+    ``input_*.pb`` of the ``test_image_decoder_*`` family -- those are encoded-image
+    blobs whose bytes are codec/env-dependent (and the family is globally excluded
+    downstream), so input-byte divergence there is an accepted, logged, non-fatal class,
   * ``output_*.pb`` byte-identical OR within the Class-A float-ULP band (numpy-gen
     skew -> logged warning), else hard-fail,
   * a min-count floor so an empty/undersized tree fails loud.

--- a/tools/python/materialize_onnx_node_tests.py
+++ b/tools/python/materialize_onnx_node_tests.py
@@ -76,6 +76,19 @@ class MaterializeError(RuntimeError):
 _CLASS_A_MAX_ULP = 4
 
 
+# Accepted-diff class for INPUT artifacts of the image_decoder test family.
+# image_decoder inputs are ENCODED-IMAGE blobs (jpeg/jpeg2k/webp/png/bmp/pnm/tiff),
+# whose exact bytes are codec-/environment-dependent, NOT opset/IR drift. The
+# materializer is deterministic run-to-run (proven), so a byte-divergence here is
+# only ever against the historical on-disk oracle -- a known-non-reproducible class,
+# analogous to the Class-A float-ULP band. All 9 of these cases are ALSO globally
+# excluded in the Python backend series (onnx_backend_test_series filters.jsonc), so
+# their exact input bytes never affect a real test outcome. We therefore ACCEPT
+# input-artifact byte-diffs for this family (dir-set must still match; the case is
+# still materialized), while keeping every other input strictly byte-identical.
+_IMAGE_DECODER_CASE_PREFIX = "test_image_decoder_"
+
+
 # --------------------------------------------------------------------------- #
 # Version / count guards
 # --------------------------------------------------------------------------- #
@@ -180,7 +193,21 @@ def _write_case(case, output_root: str) -> None:
 
     if not case.data_sets:
         raise MaterializeError(f"node case {case.name!r} has no data_sets")
+    n_graph_in = len(case.model.graph.input)
+    n_graph_out = len(case.model.graph.output)
     for i, (inputs, outputs) in enumerate(case.data_sets):
+        # Fail loud BEFORE writing any .pb for this dataset: the writer indexes
+        # graph.input[j]/graph.output[j] per collected value, so more collected
+        # values than graph arity would raise a bare IndexError mid-write (not
+        # caught by main's MaterializeError handler) and leave a partial tree.
+        if len(inputs) > n_graph_in or len(outputs) > n_graph_out:
+            raise MaterializeError(
+                f"node case {case.name!r} data_set {i}: arity mismatch -- collected "
+                f"{len(inputs)} input(s)/{len(outputs)} output(s) but the model graph "
+                f"declares {n_graph_in} input(s)/{n_graph_out} output(s). The ONNX "
+                f"generator produced a fixture the model shape cannot address; refusing "
+                f"to write a partial/misaligned tree."
+            )
         data_set_dir = os.path.join(output_dir, f"test_data_set_{i}")
         _prepare_dir(data_set_dir)
         # `input` shadows a builtin but is VERBATIM from ONNX cmd_tools.py -- do not rename.
@@ -228,11 +255,12 @@ def materialize(
     """
     _check_versions(expected_onnx, expected_numpy)
     cases = _collect_node_cases()
-    if len(cases) < min_cases:
+    if not cases:
+        # Total generator breakage (e.g. an ONNX API change): fail loud BEFORE
+        # touching disk so we never destroy an existing tree over an empty collect.
         raise MaterializeError(
-            f"only {len(cases)} node cases collected (< floor {min_cases}). A silently "
-            f"empty/undersized materialization would ship an un-guarded, still-green "
-            f"test suite. Refusing to write."
+            "collect_testcases returned no cases at all -- the ONNX node-test "
+            "generator API likely changed. Refusing to touch the output tree."
         )
     node_root = os.path.join(output_root, "node")
     if os.path.exists(node_root):
@@ -245,6 +273,15 @@ def materialize(
         _write_case(case, output_root)
         written.append(case.name)
     written.sort()
+    # Authoritative floor: assert on the WRITTEN node count (post kind-filter), not
+    # the pre-filter collected count. A silently empty/undersized materialization
+    # would ship an un-guarded, still-green test suite.
+    if len(written) < min_cases:
+        raise MaterializeError(
+            f"only {len(written)} node case(s) written (< floor {min_cases}); "
+            f"{len(cases)} case(s) were collected before the kind filter. Refusing to "
+            f"ship an un-guarded, still-green node-test tree."
+        )
     return written
 
 
@@ -319,26 +356,47 @@ def _classify_tensor_diff(a_path: str, b_path: str) -> tuple[str, str]:
 
 
 def _max_ulp_diff(a, b) -> int:
-    """Max ULP distance between two same-shape float arrays."""
+    """Max ULP distance between two same-shape float arrays.
+
+    Maps each float to a monotonic "sortable" magnitude key computed in the
+    UNSIGNED bit domain, then measures the max absolute key distance. Using a
+    sign-magnitude fold (``signmask +/- magnitude``) merges signed zeros (so
+    ``+0.0`` and ``-0.0`` are 0 ULP apart) and never overflows -- the previous
+    signed ``sign_bit - ia`` fold wrapped int64 for negative operands (e.g. fp32
+    ``-0.0`` vs ``+0.0`` reported 2**32 instead of 0). Keys are promoted to
+    Python ints (object dtype) before subtraction so even float64 (64-bit) key
+    distances cannot overflow.
+
+    float16/float32/float64 are handled exactly. Other float kinds (e.g.
+    ml_dtypes bfloat16) have no matching fixed-width unsigned view here; the
+    caller classifies them as Class B before calling, and the fall-through
+    returns an out-of-band sentinel so an accidental call can never look Class A.
+    """
     import numpy as np  # noqa: PLC0415
 
-    if a.dtype == np.float32:
-        ia = a.view(np.int32).astype(np.int64)
-        ib = b.view(np.int32).astype(np.int64)
-        sign_bit = np.int64(1) << 31
+    if a.dtype == np.float16:
+        uint, width = np.uint16, 16
+    elif a.dtype == np.float32:
+        uint, width = np.uint32, 32
     elif a.dtype == np.float64:
-        ia = a.view(np.int64).astype(np.int64)
-        ib = b.view(np.int64).astype(np.int64)
-        sign_bit = np.int64(1) << 63
+        uint, width = np.uint64, 64
     else:
-        # float16 / bfloat16 etc: fall back to a coarse bit compare.
-        ia = a.view(np.uint16).astype(np.int64)
-        ib = b.view(np.uint16).astype(np.int64)
-        sign_bit = np.int64(1) << 15
-    # Map to monotonic ordering so ULP distance is well-defined across zero.
-    ia = np.where(ia < 0, sign_bit - ia, ia)
-    ib = np.where(ib < 0, sign_bit - ib, ib)
-    return int(np.max(np.abs(ia - ib))) if ia.size else 0
+        return _CLASS_A_MAX_ULP + 1
+
+    signmask = 1 << (width - 1)
+    magmask = signmask - 1
+
+    def _key(arr):
+        # Promote raw bits to Python ints (object dtype) => overflow-proof.
+        u = np.ascontiguousarray(arr).view(uint).astype(object)
+        mag = u & magmask
+        neg = (u & signmask) != 0
+        # Sign-magnitude fold: negatives descend below signmask, non-negatives
+        # ascend above it; both zeros collapse to exactly signmask.
+        return np.where(neg, signmask - mag, signmask + mag)
+
+    d = np.abs(_key(a) - _key(b))
+    return int(np.max(d)) if d.size else 0
 
 
 def compare_to_oracle(materialized_root: str, oracle_root: str, min_cases: int = 1) -> None:
@@ -374,6 +432,7 @@ def compare_to_oracle(materialized_root: str, oracle_root: str, min_cases: int =
 
     class_b: list[str] = []
     class_a: list[str] = []
+    class_img: list[str] = []
     for case in sorted(mat_cases):
         mat_dir = os.path.join(mat_node, case)
         ora_dir = os.path.join(ora_node, case)
@@ -407,7 +466,15 @@ def compare_to_oracle(materialized_root: str, oracle_root: str, min_cases: int =
                     f"{_classify_model_diff(mp, op)} (Class B: onnx-version skew)"
                 )
             else:
-                # input_*.pb or any other artifact: strict byte-identity required.
+                # input_*.pb or any other artifact: strict byte-identity required,
+                # EXCEPT encoded-image inputs of the image_decoder family, whose bytes
+                # are codec/env-dependent and globally excluded downstream (see
+                # _IMAGE_DECODER_CASE_PREFIX). Those are an accepted, non-load-bearing
+                # class; every other input must still match byte-for-byte.
+                is_input_tensor = base.startswith("input_") and base.endswith(".pb")
+                if is_input_tensor and case.startswith(_IMAGE_DECODER_CASE_PREFIX):
+                    class_img.append(f"{case}/{rel}: encoded-image input bytes differ (codec/env-dependent)")
+                    continue
                 class_b.append(f"{case}/{rel}: input/artifact bytes differ (Class B)")
 
     if class_a:
@@ -418,6 +485,18 @@ def compare_to_oracle(materialized_root: str, oracle_root: str, min_cases: int =
             file=sys.stderr,
         )
         for line in class_a[:20]:
+            print(f"    {line}", file=sys.stderr)
+
+    if class_img:
+        # Non-fatal: encoded-image inputs are codec/env-dependent and globally
+        # excluded downstream, so byte-divergence from the historical oracle is
+        # expected and non-load-bearing (see _IMAGE_DECODER_CASE_PREFIX).
+        print(
+            f"[materialize_onnx_node_tests] WARNING: {len(class_img)} image_decoder input "
+            f"artifact(s) differ from the oracle (codec/env-dependent encoded bytes, accepted):",
+            file=sys.stderr,
+        )
+        for line in class_img[:20]:
             print(f"    {line}", file=sys.stderr)
 
     if class_b:

--- a/tools/python/materialize_onnx_node_tests.py
+++ b/tools/python/materialize_onnx_node_tests.py
@@ -1,0 +1,539 @@
+#!/usr/bin/env python
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+"""Materialize ONNX node-test artifacts from ONNX's Python generators.
+
+ONNX PR onnx/onnx#7959 deletes the on-disk node-test corpus
+(``onnx/backend/test/data/node/**``) that ONNX Runtime's C++ ``onnx_test_runner``
+consumes as a golden oracle for operator kernels. This script detaches ORT from
+those shipped ``.pb`` artifacts by regenerating an identical tree at build time
+from ONNX's *surviving* Python generators (``collect_testcases``), so ORT keeps
+its per-operator guard regardless of what ONNX ships on disk.
+
+Entry points:
+
+* ``materialize`` (default) -- write ``<out>/node/<case>/model.onnx`` +
+  ``test_data_set_*/{input,output}_k.pb`` mirroring ONNX's exact on-disk layout.
+* ``--oracle-dir`` -- a DEV-CONVENIENCE alias that materializes and then
+  byte-compares in one shot. The CANONICAL equivalence check wired into the
+  build is the sibling ``compare_node_test_corpora.py`` (which compares the
+  ALREADY-materialized build artifact against the oracle without regenerating
+  it); this ``--oracle-dir`` path exists only for a quick one-command local
+  check and shares the same ``compare_to_oracle`` core, so the two never drift.
+  Both classify any mismatch (Class A = <=4-ULP numpy-recompute drift;
+  Class B = structural onnx-version skew) and both retire when the oracle is gone.
+
+MANDATORY correctness guards (run before any generation):
+  * ``onnx.__version__ == --expected-onnx-version`` -- HARD FAIL. The model
+    opset/IR is stamped from the *compiled* schema registry
+    (``get_schema().since_version``), so a mismatched wheel silently bakes the
+    wrong opset into ``model.onnx``. Compared on the release base so a pre-release
+    (``rcN`` / ``.dev``) wheel of the pinned tag does not false-FATAL.
+  * ``numpy.__version__`` vs ``--expected-numpy-version`` -- SOFT WARNING only,
+    never a hard gate. ONNX's own corpus-gen numpy is uncontrollable/unknowable,
+    so a fixed pin cannot guarantee byte-identity and a FATAL would false-red on
+    a legitimate numpy. numpy correctness rests on requirements.txt + the Class-A
+    ULP band pre-#7959, and on requirements.txt alone post-retirement. The flag
+    is an informational/forensic value, not an assert.
+  * ``len(cases) >= --min-cases`` -- a silently-empty materialization
+    (e.g. an API change that makes ``collect_testcases`` return nothing) must
+    fail loud instead of shipping an un-guarded, still-green test suite.
+
+The writer body (the 4-branch container dispatch on the graph value type:
+map -> from_dict, sequence -> from_list, optional -> from_optional,
+tensor -> from_array / SerializeToString) is vendored **verbatim** from ONNX's
+``onnx/backend/test/cmd_tools.py::generate_data`` -- the exact routine #7959
+removes. It must NOT be simplified to a ``from_array``-only path: doing so would
+silently mis-serialize Sequence / Map / Optional fixtures.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import shutil
+import sys
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+
+class MaterializeError(RuntimeError):
+    """Raised on a fail-loud condition (version skew, empty corpus, arity mismatch)."""
+
+
+# Class A (accepted numpy-gen skew) band for recomputed FLOAT OUTPUT tensors.
+# When model.onnx and all inputs are byte-identical, any output difference is by
+# construction pure numpy-recompute drift of the reference output. Inverse-trig /
+# transcendental references (acos/acosh/asin/asinh/atan/atanh) legitimately differ
+# by a few ULP across numpy versions -- empirically 1-2 ULP for the 6 inverse-trig
+# node cases in the v1.22.0 corpus. Band at 4 (2x the observed max) for margin:
+# tight enough that a real structural/opset regression (which changes model.onnx,
+# shape/dtype, or produces large value drift) blows well past it and stays Class B.
+_CLASS_A_MAX_ULP = 4
+
+
+# --------------------------------------------------------------------------- #
+# Version / count guards
+# --------------------------------------------------------------------------- #
+def _release_base(version: str) -> str:
+    """Return the release base (major.minor.micro) of a possibly-prerelease version.
+
+    The ONNX opset-bump workflow ships release-candidate / dev wheels like
+    ``1.23.0rc1`` or ``1.23.0.dev20240101`` whose COMPILED opset registry already
+    matches the formal ``1.23.0`` tag. Comparing on the release base lets an RC
+    wheel of the pinned tag pass, while a genuine major/minor/micro mismatch
+    (e.g. ``1.22.0`` vs ``1.23.0``) still fails loud.
+    """
+    m = re.match(r"^\s*(\d+)\.(\d+)\.(\d+)", version)
+    return ".".join(m.groups()) if m else version.strip()
+
+
+def _check_versions(expected_onnx: str, expected_numpy: str | None) -> None:
+    """Assert wheel parity BEFORE importing/collecting cases.
+
+    Must run before ``collect_testcases`` because ``expect()`` stamps the model
+    opset from the compiled schema registry at collect time.
+
+    onnx is a HARD gate (a mismatched wheel bakes the wrong opset); numpy is a
+    SOFT warning only (see below).
+
+    CAVEAT: the onnx gate compares ``onnx.__version__`` and so assumes that string
+    is truthful. An editable / ``-e`` / dev onnx install can report a STALE
+    ``__version__`` that disagrees with the actually-compiled schema registry,
+    silently defeating the assert. Normal pip-wheel CI installs (what the build
+    uses) report a truthful version, so this is a local-dev caveat, not a CI gap.
+    """
+    import numpy  # noqa: PLC0415
+    import onnx  # noqa: PLC0415
+
+    # onnx: HARD FAIL, RC/pre-release aware (compare release base, not the raw
+    # string) so an rcN/dev wheel of the pinned tag isn't a false FATAL.
+    if expected_onnx and _release_base(onnx.__version__) != _release_base(expected_onnx):
+        raise MaterializeError(
+            f"onnx version mismatch: installed onnx=={onnx.__version__} but "
+            f"--expected-onnx-version=={expected_onnx} (release base "
+            f"{_release_base(onnx.__version__)} != {_release_base(expected_onnx)}). "
+            f"The node-test corpus opset/IR is baked from the COMPILED onnx schema "
+            f"registry, so a mismatched wheel produces a silently-drifted corpus. "
+            f"Install onnx=={expected_onnx} (the cmake/deps.txt pin) before materializing. "
+            f"A pre-release (rcN/.dev) of the SAME release base is accepted."
+        )
+    # numpy: SOFT WARNING, never a hard gate. ONNX's OWN corpus-gen numpy is
+    # uncontrollable and unknowable, so a fixed pin can neither guarantee
+    # byte-identity nor justify a FATAL (it would false-red on a legitimate
+    # numpy). numpy correctness rests on requirements.txt + the Class-A ULP band
+    # pre-#7959, and on requirements.txt alone post-retirement. The value is
+    # informational/forensic -- treat --expected-numpy-version as advisory.
+    if expected_numpy and numpy.__version__ != expected_numpy:
+        print(
+            f"[materialize_onnx_node_tests] WARNING: numpy version skew: installed "
+            f"numpy=={numpy.__version__} but --expected-numpy-version=={expected_numpy}. "
+            f"Informational only -- recomputed float outputs are numpy-sensitive, but the "
+            f"Class-A ULP band absorbs small drift and the corpus-gen numpy is set by ONNX, "
+            f"not ORT. Not failing.",
+            file=sys.stderr,
+        )
+
+
+def _collect_node_cases() -> list:
+    """Return all node test cases (op_type=None) via ONNX's public collector.
+
+    ``collect_testcases`` self-invokes ``import_recursive`` so this is
+    self-contained and era-agnostic (works pre- and post-#7959).
+
+    Post-#7959 (ONNX >= 1.23), the blessed public accessor is
+    ``onnx.backend.test.loader.load_model_tests(kind="node")``, which returns the
+    same in-memory ``TestCase`` list -- so only this collection call swaps, the
+    writer below is unaffected. It does NOT exist on the pinned onnx 1.22, so do
+    not import it here yet; swap the import if ``collect_testcases`` is removed.
+    """
+    from onnx.backend.test.case.node import collect_testcases  # noqa: PLC0415
+
+    return list(collect_testcases(None))
+
+
+# --------------------------------------------------------------------------- #
+# Writer -- vendored VERBATIM from onnx/backend/test/cmd_tools.py::generate_data
+# (the 4-branch container dispatch, inputs + outputs). Do NOT simplify.
+# --------------------------------------------------------------------------- #
+def _prepare_dir(path: str) -> None:
+    if os.path.exists(path):
+        shutil.rmtree(path)
+    os.makedirs(path)
+
+
+def _write_case(case, output_root: str) -> None:
+    from onnx import TensorProto, numpy_helper  # noqa: PLC0415
+
+    # case.name already carries the "test_" prefix; case.kind == "node".
+    output_dir = os.path.join(output_root, case.kind, case.name)
+    _prepare_dir(output_dir)
+
+    if not case.model:
+        raise MaterializeError(f"node case {case.name!r} has no model")
+    with open(os.path.join(output_dir, "model.onnx"), "wb") as f:
+        f.write(case.model.SerializeToString())
+
+    if not case.data_sets:
+        raise MaterializeError(f"node case {case.name!r} has no data_sets")
+    for i, (inputs, outputs) in enumerate(case.data_sets):
+        data_set_dir = os.path.join(output_dir, f"test_data_set_{i}")
+        _prepare_dir(data_set_dir)
+        # `input` shadows a builtin but is VERBATIM from ONNX cmd_tools.py -- do not rename.
+        for j, input in enumerate(inputs):
+            with open(os.path.join(data_set_dir, f"input_{j}.pb"), "wb") as f:
+                if case.model.graph.input[j].type.HasField("map_type"):
+                    f.write(numpy_helper.from_dict(input, case.model.graph.input[j].name).SerializeToString())
+                elif case.model.graph.input[j].type.HasField("sequence_type"):
+                    f.write(numpy_helper.from_list(input, case.model.graph.input[j].name).SerializeToString())
+                elif case.model.graph.input[j].type.HasField("optional_type"):
+                    f.write(numpy_helper.from_optional(input, case.model.graph.input[j].name).SerializeToString())
+                else:
+                    assert case.model.graph.input[j].type.HasField("tensor_type")
+                    if isinstance(input, TensorProto):
+                        f.write(input.SerializeToString())
+                    else:
+                        f.write(numpy_helper.from_array(input, case.model.graph.input[j].name).SerializeToString())
+        # `output` shadows a builtin but is VERBATIM from ONNX cmd_tools.py -- do not rename.
+        for j, output in enumerate(outputs):
+            with open(os.path.join(data_set_dir, f"output_{j}.pb"), "wb") as f:
+                if case.model.graph.output[j].type.HasField("map_type"):
+                    f.write(numpy_helper.from_dict(output, case.model.graph.output[j].name).SerializeToString())
+                elif case.model.graph.output[j].type.HasField("sequence_type"):
+                    f.write(numpy_helper.from_list(output, case.model.graph.output[j].name).SerializeToString())
+                elif case.model.graph.output[j].type.HasField("optional_type"):
+                    f.write(numpy_helper.from_optional(output, case.model.graph.output[j].name).SerializeToString())
+                else:
+                    assert case.model.graph.output[j].type.HasField("tensor_type")
+                    if isinstance(output, TensorProto):
+                        f.write(output.SerializeToString())
+                    else:
+                        f.write(numpy_helper.from_array(output, case.model.graph.output[j].name).SerializeToString())
+
+
+def materialize(
+    output_root: str,
+    expected_onnx: str,
+    expected_numpy: str | None = None,
+    min_cases: int = 1,
+) -> list[str]:
+    """Materialize the node-test tree under ``<output_root>/node/``.
+
+    Returns the sorted list of case names written. Raises ``MaterializeError``
+    on version skew, empty corpus, or an arity mismatch.
+    """
+    _check_versions(expected_onnx, expected_numpy)
+    cases = _collect_node_cases()
+    if len(cases) < min_cases:
+        raise MaterializeError(
+            f"only {len(cases)} node cases collected (< floor {min_cases}). A silently "
+            f"empty/undersized materialization would ship an un-guarded, still-green "
+            f"test suite. Refusing to write."
+        )
+    node_root = os.path.join(output_root, "node")
+    if os.path.exists(node_root):
+        shutil.rmtree(node_root)
+    os.makedirs(node_root, exist_ok=True)
+    written = []
+    for case in cases:
+        if case.kind != "node":
+            continue
+        _write_case(case, output_root)
+        written.append(case.name)
+    written.sort()
+    return written
+
+
+# --------------------------------------------------------------------------- #
+# Equivalence check -- byte compare materialized tree vs on-disk oracle
+# --------------------------------------------------------------------------- #
+def _list_case_dirs(node_root: str) -> set[str]:
+    if not os.path.isdir(node_root):
+        return set()
+    return {name for name in os.listdir(node_root) if os.path.isdir(os.path.join(node_root, name))}
+
+
+def _resolve_node_dir(path: str) -> str:
+    """Normalize a corpus path to the ``node/`` directory.
+
+    Accepts either the ``node/`` dir itself (contains ``test_*`` case dirs) or a
+    parent that contains a ``node/`` subdir. Lets callers pass either form.
+    """
+    if os.path.isdir(path) and any(name.startswith("test_") for name in os.listdir(path)):
+        return path
+    return os.path.join(path, "node")
+
+
+def _iter_files(root: str) -> Iterable[str]:
+    for dirpath, _dirnames, filenames in os.walk(root):
+        for fn in sorted(filenames):
+            yield os.path.relpath(os.path.join(dirpath, fn), root)
+
+
+def _classify_tensor_diff(a_path: str, b_path: str) -> tuple[str, str]:
+    """Classify a mismatching .pb pair. Returns (class, human message).
+
+    Class A: recomputed float tensor within the numpy-gen ULP band (accepted,
+    pass-with-warning). Class B: structural / out-of-band / non-float /
+    unparseable (hard-fail).
+    """
+    try:
+        import numpy as np  # noqa: PLC0415
+        from onnx import TensorProto, numpy_helper  # noqa: PLC0415
+
+        def _load(p):
+            with open(p, "rb") as f:
+                t = TensorProto()
+                t.ParseFromString(f.read())
+            return numpy_helper.to_array(t)
+
+        a = _load(a_path)
+        b = _load(b_path)
+        if a.shape != b.shape or a.dtype != b.dtype:
+            return "B", f"shape/dtype differ: {a.shape}/{a.dtype} vs {b.shape}/{b.dtype}"
+        if np.array_equal(a, b):
+            # equal arrays w/ differing bytes => nondeterministic serialization;
+            # fail to preserve byte-reproducibility.
+            # Bytes differ yet decoded arrays are equal -> the PROTO ENCODING
+            # drifted (field order, raw_data vs typed field, default-value
+            # elision). Byte-identity is the contract, so this is a real (Class B)
+            # failure, not tolerable numpy float skew.
+            return "B", "bytes differ but arrays equal (proto encoding drift)"
+        if not np.issubdtype(a.dtype, np.floating):
+            return "B", "non-float tensor values differ (real regression)"
+        with np.errstate(over="ignore", invalid="ignore"):
+            ulp = _max_ulp_diff(a, b)
+        max_abs = float(np.nanmax(np.abs(a.astype(np.float64) - b.astype(np.float64))))
+        if ulp <= _CLASS_A_MAX_ULP:
+            return (
+                "A",
+                f"float outputs differ by {ulp} ULP (<= {_CLASS_A_MAX_ULP}, max|d|={max_abs:.3e}); numpy-gen skew",
+            )
+        return "B", f"float outputs differ by {ulp} ULP (max|d|={max_abs:.3e}); real drift"
+    except Exception as exc:  # diagnostic path, never the pass criterion
+        return "B", f"could not classify (treated as structural): {exc}"
+
+
+def _max_ulp_diff(a, b) -> int:
+    """Max ULP distance between two same-shape float arrays."""
+    import numpy as np  # noqa: PLC0415
+
+    if a.dtype == np.float32:
+        ia = a.view(np.int32).astype(np.int64)
+        ib = b.view(np.int32).astype(np.int64)
+        sign_bit = np.int64(1) << 31
+    elif a.dtype == np.float64:
+        ia = a.view(np.int64).astype(np.int64)
+        ib = b.view(np.int64).astype(np.int64)
+        sign_bit = np.int64(1) << 63
+    else:
+        # float16 / bfloat16 etc: fall back to a coarse bit compare.
+        ia = a.view(np.uint16).astype(np.int64)
+        ib = b.view(np.uint16).astype(np.int64)
+        sign_bit = np.int64(1) << 15
+    # Map to monotonic ordering so ULP distance is well-defined across zero.
+    ia = np.where(ia < 0, sign_bit - ia, ia)
+    ib = np.where(ib < 0, sign_bit - ib, ib)
+    return int(np.max(np.abs(ia - ib))) if ia.size else 0
+
+
+def compare_to_oracle(materialized_root: str, oracle_root: str, min_cases: int = 1) -> None:
+    """Byte-compare the materialized node tree against the on-disk oracle.
+
+    Pass criterion:
+      * dir-set equality (both directions),
+      * per-case byte-identity of model.onnx + input_*.pb (hard),
+      * per-case byte-identity of output_*.pb, OR <=4-ULP float drift (Class A warn),
+      * >= ``min_cases`` cases present.
+
+    Raises ``MaterializeError`` with an actionable, classified message on failure.
+    """
+    mat_node = _resolve_node_dir(materialized_root)
+    ora_node = _resolve_node_dir(oracle_root)
+
+    mat_cases = _list_case_dirs(mat_node)
+    ora_cases = _list_case_dirs(ora_node)
+
+    if len(mat_cases) < min_cases:
+        raise MaterializeError(f"materialized corpus has {len(mat_cases)} cases (< floor {min_cases})")
+
+    only_oracle = sorted(ora_cases - mat_cases)
+    only_mat = sorted(mat_cases - ora_cases)
+    if only_oracle or only_mat:
+        raise MaterializeError(
+            "dir-set mismatch between materialized tree and oracle:\n"
+            f"  {len(only_oracle)} oracle-only (missing from materialization): "
+            f"{only_oracle[:10]}{' ...' if len(only_oracle) > 10 else ''}\n"
+            f"  {len(only_mat)} materialized-only (not in oracle): "
+            f"{only_mat[:10]}{' ...' if len(only_mat) > 10 else ''}"
+        )
+
+    class_b: list[str] = []
+    class_a: list[str] = []
+    for case in sorted(mat_cases):
+        mat_dir = os.path.join(mat_node, case)
+        ora_dir = os.path.join(ora_node, case)
+        mat_files = set(_iter_files(mat_dir))
+        ora_files = set(_iter_files(ora_dir))
+        if mat_files != ora_files:
+            class_b.append(
+                f"{case}: file-set differs (+{sorted(mat_files - ora_files)} / -{sorted(ora_files - mat_files)})"
+            )
+            continue
+        for rel in sorted(mat_files):
+            mp = os.path.join(mat_dir, rel)
+            op = os.path.join(ora_dir, rel)
+            with open(mp, "rb") as f:
+                mb = f.read()
+            with open(op, "rb") as f:
+                ob = f.read()
+            if mb == ob:
+                continue
+            base = os.path.basename(rel)
+            is_output_tensor = base.startswith("output_") and base.endswith(".pb")
+            if is_output_tensor:
+                cls, msg = _classify_tensor_diff(mp, op)
+                if cls == "A":
+                    class_a.append(f"{case}/{rel}: {msg}")
+                    continue
+                class_b.append(f"{case}/{rel}: {msg}")
+            elif base == "model.onnx":
+                class_b.append(
+                    f"{case}/{rel}: model.onnx bytes differ -- "
+                    f"{_classify_model_diff(mp, op)} (Class B: onnx-version skew)"
+                )
+            else:
+                # input_*.pb or any other artifact: strict byte-identity required.
+                class_b.append(f"{case}/{rel}: input/artifact bytes differ (Class B)")
+
+    if class_a:
+        # Non-fatal: log to stderr so a maintainer sees numpy-gen skew explicitly.
+        print(
+            f"[materialize_onnx_node_tests] WARNING: {len(class_a)} case(s) differ by "
+            f"<= {_CLASS_A_MAX_ULP} float ULP (Class A numpy-gen skew, accepted):",
+            file=sys.stderr,
+        )
+        for line in class_a[:20]:
+            print(f"    {line}", file=sys.stderr)
+
+    if class_b:
+        detail = "\n".join(f"    {line}" for line in class_b[:30])
+        more = "" if len(class_b) <= 30 else f"\n    ... and {len(class_b) - 30} more"
+        raise MaterializeError(
+            f"EQUIVALENCE FAILED: {len(class_b)} Class B (structural) mismatch(es) between "
+            f"the materialized tree and the on-disk oracle. Class B means a real corpus "
+            f"drift -- most likely an onnx-version skew (installed wheel != cmake/deps.txt "
+            f"pin) baking a different opset/IR into model.onnx. Fix the onnx pin parity.\n"
+            f"{detail}{more}"
+        )
+
+
+def _classify_model_diff(mat_path: str, ora_path: str) -> str:
+    try:
+        import onnx  # noqa: PLC0415
+
+        m = onnx.load(mat_path)
+        o = onnx.load(ora_path)
+        mo = {i.domain or "ai.onnx": i.version for i in m.opset_import}
+        oo = {i.domain or "ai.onnx": i.version for i in o.opset_import}
+        return (
+            f"opset {mo} vs {oo}; IR {m.ir_version} vs {o.ir_version}; nodes {len(m.graph.node)} vs {len(o.graph.node)}"
+        )
+    except Exception as exc:
+        return f"(unparseable: {exc})"
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Materialize ONNX node-test artifacts from ONNX Python generators.",
+    )
+    p.add_argument(
+        "--out",
+        "--output",
+        dest="out",
+        required=True,
+        help="Output root; writes <out>/node/<case>/... mirroring ONNX's layout.",
+    )
+    p.add_argument(
+        "--expected-onnx-version",
+        required=True,
+        help="Assert onnx.__version__ equals this (the cmake/deps.txt pin). MANDATORY.",
+    )
+    p.add_argument(
+        "--expected-numpy-version",
+        default=None,
+        help="Informational/forensic only: logs a WARNING (never fails) if "
+        "numpy.__version__ differs. numpy is not a hard gate -- ONNX controls the "
+        "corpus-gen numpy and the Class-A ULP band absorbs small drift.",
+    )
+    p.add_argument(
+        "--min-cases",
+        type=int,
+        default=1,
+        help="Fail loud if fewer than this many node cases are collected/compared.",
+    )
+    p.add_argument(
+        "--oracle-dir",
+        default=None,
+        help="DEV-CONVENIENCE alias: if set, materialize then byte-compare against "
+        "this on-disk oracle in one command. The build wires the CANONICAL check via "
+        "compare_node_test_corpora.py (compares the existing artifact, no regeneration); "
+        "this flag shares the same compare_to_oracle core for quick local use.",
+    )
+    p.add_argument(
+        "--stamp",
+        default=None,
+        help="Touch this file LAST, only after a full successful write, so a partial "
+        "tree never satisfies a build stamp.",
+    )
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    if not args.expected_numpy_version:
+        print(
+            "[materialize_onnx_node_tests] WARNING: --expected-numpy-version not given; "
+            "recomputed float outputs are numpy-sensitive and reproducibility is not guarded.",
+            file=sys.stderr,
+        )
+    # Unlink any pre-existing stamp FIRST, before regeneration. If generation
+    # crashes midway, a stale stamp must not survive to mask a partial/absent tree
+    # as an up-to-date build output; the stamp is re-created LAST only on success.
+    if args.stamp and os.path.exists(args.stamp):
+        os.unlink(args.stamp)
+    try:
+        written = materialize(
+            args.out,
+            expected_onnx=args.expected_onnx_version,
+            expected_numpy=args.expected_numpy_version,
+            min_cases=args.min_cases,
+        )
+        print(f"[materialize_onnx_node_tests] wrote {len(written)} node cases to {os.path.join(args.out, 'node')}")
+        if args.oracle_dir:
+            compare_to_oracle(args.out, args.oracle_dir, min_cases=args.min_cases)
+            print(
+                f"[materialize_onnx_node_tests] EQUIVALENCE OK vs oracle {args.oracle_dir} "
+                f"({len(written)} cases byte-identical modulo <= {_CLASS_A_MAX_ULP}-ULP float drift)"
+            )
+    except MaterializeError as exc:
+        print(f"[materialize_onnx_node_tests] ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    if args.stamp:
+        # Touch LAST: a partial/aborted tree must never satisfy the build stamp.
+        os.makedirs(os.path.dirname(os.path.abspath(args.stamp)), exist_ok=True)
+        with open(args.stamp, "w") as f:
+            f.write(f"{len(written)}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/python/materialize_onnx_node_tests.py
+++ b/tools/python/materialize_onnx_node_tests.py
@@ -55,6 +55,7 @@ import os
 import re
 import shutil
 import sys
+import warnings
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -338,13 +339,29 @@ def _classify_tensor_diff(a_path: str, b_path: str) -> tuple[str, str]:
             # Bytes differ yet decoded arrays are equal -> the PROTO ENCODING
             # drifted (field order, raw_data vs typed field, default-value
             # elision). Byte-identity is the contract, so this is a real (Class B)
-            # failure, not tolerable numpy float skew.
-            return "B", "bytes differ but arrays equal (proto encoding drift)"
+            # failure, not tolerable numpy float skew. NOTE: a pure +0.0/-0.0
+            # flip lands here by design -- ``np.array_equal`` treats the zeros as
+            # equal while the bytes differ, so it is (correctly) a byte/proto
+            # drift, NOT tolerable skew. The signed-zero merging in
+            # ``_max_ulp_diff`` is for MIXED tensors (a co-occurring signed zero
+            # must not inflate the ULP of a genuine sub-band skew); it is not a
+            # claim that a pure sign-of-zero flip passes.
+            return "B", "bytes differ but arrays equal (proto encoding drift or signed-zero flip)"
         if not np.issubdtype(a.dtype, np.floating):
             return "B", "non-float tensor values differ (real regression)"
         with np.errstate(over="ignore", invalid="ignore"):
             ulp = _max_ulp_diff(a, b)
-        max_abs = float(np.nanmax(np.abs(a.astype(np.float64) - b.astype(np.float64))))
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", RuntimeWarning)  # inf/NaN -> All-NaN slice is expected here
+                max_abs = float(np.nanmax(np.abs(a.astype(np.float64) - b.astype(np.float64))))
+        # A raw-bit ULP metric treats max-finite<->inf and inf<->NaN as adjacent
+        # (both are 1 ULP), so a STRUCTURAL finite->inf or inf->NaN output drift
+        # (max|d|=inf/nan) would otherwise be mis-blessed as a tolerable <=4-ULP
+        # numpy skew. A genuine numpy-gen skew never changes the finite/inf/NaN
+        # structure, so require the two arrays to share it -- and the max abs
+        # diff to be finite -- before Class A can apply.
+        if np.any(np.isfinite(a) != np.isfinite(b)) or np.any(np.isnan(a) != np.isnan(b)) or not np.isfinite(max_abs):
+            return "B", f"finite/inf/NaN structure differs (max|d|={max_abs:.3e}); real drift"
         if ulp <= _CLASS_A_MAX_ULP:
             return (
                 "A",
@@ -366,6 +383,19 @@ def _max_ulp_diff(a, b) -> int:
     ``-0.0`` vs ``+0.0`` reported 2**32 instead of 0). Keys are promoted to
     Python ints (object dtype) before subtraction so even float64 (64-bit) key
     distances cannot overflow.
+
+    The signed-zero merge matters for MIXED tensors: a co-occurring ``+0.0``/
+    ``-0.0`` element must not inflate the max ULP of an otherwise genuine
+    sub-band skew. It is NOT a claim that a pure signed-zero-only difference is
+    tolerated -- that case has no other diff, so ``_classify_tensor_diff``
+    catches it upstream via the byte-identity (``np.array_equal``) Class-B gate
+    before this metric is ever consulted.
+
+    NOTE: this raw-bit metric is intentionally NOT finite-aware -- max-finite
+    and ``inf`` (and ``inf`` and the adjacent ``NaN`` bit pattern) are 1 ULP
+    apart here. The caller (``_classify_tensor_diff``) rejects any finite/inf/NaN
+    structural mismatch BEFORE applying the Class-A ULP band, so a finite->inf or
+    inf->NaN drift can never be mis-accepted despite its small raw-bit distance.
 
     float16/float32/float64 are handled exactly. Other float kinds (e.g.
     ml_dtypes bfloat16) have no matching fixed-width unsigned view here; the


### PR DESCRIPTION
### Motivation
ONNX onnx/onnx#7959 removes the on-disk `onnx/backend/test/data/node/` corpus (targeted for ONNX 1.23), replacing it with on-the-fly in-memory generation. ORT's C++ `onnx_test_runner` reads that corpus from disk — after the deletion it would load **0 node tests and silently exit 0** (green CI on a corpus that no longer exists). This PR detaches ORT from the deleted artifacts *ahead* of the bump.

### What this does (3 pieces)
1. **Detach** — a build-time materializer (`tools/python/materialize_onnx_node_tests.py`) regenerates the node corpus to disk from ONNX's surviving generator (`collect_testcases`), so the C++ runner keeps reading from disk unchanged. EP-agnostic (CPU/CUDA/QNN share one materialized tree).
2. **Equivalence proof** — a *retiring* test (`onnxruntime/test/python/onnx_node_test_equivalence_test.py` + `tools/python/compare_node_test_corpora.py`) proves the materialized corpus is byte-identical to the original (modulo a documented ULP band); it auto-skips once the ONNX on-disk oracle disappears post-#7959.
3. **Cause-agnostic tripwire** — build-time `--min-cases` gate (FATALs the build on every MATERIALIZE=ON leg if generation < floor) + a runtime `-m` floor on the CPU node ctest, turning silent-green-on-empty into a loud red.

### Key decisions
- **numpy**: cmake configure = HARD FATAL on off-pin numpy (build-env reproducibility across CI legs); Python materializer = SOFT WARN (standalone advisory). Different layers, different questions. The onnx pin stays HARD on both sides.
- **QNN legs**: repointed to the materialized tree + pinned onnx/numpy installed pre-build. Node-dir runs carry a **low `-m 1` collapse sentinel** (NOT the 1500 build floor): `-e qnn` legitimately reduces the collected set to ~1529, so a 1500 runtime floor would be a false-red timebomb on the next opset bump — the strict count is enforced at build time via `--min-cases`, while `-m 1` (zero false-red risk) catches a per-leg `MATERIALIZE=OFF` that still runs the node dir. The android leg's single-case `cp -r` source is repointed to the materialized tree (the old `data/node` source vanishes post-#7959).

### Testing
- Runtime tripwire empirically verified: empty/truncated corpus → runner FATAL (nonzero); full → exit 0; default (no `-m`) unchanged.
- Equivalence: 1799-case byte-probe (dir-set match; byte-identical modulo the documented ULP band).
- cmake configure verified to generate cleanly on latest main (ep_context + node-test regions coexist, no collisions).
- **[needs-run]** on a pinned-numpy CI box: the `MATERIALIZE=ON` inner path (actual materialization + the two add_test bodies) — this dev box is off-pin so the numpy gate FATALs by design.

Relates to: onnx/onnx#7959


---
## Cross-consumer viability note (re: onnx/onnx#7959)

While detaching, we assessed all of ORT's node-test consumers. The in-memory generator approach behind #7959 works cleanly for **single-version** consumers (C++, C#, docs), but has a gap for consumers needing a **historical multi-opset matrix**:
- ORT's JS/web tests pull node data for opset 7–21 from 15 immutable `rel-*` release archives. Since onnx's generator is single-version, old opsets can't be regenerated from a new onnx.
- Those consumers stay green post-#7959 only because released branches are immutable — there is no generator-based path to add a *new* post-#7959 opset for them.

Net: workable for single-version consumers; the multi-version case would need a small per-version serialization utility or a documented migration note upstream.
---
