### PR TITLE
[WebGPU] Intel SubgroupMatrix MatMul: batched-B support

### DIFF
--- a/onnxruntime/core/providers/webgpu/math/matmul.cc
+++ b/onnxruntime/core/providers/webgpu/math/matmul.cc
@@ -124,7 +124,15 @@ Status MatMul::ComputeInternal(ComputeContext& context) const {
   bool has_bias = context.InputCount() > 2;
 
 #if !defined(__wasm__)
-  // Try the subgroup-matrix implementation (with a vendor-specific tiling policy) first.
+  // Lazily create the subgroup-matrix implementation (with a vendor-specific tiling
+  // policy) on the first Compute call. PrePack is only invoked for constant
+  // initializers, so it cannot be relied on when B is a runtime tensor (e.g. batched
+  // matmul). Creating it here guarantees the subgroup-matrix path is considered for every
+  // MatMul. std::call_once makes the one-time init safe against concurrent Compute
+  // calls on this shared kernel.
+  std::call_once(impl_init_flag_, [&]() {
+    impl_ = CreateSubgroupMatrixMatMulImpl(*this, context);
+  });
   if (impl_) {
     bool handled = false;
     ORT_RETURN_IF_ERROR(impl_->Compute(context, handled));
@@ -186,26 +194,6 @@ Status MatMul::ComputeInternal(ComputeContext& context) const {
   }
 
   return ComputeMatMul(&context, Activation(), inputs, output_tensor);
-}
-
-Status MatMul::PrePackInternal(ComputeContextBase& context,
-                               const Tensor& tensor,
-                               int input_idx,
-                               AllocatorPtr alloc,
-                               /*out*/ bool& is_packed) {
-  is_packed = false;
-#if !defined(__wasm__)
-  // Create the subgroup-matrix implementation once based on device capabilities.
-  if (!impl_) {
-    impl_ = CreateSubgroupMatrixMatMulImpl(*this, context);
-  }
-#else
-  ORT_UNUSED_PARAMETER(context);
-#endif
-  ORT_UNUSED_PARAMETER(tensor);
-  ORT_UNUSED_PARAMETER(input_idx);
-  ORT_UNUSED_PARAMETER(alloc);
-  return Status::OK();
 }
 
 Status ComputeMatMul(ComputeContext* context,

--- a/onnxruntime/core/providers/webgpu/math/matmul.h
+++ b/onnxruntime/core/providers/webgpu/math/matmul.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <memory>
+#include <mutex>
 
 #include "core/providers/webgpu/webgpu_kernel.h"
 #include "core/providers/webgpu/program.h"
@@ -53,19 +54,16 @@ class MatMul final : public WebGpuKernel {
 
   Status ComputeInternal(ComputeContext& context) const override;
 
-  Status PrePackInternal(ComputeContextBase& context,
-                         const Tensor& tensor,
-                         int input_idx,
-                         AllocatorPtr alloc,
-                         /*out*/ bool& is_packed) override;
-
   constexpr static uint32_t MATMUL_PACKED_WORKGROUP_SIZE_X = 8;
   constexpr static uint32_t MATMUL_PACKED_WORKGROUP_SIZE_Y = 8;
   constexpr static uint32_t MATMUL_PACKED_WORKGROUP_SIZE_Z = 1;
 
  private:
-  // Alternative optimized implementation (created during PrePack if applicable)
+  // Alternative optimized implementation (lazily created on the first Compute call,
+  // once the device capabilities can be queried from the compute context). A null
+  // impl_ after initialization means this device has no optimized path.
   mutable std::unique_ptr<MatMulOptImpl> impl_;
+  mutable std::once_flag impl_init_flag_;
 };
 
 class MatMulNaiveProgram final : public Program<MatMulNaiveProgram> {

--- a/onnxruntime/core/providers/webgpu/math/subgroup_matrix_matmul.cc
+++ b/onnxruntime/core/providers/webgpu/math/subgroup_matrix_matmul.cc
@@ -44,31 +44,75 @@ class SubgroupMatrixMatMulImpl final : public MatMul::MatMulOptImpl {
 
     const auto* a = context.Input(0);
     const auto* b = context.Input(1);
-    // B must be a 2D KxN weight; A may be batched ([..., M, K]) and its leading
-    // dims are folded into M. Anything else falls back.
     const auto& a_shape = a->Shape();
     const auto& b_shape = b->Shape();
-    if (a_shape.NumDimensions() < 2 || b_shape.NumDimensions() != 2 ||
-        !a->IsDataType<MLFloat16>() || !b->IsDataType<MLFloat16>()) {
+    if (a_shape.NumDimensions() < 2 || !a->IsDataType<MLFloat16>() || !b->IsDataType<MLFloat16>()) {
       return Status::OK();
     }
 
     const uint32_t K = narrow<uint32_t>(a_shape[a_shape.NumDimensions() - 1]);
+    // The tiling selector is responsible for any subgroup-matrix alignment
+    // requirements (e.g. K % sg_mat_k == 0) and declines otherwise.
     if (K == 0) {
       return Status::OK();
     }
-    const uint32_t M = narrow<uint32_t>(a_shape.Size() / static_cast<int64_t>(K));
-    const uint32_t N = narrow<uint32_t>(b_shape[1]);
+
+    // Two shapes are handled:
+    //  * Shared 2D weight B [K, N]: all leading A dims fold into M and the whole
+    //    problem runs as one z-slice (batch == 1). Optimal for weight matmuls -
+    //    B is read once and M-parallelism is maximal.
+    //  * Batched B [..., K, N] (true bmm): A is [..., M, K] with batch dims
+    //    identical to B (no broadcasting). Each (A, B) pair is one z-dispatched
+    //    slice; the kernel derives the per-slice A/B/output strides from M, N, K.
+    // Anything else (e.g. broadcasting A across B's batch) falls back.
+    uint32_t M = 0;
+    uint32_t N = 0;
+    uint32_t batch = 1;
+    if (b_shape.NumDimensions() == 2) {
+      ORT_ENFORCE(narrow<uint32_t>(b_shape[0]) == K,
+                  "MatMul contraction dim mismatch: A K=", K, " vs B rows=", b_shape[0]);
+      N = narrow<uint32_t>(b_shape[1]);
+      M = narrow<uint32_t>(a_shape.Size() / static_cast<int64_t>(K));
+    } else {
+      // Batched B (true bmm): A is [..., M, K], B is [..., K, N]. The kernel pairs
+      // slice i of A with slice i of B and copies A's shape to the output, so it
+      // can only be correct when A and B have identical batch dims - it does not
+      // implement numpy broadcasting. Require equal rank and equal leading dims;
+      // anything broadcastable-but-not-identical (e.g. A=[2,1,M,K], B=[1,2,K,N])
+      // falls back to the generic MatMul path.
+      const size_t rank = a_shape.NumDimensions();
+      if (b_shape.NumDimensions() != rank) {
+        return Status::OK();
+      }
+      ORT_ENFORCE(narrow<uint32_t>(b_shape[rank - 2]) == K,
+                  "MatMul contraction dim mismatch: A K=", K, " vs B rows=", b_shape[rank - 2]);
+      M = narrow<uint32_t>(a_shape[rank - 2]);
+      N = narrow<uint32_t>(b_shape[rank - 1]);
+      for (size_t i = 0; i + 2 < rank; ++i) {
+        if (a_shape[i] != b_shape[i]) {
+          return Status::OK();
+        }
+      }
+      batch = narrow<uint32_t>(a_shape.SizeToDimension(rank - 2));
+    }
+
+    // An empty M or N yields an empty output (ONNX permits zero-length dims). Let
+    // the generic MatMul path allocate the empty result rather than dispatch a
+    // degenerate (zero-workgroup) kernel.
     if (M == 0 || N == 0) {
       return Status::OK();
     }
-    // K must match B; the tiling selector is responsible for any subgroup-matrix
-    // alignment requirements (e.g. K % sg_mat_k == 0) and declines otherwise.
-    if (narrow<uint32_t>(b_shape[0]) != K) {
+
+    // The B right-operand is loaded with subgroupMatrixLoad using a row stride of
+    // N (uniforms.N). Intel's f16 subgroup-matrix load reads columns in 32-bit
+    // (2xf16) pairs and requires each K-row to start 4-byte aligned, i.e. an even
+    // element stride. An odd N offsets every other K-row by 2 bytes and corrupts
+    // the odd output columns. Fall back to the generic MatMul path for odd N.
+    if (N % 2 != 0) {
       return Status::OK();
     }
 
-    const std::optional<SubgroupMatrixTiling> tiling = tiling_selector_(context, M, N, K);
+    const std::optional<SubgroupMatrixTiling> tiling = tiling_selector_(context, M, N, K, batch);
     if (!tiling) {
       return Status::OK();
     }
@@ -95,7 +139,7 @@ class SubgroupMatrixMatMulImpl final : public MatMul::MatMulOptImpl {
 
     SubgroupMatrixMatMulProgram program{has_bias, config_index_, sg_mat_count_m, sg_mat_count_n, split_k};
     program.SetWorkgroupSize(kSubgroupMatrixSubgroupSize * split_k);
-    program.SetDispatchGroupSize(dispatch_x, dispatch_y, 1);
+    program.SetDispatchGroupSize(dispatch_x, dispatch_y, batch);
     program.CacheHint(has_bias, config_index_, sg_mat_count_m, sg_mat_count_n, split_k)
         .AddInputs({{a, ProgramTensorMetadataDependency::TypeAndRank, 1},
                     {b, ProgramTensorMetadataDependency::TypeAndRank, 1}})
@@ -133,7 +177,7 @@ Status GenerateShaderCode8x16x16(ShaderHelper& shader, const ShaderVariableHelpe
 // output tile with no split-K.
 SubgroupMatrixTilingSelector MakeDefaultTilingSelector() {
   return [](const ComputeContext&, uint32_t /*M*/, uint32_t /*N*/,
-            uint32_t /*K*/) -> std::optional<SubgroupMatrixTiling> {
+            uint32_t /*K*/, uint32_t /*batch*/) -> std::optional<SubgroupMatrixTiling> {
     return SubgroupMatrixTiling{32, 32, 1};
   };
 }

--- a/onnxruntime/core/providers/webgpu/math/subgroup_matrix_matmul.h
+++ b/onnxruntime/core/providers/webgpu/math/subgroup_matrix_matmul.h
@@ -26,11 +26,13 @@ struct SubgroupMatrixTiling {
 };
 
 // Vendor-supplied callback that selects the output tiling for a given problem.
-// Returning nullopt declines the problem, so MatMul falls back to another
-// compute path. An empty selector likewise yields no implementation.
+// batch is the number of z-dispatched slices (1 for a shared 2D weight), used by
+// the policy to scale occupancy. Returning nullopt declines the problem, so
+// MatMul falls back to another compute path. An empty selector likewise yields
+// no implementation.
 using SubgroupMatrixTilingSelector =
     std::function<std::optional<SubgroupMatrixTiling>(const ComputeContext& context,
-                                                      uint32_t M, uint32_t N, uint32_t K)>;
+                                                      uint32_t M, uint32_t N, uint32_t K, uint32_t batch)>;
 
 // Creates a MatMulOptImpl that runs the subgroup-matrix kernel on devices whose
 // vendor policy supports it. The per-problem output tiling comes from a

--- a/onnxruntime/core/providers/webgpu/math/subgroup_matrix_matmul_8x16x16.wgsl.template
+++ b/onnxruntime/core/providers/webgpu/math/subgroup_matrix_matmul_8x16x16.wgsl.template
@@ -23,6 +23,13 @@
 // Preconditions enforced by the host: K % sg_mat_k == 0. M and N may be any
 // size; partial tiles are handled by bounds-checked stores. Out-of-range A/B
 // loads return zero (WebGPU bounds checking).
+//
+// Batching: the host dispatches one num_n_tile x num_m_tile tile grid per batch
+// slice; the batch slice is recovered from the flattened workgroup_idx (the
+// dispatch may be normalized across x/y/z). A and the output are laid out as
+// [batch, M, K] / [batch, M, N]; B is either a shared [K, N] weight (batch 1)
+// or batched as [batch, K, N]. Per-slice flat offsets are derived from M, N, K.
+// Each slice is an independent tile grid.
 
 #param has_bias
 #param sg_mat_k
@@ -51,14 +58,25 @@ const kSubgroupSize: u32 = 32;                   // Lanes per subgroup
 var<workgroup> scratch: array<f16, kTileM * kTileN * kSplitK>;
 
 $MAIN {
-    // Recover the logical (n_tile, m_tile) from the flattened workgroup index.
-    // The host dispatch may be normalized (reshaped across x/y/z to stay within
-    // per-dimension limits), so workgroup_id.x/y cannot be used directly; the
-    // row-major grid is num_n_tile columns wide.
-    let n_tile = workgroup_idx % uniforms.num_n_tile;   // which kTileN-wide column tile
+    // Recover the batch slice and the logical (n_tile, m_tile) from the flattened
+    // workgroup index. The host dispatches num_n_tile x num_m_tile tiles per batch
+    // slice on (x, y, z=batch), but that grid may be normalized (reshaped across
+    // x/y/z to stay within per-dimension limits), so workgroup_id.x/y/z cannot be
+    // used directly. workgroup_idx is the true linear index, invariant under
+    // normalization; batch slices are contiguous blocks of tiles_per_slice tiles.
+    let num_m_tile = (uniforms.M + kTileM - 1u) / kTileM;
+    let tiles_per_slice = uniforms.num_n_tile * num_m_tile;
+    let batch_id = workgroup_idx / tiles_per_slice;     // which batch slice (0 for a shared 2D weight)
+    let slice_idx = workgroup_idx % tiles_per_slice;    // tile index within the slice
+    let n_tile = slice_idx % uniforms.num_n_tile;       // which kTileN-wide column tile
     let global_base_n = n_tile * kTileN;
-    let m_tile = workgroup_idx / uniforms.num_n_tile;   // which kTileM-tall row tile
+    let m_tile = slice_idx / uniforms.num_n_tile;       // which kTileM-tall row tile
     let m_base = m_tile * kTileM;
+    // Flat-element offsets into A/B/output for this batch slice, derived from
+    // M/N/K. For a shared 2D weight batch_id is 0, so B collapses to its base.
+    let a_batch_offset = batch_id * uniforms.M * uniforms.K;
+    let b_batch_offset = batch_id * uniforms.K * uniforms.N;
+    let out_batch_offset = batch_id * uniforms.M * uniforms.N;
     let k_blocks = uniforms.K / kSgMatK;
     let sg_index = local_idx / kSubgroupSize;          // which split-K subgroup (0..kSplitK-1)
     let sg_lane = local_idx % kSubgroupSize;           // lane within the subgroup (0..kSubgroupSize-1)
@@ -162,7 +180,7 @@ $MAIN {
 
     for (var kb: u32 = sg_index; kb < k_blocks; kb = kb + kSplitK) {
         // Load the B right tiles for this K block (KxN row-major, stride N).
-        let b_base = kb * kSgMatK * uniforms.N + global_base_n;
+        let b_base = b_batch_offset + kb * kSgMatK * uniforms.N + global_base_n;
         var sg_mat_b0: subgroup_matrix_right<f16, sg_mat_n, sg_mat_k> =
             subgroupMatrixLoad<subgroup_matrix_right<f16, sg_mat_n, sg_mat_k>>(
                 &input_b, b_base + 0 * kSgMatN, false, uniforms.N);
@@ -183,7 +201,9 @@ $MAIN {
 #endif
 
         // Load the A left tiles (one per M block), row-major with stride K.
-        let a_col = kb * kSgMatK;
+        // a_batch_offset folds this z-slice's flat offset into the column term so
+        // every A load below reads from the correct batch slice.
+        let a_col = a_batch_offset + kb * kSgMatK;
         var sg_mat_a0: subgroup_matrix_left<f16, sg_mat_k, sg_mat_m> =
             subgroupMatrixLoad<subgroup_matrix_left<f16, sg_mat_k, sg_mat_m>>(
                 &input_a, (m_base + 0 * kSgMatM) * uniforms.K + a_col, false, uniforms.K);
@@ -450,7 +470,7 @@ $MAIN {
         let global_m = m_base + r;
         if (global_m < uniforms.M) {
             let scratch_base = r * kTileN;
-            let out_base = global_m * uniforms.N + global_base_n;
+            let out_base = out_batch_offset + global_m * uniforms.N + global_base_n;
             for (var i: u32 = sg_lane; i < n_count; i = i + kSubgroupSize) {
                 var val = output_element_t(scratch[scratch_base + i]);
 #if has_bias

--- a/onnxruntime/core/providers/webgpu/vendor/intel/math/subgroup_matrix_tiling_selector.cc
+++ b/onnxruntime/core/providers/webgpu/vendor/intel/math/subgroup_matrix_tiling_selector.cc
@@ -52,20 +52,24 @@ bool IsTilingValid(const SubgroupMatrixTiling& t, uint32_t K) {
   return t.tile_m * t.tile_n * t.split_k <= kMaxScratchElems;
 }
 
+// HwSubgroups returns 0 for an unrecognized arch; fall back to a conservative
+// default so the occupancy target is still reasonable.
+uint32_t EffectiveHwSubgroups(std::string_view arch) {
+  const uint32_t hw = HwSubgroups(arch);
+  return hw == 0 ? 256u : hw;
+}
+
 // Fallback tiling selection when no pretuned entry applies. The goal is to keep
 // the GPU busy without over-subscribing it: pick the tile whose independent
 // output-tile grid just fills the resident subgroups, preferring larger tiles
 // (more data reuse) among those that qualify, and only using smaller tiles when
 // nothing else would fill the machine. Split-K then adds cooperative subgroups
 // to reach up to 2x occupancy, subject to the per-subgroup K-work minimum and
-// the scratch (SLM) budget.
-SubgroupMatrixTiling HeuristicTiling(std::string_view arch, uint32_t M, uint32_t N, uint32_t K) {
-  // HwSubgroups returns 0 for an unrecognized arch; fall back to a conservative
-  // default so the occupancy target is still reasonable.
-  uint32_t hw = HwSubgroups(arch);
-  if (hw == 0) {
-    hw = 256;
-  }
+// the scratch (SLM) budget. batch scales the independent-tile count: each z
+// slice contributes its own output-tile grid, so a larger batch fills the
+// machine with bigger tiles and needs less (or no) split-K.
+SubgroupMatrixTiling HeuristicTiling(std::string_view arch, uint32_t M, uint32_t N, uint32_t K, uint32_t batch) {
+  const uint32_t hw = EffectiveHwSubgroups(arch);
   const uint32_t k_blocks = K / kSubgroupMatrixK;
   auto tile_count = [](uint32_t dim, uint32_t tile) { return (dim + tile - 1) / tile; };
 
@@ -86,7 +90,7 @@ SubgroupMatrixTiling HeuristicTiling(std::string_view arch, uint32_t M, uint32_t
       if (tn > N && tn != kTileNCandidates[0]) {
         continue;
       }
-      const uint32_t tiles = tile_count(M, tm) * tile_count(N, tn);
+      const uint32_t tiles = batch * tile_count(M, tm) * tile_count(N, tn);
       const uint32_t area = tm * tn;
       if (tiles >= hw) {
         // This tile fills the machine on its own. Among all such tiles, keep the
@@ -111,7 +115,7 @@ SubgroupMatrixTiling HeuristicTiling(std::string_view arch, uint32_t M, uint32_t
 
   // Add split-K only while the independent tiles under-fill the machine; cap the
   // total at 2x hardware and keep enough K work per subgroup and scratch budget.
-  const uint32_t num_tiles = tile_count(M, tile_m) * tile_count(N, tile_n);
+  const uint32_t num_tiles = batch * tile_count(M, tile_m) * tile_count(N, tile_n);
   constexpr uint32_t kMinBlocksPerSplit = 2;
   uint32_t split_k = 1;
   for (uint32_t cand : kSplitKCandidates) {
@@ -158,13 +162,34 @@ std::optional<SubgroupMatrixTiling> LookupPretunedTiling(std::string_view arch, 
   return std::nullopt;
 }
 
+// Batch slices are dispatched on z as independent output-tile grids, so batch is
+// a pure occupancy multiplier. The pretuned table and heuristic pick tile shape
+// for a single (M, N, K) slice; once batch fills the machine, split-K's
+// cooperative subgroups are redundant. Retire split-K factors whose batch-scaled
+// occupancy would exceed ~2x hardware.
+void ClampSplitKForBatch(SubgroupMatrixTiling& t, uint32_t M, uint32_t N, uint32_t batch, uint32_t hw) {
+  auto tile_count = [](uint32_t dim, uint32_t tile) { return (dim + tile - 1) / tile; };
+  const uint32_t eff_tiles = batch * tile_count(M, t.tile_m) * tile_count(N, t.tile_n);
+  while (t.split_k > 1 && eff_tiles * t.split_k > 2 * hw) {
+    t.split_k /= 2;
+  }
+}
+
 // Chooses the tile + split-K tiling for the given problem: use the pretuned
 // table entry when one exists and fits, otherwise fall back to the heuristic.
-SubgroupMatrixTiling SelectTiling(std::string_view arch, uint32_t M, uint32_t N, uint32_t K) {
+// batch is the number of z-dispatched slices; it scales occupancy (see
+// ClampSplitKForBatch) but not the per-slice tile shape.
+SubgroupMatrixTiling SelectTiling(std::string_view arch, uint32_t M, uint32_t N, uint32_t K, uint32_t batch) {
   if (const auto tuned = LookupPretunedTiling(arch, M, N, K); tuned && IsTilingValid(*tuned, K)) {
-    return *tuned;
+    SubgroupMatrixTiling tiling = *tuned;
+    // The table is tuned per (M, N, K) at batch 1, so only revisit split-K when
+    // batch adds occupancy.
+    if (batch > 1) {
+      ClampSplitKForBatch(tiling, M, N, batch, EffectiveHwSubgroups(arch));
+    }
+    return tiling;
   }
-  return HeuristicTiling(arch, M, N, K);
+  return HeuristicTiling(arch, M, N, K, batch);
 }
 
 }  // namespace
@@ -178,14 +203,14 @@ SubgroupMatrixTilingSelector CreateSubgroupMatrixTilingSelector(
   // the tile shape and split-K factor from the pretuned table or the heuristic.
   // The subgroup-matrix shape itself is fixed by the kernel and not selected here.
   return [](const ComputeContext& context, uint32_t M, uint32_t N,
-            uint32_t K) -> std::optional<SubgroupMatrixTiling> {
+            uint32_t K, uint32_t batch) -> std::optional<SubgroupMatrixTiling> {
     // Only K needs to align to the subgroup tiling; M and N partial tiles are
     // handled by bounds-checked stores in the kernel.
     if (K % kSubgroupMatrixK != 0) {
       return std::nullopt;
     }
     const std::string_view arch = std::string_view{context.AdapterInfo().architecture};
-    return SelectTiling(arch, M, N, K);
+    return SelectTiling(arch, M, N, K, batch);
   };
 }
 

--- a/onnxruntime/test/providers/webgpu/matmul_large_test.cc
+++ b/onnxruntime/test/providers/webgpu/matmul_large_test.cc
@@ -114,5 +114,52 @@ TEST(MatMul_Large, DISABLED_Broadcast4D) {
   RunBothTypes({2, 2, 128, 64}, {2, 64, 1023});
 }
 
+// Batched B (true bmm): A [..., M, K] x B [..., K, N] with matching batch. On the
+// Intel subgroup path each (A, B) slice is dispatched on z. Covers small and
+// larger batch counts with tile-aligned per-slice shapes.
+TEST(MatMul_Large, DISABLED_BatchedB) {
+  RunBothTypes({2, 128, 64}, {2, 64, 1024});
+  RunBothTypes({4, 64, 128}, {4, 128, 256});
+  RunBothTypes({8, 32, 64}, {8, 64, 64});
+  RunBothTypes({16, 64, 64}, {16, 64, 128});
+}
+
+// Batched B with per-slice shapes that are not tile multiples. The odd-N slices
+// (1023, 33) fall back to the generic path (the Intel f16 subgroup kernel needs
+// an even B row stride); the even-N odd-M slice (130 x 65) still exercises the
+// kernel's bounds-checked partial-M stores under z-dispatch. All must be correct.
+TEST(MatMul_Large, DISABLED_BatchedB_Unaligned) {
+  RunBothTypes({3, 127, 64}, {3, 64, 1023});
+  RunBothTypes({5, 65, 96}, {5, 96, 130});
+  RunBothTypes({2, 129, 80}, {2, 80, 33});
+}
+
+// Multi-dimensional batch: leading A/B dims collapse into the z grid.
+TEST(MatMul_Large, DISABLED_BatchedB_4D) {
+  RunBothTypes({2, 2, 64, 128}, {2, 2, 128, 256});
+  RunBothTypes({2, 3, 32, 64}, {2, 3, 64, 96});
+}
+
+// Large batch with a small per-slice M x N grid: batch alone fills the machine,
+// so the selector should retire split-K (ClampSplitKForBatch). Correctness must
+// hold regardless of the chosen config.
+TEST(MatMul_Large, DISABLED_BatchedB_LargeBatchSmallTile) {
+  RunBothTypes({64, 16, 128}, {64, 128, 32});
+  RunBothTypes({128, 8, 256}, {128, 256, 16});
+}
+
+// Broadcasted batch dims that are NOT identical but share the same batch
+// *product* (A=[2,1,...], B=[1,2,...] -> [2,2,...]; A=[1,4,...], B=[4,1,...] ->
+// [4,4,...]). A product-only batch check would wrongly route these onto the
+// Intel subgroup path, which pairs slice i of A with slice i of B and copies A's
+// shape to the output - producing the wrong output shape and mismatched pairing.
+// N is even and every per-slice shape is tile-aligned, so only the
+// identical-batch-dims guard (not the odd-N or partial-tile fallbacks) keeps them
+// on the generic broadcasting MatMul. Results must match the broadcast reference.
+TEST(MatMul_Large, DISABLED_BatchedB_BroadcastEqualProduct) {
+  RunBothTypes({2, 1, 128, 64}, {1, 2, 64, 256});
+  RunBothTypes({1, 4, 64, 128}, {4, 1, 128, 96});
+}
+
 }  // namespace test
 }  // namespace onnxruntime


### PR DESCRIPTION
- Create the Intel subgroup-matrix impl lazily in ComputeInternal (via std::call_once) instead of PrePackInternal, which only fires for constant initializers and so skipped the subgroup-matrix path for runtime/dynamic B (batched matmul).
- Fall back to the generic MatMul path when N is odd: Intel's f16 subgroup-matrix B load requires an even row stride (4-byte-aligned K-rows); an odd N corrupts odd output columns.
- Add batched f16 MatMul tests (matmul_large_test.cc).
