### PR TITLE
Extend memory importer with host pointer support

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -1059,10 +1059,11 @@ typedef void (*RunAsyncCallbackFn)(void* user_data, OrtValue** outputs, size_t n
  * \since Version 1.24.
  */
 typedef enum OrtExternalMemoryHandleType {
-  ORT_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_RESOURCE = 0,      /**< Shared HANDLE from ID3D12Device::CreateSharedHandle(resource) */
-  ORT_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_HEAP = 1,          /**< Shared HANDLE from ID3D12Device::CreateSharedHandle(heap) */
-  ORT_EXTERNAL_MEMORY_HANDLE_TYPE_VK_MEMORY_WIN32 = 2,     /**< Shared HANDLE from vkGetMemoryWin32HandleKHR, non-dedicated allocation */
-  ORT_EXTERNAL_MEMORY_HANDLE_TYPE_VK_MEMORY_OPAQUE_FD = 3, /**< File descriptor from vkGetMemoryOpaqueFdKHR, non-dedicated allocation */
+  ORT_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_RESOURCE = 0,   /**< Shared HANDLE from ID3D12Device::CreateSharedHandle(resource) */
+  ORT_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_HEAP = 1,       /**< Shared HANDLE from ID3D12Device::CreateSharedHandle(heap) */
+  ORT_EXTERNAL_MEMORY_HANDLE_TYPE_MEMORY_WIN32 = 2,     /**< Shared HANDLE from vkGetMemoryWin32HandleKHR or clGetMemObjectInfo with CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_WIN32_KHR, non-dedicated allocation */
+  ORT_EXTERNAL_MEMORY_HANDLE_TYPE_MEMORY_OPAQUE_FD = 3, /**< File descriptor from vkGetMemoryOpaqueFdKHR or clGetMemObjectInfo with CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_FD_KHR, non-dedicated allocation */
+  ORT_EXTERNAL_MEMORY_HANDLE_TYPE_HOST_ALLOCATION = 4,  /**< Equivalent to VK_EXTERNAL_MEMORY_HANDLE_TYPE_HOST_ALLOCATION_BIT_EXT or CL_MEM_USE_HOST_PTR */
 } OrtExternalMemoryHandleType;
 
 /** \brief Descriptor for importing external memory.

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -1052,7 +1052,7 @@ typedef OrtStatus*(ORT_API_CALL* RegisterCustomOpsFn)(OrtSessionOptions* options
  */
 typedef void (*RunAsyncCallbackFn)(void* user_data, OrtValue** outputs, size_t num_outputs, OrtStatusPtr status);
 
-/** \brief External memory handle type for importing GPU resources.
+/** \brief External memory handle type for importing GPU/NPU resources.
  *
  * \todo Add Linux DMA-BUF file descriptor for embedded GPU memory sharing
  *
@@ -1065,6 +1065,10 @@ typedef enum OrtExternalMemoryHandleType {
   ORT_EXTERNAL_MEMORY_HANDLE_TYPE_MEMORY_OPAQUE_FD = 3, /**< File descriptor from vkGetMemoryOpaqueFdKHR or clGetMemObjectInfo with CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_FD_KHR, non-dedicated allocation */
   ORT_EXTERNAL_MEMORY_HANDLE_TYPE_HOST_ALLOCATION = 4,  /**< Equivalent to VK_EXTERNAL_MEMORY_HANDLE_TYPE_HOST_ALLOCATION_BIT_EXT or CL_MEM_USE_HOST_PTR */
 } OrtExternalMemoryHandleType;
+
+// Previous enum values added for backwards compatibility
+#define ORT_EXTERNAL_MEMORY_HANDLE_TYPE_VK_MEMORY_WIN32 ORT_EXTERNAL_MEMORY_HANDLE_TYPE_MEMORY_WIN32
+#define ORT_EXTERNAL_MEMORY_HANDLE_TYPE_VK_MEMORY_OPAQUE_FD ORT_EXTERNAL_MEMORY_HANDLE_TYPE_MEMORY_OPAQUE_FD
 
 /** \brief Descriptor for importing external memory.
  *

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -1061,14 +1061,22 @@ typedef void (*RunAsyncCallbackFn)(void* user_data, OrtValue** outputs, size_t n
 typedef enum OrtExternalMemoryHandleType {
   ORT_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_RESOURCE = 0,   /**< Shared HANDLE from ID3D12Device::CreateSharedHandle(resource) */
   ORT_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_HEAP = 1,       /**< Shared HANDLE from ID3D12Device::CreateSharedHandle(heap) */
