### PR TITLE
setup gates for CI jobs

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -10,9 +10,13 @@ on:
   workflow_call: # Allows this workflow to be invoked as the Stage 2 "nnapi provider" gate by ci_orchestrator.yml
   # NOTE: standalone `pull_request:` trigger removed - ci_orchestrator.yml is now the sole PR entry point.
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
-  cancel-in-progress: true
+# NOTE: no standalone `concurrency:` block here - this workflow's own group would be
+# `${{ github.workflow }}-<ref>`, but github.workflow resolves to the *caller's* name
+# ("CI Orchestrator") when invoked via workflow_call, which is identical to the
+# orchestrator's own top-level group and causes GitHub to detect a deadlock and cancel
+# this job outright. ci_orchestrator.yml's top-level `concurrency:` already covers
+# cancel-in-progress for the whole PR run; standalone push/workflow_dispatch triggers
+# here are keyed off github.sha, which is always unique, so no dedicated group is needed.
 
 permissions:
   contents: read

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -6,11 +6,9 @@ on:
     branches:
       - main
       - rel-*
-  pull_request:
-    branches:
-      - main
-      - rel-*
   workflow_dispatch:
+  workflow_call: # Allows this workflow to be invoked as the Stage 2 "nnapi provider" gate by ci_orchestrator.yml
+  # NOTE: standalone `pull_request:` trigger removed - ci_orchestrator.yml is now the sole PR entry point.
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}

--- a/.github/workflows/ci_orchestrator.yml
+++ b/.github/workflows/ci_orchestrator.yml
@@ -4,13 +4,21 @@
 # Stage 2 (targeted gates):  Only the CI job(s) covering the changed area run here, gated on Stage 1:
 #                              - "framework" gate (onnxruntime/core/** excluding core/providers/**
 #                                and core/platform/**, plus include/onnxruntime/core/** and cmake/**)
-#                                -> linux_ci.yml (Linux CPU build+test): cheapest/fastest full leg,
-#                                highest-signal predictor of framework-level breakage.
+#                                -> linux_ci.yml (Linux CPU build+test, cheapest/fastest full leg,
+#                                highest-signal predictor of framework-level breakage), plus the
+#                                generic (non-provider-specific) full-ORT Windows builds that used
+#                                to run unconditionally on every PR: windows_x64_release,
+#                                windows_x64_debug, windows_x64_release_ep_generic_interface,
+#                                Windows CPU CI Pipeline (x86), windows_x64_asan.
 #                              - "<provider>" gate (onnxruntime/core/providers/<provider>/**) -> that
-#                                provider's own CI workflow(s). Wired so far: cuda, tensorrt,
-#                                openvino, dml, webgpu, qnn, xnnpack, vitisai, coreml, nnapi,
-#                                js/webnn. Not yet wired (no obvious reusable CI workflow or low PR
-#                                volume): acl, azure, cann, dnnl, migraphx, rknpu, snpe, vsinpu, winml.
+#                                provider's own CI workflow(s), Linux and Windows legs alike. Wired
+#                                so far: cuda (Linux CUDA CI, ONNX Runtime CUDA Builds, CUDA Plugin
+#                                Windows CI), tensorrt (Linux + Windows GPU TensorRT CI Pipeline),
+#                                openvino (Linux + Windows OpenVINO CI Pipeline), webgpu (Linux +
+#                                ONNX Runtime WebGPU Builds), dml, qnn, xnnpack, vitisai, coreml,
+#                                nnapi, js/webnn. Not yet wired (no obvious
+#                                reusable CI workflow or low PR volume): acl, azure, cann, dnnl,
+#                                migraphx, rknpu, snpe, vsinpu, winml.
 #                            Multiple gates can run in parallel when a PR touches more than one area
 #                            (e.g. framework + cuda).
 # Stage 3 (everything else): Placeholder for now - will fan out to the remaining CI workflows as
@@ -18,9 +26,10 @@
 #                            Waits for all Stage 2 gates that were triggered to succeed (skipped
 #                            gates count as pass-through).
 #
-# NOTE: This orchestrator currently runs ALONGSIDE the existing standalone `pull_request` triggers
-# on lint.yml / linux_ci.yml (not yet replacing them), so nothing is required or blocking yet. This
-# is intentional for validation before cutting real required-status-checks over to this workflow.
+# NOTE: Every workflow wired into Stage 2 above has had its standalone `pull_request:` trigger
+# removed (see each workflow's `on:` block) - ci_orchestrator.yml is now the sole PR entry point for
+# those workflows, so unrelated PRs no longer queue Windows/Linux GPU runners they don't need. This
+# is what actually reduces contention on the self-hosted runner pools, not just a cosmetic gate.
 
 name: CI Orchestrator
 
@@ -109,11 +118,56 @@ jobs:
     if: needs.detect-changes.outputs.framework == 'true'
     uses: ./.github/workflows/linux_ci.yml
 
+  # windows_x64_release / windows_x64_debug / windows_x64_release_ep_generic_interface / Windows CPU
+  # CI Pipeline / windows_x64_asan are generic full-ORT builds (not tied to one provider), so they
+  # ride on the same "framework" gate as stage2-linux-cpu above.
+  stage2-windows-release:
+    name: "Stage 2: Windows x64 Release (framework gate)"
+    needs: detect-changes
+    if: needs.detect-changes.outputs.framework == 'true'
+    uses: ./.github/workflows/windows_x64_release_build_x64_release.yml
+
+  stage2-windows-debug:
+    name: "Stage 2: Windows x64 Debug (framework gate)"
+    needs: detect-changes
+    if: needs.detect-changes.outputs.framework == 'true'
+    uses: ./.github/workflows/windows_x64_debug_build_x64_debug.yml
+
+  stage2-windows-ep-generic:
+    name: "Stage 2: Windows x64 Release EP Generic Interface (framework gate)"
+    needs: detect-changes
+    if: needs.detect-changes.outputs.framework == 'true'
+    uses: ./.github/workflows/windows_x64_release_ep_generic_interface_build_x64_release_ep_generic_interface.yml
+
+  stage2-windows-cpu:
+    name: "Stage 2: Windows CPU CI Pipeline (framework gate)"
+    needs: detect-changes
+    if: needs.detect-changes.outputs.framework == 'true'
+    uses: ./.github/workflows/windows_x86.yml
+
+  stage2-windows-asan:
+    name: "Stage 2: Windows x64 ASan (framework gate)"
+    needs: detect-changes
+    if: needs.detect-changes.outputs.framework == 'true'
+    uses: ./.github/workflows/windows_build_x64_asan.yml
+
   stage2-cuda:
     name: "Stage 2: Linux CUDA CI (cuda provider gate)"
     needs: detect-changes
     if: needs.detect-changes.outputs.cuda == 'true'
     uses: ./.github/workflows/linux_cuda_ci.yml
+
+  stage2-windows-cuda:
+    name: "Stage 2: Windows CUDA Builds (cuda provider gate)"
+    needs: detect-changes
+    if: needs.detect-changes.outputs.cuda == 'true'
+    uses: ./.github/workflows/windows_cuda.yml
+
+  stage2-windows-cuda-plugin:
+    name: "Stage 2: CUDA Plugin Windows CI (cuda provider gate)"
+    needs: detect-changes
+    if: needs.detect-changes.outputs.cuda == 'true'
+    uses: ./.github/workflows/windows_cuda_plugin.yml
 
   stage2-tensorrt:
     name: "Stage 2: Linux TensorRT CI (tensorrt provider gate)"
@@ -121,11 +175,23 @@ jobs:
     if: needs.detect-changes.outputs.tensorrt == 'true'
     uses: ./.github/workflows/linux_tensorrt_ci.yml
 
+  stage2-windows-tensorrt:
+    name: "Stage 2: Windows GPU TensorRT CI Pipeline (tensorrt provider gate)"
+    needs: detect-changes
+    if: needs.detect-changes.outputs.tensorrt == 'true'
+    uses: ./.github/workflows/windows_tensorrt.yml
+
   stage2-openvino:
     name: "Stage 2: Linux OpenVINO CI (openvino provider gate)"
     needs: detect-changes
     if: needs.detect-changes.outputs.openvino == 'true'
     uses: ./.github/workflows/linux_openvino_ci.yml
+
+  stage2-windows-openvino:
+    name: "Stage 2: Windows OpenVINO CI Pipeline (openvino provider gate)"
+    needs: detect-changes
+    if: needs.detect-changes.outputs.openvino == 'true'
+    uses: ./.github/workflows/windows_openvino.yml
 
   stage2-dml:
     name: "Stage 2: Windows DML CI (dml provider gate)"
@@ -138,6 +204,12 @@ jobs:
     needs: detect-changes
     if: needs.detect-changes.outputs.webgpu == 'true'
     uses: ./.github/workflows/linux_webgpu.yml
+
+  stage2-windows-webgpu:
+    name: "Stage 2: ONNX Runtime WebGPU Builds (webgpu provider gate)"
+    needs: detect-changes
+    if: needs.detect-changes.outputs.webgpu == 'true'
+    uses: ./.github/workflows/windows_webgpu.yml
 
   stage2-qnn:
     name: "Stage 2: Windows QNN CI (qnn provider gate)"
@@ -178,21 +250,35 @@ jobs:
   # Stage 3 placeholder: remaining CI workflows will be added here as jobs (one `uses:` per
   # workflow, converted to workflow_call) once each has been validated individually. Each such job
   # should set:
-  #   needs: [detect-changes, stage2-linux-cpu, stage2-cuda, stage2-tensorrt, stage2-openvino,
-  #           stage2-dml, stage2-webgpu, stage2-qnn, stage2-xnnpack, stage2-vitisai, stage2-coreml,
+  #   needs: [detect-changes, stage2-linux-cpu, stage2-windows-release, stage2-windows-debug,
+  #           stage2-windows-ep-generic, stage2-windows-cpu, stage2-windows-asan, stage2-cuda,
+  #           stage2-windows-cuda, stage2-windows-cuda-plugin, stage2-tensorrt,
+  #           stage2-windows-tensorrt, stage2-openvino, stage2-windows-openvino, stage2-dml,
+  #           stage2-webgpu, stage2-windows-webgpu, stage2-qnn, stage2-xnnpack, stage2-vitisai, stage2-coreml,
   #           stage2-nnapi, stage2-js]
   #   if: |
   #     always() &&
   #     needs.detect-changes.result == 'success' &&
   #     (needs.stage2-linux-cpu.result == 'success' || needs.stage2-linux-cpu.result == 'skipped') &&
+  #     (needs.stage2-windows-release.result == 'success' || needs.stage2-windows-release.result == 'skipped') &&
+  #     (needs.stage2-windows-debug.result == 'success' || needs.stage2-windows-debug.result == 'skipped') &&
+  #     (needs.stage2-windows-ep-generic.result == 'success' || needs.stage2-windows-ep-generic.result == 'skipped') &&
+  #     (needs.stage2-windows-cpu.result == 'success' || needs.stage2-windows-cpu.result == 'skipped') &&
+  #     (needs.stage2-windows-asan.result == 'success' || needs.stage2-windows-asan.result == 'skipped') &&
   #     (needs.stage2-cuda.result == 'success' || needs.stage2-cuda.result == 'skipped') &&
+  #     (needs.stage2-windows-cuda.result == 'success' || needs.stage2-windows-cuda.result == 'skipped') &&
+  #     (needs.stage2-windows-cuda-plugin.result == 'success' || needs.stage2-windows-cuda-plugin.result == 'skipped') &&
   #     (needs.stage2-tensorrt.result == 'success' || needs.stage2-tensorrt.result == 'skipped') &&
+  #     (needs.stage2-windows-tensorrt.result == 'success' || needs.stage2-windows-tensorrt.result == 'skipped') &&
   #     (needs.stage2-openvino.result == 'success' || needs.stage2-openvino.result == 'skipped') &&
+  #     (needs.stage2-windows-openvino.result == 'success' || needs.stage2-windows-openvino.result == 'skipped') &&
   #     (needs.stage2-dml.result == 'success' || needs.stage2-dml.result == 'skipped') &&
   #     (needs.stage2-webgpu.result == 'success' || needs.stage2-webgpu.result == 'skipped') &&
+  #     (needs.stage2-windows-webgpu.result == 'success' || needs.stage2-windows-webgpu.result == 'skipped') &&
   #     (needs.stage2-qnn.result == 'success' || needs.stage2-qnn.result == 'skipped') &&
   #     (needs.stage2-xnnpack.result == 'success' || needs.stage2-xnnpack.result == 'skipped') &&
   #     (needs.stage2-vitisai.result == 'success' || needs.stage2-vitisai.result == 'skipped') &&
   #     (needs.stage2-coreml.result == 'success' || needs.stage2-coreml.result == 'skipped') &&
   #     (needs.stage2-nnapi.result == 'success' || needs.stage2-nnapi.result == 'skipped') &&
   #     (needs.stage2-js.result == 'success' || needs.stage2-js.result == 'skipped')
+

--- a/.github/workflows/ci_orchestrator.yml
+++ b/.github/workflows/ci_orchestrator.yml
@@ -26,22 +26,23 @@
 #                            provider area and so have no path-filter of their own:
 #                            windows_x64_release, windows_x64_debug,
 #                            windows_x64_release_ep_generic_interface, windows_x86 (x64 CPU
