### PR TITLE
[TensorRT] Deduplicate context path helpers

### DIFF
--- a/onnxruntime/core/common/path_utils.h
+++ b/onnxruntime/core/common/path_utils.h
@@ -3,6 +3,10 @@
 
 #pragma once
 
+#include <filesystem>
+#include <string>
+#include <string_view>
+
 #include "core/common/common.h"
 #include "core/common/path_string.h"
 
@@ -19,5 +23,55 @@ PathString MakePathString(const Args&... args) {
   const std::string str = onnxruntime::MakeString(args...);
   return ToPathString(str);
 }
+
+/** Return a directory path unchanged, or the parent path if the input is a file path. */
+inline std::filesystem::path GetDirOrParentPath(const std::filesystem::path& path) {
+  if (path.empty() || std::filesystem::is_directory(path)) {
+    return path;
+  }
+
+  return path.parent_path();
+}
+
+/**
+ * Return file_or_directory_path if it names a file. Otherwise, generate a filename from source_file_path's stem and
+ * suffix, optionally under file_or_directory_path when it names a directory.
+ */
+inline std::string GetPathWithStemSuffix(const std::string& file_or_directory_path,
+                                         const std::string& source_file_path,
+                                         std::string_view suffix) {
+  if (!file_or_directory_path.empty() && !std::filesystem::is_directory(file_or_directory_path)) {
+    return file_or_directory_path;
+  }
+
+  const std::filesystem::path source_path = source_file_path;
+  const std::string default_filename = source_path.stem().string() + std::string{suffix};
+  if (std::filesystem::is_directory(file_or_directory_path)) {
+    std::filesystem::path directory = file_or_directory_path;
+    return directory.append(default_filename).string();
+  }
+
+  return default_filename;
+}
+
+inline bool IsAbsolutePath(const std::string& path_string) {
+#ifdef _WIN32
+  const auto path = std::filesystem::path{ToPathString(path_string)};
+  return path.is_absolute();
+#else
+  return !path_string.empty() && path_string.front() == '/';
+#endif
+}
+
+inline bool IsRelativePathToParentPath(const std::string& path_string) {
+#ifdef _WIN32
+  const auto path = std::filesystem::path{ToPathString(path_string)};
+  const auto relative_path = path.lexically_normal().make_preferred().wstring();
+  return relative_path.find(L"..") != std::wstring::npos;
+#else
+  return !path_string.empty() && path_string.find("..") != std::string::npos;
+#endif
+}
+
 }  // namespace path_utils
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.cc
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/nv_execution_provider.cc
@@ -11,6 +11,7 @@
 #include "core/session/onnxruntime_cxx_api.h"
 #include "core/common/common.h"
 #include "core/common/narrow.h"
+#include "core/common/path_utils.h"
 #include "core/common/safeint.h"
 #include "core/framework/ort_value.h"
 #include "nv_execution_provider.h"
