### PR TITLE
Add OrtErrorCode::ORT_DEVICE_RESET.

### DIFF
--- a/include/onnxruntime/core/common/status.h
+++ b/include/onnxruntime/core/common/status.h
@@ -54,6 +54,7 @@ enum StatusCode {
   MODEL_LOAD_CANCELED = ORT_MODEL_LOAD_CANCELED,
   MODEL_REQUIRES_COMPILATION = ORT_MODEL_REQUIRES_COMPILATION,
   NOT_FOUND = ORT_NOT_FOUND,
+  DEVICE_RESET = ORT_DEVICE_RESET,
 };
 
 constexpr const char* StatusCodeToString(StatusCode status) noexcept {

--- a/include/onnxruntime/core/common/status.h
+++ b/include/onnxruntime/core/common/status.h
@@ -89,6 +89,8 @@ constexpr const char* StatusCodeToString(StatusCode status) noexcept {
       return "MODEL_REQUIRES_COMPILATION";
     case StatusCode::NOT_FOUND:
       return "NOT_FOUND";
+    case StatusCode::DEVICE_RESET:
+      return "DEVICE_RESET";
     default:
       return "GENERAL ERROR";
   }
@@ -127,6 +129,8 @@ constexpr HRESULT StatusCodeToHRESULT(StatusCode status) noexcept {
       return HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED);
     case StatusCode::NOT_FOUND:
       return HRESULT_FROM_WIN32(ERROR_NOT_FOUND);
+    case StatusCode::DEVICE_RESET:
+      return E_FAIL;
     default:
       return E_FAIL;
   }

--- a/include/onnxruntime/core/session/onnxruntime_error_code.h
+++ b/include/onnxruntime/core/session/onnxruntime_error_code.h
@@ -83,6 +83,12 @@ typedef enum OrtErrorCode {
    * A requested resource could not be found.
    */
   ORT_NOT_FOUND,
+  /**
+   * The execution provider's hardware device has been reset.
+   *
+   * The caller should stop using the existing session (and release it) and create a new session.
+   */
+  ORT_DEVICE_RESET,
 } OrtErrorCode;
 
 #ifdef __cplusplus

--- a/java/src/main/java/ai/onnxruntime/OrtException.java
+++ b/java/src/main/java/ai/onnxruntime/OrtException.java
@@ -87,11 +87,16 @@ public class OrtException extends Exception {
     /** Model requires compilation. */
     ORT_MODEL_REQUIRES_COMPILATION(13),
     /** Item was not found. */
-    ORT_NOT_FOUND(14);
+    ORT_NOT_FOUND(14),
+    /** The execution provider's hardware device has been reset. Create a new session. */
+    ORT_DEVICE_RESET(15);
 
     private final int value;
 
-    private static final OrtErrorCode[] values = new OrtErrorCode[15];
+    // Assumptions about the array and its length:
+    // - We don't include the negative ORT_JAVA_UNKNOWN value.
+    // - There are N other error code values, with values from 0 to N-1.
+    private static final OrtErrorCode[] values = new OrtErrorCode[OrtErrorCode.values().length - 1];
 
     static {
       for (OrtErrorCode ot : OrtErrorCode.values()) {

--- a/java/src/main/native/OrtJniUtil.c
+++ b/java/src/main/native/OrtJniUtil.c
@@ -1123,6 +1123,8 @@ jint convertErrorCode(OrtErrorCode code) {
             return 13;
         case ORT_NOT_FOUND:
             return 14;
+        case ORT_DEVICE_RESET:
+            return 15;
         default:
             return -1; // Unknown error code
     }

--- a/onnxruntime/python/onnxruntime_pybind_exceptions.cc
+++ b/onnxruntime/python/onnxruntime_pybind_exceptions.cc
@@ -38,6 +38,7 @@ void RegisterExceptions(pybind11::module& m) {
   pybind11::register_exception<ModelLoadCanceled>(m, "ModelLoadCanceled");
   pybind11::register_exception<ModelRequiresCompilation>(m, "ModelRequiresCompilation");
   pybind11::register_exception<NotFound>(m, "NotFound");
+  pybind11::register_exception<DeviceReset>(m, "DeviceReset");
 }
 
 void OrtPybindThrowIfError(onnxruntime::common::Status status) {
@@ -70,6 +71,8 @@ void OrtPybindThrowIfError(onnxruntime::common::Status status) {
         throw ModelRequiresCompilation(std::move(msg));
       case onnxruntime::common::StatusCode::NOT_FOUND:
         throw NotFound(std::move(msg));
+      case onnxruntime::common::StatusCode::DEVICE_RESET:
+        throw DeviceReset(std::move(msg));
       default:
         throw std::runtime_error(std::move(msg));
     }

--- a/onnxruntime/python/onnxruntime_pybind_exceptions.h
+++ b/onnxruntime/python/onnxruntime_pybind_exceptions.h
@@ -54,6 +54,10 @@ struct NotFound : std::runtime_error {
   explicit NotFound(const std::string& what) : std::runtime_error(what) {}
 };
 
+struct DeviceReset : std::runtime_error {
+  explicit DeviceReset(const std::string& what) : std::runtime_error(what) {}
+};
+
 void RegisterExceptions(pybind11::module& m);
 
 void OrtPybindThrowIfError(onnxruntime::common::Status status);


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Add `OrtErrorCode::ORT_DEVICE_RESET`.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

This error code was requested to support cases like QNN EP subsystem restart.