### PR TITLE
Fix uninterpolated error messages in per-channel TensorQuantOverrides validation

### DIFF
--- a/onnxruntime/python/tools/quantization/tensor_quant_overrides.py
+++ b/onnxruntime/python/tools/quantization/tensor_quant_overrides.py
@@ -311,22 +311,22 @@ class TensorQuantOverridesHelper(MutableMapping):
             if "quant_type" in quant_overrides and quant_type != quant_overrides["quant_type"]:
                 return (
                     False,
-                    "Channel quantization types for tensor '{tensor_name}' do not match at index {index}.",
+                    f"Channel quantization types for tensor '{tensor_name}' do not match at index {index}.",
                 )
             if "axis" in quant_overrides and axis != quant_overrides["axis"] and norm_axis != quant_overrides["axis"]:
                 return (
                     False,
-                    "Channel axis for tensor '{tensor_name}' does not match at index {index}.",
+                    f"Channel axis for tensor '{tensor_name}' does not match at index {index}.",
                 )
             if "symmetric" in quant_overrides and symmetric != quant_overrides["symmetric"]:
                 return (
                     False,
-                    "Channel symmetric value for tensor '{tensor_name}' does not match at index {index}.",
+                    f"Channel symmetric value for tensor '{tensor_name}' does not match at index {index}.",
                 )
             if "reduce_range" in quant_overrides and reduce_range != quant_overrides["reduce_range"]:
                 return (
                     False,
-                    "Channel reduce_range value for tensor '{tensor_name}' does not match at index {index}.",
+                    f"Channel reduce_range value for tensor '{tensor_name}' does not match at index {index}.",
                 )
 
             # If override scale/zp, must do so for all channels.

--- a/onnxruntime/test/python/quantization/test_tensor_quant_overrides_option.py
+++ b/onnxruntime/test/python/quantization/test_tensor_quant_overrides_option.py
@@ -662,6 +662,28 @@ class TestTensorQuantOverridesOption(unittest.TestCase):
 
         self.assertIn("option(s) [reduce_range] are invalid with 'scale' and 'zero_point'", str(context.exception))
 
+    def test_override_validation_per_channel_mismatch(self):
+        """
+        Test that per-channel overrides that disagree between channels produce an
+        error message with the tensor name and channel index actually filled in
+        (and not the literal, uninterpolated `{tensor_name}`/`{index}` placeholders).
+        """
+        with self.assertRaises(ValueError) as context:
+            self.perform_qdq_quantization(
+                "model_validation.onnx",
+                extra_options={
+                    "TensorQuantOverrides": {
+                        "WGT": [
+                            {"axis": 0, "symmetric": True},
+                            {"symmetric": False},
+                        ]
+                    }
+                },
+                per_channel=True,
+            )
+
+        self.assertIn("Channel symmetric value for tensor 'WGT' does not match at index 0.", str(context.exception))
+
     def test_get_qnn_qdq_config_sigmoid(self):
         """
         Test that the QNN-specific configs override the scale and zero-point of 16-bit Sigmoid.


### PR DESCRIPTION
While reading through `TensorQuantOverridesHelper._is_valid_per_channel` in `onnxruntime/python/tools/quantization/tensor_quant_overrides.py`, I noticed the four per-channel mismatch checks (`quant_type`, `axis`, `symmetric`, `reduce_range`) build their error strings without the `f` prefix, even though every other message in the same method uses an f-string. That means when per-channel overrides disagree between channels, the exception raised in `base_quantizer.py` (`raise ValueError(overrides_err)`) literally contains the placeholders `{tensor_name}` and `{index}` instead of the actual tensor name and channel index, e.g.:

```
ValueError: Channel symmetric value for tensor '{tensor_name}' does not match at index {index}.
```

instead of something actually useful like:

```
ValueError: Channel symmetric value for tensor 'WGT' does not match at index 0.
```

which makes it pretty hard to figure out which tensor/channel is causing the validation failure when you're configuring `TensorQuantOverrides` for per-channel quantization.

Fix is just adding the missing `f` prefix to the four return strings. Added a test (`test_override_validation_per_channel_mismatch`) that triggers a per-channel `symmetric` mismatch and asserts the interpolated message comes back correctly. I confirmed the test fails against the old code (literal placeholders in the message) and passes with the fix.

Note on testing: I don't have a full C++ build of onnxruntime available in my environment, so I validated this by installing the published `onnxruntime` wheel and swapping in the modified `onnxruntime/python/tools/quantization` package (pure Python, no native code touched), then running the full `test_tensor_quant_overrides_option.py` suite (22 tests, all passing) plus the new test. Since this change is confined to pure-Python string formatting, I'm confident it applies cleanly on top of a proper source build too.