### PR TITLE
[Build] Fix cuda packaging build error

### DIFF
--- a/onnxruntime/contrib_ops/cuda/quantization/matmul_4bits.cu
+++ b/onnxruntime/contrib_ops/cuda/quantization/matmul_4bits.cu
@@ -583,12 +583,10 @@ __device__ __forceinline__ void AccumulateRow(const DequantizedEight<nv_bfloat16
 // 2-wide accumulator type (half2 / bf162).
 template <class T>
 struct Acc2;
-#if (!defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 530) && !defined(__HIPCC__)
 template <>
 struct Acc2<half> {
   using type = half2;
 };
-#endif
 template <>
 struct Acc2<nv_bfloat16> {
   using type = __nv_bfloat162;
@@ -603,16 +601,18 @@ struct WPack {
 
 // DequantizeEight emits [04,15,26,37] (the order of Convert8xInt4To8xHalfs); repack to natural order
 // once per column. Doing the prmt on the (CtaN) weights instead of the (CtaM) activations cuts the
-// permute count by CtaM/CtaN, which dominates at small M.
-#if (!defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 530) && !defined(__HIPCC__)
+// permute count by CtaM/CtaN, which dominates at small M. The signatures are always defined so
+// MatMulFloat4BatchedKernel<half> still compiles for archs below sm_53 (e.g. sm_52); only the
+// half2-intrinsic bodies are gated, mirroring the nv_bfloat16 helpers below.
 __device__ __forceinline__ WPack<half> PackNatural(const DequantizedEight<half>& d) {
+  WPack<half> w;
+#if (!defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 530) && !defined(__HIPCC__)
   uint32_t d0 = *reinterpret_cast<const uint32_t*>(&d.v[0]);
   uint32_t d1 = *reinterpret_cast<const uint32_t*>(&d.v[1]);
   uint32_t d2 = *reinterpret_cast<const uint32_t*>(&d.v[2]);
   uint32_t d3 = *reinterpret_cast<const uint32_t*>(&d.v[3]);
   constexpr uint32_t kLo = 0x5410;  // (x0,x1) of two half2 -> elements 0,1
   constexpr uint32_t kHi = 0x7632;  // (y0,y1) -> elements 4,5
-  WPack<half> w;
   uint32_t t;
   asm volatile("prmt.b32 %0, %1, %2, %3;\n" : "=r"(t) : "r"(d0), "r"(d1), "r"(kLo));
   w.v[0] = *reinterpret_cast<half2*>(&t);
@@ -622,18 +622,24 @@ __device__ __forceinline__ WPack<half> PackNatural(const DequantizedEight<half>&
   w.v[2] = *reinterpret_cast<half2*>(&t);
   asm volatile("prmt.b32 %0, %1, %2, %3;\n" : "=r"(t) : "r"(d2), "r"(d3), "r"(kHi));
   w.v[3] = *reinterpret_cast<half2*>(&t);
+#endif
   return w;
 }
 __device__ __forceinline__ void DotAccum(const WPack<half>& w, const half2* a4, half2& acc) {
+#if (!defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 530) && !defined(__HIPCC__)
   acc = __hfma2(w.v[0], a4[0], acc);
   acc = __hfma2(w.v[1], a4[1], acc);
   acc = __hfma2(w.v[2], a4[2], acc);
   acc = __hfma2(w.v[3], a4[3], acc);
+#endif
 }
 __device__ __forceinline__ float HorizontalAdd(half2 acc) {
+#if (!defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 530) && !defined(__HIPCC__)
   return static_cast<float>(acc.x) + static_cast<float>(acc.y);
-}
+#else
+  return 0.f;
 #endif
+}
 
 __device__ __forceinline__ WPack<nv_bfloat16> PackNatural(const DequantizedEight<nv_bfloat16>& d) {
   WPack<nv_bfloat16> w;


### PR DESCRIPTION
### Description

Fixes the CUDA packaging pipeline build error (with CUDA arch `52-real`) that was introduced by #29451.

### Root cause

The small-M batched GEMV path added in #29451 defines `half` helpers for the batched kernel — the `Acc2<half>` accumulator trait and the `PackNatural` / `DotAccum` / `HorizontalAdd` overloads — inside a single `#if (!defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 530)` guard that compiles the *entire* declaration out for archs below `sm_53`.

However, `MatMulFloat4BatchedKernel<half>` is launched from host code and is therefore instantiated for **every** target architecture, including `sm_52`. During the `sm_52` device pass those `half` helpers no longer exist, so `nvcc` reported (100 errors, e.g.):

- `incomplete type "Acc2<half>" is not allowed`
- `no suitable user-defined conversion from "WPack<half>" to "const WPack<nv_bfloat16>" exists` (the compiler fell back to the `nv_bfloat16` overloads)

### Fix

Mirror the existing `nv_bfloat16` convention in the same file: always define the type and function **signatures**, and gate only the arch-specific (half2-intrinsic) **bodies**. Now `Acc2<half>` is always a complete type and the `half` overloads always exist, so `MatMulFloat4BatchedKernel<half>` compiles for `sm_52`. On archs below `sm_53` the bodies compile to no-ops (returning zeros), which matches the already-shipped `nv_bfloat16` behavior for archs below `sm_80`.

### Motivation and Context

The CUDA packaging pipeline builds with `CMAKE_CUDA_ARCHITECTURES=52-real;61-real;75-real;86-real;89-real;90-virtual`, so the `sm_52` device pass is required and the pipeline was broken by #29451.
