### PR TITLE
[WebNN EP] Support uint8-packed 4-bit GatherBlockQuantized

### DIFF
--- a/js/web/docs/webnn-operators.md
+++ b/js/web/docs/webnn-operators.md
@@ -43,7 +43,7 @@ platforms. Check the [WebNN status](https://webmachinelearning.github.io/webnn-s
 | Flatten | ai.onnx(7-8, 9-10, 11-12, 13-20, 21+) | reshape | |
 | Floor | ai.onnx(7-12, 13+) | floor | |
 | Gather | ai.onnx(7-10, 11-12, 13+) | gather | |
-| GatherBlockQuantized | com.microsoft(1+) | dequantizeLinear, gather | |
+| GatherBlockQuantized | com.microsoft(1+) | dequantizeLinear, gather | uint8-packed 4-bit data (bits=4) is reinterpreted as uint4, which requires 'quantize_axis' to be the last axis and 'data' (and 'zero_points', if present) to be constant initializers |
 | GatherElements | ai.onnx(11-12, 13+) | gatherElements | |
 | GatherND | ai.onnx(11, 12, 13+) | gatherND | Only supports 'batch_dims' == 0 |
 | Gelu | ai.onnx(20+) | gelu | |

--- a/onnxruntime/core/providers/webnn/builders/impl/gatherBlockQuantized_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/gatherBlockQuantized_op_builder.cc
@@ -14,6 +14,9 @@ namespace onnxruntime {
 namespace webnn {
 
 class GatherBlockQuantizedOpBuilder : public BaseOpBuilder {
+ public:
+  void AddInitializersToSkip(ModelBuilder& model_builder, const Node& node) const override;
+
   // Add operator related.
  private:
   Status AddToModelBuilderImpl(ModelBuilder& model_builder, const Node& node,
@@ -21,18 +24,40 @@ class GatherBlockQuantizedOpBuilder : public BaseOpBuilder {
 
   // Operator support related.
  private:
-  bool IsOpSupportedImpl(const GraphViewer&, const Node& node,
-                         const WebnnDeviceType /* device_type */, const logging::Logger& logger) const override;
-  bool HasSupportedInputsImpl(const GraphViewer&, const Node& node,
-                              const emscripten::val& wnn_limits, const logging::Logger& logger) const override;
+  bool IsOpSupportedImpl(const GraphViewer&, const Node& node, const WebnnDeviceType /* device_type */,
+                         const logging::Logger& logger) const override;
+  bool HasSupportedInputsImpl(const GraphViewer&, const Node& node, const emscripten::val& wnn_limits,
+                              const logging::Logger& logger) const override;
   bool HasSupportedOutputsImpl(const Node& node, const emscripten::val& wnn_limits,
                                const logging::Logger& logger) const override;
 };
 
+// The quantized data (T1) is one of {int4, uint4, uint8}. Only uint8 with bits==4 is bit-packed
+// (two 4-bit values per byte) and must be reinterpreted as a WebNN uint4 constant with the logical
+// (unpacked) shape. uint8 with bits==8 is genuine 8-bit; int4/uint4 are already at their logical shape.
+static bool RequiresUint4Reinterpret(int32_t data_type, int64_t bits) {
+  return data_type == ONNX_NAMESPACE::TensorProto_DataType_UINT8 && bits == 4;
+}
+
+void GatherBlockQuantizedOpBuilder::AddInitializersToSkip(ModelBuilder& model_builder, const Node& node) const {
+  const auto& input_defs = node.InputDefs();
+  NodeAttrHelper helper(node);
+  // No logger is available in this callback, so read the declared element type from the proto.
+  const int32_t data_type = input_defs[0]->TypeAsProto()->tensor_type().elem_type();
+  if (!RequiresUint4Reinterpret(data_type, helper.Get("bits", 4))) {
+    return;
+  }
+  // The reinterpreted data/zero_point are registered as uint4 constants in AddToModelBuilderImpl,
+  // so skip their default (uint8) registration to avoid a duplicate, oversized operand.
+  model_builder.AddInitializerToSkip(input_defs[0]->Name());  // data
+  if (TensorExists(input_defs, 3)) {
+    model_builder.AddInitializerToSkip(input_defs[3]->Name());  // zero_points
+  }
+}
+
 // WebNN doesn't provide a dedicated op for GatherBlockQuantizedOpBuilder, it can be simply
 // decomposed by DequantizeLinear + Gather.
-Status GatherBlockQuantizedOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
-                                                            const Node& node,
+Status GatherBlockQuantizedOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, const Node& node,
                                                             const logging::Logger& logger) const {
   const auto& input_defs = node.InputDefs();
   std::vector<int64_t> input_shape;
@@ -44,43 +69,79 @@ Status GatherBlockQuantizedOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_
   int32_t input_type = 0;
   ORT_RETURN_IF_NOT(GetType(*input_defs[0], input_type, logger), "Cannot get input data type");
 
-  emscripten::val input = model_builder.GetOperand(input_defs[0]->Name());
+  NodeAttrHelper helper(node);
+  const int64_t bits = helper.Get("bits", 4);
+  const uint32_t gather_axis = SafeInt<uint32_t>(HandleNegativeAxis(helper.Get("gather_axis", 0), input_rank));
+  const bool has_zero_points = TensorExists(input_defs, 3);
+  const bool reinterpret_u4 = RequiresUint4Reinterpret(input_type, bits);
+
+  emscripten::val input = emscripten::val::undefined();
+  emscripten::val zero_points = emscripten::val::undefined();
+
+  if (reinterpret_u4) {
+    // Reinterpret the uint8-packed data/zero_point as WebNN uint4 constants. The raw bytes are
+    // unchanged; only the element type and logical shape differ (2 uint4 values per byte). The data's
+    // last (quantize) axis doubles; the zero_point takes the scales shape, which dequantizeLinear
+    // requires to equal the scale shape.
+    const auto& initializers = model_builder.GetInitializerTensors();
+    auto register_u4 = [&](const std::string& name, const std::vector<int64_t>& logical_shape,
+                           emscripten::val& out) -> Status {
+      const std::vector<uint32_t> shape_u32 = GetNarrowedIntFromInt64<uint32_t>(logical_shape);
+      emscripten::val desc = emscripten::val::object();
+      desc.set("dataType", emscripten::val("uint4"));
+      desc.set("shape", emscripten::val::array(shape_u32));
+      desc.set("dimensions", emscripten::val::array(shape_u32));
+      return model_builder.RegisterConstant(*initializers.at(name), out, desc, logger);
+    };
+
+    std::vector<int64_t> data_logical(input_shape);
+    data_logical.back() *= 2;  // 8 / bits, with bits == 4
+    ORT_RETURN_IF_ERROR(register_u4(input_defs[0]->Name(), data_logical, input));
+    if (has_zero_points) {
+      ORT_RETURN_IF_ERROR(register_u4(input_defs[3]->Name(), scales_shape, zero_points));
+    }
+  } else {
+    input = model_builder.GetOperand(input_defs[0]->Name());
+    if (has_zero_points) {
+      zero_points = model_builder.GetOperand(input_defs[3]->Name());
+    }
+  }
+
   emscripten::val indices = model_builder.GetOperand(input_defs[1]->Name());
   emscripten::val scales = model_builder.GetOperand(input_defs[2]->Name());
   emscripten::val common_options = emscripten::val::object();
 
-  NodeAttrHelper helper(node);
-  const int32_t bits = helper.Get("bits", 4);
-  const uint32_t gather_axis = SafeInt<uint32_t>(HandleNegativeAxis(helper.Get("gather_axis", 0), input_rank));
-
   // GatherBlockQuantized only supports block-wise quantization, the input and scales should have the same rank.
   // So we don't need to reshape scales for broadcasting.
-  emscripten::val zero_points = emscripten::val::undefined();
-  if (TensorExists(input_defs, 3)) {  // zero_points
-    zero_points = model_builder.GetOperand(input_defs[3]->Name());
-  } else {
-    const uint8_t default_zero_point = bits == 4 ? 0 : 128;
-    // Create a constant for zero_points, which has the same shape as scales and same type as input.
-    zero_points = model_builder.CreateOrGetConstant<uint8_t>(input_type,
-                                                             default_zero_point,
-                                                             GetNarrowedIntFromInt64<uint32_t>(scales_shape));
+  if (zero_points.isUndefined()) {
+    // No zero_point input was provided. Build a default matching the scales shape, with a dtype
+    // matching the (possibly reinterpreted) input.
+    const std::vector<uint32_t> zp_shape = GetNarrowedIntFromInt64<uint32_t>(scales_shape);
+    if (reinterpret_u4) {
+      // uint8-packed 4-bit: the default zero_point must also be a uint4 constant (two values per byte).
+      emscripten::val zp_desc = emscripten::val::object();
+      zp_desc.set("dataType", emscripten::val("uint4"));
+      zp_desc.set("shape", emscripten::val::array(zp_shape));
+      zp_desc.set("dimensions", emscripten::val::array(zp_shape));
+      emscripten::val zp_buffer = emscripten::val::global("Uint8Array").new_((Product(scales_shape) + 1) / 2);
+      zero_points = model_builder.GetBuilder().call<emscripten::val>("constant", zp_desc, zp_buffer);
+    } else {
+      const uint8_t default_zero_point = bits == 4 ? 0 : 128;
+      // Create a constant for zero_points, which has the same shape as scales and same type as input.
+      zero_points = model_builder.CreateOrGetConstant<uint8_t>(input_type, default_zero_point, zp_shape);
+    }
   }
 
   // dequantized_input = DequantizeLinear(input, scales, zero_points)
   common_options.set("label", node.Name() + "_dequantize_input");
-  emscripten::val dequantized_input = model_builder.GetBuilder().call<emscripten::val>("dequantizeLinear",
-                                                                                       input,
-                                                                                       scales,
-                                                                                       zero_points,
-                                                                                       common_options);
+  emscripten::val dequantized_input =
+      model_builder.GetBuilder().call<emscripten::val>("dequantizeLinear", input, scales, zero_points, common_options);
 
   // output = Gather(dequantized_input, indices, axis=gather_axis)
   common_options.set("label", node.Name() + "_gather");
   common_options.set("axis", gather_axis);
-  emscripten::val output = model_builder.GetBuilder().call<emscripten::val>("gather",
-                                                                            dequantized_input,
-                                                                            indices,
-                                                                            common_options);
+  emscripten::val output =
+      model_builder.GetBuilder().call<emscripten::val>("gather", dequantized_input, indices, common_options);
 
   model_builder.AddOperand(node.OutputDefs()[0]->Name(), std::move(output));
   return Status::OK();
@@ -88,10 +149,10 @@ Status GatherBlockQuantizedOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_
 
 // Operator support related.
 
-bool GatherBlockQuantizedOpBuilder::IsOpSupportedImpl(const GraphViewer&,
-                                                      const Node& node,
+bool GatherBlockQuantizedOpBuilder::IsOpSupportedImpl(const GraphViewer& graph_viewer, const Node& node,
                                                       const WebnnDeviceType /* device_type */,
                                                       const logging::Logger& logger) const {
+  const auto& input_defs = node.InputDefs();
   NodeAttrHelper helper(node);
   const int32_t bits = helper.Get("bits", 4);
   const int32_t block_size = helper.Get("block_size", 128);
@@ -106,6 +167,41 @@ bool GatherBlockQuantizedOpBuilder::IsOpSupportedImpl(const GraphViewer&,
     return false;
   }
 
+  // uint8-packed 4-bit data is reinterpreted to uint4 as a zero-copy relabel of the same byte buffer.
+  // WebNN reads that buffer as a flat row-major stream of 4-bit values (low nibble first), while ONNX
+  // packs the two values sharing a byte along the quantize axis. Those two values are memory-adjacent
+  // (and therefore correctly reinterpreted by doubling that axis) only when the quantize axis is the
+  // innermost (last) axis; for an inner axis the packed pair is strided apart and the flat reinterpret
+  // would interleave the wrong values. So restrict support to quantize_axis == last axis (else fallback).
+  int32_t data_type = 0;
+  if (!GetType(*input_defs[0], data_type, logger)) {
+    return false;
+  }
+  if (RequiresUint4Reinterpret(data_type, bits)) {
+    // The uint4 reinterpret path registers 'data' (and 'zero_points', if present) as WebNN constants
+    // from their initializer bytes, so both must be constant initializers (else fallback).
+    if (!graph_viewer.GetConstantInitializer(input_defs[0]->Name())) {  // data
+      LOGS(logger, VERBOSE) << "GatherBlockQuantized: uint8-packed 4-bit 'data' must be a constant initializer.";
+      return false;
+    }
+    if (TensorExists(input_defs, 3) && !graph_viewer.GetConstantInitializer(input_defs[3]->Name())) {  // zero_points
+      LOGS(logger, VERBOSE) << "GatherBlockQuantized: uint8-packed 4-bit 'zero_points' must be a constant "
+                               "initializer.";
+      return false;
+    }
+
+    std::vector<int64_t> input_shape;
+    if (!GetShape(*input_defs[0], input_shape, logger) || input_shape.empty()) {
+      return false;
+    }
+    const int64_t quantize_axis = HandleNegativeAxis(helper.Get("quantize_axis", 1), input_shape.size());
+    if (quantize_axis != static_cast<int64_t>(input_shape.size()) - 1) {
+      LOGS(logger, VERBOSE) << "GatherBlockQuantized: uint8-packed 4-bit data is only supported when "
+                               "quantize_axis is the last axis.";
+      return false;
+    }
+  }
+
   return true;
 }
 
@@ -115,8 +211,7 @@ bool GatherBlockQuantizedOpBuilder::HasSupportedInputsImpl(const GraphViewer&, c
   const auto& input_defs = node.InputDefs();
   std::vector<int64_t> input_shape;
   std::vector<int64_t> scales_shape;
-  if (!GetShape(*input_defs[0], input_shape, logger) ||
-      !GetShape(*input_defs[2], scales_shape, logger)) {
+  if (!GetShape(*input_defs[0], input_shape, logger) || !GetShape(*input_defs[2], scales_shape, logger)) {
     return false;
   }
 
@@ -128,21 +223,26 @@ bool GatherBlockQuantizedOpBuilder::HasSupportedInputsImpl(const GraphViewer&, c
   const std::string_view op_type = node.OpType();
   int32_t input_type = 0;
   int32_t scales_type = 0;
-  if (!GetType(*input_defs[0], input_type, logger) ||
-      !GetType(*input_defs[2], scales_type, logger)) {
+  if (!GetType(*input_defs[0], input_type, logger) || !GetType(*input_defs[2], scales_type, logger)) {
     return false;
+  }
+
+  // For uint8-packed 4-bit data, dequantizeLinear actually receives a uint4 operand (the uint8 tensor
+  // is reinterpreted), so validate the reinterpreted dtype rather than the declared one.
+  NodeAttrHelper helper(node);
+  int32_t dq_input_type = input_type;
+  if (RequiresUint4Reinterpret(input_type, helper.Get("bits", 4))) {
+    dq_input_type = ONNX_NAMESPACE::TensorProto_DataType_UINT4;
   }
 
   // Only need to check the input data type of ops that consume the inputs of GatherBlockQuantized.
   // WebNN dequantizeLinear's input should be same as input. WebNN gather's input should be same as scales input.
-  return IsDataTypeSupportedByWebNNOp(op_type, "dequantizeLinear", input_type, wnn_limits, "input", "data", logger) &&
+  return IsDataTypeSupportedByWebNNOp(op_type, "dequantizeLinear", dq_input_type, wnn_limits, "input", "data",
+                                      logger) &&
          IsDataTypeSupportedByWebNNOp(op_type, "gather", scales_type, wnn_limits, "input", "scales", logger);
-
-  return true;
 }
 
-bool GatherBlockQuantizedOpBuilder::HasSupportedOutputsImpl(const Node& node,
-                                                            const emscripten::val& wnn_limits,
+bool GatherBlockQuantizedOpBuilder::HasSupportedOutputsImpl(const Node& node, const emscripten::val& wnn_limits,
                                                             const logging::Logger& logger) const {
   const auto& output_defs = node.OutputDefs();
   const std::string_view op_type = node.OpType();

--- a/onnxruntime/core/providers/webnn/builders/impl/gatherBlockQuantized_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/gatherBlockQuantized_op_builder.cc
@@ -32,9 +32,10 @@ class GatherBlockQuantizedOpBuilder : public BaseOpBuilder {
                                const logging::Logger& logger) const override;
 };
 
-// The quantized data (T1) is one of {int4, uint4, uint8}. Only uint8 with bits==4 is bit-packed
-// (two 4-bit values per byte) and must be reinterpreted as a WebNN uint4 constant with the logical
-// (unpacked) shape. uint8 with bits==8 is genuine 8-bit; int4/uint4 are already at their logical shape.
+// The quantized data (T1) is one of {int4, uint4, uint8}. int4/uint4 map to WebNN's int4/uint4 dtypes
+// directly. uint8 with bits==4 packs two 4-bit values per byte and has no matching WebNN dtype, so it is
+// relabeled as a uint4 constant with the logical (unpacked) shape, leaving the raw bytes unchanged.
+// uint8 with bits==8 stays as 8-bit.
 static bool RequiresUint4Reinterpret(int32_t data_type, int64_t bits) {
   return data_type == ONNX_NAMESPACE::TensorProto_DataType_UINT8 && bits == 4;
 }
@@ -42,7 +43,8 @@ static bool RequiresUint4Reinterpret(int32_t data_type, int64_t bits) {
 void GatherBlockQuantizedOpBuilder::AddInitializersToSkip(ModelBuilder& model_builder, const Node& node) const {
   const auto& input_defs = node.InputDefs();
   NodeAttrHelper helper(node);
-  // No logger is available in this callback, so read the declared element type from the proto.
+  // The GetType() helper takes a logger for diagnostics, but this callback isn't given one, so read
+  // the declared element type straight from the proto instead.
   const int32_t data_type = input_defs[0]->TypeAsProto()->tensor_type().elem_type();
   if (!RequiresUint4Reinterpret(data_type, helper.Get("bits", 4))) {
     return;
@@ -73,12 +75,12 @@ Status GatherBlockQuantizedOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_
   const int64_t bits = helper.Get("bits", 4);
   const uint32_t gather_axis = SafeInt<uint32_t>(HandleNegativeAxis(helper.Get("gather_axis", 0), input_rank));
   const bool has_zero_points = TensorExists(input_defs, 3);
-  const bool reinterpret_u4 = RequiresUint4Reinterpret(input_type, bits);
+  const bool requires_reinterpret_u4 = RequiresUint4Reinterpret(input_type, bits);
 
   emscripten::val input = emscripten::val::undefined();
   emscripten::val zero_points = emscripten::val::undefined();
 
-  if (reinterpret_u4) {
+  if (requires_reinterpret_u4) {
     // Reinterpret the uint8-packed data/zero_point as WebNN uint4 constants. The raw bytes are
     // unchanged; only the element type and logical shape differ (2 uint4 values per byte). The data's
     // last (quantize) axis doubles; the zero_point takes the scales shape, which dequantizeLinear
@@ -114,20 +116,20 @@ Status GatherBlockQuantizedOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_
   // GatherBlockQuantized only supports block-wise quantization, the input and scales should have the same rank.
   // So we don't need to reshape scales for broadcasting.
   if (zero_points.isUndefined()) {
-    // No zero_point input was provided. Build a default matching the scales shape, with a dtype
-    // matching the (possibly reinterpreted) input.
+    // Create a default zero_point with the same shape as scales.
     const std::vector<uint32_t> zp_shape = GetNarrowedIntFromInt64<uint32_t>(scales_shape);
-    if (reinterpret_u4) {
-      // uint8-packed 4-bit: the default zero_point must also be a uint4 constant (two values per byte).
+    if (requires_reinterpret_u4) {
+      // Default zero_point for uint8-packed 4-bit is 8, stored as uint4 (two per byte, so 0x88).
       emscripten::val zp_desc = emscripten::val::object();
       zp_desc.set("dataType", emscripten::val("uint4"));
       zp_desc.set("shape", emscripten::val::array(zp_shape));
       zp_desc.set("dimensions", emscripten::val::array(zp_shape));
       emscripten::val zp_buffer = emscripten::val::global("Uint8Array").new_((Product(scales_shape) + 1) / 2);
+      zp_buffer.call<void>("fill", emscripten::val(0x88));
       zero_points = model_builder.GetBuilder().call<emscripten::val>("constant", zp_desc, zp_buffer);
     } else {
-      const uint8_t default_zero_point = bits == 4 ? 0 : 128;
-      // Create a constant for zero_points, which has the same shape as scales and same type as input.
+      // Default zero_point is 128 for uint8, 0 for int4/uint4.
+      const uint8_t default_zero_point = input_type == ONNX_NAMESPACE::TensorProto_DataType_UINT8 ? 128 : 0;
       zero_points = model_builder.CreateOrGetConstant<uint8_t>(input_type, default_zero_point, zp_shape);
     }
   }


### PR DESCRIPTION
`GatherBlockQuantized` previously passed its quantized `data` and `zero_point` initializers straight to `dequantizeLinear` via `GetOperand`. When 4-bit data is stored bit-packed in a `uint8` tensor (2 nibbles per byte, e.g. Qwen3.5's `embed_tokens`), the declared `uint8` shape is half the logical size, so `dequantizeLinear` received a `scale` and `zero_point` with mismatched shapes and failed with "The shape of scale and zero point must be the same."

Re-register the uint8-packed `data` and `zero_point` as WebNN `uint4` constants with their logical (unpacked) shapes — a zero-copy relabel of the same byte buffer — and skip their default `uint8` registration. Now `data`, `scale` and `zero_point` are dimensionally consistent for the blockwise dequant.


