### PR TITLE
[MLAS] Add AVX2 (+VNNI) 2-bit weight CPU kernels

### DIFF
--- a/cmake/onnxruntime_mlas.cmake
+++ b/cmake/onnxruntime_mlas.cmake
@@ -871,13 +871,13 @@ endif()
         )
         set_source_files_properties(${mlas_platform_srcs_avx512core} PROPERTIES COMPILE_FLAGS "-mfma -mavx512vnni -mavx512bw -mavx512dq -mavx512vl")
 
-        # Strip -mavx512vnni from the W2 scalar oracle / pack-helper TU so the
-        # compiler cannot autovectorize its int8 dot-product loops to vpdpbusd.
-        # Needed because this helper runs at model load on AVX-512-only
-        # (non-VNNI) hosts via the AVX-512 W2 dispatch. TU is pure C++ -- no
-        # AVX-512 intrinsics inside.
+        # Build the W2 scalar oracle / pack-helper TU without any AVX-512
+        # flags so the compiler cannot autovectorize its scalar loops into
+        # EVEX instructions. This helper runs at model load on AVX-512-only
+        # (non-VNNI) hosts via the AVX-512 W2 dispatch and on AVX2-only hosts
+        # via the AVX2 W2 dispatch. TU is pure C++ -- no intrinsics inside.
         set_source_files_properties(${MLAS_SRC_DIR}/sqnbitgemm_kernel_avx512_2bit.cpp PROPERTIES
-          COMPILE_FLAGS "-mfma -mavx512bw -mavx512dq -mavx512vl")
+          COMPILE_FLAGS "")
 
         set(mlas_platform_srcs_avx512vnni
           ${MLAS_SRC_DIR}/sqnbitgemm_kernel_avx512vnni.cpp

--- a/cmake/onnxruntime_mlas.cmake
+++ b/cmake/onnxruntime_mlas.cmake
@@ -871,11 +871,13 @@ endif()
         )
         set_source_files_properties(${mlas_platform_srcs_avx512core} PROPERTIES COMPILE_FLAGS "-mfma -mavx512vnni -mavx512bw -mavx512dq -mavx512vl")
 
-        # Build the W2 scalar oracle / pack-helper TU without any AVX-512
-        # flags so the compiler cannot autovectorize its scalar loops into
-        # EVEX instructions. This helper runs at model load on AVX-512-only
-        # (non-VNNI) hosts via the AVX-512 W2 dispatch and on AVX2-only hosts
-        # via the AVX2 W2 dispatch. TU is pure C++ -- no intrinsics inside.
+        # NOTE: this TU is intrinsic-free scalar helpers reached from both the
+        # AVX2 and AVX-512 W2 dispatch tables at model load. Flags must not
+        # enable any ISA the AVX2-only host lacks, or the compiler may
+        # autovectorize the scalar loops into EVEX instructions and SIGILL.
+        # If the AVX-512 W2 pack ever becomes a perf hot spot, split this
+        # file: keep the scalar pack in a flag-less TU and put an optimized
+        # variant in a separate one only used by the AVX-512 tables.
         set_source_files_properties(${MLAS_SRC_DIR}/sqnbitgemm_kernel_avx512_2bit.cpp PROPERTIES
           COMPILE_FLAGS "")
 

--- a/onnxruntime/core/mlas/lib/sqnbitgemm_kernel_avx2.cpp
+++ b/onnxruntime/core/mlas/lib/sqnbitgemm_kernel_avx2.cpp
@@ -26,6 +26,11 @@ Abstract:
 #include "sqnbitgemm_kernel_avx2_int8_blklen32.h"
 #include "sqnbitgemm_kernel_avx2_int8_blklen64.h"
 
+#include "sqnbitgemm_kernel_avx2_2bit.h"
+#include "sqnbitgemm_kernel_avx2_2bit_blklen32.h"
+#include "sqnbitgemm_kernel_avx2_2bit_blklen64.h"
+#include "sqnbitgemm_kernel_avx2_2bit_blklen128.h"
+
 #include "sqnbitgemm_m1_sym_kernel_avx2_int8_blklen32.h"
 #include "sqnbitgemm_m1_sym_kernel_avx2_int8_blklen64.h"
 
@@ -1440,6 +1445,80 @@ SQ8BitGemmPackQuantBDataAndBlkSum(
 }
 
 //
