### PR TITLE
Fix JSEP pooling output shape to honor ceil_mode

### DIFF
--- a/js/web/lib/onnxjs/util.ts
+++ b/js/web/lib/onnxjs/util.ts
@@ -1417,7 +1417,7 @@ export class PoolConvUtil {
           if (dilation !== 1) {
             throw new Error('Dilation not supported for SAME_UPPER or SAME_LOWER');
           } else {
-            const legacyTargetSize = (inSize + stride - 1) / stride;
+            const legacyTargetSize = Math.floor((inSize + stride - 1) / stride);
             const padNeeded = (legacyTargetSize - 1) * stride + kernel - inSize;
             pads[padHeadIndex] = autoPad === 'SAME_LOWER' ? Math.floor((padNeeded + 1) / 2) : Math.floor(padNeeded / 2);
             pads[padTailIndex] = padNeeded - pads[padHeadIndex];

--- a/js/web/lib/onnxjs/util.ts
+++ b/js/web/lib/onnxjs/util.ts
@@ -1417,6 +1417,7 @@ export class PoolConvUtil {
           if (dilation !== 1) {
             throw new Error('Dilation not supported for SAME_UPPER or SAME_LOWER');
           } else {
+            // Integer division to match C++ pool_attributes.h ComputeSizePadDilations; float division mis-rounds SAME_* pads.
             const legacyTargetSize = Math.floor((inSize + stride - 1) / stride);
             const padNeeded = (legacyTargetSize - 1) * stride + kernel - inSize;
             pads[padHeadIndex] = autoPad === 'SAME_LOWER' ? Math.floor((padNeeded + 1) / 2) : Math.floor(padNeeded / 2);

--- a/js/web/lib/onnxjs/util.ts
+++ b/js/web/lib/onnxjs/util.ts
@@ -1260,6 +1260,8 @@ export class PoolConvUtil {
    * @param pads Padding for the beginning and ending along each axis.
    * @param autoPad DEPRECATED attribute supported for legacy models. Specifies how to implicitly calculate pads in each
    *     dimension. Can take values NOTSET, SAME_UPPER, SAME_LOWER, or VALID.
+   * @param ceilMode When set to 1, use ceil() instead of floor() to compute the output spatial size (and apply the
+   *     "shrink the last window if it starts entirely in padding" rule). Defaults to 0 (floor).
    */
   static computePoolOutputShape(
     isGlobalOperator: boolean,
@@ -1269,6 +1271,7 @@ export class PoolConvUtil {
     kernelShape: number[],
     pads: number[],
     autoPad?: string,
+    ceilMode = 0,
   ): number[] {
     if (inputDims.length <= 0) {
       throw new Error('input shape must be of size greater than 0');
@@ -1286,6 +1289,7 @@ export class PoolConvUtil {
       kernelShape,
       pads,
       autoPad,
+      ceilMode,
     );
     return outputDims;
   }
@@ -1332,6 +1336,7 @@ export class PoolConvUtil {
     kernelShape: readonly number[],
     pads: number[],
     autoPad?: string,
+    ceilMode = 0,
   ) {
     if (isGlobalOperator) {
       for (let dim = 0; dim < inputDims.length - 2; dim++) {
@@ -1349,10 +1354,35 @@ export class PoolConvUtil {
             dim,
             dim + inputDims.length - 2,
             autoPad,
+            ceilMode,
           ),
         );
       }
     }
+  }
+
+  // Computes the output spatial size for a single dimension.
+  // Replicates the C++ PoolAttributes::ComputeOutputSize
+  // (onnxruntime/core/providers/cpu/nn/pool_attributes.h) EXACTLY, including the ceil_mode
+  // "shrink the last window if it starts entirely in the trailing padding" rule. Keep the two
+  // in algebraic lockstep: `numerator` here already equals `inSize + padHead + padTail - dkernel`,
+  // matching the C++ `in_size + pad_head + pad_tail - dilation * (kernel - 1) - 1`.
+  private static computeOutputSize(
+    numerator: number,
+    stride: number,
+    inSize: number,
+    padHead: number,
+    ceilMode: number,
+  ): number {
+    let outSize = Math.floor(numerator / stride) + 1;
+    if (ceilMode) {
+      outSize = Math.ceil(numerator / stride) + 1;
+      // Ensure the last pooling window starts inside the image (ref: https://github.com/onnx/onnx/pull/5741).
+      if ((outSize - 1) * stride >= inSize + padHead) {
+        outSize -= 1;
+      }
+    }
+    return outSize;
   }
 
   // helper for computeShapeHelper() and adjustPadsBasedOnAutoPad()
@@ -1366,6 +1396,7 @@ export class PoolConvUtil {
     padHeadIndex: number,
     padTailIndex: number,
     autoPad?: string,
+    ceilMode = 0,
   ): number {
     const dkernel = dilation * (kernel - 1) + 1;
     if (autoPad && autoPad !== 'NOTSET') {
@@ -1373,7 +1404,7 @@ export class PoolConvUtil {
         case 'VALID':
           pads[padHeadIndex] = 0;
           pads[padTailIndex] = 0;
-          return Math.floor((inSize - dkernel) / stride + 1);
+          return PoolConvUtil.computeOutputSize(inSize - dkernel, stride, inSize, 0, ceilMode);
         case 'SAME_LOWER':
         case 'SAME_UPPER':
           if (dilation !== 1) {
@@ -1383,13 +1414,25 @@ export class PoolConvUtil {
             const padNeeded = (legacyTargetSize - 1) * stride + kernel - inSize;
             pads[padHeadIndex] = autoPad === 'SAME_LOWER' ? Math.floor((padNeeded + 1) / 2) : Math.floor(padNeeded / 2);
             pads[padTailIndex] = padNeeded - pads[padHeadIndex];
-            return Math.floor((inSize + padNeeded - kernel) / stride + 1);
+            return PoolConvUtil.computeOutputSize(
+              inSize + pads[padHeadIndex] + pads[padTailIndex] - dkernel,
+              stride,
+              inSize,
+              pads[padHeadIndex],
+              ceilMode,
+            );
           }
         default:
           throw new Error('Unsupported AutoPad type');
       }
     } else {
-      return Math.floor((inSize + pads[padHeadIndex] + pads[padTailIndex] - dkernel) / stride + 1);
+      return PoolConvUtil.computeOutputSize(
+        inSize + pads[padHeadIndex] + pads[padTailIndex] - dkernel,
+        stride,
+        inSize,
+        pads[padHeadIndex],
+        ceilMode,
+      );
     }
   }
 }

--- a/js/web/lib/onnxjs/util.ts
+++ b/js/web/lib/onnxjs/util.ts
@@ -1362,11 +1362,16 @@ export class PoolConvUtil {
   }
 
   // Computes the output spatial size for a single dimension.
-  // Replicates the C++ PoolAttributes::ComputeOutputSize
-  // (onnxruntime/core/providers/cpu/nn/pool_attributes.h) EXACTLY, including the ceil_mode
-  // "shrink the last window if it starts entirely in the trailing padding" rule. Keep the two
-  // in algebraic lockstep: `numerator` here already equals `inSize + padHead + padTail - dkernel`,
-  // matching the C++ `in_size + pad_head + pad_tail - dilation * (kernel - 1) - 1`.
+  // Produces results identical to the C++ PoolAttributes::ComputeOutputSize
+  // (onnxruntime/core/providers/cpu/nn/pool_attributes.h), including the ceil_mode
+  // "shrink the last window if it starts entirely in the trailing padding" rule. The JS
+  // signature takes a pre-computed `numerator` (equal to `inSize + padHead + padTail - dkernel`,
+  // matching the C++ `in_size + pad_head + pad_tail - dilation * (kernel - 1) - 1`) instead of
+  // the raw pooling attributes, but the computed output size is the same.
+  // Keep in sync with the onnxjs/jsep copy.
+  // NOTE: In this onnxjs copy the ceilMode path exists for shape-test parity with the jsep copy;
+  // the onnxjs WebGL pooling caller (backends/webgl/ops/pool.ts) intentionally does NOT pass
+  // ceilMode (legacy path still throws on ceil_mode != 0), so it always uses the floor default.
   private static computeOutputSize(
     numerator: number,
     stride: number,
@@ -1375,9 +1380,11 @@ export class PoolConvUtil {
     ceilMode: number,
   ): number {
     let outSize = Math.floor(numerator / stride) + 1;
-    if (ceilMode) {
+    // Match C++ `ceil_mode == 1` exactly so out-of-spec ceil_mode values do not diverge.
+    if (ceilMode === 1) {
       outSize = Math.ceil(numerator / stride) + 1;
       // Ensure the last pooling window starts inside the image (ref: https://github.com/onnx/onnx/pull/5741).
+      // inSize and padHead are needed here to reconstruct the last window's start position.
       if ((outSize - 1) * stride >= inSize + padHead) {
         outSize -= 1;
       }

--- a/js/web/lib/wasm/jsep/util.ts
+++ b/js/web/lib/wasm/jsep/util.ts
@@ -520,6 +520,7 @@ export class PoolConvUtil {
           if (dilation !== 1) {
             throw new Error('Dilation not supported for SAME_UPPER or SAME_LOWER');
           } else {
+            // Integer division to match C++ pool_attributes.h ComputeSizePadDilations; float division mis-rounds SAME_* pads.
             const legacyTargetSize = Math.floor((inSize + stride - 1) / stride);
             const padNeeded = (legacyTargetSize - 1) * stride + kernel - inSize;
             pads[padHeadIndex] = autoPad === 'SAME_LOWER' ? Math.floor((padNeeded + 1) / 2) : Math.floor(padNeeded / 2);

--- a/js/web/lib/wasm/jsep/util.ts
+++ b/js/web/lib/wasm/jsep/util.ts
@@ -366,6 +366,8 @@ export class PoolConvUtil {
    * @param pads Padding for the beginning and ending along each axis.
    * @param autoPad DEPRECATED attribute supported for legacy models. Specifies how to implicitly calculate pads in each
    *     dimension. Can take values NOTSET, SAME_UPPER, SAME_LOWER, or VALID.
+   * @param ceilMode When set to 1, use ceil() instead of floor() to compute the output spatial size (and apply the
+   *     "shrink the last window if it starts entirely in padding" rule). Defaults to 0 (floor).
    */
   static computePoolOutputShape(
     isGlobalOperator: boolean,
@@ -375,6 +377,7 @@ export class PoolConvUtil {
     kernelShape: number[],
     pads: number[],
     autoPad?: string,
+    ceilMode = 0,
   ): number[] {
     if (inputDims.length <= 0) {
       throw new Error('input shape must be of size greater than 0');
@@ -392,6 +395,7 @@ export class PoolConvUtil {
       kernelShape,
       pads,
       autoPad,
+      ceilMode,
     );
     return outputDims;
   }
@@ -438,6 +442,7 @@ export class PoolConvUtil {
     kernelShape: readonly number[],
     pads: number[],
     autoPad?: string,
+    ceilMode = 0,
   ) {
     if (isGlobalOperator) {
       for (let dim = 0; dim < inputDims.length - 2; dim++) {
@@ -455,10 +460,35 @@ export class PoolConvUtil {
             dim,
             dim + inputDims.length - 2,
             autoPad,
+            ceilMode,
           ),
         );
       }
     }
+  }
+
+  // Computes the output spatial size for a single dimension.
+  // Replicates the C++ PoolAttributes::ComputeOutputSize
+  // (onnxruntime/core/providers/cpu/nn/pool_attributes.h) EXACTLY, including the ceil_mode
+  // "shrink the last window if it starts entirely in the trailing padding" rule. Keep the two
+  // in algebraic lockstep: `numerator` here already equals `inSize + padHead + padTail - dkernel`,
+  // matching the C++ `in_size + pad_head + pad_tail - dilation * (kernel - 1) - 1`.
+  private static computeOutputSize(
+    numerator: number,
+    stride: number,
+    inSize: number,
+    padHead: number,
+    ceilMode: number,
+  ): number {
+    let outSize = Math.floor(numerator / stride) + 1;
+    if (ceilMode) {
+      outSize = Math.ceil(numerator / stride) + 1;
+      // Ensure the last pooling window starts inside the image (ref: https://github.com/onnx/onnx/pull/5741).
+      if ((outSize - 1) * stride >= inSize + padHead) {
+        outSize -= 1;
+      }
+    }
+    return outSize;
   }
 
   // helper for computeShapeHelper() and adjustPadsBasedOnAutoPad()
@@ -472,6 +502,7 @@ export class PoolConvUtil {
     padHeadIndex: number,
     padTailIndex: number,
     autoPad?: string,
+    ceilMode = 0,
   ): number {
     const dkernel = dilation * (kernel - 1) + 1;
     if (autoPad && autoPad !== 'NOTSET') {
@@ -479,7 +510,7 @@ export class PoolConvUtil {
         case 'VALID':
           pads[padHeadIndex] = 0;
           pads[padTailIndex] = 0;
-          return Math.floor((inSize - dkernel) / stride + 1);
+          return PoolConvUtil.computeOutputSize(inSize - dkernel, stride, inSize, 0, ceilMode);
         case 'SAME_LOWER':
         case 'SAME_UPPER':
           if (dilation !== 1) {
@@ -489,13 +520,25 @@ export class PoolConvUtil {
             const padNeeded = (legacyTargetSize - 1) * stride + kernel - inSize;
             pads[padHeadIndex] = autoPad === 'SAME_LOWER' ? Math.floor((padNeeded + 1) / 2) : Math.floor(padNeeded / 2);
             pads[padTailIndex] = padNeeded - pads[padHeadIndex];
-            return Math.floor((inSize + padNeeded - kernel) / stride + 1);
+            return PoolConvUtil.computeOutputSize(
+              inSize + pads[padHeadIndex] + pads[padTailIndex] - dkernel,
+              stride,
+              inSize,
+              pads[padHeadIndex],
+              ceilMode,
+            );
           }
         default:
           throw new Error('Unsupported AutoPad type');
       }
     } else {
-      return Math.floor((inSize + pads[padHeadIndex] + pads[padTailIndex] - dkernel) / stride + 1);
+      return PoolConvUtil.computeOutputSize(
+        inSize + pads[padHeadIndex] + pads[padTailIndex] - dkernel,
+        stride,
+        inSize,
+        pads[padHeadIndex],
+        ceilMode,
+      );
     }
   }
 }

--- a/js/web/lib/wasm/jsep/util.ts
+++ b/js/web/lib/wasm/jsep/util.ts
@@ -520,7 +520,7 @@ export class PoolConvUtil {
           if (dilation !== 1) {
             throw new Error('Dilation not supported for SAME_UPPER or SAME_LOWER');
           } else {
-            const legacyTargetSize = (inSize + stride - 1) / stride;
+            const legacyTargetSize = Math.floor((inSize + stride - 1) / stride);
             const padNeeded = (legacyTargetSize - 1) * stride + kernel - inSize;
             pads[padHeadIndex] = autoPad === 'SAME_LOWER' ? Math.floor((padNeeded + 1) / 2) : Math.floor(padNeeded / 2);
             pads[padTailIndex] = padNeeded - pads[padHeadIndex];

--- a/js/web/lib/wasm/jsep/util.ts
+++ b/js/web/lib/wasm/jsep/util.ts
@@ -468,11 +468,13 @@ export class PoolConvUtil {
   }
 
   // Computes the output spatial size for a single dimension.
-  // Replicates the C++ PoolAttributes::ComputeOutputSize
-  // (onnxruntime/core/providers/cpu/nn/pool_attributes.h) EXACTLY, including the ceil_mode
-  // "shrink the last window if it starts entirely in the trailing padding" rule. Keep the two
-  // in algebraic lockstep: `numerator` here already equals `inSize + padHead + padTail - dkernel`,
-  // matching the C++ `in_size + pad_head + pad_tail - dilation * (kernel - 1) - 1`.
+  // Produces results identical to the C++ PoolAttributes::ComputeOutputSize
+  // (onnxruntime/core/providers/cpu/nn/pool_attributes.h), including the ceil_mode
+  // "shrink the last window if it starts entirely in the trailing padding" rule. The JS
+  // signature takes a pre-computed `numerator` (equal to `inSize + padHead + padTail - dkernel`,
+  // matching the C++ `in_size + pad_head + pad_tail - dilation * (kernel - 1) - 1`) instead of
+  // the raw pooling attributes, but the computed output size is the same.
+  // Keep in sync with the onnxjs/jsep copy.
   private static computeOutputSize(
     numerator: number,
     stride: number,
@@ -481,9 +483,11 @@ export class PoolConvUtil {
     ceilMode: number,
   ): number {
     let outSize = Math.floor(numerator / stride) + 1;
-    if (ceilMode) {
+    // Match C++ `ceil_mode == 1` exactly so out-of-spec ceil_mode values do not diverge.
+    if (ceilMode === 1) {
       outSize = Math.ceil(numerator / stride) + 1;
       // Ensure the last pooling window starts inside the image (ref: https://github.com/onnx/onnx/pull/5741).
+      // inSize and padHead are needed here to reconstruct the last window's start position.
       if ((outSize - 1) * stride >= inSize + padHead) {
         outSize -= 1;
       }

--- a/js/web/lib/wasm/jsep/webgpu/ops/pool.ts
+++ b/js/web/lib/wasm/jsep/webgpu/ops/pool.ts
@@ -56,6 +56,7 @@ const getAdjustedPoolAttributesAndOutputShape = <AttributeType extends AveragePo
     kernelShape,
     pads,
     attributes.autoPad,
+    attributes.ceilMode,
   );
 
   const newAttributes = Object.assign({}, attributes);

--- a/js/web/lib/wasm/jsep/webgpu/ops/pool.ts
+++ b/js/web/lib/wasm/jsep/webgpu/ops/pool.ts
@@ -392,7 +392,11 @@ export const parseAveragePoolAttributes = (attributes: Record<string, unknown>):
   const countIncludePad = (attributes.count_include_pad as number) === 0 ? false : true;
 
   const attr = parsePoolCommonAttributes(attributes);
-  // TODO: support attribute 'ceil_mode'
+  // ceil_mode is honored by the output-shape math (PoolConvUtil.computePoolOutputShape now
+  // threads ceilMode and matches the C++ reference), but end-to-end execution stays gated
+  // here: the WebGPU pooling kernel must also apply the ceil_mode trailing-padding handling
+  // (and, for AveragePool, the count_include_pad divisor) before this throw can be removed.
+  // Tracked follow-up: remove this guard + add kernel ceil_mode padding support.
   if (attr.ceilMode !== 0) {
     throw new Error('using ceil() in shape computation is not yet supported for AveragePool');
   }
@@ -492,10 +496,15 @@ export const parseMaxPoolAttributes = (attributes: Record<string, unknown>): Max
   const dilations = attributes.dilations as [number, number];
 
   const attr = parsePoolCommonAttributes(attributes);
-  // TODO: support attribute 'ceil_mode' and 'storage_order'
+  // TODO: support attribute 'storage_order'
   if (storageOrder !== 0) {
     throw new Error('column major storage order is not yet supported for MaxPool');
   }
+  // ceil_mode is honored by the output-shape math (PoolConvUtil.computePoolOutputShape now
+  // threads ceilMode and matches the C++ reference), but end-to-end execution stays gated
+  // here: the WebGPU pooling kernel must also apply the ceil_mode trailing-padding handling
+  // before this throw can be removed. Tracked follow-up: remove this guard + add kernel
+  // ceil_mode padding support.
   if (attr.ceilMode !== 0) {
     throw new Error('using ceil() in shape computation is not yet supported for MaxPool');
   }

--- a/js/web/lib/wasm/jsep/webgpu/ops/pool.ts
+++ b/js/web/lib/wasm/jsep/webgpu/ops/pool.ts
@@ -20,7 +20,8 @@ import {
 } from './common';
 
 // TODO: support:
-// - ceil_mode                 "test_maxpool_2d_ceil"
+// - ceil_mode kernel execution "test_maxpool_2d_ceil" (output SHAPE already honors ceil_mode
+//   via PoolConvUtil.computePoolOutputShape; the WebGPU kernel padding/divisor handling is pending)
 // - storage_order             "test_maxpool_with_argmax_2d_precomputed_strides"
 // - [MaxPool] dilations       "test_maxpool_2d_dilations"
 // - [MaxPool] output[1]       "test_maxpool_with_argmax_2d_precomputed_pads"
@@ -398,7 +399,9 @@ export const parseAveragePoolAttributes = (attributes: Record<string, unknown>):
   // (and, for AveragePool, the count_include_pad divisor) before this throw can be removed.
   // Tracked follow-up: remove this guard + add kernel ceil_mode padding support.
   if (attr.ceilMode !== 0) {
-    throw new Error('using ceil() in shape computation is not yet supported for AveragePool');
+    throw new Error(
+      'ceil_mode output-shape is computed, but ceil_mode kernel execution (padding/divisor) is not yet implemented in the WebGPU AveragePool kernel',
+    );
   }
   const averagePoolAttributes = { countIncludePad, ...attr, cacheKey: '' };
   return { ...averagePoolAttributes, cacheKey: createAveragePoolShaderKeyFromAttributes(averagePoolAttributes) };
@@ -506,7 +509,9 @@ export const parseMaxPoolAttributes = (attributes: Record<string, unknown>): Max
   // before this throw can be removed. Tracked follow-up: remove this guard + add kernel
   // ceil_mode padding support.
   if (attr.ceilMode !== 0) {
-    throw new Error('using ceil() in shape computation is not yet supported for MaxPool');
+    throw new Error(
+      'ceil_mode output-shape is computed, but ceil_mode kernel execution (padding) is not yet implemented in the WebGPU MaxPool kernel',
+    );
   }
   const maxPoolAttributes = { storageOrder, dilations, ...attr, cacheKey: '' };
   return { ...maxPoolAttributes, cacheKey: createMaxPoolShaderKeyFromAttributes(maxPoolAttributes) };

--- a/js/web/test/unittests/index.ts
+++ b/js/web/test/unittests/index.ts
@@ -13,4 +13,6 @@ if (typeof window !== 'undefined') {
 
 require('./backends/wasm/test-model-metadata');
 
+require('./pool-output-shape');
+
 require('./opset');

--- a/js/web/test/unittests/pool-output-shape.ts
+++ b/js/web/test/unittests/pool-output-shape.ts
@@ -1,6 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+// These tests target PoolConvUtil.computePoolOutputShape directly (the pure shape function),
+// not the end-to-end pooling op. That is intentional: while the shape math now honors
+// ceil_mode, execution is still gated by the ceil_mode throw in parseAveragePool/MaxPoolAttributes
+// (js/web/lib/wasm/jsep/webgpu/ops/pool.ts), because the WebGPU kernel does not yet implement
+// ceil_mode trailing-padding handling. Removing that throw + adding kernel support is a tracked
+// follow-up; until then the shape path is only reachable via this unit test.
+
 import { expect } from 'chai';
 
 import { PoolConvUtil as JsepPoolConvUtil } from '../../lib/wasm/jsep/util';

--- a/js/web/test/unittests/pool-output-shape.ts
+++ b/js/web/test/unittests/pool-output-shape.ts
@@ -28,6 +28,8 @@ interface PoolShapeCase {
   readonly autoPad?: string;
   readonly ceilMode: number;
   readonly expectedShape: number[];
+  // When set, asserts the auto_pad pad distribution written back to the pads out-param.
+  readonly expectedPads?: number[];
 }
 
 const poolShapeCases: PoolShapeCase[] = [
@@ -196,37 +198,74 @@ const poolShapeCases: PoolShapeCase[] = [
     ceilMode: 1,
     expectedShape: [1, 1, 1],
   },
+  // ceilMode=0 SAME_* regression guards: the Math.floor(legacyTargetSize) fix also corrects the
+  // auto_pad pad DISTRIBUTION on the floor path (output shape is unchanged, so only asserting the
+  // shape would miss it). Old float division gave pads (1,1); C++ integer division gives (0,1) for
+  // SAME_UPPER and (1,0) for SAME_LOWER at in=2, stride=2, kernel=3.
+  {
+    name: 'SAME_UPPER auto_pad ceilMode=0 non-divisible corrects pad split -> pads [0,1]',
+    isGlobalOperator: false,
+    inputDims: [1, 1, 2],
+    strides: [2],
+    dilations: [1],
+    kernelShape: [3],
+    pads: [0, 0],
+    autoPad: 'SAME_UPPER',
+    ceilMode: 0,
+    expectedShape: [1, 1, 1],
+    expectedPads: [0, 1],
+  },
+  {
+    name: 'SAME_LOWER auto_pad ceilMode=0 non-divisible corrects pad split -> pads [1,0]',
+    isGlobalOperator: false,
+    inputDims: [1, 1, 2],
+    strides: [2],
+    dilations: [1],
+    kernelShape: [3],
+    pads: [0, 0],
+    autoPad: 'SAME_LOWER',
+    ceilMode: 0,
+    expectedShape: [1, 1, 1],
+    expectedPads: [1, 0],
+  },
 ];
 
 function runPoolConvUtil(
   computePoolOutputShape: typeof JsepPoolConvUtil.computePoolOutputShape,
   testCase: PoolShapeCase,
-): number[] {
-  // pads/strides/dilations/kernelShape are copied because computePoolOutputShape mutates pads
-  // in the auto_pad branches.
-  return computePoolOutputShape(
+): { shape: number[]; pads: number[] } {
+  // strides/dilations/kernelShape/pads are copied because computePoolOutputShape mutates pads
+  // in the auto_pad branches. The mutated pads copy is returned so tests can assert the
+  // computed auto_pad pad distribution, not just the output shape.
+  const pads = testCase.pads.slice();
+  const shape = computePoolOutputShape(
     testCase.isGlobalOperator,
     testCase.inputDims,
     testCase.strides.slice(),
     testCase.dilations.slice(),
     testCase.kernelShape.slice(),
-    testCase.pads.slice(),
+    pads,
     testCase.autoPad,
     testCase.ceilMode,
   );
+  return { shape, pads };
 }
 
 describe('PoolConvUtil.computePoolOutputShape ceil_mode', () => {
   for (const testCase of poolShapeCases) {
     it(`[jsep] ${testCase.name}`, () => {
-      expect(runPoolConvUtil(JsepPoolConvUtil.computePoolOutputShape, testCase)).to.deep.equal(
-        testCase.expectedShape,
-      );
+      const { shape, pads } = runPoolConvUtil(JsepPoolConvUtil.computePoolOutputShape, testCase);
+      expect(shape).to.deep.equal(testCase.expectedShape);
+      if (testCase.expectedPads) {
+        expect(pads).to.deep.equal(testCase.expectedPads);
+      }
     });
     it(`[onnxjs] ${testCase.name}`, () => {
-      expect(runPoolConvUtil(OnnxjsPoolConvUtil.computePoolOutputShape, testCase)).to.deep.equal(
-        testCase.expectedShape,
-      );
+      const { shape, pads } = runPoolConvUtil(OnnxjsPoolConvUtil.computePoolOutputShape, testCase);
+      expect(shape).to.deep.equal(testCase.expectedShape);
+      if (testCase.expectedPads) {
+        expect(pads).to.deep.equal(testCase.expectedPads);
+      }
     });
   }
 

--- a/js/web/test/unittests/pool-output-shape.ts
+++ b/js/web/test/unittests/pool-output-shape.ts
@@ -1,0 +1,177 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { expect } from 'chai';
+
+import { PoolConvUtil as JsepPoolConvUtil } from '../../lib/wasm/jsep/util';
+import { PoolConvUtil as OnnxjsPoolConvUtil } from '../../lib/onnxjs/util';
+
+// Ground-truth output shapes are taken from the C++ CPU reference
+// (onnxruntime/core/providers/cpu/nn/pool_attributes.h ComputeOutputSize) and the
+// matching CPU pool_op_test.cc cases, so all pooling targets share one oracle and
+// cannot silently re-diverge on ceil_mode.
+interface PoolShapeCase {
+  readonly name: string;
+  readonly isGlobalOperator: boolean;
+  readonly inputDims: number[];
+  readonly strides: number[];
+  readonly dilations: number[];
+  readonly kernelShape: number[];
+  readonly pads: number[];
+  readonly autoPad?: string;
+  readonly ceilMode: number;
+  readonly expectedShape: number[];
+}
+
+const poolShapeCases: PoolShapeCase[] = [
+  // floor mode must stay identical to the previous behavior (no regression).
+  {
+    name: 'NOTSET floor mode is unchanged (test_maxpool_2d_default analogue)',
+    isGlobalOperator: false,
+    inputDims: [1, 1, 4, 4],
+    strides: [2, 2],
+    dilations: [1, 1],
+    kernelShape: [3, 3],
+    pads: [0, 0, 0, 0],
+    ceilMode: 0,
+    expectedShape: [1, 1, 1, 1],
+  },
+  // test_maxpool_2d_ceil: floor would give [1,1] but ceil_mode gives [2,2].
+  {
+    name: 'test_maxpool_2d_ceil -> [1,1,2,2]',
+    isGlobalOperator: false,
+    inputDims: [1, 1, 4, 4],
+    strides: [2, 2],
+    dilations: [1, 1],
+    kernelShape: [3, 3],
+    pads: [0, 0, 0, 0],
+    ceilMode: 1,
+    expectedShape: [1, 1, 2, 2],
+  },
+  // AveragePool_10_ceil1_2d: asymmetric strides [3,1] -> [2,3].
+  {
+    name: 'AveragePool_10_ceil1_2d -> [1,1,2,3]',
+    isGlobalOperator: false,
+    inputDims: [1, 1, 4, 4],
+    strides: [3, 1],
+    dilations: [1, 1],
+    kernelShape: [2, 2],
+    pads: [0, 0, 0, 0],
+    ceilMode: 1,
+    expectedShape: [1, 1, 2, 3],
+  },
+  // AveragePool_18/19_ceil_count_include_pad_1d: PyTorch #183528 repro shape.
+  {
+    name: 'AveragePool ceil 1d (pads 3,3 kernel 7 stride 3) -> [1,2,4]',
+    isGlobalOperator: false,
+    inputDims: [1, 2, 9],
+    strides: [3],
+    dilations: [1],
+    kernelShape: [7],
+    pads: [3, 3],
+    ceilMode: 1,
+    expectedShape: [1, 2, 4],
+  },
+  // AveragePool_18_ceil_count_include_pad_2d.
+  {
+    name: 'AveragePool ceil 2d (pads 1 kernel 3 stride 2) -> [1,1,3,3]',
+    isGlobalOperator: false,
+    inputDims: [1, 1, 4, 4],
+    strides: [2, 2],
+    dilations: [1, 1],
+    kernelShape: [3, 3],
+    pads: [1, 1, 1, 1],
+    ceilMode: 1,
+    expectedShape: [1, 1, 3, 3],
+  },
+  // AveragePool_18_ceil_count_include_pad_3d.
+  {
+    name: 'AveragePool ceil 3d (pads 1 kernel 3 stride 2) -> [1,1,2,2,2]',
+    isGlobalOperator: false,
+    inputDims: [1, 1, 3, 3, 3],
+    strides: [2, 2, 2],
+    dilations: [1, 1, 1],
+    kernelShape: [3, 3, 3],
+    pads: [1, 1, 1, 1, 1, 1],
+    ceilMode: 1,
+    expectedShape: [1, 1, 2, 2, 2],
+  },
+  // Shrink-rule discriminator: naive ceil() would give 3, but the last window would start
+  // entirely in the trailing padding, so C++ ComputeOutputSize shrinks it back to 2.
+  {
+    name: 'shrink rule: last window starting in padding is dropped -> [1,1,2]',
+    isGlobalOperator: false,
+    inputDims: [1, 1, 3],
+    strides: [2],
+    dilations: [1],
+    kernelShape: [2],
+    pads: [1, 1],
+    ceilMode: 1,
+    expectedShape: [1, 1, 2],
+  },
+  // ceil_mode with dilation (AveragePool_19_dilation_2d shape).
+  {
+    name: 'ceil 2d with dilation 2 -> [1,1,2,2]',
+    isGlobalOperator: false,
+    inputDims: [1, 1, 4, 4],
+    strides: [1, 1],
+    dilations: [2, 2],
+    kernelShape: [2, 2],
+    pads: [0, 0, 0, 0],
+    ceilMode: 1,
+    expectedShape: [1, 1, 2, 2],
+  },
+  // VALID auto_pad honors ceil_mode.
+  {
+    name: 'VALID auto_pad + ceil_mode -> [1,1,2,2]',
+    isGlobalOperator: false,
+    inputDims: [1, 1, 4, 4],
+    strides: [2, 2],
+    dilations: [1, 1],
+    kernelShape: [3, 3],
+    pads: [0, 0, 0, 0],
+    autoPad: 'VALID',
+    ceilMode: 1,
+    expectedShape: [1, 1, 2, 2],
+  },
+];
+
+function runPoolConvUtil(
+  computePoolOutputShape: typeof JsepPoolConvUtil.computePoolOutputShape,
+  testCase: PoolShapeCase,
+): number[] {
+  // pads/strides/dilations/kernelShape are copied because computePoolOutputShape mutates pads
+  // in the auto_pad branches.
+  return computePoolOutputShape(
+    testCase.isGlobalOperator,
+    testCase.inputDims,
+    testCase.strides.slice(),
+    testCase.dilations.slice(),
+    testCase.kernelShape.slice(),
+    testCase.pads.slice(),
+    testCase.autoPad,
+    testCase.ceilMode,
+  );
+}
+
+describe('PoolConvUtil.computePoolOutputShape ceil_mode', () => {
+  for (const testCase of poolShapeCases) {
+    it(`[jsep] ${testCase.name}`, () => {
+      expect(runPoolConvUtil(JsepPoolConvUtil.computePoolOutputShape, testCase)).to.deep.equal(
+        testCase.expectedShape,
+      );
+    });
+    it(`[onnxjs] ${testCase.name}`, () => {
+      expect(runPoolConvUtil(OnnxjsPoolConvUtil.computePoolOutputShape, testCase)).to.deep.equal(
+        testCase.expectedShape,
+      );
+    });
+  }
+
+  it('defaults to floor when ceilMode is omitted', () => {
+    const jsep = JsepPoolConvUtil.computePoolOutputShape(false, [1, 1, 4, 4], [2, 2], [1, 1], [3, 3], [0, 0, 0, 0]);
+    const onnxjs = OnnxjsPoolConvUtil.computePoolOutputShape(false, [1, 1, 4, 4], [2, 2], [1, 1], [3, 3], [0, 0, 0, 0]);
+    expect(jsep).to.deep.equal([1, 1, 1, 1]);
+    expect(onnxjs).to.deep.equal([1, 1, 1, 1]);
+  });
+});

--- a/js/web/test/unittests/pool-output-shape.ts
+++ b/js/web/test/unittests/pool-output-shape.ts
@@ -141,6 +141,33 @@ const poolShapeCases: PoolShapeCase[] = [
     ceilMode: 1,
     expectedShape: [1, 1, 2, 2],
   },
+  // SAME_UPPER auto_pad honors ceil_mode (exercises the recomputed-pad branch).
+  // Reviewer-verified: in=5, stride=2, kernel=3, SAME_UPPER, ceil -> 3.
+  {
+    name: 'SAME_UPPER auto_pad + ceil_mode -> [1,1,3]',
+    isGlobalOperator: false,
+    inputDims: [1, 1, 5],
+    strides: [2],
+    dilations: [1],
+    kernelShape: [3],
+    pads: [0, 0],
+    autoPad: 'SAME_UPPER',
+    ceilMode: 1,
+    expectedShape: [1, 1, 3],
+  },
+  // SAME_LOWER auto_pad honors ceil_mode (same numeric case, mirrored padding split).
+  {
+    name: 'SAME_LOWER auto_pad + ceil_mode -> [1,1,3]',
+    isGlobalOperator: false,
+    inputDims: [1, 1, 5],
+    strides: [2],
+    dilations: [1],
+    kernelShape: [3],
+    pads: [0, 0],
+    autoPad: 'SAME_LOWER',
+    ceilMode: 1,
+    expectedShape: [1, 1, 3],
+  },
 ];
 
 function runPoolConvUtil(

--- a/js/web/test/unittests/pool-output-shape.ts
+++ b/js/web/test/unittests/pool-output-shape.ts
@@ -168,6 +168,34 @@ const poolShapeCases: PoolShapeCase[] = [
     ceilMode: 1,
     expectedShape: [1, 1, 3],
   },
+  // Non-divisible SAME_UPPER + ceil_mode regression guard: legacyTargetSize must use C++
+  // integer division. With float division this yielded [1,1,2] instead of the correct [1,1,1].
+  // (in=2, stride=2, kernel=3, SAME_UPPER, ceil -> 1, matching C++ ComputeSizePadDilations.)
+  {
+    name: 'SAME_UPPER auto_pad + ceil_mode non-divisible -> [1,1,1]',
+    isGlobalOperator: false,
+    inputDims: [1, 1, 2],
+    strides: [2],
+    dilations: [1],
+    kernelShape: [3],
+    pads: [0, 0],
+    autoPad: 'SAME_UPPER',
+    ceilMode: 1,
+    expectedShape: [1, 1, 1],
+  },
+  // SAME_LOWER symmetric counterpart of the non-divisible regression guard.
+  {
+    name: 'SAME_LOWER auto_pad + ceil_mode non-divisible -> [1,1,1]',
+    isGlobalOperator: false,
+    inputDims: [1, 1, 2],
+    strides: [2],
+    dilations: [1],
+    kernelShape: [3],
+    pads: [0, 0],
+    autoPad: 'SAME_LOWER',
+    ceilMode: 1,
+    expectedShape: [1, 1, 1],
+  },
 ];
 
 function runPoolConvUtil(


### PR DESCRIPTION
### Summary

The ORT-Web JSEP pooling output-shape helper (`PoolConvUtil.computePoolOutputShape` → `computeShapeHelper` → `adjustPadAndReturnShape`) was **floor-only**: it had no `ceilMode` parameter and silently ignored `ceil_mode`. Under `ceil_mode=1` this allocated the output tensor one element too small along each affected spatial axis, producing a wrong output shape (and downstream shape mismatches) — independent of any pooling divisor concern.

The same floor-only helper is duplicated in the legacy `js/web/lib/onnxjs/util.ts`; both copies are fixed.

### Fix

- Thread a `ceilMode` parameter (default `0`, i.e. floor) through `computePoolOutputShape` → `computeShapeHelper` → `adjustPadAndReturnShape` in **both** `js/web/lib/wasm/jsep/util.ts` and `js/web/lib/onnxjs/util.ts`.
- Route the NOTSET / VALID / SAME_UPPER / SAME_LOWER branches through a new `computeOutputSize()` helper that produces results identical to the C++ reference `PoolAttributes::ComputeOutputSize` (`onnxruntime/core/providers/cpu/nn/pool_attributes.h`), including the `ceil_mode` **"shrink the last window if it starts entirely in the trailing padding"** rule (ref: onnx/onnx#5741).
- The floor path (`ceilMode` default) is algebraically unchanged, so Conv and `auto_pad` pad-adjustment are unaffected.
- `js/web/lib/wasm/jsep/webgpu/ops/pool.ts` now passes `attributes.ceilMode` into the shape computation.

### Scope: SHAPE-only

This PR fixes the **output-shape** computation only. End-to-end `ceil_mode` execution remains gated by the existing `throw` guards in `parseAveragePoolAttributes` / `parseMaxPoolAttributes`, because the WebGPU pooling kernel does not yet implement `ceil_mode` trailing-padding handling (and, for AveragePool, the `count_include_pad` divisor). Removing those throws + adding kernel support is a **tracked follow-up**; the now-correct shape path is exercised directly by the added unit tests until then. Comments at the throw sites and in the test header document this.

### Tests

Adds `js/web/test/unittests/pool-output-shape.ts` (registered in `unittests/index.ts`), asserting output shapes for **both** implementations (jsep + onnxjs) against the C++ CPU reference ground truth:

- `test_maxpool_2d_ceil` → `[1,1,2,2]`, `AveragePool_10_ceil1_2d` → `[1,1,2,3]`
- AvgPool `ceil` 1D `[1,2,4]` / 2D `[1,1,3,3]` / 3D `[1,1,2,2,2]` (matching the CPU `pool_op_test.cc` cases)
- `ceil_mode` with dilation, `VALID` / `SAME_UPPER` / `SAME_LOWER` auto_pad
- a shrink-rule discriminator (naive `ceil()` would give 3; correct = 2)
- floor-mode no-regression case

### Related

- PyTorch context: pytorch/pytorch#183528
- Related ORT PR: #16752


### Post-review fixups

- **SAME_UPPER/SAME_LOWER integer division (external-review Major).** The `legacyTargetSize = (inSize + stride - 1) / stride` computation now uses `Math.floor(...)` to match C++ `pool_attributes.h` `ComputeSizePadDilations`, which uses integer division. This fixes a latent float-division divergence that mis-rounded the auto_pad pad distribution. The correction applies to **all** ceil modes (not only `ceil_mode=1`), aligning JSEP/onnxjs with the CPU/CUDA EPs. The floor-path (`ceil_mode=0`) **output shape is unchanged** — only the SAME_* pad split is corrected — so nothing previously-correct regresses. Added `ceil_mode=0` SAME_UPPER/SAME_LOWER non-divisible regression tests that assert the corrected pad out-param (SAME_UPPER → `[0,1]`, SAME_LOWER → `[1,0]`).
- **Throw-message / TODO clarity.** The retained `ceil_mode` `throw` statements and the pool op TODO banner were reworded to make explicit that the output **shape** is now computed correctly, while `ceil_mode` **kernel execution** (padding/divisor) remains the pending WebGPU follow-up.