-  ORT_EXTERNAL_MEMORY_HANDLE_TYPE_MEMORY_WIN32 = 2,     /**< Shared HANDLE from vkGetMemoryWin32HandleKHR or clGetMemObjectInfo with CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_WIN32_KHR, non-dedicated allocation */
-  ORT_EXTERNAL_MEMORY_HANDLE_TYPE_MEMORY_OPAQUE_FD = 3, /**< File descriptor from vkGetMemoryOpaqueFdKHR or clGetMemObjectInfo with CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_FD_KHR, non-dedicated allocation */
-  ORT_EXTERNAL_MEMORY_HANDLE_TYPE_HOST_ALLOCATION = 4,  /**< Equivalent to VK_EXTERNAL_MEMORY_HANDLE_TYPE_HOST_ALLOCATION_BIT_EXT or CL_MEM_USE_HOST_PTR */
+  ORT_EXTERNAL_MEMORY_HANDLE_TYPE_MEMORY_WIN32 = 2,     /**< Shared HANDLE from vkGetMemoryWin32HandleKHR or
+                                                             clGetMemObjectInfo with CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_WIN32_KHR */
+  ORT_EXTERNAL_MEMORY_HANDLE_TYPE_MEMORY_OPAQUE_FD = 3, /**< File descriptor from vkGetMemoryOpaqueFdKHR or
+                                                             clGetMemObjectInfo with CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_FD_KHR */
+  ORT_EXTERNAL_MEMORY_HANDLE_TYPE_HOST_ALLOCATION = 4,  /**< Host-allocated CPU virtual address (pointer). Must be page-aligned.
+                                                             Equivalent to VK_EXTERNAL_MEMORY_HANDLE_TYPE_HOST_ALLOCATION_BIT_EXT
+                                                             or CL_MEM_USE_HOST_PTR, @since 1.30 */
 } OrtExternalMemoryHandleType;
 
 // Previous enum values added for backwards compatibility
+#ifndef ORT_EXTERNAL_MEMORY_HANDLE_TYPE_VK_MEMORY_WIN32
 #define ORT_EXTERNAL_MEMORY_HANDLE_TYPE_VK_MEMORY_WIN32 ORT_EXTERNAL_MEMORY_HANDLE_TYPE_MEMORY_WIN32
+#endif
+#ifndef ORT_EXTERNAL_MEMORY_HANDLE_TYPE_VK_MEMORY_OPAQUE_FD
 #define ORT_EXTERNAL_MEMORY_HANDLE_TYPE_VK_MEMORY_OPAQUE_FD ORT_EXTERNAL_MEMORY_HANDLE_TYPE_MEMORY_OPAQUE_FD
+#endif
 
 /** \brief Descriptor for importing external memory.
  *

--- a/onnxruntime/test/autoep/library/example_plugin_ep/ep_external_resource_importer.cc
+++ b/onnxruntime/test/autoep/library/example_plugin_ep/ep_external_resource_importer.cc
@@ -34,7 +34,8 @@ ExampleExternalResourceImporter::ExampleExternalResourceImporter(const ApiPtrs& 
 bool ORT_API_CALL ExampleExternalResourceImporter::CanImportMemoryImpl(
     _In_ const OrtExternalResourceImporterImpl* /*this_ptr*/,
     _In_ OrtExternalMemoryHandleType handle_type) noexcept {
-  // The example EP supports both D3D12 resource and heap handle types for testing
+  // The example EP supports D3D12 resource, D3D12 heap, and host allocation
+  // handle types for testing.
   return handle_type == ORT_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_RESOURCE ||
          handle_type == ORT_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_HEAP ||
          handle_type == ORT_EXTERNAL_MEMORY_HANDLE_TYPE_HOST_ALLOCATION;

--- a/onnxruntime/test/autoep/library/example_plugin_ep/ep_external_resource_importer.cc
+++ b/onnxruntime/test/autoep/library/example_plugin_ep/ep_external_resource_importer.cc
@@ -36,7 +36,8 @@ bool ORT_API_CALL ExampleExternalResourceImporter::CanImportMemoryImpl(
     _In_ OrtExternalMemoryHandleType handle_type) noexcept {
   // The example EP supports both D3D12 resource and heap handle types for testing
   return handle_type == ORT_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_RESOURCE ||
-         handle_type == ORT_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_HEAP;
+         handle_type == ORT_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_HEAP ||
+         handle_type == ORT_EXTERNAL_MEMORY_HANDLE_TYPE_HOST_ALLOCATION;
 }
 
 /*static*/

--- a/onnxruntime/test/autoep/test_external_resource_importer.cc
+++ b/onnxruntime/test/autoep/test_external_resource_importer.cc
@@ -32,6 +32,21 @@ class ExternalResourceImporterTest : public ::testing::Test {
     return Ort::GetInteropApi();
   }
 
+  OrtStatus* ImportMemory(OrtExternalResourceImporter* importer,
+                          OrtExternalMemoryHandleType type,
+                          size_t buffer_size,
+                          void* dummy_handle,
+                          OrtExternalMemoryHandle** mem_handle) {
+    OrtExternalMemoryDescriptor mem_desc = {};
+    mem_desc.version = ORT_API_VERSION;
+    mem_desc.handle_type = type;
+    mem_desc.native_handle = dummy_handle;
+    mem_desc.size_bytes = buffer_size;
+    mem_desc.offset_bytes = 0;
+
+    return GetInteropApi().ImportMemory(importer, &mem_desc, mem_handle);
+  };
+
   RegisteredEpDeviceUniquePtr registered_ep_;
   const OrtEpDevice* ep_device_ = nullptr;
 };
