### PR TITLE
Use the latest version of AnyChart in the perf tool

### DIFF
--- a/tools/perf_view/ort_perf_view.html
+++ b/tools/perf_view/ort_perf_view.html
@@ -3,9 +3,9 @@
   <head>
     <title id="filename">Onnxruntime Perf View</title>
     <script type="text/javascript" src="https://cdn.anychart.com/releases/v8/js/anychart-core.min.js"></script>
-    <script src="https://cdn.anychart.com/releases/8.13.0/js/anychart-ui.min.js"></script>
+    <script src="https://cdn.anychart.com/releases/v8/js/anychart-ui.min.js"></script>
     <script type="text/javascript" src="https://cdn.anychart.com/releases/v8/js/anychart-treemap.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="https://cdn.anychart.com/releases/8.13.0/css/anychart-ui.min.css"/>
+    <link rel="stylesheet" type="text/css" href="https://cdn.anychart.com/releases/v8/css/anychart-ui.min.css"/>
     <style>
       html, body {
         width: 100%;


### PR DESCRIPTION
### Description

Fixes once more the display of profile data in the `ort_perf_view` tool, and should make it so that it stays fixed.

### Motivation and Context

The `ort_perf_view` tool is back to no longer showing profiling data, like it happened previously in issue #16873, which was fixed in PR #16932, and again in PR #24684.

This PR attempts to fix this issue once and for all by avoiding to partially hardcode the specific versions of the AnyChart modules it uses, and instead using the latest `8.x` release for all modules.


