### PR TITLE
[MLAS] Route ARM64 S8U8 QGEMM to the UDOT kernel

### DIFF
--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -1598,6 +1598,7 @@ struct MLAS_PLATFORM {
     const MLAS_GEMM_QUANT_DISPATCH* GemmU8U8Dispatch;
     const MLAS_GEMM_QUANT_DISPATCH* GemmU8S8Dispatch;
     const MLAS_GEMM_QUANT_DISPATCH* GemmS8S8Dispatch;
+    const MLAS_GEMM_QUANT_DISPATCH* GemmS8U8Dispatch;
 #if defined(MLAS_USE_ARM_NEON_NCHWC)
     MLAS_CONV_FLOAT_KERNEL* ConvNchwFloatKernel;
     MLAS_CONV_FLOAT_KERNEL* ConvNchwcFloatKernel;

--- a/onnxruntime/core/mlas/lib/platform.cpp
+++ b/onnxruntime/core/mlas/lib/platform.cpp
@@ -646,6 +646,7 @@ Return Value:
     this->GemmU8U8Dispatch = &MlasGemmU8X8DispatchNeon;
     this->GemmU8S8Dispatch = &MlasGemmX8S8DispatchNeon;
     this->GemmS8S8Dispatch = &MlasGemmX8S8DispatchNeon;
+    this->GemmS8U8Dispatch = &MlasGemmQuantDispatchDefault;
     this->SymmQgemmDispatch = &MlasSymmQgemmS8DispatchNeon;
     this->ConvSymU8S8Dispatch = &MlasConvSymU8DispatchNeon;
     this->ConvSymS8S8Dispatch = &MlasConvSymS8DispatchNeon;
@@ -697,6 +698,7 @@ Return Value:
     if (HasDotProductInstructions) {
         this->GemmU8U8Dispatch = &MlasGemmU8X8DispatchUdot;
         this->GemmU8S8Dispatch = &MlasGemmU8X8DispatchUdot;
+        this->GemmS8U8Dispatch = &MlasGemmU8X8DispatchUdot;
         this->GemmS8S8Dispatch = &MlasGemmS8S8DispatchSdot;
         this->SymmQgemmDispatch = &MlasSymmQgemmS8DispatchSdot;
         this->ConvSymU8S8Dispatch = &MlasConvSymU8DispatchDot;

--- a/onnxruntime/core/mlas/lib/qgemm.h
+++ b/onnxruntime/core/mlas/lib/qgemm.h
@@ -879,8 +879,8 @@ MlasGemmQuantGetDispatch(
 #elif defined(MLAS_TARGET_ARM64)
     if(BIsSigned) {
         GemmQuantDispatch = AIsSigned ? GetMlasPlatform().GemmS8S8Dispatch : GetMlasPlatform().GemmU8S8Dispatch;
-    } else if(!AIsSigned) {
-        GemmQuantDispatch = GetMlasPlatform().GemmU8U8Dispatch;
+    } else {
+        GemmQuantDispatch = AIsSigned ? GetMlasPlatform().GemmS8U8Dispatch : GetMlasPlatform().GemmU8U8Dispatch;
     }
 #elif defined(MLAS_TARGET_ARM64EC) || (defined(MLAS_TARGET_ARM) && !defined(_MSC_VER))
     if(BIsSigned || !AIsSigned) {

--- a/onnxruntime/core/mlas/lib/qgemm_kernel_udot.cpp
+++ b/onnxruntime/core/mlas/lib/qgemm_kernel_udot.cpp
@@ -72,6 +72,21 @@ MlasGemmQuantFixupZeroPointB<MLAS_GEMM_U8X8_KERNEL_UDOT>(
 }
 
 template<>
+MLAS_FORCEINLINE
+int32_t
+MlasGemmQuantFixupZeroPointA<MLAS_GEMM_U8X8_KERNEL_UDOT>(
+    int32_t ZeroPointA,
+    bool AIsSigned
+    )
+{
+    if (AIsSigned) {
+        ZeroPointA = MLAS_GEMM_U8X8_KERNEL_UDOT::OffsetAType(ZeroPointA ^ 0x80);
+    }
+
+    return ZeroPointA;
+}
+
+template<>
 void
 MlasGemmQuantCopyPackA<MLAS_GEMM_U8X8_KERNEL_UDOT>(
     MLAS_GEMM_U8X8_KERNEL_UDOT::PackedAType* D,
@@ -83,8 +98,25 @@ MlasGemmQuantCopyPackA<MLAS_GEMM_U8X8_KERNEL_UDOT>(
     bool AIsSigned
     )
 {
-    MLAS_UNREFERENCED_PARAMETER(AIsSigned);
     uint8_t PaddedMatrixAData[16];
+
+    //
+    // UDOT is an unsigned x unsigned dot product instruction, so a signed A
+    // matrix is shifted into the unsigned domain by flipping the sign bit of
+    // every real data byte (equivalent to adding 128). Padding bytes must stay
+    // literal zero so they keep contributing nothing to the dot product or to
+    // RowSumBuffer; MlasGemmQuantFixupZeroPointA applies the matching shift to
+    // ZeroPointA so the zero-point correction stays consistent.
+    //
+
+    // Four views of the same flip value, one per register width used below:
+    // the 8/4/2/1-row blocks mix uint32_t scalar loads, uint32x4_t vector
+    // loads, and byte-at-a-time tail copies, so each width needs its own
+    // pre-splatted constant.
+    const uint8_t AByteFlip = AIsSigned ? 0x80 : 0;
+    const uint8x16_t AFlipVector = vdupq_n_u8(AByteFlip);
+    const uint32x4_t AFlipVector32 = vdupq_n_u32(AIsSigned ? 0x80808080u : 0u);
+    const uint32_t AFlipWord32 = AIsSigned ? 0x80808080u : 0u;
 
     //
     // Process 8 rows of matrix A.
@@ -122,21 +154,21 @@ MlasGemmQuantCopyPackA<MLAS_GEMM_U8X8_KERNEL_UDOT>(
         uint32x4_t RowSums1 = vmovq_n_u32(0);
 
         while (k >= 16) {
-            uint32x4_t v0 = vld1q_u32(reinterpret_cast<const uint32_t*>(a0));
+            uint32x4_t v0 = veorq_u32(vld1q_u32(reinterpret_cast<const uint32_t*>(a0)), AFlipVector32);
             a0 += 16;
-            uint32x4_t v1 = vld1q_u32(reinterpret_cast<const uint32_t*>(a1));
+            uint32x4_t v1 = veorq_u32(vld1q_u32(reinterpret_cast<const uint32_t*>(a1)), AFlipVector32);
             a1 += 16;
-            uint32x4_t v2 = vld1q_u32(reinterpret_cast<const uint32_t*>(a2));
+            uint32x4_t v2 = veorq_u32(vld1q_u32(reinterpret_cast<const uint32_t*>(a2)), AFlipVector32);
             a2 += 16;
-            uint32x4_t v3 = vld1q_u32(reinterpret_cast<const uint32_t*>(a3));
+            uint32x4_t v3 = veorq_u32(vld1q_u32(reinterpret_cast<const uint32_t*>(a3)), AFlipVector32);
             a3 += 16;
-            uint32x4_t v4 = vld1q_u32(reinterpret_cast<const uint32_t*>(a4));
+            uint32x4_t v4 = veorq_u32(vld1q_u32(reinterpret_cast<const uint32_t*>(a4)), AFlipVector32);
             a4 += 16;
-            uint32x4_t v5 = vld1q_u32(reinterpret_cast<const uint32_t*>(a5));
+            uint32x4_t v5 = veorq_u32(vld1q_u32(reinterpret_cast<const uint32_t*>(a5)), AFlipVector32);
             a5 += 16;
-            uint32x4_t v6 = vld1q_u32(reinterpret_cast<const uint32_t*>(a6));
+            uint32x4_t v6 = veorq_u32(vld1q_u32(reinterpret_cast<const uint32_t*>(a6)), AFlipVector32);
             a6 += 16;
-            uint32x4_t v7 = vld1q_u32(reinterpret_cast<const uint32_t*>(a7));
+            uint32x4_t v7 = veorq_u32(vld1q_u32(reinterpret_cast<const uint32_t*>(a7)), AFlipVector32);
             a7 += 16;
 
             uint32x4_t z0 = vzip1q_u32(v0, v2);
@@ -183,21 +215,21 @@ MlasGemmQuantCopyPackA<MLAS_GEMM_U8X8_KERNEL_UDOT>(
         }
 
         while (k >= 4) {
-            uint32_t v0 = *reinterpret_cast<const uint32_t*>(a0);
+            uint32_t v0 = *reinterpret_cast<const uint32_t*>(a0) ^ AFlipWord32;
             a0 += 4;
-            uint32_t v1 = *reinterpret_cast<const uint32_t*>(a1);
+            uint32_t v1 = *reinterpret_cast<const uint32_t*>(a1) ^ AFlipWord32;
             a1 += 4;
-            uint32_t v2 = *reinterpret_cast<const uint32_t*>(a2);
+            uint32_t v2 = *reinterpret_cast<const uint32_t*>(a2) ^ AFlipWord32;
             a2 += 4;
-            uint32_t v3 = *reinterpret_cast<const uint32_t*>(a3);
+            uint32_t v3 = *reinterpret_cast<const uint32_t*>(a3) ^ AFlipWord32;
             a3 += 4;
-            uint32_t v4 = *reinterpret_cast<const uint32_t*>(a4);
+            uint32_t v4 = *reinterpret_cast<const uint32_t*>(a4) ^ AFlipWord32;
             a4 += 4;
-            uint32_t v5 = *reinterpret_cast<const uint32_t*>(a5);
+            uint32_t v5 = *reinterpret_cast<const uint32_t*>(a5) ^ AFlipWord32;
             a5 += 4;
-            uint32_t v6 = *reinterpret_cast<const uint32_t*>(a6);
+            uint32_t v6 = *reinterpret_cast<const uint32_t*>(a6) ^ AFlipWord32;
             a6 += 4;
-            uint32_t v7 = *reinterpret_cast<const uint32_t*>(a7);
+            uint32_t v7 = *reinterpret_cast<const uint32_t*>(a7) ^ AFlipWord32;
             a7 += 4;
 
             *reinterpret_cast<uint32_t*>(&D[0]) = v0;
@@ -226,14 +258,14 @@ MlasGemmQuantCopyPackA<MLAS_GEMM_U8X8_KERNEL_UDOT>(
             vst1q_u8(&d[16], vmovq_n_u8(0));
 
             while (k > 0) {
-                d[0] = *a0++;
-                d[4] = *a1++;
-                d[8] = *a2++;
-                d[12] = *a3++;
-                d[16] = *a4++;
-                d[20] = *a5++;
-                d[24] = *a6++;
-                d[28] = *a7++;
+                d[0] = (*a0++) ^ AByteFlip;
+                d[4] = (*a1++) ^ AByteFlip;
+                d[8] = (*a2++) ^ AByteFlip;
+                d[12] = (*a3++) ^ AByteFlip;
+                d[16] = (*a4++) ^ AByteFlip;
+                d[20] = (*a5++) ^ AByteFlip;
+                d[24] = (*a6++) ^ AByteFlip;
+                d[28] = (*a7++) ^ AByteFlip;
                 d += 1;
                 k -= 1;
             }
@@ -286,13 +318,13 @@ MlasGemmQuantCopyPackA<MLAS_GEMM_U8X8_KERNEL_UDOT>(
 
         while (k >= 16) {
 
-            uint32x4_t v0 = vld1q_u32(reinterpret_cast<const uint32_t*>(a0));
+            uint32x4_t v0 = veorq_u32(vld1q_u32(reinterpret_cast<const uint32_t*>(a0)), AFlipVector32);
             a0 += 16;
-            uint32x4_t v1 = vld1q_u32(reinterpret_cast<const uint32_t*>(a1));
+            uint32x4_t v1 = veorq_u32(vld1q_u32(reinterpret_cast<const uint32_t*>(a1)), AFlipVector32);
             a1 += 16;
-            uint32x4_t v2 = vld1q_u32(reinterpret_cast<const uint32_t*>(a2));
+            uint32x4_t v2 = veorq_u32(vld1q_u32(reinterpret_cast<const uint32_t*>(a2)), AFlipVector32);
             a2 += 16;
-            uint32x4_t v3 = vld1q_u32(reinterpret_cast<const uint32_t*>(a3));
+            uint32x4_t v3 = veorq_u32(vld1q_u32(reinterpret_cast<const uint32_t*>(a3)), AFlipVector32);
             a3 += 16;
 
             uint32x4_t z0 = vzip1q_u32(v0, v2);
@@ -321,13 +353,13 @@ MlasGemmQuantCopyPackA<MLAS_GEMM_U8X8_KERNEL_UDOT>(
 
         while (k >= 4) {
 
-            uint32_t v0 = *reinterpret_cast<const uint32_t*>(a0);
+            uint32_t v0 = *reinterpret_cast<const uint32_t*>(a0) ^ AFlipWord32;
             a0 += 4;
-            uint32_t v1 = *reinterpret_cast<const uint32_t*>(a1);
+            uint32_t v1 = *reinterpret_cast<const uint32_t*>(a1) ^ AFlipWord32;
             a1 += 4;
-            uint32_t v2 = *reinterpret_cast<const uint32_t*>(a2);
+            uint32_t v2 = *reinterpret_cast<const uint32_t*>(a2) ^ AFlipWord32;
             a2 += 4;
-            uint32_t v3 = *reinterpret_cast<const uint32_t*>(a3);
+            uint32_t v3 = *reinterpret_cast<const uint32_t*>(a3) ^ AFlipWord32;
             a3 += 4;
 
             *reinterpret_cast<uint32_t*>(&D[0]) = v0;
@@ -353,10 +385,10 @@ MlasGemmQuantCopyPackA<MLAS_GEMM_U8X8_KERNEL_UDOT>(
 
             while (k > 0) {
 
-                d[0] = *a0++;
-                d[4] = *a1++;
-                d[8] = *a2++;
-                d[12] = *a3++;
+                d[0] = (*a0++) ^ AByteFlip;
+                d[4] = (*a1++) ^ AByteFlip;
+                d[8] = (*a2++) ^ AByteFlip;
+                d[12] = (*a3++) ^ AByteFlip;
 
                 d += 1;
                 k -= 1;
@@ -409,9 +441,9 @@ MlasGemmQuantCopyPackA<MLAS_GEMM_U8X8_KERNEL_UDOT>(
 
         while (k >= 4) {
 
-            uint32_t v0 = *reinterpret_cast<const uint32_t*>(a0);
+            uint32_t v0 = *reinterpret_cast<const uint32_t*>(a0) ^ AFlipWord32;
             a0 += 4;
-            uint32_t v1 = *reinterpret_cast<const uint32_t*>(a1);
+            uint32_t v1 = *reinterpret_cast<const uint32_t*>(a1) ^ AFlipWord32;
             a1 += 4;
 
             *reinterpret_cast<uint32_t*>(&D[0]) = v0;
@@ -435,8 +467,8 @@ MlasGemmQuantCopyPackA<MLAS_GEMM_U8X8_KERNEL_UDOT>(
 
             while (k > 0) {
 
-                d[0] = *a0++;
-                d[4] = *a1++;
+                d[0] = (*a0++) ^ AByteFlip;
+                d[4] = (*a1++) ^ AByteFlip;
 
                 d += 1;
                 k -= 1;
@@ -486,7 +518,7 @@ MlasGemmQuantCopyPackA<MLAS_GEMM_U8X8_KERNEL_UDOT>(
 
         while (k >= 16) {
 
-            uint8x16_t v = vld1q_u8(a);
+            uint8x16_t v = veorq_u8(vld1q_u8(a), AFlipVector);
             a += 16;
 
             vst1q_u8(D, v);
@@ -506,7 +538,7 @@ MlasGemmQuantCopyPackA<MLAS_GEMM_U8X8_KERNEL_UDOT>(
             vst1q_u8(PaddedMatrixAData, vmovq_n_u8(0));
 
             for (size_t kk = 0; kk < k; kk++) {
-                PaddedMatrixAData[kk] = a[kk];
+                PaddedMatrixAData[kk] = a[kk] ^ AByteFlip;
             }
 
             uint8x16_t v = vld1q_u8(PaddedMatrixAData);

--- a/onnxruntime/test/mlas/bench/bench_qgemm.cpp
+++ b/onnxruntime/test/mlas/bench/bench_qgemm.cpp
@@ -49,7 +49,7 @@ void QGEMM(benchmark::State& state, bool pack_b, bool a_is_signed, bool b_is_sig
       // AIsSigned/BIsSigned combination does not support packing (e.g. the
       // scalar reference dispatch). Calling MlasGemmPackB in that case would
       // dereference a null CopyPackBRoutine, so skip instead of crashing.
-      state.SkipWithError("Packing is not supported for this A/B signedness combination on this target");
+      state.SkipWithMessage("Packing is not supported for this A/B signedness combination on this target");
       return;
     }
     pack_b_holder.resize(packed_b_size * batch);

--- a/onnxruntime/test/mlas/bench/bench_qgemm.cpp
+++ b/onnxruntime/test/mlas/bench/bench_qgemm.cpp
@@ -12,8 +12,7 @@
 
 static const std::vector<std::string> qgemm_arg_names = {"M", "N", "K", "Batch", "Threads"};
 
-void QGEMM(benchmark::State& state, bool pack_b, bool a_is_signed) {
-  constexpr bool b_is_signed = true;
+void QGEMM(benchmark::State& state, bool pack_b, bool a_is_signed, bool b_is_signed) {
   constexpr uint8_t a_zero_point = 29;
   constexpr uint8_t b_zero_point = 179;
 
@@ -45,6 +44,14 @@ void QGEMM(benchmark::State& state, bool pack_b, bool a_is_signed) {
   size_t packed_b_size = 0;
   if (pack_b) {
     packed_b_size = MlasGemmPackBSize(N, K, a_is_signed, b_is_signed, nullptr);
+    if (packed_b_size == 0) {
+      // MlasGemmPackBSize returns zero when the active dispatch for this
+      // AIsSigned/BIsSigned combination does not support packing (e.g. the
+      // scalar reference dispatch). Calling MlasGemmPackB in that case would
+      // dereference a null CopyPackBRoutine, so skip instead of crashing.
+      state.SkipWithError("Packing is not supported for this A/B signedness combination on this target");
+      return;
+    }
     pack_b_holder.resize(packed_b_size * batch);
   }
 
@@ -103,11 +110,16 @@ static void QGemmSize(benchmark::internal::Benchmark* b) {
   b->Args({3072, 4096, 1024, 1, 16});
 }
 
-BENCHMARK_CAPTURE(QGEMM, UnsignedAPackB, true, false)->Apply(QGemmSize)->UseRealTime();
-BENCHMARK_CAPTURE(QGEMM, UnsignedANoPackB, false, false)->Apply(QGemmSize)->UseRealTime();
+BENCHMARK_CAPTURE(QGEMM, UnsignedAPackB, true, false, true)->Apply(QGemmSize)->UseRealTime();
+BENCHMARK_CAPTURE(QGEMM, UnsignedANoPackB, false, false, true)->Apply(QGemmSize)->UseRealTime();
 #if !defined(MLAS_TARGET_AMD64)
 // QGEMM is not supported for signed A, signed B (Packed) on AMD64 CPU. The
 // benchmark assumes MlasGemmPackBSize return non-zero is not true.
-BENCHMARK_CAPTURE(QGEMM, SignedAPackB, true, true)->Apply(QGemmSize)->UseRealTime();
+BENCHMARK_CAPTURE(QGEMM, SignedAPackB, true, true, true)->Apply(QGemmSize)->UseRealTime();
 #endif
-BENCHMARK_CAPTURE(QGEMM, SignedANoPackB, false, true)->Apply(QGemmSize)->UseRealTime();
+BENCHMARK_CAPTURE(QGEMM, SignedANoPackB, false, true, true)->Apply(QGemmSize)->UseRealTime();
+
+// A=int8(signed), B=uint8(unsigned): on ARM64 this now dispatches through the
+// UDOT kernel (see qgemm_kernel_udot.cpp) instead of falling back to scalar.
+BENCHMARK_CAPTURE(QGEMM, SignedAUnsignedBPackB, true, true, false)->Apply(QGemmSize)->UseRealTime();
+BENCHMARK_CAPTURE(QGEMM, SignedAUnsignedBNoPackB, false, true, false)->Apply(QGemmSize)->UseRealTime();

--- a/onnxruntime/test/mlas/unittest/test_qgemm.cpp
+++ b/onnxruntime/test/mlas/unittest/test_qgemm.cpp
@@ -38,6 +38,7 @@ static size_t QGemmRegistShortExecute() {
   count += QgemmShortExecuteTest<int8_t, int8_t, int32_t, false, false>::RegisterShortExecuteTests();
   count += QgemmShortExecuteTest<int8_t, uint8_t, float, false, false>::RegisterShortExecuteTests();
   count += QgemmShortExecuteTest<int8_t, uint8_t, int32_t, false, false>::RegisterShortExecuteTests();
+  count += QgemmS8U8SignedInputTest<false>::RegisterShortExecuteTests();
   if (MlasGemmPackBSize(128, 128, false /*AIsSigned*/, false /*BIsSigned*/, nullptr) > 0) {
     // QGEMM U8U8=float packed tests
     count += QgemmShortExecuteTest<uint8_t, uint8_t, float, true, false>::RegisterShortExecuteTests();
@@ -72,6 +73,7 @@ static size_t QGemmRegistShortExecute() {
     count += QgemmShortExecuteTest<int8_t, int8_t, int32_t, false, true>::RegisterShortExecuteTests();
     count += QgemmShortExecuteTest<int8_t, uint8_t, float, false, true>::RegisterShortExecuteTests();
     count += QgemmShortExecuteTest<int8_t, uint8_t, int32_t, false, true>::RegisterShortExecuteTests();
+    count += QgemmS8U8SignedInputTest<true>::RegisterShortExecuteTests();
     if (MlasGemmPackBSize(128, 128, false /*AIsSigned*/, false /*BIsSigned*/, nullptr) > 0) {
       count += QgemmShortExecuteTest<uint8_t, uint8_t, float, true, true>::RegisterShortExecuteTests();
       count += QgemmShortExecuteTest<uint8_t, uint8_t, int32_t, true, true>::RegisterShortExecuteTests();

--- a/onnxruntime/test/mlas/unittest/test_qgemm_fixture.h
+++ b/onnxruntime/test/mlas/unittest/test_qgemm_fixture.h
@@ -186,3 +186,85 @@ class QgemmShortExecuteTest<AType, BType, float, Packed, Threaded> : public Mlas
   size_t M_, N_, K_;
   uint8_t offa_, offb_;
 };
+
+//
+// Explicit S8U8 coverage for signed A boundary values (-128/-1/0/127); the
+// generic buffer fill never produces bytes outside [21,63].
+//
+template <bool Threaded>
+class QgemmS8U8SignedInputTest : public MlasTestFixture<MlasQgemmTest<int8_t, uint8_t, int32_t, false, Threaded>> {
+ public:
+  QgemmS8U8SignedInputTest(size_t M, size_t N, size_t K, uint8_t offa, uint8_t offb)
+      : M_(M), N_(N), K_(K), offa_(offa), offb_(offb) {
+  }
+
+  void TestBody() override {
+    static const int8_t a_values[] = {-128, -1, 0, 1, 127, -64, 64, -33};
+    static const uint8_t b_values[] = {0, 1, 127, 128, 255, 63, 200, 17};
+
+    uint8_t* A = BufferA.GetFilledBuffer(M_ * K_, [](uint8_t* p, size_t n) {
+      for (size_t i = 0; i < n; i++) {
+        p[i] = uint8_t(a_values[i % _countof(a_values)]);
+      }
+    });
+    uint8_t* B = BufferB.GetFilledBuffer(K_ * N_, [](uint8_t* p, size_t n) {
+      for (size_t i = 0; i < n; i++) {
+        p[i] = b_values[i % _countof(b_values)];
+      }
+    });
+    int32_t* C = BufferC.GetBuffer(M_ * N_);
+    int32_t* CReference = BufferCReference.GetBuffer(M_ * N_);
+
+    MlasTestFixture<MlasQgemmTest<int8_t, uint8_t, int32_t, false, Threaded>>::mlas_tester
+        ->Test(M_, N_, K_, 1, A, K_, offa_, B, N_, offb_, C, CReference, N_);
+  }
+
+  static size_t RegisterSingleTest(size_t M, size_t N, size_t K, uint8_t offa, uint8_t offb) {
+    std::stringstream ss;
+    ss << "M" << M << "xN" << N << "xK" << K << "/"
+       << "offa" << (unsigned)offa << "/"
+       << "offb" << (unsigned)offb;
+    auto test_name = ss.str();
+
+    testing::RegisterTest(
+        Threaded ? "QGemmS8U8_Int32_SignedInput_Threaded" : "QGemmS8U8_Int32_SignedInput_SingleThread",
+        test_name.c_str(),
+        nullptr,
+        test_name.c_str(),
+        __FILE__,
+        __LINE__,
+        [=]() -> MlasTestFixture<MlasQgemmTest<int8_t, uint8_t, int32_t, false, Threaded>>* {
+          return new QgemmS8U8SignedInputTest<Threaded>(M, N, K, offa, offb);
+        });
+    return 1;
+  }
+
+  static size_t RegisterShortExecuteTests() {
+    size_t test_registered = 0;
+
+    static const size_t Ks[] = {1, 3, 4, 5, 7, 8, 9, 15, 16, 17};
+    static const size_t Ms[] = {1, 2, 3, 4, 7, 8, 9};
+    static const uint8_t offas[] = {0, 128, 255};
+    static const uint8_t offbs[] = {0, 255};
+
+    for (size_t k = 0; k < _countof(Ks); k++) {
+      for (size_t m = 0; m < _countof(Ms); m++) {
+        for (size_t a = 0; a < _countof(offas); a++) {
+          for (size_t b = 0; b < _countof(offbs); b++) {
+            test_registered += RegisterSingleTest(Ms[m], 16, Ks[k], offas[a], offbs[b]);
+          }
+        }
+      }
+    }
+
+    return test_registered;
+  }
+
+ private:
+  MatrixGuardBuffer<uint8_t> BufferA;
+  MatrixGuardBuffer<uint8_t> BufferB;
+  MatrixGuardBuffer<int32_t> BufferC;
+  MatrixGuardBuffer<int32_t> BufferCReference;
+  size_t M_, N_, K_;
+  uint8_t offa_, offb_;
+};


### PR DESCRIPTION
### Description

ARM64 quantized GEMM never routed the signed-A/unsigned-B (S8U8) combination to a SIMD dispatch — `MLAS_PLATFORM` didn't even declare a `GemmS8U8Dispatch` member on ARM64, unlike x86_64 (AVX2/VNNI), LoongArch64 (LSX), and RISC-V64, which all have one. It fell through to the generic scalar reference kernel.

This reuses the existing UDOT kernel (already shared by U8U8 and U8S8) instead of adding new assembly. UDOT only does unsigned x unsigned, so B is already shifted into the unsigned domain with an XOR 0x80 sign flip when signed; this does the same for A (`MlasGemmQuantFixupZeroPointA`, `MlasGemmQuantCopyPackA`). K-padding bytes are left untouched across all four row-count paths (8/4/2/1-row) so they keep contributing zero to the dot product and `RowSumBuffer`. `platform.cpp` initializes the new dispatch member to the scalar default and only overrides it to UDOT inside the existing dot-product-support check, so cores without dot-product stay on the scalar path exactly as before.

Also parameterized `bench_qgemm.cpp` to cover S8U8, and added a guard around the packed-B benchmark: `MlasGemmPackBSize` returns 0 for combinations the active dispatch doesn't support packing for, and calling `MlasGemmPackB` anyway was dereferencing a null `CopyPackBRoutine`.

### Motivation and Context

`QLinearMatMul`, `MatMulInteger`, and `QLinearConv` register their signed-A kernels with `T2` accepting both `int8` and `uint8`, so S8U8 is reachable from real models, not just a synthetic case. Existing `test_qgemm.cpp` correctness tests already cover `int8_t`/`uint8_t`, they were just exercising the scalar fallback on ARM64.

Tested on Apple M1 (macOS) and Ampere Neoverse-N1 (Ubuntu), both with NEON dot-product:

- Existing MLAS qgemm suites (S8U8/U8U8/U8S8/S8S8) pass on both, no regressions.
- Benchmarked `bench_qgemm` (NoPackB, real_time) before/after by temporarily forcing the scalar dispatch for comparison:

| Shape (M/N/K, threads) | M1 | Neoverse-N1 |
|---|---|---|
| 1/512/512, 1 | 149µs → 29µs | 152µs → 51µs |
| 1/1024/1024, 1 | 610µs → 202µs | 1544µs → 240µs |
| 384/1024/1024, 4 | 4.96ms → 3.98ms | 12.3ms → 1.34ms |
| 384/1024/3072, 4 | 20.7ms → 4.68ms | 37.2ms → 4.17ms |
| 1536/1024/4096, 16 | 124.6ms → 37.6ms | 201.6ms → 37.4ms |
| 3072/4096/1024, 16 | 135.4ms → 53.4ms | 388.8ms → 69.2ms |

Packed-B for S8U8 works correctly on both machines now that they're on the UDOT dispatch. Without the guard mentioned above, the new packed-B benchmark case would crash on any target that still resolves to the scalar dispatch, since `MlasGemmPackBSize` returns 0 there and `MlasGemmPackB` would call a null `CopyPackBRoutine`.

ARM64 cores without dot-product support are unaffected by the dispatch change — they stay on `MlasGemmQuantDispatchDefault` (scalar) exactly as before, `MlasGemmPackBSize` still returns 0 for S8U8 there, and the benchmark guard keeps that case skipping cleanly instead of crashing. This PR doesn't add an optimized S8U8 path or packed-B support for those cores; that's left for a follow-up if there's interest.

The routing change in `qgemm.h` lives inside the `#if defined(MLAS_TARGET_ARM64)` guard, so native Windows ARM64 (MSVC, `MLAS_TARGET_ARM64`) picks up the same S8U8 → UDOT routing as macOS/Linux ARM64 — it wasn't separately benchmarked here. ARM64EC (`MLAS_TARGET_ARM64EC`) and 32-bit ARM stay on their existing logic, unaffected.

