### PR TITLE
Fuse BatchNormalization into ConvTranspose

### DIFF
--- a/onnxruntime/core/optimizer/conv_bn_fusion.cc
+++ b/onnxruntime/core/optimizer/conv_bn_fusion.cc
@@ -15,6 +15,8 @@ namespace onnxruntime {
 
 namespace {
 
+constexpr float kDefaultBatchNormalizationEpsilon = 1e-5f;
+
 int64_t GetGroup(const Node& node) {
   const auto* group_attr = graph_utils::GetNodeAttribute(node, "group");
   return group_attr != nullptr && utils::HasInt(*group_attr) ? group_attr->i() : 1;
@@ -112,13 +114,14 @@ Status ConvBNFusion::Apply(Graph& graph, Node& node, RewriteRuleEffect& rule_eff
   const bool is_conv_transpose = conv_node.OpType() == "ConvTranspose";
   const int64_t group = is_conv_transpose ? GetGroup(conv_node) : 1;
 
-  // Get value of attribute epsilon
-  const onnxruntime::NodeAttributes& attributes = bn_node.GetAttributes();
-  const ONNX_NAMESPACE::AttributeProto* attr = &(attributes.find("epsilon")->second);
-  if (attr == nullptr || attr->type() != AttributeProto_AttributeType_FLOAT) {
-    return Status::OK();
+  float epsilon = kDefaultBatchNormalizationEpsilon;
+  const auto* attr = graph_utils::GetNodeAttribute(bn_node, "epsilon");
+  if (attr != nullptr) {
+    if (!utils::HasFloat(*attr)) {
+      return Status::OK();
+    }
+    epsilon = static_cast<float>(attr->f());
   }
-  float epsilon = static_cast<float>(attr->f());
 
   // Get initializers of BatchNormalization
   const auto& bn_inputs = bn_node.InputDefs();

--- a/onnxruntime/core/optimizer/conv_bn_fusion.cc
+++ b/onnxruntime/core/optimizer/conv_bn_fusion.cc
@@ -6,13 +6,111 @@
 #include "core/optimizer/conv_bn_fusion.h"
 #include "core/optimizer/utils.h"
 
+#include <limits>
+#include <type_traits>
+
 using namespace ONNX_NAMESPACE;
 using namespace onnxruntime::common;
 namespace onnxruntime {
 
+namespace {
+
+int64_t GetGroup(const Node& node) {
+  const auto* group_attr = graph_utils::GetNodeAttribute(node, "group");
+  return group_attr != nullptr && utils::HasInt(*group_attr) ? group_attr->i() : 1;
+}
+
+bool IsValidWeightShapeForFusion(const TensorProto& weight,
+                                 int64_t bn_channels,
+                                 bool is_conv_transpose,
+                                 int64_t group) {
+  if (weight.dims_size() <= 2) {
+    return false;
+  }
+
+  if (!is_conv_transpose) {
+    return weight.dims(0) == bn_channels;
+  }
+
+  if (group <= 0 ||
+      weight.dims(0) <= 0 ||
+      weight.dims(1) <= 0 ||
+      weight.dims(0) % group != 0 ||
+      weight.dims(1) > std::numeric_limits<int64_t>::max() / group) {
+    return false;
+  }
+
+  return weight.dims(1) * group == bn_channels;
+}
+
+template <typename T>
+void ScaleConvTransposeWeightData(Initializer& weight, const Initializer& scalers, int64_t group) {
+  const auto dims = weight.dims();
+  ORT_ENFORCE(dims.size() > 2, "ConvTranspose weight should have at least 3 dimensions.");
+  ORT_ENFORCE(group > 0, "ConvTranspose group should be positive.");
+
+  const int64_t input_channels = dims[0];
+  const int64_t output_channels_per_group = dims[1];
+  ORT_ENFORCE(input_channels > 0 && output_channels_per_group > 0, "Invalid ConvTranspose weight shape.");
+  ORT_ENFORCE(input_channels % group == 0, "Invalid ConvTranspose group for weight shape.");
+  ORT_ENFORCE(output_channels_per_group <= std::numeric_limits<int64_t>::max() / group,
+              "Invalid ConvTranspose output channel count.");
+
+  const int64_t input_channels_per_group = input_channels / group;
+  ORT_ENFORCE(static_cast<size_t>(output_channels_per_group * group) == scalers.size(),
+              "Invalid ConvTranspose channel scaler size.");
+
+  size_t kernel_size = 1;
+  for (size_t i = 2; i < dims.size(); ++i) {
+    ORT_ENFORCE(dims[i] > 0, "Invalid ConvTranspose kernel shape.");
+    kernel_size *= static_cast<size_t>(dims[i]);
+  }
+
+  using Numeric = std::conditional_t<std::is_same_v<T, double>, double, float>;
+  T* weight_data = weight.data<T>();
+  const T* scaler_data = scalers.data<T>();
+
+  for (int64_t input_channel = 0; input_channel < input_channels; ++input_channel) {
+    const int64_t group_index = input_channel / input_channels_per_group;
+    for (int64_t output_channel = 0; output_channel < output_channels_per_group; ++output_channel) {
+      const auto scaler_index = static_cast<size_t>(group_index * output_channels_per_group + output_channel);
+      const Numeric scale = static_cast<Numeric>(scaler_data[scaler_index]);
+      const size_t weight_offset =
+          (static_cast<size_t>(input_channel) * static_cast<size_t>(output_channels_per_group) +
+           static_cast<size_t>(output_channel)) *
+          kernel_size;
+
+      for (size_t kernel_index = 0; kernel_index < kernel_size; ++kernel_index) {
+        T& value = weight_data[weight_offset + kernel_index];
+        value = T(static_cast<Numeric>(value) * scale);
+      }
+    }
+  }
+}
+
+void ScaleConvTransposeWeightByOutputChannel(Initializer& weight, const Initializer& scalers, int64_t group) {
+  switch (weight.data_type()) {
+    case ONNX_NAMESPACE::TensorProto_DataType_FLOAT:
+      ScaleConvTransposeWeightData<float>(weight, scalers, group);
+      break;
+    case ONNX_NAMESPACE::TensorProto_DataType_FLOAT16:
+      ScaleConvTransposeWeightData<MLFloat16>(weight, scalers, group);
+      break;
+    case ONNX_NAMESPACE::TensorProto_DataType_DOUBLE:
+      ScaleConvTransposeWeightData<double>(weight, scalers, group);
+      break;
+    default:
+      ORT_ENFORCE(false, "Unsupported ConvTranspose weight data type for BN fusion.");
+  }
+}
+
+}  // namespace
+
 Status ConvBNFusion::Apply(Graph& graph, Node& node, RewriteRuleEffect& rule_effect, const logging::Logger&) const {
   auto& conv_node = node;
   Node& bn_node = *graph.GetNode(conv_node.OutputNodesBegin()->Index());
+  const bool is_conv_transpose = conv_node.OpType() == "ConvTranspose";
+  const int64_t group = is_conv_transpose ? GetGroup(conv_node) : 1;
 
   // Get value of attribute epsilon
   const onnxruntime::NodeAttributes& attributes = bn_node.GetAttributes();
@@ -40,7 +138,7 @@ Status ConvBNFusion::Apply(Graph& graph, Node& node, RewriteRuleEffect& rule_eff
   const auto* conv_W_tensor_proto = graph_utils::GetConstantInitializer(graph, conv_inputs[1]->Name());
   ORT_ENFORCE(conv_W_tensor_proto);
 
-  // Conv only supports floating point data types, so can only fuse with an initializer containing those types
+  // Conv and ConvTranspose only support floating point data types, so can only fuse with initializers containing those types
   if (!optimizer_utils::IsFloatingPointDataType(*bn_scale_tensor_proto) ||
       !optimizer_utils::IsFloatingPointDataType(*bn_B_tensor_proto) ||
       !optimizer_utils::IsFloatingPointDataType(*bn_mean_tensor_proto) ||
@@ -56,8 +154,11 @@ Status ConvBNFusion::Apply(Graph& graph, Node& node, RewriteRuleEffect& rule_eff
       bn_scale_tensor_proto->data_type() != bn_B_tensor_proto->data_type() ||
       bn_B_tensor_proto->data_type() != bn_mean_tensor_proto->data_type() ||
       bn_mean_tensor_proto->data_type() != bn_var_tensor_proto->data_type() ||
-      conv_W_tensor_proto->data_type() != bn_scale_tensor_proto->data_type() ||
-      !(conv_W_tensor_proto->dims_size() > 2 && conv_W_tensor_proto->dims(0) == bn_scale_tensor_proto->dims(0))) {
+      conv_W_tensor_proto->data_type() != bn_scale_tensor_proto->data_type()) {
+    return Status::OK();
+  }
+
+  if (!IsValidWeightShapeForFusion(*conv_W_tensor_proto, bn_scale_tensor_proto->dims(0), is_conv_transpose, group)) {
     return Status::OK();
   }
 
@@ -86,7 +187,11 @@ Status ConvBNFusion::Apply(Graph& graph, Node& node, RewriteRuleEffect& rule_eff
   bn_var.add(epsilon);
   bn_var.sqrt();
   bn_scale.div(bn_var);
-  conv_W.scale_by_axis(bn_scale, 1);
+  if (is_conv_transpose) {
+    ScaleConvTransposeWeightByOutputChannel(conv_W, bn_scale, group);
+  } else {
+    conv_W.scale_by_axis(bn_scale, 1);
+  }
 
   if (conv_inputs.size() == 3) {
     conv_B->sub(bn_mean);
@@ -145,7 +250,11 @@ Status ConvBNFusion::Apply(Graph& graph, Node& node, RewriteRuleEffect& rule_eff
 }
 
 bool ConvBNFusion::SatisfyCondition(const Graph& graph, const Node& node, const logging::Logger&) const {
-  if (!graph_utils::IsSupportedOptypeVersionAndDomain(node, "Conv", {1, 11, 22}) ||
+  const bool is_supported_conv = graph_utils::IsSupportedOptypeVersionAndDomain(node, "Conv", {1, 11, 22});
+  const bool is_supported_conv_transpose =
+      graph_utils::IsSupportedOptypeVersionAndDomain(node, "ConvTranspose", {1, 11, 22});
+
+  if ((!is_supported_conv && !is_supported_conv_transpose) ||
       node.GetOutputEdgesCount() != 1) {
     return false;
   }

--- a/onnxruntime/core/optimizer/conv_bn_fusion.cc
+++ b/onnxruntime/core/optimizer/conv_bn_fusion.cc
@@ -5,6 +5,7 @@
 #include "core/optimizer/initializer.h"
 #include "core/optimizer/conv_bn_fusion.h"
 #include "core/optimizer/utils.h"
+#include "core/common/safeint.h"
 
 #include <limits>
 #include <type_traits>
@@ -59,14 +60,15 @@ void ScaleConvTransposeWeightData(Initializer& weight, const Initializer& scaler
               "Invalid ConvTranspose output channel count.");
 
   const int64_t input_channels_per_group = input_channels / group;
-  ORT_ENFORCE(static_cast<size_t>(output_channels_per_group * group) == scalers.size(),
+  ORT_ENFORCE(SafeInt<size_t>(output_channels_per_group) * group == scalers.size(),
               "Invalid ConvTranspose channel scaler size.");
 
-  size_t kernel_size = 1;
+  SafeInt<size_t> safe_kernel_size = 1;
   for (size_t i = 2; i < dims.size(); ++i) {
     ORT_ENFORCE(dims[i] > 0, "Invalid ConvTranspose kernel shape.");
-    kernel_size *= static_cast<size_t>(dims[i]);
+    safe_kernel_size *= SafeInt<size_t>(dims[i]);
   }
+  const size_t kernel_size = safe_kernel_size;
 
   using Numeric = std::conditional_t<std::is_same_v<T, double>, double, float>;
   T* weight_data = weight.data<T>();
@@ -78,9 +80,7 @@ void ScaleConvTransposeWeightData(Initializer& weight, const Initializer& scaler
       const auto scaler_index = static_cast<size_t>(group_index * output_channels_per_group + output_channel);
       const Numeric scale = static_cast<Numeric>(scaler_data[scaler_index]);
       const size_t weight_offset =
-          (static_cast<size_t>(input_channel) * static_cast<size_t>(output_channels_per_group) +
-           static_cast<size_t>(output_channel)) *
-          kernel_size;
+          (SafeInt<size_t>(input_channel) * output_channels_per_group + output_channel) * kernel_size;
 
       for (size_t kernel_index = 0; kernel_index < kernel_size; ++kernel_index) {
         T& value = weight_data[weight_offset + kernel_index];

--- a/onnxruntime/core/optimizer/conv_bn_fusion.h
+++ b/onnxruntime/core/optimizer/conv_bn_fusion.h
@@ -10,16 +10,16 @@ namespace onnxruntime {
 /**
 @Class ConvBNFusion
 
-Rewrite rule that fuses two Conv+BN nodes to a single Conv node.
+Rewrite rule that fuses Conv/ConvTranspose+BN nodes to a single Conv/ConvTranspose node.
 
-It is attempted to be triggered only on nodes with op type "Conv".
+It is attempted to be triggered only on nodes with op type "Conv" or "ConvTranspose".
 */
 class ConvBNFusion : public RewriteRule {
  public:
   ConvBNFusion() noexcept : RewriteRule("ConvBNFusion") {}
 
   std::vector<std::string> TargetOpTypes() const noexcept override {
-    return {"Conv"};
+    return {"Conv", "ConvTranspose"};
   }
 
  private:

--- a/onnxruntime/test/optimizer/graph_transform_test.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test.cc
@@ -1887,7 +1887,7 @@ TEST_F(GraphTransformationTests, FuseConvBNNoBias) {
   }
 }
 
-static void RunConvTransposeBNFusionTest(bool add_conv_bias, int64_t group) {
+static void RunConvTransposeBNFusionTest(bool add_conv_bias, int64_t group, bool add_epsilon = true) {
   const int64_t input_channels_per_group = 2;
   const int64_t input_channels = input_channels_per_group * group;
   const int64_t output_channels_per_group = 3;
@@ -1948,8 +1948,10 @@ static void RunConvTransposeBNFusionTest(bool add_conv_bias, int64_t group) {
     auto* output = builder.MakeOutput<float>(std::vector<int64_t>{1, output_channels, output_h, output_w});
     bn_output_name = output->Name();
 
-    builder.AddNode("BatchNormalization", {conv_output, bn_scale, bn_bias, bn_mean, bn_var}, {output})
-        .AddAttribute("epsilon", 1e-5f);
+    auto& batch_norm = builder.AddNode("BatchNormalization", {conv_output, bn_scale, bn_bias, bn_mean, bn_var}, {output});
+    if (add_epsilon) {
+      batch_norm.AddAttribute("epsilon", 1e-5f);
+    }
   };
 
   auto check_transformed_graph = [&bn_output_name](InferenceSessionWrapper& session) {
@@ -1984,6 +1986,10 @@ static void RunConvTransposeBNFusionTest(bool add_conv_bias, int64_t group) {
 
 TEST_F(GraphTransformationTests, FuseConvTransposeBNNoBias) {
   RunConvTransposeBNFusionTest(false, 1);
+}
+
+TEST_F(GraphTransformationTests, FuseConvTransposeBNWithDefaultEpsilon) {
+  RunConvTransposeBNFusionTest(false, 1, false);
 }
 
 TEST_F(GraphTransformationTests, FuseConvTransposeBNWithBias) {

--- a/onnxruntime/test/optimizer/graph_transform_test.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test.cc
@@ -1887,6 +1887,161 @@ TEST_F(GraphTransformationTests, FuseConvBNNoBias) {
   }
 }
 
+static void RunConvTransposeBNFusionTest(bool add_conv_bias, int64_t group) {
+  const int64_t input_channels_per_group = 2;
+  const int64_t input_channels = input_channels_per_group * group;
+  const int64_t output_channels_per_group = 3;
+  const int64_t output_channels = output_channels_per_group * group;
+  const int64_t input_h = 4;
+  const int64_t input_w = 4;
+  const int64_t kernel_h = 3;
+  const int64_t kernel_w = 3;
+  const int64_t output_h = input_h + kernel_h - 1;
+  const int64_t output_w = input_w + kernel_w - 1;
+
+  auto make_values = [](size_t size, float scale, float offset) {
+    std::vector<float> values(size);
+    for (size_t i = 0; i < values.size(); ++i) {
+      values[i] = offset + scale * static_cast<float>(static_cast<int64_t>(i % 17) - 8);
+    }
+
+    return values;
+  };
+
+  const auto weight_data = make_values(static_cast<size_t>(input_channels) *
+                                           static_cast<size_t>(output_channels_per_group) *
+                                           static_cast<size_t>(kernel_h) *
+                                           static_cast<size_t>(kernel_w),
+                                       0.02f,
+                                       0.01f);
+  const auto conv_bias_data = make_values(static_cast<size_t>(output_channels), 0.03f, -0.02f);
+  const auto bn_scale_data = make_values(static_cast<size_t>(output_channels), 0.04f, 0.9f);
+  const auto bn_bias_data = make_values(static_cast<size_t>(output_channels), 0.05f, -0.1f);
+  const auto bn_mean_data = make_values(static_cast<size_t>(output_channels), 0.02f, 0.12f);
+  std::vector<float> bn_var_data(static_cast<size_t>(output_channels));
+  for (size_t i = 0; i < bn_var_data.size(); ++i) {
+    bn_var_data[i] = 0.7f + 0.05f * static_cast<float>(i);
+  }
+
+  std::string bn_output_name;
+  auto build_test_case = [&](ModelTestBuilder& builder) {
+    auto* input = builder.MakeInput<float>(std::vector<int64_t>{1, input_channels, input_h, input_w}, -1.0f, 1.0f);
+    auto* weight = builder.MakeInitializer<float>({input_channels, output_channels_per_group, kernel_h, kernel_w},
+                                                  weight_data);
+
+    std::vector<NodeArg*> conv_inputs{input, weight};
+    if (add_conv_bias) {
+      conv_inputs.push_back(builder.MakeInitializer<float>({output_channels}, conv_bias_data));
+    }
+
+    auto* conv_output =
+        builder.MakeIntermediate<float>(std::vector<int64_t>{1, output_channels, output_h, output_w});
+    auto& conv_transpose = builder.AddNode("ConvTranspose", conv_inputs, {conv_output});
+    if (group != 1) {
+      conv_transpose.AddAttribute("group", group);
+    }
+
+    auto* bn_scale = builder.MakeInitializer<float>({output_channels}, bn_scale_data);
+    auto* bn_bias = builder.MakeInitializer<float>({output_channels}, bn_bias_data);
+    auto* bn_mean = builder.MakeInitializer<float>({output_channels}, bn_mean_data);
+    auto* bn_var = builder.MakeInitializer<float>({output_channels}, bn_var_data);
+    auto* output = builder.MakeOutput<float>(std::vector<int64_t>{1, output_channels, output_h, output_w});
+    bn_output_name = output->Name();
+
+    builder.AddNode("BatchNormalization", {conv_output, bn_scale, bn_bias, bn_mean, bn_var}, {output})
+        .AddAttribute("epsilon", 1e-5f);
+  };
+
+  auto check_transformed_graph = [&bn_output_name](InferenceSessionWrapper& session) {
+    const Graph& graph = session.GetGraph();
+    auto op_to_count = CountOpsInGraph(graph);
+    ASSERT_EQ(op_to_count["BatchNormalization"], 0);
+    ASSERT_EQ(op_to_count["ConvTranspose"], 1);
+
+    bool found_conv_transpose = false;
+    for (const auto& node : graph.Nodes()) {
+      if (node.OpType() == "ConvTranspose") {
+        found_conv_transpose = true;
+        ASSERT_EQ(node.InputDefs().size(), 3U);
+        ASSERT_EQ(node.OutputDefs()[0]->Name(), bn_output_name)
+            << "fusion should produce the same output name as the last node";
+      }
+    }
+    ASSERT_TRUE(found_conv_transpose);
+  };
+
+  auto rule_transformer_L1 = std::make_unique<RuleBasedGraphTransformer>("RuleTransformerL1");
+  ASSERT_STATUS_OK(rule_transformer_L1->Register(std::make_unique<ConvBNFusion>()));
+  TransformerTester(build_test_case,
+                    check_transformed_graph,
+                    TransformerLevel::Default,
+                    TransformerLevel::Level1,
+                    14,
+                    1e-4,
+                    1e-4,
+                    std::move(rule_transformer_L1));
+}
+
+TEST_F(GraphTransformationTests, FuseConvTransposeBNNoBias) {
+  RunConvTransposeBNFusionTest(false, 1);
+}
+
+TEST_F(GraphTransformationTests, FuseConvTransposeBNWithBias) {
+  RunConvTransposeBNFusionTest(true, 1);
+}
+
+TEST_F(GraphTransformationTests, FuseGroupedConvTransposeBN) {
+  RunConvTransposeBNFusionTest(true, 2);
+}
+
+TEST_F(GraphTransformationTests, DontFuseConvTransposeWithBNWithNonConstantWeight) {
+  const int64_t input_channels = 2;
+  const int64_t output_channels = 3;
+  const int64_t kernel_h = 3;
+  const int64_t kernel_w = 3;
+  const int64_t output_h = 6;
+  const int64_t output_w = 6;
+
+  auto build_test_case = [&](ModelTestBuilder& builder) {
+    auto* input = builder.MakeInput<float>(std::vector<int64_t>{1, input_channels, 4, 4}, -1.0f, 1.0f);
+    auto* weight =
+        builder.MakeInput<float>(std::vector<int64_t>{input_channels, output_channels, kernel_h, kernel_w},
+                                 -0.2f,
+                                 0.2f);
+
+    auto* conv_output =
+        builder.MakeIntermediate<float>(std::vector<int64_t>{1, output_channels, output_h, output_w});
+    builder.AddNode("ConvTranspose", {input, weight}, {conv_output});
+
+    auto* bn_scale = builder.MakeInitializer<float>({output_channels}, {0.8f, 0.9f, 1.0f});
+    auto* bn_bias = builder.MakeInitializer<float>({output_channels}, {-0.1f, 0.0f, 0.1f});
+    auto* bn_mean = builder.MakeInitializer<float>({output_channels}, {0.2f, 0.3f, 0.4f});
+    auto* bn_var = builder.MakeInitializer<float>({output_channels}, {0.7f, 0.8f, 0.9f});
+    auto* output = builder.MakeOutput<float>(std::vector<int64_t>{1, output_channels, output_h, output_w});
+
+    builder.AddNode("BatchNormalization", {conv_output, bn_scale, bn_bias, bn_mean, bn_var}, {output})
+        .AddAttribute("epsilon", 1e-5f);
+  };
+
+  auto check_transformed_graph = [](InferenceSessionWrapper& session) {
+    const Graph& graph = session.GetGraph();
+    auto op_to_count = CountOpsInGraph(graph);
+    ASSERT_EQ(op_to_count["BatchNormalization"], 1);
+    ASSERT_EQ(op_to_count["ConvTranspose"], 1);
+  };
+
+  auto rule_transformer_L1 = std::make_unique<RuleBasedGraphTransformer>("RuleTransformerL1");
+  ASSERT_STATUS_OK(rule_transformer_L1->Register(std::make_unique<ConvBNFusion>()));
+  TransformerTester(build_test_case,
+                    check_transformed_graph,
+                    TransformerLevel::Default,
+                    TransformerLevel::Level1,
+                    14,
+                    0.0,
+                    0.0,
+                    std::move(rule_transformer_L1));
+}
+
 TEST_F(GraphTransformationTests, FusePadWithConv) {
   constexpr const ORTCHAR_T* model_uri = MODEL_FOLDER "fusion/fuse-pad-conv.onnx";
 


### PR DESCRIPTION
### Description

Extends `ConvBNFusion` to support fusing `ConvTranspose -> BatchNormalization`.

The existing fusion path only handled `Conv -> BatchNormalization`. This change adds `ConvTranspose` as a supported target and folds BatchNormalization parameters into ConvTranspose when the required initializers are constant and the channel shapes are compatible.

For ConvTranspose, the weight layout is `[C_in, C_out/group, ...]`, so the BatchNormalization scale is applied by absolute output channel instead of using the existing Conv weight-axis scaling path. The existing Conv fusion behavior is unchanged.

This also adds graph transformer tests for:

- ConvTranspose without bias
- ConvTranspose with bias
- grouped ConvTranspose
- no fusion when ConvTranspose weight is not constant

### Motivation and Context

`Conv -> BatchNormalization` is already fused by `ConvBNFusion`, but the same optimization was not applied to `ConvTranspose -> BatchNormalization`. As a result, eligible ConvTranspose models kept an extra BatchNormalization node after graph optimization.

Fusing the BatchNormalization into ConvTranspose removes the redundant node and makes ConvTranspose consistent with the existing Conv fusion behavior while preserving numerical equivalence.

Fixes #14270