### PR TITLE
[WebGPU EP] Support device-free compile-only sessions for offline graph transformation

### DIFF
--- a/cmake/onnxruntime.cmake
+++ b/cmake/onnxruntime.cmake
@@ -297,10 +297,15 @@ else()
   )
 endif()
 
-# In a static build the onnxruntime target is an INTERFACE library, which rejects
-# the PRIVATE keyword.
+# Delay-load flags only apply to the actual onnxruntime.dll. In a static build the onnxruntime target is an
+# INTERFACE library, which rejects the PRIVATE keyword ("may only set INTERFACE properties on INTERFACE targets"),
+# and delay-loading is meaningless for a static lib anyway. Consumers that need delay-load in a static build (e.g.
+# the WebGPU plugin EP DLL) apply onnxruntime_DELAYLOAD_FLAGS to their own target.
 if(WIN32 AND onnxruntime_BUILD_SHARED_LIB)
   target_link_options(onnxruntime PRIVATE ${onnxruntime_DELAYLOAD_FLAGS})
+  if(onnxruntime_DELAYLOAD_FLAGS)
+    target_link_libraries(onnxruntime PRIVATE delayimp.lib)
+  endif()
 endif()
 #See: https://cmake.org/cmake/help/latest/prop_tgt/SOVERSION.html
 if(NOT WIN32)

--- a/cmake/onnxruntime_providers_webgpu.cmake
+++ b/cmake/onnxruntime_providers_webgpu.cmake
@@ -191,6 +191,16 @@
 
     set(onnxruntime_providers_webgpu_dll_deps)
 
+    # Delay-load user32.dll which is pulled in by the WebGPU EP build.
+    # This allows onnxruntime.dll to load in processes with
+    # MITIGATION_WIN32K_DISABLE (e.g., a sandboxed process under Win32k lockdown).
+    # ORT's device discovery already skips SetupDi calls when Win32k syscalls
+    # are disallowed (Win32kSystemCallsDisallowed() in device_discovery.cc),
+    # so user32.dll is never actually needed in those processes.
+    if (WIN32 AND onnxruntime_ENABLE_DELAY_LOADING_WIN_DLLS)
+      list(APPEND onnxruntime_DELAYLOAD_FLAGS "/DELAYLOAD:user32.dll")
+    endif()
+
     if (onnxruntime_BUILD_DAWN_SHARED_LIBRARY)
       target_link_libraries(onnxruntime_providers_webgpu PUBLIC dawn::webgpu_dawn)
 
@@ -243,6 +253,17 @@
         list(APPEND onnxruntime_providers_webgpu_dll_deps "$<TARGET_FILE_DIR:dxcompiler>/dxil.dll")
         list(APPEND onnxruntime_providers_webgpu_dll_deps "$<TARGET_FILE_DIR:dxcompiler>/dxcompiler.dll")
       endif()
+    endif()
+
+    # In the plugin/adapter build (onnxruntime_USE_EP_API_ADAPTERS) the WebGPU EP is its own DLL
+    # (onnxruntime_providers_webgpu.dll) rather than being statically linked into onnxruntime.dll, so the
+    # delay-load flags accumulated above (notably /DELAYLOAD:user32.dll) must be applied to THIS target.
+    # Without it the DLL keeps a static import on user32.dll and fails to load in a Win32k-lockdown sandbox
+    # (e.g. Chromium's WebNN compiler process): 'depends on "USER32.dll" which is missing' (Error 1359).
+    # In the static build these same flags are applied to the onnxruntime target in onnxruntime.cmake.
+    if (WIN32 AND onnxruntime_USE_EP_API_ADAPTERS AND onnxruntime_DELAYLOAD_FLAGS)
+      target_link_options(onnxruntime_providers_webgpu PRIVATE ${onnxruntime_DELAYLOAD_FLAGS})
+      target_link_libraries(onnxruntime_providers_webgpu PRIVATE delayimp.lib)
     endif()
 
     if (onnxruntime_providers_webgpu_dll_deps)

--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -1233,6 +1233,20 @@ if (onnxruntime_USE_CUDA AND onnxruntime_BUILD_CUDA_EP_AS_PLUGIN)
     ORT_UNIT_TEST_HAS_CUDA_PLUGIN_EP=1)
 endif()
 
+if (onnxruntime_USE_WEBGPU AND onnxruntime_USE_EP_API_ADAPTERS)
+  # Route the WebGPU EP through the dynamic plugin EP infrastructure in plugin builds
+  # (--use_webgpu shared_lib). Same rationale as the CUDA-as-plugin block above: without initializing the
+  # infra in test_main.cc, WebGpuExecutionProviderWithOptions() (default_providers.cc, adapters branch)
+  # returns null and every WebGPU test skips itself, leaving the plugin path with no test coverage.
+  target_compile_definitions(onnxruntime_test_all PRIVATE
+    ORT_UNIT_TEST_ENABLE_DYNAMIC_PLUGIN_EP_USAGE
+    ORT_UNIT_TEST_WEBGPU_PLUGIN_EP_LIBRARY_PATH="$<TARGET_FILE_NAME:onnxruntime_providers_webgpu>"
+    ORT_UNIT_TEST_HAS_WEBGPU_PLUGIN_EP=1)
+  # The plugin EP DLL is dlopen'd at test-run time (not linked), so add an explicit build-order
+  # dependency to ensure it (and its co-located dawn/dxcompiler DLLs) exist before the tests run.
+  add_dependencies(onnxruntime_test_all onnxruntime_providers_webgpu)
+endif()
+
 if (MSVC)
   # The warning means the type of two integral values around a binary operator is narrow than their result.
   # If we promote the two input values first, it could be more tolerant to integer overflow.

--- a/onnxruntime/core/framework/ep_context_utils.cc
+++ b/onnxruntime/core/framework/ep_context_utils.cc
@@ -3,10 +3,14 @@
 
 #if !defined(ORT_MINIMAL_BUILD)
 #include <limits>
+#include <memory>
 #include <utility>
 #include "core/framework/ep_context_utils.h"
 #include "core/framework/error_code_helper.h"
 #include "core/graph/model_saving_options.h"
+#include "core/platform/env.h"
+
+#include "google/protobuf/io/zero_copy_stream_impl.h"
 
 namespace onnxruntime {
 namespace epctx {
@@ -52,6 +56,148 @@ Status EpContextModelToProto(const onnxruntime::Model& ep_context_model,
 
   return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Unexpected location for initializers while generating ",
                          validated_model_path);
+}
+
+// Validate the ep_context_path to make sure it is a file path and check whether the file exists already.
+Status GetValidatedEpContextPath(const std::filesystem::path& ep_context_path,
+                                 const std::filesystem::path& model_path,
+                                 std::filesystem::path& context_cache_path,
+                                 bool error_if_output_file_exists) {
+  if (!ep_context_path.empty()) {
+    context_cache_path = ep_context_path;
+    if (!(context_cache_path.has_filename() && context_cache_path.extension() != "")) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "context_file_path should not point to a folder.");
+    }
+  } else if (!model_path.empty()) {
+    auto pos = model_path.native().find_last_of(ORT_TSTR("."));
+    if (pos != std::string::npos) {
+      context_cache_path = model_path.native().substr(0, pos) + ORT_TSTR("_ctx.onnx");
+    } else {
+      context_cache_path = model_path.native() + ORT_TSTR("_ctx.onnx");
+    }
+  } else {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Both ep_context_path and model_path are empty.");
+  }
+
+  if (std::filesystem::exists(context_cache_path) && error_if_output_file_exists) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Failed to generate EP context model since the file '",
+                           context_cache_path, "' exists already. Please remove the EP context model if you want to re-generate it.");
+  }
+
+  return Status::OK();
+}
+
+Status SaveModelProtoToLocation(ONNX_NAMESPACE::ModelProto& model_proto,
+                                const epctx::ModelGenOptions& gen_options,
+                                const std::filesystem::path& valid_output_model_path,
+                                const logging::Logger& logger) {
+  ORT_UNUSED_PARAMETER(logger);
+  const epctx::BufferHolder* output_buffer_holder = gen_options.TryGetOutputModelBuffer();
+  const epctx::BufferWriteFuncHolder* output_write_func_holder = gen_options.TryGetOutputModelWriteFunc();
+
+  if (output_buffer_holder != nullptr) {
+    // Write output model into a buffer ORT allocates for the user.
+    size_t buffer_size = model_proto.ByteSizeLong();
+    ORT_RETURN_IF(buffer_size > static_cast<size_t>(std::numeric_limits<int>::max()),
+                  "Cannot serialize ONNX ModelProto larger than 2GB");
+
+    AllocatorPtr allocator = output_buffer_holder->buffer_allocator;
+    IAllocatorUniquePtr<void> buffer = IAllocator::MakeUniquePtr<void>(allocator, buffer_size);
+    const bool ok = model_proto.SerializeToArray(buffer.get(), static_cast<int>(buffer_size));
+    ORT_RETURN_IF(!ok, "Protobuf serialization failed when saving model to output buffer");
+
+    *output_buffer_holder->buffer_size_ptr = buffer_size;
+    *output_buffer_holder->buffer_ptr = buffer.release();
+  } else if (output_write_func_holder != nullptr) {
+    // Write output model to user's output stream.
+    size_t buffer_size = model_proto.ByteSizeLong();
+    ORT_RETURN_IF(buffer_size > static_cast<size_t>(std::numeric_limits<int>::max()),
+                  "Cannot serialize ONNX ModelProto larger than 2GB");
+
+    auto out_stream_buf = std::make_unique<epctx::OutStreamBuf>(*output_write_func_holder);
+    std::ostream out_stream(out_stream_buf.get());
+
+    model_proto.SerializeToOstream(&out_stream);
+    out_stream.flush();
+    ORT_RETURN_IF_ERROR(out_stream_buf->GetStatus());
+  } else {
+    // Write output model to a file.
+    int fd = 0;
+    Status status = Env::Default().FileOpenWr(valid_output_model_path, fd);
+    ORT_RETURN_IF_ERROR(status);
+
+    ORT_TRY {
+      google::protobuf::io::FileOutputStream output(fd);
+      bool serialize_result = model_proto.SerializeToZeroCopyStream(&output) && output.Flush();
+      if (!serialize_result) {
+        status = ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_PROTOBUF,
+                                 "Protobuf serialization failed when saving model to ",
+                                 valid_output_model_path);
+      }
+    }
+    ORT_CATCH(const std::exception& ex) {
+      ORT_HANDLE_EXCEPTION([&]() {
+        status = ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, ex.what());
+      });
+    }
+    if (!status.IsOK()) {
+      GSL_SUPPRESS(es .84)
+      ORT_IGNORE_RETURN_VALUE(Env::Default().FileClose(fd));
+      return status;
+    }
+    ORT_RETURN_IF_ERROR(Env::Default().FileClose(fd));
+  }
+
+  return Status::OK();
+}
+
+Status BuildAndSaveOptimizedModel(const onnxruntime::Model& model,
+                                  const epctx::ModelGenOptions& gen_options,
+                                  const logging::Logger& logger) {
+  // Resolve the validated output path up front so any file-conflict error surfaces before serialization.
+  std::filesystem::path valid_output_model_path;
+  const epctx::BufferHolder* output_buffer_holder = gen_options.TryGetOutputModelBuffer();
+  const epctx::BufferWriteFuncHolder* output_write_func_holder = gen_options.TryGetOutputModelWriteFunc();
+  const std::filesystem::path* output_model_path_ptr = gen_options.TryGetOutputModelPath();
+  const bool output_is_to_file = (output_buffer_holder == nullptr && output_write_func_holder == nullptr);
+  const bool needs_path_for_external_initializers = (gen_options.TryGetExternalInitializerFileInfo() != nullptr);
+
+  if ((output_is_to_file || needs_path_for_external_initializers) &&
+      (output_model_path_ptr != nullptr || !model.MainGraph().ModelPath().empty())) {
+    std::filesystem::path output_model_path = (output_model_path_ptr != nullptr)
+                                                  ? *output_model_path_ptr
+                                                  : std::filesystem::path("");
+    ORT_RETURN_IF_ERROR(GetValidatedEpContextPath(output_model_path,
+                                                  model.MainGraph().ModelPath(),
+                                                  valid_output_model_path,
+                                                  gen_options.error_if_output_file_exists));
+  }
+
+  // Build the ModelProto from the in-memory model (optimized to the session's configured level). The
+  // initializer location is one of three mutually exclusive cases; the default (neither external file
+  // nor custom handler) embeds them inline.
+  ONNX_NAMESPACE::ModelProto model_proto;
+  if (const epctx::ExternalInitializerFileInfo* ext_info = gen_options.TryGetExternalInitializerFileInfo();
+      ext_info != nullptr) {
+    ModelSavingOptions model_saving_options{ext_info->size_threshold};
+    model_proto = model.ToGraphProtoWithExternalInitializers(ext_info->file_path,
+                                                             valid_output_model_path,
+                                                             model_saving_options);
+  } else if (const epctx::InitializerHandler* custom_handler = gen_options.TryGetInitializerHandler();
+             custom_handler != nullptr) {
+    ORT_RETURN_IF_ERROR(model.ToGraphProtoWithCustomInitializerHandling(
+        custom_handler->handle_initializer_func, custom_handler->state, model_proto));
+  } else {
+    // Default: embed all initializers inline. Passing an empty external-file path with a SIZE_MAX
+    // threshold and force_embed_external_ini avoids creating an intermediate file.
+    ModelSavingOptions model_saving_options{/*size_threshold*/ SIZE_MAX};
+    model_saving_options.force_embed_external_ini = true;
+    model_proto = model.ToGraphProtoWithExternalInitializers(std::filesystem::path{},
+                                                             valid_output_model_path,
+                                                             model_saving_options);
+  }
+
+  return SaveModelProtoToLocation(model_proto, gen_options, valid_output_model_path, logger);
 }
 
 //

--- a/onnxruntime/core/framework/ep_context_utils.cc
+++ b/onnxruntime/core/framework/ep_context_utils.cc
@@ -5,8 +5,10 @@
 #include <limits>
 #include <memory>
 #include <utility>
+#include "core/common/inlined_containers.h"
 #include "core/framework/ep_context_utils.h"
 #include "core/framework/error_code_helper.h"
+#include "core/graph/graph_utils.h"
 #include "core/graph/model_saving_options.h"
 #include "core/platform/env.h"
 
@@ -173,28 +175,92 @@ Status BuildAndSaveOptimizedModel(const onnxruntime::Model& model,
                                                   gen_options.error_if_output_file_exists));
   }
 
-  // Build the ModelProto from the in-memory model (optimized to the session's configured level). The
+  // Rebuild a fresh, self-consistent copy of the (already optimized/partitioned) graph and Resolve() it
+  // before serialization. Serializing the live session graph as-is (ToGraphProto on `model`) can emit a
+  // model that reflects mid-transformation state (e.g. missing value_info on intermediate edges produced
+  // by the layout transform), which a downstream session cannot re-partition cleanly - leaving layout
+  // boundary Transpose nodes stranded on the CPU EP. Rebuilding node-by-node with explicit inputs/outputs
+  // and a full Resolve() regenerates complete type/shape information and a canonical graph, matching the
+  // model that CreateEpContextModel produces for the EPContext path. This does no EPContext-node
+  // substitution - it is a plain optimized copy.
+  const Graph& src_graph = model.MainGraph();
+
+  Model rebuilt_model(src_graph.Name(), false, model.MetaData(),
+                      model.ModelPath(),  // use source model path so external initializers can find the data file
+                      IOnnxRuntimeOpSchemaRegistryList{src_graph.GetSchemaRegistry()},
+                      src_graph.DomainToVersionMap(), {}, logger);
+  Graph& dst_graph = rebuilt_model.MainGraph();
+  dst_graph.SetDescription(src_graph.Description());
+
+  // Set inputs/outputs explicitly to preserve the order from the source graph.
+  const auto& src_inputs = src_graph.GetInputs();
+  const auto& src_outputs = src_graph.GetOutputs();
+
+  InlinedVector<const NodeArg*> dst_graph_inputs;
+  dst_graph_inputs.reserve(src_inputs.size());
+  for (const auto* input : src_inputs) {
+    const auto* input_arg = src_graph.GetNodeArg(input->Name());
+    auto& dst_input_arg = dst_graph.GetOrCreateNodeArg(input_arg->Name(), input_arg->TypeAsProto());
+    dst_graph_inputs.push_back(&dst_input_arg);
+  }
+
+  InlinedVector<const NodeArg*> dst_graph_outputs;
+  dst_graph_outputs.reserve(src_outputs.size());
+  for (const auto* output : src_outputs) {
+    const auto* output_arg = src_graph.GetNodeArg(output->Name());
+    auto& dst_output_arg = dst_graph.GetOrCreateNodeArg(output_arg->Name(), output_arg->TypeAsProto());
+    dst_graph_outputs.push_back(&dst_output_arg);
+  }
+
+  dst_graph.SetInputs(dst_graph_inputs);
+  dst_graph.SetOutputs(dst_graph_outputs);
+
+  // Reject an already-compiled input model: a Fused node whose domain is not in the graph's domain map
+  // indicates the model was previously compiled. This mirrors the guard in CreateEpContextModel.
+  auto is_invalid_fused_node = [&src_graph](const Node& node) {
+    const std::unordered_map<std::string, int>& supported_domains = src_graph.DomainToVersionMap();
+    return (node.NodeType() == Node::Type::Fused) &&
+           (supported_domains.find(node.Domain()) == supported_domains.end());
+  };
+
+  for (const auto& node : src_graph.Nodes()) {
+    if (is_invalid_fused_node(node)) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_GRAPH, "Encountered an invalid node while compiling a model. ",
+                             "Please ensure the input model is not already compiled.");
+    }
+    dst_graph.AddNode(node);
+  }
+
+  for (const auto& [name, _] : src_graph.GetAllInitializedTensors()) {
+    if (dst_graph.GetNodeArg(name) != nullptr) {
+      graph_utils::MakeInitializerCopyIfNotExist(src_graph, dst_graph, name);
+    }
+  }
+
+  ORT_RETURN_IF_ERROR(dst_graph.Resolve());
+
+  // Build the ModelProto from the rebuilt model (optimized to the session's configured level). The
   // initializer location is one of three mutually exclusive cases; the default (neither external file
   // nor custom handler) embeds them inline.
   ONNX_NAMESPACE::ModelProto model_proto;
   if (const epctx::ExternalInitializerFileInfo* ext_info = gen_options.TryGetExternalInitializerFileInfo();
       ext_info != nullptr) {
     ModelSavingOptions model_saving_options{ext_info->size_threshold};
-    model_proto = model.ToGraphProtoWithExternalInitializers(ext_info->file_path,
-                                                             valid_output_model_path,
-                                                             model_saving_options);
+    model_proto = rebuilt_model.ToGraphProtoWithExternalInitializers(ext_info->file_path,
+                                                                     valid_output_model_path,
+                                                                     model_saving_options);
   } else if (const epctx::InitializerHandler* custom_handler = gen_options.TryGetInitializerHandler();
              custom_handler != nullptr) {
-    ORT_RETURN_IF_ERROR(model.ToGraphProtoWithCustomInitializerHandling(
+    ORT_RETURN_IF_ERROR(rebuilt_model.ToGraphProtoWithCustomInitializerHandling(
         custom_handler->handle_initializer_func, custom_handler->state, model_proto));
   } else {
     // Default: embed all initializers inline. Passing an empty external-file path with a SIZE_MAX
     // threshold and force_embed_external_ini avoids creating an intermediate file.
     ModelSavingOptions model_saving_options{/*size_threshold*/ SIZE_MAX};
     model_saving_options.force_embed_external_ini = true;
-    model_proto = model.ToGraphProtoWithExternalInitializers(std::filesystem::path{},
-                                                             valid_output_model_path,
-                                                             model_saving_options);
+    model_proto = rebuilt_model.ToGraphProtoWithExternalInitializers(std::filesystem::path{},
+                                                                     valid_output_model_path,
+                                                                     model_saving_options);
   }
 
   return SaveModelProtoToLocation(model_proto, gen_options, valid_output_model_path, logger);

--- a/onnxruntime/core/framework/ep_context_utils.cc
+++ b/onnxruntime/core/framework/ep_context_utils.cc
@@ -5,10 +5,8 @@
 #include <limits>
 #include <memory>
 #include <utility>
-#include "core/common/inlined_containers.h"
 #include "core/framework/ep_context_utils.h"
 #include "core/framework/error_code_helper.h"
-#include "core/graph/graph_utils.h"
 #include "core/graph/model_saving_options.h"
 #include "core/platform/env.h"
 
@@ -175,92 +173,28 @@ Status BuildAndSaveOptimizedModel(const onnxruntime::Model& model,
                                                   gen_options.error_if_output_file_exists));
   }
 