+// BlkLen-routing wrappers for the W2 CompInt8 AVX2 / AVX2-VNNI dispatch
+// entries. Production code reaches these via the MLAS dispatch table; tests
+// call them directly via the namespace. Siblings of the AVX-512 variants in
+// sqnbitgemm_kernel_avx512.cpp / sqnbitgemm_kernel_avx512vnni.cpp.
+//
+namespace onnxruntime::mlas::sq2bit_avx2 {
+size_t MLASCALL
+SQ2BitGemmKernel_BlkSum_CompInt8_Avx2_Dispatch(
+    size_t BlkLen,
+    const std::byte* QuantA,
+    const float* QuantAScale,
+    const std::byte* QuantBData,
+    const float* QuantBScale,
+    const std::byte* QuantBZeroPoint,
+    float* C,
+    size_t CountM,
+    size_t CountN,
+    size_t CountK,
+    size_t BlockCountK,
+    const float* Bias,
+    size_t ldc,
+    const float* ABlockSum,
+    const float* QuantBBlkSum)
+{
+    if (BlkLen == 128) {
+        return SQ2BitGemmKernel_BlkSum_CompInt8_BlkLen128_Avx2(
+            QuantA, QuantAScale, QuantBData, QuantBScale,
+            C, CountM, CountN, BlockCountK, Bias, ldc, ABlockSum, QuantBBlkSum);
+    }
+    if (BlkLen == 32) {
+        return SQ2BitGemmKernel_BlkSum_CompInt8_BlkLen32_Avx2(
+            QuantA, QuantAScale, QuantBData, QuantBScale,
+            C, CountM, CountN, BlockCountK, Bias, ldc, ABlockSum, QuantBBlkSum);
+    }
+    return SQ2BitGemmKernel_BlkSum_CompInt8_Avx2(
+        BlkLen, QuantA, QuantAScale, QuantBData, QuantBScale, QuantBZeroPoint,
+        C, CountM, CountN, CountK, BlockCountK, Bias, ldc, ABlockSum, QuantBBlkSum);
+}
+
+size_t MLASCALL
+SQ2BitGemmKernel_BlkSum_CompInt8_Avx2Vnni_Dispatch(
+    size_t BlkLen,
+    const std::byte* QuantA,
+    const float* QuantAScale,
+    const std::byte* QuantBData,
+    const float* QuantBScale,
+    const std::byte* QuantBZeroPoint,
+    float* C,
+    size_t CountM,
+    size_t CountN,
+    size_t CountK,
+    size_t BlockCountK,
+    const float* Bias,
+    size_t ldc,
+    const float* ABlockSum,
+    const float* QuantBBlkSum)
+{
+    if (BlkLen == 128) {
+        return SQ2BitGemmKernel_BlkSum_CompInt8_BlkLen128_Avx2Vnni(
+            QuantA, QuantAScale, QuantBData, QuantBScale,
+            C, CountM, CountN, BlockCountK, Bias, ldc, ABlockSum, QuantBBlkSum);
+    }
+    if (BlkLen == 32) {
+        return SQ2BitGemmKernel_BlkSum_CompInt8_BlkLen32_Avx2Vnni(
+            QuantA, QuantAScale, QuantBData, QuantBScale,
+            C, CountM, CountN, BlockCountK, Bias, ldc, ABlockSum, QuantBBlkSum);
+    }
+    return SQ2BitGemmKernel_BlkSum_CompInt8_Avx2Vnni(
+        BlkLen, QuantA, QuantAScale, QuantBData, QuantBScale, QuantBZeroPoint,
+        C, CountM, CountN, CountK, BlockCountK, Bias, ldc, ABlockSum, QuantBBlkSum);
+}
+}  // namespace onnxruntime::mlas::sq2bit_avx2
+
+//
 // Kernel dispatch structure definition.
 //
 const MLAS_QNBIT_GEMM_DISPATCH MlasSQNBitGemmDispatchAvx2 = []() {
@@ -1460,6 +1539,20 @@ const MLAS_QNBIT_GEMM_DISPATCH MlasSQNBitGemmDispatchAvx2 = []() {
     d.SQ4BitGemmKernel_BlkSum_CompInt8 = SQ4BitGemmKernel_BlkSum_CompInt8_avx2;
     d.SQ8BitGemmKernel_BlkSum_CompInt8 = SQ8BitGemmKernel_BlkSum_CompInt8_avx2<false>;
     d.QuantizeARowComputeBlkSum_CompInt8 = QuantizeARow_CompInt8_avx2;
+
+    // 2-bit native CompInt8 path. Reuses the portable block-group packer and
+    // effective-K helper (shared with AVX-512); the AVX2 kernel supplies the
+    // 256-bit compute. QuantizeARow above already provides the signed-int8 A
+    // layout the W2 path consumes.
+    static_assert(
+        onnxruntime::mlas::sq2bit_avx512::kBlockGroupBlks == kSq2BitAvx512WeightKBlockGroup,
+        "kBlockGroupBlks (kernel-internal) must match kSq2BitAvx512WeightKBlockGroup (qnbitgemm.h).");
+    d.Q2BitGemmPackQuantBDataSize       = onnxruntime::mlas::sq2bit_avx512::Q2BitGemmPackQuantBDataSize_Avx512;
+    d.SQ2BitGemmPackQuantBDataAndBlkSum = onnxruntime::mlas::sq2bit_avx512::SQ2BitGemmPackQuantBDataAndBlkSum_Scalar;
+    d.SQ2BitGemmKernel_BlkSum_CompInt8  = onnxruntime::mlas::sq2bit_avx2::SQ2BitGemmKernel_BlkSum_CompInt8_Avx2_Dispatch;
+    d.Q2BitGemmEffectiveBlockCountK     = [](size_t BlockCountK) {
+        return MlasDivRoundup(BlockCountK, kSq2BitAvx512WeightKBlockGroup) * kSq2BitAvx512WeightKBlockGroup;
+    };
 
     return d;
 }();
@@ -1482,6 +1575,17 @@ const MLAS_QNBIT_GEMM_DISPATCH MlasSQNBitGemmDispatchAvx2vnni = []() {
     d.SQ4BitGemmKernel_BlkSum_CompInt8 = SQ4BitGemmKernel_BlkSum_CompInt8_avx2vnni;
     d.SQ8BitGemmKernel_BlkSum_CompInt8 = SQ8BitGemmKernel_BlkSum_CompInt8_avx2<true>;
     d.QuantizeARowComputeBlkSum_CompInt8 = QuantizeARow_CompInt8_avx2;
+
+    // 2-bit native CompInt8 path (AVX-VNNI compute). See the AVX2 table above.
+    static_assert(
+        onnxruntime::mlas::sq2bit_avx512::kBlockGroupBlks == kSq2BitAvx512WeightKBlockGroup,
+        "kBlockGroupBlks (kernel-internal) must match kSq2BitAvx512WeightKBlockGroup (qnbitgemm.h).");
+    d.Q2BitGemmPackQuantBDataSize       = onnxruntime::mlas::sq2bit_avx512::Q2BitGemmPackQuantBDataSize_Avx512;
+    d.SQ2BitGemmPackQuantBDataAndBlkSum = onnxruntime::mlas::sq2bit_avx512::SQ2BitGemmPackQuantBDataAndBlkSum_Scalar;
+    d.SQ2BitGemmKernel_BlkSum_CompInt8  = onnxruntime::mlas::sq2bit_avx2::SQ2BitGemmKernel_BlkSum_CompInt8_Avx2Vnni_Dispatch;
+    d.Q2BitGemmEffectiveBlockCountK     = [](size_t BlockCountK) {
+        return MlasDivRoundup(BlockCountK, kSq2BitAvx512WeightKBlockGroup) * kSq2BitAvx512WeightKBlockGroup;
+    };
 
     return d;
 }();

--- a/onnxruntime/core/mlas/lib/sqnbitgemm_kernel_avx2.cpp
+++ b/onnxruntime/core/mlas/lib/sqnbitgemm_kernel_avx2.cpp
@@ -26,6 +26,7 @@ Abstract:
 #include "sqnbitgemm_kernel_avx2_int8_blklen32.h"
 #include "sqnbitgemm_kernel_avx2_int8_blklen64.h"
 
+#include "sqnbitgemm_kernel_avx512_2bit.h"
 #include "sqnbitgemm_kernel_avx2_2bit.h"
 #include "sqnbitgemm_kernel_avx2_2bit_blklen32.h"
 #include "sqnbitgemm_kernel_avx2_2bit_blklen64.h"
@@ -1550,9 +1551,7 @@ const MLAS_QNBIT_GEMM_DISPATCH MlasSQNBitGemmDispatchAvx2 = []() {
     d.Q2BitGemmPackQuantBDataSize       = onnxruntime::mlas::sq2bit_avx512::Q2BitGemmPackQuantBDataSize_Avx512;
     d.SQ2BitGemmPackQuantBDataAndBlkSum = onnxruntime::mlas::sq2bit_avx512::SQ2BitGemmPackQuantBDataAndBlkSum_Scalar;
     d.SQ2BitGemmKernel_BlkSum_CompInt8  = onnxruntime::mlas::sq2bit_avx2::SQ2BitGemmKernel_BlkSum_CompInt8_Avx2_Dispatch;
-    d.Q2BitGemmEffectiveBlockCountK     = [](size_t BlockCountK) {
-        return MlasDivRoundup(BlockCountK, kSq2BitAvx512WeightKBlockGroup) * kSq2BitAvx512WeightKBlockGroup;
-    };
+    d.Q2BitGemmEffectiveBlockCountK     = onnxruntime::mlas::sq2bit_avx512::Q2BitGemmEffectiveBlockCountK;
 
     return d;
 }();
@@ -1583,9 +1582,7 @@ const MLAS_QNBIT_GEMM_DISPATCH MlasSQNBitGemmDispatchAvx2vnni = []() {
     d.Q2BitGemmPackQuantBDataSize       = onnxruntime::mlas::sq2bit_avx512::Q2BitGemmPackQuantBDataSize_Avx512;
     d.SQ2BitGemmPackQuantBDataAndBlkSum = onnxruntime::mlas::sq2bit_avx512::SQ2BitGemmPackQuantBDataAndBlkSum_Scalar;
     d.SQ2BitGemmKernel_BlkSum_CompInt8  = onnxruntime::mlas::sq2bit_avx2::SQ2BitGemmKernel_BlkSum_CompInt8_Avx2Vnni_Dispatch;
-    d.Q2BitGemmEffectiveBlockCountK     = [](size_t BlockCountK) {
-        return MlasDivRoundup(BlockCountK, kSq2BitAvx512WeightKBlockGroup) * kSq2BitAvx512WeightKBlockGroup;
-    };
+    d.Q2BitGemmEffectiveBlockCountK     = onnxruntime::mlas::sq2bit_avx512::Q2BitGemmEffectiveBlockCountK;
 
     return d;
 }();

--- a/onnxruntime/core/mlas/lib/sqnbitgemm_kernel_avx2_2bit.h
+++ b/onnxruntime/core/mlas/lib/sqnbitgemm_kernel_avx2_2bit.h
@@ -1,0 +1,72 @@
+/*++
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the MIT License.
+
+Module Name:
+
+    sqnbitgemm_kernel_avx2_2bit.h
+
+Abstract:
+
+    Declarations for the AVX2 / AVX2-VNNI W2 CompInt8 BlkLen-routing dispatch
+    forwarders. The forwarders are defined in sqnbitgemm_kernel_avx2.cpp and the
+    per-BlkLen kernels live in sqnbitgemm_kernel_avx2_2bit_blklen{32,64,128}.h.
+    Declared here so the dispatch tables and the unit tests can reference them,
+    mirroring the AVX-512 forwarder declarations in
+    sqnbitgemm_kernel_avx512_2bit.h.
+
+--*/
+
+#pragma once
+
+#include <cstddef>
+
+#include "mlas.h"
+
+namespace onnxruntime {
+namespace mlas {
+namespace sq2bit_avx2 {
+
+size_t MLASCALL
+SQ2BitGemmKernel_BlkSum_CompInt8_Avx2_Dispatch(
+    size_t BlkLen,
+    const std::byte* QuantA,
+    const float* QuantAScale,
+    const std::byte* QuantBData,
+    const float* QuantBScale,
+    const std::byte* QuantBZeroPoint,
+    float* C,
+    size_t CountM,
+    size_t CountN,
+    size_t CountK,
+    size_t BlockCountK,
+    const float* Bias,
+    size_t ldc,
+    const float* ABlockSum,
+    const float* QuantBBlkSum
+);
+
+size_t MLASCALL
+SQ2BitGemmKernel_BlkSum_CompInt8_Avx2Vnni_Dispatch(
+    size_t BlkLen,
+    const std::byte* QuantA,
+    const float* QuantAScale,
+    const std::byte* QuantBData,
+    const float* QuantBScale,
+    const std::byte* QuantBZeroPoint,
+    float* C,
+    size_t CountM,
+    size_t CountN,
+    size_t CountK,
+    size_t BlockCountK,
+    const float* Bias,
+    size_t ldc,
+    const float* ABlockSum,
+    const float* QuantBBlkSum
+);
+
+}  // namespace sq2bit_avx2
+}  // namespace mlas
+}  // namespace onnxruntime

--- a/onnxruntime/core/mlas/lib/sqnbitgemm_kernel_avx2_2bit_blklen128.h
+++ b/onnxruntime/core/mlas/lib/sqnbitgemm_kernel_avx2_2bit_blklen128.h
@@ -1,0 +1,360 @@
+/*++
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the MIT License.
+
+Module Name:
+
+    sqnbitgemm_kernel_avx2_2bit_blklen128.h
+
+Abstract:
+
+    AVX2 (-VNNI) W2 kernel for BlkLen=128, consuming the block-group packed
+    layout (sqnbitgemm_kernel_avx512_2bit.h). A 128-element K-block is four YMM
+    quarters on AVX2, so each block's dot is four chained VPDPBUSD. Preloading
+    all activations would exceed the 16-YMM file, so the accumulator loads
+    activations from a base pointer guarded by a valid-block count, which also
+    folds in the K-tail handling.
+
+    Templated on `<bool kVnni>`.
+
+--*/
+
+#pragma once
+
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+
+#include <immintrin.h>
+
+#include "mlasi.h"
+#include "qnbitgemm.h"
+#include "sqnbitgemm_kernel_avx_common.h"
+#include "sqnbitgemm_kernel_avx512_2bit.h"
+
+namespace onnxruntime {
+namespace mlas {
+namespace sq2bit_avx2 {
+
+using namespace sq2bit_avx512;
+
+// One block's dot: four 32-lane quarters summed into one int32 vector. `Shift`
+// selects the 2-bit field (0/2/4/6) for block {0,1,2,3}.
+template <bool kVnni, int Shift>
+static MLAS_FORCEINLINE __m256i
+dot_one_block_w2_blklen128(
+    const __m256i& g0, const __m256i& g1, const __m256i& g2, const __m256i& g3,
+    const __m256i& m03, const std::byte* a_blk)
+{
+    const __m256i b0 = _mm256_and_si256(_mm256_srli_epi16(g0, Shift), m03);
+    const __m256i b1 = _mm256_and_si256(_mm256_srli_epi16(g1, Shift), m03);
+    const __m256i b2 = _mm256_and_si256(_mm256_srli_epi16(g2, Shift), m03);
+    const __m256i b3 = _mm256_and_si256(_mm256_srli_epi16(g3, Shift), m03);
+    const __m256i a0 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(a_blk + 0));
+    const __m256i a1 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(a_blk + 32));
+    const __m256i a2 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(a_blk + 64));
+    const __m256i a3 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(a_blk + 96));
+#if !defined(__GNUC__) || (__GNUC__ > 10)
+    if constexpr (kVnni) {
+        __m256i d = _mm256_dpbusds_avx_epi32(_mm256_setzero_si256(), b0, a0);
+        d = _mm256_dpbusds_avx_epi32(d, b1, a1);
+        d = _mm256_dpbusds_avx_epi32(d, b2, a2);
+        d = _mm256_dpbusds_avx_epi32(d, b3, a3);
+        return d;
+    } else
+#endif
+    {
+        const __m256i ones = _mm256_set1_epi16(1);
+        __m256i d = _mm256_madd_epi16(_mm256_maddubs_epi16(b0, a0), ones);
+        d = _mm256_add_epi32(d, _mm256_madd_epi16(_mm256_maddubs_epi16(b1, a1), ones));
+        d = _mm256_add_epi32(d, _mm256_madd_epi16(_mm256_maddubs_epi16(b2, a2), ones));
+        d = _mm256_add_epi32(d, _mm256_madd_epi16(_mm256_maddubs_epi16(b3, a3), ones));
+        return d;
+    }
+}
+
+//
+// acc += sum_{k<nblk} scale_a[k]*scale_b[k] * dot128(a_base + k*128, block k).
+// nblk is 4 for a full group or 1..3 for the K-tail; a_base blocks at k >= nblk
+// are never loaded and their scale_a is 0.
+//
+template <bool kVnni>
+static MLAS_FORCEINLINE void
+accumulate_w2_blklen128_r1c1blk4(
+    const std::byte* a_base, size_t nblk,
+    const std::byte* QuantBDataPtr,
+    const float* scale_a, const float* scale_b, __m256& acc)
+{
+    const __m256i g0 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(QuantBDataPtr + 0));
+    const __m256i g1 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(QuantBDataPtr + 32));
+    const __m256i g2 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(QuantBDataPtr + 64));
+    const __m256i g3 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(QuantBDataPtr + 96));
+    const __m256i m03 = _mm256_set1_epi8(0x03);
+    const __m256i zeroi = _mm256_setzero_si256();
+
+    const __m256i d0 = dot_one_block_w2_blklen128<kVnni, 0>(g0, g1, g2, g3, m03, a_base + 0 * kBlkLen128);
+    const __m256i d1 =
+        (nblk > 1) ? dot_one_block_w2_blklen128<kVnni, 2>(g0, g1, g2, g3, m03, a_base + 1 * kBlkLen128) : zeroi;
+    const __m256i d2 =
+        (nblk > 2) ? dot_one_block_w2_blklen128<kVnni, 4>(g0, g1, g2, g3, m03, a_base + 2 * kBlkLen128) : zeroi;
+    const __m256i d3 =
+        (nblk > 3) ? dot_one_block_w2_blklen128<kVnni, 6>(g0, g1, g2, g3, m03, a_base + 3 * kBlkLen128) : zeroi;
+
+    const __m256 s0 = _mm256_set1_ps(scale_a[0] * scale_b[0]);
+    const __m256 s1 = _mm256_set1_ps(scale_a[1] * scale_b[1]);
+    const __m256 s2 = _mm256_set1_ps(scale_a[2] * scale_b[2]);
+    const __m256 s3 = _mm256_set1_ps(scale_a[3] * scale_b[3]);
+
+    __m256 acc_lo = _mm256_mul_ps(_mm256_cvtepi32_ps(d0), s0);
+    __m256 acc_hi = _mm256_mul_ps(_mm256_cvtepi32_ps(d1), s1);
+    acc_lo = _mm256_fmadd_ps(_mm256_cvtepi32_ps(d2), s2, acc_lo);
+    acc_hi = _mm256_fmadd_ps(_mm256_cvtepi32_ps(d3), s3, acc_hi);
+    acc = _mm256_add_ps(acc, _mm256_add_ps(acc_lo, acc_hi));
+}
+
+template <bool kVnni>
+MLAS_FORCEINLINE void
+Q2Int8GemmR1xC4BlkLen128Avx2(
+    const std::byte* QuantA,
+    const float* QuantAScale,
+    const std::byte* QuantBData,
+    const float* QuantBScale,
+    float* C,
+    size_t CountM,
+    size_t CountN,
+    size_t BlockCountK,
+    const float* Bias,
+    size_t ldc)
+{
+    const size_t lda = BlockCountK * kBlkLen128;
+    constexpr size_t PerColGroupBytes = kBlockGroupBytes128;
+    constexpr size_t PerColGroupScale = kBlockGroupBlks;
+    constexpr size_t PerKGroupAdvanceBytes = kNCols4 * PerColGroupBytes;
+    constexpr size_t PerKGroupAdvanceScale = kNCols4 * PerColGroupScale;
+    const size_t BlockGroupCountKPadded = MlasDivRoundup(BlockCountK, kBlockGroupBlks);
+    const size_t BlockCountKPadded = BlockGroupCountKPadded * kBlockGroupBlks;
+    const size_t GroupStrideBytes = BlockCountKPadded * kNCols4 * kBlkBytes128;
+    const size_t GroupStrideScale = BlockCountKPadded * kNCols4;
+
+    assert(CountN % kNCols4 == 0);
+    const size_t FullGroups = BlockCountK / kBlockGroupBlks;
+    const size_t TailBlocks = BlockCountK % kBlockGroupBlks;
+
+    for (size_t m = 0; m < CountM; ++m) {
+        const std::byte* QuantBDataColPtr = QuantBData;
+        const float* QuantBScaleColPtr = QuantBScale;
+        const float* BiasPtr = Bias;
+        float* SumPtr = C + m * ldc;
+
+        for (size_t n = 0; n < CountN; n += kNCols4) {
+            const std::byte* QuantAPtr = QuantA + m * lda;
+            const float* QuantAScalePtr = QuantAScale + m * BlockCountK;
+            const std::byte* QuantBDataPtr = QuantBDataColPtr;
+            const float* QuantBScalePtr = QuantBScaleColPtr;
+
+            __m256 acc[kNCols4] = {
+                _mm256_setzero_ps(), _mm256_setzero_ps(),
+                _mm256_setzero_ps(), _mm256_setzero_ps()
+            };
+
+            for (size_t sb = 0; sb < FullGroups; ++sb) {
+                for (size_t c = 0; c < kNCols4; ++c) {
+                    accumulate_w2_blklen128_r1c1blk4<kVnni>(
+                        QuantAPtr, kBlockGroupBlks,
+                        QuantBDataPtr + c * PerColGroupBytes,
+                        QuantAScalePtr, QuantBScalePtr + c * PerColGroupScale, acc[c]);
+                }
+                QuantAPtr += kBlkLen128 * kBlockGroupBlks;
+                QuantAScalePtr += kBlockGroupBlks;
+                QuantBDataPtr += PerKGroupAdvanceBytes;
+                QuantBScalePtr += PerKGroupAdvanceScale;
+            }
+
+            if (TailBlocks > 0) {
+                float scale_a_safe[kBlockGroupBlks] = {0.0f, 0.0f, 0.0f, 0.0f};
+                for (size_t i = 0; i < TailBlocks; ++i) scale_a_safe[i] = QuantAScalePtr[i];
+                for (size_t c = 0; c < kNCols4; ++c) {
+                    accumulate_w2_blklen128_r1c1blk4<kVnni>(
+                        QuantAPtr, TailBlocks,
+                        QuantBDataPtr + c * PerColGroupBytes,
+                        scale_a_safe, QuantBScalePtr + c * PerColGroupScale, acc[c]);
+                }
+            }
+
+            SumPtr[0] = hsum_float_8(acc[0]);
+            SumPtr[1] = hsum_float_8(acc[1]);
+            SumPtr[2] = hsum_float_8(acc[2]);
+            SumPtr[3] = hsum_float_8(acc[3]);
+            if (BiasPtr != nullptr) {
+                SumPtr[0] += BiasPtr[0];
+                SumPtr[1] += BiasPtr[1];
+                SumPtr[2] += BiasPtr[2];
+                SumPtr[3] += BiasPtr[3];
+            }
+
+            QuantBDataColPtr += GroupStrideBytes;
+            QuantBScaleColPtr += GroupStrideScale;
+            BiasPtr += BiasPtr != nullptr ? kNCols4 : 0;
+            SumPtr += kNCols4;
+        }
+    }
+}
+
+template <bool kVnni>
+MLAS_FORCEINLINE void
+Q2Int8GemmRMxC_Tail_BlkLen128Avx2(
+    const std::byte* QuantA,
+    const float* QuantAScale,
+    const std::byte* QuantBDataTail,
+    const float* QuantBScaleTail,
+    float* C,
+    size_t CountM,
+    size_t TailN,
+    size_t BlockCountK,
+    const float* BiasTail,
+    size_t ldc)
+{
+    assert(TailN >= 1 && TailN <= 3);
+    const size_t lda = BlockCountK * kBlkLen128;
+    const size_t BlockGroupCountKPadded = MlasDivRoundup(BlockCountK, kBlockGroupBlks);
+    const size_t FullGroups = BlockCountK / kBlockGroupBlks;
+    const size_t TailBlocks = BlockCountK % kBlockGroupBlks;
+    const size_t ColStrideBytes = BlockGroupCountKPadded * kBlockGroupBytes128;
+    const size_t ColStrideScale = BlockGroupCountKPadded * kBlockGroupBlks;
+
+    for (size_t m = 0; m < CountM; ++m) {
+        for (size_t c = 0; c < TailN; ++c) {
+            const std::byte* QuantAPtr = QuantA + m * lda;
+            const float* QuantAScalePtr = QuantAScale + m * BlockCountK;
+            const std::byte* QuantBDataPtr = QuantBDataTail + c * ColStrideBytes;
+            const float* QuantBScalePtr = QuantBScaleTail + c * ColStrideScale;
+
+            __m256 acc = _mm256_setzero_ps();
+
+            for (size_t sb = 0; sb < FullGroups; ++sb) {
+                accumulate_w2_blklen128_r1c1blk4<kVnni>(
+                    QuantAPtr, kBlockGroupBlks, QuantBDataPtr, QuantAScalePtr, QuantBScalePtr, acc);
+                QuantAPtr += kBlkLen128 * kBlockGroupBlks;
+                QuantAScalePtr += kBlockGroupBlks;
+                QuantBDataPtr += kBlockGroupBytes128;
+                QuantBScalePtr += kBlockGroupBlks;
+            }
+
+            if (TailBlocks > 0) {
+                float scale_a_safe[kBlockGroupBlks] = {0.0f, 0.0f, 0.0f, 0.0f};
+                for (size_t i = 0; i < TailBlocks; ++i) scale_a_safe[i] = QuantAScalePtr[i];
+                accumulate_w2_blklen128_r1c1blk4<kVnni>(
+                    QuantAPtr, TailBlocks, QuantBDataPtr, scale_a_safe, QuantBScalePtr, acc);
+            }
+
+            float v = hsum_float_8(acc);
+            if (BiasTail != nullptr) v += BiasTail[c];
+            C[m * ldc + c] = v;
+        }
+    }
+}
+
+template <bool kVnni>
+static MLAS_FORCEINLINE size_t
+SQ2BitGemmKernel_BlkSum_CompInt8_BlkLen128_Impl(
+    const std::byte* QuantA,
+    const float* QuantAScale,
+    const std::byte* QuantBData,
+    const float* QuantBScale,
+    float* C,
+    size_t CountM,
+    size_t CountN,
+    size_t BlockCountK,
+    const float* Bias,
+    size_t ldc,
+    const float* ABlockSum,
+    const float* QuantBBlkSum)
+{
+    if (BlockCountK == 0 || CountM == 0 || CountN == 0) {
+        return 0;
+    }
+
+    const size_t NMain = (CountN / kNCols4) * kNCols4;
+    const size_t NTail = CountN - NMain;
+
+    if (NMain > 0) {
+        Q2Int8GemmR1xC4BlkLen128Avx2<kVnni>(
+            QuantA, QuantAScale, QuantBData, QuantBScale,
+            C, CountM, NMain, BlockCountK, Bias, ldc);
+    }
+
+    if (NTail > 0) {
+        const size_t BlockGroupCountKPadded = MlasDivRoundup(BlockCountK, kBlockGroupBlks);
+        const std::byte* QuantBDataTail =
+            QuantBData + NMain * BlockGroupCountKPadded * kBlockGroupBytes128;
+        const float* QuantBScaleTail =
+            QuantBScale + NMain * BlockGroupCountKPadded * kBlockGroupBlks;
+        const float* BiasTail = (Bias != nullptr) ? Bias + NMain : nullptr;
+
+        Q2Int8GemmRMxC_Tail_BlkLen128Avx2<kVnni>(
+            QuantA, QuantAScale, QuantBDataTail, QuantBScaleTail,
+            C + NMain, CountM, NTail, BlockCountK, BiasTail, ldc);
+    }
+
+    float* c_blk = C;
+    const float* b_blk_sum = QuantBBlkSum;
+    size_t RowsRemaining = CountM;
+    const float* a_blksum_row = ABlockSum;
+    while (RowsRemaining > 0) {
+        const auto RowsHandled = GetMlasPlatform().GemmFloatKernel(
+            a_blksum_row, b_blk_sum, c_blk,
+            BlockCountK, RowsRemaining, CountN, BlockCountK, ldc,
+            1.0f, /*ZeroMode=*/false);
+
+        c_blk += ldc * RowsHandled;
+        a_blksum_row += BlockCountK * RowsHandled;
+        RowsRemaining -= RowsHandled;
+    }
+    return CountM;
+}
+
+static MLAS_FORCEINLINE size_t MLASCALL
+SQ2BitGemmKernel_BlkSum_CompInt8_BlkLen128_Avx2Vnni(
+    const std::byte* QuantA,
+    const float* QuantAScale,
+    const std::byte* QuantBData,
+    const float* QuantBScale,
+    float* C,
+    size_t CountM,
+    size_t CountN,
+    size_t BlockCountK,
+    const float* Bias,
+    size_t ldc,
+    const float* ABlockSum,
+    const float* QuantBBlkSum)
+{
+    return SQ2BitGemmKernel_BlkSum_CompInt8_BlkLen128_Impl<true>(
+        QuantA, QuantAScale, QuantBData, QuantBScale,
+        C, CountM, CountN, BlockCountK, Bias, ldc, ABlockSum, QuantBBlkSum);
+}
+
+static MLAS_FORCEINLINE size_t MLASCALL
+SQ2BitGemmKernel_BlkSum_CompInt8_BlkLen128_Avx2(
+    const std::byte* QuantA,
+    const float* QuantAScale,
+    const std::byte* QuantBData,
+    const float* QuantBScale,
+    float* C,
+    size_t CountM,
+    size_t CountN,
+    size_t BlockCountK,
+    const float* Bias,
+    size_t ldc,
+    const float* ABlockSum,
+    const float* QuantBBlkSum)
+{
+    return SQ2BitGemmKernel_BlkSum_CompInt8_BlkLen128_Impl<false>(
+        QuantA, QuantAScale, QuantBData, QuantBScale,
+        C, CountM, CountN, BlockCountK, Bias, ldc, ABlockSum, QuantBBlkSum);
+}
+
+}  // namespace sq2bit_avx2
+}  // namespace mlas
+}  // namespace onnxruntime

