### PR TITLE
[CUDA] Enable native SM90, block_size=32, and fused bias for fpA_intB MatMulNBits

### DIFF
--- a/docs/ContribOperators.md
+++ b/docs/ContribOperators.md
@@ -3159,7 +3159,7 @@ This version of the operator has been available since version 1 of the 'com.micr
 <dt><tt>block_size</tt> : int (required)</dt>
 <dd>Size of each quantization block along the K (input feature) dimension. Must be a power of two and ≥ 16 (e.g., 16, 32, 64, 128).</dd>
 <dt><tt>weight_prepacked</tt> : int</dt>
-<dd>If set, input B is already prepacked into an EP-specific layout and the EP skips runtime weight prepacking. 0 (default): not prepacked. 1: prepacked in the CUDA SM80 fpA_intB layout. 2: reserved for a future SM90 layout (currently rejected at kernel construction).</dd>
+<dd>If set, input B is already prepacked into an EP-specific layout and the EP skips runtime weight prepacking. 0 (default): not prepacked. 1: prepacked in the CUDA SM80 fpA_intB layout. 2: prepacked in the CUDA SM90 (Hopper) fpA_intB layout, consumed by the native SM90 kernel (requires a compute capability 9.0 device and block_size in {64, 128}).</dd>
 </dl>
 
 #### Inputs (3 - 6)

--- a/docs/contrib_ops/cuda/matmul_nbits.md
+++ b/docs/contrib_ops/cuda/matmul_nbits.md
@@ -44,7 +44,7 @@ Source files:
 | `bits` | Quantization bit width: `4` or `8`. |
 | `block_size` | Quantization group size along `K` (16 / 32 / 64 / 128). One scale (and optional zero point) per group. |
 | `accuracy_level` | Minimum accuracy level for internal handling of `A`; default `0` means unset. |
-| `weight_prepacked` | CUDA fpA_intB weight-layout selector. `0` (default): `B` is in standard MatMulNBits layout and may be runtime-prepacked. `1`: `B` is already prepacked in the CUDA SM80 fpA_intB layout. `2`: reserved SM90 layout; currently rejected. |
+| `weight_prepacked` | CUDA fpA_intB weight-layout selector. `0` (default): `B` is in standard MatMulNBits layout and may be runtime-prepacked. `1`: `B` is already prepacked in the CUDA SM80 fpA_intB layout. `2`: `B` is prepacked in the CUDA SM90 (Hopper) fpA_intB layout, consumed by the native SM90 kernel (requires an SM90 device and `block_size` in {64, 128}). |
 
 | Input | Index | Notes |
 |-------|-------|-------|