-#                            Pipeline), windows_x64_asan, CUDA Plugin Linux CI, Linux CPU Minimal
-#                            Build E2E, iOS CI on Mac, React Native CI Pipeline. Note the first four
-#                            all run on the contended Win2022-GPU-A10 pool despite being "generic"
-#                            builds - they deliberately live in Stage 3, not Stage 2, so a broad
-#                            "framework" match (e.g. touching .github/workflows/** or a big chunk of
-#                            onnxruntime/core/**) doesn't put them on the hook for every PR; they
-#                            still build/test on every PR, just gated behind Stage 2 succeeding
-#                            (or being skipped) instead of racing it or being mislabeled as a
-#                            "targeted" gate. Not included here (left as standalone,
-#                            independently-triggered workflows): CodeQL and
+#                            Pipeline), windows_x64_asan, windows_gpu_doc_gen.yml (Windows GPU
+#                            Kernel Documentation Validation), CUDA Plugin Linux CI, Linux CPU
+#                            Minimal Build E2E, iOS CI on Mac, React Native CI Pipeline. Note the
+#                            first five all run on the contended Win2022-GPU-A10 pool despite being
+#                            "generic"/near-unfiltered (windows_gpu_doc_gen.yml's own `paths: '**'`
+#                            match is effectively no filter at all) - they deliberately live in
+#                            Stage 3, not Stage 2, so a broad "framework" match (e.g. touching
+#                            .github/workflows/** or a big chunk of onnxruntime/core/**) doesn't put
+#                            them on the hook for every PR; they still build/test on every PR, just
+#                            gated behind Stage 2 succeeding (or being skipped) instead of racing it
+#                            or being mislabeled as a "targeted" gate. Not included here (left as
+#                            standalone, independently-triggered workflows): CodeQL and
 #                            gradle-wrapper-validation (security/policy checks, kept independent of
 #                            build gating on purpose), pr_checks.yml (lightweight bot job), the
 #                            publish-*-apidocs.yml workflows and linux/windows_cuda_no_cudnn.yml
 #                            (each already has its own narrow `paths:` filter so isn't a backlog
-#                            contributor), and windows_gpu_doc_gen.yml (broad path filter, but
-#                            empirically fast/low-contention, not a queue-timeout contributor).
+#                            contributor).
 #
 # NOTE: Every workflow wired into Stage 2 and Stage 3 above has had its standalone `pull_request:`
 # trigger removed (see each workflow's `on:` block) - ci_orchestrator.yml is now the sole PR entry
@@ -292,6 +293,15 @@ jobs:
     needs: *stage3_needs
     if: *stage3_gate
     uses: ./.github/workflows/windows_build_x64_asan.yml
+
+  # windows_gpu_doc_gen.yml has a near-unfiltered `paths: '**'` match and runs on the contended
+  # Win2022-GPU-A10 pool (300 min timeout) - it belongs in Stage 3, not left standalone, so it
+  # doesn't race every PR independently of Stage 2.
+  stage3-windows-gpu-doc-gen:
+    name: "Stage 3: Windows GPU Kernel Documentation Validation"
+    needs: *stage3_needs
+    if: *stage3_gate
+    uses: ./.github/workflows/windows_gpu_doc_gen.yml
 
   stage3-linux-cuda-plugin:
     name: "Stage 3: CUDA Plugin Linux CI"

--- a/.github/workflows/ci_orchestrator.yml
+++ b/.github/workflows/ci_orchestrator.yml
@@ -117,55 +117,46 @@ jobs:
             cuda:
               - 'onnxruntime/core/providers/cuda/**'
               - 'onnxruntime/contrib_ops/cuda/**'
-              - '.github/workflows/linux_cuda_ci.yml'
-              - '.github/workflows/windows_cuda.yml'
-              - '.github/workflows/windows_cuda_plugin.yml'
             tensorrt:
               - 'onnxruntime/core/providers/tensorrt/**'
               - 'onnxruntime/core/providers/nv_tensorrt_rtx/**'
-              - '.github/workflows/linux_tensorrt_ci.yml'
-              - '.github/workflows/windows_tensorrt.yml'
             openvino:
               - 'onnxruntime/core/providers/openvino/**'
-              - '.github/workflows/linux_openvino_ci.yml'
-              - '.github/workflows/windows_openvino.yml'
             dml:
               - 'onnxruntime/core/providers/dml/**'
-              - '.github/workflows/windows_dml.yml'
             webgpu:
               - 'onnxruntime/core/providers/webgpu/**'
               - 'onnxruntime/contrib_ops/webgpu/**'
-              - '.github/workflows/linux_webgpu.yml'
-              - '.github/workflows/windows_webgpu.yml'
             qnn:
               - 'onnxruntime/core/providers/qnn/**'
-              - '.github/workflows/windows_qnn_x64.yml'
             xnnpack:
               - 'onnxruntime/core/providers/xnnpack/**'
-              - '.github/workflows/windows_x64_release_xnnpack.yml'
             vitisai:
               - 'onnxruntime/core/providers/vitisai/**'
-              - '.github/workflows/windows_x64_release_vitisai_build_x64_release.yml'
             coreml:
               - 'onnxruntime/core/providers/coreml/**'
-              - '.github/workflows/mac.yml'
             nnapi:
               - 'onnxruntime/core/providers/nnapi/**'
-              - '.github/workflows/android.yml'
             js:
               - 'onnxruntime/core/providers/js/**'
               - 'onnxruntime/core/providers/webnn/**'
               - 'js/**'
-              - '.github/workflows/web.yml'
             # Providers intentionally not yet wired to a Stage 2 gate (no reusable CI workflow
             # identified / low PR volume): acl, azure, cann, dnnl, migraphx, rknpu, snpe, vsinpu,
             # winml. Add filters + jobs here the same way once their workflow is converted.
             #
-            # NOTE: each provider filter above also matches that provider's own CI workflow
-            # file(s) directly (not just source paths). Without this, a PR that only edits e.g.
-            # windows_cuda.yml would trip the broad "framework" gate (via .github/workflows/**)
-            # but never run the CUDA gate whose YAML actually changed, leaving the edit
-            # unvalidated.
+            # NOTE (deliberate trade-off): provider filters intentionally match only that
+            # provider's *source* paths, not its own CI workflow file. A PR that edits only e.g.
+            # windows_cuda.yml (no onnxruntime/core/providers/cuda/** change) will trip the broad
+            # "framework" gate (via .github/workflows/**) but not the cuda gate - accepted because
+            # the alternative (matching each provider's own workflow file) makes any PR that edits
+            # many workflow files at once - such as this CI-gating PR itself, which touches nearly
+            # every provider's workflow file purely for the workflow_call conversion, with zero
+            # provider source changes - trigger every single Stage 2 gate simultaneously. That
+            # defeats the entire point of narrow gating for exactly the kind of PR most likely to
+            # touch these files. YAML/schema issues in a provider's own workflow file are still
+            # caught the next time that gate is exercised by a real source change, or can be
+            # smoke-tested manually via workflow_dispatch.
 
   stage2-linux-cpu:
     name: "Stage 2: Linux CI CPU (framework gate)"

--- a/.github/workflows/ci_orchestrator.yml
+++ b/.github/workflows/ci_orchestrator.yml
@@ -7,10 +7,10 @@
 #                                -> linux_ci.yml (Linux CPU build+test): cheapest/fastest full leg,
 #                                highest-signal predictor of framework-level breakage.
 #                              - "<provider>" gate (onnxruntime/core/providers/<provider>/**) -> that
-#                                provider's own CI workflow(s), e.g. cuda -> linux_cuda_ci.yml.
-#                                Piloting with CUDA only for now; other providers (tensorrt, dml,
-#                                openvino, webgpu, qnn, coreml, nnapi, js/webnn, ...) will be added
-#                                the same way as their workflows are converted to workflow_call.
+#                                provider's own CI workflow(s). Wired so far: cuda, tensorrt,
+#                                openvino, dml, webgpu, qnn, xnnpack, vitisai, coreml, nnapi,
+#                                js/webnn. Not yet wired (no obvious reusable CI workflow or low PR
+#                                volume): acl, azure, cann, dnnl, migraphx, rknpu, snpe, vsinpu, winml.
 #                            Multiple gates can run in parallel when a PR touches more than one area
 #                            (e.g. framework + cuda).
 # Stage 3 (everything else): Placeholder for now - will fan out to the remaining CI workflows as
@@ -49,6 +49,16 @@ jobs:
     outputs:
       framework: ${{ steps.filter.outputs.framework }}
       cuda: ${{ steps.filter.outputs.cuda }}
+      tensorrt: ${{ steps.filter.outputs.tensorrt }}
+      openvino: ${{ steps.filter.outputs.openvino }}
+      dml: ${{ steps.filter.outputs.dml }}
+      webgpu: ${{ steps.filter.outputs.webgpu }}
+      qnn: ${{ steps.filter.outputs.qnn }}
+      xnnpack: ${{ steps.filter.outputs.xnnpack }}
+      vitisai: ${{ steps.filter.outputs.vitisai }}
+      coreml: ${{ steps.filter.outputs.coreml }}
+      nnapi: ${{ steps.filter.outputs.nnapi }}
+      js: ${{ steps.filter.outputs.js }}
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v3
@@ -61,12 +71,37 @@ jobs:
               - '!onnxruntime/core/platform/**'
               - 'include/onnxruntime/core/**'
               - 'cmake/**'
+              - '.github/workflows/**' # CI infra changes are treated as framework-level
             cuda:
               - 'onnxruntime/core/providers/cuda/**'
               - 'onnxruntime/contrib_ops/cuda/**'
-            # Additional provider filters (tensorrt, dml, openvino, webgpu, qnn, coreml, nnapi,
-            # js/webnn, ...) will be added here as their CI workflows are converted to
-            # workflow_call and wired up as Stage 2 gates below.
+            tensorrt:
+              - 'onnxruntime/core/providers/tensorrt/**'
+              - 'onnxruntime/core/providers/nv_tensorrt_rtx/**'
+            openvino:
+              - 'onnxruntime/core/providers/openvino/**'
+            dml:
+              - 'onnxruntime/core/providers/dml/**'
+            webgpu:
+              - 'onnxruntime/core/providers/webgpu/**'
+              - 'onnxruntime/contrib_ops/webgpu/**'
+            qnn:
+              - 'onnxruntime/core/providers/qnn/**'
+            xnnpack:
+              - 'onnxruntime/core/providers/xnnpack/**'
+            vitisai:
+              - 'onnxruntime/core/providers/vitisai/**'
+            coreml:
+              - 'onnxruntime/core/providers/coreml/**'
+            nnapi:
+              - 'onnxruntime/core/providers/nnapi/**'
+            js:
+              - 'onnxruntime/core/providers/js/**'
+              - 'onnxruntime/core/providers/webnn/**'
+              - 'js/**'
+            # Providers intentionally not yet wired to a Stage 2 gate (no reusable CI workflow
+            # identified / low PR volume): acl, azure, cann, dnnl, migraphx, rknpu, snpe, vsinpu,
+            # winml. Add filters + jobs here the same way once their workflow is converted.
 
   stage2-linux-cpu:
     name: "Stage 2: Linux CI CPU (framework gate)"
@@ -80,12 +115,84 @@ jobs:
     if: needs.detect-changes.outputs.cuda == 'true'
     uses: ./.github/workflows/linux_cuda_ci.yml
 
+  stage2-tensorrt:
+    name: "Stage 2: Linux TensorRT CI (tensorrt provider gate)"
+    needs: detect-changes
+    if: needs.detect-changes.outputs.tensorrt == 'true'
+    uses: ./.github/workflows/linux_tensorrt_ci.yml
+
+  stage2-openvino:
+    name: "Stage 2: Linux OpenVINO CI (openvino provider gate)"
+    needs: detect-changes
+    if: needs.detect-changes.outputs.openvino == 'true'
+    uses: ./.github/workflows/linux_openvino_ci.yml
+
+  stage2-dml:
+    name: "Stage 2: Windows DML CI (dml provider gate)"
+    needs: detect-changes
+    if: needs.detect-changes.outputs.dml == 'true'
+    uses: ./.github/workflows/windows_dml.yml
+
+  stage2-webgpu:
+    name: "Stage 2: Linux WebGPU CI (webgpu provider gate)"
+    needs: detect-changes
+    if: needs.detect-changes.outputs.webgpu == 'true'
+    uses: ./.github/workflows/linux_webgpu.yml
+
+  stage2-qnn:
+    name: "Stage 2: Windows QNN CI (qnn provider gate)"
+    needs: detect-changes
+    if: needs.detect-changes.outputs.qnn == 'true'
+    uses: ./.github/workflows/windows_qnn_x64.yml
+
+  stage2-xnnpack:
+    name: "Stage 2: Windows XNNPACK CI (xnnpack provider gate)"
+    needs: detect-changes
+    if: needs.detect-changes.outputs.xnnpack == 'true'
+    uses: ./.github/workflows/windows_x64_release_xnnpack.yml
+
+  stage2-vitisai:
+    name: "Stage 2: Windows VitisAI CI (vitisai provider gate)"
+    needs: detect-changes
+    if: needs.detect-changes.outputs.vitisai == 'true'
+    uses: ./.github/workflows/windows_x64_release_vitisai_build_x64_release.yml
+
+  stage2-coreml:
+    name: "Stage 2: macOS CI (coreml provider gate)"
+    needs: detect-changes
+    if: needs.detect-changes.outputs.coreml == 'true'
+    uses: ./.github/workflows/mac.yml
+
+  stage2-nnapi:
+    name: "Stage 2: Android CI (nnapi provider gate)"
+    needs: detect-changes
+    if: needs.detect-changes.outputs.nnapi == 'true'
+    uses: ./.github/workflows/android.yml
+
+  stage2-js:
+    name: "Stage 2: Web CI (js/webnn provider gate)"
+    needs: detect-changes
+    if: needs.detect-changes.outputs.js == 'true'
+    uses: ./.github/workflows/web.yml
+
   # Stage 3 placeholder: remaining CI workflows will be added here as jobs (one `uses:` per
   # workflow, converted to workflow_call) once each has been validated individually. Each such job
   # should set:
