### PR TITLE
Add Java setup to Windows x64 QNN CI Pipeline

### DIFF
--- a/.github/workflows/windows_qnn_x64.yml
+++ b/.github/workflows/windows_qnn_x64.yml
@@ -43,6 +43,13 @@ jobs:
           python-version: '3.12'
           architecture: x64
 
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          architecture: x64
+
       # onnx (pinned to cmake/deps.txt) + numpy (pinned to requirements.txt, python-conditional)
       # are required at configure time by the onnxruntime_MATERIALIZE_ONNX_NODE_TESTS gate, which
       # regenerates the onnx node-test corpus into the build tree (onnx_node_tests\node) for


### PR DESCRIPTION
### Description

Copies the Java setup step from sibling files `windows_webgpu.yml`, `windows_x64_release_xnnpack.yml`,
`windows_x64_release_build_x64_release.yml` to `windows_qnn_x64.yml`.

This explicitly ensures a compatible Java version, rather than relying on the JDK already installed on the self-hosted runner. Otherwise there may be breakages when switching the runner.

### Motivation and Context

I believe this will fix the failures in CI for the Windows x64 QNN CI Pipeline. I'm seeing it fail in both an unrelated PR:

https://github.com/microsoft/onnxruntime/pull/29728
https://github.com/microsoft/onnxruntime/actions/runs/29509983398/job/87780661649?pr=29728

and in commits to main:

https://github.com/microsoft/onnxruntime/actions/runs/29546572913/job/87780090142
https://github.com/microsoft/onnxruntime/actions/runs/29499730505/job/87625355397

This is assuming the chain of causation:

1. https://github.com/microsoft/onnxruntime/pull/29731 switches the runner pool
2. The `windows_qnn_x64.yml` pipeline finds JDK 8 already on the runner (previous runner pool had JDK 11)
3. The Spotless Gradle plugin v7.2.1 isn't compatible with JDK 8
4. onnxruntime Java project can't be configured
5. Build fails

This new workflow action hopefully installs a compatible JDK & all will be well. 

https://github.com/microsoft/onnxruntime/issues/29753
