### PR TITLE
Release outputHandlesArr in OrtTrainingSession.evalStep JNI binding

### DIFF
--- a/java/src/main/native/ai_onnxruntime_OrtTrainingSession.c
+++ b/java/src/main/native/ai_onnxruntime_OrtTrainingSession.c
@@ -533,6 +533,9 @@ JNIEXPORT jbooleanArray JNICALL Java_ai_onnxruntime_OrtTrainingSession_evalStep
     outputValues[i] = (OrtValue*)outputHandleLongs[i];
   }
 
+  // Release the java array copy of pointers to the outputs.
+  (*jniEnv)->ReleaseLongArrayElements(jniEnv, outputHandlesArr, outputHandleLongs, JNI_ABORT);
+
   // Actually score the inputs.
   //ORT_API2_STATUS(EvalStep, _In_ const OrtTrainingSession* sess, _In_opt_ const OrtRunOptions* run_options,
   //                size_t inputs_len, _In_reads_(inputs_len) const OrtValue* const* inputs,


### PR DESCRIPTION
### Description

`Java_ai_onnxruntime_OrtTrainingSession_evalStep` acquires the output handle array with `GetLongArrayElements(jniEnv, outputHandlesArr, NULL)` but never calls the matching `ReleaseLongArrayElements`, so the pinned array (or its native copy, depending on the JVM) leaks on every call and on all return paths: the `EvalStep` error `goto`, the output-conversion failure, and the normal success return.

This adds the release with `JNI_ABORT` immediately after the handle pointers are copied into `outputValues`, before `EvalStep` is invoked, so it covers every subsequent path. `JNI_ABORT` is correct because the handles are only read. The change mirrors the input handling a few lines above in the same function, and the sibling `trainStep()` and `OrtSession.run()` bindings, which already release their output handles this way. Inference results are unaffected, which is why functional tests do not catch the leak.

### Motivation and Context

Fixes #29573. `evalStep()` was the only one of the three equivalent bindings missing the release, so repeated evaluation (for example a validation loop) accumulated native memory and GC pressure.