@@ -76,6 +91,13 @@ TEST_F(ExternalResourceImporterTest, CanImportMemory) {
   ASSERT_EQ(status, nullptr) << "CanImportMemory for D3D12_HEAP should succeed";
   EXPECT_TRUE(can_import_heap) << "Example EP should support D3D12 Heap import";
 
+  // Check host allocation support
+  bool can_import_host_allocation = false;
+  status = GetInteropApi().CanImportMemory(
+      importer, ORT_EXTERNAL_MEMORY_HANDLE_TYPE_HOST_ALLOCATION, &can_import_host_allocation);
+  ASSERT_EQ(status, nullptr) << "CanImportMemory for HOST_ALLOCATION should succeed";
+  EXPECT_TRUE(can_import_host_allocation) << "Example EP should support host allocation import";
+
   GetInteropApi().ReleaseExternalResourceImporter(importer);
 }
 
@@ -107,30 +129,41 @@ TEST_F(ExternalResourceImporterTest, ImportMemory) {
     GTEST_SKIP() << "External resource interop not supported";
   }
 
-  // Import memory (using a dummy handle for testing)
-  const size_t buffer_size = 1024 * sizeof(float);
-  void* dummy_handle = reinterpret_cast<void*>(static_cast<uintptr_t>(0x12345678));  // Simulated handle
+  // Import D3D12 Resource
+  {
+    // Create a dummy handle for testing
+    const size_t buffer_size = 1024 * sizeof(float);
+    void* dummy_handle = reinterpret_cast<void*>(static_cast<uintptr_t>(0x12345678));  // Simulated handle
 
-  OrtExternalMemoryDescriptor mem_desc = {};
-  mem_desc.version = ORT_API_VERSION;
-  mem_desc.handle_type = ORT_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_RESOURCE;
-  mem_desc.native_handle = dummy_handle;
-  mem_desc.size_bytes = buffer_size;
-  mem_desc.offset_bytes = 0;
+    OrtExternalMemoryHandle* mem_handle = nullptr;
+    status = ImportMemory(importer, ORT_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_RESOURCE, buffer_size, dummy_handle, &mem_handle);
+    ASSERT_EQ(status, nullptr) << "ImportMemory should succeed";
+    ASSERT_NE(mem_handle, nullptr) << "Memory handle should not be null";
 
-  OrtExternalMemoryHandle* mem_handle = nullptr;
-  status = GetInteropApi().ImportMemory(importer, &mem_desc, &mem_handle);
-  ASSERT_EQ(status, nullptr) << "ImportMemory should succeed";
-  ASSERT_NE(mem_handle, nullptr) << "Memory handle should not be null";
+    // Release memory handle
+    GetInteropApi().ReleaseExternalMemoryHandle(mem_handle);
+  }
 
-  // Release memory handle
-  GetInteropApi().ReleaseExternalMemoryHandle(mem_handle);
+  // Import host allocatione
+  {
+    // Create a dummy host pointer for testing
+    const size_t buffer_size = 10 * 4096;                                                      // Ten pages
+    void* dummy_handle = reinterpret_cast<void*>(static_cast<uintptr_t>(0x123456789ABCD000));  // Simulated page-aligned address
+
+    OrtExternalMemoryHandle* mem_handle = nullptr;
+    status = ImportMemory(importer, ORT_EXTERNAL_MEMORY_HANDLE_TYPE_HOST_ALLOCATION, buffer_size, dummy_handle, &mem_handle);
+    ASSERT_EQ(status, nullptr) << "ImportMemory should succeed";
+    ASSERT_NE(mem_handle, nullptr) << "Memory handle should not be null";
+
+    // Release memory handle
+    GetInteropApi().ReleaseExternalMemoryHandle(mem_handle);
+  }
 
   GetInteropApi().ReleaseExternalResourceImporter(importer);
 }
 
