### PR TITLE
Fix Qwen3 RotaryEmbedding fusion emitting invalid position_ids shape

### DIFF
--- a/onnxruntime/python/tools/transformers/fusion_rotary_attention.py
+++ b/onnxruntime/python/tools/transformers/fusion_rotary_attention.py
@@ -1365,6 +1365,52 @@ class FusionRotaryEmbeddings(Fusion):
 
         return cos_cache_name, sin_cache_name, position_ids
 
+    def make_position_ids_format0(self, position_ids: str) -> str:
+        """Reduce on-the-fly RoPE position_ids to a format-0 (single-offset) tensor.
+
+        In on-the-fly RoPE (Qwen3) the traced position_ids is cache_position broadcast
+        over the batch axis, i.e. a (1, sequence_length) tensor holding the contiguous
+        positions [base, base + 1, ..., base + sequence_length - 1]. The RotaryEmbedding
+        kernel only accepts a scalar/1-element position_ids (format 0) or an exact
+        (batch_size, sequence_length) tensor (format 1); a (1, sequence_length) tensor is
+        rejected once batch_size > 1. Format 0 computes the effective position as
+        position_ids[0] + s for every batch row, which reproduces the arange exactly, so
+        taking the first position yields an equivalent, batch-independent input.
+
+        The reduction flattens then slices the first element so it is correct for any
+        leading batch dimension. Returns the name of a (1,) tensor feeding RotaryEmbedding.
+        """
+        flatten_shape_name = "position_ids_format0_flatten_shape"
+        starts_name = "position_ids_format0_starts"
+        ends_name = "position_ids_format0_ends"
+        axes_name = "position_ids_format0_axes"
+        if self.model.get_initializer(flatten_shape_name) is None:
+            self.add_initializer(flatten_shape_name, TensorProto.INT64, dims=[1], vals=[-1], raw=False)
+            self.add_initializer(starts_name, TensorProto.INT64, dims=[1], vals=[0], raw=False)
+            self.add_initializer(ends_name, TensorProto.INT64, dims=[1], vals=[1], raw=False)
+            self.add_initializer(axes_name, TensorProto.INT64, dims=[1], vals=[0], raw=False)
+
+        flatten_node_name = self.model.create_node_name("Reshape", name_prefix="position_ids_format0_flatten")
+        flatten_node = helper.make_node(
+            "Reshape",
+            inputs=[position_ids, flatten_shape_name],
+            outputs=[flatten_node_name + "_output_0"],
+            name=flatten_node_name,
+        )
+        slice_node_name = self.model.create_node_name("Slice", name_prefix="position_ids_format0_slice")
+        slice_node = helper.make_node(
+            "Slice",
+            inputs=[flatten_node.output[0], starts_name, ends_name, axes_name],
+            outputs=[slice_node_name + "_output_0"],
+            name=slice_node_name,
+        )
+
+        self.nodes_to_add.extend([flatten_node, slice_node])
+        self.node_name_to_graph_name[flatten_node.name] = self.this_graph_name
+        self.node_name_to_graph_name[slice_node.name] = self.this_graph_name
+
+        return slice_node.output[0]
+
     def fuse(self, node, input_name_to_nodes, output_name_to_node):
         # Node is either RotaryEmbedding function or Add
         if self.base_name not in node.op_type and node.op_type != "Add":
@@ -1671,6 +1717,11 @@ class FusionRotaryEmbeddings(Fusion):
                 if cos_cache is None:
                     logger.debug("fuse_rotary_embeddings: failed to create cos/sin cache from on-the-fly RoPE")
                     return
+
+                # The traced position_ids is cache_position broadcast over the batch axis
+                # (shape (1, sequence_length)), which the RotaryEmbedding kernel rejects for
+                # batch_size > 1. Reduce it to an equivalent format-0 single-offset tensor.
+                position_ids = self.make_position_ids_format0(position_ids)
             else:
                 # Check path for position ids
                 if position_ids == "":

--- a/onnxruntime/test/python/transformers/test_attention_fusion.py
+++ b/onnxruntime/test/python/transformers/test_attention_fusion.py
@@ -642,6 +642,79 @@ class TestFusion(unittest.TestCase):
                 err_msg=f"sin_cache mismatch at position {pos}",
             )
 
