### PR TITLE
Fix false-green in Pow_float16_float16 when CUDA/CoreML are unavailable

### DIFF
--- a/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
@@ -1485,9 +1485,13 @@ TEST(MathOpTest, Pow_double_int64) {
 }
 
 TEST(MathOpTest, Pow_float16_float16) {
+#if defined(USE_CUDA) || defined(USE_COREML)
   std::vector<int64_t> dims{4};
   TestBinaryFloat16("Pow", dims, {2.0f, 2.0f, std::sqrt(2.0f), 1.0f}, dims, {0.0f, 8.0f, 2.0f, 9.0f},
                     dims, {1.0f, 256.0f, 2.0f, 1.0f}, false);
+#else
+  GTEST_SKIP() << "Pow float16 is only exercised on CUDA or CoreML EP builds.";
+#endif
 }
 
 #if defined(USE_CUDA) || defined(USE_COREML)


### PR DESCRIPTION
### Description

`TEST(MathOpTest, Pow_float16_float16)` calls the `TestBinaryFloat16` helper as its **only** body. That helper builds an fp16 `OpTester` only when a fp16-capable EP (CUDA or CoreML) is compiled in; on a CPU-only build the `execution_providers` list is empty and nothing runs. Because there is no other assertion in the test, on CPU-only builds the test reported **PASS while asserting nothing** — a false green.

This change guards the test body so it explicitly `GTEST_SKIP()`s on builds without CUDA/CoreML, and runs exactly as before where an fp16-capable EP is available.

```cpp
TEST(MathOpTest, Pow_float16_float16) {
#if defined(USE_CUDA) || defined(USE_COREML)
  std::vector<int64_t> dims{4};
  TestBinaryFloat16("Pow", dims, {...}, dims, {...}, dims, {...}, false);
#else
  GTEST_SKIP() << "Pow float16 is only exercised on CUDA or CoreML EP builds.";
#endif
}
```

### Motivation and Context

Converts a misleading "passed-but-verified-nothing" result into an honest **skipped** on CPU-only builds, so test dashboards don't over-count green. No coverage is lost: the fp16 path still runs on CUDA/CoreML builds.

### Scope / safety

- Test-only change; no product/runtime code is touched.
- Only this single test is changed. The shared `TestBinaryFloat16` / `TestUnaryFloat16` helpers are intentionally left **unchanged**, because their other callers (e.g. `Add_float`, `Sub_float`, `Mul_float`, `Reciprocal`, `Sqrt`) run a CPU `Run()` assertion first and then call the helper as a supplement — placing the skip inside the helper would wrongly flip those genuinely-passing CPU tests to "skipped". `Pow_float16_float16` was the only caller that used the helper as its sole body, so it is the only true false-green.
