### PR TITLE
Guard GridSample CUDA coordinate conversion

### DIFF
--- a/onnxruntime/core/providers/cpu/tensor/grid_sample.cc
+++ b/onnxruntime/core/providers/cpu/tensor/grid_sample.cc
@@ -64,10 +64,16 @@ template <typename T>
 T GsReflect(T x, T x_min, T x_max) {
   T dx = {};
   T fx = static_cast<T>(x);
+  // Guard against NaN or Inf first, before computing the range, so a non-finite coordinate
+  // returns early without an unnecessary subtraction and can never reach the float->int cast
+  // (undefined behavior) below.
+  if (!std::isfinite(fx)) {
+    return x_min;
+  }
   T range = x_max - x_min;
-  // Guard against NaN, Inf, or non-positive range (e.g. dim==1 with align_corners=true)
-  // which would otherwise produce wild indices via division by zero or UB float->int casts.
-  if (!std::isfinite(fx) || !(range > T{0})) {
+  // Guard against a non-positive range (e.g. dim==1 with align_corners=true) which would
+  // otherwise produce wild indices via division by zero.
+  if (!(range > T{0})) {
     return x_min;
   }
   if (fx < x_min) {

--- a/onnxruntime/core/providers/cuda/tensor/grid_sample_impl.cu
+++ b/onnxruntime/core/providers/cuda/tensor/grid_sample_impl.cu
@@ -26,9 +26,17 @@ __device__ T GsReflect(T x, float x_min, float x_max) {
   float fx = static_cast<float>(x);
   float dx = {};
   float range = x_max - x_min;
+  // Guard against NaN, Inf, or a non-positive range (e.g. dim==1 with align_corners=true)
+  // which would otherwise produce wild indices via division by zero or an out-of-range
+  // float->int cast (undefined behavior).
+  if (!isfinite(fx) || !(range > 0.0f)) {
+    return static_cast<T>(x_min);
+  }
   if (fx < x_min) {
     dx = x_min - fx;
-    int n = static_cast<int>(dx / range);
+    // Use int64_t rather than int: for extreme (but finite) inputs, dx / range can exceed
+    // INT_MAX, making a float->int cast undefined behavior.
+    int64_t n = static_cast<int64_t>(dx / range);
     float r = dx - n * range;
     if (n % 2 == 0) {
       fx = x_min + r;
@@ -37,7 +45,7 @@ __device__ T GsReflect(T x, float x_min, float x_max) {
     }
   } else if (fx > x_max) {
     dx = fx - x_max;
-    int n = static_cast<int>(dx / range);
+    int64_t n = static_cast<int64_t>(dx / range);
     float r = dx - n * range;
     if (n % 2 == 0) {
       fx = x_max - r;
@@ -47,6 +55,15 @@ __device__ T GsReflect(T x, float x_min, float x_max) {
   }
   // else fallthrough
   return static_cast<T>(fx);
+}
+
+// Returns true when v is finite and its magnitude is small enough that converting it to
+// int64_t via floor / nearbyint is well-defined. 2^62 is far below INT64_MAX (~9.22e18)
+// and leaves ample margin for any realistic image dimension.
+template <typename T>
+__device__ inline bool IsSafeForInt64Conversion(T v) {
+  constexpr T kSafeBound = static_cast<T>(int64_t{1} << 62);
+  return isfinite(v) && v >= -kSafeBound && v <= kSafeBound;
 }
 
 template <typename T, bool Layout>
@@ -71,6 +88,11 @@ __device__ T PixelAtGrid(const T* input_data, int64_t bIdx, int64_t cIdx, int64_
   } else {  // Reflection
     x = (int64_t)GsReflect<T>(x, border[0], border[2]);
     y = (int64_t)GsReflect<T>(y, border[1], border[3]);
+    // Safety clamp: GsReflect is computed in floating point and cast back to int64_t.
+    // Extreme grid coordinates can overflow that cast, so clamp the resulting indices
+    // back into the image range before indexing.
+    x = max((int64_t)0, min((int64_t)W - 1, x));
+    y = max((int64_t)0, min((int64_t)H - 1, y));
     pixel = input_data[PixelOffset(x, y)];
   }
   return pixel;
@@ -168,6 +190,16 @@ __global__ void _GridSampleKernel(
     y_max = float(H_in) - 1.0f;
   }
   float border[] = {x_min, y_min, x_max, y_max};  // l-t-r-b
+
+  // Sanitize coordinates that are non-finite or whose magnitude is too large for a safe
+  // float->int64 conversion. Substituting the in-range lower border keeps the subsequent
+  // floor / nearbyint casts well-defined for every padding mode.
+  if (!IsSafeForInt64Conversion(grid_x_imgSpace)) {
+    grid_x_imgSpace = x_min;
+  }
+  if (!IsSafeForInt64Conversion(grid_y_imgSpace)) {
+    grid_y_imgSpace = y_min;
+  }
   if (grid_x_imgSpace < x_min || grid_x_imgSpace > x_max ||
       grid_y_imgSpace < y_min || grid_y_imgSpace > y_max) {  // out of bound
     if (padding_mode == 1) {                                 // border
@@ -181,10 +213,10 @@ __global__ void _GridSampleKernel(
   }
 
   if (mode == 0) {  // bilinear
-    int x1 = floor(grid_x_imgSpace);
-    int y1 = floor(grid_y_imgSpace);
-    int x2 = x1 + 1;
-    int y2 = y1 + 1;
+    int64_t x1 = static_cast<int64_t>(floor(grid_x_imgSpace));
+    int64_t y1 = static_cast<int64_t>(floor(grid_y_imgSpace));
+    int64_t x2 = x1 + 1;
+    int64_t y2 = y1 + 1;
     T w_lt = 0.0f;
     T w_rt = 0.0f;
     T w_lb = 0.0f;
@@ -209,8 +241,8 @@ __global__ void _GridSampleKernel(
     return;
   }
   if (mode == 1) {  // nearest
-    int x_n = grid_x_imgSpace;
-    int y_n = grid_y_imgSpace;
+    int64_t x_n = static_cast<int64_t>(grid_x_imgSpace);
+    int64_t y_n = static_cast<int64_t>(grid_y_imgSpace);
     output_data[outIdx] =
         PixelAtGrid<T, Layout>(input_data, BIdx, cIdx, y_n, x_n, padding_mode, N, C, H_in, W_in, border);
     return;
@@ -286,7 +318,12 @@ __device__ T PixelAtGrid3D(const T* input_data, int64_t bIdx, int64_t cIdx, int6
     z = (int64_t)GsReflect<T>(z, border[0], border[3]);
     y = (int64_t)GsReflect<T>(y, border[1], border[4]);
     x = (int64_t)GsReflect<T>(x, border[2], border[5]);
-
+    // Safety clamp: GsReflect is computed in floating point and cast back to int64_t.
+    // Extreme grid coordinates can overflow that cast, so clamp the resulting indices
+    // back into the volume range before indexing.
+    z = max((int64_t)0, min((int64_t)D - 1, z));
+    y = max((int64_t)0, min((int64_t)H - 1, y));
+    x = max((int64_t)0, min((int64_t)W - 1, x));
     pixel = input_data[PixelOffset3D(z, y, x)];
   }
   return pixel;
@@ -381,6 +418,19 @@ __global__ void _GridSampleKernel3D(
   }
 
   float border[] = {z_min, y_min, x_min, z_max, y_max, x_max};  // zmin,ymin,xmin,zmax,ymax,xmax
+
+  // Sanitize coordinates that are non-finite or whose magnitude is too large for a safe
+  // float->int64 conversion. Substituting the in-range lower border keeps the subsequent
+  // floor / nearbyint casts well-defined for every padding mode.
+  if (!IsSafeForInt64Conversion(grid_x_volSpace)) {
+    grid_x_volSpace = x_min;
+  }
+  if (!IsSafeForInt64Conversion(grid_y_volSpace)) {
+    grid_y_volSpace = y_min;
+  }
+  if (!IsSafeForInt64Conversion(grid_z_volSpace)) {
+    grid_z_volSpace = z_min;
+  }
   if (grid_z_volSpace < z_min || grid_z_volSpace > z_max ||
       grid_y_volSpace < y_min || grid_y_volSpace > y_max ||
       grid_x_volSpace < x_min || grid_x_volSpace > x_max) {  // out of bound
@@ -397,12 +447,12 @@ __global__ void _GridSampleKernel3D(
   }
 
   if (mode == 0) {  // bilinear
-    int z1 = floor(grid_z_volSpace);
-    int y1 = floor(grid_y_volSpace);
-    int x1 = floor(grid_x_volSpace);
-    int z2 = z1 + 1;
-    int y2 = y1 + 1;
-    int x2 = x1 + 1;
+    int64_t z1 = static_cast<int64_t>(floor(grid_z_volSpace));
+    int64_t y1 = static_cast<int64_t>(floor(grid_y_volSpace));
+    int64_t x1 = static_cast<int64_t>(floor(grid_x_volSpace));
+    int64_t z2 = z1 + 1;
+    int64_t y2 = y1 + 1;
+    int64_t x2 = x1 + 1;
 
     // Weights
     T w_lt_front = 0.0f;
@@ -450,9 +500,9 @@ __global__ void _GridSampleKernel3D(
     return;
   }
   if (mode == 1) {  // nearest
-    int x_n = grid_x_volSpace;
-    int y_n = grid_y_volSpace;
-    int z_n = grid_z_volSpace;
+    int64_t x_n = static_cast<int64_t>(grid_x_volSpace);
+    int64_t y_n = static_cast<int64_t>(grid_y_volSpace);
+    int64_t z_n = static_cast<int64_t>(grid_z_volSpace);
 
     output_data[outIdx] =
         PixelAtGrid3D<T, Layout>(input_data, BIdx, cIdx, z_n, y_n, x_n, padding_mode, N, C, D_in, H_in, W_in, border);

--- a/onnxruntime/core/providers/cuda/tensor/grid_sample_impl.cu
+++ b/onnxruntime/core/providers/cuda/tensor/grid_sample_impl.cu
@@ -25,11 +25,16 @@ template <typename T>
 __device__ T GsReflect(T x, float x_min, float x_max) {
   float fx = static_cast<float>(x);
   float dx = {};
+  // Guard against NaN or Inf first, before computing the range, so a non-finite coordinate
+  // returns early without an unnecessary subtraction and can never reach the float->int cast
+  // (undefined behavior) below.
+  if (!isfinite(fx)) {
+    return static_cast<T>(x_min);
+  }
   float range = x_max - x_min;
-  // Guard against NaN, Inf, or a non-positive range (e.g. dim==1 with align_corners=true)
-  // which would otherwise produce wild indices via division by zero or an out-of-range
-  // float->int cast (undefined behavior).
-  if (!isfinite(fx) || !(range > 0.0f)) {
+  // Guard against a non-positive range (e.g. dim==1 with align_corners=true) which would
+  // otherwise produce wild indices via division by zero.
+  if (!(range > 0.0f)) {
     return static_cast<T>(x_min);
   }
   if (fx < x_min) {

--- a/onnxruntime/test/providers/cpu/tensor/grid_sample_test_custom.cc
+++ b/onnxruntime/test/providers/cpu/tensor/grid_sample_test_custom.cc
@@ -63,6 +63,30 @@ void RunCpuOnly(T& test) {
   RunTests(test, GetCpuExecutionProviders());
 }
 
+// Execution providers targeted by the float->int64 cast hardening in the CUDA GridSample
+// kernels (onnxruntime/core/providers/cuda/tensor/grid_sample_impl.cu). CoreML and WebGPU
+// are intentionally excluded here: their integer-conversion semantics differ from the
+// CPU/CUDA "substitute the in-range border" behavior on NaN/Inf/extreme coordinates, so
+// their outputs for these adversarial inputs are not expected to match.
+std::vector<std::unique_ptr<IExecutionProvider>> GetCpuAndCudaExecutionProviders() {
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.emplace_back(DefaultCpuExecutionProvider());
+
+#ifdef USE_CUDA
+  execution_providers.emplace_back(DefaultCudaExecutionProvider());
+#ifdef ENABLE_CUDA_NHWC_OPS
+  execution_providers.push_back(DefaultCudaNHWCExecutionProvider());
+#endif
+#endif
+
+  return execution_providers;
+}
+
+template <typename T>
+void RunCpuAndCuda(T& test) {
+  RunTests(test, GetCpuAndCudaExecutionProviders());
+}
+
 }  // namespace
 
 template <typename T>
@@ -576,6 +600,195 @@ TYPED_TEST(GridSampleCustomTest, test_grid_sample_20_4D_nearest_reflection_mixed
   test.AddOutput<TypeParam>("Y", Y_shape,
                             {TypeParam(5.0f), TypeParam(1.0f), TypeParam(1.0f), TypeParam(1.0f)});
   RunCpuOnly(test);
+}
+
+// -----------------------------------------------------------------------------------------
+// CUDA hardening regression tests.
+//
+// These mirror the CPU-only cases above but also run on the CUDA execution provider (when
+// built) to cover the equivalent float->int64 cast hardening in
+// onnxruntime/core/providers/cuda/tensor/grid_sample_impl.cu. They are float-only because
+// the CUDA GridSample kernel is registered for float only, and they use constant-valued
+// images so the expected output is well-defined regardless of which in-range pixel each
+// (now clamped) index resolves to.
+// -----------------------------------------------------------------------------------------
+
+TEST(GridSampleCudaHardeningTest, nearest_reflection_extreme_and_nan_coords) {
+  // Exercises the CUDA _GridSampleKernel reflection path: GsReflect now guards NaN/Inf and
+  // uses int64_t for the wrap count (1e10 exceeds INT_MAX), and PixelAtGrid clamps the
+  // reflected index back into range.
+  OpTester test("GridSample", 20);
+  test.AddAttribute("mode", std::string("nearest"));
+  test.AddAttribute("padding_mode", std::string("reflection"));
+  test.AddAttribute("align_corners", int64_t{0});
+
+  std::initializer_list<int64_t> X_shape{1, 1, 2, 2};
+  std::initializer_list<float> X_data{1.0f, 1.0f, 1.0f, 1.0f};
+
+  std::initializer_list<int64_t> Grid_shape{1, 1, 2, 2};
+  std::initializer_list<float> Grid_data{
+      1.0e+10f, 1.0e+10f,
+      std::numeric_limits<float>::quiet_NaN(), std::numeric_limits<float>::quiet_NaN()};
+
+  std::initializer_list<int64_t> Y_shape{1, 1, 1, 2};
+
+  test.AddInput<float>("X", X_shape, X_data);
+  test.AddInput<float>("Grid", Grid_shape, Grid_data);
+  test.AddOutput<float>("Y", Y_shape, {1.0f, 1.0f});
+  RunCpuAndCuda(test);
+}
+
+TEST(GridSampleCudaHardeningTest, bilinear_reflection_infinity_coords) {
+  // CUDA bilinear reflection path: the GsReflect finite guard and coordinate sanitization
+  // keep the floor(...) cast well-defined for +/-Inf inputs.
+  OpTester test("GridSample", 20);
+  test.AddAttribute("mode", std::string("linear"));
+  test.AddAttribute("padding_mode", std::string("reflection"));
+  test.AddAttribute("align_corners", int64_t{0});
+
+  std::initializer_list<int64_t> X_shape{1, 1, 2, 2};
+  std::initializer_list<float> X_data{1.0f, 1.0f, 1.0f, 1.0f};
+
+  std::initializer_list<int64_t> Grid_shape{1, 1, 2, 2};
+  const float inf_val = std::numeric_limits<float>::infinity();
+  std::initializer_list<float> Grid_data{
+      inf_val, -inf_val,
+      -inf_val, inf_val};
+
+  std::initializer_list<int64_t> Y_shape{1, 1, 1, 2};
+
+  test.AddInput<float>("X", X_shape, X_data);
+  test.AddInput<float>("Grid", Grid_shape, Grid_data);
+  test.AddOutput<float>("Y", Y_shape, {1.0f, 1.0f});
+  RunCpuAndCuda(test);
+}
+
+TEST(GridSampleCudaHardeningTest, bilinear_zeros_nan_inf_extreme_coords) {
+  // Zeros padding: the CUDA kernel's IsSafeForInt64Conversion sanitization substitutes the
+  // lower border (-0.5) for NaN/Inf/extreme coordinates before the floor cast. Only the
+  // bottom-right neighbor (pixel(0, 0) = 1.0) is in bounds with weight 0.5 * 0.5 = 0.25.
+  OpTester test("GridSample", 20);
+  test.AddAttribute("mode", std::string("linear"));
+  test.AddAttribute("padding_mode", std::string("zeros"));
+  test.AddAttribute("align_corners", int64_t{0});
+
+  std::initializer_list<int64_t> X_shape{1, 1, 2, 2};
+  std::initializer_list<float> X_data{1.0f, 1.0f, 1.0f, 1.0f};
+
+  std::initializer_list<int64_t> Grid_shape{1, 1, 3, 2};
+  std::initializer_list<float> Grid_data{
+      std::numeric_limits<float>::quiet_NaN(), std::numeric_limits<float>::quiet_NaN(),
+      std::numeric_limits<float>::infinity(), -std::numeric_limits<float>::infinity(),
+      1.0e+20f, -1.0e+20f};
+
+  std::initializer_list<int64_t> Y_shape{1, 1, 1, 3};
+
+  test.AddInput<float>("X", X_shape, X_data);
+  test.AddInput<float>("Grid", Grid_shape, Grid_data);
+  test.AddOutput<float>("Y", Y_shape, {0.25f, 0.25f, 0.25f});
+  RunCpuAndCuda(test);
+}
+
+TEST(GridSampleCudaHardeningTest, cubic_reflection_extreme_coords) {
+  // CUDA bicubic path (4-D only): static_cast<int64_t>(std::floor(...)) - 1 is now
+  // protected by the coordinate sanitization. Constant-valued image => 1.0.
+  OpTester test("GridSample", 20);
+  test.AddAttribute("mode", std::string("cubic"));
+  test.AddAttribute("padding_mode", std::string("reflection"));
+  test.AddAttribute("align_corners", int64_t{0});
+
+  std::initializer_list<int64_t> X_shape{1, 1, 4, 4};
+  std::initializer_list<float> X_data{
+      1.0f, 1.0f, 1.0f, 1.0f,
+      1.0f, 1.0f, 1.0f, 1.0f,
+      1.0f, 1.0f, 1.0f, 1.0f,
+      1.0f, 1.0f, 1.0f, 1.0f};
+
+  std::initializer_list<int64_t> Grid_shape{1, 1, 1, 2};
+  std::initializer_list<float> Grid_data{1.0e+10f, -1.0e+10f};
+
+  std::initializer_list<int64_t> Y_shape{1, 1, 1, 1};
+
+  test.AddInput<float>("X", X_shape, X_data);
+  test.AddInput<float>("Grid", Grid_shape, Grid_data);
+  test.AddOutput<float>("Y", Y_shape, {1.0f});
+  RunCpuAndCuda(test);
+}
+
+TEST(GridSampleCudaHardeningTest, nearest_reflection_dim1_align_corners) {
+  // 1x1 image with align_corners=1 makes the reflection range zero (x_min == x_max), so
+  // GsReflect must not divide by zero. The single input pixel is the only valid sample.
+  OpTester test("GridSample", 20);
+  test.AddAttribute("mode", std::string("nearest"));
+  test.AddAttribute("padding_mode", std::string("reflection"));
+  test.AddAttribute("align_corners", int64_t{1});
+
+  std::initializer_list<int64_t> X_shape{1, 1, 1, 1};
+  std::initializer_list<float> X_data{7.0f};
+
+  std::initializer_list<int64_t> Grid_shape{1, 1, 2, 2};
+  std::initializer_list<float> Grid_data{
+      0.5f, 0.5f,
+      -0.5f, -0.5f};
+
+  std::initializer_list<int64_t> Y_shape{1, 1, 1, 2};
+
+  test.AddInput<float>("X", X_shape, X_data);
+  test.AddInput<float>("Grid", Grid_shape, Grid_data);
+  test.AddOutput<float>("Y", Y_shape, {7.0f, 7.0f});
+  RunCpuAndCuda(test);
+}
+
+TEST(GridSampleCudaHardeningTest, nearest_reflection_5D_extreme_coords) {
+  // CUDA _GridSampleKernel3D reflection path: PixelAtGrid3D received the same safety clamp
+  // as PixelAtGrid. Constant-valued volume => 1.0.
+  OpTester test("GridSample", 20);
+  test.AddAttribute("mode", std::string("nearest"));
+  test.AddAttribute("padding_mode", std::string("reflection"));
+  test.AddAttribute("align_corners", int64_t{0});
+
+  std::initializer_list<int64_t> X_shape{1, 1, 2, 2, 2};
+  std::initializer_list<float> X_data{
+      1.0f, 1.0f, 1.0f, 1.0f,
+      1.0f, 1.0f, 1.0f, 1.0f};
+
+  std::initializer_list<int64_t> Grid_shape{1, 1, 1, 2, 3};
+  std::initializer_list<float> Grid_data{
+      1.0e+10f, 1.0e+10f, 1.0e+10f,
+      -1.0e+10f, -1.0e+10f, -1.0e+10f};
+
+  std::initializer_list<int64_t> Y_shape{1, 1, 1, 1, 2};
+
+  test.AddInput<float>("X", X_shape, X_data);
+  test.AddInput<float>("Grid", Grid_shape, Grid_data);
+  test.AddOutput<float>("Y", Y_shape, {1.0f, 1.0f});
+  RunCpuAndCuda(test);
+}
+
+TEST(GridSampleCudaHardeningTest, bilinear_reflection_5D_extreme_coords) {
+  // CUDA 3D trilinear path: the x/y/z indices are computed via int64_t floor casts after
+  // sanitization. Constant-valued volume => 1.0.
+  OpTester test("GridSample", 20);
+  test.AddAttribute("mode", std::string("linear"));
+  test.AddAttribute("padding_mode", std::string("reflection"));
+  test.AddAttribute("align_corners", int64_t{0});
+
+  std::initializer_list<int64_t> X_shape{1, 1, 2, 2, 2};
+  std::initializer_list<float> X_data{
+      1.0f, 1.0f, 1.0f, 1.0f,
+      1.0f, 1.0f, 1.0f, 1.0f};
+
+  std::initializer_list<int64_t> Grid_shape{1, 1, 1, 2, 3};
+  std::initializer_list<float> Grid_data{
+      1.0e+20f, 1.0e+20f, 1.0e+20f,
+      -1.0e+20f, -1.0e+20f, -1.0e+20f};
+
+  std::initializer_list<int64_t> Y_shape{1, 1, 1, 1, 2};
+
+  test.AddInput<float>("X", X_shape, X_data);
+  test.AddInput<float>("Grid", Grid_shape, Grid_data);
+  test.AddOutput<float>("Y", Y_shape, {1.0f, 1.0f});
+  RunCpuAndCuda(test);
 }
 
 }  // namespace test

--- a/onnxruntime/test/providers/cpu/tensor/grid_sample_test_custom.cc
+++ b/onnxruntime/test/providers/cpu/tensor/grid_sample_test_custom.cc
@@ -663,6 +663,31 @@ TEST(GridSampleCudaHardeningTest, bilinear_reflection_infinity_coords) {
   RunCpuAndCuda(test);
 }
 
+TEST(GridSampleCudaHardeningTest, bilinear_border_nan_inf_extreme_coords) {
+  // CUDA bilinear border path: coordinate sanitization keeps the floor(...) cast
+  // well-defined before PixelAtGrid clamps border-padding samples into range.
+  OpTester test("GridSample", 20);
+  test.AddAttribute("mode", std::string("linear"));
+  test.AddAttribute("padding_mode", std::string("border"));
+  test.AddAttribute("align_corners", int64_t{0});
+
+  std::initializer_list<int64_t> X_shape{1, 1, 2, 2};
+  std::initializer_list<float> X_data{1.0f, 1.0f, 1.0f, 1.0f};
+
+  std::initializer_list<int64_t> Grid_shape{1, 1, 3, 2};
+  std::initializer_list<float> Grid_data{
+      std::numeric_limits<float>::quiet_NaN(), std::numeric_limits<float>::quiet_NaN(),
+      std::numeric_limits<float>::infinity(), -std::numeric_limits<float>::infinity(),
+      1.0e+20f, -1.0e+20f};
+
+  std::initializer_list<int64_t> Y_shape{1, 1, 1, 3};
+
+  test.AddInput<float>("X", X_shape, X_data);
+  test.AddInput<float>("Grid", Grid_shape, Grid_data);
+  test.AddOutput<float>("Y", Y_shape, {1.0f, 1.0f, 1.0f});
+  RunCpuAndCuda(test);
+}
+
 TEST(GridSampleCudaHardeningTest, bilinear_zeros_nan_inf_extreme_coords) {
   // Zeros padding: the CUDA kernel's IsSafeForInt64Conversion sanitization substitutes the
   // lower border (-0.5) for NaN/Inf/extreme coordinates before the floor cast. Only the


### PR DESCRIPTION
### Description

Guards the CUDA GridSample coordinate conversion paths for non-finite and extreme grid values, matching the existing CPU behavior for float grids. The CUDA path now sanitizes coordinates before integer conversion, uses wider intermediate indices where needed, and clamps reflected indices before sampling.

Per review feedback, `GsReflect` performs the `isfinite` check before computing the reflection range (`x_max - x_min`), so a non-finite coordinate returns early without the extra subtraction. The same reorder is applied to the CPU `GsReflect` (`core/providers/cpu/tensor/grid_sample.cc`) to keep the CPU and CUDA implementations in lockstep; behavior is unchanged.

### Tests

- `.\.venv\Scripts\python.exe tools\ci_build\build.py --config RelWithDebInfo --build --parallel --target onnxruntime_provider_test --build_dir build\Windows`
- `.\build\Windows\RelWithDebInfo\RelWithDebInfo\onnxruntime_provider_test.exe --gtest_filter=*Grid*`
  - 180 tests passed
- `.\.venv\Scripts\clang-format.exe` on touched C++ files

Note: the local build is CPU-only (`onnxruntime_USE_CUDA=OFF`), so CUDA compilation/runtime coverage will come from CUDA CI.

### Test coverage

The hardening is applied at shared choke-points: coordinate sanitization runs before interpolation-mode dispatch, and the `int64_t` index widening and reflected-index clamps are single shared branches. So one representative case per {mode, padding, dimensionality} exercises the hardened path rather than the full cross-product. Regression tests use constant-valued images, so the expected output is well-defined regardless of which (now sanitized/clamped) index each adversarial coordinate resolves to; this also sidesteps a pre-existing CPU-vs-CUDA reflected-index difference (double-reflect + round-half-to-even). The new `GridSampleCudaHardeningTest` cases run on CPU and CUDA (and CUDA-NHWC when `ENABLE_CUDA_NHWC_OPS` is enabled); the CUDA kernel is registered for `float` only, so `double` is exercised through the shared templated CPU path.