-// Test: Create Tensor from Imported Memory
-TEST_F(ExternalResourceImporterTest, CreateTensorFromMemory) {
+// Test: Create Tensor from D3D12 Resource Imported Memory
+TEST_F(ExternalResourceImporterTest, CreateTensorFromMemoryD3D12Resource) {
   OrtExternalResourceImporter* importer = nullptr;
   OrtStatus* status = GetInteropApi().CreateExternalResourceImporterForDevice(ep_device_, &importer);
   ASSERT_EQ(status, nullptr) << "CreateExternalResourceImporterForDevice should succeed";
@@ -147,15 +180,75 @@ TEST_F(ExternalResourceImporterTest, CreateTensorFromMemory) {
   // Import memory
   void* dummy_handle = reinterpret_cast<void*>(static_cast<uintptr_t>(0x12345678));
 
-  OrtExternalMemoryDescriptor mem_desc = {};
-  mem_desc.version = ORT_API_VERSION;
-  mem_desc.handle_type = ORT_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_RESOURCE;
-  mem_desc.native_handle = dummy_handle;
-  mem_desc.size_bytes = buffer_size;
-  mem_desc.offset_bytes = 0;
+  OrtExternalMemoryHandle* mem_handle = nullptr;
+  status = ImportMemory(importer, ORT_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_RESOURCE, buffer_size, dummy_handle, &mem_handle);
+  ASSERT_EQ(status, nullptr);
+
+  // Create tensor from imported memory
+  OrtExternalTensorDescriptor tensor_desc = {};
+  tensor_desc.version = ORT_API_VERSION;
+  tensor_desc.element_type = ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT;
+  tensor_desc.shape = shape;
+  tensor_desc.rank = 4;
+  tensor_desc.offset_bytes = 0;
+
+  OrtValue* tensor = nullptr;
+  status = GetInteropApi().CreateTensorFromMemory(
+      importer, mem_handle, &tensor_desc, &tensor);
+  ASSERT_EQ(status, nullptr) << "CreateTensorFromMemory should succeed";
+  ASSERT_NE(tensor, nullptr) << "Tensor should not be null";
+
+  // Verify tensor properties
+  OrtTensorTypeAndShapeInfo* type_info = nullptr;
+  status = Ort::GetApi().GetTensorTypeAndShape(tensor, &type_info);
+  ASSERT_EQ(status, nullptr);
+
+  size_t rank = 0;
+  status = Ort::GetApi().GetDimensionsCount(type_info, &rank);
+  ASSERT_EQ(status, nullptr);
+  EXPECT_EQ(rank, 4u);
+
+  std::vector<int64_t> actual_shape(rank);
+  status = Ort::GetApi().GetDimensions(type_info, actual_shape.data(), rank);
+  ASSERT_EQ(status, nullptr);
+  EXPECT_EQ(actual_shape[0], batch);
+  EXPECT_EQ(actual_shape[1], channels);
+  EXPECT_EQ(actual_shape[2], height);
+  EXPECT_EQ(actual_shape[3], width);
+
+  ONNXTensorElementDataType elem_type;
+  status = Ort::GetApi().GetTensorElementType(type_info, &elem_type);
+  ASSERT_EQ(status, nullptr);
+  EXPECT_EQ(elem_type, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT);
+
+  Ort::GetApi().ReleaseTensorTypeAndShapeInfo(type_info);
+
+  // Cleanup
+  Ort::GetApi().ReleaseValue(tensor);
+  GetInteropApi().ReleaseExternalMemoryHandle(mem_handle);
+  GetInteropApi().ReleaseExternalResourceImporter(importer);
+}
+
+// Test: Create Tensor from D3D12 Resource Imported Memory
+TEST_F(ExternalResourceImporterTest, CreateTensorFromMemoryHostAlloc) {
+  OrtExternalResourceImporter* importer = nullptr;
+  OrtStatus* status = GetInteropApi().CreateExternalResourceImporterForDevice(ep_device_, &importer);
+  ASSERT_EQ(status, nullptr) << "CreateExternalResourceImporterForDevice should succeed";
+  if (importer == nullptr) {
+    GTEST_SKIP() << "External resource interop not supported";
+  }
+
+  // Create tensor shape: [1, 3, 32, 32]
+  const int64_t batch = 1, channels = 3, height = 32, width = 32;
+  const int64_t shape[] = {batch, channels, height, width};
+  const size_t num_elements = batch * channels * height * width;
+  const size_t buffer_size = num_elements * sizeof(float);
+
+  // Import memory
+  void* dummy_handle = reinterpret_cast<void*>(static_cast<uintptr_t>(0x12345678));
 
   OrtExternalMemoryHandle* mem_handle = nullptr;
-  status = GetInteropApi().ImportMemory(importer, &mem_desc, &mem_handle);
+  status = ImportMemory(importer, ORT_EXTERNAL_MEMORY_HANDLE_TYPE_HOST_ALLOCATION, buffer_size, dummy_handle, &mem_handle);
   ASSERT_EQ(status, nullptr);
 
   // Create tensor from imported memory

--- a/onnxruntime/test/autoep/test_external_resource_importer.cc
+++ b/onnxruntime/test/autoep/test_external_resource_importer.cc
@@ -45,7 +45,7 @@ class ExternalResourceImporterTest : public ::testing::Test {
     mem_desc.offset_bytes = 0;
 
     return GetInteropApi().ImportMemory(importer, &mem_desc, mem_handle);
-  };
+  }
 
   RegisteredEpDeviceUniquePtr registered_ep_;
   const OrtEpDevice* ep_device_ = nullptr;
@@ -144,7 +144,7 @@ TEST_F(ExternalResourceImporterTest, ImportMemory) {
     GetInteropApi().ReleaseExternalMemoryHandle(mem_handle);
   }
 
-  // Import host allocatione
+  // Import host allocation
   {
     // Create a dummy host pointer for testing
     const size_t buffer_size = 10 * 4096;                                                      // Ten pages
@@ -183,6 +183,7 @@ TEST_F(ExternalResourceImporterTest, CreateTensorFromMemoryD3D12Resource) {
   OrtExternalMemoryHandle* mem_handle = nullptr;
   status = ImportMemory(importer, ORT_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_RESOURCE, buffer_size, dummy_handle, &mem_handle);
   ASSERT_EQ(status, nullptr);
+  ASSERT_NE(mem_handle, nullptr) << "ImportMemory should return a non-null memory handle";
 
   // Create tensor from imported memory
   OrtExternalTensorDescriptor tensor_desc = {};
@@ -229,7 +230,7 @@ TEST_F(ExternalResourceImporterTest, CreateTensorFromMemoryD3D12Resource) {
   GetInteropApi().ReleaseExternalResourceImporter(importer);
 }
 
-// Test: Create Tensor from D3D12 Resource Imported Memory
+// Test: Create Tensor from Host Allocation Imported Memory
 TEST_F(ExternalResourceImporterTest, CreateTensorFromMemoryHostAlloc) {
   OrtExternalResourceImporter* importer = nullptr;
   OrtStatus* status = GetInteropApi().CreateExternalResourceImporterForDevice(ep_device_, &importer);
@@ -245,11 +246,12 @@ TEST_F(ExternalResourceImporterTest, CreateTensorFromMemoryHostAlloc) {
   const size_t buffer_size = num_elements * sizeof(float);
 
   // Import memory
-  void* dummy_handle = reinterpret_cast<void*>(static_cast<uintptr_t>(0x12345678));
+  void* dummy_handle = reinterpret_cast<void*>(static_cast<uintptr_t>(0x123456789ABCD000));  // Simulated page-aligned address
 
   OrtExternalMemoryHandle* mem_handle = nullptr;
   status = ImportMemory(importer, ORT_EXTERNAL_MEMORY_HANDLE_TYPE_HOST_ALLOCATION, buffer_size, dummy_handle, &mem_handle);
   ASSERT_EQ(status, nullptr);
+  ASSERT_NE(mem_handle, nullptr) << "ImportMemory should return a non-null memory handle";
 
   // Create tensor from imported memory
   OrtExternalTensorDescriptor tensor_desc = {};


### PR DESCRIPTION
Update OrtExternalMemoryHandleType to add a new enum to allow for importing a host pointer, similar to Vulkan and OpenCL.

### Description
This PR adds one enum for host pointers as a valid native handle type. It also removes _VK from two existing enums to better convey that NT handes and file descriptors are not required to be exported from Vulkan.

### Motivation and Context
There are many uses cases that benefit from importing existing (pre-allocated) memory for use in UMA devices to eliminate copies (i.e. zero-copy). Some examples are object detection from a camera frame, cross API interaction (beyond DX12 and Vulkan), cross device buffer exchange and ORT inference integration into existing pipelines to name a few. 


