### PR TITLE
[MLAS] Add RISC-V RVV backend for MLAS QNBitGemm (MatMulNBits)

### DIFF
--- a/cmake/onnxruntime_mlas.cmake
+++ b/cmake/onnxruntime_mlas.cmake
@@ -984,6 +984,7 @@ endif()
               ${MLAS_SRC_DIR}/riscv64/layernorm_kernel_rvv.cpp
               ${MLAS_SRC_DIR}/riscv64/qgemm_kernel_rvv.cpp
               ${MLAS_SRC_DIR}/riscv64/activation_kernel_rvv.cpp
+              ${MLAS_SRC_DIR}/riscv64/qnbitgemm_kernel_rvv.cpp
             )
             list(REMOVE_ITEM mlas_platform_srcs
               "${MLAS_SRC_DIR}/sconv_nchw_depthwise_multiplier_1.cpp")
@@ -997,6 +998,7 @@ endif()
               ${MLAS_SRC_DIR}/riscv64/layernorm_kernel_rvv.cpp
               ${MLAS_SRC_DIR}/riscv64/qgemm_kernel_rvv.cpp
               ${MLAS_SRC_DIR}/riscv64/activation_kernel_rvv.cpp
+              ${MLAS_SRC_DIR}/riscv64/qnbitgemm_kernel_rvv.cpp
               PROPERTIES COMPILE_FLAGS "-march=rv64gcv -mabi=lp64d")
             list(APPEND mlas_private_compile_definitions MLAS_USE_RVV=1)
 
@@ -1004,10 +1006,12 @@ endif()
               list(APPEND mlas_platform_srcs
                 ${MLAS_SRC_DIR}/riscv64/halfgemm_kernel_rvv.cpp
                 ${MLAS_SRC_DIR}/riscv64/cast_kernel_rvv.cpp
+                ${MLAS_SRC_DIR}/riscv64/hqnbitgemm_kernel_rvv.cpp
               )
               set_source_files_properties(
                 ${MLAS_SRC_DIR}/riscv64/halfgemm_kernel_rvv.cpp
                 ${MLAS_SRC_DIR}/riscv64/cast_kernel_rvv.cpp
+                ${MLAS_SRC_DIR}/riscv64/hqnbitgemm_kernel_rvv.cpp
                 PROPERTIES COMPILE_FLAGS "-march=rv64gcv_zvfh -mabi=lp64d")
               list(APPEND mlas_private_compile_definitions MLAS_USE_RVV_ZVFH=1)
             endif()

--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -1444,6 +1444,8 @@ extern const MLAS_QNBIT_GEMM_DISPATCH MlasSQNBitGemmDispatchAvx512vnni;
 
 extern const MLAS_QNBIT_GEMM_DISPATCH MlasSQNBitGemmDispatchLasx;
 
+extern const MLAS_QNBIT_GEMM_DISPATCH MlasSQNBitGemmDispatchRvv;
+
 struct MLAS_QNBIT_LUT_GEMM_DISPATCH;
 
 extern const MLAS_QNBIT_LUT_GEMM_DISPATCH MlasLutGenKernelAvx2;

--- a/onnxruntime/core/mlas/lib/platform.cpp
+++ b/onnxruntime/core/mlas/lib/platform.cpp
@@ -312,6 +312,7 @@ Return Value:
     this->ComputeLogSoftmaxOutputF32Kernel = MlasComputeLogSoftmaxOutputF32KernelRvv;
     this->RopeDispatch = &MlasRopeDispatchRvv;
     this->LayerNormF32Kernel = &MlasLayerNormKernelRvv;
