### PR TITLE
Add SVE256 QGEMM U8×X8→S32 kernel 

### DIFF
--- a/cmake/onnxruntime_mlas.cmake
+++ b/cmake/onnxruntime_mlas.cmake
@@ -542,7 +542,7 @@ else()
           set_source_files_properties(${MLAS_SRC_DIR}/sve/elementwise_sve_fp16.cpp PROPERTIES COMPILE_FLAGS " -march=armv8.2-a+sve+fp16 ")
           list(APPEND mlas_private_compile_definitions MLAS_USE_SVE)
           list(APPEND mlas_platform_srcs ${MLAS_SRC_DIR}/sve/qgemm_sve256.cpp)
-          set_source_files_properties(${MLAS_SRC_DIR}/sve/qgemm_sve256.cpp PROPERTIES COMPILE_FLAGS " -march=armv8.2-a+sve+i8mm ")
+          set_source_files_properties(${MLAS_SRC_DIR}/sve/qgemm_sve256.cpp PROPERTIES COMPILE_FLAGS " -march=armv8.2-a+sve+i8mm -O3 -funroll-loops")
         endif()
 
         if (onnxruntime_USE_ARM_NEON_NCHWC)

--- a/cmake/onnxruntime_mlas.cmake
+++ b/cmake/onnxruntime_mlas.cmake
@@ -534,6 +534,7 @@ else()
         # Conditionally add the SVE implementation if compiler supports it
         if (onnxruntime_USE_SVE)
           list(APPEND mlas_platform_srcs ${MLAS_SRC_DIR}/sve/mlasi_sve.h)
+          list(APPEND mlas_platform_srcs ${MLAS_SRC_DIR}/sve/mlasi_sve_i8.h)
           list(APPEND mlas_platform_srcs ${MLAS_SRC_DIR}/sve/elementwise_sve.cpp)
           list(APPEND mlas_platform_srcs ${MLAS_SRC_DIR}/sve/elementwise_sve_fp16.cpp)
           list(APPEND mlas_platform_srcs ${MLAS_SRC_DIR}/sve/mlas_sve_fp16.h)

--- a/cmake/onnxruntime_mlas.cmake
+++ b/cmake/onnxruntime_mlas.cmake
@@ -540,6 +540,8 @@ else()
           set_source_files_properties(${MLAS_SRC_DIR}/sve/elementwise_sve.cpp PROPERTIES COMPILE_FLAGS " -march=armv8.2-a+sve+fp16 ")
           set_source_files_properties(${MLAS_SRC_DIR}/sve/elementwise_sve_fp16.cpp PROPERTIES COMPILE_FLAGS " -march=armv8.2-a+sve+fp16 ")
           list(APPEND mlas_private_compile_definitions MLAS_USE_SVE)
+          list(APPEND mlas_platform_srcs ${MLAS_SRC_DIR}/sve/qgemm_sve256.cpp)
+          set_source_files_properties(${MLAS_SRC_DIR}/sve/qgemm_sve256.cpp PROPERTIES COMPILE_FLAGS " -march=armv8.2-a+sve+i8mm ")
         endif()
 
         if (onnxruntime_USE_ARM_NEON_NCHWC)

--- a/cmake/onnxruntime_mlas.cmake
+++ b/cmake/onnxruntime_mlas.cmake
@@ -542,7 +542,7 @@ else()
           set_source_files_properties(${MLAS_SRC_DIR}/sve/elementwise_sve_fp16.cpp PROPERTIES COMPILE_FLAGS " -march=armv8.2-a+sve+fp16 ")
           list(APPEND mlas_private_compile_definitions MLAS_USE_SVE)
           list(APPEND mlas_platform_srcs ${MLAS_SRC_DIR}/sve/qgemm_sve256.cpp)
-          set_source_files_properties(${MLAS_SRC_DIR}/sve/qgemm_sve256.cpp PROPERTIES COMPILE_FLAGS " -march=armv8.2-a+sve+i8mm -O3 -funroll-loops")
+          set_source_files_properties(${MLAS_SRC_DIR}/sve/qgemm_sve256.cpp PROPERTIES COMPILE_FLAGS " -march=armv8.2-a+sve+i8mm ")
         endif()
 
         if (onnxruntime_USE_ARM_NEON_NCHWC)

--- a/onnxruntime/core/mlas/lib/qgemm_kernel_ummla.cpp
+++ b/onnxruntime/core/mlas/lib/qgemm_kernel_ummla.cpp
@@ -974,20 +974,24 @@ MlasGemmQuantKernel<MLAS_GEMM_U8X8_KERNEL_UMMLA>(const MLAS_GEMM_U8X8_KERNEL_UMM
     size_t RowsHandled;
 
     if (ZeroMode) {
-        if(MLAS_CPUIDINFO::GetCPUIDInfo().HasArmSve()){
+    #if defined(MLAS_USE_SVE)
+        if (MLAS_CPUIDINFO::GetCPUIDInfo().HasArmSVE_I8MM()) {
             RowsHandled = MlasSveQgemmU8X8KernelUmmlaZero(A, B, C, PackedCountK, CountM, CountN, ldc,
-                                                  RowSumBuffer, ColumnSumBuffer, ZeroPointB);
-        }
-        else{
+                                                        RowSumBuffer, ColumnSumBuffer, ZeroPointB);
+        } else
+    #endif
+        {
             RowsHandled = MlasGemmU8X8KernelUmmlaZero(A, B, C, PackedCountK, CountM, CountN, ldc,
-                                                  RowSumBuffer, ColumnSumBuffer, ZeroPointB);
+                                                    RowSumBuffer, ColumnSumBuffer, ZeroPointB);
         }
     } else {
-        if(MLAS_CPUIDINFO::GetCPUIDInfo().HasArmSve()){
+    #if defined(MLAS_USE_SVE)
+        if (MLAS_CPUIDINFO::GetCPUIDInfo().HasArmSVE_I8MM()) {
             RowsHandled = MlasSveQgemmU8X8KernelUmmlaAdd(A, B, C, PackedCountK, CountM, CountN, ldc,
-                                                 RowSumBuffer, ColumnSumBuffer, ZeroPointB);
-        }
-        else{
+                                                        RowSumBuffer, ColumnSumBuffer, ZeroPointB);
+        } else
+    #endif
+        {
             RowsHandled = MlasGemmU8X8KernelUmmlaAdd(A, B, C, PackedCountK, CountM, CountN, ldc,
                                                     RowSumBuffer, ColumnSumBuffer, ZeroPointB);
         }

--- a/onnxruntime/core/mlas/lib/qgemm_kernel_ummla.cpp
+++ b/onnxruntime/core/mlas/lib/qgemm_kernel_ummla.cpp
@@ -17,10 +17,12 @@ Abstract:
 
 #include "mlasi.h"
 #include "qgemm.h"
+#ifdef __ARM_FEATURE_SVE
 #include "sve/mlasi_sve.h"
+#endif
 
 //
-// Define the prototypes of the NEON UMMLA routines written in assembly.
+// Define the prototypes of the SVE routines and NEON UMMLA routines written in assembly.
 //
 
 extern "C" {

--- a/onnxruntime/core/mlas/lib/qgemm_kernel_ummla.cpp
+++ b/onnxruntime/core/mlas/lib/qgemm_kernel_ummla.cpp
@@ -17,7 +17,7 @@ Abstract:
 
 #include "mlasi.h"
 #include "qgemm.h"
-#ifdef __ARM_FEATURE_SVE
+#ifdef MLAS_USE_SVE
 #include "sve/mlasi_sve.h"
 #endif
 

--- a/onnxruntime/core/mlas/lib/qgemm_kernel_ummla.cpp
+++ b/onnxruntime/core/mlas/lib/qgemm_kernel_ummla.cpp
@@ -17,6 +17,7 @@ Abstract:
 
 #include "mlasi.h"
 #include "qgemm.h"
+#include "sve/mlasi_sve.h"
 
 //
 // Define the prototypes of the NEON UMMLA routines written in assembly.
@@ -63,6 +64,29 @@ struct MLAS_GEMM_U8X8_KERNEL_UMMLA {
 constexpr size_t MLAS_GEMM_U8X8_KERNEL_UMMLA::PackedK;
 constexpr MLAS_GEMM_QUANT_STRIDES MLAS_GEMM_U8X8_KERNEL_UMMLA::Strides;
 constexpr MLAS_GEMM_QUANT_STRIDES MLAS_GEMM_U8X8_KERNEL_UMMLA::PackedStrides;
+
+size_t MLASCALL MlasSveQgemmU8X8KernelUmmlaZero(const MLAS_GEMM_U8X8_KERNEL_UMMLA::PackedAType* A,
+                                const MLAS_GEMM_U8X8_KERNEL_UMMLA::PackedBType* B,
+                                int32_t* C,
+                                size_t PackedCountK,
+                                size_t CountM,
+                                size_t CountN,
+                                size_t ldc,
+                                const int32_t* RowSumBuffer,
+                                const int32_t* ColumnSumBuffer,
+                                const int32_t* ZeroPointB
+                              );
+size_t MLASCALL MlasSveQgemmU8X8KernelUmmlaAdd(const MLAS_GEMM_U8X8_KERNEL_UMMLA::PackedAType* A,
+                                const MLAS_GEMM_U8X8_KERNEL_UMMLA::PackedBType* B,
+                                int32_t* C,
+                                size_t PackedCountK,
+                                size_t CountM,
+                                size_t CountN,
+                                size_t ldc,
+                                const int32_t* RowSumBuffer,
+                                const int32_t* ColumnSumBuffer,
+                                const int32_t* ZeroPointB
+                              );
 
 template <>
 MLAS_FORCEINLINE int32_t
@@ -948,11 +972,23 @@ MlasGemmQuantKernel<MLAS_GEMM_U8X8_KERNEL_UMMLA>(const MLAS_GEMM_U8X8_KERNEL_UMM
     size_t RowsHandled;
 
     if (ZeroMode) {
-        RowsHandled = MlasGemmU8X8KernelUmmlaZero(A, B, C, PackedCountK, CountM, CountN, ldc,
+        if(MLAS_CPUIDINFO::GetCPUIDInfo().HasArmSve()){
+            RowsHandled = MlasSveQgemmU8X8KernelUmmlaZero(A, B, C, PackedCountK, CountM, CountN, ldc,
                                                   RowSumBuffer, ColumnSumBuffer, ZeroPointB);
+        }
+        else{
+            RowsHandled = MlasGemmU8X8KernelUmmlaZero(A, B, C, PackedCountK, CountM, CountN, ldc,
+                                                  RowSumBuffer, ColumnSumBuffer, ZeroPointB);
+        }
     } else {
-        RowsHandled = MlasGemmU8X8KernelUmmlaAdd(A, B, C, PackedCountK, CountM, CountN, ldc,
+        if(MLAS_CPUIDINFO::GetCPUIDInfo().HasArmSve()){
+            RowsHandled = MlasSveQgemmU8X8KernelUmmlaAdd(A, B, C, PackedCountK, CountM, CountN, ldc,
                                                  RowSumBuffer, ColumnSumBuffer, ZeroPointB);
+        }
+        else{
+            RowsHandled = MlasGemmU8X8KernelUmmlaAdd(A, B, C, PackedCountK, CountM, CountN, ldc,
+                                                    RowSumBuffer, ColumnSumBuffer, ZeroPointB);
+        }
     }
 
     return RowsHandled;

--- a/onnxruntime/core/mlas/lib/sve/mlasi_sve.h
+++ b/onnxruntime/core/mlas/lib/sve/mlasi_sve.h
@@ -866,5 +866,3 @@ MlasSveDupqU32(uint32_t w0, uint32_t w1, uint32_t w2, uint32_t w3)
 #ifndef __clang__
 #pragma GCC pop_options
 #endif
-
-#endif

--- a/onnxruntime/core/mlas/lib/sve/mlasi_sve.h
+++ b/onnxruntime/core/mlas/lib/sve/mlasi_sve.h
@@ -690,6 +690,15 @@ MlasSveWhileLtB32(int32_t From, int32_t To)
     return svwhilelt_b32(From, To);
 }
 
+/// Returns a predicate with lanes [From, To) active for int8 elements.
+MLAS_SVE_TARGET
+MLAS_FORCEINLINE
+MLAS_SVBOOL
+MlasSveWhileLtB8(int32_t From, int32_t To)
+{
+    return svwhilelt_b8(From, To);
+}
+
 /// Returns an all-true int32 predicate (svptrue_b32).
 MLAS_SVE_TARGET
 MLAS_FORCEINLINE

--- a/onnxruntime/core/mlas/lib/sve/mlasi_sve.h
+++ b/onnxruntime/core/mlas/lib/sve/mlasi_sve.h
@@ -480,6 +480,18 @@ MlasSveMultiplyAddFloat32(MLAS_SVBOOL Pred, MLAS_SVFLOAT32 Vector1, MLAS_SVFLOAT
 
 MLAS_SVE_TARGET
 MLAS_FORCEINLINE
+MLAS_SVINT32
+MlasSveMultiplyAddInt32(
+    svbool_t Pred,
+    svint32_t Vector1,
+    svint32_t Vector2,
+    svint32_t Vector3)
+{
+    return svmla_s32_m(Pred, Vector3, Vector1, Vector2);
+}
+
+MLAS_SVE_TARGET
+MLAS_FORCEINLINE
 MLAS_SVFLOAT32
 MlasSveMultiplyAddFloat32(MLAS_SVBOOL Pred, MLAS_SVFLOAT32 Vector1, float Scalar2, MLAS_SVFLOAT32 Vector3)
 {

--- a/onnxruntime/core/mlas/lib/sve/mlasi_sve.h
+++ b/onnxruntime/core/mlas/lib/sve/mlasi_sve.h
@@ -672,9 +672,178 @@ MlasSveCompareGreaterThan(svbool_t Pred, MLAS_SVFLOAT32 A, MLAS_SVFLOAT32 B)
     return svcmpgt_f32(Pred, A, B);
 }
 
+//===========================================================================
+// General-purpose integer SVE APIs
+// Used by QGEMM and other integer kernels
+//===========================================================================
+
+// ---------------------------------------------------------------------------
+// Predicate helpers
+// ---------------------------------------------------------------------------
+
+/// Returns a predicate with lanes [From, To) active for int32 elements.
+MLAS_SVE_TARGET
+MLAS_FORCEINLINE
+MLAS_SVBOOL
+MlasSveWhileLtB32(int32_t From, int32_t To)
+{
+    return svwhilelt_b32(From, To);
+}
+
+/// Returns an all-true int32 predicate (svptrue_b32).
+MLAS_SVE_TARGET
+MLAS_FORCEINLINE
+MLAS_SVBOOL
+MlasSvePtrueB32(void)
+{
+    return svptrue_b32();
+}
+
+/// Returns an all-true byte predicate (svptrue_b8).
+MLAS_SVE_TARGET
+MLAS_FORCEINLINE
+MLAS_SVBOOL
+MlasSvePtrueB8(void)
+{
+    return svptrue_b8();
+}
+
+// ---------------------------------------------------------------------------
+// Runtime vector-length query
+// ---------------------------------------------------------------------------
+
+/// Returns the SVE vector length in bytes (svcntb).
+MLAS_SVE_TARGET
+MLAS_FORCEINLINE
+uint64_t
+MlasSveCntb(void)
+{
+    return svcntb();
+}
+
+// ---------------------------------------------------------------------------
+// Integer broadcast
+// ---------------------------------------------------------------------------
+
+/// Broadcasts a scalar int64 to all lanes (svdup_n_s64).
+MLAS_SVE_TARGET
+MLAS_FORCEINLINE
+svint64_t
+MlasSveBroadcastInt64(int64_t Value)
+{
+    return svdup_n_s64(Value);
+}
+
+// ---------------------------------------------------------------------------
+// Reinterpret casts – integer types
+// ---------------------------------------------------------------------------
+
+/// Reinterpret svint32_t as svuint32_t.
+MLAS_SVE_TARGET
+MLAS_FORCEINLINE
+svuint32_t
+MlasSveReinterpretU32FromS32(MLAS_SVINT32 Vector)
+{
+    return svreinterpret_u32_s32(Vector);
+}
+
+/// Reinterpret svuint32_t as svint32_t.
+MLAS_SVE_TARGET
+MLAS_FORCEINLINE
+MLAS_SVINT32
+MlasSveReinterpretS32FromU32(svuint32_t Vector)
+{
+    return svreinterpret_s32_u32(Vector);
+}
+
+/// Reinterpret svint32_t as svint64_t.
+MLAS_SVE_TARGET
+MLAS_FORCEINLINE
+svint64_t
+MlasSveReinterpretS64FromS32(MLAS_SVINT32 Vector)
+{
+    return svreinterpret_s64_s32(Vector);
+}
+
+/// Reinterpret svint64_t as svint32_t.
+MLAS_SVE_TARGET
+MLAS_FORCEINLINE
+MLAS_SVINT32
+MlasSveReinterpretS32FromS64(svint64_t Vector)
+{
+    return svreinterpret_s32_s64(Vector);
+}
+
+// ---------------------------------------------------------------------------
+// Integer arithmetic – unpredicated (_x) variants
+// ---------------------------------------------------------------------------
+
+/// Multiply two int32 vectors, inactive lanes zeroed (svmul_s32_x).
+MLAS_SVE_TARGET
+MLAS_FORCEINLINE
+MLAS_SVINT32
+MlasSveMulInt32(MLAS_SVBOOL Pred, MLAS_SVINT32 Vector1, MLAS_SVINT32 Vector2)
+{
+    return svmul_s32_x(Pred, Vector1, Vector2);
+}
+
+/// Add two int32 vectors, inactive lanes zeroed (svadd_s32_x).
+/// Complements MlasSveAddInt32 which uses the _m (merging) form.
+MLAS_SVE_TARGET
+MLAS_FORCEINLINE
+MLAS_SVINT32
+MlasSveAddInt32X(MLAS_SVBOOL Pred, MLAS_SVINT32 Vector1, MLAS_SVINT32 Vector2)
+{
+    return svadd_s32_x(Pred, Vector1, Vector2);
+}
+
+// ---------------------------------------------------------------------------
+// int64 lane interleave / transpose
+// ---------------------------------------------------------------------------
+
+/// Interleave even int64 elements from two vectors (svzip1_s64).
+MLAS_SVE_TARGET
+MLAS_FORCEINLINE
+svint64_t
+MlasSveZip1S64(svint64_t Vector1, svint64_t Vector2)
+{
+    return svzip1_s64(Vector1, Vector2);
+}
+
+/// Transpose even int64 elements from two vectors (svtrn1_s64).
+MLAS_SVE_TARGET
+MLAS_FORCEINLINE
+svint64_t
+MlasSveTrn1S64(svint64_t Vector1, svint64_t Vector2)
+{
+    return svtrn1_s64(Vector1, Vector2);
+}
+
+// ---------------------------------------------------------------------------
+// uint32 permute
+// ---------------------------------------------------------------------------
+
+/// Table-lookup permute of uint32 lanes (svtbl_u32).
+MLAS_SVE_TARGET
+MLAS_FORCEINLINE
+svuint32_t
+MlasSveTblU32(svuint32_t Vector, svuint32_t Indices)
+{
+    return svtbl_u32(Vector, Indices);
+}
+
+/// Broadcast a 128-bit immediate pattern across uint32 lanes (svdupq_n_u32).
+MLAS_SVE_TARGET
+MLAS_FORCEINLINE
+svuint32_t
+MlasSveDupqU32(uint32_t w0, uint32_t w1, uint32_t w2, uint32_t w3)
+{
+    return svdupq_n_u32(w0, w1, w2, w3);
+}
+
 // GCC: Pop options after SVE-specific functions
 #ifndef __clang__
 #pragma GCC pop_options
 #endif
 
-
+#endif

--- a/onnxruntime/core/mlas/lib/sve/mlasi_sve_i8.h
+++ b/onnxruntime/core/mlas/lib/sve/mlasi_sve_i8.h
@@ -1,0 +1,82 @@
+/*++
+
+Copyright 2025 FUJITSU LIMITED
+
+Module Name:
+
+    mlasi_sve_i8.h
+
+Abstract:
+
+    SVE intrinsic wrappers specific to int8 / QGEMM kernels (FEAT_I8MM).
+    Contains only the instructions that operate on uint8 data or the
+    svmmla_u32 matrix-multiply-accumulate (UMMLA) instruction.
+
+    All general-purpose integer SVE helpers (predicates, reinterprets,
+    arithmetic, permutes) live in mlasi_sve.h, which is included here.
+
+--*/
+
+#pragma once
+
+#include "mlasi_sve.h"
+
+#ifndef __clang__
+#pragma GCC push_options
+#pragma GCC target("arch=armv8.2-a+sve+i8mm")
+#endif
+
+// ---------------------------------------------------------------------------
+// uint8 reinterpret
+// ---------------------------------------------------------------------------
+
+/// Reinterpret svuint8_t as svuint32_t.
+MLAS_SVE_TARGET
+MLAS_FORCEINLINE
+svuint32_t
+MlasSveReinterpretU32FromU8(svuint8_t Vector)
+{
+    return svreinterpret_u32_u8(Vector);
+}
+
+// ---------------------------------------------------------------------------
+// uint8 loads
+// ---------------------------------------------------------------------------
+
+/// Load 16 bytes and replicate across the full SVE vector (svld1rq_u8).
+/// Used to broadcast an A tile across the accumulator width.
+MLAS_SVE_TARGET
+MLAS_FORCEINLINE
+svuint8_t
+MlasSveLoadReplicateU8(MLAS_SVBOOL Pred, const uint8_t* Buffer)
+{
+    return svld1rq_u8(Pred, Buffer);
+}
+
+/// Load a full SVE vector of uint8 elements (svld1_u8).
+/// Used to load B tiles.
+MLAS_SVE_TARGET
+MLAS_FORCEINLINE
+svuint8_t
+MlasSveLoadU8(MLAS_SVBOOL Pred, const uint8_t* Buffer)
+{
+    return svld1_u8(Pred, Buffer);
+}
+
+// ---------------------------------------------------------------------------
+// Matrix-multiply-accumulate (FEAT_I8MM)
+// ---------------------------------------------------------------------------
+
+/// Unsigned 8-bit matrix multiply-accumulate into uint32 (svmmla_u32 / UMMLA).
+/// Computes: Acc += A_tile * B_tile
+MLAS_SVE_TARGET
+MLAS_FORCEINLINE
+svuint32_t
+MlasSveMatMulAddU32(svuint32_t Acc, svuint8_t A, svuint8_t B)
+{
+    return svmmla_u32(Acc, A, B);
+}
+
+#ifndef __clang__
+#pragma GCC pop_options
+#endif

--- a/onnxruntime/core/mlas/lib/sve/mlasi_sve_i8.h
+++ b/onnxruntime/core/mlas/lib/sve/mlasi_sve_i8.h
@@ -21,6 +21,11 @@ Abstract:
 
 #include "mlasi_sve.h"
 
+#ifdef __clang__
+#undef MLAS_SVE_TARGET
+#define MLAS_SVE_TARGET __attribute__((target("arch=armv8.2-a+sve+i8mm")))
+#endif
+
 #ifndef __clang__
 #pragma GCC push_options
 #pragma GCC target("arch=armv8.2-a+sve+i8mm")

--- a/onnxruntime/core/mlas/lib/sve/qgemm_sve256.cpp
+++ b/onnxruntime/core/mlas/lib/sve/qgemm_sve256.cpp
@@ -1,0 +1,1397 @@
+#include <arm_sve.h>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <vector>
+
+#include "mlasi_sve.h"
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+struct MLAS_GEMM_U8X8_KERNEL_UMMLA {
+    using PackedAType = uint8_t;
+    using PackedBType = uint8_t;
+};
+
+size_t Process1RowTest256(
+    const uint8_t* A,
+    const uint8_t* B,
+    int32_t* C,
+    size_t PackedCountK,
+    size_t CountM,
+    size_t CountN,
+    size_t ldc,
+    const int32_t* RowSumBuffer,
+    const int32_t* ColumnSumBuffer,
+    const int32_t* ZeroPointB,
+    bool isZeroPointB)
+{
+    (void)CountM;
+    (void)ldc;
+
+    //------------------------------------------------------------------
+    // VL = 256 → int32 lanes = 8 → process columns in groups of 4
+    //------------------------------------------------------------------
+    svbool_t pg_b32_4 = svwhilelt_b32(0, 4);  // stores 4 output columns
+    svbool_t pg_b32_8 = svptrue_b32();  // full accumulator lanes
+    svbool_t pg_b8_32 = svptrue_b8(); // loads 32 bytes from A/B
+    svuint32_t acc03, acc47;
+
+    const int32_t rowsum = RowSumBuffer[0];
+    const svint32_t rowSumVec = svdup_s32(rowsum);
+
+    const uint8_t* A_ptr;
+    int32_t* C_ptr = C;
+
+    //------------------------------------------------------------------
+    // Loop over N in chunks of 8 columns
+    //------------------------------------------------------------------
+    for (size_t col = 0; col < CountN; )
+    {
+        size_t remaining = CountN - col;
+        size_t cols_this = std::min<size_t>(remaining, 8);
+
+        A_ptr = A;
+
+        //------------------------------------------------------------------
+        // Create ZPB and ColumnSum interleaved groups:
+        //   VL=256: 8 lanes → represent 4 output columns at once
+        //------------------------------------------------------------------
+        // svint32_t acc00 = svdup_s32(0); // for columns 0–3
+        // svint32_t acc01 = svdup_s32(0); // for columns 4–7
+
+        // can this give seg faults when #Columns are not checked? 
+        svint32_t zpb_0_3, col_0_3, zpb_4_7, col_4_7;
+        svint64_t zpb64_0_3, col64_0_3, zpb64_4_7, col64_4_7;
+        // --- Columns 0–3 ---
+        if (ZeroPointB){
+            zpb_0_3 = svld1_s32(pg_b32_4, ZeroPointB); //pg_b32_4
+            zpb64_0_3 = svreinterpret_s64_s32(zpb_0_3);
+            zpb_0_3 = svreinterpret_s32_s64(svzip1_s64(zpb64_0_3, zpb64_0_3));
+        }
+        else
+            zpb_0_3 = svdup_s32(1);
+        col_0_3 = svld1_s32(pg_b32_4, ColumnSumBuffer);
+        col64_0_3 = svreinterpret_s64_s32(col_0_3);
+        col_0_3 = svreinterpret_s32_s64(svzip1_s64(col64_0_3, col64_0_3));
+        acc03 = svreinterpret_u32_s32(svadd_s32_x(pg_b32_8, svmul_s32_x(pg_b32_8, rowSumVec, zpb_0_3), col_0_3));
+        // --- Columns 4–7 ---
+        if (cols_this > 4) {
+            if (ZeroPointB){
+                zpb_4_7 = svld1_s32(pg_b32_4, ZeroPointB + 4);
+                zpb64_4_7 = svreinterpret_s64_s32(zpb_4_7);
+                zpb_4_7 = svreinterpret_s32_s64(svzip1_s64(zpb64_4_7, zpb64_4_7));
+            }
+            else{
+                zpb_4_7 = svdup_s32(1);
+            }
+            col_4_7 = svld1_s32(pg_b32_4, ColumnSumBuffer + 4);
+            col64_4_7 = svreinterpret_s64_s32(col_4_7);
+            col_4_7 = svreinterpret_s32_s64(svzip1_s64(col64_4_7, col64_4_7));
+            // acc47 = svreinterpret_u32_s32(svmad_s32_x(pg_b32_4, rowSumVec, zpb_4_7, col_4_7));
+            acc47 = svreinterpret_u32_s32(svadd_s32_x(pg_b32_8, svmul_s32_x(pg_b32_8, rowSumVec, zpb_4_7), col_4_7));
+        }
+        //------------------------------------------------------------------
+        // K loop
+        //------------------------------------------------------------------
+        // const uint8_t* B_ptr = B + col * 32; // 32 bytes per slice for VL=256
+
+        for (size_t k = 0; k < PackedCountK; k++)
+        {
+            // A: 32 bytes, B: 32 bytes per 4 columns
+            svuint8_t a  = svld1rq_u8(pg_b8_32, A_ptr); //load and replicate
+            svuint8_t b0 = svld1_u8(pg_b8_32, B);
+            svuint8_t b1 = svld1_u8(pg_b8_32, B + 32);
+
+            acc03 = svmmla_u32(acc03, a, b0);
+            if (cols_this > 4)
+                acc47 = svmmla_u32(acc47, a, b1);
+
+            A_ptr += 8;   // Each tile is 32 bytes for 256-bit
+            B += 64;     // Two × 32-byte blocks per 8 columns
+        }
+
+        //------------------------------------------------------------------
+        // Store results into C
+        //------------------------------------------------------------------
+        const svuint32_t idx = svdupq_n_u32(0, 1, 4, 5);
+        acc03 = svtbl_u32(acc03, idx);
+        if (cols_this > 4)
+            acc47 = svtbl_u32(acc47, idx);
+        // First 4 columns
+        // 
+        if(cols_this > 6){
+            if(isZeroPointB){
+                svst1_s32(pg_b32_4, C_ptr, svreinterpret_s32_u32(acc03));
+                if(cols_this >= 8){
+                    svst1_s32(pg_b32_4, C_ptr + 4, svreinterpret_s32_u32(acc47));
+                }
+                else{
+                    svst1_s32(svwhilelt_b32(0,3), C_ptr + 4, svreinterpret_s32_u32(acc47));
+                }            
+            }
+            else{
+                // Row 0 (C0)
+                svint32_t prev = svld1_s32(pg_b32_4, C_ptr);
+                svint32_t sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03));
+                svst1_s32(pg_b32_4, C_ptr, sum);
+
+                // Row 1 (C1)
+                if(cols_this >= 8){
+                    prev = svld1_s32(pg_b32_4, C_ptr + 4);
+                    sum  = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc47));
+                    svst1_s32(pg_b32_4, C_ptr + 4, sum);
+                }
+                else{
+                    prev = svld1_s32(svwhilelt_b32(0,3), C_ptr + 4);
+                    sum  = svadd_s32_x(svwhilelt_b32(0,3), prev, svreinterpret_s32_u32(acc47));
+                    svst1_s32(svwhilelt_b32(0,3), C_ptr + 4, sum);
+                }
+            }
+        }
+        else if(cols_this > 4){
+            if(isZeroPointB){
+                svst1_s32(pg_b32_4, C_ptr, svreinterpret_s32_u32(acc03));
+                if(cols_this >= 6){
+                    svst1_s32(svwhilelt_b32(0, 2), C_ptr + 4, svreinterpret_s32_u32(acc47));
+                }
+                else{
+                    svst1_s32(svwhilelt_b32(0, 1), C_ptr + 4, svreinterpret_s32_u32(acc47));
+                }
+            }
+            else{
+                // Row 0 (C0)
+                svint32_t prev = svld1_s32(pg_b32_4, C_ptr);
+                svint32_t sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03));
+                svst1_s32(pg_b32_4, C_ptr, sum);
+                if(cols_this >= 6){
+                    prev = svld1_s32(svwhilelt_b32(0, 2), C_ptr + 4);
+                    sum  = svadd_s32_x(svwhilelt_b32(0, 2), prev, svreinterpret_s32_u32(acc47));
+                    svst1_s32(svwhilelt_b32(0, 2), C_ptr + 4, sum);
+                }
+                else{
+                    prev = svld1_s32(svwhilelt_b32(0, 1), C_ptr + 4);
+                    sum  = svadd_s32_x(svwhilelt_b32(0, 1), prev, svreinterpret_s32_u32(acc47));
+                    svst1_s32(svwhilelt_b32(0, 1), C_ptr + 4, sum);
+                }
+            }
+        }
+        else if(cols_this > 2){
+            if(isZeroPointB){
+                if(cols_this >= 4){
+                    svst1_s32(pg_b32_4, C_ptr, svreinterpret_s32_u32(acc03));
+                }
+                else{
+                    svst1_s32(svwhilelt_b32(0,3), C_ptr, svreinterpret_s32_u32(acc03));
+                }
+            }
+            else{
+                if(cols_this >= 4){
+                    // Row 0 (C0)
+                    svint32_t prev = svld1_s32(pg_b32_4, C_ptr);
+                    svint32_t sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03));
+                    svst1_s32(pg_b32_4, C_ptr, sum);
+                }
+                else{
+                    // Row 0 (C0)
+                    svint32_t prev = svld1_s32(svwhilelt_b32(0,3), C_ptr);
+                    svint32_t sum = svadd_s32_x(svwhilelt_b32(0,3), prev, svreinterpret_s32_u32(acc03));
+                    svst1_s32(svwhilelt_b32(0,3), C_ptr, sum);
+                }   
+            }
+        }
+        else{
+            if(isZeroPointB){
+                svst1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C_ptr, svreinterpret_s32_u32(acc03));
+            }
+            else{
+                // Row 0 (C0)
+                svint32_t prev = svld1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C_ptr);
+                svint32_t sum = svadd_s32_x(svwhilelt_b32(0, std::min(int(cols_this), 2)), prev, svreinterpret_s32_u32(acc03));
+                svst1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C_ptr, sum);
+            }
+        }
+        // Last 4 columns
+
+        //------------------------------------------------------------------
+        // Advance
+        //------------------------------------------------------------------
+        C_ptr            += cols_this;
+        ColumnSumBuffer  += cols_this;
+        col              += cols_this;
+        if (ZeroPointB) {
+            ZeroPointB += cols_this;
+        }
+    }
+    return 1;
+}
+
+size_t Process2RowsTest256(
+    const uint8_t* A,
+    const uint8_t* B,
+    int32_t* C,
+    size_t PackedCountK,
+    size_t CountM,
+    size_t CountN,
+    size_t ldc,
+    const int32_t* RowSumBuffer,
+    const int32_t* ColumnSumBuffer,
+    const int32_t* ZeroPointB,
+    bool isZeroPointB)
+{
+    (void)CountM;
+
+    //------------------------------------------------------------------
+    // VL = 256 → int32 lanes = 8 → process columns in groups of 4
+    //------------------------------------------------------------------
+    svbool_t pg_b32_4 = svwhilelt_b32(0, 4);  // stores 4 output columns
+    svbool_t pg_b32_8 = svptrue_b32();  // full accumulator lanes
+    svbool_t pg_b8_32 = svptrue_b8(); // loads 32 bytes from A/B
+    svuint32_t acc03, acc47;
+
+    // const int32_t rowsum = RowSumBuffer[0];
+    svint32_t rowSumVec, r0, r1;
+    r0 = svdup_s32(RowSumBuffer[0]);
+    r1 = svdup_s32(RowSumBuffer[1]);
+    rowSumVec = svreinterpret_s32_s64(svtrn1_s64(svreinterpret_s64_s32(r0), svreinterpret_s64_s32(r1)));
+    const uint8_t* A_ptr;
+    int32_t *C0, *C1;
+    C0 = C;
+    C1 = C0 + ldc;
+
+    //------------------------------------------------------------------
+    // Loop over N in chunks of 8 columns
+    //------------------------------------------------------------------
+    for (size_t col = 0; col < CountN; )
+    {
+        size_t remaining = CountN - col;
+        size_t cols_this = std::min<size_t>(remaining, 8);
+
+        A_ptr = A;
+
+        svint32_t zpb_0_3, col_0_3, zpb_4_7, col_4_7;
+        svint64_t zpb64_0_3, col64_0_3, zpb64_4_7, col64_4_7;
+        // --- Columns 0–3 ---
+        if (ZeroPointB){
+            zpb_0_3 = svld1_s32(pg_b32_4, ZeroPointB); //pg_b32_4
+            zpb64_0_3 = svreinterpret_s64_s32(zpb_0_3);
+            zpb_0_3 = svreinterpret_s32_s64(svzip1_s64(zpb64_0_3, zpb64_0_3));
+        }
+        else
+            zpb_0_3 = svdup_s32(1);
+
+        col_0_3 = svld1_s32(pg_b32_4, ColumnSumBuffer);
+        col64_0_3 = svreinterpret_s64_s32(col_0_3);
+        col_0_3 = svreinterpret_s32_s64(svzip1_s64(col64_0_3, col64_0_3));
+        acc03 = svreinterpret_u32_s32(svadd_s32_x(pg_b32_8, svmul_s32_x(pg_b32_8, rowSumVec, zpb_0_3), col_0_3));
+        // --- Columns 4–7 ---
+        if (cols_this > 4) {
+            if (ZeroPointB){
+                zpb_4_7 = svld1_s32(pg_b32_4, ZeroPointB + 4);
+                zpb64_4_7 = svreinterpret_s64_s32(zpb_4_7);
+                zpb_4_7 = svreinterpret_s32_s64(svzip1_s64(zpb64_4_7, zpb64_4_7));
+            }
+            else{
+                zpb_4_7 = svdup_s32(1);
+            }
+            col_4_7 = svld1_s32(pg_b32_4, ColumnSumBuffer + 4);
+            col64_4_7 = svreinterpret_s64_s32(col_4_7);
+            col_4_7 = svreinterpret_s32_s64(svzip1_s64(col64_4_7, col64_4_7));
+            // acc47 = svreinterpret_u32_s32(svmad_s32_x(pg_b32_4, rowSumVec, zpb_4_7, col_4_7));
+            acc47 = svreinterpret_u32_s32(svadd_s32_x(pg_b32_8, svmul_s32_x(pg_b32_8, rowSumVec, zpb_4_7), col_4_7));
+        }
+        //------------------------------------------------------------------
+        // K loop
+        //------------------------------------------------------------------
+        // const uint8_t* B_ptr = B + col * 32; // 32 bytes per slice for VL=256
+
+        for (size_t k = 0; k < PackedCountK; k++)
+        {
+            // A: 32 bytes, B: 32 bytes per 4 columns
+            svuint8_t a  = svld1rq_u8(pg_b8_32, A_ptr); //load and replicate
+            svuint8_t b0 = svld1_u8(pg_b8_32, B);
+            svuint8_t b1 = svld1_u8(pg_b8_32, B + 32);
+
+            acc03 = svmmla_u32(acc03, a, b0);
+            if (cols_this > 4)
+                acc47 = svmmla_u32(acc47, a, b1); 
+
+            A_ptr += 16;   // Each tile is 32 bytes for 256-bit
+            B += 64;     // Two × 32-byte blocks per 8 columns
+        }
+
+        //------------------------------------------------------------------
+        // Store results into C
+        //------------------------------------------------------------------
+        const svuint32_t idx1 = svdupq_n_u32(0, 1, 4, 5);
+        const svuint32_t idx2 = svdupq_n_u32(2, 3, 6, 7);
+        svuint32_t acc03_c0, acc03_c1, acc47_c0, acc47_c1;
+        acc03_c0 = svtbl_u32(acc03, idx1);
+        acc03_c1 = svtbl_u32(acc03, idx2);
+        if (cols_this > 4){
+            acc47_c0 = svtbl_u32(acc47, idx1);
+            acc47_c1 = svtbl_u32(acc47, idx2);
+        }
+        // First 4 columns
+        // 
+        if(cols_this > 6){
+            if(isZeroPointB){
+                svst1_s32(pg_b32_4, C0, svreinterpret_s32_u32(acc03_c0));
+                svst1_s32(pg_b32_4, C1, svreinterpret_s32_u32(acc03_c1));
+                if(cols_this >= 8){
+                    svst1_s32(pg_b32_4, C0 + 4, svreinterpret_s32_u32(acc47_c0));
+                    svst1_s32(pg_b32_4, C1 + 4, svreinterpret_s32_u32(acc47_c1));
+                }
+                else{
+                    svst1_s32(svwhilelt_b32(0,3), C0 + 4, svreinterpret_s32_u32(acc47_c0));
+                    svst1_s32(svwhilelt_b32(0,3), C1 + 4, svreinterpret_s32_u32(acc47_c1));
+                }            
+            }
+            else{
+                // Row 0 (C0)
+                svint32_t prev = svld1_s32(pg_b32_4, C0);
+                svint32_t sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c0));
+                svst1_s32(pg_b32_4, C0, sum);
+                prev = svld1_s32(pg_b32_4, C1);
+                sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c1));
+                svst1_s32(pg_b32_4, C1, sum);
+                // Row 1 (C1)
+                if(cols_this >= 8){
+                    prev = svld1_s32(pg_b32_4, C0 + 4);
+                    sum  = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc47_c0));
+                    svst1_s32(pg_b32_4, C0 + 4, sum);
+                    prev = svld1_s32(pg_b32_4, C1 + 4);
+                    sum  = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc47_c1));
+                    svst1_s32(pg_b32_4, C1 + 4, sum);
+                }
+                else{
+                    prev = svld1_s32(svwhilelt_b32(0,3), C0 + 4);
+                    sum  = svadd_s32_x(svwhilelt_b32(0,3), prev, svreinterpret_s32_u32(acc47_c0));
+                    svst1_s32(svwhilelt_b32(0,3), C0 + 4, sum);
+                    prev = svld1_s32(svwhilelt_b32(0,3), C1 + 4);
+                    sum  = svadd_s32_x(svwhilelt_b32(0,3), prev, svreinterpret_s32_u32(acc47_c1));
+                    svst1_s32(svwhilelt_b32(0,3), C1 + 4, sum);
+                }
+            }
+        }
+        else if(cols_this > 4){
+            if(isZeroPointB){
+                svst1_s32(pg_b32_4, C0, svreinterpret_s32_u32(acc03_c0));
+                svst1_s32(pg_b32_4, C1, svreinterpret_s32_u32(acc03_c1));
+                if(cols_this >= 6){
+                    svst1_s32(svwhilelt_b32(0, 2), C0 + 4, svreinterpret_s32_u32(acc47_c0));
+                    svst1_s32(svwhilelt_b32(0, 2), C1 + 4, svreinterpret_s32_u32(acc47_c1));
+                }
+                else{
+                    svst1_s32(svwhilelt_b32(0, 1), C0 + 4, svreinterpret_s32_u32(acc47_c0));
+                    svst1_s32(svwhilelt_b32(0, 1), C1 + 4, svreinterpret_s32_u32(acc47_c1));
+                }
+            }
+            else{
+                // Row 0 (C0)
+                svint32_t prev = svld1_s32(pg_b32_4, C0);
+                svint32_t sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c0));
+                svst1_s32(pg_b32_4, C0, sum);
+                prev = svld1_s32(pg_b32_4, C1);
+                sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c1));
+                svst1_s32(pg_b32_4, C1, sum);
+                if(cols_this >= 6){
+                    prev = svld1_s32(svwhilelt_b32(0, 2), C0 + 4);
+                    sum  = svadd_s32_x(svwhilelt_b32(0, 2), prev, svreinterpret_s32_u32(acc47_c0));
+                    svst1_s32(svwhilelt_b32(0, 2), C0 + 4, sum);
+                    prev = svld1_s32(svwhilelt_b32(0, 2), C1 + 4);
+                    sum  = svadd_s32_x(svwhilelt_b32(0, 2), prev, svreinterpret_s32_u32(acc47_c1));
+                    svst1_s32(svwhilelt_b32(0, 2), C1 + 4, sum);
+                }
+                else{
+                    prev = svld1_s32(svwhilelt_b32(0, 1), C0 + 4);
+                    sum  = svadd_s32_x(svwhilelt_b32(0, 1), prev, svreinterpret_s32_u32(acc47_c0));
+                    svst1_s32(svwhilelt_b32(0, 1), C0 + 4, sum);
+                    prev = svld1_s32(svwhilelt_b32(0, 1), C1 + 4);
+                    sum  = svadd_s32_x(svwhilelt_b32(0, 1), prev, svreinterpret_s32_u32(acc47_c1));
+                    svst1_s32(svwhilelt_b32(0, 1), C1 + 4, sum);
+                }
+            }
+        }
+        else if(cols_this > 2){
+            if(isZeroPointB){
+                if(cols_this >= 4){
+                    svst1_s32(pg_b32_4, C0, svreinterpret_s32_u32(acc03_c0));
+                    svst1_s32(pg_b32_4, C1, svreinterpret_s32_u32(acc03_c1));
+                }
+                else{
+                    svst1_s32(svwhilelt_b32(0,3), C0, svreinterpret_s32_u32(acc03_c0));
+                    svst1_s32(svwhilelt_b32(0,3), C1, svreinterpret_s32_u32(acc03_c1));
+                }
+            }
+            else{
+                if(cols_this >= 4){
+                    // Row 0 (C0)
+                    svint32_t prev = svld1_s32(pg_b32_4, C0);
+                    svint32_t sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c0));
+                    svst1_s32(pg_b32_4, C0, sum);
+                    prev = svld1_s32(pg_b32_4, C1);
+                    sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c1));
+                    svst1_s32(pg_b32_4, C1, sum);
+                }
+                else{
+                    // Row 0 (C0)
+                    svint32_t prev = svld1_s32(svwhilelt_b32(0,3), C0);
+                    svint32_t sum = svadd_s32_x(svwhilelt_b32(0,3), prev, svreinterpret_s32_u32(acc03_c0));
+                    svst1_s32(svwhilelt_b32(0,3), C0, sum);
+                    prev = svld1_s32(svwhilelt_b32(0,3), C1);
+                    sum = svadd_s32_x(svwhilelt_b32(0,3), prev, svreinterpret_s32_u32(acc03_c1));
+                    svst1_s32(svwhilelt_b32(0,3), C1, sum);
+                }   
+            }
+        }
+        else{
+            if(isZeroPointB){
+                svst1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C0, svreinterpret_s32_u32(acc03_c0));
+                svst1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C1, svreinterpret_s32_u32(acc03_c1));
+            }
+            else{
+                // Row 0 (C0)
+                svint32_t prev = svld1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C0);
+                svint32_t sum = svadd_s32_x(svwhilelt_b32(0, std::min(int(cols_this), 2)), prev, svreinterpret_s32_u32(acc03_c0));
+                svst1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C0, sum);
+                prev = svld1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C1);
+                sum = svadd_s32_x(svwhilelt_b32(0, std::min(int(cols_this), 2)), prev, svreinterpret_s32_u32(acc03_c1));
+                svst1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C1, sum);
+            }
+        }
+        // Last 4 columns
+
+        //------------------------------------------------------------------
+        // Advance
+        //------------------------------------------------------------------
+        C0            += cols_this;
+        C1            += cols_this;
+        ColumnSumBuffer  += cols_this;
+        col              += cols_this;
+        if (ZeroPointB) {
+            ZeroPointB += cols_this;
+        }
+    }
+    return 2;
+}
+
+size_t Process4RowsTest256(
+    const uint8_t* A,
+    const uint8_t* B,
+    int32_t* C,
+    size_t PackedCountK,
+    size_t CountM,
+    size_t CountN,
+    size_t ldc,
+    const int32_t* RowSumBuffer,
+    const int32_t* ColumnSumBuffer,
+    const int32_t* ZeroPointB,
+    bool isZeroPointB)
+{
+    (void)CountM;
+
+    //------------------------------------------------------------------
+    // VL = 256 → int32 lanes = 8 → process columns in groups of 4
+    //------------------------------------------------------------------
+    svbool_t pg_b32_4 = svwhilelt_b32(0, 4);  // stores 4 output columns
+    svbool_t pg_b32_8 = svptrue_b32();  // full accumulator lanes
+    svbool_t pg_b8_32 = svptrue_b8(); // loads 32 bytes from A/B
+    svuint32_t acc03_0, acc03_1, acc47_0, acc47_1;
+
+    // const int32_t rowsum = RowSumBuffer[0];
+    svint32_t rowSumVec01, rowSumVec23, r0, r1, r2, r3;
+    r0 = svdup_s32(RowSumBuffer[0]);
+    r1 = svdup_s32(RowSumBuffer[1]);
+    rowSumVec01 = svreinterpret_s32_s64(svtrn1_s64(svreinterpret_s64_s32(r0), svreinterpret_s64_s32(r1)));
+    r2 = svdup_s32(RowSumBuffer[2]);
+    r3 = svdup_s32(RowSumBuffer[3]);
+    rowSumVec23 = svreinterpret_s32_s64(svtrn1_s64(svreinterpret_s64_s32(r2), svreinterpret_s64_s32(r3)));
+    const uint8_t* A_ptr;
+    int32_t *C0, *C1, *C2, *C3;
+    C0 = C;
+    C1 = C0 + ldc;
+    C2 = C1 + ldc;
+    C3 = C2 + ldc;
+
+    //------------------------------------------------------------------
+    // Loop over N in chunks of 8 columns
+    //------------------------------------------------------------------
+    for (size_t col = 0; col < CountN; )
+    {
+        size_t remaining = CountN - col;
+        size_t cols_this = std::min<size_t>(remaining, 8);
+
+        A_ptr = A;
+
+        svint32_t zpb_0_3, col_0_3, zpb_4_7, col_4_7;
+        svint64_t zpb64_0_3, col64_0_3, zpb64_4_7, col64_4_7;
+        // --- Columns 0–3 ---
+        if (ZeroPointB){
+            zpb_0_3 = svld1_s32(pg_b32_4, ZeroPointB); //pg_b32_4
+            zpb64_0_3 = svreinterpret_s64_s32(zpb_0_3);
+            zpb_0_3 = svreinterpret_s32_s64(svzip1_s64(zpb64_0_3, zpb64_0_3));
+        }
+        else
+            zpb_0_3 = svdup_s32(1);
+        col_0_3 = svld1_s32(pg_b32_4, ColumnSumBuffer);
+        col64_0_3 = svreinterpret_s64_s32(col_0_3);
+        col_0_3 = svreinterpret_s32_s64(svzip1_s64(col64_0_3, col64_0_3));
+
+        acc03_0 = svreinterpret_u32_s32(svadd_s32_x(pg_b32_8, svmul_s32_x(pg_b32_8, rowSumVec01, zpb_0_3), col_0_3));
+        acc03_1 = svreinterpret_u32_s32(svadd_s32_x(pg_b32_8, svmul_s32_x(pg_b32_8, rowSumVec23, zpb_0_3), col_0_3));
+
+        // --- Columns 4–7 ---
+        if (cols_this > 4) {
+            if (ZeroPointB){
+                zpb_4_7 = svld1_s32(pg_b32_4, ZeroPointB + 4);
+                zpb64_4_7 = svreinterpret_s64_s32(zpb_4_7);
+                zpb_4_7 = svreinterpret_s32_s64(svzip1_s64(zpb64_4_7, zpb64_4_7));
+            }
+            else{
+                zpb_4_7 = svdup_s32(1);
+            }
+            col_4_7 = svld1_s32(pg_b32_4, ColumnSumBuffer + 4);
+            col64_4_7 = svreinterpret_s64_s32(col_4_7);
+            col_4_7 = svreinterpret_s32_s64(svzip1_s64(col64_4_7, col64_4_7));
+            // acc47 = svreinterpret_u32_s32(svmad_s32_x(pg_b32_4, rowSumVec, zpb_4_7, col_4_7));
+            acc47_0 = svreinterpret_u32_s32(svadd_s32_x(pg_b32_8, svmul_s32_x(pg_b32_8, rowSumVec01, zpb_4_7), col_4_7));
+            acc47_1 = svreinterpret_u32_s32(svadd_s32_x(pg_b32_8, svmul_s32_x(pg_b32_8, rowSumVec23, zpb_4_7), col_4_7));
+        }
+        //------------------------------------------------------------------
+        // K loop
+        //------------------------------------------------------------------
+        // const uint8_t* B_ptr = B + col * 32; // 32 bytes per slice for VL=256
+
+        for (size_t k = 0; k < PackedCountK; k++)
+        {
+            // A: 32 bytes, B: 32 bytes per 4 columns
+            svuint8_t a0  = svld1rq_u8(pg_b8_32, A_ptr); //load and replicate
+            svuint8_t a1  = svld1rq_u8(pg_b8_32, A_ptr + 16); //load and replicate
+            svuint8_t b0 = svld1_u8(pg_b8_32, B);
+            svuint8_t b1 = svld1_u8(pg_b8_32, B + 32);
+
+            acc03_0 = svmmla_u32(acc03_0, a0, b0);
+            acc03_1 = svmmla_u32(acc03_1, a1, b0);
+            if (cols_this > 4){
+                acc47_0 = svmmla_u32(acc47_0, a0, b1);
+                acc47_1 = svmmla_u32(acc47_1, a1, b1);
+            }
+
+            A_ptr += 32;   // Each tile is 32 bytes for 256-bit
+            B += 64;     // Two × 32-byte blocks per 8 columns
+        }
+
+        //------------------------------------------------------------------
+        // Store results into C
+        //------------------------------------------------------------------
+        const svuint32_t idx1 = svdupq_n_u32(0, 1, 4, 5);
+        const svuint32_t idx2 = svdupq_n_u32(2, 3, 6, 7);
+        svuint32_t acc03_c0, acc03_c1, acc47_c0, acc47_c1, acc03_c2, acc03_c3, acc47_c2, acc47_c3;
+        acc03_c0 = svtbl_u32(acc03_0, idx1);
+        acc03_c1 = svtbl_u32(acc03_0, idx2);
+        acc03_c2 = svtbl_u32(acc03_1, idx1);
+        acc03_c3 = svtbl_u32(acc03_1, idx2);
+        if (cols_this > 4){
+            acc47_c0 = svtbl_u32(acc47_0, idx1);
+            acc47_c1 = svtbl_u32(acc47_0, idx2);
+            acc47_c2 = svtbl_u32(acc47_1, idx1);
+            acc47_c3 = svtbl_u32(acc47_1, idx2);
+        }
+        // First 4 columns
+        // 
+        if(cols_this > 6){
+            if(isZeroPointB){
+                svst1_s32(pg_b32_4, C0, svreinterpret_s32_u32(acc03_c0));
+                svst1_s32(pg_b32_4, C1, svreinterpret_s32_u32(acc03_c1));
+                svst1_s32(pg_b32_4, C2, svreinterpret_s32_u32(acc03_c2));
+                svst1_s32(pg_b32_4, C3, svreinterpret_s32_u32(acc03_c3));
+                if(cols_this >= 8){
+                    svst1_s32(pg_b32_4, C0 + 4, svreinterpret_s32_u32(acc47_c0));
+                    svst1_s32(pg_b32_4, C1 + 4, svreinterpret_s32_u32(acc47_c1));
+                    svst1_s32(pg_b32_4, C2 + 4, svreinterpret_s32_u32(acc47_c2));
+                    svst1_s32(pg_b32_4, C3 + 4, svreinterpret_s32_u32(acc47_c3));
+                }
+                else{
+                    svst1_s32(svwhilelt_b32(0,3), C0 + 4, svreinterpret_s32_u32(acc47_c0));
+                    svst1_s32(svwhilelt_b32(0,3), C1 + 4, svreinterpret_s32_u32(acc47_c1));
+                    svst1_s32(svwhilelt_b32(0,3), C2 + 4, svreinterpret_s32_u32(acc47_c2));
+                    svst1_s32(svwhilelt_b32(0,3), C3 + 4, svreinterpret_s32_u32(acc47_c3));
+                }            
+            }
+            else{
+                // Row 0 (C0)
+                svint32_t prev = svld1_s32(pg_b32_4, C0);
+                svint32_t sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c0));
+                svst1_s32(pg_b32_4, C0, sum);
+                prev = svld1_s32(pg_b32_4, C1);
+                sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c1));
+                svst1_s32(pg_b32_4, C1, sum);
+                prev = svld1_s32(pg_b32_4, C2);
+                sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c2));
+                svst1_s32(pg_b32_4, C2, sum);
+                prev = svld1_s32(pg_b32_4, C3);
+                sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c3));
+                svst1_s32(pg_b32_4, C3, sum);
+                // Row 1 (C1)
+                if(cols_this >= 8){
+                    prev = svld1_s32(pg_b32_4, C0 + 4);
+                    sum  = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc47_c0));
+                    svst1_s32(pg_b32_4, C0 + 4, sum);
+                    prev = svld1_s32(pg_b32_4, C1 + 4);
+                    sum  = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc47_c1));
+                    svst1_s32(pg_b32_4, C1 + 4, sum);
+                    prev = svld1_s32(pg_b32_4, C2 + 4);
+                    sum  = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc47_c2));
+                    svst1_s32(pg_b32_4, C2 + 4, sum);
+                    prev = svld1_s32(pg_b32_4, C3 + 4);
+                    sum  = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc47_c3));
+                    svst1_s32(pg_b32_4, C3 + 4, sum);
+                }
+                else{
+                    prev = svld1_s32(svwhilelt_b32(0,3), C0 + 4);
+                    sum  = svadd_s32_x(svwhilelt_b32(0,3), prev, svreinterpret_s32_u32(acc47_c0));
+                    svst1_s32(svwhilelt_b32(0,3), C0 + 4, sum);
+                    prev = svld1_s32(svwhilelt_b32(0,3), C1 + 4);
+                    sum  = svadd_s32_x(svwhilelt_b32(0,3), prev, svreinterpret_s32_u32(acc47_c1));
+                    svst1_s32(svwhilelt_b32(0,3), C1 + 4, sum);
+                    prev = svld1_s32(svwhilelt_b32(0,3), C2 + 4);
+                    sum  = svadd_s32_x(svwhilelt_b32(0,3), prev, svreinterpret_s32_u32(acc47_c2));
+                    svst1_s32(svwhilelt_b32(0,3), C2 + 4, sum);
+                    prev = svld1_s32(svwhilelt_b32(0,3), C3 + 4);
+                    sum  = svadd_s32_x(svwhilelt_b32(0,3), prev, svreinterpret_s32_u32(acc47_c3));
+                    svst1_s32(svwhilelt_b32(0,3), C3 + 4, sum);
+                }
+            }
+        }
+        else if(cols_this > 4){
+            if(isZeroPointB){
+                svst1_s32(pg_b32_4, C0, svreinterpret_s32_u32(acc03_c0));
+                svst1_s32(pg_b32_4, C1, svreinterpret_s32_u32(acc03_c1));
+                svst1_s32(pg_b32_4, C2, svreinterpret_s32_u32(acc03_c2));
+                svst1_s32(pg_b32_4, C3, svreinterpret_s32_u32(acc03_c3));
+                if(cols_this >= 6){
+                    svst1_s32(svwhilelt_b32(0, 2), C0 + 4, svreinterpret_s32_u32(acc47_c0));
+                    svst1_s32(svwhilelt_b32(0, 2), C1 + 4, svreinterpret_s32_u32(acc47_c1));
+                    svst1_s32(svwhilelt_b32(0, 2), C2 + 4, svreinterpret_s32_u32(acc47_c2));
+                    svst1_s32(svwhilelt_b32(0, 2), C3 + 4, svreinterpret_s32_u32(acc47_c3));
+                }
+                else{
+                    svst1_s32(svwhilelt_b32(0, 1), C0 + 4, svreinterpret_s32_u32(acc47_c0));
+                    svst1_s32(svwhilelt_b32(0, 1), C1 + 4, svreinterpret_s32_u32(acc47_c1));
+                    svst1_s32(svwhilelt_b32(0, 1), C2 + 4, svreinterpret_s32_u32(acc47_c2));
+                    svst1_s32(svwhilelt_b32(0, 1), C3 + 4, svreinterpret_s32_u32(acc47_c3));
+                }
+            }
+            else{
+                // Row 0 (C0)
+                svint32_t prev = svld1_s32(pg_b32_4, C0);
+                svint32_t sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c0));
+                svst1_s32(pg_b32_4, C0, sum);
+                prev = svld1_s32(pg_b32_4, C1);
+                sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c1));
+                svst1_s32(pg_b32_4, C1, sum);
+                prev = svld1_s32(pg_b32_4, C2);
+                sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c2));
+                svst1_s32(pg_b32_4, C2, sum);
+                prev = svld1_s32(pg_b32_4, C3);
+                sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c3));
+                svst1_s32(pg_b32_4, C3, sum);
+                if(cols_this >= 6){
+                    prev = svld1_s32(svwhilelt_b32(0, 2), C0 + 4);
+                    sum  = svadd_s32_x(svwhilelt_b32(0, 2), prev, svreinterpret_s32_u32(acc47_c0));
+                    svst1_s32(svwhilelt_b32(0, 2), C0 + 4, sum);
+                    prev = svld1_s32(svwhilelt_b32(0, 2), C1 + 4);
+                    sum  = svadd_s32_x(svwhilelt_b32(0, 2), prev, svreinterpret_s32_u32(acc47_c1));
+                    svst1_s32(svwhilelt_b32(0, 2), C1 + 4, sum);
+                    prev = svld1_s32(svwhilelt_b32(0, 2), C2 + 4);
+                    sum  = svadd_s32_x(svwhilelt_b32(0, 2), prev, svreinterpret_s32_u32(acc47_c2));
+                    svst1_s32(svwhilelt_b32(0, 2), C2 + 4, sum);
+                    prev = svld1_s32(svwhilelt_b32(0, 2), C3 + 4);
+                    sum  = svadd_s32_x(svwhilelt_b32(0, 2), prev, svreinterpret_s32_u32(acc47_c3));
+                    svst1_s32(svwhilelt_b32(0, 2), C3 + 4, sum);
+                }
+                else{
+                    prev = svld1_s32(svwhilelt_b32(0, 1), C0 + 4);
+                    sum  = svadd_s32_x(svwhilelt_b32(0, 1), prev, svreinterpret_s32_u32(acc47_c0));
+                    svst1_s32(svwhilelt_b32(0, 1), C0 + 4, sum);
+                    prev = svld1_s32(svwhilelt_b32(0, 1), C1 + 4);
+                    sum  = svadd_s32_x(svwhilelt_b32(0, 1), prev, svreinterpret_s32_u32(acc47_c1));
+                    svst1_s32(svwhilelt_b32(0, 1), C1 + 4, sum);
+                    prev = svld1_s32(svwhilelt_b32(0, 1), C2 + 4);
+                    sum  = svadd_s32_x(svwhilelt_b32(0, 1), prev, svreinterpret_s32_u32(acc47_c2));
+                    svst1_s32(svwhilelt_b32(0, 1), C2 + 4, sum);
+                    prev = svld1_s32(svwhilelt_b32(0, 1), C3 + 4);
+                    sum  = svadd_s32_x(svwhilelt_b32(0, 1), prev, svreinterpret_s32_u32(acc47_c3));
+                    svst1_s32(svwhilelt_b32(0, 1), C3 + 4, sum);
+                }
+            }
+        }
+        else if(cols_this > 2){
+            if(isZeroPointB){
+                if(cols_this >= 4){
+                    svst1_s32(pg_b32_4, C0, svreinterpret_s32_u32(acc03_c0));
+                    svst1_s32(pg_b32_4, C1, svreinterpret_s32_u32(acc03_c1));
+                    svst1_s32(pg_b32_4, C2, svreinterpret_s32_u32(acc03_c2));
+                    svst1_s32(pg_b32_4, C3, svreinterpret_s32_u32(acc03_c3));
+                }
+                else{
+                    svst1_s32(svwhilelt_b32(0,3), C0, svreinterpret_s32_u32(acc03_c0));
+                    svst1_s32(svwhilelt_b32(0,3), C1, svreinterpret_s32_u32(acc03_c1));
+                    svst1_s32(svwhilelt_b32(0,3), C2, svreinterpret_s32_u32(acc03_c2));
+                    svst1_s32(svwhilelt_b32(0,3), C3, svreinterpret_s32_u32(acc03_c3));
+                }
+            }
+            else{
+                if(cols_this >= 4){
+                    // Row 0 (C0)
+                    svint32_t prev = svld1_s32(pg_b32_4, C0);
+                    svint32_t sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c0));
+                    svst1_s32(pg_b32_4, C0, sum);
+                    prev = svld1_s32(pg_b32_4, C1);
+                    sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c1));
+                    svst1_s32(pg_b32_4, C1, sum);
+                    prev = svld1_s32(pg_b32_4, C2);
+                    sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c2));
+                    svst1_s32(pg_b32_4, C2, sum);
+                    prev = svld1_s32(pg_b32_4, C3);
+                    sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c3));
+                    svst1_s32(pg_b32_4, C3, sum);
+                }
+                else{
+                    // Row 0 (C0)
+                    svint32_t prev = svld1_s32(svwhilelt_b32(0,3), C0);
+                    svint32_t sum = svadd_s32_x(svwhilelt_b32(0,3), prev, svreinterpret_s32_u32(acc03_c0));
+                    svst1_s32(svwhilelt_b32(0,3), C0, sum);
+                    prev = svld1_s32(svwhilelt_b32(0,3), C1);
+                    sum = svadd_s32_x(svwhilelt_b32(0,3), prev, svreinterpret_s32_u32(acc03_c1));
+                    svst1_s32(svwhilelt_b32(0,3), C1, sum);
+                    prev = svld1_s32(svwhilelt_b32(0,3), C2);
+                    sum = svadd_s32_x(svwhilelt_b32(0,3), prev, svreinterpret_s32_u32(acc03_c2));
+                    svst1_s32(svwhilelt_b32(0,3), C2, sum);
+                    prev = svld1_s32(svwhilelt_b32(0,3), C3);
+                    sum = svadd_s32_x(svwhilelt_b32(0,3), prev, svreinterpret_s32_u32(acc03_c3));
+                    svst1_s32(svwhilelt_b32(0,3), C3, sum);
+                }   
+            }
+        }
+        else{
+            if(isZeroPointB){
+                svst1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C0, svreinterpret_s32_u32(acc03_c0));
+                svst1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C1, svreinterpret_s32_u32(acc03_c1));
+                svst1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C2, svreinterpret_s32_u32(acc03_c2));
+                svst1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C3, svreinterpret_s32_u32(acc03_c3));
+            }
+            else{
+                // Row 0 (C0)
+                svint32_t prev = svld1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C0);
+                svint32_t sum = svadd_s32_x(svwhilelt_b32(0, std::min(int(cols_this), 2)), prev, svreinterpret_s32_u32(acc03_c0));
+                svst1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C0, sum);
+                prev = svld1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C1);
+                sum = svadd_s32_x(svwhilelt_b32(0, std::min(int(cols_this), 2)), prev, svreinterpret_s32_u32(acc03_c1));
+                svst1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C1, sum);
+                prev = svld1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C2);
+                sum = svadd_s32_x(svwhilelt_b32(0, std::min(int(cols_this), 2)), prev, svreinterpret_s32_u32(acc03_c2));
+                svst1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C2, sum);
+                prev = svld1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C3);
+                sum = svadd_s32_x(svwhilelt_b32(0, std::min(int(cols_this), 2)), prev, svreinterpret_s32_u32(acc03_c3));
+                svst1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C3, sum);
+            }
+        }
+        // Last 4 columns
+
+        //------------------------------------------------------------------
+        // Advance
+        //------------------------------------------------------------------
+        C0            += cols_this;
+        C1            += cols_this;
+        C2            += cols_this;
+        C3            += cols_this;
+        ColumnSumBuffer  += cols_this;
+        col              += cols_this;
+        if (ZeroPointB) {
+            ZeroPointB += cols_this;
+        }
+    }
+    return 4;
+}
+
+size_t Process8RowsTest256(
+    const uint8_t* A,
+    const uint8_t* B,
+    int32_t* C,
+    size_t PackedCountK,
+    size_t CountM,
+    size_t CountN,
+    size_t ldc,
+    const int32_t* RowSumBuffer,
+    const int32_t* ColumnSumBuffer,
+    const int32_t* ZeroPointB,
+    bool isZeroPointB)
+{
+    (void)CountM;
+
+    //------------------------------------------------------------------
+    // VL = 256 → int32 lanes = 8 → process columns in groups of 4
+    //------------------------------------------------------------------
+    svbool_t pg_b32_4 = svwhilelt_b32(0, 4);  // stores 4 output columns
+    svbool_t pg_b32_8 = svptrue_b32();  // full accumulator lanes
+    svbool_t pg_b8_32 = svptrue_b8(); // loads 32 bytes from A/B
+    svuint32_t acc03_0, acc03_1, acc03_2, acc03_3, acc47_0, acc47_1, acc47_2, acc47_3;
+
+    // const int32_t rowsum = RowSumBuffer[0];
+    svint32_t rowSumVec01, rowSumVec23, rowSumVec45, rowSumVec67, r0, r1, r2, r3, r4, r5, r6, r7;
+    r0 = svdup_s32(RowSumBuffer[0]);
+    r1 = svdup_s32(RowSumBuffer[1]);
+    rowSumVec01 = svreinterpret_s32_s64(svtrn1_s64(svreinterpret_s64_s32(r0), svreinterpret_s64_s32(r1)));
+    r2 = svdup_s32(RowSumBuffer[2]);
+    r3 = svdup_s32(RowSumBuffer[3]);
+    rowSumVec23 = svreinterpret_s32_s64(svtrn1_s64(svreinterpret_s64_s32(r2), svreinterpret_s64_s32(r3)));
+    r4 = svdup_s32(RowSumBuffer[4]);
+    r5 = svdup_s32(RowSumBuffer[5]);
+    rowSumVec45 = svreinterpret_s32_s64(svtrn1_s64(svreinterpret_s64_s32(r4), svreinterpret_s64_s32(r5)));
+    r6 = svdup_s32(RowSumBuffer[6]);
+    r7 = svdup_s32(RowSumBuffer[7]);
+    rowSumVec67 = svreinterpret_s32_s64(svtrn1_s64(svreinterpret_s64_s32(r6), svreinterpret_s64_s32(r7)));
+    const uint8_t* A_ptr;
+    int32_t *C0, *C1, *C2, *C3, *C4, *C5, *C6, *C7;
+    C0 = C;
+    C1 = C0 + ldc;
+    C2 = C1 + ldc;
+    C3 = C2 + ldc;
+    C4 = C3 + ldc;
+    C5 = C4 + ldc;
+    C6 = C5 + ldc;
+    C7 = C6 + ldc;
+    //------------------------------------------------------------------
+    // Loop over N in chunks of 8 columns
+    //------------------------------------------------------------------
+    for (size_t col = 0; col < CountN; )
+    {
+        size_t remaining = CountN - col;
+        size_t cols_this = std::min<size_t>(remaining, 8);
+
+        A_ptr = A;
+
+        svint32_t zpb_0_3, col_0_3, zpb_4_7, col_4_7;
+        svint64_t zpb64_0_3, col64_0_3, zpb64_4_7, col64_4_7;
+        // --- Columns 0–3 ---
+        if (ZeroPointB){
+            zpb_0_3 = svld1_s32(pg_b32_4, ZeroPointB); //pg_b32_4
+            zpb64_0_3 = svreinterpret_s64_s32(zpb_0_3);
+            zpb_0_3 = svreinterpret_s32_s64(svzip1_s64(zpb64_0_3, zpb64_0_3));
+        }
+        else
+            zpb_0_3 = svdup_s32(1);
+        col_0_3 = svld1_s32(pg_b32_4, ColumnSumBuffer);
+        col64_0_3 = svreinterpret_s64_s32(col_0_3);
+        col_0_3 = svreinterpret_s32_s64(svzip1_s64(col64_0_3, col64_0_3));
+
+        acc03_0 = svreinterpret_u32_s32(svadd_s32_x(pg_b32_8, svmul_s32_x(pg_b32_8, rowSumVec01, zpb_0_3), col_0_3));
+        acc03_1 = svreinterpret_u32_s32(svadd_s32_x(pg_b32_8, svmul_s32_x(pg_b32_8, rowSumVec23, zpb_0_3), col_0_3));
+        acc03_2 = svreinterpret_u32_s32(svadd_s32_x(pg_b32_8, svmul_s32_x(pg_b32_8, rowSumVec45, zpb_0_3), col_0_3));
+        acc03_3 = svreinterpret_u32_s32(svadd_s32_x(pg_b32_8, svmul_s32_x(pg_b32_8, rowSumVec67, zpb_0_3), col_0_3));
+        // --- Columns 4–7 ---
+        if (cols_this > 4) {
+            if (ZeroPointB){
+                zpb_4_7 = svld1_s32(pg_b32_4, ZeroPointB + 4);
+                zpb64_4_7 = svreinterpret_s64_s32(zpb_4_7);
+                zpb_4_7 = svreinterpret_s32_s64(svzip1_s64(zpb64_4_7, zpb64_4_7));
+            }
+            else{
+                zpb_4_7 = svdup_s32(1);
+            }
+            col_4_7 = svld1_s32(pg_b32_4, ColumnSumBuffer + 4);
+            col64_4_7 = svreinterpret_s64_s32(col_4_7);
+            col_4_7 = svreinterpret_s32_s64(svzip1_s64(col64_4_7, col64_4_7));
+            // acc47 = svreinterpret_u32_s32(svmad_s32_x(pg_b32_4, rowSumVec, zpb_4_7, col_4_7));
+            acc47_0 = svreinterpret_u32_s32(svadd_s32_x(pg_b32_8, svmul_s32_x(pg_b32_8, rowSumVec01, zpb_4_7), col_4_7));
+            acc47_1 = svreinterpret_u32_s32(svadd_s32_x(pg_b32_8, svmul_s32_x(pg_b32_8, rowSumVec23, zpb_4_7), col_4_7));
+            acc47_2 = svreinterpret_u32_s32(svadd_s32_x(pg_b32_8, svmul_s32_x(pg_b32_8, rowSumVec45, zpb_4_7), col_4_7));
+            acc47_3 = svreinterpret_u32_s32(svadd_s32_x(pg_b32_8, svmul_s32_x(pg_b32_8, rowSumVec67, zpb_4_7), col_4_7));
+        }
+        //------------------------------------------------------------------
+        // K loop
+        //------------------------------------------------------------------
+        // const uint8_t* B_ptr = B + col * 32; // 32 bytes per slice for VL=256
+
+        for (size_t k = 0; k < PackedCountK; k++)
+        {
+            // A: 32 bytes, B: 32 bytes per 4 columns
+            svuint8_t a0  = svld1rq_u8(pg_b8_32, A_ptr); //load and replicate
+            svuint8_t a1  = svld1rq_u8(pg_b8_32, A_ptr + 16); //load and replicate
+            svuint8_t a2  = svld1rq_u8(pg_b8_32, A_ptr + 32); //load and replicate
+            svuint8_t a3  = svld1rq_u8(pg_b8_32, A_ptr + 48); //load and replicate
+            svuint8_t b0 = svld1_u8(pg_b8_32, B);
+            svuint8_t b1 = svld1_u8(pg_b8_32, B + 32);
+
+            acc03_0 = svmmla_u32(acc03_0, a0, b0);
+            acc03_1 = svmmla_u32(acc03_1, a1, b0);
+            acc03_2 = svmmla_u32(acc03_2, a2, b0);
+            acc03_3 = svmmla_u32(acc03_3, a3, b0);
+            if (cols_this > 4){
+                acc47_0 = svmmla_u32(acc47_0, a0, b1);
+                acc47_1 = svmmla_u32(acc47_1, a1, b1);
+                acc47_2 = svmmla_u32(acc47_2, a2, b1);
+                acc47_3 = svmmla_u32(acc47_3, a3, b1);
+            }
+
+            A_ptr += 64;   // Each tile is 32 bytes for 256-bit
+            B += 64;     // Two × 32-byte blocks per 8 columns
+        }
+
+        //------------------------------------------------------------------
+        // Store results into C
+        //------------------------------------------------------------------
+        const svuint32_t idx1 = svdupq_n_u32(0, 1, 4, 5);
+        const svuint32_t idx2 = svdupq_n_u32(2, 3, 6, 7);
+        svuint32_t acc03_c0, acc03_c1, acc47_c0, acc47_c1, acc03_c2, acc03_c3, acc47_c2, acc47_c3, acc03_c4, acc03_c5, acc47_c4, acc47_c5, acc03_c6, acc03_c7, acc47_c6, acc47_c7;
+        acc03_c0 = svtbl_u32(acc03_0, idx1);
+        acc03_c1 = svtbl_u32(acc03_0, idx2);
+        acc03_c2 = svtbl_u32(acc03_1, idx1);
+        acc03_c3 = svtbl_u32(acc03_1, idx2);
+        acc03_c4 = svtbl_u32(acc03_2, idx1);
+        acc03_c5 = svtbl_u32(acc03_2, idx2);
+        acc03_c6 = svtbl_u32(acc03_3, idx1);
+        acc03_c7 = svtbl_u32(acc03_3, idx2);
+        if (cols_this > 4){
+            acc47_c0 = svtbl_u32(acc47_0, idx1);
+            acc47_c1 = svtbl_u32(acc47_0, idx2);
+            acc47_c2 = svtbl_u32(acc47_1, idx1);
+            acc47_c3 = svtbl_u32(acc47_1, idx2);
+            acc47_c4 = svtbl_u32(acc47_2, idx1);
+            acc47_c5 = svtbl_u32(acc47_2, idx2);
+            acc47_c6 = svtbl_u32(acc47_3, idx1);
+            acc47_c7 = svtbl_u32(acc47_3, idx2);
+        }
+        // First 4 columns
+        // 
+        if(cols_this > 6){
+            if(isZeroPointB){
+                svst1_s32(pg_b32_4, C0, svreinterpret_s32_u32(acc03_c0));
+                svst1_s32(pg_b32_4, C1, svreinterpret_s32_u32(acc03_c1));
+                svst1_s32(pg_b32_4, C2, svreinterpret_s32_u32(acc03_c2));
+                svst1_s32(pg_b32_4, C3, svreinterpret_s32_u32(acc03_c3));
+                svst1_s32(pg_b32_4, C4, svreinterpret_s32_u32(acc03_c4));
+                svst1_s32(pg_b32_4, C5, svreinterpret_s32_u32(acc03_c5));
+                svst1_s32(pg_b32_4, C6, svreinterpret_s32_u32(acc03_c6));
+                svst1_s32(pg_b32_4, C7, svreinterpret_s32_u32(acc03_c7));
+                if(cols_this >= 8){
+                    svst1_s32(pg_b32_4, C0 + 4, svreinterpret_s32_u32(acc47_c0));
+                    svst1_s32(pg_b32_4, C1 + 4, svreinterpret_s32_u32(acc47_c1));
+                    svst1_s32(pg_b32_4, C2 + 4, svreinterpret_s32_u32(acc47_c2));
+                    svst1_s32(pg_b32_4, C3 + 4, svreinterpret_s32_u32(acc47_c3));
+                    svst1_s32(pg_b32_4, C4 + 4, svreinterpret_s32_u32(acc47_c4));
+                    svst1_s32(pg_b32_4, C5 + 4, svreinterpret_s32_u32(acc47_c5));
+                    svst1_s32(pg_b32_4, C6 + 4, svreinterpret_s32_u32(acc47_c6));
+                    svst1_s32(pg_b32_4, C7 + 4, svreinterpret_s32_u32(acc47_c7));
+                }
+                else{
+                    svst1_s32(svwhilelt_b32(0,3), C0 + 4, svreinterpret_s32_u32(acc47_c0));
+                    svst1_s32(svwhilelt_b32(0,3), C1 + 4, svreinterpret_s32_u32(acc47_c1));
+                    svst1_s32(svwhilelt_b32(0,3), C2 + 4, svreinterpret_s32_u32(acc47_c2));
+                    svst1_s32(svwhilelt_b32(0,3), C3 + 4, svreinterpret_s32_u32(acc47_c3));
+                    svst1_s32(svwhilelt_b32(0,3), C4 + 4, svreinterpret_s32_u32(acc47_c4));
+                    svst1_s32(svwhilelt_b32(0,3), C5 + 4, svreinterpret_s32_u32(acc47_c5));
+                    svst1_s32(svwhilelt_b32(0,3), C6 + 4, svreinterpret_s32_u32(acc47_c6));
+                    svst1_s32(svwhilelt_b32(0,3), C7 + 4, svreinterpret_s32_u32(acc47_c7));
+                }            
+            }
+            else{
+                // Row 0 (C0)
+                svint32_t prev = svld1_s32(pg_b32_4, C0);
+                svint32_t sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c0));
+                svst1_s32(pg_b32_4, C0, sum);
+                prev = svld1_s32(pg_b32_4, C1);
+                sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c1));
+                svst1_s32(pg_b32_4, C1, sum);
+                prev = svld1_s32(pg_b32_4, C2);
+                sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c2));
+                svst1_s32(pg_b32_4, C2, sum);
+                prev = svld1_s32(pg_b32_4, C3);
+                sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c3));
+                svst1_s32(pg_b32_4, C3, sum);
+                prev = svld1_s32(pg_b32_4, C4);
+                sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c4));
+                svst1_s32(pg_b32_4, C4, sum);
+                prev = svld1_s32(pg_b32_4, C5);
+                sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c5));
+                svst1_s32(pg_b32_4, C5, sum);
+                prev = svld1_s32(pg_b32_4, C6);
+                sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c6));
+                svst1_s32(pg_b32_4, C6, sum);
+                prev = svld1_s32(pg_b32_4, C7);
+                sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c7));
+                svst1_s32(pg_b32_4, C7, sum);
+                // Row 1 (C1)
+                if(cols_this >= 8){
+                    prev = svld1_s32(pg_b32_4, C0 + 4);
+                    sum  = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc47_c0));
+                    svst1_s32(pg_b32_4, C0 + 4, sum);
+                    prev = svld1_s32(pg_b32_4, C1 + 4);
+                    sum  = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc47_c1));
+                    svst1_s32(pg_b32_4, C1 + 4, sum);
+                    prev = svld1_s32(pg_b32_4, C2 + 4);
+                    sum  = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc47_c2));
+                    svst1_s32(pg_b32_4, C2 + 4, sum);
+                    prev = svld1_s32(pg_b32_4, C3 + 4);
+                    sum  = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc47_c3));
+                    svst1_s32(pg_b32_4, C3 + 4, sum);
+                    prev = svld1_s32(pg_b32_4, C4 + 4);
+                    sum  = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc47_c4));
+                    svst1_s32(pg_b32_4, C4 + 4, sum);
+                    prev = svld1_s32(pg_b32_4, C5 + 4);
+                    sum  = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc47_c5));
+                    svst1_s32(pg_b32_4, C5 + 4, sum);
+                    prev = svld1_s32(pg_b32_4, C6 + 4);
+                    sum  = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc47_c6));
+                    svst1_s32(pg_b32_4, C6 + 4, sum);
+                    prev = svld1_s32(pg_b32_4, C7 + 4);
+                    sum  = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc47_c7));
+                    svst1_s32(pg_b32_4, C7 + 4, sum);
+                }
+                else{
+                    prev = svld1_s32(svwhilelt_b32(0,3), C0 + 4);
+                    sum  = svadd_s32_x(svwhilelt_b32(0,3), prev, svreinterpret_s32_u32(acc47_c0));
+                    svst1_s32(svwhilelt_b32(0,3), C0 + 4, sum);
+                    prev = svld1_s32(svwhilelt_b32(0,3), C1 + 4);
+                    sum  = svadd_s32_x(svwhilelt_b32(0,3), prev, svreinterpret_s32_u32(acc47_c1));
+                    svst1_s32(svwhilelt_b32(0,3), C1 + 4, sum);
+                    prev = svld1_s32(svwhilelt_b32(0,3), C2 + 4);
+                    sum  = svadd_s32_x(svwhilelt_b32(0,3), prev, svreinterpret_s32_u32(acc47_c2));
+                    svst1_s32(svwhilelt_b32(0,3), C2 + 4, sum);
+                    prev = svld1_s32(svwhilelt_b32(0,3), C3 + 4);
+                    sum  = svadd_s32_x(svwhilelt_b32(0,3), prev, svreinterpret_s32_u32(acc47_c3));
+                    svst1_s32(svwhilelt_b32(0,3), C3 + 4, sum);
+                    prev = svld1_s32(svwhilelt_b32(0,3), C4 + 4);
+                    sum  = svadd_s32_x(svwhilelt_b32(0,3), prev, svreinterpret_s32_u32(acc47_c4));
+                    svst1_s32(svwhilelt_b32(0,3), C4 + 4, sum);
+                    prev = svld1_s32(svwhilelt_b32(0,3), C5 + 4);
+                    sum  = svadd_s32_x(svwhilelt_b32(0,3), prev, svreinterpret_s32_u32(acc47_c5));
+                    svst1_s32(svwhilelt_b32(0,3), C5 + 4, sum);
+                    prev = svld1_s32(svwhilelt_b32(0,3), C6 + 4);
+                    sum  = svadd_s32_x(svwhilelt_b32(0,3), prev, svreinterpret_s32_u32(acc47_c6));
+                    svst1_s32(svwhilelt_b32(0,3), C6 + 4, sum);
+                    prev = svld1_s32(svwhilelt_b32(0,3), C7 + 4);
+                    sum  = svadd_s32_x(svwhilelt_b32(0,3), prev, svreinterpret_s32_u32(acc47_c7));
+                    svst1_s32(svwhilelt_b32(0,3), C7 + 4, sum);
+                }
+            }
+        }
+        else if(cols_this > 4){
+            if(isZeroPointB){
+                svst1_s32(pg_b32_4, C0, svreinterpret_s32_u32(acc03_c0));
+                svst1_s32(pg_b32_4, C1, svreinterpret_s32_u32(acc03_c1));
+                svst1_s32(pg_b32_4, C2, svreinterpret_s32_u32(acc03_c2));
+                svst1_s32(pg_b32_4, C3, svreinterpret_s32_u32(acc03_c3));
+                svst1_s32(pg_b32_4, C4, svreinterpret_s32_u32(acc03_c4));
+                svst1_s32(pg_b32_4, C5, svreinterpret_s32_u32(acc03_c5));
+                svst1_s32(pg_b32_4, C6, svreinterpret_s32_u32(acc03_c6));
+                svst1_s32(pg_b32_4, C7, svreinterpret_s32_u32(acc03_c7));
+                if(cols_this >= 6){
+                    svst1_s32(svwhilelt_b32(0, 2), C0 + 4, svreinterpret_s32_u32(acc47_c0));
+                    svst1_s32(svwhilelt_b32(0, 2), C1 + 4, svreinterpret_s32_u32(acc47_c1));
+                    svst1_s32(svwhilelt_b32(0, 2), C2 + 4, svreinterpret_s32_u32(acc47_c2));
+                    svst1_s32(svwhilelt_b32(0, 2), C3 + 4, svreinterpret_s32_u32(acc47_c3));
+                    svst1_s32(svwhilelt_b32(0, 2), C4 + 4, svreinterpret_s32_u32(acc47_c4));
+                    svst1_s32(svwhilelt_b32(0, 2), C5 + 4, svreinterpret_s32_u32(acc47_c5));
+                    svst1_s32(svwhilelt_b32(0, 2), C6 + 4, svreinterpret_s32_u32(acc47_c6));
+                    svst1_s32(svwhilelt_b32(0, 2), C7 + 4, svreinterpret_s32_u32(acc47_c7));
+                }
+                else{
+                    svst1_s32(svwhilelt_b32(0, 1), C0 + 4, svreinterpret_s32_u32(acc47_c0));
+                    svst1_s32(svwhilelt_b32(0, 1), C1 + 4, svreinterpret_s32_u32(acc47_c1));
+                    svst1_s32(svwhilelt_b32(0, 1), C2 + 4, svreinterpret_s32_u32(acc47_c2));
+                    svst1_s32(svwhilelt_b32(0, 1), C3 + 4, svreinterpret_s32_u32(acc47_c3));
+                    svst1_s32(svwhilelt_b32(0, 1), C4 + 4, svreinterpret_s32_u32(acc47_c4));
+                    svst1_s32(svwhilelt_b32(0, 1), C5 + 4, svreinterpret_s32_u32(acc47_c5));
+                    svst1_s32(svwhilelt_b32(0, 1), C6 + 4, svreinterpret_s32_u32(acc47_c6));
+                    svst1_s32(svwhilelt_b32(0, 1), C7 + 4, svreinterpret_s32_u32(acc47_c7));
+                }
+            }
+            else{
+                // Row 0 (C0)
+                svint32_t prev = svld1_s32(pg_b32_4, C0);
+                svint32_t sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c0));
+                svst1_s32(pg_b32_4, C0, sum);
+                prev = svld1_s32(pg_b32_4, C1);
+                sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c1));
+                svst1_s32(pg_b32_4, C1, sum);
+                prev = svld1_s32(pg_b32_4, C2);
+                sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c2));
+                svst1_s32(pg_b32_4, C2, sum);
+                prev = svld1_s32(pg_b32_4, C3);
+                sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c3));
+                svst1_s32(pg_b32_4, C3, sum);
+                prev = svld1_s32(pg_b32_4, C4);
+                sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c4));
+                svst1_s32(pg_b32_4, C4, sum);
+                prev = svld1_s32(pg_b32_4, C5);
+                sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c5));
+                svst1_s32(pg_b32_4, C5, sum);
+                prev = svld1_s32(pg_b32_4, C6);
+                sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c6));
+                svst1_s32(pg_b32_4, C6, sum);
+                prev = svld1_s32(pg_b32_4, C7);
+                sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c7));
+                svst1_s32(pg_b32_4, C7, sum);
+                // Row 1 (C1)
+                if(cols_this >= 6){
+                    prev = svld1_s32(svwhilelt_b32(0, 2), C0 + 4);
+                    sum  = svadd_s32_x(svwhilelt_b32(0, 2), prev, svreinterpret_s32_u32(acc47_c0));
+                    svst1_s32(svwhilelt_b32(0, 2), C0 + 4, sum);
+                    prev = svld1_s32(svwhilelt_b32(0, 2), C1 + 4);
+                    sum  = svadd_s32_x(svwhilelt_b32(0, 2), prev, svreinterpret_s32_u32(acc47_c1));
+                    svst1_s32(svwhilelt_b32(0, 2), C1 + 4, sum);
+                    prev = svld1_s32(svwhilelt_b32(0, 2), C2 + 4);
+                    sum  = svadd_s32_x(svwhilelt_b32(0, 2), prev, svreinterpret_s32_u32(acc47_c2));
+                    svst1_s32(svwhilelt_b32(0, 2), C2 + 4, sum);
+                    prev = svld1_s32(svwhilelt_b32(0, 2), C3 + 4);
+                    sum  = svadd_s32_x(svwhilelt_b32(0, 2), prev, svreinterpret_s32_u32(acc47_c3));
+                    svst1_s32(svwhilelt_b32(0, 2), C3 + 4, sum);
+                    prev = svld1_s32(svwhilelt_b32(0, 2), C4 + 4);
+                    sum  = svadd_s32_x(svwhilelt_b32(0, 2), prev, svreinterpret_s32_u32(acc47_c4));
+                    svst1_s32(svwhilelt_b32(0, 2), C4 + 4, sum);
+                    prev = svld1_s32(svwhilelt_b32(0, 2), C5 + 4);
+                    sum  = svadd_s32_x(svwhilelt_b32(0, 2), prev, svreinterpret_s32_u32(acc47_c5));
+                    svst1_s32(svwhilelt_b32(0, 2), C5 + 4, sum);
+                    prev = svld1_s32(svwhilelt_b32(0, 2), C6 + 4);
+                    sum  = svadd_s32_x(svwhilelt_b32(0, 2), prev, svreinterpret_s32_u32(acc47_c6));
+                    svst1_s32(svwhilelt_b32(0, 2), C6 + 4, sum);
+                    prev = svld1_s32(svwhilelt_b32(0, 2), C7 + 4);
+                    sum  = svadd_s32_x(svwhilelt_b32(0, 2), prev, svreinterpret_s32_u32(acc47_c7));
+                    svst1_s32(svwhilelt_b32(0, 2), C7 + 4, sum);
+                }
+                else{
+                    prev = svld1_s32(svwhilelt_b32(0, 1), C0 + 4);
+                    sum  = svadd_s32_x(svwhilelt_b32(0, 1), prev, svreinterpret_s32_u32(acc47_c0));
+                    svst1_s32(svwhilelt_b32(0, 1), C0 + 4, sum);
+                    prev = svld1_s32(svwhilelt_b32(0, 1), C1 + 4);
+                    sum  = svadd_s32_x(svwhilelt_b32(0, 1), prev, svreinterpret_s32_u32(acc47_c1));
+                    svst1_s32(svwhilelt_b32(0, 1), C1 + 4, sum);
+                    prev = svld1_s32(svwhilelt_b32(0, 1), C2 + 4);
+                    sum  = svadd_s32_x(svwhilelt_b32(0, 1), prev, svreinterpret_s32_u32(acc47_c2));
+                    svst1_s32(svwhilelt_b32(0, 1), C2 + 4, sum);
+                    prev = svld1_s32(svwhilelt_b32(0, 1), C3 + 4);
+                    sum  = svadd_s32_x(svwhilelt_b32(0, 1), prev, svreinterpret_s32_u32(acc47_c3));
+                    svst1_s32(svwhilelt_b32(0, 1), C3 + 4, sum);
+                    prev = svld1_s32(svwhilelt_b32(0, 1), C4 + 4);
+                    sum  = svadd_s32_x(svwhilelt_b32(0, 1), prev, svreinterpret_s32_u32(acc47_c4));
+                    svst1_s32(svwhilelt_b32(0, 1), C4 + 4, sum);
+                    prev = svld1_s32(svwhilelt_b32(0, 1), C5 + 4);
+                    sum  = svadd_s32_x(svwhilelt_b32(0, 1), prev, svreinterpret_s32_u32(acc47_c5));
+                    svst1_s32(svwhilelt_b32(0, 1), C5 + 4, sum);
+                    prev = svld1_s32(svwhilelt_b32(0, 1), C6 + 4);
+                    sum  = svadd_s32_x(svwhilelt_b32(0, 1), prev, svreinterpret_s32_u32(acc47_c6));
+                    svst1_s32(svwhilelt_b32(0, 1), C6 + 4, sum);
+                    prev = svld1_s32(svwhilelt_b32(0, 1), C7 + 4);
+                    sum  = svadd_s32_x(svwhilelt_b32(0, 1), prev, svreinterpret_s32_u32(acc47_c7));
+                    svst1_s32(svwhilelt_b32(0, 1), C7 + 4, sum);
+                }
+            }
+        }
+        else if(cols_this > 2){
+            if(isZeroPointB){
+                if(cols_this >= 4){
+                    svst1_s32(pg_b32_4, C0, svreinterpret_s32_u32(acc03_c0));
+                    svst1_s32(pg_b32_4, C1, svreinterpret_s32_u32(acc03_c1));
+                    svst1_s32(pg_b32_4, C2, svreinterpret_s32_u32(acc03_c2));
+                    svst1_s32(pg_b32_4, C3, svreinterpret_s32_u32(acc03_c3));
+                    svst1_s32(pg_b32_4, C4, svreinterpret_s32_u32(acc03_c4));
+                    svst1_s32(pg_b32_4, C5, svreinterpret_s32_u32(acc03_c5));
+                    svst1_s32(pg_b32_4, C6, svreinterpret_s32_u32(acc03_c6));
+                    svst1_s32(pg_b32_4, C7, svreinterpret_s32_u32(acc03_c7));
+                }
+                else{
+                    svst1_s32(svwhilelt_b32(0,3), C0, svreinterpret_s32_u32(acc03_c0));
+                    svst1_s32(svwhilelt_b32(0,3), C1, svreinterpret_s32_u32(acc03_c1));
+                    svst1_s32(svwhilelt_b32(0,3), C2, svreinterpret_s32_u32(acc03_c2));
+                    svst1_s32(svwhilelt_b32(0,3), C3, svreinterpret_s32_u32(acc03_c3));
+                    svst1_s32(svwhilelt_b32(0,3), C4, svreinterpret_s32_u32(acc03_c4));
+                    svst1_s32(svwhilelt_b32(0,3), C5, svreinterpret_s32_u32(acc03_c5));
+                    svst1_s32(svwhilelt_b32(0,3), C6, svreinterpret_s32_u32(acc03_c6));
+                    svst1_s32(svwhilelt_b32(0,3), C7, svreinterpret_s32_u32(acc03_c7));
+                }
+            }
+            else{
+                if(cols_this >= 4){
+                    // Row 0 (C0)
+                    svint32_t prev = svld1_s32(pg_b32_4, C0);
+                    svint32_t sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c0));
+                    svst1_s32(pg_b32_4, C0, sum);
+                    prev = svld1_s32(pg_b32_4, C1);
+                    sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c1));
+                    svst1_s32(pg_b32_4, C1, sum);
+                    prev = svld1_s32(pg_b32_4, C2);
+                    sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c2));
+                    svst1_s32(pg_b32_4, C2, sum);
+                    prev = svld1_s32(pg_b32_4, C3);
+                    sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c3));
+                    svst1_s32(pg_b32_4, C3, sum);
+                    prev = svld1_s32(pg_b32_4, C4);
+                    sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c4));
+                    svst1_s32(pg_b32_4, C4, sum);
+                    prev = svld1_s32(pg_b32_4, C5);
+                    sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c5));
+                    svst1_s32(pg_b32_4, C5, sum);
+                    prev = svld1_s32(pg_b32_4, C6);
+                    sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c6));
+                    svst1_s32(pg_b32_4, C6, sum);
+                    prev = svld1_s32(pg_b32_4, C7);
+                    sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c7));
+                    svst1_s32(pg_b32_4, C7, sum);
+                }
+                else{
+                    // Row 0 (C0)
+                    svint32_t prev = svld1_s32(svwhilelt_b32(0,3), C0);
+                    svint32_t sum = svadd_s32_x(svwhilelt_b32(0,3), prev, svreinterpret_s32_u32(acc03_c0));
+                    svst1_s32(svwhilelt_b32(0,3), C0, sum);
+                    prev = svld1_s32(svwhilelt_b32(0,3), C1);
+                    sum = svadd_s32_x(svwhilelt_b32(0,3), prev, svreinterpret_s32_u32(acc03_c1));
+                    svst1_s32(svwhilelt_b32(0,3), C1, sum);
+                    prev = svld1_s32(svwhilelt_b32(0,3), C2);
+                    sum = svadd_s32_x(svwhilelt_b32(0,3), prev, svreinterpret_s32_u32(acc03_c2));
+                    svst1_s32(svwhilelt_b32(0,3), C2, sum);
+                    prev = svld1_s32(svwhilelt_b32(0,3), C3);
+                    sum = svadd_s32_x(svwhilelt_b32(0,3), prev, svreinterpret_s32_u32(acc03_c3));
+                    svst1_s32(svwhilelt_b32(0,3), C3, sum);
+                    prev = svld1_s32(svwhilelt_b32(0,3), C4);
+                    sum = svadd_s32_x(svwhilelt_b32(0,3), prev, svreinterpret_s32_u32(acc03_c4));
+                    svst1_s32(svwhilelt_b32(0,3), C4, sum);
+                    prev = svld1_s32(svwhilelt_b32(0,3), C5);
+                    sum = svadd_s32_x(svwhilelt_b32(0,3), prev, svreinterpret_s32_u32(acc03_c5));
+                    svst1_s32(svwhilelt_b32(0,3), C5, sum);
+                    prev = svld1_s32(svwhilelt_b32(0,3), C6);
+                    sum = svadd_s32_x(svwhilelt_b32(0,3), prev, svreinterpret_s32_u32(acc03_c6));
+                    svst1_s32(svwhilelt_b32(0,3), C6, sum);
+                    prev = svld1_s32(svwhilelt_b32(0,3), C7);
+                    sum = svadd_s32_x(svwhilelt_b32(0,3), prev, svreinterpret_s32_u32(acc03_c7));
+                    svst1_s32(svwhilelt_b32(0,3), C7, sum);
+                }   
+            }
+        }
+        else{
+            if(isZeroPointB){
+                svst1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C0, svreinterpret_s32_u32(acc03_c0));
+                svst1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C1, svreinterpret_s32_u32(acc03_c1));
+                svst1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C2, svreinterpret_s32_u32(acc03_c2));
+                svst1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C3, svreinterpret_s32_u32(acc03_c3));
+                svst1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C4, svreinterpret_s32_u32(acc03_c4));
+                svst1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C5, svreinterpret_s32_u32(acc03_c5));
+                svst1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C6, svreinterpret_s32_u32(acc03_c6));
+                svst1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C7, svreinterpret_s32_u32(acc03_c7));
+            }
+            else{
+                // Row 0 (C0)
+                svint32_t prev = svld1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C0);
+                svint32_t sum = svadd_s32_x(svwhilelt_b32(0, std::min(int(cols_this), 2)), prev, svreinterpret_s32_u32(acc03_c0));
+                svst1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C0, sum);
+                prev = svld1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C1);
+                sum = svadd_s32_x(svwhilelt_b32(0, std::min(int(cols_this), 2)), prev, svreinterpret_s32_u32(acc03_c1));
+                svst1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C1, sum);
+                prev = svld1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C2);
+                sum = svadd_s32_x(svwhilelt_b32(0, std::min(int(cols_this), 2)), prev, svreinterpret_s32_u32(acc03_c2));
+                svst1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C2, sum);
+                prev = svld1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C3);
+                sum = svadd_s32_x(svwhilelt_b32(0, std::min(int(cols_this), 2)), prev, svreinterpret_s32_u32(acc03_c3));
+                svst1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C3, sum);
+                prev = svld1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C4);
+                sum = svadd_s32_x(svwhilelt_b32(0, std::min(int(cols_this), 2)), prev, svreinterpret_s32_u32(acc03_c4));
+                svst1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C4, sum);
+                prev = svld1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C5);
+                sum = svadd_s32_x(svwhilelt_b32(0, std::min(int(cols_this), 2)), prev, svreinterpret_s32_u32(acc03_c5));
+                svst1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C5, sum);
+                prev = svld1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C6);
+                sum = svadd_s32_x(svwhilelt_b32(0, std::min(int(cols_this), 2)), prev, svreinterpret_s32_u32(acc03_c6));
+                svst1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C6, sum);
+                prev = svld1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C7);
+                sum = svadd_s32_x(svwhilelt_b32(0, std::min(int(cols_this), 2)), prev, svreinterpret_s32_u32(acc03_c7));
+                svst1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C7, sum);
+            }
+        }
+        // Last 4 columns
+
+        //------------------------------------------------------------------
+        // Advance
+        //------------------------------------------------------------------
+        C0            += cols_this;
+        C1            += cols_this;
+        C2            += cols_this;
+        C3            += cols_this;
+        C4            += cols_this;
+        C5            += cols_this;
+        C6            += cols_this;
+        C7            += cols_this;
+        ColumnSumBuffer  += cols_this;
+        col              += cols_this;
+        if (ZeroPointB) {
+            ZeroPointB += cols_this;
+        }
+    }
+    return 8;
+}
+
+size_t MlasSveQgemmU8X8KernelUmmlaAdd(const MLAS_GEMM_U8X8_KERNEL_UMMLA::PackedAType* A,
+                                const MLAS_GEMM_U8X8_KERNEL_UMMLA::PackedBType* B,
+                                int32_t* C,
+                                size_t PackedCountK,
+                                size_t CountM,
+                                size_t CountN,
+                                size_t ldc,
+                                const int32_t* RowSumBuffer,
+                                const int32_t* ColumnSumBuffer,
+                                const int32_t* ZeroPointB
+                              )
+{
+    bool isZeroPointB = false;
+    if (CountM >= 8) {
+        return Process8RowsTest256(A, B, C, PackedCountK, CountM, CountN, ldc,
+                                RowSumBuffer, ColumnSumBuffer, ZeroPointB, isZeroPointB);
+    } 
+    else if (CountM >= 4) {
+        return Process4RowsTest256(A, B, C, PackedCountK, CountM, CountN, ldc,
+                                RowSumBuffer, ColumnSumBuffer, ZeroPointB, isZeroPointB);
+    } else if (CountM >= 2) {
+        return Process2RowsTest256(A, B, C, PackedCountK, CountM, CountN, ldc,
+                                RowSumBuffer, ColumnSumBuffer, ZeroPointB, isZeroPointB);
+    } else if (CountM >= 1) {
+        return Process1RowTest256(A, B, C, PackedCountK, CountM, CountN, ldc,
+                               RowSumBuffer, ColumnSumBuffer, ZeroPointB, isZeroPointB);
+    }
+    return 0; // Unsupported CountM
+}
+
+size_t MlasSveQgemmU8X8KernelUmmlaZero(const MLAS_GEMM_U8X8_KERNEL_UMMLA::PackedAType* A,
+                                const MLAS_GEMM_U8X8_KERNEL_UMMLA::PackedBType* B,
+                                int32_t* C,
+                                size_t PackedCountK,
+                                size_t CountM,
+                                size_t CountN,
+                                size_t ldc,
+                                const int32_t* RowSumBuffer,
+                                const int32_t* ColumnSumBuffer,
+                                const int32_t* ZeroPointB
+                              )
+{
+    bool isZeroPointB = true;
+    if (CountM >= 8) {
+        return Process8RowsTest256(A, B, C, PackedCountK, CountM, CountN, ldc,
+                                RowSumBuffer, ColumnSumBuffer, ZeroPointB, isZeroPointB);
+    }
+    else if (CountM >= 4) {
+        return Process4RowsTest256(A, B, C, PackedCountK, CountM, CountN, ldc,
+                                RowSumBuffer, ColumnSumBuffer, ZeroPointB, isZeroPointB);
+        
+    } else if (CountM >= 2) {
+        return Process2RowsTest256(A, B, C, PackedCountK, CountM, CountN, ldc,
+                                RowSumBuffer, ColumnSumBuffer, ZeroPointB, isZeroPointB);
+
+    } else if (CountM >= 1) {
+        return Process1RowTest256(A, B, C, PackedCountK, CountM, CountN, ldc,
+                               RowSumBuffer, ColumnSumBuffer, ZeroPointB, isZeroPointB);
+    }
+    return 0; // Unsupported CountM
+}
+#pragma GCC diagnostic pop

--- a/onnxruntime/core/mlas/lib/sve/qgemm_sve256.cpp
+++ b/onnxruntime/core/mlas/lib/sve/qgemm_sve256.cpp
@@ -1,4 +1,5 @@
 #include <arm_sve.h>
+#include <algorithm>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
@@ -43,7 +44,7 @@ struct MLAS_GEMM_U8X8_KERNEL_UMMLA {
     using PackedBType = uint8_t;
 };
 
-template<bool HasZeroPointB>
+template<bool ZeroMode>
 MLAS_FORCEINLINE size_t Process1Row(
     const uint8_t* A,
     const uint8_t* B,
@@ -147,7 +148,7 @@ MLAS_FORCEINLINE size_t Process1Row(
         // First 4 columns
         // 
         if(cols_this > 4){
-            if(HasZeroPointB){
+            if(ZeroMode){
                 MlasSveStoreInt32(pg_b32_4, C_ptr, MlasSveReinterpretS32FromU32(acc03));
         
                 MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C_ptr + 4, MlasSveReinterpretS32FromU32(acc47));
@@ -164,7 +165,7 @@ MLAS_FORCEINLINE size_t Process1Row(
             }
         }
         else{
-            if(HasZeroPointB){
+            if(ZeroMode){
                 MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C_ptr, MlasSveReinterpretS32FromU32(acc03));
             }
             else{
@@ -189,7 +190,7 @@ MLAS_FORCEINLINE size_t Process1Row(
     return 1;
 }
 
-template<bool HasZeroPointB>
+template<bool ZeroMode>
 MLAS_FORCEINLINE size_t Process2Rows(
     const uint8_t* A,
     const uint8_t* B,
@@ -296,7 +297,7 @@ MLAS_FORCEINLINE size_t Process2Rows(
         // First 4 columns
         // 
         if(cols_this > 4){
-            if(HasZeroPointB){
+            if(ZeroMode){
                 MlasSveStoreInt32(pg_b32_4, C0, MlasSveReinterpretS32FromU32(acc03_c0));
                 MlasSveStoreInt32(pg_b32_4, C1, MlasSveReinterpretS32FromU32(acc03_c1));
 
@@ -321,7 +322,7 @@ MLAS_FORCEINLINE size_t Process2Rows(
             }
         }
         else{
-            if(HasZeroPointB){
+            if(ZeroMode){
                 MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C0, MlasSveReinterpretS32FromU32(acc03_c0));
                 MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C1, MlasSveReinterpretS32FromU32(acc03_c1));
             }
@@ -351,7 +352,7 @@ MLAS_FORCEINLINE size_t Process2Rows(
     return 2;
 }
 
-template<bool HasZeroPointB>
+template<bool ZeroMode>
 MLAS_FORCEINLINE size_t Process4Rows(
     const uint8_t* A,
     const uint8_t* B,
@@ -474,7 +475,7 @@ MLAS_FORCEINLINE size_t Process4Rows(
         // First 4 columns
         // 
         if(cols_this > 4){
-            if(HasZeroPointB){
+            if(ZeroMode){
                 MlasSveStoreInt32(pg_b32_4, C0, MlasSveReinterpretS32FromU32(acc03_c0));
                 MlasSveStoreInt32(pg_b32_4, C1, MlasSveReinterpretS32FromU32(acc03_c1));
                 MlasSveStoreInt32(pg_b32_4, C2, MlasSveReinterpretS32FromU32(acc03_c2));
@@ -515,7 +516,7 @@ MLAS_FORCEINLINE size_t Process4Rows(
             }
         }
         else{
-            if(HasZeroPointB){
+            if(ZeroMode){
                 MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C0, MlasSveReinterpretS32FromU32(acc03_c0));
                 MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C1, MlasSveReinterpretS32FromU32(acc03_c1));
                 MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C2, MlasSveReinterpretS32FromU32(acc03_c2));
@@ -555,7 +556,7 @@ MLAS_FORCEINLINE size_t Process4Rows(
     return 4;
 }
 
-template<bool HasZeroPointB>
+template<bool ZeroMode>
 MLAS_FORCEINLINE size_t Process8Rows(
     const uint8_t* A,
     const uint8_t* B,
@@ -705,7 +706,7 @@ MLAS_FORCEINLINE size_t Process8Rows(
         // First 4 columns
         // 
         if(cols_this > 4){
-            if(HasZeroPointB){
+            if(ZeroMode){
                 MlasSveStoreInt32(pg_b32_4, C0, MlasSveReinterpretS32FromU32(acc03_c0));
                 MlasSveStoreInt32(pg_b32_4, C1, MlasSveReinterpretS32FromU32(acc03_c1));
                 MlasSveStoreInt32(pg_b32_4, C2, MlasSveReinterpretS32FromU32(acc03_c2));
@@ -779,7 +780,7 @@ MLAS_FORCEINLINE size_t Process8Rows(
             }
         }
         else{
-            if(HasZeroPointB){
+            if(ZeroMode){
                 MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C0, MlasSveReinterpretS32FromU32(acc03_c0));
                 MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C1, MlasSveReinterpretS32FromU32(acc03_c1));
                 MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C2, MlasSveReinterpretS32FromU32(acc03_c2));
@@ -839,7 +840,7 @@ MLAS_FORCEINLINE size_t Process8Rows(
     return 8;
 }
 
-template<bool HasZeroPointB>
+template<bool ZeroMode>
 MLAS_FORCEINLINE size_t
 MlasSveQgemmU8X8KernelUmmlaImpl(
     const MLAS_GEMM_U8X8_KERNEL_UMMLA::PackedAType* A,
@@ -856,32 +857,32 @@ MlasSveQgemmU8X8KernelUmmlaImpl(
     if (svcntb() == 32) {
 
         if (CountM >= 8) {
-            return Process8Rows<HasZeroPointB>(
+            return Process8Rows<ZeroMode>(
                 A, B, C, PackedCountK, CountM, CountN, ldc,
                 RowSumBuffer, ColumnSumBuffer,
                 ZeroPointB);
         }
         else if (CountM >= 4) {
-            return Process4Rows<HasZeroPointB>(
+            return Process4Rows<ZeroMode>(
                 A, B, C, PackedCountK, CountM, CountN, ldc,
                 RowSumBuffer, ColumnSumBuffer,
                 ZeroPointB);
         }
         else if (CountM >= 2) {
-            return Process2Rows<HasZeroPointB>(
+            return Process2Rows<ZeroMode>(
                 A, B, C, PackedCountK, CountM, CountN, ldc,
                 RowSumBuffer, ColumnSumBuffer,
                 ZeroPointB);
         }
         else if (CountM >= 1) {
-            return Process1Row<HasZeroPointB>(
+            return Process1Row<ZeroMode>(
                 A, B, C, PackedCountK, CountM, CountN, ldc,
                 RowSumBuffer, ColumnSumBuffer,
                 ZeroPointB);
         }
     }
     else {
-        if constexpr (HasZeroPointB) {
+        if constexpr (ZeroMode) {
             return MlasGemmU8X8KernelUmmlaZero(
                 A, B, C, PackedCountK, CountM, CountN, ldc,
                 RowSumBuffer, ColumnSumBuffer, ZeroPointB);

--- a/onnxruntime/core/mlas/lib/sve/qgemm_sve256.cpp
+++ b/onnxruntime/core/mlas/lib/sve/qgemm_sve256.cpp
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "mlasi_sve.h"
+#include "mlasi_sve_i8.h"
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
@@ -62,13 +63,13 @@ size_t Process1RowTest256(
     //------------------------------------------------------------------
     // VL = 256 → int32 lanes = 8 → process columns in groups of 4
     //------------------------------------------------------------------
-    svbool_t pg_b32_4 = svwhilelt_b32(0, 4);  // stores 4 output columns
-    svbool_t pg_b32_8 = svptrue_b32();  // full accumulator lanes
-    svbool_t pg_b8_32 = svptrue_b8(); // loads 32 bytes from A/B
+    svbool_t pg_b32_4 = MlasSveWhileLtB32(0, 4);  // stores 4 output columns
+    svbool_t pg_b32_8 = MlasSvePtrueB32();  // full accumulator lanes
+    svbool_t pg_b8_32 = MlasSvePtrueB8(); // loads 32 bytes from A/B
     svuint32_t acc03, acc47;
 
     const int32_t rowsum = RowSumBuffer[0];
-    const svint32_t rowSumVec = svdup_s32(rowsum);
+    const svint32_t rowSumVec = MlasSveBroadcastInt32(rowsum);
 
     const uint8_t* A_ptr;
     int32_t* C_ptr = C;
@@ -87,38 +88,38 @@ size_t Process1RowTest256(
         // Create ZPB and ColumnSum interleaved groups:
         //   VL=256: 8 lanes → represent 4 output columns at once
         //------------------------------------------------------------------
-        // svint32_t acc00 = svdup_s32(0); // for columns 0–3
-        // svint32_t acc01 = svdup_s32(0); // for columns 4–7
+        // svint32_t acc00 = MlasSveBroadcastInt32(0); // for columns 0–3
+        // svint32_t acc01 = MlasSveBroadcastInt32(0); // for columns 4–7
 
         svint32_t zpb_0_3, col_0_3, zpb_4_7, col_4_7;
         svint64_t zpb64_0_3, col64_0_3, zpb64_4_7, col64_4_7;
         // --- Columns 0–3 ---
         if (ZeroPointB){
-            zpb_0_3 = svld1_s32(pg_b32_4, ZeroPointB); //pg_b32_4
-            zpb64_0_3 = svreinterpret_s64_s32(zpb_0_3);
-            zpb_0_3 = svreinterpret_s32_s64(svzip1_s64(zpb64_0_3, zpb64_0_3));
+            zpb_0_3 = MlasSveLoadInt32(pg_b32_4, ZeroPointB); //pg_b32_4
+            zpb64_0_3 = MlasSveReinterpretS64FromS32(zpb_0_3);
+            zpb_0_3 = MlasSveReinterpretS32FromS64(MlasSveZip1S64(zpb64_0_3, zpb64_0_3));
         }
         else
-            zpb_0_3 = svdup_s32(1);
-        col_0_3 = svld1_s32(pg_b32_4, ColumnSumBuffer);
-        col64_0_3 = svreinterpret_s64_s32(col_0_3);
-        col_0_3 = svreinterpret_s32_s64(svzip1_s64(col64_0_3, col64_0_3));
-        acc03 = svreinterpret_u32_s32(svadd_s32_x(pg_b32_8, svmul_s32_x(pg_b32_8, rowSumVec, zpb_0_3), col_0_3));
+            zpb_0_3 = MlasSveBroadcastInt32(1);
+        col_0_3 = MlasSveLoadInt32(pg_b32_4, ColumnSumBuffer);
+        col64_0_3 = MlasSveReinterpretS64FromS32(col_0_3);
+        col_0_3 = MlasSveReinterpretS32FromS64(MlasSveZip1S64(col64_0_3, col64_0_3));
+        acc03 = MlasSveReinterpretU32FromS32(MlasSveAddInt32X(pg_b32_8, MlasSveMulInt32(pg_b32_8, rowSumVec, zpb_0_3), col_0_3));
         // --- Columns 4–7 ---
         if (cols_this > 4) {
             if (ZeroPointB){
-                zpb_4_7 = svld1_s32(pg_b32_4, ZeroPointB + 4);
-                zpb64_4_7 = svreinterpret_s64_s32(zpb_4_7);
-                zpb_4_7 = svreinterpret_s32_s64(svzip1_s64(zpb64_4_7, zpb64_4_7));
+                zpb_4_7 = MlasSveLoadInt32(pg_b32_4, ZeroPointB + 4);
+                zpb64_4_7 = MlasSveReinterpretS64FromS32(zpb_4_7);
+                zpb_4_7 = MlasSveReinterpretS32FromS64(MlasSveZip1S64(zpb64_4_7, zpb64_4_7));
             }
             else{
-                zpb_4_7 = svdup_s32(1);
+                zpb_4_7 = MlasSveBroadcastInt32(1);
             }
-            col_4_7 = svld1_s32(pg_b32_4, ColumnSumBuffer + 4);
-            col64_4_7 = svreinterpret_s64_s32(col_4_7);
-            col_4_7 = svreinterpret_s32_s64(svzip1_s64(col64_4_7, col64_4_7));
-            // acc47 = svreinterpret_u32_s32(svmad_s32_x(pg_b32_4, rowSumVec, zpb_4_7, col_4_7));
-            acc47 = svreinterpret_u32_s32(svadd_s32_x(pg_b32_8, svmul_s32_x(pg_b32_8, rowSumVec, zpb_4_7), col_4_7));
+            col_4_7 = MlasSveLoadInt32(pg_b32_4, ColumnSumBuffer + 4);
+            col64_4_7 = MlasSveReinterpretS64FromS32(col_4_7);
+            col_4_7 = MlasSveReinterpretS32FromS64(MlasSveZip1S64(col64_4_7, col64_4_7));
+            // acc47 = MlasSveReinterpretU32FromS32(svmad_s32_x(pg_b32_4, rowSumVec, zpb_4_7, col_4_7));
+            acc47 = MlasSveReinterpretU32FromS32(MlasSveAddInt32X(pg_b32_8, MlasSveMulInt32(pg_b32_8, rowSumVec, zpb_4_7), col_4_7));
         }
         //------------------------------------------------------------------
         // K loop
@@ -128,13 +129,13 @@ size_t Process1RowTest256(
         for (size_t k = 0; k < PackedCountK; k++)
         {
             // A: 32 bytes, B: 32 bytes per 4 columns
-            svuint8_t a  = svld1rq_u8(pg_b8_32, A_ptr); //load and replicate
-            svuint8_t b0 = svld1_u8(pg_b8_32, B);
-            svuint8_t b1 = svld1_u8(pg_b8_32, B + 32);
+            svuint8_t a  = MlasSveLoadReplicateU8(pg_b8_32, A_ptr); //load and replicate
+            svuint8_t b0 = MlasSveLoadU8(pg_b8_32, B);
+            svuint8_t b1 = MlasSveLoadU8(pg_b8_32, B + 32);
 
-            acc03 = svmmla_u32(acc03, a, b0);
+            acc03 = MlasSveMatMulAddU32(acc03, a, b0);
             if (cols_this > 4)
-                acc47 = svmmla_u32(acc47, a, b1);
+                acc47 = MlasSveMatMulAddU32(acc47, a, b1);
 
             A_ptr += 8;   // Each tile is 32 bytes for 256-bit
             B += 64;     // Two × 32-byte blocks per 8 columns
@@ -143,101 +144,101 @@ size_t Process1RowTest256(
         //------------------------------------------------------------------
         // Store results into C
         //------------------------------------------------------------------
-        const svuint32_t idx = svdupq_n_u32(0, 1, 4, 5);
-        acc03 = svtbl_u32(acc03, idx);
+        const svuint32_t idx = MlasSveDupqU32(0, 1, 4, 5);
+        acc03 = MlasSveTblU32(acc03, idx);
         if (cols_this > 4)
-            acc47 = svtbl_u32(acc47, idx);
+            acc47 = MlasSveTblU32(acc47, idx);
         // First 4 columns
         // 
         if(cols_this > 6){
             if(isZeroPointB){
-                svst1_s32(pg_b32_4, C_ptr, svreinterpret_s32_u32(acc03));
+                MlasSveStoreInt32(pg_b32_4, C_ptr, MlasSveReinterpretS32FromU32(acc03));
                 if(cols_this >= 8){
-                    svst1_s32(pg_b32_4, C_ptr + 4, svreinterpret_s32_u32(acc47));
+                    MlasSveStoreInt32(pg_b32_4, C_ptr + 4, MlasSveReinterpretS32FromU32(acc47));
                 }
                 else{
-                    svst1_s32(svwhilelt_b32(0,3), C_ptr + 4, svreinterpret_s32_u32(acc47));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C_ptr + 4, MlasSveReinterpretS32FromU32(acc47));
                 }            
             }
             else{
                 // Row 0 (C0)
-                svint32_t prev = svld1_s32(pg_b32_4, C_ptr);
-                svint32_t sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03));
-                svst1_s32(pg_b32_4, C_ptr, sum);
+                svint32_t prev = MlasSveLoadInt32(pg_b32_4, C_ptr);
+                svint32_t sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03));
+                MlasSveStoreInt32(pg_b32_4, C_ptr, sum);
 
                 // Row 1 (C1)
                 if(cols_this >= 8){
-                    prev = svld1_s32(pg_b32_4, C_ptr + 4);
-                    sum  = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc47));
-                    svst1_s32(pg_b32_4, C_ptr + 4, sum);
+                    prev = MlasSveLoadInt32(pg_b32_4, C_ptr + 4);
+                    sum  = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc47));
+                    MlasSveStoreInt32(pg_b32_4, C_ptr + 4, sum);
                 }
                 else{
-                    prev = svld1_s32(svwhilelt_b32(0,3), C_ptr + 4);
-                    sum  = svadd_s32_x(svwhilelt_b32(0,3), prev, svreinterpret_s32_u32(acc47));
-                    svst1_s32(svwhilelt_b32(0,3), C_ptr + 4, sum);
+                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 3), C_ptr + 4);
+                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 3), prev, MlasSveReinterpretS32FromU32(acc47));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C_ptr + 4, sum);
                 }
             }
         }
         else if(cols_this > 4){
             if(isZeroPointB){
-                svst1_s32(pg_b32_4, C_ptr, svreinterpret_s32_u32(acc03));
+                MlasSveStoreInt32(pg_b32_4, C_ptr, MlasSveReinterpretS32FromU32(acc03));
                 if(cols_this >= 6){
-                    svst1_s32(svwhilelt_b32(0, 2), C_ptr + 4, svreinterpret_s32_u32(acc47));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 2), C_ptr + 4, MlasSveReinterpretS32FromU32(acc47));
                 }
                 else{
-                    svst1_s32(svwhilelt_b32(0, 1), C_ptr + 4, svreinterpret_s32_u32(acc47));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 1), C_ptr + 4, MlasSveReinterpretS32FromU32(acc47));
                 }
             }
             else{
                 // Row 0 (C0)
-                svint32_t prev = svld1_s32(pg_b32_4, C_ptr);
-                svint32_t sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03));
-                svst1_s32(pg_b32_4, C_ptr, sum);
+                svint32_t prev = MlasSveLoadInt32(pg_b32_4, C_ptr);
+                svint32_t sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03));
+                MlasSveStoreInt32(pg_b32_4, C_ptr, sum);
                 if(cols_this >= 6){
-                    prev = svld1_s32(svwhilelt_b32(0, 2), C_ptr + 4);
-                    sum  = svadd_s32_x(svwhilelt_b32(0, 2), prev, svreinterpret_s32_u32(acc47));
-                    svst1_s32(svwhilelt_b32(0, 2), C_ptr + 4, sum);
+                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 2), C_ptr + 4);
+                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 2), prev, MlasSveReinterpretS32FromU32(acc47));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 2), C_ptr + 4, sum);
                 }
                 else{
-                    prev = svld1_s32(svwhilelt_b32(0, 1), C_ptr + 4);
-                    sum  = svadd_s32_x(svwhilelt_b32(0, 1), prev, svreinterpret_s32_u32(acc47));
-                    svst1_s32(svwhilelt_b32(0, 1), C_ptr + 4, sum);
+                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 1), C_ptr + 4);
+                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 1), prev, MlasSveReinterpretS32FromU32(acc47));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 1), C_ptr + 4, sum);
                 }
             }
         }
         else if(cols_this > 2){
             if(isZeroPointB){
                 if(cols_this >= 4){
-                    svst1_s32(pg_b32_4, C_ptr, svreinterpret_s32_u32(acc03));
+                    MlasSveStoreInt32(pg_b32_4, C_ptr, MlasSveReinterpretS32FromU32(acc03));
                 }
                 else{
-                    svst1_s32(svwhilelt_b32(0,3), C_ptr, svreinterpret_s32_u32(acc03));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C_ptr, MlasSveReinterpretS32FromU32(acc03));
                 }
             }
             else{
                 if(cols_this >= 4){
                     // Row 0 (C0)
-                    svint32_t prev = svld1_s32(pg_b32_4, C_ptr);
-                    svint32_t sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03));
-                    svst1_s32(pg_b32_4, C_ptr, sum);
+                    svint32_t prev = MlasSveLoadInt32(pg_b32_4, C_ptr);
+                    svint32_t sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03));
+                    MlasSveStoreInt32(pg_b32_4, C_ptr, sum);
                 }
                 else{
                     // Row 0 (C0)
-                    svint32_t prev = svld1_s32(svwhilelt_b32(0,3), C_ptr);
-                    svint32_t sum = svadd_s32_x(svwhilelt_b32(0,3), prev, svreinterpret_s32_u32(acc03));
-                    svst1_s32(svwhilelt_b32(0,3), C_ptr, sum);
+                    svint32_t prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 3), C_ptr);
+                    svint32_t sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, 3), prev, MlasSveReinterpretS32FromU32(acc03));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C_ptr, sum);
                 }   
             }
         }
         else{
             if(isZeroPointB){
-                svst1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C_ptr, svreinterpret_s32_u32(acc03));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C_ptr, MlasSveReinterpretS32FromU32(acc03));
             }
             else{
                 // Row 0 (C0)
-                svint32_t prev = svld1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C_ptr);
-                svint32_t sum = svadd_s32_x(svwhilelt_b32(0, std::min(int(cols_this), 2)), prev, svreinterpret_s32_u32(acc03));
-                svst1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C_ptr, sum);
+                svint32_t prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C_ptr);
+                svint32_t sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), prev, MlasSveReinterpretS32FromU32(acc03));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C_ptr, sum);
             }
         }
         // Last 4 columns
@@ -273,16 +274,16 @@ size_t Process2RowsTest256(
     //------------------------------------------------------------------
     // VL = 256 → int32 lanes = 8 → process columns in groups of 4
     //------------------------------------------------------------------
-    svbool_t pg_b32_4 = svwhilelt_b32(0, 4);  // stores 4 output columns
-    svbool_t pg_b32_8 = svptrue_b32();  // full accumulator lanes
-    svbool_t pg_b8_32 = svptrue_b8(); // loads 32 bytes from A/B
+    svbool_t pg_b32_4 = MlasSveWhileLtB32(0, 4);  // stores 4 output columns
+    svbool_t pg_b32_8 = MlasSvePtrueB32();  // full accumulator lanes
+    svbool_t pg_b8_32 = MlasSvePtrueB8(); // loads 32 bytes from A/B
     svuint32_t acc03, acc47;
 
     // const int32_t rowsum = RowSumBuffer[0];
     svint32_t rowSumVec, r0, r1;
-    r0 = svdup_s32(RowSumBuffer[0]);
-    r1 = svdup_s32(RowSumBuffer[1]);
-    rowSumVec = svreinterpret_s32_s64(svtrn1_s64(svreinterpret_s64_s32(r0), svreinterpret_s64_s32(r1)));
+    r0 = MlasSveBroadcastInt32(RowSumBuffer[0]);
+    r1 = MlasSveBroadcastInt32(RowSumBuffer[1]);
+    rowSumVec = MlasSveReinterpretS32FromS64(MlasSveTrn1S64(MlasSveReinterpretS64FromS32(r0), MlasSveReinterpretS64FromS32(r1)));
     const uint8_t* A_ptr;
     int32_t *C0, *C1;
     C0 = C;
@@ -302,32 +303,32 @@ size_t Process2RowsTest256(
         svint64_t zpb64_0_3, col64_0_3, zpb64_4_7, col64_4_7;
         // --- Columns 0–3 ---
         if (ZeroPointB){
-            zpb_0_3 = svld1_s32(pg_b32_4, ZeroPointB); //pg_b32_4
-            zpb64_0_3 = svreinterpret_s64_s32(zpb_0_3);
-            zpb_0_3 = svreinterpret_s32_s64(svzip1_s64(zpb64_0_3, zpb64_0_3));
+            zpb_0_3 = MlasSveLoadInt32(pg_b32_4, ZeroPointB); //pg_b32_4
+            zpb64_0_3 = MlasSveReinterpretS64FromS32(zpb_0_3);
+            zpb_0_3 = MlasSveReinterpretS32FromS64(MlasSveZip1S64(zpb64_0_3, zpb64_0_3));
         }
         else
-            zpb_0_3 = svdup_s32(1);
+            zpb_0_3 = MlasSveBroadcastInt32(1);
 
-        col_0_3 = svld1_s32(pg_b32_4, ColumnSumBuffer);
-        col64_0_3 = svreinterpret_s64_s32(col_0_3);
-        col_0_3 = svreinterpret_s32_s64(svzip1_s64(col64_0_3, col64_0_3));
-        acc03 = svreinterpret_u32_s32(svadd_s32_x(pg_b32_8, svmul_s32_x(pg_b32_8, rowSumVec, zpb_0_3), col_0_3));
+        col_0_3 = MlasSveLoadInt32(pg_b32_4, ColumnSumBuffer);
+        col64_0_3 = MlasSveReinterpretS64FromS32(col_0_3);
+        col_0_3 = MlasSveReinterpretS32FromS64(MlasSveZip1S64(col64_0_3, col64_0_3));
+        acc03 = MlasSveReinterpretU32FromS32(MlasSveAddInt32X(pg_b32_8, MlasSveMulInt32(pg_b32_8, rowSumVec, zpb_0_3), col_0_3));
         // --- Columns 4–7 ---
         if (cols_this > 4) {
             if (ZeroPointB){
-                zpb_4_7 = svld1_s32(pg_b32_4, ZeroPointB + 4);
-                zpb64_4_7 = svreinterpret_s64_s32(zpb_4_7);
-                zpb_4_7 = svreinterpret_s32_s64(svzip1_s64(zpb64_4_7, zpb64_4_7));
+                zpb_4_7 = MlasSveLoadInt32(pg_b32_4, ZeroPointB + 4);
+                zpb64_4_7 = MlasSveReinterpretS64FromS32(zpb_4_7);
+                zpb_4_7 = MlasSveReinterpretS32FromS64(MlasSveZip1S64(zpb64_4_7, zpb64_4_7));
             }
             else{
-                zpb_4_7 = svdup_s32(1);
+                zpb_4_7 = MlasSveBroadcastInt32(1);
             }
-            col_4_7 = svld1_s32(pg_b32_4, ColumnSumBuffer + 4);
-            col64_4_7 = svreinterpret_s64_s32(col_4_7);
-            col_4_7 = svreinterpret_s32_s64(svzip1_s64(col64_4_7, col64_4_7));
-            // acc47 = svreinterpret_u32_s32(svmad_s32_x(pg_b32_4, rowSumVec, zpb_4_7, col_4_7));
-            acc47 = svreinterpret_u32_s32(svadd_s32_x(pg_b32_8, svmul_s32_x(pg_b32_8, rowSumVec, zpb_4_7), col_4_7));
+            col_4_7 = MlasSveLoadInt32(pg_b32_4, ColumnSumBuffer + 4);
+            col64_4_7 = MlasSveReinterpretS64FromS32(col_4_7);
+            col_4_7 = MlasSveReinterpretS32FromS64(MlasSveZip1S64(col64_4_7, col64_4_7));
+            // acc47 = MlasSveReinterpretU32FromS32(svmad_s32_x(pg_b32_4, rowSumVec, zpb_4_7, col_4_7));
+            acc47 = MlasSveReinterpretU32FromS32(MlasSveAddInt32X(pg_b32_8, MlasSveMulInt32(pg_b32_8, rowSumVec, zpb_4_7), col_4_7));
         }
         //------------------------------------------------------------------
         // K loop
@@ -337,13 +338,13 @@ size_t Process2RowsTest256(
         for (size_t k = 0; k < PackedCountK; k++)
         {
             // A: 32 bytes, B: 32 bytes per 4 columns
-            svuint8_t a  = svld1rq_u8(pg_b8_32, A_ptr); //load and replicate
-            svuint8_t b0 = svld1_u8(pg_b8_32, B);
-            svuint8_t b1 = svld1_u8(pg_b8_32, B + 32);
+            svuint8_t a  = MlasSveLoadReplicateU8(pg_b8_32, A_ptr); //load and replicate
+            svuint8_t b0 = MlasSveLoadU8(pg_b8_32, B);
+            svuint8_t b1 = MlasSveLoadU8(pg_b8_32, B + 32);
 
-            acc03 = svmmla_u32(acc03, a, b0);
+            acc03 = MlasSveMatMulAddU32(acc03, a, b0);
             if (cols_this > 4)
-                acc47 = svmmla_u32(acc47, a, b1); 
+                acc47 = MlasSveMatMulAddU32(acc47, a, b1); 
 
             A_ptr += 16;   // Each tile is 32 bytes for 256-bit
             B += 64;     // Two × 32-byte blocks per 8 columns
@@ -352,141 +353,141 @@ size_t Process2RowsTest256(
         //------------------------------------------------------------------
         // Store results into C
         //------------------------------------------------------------------
-        const svuint32_t idx1 = svdupq_n_u32(0, 1, 4, 5);
-        const svuint32_t idx2 = svdupq_n_u32(2, 3, 6, 7);
+        const svuint32_t idx1 = MlasSveDupqU32(0, 1, 4, 5);
+        const svuint32_t idx2 = MlasSveDupqU32(2, 3, 6, 7);
         svuint32_t acc03_c0, acc03_c1, acc47_c0, acc47_c1;
-        acc03_c0 = svtbl_u32(acc03, idx1);
-        acc03_c1 = svtbl_u32(acc03, idx2);
+        acc03_c0 = MlasSveTblU32(acc03, idx1);
+        acc03_c1 = MlasSveTblU32(acc03, idx2);
         if (cols_this > 4){
-            acc47_c0 = svtbl_u32(acc47, idx1);
-            acc47_c1 = svtbl_u32(acc47, idx2);
+            acc47_c0 = MlasSveTblU32(acc47, idx1);
+            acc47_c1 = MlasSveTblU32(acc47, idx2);
         }
         // First 4 columns
         // 
         if(cols_this > 6){
             if(isZeroPointB){
-                svst1_s32(pg_b32_4, C0, svreinterpret_s32_u32(acc03_c0));
-                svst1_s32(pg_b32_4, C1, svreinterpret_s32_u32(acc03_c1));
+                MlasSveStoreInt32(pg_b32_4, C0, MlasSveReinterpretS32FromU32(acc03_c0));
+                MlasSveStoreInt32(pg_b32_4, C1, MlasSveReinterpretS32FromU32(acc03_c1));
                 if(cols_this >= 8){
-                    svst1_s32(pg_b32_4, C0 + 4, svreinterpret_s32_u32(acc47_c0));
-                    svst1_s32(pg_b32_4, C1 + 4, svreinterpret_s32_u32(acc47_c1));
+                    MlasSveStoreInt32(pg_b32_4, C0 + 4, MlasSveReinterpretS32FromU32(acc47_c0));
+                    MlasSveStoreInt32(pg_b32_4, C1 + 4, MlasSveReinterpretS32FromU32(acc47_c1));
                 }
                 else{
-                    svst1_s32(svwhilelt_b32(0,3), C0 + 4, svreinterpret_s32_u32(acc47_c0));
-                    svst1_s32(svwhilelt_b32(0,3), C1 + 4, svreinterpret_s32_u32(acc47_c1));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C0 + 4, MlasSveReinterpretS32FromU32(acc47_c0));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C1 + 4, MlasSveReinterpretS32FromU32(acc47_c1));
                 }            
             }
             else{
                 // Row 0 (C0)
-                svint32_t prev = svld1_s32(pg_b32_4, C0);
-                svint32_t sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c0));
-                svst1_s32(pg_b32_4, C0, sum);
-                prev = svld1_s32(pg_b32_4, C1);
-                sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c1));
-                svst1_s32(pg_b32_4, C1, sum);
+                svint32_t prev = MlasSveLoadInt32(pg_b32_4, C0);
+                svint32_t sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c0));
+                MlasSveStoreInt32(pg_b32_4, C0, sum);
+                prev = MlasSveLoadInt32(pg_b32_4, C1);
+                sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c1));
+                MlasSveStoreInt32(pg_b32_4, C1, sum);
                 // Row 1 (C1)
                 if(cols_this >= 8){
-                    prev = svld1_s32(pg_b32_4, C0 + 4);
-                    sum  = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc47_c0));
-                    svst1_s32(pg_b32_4, C0 + 4, sum);
-                    prev = svld1_s32(pg_b32_4, C1 + 4);
-                    sum  = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc47_c1));
-                    svst1_s32(pg_b32_4, C1 + 4, sum);
+                    prev = MlasSveLoadInt32(pg_b32_4, C0 + 4);
+                    sum  = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc47_c0));
+                    MlasSveStoreInt32(pg_b32_4, C0 + 4, sum);
+                    prev = MlasSveLoadInt32(pg_b32_4, C1 + 4);
+                    sum  = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc47_c1));
+                    MlasSveStoreInt32(pg_b32_4, C1 + 4, sum);
                 }
                 else{
-                    prev = svld1_s32(svwhilelt_b32(0,3), C0 + 4);
-                    sum  = svadd_s32_x(svwhilelt_b32(0,3), prev, svreinterpret_s32_u32(acc47_c0));
-                    svst1_s32(svwhilelt_b32(0,3), C0 + 4, sum);
-                    prev = svld1_s32(svwhilelt_b32(0,3), C1 + 4);
-                    sum  = svadd_s32_x(svwhilelt_b32(0,3), prev, svreinterpret_s32_u32(acc47_c1));
-                    svst1_s32(svwhilelt_b32(0,3), C1 + 4, sum);
+                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 3), C0 + 4);
+                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 3), prev, MlasSveReinterpretS32FromU32(acc47_c0));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C0 + 4, sum);
+                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 3), C1 + 4);
+                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 3), prev, MlasSveReinterpretS32FromU32(acc47_c1));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C1 + 4, sum);
                 }
             }
         }
         else if(cols_this > 4){
             if(isZeroPointB){
-                svst1_s32(pg_b32_4, C0, svreinterpret_s32_u32(acc03_c0));
-                svst1_s32(pg_b32_4, C1, svreinterpret_s32_u32(acc03_c1));
+                MlasSveStoreInt32(pg_b32_4, C0, MlasSveReinterpretS32FromU32(acc03_c0));
+                MlasSveStoreInt32(pg_b32_4, C1, MlasSveReinterpretS32FromU32(acc03_c1));
                 if(cols_this >= 6){
-                    svst1_s32(svwhilelt_b32(0, 2), C0 + 4, svreinterpret_s32_u32(acc47_c0));
-                    svst1_s32(svwhilelt_b32(0, 2), C1 + 4, svreinterpret_s32_u32(acc47_c1));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 2), C0 + 4, MlasSveReinterpretS32FromU32(acc47_c0));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 2), C1 + 4, MlasSveReinterpretS32FromU32(acc47_c1));
                 }
                 else{
-                    svst1_s32(svwhilelt_b32(0, 1), C0 + 4, svreinterpret_s32_u32(acc47_c0));
-                    svst1_s32(svwhilelt_b32(0, 1), C1 + 4, svreinterpret_s32_u32(acc47_c1));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 1), C0 + 4, MlasSveReinterpretS32FromU32(acc47_c0));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 1), C1 + 4, MlasSveReinterpretS32FromU32(acc47_c1));
                 }
             }
             else{
                 // Row 0 (C0)
-                svint32_t prev = svld1_s32(pg_b32_4, C0);
-                svint32_t sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c0));
-                svst1_s32(pg_b32_4, C0, sum);
-                prev = svld1_s32(pg_b32_4, C1);
-                sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c1));
-                svst1_s32(pg_b32_4, C1, sum);
+                svint32_t prev = MlasSveLoadInt32(pg_b32_4, C0);
+                svint32_t sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c0));
+                MlasSveStoreInt32(pg_b32_4, C0, sum);
+                prev = MlasSveLoadInt32(pg_b32_4, C1);
+                sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c1));
+                MlasSveStoreInt32(pg_b32_4, C1, sum);
                 if(cols_this >= 6){
-                    prev = svld1_s32(svwhilelt_b32(0, 2), C0 + 4);
-                    sum  = svadd_s32_x(svwhilelt_b32(0, 2), prev, svreinterpret_s32_u32(acc47_c0));
-                    svst1_s32(svwhilelt_b32(0, 2), C0 + 4, sum);
-                    prev = svld1_s32(svwhilelt_b32(0, 2), C1 + 4);
-                    sum  = svadd_s32_x(svwhilelt_b32(0, 2), prev, svreinterpret_s32_u32(acc47_c1));
-                    svst1_s32(svwhilelt_b32(0, 2), C1 + 4, sum);
+                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 2), C0 + 4);
+                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 2), prev, MlasSveReinterpretS32FromU32(acc47_c0));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 2), C0 + 4, sum);
+                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 2), C1 + 4);
+                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 2), prev, MlasSveReinterpretS32FromU32(acc47_c1));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 2), C1 + 4, sum);
                 }
                 else{
-                    prev = svld1_s32(svwhilelt_b32(0, 1), C0 + 4);
-                    sum  = svadd_s32_x(svwhilelt_b32(0, 1), prev, svreinterpret_s32_u32(acc47_c0));
-                    svst1_s32(svwhilelt_b32(0, 1), C0 + 4, sum);
-                    prev = svld1_s32(svwhilelt_b32(0, 1), C1 + 4);
-                    sum  = svadd_s32_x(svwhilelt_b32(0, 1), prev, svreinterpret_s32_u32(acc47_c1));
-                    svst1_s32(svwhilelt_b32(0, 1), C1 + 4, sum);
+                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 1), C0 + 4);
+                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 1), prev, MlasSveReinterpretS32FromU32(acc47_c0));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 1), C0 + 4, sum);
+                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 1), C1 + 4);
+                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 1), prev, MlasSveReinterpretS32FromU32(acc47_c1));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 1), C1 + 4, sum);
                 }
             }
         }
         else if(cols_this > 2){
             if(isZeroPointB){
                 if(cols_this >= 4){
-                    svst1_s32(pg_b32_4, C0, svreinterpret_s32_u32(acc03_c0));
-                    svst1_s32(pg_b32_4, C1, svreinterpret_s32_u32(acc03_c1));
+                    MlasSveStoreInt32(pg_b32_4, C0, MlasSveReinterpretS32FromU32(acc03_c0));
+                    MlasSveStoreInt32(pg_b32_4, C1, MlasSveReinterpretS32FromU32(acc03_c1));
                 }
                 else{
-                    svst1_s32(svwhilelt_b32(0,3), C0, svreinterpret_s32_u32(acc03_c0));
-                    svst1_s32(svwhilelt_b32(0,3), C1, svreinterpret_s32_u32(acc03_c1));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C0, MlasSveReinterpretS32FromU32(acc03_c0));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C1, MlasSveReinterpretS32FromU32(acc03_c1));
                 }
             }
             else{
                 if(cols_this >= 4){
                     // Row 0 (C0)
-                    svint32_t prev = svld1_s32(pg_b32_4, C0);
-                    svint32_t sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c0));
-                    svst1_s32(pg_b32_4, C0, sum);
-                    prev = svld1_s32(pg_b32_4, C1);
-                    sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c1));
-                    svst1_s32(pg_b32_4, C1, sum);
+                    svint32_t prev = MlasSveLoadInt32(pg_b32_4, C0);
+                    svint32_t sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c0));
+                    MlasSveStoreInt32(pg_b32_4, C0, sum);
+                    prev = MlasSveLoadInt32(pg_b32_4, C1);
+                    sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c1));
+                    MlasSveStoreInt32(pg_b32_4, C1, sum);
                 }
                 else{
                     // Row 0 (C0)
-                    svint32_t prev = svld1_s32(svwhilelt_b32(0,3), C0);
-                    svint32_t sum = svadd_s32_x(svwhilelt_b32(0,3), prev, svreinterpret_s32_u32(acc03_c0));
-                    svst1_s32(svwhilelt_b32(0,3), C0, sum);
-                    prev = svld1_s32(svwhilelt_b32(0,3), C1);
-                    sum = svadd_s32_x(svwhilelt_b32(0,3), prev, svreinterpret_s32_u32(acc03_c1));
-                    svst1_s32(svwhilelt_b32(0,3), C1, sum);
+                    svint32_t prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 3), C0);
+                    svint32_t sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, 3), prev, MlasSveReinterpretS32FromU32(acc03_c0));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C0, sum);
+                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 3), C1);
+                    sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, 3), prev, MlasSveReinterpretS32FromU32(acc03_c1));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C1, sum);
                 }   
             }
         }
         else{
             if(isZeroPointB){
-                svst1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C0, svreinterpret_s32_u32(acc03_c0));
-                svst1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C1, svreinterpret_s32_u32(acc03_c1));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C0, MlasSveReinterpretS32FromU32(acc03_c0));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C1, MlasSveReinterpretS32FromU32(acc03_c1));
             }
             else{
                 // Row 0 (C0)
-                svint32_t prev = svld1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C0);
-                svint32_t sum = svadd_s32_x(svwhilelt_b32(0, std::min(int(cols_this), 2)), prev, svreinterpret_s32_u32(acc03_c0));
-                svst1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C0, sum);
-                prev = svld1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C1);
-                sum = svadd_s32_x(svwhilelt_b32(0, std::min(int(cols_this), 2)), prev, svreinterpret_s32_u32(acc03_c1));
-                svst1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C1, sum);
+                svint32_t prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C0);
+                svint32_t sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), prev, MlasSveReinterpretS32FromU32(acc03_c0));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C0, sum);
+                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C1);
+                sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), prev, MlasSveReinterpretS32FromU32(acc03_c1));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C1, sum);
             }
         }
         // Last 4 columns
@@ -523,19 +524,19 @@ size_t Process4RowsTest256(
     //------------------------------------------------------------------
     // VL = 256 → int32 lanes = 8 → process columns in groups of 4
     //------------------------------------------------------------------
-    svbool_t pg_b32_4 = svwhilelt_b32(0, 4);  // stores 4 output columns
-    svbool_t pg_b32_8 = svptrue_b32();  // full accumulator lanes
-    svbool_t pg_b8_32 = svptrue_b8(); // loads 32 bytes from A/B
+    svbool_t pg_b32_4 = MlasSveWhileLtB32(0, 4);  // stores 4 output columns
+    svbool_t pg_b32_8 = MlasSvePtrueB32();  // full accumulator lanes
+    svbool_t pg_b8_32 = MlasSvePtrueB8(); // loads 32 bytes from A/B
     svuint32_t acc03_0, acc03_1, acc47_0, acc47_1;
 
     // const int32_t rowsum = RowSumBuffer[0];
     svint32_t rowSumVec01, rowSumVec23, r0, r1, r2, r3;
-    r0 = svdup_s32(RowSumBuffer[0]);
-    r1 = svdup_s32(RowSumBuffer[1]);
-    rowSumVec01 = svreinterpret_s32_s64(svtrn1_s64(svreinterpret_s64_s32(r0), svreinterpret_s64_s32(r1)));
-    r2 = svdup_s32(RowSumBuffer[2]);
-    r3 = svdup_s32(RowSumBuffer[3]);
-    rowSumVec23 = svreinterpret_s32_s64(svtrn1_s64(svreinterpret_s64_s32(r2), svreinterpret_s64_s32(r3)));
+    r0 = MlasSveBroadcastInt32(RowSumBuffer[0]);
+    r1 = MlasSveBroadcastInt32(RowSumBuffer[1]);
+    rowSumVec01 = MlasSveReinterpretS32FromS64(MlasSveTrn1S64(MlasSveReinterpretS64FromS32(r0), MlasSveReinterpretS64FromS32(r1)));
+    r2 = MlasSveBroadcastInt32(RowSumBuffer[2]);
+    r3 = MlasSveBroadcastInt32(RowSumBuffer[3]);
+    rowSumVec23 = MlasSveReinterpretS32FromS64(MlasSveTrn1S64(MlasSveReinterpretS64FromS32(r2), MlasSveReinterpretS64FromS32(r3)));
     const uint8_t* A_ptr;
     int32_t *C0, *C1, *C2, *C3;
     C0 = C;
@@ -557,35 +558,35 @@ size_t Process4RowsTest256(
         svint64_t zpb64_0_3, col64_0_3, zpb64_4_7, col64_4_7;
         // --- Columns 0–3 ---
         if (ZeroPointB){
-            zpb_0_3 = svld1_s32(pg_b32_4, ZeroPointB); //pg_b32_4
-            zpb64_0_3 = svreinterpret_s64_s32(zpb_0_3);
-            zpb_0_3 = svreinterpret_s32_s64(svzip1_s64(zpb64_0_3, zpb64_0_3));
+            zpb_0_3 = MlasSveLoadInt32(pg_b32_4, ZeroPointB); //pg_b32_4
+            zpb64_0_3 = MlasSveReinterpretS64FromS32(zpb_0_3);
+            zpb_0_3 = MlasSveReinterpretS32FromS64(MlasSveZip1S64(zpb64_0_3, zpb64_0_3));
         }
         else
-            zpb_0_3 = svdup_s32(1);
-        col_0_3 = svld1_s32(pg_b32_4, ColumnSumBuffer);
-        col64_0_3 = svreinterpret_s64_s32(col_0_3);
-        col_0_3 = svreinterpret_s32_s64(svzip1_s64(col64_0_3, col64_0_3));
+            zpb_0_3 = MlasSveBroadcastInt32(1);
+        col_0_3 = MlasSveLoadInt32(pg_b32_4, ColumnSumBuffer);
+        col64_0_3 = MlasSveReinterpretS64FromS32(col_0_3);
+        col_0_3 = MlasSveReinterpretS32FromS64(MlasSveZip1S64(col64_0_3, col64_0_3));
 
-        acc03_0 = svreinterpret_u32_s32(svadd_s32_x(pg_b32_8, svmul_s32_x(pg_b32_8, rowSumVec01, zpb_0_3), col_0_3));
-        acc03_1 = svreinterpret_u32_s32(svadd_s32_x(pg_b32_8, svmul_s32_x(pg_b32_8, rowSumVec23, zpb_0_3), col_0_3));
+        acc03_0 = MlasSveReinterpretU32FromS32(MlasSveAddInt32X(pg_b32_8, MlasSveMulInt32(pg_b32_8, rowSumVec01, zpb_0_3), col_0_3));
+        acc03_1 = MlasSveReinterpretU32FromS32(MlasSveAddInt32X(pg_b32_8, MlasSveMulInt32(pg_b32_8, rowSumVec23, zpb_0_3), col_0_3));
 
         // --- Columns 4–7 ---
         if (cols_this > 4) {
             if (ZeroPointB){
-                zpb_4_7 = svld1_s32(pg_b32_4, ZeroPointB + 4);
-                zpb64_4_7 = svreinterpret_s64_s32(zpb_4_7);
-                zpb_4_7 = svreinterpret_s32_s64(svzip1_s64(zpb64_4_7, zpb64_4_7));
+                zpb_4_7 = MlasSveLoadInt32(pg_b32_4, ZeroPointB + 4);
+                zpb64_4_7 = MlasSveReinterpretS64FromS32(zpb_4_7);
+                zpb_4_7 = MlasSveReinterpretS32FromS64(MlasSveZip1S64(zpb64_4_7, zpb64_4_7));
             }
             else{
-                zpb_4_7 = svdup_s32(1);
+                zpb_4_7 = MlasSveBroadcastInt32(1);
             }
-            col_4_7 = svld1_s32(pg_b32_4, ColumnSumBuffer + 4);
-            col64_4_7 = svreinterpret_s64_s32(col_4_7);
-            col_4_7 = svreinterpret_s32_s64(svzip1_s64(col64_4_7, col64_4_7));
-            // acc47 = svreinterpret_u32_s32(svmad_s32_x(pg_b32_4, rowSumVec, zpb_4_7, col_4_7));
-            acc47_0 = svreinterpret_u32_s32(svadd_s32_x(pg_b32_8, svmul_s32_x(pg_b32_8, rowSumVec01, zpb_4_7), col_4_7));
-            acc47_1 = svreinterpret_u32_s32(svadd_s32_x(pg_b32_8, svmul_s32_x(pg_b32_8, rowSumVec23, zpb_4_7), col_4_7));
+            col_4_7 = MlasSveLoadInt32(pg_b32_4, ColumnSumBuffer + 4);
+            col64_4_7 = MlasSveReinterpretS64FromS32(col_4_7);
+            col_4_7 = MlasSveReinterpretS32FromS64(MlasSveZip1S64(col64_4_7, col64_4_7));
+            // acc47 = MlasSveReinterpretU32FromS32(svmad_s32_x(pg_b32_4, rowSumVec, zpb_4_7, col_4_7));
+            acc47_0 = MlasSveReinterpretU32FromS32(MlasSveAddInt32X(pg_b32_8, MlasSveMulInt32(pg_b32_8, rowSumVec01, zpb_4_7), col_4_7));
+            acc47_1 = MlasSveReinterpretU32FromS32(MlasSveAddInt32X(pg_b32_8, MlasSveMulInt32(pg_b32_8, rowSumVec23, zpb_4_7), col_4_7));
         }
         //------------------------------------------------------------------
         // K loop
@@ -595,16 +596,16 @@ size_t Process4RowsTest256(
         for (size_t k = 0; k < PackedCountK; k++)
         {
             // A: 32 bytes, B: 32 bytes per 4 columns
-            svuint8_t a0  = svld1rq_u8(pg_b8_32, A_ptr); //load and replicate
-            svuint8_t a1  = svld1rq_u8(pg_b8_32, A_ptr + 16); //load and replicate
-            svuint8_t b0 = svld1_u8(pg_b8_32, B);
-            svuint8_t b1 = svld1_u8(pg_b8_32, B + 32);
+            svuint8_t a0  = MlasSveLoadReplicateU8(pg_b8_32, A_ptr); //load and replicate
+            svuint8_t a1  = MlasSveLoadReplicateU8(pg_b8_32, A_ptr + 16); //load and replicate
+            svuint8_t b0 = MlasSveLoadU8(pg_b8_32, B);
+            svuint8_t b1 = MlasSveLoadU8(pg_b8_32, B + 32);
 
-            acc03_0 = svmmla_u32(acc03_0, a0, b0);
-            acc03_1 = svmmla_u32(acc03_1, a1, b0);
+            acc03_0 = MlasSveMatMulAddU32(acc03_0, a0, b0);
+            acc03_1 = MlasSveMatMulAddU32(acc03_1, a1, b0);
             if (cols_this > 4){
-                acc47_0 = svmmla_u32(acc47_0, a0, b1);
-                acc47_1 = svmmla_u32(acc47_1, a1, b1);
+                acc47_0 = MlasSveMatMulAddU32(acc47_0, a0, b1);
+                acc47_1 = MlasSveMatMulAddU32(acc47_1, a1, b1);
             }
 
             A_ptr += 32;   // Each tile is 32 bytes for 256-bit
@@ -614,217 +615,217 @@ size_t Process4RowsTest256(
         //------------------------------------------------------------------
         // Store results into C
         //------------------------------------------------------------------
-        const svuint32_t idx1 = svdupq_n_u32(0, 1, 4, 5);
-        const svuint32_t idx2 = svdupq_n_u32(2, 3, 6, 7);
+        const svuint32_t idx1 = MlasSveDupqU32(0, 1, 4, 5);
+        const svuint32_t idx2 = MlasSveDupqU32(2, 3, 6, 7);
         svuint32_t acc03_c0, acc03_c1, acc47_c0, acc47_c1, acc03_c2, acc03_c3, acc47_c2, acc47_c3;
-        acc03_c0 = svtbl_u32(acc03_0, idx1);
-        acc03_c1 = svtbl_u32(acc03_0, idx2);
-        acc03_c2 = svtbl_u32(acc03_1, idx1);
-        acc03_c3 = svtbl_u32(acc03_1, idx2);
+        acc03_c0 = MlasSveTblU32(acc03_0, idx1);
+        acc03_c1 = MlasSveTblU32(acc03_0, idx2);
+        acc03_c2 = MlasSveTblU32(acc03_1, idx1);
+        acc03_c3 = MlasSveTblU32(acc03_1, idx2);
         if (cols_this > 4){
-            acc47_c0 = svtbl_u32(acc47_0, idx1);
-            acc47_c1 = svtbl_u32(acc47_0, idx2);
-            acc47_c2 = svtbl_u32(acc47_1, idx1);
-            acc47_c3 = svtbl_u32(acc47_1, idx2);
+            acc47_c0 = MlasSveTblU32(acc47_0, idx1);
+            acc47_c1 = MlasSveTblU32(acc47_0, idx2);
+            acc47_c2 = MlasSveTblU32(acc47_1, idx1);
+            acc47_c3 = MlasSveTblU32(acc47_1, idx2);
         }
         // First 4 columns
         // 
         if(cols_this > 6){
             if(isZeroPointB){
-                svst1_s32(pg_b32_4, C0, svreinterpret_s32_u32(acc03_c0));
-                svst1_s32(pg_b32_4, C1, svreinterpret_s32_u32(acc03_c1));
-                svst1_s32(pg_b32_4, C2, svreinterpret_s32_u32(acc03_c2));
-                svst1_s32(pg_b32_4, C3, svreinterpret_s32_u32(acc03_c3));
+                MlasSveStoreInt32(pg_b32_4, C0, MlasSveReinterpretS32FromU32(acc03_c0));
+                MlasSveStoreInt32(pg_b32_4, C1, MlasSveReinterpretS32FromU32(acc03_c1));
+                MlasSveStoreInt32(pg_b32_4, C2, MlasSveReinterpretS32FromU32(acc03_c2));
+                MlasSveStoreInt32(pg_b32_4, C3, MlasSveReinterpretS32FromU32(acc03_c3));
                 if(cols_this >= 8){
-                    svst1_s32(pg_b32_4, C0 + 4, svreinterpret_s32_u32(acc47_c0));
-                    svst1_s32(pg_b32_4, C1 + 4, svreinterpret_s32_u32(acc47_c1));
-                    svst1_s32(pg_b32_4, C2 + 4, svreinterpret_s32_u32(acc47_c2));
-                    svst1_s32(pg_b32_4, C3 + 4, svreinterpret_s32_u32(acc47_c3));
+                    MlasSveStoreInt32(pg_b32_4, C0 + 4, MlasSveReinterpretS32FromU32(acc47_c0));
+                    MlasSveStoreInt32(pg_b32_4, C1 + 4, MlasSveReinterpretS32FromU32(acc47_c1));
+                    MlasSveStoreInt32(pg_b32_4, C2 + 4, MlasSveReinterpretS32FromU32(acc47_c2));
+                    MlasSveStoreInt32(pg_b32_4, C3 + 4, MlasSveReinterpretS32FromU32(acc47_c3));
                 }
                 else{
-                    svst1_s32(svwhilelt_b32(0,3), C0 + 4, svreinterpret_s32_u32(acc47_c0));
-                    svst1_s32(svwhilelt_b32(0,3), C1 + 4, svreinterpret_s32_u32(acc47_c1));
-                    svst1_s32(svwhilelt_b32(0,3), C2 + 4, svreinterpret_s32_u32(acc47_c2));
-                    svst1_s32(svwhilelt_b32(0,3), C3 + 4, svreinterpret_s32_u32(acc47_c3));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C0 + 4, MlasSveReinterpretS32FromU32(acc47_c0));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C1 + 4, MlasSveReinterpretS32FromU32(acc47_c1));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C2 + 4, MlasSveReinterpretS32FromU32(acc47_c2));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C3 + 4, MlasSveReinterpretS32FromU32(acc47_c3));
                 }            
             }
             else{
                 // Row 0 (C0)
-                svint32_t prev = svld1_s32(pg_b32_4, C0);
-                svint32_t sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c0));
-                svst1_s32(pg_b32_4, C0, sum);
-                prev = svld1_s32(pg_b32_4, C1);
-                sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c1));
-                svst1_s32(pg_b32_4, C1, sum);
-                prev = svld1_s32(pg_b32_4, C2);
-                sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c2));
-                svst1_s32(pg_b32_4, C2, sum);
-                prev = svld1_s32(pg_b32_4, C3);
-                sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c3));
-                svst1_s32(pg_b32_4, C3, sum);
+                svint32_t prev = MlasSveLoadInt32(pg_b32_4, C0);
+                svint32_t sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c0));
+                MlasSveStoreInt32(pg_b32_4, C0, sum);
+                prev = MlasSveLoadInt32(pg_b32_4, C1);
+                sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c1));
+                MlasSveStoreInt32(pg_b32_4, C1, sum);
+                prev = MlasSveLoadInt32(pg_b32_4, C2);
+                sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c2));
+                MlasSveStoreInt32(pg_b32_4, C2, sum);
+                prev = MlasSveLoadInt32(pg_b32_4, C3);
+                sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c3));
+                MlasSveStoreInt32(pg_b32_4, C3, sum);
                 // Row 1 (C1)
                 if(cols_this >= 8){
-                    prev = svld1_s32(pg_b32_4, C0 + 4);
-                    sum  = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc47_c0));
-                    svst1_s32(pg_b32_4, C0 + 4, sum);
-                    prev = svld1_s32(pg_b32_4, C1 + 4);
-                    sum  = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc47_c1));
-                    svst1_s32(pg_b32_4, C1 + 4, sum);
-                    prev = svld1_s32(pg_b32_4, C2 + 4);
-                    sum  = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc47_c2));
-                    svst1_s32(pg_b32_4, C2 + 4, sum);
-                    prev = svld1_s32(pg_b32_4, C3 + 4);
-                    sum  = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc47_c3));
-                    svst1_s32(pg_b32_4, C3 + 4, sum);
+                    prev = MlasSveLoadInt32(pg_b32_4, C0 + 4);
+                    sum  = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc47_c0));
+                    MlasSveStoreInt32(pg_b32_4, C0 + 4, sum);
+                    prev = MlasSveLoadInt32(pg_b32_4, C1 + 4);
+                    sum  = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc47_c1));
+                    MlasSveStoreInt32(pg_b32_4, C1 + 4, sum);
+                    prev = MlasSveLoadInt32(pg_b32_4, C2 + 4);
+                    sum  = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc47_c2));
+                    MlasSveStoreInt32(pg_b32_4, C2 + 4, sum);
+                    prev = MlasSveLoadInt32(pg_b32_4, C3 + 4);
+                    sum  = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc47_c3));
+                    MlasSveStoreInt32(pg_b32_4, C3 + 4, sum);
                 }
                 else{
-                    prev = svld1_s32(svwhilelt_b32(0,3), C0 + 4);
-                    sum  = svadd_s32_x(svwhilelt_b32(0,3), prev, svreinterpret_s32_u32(acc47_c0));
-                    svst1_s32(svwhilelt_b32(0,3), C0 + 4, sum);
-                    prev = svld1_s32(svwhilelt_b32(0,3), C1 + 4);
-                    sum  = svadd_s32_x(svwhilelt_b32(0,3), prev, svreinterpret_s32_u32(acc47_c1));
-                    svst1_s32(svwhilelt_b32(0,3), C1 + 4, sum);
-                    prev = svld1_s32(svwhilelt_b32(0,3), C2 + 4);
-                    sum  = svadd_s32_x(svwhilelt_b32(0,3), prev, svreinterpret_s32_u32(acc47_c2));
-                    svst1_s32(svwhilelt_b32(0,3), C2 + 4, sum);
-                    prev = svld1_s32(svwhilelt_b32(0,3), C3 + 4);
-                    sum  = svadd_s32_x(svwhilelt_b32(0,3), prev, svreinterpret_s32_u32(acc47_c3));
-                    svst1_s32(svwhilelt_b32(0,3), C3 + 4, sum);
+                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 3), C0 + 4);
+                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 3), prev, MlasSveReinterpretS32FromU32(acc47_c0));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C0 + 4, sum);
+                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 3), C1 + 4);
+                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 3), prev, MlasSveReinterpretS32FromU32(acc47_c1));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C1 + 4, sum);
+                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 3), C2 + 4);
+                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 3), prev, MlasSveReinterpretS32FromU32(acc47_c2));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C2 + 4, sum);
+                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 3), C3 + 4);
+                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 3), prev, MlasSveReinterpretS32FromU32(acc47_c3));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C3 + 4, sum);
                 }
             }
         }
         else if(cols_this > 4){
             if(isZeroPointB){
-                svst1_s32(pg_b32_4, C0, svreinterpret_s32_u32(acc03_c0));
-                svst1_s32(pg_b32_4, C1, svreinterpret_s32_u32(acc03_c1));
-                svst1_s32(pg_b32_4, C2, svreinterpret_s32_u32(acc03_c2));
-                svst1_s32(pg_b32_4, C3, svreinterpret_s32_u32(acc03_c3));
+                MlasSveStoreInt32(pg_b32_4, C0, MlasSveReinterpretS32FromU32(acc03_c0));
+                MlasSveStoreInt32(pg_b32_4, C1, MlasSveReinterpretS32FromU32(acc03_c1));
+                MlasSveStoreInt32(pg_b32_4, C2, MlasSveReinterpretS32FromU32(acc03_c2));
+                MlasSveStoreInt32(pg_b32_4, C3, MlasSveReinterpretS32FromU32(acc03_c3));
                 if(cols_this >= 6){
-                    svst1_s32(svwhilelt_b32(0, 2), C0 + 4, svreinterpret_s32_u32(acc47_c0));
-                    svst1_s32(svwhilelt_b32(0, 2), C1 + 4, svreinterpret_s32_u32(acc47_c1));
-                    svst1_s32(svwhilelt_b32(0, 2), C2 + 4, svreinterpret_s32_u32(acc47_c2));
-                    svst1_s32(svwhilelt_b32(0, 2), C3 + 4, svreinterpret_s32_u32(acc47_c3));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 2), C0 + 4, MlasSveReinterpretS32FromU32(acc47_c0));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 2), C1 + 4, MlasSveReinterpretS32FromU32(acc47_c1));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 2), C2 + 4, MlasSveReinterpretS32FromU32(acc47_c2));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 2), C3 + 4, MlasSveReinterpretS32FromU32(acc47_c3));
                 }
                 else{
-                    svst1_s32(svwhilelt_b32(0, 1), C0 + 4, svreinterpret_s32_u32(acc47_c0));
-                    svst1_s32(svwhilelt_b32(0, 1), C1 + 4, svreinterpret_s32_u32(acc47_c1));
-                    svst1_s32(svwhilelt_b32(0, 1), C2 + 4, svreinterpret_s32_u32(acc47_c2));
-                    svst1_s32(svwhilelt_b32(0, 1), C3 + 4, svreinterpret_s32_u32(acc47_c3));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 1), C0 + 4, MlasSveReinterpretS32FromU32(acc47_c0));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 1), C1 + 4, MlasSveReinterpretS32FromU32(acc47_c1));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 1), C2 + 4, MlasSveReinterpretS32FromU32(acc47_c2));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 1), C3 + 4, MlasSveReinterpretS32FromU32(acc47_c3));
                 }
             }
             else{
                 // Row 0 (C0)
-                svint32_t prev = svld1_s32(pg_b32_4, C0);
-                svint32_t sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c0));
-                svst1_s32(pg_b32_4, C0, sum);
-                prev = svld1_s32(pg_b32_4, C1);
-                sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c1));
-                svst1_s32(pg_b32_4, C1, sum);
-                prev = svld1_s32(pg_b32_4, C2);
-                sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c2));
-                svst1_s32(pg_b32_4, C2, sum);
-                prev = svld1_s32(pg_b32_4, C3);
-                sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c3));
-                svst1_s32(pg_b32_4, C3, sum);
+                svint32_t prev = MlasSveLoadInt32(pg_b32_4, C0);
+                svint32_t sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c0));
+                MlasSveStoreInt32(pg_b32_4, C0, sum);
+                prev = MlasSveLoadInt32(pg_b32_4, C1);
+                sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c1));
+                MlasSveStoreInt32(pg_b32_4, C1, sum);
+                prev = MlasSveLoadInt32(pg_b32_4, C2);
+                sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c2));
+                MlasSveStoreInt32(pg_b32_4, C2, sum);
+                prev = MlasSveLoadInt32(pg_b32_4, C3);
+                sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c3));
+                MlasSveStoreInt32(pg_b32_4, C3, sum);
                 if(cols_this >= 6){
-                    prev = svld1_s32(svwhilelt_b32(0, 2), C0 + 4);
-                    sum  = svadd_s32_x(svwhilelt_b32(0, 2), prev, svreinterpret_s32_u32(acc47_c0));
-                    svst1_s32(svwhilelt_b32(0, 2), C0 + 4, sum);
-                    prev = svld1_s32(svwhilelt_b32(0, 2), C1 + 4);
-                    sum  = svadd_s32_x(svwhilelt_b32(0, 2), prev, svreinterpret_s32_u32(acc47_c1));
-                    svst1_s32(svwhilelt_b32(0, 2), C1 + 4, sum);
-                    prev = svld1_s32(svwhilelt_b32(0, 2), C2 + 4);
-                    sum  = svadd_s32_x(svwhilelt_b32(0, 2), prev, svreinterpret_s32_u32(acc47_c2));
-                    svst1_s32(svwhilelt_b32(0, 2), C2 + 4, sum);
-                    prev = svld1_s32(svwhilelt_b32(0, 2), C3 + 4);
-                    sum  = svadd_s32_x(svwhilelt_b32(0, 2), prev, svreinterpret_s32_u32(acc47_c3));
-                    svst1_s32(svwhilelt_b32(0, 2), C3 + 4, sum);
+                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 2), C0 + 4);
+                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 2), prev, MlasSveReinterpretS32FromU32(acc47_c0));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 2), C0 + 4, sum);
+                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 2), C1 + 4);
+                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 2), prev, MlasSveReinterpretS32FromU32(acc47_c1));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 2), C1 + 4, sum);
+                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 2), C2 + 4);
+                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 2), prev, MlasSveReinterpretS32FromU32(acc47_c2));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 2), C2 + 4, sum);
+                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 2), C3 + 4);
+                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 2), prev, MlasSveReinterpretS32FromU32(acc47_c3));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 2), C3 + 4, sum);
                 }
                 else{
-                    prev = svld1_s32(svwhilelt_b32(0, 1), C0 + 4);
-                    sum  = svadd_s32_x(svwhilelt_b32(0, 1), prev, svreinterpret_s32_u32(acc47_c0));
-                    svst1_s32(svwhilelt_b32(0, 1), C0 + 4, sum);
-                    prev = svld1_s32(svwhilelt_b32(0, 1), C1 + 4);
-                    sum  = svadd_s32_x(svwhilelt_b32(0, 1), prev, svreinterpret_s32_u32(acc47_c1));
-                    svst1_s32(svwhilelt_b32(0, 1), C1 + 4, sum);
-                    prev = svld1_s32(svwhilelt_b32(0, 1), C2 + 4);
-                    sum  = svadd_s32_x(svwhilelt_b32(0, 1), prev, svreinterpret_s32_u32(acc47_c2));
-                    svst1_s32(svwhilelt_b32(0, 1), C2 + 4, sum);
-                    prev = svld1_s32(svwhilelt_b32(0, 1), C3 + 4);
-                    sum  = svadd_s32_x(svwhilelt_b32(0, 1), prev, svreinterpret_s32_u32(acc47_c3));
-                    svst1_s32(svwhilelt_b32(0, 1), C3 + 4, sum);
+                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 1), C0 + 4);
+                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 1), prev, MlasSveReinterpretS32FromU32(acc47_c0));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 1), C0 + 4, sum);
+                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 1), C1 + 4);
+                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 1), prev, MlasSveReinterpretS32FromU32(acc47_c1));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 1), C1 + 4, sum);
+                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 1), C2 + 4);
+                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 1), prev, MlasSveReinterpretS32FromU32(acc47_c2));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 1), C2 + 4, sum);
+                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 1), C3 + 4);
+                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 1), prev, MlasSveReinterpretS32FromU32(acc47_c3));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 1), C3 + 4, sum);
                 }
             }
         }
         else if(cols_this > 2){
             if(isZeroPointB){
                 if(cols_this >= 4){
-                    svst1_s32(pg_b32_4, C0, svreinterpret_s32_u32(acc03_c0));
-                    svst1_s32(pg_b32_4, C1, svreinterpret_s32_u32(acc03_c1));
-                    svst1_s32(pg_b32_4, C2, svreinterpret_s32_u32(acc03_c2));
-                    svst1_s32(pg_b32_4, C3, svreinterpret_s32_u32(acc03_c3));
+                    MlasSveStoreInt32(pg_b32_4, C0, MlasSveReinterpretS32FromU32(acc03_c0));
+                    MlasSveStoreInt32(pg_b32_4, C1, MlasSveReinterpretS32FromU32(acc03_c1));
+                    MlasSveStoreInt32(pg_b32_4, C2, MlasSveReinterpretS32FromU32(acc03_c2));
+                    MlasSveStoreInt32(pg_b32_4, C3, MlasSveReinterpretS32FromU32(acc03_c3));
                 }
                 else{
-                    svst1_s32(svwhilelt_b32(0,3), C0, svreinterpret_s32_u32(acc03_c0));
-                    svst1_s32(svwhilelt_b32(0,3), C1, svreinterpret_s32_u32(acc03_c1));
-                    svst1_s32(svwhilelt_b32(0,3), C2, svreinterpret_s32_u32(acc03_c2));
-                    svst1_s32(svwhilelt_b32(0,3), C3, svreinterpret_s32_u32(acc03_c3));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C0, MlasSveReinterpretS32FromU32(acc03_c0));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C1, MlasSveReinterpretS32FromU32(acc03_c1));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C2, MlasSveReinterpretS32FromU32(acc03_c2));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C3, MlasSveReinterpretS32FromU32(acc03_c3));
                 }
             }
             else{
                 if(cols_this >= 4){
                     // Row 0 (C0)
-                    svint32_t prev = svld1_s32(pg_b32_4, C0);
-                    svint32_t sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c0));
-                    svst1_s32(pg_b32_4, C0, sum);
-                    prev = svld1_s32(pg_b32_4, C1);
-                    sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c1));
-                    svst1_s32(pg_b32_4, C1, sum);
-                    prev = svld1_s32(pg_b32_4, C2);
-                    sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c2));
-                    svst1_s32(pg_b32_4, C2, sum);
-                    prev = svld1_s32(pg_b32_4, C3);
-                    sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c3));
-                    svst1_s32(pg_b32_4, C3, sum);
+                    svint32_t prev = MlasSveLoadInt32(pg_b32_4, C0);
+                    svint32_t sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c0));
+                    MlasSveStoreInt32(pg_b32_4, C0, sum);
+                    prev = MlasSveLoadInt32(pg_b32_4, C1);
+                    sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c1));
+                    MlasSveStoreInt32(pg_b32_4, C1, sum);
+                    prev = MlasSveLoadInt32(pg_b32_4, C2);
+                    sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c2));
+                    MlasSveStoreInt32(pg_b32_4, C2, sum);
+                    prev = MlasSveLoadInt32(pg_b32_4, C3);
+                    sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c3));
+                    MlasSveStoreInt32(pg_b32_4, C3, sum);
                 }
                 else{
                     // Row 0 (C0)
-                    svint32_t prev = svld1_s32(svwhilelt_b32(0,3), C0);
-                    svint32_t sum = svadd_s32_x(svwhilelt_b32(0,3), prev, svreinterpret_s32_u32(acc03_c0));
-                    svst1_s32(svwhilelt_b32(0,3), C0, sum);
-                    prev = svld1_s32(svwhilelt_b32(0,3), C1);
-                    sum = svadd_s32_x(svwhilelt_b32(0,3), prev, svreinterpret_s32_u32(acc03_c1));
-                    svst1_s32(svwhilelt_b32(0,3), C1, sum);
-                    prev = svld1_s32(svwhilelt_b32(0,3), C2);
-                    sum = svadd_s32_x(svwhilelt_b32(0,3), prev, svreinterpret_s32_u32(acc03_c2));
-                    svst1_s32(svwhilelt_b32(0,3), C2, sum);
-                    prev = svld1_s32(svwhilelt_b32(0,3), C3);
-                    sum = svadd_s32_x(svwhilelt_b32(0,3), prev, svreinterpret_s32_u32(acc03_c3));
-                    svst1_s32(svwhilelt_b32(0,3), C3, sum);
+                    svint32_t prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 3), C0);
+                    svint32_t sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, 3), prev, MlasSveReinterpretS32FromU32(acc03_c0));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C0, sum);
+                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 3), C1);
+                    sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, 3), prev, MlasSveReinterpretS32FromU32(acc03_c1));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C1, sum);
+                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 3), C2);
+                    sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, 3), prev, MlasSveReinterpretS32FromU32(acc03_c2));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C2, sum);
+                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 3), C3);
+                    sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, 3), prev, MlasSveReinterpretS32FromU32(acc03_c3));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C3, sum);
                 }   
             }
         }
         else{
             if(isZeroPointB){
-                svst1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C0, svreinterpret_s32_u32(acc03_c0));
-                svst1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C1, svreinterpret_s32_u32(acc03_c1));
-                svst1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C2, svreinterpret_s32_u32(acc03_c2));
-                svst1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C3, svreinterpret_s32_u32(acc03_c3));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C0, MlasSveReinterpretS32FromU32(acc03_c0));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C1, MlasSveReinterpretS32FromU32(acc03_c1));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C2, MlasSveReinterpretS32FromU32(acc03_c2));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C3, MlasSveReinterpretS32FromU32(acc03_c3));
             }
             else{
                 // Row 0 (C0)
-                svint32_t prev = svld1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C0);
-                svint32_t sum = svadd_s32_x(svwhilelt_b32(0, std::min(int(cols_this), 2)), prev, svreinterpret_s32_u32(acc03_c0));
-                svst1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C0, sum);
-                prev = svld1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C1);
-                sum = svadd_s32_x(svwhilelt_b32(0, std::min(int(cols_this), 2)), prev, svreinterpret_s32_u32(acc03_c1));
-                svst1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C1, sum);
-                prev = svld1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C2);
-                sum = svadd_s32_x(svwhilelt_b32(0, std::min(int(cols_this), 2)), prev, svreinterpret_s32_u32(acc03_c2));
-                svst1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C2, sum);
-                prev = svld1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C3);
-                sum = svadd_s32_x(svwhilelt_b32(0, std::min(int(cols_this), 2)), prev, svreinterpret_s32_u32(acc03_c3));
-                svst1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C3, sum);
+                svint32_t prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C0);
+                svint32_t sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), prev, MlasSveReinterpretS32FromU32(acc03_c0));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C0, sum);
+                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C1);
+                sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), prev, MlasSveReinterpretS32FromU32(acc03_c1));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C1, sum);
+                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C2);
+                sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), prev, MlasSveReinterpretS32FromU32(acc03_c2));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C2, sum);
+                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C3);
+                sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), prev, MlasSveReinterpretS32FromU32(acc03_c3));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C3, sum);
             }
         }
         // Last 4 columns
@@ -863,25 +864,25 @@ size_t Process8RowsTest256(
     //------------------------------------------------------------------
     // VL = 256 → int32 lanes = 8 → process columns in groups of 4
     //------------------------------------------------------------------
-    svbool_t pg_b32_4 = svwhilelt_b32(0, 4);  // stores 4 output columns
-    svbool_t pg_b32_8 = svptrue_b32();  // full accumulator lanes
-    svbool_t pg_b8_32 = svptrue_b8(); // loads 32 bytes from A/B
+    svbool_t pg_b32_4 = MlasSveWhileLtB32(0, 4);  // stores 4 output columns
+    svbool_t pg_b32_8 = MlasSvePtrueB32();  // full accumulator lanes
+    svbool_t pg_b8_32 = MlasSvePtrueB8(); // loads 32 bytes from A/B
     svuint32_t acc03_0, acc03_1, acc03_2, acc03_3, acc47_0, acc47_1, acc47_2, acc47_3;
 
     // const int32_t rowsum = RowSumBuffer[0];
     svint32_t rowSumVec01, rowSumVec23, rowSumVec45, rowSumVec67, r0, r1, r2, r3, r4, r5, r6, r7;
-    r0 = svdup_s32(RowSumBuffer[0]);
-    r1 = svdup_s32(RowSumBuffer[1]);
-    rowSumVec01 = svreinterpret_s32_s64(svtrn1_s64(svreinterpret_s64_s32(r0), svreinterpret_s64_s32(r1)));
-    r2 = svdup_s32(RowSumBuffer[2]);
-    r3 = svdup_s32(RowSumBuffer[3]);
-    rowSumVec23 = svreinterpret_s32_s64(svtrn1_s64(svreinterpret_s64_s32(r2), svreinterpret_s64_s32(r3)));
-    r4 = svdup_s32(RowSumBuffer[4]);
-    r5 = svdup_s32(RowSumBuffer[5]);
-    rowSumVec45 = svreinterpret_s32_s64(svtrn1_s64(svreinterpret_s64_s32(r4), svreinterpret_s64_s32(r5)));
-    r6 = svdup_s32(RowSumBuffer[6]);
-    r7 = svdup_s32(RowSumBuffer[7]);
-    rowSumVec67 = svreinterpret_s32_s64(svtrn1_s64(svreinterpret_s64_s32(r6), svreinterpret_s64_s32(r7)));
+    r0 = MlasSveBroadcastInt32(RowSumBuffer[0]);
+    r1 = MlasSveBroadcastInt32(RowSumBuffer[1]);
+    rowSumVec01 = MlasSveReinterpretS32FromS64(MlasSveTrn1S64(MlasSveReinterpretS64FromS32(r0), MlasSveReinterpretS64FromS32(r1)));
+    r2 = MlasSveBroadcastInt32(RowSumBuffer[2]);
+    r3 = MlasSveBroadcastInt32(RowSumBuffer[3]);
+    rowSumVec23 = MlasSveReinterpretS32FromS64(MlasSveTrn1S64(MlasSveReinterpretS64FromS32(r2), MlasSveReinterpretS64FromS32(r3)));
+    r4 = MlasSveBroadcastInt32(RowSumBuffer[4]);
+    r5 = MlasSveBroadcastInt32(RowSumBuffer[5]);
+    rowSumVec45 = MlasSveReinterpretS32FromS64(MlasSveTrn1S64(MlasSveReinterpretS64FromS32(r4), MlasSveReinterpretS64FromS32(r5)));
+    r6 = MlasSveBroadcastInt32(RowSumBuffer[6]);
+    r7 = MlasSveBroadcastInt32(RowSumBuffer[7]);
+    rowSumVec67 = MlasSveReinterpretS32FromS64(MlasSveTrn1S64(MlasSveReinterpretS64FromS32(r6), MlasSveReinterpretS64FromS32(r7)));
     const uint8_t* A_ptr;
     int32_t *C0, *C1, *C2, *C3, *C4, *C5, *C6, *C7;
     C0 = C;
@@ -906,38 +907,38 @@ size_t Process8RowsTest256(
         svint64_t zpb64_0_3, col64_0_3, zpb64_4_7, col64_4_7;
         // --- Columns 0–3 ---
         if (ZeroPointB){
-            zpb_0_3 = svld1_s32(pg_b32_4, ZeroPointB); //pg_b32_4
-            zpb64_0_3 = svreinterpret_s64_s32(zpb_0_3);
-            zpb_0_3 = svreinterpret_s32_s64(svzip1_s64(zpb64_0_3, zpb64_0_3));
+            zpb_0_3 = MlasSveLoadInt32(pg_b32_4, ZeroPointB); //pg_b32_4
+            zpb64_0_3 = MlasSveReinterpretS64FromS32(zpb_0_3);
+            zpb_0_3 = MlasSveReinterpretS32FromS64(MlasSveZip1S64(zpb64_0_3, zpb64_0_3));
         }
         else
-            zpb_0_3 = svdup_s32(1);
-        col_0_3 = svld1_s32(pg_b32_4, ColumnSumBuffer);
-        col64_0_3 = svreinterpret_s64_s32(col_0_3);
-        col_0_3 = svreinterpret_s32_s64(svzip1_s64(col64_0_3, col64_0_3));
+            zpb_0_3 = MlasSveBroadcastInt32(1);
+        col_0_3 = MlasSveLoadInt32(pg_b32_4, ColumnSumBuffer);
+        col64_0_3 = MlasSveReinterpretS64FromS32(col_0_3);
+        col_0_3 = MlasSveReinterpretS32FromS64(MlasSveZip1S64(col64_0_3, col64_0_3));
 
-        acc03_0 = svreinterpret_u32_s32(svadd_s32_x(pg_b32_8, svmul_s32_x(pg_b32_8, rowSumVec01, zpb_0_3), col_0_3));
-        acc03_1 = svreinterpret_u32_s32(svadd_s32_x(pg_b32_8, svmul_s32_x(pg_b32_8, rowSumVec23, zpb_0_3), col_0_3));
-        acc03_2 = svreinterpret_u32_s32(svadd_s32_x(pg_b32_8, svmul_s32_x(pg_b32_8, rowSumVec45, zpb_0_3), col_0_3));
-        acc03_3 = svreinterpret_u32_s32(svadd_s32_x(pg_b32_8, svmul_s32_x(pg_b32_8, rowSumVec67, zpb_0_3), col_0_3));
+        acc03_0 = MlasSveReinterpretU32FromS32(MlasSveAddInt32X(pg_b32_8, MlasSveMulInt32(pg_b32_8, rowSumVec01, zpb_0_3), col_0_3));
+        acc03_1 = MlasSveReinterpretU32FromS32(MlasSveAddInt32X(pg_b32_8, MlasSveMulInt32(pg_b32_8, rowSumVec23, zpb_0_3), col_0_3));
+        acc03_2 = MlasSveReinterpretU32FromS32(MlasSveAddInt32X(pg_b32_8, MlasSveMulInt32(pg_b32_8, rowSumVec45, zpb_0_3), col_0_3));
+        acc03_3 = MlasSveReinterpretU32FromS32(MlasSveAddInt32X(pg_b32_8, MlasSveMulInt32(pg_b32_8, rowSumVec67, zpb_0_3), col_0_3));
         // --- Columns 4–7 ---
         if (cols_this > 4) {
             if (ZeroPointB){
-                zpb_4_7 = svld1_s32(pg_b32_4, ZeroPointB + 4);
-                zpb64_4_7 = svreinterpret_s64_s32(zpb_4_7);
-                zpb_4_7 = svreinterpret_s32_s64(svzip1_s64(zpb64_4_7, zpb64_4_7));
+                zpb_4_7 = MlasSveLoadInt32(pg_b32_4, ZeroPointB + 4);
+                zpb64_4_7 = MlasSveReinterpretS64FromS32(zpb_4_7);
+                zpb_4_7 = MlasSveReinterpretS32FromS64(MlasSveZip1S64(zpb64_4_7, zpb64_4_7));
             }
             else{
-                zpb_4_7 = svdup_s32(1);
+                zpb_4_7 = MlasSveBroadcastInt32(1);
             }
-            col_4_7 = svld1_s32(pg_b32_4, ColumnSumBuffer + 4);
-            col64_4_7 = svreinterpret_s64_s32(col_4_7);
-            col_4_7 = svreinterpret_s32_s64(svzip1_s64(col64_4_7, col64_4_7));
-            // acc47 = svreinterpret_u32_s32(svmad_s32_x(pg_b32_4, rowSumVec, zpb_4_7, col_4_7));
-            acc47_0 = svreinterpret_u32_s32(svadd_s32_x(pg_b32_8, svmul_s32_x(pg_b32_8, rowSumVec01, zpb_4_7), col_4_7));
-            acc47_1 = svreinterpret_u32_s32(svadd_s32_x(pg_b32_8, svmul_s32_x(pg_b32_8, rowSumVec23, zpb_4_7), col_4_7));
-            acc47_2 = svreinterpret_u32_s32(svadd_s32_x(pg_b32_8, svmul_s32_x(pg_b32_8, rowSumVec45, zpb_4_7), col_4_7));
-            acc47_3 = svreinterpret_u32_s32(svadd_s32_x(pg_b32_8, svmul_s32_x(pg_b32_8, rowSumVec67, zpb_4_7), col_4_7));
+            col_4_7 = MlasSveLoadInt32(pg_b32_4, ColumnSumBuffer + 4);
+            col64_4_7 = MlasSveReinterpretS64FromS32(col_4_7);
+            col_4_7 = MlasSveReinterpretS32FromS64(MlasSveZip1S64(col64_4_7, col64_4_7));
+            // acc47 = MlasSveReinterpretU32FromS32(svmad_s32_x(pg_b32_4, rowSumVec, zpb_4_7, col_4_7));
+            acc47_0 = MlasSveReinterpretU32FromS32(MlasSveAddInt32X(pg_b32_8, MlasSveMulInt32(pg_b32_8, rowSumVec01, zpb_4_7), col_4_7));
+            acc47_1 = MlasSveReinterpretU32FromS32(MlasSveAddInt32X(pg_b32_8, MlasSveMulInt32(pg_b32_8, rowSumVec23, zpb_4_7), col_4_7));
+            acc47_2 = MlasSveReinterpretU32FromS32(MlasSveAddInt32X(pg_b32_8, MlasSveMulInt32(pg_b32_8, rowSumVec45, zpb_4_7), col_4_7));
+            acc47_3 = MlasSveReinterpretU32FromS32(MlasSveAddInt32X(pg_b32_8, MlasSveMulInt32(pg_b32_8, rowSumVec67, zpb_4_7), col_4_7));
         }
         //------------------------------------------------------------------
         // K loop
@@ -947,22 +948,22 @@ size_t Process8RowsTest256(
         for (size_t k = 0; k < PackedCountK; k++)
         {
             // A: 32 bytes, B: 32 bytes per 4 columns
-            svuint8_t a0  = svld1rq_u8(pg_b8_32, A_ptr); //load and replicate
-            svuint8_t a1  = svld1rq_u8(pg_b8_32, A_ptr + 16); //load and replicate
-            svuint8_t a2  = svld1rq_u8(pg_b8_32, A_ptr + 32); //load and replicate
-            svuint8_t a3  = svld1rq_u8(pg_b8_32, A_ptr + 48); //load and replicate
-            svuint8_t b0 = svld1_u8(pg_b8_32, B);
-            svuint8_t b1 = svld1_u8(pg_b8_32, B + 32);
+            svuint8_t a0  = MlasSveLoadReplicateU8(pg_b8_32, A_ptr); //load and replicate
+            svuint8_t a1  = MlasSveLoadReplicateU8(pg_b8_32, A_ptr + 16); //load and replicate
+            svuint8_t a2  = MlasSveLoadReplicateU8(pg_b8_32, A_ptr + 32); //load and replicate
+            svuint8_t a3  = MlasSveLoadReplicateU8(pg_b8_32, A_ptr + 48); //load and replicate
+            svuint8_t b0 = MlasSveLoadU8(pg_b8_32, B);
+            svuint8_t b1 = MlasSveLoadU8(pg_b8_32, B + 32);
 
-            acc03_0 = svmmla_u32(acc03_0, a0, b0);
-            acc03_1 = svmmla_u32(acc03_1, a1, b0);
-            acc03_2 = svmmla_u32(acc03_2, a2, b0);
-            acc03_3 = svmmla_u32(acc03_3, a3, b0);
+            acc03_0 = MlasSveMatMulAddU32(acc03_0, a0, b0);
+            acc03_1 = MlasSveMatMulAddU32(acc03_1, a1, b0);
+            acc03_2 = MlasSveMatMulAddU32(acc03_2, a2, b0);
+            acc03_3 = MlasSveMatMulAddU32(acc03_3, a3, b0);
             if (cols_this > 4){
-                acc47_0 = svmmla_u32(acc47_0, a0, b1);
-                acc47_1 = svmmla_u32(acc47_1, a1, b1);
-                acc47_2 = svmmla_u32(acc47_2, a2, b1);
-                acc47_3 = svmmla_u32(acc47_3, a3, b1);
+                acc47_0 = MlasSveMatMulAddU32(acc47_0, a0, b1);
+                acc47_1 = MlasSveMatMulAddU32(acc47_1, a1, b1);
+                acc47_2 = MlasSveMatMulAddU32(acc47_2, a2, b1);
+                acc47_3 = MlasSveMatMulAddU32(acc47_3, a3, b1);
             }
 
             A_ptr += 64;   // Each tile is 32 bytes for 256-bit
@@ -972,370 +973,370 @@ size_t Process8RowsTest256(
         //------------------------------------------------------------------
         // Store results into C
         //------------------------------------------------------------------
-        const svuint32_t idx1 = svdupq_n_u32(0, 1, 4, 5);
-        const svuint32_t idx2 = svdupq_n_u32(2, 3, 6, 7);
+        const svuint32_t idx1 = MlasSveDupqU32(0, 1, 4, 5);
+        const svuint32_t idx2 = MlasSveDupqU32(2, 3, 6, 7);
         svuint32_t acc03_c0, acc03_c1, acc47_c0, acc47_c1, acc03_c2, acc03_c3, acc47_c2, acc47_c3, acc03_c4, acc03_c5, acc47_c4, acc47_c5, acc03_c6, acc03_c7, acc47_c6, acc47_c7;
-        acc03_c0 = svtbl_u32(acc03_0, idx1);
-        acc03_c1 = svtbl_u32(acc03_0, idx2);
-        acc03_c2 = svtbl_u32(acc03_1, idx1);
-        acc03_c3 = svtbl_u32(acc03_1, idx2);
-        acc03_c4 = svtbl_u32(acc03_2, idx1);
-        acc03_c5 = svtbl_u32(acc03_2, idx2);
-        acc03_c6 = svtbl_u32(acc03_3, idx1);
-        acc03_c7 = svtbl_u32(acc03_3, idx2);
+        acc03_c0 = MlasSveTblU32(acc03_0, idx1);
+        acc03_c1 = MlasSveTblU32(acc03_0, idx2);
+        acc03_c2 = MlasSveTblU32(acc03_1, idx1);
+        acc03_c3 = MlasSveTblU32(acc03_1, idx2);
+        acc03_c4 = MlasSveTblU32(acc03_2, idx1);
+        acc03_c5 = MlasSveTblU32(acc03_2, idx2);
+        acc03_c6 = MlasSveTblU32(acc03_3, idx1);
+        acc03_c7 = MlasSveTblU32(acc03_3, idx2);
         if (cols_this > 4){
-            acc47_c0 = svtbl_u32(acc47_0, idx1);
-            acc47_c1 = svtbl_u32(acc47_0, idx2);
-            acc47_c2 = svtbl_u32(acc47_1, idx1);
-            acc47_c3 = svtbl_u32(acc47_1, idx2);
-            acc47_c4 = svtbl_u32(acc47_2, idx1);
-            acc47_c5 = svtbl_u32(acc47_2, idx2);
-            acc47_c6 = svtbl_u32(acc47_3, idx1);
-            acc47_c7 = svtbl_u32(acc47_3, idx2);
+            acc47_c0 = MlasSveTblU32(acc47_0, idx1);
+            acc47_c1 = MlasSveTblU32(acc47_0, idx2);
+            acc47_c2 = MlasSveTblU32(acc47_1, idx1);
+            acc47_c3 = MlasSveTblU32(acc47_1, idx2);
+            acc47_c4 = MlasSveTblU32(acc47_2, idx1);
+            acc47_c5 = MlasSveTblU32(acc47_2, idx2);
+            acc47_c6 = MlasSveTblU32(acc47_3, idx1);
+            acc47_c7 = MlasSveTblU32(acc47_3, idx2);
         }
         // First 4 columns
         // 
         if(cols_this > 6){
             if(isZeroPointB){
-                svst1_s32(pg_b32_4, C0, svreinterpret_s32_u32(acc03_c0));
-                svst1_s32(pg_b32_4, C1, svreinterpret_s32_u32(acc03_c1));
-                svst1_s32(pg_b32_4, C2, svreinterpret_s32_u32(acc03_c2));
-                svst1_s32(pg_b32_4, C3, svreinterpret_s32_u32(acc03_c3));
-                svst1_s32(pg_b32_4, C4, svreinterpret_s32_u32(acc03_c4));
-                svst1_s32(pg_b32_4, C5, svreinterpret_s32_u32(acc03_c5));
-                svst1_s32(pg_b32_4, C6, svreinterpret_s32_u32(acc03_c6));
-                svst1_s32(pg_b32_4, C7, svreinterpret_s32_u32(acc03_c7));
+                MlasSveStoreInt32(pg_b32_4, C0, MlasSveReinterpretS32FromU32(acc03_c0));
+                MlasSveStoreInt32(pg_b32_4, C1, MlasSveReinterpretS32FromU32(acc03_c1));
+                MlasSveStoreInt32(pg_b32_4, C2, MlasSveReinterpretS32FromU32(acc03_c2));
+                MlasSveStoreInt32(pg_b32_4, C3, MlasSveReinterpretS32FromU32(acc03_c3));
+                MlasSveStoreInt32(pg_b32_4, C4, MlasSveReinterpretS32FromU32(acc03_c4));
+                MlasSveStoreInt32(pg_b32_4, C5, MlasSveReinterpretS32FromU32(acc03_c5));
+                MlasSveStoreInt32(pg_b32_4, C6, MlasSveReinterpretS32FromU32(acc03_c6));
+                MlasSveStoreInt32(pg_b32_4, C7, MlasSveReinterpretS32FromU32(acc03_c7));
                 if(cols_this >= 8){
-                    svst1_s32(pg_b32_4, C0 + 4, svreinterpret_s32_u32(acc47_c0));
-                    svst1_s32(pg_b32_4, C1 + 4, svreinterpret_s32_u32(acc47_c1));
-                    svst1_s32(pg_b32_4, C2 + 4, svreinterpret_s32_u32(acc47_c2));
-                    svst1_s32(pg_b32_4, C3 + 4, svreinterpret_s32_u32(acc47_c3));
-                    svst1_s32(pg_b32_4, C4 + 4, svreinterpret_s32_u32(acc47_c4));
-                    svst1_s32(pg_b32_4, C5 + 4, svreinterpret_s32_u32(acc47_c5));
-                    svst1_s32(pg_b32_4, C6 + 4, svreinterpret_s32_u32(acc47_c6));
-                    svst1_s32(pg_b32_4, C7 + 4, svreinterpret_s32_u32(acc47_c7));
+                    MlasSveStoreInt32(pg_b32_4, C0 + 4, MlasSveReinterpretS32FromU32(acc47_c0));
+                    MlasSveStoreInt32(pg_b32_4, C1 + 4, MlasSveReinterpretS32FromU32(acc47_c1));
+                    MlasSveStoreInt32(pg_b32_4, C2 + 4, MlasSveReinterpretS32FromU32(acc47_c2));
+                    MlasSveStoreInt32(pg_b32_4, C3 + 4, MlasSveReinterpretS32FromU32(acc47_c3));
+                    MlasSveStoreInt32(pg_b32_4, C4 + 4, MlasSveReinterpretS32FromU32(acc47_c4));
+                    MlasSveStoreInt32(pg_b32_4, C5 + 4, MlasSveReinterpretS32FromU32(acc47_c5));
+                    MlasSveStoreInt32(pg_b32_4, C6 + 4, MlasSveReinterpretS32FromU32(acc47_c6));
+                    MlasSveStoreInt32(pg_b32_4, C7 + 4, MlasSveReinterpretS32FromU32(acc47_c7));
                 }
                 else{
-                    svst1_s32(svwhilelt_b32(0,3), C0 + 4, svreinterpret_s32_u32(acc47_c0));
-                    svst1_s32(svwhilelt_b32(0,3), C1 + 4, svreinterpret_s32_u32(acc47_c1));
-                    svst1_s32(svwhilelt_b32(0,3), C2 + 4, svreinterpret_s32_u32(acc47_c2));
-                    svst1_s32(svwhilelt_b32(0,3), C3 + 4, svreinterpret_s32_u32(acc47_c3));
-                    svst1_s32(svwhilelt_b32(0,3), C4 + 4, svreinterpret_s32_u32(acc47_c4));
-                    svst1_s32(svwhilelt_b32(0,3), C5 + 4, svreinterpret_s32_u32(acc47_c5));
-                    svst1_s32(svwhilelt_b32(0,3), C6 + 4, svreinterpret_s32_u32(acc47_c6));
-                    svst1_s32(svwhilelt_b32(0,3), C7 + 4, svreinterpret_s32_u32(acc47_c7));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C0 + 4, MlasSveReinterpretS32FromU32(acc47_c0));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C1 + 4, MlasSveReinterpretS32FromU32(acc47_c1));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C2 + 4, MlasSveReinterpretS32FromU32(acc47_c2));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C3 + 4, MlasSveReinterpretS32FromU32(acc47_c3));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C4 + 4, MlasSveReinterpretS32FromU32(acc47_c4));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C5 + 4, MlasSveReinterpretS32FromU32(acc47_c5));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C6 + 4, MlasSveReinterpretS32FromU32(acc47_c6));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C7 + 4, MlasSveReinterpretS32FromU32(acc47_c7));
                 }            
             }
             else{
                 // Row 0 (C0)
-                svint32_t prev = svld1_s32(pg_b32_4, C0);
-                svint32_t sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c0));
-                svst1_s32(pg_b32_4, C0, sum);
-                prev = svld1_s32(pg_b32_4, C1);
-                sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c1));
-                svst1_s32(pg_b32_4, C1, sum);
-                prev = svld1_s32(pg_b32_4, C2);
-                sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c2));
-                svst1_s32(pg_b32_4, C2, sum);
-                prev = svld1_s32(pg_b32_4, C3);
-                sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c3));
-                svst1_s32(pg_b32_4, C3, sum);
-                prev = svld1_s32(pg_b32_4, C4);
-                sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c4));
-                svst1_s32(pg_b32_4, C4, sum);
-                prev = svld1_s32(pg_b32_4, C5);
-                sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c5));
-                svst1_s32(pg_b32_4, C5, sum);
-                prev = svld1_s32(pg_b32_4, C6);
-                sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c6));
-                svst1_s32(pg_b32_4, C6, sum);
-                prev = svld1_s32(pg_b32_4, C7);
-                sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c7));
-                svst1_s32(pg_b32_4, C7, sum);
+                svint32_t prev = MlasSveLoadInt32(pg_b32_4, C0);
+                svint32_t sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c0));
+                MlasSveStoreInt32(pg_b32_4, C0, sum);
+                prev = MlasSveLoadInt32(pg_b32_4, C1);
+                sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c1));
+                MlasSveStoreInt32(pg_b32_4, C1, sum);
+                prev = MlasSveLoadInt32(pg_b32_4, C2);
+                sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c2));
+                MlasSveStoreInt32(pg_b32_4, C2, sum);
+                prev = MlasSveLoadInt32(pg_b32_4, C3);
+                sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c3));
+                MlasSveStoreInt32(pg_b32_4, C3, sum);
+                prev = MlasSveLoadInt32(pg_b32_4, C4);
+                sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c4));
+                MlasSveStoreInt32(pg_b32_4, C4, sum);
+                prev = MlasSveLoadInt32(pg_b32_4, C5);
+                sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c5));
+                MlasSveStoreInt32(pg_b32_4, C5, sum);
+                prev = MlasSveLoadInt32(pg_b32_4, C6);
+                sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c6));
+                MlasSveStoreInt32(pg_b32_4, C6, sum);
+                prev = MlasSveLoadInt32(pg_b32_4, C7);
+                sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c7));
+                MlasSveStoreInt32(pg_b32_4, C7, sum);
                 // Row 1 (C1)
                 if(cols_this >= 8){
-                    prev = svld1_s32(pg_b32_4, C0 + 4);
-                    sum  = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc47_c0));
-                    svst1_s32(pg_b32_4, C0 + 4, sum);
-                    prev = svld1_s32(pg_b32_4, C1 + 4);
-                    sum  = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc47_c1));
-                    svst1_s32(pg_b32_4, C1 + 4, sum);
-                    prev = svld1_s32(pg_b32_4, C2 + 4);
-                    sum  = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc47_c2));
-                    svst1_s32(pg_b32_4, C2 + 4, sum);
-                    prev = svld1_s32(pg_b32_4, C3 + 4);
-                    sum  = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc47_c3));
-                    svst1_s32(pg_b32_4, C3 + 4, sum);
-                    prev = svld1_s32(pg_b32_4, C4 + 4);
-                    sum  = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc47_c4));
-                    svst1_s32(pg_b32_4, C4 + 4, sum);
-                    prev = svld1_s32(pg_b32_4, C5 + 4);
-                    sum  = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc47_c5));
-                    svst1_s32(pg_b32_4, C5 + 4, sum);
-                    prev = svld1_s32(pg_b32_4, C6 + 4);
-                    sum  = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc47_c6));
-                    svst1_s32(pg_b32_4, C6 + 4, sum);
-                    prev = svld1_s32(pg_b32_4, C7 + 4);
-                    sum  = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc47_c7));
-                    svst1_s32(pg_b32_4, C7 + 4, sum);
+                    prev = MlasSveLoadInt32(pg_b32_4, C0 + 4);
+                    sum  = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc47_c0));
+                    MlasSveStoreInt32(pg_b32_4, C0 + 4, sum);
+                    prev = MlasSveLoadInt32(pg_b32_4, C1 + 4);
+                    sum  = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc47_c1));
+                    MlasSveStoreInt32(pg_b32_4, C1 + 4, sum);
+                    prev = MlasSveLoadInt32(pg_b32_4, C2 + 4);
+                    sum  = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc47_c2));
+                    MlasSveStoreInt32(pg_b32_4, C2 + 4, sum);
+                    prev = MlasSveLoadInt32(pg_b32_4, C3 + 4);
+                    sum  = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc47_c3));
+                    MlasSveStoreInt32(pg_b32_4, C3 + 4, sum);
+                    prev = MlasSveLoadInt32(pg_b32_4, C4 + 4);
+                    sum  = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc47_c4));
+                    MlasSveStoreInt32(pg_b32_4, C4 + 4, sum);
+                    prev = MlasSveLoadInt32(pg_b32_4, C5 + 4);
+                    sum  = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc47_c5));
+                    MlasSveStoreInt32(pg_b32_4, C5 + 4, sum);
+                    prev = MlasSveLoadInt32(pg_b32_4, C6 + 4);
+                    sum  = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc47_c6));
+                    MlasSveStoreInt32(pg_b32_4, C6 + 4, sum);
+                    prev = MlasSveLoadInt32(pg_b32_4, C7 + 4);
+                    sum  = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc47_c7));
+                    MlasSveStoreInt32(pg_b32_4, C7 + 4, sum);
                 }
                 else{
-                    prev = svld1_s32(svwhilelt_b32(0,3), C0 + 4);
-                    sum  = svadd_s32_x(svwhilelt_b32(0,3), prev, svreinterpret_s32_u32(acc47_c0));
-                    svst1_s32(svwhilelt_b32(0,3), C0 + 4, sum);
-                    prev = svld1_s32(svwhilelt_b32(0,3), C1 + 4);
-                    sum  = svadd_s32_x(svwhilelt_b32(0,3), prev, svreinterpret_s32_u32(acc47_c1));
-                    svst1_s32(svwhilelt_b32(0,3), C1 + 4, sum);
-                    prev = svld1_s32(svwhilelt_b32(0,3), C2 + 4);
-                    sum  = svadd_s32_x(svwhilelt_b32(0,3), prev, svreinterpret_s32_u32(acc47_c2));
-                    svst1_s32(svwhilelt_b32(0,3), C2 + 4, sum);
-                    prev = svld1_s32(svwhilelt_b32(0,3), C3 + 4);
-                    sum  = svadd_s32_x(svwhilelt_b32(0,3), prev, svreinterpret_s32_u32(acc47_c3));
-                    svst1_s32(svwhilelt_b32(0,3), C3 + 4, sum);
-                    prev = svld1_s32(svwhilelt_b32(0,3), C4 + 4);
-                    sum  = svadd_s32_x(svwhilelt_b32(0,3), prev, svreinterpret_s32_u32(acc47_c4));
-                    svst1_s32(svwhilelt_b32(0,3), C4 + 4, sum);
-                    prev = svld1_s32(svwhilelt_b32(0,3), C5 + 4);
-                    sum  = svadd_s32_x(svwhilelt_b32(0,3), prev, svreinterpret_s32_u32(acc47_c5));
-                    svst1_s32(svwhilelt_b32(0,3), C5 + 4, sum);
-                    prev = svld1_s32(svwhilelt_b32(0,3), C6 + 4);
-                    sum  = svadd_s32_x(svwhilelt_b32(0,3), prev, svreinterpret_s32_u32(acc47_c6));
-                    svst1_s32(svwhilelt_b32(0,3), C6 + 4, sum);
-                    prev = svld1_s32(svwhilelt_b32(0,3), C7 + 4);
-                    sum  = svadd_s32_x(svwhilelt_b32(0,3), prev, svreinterpret_s32_u32(acc47_c7));
-                    svst1_s32(svwhilelt_b32(0,3), C7 + 4, sum);
+                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 3), C0 + 4);
+                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 3), prev, MlasSveReinterpretS32FromU32(acc47_c0));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C0 + 4, sum);
+                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 3), C1 + 4);
+                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 3), prev, MlasSveReinterpretS32FromU32(acc47_c1));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C1 + 4, sum);
+                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 3), C2 + 4);
+                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 3), prev, MlasSveReinterpretS32FromU32(acc47_c2));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C2 + 4, sum);
+                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 3), C3 + 4);
+                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 3), prev, MlasSveReinterpretS32FromU32(acc47_c3));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C3 + 4, sum);
+                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 3), C4 + 4);
+                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 3), prev, MlasSveReinterpretS32FromU32(acc47_c4));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C4 + 4, sum);
+                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 3), C5 + 4);
+                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 3), prev, MlasSveReinterpretS32FromU32(acc47_c5));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C5 + 4, sum);
+                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 3), C6 + 4);
+                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 3), prev, MlasSveReinterpretS32FromU32(acc47_c6));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C6 + 4, sum);
+                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 3), C7 + 4);
+                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 3), prev, MlasSveReinterpretS32FromU32(acc47_c7));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C7 + 4, sum);
                 }
             }
         }
         else if(cols_this > 4){
             if(isZeroPointB){
-                svst1_s32(pg_b32_4, C0, svreinterpret_s32_u32(acc03_c0));
-                svst1_s32(pg_b32_4, C1, svreinterpret_s32_u32(acc03_c1));
-                svst1_s32(pg_b32_4, C2, svreinterpret_s32_u32(acc03_c2));
-                svst1_s32(pg_b32_4, C3, svreinterpret_s32_u32(acc03_c3));
-                svst1_s32(pg_b32_4, C4, svreinterpret_s32_u32(acc03_c4));
-                svst1_s32(pg_b32_4, C5, svreinterpret_s32_u32(acc03_c5));
-                svst1_s32(pg_b32_4, C6, svreinterpret_s32_u32(acc03_c6));
-                svst1_s32(pg_b32_4, C7, svreinterpret_s32_u32(acc03_c7));
+                MlasSveStoreInt32(pg_b32_4, C0, MlasSveReinterpretS32FromU32(acc03_c0));
+                MlasSveStoreInt32(pg_b32_4, C1, MlasSveReinterpretS32FromU32(acc03_c1));
+                MlasSveStoreInt32(pg_b32_4, C2, MlasSveReinterpretS32FromU32(acc03_c2));
+                MlasSveStoreInt32(pg_b32_4, C3, MlasSveReinterpretS32FromU32(acc03_c3));
+                MlasSveStoreInt32(pg_b32_4, C4, MlasSveReinterpretS32FromU32(acc03_c4));
+                MlasSveStoreInt32(pg_b32_4, C5, MlasSveReinterpretS32FromU32(acc03_c5));
+                MlasSveStoreInt32(pg_b32_4, C6, MlasSveReinterpretS32FromU32(acc03_c6));
+                MlasSveStoreInt32(pg_b32_4, C7, MlasSveReinterpretS32FromU32(acc03_c7));
                 if(cols_this >= 6){
-                    svst1_s32(svwhilelt_b32(0, 2), C0 + 4, svreinterpret_s32_u32(acc47_c0));
-                    svst1_s32(svwhilelt_b32(0, 2), C1 + 4, svreinterpret_s32_u32(acc47_c1));
-                    svst1_s32(svwhilelt_b32(0, 2), C2 + 4, svreinterpret_s32_u32(acc47_c2));
-                    svst1_s32(svwhilelt_b32(0, 2), C3 + 4, svreinterpret_s32_u32(acc47_c3));
-                    svst1_s32(svwhilelt_b32(0, 2), C4 + 4, svreinterpret_s32_u32(acc47_c4));
-                    svst1_s32(svwhilelt_b32(0, 2), C5 + 4, svreinterpret_s32_u32(acc47_c5));
-                    svst1_s32(svwhilelt_b32(0, 2), C6 + 4, svreinterpret_s32_u32(acc47_c6));
-                    svst1_s32(svwhilelt_b32(0, 2), C7 + 4, svreinterpret_s32_u32(acc47_c7));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 2), C0 + 4, MlasSveReinterpretS32FromU32(acc47_c0));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 2), C1 + 4, MlasSveReinterpretS32FromU32(acc47_c1));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 2), C2 + 4, MlasSveReinterpretS32FromU32(acc47_c2));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 2), C3 + 4, MlasSveReinterpretS32FromU32(acc47_c3));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 2), C4 + 4, MlasSveReinterpretS32FromU32(acc47_c4));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 2), C5 + 4, MlasSveReinterpretS32FromU32(acc47_c5));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 2), C6 + 4, MlasSveReinterpretS32FromU32(acc47_c6));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 2), C7 + 4, MlasSveReinterpretS32FromU32(acc47_c7));
                 }
                 else{
-                    svst1_s32(svwhilelt_b32(0, 1), C0 + 4, svreinterpret_s32_u32(acc47_c0));
-                    svst1_s32(svwhilelt_b32(0, 1), C1 + 4, svreinterpret_s32_u32(acc47_c1));
-                    svst1_s32(svwhilelt_b32(0, 1), C2 + 4, svreinterpret_s32_u32(acc47_c2));
-                    svst1_s32(svwhilelt_b32(0, 1), C3 + 4, svreinterpret_s32_u32(acc47_c3));
-                    svst1_s32(svwhilelt_b32(0, 1), C4 + 4, svreinterpret_s32_u32(acc47_c4));
-                    svst1_s32(svwhilelt_b32(0, 1), C5 + 4, svreinterpret_s32_u32(acc47_c5));
-                    svst1_s32(svwhilelt_b32(0, 1), C6 + 4, svreinterpret_s32_u32(acc47_c6));
-                    svst1_s32(svwhilelt_b32(0, 1), C7 + 4, svreinterpret_s32_u32(acc47_c7));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 1), C0 + 4, MlasSveReinterpretS32FromU32(acc47_c0));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 1), C1 + 4, MlasSveReinterpretS32FromU32(acc47_c1));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 1), C2 + 4, MlasSveReinterpretS32FromU32(acc47_c2));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 1), C3 + 4, MlasSveReinterpretS32FromU32(acc47_c3));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 1), C4 + 4, MlasSveReinterpretS32FromU32(acc47_c4));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 1), C5 + 4, MlasSveReinterpretS32FromU32(acc47_c5));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 1), C6 + 4, MlasSveReinterpretS32FromU32(acc47_c6));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 1), C7 + 4, MlasSveReinterpretS32FromU32(acc47_c7));
                 }
             }
             else{
                 // Row 0 (C0)
-                svint32_t prev = svld1_s32(pg_b32_4, C0);
-                svint32_t sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c0));
-                svst1_s32(pg_b32_4, C0, sum);
-                prev = svld1_s32(pg_b32_4, C1);
-                sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c1));
-                svst1_s32(pg_b32_4, C1, sum);
-                prev = svld1_s32(pg_b32_4, C2);
-                sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c2));
-                svst1_s32(pg_b32_4, C2, sum);
-                prev = svld1_s32(pg_b32_4, C3);
-                sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c3));
-                svst1_s32(pg_b32_4, C3, sum);
-                prev = svld1_s32(pg_b32_4, C4);
-                sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c4));
-                svst1_s32(pg_b32_4, C4, sum);
-                prev = svld1_s32(pg_b32_4, C5);
-                sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c5));
-                svst1_s32(pg_b32_4, C5, sum);
-                prev = svld1_s32(pg_b32_4, C6);
-                sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c6));
-                svst1_s32(pg_b32_4, C6, sum);
-                prev = svld1_s32(pg_b32_4, C7);
-                sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c7));
-                svst1_s32(pg_b32_4, C7, sum);
+                svint32_t prev = MlasSveLoadInt32(pg_b32_4, C0);
+                svint32_t sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c0));
+                MlasSveStoreInt32(pg_b32_4, C0, sum);
+                prev = MlasSveLoadInt32(pg_b32_4, C1);
+                sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c1));
+                MlasSveStoreInt32(pg_b32_4, C1, sum);
+                prev = MlasSveLoadInt32(pg_b32_4, C2);
+                sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c2));
+                MlasSveStoreInt32(pg_b32_4, C2, sum);
+                prev = MlasSveLoadInt32(pg_b32_4, C3);
+                sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c3));
+                MlasSveStoreInt32(pg_b32_4, C3, sum);
+                prev = MlasSveLoadInt32(pg_b32_4, C4);
+                sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c4));
+                MlasSveStoreInt32(pg_b32_4, C4, sum);
+                prev = MlasSveLoadInt32(pg_b32_4, C5);
+                sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c5));
+                MlasSveStoreInt32(pg_b32_4, C5, sum);
+                prev = MlasSveLoadInt32(pg_b32_4, C6);
+                sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c6));
+                MlasSveStoreInt32(pg_b32_4, C6, sum);
+                prev = MlasSveLoadInt32(pg_b32_4, C7);
+                sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c7));
+                MlasSveStoreInt32(pg_b32_4, C7, sum);
                 // Row 1 (C1)
                 if(cols_this >= 6){
-                    prev = svld1_s32(svwhilelt_b32(0, 2), C0 + 4);
-                    sum  = svadd_s32_x(svwhilelt_b32(0, 2), prev, svreinterpret_s32_u32(acc47_c0));
-                    svst1_s32(svwhilelt_b32(0, 2), C0 + 4, sum);
-                    prev = svld1_s32(svwhilelt_b32(0, 2), C1 + 4);
-                    sum  = svadd_s32_x(svwhilelt_b32(0, 2), prev, svreinterpret_s32_u32(acc47_c1));
-                    svst1_s32(svwhilelt_b32(0, 2), C1 + 4, sum);
-                    prev = svld1_s32(svwhilelt_b32(0, 2), C2 + 4);
-                    sum  = svadd_s32_x(svwhilelt_b32(0, 2), prev, svreinterpret_s32_u32(acc47_c2));
-                    svst1_s32(svwhilelt_b32(0, 2), C2 + 4, sum);
-                    prev = svld1_s32(svwhilelt_b32(0, 2), C3 + 4);
-                    sum  = svadd_s32_x(svwhilelt_b32(0, 2), prev, svreinterpret_s32_u32(acc47_c3));
-                    svst1_s32(svwhilelt_b32(0, 2), C3 + 4, sum);
-                    prev = svld1_s32(svwhilelt_b32(0, 2), C4 + 4);
-                    sum  = svadd_s32_x(svwhilelt_b32(0, 2), prev, svreinterpret_s32_u32(acc47_c4));
-                    svst1_s32(svwhilelt_b32(0, 2), C4 + 4, sum);
-                    prev = svld1_s32(svwhilelt_b32(0, 2), C5 + 4);
-                    sum  = svadd_s32_x(svwhilelt_b32(0, 2), prev, svreinterpret_s32_u32(acc47_c5));
-                    svst1_s32(svwhilelt_b32(0, 2), C5 + 4, sum);
-                    prev = svld1_s32(svwhilelt_b32(0, 2), C6 + 4);
-                    sum  = svadd_s32_x(svwhilelt_b32(0, 2), prev, svreinterpret_s32_u32(acc47_c6));
-                    svst1_s32(svwhilelt_b32(0, 2), C6 + 4, sum);
-                    prev = svld1_s32(svwhilelt_b32(0, 2), C7 + 4);
-                    sum  = svadd_s32_x(svwhilelt_b32(0, 2), prev, svreinterpret_s32_u32(acc47_c7));
-                    svst1_s32(svwhilelt_b32(0, 2), C7 + 4, sum);
+                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 2), C0 + 4);
+                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 2), prev, MlasSveReinterpretS32FromU32(acc47_c0));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 2), C0 + 4, sum);
+                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 2), C1 + 4);
+                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 2), prev, MlasSveReinterpretS32FromU32(acc47_c1));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 2), C1 + 4, sum);
+                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 2), C2 + 4);
+                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 2), prev, MlasSveReinterpretS32FromU32(acc47_c2));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 2), C2 + 4, sum);
+                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 2), C3 + 4);
+                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 2), prev, MlasSveReinterpretS32FromU32(acc47_c3));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 2), C3 + 4, sum);
+                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 2), C4 + 4);
+                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 2), prev, MlasSveReinterpretS32FromU32(acc47_c4));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 2), C4 + 4, sum);
+                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 2), C5 + 4);
+                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 2), prev, MlasSveReinterpretS32FromU32(acc47_c5));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 2), C5 + 4, sum);
+                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 2), C6 + 4);
+                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 2), prev, MlasSveReinterpretS32FromU32(acc47_c6));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 2), C6 + 4, sum);
+                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 2), C7 + 4);
+                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 2), prev, MlasSveReinterpretS32FromU32(acc47_c7));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 2), C7 + 4, sum);
                 }
                 else{
-                    prev = svld1_s32(svwhilelt_b32(0, 1), C0 + 4);
-                    sum  = svadd_s32_x(svwhilelt_b32(0, 1), prev, svreinterpret_s32_u32(acc47_c0));
-                    svst1_s32(svwhilelt_b32(0, 1), C0 + 4, sum);
-                    prev = svld1_s32(svwhilelt_b32(0, 1), C1 + 4);
-                    sum  = svadd_s32_x(svwhilelt_b32(0, 1), prev, svreinterpret_s32_u32(acc47_c1));
-                    svst1_s32(svwhilelt_b32(0, 1), C1 + 4, sum);
-                    prev = svld1_s32(svwhilelt_b32(0, 1), C2 + 4);
-                    sum  = svadd_s32_x(svwhilelt_b32(0, 1), prev, svreinterpret_s32_u32(acc47_c2));
-                    svst1_s32(svwhilelt_b32(0, 1), C2 + 4, sum);
-                    prev = svld1_s32(svwhilelt_b32(0, 1), C3 + 4);
-                    sum  = svadd_s32_x(svwhilelt_b32(0, 1), prev, svreinterpret_s32_u32(acc47_c3));
-                    svst1_s32(svwhilelt_b32(0, 1), C3 + 4, sum);
-                    prev = svld1_s32(svwhilelt_b32(0, 1), C4 + 4);
-                    sum  = svadd_s32_x(svwhilelt_b32(0, 1), prev, svreinterpret_s32_u32(acc47_c4));
-                    svst1_s32(svwhilelt_b32(0, 1), C4 + 4, sum);
-                    prev = svld1_s32(svwhilelt_b32(0, 1), C5 + 4);
-                    sum  = svadd_s32_x(svwhilelt_b32(0, 1), prev, svreinterpret_s32_u32(acc47_c5));
-                    svst1_s32(svwhilelt_b32(0, 1), C5 + 4, sum);
-                    prev = svld1_s32(svwhilelt_b32(0, 1), C6 + 4);
-                    sum  = svadd_s32_x(svwhilelt_b32(0, 1), prev, svreinterpret_s32_u32(acc47_c6));
-                    svst1_s32(svwhilelt_b32(0, 1), C6 + 4, sum);
-                    prev = svld1_s32(svwhilelt_b32(0, 1), C7 + 4);
-                    sum  = svadd_s32_x(svwhilelt_b32(0, 1), prev, svreinterpret_s32_u32(acc47_c7));
-                    svst1_s32(svwhilelt_b32(0, 1), C7 + 4, sum);
+                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 1), C0 + 4);
+                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 1), prev, MlasSveReinterpretS32FromU32(acc47_c0));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 1), C0 + 4, sum);
+                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 1), C1 + 4);
+                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 1), prev, MlasSveReinterpretS32FromU32(acc47_c1));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 1), C1 + 4, sum);
+                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 1), C2 + 4);
+                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 1), prev, MlasSveReinterpretS32FromU32(acc47_c2));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 1), C2 + 4, sum);
+                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 1), C3 + 4);
+                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 1), prev, MlasSveReinterpretS32FromU32(acc47_c3));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 1), C3 + 4, sum);
+                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 1), C4 + 4);
+                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 1), prev, MlasSveReinterpretS32FromU32(acc47_c4));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 1), C4 + 4, sum);
+                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 1), C5 + 4);
+                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 1), prev, MlasSveReinterpretS32FromU32(acc47_c5));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 1), C5 + 4, sum);
+                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 1), C6 + 4);
+                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 1), prev, MlasSveReinterpretS32FromU32(acc47_c6));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 1), C6 + 4, sum);
+                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 1), C7 + 4);
+                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 1), prev, MlasSveReinterpretS32FromU32(acc47_c7));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 1), C7 + 4, sum);
                 }
             }
         }
         else if(cols_this > 2){
             if(isZeroPointB){
                 if(cols_this >= 4){
-                    svst1_s32(pg_b32_4, C0, svreinterpret_s32_u32(acc03_c0));
-                    svst1_s32(pg_b32_4, C1, svreinterpret_s32_u32(acc03_c1));
-                    svst1_s32(pg_b32_4, C2, svreinterpret_s32_u32(acc03_c2));
-                    svst1_s32(pg_b32_4, C3, svreinterpret_s32_u32(acc03_c3));
-                    svst1_s32(pg_b32_4, C4, svreinterpret_s32_u32(acc03_c4));
-                    svst1_s32(pg_b32_4, C5, svreinterpret_s32_u32(acc03_c5));
-                    svst1_s32(pg_b32_4, C6, svreinterpret_s32_u32(acc03_c6));
-                    svst1_s32(pg_b32_4, C7, svreinterpret_s32_u32(acc03_c7));
+                    MlasSveStoreInt32(pg_b32_4, C0, MlasSveReinterpretS32FromU32(acc03_c0));
+                    MlasSveStoreInt32(pg_b32_4, C1, MlasSveReinterpretS32FromU32(acc03_c1));
+                    MlasSveStoreInt32(pg_b32_4, C2, MlasSveReinterpretS32FromU32(acc03_c2));
+                    MlasSveStoreInt32(pg_b32_4, C3, MlasSveReinterpretS32FromU32(acc03_c3));
+                    MlasSveStoreInt32(pg_b32_4, C4, MlasSveReinterpretS32FromU32(acc03_c4));
+                    MlasSveStoreInt32(pg_b32_4, C5, MlasSveReinterpretS32FromU32(acc03_c5));
+                    MlasSveStoreInt32(pg_b32_4, C6, MlasSveReinterpretS32FromU32(acc03_c6));
+                    MlasSveStoreInt32(pg_b32_4, C7, MlasSveReinterpretS32FromU32(acc03_c7));
                 }
                 else{
-                    svst1_s32(svwhilelt_b32(0,3), C0, svreinterpret_s32_u32(acc03_c0));
-                    svst1_s32(svwhilelt_b32(0,3), C1, svreinterpret_s32_u32(acc03_c1));
-                    svst1_s32(svwhilelt_b32(0,3), C2, svreinterpret_s32_u32(acc03_c2));
-                    svst1_s32(svwhilelt_b32(0,3), C3, svreinterpret_s32_u32(acc03_c3));
-                    svst1_s32(svwhilelt_b32(0,3), C4, svreinterpret_s32_u32(acc03_c4));
-                    svst1_s32(svwhilelt_b32(0,3), C5, svreinterpret_s32_u32(acc03_c5));
-                    svst1_s32(svwhilelt_b32(0,3), C6, svreinterpret_s32_u32(acc03_c6));
-                    svst1_s32(svwhilelt_b32(0,3), C7, svreinterpret_s32_u32(acc03_c7));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C0, MlasSveReinterpretS32FromU32(acc03_c0));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C1, MlasSveReinterpretS32FromU32(acc03_c1));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C2, MlasSveReinterpretS32FromU32(acc03_c2));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C3, MlasSveReinterpretS32FromU32(acc03_c3));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C4, MlasSveReinterpretS32FromU32(acc03_c4));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C5, MlasSveReinterpretS32FromU32(acc03_c5));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C6, MlasSveReinterpretS32FromU32(acc03_c6));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C7, MlasSveReinterpretS32FromU32(acc03_c7));
                 }
             }
             else{
                 if(cols_this >= 4){
                     // Row 0 (C0)
-                    svint32_t prev = svld1_s32(pg_b32_4, C0);
-                    svint32_t sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c0));
-                    svst1_s32(pg_b32_4, C0, sum);
-                    prev = svld1_s32(pg_b32_4, C1);
-                    sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c1));
-                    svst1_s32(pg_b32_4, C1, sum);
-                    prev = svld1_s32(pg_b32_4, C2);
-                    sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c2));
-                    svst1_s32(pg_b32_4, C2, sum);
-                    prev = svld1_s32(pg_b32_4, C3);
-                    sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c3));
-                    svst1_s32(pg_b32_4, C3, sum);
-                    prev = svld1_s32(pg_b32_4, C4);
-                    sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c4));
-                    svst1_s32(pg_b32_4, C4, sum);
-                    prev = svld1_s32(pg_b32_4, C5);
-                    sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c5));
-                    svst1_s32(pg_b32_4, C5, sum);
-                    prev = svld1_s32(pg_b32_4, C6);
-                    sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c6));
-                    svst1_s32(pg_b32_4, C6, sum);
-                    prev = svld1_s32(pg_b32_4, C7);
-                    sum = svadd_s32_x(pg_b32_4, prev, svreinterpret_s32_u32(acc03_c7));
-                    svst1_s32(pg_b32_4, C7, sum);
+                    svint32_t prev = MlasSveLoadInt32(pg_b32_4, C0);
+                    svint32_t sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c0));
+                    MlasSveStoreInt32(pg_b32_4, C0, sum);
+                    prev = MlasSveLoadInt32(pg_b32_4, C1);
+                    sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c1));
+                    MlasSveStoreInt32(pg_b32_4, C1, sum);
+                    prev = MlasSveLoadInt32(pg_b32_4, C2);
+                    sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c2));
+                    MlasSveStoreInt32(pg_b32_4, C2, sum);
+                    prev = MlasSveLoadInt32(pg_b32_4, C3);
+                    sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c3));
+                    MlasSveStoreInt32(pg_b32_4, C3, sum);
+                    prev = MlasSveLoadInt32(pg_b32_4, C4);
+                    sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c4));
+                    MlasSveStoreInt32(pg_b32_4, C4, sum);
+                    prev = MlasSveLoadInt32(pg_b32_4, C5);
+                    sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c5));
+                    MlasSveStoreInt32(pg_b32_4, C5, sum);
+                    prev = MlasSveLoadInt32(pg_b32_4, C6);
+                    sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c6));
+                    MlasSveStoreInt32(pg_b32_4, C6, sum);
+                    prev = MlasSveLoadInt32(pg_b32_4, C7);
+                    sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c7));
+                    MlasSveStoreInt32(pg_b32_4, C7, sum);
                 }
                 else{
                     // Row 0 (C0)
-                    svint32_t prev = svld1_s32(svwhilelt_b32(0,3), C0);
-                    svint32_t sum = svadd_s32_x(svwhilelt_b32(0,3), prev, svreinterpret_s32_u32(acc03_c0));
-                    svst1_s32(svwhilelt_b32(0,3), C0, sum);
-                    prev = svld1_s32(svwhilelt_b32(0,3), C1);
-                    sum = svadd_s32_x(svwhilelt_b32(0,3), prev, svreinterpret_s32_u32(acc03_c1));
-                    svst1_s32(svwhilelt_b32(0,3), C1, sum);
-                    prev = svld1_s32(svwhilelt_b32(0,3), C2);
-                    sum = svadd_s32_x(svwhilelt_b32(0,3), prev, svreinterpret_s32_u32(acc03_c2));
-                    svst1_s32(svwhilelt_b32(0,3), C2, sum);
-                    prev = svld1_s32(svwhilelt_b32(0,3), C3);
-                    sum = svadd_s32_x(svwhilelt_b32(0,3), prev, svreinterpret_s32_u32(acc03_c3));
-                    svst1_s32(svwhilelt_b32(0,3), C3, sum);
-                    prev = svld1_s32(svwhilelt_b32(0,3), C4);
-                    sum = svadd_s32_x(svwhilelt_b32(0,3), prev, svreinterpret_s32_u32(acc03_c4));
-                    svst1_s32(svwhilelt_b32(0,3), C4, sum);
-                    prev = svld1_s32(svwhilelt_b32(0,3), C5);
-                    sum = svadd_s32_x(svwhilelt_b32(0,3), prev, svreinterpret_s32_u32(acc03_c5));
-                    svst1_s32(svwhilelt_b32(0,3), C5, sum);
-                    prev = svld1_s32(svwhilelt_b32(0,3), C6);
-                    sum = svadd_s32_x(svwhilelt_b32(0,3), prev, svreinterpret_s32_u32(acc03_c6));
-                    svst1_s32(svwhilelt_b32(0,3), C6, sum);
-                    prev = svld1_s32(svwhilelt_b32(0,3), C7);
-                    sum = svadd_s32_x(svwhilelt_b32(0,3), prev, svreinterpret_s32_u32(acc03_c7));
-                    svst1_s32(svwhilelt_b32(0,3), C7, sum);
+                    svint32_t prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 3), C0);
+                    svint32_t sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, 3), prev, MlasSveReinterpretS32FromU32(acc03_c0));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C0, sum);
+                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 3), C1);
+                    sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, 3), prev, MlasSveReinterpretS32FromU32(acc03_c1));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C1, sum);
+                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 3), C2);
+                    sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, 3), prev, MlasSveReinterpretS32FromU32(acc03_c2));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C2, sum);
+                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 3), C3);
+                    sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, 3), prev, MlasSveReinterpretS32FromU32(acc03_c3));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C3, sum);
+                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 3), C4);
+                    sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, 3), prev, MlasSveReinterpretS32FromU32(acc03_c4));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C4, sum);
+                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 3), C5);
+                    sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, 3), prev, MlasSveReinterpretS32FromU32(acc03_c5));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C5, sum);
+                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 3), C6);
+                    sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, 3), prev, MlasSveReinterpretS32FromU32(acc03_c6));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C6, sum);
+                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 3), C7);
+                    sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, 3), prev, MlasSveReinterpretS32FromU32(acc03_c7));
+                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C7, sum);
                 }   
             }
         }
         else{
             if(isZeroPointB){
-                svst1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C0, svreinterpret_s32_u32(acc03_c0));
-                svst1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C1, svreinterpret_s32_u32(acc03_c1));
-                svst1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C2, svreinterpret_s32_u32(acc03_c2));
-                svst1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C3, svreinterpret_s32_u32(acc03_c3));
-                svst1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C4, svreinterpret_s32_u32(acc03_c4));
-                svst1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C5, svreinterpret_s32_u32(acc03_c5));
-                svst1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C6, svreinterpret_s32_u32(acc03_c6));
-                svst1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C7, svreinterpret_s32_u32(acc03_c7));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C0, MlasSveReinterpretS32FromU32(acc03_c0));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C1, MlasSveReinterpretS32FromU32(acc03_c1));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C2, MlasSveReinterpretS32FromU32(acc03_c2));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C3, MlasSveReinterpretS32FromU32(acc03_c3));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C4, MlasSveReinterpretS32FromU32(acc03_c4));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C5, MlasSveReinterpretS32FromU32(acc03_c5));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C6, MlasSveReinterpretS32FromU32(acc03_c6));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C7, MlasSveReinterpretS32FromU32(acc03_c7));
             }
             else{
                 // Row 0 (C0)
-                svint32_t prev = svld1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C0);
-                svint32_t sum = svadd_s32_x(svwhilelt_b32(0, std::min(int(cols_this), 2)), prev, svreinterpret_s32_u32(acc03_c0));
-                svst1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C0, sum);
-                prev = svld1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C1);
-                sum = svadd_s32_x(svwhilelt_b32(0, std::min(int(cols_this), 2)), prev, svreinterpret_s32_u32(acc03_c1));
-                svst1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C1, sum);
-                prev = svld1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C2);
-                sum = svadd_s32_x(svwhilelt_b32(0, std::min(int(cols_this), 2)), prev, svreinterpret_s32_u32(acc03_c2));
-                svst1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C2, sum);
-                prev = svld1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C3);
-                sum = svadd_s32_x(svwhilelt_b32(0, std::min(int(cols_this), 2)), prev, svreinterpret_s32_u32(acc03_c3));
-                svst1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C3, sum);
-                prev = svld1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C4);
-                sum = svadd_s32_x(svwhilelt_b32(0, std::min(int(cols_this), 2)), prev, svreinterpret_s32_u32(acc03_c4));
-                svst1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C4, sum);
-                prev = svld1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C5);
-                sum = svadd_s32_x(svwhilelt_b32(0, std::min(int(cols_this), 2)), prev, svreinterpret_s32_u32(acc03_c5));
-                svst1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C5, sum);
-                prev = svld1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C6);
-                sum = svadd_s32_x(svwhilelt_b32(0, std::min(int(cols_this), 2)), prev, svreinterpret_s32_u32(acc03_c6));
-                svst1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C6, sum);
-                prev = svld1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C7);
-                sum = svadd_s32_x(svwhilelt_b32(0, std::min(int(cols_this), 2)), prev, svreinterpret_s32_u32(acc03_c7));
-                svst1_s32(svwhilelt_b32(0, std::min(int(cols_this), 2)), C7, sum);
+                svint32_t prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C0);
+                svint32_t sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), prev, MlasSveReinterpretS32FromU32(acc03_c0));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C0, sum);
+                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C1);
+                sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), prev, MlasSveReinterpretS32FromU32(acc03_c1));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C1, sum);
+                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C2);
+                sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), prev, MlasSveReinterpretS32FromU32(acc03_c2));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C2, sum);
+                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C3);
+                sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), prev, MlasSveReinterpretS32FromU32(acc03_c3));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C3, sum);
+                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C4);
+                sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), prev, MlasSveReinterpretS32FromU32(acc03_c4));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C4, sum);
+                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C5);
+                sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), prev, MlasSveReinterpretS32FromU32(acc03_c5));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C5, sum);
+                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C6);
+                sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), prev, MlasSveReinterpretS32FromU32(acc03_c6));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C6, sum);
+                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C7);
+                sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), prev, MlasSveReinterpretS32FromU32(acc03_c7));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C7, sum);
             }
         }
         // Last 4 columns
@@ -1373,7 +1374,7 @@ size_t MlasSveQgemmU8X8KernelUmmlaAdd(const MLAS_GEMM_U8X8_KERNEL_UMMLA::PackedA
                               )
 {
     bool isZeroPointB = false;
-     if (svcntb() >= 32) {
+     if (MlasSveCntb() >= 32) {
         if (CountM >= 8) {
                 return Process8RowsTest256(A, B, C, PackedCountK, CountM, CountN, ldc,
                                         RowSumBuffer, ColumnSumBuffer, ZeroPointB, isZeroPointB);
@@ -1409,7 +1410,7 @@ size_t MlasSveQgemmU8X8KernelUmmlaZero(const MLAS_GEMM_U8X8_KERNEL_UMMLA::Packed
                               )
 {
     bool isZeroPointB = true;
-    if(svcntb() >= 32){
+    if(MlasSveCntb() >= 32){
         if (CountM >= 8) {
             return Process8RowsTest256(A, B, C, PackedCountK, CountM, CountN, ldc,
                                     RowSumBuffer, ColumnSumBuffer, ZeroPointB, isZeroPointB);

--- a/onnxruntime/core/mlas/lib/sve/qgemm_sve256.cpp
+++ b/onnxruntime/core/mlas/lib/sve/qgemm_sve256.cpp
@@ -180,17 +180,6 @@ MLAS_FORCEINLINE size_t Process1Row(
                 MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C_ptr + 4, sum);
             }
         }
-        else if(cols_this > 2){
-            if(HasZeroPointB){
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C_ptr, MlasSveReinterpretS32FromU32(acc03));
-            }
-            else{
-                // Row 0 (C0)
-                svint32_t prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this), C_ptr);
-                svint32_t sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this), prev, MlasSveReinterpretS32FromU32(acc03));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C_ptr, sum);
-            }
-        }
         else{
             if(HasZeroPointB){
                 MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C_ptr, MlasSveReinterpretS32FromU32(acc03));
@@ -371,21 +360,6 @@ MLAS_FORCEINLINE size_t Process2Rows(
                 prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this - 4), C1 + 4);
                 sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this - 4), prev, MlasSveReinterpretS32FromU32(acc47_c1));
                 MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C1 + 4, sum);
-            }
-        }
-        else if(cols_this > 2){
-            if(HasZeroPointB){
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C0, MlasSveReinterpretS32FromU32(acc03_c0));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C1, MlasSveReinterpretS32FromU32(acc03_c1));
-            }
-            else{
-                // Row 0 (C0)
-                svint32_t prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this), C0);
-                svint32_t sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this), prev, MlasSveReinterpretS32FromU32(acc03_c0));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C0, sum);
-                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this), C1);
-                sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this), prev, MlasSveReinterpretS32FromU32(acc03_c1));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C1, sum);   
             }
         }
         else{
@@ -624,35 +598,12 @@ MLAS_FORCEINLINE size_t Process4Rows(
                 MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C3 + 4, sum);
             }
         }
-        else if(cols_this > 2){
+        else{
             if(HasZeroPointB){
                 MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C0, MlasSveReinterpretS32FromU32(acc03_c0));
                 MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C1, MlasSveReinterpretS32FromU32(acc03_c1));
                 MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C2, MlasSveReinterpretS32FromU32(acc03_c2));
                 MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C3, MlasSveReinterpretS32FromU32(acc03_c3));
-            }
-            else{
-                // Row 0 (C0)
-                svint32_t prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this), C0);
-                svint32_t sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this), prev, MlasSveReinterpretS32FromU32(acc03_c0));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C0, sum);
-                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this), C1);
-                sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this), prev, MlasSveReinterpretS32FromU32(acc03_c1));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C1, sum);
-                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this), C2);
-                sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this), prev, MlasSveReinterpretS32FromU32(acc03_c2));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C2, sum);
-                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this), C3);
-                sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this), prev, MlasSveReinterpretS32FromU32(acc03_c3));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C3, sum);
-            }
-        }
-        else{
-            if(HasZeroPointB){
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C0, MlasSveReinterpretS32FromU32(acc03_c0));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C1, MlasSveReinterpretS32FromU32(acc03_c1));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C2, MlasSveReinterpretS32FromU32(acc03_c2));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C3, MlasSveReinterpretS32FromU32(acc03_c3));
             }
             else{
                 // Row 0 (C0)
@@ -985,45 +936,6 @@ MLAS_FORCEINLINE size_t Process8Rows(
                 sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this - 4), prev, MlasSveReinterpretS32FromU32(acc47_c7));
                 MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C7 + 4, sum);
             }
-        }
-        else if(cols_this > 2){
-            if(HasZeroPointB){
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C0, MlasSveReinterpretS32FromU32(acc03_c0));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C1, MlasSveReinterpretS32FromU32(acc03_c1));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C2, MlasSveReinterpretS32FromU32(acc03_c2));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C3, MlasSveReinterpretS32FromU32(acc03_c3));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C4, MlasSveReinterpretS32FromU32(acc03_c4));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C5, MlasSveReinterpretS32FromU32(acc03_c5));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C6, MlasSveReinterpretS32FromU32(acc03_c6));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C7, MlasSveReinterpretS32FromU32(acc03_c7));
-            }
-            else{
-                // Row 0 (C0)
-                svint32_t prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this), C0);
-                svint32_t sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this), prev, MlasSveReinterpretS32FromU32(acc03_c0));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C0, sum);
-                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this), C1);
-                sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this), prev, MlasSveReinterpretS32FromU32(acc03_c1));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C1, sum);
-                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this), C2);
-                sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this), prev, MlasSveReinterpretS32FromU32(acc03_c2));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C2, sum);
-                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this), C3);
-                sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this), prev, MlasSveReinterpretS32FromU32(acc03_c3));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C3, sum);
-                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this), C4);
-                sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this), prev, MlasSveReinterpretS32FromU32(acc03_c4));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C4, sum);
-                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this), C5);
-                sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this), prev, MlasSveReinterpretS32FromU32(acc03_c5));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C5, sum);
-                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this), C6);
-                sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this), prev, MlasSveReinterpretS32FromU32(acc03_c6));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C6, sum);
-                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this), C7);
-                sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this), prev, MlasSveReinterpretS32FromU32(acc03_c7));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C7, sum);
-            }  
         }
         else{
             if(HasZeroPointB){

--- a/onnxruntime/core/mlas/lib/sve/qgemm_sve256.cpp
+++ b/onnxruntime/core/mlas/lib/sve/qgemm_sve256.cpp
@@ -10,6 +10,34 @@
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+
+extern "C" {
+
+size_t MLASCALL
+MlasGemmU8X8KernelUmmlaZero(const uint8_t* A,
+                            const uint8_t* B,
+                            int32_t* C,
+                            size_t PackedCountK,
+                            size_t CountM,
+                            size_t CountN,
+                            size_t ldc,
+                            const int32_t* RowSumVector,
+                            const int32_t* ColumnSumVector,
+                            const int32_t* ZeroPointB);
+
+size_t MLASCALL
+MlasGemmU8X8KernelUmmlaAdd(const uint8_t* A,
+                           const uint8_t* B,
+                           int32_t* C,
+                           size_t PackedCountK,
+                           size_t CountM,
+                           size_t CountN,
+                           size_t ldc,
+                           const int32_t* RowSumVector,
+                           const int32_t* ColumnSumVector,
+                           const int32_t* ZeroPointB);
+}
+
 struct MLAS_GEMM_U8X8_KERNEL_UMMLA {
     using PackedAType = uint8_t;
     using PackedBType = uint8_t;
@@ -62,7 +90,6 @@ size_t Process1RowTest256(
         // svint32_t acc00 = svdup_s32(0); // for columns 0–3
         // svint32_t acc01 = svdup_s32(0); // for columns 4–7
 
-        // can this give seg faults when #Columns are not checked? 
         svint32_t zpb_0_3, col_0_3, zpb_4_7, col_4_7;
         svint64_t zpb64_0_3, col64_0_3, zpb64_4_7, col64_4_7;
         // --- Columns 0–3 ---
@@ -1346,20 +1373,26 @@ size_t MlasSveQgemmU8X8KernelUmmlaAdd(const MLAS_GEMM_U8X8_KERNEL_UMMLA::PackedA
                               )
 {
     bool isZeroPointB = false;
-    if (CountM >= 8) {
-        return Process8RowsTest256(A, B, C, PackedCountK, CountM, CountN, ldc,
+     if (svcntb() >= 32) {
+        if (CountM >= 8) {
+                return Process8RowsTest256(A, B, C, PackedCountK, CountM, CountN, ldc,
+                                        RowSumBuffer, ColumnSumBuffer, ZeroPointB, isZeroPointB);
+        } 
+        else if (CountM >= 4) {
+            return Process4RowsTest256(A, B, C, PackedCountK, CountM, CountN, ldc,
+                                    RowSumBuffer, ColumnSumBuffer, ZeroPointB, isZeroPointB);
+        } else if (CountM >= 2) {
+            return Process2RowsTest256(A, B, C, PackedCountK, CountM, CountN, ldc,
+                                    RowSumBuffer, ColumnSumBuffer, ZeroPointB, isZeroPointB);
+        } else if (CountM >= 1) {
+            return Process1RowTest256(A, B, C, PackedCountK, CountM, CountN, ldc,
                                 RowSumBuffer, ColumnSumBuffer, ZeroPointB, isZeroPointB);
-    } 
-    else if (CountM >= 4) {
-        return Process4RowsTest256(A, B, C, PackedCountK, CountM, CountN, ldc,
-                                RowSumBuffer, ColumnSumBuffer, ZeroPointB, isZeroPointB);
-    } else if (CountM >= 2) {
-        return Process2RowsTest256(A, B, C, PackedCountK, CountM, CountN, ldc,
-                                RowSumBuffer, ColumnSumBuffer, ZeroPointB, isZeroPointB);
-    } else if (CountM >= 1) {
-        return Process1RowTest256(A, B, C, PackedCountK, CountM, CountN, ldc,
-                               RowSumBuffer, ColumnSumBuffer, ZeroPointB, isZeroPointB);
-    }
+        }
+     }
+     else{
+        MlasGemmU8X8KernelUmmlaAdd(A, B, C, PackedCountK, CountM, CountN, ldc,
+                RowSumBuffer, ColumnSumBuffer, ZeroPointB);
+     };
     return 0; // Unsupported CountM
 }
 
@@ -1376,21 +1409,27 @@ size_t MlasSveQgemmU8X8KernelUmmlaZero(const MLAS_GEMM_U8X8_KERNEL_UMMLA::Packed
                               )
 {
     bool isZeroPointB = true;
-    if (CountM >= 8) {
-        return Process8RowsTest256(A, B, C, PackedCountK, CountM, CountN, ldc,
-                                RowSumBuffer, ColumnSumBuffer, ZeroPointB, isZeroPointB);
-    }
-    else if (CountM >= 4) {
-        return Process4RowsTest256(A, B, C, PackedCountK, CountM, CountN, ldc,
-                                RowSumBuffer, ColumnSumBuffer, ZeroPointB, isZeroPointB);
-        
-    } else if (CountM >= 2) {
-        return Process2RowsTest256(A, B, C, PackedCountK, CountM, CountN, ldc,
-                                RowSumBuffer, ColumnSumBuffer, ZeroPointB, isZeroPointB);
+    if(svcntb() >= 32){
+        if (CountM >= 8) {
+            return Process8RowsTest256(A, B, C, PackedCountK, CountM, CountN, ldc,
+                                    RowSumBuffer, ColumnSumBuffer, ZeroPointB, isZeroPointB);
+        }
+        else if (CountM >= 4) {
+            return Process4RowsTest256(A, B, C, PackedCountK, CountM, CountN, ldc,
+                                    RowSumBuffer, ColumnSumBuffer, ZeroPointB, isZeroPointB);
+            
+        } else if (CountM >= 2) {
+            return Process2RowsTest256(A, B, C, PackedCountK, CountM, CountN, ldc,
+                                    RowSumBuffer, ColumnSumBuffer, ZeroPointB, isZeroPointB);
 
-    } else if (CountM >= 1) {
-        return Process1RowTest256(A, B, C, PackedCountK, CountM, CountN, ldc,
-                               RowSumBuffer, ColumnSumBuffer, ZeroPointB, isZeroPointB);
+        } else if (CountM >= 1) {
+            return Process1RowTest256(A, B, C, PackedCountK, CountM, CountN, ldc,
+                                RowSumBuffer, ColumnSumBuffer, ZeroPointB, isZeroPointB);
+        }
+    }
+    else{
+        MlasGemmU8X8KernelUmmlaZero(A, B, C, PackedCountK, CountM, CountN, ldc,
+                RowSumBuffer, ColumnSumBuffer, ZeroPointB);
     }
     return 0; // Unsupported CountM
 }

--- a/onnxruntime/core/mlas/lib/sve/qgemm_sve256.cpp
+++ b/onnxruntime/core/mlas/lib/sve/qgemm_sve256.cpp
@@ -146,24 +146,7 @@ MLAS_FORCEINLINE size_t Process1Row(
             acc47 = MlasSveTblU32(acc47, idx);
         // First 4 columns
         // 
-        if(cols_this > 6){
-            if(HasZeroPointB){
-                MlasSveStoreInt32(pg_b32_4, C_ptr, MlasSveReinterpretS32FromU32(acc03));
-
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C_ptr + 4, MlasSveReinterpretS32FromU32(acc47));          
-            }
-            else{
-                // Row 0 (C0)
-                svint32_t prev = MlasSveLoadInt32(pg_b32_4, C_ptr);
-                svint32_t sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03));
-                MlasSveStoreInt32(pg_b32_4, C_ptr, sum);
-
-                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this - 4), C_ptr + 4);
-                sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this - 4), prev, MlasSveReinterpretS32FromU32(acc47));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C_ptr + 4, sum);
-            }
-        }
-        else if(cols_this > 4){
+        if(cols_this > 4){
             if(HasZeroPointB){
                 MlasSveStoreInt32(pg_b32_4, C_ptr, MlasSveReinterpretS32FromU32(acc03));
         
@@ -312,32 +295,7 @@ MLAS_FORCEINLINE size_t Process2Rows(
         }
         // First 4 columns
         // 
-        if(cols_this > 6){
-            if(HasZeroPointB){
-                MlasSveStoreInt32(pg_b32_4, C0, MlasSveReinterpretS32FromU32(acc03_c0));
-                MlasSveStoreInt32(pg_b32_4, C1, MlasSveReinterpretS32FromU32(acc03_c1));
-
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C0 + 4, MlasSveReinterpretS32FromU32(acc47_c0));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C1 + 4, MlasSveReinterpretS32FromU32(acc47_c1));
-            }        
-            else{
-                // Row 0 (C0)
-                svint32_t prev = MlasSveLoadInt32(pg_b32_4, C0);
-                svint32_t sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c0));
-                MlasSveStoreInt32(pg_b32_4, C0, sum);
-                prev = MlasSveLoadInt32(pg_b32_4, C1);
-                sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c1));
-                MlasSveStoreInt32(pg_b32_4, C1, sum);
-                // Row 1 (C1)
-                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this - 4), C0 + 4);
-                sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this - 4), prev, MlasSveReinterpretS32FromU32(acc47_c0));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C0 + 4, sum);
-                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this - 4), C1 + 4);
-                sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this - 4), prev, MlasSveReinterpretS32FromU32(acc47_c1));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C1 + 4, sum);
-            }
-        }
-        else if(cols_this > 4){
+        if(cols_this > 4){
             if(HasZeroPointB){
                 MlasSveStoreInt32(pg_b32_4, C0, MlasSveReinterpretS32FromU32(acc03_c0));
                 MlasSveStoreInt32(pg_b32_4, C1, MlasSveReinterpretS32FromU32(acc03_c1));
@@ -515,59 +473,17 @@ MLAS_FORCEINLINE size_t Process4Rows(
         }
         // First 4 columns
         // 
-        if(cols_this > 6){
+        if(cols_this > 4){
             if(HasZeroPointB){
                 MlasSveStoreInt32(pg_b32_4, C0, MlasSveReinterpretS32FromU32(acc03_c0));
                 MlasSveStoreInt32(pg_b32_4, C1, MlasSveReinterpretS32FromU32(acc03_c1));
                 MlasSveStoreInt32(pg_b32_4, C2, MlasSveReinterpretS32FromU32(acc03_c2));
                 MlasSveStoreInt32(pg_b32_4, C3, MlasSveReinterpretS32FromU32(acc03_c3));
-                
+
                 MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C0 + 4, MlasSveReinterpretS32FromU32(acc47_c0));
                 MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C1 + 4, MlasSveReinterpretS32FromU32(acc47_c1));
                 MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C2 + 4, MlasSveReinterpretS32FromU32(acc47_c2));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C3 + 4, MlasSveReinterpretS32FromU32(acc47_c3));           
-            }
-            else{
-                // Row 0 (C0)
-                svint32_t prev = MlasSveLoadInt32(pg_b32_4, C0);
-                svint32_t sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c0));
-                MlasSveStoreInt32(pg_b32_4, C0, sum);
-                prev = MlasSveLoadInt32(pg_b32_4, C1);
-                sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c1));
-                MlasSveStoreInt32(pg_b32_4, C1, sum);
-                prev = MlasSveLoadInt32(pg_b32_4, C2);
-                sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c2));
-                MlasSveStoreInt32(pg_b32_4, C2, sum);
-                prev = MlasSveLoadInt32(pg_b32_4, C3);
-                sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c3));
-                MlasSveStoreInt32(pg_b32_4, C3, sum);
-
-                // Row 1 (C1)
-                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this - 4), C0 + 4);
-                sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this - 4), prev, MlasSveReinterpretS32FromU32(acc47_c0));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C0 + 4, sum);
-                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this - 4), C1 + 4);
-                sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this - 4), prev, MlasSveReinterpretS32FromU32(acc47_c1));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C1 + 4, sum);
-                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this - 4), C2 + 4);
-                sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this - 4), prev, MlasSveReinterpretS32FromU32(acc47_c2));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C2 + 4, sum);
-                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this - 4), C3 + 4);
-                sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this - 4), prev, MlasSveReinterpretS32FromU32(acc47_c3));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C3 + 4, sum);
-            }
-        }
-        else if(cols_this > 4){
-            if(HasZeroPointB){
-                MlasSveStoreInt32(pg_b32_4, C0, MlasSveReinterpretS32FromU32(acc03_c0));
-                MlasSveStoreInt32(pg_b32_4, C1, MlasSveReinterpretS32FromU32(acc03_c1));
-                MlasSveStoreInt32(pg_b32_4, C2, MlasSveReinterpretS32FromU32(acc03_c2));
-                MlasSveStoreInt32(pg_b32_4, C3, MlasSveReinterpretS32FromU32(acc03_c3));
-
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this -4), C0 + 4, MlasSveReinterpretS32FromU32(acc47_c0));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this -4), C1 + 4, MlasSveReinterpretS32FromU32(acc47_c1));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this -4), C2 + 4, MlasSveReinterpretS32FromU32(acc47_c2));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this -4), C3 + 4, MlasSveReinterpretS32FromU32(acc47_c3));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C3 + 4, MlasSveReinterpretS32FromU32(acc47_c3));
             }
             else{
                 // Row 0 (C0)
@@ -788,82 +704,7 @@ MLAS_FORCEINLINE size_t Process8Rows(
         }
         // First 4 columns
         // 
-        if(cols_this > 6){
-            if(HasZeroPointB){
-                MlasSveStoreInt32(pg_b32_4, C0, MlasSveReinterpretS32FromU32(acc03_c0));
-                MlasSveStoreInt32(pg_b32_4, C1, MlasSveReinterpretS32FromU32(acc03_c1));
-                MlasSveStoreInt32(pg_b32_4, C2, MlasSveReinterpretS32FromU32(acc03_c2));
-                MlasSveStoreInt32(pg_b32_4, C3, MlasSveReinterpretS32FromU32(acc03_c3));
-                MlasSveStoreInt32(pg_b32_4, C4, MlasSveReinterpretS32FromU32(acc03_c4));
-                MlasSveStoreInt32(pg_b32_4, C5, MlasSveReinterpretS32FromU32(acc03_c5));
-                MlasSveStoreInt32(pg_b32_4, C6, MlasSveReinterpretS32FromU32(acc03_c6));
-                MlasSveStoreInt32(pg_b32_4, C7, MlasSveReinterpretS32FromU32(acc03_c7));
-                
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C0 + 4, MlasSveReinterpretS32FromU32(acc47_c0));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C1 + 4, MlasSveReinterpretS32FromU32(acc47_c1));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C2 + 4, MlasSveReinterpretS32FromU32(acc47_c2));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C3 + 4, MlasSveReinterpretS32FromU32(acc47_c3));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C4 + 4, MlasSveReinterpretS32FromU32(acc47_c4));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C5 + 4, MlasSveReinterpretS32FromU32(acc47_c5));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C6 + 4, MlasSveReinterpretS32FromU32(acc47_c6));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C7 + 4, MlasSveReinterpretS32FromU32(acc47_c7));
-                          
-            }
-            else{
-                // Row 0 (C0)
-                svint32_t prev = MlasSveLoadInt32(pg_b32_4, C0);
-                svint32_t sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c0));
-                MlasSveStoreInt32(pg_b32_4, C0, sum);
-                prev = MlasSveLoadInt32(pg_b32_4, C1);
-                sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c1));
-                MlasSveStoreInt32(pg_b32_4, C1, sum);
-                prev = MlasSveLoadInt32(pg_b32_4, C2);
-                sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c2));
-                MlasSveStoreInt32(pg_b32_4, C2, sum);
-                prev = MlasSveLoadInt32(pg_b32_4, C3);
-                sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c3));
-                MlasSveStoreInt32(pg_b32_4, C3, sum);
-                prev = MlasSveLoadInt32(pg_b32_4, C4);
-                sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c4));
-                MlasSveStoreInt32(pg_b32_4, C4, sum);
-                prev = MlasSveLoadInt32(pg_b32_4, C5);
-                sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c5));
-                MlasSveStoreInt32(pg_b32_4, C5, sum);
-                prev = MlasSveLoadInt32(pg_b32_4, C6);
-                sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c6));
-                MlasSveStoreInt32(pg_b32_4, C6, sum);
-                prev = MlasSveLoadInt32(pg_b32_4, C7);
-                sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c7));
-                MlasSveStoreInt32(pg_b32_4, C7, sum);
-                // Row 1 (C1)
-                
-                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this - 4), C0 + 4);
-                sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this - 4), prev, MlasSveReinterpretS32FromU32(acc47_c0));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C0 + 4, sum);
-                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this - 4), C1 + 4);
-                sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this - 4), prev, MlasSveReinterpretS32FromU32(acc47_c1));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C1 + 4, sum);
-                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this - 4), C2 + 4);
-                sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this - 4), prev, MlasSveReinterpretS32FromU32(acc47_c2));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C2 + 4, sum);
-                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this - 4), C3 + 4);
-                sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this - 4), prev, MlasSveReinterpretS32FromU32(acc47_c3));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C3 + 4, sum);
-                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this - 4), C4 + 4);
-                sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this - 4), prev, MlasSveReinterpretS32FromU32(acc47_c4));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C4 + 4, sum);
-                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this - 4), C5 + 4);
-                sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this - 4), prev, MlasSveReinterpretS32FromU32(acc47_c5));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C5 + 4, sum);
-                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this - 4), C6 + 4);
-                sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this - 4), prev, MlasSveReinterpretS32FromU32(acc47_c6));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C6 + 4, sum);
-                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this - 4), C7 + 4);
-                sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this - 4), prev, MlasSveReinterpretS32FromU32(acc47_c7));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C7 + 4, sum);
-            }
-        }
-        else if(cols_this > 4){
+        if(cols_this > 4){
             if(HasZeroPointB){
                 MlasSveStoreInt32(pg_b32_4, C0, MlasSveReinterpretS32FromU32(acc03_c0));
                 MlasSveStoreInt32(pg_b32_4, C1, MlasSveReinterpretS32FromU32(acc03_c1));

--- a/onnxruntime/core/mlas/lib/sve/qgemm_sve256.cpp
+++ b/onnxruntime/core/mlas/lib/sve/qgemm_sve256.cpp
@@ -63,7 +63,7 @@ MLAS_FORCEINLINE size_t Process1Row(
     // VL = 256 → int32 lanes = 8 → process columns in groups of 4
     //------------------------------------------------------------------
     svbool_t pg_b32_4 = MlasSveWhileLtB32(0, 4);  // stores 4 output columns
-    svbool_t pg_b32_8 = MlasSvePtrueB32();  // full accumulator lanes
+    svbool_t pg_b32_8 = MlasSveWhileLtB32(0, 8);  // full accumulator lanes
     svbool_t pg_b8_32 = MlasSveWhileLtB8(0, 32); // loads 32 bytes from A/B
     svuint32_t acc03, acc47;
 
@@ -87,8 +87,6 @@ MLAS_FORCEINLINE size_t Process1Row(
         // Create ZPB and ColumnSum interleaved groups:
         //   VL=256: 8 lanes → represent 4 output columns at once
         //------------------------------------------------------------------
-        // svint32_t acc00 = MlasSveBroadcastInt32(0); // for columns 0–3
-        // svint32_t acc01 = MlasSveBroadcastInt32(0); // for columns 4–7
 
         svint32_t zpb_0_3, col_0_3, zpb_4_7, col_4_7;
         svint64_t zpb64_0_3, col64_0_3, zpb64_4_7, col64_4_7;
@@ -103,7 +101,7 @@ MLAS_FORCEINLINE size_t Process1Row(
         col_0_3 = MlasSveLoadInt32(pg_b32_4, ColumnSumBuffer);
         col64_0_3 = MlasSveReinterpretS64FromS32(col_0_3);
         col_0_3 = MlasSveReinterpretS32FromS64(MlasSveZip1S64(col64_0_3, col64_0_3));
-        acc03 = MlasSveReinterpretU32FromS32(MlasSveAddInt32X(pg_b32_8, MlasSveMulInt32(pg_b32_8, rowSumVec, zpb_0_3), col_0_3));
+        acc03 = MlasSveReinterpretU32FromS32(MlasSveMultiplyAddInt32(pg_b32_8, rowSumVec, zpb_0_3, col_0_3));
         // --- Columns 4–7 ---
         if (cols_this > 4) {
             if (ZeroPointB){
@@ -117,8 +115,7 @@ MLAS_FORCEINLINE size_t Process1Row(
             col_4_7 = MlasSveLoadInt32(pg_b32_4, ColumnSumBuffer + 4);
             col64_4_7 = MlasSveReinterpretS64FromS32(col_4_7);
             col_4_7 = MlasSveReinterpretS32FromS64(MlasSveZip1S64(col64_4_7, col64_4_7));
-            // acc47 = MlasSveReinterpretU32FromS32(svmad_s32_x(pg_b32_4, rowSumVec, zpb_4_7, col_4_7));
-            acc47 = MlasSveReinterpretU32FromS32(MlasSveAddInt32X(pg_b32_8, MlasSveMulInt32(pg_b32_8, rowSumVec, zpb_4_7), col_4_7));
+            acc47 = MlasSveReinterpretU32FromS32(MlasSveMultiplyAddInt32(pg_b32_8, rowSumVec, zpb_4_7, col_4_7));
         }
         //------------------------------------------------------------------
         // K loop
@@ -152,12 +149,8 @@ MLAS_FORCEINLINE size_t Process1Row(
         if(cols_this > 6){
             if(HasZeroPointB){
                 MlasSveStoreInt32(pg_b32_4, C_ptr, MlasSveReinterpretS32FromU32(acc03));
-                if(cols_this >= 8){
-                    MlasSveStoreInt32(pg_b32_4, C_ptr + 4, MlasSveReinterpretS32FromU32(acc47));
-                }
-                else{
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C_ptr + 4, MlasSveReinterpretS32FromU32(acc47));
-                }            
+
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C_ptr + 4, MlasSveReinterpretS32FromU32(acc47));          
             }
             else{
                 // Row 0 (C0)
@@ -165,79 +158,48 @@ MLAS_FORCEINLINE size_t Process1Row(
                 svint32_t sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03));
                 MlasSveStoreInt32(pg_b32_4, C_ptr, sum);
 
-                // Row 1 (C1)
-                if(cols_this >= 8){
-                    prev = MlasSveLoadInt32(pg_b32_4, C_ptr + 4);
-                    sum  = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc47));
-                    MlasSveStoreInt32(pg_b32_4, C_ptr + 4, sum);
-                }
-                else{
-                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 3), C_ptr + 4);
-                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 3), prev, MlasSveReinterpretS32FromU32(acc47));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C_ptr + 4, sum);
-                }
+                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this - 4), C_ptr + 4);
+                sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this - 4), prev, MlasSveReinterpretS32FromU32(acc47));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C_ptr + 4, sum);
             }
         }
         else if(cols_this > 4){
             if(HasZeroPointB){
                 MlasSveStoreInt32(pg_b32_4, C_ptr, MlasSveReinterpretS32FromU32(acc03));
-                if(cols_this >= 6){
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 2), C_ptr + 4, MlasSveReinterpretS32FromU32(acc47));
-                }
-                else{
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 1), C_ptr + 4, MlasSveReinterpretS32FromU32(acc47));
-                }
+        
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C_ptr + 4, MlasSveReinterpretS32FromU32(acc47));
             }
             else{
                 // Row 0 (C0)
                 svint32_t prev = MlasSveLoadInt32(pg_b32_4, C_ptr);
                 svint32_t sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03));
                 MlasSveStoreInt32(pg_b32_4, C_ptr, sum);
-                if(cols_this >= 6){
-                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 2), C_ptr + 4);
-                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 2), prev, MlasSveReinterpretS32FromU32(acc47));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 2), C_ptr + 4, sum);
-                }
-                else{
-                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 1), C_ptr + 4);
-                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 1), prev, MlasSveReinterpretS32FromU32(acc47));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 1), C_ptr + 4, sum);
-                }
+            
+                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this - 4), C_ptr + 4);
+                sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this - 4), prev, MlasSveReinterpretS32FromU32(acc47));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C_ptr + 4, sum);
             }
         }
         else if(cols_this > 2){
             if(HasZeroPointB){
-                if(cols_this >= 4){
-                    MlasSveStoreInt32(pg_b32_4, C_ptr, MlasSveReinterpretS32FromU32(acc03));
-                }
-                else{
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C_ptr, MlasSveReinterpretS32FromU32(acc03));
-                }
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C_ptr, MlasSveReinterpretS32FromU32(acc03));
             }
             else{
-                if(cols_this >= 4){
-                    // Row 0 (C0)
-                    svint32_t prev = MlasSveLoadInt32(pg_b32_4, C_ptr);
-                    svint32_t sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03));
-                    MlasSveStoreInt32(pg_b32_4, C_ptr, sum);
-                }
-                else{
-                    // Row 0 (C0)
-                    svint32_t prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 3), C_ptr);
-                    svint32_t sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, 3), prev, MlasSveReinterpretS32FromU32(acc03));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C_ptr, sum);
-                }   
+                // Row 0 (C0)
+                svint32_t prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this), C_ptr);
+                svint32_t sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this), prev, MlasSveReinterpretS32FromU32(acc03));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C_ptr, sum);
             }
         }
         else{
             if(HasZeroPointB){
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C_ptr, MlasSveReinterpretS32FromU32(acc03));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C_ptr, MlasSveReinterpretS32FromU32(acc03));
             }
             else{
                 // Row 0 (C0)
-                svint32_t prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C_ptr);
-                svint32_t sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), prev, MlasSveReinterpretS32FromU32(acc03));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C_ptr, sum);
+                svint32_t prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this), C_ptr);
+                svint32_t sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this), prev, MlasSveReinterpretS32FromU32(acc03));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C_ptr, sum);
             }
         }
         // Last 4 columns
@@ -274,11 +236,10 @@ MLAS_FORCEINLINE size_t Process2Rows(
     // VL = 256 → int32 lanes = 8 → process columns in groups of 4
     //------------------------------------------------------------------
     svbool_t pg_b32_4 = MlasSveWhileLtB32(0, 4);  // stores 4 output columns
-    svbool_t pg_b32_8 = MlasSvePtrueB32();  // full accumulator lanes
+    svbool_t pg_b32_8 = MlasSveWhileLtB32(0, 8);  // full accumulator lanes
     svbool_t pg_b8_32 = MlasSveWhileLtB8(0, 32); // loads 32 bytes from A/B
     svuint32_t acc03, acc47;
 
-    // const int32_t rowsum = RowSumBuffer[0];
     svint32_t rowSumVec, r0, r1;
     r0 = MlasSveBroadcastInt32(RowSumBuffer[0]);
     r1 = MlasSveBroadcastInt32(RowSumBuffer[1]);
@@ -312,7 +273,7 @@ MLAS_FORCEINLINE size_t Process2Rows(
         col_0_3 = MlasSveLoadInt32(pg_b32_4, ColumnSumBuffer);
         col64_0_3 = MlasSveReinterpretS64FromS32(col_0_3);
         col_0_3 = MlasSveReinterpretS32FromS64(MlasSveZip1S64(col64_0_3, col64_0_3));
-        acc03 = MlasSveReinterpretU32FromS32(MlasSveAddInt32X(pg_b32_8, MlasSveMulInt32(pg_b32_8, rowSumVec, zpb_0_3), col_0_3));
+        acc03 = MlasSveReinterpretU32FromS32(MlasSveMultiplyAddInt32(pg_b32_8, rowSumVec, zpb_0_3, col_0_3));
         // --- Columns 4–7 ---
         if (cols_this > 4) {
             if (ZeroPointB){
@@ -326,8 +287,7 @@ MLAS_FORCEINLINE size_t Process2Rows(
             col_4_7 = MlasSveLoadInt32(pg_b32_4, ColumnSumBuffer + 4);
             col64_4_7 = MlasSveReinterpretS64FromS32(col_4_7);
             col_4_7 = MlasSveReinterpretS32FromS64(MlasSveZip1S64(col64_4_7, col64_4_7));
-            // acc47 = MlasSveReinterpretU32FromS32(svmad_s32_x(pg_b32_4, rowSumVec, zpb_4_7, col_4_7));
-            acc47 = MlasSveReinterpretU32FromS32(MlasSveAddInt32X(pg_b32_8, MlasSveMulInt32(pg_b32_8, rowSumVec, zpb_4_7), col_4_7));
+            acc47 = MlasSveReinterpretU32FromS32(MlasSveMultiplyAddInt32(pg_b32_8, rowSumVec, zpb_4_7, col_4_7));
         }
         //------------------------------------------------------------------
         // K loop
@@ -367,15 +327,10 @@ MLAS_FORCEINLINE size_t Process2Rows(
             if(HasZeroPointB){
                 MlasSveStoreInt32(pg_b32_4, C0, MlasSveReinterpretS32FromU32(acc03_c0));
                 MlasSveStoreInt32(pg_b32_4, C1, MlasSveReinterpretS32FromU32(acc03_c1));
-                if(cols_this >= 8){
-                    MlasSveStoreInt32(pg_b32_4, C0 + 4, MlasSveReinterpretS32FromU32(acc47_c0));
-                    MlasSveStoreInt32(pg_b32_4, C1 + 4, MlasSveReinterpretS32FromU32(acc47_c1));
-                }
-                else{
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C0 + 4, MlasSveReinterpretS32FromU32(acc47_c0));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C1 + 4, MlasSveReinterpretS32FromU32(acc47_c1));
-                }            
-            }
+
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C0 + 4, MlasSveReinterpretS32FromU32(acc47_c0));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C1 + 4, MlasSveReinterpretS32FromU32(acc47_c1));
+            }        
             else{
                 // Row 0 (C0)
                 svint32_t prev = MlasSveLoadInt32(pg_b32_4, C0);
@@ -385,36 +340,21 @@ MLAS_FORCEINLINE size_t Process2Rows(
                 sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c1));
                 MlasSveStoreInt32(pg_b32_4, C1, sum);
                 // Row 1 (C1)
-                if(cols_this >= 8){
-                    prev = MlasSveLoadInt32(pg_b32_4, C0 + 4);
-                    sum  = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc47_c0));
-                    MlasSveStoreInt32(pg_b32_4, C0 + 4, sum);
-                    prev = MlasSveLoadInt32(pg_b32_4, C1 + 4);
-                    sum  = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc47_c1));
-                    MlasSveStoreInt32(pg_b32_4, C1 + 4, sum);
-                }
-                else{
-                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 3), C0 + 4);
-                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 3), prev, MlasSveReinterpretS32FromU32(acc47_c0));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C0 + 4, sum);
-                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 3), C1 + 4);
-                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 3), prev, MlasSveReinterpretS32FromU32(acc47_c1));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C1 + 4, sum);
-                }
+                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this - 4), C0 + 4);
+                sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this - 4), prev, MlasSveReinterpretS32FromU32(acc47_c0));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C0 + 4, sum);
+                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this - 4), C1 + 4);
+                sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this - 4), prev, MlasSveReinterpretS32FromU32(acc47_c1));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C1 + 4, sum);
             }
         }
         else if(cols_this > 4){
             if(HasZeroPointB){
                 MlasSveStoreInt32(pg_b32_4, C0, MlasSveReinterpretS32FromU32(acc03_c0));
                 MlasSveStoreInt32(pg_b32_4, C1, MlasSveReinterpretS32FromU32(acc03_c1));
-                if(cols_this >= 6){
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 2), C0 + 4, MlasSveReinterpretS32FromU32(acc47_c0));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 2), C1 + 4, MlasSveReinterpretS32FromU32(acc47_c1));
-                }
-                else{
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 1), C0 + 4, MlasSveReinterpretS32FromU32(acc47_c0));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 1), C1 + 4, MlasSveReinterpretS32FromU32(acc47_c1));
-                }
+
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C0 + 4, MlasSveReinterpretS32FromU32(acc47_c0));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C1 + 4, MlasSveReinterpretS32FromU32(acc47_c1));
             }
             else{
                 // Row 0 (C0)
@@ -424,69 +364,43 @@ MLAS_FORCEINLINE size_t Process2Rows(
                 prev = MlasSveLoadInt32(pg_b32_4, C1);
                 sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c1));
                 MlasSveStoreInt32(pg_b32_4, C1, sum);
-                if(cols_this >= 6){
-                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 2), C0 + 4);
-                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 2), prev, MlasSveReinterpretS32FromU32(acc47_c0));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 2), C0 + 4, sum);
-                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 2), C1 + 4);
-                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 2), prev, MlasSveReinterpretS32FromU32(acc47_c1));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 2), C1 + 4, sum);
-                }
-                else{
-                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 1), C0 + 4);
-                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 1), prev, MlasSveReinterpretS32FromU32(acc47_c0));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 1), C0 + 4, sum);
-                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 1), C1 + 4);
-                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 1), prev, MlasSveReinterpretS32FromU32(acc47_c1));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 1), C1 + 4, sum);
-                }
+
+                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this - 4), C0 + 4);
+                sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this - 4), prev, MlasSveReinterpretS32FromU32(acc47_c0));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C0 + 4, sum);
+                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this - 4), C1 + 4);
+                sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this - 4), prev, MlasSveReinterpretS32FromU32(acc47_c1));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C1 + 4, sum);
             }
         }
         else if(cols_this > 2){
             if(HasZeroPointB){
-                if(cols_this >= 4){
-                    MlasSveStoreInt32(pg_b32_4, C0, MlasSveReinterpretS32FromU32(acc03_c0));
-                    MlasSveStoreInt32(pg_b32_4, C1, MlasSveReinterpretS32FromU32(acc03_c1));
-                }
-                else{
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C0, MlasSveReinterpretS32FromU32(acc03_c0));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C1, MlasSveReinterpretS32FromU32(acc03_c1));
-                }
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C0, MlasSveReinterpretS32FromU32(acc03_c0));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C1, MlasSveReinterpretS32FromU32(acc03_c1));
             }
             else{
-                if(cols_this >= 4){
-                    // Row 0 (C0)
-                    svint32_t prev = MlasSveLoadInt32(pg_b32_4, C0);
-                    svint32_t sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c0));
-                    MlasSveStoreInt32(pg_b32_4, C0, sum);
-                    prev = MlasSveLoadInt32(pg_b32_4, C1);
-                    sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c1));
-                    MlasSveStoreInt32(pg_b32_4, C1, sum);
-                }
-                else{
-                    // Row 0 (C0)
-                    svint32_t prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 3), C0);
-                    svint32_t sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, 3), prev, MlasSveReinterpretS32FromU32(acc03_c0));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C0, sum);
-                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 3), C1);
-                    sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, 3), prev, MlasSveReinterpretS32FromU32(acc03_c1));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C1, sum);
-                }   
+                // Row 0 (C0)
+                svint32_t prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this), C0);
+                svint32_t sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this), prev, MlasSveReinterpretS32FromU32(acc03_c0));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C0, sum);
+                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this), C1);
+                sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this), prev, MlasSveReinterpretS32FromU32(acc03_c1));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C1, sum);   
             }
         }
         else{
             if(HasZeroPointB){
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C0, MlasSveReinterpretS32FromU32(acc03_c0));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C1, MlasSveReinterpretS32FromU32(acc03_c1));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C0, MlasSveReinterpretS32FromU32(acc03_c0));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C1, MlasSveReinterpretS32FromU32(acc03_c1));
             }
             else{
                 // Row 0 (C0)
-                svint32_t prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C0);
-                svint32_t sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), prev, MlasSveReinterpretS32FromU32(acc03_c0));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C0, sum);
-                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C1);
-                sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), prev, MlasSveReinterpretS32FromU32(acc03_c1));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C1, sum);
+                svint32_t prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this), C0);
+                svint32_t sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this), prev, MlasSveReinterpretS32FromU32(acc03_c0));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C0, sum);
+                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this), C1);
+                sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this), prev, MlasSveReinterpretS32FromU32(acc03_c1));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C1, sum);
             }
         }
         // Last 4 columns
@@ -524,11 +438,10 @@ MLAS_FORCEINLINE size_t Process4Rows(
     // VL = 256 → int32 lanes = 8 → process columns in groups of 4
     //------------------------------------------------------------------
     svbool_t pg_b32_4 = MlasSveWhileLtB32(0, 4);  // stores 4 output columns
-    svbool_t pg_b32_8 = MlasSvePtrueB32();  // full accumulator lanes
+    svbool_t pg_b32_8 = MlasSveWhileLtB32(0, 8);  // full accumulator lanes
     svbool_t pg_b8_32 = MlasSveWhileLtB8(0, 32); // loads 32 bytes from A/B
     svuint32_t acc03_0, acc03_1, acc47_0, acc47_1;
 
-    // const int32_t rowsum = RowSumBuffer[0];
     svint32_t rowSumVec01, rowSumVec23, r0, r1, r2, r3;
     r0 = MlasSveBroadcastInt32(RowSumBuffer[0]);
     r1 = MlasSveBroadcastInt32(RowSumBuffer[1]);
@@ -567,9 +480,8 @@ MLAS_FORCEINLINE size_t Process4Rows(
         col64_0_3 = MlasSveReinterpretS64FromS32(col_0_3);
         col_0_3 = MlasSveReinterpretS32FromS64(MlasSveZip1S64(col64_0_3, col64_0_3));
 
-        acc03_0 = MlasSveReinterpretU32FromS32(MlasSveAddInt32X(pg_b32_8, MlasSveMulInt32(pg_b32_8, rowSumVec01, zpb_0_3), col_0_3));
-        acc03_1 = MlasSveReinterpretU32FromS32(MlasSveAddInt32X(pg_b32_8, MlasSveMulInt32(pg_b32_8, rowSumVec23, zpb_0_3), col_0_3));
-
+        acc03_0 = MlasSveReinterpretU32FromS32(MlasSveMultiplyAddInt32(pg_b32_8, rowSumVec01, zpb_0_3, col_0_3));
+        acc03_1 = MlasSveReinterpretU32FromS32(MlasSveMultiplyAddInt32(pg_b32_8, rowSumVec23, zpb_0_3, col_0_3));
         // --- Columns 4–7 ---
         if (cols_this > 4) {
             if (ZeroPointB){
@@ -583,9 +495,9 @@ MLAS_FORCEINLINE size_t Process4Rows(
             col_4_7 = MlasSveLoadInt32(pg_b32_4, ColumnSumBuffer + 4);
             col64_4_7 = MlasSveReinterpretS64FromS32(col_4_7);
             col_4_7 = MlasSveReinterpretS32FromS64(MlasSveZip1S64(col64_4_7, col64_4_7));
-            // acc47 = MlasSveReinterpretU32FromS32(svmad_s32_x(pg_b32_4, rowSumVec, zpb_4_7, col_4_7));
-            acc47_0 = MlasSveReinterpretU32FromS32(MlasSveAddInt32X(pg_b32_8, MlasSveMulInt32(pg_b32_8, rowSumVec01, zpb_4_7), col_4_7));
-            acc47_1 = MlasSveReinterpretU32FromS32(MlasSveAddInt32X(pg_b32_8, MlasSveMulInt32(pg_b32_8, rowSumVec23, zpb_4_7), col_4_7));
+
+            acc47_0 = MlasSveReinterpretU32FromS32(MlasSveMultiplyAddInt32(pg_b32_8, rowSumVec01, zpb_4_7, col_4_7));
+            acc47_1 = MlasSveReinterpretU32FromS32(MlasSveMultiplyAddInt32(pg_b32_8, rowSumVec23, zpb_4_7, col_4_7));
         }
         //------------------------------------------------------------------
         // K loop
@@ -635,18 +547,11 @@ MLAS_FORCEINLINE size_t Process4Rows(
                 MlasSveStoreInt32(pg_b32_4, C1, MlasSveReinterpretS32FromU32(acc03_c1));
                 MlasSveStoreInt32(pg_b32_4, C2, MlasSveReinterpretS32FromU32(acc03_c2));
                 MlasSveStoreInt32(pg_b32_4, C3, MlasSveReinterpretS32FromU32(acc03_c3));
-                if(cols_this >= 8){
-                    MlasSveStoreInt32(pg_b32_4, C0 + 4, MlasSveReinterpretS32FromU32(acc47_c0));
-                    MlasSveStoreInt32(pg_b32_4, C1 + 4, MlasSveReinterpretS32FromU32(acc47_c1));
-                    MlasSveStoreInt32(pg_b32_4, C2 + 4, MlasSveReinterpretS32FromU32(acc47_c2));
-                    MlasSveStoreInt32(pg_b32_4, C3 + 4, MlasSveReinterpretS32FromU32(acc47_c3));
-                }
-                else{
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C0 + 4, MlasSveReinterpretS32FromU32(acc47_c0));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C1 + 4, MlasSveReinterpretS32FromU32(acc47_c1));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C2 + 4, MlasSveReinterpretS32FromU32(acc47_c2));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C3 + 4, MlasSveReinterpretS32FromU32(acc47_c3));
-                }            
+                
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C0 + 4, MlasSveReinterpretS32FromU32(acc47_c0));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C1 + 4, MlasSveReinterpretS32FromU32(acc47_c1));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C2 + 4, MlasSveReinterpretS32FromU32(acc47_c2));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C3 + 4, MlasSveReinterpretS32FromU32(acc47_c3));           
             }
             else{
                 // Row 0 (C0)
@@ -662,35 +567,20 @@ MLAS_FORCEINLINE size_t Process4Rows(
                 prev = MlasSveLoadInt32(pg_b32_4, C3);
                 sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c3));
                 MlasSveStoreInt32(pg_b32_4, C3, sum);
+
                 // Row 1 (C1)
-                if(cols_this >= 8){
-                    prev = MlasSveLoadInt32(pg_b32_4, C0 + 4);
-                    sum  = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc47_c0));
-                    MlasSveStoreInt32(pg_b32_4, C0 + 4, sum);
-                    prev = MlasSveLoadInt32(pg_b32_4, C1 + 4);
-                    sum  = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc47_c1));
-                    MlasSveStoreInt32(pg_b32_4, C1 + 4, sum);
-                    prev = MlasSveLoadInt32(pg_b32_4, C2 + 4);
-                    sum  = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc47_c2));
-                    MlasSveStoreInt32(pg_b32_4, C2 + 4, sum);
-                    prev = MlasSveLoadInt32(pg_b32_4, C3 + 4);
-                    sum  = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc47_c3));
-                    MlasSveStoreInt32(pg_b32_4, C3 + 4, sum);
-                }
-                else{
-                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 3), C0 + 4);
-                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 3), prev, MlasSveReinterpretS32FromU32(acc47_c0));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C0 + 4, sum);
-                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 3), C1 + 4);
-                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 3), prev, MlasSveReinterpretS32FromU32(acc47_c1));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C1 + 4, sum);
-                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 3), C2 + 4);
-                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 3), prev, MlasSveReinterpretS32FromU32(acc47_c2));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C2 + 4, sum);
-                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 3), C3 + 4);
-                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 3), prev, MlasSveReinterpretS32FromU32(acc47_c3));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C3 + 4, sum);
-                }
+                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this - 4), C0 + 4);
+                sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this - 4), prev, MlasSveReinterpretS32FromU32(acc47_c0));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C0 + 4, sum);
+                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this - 4), C1 + 4);
+                sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this - 4), prev, MlasSveReinterpretS32FromU32(acc47_c1));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C1 + 4, sum);
+                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this - 4), C2 + 4);
+                sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this - 4), prev, MlasSveReinterpretS32FromU32(acc47_c2));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C2 + 4, sum);
+                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this - 4), C3 + 4);
+                sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this - 4), prev, MlasSveReinterpretS32FromU32(acc47_c3));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C3 + 4, sum);
             }
         }
         else if(cols_this > 4){
@@ -699,18 +589,11 @@ MLAS_FORCEINLINE size_t Process4Rows(
                 MlasSveStoreInt32(pg_b32_4, C1, MlasSveReinterpretS32FromU32(acc03_c1));
                 MlasSveStoreInt32(pg_b32_4, C2, MlasSveReinterpretS32FromU32(acc03_c2));
                 MlasSveStoreInt32(pg_b32_4, C3, MlasSveReinterpretS32FromU32(acc03_c3));
-                if(cols_this >= 6){
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 2), C0 + 4, MlasSveReinterpretS32FromU32(acc47_c0));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 2), C1 + 4, MlasSveReinterpretS32FromU32(acc47_c1));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 2), C2 + 4, MlasSveReinterpretS32FromU32(acc47_c2));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 2), C3 + 4, MlasSveReinterpretS32FromU32(acc47_c3));
-                }
-                else{
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 1), C0 + 4, MlasSveReinterpretS32FromU32(acc47_c0));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 1), C1 + 4, MlasSveReinterpretS32FromU32(acc47_c1));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 1), C2 + 4, MlasSveReinterpretS32FromU32(acc47_c2));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 1), C3 + 4, MlasSveReinterpretS32FromU32(acc47_c3));
-                }
+
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this -4), C0 + 4, MlasSveReinterpretS32FromU32(acc47_c0));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this -4), C1 + 4, MlasSveReinterpretS32FromU32(acc47_c1));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this -4), C2 + 4, MlasSveReinterpretS32FromU32(acc47_c2));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this -4), C3 + 4, MlasSveReinterpretS32FromU32(acc47_c3));
             }
             else{
                 // Row 0 (C0)
@@ -726,82 +609,42 @@ MLAS_FORCEINLINE size_t Process4Rows(
                 prev = MlasSveLoadInt32(pg_b32_4, C3);
                 sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c3));
                 MlasSveStoreInt32(pg_b32_4, C3, sum);
-                if(cols_this >= 6){
-                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 2), C0 + 4);
-                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 2), prev, MlasSveReinterpretS32FromU32(acc47_c0));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 2), C0 + 4, sum);
-                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 2), C1 + 4);
-                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 2), prev, MlasSveReinterpretS32FromU32(acc47_c1));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 2), C1 + 4, sum);
-                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 2), C2 + 4);
-                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 2), prev, MlasSveReinterpretS32FromU32(acc47_c2));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 2), C2 + 4, sum);
-                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 2), C3 + 4);
-                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 2), prev, MlasSveReinterpretS32FromU32(acc47_c3));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 2), C3 + 4, sum);
-                }
-                else{
-                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 1), C0 + 4);
-                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 1), prev, MlasSveReinterpretS32FromU32(acc47_c0));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 1), C0 + 4, sum);
-                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 1), C1 + 4);
-                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 1), prev, MlasSveReinterpretS32FromU32(acc47_c1));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 1), C1 + 4, sum);
-                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 1), C2 + 4);
-                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 1), prev, MlasSveReinterpretS32FromU32(acc47_c2));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 1), C2 + 4, sum);
-                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 1), C3 + 4);
-                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 1), prev, MlasSveReinterpretS32FromU32(acc47_c3));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 1), C3 + 4, sum);
-                }
+
+                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this - 4), C0 + 4);
+                sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this - 4), prev, MlasSveReinterpretS32FromU32(acc47_c0));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C0 + 4, sum);
+                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this - 4), C1 + 4);
+                sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this - 4), prev, MlasSveReinterpretS32FromU32(acc47_c1));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C1 + 4, sum);
+                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this - 4), C2 + 4);
+                sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this - 4), prev, MlasSveReinterpretS32FromU32(acc47_c2));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C2 + 4, sum);
+                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this - 4), C3 + 4);
+                sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this - 4), prev, MlasSveReinterpretS32FromU32(acc47_c3));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C3 + 4, sum);
             }
         }
         else if(cols_this > 2){
             if(HasZeroPointB){
-                if(cols_this >= 4){
-                    MlasSveStoreInt32(pg_b32_4, C0, MlasSveReinterpretS32FromU32(acc03_c0));
-                    MlasSveStoreInt32(pg_b32_4, C1, MlasSveReinterpretS32FromU32(acc03_c1));
-                    MlasSveStoreInt32(pg_b32_4, C2, MlasSveReinterpretS32FromU32(acc03_c2));
-                    MlasSveStoreInt32(pg_b32_4, C3, MlasSveReinterpretS32FromU32(acc03_c3));
-                }
-                else{
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C0, MlasSveReinterpretS32FromU32(acc03_c0));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C1, MlasSveReinterpretS32FromU32(acc03_c1));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C2, MlasSveReinterpretS32FromU32(acc03_c2));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C3, MlasSveReinterpretS32FromU32(acc03_c3));
-                }
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C0, MlasSveReinterpretS32FromU32(acc03_c0));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C1, MlasSveReinterpretS32FromU32(acc03_c1));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C2, MlasSveReinterpretS32FromU32(acc03_c2));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C3, MlasSveReinterpretS32FromU32(acc03_c3));
             }
             else{
-                if(cols_this >= 4){
-                    // Row 0 (C0)
-                    svint32_t prev = MlasSveLoadInt32(pg_b32_4, C0);
-                    svint32_t sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c0));
-                    MlasSveStoreInt32(pg_b32_4, C0, sum);
-                    prev = MlasSveLoadInt32(pg_b32_4, C1);
-                    sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c1));
-                    MlasSveStoreInt32(pg_b32_4, C1, sum);
-                    prev = MlasSveLoadInt32(pg_b32_4, C2);
-                    sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c2));
-                    MlasSveStoreInt32(pg_b32_4, C2, sum);
-                    prev = MlasSveLoadInt32(pg_b32_4, C3);
-                    sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c3));
-                    MlasSveStoreInt32(pg_b32_4, C3, sum);
-                }
-                else{
-                    // Row 0 (C0)
-                    svint32_t prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 3), C0);
-                    svint32_t sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, 3), prev, MlasSveReinterpretS32FromU32(acc03_c0));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C0, sum);
-                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 3), C1);
-                    sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, 3), prev, MlasSveReinterpretS32FromU32(acc03_c1));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C1, sum);
-                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 3), C2);
-                    sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, 3), prev, MlasSveReinterpretS32FromU32(acc03_c2));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C2, sum);
-                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 3), C3);
-                    sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, 3), prev, MlasSveReinterpretS32FromU32(acc03_c3));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C3, sum);
-                }   
+                // Row 0 (C0)
+                svint32_t prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this), C0);
+                svint32_t sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this), prev, MlasSveReinterpretS32FromU32(acc03_c0));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C0, sum);
+                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this), C1);
+                sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this), prev, MlasSveReinterpretS32FromU32(acc03_c1));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C1, sum);
+                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this), C2);
+                sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this), prev, MlasSveReinterpretS32FromU32(acc03_c2));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C2, sum);
+                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this), C3);
+                sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this), prev, MlasSveReinterpretS32FromU32(acc03_c3));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C3, sum);
             }
         }
         else{
@@ -813,18 +656,18 @@ MLAS_FORCEINLINE size_t Process4Rows(
             }
             else{
                 // Row 0 (C0)
-                svint32_t prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C0);
-                svint32_t sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), prev, MlasSveReinterpretS32FromU32(acc03_c0));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C0, sum);
-                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C1);
-                sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), prev, MlasSveReinterpretS32FromU32(acc03_c1));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C1, sum);
-                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C2);
-                sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), prev, MlasSveReinterpretS32FromU32(acc03_c2));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C2, sum);
-                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C3);
-                sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), prev, MlasSveReinterpretS32FromU32(acc03_c3));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C3, sum);
+                svint32_t prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this), C0);
+                svint32_t sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this), prev, MlasSveReinterpretS32FromU32(acc03_c0));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C0, sum);
+                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this), C1);
+                sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this), prev, MlasSveReinterpretS32FromU32(acc03_c1));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C1, sum);
+                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this), C2);
+                sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this), prev, MlasSveReinterpretS32FromU32(acc03_c2));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C2, sum);
+                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this), C3);
+                sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this), prev, MlasSveReinterpretS32FromU32(acc03_c3));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C3, sum);
             }
         }
         // Last 4 columns
@@ -864,11 +707,10 @@ MLAS_FORCEINLINE size_t Process8Rows(
     // VL = 256 → int32 lanes = 8 → process columns in groups of 4
     //------------------------------------------------------------------
     svbool_t pg_b32_4 = MlasSveWhileLtB32(0, 4);  // stores 4 output columns
-    svbool_t pg_b32_8 = MlasSvePtrueB32();  // full accumulator lanes
+    svbool_t pg_b32_8 = MlasSveWhileLtB32(0, 8);  // full accumulator lanes
     svbool_t pg_b8_32 = MlasSveWhileLtB8(0, 32); // loads 32 bytes from A/B
     svuint32_t acc03_0, acc03_1, acc03_2, acc03_3, acc47_0, acc47_1, acc47_2, acc47_3;
 
-    // const int32_t rowsum = RowSumBuffer[0];
     svint32_t rowSumVec01, rowSumVec23, rowSumVec45, rowSumVec67, r0, r1, r2, r3, r4, r5, r6, r7;
     r0 = MlasSveBroadcastInt32(RowSumBuffer[0]);
     r1 = MlasSveBroadcastInt32(RowSumBuffer[1]);
@@ -916,10 +758,10 @@ MLAS_FORCEINLINE size_t Process8Rows(
         col64_0_3 = MlasSveReinterpretS64FromS32(col_0_3);
         col_0_3 = MlasSveReinterpretS32FromS64(MlasSveZip1S64(col64_0_3, col64_0_3));
 
-        acc03_0 = MlasSveReinterpretU32FromS32(MlasSveAddInt32X(pg_b32_8, MlasSveMulInt32(pg_b32_8, rowSumVec01, zpb_0_3), col_0_3));
-        acc03_1 = MlasSveReinterpretU32FromS32(MlasSveAddInt32X(pg_b32_8, MlasSveMulInt32(pg_b32_8, rowSumVec23, zpb_0_3), col_0_3));
-        acc03_2 = MlasSveReinterpretU32FromS32(MlasSveAddInt32X(pg_b32_8, MlasSveMulInt32(pg_b32_8, rowSumVec45, zpb_0_3), col_0_3));
-        acc03_3 = MlasSveReinterpretU32FromS32(MlasSveAddInt32X(pg_b32_8, MlasSveMulInt32(pg_b32_8, rowSumVec67, zpb_0_3), col_0_3));
+        acc03_0 = MlasSveReinterpretU32FromS32(MlasSveMultiplyAddInt32(pg_b32_8, rowSumVec01, zpb_0_3, col_0_3));
+        acc03_1 = MlasSveReinterpretU32FromS32(MlasSveMultiplyAddInt32(pg_b32_8, rowSumVec23, zpb_0_3, col_0_3));
+        acc03_2 = MlasSveReinterpretU32FromS32(MlasSveMultiplyAddInt32(pg_b32_8, rowSumVec45, zpb_0_3, col_0_3));
+        acc03_3 = MlasSveReinterpretU32FromS32(MlasSveMultiplyAddInt32(pg_b32_8, rowSumVec67, zpb_0_3, col_0_3));
         // --- Columns 4–7 ---
         if (cols_this > 4) {
             if (ZeroPointB){
@@ -933,12 +775,12 @@ MLAS_FORCEINLINE size_t Process8Rows(
             col_4_7 = MlasSveLoadInt32(pg_b32_4, ColumnSumBuffer + 4);
             col64_4_7 = MlasSveReinterpretS64FromS32(col_4_7);
             col_4_7 = MlasSveReinterpretS32FromS64(MlasSveZip1S64(col64_4_7, col64_4_7));
-            // acc47 = MlasSveReinterpretU32FromS32(svmad_s32_x(pg_b32_4, rowSumVec, zpb_4_7, col_4_7));
-            acc47_0 = MlasSveReinterpretU32FromS32(MlasSveAddInt32X(pg_b32_8, MlasSveMulInt32(pg_b32_8, rowSumVec01, zpb_4_7), col_4_7));
-            acc47_1 = MlasSveReinterpretU32FromS32(MlasSveAddInt32X(pg_b32_8, MlasSveMulInt32(pg_b32_8, rowSumVec23, zpb_4_7), col_4_7));
-            acc47_2 = MlasSveReinterpretU32FromS32(MlasSveAddInt32X(pg_b32_8, MlasSveMulInt32(pg_b32_8, rowSumVec45, zpb_4_7), col_4_7));
-            acc47_3 = MlasSveReinterpretU32FromS32(MlasSveAddInt32X(pg_b32_8, MlasSveMulInt32(pg_b32_8, rowSumVec67, zpb_4_7), col_4_7));
-        }
+            
+            acc47_0 = MlasSveReinterpretU32FromS32(MlasSveMultiplyAddInt32(pg_b32_8, rowSumVec01, zpb_4_7, col_4_7));
+            acc47_1 = MlasSveReinterpretU32FromS32(MlasSveMultiplyAddInt32(pg_b32_8, rowSumVec23, zpb_4_7, col_4_7));
+            acc47_2 = MlasSveReinterpretU32FromS32(MlasSveMultiplyAddInt32(pg_b32_8, rowSumVec45, zpb_4_7, col_4_7));
+            acc47_3 = MlasSveReinterpretU32FromS32(MlasSveMultiplyAddInt32(pg_b32_8, rowSumVec67, zpb_4_7, col_4_7));
+        }   
         //------------------------------------------------------------------
         // K loop
         //------------------------------------------------------------------
@@ -1005,26 +847,16 @@ MLAS_FORCEINLINE size_t Process8Rows(
                 MlasSveStoreInt32(pg_b32_4, C5, MlasSveReinterpretS32FromU32(acc03_c5));
                 MlasSveStoreInt32(pg_b32_4, C6, MlasSveReinterpretS32FromU32(acc03_c6));
                 MlasSveStoreInt32(pg_b32_4, C7, MlasSveReinterpretS32FromU32(acc03_c7));
-                if(cols_this >= 8){
-                    MlasSveStoreInt32(pg_b32_4, C0 + 4, MlasSveReinterpretS32FromU32(acc47_c0));
-                    MlasSveStoreInt32(pg_b32_4, C1 + 4, MlasSveReinterpretS32FromU32(acc47_c1));
-                    MlasSveStoreInt32(pg_b32_4, C2 + 4, MlasSveReinterpretS32FromU32(acc47_c2));
-                    MlasSveStoreInt32(pg_b32_4, C3 + 4, MlasSveReinterpretS32FromU32(acc47_c3));
-                    MlasSveStoreInt32(pg_b32_4, C4 + 4, MlasSveReinterpretS32FromU32(acc47_c4));
-                    MlasSveStoreInt32(pg_b32_4, C5 + 4, MlasSveReinterpretS32FromU32(acc47_c5));
-                    MlasSveStoreInt32(pg_b32_4, C6 + 4, MlasSveReinterpretS32FromU32(acc47_c6));
-                    MlasSveStoreInt32(pg_b32_4, C7 + 4, MlasSveReinterpretS32FromU32(acc47_c7));
-                }
-                else{
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C0 + 4, MlasSveReinterpretS32FromU32(acc47_c0));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C1 + 4, MlasSveReinterpretS32FromU32(acc47_c1));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C2 + 4, MlasSveReinterpretS32FromU32(acc47_c2));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C3 + 4, MlasSveReinterpretS32FromU32(acc47_c3));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C4 + 4, MlasSveReinterpretS32FromU32(acc47_c4));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C5 + 4, MlasSveReinterpretS32FromU32(acc47_c5));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C6 + 4, MlasSveReinterpretS32FromU32(acc47_c6));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C7 + 4, MlasSveReinterpretS32FromU32(acc47_c7));
-                }            
+                
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C0 + 4, MlasSveReinterpretS32FromU32(acc47_c0));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C1 + 4, MlasSveReinterpretS32FromU32(acc47_c1));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C2 + 4, MlasSveReinterpretS32FromU32(acc47_c2));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C3 + 4, MlasSveReinterpretS32FromU32(acc47_c3));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C4 + 4, MlasSveReinterpretS32FromU32(acc47_c4));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C5 + 4, MlasSveReinterpretS32FromU32(acc47_c5));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C6 + 4, MlasSveReinterpretS32FromU32(acc47_c6));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C7 + 4, MlasSveReinterpretS32FromU32(acc47_c7));
+                          
             }
             else{
                 // Row 0 (C0)
@@ -1053,58 +885,31 @@ MLAS_FORCEINLINE size_t Process8Rows(
                 sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c7));
                 MlasSveStoreInt32(pg_b32_4, C7, sum);
                 // Row 1 (C1)
-                if(cols_this >= 8){
-                    prev = MlasSveLoadInt32(pg_b32_4, C0 + 4);
-                    sum  = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc47_c0));
-                    MlasSveStoreInt32(pg_b32_4, C0 + 4, sum);
-                    prev = MlasSveLoadInt32(pg_b32_4, C1 + 4);
-                    sum  = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc47_c1));
-                    MlasSveStoreInt32(pg_b32_4, C1 + 4, sum);
-                    prev = MlasSveLoadInt32(pg_b32_4, C2 + 4);
-                    sum  = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc47_c2));
-                    MlasSveStoreInt32(pg_b32_4, C2 + 4, sum);
-                    prev = MlasSveLoadInt32(pg_b32_4, C3 + 4);
-                    sum  = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc47_c3));
-                    MlasSveStoreInt32(pg_b32_4, C3 + 4, sum);
-                    prev = MlasSveLoadInt32(pg_b32_4, C4 + 4);
-                    sum  = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc47_c4));
-                    MlasSveStoreInt32(pg_b32_4, C4 + 4, sum);
-                    prev = MlasSveLoadInt32(pg_b32_4, C5 + 4);
-                    sum  = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc47_c5));
-                    MlasSveStoreInt32(pg_b32_4, C5 + 4, sum);
-                    prev = MlasSveLoadInt32(pg_b32_4, C6 + 4);
-                    sum  = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc47_c6));
-                    MlasSveStoreInt32(pg_b32_4, C6 + 4, sum);
-                    prev = MlasSveLoadInt32(pg_b32_4, C7 + 4);
-                    sum  = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc47_c7));
-                    MlasSveStoreInt32(pg_b32_4, C7 + 4, sum);
-                }
-                else{
-                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 3), C0 + 4);
-                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 3), prev, MlasSveReinterpretS32FromU32(acc47_c0));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C0 + 4, sum);
-                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 3), C1 + 4);
-                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 3), prev, MlasSveReinterpretS32FromU32(acc47_c1));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C1 + 4, sum);
-                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 3), C2 + 4);
-                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 3), prev, MlasSveReinterpretS32FromU32(acc47_c2));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C2 + 4, sum);
-                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 3), C3 + 4);
-                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 3), prev, MlasSveReinterpretS32FromU32(acc47_c3));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C3 + 4, sum);
-                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 3), C4 + 4);
-                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 3), prev, MlasSveReinterpretS32FromU32(acc47_c4));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C4 + 4, sum);
-                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 3), C5 + 4);
-                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 3), prev, MlasSveReinterpretS32FromU32(acc47_c5));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C5 + 4, sum);
-                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 3), C6 + 4);
-                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 3), prev, MlasSveReinterpretS32FromU32(acc47_c6));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C6 + 4, sum);
-                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 3), C7 + 4);
-                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 3), prev, MlasSveReinterpretS32FromU32(acc47_c7));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C7 + 4, sum);
-                }
+                
+                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this - 4), C0 + 4);
+                sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this - 4), prev, MlasSveReinterpretS32FromU32(acc47_c0));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C0 + 4, sum);
+                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this - 4), C1 + 4);
+                sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this - 4), prev, MlasSveReinterpretS32FromU32(acc47_c1));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C1 + 4, sum);
+                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this - 4), C2 + 4);
+                sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this - 4), prev, MlasSveReinterpretS32FromU32(acc47_c2));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C2 + 4, sum);
+                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this - 4), C3 + 4);
+                sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this - 4), prev, MlasSveReinterpretS32FromU32(acc47_c3));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C3 + 4, sum);
+                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this - 4), C4 + 4);
+                sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this - 4), prev, MlasSveReinterpretS32FromU32(acc47_c4));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C4 + 4, sum);
+                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this - 4), C5 + 4);
+                sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this - 4), prev, MlasSveReinterpretS32FromU32(acc47_c5));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C5 + 4, sum);
+                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this - 4), C6 + 4);
+                sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this - 4), prev, MlasSveReinterpretS32FromU32(acc47_c6));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C6 + 4, sum);
+                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this - 4), C7 + 4);
+                sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this - 4), prev, MlasSveReinterpretS32FromU32(acc47_c7));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C7 + 4, sum);
             }
         }
         else if(cols_this > 4){
@@ -1117,26 +922,15 @@ MLAS_FORCEINLINE size_t Process8Rows(
                 MlasSveStoreInt32(pg_b32_4, C5, MlasSveReinterpretS32FromU32(acc03_c5));
                 MlasSveStoreInt32(pg_b32_4, C6, MlasSveReinterpretS32FromU32(acc03_c6));
                 MlasSveStoreInt32(pg_b32_4, C7, MlasSveReinterpretS32FromU32(acc03_c7));
-                if(cols_this >= 6){
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 2), C0 + 4, MlasSveReinterpretS32FromU32(acc47_c0));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 2), C1 + 4, MlasSveReinterpretS32FromU32(acc47_c1));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 2), C2 + 4, MlasSveReinterpretS32FromU32(acc47_c2));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 2), C3 + 4, MlasSveReinterpretS32FromU32(acc47_c3));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 2), C4 + 4, MlasSveReinterpretS32FromU32(acc47_c4));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 2), C5 + 4, MlasSveReinterpretS32FromU32(acc47_c5));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 2), C6 + 4, MlasSveReinterpretS32FromU32(acc47_c6));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 2), C7 + 4, MlasSveReinterpretS32FromU32(acc47_c7));
-                }
-                else{
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 1), C0 + 4, MlasSveReinterpretS32FromU32(acc47_c0));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 1), C1 + 4, MlasSveReinterpretS32FromU32(acc47_c1));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 1), C2 + 4, MlasSveReinterpretS32FromU32(acc47_c2));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 1), C3 + 4, MlasSveReinterpretS32FromU32(acc47_c3));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 1), C4 + 4, MlasSveReinterpretS32FromU32(acc47_c4));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 1), C5 + 4, MlasSveReinterpretS32FromU32(acc47_c5));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 1), C6 + 4, MlasSveReinterpretS32FromU32(acc47_c6));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 1), C7 + 4, MlasSveReinterpretS32FromU32(acc47_c7));
-                }
+
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C0 + 4, MlasSveReinterpretS32FromU32(acc47_c0));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C1 + 4, MlasSveReinterpretS32FromU32(acc47_c1));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C2 + 4, MlasSveReinterpretS32FromU32(acc47_c2));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C3 + 4, MlasSveReinterpretS32FromU32(acc47_c3));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C4 + 4, MlasSveReinterpretS32FromU32(acc47_c4));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C5 + 4, MlasSveReinterpretS32FromU32(acc47_c5));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C6 + 4, MlasSveReinterpretS32FromU32(acc47_c6));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C7 + 4, MlasSveReinterpretS32FromU32(acc47_c7));
             }
             else{
                 // Row 0 (C0)
@@ -1164,178 +958,110 @@ MLAS_FORCEINLINE size_t Process8Rows(
                 prev = MlasSveLoadInt32(pg_b32_4, C7);
                 sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c7));
                 MlasSveStoreInt32(pg_b32_4, C7, sum);
+
                 // Row 1 (C1)
-                if(cols_this >= 6){
-                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 2), C0 + 4);
-                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 2), prev, MlasSveReinterpretS32FromU32(acc47_c0));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 2), C0 + 4, sum);
-                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 2), C1 + 4);
-                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 2), prev, MlasSveReinterpretS32FromU32(acc47_c1));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 2), C1 + 4, sum);
-                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 2), C2 + 4);
-                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 2), prev, MlasSveReinterpretS32FromU32(acc47_c2));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 2), C2 + 4, sum);
-                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 2), C3 + 4);
-                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 2), prev, MlasSveReinterpretS32FromU32(acc47_c3));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 2), C3 + 4, sum);
-                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 2), C4 + 4);
-                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 2), prev, MlasSveReinterpretS32FromU32(acc47_c4));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 2), C4 + 4, sum);
-                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 2), C5 + 4);
-                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 2), prev, MlasSveReinterpretS32FromU32(acc47_c5));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 2), C5 + 4, sum);
-                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 2), C6 + 4);
-                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 2), prev, MlasSveReinterpretS32FromU32(acc47_c6));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 2), C6 + 4, sum);
-                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 2), C7 + 4);
-                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 2), prev, MlasSveReinterpretS32FromU32(acc47_c7));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 2), C7 + 4, sum);
-                }
-                else{
-                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 1), C0 + 4);
-                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 1), prev, MlasSveReinterpretS32FromU32(acc47_c0));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 1), C0 + 4, sum);
-                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 1), C1 + 4);
-                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 1), prev, MlasSveReinterpretS32FromU32(acc47_c1));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 1), C1 + 4, sum);
-                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 1), C2 + 4);
-                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 1), prev, MlasSveReinterpretS32FromU32(acc47_c2));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 1), C2 + 4, sum);
-                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 1), C3 + 4);
-                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 1), prev, MlasSveReinterpretS32FromU32(acc47_c3));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 1), C3 + 4, sum);
-                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 1), C4 + 4);
-                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 1), prev, MlasSveReinterpretS32FromU32(acc47_c4));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 1), C4 + 4, sum);
-                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 1), C5 + 4);
-                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 1), prev, MlasSveReinterpretS32FromU32(acc47_c5));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 1), C5 + 4, sum);
-                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 1), C6 + 4);
-                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 1), prev, MlasSveReinterpretS32FromU32(acc47_c6));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 1), C6 + 4, sum);
-                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 1), C7 + 4);
-                    sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, 1), prev, MlasSveReinterpretS32FromU32(acc47_c7));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 1), C7 + 4, sum);
-                }
+                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this - 4), C0 + 4);
+                sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this - 4), prev, MlasSveReinterpretS32FromU32(acc47_c0));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C0 + 4, sum);
+                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this - 4), C1 + 4);
+                sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this - 4), prev, MlasSveReinterpretS32FromU32(acc47_c1));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C1 + 4, sum);
+                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this - 4), C2 + 4);
+                sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this - 4), prev, MlasSveReinterpretS32FromU32(acc47_c2));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C2 + 4, sum);
+                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this - 4), C3 + 4);
+                sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this - 4), prev, MlasSveReinterpretS32FromU32(acc47_c3));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C3 + 4, sum);
+                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this - 4), C4 + 4);
+                sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this - 4), prev, MlasSveReinterpretS32FromU32(acc47_c4));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C4 + 4, sum);
+                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this - 4), C5 + 4);
+                sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this - 4), prev, MlasSveReinterpretS32FromU32(acc47_c5));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C5 + 4, sum);
+                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this - 4), C6 + 4);
+                sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this - 4), prev, MlasSveReinterpretS32FromU32(acc47_c6));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C6 + 4, sum);
+                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this - 4), C7 + 4);
+                sum  = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this - 4), prev, MlasSveReinterpretS32FromU32(acc47_c7));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this - 4), C7 + 4, sum);
             }
         }
         else if(cols_this > 2){
             if(HasZeroPointB){
-                if(cols_this >= 4){
-                    MlasSveStoreInt32(pg_b32_4, C0, MlasSveReinterpretS32FromU32(acc03_c0));
-                    MlasSveStoreInt32(pg_b32_4, C1, MlasSveReinterpretS32FromU32(acc03_c1));
-                    MlasSveStoreInt32(pg_b32_4, C2, MlasSveReinterpretS32FromU32(acc03_c2));
-                    MlasSveStoreInt32(pg_b32_4, C3, MlasSveReinterpretS32FromU32(acc03_c3));
-                    MlasSveStoreInt32(pg_b32_4, C4, MlasSveReinterpretS32FromU32(acc03_c4));
-                    MlasSveStoreInt32(pg_b32_4, C5, MlasSveReinterpretS32FromU32(acc03_c5));
-                    MlasSveStoreInt32(pg_b32_4, C6, MlasSveReinterpretS32FromU32(acc03_c6));
-                    MlasSveStoreInt32(pg_b32_4, C7, MlasSveReinterpretS32FromU32(acc03_c7));
-                }
-                else{
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C0, MlasSveReinterpretS32FromU32(acc03_c0));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C1, MlasSveReinterpretS32FromU32(acc03_c1));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C2, MlasSveReinterpretS32FromU32(acc03_c2));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C3, MlasSveReinterpretS32FromU32(acc03_c3));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C4, MlasSveReinterpretS32FromU32(acc03_c4));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C5, MlasSveReinterpretS32FromU32(acc03_c5));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C6, MlasSveReinterpretS32FromU32(acc03_c6));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C7, MlasSveReinterpretS32FromU32(acc03_c7));
-                }
-            }
-            else{
-                if(cols_this >= 4){
-                    // Row 0 (C0)
-                    svint32_t prev = MlasSveLoadInt32(pg_b32_4, C0);
-                    svint32_t sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c0));
-                    MlasSveStoreInt32(pg_b32_4, C0, sum);
-                    prev = MlasSveLoadInt32(pg_b32_4, C1);
-                    sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c1));
-                    MlasSveStoreInt32(pg_b32_4, C1, sum);
-                    prev = MlasSveLoadInt32(pg_b32_4, C2);
-                    sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c2));
-                    MlasSveStoreInt32(pg_b32_4, C2, sum);
-                    prev = MlasSveLoadInt32(pg_b32_4, C3);
-                    sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c3));
-                    MlasSveStoreInt32(pg_b32_4, C3, sum);
-                    prev = MlasSveLoadInt32(pg_b32_4, C4);
-                    sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c4));
-                    MlasSveStoreInt32(pg_b32_4, C4, sum);
-                    prev = MlasSveLoadInt32(pg_b32_4, C5);
-                    sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c5));
-                    MlasSveStoreInt32(pg_b32_4, C5, sum);
-                    prev = MlasSveLoadInt32(pg_b32_4, C6);
-                    sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c6));
-                    MlasSveStoreInt32(pg_b32_4, C6, sum);
-                    prev = MlasSveLoadInt32(pg_b32_4, C7);
-                    sum = MlasSveAddInt32X(pg_b32_4, prev, MlasSveReinterpretS32FromU32(acc03_c7));
-                    MlasSveStoreInt32(pg_b32_4, C7, sum);
-                }
-                else{
-                    // Row 0 (C0)
-                    svint32_t prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 3), C0);
-                    svint32_t sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, 3), prev, MlasSveReinterpretS32FromU32(acc03_c0));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C0, sum);
-                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 3), C1);
-                    sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, 3), prev, MlasSveReinterpretS32FromU32(acc03_c1));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C1, sum);
-                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 3), C2);
-                    sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, 3), prev, MlasSveReinterpretS32FromU32(acc03_c2));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C2, sum);
-                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 3), C3);
-                    sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, 3), prev, MlasSveReinterpretS32FromU32(acc03_c3));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C3, sum);
-                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 3), C4);
-                    sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, 3), prev, MlasSveReinterpretS32FromU32(acc03_c4));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C4, sum);
-                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 3), C5);
-                    sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, 3), prev, MlasSveReinterpretS32FromU32(acc03_c5));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C5, sum);
-                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 3), C6);
-                    sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, 3), prev, MlasSveReinterpretS32FromU32(acc03_c6));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C6, sum);
-                    prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, 3), C7);
-                    sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, 3), prev, MlasSveReinterpretS32FromU32(acc03_c7));
-                    MlasSveStoreInt32(MlasSveWhileLtB32(0, 3), C7, sum);
-                }   
-            }
-        }
-        else{
-            if(HasZeroPointB){
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C0, MlasSveReinterpretS32FromU32(acc03_c0));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C1, MlasSveReinterpretS32FromU32(acc03_c1));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C2, MlasSveReinterpretS32FromU32(acc03_c2));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C3, MlasSveReinterpretS32FromU32(acc03_c3));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C4, MlasSveReinterpretS32FromU32(acc03_c4));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C5, MlasSveReinterpretS32FromU32(acc03_c5));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C6, MlasSveReinterpretS32FromU32(acc03_c6));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C7, MlasSveReinterpretS32FromU32(acc03_c7));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C0, MlasSveReinterpretS32FromU32(acc03_c0));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C1, MlasSveReinterpretS32FromU32(acc03_c1));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C2, MlasSveReinterpretS32FromU32(acc03_c2));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C3, MlasSveReinterpretS32FromU32(acc03_c3));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C4, MlasSveReinterpretS32FromU32(acc03_c4));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C5, MlasSveReinterpretS32FromU32(acc03_c5));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C6, MlasSveReinterpretS32FromU32(acc03_c6));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C7, MlasSveReinterpretS32FromU32(acc03_c7));
             }
             else{
                 // Row 0 (C0)
-                svint32_t prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C0);
-                svint32_t sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), prev, MlasSveReinterpretS32FromU32(acc03_c0));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C0, sum);
-                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C1);
-                sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), prev, MlasSveReinterpretS32FromU32(acc03_c1));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C1, sum);
-                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C2);
-                sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), prev, MlasSveReinterpretS32FromU32(acc03_c2));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C2, sum);
-                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C3);
-                sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), prev, MlasSveReinterpretS32FromU32(acc03_c3));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C3, sum);
-                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C4);
-                sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), prev, MlasSveReinterpretS32FromU32(acc03_c4));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C4, sum);
-                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C5);
-                sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), prev, MlasSveReinterpretS32FromU32(acc03_c5));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C5, sum);
-                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C6);
-                sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), prev, MlasSveReinterpretS32FromU32(acc03_c6));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C6, sum);
-                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C7);
-                sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), prev, MlasSveReinterpretS32FromU32(acc03_c7));
-                MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C7, sum);
+                svint32_t prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this), C0);
+                svint32_t sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this), prev, MlasSveReinterpretS32FromU32(acc03_c0));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C0, sum);
+                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this), C1);
+                sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this), prev, MlasSveReinterpretS32FromU32(acc03_c1));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C1, sum);
+                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this), C2);
+                sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this), prev, MlasSveReinterpretS32FromU32(acc03_c2));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C2, sum);
+                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this), C3);
+                sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this), prev, MlasSveReinterpretS32FromU32(acc03_c3));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C3, sum);
+                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this), C4);
+                sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this), prev, MlasSveReinterpretS32FromU32(acc03_c4));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C4, sum);
+                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this), C5);
+                sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this), prev, MlasSveReinterpretS32FromU32(acc03_c5));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C5, sum);
+                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this), C6);
+                sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this), prev, MlasSveReinterpretS32FromU32(acc03_c6));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C6, sum);
+                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this), C7);
+                sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this), prev, MlasSveReinterpretS32FromU32(acc03_c7));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C7, sum);
+            }  
+        }
+        else{
+            if(HasZeroPointB){
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C0, MlasSveReinterpretS32FromU32(acc03_c0));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C1, MlasSveReinterpretS32FromU32(acc03_c1));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C2, MlasSveReinterpretS32FromU32(acc03_c2));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C3, MlasSveReinterpretS32FromU32(acc03_c3));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C4, MlasSveReinterpretS32FromU32(acc03_c4));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C5, MlasSveReinterpretS32FromU32(acc03_c5));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C6, MlasSveReinterpretS32FromU32(acc03_c6));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C7, MlasSveReinterpretS32FromU32(acc03_c7));
+            }
+            else{
+                // Row 0 (C0)
+                svint32_t prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this), C0);
+                svint32_t sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this), prev, MlasSveReinterpretS32FromU32(acc03_c0));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C0, sum);
+                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this), C1);
+                sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this), prev, MlasSveReinterpretS32FromU32(acc03_c1));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C1, sum);
+                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this), C2);
+                sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this), prev, MlasSveReinterpretS32FromU32(acc03_c2));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C2, sum);
+                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this), C3);
+                sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this), prev, MlasSveReinterpretS32FromU32(acc03_c3));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C3, sum);
+                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this), C4);
+                sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this), prev, MlasSveReinterpretS32FromU32(acc03_c4));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C4, sum);
+                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this), C5);
+                sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this), prev, MlasSveReinterpretS32FromU32(acc03_c5));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C5, sum);
+                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this), C6);
+                sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this), prev, MlasSveReinterpretS32FromU32(acc03_c6));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C6, sum);
+                prev = MlasSveLoadInt32(MlasSveWhileLtB32(0, cols_this), C7);
+                sum = MlasSveAddInt32X(MlasSveWhileLtB32(0, cols_this), prev, MlasSveReinterpretS32FromU32(acc03_c7));
+                MlasSveStoreInt32(MlasSveWhileLtB32(0, cols_this), C7, sum);
             }
         }
         // Last 4 columns

--- a/onnxruntime/core/mlas/lib/sve/qgemm_sve256.cpp
+++ b/onnxruntime/core/mlas/lib/sve/qgemm_sve256.cpp
@@ -3,7 +3,6 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include <iostream>
 #include <vector>
 
 #include "mlasi_sve.h"
@@ -44,7 +43,8 @@ struct MLAS_GEMM_U8X8_KERNEL_UMMLA {
     using PackedBType = uint8_t;
 };
 
-size_t Process1RowTest256(
+template<bool HasZeroPointB>
+MLAS_FORCEINLINE size_t Process1Row(
     const uint8_t* A,
     const uint8_t* B,
     int32_t* C,
@@ -54,8 +54,7 @@ size_t Process1RowTest256(
     size_t ldc,
     const int32_t* RowSumBuffer,
     const int32_t* ColumnSumBuffer,
-    const int32_t* ZeroPointB,
-    bool isZeroPointB)
+    const int32_t* ZeroPointB)
 {
     (void)CountM;
     (void)ldc;
@@ -151,7 +150,7 @@ size_t Process1RowTest256(
         // First 4 columns
         // 
         if(cols_this > 6){
-            if(isZeroPointB){
+            if(HasZeroPointB){
                 MlasSveStoreInt32(pg_b32_4, C_ptr, MlasSveReinterpretS32FromU32(acc03));
                 if(cols_this >= 8){
                     MlasSveStoreInt32(pg_b32_4, C_ptr + 4, MlasSveReinterpretS32FromU32(acc47));
@@ -180,7 +179,7 @@ size_t Process1RowTest256(
             }
         }
         else if(cols_this > 4){
-            if(isZeroPointB){
+            if(HasZeroPointB){
                 MlasSveStoreInt32(pg_b32_4, C_ptr, MlasSveReinterpretS32FromU32(acc03));
                 if(cols_this >= 6){
                     MlasSveStoreInt32(MlasSveWhileLtB32(0, 2), C_ptr + 4, MlasSveReinterpretS32FromU32(acc47));
@@ -207,7 +206,7 @@ size_t Process1RowTest256(
             }
         }
         else if(cols_this > 2){
-            if(isZeroPointB){
+            if(HasZeroPointB){
                 if(cols_this >= 4){
                     MlasSveStoreInt32(pg_b32_4, C_ptr, MlasSveReinterpretS32FromU32(acc03));
                 }
@@ -231,7 +230,7 @@ size_t Process1RowTest256(
             }
         }
         else{
-            if(isZeroPointB){
+            if(HasZeroPointB){
                 MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C_ptr, MlasSveReinterpretS32FromU32(acc03));
             }
             else{
@@ -256,7 +255,8 @@ size_t Process1RowTest256(
     return 1;
 }
 
-size_t Process2RowsTest256(
+template<bool HasZeroPointB>
+MLAS_FORCEINLINE size_t Process2Rows(
     const uint8_t* A,
     const uint8_t* B,
     int32_t* C,
@@ -266,8 +266,7 @@ size_t Process2RowsTest256(
     size_t ldc,
     const int32_t* RowSumBuffer,
     const int32_t* ColumnSumBuffer,
-    const int32_t* ZeroPointB,
-    bool isZeroPointB)
+    const int32_t* ZeroPointB)
 {
     (void)CountM;
 
@@ -365,7 +364,7 @@ size_t Process2RowsTest256(
         // First 4 columns
         // 
         if(cols_this > 6){
-            if(isZeroPointB){
+            if(HasZeroPointB){
                 MlasSveStoreInt32(pg_b32_4, C0, MlasSveReinterpretS32FromU32(acc03_c0));
                 MlasSveStoreInt32(pg_b32_4, C1, MlasSveReinterpretS32FromU32(acc03_c1));
                 if(cols_this >= 8){
@@ -405,7 +404,7 @@ size_t Process2RowsTest256(
             }
         }
         else if(cols_this > 4){
-            if(isZeroPointB){
+            if(HasZeroPointB){
                 MlasSveStoreInt32(pg_b32_4, C0, MlasSveReinterpretS32FromU32(acc03_c0));
                 MlasSveStoreInt32(pg_b32_4, C1, MlasSveReinterpretS32FromU32(acc03_c1));
                 if(cols_this >= 6){
@@ -444,7 +443,7 @@ size_t Process2RowsTest256(
             }
         }
         else if(cols_this > 2){
-            if(isZeroPointB){
+            if(HasZeroPointB){
                 if(cols_this >= 4){
                     MlasSveStoreInt32(pg_b32_4, C0, MlasSveReinterpretS32FromU32(acc03_c0));
                     MlasSveStoreInt32(pg_b32_4, C1, MlasSveReinterpretS32FromU32(acc03_c1));
@@ -476,7 +475,7 @@ size_t Process2RowsTest256(
             }
         }
         else{
-            if(isZeroPointB){
+            if(HasZeroPointB){
                 MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C0, MlasSveReinterpretS32FromU32(acc03_c0));
                 MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C1, MlasSveReinterpretS32FromU32(acc03_c1));
             }
@@ -506,7 +505,8 @@ size_t Process2RowsTest256(
     return 2;
 }
 
-size_t Process4RowsTest256(
+template<bool HasZeroPointB>
+MLAS_FORCEINLINE size_t Process4Rows(
     const uint8_t* A,
     const uint8_t* B,
     int32_t* C,
@@ -516,8 +516,7 @@ size_t Process4RowsTest256(
     size_t ldc,
     const int32_t* RowSumBuffer,
     const int32_t* ColumnSumBuffer,
-    const int32_t* ZeroPointB,
-    bool isZeroPointB)
+    const int32_t* ZeroPointB)
 {
     (void)CountM;
 
@@ -631,7 +630,7 @@ size_t Process4RowsTest256(
         // First 4 columns
         // 
         if(cols_this > 6){
-            if(isZeroPointB){
+            if(HasZeroPointB){
                 MlasSveStoreInt32(pg_b32_4, C0, MlasSveReinterpretS32FromU32(acc03_c0));
                 MlasSveStoreInt32(pg_b32_4, C1, MlasSveReinterpretS32FromU32(acc03_c1));
                 MlasSveStoreInt32(pg_b32_4, C2, MlasSveReinterpretS32FromU32(acc03_c2));
@@ -695,7 +694,7 @@ size_t Process4RowsTest256(
             }
         }
         else if(cols_this > 4){
-            if(isZeroPointB){
+            if(HasZeroPointB){
                 MlasSveStoreInt32(pg_b32_4, C0, MlasSveReinterpretS32FromU32(acc03_c0));
                 MlasSveStoreInt32(pg_b32_4, C1, MlasSveReinterpretS32FromU32(acc03_c1));
                 MlasSveStoreInt32(pg_b32_4, C2, MlasSveReinterpretS32FromU32(acc03_c2));
@@ -758,7 +757,7 @@ size_t Process4RowsTest256(
             }
         }
         else if(cols_this > 2){
-            if(isZeroPointB){
+            if(HasZeroPointB){
                 if(cols_this >= 4){
                     MlasSveStoreInt32(pg_b32_4, C0, MlasSveReinterpretS32FromU32(acc03_c0));
                     MlasSveStoreInt32(pg_b32_4, C1, MlasSveReinterpretS32FromU32(acc03_c1));
@@ -806,7 +805,7 @@ size_t Process4RowsTest256(
             }
         }
         else{
-            if(isZeroPointB){
+            if(HasZeroPointB){
                 MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C0, MlasSveReinterpretS32FromU32(acc03_c0));
                 MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C1, MlasSveReinterpretS32FromU32(acc03_c1));
                 MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C2, MlasSveReinterpretS32FromU32(acc03_c2));
@@ -846,7 +845,8 @@ size_t Process4RowsTest256(
     return 4;
 }
 
-size_t Process8RowsTest256(
+template<bool HasZeroPointB>
+MLAS_FORCEINLINE size_t Process8Rows(
     const uint8_t* A,
     const uint8_t* B,
     int32_t* C,
@@ -856,8 +856,7 @@ size_t Process8RowsTest256(
     size_t ldc,
     const int32_t* RowSumBuffer,
     const int32_t* ColumnSumBuffer,
-    const int32_t* ZeroPointB,
-    bool isZeroPointB)
+    const int32_t* ZeroPointB)
 {
     (void)CountM;
 
@@ -997,7 +996,7 @@ size_t Process8RowsTest256(
         // First 4 columns
         // 
         if(cols_this > 6){
-            if(isZeroPointB){
+            if(HasZeroPointB){
                 MlasSveStoreInt32(pg_b32_4, C0, MlasSveReinterpretS32FromU32(acc03_c0));
                 MlasSveStoreInt32(pg_b32_4, C1, MlasSveReinterpretS32FromU32(acc03_c1));
                 MlasSveStoreInt32(pg_b32_4, C2, MlasSveReinterpretS32FromU32(acc03_c2));
@@ -1109,7 +1108,7 @@ size_t Process8RowsTest256(
             }
         }
         else if(cols_this > 4){
-            if(isZeroPointB){
+            if(HasZeroPointB){
                 MlasSveStoreInt32(pg_b32_4, C0, MlasSveReinterpretS32FromU32(acc03_c0));
                 MlasSveStoreInt32(pg_b32_4, C1, MlasSveReinterpretS32FromU32(acc03_c1));
                 MlasSveStoreInt32(pg_b32_4, C2, MlasSveReinterpretS32FromU32(acc03_c2));
@@ -1221,7 +1220,7 @@ size_t Process8RowsTest256(
             }
         }
         else if(cols_this > 2){
-            if(isZeroPointB){
+            if(HasZeroPointB){
                 if(cols_this >= 4){
                     MlasSveStoreInt32(pg_b32_4, C0, MlasSveReinterpretS32FromU32(acc03_c0));
                     MlasSveStoreInt32(pg_b32_4, C1, MlasSveReinterpretS32FromU32(acc03_c1));
@@ -1301,7 +1300,7 @@ size_t Process8RowsTest256(
             }
         }
         else{
-            if(isZeroPointB){
+            if(HasZeroPointB){
                 MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C0, MlasSveReinterpretS32FromU32(acc03_c0));
                 MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C1, MlasSveReinterpretS32FromU32(acc03_c1));
                 MlasSveStoreInt32(MlasSveWhileLtB32(0, std::min(int(cols_this), 2)), C2, MlasSveReinterpretS32FromU32(acc03_c2));
@@ -1361,77 +1360,96 @@ size_t Process8RowsTest256(
     return 8;
 }
 
-size_t MlasSveQgemmU8X8KernelUmmlaAdd(const MLAS_GEMM_U8X8_KERNEL_UMMLA::PackedAType* A,
-                                const MLAS_GEMM_U8X8_KERNEL_UMMLA::PackedBType* B,
-                                int32_t* C,
-                                size_t PackedCountK,
-                                size_t CountM,
-                                size_t CountN,
-                                size_t ldc,
-                                const int32_t* RowSumBuffer,
-                                const int32_t* ColumnSumBuffer,
-                                const int32_t* ZeroPointB
-                              )
+template<bool HasZeroPointB>
+MLAS_FORCEINLINE size_t
+MlasSveQgemmU8X8KernelUmmlaImpl(
+    const MLAS_GEMM_U8X8_KERNEL_UMMLA::PackedAType* A,
+    const MLAS_GEMM_U8X8_KERNEL_UMMLA::PackedBType* B,
+    int32_t* C,
+    size_t PackedCountK,
+    size_t CountM,
+    size_t CountN,
+    size_t ldc,
+    const int32_t* RowSumBuffer,
+    const int32_t* ColumnSumBuffer,
+    const int32_t* ZeroPointB)
 {
-    bool isZeroPointB = false;
-     if (MlasSveCntb() >= 32) {
+    if (svcntb() == 32) {
+
         if (CountM >= 8) {
-                return Process8RowsTest256(A, B, C, PackedCountK, CountM, CountN, ldc,
-                                        RowSumBuffer, ColumnSumBuffer, ZeroPointB, isZeroPointB);
-        } 
-        else if (CountM >= 4) {
-            return Process4RowsTest256(A, B, C, PackedCountK, CountM, CountN, ldc,
-                                    RowSumBuffer, ColumnSumBuffer, ZeroPointB, isZeroPointB);
-        } else if (CountM >= 2) {
-            return Process2RowsTest256(A, B, C, PackedCountK, CountM, CountN, ldc,
-                                    RowSumBuffer, ColumnSumBuffer, ZeroPointB, isZeroPointB);
-        } else if (CountM >= 1) {
-            return Process1RowTest256(A, B, C, PackedCountK, CountM, CountN, ldc,
-                                RowSumBuffer, ColumnSumBuffer, ZeroPointB, isZeroPointB);
+            return Process8Rows<HasZeroPointB>(
+                A, B, C, PackedCountK, CountM, CountN, ldc,
+                RowSumBuffer, ColumnSumBuffer,
+                ZeroPointB);
         }
-     }
-     else{
-        MlasGemmU8X8KernelUmmlaAdd(A, B, C, PackedCountK, CountM, CountN, ldc,
+        else if (CountM >= 4) {
+            return Process4Rows<HasZeroPointB>(
+                A, B, C, PackedCountK, CountM, CountN, ldc,
+                RowSumBuffer, ColumnSumBuffer,
+                ZeroPointB);
+        }
+        else if (CountM >= 2) {
+            return Process2Rows<HasZeroPointB>(
+                A, B, C, PackedCountK, CountM, CountN, ldc,
+                RowSumBuffer, ColumnSumBuffer,
+                ZeroPointB);
+        }
+        else if (CountM >= 1) {
+            return Process1Row<HasZeroPointB>(
+                A, B, C, PackedCountK, CountM, CountN, ldc,
+                RowSumBuffer, ColumnSumBuffer,
+                ZeroPointB);
+        }
+    }
+    else {
+        if constexpr (HasZeroPointB) {
+            return MlasGemmU8X8KernelUmmlaZero(
+                A, B, C, PackedCountK, CountM, CountN, ldc,
                 RowSumBuffer, ColumnSumBuffer, ZeroPointB);
-     };
-    return 0; // Unsupported CountM
+
+        } else {
+            return MlasGemmU8X8KernelUmmlaAdd(
+                A, B, C, PackedCountK, CountM, CountN, ldc,
+                RowSumBuffer, ColumnSumBuffer, ZeroPointB);
+        }
+    }
+
+    return 0;
 }
 
-size_t MlasSveQgemmU8X8KernelUmmlaZero(const MLAS_GEMM_U8X8_KERNEL_UMMLA::PackedAType* A,
-                                const MLAS_GEMM_U8X8_KERNEL_UMMLA::PackedBType* B,
-                                int32_t* C,
-                                size_t PackedCountK,
-                                size_t CountM,
-                                size_t CountN,
-                                size_t ldc,
-                                const int32_t* RowSumBuffer,
-                                const int32_t* ColumnSumBuffer,
-                                const int32_t* ZeroPointB
-                              )
+size_t
+MlasSveQgemmU8X8KernelUmmlaZero(
+    const MLAS_GEMM_U8X8_KERNEL_UMMLA::PackedAType* A,
+    const MLAS_GEMM_U8X8_KERNEL_UMMLA::PackedBType* B,
+    int32_t* C,
+    size_t PackedCountK,
+    size_t CountM,
+    size_t CountN,
+    size_t ldc,
+    const int32_t* RowSumBuffer,
+    const int32_t* ColumnSumBuffer,
+    const int32_t* ZeroPointB)
 {
-    bool isZeroPointB = true;
-    if(MlasSveCntb() >= 32){
-        if (CountM >= 8) {
-            return Process8RowsTest256(A, B, C, PackedCountK, CountM, CountN, ldc,
-                                    RowSumBuffer, ColumnSumBuffer, ZeroPointB, isZeroPointB);
-        }
-        else if (CountM >= 4) {
-            return Process4RowsTest256(A, B, C, PackedCountK, CountM, CountN, ldc,
-                                    RowSumBuffer, ColumnSumBuffer, ZeroPointB, isZeroPointB);
-            
-        } else if (CountM >= 2) {
-            return Process2RowsTest256(A, B, C, PackedCountK, CountM, CountN, ldc,
-                                    RowSumBuffer, ColumnSumBuffer, ZeroPointB, isZeroPointB);
+    return MlasSveQgemmU8X8KernelUmmlaImpl<true>(
+        A, B, C, PackedCountK, CountM, CountN, ldc,
+        RowSumBuffer, ColumnSumBuffer, ZeroPointB);
+}
 
-        } else if (CountM >= 1) {
-            return Process1RowTest256(A, B, C, PackedCountK, CountM, CountN, ldc,
-                                RowSumBuffer, ColumnSumBuffer, ZeroPointB, isZeroPointB);
-        }
-    }
-    else{
-        MlasGemmU8X8KernelUmmlaZero(A, B, C, PackedCountK, CountM, CountN, ldc,
-                RowSumBuffer, ColumnSumBuffer, ZeroPointB);
-    }
-    return 0; // Unsupported CountM
+size_t
+MlasSveQgemmU8X8KernelUmmlaAdd(
+    const MLAS_GEMM_U8X8_KERNEL_UMMLA::PackedAType* A,
+    const MLAS_GEMM_U8X8_KERNEL_UMMLA::PackedBType* B,
+    int32_t* C,
+    size_t PackedCountK,
+    size_t CountM,
+    size_t CountN,
+    size_t ldc,
+    const int32_t* RowSumBuffer,
+    const int32_t* ColumnSumBuffer,
+    const int32_t* ZeroPointB)
+{
+    return MlasSveQgemmU8X8KernelUmmlaImpl<false>(
+        A, B, C, PackedCountK, CountM, CountN, ldc,
+        RowSumBuffer, ColumnSumBuffer, ZeroPointB);
 }
 #pragma GCC diagnostic pop

--- a/onnxruntime/core/mlas/lib/sve/qgemm_sve256.cpp
+++ b/onnxruntime/core/mlas/lib/sve/qgemm_sve256.cpp
@@ -64,7 +64,7 @@ MLAS_FORCEINLINE size_t Process1Row(
     //------------------------------------------------------------------
     svbool_t pg_b32_4 = MlasSveWhileLtB32(0, 4);  // stores 4 output columns
     svbool_t pg_b32_8 = MlasSvePtrueB32();  // full accumulator lanes
-    svbool_t pg_b8_32 = MlasSvePtrueB8(); // loads 32 bytes from A/B
+    svbool_t pg_b8_32 = MlasSveWhileLtB8(0, 32); // loads 32 bytes from A/B
     svuint32_t acc03, acc47;
 
     const int32_t rowsum = RowSumBuffer[0];
@@ -275,7 +275,7 @@ MLAS_FORCEINLINE size_t Process2Rows(
     //------------------------------------------------------------------
     svbool_t pg_b32_4 = MlasSveWhileLtB32(0, 4);  // stores 4 output columns
     svbool_t pg_b32_8 = MlasSvePtrueB32();  // full accumulator lanes
-    svbool_t pg_b8_32 = MlasSvePtrueB8(); // loads 32 bytes from A/B
+    svbool_t pg_b8_32 = MlasSveWhileLtB8(0, 32); // loads 32 bytes from A/B
     svuint32_t acc03, acc47;
 
     // const int32_t rowsum = RowSumBuffer[0];
@@ -525,7 +525,7 @@ MLAS_FORCEINLINE size_t Process4Rows(
     //------------------------------------------------------------------
     svbool_t pg_b32_4 = MlasSveWhileLtB32(0, 4);  // stores 4 output columns
     svbool_t pg_b32_8 = MlasSvePtrueB32();  // full accumulator lanes
-    svbool_t pg_b8_32 = MlasSvePtrueB8(); // loads 32 bytes from A/B
+    svbool_t pg_b8_32 = MlasSveWhileLtB8(0, 32); // loads 32 bytes from A/B
     svuint32_t acc03_0, acc03_1, acc47_0, acc47_1;
 
     // const int32_t rowsum = RowSumBuffer[0];
@@ -865,7 +865,7 @@ MLAS_FORCEINLINE size_t Process8Rows(
     //------------------------------------------------------------------
     svbool_t pg_b32_4 = MlasSveWhileLtB32(0, 4);  // stores 4 output columns
     svbool_t pg_b32_8 = MlasSvePtrueB32();  // full accumulator lanes
-    svbool_t pg_b8_32 = MlasSvePtrueB8(); // loads 32 bytes from A/B
+    svbool_t pg_b8_32 = MlasSveWhileLtB8(0, 32); // loads 32 bytes from A/B
     svuint32_t acc03_0, acc03_1, acc03_2, acc03_3, acc47_0, acc47_1, acc47_2, acc47_3;
 
     // const int32_t rowsum = RowSumBuffer[0];

--- a/onnxruntime/core/mlas/lib/sve/qgemm_sve256.cpp
+++ b/onnxruntime/core/mlas/lib/sve/qgemm_sve256.cpp
@@ -9,8 +9,10 @@
 #include "mlasi_sve.h"
 #include "mlasi_sve_i8.h"
 
+#if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
 
 extern "C" {
 
@@ -932,4 +934,7 @@ MlasSveQgemmU8X8KernelUmmlaAdd(
         A, B, C, PackedCountK, CountM, CountN, ldc,
         RowSumBuffer, ColumnSumBuffer, ZeroPointB);
 }
+
+#if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic pop
+#endif


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
This PR adds a complete SVE256-based QGEMM U8×X8→S32 kernel, providing a portable, scalable-vector alternative to the existing UMMLA assembly path. It includes SVE implementations for all row kernel variants (8/6/4/2), full accumulator setup, zero-point/row-sum/column-sum compensation, and correct partial-column store handling. Machines with an SVE vector register length other than 256 bits will fall back to the existing NEON (UMMLA) path.

## Performance
Benchmarked against the existing NEON (UMMLA) int8 path across three quantized models on Graviton3E SVE256 machine:
| Model | Size (Int8) | Batch Size | SVE (ms) | NEON (ms) |
|---|---|---|---|---|
| T5 | 60.5M | 1 | 5.47 | 5.61 |
| Jina | 239M | 1 | 2.50 | 2.49 |
| intfloat/multilingual-e5-large | 600M | 8 (seq len 256) | 299 | 321 |

The SVE256 kernel matches or outperforms the existing NEON UMMLA path by ~1.1x while adding the portability benefits of a scalable-vector implementation.

**Contributors:** @sanketkaleoss, @abhijain1204fujitsu

