### PR TITLE
Handle non-finite ROI coordinates in CropAndResize

### DIFF
--- a/onnxruntime/contrib_ops/cpu/crop_and_resize.cc
+++ b/onnxruntime/contrib_ops/cpu/crop_and_resize.cc
@@ -17,16 +17,12 @@ limitations under the License.
 #include "contrib_ops/cpu/crop_and_resize.h"
 
 #include <cmath>
+#include "core/common/safeint.h"
 #include "core/util/math_cpuonly.h"
 #include "core/common/common.h"
 #include "core/framework/tensor.h"
 #include "core/platform/threadpool.h"
 #include "core/providers/cpu/object_detection/roialign.h"
-// TODO: fix the warnings
-#if defined(_MSC_VER) && !defined(__clang__)
-// Chance of arithmetic overflow could be reduced
-#pragma warning(disable : 26451)
-#endif
 using namespace onnxruntime::concurrency;
 
 namespace onnxruntime {
@@ -97,7 +93,11 @@ void CropAndResizeForward(const TensorShape& output_shape,
                                       ? roi_start_h * (height - 1)
                                       : 0.5 * (roi_start_h + roi_end_h) * (height - 1));
           }
-          if (in_y < 0 || in_y > height - 1) {
+          // Route non-finite (NaN/inf) or out-of-image coordinates to the extrapolation
+          // branch. The negated-conjunction form is NaN-safe: every comparison with NaN is
+          // false, so !(in_y >= 0 && in_y <= height - 1) is true and NaN cannot reach the
+          // integer index math below. For finite values this is identical to the < / > form.
+          if (!(in_y >= 0 && in_y <= static_cast<T>(height - 1))) {
             for (int64_t pw = 0; pw < pooled_width; pw++) {
               for (int64_t c = 0; c < channels; c++) {
                 int64_t index_n_c = index_n + c * pooled_width * pooled_height;
@@ -126,7 +126,8 @@ void CropAndResizeForward(const TensorShape& output_shape,
                                         ? roi_start_w * (width - 1)
                                         : 0.5 * (roi_start_w + roi_end_w) * (width - 1));
             }
-            if (in_x < 0 || in_x > width - 1) {
+            // NaN-safe bounds guard (see the in_y guard above for rationale).
+            if (!(in_x >= 0 && in_x <= static_cast<T>(width - 1))) {
               for (int64_t c = 0; c < channels; c++) {
                 int64_t index_n_c = index_n + c * pooled_width * pooled_height;
                 int64_t index = index_n_c + ph * pooled_width + pw;
@@ -140,16 +141,17 @@ void CropAndResizeForward(const TensorShape& output_shape,
               const int left_x_index = static_cast<int>(floorf(static_cast<float>(in_x)));
               const int right_x_index = static_cast<int>(ceilf(static_cast<float>(in_x)));
               const float x_lerp = static_cast<float>(in_x - left_x_index);
-              auto top_left_index = top_y_index * width + left_x_index;
-              auto top_right_index = top_y_index * width + right_x_index;
-              auto bottom_left_index = bottom_y_index * width + left_x_index;
-              auto bottom_right_index = bottom_y_index * width + right_x_index;
+              auto top_left_index = SafeInt<int64_t>(top_y_index) * width + left_x_index;
+              auto top_right_index = SafeInt<int64_t>(top_y_index) * width + right_x_index;
+              auto bottom_left_index = SafeInt<int64_t>(bottom_y_index) * width + left_x_index;
+              auto bottom_right_index = SafeInt<int64_t>(bottom_y_index) * width + right_x_index;
 
               for (auto c = 0; c < channels; c++) {
                 int64_t index_n_c = index_n + c * pooled_width * pooled_height;
                 int64_t index = index_n_c + ph * pooled_width + pw;
                 const T* offset_bottom_data =
-                    bottom_data + static_cast<int64_t>((roi_batch_ind * channels + c) * height * width);
+                    bottom_data +
+                    static_cast<int64_t>((SafeInt<int64_t>(roi_batch_ind) * channels + c) * height * width);
                 const float top_left(static_cast<float>(offset_bottom_data[top_left_index]));
                 const float top_right(static_cast<float>(offset_bottom_data[top_right_index]));
                 const float bottom_left(static_cast<float>(offset_bottom_data[bottom_left_index]));
@@ -162,13 +164,14 @@ void CropAndResizeForward(const TensorShape& output_shape,
             } else {  // mode == "nearest"
               const int closest_x_index = static_cast<int>(roundf(static_cast<float>(in_x)));
               const int closest_y_index = static_cast<int>(roundf(static_cast<float>(in_y)));
-              auto closest_index = closest_y_index * width + closest_x_index;
+              auto closest_index = SafeInt<int64_t>(closest_y_index) * width + closest_x_index;
 
               for (auto c = 0; c < channels; c++) {
                 int64_t index_n_c = index_n + c * pooled_width * pooled_height;
                 int64_t index = index_n_c + ph * pooled_width + pw;
                 const T* offset_bottom_data =
-                    bottom_data + static_cast<int64_t>((roi_batch_ind * channels + c) * height * width);
+                    bottom_data +
+                    static_cast<int64_t>((SafeInt<int64_t>(roi_batch_ind) * channels + c) * height * width);
                 top_data[index] = static_cast<float>(offset_bottom_data[closest_index]);
               }
             }
@@ -216,6 +219,9 @@ Status CropAndResize<T>::Compute(OpKernelContext* context) const {
   auto crop_size_data = crop_size_ptr->Data<int32_t>();
   auto crop_height = crop_size_data[0];
   auto crop_width = crop_size_data[1];
+
+  ORT_RETURN_IF_NOT(crop_height > 0 && crop_width > 0,
+                    "crop_size values must be positive; got [", crop_height, ", ", crop_width, "]");
 
   auto status = CheckROIAlignValidInput(X_ptr, rois_ptr, batch_indices_ptr);
   if (status != Status::OK()) {

--- a/onnxruntime/test/contrib_ops/crop_and_resize_op_test.cc
+++ b/onnxruntime/test/contrib_ops/crop_and_resize_op_test.cc
@@ -4,6 +4,8 @@
 #include "gtest/gtest.h"
 #include "test/providers/provider_test_utils.h"
 
+#include <limits>
+
 namespace onnxruntime {
 namespace test {
 
@@ -121,6 +123,123 @@ TEST(CropAndResizeTest, CropAndResize_1133) {
   test3.AddAttribute("mode", "nearest");
   test3.AddOutput<float>("output", {3, 1, 2, 2}, {1.1f, 3.3f, 7.7f, 9.9f, 1.1f, 2.2f, 4.4f, 5.5f, 1.1f, 3.3f, 4.4f, 6.6f});
   test3.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+}
+
+// Non-finite ROI coordinates (NaN) must route to the extrapolation branch instead of
+// reaching the integer index math, which would otherwise compute an invalid image index.
+TEST(CropAndResizeTest, CropAndResize_NaN_roi_extrapolates) {
+  const float nan = std::numeric_limits<float>::quiet_NaN();
+
+  // NaN start/end height -> in_y is NaN for every row -> whole output extrapolates.
+  OpTester test_y("CropAndResize", 1, onnxruntime::kMSDomain);
+  test_y.AddInput<float>("X", {1, 1, 2, 2}, {1.1f, 2.2f, 3.3f, 4.4f});
+  test_y.AddInput<float>("rois", {1, 4}, {nan, 0.0f, nan, 1.0f});
+  test_y.AddInput<int32_t>("batch_indices", {1}, {0});
+  test_y.AddInput<int32_t>("crop_size", {2}, {2, 2});
+  test_y.AddAttribute("extrapolation_value", 5.5f);
+  test_y.AddOutput<float>("output", {1, 1, 2, 2}, {5.5f, 5.5f, 5.5f, 5.5f});
+  test_y.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+
+  // Finite height but NaN width -> in_y is in range, in_x is NaN -> every pixel extrapolates.
+  OpTester test_x("CropAndResize", 1, onnxruntime::kMSDomain);
+  test_x.AddInput<float>("X", {1, 1, 2, 2}, {1.1f, 2.2f, 3.3f, 4.4f});
+  test_x.AddInput<float>("rois", {1, 4}, {0.0f, nan, 1.0f, nan});
+  test_x.AddInput<int32_t>("batch_indices", {1}, {0});
+  test_x.AddInput<int32_t>("crop_size", {2}, {2, 2});
+  test_x.AddAttribute("extrapolation_value", 5.5f);
+  test_x.AddOutput<float>("output", {1, 1, 2, 2}, {5.5f, 5.5f, 5.5f, 5.5f});
+  test_x.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+
+  // Same NaN-height case in nearest mode.
+  OpTester test_nearest("CropAndResize", 1, onnxruntime::kMSDomain);
+  test_nearest.AddInput<float>("X", {1, 1, 2, 2}, {1.1f, 2.2f, 3.3f, 4.4f});
+  test_nearest.AddInput<float>("rois", {1, 4}, {nan, 0.0f, nan, 1.0f});
+  test_nearest.AddInput<int32_t>("batch_indices", {1}, {0});
+  test_nearest.AddInput<int32_t>("crop_size", {2}, {2, 2});
+  test_nearest.AddAttribute("mode", "nearest");
+  test_nearest.AddAttribute("extrapolation_value", 5.5f);
+  test_nearest.AddOutput<float>("output", {1, 1, 2, 2}, {5.5f, 5.5f, 5.5f, 5.5f});
+  test_nearest.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+}
+
+// Infinite ROI coordinates must also land in the extrapolation branch.
+TEST(CropAndResizeTest, CropAndResize_Inf_roi_extrapolates) {
+  const float inf = std::numeric_limits<float>::infinity();
+
+  OpTester test_pos("CropAndResize", 1, onnxruntime::kMSDomain);
+  test_pos.AddInput<float>("X", {1, 1, 2, 2}, {1.1f, 2.2f, 3.3f, 4.4f});
+  test_pos.AddInput<float>("rois", {1, 4}, {inf, 0.0f, inf, 1.0f});
+  test_pos.AddInput<int32_t>("batch_indices", {1}, {0});
+  test_pos.AddInput<int32_t>("crop_size", {2}, {2, 2});
+  test_pos.AddAttribute("extrapolation_value", 5.5f);
+  test_pos.AddOutput<float>("output", {1, 1, 2, 2}, {5.5f, 5.5f, 5.5f, 5.5f});
+  test_pos.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+
+  OpTester test_neg("CropAndResize", 1, onnxruntime::kMSDomain);
+  test_neg.AddInput<float>("X", {1, 1, 2, 2}, {1.1f, 2.2f, 3.3f, 4.4f});
+  test_neg.AddInput<float>("rois", {1, 4}, {-inf, 0.0f, -inf, 1.0f});
+  test_neg.AddInput<int32_t>("batch_indices", {1}, {0});
+  test_neg.AddInput<int32_t>("crop_size", {2}, {2, 2});
+  test_neg.AddAttribute("extrapolation_value", 5.5f);
+  test_neg.AddOutput<float>("output", {1, 1, 2, 2}, {5.5f, 5.5f, 5.5f, 5.5f});
+  test_neg.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+}
+
+// Finite coordinates on and just outside the image boundary must behave exactly as the
+// original guard: coordinates in [0, dim-1] interpolate, coordinates just past dim-1 extrapolate.
+TEST(CropAndResizeTest, CropAndResize_finite_boundary_no_regression) {
+  // Exact boundary [0, 1] maps to the identity crop (no extrapolation at 0 or height-1).
+  OpTester test_exact("CropAndResize", 1, onnxruntime::kMSDomain);
+  test_exact.AddInput<float>("X", {1, 1, 2, 2}, {1.1f, 2.2f, 3.3f, 4.4f});
+  test_exact.AddInput<float>("rois", {1, 4}, {0.0f, 0.0f, 1.0f, 1.0f});
+  test_exact.AddInput<int32_t>("batch_indices", {1}, {0});
+  test_exact.AddInput<int32_t>("crop_size", {2}, {2, 2});
+  test_exact.AddAttribute("extrapolation_value", 9.0f);
+  test_exact.AddOutput<float>("output", {1, 1, 2, 2}, {1.1f, 2.2f, 3.3f, 4.4f});
+  test_exact.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+
+  // End just past the boundary (1.0001) extrapolates only the out-of-range row/column.
+  OpTester test_outside("CropAndResize", 1, onnxruntime::kMSDomain);
+  test_outside.AddInput<float>("X", {1, 1, 2, 2}, {1.1f, 2.2f, 3.3f, 4.4f});
+  test_outside.AddInput<float>("rois", {1, 4}, {0.0f, 0.0f, 1.0001f, 1.0001f});
+  test_outside.AddInput<int32_t>("batch_indices", {1}, {0});
+  test_outside.AddInput<int32_t>("crop_size", {2}, {2, 2});
+  test_outside.AddAttribute("extrapolation_value", 9.0f);
+  test_outside.AddOutput<float>("output", {1, 1, 2, 2}, {1.1f, 9.0f, 9.0f, 9.0f});
+  test_outside.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+}
+
+// crop_size values must be positive; non-positive crop dimensions are rejected via Status.
+TEST(CropAndResizeTest, CropAndResize_rejects_nonpositive_crop_size) {
+  OpTester test_zero("CropAndResize", 1, onnxruntime::kMSDomain);
+  test_zero.AddInput<float>("X", {1, 1, 2, 2}, {1.1f, 2.2f, 3.3f, 4.4f});
+  test_zero.AddInput<float>("rois", {1, 4}, {0.0f, 0.0f, 1.0f, 1.0f});
+  test_zero.AddInput<int32_t>("batch_indices", {1}, {0});
+  test_zero.AddInput<int32_t>("crop_size", {2}, {0, 2});
+  test_zero.AddOutput<float>("output", {1, 1, 1, 1}, {0.0f});
+  test_zero.Run(OpTester::ExpectResult::kExpectFailure,
+                "crop_size values must be positive", {kTensorrtExecutionProvider});
+
+  OpTester test_negative("CropAndResize", 1, onnxruntime::kMSDomain);
+  test_negative.AddInput<float>("X", {1, 1, 2, 2}, {1.1f, 2.2f, 3.3f, 4.4f});
+  test_negative.AddInput<float>("rois", {1, 4}, {0.0f, 0.0f, 1.0f, 1.0f});
+  test_negative.AddInput<int32_t>("batch_indices", {1}, {0});
+  test_negative.AddInput<int32_t>("crop_size", {2}, {-1, 2});
+  test_negative.AddOutput<float>("output", {1, 1, 1, 1}, {0.0f});
+  test_negative.Run(OpTester::ExpectResult::kExpectFailure,
+                    "crop_size values must be positive", {kTensorrtExecutionProvider});
+}
+
+// A batch index outside [0, batch_size) must be rejected rather than computing an invalid image index.
+TEST(CropAndResizeTest, CropAndResize_rejects_out_of_range_batch_index) {
+  OpTester test("CropAndResize", 1, onnxruntime::kMSDomain);
+  test.AddInput<float>("X", {1, 1, 2, 2}, {1.1f, 2.2f, 3.3f, 4.4f});
+  test.AddInput<float>("rois", {1, 4}, {0.0f, 0.0f, 1.0f, 1.0f});
+  test.AddInput<int32_t>("batch_indices", {1}, {5});
+  test.AddInput<int32_t>("crop_size", {2}, {2, 2});
+  test.AddOutput<float>("output", {1, 1, 2, 2}, {0.0f, 0.0f, 0.0f, 0.0f});
+  test.Run(OpTester::ExpectResult::kExpectFailure,
+           "is out of range [0, 1)", {kTensorrtExecutionProvider});
 }
 
 }  // namespace test


### PR DESCRIPTION
### Description

The `CropAndResize` CPU contrib op (`com.microsoft::CropAndResize`) computes bilinear/nearest interpolation indices from the ROI box coordinates. The bounds guards were written as `if (in_y < 0 || in_y > height - 1)` / `if (in_x < 0 || in_x > width - 1)`. Because every comparison involving a NaN is false, a non-finite (NaN or ±inf) ROI coordinate slipped past both comparisons, skipped the extrapolation `continue`, and reached the integer index computation (`(int)floorf(NaN)`) with an invalid value.

This is a robustness/correctness gap: ROI coordinates are a runtime input, and non-finite values are not handled gracefully.

### Fix

- **NaN-safe bounds guards.** Rewrite both guards into negated-conjunction form: `if (!(in_y >= 0 && in_y <= height - 1))` / `if (!(in_x >= 0 && in_x <= width - 1))`. This is logically identical for all finite coordinates, but is `true` for NaN/±inf, so non-finite coordinates now take the extrapolation branch and are filled with `extrapolation_value` (matching the documented behavior for out-of-range coordinates).
- **crop_size validation.** Add a Status-based `ORT_RETURN_IF_NOT(crop_height > 0 && crop_width > 0, ...)` check in `Compute` so non-positive crop sizes are rejected with a clear error rather than producing degenerate work.
- **Index arithmetic hardening.** Use `SafeInt<int64_t>` for the interpolation index computation, which allows the now-unnecessary MSVC 26451 (arithmetic-overflow) suppression pragma to be removed.

No behavior change for valid finite ROIs. CPU-only — there is no CUDA `CropAndResize` kernel.

### Tests

Added to `onnxruntime/test/contrib_ops/crop_and_resize_op_test.cc`:

- NaN ROI coordinate → extrapolation (bilinear height, bilinear width, and nearest).
- ±inf ROI coordinate → extrapolation.
- Finite boundary values (exact `[0, 1]` identity crop and just-outside `1.0001`) — no regression.
- Non-positive `crop_size` (`{0, 2}` and `{-1, 2}`) rejected.
- Out-of-range batch index rejected.

Run with:

```
onnxruntime_provider_test --gtest_filter='CropAndResizeTest.*'
```

All 10 CropAndResize tests pass (5 new + 5 pre-existing, no regression). An AddressSanitizer build can additionally corroborate the index handling in CI.

### Motivation and Context

Handles non-finite ROI coordinates gracefully and makes the CropAndResize index arithmetic robust, consistent with how out-of-range coordinates are already treated (extrapolation).