--- a/onnxruntime/core/mlas/lib/sqnbitgemm_kernel_avx2_2bit_blklen128.h
+++ b/onnxruntime/core/mlas/lib/sqnbitgemm_kernel_avx2_2bit_blklen128.h
@@ -56,6 +56,8 @@ dot_one_block_w2_blklen128(
     const __m256i a1 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(a_blk + 32));
     const __m256i a2 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(a_blk + 64));
     const __m256i a3 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(a_blk + 96));
+    // GCC 11+ is needed for _mm256_dpbusds_avx_epi32; older toolchains fall
+    // through to the vpmaddubsw+vpmaddwd path even on AVX-VNNI hardware.
 #if !defined(__GNUC__) || (__GNUC__ > 10)
     if constexpr (kVnni) {
         __m256i d = _mm256_dpbusds_avx_epi32(_mm256_setzero_si256(), b0, a0);

--- a/onnxruntime/core/mlas/lib/sqnbitgemm_kernel_avx2_2bit_blklen128.h
+++ b/onnxruntime/core/mlas/lib/sqnbitgemm_kernel_avx2_2bit_blklen128.h
@@ -198,7 +198,9 @@ Q2Int8GemmR1xC4BlkLen128Avx2(
 
             QuantBDataColPtr += GroupStrideBytes;
             QuantBScaleColPtr += GroupStrideScale;
-            BiasPtr += BiasPtr != nullptr ? kNCols4 : 0;
+            if (BiasPtr != nullptr) {
+                BiasPtr += kNCols4;
+            }
             SumPtr += kNCols4;
         }
     }

