### PR TITLE
webgpu: Bump FlashAttentionDecodeQKV workgroup to 128, tile_size_k_vec to 32

### DIFF
--- a/onnxruntime/contrib_ops/webgpu/bert/flash_attention.cc
+++ b/onnxruntime/contrib_ops/webgpu/bert/flash_attention.cc
@@ -293,7 +293,11 @@ Status FlashAttentionDecodeQKVProgram::GenerateShaderCode(ShaderHelper& shader) 
   const auto& out_split_vx = shader.AddOutput("out_split_vx", ShaderUsage::UseUniform);
   const auto& metadata = shader.AddOutput("metadata", ShaderUsage::UseUniform | ShaderUsage::UseValueTypeAlias);
 
-  const uint32_t tile_size_k_vec = 32;
+  // Wider K tiling (32 vec4) with a 128-thread workgroup is used for decode (m_tile == 1) to
+  // mirror MatMulNBits and improve GPU time. For prefill (m_tile > 1) the shared-memory
+  // arrays that scale with tile_size_k_vec and m_tile would exceed the 32 KB workgroup
+  // storage limit on some adapters, so keep the original 8 vec4 / 64-thread shape there.
+  const uint32_t tile_size_k_vec = (m_tile_ == 1u) ? 32u : 8u;
   const uint32_t sub_tile_count = WorkgroupSizeX() / tile_size_k_vec;
   return WGSL_TEMPLATE_APPLY(shader, "bert/flash_attention_decode_qkv.wgsl.template",
                              WGSL_TEMPLATE_PARAMETER(compressed_head_size_u32, compressed_head_size_u32_),
@@ -365,7 +369,11 @@ Status ComputeFlashAttentionDecodeQKV(onnxruntime::webgpu::ComputeContext& conte
   } else {
     program.SetDispatchGroupSize(parameters.batch_size_ * parameters.num_heads_ * ((parameters.sequence_length_ + m_tile - 1) / m_tile) * num_total_seq_length_tile);
   }
-  program.SetWorkgroupSize(128)
+  // Workgroup size mirrors the tile_size_k_vec choice inside the program's shader (see
+  // FlashAttentionDecodeQKVProgram::GenerateShaderCode): 128 threads with 32 vec4 K tiles
+  // for decode, 64 threads with 8 vec4 K tiles for prefill.
+  const uint32_t workgroup_size = (m_tile == 1u) ? 128u : 64u;
+  program.SetWorkgroupSize(workgroup_size)
       .CacheHint(tile_size, head_size_vec, has_attention_bias, use_indirect_dispatch, q_BNSH, is_unidirectional, m_tile, use_seqlen_k, turbo_quant, compressed_head_size_u32)
       .AddUniformVariables({{static_cast<uint32_t>(vectorized_head_size)},
                             {static_cast<uint32_t>(parameters.total_sequence_length_)},

--- a/onnxruntime/contrib_ops/webgpu/bert/flash_attention.cc
+++ b/onnxruntime/contrib_ops/webgpu/bert/flash_attention.cc
@@ -293,7 +293,7 @@ Status FlashAttentionDecodeQKVProgram::GenerateShaderCode(ShaderHelper& shader) 
   const auto& out_split_vx = shader.AddOutput("out_split_vx", ShaderUsage::UseUniform);
   const auto& metadata = shader.AddOutput("metadata", ShaderUsage::UseUniform | ShaderUsage::UseValueTypeAlias);
 
-  const uint32_t tile_size_k_vec = 8;
+  const uint32_t tile_size_k_vec = 32;
   const uint32_t sub_tile_count = WorkgroupSizeX() / tile_size_k_vec;
   return WGSL_TEMPLATE_APPLY(shader, "bert/flash_attention_decode_qkv.wgsl.template",
                              WGSL_TEMPLATE_PARAMETER(compressed_head_size_u32, compressed_head_size_u32_),
@@ -365,7 +365,7 @@ Status ComputeFlashAttentionDecodeQKV(onnxruntime::webgpu::ComputeContext& conte
   } else {
     program.SetDispatchGroupSize(parameters.batch_size_ * parameters.num_heads_ * ((parameters.sequence_length_ + m_tile - 1) / m_tile) * num_total_seq_length_tile);
   }
-  program.SetWorkgroupSize(64)
+  program.SetWorkgroupSize(128)
       .CacheHint(tile_size, head_size_vec, has_attention_bias, use_indirect_dispatch, q_BNSH, is_unidirectional, m_tile, use_seqlen_k, turbo_quant, compressed_head_size_u32)
       .AddUniformVariables({{static_cast<uint32_t>(vectorized_head_size)},
                             {static_cast<uint32_t>(parameters.total_sequence_length_)},


### PR DESCRIPTION
## Summary

- Bump `FlashAttentionDecodeQKVProgram` workgroup size from 64 to 128.
- Bump `tile_size_k_vec` from 8 to 32.
- `sub_tile_count` is derived from `WorkgroupSizeX() / tile_size_k_vec`, so it goes from 8 to 4 automatically. The shader template expresses all loops in terms of these parameters, so no shader-side changes are needed.

## Motivation

`FlashAttentionDecodeQKVProgram` was dispatching with a smaller workgroup / tile_size_k_vec than `MatMulNBitsProgram` on the same class of hardware. Mirroring the MatMulNBits dispatch shape improves occupancy and reduces the per-call cost of the fused QK^T + softmax + V multiply step during token generation.

Measured on Qwen3-1.7B-graph-prune (WebGPU EP, D3D12, decode):

| Metric | Before | After |
|---|---|---|
| `GroupQueryAttention\|FlashAttentionDecodeQKV` per-call GPU time | 0.83 ms | 0.47 ms |
| Token generation throughput | 257 tps | 282 tps |

## Test plan

- [x] Built ORT with WebGPU EP (Release, D3D12) on Windows.
- [x] `onnxruntime_provider_test.exe --gtest_filter="GroupQueryAttentionTest.*"` — 52 passed, 12 CUDA-only tests skipped. All WebGPU FlashAttention paths pass, including `BatchedRightPaddedRotaryPrefillFlashAttention_WebGPU`, `BatchedRightPaddedRotaryPrefillFlashAttentionLargeSpread_WebGPU`, and `WebGPU_SharedKV_*` variants.
- [x] End-to-end correctness on Qwen3-1.7B-graph-prune (decode).
- [x] Profiled Qwen3-1.7B-graph-prune with the WebGPU profiling pipeline; confirmed the per-op time improvement above.