### PR TITLE
Make element-wise fp16 tests skip explicitly when CUDA/CoreML are unavailable

### DIFF
--- a/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
@@ -279,11 +279,21 @@ TEST(MathOpTest, Add_float) {
   test.Run();
 #endif
 
-  TestBinaryFloat16("Add", dims, lhs_values, dims, rhs_values, dims, out_values);
-
 #if defined(USE_DNNL)
   TestBFloat16("Add", dims, lhs_values, dims, rhs_values, dims, out_values);
 #endif  // USE_DNNL
+}
+
+TEST(MathOpTest, Add_float16) {
+#if defined(USE_CUDA) || defined(USE_COREML)
+  std::vector<int64_t> dims{3, 3};
+  std::initializer_list<float> lhs_values{1.0f, 2.0f, -1.0f, 0.0f, 1.5f, -100.0f, -5.4f, 9.3f, -10000.0f};
+  std::initializer_list<float> rhs_values{-1.0f, 4.4f, 432.3f, 0.0f, 3.5f, 64.0f, -5.4f, 9.3f, 10000.0f};
+  std::initializer_list<float> out_values{0.0f, 6.4f, 431.3f, 0.0f, 5.0f, -36.0f, -10.8f, 18.6f, 0.0f};
+  TestBinaryFloat16("Add", dims, lhs_values, dims, rhs_values, dims, out_values);
+#else
+  GTEST_SKIP() << "Add float16 is only exercised on CUDA or CoreML EP builds.";
+#endif
 }
 
 TEST(MathOpTest, Add_double) {
@@ -316,11 +326,21 @@ TEST(MathOpTest, Add_Broadcast_Axis) {
   test.AddOutput<float>("C", dims, out_values);
   test.Run(OpTester::ExpectResult::kExpectSuccess, "");
 
-  TestBinaryFloat16("Add", dims, lhs_values, {3, 1}, rhs_values, dims, out_values);
-
 #if defined(USE_DNNL)
   TestBFloat16("Add", dims, lhs_values, {3, 1}, rhs_values, dims, out_values);
 #endif  // USE_DNNL
+}
+
+TEST(MathOpTest, Add_Broadcast_Axis_float16) {
+#if defined(USE_CUDA) || defined(USE_COREML)
+  std::vector<int64_t> dims{3, 3};
+  std::initializer_list<float> lhs_values{1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f};
+  std::initializer_list<float> rhs_values{3.0f, 2.0f, 1.0f};
+  std::initializer_list<float> out_values{4.0f, 5.0f, 6.0f, 6.0f, 7.0f, 8.0f, 8.0f, 9.0f, 10.0f};
+  TestBinaryFloat16("Add", dims, lhs_values, {3, 1}, rhs_values, dims, out_values);
+#else
+  GTEST_SKIP() << "Add broadcast float16 is only exercised on CUDA or CoreML EP builds.";
+#endif
 }
 
 TEST(MathOpTest, Add_Broadcast_MultidirectionalAB) {
@@ -340,11 +360,20 @@ TEST(MathOpTest, Add_Broadcast_MultidirectionalAB) {
            {kTensorrtExecutionProvider});  // TensorRT: got C with shape [3, 1]
 #endif
 
-  TestBinaryFloat16("Add", {3, 1}, lhs_values, {3}, rhs_values, {3, 3}, out_values);
-
 #if defined(USE_DNNL)
   TestBFloat16("Add", {3, 1}, lhs_values, {3}, rhs_values, {3, 3}, out_values);
 #endif  // USE_DNNL
+}
+
+TEST(MathOpTest, Add_Broadcast_MultidirectionalAB_float16) {
+#if defined(USE_CUDA) || defined(USE_COREML)
+  std::initializer_list<float> lhs_values{3.0f, 2.0f, 1.0f};
+  std::initializer_list<float> rhs_values{1.0f, 2.0f, 3.0f};
+  std::initializer_list<float> out_values{4.0f, 5.0f, 6.0f, 3.0f, 4.0f, 5.0f, 2.0f, 3.0f, 4.0f};
+  TestBinaryFloat16("Add", {3, 1}, lhs_values, {3}, rhs_values, {3, 3}, out_values);
+#else
+  GTEST_SKIP() << "Add broadcast float16 is only exercised on CUDA or CoreML EP builds.";
+#endif
 }
 
 TEST(MathOpTest, Add_Broadcast_MultidirectionalBA) {
@@ -364,11 +393,20 @@ TEST(MathOpTest, Add_Broadcast_MultidirectionalBA) {
            {kTensorrtExecutionProvider});  // TensorRT: got C with shape [3, 1]
 #endif
 
-  TestBinaryFloat16("Add", {3}, lhs_values, {3, 1}, rhs_values, {3, 3}, out_values);
-
 #if defined(USE_DNNL)
   TestBFloat16("Add", {3}, lhs_values, {3, 1}, rhs_values, {3, 3}, out_values);
 #endif  // USE_DNNL
+}
+
+TEST(MathOpTest, Add_Broadcast_MultidirectionalBA_float16) {
+#if defined(USE_CUDA) || defined(USE_COREML)
+  std::initializer_list<float> lhs_values{1.0f, 2.0f, 3.0f};
+  std::initializer_list<float> rhs_values{3.0f, 2.0f, 1.0f};
+  std::initializer_list<float> out_values{4.0f, 5.0f, 6.0f, 3.0f, 4.0f, 5.0f, 2.0f, 3.0f, 4.0f};
+  TestBinaryFloat16("Add", {3}, lhs_values, {3, 1}, rhs_values, {3, 3}, out_values);
+#else
+  GTEST_SKIP() << "Add broadcast float16 is only exercised on CUDA or CoreML EP builds.";
+#endif
 }
 
 TEST(MathOpTest, Add_Broadcast_0x0) {
@@ -715,10 +753,20 @@ TEST(MathOpTest, Sub_float) {
   test.AddOutput<float>("C", dims, out_values);
   test.Run();
 
-  TestBinaryFloat16("Sub", dims, lhs_values, dims, rhs_values, dims, out_values);
-
 #if defined(USE_DNNL)
   TestBFloat16("Sub", dims, lhs_values, dims, rhs_values, dims, out_values);
+#endif
+}
+
+TEST(MathOpTest, Sub_float16) {
+#if defined(USE_CUDA) || defined(USE_COREML)
+  std::vector<int64_t> dims{3, 3};
+  std::initializer_list<float> lhs_values{1.0f, 2.0f, -1.0f, 0.0f, 1.5f, -100.0f, -5.4f, 9.3f, -10000.0f};
+  std::initializer_list<float> rhs_values{-1.0f, 4.4f, 432.3f, 0.0f, 3.5f, 64.0f, -5.4f, 9.3f, 10000.0f};
+  std::initializer_list<float> out_values{2.0f, -2.4f, -433.3f, 0.0f, -2.0f, -164.0f, 0.0f, 0.0f, -20000.0f};
+  TestBinaryFloat16("Sub", dims, lhs_values, dims, rhs_values, dims, out_values);
+#else
+  GTEST_SKIP() << "Sub float16 is only exercised on CUDA or CoreML EP builds.";
 #endif
 }
 
@@ -837,10 +885,20 @@ TEST(MathOpTest, Mul_float) {
 
   test.Run();
 
-  TestBinaryFloat16("Mul", dims, lhs_values, dims, rhs_values, dims, out_values);
-
 #if defined(USE_DNNL)
   TestBFloat16("Mul", dims, lhs_values, dims, rhs_values, dims, out_values);
+#endif
+}
+
+TEST(MathOpTest, Mul_float16) {
+#if defined(USE_CUDA) || defined(USE_COREML)
+  std::vector<int64_t> dims{3, 3};
+  std::initializer_list<float> lhs_values{1.0f, 2.0f, -1.0f, 0.0f, 1.5f, -100.0f, -5.0f, 9.3f, -10000.0f};
+  std::initializer_list<float> rhs_values{-1.0f, 4.4f, 432.3f, 0.0f, 3.5f, 64.0f, -5.4f, 9.0f, 10000.0f};
+  std::initializer_list<float> out_values{-1.0f, 8.8f, -432.3f, 0.0f, 5.25f, -6400.0f, 27.0f, 83.7f, -100000000.0f};
+  TestBinaryFloat16("Mul", dims, lhs_values, dims, rhs_values, dims, out_values);
+#else
+  GTEST_SKIP() << "Mul float16 is only exercised on CUDA or CoreML EP builds.";
 #endif
 }
 
@@ -1000,10 +1058,20 @@ TEST(MathOpTest, Div_float) {
   test.AddOutput<float>("C", dims, out_values);
   test.Run();
 
-  TestBinaryFloat16("Div", dims, lhs_values, dims, rhs_values, dims, out_values);
-
 #if defined(USE_DNNL)
   TestBFloat16("Div", dims, lhs_values, dims, rhs_values, dims, out_values);
+#endif
+}
+
+TEST(MathOpTest, Div_float16) {
+#if defined(USE_CUDA) || defined(USE_COREML)
+  std::vector<int64_t> dims{2, 3};
+  std::initializer_list<float> lhs_values{1000.0f, 1.0f, 6.0f, 0.0f, -10.0f, -1.0f};
+  std::initializer_list<float> rhs_values{1000.0f, 2.0f, 3.0f, 1.0f, -1.0f, 4.0f};
+  std::initializer_list<float> out_values{1.0f, 0.5f, 2.0f, 0.0f, 10.0f, -0.25f};
+  TestBinaryFloat16("Div", dims, lhs_values, dims, rhs_values, dims, out_values);
+#else
+  GTEST_SKIP() << "Div float16 is only exercised on CUDA or CoreML EP builds.";
 #endif
 }
 
@@ -1198,7 +1266,17 @@ TEST(MathOpTest, Reciprocal) {
   test.AddInput<float>("X", dims, inputs);
   test.AddOutput<float>("Y", dims, outputs);
   test.Run();
+}
+
+TEST(MathOpTest, Reciprocal_float16) {
+#if defined(USE_CUDA) || defined(USE_COREML)
+  std::vector<int64_t> dims{2, 2};
+  std::initializer_list<float> inputs = {1.0f, 2.0f, -1.0f, -2.0f};
+  std::initializer_list<float> outputs = {1.0f, 0.5f, -1.0f, -0.5f};
   TestUnaryFloat16("Reciprocal", dims, inputs, dims, outputs, 12, false);
+#else
+  GTEST_SKIP() << "Reciprocal float16 is only exercised on CUDA or CoreML EP builds.";
+#endif
 }
 
 TEST(MathOpTest, Reciprocal_double) {
@@ -1221,7 +1299,17 @@ TEST(MathOpTest, Sqrt_Float) {
   test.AddInput<float>("X", dims, inputs);
   test.AddOutput<float>("Y", dims, outputs);
   test.Run();
+}
+
+TEST(MathOpTest, Sqrt_float16) {
+#if defined(USE_CUDA) || defined(USE_COREML)
+  std::initializer_list<float> inputs = {1.0f, 4.0f, 0.0f, 9.0f};
+  std::initializer_list<float> outputs = {1.0f, 2.0f, 0.0f, 3.0f};
+  std::vector<int64_t> dims{2, 2};
   TestUnaryFloat16("Sqrt", dims, inputs, dims, outputs);
+#else
+  GTEST_SKIP() << "Sqrt float16 is only exercised on CUDA or CoreML EP builds.";
+#endif
 }
 
 #if defined(USE_DNNL) || defined(USE_CUDA)


### PR DESCRIPTION
### Description

The `TestBinaryFloat16` / `TestUnaryFloat16` helpers in `element_wise_ops_test.cc` only run when a CoreML or CUDA execution provider is compiled in (they build an `execution_providers` list under `#ifdef USE_COREML` / `USE_CUDA` and guard the actual `OpTester::Run` on `execution_providers.size() > 0`). On a CPU-only build the list is empty, so the helper silently does nothing — but the enclosing float32 test still reports success, so the fp16/bf16 path looks covered when it never ran.

These helpers are called *inside* the combined float32 tests (e.g. `TEST(MathOpTest, Add)` runs float32 via `test.Run()` and then calls `TestBinaryFloat16`). A `GTEST_SKIP()` placed inside the helper would therefore mark the *whole* test skipped and hide the float32 coverage that did run.

This PR instead extracts each fp16 call into a dedicated `<Op>_float16` test guarded by a compile-time check, matching the existing `Pow_float16_float16` test:

```cpp
TEST(MathOpTest, Add_float16) {
#if defined(USE_CUDA) || defined(USE_COREML)
  ...
  TestBinaryFloat16("Add", ...);
#else
  GTEST_SKIP() << "Add float16 is only exercised on CUDA or CoreML EP builds.";
#endif
}
```

New tests: `Add_float16`, `Add_Broadcast_Axis_float16`, `Add_Broadcast_MultidirectionalAB_float16`, `Add_Broadcast_MultidirectionalBA_float16`, `Sub_float16`, `Mul_float16`, `Div_float16`, `Reciprocal_float16`, `Sqrt_float16`.

The float32 tests keep running exactly as before. The `#if defined(USE_DNNL)` `TestBFloat16(...)` calls are left in place because they are already compile-time gated (no silent runtime no-op). `Pow_float16_float16` is intentionally left untouched.

### Motivation and Context

Addresses a test-signal gap: on CPU-only builds these tests reported green without exercising the fp16/bf16 path. After this change the float32 coverage is still reported as passing and the fp16 paths report `SKIPPED` on builds where no supporting EP is compiled in, so the result is honest.

### Testing

Built `onnxruntime_provider_test` (Release, Windows, CPU-only) and ran `MathOpTest.*`:

- `344 passed, 0 failed` (float32 coverage intact — no regression).
- The 9 new `*_float16` tests report `SKIPPED` with an explanatory message instead of silently passing.
