### PR TITLE
Deduplicate ONNX graph navigation helpers

### DIFF
--- a/onnxruntime/python/tools/onnx_graph_utils.py
+++ b/onnxruntime/python/tools/onnx_graph_utils.py
@@ -1,0 +1,70 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+from collections.abc import Iterable, Mapping, Sequence
+
+from onnx import NodeProto
+
+
+def input_name_to_nodes(nodes: Iterable[NodeProto]) -> dict[str, list[NodeProto]]:
+    input_name_to_nodes = {}
+    for node in nodes:
+        for input_name in node.input:
+            if input_name:
+                input_name_to_nodes.setdefault(input_name, []).append(node)
+    return input_name_to_nodes
+
+
+def output_name_to_node(nodes: Iterable[NodeProto]) -> dict[str, NodeProto]:
+    output_name_to_node = {}
+    for node in nodes:
+        for output_name in node.output:
+            if output_name:
+                output_name_to_node[output_name] = node
+    return output_name_to_node
+
+
+def get_children(
+    node: NodeProto,
+    input_name_to_nodes: Mapping[str, Sequence[NodeProto]],
+    output_index: int | None = None,
+) -> list[NodeProto]:
+    children = []
+    if output_index is not None:
+        if output_index < len(node.output):
+            output = node.output[output_index]
+            if output in input_name_to_nodes:
+                children = list(input_name_to_nodes[output])
+        return children
+
+    for output in node.output:
+        if output in input_name_to_nodes:
+            children.extend(input_name_to_nodes[output])
+    return children
+
+
+def get_parents(
+    node: NodeProto,
+    output_name_to_node: Mapping[str, NodeProto],
+) -> list[NodeProto]:
+    parents = []
+    for input_name in node.input:
+        if input_name in output_name_to_node:
+            parents.append(output_name_to_node[input_name])
+    return parents
+
+
+def get_parent(
+    node: NodeProto,
+    input_index: int,
+    output_name_to_node: Mapping[str, NodeProto],
+) -> NodeProto | None:
+    if len(node.input) <= input_index:
+        return None
+
+    input_name = node.input[input_index]
+    if input_name not in output_name_to_node:
+        return None
+
+    return output_name_to_node[input_name]

--- a/onnxruntime/python/tools/quantization/onnx_model.py
+++ b/onnxruntime/python/tools/quantization/onnx_model.py
@@ -9,6 +9,14 @@ import onnx.helper as onnx_helper
 import onnx.numpy_helper as onnx_numpy_helper
 from onnx.onnx_pb import ModelProto
 
+from onnxruntime.tools.onnx_graph_utils import (
+    get_children,
+    get_parent,
+    get_parents,
+    input_name_to_nodes,
+    output_name_to_node,
+)
+
 from .quant_utils import attribute_to_kwarg, find_by_name
 
 
@@ -215,57 +223,28 @@ class ONNXModel:
         return non_initializer_inputs
 
     def input_name_to_nodes(self):
-        input_name_to_nodes = {}
-        for node in self.model.graph.node:
-            for input_name in node.input:
-                if input_name:  # Could be empty when it is optional
-                    if input_name not in input_name_to_nodes:
-                        input_name_to_nodes[input_name] = [node]
-                    else:
-                        input_name_to_nodes[input_name].append(node)
-        return input_name_to_nodes
+        return input_name_to_nodes(self.model.graph.node)
 
     def output_name_to_node(self):
-        output_name_to_node = {}
-        for node in self.model.graph.node:
-            for output_name in node.output:
-                if output_name:  # Could be empty when it is optional
-                    output_name_to_node[output_name] = node
-        return output_name_to_node
+        return output_name_to_node(self.model.graph.node)
 
     def get_children(self, node, input_name_to_nodes=None):
         if input_name_to_nodes is None:
             input_name_to_nodes = self.input_name_to_nodes()
 