-  // Rebuild a fresh, self-consistent copy of the (already optimized/partitioned) graph and Resolve() it
-  // before serialization. Serializing the live session graph as-is (ToGraphProto on `model`) can emit a
-  // model that reflects mid-transformation state (e.g. missing value_info on intermediate edges produced
-  // by the layout transform), which a downstream session cannot re-partition cleanly - leaving layout
-  // boundary Transpose nodes stranded on the CPU EP. Rebuilding node-by-node with explicit inputs/outputs
-  // and a full Resolve() regenerates complete type/shape information and a canonical graph, matching the
-  // model that CreateEpContextModel produces for the EPContext path. This does no EPContext-node
-  // substitution - it is a plain optimized copy.
-  const Graph& src_graph = model.MainGraph();
-
-  Model rebuilt_model(src_graph.Name(), false, model.MetaData(),
-                      model.ModelPath(),  // use source model path so external initializers can find the data file
-                      IOnnxRuntimeOpSchemaRegistryList{src_graph.GetSchemaRegistry()},
-                      src_graph.DomainToVersionMap(), {}, logger);
-  Graph& dst_graph = rebuilt_model.MainGraph();
-  dst_graph.SetDescription(src_graph.Description());
-
-  // Set inputs/outputs explicitly to preserve the order from the source graph.
-  const auto& src_inputs = src_graph.GetInputs();
-  const auto& src_outputs = src_graph.GetOutputs();
-
-  InlinedVector<const NodeArg*> dst_graph_inputs;
-  dst_graph_inputs.reserve(src_inputs.size());
-  for (const auto* input : src_inputs) {
-    const auto* input_arg = src_graph.GetNodeArg(input->Name());
-    auto& dst_input_arg = dst_graph.GetOrCreateNodeArg(input_arg->Name(), input_arg->TypeAsProto());
-    dst_graph_inputs.push_back(&dst_input_arg);
-  }
-
-  InlinedVector<const NodeArg*> dst_graph_outputs;
-  dst_graph_outputs.reserve(src_outputs.size());
-  for (const auto* output : src_outputs) {
-    const auto* output_arg = src_graph.GetNodeArg(output->Name());
-    auto& dst_output_arg = dst_graph.GetOrCreateNodeArg(output_arg->Name(), output_arg->TypeAsProto());
-    dst_graph_outputs.push_back(&dst_output_arg);
-  }
-
-  dst_graph.SetInputs(dst_graph_inputs);
-  dst_graph.SetOutputs(dst_graph_outputs);
-
-  // Reject an already-compiled input model: a Fused node whose domain is not in the graph's domain map
-  // indicates the model was previously compiled. This mirrors the guard in CreateEpContextModel.
-  auto is_invalid_fused_node = [&src_graph](const Node& node) {
-    const std::unordered_map<std::string, int>& supported_domains = src_graph.DomainToVersionMap();
-    return (node.NodeType() == Node::Type::Fused) &&
-           (supported_domains.find(node.Domain()) == supported_domains.end());
-  };
-
-  for (const auto& node : src_graph.Nodes()) {
-    if (is_invalid_fused_node(node)) {
-      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_GRAPH, "Encountered an invalid node while compiling a model. ",
-                             "Please ensure the input model is not already compiled.");
-    }
-    dst_graph.AddNode(node);
-  }
-
-  for (const auto& [name, _] : src_graph.GetAllInitializedTensors()) {
-    if (dst_graph.GetNodeArg(name) != nullptr) {
-      graph_utils::MakeInitializerCopyIfNotExist(src_graph, dst_graph, name);
-    }
-  }
-
-  ORT_RETURN_IF_ERROR(dst_graph.Resolve());
-
-  // Build the ModelProto from the rebuilt model (optimized to the session's configured level). The
+  // Build the ModelProto from the in-memory model (optimized to the session's configured level). The
   // initializer location is one of three mutually exclusive cases; the default (neither external file
   // nor custom handler) embeds them inline.
   ONNX_NAMESPACE::ModelProto model_proto;
   if (const epctx::ExternalInitializerFileInfo* ext_info = gen_options.TryGetExternalInitializerFileInfo();
       ext_info != nullptr) {
     ModelSavingOptions model_saving_options{ext_info->size_threshold};
-    model_proto = rebuilt_model.ToGraphProtoWithExternalInitializers(ext_info->file_path,
-                                                                     valid_output_model_path,
-                                                                     model_saving_options);
+    model_proto = model.ToGraphProtoWithExternalInitializers(ext_info->file_path,
+                                                             valid_output_model_path,
+                                                             model_saving_options);
   } else if (const epctx::InitializerHandler* custom_handler = gen_options.TryGetInitializerHandler();
              custom_handler != nullptr) {
-    ORT_RETURN_IF_ERROR(rebuilt_model.ToGraphProtoWithCustomInitializerHandling(
+    ORT_RETURN_IF_ERROR(model.ToGraphProtoWithCustomInitializerHandling(
         custom_handler->handle_initializer_func, custom_handler->state, model_proto));
   } else {
     // Default: embed all initializers inline. Passing an empty external-file path with a SIZE_MAX
     // threshold and force_embed_external_ini avoids creating an intermediate file.
     ModelSavingOptions model_saving_options{/*size_threshold*/ SIZE_MAX};
     model_saving_options.force_embed_external_ini = true;
-    model_proto = rebuilt_model.ToGraphProtoWithExternalInitializers(std::filesystem::path{},
-                                                                     valid_output_model_path,
-                                                                     model_saving_options);
+    model_proto = model.ToGraphProtoWithExternalInitializers(std::filesystem::path{},
+                                                             valid_output_model_path,
+                                                             model_saving_options);
   }
 
   return SaveModelProtoToLocation(model_proto, gen_options, valid_output_model_path, logger);

--- a/onnxruntime/core/framework/ep_context_utils.h
+++ b/onnxruntime/core/framework/ep_context_utils.h
@@ -30,6 +30,50 @@ Status EpContextModelToProto(const onnxruntime::Model& ep_context_model,
                              const epctx::ModelGenOptions& ep_context_gen_options,
                              /*out*/ ONNX_NAMESPACE::ModelProto& model_proto);
 
+/// <summary>
+/// Validate an output-model path: ensure it points to a file (not a folder), derive a default
+/// "<model>_ctx.onnx" name from the source model path when none is given, and optionally fail if the
+/// target file already exists.
+/// </summary>
+/// <param name="ep_context_path">The requested output path. May be empty.</param>
+/// <param name="model_path">The source model path, used to derive a default output name.</param>
+/// <param name="context_cache_path">Output parameter set to the validated path.</param>
+/// <param name="error_if_output_file_exists">Whether to fail if the target file already exists.</param>
+/// <returns>A status indicating success or an error.</returns>
+Status GetValidatedEpContextPath(const std::filesystem::path& ep_context_path,
+                                 const std::filesystem::path& model_path,
+                                 std::filesystem::path& context_cache_path,
+                                 bool error_if_output_file_exists = true);
+
+/// <summary>
+/// Write a serialized onnx::ModelProto to the location configured in the generation options: a buffer
+/// ORT allocates for the caller, the caller's output-stream write function, or a file.
+/// </summary>
+/// <param name="model_proto">The model proto to serialize.</param>
+/// <param name="gen_options">The model generation options selecting the output location.</param>
+/// <param name="valid_output_model_path">The validated file path (used only for the file case).</param>
+/// <param name="logger">Session logger.</param>
+/// <returns>A status indicating success or an error.</returns>
+Status SaveModelProtoToLocation(ONNX_NAMESPACE::ModelProto& model_proto,
+                                const epctx::ModelGenOptions& gen_options,
+                                const std::filesystem::path& valid_output_model_path,
+                                const logging::Logger& logger);
+
+/// <summary>
+/// Build and save a plain optimized (non-EPContext) output model from an already optimized,
+/// in-memory model. Used by the Compile API when no nodes were compiled (the kGenerateModel case, e.g. a
+/// non-compiling EP such as WebGPU), so the emitted model captures whatever optimizations the session's
+/// configured level produced. Unlike CreateEpContextModel this does no EPContext-node substitution - it
+/// serializes the model as-is.
+/// </summary>
+/// <param name="model">The in-memory model to serialize.</param>
+/// <param name="gen_options">The model generation options.</param>
+/// <param name="logger">Session logger.</param>
+/// <returns>A status indicating success or an error.</returns>
+Status BuildAndSaveOptimizedModel(const onnxruntime::Model& model,
+                                  const epctx::ModelGenOptions& gen_options,
+                                  const logging::Logger& logger);
+
 // Class that wraps the user's OrtBufferWriteFunc function to enable use with
 // C++'s std::ostream.
 // Example:

--- a/onnxruntime/core/framework/graph_partitioner.cc
+++ b/onnxruntime/core/framework/graph_partitioner.cc
@@ -1496,11 +1496,9 @@ Status GraphPartitioner::Partition(Graph& graph, FuncManager& func_mgr,
                                                  ep_acc_map, *graph_optimizer_registry_, logger,
                                                  disable_model_compile));  // Pass param
 
-    // Serialize here only when the output is EPContext-based (some EP produced EPContext nodes). The
-    // compiling EPs' core optimization lives inside the EPContext blobs, which are opaque to the Level2+
-    // passes, so there is nothing to gain by deferring this to after the optimizer loop. The plain form
-    // (no nodes compiled) is instead emitted by InferenceSession after that loop
-    // (epctx::BuildAndSaveOptimizedModel), so it captures the Level2+ passes.
+    // Serialize here only when the output is EPContext-based (some EP produced EPContext nodes). The plain
+    // form (no nodes compiled) is instead emitted by InferenceSession (epctx::BuildAndSaveOptimizedModel);
+    // see there for how its serialization point is chosen.
     if (ep_context_gen_options.enable && AnyEpContextNodesProduced()) {
       ORT_RETURN_IF_ERROR(CreateEpContextModel(providers_, graph, ep_context_gen_options, logger));
     }

--- a/onnxruntime/core/framework/graph_partitioner.cc
+++ b/onnxruntime/core/framework/graph_partitioner.cc
@@ -1024,36 +1024,6 @@ static Status InlineFunctionsAOTImpl(const ExecutionProviders& execution_provide
   return Status::OK();
 }
 
-// Validate the ep_context_path to make sure it is file path and check whether the file exist already
-// TODO: Move function to ep_context_utils.h/cc
-static Status GetValidatedEpContextPath(const std::filesystem::path& ep_context_path,
-                                        const std::filesystem::path& model_path,
-                                        std::filesystem::path& context_cache_path,
-                                        bool error_if_output_file_exists = true) {
-  if (!ep_context_path.empty()) {
-    context_cache_path = ep_context_path;
-    if (!(context_cache_path.has_filename() && context_cache_path.extension() != "")) {
-      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "context_file_path should not point to a folder.");
-    }
-  } else if (!model_path.empty()) {
-    auto pos = model_path.native().find_last_of(ORT_TSTR("."));
-    if (pos != std::string::npos) {
-      context_cache_path = model_path.native().substr(0, pos) + ORT_TSTR("_ctx.onnx");
-    } else {
-      context_cache_path = model_path.native() + ORT_TSTR("_ctx.onnx");
-    }
-  } else {
-    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Both ep_context_path and model_path are empty.");
-  }
-
-  if (std::filesystem::exists(context_cache_path) && error_if_output_file_exists) {
-    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Failed to generate EP context model since the file '",
-                           context_cache_path, "' exists already. Please remove the EP context model if you want to re-generate it.");
-  }
-
-  return Status::OK();
-}
-
 // TODO: Move function to ep_context_utils.h/cc
 static Status CreateEpContextModel(const ExecutionProviders& execution_providers,
                                    const Graph& graph,
@@ -1065,27 +1035,10 @@ static Status CreateEpContextModel(const ExecutionProviders& execution_providers
     all_ep_context_nodes.insert(all_ep_context_nodes.begin(), ep_context_nodes.begin(), ep_context_nodes.end());
   }
 
-  if (all_ep_context_nodes.size() < 1) {
-    auto action_if_no_compiled_nodes = ep_context_gen_options.action_if_no_compiled_nodes;
-
-    ORT_RETURN_IF(action_if_no_compiled_nodes == epctx::ModelGenOptions::ActionIfNoCompiledNodes::kReturnError,
-                  "Unable to compile any nodes. Check that the session EPs support compilation and can execute "
-                  "at least one subgraph in the model.");
-
-    if (action_if_no_compiled_nodes == epctx::ModelGenOptions::ActionIfNoCompiledNodes::kDontGenerateModel) {
-      LOGS(logger, WARNING) << "Unable to compile any nodes. ONNX Runtime will not generate a compiled model. "
-                               "Either the session EPs do not support compilation or the model is already compiled.";
-      // Note: this path is only taken if a model is compiled with the original compilation approach that uses
-      // session options configs only. The explicit compile API instead only chooses between
-      // kReturnError and kGenerateModel.
-      return Status::OK();
-    }
-
-    // Assert so that this is caught in a test in DEBUG builds (in case a new enum value is added)
-    assert(action_if_no_compiled_nodes == epctx::ModelGenOptions::ActionIfNoCompiledNodes::kGenerateModel);
-    LOGS(logger, INFO) << "Unable to compile any nodes but will still generate an output model. "
-                          "Either the session EPs do not support compilation or the model is already compiled.";
-  }
+  // This function serializes the EPContext form only; the sole caller (GraphPartitioner::Partition) invokes
+  // it just when AnyEpContextNodesProduced() is true, so at least one EPContext node is guaranteed here. The
+  // no-compiled-nodes policy (kReturnError / kGenerateModel) is handled by InferenceSession instead.
+  assert(!all_ep_context_nodes.empty());
 
   auto get_ep_context_node = [&all_ep_context_nodes](const std::string& node_name) -> std::pair<bool, const Node*> {
     for (auto& node : all_ep_context_nodes) {
@@ -1113,10 +1066,10 @@ static Status CreateEpContextModel(const ExecutionProviders& execution_providers
       (output_model_path_ptr != nullptr || !graph.ModelPath().empty())) {
     std::filesystem::path output_model_path = (output_model_path_ptr != nullptr) ? *output_model_path_ptr
                                                                                  : std::filesystem::path("");
-    ORT_RETURN_IF_ERROR(GetValidatedEpContextPath(output_model_path,
-                                                  graph.ModelPath(),
-                                                  valid_output_model_path,
-                                                  ep_context_gen_options.error_if_output_file_exists));
+    ORT_RETURN_IF_ERROR(epctx::GetValidatedEpContextPath(output_model_path,
+                                                         graph.ModelPath(),
+                                                         valid_output_model_path,
+                                                         ep_context_gen_options.error_if_output_file_exists));
   }
 
   // Utility function to detect a fused node with an unsupported domain.
@@ -1215,59 +1168,7 @@ static Status CreateEpContextModel(const ExecutionProviders& execution_providers
   ORT_RETURN_IF_ERROR(EpContextModelToProto(ep_context_model, valid_output_model_path, ep_context_gen_options,
                                             /*out*/ model_proto));
 
-  if (output_buffer_holder != nullptr) {
-    // Write output model into a buffer ORT allocates for the user.
-    size_t buffer_size = model_proto.ByteSizeLong();
-    ORT_RETURN_IF(buffer_size > static_cast<size_t>(std::numeric_limits<int>::max()),
-                  "Cannot serialize ONNX ModelProto larger than 2GB");
-
-    AllocatorPtr allocator = output_buffer_holder->buffer_allocator;
-    IAllocatorUniquePtr<void> buffer = IAllocator::MakeUniquePtr<void>(allocator, buffer_size);
-    model_proto.SerializeToArray(buffer.get(), static_cast<int>(buffer_size));
-
-    *output_buffer_holder->buffer_size_ptr = buffer_size;
-    *output_buffer_holder->buffer_ptr = buffer.release();
-  } else if (output_write_func_holder != nullptr) {
-    // Write output model to user's output stream.
-    size_t buffer_size = model_proto.ByteSizeLong();
-    ORT_RETURN_IF(buffer_size > static_cast<size_t>(std::numeric_limits<int>::max()),
-                  "Cannot serialize ONNX ModelProto larger than 2GB");
-
-    auto out_stream_buf = std::make_unique<epctx::OutStreamBuf>(*output_write_func_holder);
-    std::ostream out_stream(out_stream_buf.get());
-
-    model_proto.SerializeToOstream(&out_stream);
-    out_stream.flush();
-    ORT_RETURN_IF_ERROR(out_stream_buf->GetStatus());
-  } else {
-    // Write output model to a file.
-    int fd = 0;
-    Status status = Env::Default().FileOpenWr(valid_output_model_path, fd);
-    ORT_RETURN_IF_ERROR(status);
-
-    ORT_TRY {
-      google::protobuf::io::FileOutputStream output(fd);
-      bool serialize_result = model_proto.SerializeToZeroCopyStream(&output) && output.Flush();
-      if (!serialize_result) {
-        status = ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_PROTOBUF,
-                                 "Protobuf serialization failed when generating EPContext model ",
-                                 valid_output_model_path);
-      }
-    }
-    ORT_CATCH(const std::exception& ex) {
-      ORT_HANDLE_EXCEPTION([&]() {
-        status = ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, ex.what());
-      });
-    }
-    if (!status.IsOK()) {
-      GSL_SUPPRESS(es .84)
-      ORT_IGNORE_RETURN_VALUE(Env::Default().FileClose(fd));
-      return status;
-    }
-    ORT_RETURN_IF_ERROR(Env::Default().FileClose(fd));
-  }
-
-  return Status::OK();
+  return epctx::SaveModelProtoToLocation(model_proto, ep_context_gen_options, valid_output_model_path, logger);
 }
 
 static Status PartitionOnnxFormatModel(const PartitionParams& partition_params, GraphPartitioner::Mode mode,
@@ -1579,9 +1480,9 @@ Status GraphPartitioner::Partition(Graph& graph, FuncManager& func_mgr,
           output_model_path_ptr != nullptr) {
         // Check before EP compile graphs
         std::filesystem::path context_cache_path;
-        ORT_RETURN_IF_ERROR(GetValidatedEpContextPath(*output_model_path_ptr, graph.ModelPath(),
-                                                      context_cache_path,
-                                                      ep_context_gen_options.error_if_output_file_exists));
+        ORT_RETURN_IF_ERROR(epctx::GetValidatedEpContextPath(*output_model_path_ptr, graph.ModelPath(),
+                                                             context_cache_path,
+                                                             ep_context_gen_options.error_if_output_file_exists));
       }
     }
 
@@ -1595,7 +1496,12 @@ Status GraphPartitioner::Partition(Graph& graph, FuncManager& func_mgr,
                                                  ep_acc_map, *graph_optimizer_registry_, logger,
                                                  disable_model_compile));  // Pass param
 