+    def test_qwen3_rotary_embedding_fusion_position_ids_format0(self):
+        """Test that on-the-fly RoPE fusion emits a format-0 position_ids.
+
+        In a real Qwen3 export the traced position_ids is cache_position broadcast over the
+        batch axis (shape (1, sequence_length)), which the RotaryEmbedding kernel rejects for
+        batch_size > 1. The fusion must reduce it to a scalar/1-element (format 0) tensor so the
+        node works for any batch size. Regression test for the invalid position_ids shape issue.
+        """
+        hidden_size = 64
+        num_heads = 8
+        num_kv_heads = 2
+
+        model = create_qwen3_decoder_layer(
+            hidden_size=hidden_size,
+            num_heads=num_heads,
+            num_kv_heads=num_kv_heads,
+            include_rope=True,
+        )
+
+        dir = tempfile.mkdtemp()
+        model_path = os.path.join(dir, "qwen3_decoder_rope_pos_format0.onnx")
+        onnx.save(model, model_path)
+
+        options = FusionOptions("qwen3")
+        optimized_model = optimize_model(
+            model_path,
+            model_type="qwen3",
+            num_heads=num_heads,
+            hidden_size=hidden_size,
+            optimization_options=options,
+        )
+
+        os.remove(model_path)
+
+        nodes = optimized_model.model.graph.node
+        rope_nodes = [n for n in nodes if n.op_type == "RotaryEmbedding"]
+        self.assertEqual(len(rope_nodes), 2, f"Expected 2 RotaryEmbedding (Q + K), got {len(rope_nodes)}")
+
+        output_to_node = {output: node for node in nodes for output in node.output}
+
+        # Every RotaryEmbedding node's position_ids (input index 1) must be produced by the
+        # format-0 reduction (Reshape flatten -> Slice first element) rather than the raw
+        # (1, sequence_length) / (batch, sequence_length) tensor the kernel rejects.
+        for rope_node in rope_nodes:
+            position_ids_name = rope_node.input[1]
+            slice_node = output_to_node.get(position_ids_name)
+            self.assertIsNotNone(
+                slice_node,
+                f"position_ids '{position_ids_name}' for {rope_node.name} has no producing node",
+            )
+            self.assertEqual(
+                slice_node.op_type,
+                "Slice",
+                f"position_ids for {rope_node.name} should be produced by the format-0 Slice, got {slice_node.op_type}",
+            )
+            # Slice takes the first element: starts=[0], ends=[1], axes=[0].
+            starts = optimized_model.get_initializer(slice_node.input[1])
+            ends = optimized_model.get_initializer(slice_node.input[2])
+            self.assertIsNotNone(starts, "format-0 Slice starts must be a constant initializer")
+            self.assertIsNotNone(ends, "format-0 Slice ends must be a constant initializer")
+            self.assertEqual(list(numpy_helper.to_array(starts)), [0], "format-0 Slice must start at 0")
+            self.assertEqual(list(numpy_helper.to_array(ends)), [1], "format-0 Slice must take one element")
+            flatten_node = output_to_node.get(slice_node.input[0])
+            self.assertIsNotNone(flatten_node, "format-0 Slice input must be produced by the flatten Reshape")
+            self.assertEqual(flatten_node.op_type, "Reshape", "format-0 position_ids must be flattened by Reshape")
+            flatten_shape = optimized_model.get_initializer(flatten_node.input[1])
+            self.assertIsNotNone(flatten_shape, "format-0 flatten Reshape shape must be a constant initializer")
+            self.assertEqual(
+                list(numpy_helper.to_array(flatten_shape)),
+                [-1],
+                "format-0 position_ids must be flattened to 1D before slicing",
+            )
+
     def test_dit_attention_fusion(self):
         """Test DiT attention fusion for F5-TTS-style pattern (FP32, with K pre-transpose)."""
         model = create_dit_attention(


### PR DESCRIPTION
The on-the-fly RoPE fusion added for Qwen3 in #27590 wires the traced position_ids into the com.microsoft.RotaryEmbedding node without adapting its shape. A real Qwen3 export has no position_ids input, so HuggingFace builds one with a hardcoded batch axis of 1, shape 1 by sequence_length. The kernel only accepts a scalar or single-element position_ids, or an exact batch_size by sequence_length tensor, so any request with batch_size greater than 1 fails with "Input 'position_ids' dimension 0 should be of size batch_size, got 1". The existing tests missed it because the Qwen3 test generator declared position_ids as an already correct batch_size by sequence_length input.

In on-the-fly RoPE the position_ids is just the contiguous arange, and the kernel's scalar path derives every position from the first element, which reproduces that arange exactly and is batch-independent. This flattens the traced tensor and slices its first element to an equivalent single-offset input, so the fused node is correct at any batch size. A standalone check confirms the reduced output is bit-identical to the intended full arange, and a regression test verifies the fusion now emits it.

Fixes #29618.
