### PR TITLE
Fix non-deterministic constant folding output

### DIFF
--- a/onnxruntime/core/optimizer/constant_folding.cc
+++ b/onnxruntime/core/optimizer/constant_folding.cc
@@ -667,11 +667,11 @@ Status ConstantFolding::ApplyImpl(Graph& graph, bool& modified, int graph_level,
           // Build the TensorProto that corresponds to the computed OrtValue and add it as initializer to the graph.
           auto* constant_arg_out = node->MutableOutputDefs()[output_idx];
           const Tensor& out_tensor = ort_value.Get<Tensor>();
-          constexpr const bool use_tensor_buffer_true = true;
+          const bool use_tensor_buffer = out_tensor.OwnsBuffer();
           ONNX_NAMESPACE::TensorProto out_tensorproto = utils::TensorToTensorProto(
               out_tensor,
               constant_arg_out->Name(),
-              use_tensor_buffer_true);
+              use_tensor_buffer);
 
           ONNX_NAMESPACE::TensorShapeProto result_shape;
           for (auto& dim : out_tensor.Shape().GetDims()) {

--- a/onnxruntime/core/optimizer/constant_folding.cc
+++ b/onnxruntime/core/optimizer/constant_folding.cc
@@ -667,6 +667,8 @@ Status ConstantFolding::ApplyImpl(Graph& graph, bool& modified, int graph_level,
           // Build the TensorProto that corresponds to the computed OrtValue and add it as initializer to the graph.
           auto* constant_arg_out = node->MutableOutputDefs()[output_idx];
           const Tensor& out_tensor = ort_value.Get<Tensor>();
+          // Fallback to deep copy for aliased tensors (e.g., Reshape, Unsqueeze)
+          // to prevent dangling pointers when parent initializers are freed.
           const bool use_tensor_buffer = out_tensor.OwnsBuffer();
           ONNX_NAMESPACE::TensorProto out_tensorproto = utils::TensorToTensorProto(
               out_tensor,
@@ -679,7 +681,7 @@ Status ConstantFolding::ApplyImpl(Graph& graph, bool& modified, int graph_level,
           }
 
           constant_arg_out->SetShape(result_shape);
-          // The data is too small and has been inlined.
+          // Inlined data (small or deep-copied tensors) does not need to hold an OrtValue reference.
           if (!utils::HasExternalData(out_tensorproto)) {
             ORT_THROW_IF_ERROR(graph.AddInitializedOrtValue(out_tensorproto, OrtValue()));
           } else {


### PR DESCRIPTION
### Description
From `v1.24.1`, `use_tensor_buffer=true` is set in `TensorToTensorProto` during constant folding. For ops that return aliased OrtValues (e.g. Reshape), the folded initializer referenced memory owned by an input initializer. When that input was removed later in the pass, the reference dangled, producing unstable (often huge/negative) values.

Use `out_tensor.OwnsBuffer()` to decide `use_tensor_buffer`. Owned tensors are referenced zero-copy (safe via `OrtValue` shared lifetime); aliased tensors are deep-copied into the proto

### Related issue
https://github.com/microsoft/onnxruntime/issues/29788