### PR TITLE
Capture higher-level (L2-L4) optimizations in Compile API generate-model output

### DIFF
--- a/onnxruntime/core/framework/ep_context_utils.cc
+++ b/onnxruntime/core/framework/ep_context_utils.cc
@@ -3,10 +3,14 @@
 
 #if !defined(ORT_MINIMAL_BUILD)
 #include <limits>
+#include <memory>
 #include <utility>
 #include "core/framework/ep_context_utils.h"
 #include "core/framework/error_code_helper.h"
 #include "core/graph/model_saving_options.h"
+#include "core/platform/env.h"
+
+#include "google/protobuf/io/zero_copy_stream_impl.h"
 
 namespace onnxruntime {
 namespace epctx {
@@ -52,6 +56,148 @@ Status EpContextModelToProto(const onnxruntime::Model& ep_context_model,
 
   return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Unexpected location for initializers while generating ",
                          validated_model_path);
+}
+
+// Validate the ep_context_path to make sure it is a file path and check whether the file exists already.
+Status GetValidatedEpContextPath(const std::filesystem::path& ep_context_path,
+                                 const std::filesystem::path& model_path,
+                                 std::filesystem::path& context_cache_path,
+                                 bool error_if_output_file_exists) {
+  if (!ep_context_path.empty()) {
+    context_cache_path = ep_context_path;
+    if (!(context_cache_path.has_filename() && context_cache_path.extension() != "")) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "context_file_path should not point to a folder.");
+    }
+  } else if (!model_path.empty()) {
+    auto pos = model_path.native().find_last_of(ORT_TSTR("."));
+    if (pos != std::string::npos) {
+      context_cache_path = model_path.native().substr(0, pos) + ORT_TSTR("_ctx.onnx");
+    } else {
+      context_cache_path = model_path.native() + ORT_TSTR("_ctx.onnx");
+    }
+  } else {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Both ep_context_path and model_path are empty.");
+  }
+
+  if (std::filesystem::exists(context_cache_path) && error_if_output_file_exists) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Failed to generate EP context model since the file '",
+                           context_cache_path, "' exists already. Please remove the EP context model if you want to re-generate it.");
+  }
+
+  return Status::OK();
+}
+
+Status SaveModelProtoToLocation(ONNX_NAMESPACE::ModelProto& model_proto,
+                                const epctx::ModelGenOptions& gen_options,
+                                const std::filesystem::path& valid_output_model_path,
+                                const logging::Logger& logger) {
+  ORT_UNUSED_PARAMETER(logger);
+  const epctx::BufferHolder* output_buffer_holder = gen_options.TryGetOutputModelBuffer();
+  const epctx::BufferWriteFuncHolder* output_write_func_holder = gen_options.TryGetOutputModelWriteFunc();
+
+  if (output_buffer_holder != nullptr) {
+    // Write output model into a buffer ORT allocates for the user.
+    size_t buffer_size = model_proto.ByteSizeLong();
+    ORT_RETURN_IF(buffer_size > static_cast<size_t>(std::numeric_limits<int>::max()),
+                  "Cannot serialize ONNX ModelProto larger than 2GB");
+
+    AllocatorPtr allocator = output_buffer_holder->buffer_allocator;
+    IAllocatorUniquePtr<void> buffer = IAllocator::MakeUniquePtr<void>(allocator, buffer_size);
+    const bool ok = model_proto.SerializeToArray(buffer.get(), static_cast<int>(buffer_size));
+    ORT_RETURN_IF(!ok, "Protobuf serialization failed when saving model to output buffer");
+
+    *output_buffer_holder->buffer_size_ptr = buffer_size;
+    *output_buffer_holder->buffer_ptr = buffer.release();
+  } else if (output_write_func_holder != nullptr) {
+    // Write output model to user's output stream.
+    size_t buffer_size = model_proto.ByteSizeLong();
+    ORT_RETURN_IF(buffer_size > static_cast<size_t>(std::numeric_limits<int>::max()),
+                  "Cannot serialize ONNX ModelProto larger than 2GB");
+
+    auto out_stream_buf = std::make_unique<epctx::OutStreamBuf>(*output_write_func_holder);
+    std::ostream out_stream(out_stream_buf.get());
+
+    model_proto.SerializeToOstream(&out_stream);
+    out_stream.flush();
+    ORT_RETURN_IF_ERROR(out_stream_buf->GetStatus());
+  } else {
+    // Write output model to a file.
+    int fd = 0;
+    Status status = Env::Default().FileOpenWr(valid_output_model_path, fd);
+    ORT_RETURN_IF_ERROR(status);
+
+    ORT_TRY {
+      google::protobuf::io::FileOutputStream output(fd);
+      bool serialize_result = model_proto.SerializeToZeroCopyStream(&output) && output.Flush();
+      if (!serialize_result) {
+        status = ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_PROTOBUF,
+                                 "Protobuf serialization failed when saving model to ",
+                                 valid_output_model_path);
+      }
+    }
+    ORT_CATCH(const std::exception& ex) {
+      ORT_HANDLE_EXCEPTION([&]() {
+        status = ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, ex.what());
+      });
+    }
+    if (!status.IsOK()) {
+      GSL_SUPPRESS(es .84)
+      ORT_IGNORE_RETURN_VALUE(Env::Default().FileClose(fd));
+      return status;
+    }
+    ORT_RETURN_IF_ERROR(Env::Default().FileClose(fd));
+  }
+
+  return Status::OK();
+}
+
+Status BuildAndSaveOptimizedModel(const onnxruntime::Model& model,
+                                  const epctx::ModelGenOptions& gen_options,
+                                  const logging::Logger& logger) {
+  // Resolve the validated output path up front so any file-conflict error surfaces before serialization.
+  std::filesystem::path valid_output_model_path;
+  const epctx::BufferHolder* output_buffer_holder = gen_options.TryGetOutputModelBuffer();
+  const epctx::BufferWriteFuncHolder* output_write_func_holder = gen_options.TryGetOutputModelWriteFunc();
+  const std::filesystem::path* output_model_path_ptr = gen_options.TryGetOutputModelPath();
+  const bool output_is_to_file = (output_buffer_holder == nullptr && output_write_func_holder == nullptr);
+  const bool needs_path_for_external_initializers = (gen_options.TryGetExternalInitializerFileInfo() != nullptr);
+
+  if ((output_is_to_file || needs_path_for_external_initializers) &&
+      (output_model_path_ptr != nullptr || !model.MainGraph().ModelPath().empty())) {
+    std::filesystem::path output_model_path = (output_model_path_ptr != nullptr)
+                                                  ? *output_model_path_ptr
+                                                  : std::filesystem::path("");
+    ORT_RETURN_IF_ERROR(GetValidatedEpContextPath(output_model_path,
+                                                  model.MainGraph().ModelPath(),
+                                                  valid_output_model_path,
+                                                  gen_options.error_if_output_file_exists));
+  }
+
+  // Build the ModelProto from the in-memory model (optimized to the session's configured level). The
+  // initializer location is one of three mutually exclusive cases; the default (neither external file
+  // nor custom handler) embeds them inline.
+  ONNX_NAMESPACE::ModelProto model_proto;
+  if (const epctx::ExternalInitializerFileInfo* ext_info = gen_options.TryGetExternalInitializerFileInfo();
+      ext_info != nullptr) {
+    ModelSavingOptions model_saving_options{ext_info->size_threshold};
+    model_proto = model.ToGraphProtoWithExternalInitializers(ext_info->file_path,
+                                                             valid_output_model_path,
+                                                             model_saving_options);
+  } else if (const epctx::InitializerHandler* custom_handler = gen_options.TryGetInitializerHandler();
+             custom_handler != nullptr) {
+    ORT_RETURN_IF_ERROR(model.ToGraphProtoWithCustomInitializerHandling(
+        custom_handler->handle_initializer_func, custom_handler->state, model_proto));
+  } else {
+    // Default: embed all initializers inline. Passing an empty external-file path with a SIZE_MAX
+    // threshold and force_embed_external_ini avoids creating an intermediate file.
+    ModelSavingOptions model_saving_options{/*size_threshold*/ SIZE_MAX};
+    model_saving_options.force_embed_external_ini = true;
+    model_proto = model.ToGraphProtoWithExternalInitializers(std::filesystem::path{},
+                                                             valid_output_model_path,
+                                                             model_saving_options);
+  }
+
+  return SaveModelProtoToLocation(model_proto, gen_options, valid_output_model_path, logger);
 }
 
 //

