### PR TITLE
Add allocation planner test for disabled memory reuse

### DIFF
--- a/onnxruntime/test/framework/allocation_planner_test.cc
+++ b/onnxruntime/test/framework/allocation_planner_test.cc
@@ -278,7 +278,8 @@ class PlannerTest : public ::testing::Test {
   }
 
   void CreatePlan(const std::vector<const NodeArg*>& outer_scope_node_args = {},
-                  bool invoke_createPlan_explicityly = true) {
+                  bool invoke_createPlan_explicityly = true,
+                  const ISequentialPlannerContext* planner_context = nullptr) {
     state_.reset(new SessionState(graph_, execution_providers_, tp_.get(), nullptr, dtm_, edlm_,
                                   DefaultLoggingManager().DefaultLogger(), profiler_, *sess_options_));
     EXPECT_EQ(graph_.Resolve(), Status::OK());
@@ -302,7 +303,6 @@ class PlannerTest : public ::testing::Test {
     status = state_->FinalizeSessionState(ORT_TSTR(""), kernel_registry_manager, {}, remove_initializers);
 
     EXPECT_TRUE(status.IsOK()) << status.ErrorMessage();
-    SequentialPlannerTestContext test_context(&shape_map_);
     plan_.emplace();
 
     class MockStreamHandleRegsitry : public IStreamCommandHandleRegistry {
@@ -324,6 +324,8 @@ class PlannerTest : public ::testing::Test {
     };
 
     if (invoke_createPlan_explicityly) {
+      SequentialPlannerTestContext default_test_context(&shape_map_);
+      const ISequentialPlannerContext& test_context = planner_context != nullptr ? *planner_context : default_test_context;
       onnxruntime::GraphViewer graph_viewer{graph_};
       status = SequentialPlanner::CreatePlan(
           nullptr,
@@ -346,6 +348,11 @@ class PlannerTest : public ::testing::Test {
       EXPECT_TRUE(status.IsOK()) << status.ErrorMessage();
       // AllocationPlanTestUtility::BasicIntegrityCheck(*plan_, name_to_arg_.size());
     }
+  }
+
+  void CreatePlanWithMemoryReuseDisabled() {
+    ParallelPlannerTestContext test_context(&shape_map_);
+    CreatePlan({}, true, &test_context);
   }
 
   void CheckAllocKind(const std::string& name, AllocKind kind) {
@@ -443,6 +450,36 @@ TEST_F(PlannerTest, ChainTest) {
   CheckFreed(1, {});
   CheckFreed(2, {B});
   CheckFreed(3, {X});
+}
+
+TEST_F(PlannerTest, DisabledMemoryReuseDoesNotReuseFreedBuffers) {
+  // tensor variables:
+  std::string W("W"), X("X"), B("B"), Y("Y"), Z("Z");
+
+  ONNX_NAMESPACE::TensorProto tensor;
+  tensor.add_dims(1);
+  tensor.add_float_data(1.0f);
+  tensor.set_data_type(TensorProto_DataType_FLOAT);
+  tensor.set_name("W");
+  GetGraph().AddInitializedTensor(tensor);
+
+  AddNormalNode(W, X);
+  AddNormalNode(X, B);
+  AddNormalNode(B, Y);
+  AddNormalNode(Y, Z);
+
+  Shape shape1{50, 100};
+  auto shape = &shape1.value;
+  SetShape({{X, shape}, {B, shape}, {Y, shape}, {Z, shape}});
+
+  CreatePlanWithMemoryReuseDisabled();
+
+  // This graph normally reuses X's buffer for Y. With memory reuse disabled, Y must allocate its own buffer.
+  CheckAllocKind(W, AllocKind::kAllocateStatically);
+  CheckAllocKind(X, AllocKind::kAllocate);
+  CheckAllocKind(B, AllocKind::kAllocate);
+  CheckAllocKind(Y, AllocKind::kAllocate);
+  CheckAllocKind(Z, AllocKind::kAllocateOutput);
 }
 
 /* InputOutputTest: Test that:


### PR DESCRIPTION
### Description

Adds a focused allocation planner regression test for the no-memory-reuse planning path.

`PlannerTest.ChainTest` already verifies that a simple chain reuses a freed temporary buffer when memory reuse is enabled: `Y` reuses `X`'s buffer. This PR adds the corresponding disabled-reuse case:

- extends the `PlannerTest::CreatePlan` helper so tests can pass a custom `ISequentialPlannerContext`;
- uses the existing `ParallelPlannerTestContext`, whose `GetEnableMemoryReuse()` returns `false`;
- verifies the same chain allocates `Y` independently (`AllocKind::kAllocate`) instead of reusing `X`.

This locks in the allocation planner behavior used for parallel/no-memory-reuse planning without changing production code.

### Motivation and Context

Memory planning and copy/memory reuse behavior has direct runtime impact. The planner already has a `GetEnableMemoryReuse()` guard in `FindReusableTensor`; this test ensures that guard is reflected in the final `SequentialExecutionPlan` for a graph that would otherwise reuse a freed buffer.

### Testing

Built `onnxruntime_test_all` (Release, Windows) and ran:

```powershell
.\onnxruntime_test_all.exe --gtest_filter="PlannerTest.ChainTest:PlannerTest.DisabledMemoryReuseDoesNotReuseFreedBuffers"
```

Result:

```text
[==========] 2 tests from 1 test suite ran.
[  PASSED  ] 2 tests.
```
