### PR TITLE
Follow standard CMake semantics for CUDA architecture suffixes

### DIFF
--- a/cmake/external/cuda_configuration.cmake
+++ b/cmake/external/cuda_configuration.cmake
@@ -83,7 +83,9 @@ macro(setup_cuda_architectures)
   #  * A suffix-less architecture (e.g. `86`) enables BOTH `86-real` (SASS) and `86-virtual` (PTX).
   #  * A `-real` architecture is kept real only, and a `-virtual` architecture is kept virtual only.
   #    Every `-virtual` entry embeds its own PTX (the whole list is preserved, not just the last one).
-  #  * Always use accelerated (`-a` suffix) target for supported real and virtual architectures (SM >= 90).
+  #  * Supported real (SASS) architectures (SM >= 90) use the accelerated (`-a` suffix) target for
+  #    features like WGMMA and TMA. Virtual (PTX) architectures keep the user-specified variant so the
+  #    embedded PTX stays forward compatible on newer GPUs.
   # cmake-format: on
 
   # Allow override via CUDAARCHS environment variable (standard CMake variable)
@@ -147,7 +149,7 @@ macro(setup_cuda_architectures)
 
     if(CUDA_ARCH MATCHES "^(([1-9])([0-9])+[af]?)-virtual$")
       list(APPEND CMAKE_CUDA_ARCHITECTURES_VIRTUAL_CLEAN ${CMAKE_MATCH_1})
-    elseif(CUDA_ARCH MATCHES "^(([1-9])([0-9])+)[af]?-real$")
+    elseif(CUDA_ARCH MATCHES "^(([1-9])([0-9])+[af]?)-real$")
       list(APPEND CMAKE_CUDA_ARCHITECTURES_REAL_CLEAN ${CMAKE_MATCH_1})
     elseif(CUDA_ARCH MATCHES "^(([1-9])([0-9])+)([af]?)$")
       # Suffix-less architecture: standard CMake enables both real (SASS) and virtual (PTX).
@@ -226,12 +228,14 @@ macro(setup_cuda_architectures)
     if(CUDA_ARCH MATCHES "^([0-9]+)f$")
       # Family code, no -virtual suffix
       list(APPEND CMAKE_CUDA_ARCHITECTURES_NORMALIZED "${CUDA_ARCH}")
-    elseif("${CUDA_ARCH}" IN_LIST ARCHITECTURES_WITH_ACCEL)
-      list(APPEND CMAKE_CUDA_ARCHITECTURES_NORMALIZED "${CUDA_ARCH}a-virtual")
     else()
+      # Keep the user-specified virtual arch and do not force the accelerated `a` suffix:
+      # `Na-virtual` PTX is not forward compatible, while `N-virtual` PTX JITs onto newer GPUs.
       list(APPEND CMAKE_CUDA_ARCHITECTURES_NORMALIZED "${CUDA_ARCH}-virtual")
     endif()
   endforeach()
+
+  list(REMOVE_DUPLICATES CMAKE_CUDA_ARCHITECTURES_NORMALIZED)
 
   set(CMAKE_CUDA_ARCHITECTURES ${CMAKE_CUDA_ARCHITECTURES_NORMALIZED})
 

--- a/cmake/external/cuda_configuration.cmake
+++ b/cmake/external/cuda_configuration.cmake
@@ -79,10 +79,11 @@ macro(setup_cuda_architectures)
   # Special values:
   # (1) `native` is resolved to HIGHEST available architecture. Fallback to `all` if detection failed.
   # (2) `all` / `all-major` / unset is resolved to a default set of architectures we optimized and compiler supports.
