### PR TITLE
Add verbose trace logs for graph transformer manager

### DIFF
--- a/onnxruntime/core/optimizer/graph_transformer_mgr.cc
+++ b/onnxruntime/core/optimizer/graph_transformer_mgr.cc
@@ -27,24 +27,44 @@ common::Status GraphTransformerManager::ApplyTransformers(Graph& graph, Transfor
   _is_graph_modified = false;
   const auto& transformers = level_to_transformer_map_.find(level);
   if (transformers == level_to_transformer_map_.end()) {
+    LOGS(logger, VERBOSE) << "No graph transformers registered for level " << static_cast<int>(level) << ".";
     return Status::OK();
   }
+
+  LOGS(logger, VERBOSE) << "Applying " << transformers->second.size() << " graph transformer(s) for level "
+                        << static_cast<int>(level) << " for up to " << steps_ << " step(s).";
 
   for (unsigned step = 0; step < steps_; ++step) {
     if (IsLoadCancellationFlagSet()) {
       return ORT_MAKE_STATUS(ONNXRUNTIME, MODEL_LOAD_CANCELED, "Graph transformation canceled due to user request.");
     }
+
+    LOGS(logger, VERBOSE) << "Graph transformer step " << (step + 1) << " of " << steps_
+                          << " for level " << static_cast<int>(level) << " started.";
+
     bool graph_changed = false;
     for (const auto& transformer : transformers->second) {
-      if (step > 0 && transformer->ShouldOnlyApplyOnce())
+      if (step > 0 && transformer->ShouldOnlyApplyOnce()) {
+        LOGS(logger, VERBOSE) << "Skipping graph transformer " << transformer->Name()
+                              << " on step " << (step + 1) << " because it should only apply once.";
         continue;
+      }
 
       bool modified = false;
+      LOGS(logger, VERBOSE) << "Applying graph transformer " << transformer->Name()
+                            << " on step " << (step + 1) << ".";
       ORT_RETURN_IF_ERROR(transformer->Apply(graph, modified, logger));
       graph_changed = graph_changed || modified;
       _is_graph_modified = _is_graph_modified || modified;
     }
+
+    LOGS(logger, VERBOSE) << "Graph transformer step " << (step + 1) << " of " << steps_
+                          << " for level " << static_cast<int>(level)
+                          << " completed. graph_changed: " << graph_changed << ".";
+
     if (!graph_changed) {
+      LOGS(logger, VERBOSE) << "Stopping graph transformer iteration for level " << static_cast<int>(level)
+                            << " after step " << (step + 1) << " because the graph was not modified.";
       break;
     }
   }

--- a/onnxruntime/test/optimizer/graph_transform_test.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test.cc
@@ -109,6 +109,50 @@ namespace onnxruntime {
 namespace test {
 
 #define MODEL_FOLDER ORT_TSTR("testdata/transform/")
+
+namespace {
+
+class NoOpTraceGraphTransformer : public GraphTransformer {
+ public:
+  NoOpTraceGraphTransformer() : GraphTransformer("NoOpTraceGraphTransformer") {}
+
+ private:
+  Status ApplyImpl(Graph& /*graph*/, bool& modified, int /*graph_level*/,
+                   const logging::Logger& /*logger*/) const override {
+    modified = false;
+    return Status::OK();
+  }
+};
+
+}  // namespace
+
+TEST_F(GraphTransformationTests, GraphTransformerManagerEmitsVerboseTrace) {
+  constexpr const ORTCHAR_T* model_uri = MODEL_FOLDER "abs-id-max.onnx";
+  std::shared_ptr<Model> model;
+  ASSERT_STATUS_OK(Model::Load(model_uri, model, nullptr, *logger_));
+
+  auto capturing_sink = std::make_unique<CapturingSink>();
+  const auto* capturing_sink_raw = capturing_sink.get();
+  logging::LoggingManager logging_manager(std::move(capturing_sink), logging::Severity::kVERBOSE, false,
+                                          logging::LoggingManager::InstanceType::Temporal);
+  auto logger = logging_manager.CreateLogger("GraphTransformerTraceTest");
+
+  GraphTransformerManager graph_transformation_mgr{5};
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<NoOpTraceGraphTransformer>(),
+                                                     TransformerLevel::Level1));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(model->MainGraph(), TransformerLevel::Level1, *logger));
+
+  const auto& messages = capturing_sink_raw->Messages();
+  EXPECT_THAT(messages, testing::Contains(testing::HasSubstr(
+                            "Applying 1 graph transformer(s) for level 1 for up to 5 step(s).")));
+  EXPECT_THAT(messages, testing::Contains(testing::HasSubstr(
+                            "Applying graph transformer NoOpTraceGraphTransformer on step 1.")));
+  EXPECT_THAT(messages, testing::Contains(testing::HasSubstr(
+                            "Graph transformer step 1 of 5 for level 1 completed. graph_changed: 0.")));
+  EXPECT_THAT(messages, testing::Contains(testing::HasSubstr(
+                            "Stopping graph transformer iteration for level 1 after step 1 because the graph was not modified.")));
+}
+
 TEST_F(GraphTransformationTests, IdentityElimination) {
   constexpr const ORTCHAR_T* model_uri = MODEL_FOLDER "abs-id-max.onnx";
   std::shared_ptr<Model> model;


### PR DESCRIPTION
### Description

Adds verbose trace logging around `GraphTransformerManager::ApplyTransformers`.

The manager now logs:

- when no transformers are registered for a requested level;
- how many transformers will run for a level and the maximum number of steps;
- step start/end;
- each transformer invocation;
- when a `ShouldOnlyApplyOnce()` transformer is skipped on a later step;
- early stop when a step does not modify the graph.

This complements the existing per-transformer `GraphTransformer::Apply` log (`GraphTransformer <name> modified: ...`) with manager-level pass/iteration context.

### Motivation and Context

Graph optimizer changes are a frequent source of performance differences. When a fusion does or does not happen, it is useful to see not just an individual transformer's result, but also the manager-level iteration flow: which level ran, which step ran, which transformer was invoked, and why iteration stopped. This makes future perf investigations safer and easier to localize without changing optimization behavior.

### Testing

Added `GraphTransformationTests.GraphTransformerManagerEmitsVerboseTrace`, which uses a no-op transformer and `CapturingSink` to assert the manager-level trace messages are emitted.

Built `onnxruntime_test_all` (Release, Windows) and ran:

```powershell
.\onnxruntime_test_all.exe --gtest_filter="GraphTransformationTests.GraphTransformerManagerEmitsVerboseTrace"
```

Result:

```text
[==========] 1 test from 1 test suite ran.
[  PASSED  ] 1 test.
```