@@ -95,13 +95,18 @@ prepacked_flat = _pybind.pack_weights_for_cuda_mixed_gemm(
 prepacked_b = np.asarray(prepacked_flat, dtype=np.int8).view(np.uint8).reshape(q_weight.shape)
 ```
 
-The final argument is the target packing architecture. For MatMulNBits v1, use
-`80`: both runtime preprocessing and offline preprocessing force the SM80
-layout. On SM90 devices, the supported mixed FP16/BF16 activation + int4/int8
-weight path routes to the SM80 CUTLASS kernel/layout for this operator.
+The final argument is the target packing architecture. Use `80` for the SM80
+layout (consumed by the SM80 CUTLASS kernel, including on newer GPUs via the
+compatibility path) and set `weight_prepacked=1` on the node. Use `90` for the
+native SM90 (Hopper) layout and set `weight_prepacked=2` on the node.
 
-`weight_prepacked=2` is reserved for a future SM90/Hopper-specific layout and is
-currently rejected during kernel construction.
+`weight_prepacked=2` selects the native SM90 (Hopper TMA/WGMMA) mixed-GEMM
+kernel and its Hopper weight layout. It requires a compute capability 9.0 device
+and `block_size` in `{64, 128}` (the SM90 kernel needs `group_size` to be a
+multiple of the 64-element Hopper K tile, so `block_size=32` is SM80-only). On
+SM90 devices, runtime-prepacked (`weight_prepacked=0`) and SM80-prepacked
+(`weight_prepacked=1`) weights continue to route to the SM80 CUTLASS
+kernel/layout.
 
 ---
 
@@ -112,7 +117,7 @@ falls through to progressively more general ones:
 
 ```mermaid
 flowchart TD
-  A[ComputeInternal] --> F{has_fpA_intB_gemm_?<br/>FP16/BF16, ORT-prepackable weights,<br/>block 64/128, sm>=75}
+  A[ComputeInternal] --> F{has_fpA_intB_gemm_?<br/>FP16/BF16, ORT-prepackable weights,<br/>block 32/64/128, sm>=75}
   F -- yes --> FP[fpA_intB CUDA GEMV<br/>or CUTLASS grouped GEMM] --> R[return]
   F -- no --> G{reorder_idx == null<br/>and zero_points not typed-T?}
   G -- no --> DQ
@@ -236,10 +241,14 @@ and enabled via `ORT_FPA_INTB_GEMM`, FP16/BF16 MatMulNBits can use the
 TensorRT-LLM-derived CUTLASS weight-only kernels. The constructor sets
 `has_fpA_intB_gemm_` only when:
 
-- dtype is FP16 or BF16, `bits ∈ {4, 8}`, `block_size ∈ {64, 128}`,
-- no `g_idx`, no `bias`, `N % (bits==8 ? 32 : 64) == 0`, `K % block_size == 0`,
+- dtype is FP16 or BF16, `bits ∈ {4, 8}`, `block_size ∈ {32, 64, 128}`,
+- no `g_idx`, `N % (bits==8 ? 32 : 64) == 0`, `K % block_size == 0`,
 - `sm_ >= 75`, and weight/scale/zero-point inputs are constant initializers that
   ORT can prepack.
+
+`block_size=32` is served by the SM80/Ampere-class fine-grained kernel (and its
+SM90 compatibility path); the native SM90 kernel (`weight_prepacked=2`) supports
+only `block_size ∈ {64, 128}` — see §2.1.
 
 At run time a profiler picks the best tactic; small `M` may use a dedicated CUDA
 GEMV kernel (`bestTactic->enableCudaKernel`), otherwise a CUTLASS grouped GEMM.
@@ -258,8 +267,10 @@ Prepacked weights are intentionally strict:
   throws instead of silently falling back to a raw-layout path.
 - Nonzero `weight_prepacked` requires FP16 or BF16 input `A`, because only the
   CUDA fpA_intB path consumes this layout.
-- `weight_prepacked=1` must match the currently required SM80 layout; `2` is
-  reserved and rejected.
+- `weight_prepacked` must match the layout the selected kernel expects: `1` is
+  the SM80 layout, `2` is the native SM90 (Hopper) layout. `2` additionally
+  requires a compute-capability 9.0 device and `block_size ∈ {64, 128}` and is
+  rejected otherwise.
 
 ---
 

--- a/onnxruntime/contrib_ops/cuda/llm/cutlass_extensions/gemm/kernel/fpA_intB_gemm.h
+++ b/onnxruntime/contrib_ops/cuda/llm/cutlass_extensions/gemm/kernel/fpA_intB_gemm.h
@@ -247,7 +247,7 @@ struct GemmFpAIntB {
     }
 
     if constexpr (isFinegrained(Mma::QuantOp)) {
-      if (args.group_size != 64 && args.group_size != 128) {
+      if (args.group_size != 32 && args.group_size != 64 && args.group_size != 128) {
         return Status::kErrorNotSupported;
       }
     }
@@ -442,11 +442,16 @@ struct GemmFpAIntB {
     run_kernel<arch::Sm80>(params, shared_storage);
 #elif (__CUDA_ARCH__ == 890)
     run_kernel<arch::Sm89>(params, shared_storage);
-#elif (__CUDA_ARCH__ >= 1000)
-    // Use SM80 implementation for GB10x, GB20x.
+#elif (__CUDA_ARCH__ >= 900)
+    // Reuse the SM80 (Ampere) mixed-GEMM kernel on Hopper (SM90) and Blackwell (SM100+, e.g.
+    // GB10x/GB20x). The Ampere tensor-core mixed-input path is valid on these archs, so callers
+    // that pack the SM80 weight layout and dispatch KernelArch=Sm80 (see MatMulNBits) get a real
+    // kernel here instead of a stub. The dedicated CUTLASS 3.x Hopper TMA warp-specialized
+    // mixed-input kernels are reached through the separate sm90_dispatch path, not this operator.
+    // Mirrors MoeFCGemm::operator() which already reuses the SM80 kernel for SM90+.
     run_kernel<arch::Sm80>(params, shared_storage);
 #else
-    CUTLASS_NOT_IMPLEMENTED();  // Don't compile these for Hopper or later. Use CUTLASS 3.x kernels.
+    CUTLASS_NOT_IMPLEMENTED();
 #endif
 #else
     CUTLASS_NOT_IMPLEMENTED();

--- a/onnxruntime/contrib_ops/cuda/llm/fpA_intB_gemm/fpA_intB_gemm.h
+++ b/onnxruntime/contrib_ops/cuda/llm/fpA_intB_gemm/fpA_intB_gemm.h
@@ -74,6 +74,19 @@ class CutlassFpAIntBGemmRunnerInterface {
 
   virtual std::vector<tkc::CutlassGemmConfig> getConfigs() const = 0;
 
+  // Overrides the SM architecture used for tactic/config enumeration, workspace sizing and kernel
+  // dispatch. By default the runner targets the detected device SM. On SM90 the half/bf16
+  // weight-only path dispatches the SM80 (Ampere) mixed-GEMM kernel (which now runs on Hopper, see
+  // GemmFpAIntB::operator()), so MatMulNBits forces the runner to SM80 to keep the enumerated
+  // tactics (tile_config_sm80) and workspace sizing consistent with the dispatched kernel.
+  // Default: no-op (keep detected SM).
+  virtual void setArch(int /*sm*/) {}
+
+  // Opts in to the native SM90 (Hopper TMA/WGMMA) mixed-GEMM kernel instead of the SM80
+  // compatibility path. Only meaningful when the runner targets SM90 (setArch is left at 90) and
+  // the weights were prepacked for the Hopper layout. Default: no-op (keep the SM80 kernel).
+  virtual void setUseSm90Native(bool /*use*/) {}
+
  protected:
   static constexpr int SPLIT_K_LIMIT = 7;
   static constexpr int MIN_M_TILE = 16;
@@ -118,6 +131,10 @@ class CutlassFpAIntBGemmRunner : public virtual CutlassFpAIntBGemmRunnerInterfac
 
   std::vector<tkc::CutlassGemmConfig> getConfigs() const override;
 
+  void setArch(int sm) override { sm_ = sm; }
+
+  void setUseSm90Native(bool use) override { use_sm90_native_ = use; }
+
  private:
   template <typename EpilogueTag>
   void dispatch_to_arch(ActivationType const* A, WeightType const* B, ScaleZeroType const* weight_scales,
@@ -128,6 +145,7 @@ class CutlassFpAIntBGemmRunner : public virtual CutlassFpAIntBGemmRunnerInterfac
  private:
   int sm_;
   int multi_processor_count_;
+  bool use_sm90_native_{false};
 };
 
 }  // namespace cutlass_kernels

--- a/onnxruntime/contrib_ops/cuda/llm/fpA_intB_gemm/fpA_intB_gemm_template.h
+++ b/onnxruntime/contrib_ops/cuda/llm/fpA_intB_gemm/fpA_intB_gemm_template.h
@@ -134,8 +134,8 @@ void generic_mixed_gemm_kernelLauncher(ActivationType const* A, WeightType const
       }
     }
 
-    if (group_size != 64 && group_size != 128) {
-      ORT_THROW("Only group size 64 and 128 supported for fine grained kernels.");
+    if (group_size != 32 && group_size != 64 && group_size != 128) {
+      ORT_THROW("Only group size 32, 64 and 128 supported for fine grained kernels.");
     }
 
     if constexpr (QuantOp == cutlass::WeightOnlyQuantOp::FINEGRAINED_SCALE_ONLY) {
@@ -393,9 +393,20 @@ void CutlassFpAIntBGemmRunner<ActivationType, WeightType, QuantOp, ScaleZeroType
                   cutlass::platform::is_same<ActivationType, ScaleZeroType>::value &&
                   cutlass::platform::is_same<ActivationType, BiasType>::value &&
                   cutlass::platform::is_same<ActivationType, OutputType>::value) {
-      dispatch_gemm_to_cutlass<ActivationType, WeightType, ScaleZeroType, BiasType, OutputType, cutlass::arch::Sm80,
-                               QuantOp, EpilogueTag>(A, B, weight_scales, weight_zero_points, biases, alpha, C, m, n, k, group_size,
-                                                     workspace_ptr, workspace_bytes, gemm_config, stream, occupancy);
+      // For half/bf16 weight-only GEMM on Hopper we support two paths:
+      //   - use_sm90_native_ == false: reuse the SM80 (Ampere) mixed-GEMM kernel (compat path,
+      //     consumes the SM80 column-interleaved weight layout).
+      //   - use_sm90_native_ == true: the native SM90 TMA/WGMMA mixed-GEMM kernel, which consumes
+      //     the Hopper weight layout (prepacked with arch=90, no column interleave).
+      if (use_sm90_native_) {
+        sm90_dispatch_gemm_to_cutlass<ActivationType, WeightType, ScaleZeroType, BiasType, OutputType, QuantOp,
+                                      EpilogueTag>(A, B, weight_scales, weight_zero_points, biases, alpha, C, m, n, k, group_size, workspace_ptr,
+                                                   workspace_bytes, gemm_config, stream, occupancy);
+      } else {
+        dispatch_gemm_to_cutlass<ActivationType, WeightType, ScaleZeroType, BiasType, OutputType, cutlass::arch::Sm80,
+                                 QuantOp, EpilogueTag>(A, B, weight_scales, weight_zero_points, biases, alpha, C, m, n, k, group_size,
+                                                       workspace_ptr, workspace_bytes, gemm_config, stream, occupancy);
+      }
     } else {
       static_assert(!cutlass::platform::is_same<ActivationType, __nv_fp8_e4m3>::value || cutlass::platform::is_same<ScaleZeroType, half>::value,
                     "ScaleZeroType must be half for activation=fp8");

--- a/onnxruntime/contrib_ops/cuda/llm/fpA_intB_gemm/launchers/fpA_intB_launcher_sm90.inl
+++ b/onnxruntime/contrib_ops/cuda/llm/fpA_intB_gemm/launchers/fpA_intB_launcher_sm90.inl
@@ -59,7 +59,13 @@ using namespace cute;
 template <typename ActivationType, typename WeightType, typename ScaleZeroType, typename BiasType, typename OutputType,
           cutlass::WeightOnlyQuantOp QuantOp, typename EpilogueTag, typename CTAShape, typename ClusterShape,
           typename MainloopScheduleType, typename EpilogueScheduleType>
-#if defined(COMPILE_HOPPER_TMA_GEMMS) && defined(__CUDA_ARCH__) && (__CUDA_ARCH__ == 900) && defined(__NV_SASS_VERSION__)
+// Gate the real launcher on the COMPILE_HOPPER_TMA_GEMMS preprocessor macro only (matching the MoE
+// TMA launcher in moe_gemm_tma_ws_launcher.inl). The host-callable launcher symbol is emitted from
+// the host compilation pass, so it must NOT be gated on __CUDA_ARCH__/__NV_SASS_VERSION__ (which are
+// only set during device passes) — otherwise the host links the stub below and every SM90 tactic
+// fails at runtime with "recompile ... 90a". The device kernel body is guarded internally by the
+// collective (CUTE_ARCH_MMA_SM90A_ENABLED); these files are compiled at sm_90a-real.
+#if defined(COMPILE_HOPPER_TMA_GEMMS)
 void sm90_generic_mixed_gemm_kernelLauncher(
     ActivationType const* A, WeightType const* B,
     ScaleZeroType const* weight_scales, ScaleZeroType const* weight_zero_points, BiasType const* biases,

--- a/onnxruntime/contrib_ops/cuda/llm/fpA_intB_gemv/dispatcher.h
+++ b/onnxruntime/contrib_ops/cuda/llm/fpA_intB_gemv/dispatcher.h
@@ -444,7 +444,10 @@ void check_pointer(Params& params, cudaStream_t s) {
 template <bool isGroupwise, typename Details>
 void select_gs(Params& params, cudaStream_t s) {
   if constexpr (isGroupwise) {
-    if (params.groupsize == 64) {
+    if (params.groupsize == 32) {
+      check_pointer<Details, 32>(params, s);
+      return;
+    } else if (params.groupsize == 64) {
       check_pointer<Details, 64>(params, s);
       return;
     } else if (params.groupsize == 128) {

--- a/onnxruntime/contrib_ops/cuda/llm/gemm_profiler.h
+++ b/onnxruntime/contrib_ops/cuda/llm/gemm_profiler.h
@@ -57,20 +57,22 @@ struct GemmDims {
 };
 
 // Unique ID of GEMM
-// In our case GEMM is uniqly identified by N and K
+// In our case GEMM is uniquely identified by N and K, plus the target SM architecture (so the
+// SM80-compatibility and native SM90 kernels for the same shape do not share profiled configs).
 class GemmIdCore {
  public:
   int n;
   int k;
   nvinfer::DataType dtype;
+  int sm;
 
-  GemmIdCore(int n_, int k_, nvinfer::DataType const& dtype_)
-      : n(n_), k(k_), dtype(dtype_) {
+  GemmIdCore(int n_, int k_, nvinfer::DataType const& dtype_, int sm_ = 0)
+      : n(n_), k(k_), dtype(dtype_), sm(sm_) {
   }
 
   GemmIdCore()
-      : n(-1), k(-1), dtype(nvinfer::DataType::kFLOAT)  // dtype does not matter here
-  {
+      : n(-1), k(-1), dtype(nvinfer::DataType::kFLOAT),  // dtype does not matter here
+        sm(0) {
   }
 
   bool operator==(GemmIdCore const& id) const {
@@ -80,12 +82,13 @@ class GemmIdCore {
   friend std::ostream& operator<<(std::ostream& out, GemmIdCore const& id) {
     out << "(N;K)=(" << id.n << ";" << id.k << "),";
     out << " type=" << static_cast<int>(id.dtype);
+    out << " sm=" << id.sm;
     return out;
   }
 
  protected:
   bool isEqual(GemmIdCore const& id) const {
-    return n == id.n && k == id.k && dtype == id.dtype;
+    return n == id.n && k == id.k && dtype == id.dtype && sm == id.sm;
   }
 };
 
@@ -95,7 +98,8 @@ struct GemmIdCoreHash {
     auto h1 = std::hash<int>{}(id.n);
     auto h2 = std::hash<int>{}(id.k);
     auto h3 = std::hash<int>{}(static_cast<int>(id.dtype));
-    return h1 ^ h2 ^ h3;
+    auto h4 = std::hash<int>{}(id.sm);
+    return h1 ^ h2 ^ h3 ^ h4;
   }
 };
 

--- a/onnxruntime/contrib_ops/cuda/quantization/matmul_nbits.cc
+++ b/onnxruntime/contrib_ops/cuda/quantization/matmul_nbits.cc
@@ -41,7 +41,12 @@ constexpr auto kScaleOnly = cutlass::WeightOnlyQuantOp::FINEGRAINED_SCALE_ONLY;
 
 template <typename T>
 int MatMulNBits<T>::FpAIntBPackingSmForKernel() const {
-  // MatMulNBits mixed int-weight GEMM/GEMV consumes the SM80 fpA_intB weight layout in v1.
+  // Select the native SM90 (Hopper) mixed-weight layout only when the weights were prepacked for it
+  // (weight_prepacked_ == 2) AND the device is SM90. Otherwise use the SM80 layout, which is also
+  // used as the SM90 compatibility path for runtime-prepacked (or SM80-prepacked) weights.
+  if (sm_ == 90 && weight_prepacked_ == kMatMulNBitsWeightPrepackedSm90) {
+    return 90;
+  }
   return 80;
 }
 
@@ -88,6 +93,21 @@ void MatMulNBits<T>::InitGemmProfiler(int sm) {
     }
   }
 
+  // On SM90 the half/bf16 weight-only path can run either the native Hopper (SM90 TMA/WGMMA) kernel
+  // or the SM80 (Ampere) mixed-GEMM kernel (which also runs on Hopper via GemmFpAIntB::operator()).
+  //   - Native SM90 (sm == 90): keep the runner targeting SM90 so getConfigs() enumerates Hopper
+  //     tactics (tile_config_sm90) and getWorkspaceSize() reserves the stream-K workspace; opt in to
+  //     the native kernel via setUseSm90Native(true).
+  //   - SM80 compat (sm == 80 while the device is SM90): force the runner to SM80 so tactic
+  //     enumeration and workspace sizing stay consistent with the dispatched SM80 kernel (the runner
+  //     otherwise defaults to the detected device SM and would enumerate Hopper tactics the SM80
+  //     dispatch cannot consume, leaving no CUTLASS GEMM tactic for M>=16).
+  if (sm == 90) {
+    weightOnlyGemmRunner_->setUseSm90Native(true);
+  } else if (sm_ == 90) {
+    weightOnlyGemmRunner_->setArch(sm);
+  }
+
   gemmProfiler_->setCudaKernelType(cuda_kernel_type, sm);
   gemmProfiler_->setQuant(nbits_, has_bias_, has_zero_points_);
   gemmProfiler_->setGroupSize(block_size_);
@@ -101,10 +121,13 @@ void MatMulNBits<T>::RunGemmProfile(bool hasWeightOnlyCudaKernel, int min_m, int
   // Number of 16-bit elements after casting int8/int4 to fp16.
   int n_16b = N_ / (nbits_ == 8 ? 2 : 4);
 
+  // Include the packing/kernel SM in the GEMM id so the SM80-compatibility and native SM90 kernels
+  // (which need different tactics) do not share profiled configs for the same (N, K, dtype).
+  const int kernel_sm = FpAIntBPackingSmForKernel();
   if constexpr (std::is_same_v<T, MLFloat16>) {
-    gemmId_ = GemmIdCore(n_16b, K_, onnxruntime::llm::nvinfer::DataType::kHALF);
+    gemmId_ = GemmIdCore(n_16b, K_, onnxruntime::llm::nvinfer::DataType::kHALF, kernel_sm);
   } else if constexpr (std::is_same_v<T, BFloat16>) {
-    gemmId_ = GemmIdCore(n_16b, K_, onnxruntime::llm::nvinfer::DataType::kBF16);
+    gemmId_ = GemmIdCore(n_16b, K_, onnxruntime::llm::nvinfer::DataType::kBF16, kernel_sm);
   }
 
   GemmDims dims = {min_m, max_m, n_16b, K_};
@@ -355,7 +378,34 @@ Status MatMulNBits<T>::ComputeInternal(OpKernelContext* ctx) const {
 
       const void* fpA_intB_weight = is_prepacked_weight_ ? fpA_intB_weight_buffer_.get() : static_cast<const void*>(blob_data);
 
-      auto const& bestTactic = gemmProfiler_->getBestConfig(m, gemmId_);
+      auto const bestTactic = gemmProfiler_->getBestConfig(m, gemmId_);
+      if (!bestTactic.has_value()) {
+        return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
+                               "No valid fpA_intB MatMulNBits tactic for M=", m,
+                               ", N=", n, ", K=", k);
+      }
+
+      // Env-gated diagnostics (ORT_FPA_INTB_DEBUG=1): dump the selected tactic, the kernel path
+      // (GEMV CUDA kernel vs CUTLASS GEMM), the weight format, and the device/packing SM so that
+      // SM90 correctness issues (e.g. running the SM80 kernel on Hopper) can be traced.
+      static const bool fpA_intB_debug =
+          ParseEnvironmentVariableWithDefault<int>("ORT_FPA_INTB_DEBUG", 0) != 0;
+      if (fpA_intB_debug) {
+        const char* weight_fmt = is_prepacked_weight_ ? "runtime-prepacked(SM80 layout)"
+                                                      : (weight_prepacked_ == kMatMulNBitsWeightPrepackedSm80 ? "offline-prepacked-SM80"
+                                                                                                              : (weight_prepacked_ == kMatMulNBitsWeightPrepackedSm90 ? "offline-prepacked-SM90"
+                                                                                                                                                                      : "raw"));
+        std::cout << "[fpA_intB_debug] M=" << m << " N=" << n << " K=" << k
+                  << " nbits=" << nbits_ << " block_size=" << block_size_
+                  << " device_sm=" << sm_
+                  << " packing_sm=" << FpAIntBPackingSmForKernel()
+                  << " has_bias=" << (bias_data != nullptr ? 1 : 0)
+                  << " has_zero_points=" << (has_zero_points_ ? 1 : 0)
+                  << " weight_format=" << weight_fmt
+                  << " kernel=" << (bestTactic->enableCudaKernel ? "GEMV(cuda)" : (FpAIntBPackingSmForKernel() == 90 ? "CUTLASS(sm90 gemm)" : "CUTLASS(sm80 gemm)"))
+                  << " tactic=" << bestTactic->toString()
+                  << std::endl;
+      }
 
 #if ORT_LLM_VERBOSE > 1
       std::cout << "Best tactic for m=" << m << ", n=" << n << ", k=" << k << "group_size=" << block_size_
@@ -380,7 +430,13 @@ Status MatMulNBits<T>::ComputeInternal(OpKernelContext* ctx) const {
             bias_data, out_data,
             alpha, m, n, k, block_size_, cuda_kernel_type, apply_alpha_in_advance);
 
-        onnxruntime::llm::kernels::fpA_intB_gemv::kernel_launcher(sm_, params, stream);
+        // Launch the GEMV with the arch the weights were PACKED for (FpAIntBPackingSmForKernel),
+        // not the raw device SM. The GEMV interleave layout is arch-dependent: arch in [90,100)
+        // uses ColumnMajorInterleavedForHopper while the SM80 packing uses ColumnMajorInterleaved.
+        // PrePack_B packs the SM80 layout, and the tactic profiler also profiles with the packing
+        // arch, so passing the device SM (e.g. 90) here would read the SM80-packed weights with the
+        // Hopper interleave and produce wrong results.
+        onnxruntime::llm::kernels::fpA_intB_gemv::kernel_launcher(FpAIntBPackingSmForKernel(), params, stream);
       } else {
         const size_t workspace_size = weightOnlyGemmRunner_->getWorkspaceSize(m, n, k);
         auto workspace_buffer = this->template GetScratchBuffer<void>(workspace_size, this->GetComputeStream(ctx));

--- a/onnxruntime/contrib_ops/cuda/quantization/matmul_nbits.h
+++ b/onnxruntime/contrib_ops/cuda/quantization/matmul_nbits.h
@@ -93,19 +93,29 @@ class MatMulNBits final : public CudaKernel {
     ORT_ENFORCE(weight_prepacked_ == kMatMulNBitsWeightNotPrepacked ||
                     weight_prepacked_ == kMatMulNBitsWeightPrepackedSm80 ||
                     weight_prepacked_ == kMatMulNBitsWeightPrepackedSm90,
-                "weight_prepacked must be 0 (not prepacked), 1 (SM80 layout), or 2 (reserved SM90 layout), but got ",
+                "weight_prepacked must be 0 (not prepacked), 1 (SM80 layout), or 2 (SM90 layout), but got ",
                 weight_prepacked_);
-    ORT_ENFORCE(weight_prepacked_ != kMatMulNBitsWeightPrepackedSm90,
-                "weight_prepacked=2 (SM90 layout) is reserved and not supported yet");
+    if (weight_prepacked_ == kMatMulNBitsWeightPrepackedSm90) {
+      // The native SM90 (Hopper TMA/WGMMA) mixed-GEMM kernel requires a compute-capability 9.0
+      // device and a block_size that is a multiple of the Hopper K tile (128 / sizeof(half) = 64).
+      // block_size=32 is only supported by the SM80/Ampere-class kernel + GEMV path.
+      ORT_ENFORCE(sm_ == 90,
+                  "weight_prepacked=2 (SM90 layout) requires a compute capability 9.0 (Hopper) device, but got sm ", sm_);
+      ORT_ENFORCE(block_size_ == 64 || block_size_ == 128,
+                  "weight_prepacked=2 (SM90 layout) supports block_size 64 or 128 only, but got ", block_size_);
+    }
 
     if constexpr (std::is_same<T, MLFloat16>::value || std::is_same<T, BFloat16>::value) {
       int option = ParseEnvironmentVariableWithDefault<int>(kFpAIntBGemmOption, 0);
       ORT_ENFORCE(!(weight_prepacked_ != kMatMulNBitsWeightNotPrepacked && option == 0),
                   "weight_prepacked requires the fpA_intB path, but ORT_FPA_INTB_GEMM is off for this node");
+      // Note: a fused bias (input[5]) is fully supported by the fpA_intB GEMV, CUTLASS SM80/SM90
+      // GEMM (EpilogueOpBias), and the tactic profiler, so bias-bearing nodes (e.g. gpt-oss
+      // qkv_proj/o_proj) are eligible. Only g_idx/reorder remains unsupported by this path.
       if ((option & (static_cast<int>(nbits_) | kFpAIntBGemmOption_All)) != 0 &&
-          (block_size_ == 64 || block_size_ == 128) &&
+          (block_size_ == 32 || block_size_ == 64 || block_size_ == 128) &&
           (nbits_ == 4 || nbits_ == 8) &&
-          !has_g_idx_ && !has_bias_ &&
+          !has_g_idx_ &&
           N_ % (nbits_ == 8 ? 32 : 64) == 0 &&
           K_ % block_size_ == 0 &&
           sm_ >= 75) {

--- a/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
@@ -3666,7 +3666,8 @@ For example, for 4 bits, the first 4 bits are stored in the lower 4 bits of a by
       .Attr("weight_prepacked",
             "If set, input B is already prepacked into an EP-specific layout and the EP skips runtime "
             "weight prepacking. 0 (default): not prepacked. 1: prepacked in the CUDA SM80 fpA_intB layout. "
-            "2: reserved for a future SM90 layout (currently rejected at kernel construction).",
+            "2: prepacked in the CUDA SM90 (Hopper) fpA_intB layout, consumed by the native SM90 kernel "
+            "(requires a compute capability 9.0 device and block_size in {64, 128}).",
             AttributeProto::INT, static_cast<int64_t>(0))
       .Input(0, "A", "The input tensor, not quantized.", "T1")
       .Input(1, "B",

--- a/onnxruntime/test/contrib_ops/matmul_4bits_test.cc
+++ b/onnxruntime/test/contrib_ops/matmul_4bits_test.cc
@@ -890,6 +890,100 @@ TEST(MatMulNBits, Fp16_Int4_NoZeroPoint) {
   }
 }
 
+// block_size=32 with the fpA_intB path. Production rc2/rc3 int4 models are quantized with
+// block_size=32. The fpA_intB kernels support group_size=32: the GEMV select_gs dispatches
+// GroupSize==32, and the SM80/Ampere fine-grained CUTLASS GEMM uses kMinFinegrainedGroupSize=32
+// (two scale rows per 64-element K tile). Exercises M=1 (GEMV) and M=32 (CUTLASS), with and
+// without zero-points, for fp16 and bf16.
+TEST(MatMulNBits, Fp16_Int4_BlockSize32_FpAIntB) {
+  constexpr float abs_error = 0.1f;
+  constexpr bool zp_is_4bit = true;
+
+  ScopedEnvironmentVariables scoped_env_vars{EnvVarMap{{"ORT_FPA_INTB_GEMM", "1"}}};
+
+  for (auto has_zeropoint : {false, true}) {
+    RunTest<MLFloat16>(1, 256, 1024, 32, has_zeropoint, zp_is_4bit, abs_error);
+    RunTest<MLFloat16>(32, 1024, 2048, 32, has_zeropoint, zp_is_4bit, abs_error);
+  }
+}
+
+TEST(MatMulNBits, BFloat16_Int4_BlockSize32_FpAIntB) {
+  if (!HasCudaEnvironment(800)) {
+    GTEST_SKIP() << "Skipping BFloat16 MatMul tests on CUDA < 8.0";
+  }
+
+  constexpr float abs_error = 0.5f;
+  constexpr bool zp_is_4bit = true;
+
+  ScopedEnvironmentVariables scoped_env_vars{EnvVarMap{{"ORT_FPA_INTB_GEMM", "1"}}};
+
+  for (auto has_zeropoint : {false, true}) {
+    RunTest<BFloat16>(1, 256, 1024, 32, has_zeropoint, zp_is_4bit, abs_error);
+    RunTest<BFloat16>(32, 1024, 2048, 32, has_zeropoint, zp_is_4bit, abs_error);
+  }
+}
+
+// Fused bias with the fpA_intB path. Exercises both the GEMV path (M=1) and the CUTLASS GEMM path
+// (M=32), for fp16 and bf16, with block_size 64/128. This is the gpt-oss qkv_proj/o_proj scenario
+// where MatMulNBitsFusion folds the Add(bias) into MatMulNBits input[5].
+TEST(MatMulNBits, Fp16_Int4_NoZeroPoint_Bias) {
+  constexpr float abs_error = 0.1f;
+  constexpr bool zp_is_4bit = true;
+  constexpr bool has_zeropoint = false;
+  constexpr bool has_g_idx = false;
+  constexpr bool has_bias = true;
+
+  ScopedEnvironmentVariables scoped_env_vars{EnvVarMap{{"ORT_FPA_INTB_GEMM", "1"}}};
+
+  for (auto block_size : {64, 128}) {
+    RunTest<MLFloat16>(1, 256, 1024, block_size, has_zeropoint, zp_is_4bit, abs_error, has_g_idx, has_bias);
+    RunTest<MLFloat16>(32, 1024, 2048, block_size, has_zeropoint, zp_is_4bit, abs_error, has_g_idx, has_bias);
+  }
+}
+
+TEST(MatMulNBits, BFloat16_Int4_NoZeroPoint_Bias) {
+  if (!HasCudaEnvironment(800)) {
+    GTEST_SKIP() << "Skipping BFloat16 MatMul tests on CUDA < 8.0";
+  }
+
+  constexpr float abs_error = 0.5f;
+  constexpr bool zp_is_4bit = true;
+  constexpr bool has_zeropoint = false;
+  constexpr bool has_g_idx = false;
+  constexpr bool has_bias = true;
+
+  ScopedEnvironmentVariables scoped_env_vars{EnvVarMap{{"ORT_FPA_INTB_GEMM", "1"}}};
+
+  for (auto block_size : {64, 128}) {
+    RunTest<BFloat16>(1, 256, 1024, block_size, has_zeropoint, zp_is_4bit, abs_error, has_g_idx, has_bias);
+    RunTest<BFloat16>(32, 1024, 2048, block_size, has_zeropoint, zp_is_4bit, abs_error, has_g_idx, has_bias);
+  }
+}
+
+TEST(MatMulNBits, Fp16_Int4_NoZeroPoint_Bias_Prepacked) {
+  ScopedEnvironmentVariables scoped_env_vars{EnvVarMap{{"ORT_FPA_INTB_GEMM", "1"}}};
+
+  auto cuda_ep = DefaultCudaExecutionProvider();
+  if (!cuda_ep) {
+    GTEST_SKIP() << "CUDA execution provider is unavailable";
+  }
+
+  // Bias-bearing node with runtime prepacking (weight_prepacked=0): the kernel's PrePack transforms
+  // the raw weight into the fpA_intB layout at session init and the fused bias flows through the
+  // CUTLASS/GEMV epilogue. Offline weight_prepacked=1 parity for bias is covered by the Python test
+  // test_op_matmulnbits_prepacked_cuda.py.
+  TestOptions opts{};
+  opts.M = 32, opts.N = 1024, opts.K = 2048;
+  opts.block_size = 64;
+  opts.has_zero_point = false;
+  opts.has_bias = true;
+  opts.output_abs_error = 0.1f;
+  opts.output_rel_error = 0.02f;
+  std::vector<std::unique_ptr<IExecutionProvider>> eps;
+  eps.push_back(std::move(cuda_ep));
+  RunTest<MLFloat16>(opts, std::move(eps));
+}
+
 TEST(MatMulNBits, Fp16_Int4_PrepackedWeightRequiresFpAIntBGemm) {
   ScopedEnvironmentVariables scoped_env_vars{EnvVarMap{{"ORT_FPA_INTB_GEMM", "0"}}};
 
@@ -909,7 +1003,14 @@ TEST(MatMulNBits, Fp16_Int4_PrepackedWeightRequiresFpAIntBGemm) {
   RunTest<MLFloat16>(opts, std::move(eps));
 }
 
-TEST(MatMulNBits, Fp16_Int4_PrepackedSm90WeightReserved) {
+// weight_prepacked=2 selects the native SM90 (Hopper) mixed-GEMM layout. It is rejected up front
+// unless the device is SM90 and block_size is 64 or 128 (the SM90 TMA kernel requires group_size to
+// be a multiple of the 64-element Hopper K tile, so block_size=32 is SM80-only). When the fpA_intB
+// path is compiled in, both rejection messages begin with "weight_prepacked=2 (SM90 layout)", so the
+// check is device-independent: non-Hopper hits the compute-capability guard, Hopper hits the
+// block_size guard. In a build without onnxruntime_USE_FPA_INTB_GEMM the kernel rejects any
+// weight_prepacked!=0 up front with a different ("weight_prepacked requires ...") message.
+TEST(MatMulNBits, Fp16_Int4_PrepackedSm90BlockSize32Rejected) {
   ScopedEnvironmentVariables scoped_env_vars{EnvVarMap{{"ORT_FPA_INTB_GEMM", "1"}}};
 
   auto cuda_ep = DefaultCudaExecutionProvider();
@@ -919,10 +1020,14 @@ TEST(MatMulNBits, Fp16_Int4_PrepackedSm90WeightReserved) {
 
   TestOptions opts{};
   opts.M = 1, opts.N = 256, opts.K = 1024;
-  opts.block_size = 64;
+  opts.block_size = 32;
   opts.disable_cpu_ep_fallback = true;
   opts.weight_prepacked = 2;
-  opts.expected_failure = "weight_prepacked";
+#if USE_FPA_INTB_GEMM
+  opts.expected_failure = "weight_prepacked=2 (SM90 layout)";
+#else
+  opts.expected_failure = "weight_prepacked requires";
+#endif
   std::vector<std::unique_ptr<IExecutionProvider>> eps;
   eps.push_back(std::move(cuda_ep));
   RunTest<MLFloat16>(opts, std::move(eps));

--- a/onnxruntime/test/python/quantization/test_op_matmulnbits_prepacked_cuda.py
+++ b/onnxruntime/test/python/quantization/test_op_matmulnbits_prepacked_cuda.py
@@ -5,6 +5,8 @@
 # license information.
 # --------------------------------------------------------------------------
 
+from __future__ import annotations
+
 import os
 import unittest
 from contextlib import contextmanager
@@ -57,12 +59,22 @@ class TestMatMulNBitsPrepackedCuda(unittest.TestCase):
         bits: int,
         block_size: int,
         weight_prepacked: int,
+        bias: np.ndarray | None = None,
     ) -> ModelProto:
         m, k = a_shape
         n = b.shape[0]
+        inputs = ["A", "B", "scales"]
+        initializer = [
+            numpy_helper.from_array(b, name="B"),
+            numpy_helper.from_array(scales, name="scales"),
+        ]
+        if bias is not None:
+            # bias is input index 5; indices 3 (zero_points) and 4 (g_idx) are left empty.
+            inputs.extend(["", "", "bias"])
+            initializer.append(numpy_helper.from_array(bias, name="bias"))
         node = helper.make_node(
             "MatMulNBits",
-            ["A", "B", "scales"],
+            inputs,
             ["Y"],
             domain="com.microsoft",
             K=k,
@@ -76,10 +88,7 @@ class TestMatMulNBitsPrepackedCuda(unittest.TestCase):
             "matmulnbits_prepacked_cuda_test",
             [helper.make_tensor_value_info("A", TensorProto.FLOAT16, [m, k])],
             [helper.make_tensor_value_info("Y", TensorProto.FLOAT16, [m, n])],
-            initializer=[
-                numpy_helper.from_array(b, name="B"),
-                numpy_helper.from_array(scales, name="scales"),
-            ],
+            initializer=initializer,
         )
         model = helper.make_model(
             graph,
@@ -92,19 +101,30 @@ class TestMatMulNBitsPrepackedCuda(unittest.TestCase):
         sess = ort.InferenceSession(model.SerializeToString(), providers=["CUDAExecutionProvider"])
         return sess.run(None, {"A": a})[0]
 
-    def _check_prepacked_parity(self, bits: int, block_size: int, m: int):
+    def _check_prepacked_parity(
+        self,
+        bits: int,
+        block_size: int,
+        m: int,
+        has_bias: bool = False,
+        force_arch: int = 80,
+        weight_prepacked: int = 1,
+    ):
         rng = np.random.default_rng(1234 + bits * 10 + block_size + m)
         k = 256
         n = 256 if bits == 8 else 512
         a = rng.normal(0.0, 0.25, size=(m, k)).astype(np.float16)
         weight = rng.normal(0.0, 0.25, size=(k, n)).astype(np.float16)
+        bias = rng.normal(0.0, 1.0, size=(n,)).astype(np.float16) if has_bias else None
 
         q_weight, scales = self._quantize_weight(weight, bits, block_size)
-        prepacked_flat = _pybind.pack_weights_for_cuda_mixed_gemm(q_weight.reshape(n, -1), n, k, bits, 80)
+        prepacked_flat = _pybind.pack_weights_for_cuda_mixed_gemm(q_weight.reshape(n, -1), n, k, bits, force_arch)
         prepacked_weight = np.asarray(prepacked_flat, dtype=np.int8).view(np.uint8).reshape(q_weight.shape)
 
-        raw_model = self._make_model((m, k), q_weight, scales, bits, block_size, weight_prepacked=0)
-        prepacked_model = self._make_model((m, k), prepacked_weight, scales, bits, block_size, weight_prepacked=1)
+        raw_model = self._make_model((m, k), q_weight, scales, bits, block_size, weight_prepacked=0, bias=bias)
+        prepacked_model = self._make_model(
+            (m, k), prepacked_weight, scales, bits, block_size, weight_prepacked=weight_prepacked, bias=bias
+        )
 
         with set_env("ORT_FPA_INTB_GEMM", "1"):
             raw_output = self._run_model(raw_model, a)
@@ -116,9 +136,39 @@ class TestMatMulNBitsPrepackedCuda(unittest.TestCase):
         self._check_prepacked_parity(bits=4, block_size=64, m=1)
         self._check_prepacked_parity(bits=4, block_size=128, m=32)
 
+    def test_int4_bs32_sm80_prepacked_weight_matches_runtime_prepack(self):
+        # Production rc2/rc3 models use block_size=32 (SM80/Ampere layout, weight_prepacked=1).
+        self._check_prepacked_parity(bits=4, block_size=32, m=1)
+        self._check_prepacked_parity(bits=4, block_size=32, m=32)
+
     def test_int8_sm80_prepacked_weight_matches_runtime_prepack(self):
         self._check_prepacked_parity(bits=8, block_size=64, m=1)
         self._check_prepacked_parity(bits=8, block_size=128, m=32)
+
+    def test_int4_sm80_prepacked_weight_with_bias_matches_runtime_prepack(self):
+        self._check_prepacked_parity(bits=4, block_size=64, m=1, has_bias=True)
+        self._check_prepacked_parity(bits=4, block_size=128, m=32, has_bias=True)
+
+    def _check_sm90_parity(self, **kwargs):
+        # The native SM90 (Hopper) layout (force_arch=90, weight_prepacked=2) only runs on an SM90
+        # device; the MatMulNBits kernel rejects it up front elsewhere. Self-gate by skipping when
+        # the compute-capability guard fires so the test is a no-op on non-Hopper CI.
+        try:
+            self._check_prepacked_parity(force_arch=90, weight_prepacked=2, **kwargs)
+        except Exception as exc:
+            if "compute capability 9.0" in str(exc):
+                self.skipTest("native SM90 fpA_intB requires a Hopper (SM90) device")
+            raise
+
+    def test_int4_sm90_prepacked_weight_matches_runtime_prepack(self):
+        self._check_sm90_parity(bits=4, block_size=64, m=1)
+        self._check_sm90_parity(bits=4, block_size=128, m=32)
+
+    def test_int4_sm90_prepacked_weight_with_bias_matches_runtime_prepack(self):
+        self._check_sm90_parity(bits=4, block_size=128, m=32, has_bias=True)
+
+    def test_int8_sm90_prepacked_weight_matches_runtime_prepack(self):
+        self._check_sm90_parity(bits=8, block_size=128, m=32)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Description

Extends the CUDA fpA_intB weight-only `MatMulNBits` path (FP16/BF16 int4/int8) in three ways. All are gated behind the existing `ORT_FPA_INTB_GEMM` opt-in; default behavior is unchanged.

**1. Native SM90 (Hopper) mixed-GEMM kernel**
- `cutlass_extensions` `GemmFpAIntB::operator()`: reuse the SM80 (Ampere) mixed-GEMM kernel for `__CUDA_ARCH__ >= 900` (Hopper/Blackwell) instead of stubbing it out, so the SM80-compat dispatch produces a real kernel on Hopper (mirrors `MoeFCGemm::operator()`).
- `fpA_intB_launcher_sm90.inl`: gate the host-callable launcher on `COMPILE_HOPPER_TMA_GEMMS` only (not `__CUDA_ARCH__` / `__NV_SASS_VERSION__`, which are unset in the host pass), so the native SM90 TMA/WGMMA launcher symbol is emitted instead of the "recompile with 90a" stub.
- `CutlassFpAIntBGemmRunnerInterface`: add `setArch(int)` and `setUseSm90Native(bool)`; the runner routes SM90 to `sm90_dispatch` when native, else the SM80 compat path.
- `matmul_nbits`: `FpAIntBPackingSmForKernel()` returns 90 for `weight_prepacked=2` on an SM90 device (else 80); `InitGemmProfiler` opts into the native kernel (sm==90) or forces the runner to SM80 (compat on Hopper) so tactic enumeration and workspace sizing match the dispatched kernel; `GemmIdCore` gains an `sm` field so SM80-compat and SM90-native tactics for the same shape are not confused; the GEMV is launched with the packing arch (not the raw device SM) to match the packed interleave layout.
- `weight_prepacked=2` (SM90 layout) is now accepted (was reserved/rejected): requires an SM90 device and `block_size ∈ {64, 128}`. Contrib-op docs updated accordingly.

**2. `block_size=32`**
- Relax the group-size gates in the GEMV dispatcher, the CUTLASS fine-grained `can_implement` / kernel launcher, and the `MatMulNBits` eligibility check. The SM80 fine-grained kernel supports group size 32 natively.

**3. Fused bias**
- Drop the `!has_bias_` gate: a fused bias (input 5) is already supported by the GEMV, the SM80/SM90 CUTLASS epilogue, and the tactic profiler, so bias-bearing nodes (e.g. gpt-oss `qkv_proj`/`o_proj`) become eligible.

### Motivation and Context

Enables the fpA_intB weight-only path for more shapes and for Hopper-native execution, unblocking int4/int8 models with fused bias and `block_size=32` on H200. Builds on #29499 (prepacked fpA_intB weights).

### Testing

- Built with `USE_FPA_INTB_GEMM=ON` (arch 80;90) on H200.
- C++ `onnxruntime_provider_test --gtest_filter='*MatMulNBits*:*FpAIntB*'`: 65 passed, 1 skipped.
- `test_op_matmulnbits_prepacked_cuda.py`: 7 passed (int4/int8, SM80/SM90, bias parity vs runtime prepack).