### PR TITLE
Skip DXGI device discovery if Win32k system calls are disabled

### DIFF
--- a/onnxruntime/core/platform/windows/device_discovery.cc
+++ b/onnxruntime/core/platform/windows/device_discovery.cc
@@ -572,8 +572,8 @@ std::unordered_set<OrtHardwareDevice> DeviceDiscovery::DiscoverDevicesForPlatfor
   }
 
   bool have_remote_display_adapter = false;  // set if we see the RdpIdd_IndirectDisplay hardware ID.
-  std::unordered_map<uint64_t, DeviceInfo> setupapi_info;  // setupapi_info. key is vendor_id+device_id
-  std::unordered_map<uint64_t, DeviceInfo> luid_to_d3d12_info;  // d3d12 info. key is luid
+  std::unordered_map<uint64_t, DeviceInfo> setupapi_info;  // key is vendor_id+device_id
+  std::unordered_map<uint64_t, DeviceInfo> luid_to_d3d12_info;  // key is luid
   if (!Win32kSystemCallsDisallowed()) {
     setupapi_info = GetDeviceInfoSetupApi(npus, have_remote_display_adapter);
     luid_to_d3d12_info = GetDeviceInfoD3D12(have_remote_display_adapter);

--- a/onnxruntime/core/platform/windows/device_discovery.cc
+++ b/onnxruntime/core/platform/windows/device_discovery.cc
@@ -571,7 +571,7 @@ std::unordered_set<OrtHardwareDevice> DeviceDiscovery::DiscoverDevicesForPlatfor
     }
   }
 