-  #   needs: [detect-changes, stage2-linux-cpu, stage2-cuda]
+  #   needs: [detect-changes, stage2-linux-cpu, stage2-cuda, stage2-tensorrt, stage2-openvino,
+  #           stage2-dml, stage2-webgpu, stage2-qnn, stage2-xnnpack, stage2-vitisai, stage2-coreml,
+  #           stage2-nnapi, stage2-js]
   #   if: |
   #     always() &&
   #     needs.detect-changes.result == 'success' &&
   #     (needs.stage2-linux-cpu.result == 'success' || needs.stage2-linux-cpu.result == 'skipped') &&
-  #     (needs.stage2-cuda.result == 'success' || needs.stage2-cuda.result == 'skipped')
+  #     (needs.stage2-cuda.result == 'success' || needs.stage2-cuda.result == 'skipped') &&
+  #     (needs.stage2-tensorrt.result == 'success' || needs.stage2-tensorrt.result == 'skipped') &&
+  #     (needs.stage2-openvino.result == 'success' || needs.stage2-openvino.result == 'skipped') &&
+  #     (needs.stage2-dml.result == 'success' || needs.stage2-dml.result == 'skipped') &&
+  #     (needs.stage2-webgpu.result == 'success' || needs.stage2-webgpu.result == 'skipped') &&
+  #     (needs.stage2-qnn.result == 'success' || needs.stage2-qnn.result == 'skipped') &&
+  #     (needs.stage2-xnnpack.result == 'success' || needs.stage2-xnnpack.result == 'skipped') &&
+  #     (needs.stage2-vitisai.result == 'success' || needs.stage2-vitisai.result == 'skipped') &&
+  #     (needs.stage2-coreml.result == 'success' || needs.stage2-coreml.result == 'skipped') &&
+  #     (needs.stage2-nnapi.result == 'success' || needs.stage2-nnapi.result == 'skipped') &&
+  #     (needs.stage2-js.result == 'success' || needs.stage2-js.result == 'skipped')

--- a/.github/workflows/ci_orchestrator.yml
+++ b/.github/workflows/ci_orchestrator.yml
@@ -62,6 +62,17 @@ concurrency:
 
 permissions:
   contents: read
+  # Reusable workflows are capped at the permissions the caller grants, so this must be a superset
+  # of what every Stage 1-3 callee (and its jobs) requests: lint.yml's Python-format job asks for
+  # security-events: write and its optional-lint job's reviewdog reporters need checks: write;
+  # linux_ci.yml/linux_cuda_ci.yml/android.yml/etc. ask for packages: write, attestations: write,
+  # and id-token: write. Without these, GitHub can reject the call outright (startup failure) or
+  # individual steps fail with permission errors instead of a clear message.
+  packages: write
+  attestations: write
+  id-token: write
+  security-events: write
+  checks: write
 
 jobs:
   lint:
@@ -74,6 +85,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      # dorny/paths-filter needs this to query the PR's changed files via the API on
+      # pull_request events; without it the filter step can fail and no Stage 2/3 job would run.
+      pull-requests: read
     outputs:
       framework: ${{ steps.filter.outputs.framework }}
       cuda: ${{ steps.filter.outputs.cuda }}
@@ -103,33 +117,55 @@ jobs:
             cuda:
               - 'onnxruntime/core/providers/cuda/**'
               - 'onnxruntime/contrib_ops/cuda/**'
+              - '.github/workflows/linux_cuda_ci.yml'
+              - '.github/workflows/windows_cuda.yml'
+              - '.github/workflows/windows_cuda_plugin.yml'
             tensorrt:
               - 'onnxruntime/core/providers/tensorrt/**'
               - 'onnxruntime/core/providers/nv_tensorrt_rtx/**'
+              - '.github/workflows/linux_tensorrt_ci.yml'
+              - '.github/workflows/windows_tensorrt.yml'
             openvino:
               - 'onnxruntime/core/providers/openvino/**'
+              - '.github/workflows/linux_openvino_ci.yml'
+              - '.github/workflows/windows_openvino.yml'
             dml:
               - 'onnxruntime/core/providers/dml/**'
+              - '.github/workflows/windows_dml.yml'
             webgpu:
               - 'onnxruntime/core/providers/webgpu/**'
               - 'onnxruntime/contrib_ops/webgpu/**'
+              - '.github/workflows/linux_webgpu.yml'
+              - '.github/workflows/windows_webgpu.yml'
             qnn:
               - 'onnxruntime/core/providers/qnn/**'
+              - '.github/workflows/windows_qnn_x64.yml'
             xnnpack:
               - 'onnxruntime/core/providers/xnnpack/**'
+              - '.github/workflows/windows_x64_release_xnnpack.yml'
             vitisai:
               - 'onnxruntime/core/providers/vitisai/**'
+              - '.github/workflows/windows_x64_release_vitisai_build_x64_release.yml'
             coreml:
               - 'onnxruntime/core/providers/coreml/**'
+              - '.github/workflows/mac.yml'
             nnapi:
               - 'onnxruntime/core/providers/nnapi/**'
+              - '.github/workflows/android.yml'
             js:
               - 'onnxruntime/core/providers/js/**'
               - 'onnxruntime/core/providers/webnn/**'
               - 'js/**'
+              - '.github/workflows/web.yml'
             # Providers intentionally not yet wired to a Stage 2 gate (no reusable CI workflow
             # identified / low PR volume): acl, azure, cann, dnnl, migraphx, rknpu, snpe, vsinpu,
             # winml. Add filters + jobs here the same way once their workflow is converted.
+            #
+            # NOTE: each provider filter above also matches that provider's own CI workflow
+            # file(s) directly (not just source paths). Without this, a PR that only edits e.g.
+            # windows_cuda.yml would trip the broad "framework" gate (via .github/workflows/**)
+            # but never run the CUDA gate whose YAML actually changed, leaving the edit
+            # unvalidated.
 
   stage2-linux-cpu:
     name: "Stage 2: Linux CI CPU (framework gate)"

--- a/.github/workflows/ci_orchestrator.yml
+++ b/.github/workflows/ci_orchestrator.yml
@@ -21,15 +21,27 @@
 #                                migraphx, rknpu, snpe, vsinpu, winml.
 #                            Multiple gates can run in parallel when a PR touches more than one area
 #                            (e.g. framework + cuda).
-# Stage 3 (everything else): Placeholder for now - will fan out to the remaining CI workflows as
-#                            they are incrementally converted to workflow_call (see rollout plan).
-#                            Waits for all Stage 2 gates that were triggered to succeed (skipped
-#                            gates count as pass-through).
+# Stage 3 (everything else):  Runs after all Stage 2 gates that were triggered succeed (skipped
+#                            gates count as pass-through, via the shared `&stage3_gate` anchor).
+#                            Fans out to the remaining CI workflows that aren't tied to a single
+#                            provider area and so have no path-filter of their own: CUDA Plugin
+#                            Linux CI, Linux CPU Minimal Build E2E, iOS CI on Mac, React Native CI
+#                            Pipeline. These still build/test on every PR, just no longer racing
+#                            Stage 2 independently - if Stage 2 already caught a break, Stage 3 is
+#                            skipped instead of burning a runner. Not included here (left as
+#                            standalone, independently-triggered workflows): CodeQL and
+#                            gradle-wrapper-validation (security/policy checks, kept independent of
+#                            build gating on purpose), pr_checks.yml (lightweight bot job), the
+#                            publish-*-apidocs.yml workflows and linux/windows_cuda_no_cudnn.yml
+#                            (each already has its own narrow `paths:` filter so isn't a backlog
+#                            contributor), and windows_gpu_doc_gen.yml (broad path filter, but
+#                            empirically fast/low-contention, not a queue-timeout contributor).
 #
-# NOTE: Every workflow wired into Stage 2 above has had its standalone `pull_request:` trigger
-# removed (see each workflow's `on:` block) - ci_orchestrator.yml is now the sole PR entry point for
-# those workflows, so unrelated PRs no longer queue Windows/Linux GPU runners they don't need. This
-# is what actually reduces contention on the self-hosted runner pools, not just a cosmetic gate.
+# NOTE: Every workflow wired into Stage 2 and Stage 3 above has had its standalone `pull_request:`
+# trigger removed (see each workflow's `on:` block) - ci_orchestrator.yml is now the sole PR entry
+# point for those workflows, so unrelated PRs no longer queue Windows/Linux GPU runners they don't
+# need. This is what actually reduces contention on the self-hosted runner pools, not just a
+# cosmetic gate.
 
 name: CI Orchestrator
 
@@ -247,36 +259,62 @@ jobs:
     if: needs.detect-changes.outputs.js == 'true'
     uses: ./.github/workflows/web.yml
 
-  # Stage 3 placeholder: remaining CI workflows will be added here as jobs (one `uses:` per
-  # workflow, converted to workflow_call) once each has been validated individually. Each such job
-  # should set:
-  #   needs: [detect-changes, stage2-linux-cpu, stage2-windows-release, stage2-windows-debug,
-  #           stage2-windows-ep-generic, stage2-windows-cpu, stage2-windows-asan, stage2-cuda,
-  #           stage2-windows-cuda, stage2-windows-cuda-plugin, stage2-tensorrt,
-  #           stage2-windows-tensorrt, stage2-openvino, stage2-windows-openvino, stage2-dml,
-  #           stage2-webgpu, stage2-windows-webgpu, stage2-qnn, stage2-xnnpack, stage2-vitisai, stage2-coreml,
-  #           stage2-nnapi, stage2-js]
-  #   if: |
-  #     always() &&
-  #     needs.detect-changes.result == 'success' &&
-  #     (needs.stage2-linux-cpu.result == 'success' || needs.stage2-linux-cpu.result == 'skipped') &&
-  #     (needs.stage2-windows-release.result == 'success' || needs.stage2-windows-release.result == 'skipped') &&
-  #     (needs.stage2-windows-debug.result == 'success' || needs.stage2-windows-debug.result == 'skipped') &&
-  #     (needs.stage2-windows-ep-generic.result == 'success' || needs.stage2-windows-ep-generic.result == 'skipped') &&
-  #     (needs.stage2-windows-cpu.result == 'success' || needs.stage2-windows-cpu.result == 'skipped') &&
-  #     (needs.stage2-windows-asan.result == 'success' || needs.stage2-windows-asan.result == 'skipped') &&
-  #     (needs.stage2-cuda.result == 'success' || needs.stage2-cuda.result == 'skipped') &&
-  #     (needs.stage2-windows-cuda.result == 'success' || needs.stage2-windows-cuda.result == 'skipped') &&
-  #     (needs.stage2-windows-cuda-plugin.result == 'success' || needs.stage2-windows-cuda-plugin.result == 'skipped') &&
-  #     (needs.stage2-tensorrt.result == 'success' || needs.stage2-tensorrt.result == 'skipped') &&
-  #     (needs.stage2-windows-tensorrt.result == 'success' || needs.stage2-windows-tensorrt.result == 'skipped') &&
-  #     (needs.stage2-openvino.result == 'success' || needs.stage2-openvino.result == 'skipped') &&
-  #     (needs.stage2-windows-openvino.result == 'success' || needs.stage2-windows-openvino.result == 'skipped') &&
-  #     (needs.stage2-dml.result == 'success' || needs.stage2-dml.result == 'skipped') &&
-  #     (needs.stage2-webgpu.result == 'success' || needs.stage2-webgpu.result == 'skipped') &&
-  #     (needs.stage2-windows-webgpu.result == 'success' || needs.stage2-windows-webgpu.result == 'skipped') &&
-  #     (needs.stage2-qnn.result == 'success' || needs.stage2-qnn.result == 'skipped') &&
-  #     (needs.stage2-xnnpack.result == 'success' || needs.stage2-xnnpack.result == 'skipped') &&
+  # Stage 3: fan out to the remaining CI workflows that aren't tied to one provider area, so they
+  # don't waste a runner if Stage 2 already found a break. These still run for every PR (no
+  # path-filter gate of their own), just after Stage 2 instead of racing it independently.
+  stage3-linux-cuda-plugin:
+    name: "Stage 3: CUDA Plugin Linux CI"
+    needs: &stage3_needs [detect-changes, stage2-linux-cpu, stage2-windows-release, stage2-windows-debug,
+            stage2-windows-ep-generic, stage2-windows-cpu, stage2-windows-asan, stage2-cuda,
+            stage2-windows-cuda, stage2-windows-cuda-plugin, stage2-tensorrt,
+            stage2-windows-tensorrt, stage2-openvino, stage2-windows-openvino, stage2-dml,
+            stage2-webgpu, stage2-windows-webgpu, stage2-qnn, stage2-xnnpack, stage2-vitisai,
+            stage2-coreml, stage2-nnapi, stage2-js]
+    if: &stage3_gate |
+      always() &&
+      needs.detect-changes.result == 'success' &&
+      (needs.stage2-linux-cpu.result == 'success' || needs.stage2-linux-cpu.result == 'skipped') &&
+      (needs.stage2-windows-release.result == 'success' || needs.stage2-windows-release.result == 'skipped') &&
+      (needs.stage2-windows-debug.result == 'success' || needs.stage2-windows-debug.result == 'skipped') &&
+      (needs.stage2-windows-ep-generic.result == 'success' || needs.stage2-windows-ep-generic.result == 'skipped') &&
+      (needs.stage2-windows-cpu.result == 'success' || needs.stage2-windows-cpu.result == 'skipped') &&
+      (needs.stage2-windows-asan.result == 'success' || needs.stage2-windows-asan.result == 'skipped') &&
+      (needs.stage2-cuda.result == 'success' || needs.stage2-cuda.result == 'skipped') &&
+      (needs.stage2-windows-cuda.result == 'success' || needs.stage2-windows-cuda.result == 'skipped') &&
+      (needs.stage2-windows-cuda-plugin.result == 'success' || needs.stage2-windows-cuda-plugin.result == 'skipped') &&
+      (needs.stage2-tensorrt.result == 'success' || needs.stage2-tensorrt.result == 'skipped') &&
+      (needs.stage2-windows-tensorrt.result == 'success' || needs.stage2-windows-tensorrt.result == 'skipped') &&
+      (needs.stage2-openvino.result == 'success' || needs.stage2-openvino.result == 'skipped') &&
+      (needs.stage2-windows-openvino.result == 'success' || needs.stage2-windows-openvino.result == 'skipped') &&
+      (needs.stage2-dml.result == 'success' || needs.stage2-dml.result == 'skipped') &&
+      (needs.stage2-webgpu.result == 'success' || needs.stage2-webgpu.result == 'skipped') &&
+      (needs.stage2-windows-webgpu.result == 'success' || needs.stage2-windows-webgpu.result == 'skipped') &&
+      (needs.stage2-qnn.result == 'success' || needs.stage2-qnn.result == 'skipped') &&
+      (needs.stage2-xnnpack.result == 'success' || needs.stage2-xnnpack.result == 'skipped') &&
+      (needs.stage2-vitisai.result == 'success' || needs.stage2-vitisai.result == 'skipped') &&
+      (needs.stage2-coreml.result == 'success' || needs.stage2-coreml.result == 'skipped') &&
+      (needs.stage2-nnapi.result == 'success' || needs.stage2-nnapi.result == 'skipped') &&
+      (needs.stage2-js.result == 'success' || needs.stage2-js.result == 'skipped')
+    uses: ./.github/workflows/linux_cuda_plugin_ci.yml
+
+  stage3-linux-minimal-build:
+    name: "Stage 3: Linux CPU Minimal Build E2E"
+    needs: *stage3_needs
+    if: *stage3_gate
+    uses: ./.github/workflows/linux_minimal_build.yml
+
+  stage3-ios:
+    name: "Stage 3: iOS CI on Mac"
+    needs: *stage3_needs
+    if: *stage3_gate
+    uses: ./.github/workflows/ios.yml
+
+  stage3-react-native:
+    name: "Stage 3: React Native CI Pipeline"
+    needs: *stage3_needs
+    if: *stage3_gate
+    uses: ./.github/workflows/react_native.yml
+
   #     (needs.stage2-vitisai.result == 'success' || needs.stage2-vitisai.result == 'skipped') &&
   #     (needs.stage2-coreml.result == 'success' || needs.stage2-coreml.result == 'skipped') &&
   #     (needs.stage2-nnapi.result == 'success' || needs.stage2-nnapi.result == 'skipped') &&

