### PR TITLE
[CUDA] Fix same-buffer copy abort on retained in-memory initializers (#29713)

### DIFF
--- a/onnxruntime/core/providers/cuda/gpu_data_transfer.cc
+++ b/onnxruntime/core/providers/cuda/gpu_data_transfer.cc
@@ -59,7 +59,12 @@ common::Status GPUDataTransfer::CopyTensor(const Tensor& src, Tensor& dst) const
     CUDA_RETURN_IF_ERROR(cudaMemcpy(dst_data, src_data, bytes, cudaMemcpyDeviceToHost));
   } else {
     // copying between cpu memory
-    ORT_ENFORCE(dst_data != src_data);
+    if (dst_data == src_data) {
+      // No copy needed: source and destination are the same physical buffer. This can happen
+      // when a retained in-memory OrtValue initializer is scheduled for a device copy (GH #29713).
+      // Matches CPUDataTransfer::CopyTensor and the device->device branch above.
+      return Status::OK();
+    }
     memcpy(dst_data, src_data, bytes);
   }
 
@@ -96,12 +101,19 @@ common::Status GPUDataTransfer::CopyTensorAsync(const Tensor& src, Tensor& dst, 
     CUDA_RETURN_IF_ERROR(cudaMemcpyAsync(dst_data, src_data, bytes, cudaMemcpyDeviceToHost,
                                          static_cast<cudaStream_t>(stream.GetHandle())));
   } else {
+    // No copy needed: source and destination are the same physical buffer. This can happen when a
+    // retained in-memory OrtValue initializer is scheduled for a device copy (GH #29713). Return
+    // early *before* the HOST_ACCESSIBLE stream sync below, which is illegal during CUDA-graph
+    // capture. Matches CPUDataTransfer::CopyTensor and the device->device branch above.
+    if (dst_data == src_data) {
+      return Status::OK();
+    }
+
     if (src_device.MemType() == OrtDevice::MemType::HOST_ACCESSIBLE) {
       // sync the stream first to make sure the data arrived
       CUDA_RETURN_IF_ERROR(cudaStreamSynchronize(static_cast<cudaStream_t>(stream.GetHandle())));
     }
 
-    ORT_ENFORCE(dst_data != src_data);
     memcpy(dst_data, src_data, bytes);
   }
 

