### PR TITLE
Don't echo command when setting VSO variable in mac-cpu-packing-jobs.yml.

### DIFF
--- a/tools/ci_build/github/azure-pipelines/templates/mac-cpu-packing-jobs.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/mac-cpu-packing-jobs.yml
@@ -51,6 +51,10 @@ jobs:
         brew install --cask temurin@17
       fi
       JAVA_HOME=$(/usr/libexec/java_home -v 17)
+
+      # Do not output ##vso[] commands with `set -x` or they may be parsed again and include a trailing quote.
+      set +x
+
       echo "JAVA_HOME is set to: $JAVA_HOME"
       echo "##vso[task.setvariable variable=JAVA_HOME]$JAVA_HOME"
       echo "##vso[task.prependpath]$JAVA_HOME/bin"


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Don't echo command when setting VSO variable in mac-cpu-packing-jobs.yml.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

If the command is echoed again with `set -x`, the VSO variable may end up with a trailing `'`, which is invalid.
Whether this actually happens is intermittent and probably dependent on the output ordering.