### PR TITLE
[webgpu] Enable im2col-matmul for newer Xe platforms; limit to fp16

### DIFF
--- a/onnxruntime/core/providers/webgpu/nn/conv.cc
+++ b/onnxruntime/core/providers/webgpu/nn/conv.cc
@@ -164,7 +164,8 @@ Status Conv<is_channels_last, is_fused>::ComputeInternal(ComputeContext& context
                                   is_channels_last,
                                   activation_.activation_kind_ != ActivationKind::None,
                                   kernel_shape,
-                                  onnxruntime::narrow<uint32_t>(conv_attrs_.group))) {
+                                  onnxruntime::narrow<uint32_t>(conv_attrs_.group),
+                                  kernel->DataType())) {
     return ApplyIm2ColMatMulProgram(context,
                                     is_channels_last,
                                     dilations,
@@ -334,7 +335,8 @@ Status Conv<is_channels_last, is_fused>::PrePackInternal(ComputeContextBase& con
   // kernel directly from context.Input(1), ignoring prepacked weights.
   // Skip prepacking when this path will be used at runtime.
   if (CanApplyIm2ColMatMulProgram(context, is_channels_last, activation_.activation_kind_ != ActivationKind::None,
-                                  kernel_shape, onnxruntime::narrow<uint32_t>(conv_attrs_.group))) {
+                                  kernel_shape, onnxruntime::narrow<uint32_t>(conv_attrs_.group),
+                                  tensor.DataType())) {
     return Status::OK();
   }
 

--- a/onnxruntime/core/providers/webgpu/nn/im2col_matmul.cc
+++ b/onnxruntime/core/providers/webgpu/nn/im2col_matmul.cc
@@ -43,7 +43,10 @@ bool IsDeviceSupported(const ComputeContextBase& context) {
   const wgpu::AdapterInfo& adapter_info = context.AdapterInfo();
 
   if (adapter_info.vendor == std::string_view("intel")) {
-    if (adapter_info.architecture == std::string_view("xe-2lpg")) {
+    if (adapter_info.architecture == std::string_view("xe-2lpg") ||
+        adapter_info.architecture == std::string_view("xe-2hpg") ||
+        adapter_info.architecture == std::string_view("xe-3lpg") ||
+        adapter_info.architecture == std::string_view("xe-3lpg-xs")) {
       return true;
     }
   }
@@ -167,8 +170,15 @@ bool CanApplyIm2ColMatMulProgram(ComputeContextBase& context,
                                  const bool is_channels_last,
                                  const bool is_fused,
                                  const TensorShape weight_shape,
-                                 const uint32_t group) {
+                                 const uint32_t group,
+                                 const MLDataType data_type) {
   if (!IsDeviceSupported(context)) {
+    return false;
+  }
+
+  // The im2col-matmul kernel is performance-tuned for fp16. Use the default
+  // conv path for fp32.
+  if (data_type != DataTypeImpl::GetType<MLFloat16>()) {
     return false;
   }
 

--- a/onnxruntime/core/providers/webgpu/nn/im2col_matmul.h
+++ b/onnxruntime/core/providers/webgpu/nn/im2col_matmul.h
@@ -65,7 +65,8 @@ bool CanApplyIm2ColMatMulProgram(ComputeContextBase& context,
                                  const bool is_channels_last,
                                  const bool is_fused,
                                  const TensorShape kernel_shape,
-                                 const uint32_t group);
+                                 const uint32_t group,
+                                 const MLDataType data_type);
 
 Status ApplyIm2ColMatMulProgram(ComputeContext& context,
                                 const bool is_channels_last,


### PR DESCRIPTION

### Description
- Add xe-2hpg, xe-3lpg, and xe-3lpg-xs to the execution allowlist.
- Gate im2col-matmul on fp16 as the kernel is tuned for it.
- Fall back to default convolution for fp32 and other data types.


### Motivation and Context
See above.