-        children = []
-        for output in node.output:
-            if output in input_name_to_nodes:
-                for node in input_name_to_nodes[output]:
-                    children.append(node)  # noqa: PERF402
-        return children
+        return get_children(node, input_name_to_nodes)
 
     def get_parents(self, node, output_name_to_node=None):
         if output_name_to_node is None:
             output_name_to_node = self.output_name_to_node()
 
-        parents = []
-        for input in node.input:
-            if input in output_name_to_node:
-                parents.append(output_name_to_node[input])
-        return parents
+        return get_parents(node, output_name_to_node)
 
     def get_parent(self, node, idx, output_name_to_node=None):
         if output_name_to_node is None:
             output_name_to_node = self.output_name_to_node()
 
-        if len(node.input) <= idx:
-            return None
-
-        input = node.input[idx]
-        if input not in output_name_to_node:
-            return None
-
-        return output_name_to_node[input]
+        return get_parent(node, idx, output_name_to_node)
 
     def find_node_by_name(self, node_name, new_nodes_list, graph):
         """Find out if a node exists in a graph or a node is in the

--- a/onnxruntime/python/tools/transformers/onnx_model.py
+++ b/onnxruntime/python/tools/transformers/onnx_model.py
@@ -29,6 +29,21 @@ from onnx import (
 )
 from onnx.external_data_helper import load_external_data_for_tensor, uses_external_data
 
+if __package__:
+    from onnxruntime.tools.onnx_graph_utils import (
+        get_children,
+        get_parent,
+        get_parents,
+        input_name_to_nodes,
+        output_name_to_node,
+    )
+else:
+    _tools_dir = Path(__file__).resolve().parent.parent
+    _shared_module_dir = _tools_dir if (_tools_dir / "onnx_graph_utils.py").is_file() else _tools_dir / "tools"
+    if str(_shared_module_dir) not in sys.path:
+        sys.path.append(str(_shared_module_dir))
+    from onnx_graph_utils import get_children, get_parent, get_parents, input_name_to_nodes, output_name_to_node
+
 logger = logging.getLogger(__name__)
 
 
@@ -69,25 +84,12 @@ class OnnxModel:
         return None
 
     def input_name_to_nodes(self, exclude_subgraphs=False):
-        input_name_to_nodes = {}
         nodes_to_search = self.nodes() if not exclude_subgraphs else self.model.graph.node
-        for node in nodes_to_search:
-            for input_name in node.input:
-                if input_name:  # could be empty when it is optional
-                    if input_name not in input_name_to_nodes:
-                        input_name_to_nodes[input_name] = [node]
-                    else:
-                        input_name_to_nodes[input_name].append(node)
-        return input_name_to_nodes
+        return input_name_to_nodes(nodes_to_search)
 
     def output_name_to_node(self, exclude_subgraphs=False):
-        output_name_to_node = {}
         nodes_to_search = self.nodes() if not exclude_subgraphs else self.model.graph.node
-        for node in nodes_to_search:
-            for output_name in node.output:
-                if output_name:  # could be empty when it is optional
-                    output_name_to_node[output_name] = node
-        return output_name_to_node
+        return output_name_to_node(nodes_to_search)
 
     def functions(self):
         all_functions = [list(self.model.functions)]
@@ -242,41 +244,19 @@ class OnnxModel:
         if input_name_to_nodes is None:
             input_name_to_nodes = self.input_name_to_nodes()
 
-        children = []
-        if output_index is not None:
-            if output_index < len(node.output):
-                output = node.output[output_index]
-                if output in input_name_to_nodes:
-                    children = list(input_name_to_nodes[output])
-        else:
-            for output in node.output:
-                if output in input_name_to_nodes:
-                    children.extend(input_name_to_nodes[output])
-
-        return children
+        return get_children(node, input_name_to_nodes, output_index)
 
     def get_parents(self, node, output_name_to_node=None):
         if output_name_to_node is None:
             output_name_to_node = self.output_name_to_node()
 
-        parents = []
-        for input in node.input:
-            if input in output_name_to_node:
-                parents.append(output_name_to_node[input])
-        return parents
+        return get_parents(node, output_name_to_node)
 
     def get_parent(self, node, i, output_name_to_node=None):
         if output_name_to_node is None:
             output_name_to_node = self.output_name_to_node()
 
-        if len(node.input) <= i:
-            return None
-
-        input = node.input[i]
-        if input not in output_name_to_node:
-            return None
-
-        return output_name_to_node[input]
+        return get_parent(node, i, output_name_to_node)
 
     def match_first_parent(self, node, parent_op_type, output_name_to_node, exclude=[]):  # noqa: B006
         """