-  bool have_remote_display_adapter = false;  // set if we see the RdpIdd_IndirectDisplay hardware ID.
+  bool have_remote_display_adapter = false;                // set if we see the RdpIdd_IndirectDisplay hardware ID.
   std::unordered_map<uint64_t, DeviceInfo> setupapi_info;  // key is vendor_id+device_id
   std::unordered_map<uint64_t, DeviceInfo> luid_to_d3d12_info;
   if (!Win32kSystemCallsDisallowed()) {

--- a/onnxruntime/core/platform/windows/device_discovery.cc
+++ b/onnxruntime/core/platform/windows/device_discovery.cc
@@ -541,8 +541,8 @@ DeviceInfo GetDeviceInfoCPUID() {
   return cpu_info;
 }
 
-// Returns true if the Win32k system calls are disabled (e.g., in a sandboxed process), in which case calling
-// SetupDiGetClassDevs will throw an SEH exception.
+// Returns true if the Win32k system calls are disabled (e.g., in a sandboxed process).
+// Both SetupDi and DXGI depend on Win32k and must be skipped under this policy.
 bool Win32kSystemCallsDisallowed() {
   PROCESS_MITIGATION_SYSTEM_CALL_DISABLE_POLICY policy = {};
   if (GetProcessMitigationPolicy(GetCurrentProcess(), ProcessSystemCallDisablePolicy,
@@ -571,17 +571,15 @@ std::unordered_set<OrtHardwareDevice> DeviceDiscovery::DiscoverDevicesForPlatfor
     }
   }
 
-  // setupapi_info. key is vendor_id+device_id
   bool have_remote_display_adapter = false;  // set if we see the RdpIdd_IndirectDisplay hardware ID.
-  std::unordered_map<uint64_t, DeviceInfo> setupapi_info;
+  std::unordered_map<uint64_t, DeviceInfo> setupapi_info;  // setupapi_info. key is vendor_id+device_id
+  std::unordered_map<uint64_t, DeviceInfo> luid_to_d3d12_info;  // d3d12 info. key is luid
   if (!Win32kSystemCallsDisallowed()) {
     setupapi_info = GetDeviceInfoSetupApi(npus, have_remote_display_adapter);
+    luid_to_d3d12_info = GetDeviceInfoD3D12(have_remote_display_adapter);
   } else {
-    LOGS_DEFAULT(INFO) << "Skip SetupDi device discovery due to Win32k lockdown.";
+    LOGS_DEFAULT(INFO) << "Skip SetupDi and D3D12 device discovery due to Win32k lockdown.";
   }
-
-  // d3d12 info. key is luid
-  std::unordered_map<uint64_t, DeviceInfo> luid_to_d3d12_info = GetDeviceInfoD3D12(have_remote_display_adapter);
 
   // Ensure we have at least one CPU
   bool found_cpu = false;

--- a/onnxruntime/core/platform/windows/device_discovery.cc
+++ b/onnxruntime/core/platform/windows/device_discovery.cc
@@ -573,7 +573,7 @@ std::unordered_set<OrtHardwareDevice> DeviceDiscovery::DiscoverDevicesForPlatfor
 
   bool have_remote_display_adapter = false;  // set if we see the RdpIdd_IndirectDisplay hardware ID.
   std::unordered_map<uint64_t, DeviceInfo> setupapi_info;  // key is vendor_id+device_id
-  std::unordered_map<uint64_t, DeviceInfo> luid_to_d3d12_info;  // key is luid
+  std::unordered_map<uint64_t, DeviceInfo> luid_to_d3d12_info;
   if (!Win32kSystemCallsDisallowed()) {
     setupapi_info = GetDeviceInfoSetupApi(npus, have_remote_display_adapter);
     luid_to_d3d12_info = GetDeviceInfoD3D12(have_remote_display_adapter);


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Skip DXGI device discovery when Win32k system calls are disabled.

DXGI internally calls `gdi32!DdQueryDisplaySettingsUniqueness`, which reads from the GDI shared memory section. Under Win32k lockdown this section may not be mapped (depending on the host's gdi32 initialization strategy), causing an access violation.
```
gdi32!DdQueryDisplaySettingsUniqueness+0x7:
00007ff8`30cf45f7 8b8090001800    mov     eax,dword ptr [rax+180090h] ds:00000000`00180090=????????

# Child-SP          RetAddr               Call Site
00 00000072`4b5fc6f8 00007ff8`2b0f583e     gdi32!DdQueryDisplaySettingsUniqueness+0x7
01 00000072`4b5fc700 00007ff8`2b0f433f     dxgi!CDXGIFactory::SampleAdapters+0xae
02 00000072`4b5fc780 00007ff8`2b0f3f6a     dxgi!CDXGIFactory::Initialize+0x10f
03 00000072`4b5fc870 00007ff8`2b0f34b8     dxgi!CreateDXGIFactoryImpl+0x9a
04 00000072`4b5fc8f0 00007fff`a9e08856     dxgi!CreateDXGIFactoryActualImpl2+0x58
05 00000072`4b5fc930 00007fff`a9e075c3     onnxruntime!onnxruntime::`anonymous namespace'::GetDeviceInfoD3D12+0x86 [device_discovery.cc @ 337]
06 00000072`4b5fcc10 00007fff`a9dec8a1     onnxruntime!onnxruntime::DeviceDiscovery::DiscoverDevicesForPlatform+0x323 [device_discovery.cc @ 584]
07 00000072`4b5fd000 00007fff`a9ded12e     onnxruntime!`onnxruntime::DeviceDiscovery::GetDevices'::`2'::<lambda_1>::operator()+0x61 [device_discovery_common.cc @ 20]
08 00000072`4b5fd4c0 00007fff`a93b6c46     onnxruntime!onnxruntime::DeviceDiscovery::GetDevices+0x7e [device_discovery_common.cc @ 19]
09 00000072`4b5fd4f0 00007fff`a93b2d7d     onnxruntime!onnxruntime::`anonymous namespace'::SortDevicesByType+0x36 [environment.cc @ 781]
```

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
WebNN is migrating ORT graph compilation to a sandboxed process with PROCESS_MITIGATION_SYSTEM_CALL_DISABLE_POLICY.DisallowWin32kSystemCalls enabled. This prevents calls through GDI for security hardening.

This change has no effect on normal (unsandboxed) processes.