--- a/onnxruntime/core/mlas/lib/sqnbitgemm_kernel_avx2_2bit_blklen32.h
+++ b/onnxruntime/core/mlas/lib/sqnbitgemm_kernel_avx2_2bit_blklen32.h
@@ -1,0 +1,619 @@
+/*++
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the MIT License.
+
+Module Name:
+
+    sqnbitgemm_kernel_avx2_2bit_blklen32.h
+
+Abstract:
+
+    AVX2 (-VNNI) W2 kernel for BlkLen=32, consuming the block-group packed
+    layout (sqnbitgemm_kernel_avx512_2bit.h). The AVX-512 BlkLen=32 kernel
+    zero-extends a 32-byte YMM group into a ZMM and runs a half-width dpbusd;
+    here the whole computation stays 256-bit, so a 32-byte block-group is one
+    YMM load + four fixed shift/mask pairs and each dpbusd uses all 8 int32
+    lanes.
+
+    Templated on `<bool kVnni>`: the VNNI variant uses `_mm256_dpbusds_avx_epi32`
+    for the integer MAC; non-VNNI uses the `vpmaddubsw + vpmaddwd` chain. Both
+    produce bit-identical results.
+
+    Constraints match the AVX-512 sibling: BlkLen == 32; no alignment
+    requirement on CountM, CountN, or BlockCountK.
+
+--*/
+
+#pragma once
+
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+
+#include <immintrin.h>
+
+#include "mlasi.h"
+#include "qnbitgemm.h"
+#include "sqnbitgemm_kernel_avx_common.h"
+#include "sqnbitgemm_kernel_avx512_2bit.h"
+
+namespace onnxruntime {
+namespace mlas {
+namespace sq2bit_avx2 {
+
+using namespace sq2bit_avx512;  // shared block-group W2 constants and pack helpers
+
+inline constexpr size_t kNRows2_BlkLen32 = 2;
+
+//
+// One YMM load + four fixed shift/AND -> 4 YMMs of 32 unsigned weights [0,3].
+// Bit layout of each byte b of `packed`:
+//   bits[0..1] = block_0.weight[b], ..., bits[6..7] = block_3.weight[b].
+//
+static MLAS_FORCEINLINE void
+load_unpack_w2_block_group_blklen32(
+    const std::byte* packed,
+    __m256i& bv0, __m256i& bv1, __m256i& bv2, __m256i& bv3)
+{
+    const __m256i group = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(packed));
+    const __m256i mask03 = _mm256_set1_epi8(0x03);
+    bv0 = _mm256_and_si256(group, mask03);
+    bv1 = _mm256_and_si256(_mm256_srli_epi16(group, 2), mask03);
+    bv2 = _mm256_and_si256(_mm256_srli_epi16(group, 4), mask03);
+    bv3 = _mm256_and_si256(_mm256_srli_epi16(group, 6), mask03);
+}
+
+static MLAS_FORCEINLINE __m256i
+load_a_blklen32(const std::byte* a_block)
+{
+    return _mm256_loadu_si256(reinterpret_cast<const __m256i*>(a_block));
+}
+
+//
+// Per single M-row, 4-K-block dot-and-accumulate. Two interleaved
+// sub-accumulators (blocks {0,2} and {1,3}) keep the per-cell FMA chain two
+// deep. Math per K-block: acc += scale_a[blk] * scale_b[blk] * dot(av, bv).
+//
+template <bool kVnni>
+static MLAS_FORCEINLINE void
+dot_accumulate_4blk_w2_blklen32(
+    const __m256i& av0, const __m256i& av1, const __m256i& av2, const __m256i& av3,
+    const __m256i& bv0, const __m256i& bv1, const __m256i& bv2, const __m256i& bv3,
+    const float* scale_a, const float* scale_b, __m256& acc)
+{
+    __m256i d0, d1, d2, d3;
+#if !defined(__GNUC__) || (__GNUC__ > 10)
+    if constexpr (kVnni) {
+        // dpbusds: 2nd operand (bv=unsigned [0,3]) x 3rd operand (av=signed int8); consistent with maddubs(bv, av)
+        d0 = _mm256_dpbusds_avx_epi32(_mm256_setzero_si256(), bv0, av0);
+        d1 = _mm256_dpbusds_avx_epi32(_mm256_setzero_si256(), bv1, av1);
+        d2 = _mm256_dpbusds_avx_epi32(_mm256_setzero_si256(), bv2, av2);
+        d3 = _mm256_dpbusds_avx_epi32(_mm256_setzero_si256(), bv3, av3);
+    } else
+#endif
+    {
+        const __m256i ones = _mm256_set1_epi16(1);
+        d0 = _mm256_madd_epi16(_mm256_maddubs_epi16(bv0, av0), ones);
+        d1 = _mm256_madd_epi16(_mm256_maddubs_epi16(bv1, av1), ones);
+        d2 = _mm256_madd_epi16(_mm256_maddubs_epi16(bv2, av2), ones);
+        d3 = _mm256_madd_epi16(_mm256_maddubs_epi16(bv3, av3), ones);
+    }
+
+    const __m256 s0 = _mm256_set1_ps(scale_a[0] * scale_b[0]);
+    const __m256 s1 = _mm256_set1_ps(scale_a[1] * scale_b[1]);
+    const __m256 s2 = _mm256_set1_ps(scale_a[2] * scale_b[2]);
+    const __m256 s3 = _mm256_set1_ps(scale_a[3] * scale_b[3]);
+
+    __m256 acc_lo = _mm256_mul_ps(_mm256_cvtepi32_ps(d0), s0);
+    __m256 acc_hi = _mm256_mul_ps(_mm256_cvtepi32_ps(d1), s1);
+    acc_lo = _mm256_fmadd_ps(_mm256_cvtepi32_ps(d2), s2, acc_lo);
+    acc_hi = _mm256_fmadd_ps(_mm256_cvtepi32_ps(d3), s3, acc_hi);
+    acc = _mm256_add_ps(acc, _mm256_add_ps(acc_lo, acc_hi));
+}
+
+template <bool kVnni>
+static MLAS_FORCEINLINE void
+accumulate_w2_blklen32_r1c1blk4(
+    const __m256i& av0, const __m256i& av1, const __m256i& av2, const __m256i& av3,
+    const std::byte* QuantBDataPtr,
+    const float* scale_a, const float* scale_b, __m256& acc)
+{
+    __m256i bv0, bv1, bv2, bv3;
+    load_unpack_w2_block_group_blklen32(QuantBDataPtr, bv0, bv1, bv2, bv3);
+    dot_accumulate_4blk_w2_blklen32<kVnni>(av0, av1, av2, av3, bv0, bv1, bv2, bv3, scale_a, scale_b, acc);
+}
+
+//
+// 2 M-rows x 1 N-col x 4 K-blocks (one block-group) accumulator. The
+// block-group B load + unpack is shared across the 2 M-rows.
+//
+template <bool kVnni>
+static MLAS_FORCEINLINE void
+accumulate_w2_blklen32_r2c1blk4(
+    const __m256i& av00, const __m256i& av01, const __m256i& av02, const __m256i& av03,
+    const __m256i& av10, const __m256i& av11, const __m256i& av12, const __m256i& av13,
+    const std::byte* QuantBDataPtr,
+    const float* scale_a0, const float* scale_a1, const float* scale_b,
+    __m256& acc0, __m256& acc1)
+{
+    __m256i bv0, bv1, bv2, bv3;
+    load_unpack_w2_block_group_blklen32(QuantBDataPtr, bv0, bv1, bv2, bv3);
+    dot_accumulate_4blk_w2_blklen32<kVnni>(av00, av01, av02, av03, bv0, bv1, bv2, bv3, scale_a0, scale_b, acc0);
+    dot_accumulate_4blk_w2_blklen32<kVnni>(av10, av11, av12, av13, bv0, bv1, bv2, bv3, scale_a1, scale_b, acc1);
+}
+
+//
+// R1 x C4 tile. Serves M=1 decode and, looped over CountM, every M-row.
+//
+template <bool kVnni>
+MLAS_FORCEINLINE void
+Q2Int8GemmR1xC4BlkLen32Avx2(
+    const std::byte* QuantA,
+    const float* QuantAScale,
+    const std::byte* QuantBData,
+    const float* QuantBScale,
+    float* C,
+    size_t CountM,
+    size_t CountN,
+    size_t BlockCountK,
+    const float* Bias,
+    size_t ldc)
+{
+    const size_t lda = BlockCountK * kBlkLen32;
+    constexpr size_t PerColGroupBytes = kBlockGroupBytes32;
+    constexpr size_t PerColGroupScale = kBlockGroupBlks;
+    constexpr size_t PerKGroupAdvanceBytes = kNCols4 * PerColGroupBytes;
+    constexpr size_t PerKGroupAdvanceScale = kNCols4 * PerColGroupScale;
+    const size_t BlockGroupCountKPadded = MlasDivRoundup(BlockCountK, kBlockGroupBlks);
+    const size_t BlockCountKPadded = BlockGroupCountKPadded * kBlockGroupBlks;
+    const size_t GroupStrideBytes = BlockCountKPadded * kNCols4 * kBlkBytes32;
+    const size_t GroupStrideScale = BlockCountKPadded * kNCols4;
+
+    assert(CountN % kNCols4 == 0);
+    const size_t FullGroups = BlockCountK / kBlockGroupBlks;
+    const size_t TailBlocks = BlockCountK % kBlockGroupBlks;
+
+    for (size_t m = 0; m < CountM; ++m) {
+        const std::byte* QuantBDataColPtr = QuantBData;
+        const float* QuantBScaleColPtr = QuantBScale;
+        const float* BiasPtr = Bias;
+        float* SumPtr = C + m * ldc;
+
+        for (size_t n = 0; n < CountN; n += kNCols4) {
+            const std::byte* QuantAPtr = QuantA + m * lda;
+            const float* QuantAScalePtr = QuantAScale + m * BlockCountK;
+            const std::byte* QuantBDataPtr = QuantBDataColPtr;
+            const float* QuantBScalePtr = QuantBScaleColPtr;
+
+            __m256 acc[kNCols4] = {
+                _mm256_setzero_ps(), _mm256_setzero_ps(),
+                _mm256_setzero_ps(), _mm256_setzero_ps()
+            };
+
+            for (size_t sb = 0; sb < FullGroups; ++sb) {
+                const __m256i av0 = load_a_blklen32(QuantAPtr + 0 * kBlkLen32);
+                const __m256i av1 = load_a_blklen32(QuantAPtr + 1 * kBlkLen32);
+                const __m256i av2 = load_a_blklen32(QuantAPtr + 2 * kBlkLen32);
+                const __m256i av3 = load_a_blklen32(QuantAPtr + 3 * kBlkLen32);
+
+                accumulate_w2_blklen32_r1c1blk4<kVnni>(av0, av1, av2, av3,
+                    QuantBDataPtr + 0 * PerColGroupBytes, QuantAScalePtr,
+                    QuantBScalePtr + 0 * PerColGroupScale, acc[0]);
+                accumulate_w2_blklen32_r1c1blk4<kVnni>(av0, av1, av2, av3,
+                    QuantBDataPtr + 1 * PerColGroupBytes, QuantAScalePtr,
+                    QuantBScalePtr + 1 * PerColGroupScale, acc[1]);
+                accumulate_w2_blklen32_r1c1blk4<kVnni>(av0, av1, av2, av3,
+                    QuantBDataPtr + 2 * PerColGroupBytes, QuantAScalePtr,
+                    QuantBScalePtr + 2 * PerColGroupScale, acc[2]);
+                accumulate_w2_blklen32_r1c1blk4<kVnni>(av0, av1, av2, av3,
+                    QuantBDataPtr + 3 * PerColGroupBytes, QuantAScalePtr,
+                    QuantBScalePtr + 3 * PerColGroupScale, acc[3]);
+
+                QuantAPtr += kBlkLen32 * kBlockGroupBlks;
+                QuantAScalePtr += kBlockGroupBlks;
+                QuantBDataPtr += PerKGroupAdvanceBytes;
+                QuantBScalePtr += PerKGroupAdvanceScale;
+            }
+
+            // K-tail: 1-3 trailing real K-blocks. Zero YMM for missing A blocks
+            // and a bounded scale_a copy to avoid reading uninitialised scales.
+            if (TailBlocks > 0) {
+                const __m256i zero = _mm256_setzero_si256();
+                const __m256i av0 = load_a_blklen32(QuantAPtr + 0 * kBlkLen32);
+                const __m256i av1 = (TailBlocks > 1) ? load_a_blklen32(QuantAPtr + 1 * kBlkLen32) : zero;
+                const __m256i av2 = (TailBlocks > 2) ? load_a_blklen32(QuantAPtr + 2 * kBlkLen32) : zero;
+                const __m256i av3 = zero;
+
+                float scale_a_safe[kBlockGroupBlks] = {0.0f, 0.0f, 0.0f, 0.0f};
+                for (size_t i = 0; i < TailBlocks; ++i) {
+                    scale_a_safe[i] = QuantAScalePtr[i];
+                }
+
+                accumulate_w2_blklen32_r1c1blk4<kVnni>(av0, av1, av2, av3,
+                    QuantBDataPtr + 0 * PerColGroupBytes, scale_a_safe,
+                    QuantBScalePtr + 0 * PerColGroupScale, acc[0]);
+                accumulate_w2_blklen32_r1c1blk4<kVnni>(av0, av1, av2, av3,
+                    QuantBDataPtr + 1 * PerColGroupBytes, scale_a_safe,
+                    QuantBScalePtr + 1 * PerColGroupScale, acc[1]);
+                accumulate_w2_blklen32_r1c1blk4<kVnni>(av0, av1, av2, av3,
+                    QuantBDataPtr + 2 * PerColGroupBytes, scale_a_safe,
+                    QuantBScalePtr + 2 * PerColGroupScale, acc[2]);
+                accumulate_w2_blklen32_r1c1blk4<kVnni>(av0, av1, av2, av3,
+                    QuantBDataPtr + 3 * PerColGroupBytes, scale_a_safe,
+                    QuantBScalePtr + 3 * PerColGroupScale, acc[3]);
+            }
+
+            SumPtr[0] = hsum_float_8(acc[0]);
+            SumPtr[1] = hsum_float_8(acc[1]);
+            SumPtr[2] = hsum_float_8(acc[2]);
+            SumPtr[3] = hsum_float_8(acc[3]);
+            if (BiasPtr != nullptr) {
+                SumPtr[0] += BiasPtr[0];
+                SumPtr[1] += BiasPtr[1];
+                SumPtr[2] += BiasPtr[2];
+                SumPtr[3] += BiasPtr[3];
+            }
+
+            QuantBDataColPtr += GroupStrideBytes;
+            QuantBScaleColPtr += GroupStrideScale;
+            BiasPtr += BiasPtr != nullptr ? kNCols4 : 0;
+            SumPtr += kNCols4;
+        }
+    }
+}
+
+//
+// R2 x C4 tile -- the prefill hot path (CountM >= 2 even; the caller routes the
+// odd trailing row through R1xC4). Sharing each column's block-group load +
+// unpack across 2 M-rows measured ~5% faster than R1 at prefill shapes on
+// AVX2-VNNI client silicon; M=1 decode always takes the R1 tile.
+//
+template <bool kVnni>
+MLAS_FORCEINLINE void
+Q2Int8GemmR2xC4BlkLen32Avx2(
+    const std::byte* QuantA,
+    const float* QuantAScale,
+    const std::byte* QuantBData,
+    const float* QuantBScale,
+    float* C,
+    size_t CountM,
+    size_t CountN,
+    size_t BlockCountK,
+    const float* Bias,
+    size_t ldc)
+{
+    const size_t lda = BlockCountK * kBlkLen32;
+    constexpr size_t PerColGroupBytes = kBlockGroupBytes32;
+    constexpr size_t PerColGroupScale = kBlockGroupBlks;
+    constexpr size_t PerKGroupAdvanceBytes = kNCols4 * PerColGroupBytes;
+    constexpr size_t PerKGroupAdvanceScale = kNCols4 * PerColGroupScale;
+    const size_t BlockGroupCountKPadded = MlasDivRoundup(BlockCountK, kBlockGroupBlks);
+    const size_t BlockCountKPadded = BlockGroupCountKPadded * kBlockGroupBlks;
+    const size_t GroupStrideBytes = BlockCountKPadded * kNCols4 * kBlkBytes32;
+    const size_t GroupStrideScale = BlockCountKPadded * kNCols4;
+
+    assert(CountM % kNRows2_BlkLen32 == 0);
+    assert(CountN % kNCols4 == 0);
+    const size_t FullGroups = BlockCountK / kBlockGroupBlks;
+    const size_t TailBlocks = BlockCountK % kBlockGroupBlks;
+
+    for (size_t m = 0; m < CountM; m += kNRows2_BlkLen32) {
+        const std::byte* QuantBDataColPtr = QuantBData;
+        const float* QuantBScaleColPtr = QuantBScale;
+        const float* BiasPtr = Bias;
+        float* SumPtr = C + m * ldc;
+
+        for (size_t n = 0; n < CountN; n += kNCols4) {
+            const std::byte* QuantAPtr = QuantA + m * lda;
+            const float* QuantAScalePtr = QuantAScale + m * BlockCountK;
+            const std::byte* QuantBDataPtr = QuantBDataColPtr;
+            const float* QuantBScalePtr = QuantBScaleColPtr;
+
+            __m256 acc[kNCols4 * kNRows2_BlkLen32] = {
+                _mm256_setzero_ps(), _mm256_setzero_ps(), _mm256_setzero_ps(), _mm256_setzero_ps(),
+                _mm256_setzero_ps(), _mm256_setzero_ps(), _mm256_setzero_ps(), _mm256_setzero_ps()
+            };
+
+            for (size_t sb = 0; sb < FullGroups; ++sb) {
+                const __m256i av00 = load_a_blklen32(QuantAPtr + 0 * kBlkLen32);
+                const __m256i av01 = load_a_blklen32(QuantAPtr + 1 * kBlkLen32);
+                const __m256i av02 = load_a_blklen32(QuantAPtr + 2 * kBlkLen32);
+                const __m256i av03 = load_a_blklen32(QuantAPtr + 3 * kBlkLen32);
+                const __m256i av10 = load_a_blklen32(QuantAPtr + lda + 0 * kBlkLen32);
+                const __m256i av11 = load_a_blklen32(QuantAPtr + lda + 1 * kBlkLen32);
+                const __m256i av12 = load_a_blklen32(QuantAPtr + lda + 2 * kBlkLen32);
+                const __m256i av13 = load_a_blklen32(QuantAPtr + lda + 3 * kBlkLen32);
+
+                accumulate_w2_blklen32_r2c1blk4<kVnni>(
+                    av00, av01, av02, av03, av10, av11, av12, av13,
+                    QuantBDataPtr + 0 * PerColGroupBytes,
+                    QuantAScalePtr, QuantAScalePtr + BlockCountK,
+                    QuantBScalePtr + 0 * PerColGroupScale, acc[0], acc[kNCols4 + 0]);
+                accumulate_w2_blklen32_r2c1blk4<kVnni>(
+                    av00, av01, av02, av03, av10, av11, av12, av13,
+                    QuantBDataPtr + 1 * PerColGroupBytes,
+                    QuantAScalePtr, QuantAScalePtr + BlockCountK,
+                    QuantBScalePtr + 1 * PerColGroupScale, acc[1], acc[kNCols4 + 1]);
+                accumulate_w2_blklen32_r2c1blk4<kVnni>(
+                    av00, av01, av02, av03, av10, av11, av12, av13,
+                    QuantBDataPtr + 2 * PerColGroupBytes,
+                    QuantAScalePtr, QuantAScalePtr + BlockCountK,
+                    QuantBScalePtr + 2 * PerColGroupScale, acc[2], acc[kNCols4 + 2]);
+                accumulate_w2_blklen32_r2c1blk4<kVnni>(
+                    av00, av01, av02, av03, av10, av11, av12, av13,
+                    QuantBDataPtr + 3 * PerColGroupBytes,
+                    QuantAScalePtr, QuantAScalePtr + BlockCountK,
+                    QuantBScalePtr + 3 * PerColGroupScale, acc[3], acc[kNCols4 + 3]);
+
+                QuantAPtr += kBlkLen32 * kBlockGroupBlks;
+                QuantAScalePtr += kBlockGroupBlks;
+                QuantBDataPtr += PerKGroupAdvanceBytes;
+                QuantBScalePtr += PerKGroupAdvanceScale;
+            }
+
+            // K-tail: 1-3 trailing real K-blocks; zero YMM for missing A blocks
+            // and bounded scale_a copies for both M-rows.
+            if (TailBlocks > 0) {
+                const __m256i zero = _mm256_setzero_si256();
+                const __m256i av00 = load_a_blklen32(QuantAPtr + 0 * kBlkLen32);
+                const __m256i av01 = (TailBlocks > 1) ? load_a_blklen32(QuantAPtr + 1 * kBlkLen32) : zero;
+                const __m256i av02 = (TailBlocks > 2) ? load_a_blklen32(QuantAPtr + 2 * kBlkLen32) : zero;
+                const __m256i av03 = zero;
+                const __m256i av10 = load_a_blklen32(QuantAPtr + lda + 0 * kBlkLen32);
+                const __m256i av11 = (TailBlocks > 1) ? load_a_blklen32(QuantAPtr + lda + 1 * kBlkLen32) : zero;
+                const __m256i av12 = (TailBlocks > 2) ? load_a_blklen32(QuantAPtr + lda + 2 * kBlkLen32) : zero;
+                const __m256i av13 = zero;
+
+                float scale_a0_safe[kBlockGroupBlks] = {0.0f, 0.0f, 0.0f, 0.0f};
+                float scale_a1_safe[kBlockGroupBlks] = {0.0f, 0.0f, 0.0f, 0.0f};
+                for (size_t i = 0; i < TailBlocks; ++i) {
+                    scale_a0_safe[i] = QuantAScalePtr[i];
+                    scale_a1_safe[i] = QuantAScalePtr[BlockCountK + i];
+                }
+
+                accumulate_w2_blklen32_r2c1blk4<kVnni>(
+                    av00, av01, av02, av03, av10, av11, av12, av13,
+                    QuantBDataPtr + 0 * PerColGroupBytes,
+                    scale_a0_safe, scale_a1_safe,
+                    QuantBScalePtr + 0 * PerColGroupScale, acc[0], acc[kNCols4 + 0]);
+                accumulate_w2_blklen32_r2c1blk4<kVnni>(
+                    av00, av01, av02, av03, av10, av11, av12, av13,
+                    QuantBDataPtr + 1 * PerColGroupBytes,
+                    scale_a0_safe, scale_a1_safe,
+                    QuantBScalePtr + 1 * PerColGroupScale, acc[1], acc[kNCols4 + 1]);
+                accumulate_w2_blklen32_r2c1blk4<kVnni>(
+                    av00, av01, av02, av03, av10, av11, av12, av13,
+                    QuantBDataPtr + 2 * PerColGroupBytes,
+                    scale_a0_safe, scale_a1_safe,
+                    QuantBScalePtr + 2 * PerColGroupScale, acc[2], acc[kNCols4 + 2]);
+                accumulate_w2_blklen32_r2c1blk4<kVnni>(
+                    av00, av01, av02, av03, av10, av11, av12, av13,
+                    QuantBDataPtr + 3 * PerColGroupBytes,
+                    scale_a0_safe, scale_a1_safe,
+                    QuantBScalePtr + 3 * PerColGroupScale, acc[3], acc[kNCols4 + 3]);
+            }
+
+            SumPtr[0] = hsum_float_8(acc[0]);
+            SumPtr[1] = hsum_float_8(acc[1]);
+            SumPtr[2] = hsum_float_8(acc[2]);
+            SumPtr[3] = hsum_float_8(acc[3]);
+            SumPtr[ldc + 0] = hsum_float_8(acc[kNCols4 + 0]);
+            SumPtr[ldc + 1] = hsum_float_8(acc[kNCols4 + 1]);
+            SumPtr[ldc + 2] = hsum_float_8(acc[kNCols4 + 2]);
+            SumPtr[ldc + 3] = hsum_float_8(acc[kNCols4 + 3]);
+            if (BiasPtr != nullptr) {
+                SumPtr[0] += BiasPtr[0];
+                SumPtr[1] += BiasPtr[1];
+                SumPtr[2] += BiasPtr[2];
+                SumPtr[3] += BiasPtr[3];
+                SumPtr[ldc + 0] += BiasPtr[0];
+                SumPtr[ldc + 1] += BiasPtr[1];
+                SumPtr[ldc + 2] += BiasPtr[2];
+                SumPtr[ldc + 3] += BiasPtr[3];
+            }
+
+            QuantBDataColPtr += GroupStrideBytes;
+            QuantBScaleColPtr += GroupStrideScale;
+            BiasPtr += BiasPtr != nullptr ? kNCols4 : 0;
+            SumPtr += kNCols4;
+        }
+    }
+}
+
+//
+// 1 M-row x 1 N-col N-tail tile for the trailing 1-3 N-cols. The tail region of
+// the packed B buffer is column-major (see PackedQuantBOffsetBytes_W2 for
+// n >= NMain), so this walks one column at a time.
+//
+template <bool kVnni>
+MLAS_FORCEINLINE void
+Q2Int8GemmRMxC_Tail_BlkLen32Avx2(
+    const std::byte* QuantA,
+    const float* QuantAScale,
+    const std::byte* QuantBDataTail,
+    const float* QuantBScaleTail,
+    float* C,
+    size_t CountM,
+    size_t TailN,
+    size_t BlockCountK,
+    const float* BiasTail,
+    size_t ldc)
+{
+    assert(TailN >= 1 && TailN <= 3);
+    const size_t lda = BlockCountK * kBlkLen32;
+    const size_t BlockGroupCountKPadded = MlasDivRoundup(BlockCountK, kBlockGroupBlks);
+    const size_t FullGroups = BlockCountK / kBlockGroupBlks;
+    const size_t TailBlocks = BlockCountK % kBlockGroupBlks;
+    const size_t ColStrideBytes = BlockGroupCountKPadded * kBlockGroupBytes32;
+    const size_t ColStrideScale = BlockGroupCountKPadded * kBlockGroupBlks;
+
+    for (size_t m = 0; m < CountM; ++m) {
+        for (size_t c = 0; c < TailN; ++c) {
+            const std::byte* QuantAPtr = QuantA + m * lda;
+            const float* QuantAScalePtr = QuantAScale + m * BlockCountK;
+            const std::byte* QuantBDataPtr = QuantBDataTail + c * ColStrideBytes;
+            const float* QuantBScalePtr = QuantBScaleTail + c * ColStrideScale;
+
+            __m256 acc = _mm256_setzero_ps();
+
+            for (size_t sb = 0; sb < FullGroups; ++sb) {
+                const __m256i av0 = load_a_blklen32(QuantAPtr + 0 * kBlkLen32);
+                const __m256i av1 = load_a_blklen32(QuantAPtr + 1 * kBlkLen32);
+                const __m256i av2 = load_a_blklen32(QuantAPtr + 2 * kBlkLen32);
+                const __m256i av3 = load_a_blklen32(QuantAPtr + 3 * kBlkLen32);
+                accumulate_w2_blklen32_r1c1blk4<kVnni>(av0, av1, av2, av3,
+                    QuantBDataPtr, QuantAScalePtr, QuantBScalePtr, acc);
+
+                QuantAPtr += kBlkLen32 * kBlockGroupBlks;
+                QuantAScalePtr += kBlockGroupBlks;
+                QuantBDataPtr += kBlockGroupBytes32;
+                QuantBScalePtr += kBlockGroupBlks;
+            }
+
+            if (TailBlocks > 0) {
+                const __m256i zero = _mm256_setzero_si256();
+                const __m256i av0 = load_a_blklen32(QuantAPtr + 0 * kBlkLen32);
+                const __m256i av1 = (TailBlocks > 1) ? load_a_blklen32(QuantAPtr + 1 * kBlkLen32) : zero;
+                const __m256i av2 = (TailBlocks > 2) ? load_a_blklen32(QuantAPtr + 2 * kBlkLen32) : zero;
+                const __m256i av3 = zero;
+
+                float scale_a_safe[kBlockGroupBlks] = {0.0f, 0.0f, 0.0f, 0.0f};
+                for (size_t i = 0; i < TailBlocks; ++i) {
+                    scale_a_safe[i] = QuantAScalePtr[i];
+                }
+                accumulate_w2_blklen32_r1c1blk4<kVnni>(av0, av1, av2, av3,
+                    QuantBDataPtr, scale_a_safe, QuantBScalePtr, acc);
+            }
+
+            float v = hsum_float_8(acc);
+            if (BiasTail != nullptr) v += BiasTail[c];
+            C[m * ldc + c] = v;
+        }
+    }
+}
+
+//
+// Top-level BlkLen=32 kernel body. Runs the integer tiles over NMain (R2xC4
+// head + R1xC4 odd-row tail) and the 1-3 col N-tail, then the shared SGEMM
+// BlkSum correction.
+//
+template <bool kVnni>
+static MLAS_FORCEINLINE size_t
+SQ2BitGemmKernel_BlkSum_CompInt8_BlkLen32_Impl(
+    const std::byte* QuantA,
+    const float* QuantAScale,
+    const std::byte* QuantBData,
+    const float* QuantBScale,
+    float* C,
+    size_t CountM,
+    size_t CountN,
+    size_t BlockCountK,
+    const float* Bias,
+    size_t ldc,
+    const float* ABlockSum,
+    const float* QuantBBlkSum)
+{
+    if (BlockCountK == 0 || CountM == 0 || CountN == 0) {
+        return 0;
+    }
+
+    const size_t NMain = (CountN / kNCols4) * kNCols4;
+    const size_t NTail = CountN - NMain;
+
+    const size_t M_pairs = CountM / kNRows2_BlkLen32;
+    const size_t M_main = M_pairs * kNRows2_BlkLen32;
+    const size_t M_tail = CountM - M_main;
+    const size_t lda = BlockCountK * kBlkLen32;
+
+    if (NMain > 0) {
+        if (M_main > 0) {
+            Q2Int8GemmR2xC4BlkLen32Avx2<kVnni>(
+                QuantA, QuantAScale, QuantBData, QuantBScale,
+                C, M_main, NMain, BlockCountK, Bias, ldc);
+        }
+        if (M_tail > 0) {
+            Q2Int8GemmR1xC4BlkLen32Avx2<kVnni>(
+                QuantA + M_main * lda,
+                QuantAScale + M_main * BlockCountK,
+                QuantBData, QuantBScale,
+                C + M_main * ldc,
+                /*CountM=*/M_tail,
+                NMain, BlockCountK, Bias, ldc);
+        }
+    }
+
+    if (NTail > 0) {
+        const size_t BlockGroupCountKPadded = MlasDivRoundup(BlockCountK, kBlockGroupBlks);
+        const std::byte* QuantBDataTail =
+            QuantBData + NMain * BlockGroupCountKPadded * kBlockGroupBytes32;
+        const float* QuantBScaleTail =
+            QuantBScale + NMain * BlockGroupCountKPadded * kBlockGroupBlks;
+        const float* BiasTail = (Bias != nullptr) ? Bias + NMain : nullptr;
+
+        Q2Int8GemmRMxC_Tail_BlkLen32Avx2<kVnni>(
+            QuantA, QuantAScale, QuantBDataTail, QuantBScaleTail,
+            C + NMain, CountM, NTail, BlockCountK, BiasTail, ldc);
+    }
+
+    float* c_blk = C;
+    const float* b_blk_sum = QuantBBlkSum;
+    size_t RowsRemaining = CountM;
+    const float* a_blksum_row = ABlockSum;
+    while (RowsRemaining > 0) {
+        const auto RowsHandled = GetMlasPlatform().GemmFloatKernel(
+            a_blksum_row, b_blk_sum, c_blk,
+            BlockCountK, RowsRemaining, CountN, BlockCountK, ldc,
+            1.0f, /*ZeroMode=*/false);
+
+        c_blk += ldc * RowsHandled;
+        a_blksum_row += BlockCountK * RowsHandled;
+        RowsRemaining -= RowsHandled;
+    }
+    return CountM;
+}
+
+static MLAS_FORCEINLINE size_t MLASCALL
+SQ2BitGemmKernel_BlkSum_CompInt8_BlkLen32_Avx2Vnni(
+    const std::byte* QuantA,
+    const float* QuantAScale,
+    const std::byte* QuantBData,
+    const float* QuantBScale,
+    float* C,
+    size_t CountM,
+    size_t CountN,
+    size_t BlockCountK,
+    const float* Bias,
+    size_t ldc,
+    const float* ABlockSum,
+    const float* QuantBBlkSum)
+{
+    return SQ2BitGemmKernel_BlkSum_CompInt8_BlkLen32_Impl<true>(
+        QuantA, QuantAScale, QuantBData, QuantBScale,
+        C, CountM, CountN, BlockCountK, Bias, ldc, ABlockSum, QuantBBlkSum);
+}
+
+static MLAS_FORCEINLINE size_t MLASCALL
+SQ2BitGemmKernel_BlkSum_CompInt8_BlkLen32_Avx2(
+    const std::byte* QuantA,
+    const float* QuantAScale,
+    const std::byte* QuantBData,
+    const float* QuantBScale,
+    float* C,
+    size_t CountM,
+    size_t CountN,
+    size_t BlockCountK,
+    const float* Bias,
+    size_t ldc,
+    const float* ABlockSum,
+    const float* QuantBBlkSum)
+{
+    return SQ2BitGemmKernel_BlkSum_CompInt8_BlkLen32_Impl<false>(
+        QuantA, QuantAScale, QuantBData, QuantBScale,
+        C, CountM, CountN, BlockCountK, Bias, ldc, ABlockSum, QuantBBlkSum);
+}
+
+}  // namespace sq2bit_avx2
+}  // namespace mlas
+}  // namespace onnxruntime