@@ -1138,10 +1139,10 @@ NvExecutionProvider::NvExecutionProvider(const NvExecutionProviderInfo& info)
   if (dump_ep_context_model_) {
     // TODO(maximilianm) not sure if this is still needed
     engine_cache_enable_ = true;
-    if (IsAbsolutePath(cache_path_)) {
+    if (path_utils::IsAbsolutePath(cache_path_)) {
       LOGS_DEFAULT(ERROR) << "In the case of dumping context model and for security purpose, the trt_engine_cache_path should be set with a relative path, but it is an absolute path:  " << cache_path_;
     }
-    if (IsRelativePathToParentPath(cache_path_)) {
+    if (path_utils::IsRelativePathToParentPath(cache_path_)) {
       LOGS_DEFAULT(ERROR) << "In the case of dumping context model and for security purpose, The trt_engine_cache_path has '..', it's not allowed to point outside the directory.";
     }
 
@@ -1150,7 +1151,7 @@ NvExecutionProvider::NvExecutionProvider(const NvExecutionProviderInfo& info)
     engine_cache_relative_path_to_context_model_dir = cache_path_;
 
     // Make cache_path_ to be the relative path of ep_context_file_path_
-    cache_path_ = GetPathOrParentPathOfCtxModel(ep_context_file_path_).append(cache_path_).string();
+    cache_path_ = path_utils::GetDirOrParentPath(ep_context_file_path_).append(cache_path_).string();
   }
 
   if (engine_decryption_enable_) {
@@ -2930,7 +2931,7 @@ Status NvExecutionProvider::CreateNodeComputeInfoFromGraph(const GraphViewer& gr
 
   // Generate file name for dumping ep context model
   if (dump_ep_context_model_ && ctx_model_path_.empty()) {
-    ctx_model_path_ = GetCtxModelPath(ep_context_file_path_, model_path_);
+    ctx_model_path_ = path_utils::GetPathWithStemSuffix(ep_context_file_path_, model_path_, "_ctx.onnx");
   }
   {
     auto lock = GetApiLock();

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/onnx_ctx_model_helper.cc
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/onnx_ctx_model_helper.cc
@@ -7,6 +7,7 @@
 #include <filesystem>
 
 #include "onnx_ctx_model_helper.h"
+#include "core/common/path_utils.h"
 #include "core/providers/cuda/shared_inc/cuda_call.h"
 #include "core/framework/execution_provider.h"
 #include "nv_execution_provider.h"
@@ -216,103 +217,6 @@ Status CreateCtxNode(const GraphViewer& graph_viewer,
   return Status::OK();
 }
 
-/*
- * Return the directory where the ep context model locates
- */
-std::filesystem::path GetPathOrParentPathOfCtxModel(const std::string& ep_context_file_path) {
-  if (ep_context_file_path.empty()) {
-    return std::filesystem::path();
-  }
-  std::filesystem::path ctx_path(ep_context_file_path);
-  if (std::filesystem::is_directory(ep_context_file_path)) {
-    return ctx_path;
-  } else {
-    return ctx_path.parent_path();
-  }
-}
-
-/*
- * Get "EP context" model path.
- *
- * Function logic:
- * If ep_context_file_path is provided,
- *     - If ep_context_file_path is a file, return "ep_context_file_path".
- *     - If ep_context_file_path is a directory, return "ep_context_file_path/original_model_name_ctx.onnx".
- * If ep_context_file_path is not provided,
- *     - Return "original_model_name_ctx.onnx".
- *
- * TRT EP has rules about context model path and engine cache path (see tensorrt_execution_provider.cc):
- * - If dump_ep_context_model_ and engine_cache_enabled_ is enabled, TRT EP will dump context model and save engine cache
- *   to the same directory provided by ep_context_file_path_. (i.e. engine_cache_path_ = ep_context_file_path_)
- *
- * Example 1:
- * ep_context_file_path = "/home/user/ep_context_model_directory"
- * original_model_path = "model.onnx"
- * => return "/home/user/ep_context_model_folder/model_ctx.onnx"
- *
- * Example 2:
- * ep_context_file_path = "my_ctx_model.onnx"
- * original_model_path = "model.onnx"
- * => return "my_ctx_model.onnx"
- *
- * Example 3:
- * ep_context_file_path = "/home/user2/ep_context_model_directory/my_ctx_model.onnx"
- * original_model_path = "model.onnx"
- * => return "/home/user2/ep_context_model_directory/my_ctx_model.onnx"
- *
- */
-std::string GetCtxModelPath(const std::string& ep_context_file_path,
-                            const std::string& original_model_path) {
-  std::string ctx_model_path;
-
-  if (!ep_context_file_path.empty() && !std::filesystem::is_directory(ep_context_file_path)) {
-    ctx_model_path = ep_context_file_path;
-  } else {
-    std::filesystem::path model_path = original_model_path;
-    std::filesystem::path model_name_stem = model_path.stem();  // model_name.onnx -> model_name
-    std::string ctx_model_name = model_name_stem.string() + "_ctx.onnx";
-
-    if (std::filesystem::is_directory(ep_context_file_path)) {
-      std::filesystem::path model_directory = ep_context_file_path;
-      ctx_model_path = model_directory.append(ctx_model_name).string();
-    } else {
-      ctx_model_path = ctx_model_name;
-    }
-  }
-  return ctx_model_path;
-}
-
-bool IsAbsolutePath(const std::string& path_string) {
-#ifdef _WIN32
-  onnxruntime::PathString ort_path_string = onnxruntime::ToPathString(path_string);
-  auto path = std::filesystem::path(ort_path_string.c_str());
-  return path.is_absolute();
-#else
-  if (!path_string.empty() && path_string[0] == '/') {
-    return true;
-  }
-  return false;
-#endif
-}
-
-// Like "../file_path"
-bool IsRelativePathToParentPath(const std::string& path_string) {
-#ifdef _WIN32
-  onnxruntime::PathString ort_path_string = onnxruntime::ToPathString(path_string);
-  auto path = std::filesystem::path(ort_path_string.c_str());
-  auto relative_path = path.lexically_normal().make_preferred().wstring();
-  if (relative_path.find(L"..", 0) != std::string::npos) {
-    return true;
-  }
-  return false;
-#else
-  if (!path_string.empty() && path_string.find("..", 0) != std::string::npos) {
-    return true;
-  }
-  return false;
-#endif
-}
-
 Status TensorRTCacheModelHandler::GetEpContextFromGraph(const Node& node) {
   auto& attrs = node.GetAttributes();
 
@@ -352,7 +256,7 @@ Status TensorRTCacheModelHandler::GetEpContextFromGraph(const Node& node) {
 
     // Validate that the cache path does not escape the model directory.
     // Rejects absolute paths, ".." traversal, and symlink-based escapes.
-    std::filesystem::path ctx_model_dir(GetPathOrParentPathOfCtxModel(ep_context_model_path_));
+    std::filesystem::path ctx_model_dir(path_utils::GetDirOrParentPath(ep_context_model_path_));
     ORT_RETURN_IF_ERROR(utils::ValidateExternalDataPathFromDir(ctx_model_dir, std::filesystem::path(cache_path)));
 
     // The engine cache and context model (current model) should be in the same directory

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/onnx_ctx_model_helper.h
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/onnx_ctx_model_helper.h
@@ -30,10 +30,8 @@ constexpr size_t kTensorRTEngineHeaderSize = 64;
 // Helper functions for engine header validation
 std::string BinaryToHexString(const void* data, size_t size);
 std::vector<uint8_t> HexStringToBinary(const std::string& hex);
-
 bool GraphHasCtxNode(const GraphViewer& graph_viewer, size_t& node_idx);
 const std::filesystem::path& GetModelPath(const GraphViewer& graph_viewer);
-std::filesystem::path GetPathOrParentPathOfCtxModel(const std::string& ep_context_file_path);
 Status CreateCtxNode(const GraphViewer& graph_viewer,
                      Graph& graph_build,
                      const std::string engine_cache_path,
@@ -44,10 +42,6 @@ Status CreateCtxNode(const GraphViewer& graph_viewer,
                      const std::string onnx_model_path,
                      const std::string& ep_context_node_name,
                      int trt_version);
-std::string GetCtxModelPath(const std::string& ep_context_file_path,
-                            const std::string& original_model_path);
-bool IsAbsolutePath(const std::string& path_string);
-bool IsRelativePathToParentPath(const std::string& path_string);
 void UpdateCtxNodeModelEngineContext(ONNX_NAMESPACE::ModelProto* model_proto,
                                      char* engine_data,
                                      size_t size);

--- a/onnxruntime/core/providers/tensorrt/onnx_ctx_model_helper.cc
+++ b/onnxruntime/core/providers/tensorrt/onnx_ctx_model_helper.cc
@@ -6,6 +6,7 @@
 #include <filesystem>
 
 #include "onnx_ctx_model_helper.h"
+#include "core/common/path_utils.h"
 #include "core/providers/cuda/shared_inc/cuda_call.h"
 #include "core/framework/execution_provider.h"
 #include "tensorrt_execution_provider.h"
@@ -150,72 +151,6 @@ ONNX_NAMESPACE::ModelProto* CreateCtxModel(const GraphViewer& graph_viewer,
 }
 
 /*
- * Return the directory where the ep context model locates
- */
-std::filesystem::path GetPathOrParentPathOfCtxModel(const std::string& ep_context_file_path) {
-  if (ep_context_file_path.empty()) {
-    return std::filesystem::path();
-  }
-  std::filesystem::path ctx_path(ep_context_file_path);
-  if (std::filesystem::is_directory(ep_context_file_path)) {
-    return ctx_path;
-  } else {
-    return ctx_path.parent_path();
-  }
-}
-
-/*
- * Get "EP context" model path.
- *
- * Function logic:
- * If ep_context_file_path is provided,
- *     - If ep_context_file_path is a file, return "ep_context_file_path".
- *     - If ep_context_file_path is a directory, return "ep_context_file_path/original_model_name_ctx.onnx".
- * If ep_context_file_path is not provided,
- *     - Return "original_model_name_ctx.onnx".
- *
- * TRT EP has rules about context model path and engine cache path (see tensorrt_execution_provider.cc):
- * - If dump_ep_context_model_ and engine_cache_enabled_ is enabled, TRT EP will dump context model and save engine cache
- *   to the same directory provided by ep_context_file_path_. (i.e. engine_cache_path_ = ep_context_file_path_)
- *
- * Example 1:
- * ep_context_file_path = "/home/user/ep_context_model_directory"
- * original_model_path = "model.onnx"
- * => return "/home/user/ep_context_model_folder/model_ctx.onnx"
- *
- * Example 2:
- * ep_context_file_path = "my_ctx_model.onnx"
- * original_model_path = "model.onnx"
- * => return "my_ctx_model.onnx"
- *
- * Example 3:
- * ep_context_file_path = "/home/user2/ep_context_model_directory/my_ctx_model.onnx"
- * original_model_path = "model.onnx"
- * => return "/home/user2/ep_context_model_directory/my_ctx_model.onnx"
- *
- */
-std::string GetCtxModelPath(const std::string& ep_context_file_path,
-                            const std::string& original_model_path) {
-  std::string ctx_model_path;
-
-  if (!ep_context_file_path.empty() && !std::filesystem::is_directory(ep_context_file_path)) {
-    ctx_model_path = ep_context_file_path;
-  } else {
-    std::filesystem::path model_path = original_model_path;
-    std::filesystem::path model_name_stem = model_path.stem();  // model_name.onnx -> model_name
-    std::string ctx_model_name = model_name_stem.string() + "_ctx.onnx";
-
-    if (std::filesystem::is_directory(ep_context_file_path)) {
-      std::filesystem::path model_directory = ep_context_file_path;
-      ctx_model_path = model_directory.append(ctx_model_name).string();
-    } else {
-      ctx_model_path = ctx_model_name;
-    }
-  }
-  return ctx_model_path;
-}
-
-/*
  * Dump "EP context" model
  *
  */
@@ -224,37 +159,6 @@ void DumpCtxModel(ONNX_NAMESPACE::ModelProto* model_proto,
   std::fstream dump(ctx_model_path, std::ios::out | std::ios::trunc | std::ios::binary);
   model_proto->SerializeToOstream(dump);
   LOGS_DEFAULT(VERBOSE) << "[TensorRT EP] Dumped " + ctx_model_path;
-}
-
-bool IsAbsolutePath(const std::string& path_string) {
-#ifdef _WIN32
-  onnxruntime::PathString ort_path_string = onnxruntime::ToPathString(path_string);
-  auto path = std::filesystem::path(ort_path_string.c_str());
-  return path.is_absolute();
-#else
-  if (!path_string.empty() && path_string[0] == '/') {
-    return true;
-  }
-  return false;
-#endif
-}
-
-// Like "../file_path"
-bool IsRelativePathToParentPath(const std::string& path_string) {
-#ifdef _WIN32
-  onnxruntime::PathString ort_path_string = onnxruntime::ToPathString(path_string);
-  auto path = std::filesystem::path(ort_path_string.c_str());
-  auto relative_path = path.lexically_normal().make_preferred().wstring();
-  if (relative_path.find(L"..", 0) != std::string::npos) {
-    return true;
-  }
-  return false;
-#else
-  if (!path_string.empty() && path_string.find("..", 0) != std::string::npos) {
-    return true;
-  }
-  return false;
-#endif
 }
 
 /*
@@ -325,7 +229,7 @@ Status TensorRTCacheModelHandler::GetEpContextFromGraph(const GraphViewer& graph
 
     // Validate that the cache path does not escape the model directory.
     // Rejects absolute paths, ".." traversal, and symlink-based escapes.
-    std::filesystem::path ctx_model_dir(GetPathOrParentPathOfCtxModel(ep_context_model_path_));
+    std::filesystem::path ctx_model_dir(path_utils::GetDirOrParentPath(ep_context_model_path_));
     ORT_RETURN_IF_ERROR(utils::ValidateExternalDataPathFromDir(ctx_model_dir, std::filesystem::path(cache_path)));
 
     // The engine cache and context model (current model) should be in the same directory

--- a/onnxruntime/core/providers/tensorrt/onnx_ctx_model_helper.h
+++ b/onnxruntime/core/providers/tensorrt/onnx_ctx_model_helper.h
@@ -26,7 +26,6 @@ static const std::string EPCONTEXT_WARNING =
 
 bool GraphHasCtxNode(const GraphViewer& graph_viewer);
 const std::filesystem::path& GetModelPath(const GraphViewer& graph_viewer);
-std::filesystem::path GetPathOrParentPathOfCtxModel(const std::string& ep_context_file_path);
 ONNX_NAMESPACE::ModelProto* CreateCtxModel(const GraphViewer& graph_viewer,
                                            const std::string engine_cache_path,
                                            char* engine_data,
@@ -35,10 +34,6 @@ ONNX_NAMESPACE::ModelProto* CreateCtxModel(const GraphViewer& graph_viewer,
                                            const std::string compute_capability,
                                            const std::string onnx_model_path,
                                            const logging::Logger* logger);
-std::string GetCtxModelPath(const std::string& ep_context_file_path,
-                            const std::string& original_model_path);
-bool IsAbsolutePath(const std::string& path_string);
-bool IsRelativePathToParentPath(const std::string& path_string);
 void DumpCtxModel(ONNX_NAMESPACE::ModelProto* model_proto,
                   const std::string& ctx_model_path);
 void UpdateCtxNodeModelEngineContext(ONNX_NAMESPACE::ModelProto* model_proto,

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -8,6 +8,7 @@
 #include "core/session/onnxruntime_cxx_api.h"
 #include "core/common/common.h"
 #include "core/common/narrow.h"
+#include "core/common/path_utils.h"
 #include "core/common/safeint.h"
 #include "tensorrt_execution_provider.h"
 #include "tensorrt_execution_provider_utils.h"
@@ -1686,10 +1687,10 @@ TensorrtExecutionProvider::TensorrtExecutionProvider(const TensorrtExecutionProv
   // The new cache path will be saved as the "ep_cache_context" node attritue of the EP context node.
   // For security reason, it needs to make sure the engine cache is saved inside context model directory.
   if (dump_ep_context_model_ && engine_cache_enable_) {
-    if (IsAbsolutePath(cache_path_)) {
+    if (path_utils::IsAbsolutePath(cache_path_)) {
       LOGS_DEFAULT(ERROR) << "In the case of dumping context model and for security purpose, the trt_engine_cache_path should be set with a relative path, but it is an absolute path:  " << cache_path_;
     }
-    if (IsRelativePathToParentPath(cache_path_)) {
+    if (path_utils::IsRelativePathToParentPath(cache_path_)) {
       LOGS_DEFAULT(ERROR) << "In the case of dumping context model and for security purpose, The trt_engine_cache_path has '..', it's not allowed to point outside the directory.";
     }
 
@@ -1698,7 +1699,7 @@ TensorrtExecutionProvider::TensorrtExecutionProvider(const TensorrtExecutionProv
     engine_cache_relative_path_to_context_model_dir = cache_path_;
 
     // Make cache_path_ to be the relative path of ep_context_file_path_
-    cache_path_ = GetPathOrParentPathOfCtxModel(ep_context_file_path_).append(cache_path_).string();
+    cache_path_ = path_utils::GetDirOrParentPath(ep_context_file_path_).append(cache_path_).string();
   }
 
   // Hardware compatibility: pre-check on environment
@@ -3536,7 +3537,7 @@ Status TensorrtExecutionProvider::CreateNodeComputeInfoFromGraph(const GraphView
 
   // Generate file name for dumping ep context model
   if (dump_ep_context_model_ && ctx_model_path_.empty()) {
-    ctx_model_path_ = GetCtxModelPath(ep_context_file_path_, model_path_);
+    ctx_model_path_ = path_utils::GetPathWithStemSuffix(ep_context_file_path_, model_path_, "_ctx.onnx");
   }
 
   if (!has_dynamic_shape) {

--- a/onnxruntime/test/common/path_utils_test.cc
+++ b/onnxruntime/test/common/path_utils_test.cc
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <filesystem>
+
+#include "gtest/gtest.h"
+
+#include "core/common/path_utils.h"
+#include "test/util/include/temp_dir.h"
+
+namespace onnxruntime {
+namespace test {
+
+TEST(PathUtilsTest, GetDirOrParentPath) {
+  TemporaryDirectory temp_dir{ORT_TSTR("path_utils_test")};
+  const std::filesystem::path directory{temp_dir.Path()};
+
+  EXPECT_TRUE(path_utils::GetDirOrParentPath({}).empty());
+  EXPECT_EQ(path_utils::GetDirOrParentPath(directory), directory);
+  EXPECT_EQ(path_utils::GetDirOrParentPath(directory / "model.onnx"), directory);
+}
+
+TEST(PathUtilsTest, GetPathWithStemSuffix) {
+  TemporaryDirectory temp_dir{ORT_TSTR("path_utils_test")};
+  const std::filesystem::path directory{temp_dir.Path()};
+  const std::string directory_string = PathToUTF8String(directory.native());
+  const std::filesystem::path explicit_path = directory / "custom_context.onnx";
+  const std::string explicit_path_string = PathToUTF8String(explicit_path.native());
+
+  EXPECT_EQ(path_utils::GetPathWithStemSuffix("", "model.onnx", "_ctx.onnx"), "model_ctx.onnx");
+  EXPECT_EQ(path_utils::GetPathWithStemSuffix("", "model.v1.onnx", "_ctx.onnx"), "model.v1_ctx.onnx");
+  EXPECT_EQ(path_utils::GetPathWithStemSuffix(explicit_path_string, "model.onnx", "_ctx.onnx"),
+            explicit_path_string);
+  EXPECT_EQ(path_utils::GetPathWithStemSuffix(directory_string, "model.onnx", "_ctx.onnx"),
+            (directory / "model_ctx.onnx").string());
+}
+
+TEST(PathUtilsTest, IsAbsolutePath) {
+  const std::filesystem::path absolute_path = std::filesystem::absolute("cache");
+
+  EXPECT_TRUE(path_utils::IsAbsolutePath(PathToUTF8String(absolute_path.native())));
+  EXPECT_FALSE(path_utils::IsAbsolutePath("cache/engine"));
+  EXPECT_FALSE(path_utils::IsAbsolutePath(""));
+}
+
+TEST(PathUtilsTest, IsRelativePathToParentPath) {
+  EXPECT_TRUE(path_utils::IsRelativePathToParentPath("../cache"));
+#ifdef _WIN32
+  EXPECT_FALSE(path_utils::IsRelativePathToParentPath("cache/../engine"));
+#else
+  EXPECT_TRUE(path_utils::IsRelativePathToParentPath("cache/../engine"));
+#endif
+  EXPECT_TRUE(path_utils::IsRelativePathToParentPath("cache..engine"));
+  EXPECT_FALSE(path_utils::IsRelativePathToParentPath("cache/engine"));
+  EXPECT_FALSE(path_utils::IsRelativePathToParentPath(""));
+}
+
+}  // namespace test
+}  // namespace onnxruntime


### PR DESCRIPTION
## Summary
- move duplicated TensorRT context path helpers into `core/common/path_utils.h`
- reuse the shared helpers from the TensorRT and NvTensorRT RTX providers
- add cross-platform unit coverage for path construction and validation behavior

## Testing
- `lintrunner`
- `onnxruntime_test_all.exe --gtest_filter=PathUtilsTest.*:PathTest.*:PathValidationTest.*`
- `onnxruntime_test_all.exe` (1,843 tests: 1,816 passed, 27 skipped)