### PR TITLE
Fix GroupQueryAttentionFusion crash on ONNX-domain RotaryEmbedding

### DIFF
--- a/onnxruntime/core/optimizer/group_query_attention_fusion.cc
+++ b/onnxruntime/core/optimizer/group_query_attention_fusion.cc
@@ -334,7 +334,8 @@ Status GroupQueryAttentionFusion::ApplyImpl(
     for (auto pre_gqa_node = node.InputNodesBegin(); pre_gqa_node != node.InputNodesEnd(); ++pre_gqa_node) {
       Node& rotary_or_v_node = *graph.GetNode(pre_gqa_node->Index());
 
-      if (rotary_or_v_node.OpType() == "RotaryEmbedding") {
+      // The ONNX-domain (opset 23) RotaryEmbedding has a different input layout; only match the contrib op.
+      if (rotary_or_v_node.OpType() == "RotaryEmbedding" && rotary_or_v_node.Domain() == kMSDomain) {
         if (!rotary_node_1) {
           rotary_node_1 = &rotary_or_v_node;
         } else {

--- a/onnxruntime/test/optimizer/graph_transform_test_layernorm.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test_layernorm.cc
@@ -1141,6 +1141,44 @@ TEST_F(GraphTransformationTests, GroupQueryAttentionFusionTest) {
   TestGQAFusion(MODEL_FOLDER "fusion/gqa_fusion_quantized_different_head_sizes.onnx", 1, 0, logger_.get());
 }
 
+// The fusion must skip the ONNX-domain (opset 23) RotaryEmbedding: its input layout differs from
+// the contrib op's, and its position_ids input is optional (issue #28604).
+TEST_F(GraphTransformationTests, GroupQueryAttentionFusionSkipsOnnxDomainRotaryEmbedding) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    auto fp16_input = [&](std::vector<int64_t> shape) {
+      return builder.MakeInput<MLFloat16>(shape, MLFloat16(-1.0f), MLFloat16(1.0f));
+    };
+    NodeArg* cos_cache = builder.MakeInitializer<MLFloat16>({8, 2}, MLFloat16(1.0f), MLFloat16(1.0f));
+    NodeArg* sin_cache = builder.MakeInitializer<MLFloat16>({8, 2}, MLFloat16(1.0f), MLFloat16(1.0f));
+    NodeArg* q = builder.MakeIntermediate<MLFloat16>(std::vector<int64_t>{1, 1, 8});
+    builder.AddNode("RotaryEmbedding", {fp16_input({1, 1, 8}), cos_cache, sin_cache}, {q})
+        .AddAttribute("num_heads", static_cast<int64_t>(2));
+
+    Node& gqa = builder.AddNode(
+        "GroupQueryAttention",
+        {q, fp16_input({1, 1, 4}), fp16_input({1, 1, 4}), fp16_input({1, 1, 4, 4}), fp16_input({1, 1, 4, 4}),
+         builder.MakeInput<int32_t>(std::vector<int64_t>{1}, std::vector<int32_t>{0}),
+         builder.MakeInput<int32_t>(std::vector<int64_t>{1}, std::vector<int32_t>{1})},
+        {builder.MakeOutput<MLFloat16>(std::vector<int64_t>{1, 1, 8}),
+         builder.MakeOutput<MLFloat16>(std::vector<int64_t>{1, 1, 4, 4}),
+         builder.MakeOutput<MLFloat16>(std::vector<int64_t>{1, 1, 4, 4})},
+        kMSDomain);
+    gqa.AddAttribute("num_heads", static_cast<int64_t>(2));
+    gqa.AddAttribute("kv_num_heads", static_cast<int64_t>(1));
+  };
+
+  auto post_graph_checker = [](Graph& graph) {
+    auto op_count = CountOpsInGraph(graph);
+    TEST_RETURN_IF_NOT(op_count["RotaryEmbedding"] == 1);
+    TEST_RETURN_IF_NOT(op_count["com.microsoft.GroupQueryAttention"] == 1);
+    return Status::OK();
+  };
+
+  ASSERT_STATUS_OK(TestGraphTransformer(build_test_case, 23, *logger_,
+                                        std::make_unique<GroupQueryAttentionFusion>(),
+                                        TransformerLevel::Level2, 1, nullptr, post_graph_checker));
+}
+
 TEST_F(GraphTransformationTests, SkipLayerNormFusionWithCastTest) {
   TestSkipLayerNormFusion(MODEL_FOLDER "fusion/skip_layer_norm_format1_with_cast.onnx", 0, 0, 1, 3, logger_.get());
   TestSkipLayerNormFusion(MODEL_FOLDER "fusion/skip_layer_norm_format2_with_cast.onnx", 0, 0, 1, 3, logger_.get());


### PR DESCRIPTION
### Description

`GroupQueryAttentionFusion` matches GQA input producers by `OpType() == "RotaryEmbedding"` without a domain check, and reads `InputDefs()[2]`/`[3]` assuming the contrib signature `(input, position_ids, cos_cache, sin_cache)`. The ONNX-domain opset-23 op is `(X, cos_cache, sin_cache, position_ids?)`, so a spec-valid 3-input node reads out of bounds — aborting session init on builds with `_GLIBCXX_ASSERTIONS` (e.g. nightly wheels), silent UB otherwise.

Fix: require `Domain() == kMSDomain`, so the fusion skips ONNX-domain graphs instead of misreading them. Adds a regression test that aborts without the fix.

### Motivation and Context

Fixes #28604 (repro and analysis: https://github.com/microsoft/onnxruntime/issues/28604#issuecomment-4966897664). #29524/#29552 concern a different defect in this function and are not changed here.

*Developed with AI assistance (Claude Code); reviewed by the author.*