### PR TITLE
Add Intel WebGPU subgroup-matrix Gemm f16 kernel

### DIFF
--- a/onnxruntime/core/providers/webgpu/math/gemm.cc
+++ b/onnxruntime/core/providers/webgpu/math/gemm.cc
@@ -9,6 +9,9 @@
 
 #include "core/providers/webgpu/shader_helper.h"
 #include "core/providers/webgpu/webgpu_supported_types.h"
+#if !defined(__wasm__)
+#include "core/providers/webgpu/math/subgroup_matrix_gemm.h"
+#endif
 
 namespace onnxruntime {
 namespace webgpu {
@@ -118,6 +121,23 @@ Status Gemm::ComputeInternal(ComputeContext& context) const {
   if (output_size == 0) {
     return Status::OK();
   }
+
+#if !defined(__wasm__)
+  // Lazily create the vendor-optimized implementation (e.g. Intel subgroup-matrix)
+  // on the first Compute call, once the device capabilities can be queried from the
+  // compute context. std::call_once makes the one-time init safe against concurrent
+  // Compute calls on this shared kernel; a null impl_ means no vendor path exists.
+  std::call_once(impl_init_flag_, [&]() {
+    impl_ = CreateSubgroupMatrixGemmImpl(*this, context);
+  });
+  if (impl_) {
+    bool handled = false;
+    ORT_RETURN_IF_ERROR(impl_->Compute(context, handled));
+    if (handled) {
+      return Status::OK();
+    }
+  }
+#endif
 
   // WebGPU doesn't support binding a zero-sized buffer, so we need to check if A or B is empty.
   bool need_handle_matmul = A_shape.Size() > 0 && B_shape.Size() > 0;

--- a/onnxruntime/core/providers/webgpu/math/gemm.h
+++ b/onnxruntime/core/providers/webgpu/math/gemm.h
@@ -3,6 +3,9 @@
 
 #pragma once
 
+#include <memory>
+#include <mutex>
+
 #include "core/providers/webgpu/webgpu_kernel.h"
 #include "core/providers/webgpu/shader_helper.h"
 #include "core/providers/webgpu/program.h"
@@ -38,6 +41,24 @@ class GemmNaiveProgram final : public Program<GemmNaiveProgram> {
 
 class Gemm final : public WebGpuKernel {
  public:
+  // Abstract base class for alternative optimized Gemm implementations.
+  // Implementations can provide optimized computation paths by deriving from this class.
+  class GemmOptImpl {
+   public:
+    explicit GemmOptImpl(const Gemm& parent) : parent_(parent) {}
+    virtual ~GemmOptImpl() = default;
+
+    // Called during Compute phase to execute implementation-specific computation.
+    // @param context       The WebGPU compute context.
+    // @param handled       Output parameter. Set to true if this implementation handled the computation.
+    // @return Status::OK() on success, or an error status on failure.
+    virtual Status Compute(ComputeContext& context,
+                           /*out*/ bool& handled) = 0;
+
+   protected:
+    const Gemm& parent_;
+  };
+
   Gemm(const OpKernelInfo& info) : WebGpuKernel(info) {
     int64_t transA_temp;
     info.GetAttrOrDefault("transA", &transA_temp, static_cast<int64_t>(0));
@@ -53,11 +74,22 @@ class Gemm final : public WebGpuKernel {
 
   Status ComputeInternal(ComputeContext& context) const override;
 
+  bool TransA() const { return transA_; }
+  bool TransB() const { return transB_; }
+  float Alpha() const { return alpha_; }
+  float Beta() const { return beta_; }
+
  private:
   bool transA_;
   bool transB_;
   float alpha_;
   float beta_;
+
+  // Alternative optimized implementation (lazily created on the first Compute call,
+  // once the device capabilities can be queried from the compute context). A null
+  // impl_ after initialization means this device has no vendor-optimized path.
+  mutable std::unique_ptr<GemmOptImpl> impl_;
+  mutable std::once_flag impl_init_flag_;
 };
 
 }  // namespace webgpu

--- a/onnxruntime/core/providers/webgpu/math/subgroup_matrix_gemm.cc
+++ b/onnxruntime/core/providers/webgpu/math/subgroup_matrix_gemm.cc
@@ -1,0 +1,227 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#if !defined(__wasm__)
+
+#include "core/providers/webgpu/math/subgroup_matrix_gemm.h"
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string_view>
+#include <utility>
+
+#include "core/common/narrow.h"
+#include "core/providers/webgpu/compute_context.h"
+#include "core/providers/webgpu/math/subgroup_matrix_config.h"
+#include "core/providers/webgpu/shader_helper.h"
+#include "core/providers/webgpu/vendor/intel/math/subgroup_matrix_tiling_selector.h"
+
+namespace onnxruntime {
+namespace webgpu {
+
+namespace {
+
+// Lanes per subgroup assumed by the subgroup-matrix kernel. The workgroup runs
+// split_k subgroups, so its size is kSubgroupMatrixSubgroupSize * split_k.
+// TODO: use subgroup-size-control to enforce the subgroup size is 32.
+constexpr uint32_t kSubgroupMatrixSubgroupSize = 32;
+
+// Subgroup-matrix Gemm implementation. Loads A and B directly from global memory
+// (transposed operands via column-major loads) and runs the cooperative
+// subgroup-matrix kernel during Compute. Y = alpha * op(A) @ op(B) + beta * C.
+// f16 only; anything the kernel cannot serve (odd load stride, non-f16, K not a
+// multiple of the tile) falls back to the generic Gemm path. The per-problem
+// output tiling is supplied by a vendor-specific selector kept internal to this
+// impl (shared with the subgroup-matrix MatMul kernel).
+class SubgroupMatrixGemmImpl final : public Gemm::GemmOptImpl {
+ public:
+  SubgroupMatrixGemmImpl(const Gemm& parent, int32_t config_index,
+                         SubgroupMatrixTilingSelector tiling_selector)
+      : Gemm::GemmOptImpl(parent),
+        config_index_(config_index),
+        tiling_selector_(std::move(tiling_selector)) {}
+
+  Status Compute(ComputeContext& context, /*out*/ bool& handled) override {
+    handled = false;
+
+    const auto* a = context.Input<Tensor>(0);
+    const auto* b = context.Input<Tensor>(1);
+    if (a == nullptr || b == nullptr) {
+      return Status::OK();
+    }
+    const auto& a_shape = a->Shape();
+    const auto& b_shape = b->Shape();
+    if (a_shape.NumDimensions() != 2 || b_shape.NumDimensions() != 2 ||
+        !a->IsDataType<MLFloat16>() || !b->IsDataType<MLFloat16>()) {
+      return Status::OK();
+    }
+
+    const bool trans_a = parent_.TransA();
+    const bool trans_b = parent_.TransB();
+    const uint32_t M = narrow<uint32_t>(trans_a ? a_shape[1] : a_shape[0]);
+    const uint32_t K = narrow<uint32_t>(trans_a ? a_shape[0] : a_shape[1]);
+    const uint32_t N = narrow<uint32_t>(trans_b ? b_shape[0] : b_shape[1]);
+    if (M == 0 || N == 0 || K == 0) {
+      return Status::OK();
+    }
+
+    // Even-stride constraint: Intel's f16 subgroupMatrixLoad reads the contiguous
+    // (minor) dimension in 32-bit (2xf16) pairs, so the load row stride must be
+    // even. The B row-major load (trans_b == false) strides by N; the A
+    // column-major load (trans_a == true) strides by M. The other two cases
+    // stride by K, which is already a multiple of the tile size. Fall back when
+    // the relevant stride is odd.
+    if ((!trans_b && (N % 2 != 0)) || (trans_a && (M % 2 != 0))) {
+      return Status::OK();
+    }
+
+    const auto* c = context.Input<Tensor>(2);
+    const float alpha = parent_.Alpha();
+    const float beta = parent_.Beta();
+    const bool has_c = c != nullptr && beta != 0.0f;
+
+    // Encode C's broadcast to [M, N] as element strides (0 for a broadcast dim).
+    // C is unidirectionally broadcastable to (M, N): its (optional) trailing two
+    // dims must each be the matching output extent or 1; any leading dims must be 1.
+    uint32_t c_stride_m = 0;
+    uint32_t c_stride_n = 0;
+    if (has_c) {
+      if (!c->IsDataType<MLFloat16>()) {
+        return Status::OK();
+      }
+      const auto& c_shape = c->Shape();
+      const size_t c_rank = c_shape.NumDimensions();
+      const int64_t rn = c_rank >= 1 ? c_shape[c_rank - 1] : 1;
+      const int64_t rm = c_rank >= 2 ? c_shape[c_rank - 2] : 1;
+      for (size_t i = 0; i + 2 < c_rank; ++i) {
+        if (c_shape[i] != 1) {
+          return Status::OK();
+        }
+      }
+      if (!((rn == static_cast<int64_t>(N) || rn == 1) &&
+            (rm == static_cast<int64_t>(M) || rm == 1))) {
+        return Status::OK();
+      }
+      c_stride_n = (rn == static_cast<int64_t>(N)) ? 1u : 0u;
+      c_stride_m = (rm == static_cast<int64_t>(M)) ? narrow<uint32_t>(rn) : 0u;
+    }
+
+    // Tile shape and split-K come from the vendor selector, which also enforces
+    // the subgroup-matrix K alignment (K % sg_mat_k == 0) and declines otherwise.
+    // Gemm is 2D (no batch), so batch is fixed at 1; the cooperative-matrix kernel
+    // shape matches MatMul's, so the same selection and pretuned table apply.
+    const std::optional<SubgroupMatrixTiling> tiling = tiling_selector_(context, M, N, K, /*batch=*/1);
+    if (!tiling) {
+      return Status::OK();
+    }
+
+    TensorShape output_shape{{static_cast<int64_t>(M), static_cast<int64_t>(N)}};
+    auto* output = context.Output(0, output_shape);
+    if (output->Shape().Size() == 0) {
+      handled = true;
+      return Status::OK();
+    }
+
+    const auto& config = supported_subgroup_matrix_configs[config_index_];
+    const uint32_t tile_m = tiling->tile_m;
+    const uint32_t tile_n = tiling->tile_n;
+    const uint32_t split_k = tiling->split_k;
+    ORT_ENFORCE(tile_m % config.M == 0 && tile_n % config.N == 0,
+                "Tiling must be a multiple of the subgroup-matrix shape: ",
+                tile_m, "x", tile_n, " vs ", config.M, "x", config.N);
+    const uint32_t sg_mat_count_m = tile_m / config.M;
+    const uint32_t sg_mat_count_n = tile_n / config.N;
+    const uint32_t dispatch_x = (N + tile_n - 1) / tile_n;
+    const uint32_t dispatch_y = (M + tile_m - 1) / tile_m;
+
+    SubgroupMatrixGemmProgram program{has_c, trans_a, trans_b, config_index_, sg_mat_count_m, sg_mat_count_n, split_k};
+    program.SetWorkgroupSize(kSubgroupMatrixSubgroupSize * split_k);
+    program.SetDispatchGroupSize(dispatch_x, dispatch_y, 1);
+    program.CacheHint(has_c, trans_a, trans_b, config_index_, sg_mat_count_m, sg_mat_count_n, split_k)
+        .AddInputs({{a, ProgramTensorMetadataDependency::TypeAndRank, 1},
+                    {b, ProgramTensorMetadataDependency::TypeAndRank, 1}})
+        .AddOutput({output, ProgramTensorMetadataDependency::Rank, output->Shape(), 1})
+        .AddUniformVariables({{M}, {N}, {K}, {alpha}, {beta}, {c_stride_m}, {c_stride_n}});
+    if (has_c) {
+      program.AddInput({c, ProgramTensorMetadataDependency::None});
+    }
+    ORT_RETURN_IF_ERROR(context.RunProgram(program));
+
+    handled = true;
+    return Status::OK();
+  }
+
+ private:
+  const int32_t config_index_;
+  SubgroupMatrixTilingSelector tiling_selector_;
+};
+
+Status GenerateShaderCode8x16x16(ShaderHelper& shader, const ShaderVariableHelper& output,
+                                 bool has_c, bool trans_a, bool trans_b,
+                                 uint32_t sg_mat_count_m, uint32_t sg_mat_count_n, uint32_t split_k) {
+  return WGSL_TEMPLATE_APPLY(shader, "math/subgroup_matrix_gemm_8x16x16.wgsl.template",
+                             WGSL_TEMPLATE_PARAMETER(has_c, has_c),
+                             WGSL_TEMPLATE_PARAMETER(sg_mat_count_m, sg_mat_count_m),
+                             WGSL_TEMPLATE_PARAMETER(sg_mat_count_n, sg_mat_count_n),
+                             WGSL_TEMPLATE_PARAMETER(sg_mat_k, 16),
+                             WGSL_TEMPLATE_PARAMETER(sg_mat_m, 8),
+                             WGSL_TEMPLATE_PARAMETER(sg_mat_n, 16),
+                             WGSL_TEMPLATE_PARAMETER(split_k, split_k),
+                             WGSL_TEMPLATE_PARAMETER(trans_a, trans_a),
+                             WGSL_TEMPLATE_PARAMETER(trans_b, trans_b),
+                             WGSL_TEMPLATE_VARIABLE(output, output));
+}
+
+// Default tiling used on any vendor without a specialized policy: a fixed 32x32
+// output tile with no split-K.
+SubgroupMatrixTilingSelector MakeDefaultTilingSelector() {
+  return [](const ComputeContext&, uint32_t /*M*/, uint32_t /*N*/,
+            uint32_t /*K*/, uint32_t /*batch*/) -> std::optional<SubgroupMatrixTiling> {
+    return SubgroupMatrixTiling{32, 32, 1};
+  };
+}
+
+}  // namespace
+
+Status SubgroupMatrixGemmProgram::GenerateShaderCode(ShaderHelper& shader) const {
+  shader.AddInput("input_a", ShaderUsage::UseUniform);
+  shader.AddInput("input_b", ShaderUsage::UseUniform);
+  if (has_c_) {
+    shader.AddInput("input_c", ShaderUsage::UseUniform);
+  }
+  const auto& output = shader.AddOutput("output", ShaderUsage::UseUniform | ShaderUsage::UseElementTypeAlias);
+
+  const auto& config = supported_subgroup_matrix_configs[config_index_];
+  if (config.Is(8, 16, 16)) {
+    return GenerateShaderCode8x16x16(shader, output, has_c_, trans_a_, trans_b_,
+                                     sg_mat_count_m_, sg_mat_count_n_, split_k_);
+  }
+  return Status(onnxruntime::common::ONNXRUNTIME, onnxruntime::common::NOT_IMPLEMENTED,
+                "Unsupported subgroup matrix config dimensions.");
+}
+
+std::unique_ptr<Gemm::GemmOptImpl> CreateSubgroupMatrixGemmImpl(
+    const Gemm& parent, const ComputeContextBase& context) {
+  // Only run on devices that report the fixed 8x16x16 F16 subgroup-matrix config
+  // this kernel is implemented for.
+  int32_t config_index = 0;
+  if (!IsSubgroupMatrixConfigSupported(context, /*is_fp16=*/true, config_index) ||
+      !supported_subgroup_matrix_configs[config_index].Is(8, 16, 16)) {
+    return nullptr;
+  }
+  // Intel GPUs use a tuned/heuristic tiling policy; every other vendor falls back
+  // to a fixed default tiling.
+  const bool is_intel = context.AdapterInfo().vendor == std::string_view{"intel"};
+  SubgroupMatrixTilingSelector tiling_selector =
+      is_intel ? intel::CreateSubgroupMatrixTilingSelector(context) : MakeDefaultTilingSelector();
+  if (!tiling_selector) {
+    return nullptr;
+  }
+  return std::make_unique<SubgroupMatrixGemmImpl>(parent, config_index, std::move(tiling_selector));
+}
+
+}  // namespace webgpu
+}  // namespace onnxruntime
+
+#endif  // !defined(__wasm__)

--- a/onnxruntime/core/providers/webgpu/math/subgroup_matrix_gemm.h
+++ b/onnxruntime/core/providers/webgpu/math/subgroup_matrix_gemm.h
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#if !defined(__wasm__)
+
+#include <memory>
+
+#include "core/providers/webgpu/math/gemm.h"
+#include "core/providers/webgpu/program.h"
+#include "core/providers/webgpu/shader_helper.h"
+
+namespace onnxruntime {
+namespace webgpu {
+
+// Creates a GemmOptImpl that runs the subgroup-matrix kernel on devices whose
+// vendor policy supports it. The per-problem output tiling comes from a
+// vendor-specific selector chosen internally from the device context (the same
+// selector used by the subgroup-matrix MatMul). Returns nullptr when no vendor
+// policy applies, so the caller falls back to the default Gemm path.
+std::unique_ptr<Gemm::GemmOptImpl> CreateSubgroupMatrixGemmImpl(
+    const Gemm& parent, const ComputeContextBase& context);
+
+// Computes Y = alpha * op(A) @ op(B) + beta * C using subgroupMatrixMultiplyAccumulate.
+// config_index selects the device subgroup-matrix config (into
+// supported_subgroup_matrix_configs); sg_mat_count_m/n select how many subgroup
+// matrices the tile spans along M/N; split_k is the number of subgroups that
+// cooperatively reduce the K dimension. trans_a / trans_b select the A / B load
+// majorness; has_c enables the beta * C epilogue (C broadcast to [M, N] via the
+// c_stride_m / c_stride_n uniforms).
+class SubgroupMatrixGemmProgram final : public Program<SubgroupMatrixGemmProgram> {
+ public:
+  SubgroupMatrixGemmProgram(bool has_c, bool trans_a, bool trans_b, int32_t config_index,
+                            uint32_t sg_mat_count_m, uint32_t sg_mat_count_n, uint32_t split_k)
+      : Program{"SubgroupMatrixGemm"},
+        has_c_(has_c),
+        trans_a_(trans_a),
+        trans_b_(trans_b),
+        config_index_(config_index),
+        sg_mat_count_m_(sg_mat_count_m),
+        sg_mat_count_n_(sg_mat_count_n),
+        split_k_(split_k) {}
+  Status GenerateShaderCode(ShaderHelper& sh) const override;
+  WEBGPU_PROGRAM_DEFINE_UNIFORM_VARIABLES({"M", ProgramUniformVariableDataType::Uint32},
+                                          {"N", ProgramUniformVariableDataType::Uint32},
+                                          {"K", ProgramUniformVariableDataType::Uint32},
+                                          {"alpha", ProgramUniformVariableDataType::Float32},
+                                          {"beta", ProgramUniformVariableDataType::Float32},
+                                          {"c_stride_m", ProgramUniformVariableDataType::Uint32},
+                                          {"c_stride_n", ProgramUniformVariableDataType::Uint32});
+
+ private:
+  const bool has_c_;
+  const bool trans_a_;
+  const bool trans_b_;
+  const int32_t config_index_;
+  const uint32_t sg_mat_count_m_;
+  const uint32_t sg_mat_count_n_;
+  const uint32_t split_k_;
+};
+
+}  // namespace webgpu
+}  // namespace onnxruntime
+
+#endif  // !defined(__wasm__)

--- a/onnxruntime/core/providers/webgpu/math/subgroup_matrix_gemm_8x16x16.wgsl.template
+++ b/onnxruntime/core/providers/webgpu/math/subgroup_matrix_gemm_8x16x16.wgsl.template
@@ -32,8 +32,16 @@
 // Preconditions enforced by the host: K % sg_mat_k == 0; the load row stride is
 // even (Intel f16 subgroupMatrixLoad reads columns as 32-bit pairs), i.e. N even
 // when trans_b == 0 and M even when trans_a == 1. M and N may otherwise be any
-// size; partial tiles are handled by bounds-checked stores at write-out. Gemm is
-// strictly 2D (no batching).
+// size; partial tiles are handled by bounds-checked stores at write-out. The
+// matching loads in the last partial M/N tiles do read A rows >= M and B columns
+// >= N, but since K is never partial those over-read values only feed output
+// elements with m >= M or n >= N, which the bounds-checked stores discard - so
+// they can never corrupt a valid result, on any GPU. The out-of-range reads
+// themselves are made safe by WebGPU robust buffer access in the wasm/browser
+// build; the native (Dawn) build enables the disable_robustness device toggle, so
+// there they instead rely on backend-level bounds (e.g. D3D12 returns 0 for
+// out-of-range buffer reads), which holds on the Intel backends this
+// subgroup-matrix path is gated to. Gemm is strictly 2D (no batching).
 
 #param has_c
 #param trans_a

--- a/onnxruntime/core/providers/webgpu/math/subgroup_matrix_gemm_8x16x16.wgsl.template
+++ b/onnxruntime/core/providers/webgpu/math/subgroup_matrix_gemm_8x16x16.wgsl.template
@@ -1,0 +1,554 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Intel SubgroupMatrix Gemm kernel (8x16x16 config, F16).
+//
+// Computes Y[MxN] = alpha * op(A) @ op(B) + beta * C using
+// subgroupMatrixMultiplyAccumulate, where op(X) is X or X^T.
+//
+// M, N, K are the logical (post-transpose) dimensions: M output rows, N output
+// columns, K reduction. op(A) is MxK, op(B) is KxN.
+//
+// A (left operand, subgroup_matrix_left<f16, sg_mat_k, sg_mat_m>):
+//   trans_a == 0: A stored [M, K] row-major, loaded row-major with stride K.
+//   trans_a == 1: A stored [K, M] row-major, loaded column-major with stride M.
+// B (right operand, subgroup_matrix_right<f16, sg_mat_n, sg_mat_k>):
+//   trans_b == 0: B stored [K, N] row-major, loaded row-major with stride N.
+//   trans_b == 1: B stored [N, K] row-major, loaded column-major with stride K.
+//
+// Epilogue: each result element is scaled by alpha and, when has_c, has
+// beta * C[m, n] added. C is broadcastable to [M, N]; the host encodes the
+// broadcast as element strides c_stride_m / c_stride_n (0 for a broadcast dim).
+//
+// Workgroup: split_k subgroups x 32 lanes (split_k in {1,2,4,8}).
+// Tile: kTileM x kTileN, chosen adaptively by the host. Each subgroup computes
+// the whole tile as kSgMatCountM x kSgMatCountN subgroup matrices.
+// kSgMatCountM is in {1,2,4,8} (TileM in {8,16,32,64}) and kSgMatCountN is in
+// {1,2,4} (TileN in {16,32,64}). K is iterated in sg_mat_k blocks. When
+// split_k > 1 the K blocks are distributed round-robin across the subgroups,
+// each accumulates its own partial tile in shared memory, and the partials are
+// summed at write-out.
+//
+// Preconditions enforced by the host: K % sg_mat_k == 0; the load row stride is
+// even (Intel f16 subgroupMatrixLoad reads columns as 32-bit pairs), i.e. N even
+// when trans_b == 0 and M even when trans_a == 1. M and N may otherwise be any
+// size; partial tiles are handled by bounds-checked stores at write-out. Gemm is
+// strictly 2D (no batching).
+
+#param has_c
+#param trans_a
+#param trans_b
+#param sg_mat_k
+#param sg_mat_m
+#param sg_mat_n
+#param sg_mat_count_m
+#param sg_mat_count_n
+#param split_k
+
+#use .setByOffset
+
+const kSgMatM: u32 = u32(sg_mat_m);              // Subgroup matrix M dimension (rows)
+const kSgMatN: u32 = u32(sg_mat_n);              // Subgroup matrix N dimension (columns)
+const kSgMatK: u32 = u32(sg_mat_k);              // Subgroup matrix K dimension (reduction)
+const kSgMatCountM: u32 = u32(sg_mat_count_m);   // Number of subgroup matrices per tile along M
+const kSgMatCountN: u32 = u32(sg_mat_count_n);   // Number of subgroup matrices per tile along N
+const kTileM: u32 = kSgMatM * kSgMatCountM;      // Tile size along M (output rows per workgroup)
+const kTileN: u32 = kSgMatN * kSgMatCountN;      // Tile size along N (output columns per workgroup)
+const kSplitK: u32 = u32(split_k);               // Number of subgroups cooperating along K
+const kSubgroupSize: u32 = 32;                   // Lanes per subgroup
+
+// Scratch space for kSplitK partial [kTileM, kTileN] tiles, row-major. Each
+// split-K subgroup accumulates its slice of K into its own slot; the slots are
+// summed during write-back. Storing here also lets us write to global memory
+// with M/N bounds checks for dimensions that are not multiples of the tile size.
+var<workgroup> scratch: array<f16, kTileM * kTileN * kSplitK>;
+
+$MAIN {
+    // Recover the logical (n_tile, m_tile) from the flattened workgroup index. The
+    // host dispatches a num_n_tile x num_m_tile tile grid on (x, y), but that grid
+    // may be normalized (reshaped across x/y/z to stay within per-dimension
+    // limits), so workgroup_id.x/y cannot be used directly. workgroup_idx is the
+    // true linear index, invariant under normalization, laid out as
+    // m_tile * num_n_tile + n_tile.
+    let num_n_tile = (uniforms.N + kTileN - 1u) / kTileN;
+    let n_tile = workgroup_idx % num_n_tile;   // which kTileN-wide column tile
+    let global_base_n = n_tile * kTileN;
+    let m_tile = workgroup_idx / num_n_tile;   // which kTileM-tall row tile
+    let m_base = m_tile * kTileM;
+    let k_blocks = uniforms.K / kSgMatK;
+    let sg_index = local_idx / kSubgroupSize;          // which split-K subgroup (0..kSplitK-1)
+    let sg_lane = local_idx % kSubgroupSize;           // lane within the subgroup (0..kSubgroupSize-1)
+    let sg_scratch_base = sg_index * kTileM * kTileN;  // this subgroup's scratch slot
+
+    // Accumulators: kSgMatCountM M blocks x kSgMatCountN N blocks (sg_mat_c<mi>_<ni>).
+    var sg_mat_c0_0: subgroup_matrix_result<f16, sg_mat_n, sg_mat_m>;
+#if sg_mat_count_n >= 2
+    var sg_mat_c0_1: subgroup_matrix_result<f16, sg_mat_n, sg_mat_m>;
+#endif
+#if sg_mat_count_n >= 3
+    var sg_mat_c0_2: subgroup_matrix_result<f16, sg_mat_n, sg_mat_m>;
+#endif
+#if sg_mat_count_n >= 4
+    var sg_mat_c0_3: subgroup_matrix_result<f16, sg_mat_n, sg_mat_m>;
+#endif
+#if sg_mat_count_m >= 2
+    var sg_mat_c1_0: subgroup_matrix_result<f16, sg_mat_n, sg_mat_m>;
+#if sg_mat_count_n >= 2
+    var sg_mat_c1_1: subgroup_matrix_result<f16, sg_mat_n, sg_mat_m>;
+#endif
+#if sg_mat_count_n >= 3
+    var sg_mat_c1_2: subgroup_matrix_result<f16, sg_mat_n, sg_mat_m>;
+#endif
+#if sg_mat_count_n >= 4
+    var sg_mat_c1_3: subgroup_matrix_result<f16, sg_mat_n, sg_mat_m>;
+#endif
+#endif
+#if sg_mat_count_m >= 3
+    var sg_mat_c2_0: subgroup_matrix_result<f16, sg_mat_n, sg_mat_m>;
+#if sg_mat_count_n >= 2
+    var sg_mat_c2_1: subgroup_matrix_result<f16, sg_mat_n, sg_mat_m>;
+#endif
+#if sg_mat_count_n >= 3
+    var sg_mat_c2_2: subgroup_matrix_result<f16, sg_mat_n, sg_mat_m>;
+#endif
+#if sg_mat_count_n >= 4
+    var sg_mat_c2_3: subgroup_matrix_result<f16, sg_mat_n, sg_mat_m>;
+#endif
+#endif
+#if sg_mat_count_m >= 4
+    var sg_mat_c3_0: subgroup_matrix_result<f16, sg_mat_n, sg_mat_m>;
+#if sg_mat_count_n >= 2
+    var sg_mat_c3_1: subgroup_matrix_result<f16, sg_mat_n, sg_mat_m>;
+#endif
+#if sg_mat_count_n >= 3
+    var sg_mat_c3_2: subgroup_matrix_result<f16, sg_mat_n, sg_mat_m>;
+#endif
+#if sg_mat_count_n >= 4
+    var sg_mat_c3_3: subgroup_matrix_result<f16, sg_mat_n, sg_mat_m>;
+#endif
+#endif
+#if sg_mat_count_m >= 5
+    var sg_mat_c4_0: subgroup_matrix_result<f16, sg_mat_n, sg_mat_m>;
+#if sg_mat_count_n >= 2
+    var sg_mat_c4_1: subgroup_matrix_result<f16, sg_mat_n, sg_mat_m>;
+#endif
+#if sg_mat_count_n >= 3
+    var sg_mat_c4_2: subgroup_matrix_result<f16, sg_mat_n, sg_mat_m>;
+#endif
+#if sg_mat_count_n >= 4
+    var sg_mat_c4_3: subgroup_matrix_result<f16, sg_mat_n, sg_mat_m>;
+#endif
+#endif
+#if sg_mat_count_m >= 6
+    var sg_mat_c5_0: subgroup_matrix_result<f16, sg_mat_n, sg_mat_m>;
+#if sg_mat_count_n >= 2
+    var sg_mat_c5_1: subgroup_matrix_result<f16, sg_mat_n, sg_mat_m>;
+#endif
+#if sg_mat_count_n >= 3
+    var sg_mat_c5_2: subgroup_matrix_result<f16, sg_mat_n, sg_mat_m>;
+#endif
+#if sg_mat_count_n >= 4
+    var sg_mat_c5_3: subgroup_matrix_result<f16, sg_mat_n, sg_mat_m>;
+#endif
+#endif
+#if sg_mat_count_m >= 7
+    var sg_mat_c6_0: subgroup_matrix_result<f16, sg_mat_n, sg_mat_m>;
+#if sg_mat_count_n >= 2
+    var sg_mat_c6_1: subgroup_matrix_result<f16, sg_mat_n, sg_mat_m>;
+#endif
+#if sg_mat_count_n >= 3
+    var sg_mat_c6_2: subgroup_matrix_result<f16, sg_mat_n, sg_mat_m>;
+#endif
+#if sg_mat_count_n >= 4
+    var sg_mat_c6_3: subgroup_matrix_result<f16, sg_mat_n, sg_mat_m>;
+#endif
+#endif
+#if sg_mat_count_m >= 8
+    var sg_mat_c7_0: subgroup_matrix_result<f16, sg_mat_n, sg_mat_m>;
+#if sg_mat_count_n >= 2
+    var sg_mat_c7_1: subgroup_matrix_result<f16, sg_mat_n, sg_mat_m>;
+#endif
+#if sg_mat_count_n >= 3
+    var sg_mat_c7_2: subgroup_matrix_result<f16, sg_mat_n, sg_mat_m>;
+#endif
+#if sg_mat_count_n >= 4
+    var sg_mat_c7_3: subgroup_matrix_result<f16, sg_mat_n, sg_mat_m>;
+#endif
+#endif
+
+    for (var kb: u32 = sg_index; kb < k_blocks; kb = kb + kSplitK) {
+        let kb_k = kb * kSgMatK;
+        // Load the B right tiles for this K block.
+#if trans_b
+        // B stored [N, K] row-major: load column-major with stride K. The tile for
+        // N block ni starts at logical element (n = global_base_n + ni*kSgMatN,
+        // k = kb_k), i.e. flat offset (global_base_n + ni*kSgMatN) * K + kb_k.
+        var sg_mat_b0: subgroup_matrix_right<f16, sg_mat_n, sg_mat_k> =
+            subgroupMatrixLoad<subgroup_matrix_right<f16, sg_mat_n, sg_mat_k>>(
+                &input_b, (global_base_n + 0 * kSgMatN) * uniforms.K + kb_k, true, uniforms.K);
+#if sg_mat_count_n >= 2
+        var sg_mat_b1: subgroup_matrix_right<f16, sg_mat_n, sg_mat_k> =
+            subgroupMatrixLoad<subgroup_matrix_right<f16, sg_mat_n, sg_mat_k>>(
+                &input_b, (global_base_n + 1 * kSgMatN) * uniforms.K + kb_k, true, uniforms.K);
+#endif
+#if sg_mat_count_n >= 3
+        var sg_mat_b2: subgroup_matrix_right<f16, sg_mat_n, sg_mat_k> =
+            subgroupMatrixLoad<subgroup_matrix_right<f16, sg_mat_n, sg_mat_k>>(
+                &input_b, (global_base_n + 2 * kSgMatN) * uniforms.K + kb_k, true, uniforms.K);
+#endif
+#if sg_mat_count_n >= 4
+        var sg_mat_b3: subgroup_matrix_right<f16, sg_mat_n, sg_mat_k> =
+            subgroupMatrixLoad<subgroup_matrix_right<f16, sg_mat_n, sg_mat_k>>(
+                &input_b, (global_base_n + 3 * kSgMatN) * uniforms.K + kb_k, true, uniforms.K);
+#endif
+#else
+        // B stored [K, N] row-major: load row-major with stride N.
+        let b_base = kb_k * uniforms.N + global_base_n;
+        var sg_mat_b0: subgroup_matrix_right<f16, sg_mat_n, sg_mat_k> =
+            subgroupMatrixLoad<subgroup_matrix_right<f16, sg_mat_n, sg_mat_k>>(
+                &input_b, b_base + 0 * kSgMatN, false, uniforms.N);
+#if sg_mat_count_n >= 2
+        var sg_mat_b1: subgroup_matrix_right<f16, sg_mat_n, sg_mat_k> =
+            subgroupMatrixLoad<subgroup_matrix_right<f16, sg_mat_n, sg_mat_k>>(
+                &input_b, b_base + 1 * kSgMatN, false, uniforms.N);
+#endif
+#if sg_mat_count_n >= 3
+        var sg_mat_b2: subgroup_matrix_right<f16, sg_mat_n, sg_mat_k> =
+            subgroupMatrixLoad<subgroup_matrix_right<f16, sg_mat_n, sg_mat_k>>(
+                &input_b, b_base + 2 * kSgMatN, false, uniforms.N);
+#endif
+#if sg_mat_count_n >= 4
+        var sg_mat_b3: subgroup_matrix_right<f16, sg_mat_n, sg_mat_k> =
+            subgroupMatrixLoad<subgroup_matrix_right<f16, sg_mat_n, sg_mat_k>>(
+                &input_b, b_base + 3 * kSgMatN, false, uniforms.N);
+#endif
+#endif
+
+        // Load the A left tiles (one per M block).
+#if trans_a
+        // A stored [K, M] row-major: load column-major with stride M. The tile for
+        // M block mi starts at logical element (m = m_base + mi*kSgMatM, k = kb_k),
+        // i.e. flat offset kb_k * M + (m_base + mi*kSgMatM).
+        let a_row = kb_k * uniforms.M;
+        var sg_mat_a0: subgroup_matrix_left<f16, sg_mat_k, sg_mat_m> =
+            subgroupMatrixLoad<subgroup_matrix_left<f16, sg_mat_k, sg_mat_m>>(
+                &input_a, a_row + (m_base + 0 * kSgMatM), true, uniforms.M);
+#if sg_mat_count_m >= 2
+        var sg_mat_a1: subgroup_matrix_left<f16, sg_mat_k, sg_mat_m> =
+            subgroupMatrixLoad<subgroup_matrix_left<f16, sg_mat_k, sg_mat_m>>(
+                &input_a, a_row + (m_base + 1 * kSgMatM), true, uniforms.M);
+#endif
+#if sg_mat_count_m >= 3
+        var sg_mat_a2: subgroup_matrix_left<f16, sg_mat_k, sg_mat_m> =
+            subgroupMatrixLoad<subgroup_matrix_left<f16, sg_mat_k, sg_mat_m>>(
+                &input_a, a_row + (m_base + 2 * kSgMatM), true, uniforms.M);
+#endif
+#if sg_mat_count_m >= 4
+        var sg_mat_a3: subgroup_matrix_left<f16, sg_mat_k, sg_mat_m> =
+            subgroupMatrixLoad<subgroup_matrix_left<f16, sg_mat_k, sg_mat_m>>(
+                &input_a, a_row + (m_base + 3 * kSgMatM), true, uniforms.M);
+#endif
+#if sg_mat_count_m >= 5
+        var sg_mat_a4: subgroup_matrix_left<f16, sg_mat_k, sg_mat_m> =
+            subgroupMatrixLoad<subgroup_matrix_left<f16, sg_mat_k, sg_mat_m>>(
+                &input_a, a_row + (m_base + 4 * kSgMatM), true, uniforms.M);
+#endif
+#if sg_mat_count_m >= 6
+        var sg_mat_a5: subgroup_matrix_left<f16, sg_mat_k, sg_mat_m> =
+            subgroupMatrixLoad<subgroup_matrix_left<f16, sg_mat_k, sg_mat_m>>(
+                &input_a, a_row + (m_base + 5 * kSgMatM), true, uniforms.M);
+#endif
+#if sg_mat_count_m >= 7
+        var sg_mat_a6: subgroup_matrix_left<f16, sg_mat_k, sg_mat_m> =
+            subgroupMatrixLoad<subgroup_matrix_left<f16, sg_mat_k, sg_mat_m>>(
+                &input_a, a_row + (m_base + 6 * kSgMatM), true, uniforms.M);
+#endif
+#if sg_mat_count_m >= 8
+        var sg_mat_a7: subgroup_matrix_left<f16, sg_mat_k, sg_mat_m> =
+            subgroupMatrixLoad<subgroup_matrix_left<f16, sg_mat_k, sg_mat_m>>(
+                &input_a, a_row + (m_base + 7 * kSgMatM), true, uniforms.M);
+#endif
+#else
+        // A stored [M, K] row-major: load row-major with stride K.
+        let a_col = kb_k;
+        var sg_mat_a0: subgroup_matrix_left<f16, sg_mat_k, sg_mat_m> =
+            subgroupMatrixLoad<subgroup_matrix_left<f16, sg_mat_k, sg_mat_m>>(
+                &input_a, (m_base + 0 * kSgMatM) * uniforms.K + a_col, false, uniforms.K);
+#if sg_mat_count_m >= 2
+        var sg_mat_a1: subgroup_matrix_left<f16, sg_mat_k, sg_mat_m> =
+            subgroupMatrixLoad<subgroup_matrix_left<f16, sg_mat_k, sg_mat_m>>(
+                &input_a, (m_base + 1 * kSgMatM) * uniforms.K + a_col, false, uniforms.K);
+#endif
+#if sg_mat_count_m >= 3
+        var sg_mat_a2: subgroup_matrix_left<f16, sg_mat_k, sg_mat_m> =
+            subgroupMatrixLoad<subgroup_matrix_left<f16, sg_mat_k, sg_mat_m>>(
+                &input_a, (m_base + 2 * kSgMatM) * uniforms.K + a_col, false, uniforms.K);
+#endif
+#if sg_mat_count_m >= 4
+        var sg_mat_a3: subgroup_matrix_left<f16, sg_mat_k, sg_mat_m> =
+            subgroupMatrixLoad<subgroup_matrix_left<f16, sg_mat_k, sg_mat_m>>(
+                &input_a, (m_base + 3 * kSgMatM) * uniforms.K + a_col, false, uniforms.K);
+#endif
+#if sg_mat_count_m >= 5
+        var sg_mat_a4: subgroup_matrix_left<f16, sg_mat_k, sg_mat_m> =
+            subgroupMatrixLoad<subgroup_matrix_left<f16, sg_mat_k, sg_mat_m>>(
+                &input_a, (m_base + 4 * kSgMatM) * uniforms.K + a_col, false, uniforms.K);
+#endif
+#if sg_mat_count_m >= 6
+        var sg_mat_a5: subgroup_matrix_left<f16, sg_mat_k, sg_mat_m> =
+            subgroupMatrixLoad<subgroup_matrix_left<f16, sg_mat_k, sg_mat_m>>(
+                &input_a, (m_base + 5 * kSgMatM) * uniforms.K + a_col, false, uniforms.K);
+#endif
+#if sg_mat_count_m >= 7
+        var sg_mat_a6: subgroup_matrix_left<f16, sg_mat_k, sg_mat_m> =
+            subgroupMatrixLoad<subgroup_matrix_left<f16, sg_mat_k, sg_mat_m>>(
+                &input_a, (m_base + 6 * kSgMatM) * uniforms.K + a_col, false, uniforms.K);
+#endif
+#if sg_mat_count_m >= 8
+        var sg_mat_a7: subgroup_matrix_left<f16, sg_mat_k, sg_mat_m> =
+            subgroupMatrixLoad<subgroup_matrix_left<f16, sg_mat_k, sg_mat_m>>(
+                &input_a, (m_base + 7 * kSgMatM) * uniforms.K + a_col, false, uniforms.K);
+#endif
+#endif
+
+        // Accumulate every (M block, N block) pair.
+        sg_mat_c0_0 = subgroupMatrixMultiplyAccumulate(sg_mat_a0, sg_mat_b0, sg_mat_c0_0);
+#if sg_mat_count_n >= 2
+        sg_mat_c0_1 = subgroupMatrixMultiplyAccumulate(sg_mat_a0, sg_mat_b1, sg_mat_c0_1);
+#endif
+#if sg_mat_count_n >= 3
+        sg_mat_c0_2 = subgroupMatrixMultiplyAccumulate(sg_mat_a0, sg_mat_b2, sg_mat_c0_2);
+#endif
+#if sg_mat_count_n >= 4
+        sg_mat_c0_3 = subgroupMatrixMultiplyAccumulate(sg_mat_a0, sg_mat_b3, sg_mat_c0_3);
+#endif
+#if sg_mat_count_m >= 2
+        sg_mat_c1_0 = subgroupMatrixMultiplyAccumulate(sg_mat_a1, sg_mat_b0, sg_mat_c1_0);
+#if sg_mat_count_n >= 2
+        sg_mat_c1_1 = subgroupMatrixMultiplyAccumulate(sg_mat_a1, sg_mat_b1, sg_mat_c1_1);
+#endif
+#if sg_mat_count_n >= 3
+        sg_mat_c1_2 = subgroupMatrixMultiplyAccumulate(sg_mat_a1, sg_mat_b2, sg_mat_c1_2);
+#endif
+#if sg_mat_count_n >= 4
+        sg_mat_c1_3 = subgroupMatrixMultiplyAccumulate(sg_mat_a1, sg_mat_b3, sg_mat_c1_3);
+#endif
+#endif
+#if sg_mat_count_m >= 3
+        sg_mat_c2_0 = subgroupMatrixMultiplyAccumulate(sg_mat_a2, sg_mat_b0, sg_mat_c2_0);
+#if sg_mat_count_n >= 2
+        sg_mat_c2_1 = subgroupMatrixMultiplyAccumulate(sg_mat_a2, sg_mat_b1, sg_mat_c2_1);
+#endif
+#if sg_mat_count_n >= 3
+        sg_mat_c2_2 = subgroupMatrixMultiplyAccumulate(sg_mat_a2, sg_mat_b2, sg_mat_c2_2);
+#endif
+#if sg_mat_count_n >= 4
+        sg_mat_c2_3 = subgroupMatrixMultiplyAccumulate(sg_mat_a2, sg_mat_b3, sg_mat_c2_3);
+#endif
+#endif
+#if sg_mat_count_m >= 4
+        sg_mat_c3_0 = subgroupMatrixMultiplyAccumulate(sg_mat_a3, sg_mat_b0, sg_mat_c3_0);
+#if sg_mat_count_n >= 2
+        sg_mat_c3_1 = subgroupMatrixMultiplyAccumulate(sg_mat_a3, sg_mat_b1, sg_mat_c3_1);
+#endif
+#if sg_mat_count_n >= 3
+        sg_mat_c3_2 = subgroupMatrixMultiplyAccumulate(sg_mat_a3, sg_mat_b2, sg_mat_c3_2);
+#endif
+#if sg_mat_count_n >= 4
+        sg_mat_c3_3 = subgroupMatrixMultiplyAccumulate(sg_mat_a3, sg_mat_b3, sg_mat_c3_3);
+#endif
+#endif
+#if sg_mat_count_m >= 5
+        sg_mat_c4_0 = subgroupMatrixMultiplyAccumulate(sg_mat_a4, sg_mat_b0, sg_mat_c4_0);
+#if sg_mat_count_n >= 2
+        sg_mat_c4_1 = subgroupMatrixMultiplyAccumulate(sg_mat_a4, sg_mat_b1, sg_mat_c4_1);
+#endif
+#if sg_mat_count_n >= 3
+        sg_mat_c4_2 = subgroupMatrixMultiplyAccumulate(sg_mat_a4, sg_mat_b2, sg_mat_c4_2);
+#endif
+#if sg_mat_count_n >= 4
+        sg_mat_c4_3 = subgroupMatrixMultiplyAccumulate(sg_mat_a4, sg_mat_b3, sg_mat_c4_3);
+#endif
+#endif
+#if sg_mat_count_m >= 6
+        sg_mat_c5_0 = subgroupMatrixMultiplyAccumulate(sg_mat_a5, sg_mat_b0, sg_mat_c5_0);
+#if sg_mat_count_n >= 2
+        sg_mat_c5_1 = subgroupMatrixMultiplyAccumulate(sg_mat_a5, sg_mat_b1, sg_mat_c5_1);
+#endif
+#if sg_mat_count_n >= 3
+        sg_mat_c5_2 = subgroupMatrixMultiplyAccumulate(sg_mat_a5, sg_mat_b2, sg_mat_c5_2);
+#endif
+#if sg_mat_count_n >= 4
+        sg_mat_c5_3 = subgroupMatrixMultiplyAccumulate(sg_mat_a5, sg_mat_b3, sg_mat_c5_3);
+#endif
+#endif
+#if sg_mat_count_m >= 7
+        sg_mat_c6_0 = subgroupMatrixMultiplyAccumulate(sg_mat_a6, sg_mat_b0, sg_mat_c6_0);
+#if sg_mat_count_n >= 2
+        sg_mat_c6_1 = subgroupMatrixMultiplyAccumulate(sg_mat_a6, sg_mat_b1, sg_mat_c6_1);
+#endif
+#if sg_mat_count_n >= 3
+        sg_mat_c6_2 = subgroupMatrixMultiplyAccumulate(sg_mat_a6, sg_mat_b2, sg_mat_c6_2);
+#endif
+#if sg_mat_count_n >= 4
+        sg_mat_c6_3 = subgroupMatrixMultiplyAccumulate(sg_mat_a6, sg_mat_b3, sg_mat_c6_3);
+#endif
+#endif
+#if sg_mat_count_m >= 8
+        sg_mat_c7_0 = subgroupMatrixMultiplyAccumulate(sg_mat_a7, sg_mat_b0, sg_mat_c7_0);
+#if sg_mat_count_n >= 2
+        sg_mat_c7_1 = subgroupMatrixMultiplyAccumulate(sg_mat_a7, sg_mat_b1, sg_mat_c7_1);
+#endif
+#if sg_mat_count_n >= 3
+        sg_mat_c7_2 = subgroupMatrixMultiplyAccumulate(sg_mat_a7, sg_mat_b2, sg_mat_c7_2);
+#endif
+#if sg_mat_count_n >= 4
+        sg_mat_c7_3 = subgroupMatrixMultiplyAccumulate(sg_mat_a7, sg_mat_b3, sg_mat_c7_3);
+#endif
+#endif
+    }
+
+    // Store this subgroup's partial results into its split-K slot of scratch,
+    // laid out as kSplitK x [kTileM, kTileN] row-major. Offset of block (mi, ni)
+    // within a slot = mi * kSgMatM * kTileN + ni * kSgMatN, stride kTileN.
+    subgroupMatrixStore(&scratch, sg_scratch_base + 0 * kSgMatM * kTileN + 0 * kSgMatN, sg_mat_c0_0, false, kTileN);
+#if sg_mat_count_n >= 2
+    subgroupMatrixStore(&scratch, sg_scratch_base + 0 * kSgMatM * kTileN + 1 * kSgMatN, sg_mat_c0_1, false, kTileN);
+#endif
+#if sg_mat_count_n >= 3
+    subgroupMatrixStore(&scratch, sg_scratch_base + 0 * kSgMatM * kTileN + 2 * kSgMatN, sg_mat_c0_2, false, kTileN);
+#endif
+#if sg_mat_count_n >= 4
+    subgroupMatrixStore(&scratch, sg_scratch_base + 0 * kSgMatM * kTileN + 3 * kSgMatN, sg_mat_c0_3, false, kTileN);
+#endif
+#if sg_mat_count_m >= 2
+    subgroupMatrixStore(&scratch, sg_scratch_base + 1 * kSgMatM * kTileN + 0 * kSgMatN, sg_mat_c1_0, false, kTileN);
+#if sg_mat_count_n >= 2
+    subgroupMatrixStore(&scratch, sg_scratch_base + 1 * kSgMatM * kTileN + 1 * kSgMatN, sg_mat_c1_1, false, kTileN);
+#endif
+#if sg_mat_count_n >= 3
+    subgroupMatrixStore(&scratch, sg_scratch_base + 1 * kSgMatM * kTileN + 2 * kSgMatN, sg_mat_c1_2, false, kTileN);
+#endif
+#if sg_mat_count_n >= 4
+    subgroupMatrixStore(&scratch, sg_scratch_base + 1 * kSgMatM * kTileN + 3 * kSgMatN, sg_mat_c1_3, false, kTileN);
+#endif
+#endif
+#if sg_mat_count_m >= 3
+    subgroupMatrixStore(&scratch, sg_scratch_base + 2 * kSgMatM * kTileN + 0 * kSgMatN, sg_mat_c2_0, false, kTileN);
+#if sg_mat_count_n >= 2
+    subgroupMatrixStore(&scratch, sg_scratch_base + 2 * kSgMatM * kTileN + 1 * kSgMatN, sg_mat_c2_1, false, kTileN);
+#endif
+#if sg_mat_count_n >= 3
+    subgroupMatrixStore(&scratch, sg_scratch_base + 2 * kSgMatM * kTileN + 2 * kSgMatN, sg_mat_c2_2, false, kTileN);
+#endif
+#if sg_mat_count_n >= 4
+    subgroupMatrixStore(&scratch, sg_scratch_base + 2 * kSgMatM * kTileN + 3 * kSgMatN, sg_mat_c2_3, false, kTileN);
+#endif
+#endif
+#if sg_mat_count_m >= 4
+    subgroupMatrixStore(&scratch, sg_scratch_base + 3 * kSgMatM * kTileN + 0 * kSgMatN, sg_mat_c3_0, false, kTileN);
+#if sg_mat_count_n >= 2
+    subgroupMatrixStore(&scratch, sg_scratch_base + 3 * kSgMatM * kTileN + 1 * kSgMatN, sg_mat_c3_1, false, kTileN);
+#endif
+#if sg_mat_count_n >= 3
+    subgroupMatrixStore(&scratch, sg_scratch_base + 3 * kSgMatM * kTileN + 2 * kSgMatN, sg_mat_c3_2, false, kTileN);
+#endif
+#if sg_mat_count_n >= 4
+    subgroupMatrixStore(&scratch, sg_scratch_base + 3 * kSgMatM * kTileN + 3 * kSgMatN, sg_mat_c3_3, false, kTileN);
+#endif
+#endif
+#if sg_mat_count_m >= 5
+    subgroupMatrixStore(&scratch, sg_scratch_base + 4 * kSgMatM * kTileN + 0 * kSgMatN, sg_mat_c4_0, false, kTileN);
+#if sg_mat_count_n >= 2
+    subgroupMatrixStore(&scratch, sg_scratch_base + 4 * kSgMatM * kTileN + 1 * kSgMatN, sg_mat_c4_1, false, kTileN);
+#endif
+#if sg_mat_count_n >= 3
+    subgroupMatrixStore(&scratch, sg_scratch_base + 4 * kSgMatM * kTileN + 2 * kSgMatN, sg_mat_c4_2, false, kTileN);
+#endif
+#if sg_mat_count_n >= 4
+    subgroupMatrixStore(&scratch, sg_scratch_base + 4 * kSgMatM * kTileN + 3 * kSgMatN, sg_mat_c4_3, false, kTileN);
+#endif
+#endif
+#if sg_mat_count_m >= 6
+    subgroupMatrixStore(&scratch, sg_scratch_base + 5 * kSgMatM * kTileN + 0 * kSgMatN, sg_mat_c5_0, false, kTileN);
+#if sg_mat_count_n >= 2
+    subgroupMatrixStore(&scratch, sg_scratch_base + 5 * kSgMatM * kTileN + 1 * kSgMatN, sg_mat_c5_1, false, kTileN);
+#endif
+#if sg_mat_count_n >= 3
+    subgroupMatrixStore(&scratch, sg_scratch_base + 5 * kSgMatM * kTileN + 2 * kSgMatN, sg_mat_c5_2, false, kTileN);
+#endif
+#if sg_mat_count_n >= 4
+    subgroupMatrixStore(&scratch, sg_scratch_base + 5 * kSgMatM * kTileN + 3 * kSgMatN, sg_mat_c5_3, false, kTileN);
+#endif
+#endif
+#if sg_mat_count_m >= 7
+    subgroupMatrixStore(&scratch, sg_scratch_base + 6 * kSgMatM * kTileN + 0 * kSgMatN, sg_mat_c6_0, false, kTileN);
+#if sg_mat_count_n >= 2
+    subgroupMatrixStore(&scratch, sg_scratch_base + 6 * kSgMatM * kTileN + 1 * kSgMatN, sg_mat_c6_1, false, kTileN);
+#endif
+#if sg_mat_count_n >= 3
+    subgroupMatrixStore(&scratch, sg_scratch_base + 6 * kSgMatM * kTileN + 2 * kSgMatN, sg_mat_c6_2, false, kTileN);
+#endif
+#if sg_mat_count_n >= 4
+    subgroupMatrixStore(&scratch, sg_scratch_base + 6 * kSgMatM * kTileN + 3 * kSgMatN, sg_mat_c6_3, false, kTileN);
+#endif
+#endif
+#if sg_mat_count_m >= 8
+    subgroupMatrixStore(&scratch, sg_scratch_base + 7 * kSgMatM * kTileN + 0 * kSgMatN, sg_mat_c7_0, false, kTileN);
+#if sg_mat_count_n >= 2
+    subgroupMatrixStore(&scratch, sg_scratch_base + 7 * kSgMatM * kTileN + 1 * kSgMatN, sg_mat_c7_1, false, kTileN);
+#endif
+#if sg_mat_count_n >= 3
+    subgroupMatrixStore(&scratch, sg_scratch_base + 7 * kSgMatM * kTileN + 2 * kSgMatN, sg_mat_c7_2, false, kTileN);
+#endif
+#if sg_mat_count_n >= 4
+    subgroupMatrixStore(&scratch, sg_scratch_base + 7 * kSgMatM * kTileN + 3 * kSgMatN, sg_mat_c7_3, false, kTileN);
+#endif
+#endif
+
+#if split_k >= 2
+    // Make all subgroups' partial tiles visible before the reduction.
+    workgroupBarrier();
+
+    // Sum pass: a single subgroup reduces the kSplitK partial [kTileM, kTileN]
+    // tiles into slot 0 of scratch. Each lane owns a strided set of element
+    // positions and sums that position across all kSplitK slots. Writing slot 0
+    // is safe: a position is only overwritten by the same lane that already read
+    // it as the slot-0 term of its own sum.
+    if (sg_index == 0u) {
+        for (var idx: u32 = sg_lane; idx < kTileM * kTileN; idx = idx + kSubgroupSize) {
+            var acc: f16 = f16(0);
+            for (var s: u32 = 0; s < kSplitK; s++) {
+                acc += scratch[s * kTileM * kTileN + idx];
+            }
+            scratch[idx] = acc;
+        }
+    }
+    // Publish the summed tile (slot 0) to every subgroup for the write-out pass.
+    workgroupBarrier();
+#endif
+
+    // Write-out pass: every subgroup writes out whole M-rows from the summed tile
+    // in slot 0, striding by kSplitK subgroups (subgroup sg_index handles rows
+    // sg_index, sg_index + kSplitK, ...). The subgroup's lanes cooperate on a
+    // row's N elements (strided by the subgroup size). M and N are bounds-checked
+    // so non-multiple dimensions only write valid data. Each element is scaled by
+    // alpha and, when has_c, has beta * C[m, n] added (C broadcast via strides).
+    let n_count = min(kTileN, uniforms.N - global_base_n);
+    for (var r: u32 = sg_index; r < kTileM; r = r + kSplitK) {
+        let global_m = m_base + r;
+        if (global_m < uniforms.M) {
+            let scratch_base = r * kTileN;
+            let out_base = global_m * uniforms.N + global_base_n;
+            for (var i: u32 = sg_lane; i < n_count; i = i + kSubgroupSize) {
+                var val = output_element_t(scratch[scratch_base + i]) * output_element_t(uniforms.alpha);
+#if has_c
+                let global_n = global_base_n + i;
+                let c_offset = global_m * uniforms.c_stride_m + global_n * uniforms.c_stride_n;
+                val += output_element_t(uniforms.beta) * input_c[c_offset];
+#endif
+                output.setByOffset(out_base + i, val);
+            }
+        }
+    }
+}  // MAIN

--- a/onnxruntime/test/providers/webgpu/gemm_large_test.cc
+++ b/onnxruntime/test/providers/webgpu/gemm_large_test.cc
@@ -154,5 +154,26 @@ TEST(Gemm_Large, DISABLED_BiasBroadcast) {
   RunBothTypes({16, 1024}, 0, {1024, 192}, 0, {16, 192}, 1.5f, 1.3f);
 }
 
+// Intel subgroup-matrix (cooperative-matrix) path edge cases. K is a multiple of
+// 16 so the f16 kernel is engaged. transA loads A column-major with stride M (so
+// M must be even, else it falls back); transB loads B column-major with stride K
+// (always a multiple of 16, so safe). Even-but-not-tile-multiple M/N exercise the
+// column-major partial-tile stores; odd strides must fall back to the generic
+// path and still be correct.
+TEST(Gemm_Large, DISABLED_SubgroupMatrixEdges) {
+  // transA, even non-tile-multiple M: column-major A load + partial-M stores.
+  RunBothTypes({1024, 66}, 1, {1024, 192}, 0, {66, 192});
+  // transB, even non-tile-multiple N: column-major B load + partial-N stores.
+  RunBothTypes({48, 1024}, 0, {208, 1024}, 1, {208});
+  // transA + transB with partial M and N, plus alpha/beta scaling.
+  RunBothTypes({1024, 66}, 1, {208, 1024}, 1, {66, 208}, 1.5f, 1.3f);
+  // Odd M with transA: A load stride M is odd -> generic fallback (must be correct).
+  RunBothTypes({1024, 65}, 1, {1024, 192}, 0, {65, 192});
+  // Odd N without transB: B load stride N is odd -> generic fallback (must be correct).
+  RunBothTypes({64, 1024}, 0, {1024, 193}, 0, {193});
+  // Small K (still a multiple of 16) keeps split-K minimal over a large M x N grid.
+  RunBothTypes({256, 32}, 0, {32, 256}, 0, {256});
+}
+
 }  // namespace test
 }  // namespace onnxruntime


### PR DESCRIPTION
- Add a cooperative subgroup-matrix Gemm kernel for Intel Xe2/Xe3 (f16), mirroring the MatMul path with an alpha/beta*C epilogue and transA/transB support.
- Add Gemm edge-case correctness tests.
