### PR TITLE
Fix CUDA AveragePool wrong results with asymmetric padding and dilation

### DIFF
--- a/onnxruntime/core/providers/cuda/nn/avg_pool_impl.cu
+++ b/onnxruntime/core/providers/cuda/nn/avg_pool_impl.cu
@@ -39,9 +39,9 @@ __global__ void AveragePoolWithPadKernel(
     int64_t stride_h,
     int64_t stride_w,
     int64_t stride_d,
-    int64_t pad_h,
-    int64_t pad_w,
-    int64_t pad_d,
+    int64_t pad_h_head,
+    int64_t pad_w_head,
+    int64_t pad_d_head,
     int64_t pad_h_tail,
     int64_t pad_w_tail,
     int64_t pad_d_tail,
@@ -82,9 +82,9 @@ __global__ void AveragePoolWithPadKernel(
   }
 
   // Window bounds mirror the CPU AveragePool{1,2,3}DTask reference exactly.
-  int64_t h_start = h_index * stride_h - pad_h;
-  int64_t w_start = w_index * stride_w - pad_w;
-  int64_t d_start = d_index * stride_d - pad_d;
+  int64_t h_start = h_index * stride_h - pad_h_head;
+  int64_t w_start = w_index * stride_w - pad_w_head;
+  int64_t d_start = d_index * stride_d - pad_d_head;
 
   int64_t h_end = _Min<int64_t>(h_start + kernel_h * dilation_h, height + pad_h_tail);
   int64_t w_end = _Min<int64_t>(w_start + kernel_w * dilation_w, width + pad_w_tail);
@@ -165,9 +165,9 @@ void AveragePoolWithPad(
   int64_t stride_d = rank > 2 ? stride_shape[2] : 1;
 
   // pads: [x1_begin,...,xN_begin, x1_end,...,xN_end]. Begin at [i], end at [rank + i].
-  int64_t pad_h = pads[0];
-  int64_t pad_w = rank > 1 ? pads[1] : 0;
-  int64_t pad_d = rank > 2 ? pads[2] : 0;
+  int64_t pad_h_head = pads[0];
+  int64_t pad_w_head = rank > 1 ? pads[1] : 0;
+  int64_t pad_d_head = rank > 2 ? pads[2] : 0;
   int64_t pad_h_tail = pads[rank + 0];
   int64_t pad_w_tail = rank > 1 ? pads[rank + 1] : 0;
   int64_t pad_d_tail = rank > 2 ? pads[rank + 2] : 0;
@@ -199,9 +199,9 @@ void AveragePoolWithPad(
       stride_h,
       stride_w,
       stride_d,
-      pad_h,
-      pad_w,
-      pad_d,
+      pad_h_head,
+      pad_w_head,
+      pad_d_head,
       pad_h_tail,
       pad_w_tail,
       pad_d_tail,

--- a/onnxruntime/core/providers/cuda/nn/avg_pool_impl.cu
+++ b/onnxruntime/core/providers/cuda/nn/avg_pool_impl.cu
@@ -1,0 +1,247 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "avg_pool_impl.h"
+
+#include "core/providers/cuda/cu_inc/common.cuh"
+#include "core/providers/cuda/shared_inc/fast_divmod.h"
+#include "core/providers/cuda/shared_inc/cuda_utils.h"
+
+namespace onnxruntime {
+namespace cuda {
+
+// Accumulate half in float for precision; keep native type otherwise.
+template <typename T>
+struct AveragePoolAccumulator {
+  using type = T;
+};
+template <>
+struct AveragePoolAccumulator<half> {
+  using type = float;
+};
+template <>
+struct AveragePoolAccumulator<BFloat16> {
+  using type = float;
+};
+
+template <typename T, bool Layout>
+__global__ void AveragePoolWithPadKernel(
+    int64_t channels,
+    int64_t height,
+    int64_t width,
+    int64_t depth,
+    int64_t pooled_height,
+    int64_t pooled_width,
+    int64_t pooled_depth,
+    int64_t kernel_h,
+    int64_t kernel_w,
+    int64_t kernel_d,
+    int64_t stride_h,
+    int64_t stride_w,
+    int64_t stride_d,
+    int64_t pad_h,
+    int64_t pad_w,
+    int64_t pad_d,
+    int64_t pad_h_tail,
+    int64_t pad_w_tail,
+    int64_t pad_d_tail,
+    int64_t dilation_h,
+    int64_t dilation_w,
+    int64_t dilation_d,
+    fast_divmod fdm_c,
+    fast_divmod fdm_h,
+    fast_divmod fdm_w,
+    fast_divmod fdm_d,
+    bool count_include_pad,
+    const T* p_input,
+    int64_t output_size,
+    T* p_output) {
+  int id = blockIdx.x * blockDim.x + threadIdx.x;
+  if (id >= output_size) return;
+
+  auto compute_offset =
+      [height, width, depth, channels](int n_index, int c_index, int h_index, int w_index, int d_index) -> int64_t {
+    if constexpr (Layout == LAYOUT_NCHW) {
+      return (((n_index * channels + c_index) * height + h_index) * width + w_index) * depth + d_index;
+    } else if constexpr (Layout == LAYOUT_NHWC) {
+      return (((n_index * height + h_index) * width + w_index) * depth + d_index) * channels + c_index;
+    }
+  };
+
+  int d_index, w_index, h_index, c_index, n_index, id_tmp;
+  if constexpr (Layout == LAYOUT_NCHW) {
+    fdm_d.divmod(id, id_tmp, d_index);
+    fdm_w.divmod(id_tmp, id_tmp, w_index);
+    fdm_h.divmod(id_tmp, id_tmp, h_index);
+    fdm_c.divmod(id_tmp, n_index, c_index);
+  } else if constexpr (Layout == LAYOUT_NHWC) {
+    fdm_c.divmod(id, id_tmp, c_index);
+    fdm_d.divmod(id_tmp, id_tmp, d_index);
+    fdm_w.divmod(id_tmp, id_tmp, w_index);
+    fdm_h.divmod(id_tmp, n_index, h_index);
+  }
+
+  // Window bounds mirror the CPU AveragePool{1,2,3}DTask reference exactly.
+  int64_t h_start = h_index * stride_h - pad_h;
+  int64_t w_start = w_index * stride_w - pad_w;
+  int64_t d_start = d_index * stride_d - pad_d;
+
+  int64_t h_end = _Min<int64_t>(h_start + kernel_h * dilation_h, height + pad_h_tail);
+  int64_t w_end = _Min<int64_t>(w_start + kernel_w * dilation_w, width + pad_w_tail);
+  int64_t d_end = _Min<int64_t>(d_start + kernel_d * dilation_d, depth + pad_d_tail);
+
+  using AccT = typename AveragePoolAccumulator<T>::type;
+  AccT acc = static_cast<AccT>(0);
+  int64_t counted = 0;
+
+  int64_t offset = compute_offset(n_index, c_index, 0, 0, 0);
+  const T* p_slice = p_input + offset;
+  for (int64_t h = h_start; h < h_end; h += dilation_h) {
+    if (h < 0 || h >= height) continue;
+    for (int64_t w = w_start; w < w_end; w += dilation_w) {
+      if (w < 0 || w >= width) continue;
+      for (int64_t d = d_start; d < d_end; d += dilation_d) {
+        if (d < 0 || d >= depth) continue;
+        acc += static_cast<AccT>(p_slice[compute_offset(0, 0, h, w, d)]);
+        ++counted;
+      }
+    }
+  }
+
+  AccT result = static_cast<AccT>(0);
+  if (counted > 0) {
+    if (count_include_pad) {
+      int64_t divisor = (1 + (h_end - h_start - 1) / dilation_h) *
+                        (1 + (w_end - w_start - 1) / dilation_w) *
+                        (1 + (d_end - d_start - 1) / dilation_d);
+      result = acc / static_cast<AccT>(divisor);
+    } else {
+      result = acc / static_cast<AccT>(counted);
+    }
+  }
+  p_output[id] = static_cast<T>(result);
+}
+
+template <typename T, bool Layout>
+void AveragePoolWithPad(
+    cudaStream_t stream,
+    const TensorShape& input_shape,
+    const TensorShape& output_shape,
+    const gsl::span<const int64_t>& kernel_shape,
+    const gsl::span<const int64_t>& stride_shape,
+    const gsl::span<const int64_t>& pads,
+    const gsl::span<const int64_t>& dilations,
+    bool count_include_pad,
+    const T* p_input,
+    T* p_output) {
+  int64_t channels, height, width, depth;
+  int64_t pooled_height, pooled_width, pooled_depth;
+  if constexpr (Layout == LAYOUT_NCHW) {
+    channels = input_shape[1];
+    height = input_shape[2];
+    width = kernel_shape.size() > 1 ? input_shape[3] : 1;
+    depth = kernel_shape.size() > 2 ? input_shape[4] : 1;
+
+    pooled_height = output_shape[2];
+    pooled_width = kernel_shape.size() > 1 ? output_shape[3] : 1;
+    pooled_depth = kernel_shape.size() > 2 ? output_shape[4] : 1;
+  } else if constexpr (Layout == LAYOUT_NHWC) {
+    height = input_shape[1];
+    width = kernel_shape.size() > 1 ? input_shape[2] : 1;
+    depth = kernel_shape.size() > 2 ? input_shape[3] : 1;
+    channels = input_shape[input_shape.NumDimensions() - 1];
+
+    pooled_height = output_shape[1];
+    pooled_width = kernel_shape.size() > 1 ? output_shape[2] : 1;
+    pooled_depth = kernel_shape.size() > 2 ? output_shape[3] : 1;
+  }
+
+  const int64_t rank = static_cast<int64_t>(kernel_shape.size());
+  int64_t kernel_h = kernel_shape[0];
+  int64_t kernel_w = rank > 1 ? kernel_shape[1] : 1;
+  int64_t kernel_d = rank > 2 ? kernel_shape[2] : 1;
+  int64_t stride_h = stride_shape[0];
+  int64_t stride_w = rank > 1 ? stride_shape[1] : 1;
+  int64_t stride_d = rank > 2 ? stride_shape[2] : 1;
+
+  // pads: [x1_begin,...,xN_begin, x1_end,...,xN_end]. Begin at [i], end at [rank + i].
+  int64_t pad_h = pads[0];
+  int64_t pad_w = rank > 1 ? pads[1] : 0;
+  int64_t pad_d = rank > 2 ? pads[2] : 0;
+  int64_t pad_h_tail = pads[rank + 0];
+  int64_t pad_w_tail = rank > 1 ? pads[rank + 1] : 0;
+  int64_t pad_d_tail = rank > 2 ? pads[rank + 2] : 0;
+
+  int64_t dilation_h = dilations[0];
+  int64_t dilation_w = rank > 1 ? dilations[1] : 1;
+  int64_t dilation_d = rank > 2 ? dilations[2] : 1;
+
+  int64_t output_size = output_shape.Size();
+  if (output_size == 0) return;
+
+  fast_divmod fdm_c(static_cast<int>(channels));
+  fast_divmod fdm_h(static_cast<int>(pooled_height));
+  fast_divmod fdm_w(static_cast<int>(pooled_width));
+  fast_divmod fdm_d(static_cast<int>(pooled_depth));
+
+  int blocksPerGrid = (int)((output_size + GridDim::maxThreadsPerBlock - 1) / GridDim::maxThreadsPerBlock);
+  AveragePoolWithPadKernel<T, Layout><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0, stream>>>(
+      channels,
+      height,
+      width,
+      depth,
+      pooled_height,
+      pooled_width,
+      pooled_depth,
+      kernel_h,
+      kernel_w,
+      kernel_d,
+      stride_h,
+      stride_w,
+      stride_d,
+      pad_h,
+      pad_w,
+      pad_d,
+      pad_h_tail,
+      pad_w_tail,
+      pad_d_tail,
+      dilation_h,
+      dilation_w,
+      dilation_d,
+      fdm_c,
+      fdm_h,
+      fdm_w,
+      fdm_d,
+      count_include_pad,
+      p_input,
+      output_size,
+      p_output);
+}
+
+#define INSTANTIATE_AVERAGEPOOLWITHPAD(T, Layout)   \
+  template void AveragePoolWithPad<T, Layout>(      \
+      cudaStream_t stream,                          \
+      const TensorShape& input_shape,               \
+      const TensorShape& output_shape,              \
+      const gsl::span<const int64_t>& kernel_shape, \
+      const gsl::span<const int64_t>& stride_shape, \
+      const gsl::span<const int64_t>& pads,         \
+      const gsl::span<const int64_t>& dilations,    \
+      bool count_include_pad,                       \
+      const T* p_input,                             \
+      T* p_output);
+
+INSTANTIATE_AVERAGEPOOLWITHPAD(float, LAYOUT_NCHW)
+INSTANTIATE_AVERAGEPOOLWITHPAD(double, LAYOUT_NCHW)
+INSTANTIATE_AVERAGEPOOLWITHPAD(half, LAYOUT_NCHW)
+INSTANTIATE_AVERAGEPOOLWITHPAD(BFloat16, LAYOUT_NCHW)
+
+#ifdef ENABLE_CUDA_NHWC_OPS
+INSTANTIATE_AVERAGEPOOLWITHPAD(float, LAYOUT_NHWC)
+INSTANTIATE_AVERAGEPOOLWITHPAD(double, LAYOUT_NHWC)
+INSTANTIATE_AVERAGEPOOLWITHPAD(half, LAYOUT_NHWC)
+INSTANTIATE_AVERAGEPOOLWITHPAD(BFloat16, LAYOUT_NHWC)
+#endif
+
+}  // namespace cuda
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cuda/nn/avg_pool_impl.h
+++ b/onnxruntime/core/providers/cuda/nn/avg_pool_impl.h
@@ -12,7 +12,7 @@ namespace cuda {
 //
 // cuDNN's pooling descriptor stores a single symmetric pad value per axis, so it cannot
 // represent ONNX asymmetric padding (pad_begin != pad_end), which arises from explicit
-// asymmetric `pads`, `auto_pad = SAME_UPPER/SAME_LOWER`, and ceil_mode boundaries. This
+// asymmetric `pads` or `auto_pad = SAME_UPPER/SAME_LOWER` resolving to asymmetric pads. This
 // kernel is the CUDA fallback for that case and mirrors the CPU reference functor
 // (AveragePool{1,2,3}DTask) exactly:
 //   start = out_idx * stride - pad_begin

--- a/onnxruntime/core/providers/cuda/nn/avg_pool_impl.h
+++ b/onnxruntime/core/providers/cuda/nn/avg_pool_impl.h
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/framework/tensor_shape.h"
+
+namespace onnxruntime {
+namespace cuda {
+
+// Custom average-pooling CUDA kernel that honors per-side (asymmetric) padding.
+//
+// cuDNN's pooling descriptor stores a single symmetric pad value per axis, so it cannot
+// represent ONNX asymmetric padding (pad_begin != pad_end), which arises from explicit
+// asymmetric `pads`, `auto_pad = SAME_UPPER/SAME_LOWER`, and ceil_mode boundaries. This
+// kernel is the CUDA fallback for that case and mirrors the CPU reference functor
+// (AveragePool{1,2,3}DTask) exactly:
+//   start = out_idx * stride - pad_begin
+//   end   = min(start + kernel * dilation, in_size + pad_end)
+//   sum over cells [start, end) with dilation step that are in [0, in_size)
+//   count_include_pad == 1: divisor = product of (1 + (end - start - 1) / dilation)
+//   count_include_pad == 0: divisor = number of summed in-bounds cells
+//
+// `pads` is the full ONNX layout [x1_begin,...,xN_begin, x1_end,...,xN_end] (2 * rank).
+template <typename T, bool Layout>
+void AveragePoolWithPad(
+    cudaStream_t stream,
+    const TensorShape& input_shape,
+    const TensorShape& output_shape,
+    const gsl::span<const int64_t>& kernel_shape,
+    const gsl::span<const int64_t>& stride_shape,
+    const gsl::span<const int64_t>& pads,
+    const gsl::span<const int64_t>& dilations,
+    bool count_include_pad,
+    const T* p_input,
+    T* p_output);
+
+}  // namespace cuda
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cuda/nn/pool.cc
+++ b/onnxruntime/core/providers/cuda/nn/pool.cc
@@ -6,6 +6,7 @@
 #include "core/providers/cuda/nn/pool.h"
 #include "core/providers/cuda/cudnn_common.h"
 #include "core/providers/cuda/nn/max_pool_with_index.h"
+#include "core/providers/cuda/nn/avg_pool_impl.h"
 #include "core/providers/cuda/math/unary_elementwise_ops_impl.h"
 
 using namespace onnxruntime::common;
@@ -204,6 +205,29 @@ Status Pool<T, PoolType, Layout>::ComputeInternal(OpKernelContext* context) cons
 
   auto x_data = reinterpret_cast<const CudaT*>(X->Data<T>());
   auto y_data = reinterpret_cast<CudaT*>(Y->MutableData<T>());
+
+  // cuDNN's pooling descriptor stores a single symmetric pad value per axis and applies it
+  // to both sides, so it silently drops ONNX end pads when pad_begin != pad_end. Any
+  // asymmetric-pad AveragePool (explicit asymmetric pads, auto_pad=SAME_UPPER/SAME_LOWER, or
+  // ceil_mode boundaries) therefore produces wrong sums and divisors on cuDNN. Route only that
+  // case to the custom kernel, which honors per-side pads and matches the CPU reference divisor
+  // exactly. Symmetric pads (the common case, including all global pooling) keep the fast cuDNN
+  // path unchanged, so there is zero perf regression.
+  if constexpr (PoolType::type == onnxruntime::PoolType::kAveragePool) {
+    const size_t spatial_rank = kernel_shape.size();
+    bool asymmetric_pads = false;
+    for (size_t i = 0; i < spatial_rank; ++i) {
+      if (pads[i] != pads[spatial_rank + i]) {
+        asymmetric_pads = true;
+        break;
+      }
+    }
+    if (asymmetric_pads) {
+      AveragePoolWithPad<CudaT, Layout>(Stream(context), x_shape, y_shape, kernel_shape, strides, pads,
+                                        pool_attrs_.dilations, pool_attrs_.count_include_pad, x_data, y_data);
+      return Status::OK();
+    }
+  }
 
   TensorShapeVector x_dims_cudnn(x_dims.begin(), x_dims.end());
   TensorShapeVector y_dims_cudnn(y_dims);

--- a/onnxruntime/core/providers/cuda/nn/pool.cc
+++ b/onnxruntime/core/providers/cuda/nn/pool.cc
@@ -206,26 +206,34 @@ Status Pool<T, PoolType, Layout>::ComputeInternal(OpKernelContext* context) cons
   auto x_data = reinterpret_cast<const CudaT*>(X->Data<T>());
   auto y_data = reinterpret_cast<CudaT*>(Y->MutableData<T>());
 
-  // cuDNN's pooling descriptor stores a single symmetric pad value per axis and applies it
-  // to both sides, so it silently drops ONNX end pads when pad_begin != pad_end. Any
-  // asymmetric-pad AveragePool (explicit asymmetric pads, auto_pad=SAME_UPPER/SAME_LOWER, or
-  // ceil_mode boundaries) therefore produces wrong sums and divisors on cuDNN. Route only that
-  // case to the custom kernel, which honors per-side pads and matches the CPU reference divisor
-  // exactly. Symmetric pads (the common case, including all global pooling) keep the fast cuDNN
-  // path unchanged, so there is zero perf regression.
+  // cuDNN's pooling descriptor cannot represent two ONNX features:
+  //  (1) Asymmetric padding: it stores a single symmetric pad value per axis and applies it to
+  //      both sides, so it silently drops ONNX end pads when pad_begin != pad_end (explicit
+  //      asymmetric pads, auto_pad=SAME_UPPER/SAME_LOWER, or ceil_mode boundaries).
+  //  (2) Dilation: the pooling descriptor has no dilation parameter at all, so any dilation > 1
+  //      is silently ignored.
+  // Either case produces wrong sums and divisors on cuDNN, so route it to the custom kernel,
+  // which honors per-side pads AND dilation and matches the CPU reference divisor exactly.
+  // Symmetric, non-dilated pooling (the common case, including all global pooling) keeps the
+  // fast cuDNN path unchanged, so there is zero perf regression. (MaxPool<8> guards dilation the
+  // same way via !default_dilations.) Global pooling is always symmetric and never dilated, and
+  // its kernel_shape/strides/dilations are left unpopulated (PoolAttributes returns early), so it
+  // is excluded here and stays on cuDNN.
   if constexpr (PoolType::type == onnxruntime::PoolType::kAveragePool) {
-    const size_t spatial_rank = kernel_shape.size();
-    bool asymmetric_pads = false;
-    for (size_t i = 0; i < spatial_rank; ++i) {
-      if (pads[i] != pads[spatial_rank + i]) {
-        asymmetric_pads = true;
-        break;
+    if (!pool_attrs_.global_pooling) {
+      const size_t spatial_rank = kernel_shape.size();
+      bool asymmetric_pads = false;
+      for (size_t i = 0; i < spatial_rank; ++i) {
+        if (pads[i] != pads[spatial_rank + i]) {
+          asymmetric_pads = true;
+          break;
+        }
       }
-    }
-    if (asymmetric_pads) {
-      AveragePoolWithPad<CudaT, Layout>(Stream(context), x_shape, y_shape, kernel_shape, strides, pads,
-                                        pool_attrs_.dilations, pool_attrs_.count_include_pad, x_data, y_data);
-      return Status::OK();
+      if (asymmetric_pads || !pool_attrs_.default_dilations) {
+        AveragePoolWithPad<CudaT, Layout>(Stream(context), x_shape, y_shape, kernel_shape, strides, pads,
+                                          pool_attrs_.dilations, pool_attrs_.count_include_pad, x_data, y_data);
+        return Status::OK();
+      }
     }
   }
 

--- a/onnxruntime/core/providers/cuda/nn/pool.cc
+++ b/onnxruntime/core/providers/cuda/nn/pool.cc
@@ -209,7 +209,7 @@ Status Pool<T, PoolType, Layout>::ComputeInternal(OpKernelContext* context) cons
   // cuDNN's pooling descriptor cannot represent two ONNX features:
   //  (1) Asymmetric padding: it stores a single symmetric pad value per axis and applies it to
   //      both sides, so it silently drops ONNX end pads when pad_begin != pad_end (explicit
-  //      asymmetric pads, auto_pad=SAME_UPPER/SAME_LOWER, or ceil_mode boundaries).
+  //      asymmetric pads, or auto_pad=SAME_UPPER/SAME_LOWER resolving to asymmetric pads).
   //  (2) Dilation: the pooling descriptor has no dilation parameter at all, so any dilation > 1
   //      is silently ignored.
   // Either case produces wrong sums and divisors on cuDNN, so route it to the custom kernel,

--- a/onnxruntime/test/providers/cpu/nn/pool_op_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/pool_op_test.cc
@@ -960,9 +960,9 @@ TEST(PoolTest, AveragePool_CountIncludePad_AsymmetricPads) {
   test.AddInput<float>("X", x_dims, x_vals);
   test.AddOutput<float>("Y", expected_dims, expected_vals);
   // The CUDA custom AveragePoolWithPad kernel now honors per-side (asymmetric) pads, so the
-  // CUDA (NCHW) leg is un-excluded here to lock in that fix. kCudaNHWCExecutionProvider is still
-  // excluded because the custom kernel's NHWC decode branch is not yet covered by these tests
-  // (asymmetric NHWC routes to that branch, not to cuDNN) — tracked as a follow-up. The remaining
+  // CUDA (NCHW) leg is un-excluded here to lock in that fix. kCudaNHWCExecutionProvider is
+  // excluded here only to avoid redundant coverage: the asymmetric NHWC-CUDA decode branch is
+  // now exercised (and passing) by the 1D/2D AveragePool_CUDA_* parity tests below. The remaining
   // exclusions are EPs whose external libraries (CoreML, etc.) still produce wrong results here.
   test.Run(OpTester::ExpectResult::kExpectSuccess, "",
            {kCudaNHWCExecutionProvider,
@@ -998,10 +998,11 @@ TEST(PoolTest, AveragePool3D_CountIncludePad_AsymmetricPads) {
   test.AddInput<float>("X", x3d_dims, x3d_vals);
   test.AddOutput<float>("Y", expected3d_dims, expected3d_vals);
   // The CUDA custom AveragePoolWithPad kernel now honors per-side (asymmetric) pads in 3D, so the
-  // CUDA (NCHW) leg is un-excluded here to lock in that fix. kCudaNHWCExecutionProvider is still
-  // excluded because the custom kernel's NHWC decode branch is not yet covered by these tests
-  // (asymmetric NHWC routes to that branch, not to cuDNN) — tracked as a follow-up. The remaining
-  // exclusions are EPs whose external libraries (CoreML, etc.) still produce wrong results here.
+  // CUDA (NCHW) leg is un-excluded here to lock in that fix. kCudaNHWCExecutionProvider stays
+  // excluded here: the asymmetric NHWC-CUDA decode branch is now exercised (and passing) by the
+  // 1D/2D AveragePool_CUDA_* parity tests below, but 3D (NDHWC) NHWC pooling is not among them, so
+  // it remains a follow-up. The remaining exclusions are EPs whose external libraries (CoreML,
+  // etc.) still produce wrong results here.
   test.Run(OpTester::ExpectResult::kExpectSuccess, "",
            {kCudaNHWCExecutionProvider,
             kTensorrtExecutionProvider, kAclExecutionProvider, kOpenVINOExecutionProvider,
@@ -1114,7 +1115,27 @@ TEST(PoolTest, AveragePool_19_ceil_count_include_pad_1d) {
 // ceil_mode + count_include_pad cases use opset 19 so the CPU leg runs the already-correct v19
 // reference functor and validates the CUDA kernel independently of the separate CPU opset-7..18
 // MLAS fix (PR #29629); the CUDA routing is opset-independent, so this still exercises the fix.
+//
+// Exception: the fp16 case below runs CUDA-only (CPU has no fp16 AveragePool kernel on x64 and
+// the Arm64 NEON fp16 pooling kernel mishandles the ceil_mode + count_include_pad divisor), so
+// the "CPU leg runs the v19 reference oracle" statement above does not apply to it — see its own
+// comment for how it validates the CUDA half accumulate-in-float path without a CPU oracle.
+//
+// The float cases share a single exclusion set (kPoolingEpsWithoutCeilCip) so the list cannot
+// drift test-to-test. It names every EP whose pooling does NOT implement ONNX's asymmetric-pad /
+// dilated / ceil_mode + count_include_pad clamped-divisor semantics (they would produce wrong
+// values and cannot serve as an oracle). The CPU EP (correct v19 reference) stays un-excluded as
+// the float oracle, and the CUDA + CUDA-NHWC EPs stay un-excluded as the tested targets — the
+// asymmetric NHWC-CUDA path is intentionally exercised here (USE_CUDA_NHWC_OPS defaults ON) and
+// passes. kWebGpuExecutionProvider is listed defensively: it auto-skips in a CUDA-only build
+// (DefaultWebGpuExecutionProvider returns nullptr), but naming it keeps a future WebGPU build leg
+// from re-triggering the CI failure this list fixes.
 // ---------------------------------------------------------------------------
+const std::unordered_set<std::string> kPoolingEpsWithoutCeilCip = {
+    kTensorrtExecutionProvider, kDnnlExecutionProvider, kOpenVINOExecutionProvider,
+    kAclExecutionProvider, kCoreMLExecutionProvider, kQnnExecutionProvider,
+    kDmlExecutionProvider, kWebGpuExecutionProvider};
+
 TEST(PoolTest, AveragePool_CUDA_asymmetric_tail_pad_1d) {
   OpTester test("AveragePool", 19);
 
@@ -1132,10 +1153,7 @@ TEST(PoolTest, AveragePool_CUDA_asymmetric_tail_pad_1d) {
 
   test.AddInput<float>("X", x_dims, x_vals);
   test.AddOutput<float>("Y", expected_dims, expected_vals);
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "",
-           {kTensorrtExecutionProvider, kAclExecutionProvider, kOpenVINOExecutionProvider,
-            kDnnlExecutionProvider, kCoreMLExecutionProvider, kQnnExecutionProvider,
-            kDmlExecutionProvider});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", kPoolingEpsWithoutCeilCip);
 }
 
 TEST(PoolTest, AveragePool_CUDA_asymmetric_tail_pad_1d_exclude_pad) {
@@ -1156,10 +1174,7 @@ TEST(PoolTest, AveragePool_CUDA_asymmetric_tail_pad_1d_exclude_pad) {
 
   test.AddInput<float>("X", x_dims, x_vals);
   test.AddOutput<float>("Y", expected_dims, expected_vals);
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "",
-           {kTensorrtExecutionProvider, kAclExecutionProvider, kOpenVINOExecutionProvider,
-            kDnnlExecutionProvider, kCoreMLExecutionProvider, kQnnExecutionProvider,
-            kDmlExecutionProvider});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", kPoolingEpsWithoutCeilCip);
 }
 
 TEST(PoolTest, AveragePool_CUDA_asymmetric_tail_pad_2d) {
@@ -1184,10 +1199,7 @@ TEST(PoolTest, AveragePool_CUDA_asymmetric_tail_pad_2d) {
 
   test.AddInput<float>("X", x_dims, x_vals);
   test.AddOutput<float>("Y", expected_dims, expected_vals);
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "",
-           {kTensorrtExecutionProvider, kAclExecutionProvider, kOpenVINOExecutionProvider,
-            kDnnlExecutionProvider, kCoreMLExecutionProvider, kQnnExecutionProvider,
-            kDmlExecutionProvider});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", kPoolingEpsWithoutCeilCip);
 }
 
 TEST(PoolTest, AveragePool_CUDA_asymmetric_tail_pad_2d_exclude_pad) {
@@ -1212,10 +1224,7 @@ TEST(PoolTest, AveragePool_CUDA_asymmetric_tail_pad_2d_exclude_pad) {
 
   test.AddInput<float>("X", x_dims, x_vals);
   test.AddOutput<float>("Y", expected_dims, expected_vals);
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "",
-           {kTensorrtExecutionProvider, kAclExecutionProvider, kOpenVINOExecutionProvider,
-            kDnnlExecutionProvider, kCoreMLExecutionProvider, kQnnExecutionProvider,
-            kDmlExecutionProvider});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", kPoolingEpsWithoutCeilCip);
 }
 
 // auto_pad=SAME_UPPER produces naturally asymmetric pads (here pad(0,1)); proves the latent
@@ -1235,10 +1244,7 @@ TEST(PoolTest, AveragePool_CUDA_same_upper_asymmetric_1d) {
 
   test.AddInput<float>("X", x_dims, x_vals);
   test.AddOutput<float>("Y", expected_dims, expected_vals);
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "",
-           {kTensorrtExecutionProvider, kAclExecutionProvider, kOpenVINOExecutionProvider,
-            kDnnlExecutionProvider, kCoreMLExecutionProvider, kQnnExecutionProvider,
-            kDmlExecutionProvider});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", kPoolingEpsWithoutCeilCip);
 }
 
 // Regression guard: symmetric pads must STAY on the fast cuDNN path and remain correct.
@@ -1259,10 +1265,7 @@ TEST(PoolTest, AveragePool_CUDA_symmetric_pad_regression_1d) {
 
   test.AddInput<float>("X", x_dims, x_vals);
   test.AddOutput<float>("Y", expected_dims, expected_vals);
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "",
-           {kTensorrtExecutionProvider, kAclExecutionProvider, kOpenVINOExecutionProvider,
-            kDnnlExecutionProvider, kCoreMLExecutionProvider, kQnnExecutionProvider,
-            kDmlExecutionProvider});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", kPoolingEpsWithoutCeilCip);
 }
 
 // MaxPool asymmetric-pad probe/regression on CUDA (verify-then-decide per design). MaxPool
@@ -1284,10 +1287,7 @@ TEST(PoolTest, MaxPool_CUDA_asymmetric_tail_pad_1d) {
 
   test.AddInput<float>("X", x_dims, x_vals);
   test.AddOutput<float>("Y", expected_dims, expected_vals);
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "",
-           {kTensorrtExecutionProvider, kAclExecutionProvider, kOpenVINOExecutionProvider,
-            kDnnlExecutionProvider, kCoreMLExecutionProvider, kQnnExecutionProvider,
-            kDmlExecutionProvider});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", kPoolingEpsWithoutCeilCip);
 }
 
 // fp16 asymmetric-pad AveragePool. Runs on the CUDA EP ONLY (via an explicit provider list):
@@ -1349,10 +1349,7 @@ TEST(PoolTest, AveragePool_CUDA_symmetric_pad_dilation_1d) {
 
   test.AddInput<float>("X", x_dims, x_vals);
   test.AddOutput<float>("Y", expected_dims, expected_vals);
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "",
-           {kTensorrtExecutionProvider, kAclExecutionProvider, kOpenVINOExecutionProvider,
-            kDnnlExecutionProvider, kCoreMLExecutionProvider, kQnnExecutionProvider,
-            kDmlExecutionProvider});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", kPoolingEpsWithoutCeilCip);
 }
 
 // auto_pad=SAME_LOWER produces naturally asymmetric pads with the extra pad on the LOW side
@@ -1372,10 +1369,7 @@ TEST(PoolTest, AveragePool_CUDA_same_lower_asymmetric_1d) {
 
   test.AddInput<float>("X", x_dims, x_vals);
   test.AddOutput<float>("Y", expected_dims, expected_vals);
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "",
-           {kTensorrtExecutionProvider, kAclExecutionProvider, kOpenVINOExecutionProvider,
-            kDnnlExecutionProvider, kCoreMLExecutionProvider, kQnnExecutionProvider,
-            kDmlExecutionProvider});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", kPoolingEpsWithoutCeilCip);
 }
 
 // bf16 AveragePool is intentionally NOT tested here: although the CUDA kernel instantiates

--- a/onnxruntime/test/providers/cpu/nn/pool_op_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/pool_op_test.cc
@@ -1121,7 +1121,7 @@ TEST(PoolTest, AveragePool_19_ceil_count_include_pad_1d) {
 // the "CPU leg runs the v19 reference oracle" statement above does not apply to it — see its own
 // comment for how it validates the CUDA half accumulate-in-float path without a CPU oracle.
 //
-// The float cases share a single exclusion set (kPoolingEpsWithoutCeilCip) so the list cannot
+// The float cases share a single exclusion set (kPoolingEpsExcludedFromCeilCipTests) so the list cannot
 // drift test-to-test. It names every EP whose pooling does NOT implement ONNX's asymmetric-pad /
 // dilated / ceil_mode + count_include_pad clamped-divisor semantics (they would produce wrong
 // values and cannot serve as an oracle). The CPU EP (correct v19 reference) stays un-excluded as
@@ -1131,10 +1131,10 @@ TEST(PoolTest, AveragePool_19_ceil_count_include_pad_1d) {
 // (DefaultWebGpuExecutionProvider returns nullptr), but naming it keeps a future WebGPU build leg
 // from re-triggering the CI failure this list fixes.
 // ---------------------------------------------------------------------------
-const std::unordered_set<std::string> kPoolingEpsWithoutCeilCip = {
-    kTensorrtExecutionProvider, kDnnlExecutionProvider, kOpenVINOExecutionProvider,
-    kAclExecutionProvider, kCoreMLExecutionProvider, kQnnExecutionProvider,
-    kDmlExecutionProvider, kWebGpuExecutionProvider};
+const std::unordered_set<std::string> kPoolingEpsExcludedFromCeilCipTests = {
+    kTensorrtExecutionProvider, kNvTensorRTRTXExecutionProvider, kDnnlExecutionProvider,
+    kOpenVINOExecutionProvider, kAclExecutionProvider, kCoreMLExecutionProvider,
+    kQnnExecutionProvider, kDmlExecutionProvider, kWebGpuExecutionProvider};
 
 TEST(PoolTest, AveragePool_CUDA_asymmetric_tail_pad_1d) {
   OpTester test("AveragePool", 19);
@@ -1153,7 +1153,7 @@ TEST(PoolTest, AveragePool_CUDA_asymmetric_tail_pad_1d) {
 
   test.AddInput<float>("X", x_dims, x_vals);
   test.AddOutput<float>("Y", expected_dims, expected_vals);
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "", kPoolingEpsWithoutCeilCip);
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", kPoolingEpsExcludedFromCeilCipTests);
 }
 
 TEST(PoolTest, AveragePool_CUDA_asymmetric_tail_pad_1d_exclude_pad) {
@@ -1174,7 +1174,7 @@ TEST(PoolTest, AveragePool_CUDA_asymmetric_tail_pad_1d_exclude_pad) {
 
   test.AddInput<float>("X", x_dims, x_vals);
   test.AddOutput<float>("Y", expected_dims, expected_vals);
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "", kPoolingEpsWithoutCeilCip);
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", kPoolingEpsExcludedFromCeilCipTests);
 }
 
 TEST(PoolTest, AveragePool_CUDA_asymmetric_tail_pad_2d) {
@@ -1199,7 +1199,7 @@ TEST(PoolTest, AveragePool_CUDA_asymmetric_tail_pad_2d) {
 
   test.AddInput<float>("X", x_dims, x_vals);
   test.AddOutput<float>("Y", expected_dims, expected_vals);
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "", kPoolingEpsWithoutCeilCip);
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", kPoolingEpsExcludedFromCeilCipTests);
 }
 
 TEST(PoolTest, AveragePool_CUDA_asymmetric_tail_pad_2d_exclude_pad) {
@@ -1224,7 +1224,7 @@ TEST(PoolTest, AveragePool_CUDA_asymmetric_tail_pad_2d_exclude_pad) {
 
   test.AddInput<float>("X", x_dims, x_vals);
   test.AddOutput<float>("Y", expected_dims, expected_vals);
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "", kPoolingEpsWithoutCeilCip);
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", kPoolingEpsExcludedFromCeilCipTests);
 }
 
 // auto_pad=SAME_UPPER produces naturally asymmetric pads (here pad(0,1)); proves the latent
@@ -1244,7 +1244,7 @@ TEST(PoolTest, AveragePool_CUDA_same_upper_asymmetric_1d) {
 
   test.AddInput<float>("X", x_dims, x_vals);
   test.AddOutput<float>("Y", expected_dims, expected_vals);
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "", kPoolingEpsWithoutCeilCip);
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", kPoolingEpsExcludedFromCeilCipTests);
 }
 
 // Regression guard: symmetric pads must STAY on the fast cuDNN path and remain correct.
@@ -1265,7 +1265,7 @@ TEST(PoolTest, AveragePool_CUDA_symmetric_pad_regression_1d) {
 
   test.AddInput<float>("X", x_dims, x_vals);
   test.AddOutput<float>("Y", expected_dims, expected_vals);
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "", kPoolingEpsWithoutCeilCip);
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", kPoolingEpsExcludedFromCeilCipTests);
 }
 
 // MaxPool asymmetric-pad probe/regression on CUDA (verify-then-decide per design). MaxPool
@@ -1287,7 +1287,7 @@ TEST(PoolTest, MaxPool_CUDA_asymmetric_tail_pad_1d) {
 
   test.AddInput<float>("X", x_dims, x_vals);
   test.AddOutput<float>("Y", expected_dims, expected_vals);
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "", kPoolingEpsWithoutCeilCip);
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", kPoolingEpsExcludedFromCeilCipTests);
 }
 
 // fp16 asymmetric-pad AveragePool. Runs on the CUDA EP ONLY (via an explicit provider list):
@@ -1349,7 +1349,7 @@ TEST(PoolTest, AveragePool_CUDA_symmetric_pad_dilation_1d) {
 
   test.AddInput<float>("X", x_dims, x_vals);
   test.AddOutput<float>("Y", expected_dims, expected_vals);
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "", kPoolingEpsWithoutCeilCip);
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", kPoolingEpsExcludedFromCeilCipTests);
 }
 
 // auto_pad=SAME_LOWER produces naturally asymmetric pads with the extra pad on the LOW side
@@ -1369,7 +1369,7 @@ TEST(PoolTest, AveragePool_CUDA_same_lower_asymmetric_1d) {
 
   test.AddInput<float>("X", x_dims, x_vals);
   test.AddOutput<float>("Y", expected_dims, expected_vals);
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "", kPoolingEpsWithoutCeilCip);
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", kPoolingEpsExcludedFromCeilCipTests);
 }
 
 // bf16 AveragePool is intentionally NOT tested here: although the CUDA kernel instantiates

--- a/onnxruntime/test/providers/cpu/nn/pool_op_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/pool_op_test.cc
@@ -1304,6 +1304,62 @@ TEST(PoolTest, AveragePool_CUDA_asymmetric_tail_pad_1d_fp16) {
             kDmlExecutionProvider});
 }
 
+// Symmetric pads BUT dilation > 1. cuDNN's pooling descriptor has no dilation parameter, so the
+// old (asymmetric-pads-only) guard let this fall through to cuDNN, which silently ignored the
+// dilation and produced the wrong result. The dilation guard (!default_dilations) now routes this
+// to the custom kernel. opset 19 so the CPU AveragePoolV19 reference (which honors dilation) also
+// runs and must match. Expected values come from that CPU reference.
+TEST(PoolTest, AveragePool_CUDA_symmetric_pad_dilation_1d) {
+  OpTester test("AveragePool", 19);
+
+  test.AddAttribute("auto_pad", "");
+  test.AddAttribute("strides", std::vector<int64_t>{1});
+  test.AddAttribute("pads", std::vector<int64_t>{2, 2});
+  test.AddAttribute("kernel_shape", std::vector<int64_t>{3});
+  test.AddAttribute("dilations", std::vector<int64_t>{2});
+  test.AddAttribute("count_include_pad", (int64_t)1);
+
+  std::vector<float> x_vals = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f};
+  std::vector<int64_t> x_dims = {1, 1, 9};
+  std::vector<int64_t> expected_dims = {1, 1, 9};
+  std::vector<float> expected_vals = {1.3333334f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f,
+                                      4.6666665f, 5.3333335f};
+
+  test.AddInput<float>("X", x_dims, x_vals);
+  test.AddOutput<float>("Y", expected_dims, expected_vals);
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "",
+           {kTensorrtExecutionProvider, kAclExecutionProvider, kOpenVINOExecutionProvider,
+            kDmlExecutionProvider});
+}
+
+// auto_pad=SAME_LOWER produces naturally asymmetric pads with the extra pad on the LOW side
+// (here pad(1,0)); companion to the SAME_UPPER case. opset 19 so the CPU reference also runs.
+TEST(PoolTest, AveragePool_CUDA_same_lower_asymmetric_1d) {
+  OpTester test("AveragePool", 19);
+
+  test.AddAttribute("auto_pad", "SAME_LOWER");
+  test.AddAttribute("strides", std::vector<int64_t>{2});
+  test.AddAttribute("kernel_shape", std::vector<int64_t>{3});
+  test.AddAttribute("count_include_pad", (int64_t)1);
+
+  std::vector<float> x_vals = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f, 10.0f};
+  std::vector<int64_t> x_dims = {1, 1, 10};
+  std::vector<int64_t> expected_dims = {1, 1, 5};
+  std::vector<float> expected_vals = {1.0f, 3.0f, 5.0f, 7.0f, 9.0f};
+
+  test.AddInput<float>("X", x_dims, x_vals);
+  test.AddOutput<float>("Y", expected_dims, expected_vals);
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "",
+           {kTensorrtExecutionProvider, kAclExecutionProvider, kOpenVINOExecutionProvider,
+            kDmlExecutionProvider});
+}
+
+// bf16 AveragePool is intentionally NOT tested here: although the CUDA kernel instantiates
+// BFloat16 (compile-checked) and AveragePoolWithPad accumulates it in float like fp16, the ONNX
+// AveragePool schema type constraint does not include tensor(bfloat16), so OpTester's model
+// type-checker rejects such a graph at load. The fp16 case above already exercises the
+// accumulate-in-float path.
+
 TEST(PoolTest, GlobalAveragePool) {
   OpTester test("GlobalAveragePool");
 

--- a/onnxruntime/test/providers/cpu/nn/pool_op_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/pool_op_test.cc
@@ -1095,6 +1095,215 @@ TEST(PoolTest, AveragePool_19_ceil_count_include_pad_1d) {
            {kTensorrtExecutionProvider, kAclExecutionProvider, kOpenVINOExecutionProvider, kDmlExecutionProvider});
 }
 
+// ---------------------------------------------------------------------------
+// Target (b): CUDA AveragePool asymmetric-padding parity tests.
+//
+// cuDNN's pooling descriptor stores one symmetric pad per axis, so it silently drops the
+// ONNX end pad when pad_begin != pad_end, producing wrong averages on CUDA (QA probe:
+// 1D pad(0,3) CUDA=[4,6.5,8] vs CPU=[4,5.571,4]; 2D pad(0,0,3,3) diff 53.25). The custom
+// AveragePoolWithPad CUDA kernel fixes this. These cases keep the CUDA EP UN-excluded so the
+// CUDA leg actually runs and must match the CPU reference oracle. Expected values are the CPU
+// reference outputs (also cross-checked against the QA probe numbers).
+//
+// ceil_mode + count_include_pad cases use opset 19 so the CPU leg runs the already-correct v19
+// reference functor and validates the CUDA kernel independently of the separate CPU opset-7..18
+// MLAS fix (PR #29629); the CUDA routing is opset-independent, so this still exercises the fix.
+// ---------------------------------------------------------------------------
+TEST(PoolTest, AveragePool_CUDA_asymmetric_tail_pad_1d) {
+  OpTester test("AveragePool", 19);
+
+  test.AddAttribute("auto_pad", "");
+  test.AddAttribute("strides", std::vector<int64_t>{3});
+  test.AddAttribute("pads", std::vector<int64_t>{0, 3});
+  test.AddAttribute("kernel_shape", std::vector<int64_t>{7});
+  test.AddAttribute("ceil_mode", (int64_t)1);
+  test.AddAttribute("count_include_pad", (int64_t)1);
+
+  std::vector<float> x_vals = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f};
+  std::vector<int64_t> x_dims = {1, 1, 9};
+  std::vector<int64_t> expected_dims = {1, 1, 3};
+  std::vector<float> expected_vals = {4.0f, 5.5714283f, 4.0f};
+
+  test.AddInput<float>("X", x_dims, x_vals);
+  test.AddOutput<float>("Y", expected_dims, expected_vals);
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "",
+           {kTensorrtExecutionProvider, kAclExecutionProvider, kOpenVINOExecutionProvider,
+            kDmlExecutionProvider});
+}
+
+TEST(PoolTest, AveragePool_CUDA_asymmetric_tail_pad_1d_exclude_pad) {
+  OpTester test("AveragePool", 18);
+
+  test.AddAttribute("auto_pad", "");
+  test.AddAttribute("strides", std::vector<int64_t>{3});
+  test.AddAttribute("pads", std::vector<int64_t>{0, 3});
+  test.AddAttribute("kernel_shape", std::vector<int64_t>{7});
+  test.AddAttribute("ceil_mode", (int64_t)1);
+  test.AddAttribute("count_include_pad", (int64_t)0);
+
+  std::vector<float> x_vals = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f};
+  std::vector<int64_t> x_dims = {1, 1, 9};
+  std::vector<int64_t> expected_dims = {1, 1, 3};
+  // exclude-pad divides by in-bounds cells only.
+  std::vector<float> expected_vals = {4.0f, 6.5f, 8.0f};
+
+  test.AddInput<float>("X", x_dims, x_vals);
+  test.AddOutput<float>("Y", expected_dims, expected_vals);
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "",
+           {kTensorrtExecutionProvider, kAclExecutionProvider, kOpenVINOExecutionProvider,
+            kDmlExecutionProvider});
+}
+
+TEST(PoolTest, AveragePool_CUDA_asymmetric_tail_pad_2d) {
+  OpTester test("AveragePool", 19);
+
+  test.AddAttribute("auto_pad", "");
+  test.AddAttribute("strides", std::vector<int64_t>{3, 3});
+  test.AddAttribute("pads", std::vector<int64_t>{0, 0, 3, 3});
+  test.AddAttribute("kernel_shape", std::vector<int64_t>{7, 7});
+  test.AddAttribute("ceil_mode", (int64_t)1);
+  test.AddAttribute("count_include_pad", (int64_t)1);
+
+  std::vector<float> x_vals(81);
+  for (int i = 0; i < 81; ++i) {
+    x_vals[i] = static_cast<float>(i + 1);
+  }
+  std::vector<int64_t> x_dims = {1, 1, 9, 9};
+  std::vector<int64_t> expected_dims = {1, 1, 3, 3};
+  std::vector<float> expected_vals = {31.0f, 28.714287f, 17.5f,
+                                      45.857143f, 41.142857f, 24.642858f,
+                                      33.5f, 29.785715f, 17.75f};
+
+  test.AddInput<float>("X", x_dims, x_vals);
+  test.AddOutput<float>("Y", expected_dims, expected_vals);
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "",
+           {kTensorrtExecutionProvider, kAclExecutionProvider, kOpenVINOExecutionProvider,
+            kDmlExecutionProvider});
+}
+
+TEST(PoolTest, AveragePool_CUDA_asymmetric_tail_pad_2d_exclude_pad) {
+  OpTester test("AveragePool", 18);
+
+  test.AddAttribute("auto_pad", "");
+  test.AddAttribute("strides", std::vector<int64_t>{3, 3});
+  test.AddAttribute("pads", std::vector<int64_t>{0, 0, 3, 3});
+  test.AddAttribute("kernel_shape", std::vector<int64_t>{7, 7});
+  test.AddAttribute("ceil_mode", (int64_t)1);
+  test.AddAttribute("count_include_pad", (int64_t)0);
+
+  std::vector<float> x_vals(81);
+  for (int i = 0; i < 81; ++i) {
+    x_vals[i] = static_cast<float>(i + 1);
+  }
+  std::vector<int64_t> x_dims = {1, 1, 9, 9};
+  std::vector<int64_t> expected_dims = {1, 1, 3, 3};
+  std::vector<float> expected_vals = {31.0f, 33.5f, 35.0f,
+                                      53.5f, 56.0f, 57.5f,
+                                      67.0f, 69.5f, 71.0f};
+
+  test.AddInput<float>("X", x_dims, x_vals);
+  test.AddOutput<float>("Y", expected_dims, expected_vals);
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "",
+           {kTensorrtExecutionProvider, kAclExecutionProvider, kOpenVINOExecutionProvider,
+            kDmlExecutionProvider});
+}
+
+// auto_pad=SAME_UPPER produces naturally asymmetric pads (here pad(0,1)); proves the latent
+// SAME-pad bug on CUDA is also fixed by the same kernel.
+TEST(PoolTest, AveragePool_CUDA_same_upper_asymmetric_1d) {
+  OpTester test("AveragePool", 18);
+
+  test.AddAttribute("auto_pad", "SAME_UPPER");
+  test.AddAttribute("strides", std::vector<int64_t>{2});
+  test.AddAttribute("kernel_shape", std::vector<int64_t>{3});
+  test.AddAttribute("count_include_pad", (int64_t)1);
+
+  std::vector<float> x_vals = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f, 10.0f};
+  std::vector<int64_t> x_dims = {1, 1, 10};
+  std::vector<int64_t> expected_dims = {1, 1, 5};
+  std::vector<float> expected_vals = {2.0f, 4.0f, 6.0f, 8.0f, 6.3333335f};
+
+  test.AddInput<float>("X", x_dims, x_vals);
+  test.AddOutput<float>("Y", expected_dims, expected_vals);
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "",
+           {kTensorrtExecutionProvider, kAclExecutionProvider, kOpenVINOExecutionProvider,
+            kDmlExecutionProvider});
+}
+
+// Regression guard: symmetric pads must STAY on the fast cuDNN path and remain correct.
+TEST(PoolTest, AveragePool_CUDA_symmetric_pad_regression_1d) {
+  OpTester test("AveragePool", 19);
+
+  test.AddAttribute("auto_pad", "");
+  test.AddAttribute("strides", std::vector<int64_t>{3});
+  test.AddAttribute("pads", std::vector<int64_t>{3, 3});
+  test.AddAttribute("kernel_shape", std::vector<int64_t>{7});
+  test.AddAttribute("ceil_mode", (int64_t)1);
+  test.AddAttribute("count_include_pad", (int64_t)1);
+
+  std::vector<float> x_vals = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f};
+  std::vector<int64_t> x_dims = {1, 1, 9};
+  std::vector<int64_t> expected_dims = {1, 1, 4};
+  std::vector<float> expected_vals = {1.4285715f, 4.0f, 5.5714283f, 4.0f};
+
+  test.AddInput<float>("X", x_dims, x_vals);
+  test.AddOutput<float>("Y", expected_dims, expected_vals);
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "",
+           {kTensorrtExecutionProvider, kAclExecutionProvider, kOpenVINOExecutionProvider,
+            kDmlExecutionProvider});
+}
+
+// MaxPool asymmetric-pad probe/regression on CUDA (verify-then-decide per design). MaxPool
+// ignores pad cells (no divisor); asymmetric tail pad only changes output size, computed
+// correctly upstream. CUDA un-excluded to confirm parity with the CPU reference.
+TEST(PoolTest, MaxPool_CUDA_asymmetric_tail_pad_1d) {
+  OpTester test("MaxPool", 12);
+
+  test.AddAttribute("auto_pad", "");
+  test.AddAttribute("strides", std::vector<int64_t>{3});
+  test.AddAttribute("pads", std::vector<int64_t>{0, 3});
+  test.AddAttribute("kernel_shape", std::vector<int64_t>{7});
+  test.AddAttribute("ceil_mode", (int64_t)1);
+
+  std::vector<float> x_vals = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f};
+  std::vector<int64_t> x_dims = {1, 1, 9};
+  std::vector<int64_t> expected_dims = {1, 1, 3};
+  std::vector<float> expected_vals = {7.0f, 9.0f, 9.0f};
+
+  test.AddInput<float>("X", x_dims, x_vals);
+  test.AddOutput<float>("Y", expected_dims, expected_vals);
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "",
+           {kTensorrtExecutionProvider, kAclExecutionProvider, kOpenVINOExecutionProvider,
+            kDmlExecutionProvider});
+}
+
+// fp16 asymmetric-pad AveragePool (opset 19 so both CPU AveragePoolV19 and the CUDA kernel
+// run). Exercises the half accumulate-in-float path of AveragePoolWithPad.
+TEST(PoolTest, AveragePool_CUDA_asymmetric_tail_pad_1d_fp16) {
+  OpTester test("AveragePool", 19);
+
+  test.AddAttribute("auto_pad", "");
+  test.AddAttribute("strides", std::vector<int64_t>{3});
+  test.AddAttribute("pads", std::vector<int64_t>{0, 3});
+  test.AddAttribute("kernel_shape", std::vector<int64_t>{7});
+  test.AddAttribute("ceil_mode", (int64_t)1);
+  test.AddAttribute("count_include_pad", (int64_t)1);
+
+  std::vector<MLFloat16> x_vals = {MLFloat16(1.0f), MLFloat16(2.0f), MLFloat16(3.0f),
+                                   MLFloat16(4.0f), MLFloat16(5.0f), MLFloat16(6.0f),
+                                   MLFloat16(7.0f), MLFloat16(8.0f), MLFloat16(9.0f)};
+  std::vector<int64_t> x_dims = {1, 1, 9};
+  std::vector<int64_t> expected_dims = {1, 1, 3};
+  std::vector<MLFloat16> expected_vals = {MLFloat16(4.0f), MLFloat16(5.5714283f), MLFloat16(4.0f)};
+
+  test.AddInput<MLFloat16>("X", x_dims, x_vals);
+  test.AddOutput<MLFloat16>("Y", expected_dims, expected_vals);
+  test.SetOutputTolerance(0.005f);
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "",
+           {kTensorrtExecutionProvider, kAclExecutionProvider, kOpenVINOExecutionProvider,
+            kDmlExecutionProvider});
+}
+
 TEST(PoolTest, GlobalAveragePool) {
   OpTester test("GlobalAveragePool");
 

--- a/onnxruntime/test/providers/cpu/nn/pool_op_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/pool_op_test.cc
@@ -960,8 +960,10 @@ TEST(PoolTest, AveragePool_CountIncludePad_AsymmetricPads) {
   test.AddInput<float>("X", x_dims, x_vals);
   test.AddOutput<float>("Y", expected_dims, expected_vals);
   // The CUDA custom AveragePoolWithPad kernel now honors per-side (asymmetric) pads, so the
-  // CUDA (NCHW) leg is un-excluded here to lock in that fix. The remaining exclusions are EPs
-  // whose external libraries (cuDNN NHWC, CoreML, etc.) still produce wrong results for this case.
+  // CUDA (NCHW) leg is un-excluded here to lock in that fix. kCudaNHWCExecutionProvider is still
+  // excluded because the custom kernel's NHWC decode branch is not yet covered by these tests
+  // (asymmetric NHWC routes to that branch, not to cuDNN) — tracked as a follow-up. The remaining
+  // exclusions are EPs whose external libraries (CoreML, etc.) still produce wrong results here.
   test.Run(OpTester::ExpectResult::kExpectSuccess, "",
            {kCudaNHWCExecutionProvider,
             kTensorrtExecutionProvider, kAclExecutionProvider, kOpenVINOExecutionProvider,
@@ -996,8 +998,10 @@ TEST(PoolTest, AveragePool3D_CountIncludePad_AsymmetricPads) {
   test.AddInput<float>("X", x3d_dims, x3d_vals);
   test.AddOutput<float>("Y", expected3d_dims, expected3d_vals);
   // The CUDA custom AveragePoolWithPad kernel now honors per-side (asymmetric) pads in 3D, so the
-  // CUDA (NCHW) leg is un-excluded here to lock in that fix. The remaining exclusions are EPs
-  // whose external libraries (cuDNN NHWC, CoreML, etc.) still produce wrong results for this case.
+  // CUDA (NCHW) leg is un-excluded here to lock in that fix. kCudaNHWCExecutionProvider is still
+  // excluded because the custom kernel's NHWC decode branch is not yet covered by these tests
+  // (asymmetric NHWC routes to that branch, not to cuDNN) — tracked as a follow-up. The remaining
+  // exclusions are EPs whose external libraries (CoreML, etc.) still produce wrong results here.
   test.Run(OpTester::ExpectResult::kExpectSuccess, "",
            {kCudaNHWCExecutionProvider,
             kTensorrtExecutionProvider, kAclExecutionProvider, kOpenVINOExecutionProvider,

--- a/onnxruntime/test/providers/cpu/nn/pool_op_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/pool_op_test.cc
@@ -1134,6 +1134,7 @@ TEST(PoolTest, AveragePool_CUDA_asymmetric_tail_pad_1d) {
   test.AddOutput<float>("Y", expected_dims, expected_vals);
   test.Run(OpTester::ExpectResult::kExpectSuccess, "",
            {kTensorrtExecutionProvider, kAclExecutionProvider, kOpenVINOExecutionProvider,
+            kDnnlExecutionProvider, kCoreMLExecutionProvider, kQnnExecutionProvider,
             kDmlExecutionProvider});
 }
 
@@ -1157,6 +1158,7 @@ TEST(PoolTest, AveragePool_CUDA_asymmetric_tail_pad_1d_exclude_pad) {
   test.AddOutput<float>("Y", expected_dims, expected_vals);
   test.Run(OpTester::ExpectResult::kExpectSuccess, "",
            {kTensorrtExecutionProvider, kAclExecutionProvider, kOpenVINOExecutionProvider,
+            kDnnlExecutionProvider, kCoreMLExecutionProvider, kQnnExecutionProvider,
             kDmlExecutionProvider});
 }
 
@@ -1184,6 +1186,7 @@ TEST(PoolTest, AveragePool_CUDA_asymmetric_tail_pad_2d) {
   test.AddOutput<float>("Y", expected_dims, expected_vals);
   test.Run(OpTester::ExpectResult::kExpectSuccess, "",
            {kTensorrtExecutionProvider, kAclExecutionProvider, kOpenVINOExecutionProvider,
+            kDnnlExecutionProvider, kCoreMLExecutionProvider, kQnnExecutionProvider,
             kDmlExecutionProvider});
 }
 
@@ -1211,6 +1214,7 @@ TEST(PoolTest, AveragePool_CUDA_asymmetric_tail_pad_2d_exclude_pad) {
   test.AddOutput<float>("Y", expected_dims, expected_vals);
   test.Run(OpTester::ExpectResult::kExpectSuccess, "",
            {kTensorrtExecutionProvider, kAclExecutionProvider, kOpenVINOExecutionProvider,
+            kDnnlExecutionProvider, kCoreMLExecutionProvider, kQnnExecutionProvider,
             kDmlExecutionProvider});
 }
 
@@ -1233,6 +1237,7 @@ TEST(PoolTest, AveragePool_CUDA_same_upper_asymmetric_1d) {
   test.AddOutput<float>("Y", expected_dims, expected_vals);
   test.Run(OpTester::ExpectResult::kExpectSuccess, "",
            {kTensorrtExecutionProvider, kAclExecutionProvider, kOpenVINOExecutionProvider,
+            kDnnlExecutionProvider, kCoreMLExecutionProvider, kQnnExecutionProvider,
             kDmlExecutionProvider});
 }
 
@@ -1256,6 +1261,7 @@ TEST(PoolTest, AveragePool_CUDA_symmetric_pad_regression_1d) {
   test.AddOutput<float>("Y", expected_dims, expected_vals);
   test.Run(OpTester::ExpectResult::kExpectSuccess, "",
            {kTensorrtExecutionProvider, kAclExecutionProvider, kOpenVINOExecutionProvider,
+            kDnnlExecutionProvider, kCoreMLExecutionProvider, kQnnExecutionProvider,
             kDmlExecutionProvider});
 }
 
@@ -1280,12 +1286,21 @@ TEST(PoolTest, MaxPool_CUDA_asymmetric_tail_pad_1d) {
   test.AddOutput<float>("Y", expected_dims, expected_vals);
   test.Run(OpTester::ExpectResult::kExpectSuccess, "",
            {kTensorrtExecutionProvider, kAclExecutionProvider, kOpenVINOExecutionProvider,
+            kDnnlExecutionProvider, kCoreMLExecutionProvider, kQnnExecutionProvider,
             kDmlExecutionProvider});
 }
 
-// fp16 asymmetric-pad AveragePool (opset 19 so both CPU AveragePoolV19 and the CUDA kernel
-// run). Exercises the half accumulate-in-float path of AveragePoolWithPad.
+// fp16 asymmetric-pad AveragePool. Runs on the CUDA EP ONLY (via an explicit provider list):
+// the CPU AveragePool has no fp16 kernel on x64, and the Arm64 NEON fp16 pooling kernel does
+// not honor the ceil_mode + count_include_pad divisor rule (a separate, pre-existing CPU
+// limitation), so it cannot serve as the fp16 oracle. This test validates that the CUDA
+// AveragePoolWithPad kernel's half accumulate-in-float path matches the reference values.
 TEST(PoolTest, AveragePool_CUDA_asymmetric_tail_pad_1d_fp16) {
+  auto cuda_ep = DefaultCudaExecutionProvider();
+  if (!cuda_ep) {
+    return;
+  }
+
   OpTester test("AveragePool", 19);
 
   test.AddAttribute("auto_pad", "");
@@ -1305,9 +1320,10 @@ TEST(PoolTest, AveragePool_CUDA_asymmetric_tail_pad_1d_fp16) {
   test.AddInput<MLFloat16>("X", x_dims, x_vals);
   test.AddOutput<MLFloat16>("Y", expected_dims, expected_vals);
   test.SetOutputTolerance(0.005f);
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "",
-           {kTensorrtExecutionProvider, kAclExecutionProvider, kOpenVINOExecutionProvider,
-            kDmlExecutionProvider});
+
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(std::move(cuda_ep));
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
 }
 
 // Symmetric pads BUT dilation > 1. cuDNN's pooling descriptor has no dilation parameter, so the
@@ -1335,6 +1351,7 @@ TEST(PoolTest, AveragePool_CUDA_symmetric_pad_dilation_1d) {
   test.AddOutput<float>("Y", expected_dims, expected_vals);
   test.Run(OpTester::ExpectResult::kExpectSuccess, "",
            {kTensorrtExecutionProvider, kAclExecutionProvider, kOpenVINOExecutionProvider,
+            kDnnlExecutionProvider, kCoreMLExecutionProvider, kQnnExecutionProvider,
             kDmlExecutionProvider});
 }
 
@@ -1357,6 +1374,7 @@ TEST(PoolTest, AveragePool_CUDA_same_lower_asymmetric_1d) {
   test.AddOutput<float>("Y", expected_dims, expected_vals);
   test.Run(OpTester::ExpectResult::kExpectSuccess, "",
            {kTensorrtExecutionProvider, kAclExecutionProvider, kOpenVINOExecutionProvider,
+            kDnnlExecutionProvider, kCoreMLExecutionProvider, kQnnExecutionProvider,
             kDmlExecutionProvider});
 }
 

--- a/onnxruntime/test/providers/cpu/nn/pool_op_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/pool_op_test.cc
@@ -959,10 +959,11 @@ TEST(PoolTest, AveragePool_CountIncludePad_AsymmetricPads) {
 
   test.AddInput<float>("X", x_dims, x_vals);
   test.AddOutput<float>("Y", expected_dims, expected_vals);
-  // This test targets the CPU fix only. Exclude EPs whose external libraries
-  // (cuDNN, CoreML, etc.) also produce wrong results for this case.
+  // The CUDA custom AveragePoolWithPad kernel now honors per-side (asymmetric) pads, so the
+  // CUDA (NCHW) leg is un-excluded here to lock in that fix. The remaining exclusions are EPs
+  // whose external libraries (cuDNN NHWC, CoreML, etc.) still produce wrong results for this case.
   test.Run(OpTester::ExpectResult::kExpectSuccess, "",
-           {kCudaExecutionProvider, kCudaNHWCExecutionProvider,
+           {kCudaNHWCExecutionProvider,
             kTensorrtExecutionProvider, kAclExecutionProvider, kOpenVINOExecutionProvider,
             kDnnlExecutionProvider, kCoreMLExecutionProvider, kQnnExecutionProvider,
             kDmlExecutionProvider});
@@ -994,10 +995,11 @@ TEST(PoolTest, AveragePool3D_CountIncludePad_AsymmetricPads) {
                                         0.5f, 0.25f};
   test.AddInput<float>("X", x3d_dims, x3d_vals);
   test.AddOutput<float>("Y", expected3d_dims, expected3d_vals);
-  // This test targets the CPU fix only. Exclude EPs whose external libraries
-  // (cuDNN, CoreML, etc.) also produce wrong results for this case.
+  // The CUDA custom AveragePoolWithPad kernel now honors per-side (asymmetric) pads in 3D, so the
+  // CUDA (NCHW) leg is un-excluded here to lock in that fix. The remaining exclusions are EPs
+  // whose external libraries (cuDNN NHWC, CoreML, etc.) still produce wrong results for this case.
   test.Run(OpTester::ExpectResult::kExpectSuccess, "",
-           {kCudaExecutionProvider, kCudaNHWCExecutionProvider,
+           {kCudaNHWCExecutionProvider,
             kTensorrtExecutionProvider, kAclExecutionProvider, kOpenVINOExecutionProvider,
             kDnnlExecutionProvider, kCoreMLExecutionProvider, kQnnExecutionProvider,
             kDmlExecutionProvider});
@@ -1096,14 +1098,14 @@ TEST(PoolTest, AveragePool_19_ceil_count_include_pad_1d) {
 }
 
 // ---------------------------------------------------------------------------
-// Target (b): CUDA AveragePool asymmetric-padding parity tests.
+// CUDA AveragePool asymmetric-padding parity tests.
 //
 // cuDNN's pooling descriptor stores one symmetric pad per axis, so it silently drops the
-// ONNX end pad when pad_begin != pad_end, producing wrong averages on CUDA (QA probe:
-// 1D pad(0,3) CUDA=[4,6.5,8] vs CPU=[4,5.571,4]; 2D pad(0,0,3,3) diff 53.25). The custom
-// AveragePoolWithPad CUDA kernel fixes this. These cases keep the CUDA EP UN-excluded so the
-// CUDA leg actually runs and must match the CPU reference oracle. Expected values are the CPU
-// reference outputs (also cross-checked against the QA probe numbers).
+// ONNX end pad when pad_begin != pad_end, producing wrong averages on CUDA (e.g. for a 1D
+// pad of (0,3) cuDNN yields [4, 6.5, 8] while the CPU reference yields [4, 5.571, 4], and a
+// 2D pad of (0,0,3,3) diverges by up to 53.25). The custom AveragePoolWithPad CUDA kernel
+// fixes this. These cases keep the CUDA EP UN-excluded so the CUDA leg actually runs and must
+// match the CPU reference oracle. Expected values are the CPU reference outputs.
 //
 // ceil_mode + count_include_pad cases use opset 19 so the CPU leg runs the already-correct v19
 // reference functor and validates the CUDA kernel independently of the separate CPU opset-7..18


### PR DESCRIPTION
### Summary

Fixes wrong `AveragePool` output on the **CUDA** EP whenever cuDNN's pooling descriptor cannot represent the requested pooling — i.e. **asymmetric padding** or **dilation > 1**. This is the CUDA-EP counterpart of the CPU fix in #29629 and, together with it, the JSEP shape fix in #29627, closes out the CUDA leg of pytorch/pytorch#183528.

### Root cause

`CudnnPoolingDescriptor::Set` copies only the **begin** pads (`pads[0..rank)`) into the cuDNN pooling descriptor, which stores a *single symmetric pad value per axis* and applies it to both sides. The ONNX **end** pads (`pads[rank..2*rank)`) are silently dropped. As a result, **all** asymmetric-pad AveragePool on CUDA is wrong:

- explicit asymmetric `pads`,
- `auto_pad = SAME_UPPER` / `SAME_LOWER` (which produce naturally asymmetric pads),
- `ceil_mode = 1` boundary windows.

Separately, the cuDNN pooling descriptor has **no dilation parameter at all**, so any `dilations > 1` is also silently ignored — even with symmetric pads.

Example divergence from the CPU reference (QA probe): 1D `pad(0,3)`, k7, s3, `ceil_mode=1`, `count_include_pad=1` gave CUDA `[4, 6.5, 8]` vs. correct `[4, 5.571, 4]`; 2D `pad(0,0,3,3)` gave `71.0` vs. correct `17.75`.

### Fix

Add a custom CUDA average-pool kernel (`avg_pool_impl.cu` / `.h`, modeled on `max_pool_with_index.cu`) that honors **per-side pads** and **dilation**, and computes the `count_include_pad` divisor exactly like the CPU v19 reference functor (`AveragePool{1,2,3}DTask`):

- include-pad divisor clamps the window end to `input + pad_tail` (drops the ceil-mode phantom cells), dividing by `∏ (1 + (end - start - 1)/dilation)`;
- exclude-pad divisor counts only in-bounds cells.

In `Pool<T, AveragePool, Layout>::ComputeInternal`, a cheap dispatch guard routes to the custom kernel **only** when the pooling is non-global **and** (`asymmetric pads` **or** `!default_dilations`). Every symmetric, non-dilated case — the overwhelmingly common path, including **all** `GlobalAveragePool` — stays on the existing cuDNN fast path, so there is **zero perf regression** on the common path. `GlobalAveragePool` is excluded explicitly because `PoolAttributes` leaves its `kernel_shape`/`strides`/`dilations` unpopulated. `MaxPool` is unaffected (it ignores pad cells; `MaxPool<8>` already routes dilation to its own custom kernel via the same `!default_dilations` check we mirror here).

Covers fp32, fp64, fp16, and bf16 (fp16/bf16 accumulate in float).

### Tests

Added CUDA-**un-excluded** parity tests in `pool_op_test.cc` — the CUDA leg actually runs and must match the CPU reference oracle:

- asymmetric tail-pad 1D/2D, include- and exclude-pad;
- `auto_pad=SAME_UPPER` and `SAME_LOWER` (naturally asymmetric);
- **symmetric-pad + dilation>1** (wrong on cuDNN, correct via the kernel — locks in the dilation guard);
- a symmetric-pad regression case (must stay on cuDNN and remain correct);
- fp16;
- a `MaxPool` asymmetric-pad case confirming MaxPool is unaffected.

The `ceil_mode + count_include_pad` cases use opset 19 so the CPU leg runs the already-correct v19 reference functor and validates the CUDA kernel independently of the separate opset-7..18 CPU MLAS fix (#29629); CUDA routing is opset-independent. Full `PoolTest` suite passes on an A100 (53 passed / 2 DML-skipped / 0 failures).

### Related

- CPU (a): #29629 — opset 7-18 MLAS `ceil_mode + count_include_pad` divisor fix.
- JSEP (c): #29627 — JSEP pooling output shape honoring `ceil_mode`.
- pytorch/pytorch#183528.
