### PR TITLE
[CUDA] Fix QMoE profiler cross-stream race and CUDA-graph-capture safety

### DIFF
--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemm_profiler.cc
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemm_profiler.cc
@@ -28,7 +28,8 @@ void MoeGemmProfiler::initBackend(CutlassMoeFCRunnerInterface* runner, MoeGemmId
                 need_weights_, parallelism_config_);
 }
 
-std::optional<MoeGemmProfiler::Config> MoeGemmProfiler::runProfiling(int maxM, MoeGemmId const& gemmId) {
+std::optional<MoeGemmProfiler::Config> MoeGemmProfiler::runProfiling(int maxM, MoeGemmId const& gemmId,
+                                                                     cudaStream_t timing_stream) {
   ORT_LLM_LOG_ENTRY();
   ORT_LLM_LOG_DEBUG(onnxruntime::MakeString("MoeGemmProfiler::runProfiling for M=", maxM, " ", gemmId));
 
@@ -59,10 +60,22 @@ std::optional<MoeGemmProfiler::Config> MoeGemmProfiler::runProfiling(int maxM, M
       workspace, [a = allocator_](void* p) { if (p) a->Free(p); });
   auto* workspace_ptr = static_cast<char*>(workspace);
 
-  cudaStream_t stream = nullptr;
-  CUDA_CALL_THROW(cudaStreamCreate(&stream));
+  // Run profiling on the caller-supplied stream (the ORT compute stream) when one is provided,
+  // so every profiler kernel is strictly ordered with the surrounding compute-stream work and
+  // shares its stream context with the temp allocator. Profiling on a private side stream instead
+  // races with the compute stream: the temp arena is stream-aware and, because the side-stream
+  // usage is invisible to it, can hand the same scratch block to a later compute-stream allocation
+  // (e.g. the real MoE workspace) while the profiler's grouped-GEMM kernels are still in flight.
+  // The resulting overlapping access corrupts the profiler's routing/GEMM buffers and surfaces as a
+  // sticky CUDA 700 (illegal memory access) at a downstream MoE kernel launch. Only create and
+  // destroy a private stream when the caller does not supply one (e.g. standalone profiling).
+  cudaStream_t stream = timing_stream;
   std::unique_ptr<CUstream_st, void (*)(cudaStream_t)> stream_guard(
-      stream, [](cudaStream_t s) { if (s) cudaStreamDestroy(s); });
+      nullptr, [](cudaStream_t s) { if (s) cudaStreamDestroy(s); });
+  if (stream == nullptr) {
+    CUDA_CALL_THROW(cudaStreamCreate(&stream));
+    stream_guard.reset(stream);
+  }
 
   cudaEvent_t start = nullptr;
   cudaEvent_t stop = nullptr;
@@ -129,7 +142,8 @@ std::optional<MoeGemmProfiler::Config> MoeGemmProfiler::runProfiling(int maxM, M
 }
 
 void MoeGemmProfiler::profileTactics(CutlassMoeFCRunnerInterface* runner,
-                                     weight_only::GemmDims const& dims, MoeGemmId const& gemmId) {
+                                     weight_only::GemmDims const& dims, MoeGemmId const& gemmId,
+                                     cudaStream_t timing_stream) {
   ORT_LLM_LOG_ENTRY();
 
   // Profile per M bucket: decode (small M) and prefill (large M) prefer different tile shapes,
@@ -144,7 +158,7 @@ void MoeGemmProfiler::profileTactics(CutlassMoeFCRunnerInterface* runner,
   initBackend(runner, gemmId);
 
   // Run profiling at the bucket's representative M.
-  auto result = runProfiling(bucket, gemmId);
+  auto result = runProfiling(bucket, gemmId, timing_stream);
 
   // Cache result for this bucket
   bucket_map[bucket] = result;

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemm_profiler.h
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemm_profiler.h
@@ -94,8 +94,12 @@ class MoeGemmProfiler {
   // Profiles (and caches) the best config for the M bucket that contains dims.maxM. The first
   // call for a new (GemmId, M-bucket) pair runs the profiler; subsequent calls return immediately.
   // The data/weight types are taken from gemmId, so no separate dtype argument is needed.
+  // When `timing_stream` is non-null the profiler runs on it (the ORT compute stream) so its
+  // kernels are strictly ordered with the surrounding compute-stream work; otherwise it creates a
+  // private stream. Must not be called while `timing_stream` is being captured into a CUDA graph.
   void profileTactics(CutlassMoeFCRunnerInterface* runner,
-                      weight_only::GemmDims const& dims, MoeGemmId const& gemmId);
+                      weight_only::GemmDims const& dims, MoeGemmId const& gemmId,
+                      cudaStream_t timing_stream = nullptr);
 
   // Get best config for a given M and GemmId. Selects the config profiled for the M bucket that
   // contains m, so small-M (decode) GEMMs use a decode-tuned tile instead of a prefill-tuned one.
@@ -111,7 +115,7 @@ class MoeGemmProfiler {
   void initBackend(CutlassMoeFCRunnerInterface* runner, MoeGemmId const& gemmId);
 
   // Run profiling for all tactics
-  std::optional<Config> runProfiling(int maxM, MoeGemmId const& gemmId);
+  std::optional<Config> runProfiling(int maxM, MoeGemmId const& gemmId, cudaStream_t timing_stream);
 
   AllocatorPtr allocator_;
   GemmProfilerBackend backend_;

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_kernels.cu
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_kernels.cu
@@ -3125,7 +3125,15 @@ void GemmProfilerBackend::runProfiler(int original_num_tokens, Config const& tac
 
   mSampleIndex = (mSampleIndex + 1) % NUM_ROUTING_SAMPLES;
 
-  auto workspaces = getProfilerWorkspaces(original_num_tokens, tactic.is_tma_warp_specialized);
+  // The workspace layout must match the one used to size the allocation (getWorkspaceSize) and to
+  // populate routing/quant/TMA inputs (prepareRouting/prepareQuantParams/prepareTmaWsInputs), all of
+  // which key the layout on `mSM >= 90`. Keying it here on the per-tactic `tactic.is_tma_warp_specialized`
+  // instead diverges on SM90 whenever a non-TMA (Ampere-fallback) tactic is profiled — e.g. the INT4
+  // mixed-input GEMM tiles. That divergence drops the tma_ws_input region and shifts every subsequent
+  // sub-buffer offset, so runProfiler would read expert_first_token_offset (and the GEMM inputs) from the
+  // wrong, random-filled locations, producing garbage per-expert token counts and an out-of-bounds read
+  // in the grouped GEMM (surfacing as a sticky CUDA 700 at a later launch). Use the same key everywhere.
+  auto workspaces = getProfilerWorkspaces(original_num_tokens, mSM >= 90);
 
 #define GET_WS_PTR_OFFSET(type, name, offset)                                                             \
   auto* name = (workspaces.at(#name).first                                                                \

--- a/onnxruntime/contrib_ops/cuda/moe/moe_quantization.cc
+++ b/onnxruntime/contrib_ops/cuda/moe/moe_quantization.cc
@@ -15,6 +15,7 @@
 #include "contrib_ops/cuda/moe/qmoe_kernels.h"
 #include "contrib_ops/cuda/llm/common/env_utils.h"
 #include "contrib_ops/cuda/llm/common/logger.h"
+#include "contrib_ops/cuda/llm/common/cuda_runtime_utils.h"
 #include "contrib_ops/cuda/llm/fpA_intB_gemm_adaptor.h"
 #include "contrib_ops/cuda/llm/fpA_intB_gemm_preprocessors.h"
 
@@ -460,6 +461,17 @@ Status QMoE::ComputeInternal(OpKernelContext* context) const {
   {
     std::lock_guard<std::mutex> profiler_lock(mGemmProfilerMutex);
 
+    // Profiling launches grouped-GEMM kernels, records/synchronizes CUDA events, and
+    // allocates/frees scratch from the temp allocator on the compute stream. All of these are
+    // illegal while that stream is being captured into a CUDA graph; performing them corrupts the
+    // capture and later surfaces as an illegal memory access (CUDA 700) reported at a downstream
+    // MoE kernel launch (e.g. moe_kernels.cu cudaFuncSetAttribute). During capture we therefore
+    // skip profiling and reuse a config cached from an earlier non-capturing run, falling back to
+    // the default tactic when nothing is cached.
+    cudaStream_t compute_stream = Stream(context);
+    const bool stream_is_capturing =
+        compute_stream != nullptr && onnxruntime::llm::common::isCapturing(compute_stream);
+
     // Use profiler with proper weight type for quantized weights
     if (onnxruntime::llm::common::getEnvForceDeterministicMOE()) {
       auto tactics = m_moe_runner->getTactics();
@@ -507,23 +519,38 @@ Status QMoE::ComputeInternal(OpKernelContext* context) const {
 
       // GEMM 1: N=fc1_out_size (doubled for gated), K=hidden_size
       MoeGemmId id1(static_cast<int>(fc1_out_size), static_cast<int>(moe_params.hidden_size), dtype, wtype, MoeGemmId::GemmType::Gemm1);
-      {
+      if (!stream_is_capturing) {
         // profileTactics caches per (GemmId, M bucket); calling it every forward lets decode
         // (small M) and prefill (large M) each profile and select their own best tile shape.
         GemmDims dims(static_cast<int64_t>(moe_params.num_rows), static_cast<int64_t>(moe_params.num_rows),
                       fc1_out_size, static_cast<int64_t>(moe_params.hidden_size));
-        mGemmProfiler.profileTactics(m_moe_runner.get(), dims, id1);
+        mGemmProfiler.profileTactics(m_moe_runner.get(), dims, id1, compute_stream);
       }
       config1 = mGemmProfiler.getBestConfig(static_cast<int>(moe_params.num_rows), id1);
 
       // GEMM 2
       MoeGemmId id2(static_cast<int>(moe_params.hidden_size), static_cast<int>(moe_params.inter_size), dtype, wtype, MoeGemmId::GemmType::Gemm2);
-      {
+      if (!stream_is_capturing) {
         GemmDims dims(static_cast<int64_t>(moe_params.num_rows), static_cast<int64_t>(moe_params.num_rows),
                       static_cast<int64_t>(moe_params.hidden_size), static_cast<int64_t>(moe_params.inter_size));
-        mGemmProfiler.profileTactics(m_moe_runner.get(), dims, id2);
+        mGemmProfiler.profileTactics(m_moe_runner.get(), dims, id2, compute_stream);
       }
       config2 = mGemmProfiler.getBestConfig(static_cast<int>(moe_params.num_rows), id2);
+
+      // Capture-safe fallback: if profiling was skipped (graph capture) and no tuned config was
+      // cached from a prior non-capturing run, use the runner's default tactic instead of leaving
+      // the config unset.
+      if (!config1 || !config2) {
+        auto tactics = m_moe_runner->getTactics();
+        if (!tactics.empty()) {
+          if (!config1) {
+            config1 = tactics[0];
+          }
+          if (!config2) {
+            config2 = tactics[0];
+          }
+        }
+      }
 
       m_moe_runner->setTactic(config1, config2);
     }


### PR DESCRIPTION
### Description

Three related fixes in the QMoE (`contrib_ops/cuda/moe`) weight-only GEMM profiling path that can cause a sticky `CUDA 700` (illegal memory access) surfacing at a later MoE kernel launch:

- **`moe_kernels.cu`** — `GemmProfilerBackend::runProfiler` now keys its workspace layout on `mSM >= 90`, the same key used by `getWorkspaceSize` / `prepareRouting` / `prepareQuantParams` / `prepareTmaWsInputs`. Previously it keyed on the per-tactic `is_tma_warp_specialized`, which diverges on SM90 when a non-TMA (Ampere-fallback) tactic is profiled (e.g. INT4 mixed-input GEMM tiles). That divergence drops the `tma_ws_input` region and shifts every subsequent sub-buffer offset, so the profiler reads `expert_first_token_offset` and the GEMM inputs from the wrong (random-filled) locations → OOB read in the grouped GEMM.

- **`moe_gemm_profiler`** — `profileTactics`/`runProfiling` accept an optional `timing_stream`; the profiler runs on the caller-supplied compute stream when provided, so its kernels are strictly ordered with surrounding compute-stream work and share the temp allocator's stream context. Profiling on a private side stream races with the stream-aware temp arena, which can hand the same scratch block to a later compute-stream allocation (e.g. the real MoE workspace) while the profiler's grouped-GEMM kernels are still in flight.

- **`moe_quantization.cc`** — Skip profiling while the compute stream is being captured into a CUDA graph (profiling launches kernels, records/synchronizes events, and allocates/frees scratch — all illegal during capture) and fall back to a config cached from an earlier non-capturing run, or the runner's default tactic.

### Motivation and Context

These are latent correctness/stability bugs in the QMoE tactic profiler that manifest on SM90 (H200) and under CUDA graph capture. They are independent of the fpA_intB MatMulNBits work and are split out as a standalone fix.

### Testing

- Built with `USE_FPA_INTB_GEMM=ON` (arch 80;90) on H200.
- `test_qmoe_cuda.py` passes (SwiGLU int4/int8, FP16/BF16, multiple batch/seq shapes).