--- a/onnxruntime/core/mlas/lib/sqnbitgemm_kernel_avx2_2bit_blklen32.h
+++ b/onnxruntime/core/mlas/lib/sqnbitgemm_kernel_avx2_2bit_blklen32.h
@@ -260,7 +260,9 @@ Q2Int8GemmR1xC4BlkLen32Avx2(
 
             QuantBDataColPtr += GroupStrideBytes;
             QuantBScaleColPtr += GroupStrideScale;
-            BiasPtr += BiasPtr != nullptr ? kNCols4 : 0;
+            if (BiasPtr != nullptr) {
+                BiasPtr += kNCols4;
+            }
             SumPtr += kNCols4;
         }
     }
@@ -418,7 +420,9 @@ Q2Int8GemmR2xC4BlkLen32Avx2(
 
             QuantBDataColPtr += GroupStrideBytes;
             QuantBScaleColPtr += GroupStrideScale;
-            BiasPtr += BiasPtr != nullptr ? kNCols4 : 0;
+            if (BiasPtr != nullptr) {
+                BiasPtr += kNCols4;
+            }
             SumPtr += kNCols4;
         }
     }

--- a/onnxruntime/core/mlas/lib/sqnbitgemm_kernel_avx2_2bit_blklen32.h
+++ b/onnxruntime/core/mlas/lib/sqnbitgemm_kernel_avx2_2bit_blklen32.h
@@ -84,6 +84,8 @@ dot_accumulate_4blk_w2_blklen32(
     const float* scale_a, const float* scale_b, __m256& acc)
 {
     __m256i d0, d1, d2, d3;
+    // GCC 11+ is needed for _mm256_dpbusds_avx_epi32; older toolchains fall
+    // through to the vpmaddubsw+vpmaddwd path even on AVX-VNNI hardware.
 #if !defined(__GNUC__) || (__GNUC__ > 10)
     if constexpr (kVnni) {
         // dpbusds: 2nd operand (bv=unsigned [0,3]) x 3rd operand (av=signed int8); consistent with maddubs(bv, av)

--- a/onnxruntime/core/mlas/lib/sqnbitgemm_kernel_avx2_2bit_blklen64.h
+++ b/onnxruntime/core/mlas/lib/sqnbitgemm_kernel_avx2_2bit_blklen64.h
@@ -58,6 +58,8 @@ dot_accumulate_4blk_w2_blklen64(
 {
     const __m256i m03 = _mm256_set1_epi8(0x03);
     __m256i d0, d1, d2, d3;
+    // GCC 11+ is needed for _mm256_dpbusds_avx_epi32; older toolchains fall
+    // through to the vpmaddubsw+vpmaddwd path even on AVX-VNNI hardware.
 #if !defined(__GNUC__) || (__GNUC__ > 10)
     if constexpr (kVnni) {
         d0 = _mm256_dpbusds_avx_epi32(_mm256_setzero_si256(), _mm256_and_si256(glo, m03), a0lo);

--- a/onnxruntime/core/mlas/lib/sqnbitgemm_kernel_avx2_2bit_blklen64.h
+++ b/onnxruntime/core/mlas/lib/sqnbitgemm_kernel_avx2_2bit_blklen64.h
@@ -1,0 +1,603 @@
+/*++
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the MIT License.
+
+Module Name:
+
+    sqnbitgemm_kernel_avx2_2bit_blklen64.h
+
+Abstract:
+
+    AVX2 (-VNNI) W2 kernel for BlkLen=64, consuming the block-group packed
+    layout (sqnbitgemm_kernel_avx512_2bit.h). A 64-element K-block is one ZMM on
+    AVX-512; on AVX2 it is two YMM halves, so each block's dot is two chained
+    VPDPBUSD (one per 32-lane half) summed into the same int32 vector. Layout,
+    stride math, scale handling, and tail logic match the AVX-512 sibling.
+
+    Templated on `<bool kVnni>`. The un-suffixed
+    SQ2BitGemmKernel_BlkSum_CompInt8_Avx2(Vnni) wrappers are the default entry
+    the dispatcher routes to for BlkLen == 64.
+
+--*/
+
+#pragma once
+
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+
+#include <immintrin.h>
+
+#include "mlasi.h"
+#include "qnbitgemm.h"
+#include "sqnbitgemm_kernel_avx_common.h"
+#include "sqnbitgemm_kernel_avx512_2bit.h"
+
+namespace onnxruntime {
+namespace mlas {
+namespace sq2bit_avx2 {
+
+using namespace sq2bit_avx512;
+
+inline constexpr size_t kNRows2 = 2;
+
+//
+// acc += sum_{k=0..3} scale_a[k]*scale_b[k] * dot64(av_k, bv_k). Each block's
+// 64 unsigned weights come from the block-group halves glo/ghi via a fixed
+// shift+mask; each block's 64 int8 activations are two YMM halves.
+//
+template <bool kVnni>
+static MLAS_FORCEINLINE void
+dot_accumulate_4blk_w2_blklen64(
+    const __m256i& glo, const __m256i& ghi,
+    const __m256i& a0lo, const __m256i& a0hi, const __m256i& a1lo, const __m256i& a1hi,
+    const __m256i& a2lo, const __m256i& a2hi, const __m256i& a3lo, const __m256i& a3hi,
+    const float* scale_a, const float* scale_b, __m256& acc)
+{
+    const __m256i m03 = _mm256_set1_epi8(0x03);
+    __m256i d0, d1, d2, d3;
+#if !defined(__GNUC__) || (__GNUC__ > 10)
+    if constexpr (kVnni) {
+        d0 = _mm256_dpbusds_avx_epi32(_mm256_setzero_si256(), _mm256_and_si256(glo, m03), a0lo);
+        d0 = _mm256_dpbusds_avx_epi32(d0, _mm256_and_si256(ghi, m03), a0hi);
+        d1 = _mm256_dpbusds_avx_epi32(_mm256_setzero_si256(), _mm256_and_si256(_mm256_srli_epi16(glo, 2), m03), a1lo);
+        d1 = _mm256_dpbusds_avx_epi32(d1, _mm256_and_si256(_mm256_srli_epi16(ghi, 2), m03), a1hi);
+        d2 = _mm256_dpbusds_avx_epi32(_mm256_setzero_si256(), _mm256_and_si256(_mm256_srli_epi16(glo, 4), m03), a2lo);
+        d2 = _mm256_dpbusds_avx_epi32(d2, _mm256_and_si256(_mm256_srli_epi16(ghi, 4), m03), a2hi);
+        d3 = _mm256_dpbusds_avx_epi32(_mm256_setzero_si256(), _mm256_and_si256(_mm256_srli_epi16(glo, 6), m03), a3lo);
+        d3 = _mm256_dpbusds_avx_epi32(d3, _mm256_and_si256(_mm256_srli_epi16(ghi, 6), m03), a3hi);
+    } else
+#endif
+    {
+        const __m256i ones = _mm256_set1_epi16(1);
+        auto dot2 = [&](const __m256i& blo, const __m256i& bhi, const __m256i& alo, const __m256i& ahi) -> __m256i {
+            const __m256i t_lo = _mm256_madd_epi16(_mm256_maddubs_epi16(blo, alo), ones);
+            const __m256i t_hi = _mm256_madd_epi16(_mm256_maddubs_epi16(bhi, ahi), ones);
+            return _mm256_add_epi32(t_lo, t_hi);
+        };
+        d0 = dot2(_mm256_and_si256(glo, m03), _mm256_and_si256(ghi, m03), a0lo, a0hi);
+        d1 = dot2(_mm256_and_si256(_mm256_srli_epi16(glo, 2), m03),
+                  _mm256_and_si256(_mm256_srli_epi16(ghi, 2), m03), a1lo, a1hi);
+        d2 = dot2(_mm256_and_si256(_mm256_srli_epi16(glo, 4), m03),
+                  _mm256_and_si256(_mm256_srli_epi16(ghi, 4), m03), a2lo, a2hi);
+        d3 = dot2(_mm256_and_si256(_mm256_srli_epi16(glo, 6), m03),
+                  _mm256_and_si256(_mm256_srli_epi16(ghi, 6), m03), a3lo, a3hi);
+    }
+
+    const __m256 s0 = _mm256_set1_ps(scale_a[0] * scale_b[0]);
+    const __m256 s1 = _mm256_set1_ps(scale_a[1] * scale_b[1]);
+    const __m256 s2 = _mm256_set1_ps(scale_a[2] * scale_b[2]);
+    const __m256 s3 = _mm256_set1_ps(scale_a[3] * scale_b[3]);
+
+    __m256 acc_lo = _mm256_mul_ps(_mm256_cvtepi32_ps(d0), s0);
+    __m256 acc_hi = _mm256_mul_ps(_mm256_cvtepi32_ps(d1), s1);
+    acc_lo = _mm256_fmadd_ps(_mm256_cvtepi32_ps(d2), s2, acc_lo);
+    acc_hi = _mm256_fmadd_ps(_mm256_cvtepi32_ps(d3), s3, acc_hi);
+    acc = _mm256_add_ps(acc, _mm256_add_ps(acc_lo, acc_hi));
+}
+
+static MLAS_FORCEINLINE __m256i
+load_a_half_blklen64(const std::byte* p)
+{
+    return _mm256_loadu_si256(reinterpret_cast<const __m256i*>(p));
+}
+
+template <bool kVnni>
+static MLAS_FORCEINLINE void
+accumulate_w2_blklen64_r1c1blk4(
+    const __m256i& a0lo, const __m256i& a0hi, const __m256i& a1lo, const __m256i& a1hi,
+    const __m256i& a2lo, const __m256i& a2hi, const __m256i& a3lo, const __m256i& a3hi,
+    const std::byte* QuantBDataPtr,
+    const float* scale_a, const float* scale_b, __m256& acc)
+{
+    const __m256i glo = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(QuantBDataPtr));
+    const __m256i ghi = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(QuantBDataPtr + 32));
+    dot_accumulate_4blk_w2_blklen64<kVnni>(glo, ghi, a0lo, a0hi, a1lo, a1hi, a2lo, a2hi, a3lo, a3hi,
+                                           scale_a, scale_b, acc);
+}
+
+//
+// One block's contribution for both M-rows, sharing the unpacked bv pair.
+// `Shift` selects the 2-bit field (0/2/4/6) for block {0,1,2,3}. A halves are
+// loaded per call rather than preloaded: 16 A-half registers for an R2 group
+// do not fit the 16-YMM file, and the reloads are L1-resident.
+//
+template <bool kVnni, int Shift>
+static MLAS_FORCEINLINE void
+dot_one_block_w2_blklen64_r2(
+    const __m256i& glo, const __m256i& ghi, const __m256i& m03,
+    const std::byte* a0_blk, const std::byte* a1_blk,
+    float s0, float s1, __m256& acc0, __m256& acc1)
+{
+    const __m256i bvlo = _mm256_and_si256(_mm256_srli_epi16(glo, Shift), m03);
+    const __m256i bvhi = _mm256_and_si256(_mm256_srli_epi16(ghi, Shift), m03);
+    const __m256i a0lo = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(a0_blk));
+    const __m256i a0hi = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(a0_blk + 32));
+    const __m256i a1lo = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(a1_blk));
+    const __m256i a1hi = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(a1_blk + 32));
+    __m256i d0, d1;
+#if !defined(__GNUC__) || (__GNUC__ > 10)
+    if constexpr (kVnni) {
+        d0 = _mm256_dpbusds_avx_epi32(_mm256_dpbusds_avx_epi32(_mm256_setzero_si256(), bvlo, a0lo), bvhi, a0hi);
+        d1 = _mm256_dpbusds_avx_epi32(_mm256_dpbusds_avx_epi32(_mm256_setzero_si256(), bvlo, a1lo), bvhi, a1hi);
+    } else
+#endif
+    {
+        const __m256i ones = _mm256_set1_epi16(1);
+        d0 = _mm256_add_epi32(_mm256_madd_epi16(_mm256_maddubs_epi16(bvlo, a0lo), ones),
+                              _mm256_madd_epi16(_mm256_maddubs_epi16(bvhi, a0hi), ones));
+        d1 = _mm256_add_epi32(_mm256_madd_epi16(_mm256_maddubs_epi16(bvlo, a1lo), ones),
+                              _mm256_madd_epi16(_mm256_maddubs_epi16(bvhi, a1hi), ones));
+    }
+    acc0 = _mm256_fmadd_ps(_mm256_cvtepi32_ps(d0), _mm256_set1_ps(s0), acc0);
+    acc1 = _mm256_fmadd_ps(_mm256_cvtepi32_ps(d1), _mm256_set1_ps(s1), acc1);
+}
+
+//
+// 2 M-rows share one B-group load+unpack. nblk is 4 for a full group, 1..3 for
+// the K-tail (guarded per-block calls; caller zero-pads trailing scale_a slots).
+//
+template <bool kVnni>
+static MLAS_FORCEINLINE void
+accumulate_w2_blklen64_r2c1blk4(
+    const std::byte* a0, const std::byte* a1, size_t nblk,
+    const std::byte* QuantBDataPtr,
+    const float* scale_a0, const float* scale_a1, const float* scale_b,
+    __m256& acc0, __m256& acc1)
+{
+    const __m256i glo = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(QuantBDataPtr));
+    const __m256i ghi = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(QuantBDataPtr + 32));
+    const __m256i m03 = _mm256_set1_epi8(0x03);
+
+    dot_one_block_w2_blklen64_r2<kVnni, 0>(glo, ghi, m03, a0, a1,
+        scale_a0[0] * scale_b[0], scale_a1[0] * scale_b[0], acc0, acc1);
+    if (nblk > 1) {
+        dot_one_block_w2_blklen64_r2<kVnni, 2>(glo, ghi, m03, a0 + kBlkLen, a1 + kBlkLen,
+            scale_a0[1] * scale_b[1], scale_a1[1] * scale_b[1], acc0, acc1);
+    }
+    if (nblk > 2) {
+        dot_one_block_w2_blklen64_r2<kVnni, 4>(glo, ghi, m03, a0 + 2 * kBlkLen, a1 + 2 * kBlkLen,
+            scale_a0[2] * scale_b[2], scale_a1[2] * scale_b[2], acc0, acc1);
+    }
+    if (nblk > 3) {
+        dot_one_block_w2_blklen64_r2<kVnni, 6>(glo, ghi, m03, a0 + 3 * kBlkLen, a1 + 3 * kBlkLen,
+            scale_a0[3] * scale_b[3], scale_a1[3] * scale_b[3], acc0, acc1);
+    }
+}
+
+template <bool kVnni>
+MLAS_FORCEINLINE void
+Q2Int8GemmR1xC4BlkLen64Avx2(
+    const std::byte* QuantA,
+    const float* QuantAScale,
+    const std::byte* QuantBData,
+    const float* QuantBScale,
+    float* C,
+    size_t CountM,
+    size_t CountN,
+    size_t BlockCountK,
+    const float* Bias,
+    size_t ldc)
+{
+    const size_t lda = BlockCountK * kBlkLen;
+    constexpr size_t PerColGroupBytes = kBlockGroupBytes;
+    constexpr size_t PerColGroupScale = kBlockGroupBlks;
+    constexpr size_t PerKGroupAdvanceBytes = kNCols4 * PerColGroupBytes;
+    constexpr size_t PerKGroupAdvanceScale = kNCols4 * PerColGroupScale;
+    const size_t BlockGroupCountKPadded = MlasDivRoundup(BlockCountK, kBlockGroupBlks);
+    const size_t BlockCountKPadded = BlockGroupCountKPadded * kBlockGroupBlks;
+    const size_t GroupStrideBytes = BlockCountKPadded * kNCols4 * kBlkBytes;
+    const size_t GroupStrideScale = BlockCountKPadded * kNCols4;
+
+    assert(CountN % kNCols4 == 0);
+    const size_t FullGroups = BlockCountK / kBlockGroupBlks;
+    const size_t TailBlocks = BlockCountK % kBlockGroupBlks;
+
+    for (size_t m = 0; m < CountM; ++m) {
+        const std::byte* QuantBDataColPtr = QuantBData;
+        const float* QuantBScaleColPtr = QuantBScale;
+        const float* BiasPtr = Bias;
+        float* SumPtr = C + m * ldc;
+
+        for (size_t n = 0; n < CountN; n += kNCols4) {
+            const std::byte* QuantAPtr = QuantA + m * lda;
+            const float* QuantAScalePtr = QuantAScale + m * BlockCountK;
+            const std::byte* QuantBDataPtr = QuantBDataColPtr;
+            const float* QuantBScalePtr = QuantBScaleColPtr;
+
+            __m256 acc[kNCols4] = {
+                _mm256_setzero_ps(), _mm256_setzero_ps(),
+                _mm256_setzero_ps(), _mm256_setzero_ps()
+            };
+
+            for (size_t sb = 0; sb < FullGroups; ++sb) {
+                const __m256i a0lo = load_a_half_blklen64(QuantAPtr + 0 * kBlkLen);
+                const __m256i a0hi = load_a_half_blklen64(QuantAPtr + 0 * kBlkLen + 32);
+                const __m256i a1lo = load_a_half_blklen64(QuantAPtr + 1 * kBlkLen);
+                const __m256i a1hi = load_a_half_blklen64(QuantAPtr + 1 * kBlkLen + 32);
+                const __m256i a2lo = load_a_half_blklen64(QuantAPtr + 2 * kBlkLen);
+                const __m256i a2hi = load_a_half_blklen64(QuantAPtr + 2 * kBlkLen + 32);
+                const __m256i a3lo = load_a_half_blklen64(QuantAPtr + 3 * kBlkLen);
+                const __m256i a3hi = load_a_half_blklen64(QuantAPtr + 3 * kBlkLen + 32);
+
+                for (size_t c = 0; c < kNCols4; ++c) {
+                    accumulate_w2_blklen64_r1c1blk4<kVnni>(
+                        a0lo, a0hi, a1lo, a1hi, a2lo, a2hi, a3lo, a3hi,
+                        QuantBDataPtr + c * PerColGroupBytes,
+                        QuantAScalePtr, QuantBScalePtr + c * PerColGroupScale, acc[c]);
+                }
+
+                QuantAPtr += kBlkLen * kBlockGroupBlks;
+                QuantAScalePtr += kBlockGroupBlks;
+                QuantBDataPtr += PerKGroupAdvanceBytes;
+                QuantBScalePtr += PerKGroupAdvanceScale;
+            }
+
+            if (TailBlocks > 0) {
+                const __m256i zero = _mm256_setzero_si256();
+                const __m256i a0lo = load_a_half_blklen64(QuantAPtr + 0 * kBlkLen);
+                const __m256i a0hi = load_a_half_blklen64(QuantAPtr + 0 * kBlkLen + 32);
+                const __m256i a1lo = (TailBlocks > 1) ? load_a_half_blklen64(QuantAPtr + 1 * kBlkLen) : zero;
+                const __m256i a1hi = (TailBlocks > 1) ? load_a_half_blklen64(QuantAPtr + 1 * kBlkLen + 32) : zero;
+                const __m256i a2lo = (TailBlocks > 2) ? load_a_half_blklen64(QuantAPtr + 2 * kBlkLen) : zero;
+                const __m256i a2hi = (TailBlocks > 2) ? load_a_half_blklen64(QuantAPtr + 2 * kBlkLen + 32) : zero;
+
+                float scale_a_safe[kBlockGroupBlks] = {0.0f, 0.0f, 0.0f, 0.0f};
+                for (size_t i = 0; i < TailBlocks; ++i) {
+                    scale_a_safe[i] = QuantAScalePtr[i];
+                }
+
+                for (size_t c = 0; c < kNCols4; ++c) {
+                    accumulate_w2_blklen64_r1c1blk4<kVnni>(
+                        a0lo, a0hi, a1lo, a1hi, a2lo, a2hi, zero, zero,
+                        QuantBDataPtr + c * PerColGroupBytes,
+                        scale_a_safe, QuantBScalePtr + c * PerColGroupScale, acc[c]);
+                }
+            }
+
+            SumPtr[0] = hsum_float_8(acc[0]);
+            SumPtr[1] = hsum_float_8(acc[1]);
+            SumPtr[2] = hsum_float_8(acc[2]);
+            SumPtr[3] = hsum_float_8(acc[3]);
+            if (BiasPtr != nullptr) {
+                SumPtr[0] += BiasPtr[0];
+                SumPtr[1] += BiasPtr[1];
+                SumPtr[2] += BiasPtr[2];
+                SumPtr[3] += BiasPtr[3];
+            }
+
+            QuantBDataColPtr += GroupStrideBytes;
+            QuantBScaleColPtr += GroupStrideScale;
+            BiasPtr += BiasPtr != nullptr ? kNCols4 : 0;
+            SumPtr += kNCols4;
+        }
+    }
+}
+
+//
+// R2 x C4 tile -- the prefill hot path (CountM >= 2 even; the caller routes the
+// odd trailing row through R1xC4). Sharing each column's block-group load +
+// unpack across 2 M-rows measured 11-15% faster than R1 at prefill shapes on
+// AVX2-VNNI client silicon; M=1 decode always takes the R1 tile.
+//
+template <bool kVnni>
+MLAS_FORCEINLINE void
+Q2Int8GemmR2xC4BlkLen64Avx2(
+    const std::byte* QuantA,
+    const float* QuantAScale,
+    const std::byte* QuantBData,
+    const float* QuantBScale,
+    float* C,
+    size_t CountM,
+    size_t CountN,
+    size_t BlockCountK,
+    const float* Bias,
+    size_t ldc)
+{
+    const size_t lda = BlockCountK * kBlkLen;
+    constexpr size_t PerColGroupBytes = kBlockGroupBytes;
+    constexpr size_t PerColGroupScale = kBlockGroupBlks;
+    constexpr size_t PerKGroupAdvanceBytes = kNCols4 * PerColGroupBytes;
+    constexpr size_t PerKGroupAdvanceScale = kNCols4 * PerColGroupScale;
+    const size_t BlockGroupCountKPadded = MlasDivRoundup(BlockCountK, kBlockGroupBlks);
+    const size_t BlockCountKPadded = BlockGroupCountKPadded * kBlockGroupBlks;
+    const size_t GroupStrideBytes = BlockCountKPadded * kNCols4 * kBlkBytes;
+    const size_t GroupStrideScale = BlockCountKPadded * kNCols4;
+
+    assert(CountM % kNRows2 == 0);
+    assert(CountN % kNCols4 == 0);
+    const size_t FullGroups = BlockCountK / kBlockGroupBlks;
+    const size_t TailBlocks = BlockCountK % kBlockGroupBlks;
+
+    for (size_t m = 0; m < CountM; m += kNRows2) {
+        const std::byte* QuantBDataColPtr = QuantBData;
+        const float* QuantBScaleColPtr = QuantBScale;
+        const float* BiasPtr = Bias;
+        float* SumPtr = C + m * ldc;
+
+        for (size_t n = 0; n < CountN; n += kNCols4) {
+            const std::byte* QuantAPtr = QuantA + m * lda;
+            const float* QuantAScalePtr = QuantAScale + m * BlockCountK;
+            const std::byte* QuantBDataPtr = QuantBDataColPtr;
+            const float* QuantBScalePtr = QuantBScaleColPtr;
+
+            __m256 acc[kNCols4 * kNRows2] = {
+                _mm256_setzero_ps(), _mm256_setzero_ps(), _mm256_setzero_ps(), _mm256_setzero_ps(),
+                _mm256_setzero_ps(), _mm256_setzero_ps(), _mm256_setzero_ps(), _mm256_setzero_ps()
+            };
+
+            for (size_t sb = 0; sb < FullGroups; ++sb) {
+                for (size_t c = 0; c < kNCols4; ++c) {
+                    accumulate_w2_blklen64_r2c1blk4<kVnni>(
+                        QuantAPtr, QuantAPtr + lda, kBlockGroupBlks,
+                        QuantBDataPtr + c * PerColGroupBytes,
+                        QuantAScalePtr, QuantAScalePtr + BlockCountK,
+                        QuantBScalePtr + c * PerColGroupScale,
+                        acc[c], acc[kNCols4 + c]);
+                }
+                QuantAPtr += kBlkLen * kBlockGroupBlks;
+                QuantAScalePtr += kBlockGroupBlks;
+                QuantBDataPtr += PerKGroupAdvanceBytes;
+                QuantBScalePtr += PerKGroupAdvanceScale;
+            }
+
+            // K-tail: 1-3 trailing real K-blocks; guarded per-block calls plus
+            // bounded scale_a copies for both M-rows.
+            if (TailBlocks > 0) {
+                float scale_a0_safe[kBlockGroupBlks] = {0.0f, 0.0f, 0.0f, 0.0f};
+                float scale_a1_safe[kBlockGroupBlks] = {0.0f, 0.0f, 0.0f, 0.0f};
+                for (size_t i = 0; i < TailBlocks; ++i) {
+                    scale_a0_safe[i] = QuantAScalePtr[i];
+                    scale_a1_safe[i] = QuantAScalePtr[BlockCountK + i];
+                }
+                for (size_t c = 0; c < kNCols4; ++c) {
+                    accumulate_w2_blklen64_r2c1blk4<kVnni>(
+                        QuantAPtr, QuantAPtr + lda, TailBlocks,
+                        QuantBDataPtr + c * PerColGroupBytes,
+                        scale_a0_safe, scale_a1_safe,
+                        QuantBScalePtr + c * PerColGroupScale,
+                        acc[c], acc[kNCols4 + c]);
+                }
+            }
+
+            for (size_t c = 0; c < kNCols4; ++c) {
+                SumPtr[c] = hsum_float_8(acc[c]);
+                SumPtr[ldc + c] = hsum_float_8(acc[kNCols4 + c]);
+                if (BiasPtr != nullptr) {
+                    SumPtr[c] += BiasPtr[c];
+                    SumPtr[ldc + c] += BiasPtr[c];
+                }
+            }
+
+            QuantBDataColPtr += GroupStrideBytes;
+            QuantBScaleColPtr += GroupStrideScale;
+            BiasPtr += BiasPtr != nullptr ? kNCols4 : 0;
+            SumPtr += kNCols4;
+        }
+    }
+}
+
+template <bool kVnni>
+MLAS_FORCEINLINE void
+Q2Int8GemmRMxC_Tail_BlkLen64Avx2(
+    const std::byte* QuantA,
+    const float* QuantAScale,
+    const std::byte* QuantBDataTail,
+    const float* QuantBScaleTail,
+    float* C,
+    size_t CountM,
+    size_t TailN,
+    size_t BlockCountK,
+    const float* BiasTail,
+    size_t ldc)
+{
+    assert(TailN >= 1 && TailN <= 3);
+    const size_t lda = BlockCountK * kBlkLen;
+    const size_t BlockGroupCountKPadded = MlasDivRoundup(BlockCountK, kBlockGroupBlks);
+    const size_t FullGroups = BlockCountK / kBlockGroupBlks;
+    const size_t TailBlocks = BlockCountK % kBlockGroupBlks;
+    const size_t ColStrideBytes = BlockGroupCountKPadded * kBlockGroupBytes;
+    const size_t ColStrideScale = BlockGroupCountKPadded * kBlockGroupBlks;
+
+    for (size_t m = 0; m < CountM; ++m) {
+        for (size_t c = 0; c < TailN; ++c) {
+            const std::byte* QuantAPtr = QuantA + m * lda;
+            const float* QuantAScalePtr = QuantAScale + m * BlockCountK;
+            const std::byte* QuantBDataPtr = QuantBDataTail + c * ColStrideBytes;
+            const float* QuantBScalePtr = QuantBScaleTail + c * ColStrideScale;
+
+            __m256 acc = _mm256_setzero_ps();
+
+            for (size_t sb = 0; sb < FullGroups; ++sb) {
+                accumulate_w2_blklen64_r1c1blk4<kVnni>(
+                    load_a_half_blklen64(QuantAPtr + 0 * kBlkLen), load_a_half_blklen64(QuantAPtr + 0 * kBlkLen + 32),
+                    load_a_half_blklen64(QuantAPtr + 1 * kBlkLen), load_a_half_blklen64(QuantAPtr + 1 * kBlkLen + 32),
+                    load_a_half_blklen64(QuantAPtr + 2 * kBlkLen), load_a_half_blklen64(QuantAPtr + 2 * kBlkLen + 32),
+                    load_a_half_blklen64(QuantAPtr + 3 * kBlkLen), load_a_half_blklen64(QuantAPtr + 3 * kBlkLen + 32),
+                    QuantBDataPtr, QuantAScalePtr, QuantBScalePtr, acc);
+
+                QuantAPtr += kBlkLen * kBlockGroupBlks;
+                QuantAScalePtr += kBlockGroupBlks;
+                QuantBDataPtr += kBlockGroupBytes;
+                QuantBScalePtr += kBlockGroupBlks;
+            }
+
+            if (TailBlocks > 0) {
+                const __m256i zero = _mm256_setzero_si256();
+                const __m256i a0lo = load_a_half_blklen64(QuantAPtr + 0 * kBlkLen);
+                const __m256i a0hi = load_a_half_blklen64(QuantAPtr + 0 * kBlkLen + 32);
+                const __m256i a1lo = (TailBlocks > 1) ? load_a_half_blklen64(QuantAPtr + 1 * kBlkLen) : zero;
+                const __m256i a1hi = (TailBlocks > 1) ? load_a_half_blklen64(QuantAPtr + 1 * kBlkLen + 32) : zero;
+                const __m256i a2lo = (TailBlocks > 2) ? load_a_half_blklen64(QuantAPtr + 2 * kBlkLen) : zero;
+                const __m256i a2hi = (TailBlocks > 2) ? load_a_half_blklen64(QuantAPtr + 2 * kBlkLen + 32) : zero;
+
+                float scale_a_safe[kBlockGroupBlks] = {0.0f, 0.0f, 0.0f, 0.0f};
+                for (size_t i = 0; i < TailBlocks; ++i) {
+                    scale_a_safe[i] = QuantAScalePtr[i];
+                }
+                accumulate_w2_blklen64_r1c1blk4<kVnni>(
+                    a0lo, a0hi, a1lo, a1hi, a2lo, a2hi, zero, zero,
+                    QuantBDataPtr, scale_a_safe, QuantBScalePtr, acc);
+            }
+
+            float v = hsum_float_8(acc);
+            if (BiasTail != nullptr) v += BiasTail[c];
+            C[m * ldc + c] = v;
+        }
+    }
+}
+
+//
+// Top-level BlkLen=64 kernel body (full signature; the dispatcher's default
+// case). Returns 0 unless BlkLen == 64 so the caller can fall back.
+//
+template <bool kVnni>
+static MLAS_FORCEINLINE size_t
+SQ2BitGemmKernel_BlkSum_CompInt8_BlkLen64_Impl(
+    const size_t BlkLen,
+    const std::byte* QuantA,
+    const float* QuantAScale,
+    const std::byte* QuantBData,
+    const float* QuantBScale,
+    float* C,
+    size_t CountM,
+    size_t CountN,
+    size_t BlockCountK,
+    const float* Bias,
+    size_t ldc,
+    const float* ABlockSum,
+    const float* QuantBBlkSum)
+{
+    if (BlkLen != kBlkLen) {
+        return 0;
+    }
+    if (BlockCountK == 0 || CountM == 0 || CountN == 0) {
+        return 0;
+    }
+
+    const size_t NMain = (CountN / kNCols4) * kNCols4;
+    const size_t NTail = CountN - NMain;
+
+    const size_t M_pairs = CountM / kNRows2;
+    const size_t M_main = M_pairs * kNRows2;
+    const size_t M_tail = CountM - M_main;
+    const size_t lda = BlockCountK * kBlkLen;
+
+    if (NMain > 0) {
+        if (M_main > 0) {
+            Q2Int8GemmR2xC4BlkLen64Avx2<kVnni>(
+                QuantA, QuantAScale, QuantBData, QuantBScale,
+                C, M_main, NMain, BlockCountK, Bias, ldc);
+        }
+        if (M_tail > 0) {
+            Q2Int8GemmR1xC4BlkLen64Avx2<kVnni>(
+                QuantA + M_main * lda,
+                QuantAScale + M_main * BlockCountK,
+                QuantBData, QuantBScale,
+                C + M_main * ldc,
+                /*CountM=*/M_tail,
+                NMain, BlockCountK, Bias, ldc);
+        }
+    }
+
+    if (NTail > 0) {
+        const size_t BlockGroupCountKPadded = MlasDivRoundup(BlockCountK, kBlockGroupBlks);
+        const std::byte* QuantBDataTail =
+            QuantBData + NMain * BlockGroupCountKPadded * kBlockGroupBytes;
+        const float* QuantBScaleTail =
+            QuantBScale + NMain * BlockGroupCountKPadded * kBlockGroupBlks;
+        const float* BiasTail = (Bias != nullptr) ? Bias + NMain : nullptr;
+
+        Q2Int8GemmRMxC_Tail_BlkLen64Avx2<kVnni>(
+            QuantA, QuantAScale, QuantBDataTail, QuantBScaleTail,
+            C + NMain, CountM, NTail, BlockCountK, BiasTail, ldc);
+    }
+
+    float* c_blk = C;
+    const float* b_blk_sum = QuantBBlkSum;
+    size_t RowsRemaining = CountM;
+    const float* a_blksum_row = ABlockSum;
+    while (RowsRemaining > 0) {
+        const auto RowsHandled = GetMlasPlatform().GemmFloatKernel(
+            a_blksum_row, b_blk_sum, c_blk,
+            BlockCountK, RowsRemaining, CountN, BlockCountK, ldc,
+            1.0f, /*ZeroMode=*/false);
+
+        c_blk += ldc * RowsHandled;
+        a_blksum_row += BlockCountK * RowsHandled;
+        RowsRemaining -= RowsHandled;
+    }
+    return CountM;
+}
+
+static MLAS_FORCEINLINE size_t MLASCALL
+SQ2BitGemmKernel_BlkSum_CompInt8_Avx2Vnni(
+    const size_t BlkLen,
+    const std::byte* QuantA,
+    const float* QuantAScale,
+    const std::byte* QuantBData,
+    const float* QuantBScale,
+    const std::byte* /* QuantBZeroPoint */,
+    float* C,
+    size_t CountM,
+    size_t CountN,
+    size_t /* CountK */,
+    size_t BlockCountK,
+    const float* Bias,
+    size_t ldc,
+    const float* ABlockSum,
+    const float* QuantBBlkSum)
+{
+    return SQ2BitGemmKernel_BlkSum_CompInt8_BlkLen64_Impl<true>(
+        BlkLen, QuantA, QuantAScale, QuantBData, QuantBScale,
+        C, CountM, CountN, BlockCountK, Bias, ldc, ABlockSum, QuantBBlkSum);
+}
+
+static MLAS_FORCEINLINE size_t MLASCALL
+SQ2BitGemmKernel_BlkSum_CompInt8_Avx2(
+    const size_t BlkLen,
+    const std::byte* QuantA,
+    const float* QuantAScale,
+    const std::byte* QuantBData,
+    const float* QuantBScale,
+    const std::byte* /* QuantBZeroPoint */,
+    float* C,
+    size_t CountM,
+    size_t CountN,
+    size_t /* CountK */,
+    size_t BlockCountK,
+    const float* Bias,
+    size_t ldc,
+    const float* ABlockSum,
+    const float* QuantBBlkSum)
+{
+    return SQ2BitGemmKernel_BlkSum_CompInt8_BlkLen64_Impl<false>(
+        BlkLen, QuantA, QuantAScale, QuantBData, QuantBScale,
+        C, CountM, CountN, BlockCountK, Bias, ldc, ABlockSum, QuantBBlkSum);
+}
+
+}  // namespace sq2bit_avx2
+}  // namespace mlas
+}  // namespace onnxruntime