-    if (ep_context_gen_options.enable) {
+    // Serialize here only when the output is EPContext-based (some EP produced EPContext nodes). The
+    // compiling EPs' core optimization lives inside the EPContext blobs, which are opaque to the Level2+
+    // passes, so there is nothing to gain by deferring this to after the optimizer loop. The plain form
+    // (no nodes compiled) is instead emitted by InferenceSession after that loop
+    // (epctx::BuildAndSaveOptimizedModel), so it captures the Level2+ passes.
+    if (ep_context_gen_options.enable && AnyEpContextNodesProduced()) {
       ORT_RETURN_IF_ERROR(CreateEpContextModel(providers_, graph, ep_context_gen_options, logger));
     }
 #else
@@ -1616,5 +1522,16 @@ Status GraphPartitioner::Partition(Graph& graph, FuncManager& func_mgr,
 
   return Status::OK();
 }
+
+#ifndef ORT_MINIMAL_BUILD
+bool GraphPartitioner::AnyEpContextNodesProduced() const {
+  for (const auto& ep : providers_) {
+    if (!ep->GetEpContextNodes().empty()) {
+      return true;
+    }
+  }
+  return false;
+}
+#endif  // !defined(ORT_MINIMAL_BUILD)
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/framework/graph_partitioner.h
+++ b/onnxruntime/core/framework/graph_partitioner.h
@@ -62,7 +62,7 @@ class GraphPartitioner {
   // the partition boundary. If no nodes were compiled it is a plain optimized copy of the graph, NOT
   // serialized here - InferenceSession emits it (epctx::BuildAndSaveOptimizedModel) at a point chosen by the
   // requested optimization level: before the Level2+ loop for level < Level2 (a BASIC snapshot matching the
-  // partition boundary), or after the loop for level >= Level2 (capturing the L2-L4 passes). Callers
+  // partition boundary), or after all graph transforms for level >= Level2 (capturing the L2-L4 passes). Callers
   // distinguish the two output forms via AnyEpContextNodesProduced().
   Status Partition(Graph& graph, FuncManager& func_mgr,
                    const layout_transformation::TransformLayoutFunction& transform_layout_function,

--- a/onnxruntime/core/framework/graph_partitioner.h
+++ b/onnxruntime/core/framework/graph_partitioner.h
@@ -60,8 +60,10 @@ class GraphPartitioner {
   //
   // If the output is EPContext-based (a compiling EP produced EPContext nodes) it is serialized here at
   // the partition boundary. If no nodes were compiled it is a plain optimized copy of the graph, NOT
-  // serialized here - InferenceSession emits it after the Level2+ loop (epctx::BuildAndSaveOptimizedModel),
-  // since only that form is affected by those passes. Callers distinguish via AnyEpContextNodesProduced().
+  // serialized here - InferenceSession emits it (epctx::BuildAndSaveOptimizedModel) at a point chosen by the
+  // requested optimization level: before the Level2+ loop for level < Level2 (a BASIC snapshot matching the
+  // partition boundary), or after the loop for level >= Level2 (capturing the L2-L4 passes). Callers
+  // distinguish the two output forms via AnyEpContextNodesProduced().
   Status Partition(Graph& graph, FuncManager& func_mgr,
                    const layout_transformation::TransformLayoutFunction& transform_layout_function,
                    const ConfigOptions& config_options,
@@ -72,9 +74,7 @@ class GraphPartitioner {
                    const layout_transformation::DebugGraphFn& debug_graph_fn = {}) const;
 
 #ifndef ORT_MINIMAL_BUILD
-  // Returns true if any execution provider produced EPContext (compiled) nodes during partitioning -
-  // i.e. the output is an EPContext model (serialized in Partition) rather than a plain optimized copy
-  // (emitted by InferenceSession after the Level2+ loop). Stable once partitioning has run.
+  // Returns true if any execution provider produced EPContext (compiled) nodes during partitioning.
   bool AnyEpContextNodesProduced() const;
 #endif
 

--- a/onnxruntime/core/framework/graph_partitioner.h
+++ b/onnxruntime/core/framework/graph_partitioner.h
@@ -57,6 +57,11 @@ class GraphPartitioner {
   }
 
   // Run partitioning.
+  //
+  // If the output is EPContext-based (a compiling EP produced EPContext nodes) it is serialized here at
+  // the partition boundary. If no nodes were compiled it is a plain optimized copy of the graph, NOT
+  // serialized here - InferenceSession emits it after the Level2+ loop (epctx::BuildAndSaveOptimizedModel),
+  // since only that form is affected by those passes. Callers distinguish via AnyEpContextNodesProduced().
   Status Partition(Graph& graph, FuncManager& func_mgr,
                    const layout_transformation::TransformLayoutFunction& transform_layout_function,
                    const ConfigOptions& config_options,
@@ -65,6 +70,13 @@ class GraphPartitioner {
                    Mode mode = Mode::kNormal,
                    const epctx::ModelGenOptions& ep_context_gen_options = {},
                    const layout_transformation::DebugGraphFn& debug_graph_fn = {}) const;
+
+#ifndef ORT_MINIMAL_BUILD
+  // Returns true if any execution provider produced EPContext (compiled) nodes during partitioning -
+  // i.e. the output is an EPContext model (serialized in Partition) rather than a plain optimized copy
+  // (emitted by InferenceSession after the Level2+ loop). Stable once partitioning has run.
+  bool AnyEpContextNodesProduced() const;
+#endif
 
   bool IsLoadCancellationFlagSet() const {
     return check_load_cancellation_fn_ && check_load_cancellation_fn_();

--- a/onnxruntime/core/framework/graph_partitioner.h
+++ b/onnxruntime/core/framework/graph_partitioner.h
@@ -58,12 +58,12 @@ class GraphPartitioner {
 
   // Run partitioning.
   //
-  // If the output is EPContext-based (a compiling EP produced EPContext nodes) it is serialized here at
-  // the partition boundary. If no nodes were compiled it is a plain optimized copy of the graph, NOT
-  // serialized here - InferenceSession emits it (epctx::BuildAndSaveOptimizedModel) at a point chosen by the
-  // requested optimization level: before the Level2+ loop for level < Level2 (a BASIC snapshot matching the
-  // partition boundary), or after all graph transforms for level >= Level2 (capturing the L2-L4 passes). Callers
-  // distinguish the two output forms via AnyEpContextNodesProduced().
+  // Output-model serialization (only when ep_context_gen_options is enabled, e.g. via the Compile API): if
+  // a compiling EP produced EPContext nodes, that model is serialized here at the end of partition.
+  // Otherwise, for a compile-only session (the Compile API with no compiled nodes), the plain optimized
+  // graph is emitted by InferenceSession (not here) at a point chosen by the optimization level - before
+  // the Level2+ loop for < Level2, or after all transforms for >= Level2 (to capture the L2-L4 fusions).
+  // Callers distinguish via AnyEpContextNodesProduced().
   Status Partition(Graph& graph, FuncManager& func_mgr,
                    const layout_transformation::TransformLayoutFunction& transform_layout_function,
                    const ConfigOptions& config_options,

--- a/onnxruntime/core/graph/model.cc
+++ b/onnxruntime/core/graph/model.cc
@@ -877,12 +877,17 @@ common::Status Model::LoadFromModelEditorApiModel(const OrtModel& model_editor_a
   auto domain_map = allow_official_onnx_release_only_final ? schema_registry->GetLastReleasedOpsetVersions(false)
                                                            : schema_registry->GetLatestOpsetVersions(false);
 
+  // Merge in the other domains ORT may use internally, without overriding opsets the caller supplied
+  // explicitly (e.g. the ONNX domain). Only missing domains get the registry version from domain_map.
   for (const auto& [domain, version] : domain_map) {
     if (domain_to_version.find(domain) == domain_to_version.end()) {
       domain_to_version[domain] = version;
     }
+  }
 
-    // add to the model proto so that if we save the optimized model it has the required opset imports
+  // Populate the model proto's opset imports from the merged map (not domain_map) so they stay consistent
+  // with the graph's domain-to-version map and preserve the caller's explicit opsets.
+  for (const auto& [domain, version] : domain_to_version) {
     const gsl::not_null<OperatorSetIdProto*> opset_id_proto{model->model_proto_.add_opset_import()};
     opset_id_proto->set_domain(domain);
     opset_id_proto->set_version(version);

--- a/onnxruntime/core/providers/webgpu/allocator.cc
+++ b/onnxruntime/core/providers/webgpu/allocator.cc
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <memory>
+#include <utility>
+
 #include "core/framework/session_state.h"
 #include "core/providers/webgpu/allocator.h"
 #include "core/providers/webgpu/buffer_manager.h"
@@ -43,6 +46,31 @@ void GpuBufferAllocator::Free(void* p) {
 
 void GpuBufferAllocator::GetStats(AllocatorStats* stats) {
   *stats = stats_;
+}
+
+WebGpuNoOpAllocator::WebGpuNoOpAllocator(bool is_read_only_allocator)
+    : IAllocator(
+          OrtMemoryInfo(WEBGPU_BUFFER,
+                        is_read_only_allocator ? OrtAllocatorType::OrtReadOnlyAllocator
+                                               : OrtAllocatorType::OrtDeviceAllocator,
+                        WebGpuDevice,
+                        OrtMemTypeDefault)) {
+}
+
+void* WebGpuNoOpAllocator::Alloc(size_t /*size*/) {
+  ORT_THROW("WebGPU EP device-free context must not allocate device memory.");
+}
+
+void WebGpuNoOpAllocator::Free(void* /*p*/) {
+}
+
+AllocatorPtr CreateWebGpuAllocator(bool device_free,
+                                   std::function<const BufferManager&()> buffer_manager_getter,
+                                   bool is_read_only_allocator) {
+  if (device_free) {
+    return std::make_shared<WebGpuNoOpAllocator>(is_read_only_allocator);
+  }
+  return std::make_shared<GpuBufferAllocator>(std::move(buffer_manager_getter), is_read_only_allocator);
 }
 
 }  // namespace webgpu

--- a/onnxruntime/core/providers/webgpu/allocator.h
+++ b/onnxruntime/core/providers/webgpu/allocator.h
@@ -35,5 +35,25 @@ class GpuBufferAllocator : public IAllocator {
   bool mapped_at_creation_;
 };
 
+// No-op allocator used for the WebGPU device when the context has no Dawn device (a device-free /
+// "virtual device" context). A real GpuBufferAllocator cannot be constructed without a device (its ctor
+// queries the device via BufferManager::SupportsUMA), and such a context only runs graph transformation
+// and never allocates. This exposes the same OrtMemoryInfo so the device's allocator contract is met,
+// but Alloc/Free are never expected to be called.
+class WebGpuNoOpAllocator : public IAllocator {
+ public:
+  explicit WebGpuNoOpAllocator(bool is_read_only_allocator);
+
+  void* Alloc(size_t size) override;
+  void Free(void* p) override;
+};
+
+// Creates the WebGPU device allocator: a real GpuBufferAllocator when the context has a device, or a
+// no-op WebGpuNoOpAllocator for a device-free context, where a real one can't be constructed and no
+// allocation ever happens.
+AllocatorPtr CreateWebGpuAllocator(bool device_free,
+                                   std::function<const BufferManager&()> buffer_manager_getter,
+                                   bool is_read_only_allocator);
+
 }  // namespace webgpu
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/webgpu/ep/factory.cc
+++ b/onnxruntime/core/providers/webgpu/ep/factory.cc
@@ -7,12 +7,17 @@
 #include "core/framework/error_code_helper.h"
 #include "core/graph/constants.h"
 
+#include <cstring>
+
 #include "core/framework/execution_provider.h"
 #include "core/framework/config_options.h"
 #include "core/providers/webgpu/webgpu_provider_factory_creator.h"
 #include "core/providers/webgpu/webgpu_execution_provider.h"
 #include "core/providers/webgpu/webgpu_context.h"
 #include "core/providers/webgpu/allocator.h"
+#include "core/session/onnxruntime_env_config_keys.h"
+#include "core/session/onnxruntime_ep_device_ep_metadata_keys.h"
+#include "core/session/onnxruntime_session_options_config_keys.h"
 
 namespace onnxruntime {
 namespace webgpu {
@@ -50,6 +55,14 @@ Factory::Factory() : OrtEpFactory{},
   CreateDataTransfer = CreateDataTransferImpl;
 
   IsStreamAware = IsStreamAwareImpl;
+}
+
+// Destructor: release the virtual hardware device if one was created in GetSupportedDevices.
+Factory::~Factory() {
+  if (virtual_hw_device_ != nullptr) {
+    Api().ep.ReleaseHardwareDevice(virtual_hw_device_);
+    virtual_hw_device_ = nullptr;
+  }
 }
 
 // Static C API implementations
@@ -97,21 +110,55 @@ OrtStatus* ORT_API_CALL Factory::GetSupportedDevicesImpl(
     }
   }
 
+  // If the environment allows virtual devices, register a virtual GPU EP device (vendor/device id 0) so
+  // the WebGPU EP stays selectable for a device-free compile-only session on hosts where OS device
+  // enumeration finds no GPU (e.g. a Win32k-lockdown sandbox). It is offered *in addition* to any real
+  // GPU device, so the device-free path remains exercisable on a host that also has a real GPU. Since
+  // allow_virtual_devices is opt-in, normal (real GPU) usage is unaffected.
+  if (num_ep_devices < max_ep_devices) {
+    OrtKeyValuePairs* env_config = nullptr;
+    ORT_API_RETURN_IF_ERROR(Api().ep.GetEnvConfigEntries(&env_config));
+    Ort::KeyValuePairs env_config_holder(env_config);  // allow automatic release
+    const char* allow_virtual = env_config_holder.GetValue(kOrtEnvAllowVirtualDevices);
+    const bool allow_virtual_devices = allow_virtual != nullptr && std::strcmp(allow_virtual, "1") == 0;
+
+    if (allow_virtual_devices) {
+      OrtKeyValuePairs* hw_metadata = nullptr;
+      Api().ort.CreateKeyValuePairs(&hw_metadata);
+      Api().ort.AddKeyValuePair(hw_metadata, kOrtHardwareDevice_MetadataKey_IsVirtual, "1");
+      OrtStatus* status = Api().ep.CreateHardwareDevice(OrtHardwareDeviceType::OrtHardwareDeviceType_GPU,
+                                                        /*vendor_id=*/0, /*device_id=*/0,
+                                                        GetVendorImpl(this_ptr), hw_metadata,
+                                                        &factory->virtual_hw_device_);
+      Api().ort.ReleaseKeyValuePairs(hw_metadata);  // ORT makes a copy
+      ORT_API_RETURN_IF_ERROR(status);
+
+      OrtEpDevice* ep_device = nullptr;
+      ORT_API_RETURN_IF_ERROR(Api().ep.CreateEpDevice(this_ptr, factory->virtual_hw_device_,
+                                                      nullptr, nullptr, &ep_device));
+      // No allocator info: a virtual device only backs a device-free compile-only session, which stops
+      // before session-state finalization and never allocates. Leaving the memory info unset also avoids
+      // ORT trying to create a shared WebGPU allocator (environment.cc) with no underlying device.
+      ep_devices[num_ep_devices++] = ep_device;
+    }
+  }
+
   return nullptr;
   EXCEPTION_TO_RETURNED_STATUS_END
 }
 
 OrtStatus* ORT_API_CALL Factory::CreateEpImpl(
     OrtEpFactory* this_ptr,
-    const OrtHardwareDevice* const* /*devices*/,
+    const OrtHardwareDevice* const* devices,
     const OrtKeyValuePairs* const* /*ep_metadata*/,
     size_t num_devices,
     const OrtSessionOptions* session_options,
     const OrtLogger* logger,
     OrtEp** ep) noexcept {
   EXCEPTION_TO_RETURNED_STATUS_BEGIN
-  if (num_devices == 0) {
-    return Api().ort.CreateStatus(ORT_INVALID_ARGUMENT, "No hardware devices provided to create WebGPU EP.");
+  if (num_devices != 1) {
+    return Api().ort.CreateStatus(ORT_INVALID_ARGUMENT,
+                                  "WebGPU EP factory currently only supports one device at a time.");
   }
 
   OrtKeyValuePairs* session_config_entries = nullptr;
@@ -130,18 +177,38 @@ OrtStatus* ORT_API_CALL Factory::CreateEpImpl(
     }
   }
 
+  // A virtual GPU device has no real GPU behind it, so it can only back a device-free compile-only session
+  // (see the concept map in webgpu_context.cc). Reject the invalid combination up front with a clear message
+  // instead of letting Dawn fail obscurely when it later tries to create a device.
+  const bool compile_only = config_options.GetConfigOrDefault(kOrtSessionOptionCompileOnly, "0") == "1";
+  const OrtKeyValuePairs* device_metadata = Api().ort.HardwareDevice_Metadata(devices[0]);
+  const bool selected_virtual_device =
+      device_metadata != nullptr &&
+      Api().ort.GetKeyValue(device_metadata, kOrtHardwareDevice_MetadataKey_IsVirtual) != nullptr;
+  if (selected_virtual_device && !compile_only) {
+    return Api().ort.CreateStatus(
+        ORT_INVALID_ARGUMENT,
+        "WebGPU EP was selected on a virtual GPU device, which has no real GPU behind it and can only serve "
+        "a compile-only session (session.compile_only=1). Select a real GPU device to run inference.");
+  }
+
   auto webgpu_ep_factory = WebGpuProviderFactoryCreator::Create(config_options);
   auto webgpu_ep = webgpu_ep_factory->CreateProvider(*session_options, *logger);
   static_cast<WebGpuExecutionProvider*>(webgpu_ep.get())->SetEpLogger(logger);
   auto factory = static_cast<Factory*>(this_ptr);
   const int context_id = webgpu_ep->GetDeviceId();
   auto* webgpu_ep_ptr = static_cast<WebGpuExecutionProvider*>(webgpu_ep.get());
-  auto device_alloc = std::make_shared<webgpu::GpuBufferAllocator>(
+  // A device-free context (compile-only session) gets a no-op allocator: a real GpuBufferAllocator
+  // needs a device, and such a session stops before finalization and never allocates.
+  const bool device_free = !WebGpuContextFactory::GetContext(context_id).HasDevice();
+  auto device_alloc = webgpu::CreateWebGpuAllocator(
+      device_free,
       [webgpu_ep_ptr]() -> const webgpu::BufferManager& { return webgpu_ep_ptr->BufferManager(); }, false);
   Ep::Config webgpu_ep_config{
       CPUAllocator::DefaultInstance(),  // CPU allocator
       device_alloc,                     // default device allocator
-      std::make_shared<webgpu::GpuBufferAllocator>(
+      webgpu::CreateWebGpuAllocator(
+          device_free,
           [context_id]() -> const webgpu::BufferManager& {
             return WebGpuContextFactory::GetContext(context_id).InitializerBufferManager();
           },

--- a/onnxruntime/core/providers/webgpu/ep/factory.h
+++ b/onnxruntime/core/providers/webgpu/ep/factory.h
@@ -66,9 +66,16 @@ class Factory : public OrtEpFactory {
   Ort::MemoryInfo default_memory_info_;
   Ort::MemoryInfo readonly_memory_info_;  // used for initializers
 
+  // Owned virtual GPU hardware device created on demand by GetSupportedDevices when the environment
+  // allows virtual devices (OrtEnv config "allow_virtual_devices"=1) and no real GPU device was
+  // discovered -- e.g. in a sandboxed process where OS device enumeration is unavailable (such as
+  // Win32k lockdown), so ORT device discovery is skipped. Released in the destructor. nullptr when
+  // no virtual device was made.
+  OrtHardwareDevice* virtual_hw_device_ = nullptr;
+
  public:
   Factory();
-  ~Factory() = default;
+  ~Factory();
 };
 
 }  // namespace ep

--- a/onnxruntime/core/providers/webgpu/webgpu_context.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.cc
@@ -43,6 +43,20 @@ void WebGpuContext::Initialize(const WebGpuContextConfig& config) {
   std::call_once(init_flag_, [this, &config]() {
     max_num_pending_dispatches_ = config.max_num_pending_dispatches;
 
+    // Three easily-conflated concepts, at three layers (a pipeline, not the same flag):
+    //   * allow_virtual_devices (env)     -- selectability: surface a virtual GPU OrtEpDevice so WebGPU is
+    //                                        pickable when OS enumeration finds no GPU (e.g. Win32k sandbox).
+    //   * compile_only (session)          -- intent: transform only, never finalize/run.
+    //   * device-free / HasDevice() (ctx) -- mechanism: no Dawn device, no-op allocator.
+    // compile_only alone is valid (device-free even with a real GPU); a virtual device without compile_only is
+    // rejected at factory CreateEp -- it would try to build a real Dawn device with no hardware.
+    if (config.compile_only) {
+      // Device-free: skip Dawn adapter/device creation. Such a context only transforms the graph; the session
+      // stops before finalization and never executes kernels or allocates.
+      LOGS_DEFAULT(INFO) << "WebGPU EP context created device-free (compile-only session, no Dawn device).";
+      return;
+    }
+
     if (device_ == nullptr) {
       // Create wgpu::Adapter
       wgpu::RequestAdapterOptions req_adapter_options = {};

--- a/onnxruntime/core/providers/webgpu/webgpu_context.h
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.h
@@ -97,6 +97,9 @@ struct WebGpuContextConfig {
   };
   bool validation_mode_explicitly_set{false};
   bool preserve_device{false};
+  // When true, skip Dawn adapter/device creation and all device-dependent initialization; the context
+  // can only be used for graph transformation, not execution. Derived from kOrtSessionOptionCompileOnly.
+  bool compile_only{false};
   uint32_t max_num_pending_dispatches{16};
   uint64_t max_storage_buffer_binding_size{0};
   WebGpuBufferCacheConfig buffer_cache_config{};
@@ -232,6 +235,10 @@ class WebGpuContext final {
   inline webgpu::ValidationMode ValidationMode() const {
     return validation_mode_;
   }
+
+  // False for a device-free ("virtual device") context, which has no Dawn device and can only run graph
+  // transformation. Used to hand out a no-op allocator instead of a real GpuBufferAllocator.
+  inline bool HasDevice() const { return device_ != nullptr; }
 
   //
   // Get Split-K configuration.

--- a/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
@@ -631,7 +631,8 @@ WebGpuExecutionProvider::WebGpuExecutionProvider(int context_id,
       enable_int64_{config.enable_graph_capture || config.enable_int64},
       multi_rotary_cache_concat_offset_{config.multi_rotary_cache_concat_offset},
       kv_cache_quantization_bits_{config.kv_cache_quantization_bits},
-      prepack_allocator_{std::make_shared<webgpu::GpuBufferAllocator>(
+      prepack_allocator_{CreateWebGpuAllocator(
+          /*device_free=*/!context.HasDevice(),
           [this]() -> const webgpu::BufferManager& { return context_.InitializerBufferManager(); }, false)} {
   if (enable_graph_capture_ && config.session_buffer_pool_generations > 0) {
     session_buffer_pool_ = std::make_unique<webgpu::SessionBufferPool>(
@@ -648,14 +649,16 @@ WebGpuExecutionProvider::WebGpuExecutionProvider(int context_id,
 }
 
 std::vector<AllocatorPtr> WebGpuExecutionProvider::CreatePreferredAllocators() {
-  auto device_allocator = std::make_unique<webgpu::GpuBufferAllocator>(
-      [this]() -> const webgpu::BufferManager& { return BufferManager(); }, false);
+  const bool device_free = !context_.HasDevice();
   return {
       // allocator for initializers
-      std::make_unique<webgpu::GpuBufferAllocator>(
+      CreateWebGpuAllocator(
+          device_free,
           [this]() -> const webgpu::BufferManager& { return context_.InitializerBufferManager(); }, true),
       // default allocator
-      std::move(device_allocator),
+      CreateWebGpuAllocator(
+          device_free,
+          [this]() -> const webgpu::BufferManager& { return BufferManager(); }, false),
   };
 }
 

--- a/onnxruntime/core/providers/webgpu/webgpu_provider_factory.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_provider_factory.cc
@@ -10,6 +10,7 @@
 #include "core/providers/webgpu/webgpu_provider_factory_creator.h"
 #include "core/providers/webgpu/webgpu_context.h"
 #include "core/session/abi_session_options_impl.h"
+#include "core/session/onnxruntime_session_options_config_keys.h"
 #include "core/session/ort_apis.h"
 
 #include "core/providers/webgpu/webgpu_provider_options.h"
@@ -213,6 +214,11 @@ WebGpuContextConfig ParseWebGpuContextConfig(const ConfigOptions& config_options
     }
   }
 
+  // Compile-only mode (skip Dawn adapter/device creation so graph transformation can run device-free)
+  // is derived from the session config kOrtSessionOptionCompileOnly, which the Compile API sets
+  // automatically -- same signal other EPs use (e.g. NV TensorRT RTX). Not a WebGPU-specific option.
+  config.compile_only = config_options.GetConfigOrDefault(kOrtSessionOptionCompileOnly, "0") == "1";
+
   std::string max_storage_buffer_binding_size_str;
   if (config_options.TryGetConfigEntry(kMaxStorageBufferBindingSize, max_storage_buffer_binding_size_str)) {
     ORT_ENFORCE(
@@ -254,6 +260,7 @@ WebGpuContextConfig ParseWebGpuContextConfig(const ConfigOptions& config_options
   LOGS_DEFAULT(VERBOSE) << "WebGPU EP DawnProcTable: " << reinterpret_cast<size_t>(config.dawn_proc_table);
   LOGS_DEFAULT(VERBOSE) << "WebGPU EP ValidationMode: " << config.validation_mode;
   LOGS_DEFAULT(VERBOSE) << "WebGPU EP PreserveDevice: " << config.preserve_device;
+  LOGS_DEFAULT(VERBOSE) << "WebGPU EP CompileOnly: " << config.compile_only;
   LOGS_DEFAULT(VERBOSE) << "WebGPU EP max storage buffer binding size: " << config.max_storage_buffer_binding_size;
   LOGS_DEFAULT(VERBOSE) << "WebGPU EP max pending dispatches: " << config.max_num_pending_dispatches;
 

--- a/onnxruntime/core/session/environment.cc
+++ b/onnxruntime/core/session/environment.cc
@@ -626,7 +626,12 @@ Status Environment::RegisterExecutionProviderLibrary(const std::string& registra
 }
 
 Status Environment::CreateAndRegisterInternalEps() {
-  auto internal_ep_libraries = EpLibraryInternal::CreateInternalEps();
+  // Capture allow_virtual_devices here (lock-free) and pass it to the internal EP factories at
+  // construction. The internal WebGPU EP factory needs it in GetSupportedDevices but cannot query the
+  // OrtEnv singleton there: internal EPs are registered while OrtEnv's creation mutex is already held on
+  // this thread, so the query would self-deadlock.
+  const bool allow_virtual_devices = num_allow_virtual_device_uses_ > 0;
+  auto internal_ep_libraries = EpLibraryInternal::CreateInternalEps(allow_virtual_devices);
   for (auto& ep_library : internal_ep_libraries) {
     // we do a std::move in the function call so need a valid pointer for the args after the move
     auto* internal_library_ptr = ep_library.get();

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -2727,11 +2727,27 @@ common::Status InferenceSession::Initialize() {
 #endif  // !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
     }
 
-    ORT_RETURN_IF_ERROR_SESSIONID_(
-        session_state_->FinalizeSessionState(model_location_, kernel_registry_manager_,
-                                             // need to keep the initializers if saving the optimized model
-                                             !saving_model,
-                                             saving_ort_format));
+    // Compile-only: a compile-only session never runs inference, so skip session-state finalization (kernel creation,
+    // PrePack, initializer upload, memory planning) and return right after the model-save block below.
+    //
+    // NOTE: the model-save block is required for non-CompileAPI usage where optimized_model_filepath and a
+    // virtual device is used. e.g. WebGPU.
+    // CompileAPI based usage saves the EPContext based model during partitioning (CreateEpContextModel) so never enters
+    // this block.
+    const bool skip_session_state_finalization =
+        session_options_.config_options.GetConfigOrDefault(kOrtSessionOptionCompileOnly, "0") == "1";
+
+    if (!skip_session_state_finalization) {
+      ORT_RETURN_IF_ERROR_SESSIONID_(
+          session_state_->FinalizeSessionState(model_location_, kernel_registry_manager_,
+                                               // need to keep the initializers if saving the optimized model
+                                               !saving_model,
+                                               saving_ort_format));
+    } else {
+      LOGS(*session_logger_, INFO)
+          << "Compile-only session: skipping session-state finalization. The session is not runnable; only the "
+             "output model is produced.";
+    }
 
 #if !defined(ORT_MINIMAL_BUILD)
     if (saving_model) {
@@ -2771,6 +2787,12 @@ common::Status InferenceSession::Initialize() {
                                                                              model_saving_options));
         }
       }
+    }
+
+    // Compile-only: exit here as the model is saved and everything past here is to setup a runnable session
+    // that would never be used.
+    if (skip_session_state_finalization) {
+      return common::Status::OK();
     }
 
     std::vector<TuningResults> tuning_results;

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -1694,7 +1694,7 @@ common::Status InferenceSession::TransformGraph(onnxruntime::Graph& graph, bool 
     }
   }
 #endif  // !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
-  const epctx::ModelGenOptions ep_context_gen_options = session_options_.GetEpContextGenerationOptions();
+  const epctx::ModelGenOptions& ep_context_gen_options = session_options_.GetEpContextGenerationOptions();
 
   // Do partitioning based on execution providers' capabilities.
   ORT_RETURN_IF_ERROR_SESSIONID_(partitioner.Partition(graph, session_state_->GetMutableFuncMgr(), transform_layout_fn,

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -2783,11 +2783,13 @@ common::Status InferenceSession::Initialize() {
     // PrePack, initializer upload, memory planning) and early return here.
     //
     // Returning here also bypasses the model-save block below, because a compile-only session does not produce its
-    // output via optimized_model_filepath.
+    // output via optimized_model_filepath. We still log the session-creation telemetry and record the
+    // end-of-initialization bookkeeping that the normal path emits, so neither is lost by returning early.
     if (session_options_.config_options.GetConfigOrDefault(kOrtSessionOptionCompileOnly, "0") == "1") {
       LOGS(*session_logger_, INFO)
           << "Compile-only session: skipping session-state finalization. The session is not runnable.";
-      return common::Status::OK();
+      LogSessionCreationTelemetry(graph, model_weight_type, model_graph_hash, model_weight_hash);
+      return RecordSessionCreationEndTelemetry(tp, status);
     }
 
     ORT_RETURN_IF_ERROR_SESSIONID_(
@@ -2860,33 +2862,7 @@ common::Status InferenceSession::Initialize() {
     session_state_->PruneRemovableAttributes();
 
     // and log telemetry
-    std::filesystem::path model_path = graph.ModelPath();
-    std::string model_file_name = PathToUTF8String(model_path.filename().native());
-    bool model_has_fp16_inputs = ModelHasFP16Inputs(graph);
-
-    // Populate per-(EP, hardware-device) telemetry data captured once at session
-    // initialization. The graph partitioning is complete at this point, so we can
-    // count how many nodes each EP is assigned. This populates telemetry_.ep_device_info_
-    // and the comma-separated summary strings used to enrich SessionCreation.
-    PopulateEpDeviceInfo(graph);
-
-    env.GetTelemetryProvider().LogSessionCreation(
-        session_id_, model_->IrVersion(), model_->ProducerName(), model_->ProducerVersion(), model_->Domain(),
-        graph.DomainToVersionMap(), model_file_name, graph.Name(), model_weight_type, model_graph_hash, model_weight_hash,
-        model_->MetaData(), telemetry_.event_name_, execution_providers_.GetIds(),
-        telemetry_.ep_device_types_summary_, telemetry_.ep_device_vendor_ids_summary_,
-        telemetry_.ep_versions_summary_,
-        model_has_fp16_inputs, false);
-
-    // Emit one initial EpDeviceUsage event per (EP, device) pair with run counts of 0.
-    // Ensures we capture EP/device topology even for sessions that end before the
-    // first RuntimePerf heartbeat (2s after the first Run()).
-    for (const auto& ep_info : telemetry_.ep_device_info_) {
-      env.GetTelemetryProvider().LogEpDeviceUsage(
-          session_id_, ep_info.ep_type, ep_info.hardware_device_type,
-          ep_info.vendor_id, ep_info.device_id, ep_info.vendor, ep_info.ep_vendor,
-          ep_info.ep_version, ep_info.assigned_node_count, 0, 0);
-    }
+    LogSessionCreationTelemetry(graph, model_weight_type, model_graph_hash, model_weight_hash);
 
     LOGS(*session_logger_, INFO) << "Session successfully initialized.";
   }
@@ -2914,26 +2890,7 @@ common::Status InferenceSession::Initialize() {
     LOGS(*session_logger_, ERROR) << status.ErrorMessage();
   }
 
-  if (session_profiler_.IsEnabled()) {
-    session_profiler_.EndTimeAndRecordEvent(profiling::SESSION_EVENT, "session_initialization", tp);
-  }
-
-  if (status.IsOK()) {
-    for (auto& xp : execution_providers_) {
-      auto end_status = xp->OnSessionInitializationEnd();
-      if (status.IsOK()) {
-        status = end_status;
-      }
-    }
-  }
-
-  // Log session creation end telemetry
-  {
-    const Env& init_env = Env::Default();
-    init_env.GetTelemetryProvider().LogSessionCreationEnd(session_id_, status);
-  }
-
-  return status;
+  return RecordSessionCreationEndTelemetry(tp, status);
 }
 #if defined(_MSC_VER) && !defined(__clang__)
 #pragma warning(pop)
@@ -4284,6 +4241,58 @@ void InferenceSession::PopulateEpDeviceInfo(const onnxruntime::Graph& graph) {
   telemetry_.ep_device_types_summary_ = types_oss.str();
   telemetry_.ep_device_vendor_ids_summary_ = vendor_ids_oss.str();
   telemetry_.ep_versions_summary_ = versions_oss.str();
+}
+
+void InferenceSession::LogSessionCreationTelemetry(const onnxruntime::Graph& graph,
+                                                   const std::string& model_weight_type,
+                                                   const std::string& model_graph_hash,
+                                                   const std::string& model_weight_hash) {
+  const Env& env = Env::Default();
+  std::filesystem::path model_path = graph.ModelPath();
+  std::string model_file_name = PathToUTF8String(model_path.filename().native());
+  bool model_has_fp16_inputs = ModelHasFP16Inputs(graph);
+
+  // Populate per-(EP, hardware-device) telemetry data captured once at session
+  // initialization. The graph partitioning is complete at this point, so we can
+  // count how many nodes each EP is assigned. This populates telemetry_.ep_device_info_
+  // and the comma-separated summary strings used to enrich SessionCreation.
+  PopulateEpDeviceInfo(graph);
+
+  env.GetTelemetryProvider().LogSessionCreation(
+      session_id_, model_->IrVersion(), model_->ProducerName(), model_->ProducerVersion(), model_->Domain(),
+      graph.DomainToVersionMap(), model_file_name, graph.Name(), model_weight_type, model_graph_hash, model_weight_hash,
+      model_->MetaData(), telemetry_.event_name_, execution_providers_.GetIds(),
+      telemetry_.ep_device_types_summary_, telemetry_.ep_device_vendor_ids_summary_,
+      telemetry_.ep_versions_summary_,
+      model_has_fp16_inputs, false);
+
+  // Emit one initial EpDeviceUsage event per (EP, device) pair with run counts of 0.
+  // Ensures we capture EP/device topology even for sessions that end before the
+  // first RuntimePerf heartbeat (2s after the first Run()).
+  for (const auto& ep_info : telemetry_.ep_device_info_) {
+    env.GetTelemetryProvider().LogEpDeviceUsage(
+        session_id_, ep_info.ep_type, ep_info.hardware_device_type,
+        ep_info.vendor_id, ep_info.device_id, ep_info.vendor, ep_info.ep_vendor,
+        ep_info.ep_version, ep_info.assigned_node_count, 0, 0);
+  }
+}
+
+common::Status InferenceSession::RecordSessionCreationEndTelemetry(const TimePoint& tp, common::Status status) {
+  if (session_profiler_.IsEnabled()) {
+    session_profiler_.EndTimeAndRecordEvent(profiling::SESSION_EVENT, "session_initialization", tp);
+  }
+
+  if (status.IsOK()) {
+    for (auto& xp : execution_providers_) {
+      auto end_status = xp->OnSessionInitializationEnd();
+      if (status.IsOK()) {
+        status = end_status;
+      }
+    }
+  }
+
+  Env::Default().GetTelemetryProvider().LogSessionCreationEnd(session_id_, status);
+  return status;
 }
 
 #if !defined(ORT_MINIMAL_BUILD)

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -1723,10 +1723,19 @@ common::Status InferenceSession::TransformGraph(onnxruntime::Graph& graph, bool 
   //     boundary (no Cast, no Memcpy nodes), unchanged from prior behavior.
   //   - level >= Level2 (explicitly requested): serialize after the loop and Memcpy insertion below, so the
   //     emitted model captures the Level2-Level4 fusions (and the device-placement copy nodes).
-  const bool emit_plain_optimized_model =
+  //
+  // In either case we intentionally do not return early for a compile-only session, so that the disable_cpu_ep_fallback
+  // behavior is unchanged. There are two such non-early-return points:
+  //   - Here in TransformGraph (the level < Level2 case, where the output model is already serialized): the
+  //     InsertCast/Memcpy transformers below are inserted unconditionally, independent of the optimization level, so we
+  //     must let them run to keep the transformed graph identical to prior behavior.
+  //   - In Initialize() overall: the disable_cpu_ep_fallback check there runs on that fully transformed graph
+  //     (including the Cast/Memcpy nodes). Returning early would change what that check sees and could let a
+  //     compile-only session with CPU-assigned nodes slip through, which we intentionally want to fail.
+  const bool emit_plain_compile_only_model =
       session_options_.config_options.GetConfigOrDefault(kOrtSessionOptionCompileOnly, "0") == "1" &&
       ep_context_gen_options.enable && !partitioner.AnyEpContextNodesProduced();
-  if (emit_plain_optimized_model) {
+  if (emit_plain_compile_only_model) {
     using ActionIfNoCompiledNodes = epctx::ModelGenOptions::ActionIfNoCompiledNodes;
     if (ep_context_gen_options.action_if_no_compiled_nodes == ActionIfNoCompiledNodes::kReturnError) {
       ORT_RETURN_IF_ERROR_SESSIONID_(
@@ -1817,20 +1826,6 @@ common::Status InferenceSession::TransformGraph(onnxruntime::Graph& graph, bool 
     ORT_RETURN_IF_ERROR_SESSIONID_(apply_transformer_once(copy_transformer, *session_logger_, graph));
   }
 
-#if !defined(ORT_MINIMAL_BUILD)
-  // Second serialization point for the plain optimized (non-EPContext) output model. Reached only for an
-  // explicitly requested level >= Level2 (level < Level2 was already serialized before the loop above). This
-  // runs after the Level2+ loop and the copy-node insertion, so the emitted model reflects the fully
-  // transformed graph the session runs - the Level2-Level4 fusions plus the device-placement Memcpy nodes.
-  // action_if_no_compiled_nodes was already handled before the loop (kReturnError returned there), so only
-  // kGenerateModel reaches here.
-  if (emit_plain_optimized_model &&
-      session_options_.graph_optimization_level >= TransformerLevel::Level2) {
-    ORT_RETURN_IF_ERROR_SESSIONID_(
-        epctx::BuildAndSaveOptimizedModel(*model_, ep_context_gen_options, *session_logger_));
-  }
-#endif  // !defined(ORT_MINIMAL_BUILD)
-
 #ifdef ENABLE_TRAINING
   // Enable memory optimizations.
   // Only applicable for training scenarios.
@@ -1844,6 +1839,17 @@ common::Status InferenceSession::TransformGraph(onnxruntime::Graph& graph, bool 
     ORT_RETURN_IF_ERROR_SESSIONID_(apply_transformer_once(mem_transformer, *session_logger_, graph));
   }
 #endif
+
+  // Second serialization point for the plain optimized (non-EPContext) output model. Reached only for an
+  // explicitly requested level >= Level2 (level < Level2 was already serialized before the loop above). This runs
+  // after all graph transforms.
+  // action_if_no_compiled_nodes was already handled before the loop (kReturnError returned there), so only
+  // kGenerateModel reaches here.
+  if (emit_plain_compile_only_model &&
+      session_options_.graph_optimization_level >= TransformerLevel::Level2) {
+    ORT_RETURN_IF_ERROR_SESSIONID_(
+        epctx::BuildAndSaveOptimizedModel(*model_, ep_context_gen_options, *session_logger_));
+  }
 
   return Status::OK();
 }
@@ -2780,8 +2786,7 @@ common::Status InferenceSession::Initialize() {
     // output via optimized_model_filepath.
     if (session_options_.config_options.GetConfigOrDefault(kOrtSessionOptionCompileOnly, "0") == "1") {
       LOGS(*session_logger_, INFO)
-          << "Compile-only session: skipping session-state finalization. The session is not runnable; only the "
-             "output model is produced.";
+          << "Compile-only session: skipping session-state finalization. The session is not runnable.";
       return common::Status::OK();
     }
 

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -2728,26 +2728,22 @@ common::Status InferenceSession::Initialize() {
     }
 
     // Compile-only: a compile-only session never runs inference, so skip session-state finalization (kernel creation,
-    // PrePack, initializer upload, memory planning) and return right after the model-save block below.
+    // PrePack, initializer upload, memory planning) and early return here.
     //
-    // NOTE: the model-save block is required for non-CompileAPI usage where optimized_model_filepath and a
-    // virtual device is used. e.g. WebGPU.
-    // CompileAPI based usage saves the EPContext based model during partitioning (CreateEpContextModel) so never enters
-    // this block.
-    const bool skip_session_state_finalization =
-        session_options_.config_options.GetConfigOrDefault(kOrtSessionOptionCompileOnly, "0") == "1";
-
-    if (!skip_session_state_finalization) {
-      ORT_RETURN_IF_ERROR_SESSIONID_(
-          session_state_->FinalizeSessionState(model_location_, kernel_registry_manager_,
-                                               // need to keep the initializers if saving the optimized model
-                                               !saving_model,
-                                               saving_ort_format));
-    } else {
+    // Returning here also bypasses the model-save block below, because a compile-only session does not produce its
+    // output via optimized_model_filepath.
+    if (session_options_.config_options.GetConfigOrDefault(kOrtSessionOptionCompileOnly, "0") == "1") {
       LOGS(*session_logger_, INFO)
           << "Compile-only session: skipping session-state finalization. The session is not runnable; only the "
              "output model is produced.";
+      return common::Status::OK();
     }
+
+    ORT_RETURN_IF_ERROR_SESSIONID_(
+        session_state_->FinalizeSessionState(model_location_, kernel_registry_manager_,
+                                             // need to keep the initializers if saving the optimized model
+                                             !saving_model,
+                                             saving_ort_format));
 
 #if !defined(ORT_MINIMAL_BUILD)
     if (saving_model) {
@@ -2787,12 +2783,6 @@ common::Status InferenceSession::Initialize() {
                                                                              model_saving_options));
         }
       }
-    }
-
-    // Compile-only: exit here as the model is saved and everything past here is to setup a runnable session
-    // that would never be used.
-    if (skip_session_state_finalization) {
-      return common::Status::OK();
     }
 
     std::vector<TuningResults> tuning_results;

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -1694,9 +1694,6 @@ common::Status InferenceSession::TransformGraph(onnxruntime::Graph& graph, bool 
     }
   }
 #endif  // !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
-  // Capture the output-model generation options once so the same options are used whether the model is
-  // serialized at the partitioning boundary (EPContext model) or after the Level2+ optimizer loop below
-  // (plain optimized model).
   const epctx::ModelGenOptions ep_context_gen_options = session_options_.GetEpContextGenerationOptions();
 
   // Do partitioning based on execution providers' capabilities.
@@ -1713,6 +1710,35 @@ common::Status InferenceSession::TransformGraph(onnxruntime::Graph& graph, bool 
     layering_index_storage.reset();
   }
 #endif  // !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
+
+  // Decide whether we need to emit the plain optimized (non-EPContext) output model for a compile-only
+  // session that compiled no nodes (the kGenerateModel case, e.g. a non-compiling EP such as WebGPU;
+  // Partition() serialized only the EPContext form). If so, honor action_if_no_compiled_nodes: the compile
+  // API uses kReturnError or kGenerateModel (kDontGenerateModel never reaches a compile-only session).
+  //
+  // The error is returned regardless of level. For kGenerateModel the serialization point is chosen by the
+  // requested optimization level so the output matches what a plain (non-compile) session would produce:
+  //   - level < Level2 (includes the Compile API's Default): serialize here, before the Level2+ loop and the
+  //     InsertCast/Memcpy transformers below - a BASIC snapshot identical to the graph at the partition
+  //     boundary (no Cast, no Memcpy nodes), unchanged from prior behavior.
+  //   - level >= Level2 (explicitly requested): serialize after the loop and Memcpy insertion below, so the
+  //     emitted model captures the Level2-Level4 fusions (and the device-placement copy nodes).
+  const bool emit_plain_optimized_model =
+      session_options_.config_options.GetConfigOrDefault(kOrtSessionOptionCompileOnly, "0") == "1" &&
+      ep_context_gen_options.enable && !partitioner.AnyEpContextNodesProduced();
+  if (emit_plain_optimized_model) {
+    using ActionIfNoCompiledNodes = epctx::ModelGenOptions::ActionIfNoCompiledNodes;
+    if (ep_context_gen_options.action_if_no_compiled_nodes == ActionIfNoCompiledNodes::kReturnError) {
+      ORT_RETURN_IF_ERROR_SESSIONID_(
+          ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
+                          "Unable to compile any nodes. Check that the session EPs support compilation "
+                          "and can execute at least one subgraph in the model."));
+    }
+    if (session_options_.graph_optimization_level < TransformerLevel::Level2) {
+      ORT_RETURN_IF_ERROR_SESSIONID_(
+          epctx::BuildAndSaveOptimizedModel(*model_, ep_context_gen_options, *session_logger_));
+    }
+  }
 
   // Get graph optimizations loop level from session config, if not present, set to default value of 1 as per
   // the definition of kOrtSessionOptionsGraphOptimizationsLoopLevel.
@@ -1780,31 +1806,6 @@ common::Status InferenceSession::TransformGraph(onnxruntime::Graph& graph, bool 
     }
   }
 
-#if !defined(ORT_MINIMAL_BUILD)
-  // Emit the plain optimized (non-EPContext) output model for a compile-only session that compiled no
-  // nodes (the kGenerateModel case, e.g. WebGPU). Partition() serialized only the EPContext form; this
-  // runs after the Level2+ loop so those optimizations are captured, and before the copy-node insertion
-  // so memcpy nodes aren't baked in. Initializers are still present (FinalizeSessionState runs later).
-  const bool is_compile_only =
-      session_options_.config_options.GetConfigOrDefault(kOrtSessionOptionCompileOnly, "0") == "1";
-  if (is_compile_only && ep_context_gen_options.enable && !partitioner.AnyEpContextNodesProduced()) {
-    // No nodes compiled: honor action_if_no_compiled_nodes (the compile API uses kReturnError or
-    // kGenerateModel; kDontGenerateModel never reaches a compile-only session).
-    using ActionIfNoCompiledNodes = epctx::ModelGenOptions::ActionIfNoCompiledNodes;
-    const auto action_if_no_compiled_nodes = ep_context_gen_options.action_if_no_compiled_nodes;
-    ORT_RETURN_IF_ERROR_SESSIONID_(
-        (action_if_no_compiled_nodes == ActionIfNoCompiledNodes::kReturnError
-             ? ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
-                               "Unable to compile any nodes. Check that the session EPs support compilation "
-                               "and can execute at least one subgraph in the model.")
-             : Status::OK()));
-    if (action_if_no_compiled_nodes == ActionIfNoCompiledNodes::kGenerateModel) {
-      ORT_RETURN_IF_ERROR_SESSIONID_(
-          epctx::BuildAndSaveOptimizedModel(*model_, ep_context_gen_options, *session_logger_));
-    }
-  }
-#endif  // !defined(ORT_MINIMAL_BUILD)
-
   // Insert copy node/s.
   {
     InlinedVector<gsl::not_null<const IExecutionProvider*>> providers;
@@ -1815,6 +1816,20 @@ common::Status InferenceSession::TransformGraph(onnxruntime::Graph& graph, bool 
     MemcpyTransformer copy_transformer{std::move(providers), kernel_registry_manager_};
     ORT_RETURN_IF_ERROR_SESSIONID_(apply_transformer_once(copy_transformer, *session_logger_, graph));
   }
+
+#if !defined(ORT_MINIMAL_BUILD)
+  // Second serialization point for the plain optimized (non-EPContext) output model. Reached only for an
+  // explicitly requested level >= Level2 (level < Level2 was already serialized before the loop above). This
+  // runs after the Level2+ loop and the copy-node insertion, so the emitted model reflects the fully
+  // transformed graph the session runs - the Level2-Level4 fusions plus the device-placement Memcpy nodes.
+  // action_if_no_compiled_nodes was already handled before the loop (kReturnError returned there), so only
+  // kGenerateModel reaches here.
+  if (emit_plain_optimized_model &&
+      session_options_.graph_optimization_level >= TransformerLevel::Level2) {
+    ORT_RETURN_IF_ERROR_SESSIONID_(
+        epctx::BuildAndSaveOptimizedModel(*model_, ep_context_gen_options, *session_logger_));
+  }
+#endif  // !defined(ORT_MINIMAL_BUILD)
 
 #ifdef ENABLE_TRAINING
   // Enable memory optimizations.

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -24,6 +24,7 @@
 #include "core/framework/bfc_arena.h"
 #include "core/framework/error_code_helper.h"
 #include "core/framework/device_stream_collection.h"
+#include "core/framework/ep_context_utils.h"
 #include "core/framework/execution_frame.h"
 #include "core/framework/feeds_fetches_manager.h"
 #include "core/framework/graph_partitioner.h"
@@ -1693,10 +1694,15 @@ common::Status InferenceSession::TransformGraph(onnxruntime::Graph& graph, bool 
     }
   }
 #endif  // !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
+  // Capture the output-model generation options once so the same options are used whether the model is
+  // serialized at the partitioning boundary (EPContext model) or after the Level2+ optimizer loop below
+  // (plain optimized model).
+  const epctx::ModelGenOptions ep_context_gen_options = session_options_.GetEpContextGenerationOptions();
+
   // Do partitioning based on execution providers' capabilities.
   ORT_RETURN_IF_ERROR_SESSIONID_(partitioner.Partition(graph, session_state_->GetMutableFuncMgr(), transform_layout_fn,
                                                        session_options_.config_options, *session_logger_, layering_index,
-                                                       mode, session_options_.GetEpContextGenerationOptions(), debug_graph_fn));
+                                                       mode, ep_context_gen_options, debug_graph_fn));
 
 #if !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
   if (layering_index) {
@@ -1773,6 +1779,31 @@ common::Status InferenceSession::TransformGraph(onnxruntime::Graph& graph, bool 
       break;
     }
   }
+
+#if !defined(ORT_MINIMAL_BUILD)
+  // Emit the plain optimized (non-EPContext) output model for a compile-only session that compiled no
+  // nodes (the kGenerateModel case, e.g. WebGPU). Partition() serialized only the EPContext form; this
+  // runs after the Level2+ loop so those optimizations are captured, and before the copy-node insertion
+  // so memcpy nodes aren't baked in. Initializers are still present (FinalizeSessionState runs later).
+  const bool is_compile_only =
+      session_options_.config_options.GetConfigOrDefault(kOrtSessionOptionCompileOnly, "0") == "1";
+  if (is_compile_only && ep_context_gen_options.enable && !partitioner.AnyEpContextNodesProduced()) {
+    // No nodes compiled: honor action_if_no_compiled_nodes (the compile API uses kReturnError or
+    // kGenerateModel; kDontGenerateModel never reaches a compile-only session).
+    using ActionIfNoCompiledNodes = epctx::ModelGenOptions::ActionIfNoCompiledNodes;
+    const auto action_if_no_compiled_nodes = ep_context_gen_options.action_if_no_compiled_nodes;
+    ORT_RETURN_IF_ERROR_SESSIONID_(
+        (action_if_no_compiled_nodes == ActionIfNoCompiledNodes::kReturnError
+             ? ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
+                               "Unable to compile any nodes. Check that the session EPs support compilation "
+                               "and can execute at least one subgraph in the model.")
+             : Status::OK()));
+    if (action_if_no_compiled_nodes == ActionIfNoCompiledNodes::kGenerateModel) {
+      ORT_RETURN_IF_ERROR_SESSIONID_(
+          epctx::BuildAndSaveOptimizedModel(*model_, ep_context_gen_options, *session_logger_));
+    }
+  }
+#endif  // !defined(ORT_MINIMAL_BUILD)
 
   // Insert copy node/s.
   {

--- a/onnxruntime/core/session/inference_session.h
+++ b/onnxruntime/core/session/inference_session.h
@@ -891,6 +891,18 @@ class InferenceSession {
   // graph partitioning is complete so node counts per EP are accurate.
   void PopulateEpDeviceInfo(const onnxruntime::Graph& graph);
 
+  // Logs the SessionCreation and initial EpDeviceUsage telemetry for the initialized session. Shared by the
+  // normal initialization path and the compile-only path (which otherwise skips session-state finalization).
+  void LogSessionCreationTelemetry(const onnxruntime::Graph& graph,
+                                   const std::string& model_weight_type,
+                                   const std::string& model_graph_hash,
+                                   const std::string& model_weight_hash);
+
+  // Records the profiling event and telemetry marking the end of session initialization (profiler event,
+  // OnSessionInitializationEnd for each EP, and SessionCreationEnd). Shared by the normal initialization path
+  // and the compile-only early-return path. Returns status updated with any error from OnSessionInitializationEnd.
+  common::Status RecordSessionCreationEndTelemetry(const TimePoint& tp, common::Status status);
+
 #ifdef _WIN32
   static void LogAllSessions();
 #endif

--- a/onnxruntime/core/session/plugin_ep/ep_factory_webgpu.cc
+++ b/onnxruntime/core/session/plugin_ep/ep_factory_webgpu.cc
@@ -9,11 +9,20 @@
 #include "core/session/abi_devices.h"
 #include "core/session/abi_logger.h"
 #include "core/session/abi_session_options_impl.h"
+#include "core/session/onnxruntime_ep_device_ep_metadata_keys.h"
+#include "core/session/onnxruntime_session_options_config_keys.h"
 #include "core/session/plugin_ep/ep_api.h"
 #include "core/session/plugin_ep/ep_factory_internal.h"
 #include "core/session/ort_apis.h"
 
 namespace onnxruntime {
+
+WebGpuEpFactory::~WebGpuEpFactory() {
+  if (virtual_hw_device_ != nullptr) {
+    OrtExecutionProviderApi::ReleaseHardwareDevice(virtual_hw_device_);
+    virtual_hw_device_ = nullptr;
+  }
+}
 
 OrtStatus* WebGpuEpFactory::GetSupportedDevices(EpFactoryInternal& ep_factory,
                                                 const OrtHardwareDevice* const* devices,
@@ -34,10 +43,30 @@ OrtStatus* WebGpuEpFactory::GetSupportedDevices(EpFactoryInternal& ep_factory,
     }
   }
 
+  // If the environment allows virtual devices, register a virtual GPU EP device (vendor/device id 0) so
+  // the WebGPU EP stays selectable for a device-free compile-only session on hosts where OS device
+  // enumeration finds no GPU (e.g. a Win32k-lockdown sandbox). It is offered *in addition* to any real
+  // GPU device, so the device-free path remains exercisable on a host that also has a real GPU. Since
+  // allow_virtual_devices is opt-in, normal (real GPU) usage is unaffected.
+  if (allow_virtual_devices_ && num_ep_devices < max_ep_devices) {
+    OrtKeyValuePairs* hw_metadata = nullptr;
+    OrtApis::CreateKeyValuePairs(&hw_metadata);
+    OrtApis::AddKeyValuePair(hw_metadata, kOrtHardwareDevice_MetadataKey_IsVirtual, "1");
+    OrtStatus* status = OrtExecutionProviderApi::CreateHardwareDevice(
+        OrtHardwareDeviceType::OrtHardwareDeviceType_GPU, /*vendor_id=*/0, /*device_id=*/0,
+        /*vendor_name=*/"Microsoft", hw_metadata, &virtual_hw_device_);
+    OrtApis::ReleaseKeyValuePairs(hw_metadata);  // ORT makes a copy
+    ORT_API_RETURN_IF_ERROR(status);
+
+    ORT_API_RETURN_IF_ERROR(OrtExecutionProviderApi::CreateEpDevice(&ep_factory, virtual_hw_device_,
+                                                                    nullptr, nullptr,
+                                                                    &ep_devices[num_ep_devices++]));
+  }
+
   return nullptr;
 }
 
-OrtStatus* WebGpuEpFactory::CreateIExecutionProvider(const OrtHardwareDevice* const* /*devices*/,
+OrtStatus* WebGpuEpFactory::CreateIExecutionProvider(const OrtHardwareDevice* const* devices,
                                                      const OrtKeyValuePairs* const* /*ep_metadata_pairs*/,
                                                      size_t num_devices,
                                                      const OrtSessionOptions* session_options,
@@ -48,6 +77,20 @@ OrtStatus* WebGpuEpFactory::CreateIExecutionProvider(const OrtHardwareDevice* co
   if (num_devices != 1) {
     return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT,
                                  "WebGPU EP factory currently only supports one device at a time.");
+  }
+
+  // A virtual GPU device has no real GPU behind it, so it can only back a device-free compile-only session
+  // (see the concept map in webgpu_context.cc). Reject the invalid combination up front with a clear message
+  // instead of letting Dawn fail obscurely when it later tries to create a device.
+  const bool compile_only =
+      session_options->value.config_options.GetConfigOrDefault(kOrtSessionOptionCompileOnly, "0") == "1";
+  const auto& device_metadata = devices[0]->metadata.Entries();
+  const bool selected_virtual_device = device_metadata.count(kOrtHardwareDevice_MetadataKey_IsVirtual) != 0;
+  if (selected_virtual_device && !compile_only) {
+    return OrtApis::CreateStatus(
+        ORT_INVALID_ARGUMENT,
+        "WebGPU EP was selected on a virtual GPU device, which has no real GPU behind it and can only serve "
+        "a compile-only session (session.compile_only=1). Select a real GPU device to run inference.");
   }
 
   auto webgpu_ep_factory = WebGpuProviderFactoryCreator::Create(session_options->value.config_options);

--- a/onnxruntime/core/session/plugin_ep/ep_factory_webgpu.h
+++ b/onnxruntime/core/session/plugin_ep/ep_factory_webgpu.h
@@ -12,8 +12,16 @@ namespace onnxruntime {
 
 class WebGpuEpFactory : public EpFactoryInternalImpl {
  public:
-  WebGpuEpFactory() : EpFactoryInternalImpl(kWebGpuExecutionProvider, "Microsoft", OrtDevice::VendorIds::MICROSOFT) {
+  // allow_virtual_devices is captured at construction (from the OrtEnv config "allow_virtual_devices")
+  // rather than queried from the OrtEnv singleton inside GetSupportedDevices: internal EPs are
+  // registered while the OrtEnv creation mutex is already held on this thread, so querying the singleton
+  // there would self-deadlock.
+  explicit WebGpuEpFactory(bool allow_virtual_devices)
+      : EpFactoryInternalImpl(kWebGpuExecutionProvider, "Microsoft", OrtDevice::VendorIds::MICROSOFT),
+        allow_virtual_devices_{allow_virtual_devices} {
   }
+
+  ~WebGpuEpFactory() override;
 
  private:
   OrtStatus* GetSupportedDevices(EpFactoryInternal& ep_factory,
@@ -22,6 +30,15 @@ class WebGpuEpFactory : public EpFactoryInternalImpl {
                                  OrtEpDevice** ep_devices,
                                  size_t max_ep_devices,
                                  size_t* p_num_ep_devices) noexcept override;
+
+  const bool allow_virtual_devices_;
+
+  // Owned virtual GPU hardware device created on demand by GetSupportedDevices when the environment
+  // allows virtual devices (OrtEnv config "allow_virtual_devices"=1) and no real GPU device was
+  // discovered -- e.g. in a sandboxed process where OS device enumeration is unavailable (such as
+  // Win32k lockdown), so ORT device discovery is skipped. Released in the destructor. nullptr when
+  // no virtual device was made.
+  OrtHardwareDevice* virtual_hw_device_ = nullptr;
 
   OrtStatus* CreateIExecutionProvider(const OrtHardwareDevice* const* devices,
                                       const OrtKeyValuePairs* const* ep_metadata_pairs,

--- a/onnxruntime/core/session/plugin_ep/ep_library_internal.cc
+++ b/onnxruntime/core/session/plugin_ep/ep_library_internal.cc
@@ -24,14 +24,14 @@ std::unique_ptr<EpLibraryInternal> EpLibraryInternal::CreateDmlEp() {
 #endif
 
 #if defined(USE_WEBGPU) && !defined(ORT_USE_EP_API_ADAPTERS)
-std::unique_ptr<EpLibraryInternal> EpLibraryInternal::CreateWebGpuEp() {
-  auto webgpu_factory_impl = std::make_unique<WebGpuEpFactory>();
+std::unique_ptr<EpLibraryInternal> EpLibraryInternal::CreateWebGpuEp(bool allow_virtual_devices) {
+  auto webgpu_factory_impl = std::make_unique<WebGpuEpFactory>(allow_virtual_devices);
   auto internal_factory = std::make_unique<EpFactoryInternal>(std::move(webgpu_factory_impl));
   return std::make_unique<EpLibraryInternal>(std::move(internal_factory));
 }
 #endif
 
-std::vector<std::unique_ptr<EpLibraryInternal>> EpLibraryInternal::CreateInternalEps() {
+std::vector<std::unique_ptr<EpLibraryInternal>> EpLibraryInternal::CreateInternalEps(bool allow_virtual_devices) {
   std::vector<std::unique_ptr<EpLibraryInternal>> internal_eps;
   internal_eps.reserve(4);
 
@@ -39,7 +39,9 @@ std::vector<std::unique_ptr<EpLibraryInternal>> EpLibraryInternal::CreateInterna
   internal_eps.push_back(CreateCpuEp());
 
 #if defined(USE_WEBGPU) && !defined(ORT_USE_EP_API_ADAPTERS)
-  internal_eps.push_back(CreateWebGpuEp());
+  internal_eps.push_back(CreateWebGpuEp(allow_virtual_devices));
+#else
+  ORT_UNUSED_PARAMETER(allow_virtual_devices);
 #endif
 
 #if defined(USE_DML)

--- a/onnxruntime/core/session/plugin_ep/ep_library_internal.h
+++ b/onnxruntime/core/session/plugin_ep/ep_library_internal.h
@@ -39,8 +39,9 @@ class EpLibraryInternal : public EpLibrary {
 
   ORT_DISALLOW_COPY_AND_ASSIGNMENT(EpLibraryInternal);
 
-  // create instances for all internal EPs included in this build.
-  static std::vector<std::unique_ptr<EpLibraryInternal>> CreateInternalEps();
+  // create instances for all internal EPs included in this build. allow_virtual_devices is forwarded to
+  // the WebGPU EP factory (the only internal EP that can register a virtual device); see CreateWebGpuEp.
+  static std::vector<std::unique_ptr<EpLibraryInternal>> CreateInternalEps(bool allow_virtual_devices);
 
  private:
   static std::unique_ptr<EpLibraryInternal> CreateCpuEp();
@@ -48,7 +49,7 @@ class EpLibraryInternal : public EpLibrary {
   static std::unique_ptr<EpLibraryInternal> CreateDmlEp();
 #endif
 #if defined(USE_WEBGPU) && !defined(ORT_USE_EP_API_ADAPTERS)
-  static std::unique_ptr<EpLibraryInternal> CreateWebGpuEp();
+  static std::unique_ptr<EpLibraryInternal> CreateWebGpuEp(bool allow_virtual_devices);
 #endif
 
   std::unique_ptr<EpFactoryInternal> factory_;  // all internal EPs register a single factory currently

--- a/onnxruntime/test/framework/inference_session_test.cc
+++ b/onnxruntime/test/framework/inference_session_test.cc
@@ -45,6 +45,18 @@
 #include "core/providers/tensorrt/tensorrt_provider_options.h"
 #endif
 #include "core/session/allocator_adapters.h"
+#include "core/framework/config_options.h"
+#if defined(USE_WEBGPU) && !defined(ORT_USE_EP_API_ADAPTERS)
+#include "core/session/abi_devices.h"
+#include "core/session/plugin_ep/ep_api.h"
+#include "core/session/plugin_ep/ep_factory_internal.h"
+#include "core/session/plugin_ep/ep_factory_webgpu.h"
+#include "core/providers/webgpu/allocator.h"
+#endif
+// Virtual-device metadata key: used by the built-in WebGPU factory tests and the plugin WebGPU end-to-end test.
+#if (defined(USE_WEBGPU) && !defined(ORT_USE_EP_API_ADAPTERS)) || defined(ORT_UNIT_TEST_HAS_WEBGPU_PLUGIN_EP)
+#include "core/session/onnxruntime_ep_device_ep_metadata_keys.h"
+#endif
 #include "core/session/environment.h"
 #include "core/session/IOBinding.h"
 #include "core/session/inference_session_utils.h"
@@ -328,6 +340,313 @@ TEST(InferenceSessionTests, TestModelSerialization) {
   ASSERT_TRUE(session_object_emptyValidation.Load(test_model).IsOK());
   ASSERT_TRUE(session_object_emptyValidation.Initialize().IsOK());
 }
+
+#if defined(USE_WEBGPU)
+// A compile-only session (as marked by the Compile API via kOrtSessionOptionCompileOnly) that uses the
+// WebGPU EP stops session initialization right after graph transformation/partitioning, before
+// session-state finalization (kernel creation, PrePack, memory planning). This validates the new
+// control flow: (1) Initialize() succeeds, (2) optimized_model_filepath is still serialized and the
+// produced model is valid ONNX (loadable and runnable), and (3) Run() fails because the session was
+// never finalized. The WebGPU EP is created device-free (compile-only), so this does not require a GPU.
+TEST(InferenceSessionTests, WebGpuCompileOnlySkipsFinalization) {
+  // Create a device-free WebGPU EP: with kOrtSessionOptionCompileOnly set, the WebGPU context skips
+  // Dawn adapter/device creation, so this runs on machines without a GPU. Skip if WebGPU is not built
+  // or otherwise unavailable in this configuration.
+  ConfigOptions ep_config_options;
+  ASSERT_STATUS_OK(ep_config_options.AddConfigEntry(kOrtSessionOptionCompileOnly, "1"));
+  auto webgpu_ep = WebGpuExecutionProviderWithOptions(ep_config_options);
+  if (webgpu_ep == nullptr) {
+    GTEST_SKIP() << "WebGPU execution provider is not available.";
+  }
+
+  const std::basic_string<ORTCHAR_T> optimized_model_path = ORT_TSTR("webgpu_compile_only_optimized.onnx");
+  // Remove any stale file up front, and guarantee cleanup on every exit path (including a failed
+  // ASSERT_*, which returns from the test) so we never leave the serialized model behind.
+  std::filesystem::remove(optimized_model_path);
+  struct RemoveOnExit {
+    std::basic_string<ORTCHAR_T> path;
+    ~RemoveOnExit() { std::filesystem::remove(path); }
+  } remove_on_exit{optimized_model_path};
+
+  {
+    SessionOptions so;
+    so.session_logid = "InferenceSessionTests.WebGpuCompileOnlySkipsFinalization";
+    // The Compile API sets this internally to mark a compile-only session; set it directly here.
+    ASSERT_STATUS_OK(so.config_options.AddConfigEntry(kOrtSessionOptionCompileOnly, "1"));
+    so.optimized_model_filepath = optimized_model_path;
+
+    InferenceSession session_object{so, GetEnvironment()};
+    ASSERT_STATUS_OK(session_object.RegisterExecutionProvider(std::move(webgpu_ep)));
+    ASSERT_STATUS_OK(session_object.Load(MODEL_URI));
+
+    // Initialize succeeds, but skips session-state finalization.
+    ASSERT_STATUS_OK(session_object.Initialize());
+
+    // optimized_model_filepath must still be honored on the stop-before-finalize path.
+    ASSERT_TRUE(std::filesystem::exists(optimized_model_path));
+
+    // The session is not runnable: finalization was skipped, so Run() must fail (and not crash).
+    std::vector<int64_t> dims_x = {3, 2};
+    std::vector<float> values_x = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
+    OrtValue ml_value;
+    CreateMLValue<float>(TestCPUExecutionProvider()->CreatePreferredAllocators()[0], dims_x, values_x, &ml_value);
+    NameMLValMap feeds;
+    feeds.insert(std::make_pair("X", ml_value));
+    std::vector<std::string> output_names{"Y"};
+    std::vector<OrtValue> fetches;
+    RunOptions run_options;
+    // Run() must fail on a compile-only session that skipped session-state finalization.
+    const auto run_status = session_object.Run(run_options, feeds, output_names, &fetches);
+    ASSERT_STATUS_NOT_OK(run_status);
+  }
+
+  // The serialized optimized model must be valid ONNX: load and run it in a normal CPU session and
+  // verify it produces the expected output.
+  {
+    SessionOptions so;
+    so.session_logid = "InferenceSessionTests.WebGpuCompileOnlySkipsFinalization.Verify";
+    InferenceSession verify_session{so, GetEnvironment()};
+    ASSERT_STATUS_OK(verify_session.Load(optimized_model_path));
+    ASSERT_STATUS_OK(verify_session.Initialize());
+    RunOptions run_options;
+    RunModel(verify_session, run_options);
+  }
+}
+#endif  // defined(USE_WEBGPU)
+
+#if defined(USE_WEBGPU) && !defined(ORT_USE_EP_API_ADAPTERS)
+// The internal WebGPU EP factory registers a virtual GPU OrtEpDevice when the environment allows virtual
+// devices -- so the WebGPU EP stays selectable for a device-free compile-only session on hosts where OS
+// device enumeration finds no GPU (e.g. a Win32k-lockdown sandbox). The virtual device is offered in
+// addition to any real GPU, so the device-free path is still exercisable on a host that also has a GPU.
+// GetSupportedDevices is called directly with a controlled hardware-device list so all three cases are
+// deterministic, independent of whether the test machine actually has a GPU.
+TEST(InferenceSessionTests, WebGpuEpFactoryVirtualDevice) {
+  constexpr size_t kMaxEpDevices = 4;
+
+  // allow_virtual_devices = true, no hardware devices -> exactly one virtual GPU EP device.
+  {
+    EpFactoryInternal factory(std::make_unique<WebGpuEpFactory>(/*allow_virtual_devices=*/true));
+    OrtEpDevice* ep_devices[kMaxEpDevices] = {nullptr};
+    size_t num_ep_devices = 0;
+    OrtStatus* status = factory.GetSupportedDevices(/*devices=*/nullptr, /*num_devices=*/0,
+                                                    ep_devices, kMaxEpDevices, &num_ep_devices);
+    ASSERT_EQ(status, nullptr);
+    ASSERT_EQ(num_ep_devices, 1u);
+
+    const OrtEpDevice* ep_device = ep_devices[0];
+    EXPECT_EQ(ep_device->ep_name, kWebGpuExecutionProvider);
+    ASSERT_NE(ep_device->device, nullptr);
+    EXPECT_EQ(ep_device->device->type, OrtHardwareDeviceType_GPU);
+    EXPECT_EQ(ep_device->device->vendor_id, 0u);
+
+    const auto& metadata = ep_device->device->metadata.Entries();
+    auto is_virtual = metadata.find(kOrtHardwareDevice_MetadataKey_IsVirtual);
+    ASSERT_NE(is_virtual, metadata.end());
+    EXPECT_EQ(is_virtual->second, "1");
+
+    OrtExecutionProviderApi::ReleaseEpDevice(ep_devices[0]);
+  }
+
+  // allow_virtual_devices = false, no hardware devices -> no virtual device registered.
+  {
+    EpFactoryInternal factory(std::make_unique<WebGpuEpFactory>(/*allow_virtual_devices=*/false));
+    OrtEpDevice* ep_devices[kMaxEpDevices] = {nullptr};
+    size_t num_ep_devices = 0;
+    OrtStatus* status = factory.GetSupportedDevices(/*devices=*/nullptr, /*num_devices=*/0,
+                                                    ep_devices, kMaxEpDevices, &num_ep_devices);
+    ASSERT_EQ(status, nullptr);
+    EXPECT_EQ(num_ep_devices, 0u);
+  }
+
+  // allow_virtual_devices = true, a real GPU is present -> the real device plus one virtual GPU device.
+  // This validates that the device-free path stays selectable/testable on a host that has a real GPU.
+  {
+    OrtHardwareDevice real_gpu{};
+    real_gpu.type = OrtHardwareDeviceType_GPU;
+    real_gpu.vendor_id = 0x8086;
+    real_gpu.device_id = 0x1234;
+    real_gpu.vendor = "TestVendor";
+    const OrtHardwareDevice* devices[] = {&real_gpu};
+
+    EpFactoryInternal factory(std::make_unique<WebGpuEpFactory>(/*allow_virtual_devices=*/true));
+    OrtEpDevice* ep_devices[kMaxEpDevices] = {nullptr};
+    size_t num_ep_devices = 0;
+    OrtStatus* status = factory.GetSupportedDevices(devices, /*num_devices=*/1,
+                                                    ep_devices, kMaxEpDevices, &num_ep_devices);
+    ASSERT_EQ(status, nullptr);
+    ASSERT_EQ(num_ep_devices, 2u);
+
+    // The real device is enumerated first, then the virtual device is appended.
+    const OrtEpDevice* real_ep_device = ep_devices[0];
+    EXPECT_EQ(real_ep_device->ep_name, kWebGpuExecutionProvider);
+    ASSERT_NE(real_ep_device->device, nullptr);
+    EXPECT_EQ(real_ep_device->device->vendor_id, 0x8086u);
+    EXPECT_EQ(real_ep_device->device->metadata.Entries().count(kOrtHardwareDevice_MetadataKey_IsVirtual), 0u);
+
+    const OrtEpDevice* virtual_ep_device = ep_devices[1];
+    EXPECT_EQ(virtual_ep_device->ep_name, kWebGpuExecutionProvider);
+    ASSERT_NE(virtual_ep_device->device, nullptr);
+    EXPECT_EQ(virtual_ep_device->device->type, OrtHardwareDeviceType_GPU);
+    EXPECT_EQ(virtual_ep_device->device->vendor_id, 0u);
+    const auto& metadata = virtual_ep_device->device->metadata.Entries();
+    auto is_virtual = metadata.find(kOrtHardwareDevice_MetadataKey_IsVirtual);
+    ASSERT_NE(is_virtual, metadata.end());
+    EXPECT_EQ(is_virtual->second, "1");
+
+    OrtExecutionProviderApi::ReleaseEpDevice(ep_devices[0]);
+    OrtExecutionProviderApi::ReleaseEpDevice(ep_devices[1]);
+  }
+}
+
+// A virtual GPU device has no real GPU behind it, so it can only back a device-free compile-only session.
+// Selecting it for a normal (non-compile-only) session must be rejected up front by the factory's
+// CreateIExecutionProvider, rather than being allowed through to fail obscurely when Dawn later tries to
+// create a device. (The accepted path -- device-free compile-only -- is covered by
+// WebGpuCompileOnlySkipsFinalization.)
+TEST(InferenceSessionTests, WebGpuEpFactoryRejectsVirtualDeviceWithoutCompileOnly) {
+  OrtHardwareDevice virtual_gpu{};
+  virtual_gpu.type = OrtHardwareDeviceType_GPU;
+  virtual_gpu.vendor = "Microsoft";
+  virtual_gpu.metadata.Add(kOrtHardwareDevice_MetadataKey_IsVirtual, "1");
+  const OrtHardwareDevice* devices[] = {&virtual_gpu};
+
+  EpFactoryInternal factory(std::make_unique<WebGpuEpFactory>(/*allow_virtual_devices=*/true));
+
+  Ort::SessionOptions session_options;  // no session.compile_only set -> a runnable (non-compile-only) session
+  const OrtSessionOptions* c_session_options = session_options;
+  std::unique_ptr<IExecutionProvider> ep;
+  // logger is unused on the rejection path (CreateIExecutionProvider returns before it is dereferenced).
+  OrtStatus* status = factory.CreateIExecutionProvider(devices, /*ep_metadata_pairs=*/nullptr, /*num_devices=*/1,
+                                                       c_session_options, /*logger=*/nullptr, &ep);
+  ASSERT_NE(status, nullptr);
+  Ort::Status ort_status{status};  // takes ownership; releases on scope exit
+  EXPECT_EQ(ort_status.GetErrorCode(), ORT_INVALID_ARGUMENT);
+  EXPECT_EQ(ep, nullptr);
+}
+
+// Directly validates that a device-free (compile-only) WebGPU EP hands out the no-op "dummy" allocator
+// instead of a real GpuBufferAllocator -- the allocator that a device-free session relies on (a real one
+// can't even be constructed without a Dawn device). The other WebGPU tests assert behavior (Initialize
+// succeeds, model serialized); this one asserts the allocator *type*, which is what device-free-ness comes
+// down to. Independent of whether the host has a GPU, since device-free is driven by compile_only.
+TEST(InferenceSessionTests, WebGpuCompileOnlyUsesNoOpAllocator) {
+  ConfigOptions ep_config_options;
+  ASSERT_STATUS_OK(ep_config_options.AddConfigEntry(kOrtSessionOptionCompileOnly, "1"));
+  auto webgpu_ep = WebGpuExecutionProviderWithOptions(ep_config_options);
+  if (webgpu_ep == nullptr) {
+    GTEST_SKIP() << "WebGPU execution provider is not available.";
+  }
+
+  bool found_noop_allocator = false;
+  for (const auto& allocator : webgpu_ep->CreatePreferredAllocators()) {
+    if (dynamic_cast<const webgpu::WebGpuNoOpAllocator*>(allocator.get()) != nullptr) {
+      found_noop_allocator = true;
+      break;
+    }
+  }
+  EXPECT_TRUE(found_noop_allocator)
+      << "A device-free (compile-only) WebGPU EP must hand out the no-op (dummy) device allocator.";
+}
+#endif  // defined(USE_WEBGPU) && !defined(ORT_USE_EP_API_ADAPTERS)
+
+#if defined(ORT_UNIT_TEST_HAS_WEBGPU_PLUGIN_EP)
+// End-to-end via the public V2 API in the *plugin* WebGPU build: select the virtual WebGPU OrtEpDevice and run a
+// compile-only session.
+//
+// Key requirement / setup: this test relies on test_main.cc registering the WebGPU plugin EP under a ".virtual"
+// registration name (see the ORT_UNIT_TEST_HAS_WEBGPU_PLUGIN_EP block there). ORT treats the ".virtual" suffix as a
+// request to auto-enable the env config "allow_virtual_devices" on the global ort_env, which is what makes the WebGPU
+// factory surface a virtual GPU OrtEpDevice. Because that registration is guaranteed in this build, the test fails
+// (rather than skips) if no virtual device is surfaced -- see the ASSERT_FALSE below. This is also why the test can
+// use the shared ort_env directly instead of recreating an OrtEnv.
+//
+// It exercises the accepted (device-free) path even on a host that has a real GPU: device-free is driven by
+// session.compile_only, not by which device is selected, so no Dawn device is created. (Built-in-EP coverage of the
+// same path: WebGpuCompileOnlySkipsFinalization, WebGpuEpFactoryVirtualDevice, WebGpuCompileOnlyUsesNoOpAllocator.)
+TEST(InferenceSessionTests, WebGpuVirtualDeviceCompileOnlyEndToEnd) {
+  // Pick the virtual WebGPU device (is_virtual=1). On a host with a real GPU the factory surfaces both a real and a
+  // virtual device; we deliberately select the virtual one.
+  std::vector<Ort::ConstEpDevice> selected;
+  for (const auto& ep_device : ort_env->GetEpDevices()) {
+    if (std::string(ep_device.EpName()) != kWebGpuExecutionProvider) {
+      continue;
+    }
+    const auto metadata = ep_device.Device().Metadata().GetKeyValuePairs();
+    const auto it = metadata.find(kOrtHardwareDevice_MetadataKey_IsVirtual);
+    if (it != metadata.end() && it->second == "1") {
+      selected.push_back(ep_device);
+      break;
+    }
+  }
+  // test_main.cc registers the WebGPU plugin EP with a ".virtual" name, which enables allow_virtual_devices, so a
+  // virtual device must be present in this build. Fail (not skip) if it isn't -- that's a regression in the
+  // virtual-device path, not an environment we should quietly tolerate.
+  ASSERT_FALSE(selected.empty())
+      << "Expected a virtual WebGPU EP device from test_main.cc's .virtual registration, but none was surfaced.";
+
+  const std::basic_string<ORTCHAR_T> optimized_model_path = ORT_TSTR("webgpu_virtual_compile_only_optimized.onnx");
+  std::filesystem::remove(optimized_model_path);
+  struct RemoveOnExit {
+    std::basic_string<ORTCHAR_T> path;
+    ~RemoveOnExit() { std::filesystem::remove(path); }
+  } remove_on_exit{optimized_model_path};
+
+  Ort::SessionOptions session_options;
+  // session-level compile_only (NOT an EP option) -> drives the device-free context and stop-before-finalize.
+  session_options.AddConfigEntry(kOrtSessionOptionCompileOnly, "1");
+  session_options.SetOptimizedModelFilePath(optimized_model_path.c_str());
+  Ort::KeyValuePairs ep_options;
+  session_options.AppendExecutionProvider_V2(*ort_env, selected, ep_options);
+
+  // Constructing the session runs Initialize(): compile_only -> device-free WebGPU context (no Dawn device even if
+  // the host has a GPU) -> finalization skipped. Must succeed and still serialize the optimized model.
+  Ort::Session session(*ort_env, MODEL_URI, session_options);
+  ASSERT_TRUE(std::filesystem::exists(optimized_model_path));
+}
+
+// Plugin-build counterpart of WebGpuEpFactoryRejectsVirtualDeviceWithoutCompileOnly (which drives the built-in
+// internal factory): selecting the virtual WebGPU device for a normal (non-compile-only) session must be rejected
+// up front by the *adapter* factory's CreateEp with ORT_INVALID_ARGUMENT, rather than proceeding into Dawn to fail
+// obscurely with no real GPU behind the virtual device. Exercises the adapter factory's copy of the enforcement
+// through the public V2 API. Depends on the same test_main.cc ".virtual" registration as
+// WebGpuVirtualDeviceCompileOnlyEndToEnd above (that's what surfaces the virtual device to select).
+TEST(InferenceSessionTests, WebGpuVirtualDeviceRejectedWithoutCompileOnly) {
+  std::vector<Ort::ConstEpDevice> selected;
+  for (const auto& ep_device : ort_env->GetEpDevices()) {
+    if (std::string(ep_device.EpName()) != kWebGpuExecutionProvider) {
+      continue;
+    }
+    const auto metadata = ep_device.Device().Metadata().GetKeyValuePairs();
+    const auto it = metadata.find(kOrtHardwareDevice_MetadataKey_IsVirtual);
+    if (it != metadata.end() && it->second == "1") {
+      selected.push_back(ep_device);
+      break;
+    }
+  }
+  // See WebGpuVirtualDeviceCompileOnlyEndToEnd: a virtual device must be present from test_main.cc's .virtual
+  // registration in this build, so fail (not skip) if none was surfaced.
+  ASSERT_FALSE(selected.empty())
+      << "Expected a virtual WebGPU EP device from test_main.cc's .virtual registration, but none was surfaced.";
+
+  // Deliberately NOT setting session.compile_only -> a runnable session on a virtual device, which must be rejected.
+  Ort::SessionOptions session_options;
+  Ort::KeyValuePairs ep_options;
+  session_options.AppendExecutionProvider_V2(*ort_env, selected, ep_options);
+
+  try {
+    // EP creation (adapter factory CreateEp) runs during session Initialize(); the rejection surfaces here.
+    Ort::Session session(*ort_env, MODEL_URI, session_options);
+    FAIL() << "Selecting a virtual GPU device without compile_only must fail EP creation.";
+  } catch (const Ort::Exception& ex) {
+    // The plugin provider-factory layer (ep_plugin_provider_interfaces.cc) re-wraps the factory's
+    // ORT_INVALID_ARGUMENT as ORT_FAIL, so assert on the distinctive message rather than the error code to confirm
+    // this is our virtual-device rejection and not some unrelated failure.
+    const std::string message = ex.what();
+    EXPECT_NE(message.find("virtual GPU device"), std::string::npos) << message;
+  }
+}
+#endif  // defined(ORT_UNIT_TEST_HAS_WEBGPU_PLUGIN_EP)
 
 TEST(InferenceSessionTests, RequestLoadCancellation) {
   {

--- a/onnxruntime/test/framework/inference_session_test.cc
+++ b/onnxruntime/test/framework/inference_session_test.cc
@@ -46,6 +46,7 @@
 #endif
 #include "core/session/allocator_adapters.h"
 #include "core/framework/config_options.h"
+#include "core/framework/ep_context_options.h"
 #if defined(USE_WEBGPU) && !defined(ORT_USE_EP_API_ADAPTERS)
 #include "core/session/abi_devices.h"
 #include "core/session/plugin_ep/ep_api.h"
@@ -3683,6 +3684,167 @@ TEST(InferenceSessionTests, SessionLoggerOutlivesEPsWithUserLoggingFunction) {
   ASSERT_TRUE(found_teardown_msg)
       << "Expected EP teardown log message not found via user_logging_function.";
 }
+
+#if !defined(ORT_MINIMAL_BUILD)
+// A compile-only session (Compile API path, marked by kOrtSessionOptionCompileOnly) whose EPs compile no
+// nodes emits a plain optimized output model *after* the Level2+ optimizer loop, so the serialized graph
+// reflects those fusions. This is EP-agnostic: the CPU EP compiles nothing, so the kGenerateModel path
+// serializes the optimized graph. bias_gelu_fusion.onnx fuses to com.microsoft.BiasGelu only at Level2
+// (BiasGeluFusion is Level2-only), so its presence in the emitted model proves the Level2 fusion reached
+// the output; at ORT_ENABLE_BASIC (Level1) it is absent because that fusion never runs.
+TEST(InferenceSessionTests, CompileOnlyToFileSerializesFullyOptimizedGraph) {
+  const std::string input_model = "testdata/transform/fusion/bias_gelu_fusion.onnx";
+
+  auto compile_and_count =
+      [&](TransformerLevel level,
+          const std::basic_string<ORTCHAR_T>& output_path) -> std::map<std::string, int> {
+    std::filesystem::remove(output_path);
+
+    SessionOptions so;
+    so.session_logid = "InferenceSessionTests.CompileOnlyToFileSerializesFullyOptimizedGraph";
+    so.graph_optimization_level = level;
+    // Mark a compile-only session (as the Compile API does internally).
+    EXPECT_STATUS_OK(so.config_options.AddConfigEntry(kOrtSessionOptionCompileOnly, "1"));
+
+    // Configure EPContext model generation to a file, mirroring the explicit Compile API: generate a
+    // model even when no nodes are compiled (the CPU EP compiles nothing, so the plain optimized graph
+    // is copied into the output model).
+    epctx::ModelGenOptions gen_options;
+    gen_options.enable = true;
+    gen_options.error_if_output_file_exists = false;
+    gen_options.action_if_no_compiled_nodes = epctx::ModelGenOptions::ActionIfNoCompiledNodes::kGenerateModel;
+    gen_options.output_model_location = std::filesystem::path(output_path);
+    so.ep_context_gen_options = gen_options;
+    so.has_explicit_ep_context_gen_options = true;
+
+    InferenceSession session{so, GetEnvironment()};
+    EXPECT_STATUS_OK(session.Load(input_model));
+    EXPECT_STATUS_OK(session.Initialize());
+
+    // Load the emitted model in a plain (non-optimizing) session and count ops on the serialized graph.
+    SessionOptions verify_so;
+    verify_so.graph_optimization_level = TransformerLevel::Default;  // do not re-optimize the emitted model
+    InferenceSessionWrapper verify{verify_so, GetEnvironment()};
+    EXPECT_STATUS_OK(verify.Load(output_path));
+    EXPECT_STATUS_OK(verify.Initialize());
+    return CountOpsInGraph(verify.GetGraph());
+  };
+
+  const std::basic_string<ORTCHAR_T> all_path = ORT_TSTR("compile_only_full_opt_all.onnx");
+  const std::basic_string<ORTCHAR_T> basic_path = ORT_TSTR("compile_only_full_opt_basic.onnx");
+  struct RemoveOnExit {
+    std::vector<std::basic_string<ORTCHAR_T>> paths;
+    ~RemoveOnExit() {
+      for (const auto& p : paths) std::filesystem::remove(p);
+    }
+  } remove_on_exit{{all_path, basic_path}};
+
+  // ORT_ENABLE_ALL: the Level2 BiasGelu fusion runs and must be captured in the emitted model.
+  const std::map<std::string, int> all_counts = compile_and_count(TransformerLevel::MaxLevel, all_path);
+  EXPECT_EQ(all_counts.count("com.microsoft.BiasGelu") ? all_counts.at("com.microsoft.BiasGelu") : 0, 1);
+
+  // ORT_ENABLE_BASIC (Level1): BiasGeluFusion is Level2-only, so it never runs and must be absent.
+  const std::map<std::string, int> basic_counts = compile_and_count(TransformerLevel::Level1, basic_path);
+  EXPECT_EQ(basic_counts.count("com.microsoft.BiasGelu") ? basic_counts.at("com.microsoft.BiasGelu") : 0, 0);
+}
+
+// Same as above, but emits the plain optimized model into an in-memory buffer (BufferHolder) instead of a
+// file. This mirrors the offline-compile flow, which serializes to a buffer rather than to disk, and
+// exercises the buffer branch of SaveModelProtoToLocation. The Level2 BiasGelu fusion must still be present
+// in the serialized bytes.
+TEST(InferenceSessionTests, CompileOnlyToBufferSerializesFullyOptimizedGraph) {
+  const std::string input_model = "testdata/transform/fusion/bias_gelu_fusion.onnx";
+
+  SessionOptions so;
+  so.session_logid = "InferenceSessionTests.CompileOnlyToBufferSerializesFullyOptimizedGraph";
+  so.graph_optimization_level = TransformerLevel::MaxLevel;  // ORT_ENABLE_ALL
+  EXPECT_STATUS_OK(so.config_options.AddConfigEntry(kOrtSessionOptionCompileOnly, "1"));
+
+  void* output_buffer = nullptr;
+  size_t output_buffer_size = 0;
+  AllocatorPtr cpu_allocator = std::make_shared<CPUAllocator>();
+
+  epctx::ModelGenOptions gen_options;
+  gen_options.enable = true;
+  gen_options.action_if_no_compiled_nodes = epctx::ModelGenOptions::ActionIfNoCompiledNodes::kGenerateModel;
+  epctx::BufferHolder buffer_holder;
+  buffer_holder.buffer_ptr = &output_buffer;
+  buffer_holder.buffer_size_ptr = &output_buffer_size;
+  buffer_holder.buffer_allocator = cpu_allocator;
+  gen_options.output_model_location = buffer_holder;
+  so.ep_context_gen_options = gen_options;
+  so.has_explicit_ep_context_gen_options = true;
+
+  {
+    InferenceSession session{so, GetEnvironment()};
+    EXPECT_STATUS_OK(session.Load(input_model));
+    EXPECT_STATUS_OK(session.Initialize());
+  }
+
+  ASSERT_NE(output_buffer, nullptr);
+  ASSERT_GT(output_buffer_size, 0u);
+
+  // Load the emitted model from the buffer in a plain (non-optimizing) session and count ops.
+  SessionOptions verify_so;
+  verify_so.graph_optimization_level = TransformerLevel::Default;  // do not re-optimize the emitted model
+  InferenceSessionWrapper verify{verify_so, GetEnvironment()};
+  EXPECT_STATUS_OK(verify.Load(output_buffer, static_cast<int>(output_buffer_size)));
+  EXPECT_STATUS_OK(verify.Initialize());
+  const std::map<std::string, int> counts = CountOpsInGraph(verify.GetGraph());
+  EXPECT_EQ(counts.count("com.microsoft.BiasGelu") ? counts.at("com.microsoft.BiasGelu") : 0, 1);
+
+  cpu_allocator->Free(output_buffer);
+}
+
+// OrtWriteBufferFunc that appends the written bytes to a std::string held in stream_state.
+static OrtStatus* ORT_API_CALL AppendToStringWriteFunc(void* stream_state, const void* buffer,
+                                                       size_t buffer_num_bytes) {
+  auto* sink = reinterpret_cast<std::string*>(stream_state);
+  sink->append(reinterpret_cast<const char*>(buffer), buffer_num_bytes);
+  return nullptr;  // No error
+}
+
+// Same as above, but emits the plain optimized model through a user write function (BufferWriteFuncHolder)
+// instead of a file, exercising the write-func branch of SaveModelProtoToLocation. The Level2 BiasGelu
+// fusion must still be present in the written bytes.
+TEST(InferenceSessionTests, CompileOnlyToWriteFuncSerializesFullyOptimizedGraph) {
+  const std::string input_model = "testdata/transform/fusion/bias_gelu_fusion.onnx";
+
+  SessionOptions so;
+  so.session_logid = "InferenceSessionTests.CompileOnlyToWriteFuncSerializesFullyOptimizedGraph";
+  so.graph_optimization_level = TransformerLevel::MaxLevel;  // ORT_ENABLE_ALL
+  EXPECT_STATUS_OK(so.config_options.AddConfigEntry(kOrtSessionOptionCompileOnly, "1"));
+
+  std::string sink;
+
+  epctx::ModelGenOptions gen_options;
+  gen_options.enable = true;
+  gen_options.action_if_no_compiled_nodes = epctx::ModelGenOptions::ActionIfNoCompiledNodes::kGenerateModel;
+  epctx::BufferWriteFuncHolder write_func_holder;
+  write_func_holder.write_func = AppendToStringWriteFunc;
+  write_func_holder.stream_state = &sink;
+  gen_options.output_model_location = write_func_holder;
+  so.ep_context_gen_options = gen_options;
+  so.has_explicit_ep_context_gen_options = true;
+
+  {
+    InferenceSession session{so, GetEnvironment()};
+    EXPECT_STATUS_OK(session.Load(input_model));
+    EXPECT_STATUS_OK(session.Initialize());
+  }
+
+  ASSERT_FALSE(sink.empty());
+
+  // Load the emitted model from the written bytes in a plain (non-optimizing) session and count ops.
+  SessionOptions verify_so;
+  verify_so.graph_optimization_level = TransformerLevel::Default;  // do not re-optimize the emitted model
+  InferenceSessionWrapper verify{verify_so, GetEnvironment()};
+  EXPECT_STATUS_OK(verify.Load(sink.data(), static_cast<int>(sink.size())));
+  EXPECT_STATUS_OK(verify.Initialize());
+  const std::map<std::string, int> counts = CountOpsInGraph(verify.GetGraph());
+  EXPECT_EQ(counts.count("com.microsoft.BiasGelu") ? counts.at("com.microsoft.BiasGelu") : 0, 1);
+}
+#endif  // !defined(ORT_MINIMAL_BUILD)
 
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/framework/inference_session_test.cc
+++ b/onnxruntime/test/framework/inference_session_test.cc
@@ -342,16 +342,12 @@ TEST(InferenceSessionTests, TestModelSerialization) {
 }
 
 #if defined(USE_WEBGPU)
-// A compile-only session (as marked by the Compile API via kOrtSessionOptionCompileOnly) that uses the
-// WebGPU EP stops session initialization right after graph transformation/partitioning, before
-// session-state finalization (kernel creation, PrePack, memory planning). This validates the new
-// control flow: (1) Initialize() succeeds, (2) optimized_model_filepath is still serialized and the
-// produced model is valid ONNX (loadable and runnable), and (3) Run() fails because the session was
-// never finalized. The WebGPU EP is created device-free (compile-only), so this does not require a GPU.
+// A compile-only session (kOrtSessionOptionCompileOnly) using the WebGPU EP stops before session-state
+// finalization. Validates: (1) Initialize() succeeds, and (2) Run() fails because the session was never
+// finalized.
 TEST(InferenceSessionTests, WebGpuCompileOnlySkipsFinalization) {
-  // Create a device-free WebGPU EP: with kOrtSessionOptionCompileOnly set, the WebGPU context skips
-  // Dawn adapter/device creation, so this runs on machines without a GPU. Skip if WebGPU is not built
-  // or otherwise unavailable in this configuration.
+  // Device-free WebGPU EP: kOrtSessionOptionCompileOnly makes the WebGPU context skip Dawn device
+  // creation. Skip the test if WebGPU is not built/available.
   ConfigOptions ep_config_options;
   ASSERT_STATUS_OK(ep_config_options.AddConfigEntry(kOrtSessionOptionCompileOnly, "1"));
   auto webgpu_ep = WebGpuExecutionProviderWithOptions(ep_config_options);
@@ -359,58 +355,31 @@ TEST(InferenceSessionTests, WebGpuCompileOnlySkipsFinalization) {
     GTEST_SKIP() << "WebGPU execution provider is not available.";
   }
 
-  const std::basic_string<ORTCHAR_T> optimized_model_path = ORT_TSTR("webgpu_compile_only_optimized.onnx");
-  // Remove any stale file up front, and guarantee cleanup on every exit path (including a failed
-  // ASSERT_*, which returns from the test) so we never leave the serialized model behind.
-  std::filesystem::remove(optimized_model_path);
-  struct RemoveOnExit {
-    std::basic_string<ORTCHAR_T> path;
-    ~RemoveOnExit() { std::filesystem::remove(path); }
-  } remove_on_exit{optimized_model_path};
+  SessionOptions so;
+  so.session_logid = "InferenceSessionTests.WebGpuCompileOnlySkipsFinalization";
+  // The Compile API sets this internally to mark a compile-only session; set it directly here.
+  ASSERT_STATUS_OK(so.config_options.AddConfigEntry(kOrtSessionOptionCompileOnly, "1"));
 
-  {
-    SessionOptions so;
-    so.session_logid = "InferenceSessionTests.WebGpuCompileOnlySkipsFinalization";
-    // The Compile API sets this internally to mark a compile-only session; set it directly here.
-    ASSERT_STATUS_OK(so.config_options.AddConfigEntry(kOrtSessionOptionCompileOnly, "1"));
-    so.optimized_model_filepath = optimized_model_path;
+  InferenceSession session_object{so, GetEnvironment()};
+  ASSERT_STATUS_OK(session_object.RegisterExecutionProvider(std::move(webgpu_ep)));
+  ASSERT_STATUS_OK(session_object.Load(MODEL_URI));
 
-    InferenceSession session_object{so, GetEnvironment()};
-    ASSERT_STATUS_OK(session_object.RegisterExecutionProvider(std::move(webgpu_ep)));
-    ASSERT_STATUS_OK(session_object.Load(MODEL_URI));
+  // Initialize succeeds, but skips session-state finalization.
+  ASSERT_STATUS_OK(session_object.Initialize());
 
-    // Initialize succeeds, but skips session-state finalization.
-    ASSERT_STATUS_OK(session_object.Initialize());
-
-    // optimized_model_filepath must still be honored on the stop-before-finalize path.
-    ASSERT_TRUE(std::filesystem::exists(optimized_model_path));
-
-    // The session is not runnable: finalization was skipped, so Run() must fail (and not crash).
-    std::vector<int64_t> dims_x = {3, 2};
-    std::vector<float> values_x = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
-    OrtValue ml_value;
-    CreateMLValue<float>(TestCPUExecutionProvider()->CreatePreferredAllocators()[0], dims_x, values_x, &ml_value);
-    NameMLValMap feeds;
-    feeds.insert(std::make_pair("X", ml_value));
-    std::vector<std::string> output_names{"Y"};
-    std::vector<OrtValue> fetches;
-    RunOptions run_options;
-    // Run() must fail on a compile-only session that skipped session-state finalization.
-    const auto run_status = session_object.Run(run_options, feeds, output_names, &fetches);
-    ASSERT_STATUS_NOT_OK(run_status);
-  }
-
-  // The serialized optimized model must be valid ONNX: load and run it in a normal CPU session and
-  // verify it produces the expected output.
-  {
-    SessionOptions so;
-    so.session_logid = "InferenceSessionTests.WebGpuCompileOnlySkipsFinalization.Verify";
-    InferenceSession verify_session{so, GetEnvironment()};
-    ASSERT_STATUS_OK(verify_session.Load(optimized_model_path));
-    ASSERT_STATUS_OK(verify_session.Initialize());
-    RunOptions run_options;
-    RunModel(verify_session, run_options);
-  }
+  // The session is not runnable: finalization was skipped, so Run() must fail (and not crash).
+  std::vector<int64_t> dims_x = {3, 2};
+  std::vector<float> values_x = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
+  OrtValue ml_value;
+  CreateMLValue<float>(TestCPUExecutionProvider()->CreatePreferredAllocators()[0], dims_x, values_x, &ml_value);
+  NameMLValMap feeds;
+  feeds.insert(std::make_pair("X", ml_value));
+  std::vector<std::string> output_names{"Y"};
+  std::vector<OrtValue> fetches;
+  RunOptions run_options;
+  // Run() must fail on a compile-only session that skipped session-state finalization.
+  const auto run_status = session_object.Run(run_options, feeds, output_names, &fetches);
+  ASSERT_STATUS_NOT_OK(run_status);
 }
 #endif  // defined(USE_WEBGPU)
 
@@ -525,11 +494,10 @@ TEST(InferenceSessionTests, WebGpuEpFactoryRejectsVirtualDeviceWithoutCompileOnl
   EXPECT_EQ(ep, nullptr);
 }
 
-// Directly validates that a device-free (compile-only) WebGPU EP hands out the no-op "dummy" allocator
-// instead of a real GpuBufferAllocator -- the allocator that a device-free session relies on (a real one
-// can't even be constructed without a Dawn device). The other WebGPU tests assert behavior (Initialize
-// succeeds, model serialized); this one asserts the allocator *type*, which is what device-free-ness comes
-// down to. Independent of whether the host has a GPU, since device-free is driven by compile_only.
+// A device-free (compile-only) WebGPU EP must hand out the no-op "dummy" allocator instead of a real
+// GpuBufferAllocator, which can't be constructed without a Dawn device. Asserts the allocator *type*, which
+// is what device-free-ness comes down to. Independent of the host GPU, since device-free is driven by
+// compile_only.
 TEST(InferenceSessionTests, WebGpuCompileOnlyUsesNoOpAllocator) {
   ConfigOptions ep_config_options;
   ASSERT_STATUS_OK(ep_config_options.AddConfigEntry(kOrtSessionOptionCompileOnly, "1"));
@@ -554,16 +522,11 @@ TEST(InferenceSessionTests, WebGpuCompileOnlyUsesNoOpAllocator) {
 // End-to-end via the public V2 API in the *plugin* WebGPU build: select the virtual WebGPU OrtEpDevice and run a
 // compile-only session.
 //
-// Key requirement / setup: this test relies on test_main.cc registering the WebGPU plugin EP under a ".virtual"
-// registration name (see the ORT_UNIT_TEST_HAS_WEBGPU_PLUGIN_EP block there). ORT treats the ".virtual" suffix as a
-// request to auto-enable the env config "allow_virtual_devices" on the global ort_env, which is what makes the WebGPU
-// factory surface a virtual GPU OrtEpDevice. Because that registration is guaranteed in this build, the test fails
-// (rather than skips) if no virtual device is surfaced -- see the ASSERT_FALSE below. This is also why the test can
-// use the shared ort_env directly instead of recreating an OrtEnv.
+// Relies on test_main.cc registering the WebGPU plugin EP under a ".virtual" name, whose suffix auto-enables the env
+// config "allow_virtual_devices" so the factory surfaces a virtual GPU OrtEpDevice.
 //
 // It exercises the accepted (device-free) path even on a host that has a real GPU: device-free is driven by
-// session.compile_only, not by which device is selected, so no Dawn device is created. (Built-in-EP coverage of the
-// same path: WebGpuCompileOnlySkipsFinalization, WebGpuEpFactoryVirtualDevice, WebGpuCompileOnlyUsesNoOpAllocator.)
+// session.compile_only, not by which device is selected, so no Dawn device is created.
 TEST(InferenceSessionTests, WebGpuVirtualDeviceCompileOnlyEndToEnd) {
   // Pick the virtual WebGPU device (is_virtual=1). On a host with a real GPU the factory surfaces both a real and a
   // virtual device; we deliberately select the virtual one.
@@ -579,30 +542,19 @@ TEST(InferenceSessionTests, WebGpuVirtualDeviceCompileOnlyEndToEnd) {
       break;
     }
   }
-  // test_main.cc registers the WebGPU plugin EP with a ".virtual" name, which enables allow_virtual_devices, so a
-  // virtual device must be present in this build. Fail (not skip) if it isn't -- that's a regression in the
-  // virtual-device path, not an environment we should quietly tolerate.
+  // A virtual device must be present in this build (test_main.cc's ".virtual" registration enables it).
   ASSERT_FALSE(selected.empty())
       << "Expected a virtual WebGPU EP device from test_main.cc's .virtual registration, but none was surfaced.";
-
-  const std::basic_string<ORTCHAR_T> optimized_model_path = ORT_TSTR("webgpu_virtual_compile_only_optimized.onnx");
-  std::filesystem::remove(optimized_model_path);
-  struct RemoveOnExit {
-    std::basic_string<ORTCHAR_T> path;
-    ~RemoveOnExit() { std::filesystem::remove(path); }
-  } remove_on_exit{optimized_model_path};
 
   Ort::SessionOptions session_options;
   // session-level compile_only (NOT an EP option) -> drives the device-free context and stop-before-finalize.
   session_options.AddConfigEntry(kOrtSessionOptionCompileOnly, "1");
-  session_options.SetOptimizedModelFilePath(optimized_model_path.c_str());
   Ort::KeyValuePairs ep_options;
   session_options.AppendExecutionProvider_V2(*ort_env, selected, ep_options);
 
   // Constructing the session runs Initialize(): compile_only -> device-free WebGPU context (no Dawn device even if
-  // the host has a GPU) -> finalization skipped. Must succeed and still serialize the optimized model.
+  // the host has a GPU) -> finalization skipped. Must succeed on a host with no real GPU behind the virtual device.
   Ort::Session session(*ort_env, MODEL_URI, session_options);
-  ASSERT_TRUE(std::filesystem::exists(optimized_model_path));
 }
 
 // Plugin-build counterpart of WebGpuEpFactoryRejectsVirtualDeviceWithoutCompileOnly (which drives the built-in

--- a/onnxruntime/test/framework/inference_session_test.cc
+++ b/onnxruntime/test/framework/inference_session_test.cc
@@ -3686,6 +3686,15 @@ TEST(InferenceSessionTests, SessionLoggerOutlivesEPsWithUserLoggingFunction) {
 }
 
 #if !defined(ORT_MINIMAL_BUILD)
+// OrtWriteBufferFunc that appends the written bytes to a std::string held in stream_state.
+static OrtStatus* ORT_API_CALL AppendToStringWriteFunc(void* stream_state, const void* buffer,
+                                                       size_t buffer_num_bytes) {
+  auto* sink = reinterpret_cast<std::string*>(stream_state);
+  sink->append(reinterpret_cast<const char*>(buffer), buffer_num_bytes);
+  return nullptr;  // No error
+}
+
+#if !defined(DISABLE_CONTRIB_OPS)
 // A compile-only session (Compile API path, marked by kOrtSessionOptionCompileOnly) whose EPs compile no
 // nodes emits a plain optimized output model. The serialization point is chosen by the requested level:
 // for level >= Level2 it is emitted *after* the Level2+ optimizer loop so the serialized graph reflects
@@ -3799,14 +3808,6 @@ TEST(InferenceSessionTests, CompileOnlyToBufferSerializesFullyOptimizedGraph) {
   cpu_allocator->Free(output_buffer);
 }
 
-// OrtWriteBufferFunc that appends the written bytes to a std::string held in stream_state.
-static OrtStatus* ORT_API_CALL AppendToStringWriteFunc(void* stream_state, const void* buffer,
-                                                       size_t buffer_num_bytes) {
-  auto* sink = reinterpret_cast<std::string*>(stream_state);
-  sink->append(reinterpret_cast<const char*>(buffer), buffer_num_bytes);
-  return nullptr;  // No error
-}
-
 // Same as above, but emits the plain optimized model through a user write function (BufferWriteFuncHolder)
 // instead of a file, exercising the write-func branch of SaveModelProtoToLocation. The Level2 BiasGelu
 // fusion must still be present in the written bytes.
@@ -3847,6 +3848,136 @@ TEST(InferenceSessionTests, CompileOnlyToWriteFuncSerializesFullyOptimizedGraph)
   const std::map<std::string, int> counts = CountOpsInGraph(verify.GetGraph());
   EXPECT_EQ(counts.count("com.microsoft.BiasGelu") ? counts.at("com.microsoft.BiasGelu") : 0, 1);
 }
+#endif  // !defined(DISABLE_CONTRIB_OPS)
+
+// Unlike the tests above (which set the compile-only config directly on an InferenceSession), the tests below
+// exercise the public Compile API (Ort::ModelCompilationOptions + Ort::CompileModel) end-to-end and verify the
+// emitted output is a plain optimized ONNX model (no EPContext nodes). A CPU-only (non-compiling) EP is enough.
+
+// Loads a serialized model into a non-optimizing session and returns its node op-type counts, so a test can
+// inspect the emitted graph without re-optimizing it. Keys are domain-qualified (e.g. "com.microsoft.BiasGelu").
+static std::map<std::string, int> CountOpsInEmittedModel(const std::basic_string<ORTCHAR_T>& model_path) {
+  SessionOptions verify_so;
+  verify_so.graph_optimization_level = TransformerLevel::Default;  // do not re-optimize the emitted model
+  InferenceSessionWrapper verify{verify_so, GetEnvironment()};
+  EXPECT_STATUS_OK(verify.Load(model_path));
+  EXPECT_STATUS_OK(verify.Initialize());
+  return CountOpsInGraph(verify.GetGraph());
+}
+
+static std::map<std::string, int> CountOpsInEmittedModel(const void* model_data, size_t model_data_len) {
+  SessionOptions verify_so;
+  verify_so.graph_optimization_level = TransformerLevel::Default;  // do not re-optimize the emitted model
+  InferenceSessionWrapper verify{verify_so, GetEnvironment()};
+  EXPECT_STATUS_OK(verify.Load(model_data, static_cast<int>(model_data_len)));
+  EXPECT_STATUS_OK(verify.Initialize());
+  return CountOpsInGraph(verify.GetGraph());
+}
+
+// Public Compile API -> plain optimized ONNX written to a file: no EPContext nodes, and reloadable.
+TEST(InferenceSessionTests, CompileApiOutputsPlainOnnxToFile) {
+  const std::basic_string<ORTCHAR_T> output_path = ORT_TSTR("compile_api_plain_output.onnx");
+  std::filesystem::remove(output_path);
+  struct RemoveOnExit {
+    std::basic_string<ORTCHAR_T> path;
+    ~RemoveOnExit() { std::filesystem::remove(path); }
+  } remove_on_exit{output_path};
+
+  Ort::SessionOptions session_options;
+  Ort::ModelCompilationOptions compile_options(*ort_env, session_options);
+  compile_options.SetInputModelPath(MODEL_URI);
+  compile_options.SetOutputModelPath(output_path.c_str());
+
+  const Ort::Status status = Ort::CompileModel(*ort_env, compile_options);
+  ASSERT_TRUE(status.IsOK()) << status.GetErrorMessage();
+  ASSERT_TRUE(std::filesystem::exists(output_path));
+
+  const std::map<std::string, int> counts = CountOpsInEmittedModel(output_path);
+  EXPECT_EQ(counts.count("com.microsoft.EPContext") ? counts.at("com.microsoft.EPContext") : 0, 0)
+      << "Compile API plain output must not contain EPContext nodes.";
+  EXPECT_GT(counts.count("Mul") ? counts.at("Mul") : 0, 0);
+}
+
+// Public Compile API -> plain optimized ONNX in an in-memory buffer (the offline/sandboxed-process path with
+// no filesystem): no EPContext nodes.
+TEST(InferenceSessionTests, CompileApiOutputsPlainOnnxToBuffer) {
+  Ort::SessionOptions session_options;
+  Ort::ModelCompilationOptions compile_options(*ort_env, session_options);
+  compile_options.SetInputModelPath(MODEL_URI);
+
+  Ort::AllocatorWithDefaultOptions allocator;
+  void* output_buffer = nullptr;
+  size_t output_size = 0;
+  compile_options.SetOutputModelBuffer(allocator, &output_buffer, &output_size);
+
+  const Ort::Status status = Ort::CompileModel(*ort_env, compile_options);
+  ASSERT_TRUE(status.IsOK()) << status.GetErrorMessage();
+  ASSERT_NE(output_buffer, nullptr);
+  ASSERT_GT(output_size, 0u);
+
+  const std::map<std::string, int> counts = CountOpsInEmittedModel(output_buffer, output_size);
+  EXPECT_EQ(counts.count("com.microsoft.EPContext") ? counts.at("com.microsoft.EPContext") : 0, 0)
+      << "Compile API plain output must not contain EPContext nodes.";
+  EXPECT_GT(counts.count("Mul") ? counts.at("Mul") : 0, 0);
+
+  allocator.Free(output_buffer);
+}
+
+// Public Compile API -> plain optimized ONNX through a user write function: no EPContext nodes.
+TEST(InferenceSessionTests, CompileApiOutputsPlainOnnxToWriteFunc) {
+  std::string sink;
+  Ort::SessionOptions session_options;
+  Ort::ModelCompilationOptions compile_options(*ort_env, session_options);
+  compile_options.SetInputModelPath(MODEL_URI);
+  compile_options.SetOutputModelWriteFunc(AppendToStringWriteFunc, &sink);
+
+  const Ort::Status status = Ort::CompileModel(*ort_env, compile_options);
+  ASSERT_TRUE(status.IsOK()) << status.GetErrorMessage();
+  ASSERT_FALSE(sink.empty());
+
+  const std::map<std::string, int> counts = CountOpsInEmittedModel(sink.data(), sink.size());
+  EXPECT_EQ(counts.count("com.microsoft.EPContext") ? counts.at("com.microsoft.EPContext") : 0, 0)
+      << "Compile API plain output must not contain EPContext nodes.";
+  EXPECT_GT(counts.count("Mul") ? counts.at("Mul") : 0, 0);
+}
+
+#if !defined(DISABLE_CONTRIB_OPS)
+// The public Compile API honors SetGraphOptimizationLevel for the plain output model. bias_gelu_fusion.onnx
+// fuses to com.microsoft.BiasGelu only at Level2+, so it is present when ORT_ENABLE_ALL is requested and
+// absent at the default level (the Compile API defaults to no graph optimizations).
+TEST(InferenceSessionTests, CompileApiOutputHonorsOptimizationLevel) {
+  const ORTCHAR_T* input_model_path = ORT_TSTR("testdata/transform/fusion/bias_gelu_fusion.onnx");
+
+  auto compile_to_buffer_counts = [&](bool enable_all) -> std::map<std::string, int> {
+    Ort::SessionOptions session_options;
+    Ort::ModelCompilationOptions compile_options(*ort_env, session_options);
+    compile_options.SetInputModelPath(input_model_path);
+    if (enable_all) {
+      compile_options.SetGraphOptimizationLevel(ORT_ENABLE_ALL);
+    }
+    Ort::AllocatorWithDefaultOptions allocator;
+    void* output_buffer = nullptr;
+    size_t output_size = 0;
+    compile_options.SetOutputModelBuffer(allocator, &output_buffer, &output_size);
+
+    EXPECT_TRUE(Ort::CompileModel(*ort_env, compile_options).IsOK());
+    std::map<std::string, int> counts;
+    if (output_buffer != nullptr && output_size > 0) {
+      counts = CountOpsInEmittedModel(output_buffer, output_size);
+      allocator.Free(output_buffer);
+    }
+    return counts;
+  };
+
+  // ORT_ENABLE_ALL: the Level2 BiasGelu fusion runs and must be captured in the emitted model.
+  const std::map<std::string, int> all_counts = compile_to_buffer_counts(/*enable_all=*/true);
+  EXPECT_EQ(all_counts.count("com.microsoft.BiasGelu") ? all_counts.at("com.microsoft.BiasGelu") : 0, 1);
+
+  // Default level (no optimizations): the Level2-only fusion must be absent.
+  const std::map<std::string, int> default_counts = compile_to_buffer_counts(/*enable_all=*/false);
+  EXPECT_EQ(default_counts.count("com.microsoft.BiasGelu") ? default_counts.at("com.microsoft.BiasGelu") : 0, 0);
+}
+#endif  // !defined(DISABLE_CONTRIB_OPS)
 #endif  // !defined(ORT_MINIMAL_BUILD)
 
 }  // namespace test

--- a/onnxruntime/test/framework/inference_session_test.cc
+++ b/onnxruntime/test/framework/inference_session_test.cc
@@ -3687,11 +3687,14 @@ TEST(InferenceSessionTests, SessionLoggerOutlivesEPsWithUserLoggingFunction) {
 
 #if !defined(ORT_MINIMAL_BUILD)
 // A compile-only session (Compile API path, marked by kOrtSessionOptionCompileOnly) whose EPs compile no
-// nodes emits a plain optimized output model *after* the Level2+ optimizer loop, so the serialized graph
-// reflects those fusions. This is EP-agnostic: the CPU EP compiles nothing, so the kGenerateModel path
-// serializes the optimized graph. bias_gelu_fusion.onnx fuses to com.microsoft.BiasGelu only at Level2
-// (BiasGeluFusion is Level2-only), so its presence in the emitted model proves the Level2 fusion reached
-// the output; at ORT_ENABLE_BASIC (Level1) it is absent because that fusion never runs.
+// nodes emits a plain optimized output model. The serialization point is chosen by the requested level:
+// for level >= Level2 it is emitted *after* the Level2+ optimizer loop so the serialized graph reflects
+// those fusions; for level < Level2 it is emitted before the loop (a BASIC snapshot). This is EP-agnostic:
+// the CPU EP compiles nothing, so the kGenerateModel path serializes the optimized graph.
+// bias_gelu_fusion.onnx fuses to com.microsoft.BiasGelu only at Level2 (BiasGeluFusion is Level2-only), so
+// its presence in the emitted model proves the Level2 fusion reached the output; at ORT_ENABLE_BASIC
+// (Level1) it is absent because that fusion never runs. The two cases below therefore exercise both
+// serialization points (after-loop for ENABLE_ALL, before-loop for BASIC).
 TEST(InferenceSessionTests, CompileOnlyToFileSerializesFullyOptimizedGraph) {
   const std::string input_model = "testdata/transform/fusion/bias_gelu_fusion.onnx";
 

--- a/onnxruntime/test/unittest_main/test_main.cc
+++ b/onnxruntime/test/unittest_main/test_main.cc
@@ -119,6 +119,25 @@ extern "C" void ortenv_setup() {
       }
 #endif
 
+#if defined(ORT_UNIT_TEST_HAS_WEBGPU_PLUGIN_EP) && defined(ORT_UNIT_TEST_WEBGPU_PLUGIN_EP_LIBRARY_PATH)
+      if (!dynamic_plugin_ep_config_json.has_value()) {
+        // Register with a ".virtual" suffix so ORT auto-sets env config "allow_virtual_devices"=1, letting
+        // the WebGPU factory surface a virtual GPU device. Its only purpose here is to give
+        // dynamic_plugin_ep_infra::Initialize() (below) a selectable WebGPU device so the binary doesn't
+        // exit at startup when GetEpDevices() would otherwise be empty (no real GPU). It does not make
+        // non-compile-only WebGPU tests runnable without a device: the virtual device only backs device-free
+        // compile-only sessions, and a real GPU, when present, is enumerated first and preferred (see the
+        // resize(1) de-dup in test_dynamic_plugin_ep.cc).
+        dynamic_plugin_ep_config_json.emplace(
+            "{\n"
+            "  \"ep_library_registration_name\": \"WebGpuExecutionProvider.virtual\",\n"
+            "  \"ep_library_path\": \"" ORT_UNIT_TEST_WEBGPU_PLUGIN_EP_LIBRARY_PATH
+            "\",\n"
+            "  \"selected_ep_name\": \"WebGpuExecutionProvider\"\n"
+            "}");
+      }
+#endif
+
       if (dynamic_plugin_ep_config_json.has_value()) {
         std::cout << "Initializing dynamic plugin EP infrastructure with configuration:\n"
                   << *dynamic_plugin_ep_config_json << "\n";

--- a/onnxruntime/test/unittest_util/test_dynamic_plugin_ep.cc
+++ b/onnxruntime/test/unittest_util/test_dynamic_plugin_ep.cc
@@ -136,7 +136,12 @@ Status Initialize(Ort::Env& env, InitializationConfig config) {
                    return ep_device.EpName() == selected_ep_name;
                  });
 
-    if (config.selected_ep_name == kCudaExecutionProviderPluginName && selected_c_ep_devices.size() > 1) {
+    // Some EP factories create a provider for a single device at a time yet can surface more than one
+    // OrtEpDevice under the same EP name (e.g. multiple CUDA GPUs, or WebGPU's real + virtual GPU when
+    // virtual devices are enabled). Keep the first match for those.
+    if ((config.selected_ep_name == kCudaExecutionProviderPluginName ||
+         config.selected_ep_name == kWebGpuExecutionProviderPluginName) &&
+        selected_c_ep_devices.size() > 1) {
       selected_c_ep_devices.resize(1);
     }
   }

--- a/onnxruntime/test/unittest_util/test_dynamic_plugin_ep.h
+++ b/onnxruntime/test/unittest_util/test_dynamic_plugin_ep.h
@@ -31,6 +31,7 @@ namespace test {
 namespace dynamic_plugin_ep_infra {
 
 inline constexpr std::string_view kCudaExecutionProviderPluginName{"CUDAExecutionProvider"};
+inline constexpr std::string_view kWebGpuExecutionProviderPluginName{"WebGpuExecutionProvider"};
 
 // Note: `Initialize()` and `Shutdown()` are not thread-safe.
 // They should be called before and after calls to most of the other functions in this namespace.


### PR DESCRIPTION
### Description

Enable a compile-only session to run graph transformation (optimization + partitioning) and serialize
the optimized model **without creating a device or touching hardware**. This supports offline /
ahead-of-time compilation, where the optimized model is produced in a device-free (or sandboxed)
process and executed later in a separate device-capable process. The serialized output reflects the
requested graph-optimization level, including L2–L4 fusions.

The feature targets WebGPU offline compilation and is driven by the Compile API's existing internal
`session.compile_only` (`kOrtSessionOptionCompileOnly`) — **no new public config key**. The WebGPU-specific
parts are the device-free context, the no-op allocator, and the virtual device; two of the mechanisms are
EP-agnostic Compile-API improvements that benefit any EP: skipping session-state finalization (and returning
early) for a compile-only session, and capturing the requested optimization level in the generated model.

### Changes

* **Device-free WebGPU context** (`webgpu_provider_factory.cc`, `webgpu_context.cc/.h`): in a
  compile-only session, skip Dawn adapter/device creation and all device-dependent init. `HasDevice()`
  exposes whether a real device exists; the mechanical "device-free" concept stays separate from the
  session concept "compile-only".
* **Stop-before-finalize** (`inference_session.cc`): a compile-only session skips
  `FinalizeSessionState()` (kernel creation, initializer upload, memory planning — all need a device
  and are wasted for a throwaway session) and returns **before** the `optimized_model_filepath`
  save block. Its output is produced during graph transformation, not via that block.
* **Capture the requested optimization level in the output** (`inference_session.cc`,
  `graph_partitioner.cc/.h`, `ep_context_utils.cc/.h`): the plain (non-EPContext) optimized model is
  serialized *after* the L2–L4 optimizer passes, so the emitted graph reflects the requested level
  (previously it was frozen at the partition boundary, before L2–L4). Serialization point is chosen by
  level: before the loop for `< Level2`, after all transforms for `>= Level2`. This is a general
  Compile-API fix; it does not change the output of compiling EPs, whose optimization lives in the
  EPContext blob.
* **No-op allocator for device-free contexts** (`allocator.cc/.h`): every device-allocator construction
  site hands out `WebGpuNoOpAllocator` when there is no device, so ORT never builds a real allocator
  without one.
* **Virtual GPU device** (`ep/factory.cc/.h`, internal `WebGpuEpFactory`): when no GPU
  `OrtHardwareDevice` is discovered and `allow_virtual_devices=1`, register a virtual GPU `OrtEpDevice`
  so the WebGPU EP stays selectable on hosts where device enumeration is unavailable (e.g. a sandbox).
* **Build: delay-load `user32.dll`** (`cmake/onnxruntime.cmake`,
  `cmake/onnxruntime_providers_webgpu.cmake`) so the EP loads where `user32.dll` is unavailable but
  never actually needed (device discovery skipped).

### Tests (`test/framework/inference_session_test.cc`)

* Device-free compile-only session: `Initialize()` succeeds, `Run()` fails (non-runnable); no-op
  allocator handed out; virtual-device registration is deterministic with or without a GPU.
* Plain optimized output through the **public Compile API** (`Ort::ModelCompilationOptions` +
  `Ort::CompileModel`) for the file, in-memory buffer, and user-write-func targets: asserts the emitted
  model is plain ONNX with no EPContext nodes, and that the requested optimization level is reflected in
  the output.

### Motivation and Context

Since the WebNN Compiler process is sandboxed, graph compilation within it must be offline /
device-free: the untrusted model is parsed and graph-transformed in a low-privilege, device-free
process, and the resulting model is executed later in a separate device-ful process. This is a
**security** offload — it keeps untrusted-graph processing out of the high-privilege GPU process.