### PR TITLE
[Test] Add GPU-free unit coverage for weight_prepacked=2 (SM90) rejection

### DIFF
--- a/onnxruntime/contrib_ops/cuda/quantization/matmul_nbits.cc
+++ b/onnxruntime/contrib_ops/cuda/quantization/matmul_nbits.cc
@@ -18,6 +18,7 @@
 #include "contrib_ops/cuda/llm/fpA_intB_gemm_adaptor.h"
 #include "contrib_ops/cuda/llm/fpA_intB_gemm_preprocessors.h"
 #include "contrib_ops/cuda/llm/common/cuda_runtime_utils.h"
+#include "contrib_ops/cuda/quantization/matmul_nbits_sm90_validation.h"
 #endif
 #include "contrib_ops/cuda/llm/common/logger.h"
 #include "contrib_ops/cpu/quantization/matmul_nbits_helper.h"
@@ -54,6 +55,38 @@ int MatMulNBits<T>::FpAIntBPackingSmForKernel() const {
 template <typename T>
 int64_t MatMulNBits<T>::RequiredWeightPrepackedFormat() const {
   return FpAIntBPackingSmForKernel() == 90 ? kMatMulNBitsWeightPrepackedSm90 : kMatMulNBitsWeightPrepackedSm80;
+}
+
+// See matmul_nbits_sm90_validation.h for why these two functions are declared there but defined
+// here (non-inline, single definition, inside the CUDA EP translation unit that observes
+// COMPILE_HOPPER_TMA_GEMMS).
+bool IsNativeSm90FpAIntBGemmCompiled() {
+#if defined(COMPILE_HOPPER_TMA_GEMMS)
+  return true;
+#else
+  return false;
+#endif
+}
+
+void ValidateSm90PrepackedWeightSupport(int sm, int64_t block_size) {
+  // The native SM90 (Hopper TMA/WGMMA) mixed-GEMM kernel requires a compute-capability 9.0
+  // device and a block_size that is a multiple of the Hopper K tile (128 / sizeof(half) = 64).
+  // block_size=32 is only supported by the SM80/Ampere-class kernel + GEMV path.
+  ORT_ENFORCE(sm == 90,
+              "weight_prepacked=2 (SM90 layout) requires a compute capability 9.0 (Hopper) device, but got sm ", sm);
+#if !defined(COMPILE_HOPPER_TMA_GEMMS)
+  // The native SM90 (Hopper) fpA_intB TMA/WGMMA kernel is not compiled in this build (for
+  // example Windows/MSVC, where CUDA 13 NVCC host stubs hit MSVC C2719 with over-aligned TMA
+  // parameters; see docs/contrib_ops/cuda/moe_qmoe.md section 14.1). The SM90 weight layout
+  // cannot be consumed by the SM80 kernel, so fail early here with a clear message instead of
+  // dispatching to the throwing launcher stub during tactic profiling.
+  ORT_THROW(
+      "weight_prepacked=2 (SM90 layout) is not supported by this ONNX Runtime build "
+      "(the native SM90 Hopper fpA_intB kernel is unavailable, e.g. on Windows/MSVC). "
+      "Re-export the model with weight_prepacked=0 or 1 to use the SM80-compatible fpA_intB layout.");
+#endif
+  ORT_ENFORCE(block_size == 64 || block_size == 128,
+              "weight_prepacked=2 (SM90 layout) supports block_size 64 or 128 only, but got ", block_size);
 }
 
 template <typename T>

--- a/onnxruntime/contrib_ops/cuda/quantization/matmul_nbits.h
+++ b/onnxruntime/contrib_ops/cuda/quantization/matmul_nbits.h
@@ -14,6 +14,7 @@
 #include "core/providers/cuda/cuda_kernel.h"
 #include "core/providers/cuda/shared_inc/fpgeneric.h"
 #include "contrib_ops/cuda/llm/fpA_intB_gemm_profiler.h"
+#include "contrib_ops/cuda/quantization/matmul_nbits_sm90_validation.h"
 #include "core/platform/env_var_utils.h"
 
 namespace onnxruntime {
@@ -129,24 +130,9 @@ class MatMulNBits final : public CudaKernel {
                 "weight_prepacked must be 0 (not prepacked), 1 (SM80 layout), or 2 (SM90 layout), but got ",
                 weight_prepacked_);
     if (weight_prepacked_ == kMatMulNBitsWeightPrepackedSm90) {
-      // The native SM90 (Hopper TMA/WGMMA) mixed-GEMM kernel requires a compute-capability 9.0
-      // device and a block_size that is a multiple of the Hopper K tile (128 / sizeof(half) = 64).
-      // block_size=32 is only supported by the SM80/Ampere-class kernel + GEMV path.
-      ORT_ENFORCE(sm_ == 90,
-                  "weight_prepacked=2 (SM90 layout) requires a compute capability 9.0 (Hopper) device, but got sm ", sm_);
-#if !defined(COMPILE_HOPPER_TMA_GEMMS)
-      // The native SM90 (Hopper) fpA_intB TMA/WGMMA kernel is not compiled in this build (for
-      // example Windows/MSVC, where CUDA 13 NVCC host stubs hit MSVC C2719 with over-aligned TMA
-      // parameters; see docs/contrib_ops/cuda/moe_qmoe.md section 14.1). The SM90 weight layout
-      // cannot be consumed by the SM80 kernel, so fail early here with a clear message instead of
-      // dispatching to the throwing launcher stub during tactic profiling.
-      ORT_THROW(
-          "weight_prepacked=2 (SM90 layout) is not supported by this ONNX Runtime build "
-          "(the native SM90 Hopper fpA_intB kernel is unavailable, e.g. on Windows/MSVC). "
-          "Re-export the model with weight_prepacked=0 or 1 to use the SM80-compatible fpA_intB layout.");
-#endif
-      ORT_ENFORCE(block_size_ == 64 || block_size_ == 128,
-                  "weight_prepacked=2 (SM90 layout) supports block_size 64 or 128 only, but got ", block_size_);
+      // See matmul_nbits_sm90_validation.h / matmul_nbits.cc for the validation logic (extracted
+      // into a pure function of (sm, block_size) so it can be unit-tested without a Hopper GPU).
+      ValidateSm90PrepackedWeightSupport(sm_, block_size_);
     }
 
     if constexpr (std::is_same<T, MLFloat16>::value || std::is_same<T, BFloat16>::value) {

--- a/onnxruntime/contrib_ops/cuda/quantization/matmul_nbits_sm90_validation.h
+++ b/onnxruntime/contrib_ops/cuda/quantization/matmul_nbits_sm90_validation.h
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//
+// Pure, host-only (no GPU required) helpers for validating a MatMulNBits node that requests
+// weight_prepacked=2 (the native SM90/Hopper mixed-GEMM weight layout). These are declared here,
+// separate from matmul_nbits.h, so that unit tests can exercise the validation logic with synthetic
+// (sm, block_size) values -- e.g. a Hopper `sm` on a machine/build that has no GPU at all -- which is
+// not otherwise possible since MatMulNBits<T> normally reads `sm` from the real device properties.
+//
+// Both functions are DEFINED (non-inline) in matmul_nbits.cc, NOT in this header. matmul_nbits.cc is
+// compiled as part of the CUDA execution provider target (onnxruntime_providers_cuda /
+// onnxruntime_providers_cuda_plugin), which is the only place where the COMPILE_HOPPER_TMA_GEMMS
+// macro -- recording whether this build actually compiles the native SM90 (Hopper TMA/WGMMA)
+// fpA_intB kernel; it is left undefined on Windows/MSVC, see cmake/onnxruntime_providers_cuda.cmake
+// -- is defined consistently. If IsNativeSm90FpAIntBGemmCompiled() were instead defined inline in
+// this header, each translation unit that includes it (including one that does not receive that
+// target-scoped compile definition) could observe a different answer for whether the native SM90
+// kernel is available, silently producing an ODR violation / macro-skew bug. Keeping a single
+// non-inline definition inside matmul_nbits.cc avoids that hazard.
+//
+#pragma once
+
+#include <cstdint>
+
+#if USE_FPA_INTB_GEMM
+
+namespace onnxruntime {
+namespace contrib {
+namespace cuda {
+
+// Returns true iff this build compiled the native SM90 (Hopper TMA/WGMMA) fpA_intB mixed-GEMM
+// kernel, i.e. iff COMPILE_HOPPER_TMA_GEMMS was defined when matmul_nbits.cc was compiled.
+// Pure/host-only: does not touch the GPU and can be called without a CUDA device present.
+bool IsNativeSm90FpAIntBGemmCompiled();
+
+// Validates that a MatMulNBits node requesting weight_prepacked=2 (the native SM90 weight layout)
+// can actually be served, given the device compute capability `sm` (e.g. as computed from
+// GetDeviceProp().major*10+minor) and the node's `block_size` attribute. Throws (ORT_ENFORCE /
+// ORT_THROW) with a diagnostic message if the request cannot be served; returns normally otherwise.
+// Pure/host-only: `sm` and `block_size` are plain parameters (not read from real hardware), so this
+// can be unit-tested with synthetic values on any machine, without a GPU.
+void ValidateSm90PrepackedWeightSupport(int sm, int64_t block_size);
+
+}  // namespace cuda
+}  // namespace contrib
+}  // namespace onnxruntime
+
+#endif  // USE_FPA_INTB_GEMM

--- a/onnxruntime/test/contrib_ops/cuda_kernels/matmul_nbits_sm90_validation_test.cc
+++ b/onnxruntime/test/contrib_ops/cuda_kernels/matmul_nbits_sm90_validation_test.cc
@@ -1,0 +1,93 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// GPU-free coverage for the SM90 (Hopper) weight_prepacked=2 validation logic used by
+// contrib_ops/cuda/quantization/matmul_nbits.h's MatMulNBits<T> constructor.
+//
+// MatMulNBits<T> normally reads the device compute capability from real hardware
+// (GetDeviceProp()), so the "native SM90 kernel is not compiled in this build" throw (e.g. on
+// Windows/MSVC, see the COMPILE_HOPPER_TMA_GEMMS macro in cmake/onnxruntime_providers_cuda.cmake) is
+// only reachable on an actual Hopper GPU that was built without the native kernel -- a combination
+// existing tests cannot produce, since they all GTEST_SKIP() when no CUDA device is present (see
+// e.g. MatMulNBits.Fp16_Int4_PrepackedSm90BlockSize32Rejected in test/contrib_ops/matmul_4bits_test.cc).
+// ValidateSm90PrepackedWeightSupport() takes sm/block_size as plain parameters instead of reading
+// real hardware, so it can be exercised here with synthetic values and no GPU at all.
+//
+// This lives alongside the other CUDA-EP-internal tests under contrib_ops/cuda_kernels/ (rather than
+// in test/contrib_ops/matmul_4bits_test.cc) because onnxruntime_providers_cuda is a runtime-loaded
+// shared library (see core/providers/cuda/symbols.def, which exports only the small provider-bridge
+// interface): matmul_nbits.cc's free functions are not exported from that DLL/so, so a normal
+// provider-test binary cannot call them directly (it never links onnxruntime_providers_cuda at
+// compile time -- see AddTest()/DEPENDS in cmake/onnxruntime_unittests.cmake). Files under
+// contrib_ops/cuda_kernels/ are instead compiled directly into the onnxruntime_providers_cuda_ut
+// module together with the CUDA EP's own object files whenever
+// onnxruntime_ENABLE_CUDA_EP_INTERNAL_TESTS is set (as it is in the windows_cuda.yml / linux_cuda_ci.yml
+// CI legs), so this test both links successfully and observes COMPILE_HOPPER_TMA_GEMMS exactly as the
+// real onnxruntime_providers_cuda target does -- no ODR/macro-skew risk.
+//
+// Test can be run like the following:
+//  ./onnxruntime_provider_test --gtest_filter=CUDA_EP_Unittest.*
+#if USE_FPA_INTB_GEMM
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include <string>
+
+#include "core/common/common.h"
+#include "contrib_ops/cuda/quantization/matmul_nbits_sm90_validation.h"
+
+namespace onnxruntime {
+namespace test {
+
+namespace {
+// Runs `fn` and returns the message of any thrown exception, or "" if it did not throw.
+template <typename Fn>
+std::string CaughtMessage(Fn&& fn) {
+  std::string message;
+  ORT_TRY {
+    fn();
+  }
+  ORT_CATCH(const std::exception& ex) {
+    ORT_HANDLE_EXCEPTION([&]() { message = ex.what(); });
+  }
+  return message;
+}
+}  // namespace
+
+// Non-Hopper compute capability is always rejected, regardless of whether this build compiled the
+// native SM90 kernel. This assertion is build-independent.
+TEST(MatMulNBitsSm90ValidationTest, RejectsNonHopperComputeCapability) {
+  const std::string message = CaughtMessage([]() {
+    onnxruntime::contrib::cuda::ValidateSm90PrepackedWeightSupport(/*sm=*/80, /*block_size=*/64);
+  });
+  EXPECT_THAT(message, ::testing::HasSubstr("weight_prepacked=2 (SM90 layout) requires a compute capability 9.0"));
+}
+
+// A Hopper (sm=90) request is validated differently depending on whether this build actually
+// compiled the native SM90 (Hopper TMA/WGMMA) fpA_intB kernel.
+TEST(MatMulNBitsSm90ValidationTest, Sm90SupportMatchesBuildCapability) {
+  using onnxruntime::contrib::cuda::IsNativeSm90FpAIntBGemmCompiled;
+  using onnxruntime::contrib::cuda::ValidateSm90PrepackedWeightSupport;
+
+  if (IsNativeSm90FpAIntBGemmCompiled()) {
+    // The native SM90 kernel is available: a supported block_size (64 or 128) must be accepted ...
+    EXPECT_NO_THROW(ValidateSm90PrepackedWeightSupport(/*sm=*/90, /*block_size=*/64));
+
+    // ... but block_size=32 is SM80/GEMV-only and must still be rejected.
+    const std::string message = CaughtMessage([]() {
+      ValidateSm90PrepackedWeightSupport(/*sm=*/90, /*block_size=*/32);
+    });
+    EXPECT_THAT(message, ::testing::HasSubstr("supports block_size 64 or 128 only"));
+  } else {
+    // The native SM90 kernel is not compiled in this build (e.g. Windows/MSVC): even a Hopper
+    // device with an otherwise-supported block_size must be rejected with a build-support message.
+    const std::string message = CaughtMessage([]() {
+      ValidateSm90PrepackedWeightSupport(/*sm=*/90, /*block_size=*/64);
+    });
+    EXPECT_THAT(message, ::testing::HasSubstr("is not supported by this ONNX Runtime build"));
+  }
+}
+
+}  // namespace test
+}  // namespace onnxruntime
+#endif  // USE_FPA_INTB_GEMM

--- a/onnxruntime/test/contrib_ops/matmul_4bits_test.cc
+++ b/onnxruntime/test/contrib_ops/matmul_4bits_test.cc
@@ -1046,6 +1046,12 @@ TEST(MatMulNBits, Fp16_Int4_PrepackedSm90BlockSize32Rejected) {
   RunTest<MLFloat16>(opts, std::move(eps));
 }
 
+// This GTEST_SKIPs without a CUDA device, so it cannot cover the "build without the native SM90
+// kernel" throw on a real Hopper GPU (the only hardware/build combination that reaches it). That
+// throw is instead covered GPU-free, with synthetic (sm, block_size) values, by
+// MatMulNBitsSm90ValidationTest in test/contrib_ops/cuda_kernels/matmul_nbits_sm90_validation_test.cc
+// (see the comment there for why that coverage lives in a separate translation unit).
+
 // Exercises the CUDA small-M batched GEMV tiles: CtaM in {2,4,8,16} (with M values that are not a
 // multiple of CtaM so the row-skip path runs) and CtaN in {1,2} (N divisible / not divisible by 16).
 TEST(MatMulNBits, Fp16_Int4_SmallMBatchedTiles) {


### PR DESCRIPTION
## Summary

Adds GPU-free unit coverage for the `weight_prepacked=2` (SM90/Hopper) rejection logic that #29776 / 9ee050b introduced in `MatMulNBits<T>`'s constructor, plus the minimal, behavior-preserving refactor needed to make that logic testable without a GPU. Stacked on `tlwu/fix_windows_build` (not `main`), since this tests code that only exists on that branch.

## Coverage gap

`MatMulNBits<T>`'s constructor validates a `weight_prepacked=2` request inline with three checks, in order:
1. `ORT_ENFORCE(sm_ == 90, ...)` — device must be Hopper.
2. `#if !defined(COMPILE_HOPPER_TMA_GEMMS)` `ORT_THROW(...)` — the native SM90 kernel must actually be compiled into this build (it isn't on Windows/MSVC, which is exactly what #29776 changed).
3. `ORT_ENFORCE(block_size_ == 64 || block_size_ == 128, ...)` — block_size must be Hopper-tile-aligned.

`sm_` is read from real device properties (`GetDeviceProp()`), and check 1 runs *before* check 2. So the "native SM90 kernel not compiled in this build" throw is only reachable on an actual Hopper GPU that was built without the native kernel (e.g. real Hopper hardware + MSVC). Every existing prepacked test (`Fp16_Int4_PrepackedSm90BlockSize32Rejected`, etc.) uses `OpTester` + `GTEST_SKIP()` when no CUDA device is present, so that branch has **no coverage at all** in CI today.

## Minimal refactor

Extracted the validation into two pure, host-only functions that take `sm`/`block_size` as plain parameters instead of reading real hardware:

- New header `onnxruntime/contrib_ops/cuda/quantization/matmul_nbits_sm90_validation.h` (declarations only, guarded by `#if USE_FPA_INTB_GEMM`):
  - `bool IsNativeSm90FpAIntBGemmCompiled();`
  - `void ValidateSm90PrepackedWeightSupport(int sm, int64_t block_size);`
- Both are **defined non-inline** in `onnxruntime/contrib_ops/cuda/quantization/matmul_nbits.cc` (not in the header), so there is a single definition living inside the CUDA EP translation unit that actually observes `COMPILE_HOPPER_TMA_GEMMS` — avoiding an ODR/macro-skew hazard if a test TU saw a different value of that macro than the real target does.
- `matmul_nbits.h`'s constructor now does:
  ```cpp
  if (weight_prepacked_ == kMatMulNBitsWeightPrepackedSm90) {
    ValidateSm90PrepackedWeightSupport(sm_, block_size_);
  }
  ```
  replacing the inlined checks. **All three message strings are byte-identical** to before; only the identifiers changed from `sm_`/`block_size_` (members) to `sm`/`block_size` (parameters), which only affects the auto-stringified `ORT_ENFORCE` condition text, not the custom messages tests/users actually see. Net runtime behavior is unchanged.

## Test

Added `onnxruntime/test/contrib_ops/cuda_kernels/matmul_nbits_sm90_validation_test.cc`, which calls `ValidateSm90PrepackedWeightSupport`/`IsNativeSm90FpAIntBGemmCompiled` directly with synthetic `(sm, block_size)` values — **no CUDA device required**:
- `ValidateSm90PrepackedWeightSupport(80, 64)` throws containing `"weight_prepacked=2 (SM90 layout) requires a compute capability 9.0"` (build-independent).
- If `IsNativeSm90FpAIntBGemmCompiled()`: `ValidateSm90PrepackedWeightSupport(90, 64)` does **not** throw; `ValidateSm90PrepackedWeightSupport(90, 32)` throws containing `"supports block_size 64 or 128 only"`.
- Else (e.g. Windows/MSVC, or any non-Hopper `CMAKE_CUDA_ARCHITECTURES` build such as the sm86 used by `windows_cuda.yml`/`linux_cuda_ci.yml`): `ValidateSm90PrepackedWeightSupport(90, 64)` throws containing `"is not supported by this ONNX Runtime build"`.

### A deliberate deviation from a literal "add it to matmul_4bits_test.cc" — please sanity-check this

I initially planned to add this `TEST()` directly inside `test/contrib_ops/matmul_4bits_test.cc` and call the new function straight from there. That does not link: `onnxruntime_providers_cuda` (and `_plugin`) is built as a **runtime-loaded shared module** (`onnxruntime_add_shared_library_module`), and on Windows its exports are restricted to a 3-symbol allowlist in `core/providers/cuda/symbols.def` (`GetProvider`, `CreateEpFactories`, `ReleaseEpFactory`). `matmul_nbits.cc`'s free functions are never exported from that DLL, and `onnxruntime_provider_test`/`onnxruntime_test_all` never link the CUDA provider module at compile time (`AddTest()`'s `DEPENDS` only does `add_dependencies()`, i.e. build-order, not `target_link_libraries()`).

The established ORT mechanism for unit-testing CUDA EP internals directly is `test/contrib_ops/cuda_kernels/*.cc` (see sibling `fpA_intB_gemm_kernel_test.cc`, `softmax_topk_kernel_test.cc`): when `onnxruntime_ENABLE_CUDA_EP_INTERNAL_TESTS` is on, these sources are compiled into a separate `onnxruntime_providers_cuda_ut` shared module **together with** `$<TARGET_OBJECTS:onnxruntime_providers_cuda_obj>` (the CUDA EP's own object files) — same translation/link domain, so direct calls resolve, and the same `COMPILE_HOPPER_TMA_GEMMS` compile definition applies to both (via `config_cuda_provider_shared_module()`). This module's gtest cases run via the existing `TEST(CUDA_EP_Unittest, All)` nested-gtest bridge in `test/providers/cuda/cuda_provider_test.cc`. I confirmed both `windows_cuda.yml` and `linux_cuda_ci.yml` already set `onnxruntime_ENABLE_CUDA_EP_INTERNAL_TESTS=ON` and don't set `onnxruntime_BUILD_CUDA_EP_AS_PLUGIN`, so the new file is picked up automatically by the existing `file(GLOB ... contrib_ops/cuda_kernels/*.cc)` in `cmake/onnxruntime_unittests.cmake` — no CMake changes needed for those two legs. (Both legs build at `CMAKE_CUDA_ARCHITECTURES=86`, so `COMPILE_HOPPER_TMA_GEMMS` is undefined in both regardless of MSVC — they'll exercise the "not compiled" branch of the new test, which is exactly the previously-uncovered branch.)

I added a short breadcrumb comment in `matmul_4bits_test.cc` next to `Fp16_Int4_PrepackedSm90BlockSize32Rejected` pointing at the new file, so this redirection is discoverable from where the original tests live.

(Note: the hand-curated `onnxruntime_test_providers_cuda_plugin_internal_test_src` list used only when `onnxruntime_BUILD_CUDA_EP_AS_PLUGIN` is set was intentionally left untouched, to keep this change minimal — neither target CI leg uses that mode.)

## Verification

- Did **not** attempt a full CUDA build (needs the CUDA toolkit + hours; out of scope here).
- Wrote a standalone throwaway program (not checked in) reproducing the extracted function bodies with minimal `ORT_ENFORCE`/`ORT_THROW` stand-ins, and compiled + ran it twice with MSVC (`cl.exe`) — once with `/DCOMPILE_HOPPER_TMA_GEMMS`, once without — confirming both preprocessor branches compile cleanly and all three message strings match exactly what's specified above.
- Ran `lintrunner -a` on all changed files: no issues.
- Re-read the diff for ODR correctness (both new functions are non-inline with a single definition in `matmul_nbits.cc`), guard placement (`#if USE_FPA_INTB_GEMM` around declarations/definitions, `#if !defined(COMPILE_HOPPER_TMA_GEMMS)` around the build-support throw), and message byte-identity.
- Relying on ONNX Runtime CI (`windows_cuda.yml` / `linux_cuda_ci.yml`) for full build/link/run validation of the new test in its actual target environment.

Do not merge — opening for review/discussion.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