--- a/onnxruntime/core/mlas/lib/sqnbitgemm_kernel_avx2_2bit_blklen64.h
+++ b/onnxruntime/core/mlas/lib/sqnbitgemm_kernel_avx2_2bit_blklen64.h
@@ -292,7 +292,9 @@ Q2Int8GemmR1xC4BlkLen64Avx2(
 
             QuantBDataColPtr += GroupStrideBytes;
             QuantBScaleColPtr += GroupStrideScale;
-            BiasPtr += BiasPtr != nullptr ? kNCols4 : 0;
+            if (BiasPtr != nullptr) {
+                BiasPtr += kNCols4;
+            }
             SumPtr += kNCols4;
         }
     }
@@ -395,7 +397,9 @@ Q2Int8GemmR2xC4BlkLen64Avx2(
 
             QuantBDataColPtr += GroupStrideBytes;
             QuantBScaleColPtr += GroupStrideScale;
-            BiasPtr += BiasPtr != nullptr ? kNCols4 : 0;
+            if (BiasPtr != nullptr) {
+                BiasPtr += kNCols4;
+            }
             SumPtr += kNCols4;
         }
     }

--- a/onnxruntime/core/mlas/lib/sqnbitgemm_kernel_avx512.cpp
+++ b/onnxruntime/core/mlas/lib/sqnbitgemm_kernel_avx512.cpp
@@ -550,9 +550,7 @@ const MLAS_QNBIT_GEMM_DISPATCH MlasSQNBitGemmDispatchAvx512 = []() {
     d.Q2BitGemmPackQuantBDataSize       = onnxruntime::mlas::sq2bit_avx512::Q2BitGemmPackQuantBDataSize_Avx512;
     d.SQ2BitGemmPackQuantBDataAndBlkSum = onnxruntime::mlas::sq2bit_avx512::SQ2BitGemmPackQuantBDataAndBlkSum_Scalar;
     d.SQ2BitGemmKernel_BlkSum_CompInt8  = onnxruntime::mlas::sq2bit_avx512::SQ2BitGemmKernel_BlkSum_CompInt8_Avx512_Dispatch;
-    d.Q2BitGemmEffectiveBlockCountK     = [](size_t BlockCountK) {
-        return MlasDivRoundup(BlockCountK, kSq2BitAvx512WeightKBlockGroup) * kSq2BitAvx512WeightKBlockGroup;
-    };
+    d.Q2BitGemmEffectiveBlockCountK     = onnxruntime::mlas::sq2bit_avx512::Q2BitGemmEffectiveBlockCountK;
 
     return d;
 }();