--- a/.github/workflows/ci_orchestrator.yml
+++ b/.github/workflows/ci_orchestrator.yml
@@ -1,15 +1,14 @@
 # Pilot for staged CI gating (see design discussion / rollout plan).
 #
 # Stage 1 (lint):            Reuses lint.yml. Must succeed before anything else runs.
-# Stage 2 (targeted gates):  Only the CI job(s) covering the changed area run here, gated on Stage 1:
+# Stage 2 (targeted gates):  ONLY the CI job(s) that actually cover the changed area run here,
+#                            gated on Stage 1. Kept intentionally narrow - no generic/catch-all
+#                            builds live in Stage 2, so a PR only pays for the runners its change
+#                            actually needs:
 #                              - "framework" gate (onnxruntime/core/** excluding core/providers/**
 #                                and core/platform/**, plus include/onnxruntime/core/** and cmake/**)
-#                                -> linux_ci.yml (Linux CPU build+test, cheapest/fastest full leg,
-#                                highest-signal predictor of framework-level breakage), plus the
-#                                generic (non-provider-specific) full-ORT Windows builds that used
-#                                to run unconditionally on every PR: windows_x64_release,
-#                                windows_x64_debug, windows_x64_release_ep_generic_interface,
-#                                Windows CPU CI Pipeline (x86), windows_x64_asan.
+#                                -> linux_ci.yml only (Linux CPU build+test, cheapest/fastest full
+#                                leg, highest-signal predictor of framework-level breakage).
 #                              - "<provider>" gate (onnxruntime/core/providers/<provider>/**) -> that
 #                                provider's own CI workflow(s), Linux and Windows legs alike. Wired
 #                                so far: cuda (Linux CUDA CI, ONNX Runtime CUDA Builds, CUDA Plugin
@@ -24,12 +23,19 @@
 # Stage 3 (everything else):  Runs after all Stage 2 gates that were triggered succeed (skipped
 #                            gates count as pass-through, via the shared `&stage3_gate` anchor).
 #                            Fans out to the remaining CI workflows that aren't tied to a single
-#                            provider area and so have no path-filter of their own: CUDA Plugin
-#                            Linux CI, Linux CPU Minimal Build E2E, iOS CI on Mac, React Native CI
-#                            Pipeline. These still build/test on every PR, just no longer racing
-#                            Stage 2 independently - if Stage 2 already caught a break, Stage 3 is
-#                            skipped instead of burning a runner. Not included here (left as
-#                            standalone, independently-triggered workflows): CodeQL and
+#                            provider area and so have no path-filter of their own:
+#                            windows_x64_release, windows_x64_debug,
+#                            windows_x64_release_ep_generic_interface, windows_x86 (x64 CPU
+#                            Pipeline), windows_x64_asan, CUDA Plugin Linux CI, Linux CPU Minimal
+#                            Build E2E, iOS CI on Mac, React Native CI Pipeline. Note the first four
+#                            all run on the contended Win2022-GPU-A10 pool despite being "generic"
+#                            builds - they deliberately live in Stage 3, not Stage 2, so a broad
+#                            "framework" match (e.g. touching .github/workflows/** or a big chunk of
+#                            onnxruntime/core/**) doesn't put them on the hook for every PR; they
+#                            still build/test on every PR, just gated behind Stage 2 succeeding
+#                            (or being skipped) instead of racing it or being mislabeled as a
+#                            "targeted" gate. Not included here (left as standalone,
+#                            independently-triggered workflows): CodeQL and
 #                            gradle-wrapper-validation (security/policy checks, kept independent of
 #                            build gating on purpose), pr_checks.yml (lightweight bot job), the
 #                            publish-*-apidocs.yml workflows and linux/windows_cuda_no_cudnn.yml
@@ -130,39 +136,6 @@ jobs:
     if: needs.detect-changes.outputs.framework == 'true'
     uses: ./.github/workflows/linux_ci.yml
 
-  # windows_x64_release / windows_x64_debug / windows_x64_release_ep_generic_interface / Windows CPU
-  # CI Pipeline / windows_x64_asan are generic full-ORT builds (not tied to one provider), so they
-  # ride on the same "framework" gate as stage2-linux-cpu above.
-  stage2-windows-release:
-    name: "Stage 2: Windows x64 Release (framework gate)"
-    needs: detect-changes
-    if: needs.detect-changes.outputs.framework == 'true'
-    uses: ./.github/workflows/windows_x64_release_build_x64_release.yml
-
-  stage2-windows-debug:
-    name: "Stage 2: Windows x64 Debug (framework gate)"
-    needs: detect-changes
-    if: needs.detect-changes.outputs.framework == 'true'
-    uses: ./.github/workflows/windows_x64_debug_build_x64_debug.yml
-
-  stage2-windows-ep-generic:
-    name: "Stage 2: Windows x64 Release EP Generic Interface (framework gate)"
-    needs: detect-changes
-    if: needs.detect-changes.outputs.framework == 'true'
-    uses: ./.github/workflows/windows_x64_release_ep_generic_interface_build_x64_release_ep_generic_interface.yml
-
-  stage2-windows-cpu:
-    name: "Stage 2: Windows CPU CI Pipeline (framework gate)"
-    needs: detect-changes
-    if: needs.detect-changes.outputs.framework == 'true'
-    uses: ./.github/workflows/windows_x86.yml
-
-  stage2-windows-asan:
-    name: "Stage 2: Windows x64 ASan (framework gate)"
-    needs: detect-changes
-    if: needs.detect-changes.outputs.framework == 'true'
-    uses: ./.github/workflows/windows_build_x64_asan.yml
-
   stage2-cuda:
     name: "Stage 2: Linux CUDA CI (cuda provider gate)"
     needs: detect-changes
@@ -262,23 +235,22 @@ jobs:
   # Stage 3: fan out to the remaining CI workflows that aren't tied to one provider area, so they
   # don't waste a runner if Stage 2 already found a break. These still run for every PR (no
   # path-filter gate of their own), just after Stage 2 instead of racing it independently.
-  stage3-linux-cuda-plugin:
-    name: "Stage 3: CUDA Plugin Linux CI"
-    needs: &stage3_needs [detect-changes, stage2-linux-cpu, stage2-windows-release, stage2-windows-debug,
-            stage2-windows-ep-generic, stage2-windows-cpu, stage2-windows-asan, stage2-cuda,
-            stage2-windows-cuda, stage2-windows-cuda-plugin, stage2-tensorrt,
-            stage2-windows-tensorrt, stage2-openvino, stage2-windows-openvino, stage2-dml,
-            stage2-webgpu, stage2-windows-webgpu, stage2-qnn, stage2-xnnpack, stage2-vitisai,
-            stage2-coreml, stage2-nnapi, stage2-js]
+  # This includes windows_x64_release / windows_x64_debug / windows_x64_release_ep_generic_interface
+  # / windows_x86 - these are generic full-ORT builds that all run on the contended
+  # Win2022-GPU-A10 pool, so they belong here (behind the cheap/targeted Stage 2 gates) rather than
+  # in Stage 2 itself, where they'd fire on almost every PR (they'd previously been misclassified as
+  # a "framework" gate, which - via the broad onnxruntime/core/** and .github/workflows/** filters -
+  # defeated the point of gating: they still ran on nearly every PR, just now labeled as a "gate").
+  stage3-windows-release:
+    name: "Stage 3: Windows x64 Release"
+    needs: &stage3_needs [detect-changes, stage2-linux-cpu, stage2-cuda, stage2-windows-cuda,
+            stage2-windows-cuda-plugin, stage2-tensorrt, stage2-windows-tensorrt, stage2-openvino,
+            stage2-windows-openvino, stage2-dml, stage2-webgpu, stage2-windows-webgpu, stage2-qnn,
+            stage2-xnnpack, stage2-vitisai, stage2-coreml, stage2-nnapi, stage2-js]
     if: &stage3_gate |
       always() &&
       needs.detect-changes.result == 'success' &&
       (needs.stage2-linux-cpu.result == 'success' || needs.stage2-linux-cpu.result == 'skipped') &&
-      (needs.stage2-windows-release.result == 'success' || needs.stage2-windows-release.result == 'skipped') &&
-      (needs.stage2-windows-debug.result == 'success' || needs.stage2-windows-debug.result == 'skipped') &&
-      (needs.stage2-windows-ep-generic.result == 'success' || needs.stage2-windows-ep-generic.result == 'skipped') &&
-      (needs.stage2-windows-cpu.result == 'success' || needs.stage2-windows-cpu.result == 'skipped') &&
-      (needs.stage2-windows-asan.result == 'success' || needs.stage2-windows-asan.result == 'skipped') &&
       (needs.stage2-cuda.result == 'success' || needs.stage2-cuda.result == 'skipped') &&
       (needs.stage2-windows-cuda.result == 'success' || needs.stage2-windows-cuda.result == 'skipped') &&
       (needs.stage2-windows-cuda-plugin.result == 'success' || needs.stage2-windows-cuda-plugin.result == 'skipped') &&
@@ -295,6 +267,36 @@ jobs:
       (needs.stage2-coreml.result == 'success' || needs.stage2-coreml.result == 'skipped') &&
       (needs.stage2-nnapi.result == 'success' || needs.stage2-nnapi.result == 'skipped') &&
       (needs.stage2-js.result == 'success' || needs.stage2-js.result == 'skipped')
+    uses: ./.github/workflows/windows_x64_release_build_x64_release.yml
+
+  stage3-windows-debug:
+    name: "Stage 3: Windows x64 Debug"
+    needs: *stage3_needs
+    if: *stage3_gate
+    uses: ./.github/workflows/windows_x64_debug_build_x64_debug.yml
+
+  stage3-windows-ep-generic:
+    name: "Stage 3: Windows x64 Release EP Generic Interface"
+    needs: *stage3_needs
+    if: *stage3_gate
+    uses: ./.github/workflows/windows_x64_release_ep_generic_interface_build_x64_release_ep_generic_interface.yml
+
+  stage3-windows-cpu:
+    name: "Stage 3: Windows CPU CI Pipeline"
+    needs: *stage3_needs
+    if: *stage3_gate
+    uses: ./.github/workflows/windows_x86.yml
+
+  stage3-windows-asan:
+    name: "Stage 3: Windows x64 ASan"
+    needs: *stage3_needs
+    if: *stage3_gate
+    uses: ./.github/workflows/windows_build_x64_asan.yml
+
+  stage3-linux-cuda-plugin:
+    name: "Stage 3: CUDA Plugin Linux CI"
+    needs: *stage3_needs
+    if: *stage3_gate
     uses: ./.github/workflows/linux_cuda_plugin_ci.yml
 
   stage3-linux-minimal-build:
