### PR TITLE
Add missing rank/length validation to pooling operators (fix OOB reads)

### DIFF
--- a/onnxruntime/contrib_ops/cpu/quantization/nhwc_max_pool.cc
+++ b/onnxruntime/contrib_ops/cpu/quantization/nhwc_max_pool.cc
@@ -39,6 +39,13 @@ Status NhwcMaxPool<T8Bits>::Compute(OpKernelContext* context) const {
 
   const size_t spatial_dims = input_rank - 2;
 
+  // The spatial loop below indexes kernel_shape/strides/dilations by dim, so their length must
+  // match the input spatial rank. The PoolAttributes constructor already enforces that strides and
+  // dilations match kernel_shape, so guarding kernel_shape here covers all three.
+  ORT_RETURN_IF_NOT(pool_attrs_.kernel_shape.size() == spatial_dims,
+                    "kernel_shape rank must match the input spatial rank. Got kernel_shape rank: ",
+                    pool_attrs_.kernel_shape.size(), ", input spatial rank: ", spatial_dims);
+
   // Compute the output size and effective padding for this pooling operation.
   TensorShapeVector output_dims({N});
   TensorShapeVector pads = pool_attrs_.pads;

--- a/onnxruntime/core/providers/cpu/fp16/fp16_pool.cc
+++ b/onnxruntime/core/providers/cpu/fp16/fp16_pool.cc
@@ -77,8 +77,8 @@ Status PoolFp16::Compute(OpKernelContext* context) const {
     std::ostringstream ss;
     ss << "Invalid kernel shape. Input shape ";
     ss << (channels_last_ ? "(NHWC):[" : "(NCHW):[");
-    // Iterate over the dimension array by rank (NumDimensions), not Size() which is the element
-    // count (product of dims); indexing input_shape by the element count would read past the dims.
+    // NumDimensions() is the number of dimensions; TensorShape::Size() is the element count
+    // (product of dims), so iterating to Size() would index beyond the dimension array.
     for (size_t i = 0; i < input_shape.NumDimensions(); i++) {
       ss << input_shape[i] << ", ";
     }

--- a/onnxruntime/core/providers/cpu/fp16/fp16_pool.cc
+++ b/onnxruntime/core/providers/cpu/fp16/fp16_pool.cc
@@ -77,7 +77,9 @@ Status PoolFp16::Compute(OpKernelContext* context) const {
     std::ostringstream ss;
     ss << "Invalid kernel shape. Input shape ";
     ss << (channels_last_ ? "(NHWC):[" : "(NCHW):[");
-    for (int64_t i = 0; i < input_shape.Size(); i++) {
+    // Iterate over the dimension array by rank (NumDimensions), not Size() which is the element
+    // count (product of dims); indexing input_shape by the element count would read past the dims.
+    for (size_t i = 0; i < input_shape.NumDimensions(); i++) {
       ss << input_shape[i] << ", ";
     }
     ss << "] Kernel shape:[";

--- a/onnxruntime/core/providers/cpu/nn/pool_attributes.h
+++ b/onnxruntime/core/providers/cpu/nn/pool_attributes.h
@@ -138,7 +138,8 @@ struct PoolAttributes {
                        bool is_nhwc = false) const {
     ORT_ENFORCE(input_dims.size() >= 2,
                 "Input must have at least 2 dimensions (batch and channel) before the spatial dims. "
-                "Got rank: ", input_dims.size());
+                "Got rank: ",
+                input_dims.size());
     if (global_pooling) {
       output_dims->assign(input_dims.size() - 2, 1);
     } else {

--- a/onnxruntime/core/providers/cpu/nn/pool_attributes.h
+++ b/onnxruntime/core/providers/cpu/nn/pool_attributes.h
@@ -84,7 +84,8 @@ struct PoolAttributes {
                   "Pad should be smaller than kernel.");
     }
 
-    ORT_ENFORCE(strides.size() == kernel_shape.size());
+    ORT_ENFORCE(strides.size() == kernel_shape.size(),
+                "Strides dimensions should match kernel shape");
     for (auto stride : strides) {
       ORT_ENFORCE(stride > 0, "All stride values must be positive, got: ", stride);
     }

--- a/onnxruntime/core/providers/cpu/nn/pool_attributes.h
+++ b/onnxruntime/core/providers/cpu/nn/pool_attributes.h
@@ -206,13 +206,16 @@ struct PoolAttributes {
                             int64_t dilation) const {
     // SafeInt guards against int64 overflow in the output-size arithmetic.
     int64_t numerator = SafeInt<int64_t>(in_size) + pad_head + pad_tail - SafeInt<int64_t>(dilation) * (kernel - 1) - 1;
-    int64_t out_size = numerator / stride + 1;
+    int64_t out_size = static_cast<int64_t>(SafeInt<int64_t>(numerator / stride) + 1);
 
     if (ceil_mode == 1) {
-      out_size = static_cast<int64_t>(std::ceil(static_cast<float>(numerator) / stride)) + 1;
+      int64_t ceil_div = static_cast<int64_t>(std::ceil(static_cast<float>(numerator) / stride));
+      out_size = static_cast<int64_t>(SafeInt<int64_t>(ceil_div) + 1);
       // Ensure that the last pooling starts inside the image (at least 1 pixel)
       // Reference: https://github.com/onnx/onnx/pull/5741
-      if ((out_size - 1) * stride >= in_size + pad_head) {
+      int64_t last_pool_start = static_cast<int64_t>((SafeInt<int64_t>(out_size) - 1) * stride);
+      int64_t input_extent = static_cast<int64_t>(SafeInt<int64_t>(in_size) + pad_head);
+      if (last_pool_start >= input_extent) {
         --out_size;
       }
     }

--- a/onnxruntime/core/providers/cpu/nn/pool_attributes.h
+++ b/onnxruntime/core/providers/cpu/nn/pool_attributes.h
@@ -47,7 +47,8 @@ struct PoolAttributes {
       pads.resize(kernel_shape.size() * 2, 0);
     }
     ORT_ENFORCE(pads.size() == kernel_shape.size() * 2,
-                "'pads' attribute must have a length of 2 * kernel_shape rank.");
+                "'pads' must have twice the kernel_shape rank (2 entries per spatial dim). Got pads size: ",
+                pads.size(), ", expected: ", kernel_shape.size() * 2);
 
     if (!info.GetAttrs("strides", strides).IsOK() || strides.empty()) {
       strides.resize(kernel_shape.size(), 1);
@@ -203,6 +204,7 @@ struct PoolAttributes {
                             int64_t pad_head,
                             int64_t pad_tail,
                             int64_t dilation) const {
+    // SafeInt guards against int64 overflow in the output-size arithmetic.
     int64_t numerator = SafeInt<int64_t>(in_size) + pad_head + pad_tail - SafeInt<int64_t>(dilation) * (kernel - 1) - 1;
     int64_t out_size = numerator / stride + 1;
 

--- a/onnxruntime/core/providers/cpu/nn/pool_attributes.h
+++ b/onnxruntime/core/providers/cpu/nn/pool_attributes.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cmath>
+#include "core/common/safeint.h"
 #ifndef SHARED_PROVIDER
 #include "core/common/common.h"
 #include "core/framework/op_node_proto_helper.h"
@@ -45,6 +46,8 @@ struct PoolAttributes {
     if (!info.GetAttrs("pads", pads).IsOK() || pads.empty()) {
       pads.resize(kernel_shape.size() * 2, 0);
     }
+    ORT_ENFORCE(pads.size() == kernel_shape.size() * 2,
+                "'pads' attribute must have a length of 2 * kernel_shape rank.");
 
     if (!info.GetAttrs("strides", strides).IsOK() || strides.empty()) {
       strides.resize(kernel_shape.size(), 1);
@@ -108,6 +111,9 @@ struct PoolAttributes {
                                   int64_t output_channel,
                                   TensorShapeVector* actual_pads,
                                   bool is_nhwc = false) const {
+    ORT_ENFORCE(input_shape.NumDimensions() >= 2,
+                "Input must have at least 2 dimensions (N, C, ...spatial). Got rank: ",
+                input_shape.NumDimensions());
     ORT_ENFORCE(input_shape.Size() > 0 || input_shape[0] == 0,
                 "Invalid input shape. Only N can be zero. Got:", input_shape);
     TensorShapeVector output_dims;
@@ -130,10 +136,13 @@ struct PoolAttributes {
     if (global_pooling) {
       output_dims->assign(input_dims.size() - 2, 1);
     } else {
+      ORT_ENFORCE(input_dims.size() - 2 == kernel_shape.size(),
+                  "kernel_shape rank must match the input spatial rank. Input spatial rank: ",
+                  input_dims.size() - 2, ", kernel_shape rank: ", kernel_shape.size());
       for (size_t dim = 0; dim < input_dims.size() - 2; ++dim) {
         int64_t dim_size = 0;
         auto spatial_dim = is_nhwc ? input_dims[dim + 1] : input_dims[dim + 2];
-        ComputeSizePadDilations(static_cast<int>(spatial_dim),
+        ComputeSizePadDilations(spatial_dim,
                                 strides[dim],
                                 kernel_shape[dim],
                                 &actual_pads->at(dim),
@@ -194,7 +203,7 @@ struct PoolAttributes {
                             int64_t pad_head,
                             int64_t pad_tail,
                             int64_t dilation) const {
-    int64_t numerator = in_size + pad_head + pad_tail - dilation * (kernel - 1) - 1;
+    int64_t numerator = SafeInt<int64_t>(in_size) + pad_head + pad_tail - SafeInt<int64_t>(dilation) * (kernel - 1) - 1;
     int64_t out_size = numerator / stride + 1;
 
     if (ceil_mode == 1) {
@@ -205,6 +214,8 @@ struct PoolAttributes {
         --out_size;
       }
     }
+    ORT_ENFORCE(out_size >= 0,
+                "Calculated output dimension is negative. Check kernel_shape, pads, strides and dilations.");
     return out_size;
   }
 #if defined(_MSC_VER) && !defined(__clang__)

--- a/onnxruntime/core/providers/cpu/nn/pool_attributes.h
+++ b/onnxruntime/core/providers/cpu/nn/pool_attributes.h
@@ -75,6 +75,8 @@ struct PoolAttributes {
     if (op_name == "MaxPool") {
       if (start_version >= 8) {
         ORT_ENFORCE(info.GetAttr("storage_order", &storage_order).IsOK());
+        ORT_ENFORCE(storage_order == 0 || storage_order == 1,
+                    "storage_order must be 0 (row-major) or 1 (column-major). Got: ", storage_order);
       }
     }
 
@@ -164,6 +166,9 @@ struct PoolAttributes {
                                int64_t dilation,
                                int64_t* out_size) const {
     if (auto_pad != AutoPadType::NOTSET) {
+      // TODO: Per the ONNX spec, auto_pad and explicit pads are mutually exclusive. ORT currently
+      // accepts both and overwrites any explicit pads below when auto_pad is set, rather than
+      // rejecting the model, to preserve backward compatibility with existing models.
       switch (auto_pad) {
         case AutoPadType::VALID:
           *pad_head = 0;

--- a/onnxruntime/core/providers/cpu/nn/pool_attributes.h
+++ b/onnxruntime/core/providers/cpu/nn/pool_attributes.h
@@ -136,7 +136,9 @@ struct PoolAttributes {
                        TensorShapeVector* output_dims,
                        TensorShapeVector* actual_pads,
                        bool is_nhwc = false) const {
-    ORT_ENFORCE(input_dims.size() >= 2);
+    ORT_ENFORCE(input_dims.size() >= 2,
+                "Input must have at least 2 dimensions (batch and channel) before the spatial dims. "
+                "Got rank: ", input_dims.size());
     if (global_pooling) {
       output_dims->assign(input_dims.size() - 2, 1);
     } else {
@@ -210,7 +212,9 @@ struct PoolAttributes {
                             int64_t pad_head,
                             int64_t pad_tail,
                             int64_t dilation) const {
-    // SafeInt guards against int64 overflow in the output-size arithmetic.
+    // SafeInt wraps the residual output-size arithmetic below (the numerator terms and the +1 /
+    // ceil-mode add and subtract) to catch int64 overflow. It does not cover the auto_pad SAME_*
+    // padding math in the caller or the numerator / stride division.
     int64_t numerator = SafeInt<int64_t>(in_size) + pad_head + pad_tail - SafeInt<int64_t>(dilation) * (kernel - 1) - 1;
     int64_t out_size = static_cast<int64_t>(SafeInt<int64_t>(numerator / stride) + 1);
 

--- a/onnxruntime/test/contrib_ops/nhwc_maxpool_op_test.cc
+++ b/onnxruntime/test/contrib_ops/nhwc_maxpool_op_test.cc
@@ -258,5 +258,25 @@ TEST(NhwcMaxPoolContribOpTest, MaxPoolDilations_S8) {
   test.Run();
 }
 
+// Verify that a kernel_shape whose rank does not match the input spatial rank is rejected before
+// the spatial loop in NhwcMaxPool::Compute (which indexes kernel_shape/strides/dilations by dim).
+// AddShapeToTensorData(false) omits the input shape from the graph so ONNX shape inference is
+// bypassed and the crafted rank mismatch reaches the kernel. Exclude compiling EPs (TRT, QNN) and
+// EPs with their own validation (DML) that produce different error messages.
+TEST(NhwcMaxPoolContribOpTest, KernelRankMismatch_S8) {
+  OpTester test("NhwcMaxPool", 1, onnxruntime::kMSDomain);
+  test.AddShapeToTensorData(false);
+
+  // Input spatial rank is 2 (input rank 4) while kernel_shape rank is 1.
+  test.AddAttribute("kernel_shape", std::vector<int64_t>{3});
+
+  std::vector<int8_t> x_vals(1 * 8 * 8 * 4, 0);
+  test.AddInput<int8_t>("x", {1, 8, 8, 4}, x_vals);
+  test.AddOutput<int8_t>("y", {0}, {});
+
+  test.Run(OpTester::ExpectResult::kExpectFailure, "kernel_shape rank must match",
+           {kTensorrtExecutionProvider, kQnnExecutionProvider, kDmlExecutionProvider});
+}
+
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/cpu/nn/pool_op_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/pool_op_test.cc
@@ -1964,6 +1964,111 @@ TEST(PoolTest, MaxPool_ZeroDilation) {
            {kTensorrtExecutionProvider, kQnnExecutionProvider, kDmlExecutionProvider});
 }
 
+// Verify that a 'pads' attribute shorter than 2 * kernel_shape rank is rejected by PoolAttributes
+// kernel validation. AddShapeToTensorData(false) omits input shape from the graph so ONNX shape
+// inference is bypassed and the model reaches kernel construction where the ORT_ENFORCE fires.
+// Exclude compiling EPs (TRT, QNN) and EPs with their own validation (DML) that produce
+// different error messages.
+TEST(PoolTest, MaxPool_PadsTooShort) {
+  OpTester test("MaxPool");
+  test.AddShapeToTensorData(false);
+
+  test.AddAttribute("auto_pad", "");
+  test.AddAttribute("strides", std::vector<int64_t>{1, 1});
+  test.AddAttribute("pads", std::vector<int64_t>{0, 0});
+  test.AddAttribute("kernel_shape", std::vector<int64_t>{2, 2});
+
+  std::vector<float> x_vals(1 * 1 * 8 * 8, 1.0f);
+  test.AddInput<float>("X", {1, 1, 8, 8}, x_vals);
+  test.AddOutput<float>("Y", {0}, {});
+
+  test.Run(OpTester::ExpectResult::kExpectFailure, "pads",
+           {kTensorrtExecutionProvider, kQnnExecutionProvider, kDmlExecutionProvider});
+}
+
+TEST(PoolTest, AveragePool_PadsTooShort) {
+  OpTester test("AveragePool");
+  test.AddShapeToTensorData(false);
+
+  test.AddAttribute("auto_pad", "");
+  test.AddAttribute("strides", std::vector<int64_t>{1, 1});
+  test.AddAttribute("pads", std::vector<int64_t>{0, 0});
+  test.AddAttribute("kernel_shape", std::vector<int64_t>{2, 2});
+  test.AddAttribute("count_include_pad", static_cast<int64_t>(0));
+
+  std::vector<float> x_vals(1 * 1 * 8 * 8, 1.0f);
+  test.AddInput<float>("X", {1, 1, 8, 8}, x_vals);
+  test.AddOutput<float>("Y", {0}, {});
+
+  test.Run(OpTester::ExpectResult::kExpectFailure, "pads",
+           {kTensorrtExecutionProvider, kQnnExecutionProvider, kDmlExecutionProvider});
+}
+
+TEST(PoolTest, LpPool_PadsTooShort) {
+  OpTester test("LpPool", 18);
+  test.AddShapeToTensorData(false);
+
+  test.AddAttribute("auto_pad", "");
+  test.AddAttribute("strides", std::vector<int64_t>{1, 1});
+  test.AddAttribute("pads", std::vector<int64_t>{0, 0});
+  test.AddAttribute("kernel_shape", std::vector<int64_t>{2, 2});
+
+  std::vector<float> x_vals(1 * 1 * 8 * 8, 1.0f);
+  test.AddInput<float>("X", {1, 1, 8, 8}, x_vals);
+  test.AddOutput<float>("Y", {0}, {});
+
+  test.Run(OpTester::ExpectResult::kExpectFailure, "pads",
+           {kTensorrtExecutionProvider, kQnnExecutionProvider, kDmlExecutionProvider});
+}
+
+// Verify that a kernel_shape whose rank does not match the input spatial rank is rejected by
+// PoolAttributes::InferOutputSize. LpPool (opset < 18) uses the generic Pool::Compute path, which
+// has no earlier rank guard, so the request reaches the InferOutputSize validation directly.
+// AddShapeToTensorData(false) omits the input shape so ONNX shape inference is bypassed.
+// Exclude compiling EPs (TRT, QNN) and EPs with their own validation (DML) that produce
+// different error messages.
+TEST(PoolTest, LpPool_KernelRankMismatch) {
+  OpTester test("LpPool", 11);
+  test.AddShapeToTensorData(false);
+
+  test.AddAttribute("auto_pad", "");
+  test.AddAttribute("strides", std::vector<int64_t>{1, 1});
+  test.AddAttribute("pads", std::vector<int64_t>{0, 0, 0, 0});
+  test.AddAttribute("kernel_shape", std::vector<int64_t>{2, 2});
+
+  // Input spatial rank is 3 while kernel_shape rank is 2.
+  std::vector<float> x_vals(1 * 1 * 8 * 8 * 8, 1.0f);
+  test.AddInput<float>("X", {1, 1, 8, 8, 8}, x_vals);
+  test.AddOutput<float>("Y", {0}, {});
+
+  test.Run(OpTester::ExpectResult::kExpectFailure, "input spatial rank",
+           {kTensorrtExecutionProvider, kQnnExecutionProvider, kDmlExecutionProvider});
+}
+
+// Verify that attribute values producing a non-positive output dimension are rejected by
+// PoolAttributes::ComputeOutputSize. A 3x3 kernel over a 1x1 spatial input with no padding makes
+// the padded input smaller than the dilated kernel, so the computed output dimension is negative.
+// AddShapeToTensorData(false) omits the input shape so ONNX shape inference is bypassed.
+// Exclude compiling EPs (TRT, QNN) and EPs with their own validation (DML) that produce
+// different error messages.
+TEST(PoolTest, AveragePool_NegativeOutputDim) {
+  OpTester test("AveragePool");
+  test.AddShapeToTensorData(false);
+
+  test.AddAttribute("auto_pad", "");
+  test.AddAttribute("strides", std::vector<int64_t>{1, 1});
+  test.AddAttribute("pads", std::vector<int64_t>{0, 0, 0, 0});
+  test.AddAttribute("kernel_shape", std::vector<int64_t>{3, 3});
+  test.AddAttribute("count_include_pad", static_cast<int64_t>(0));
+
+  std::vector<float> x_vals(1 * 1 * 1 * 1, 1.0f);
+  test.AddInput<float>("X", {1, 1, 1, 1}, x_vals);
+  test.AddOutput<float>("Y", {0}, {});
+
+  test.Run(OpTester::ExpectResult::kExpectFailure, "output dimension is negative",
+           {kTensorrtExecutionProvider, kQnnExecutionProvider, kDmlExecutionProvider});
+}
+
 // DML EP validates stride/dilation in OperatorHelper.cpp (KernelHelper constructor) via
 // ML_CHECK_VALID_ARGUMENT_MSG, but the descriptive message is lost when the exception crosses
 // the COM/HRESULT boundary (CATCH_RETURN strips the message, THROW_IF_FAILED re-throws with

--- a/onnxruntime/test/providers/cpu/nn/pool_op_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/pool_op_test.cc
@@ -2092,9 +2092,9 @@ TEST(PoolTest, MaxPool_PadsTooLong) {
 }
 
 // Verify that a 'strides' attribute whose length does not match the kernel_shape rank is rejected
-// by the PoolAttributes constructor. The bare ORT_ENFORCE carries the stringified condition as its
-// message, so the assertion pins that check. AddShapeToTensorData(false) bypasses shape inference.
-// Exclude compiling EPs (TRT, QNN) and EPs with their own validation (DML) that produce
+// by the PoolAttributes constructor. The assertion pins the explicit strides length message
+// ("Strides dimensions should match kernel shape"). AddShapeToTensorData(false) bypasses shape
+// inference. Exclude compiling EPs (TRT, QNN) and EPs with their own validation (DML) that produce
 // different error messages.
 TEST(PoolTest, MaxPool_StridesLengthMismatch) {
   OpTester test("MaxPool");

--- a/onnxruntime/test/providers/cpu/nn/pool_op_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/pool_op_test.cc
@@ -2158,6 +2158,29 @@ TEST(PoolTest, MaxPool_InputRankTooLow) {
            {kTensorrtExecutionProvider, kQnnExecutionProvider, kDmlExecutionProvider});
 }
 
+// Verify that a MaxPool 'storage_order' outside the valid set {0, 1} is rejected by the
+// PoolAttributes constructor. storage_order was introduced in MaxPool opset 8, so target that
+// version. AddShapeToTensorData(false) bypasses shape inference so the model reaches kernel
+// construction where the ORT_ENFORCE fires. Exclude compiling EPs (TRT, QNN) and EPs with their
+// own validation (DML) that produce different error messages.
+TEST(PoolTest, MaxPool_InvalidStorageOrder) {
+  OpTester test("MaxPool", 8);
+  test.AddShapeToTensorData(false);
+
+  test.AddAttribute("auto_pad", "");
+  test.AddAttribute("strides", std::vector<int64_t>{1, 1});
+  test.AddAttribute("pads", std::vector<int64_t>{0, 0, 0, 0});
+  test.AddAttribute("kernel_shape", std::vector<int64_t>{2, 2});
+  test.AddAttribute("storage_order", static_cast<int64_t>(2));
+
+  std::vector<float> x_vals(1 * 1 * 8 * 8, 1.0f);
+  test.AddInput<float>("X", {1, 1, 8, 8}, x_vals);
+  test.AddOutput<float>("Y", {0}, {});
+
+  test.Run(OpTester::ExpectResult::kExpectFailure, "storage_order must be 0",
+           {kTensorrtExecutionProvider, kQnnExecutionProvider, kDmlExecutionProvider});
+}
+
 // DML EP validates stride/dilation in OperatorHelper.cpp (KernelHelper constructor) via
 // ML_CHECK_VALID_ARGUMENT_MSG, but the descriptive message is lost when the exception crosses
 // the COM/HRESULT boundary (CATCH_RETURN strips the message, THROW_IF_FAILED re-throws with

--- a/onnxruntime/test/providers/cpu/nn/pool_op_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/pool_op_test.cc
@@ -2069,6 +2069,94 @@ TEST(PoolTest, AveragePool_NegativeOutputDim) {
            {kTensorrtExecutionProvider, kQnnExecutionProvider, kDmlExecutionProvider});
 }
 
+// Verify that a 'pads' attribute longer than 2 * kernel_shape rank is rejected by the
+// PoolAttributes constructor. AddShapeToTensorData(false) omits the input shape so ONNX shape
+// inference is bypassed and the model reaches kernel construction where the ORT_ENFORCE fires.
+// Exclude compiling EPs (TRT, QNN) and EPs with their own validation (DML) that produce
+// different error messages.
+TEST(PoolTest, MaxPool_PadsTooLong) {
+  OpTester test("MaxPool");
+  test.AddShapeToTensorData(false);
+
+  test.AddAttribute("auto_pad", "");
+  test.AddAttribute("strides", std::vector<int64_t>{1, 1});
+  test.AddAttribute("pads", std::vector<int64_t>{0, 0, 0, 0, 0, 0});
+  test.AddAttribute("kernel_shape", std::vector<int64_t>{2, 2});
+
+  std::vector<float> x_vals(1 * 1 * 8 * 8, 1.0f);
+  test.AddInput<float>("X", {1, 1, 8, 8}, x_vals);
+  test.AddOutput<float>("Y", {0}, {});
+
+  test.Run(OpTester::ExpectResult::kExpectFailure, "twice the kernel_shape rank",
+           {kTensorrtExecutionProvider, kQnnExecutionProvider, kDmlExecutionProvider});
+}
+
+// Verify that a 'strides' attribute whose length does not match the kernel_shape rank is rejected
+// by the PoolAttributes constructor. The bare ORT_ENFORCE carries the stringified condition as its
+// message, so the assertion pins that check. AddShapeToTensorData(false) bypasses shape inference.
+// Exclude compiling EPs (TRT, QNN) and EPs with their own validation (DML) that produce
+// different error messages.
+TEST(PoolTest, MaxPool_StridesLengthMismatch) {
+  OpTester test("MaxPool");
+  test.AddShapeToTensorData(false);
+
+  test.AddAttribute("auto_pad", "");
+  test.AddAttribute("strides", std::vector<int64_t>{1, 1, 1});
+  test.AddAttribute("pads", std::vector<int64_t>{0, 0, 0, 0});
+  test.AddAttribute("kernel_shape", std::vector<int64_t>{2, 2});
+
+  std::vector<float> x_vals(1 * 1 * 8 * 8, 1.0f);
+  test.AddInput<float>("X", {1, 1, 8, 8}, x_vals);
+  test.AddOutput<float>("Y", {0}, {});
+
+  test.Run(OpTester::ExpectResult::kExpectFailure, "strides.size() == kernel_shape.size()",
+           {kTensorrtExecutionProvider, kQnnExecutionProvider, kDmlExecutionProvider});
+}
+
+// Verify that a 'dilations' attribute whose length does not match the kernel_shape rank is
+// rejected by the PoolAttributes constructor. AddShapeToTensorData(false) bypasses shape inference.
+// Exclude compiling EPs (TRT, QNN) and EPs with their own validation (DML) that produce
+// different error messages.
+TEST(PoolTest, MaxPool_DilationsLengthMismatch) {
+  OpTester test("MaxPool", 10);
+  test.AddShapeToTensorData(false);
+
+  test.AddAttribute("auto_pad", "");
+  test.AddAttribute("strides", std::vector<int64_t>{1, 1});
+  test.AddAttribute("pads", std::vector<int64_t>{0, 0, 0, 0});
+  test.AddAttribute("kernel_shape", std::vector<int64_t>{2, 2});
+  test.AddAttribute("dilations", std::vector<int64_t>{1, 1, 1});
+
+  std::vector<float> x_vals(1 * 1 * 8 * 8, 1.0f);
+  test.AddInput<float>("X", {1, 1, 8, 8}, x_vals);
+  test.AddOutput<float>("Y", {0}, {});
+
+  test.Run(OpTester::ExpectResult::kExpectFailure, "Dilations dimensions should match kernel shape",
+           {kTensorrtExecutionProvider, kQnnExecutionProvider, kDmlExecutionProvider});
+}
+
+// Verify that a low-rank input is rejected before pooling. The SetOutputSize F5 guard
+// (NumDimensions >= 2) is defense-in-depth for execution providers and direct callers, but the CPU
+// pooling kernels reject inputs with rank < 3 earlier in Compute, so this test pins that earlier
+// guard's message. AddShapeToTensorData(false) bypasses shape inference so the rank-2 input reaches
+// the kernel. Exclude compiling EPs (TRT, QNN) and EPs with their own validation (DML).
+TEST(PoolTest, MaxPool_InputRankTooLow) {
+  OpTester test("MaxPool");
+  test.AddShapeToTensorData(false);
+
+  test.AddAttribute("auto_pad", "");
+  test.AddAttribute("strides", std::vector<int64_t>{1, 1});
+  test.AddAttribute("pads", std::vector<int64_t>{0, 0, 0, 0});
+  test.AddAttribute("kernel_shape", std::vector<int64_t>{2, 2});
+
+  std::vector<float> x_vals(4 * 4, 1.0f);
+  test.AddInput<float>("X", {4, 4}, x_vals);
+  test.AddOutput<float>("Y", {0}, {});
+
+  test.Run(OpTester::ExpectResult::kExpectFailure, "Input dimension cannot be less than 3",
+           {kTensorrtExecutionProvider, kQnnExecutionProvider, kDmlExecutionProvider});
+}
+
 // DML EP validates stride/dilation in OperatorHelper.cpp (KernelHelper constructor) via
 // ML_CHECK_VALID_ARGUMENT_MSG, but the descriptive message is lost when the exception crosses
 // the COM/HRESULT boundary (CATCH_RETURN strips the message, THROW_IF_FAILED re-throws with

--- a/onnxruntime/test/providers/cpu/nn/pool_op_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/pool_op_test.cc
@@ -1982,7 +1982,7 @@ TEST(PoolTest, MaxPool_PadsTooShort) {
   test.AddInput<float>("X", {1, 1, 8, 8}, x_vals);
   test.AddOutput<float>("Y", {0}, {});
 
-  test.Run(OpTester::ExpectResult::kExpectFailure, "pads",
+  test.Run(OpTester::ExpectResult::kExpectFailure, "twice the kernel_shape rank",
            {kTensorrtExecutionProvider, kQnnExecutionProvider, kDmlExecutionProvider});
 }
 
@@ -2000,7 +2000,7 @@ TEST(PoolTest, AveragePool_PadsTooShort) {
   test.AddInput<float>("X", {1, 1, 8, 8}, x_vals);
   test.AddOutput<float>("Y", {0}, {});
 
-  test.Run(OpTester::ExpectResult::kExpectFailure, "pads",
+  test.Run(OpTester::ExpectResult::kExpectFailure, "twice the kernel_shape rank",
            {kTensorrtExecutionProvider, kQnnExecutionProvider, kDmlExecutionProvider});
 }
 
@@ -2017,7 +2017,7 @@ TEST(PoolTest, LpPool_PadsTooShort) {
   test.AddInput<float>("X", {1, 1, 8, 8}, x_vals);
   test.AddOutput<float>("Y", {0}, {});
 
-  test.Run(OpTester::ExpectResult::kExpectFailure, "pads",
+  test.Run(OpTester::ExpectResult::kExpectFailure, "twice the kernel_shape rank",
            {kTensorrtExecutionProvider, kQnnExecutionProvider, kDmlExecutionProvider});
 }
 

--- a/onnxruntime/test/providers/cpu/nn/pool_op_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/pool_op_test.cc
@@ -2109,7 +2109,7 @@ TEST(PoolTest, MaxPool_StridesLengthMismatch) {
   test.AddInput<float>("X", {1, 1, 8, 8}, x_vals);
   test.AddOutput<float>("Y", {0}, {});
 
-  test.Run(OpTester::ExpectResult::kExpectFailure, "strides.size() == kernel_shape.size()",
+  test.Run(OpTester::ExpectResult::kExpectFailure, "Strides dimensions should match kernel shape",
            {kTensorrtExecutionProvider, kQnnExecutionProvider, kDmlExecutionProvider});
 }
 
@@ -2118,6 +2118,7 @@ TEST(PoolTest, MaxPool_StridesLengthMismatch) {
 // Exclude compiling EPs (TRT, QNN) and EPs with their own validation (DML) that produce
 // different error messages.
 TEST(PoolTest, MaxPool_DilationsLengthMismatch) {
+  // 'dilations' is only a valid MaxPool attribute from opset 10 onward, so target that version.
   OpTester test("MaxPool", 10);
   test.AddShapeToTensorData(false);
 

--- a/onnxruntime/test/providers/cpu/nn/pool_op_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/pool_op_test.cc
@@ -2136,11 +2136,12 @@ TEST(PoolTest, MaxPool_DilationsLengthMismatch) {
            {kTensorrtExecutionProvider, kQnnExecutionProvider, kDmlExecutionProvider});
 }
 
-// Verify that a low-rank input is rejected before pooling. The SetOutputSize F5 guard
+// Verify that a low-rank input is rejected before pooling. The rank check in SetOutputSize
 // (NumDimensions >= 2) is defense-in-depth for execution providers and direct callers, but the CPU
-// pooling kernels reject inputs with rank < 3 earlier in Compute, so this test pins that earlier
-// guard's message. AddShapeToTensorData(false) bypasses shape inference so the rank-2 input reaches
-// the kernel. Exclude compiling EPs (TRT, QNN) and EPs with their own validation (DML).
+// pooling kernels reject inputs with rank < 3 earlier in Compute, so the tested path fires that
+// earlier guard and this test pins its message ("Input dimension cannot be less than 3").
+// AddShapeToTensorData(false) bypasses shape inference so the rank-2 input reaches the kernel.
+// Exclude compiling EPs (TRT, QNN) and EPs with their own validation (DML).
 TEST(PoolTest, MaxPool_InputRankTooLow) {
   OpTester test("MaxPool");
   test.AddShapeToTensorData(false);


### PR DESCRIPTION
## Summary

The pooling operators (`MaxPool` / `AveragePool` / `LpPool` and the contrib `NhwcMaxPool`) did not fully validate attribute lengths and input ranks before indexing into per-spatial-dimension attribute vectors. On malformed models this could lead to out-of-bounds reads. This PR adds the missing input-validation guards so such models are rejected with clear errors instead of reading past the end of the attribute containers.

Because all standard pooling execution providers (CPU / CUDA / ROCm / JS / WebGPU / XNNPACK / ACL) share `PoolBase` / `PoolAttributes`, the `pool_attributes.h` guards cover them all with a single change. `NhwcMaxPool` needs its own guard because it does not go through `PoolAttributes::SetOutputSize` and hand-writes its spatial loop.

## What changed, by file

### `onnxruntime/core/providers/cpu/nn/pool_attributes.h`
- Validate `pads.size() == 2 * kernel_shape.size()` before indexing `pads` (F1).
- Validate that the `kernel_shape` rank matches the input spatial rank in `InferOutputSize` before indexing `strides` / `kernel_shape` / `dilations` (F2).
- Validate input rank `>= 2` in `SetOutputSize` before indexing the input shape (F5).
- Remove the `int` truncation of the spatial dimension; use `int64` throughout (F3).
- Wrap the residual output-size arithmetic in `SafeInt<int64_t>` to guard against overflow and enforce `out_size >= 0` (F4).
- Give the `strides` length check an explicit error message (previously a bare condition).
- Validate `MaxPool` `storage_order` is 0 (row-major) or 1 (column-major) at construction (F7).

### `onnxruntime/contrib_ops/cpu/quantization/nhwc_max_pool.cc`
- `NhwcMaxPool` bypasses the shared `SetOutputSize` path and hand-writes its spatial loop, indexing `kernel_shape` / `strides` / `dilations` by dimension. Added a guard validating that the `kernel_shape` rank matches the input spatial rank before the loop. `Compute` returns `Status`, so this uses `ORT_RETURN_IF_NOT` (no-exception-build compatible), mirroring the existing guard in `fp16_pool.cc`. The `PoolAttributes` constructor already enforces that `strides` and `dilations` match `kernel_shape`, so guarding `kernel_shape` here covers all three indexed vectors.

### `onnxruntime/core/providers/cpu/fp16/fp16_pool.cc`
- Fixed an incorrect loop bound in the malformed-`kernel_shape` diagnostic path: the error-message
  loop iterated with `TensorShape::Size()` (the element count, product of dims) while indexing the
  dimension array, which is bounded by the rank. Replaced it with `NumDimensions()` so the loop
  iterates the dims correctly. This `PoolFp16` kernel is ARM64-only (built under
  `MLAS_F16VEC_INTRINSICS_SUPPORTED`, i.e. non-Apple ARM64/ARM64EC) and the affected code runs only
  on the already-failing error path. Because the kernel is not compiled on x86 and the existing
  fp16 pool tests are gated on `USE_CUDA`/`USE_COREML` (exercising those EPs' kernels rather than
  this one), no x86 CI negative test can reach this path; the fix is validated by inspection.

### Tests
Added 11 negative tests total, all using `kExpectFailure` and compatible with no-exception builds:
- `pool_op_test.cc`: `MaxPool_PadsTooShort`, `AveragePool_PadsTooShort`, `LpPool_PadsTooShort`, `LpPool_KernelRankMismatch`, `AveragePool_NegativeOutputDim`, `MaxPool_PadsTooLong`, `MaxPool_StridesLengthMismatch`, `MaxPool_DilationsLengthMismatch`, `MaxPool_InputRankTooLow`, `MaxPool_InvalidStorageOrder`.
- `nhwc_maxpool_op_test.cc`: `NhwcMaxPool KernelRankMismatch_S8`.

## Design note

The `pads.size() == 2 * kernel_shape.size()` check is intentionally **unconditional** (not gated on `auto_pad`). Making it conditional on `auto_pad == NOTSET` would reopen the out-of-bounds indexing path for models that set `auto_pad` together with a malformed `pads` list.

## Testing

All pooling and NHWC max-pool tests pass: **105 passed / 2 skipped (DML not built) / 0 failed**, with zero regression.

## Follow-ups (out of scope, tracked separately)

- F6: `auto_pad` vs explicit `pads` mutual-exclusion per the ONNX spec — deferred due to backward-compatibility risk.
- CUDA `narrow_cast<int>` truncation on `int64` dims — non-OOB.
- Optional integer-domain ceil to remove a float path in `ComputeOutputSize`.


