### PR TITLE
[CUDA] Support attention_bias in GroupQueryAttention via the unfused path

### DIFF
--- a/onnxruntime/contrib_ops/cpu/bert/group_query_attention_helper.h
+++ b/onnxruntime/contrib_ops/cpu/bert/group_query_attention_helper.h
@@ -415,6 +415,12 @@ Status CheckCustomAttentionInputs(const T* position_ids,
 
   if (attention_bias != nullptr) {
     const auto& attn_bias_shape = attention_bias->Shape();
+    // TensorShape::operator[] is unchecked — validate the rank before indexing dims.
+    if (attn_bias_shape.NumDimensions() != 4) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                             "attention_bias must be a 4D tensor, got ", attn_bias_shape.NumDimensions(),
+                             " dimensions");
+    }
     if ((attn_bias_shape[0] != parameters.batch_size) && (attn_bias_shape[0] != 1)) {
       return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
                              "attention_bias dimension 0 must be equal to the batch size or 1, got ", attn_bias_shape[0]);

--- a/onnxruntime/contrib_ops/cuda/bert/attention_data.h
+++ b/onnxruntime/contrib_ops/cuda/bert/attention_data.h
@@ -157,6 +157,11 @@ struct GroupQueryAttentionData {
   const T* sin_cache = nullptr;
   const T* head_sink = nullptr;
 
+  // Optional additive attention bias, shape (batch_size or 1, num_heads or 1, sequence_length,
+  // total_sequence_length). Broadcast on dims 0/1 is carried by
+  // parameters.broadcast_attn_bias_dim_0/1. Only consumed by the unfused fallback path.
+  const T* attention_bias = nullptr;
+
   // Optional per-head Q/K RMSNorm (QK-Norm) weights, shape (head_size,), shared across heads.
   // Both are non-null together (validated in the op) and trigger the fused normalization before RoPE.
   const T* q_norm_weight = nullptr;

--- a/onnxruntime/contrib_ops/cuda/bert/group_query_attention.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/group_query_attention.cc
@@ -205,7 +205,8 @@ Status GroupQueryAttention<T, U>::PrePack(const Tensor& tensor, int input_idx, A
 // 7. cos_cache         (Tensor) - Precomputed cosine table for RoPE
 // 8. sin_cache         (Tensor) - Precomputed sine table for RoPE
 // 9. position_ids      (Tensor) - Position indices for RoPE
-// 10. attention_bias   (Tensor) - Not supported in this kernel
+// 10. attention_bias   (Tensor) [batch or 1, num_heads or 1, sequence_length, total_sequence_length] (Optional)
+//                      Additive bias to QxK'; dispatches to the unfused fallback path.
 // 11. head_sink        (Tensor) - Attention sink for GPT-OSS
 template <typename T, typename U>
 Status GroupQueryAttention<T, U>::ComputeInternal(OpKernelContext* context) const {
@@ -272,9 +273,22 @@ Status GroupQueryAttention<T, U>::ComputeInternal(OpKernelContext* context) cons
     }
   }
 
-  if (attention_bias != nullptr) {
-    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
-                           "attention_bias is not supported in GroupQueryAttention cuda kernel.");
+  // attention_bias runs on the unfused fallback path (the fused kernels below have no bias input),
+  // so the feature combinations that path excludes stay NOT_IMPLEMENTED with the bias present.
+  const bool has_attention_bias = attention_bias != nullptr;
+  if (has_attention_bias) {
+    if (!attention_bias->IsDataType<T>()) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                             "attention_bias type must match GroupQueryAttention input type T.");
+    }
+    if (k_quant_type_ != KVQuantizationType::NONE || v_quant_type_ != KVQuantizationType::NONE) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, NOT_IMPLEMENTED,
+                             "attention_bias with quantized KV cache is not implemented in GroupQueryAttention cuda kernel.");
+    }
+    if (use_smooth_softmax_ || head_sink != nullptr) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, NOT_IMPLEMENTED,
+                             "attention_bias with smooth softmax or head_sink is not implemented in GroupQueryAttention cuda kernel.");
+    }
   }
 
   auto& device_prop = GetDeviceProp();
@@ -310,6 +324,12 @@ Status GroupQueryAttention<T, U>::ComputeInternal(OpKernelContext* context) cons
                                                                                attention_bias,
                                                                                head_sink,
                                                                                parameters));
+
+  if (has_attention_bias) {
+    const auto& bias_dims = attention_bias->Shape().GetDims();
+    parameters.broadcast_attn_bias_dim_0 = bias_dims[0] == 1;
+    parameters.broadcast_attn_bias_dim_1 = bias_dims[1] == 1;
+  }
 
   // Validate and enable the per-head Q/K RMSNorm (QK-Norm) prologue (inputs 14/15). Both weights
   // must be 1D tensors of shape (head_size) with element type T (shared across all heads).
@@ -430,7 +450,9 @@ Status GroupQueryAttention<T, U>::ComputeInternal(OpKernelContext* context) cons
   const bool use_xqa_attention_sinks = head_sink != nullptr && !is_inputs_quantized;
   const bool is_xqa_smooth_softmax_supported = !parameters.use_smooth_softmax || use_xqa_attention_sinks;
   // XQA is enabled when enable_xqa_=true; ineligible shapes/group sizes fall back via data.use_xqa below.