@@ -314,9 +316,4 @@ jobs:
     needs: *stage3_needs
     if: *stage3_gate
     uses: ./.github/workflows/react_native.yml
-
-  #     (needs.stage2-vitisai.result == 'success' || needs.stage2-vitisai.result == 'skipped') &&
-  #     (needs.stage2-coreml.result == 'success' || needs.stage2-coreml.result == 'skipped') &&
-  #     (needs.stage2-nnapi.result == 'success' || needs.stage2-nnapi.result == 'skipped') &&
-  #     (needs.stage2-js.result == 'success' || needs.stage2-js.result == 'skipped')
 

--- a/.github/workflows/ci_orchestrator.yml
+++ b/.github/workflows/ci_orchestrator.yml
@@ -1,0 +1,91 @@
+# Pilot for staged CI gating (see design discussion / rollout plan).
+#
+# Stage 1 (lint):            Reuses lint.yml. Must succeed before anything else runs.
+# Stage 2 (targeted gates):  Only the CI job(s) covering the changed area run here, gated on Stage 1:
+#                              - "framework" gate (onnxruntime/core/** excluding core/providers/**
+#                                and core/platform/**, plus include/onnxruntime/core/** and cmake/**)
+#                                -> linux_ci.yml (Linux CPU build+test): cheapest/fastest full leg,
+#                                highest-signal predictor of framework-level breakage.
+#                              - "<provider>" gate (onnxruntime/core/providers/<provider>/**) -> that
+#                                provider's own CI workflow(s), e.g. cuda -> linux_cuda_ci.yml.
+#                                Piloting with CUDA only for now; other providers (tensorrt, dml,
+#                                openvino, webgpu, qnn, coreml, nnapi, js/webnn, ...) will be added
+#                                the same way as their workflows are converted to workflow_call.
+#                            Multiple gates can run in parallel when a PR touches more than one area
+#                            (e.g. framework + cuda).
+# Stage 3 (everything else): Placeholder for now - will fan out to the remaining CI workflows as
+#                            they are incrementally converted to workflow_call (see rollout plan).
+#                            Waits for all Stage 2 gates that were triggered to succeed (skipped
+#                            gates count as pass-through).
+#
+# NOTE: This orchestrator currently runs ALONGSIDE the existing standalone `pull_request` triggers
+# on lint.yml / linux_ci.yml (not yet replacing them), so nothing is required or blocking yet. This
+# is intentional for validation before cutting real required-status-checks over to this workflow.
+
+name: CI Orchestrator
+
+on:
+  pull_request:
+    branches: [main, 'rel-*']
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: "Stage 1: Lint"
+    uses: ./.github/workflows/lint.yml
+
+  detect-changes:
+    name: "Detect changed areas"
+    needs: lint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      framework: ${{ steps.filter.outputs.framework }}
+      cuda: ${{ steps.filter.outputs.cuda }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            framework:
+              - 'onnxruntime/core/**'
+              - '!onnxruntime/core/providers/**'
+              - '!onnxruntime/core/platform/**'
+              - 'include/onnxruntime/core/**'
+              - 'cmake/**'
+            cuda:
+              - 'onnxruntime/core/providers/cuda/**'
+              - 'onnxruntime/contrib_ops/cuda/**'
+            # Additional provider filters (tensorrt, dml, openvino, webgpu, qnn, coreml, nnapi,
+            # js/webnn, ...) will be added here as their CI workflows are converted to
+            # workflow_call and wired up as Stage 2 gates below.
+
+  stage2-linux-cpu:
+    name: "Stage 2: Linux CI CPU (framework gate)"
+    needs: detect-changes
+    if: needs.detect-changes.outputs.framework == 'true'
+    uses: ./.github/workflows/linux_ci.yml
+
+  stage2-cuda:
+    name: "Stage 2: Linux CUDA CI (cuda provider gate)"
+    needs: detect-changes
+    if: needs.detect-changes.outputs.cuda == 'true'
+    uses: ./.github/workflows/linux_cuda_ci.yml
+
+  # Stage 3 placeholder: remaining CI workflows will be added here as jobs (one `uses:` per
+  # workflow, converted to workflow_call) once each has been validated individually. Each such job
+  # should set:
+  #   needs: [detect-changes, stage2-linux-cpu, stage2-cuda]
+  #   if: |
+  #     always() &&
+  #     needs.detect-changes.result == 'success' &&
+  #     (needs.stage2-linux-cpu.result == 'success' || needs.stage2-linux-cpu.result == 'skipped') &&
+  #     (needs.stage2-cuda.result == 'success' || needs.stage2-cuda.result == 'skipped')

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -5,11 +5,9 @@ on:
     branches:
       - main
       - rel-*
-  pull_request:
-    branches:
-      - main
-      - rel-*
   workflow_dispatch:
+  workflow_call: # Allows this workflow to be invoked as the Stage 3 fan-out by ci_orchestrator.yml
+  # NOTE: standalone `pull_request:` trigger removed - ci_orchestrator.yml is now the sole PR entry point.
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -9,9 +9,13 @@ on:
   workflow_call: # Allows this workflow to be invoked as the Stage 3 fan-out by ci_orchestrator.yml
   # NOTE: standalone `pull_request:` trigger removed - ci_orchestrator.yml is now the sole PR entry point.
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
-  cancel-in-progress: true
+# NOTE: no standalone `concurrency:` block here - this workflow's own group would be
+# `${{ github.workflow }}-<ref>`, but github.workflow resolves to the *caller's* name
+# ("CI Orchestrator") when invoked via workflow_call, which is identical to the
+# orchestrator's own top-level group and causes GitHub to detect a deadlock and cancel
+# this job outright. ci_orchestrator.yml's top-level `concurrency:` already covers
+# cancel-in-progress for the whole PR run; standalone push/workflow_dispatch triggers
+# here are keyed off github.sha, which is always unique, so no dedicated group is needed.
 
 jobs:
   iOS_CI_on_Mac:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,9 +5,9 @@ on:
     branches:
       - main
       - rel-*
-  pull_request:
   workflow_dispatch:
   workflow_call: # Allows this workflow to be invoked as Stage 1 by ci_orchestrator.yml
+  # NOTE: standalone `pull_request:` trigger removed - ci_orchestrator.yml is now the sole PR entry point.
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,7 @@ on:
       - rel-*
   pull_request:
   workflow_dispatch:
+  workflow_call: # Allows this workflow to be invoked as Stage 1 by ci_orchestrator.yml
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,9 +9,13 @@ on:
   workflow_call: # Allows this workflow to be invoked as Stage 1 by ci_orchestrator.yml
   # NOTE: standalone `pull_request:` trigger removed - ci_orchestrator.yml is now the sole PR entry point.
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
-  cancel-in-progress: true
+# NOTE: no standalone `concurrency:` block here - this workflow's own group would be
+# `${{ github.workflow }}-<ref>`, but github.workflow resolves to the *caller's* name
+# ("CI Orchestrator") when invoked via workflow_call, which is identical to the
+# orchestrator's own top-level group and causes GitHub to detect a deadlock and cancel
+# this job outright. ci_orchestrator.yml's top-level `concurrency:` already covers
+# cancel-in-progress for the whole PR run; standalone push/workflow_dispatch triggers
+# here are keyed off github.sha, which is always unique, so no dedicated group is needed.
 
 jobs:
   optional-lint:

--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -26,9 +26,13 @@ on:
   workflow_call: # Allows this workflow to be invoked as the Stage 2 "framework" gate by ci_orchestrator.yml
   # NOTE: standalone `pull_request:` trigger removed - ci_orchestrator.yml is now the sole PR entry point.
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
-  cancel-in-progress: true
+# NOTE: no standalone `concurrency:` block here - this workflow's own group would be
+# `${{ github.workflow }}-<ref>`, but github.workflow resolves to the *caller's* name
+# ("CI Orchestrator") when invoked via workflow_call, which is identical to the
+# orchestrator's own top-level group and causes GitHub to detect a deadlock and cancel
+# this job outright. ci_orchestrator.yml's top-level `concurrency:` already covers
+# cancel-in-progress for the whole PR run; standalone push/workflow_dispatch triggers
+# here are keyed off github.sha, which is always unique, so no dedicated group is needed.
 
 permissions:
   contents: read

--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -25,6 +25,7 @@ on:
   pull_request:
     branches: [main, 'rel-*']
   workflow_dispatch:
+  workflow_call: # Allows this workflow to be invoked as the Stage 2 "framework" gate by ci_orchestrator.yml
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}

--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -22,10 +22,9 @@ name: Linux CI
 on:
   push:
     branches: [main, 'rel-*']
-  pull_request:
-    branches: [main, 'rel-*']
   workflow_dispatch:
   workflow_call: # Allows this workflow to be invoked as the Stage 2 "framework" gate by ci_orchestrator.yml
+  # NOTE: standalone `pull_request:` trigger removed - ci_orchestrator.yml is now the sole PR entry point.
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}

--- a/.github/workflows/linux_cuda_ci.yml
+++ b/.github/workflows/linux_cuda_ci.yml
@@ -7,9 +7,13 @@ on:
   workflow_call: # Allows this workflow to be invoked as the Stage 2 "cuda provider" gate by ci_orchestrator.yml
   # NOTE: standalone `pull_request:` trigger removed - ci_orchestrator.yml is now the sole PR entry point.
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
-  cancel-in-progress: true
+# NOTE: no standalone `concurrency:` block here - this workflow's own group would be
+# `${{ github.workflow }}-<ref>`, but github.workflow resolves to the *caller's* name
+# ("CI Orchestrator") when invoked via workflow_call, which is identical to the
+# orchestrator's own top-level group and causes GitHub to detect a deadlock and cancel
+# this job outright. ci_orchestrator.yml's top-level `concurrency:` already covers
+# cancel-in-progress for the whole PR run; standalone push/workflow_dispatch triggers
+# here are keyed off github.sha, which is always unique, so no dedicated group is needed.
 
 permissions:
   contents: read

--- a/.github/workflows/linux_cuda_ci.yml
+++ b/.github/workflows/linux_cuda_ci.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches: [main, 'rel-*']
   workflow_dispatch:
+  workflow_call: # Allows this workflow to be invoked as the Stage 2 "cuda provider" gate by ci_orchestrator.yml
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}

--- a/.github/workflows/linux_cuda_ci.yml
+++ b/.github/workflows/linux_cuda_ci.yml
@@ -3,10 +3,9 @@ name: Linux CUDA CI
 on:
   push:
     branches: [main, 'rel-*']
-  pull_request:
-    branches: [main, 'rel-*']
   workflow_dispatch:
   workflow_call: # Allows this workflow to be invoked as the Stage 2 "cuda provider" gate by ci_orchestrator.yml
+  # NOTE: standalone `pull_request:` trigger removed - ci_orchestrator.yml is now the sole PR entry point.
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}

--- a/.github/workflows/linux_cuda_plugin_ci.yml
+++ b/.github/workflows/linux_cuda_plugin_ci.yml
@@ -7,9 +7,13 @@ on:
   workflow_call: # Allows this workflow to be invoked as the Stage 3 fan-out by ci_orchestrator.yml
   # NOTE: standalone `pull_request:` trigger removed - ci_orchestrator.yml is now the sole PR entry point.
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
-  cancel-in-progress: true
+# NOTE: no standalone `concurrency:` block here - this workflow's own group would be
+# `${{ github.workflow }}-<ref>`, but github.workflow resolves to the *caller's* name
+# ("CI Orchestrator") when invoked via workflow_call, which is identical to the
+# orchestrator's own top-level group and causes GitHub to detect a deadlock and cancel
+# this job outright. ci_orchestrator.yml's top-level `concurrency:` already covers
+# cancel-in-progress for the whole PR run; standalone push/workflow_dispatch triggers
+# here are keyed off github.sha, which is always unique, so no dedicated group is needed.
 
 permissions:
   contents: read

--- a/.github/workflows/linux_cuda_plugin_ci.yml
+++ b/.github/workflows/linux_cuda_plugin_ci.yml
@@ -3,9 +3,9 @@ name: CUDA Plugin Linux CI
 on:
   push:
     branches: [main, 'rel-*']
-  pull_request:
-    branches: [main, 'rel-*']
   workflow_dispatch:
+  workflow_call: # Allows this workflow to be invoked as the Stage 3 fan-out by ci_orchestrator.yml
+  # NOTE: standalone `pull_request:` trigger removed - ci_orchestrator.yml is now the sole PR entry point.
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}

--- a/.github/workflows/linux_minimal_build.yml
+++ b/.github/workflows/linux_minimal_build.yml
@@ -5,11 +5,9 @@ on:
     branches:
       - main
       - rel-*
-  pull_request:
-    branches:
-      - main
-      - rel-*
   workflow_dispatch:
+  workflow_call: # Allows this workflow to be invoked as the Stage 3 fan-out by ci_orchestrator.yml
+  # NOTE: standalone `pull_request:` trigger removed - ci_orchestrator.yml is now the sole PR entry point.
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}

