### PR TITLE
[CUDA] Fix QMoE profiler cross-stream race and CUDA-graph-capture safety

### DIFF
--- a/onnxruntime/contrib_ops/cuda/llm/common/cuda_runtime_utils.h
+++ b/onnxruntime/contrib_ops/cuda/llm/common/cuda_runtime_utils.h
@@ -75,7 +75,10 @@ inline std::optional<bool> isCudaLaunchBlocking() {
 inline bool isCapturing(cudaStream_t stream) {
   cudaStreamCaptureStatus status;
   CUDA_CALL_THROW(cudaStreamIsCapturing(stream, &status));
-  return status == cudaStreamCaptureStatus::cudaStreamCaptureStatusActive;
+  // Treat any non-None status as capturing. In addition to the common `Active` state, CUDA can
+  // report `Invalidated` when a capture has been corrupted but not yet ended; capture rules still
+  // apply in that state, so profiling/event/sync operations remain illegal and must be skipped.
+  return status != cudaStreamCaptureStatus::cudaStreamCaptureStatusNone;
 }
 
 inline bool doCheckError(cudaStream_t stream) {

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemm_profiler.cc
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemm_profiler.cc
@@ -28,7 +28,8 @@ void MoeGemmProfiler::initBackend(CutlassMoeFCRunnerInterface* runner, MoeGemmId
                 need_weights_, parallelism_config_);
 }
 
-std::optional<MoeGemmProfiler::Config> MoeGemmProfiler::runProfiling(int maxM, MoeGemmId const& gemmId) {
+std::optional<MoeGemmProfiler::Config> MoeGemmProfiler::runProfiling(int maxM, MoeGemmId const& gemmId,
+                                                                     cudaStream_t timing_stream) {
   ORT_LLM_LOG_ENTRY();
   ORT_LLM_LOG_DEBUG(onnxruntime::MakeString("MoeGemmProfiler::runProfiling for M=", maxM, " ", gemmId));
 
@@ -59,10 +60,22 @@ std::optional<MoeGemmProfiler::Config> MoeGemmProfiler::runProfiling(int maxM, M
       workspace, [a = allocator_](void* p) { if (p) a->Free(p); });
   auto* workspace_ptr = static_cast<char*>(workspace);
 
-  cudaStream_t stream = nullptr;
-  CUDA_CALL_THROW(cudaStreamCreate(&stream));
+  // Run profiling on the caller-supplied stream (the ORT compute stream) when one is provided,
+  // so every profiler kernel is strictly ordered with the surrounding compute-stream work and
+  // shares its stream context with the temp allocator. Profiling on a private side stream instead
+  // races with the compute stream: the temp arena is stream-aware and, because the side-stream
+  // usage is invisible to it, can hand the same scratch block to a later compute-stream allocation
+  // (e.g. the real MoE workspace) while the profiler's grouped-GEMM kernels are still in flight.
+  // The resulting overlapping access corrupts the profiler's routing/GEMM buffers and surfaces as a
+  // sticky CUDA 700 (illegal memory access) at a downstream MoE kernel launch. Only create and
+  // destroy a private stream when the caller does not supply one (e.g. standalone profiling).
+  cudaStream_t stream = timing_stream;
   std::unique_ptr<CUstream_st, void (*)(cudaStream_t)> stream_guard(
-      stream, [](cudaStream_t s) { if (s) cudaStreamDestroy(s); });
+      nullptr, [](cudaStream_t s) { if (s) cudaStreamDestroy(s); });
+  if (stream == nullptr) {
+    CUDA_CALL_THROW(cudaStreamCreate(&stream));
+    stream_guard.reset(stream);
+  }
 
   cudaEvent_t start = nullptr;
   cudaEvent_t stop = nullptr;
@@ -129,7 +142,8 @@ std::optional<MoeGemmProfiler::Config> MoeGemmProfiler::runProfiling(int maxM, M
 }
 
 void MoeGemmProfiler::profileTactics(CutlassMoeFCRunnerInterface* runner,
-                                     weight_only::GemmDims const& dims, MoeGemmId const& gemmId) {
+                                     weight_only::GemmDims const& dims, MoeGemmId const& gemmId,
+                                     cudaStream_t timing_stream) {
   ORT_LLM_LOG_ENTRY();
 
   // Profile per M bucket: decode (small M) and prefill (large M) prefer different tile shapes,
@@ -144,7 +158,7 @@ void MoeGemmProfiler::profileTactics(CutlassMoeFCRunnerInterface* runner,
   initBackend(runner, gemmId);
 
   // Run profiling at the bucket's representative M.
-  auto result = runProfiling(bucket, gemmId);
+  auto result = runProfiling(bucket, gemmId, timing_stream);
 
   // Cache result for this bucket
   bucket_map[bucket] = result;

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemm_profiler.h
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemm_profiler.h
@@ -94,8 +94,12 @@ class MoeGemmProfiler {
   // Profiles (and caches) the best config for the M bucket that contains dims.maxM. The first
   // call for a new (GemmId, M-bucket) pair runs the profiler; subsequent calls return immediately.
   // The data/weight types are taken from gemmId, so no separate dtype argument is needed.
+  // When `timing_stream` is non-null the profiler runs on it (the ORT compute stream) so its
+  // kernels are strictly ordered with the surrounding compute-stream work; otherwise it creates a
+  // private stream. Must not be called while `timing_stream` is being captured into a CUDA graph.
   void profileTactics(CutlassMoeFCRunnerInterface* runner,
-                      weight_only::GemmDims const& dims, MoeGemmId const& gemmId);
+                      weight_only::GemmDims const& dims, MoeGemmId const& gemmId,
+                      cudaStream_t timing_stream = nullptr);
 
   // Get best config for a given M and GemmId. Selects the config profiled for the M bucket that
   // contains m, so small-M (decode) GEMMs use a decode-tuned tile instead of a prefill-tuned one.
@@ -111,7 +115,7 @@ class MoeGemmProfiler {
   void initBackend(CutlassMoeFCRunnerInterface* runner, MoeGemmId const& gemmId);
 
   // Run profiling for all tactics
-  std::optional<Config> runProfiling(int maxM, MoeGemmId const& gemmId);
+  std::optional<Config> runProfiling(int maxM, MoeGemmId const& gemmId, cudaStream_t timing_stream);
 
   AllocatorPtr allocator_;
   GemmProfilerBackend backend_;

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemm_profiler.h
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemm_profiler.h
@@ -94,12 +94,13 @@ class MoeGemmProfiler {
   // Profiles (and caches) the best config for the M bucket that contains dims.maxM. The first
   // call for a new (GemmId, M-bucket) pair runs the profiler; subsequent calls return immediately.
   // The data/weight types are taken from gemmId, so no separate dtype argument is needed.
-  // When `timing_stream` is non-null the profiler runs on it (the ORT compute stream) so its
-  // kernels are strictly ordered with the surrounding compute-stream work; otherwise it creates a
-  // private stream. Must not be called while `timing_stream` is being captured into a CUDA graph.
+  // `timing_stream` (the ORT compute stream) is required: the profiler runs its kernels on it so
+  // they are strictly ordered with the surrounding compute-stream work and share the same temp
+  // arena, avoiding the cross-stream scratch race that a private side stream would introduce.
+  // Must not be called while `timing_stream` is being captured into a CUDA graph.
   void profileTactics(CutlassMoeFCRunnerInterface* runner,
                       weight_only::GemmDims const& dims, MoeGemmId const& gemmId,
-                      cudaStream_t timing_stream = nullptr);
+                      cudaStream_t timing_stream);
 
   // Get best config for a given M and GemmId. Selects the config profiled for the M bucket that
   // contains m, so small-M (decode) GEMMs use a decode-tuned tile instead of a prefill-tuned one.

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_kernels.cu
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_kernels.cu
@@ -3125,7 +3125,15 @@ void GemmProfilerBackend::runProfiler(int original_num_tokens, Config const& tac
 
   mSampleIndex = (mSampleIndex + 1) % NUM_ROUTING_SAMPLES;
 
-  auto workspaces = getProfilerWorkspaces(original_num_tokens, tactic.is_tma_warp_specialized);
+  // The workspace layout must match the one used to size the allocation (getWorkspaceSize) and to
+  // populate routing/quant/TMA inputs (prepareRouting/prepareQuantParams/prepareTmaWsInputs), all of
+  // which key the layout on `mSM >= 90`. Keying it here on the per-tactic `tactic.is_tma_warp_specialized`
+  // instead diverges on SM90 whenever a non-TMA (Ampere-fallback) tactic is profiled — e.g. the INT4
+  // mixed-input GEMM tiles. That divergence drops the tma_ws_input region and shifts every subsequent
+  // sub-buffer offset, so runProfiler would read expert_first_token_offset (and the GEMM inputs) from the
+  // wrong, random-filled locations, producing garbage per-expert token counts and an out-of-bounds read
+  // in the grouped GEMM (surfacing as a sticky CUDA 700 at a later launch). Use the same key everywhere.
+  auto workspaces = getProfilerWorkspaces(original_num_tokens, mSM >= 90);
 
 #define GET_WS_PTR_OFFSET(type, name, offset)                                                             \
   auto* name = (workspaces.at(#name).first                                                                \

--- a/onnxruntime/contrib_ops/cuda/moe/moe.cc
+++ b/onnxruntime/contrib_ops/cuda/moe/moe.cc
@@ -152,8 +152,7 @@ Status MoE<T>::ComputeInternal(OpKernelContext* context) const {
     // illegal while that stream is being captured into a CUDA graph; performing them corrupts the
     // capture. During capture we therefore skip profiling and reuse a config cached from an earlier
     // non-capturing run, falling back to the default tactic when nothing is cached.
-    const bool stream_is_capturing =
-        stream != nullptr && onnxruntime::llm::common::isCapturing(stream);
+    const bool stream_is_capturing = onnxruntime::llm::common::isCapturing(stream);
 
     onnxruntime::llm::nvinfer::DataType dtype = onnxruntime::llm::nvinfer::DataType::kFLOAT;
     if constexpr (std::is_same_v<CudaT, half>) {

--- a/onnxruntime/contrib_ops/cuda/moe/moe.cc
+++ b/onnxruntime/contrib_ops/cuda/moe/moe.cc
@@ -8,6 +8,7 @@
 #include "contrib_ops/cuda/moe/qmoe_kernels.h"
 #include "contrib_ops/cuda/llm/moe_gemm/moe_kernels.h"
 #include "contrib_ops/cuda/llm/common/env_utils.h"
+#include "contrib_ops/cuda/llm/common/cuda_runtime_utils.h"
 
 #include <mutex>
 
@@ -146,6 +147,14 @@ Status MoE<T>::ComputeInternal(OpKernelContext* context) const {
                                     static_cast<int64_t>(this->block_size_), kernel_activation_type,
                                     false, true, parallelism_config, sm);
 
+    // Profiling launches grouped-GEMM kernels, records/synchronizes CUDA events, and
+    // allocates/frees scratch from the temp allocator on the compute stream. All of these are
+    // illegal while that stream is being captured into a CUDA graph; performing them corrupts the
+    // capture. During capture we therefore skip profiling and reuse a config cached from an earlier
+    // non-capturing run, falling back to the default tactic when nothing is cached.
+    const bool stream_is_capturing =
+        stream != nullptr && onnxruntime::llm::common::isCapturing(stream);
+
     onnxruntime::llm::nvinfer::DataType dtype = onnxruntime::llm::nvinfer::DataType::kFLOAT;
     if constexpr (std::is_same_v<CudaT, half>) {
       dtype = onnxruntime::llm::nvinfer::DataType::kHALF;
@@ -158,23 +167,38 @@ Status MoE<T>::ComputeInternal(OpKernelContext* context) const {
 
     // GEMM 1
     MoeGemmId id1(static_cast<int>(moe_params.inter_size), static_cast<int>(moe_params.hidden_size), dtype, MoeGemmId::GemmType::Gemm1);
-    {
+    if (!stream_is_capturing) {
       // profileTactics caches per (GemmId, M bucket); calling it every forward lets decode
       // (small M) and prefill (large M) each profile and select their own best tile shape.
       GemmDims dims(static_cast<int64_t>(moe_params.num_rows), static_cast<int64_t>(moe_params.num_rows),
                     static_cast<int64_t>(moe_params.inter_size), static_cast<int64_t>(moe_params.hidden_size));
-      mGemmProfiler.profileTactics(&moe_runner, dims, id1);
+      mGemmProfiler.profileTactics(&moe_runner, dims, id1, stream);
     }
     auto config1 = mGemmProfiler.getBestConfig(static_cast<int>(moe_params.num_rows), id1);
 
     // GEMM 2
     MoeGemmId id2(static_cast<int>(moe_params.hidden_size), static_cast<int>(moe_params.inter_size), dtype, MoeGemmId::GemmType::Gemm2);
-    {
+    if (!stream_is_capturing) {
       GemmDims dims(static_cast<int64_t>(moe_params.num_rows), static_cast<int64_t>(moe_params.num_rows),
                     static_cast<int64_t>(moe_params.hidden_size), static_cast<int64_t>(moe_params.inter_size));
-      mGemmProfiler.profileTactics(&moe_runner, dims, id2);
+      mGemmProfiler.profileTactics(&moe_runner, dims, id2, stream);
     }
     auto config2 = mGemmProfiler.getBestConfig(static_cast<int>(moe_params.num_rows), id2);
+
+    // Capture-safe fallback: if profiling was skipped (graph capture) and no tuned config was
+    // cached from a prior non-capturing run, use the runner's default tactic instead of leaving
+    // the config unset.
+    if (!config1 || !config2) {
+      auto tactics = moe_runner.getTactics();
+      if (!tactics.empty()) {
+        if (!config1) {
+          config1 = tactics[0];
+        }
+        if (!config2) {
+          config2 = tactics[0];
+        }
+      }
+    }
 
     moe_runner.setTactic(config1, config2);
   }

--- a/onnxruntime/contrib_ops/cuda/moe/moe_quantization.cc
+++ b/onnxruntime/contrib_ops/cuda/moe/moe_quantization.cc
@@ -15,6 +15,7 @@
 #include "contrib_ops/cuda/moe/qmoe_kernels.h"
 #include "contrib_ops/cuda/llm/common/env_utils.h"
 #include "contrib_ops/cuda/llm/common/logger.h"
+#include "contrib_ops/cuda/llm/common/cuda_runtime_utils.h"
 #include "contrib_ops/cuda/llm/fpA_intB_gemm_adaptor.h"
 #include "contrib_ops/cuda/llm/fpA_intB_gemm_preprocessors.h"
 
@@ -460,6 +461,17 @@ Status QMoE::ComputeInternal(OpKernelContext* context) const {
   {
     std::lock_guard<std::mutex> profiler_lock(mGemmProfilerMutex);
 
+    // Profiling launches grouped-GEMM kernels, records/synchronizes CUDA events, and
+    // allocates/frees scratch from the temp allocator on the compute stream. All of these are
+    // illegal while that stream is being captured into a CUDA graph; performing them corrupts the
+    // capture and later surfaces as an illegal memory access (CUDA 700) reported at a downstream
+    // MoE kernel launch (e.g. moe_kernels.cu cudaFuncSetAttribute). During capture we therefore
+    // skip profiling and reuse a config cached from an earlier non-capturing run, falling back to
+    // the default tactic when nothing is cached.
+    cudaStream_t compute_stream = Stream(context);
+    const bool stream_is_capturing =
+        compute_stream != nullptr && onnxruntime::llm::common::isCapturing(compute_stream);
+
     // Use profiler with proper weight type for quantized weights
     if (onnxruntime::llm::common::getEnvForceDeterministicMOE()) {
       auto tactics = m_moe_runner->getTactics();
@@ -507,23 +519,38 @@ Status QMoE::ComputeInternal(OpKernelContext* context) const {
 
       // GEMM 1: N=fc1_out_size (doubled for gated), K=hidden_size
       MoeGemmId id1(static_cast<int>(fc1_out_size), static_cast<int>(moe_params.hidden_size), dtype, wtype, MoeGemmId::GemmType::Gemm1);
-      {
+      if (!stream_is_capturing) {
         // profileTactics caches per (GemmId, M bucket); calling it every forward lets decode
         // (small M) and prefill (large M) each profile and select their own best tile shape.
         GemmDims dims(static_cast<int64_t>(moe_params.num_rows), static_cast<int64_t>(moe_params.num_rows),
                       fc1_out_size, static_cast<int64_t>(moe_params.hidden_size));
-        mGemmProfiler.profileTactics(m_moe_runner.get(), dims, id1);
+        mGemmProfiler.profileTactics(m_moe_runner.get(), dims, id1, compute_stream);
       }
       config1 = mGemmProfiler.getBestConfig(static_cast<int>(moe_params.num_rows), id1);
 
       // GEMM 2
       MoeGemmId id2(static_cast<int>(moe_params.hidden_size), static_cast<int>(moe_params.inter_size), dtype, wtype, MoeGemmId::GemmType::Gemm2);
-      {
+      if (!stream_is_capturing) {
         GemmDims dims(static_cast<int64_t>(moe_params.num_rows), static_cast<int64_t>(moe_params.num_rows),
                       static_cast<int64_t>(moe_params.hidden_size), static_cast<int64_t>(moe_params.inter_size));
-        mGemmProfiler.profileTactics(m_moe_runner.get(), dims, id2);
+        mGemmProfiler.profileTactics(m_moe_runner.get(), dims, id2, compute_stream);
       }
       config2 = mGemmProfiler.getBestConfig(static_cast<int>(moe_params.num_rows), id2);
+
+      // Capture-safe fallback: if profiling was skipped (graph capture) and no tuned config was
+      // cached from a prior non-capturing run, use the runner's default tactic instead of leaving
+      // the config unset.
+      if (!config1 || !config2) {
+        auto tactics = m_moe_runner->getTactics();
+        if (!tactics.empty()) {
+          if (!config1) {
+            config1 = tactics[0];
+          }
+          if (!config2) {
+            config2 = tactics[0];
+          }
+        }
+      }
 
       m_moe_runner->setTactic(config1, config2);
     }

--- a/onnxruntime/contrib_ops/cuda/moe/moe_quantization.cc
+++ b/onnxruntime/contrib_ops/cuda/moe/moe_quantization.cc
@@ -469,8 +469,7 @@ Status QMoE::ComputeInternal(OpKernelContext* context) const {
     // skip profiling and reuse a config cached from an earlier non-capturing run, falling back to
     // the default tactic when nothing is cached.
     cudaStream_t compute_stream = Stream(context);
-    const bool stream_is_capturing =
-        compute_stream != nullptr && onnxruntime::llm::common::isCapturing(compute_stream);
+    const bool stream_is_capturing = onnxruntime::llm::common::isCapturing(compute_stream);
 
     // Use profiler with proper weight type for quantized weights
     if (onnxruntime::llm::common::getEnvForceDeterministicMOE()) {

--- a/onnxruntime/test/python/transformers/test_qmoe_cuda.py
+++ b/onnxruntime/test/python/transformers/test_qmoe_cuda.py
@@ -2934,5 +2934,162 @@ class TestQMoEIntPrePackSmoke(unittest.TestCase):
         self._run_one(hidden_size=128, inter_size=64, num_experts=8, top_k=2, swiglu_fusion=1, batch_size=16)
 
 
+class TestQMoECudaGraph(unittest.TestCase):
+    """Regression test for QMoE under CUDA graph capture/replay.
+
+    Before the profiler capture-safety fix, running an fp16 int4 QMoE node inside
+    a CUDA-graph-capturing session launched grouped-GEMM profiling kernels and
+    temp-allocator traffic on the compute stream *while that stream was being
+    captured*. That corrupted the capture and surfaced as a sticky CUDA 700
+    (illegal memory access) at a downstream MoE kernel launch on replay. The fix
+    detects an in-progress capture, skips profiling, and falls back to a cached /
+    default tactic, so capture + replay must now complete cleanly and produce
+    finite, deterministic output.
+    """
+
+    def _build_int4_qmoe_model(self, *, hidden_size, inter_size, num_experts, top_k, batch_size):
+        onnx_dtype = TensorProto.FLOAT16
+        bits = 4
+        pack = 8 // bits
+        fc1_n = 2 * inter_size  # gate + up packed along N for SwiGLU
+        fc1_k = hidden_size
+        fc2_n = hidden_size
+        fc2_k = inter_size
+
+        fc1_weights = numpy.zeros((num_experts, fc1_k, fc1_n // pack), dtype=numpy.uint8)
+        fc2_weights = numpy.zeros((num_experts, fc2_k, fc2_n // pack), dtype=numpy.uint8)
+        fc1_scales = numpy.zeros((num_experts, fc1_n), dtype=numpy.float16)
+        fc2_scales = numpy.zeros((num_experts, fc2_n), dtype=numpy.float16)
+
+        cuda_quantizer = CudaQuantizer()
+        for e in range(num_experts):
+            w1 = (torch.randn(fc1_n, fc1_k) * 0.05).numpy().astype(numpy.float16)
+            w2 = (torch.randn(fc2_n, fc2_k) * 0.05).numpy().astype(numpy.float16)
+            q1, s1 = cuda_quantizer.qmoe_per_channel_quantize(torch.from_numpy(w1), bits, True)
+            q2, s2 = cuda_quantizer.qmoe_per_channel_quantize(torch.from_numpy(w2), bits, True)
+            fc1_weights[e] = q1.numpy()
+            fc2_weights[e] = q2.numpy()
+            fc1_scales[e] = s1.numpy().astype(numpy.float16)
+            fc2_scales[e] = s2.numpy().astype(numpy.float16)
+
+        qmoe = helper.make_node(
+            "QMoE",
+            inputs=["input", "router_probs", "fc1_W", "fc1_S", "", "fc2_W", "fc2_S", ""],
+            outputs=["output"],
+            name="qmoe",
+            domain="com.microsoft",
+            k=top_k,
+            normalize_routing_weights=1,
+            activation_type="swiglu",
+            swiglu_fusion=1,
+            expert_weight_bits=bits,
+            quant_type="int",
+            # weights_prepacked omitted (default): INT weights are already in the
+            # CUDA EP's offline-prepacked fpA_intB layout emitted by CudaQuantizer.
+        )
+        # Static shapes are required for CUDA graph capture.
+        graph = helper.make_graph(
+            nodes=[qmoe],
+            name="qmoe_cuda_graph",
+            inputs=[
+                helper.make_tensor_value_info("input", onnx_dtype, [batch_size, hidden_size]),
+                helper.make_tensor_value_info("router_probs", onnx_dtype, [batch_size, num_experts]),
+            ],
+            outputs=[helper.make_tensor_value_info("output", onnx_dtype, [batch_size, hidden_size])],
+            initializer=[
+                helper.make_tensor(
+                    "fc1_W", TensorProto.UINT8, list(fc1_weights.shape), fc1_weights.tobytes(), raw=True
+                ),
+                helper.make_tensor(
+                    "fc2_W", TensorProto.UINT8, list(fc2_weights.shape), fc2_weights.tobytes(), raw=True
+                ),
+                helper.make_tensor("fc1_S", onnx_dtype, [num_experts, fc1_n], fc1_scales.flatten().tolist()),
+                helper.make_tensor("fc2_S", onnx_dtype, [num_experts, fc2_n], fc2_scales.flatten().tolist()),
+            ],
+        )
+        model = helper.make_model(
+            graph, opset_imports=[helper.make_opsetid("", 20), helper.make_opsetid("com.microsoft", 1)]
+        )
+        model.ir_version = 10
+        return model.SerializeToString()
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA is required for the QMoE CUDA graph regression test")
+    def test_int4_fp16_qmoe_cuda_graph(self):
+        hidden_size = 64
+        inter_size = 128
+        num_experts = 4
+        top_k = 2
+        batch_size = 8
+
+        torch.manual_seed(123)
+        numpy.random.seed(123)
+        model_bytes = self._build_int4_qmoe_model(
+            hidden_size=hidden_size,
+            inter_size=inter_size,
+            num_experts=num_experts,
+            top_k=top_k,
+            batch_size=batch_size,
+        )
+
+        sess_options = onnxruntime.SessionOptions()
+        sess_options.graph_optimization_level = onnxruntime.GraphOptimizationLevel.ORT_DISABLE_ALL
+        try:
+            sess = onnxruntime.InferenceSession(
+                model_bytes,
+                sess_options,
+                providers=[("CUDAExecutionProvider", {"enable_cuda_graph": True})],
+            )
+        except Exception as e:
+            self.skipTest(f"Could not create a CUDA-graph-enabled CUDA EP session: {e}")
+
+        x = numpy.random.randn(batch_size, hidden_size).astype(numpy.float16)
+        router = numpy.random.randn(batch_size, num_experts).astype(numpy.float16)
+
+        # CUDA graph capture requires all inputs/outputs to live in fixed GPU buffers.
+        x_ort = onnxruntime.OrtValue.ortvalue_from_numpy(x, "cuda", 0)
+        router_ort = onnxruntime.OrtValue.ortvalue_from_numpy(router, "cuda", 0)
+        y_ort = onnxruntime.OrtValue.ortvalue_from_shape_and_type([batch_size, hidden_size], numpy.float16, "cuda", 0)
+
+        io_binding = sess.io_binding()
+        io_binding.bind_ortvalue_input("input", x_ort)
+        io_binding.bind_ortvalue_input("router_probs", router_ort)
+        io_binding.bind_ortvalue_output("output", y_ort)
+
+        ro = onnxruntime.RunOptions()
+
+        # First run performs the allocation and captures the CUDA graph. Before the
+        # fix, QMoE profiling launched kernels / touched the temp allocator on the
+        # captured compute stream here and triggered CUDA 700 (illegal memory access).
+        io_binding.synchronize_inputs()
+        sess.run_with_iobinding(io_binding, ro)
+        io_binding.synchronize_outputs()
+        out_capture = y_ort.numpy().copy()
+
+        # Replay the captured graph with the same inputs.
+        io_binding.synchronize_inputs()
+        sess.run_with_iobinding(io_binding, ro)
+        io_binding.synchronize_outputs()
+        out_replay = y_ort.numpy().copy()
+
+        for tag, out in (("capture", out_capture), ("replay", out_replay)):
+            self.assertEqual(out.shape, (batch_size, hidden_size))
+            self.assertEqual(out.dtype, numpy.float16)
+            self.assertFalse(numpy.isnan(out).any(), f"QMoE CUDA graph {tag} output has NaN")
+            self.assertFalse(numpy.isinf(out).any(), f"QMoE CUDA graph {tag} output has Inf")
+
+        # Replaying with identical inputs must reproduce the captured output exactly.
+        numpy.testing.assert_array_equal(out_replay, out_capture)
+
+        # Update the input in place and replay again to exercise the graph past capture.
+        x2 = numpy.random.randn(batch_size, hidden_size).astype(numpy.float16)
+        x_ort.update_inplace(x2)
+        io_binding.synchronize_inputs()
+        sess.run_with_iobinding(io_binding, ro)
+        io_binding.synchronize_outputs()
+        out_updated = y_ort.numpy().copy()
+        self.assertFalse(numpy.isnan(out_updated).any(), "QMoE CUDA graph updated-input output has NaN")
+        self.assertFalse(numpy.isinf(out_updated).any(), "QMoE CUDA graph updated-input output has Inf")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/onnxruntime/test/python/transformers/test_qmoe_cuda.py
+++ b/onnxruntime/test/python/transformers/test_qmoe_cuda.py
@@ -3033,6 +3033,7 @@ class TestQMoECudaGraph(unittest.TestCase):
 
         sess_options = onnxruntime.SessionOptions()
         sess_options.graph_optimization_level = onnxruntime.GraphOptimizationLevel.ORT_DISABLE_ALL
+        sess = None
         try:
             sess = onnxruntime.InferenceSession(
                 model_bytes,
@@ -3041,6 +3042,7 @@ class TestQMoECudaGraph(unittest.TestCase):
             )
         except Exception as e:
             self.skipTest(f"Could not create a CUDA-graph-enabled CUDA EP session: {e}")
+            return
 
         x = numpy.random.randn(batch_size, hidden_size).astype(numpy.float16)
         router = numpy.random.randn(batch_size, num_experts).astype(numpy.float16)


### PR DESCRIPTION
### Description

Three related fixes in the QMoE (`contrib_ops/cuda/moe`) weight-only GEMM profiling path that can cause a sticky `CUDA 700` (illegal memory access) surfacing at a later MoE kernel launch:

- **`moe_kernels.cu`** — `GemmProfilerBackend::runProfiler` now keys its workspace layout on `mSM >= 90`, the same key used by `getWorkspaceSize` / `prepareRouting` / `prepareQuantParams` / `prepareTmaWsInputs`. Previously it keyed on the per-tactic `is_tma_warp_specialized`, which diverges on SM90 when a non-TMA (Ampere-fallback) tactic is profiled (e.g. INT4 mixed-input GEMM tiles). That divergence drops the `tma_ws_input` region and shifts every subsequent sub-buffer offset, so the profiler reads `expert_first_token_offset` and the GEMM inputs from the wrong (random-filled) locations → OOB read in the grouped GEMM.

- **`moe_gemm_profiler`** — `profileTactics`/`runProfiling` accept an optional `timing_stream`; the profiler runs on the caller-supplied compute stream when provided, so its kernels are strictly ordered with surrounding compute-stream work and share the temp allocator's stream context. Profiling on a private side stream races with the stream-aware temp arena, which can hand the same scratch block to a later compute-stream allocation (e.g. the real MoE workspace) while the profiler's grouped-GEMM kernels are still in flight.

- **`moe_quantization.cc`** — Skip profiling while the compute stream is being captured into a CUDA graph (profiling launches kernels, records/synchronizes events, and allocates/frees scratch — all illegal during capture) and fall back to a config cached from an earlier non-capturing run, or the runner's default tactic.

### Motivation and Context

These are latent correctness/stability bugs in the QMoE tactic profiler that manifest on SM90 (H200) and under CUDA graph capture. They are independent of the fpA_intB MatMulNBits work and are split out as a standalone fix.

### Testing

- Built with `USE_FPA_INTB_GEMM=ON` (arch 80;90) on H200.
- `test_qmoe_cuda.py` passes (SwiGLU int4/int8, FP16/BF16, multiple batch/seq shapes).