### PR TITLE
Fix OpenVINO Resize with negative axes

### DIFF
--- a/onnxruntime/core/providers/openvino/backend_manager.cc
+++ b/onnxruntime/core/providers/openvino/backend_manager.cc
@@ -19,6 +19,7 @@
 #include "core/providers/openvino/contexts.h"
 #include "core/providers/openvino/ibackend.h"
 #include "core/providers/openvino/ov_interface.h"
+#include "core/providers/openvino/ov_protobuf_utils.h"
 #include "core/providers/openvino/ov_versions/capability.h"
 #include "core/providers/openvino/qdq_transformations/qdq_stripping.h"
 #include "core/providers/openvino/exceptions.h"
@@ -40,6 +41,22 @@ ov::CompiledModel BackendManager::GetOVCompiledModel() {
 
 static bool ShouldExportEpContext(const SessionContext& session_context, const SubGraphContext& subgraph_context) {
   return session_context.so_context_enable && (subgraph_context.is_ep_ctx_ovir_encapsulated || !subgraph_context.is_ep_ctx_graph);
+}
+
+static TensorRankMap GetResizeInputRanks(const onnxruntime::GraphViewer& subgraph) {
+  TensorRankMap tensor_ranks;
+  for (const auto& node : subgraph.Nodes()) {
+    if (node.OpType() != "Resize" || node.SinceVersion() < 18 || node.InputDefs().empty()) {
+      continue;
+    }
+
+    const auto* input = node.InputDefs()[0];
+    if (input != nullptr && input->Shape() != nullptr) {
+      tensor_ranks[input->Name()] = input->Shape()->dim_size();
+    }
+  }
+
+  return tensor_ranks;
 }
 
 BackendManager::BackendManager(SessionContext& session_context,
@@ -459,6 +476,7 @@ BackendManager::GetModelProtoFromFusedNode(const onnxruntime::Node& fused_node,
 
   [[maybe_unused]] bool enable_ovep_qdq_optimizer = session_context_.enable_qdq_optimizer && IsQDQGraph(subgraph);
   [[maybe_unused]] std::optional<bool> enable_compiler_qdq_optimization = queryOVProperty("NPU_QDQ_OPTIMIZATION", session_context_.device_type);
+  const auto resize_input_ranks = GetResizeInputRanks(subgraph);
 #if (((OPENVINO_VERSION_MAJOR == 2025) && (OPENVINO_VERSION_MINOR > 0)) || (OPENVINO_VERSION_MAJOR > 2025))
   if (session_context_.device_type.find("NPU") != std::string::npos && session_context_.enable_qdq_optimizer) {
     if (enable_compiler_qdq_optimization.has_value() && enable_compiler_qdq_optimization.value()) {
@@ -482,6 +500,7 @@ BackendManager::GetModelProtoFromFusedNode(const onnxruntime::Node& fused_node,
     Status status = CreateModelWithStrippedQDQNodes(subgraph, logger, session_context_.so_share_ep_contexts, enable_ovep_qdq_optimizer, model, shared_context_);
     auto model_proto = model->ToProto();
     model_proto->set_ir_version(ONNX_NAMESPACE::Version::IR_VERSION);
+    normalize_negative_resize_axes(model_proto.get(), resize_input_ranks);
     print_model_proto_duration();
     DumpOpenVINOEPModel(onnx_model_path_name, model_proto.get(), fused_node, subgraph, logger, /*initializer_data_in_proto*/ true);
     ORT_ENFORCE(status.IsOK(), status.ErrorMessage());
@@ -496,6 +515,7 @@ BackendManager::GetModelProtoFromFusedNode(const onnxruntime::Node& fused_node,
     Status status = qdq_scales_fix::Transform(subgraph, logger, model);
     auto model_proto = model->ToProto();
     model_proto->set_ir_version(ONNX_NAMESPACE::Version::IR_VERSION);
+    normalize_negative_resize_axes(model_proto.get(), resize_input_ranks);
     print_model_proto_duration();
     DumpOpenVINOEPModel(onnx_model_path_name, model_proto.get(), fused_node, subgraph, logger, /*initializer_data_in_proto*/ true);
     ORT_ENFORCE(status.IsOK(), status.ErrorMessage());
@@ -537,6 +557,8 @@ BackendManager::GetModelProtoFromFusedNode(const onnxruntime::Node& fused_node,
     model_proto->set_ir_version(ONNX_NAMESPACE::Version::IR_VERSION);
     subgraph.ToProto(*model_proto->mutable_graph(), /*include_initializers*/ true,
                      /*include_outer_scope_args*/ true, /*execution_order*/ 0, /*include_initializer_data*/ include_initializer_data_in_proto);
+
+    normalize_negative_resize_axes(model_proto.get(), resize_input_ranks);
 
     print_model_proto_duration();
 

--- a/onnxruntime/core/providers/openvino/ov_protobuf_utils.cpp
+++ b/onnxruntime/core/providers/openvino/ov_protobuf_utils.cpp
@@ -5,6 +5,7 @@
 
 #include "core/graph/onnx_protobuf.h"
 #include "core/common/common.h"
+#include "core/common/inlined_containers.h"
 
 namespace onnxruntime {
 namespace openvino_ep {
@@ -20,5 +21,90 @@ void set_float_initializer_data(const void* initializer, float data) {
   // ORT_ENFORCE(initializer.dims_size() == 1);
   tp->set_float_data(0, data);
 }
+
+void normalize_negative_resize_axes(void* model_proto, const TensorRankMap& tensor_ranks) {
+  auto* model = reinterpret_cast<ONNX_NAMESPACE::ModelProto*>(model_proto);
+  ORT_ENFORCE(model != nullptr);
+
+  TensorRankMap resolved_tensor_ranks = tensor_ranks;
+  const auto add_value_info_rank = [&resolved_tensor_ranks](const ONNX_NAMESPACE::ValueInfoProto& value_info) {
+    if (value_info.has_type() && value_info.type().has_tensor_type() &&
+        value_info.type().tensor_type().has_shape()) {
+      resolved_tensor_ranks[value_info.name()] = value_info.type().tensor_type().shape().dim_size();
+    }
+  };
+
+  const auto& graph = model->graph();
+  for (const auto& input : graph.input()) {
+    add_value_info_rank(input);
+  }
+  for (const auto& output : graph.output()) {
+    add_value_info_rank(output);
+  }
+  for (const auto& value_info : graph.value_info()) {
+    add_value_info_rank(value_info);
+  }
+  for (const auto& initializer : graph.initializer()) {
+    resolved_tensor_ranks[initializer.name()] = initializer.dims_size();
+  }
+
+  int64_t onnx_opset = 0;
+  for (const auto& opset_import : model->opset_import()) {
+    if (opset_import.domain().empty() || opset_import.domain() == "ai.onnx") {
+      onnx_opset = opset_import.version();
+      break;
+    }
+  }
+
+  if (onnx_opset < 18) {
+    return;
+  }
+
+  for (auto& node : *model->mutable_graph()->mutable_node()) {
+    if (node.op_type() != "Resize" ||
+        (!node.domain().empty() && node.domain() != "ai.onnx") ||
+        node.input_size() == 0) {
+      continue;
+    }
+
+    auto* axes = static_cast<ONNX_NAMESPACE::AttributeProto*>(nullptr);
+    for (auto& attribute : *node.mutable_attribute()) {
+      if (attribute.name() == "axes") {
+        axes = &attribute;
+        break;
+      }
+    }
+
+    if (axes == nullptr) {
+      continue;
+    }
+
+    bool has_negative_axis = false;
+    for (int64_t axis : axes->ints()) {
+      has_negative_axis = has_negative_axis || axis < 0;
+    }
+    if (!has_negative_axis) {
+      continue;
+    }
+
+    const auto rank_it = resolved_tensor_ranks.find(node.input(0));
+    ORT_ENFORCE(rank_it != resolved_tensor_ranks.end(),
+                "Cannot normalize negative Resize axes: input rank is unavailable for '", node.input(0), "'.");
+    const int64_t rank = rank_it->second;
+    ORT_ENFORCE(rank > 0, "Rank must be positive when axes is provided.");
+    InlinedHashSet<int64_t> seen;
+    for (int index = 0; index < axes->ints_size(); ++index) {
+      const int64_t raw_axis = axes->ints(index);
+      ORT_ENFORCE(raw_axis >= -rank && raw_axis < rank,
+                  "axis ", raw_axis, " is not in valid range [-", rank, ",", rank - 1, "]");
+      const int64_t normalized_axis = raw_axis < 0 ? raw_axis + rank : raw_axis;
+      ORT_ENFORCE(seen.insert(normalized_axis).second,
+                  "axes attribute contains duplicate axis ", normalized_axis,
+                  " after negative-axis normalization (rank=", rank, ").");
+      axes->set_ints(index, normalized_axis);
+    }
+  }
+}
+
 }  // namespace openvino_ep
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/openvino/ov_protobuf_utils.h
+++ b/onnxruntime/core/providers/openvino/ov_protobuf_utils.h
@@ -2,9 +2,19 @@
 // Licensed under the MIT License
 
 #pragma once
+
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+
 namespace onnxruntime {
 namespace openvino_ep {
+
+using TensorRankMap = std::unordered_map<std::string, int64_t>;
+
 float get_float_initializer_data(const void* initializer);
 void set_float_initializer_data(const void* initializer, float data);
+void normalize_negative_resize_axes(void* model_proto, const TensorRankMap& tensor_ranks);
+
 }  // namespace openvino_ep
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/cpu/tensor/resize_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/resize_op_test.cc
@@ -4,6 +4,8 @@
 #include <exception>
 #include <limits>
 #include <type_traits>
+
+#include "core/session/onnxruntime_session_options_config_keys.h"
 #include "gtest/gtest.h"
 #include "test/providers/provider_test_utils.h"
 #include "test/util/include/default_providers.h"
@@ -3292,8 +3294,7 @@ TEST(ResizeOpTest, Axes_NegativeOutOfRange_18) {
            {kTensorrtExecutionProvider, kQnnExecutionProvider, kDmlExecutionProvider});
 }
 
-// Valid negative axes (within [-rank, -1]) must still produce correct output.
-TEST(ResizeOpTest, Axes_NegativeInRange_18) {
+static void ConfigureNegativeAxesInRange18Test(OpTester& test) {
   std::vector<float> X(16 * 4);
   std::iota(X.begin(), X.end(), 0.f);
   std::vector<float> Y = {3.5f, 4.8333335f, 6.1666665f, 8.833333f, 10.166667f, 11.5f, 14.166667f,
@@ -3305,7 +3306,6 @@ TEST(ResizeOpTest, Axes_NegativeInRange_18) {
   std::vector<int64_t> output_shape{1, 1, 3, 3, 3};
   std::vector<int64_t> axes{-3, -2, -1};
 
-  OpTester test("Resize", 18);
   test.AddAttribute<int64_t>("exclude_outside", 0LL);
   test.AddAttribute<std::vector<int64_t>>("axes", axes);
   test.AddAttribute<int64_t>("antialias", 0LL);
@@ -3316,11 +3316,62 @@ TEST(ResizeOpTest, Axes_NegativeInRange_18) {
   test.AddInput<float>("scales", {int64_t(scales.size())}, scales, true);
 
   test.AddOutput<float>("Y", output_shape, Y);
-  // OpenVINO EP's Resize importer does not normalize negative axes against the input rank,
-  // so it rejects models that the ONNX spec accepts. Tracked by GH issue #28788.
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "",
-           {kTensorrtExecutionProvider, kQnnExecutionProvider, kOpenVINOExecutionProvider});
 }
+
+// Valid negative axes (within [-rank, -1]) must still produce correct output.
+TEST(ResizeOpTest, Axes_NegativeInRange_18) {
+  OpTester test("Resize", 18);
+  ConfigureNegativeAxesInRange18Test(test);
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "",
+           {kTensorrtExecutionProvider, kQnnExecutionProvider});
+}
+
+#ifdef USE_OPENVINO
+class OpenVINOResizeOpTester : public OpTester {
+ public:
+  OpenVINOResizeOpTester() : OpTester("Resize", 18) {}
+
+ protected:
+  void AddNodes(onnxruntime::Graph& graph,
+                std::vector<onnxruntime::NodeArg*>& graph_input_defs,
+                std::vector<onnxruntime::NodeArg*>& graph_output_defs,
+                std::vector<std::function<void(onnxruntime::Node& node)>>& add_attribute_funcs) override {
+    auto& identity1_output = graph.GetOrCreateNodeArg("identity1_output", graph_input_defs[0]->TypeAsProto());
+    auto& identity2_output = graph.GetOrCreateNodeArg("identity2_output", graph_input_defs[0]->TypeAsProto());
+    auto& resize_output = graph.GetOrCreateNodeArg("resize_output", graph_output_defs[0]->TypeAsProto());
+
+    graph.AddNode("identity1", "Identity", "", {graph_input_defs[0]}, {&identity1_output});
+    graph.AddNode("identity2", "Identity", "", {&identity1_output}, {&identity2_output});
+
+    auto resize_inputs = graph_input_defs;
+    resize_inputs[0] = &identity2_output;
+    auto& resize_node = graph.AddNode("resize", "Resize", "", resize_inputs, {&resize_output});
+    for (auto& add_attribute_fn : add_attribute_funcs) {
+      add_attribute_fn(resize_node);
+    }
+
+    graph.AddNode("identity3", "Identity", "", {&resize_output}, graph_output_defs);
+  }
+};
+
+TEST(ResizeOpTest, Axes_NegativeInRange_18_OpenVINO) {
+  auto openvino_ep = DefaultOpenVINOExecutionProvider();
+  if (openvino_ep == nullptr) {
+    GTEST_SKIP() << "OpenVINO EP is unavailable.";
+  }
+
+  SessionOptions session_options;
+  session_options.use_per_session_threads = false;
+  session_options.graph_optimization_level = TransformerLevel::Default;
+  ASSERT_STATUS_OK(session_options.config_options.AddConfigEntry(kOrtSessionOptionsDisableCPUEPFallback, "1"));
+
+  OpenVINOResizeOpTester test;
+  ConfigureNegativeAxesInRange18Test(test);
+  test.Config(session_options)
+      .ConfigEp(std::move(openvino_ep))
+      .RunWithConfig();
+}
+#endif
 
 // When axes is provided, the sizes input length must match axes length so the scatter
 // loop does not read past the end of sizes.


### PR DESCRIPTION
### Description

Normalize valid negative axes on ONNX Resize-18 nodes in the temporary ModelProto before OpenVINO imports it. The original ORT graph is unchanged. Resolve ranks from the serialized model (with GraphViewer fallback), validate ranges and duplicate axes, and run this in the normal and QDQ serialization paths.

The existing spec test no longer excludes OpenVINO. An explicit four-node provider-only regression disables optional graph optimizations and CPU fallback so this path cannot pass on CPU.

### Motivation and Context

OpenVINO 2026.2.1 rejects valid rank-5 axes `[-3, -2, -1]` with `All axes values should less than input rank: 5`, while the equivalent `[2, 3, 4]` imports and computes correctly. Fixes #28788.

Validation:
- lintrunner / clang-format / diff-check
- OpenVINO 2026.2.1 Release `onnxruntime_provider_test` build
- five targeted tests, 5/5
- `ResizeOpTest.*`: 111 passed, 3 CUDA-only skipped

OpenAI Codex (GPT-5) assisted with the investigation and implementation.