--- a/onnxruntime/core/mlas/lib/sqnbitgemm_kernel_avx512_2bit.h
+++ b/onnxruntime/core/mlas/lib/sqnbitgemm_kernel_avx512_2bit.h
@@ -89,6 +89,14 @@ constexpr size_t kBlockGroupBlks = 4;                                // 4 K-bloc
 constexpr size_t kBlockGroupBytes = kBlockGroupBlks * kBlkBytes;     // 64 bytes
 constexpr size_t kBlockGroupWeights = kBlockGroupBlks * kBlkLen;     // 256 weights
 
+// Effective (padded) BlockCountK of the packed layout: the dispatch tables
+// report the per-column K stride rounded up to a whole block-group.
+constexpr size_t
+Q2BitGemmEffectiveBlockCountK(size_t BlockCountK)
+{
+    return ((BlockCountK + kBlockGroupBlks - 1) / kBlockGroupBlks) * kBlockGroupBlks;
+}
+
 //
 // Extract a single 2-bit weight from a standard ONNX MatMulNBits packed byte
 // stream. `src` is the start of one block (kBlkBytes bytes). `i` is the

--- a/onnxruntime/core/mlas/lib/sqnbitgemm_kernel_avx512vnni.cpp
+++ b/onnxruntime/core/mlas/lib/sqnbitgemm_kernel_avx512vnni.cpp
@@ -534,9 +534,7 @@ const MLAS_QNBIT_GEMM_DISPATCH MlasSQNBitGemmDispatchAvx512vnni = []() {
     d.Q2BitGemmPackQuantBDataSize       = onnxruntime::mlas::sq2bit_avx512::Q2BitGemmPackQuantBDataSize_Avx512;
     d.SQ2BitGemmPackQuantBDataAndBlkSum = onnxruntime::mlas::sq2bit_avx512::SQ2BitGemmPackQuantBDataAndBlkSum_Scalar;
     d.SQ2BitGemmKernel_BlkSum_CompInt8  = onnxruntime::mlas::sq2bit_avx512::SQ2BitGemmKernel_BlkSum_CompInt8_Avx512Vnni_Dispatch;
-    d.Q2BitGemmEffectiveBlockCountK     = [](size_t BlockCountK) {
-        return MlasDivRoundup(BlockCountK, kSq2BitAvx512WeightKBlockGroup) * kSq2BitAvx512WeightKBlockGroup;
-    };
+    d.Q2BitGemmEffectiveBlockCountK     = onnxruntime::mlas::sq2bit_avx512::Q2BitGemmEffectiveBlockCountK;
 
     return d;
 }();