+  // The XQA kernel has no attention_bias input.
   if (enable_xqa_ &&
+      !has_attention_bias &&
       (device_prop.major >= 8) &&
       !parameters.is_first_prompt &&
       parameters.sequence_length == 1 &&
@@ -528,6 +550,7 @@ Status GroupQueryAttention<T, U>::ComputeInternal(OpKernelContext* context) cons
   // no smooth-softmax / head sink, and no sliding window. Rotary and packed QKV are handled by
   // PrepareQKV before the kernel runs; cuDNN handles grouped-query attention natively.
   bool use_cudnn_sdpa = !data.use_xqa &&
+                        !has_attention_bias &&  // GQA's cuDNN path is bottom-right causal, which cuDNN doesn't compose with a bias
                         !is_inputs_quantized &&
                         std::is_same<T, U>::value &&
                         parameters.softcap == 0.0f &&
@@ -551,6 +574,7 @@ Status GroupQueryAttention<T, U>::ComputeInternal(OpKernelContext* context) cons
 #if USE_FLASH_ATTENTION
   bool use_flash_attention = !data.use_xqa &&
                              !data.use_cudnn_sdpa &&
+                             !has_attention_bias &&  // flash_api.h has no bias parameter
                              !disable_flash_attention_ &&
                              onnxruntime::flash::is_supported<T>(device_prop,
                                                                  parameters.head_size,
@@ -640,8 +664,13 @@ Status GroupQueryAttention<T, U>::ComputeInternal(OpKernelContext* context) cons
   if (!data.use_xqa && !data.use_cudnn_sdpa && !data.use_flash_attention) {
     // Fall back to memory efficient attention.
     int sm = (device_prop.major * 10) + device_prop.minor;
+    // With attention_bias, MEA is skipped: the cutlass wrapper computes the bias row stride from
+    // kv_sequence_length, which GQA sets to the KV-cache capacity (seqlen_present_kv_cache), not
+    // the bias row length (total_sequence_length) — mismatched under past/present buffer sharing.
+    // Bias-carrying nodes take the unfused fallback below instead.
     bool use_memory_efficient_attention =
         !disable_memory_efficient_attention_ &&
+        !has_attention_bias &&
         has_memory_efficient_attention(sm, std::is_same<T, MLFloat16>::value, std::is_same<T, BFloat16>::value, parameters.head_size, parameters.head_size);
     data.use_memory_efficient_attention = use_memory_efficient_attention;
 
@@ -742,6 +771,10 @@ Status GroupQueryAttention<T, U>::ComputeInternal(OpKernelContext* context) cons
 
   if (head_sink != nullptr) {
     data.head_sink = reinterpret_cast<const CudaT*>(head_sink->Data<T>());
+  }
+
+  if (has_attention_bias) {
+    data.attention_bias = reinterpret_cast<const CudaT*>(attention_bias->Data<T>());
   }
 
   if (parameters.use_qk_norm) {

--- a/onnxruntime/contrib_ops/cuda/bert/group_query_attention_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/group_query_attention_impl.cu
@@ -1186,8 +1186,10 @@ Status EfficientAttention(
 //
 // Not supported (caller falls through elsewhere):
 //   - Quantized KV cache (U != T): hit by the original NOT_IMPLEMENTED path.
-//   - attention_bias input: rejected by op-level ComputeInternal.
 //   - Smooth softmax / head_sink: Flash-only feature.
+//
+// attention_bias (with dim-0/dim-1 broadcast) is supported here; this is the path
+// bias-carrying GQA nodes are dispatched to, since Flash/XQA/cuDNN don't take a bias.
 // ============================================================================
 template <typename T, typename U>
 Status UnfusedGqaAttention(
@@ -1252,8 +1254,8 @@ Status UnfusedGqaAttention(
   // seqlens to the softmax so positions beyond the valid length are masked.
   p.total_kv_length = parameters.total_sequence_length;
   p.max_kv_length = max_kv;
-  p.broadcast_attn_bias_dim_0 = false;
-  p.broadcast_attn_bias_dim_1 = false;
+  p.broadcast_attn_bias_dim_0 = parameters.broadcast_attn_bias_dim_0;
+  p.broadcast_attn_bias_dim_1 = parameters.broadcast_attn_bias_dim_1;
   p.is_causal = parameters.is_unidirectional;
   p.local_window_size = parameters.local_window_size;  // -1 disables
   p.past_kv_length = parameters.total_sequence_length - parameters.sequence_length;
@@ -1266,7 +1268,7 @@ Status UnfusedGqaAttention(
       data.unfused_q_bnsh,
       reinterpret_cast<const T*>(data.present_key),
       reinterpret_cast<const T*>(data.present_value),
-      /*attn_bias=*/nullptr,
+      data.attention_bias,
       data.unfused_y_bnsh,
       data.unfused_workspace,
       /*output_qk=*/nullptr)));

--- a/onnxruntime/test/contrib_ops/group_query_attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/group_query_attention_op_test.cc
@@ -7,6 +7,7 @@
 #include <optional>
 #include <random>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 #include "gtest/gtest.h"
@@ -2594,6 +2595,136 @@ TEST(GroupQueryAttentionTest, WebGPU_SharedKV_SlidingWindow) {
   std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
   execution_providers.push_back(DefaultWebGpuExecutionProvider());
   tester.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+}
+
+// ---------------------------------------------------------------------------
+// attention_bias parity (CUDA vs CPU).
+//
+// The CUDA GQA kernel routes attention_bias-carrying nodes to the unfused
+// fallback; the CPU EP implements attention_bias directly, so it is the
+// reference. This runs the SAME prompt case on CUDA (fp16, the only float type
+// the CUDA kernel registers) and on CPU (fp32) and compares the outputs,
+// covering the three bias shapes that drive broadcast_attn_bias_dim_0/1:
+//   [batch, 1,    S, S]  -> dim0=false, dim1=true  (the default)
+//   [1,     1,    S, S]  -> dim0=true              (batch broadcast)
+//   [batch, heads, S, S] -> dim1=false             (per-head)
+// These run on real GPU in PR CI (C++ ctest), unlike the Python parity tests
+// which need a CUDA-enabled torch the PR agents don't have.
+// ---------------------------------------------------------------------------
+template <typename T>
+static std::vector<float> RunGQAPromptWithBias(
+    int batch_size, int seq_len, int num_heads, int kv_num_heads, int head_size,
+    int bias_dim0, int bias_dim1,
+    const std::vector<float>& query_data,
+    const std::vector<float>& key_data,
+    const std::vector<float>& value_data,
+    const std::vector<float>& bias_data,
+    GqaTargetEp target_ep) {
+  const int hidden_size = num_heads * head_size;
+  const int kv_hidden_size = kv_num_heads * head_size;
+  const int total_seq_len = seq_len;  // prompt: no past
+
+  auto cvt = [](const std::vector<float>& v) {
+    if constexpr (std::is_same_v<T, MLFloat16>) {
+      return ToFloat16(v);
+    } else {
+      return v;
+    }
+  };
+
+  OpTester tester("GroupQueryAttention", 1, onnxruntime::kMSDomain);
+  tester.AddAttribute<int64_t>("num_heads", static_cast<int64_t>(num_heads));
+  tester.AddAttribute<int64_t>("kv_num_heads", static_cast<int64_t>(kv_num_heads));
+
+  tester.AddInput<T>("query", {batch_size, seq_len, hidden_size}, cvt(query_data));
+  tester.AddInput<T>("key", {batch_size, seq_len, kv_hidden_size}, cvt(key_data));
+  tester.AddInput<T>("value", {batch_size, seq_len, kv_hidden_size}, cvt(value_data));
+
+  tester.AddOptionalInputEdge<T>();  // past_key
+  tester.AddOptionalInputEdge<T>();  // past_value
+  std::vector<int32_t> seqlens_k(batch_size, total_seq_len - 1);
+  tester.AddInput<int32_t>("seqlens_k", {batch_size}, seqlens_k);
+  tester.AddInput<int32_t>("total_sequence_length", {1}, {total_seq_len}, /*is_initializer=*/true);
+
+  tester.AddOptionalInputEdge<T>();        // cos_cache
+  tester.AddOptionalInputEdge<T>();        // sin_cache
+  tester.AddOptionalInputEdge<int64_t>();  // position_ids
+  tester.AddInput<T>("attention_bias", {bias_dim0, bias_dim1, seq_len, total_seq_len}, cvt(bias_data));
+
+  const int output_size = batch_size * seq_len * hidden_size;
+  tester.AddOutput<T>("output", {batch_size, seq_len, hidden_size}, std::vector<T>(output_size, T(0.0f)));
+  const int present_size = batch_size * kv_num_heads * total_seq_len * head_size;
+  tester.AddOutput<T>("present_key", {batch_size, kv_num_heads, total_seq_len, head_size},
+                      std::vector<T>(present_size, T(0.0f)));
+  tester.AddOutput<T>("present_value", {batch_size, kv_num_heads, total_seq_len, head_size},
+                      std::vector<T>(present_size, T(0.0f)));
+
+  tester.SetOutputTolerance(1e6f);  // outputs are compared explicitly by the caller
+
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(MakeExecutionProviderForGqaTest(target_ep));
+  tester.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+
+  auto fetches = tester.GetFetches();
+  const T* out = fetches[0].Get<Tensor>().Data<T>();
+  std::vector<float> result(output_size);
+  for (int i = 0; i < output_size; ++i) {
+    if constexpr (std::is_same_v<T, MLFloat16>) {
+      result[i] = out[i].ToFloat();
+    } else {
+      result[i] = out[i];
+    }
+  }
+  return result;
+}
+
+TEST(GroupQueryAttentionTest, CudaAttentionBiasParityVsCpu) {
+  auto cuda_ep = DefaultCudaExecutionProvider();
+  if (!cuda_ep) {
+    GTEST_SKIP() << "CUDA EP not available";
+  }
+
+  constexpr int batch_size = 2;
+  constexpr int seq_len = 3;
+  constexpr int num_heads = 4;
+  constexpr int kv_num_heads = 2;
+  constexpr int head_size = 8;
+  const int hidden_size = num_heads * head_size;
+  const int kv_hidden_size = kv_num_heads * head_size;
+
+  std::vector<float> query(batch_size * seq_len * hidden_size);
+  std::vector<float> key(batch_size * seq_len * kv_hidden_size);
+  std::vector<float> value(batch_size * seq_len * kv_hidden_size);
+  for (size_t i = 0; i < query.size(); ++i) query[i] = 0.1f * static_cast<float>(i % 7 + 1);
+  for (size_t i = 0; i < key.size(); ++i) key[i] = 0.2f * static_cast<float>(i % 5 + 1);
+  for (size_t i = 0; i < value.size(); ++i) value[i] = 0.3f * static_cast<float>(i % 3 + 1);
+
+  struct BiasShape {
+    int dim0;
+    int dim1;
+    const char* label;
+  };
+  const std::vector<BiasShape> shapes = {
+      {batch_size, 1, "batch_head_broadcast"},  // dim0=false, dim1=true (default)
+      {1, 1, "batch_broadcast"},                // dim0=true
+      {batch_size, num_heads, "per_head"},      // dim1=false
+  };
+
+  for (const auto& shape : shapes) {
+    std::vector<float> bias(static_cast<size_t>(shape.dim0) * shape.dim1 * seq_len * seq_len);
+    for (size_t i = 0; i < bias.size(); ++i) {
+      bias[i] = 0.5f * std::sin(0.7f * static_cast<float>(i));
+    }
+
+    auto cuda_output = RunGQAPromptWithBias<MLFloat16>(
+        batch_size, seq_len, num_heads, kv_num_heads, head_size, shape.dim0, shape.dim1,
+        query, key, value, bias, GqaTargetEp::kCuda);
+    auto cpu_output = RunGQAPromptWithBias<float>(
+        batch_size, seq_len, num_heads, kv_num_heads, head_size, shape.dim0, shape.dim1,
+        query, key, value, bias, GqaTargetEp::kCpu);
+
+    ExpectOutputsMatch(cuda_output, cpu_output, 0.02f, shape.label);
+  }
 }
 
 #ifdef USE_WEBGPU

--- a/onnxruntime/test/python/transformers/test_gqa.py
+++ b/onnxruntime/test/python/transformers/test_gqa.py
@@ -444,10 +444,11 @@ def create_gqa_node_and_io(
             )
         )
     if config.has_attention_bias:
-        bias_len = present_kv_seqlen if is_past else config.kv_sequence_length
+        # Per the op spec the last dim is total_sequence_length (past + new), which the kernel
+        # validates at runtime; declare it symbolic so one graph serves all cache states.
         graph_input.append(
             helper.make_tensor_value_info(
-                "attention_bias", ort_type, [config.batch_size, 1, config.q_sequence_length, bias_len]
+                "attention_bias", ort_type, [config.batch_size, 1, config.q_sequence_length, "total_seq_len"]
             )
         )
     if config.has_head_sink:
@@ -1125,13 +1126,17 @@ def parity_check_gqa_prompt(
             .contiguous()
         )
     if config.has_attention_bias:
-        attention_bias = torch.zeros(
-            config.batch_size,
-            1,
-            config.q_sequence_length,
-            config.kv_sequence_length,
-            device=device,
-            dtype=torch_type,
+        # Random (non-zero) bias so that a kernel silently ignoring the input fails parity.
+        attention_bias = (
+            torch.randn(
+                config.batch_size,
+                1,
+                config.q_sequence_length,
+                config.kv_sequence_length,
+                device=device,
+                dtype=torch_type,
+            )
+            * 0.5
         )
 
     arange = rearrange(torch.arange(config.buffer_sequence_length, device=device), "s -> 1 s")
@@ -1446,12 +1451,16 @@ def parity_check_gqa_past(
     if config.has_position_ids:
         position_ids = (cache_seqlens.unsqueeze(1) + torch.arange(config.q_sequence_length, device=device)).long()
     if config.has_attention_bias:
-        attention_bias = torch.zeros(
-            config.batch_size, 1, config.q_sequence_length, total_seq_len, device=device, dtype=torch_type
+        # Random (non-zero) bias so that a kernel silently ignoring the input fails parity.
+        # Positions beyond each batch's valid length get a large negative finite value
+        # (matching the CPU test convention; avoids inf-inf NaN when composed with masking).
+        attention_bias = (
+            torch.randn(config.batch_size, 1, config.q_sequence_length, total_seq_len, device=device, dtype=torch_type)
+            * 0.5
         )
         for b in range(config.batch_size):
             end_pos = cache_seqlens[b] + config.q_sequence_length
-            attention_bias[b, :, :, end_pos:] = float("-inf")
+            attention_bias[b, :, :, end_pos:] = -10000.0
 
     arange = rearrange(torch.arange(config.buffer_sequence_length, device=device), "s -> 1 s")
     cache_seqlens_expanded = rearrange(cache_seqlens, "b -> b 1")
@@ -2027,6 +2036,66 @@ def gqa_cuda_past_test_cases(
                     yield name, config
 
 
+def gqa_cuda_attention_bias_test_cases(is_past: bool):
+    """Focused cases for the attention_bias input. Dispatch must route these away from
+    the bias-incapable fused paths (flash/XQA/cuDNN), so no kernel-pinning env vars are
+    needed. Covers packed/unpacked QKV, shared/separate KV buffer, rotary, odd head
+    sizes (unfused supports any head_size) and a subsequent multi-token prompt."""
+    if is_past:
+        # (batch, new_seq, past_seq, num_heads, kv_num_heads, head_size, packed, share_buffer, rotary)
+        cases = [
+            (2, 1, 128, 32, 8, 128, False, True, False),
+            (1, 1, 2048, 6, 3, 128, True, True, True),
+            (3, 1, 500, 9, 9, 80, False, False, False),
+            (1, 3, 256, 6, 3, 128, True, True, False),  # subsequent prompt
+            (2, 1, 128, 6, 3, 40, False, True, False),  # odd head size
+        ]
+        for b, s, s2, n, n2, h, packed, share_buffer, rotary in cases:
+            # The past-parity harness compares the full present buffer; without buffer
+            # sharing the op emits exactly past+new, so the buffer must match that size.
+            config = GQAConfig(
+                batch_size=b,
+                q_sequence_length=s,
+                kv_sequence_length=s,
+                past_kv_sequence_length=s2,
+                buffer_sequence_length=s + s2 + (8 if share_buffer else 0),
+                num_heads=n,
+                kv_num_heads=n2,
+                head_size=h,
+                rotary=rotary,
+                packed=packed,
+                share_buffer=share_buffer,
+                has_attention_bias=True,
+            )
+            name = f"bias_b{b}_s{s}_{s2}_nh{n}_{n2}_h{h}_pkd{packed}_sb{share_buffer}_rot{rotary}"
+            yield name, config
+    else:
+        # (batch, seq, num_heads, kv_num_heads, head_size, packed, share_buffer, rotary)
+        cases = [
+            (2, 127, 6, 3, 128, False, True, False),
+            (1, 500, 32, 8, 128, True, True, True),
+            (3, 64, 9, 9, 80, False, False, False),
+            (2, 127, 6, 3, 40, True, True, False),  # odd head size
+        ]
+        for b, sq, n, n2, h, packed, share_buffer, rotary in cases:
+            config = GQAConfig(
+                batch_size=b,
+                q_sequence_length=sq,
+                kv_sequence_length=sq,
+                past_kv_sequence_length=0,
+                buffer_sequence_length=sq + 8,
+                num_heads=n,
+                kv_num_heads=n2,
+                head_size=h,
+                rotary=rotary,
+                packed=packed,
+                share_buffer=share_buffer,
+                has_attention_bias=True,
+            )
+            name = f"bias_b{b}_sq{sq}_nh{n}_{n2}_h{h}_pkd{packed}_sb{share_buffer}_rot{rotary}"
+            yield name, config
+
+
 def gqa_cuda_quantized_test_cases(is_past: bool):
     base_cases = (
         gqa_cuda_past_test_cases(allow_local=True, enforce_share_buffer=True)
@@ -2546,6 +2615,45 @@ class TestBF16MemoryEfficientGQA(unittest.TestCase):
                 rtol=rtol["bf16"],
                 atol=atol["bf16"],
             )
+
+
+class TestGQAAttentionBias(unittest.TestCase):
+    """Parity for the optional attention_bias input (CUDA). No kernel-pinning env vars:
+    bias-aware dispatch itself must route to a bias-capable path."""
+
+    @parameterized.expand(gqa_cuda_attention_bias_test_cases(is_past=False))
+    def test_gqa_prompt_attention_bias(self, name, config):
+        if enable_debug_print:
+            print("-" * 20)
+            print(f"test_case: {name}\n{config}")
+
+        parity_check_gqa_prompt(
+            config=config,
+            ep="CUDAExecutionProvider",
+            device="cuda",
+            torch_type=torch.float16,
+            ort_type=TensorProto.FLOAT16,
+            causal=True,
+            rtol=rtol["fp16"],
+            atol=atol["fp16"],
+        )
+
+    @parameterized.expand(gqa_cuda_attention_bias_test_cases(is_past=True))
+    def test_gqa_past_attention_bias(self, name, config):
+        if enable_debug_print:
+            print("-" * 20)
+            print(f"test_case: {name}\n{config}")
+
+        parity_check_gqa_past(
+            config=config,
+            ep="CUDAExecutionProvider",
+            device="cuda",
+            torch_type=torch.float16,
+            ort_type=TensorProto.FLOAT16,
+            causal=True,
+            rtol=rtol["fp16"],
+            atol=atol["fp16"],
+        )
 
 
 @unittest.skipIf(not has_flash_attention(), "Flash Attention is not available, skipping tests.")

--- a/onnxruntime/test/python/transformers/test_gqa.py
+++ b/onnxruntime/test/python/transformers/test_gqa.py
@@ -448,7 +448,7 @@ def create_gqa_node_and_io(
         # validates at runtime; declare it symbolic so one graph serves all cache states.
         graph_input.append(
             helper.make_tensor_value_info(
-                "attention_bias", ort_type, [config.batch_size, 1, config.q_sequence_length, "total_seq_len"]
+                "attention_bias", ort_type, [config.batch_size, 1, config.q_sequence_length, "total_sequence_length"]
             )
         )
     if config.has_head_sink:
@@ -1455,7 +1455,14 @@ def parity_check_gqa_past(
         # Positions beyond each batch's valid length get a large negative finite value
         # (matching the CPU test convention; avoids inf-inf NaN when composed with masking).
         attention_bias = (
-            torch.randn(config.batch_size, 1, config.q_sequence_length, total_seq_len, device=device, dtype=torch_type)
+            torch.randn(
+                config.batch_size,
+                1,
+                config.q_sequence_length,
+                total_seq_len,
+                device=device,
+                dtype=torch_type,
+            )
             * 0.5
         )
         for b in range(config.batch_size):

--- a/onnxruntime/test/python/transformers/test_gqa.py
+++ b/onnxruntime/test/python/transformers/test_gqa.py
@@ -155,6 +155,10 @@ class GQAConfig:
 
     has_position_ids: bool = False
     has_attention_bias: bool = False
+    # attention_bias leading dims: dim 0 is batch_size (or 1 when broadcast), dim 1 is
+    # 1 (broadcast over heads) or num_heads. Defaults keep the original [batch, 1, ...] shape.
+    attention_bias_broadcast_dim_0: bool = False
+    attention_bias_per_head: bool = False
 
     # Quantization parameters
     k_quant_type: str = "NONE"
@@ -446,9 +450,11 @@ def create_gqa_node_and_io(
     if config.has_attention_bias:
         # Per the op spec the last dim is total_sequence_length (past + new), which the kernel
         # validates at runtime; declare it symbolic so one graph serves all cache states.
+        bias_dim_0 = 1 if config.attention_bias_broadcast_dim_0 else config.batch_size
+        bias_dim_1 = config.num_heads if config.attention_bias_per_head else 1
         graph_input.append(
             helper.make_tensor_value_info(
-                "attention_bias", ort_type, [config.batch_size, 1, config.q_sequence_length, "total_sequence_length"]
+                "attention_bias", ort_type, [bias_dim_0, bias_dim_1, config.q_sequence_length, "total_sequence_length"]
             )
         )
     if config.has_head_sink:
@@ -1129,8 +1135,8 @@ def parity_check_gqa_prompt(
         # Random (non-zero) bias so that a kernel silently ignoring the input fails parity.
         attention_bias = (
             torch.randn(
-                config.batch_size,
-                1,
+                1 if config.attention_bias_broadcast_dim_0 else config.batch_size,
+                config.num_heads if config.attention_bias_per_head else 1,
                 config.q_sequence_length,
                 config.kv_sequence_length,
                 device=device,
@@ -1454,10 +1460,13 @@ def parity_check_gqa_past(
         # Random (non-zero) bias so that a kernel silently ignoring the input fails parity.
         # Positions beyond each batch's valid length get a large negative finite value
         # (matching the CPU test convention; avoids inf-inf NaN when composed with masking).
+        # A batch-broadcast bias (dim 0 == 1) cannot carry per-batch tails; it relies on
+        # the kernel's seqlens_k cutoff and the reference mask never reading those
+        # positions — which the dim0-broadcast past cases below verify holds.
         attention_bias = (
             torch.randn(
-                config.batch_size,
-                1,
+                1 if config.attention_bias_broadcast_dim_0 else config.batch_size,
+                config.num_heads if config.attention_bias_per_head else 1,
                 config.q_sequence_length,
                 total_seq_len,
                 device=device,
@@ -1465,9 +1474,10 @@ def parity_check_gqa_past(
             )
             * 0.5
         )
-        for b in range(config.batch_size):
-            end_pos = cache_seqlens[b] + config.q_sequence_length
-            attention_bias[b, :, :, end_pos:] = -10000.0
+        if not config.attention_bias_broadcast_dim_0:
+            for b in range(config.batch_size):
+                end_pos = cache_seqlens[b] + config.q_sequence_length
+                attention_bias[b, :, :, end_pos:] = -10000.0
 
     arange = rearrange(torch.arange(config.buffer_sequence_length, device=device), "s -> 1 s")
     cache_seqlens_expanded = rearrange(cache_seqlens, "b -> b 1")
@@ -2049,15 +2059,21 @@ def gqa_cuda_attention_bias_test_cases(is_past: bool):
     needed. Covers packed/unpacked QKV, shared/separate KV buffer, rotary, odd head
     sizes (unfused supports any head_size) and a subsequent multi-token prompt."""
     if is_past:
-        # (batch, new_seq, past_seq, num_heads, kv_num_heads, head_size, packed, share_buffer, rotary)
+        # (batch, new_seq, past_seq, num_heads, kv_num_heads, head_size, packed, share_buffer,
+        #  rotary, per_head_bias)
         cases = [
-            (2, 1, 128, 32, 8, 128, False, True, False),
-            (1, 1, 2048, 6, 3, 128, True, True, True),
-            (3, 1, 500, 9, 9, 80, False, False, False),
-            (1, 3, 256, 6, 3, 128, True, True, False),  # subsequent prompt
-            (2, 1, 128, 6, 3, 40, False, True, False),  # odd head size
+            (2, 1, 128, 32, 8, 128, False, True, False, False),
+            (1, 1, 2048, 6, 3, 128, True, True, True, False),
+            (3, 1, 500, 9, 9, 80, False, False, False, False),
+            (1, 3, 256, 6, 3, 128, True, True, False, False),  # subsequent prompt
+            (2, 1, 128, 6, 3, 40, False, True, False, False),  # odd head size
+            (2, 1, 128, 32, 8, 128, False, True, False, True),  # per-head bias (dim 1 == num_heads)
         ]
-        for b, s, s2, n, n2, h, packed, share_buffer, rotary in cases:
+        cases = [c + (False,) for c in cases] + [
+            (3, 1, 500, 9, 9, 80, False, False, False, False, True),  # batch-broadcast bias (dim 0 == 1)
+            (2, 1, 128, 6, 3, 40, False, True, False, False, True),   # batch-broadcast, shared buffer
+        ]
+        for b, s, s2, n, n2, h, packed, share_buffer, rotary, per_head, bcast0 in cases:
             # The past-parity harness compares the full present buffer; without buffer
             # sharing the op emits exactly past+new, so the buffer must match that size.
             config = GQAConfig(
@@ -2073,18 +2089,23 @@ def gqa_cuda_attention_bias_test_cases(is_past: bool):
                 packed=packed,
                 share_buffer=share_buffer,
                 has_attention_bias=True,
+                attention_bias_per_head=per_head,
+                attention_bias_broadcast_dim_0=bcast0,
             )
-            name = f"bias_b{b}_s{s}_{s2}_nh{n}_{n2}_h{h}_pkd{packed}_sb{share_buffer}_rot{rotary}"
+            name = f"bias_b{b}_s{s}_{s2}_nh{n}_{n2}_h{h}_pkd{packed}_sb{share_buffer}_rot{rotary}_ph{per_head}_bc0{bcast0}"
             yield name, config
     else:
-        # (batch, seq, num_heads, kv_num_heads, head_size, packed, share_buffer, rotary)
+        # (batch, seq, num_heads, kv_num_heads, head_size, packed, share_buffer, rotary,
+        #  bias_broadcast_dim_0, per_head_bias)
         cases = [
-            (2, 127, 6, 3, 128, False, True, False),
-            (1, 500, 32, 8, 128, True, True, True),
-            (3, 64, 9, 9, 80, False, False, False),
-            (2, 127, 6, 3, 40, True, True, False),  # odd head size
+            (2, 127, 6, 3, 128, False, True, False, False, False),
+            (1, 500, 32, 8, 128, True, True, True, False, False),
+            (3, 64, 9, 9, 80, False, False, False, False, False),
+            (2, 127, 6, 3, 40, True, True, False, False, False),  # odd head size
+            (3, 64, 9, 9, 80, False, False, False, True, False),  # batch-broadcast bias (dim 0 == 1)
+            (2, 127, 6, 3, 128, False, True, False, False, True),  # per-head bias (dim 1 == num_heads)
         ]
-        for b, sq, n, n2, h, packed, share_buffer, rotary in cases:
+        for b, sq, n, n2, h, packed, share_buffer, rotary, bcast0, per_head in cases:
             config = GQAConfig(
                 batch_size=b,
                 q_sequence_length=sq,
@@ -2098,8 +2119,10 @@ def gqa_cuda_attention_bias_test_cases(is_past: bool):
                 packed=packed,
                 share_buffer=share_buffer,
                 has_attention_bias=True,
+                attention_bias_broadcast_dim_0=bcast0,
+                attention_bias_per_head=per_head,
             )
-            name = f"bias_b{b}_sq{sq}_nh{n}_{n2}_h{h}_pkd{packed}_sb{share_buffer}_rot{rotary}"
+            name = f"bias_b{b}_sq{sq}_nh{n}_{n2}_h{h}_pkd{packed}_sb{share_buffer}_rot{rotary}_bc0{bcast0}_ph{per_head}"
             yield name, config
 
 
@@ -2624,6 +2647,7 @@ class TestBF16MemoryEfficientGQA(unittest.TestCase):
             )
 
 
+@unittest.skipIf(not has_cuda_device(53), "attention_bias CUDA parity tests require a CUDA GPU, skipping tests.")
 class TestGQAAttentionBias(unittest.TestCase):
     """Parity for the optional attention_bias input (CUDA). No kernel-pinning env vars:
     bias-aware dispatch itself must route to a bias-capable path."""

--- a/onnxruntime/test/python/transformers/test_gqa.py
+++ b/onnxruntime/test/python/transformers/test_gqa.py
@@ -2069,9 +2069,9 @@ def gqa_cuda_attention_bias_test_cases(is_past: bool):
             (2, 1, 128, 6, 3, 40, False, True, False, False),  # odd head size
             (2, 1, 128, 32, 8, 128, False, True, False, True),  # per-head bias (dim 1 == num_heads)
         ]
-        cases = [c + (False,) for c in cases] + [
+        cases = [(*c, False) for c in cases] + [
             (3, 1, 500, 9, 9, 80, False, False, False, False, True),  # batch-broadcast bias (dim 0 == 1)
-            (2, 1, 128, 6, 3, 40, False, True, False, False, True),   # batch-broadcast, shared buffer
+            (2, 1, 128, 6, 3, 40, False, True, False, False, True),  # batch-broadcast, shared buffer
         ]
         for b, s, s2, n, n2, h, packed, share_buffer, rotary, per_head, bcast0 in cases:
             # The past-parity harness compares the full present buffer; without buffer
@@ -2092,7 +2092,9 @@ def gqa_cuda_attention_bias_test_cases(is_past: bool):
                 attention_bias_per_head=per_head,
                 attention_bias_broadcast_dim_0=bcast0,
             )
-            name = f"bias_b{b}_s{s}_{s2}_nh{n}_{n2}_h{h}_pkd{packed}_sb{share_buffer}_rot{rotary}_ph{per_head}_bc0{bcast0}"
+            name = (
+                f"bias_b{b}_s{s}_{s2}_nh{n}_{n2}_h{h}_pkd{packed}_sb{share_buffer}_rot{rotary}_ph{per_head}_bc0{bcast0}"
+            )
             yield name, config
     else:
         # (batch, seq, num_heads, kv_num_heads, head_size, packed, share_buffer, rotary,


### PR DESCRIPTION
### Description

`com.microsoft.GroupQueryAttention`'s optional `attention_bias` input (input #10) is implemented by the CPU EP (#23944) and the WebGPU EP (#25285, #26769), but the CUDA EP rejects it at runtime. This PR wires it through.

No new kernel is needed: the unfused GQA fallback added for #28195 calls `LaunchUnfusedAttention`, whose kernel already implements an additive bias with dim-0/dim-1 broadcast, per-batch `seqlens_k`, causal/sliding-window masking and softcap — the op just passed `attn_bias=nullptr`. The change is dispatch plumbing:

- **`group_query_attention.cc`** — remove the blanket rejection; validate the bias element type; set `broadcast_attn_bias_dim_0/1` from the bias shape (the fields already exist on `AttentionParameters`); add `!has_attention_bias` to the XQA / cuDNN SDPA / flash / flash-fast-decode / MEA eligibility so bias-carrying nodes dispatch to the unfused fallback; set `data.attention_bias`.
- **`attention_data.h`** — add the `attention_bias` pointer to `GroupQueryAttentionData`.
- **`group_query_attention_impl.cu`** — pass the real pointer and broadcast flags in `UnfusedGqaAttention` (previously hardcoded `nullptr`/`false`).

Why each fused path stays disqualified with a bias:
- flash / flash fast-decode: `flash_api.h` has no bias parameter (same exclusion as MHA and the ONNX `Attention`-op CUDA kernel).
- XQA: no bias parameter.
- cuDNN SDPA: GQA's cuDNN path is bottom-right causal, which cuDNN documents as incompatible with a bias (`multihead_attention.cc` has the same restriction).
- cutlass MEA: the wrapper computes the bias row stride from `kv_sequence_length`, which GQA sets to the KV-cache capacity (`seqlen_present_kv_cache`) rather than `total_sequence_length`, so rows would be misaligned under past/present buffer sharing. Left for a follow-up (needs an explicit `attn_bias_strideM` in `MemoryEfficientAttentionParams`).

Kept `NOT_IMPLEMENTED` (explicit, clear errors instead of the previous blanket rejection): bias × quantized KV cache (unfused requires `T == U`), bias × smooth-softmax/head_sink.

### Tests

New `TestGQAAttentionBias` in `test_gqa.py`: prompt and past/decode parity across packed/unpacked QKV, shared/separate KV buffer, rotary, odd head sizes (40/80), and a subsequent multi-token prompt. The bias is **non-zero random** so a kernel that silently ignores the input fails parity (the harness previously modeled a zeros bias). Also fixes the test graph builder declaring the bias input's last dim as the KV-cache capacity instead of `total_sequence_length` (the shape the op validates).

Full `test_gqa.py` suite: 476 tests pass, no regressions (SM89, CUDA 12.8).

### Motivation and Context

Fixes #29506.

Transformers.js-exported speech models carry non-causal attention patterns as `attention_bias` and currently cannot run on the CUDA EP at all, while running fine on WebGPU and CPU:
- [`onnx-community/Voxtral-Mini-4B-Realtime-2602-ONNX`](https://huggingface.co/onnx-community/Voxtral-Mini-4B-Realtime-2602-ONNX) (streaming ASR)
- [`onnx-community/cohere-transcribe-03-2026-ONNX`](https://huggingface.co/onnx-community/cohere-transcribe-03-2026-ONNX)

End-to-end validation with this patch on an RTX 4070 SUPER: the full Voxtral-Mini-4B-Realtime streaming pipeline (q4f16) transcribes correctly at **RTF 0.23** (31 s clip, 25.6 tok/s sustained decode, 6.4 GB VRAM) — on this workload the unfused-attention path outperforms the same model on the WebGPU EP (RTF 0.26).

(While validating, an unrelated pre-existing issue surfaced: `GroupQueryAttentionFusion` breaks graphs whose GQA nodes carry >9 inputs — filed as #29524.)