--- a/.github/workflows/linux_minimal_build.yml
+++ b/.github/workflows/linux_minimal_build.yml
@@ -9,9 +9,13 @@ on:
   workflow_call: # Allows this workflow to be invoked as the Stage 3 fan-out by ci_orchestrator.yml
   # NOTE: standalone `pull_request:` trigger removed - ci_orchestrator.yml is now the sole PR entry point.
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
-  cancel-in-progress: true
+# NOTE: no standalone `concurrency:` block here - this workflow's own group would be
+# `${{ github.workflow }}-<ref>`, but github.workflow resolves to the *caller's* name
+# ("CI Orchestrator") when invoked via workflow_call, which is identical to the
+# orchestrator's own top-level group and causes GitHub to detect a deadlock and cancel
+# this job outright. ci_orchestrator.yml's top-level `concurrency:` already covers
+# cancel-in-progress for the whole PR run; standalone push/workflow_dispatch triggers
+# here are keyed off github.sha, which is always unique, so no dedicated group is needed.
 
 env:
   BUILD_SOURCES_DIRECTORY: ${{ github.workspace }}

--- a/.github/workflows/linux_openvino_ci.yml
+++ b/.github/workflows/linux_openvino_ci.yml
@@ -3,9 +3,9 @@ name: Linux OpenVINO CI
 on:
   push:
     branches: [main, 'rel-*']
-  pull_request:
-    branches: [main, 'rel-*']
   workflow_dispatch:
+  workflow_call: # Allows this workflow to be invoked as the Stage 2 "openvino provider" gate by ci_orchestrator.yml
+  # NOTE: standalone `pull_request:` trigger removed - ci_orchestrator.yml is now the sole PR entry point.
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}

--- a/.github/workflows/linux_openvino_ci.yml
+++ b/.github/workflows/linux_openvino_ci.yml
@@ -7,9 +7,13 @@ on:
   workflow_call: # Allows this workflow to be invoked as the Stage 2 "openvino provider" gate by ci_orchestrator.yml
   # NOTE: standalone `pull_request:` trigger removed - ci_orchestrator.yml is now the sole PR entry point.
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
-  cancel-in-progress: true
+# NOTE: no standalone `concurrency:` block here - this workflow's own group would be
+# `${{ github.workflow }}-<ref>`, but github.workflow resolves to the *caller's* name
+# ("CI Orchestrator") when invoked via workflow_call, which is identical to the
+# orchestrator's own top-level group and causes GitHub to detect a deadlock and cancel
+# this job outright. ci_orchestrator.yml's top-level `concurrency:` already covers
+# cancel-in-progress for the whole PR run; standalone push/workflow_dispatch triggers
+# here are keyed off github.sha, which is always unique, so no dedicated group is needed.
 
 permissions:
   contents: read

--- a/.github/workflows/linux_tensorrt_ci.yml
+++ b/.github/workflows/linux_tensorrt_ci.yml
@@ -7,9 +7,13 @@ on:
   workflow_call: # Allows this workflow to be invoked as the Stage 2 "tensorrt provider" gate by ci_orchestrator.yml
   # NOTE: standalone `pull_request:` trigger removed - ci_orchestrator.yml is now the sole PR entry point.
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
-  cancel-in-progress: true
+# NOTE: no standalone `concurrency:` block here - this workflow's own group would be
+# `${{ github.workflow }}-<ref>`, but github.workflow resolves to the *caller's* name
+# ("CI Orchestrator") when invoked via workflow_call, which is identical to the
+# orchestrator's own top-level group and causes GitHub to detect a deadlock and cancel
+# this job outright. ci_orchestrator.yml's top-level `concurrency:` already covers
+# cancel-in-progress for the whole PR run; standalone push/workflow_dispatch triggers
+# here are keyed off github.sha, which is always unique, so no dedicated group is needed.
 
 permissions:
   contents: read

--- a/.github/workflows/linux_tensorrt_ci.yml
+++ b/.github/workflows/linux_tensorrt_ci.yml
@@ -3,9 +3,9 @@ name: Linux TensorRT CI
 on:
   push:
     branches: [main, 'rel-*']
-  pull_request:
-    branches: [main, 'rel-*']
   workflow_dispatch:
+  workflow_call: # Allows this workflow to be invoked as the Stage 2 "tensorrt provider" gate by ci_orchestrator.yml
+  # NOTE: standalone `pull_request:` trigger removed - ci_orchestrator.yml is now the sole PR entry point.
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}

--- a/.github/workflows/linux_webgpu.yml
+++ b/.github/workflows/linux_webgpu.yml
@@ -7,9 +7,13 @@ on:
   workflow_call: # Allows this workflow to be invoked as the Stage 2 "webgpu provider" gate by ci_orchestrator.yml
   # NOTE: standalone `pull_request:` trigger removed - ci_orchestrator.yml is now the sole PR entry point.
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
-  cancel-in-progress: true
+# NOTE: no standalone `concurrency:` block here - this workflow's own group would be
+# `${{ github.workflow }}-<ref>`, but github.workflow resolves to the *caller's* name
+# ("CI Orchestrator") when invoked via workflow_call, which is identical to the
+# orchestrator's own top-level group and causes GitHub to detect a deadlock and cancel
+# this job outright. ci_orchestrator.yml's top-level `concurrency:` already covers
+# cancel-in-progress for the whole PR run; standalone push/workflow_dispatch triggers
+# here are keyed off github.sha, which is always unique, so no dedicated group is needed.
 
 permissions:
   contents: read

--- a/.github/workflows/linux_webgpu.yml
+++ b/.github/workflows/linux_webgpu.yml
@@ -3,9 +3,9 @@ name: Linux WebGPU CI
 on:
   push:
     branches: [main, 'rel-*']
-  pull_request:
-    branches: [main, 'rel-*']
   workflow_dispatch:
+  workflow_call: # Allows this workflow to be invoked as the Stage 2 "webgpu provider" gate by ci_orchestrator.yml
+  # NOTE: standalone `pull_request:` trigger removed - ci_orchestrator.yml is now the sole PR entry point.
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -9,9 +9,13 @@ on:
   workflow_call: # Allows this workflow to be invoked as the Stage 2 "coreml provider" gate by ci_orchestrator.yml
   # NOTE: standalone `pull_request:` trigger removed - ci_orchestrator.yml is now the sole PR entry point.
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
-  cancel-in-progress: true
+# NOTE: no standalone `concurrency:` block here - this workflow's own group would be
+# `${{ github.workflow }}-<ref>`, but github.workflow resolves to the *caller's* name
+# ("CI Orchestrator") when invoked via workflow_call, which is identical to the
+# orchestrator's own top-level group and causes GitHub to detect a deadlock and cancel
+# this job outright. ci_orchestrator.yml's top-level `concurrency:` already covers
+# cancel-in-progress for the whole PR run; standalone push/workflow_dispatch triggers
+# here are keyed off github.sha, which is always unique, so no dedicated group is needed.
 
 env:
   python_version: "3.14"

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -5,11 +5,9 @@ on:
     branches:
       - main
       - rel-*
-  pull_request:
-    branches:
-      - main
-      - rel-*
   workflow_dispatch:
+  workflow_call: # Allows this workflow to be invoked as the Stage 2 "coreml provider" gate by ci_orchestrator.yml
+  # NOTE: standalone `pull_request:` trigger removed - ci_orchestrator.yml is now the sole PR entry point.
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}

--- a/.github/workflows/react_native.yml
+++ b/.github/workflows/react_native.yml
@@ -7,9 +7,13 @@ on:
   workflow_call: # Allows this workflow to be invoked as the Stage 3 fan-out by ci_orchestrator.yml
   # NOTE: standalone `pull_request:` trigger removed - ci_orchestrator.yml is now the sole PR entry point.
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
-  cancel-in-progress: true
+# NOTE: no standalone `concurrency:` block here - this workflow's own group would be
+# `${{ github.workflow }}-<ref>`, but github.workflow resolves to the *caller's* name
+# ("CI Orchestrator") when invoked via workflow_call, which is identical to the
+# orchestrator's own top-level group and causes GitHub to detect a deadlock and cancel
+# this job outright. ci_orchestrator.yml's top-level `concurrency:` already covers
+# cancel-in-progress for the whole PR run; standalone push/workflow_dispatch triggers
+# here are keyed off github.sha, which is always unique, so no dedicated group is needed.
 
 jobs:
   build_android_packages:

--- a/.github/workflows/react_native.yml
+++ b/.github/workflows/react_native.yml
@@ -3,9 +3,9 @@ name: React Native CI Pipeline
 on:
   push:
     branches: [main, 'rel-*']
-  pull_request:
-    branches: [main, 'rel-*']
   workflow_dispatch:
+  workflow_call: # Allows this workflow to be invoked as the Stage 3 fan-out by ci_orchestrator.yml
+  # NOTE: standalone `pull_request:` trigger removed - ci_orchestrator.yml is now the sole PR entry point.
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -9,9 +9,13 @@ on:
   workflow_call: # Allows this workflow to be invoked as the Stage 2 "js/webnn provider" gate by ci_orchestrator.yml
   # NOTE: standalone `pull_request:` trigger removed - ci_orchestrator.yml is now the sole PR entry point.
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
-  cancel-in-progress: true
+# NOTE: no standalone `concurrency:` block here - this workflow's own group would be
+# `${{ github.workflow }}-<ref>`, but github.workflow resolves to the *caller's* name
+# ("CI Orchestrator") when invoked via workflow_call, which is identical to the
+# orchestrator's own top-level group and causes GitHub to detect a deadlock and cancel
+# this job outright. ci_orchestrator.yml's top-level `concurrency:` already covers
+# cancel-in-progress for the whole PR run; standalone push/workflow_dispatch triggers
+# here are keyed off github.sha, which is always unique, so no dedicated group is needed.
 
 jobs:
   precheck:

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -5,11 +5,9 @@ on:
     branches:
       - main
       - rel-*
-  pull_request:
-    branches:
-      - main
-      - rel-*
   workflow_dispatch:
+  workflow_call: # Allows this workflow to be invoked as the Stage 2 "js/webnn provider" gate by ci_orchestrator.yml
+  # NOTE: standalone `pull_request:` trigger removed - ci_orchestrator.yml is now the sole PR entry point.
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}

--- a/.github/workflows/windows_build_x64_asan.yml
+++ b/.github/workflows/windows_build_x64_asan.yml
@@ -4,9 +4,9 @@ name: windows_x64_asan
 on:
   push:
     branches: [main, 'rel-*']
-  pull_request:
-    branches: [main]
   workflow_dispatch:
+  workflow_call: # Allows this workflow to be invoked as the Stage 2 "framework" gate by ci_orchestrator.yml
+  # NOTE: standalone `pull_request:` trigger removed - ci_orchestrator.yml is now the sole PR entry point.
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}

--- a/.github/workflows/windows_build_x64_asan.yml
+++ b/.github/workflows/windows_build_x64_asan.yml
@@ -8,9 +8,13 @@ on:
   workflow_call: # Allows this workflow to be invoked as a Stage 3 "everything else" job by ci_orchestrator.yml
   # NOTE: standalone `pull_request:` trigger removed - ci_orchestrator.yml is now the sole PR entry point.
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
-  cancel-in-progress: true
+# NOTE: no standalone `concurrency:` block here - this workflow's own group would be
+# `${{ github.workflow }}-<ref>`, but github.workflow resolves to the *caller's* name
+# ("CI Orchestrator") when invoked via workflow_call, which is identical to the
+# orchestrator's own top-level group and causes GitHub to detect a deadlock and cancel
+# this job outright. ci_orchestrator.yml's top-level `concurrency:` already covers
+# cancel-in-progress for the whole PR run; standalone push/workflow_dispatch triggers
+# here are keyed off github.sha, which is always unique, so no dedicated group is needed.
 
 jobs:
   build_x64:

--- a/.github/workflows/windows_build_x64_asan.yml
+++ b/.github/workflows/windows_build_x64_asan.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches: [main, 'rel-*']
   workflow_dispatch:
-  workflow_call: # Allows this workflow to be invoked as the Stage 2 "framework" gate by ci_orchestrator.yml
+  workflow_call: # Allows this workflow to be invoked as a Stage 3 "everything else" job by ci_orchestrator.yml
   # NOTE: standalone `pull_request:` trigger removed - ci_orchestrator.yml is now the sole PR entry point.
 
 concurrency:

--- a/.github/workflows/windows_cuda.yml
+++ b/.github/workflows/windows_cuda.yml
@@ -5,11 +5,9 @@ on:
     branches:
       - main
       - rel-*
-  pull_request:
-    branches:
-      - main
-      - rel-*
   workflow_dispatch:
+  workflow_call: # Allows this workflow to be invoked as the Stage 2 "cuda provider" gate by ci_orchestrator.yml
+  # NOTE: standalone `pull_request:` trigger removed - ci_orchestrator.yml is now the sole PR entry point.
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}

--- a/.github/workflows/windows_cuda.yml
+++ b/.github/workflows/windows_cuda.yml
@@ -9,9 +9,13 @@ on:
   workflow_call: # Allows this workflow to be invoked as the Stage 2 "cuda provider" gate by ci_orchestrator.yml
   # NOTE: standalone `pull_request:` trigger removed - ci_orchestrator.yml is now the sole PR entry point.
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
-  cancel-in-progress: true
+# NOTE: no standalone `concurrency:` block here - this workflow's own group would be
+# `${{ github.workflow }}-<ref>`, but github.workflow resolves to the *caller's* name
+# ("CI Orchestrator") when invoked via workflow_call, which is identical to the
+# orchestrator's own top-level group and causes GitHub to detect a deadlock and cancel
+# this job outright. ci_orchestrator.yml's top-level `concurrency:` already covers
+# cancel-in-progress for the whole PR run; standalone push/workflow_dispatch triggers
+# here are keyed off github.sha, which is always unique, so no dedicated group is needed.
 
 #TODO: enable  --build_nodejs
 jobs:

--- a/.github/workflows/windows_cuda_plugin.yml
+++ b/.github/workflows/windows_cuda_plugin.yml
@@ -5,11 +5,9 @@ on:
     branches:
       - main
       - rel-*