+    this->QNBitGemmDispatch = &MlasSQNBitGemmDispatchRvv;
 
 #if defined(MLAS_USE_RVV_ZVFH)
     if (MLAS_CPUIDINFO::GetCPUIDInfo().HasFp16VectorAcceleration()) {

--- a/onnxruntime/core/mlas/lib/riscv64/hqnbitgemm_kernel_rvv.cpp
+++ b/onnxruntime/core/mlas/lib/riscv64/hqnbitgemm_kernel_rvv.cpp
@@ -1,0 +1,332 @@
+/*++
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the MIT License.
+
+Module Name:
+
+    hqnbitgemm_kernel_rvv.cpp
+
+Abstract:
+
+    RISC-V Vector (RVV) kernels for the half-precision (fp16) activation path of
+    n-bit quantized GEMM (MatMulNBits), i.e. MLAS_QNBIT_GEMM_COMPUTE_TYPE
+    HQNBIT_CompFp16 with 4-bit weights.
+
+    Requires the Zvfh extension (native fp16 vectors); this file is compiled with
+    -march=rv64gcv_zvfh and only when MLAS_USE_RVV_ZVFH is defined.
+
+    Two kernels are provided: dequantize packed 4-bit B into an fp16 buffer, and
+    an fp16 GEMM that consumes it. Both are paired with each other and with the
+    RVV packing (SubBlkLen == 16 nibble interleave), so the intermediate layouts
+    are private to this dispatch. The dequantized B is stored column-major
+    (B[n*ldb + k]); the GEMM accumulates in fp32 for accuracy and rounds the
+    result to fp16.
+
+--*/
+
+#include "mlasi.h"
+
+#if defined(MLAS_USE_RVV_ZVFH)
+
+#include <riscv_vector.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+
+#include "mlas_float16.h"
+#include "qnbitgemm.h"
+
+namespace
+{
+
+constexpr size_t SubBlkLen = 16;
+
+MLAS_FORCEINLINE float
+Fp16BitsToFloat(_mlas_fp16_ bits)
+{
+    _Float16 h;
+    std::memcpy(&h, &bits, sizeof(h));
+    return static_cast<float>(h);
+}
+
+MLAS_FORCEINLINE _mlas_fp16_
+FloatToFp16Bits(float f)
+{
+    _Float16 h = static_cast<_Float16>(f);
+    _mlas_fp16_ bits;
+    std::memcpy(&bits, &h, sizeof(bits));
+    return bits;
+}
+
+MLAS_FORCEINLINE float
+DequantOffset(const std::byte* zp_col, size_t blk_idx, bool has_zero_point)
+{
+    if (!has_zero_point) {
+        return 8.0f;
+    }
+    const std::byte zp_packed = zp_col[blk_idx / 2];
+    const uint8_t zp = ((blk_idx & 1) == 1)
+                           ? std::to_integer<uint8_t>(zp_packed >> 4)
+                           : std::to_integer<uint8_t>(zp_packed & std::byte{0x0F});
+    return static_cast<float>(zp);
+}
+
+// Dequantize one sub-block (up to 16 elements) of a single B column into fp16
+// (natural order): out[i] = fp16((nibble_i - offset) * scale).
+MLAS_FORCEINLINE void
+DequantSubblockToFp16(const uint8_t* packed, size_t len, float offset, float scale, _mlas_fp16_* out)
+{
+    const size_t low_count = std::min(len, SubBlkLen / 2);
+    {
+        const size_t vl = __riscv_vsetvl_e8m1(low_count);
+        const vuint8m1_t b = __riscv_vle8_v_u8m1(packed, vl);
+        const vuint8m1_t nib = __riscv_vand_vx_u8m1(b, 0x0F, vl);
+        const vuint16m2_t w16 = __riscv_vzext_vf2_u16m2(nib, vl);
+        const vuint32m4_t w32 = __riscv_vzext_vf2_u32m4(w16, vl);
+        vfloat32m4_t f = __riscv_vfcvt_f_xu_v_f32m4(w32, vl);
+        f = __riscv_vfsub_vf_f32m4(f, offset, vl);
+        f = __riscv_vfmul_vf_f32m4(f, scale, vl);
+        const vfloat16m2_t h = __riscv_vfncvt_f_f_w_f16m2(f, vl);
+        __riscv_vse16_v_u16m2(out, __riscv_vreinterpret_v_f16m2_u16m2(h), vl);
+    }
+    if (len > SubBlkLen / 2) {
+        const size_t high_count = len - SubBlkLen / 2;
+        const size_t vl = __riscv_vsetvl_e8m1(high_count);
+        const vuint8m1_t b = __riscv_vle8_v_u8m1(packed, vl);
+        const vuint8m1_t nib = __riscv_vsrl_vx_u8m1(b, 4, vl);
+        const vuint16m2_t w16 = __riscv_vzext_vf2_u16m2(nib, vl);
+        const vuint32m4_t w32 = __riscv_vzext_vf2_u32m4(w16, vl);
+        vfloat32m4_t f = __riscv_vfcvt_f_xu_v_f32m4(w32, vl);
+        f = __riscv_vfsub_vf_f32m4(f, offset, vl);
+        f = __riscv_vfmul_vf_f32m4(f, scale, vl);
+        const vfloat16m2_t h = __riscv_vfncvt_f_f_w_f16m2(f, vl);
+        __riscv_vse16_v_u16m2(out + SubBlkLen / 2, __riscv_vreinterpret_v_f16m2_u16m2(h), vl);
+    }
+}
+
+template <bool HasZeroPoint>
+void
+HQ4BitBlkDequantBForHgemm_CompFp16_Impl(
+    size_t BlkLen,
+    _mlas_fp16_* FpData,
+    const std::byte* QuantBData,
+    const _mlas_fp16_* QuantBScale,
+    const std::byte* QuantBZeroPoint,
+    size_t CountN,
+    size_t CountK,
+    size_t BlockCountK
+)
+{
+    constexpr size_t BlkBitWidth = 4;
+    const size_t BlkDataSize = MlasQNBitBlkDataSizeInBytes(BlkBitWidth, BlkLen);
+    const size_t StrideQuantBData = BlockCountK * BlkDataSize;
+    const size_t StrideQuantBZeroPoint = MlasQNBitZeroPointsForBlksSizeInBytes<BlkBitWidth>(BlockCountK);
+    const size_t ldb = BlockCountK * BlkLen;
+
+    for (size_t n = 0; n < CountN; ++n) {
+        const uint8_t* b_data = reinterpret_cast<const uint8_t*>(QuantBData) + n * StrideQuantBData;
+        const _mlas_fp16_* b_scale = QuantBScale + n * BlockCountK;
+        const std::byte* b_zp = HasZeroPoint ? QuantBZeroPoint + n * StrideQuantBZeroPoint : nullptr;
+        _mlas_fp16_* dst_col = FpData + n * ldb;
+
+        for (size_t b = 0; b < BlockCountK; ++b) {
+            const float scale = Fp16BitsToFloat(b_scale[b]);
+            const float offset = DequantOffset(b_zp, b, HasZeroPoint);
+            const size_t k0 = b * BlkLen;
+            const size_t len = std::min(BlkLen, CountK - k0);
+            const uint8_t* blk_ptr = b_data + b * BlkDataSize;
+
+            for (size_t kk = 0; kk < len; kk += SubBlkLen) {
+                const size_t sub_len = std::min(len - kk, SubBlkLen);
+                DequantSubblockToFp16(blk_ptr + kk / 2, sub_len, offset, scale, dst_col + k0 + kk);
+            }
+        }
+
+        // zero-pad [CountK, ldb)
+        for (size_t k = CountK; k < ldb; ++k) {
+            dst_col[k] = _mlas_fp16_{0};
+        }
+    }
+}
+
+template <bool HasZeroPoint>
+void
+HQ8BitBlkDequantBForHgemm_CompFp16_Impl(
+    size_t BlkLen,
+    _mlas_fp16_* FpData,
+    const std::byte* QuantBData,
+    const _mlas_fp16_* QuantBScale,
+    const std::byte* QuantBZeroPoint,
+    size_t CountN,
+    size_t CountK,
+    size_t BlockCountK
+)
+{
+    const size_t StrideQuantBData = BlockCountK * BlkLen;  // 8-bit: one byte per weight
+    const size_t StrideQuantBZeroPoint = BlockCountK;      // 8-bit: one zp byte per block
+    const size_t ldb = BlockCountK * BlkLen;
+
+    for (size_t n = 0; n < CountN; ++n) {
+        const uint8_t* b_data = reinterpret_cast<const uint8_t*>(QuantBData) + n * StrideQuantBData;
+        const _mlas_fp16_* b_scale = QuantBScale + n * BlockCountK;
+        const std::byte* b_zp = HasZeroPoint ? QuantBZeroPoint + n * StrideQuantBZeroPoint : nullptr;
+        _mlas_fp16_* dst_col = FpData + n * ldb;
+
+        for (size_t b = 0; b < BlockCountK; ++b) {
+            const float scale = Fp16BitsToFloat(b_scale[b]);
+            const float zp = HasZeroPoint ? static_cast<float>(std::to_integer<uint8_t>(b_zp[b])) : 128.0f;
+            const size_t k0 = b * BlkLen;
+            const size_t len = std::min(BlkLen, CountK - k0);
+            const uint8_t* src = b_data + k0;
+
+            for (size_t off = 0; off < len;) {
+                const size_t vl = __riscv_vsetvl_e8m1(len - off);
+                const vuint8m1_t q = __riscv_vle8_v_u8m1(src + off, vl);
+                const vuint16m2_t w16 = __riscv_vzext_vf2_u16m2(q, vl);
+                const vuint32m4_t w32 = __riscv_vzext_vf2_u32m4(w16, vl);
+                vfloat32m4_t f = __riscv_vfcvt_f_xu_v_f32m4(w32, vl);
+                f = __riscv_vfsub_vf_f32m4(f, zp, vl);
+                f = __riscv_vfmul_vf_f32m4(f, scale, vl);
+                const vfloat16m2_t h = __riscv_vfncvt_f_f_w_f16m2(f, vl);
+                __riscv_vse16_v_u16m2(dst_col + k0 + off, __riscv_vreinterpret_v_f16m2_u16m2(h), vl);
+                off += vl;
+            }
+        }
+
+        for (size_t k = CountK; k < ldb; ++k) {
+            dst_col[k] = _mlas_fp16_{0};
+        }
+    }
+}
+
+}  // namespace
+
+void
+RvvHQ4BitBlkDequantBForHgemm_CompFp16(
+    size_t BlkLen,
+    MLAS_FP16* FpData,
+    const std::byte* QuantBData,
+    const MLAS_FP16* QuantBScale,
+    const std::byte* QuantBZeroPoint,
+    size_t CountN,
+    size_t CountK,
+    size_t BlockCountK
+)
+{
+    auto* fp = reinterpret_cast<_mlas_fp16_*>(FpData);
+    const auto* scale = reinterpret_cast<const _mlas_fp16_*>(QuantBScale);
+    if (QuantBZeroPoint != nullptr) {
+        HQ4BitBlkDequantBForHgemm_CompFp16_Impl<true>(
+            BlkLen, fp, QuantBData, scale, QuantBZeroPoint, CountN, CountK, BlockCountK);
+    } else {
+        HQ4BitBlkDequantBForHgemm_CompFp16_Impl<false>(
+            BlkLen, fp, QuantBData, scale, QuantBZeroPoint, CountN, CountK, BlockCountK);
+    }
+}
+
+void
+RvvHQ8BitBlkDequantBForHgemm_CompFp16(
+    size_t BlkLen,
+    MLAS_FP16* FpData,
+    const std::byte* QuantBData,
+    const MLAS_FP16* QuantBScale,
+    const std::byte* QuantBZeroPoint,
+    size_t CountN,
+    size_t CountK,
+    size_t BlockCountK
+)
+{
+    auto* fp = reinterpret_cast<_mlas_fp16_*>(FpData);
+    const auto* scale = reinterpret_cast<const _mlas_fp16_*>(QuantBScale);
+    if (QuantBZeroPoint != nullptr) {
+        HQ8BitBlkDequantBForHgemm_CompFp16_Impl<true>(
+            BlkLen, fp, QuantBData, scale, QuantBZeroPoint, CountN, CountK, BlockCountK);
+    } else {
+        HQ8BitBlkDequantBForHgemm_CompFp16_Impl<false>(
+            BlkLen, fp, QuantBData, scale, QuantBZeroPoint, CountN, CountK, BlockCountK);
+    }
+}
+
+void
+RvvHQ4BitGemmKernel_CompFp16(
+    const MLAS_FP16* A,
+    const MLAS_FP16* B,
+    const MLAS_FP16* Bias,
+    MLAS_FP16* C,
+    size_t CountM,
+    size_t CountN,
+    size_t K,
+    size_t lda,
+    size_t ldb,
+    size_t ldc
+)
+{
+    const auto* a_base = reinterpret_cast<const _mlas_fp16_*>(A);
+    const auto* b_base = reinterpret_cast<const _mlas_fp16_*>(B);
+    const auto* bias = reinterpret_cast<const _mlas_fp16_*>(Bias);
+    auto* c_base = reinterpret_cast<_mlas_fp16_*>(C);
+
+    // RVV vector types are sizeless (cannot be array elements), so the 4-row
+    // tile is unrolled with named accumulators. Each B chunk is widened once and
+    // reused across the 4 rows; rows past a multiple of 4 use a 1-row tail.
+    const size_t vlmax = __riscv_vsetvlmax_e32m2();
+
+    auto load_a = [](const _mlas_fp16_* p, size_t vl) {
+        return __riscv_vfwcvt_f_f_v_f32m2(
+            __riscv_vreinterpret_v_u16m1_f16m1(__riscv_vle16_v_u16m1(p, vl)), vl);
+    };
+
+    for (size_t n = 0; n < CountN; ++n) {
+        const _mlas_fp16_* b_row = b_base + n * ldb;
+        const float bias_n = (bias != nullptr) ? Fp16BitsToFloat(bias[n]) : 0.0f;
+
+        size_t m = 0;
+        for (; m + 4 <= CountM; m += 4) {
+            vfloat32m2_t acc0 = __riscv_vfmv_v_f_f32m2(0.0f, vlmax);
+            vfloat32m2_t acc1 = __riscv_vfmv_v_f_f32m2(0.0f, vlmax);
+            vfloat32m2_t acc2 = __riscv_vfmv_v_f_f32m2(0.0f, vlmax);
+            vfloat32m2_t acc3 = __riscv_vfmv_v_f_f32m2(0.0f, vlmax);
+            const _mlas_fp16_* a0 = a_base + (m + 0) * lda;
+            const _mlas_fp16_* a1 = a_base + (m + 1) * lda;
+            const _mlas_fp16_* a2 = a_base + (m + 2) * lda;
+            const _mlas_fp16_* a3 = a_base + (m + 3) * lda;
+
+            for (size_t off = 0; off < K;) {
+                const size_t vl = __riscv_vsetvl_e16m1(K - off);
+                const vfloat32m2_t bf = __riscv_vfwcvt_f_f_v_f32m2(
+                    __riscv_vreinterpret_v_u16m1_f16m1(__riscv_vle16_v_u16m1(b_row + off, vl)), vl);  // widen B once
+                acc0 = __riscv_vfmacc_vv_f32m2_tu(acc0, load_a(a0 + off, vl), bf, vl);
+                acc1 = __riscv_vfmacc_vv_f32m2_tu(acc1, load_a(a1 + off, vl), bf, vl);
+                acc2 = __riscv_vfmacc_vv_f32m2_tu(acc2, load_a(a2 + off, vl), bf, vl);
+                acc3 = __riscv_vfmacc_vv_f32m2_tu(acc3, load_a(a3 + off, vl), bf, vl);
+                off += vl;
+            }
+
+            vfloat32m1_t z = __riscv_vfmv_s_f_f32m1(0.0f, 1);
+            c_base[(m + 0) * ldc + n] = FloatToFp16Bits(__riscv_vfmv_f_s_f32m1_f32(__riscv_vfredusum_vs_f32m2_f32m1(acc0, z, vlmax)) + bias_n);
+            c_base[(m + 1) * ldc + n] = FloatToFp16Bits(__riscv_vfmv_f_s_f32m1_f32(__riscv_vfredusum_vs_f32m2_f32m1(acc1, z, vlmax)) + bias_n);
+            c_base[(m + 2) * ldc + n] = FloatToFp16Bits(__riscv_vfmv_f_s_f32m1_f32(__riscv_vfredusum_vs_f32m2_f32m1(acc2, z, vlmax)) + bias_n);
+            c_base[(m + 3) * ldc + n] = FloatToFp16Bits(__riscv_vfmv_f_s_f32m1_f32(__riscv_vfredusum_vs_f32m2_f32m1(acc3, z, vlmax)) + bias_n);
+        }
+
+        for (; m < CountM; ++m) {
+            const _mlas_fp16_* a_row = a_base + m * lda;
+            vfloat32m2_t acc = __riscv_vfmv_v_f_f32m2(0.0f, vlmax);
+            for (size_t off = 0; off < K;) {
+                const size_t vl = __riscv_vsetvl_e16m1(K - off);
+                const vfloat32m2_t bf = __riscv_vfwcvt_f_f_v_f32m2(
+                    __riscv_vreinterpret_v_u16m1_f16m1(__riscv_vle16_v_u16m1(b_row + off, vl)), vl);
+                acc = __riscv_vfmacc_vv_f32m2_tu(acc, load_a(a_row + off, vl), bf, vl);
+                off += vl;
+            }
+            vfloat32m1_t z = __riscv_vfmv_s_f_f32m1(0.0f, 1);
+            c_base[m * ldc + n] = FloatToFp16Bits(__riscv_vfmv_f_s_f32m1_f32(__riscv_vfredusum_vs_f32m2_f32m1(acc, z, vlmax)) + bias_n);
+        }
+    }
+}
+
+#endif  // MLAS_USE_RVV_ZVFH

--- a/onnxruntime/core/mlas/lib/riscv64/hqnbitgemm_kernel_rvv.cpp
+++ b/onnxruntime/core/mlas/lib/riscv64/hqnbitgemm_kernel_rvv.cpp
@@ -12,17 +12,18 @@ Abstract:
 
     RISC-V Vector (RVV) kernels for the half-precision (fp16) activation path of
     n-bit quantized GEMM (MatMulNBits), i.e. MLAS_QNBIT_GEMM_COMPUTE_TYPE
-    HQNBIT_CompFp16 with 4-bit weights.
+    HQNBIT_CompFp16, for both 4-bit and 8-bit weights.
 
     Requires the Zvfh extension (native fp16 vectors); this file is compiled with
     -march=rv64gcv_zvfh and only when MLAS_USE_RVV_ZVFH is defined.
 
-    Two kernels are provided: dequantize packed 4-bit B into an fp16 buffer, and
-    an fp16 GEMM that consumes it. Both are paired with each other and with the
-    RVV packing (SubBlkLen == 16 nibble interleave), so the intermediate layouts
-    are private to this dispatch. The dequantized B is stored column-major
-    (B[n*ldb + k]); the GEMM accumulates in fp32 for accuracy and rounds the
-    result to fp16.
+    Three entry points are provided: dequantize packed 4-bit B into an fp16
+    buffer, dequantize packed 8-bit B into an fp16 buffer, and a single fp16 GEMM
+    that consumes either. The 4-bit dequant reads the RVV nibble-interleave pack
+    (SubBlkLen == 16); the 8-bit dequant reads a plain byte pack; both
+    intermediate layouts are private to this dispatch. The dequantized B is stored
+    column-major (B[n*ldb + k]); the GEMM accumulates in fp32 for accuracy and
+    rounds the result to fp16.
 
 --*/
 

--- a/onnxruntime/core/mlas/lib/riscv64/hqnbitgemm_kernel_rvv.cpp
+++ b/onnxruntime/core/mlas/lib/riscv64/hqnbitgemm_kernel_rvv.cpp
@@ -221,10 +221,12 @@ RvvHQ4BitBlkDequantBForHgemm_CompFp16(
     const auto* scale = reinterpret_cast<const _mlas_fp16_*>(QuantBScale);
     if (QuantBZeroPoint != nullptr) {
         HQ4BitBlkDequantBForHgemm_CompFp16_Impl<true>(
-            BlkLen, fp, QuantBData, scale, QuantBZeroPoint, CountN, CountK, BlockCountK);
+            BlkLen, fp, QuantBData, scale, QuantBZeroPoint, CountN, CountK, BlockCountK
+        );
     } else {
         HQ4BitBlkDequantBForHgemm_CompFp16_Impl<false>(
-            BlkLen, fp, QuantBData, scale, QuantBZeroPoint, CountN, CountK, BlockCountK);
+            BlkLen, fp, QuantBData, scale, QuantBZeroPoint, CountN, CountK, BlockCountK
+        );
     }
 }
 
@@ -244,10 +246,12 @@ RvvHQ8BitBlkDequantBForHgemm_CompFp16(
     const auto* scale = reinterpret_cast<const _mlas_fp16_*>(QuantBScale);
     if (QuantBZeroPoint != nullptr) {
         HQ8BitBlkDequantBForHgemm_CompFp16_Impl<true>(
-            BlkLen, fp, QuantBData, scale, QuantBZeroPoint, CountN, CountK, BlockCountK);
+            BlkLen, fp, QuantBData, scale, QuantBZeroPoint, CountN, CountK, BlockCountK
+        );
     } else {
         HQ8BitBlkDequantBForHgemm_CompFp16_Impl<false>(
-            BlkLen, fp, QuantBData, scale, QuantBZeroPoint, CountN, CountK, BlockCountK);
+            BlkLen, fp, QuantBData, scale, QuantBZeroPoint, CountN, CountK, BlockCountK
+        );
     }
 }
 