--- a/onnxruntime/test/python/quantization/test_onnx_model.py
+++ b/onnxruntime/test/python/quantization/test_onnx_model.py
@@ -15,6 +15,13 @@ from onnx import TensorProto, helper, numpy_helper
 from op_test_utils import check_op_type_order
 
 from onnxruntime.quantization.onnx_model import ONNXModel
+from onnxruntime.tools.onnx_graph_utils import (
+    get_children,
+    get_parent,
+    get_parents,
+    input_name_to_nodes,
+    output_name_to_node,
+)
 
 
 def generate_input_initializer(tensor_shape, tensor_dtype, input_name):
@@ -135,6 +142,65 @@ def construct_model_for_topo_sort_empty_input_output(model_path):
     onnx.save(model, model_path)
 
 
+class TestOnnxGraphUtils(unittest.TestCase):
+    def test_name_maps_ignore_empty_names_and_preserve_order(self):
+        first = helper.make_node("First", ["input", ""], ["shared", "", "first_output"], name="first")
+        second = helper.make_node("Second", ["shared", "shared"], ["shared"], name="second")
+
+        input_map = input_name_to_nodes([first, second])
+        self.assertNotIn("", input_map)
+        self.assertEqual([node.name for node in input_map["shared"]], ["second", "second"])
+
+        output_map = output_name_to_node([first, second])
+        self.assertNotIn("", output_map)
+        self.assertIs(output_map["shared"], second)
+        self.assertIs(output_map["first_output"], first)
+
+    def test_children_preserve_order_duplicates_and_output_selection(self):
+        parent = helper.make_node("Parent", [], ["first", "", "second"], name="parent")
+        first_child = helper.make_node("FirstChild", ["second", "first"], ["first_child"], name="first_child")
+        second_child = helper.make_node(
+            "SecondChild",
+            ["first", "", "first"],
+            ["second_child"],
+            name="second_child",
+        )
+        input_map = input_name_to_nodes([first_child, second_child])
+
+        self.assertEqual(
+            [node.name for node in get_children(parent, input_map)],
+            ["first_child", "second_child", "second_child", "first_child"],
+        )
+        self.assertEqual(
+            [node.name for node in get_children(parent, input_map, output_index=0)],
+            ["first_child", "second_child", "second_child"],
+        )
+        self.assertEqual(get_children(parent, input_map, output_index=1), [])
+        self.assertEqual([node.name for node in get_children(parent, input_map, output_index=2)], ["first_child"])
+        self.assertEqual(get_children(parent, input_map, output_index=3), [])
+
+    def test_parents_preserve_duplicates_and_handle_missing_inputs(self):
+        first_parent = helper.make_node("FirstParent", [], ["first"], name="first_parent")
+        second_parent = helper.make_node("SecondParent", [], ["second"], name="second_parent")
+        child = helper.make_node(
+            "Child",
+            ["second", "missing", "", "first", "first"],
+            ["child"],
+            name="child",
+        )
+        output_map = output_name_to_node([first_parent, second_parent])
+
+        self.assertEqual(
+            [node.name for node in get_parents(child, output_map)],
+            ["second_parent", "first_parent", "first_parent"],
+        )
+        self.assertIs(get_parent(child, 0, output_map), second_parent)
+        self.assertIsNone(get_parent(child, 1, output_map))
+        self.assertIsNone(get_parent(child, 2, output_map))
+        self.assertIs(get_parent(child, 3, output_map), first_parent)
+        self.assertIsNone(get_parent(child, 5, output_map))
+
+
 class TestONNXModel(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -167,6 +233,37 @@ class TestONNXModel(unittest.TestCase):
         check_op_type_order(self, onnx_model.model, ["Op1", "Op1", "Op3", "Op2"])
         onnx_model.topological_sort()
         check_op_type_order(self, onnx_model.model, ["Op1", "Op1", "Op2", "Op3"])
+
+    def test_navigation_searches_only_main_graph(self):
+        subgraph_node = helper.make_node("Identity", ["subgraph_input", ""], ["subgraph_output", ""], name="subgraph")
+        subgraph = helper.make_graph(
+            [subgraph_node],
+            "subgraph",
+            [],
+            [helper.make_tensor_value_info("subgraph_output", TensorProto.FLOAT, [1])],
+        )
+        main_node = helper.make_node(
+            "If",
+            ["condition", ""],
+            ["main_output", ""],
+            name="main",
+            then_branch=subgraph,
+            else_branch=subgraph,
+        )
+        graph = helper.make_graph(
+            [main_node],
+            "main_graph",
+            [helper.make_tensor_value_info("condition", TensorProto.BOOL, [])],
+            [helper.make_tensor_value_info("main_output", TensorProto.FLOAT, [1])],
+        )
+        onnx_model = ONNXModel(helper.make_model(graph))
+
+        input_map = onnx_model.input_name_to_nodes()
+        output_map = onnx_model.output_name_to_node()
+        self.assertEqual(set(input_map), {"condition"})
+        self.assertEqual(set(output_map), {"main_output"})
+        self.assertEqual(input_map["condition"][0].name, main_node.name)
+        self.assertEqual(output_map["main_output"].name, main_node.name)
 
 
 if __name__ == "__main__":

--- a/onnxruntime/test/python/transformers/test_transformer_onnx_model.py
+++ b/onnxruntime/test/python/transformers/test_transformer_onnx_model.py
@@ -1,0 +1,113 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+import sys
+import unittest
+from pathlib import Path
+
+from onnx import TensorProto, helper
+
+transformers_source = Path(__file__).resolve().parents[3] / "python" / "tools" / "transformers"
+if transformers_source.is_dir():
+    sys.path.append(str(transformers_source))
+    from onnx_model import OnnxModel
+else:
+    from onnxruntime.transformers.onnx_model import OnnxModel
+
+
+class TestOnnxModel(unittest.TestCase):
+    @staticmethod
+    def _create_model():
+        then_node = helper.make_node("Identity", ["left_output"], ["then_output"], name="then_node")
+        then_graph = helper.make_graph(
+            [then_node],
+            "then_graph",
+            [],
+            [helper.make_tensor_value_info("then_output", TensorProto.FLOAT, [1])],
+        )
+        else_node = helper.make_node("Identity", ["right"], ["else_output"], name="else_node")
+        else_graph = helper.make_graph(
+            [else_node],
+            "else_graph",
+            [],
+            [helper.make_tensor_value_info("else_output", TensorProto.FLOAT, [1])],
+        )
+
+        producer = helper.make_node("Producer", ["input"], ["left", "", "right"], name="producer", domain="Test")
+        left_child = helper.make_node("Add", ["left", "left"], ["left_output"], name="left_child")
+        right_child = helper.make_node("Identity", ["right"], ["right_output"], name="right_child")
+        missing_parent = helper.make_node("Identity", ["missing"], ["missing_output"], name="missing_parent")
+        branch = helper.make_node(
+            "If",
+            ["condition"],
+            ["output"],
+            name="branch",
+            then_branch=then_graph,
+            else_branch=else_graph,
+        )
+        graph = helper.make_graph(
+            [producer, left_child, right_child, missing_parent, branch],
+            "main_graph",
+            [
+                helper.make_tensor_value_info("input", TensorProto.FLOAT, [1]),
+                helper.make_tensor_value_info("condition", TensorProto.BOOL, []),
+            ],
+            [helper.make_tensor_value_info("output", TensorProto.FLOAT, [1])],
+        )
+        return helper.make_model(graph), producer, left_child, right_child, missing_parent, then_node, else_node
+
+    def test_name_maps_include_subgraphs_by_default(self):
+        model, producer, _, _, _, then_node, else_node = self._create_model()
+        onnx_model = OnnxModel(model)
+
+        input_map = onnx_model.input_name_to_nodes()
+        self.assertNotIn("", input_map)
+        self.assertEqual([node.name for node in input_map["left"]], ["left_child", "left_child"])
+        self.assertEqual(input_map["left_output"][0].name, then_node.name)
+        self.assertEqual(input_map["right"][1].name, else_node.name)
+
+        output_map = onnx_model.output_name_to_node()
+        self.assertNotIn("", output_map)
+        self.assertEqual(output_map["left"].name, producer.name)
+        self.assertEqual(output_map["then_output"].name, then_node.name)
+        self.assertEqual(output_map["else_output"].name, else_node.name)
+
+        main_input_map = onnx_model.input_name_to_nodes(exclude_subgraphs=True)
+        main_output_map = onnx_model.output_name_to_node(exclude_subgraphs=True)
+        self.assertNotIn("left_output", main_input_map)
+        self.assertNotIn("then_output", main_output_map)
+        self.assertNotIn("else_output", main_output_map)
+
+    def test_navigation_preserves_order_duplicates_and_output_selection(self):
+        model, producer, left_child, right_child, missing_parent, _, _ = self._create_model()
+        onnx_model = OnnxModel(model)
+        input_map = onnx_model.input_name_to_nodes()
+        output_map = onnx_model.output_name_to_node()
+
+        self.assertEqual(
+            [node.name for node in onnx_model.get_children(producer, input_map)],
+            ["left_child", "left_child", "right_child", "else_node"],
+        )
+        self.assertEqual(
+            [node.name for node in onnx_model.get_children(producer, input_map, output_index=0)],
+            ["left_child", "left_child"],
+        )
+        self.assertEqual(onnx_model.get_children(producer, input_map, output_index=1), [])
+        self.assertEqual(
+            [node.name for node in onnx_model.get_children(producer, input_map, output_index=2)],
+            ["right_child", "else_node"],
+        )
+        self.assertEqual(onnx_model.get_children(producer, input_map, output_index=3), [])
+
+        self.assertEqual(
+            [node.name for node in onnx_model.get_parents(left_child, output_map)], ["producer", "producer"]
+        )
+        self.assertEqual(onnx_model.get_parent(left_child, 0, output_map).name, producer.name)
+        self.assertIsNone(onnx_model.get_parent(missing_parent, 0, output_map))
+        self.assertIsNone(onnx_model.get_parent(left_child, 2, output_map))
+        self.assertEqual(onnx_model.get_parent(right_child, 0, output_map).name, producer.name)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add pure graph-navigation helpers in `onnxruntime.tools.onnx_graph_utils`
- share name-map and parent/child traversal logic between quantization and transformer ONNX models while preserving graph scope, ordering, duplicates, and output-index behavior
- add focused coverage for optional names, parent misses, output selection, and main-graph versus subgraph traversal

## Tests
- `.venv\Scripts\lintrunner.exe onnxruntime\python\tools\onnx_graph_utils.py onnxruntime\python\tools\quantization\onnx_model.py onnxruntime\python\tools\transformers\onnx_model.py onnxruntime\test\python\quantization\test_onnx_model.py onnxruntime\test\python\transformers\test_transformer_onnx_model.py`
- `.venv\Scripts\python.exe -m pytest onnxruntime\test\python\quantization\test_onnx_model.py onnxruntime\test\python\transformers\test_transformer_onnx_model.py onnxruntime\test\python\transformers\test_onnx_utils.py -q` (12 passed)