-  pull_request:
-    branches:
-      - main
-      - rel-*
   workflow_dispatch:
+  workflow_call: # Allows this workflow to be invoked as the Stage 2 "cuda provider" gate by ci_orchestrator.yml
+  # NOTE: standalone `pull_request:` trigger removed - ci_orchestrator.yml is now the sole PR entry point.
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}

--- a/.github/workflows/windows_cuda_plugin.yml
+++ b/.github/workflows/windows_cuda_plugin.yml
@@ -9,9 +9,13 @@ on:
   workflow_call: # Allows this workflow to be invoked as the Stage 2 "cuda provider" gate by ci_orchestrator.yml
   # NOTE: standalone `pull_request:` trigger removed - ci_orchestrator.yml is now the sole PR entry point.
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
-  cancel-in-progress: true
+# NOTE: no standalone `concurrency:` block here - this workflow's own group would be
+# `${{ github.workflow }}-<ref>`, but github.workflow resolves to the *caller's* name
+# ("CI Orchestrator") when invoked via workflow_call, which is identical to the
+# orchestrator's own top-level group and causes GitHub to detect a deadlock and cancel
+# this job outright. ci_orchestrator.yml's top-level `concurrency:` already covers
+# cancel-in-progress for the whole PR run; standalone push/workflow_dispatch triggers
+# here are keyed off github.sha, which is always unique, so no dedicated group is needed.
 
 jobs:
   build:

--- a/.github/workflows/windows_dml.yml
+++ b/.github/workflows/windows_dml.yml
@@ -5,11 +5,9 @@ on:
     branches:
       - main
       - rel-*
-  pull_request:
-    branches:
-      - main
-      - rel-*
   workflow_dispatch:
+  workflow_call: # Allows this workflow to be invoked as the Stage 2 "dml provider" gate by ci_orchestrator.yml
+  # NOTE: standalone `pull_request:` trigger removed - ci_orchestrator.yml is now the sole PR entry point.
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}

--- a/.github/workflows/windows_dml.yml
+++ b/.github/workflows/windows_dml.yml
@@ -9,9 +9,13 @@ on:
   workflow_call: # Allows this workflow to be invoked as the Stage 2 "dml provider" gate by ci_orchestrator.yml
   # NOTE: standalone `pull_request:` trigger removed - ci_orchestrator.yml is now the sole PR entry point.
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
-  cancel-in-progress: true
+# NOTE: no standalone `concurrency:` block here - this workflow's own group would be
+# `${{ github.workflow }}-<ref>`, but github.workflow resolves to the *caller's* name
+# ("CI Orchestrator") when invoked via workflow_call, which is identical to the
+# orchestrator's own top-level group and causes GitHub to detect a deadlock and cancel
+# this job outright. ci_orchestrator.yml's top-level `concurrency:` already covers
+# cancel-in-progress for the whole PR run; standalone push/workflow_dispatch triggers
+# here are keyed off github.sha, which is always unique, so no dedicated group is needed.
 
 jobs:
   build_x64_RelWithDebInfo:

--- a/.github/workflows/windows_gpu_doc_gen.yml
+++ b/.github/workflows/windows_gpu_doc_gen.yml
@@ -24,9 +24,13 @@ on:
     # Allows this workflow to be invoked as part of Stage 3 by ci_orchestrator.yml
   workflow_dispatch:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
-  cancel-in-progress: true
+# NOTE: no standalone `concurrency:` block here - this workflow's own group would be
+# `${{ github.workflow }}-<ref>`, but github.workflow resolves to the *caller's* name
+# ("CI Orchestrator") when invoked via workflow_call, which is identical to the
+# orchestrator's own top-level group and causes GitHub to detect a deadlock and cancel
+# this job outright. ci_orchestrator.yml's top-level `concurrency:` already covers
+# cancel-in-progress for the whole PR run; standalone push/workflow_dispatch triggers
+# here are keyed off github.sha, which is always unique, so no dedicated group is needed.
 
 jobs:
   kernel_documentation:

--- a/.github/workflows/windows_gpu_doc_gen.yml
+++ b/.github/workflows/windows_gpu_doc_gen.yml
@@ -15,20 +15,13 @@ on:
       - '!BUILD.md'
       - '!js/web/**'
       - '!onnxruntime/core/providers/js/**'
-  pull_request:
-    branches:
-      - main
-      - rel-*
-    paths:
-      - '**'
-      - '!docs/**'
-      - 'docs/OperatorKernels.md'
-      - 'docs/ContribOperators.md'
-      - '!README.md'
-      - '!CONTRIBUTING.md'
-      - '!BUILD.md'
-      - '!js/web/**'
-      - '!onnxruntime/core/providers/js/**'
+  # NOTE: standalone pull_request: trigger removed - this runs on the contended Win2022-GPU-A10
+  # pool with a near-unfiltered `paths: '**'` match, so it belongs in Stage 3 of
+  # ci_orchestrator.yml (gated behind Stage 2 succeeding/skipping) rather than racing every PR
+  # independently. push: (main/rel-*) is left as-is since the orchestrator only runs on
+  # pull_request.
+  workflow_call:
+    # Allows this workflow to be invoked as part of Stage 3 by ci_orchestrator.yml
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/windows_openvino.yml
+++ b/.github/workflows/windows_openvino.yml
@@ -5,11 +5,9 @@ on:
     branches:
       - main
       - rel-*
-  pull_request:
-    branches:
-      - main
-      - rel-*
   workflow_dispatch:
+  workflow_call: # Allows this workflow to be invoked as the Stage 2 "openvino provider" gate by ci_orchestrator.yml
+  # NOTE: standalone `pull_request:` trigger removed - ci_orchestrator.yml is now the sole PR entry point.
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}

--- a/.github/workflows/windows_openvino.yml
+++ b/.github/workflows/windows_openvino.yml
@@ -9,9 +9,13 @@ on:
   workflow_call: # Allows this workflow to be invoked as the Stage 2 "openvino provider" gate by ci_orchestrator.yml
   # NOTE: standalone `pull_request:` trigger removed - ci_orchestrator.yml is now the sole PR entry point.
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
-  cancel-in-progress: true
+# NOTE: no standalone `concurrency:` block here - this workflow's own group would be
+# `${{ github.workflow }}-<ref>`, but github.workflow resolves to the *caller's* name
+# ("CI Orchestrator") when invoked via workflow_call, which is identical to the
+# orchestrator's own top-level group and causes GitHub to detect a deadlock and cancel
+# this job outright. ci_orchestrator.yml's top-level `concurrency:` already covers
+# cancel-in-progress for the whole PR run; standalone push/workflow_dispatch triggers
+# here are keyed off github.sha, which is always unique, so no dedicated group is needed.
 
 jobs:
   BUILD_OPENVINO_EP:

--- a/.github/workflows/windows_qnn_x64.yml
+++ b/.github/workflows/windows_qnn_x64.yml
@@ -5,11 +5,9 @@ on:
     branches:
       - main
       - rel-*
-  pull_request:
-    branches:
-      - main
-      - rel-*
   workflow_dispatch:
+  workflow_call: # Allows this workflow to be invoked as the Stage 2 "qnn provider" gate by ci_orchestrator.yml
+  # NOTE: standalone `pull_request:` trigger removed - ci_orchestrator.yml is now the sole PR entry point.
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}

--- a/.github/workflows/windows_qnn_x64.yml
+++ b/.github/workflows/windows_qnn_x64.yml
@@ -9,9 +9,13 @@ on:
   workflow_call: # Allows this workflow to be invoked as the Stage 2 "qnn provider" gate by ci_orchestrator.yml
   # NOTE: standalone `pull_request:` trigger removed - ci_orchestrator.yml is now the sole PR entry point.
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
-  cancel-in-progress: true
+# NOTE: no standalone `concurrency:` block here - this workflow's own group would be
+# `${{ github.workflow }}-<ref>`, but github.workflow resolves to the *caller's* name
+# ("CI Orchestrator") when invoked via workflow_call, which is identical to the
+# orchestrator's own top-level group and causes GitHub to detect a deadlock and cancel
+# this job outright. ci_orchestrator.yml's top-level `concurrency:` already covers
+# cancel-in-progress for the whole PR run; standalone push/workflow_dispatch triggers
+# here are keyed off github.sha, which is always unique, so no dedicated group is needed.
 
 jobs:
   build_test_qnn_ep:

--- a/.github/workflows/windows_tensorrt.yml
+++ b/.github/workflows/windows_tensorrt.yml
@@ -9,9 +9,13 @@ on:
   workflow_call: # Allows this workflow to be invoked as the Stage 2 "tensorrt provider" gate by ci_orchestrator.yml
   # NOTE: standalone `pull_request:` trigger removed - ci_orchestrator.yml is now the sole PR entry point.
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
-  cancel-in-progress: true
+# NOTE: no standalone `concurrency:` block here - this workflow's own group would be
+# `${{ github.workflow }}-<ref>`, but github.workflow resolves to the *caller's* name
+# ("CI Orchestrator") when invoked via workflow_call, which is identical to the
+# orchestrator's own top-level group and causes GitHub to detect a deadlock and cancel
+# this job outright. ci_orchestrator.yml's top-level `concurrency:` already covers
+# cancel-in-progress for the whole PR run; standalone push/workflow_dispatch triggers
+# here are keyed off github.sha, which is always unique, so no dedicated group is needed.
 
 #TODO: enable  --build_nodejs
 jobs:

--- a/.github/workflows/windows_tensorrt.yml
+++ b/.github/workflows/windows_tensorrt.yml
@@ -5,11 +5,9 @@ on:
     branches:
       - main
       - rel-*
-  pull_request:
-    branches:
-      - main
-      - rel-*
   workflow_dispatch:
+  workflow_call: # Allows this workflow to be invoked as the Stage 2 "tensorrt provider" gate by ci_orchestrator.yml
+  # NOTE: standalone `pull_request:` trigger removed - ci_orchestrator.yml is now the sole PR entry point.
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}

--- a/.github/workflows/windows_webgpu.yml
+++ b/.github/workflows/windows_webgpu.yml
@@ -9,9 +9,13 @@ on:
   workflow_call: # Allows this workflow to be invoked as the Stage 2 "webgpu provider" gate by ci_orchestrator.yml
   # NOTE: standalone `pull_request:` trigger removed - ci_orchestrator.yml is now the sole PR entry point.
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
-  cancel-in-progress: true
+# NOTE: no standalone `concurrency:` block here - this workflow's own group would be
+# `${{ github.workflow }}-<ref>`, but github.workflow resolves to the *caller's* name
+# ("CI Orchestrator") when invoked via workflow_call, which is identical to the
+# orchestrator's own top-level group and causes GitHub to detect a deadlock and cancel
+# this job outright. ci_orchestrator.yml's top-level `concurrency:` already covers
+# cancel-in-progress for the whole PR run; standalone push/workflow_dispatch triggers
+# here are keyed off github.sha, which is always unique, so no dedicated group is needed.
 
 jobs:
   webgpu_build_x64_RelWithDebInfo:

--- a/.github/workflows/windows_webgpu.yml
+++ b/.github/workflows/windows_webgpu.yml
@@ -5,11 +5,9 @@ on:
     branches:
       - main
       - rel-*
-  pull_request:
-    branches:
-      - main
-      - rel-*
   workflow_dispatch:
+  workflow_call: # Allows this workflow to be invoked as the Stage 2 "webgpu provider" gate by ci_orchestrator.yml
+  # NOTE: standalone `pull_request:` trigger removed - ci_orchestrator.yml is now the sole PR entry point.
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}

--- a/.github/workflows/windows_x64_debug_build_x64_debug.yml
+++ b/.github/workflows/windows_x64_debug_build_x64_debug.yml
@@ -3,9 +3,9 @@ name: windows_x64_debug
 on:
   push:
     branches: [main, 'rel-*']
-  pull_request:
-    branches: [main]
   workflow_dispatch:
+  workflow_call: # Allows this workflow to be invoked as the Stage 2 "framework" gate by ci_orchestrator.yml
+  # NOTE: standalone `pull_request:` trigger removed - ci_orchestrator.yml is now the sole PR entry point.
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}

--- a/.github/workflows/windows_x64_debug_build_x64_debug.yml
+++ b/.github/workflows/windows_x64_debug_build_x64_debug.yml
@@ -7,9 +7,13 @@ on:
   workflow_call: # Allows this workflow to be invoked as a Stage 3 "everything else" job by ci_orchestrator.yml
   # NOTE: standalone `pull_request:` trigger removed - ci_orchestrator.yml is now the sole PR entry point.
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
-  cancel-in-progress: true
+# NOTE: no standalone `concurrency:` block here - this workflow's own group would be
+# `${{ github.workflow }}-<ref>`, but github.workflow resolves to the *caller's* name
+# ("CI Orchestrator") when invoked via workflow_call, which is identical to the
+# orchestrator's own top-level group and causes GitHub to detect a deadlock and cancel
+# this job outright. ci_orchestrator.yml's top-level `concurrency:` already covers
+# cancel-in-progress for the whole PR run; standalone push/workflow_dispatch triggers
+# here are keyed off github.sha, which is always unique, so no dedicated group is needed.
 
 jobs:
   build_x64_debug:

--- a/.github/workflows/windows_x64_debug_build_x64_debug.yml
+++ b/.github/workflows/windows_x64_debug_build_x64_debug.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main, 'rel-*']
   workflow_dispatch:
