### PR TITLE
Fix plugin EP allocator deleter lifetime

### DIFF
--- a/onnxruntime/core/session/environment.cc
+++ b/onnxruntime/core/session/environment.cc
@@ -871,9 +871,10 @@ Status Environment::CreateSharedAllocatorImpl(const OrtEpDevice& ep_device,
                            "EP library should be opaque to ORT");
   }
 
+  auto* ep_factory = ep_device.ep_factory;
   auto ort_allocator = OrtAllocatorUniquePtr(allocator,
-                                             [&ep_device](OrtAllocator* allocator) {
-                                               ep_device.ep_factory->ReleaseAllocator(ep_device.ep_factory, allocator);
+                                             [ep_factory](OrtAllocator* allocator) {
+                                               ep_factory->ReleaseAllocator(ep_factory, allocator);
                                              });
 
   shared_ort_allocators_.insert(allocator);

--- a/onnxruntime/core/session/plugin_ep/ep_plugin_provider_interfaces.cc
+++ b/onnxruntime/core/session/plugin_ep/ep_plugin_provider_interfaces.cc
@@ -869,10 +869,11 @@ std::vector<AllocatorPtr> PluginExecutionProvider::CreatePreferredAllocators() {
           "EP library should be opaque to ORT");
     }
 
+    auto* ep_factory = &ep_factory_;
     auto ort_allocator = OrtAllocatorUniquePtr(
         ort_allocator_ptr,
-        [this](OrtAllocator* allocator) {
-          ep_factory_.ReleaseAllocator(&ep_factory_, allocator);
+        [ep_factory](OrtAllocator* allocator) {
+          ep_factory->ReleaseAllocator(ep_factory, allocator);
         });
 
     // Use the arena wrapper when the allocator supports Shrink(), matching


### PR DESCRIPTION
# Fix plugin EP allocator deleter lifetime

## Summary

This PR fixes an AppVerifier failure seen during ONNX Runtime / onnxruntime_genai shutdown with the plugin EP path:

```text
INVALID_POINTER_READ_AVRF_c0000005_onnxruntime.dll!OrtGetApiBase
Access violation - code c0000005
```

The bug is in the allocator deleter lifetime. Plugin EP allocators are released later by an `OrtAllocatorUniquePtr` custom deleter, but the deleter was reaching `OrtEpFactory::ReleaseAllocator` through transient owner captures:

- `Environment::CreateSharedAllocatorImpl` captured `ep_device` by reference.
- `PluginExecutionProvider::CreatePreferredAllocators` captured `this`.

The fix captures the required `OrtEpFactory*` directly in both deleters and calls:

```cpp
ep_factory->ReleaseAllocator(ep_factory, allocator);
```

This keeps allocator destruction independent from the stack reference / provider object used when the deleter was created, while preserving the same allocator ownership and release API.

## Changed files

- `onnxruntime/core/session/environment.cc`
- `onnxruntime/core/session/plugin_ep/ep_plugin_provider_interfaces.cc`

## Verification

Built ORT and the TRT-RTX EP repro stack against TRT-RTX 1.6.1.114, then ran the DeepSeek WinML AppVerifier repro.

- Fixed branch: `"appVerifierEnabled": true`, `"appVerifierFailed": false`
- Rebuilt `origin/main` negative control: `"appVerifierEnabled": true`, `"appVerifierFailed": true`

This confirms the invalid pointer read still reproduces on `origin/main` and is removed by the allocator deleter lifetime change.