-  # Numerical architectures:
-  #  * For `-virtual` architectures, the last one is kept as it is, and the others are ignored.
-  #  * `-real` suffix is automatically added for other cases.
-  #  * Always use accelerated (`-a` suffix) target for supported real architectures.
+  # Numerical architectures follow standard CMake semantics:
+  #  * A suffix-less architecture (e.g. `86`) enables BOTH `86-real` (SASS) and `86-virtual` (PTX).
+  #  * A `-real` architecture is kept real only, and a `-virtual` architecture is kept virtual only.
+  #    Every `-virtual` entry embeds its own PTX (the whole list is preserved, not just the last one).
+  #  * Always use accelerated (`-a` suffix) target for supported real and virtual architectures (SM >= 90).
   # cmake-format: on
 
   # Allow override via CUDAARCHS environment variable (standard CMake variable)
@@ -137,28 +138,33 @@ macro(setup_cuda_architectures)
     endif()
   endif()
 
-  unset(CMAKE_CUDA_ARCHITECTURES_CLEAN)
-  unset(CMAKE_CUDA_ARCHITECTURES_LAST_VIRTUAL)
+  unset(CMAKE_CUDA_ARCHITECTURES_REAL_CLEAN)
+  unset(CMAKE_CUDA_ARCHITECTURES_VIRTUAL_CLEAN)
   foreach(CUDA_ARCH IN LISTS CMAKE_CUDA_ARCHITECTURES)
     if(CUDA_ARCH STREQUAL "")
       continue()
     endif()
 
-    if(CUDA_ARCH MATCHES "^([1-9])([0-9])+[af]?-virtual$")
-      set(CMAKE_CUDA_ARCHITECTURES_LAST_VIRTUAL ${CUDA_ARCH})
+    if(CUDA_ARCH MATCHES "^(([1-9])([0-9])+[af]?)-virtual$")
+      list(APPEND CMAKE_CUDA_ARCHITECTURES_VIRTUAL_CLEAN ${CMAKE_MATCH_1})
     elseif(CUDA_ARCH MATCHES "^(([1-9])([0-9])+)[af]?-real$")
-      list(APPEND CMAKE_CUDA_ARCHITECTURES_CLEAN ${CMAKE_MATCH_1})
+      list(APPEND CMAKE_CUDA_ARCHITECTURES_REAL_CLEAN ${CMAKE_MATCH_1})
     elseif(CUDA_ARCH MATCHES "^(([1-9])([0-9])+)([af]?)$")
-      list(APPEND CMAKE_CUDA_ARCHITECTURES_CLEAN ${CMAKE_MATCH_1}${CMAKE_MATCH_4})
+      # Suffix-less architecture: standard CMake enables both real (SASS) and virtual (PTX).
+      list(APPEND CMAKE_CUDA_ARCHITECTURES_REAL_CLEAN ${CMAKE_MATCH_1}${CMAKE_MATCH_4})
+      list(APPEND CMAKE_CUDA_ARCHITECTURES_VIRTUAL_CLEAN ${CMAKE_MATCH_1}${CMAKE_MATCH_4})
     else()
       message(FATAL_ERROR "Unrecognized CUDA architecture: ${CUDA_ARCH}")
     endif()
   endforeach()
-  list(REMOVE_DUPLICATES CMAKE_CUDA_ARCHITECTURES_CLEAN)
-  set(CMAKE_CUDA_ARCHITECTURES ${CMAKE_CUDA_ARCHITECTURES_CLEAN})
+  list(REMOVE_DUPLICATES CMAKE_CUDA_ARCHITECTURES_REAL_CLEAN)
+  list(REMOVE_DUPLICATES CMAKE_CUDA_ARCHITECTURES_VIRTUAL_CLEAN)
+  set(CMAKE_CUDA_ARCHITECTURES ${CMAKE_CUDA_ARCHITECTURES_REAL_CLEAN})
 
   # CMAKE_CUDA_ARCHITECTURES_ORIG contains all architectures enabled, without automatically added -real or -a suffix.