--- a/onnxruntime/core/framework/ep_context_utils.h
+++ b/onnxruntime/core/framework/ep_context_utils.h
@@ -30,6 +30,50 @@ Status EpContextModelToProto(const onnxruntime::Model& ep_context_model,
                              const epctx::ModelGenOptions& ep_context_gen_options,
                              /*out*/ ONNX_NAMESPACE::ModelProto& model_proto);
 
+/// <summary>
+/// Validate an output-model path: ensure it points to a file (not a folder), derive a default
+/// "<model>_ctx.onnx" name from the source model path when none is given, and optionally fail if the
+/// target file already exists.
+/// </summary>
+/// <param name="ep_context_path">The requested output path. May be empty.</param>
+/// <param name="model_path">The source model path, used to derive a default output name.</param>
+/// <param name="context_cache_path">Output parameter set to the validated path.</param>
+/// <param name="error_if_output_file_exists">Whether to fail if the target file already exists.</param>
+/// <returns>A status indicating success or an error.</returns>
+Status GetValidatedEpContextPath(const std::filesystem::path& ep_context_path,
+                                 const std::filesystem::path& model_path,
+                                 std::filesystem::path& context_cache_path,
+                                 bool error_if_output_file_exists = true);
+
+/// <summary>
+/// Write a serialized onnx::ModelProto to the location configured in the generation options: a buffer
+/// ORT allocates for the caller, the caller's output-stream write function, or a file.
+/// </summary>
+/// <param name="model_proto">The model proto to serialize.</param>
+/// <param name="gen_options">The model generation options selecting the output location.</param>
+/// <param name="valid_output_model_path">The validated file path (used only for the file case).</param>
+/// <param name="logger">Session logger.</param>
+/// <returns>A status indicating success or an error.</returns>
+Status SaveModelProtoToLocation(ONNX_NAMESPACE::ModelProto& model_proto,
+                                const epctx::ModelGenOptions& gen_options,
+                                const std::filesystem::path& valid_output_model_path,
+                                const logging::Logger& logger);
+
+/// <summary>
+/// Build and save a plain optimized (non-EPContext) output model from an already optimized,
+/// in-memory model. Used by the Compile API when no nodes were compiled (the kGenerateModel case, e.g. a
+/// non-compiling EP such as WebGPU), so the emitted model captures whatever optimizations the session's
+/// configured level produced. Unlike CreateEpContextModel this does no EPContext-node substitution - it
+/// serializes the model as-is.
+/// </summary>
+/// <param name="model">The in-memory model to serialize.</param>
+/// <param name="gen_options">The model generation options.</param>
+/// <param name="logger">Session logger.</param>
+/// <returns>A status indicating success or an error.</returns>
+Status BuildAndSaveOptimizedModel(const onnxruntime::Model& model,
+                                  const epctx::ModelGenOptions& gen_options,
+                                  const logging::Logger& logger);
+
 // Class that wraps the user's OrtBufferWriteFunc function to enable use with
 // C++'s std::ostream.
 // Example:

--- a/onnxruntime/core/framework/graph_partitioner.cc
+++ b/onnxruntime/core/framework/graph_partitioner.cc
@@ -1496,11 +1496,9 @@ Status GraphPartitioner::Partition(Graph& graph, FuncManager& func_mgr,
                                                  ep_acc_map, *graph_optimizer_registry_, logger,
                                                  disable_model_compile));  // Pass param
 
-    // Serialize here only when the output is EPContext-based (some EP produced EPContext nodes). The
-    // compiling EPs' core optimization lives inside the EPContext blobs, which are opaque to the Level2+
-    // passes, so there is nothing to gain by deferring this to after the optimizer loop. The plain form
-    // (no nodes compiled) is instead emitted by InferenceSession after that loop
-    // (epctx::BuildAndSaveOptimizedModel), so it captures the Level2+ passes.
+    // Serialize here only when the output is EPContext-based (some EP produced EPContext nodes). The plain
+    // form (no nodes compiled) is instead emitted by InferenceSession (epctx::BuildAndSaveOptimizedModel);
+    // see there for how its serialization point is chosen.
     if (ep_context_gen_options.enable && AnyEpContextNodesProduced()) {
       ORT_RETURN_IF_ERROR(CreateEpContextModel(providers_, graph, ep_context_gen_options, logger));
     }

