### PR TITLE
Skip MinLength logits processor construction when eos_token_id is negative

### DIFF
--- a/onnxruntime/contrib_ops/cpu/transformers/logits_processor.h
+++ b/onnxruntime/contrib_ops/cpu/transformers/logits_processor.h
@@ -332,8 +332,9 @@ class LogitsProcessorList : public ILogitsProcessorList {
       processor_list_.push_back(prefix_vocab_mask_processor_.get());
     }
 
-    // Skip when eos_token_id is the "no eos" sentinel (negative): there is no valid token to
-    // demote, so the processor would be a no-op. Matches the conditional-add style used above.
+    // For a negative "no eos" sentinel there is no token to demote, so a MinLength processor here
+    // would be a guaranteed no-op (SetScore ignores negative token ids). Skip constructing it as a
+    // defensive, minor performance optimization, consistent with the other conditional-adds above.
     if (parameters.min_length > 0 && parameters.eos_token_id >= 0) {
       min_length_processor_ = std::make_unique<MinLengthLogitsProcessor<float>>(parameters.min_length,
                                                                                 parameters.eos_token_id);

--- a/onnxruntime/contrib_ops/cpu/transformers/logits_processor.h
+++ b/onnxruntime/contrib_ops/cpu/transformers/logits_processor.h
@@ -332,7 +332,9 @@ class LogitsProcessorList : public ILogitsProcessorList {
       processor_list_.push_back(prefix_vocab_mask_processor_.get());
     }
 
-    if (parameters.min_length > 0) {
+    // Skip when eos_token_id is the "no eos" sentinel (negative): there is no valid token to
+    // demote, so the processor would be a no-op. Matches the conditional-add style used above.
+    if (parameters.min_length > 0 && parameters.eos_token_id >= 0) {
       min_length_processor_ = std::make_unique<MinLengthLogitsProcessor<float>>(parameters.min_length,
                                                                                 parameters.eos_token_id);
       processor_list_.push_back(min_length_processor_.get());

--- a/onnxruntime/test/contrib_ops/min_length_logits_processor_test.cc
+++ b/onnxruntime/test/contrib_ops/min_length_logits_processor_test.cc
@@ -34,6 +34,22 @@ class FixedLengthSequences : public ISequences {
 constexpr int kBatchBeamSize = 2;
 constexpr int kVocabSize = 4;
 
+// Builds a minimal GreedySearchParameters that activates only the MinLength processor path, so the
+// list-level construction guard at the Init call site is the sole observable behavior.
+GreedySearchParameters MakeMinLengthOnlyParameters(int min_length, int eos_token_id) {
+  GreedySearchParameters parameters;
+  parameters.model_type = IGenerationParameters::kModelTypeGpt;
+  parameters.logits_processor = 0;
+  parameters.eos_token_id = eos_token_id;
+  parameters.min_length = min_length;
+  parameters.no_repeat_ngram_size = 0;
+  parameters.repetition_penalty = 1.0f;    // 1.0 means no penalty, so that processor is skipped
+  parameters.temperature = 0.0f;           // <= 0 skips the temperature processor
+  parameters.batch_size = kBatchBeamSize;  // GreedySearchParameters::BatchBeamSize() == batch_size
+  parameters.vocab_size = kVocabSize;
+  return parameters;
+}
+
 }  // namespace
 
 // A negative eos_token_id is the "no eos" sentinel used by greedy/sampling models. The processor
@@ -89,6 +105,52 @@ TEST(MinLengthLogitsProcessorTest, ValidEosTokenIdAtMinLengthLeavesScoresUnchang
 
   for (float value : scores) {
     EXPECT_FLOAT_EQ(value, 1.0f);
+  }
+}
+
+// The construction guard at the Init call site must skip the MinLength processor when eos_token_id is
+// the negative "no eos" sentinel. Running the list over a below-min-length sequence therefore leaves
+// all scores unchanged, because no MinLength processor was ever added to the list. This directly
+// covers the list-level guard rather than the SetScore runtime backstop.
+TEST(MinLengthLogitsProcessorTest, ListInitSkipsProcessorForNegativeEosTokenId) {
+  GreedySearchParameters parameters = MakeMinLengthOnlyParameters(/*min_length=*/5, /*eos_token_id=*/-1);
+  LogitsProcessorList processor_list;
+  processor_list.Init(parameters);
+
+  std::vector<float> scores(kBatchBeamSize * kVocabSize, 1.0f);
+  gsl::span<float> scores_span(scores);
+  FixedLengthSequences sequences(/*sequence_length=*/1);  // below min_length
+  processor_list.Process(&sequences, scores_span, /*step=*/1);
+
+  for (float value : scores) {
+    EXPECT_FLOAT_EQ(value, 1.0f);
+  }
+}
+
+// Positive control: with a valid eos_token_id the Init call site does add the MinLength processor, so
+// the same below-min-length run demotes the eos score. This proves the unchanged-scores result above
+// is caused by the guard skipping construction, not by an otherwise inert list.
+TEST(MinLengthLogitsProcessorTest, ListInitAddsProcessorForValidEosTokenId) {
+  constexpr int kEosTokenId = 2;
+  GreedySearchParameters parameters = MakeMinLengthOnlyParameters(/*min_length=*/5, kEosTokenId);
+  LogitsProcessorList processor_list;
+  processor_list.Init(parameters);
+
+  std::vector<float> scores(kBatchBeamSize * kVocabSize, 1.0f);
+  gsl::span<float> scores_span(scores);
+  FixedLengthSequences sequences(/*sequence_length=*/1);  // below min_length
+  processor_list.Process(&sequences, scores_span, /*step=*/1);
+
+  const float lowest = std::numeric_limits<float>::lowest();
+  for (int beam = 0; beam < kBatchBeamSize; ++beam) {
+    for (int token = 0; token < kVocabSize; ++token) {
+      const float value = scores[static_cast<size_t>(beam) * kVocabSize + token];
+      if (token == kEosTokenId) {
+        EXPECT_FLOAT_EQ(value, lowest);
+      } else {
+        EXPECT_FLOAT_EQ(value, 1.0f);
+      }
+    }
   }
 }
 

--- a/onnxruntime/test/contrib_ops/min_length_logits_processor_test.cc
+++ b/onnxruntime/test/contrib_ops/min_length_logits_processor_test.cc
@@ -15,8 +15,8 @@ namespace test {
 
 namespace {
 
-// Minimal ISequences stub reporting a fixed sequence length. MinLengthLogitsProcessor only reads
-// GetSequenceLength(); the device/sequence accessors are unused on this path and return empty spans.
+// Minimal ISequences stub reporting a fixed sequence length. The MinLength path only reads
+// GetSequenceLength(); the device/sequence accessors are unused here and return empty spans.
 class FixedLengthSequences : public ISequences {
  public:
   explicit FixedLengthSequences(int sequence_length) : sequence_length_(sequence_length) {}
@@ -52,56 +52,14 @@ GreedySearchParameters MakeMinLengthOnlyParameters(int min_length, int eos_token
 
 }  // namespace
 
-// A negative eos_token_id is the "no eos" sentinel used by greedy/sampling models. The processor
-// must be a no-op and must never index scores with a negative token id.
-TEST(MinLengthLogitsProcessorTest, NegativeEosTokenIdIsNoOp) {
+// Backstop: SetScore ignores a negative token id, which is the "no eos" sentinel. This guards the
+// runtime path against indexing scores with a negative token id even if a processor is reached.
+TEST(MinLengthLogitsProcessorTest, SetScoreIgnoresNegativeTokenId) {
   std::vector<float> scores(kBatchBeamSize * kVocabSize, 1.0f);
   gsl::span<float> scores_span(scores);
   NextTokenScores<float> next_token_scores{scores_span, kBatchBeamSize, kVocabSize};
 
-  FixedLengthSequences sequences(/*sequence_length=*/1);  // below min_length: eos would be demoted
-  MinLengthLogitsProcessor<float> processor(/*min_length=*/5, /*eos_token_id=*/-1);
-  processor.Process(&sequences, next_token_scores);
-
-  for (float value : scores) {
-    EXPECT_FLOAT_EQ(value, 1.0f);
-  }
-}
-
-// With a valid eos_token_id and a sequence shorter than min_length, the eos score is demoted so
-// generation cannot stop early. This locks in the enforcement behavior (no regression).
-TEST(MinLengthLogitsProcessorTest, ValidEosTokenIdBelowMinLengthDemotesEos) {
-  std::vector<float> scores(kBatchBeamSize * kVocabSize, 1.0f);
-  gsl::span<float> scores_span(scores);
-  NextTokenScores<float> next_token_scores{scores_span, kBatchBeamSize, kVocabSize};
-
-  constexpr int kEosTokenId = 2;
-  FixedLengthSequences sequences(/*sequence_length=*/1);
-  MinLengthLogitsProcessor<float> processor(/*min_length=*/5, kEosTokenId);
-  processor.Process(&sequences, next_token_scores);
-
-  const float lowest = std::numeric_limits<float>::lowest();
-  for (int beam = 0; beam < kBatchBeamSize; ++beam) {
-    for (int token = 0; token < kVocabSize; ++token) {
-      const float value = scores[static_cast<size_t>(beam) * kVocabSize + token];
-      if (token == kEosTokenId) {
-        EXPECT_FLOAT_EQ(value, lowest);
-      } else {
-        EXPECT_FLOAT_EQ(value, 1.0f);
-      }
-    }
-  }
-}
-
-// Once the sequence reaches min_length, the eos score is left untouched even for a valid eos id.
-TEST(MinLengthLogitsProcessorTest, ValidEosTokenIdAtMinLengthLeavesScoresUnchanged) {
-  std::vector<float> scores(kBatchBeamSize * kVocabSize, 1.0f);
-  gsl::span<float> scores_span(scores);
-  NextTokenScores<float> next_token_scores{scores_span, kBatchBeamSize, kVocabSize};
-
-  FixedLengthSequences sequences(/*sequence_length=*/5);  // == min_length: no demotion expected
-  MinLengthLogitsProcessor<float> processor(/*min_length=*/5, /*eos_token_id=*/2);
-  processor.Process(&sequences, next_token_scores);
+  next_token_scores.SetScore(/*token_id=*/-1, std::numeric_limits<float>::lowest());
 
   for (float value : scores) {
     EXPECT_FLOAT_EQ(value, 1.0f);
@@ -110,8 +68,7 @@ TEST(MinLengthLogitsProcessorTest, ValidEosTokenIdAtMinLengthLeavesScoresUnchang
 
 // The construction guard at the Init call site must skip the MinLength processor when eos_token_id is
 // the negative "no eos" sentinel. Running the list over a below-min-length sequence therefore leaves
-// all scores unchanged, because no MinLength processor was ever added to the list. This directly
-// covers the list-level guard rather than the SetScore runtime backstop.
+// all scores unchanged, because no MinLength processor was ever added to the list.
 TEST(MinLengthLogitsProcessorTest, ListInitSkipsProcessorForNegativeEosTokenId) {
   GreedySearchParameters parameters = MakeMinLengthOnlyParameters(/*min_length=*/5, /*eos_token_id=*/-1);
   LogitsProcessorList processor_list;
@@ -130,7 +87,7 @@ TEST(MinLengthLogitsProcessorTest, ListInitSkipsProcessorForNegativeEosTokenId) 
 // Positive control: with a valid eos_token_id the Init call site does add the MinLength processor, so
 // the same below-min-length run demotes the eos score. This proves the unchanged-scores result above
 // is caused by the guard skipping construction, not by an otherwise inert list.
-TEST(MinLengthLogitsProcessorTest, ListInitAddsProcessorForValidEosTokenId) {
+TEST(MinLengthLogitsProcessorTest, ListInitDemotesEosBelowMinLength) {
   constexpr int kEosTokenId = 2;
   GreedySearchParameters parameters = MakeMinLengthOnlyParameters(/*min_length=*/5, kEosTokenId);
   LogitsProcessorList processor_list;
@@ -151,6 +108,24 @@ TEST(MinLengthLogitsProcessorTest, ListInitAddsProcessorForValidEosTokenId) {
         EXPECT_FLOAT_EQ(value, 1.0f);
       }
     }
+  }
+}
+
+// Once the sequence reaches min_length, a valid eos score is left untouched: min_length is no longer
+// enforced. This locks in the boundary behavior and confirms the guard change is limited to the
+// negative-sentinel case (no regression for valid eos ids).
+TEST(MinLengthLogitsProcessorTest, ListInitLeavesScoresUnchangedAtMinLength) {
+  GreedySearchParameters parameters = MakeMinLengthOnlyParameters(/*min_length=*/5, /*eos_token_id=*/2);
+  LogitsProcessorList processor_list;
+  processor_list.Init(parameters);
+
+  std::vector<float> scores(kBatchBeamSize * kVocabSize, 1.0f);
+  gsl::span<float> scores_span(scores);
+  FixedLengthSequences sequences(/*sequence_length=*/5);  // == min_length: no demotion expected
+  processor_list.Process(&sequences, scores_span, /*step=*/1);
+
+  for (float value : scores) {
+    EXPECT_FLOAT_EQ(value, 1.0f);
   }
 }
 

--- a/onnxruntime/test/contrib_ops/min_length_logits_processor_test.cc
+++ b/onnxruntime/test/contrib_ops/min_length_logits_processor_test.cc
@@ -35,9 +35,9 @@ constexpr int kBatchBeamSize = 2;
 constexpr int kVocabSize = 4;
 
 // Builds a minimal GreedySearchParameters that activates only the MinLength processor path, so the
-// list-level construction guard at the Init call site is the sole observable behavior.
+// list-level tests exercise the MinLength construction condition without other processors interfering.
 GreedySearchParameters MakeMinLengthOnlyParameters(int min_length, int eos_token_id) {
-  GreedySearchParameters parameters;
+  GreedySearchParameters parameters{};
   parameters.model_type = IGenerationParameters::kModelTypeGpt;
   parameters.logits_processor = 0;
   parameters.eos_token_id = eos_token_id;
@@ -66,9 +66,10 @@ TEST(MinLengthLogitsProcessorTest, SetScoreIgnoresNegativeTokenId) {
   }
 }
 
-// The construction guard at the Init call site must skip the MinLength processor when eos_token_id is
-// the negative "no eos" sentinel. Running the list over a below-min-length sequence therefore leaves
-// all scores unchanged, because no MinLength processor was ever added to the list.
+// With a negative "no eos" sentinel there is no token to demote, so the Init guard skips constructing
+// the MinLength processor as a guaranteed no-op (a defensive/performance skip). The scores would be
+// unchanged here regardless, because SetScore also ignores a negative token id; the enforcement path
+// itself is covered by the eos >= 0 positive-control test below.
 TEST(MinLengthLogitsProcessorTest, ListInitSkipsProcessorForNegativeEosTokenId) {
   GreedySearchParameters parameters = MakeMinLengthOnlyParameters(/*min_length=*/5, /*eos_token_id=*/-1);
   LogitsProcessorList processor_list;
@@ -84,9 +85,9 @@ TEST(MinLengthLogitsProcessorTest, ListInitSkipsProcessorForNegativeEosTokenId) 
   }
 }
 
-// Positive control: with a valid eos_token_id the Init call site does add the MinLength processor, so
-// the same below-min-length run demotes the eos score. This proves the unchanged-scores result above
-// is caused by the guard skipping construction, not by an otherwise inert list.
+// Enforcement path: with a valid eos_token_id the Init call site adds the MinLength processor, so a
+// below-min-length run demotes the eos score. This is the discriminating test for the eos >= 0 branch
+// of the guard and for the min-length enforcement behavior.
 TEST(MinLengthLogitsProcessorTest, ListInitDemotesEosBelowMinLength) {
   constexpr int kEosTokenId = 2;
   GreedySearchParameters parameters = MakeMinLengthOnlyParameters(/*min_length=*/5, kEosTokenId);

--- a/onnxruntime/test/contrib_ops/min_length_logits_processor_test.cc
+++ b/onnxruntime/test/contrib_ops/min_length_logits_processor_test.cc
@@ -1,0 +1,98 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <limits>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include <gsl/gsl>
+#include "contrib_ops/cpu/transformers/logits_processor.h"
+
+namespace onnxruntime {
+namespace contrib {
+namespace transformers {
+namespace test {
+
+namespace {
+
+// Minimal ISequences stub reporting a fixed sequence length. MinLengthLogitsProcessor only reads
+// GetSequenceLength(); the device/sequence accessors are unused on this path and return empty spans.
+class FixedLengthSequences : public ISequences {
+ public:
+  explicit FixedLengthSequences(int sequence_length) : sequence_length_(sequence_length) {}
+
+  gsl::span<const int32_t> GetSequence(int /*beam_index*/) const override { return {}; }
+  gsl::span<const int32_t> GetCurrentDeviceSequences() const override { return {}; }
+  gsl::span<int32_t> GetNextDeviceSequences() override { return {}; }
+  int GetSequenceLength() const override { return sequence_length_; }
+  int GetMaxLength() const override { return sequence_length_; }
+
+ private:
+  int sequence_length_;
+};
+
+constexpr int kBatchBeamSize = 2;
+constexpr int kVocabSize = 4;
+
+}  // namespace
+
+// A negative eos_token_id is the "no eos" sentinel used by greedy/sampling models. The processor
+// must be a no-op and must never index scores with a negative token id.
+TEST(MinLengthLogitsProcessorTest, NegativeEosTokenIdIsNoOp) {
+  std::vector<float> scores(kBatchBeamSize * kVocabSize, 1.0f);
+  gsl::span<float> scores_span(scores);
+  NextTokenScores<float> next_token_scores{scores_span, kBatchBeamSize, kVocabSize};
+
+  FixedLengthSequences sequences(/*sequence_length=*/1);  // below min_length: eos would be demoted
+  MinLengthLogitsProcessor<float> processor(/*min_length=*/5, /*eos_token_id=*/-1);
+  processor.Process(&sequences, next_token_scores);
+
+  for (float value : scores) {
+    EXPECT_FLOAT_EQ(value, 1.0f);
+  }
+}
+
+// With a valid eos_token_id and a sequence shorter than min_length, the eos score is demoted so
+// generation cannot stop early. This locks in the enforcement behavior (no regression).
+TEST(MinLengthLogitsProcessorTest, ValidEosTokenIdBelowMinLengthDemotesEos) {
+  std::vector<float> scores(kBatchBeamSize * kVocabSize, 1.0f);
+  gsl::span<float> scores_span(scores);
+  NextTokenScores<float> next_token_scores{scores_span, kBatchBeamSize, kVocabSize};
+
+  constexpr int kEosTokenId = 2;
+  FixedLengthSequences sequences(/*sequence_length=*/1);
+  MinLengthLogitsProcessor<float> processor(/*min_length=*/5, kEosTokenId);
+  processor.Process(&sequences, next_token_scores);
+
+  const float lowest = std::numeric_limits<float>::lowest();
+  for (int beam = 0; beam < kBatchBeamSize; ++beam) {
+    for (int token = 0; token < kVocabSize; ++token) {
+      const float value = scores[static_cast<size_t>(beam) * kVocabSize + token];
+      if (token == kEosTokenId) {
+        EXPECT_FLOAT_EQ(value, lowest);
+      } else {
+        EXPECT_FLOAT_EQ(value, 1.0f);
+      }
+    }
+  }
+}
+
+// Once the sequence reaches min_length, the eos score is left untouched even for a valid eos id.
+TEST(MinLengthLogitsProcessorTest, ValidEosTokenIdAtMinLengthLeavesScoresUnchanged) {
+  std::vector<float> scores(kBatchBeamSize * kVocabSize, 1.0f);
+  gsl::span<float> scores_span(scores);
+  NextTokenScores<float> next_token_scores{scores_span, kBatchBeamSize, kVocabSize};
+
+  FixedLengthSequences sequences(/*sequence_length=*/5);  // == min_length: no demotion expected
+  MinLengthLogitsProcessor<float> processor(/*min_length=*/5, /*eos_token_id=*/2);
+  processor.Process(&sequences, next_token_scores);
+
+  for (float value : scores) {
+    EXPECT_FLOAT_EQ(value, 1.0f);
+  }
+}
+
+}  // namespace test
+}  // namespace transformers
+}  // namespace contrib
+}  // namespace onnxruntime


### PR DESCRIPTION
### What

Skip constructing the `MinLengthLogitsProcessor` when `eos_token_id` is negative.

A negative `eos_token_id` is the "no-EOS" sentinel used by greedy/sampling
generation (it defaults to `-1`). With no EOS token there is nothing to demote,
so a MinLength processor built with a negative eos can only ever be a guaranteed
no-op. This change guards its construction at the list level in
`LogitsProcessorInitImpl` (`logits_processor.h`), so we do not build a processor
that would do nothing.

```cpp
if (parameters.min_length > 0 && parameters.eos_token_id >= 0) {
  ...  // add MinLength processor
}
```

### Why

This is a small **defense-in-depth / code-clarity** improvement, not a behavior
change and not a correctness or security fix:

- For a valid `eos_token_id >= 0`, behavior is unchanged — the processor is
  still constructed and enforces the minimum length exactly as before.
- For a negative eos, the added guard skips a processor that would be a no-op
  anyway (`SetScore` already ignores negative token ids), so this is a minor
  performance and clarity optimization.
- It mirrors the existing conditional-adds in the same function (e.g.
  `RepetitionPenalty`), keeping the construction logic consistent.

CPU-only: the CUDA path is already inherently a no-op for a negative eos, so no
CUDA code is touched.

### Tests

Adds 4 unit tests in `min_length_logits_processor_test.cc` (run via
`onnxruntime_provider_test --gtest_filter='*MinLengthLogitsProcessorTest*'`):

- `SetScoreIgnoresNegativeTokenId` — documents the pre-existing inline backstop
  that ignores negative token ids.
- `ListInitSkipsProcessorForNegativeEosTokenId` — drives `LogitsProcessorList::Init`
  with a negative eos and confirms a below-min-length run leaves scores unchanged
  (the processor is skipped as a guaranteed no-op).
- `ListInitDemotesEosBelowMinLength` — positive control / enforcement path: with a
  valid eos the processor is constructed and demotes the eos score below min length.
- `ListInitLeavesScoresUnchangedAtMinLength` — at the min length, no demotion.

The tests only reference exported (`LogitsProcessorList::Init`/`Process`) and
header-inline symbols so they link in both static and shared-library builds.