--- a/onnxruntime/test/mlas/unittest/test_sqnbitgemm_2bit_gemm.cpp
+++ b/onnxruntime/test/mlas/unittest/test_sqnbitgemm_2bit_gemm.cpp
@@ -35,10 +35,12 @@ Abstract:
 #include "core/mlas/lib/qnbitgemm.h"
 #include "core/mlas/lib/mlasi.h"
 #include "core/mlas/lib/sqnbitgemm_kernel_avx512_2bit.h"
+#include "core/mlas/lib/sqnbitgemm_kernel_avx2_2bit.h"
 
 namespace {
 
 namespace sq2 = onnxruntime::mlas::sq2bit_avx512;
+namespace sq2a = onnxruntime::mlas::sq2bit_avx2;
 
 constexpr size_t kBlkLen = sq2::kBlkLen;      // 64
 constexpr size_t kBlkBytes = sq2::kBlkBytes;  // 16
@@ -1501,3 +1503,195 @@ TEST(MlasSq2BitTest, AvailabilityContract_BlkLens) {
   EXPECT_FALSE(MlasIsQNBitGemmAvailable(2, 64, SQNBIT_CompFp32));
   EXPECT_FALSE(MlasIsQNBitGemmAvailable(2, 64, HQNBIT_CompFp16));
 }
+
+#if defined(MLAS_TARGET_AMD64)
+
+// =============================================================================
+// AVX2 / AVX2-VNNI W2 coverage. Reuses the same RunW2Case* harnesses and
+// kSimdShapes* tables as the AVX-512 tests above. The non-VNNI tests guard on
+// Avx2Supported_, so they also run on AVX-512 hosts and exercise the
+// vpmaddubsw + vpmaddwd fallback there. The VNNI tests guard on the AVX2-VNNI
+// dispatch being the active one (the SIMD path uses _mm256_dpbusds_avx_epi32).
+// =============================================================================
+
+TEST(MlasSq2BitTest, BlkLen64_Avx2) {
+  if (!GetMlasPlatform().Avx2Supported_) {
+    GTEST_SKIP() << "AVX2 not available on this host";
+  }
+  for (uint32_t seed : {0xC0FFEEu, 0xBADC0DEu}) {
+    for (const auto& s : kSimdShapes) {
+      for (bool bias : {false, true}) {
+        RunW2Case(s.M, s.N, s.K, bias, seed + (bias ? 1u : 0u),
+                  /*WithZeroPoints=*/false,
+                  sq2a::SQ2BitGemmKernel_BlkSum_CompInt8_Avx2_Dispatch, "AVX2");
+      }
+    }
+  }
+}
+
+TEST(MlasSq2BitTest, BlkLen64_Avx2_WithZeroPoints) {
+  if (!GetMlasPlatform().Avx2Supported_) {
+    GTEST_SKIP() << "AVX2 not available on this host";
+  }
+  for (uint32_t seed : {0xC0FFEEu, 0xBADC0DEu}) {
+    for (const auto& s : kSimdShapes) {
+      for (bool bias : {false, true}) {
+        RunW2Case(s.M, s.N, s.K, bias, seed + (bias ? 1u : 0u),
+                  /*WithZeroPoints=*/true,
+                  sq2a::SQ2BitGemmKernel_BlkSum_CompInt8_Avx2_Dispatch, "AVX2");
+      }
+    }
+  }
+}
+
+TEST(MlasSq2BitTest, BlkLen64_Avx2Vnni) {
+  if (GetMlasPlatform().QNBitGemmDispatch != &MlasSQNBitGemmDispatchAvx2vnni) {
+    GTEST_SKIP() << "AVX2-VNNI not selected as the active dispatch on this host";
+  }
+  for (uint32_t seed : {0xC0FFEEu, 0xBADC0DEu}) {
+    for (const auto& s : kSimdShapes) {
+      for (bool bias : {false, true}) {
+        RunW2Case(s.M, s.N, s.K, bias, seed + (bias ? 1u : 0u),
+                  /*WithZeroPoints=*/false,
+                  sq2a::SQ2BitGemmKernel_BlkSum_CompInt8_Avx2Vnni_Dispatch, "AVX2-VNNI");
+      }
+    }
+  }
+}
+
+TEST(MlasSq2BitTest, BlkLen64_Avx2Vnni_WithZeroPoints) {
+  if (GetMlasPlatform().QNBitGemmDispatch != &MlasSQNBitGemmDispatchAvx2vnni) {
+    GTEST_SKIP() << "AVX2-VNNI not selected as the active dispatch on this host";
+  }
+  for (uint32_t seed : {0xC0FFEEu, 0xBADC0DEu}) {
+    for (const auto& s : kSimdShapes) {
+      for (bool bias : {false, true}) {
+        RunW2Case(s.M, s.N, s.K, bias, seed + (bias ? 1u : 0u),
+                  /*WithZeroPoints=*/true,
+                  sq2a::SQ2BitGemmKernel_BlkSum_CompInt8_Avx2Vnni_Dispatch, "AVX2-VNNI");
+      }
+    }
+  }
+}
+
+TEST(MlasSq2BitTest, BlkLen128_Avx2) {
+  if (!GetMlasPlatform().Avx2Supported_) {
+    GTEST_SKIP() << "AVX2 not available on this host";
+  }
+  for (uint32_t seed : {0xC0FFEEu, 0xBADC0DEu}) {
+    for (const auto& s : kSimdShapes_BlkLen128) {
+      for (bool bias : {false, true}) {
+        RunW2Case_BlkLen128(s.M, s.N, s.K, bias, seed + (bias ? 1u : 0u),
+                            /*WithZeroPoints=*/false,
+                            sq2a::SQ2BitGemmKernel_BlkSum_CompInt8_Avx2_Dispatch, "AVX2");
+      }
+    }
+  }
+}
+
+TEST(MlasSq2BitTest, BlkLen128_Avx2_WithZeroPoints) {
+  if (!GetMlasPlatform().Avx2Supported_) {
+    GTEST_SKIP() << "AVX2 not available on this host";
+  }
+  for (uint32_t seed : {0xC0FFEEu, 0xBADC0DEu}) {
+    for (const auto& s : kSimdShapes_BlkLen128) {
+      for (bool bias : {false, true}) {
+        RunW2Case_BlkLen128(s.M, s.N, s.K, bias, seed + (bias ? 1u : 0u),
+                            /*WithZeroPoints=*/true,
+                            sq2a::SQ2BitGemmKernel_BlkSum_CompInt8_Avx2_Dispatch, "AVX2");
+      }
+    }
+  }
+}
+
+TEST(MlasSq2BitTest, BlkLen128_Avx2Vnni) {
+  if (GetMlasPlatform().QNBitGemmDispatch != &MlasSQNBitGemmDispatchAvx2vnni) {
+    GTEST_SKIP() << "AVX2-VNNI not selected as the active dispatch on this host";
+  }
+  for (uint32_t seed : {0xC0FFEEu, 0xBADC0DEu}) {
+    for (const auto& s : kSimdShapes_BlkLen128) {
+      for (bool bias : {false, true}) {
+        RunW2Case_BlkLen128(s.M, s.N, s.K, bias, seed + (bias ? 1u : 0u),
+                            /*WithZeroPoints=*/false,
+                            sq2a::SQ2BitGemmKernel_BlkSum_CompInt8_Avx2Vnni_Dispatch, "AVX2-VNNI");
+      }
+    }
+  }
+}
+
+TEST(MlasSq2BitTest, BlkLen128_Avx2Vnni_WithZeroPoints) {
+  if (GetMlasPlatform().QNBitGemmDispatch != &MlasSQNBitGemmDispatchAvx2vnni) {
+    GTEST_SKIP() << "AVX2-VNNI not selected as the active dispatch on this host";
+  }
+  for (uint32_t seed : {0xC0FFEEu, 0xBADC0DEu}) {
+    for (const auto& s : kSimdShapes_BlkLen128) {
+      for (bool bias : {false, true}) {
+        RunW2Case_BlkLen128(s.M, s.N, s.K, bias, seed + (bias ? 1u : 0u),
+                            /*WithZeroPoints=*/true,
+                            sq2a::SQ2BitGemmKernel_BlkSum_CompInt8_Avx2Vnni_Dispatch, "AVX2-VNNI");
+      }
+    }
+  }
+}
+
+TEST(MlasSq2BitTest, BlkLen32_Avx2) {
+  if (!GetMlasPlatform().Avx2Supported_) {
+    GTEST_SKIP() << "AVX2 not available on this host";
+  }
+  for (uint32_t seed : {0xC0FFEEu, 0xBADC0DEu}) {
+    for (const auto& s : kSimdShapes_BlkLen32) {
+      for (bool bias : {false, true}) {
+        RunW2Case_BlkLen32(s.M, s.N, s.K, bias, seed + (bias ? 1u : 0u),
+                           /*WithZeroPoints=*/false,
+                           sq2a::SQ2BitGemmKernel_BlkSum_CompInt8_Avx2_Dispatch, "AVX2");
+      }
+    }
+  }
+}
+
+TEST(MlasSq2BitTest, BlkLen32_Avx2_WithZeroPoints) {
+  if (!GetMlasPlatform().Avx2Supported_) {
+    GTEST_SKIP() << "AVX2 not available on this host";
+  }
+  for (uint32_t seed : {0xC0FFEEu, 0xBADC0DEu}) {
+    for (const auto& s : kSimdShapes_BlkLen32) {
+      for (bool bias : {false, true}) {
+        RunW2Case_BlkLen32(s.M, s.N, s.K, bias, seed + (bias ? 1u : 0u),
+                           /*WithZeroPoints=*/true,
+                           sq2a::SQ2BitGemmKernel_BlkSum_CompInt8_Avx2_Dispatch, "AVX2");
+      }
+    }
+  }
+}
+
+TEST(MlasSq2BitTest, BlkLen32_Avx2Vnni) {
+  if (GetMlasPlatform().QNBitGemmDispatch != &MlasSQNBitGemmDispatchAvx2vnni) {
+    GTEST_SKIP() << "AVX2-VNNI not selected as the active dispatch on this host";
+  }
+  for (uint32_t seed : {0xC0FFEEu, 0xBADC0DEu}) {
+    for (const auto& s : kSimdShapes_BlkLen32) {
+      for (bool bias : {false, true}) {
+        RunW2Case_BlkLen32(s.M, s.N, s.K, bias, seed + (bias ? 1u : 0u),
+                           /*WithZeroPoints=*/false,
+                           sq2a::SQ2BitGemmKernel_BlkSum_CompInt8_Avx2Vnni_Dispatch, "AVX2-VNNI");
+      }
+    }
+  }
+}
+
+TEST(MlasSq2BitTest, BlkLen32_Avx2Vnni_WithZeroPoints) {
+  if (GetMlasPlatform().QNBitGemmDispatch != &MlasSQNBitGemmDispatchAvx2vnni) {
+    GTEST_SKIP() << "AVX2-VNNI not selected as the active dispatch on this host";
+  }
+  for (uint32_t seed : {0xC0FFEEu, 0xBADC0DEu}) {
+    for (const auto& s : kSimdShapes_BlkLen32) {
+      for (bool bias : {false, true}) {
+        RunW2Case_BlkLen32(s.M, s.N, s.K, bias, seed + (bias ? 1u : 0u),
+                           /*WithZeroPoints=*/true,
+                           sq2a::SQ2BitGemmKernel_BlkSum_CompInt8_Avx2Vnni_Dispatch, "AVX2-VNNI");
+      }
+    }
+  }
+}
+
+#endif  // defined(MLAS_TARGET_AMD64)


### PR DESCRIPTION
### Description

This adds native (non-LUT) 2-bit weight CompInt8 kernels to MLAS for AVX2 and AVX-VNNI, BlkLen 32/64/128, modeled on the AVX-512 kernels from #29064 and the ARM64 kernels from #29466. On these hosts a W2 MatMulNBits currently has the LUT path (opt-in, and only when N is a multiple of 128) or the fp32 dequant + SGEMM fallback.

The packed layout is untouched. The block-group packer, scale layout and BlkSum machinery in sqnbitgemm_kernel_avx512_2bit.{h,cpp} are portable scalar C++ and the ARM64 kernels already reuse them, so this only adds the 256-bit compute kernels and the dispatch wiring. The four W2 entries are populated in MlasSQNBitGemmDispatchAvx2 and MlasSQNBitGemmDispatchAvx2vnni with BlkLen routing forwarders like the AVX-512 ones, and A quantization reuses the QuantizeARow_CompInt8_avx2 those tables already register. No cmake changes (the kernels are header-only and the avx2 source list already carries -mavxvnni where the compiler supports it) and no operator changes.

Per-node routing:

| Host | LUT mode | before | after |
|---|---|---|---|
| AVX2 / AVX-VNNI | off (default) | fp32 dequant + SGEMM | native W2 kernel |
| AVX2 / AVX-VNNI | on, N % 128 == 0 | LUT kernel | LUT kernel (unchanged) |
| AVX2 / AVX-VNNI | on, N % 128 != 0 | fp32 dequant + SGEMM | native W2 kernel |

Tile shapes are per BlkLen and I picked them by measuring. BlkLen 32 and 64 use an R2xC4 main tile (one B block-group load and unpack shared across two rows) with an R1xC4 tail for an odd trailing row. BlkLen 128 stays R1xC4: the R2 variant measured 3 to 5% slower there, which tracks with register pressure, since a 128-byte group needs four B registers live plus eight accumulators and that does not fit sixteen YMM. M=1 always takes the R1 path, so decode is unaffected by the tiling choice either way.

Hosts with AVX2 but no AVX-VNNI use the vpmaddubsw + vpmaddwd fallback, guarded the same way as the existing int8 kernels.

Testing:
- new direct-kernel tests in test_sqnbitgemm_2bit_gemm.cpp mirroring the AVX-512 set, four per BlkLen, with and without zero points. The non-VNNI variants guard on Avx2Supported_ so they also run on the AVX-512 CI hosts and cover the maddubs path there; the VNNI variants gate on the AVX2-VNNI dispatch being the active one.
- the existing MatMul2Bits operator tests exercise the new path automatically on AVX2 hosts at accuracy_level 4.
- validated the kernels against a float64 reference over 120+ cases (N tails, K tails, odd M, both dot paths) on packing produced by the production 3-call pack sequence.

### Motivation and Context

#29064 closed this gap on AVX-512 and #29466 on ARM64, but AVX2/AVX-VNNI without AVX-512 covers most client x86 (Alder Lake through Arrow Lake, plus Zen 1-3 on the plain AVX2 path) and those hosts still land on dequant + SGEMM by default.

Kernel-level numbers from a Core Ultra 5 225 (Arrow Lake, AVX2 + AVX-VNNI, no AVX-512), single thread, interleaved arms, min of 9 rounds on rdtsc:

| BlkLen | cycles/MAC at prefill (shipped tile) | R2xC4 vs R1xC4 at prefill |
|---|---|---|
| 32 | ~0.048 | R2 5 to 6% faster (shipped) |
| 64 | ~0.031 | R2 11 to 15% faster (shipped) |
| 128 | ~0.027 | R2 3 to 5% slower (kept R1) |

These are tile-level microbenchmarks, not end-to-end model numbers; my dev box has no MSVC so my validation is kernel-level and the MSVC build rides on CI. Happy to run whatever end-to-end comparison you want on top of this, and happy to restructure the tiles if you would rather keep all three BlkLens on the same shape.
