### PR TITLE
Add duplicate domain dedup check in AddCustomOpDomain

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -1638,9 +1638,14 @@ struct OrtApi {
   /// \name OrtSessionOptions
   /// @{
 
-  /** \brief Add custom op domain to a session options
+  /** \brief Add custom op domain to a session options.
    *
-   * \note The OrtCustomOpDomain* must not be deleted until all sessions using it are released
+   * If a domain with the same name has already been added to the session options, the call is
+   * silently ignored and a warning is logged. This prevents duplicate registration errors that
+   * can occur when an EP provides custom ops through multiple paths (e.g., both
+   * OrtEpFactory::GetCustomOpDomains and a separate custom op library).
+   *
+   * \note The OrtCustomOpDomain* must not be deleted until all sessions using it are released.
    *
    * \param[in] options
    * \param[in] custom_op_domain

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -1640,8 +1640,9 @@ struct OrtApi {
 
   /** \brief Add custom op domain to a session options.
    *
-   * If a domain with the same name has already been added to the session options, the call is
-   * silently ignored and a warning is logged. This prevents duplicate registration errors that
+   * If the new domain contains any custom op that matches an op (same op name and same execution
+   * provider type) in a previously added domain with the same domain name, the entire new domain
+   * is silently skipped and a warning is logged. This prevents kernel registration conflicts that
    * can occur when an EP provides custom ops through multiple paths (e.g., both
    * OrtEpFactory::GetCustomOpDomains and a separate custom op library).
    *

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -1640,9 +1640,8 @@ struct OrtApi {
 
   /** \brief Add custom op domain to a session options.
    *
-   * If the new domain contains any custom op that matches an op (same op name and same execution
-   * provider type) in a previously added domain with the same domain name, the entire new domain
-   * is silently skipped and a warning is logged. This prevents kernel registration conflicts that
+   * If a domain with the same name has already been added to the session options, the call is
+   * silently skipped and a warning is logged. This prevents schema registration conflicts that
    * can occur when an EP provides custom ops through multiple paths (e.g., both
    * OrtEpFactory::GetCustomOpDomains and a separate custom op library).
    *

--- a/onnxruntime/core/framework/kernel_def_builder.cc
+++ b/onnxruntime/core/framework/kernel_def_builder.cc
@@ -84,7 +84,7 @@ bool KernelDef::IsConflict(const KernelDef& other) const {
   // check memory type
   auto& other_input_mem_types = other.input_memory_type_args_;
   for (auto it : input_memory_type_args_) {
-    if (other_input_mem_types.count(it.first) && other_input_mem_types.find(it.first)->second != it.second)
+    if (other_input_mem_types.count(it.first) && other_input_mem_types.find(it.first)->second == it.second)
       return false;
   }
   if (input_memory_type_args_.empty() && !other.input_memory_type_args_.empty())
@@ -92,7 +92,7 @@ bool KernelDef::IsConflict(const KernelDef& other) const {
 
   auto& other_output_mem_types = other.output_memory_type_args_;
   for (auto it : output_memory_type_args_) {
-    if (other_output_mem_types.count(it.first) && other_output_mem_types.find(it.first)->second != it.second)
+    if (other_output_mem_types.count(it.first) && other_output_mem_types.find(it.first)->second == it.second)
       return false;
   }
   return !(output_memory_type_args_.empty() && !other.output_memory_type_args_.empty());

--- a/onnxruntime/core/framework/kernel_def_builder.cc
+++ b/onnxruntime/core/framework/kernel_def_builder.cc
@@ -84,7 +84,7 @@ bool KernelDef::IsConflict(const KernelDef& other) const {
   // check memory type
   auto& other_input_mem_types = other.input_memory_type_args_;
   for (auto it : input_memory_type_args_) {
-    if (other_input_mem_types.count(it.first) && other_input_mem_types.find(it.first)->second == it.second)
+    if (other_input_mem_types.count(it.first) && other_input_mem_types.find(it.first)->second != it.second)
       return false;
   }
   if (input_memory_type_args_.empty() && !other.input_memory_type_args_.empty())
@@ -92,7 +92,7 @@ bool KernelDef::IsConflict(const KernelDef& other) const {
 
   auto& other_output_mem_types = other.output_memory_type_args_;
   for (auto it : output_memory_type_args_) {
-    if (other_output_mem_types.count(it.first) && other_output_mem_types.find(it.second)->second == it.second)
+    if (other_output_mem_types.count(it.first) && other_output_mem_types.find(it.first)->second != it.second)
       return false;
   }
   return !(output_memory_type_args_.empty() && !other.output_memory_type_args_.empty());

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -840,16 +840,37 @@ ORT_API_STATUS_IMPL(OrtApis::CustomOpDomain_Add, _Inout_ OrtCustomOpDomain* cust
 ORT_API_STATUS_IMPL(OrtApis::AddCustomOpDomain, _Inout_ OrtSessionOptions* options,
                     _In_ OrtCustomOpDomain* custom_op_domain) {
   API_IMPL_BEGIN
-  // Skip duplicate domain names. This can happen when an EP provides custom ops through both
-  // OrtEpFactory::GetCustomOpDomains (added via SessionOptionsAppendExecutionProvider_V2) and
-  // a separate custom op DLL (added via RegisterCustomOpsLibrary / AddCustomOpDomain).
+  // Check for duplicate custom ops that would conflict during kernel registration.
+  // If any op in the new domain matches an existing op (same name + EP) in a domain with the
+  // same name, skip the entire new domain. Even a single conflicting kernel would cause a
+  // registration failure, and partial overlap within the same domain name typically indicates
+  // the same ops being registered through multiple paths (e.g., EP factory + custom op DLL).
   for (const auto* existing : options->custom_op_domains_) {
-    if (existing->domain_ == custom_op_domain->domain_) {
-      LOGS_DEFAULT(WARNING) << "Skipping duplicate custom op domain '" << custom_op_domain->domain_
-                            << "'. A domain with this name has already been added to the session options.";
-      return nullptr;
+    if (existing->domain_ != custom_op_domain->domain_) {
+      continue;
+    }
+
+    // Same domain name found. Check if any op in the new domain duplicates an existing op.
+    for (const auto* new_op : custom_op_domain->custom_ops_) {
+      const char* new_name = new_op->GetName(new_op);
+      const char* new_ep = new_op->GetExecutionProviderType(new_op);
+
+      for (const auto* existing_op : existing->custom_ops_) {
+        const char* existing_name = existing_op->GetName(existing_op);
+        const char* existing_ep = existing_op->GetExecutionProviderType(existing_op);
+
+        if (strcmp(new_name, existing_name) == 0 &&
+            ((new_ep == nullptr && existing_ep == nullptr) ||
+             (new_ep != nullptr && existing_ep != nullptr && strcmp(new_ep, existing_ep) == 0))) {
+          LOGS_DEFAULT(WARNING) << "Skipping custom op domain '" << custom_op_domain->domain_
+                                << "': op '" << new_name << "' already registered in an existing domain"
+                                << " with the same name and execution provider.";
+          return nullptr;
+        }
+      }
     }
   }
+
   options->custom_op_domains_.emplace_back(custom_op_domain);
   return nullptr;
   API_IMPL_END

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -840,6 +840,16 @@ ORT_API_STATUS_IMPL(OrtApis::CustomOpDomain_Add, _Inout_ OrtCustomOpDomain* cust
 ORT_API_STATUS_IMPL(OrtApis::AddCustomOpDomain, _Inout_ OrtSessionOptions* options,
                     _In_ OrtCustomOpDomain* custom_op_domain) {
   API_IMPL_BEGIN
+  // Skip duplicate domain names. This can happen when an EP provides custom ops through both
+  // OrtEpFactory::GetCustomOpDomains (added via SessionOptionsAppendExecutionProvider_V2) and
+  // a separate custom op DLL (added via RegisterCustomOpsLibrary / AddCustomOpDomain).
+  for (const auto* existing : options->custom_op_domains_) {
+    if (existing->domain_ == custom_op_domain->domain_) {
+      LOGS_DEFAULT(WARNING) << "Skipping duplicate custom op domain '" << custom_op_domain->domain_
+                            << "'. A domain with this name has already been added to the session options.";
+      return nullptr;
+    }
+  }
   options->custom_op_domains_.emplace_back(custom_op_domain);
   return nullptr;
   API_IMPL_END

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -840,37 +840,17 @@ ORT_API_STATUS_IMPL(OrtApis::CustomOpDomain_Add, _Inout_ OrtCustomOpDomain* cust
 ORT_API_STATUS_IMPL(OrtApis::AddCustomOpDomain, _Inout_ OrtSessionOptions* options,
                     _In_ OrtCustomOpDomain* custom_op_domain) {
   API_IMPL_BEGIN
-  // Check for duplicate custom ops that would conflict during kernel registration.
-  // If any op in the new domain matches an existing op (same name + EP) in a domain with the
-  // same name, skip the entire new domain. Even a single conflicting kernel would cause a
-  // registration failure, and partial overlap within the same domain name typically indicates
-  // the same ops being registered through multiple paths (e.g., EP factory + custom op DLL).
+  // Skip duplicate domain names. SetBaselineAndOpsetVersionForDomain in schema_registry.cc rejects any
+  // domain name that has already been registered, regardless of EP or op content. This can happen when
+  // an EP provides custom ops through multiple paths (e.g., OrtEpFactory::GetCustomOpDomains and a
+  // separate custom op DLL via RegisterCustomOpsLibrary/AddCustomOpDomain).
   for (const auto* existing : options->custom_op_domains_) {
-    if (existing->domain_ != custom_op_domain->domain_) {
-      continue;
-    }
-
-    // Same domain name found. Check if any op in the new domain duplicates an existing op.
-    for (const auto* new_op : custom_op_domain->custom_ops_) {
-      const char* new_name = new_op->GetName(new_op);
-      const char* new_ep = new_op->GetExecutionProviderType(new_op);
-
-      for (const auto* existing_op : existing->custom_ops_) {
-        const char* existing_name = existing_op->GetName(existing_op);
-        const char* existing_ep = existing_op->GetExecutionProviderType(existing_op);
-
-        if (strcmp(new_name, existing_name) == 0 &&
-            ((new_ep == nullptr && existing_ep == nullptr) ||
-             (new_ep != nullptr && existing_ep != nullptr && strcmp(new_ep, existing_ep) == 0))) {
-          LOGS_DEFAULT(WARNING) << "Skipping custom op domain '" << custom_op_domain->domain_
-                                << "': op '" << new_name << "' already registered in an existing domain"
-                                << " with the same name and execution provider.";
-          return nullptr;
-        }
-      }
+    if (existing->domain_ == custom_op_domain->domain_) {
+      LOGS_DEFAULT(WARNING) << "Skipping custom op domain '" << custom_op_domain->domain_
+                            << "': a domain with this name has already been added to the session options.";
+      return nullptr;
     }
   }
-
   options->custom_op_domains_.emplace_back(custom_op_domain);
   return nullptr;
   API_IMPL_END

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -798,7 +798,7 @@ TEST(CApiTest, custom_op_duplicate_domain_dedup) {
   session_options.Add(domain2);
 
   // Session creation should succeed without conflicting schema errors
-  EXPECT_NO_THROW(Ort::Session(*ort_env, CUSTOM_OP_MODEL_URI, session_options));
+  Ort::Session(*ort_env, CUSTOM_OP_MODEL_URI, session_options);
 }
 
 // Memory leak

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -781,7 +781,6 @@ TEST(CApiTest, custom_op_forward_version_compat) {
 // Test that adding the same custom op domain name twice to session options is silently deduplicated.
 // This prevents crashes when an EP provides custom ops through both OrtEpFactory::GetCustomOpDomains
 // and a separate custom op DLL (via RegisterCustomOpsLibrary / AddCustomOpDomain).
-#ifndef ABSL_HAVE_ADDRESS_SANITIZER
 TEST(CApiTest, custom_op_duplicate_domain_dedup) {
   MyCustomOp custom_op{onnxruntime::kCpuExecutionProvider};
 
@@ -801,7 +800,6 @@ TEST(CApiTest, custom_op_duplicate_domain_dedup) {
   // Session creation should succeed without conflicting schema errors
   EXPECT_NO_THROW(Ort::Session(*ort_env, CUSTOM_OP_MODEL_URI, session_options));
 }
-#endif
 
 // Memory leak
 #ifndef ABSL_HAVE_ADDRESS_SANITIZER

--- a/onnxruntime/test/shared_lib/test_inference.cc
+++ b/onnxruntime/test/shared_lib/test_inference.cc
@@ -778,6 +778,31 @@ TEST(CApiTest, custom_op_forward_version_compat) {
                        custom_op_domain, nullptr, /*test_session_creation_only=*/true);
 }
 