--- a/onnxruntime/core/framework/graph_partitioner.cc
+++ b/onnxruntime/core/framework/graph_partitioner.cc
@@ -1024,36 +1024,6 @@ static Status InlineFunctionsAOTImpl(const ExecutionProviders& execution_provide
   return Status::OK();
 }
 
-// Validate the ep_context_path to make sure it is file path and check whether the file exist already
-// TODO: Move function to ep_context_utils.h/cc
-static Status GetValidatedEpContextPath(const std::filesystem::path& ep_context_path,
-                                        const std::filesystem::path& model_path,
-                                        std::filesystem::path& context_cache_path,
-                                        bool error_if_output_file_exists = true) {
-  if (!ep_context_path.empty()) {
-    context_cache_path = ep_context_path;
-    if (!(context_cache_path.has_filename() && context_cache_path.extension() != "")) {
-      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "context_file_path should not point to a folder.");
-    }
-  } else if (!model_path.empty()) {
-    auto pos = model_path.native().find_last_of(ORT_TSTR("."));
-    if (pos != std::string::npos) {
-      context_cache_path = model_path.native().substr(0, pos) + ORT_TSTR("_ctx.onnx");
-    } else {
-      context_cache_path = model_path.native() + ORT_TSTR("_ctx.onnx");
-    }
-  } else {
-    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Both ep_context_path and model_path are empty.");
-  }
-
-  if (std::filesystem::exists(context_cache_path) && error_if_output_file_exists) {
-    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Failed to generate EP context model since the file '",
-                           context_cache_path, "' exists already. Please remove the EP context model if you want to re-generate it.");
-  }
-
-  return Status::OK();
-}
-
 // TODO: Move function to ep_context_utils.h/cc
 static Status CreateEpContextModel(const ExecutionProviders& execution_providers,
                                    const Graph& graph,
@@ -1065,27 +1035,10 @@ static Status CreateEpContextModel(const ExecutionProviders& execution_providers
     all_ep_context_nodes.insert(all_ep_context_nodes.begin(), ep_context_nodes.begin(), ep_context_nodes.end());
   }
 
-  if (all_ep_context_nodes.size() < 1) {
-    auto action_if_no_compiled_nodes = ep_context_gen_options.action_if_no_compiled_nodes;
-
-    ORT_RETURN_IF(action_if_no_compiled_nodes == epctx::ModelGenOptions::ActionIfNoCompiledNodes::kReturnError,
-                  "Unable to compile any nodes. Check that the session EPs support compilation and can execute "
-                  "at least one subgraph in the model.");
-
-    if (action_if_no_compiled_nodes == epctx::ModelGenOptions::ActionIfNoCompiledNodes::kDontGenerateModel) {
-      LOGS(logger, WARNING) << "Unable to compile any nodes. ONNX Runtime will not generate a compiled model. "
-                               "Either the session EPs do not support compilation or the model is already compiled.";
-      // Note: this path is only taken if a model is compiled with the original compilation approach that uses
-      // session options configs only. The explicit compile API instead only chooses between
-      // kReturnError and kGenerateModel.
-      return Status::OK();
-    }
-
-    // Assert so that this is caught in a test in DEBUG builds (in case a new enum value is added)
-    assert(action_if_no_compiled_nodes == epctx::ModelGenOptions::ActionIfNoCompiledNodes::kGenerateModel);
-    LOGS(logger, INFO) << "Unable to compile any nodes but will still generate an output model. "
-                          "Either the session EPs do not support compilation or the model is already compiled.";
-  }
+  // This function serializes the EPContext form only; the sole caller (GraphPartitioner::Partition) invokes
+  // it just when AnyEpContextNodesProduced() is true, so at least one EPContext node is guaranteed here. The
+  // no-compiled-nodes policy (kReturnError / kGenerateModel) is handled by InferenceSession instead.
+  assert(!all_ep_context_nodes.empty());
 
   auto get_ep_context_node = [&all_ep_context_nodes](const std::string& node_name) -> std::pair<bool, const Node*> {
     for (auto& node : all_ep_context_nodes) {
@@ -1113,10 +1066,10 @@ static Status CreateEpContextModel(const ExecutionProviders& execution_providers
       (output_model_path_ptr != nullptr || !graph.ModelPath().empty())) {
     std::filesystem::path output_model_path = (output_model_path_ptr != nullptr) ? *output_model_path_ptr
                                                                                  : std::filesystem::path("");
-    ORT_RETURN_IF_ERROR(GetValidatedEpContextPath(output_model_path,
-                                                  graph.ModelPath(),
-                                                  valid_output_model_path,
-                                                  ep_context_gen_options.error_if_output_file_exists));
+    ORT_RETURN_IF_ERROR(epctx::GetValidatedEpContextPath(output_model_path,
+                                                         graph.ModelPath(),
+                                                         valid_output_model_path,
+                                                         ep_context_gen_options.error_if_output_file_exists));
   }
 
   // Utility function to detect a fused node with an unsupported domain.
@@ -1215,59 +1168,7 @@ static Status CreateEpContextModel(const ExecutionProviders& execution_providers
   ORT_RETURN_IF_ERROR(EpContextModelToProto(ep_context_model, valid_output_model_path, ep_context_gen_options,
                                             /*out*/ model_proto));
 
-  if (output_buffer_holder != nullptr) {
-    // Write output model into a buffer ORT allocates for the user.
-    size_t buffer_size = model_proto.ByteSizeLong();
-    ORT_RETURN_IF(buffer_size > static_cast<size_t>(std::numeric_limits<int>::max()),
-                  "Cannot serialize ONNX ModelProto larger than 2GB");
-
-    AllocatorPtr allocator = output_buffer_holder->buffer_allocator;
-    IAllocatorUniquePtr<void> buffer = IAllocator::MakeUniquePtr<void>(allocator, buffer_size);
-    model_proto.SerializeToArray(buffer.get(), static_cast<int>(buffer_size));
-
-    *output_buffer_holder->buffer_size_ptr = buffer_size;
-    *output_buffer_holder->buffer_ptr = buffer.release();
-  } else if (output_write_func_holder != nullptr) {
-    // Write output model to user's output stream.
-    size_t buffer_size = model_proto.ByteSizeLong();
-    ORT_RETURN_IF(buffer_size > static_cast<size_t>(std::numeric_limits<int>::max()),
-                  "Cannot serialize ONNX ModelProto larger than 2GB");
-
-    auto out_stream_buf = std::make_unique<epctx::OutStreamBuf>(*output_write_func_holder);
-    std::ostream out_stream(out_stream_buf.get());
-
-    model_proto.SerializeToOstream(&out_stream);
-    out_stream.flush();
-    ORT_RETURN_IF_ERROR(out_stream_buf->GetStatus());
-  } else {
-    // Write output model to a file.
-    int fd = 0;
-    Status status = Env::Default().FileOpenWr(valid_output_model_path, fd);
-    ORT_RETURN_IF_ERROR(status);
-
-    ORT_TRY {
-      google::protobuf::io::FileOutputStream output(fd);
-      bool serialize_result = model_proto.SerializeToZeroCopyStream(&output) && output.Flush();
-      if (!serialize_result) {
-        status = ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_PROTOBUF,
-                                 "Protobuf serialization failed when generating EPContext model ",
-                                 valid_output_model_path);
-      }
-    }
-    ORT_CATCH(const std::exception& ex) {
-      ORT_HANDLE_EXCEPTION([&]() {
-        status = ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, ex.what());
-      });
-    }
-    if (!status.IsOK()) {
-      GSL_SUPPRESS(es .84)
-      ORT_IGNORE_RETURN_VALUE(Env::Default().FileClose(fd));
-      return status;
-    }
-    ORT_RETURN_IF_ERROR(Env::Default().FileClose(fd));
-  }
-
-  return Status::OK();
+  return epctx::SaveModelProtoToLocation(model_proto, ep_context_gen_options, valid_output_model_path, logger);
 }
 
 static Status PartitionOnnxFormatModel(const PartitionParams& partition_params, GraphPartitioner::Mode mode,
@@ -1579,9 +1480,9 @@ Status GraphPartitioner::Partition(Graph& graph, FuncManager& func_mgr,
           output_model_path_ptr != nullptr) {
         // Check before EP compile graphs
         std::filesystem::path context_cache_path;
-        ORT_RETURN_IF_ERROR(GetValidatedEpContextPath(*output_model_path_ptr, graph.ModelPath(),
-                                                      context_cache_path,
-                                                      ep_context_gen_options.error_if_output_file_exists));
+        ORT_RETURN_IF_ERROR(epctx::GetValidatedEpContextPath(*output_model_path_ptr, graph.ModelPath(),
+                                                             context_cache_path,
+                                                             ep_context_gen_options.error_if_output_file_exists));
       }
     }
 
@@ -1595,7 +1496,12 @@ Status GraphPartitioner::Partition(Graph& graph, FuncManager& func_mgr,
                                                  ep_acc_map, *graph_optimizer_registry_, logger,
                                                  disable_model_compile));  // Pass param
 