-  workflow_call: # Allows this workflow to be invoked as the Stage 2 "framework" gate by ci_orchestrator.yml
+  workflow_call: # Allows this workflow to be invoked as a Stage 3 "everything else" job by ci_orchestrator.yml
   # NOTE: standalone `pull_request:` trigger removed - ci_orchestrator.yml is now the sole PR entry point.
 
 concurrency:

--- a/.github/workflows/windows_x64_release_build_x64_release.yml
+++ b/.github/workflows/windows_x64_release_build_x64_release.yml
@@ -7,9 +7,13 @@ on:
   workflow_call: # Allows this workflow to be invoked as a Stage 3 "everything else" job by ci_orchestrator.yml
   # NOTE: standalone `pull_request:` trigger removed - ci_orchestrator.yml is now the sole PR entry point.
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
-  cancel-in-progress: true
+# NOTE: no standalone `concurrency:` block here - this workflow's own group would be
+# `${{ github.workflow }}-<ref>`, but github.workflow resolves to the *caller's* name
+# ("CI Orchestrator") when invoked via workflow_call, which is identical to the
+# orchestrator's own top-level group and causes GitHub to detect a deadlock and cancel
+# this job outright. ci_orchestrator.yml's top-level `concurrency:` already covers
+# cancel-in-progress for the whole PR run; standalone push/workflow_dispatch triggers
+# here are keyed off github.sha, which is always unique, so no dedicated group is needed.
 
 jobs:
   build_x64_release:

--- a/.github/workflows/windows_x64_release_build_x64_release.yml
+++ b/.github/workflows/windows_x64_release_build_x64_release.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main, 'rel-*']
   workflow_dispatch:
-  workflow_call: # Allows this workflow to be invoked as the Stage 2 "framework" gate by ci_orchestrator.yml
+  workflow_call: # Allows this workflow to be invoked as a Stage 3 "everything else" job by ci_orchestrator.yml
   # NOTE: standalone `pull_request:` trigger removed - ci_orchestrator.yml is now the sole PR entry point.
 
 concurrency:

--- a/.github/workflows/windows_x64_release_build_x64_release.yml
+++ b/.github/workflows/windows_x64_release_build_x64_release.yml
@@ -3,9 +3,9 @@ name: windows_x64_release
 on:
   push:
     branches: [main, 'rel-*']
-  pull_request:
-    branches: [main]
   workflow_dispatch:
+  workflow_call: # Allows this workflow to be invoked as the Stage 2 "framework" gate by ci_orchestrator.yml
+  # NOTE: standalone `pull_request:` trigger removed - ci_orchestrator.yml is now the sole PR entry point.
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}

--- a/.github/workflows/windows_x64_release_ep_generic_interface_build_x64_release_ep_generic_interface.yml
+++ b/.github/workflows/windows_x64_release_ep_generic_interface_build_x64_release_ep_generic_interface.yml
@@ -7,9 +7,13 @@ on:
   workflow_call: # Allows this workflow to be invoked as a Stage 3 "everything else" job by ci_orchestrator.yml
   # NOTE: standalone `pull_request:` trigger removed - ci_orchestrator.yml is now the sole PR entry point.
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
-  cancel-in-progress: true
+# NOTE: no standalone `concurrency:` block here - this workflow's own group would be
+# `${{ github.workflow }}-<ref>`, but github.workflow resolves to the *caller's* name
+# ("CI Orchestrator") when invoked via workflow_call, which is identical to the
+# orchestrator's own top-level group and causes GitHub to detect a deadlock and cancel
+# this job outright. ci_orchestrator.yml's top-level `concurrency:` already covers
+# cancel-in-progress for the whole PR run; standalone push/workflow_dispatch triggers
+# here are keyed off github.sha, which is always unique, so no dedicated group is needed.
 
 jobs:
   build_x64_release_ep_generic_interface:

--- a/.github/workflows/windows_x64_release_ep_generic_interface_build_x64_release_ep_generic_interface.yml
+++ b/.github/workflows/windows_x64_release_ep_generic_interface_build_x64_release_ep_generic_interface.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main, 'rel-*']
   workflow_dispatch:
-  workflow_call: # Allows this workflow to be invoked as the Stage 2 "framework" gate by ci_orchestrator.yml
+  workflow_call: # Allows this workflow to be invoked as a Stage 3 "everything else" job by ci_orchestrator.yml
   # NOTE: standalone `pull_request:` trigger removed - ci_orchestrator.yml is now the sole PR entry point.
 
 concurrency:

--- a/.github/workflows/windows_x64_release_ep_generic_interface_build_x64_release_ep_generic_interface.yml
+++ b/.github/workflows/windows_x64_release_ep_generic_interface_build_x64_release_ep_generic_interface.yml
@@ -3,9 +3,9 @@ name: windows_x64_release_ep_generic_interface
 on:
   push:
     branches: [main, 'rel-*']
-  pull_request:
-    branches: [main]
   workflow_dispatch:
+  workflow_call: # Allows this workflow to be invoked as the Stage 2 "framework" gate by ci_orchestrator.yml
+  # NOTE: standalone `pull_request:` trigger removed - ci_orchestrator.yml is now the sole PR entry point.
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}

--- a/.github/workflows/windows_x64_release_vitisai_build_x64_release.yml
+++ b/.github/workflows/windows_x64_release_vitisai_build_x64_release.yml
@@ -3,9 +3,9 @@ name: windows_x64_release_vitisai
 on:
   push:
     branches: [main, 'rel-*']
-  pull_request:
-    branches: [main]
   workflow_dispatch:
+  workflow_call: # Allows this workflow to be invoked as the Stage 2 "vitisai provider" gate by ci_orchestrator.yml
+  # NOTE: standalone `pull_request:` trigger removed - ci_orchestrator.yml is now the sole PR entry point.
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}

--- a/.github/workflows/windows_x64_release_vitisai_build_x64_release.yml
+++ b/.github/workflows/windows_x64_release_vitisai_build_x64_release.yml
@@ -7,9 +7,13 @@ on:
   workflow_call: # Allows this workflow to be invoked as the Stage 2 "vitisai provider" gate by ci_orchestrator.yml
   # NOTE: standalone `pull_request:` trigger removed - ci_orchestrator.yml is now the sole PR entry point.
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
-  cancel-in-progress: true
+# NOTE: no standalone `concurrency:` block here - this workflow's own group would be
+# `${{ github.workflow }}-<ref>`, but github.workflow resolves to the *caller's* name
+# ("CI Orchestrator") when invoked via workflow_call, which is identical to the
+# orchestrator's own top-level group and causes GitHub to detect a deadlock and cancel
+# this job outright. ci_orchestrator.yml's top-level `concurrency:` already covers
+# cancel-in-progress for the whole PR run; standalone push/workflow_dispatch triggers
+# here are keyed off github.sha, which is always unique, so no dedicated group is needed.
 
 jobs:
   build_x64_release_vitisai:

--- a/.github/workflows/windows_x64_release_xnnpack.yml
+++ b/.github/workflows/windows_x64_release_xnnpack.yml
@@ -7,9 +7,13 @@ on:
   workflow_call: # Allows this workflow to be invoked as the Stage 2 "xnnpack provider" gate by ci_orchestrator.yml
   # NOTE: standalone `pull_request:` trigger removed - ci_orchestrator.yml is now the sole PR entry point.
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
-  cancel-in-progress: true
+# NOTE: no standalone `concurrency:` block here - this workflow's own group would be
+# `${{ github.workflow }}-<ref>`, but github.workflow resolves to the *caller's* name
+# ("CI Orchestrator") when invoked via workflow_call, which is identical to the
+# orchestrator's own top-level group and causes GitHub to detect a deadlock and cancel
+# this job outright. ci_orchestrator.yml's top-level `concurrency:` already covers
+# cancel-in-progress for the whole PR run; standalone push/workflow_dispatch triggers
+# here are keyed off github.sha, which is always unique, so no dedicated group is needed.
 
 jobs:
   build_x64_release_xnnpack:

--- a/.github/workflows/windows_x64_release_xnnpack.yml
+++ b/.github/workflows/windows_x64_release_xnnpack.yml
@@ -3,9 +3,9 @@ name: windows_x64_release_xnnpack
 on:
   push:
     branches: [main, 'rel-*']
-  pull_request:
-    branches: [main]
   workflow_dispatch:
+  workflow_call: # Allows this workflow to be invoked as the Stage 2 "xnnpack provider" gate by ci_orchestrator.yml
+  # NOTE: standalone `pull_request:` trigger removed - ci_orchestrator.yml is now the sole PR entry point.
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}

--- a/.github/workflows/windows_x86.yml
+++ b/.github/workflows/windows_x86.yml
@@ -7,9 +7,13 @@ on:
   workflow_call: # Allows this workflow to be invoked as a Stage 3 "everything else" job by ci_orchestrator.yml
   # NOTE: standalone `pull_request:` trigger removed - ci_orchestrator.yml is now the sole PR entry point.
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
-  cancel-in-progress: true
+# NOTE: no standalone `concurrency:` block here - this workflow's own group would be
+# `${{ github.workflow }}-<ref>`, but github.workflow resolves to the *caller's* name
+# ("CI Orchestrator") when invoked via workflow_call, which is identical to the
+# orchestrator's own top-level group and causes GitHub to detect a deadlock and cancel
+# this job outright. ci_orchestrator.yml's top-level `concurrency:` already covers
+# cancel-in-progress for the whole PR run; standalone push/workflow_dispatch triggers
+# here are keyed off github.sha, which is always unique, so no dedicated group is needed.
 
 jobs:
   build_x86_release:

--- a/.github/workflows/windows_x86.yml
+++ b/.github/workflows/windows_x86.yml
@@ -3,9 +3,9 @@ name: Windows CPU CI Pipeline
 on:
   push:
     branches: [main, 'rel-*']
-  pull_request:
-    branches: [main]
   workflow_dispatch:
+  workflow_call: # Allows this workflow to be invoked as the Stage 2 "framework" gate by ci_orchestrator.yml
+  # NOTE: standalone `pull_request:` trigger removed - ci_orchestrator.yml is now the sole PR entry point.
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}

--- a/.github/workflows/windows_x86.yml
+++ b/.github/workflows/windows_x86.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main, 'rel-*']
   workflow_dispatch:
-  workflow_call: # Allows this workflow to be invoked as the Stage 2 "framework" gate by ci_orchestrator.yml
+  workflow_call: # Allows this workflow to be invoked as a Stage 3 "everything else" job by ci_orchestrator.yml
   # NOTE: standalone `pull_request:` trigger removed - ci_orchestrator.yml is now the sole PR entry point.
 
 concurrency:


### PR DESCRIPTION
Add gates for CI. The goal is to run lint, then the job corresponding to the user changes, then everything else.

## What's gated

**Stage 1** — lint.

**Stage 2** — path-filtered per-provider/framework gates: framework (linux_ci.yml only), CUDA, TensorRT, OpenVINO, DML, WebGPU, QNN, xnnpack, vitisai, CoreML, NNAPI, Android/macOS/Web/JS legs. Kept intentionally narrow - only the workflow(s) covering the changed area run here.

**Stage 3** — everything else, gated on Stage 2 succeeding/skipping: the generic full-ORT builds with no provider-specific path filter (windows_x64_release/debug/ep_generic_interface/x86, ASan), `windows_gpu_doc_gen.yml` (its `paths: '**'` filter was effectively unfiltered despite running on the Win2022-GPU-A10 pool), `linux_cuda_plugin_ci.yml`, `linux_minimal_build.yml`, `ios.yml`, `react_native.yml`. All of these run on every PR regardless of what changed, so gating them behind Stage 2 avoids racing/duplicating a runner that Stage 2 already showed will fail.

**Left standalone, on purpose:** `CodeQL` / `gradle-wrapper-validation` (security/policy checks kept independent of build gating), `pr_checks.yml` (lightweight bot job), `publish-*-apidocs.yml`, `linux_cuda_no_cudnn.yml`, `windows_cuda_no_cudnn.yml` (already narrowly path-filtered).

## Why

A 3-day analysis of cancelled Windows CI runs showed a large share sat queued for the full 24h with no runner ever assigned, then were auto-cancelled by GitHub's queued-job timeout — pure self-hosted runner-pool contention caused by these workflows running unconditionally on every PR regardless of what changed. Gating them behind path filters means a PR touching only, say, a CPU kernel no longer queues CUDA/TensorRT/OpenVINO/WebGPU/QNN/DML Windows GPU runners at all.

## ⚠️ Before merging

Required status checks in branch protection reference the old standalone job names. GitHub Actions appends `(CI Orchestrator)` to the check name for any job invoked via `workflow_call` (e.g. `Linux CUDA CI / Test Linux CUDA x64 Release` → `Linux CUDA CI / Test Linux CUDA x64 Release (CI Orchestrator)`). Branch protection's required-checks list needs to be updated to the new names (requires admin/elevated rights) before this can be relied on as a blocking check — otherwise the old required checks will simply never fire again.

## Fixed: concurrency-group deadlock silently skipped every job

Earlier pushes had every job cascade-skip because the `lint` job (Stage 1) never produced a job/check-run at all. Root cause: every called workflow declared its own `concurrency: { group: ${{ github.workflow }}-... } }`, but `github.workflow` resolves to the *caller's* name ("CI Orchestrator") inside a `workflow_call`, so each callee's group collided with the orchestrator's own top-level group. GitHub treats that as a deadlock and cancels the nested job before it's scheduled — with zero UI/API trace beyond the run's page ("Canceling since a deadlock was detected..."). Fixed by removing the redundant per-workflow concurrency blocks from all 27 called workflows; the orchestrator's top-level concurrency already covers cancel-in-progress for the whole PR run. Verified the full Stage 1 → 2 → 3 cascade now actually executes end-to-end.