+// Test that adding the same custom op domain name twice to session options is silently deduplicated.
+// This prevents crashes when an EP provides custom ops through both OrtEpFactory::GetCustomOpDomains
+// and a separate custom op DLL (via RegisterCustomOpsLibrary / AddCustomOpDomain).
+#ifndef ABSL_HAVE_ADDRESS_SANITIZER
+TEST(CApiTest, custom_op_duplicate_domain_dedup) {
+  MyCustomOp custom_op{onnxruntime::kCpuExecutionProvider};
+
+  // Create two domains with the same name "test"
+  Ort::CustomOpDomain domain1("test");
+  domain1.Add(&custom_op);
+
+  Ort::CustomOpDomain domain2("test");
+  domain2.Add(&custom_op);
+
+  Ort::SessionOptions session_options;
+
+  // Add the same domain name twice — second add should be silently skipped
+  session_options.Add(domain1);
+  session_options.Add(domain2);
+
+  // Session creation should succeed without conflicting schema errors
+  EXPECT_NO_THROW(Ort::Session(*ort_env, CUSTOM_OP_MODEL_URI, session_options));
+}
+#endif
+
 // Memory leak
 #ifndef ABSL_HAVE_ADDRESS_SANITIZER
 TEST(CApiTest, custom_op_handler) {


### PR DESCRIPTION
AddCustomOpDomain was doing a blind emplace_back without checking if a domain with the same name already existed in session options. This caused crashes when an EP provided custom ops through both the EP factory path (OrtEpFactory::GetCustomOpDomains via SessionOptionsAppendExecutionProvider_V2) and a separate custom op DLL (via RegisterCustomOpsLibrary/AddCustomOpDomain).

The duplicate domains led to conflicting schema registrations during session initialization, ultimately causing ort_value_name_idx_map.MaxIdx() > -1 assertion failure.

Add a domain name check before inserting, silently skipping duplicates. Also add a unit test verifying the deduplication.

### Description
<!-- Describe your changes. -->



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