-    if (ep_context_gen_options.enable) {
+    // Serialize here only when the output is EPContext-based (some EP produced EPContext nodes). The
+    // compiling EPs' core optimization lives inside the EPContext blobs, which are opaque to the Level2+
+    // passes, so there is nothing to gain by deferring this to after the optimizer loop. The plain form
+    // (no nodes compiled) is instead emitted by InferenceSession after that loop
+    // (epctx::BuildAndSaveOptimizedModel), so it captures the Level2+ passes.
+    if (ep_context_gen_options.enable && AnyEpContextNodesProduced()) {
       ORT_RETURN_IF_ERROR(CreateEpContextModel(providers_, graph, ep_context_gen_options, logger));
     }
 #else
@@ -1616,5 +1522,16 @@ Status GraphPartitioner::Partition(Graph& graph, FuncManager& func_mgr,
 
   return Status::OK();
 }
+
+#ifndef ORT_MINIMAL_BUILD
+bool GraphPartitioner::AnyEpContextNodesProduced() const {
+  for (const auto& ep : providers_) {
+    if (!ep->GetEpContextNodes().empty()) {
+      return true;
+    }
+  }
+  return false;
+}
+#endif  // !defined(ORT_MINIMAL_BUILD)
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/framework/graph_partitioner.h
+++ b/onnxruntime/core/framework/graph_partitioner.h
@@ -60,8 +60,10 @@ class GraphPartitioner {
   //
   // If the output is EPContext-based (a compiling EP produced EPContext nodes) it is serialized here at
   // the partition boundary. If no nodes were compiled it is a plain optimized copy of the graph, NOT
-  // serialized here - InferenceSession emits it after the Level2+ loop (epctx::BuildAndSaveOptimizedModel),
-  // since only that form is affected by those passes. Callers distinguish via AnyEpContextNodesProduced().
+  // serialized here - InferenceSession emits it (epctx::BuildAndSaveOptimizedModel) at a point chosen by the
+  // requested optimization level: before the Level2+ loop for level < Level2 (a BASIC snapshot matching the
+  // partition boundary), or after the loop for level >= Level2 (capturing the L2-L4 passes). Callers
+  // distinguish the two output forms via AnyEpContextNodesProduced().
   Status Partition(Graph& graph, FuncManager& func_mgr,
                    const layout_transformation::TransformLayoutFunction& transform_layout_function,
                    const ConfigOptions& config_options,
@@ -72,9 +74,7 @@ class GraphPartitioner {
                    const layout_transformation::DebugGraphFn& debug_graph_fn = {}) const;
 
 #ifndef ORT_MINIMAL_BUILD
-  // Returns true if any execution provider produced EPContext (compiled) nodes during partitioning -
-  // i.e. the output is an EPContext model (serialized in Partition) rather than a plain optimized copy
-  // (emitted by InferenceSession after the Level2+ loop). Stable once partitioning has run.
+  // Returns true if any execution provider produced EPContext (compiled) nodes during partitioning.
   bool AnyEpContextNodesProduced() const;
 #endif
 

--- a/onnxruntime/core/framework/graph_partitioner.h
+++ b/onnxruntime/core/framework/graph_partitioner.h
@@ -57,6 +57,11 @@ class GraphPartitioner {
   }
 
   // Run partitioning.
+  //
+  // If the output is EPContext-based (a compiling EP produced EPContext nodes) it is serialized here at
+  // the partition boundary. If no nodes were compiled it is a plain optimized copy of the graph, NOT
+  // serialized here - InferenceSession emits it after the Level2+ loop (epctx::BuildAndSaveOptimizedModel),
+  // since only that form is affected by those passes. Callers distinguish via AnyEpContextNodesProduced().
   Status Partition(Graph& graph, FuncManager& func_mgr,
                    const layout_transformation::TransformLayoutFunction& transform_layout_function,
                    const ConfigOptions& config_options,
@@ -65,6 +70,13 @@ class GraphPartitioner {
                    Mode mode = Mode::kNormal,
                    const epctx::ModelGenOptions& ep_context_gen_options = {},
                    const layout_transformation::DebugGraphFn& debug_graph_fn = {}) const;
+
+#ifndef ORT_MINIMAL_BUILD
+  // Returns true if any execution provider produced EPContext (compiled) nodes during partitioning -
+  // i.e. the output is an EPContext model (serialized in Partition) rather than a plain optimized copy
+  // (emitted by InferenceSession after the Level2+ loop). Stable once partitioning has run.
+  bool AnyEpContextNodesProduced() const;
+#endif
 
   bool IsLoadCancellationFlagSet() const {
     return check_load_cancellation_fn_ && check_load_cancellation_fn_();

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -1694,9 +1694,6 @@ common::Status InferenceSession::TransformGraph(onnxruntime::Graph& graph, bool 
     }
   }
 #endif  // !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
-  // Capture the output-model generation options once so the same options are used whether the model is
-  // serialized at the partitioning boundary (EPContext model) or after the Level2+ optimizer loop below
-  // (plain optimized model).
   const epctx::ModelGenOptions ep_context_gen_options = session_options_.GetEpContextGenerationOptions();
 
   // Do partitioning based on execution providers' capabilities.
@@ -1713,6 +1710,35 @@ common::Status InferenceSession::TransformGraph(onnxruntime::Graph& graph, bool 
     layering_index_storage.reset();
   }
 #endif  // !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
+
+  // Decide whether we need to emit the plain optimized (non-EPContext) output model for a compile-only
+  // session that compiled no nodes (the kGenerateModel case, e.g. a non-compiling EP such as WebGPU;
+  // Partition() serialized only the EPContext form). If so, honor action_if_no_compiled_nodes: the compile
+  // API uses kReturnError or kGenerateModel (kDontGenerateModel never reaches a compile-only session).
+  //
+  // The error is returned regardless of level. For kGenerateModel the serialization point is chosen by the
+  // requested optimization level so the output matches what a plain (non-compile) session would produce:
+  //   - level < Level2 (includes the Compile API's Default): serialize here, before the Level2+ loop and the
+  //     InsertCast/Memcpy transformers below - a BASIC snapshot identical to the graph at the partition
+  //     boundary (no Cast, no Memcpy nodes), unchanged from prior behavior.
+  //   - level >= Level2 (explicitly requested): serialize after the loop and Memcpy insertion below, so the
+  //     emitted model captures the Level2-Level4 fusions (and the device-placement copy nodes).
+  const bool emit_plain_optimized_model =
+      session_options_.config_options.GetConfigOrDefault(kOrtSessionOptionCompileOnly, "0") == "1" &&
+      ep_context_gen_options.enable && !partitioner.AnyEpContextNodesProduced();
+  if (emit_plain_optimized_model) {
+    using ActionIfNoCompiledNodes = epctx::ModelGenOptions::ActionIfNoCompiledNodes;
+    if (ep_context_gen_options.action_if_no_compiled_nodes == ActionIfNoCompiledNodes::kReturnError) {
+      ORT_RETURN_IF_ERROR_SESSIONID_(
+          ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
+                          "Unable to compile any nodes. Check that the session EPs support compilation "
+                          "and can execute at least one subgraph in the model."));
+    }
+    if (session_options_.graph_optimization_level < TransformerLevel::Level2) {
+      ORT_RETURN_IF_ERROR_SESSIONID_(
+          epctx::BuildAndSaveOptimizedModel(*model_, ep_context_gen_options, *session_logger_));
+    }
+  }
 
   // Get graph optimizations loop level from session config, if not present, set to default value of 1 as per
   // the definition of kOrtSessionOptionsGraphOptimizationsLoopLevel.
@@ -1780,31 +1806,6 @@ common::Status InferenceSession::TransformGraph(onnxruntime::Graph& graph, bool 
     }
   }
 
-#if !defined(ORT_MINIMAL_BUILD)
-  // Emit the plain optimized (non-EPContext) output model for a compile-only session that compiled no
-  // nodes (the kGenerateModel case, e.g. WebGPU). Partition() serialized only the EPContext form; this
-  // runs after the Level2+ loop so those optimizations are captured, and before the copy-node insertion
-  // so memcpy nodes aren't baked in. Initializers are still present (FinalizeSessionState runs later).
-  const bool is_compile_only =
-      session_options_.config_options.GetConfigOrDefault(kOrtSessionOptionCompileOnly, "0") == "1";
-  if (is_compile_only && ep_context_gen_options.enable && !partitioner.AnyEpContextNodesProduced()) {
-    // No nodes compiled: honor action_if_no_compiled_nodes (the compile API uses kReturnError or
-    // kGenerateModel; kDontGenerateModel never reaches a compile-only session).
-    using ActionIfNoCompiledNodes = epctx::ModelGenOptions::ActionIfNoCompiledNodes;
-    const auto action_if_no_compiled_nodes = ep_context_gen_options.action_if_no_compiled_nodes;
-    ORT_RETURN_IF_ERROR_SESSIONID_(
-        (action_if_no_compiled_nodes == ActionIfNoCompiledNodes::kReturnError
-             ? ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
-                               "Unable to compile any nodes. Check that the session EPs support compilation "
-                               "and can execute at least one subgraph in the model.")
-             : Status::OK()));
-    if (action_if_no_compiled_nodes == ActionIfNoCompiledNodes::kGenerateModel) {
-      ORT_RETURN_IF_ERROR_SESSIONID_(
-          epctx::BuildAndSaveOptimizedModel(*model_, ep_context_gen_options, *session_logger_));
-    }
-  }
-#endif  // !defined(ORT_MINIMAL_BUILD)
-
   // Insert copy node/s.
   {
     InlinedVector<gsl::not_null<const IExecutionProvider*>> providers;
@@ -1815,6 +1816,20 @@ common::Status InferenceSession::TransformGraph(onnxruntime::Graph& graph, bool 
     MemcpyTransformer copy_transformer{std::move(providers), kernel_registry_manager_};
     ORT_RETURN_IF_ERROR_SESSIONID_(apply_transformer_once(copy_transformer, *session_logger_, graph));
   }
+
+#if !defined(ORT_MINIMAL_BUILD)
+  // Second serialization point for the plain optimized (non-EPContext) output model. Reached only for an
+  // explicitly requested level >= Level2 (level < Level2 was already serialized before the loop above). This
+  // runs after the Level2+ loop and the copy-node insertion, so the emitted model reflects the fully
+  // transformed graph the session runs - the Level2-Level4 fusions plus the device-placement Memcpy nodes.
+  // action_if_no_compiled_nodes was already handled before the loop (kReturnError returned there), so only
+  // kGenerateModel reaches here.
+  if (emit_plain_optimized_model &&
+      session_options_.graph_optimization_level >= TransformerLevel::Level2) {
+    ORT_RETURN_IF_ERROR_SESSIONID_(
+        epctx::BuildAndSaveOptimizedModel(*model_, ep_context_gen_options, *session_logger_));
+  }
+#endif  // !defined(ORT_MINIMAL_BUILD)
 
 #ifdef ENABLE_TRAINING
   // Enable memory optimizations.

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -24,6 +24,7 @@
 #include "core/framework/bfc_arena.h"
 #include "core/framework/error_code_helper.h"
 #include "core/framework/device_stream_collection.h"
+#include "core/framework/ep_context_utils.h"
 #include "core/framework/execution_frame.h"
 #include "core/framework/feeds_fetches_manager.h"
 #include "core/framework/graph_partitioner.h"
@@ -1693,10 +1694,15 @@ common::Status InferenceSession::TransformGraph(onnxruntime::Graph& graph, bool 
     }
   }
 #endif  // !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
+  // Capture the output-model generation options once so the same options are used whether the model is
+  // serialized at the partitioning boundary (EPContext model) or after the Level2+ optimizer loop below
+  // (plain optimized model).
+  const epctx::ModelGenOptions ep_context_gen_options = session_options_.GetEpContextGenerationOptions();
+
   // Do partitioning based on execution providers' capabilities.
   ORT_RETURN_IF_ERROR_SESSIONID_(partitioner.Partition(graph, session_state_->GetMutableFuncMgr(), transform_layout_fn,
                                                        session_options_.config_options, *session_logger_, layering_index,
-                                                       mode, session_options_.GetEpContextGenerationOptions(), debug_graph_fn));
+                                                       mode, ep_context_gen_options, debug_graph_fn));
 
 #if !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
   if (layering_index) {
@@ -1773,6 +1779,31 @@ common::Status InferenceSession::TransformGraph(onnxruntime::Graph& graph, bool 
       break;
     }
   }
