### PR TITLE
Add arena shrinkage run-option diagnostics test

### DIFF
--- a/onnxruntime/test/framework/inference_session_test.cc
+++ b/onnxruntime/test/framework/inference_session_test.cc
@@ -5,6 +5,7 @@
 #include "core/session/inference_session.h"
 
 #include <algorithm>
+#include <array>
 #include <cfloat>
 #include <filesystem>
 #include <functional>
@@ -2148,6 +2149,43 @@ TEST(InferenceSessionTests, TestArenaShrinkageAfterRun) {
 }
 
 #endif
+
+TEST(InferenceSessionTests, ArenaShrinkageRunOptionRejectsInvalidDeviceSpec) {
+  SessionOptions so;
+  so.session_logid = "InferenceSessionTests.ArenaShrinkageRunOptionRejectsInvalidDeviceSpec";
+  InferenceSession session_object{so, GetEnvironment()};
+
+  ASSERT_STATUS_OK(session_object.Load(MODEL_URI));
+  ASSERT_STATUS_OK(session_object.Initialize());
+
+  std::vector<int64_t> dims_mul_x = {3, 2};
+  std::vector<float> values_mul_x = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
+  OrtValue ml_value;
+  CreateMLValue<float>(TestCPUExecutionProvider()->CreatePreferredAllocators()[0], dims_mul_x, values_mul_x,
+                       &ml_value);
+  NameMLValMap feeds;
+  feeds.insert(std::make_pair("X", ml_value));
+  std::vector<std::string> output_names{"Y"};
+  std::vector<OrtValue> fetches;
+
+  struct TestCase {
+    const char* shrink_spec;
+    const char* expected_error;
+  };
+
+  const std::array<TestCase, 2> test_cases{{
+      {"npu:0", "Unsupported device specified in the memory arena shrink list: npu"},
+      {"cpu:not_an_int", "Unsupported device id in the memory arena shrink list: not_an_int"},
+  }};
+
+  for (const auto& test_case : test_cases) {
+    RunOptions run_options;
+    ASSERT_STATUS_OK(run_options.config_options.AddConfigEntry(kOrtRunOptionsConfigEnableMemoryArenaShrinkage,
+                                                               test_case.shrink_spec));
+    ASSERT_STATUS_NOT_OK_AND_HAS_SUBSTR(session_object.Run(run_options, feeds, output_names, &fetches),
+                                        test_case.expected_error);
+  }
+}
 
 // The model being tested here triggers a case where the allocation planner (AP) tries to reuse a tensor of type
 // double for a string tensor. The reuse logic of AP works correctly on Windows and Ubuntu 16.x


### PR DESCRIPTION
### Description

Adds a focused InferenceSession test for memory arena shrinkage run-option diagnostics.

The new test verifies invalid `memory.enable_memory_arena_shrinkage` values fail before execution with clear error messages:

- `npu:0` -> `Unsupported device specified in the memory arena shrink list: npu`
- `cpu:not_an_int` -> `Unsupported device id in the memory arena shrink list: not_an_int`

### Motivation and Context

The shrinkage run option is useful for memory behavior tuning, but bad configuration should be easy to diagnose. Existing coverage validates successful CPU/GPU shrinkage paths in Python/CUDA-specific tests; this adds deterministic C++ coverage for invalid configuration diagnostics.

I initially tried to assert CPU arena shrinkage counters after running `mul_1.onnx` with `cpu:0`, but that was not deterministic: the run option succeeded, yet the tiny model did not leave a fully free CPU arena region to release, so `num_arena_shrinkages` stayed unchanged. This test avoids that allocator-shape dependency and locks in stable error messages instead.

### Testing

Built `onnxruntime_test_all` (Release, Windows) and ran:

```powershell
.\onnxruntime_test_all.exe --gtest_filter="InferenceSessionTests.ArenaShrinkageRunOptionRejectsInvalidDeviceSpec"
```

Result:

```text
[==========] 1 test from 1 test suite ran.
[  PASSED  ] 1 test.
```
