### PR TITLE
Extract InferenceSession input/output validation into free functions

### DIFF
--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -2872,8 +2872,8 @@ const ExternalDataLoaderManager& InferenceSession::GetExternalDataLoaderManager(
   return external_data_loader_mgr_;
 }
 
-common::Status InferenceSession::CheckShapes(const std::string& input_output_name, const TensorShape& input_output_shape,
-                                             const TensorShape& expected_shape, const char* input_output_moniker) const {
+static common::Status CheckShapes(const std::string& input_output_name, const TensorShape& input_output_shape,
+                                  const TensorShape& expected_shape, const char* input_output_moniker) {
   const auto shape_size = input_output_shape.NumDimensions();
   const auto expected_shape_size = expected_shape.NumDimensions();
   if (shape_size != expected_shape_size) {
@@ -2917,10 +2917,12 @@ static common::Status CheckTypes(MLDataType actual, MLDataType expected, const s
                          DataTypeImpl::ToString(expected), "))");
 }
 
-common::Status InferenceSession::ValidateInputsOutputs(gsl::span<const std::string> names,
-                                                       gsl::span<const OrtValue> feeds_fetches,
-                                                       const InputOutputDefMetaMap& input_output_meta_map,
-                                                       ArgType arg_type) const {
+static common::Status ValidateInputsOutputs(gsl::span<const std::string> names,
+                                            gsl::span<const OrtValue> feeds_fetches,
+                                            const InputOutputDefMetaMap& input_output_meta_map,
+                                            ArgType arg_type,
+                                            [[maybe_unused]] const SessionState& session_state,
+                                            int session_id) {
   ORT_ENFORCE(arg_type == ArgType::kInput || arg_type == ArgType::kOutput, "Valid values kInput, kOutput");
 
   const bool is_inputs = arg_type == ArgType::kInput;
@@ -2929,10 +2931,10 @@ common::Status InferenceSession::ValidateInputsOutputs(gsl::span<const std::stri
   const char* const feed_fetches_moniker = is_inputs ? "feed" : "fetch";
 
 #if !defined(DISABLE_SPARSE_TENSORS)
-  auto is_sparse_initializer = [this](const std::string& name) -> bool {
+  auto is_sparse_initializer = [&session_state](const std::string& name) -> bool {
     int idx = -1;
-    if (session_state_->GetOrtValueNameIdxMap().GetIdx(name, idx).IsOK()) {
-      return session_state_->IsSparseInitializer(idx);
+    if (session_state.GetOrtValueNameIdxMap().GetIdx(name, idx).IsOK()) {
+      return session_state.IsSparseInitializer(idx);
     }
     return false;
   };
@@ -2982,14 +2984,16 @@ common::Status InferenceSession::ValidateInputsOutputs(gsl::span<const std::stri
 #endif
 
       const auto& input_output_tensor = input_output_ml_value.Get<Tensor>();
-      ORT_RETURN_IF_ERROR_SESSIONID_(CheckTypes(input_output_tensor.DataType(),
-                                                expected_element_type, "tensor", input_output_moniker));
+      ORT_RETURN_IF_ERROR_SESSIONID(CheckTypes(input_output_tensor.DataType(),
+                                               expected_element_type, "tensor", input_output_moniker),
+                                    session_id);
 
       // check for shape
       const auto& opt_shape = iter->second.tensor_shape;
       if (opt_shape.has_value() && !opt_shape->GetDims().empty()) {
-        ORT_RETURN_IF_ERROR_SESSIONID_(CheckShapes(name, input_output_tensor.Shape(),
-                                                   *opt_shape, input_output_moniker));
+        ORT_RETURN_IF_ERROR_SESSIONID(CheckShapes(name, input_output_tensor.Shape(),
+                                                  *opt_shape, input_output_moniker),
+                                      session_id);
       }
     } else if (input_output_ml_value.IsSparseTensor()) {
 #if !defined(DISABLE_SPARSE_TENSORS)
@@ -2997,25 +3001,29 @@ common::Status InferenceSession::ValidateInputsOutputs(gsl::span<const std::stri
       const SparseTensor& sparse_tensor = input_output_ml_value.Get<SparseTensor>();
       if (expected_type->IsSparseTensorType()) {
         auto expected_element_type = expected_type->AsSparseTensorType()->GetElementType();
-        ORT_RETURN_IF_ERROR_SESSIONID_(CheckTypes(sparse_tensor.DataType(), expected_element_type,
-                                                  "sparse_tensor", input_output_moniker));
+        ORT_RETURN_IF_ERROR_SESSIONID(CheckTypes(sparse_tensor.DataType(), expected_element_type,
+                                                 "sparse_tensor", input_output_moniker),
+                                      session_id);
         // Check shape
         const auto& opt_shape = iter->second.tensor_shape;
         if (opt_shape.has_value() && !opt_shape->GetDims().empty()) {
-          ORT_RETURN_IF_ERROR_SESSIONID_(CheckShapes(name, sparse_tensor.DenseShape(),
-                                                     *opt_shape, input_output_moniker));
+          ORT_RETURN_IF_ERROR_SESSIONID(CheckShapes(name, sparse_tensor.DenseShape(),
+                                                    *opt_shape, input_output_moniker),
+                                        session_id);
         }
       } else if (is_sparse_initializer(name) &&
                  expected_type->IsTensorType()) {
         // If this metadata came from a sparse initializer converted to dense, then still validate it.
         auto expected_element_type = expected_type->AsTensorType()->GetElementType();
-        ORT_RETURN_IF_ERROR_SESSIONID_(CheckTypes(sparse_tensor.DataType(), expected_element_type,
-                                                  "sparse_tensor", input_output_moniker));
+        ORT_RETURN_IF_ERROR_SESSIONID(CheckTypes(sparse_tensor.DataType(), expected_element_type,
+                                                 "sparse_tensor", input_output_moniker),
+                                      session_id);
         // Check shape
         const auto& opt_shape = iter->second.tensor_shape;
         if (opt_shape.has_value() && !opt_shape->GetDims().empty()) {
-          ORT_RETURN_IF_ERROR_SESSIONID_(CheckShapes(name, sparse_tensor.DenseShape(),
-                                                     *opt_shape, input_output_moniker));
+          ORT_RETURN_IF_ERROR_SESSIONID(CheckShapes(name, sparse_tensor.DenseShape(),
+                                                    *opt_shape, input_output_moniker),
+                                        session_id);
         }
       } else {
         return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, input_output_moniker, " with name: '", name,
@@ -3046,23 +3054,31 @@ common::Status InferenceSession::ValidateInputsOutputs(gsl::span<const std::stri
 #endif
 
       auto input_output_element_type = input_output_ml_value.Get<TensorSeq>().DataType();
-      ORT_RETURN_IF_ERROR_SESSIONID_(CheckTypes(input_output_element_type, expected_element_type, "seq", input_output_moniker));
+      ORT_RETURN_IF_ERROR_SESSIONID(CheckTypes(input_output_element_type, expected_element_type, "seq", input_output_moniker),
+                                    session_id);
     } else {
       auto input_output_type = input_output_ml_value.Type();
-      ORT_RETURN_IF_ERROR_SESSIONID_(CheckTypes(input_output_type, expected_type, "", input_output_moniker));
+      ORT_RETURN_IF_ERROR_SESSIONID(CheckTypes(input_output_type, expected_type, "", input_output_moniker),
+                                    session_id);
     }
   }
 
   return Status::OK();
 }
 
-common::Status InferenceSession::ValidateInputs(gsl::span<const std::string> feed_names,
-                                                gsl::span<const OrtValue> feeds) const {
-  return ValidateInputsOutputs(feed_names, feeds, input_def_map_, ArgType::kInput);
+static common::Status ValidateInputs(gsl::span<const std::string> feed_names,
+                                     gsl::span<const OrtValue> feeds,
+                                     const InputOutputDefMetaMap& input_def_map,
+                                     const SessionState& session_state,
+                                     int session_id) {
+  return ValidateInputsOutputs(feed_names, feeds, input_def_map, ArgType::kInput, session_state, session_id);
 }
 
-common::Status InferenceSession::ValidateOutputs(gsl::span<const std::string> output_names,
-                                                 const std::vector<OrtValue>* p_fetches) const {
+static common::Status ValidateOutputs(gsl::span<const std::string> output_names,
+                                      const std::vector<OrtValue>* p_fetches,
+                                      const InputOutputDefMetaMap& output_def_map,
+                                      const SessionState& session_state,
+                                      int session_id) {
   if (output_names.empty()) {
     return common::Status(common::ONNXRUNTIME, common::INVALID_ARGUMENT, "At least one output should be requested.");
   }
@@ -3071,14 +3087,14 @@ common::Status InferenceSession::ValidateOutputs(gsl::span<const std::string> ou
 
   if (fetches.empty()) {
     for (const auto& name : output_names) {
-      if (output_def_map_.count(name) == 0) {
+      if (output_def_map.count(name) == 0) {
         return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Invalid output name:", name);
       }
     }
     return Status::OK();
   }
 
-  return ValidateInputsOutputs(output_names, fetches, output_def_map_, ArgType::kOutput);
+  return ValidateInputsOutputs(output_names, fetches, output_def_map, ArgType::kOutput, session_state, session_id);
 }
 
 #ifdef ENABLE_TRAINING
@@ -3290,8 +3306,8 @@ Status InferenceSession::RunImpl(const RunOptions& run_options,
       // log evaluation start to trace logging provider
       env.GetTelemetryProvider().LogEvaluationStart(session_id_);
 
-      ORT_RETURN_IF_ERROR_SESSIONID_(ValidateInputs(feed_names, feeds));
-      ORT_RETURN_IF_ERROR_SESSIONID_(ValidateOutputs(output_names, p_fetches));
+      ORT_RETURN_IF_ERROR_SESSIONID_(ValidateInputs(feed_names, feeds, input_def_map_, *session_state_, session_id_));
+      ORT_RETURN_IF_ERROR_SESSIONID_(ValidateOutputs(output_names, p_fetches, output_def_map_, *session_state_, session_id_));
 
       // shrink certain default memory arenas if the user has requested for it
       const std::string& shrink_memory_arenas =

--- a/onnxruntime/core/session/inference_session.h
+++ b/onnxruntime/core/session/inference_session.h
@@ -120,22 +120,24 @@ struct ModelMetadata {
  *  process the output here...
  */
 
+// Metadata about a model input or output def, used to validate the feeds/fetches passed to Run().
+struct InputOutputDefMetaData {
+  InputOutputDefMetaData(const NodeArg* node_arg0, MLDataType ml_data_type0, TensorShape&& tensor_shape0)
+      : node_arg(node_arg0), ml_data_type(ml_data_type0), tensor_shape(std::move(tensor_shape0)) {
+  }
+
+  InputOutputDefMetaData(const NodeArg* node_arg0, MLDataType ml_data_type0)
+      : node_arg(node_arg0), ml_data_type(ml_data_type0) {
+  }
+
+  gsl::not_null<const NodeArg*> node_arg;
+  MLDataType ml_data_type;
+  std::optional<TensorShape> tensor_shape;  // not applicable if the input is non-tensor type
+};
+
+using InputOutputDefMetaMap = InlinedHashMap<std::string_view, InputOutputDefMetaData>;
+
 class InferenceSession {
-  struct InputOutputDefMetaData {
-    InputOutputDefMetaData(const NodeArg* node_arg0, MLDataType ml_data_type0, TensorShape&& tensor_shape0)
-        : node_arg(node_arg0), ml_data_type(ml_data_type0), tensor_shape(std::move(tensor_shape0)) {
-    }
-
-    InputOutputDefMetaData(const NodeArg* node_arg0, MLDataType ml_data_type0)
-        : node_arg(node_arg0), ml_data_type(ml_data_type0) {
-    }
-
-    gsl::not_null<const NodeArg*> node_arg;
-    MLDataType ml_data_type;
-    std::optional<TensorShape> tensor_shape;  // not applicable if the input is non-tensor type
-  };
-
-  using InputOutputDefMetaMap = InlinedHashMap<std::string_view, InputOutputDefMetaData>;
   static std::map<uint32_t, InferenceSession*> active_sessions_;
 #ifdef _WIN32
   static std::mutex active_sessions_mutex_;  // Protects access to active_sessions_
@@ -850,20 +852,6 @@ class InferenceSession {
   void InitLogger(logging::LoggingManager* logging_manager);
 
   static void TraceSessionOptions(const SessionOptions& session_options, bool captureState, const logging::Logger& logger);
-
-  [[nodiscard]] common::Status CheckShapes(const std::string& input_name, const TensorShape& input_shape,
-                                           const TensorShape& expected_shape, const char* input_output_moniker) const;
-
-  [[nodiscard]] common::Status ValidateInputs(gsl::span<const std::string> feed_names,
-                                              gsl::span<const OrtValue> feeds) const;
-
-  [[nodiscard]] common::Status ValidateOutputs(gsl::span<const std::string> output_names,
-                                               const std::vector<OrtValue>* p_fetches) const;
-
-  [[nodiscard]] common::Status ValidateInputsOutputs(gsl::span<const std::string> feed_fetches_names,
-                                                     gsl::span<const OrtValue> feeds_fetches,
-                                                     const InputOutputDefMetaMap& input_output_meta_map,
-                                                     ArgType arg_type) const;
 
   [[nodiscard]] common::Status WaitForNotification(Notification* p_executor_done, int64_t timeout_in_ms);
 

--- a/onnxruntime/test/framework/inference_session_test.cc
+++ b/onnxruntime/test/framework/inference_session_test.cc
@@ -1213,6 +1213,150 @@ TEST(InferenceSessionTests, TestOptionalInputs) {
   }
 }
 
+// The following tests exercise InferenceSession::Run's feed/fetch validation
+// (ValidateInputs/ValidateOutputs and their CheckShapes/CheckTypes helpers).
+// mul_1.onnx has a single float input "X" with static shape {3, 2} and a single float output "Y".
+static void LoadAndInitializeMul1(InferenceSession& session) {
+  ASSERT_STATUS_OK(session.Load(MODEL_URI));
+  ASSERT_STATUS_OK(session.Initialize());
+}
+
+TEST(InferenceSessionTests, RunWithMismatchedFeedNamesAndFeedsReturnsError) {
+  SessionOptions so;
+  so.session_logid = "InferenceSessionTests.RunWithMismatchedFeedNamesAndFeedsReturnsError";
+  InferenceSession session_object{so, GetEnvironment()};
+  LoadAndInitializeMul1(session_object);
+
+  std::vector<int64_t> dims_x = {3, 2};
+  std::vector<float> values_x = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
+  OrtValue ml_value;
+  CreateMLValue<float>(TestCPUExecutionProvider()->CreatePreferredAllocators()[0], dims_x, values_x, &ml_value);
+
+  // Two feed names but only one feed value.
+  std::vector<std::string> feed_names = {"X", "X"};
+  std::vector<OrtValue> feeds = {ml_value};
+  std::vector<std::string> output_names = {"Y"};
+  std::vector<OrtValue> fetches;
+
+  RunOptions run_options;
+  ASSERT_STATUS_NOT_OK_AND_HAS_SUBSTR(
+      session_object.Run(run_options, feed_names, feeds, output_names, &fetches),
+      "feed names has 2 elements, but feed has 1 elements");
+}
+
+TEST(InferenceSessionTests, RunWithUnexpectedInputTypeReturnsError) {
+  SessionOptions so;
+  so.session_logid = "InferenceSessionTests.RunWithUnexpectedInputTypeReturnsError";
+  InferenceSession session_object{so, GetEnvironment()};
+  LoadAndInitializeMul1(session_object);
+
+  // "X" is declared as float in the model; feed int32 instead.
+  std::vector<int64_t> dims_x = {3, 2};
+  std::vector<int32_t> values_x = {1, 2, 3, 4, 5, 6};
+  OrtValue ml_value;
+  CreateMLValue<int32_t>(TestCPUExecutionProvider()->CreatePreferredAllocators()[0], dims_x, values_x, &ml_value);
+
+  NameMLValMap feeds;
+  feeds.insert(std::make_pair("X", ml_value));
+  std::vector<std::string> output_names = {"Y"};
+  std::vector<OrtValue> fetches;
+
+  RunOptions run_options;
+  ASSERT_STATUS_NOT_OK_AND_HAS_SUBSTR(
+      session_object.Run(run_options, feeds, output_names, &fetches),
+      "Unexpected input data type");
+}
+
+TEST(InferenceSessionTests, RunWithWrongInputRankReturnsError) {
+  SessionOptions so;
+  so.session_logid = "InferenceSessionTests.RunWithWrongInputRankReturnsError";
+  InferenceSession session_object{so, GetEnvironment()};
+  LoadAndInitializeMul1(session_object);
+
+  // "X" expects rank 2 ({3, 2}); feed a rank-1 tensor.
+  std::vector<int64_t> dims_x = {6};
+  std::vector<float> values_x = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
+  OrtValue ml_value;
+  CreateMLValue<float>(TestCPUExecutionProvider()->CreatePreferredAllocators()[0], dims_x, values_x, &ml_value);
+
+  NameMLValMap feeds;
+  feeds.insert(std::make_pair("X", ml_value));
+  std::vector<std::string> output_names = {"Y"};
+  std::vector<OrtValue> fetches;
+
+  RunOptions run_options;
+  ASSERT_STATUS_NOT_OK_AND_HAS_SUBSTR(
+      session_object.Run(run_options, feeds, output_names, &fetches),
+      "Invalid rank for input: X");
+}
+
+TEST(InferenceSessionTests, RunWithWrongInputDimensionsReturnsError) {
+  SessionOptions so;
+  so.session_logid = "InferenceSessionTests.RunWithWrongInputDimensionsReturnsError";
+  InferenceSession session_object{so, GetEnvironment()};
+  LoadAndInitializeMul1(session_object);
+
+  // "X" expects {3, 2}; feed {2, 3} (same rank, wrong dimensions).
+  std::vector<int64_t> dims_x = {2, 3};
+  std::vector<float> values_x = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
+  OrtValue ml_value;
+  CreateMLValue<float>(TestCPUExecutionProvider()->CreatePreferredAllocators()[0], dims_x, values_x, &ml_value);
+
+  NameMLValMap feeds;
+  feeds.insert(std::make_pair("X", ml_value));
+  std::vector<std::string> output_names = {"Y"};
+  std::vector<OrtValue> fetches;
+
+  RunOptions run_options;
+  ASSERT_STATUS_NOT_OK_AND_HAS_SUBSTR(
+      session_object.Run(run_options, feeds, output_names, &fetches),
+      "Got invalid dimensions for input: X");
+}
+
+TEST(InferenceSessionTests, RunWithNoRequestedOutputsReturnsError) {
+  SessionOptions so;
+  so.session_logid = "InferenceSessionTests.RunWithNoRequestedOutputsReturnsError";
+  InferenceSession session_object{so, GetEnvironment()};
+  LoadAndInitializeMul1(session_object);
+
+  std::vector<int64_t> dims_x = {3, 2};
+  std::vector<float> values_x = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
+  OrtValue ml_value;
+  CreateMLValue<float>(TestCPUExecutionProvider()->CreatePreferredAllocators()[0], dims_x, values_x, &ml_value);
+
+  NameMLValMap feeds;
+  feeds.insert(std::make_pair("X", ml_value));
+  std::vector<std::string> output_names;  // intentionally empty
+  std::vector<OrtValue> fetches;
+
+  RunOptions run_options;
+  ASSERT_STATUS_NOT_OK_AND_HAS_SUBSTR(
+      session_object.Run(run_options, feeds, output_names, &fetches),
+      "At least one output should be requested");
+}
+
+TEST(InferenceSessionTests, RunWithInvalidOutputNameReturnsError) {
+  SessionOptions so;
+  so.session_logid = "InferenceSessionTests.RunWithInvalidOutputNameReturnsError";
+  InferenceSession session_object{so, GetEnvironment()};
+  LoadAndInitializeMul1(session_object);
+
+  std::vector<int64_t> dims_x = {3, 2};
+  std::vector<float> values_x = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
+  OrtValue ml_value;
+  CreateMLValue<float>(TestCPUExecutionProvider()->CreatePreferredAllocators()[0], dims_x, values_x, &ml_value);
+
+  NameMLValMap feeds;
+  feeds.insert(std::make_pair("X", ml_value));
+  std::vector<std::string> output_names = {"invalid_output"};
+  std::vector<OrtValue> fetches;
+
+  RunOptions run_options;
+  ASSERT_STATUS_NOT_OK_AND_HAS_SUBSTR(
+      session_object.Run(run_options, feeds, output_names, &fetches),
+      "Invalid output name");
+}
+
 static void CreateFuseOpModel(const PathString& model_file_name) {
   onnxruntime::Model model("graph_1", false, ModelMetaData(), PathString(), IOnnxRuntimeOpSchemaRegistryList(),
                            {{kOnnxDomain, 12}}, {}, DefaultLoggingManager().DefaultLogger());


### PR DESCRIPTION
### Description

Extracts the input/output validation cluster out of the `InferenceSession` class into file-local `static` free functions in `inference_session.cc`:

- `CheckShapes`, `ValidateInputsOutputs`, `ValidateInputs`, and `ValidateOutputs` are moved next to the existing `CheckTypes` free helper. `SessionState`, the session id, and the input/output def maps are now passed as parameters instead of being read from members, so `ORT_RETURN_IF_ERROR_SESSIONID` still logs with the same session id and behavior is unchanged.
- The plain `InputOutputDefMetaData` / `InputOutputDefMetaMap` data types move from private nested types to `onnxruntime` namespace scope so the free functions can name them. They are used only inside `InferenceSession` (no qualified external references).
- The four validation method declarations are removed from `inference_session.h`.

Also adds six tests to `inference_session_test.cc` that exercise the validation error paths, which previously had no direct assertions in `onnxruntime_test_all`:

| Test | Path covered | Asserted message |
| --- | --- | --- |
| `RunWithMismatchedFeedNamesAndFeedsReturnsError` | feed name/value count mismatch | `feed names has 2 elements, but feed has 1 elements` |
| `RunWithUnexpectedInputTypeReturnsError` | `CheckTypes` | `Unexpected input data type` |
| `RunWithWrongInputRankReturnsError` | `CheckShapes` (rank) | `Invalid rank for input: X` |
| `RunWithWrongInputDimensionsReturnsError` | `CheckShapes` (dims) | `Got invalid dimensions for input: X` |
| `RunWithNoRequestedOutputsReturnsError` | empty requested outputs | `At least one output should be requested` |
| `RunWithInvalidOutputNameReturnsError` | unknown output name | `Invalid output name` |

### Motivation and Context

`InferenceSession` is a large class with many responsibilities. Feed/fetch validation is a self-contained one that does not need access to the whole object — only a def map, `SessionState` (for the sparse-initializer check), and the session id. Making that explicit:

- shrinks the class's private surface (four fewer methods) and makes the validators' dependencies visible in their signatures rather than reaching into members;
- removes the declarations from `inference_session.h`, so editing validation logic no longer forces recompilation of the many translation units that include the header;
- gives the file-local helpers internal linkage.

This is a behavior-preserving refactor. The new tests lock in the exact error messages that the extracted code produces.

### Testing

Built `onnxruntime_test_all` (Release, Windows) and ran:

- `InferenceSessionTests.*` — 44/44 pass (includes the existing `TestOptionalInputs` "Invalid input name" path).
- Activation / sequence / sparse-tensor op batch — 46/46 pass (tensor/sequence/sparse validation branches on the `Run` hot path).
- The six new `InferenceSessionTests.RunWith*ReturnsError` tests — 6/6 pass.