+
+#if !defined(ORT_MINIMAL_BUILD)
+  // Emit the plain optimized (non-EPContext) output model for a compile-only session that compiled no
+  // nodes (the kGenerateModel case, e.g. WebGPU). Partition() serialized only the EPContext form; this
+  // runs after the Level2+ loop so those optimizations are captured, and before the copy-node insertion
+  // so memcpy nodes aren't baked in. Initializers are still present (FinalizeSessionState runs later).
+  const bool is_compile_only =
+      session_options_.config_options.GetConfigOrDefault(kOrtSessionOptionCompileOnly, "0") == "1";
+  if (is_compile_only && ep_context_gen_options.enable && !partitioner.AnyEpContextNodesProduced()) {
+    // No nodes compiled: honor action_if_no_compiled_nodes (the compile API uses kReturnError or
+    // kGenerateModel; kDontGenerateModel never reaches a compile-only session).
+    using ActionIfNoCompiledNodes = epctx::ModelGenOptions::ActionIfNoCompiledNodes;
+    const auto action_if_no_compiled_nodes = ep_context_gen_options.action_if_no_compiled_nodes;
+    ORT_RETURN_IF_ERROR_SESSIONID_(
+        (action_if_no_compiled_nodes == ActionIfNoCompiledNodes::kReturnError
+             ? ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
+                               "Unable to compile any nodes. Check that the session EPs support compilation "
+                               "and can execute at least one subgraph in the model.")
+             : Status::OK()));
+    if (action_if_no_compiled_nodes == ActionIfNoCompiledNodes::kGenerateModel) {
+      ORT_RETURN_IF_ERROR_SESSIONID_(
+          epctx::BuildAndSaveOptimizedModel(*model_, ep_context_gen_options, *session_logger_));
+    }
+  }
+#endif  // !defined(ORT_MINIMAL_BUILD)
 
   // Insert copy node/s.
   {

--- a/onnxruntime/test/framework/inference_session_test.cc
+++ b/onnxruntime/test/framework/inference_session_test.cc
@@ -45,6 +45,7 @@
 #include "core/providers/tensorrt/tensorrt_provider_options.h"
 #endif
 #include "core/session/allocator_adapters.h"
+#include "core/framework/ep_context_options.h"
 #include "core/session/environment.h"
 #include "core/session/IOBinding.h"
 #include "core/session/inference_session_utils.h"
@@ -3365,6 +3366,167 @@ TEST(InferenceSessionTests, SessionLoggerOutlivesEPsWithUserLoggingFunction) {
   ASSERT_TRUE(found_teardown_msg)
       << "Expected EP teardown log message not found via user_logging_function.";
 }
+
+#if !defined(ORT_MINIMAL_BUILD)
+// A compile-only session (Compile API path, marked by kOrtSessionOptionCompileOnly) whose EPs compile no
+// nodes emits a plain optimized output model *after* the Level2+ optimizer loop, so the serialized graph
+// reflects those fusions. This is EP-agnostic: the CPU EP compiles nothing, so the kGenerateModel path
+// serializes the optimized graph. bias_gelu_fusion.onnx fuses to com.microsoft.BiasGelu only at Level2
+// (BiasGeluFusion is Level2-only), so its presence in the emitted model proves the Level2 fusion reached
+// the output; at ORT_ENABLE_BASIC (Level1) it is absent because that fusion never runs.
+TEST(InferenceSessionTests, CompileOnlyToFileSerializesFullyOptimizedGraph) {
+  const std::string input_model = "testdata/transform/fusion/bias_gelu_fusion.onnx";
+
+  auto compile_and_count =
+      [&](TransformerLevel level,
+          const std::basic_string<ORTCHAR_T>& output_path) -> std::map<std::string, int> {
+    std::filesystem::remove(output_path);
+
+    SessionOptions so;
+    so.session_logid = "InferenceSessionTests.CompileOnlyToFileSerializesFullyOptimizedGraph";
+    so.graph_optimization_level = level;
+    // Mark a compile-only session (as the Compile API does internally).
+    EXPECT_STATUS_OK(so.config_options.AddConfigEntry(kOrtSessionOptionCompileOnly, "1"));
+
+    // Configure EPContext model generation to a file, mirroring the explicit Compile API: generate a
+    // model even when no nodes are compiled (the CPU EP compiles nothing, so the plain optimized graph
+    // is copied into the output model).
+    epctx::ModelGenOptions gen_options;
+    gen_options.enable = true;
+    gen_options.error_if_output_file_exists = false;
+    gen_options.action_if_no_compiled_nodes = epctx::ModelGenOptions::ActionIfNoCompiledNodes::kGenerateModel;
+    gen_options.output_model_location = std::filesystem::path(output_path);
+    so.ep_context_gen_options = gen_options;
+    so.has_explicit_ep_context_gen_options = true;
+
+    InferenceSession session{so, GetEnvironment()};
+    EXPECT_STATUS_OK(session.Load(input_model));
+    EXPECT_STATUS_OK(session.Initialize());
+
+    // Load the emitted model in a plain (non-optimizing) session and count ops on the serialized graph.
+    SessionOptions verify_so;
+    verify_so.graph_optimization_level = TransformerLevel::Default;  // do not re-optimize the emitted model
+    InferenceSessionWrapper verify{verify_so, GetEnvironment()};
+    EXPECT_STATUS_OK(verify.Load(output_path));
+    EXPECT_STATUS_OK(verify.Initialize());
+    return CountOpsInGraph(verify.GetGraph());
+  };
+
+  const std::basic_string<ORTCHAR_T> all_path = ORT_TSTR("compile_only_full_opt_all.onnx");
+  const std::basic_string<ORTCHAR_T> basic_path = ORT_TSTR("compile_only_full_opt_basic.onnx");
+  struct RemoveOnExit {
+    std::vector<std::basic_string<ORTCHAR_T>> paths;
+    ~RemoveOnExit() {
+      for (const auto& p : paths) std::filesystem::remove(p);
+    }
+  } remove_on_exit{{all_path, basic_path}};
+
+  // ORT_ENABLE_ALL: the Level2 BiasGelu fusion runs and must be captured in the emitted model.
+  const std::map<std::string, int> all_counts = compile_and_count(TransformerLevel::MaxLevel, all_path);
+  EXPECT_EQ(all_counts.count("com.microsoft.BiasGelu") ? all_counts.at("com.microsoft.BiasGelu") : 0, 1);
+
+  // ORT_ENABLE_BASIC (Level1): BiasGeluFusion is Level2-only, so it never runs and must be absent.
+  const std::map<std::string, int> basic_counts = compile_and_count(TransformerLevel::Level1, basic_path);
+  EXPECT_EQ(basic_counts.count("com.microsoft.BiasGelu") ? basic_counts.at("com.microsoft.BiasGelu") : 0, 0);
+}
+
+// Same as above, but emits the plain optimized model into an in-memory buffer (BufferHolder) instead of a
+// file. This mirrors the offline-compile flow, which serializes to a buffer rather than to disk, and
+// exercises the buffer branch of SaveModelProtoToLocation. The Level2 BiasGelu fusion must still be present
+// in the serialized bytes.
+TEST(InferenceSessionTests, CompileOnlyToBufferSerializesFullyOptimizedGraph) {
+  const std::string input_model = "testdata/transform/fusion/bias_gelu_fusion.onnx";
+
+  SessionOptions so;
+  so.session_logid = "InferenceSessionTests.CompileOnlyToBufferSerializesFullyOptimizedGraph";
+  so.graph_optimization_level = TransformerLevel::MaxLevel;  // ORT_ENABLE_ALL
+  EXPECT_STATUS_OK(so.config_options.AddConfigEntry(kOrtSessionOptionCompileOnly, "1"));
+
+  void* output_buffer = nullptr;
+  size_t output_buffer_size = 0;
+  AllocatorPtr cpu_allocator = std::make_shared<CPUAllocator>();
+
+  epctx::ModelGenOptions gen_options;
+  gen_options.enable = true;
+  gen_options.action_if_no_compiled_nodes = epctx::ModelGenOptions::ActionIfNoCompiledNodes::kGenerateModel;
+  epctx::BufferHolder buffer_holder;
+  buffer_holder.buffer_ptr = &output_buffer;
+  buffer_holder.buffer_size_ptr = &output_buffer_size;
+  buffer_holder.buffer_allocator = cpu_allocator;
+  gen_options.output_model_location = buffer_holder;
+  so.ep_context_gen_options = gen_options;
+  so.has_explicit_ep_context_gen_options = true;
+
+  {
+    InferenceSession session{so, GetEnvironment()};
+    EXPECT_STATUS_OK(session.Load(input_model));
+    EXPECT_STATUS_OK(session.Initialize());
+  }
+
+  ASSERT_NE(output_buffer, nullptr);
+  ASSERT_GT(output_buffer_size, 0u);
+
+  // Load the emitted model from the buffer in a plain (non-optimizing) session and count ops.
+  SessionOptions verify_so;
+  verify_so.graph_optimization_level = TransformerLevel::Default;  // do not re-optimize the emitted model
+  InferenceSessionWrapper verify{verify_so, GetEnvironment()};
+  EXPECT_STATUS_OK(verify.Load(output_buffer, static_cast<int>(output_buffer_size)));
+  EXPECT_STATUS_OK(verify.Initialize());
+  const std::map<std::string, int> counts = CountOpsInGraph(verify.GetGraph());
+  EXPECT_EQ(counts.count("com.microsoft.BiasGelu") ? counts.at("com.microsoft.BiasGelu") : 0, 1);
+
+  cpu_allocator->Free(output_buffer);
+}
+
+// OrtWriteBufferFunc that appends the written bytes to a std::string held in stream_state.
+static OrtStatus* ORT_API_CALL AppendToStringWriteFunc(void* stream_state, const void* buffer,
+                                                       size_t buffer_num_bytes) {
+  auto* sink = reinterpret_cast<std::string*>(stream_state);
+  sink->append(reinterpret_cast<const char*>(buffer), buffer_num_bytes);
+  return nullptr;  // No error
+}
+
+// Same as above, but emits the plain optimized model through a user write function (BufferWriteFuncHolder)
+// instead of a file, exercising the write-func branch of SaveModelProtoToLocation. The Level2 BiasGelu
+// fusion must still be present in the written bytes.
+TEST(InferenceSessionTests, CompileOnlyToWriteFuncSerializesFullyOptimizedGraph) {
+  const std::string input_model = "testdata/transform/fusion/bias_gelu_fusion.onnx";
+
+  SessionOptions so;
+  so.session_logid = "InferenceSessionTests.CompileOnlyToWriteFuncSerializesFullyOptimizedGraph";
+  so.graph_optimization_level = TransformerLevel::MaxLevel;  // ORT_ENABLE_ALL
+  EXPECT_STATUS_OK(so.config_options.AddConfigEntry(kOrtSessionOptionCompileOnly, "1"));
+
+  std::string sink;
+
+  epctx::ModelGenOptions gen_options;
+  gen_options.enable = true;
+  gen_options.action_if_no_compiled_nodes = epctx::ModelGenOptions::ActionIfNoCompiledNodes::kGenerateModel;
+  epctx::BufferWriteFuncHolder write_func_holder;
+  write_func_holder.write_func = AppendToStringWriteFunc;
+  write_func_holder.stream_state = &sink;
+  gen_options.output_model_location = write_func_holder;
+  so.ep_context_gen_options = gen_options;
+  so.has_explicit_ep_context_gen_options = true;
+
+  {
+    InferenceSession session{so, GetEnvironment()};
+    EXPECT_STATUS_OK(session.Load(input_model));
+    EXPECT_STATUS_OK(session.Initialize());
+  }
+
+  ASSERT_FALSE(sink.empty());
+
+  // Load the emitted model from the written bytes in a plain (non-optimizing) session and count ops.
+  SessionOptions verify_so;
+  verify_so.graph_optimization_level = TransformerLevel::Default;  // do not re-optimize the emitted model
+  InferenceSessionWrapper verify{verify_so, GetEnvironment()};
+  EXPECT_STATUS_OK(verify.Load(sink.data(), static_cast<int>(sink.size())));
+  EXPECT_STATUS_OK(verify.Initialize());
+  const std::map<std::string, int> counts = CountOpsInGraph(verify.GetGraph());
+  EXPECT_EQ(counts.count("com.microsoft.BiasGelu") ? counts.at("com.microsoft.BiasGelu") : 0, 1);
+}
+#endif  // !defined(ORT_MINIMAL_BUILD)
 
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/framework/inference_session_test.cc
+++ b/onnxruntime/test/framework/inference_session_test.cc
@@ -3369,11 +3369,14 @@ TEST(InferenceSessionTests, SessionLoggerOutlivesEPsWithUserLoggingFunction) {
 
 #if !defined(ORT_MINIMAL_BUILD)
 // A compile-only session (Compile API path, marked by kOrtSessionOptionCompileOnly) whose EPs compile no
-// nodes emits a plain optimized output model *after* the Level2+ optimizer loop, so the serialized graph
-// reflects those fusions. This is EP-agnostic: the CPU EP compiles nothing, so the kGenerateModel path
-// serializes the optimized graph. bias_gelu_fusion.onnx fuses to com.microsoft.BiasGelu only at Level2
-// (BiasGeluFusion is Level2-only), so its presence in the emitted model proves the Level2 fusion reached
-// the output; at ORT_ENABLE_BASIC (Level1) it is absent because that fusion never runs.
+// nodes emits a plain optimized output model. The serialization point is chosen by the requested level:
+// for level >= Level2 it is emitted *after* the Level2+ optimizer loop so the serialized graph reflects
+// those fusions; for level < Level2 it is emitted before the loop (a BASIC snapshot). This is EP-agnostic:
+// the CPU EP compiles nothing, so the kGenerateModel path serializes the optimized graph.
+// bias_gelu_fusion.onnx fuses to com.microsoft.BiasGelu only at Level2 (BiasGeluFusion is Level2-only), so
+// its presence in the emitted model proves the Level2 fusion reached the output; at ORT_ENABLE_BASIC
+// (Level1) it is absent because that fusion never runs. The two cases below therefore exercise both
+// serialization points (after-loop for ENABLE_ALL, before-loop for BASIC).
 TEST(InferenceSessionTests, CompileOnlyToFileSerializesFullyOptimizedGraph) {
   const std::string input_model = "testdata/transform/fusion/bias_gelu_fusion.onnx";
 


### PR DESCRIPTION
The Compile API can generate an output model even when no nodes were compiled into EPContext nodes
(its `kGenerateModel` action, e.g. for a non-compiling EP such as WebGPU). That model was always frozen
at `ORT_ENABLE_BASIC` because it was serialized during partitioning, before the Level2-Level4 optimizer
loop ran. It now reflects the graph optimized to the requested level, so the fusions the caller asked
for reach the output.

This is a general fix to the Compile API's model-generation path, not specific to any EP. It does not
change the output of compiling EPs (OpenVINO/QNN/TensorRT), whose optimization lives inside the EPContext
blob rather than in ORT's Level2+ passes.