### PR TITLE
Fix TensorRT build version check for 11

### DIFF
--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -2393,7 +2393,7 @@ SubGraphCollection_t TensorrtExecutionProvider::GetSupportedList(SubGraphCollect
         TensorrtLogger& trt_logger = GetTensorrtLogger(detailed_build_log_);
         auto trt_builder = GetBuilder(trt_logger);
         auto network_flags = 0;
-#if NV_TENSORRT_VERSION >= 11
+#if NV_TENSORRT_MAJOR >= 11
         network_flags |= 0;
 #elif NV_TENSORRT_MAJOR > 8
         network_flags |= (fp16_enable_ || int8_enable_ || bf16_enable_) ? 0 : 1U << static_cast<uint32_t>(nvinfer1::NetworkDefinitionCreationFlag::kSTRONGLY_TYPED);
@@ -3150,7 +3150,7 @@ Status TensorrtExecutionProvider::CreateNodeComputeInfoFromGraph(const GraphView
   TensorrtLogger& trt_logger = GetTensorrtLogger(detailed_build_log_);
   auto trt_builder = GetBuilder(trt_logger);
   auto network_flags = 0;
-#if NV_TENSORRT_VERSION >= 11
+#if NV_TENSORRT_MAJOR >= 11
   network_flags |= 0;
 #elif NV_TENSORRT_MAJOR > 8
   network_flags |= (fp16_enable_ || int8_enable_ || bf16_enable_) ? 0 : 1U << static_cast<uint32_t>(nvinfer1::NetworkDefinitionCreationFlag::kSTRONGLY_TYPED);


### PR DESCRIPTION
### Description
If onnxruntime is using TensorRT 10, the wrong version check ends up using TensorRT 11 code. This means strongly typed networks are converted to weak networks. This is a major performance penalty when using fp16 networks like Leela Chess Zero. Using `_MAJOR` version macro corrects the version check logic and fixes a major performance regression.


### Motivation and Context
This fixes a major performance regression in onnxruntime 1.27 when using strongly typed fp16 network. The performance drops to about 31% when using fp32 evaluation. The root cause for the performance drop was TensorRT seeing it as a weakly typed network and inserted type cast everywhere.

I bisected the problem to https://github.com/microsoft/onnxruntime/commit/53fcead6c747330dd69ac6b960972b535042b3ff . After careful review I noticed the accidental use of wrong version macros in a code path which set strongly typed flag. Fixing the check fixed the performance problem in my local test.