@@ -277,7 +281,8 @@ RvvHQ4BitGemmKernel_CompFp16(
 
     auto load_a = [](const _mlas_fp16_* p, size_t vl) {
         return __riscv_vfwcvt_f_f_v_f32m2(
-            __riscv_vreinterpret_v_u16m1_f16m1(__riscv_vle16_v_u16m1(p, vl)), vl);
+            __riscv_vreinterpret_v_u16m1_f16m1(__riscv_vle16_v_u16m1(p, vl)), vl
+        );
     };
 
     for (size_t n = 0; n < CountN; ++n) {
@@ -298,7 +303,8 @@ RvvHQ4BitGemmKernel_CompFp16(
             for (size_t off = 0; off < K;) {
                 const size_t vl = __riscv_vsetvl_e16m1(K - off);
                 const vfloat32m2_t bf = __riscv_vfwcvt_f_f_v_f32m2(
-                    __riscv_vreinterpret_v_u16m1_f16m1(__riscv_vle16_v_u16m1(b_row + off, vl)), vl);  // widen B once
+                    __riscv_vreinterpret_v_u16m1_f16m1(__riscv_vle16_v_u16m1(b_row + off, vl)), vl
+                );  // widen B once
                 acc0 = __riscv_vfmacc_vv_f32m2_tu(acc0, load_a(a0 + off, vl), bf, vl);
                 acc1 = __riscv_vfmacc_vv_f32m2_tu(acc1, load_a(a1 + off, vl), bf, vl);
                 acc2 = __riscv_vfmacc_vv_f32m2_tu(acc2, load_a(a2 + off, vl), bf, vl);
@@ -319,7 +325,8 @@ RvvHQ4BitGemmKernel_CompFp16(
             for (size_t off = 0; off < K;) {
                 const size_t vl = __riscv_vsetvl_e16m1(K - off);
                 const vfloat32m2_t bf = __riscv_vfwcvt_f_f_v_f32m2(
-                    __riscv_vreinterpret_v_u16m1_f16m1(__riscv_vle16_v_u16m1(b_row + off, vl)), vl);
+                    __riscv_vreinterpret_v_u16m1_f16m1(__riscv_vle16_v_u16m1(b_row + off, vl)), vl
+                );
                 acc = __riscv_vfmacc_vv_f32m2_tu(acc, load_a(a_row + off, vl), bf, vl);
                 off += vl;
             }

--- a/onnxruntime/core/mlas/lib/riscv64/qnbitgemm_kernel_rvv.cpp
+++ b/onnxruntime/core/mlas/lib/riscv64/qnbitgemm_kernel_rvv.cpp
@@ -62,7 +62,7 @@ RvvQ4BitGemmPackQuantBDataSize(
     size_t BlkLen,
     bool /*HasZeroPoint*/,
     MLAS_QNBIT_GEMM_COMPUTE_TYPE /*ComputeType*/,  // same size regardless of ComputeType
-    const MLAS_BACKEND_KERNEL_SELECTOR_CONFIG* /*BackendKernelSelectorConfig*/
+    const MLAS_BACKEND_KERNEL_SELECTOR_CONFIG*     /*BackendKernelSelectorConfig*/
 )
 {
     constexpr size_t BlkBitWidth = 4;
@@ -140,8 +140,7 @@ RvvSQ8BitGemmPackQuantBDataAndBlkSum(
             const size_t row = static_cast<size_t>(n) * BlockCountK;
 
             if (QuantBDataBegin != nullptr) {
-                std::memcpy(PackedData + static_cast<size_t>(n) * DataBytesPerCol,
-                            QuantBDataBegin + static_cast<size_t>(n) * DataBytesPerCol, DataBytesPerCol);
+                std::memcpy(PackedData + static_cast<size_t>(n) * DataBytesPerCol, QuantBDataBegin + static_cast<size_t>(n) * DataBytesPerCol, DataBytesPerCol);
             }
 
             if (QuantBScaleBegin != nullptr) {
@@ -685,7 +684,8 @@ SQ4BitGemmKernel_CompInt8_Impl(
                 const size_t k0 = b * BlkLen;
                 const size_t len = std::min(BlkLen, CountK - k0);
                 const int8_t offset = static_cast<int8_t>(
-                    HasZeroPoint ? static_cast<int>(DequantOffset(b_zp, b, true)) : 8);
+                    HasZeroPoint ? static_cast<int>(DequantOffset(b_zp, b, true)) : 8
+                );
                 const uint8_t* qb = b_data + b * MlasQNBitBlkDataSizeInBytes(BlkBitWidth, BlkLen);
 
                 int32_t isum[MTILE] = {};
@@ -703,7 +703,8 @@ SQ4BitGemmKernel_CompInt8_Impl(
                         for (size_t off = 0; off < clen;) {
                             const size_t vl = __riscv_vsetvl_e8m4(clen - off);
                             const vint16m8_t prod = __riscv_vwmul_vv_i16m8(
-                                __riscv_vle8_v_i8m4(qa + off, vl), __riscv_vle8_v_i8m4(qbc + off, vl), vl);
+                                __riscv_vle8_v_i8m4(qa + off, vl), __riscv_vle8_v_i8m4(qbc + off, vl), vl
+                            );
                             is = __riscv_vwredsum_vs_i16m8_i32m1(prod, is, vl);
                             off += vl;
                         }
@@ -840,12 +841,12 @@ SQ8BitGemmKernel_BlkSum_CompInt8_Impl(
                 for (size_t off = 0; off < len;) {
                     const size_t vl = __riscv_vsetvl_e8m4(len - off);
                     const vint16m8_t prod = __riscv_vwmulsu_vv_i16m8(
-                        __riscv_vle8_v_i8m4(qa + off, vl), __riscv_vle8_v_u8m4(qb + off, vl), vl);
+                        __riscv_vle8_v_i8m4(qa + off, vl), __riscv_vle8_v_u8m4(qb + off, vl), vl
+                    );
                     is = __riscv_vwredsum_vs_i16m8_i32m1(prod, is, vl);
                     off += vl;
                 }
-                acc += ascale_row[b] * bscale_col[b] * static_cast<float>(__riscv_vmv_x_s_i32m1_i32(is))
-                       - asum_row[b] * bblksum_col[b];
+                acc += ascale_row[b] * bscale_col[b] * static_cast<float>(__riscv_vmv_x_s_i32m1_i32(is)) - asum_row[b] * bblksum_col[b];
             }
             C[mm * ldc + cc] = acc + bias;
         }
@@ -991,24 +992,29 @@ RvvSQ8BitGemmKernel_BlkSum_CompInt8(
 
 #if defined(MLAS_USE_RVV_ZVFH)
 // Defined in hqnbitgemm_kernel_rvv.cpp (compiled with -march=rv64gcv_zvfh).
-void RvvHQ4BitBlkDequantBForHgemm_CompFp16(
-    size_t BlkLen, MLAS_FP16* FpData, const std::byte* QuantBData, const MLAS_FP16* QuantBScale,
-    const std::byte* QuantBZeroPoint, size_t CountN, size_t CountK, size_t BlockCountK);
-void RvvHQ4BitGemmKernel_CompFp16(
-    const MLAS_FP16* A, const MLAS_FP16* B, const MLAS_FP16* Bias, MLAS_FP16* C,
-    size_t CountM, size_t CountN, size_t K, size_t lda, size_t ldb, size_t ldc);
-void RvvHQ8BitBlkDequantBForHgemm_CompFp16(
-    size_t BlkLen, MLAS_FP16* FpData, const std::byte* QuantBData, const MLAS_FP16* QuantBScale,
-    const std::byte* QuantBZeroPoint, size_t CountN, size_t CountK, size_t BlockCountK);
+void
+RvvHQ4BitBlkDequantBForHgemm_CompFp16(
+    size_t BlkLen, MLAS_FP16* FpData, const std::byte* QuantBData, const MLAS_FP16* QuantBScale, const std::byte* QuantBZeroPoint, size_t CountN, size_t CountK, size_t BlockCountK
+);
+void
+RvvHQ4BitGemmKernel_CompFp16(
+    const MLAS_FP16* A, const MLAS_FP16* B, const MLAS_FP16* Bias, MLAS_FP16* C, size_t CountM, size_t CountN, size_t K, size_t lda, size_t ldb, size_t ldc
+);
+void
+RvvHQ8BitBlkDequantBForHgemm_CompFp16(
+    size_t BlkLen, MLAS_FP16* FpData, const std::byte* QuantBData, const MLAS_FP16* QuantBScale, const std::byte* QuantBZeroPoint, size_t CountN, size_t CountK, size_t BlockCountK
+);
 #endif
 
 //
 // RVV QNBit GEMM dispatch.
 //
-// SQNBIT_CompFp32 (4-bit) is wired up: the two kernels above plus the portable
-// packing/workspace helpers make MlasIsQNBitGemmAvailable() return true for
-// that variant. The CompInt8 and 8-bit compute kernels remain null and fall
-// back to the generic path.
+// Wires up the portable packing/workspace helpers (always) plus, under
+// MLAS_USE_RVV, the SQNBIT_CompFp32 (4-bit) and SQNBIT_CompInt8 (4-bit and
+// 8-bit) compute kernels, and, under MLAS_USE_RVV_ZVFH, the HQNBIT_CompFp16
+// (4-bit and 8-bit) kernels. Compute-type/bit-width variants without an
+// assignment below remain null, so MlasIsQNBitGemmAvailable() reports them
+// unavailable and they fall back to the generic path.
 //
 const MLAS_QNBIT_GEMM_DISPATCH MlasSQNBitGemmDispatchRvv = []() {
     MLAS_QNBIT_GEMM_DISPATCH d;

--- a/onnxruntime/core/mlas/lib/riscv64/qnbitgemm_kernel_rvv.cpp
+++ b/onnxruntime/core/mlas/lib/riscv64/qnbitgemm_kernel_rvv.cpp
@@ -1,0 +1,1049 @@
+/*++
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the MIT License.
+
+Module Name:
+
+    qnbitgemm_kernel_rvv.cpp
+
+Abstract:
+
+    This module implements the RISC-V Vector (RVV) kernels for n-bit quantized
+    GEMM (MatMulNBits).
+
+    Implemented:
+      - Packed-B / per-GEMM workspace sizing helpers.
+      - SQNBIT_CompFp32 (4-bit weights): M==1 GEMV kernel + dequantize-B-for-SGEMM.
+      - SQNBIT_CompInt8 (4-bit weights): QuantizeARow + int8xint4 kernel.
+      - SQNBIT_CompInt8 (8-bit weights): pack-with-blksum, QuantizeARowComputeBlkSum
+        and the int8xint8 BlkSum kernel.
+      - HQNBIT_CompFp16 pack helpers (fp16 dequant/kernel live in
+        hqnbitgemm_kernel_rvv.cpp, which requires Zvfh).
+
+    The packed-B / block-sum layouts are private to this dispatch (produced here
+    and consumed only by these kernels), so plain layouts are used throughout.
+
+--*/
+
+#include "mlasi.h"
+
+#if defined(MLAS_USE_RVV)
+
+#include <riscv_vector.h>
+
+#endif
+
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+
+#include "qnbitgemm.h"
+#include "sqnbitgemm_q8_block.h"
+
+namespace
+{
+
+//
+// Quantized B data packing.
+//
+// The packing is a pure byte-layout transform shared with the other backends
+// (see the NEON implementation); it contains no architecture-specific
+// intrinsics, so the RVV path reuses the same logic.
+//
+
+size_t
+RvvQ4BitGemmPackQuantBDataSize(
+    size_t N,
+    size_t K,
+    size_t BlkLen,
+    bool /*HasZeroPoint*/,
+    MLAS_QNBIT_GEMM_COMPUTE_TYPE /*ComputeType*/,  // same size regardless of ComputeType
+    const MLAS_BACKEND_KERNEL_SELECTOR_CONFIG* /*BackendKernelSelectorConfig*/
+)
+{
+    constexpr size_t BlkBitWidth = 4;
+    const size_t BlockCountK = MlasDivRoundup(K, BlkLen);
+    const size_t PackedQuantBDataSize = N * BlockCountK * MlasQNBitBlkDataSizeInBytes(BlkBitWidth, BlkLen);
+    return PackedQuantBDataSize;
+}
+
+// SQ8 (8-bit weight) CompInt8 packed-B workspace sizing. The workspace holds
+// the packed 8-bit B data, then the per-(N,block) B block-sums, then the B
+// scales (matching PackedQuantBDataStruct's signed-QuantA layout). Sizes and
+// alignment slack mirror the portable reference so the struct's offsets fit.
+size_t
+RvvQ8BitGemmPackQuantBDataSize(
+    size_t N,
+    size_t K,
+    size_t BlkLen,
+    bool /*HasZeroPoint*/,
+    MLAS_QNBIT_GEMM_COMPUTE_TYPE ComputeType,
+    const MLAS_BACKEND_KERNEL_SELECTOR_CONFIG* /*BackendKernelSelectorConfig*/
+)
+{
+    constexpr size_t BlkBitWidth = 8;
+    const size_t BlockCountK = MlasDivRoundup(K, BlkLen);
+    size_t PackedQuantBDataSize = N * BlockCountK * MlasQNBitBlkDataSizeInBytes(BlkBitWidth, BlkLen);
+
+    if (ComputeType == SQNBIT_CompInt8) {
+        const size_t ScaleSize = N * BlockCountK * sizeof(float);
+        size_t BlkSumSize = MlasDivRoundup(N, 16) * BlockCountK * 16 * sizeof(float);
+
+        constexpr size_t PackedQuantBDataAlignment = 32;
+        PackedQuantBDataSize += PackedQuantBDataAlignment - 1;
+        constexpr size_t BlkSumAlignment = MlasQNBitQuantBBlkSumAlignment();
+        BlkSumSize += BlkSumAlignment - 1;
+
+        return PackedQuantBDataSize + ScaleSize + BlkSumSize;
+    }
+    return PackedQuantBDataSize;
+}
+
+// Pack 8-bit B and compute per-block sums. The packed data, scales and
+// block-sums are private to the RVV dispatch, so plain [N][BlockCountK] layouts
+// are used. QuantBBlkSum[n][b] = bScale * bZeroPoint (bZeroPoint defaults to
+// 128 when zero points are absent); the kernel subtracts ABlockSum * this.
+void
+RvvSQ8BitGemmPackQuantBDataAndBlkSum(
+    size_t N,
+    size_t K,
+    size_t BlkLen,
+    MLAS_QNBIT_GEMM_COMPUTE_TYPE /*ComputeType*/,
+    const std::byte* QuantBDataBegin,
+    const float* QuantBScaleBegin,
+    bool HasZeroPoint,
+    const std::byte* QuantBZPBegin,
+    PackedQuantBDataStruct<float, 8>& PackedQuantB,
+    MLAS_THREADPOOL* ThreadPool,
+    const MLAS_BACKEND_KERNEL_SELECTOR_CONFIG* /*BackendKernelSelectorConfig*/
+)
+{
+    const size_t BlockCountK = MlasDivRoundup(K, BlkLen);
+    const size_t DataBytesPerCol = BlockCountK * BlkLen;  // 8-bit: one byte per weight
+
+    std::byte* PackedData = PackedQuantB.PackedQuantBData;
+    float* PackedScale = PackedQuantB.PackedQuantBScale;
+    float* BlkSum = PackedQuantB.QuantBBlkSum;
+
+    // MatMulNBits prepacks weights, scales and zero points in three separate
+    // calls (each with the others null). The block sum needs both the scale and
+    // the zero point, which arrive in different calls, so it is finalized from
+    // the already-packed scale: with a zero point when it arrives, or with the
+    // default zero point of 128 at scale-packing time when there is none.
+    MlasTrySimpleParallel(
+        ThreadPool, static_cast<ptrdiff_t>(N),
+        [&](ptrdiff_t n) {
+            const size_t row = static_cast<size_t>(n) * BlockCountK;
+
+            if (QuantBDataBegin != nullptr) {
+                std::memcpy(PackedData + static_cast<size_t>(n) * DataBytesPerCol,
+                            QuantBDataBegin + static_cast<size_t>(n) * DataBytesPerCol, DataBytesPerCol);
+            }
+
+            if (QuantBScaleBegin != nullptr) {
+                for (size_t b = 0; b < BlockCountK; ++b) {
+                    const float scale = QuantBScaleBegin[row + b];
+                    PackedScale[row + b] = scale;
+                    if (!HasZeroPoint) {
+                        BlkSum[row + b] = scale * 128.0f;
+                    }
+                }
+            }
+
+            if (QuantBZPBegin != nullptr) {
+                for (size_t b = 0; b < BlockCountK; ++b) {
+                    const float zp = static_cast<float>(std::to_integer<uint8_t>(QuantBZPBegin[row + b]));
+                    BlkSum[row + b] = PackedScale[row + b] * zp;
+                }
+            }
+        }
+    );
+}
+
+#if defined(MLAS_USE_RVV_ZVFH)
+// Plain 8-bit B-data packing for the HQNBIT_CompFp16 path (private to this
+// dispatch; the fp16 dequant reads it as [N][BlockCountK][BlkLen] bytes).
+void
+RvvHQ8BitGemmPackQuantBData(
+    size_t N,
+    size_t K,
+    size_t BlkLen,
+    MLAS_QNBIT_GEMM_COMPUTE_TYPE /*ComputeType*/,
+    const std::byte* QuantBDataBegin,
+    std::byte* PackedQuantBDataBegin,
+    MLAS_THREADPOOL* /*ThreadPool*/,
+    const MLAS_BACKEND_KERNEL_SELECTOR_CONFIG* /*BackendKernelSelectorConfig*/
+)
+{
+    if (QuantBDataBegin == nullptr) {
+        return;
+    }
+    const size_t total = N * MlasDivRoundup(K, BlkLen) * BlkLen;  // 8-bit: one byte per weight
+    std::memcpy(PackedQuantBDataBegin, QuantBDataBegin, total);
+}
+#endif  // MLAS_USE_RVV_ZVFH
+
+void
+RvvSQ4BitGemmPackQuantBData(
+    size_t N,
+    size_t K,
+    size_t BlkLen,
+    MLAS_QNBIT_GEMM_COMPUTE_TYPE ComputeType,
+    const std::byte* QuantBDataBegin,
+    std::byte* PackedQuantBDataBegin,
+    MLAS_THREADPOOL* ThreadPool,
+    const MLAS_BACKEND_KERNEL_SELECTOR_CONFIG* /*BackendKernelSelectorConfig*/
+)
+{
+    constexpr size_t BlkBitWidth = 4;
+
+    assert(BlkLen >= 16 && BlkLen % 16 == 0);
+
+    // MatMulNBits prepacks weights, scales and zero points in separate calls;
+    // this function only packs the weight data, so ignore the calls where the
+    // weight data is absent.
+    if (QuantBDataBegin == nullptr) {
+        return;
+    }
+
+    MLAS_UNREFERENCED_PARAMETER(ComputeType);
+
+    const size_t BlockCountK = MlasDivRoundup(K, BlkLen);
+    const size_t BlkDataSize = MlasQNBitBlkDataSizeInBytes(BlkBitWidth, BlkLen);
+    const size_t Iterations = N * BlockCountK;  // one iteration per block
+
+    // This packed layout is private to the RVV dispatch (produced here, consumed
+    // only by the RVV compute kernels), so a single SubBlkLen == 16 layout is
+    // used for both the CompFp32 and CompInt8 paths.
+    const size_t SubBlkLen = 16;
+
+    const size_t SubBlkDataSize = SubBlkLen / 2;
+    const size_t SubBlkBytePairCount = SubBlkLen / 4;
+
+    //
+    // For SubBlkLen == 16, pack 16 4-bit values (8 bytes) at a time like this:
+    //
+    // src: | v0 v1 | v2 v3 | v4 v5 | v6 v7 | v8 v9 | vA vB | vC vD | vE vF |
+    //   =>
+    // dst: | v0 v8 | v1 v9 | v2 vA | v3 vB | v4 vC | v5 vD | v6 vE | v7 vF |
+    //
+    // For SubBlkLen == 32, pack 32 4-bit values (16 bytes) at a time like this:
+    //
+    // src: | v0  v1  | v2  v3  | ... | v28 v29 | v30 v31 |
+    //   =>
+    // dst: | v0  v16 | v1  v17 | ... | v14 v30 | v15 v31 |
+    //
+
+    MlasTrySimpleParallel(
+        ThreadPool, Iterations,
+        [&](ptrdiff_t tid) {
+            const size_t n = tid / BlockCountK;
+            const size_t k_blk = tid % BlockCountK;
+
+            const size_t data_offset = n * BlockCountK * BlkDataSize + k_blk * BlkDataSize;
+            const std::byte* QuantBData = QuantBDataBegin + data_offset;
+            std::byte* PackedQuantBData = PackedQuantBDataBegin + data_offset;
+
+            for (size_t kk = 0; kk < BlkLen; kk += SubBlkLen) {
+                for (size_t byte_pair_idx = 0; byte_pair_idx < SubBlkBytePairCount; ++byte_pair_idx) {
+                    const std::byte src0 = QuantBData[byte_pair_idx];
+                    const std::byte src1 = QuantBData[byte_pair_idx + SubBlkDataSize / 2];
+
+                    std::byte& dst0 = PackedQuantBData[2 * byte_pair_idx];
+                    std::byte& dst1 = PackedQuantBData[2 * byte_pair_idx + 1];
+
+                    dst0 = (src0 & std::byte{0x0F}) | ((src1 & std::byte{0x0F}) << 4);
+                    dst1 = (src0 >> 4) | ((src1 >> 4) << 4);
+                }
+
+                QuantBData += SubBlkDataSize;
+                PackedQuantBData += SubBlkDataSize;
+            }
+        }
+    );
+}
+
+//
+// Per-GEMM intermediate workspace sizing.
+//
+// The CompInt8 path uses the workspace to hold the block-quantized int8 copy
+// of A (data + scale + block-sum). This sizing is architecture-independent.
+//
+
+size_t
+RvvQNBitGemmPerGemmWorkspaceSize(
+    size_t M,
+    size_t N,
+    size_t K,
+    size_t BlkLen,
+    bool /*HasZeroPoint*/,
+    MLAS_QNBIT_GEMM_COMPUTE_TYPE ComputeType,
+    size_t /*BlkBitWidth*/,
+    const MLAS_BACKEND_KERNEL_SELECTOR_CONFIG* /*BackendKernelSelectorConfig*/
+)
+{
+    MLAS_UNREFERENCED_PARAMETER(N);
+
+    switch (ComputeType) {
+        case SQNBIT_CompInt8: {
+            // workspace buffer is used for block quantization of A to int8
+            const size_t BlockCountK = MlasDivRoundup(K, BlkLen);
+            // QuantData + Scale + BlkSum
+            const size_t PerGemmWorkspaceSize = M * BlockCountK * (Q8BlkSize(BlkLen) + sizeof(float));
+            return PerGemmWorkspaceSize;
+        }
+        default: {
+            return 0;
+        }
+    }
+}
+
+size_t
+RvvQNBitGemmPerGemmWorkspaceAlignment(
+    size_t /*BlkLen*/,
+    MLAS_QNBIT_GEMM_COMPUTE_TYPE ComputeType
+)
+{
+    switch (ComputeType) {
+        case SQNBIT_CompInt8: {
+            return Q8BlkAlignment();
+        }
+        default: {
+            return 1;
+        }
+    }
+}
+
+#if defined(MLAS_USE_RVV)
+
+//
+// SQNBIT_CompFp32 kernels for 4-bit weights.
+//
+// Both kernels consume the packed B produced by RvvSQ4BitGemmPackQuantBData
+// with SubBlkLen == 16: within each 16-element sub-block (8 bytes), byte b
+// holds element b in its low nibble and element (b + 8) in its high nibble.
+// Dequantization is value = (nibble - offset) * scale, where offset is the
+// block's zero point, or 8 when zero points are not provided.
+//
+
+constexpr size_t SubBlkLen = 16;
+
+// Dequantize one sub-block (up to 16 elements) of a single B column into a
+// natural-order float buffer. `packed` points at the sub-block's bytes;
+// `len` valid elements are written to `out[0..len-1]`.
+MLAS_FORCEINLINE void
+DequantSubblockToFloat(
+    const uint8_t* packed,
+    size_t len,
+    float offset,
+    float scale,
+    float* out
+)
+{
+    const size_t low_count = std::min(len, SubBlkLen / 2);
+
+    // low nibbles -> elements [0, low_count)
+    {
+        const size_t vl = __riscv_vsetvl_e8m1(low_count);
+        const vuint8m1_t b = __riscv_vle8_v_u8m1(packed, vl);
+        const vuint8m1_t nib = __riscv_vand_vx_u8m1(b, 0x0F, vl);
+        const vuint16m2_t w16 = __riscv_vzext_vf2_u16m2(nib, vl);
+        const vuint32m4_t w32 = __riscv_vzext_vf2_u32m4(w16, vl);
+        vfloat32m4_t f = __riscv_vfcvt_f_xu_v_f32m4(w32, vl);
+        f = __riscv_vfsub_vf_f32m4(f, offset, vl);
+        f = __riscv_vfmul_vf_f32m4(f, scale, vl);
+        __riscv_vse32_v_f32m4(out, f, vl);
+    }
+
+    // high nibbles -> elements [8, len)
+    if (len > SubBlkLen / 2) {
+        const size_t high_count = len - SubBlkLen / 2;
+        const size_t vl = __riscv_vsetvl_e8m1(high_count);
+        const vuint8m1_t b = __riscv_vle8_v_u8m1(packed, vl);
+        const vuint8m1_t nib = __riscv_vsrl_vx_u8m1(b, 4, vl);
+        const vuint16m2_t w16 = __riscv_vzext_vf2_u16m2(nib, vl);
+        const vuint32m4_t w32 = __riscv_vzext_vf2_u32m4(w16, vl);
+        vfloat32m4_t f = __riscv_vfcvt_f_xu_v_f32m4(w32, vl);
+        f = __riscv_vfsub_vf_f32m4(f, offset, vl);
+        f = __riscv_vfmul_vf_f32m4(f, scale, vl);
+        __riscv_vse32_v_f32m4(out + SubBlkLen / 2, f, vl);
+    }
+}
+
+// Extract the 4-bit zero point for block `blk_idx` of a single column.
+MLAS_FORCEINLINE float
+DequantOffset(const std::byte* zp_col, size_t blk_idx, bool has_zero_point)
+{
+    if (!has_zero_point) {
+        return 8.0f;
+    }
+    const std::byte zp_packed = zp_col[blk_idx / 2];
+    const uint8_t zp = ((blk_idx & 1) == 1)
+                           ? std::to_integer<uint8_t>(zp_packed >> 4)
+                           : std::to_integer<uint8_t>(zp_packed & std::byte{0x0F});
+    return static_cast<float>(zp);
+}
+
+// Compute the dot product of one A row with one dequantized B column.
+template <bool HasZeroPoint>
+MLAS_FORCEINLINE float
+ComputeColumnDot_CompFp32(
+    size_t BlkLen,
+    const float* ARow,
+    const uint8_t* QuantBDataCol,
+    const float* QuantBScaleCol,
+    const std::byte* QuantBZeroPointCol,
+    size_t CountK
+)
+{
+    constexpr size_t BlkBitWidth = 4;
+    const size_t BlkDataSize = MlasQNBitBlkDataSizeInBytes(BlkBitWidth, BlkLen);
+
+    const size_t vlmax = __riscv_vsetvlmax_e32m1();
+    vfloat32m1_t acc = __riscv_vfmv_v_f_f32m1(0.0f, vlmax);
+
+    float bdeq[SubBlkLen];
+
+    size_t blk_idx = 0;
+    for (size_t k = 0; k < CountK; k += BlkLen, ++blk_idx) {
+        const float scale = QuantBScaleCol[blk_idx];
+        const float offset = DequantOffset(QuantBZeroPointCol, blk_idx, HasZeroPoint);
+        const size_t k_blk_len = std::min(CountK - k, BlkLen);
+        const uint8_t* blk_ptr = QuantBDataCol + blk_idx * BlkDataSize;
+
+        for (size_t kk = 0; kk < k_blk_len; kk += SubBlkLen) {
+            const size_t len = std::min(k_blk_len - kk, SubBlkLen);
+            DequantSubblockToFloat(blk_ptr + kk / 2, len, offset, scale, bdeq);
+
+            const float* a_ptr = ARow + k + kk;
+            for (size_t off = 0; off < len;) {
+                const size_t vl = __riscv_vsetvl_e32m1(len - off);
+                const vfloat32m1_t av = __riscv_vle32_v_f32m1(a_ptr + off, vl);
+                const vfloat32m1_t bv = __riscv_vle32_v_f32m1(bdeq + off, vl);
+                // tail-undisturbed: preserve accumulator lanes [vl, vlmax)
+                acc = __riscv_vfmacc_vv_f32m1_tu(acc, av, bv, vl);
+                off += vl;
+            }
+        }
+    }
+
+    vfloat32m1_t red = __riscv_vfmv_s_f_f32m1(0.0f, 1);
+    red = __riscv_vfredusum_vs_f32m1_f32m1(acc, red, vlmax);
+    return __riscv_vfmv_f_s_f32m1_f32(red);
+}
+
+template <bool HasZeroPoint>
+void
+SQ4BitGemmM1Kernel_CompFp32_Impl(
+    size_t BlkLen,
+    const float* A,
+    const std::byte* QuantBData,
+    const float* QuantBScale,
+    const std::byte* QuantBZeroPoint,
+    float* C,
+    size_t CountN,
+    size_t CountK,
+    size_t BlockCountK,
+    const float* Bias
+)
+{
+    constexpr size_t BlkBitWidth = 4;
+
+    const size_t StrideQuantBData = BlockCountK * MlasQNBitBlkDataSizeInBytes(BlkBitWidth, BlkLen);
+    const size_t StrideQuantBScale = BlockCountK;
+    const size_t StrideQuantBZeroPoint = MlasQNBitZeroPointsForBlksSizeInBytes<BlkBitWidth>(BlockCountK);
+
+    for (size_t n = 0; n < CountN; ++n) {
+        const uint8_t* b_data = reinterpret_cast<const uint8_t*>(QuantBData) + n * StrideQuantBData;
+        const float* b_scale = QuantBScale + n * StrideQuantBScale;
+        const std::byte* b_zp =
+            HasZeroPoint ? QuantBZeroPoint + n * StrideQuantBZeroPoint : nullptr;
+
+        float dot = ComputeColumnDot_CompFp32<HasZeroPoint>(
+            BlkLen, A, b_data, b_scale, b_zp, CountK
+        );
+
+        if (Bias != nullptr) {
+            dot += Bias[n];
+        }
+        C[n] = dot;
+    }
+}
+
+// Zero `count` floats starting at `p`.
+MLAS_FORCEINLINE void
+ZeroFloats(float* p, size_t count)
+{
+    const size_t vlmax = __riscv_vsetvlmax_e32m1();
+    const vfloat32m1_t zero = __riscv_vfmv_v_f_f32m1(0.0f, vlmax);
+    for (size_t off = 0; off < count;) {
+        const size_t vl = __riscv_vsetvl_e32m1(count - off);
+        __riscv_vse32_v_f32m1(p + off, zero, vl);
+        off += vl;
+    }
+}
+
+template <bool HasZeroPoint>
+void
+Q4BitBlkDequantBForSgemm_CompFp32_Impl(
+    size_t BlkLen,
+    float* FpData,
+    const std::byte* QuantBData,
+    const float* QuantBScale,
+    const std::byte* QuantBZeroPoint,
+    size_t CountN,
+    size_t CountK,
+    size_t BlockCountK
+)
+{
+    constexpr size_t BlkBitWidth = 4;
+    constexpr size_t PackWidth = 16;  // SGEMM CopyPackB column-panel width
+
+    const size_t BlkDataSize = MlasQNBitBlkDataSizeInBytes(BlkBitWidth, BlkLen);
+    const size_t StrideQuantBData = BlockCountK * BlkDataSize;
+    const size_t StrideQuantBScale = BlockCountK;
+    const size_t StrideQuantBZeroPoint = MlasQNBitZeroPointsForBlksSizeInBytes<BlkBitWidth>(BlockCountK);
+
+    // Destination layout matches "dequantize B then MlasSgemmCopyPackB": B is
+    // stored as PackWidth-column panels, K rows each; element (k, n_local) of
+    // panel g lives at FpData[g * PackWidth * CountK + k * PackWidth + n_local].
+    const ptrdiff_t DstColStride = static_cast<ptrdiff_t>(PackWidth * sizeof(float));
+
+    float bdeq[SubBlkLen];
+
+    size_t panel = 0;
+    for (size_t n0 = 0; n0 < CountN; n0 += PackWidth, ++panel) {
+        float* panel_base = FpData + panel * PackWidth * CountK;
+        const size_t n_cols = std::min(CountN - n0, PackWidth);
+
+        // Unused columns of a partial panel must read as zero for SGEMM.
+        if (n_cols < PackWidth) {
+            ZeroFloats(panel_base, PackWidth * CountK);
+        }
+
+        for (size_t nl = 0; nl < n_cols; ++nl) {
+            const size_t n = n0 + nl;
+            const uint8_t* b_data = reinterpret_cast<const uint8_t*>(QuantBData) + n * StrideQuantBData;
+            const float* b_scale = QuantBScale + n * StrideQuantBScale;
+            const std::byte* b_zp =
+                HasZeroPoint ? QuantBZeroPoint + n * StrideQuantBZeroPoint : nullptr;
+
+            size_t blk_idx = 0;
+            for (size_t k = 0; k < CountK; k += BlkLen, ++blk_idx) {
+                const float scale = b_scale[blk_idx];
+                const float offset = DequantOffset(b_zp, blk_idx, HasZeroPoint);
+                const size_t k_blk_len = std::min(CountK - k, BlkLen);
+                const uint8_t* blk_ptr = b_data + blk_idx * BlkDataSize;
+
+                for (size_t kk = 0; kk < k_blk_len; kk += SubBlkLen) {
+                    const size_t len = std::min(k_blk_len - kk, SubBlkLen);
+                    DequantSubblockToFloat(blk_ptr + kk / 2, len, offset, scale, bdeq);
+
+                    // Scatter the sub-block down column `nl` with panel stride.
+                    float* dst = panel_base + (k + kk) * PackWidth + nl;
+                    for (size_t off = 0; off < len;) {
+                        const size_t vl = __riscv_vsetvl_e32m1(len - off);
+                        const vfloat32m1_t v = __riscv_vle32_v_f32m1(bdeq + off, vl);
+                        __riscv_vsse32_v_f32m1(dst + off * PackWidth, DstColStride, v, vl);
+                        off += vl;
+                    }
+                }
+            }
+        }
+    }
+}
+
+//
+// SQNBIT_CompInt8 kernels for 4-bit weights.
+//
+// A is block-quantized to int8 (Q8 blocks: [float scale][BlkLen int8]); B is
+// the same packed 4-bit layout as above. For each block the integer dot
+// sum_i qa_i * (qb_i - offset) is computed exactly, then scaled by
+// (a_scale * b_scale) and accumulated across blocks.
+//
+
+// Unpack `len` (<=16) 4-bit weights of one sub-block into centered int8
+// (nibble - offset) in natural order.
+MLAS_FORCEINLINE void
+UnpackQbCentered(const uint8_t* packed, size_t len, int8_t offset, int8_t* out)
+{
+    const size_t low_count = std::min(len, SubBlkLen / 2);
+    {
+        const size_t vl = __riscv_vsetvl_e8m1(low_count);
+        const vuint8m1_t b = __riscv_vle8_v_u8m1(packed, vl);
+        const vuint8m1_t nib = __riscv_vand_vx_u8m1(b, 0x0F, vl);
+        vint8m1_t q = __riscv_vreinterpret_v_u8m1_i8m1(nib);
+        q = __riscv_vsub_vx_i8m1(q, offset, vl);
+        __riscv_vse8_v_i8m1(out, q, vl);
+    }
+    if (len > SubBlkLen / 2) {
+        const size_t high_count = len - SubBlkLen / 2;
+        const size_t vl = __riscv_vsetvl_e8m1(high_count);
+        const vuint8m1_t b = __riscv_vle8_v_u8m1(packed, vl);
+        const vuint8m1_t nib = __riscv_vsrl_vx_u8m1(b, 4, vl);
+        vint8m1_t q = __riscv_vreinterpret_v_u8m1_i8m1(nib);
+        q = __riscv_vsub_vx_i8m1(q, offset, vl);
+        __riscv_vse8_v_i8m1(out + SubBlkLen / 2, q, vl);
+    }
+}
+
+void
+RvvQuantizeARow_CompInt8_Impl(size_t BlkLen, const float* A, size_t CountK, std::byte* QuantA)
+{
+    const size_t BlockCountK = MlasDivRoundup(CountK, BlkLen);
+
+    std::byte* blk = QuantA;
+    for (size_t b = 0; b < BlockCountK; ++b, blk += Q8BlkSize(BlkLen)) {
+        const size_t k0 = b * BlkLen;
+        const size_t len = std::min(BlkLen, CountK - k0);
+        const float* a_ptr = A + k0;
+
+        // amax over the block
+        vfloat32m1_t vmax = __riscv_vfmv_s_f_f32m1(0.0f, 1);
+        for (size_t off = 0; off < len;) {
+            const size_t vl = __riscv_vsetvl_e32m1(len - off);
+            const vfloat32m1_t v = __riscv_vfabs_v_f32m1(__riscv_vle32_v_f32m1(a_ptr + off, vl), vl);
+            vmax = __riscv_vfredmax_vs_f32m1_f32m1(v, vmax, vl);
+            off += vl;
+        }
+        const float amax = __riscv_vfmv_f_s_f32m1_f32(vmax);
+        const float scale = amax / 127.0f;
+        const float inv_scale = (scale != 0.0f) ? (1.0f / scale) : 0.0f;
+
+        Q8BlkScale(blk) = scale;
+        int8_t* qd = Q8BlkData(blk);
+
+        // quantize block: q = clamp(round(a * inv_scale), -127, 127)
+        for (size_t off = 0; off < len;) {
+            const size_t vl = __riscv_vsetvl_e32m4(len - off);
+            vfloat32m4_t v = __riscv_vle32_v_f32m4(a_ptr + off, vl);
+            v = __riscv_vfmul_vf_f32m4(v, inv_scale, vl);
+            vint32m4_t iv = __riscv_vfcvt_x_f_v_i32m4(v, vl);
+            iv = __riscv_vmax_vx_i32m4(iv, -127, vl);
+            iv = __riscv_vmin_vx_i32m4(iv, 127, vl);
+            const vint16m2_t i16 = __riscv_vncvt_x_x_w_i16m2(iv, vl);
+            const vint8m1_t i8 = __riscv_vncvt_x_x_w_i8m1(i16, vl);
+            __riscv_vse8_v_i8m1(qd + off, i8, vl);
+            off += vl;
+        }
+
+        // zero-pad the remainder of the block
+        for (size_t i = len; i < BlkLen; ++i) {
+            qd[i] = 0;
+        }
+    }
+}
+
+template <bool HasZeroPoint>
+size_t
+SQ4BitGemmKernel_CompInt8_Impl(
+    size_t BlkLen,
+    const std::byte* QuantA,
+    const std::byte* QuantBData,
+    const float* QuantBScale,
+    const std::byte* QuantBZeroPoint,
+    float* C,
+    size_t CountM,
+    size_t CountN,
+    size_t CountK,
+    size_t BlockCountK,
+    size_t ldc,
+    const float* Bias
+)
+{
+    constexpr size_t BlkBitWidth = 4;
+
+    // Each B block is unpacked (nibbles -> centered int8) once into a scratch
+    // buffer and reused across an MTILE-row tile; the per-row K-reduction then
+    // runs at LMUL=4 over the whole block. This is far faster than reducing each
+    // 16-element sub-block separately (which is dominated by tiny reductions).
+    constexpr size_t MTILE = 8;
+    constexpr size_t UNPACK_CHUNK = 128;  // <= e8m4 VLMAX at VLEN>=256; bounds the scratch buffer
+
+    const size_t lda = BlockCountK * Q8BlkSize(BlkLen);
+    const size_t ldb = BlockCountK * MlasQNBitBlkDataSizeInBytes(BlkBitWidth, BlkLen);
+    const size_t Q8Sz = Q8BlkSize(BlkLen);
+    const size_t StrideQuantBZeroPoint = MlasQNBitZeroPointsForBlksSizeInBytes<BlkBitWidth>(BlockCountK);
+
+    int8_t qbc[UNPACK_CHUNK];
+
+    for (size_t nn = 0; nn < CountN; ++nn) {
+        const uint8_t* b_data = reinterpret_cast<const uint8_t*>(QuantBData) + nn * ldb;
+        const float* b_scale = QuantBScale + nn * BlockCountK;
+        const std::byte* b_zp = HasZeroPoint ? QuantBZeroPoint + nn * StrideQuantBZeroPoint : nullptr;
+        const float bias = (Bias != nullptr) ? Bias[nn] : 0.0f;
+
+        for (size_t m0 = 0; m0 < CountM; m0 += MTILE) {
+            const size_t mc = std::min(MTILE, CountM - m0);
+            float acc[MTILE] = {};
+
+            for (size_t b = 0; b < BlockCountK; ++b) {
+                const size_t k0 = b * BlkLen;
+                const size_t len = std::min(BlkLen, CountK - k0);
+                const int8_t offset = static_cast<int8_t>(
+                    HasZeroPoint ? static_cast<int>(DequantOffset(b_zp, b, true)) : 8);
+                const uint8_t* qb = b_data + b * MlasQNBitBlkDataSizeInBytes(BlkBitWidth, BlkLen);
+
+                int32_t isum[MTILE] = {};
+                for (size_t c0 = 0; c0 < len; c0 += UNPACK_CHUNK) {
+                    const size_t clen = std::min(len - c0, UNPACK_CHUNK);
+
+                    // Unpack this chunk of B once (centered int8), reused across the tile.
+                    for (size_t kk = 0; kk < clen; kk += SubBlkLen) {
+                        UnpackQbCentered(qb + (c0 + kk) / 2, std::min(clen - kk, SubBlkLen), offset, qbc + kk);
+                    }
+
+                    for (size_t mi = 0; mi < mc; ++mi) {
+                        const int8_t* qa = Q8BlkData(QuantA + (m0 + mi) * lda + b * Q8Sz) + c0;
+                        vint32m1_t is = __riscv_vmv_s_x_i32m1(0, 1);
+                        for (size_t off = 0; off < clen;) {
+                            const size_t vl = __riscv_vsetvl_e8m4(clen - off);
+                            const vint16m8_t prod = __riscv_vwmul_vv_i16m8(
+                                __riscv_vle8_v_i8m4(qa + off, vl), __riscv_vle8_v_i8m4(qbc + off, vl), vl);
+                            is = __riscv_vwredsum_vs_i16m8_i32m1(prod, is, vl);
+                            off += vl;
+                        }
+                        isum[mi] += __riscv_vmv_x_s_i32m1_i32(is);
+                    }
+                }
+
+                const float bs = b_scale[b];
+                for (size_t mi = 0; mi < mc; ++mi) {
+                    const float a_scale = Q8BlkScale(QuantA + (m0 + mi) * lda + b * Q8Sz);
+                    acc[mi] += a_scale * bs * static_cast<float>(isum[mi]);
+                }
+            }
+
+            for (size_t mi = 0; mi < mc; ++mi) {
+                C[(m0 + mi) * ldc + nn] = acc[mi] + bias;
+            }
+        }
+    }
+
+    return CountM;
+}
+
+//
+// SQNBIT_CompInt8 kernels for 8-bit weights (BlkSum path).
+//
+// A is signed int8 (scale = amax/127); B is raw uint8 with a per-block zero
+// point (default 128). Per block:
+//   C += aScale*bScale*sum_i(qa_i * qbRaw_i)  -  ABlockSum * (bScale*bZeroPoint)
+// which equals sum_i (aScale*qa_i) * (bScale*(qbRaw_i - bZeroPoint)) exactly.
+// ABlockSum = aScale * sum_i(qa_i); QuantBBlkSum = bScale*bZeroPoint.
+//
+
+void
+RvvQuantizeARowComputeBlkSum_CompInt8_Impl(
+    size_t BlkLen,
+    const float* A,
+    size_t CountK,
+    std::byte* QuantA,
+    float* QuantAScale,
+    float* AScaledBlkSum
+)
+{
+    const size_t BlockCountK = MlasDivRoundup(CountK, BlkLen);
+    int8_t* qdata = reinterpret_cast<int8_t*>(QuantA);
+
+    for (size_t b = 0; b < BlockCountK; ++b) {
+        const size_t k0 = b * BlkLen;
+        const size_t len = std::min(BlkLen, CountK - k0);
+        const float* a_ptr = A + k0;
+
+        vfloat32m1_t vmax = __riscv_vfmv_s_f_f32m1(0.0f, 1);
+        for (size_t off = 0; off < len;) {
+            const size_t vl = __riscv_vsetvl_e32m1(len - off);
+            const vfloat32m1_t v = __riscv_vfabs_v_f32m1(__riscv_vle32_v_f32m1(a_ptr + off, vl), vl);
+            vmax = __riscv_vfredmax_vs_f32m1_f32m1(v, vmax, vl);
+            off += vl;
+        }
+        const float amax = __riscv_vfmv_f_s_f32m1_f32(vmax);
+        const float scale = amax / 127.0f;
+        const float inv_scale = (amax != 0.0f) ? (127.0f / amax) : 0.0f;
+        QuantAScale[b] = scale;
+
+        int8_t* qd = qdata + b * BlkLen;
+        vint32m1_t isum = __riscv_vmv_s_x_i32m1(0, 1);
+        for (size_t off = 0; off < len;) {
+            const size_t vl = __riscv_vsetvl_e32m4(len - off);
+            vfloat32m4_t v = __riscv_vfmul_vf_f32m4(__riscv_vle32_v_f32m4(a_ptr + off, vl), inv_scale, vl);
+            vint32m4_t iv = __riscv_vfcvt_x_f_v_i32m4(v, vl);
+            iv = __riscv_vmax_vx_i32m4(iv, -127, vl);
+            iv = __riscv_vmin_vx_i32m4(iv, 127, vl);
+            const vint16m2_t i16 = __riscv_vncvt_x_x_w_i16m2(iv, vl);
+            const vint8m1_t i8 = __riscv_vncvt_x_x_w_i8m1(i16, vl);
+            __riscv_vse8_v_i8m1(qd + off, i8, vl);
+            const vint16m2_t w16 = __riscv_vsext_vf2_i16m2(i8, vl);
+            isum = __riscv_vwredsum_vs_i16m2_i32m1(w16, isum, vl);
+            off += vl;
+        }
+        const int32_t qsum = __riscv_vmv_x_s_i32m1_i32(isum);
+        AScaledBlkSum[b] = scale * static_cast<float>(qsum);
+
+        for (size_t i = len; i < BlkLen; ++i) {
+            qd[i] = 0;
+        }
+    }
+}
+
+size_t
+SQ8BitGemmKernel_BlkSum_CompInt8_Impl(
+    size_t BlkLen,
+    const std::byte* QuantA,
+    const float* QuantAScale,
+    const std::byte* QuantBData,
+    const float* QuantBScale,
+    float* C,
+    size_t CountM,
+    size_t CountN,
+    size_t CountK,
+    size_t BlockCountK,
+    const float* Bias,
+    size_t ldc,
+    const float* ABlockSum,
+    const float* QuantBBlkSum
+)
+{
+    // int8(A) x uint8(B) block-sum kernel. The K-reduction runs at LMUL=4
+    // (128 int8 elems per vwmulsu), which measurably beats LMUL=1 + row tiling
+    // on this hardware: the kernel is bound by the widening-multiply throughput,
+    // so cutting per-chunk instruction/loop overhead is the effective lever.
+    const size_t lda = BlockCountK * BlkLen;  // int8 A data per row
+    const size_t ldb = BlockCountK * BlkLen;  // uint8 B data per column
+
+    const int8_t* a_data = reinterpret_cast<const int8_t*>(QuantA);
+    const uint8_t* b_data = reinterpret_cast<const uint8_t*>(QuantBData);
+
+    for (size_t cc = 0; cc < CountN; ++cc) {
+        const uint8_t* qb_col = b_data + cc * ldb;
+        const float* bscale_col = QuantBScale + cc * BlockCountK;
+        const float* bblksum_col = QuantBBlkSum + cc * BlockCountK;
+        const float bias = (Bias != nullptr) ? Bias[cc] : 0.0f;
+
+        for (size_t mm = 0; mm < CountM; ++mm) {
+            const int8_t* qa_row = a_data + mm * lda;
+            const float* ascale_row = QuantAScale + mm * BlockCountK;
+            const float* asum_row = ABlockSum + mm * BlockCountK;
+
+            float acc = 0.0f;
+            for (size_t b = 0; b < BlockCountK; ++b) {
+                const size_t len = std::min(BlkLen, CountK - b * BlkLen);
+                const uint8_t* qb = qb_col + b * BlkLen;
+                const int8_t* qa = qa_row + b * BlkLen;
+
+                vint32m1_t is = __riscv_vmv_s_x_i32m1(0, 1);
+                for (size_t off = 0; off < len;) {
+                    const size_t vl = __riscv_vsetvl_e8m4(len - off);
+                    const vint16m8_t prod = __riscv_vwmulsu_vv_i16m8(
+                        __riscv_vle8_v_i8m4(qa + off, vl), __riscv_vle8_v_u8m4(qb + off, vl), vl);
+                    is = __riscv_vwredsum_vs_i16m8_i32m1(prod, is, vl);
+                    off += vl;
+                }
+                acc += ascale_row[b] * bscale_col[b] * static_cast<float>(__riscv_vmv_x_s_i32m1_i32(is))
+                       - asum_row[b] * bblksum_col[b];
+            }
+            C[mm * ldc + cc] = acc + bias;
+        }
+    }
+
+    return CountM;
+}
+
+#endif  // MLAS_USE_RVV
+
+}  // namespace
+
+#if defined(MLAS_USE_RVV)
+
+void
+RvvSQ4BitGemmM1Kernel_CompFp32(
+    size_t BlkLen,
+    const float* A,
+    const std::byte* QuantBData,
+    const float* QuantBScale,
+    const std::byte* QuantBZeroPoint,
+    float* C,
+    size_t CountN,
+    size_t CountK,
+    size_t BlockCountK,
+    const float* Bias
+)
+{
+    if (QuantBZeroPoint != nullptr) {
+        SQ4BitGemmM1Kernel_CompFp32_Impl<true>(
+            BlkLen, A, QuantBData, QuantBScale, QuantBZeroPoint, C, CountN, CountK, BlockCountK, Bias
+        );
+    } else {
+        SQ4BitGemmM1Kernel_CompFp32_Impl<false>(
+            BlkLen, A, QuantBData, QuantBScale, QuantBZeroPoint, C, CountN, CountK, BlockCountK, Bias
+        );
+    }
+}
+
+void
+RvvSQ4BitBlkDequantBForSgemm_CompFp32(
+    size_t BlkLen,
+    float* FpData,
+    const std::byte* QuantBData,
+    const float* QuantBScale,
+    const std::byte* QuantBZeroPoint,
+    size_t CountN,
+    size_t CountK,
+    size_t BlockCountK
+)
+{
+    if (QuantBZeroPoint != nullptr) {
+        Q4BitBlkDequantBForSgemm_CompFp32_Impl<true>(
+            BlkLen, FpData, QuantBData, QuantBScale, QuantBZeroPoint, CountN, CountK, BlockCountK
+        );
+    } else {
+        Q4BitBlkDequantBForSgemm_CompFp32_Impl<false>(
+            BlkLen, FpData, QuantBData, QuantBScale, QuantBZeroPoint, CountN, CountK, BlockCountK
+        );
+    }
+}
+
+void
+RvvQuantizeARow_CompInt8(
+    size_t BlkLen,
+    const float* A,
+    size_t CountK,
+    std::byte* QuantA
+)
+{
+    RvvQuantizeARow_CompInt8_Impl(BlkLen, A, CountK, QuantA);
+}
+
+size_t
+RvvSQ4BitGemmKernel_CompInt8(
+    size_t BlkLen,
+    const std::byte* QuantA,
+    const std::byte* QuantBData,
+    const float* QuantBScale,
+    const std::byte* QuantBZeroPoint,
+    float* C,
+    size_t CountM,
+    size_t CountN,
+    size_t CountK,
+    size_t BlockCountK,
+    size_t ldc,
+    const float* Bias
+)
+{
+    if (QuantBZeroPoint != nullptr) {
+        return SQ4BitGemmKernel_CompInt8_Impl<true>(
+            BlkLen, QuantA, QuantBData, QuantBScale, QuantBZeroPoint, C,
+            CountM, CountN, CountK, BlockCountK, ldc, Bias
+        );
+    } else {
+        return SQ4BitGemmKernel_CompInt8_Impl<false>(
+            BlkLen, QuantA, QuantBData, QuantBScale, QuantBZeroPoint, C,
+            CountM, CountN, CountK, BlockCountK, ldc, Bias
+        );
+    }
+}
+
+void
+RvvQuantizeARowComputeBlkSum_CompInt8(
+    size_t BlkLen,
+    const float* A,
+    size_t CountK,
+    std::byte* QuantA,
+    float* QuantAScale,
+    float* AScaledGroupSum
+)
+{
+    RvvQuantizeARowComputeBlkSum_CompInt8_Impl(BlkLen, A, CountK, QuantA, QuantAScale, AScaledGroupSum);
+}
+
+size_t
+RvvSQ8BitGemmKernel_BlkSum_CompInt8(
+    size_t BlkLen,
+    const std::byte* QuantA,
+    const float* QuantAScale,
+    const std::byte* QuantBData,
+    const float* QuantBScale,
+    const std::byte* /*QuantBZeroPoint*/,  // zero point folded into QuantBBlkSum
+    float* C,
+    size_t CountM,
+    size_t CountN,
+    size_t CountK,
+    size_t BlockCountK,
+    const float* Bias,
+    size_t ldc,
+    const float* ABlockSum,
+    const float* QuantBBlkSum,
+    const float* /*BlkUnsignedQuantAZeroPointCorrection*/  // unused on the signed-A path
+)
+{
+    return SQ8BitGemmKernel_BlkSum_CompInt8_Impl(
+        BlkLen, QuantA, QuantAScale, QuantBData, QuantBScale, C,
+        CountM, CountN, CountK, BlockCountK, Bias, ldc, ABlockSum, QuantBBlkSum
+    );
+}
+
+#endif  // MLAS_USE_RVV
+
+#if defined(MLAS_USE_RVV_ZVFH)
+// Defined in hqnbitgemm_kernel_rvv.cpp (compiled with -march=rv64gcv_zvfh).
+void RvvHQ4BitBlkDequantBForHgemm_CompFp16(
+    size_t BlkLen, MLAS_FP16* FpData, const std::byte* QuantBData, const MLAS_FP16* QuantBScale,
+    const std::byte* QuantBZeroPoint, size_t CountN, size_t CountK, size_t BlockCountK);
+void RvvHQ4BitGemmKernel_CompFp16(
+    const MLAS_FP16* A, const MLAS_FP16* B, const MLAS_FP16* Bias, MLAS_FP16* C,
+    size_t CountM, size_t CountN, size_t K, size_t lda, size_t ldb, size_t ldc);
+void RvvHQ8BitBlkDequantBForHgemm_CompFp16(
+    size_t BlkLen, MLAS_FP16* FpData, const std::byte* QuantBData, const MLAS_FP16* QuantBScale,
+    const std::byte* QuantBZeroPoint, size_t CountN, size_t CountK, size_t BlockCountK);
+#endif
+
+//
+// RVV QNBit GEMM dispatch.
+//
+// SQNBIT_CompFp32 (4-bit) is wired up: the two kernels above plus the portable
+// packing/workspace helpers make MlasIsQNBitGemmAvailable() return true for
+// that variant. The CompInt8 and 8-bit compute kernels remain null and fall
+// back to the generic path.
+//
+const MLAS_QNBIT_GEMM_DISPATCH MlasSQNBitGemmDispatchRvv = []() {
+    MLAS_QNBIT_GEMM_DISPATCH d;
+
+    d.Q4BitGemmPackQuantBDataSize = RvvQ4BitGemmPackQuantBDataSize;
+    d.SQ4BitGemmPackQuantBData = RvvSQ4BitGemmPackQuantBData;
+
+    d.Q8BitGemmPackQuantBDataSize = RvvQ8BitGemmPackQuantBDataSize;
+    d.SQ8BitGemmPackQuantBDataAndBlkSum = RvvSQ8BitGemmPackQuantBDataAndBlkSum;
+
+    d.QNBitGemmPerGemmWorkspaceSize = RvvQNBitGemmPerGemmWorkspaceSize;
+    d.QNBitGemmPerGemmWorkspaceAlignment = RvvQNBitGemmPerGemmWorkspaceAlignment;
+
+#if defined(MLAS_USE_RVV)
+    d.SQ4BitGemmM1Kernel_CompFp32 = RvvSQ4BitGemmM1Kernel_CompFp32;
+    d.SQ4BitBlkDequantBForSgemm_CompFp32 = RvvSQ4BitBlkDequantBForSgemm_CompFp32;
+
+    d.QuantizeARow_CompInt8 = RvvQuantizeARow_CompInt8;
+    d.SQ4BitGemmKernel_CompInt8 = RvvSQ4BitGemmKernel_CompInt8;
+
+    d.QuantizeARowComputeBlkSum_CompInt8 = RvvQuantizeARowComputeBlkSum_CompInt8;
+    d.SQ8BitGemmKernel_BlkSum_CompInt8 = RvvSQ8BitGemmKernel_BlkSum_CompInt8;
+#endif
+
+#if defined(MLAS_USE_RVV_ZVFH)
+    // HQNBIT_CompFp16 (4-bit weights, fp16 activations). The B-data packing is
+    // type-agnostic, so it reuses the SubBlkLen=16 nibble pack.
+    d.HQ4BitGemmPackQuantBData = RvvSQ4BitGemmPackQuantBData;
+    d.HQ4BitBlkDequantBForHgemm_CompFp16 = RvvHQ4BitBlkDequantBForHgemm_CompFp16;
+    d.HQ4BitGemmKernel_CompFp16 = RvvHQ4BitGemmKernel_CompFp16;
+
+    // HQ8 (8-bit weights, fp16 activations) reuses the fp16 GEMM kernel above.
+    d.HQ8BitGemmPackQuantBData = RvvHQ8BitGemmPackQuantBData;
+    d.HQ8BitBlkDequantBForHgemm_CompFp16 = RvvHQ8BitBlkDequantBForHgemm_CompFp16;
+#endif
+
+    return d;
+}();

--- a/onnxruntime/core/mlas/lib/riscv64/qnbitgemm_kernel_rvv.cpp
+++ b/onnxruntime/core/mlas/lib/riscv64/qnbitgemm_kernel_rvv.cpp
@@ -230,12 +230,6 @@ RvvSQ4BitGemmPackQuantBData(
     //   =>
     // dst: | v0 v8 | v1 v9 | v2 vA | v3 vB | v4 vC | v5 vD | v6 vE | v7 vF |
     //
-    // For SubBlkLen == 32, pack 32 4-bit values (16 bytes) at a time like this:
-    //
-    // src: | v0  v1  | v2  v3  | ... | v28 v29 | v30 v31 |
-    //   =>
-    // dst: | v0  v16 | v1  v17 | ... | v14 v30 | v15 v31 |
-    //
 
     MlasTrySimpleParallel(
         ThreadPool, Iterations,

--- a/onnxruntime/test/mlas/unittest/test_qnbitgemm_rvv_fp16.cpp
+++ b/onnxruntime/test/mlas/unittest/test_qnbitgemm_rvv_fp16.cpp
@@ -1,0 +1,192 @@
+/*++
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the MIT License.
+
+Module Name:
+
+    test_qnbitgemm_rvv_fp16.cpp
+
+Abstract:
+
+    End-to-end tests for the RISC-V RVV HQNBIT_CompFp16 (fp16 activation) path of
+    MatMulNBits: pack quantized B, dequantize it through the platform dispatch,
+    run the fp16 GEMM kernel, and compare against a reference. Requires Zvfh.
+
+--*/
+
+#include "test_util.h"
+#include "core/mlas/lib/mlasi.h"
+#include "core/mlas/lib/qnbitgemm.h"
+#include "mlas_qnbit.h"
+
+#if defined(MLAS_TARGET_RISCV64) && defined(MLAS_USE_RVV_ZVFH)
+
+class MlasRvvFp16HQ4GemmTest : public MlasTestBase {
+ private:
+  unsigned int seed_ = 1234;
+  std::mt19937 gen_{seed_};
+  MatrixGuardBuffer<uint8_t> rawB_, packedB_, zp_;
+  MatrixGuardBuffer<MLAS_FP16> A_, scale_, bias_, dequantB_, C_;
+
+  static float H2F(MLAS_FP16 h) { return h.ToFloat(); }
+
+  template <size_t M, size_t N, size_t K, size_t BlkLen, bool HasZp, bool HasBias>
+  void RunOne() {
+    if (!MlasIsQNBitGemmAvailable(4, BlkLen, HQNBIT_CompFp16)) {
+      GTEST_SKIP() << "HQNBIT_CompFp16 not available";
+    }
+    const auto* dispatch = GetMlasPlatform().QNBitGemmDispatch;
+    constexpr size_t BlkBitWidth = 4;
+    constexpr size_t BCK = (K + BlkLen - 1) / BlkLen;
+    constexpr size_t ldb = BCK * BlkLen;
+    constexpr size_t BlkDataSize = BlkLen / 2;  // 4-bit
+    const size_t ZpBytesPerCol = (BCK + 1) / 2;
+
+    std::uniform_int_distribution<int> u8(0, 255);
+
+    // Raw 4-bit B (two nibbles per byte), row-major [N][BCK*BlkDataSize].
+    auto* rawB = rawB_.GetBuffer(N * BCK * BlkDataSize, true);
+    for (size_t i = 0; i < N * BCK * BlkDataSize; ++i) rawB[i] = static_cast<uint8_t>(u8(gen_));
+
+    auto* scale = scale_.GetBuffer(N * BCK, true);
+    for (size_t i = 0; i < N * BCK; ++i) scale[i] = MLAS_FP16(0.02f + (u8(gen_) % 32) * 0.01f);
+
+    uint8_t* zp = nullptr;
+    if (HasZp) {
+      zp = zp_.GetBuffer(N * ZpBytesPerCol, true);
+      for (size_t i = 0; i < N * ZpBytesPerCol; ++i) zp[i] = static_cast<uint8_t>(u8(gen_));
+    }
+
+    auto* A = A_.GetBuffer(M * K, true);
+    for (size_t i = 0; i < M * K; ++i) A[i] = MLAS_FP16(-1.5f + (u8(gen_) % 96) * 0.03f);
+    auto* bias = bias_.GetBuffer(N, true);
+    for (size_t i = 0; i < N; ++i) bias[i] = MLAS_FP16(-0.5f + (u8(gen_) % 64) * 0.02f);
+
+    // Pack B through the real pack entry point.
+    const size_t packedSize = MlasQNBitGemmPackQuantBDataSize(N, K, BlkBitWidth, BlkLen, HasZp, HQNBIT_CompFp16, nullptr);
+    ASSERT_GT(packedSize, size_t{0});
+    auto* packedB = packedB_.GetBuffer(packedSize, true);
+    MlasQNBitGemmPackQuantBData(N, K, BlkBitWidth, BlkLen, HQNBIT_CompFp16,
+                                rawB, packedB, /*scale*/ nullptr, HasZp, /*zp*/ nullptr, nullptr, nullptr);
+
+    // Dequantize B to fp16 through the dispatch.
+    auto* dequantB = dequantB_.GetBuffer(N * ldb, true);
+    dispatch->HQ4BitBlkDequantBForHgemm_CompFp16(
+        BlkLen, dequantB, reinterpret_cast<const std::byte*>(packedB), scale,
+        HasZp ? reinterpret_cast<const std::byte*>(zp) : nullptr, N, K, BCK);
+
+    // fp16 GEMM through the dispatch.
+    auto* C = C_.GetBuffer(M * N, true);
+    dispatch->HQ4BitGemmKernel_CompFp16(A, dequantB, HasBias ? bias : nullptr, C, M, N, K, K, ldb, N);
+
+    // Reference: fp32 accumulate over the same fp16 A and fp16 dequantized B.
+    double maxrel = 0.0;
+    for (size_t m = 0; m < M; ++m) {
+      for (size_t n = 0; n < N; ++n) {
+        double acc = HasBias ? H2F(bias[n]) : 0.0;
+        double absum = HasBias ? std::fabs(H2F(bias[n])) : 0.0;
+        for (size_t k = 0; k < K; ++k) {
+          double t = static_cast<double>(H2F(A[m * K + k])) * H2F(dequantB[n * ldb + k]);
+          acc += t;
+          absum += std::fabs(t);
+        }
+        const double got = H2F(C[m * N + n]);
+        maxrel = std::max(maxrel, std::fabs(got - acc) / (absum + 1e-3));
+      }
+    }
+    ASSERT_LT(maxrel, 6e-3) << " M=" << M << " N=" << N << " K=" << K << " BlkLen=" << BlkLen
+                            << " zp=" << HasZp << " bias=" << HasBias;
+  }
+
+  // HQ8: 8-bit weights, fp16 activations (plain 8-bit pack + HQ8 dequant + shared fp16 kernel).
+  template <size_t M, size_t N, size_t K, size_t BlkLen, bool HasZp, bool HasBias>
+  void RunOne8() {
+    if (!MlasIsQNBitGemmAvailable(8, BlkLen, HQNBIT_CompFp16)) {
+      GTEST_SKIP() << "HQNBIT_CompFp16 (8-bit) not available";
+    }
+    const auto* dispatch = GetMlasPlatform().QNBitGemmDispatch;
+    constexpr size_t BlkBitWidth = 8;
+    constexpr size_t BCK = (K + BlkLen - 1) / BlkLen;
+    constexpr size_t ldb = BCK * BlkLen;  // 8-bit: one byte per weight
+
+    std::uniform_int_distribution<int> u8(0, 255);
+
+    auto* rawB = rawB_.GetBuffer(N * ldb, true);
+    for (size_t i = 0; i < N * ldb; ++i) rawB[i] = static_cast<uint8_t>(u8(gen_));
+    auto* scale = scale_.GetBuffer(N * BCK, true);
+    for (size_t i = 0; i < N * BCK; ++i) scale[i] = MLAS_FP16(0.02f + (u8(gen_) % 32) * 0.01f);
+    uint8_t* zp = nullptr;
+    if (HasZp) {
+      zp = zp_.GetBuffer(N * BCK, true);  // 8-bit: one zp byte per block
+      for (size_t i = 0; i < N * BCK; ++i) zp[i] = static_cast<uint8_t>(u8(gen_));
+    }
+    auto* A = A_.GetBuffer(M * K, true);
+    for (size_t i = 0; i < M * K; ++i) A[i] = MLAS_FP16(-1.5f + (u8(gen_) % 96) * 0.03f);
+    auto* bias = bias_.GetBuffer(N, true);
+    for (size_t i = 0; i < N; ++i) bias[i] = MLAS_FP16(-0.5f + (u8(gen_) % 64) * 0.02f);
+
+    const size_t packedSize = MlasQNBitGemmPackQuantBDataSize(N, K, BlkBitWidth, BlkLen, HasZp, HQNBIT_CompFp16, nullptr);
+    ASSERT_GT(packedSize, size_t{0});
+    auto* packedB = packedB_.GetBuffer(packedSize, true);
+    MlasQNBitGemmPackQuantBData(N, K, BlkBitWidth, BlkLen, HQNBIT_CompFp16,
+                                rawB, packedB, nullptr, HasZp, nullptr, nullptr, nullptr);
+
+    auto* dequantB = dequantB_.GetBuffer(N * ldb, true);
+    dispatch->HQ8BitBlkDequantBForHgemm_CompFp16(
+        BlkLen, dequantB, reinterpret_cast<const std::byte*>(packedB), scale,
+        HasZp ? reinterpret_cast<const std::byte*>(zp) : nullptr, N, K, BCK);
+
+    auto* C = C_.GetBuffer(M * N, true);
+    dispatch->HQ4BitGemmKernel_CompFp16(A, dequantB, HasBias ? bias : nullptr, C, M, N, K, K, ldb, N);
+
+    double maxrel = 0.0;
+    for (size_t m = 0; m < M; ++m) {
+      for (size_t n = 0; n < N; ++n) {
+        double acc = HasBias ? H2F(bias[n]) : 0.0;
+        double absum = HasBias ? std::fabs(H2F(bias[n])) : 0.0;
+        for (size_t k = 0; k < K; ++k) {
+          double t = static_cast<double>(H2F(A[m * K + k])) * H2F(dequantB[n * ldb + k]);
+          acc += t;
+          absum += std::fabs(t);
+        }
+        maxrel = std::max(maxrel, std::fabs(H2F(C[m * N + n]) - acc) / (absum + 1e-3));
+      }
+    }
+    ASSERT_LT(maxrel, 6e-3) << " HQ8 M=" << M << " N=" << N << " K=" << K << " BlkLen=" << BlkLen
+                            << " zp=" << HasZp << " bias=" << HasBias;
+  }
+
+ public:
+  static const char* GetTestSuiteName() { return "RvvFp16HQ4Gemm"; }
+
+  void ExecuteShort(void) override {
+    RunOne<1, 1, 16, 16, false, false>();
+    RunOne<1, 8, 32, 32, false, true>();
+    RunOne<4, 16, 64, 32, true, false>();
+    RunOne<4, 17, 64, 64, true, true>();
+    RunOne<8, 33, 128, 64, false, true>();
+    RunOne<8, 32, 256, 128, true, true>();
+    RunOne<2, 15, 88, 32, true, false>();   // K not multiple of BlkLen
+    RunOne<5, 16, 4096, 128, true, true>();  // large K
+
+    RunOne8<1, 1, 16, 16, false, false>();
+    RunOne8<1, 8, 32, 32, false, true>();
+    RunOne8<4, 16, 64, 32, true, false>();
+    RunOne8<4, 17, 64, 64, true, true>();
+    RunOne8<8, 33, 128, 64, false, true>();
+    RunOne8<8, 32, 256, 128, true, true>();
+    RunOne8<2, 15, 88, 32, true, false>();   // K not multiple of BlkLen
+    RunOne8<5, 16, 4096, 128, true, true>();  // large K
+  }
+};
+
+static UNUSED_VARIABLE bool added_to_main = AddTestRegister([](bool is_short_execute) -> size_t {
+  if (is_short_execute) {
+    return MlasDirectShortExecuteTests<MlasRvvFp16HQ4GemmTest>::RegisterShortExecute();
+  }
+  return 0;
+});
+
+#endif  // defined(MLAS_TARGET_RISCV64) && defined(MLAS_USE_RVV_ZVFH)

--- a/onnxruntime/test/mlas/unittest/test_qnbitgemm_rvv_fp16.cpp
+++ b/onnxruntime/test/mlas/unittest/test_qnbitgemm_rvv_fp16.cpp
@@ -168,7 +168,7 @@ class MlasRvvFp16HQ4GemmTest : public MlasTestBase {
     RunOne<4, 17, 64, 64, true, true>();
     RunOne<8, 33, 128, 64, false, true>();
     RunOne<8, 32, 256, 128, true, true>();
-    RunOne<2, 15, 88, 32, true, false>();   // K not multiple of BlkLen
+    RunOne<2, 15, 88, 32, true, false>();    // K not multiple of BlkLen
     RunOne<5, 16, 4096, 128, true, true>();  // large K
 
     RunOne8<1, 1, 16, 16, false, false>();
@@ -177,7 +177,7 @@ class MlasRvvFp16HQ4GemmTest : public MlasTestBase {
     RunOne8<4, 17, 64, 64, true, true>();
     RunOne8<8, 33, 128, 64, false, true>();
     RunOne8<8, 32, 256, 128, true, true>();
-    RunOne8<2, 15, 88, 32, true, false>();   // K not multiple of BlkLen
+    RunOne8<2, 15, 88, 32, true, false>();    // K not multiple of BlkLen
     RunOne8<5, 16, 4096, 128, true, true>();  // large K
   }
 };

--- a/onnxruntime/test/mlas/unittest/test_sq8bitgemm.cpp
+++ b/onnxruntime/test/mlas/unittest/test_sq8bitgemm.cpp
@@ -176,6 +176,54 @@ class MlasSQ8BitPrepackTest : public MlasTestBase {
       }
     }
   }
+#elif defined(MLAS_TARGET_RISCV64)
+  // The RVV dispatch uses a plain layout private to itself: weights [N][ldb],
+  // scales [N][BlockCountK], block-sums [N][BlockCountK] with block-sum =
+  // scale * zeroPoint (zeroPoint defaults to 128). These references mirror that
+  // layout so the prepack self-consistency check matches what the RVV kernels
+  // consume. End-to-end correctness is covered separately by SQ8BitGemmKernel.
+  template <size_t K, size_t N, size_t BlkLen, size_t SubBlkLen>
+  void PrepackB(const uint8_t* src, uint8_t* dst, float* /*blkUnsignedQuantAZeroPointCorrection*/) {
+    constexpr size_t ldb = (K + BlkLen - 1) & (~(BlkLen - 1));
+    for (size_t n = 0; n < N; ++n) {
+      for (size_t k = 0; k < K; ++k) {
+        dst[n * ldb + k] = src[n * ldb + k];
+      }
+    }
+  }
+
+  template <size_t K, size_t N, size_t BlkLen, size_t SubBlkLen>
+  void PrepackBlkSumAndScale(const float* scale, const uint8_t* zp, float* packedScale, float* blkSum, float* /*corr*/) {
+    constexpr size_t BlkCount = (K + BlkLen - 1) / BlkLen;
+    for (size_t n = 0; n < N; ++n) {
+      for (size_t k = 0; k < BlkCount; ++k) {
+        const size_t idx = n * BlkCount + k;
+        const float zpv = zp ? static_cast<float>(zp[idx]) : 128.f;
+        packedScale[idx] = scale[idx];
+        blkSum[idx] = scale[idx] * zpv;
+      }
+    }
+  }
+
+  template <size_t K, size_t N, size_t BlkLen, size_t SubBlkLen>
+  void CheckB(const uint8_t* packedB, const uint8_t* refB) {
+    constexpr size_t ldb = (K + BlkLen - 1) & (~(BlkLen - 1));
+    for (size_t n = 0; n < N; ++n) {
+      for (size_t k = 0; k < K; ++k) {
+        ASSERT_EQ(packedB[n * ldb + k], refB[n * ldb + k]) << " at n=" << n << " k=" << k;
+      }
+    }
+  }
+
+  template <size_t K, size_t N, size_t BlkLen, size_t SubBlkLen>
+  void CheckScale(const float* packedScale, const float* refScale) {
+    constexpr size_t BlkCount = (K + BlkLen - 1) / BlkLen;
+    for (size_t n = 0; n < N; ++n) {
+      for (size_t k = 0; k < BlkCount; ++k) {
+        ASSERT_EQ(packedScale[n * BlkCount + k], refScale[n * BlkCount + k]) << " at n=" << n << " k=" << k;
+      }
+    }
+  }
 #else  // not MLAS_TARGET_ARM64
   template <size_t K, size_t N, size_t BlkLen, size_t SubBlkLen>
   void PrepackB(const uint8_t* src, uint8_t* dst, float* blkUnsignedQuantAZeroPointCorrection) {
@@ -334,7 +382,11 @@ class MlasSQ8BitPrepackTest : public MlasTestBase {
 
     for (size_t n = 0; n < N; ++n) {
       for (size_t k = 0; k < BlkCount; ++k) {
+#if defined(MLAS_TARGET_RISCV64)
+        size_t idx = n * BlkCount + k;  // RVV dispatch stores block-sums in a plain [N][BlockCountK] layout
+#else
         size_t idx = (((n) / 16) * BlkCount + k) * 16 + (n) % 16;
+#endif
         ASSERT_EQ(packedBlkSum[idx], refBlkSum[idx])
             << " n " << n << " k " << k;
       }

--- a/onnxruntime/test/mlas/unittest/test_sq8bitgemm.cpp
+++ b/onnxruntime/test/mlas/unittest/test_sq8bitgemm.cpp
@@ -224,7 +224,7 @@ class MlasSQ8BitPrepackTest : public MlasTestBase {
       }
     }
   }
-#else  // not MLAS_TARGET_ARM64
+#else  // not MLAS_TARGET_ARM64 and not MLAS_TARGET_RISCV64 (e.g. x86)
   template <size_t K, size_t N, size_t BlkLen, size_t SubBlkLen>
   void PrepackB(const uint8_t* src, uint8_t* dst, float* blkUnsignedQuantAZeroPointCorrection) {
     MLAS_UNREFERENCED_PARAMETER(blkUnsignedQuantAZeroPointCorrection);


### PR DESCRIPTION
## Motivation

MLAS has hand-optimized QNBitGemm kernels for x86 (AVX2/AVX512), ARM (NEON), and LoongArch, but none for RISC-V — on RISC-V the dispatch was null, so MlasIsQNBitGemmAvailable returned false and MatMulNBits fell back to the generic scalar path, leaving the RISC-V Vector unit idle for the hottest kernel in quantized-LLM inference.

This PR adds a native RISC-V Vector (RVV) implementation of the QNBitGemm dispatch so weight-quantized matmul runs on the vector unit.

## What's implemented

All compute modes the operator selects among, for rv64gcv:
- 4-bit weights × fp32 activations (SQNBIT_CompFp32) — M=1 GEMV + dequant-to-SGEMM
- 4-bit weights × int8 activations (SQNBIT_CompInt8) — quantize-A + int8×int4 kernel
- 8-bit weights × int8 activations (SQNBIT_CompInt8, BlkSum path)
- 4-/8-bit weights × fp16 activations (HQNBIT_CompFp16) — requires the Zvfh extension (rv64gcv_zvfh, MLAS_USE_RVV_ZVFH)

plus the packing / quantization / workspace-sizing plumbing each mode needs (including the 3-call PrePack protocol).

## Design notes

- The packed-B / block-sum / dequant-buffer layouts are private to this dispatch (produced and consumed only by these kernels), so plain layouts are used — natural for RVV's scalable vectors.
- The SQ8 prepack unit test asserts a per-arch B layout (#ifdef ARM64 / #else x86); added a MLAS_TARGET_RISCV64 branch describing the RVV layout, following the existing per-arch pattern.
- fp16 kernels accumulate in fp32 (fp16 → vfwcvt → fp32 FMA → fp16) for accuracy.

## Files

New:
- onnxruntime/core/mlas/lib/riscv64/qnbitgemm_kernel_rvv.cpp — SQ4/SQ8 kernels, packing, dispatch object
- onnxruntime/core/mlas/lib/riscv64/hqnbitgemm_kernel_rvv.cpp — fp16 (Zvfh) dequant + GEMM
- onnxruntime/test/mlas/unittest/test_qnbitgemm_rvv_fp16.cpp — RISC-V fp16 e2e test (HQ4 + HQ8)

Modified:
- cmake/onnxruntime_mlas.cmake — add the two sources (RVV / Zvfh source lists +
- onnxruntime/core/mlas/lib/mlasi.h — extern decl of the dispatch
- onnxruntime/core/mlas/lib/platform.cpp — assign QNBitGemmDispatch on RISC-V
- onnxruntime/test/mlas/unittest/test_sq8bitgemm.cpp — RISC-V layout branch in the SQ8 prepack test

## Performance (RVV, VLEN=256, N=256, K=2048)

The K-reduction runs at LMUL=4; profiling showed the kernels are widening-multip), so cutting per-chunk instruction overhead is the lever.
- SQ4 CompInt8 (4-bit): ~3.4× vs the naive per-sub-block version (2.2 → 7.6 GOP/s)
- SQ8 CompInt8 (8-bit): ~1.2×
- fp16 GEMM tiled to reuse the B vfwcvt across rows


## Testing

Built and run on real RISC-V hardware (K3 board, rv64gcv_zvfh, VLEN=256) via onnxruntime_mlas_test:
- SQNBitGemm* : SQ8Bit* : BlockQ4* : BlockQ8* : RvvFp16* → 13,526 / 13,526 pass
- Broader suite run passed with 0 failures as far as it ran (Activation → all QGemm); the run was only bounded by the very slow threaded large-GEMM stress tests, unrelated to this change.

## Build

Enable fp16 with -Donnxruntime_USE_RVV_ZVFH=ON. The 4-/8-bit int8/fp32 paths build with the existing onnxruntime_USE_RVV.

