### PR TITLE
[CUDA] Fix fpA_intB internal test build: typed nullptr for TryMatMulNBits bias

### DIFF
--- a/onnxruntime/test/contrib_ops/cuda_kernels/fpA_intB_gemm_kernel_test.cc
+++ b/onnxruntime/test/contrib_ops/cuda_kernels/fpA_intB_gemm_kernel_test.cc
@@ -478,7 +478,7 @@ class KernelTestFixture : public ::testing::Test {
                                                          reinterpret_cast<const uint8_t*>(d_weight_->data()),
                                                          reinterpret_cast<const AType*>(d_scales_->data()),
                                                          static_cast<const uint8_t*>(d_uint8_zeros.data()),
-                                                         nullptr,
+                                                         static_cast<const AType*>(nullptr),
                                                          m_, n_, k_, block_size_, device_prop_.sharedMemPerBlock, s_);
             },
             warmup_, repeats_, s_);


### PR DESCRIPTION
### Description

Fixes a build break in the internal CUDA-EP unit-test module (`onnxruntime_ENABLE_CUDA_EP_INTERNAL_TESTS=ON`).

`TryMatMulNBits` in `matmul_nbits.cuh` is a function template:

```cpp
template <class T>
bool TryMatMulNBits(int bits, T* output, const T* a_data, const uint8_t* b_data_quant,
                    const T* scales_data, const uint8_t* zero_points, const T* bias_data,
                    int m, int n, int k, int block_size, size_t shared_mem_per_block, cudaStream_t stream);
```

The MoE router bias fusion change (#29170) added the `const T* bias_data` parameter. The internal CUDA-EP test `fpA_intB_gemm_kernel_test.cc` calls this with a bare `nullptr` for `bias_data`. Since `nullptr` has type `std::nullptr_t` (not a pointer), it fails to match `const T*` during template argument deduction, even though `T` is deducible from the other arguments. GCC reports:

```
error: no matching function for call to 'TryMatMulNBits(...)'
note:   mismatched types 'const T*' and 'std::nullptr_t'
```

This is compiled only when `onnxruntime_ENABLE_CUDA_EP_INTERNAL_TESTS=ON`, so the internal CUDA-EP unit-test build leg is currently broken on main.

### Key Changes

- Cast the `bias_data` argument at the call site to `static_cast<const AType*>(nullptr)` so `T` deduces correctly and the existing no-bias path is exercised unchanged.

### Motivation and Context

Restores the ability to build and run the internal CUDA-EP unit tests (e.g. `./onnxruntime_provider_test --gtest_filter=CUDA_EP_Unittest.*`).

### Validation

- Reproduced the exact "no matching function / mismatched types 'const T*' and 'std::nullptr_t'" deduction failure with a minimal template repro; confirmed the typed-nullptr cast compiles cleanly.