### PR TITLE
Bump onnx to 1.22.0 and protobuf to 6.33.5 to fix security CVEs

### DIFF
--- a/onnxruntime/python/tools/transformers/models/llama/requirements.txt
+++ b/onnxruntime/python/tools/transformers/models/llama/requirements.txt
@@ -3,7 +3,7 @@ optimum>=1.14.1
 optree
 transformers==4.52.1
 torch>=2.7.0
-onnx==1.18.0
+onnx==1.22.0
 datasets>=2.8.0
-protobuf==4.25.8
+protobuf==6.33.5
 psutil

--- a/onnxruntime/python/tools/transformers/models/phi2/requirements.txt
+++ b/onnxruntime/python/tools/transformers/models/phi2/requirements.txt
@@ -1,3 +1,3 @@
-onnx==1.18.0
+onnx==1.22.0
 transformers>=4.36.2
 onnxscript>=0.1.0.dev20240126


### PR DESCRIPTION
Update pinned dependencies in the llama and phi2 transformer model requirements to their patched versions, clearing the flagged 1ES Component Governance alerts.

Package changes:
- onnx: 1.18.0 -> 1.22.0 (llama, phi2)
- protobuf: 4.25.8 -> 6.33.5 (llama)

onnx 1.18.0 -> 1.22.0 (patched in 1.21.0) resolves:
- CVE-2026-27489: path traversal via symlink (arbitrary file read)
- CVE-2026-34445: unsafe setattr in ExternalDataInfo (object property overwrite via crafted model)
- CVE-2026-28500: onnx.hub.load() trust-check bypass via silent=True
- GHSA-q56x-g2fj-4rj6: TOCTOU arbitrary file read/write in save_external_data

protobuf 4.25.8 -> 6.33.5 resolves:
- CVE-2026-0994: recursion-depth bypass in json_format.ParseDict() causing DoS (no fix in the 4.25.x line; patched in 5.29.6 / 6.33.5)

Versions align with the onnx==1.22.0 / protobuf==6.33.5 pairing already used across the repo's CI and transformers-test requirements.

Files:
- onnxruntime/python/tools/transformers/models/llama/requirements.txt
- onnxruntime/python/tools/transformers/models/phi2/requirements.txt