### PR TITLE
[CUDA] Update cuda arch list for packages of cuda 12.8

### DIFF
--- a/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines.yml
+++ b/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines.yml
@@ -95,7 +95,7 @@ variables:
     value: $(Agent.TempDirectory)\9.14.0.64_cuda13
 - name: CudaArchs
   ${{ if eq(parameters.CudaVersion, '12.8') }}:
-    value: '75-real;86-real;89-real;90-virtual'
+    value: '61-real;75-real;86-real;89-real;120-real;120-virtual'
   ${{ if eq(parameters.CudaVersion, '13.0') }}:
     value: '75-real;80-real;86-real;89-real;90-real;100-real;120-real;120-virtual'
 

--- a/tools/ci_build/github/azure-pipelines/custom-nuget-packaging-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/custom-nuget-packaging-pipeline.yml
@@ -34,7 +34,7 @@ variables:
       value: $(Agent.TempDirectory)\v13.0
   - name: CmakeCudaArchitectures
     ${{ if eq(parameters.CudaVersion, '12.8') }}:
-      value: 52-real;61-real;75-real;86-real;89-real;90-virtual
+      value: 61-real;75-real;86-real;89-real;120-real;120-virtual
     ${{ if eq(parameters.CudaVersion, '13.0') }}:
       value: 75-real;80-real;86-real;89-real;90-real;100-real;120-real;120-virtual
 

--- a/tools/ci_build/github/azure-pipelines/plugin-cuda-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/plugin-cuda-pipeline.yml
@@ -133,7 +133,7 @@ extends:
             ${{ if eq(parameters.cuda_version, '12.8') }}:
               python_package_name: 'onnxruntime-ep-cuda12'
               docker_base_image: 'onnxruntimebuildcache.azurecr.io/internal/azureml/onnxruntime/build/cuda12_x64_almalinux8_gcc14:20251017.1'
-              cmake_cuda_archs: '52-real;61-real;75-real;86-real;89-real;90-virtual'
+              cmake_cuda_archs: '61-real;75-real;86-real;89-real;120-real;120-virtual'
             ${{ if eq(parameters.cuda_version, '13.0') }}:
               python_package_name: 'onnxruntime-ep-cuda13'
               docker_base_image: 'onnxruntimebuildcache.azurecr.io/internal/azureml/onnxruntime/build/cuda13_x64_almalinux8_gcc14:20251107.1'

--- a/tools/ci_build/github/azure-pipelines/py-cuda-packaging-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/py-cuda-packaging-pipeline.yml
@@ -64,5 +64,5 @@ extends:
           cmake_build_type: ${{ parameters.cmake_build_type }}
           cuda_version: '12.8'
           cudnn_folder: ''
-          cmake_cuda_archs: '52-real;61-real;75-real;86-real;89-real;90-virtual'
+          cmake_cuda_archs: '61-real;75-real;86-real;89-real;120-real;120-virtual'
           docker_base_image: 'onnxruntimebuildcache.azurecr.io/internal/azureml/onnxruntime/build/cuda12_x64_almalinux8_gcc14:20251017.1'

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-cuda-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-cuda-packaging-stage.yml
@@ -54,7 +54,7 @@ parameters:
 - name: cmake_cuda_archs
   type: string
   displayName: 'CMAKE_CUDA_ARCHITECTURES'
-  default: '52-real;61-real;75-real;86-real;89-real;90-virtual'
+  default: '61-real;75-real;86-real;89-real;120-real;120-virtual'
 
 - name: python_version
   type: string

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-linux-cuda-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-linux-cuda-stage.yml
@@ -43,7 +43,7 @@ parameters:
 
 - name: cmake_cuda_archs
   type: string
-  default: '52-real;61-real;75-real;86-real;89-real;90-virtual'
+  default: '61-real;75-real;86-real;89-real;120-real;120-virtual'
 
 - name: python_version
   type: string

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-win-cuda-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-win-cuda-stage.yml
@@ -28,7 +28,7 @@ parameters:
 
 - name: cmake_cuda_archs
   type: string
-  default: '52-real;61-real;75-real;86-real;89-real;90-virtual'
+  default: '61-real;75-real;86-real;89-real;120-real;120-virtual'
 
 stages:
   - stage: Win_plugin_cuda_x64_Build

--- a/tools/ci_build/github/linux/build_cuda_c_api_package.sh
+++ b/tools/ci_build/github/linux/build_cuda_c_api_package.sh
@@ -2,7 +2,7 @@
 set -e -x
 
 if [ "$CUDA_VERSION" == "12.8" ]; then
-    CUDA_ARCHS="60-real;70-real;75-real;80-real;90a-real;90-virtual"
+    CUDA_ARCHS="60-real;70-real;75-real;80-real;86-real;90-real;120-real;120-virtual"
 elif [ "$CUDA_VERSION" == "13.0" ]; then
     CUDA_ARCHS="75-real;80-real;86-real;89-real;90-real;100-real;120-real;120-virtual"
 else

--- a/tools/ci_build/github/linux/build_linux_python_package.sh
+++ b/tools/ci_build/github/linux/build_linux_python_package.sh
@@ -71,7 +71,7 @@ fi
 
 if [ "$BUILD_DEVICE" == "GPU" ]; then
     if [ "$CUDA_VERSION" == "12.8" ]; then
-        CUDA_ARCHS="60-real;70-real;75-real;80-real;86-real;90a-real;90-virtual"
+        CUDA_ARCHS="60-real;70-real;75-real;80-real;86-real;90-real;120-real;120-virtual"
     elif [ "$CUDA_VERSION" == "13.0" ]; then
         CUDA_ARCHS="75-real;80-real;86-real;89-real;90-real;100-real;120-real;120-virtual"
     else

--- a/tools/ci_build/github/linux/build_nodejs_package.sh
+++ b/tools/ci_build/github/linux/build_nodejs_package.sh
@@ -2,7 +2,7 @@
 set -e -x
 
 if [ "$CUDA_VERSION" == "12.8" ]; then
-    CUDA_ARCHS="60-real;70-real;75-real;80-real;90a-real;90-virtual"
+    CUDA_ARCHS="60-real;70-real;75-real;80-real;86-real;90-real;120-real;120-virtual"
 elif [ "$CUDA_VERSION" == "13.0" ]; then
     CUDA_ARCHS="75-real;80-real;86-real;89-real;90-real;100-real;120-real;120-virtual"
 else

--- a/tools/ci_build/github/linux/build_tensorrt_c_api_package.sh
+++ b/tools/ci_build/github/linux/build_tensorrt_c_api_package.sh
@@ -2,7 +2,7 @@
 set -e -x
 
 if [ "$CUDA_VERSION" == "12.8" ]; then
-    CUDA_ARCHS="60-real;70-real;75-real;80-real;90a-real;90-virtual"
+    CUDA_ARCHS="60-real;70-real;75-real;80-real;86-real;90-real;120-real;120-virtual"
 elif [ "$CUDA_VERSION" == "13.0" ]; then
     CUDA_ARCHS="75-real;80-real;86-real;89-real;90-real;100-real;120-real;120-virtual"
 else


### PR DESCRIPTION
Drop 52-real; 90-virtual
Add 120-real; 120-virtual
Ensure 86-real is included

Q: Why not add 90-real and 100-real to cuda 12.8 build?
A: We assume that those machines will have cuda 13.x for best performance.

Q: Why drops 52-real
A: Many applications require float16 support, while 52-real cannot support it.