--- a/onnxruntime/test/providers/cuda/test_cases/gpu_data_transfer_test.cc
+++ b/onnxruntime/test/providers/cuda/test_cases/gpu_data_transfer_test.cc
@@ -28,10 +28,10 @@ namespace cuda {
 namespace test {
 
 namespace {
-// A HOST_ACCESSIBLE (pinned) tensor. Passing the same Tensor as both copy source and
+// A small HOST_ACCESSIBLE (pinned) tensor. Passing the same Tensor as both copy source and
 // destination gives src_data == dst_data (a single physical allocation) — the aliased
-// in-memory initializer condition from the issue.
-// 64 * sizeof(float) = 256 bytes > kSmallTensorExternalDataThreshold (127).
+// self-copy condition from the issue. These tests call CopyTensor{,Async} directly, so the
+// tensor size is arbitrary and does not affect which branch is exercised.
 constexpr int64_t kNumElements = 64;
 
 std::unique_ptr<Tensor> MakePinnedTensor(const AllocatorPtr& pinned_alloc) {
@@ -44,6 +44,8 @@ TEST(GPUDataTransferSameBufferTest, CopyTensorSelfCopyIsNoOp) {
   CUDAExecutionProviderInfo info;
   CUDAExecutionProvider ep(info);
   AllocatorPtr pinned_alloc = ep.CreatePreferredAllocators()[1];
+  // Make the allocator assumption explicit: the copy must go through the host->host branch.
+  ASSERT_EQ(pinned_alloc->Info().device.MemType(), OrtDevice::MemType::HOST_ACCESSIBLE);
 
   auto tensor = MakePinnedTensor(pinned_alloc);
 
@@ -59,6 +61,10 @@ TEST(GPUDataTransferSameBufferTest, CopyTensorAsyncSelfCopyIsNoOp) {
   CUDAExecutionProvider ep(info);
   AllocatorPtr gpu_allocator = ep.CreatePreferredAllocators()[0];
   AllocatorPtr pinned_alloc = ep.CreatePreferredAllocators()[1];
+  // Make the allocator assumptions explicit: default-GPU stream device, HOST_ACCESSIBLE copy buffer.
+  ASSERT_EQ(gpu_allocator->Info().device.Type(), OrtDevice::GPU);
+  ASSERT_EQ(gpu_allocator->Info().device.MemType(), OrtDevice::MemType::DEFAULT);
+  ASSERT_EQ(pinned_alloc->Info().device.MemType(), OrtDevice::MemType::HOST_ACCESSIBLE);
 
   cudaStream_t cuda_stream = nullptr;
   ASSERT_EQ(cudaStreamCreate(&cuda_stream), cudaSuccess);
@@ -81,6 +87,10 @@ TEST(GPUDataTransferSameBufferTest, CopyTensorAsyncSelfCopyDuringCaptureKeepsCap
   CUDAExecutionProvider ep(info);
   AllocatorPtr gpu_allocator = ep.CreatePreferredAllocators()[0];
   AllocatorPtr pinned_alloc = ep.CreatePreferredAllocators()[1];
+  // Make the allocator assumptions explicit: default-GPU stream device, HOST_ACCESSIBLE copy buffer.
+  ASSERT_EQ(gpu_allocator->Info().device.Type(), OrtDevice::GPU);
+  ASSERT_EQ(gpu_allocator->Info().device.MemType(), OrtDevice::MemType::DEFAULT);
+  ASSERT_EQ(pinned_alloc->Info().device.MemType(), OrtDevice::MemType::HOST_ACCESSIBLE);
 
   cudaStream_t cuda_stream = nullptr;
   ASSERT_EQ(cudaStreamCreate(&cuda_stream), cudaSuccess);

--- a/onnxruntime/test/providers/cuda/test_cases/gpu_data_transfer_test.cc
+++ b/onnxruntime/test/providers/cuda/test_cases/gpu_data_transfer_test.cc
@@ -1,0 +1,108 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Regression tests for GH issue #29713:
+// On the CUDA EP, a graph whose weights are retained as in-memory-external OrtValue
+// initializers can schedule a device copy whose source and destination are the same
+// physical host buffer. The host->host branch of GPUDataTransfer::CopyTensor{,Async}
+// must treat such a self-copy as a benign no-op (matching CPUDataTransfer and the
+// GPU->GPU branch), instead of failing ORT_ENFORCE(dst_data != src_data) or issuing a
+// cudaStreamSynchronize that is illegal during CUDA-graph capture.
+//
+// This file is compiled into the CUDA EP shared-library test module, so it uses the
+// provider-bridge API (provider_api.h first, Tensor::Create) like cuda_test_provider.cc.
+
+#include "core/providers/shared_library/provider_api.h"
+
+#include "gtest/gtest.h"
+#include <memory>
+
+#include "core/providers/cuda/cuda_execution_provider.h"
+#include "core/providers/cuda/cuda_execution_provider_info.h"
+#include "core/providers/cuda/cuda_allocator.h"
+#include "core/providers/cuda/cuda_stream_handle.h"
+#include "core/providers/cuda/gpu_data_transfer.h"
+
+namespace onnxruntime {
+namespace cuda {
+namespace test {
+
+namespace {
+// A HOST_ACCESSIBLE (pinned) tensor. Passing the same Tensor as both copy source and
+// destination gives src_data == dst_data (a single physical allocation) — the aliased
+// in-memory initializer condition from the issue.
+// 64 * sizeof(float) = 256 bytes > kSmallTensorExternalDataThreshold (127).
+constexpr int64_t kNumElements = 64;
+
+std::unique_ptr<Tensor> MakePinnedTensor(const AllocatorPtr& pinned_alloc) {
+  return Tensor::Create(DataTypeImpl::GetType<float>(), TensorShape{kNumElements}, pinned_alloc);
+}
+}  // namespace
+
+// Variant A (sync): a same-buffer host->host copy must not fail ORT_ENFORCE(dst != src).
+TEST(GPUDataTransferSameBufferTest, CopyTensorSelfCopyIsNoOp) {
+  CUDAExecutionProviderInfo info;
+  CUDAExecutionProvider ep(info);
+  AllocatorPtr pinned_alloc = ep.CreatePreferredAllocators()[1];
+
+  auto tensor = MakePinnedTensor(pinned_alloc);
+
+  GPUDataTransfer data_transfer;
+  // src and dst are the same Tensor -> src_data == dst_data.
+  auto status = data_transfer.CopyTensor(*tensor, *tensor);
+  EXPECT_TRUE(status.IsOK()) << status.ErrorMessage();
+}
+
+// Variant A (async): a same-buffer host->host copy on a stream must not fail.
+TEST(GPUDataTransferSameBufferTest, CopyTensorAsyncSelfCopyIsNoOp) {
+  CUDAExecutionProviderInfo info;
+  CUDAExecutionProvider ep(info);
+  AllocatorPtr gpu_allocator = ep.CreatePreferredAllocators()[0];
+  AllocatorPtr pinned_alloc = ep.CreatePreferredAllocators()[1];
+
+  cudaStream_t cuda_stream = nullptr;
+  ASSERT_EQ(cudaStreamCreate(&cuda_stream), cudaSuccess);
+  CudaStream stream(cuda_stream, gpu_allocator->Info().device, pinned_alloc, false, false, nullptr, nullptr, info);
+
+  auto tensor = MakePinnedTensor(pinned_alloc);
+
+  GPUDataTransfer data_transfer;
+  auto status = data_transfer.CopyTensorAsync(*tensor, *tensor, stream);
+  EXPECT_TRUE(status.IsOK()) << status.ErrorMessage();
+
+  ASSERT_EQ(cudaStreamSynchronize(cuda_stream), cudaSuccess);
+  ASSERT_EQ(cudaStreamDestroy(cuda_stream), cudaSuccess);
+}
+
+// Variant B: a same-buffer host->host copy inside a CUDA-graph capture region must not
+// issue the (capture-illegal) cudaStreamSynchronize, so capture stays valid.
+TEST(GPUDataTransferSameBufferTest, CopyTensorAsyncSelfCopyDuringCaptureKeepsCaptureValid) {
+  CUDAExecutionProviderInfo info;
+  CUDAExecutionProvider ep(info);
+  AllocatorPtr gpu_allocator = ep.CreatePreferredAllocators()[0];
+  AllocatorPtr pinned_alloc = ep.CreatePreferredAllocators()[1];
+
+  cudaStream_t cuda_stream = nullptr;
+  ASSERT_EQ(cudaStreamCreate(&cuda_stream), cudaSuccess);
+  CudaStream stream(cuda_stream, gpu_allocator->Info().device, pinned_alloc, false, false, nullptr, nullptr, info);
+
+  auto tensor = MakePinnedTensor(pinned_alloc);
+
+  GPUDataTransfer data_transfer;
+  ASSERT_EQ(cudaStreamBeginCapture(cuda_stream, cudaStreamCaptureModeThreadLocal), cudaSuccess);
+  auto status = data_transfer.CopyTensorAsync(*tensor, *tensor, stream);
+  cudaGraph_t graph = nullptr;
+  cudaError_t end_capture = cudaStreamEndCapture(cuda_stream, &graph);
+
+  EXPECT_TRUE(status.IsOK()) << status.ErrorMessage();
+  EXPECT_EQ(end_capture, cudaSuccess) << "capture was invalidated: " << cudaGetErrorString(end_capture);
+
+  if (graph != nullptr) {
+    cudaGraphDestroy(graph);
+  }
+  ASSERT_EQ(cudaStreamDestroy(cuda_stream), cudaSuccess);
+}
+
+}  // namespace test
+}  // namespace cuda
+}  // namespace onnxruntime


### PR DESCRIPTION
### Description
Fixes #29713.

On the CUDA EP, a device copy scheduled for a weight retained as an in-memory-external `OrtValue` initializer can have a source and destination that are the **same physical host buffer**. The host->host branch of `GPUDataTransfer::CopyTensor`/`CopyTensorAsync` did not handle this:

- **Non-cuda-graph:** `ORT_ENFORCE(dst_data != src_data)` fired -> hard failure.
- **CUDA-graph capture:** the `HOST_ACCESSIBLE` `cudaStreamSynchronize` is illegal during capture -> `CUDA 900` -> `cudaStreamEndCapture` `CUDA 901`, invalidating the capture.

This became reachable once #29158 (initializer retention) landed.

### Fix
Early-return the no-op self-copy at the top of the host->host branch in both methods, **before** the `HOST_ACCESSIBLE` stream sync (the key to keeping capture valid). This matches `CPUDataTransfer::CopyTensor` and the existing GPU->GPU guard.

### Testing
Adds a CUDA EP internal regression test (`gpu_data_transfer_test.cc`) covering sync, async, and cuda-graph-capture self-copies. Verified failing before the fix (ORT_ENFORCE / CUDA 900->901) and passing after, on an RTX 3050 with a CUDA 12.8 `sm_86` build.
