### PR TITLE
Fix wrong ORT version in Windows DLL VersionInfo for pipeline builds

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1069,7 +1069,7 @@ def generate_build_tree(
     cmake_args += cmake_extra_args
 
     # ADO pipelines will store the pipeline build number
-    # (e.g. 191101-2300.1.master) and source version in environment
+    # (e.g. 20260615.4) and source version in environment
     # variables. If present, use these values to define the
     # WinML/ORT DLL versions.
     build_number = os.getenv("Build_BuildNumber")  # noqa: SIM112
@@ -1077,31 +1077,31 @@ def generate_build_tree(
     if build_number and source_version:
         build_matches = re.fullmatch(r"(\d\d)(\d\d)(\d\d)(\d\d)\.(\d+)", build_number)
         if build_matches:
-            YY = build_matches.group(2)  # noqa: N806
             MM = build_matches.group(3)  # noqa: N806
             DD = build_matches.group(4)  # noqa: N806
 
-            # Get ORT major and minor number
+            # Get ORT major, minor, and patch number
             with open(os.path.join(source_dir, "VERSION_NUMBER")) as f:
                 first_line = f.readline()
-                ort_version_matches = re.match(r"(\d+).(\d+)", first_line)
+                ort_version_matches = re.match(r"(\d+)\.(\d+)\.(\d+)", first_line)
                 if not ort_version_matches:
                     raise BuildError("Couldn't read version from VERSION_FILE")
                 ort_major = ort_version_matches.group(1)
                 ort_minor = ort_version_matches.group(2)
-                # Example (BuildNumber: 191101-2300.1.master,
-                # SourceVersion: 0bce7ae6755c792eda558e5d27ded701707dc404)
+                ort_patch = ort_version_matches.group(3)
+                # Example (VERSION_NUMBER: 1.27.0, BuildNumber: 20260615.4,
+                # SourceVersion: 8f0278c77bf44b0cc83c098c6c722b92a36ac4b5)
                 # MajorPart = 1
-                # MinorPart = 0
-                # BuildPart = 1911
-                # PrivatePart = 123
-                # String = 191101-2300.1.master.0bce7ae
+                # MinorPart = 27
+                # BuildPart = 0
+                # PrivatePart = 615
+                # String = 1.27.0.20260615.4.8f0278c
                 cmake_args += [
                     f"-DVERSION_MAJOR_PART={ort_major}",
                     f"-DVERSION_MINOR_PART={ort_minor}",
-                    f"-DVERSION_BUILD_PART={YY}",
+                    f"-DVERSION_BUILD_PART={ort_patch}",
                     f"-DVERSION_PRIVATE_PART={MM}{DD}",
-                    f"-DVERSION_STRING={ort_major}.{ort_minor}.{build_number}.{source_version[0:7]}",
+                    f"-DVERSION_STRING={ort_major}.{ort_minor}.{ort_patch}.{build_number}.{source_version[0:7]}",
                 ]
 
     for config in configs:

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1085,7 +1085,7 @@ def generate_build_tree(
                 first_line = f.readline()
                 ort_version_matches = re.match(r"(\d+)\.(\d+)\.(\d+)", first_line)
                 if not ort_version_matches:
-                    raise BuildError("Couldn't read version from VERSION_FILE")
+                    raise BuildError("Couldn't read version from VERSION_NUMBER")
                 ort_major = ort_version_matches.group(1)
                 ort_minor = ort_version_matches.group(2)
                 ort_patch = ort_version_matches.group(3)


### PR DESCRIPTION
### Description

Official Windows DLLs embed the wrong version in their VersionInfo resource, for example File version 1.27.26.615 for the 1.27.0 release. The cmake fix from #24606 is intact but only covers local builds; official packages are produced by the ADO pipelines, which take a different path in tools/ci_build/build.py. When Build_BuildNumber and Build_SourceVersion are set, that branch stamps VERSION_BUILD_PART from the last two digits of the build year and drops the patch version from the version string entirely. I checked the shipped 1.22.0, 1.23.0, 1.26.0, and 1.27.0 Windows packages and all four carry the wrong version, so this path was never fixed.

This change parses major.minor.patch from VERSION_NUMBER, stamps the real ORT version in the numeric FILEVERSION (keeping MMDD as the fourth part for build traceability; it fits a 16-bit WORD), and includes the patch in the version string, which becomes for example 1.27.0.20260615.4.8f0278c. Local builds are unaffected. One open question for reviewers: whether you would rather have the fourth numeric part be the pipeline revision or zero instead of MMDD.

### Motivation and Context

Fixes #29536. Anyone inspecting DLL properties, or tooling that reads VersionInfo to identify the installed ONNX Runtime version, currently sees a build-date artifact instead of the actual release version.

Verified by executing the pristine and patched stamping logic with the real 1.27.0 release inputs (the pristine output reproduces the issue exactly), and by compiling onnxruntime.rc with the Windows SDK rc.exe under both define sets and decoding VS_FIXEDFILEINFO from the .res: 1.27.26.615 before, 1.27.0.615 after. A full pipeline build was not run; confirming end to end means building with Build_BuildNumber and Build_SourceVersion set and checking the DLL's FileVersionRaw.