-  set(CMAKE_CUDA_ARCHITECTURES_ORIG "${CMAKE_CUDA_ARCHITECTURES}")
+  set(CMAKE_CUDA_ARCHITECTURES_ORIG "${CMAKE_CUDA_ARCHITECTURES_REAL_CLEAN}")
+  list(APPEND CMAKE_CUDA_ARCHITECTURES_ORIG ${CMAKE_CUDA_ARCHITECTURES_VIRTUAL_CLEAN})
+  list(REMOVE_DUPLICATES CMAKE_CUDA_ARCHITECTURES_ORIG)
   message(STATUS "GPU architectures: ${CMAKE_CUDA_ARCHITECTURES_ORIG}")
 
   unset(ORT_HAS_SM80_OR_LATER)
@@ -205,7 +211,7 @@ macro(setup_cuda_architectures)
   # Enable accelerated features (like WGMMA, TMA and setmaxnreg) for SM >= 90.
   set(ARCHITECTURES_WITH_ACCEL "90" "100" "101" "110" "120")
   unset(CMAKE_CUDA_ARCHITECTURES_NORMALIZED)
-  foreach(CUDA_ARCH IN LISTS CMAKE_CUDA_ARCHITECTURES)
+  foreach(CUDA_ARCH IN LISTS CMAKE_CUDA_ARCHITECTURES_REAL_CLEAN)
     if(CUDA_ARCH MATCHES "^([0-9]+)f$")
       # Family code, no -real suffix
       list(APPEND CMAKE_CUDA_ARCHITECTURES_NORMALIZED "${CUDA_ARCH}")
@@ -216,9 +222,16 @@ macro(setup_cuda_architectures)
     endif()
   endforeach()
 
-  if(DEFINED CMAKE_CUDA_ARCHITECTURES_LAST_VIRTUAL)
-    list(APPEND CMAKE_CUDA_ARCHITECTURES_NORMALIZED "${CMAKE_CUDA_ARCHITECTURES_LAST_VIRTUAL}")
-  endif()
+  foreach(CUDA_ARCH IN LISTS CMAKE_CUDA_ARCHITECTURES_VIRTUAL_CLEAN)
+    if(CUDA_ARCH MATCHES "^([0-9]+)f$")
+      # Family code, no -virtual suffix
+      list(APPEND CMAKE_CUDA_ARCHITECTURES_NORMALIZED "${CUDA_ARCH}")
+    elseif("${CUDA_ARCH}" IN_LIST ARCHITECTURES_WITH_ACCEL)
+      list(APPEND CMAKE_CUDA_ARCHITECTURES_NORMALIZED "${CUDA_ARCH}a-virtual")
+    else()
+      list(APPEND CMAKE_CUDA_ARCHITECTURES_NORMALIZED "${CUDA_ARCH}-virtual")
+    endif()
+  endforeach()
 
   set(CMAKE_CUDA_ARCHITECTURES ${CMAKE_CUDA_ARCHITECTURES_NORMALIZED})
 


### PR DESCRIPTION
### Description

`setup_cuda_architectures` in `cmake/external/cuda_configuration.cmake` was non-standard in two ways (#29598): only the last `-virtual` entry was kept, so `86-virtual;120-virtual` dropped PTX for 8.6; and a suffix-less arch like `86` became `86-real` only, dropping its virtual arch.

This tracks real and virtual architectures in separate lists. A suffix-less arch enables both (standard CMake: `86` gives `86-real` and `86-virtual`), `-real`/`-virtual` entries are kept as given, and all `-virtual` entries are preserved. The accelerated `a` and family-code `f` handling apply to both, and `CMAKE_CUDA_ARCHITECTURES_ORIG` is the deduplicated union.

### Motivation and Context

Fixes #29598. Thanks @cschreib-ibex for the reference patch; this builds on it, fixing that its `-virtual` regex only matched even digit counts (so `100-virtual`/`120-virtual` fatal-errored) and predated the `f` family branch. Verified the list logic with a `cmake -P` harness; nvcc compilation should be confirmed by CI.