### PR TITLE
WebGPU: Support int64 for Reshape

### DIFF
--- a/onnxruntime/core/providers/webgpu/tensor/reshape.cc
+++ b/onnxruntime/core/providers/webgpu/tensor/reshape.cc
@@ -8,89 +8,64 @@
 namespace onnxruntime {
 namespace webgpu {
 
-ONNX_OPERATOR_KERNEL_EX(
-    Reshape,
-    kOnnxDomain,
-    25,
-    kWebGpuExecutionProvider,
-    (*KernelDefBuilder::Create())
-        .TypeConstraint("T", WebGpuSupportedNumberTypes())
-        .TypeConstraint("shape", DataTypeImpl::GetTensorType<int64_t>())
-        .Alias(0, 0)
-        .InputMemoryType(OrtMemTypeCPU, 1),
-    Reshape);
+template <int StartVersion, int EndVersion>
+KernelCreateInfo CreateReshapeVersionedKernelInfo(bool enable_int64) {
+  // Reshape is a pure copy/view op. Enabling int64 is safe because element values are never
+  // interpreted or used in shader arithmetic.
+  const auto& type_constraints = GetOpTypeConstraints(enable_int64, true);
 
-ONNX_OPERATOR_VERSIONED_KERNEL_EX(
-    Reshape,
-    kOnnxDomain,
-    23, 24,
-    kWebGpuExecutionProvider,
-    (*KernelDefBuilder::Create())
-        .TypeConstraint("T", WebGpuSupportedNumberTypes())
-        .TypeConstraint("shape", DataTypeImpl::GetTensorType<int64_t>())
-        .Alias(0, 0)
-        .InputMemoryType(OrtMemTypeCPU, 1),
-    Reshape);
+  KernelCreatePtrFn kernel_create_fn = [](FuncManager&, const OpKernelInfo& info, std::unique_ptr<OpKernel>& out) -> Status {
+    out = std::make_unique<Reshape>(info);
+    return Status::OK();
+  };
 
-ONNX_OPERATOR_VERSIONED_KERNEL_EX(
-    Reshape,
-    kOnnxDomain,
-    21, 22,
-    kWebGpuExecutionProvider,
-    (*KernelDefBuilder::Create())
-        .TypeConstraint("T", WebGpuSupportedNumberTypes())
-        .TypeConstraint("shape", DataTypeImpl::GetTensorType<int64_t>())
-        .Alias(0, 0)
-        .InputMemoryType(OrtMemTypeCPU, 1),
-    Reshape);
+  return {
+      KernelDefBuilder()
+          .SetName("Reshape")
+          .SetDomain(kOnnxDomain)
+          .SinceVersion(StartVersion, EndVersion)
+          .Provider(kWebGpuExecutionProvider)
+          .TypeConstraint("T", type_constraints)
+          .TypeConstraint("shape", DataTypeImpl::GetTensorType<int64_t>())
+          .Alias(0, 0)
+          .InputMemoryType(OrtMemTypeCPU, 1)
+          .Build(),
+      kernel_create_fn};
+}
 
-ONNX_OPERATOR_VERSIONED_KERNEL_EX(
-    Reshape,
-    kOnnxDomain,
-    19, 20,
-    kWebGpuExecutionProvider,
-    (*KernelDefBuilder::Create())
-        .TypeConstraint("T", WebGpuSupportedNumberTypes())
-        .TypeConstraint("shape", DataTypeImpl::GetTensorType<int64_t>())
-        .Alias(0, 0)
-        .InputMemoryType(OrtMemTypeCPU, 1),
-    Reshape);
+template <int SinceVersion>
+KernelCreateInfo CreateReshapeKernelInfo(bool enable_int64) {
+  // Reshape is a pure copy/view op. Enabling int64 is safe because element values are never
+  // interpreted or used in shader arithmetic.
+  const auto& type_constraints = GetOpTypeConstraints(enable_int64, true);
 
-ONNX_OPERATOR_VERSIONED_KERNEL_EX(
-    Reshape,
-    kOnnxDomain,
-    14, 18,
-    kWebGpuExecutionProvider,
-    (*KernelDefBuilder::Create())
-        .TypeConstraint("T", WebGpuSupportedNumberTypes())
-        .TypeConstraint("shape", DataTypeImpl::GetTensorType<int64_t>())
-        .Alias(0, 0)
-        .InputMemoryType(OrtMemTypeCPU, 1),
-    Reshape);
+  KernelCreatePtrFn kernel_create_fn = [](FuncManager&, const OpKernelInfo& info, std::unique_ptr<OpKernel>& out) -> Status {
+    out = std::make_unique<Reshape>(info);
+    return Status::OK();
+  };
 
-ONNX_OPERATOR_VERSIONED_KERNEL_EX(
-    Reshape,
-    kOnnxDomain,
-    13, 13,
-    kWebGpuExecutionProvider,
-    (*KernelDefBuilder::Create())
-        .TypeConstraint("T", WebGpuSupportedNumberTypes())
-        .TypeConstraint("shape", DataTypeImpl::GetTensorType<int64_t>())
-        .Alias(0, 0)
-        .InputMemoryType(OrtMemTypeCPU, 1),
-    Reshape);
+  return {
+      KernelDefBuilder()
+          .SetName("Reshape")
+          .SetDomain(kOnnxDomain)
+          .SinceVersion(SinceVersion)
+          .Provider(kWebGpuExecutionProvider)
+          .TypeConstraint("T", type_constraints)
+          .TypeConstraint("shape", DataTypeImpl::GetTensorType<int64_t>())
+          .Alias(0, 0)
+          .InputMemoryType(OrtMemTypeCPU, 1)
+          .Build(),
+      kernel_create_fn};
+}
 
-ONNX_OPERATOR_VERSIONED_KERNEL_EX(
-    Reshape,
-    kOnnxDomain,
-    5, 12,
-    kWebGpuExecutionProvider,
-    (*KernelDefBuilder::Create())
-        .TypeConstraint("T", WebGpuSupportedNumberTypes())
-        .TypeConstraint("shape", DataTypeImpl::GetTensorType<int64_t>())
-        .Alias(0, 0)
-        .InputMemoryType(OrtMemTypeCPU, 1),
-    Reshape);
+// Explicit template instantiations
+template KernelCreateInfo CreateReshapeVersionedKernelInfo<5, 12>(bool);
+template KernelCreateInfo CreateReshapeVersionedKernelInfo<13, 13>(bool);
+template KernelCreateInfo CreateReshapeVersionedKernelInfo<14, 18>(bool);
+template KernelCreateInfo CreateReshapeVersionedKernelInfo<19, 20>(bool);
+template KernelCreateInfo CreateReshapeVersionedKernelInfo<21, 22>(bool);
+template KernelCreateInfo CreateReshapeVersionedKernelInfo<23, 24>(bool);
+template KernelCreateInfo CreateReshapeKernelInfo<25>(bool);
 
 }  // namespace webgpu
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/webgpu/tensor/reshape.h
+++ b/onnxruntime/core/providers/webgpu/tensor/reshape.h
@@ -47,5 +47,11 @@ class Reshape final : public OpKernel {
   bool allow_zero_;
 };
 
+// Create Reshape kernel info with appropriate type constraints based on int64 support
+template <int StartVersion, int EndVersion>
+KernelCreateInfo CreateReshapeVersionedKernelInfo(bool enable_int64);
+template <int SinceVersion>
+KernelCreateInfo CreateReshapeKernelInfo(bool enable_int64);
+
 }  // namespace webgpu
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
@@ -32,6 +32,7 @@
 #include "core/providers/webgpu/tensor/cast.h"
 #include "core/providers/webgpu/tensor/expand.h"
 #include "core/providers/webgpu/tensor/grid_sample.h"
+#include "core/providers/webgpu/tensor/reshape.h"
 #include "core/providers/webgpu/generator/range.h"
 #include "core/providers/webgpu/tensor/unsqueeze.h"
 #include "core/providers/webgpu/math/binary_elementwise_ops.h"
@@ -192,14 +193,6 @@ static const BuildKernelCreateInfoFn build_kernel_create_info_function_table[] =
     BuildKernelCreateInfo<class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 21, 22, Shape)>,
     BuildKernelCreateInfo<class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 23, 23, Shape)>,
     BuildKernelCreateInfo<class ONNX_OPERATOR_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 24, Shape)>,
-
-    BuildKernelCreateInfo<class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 5, 12, Reshape)>,
-    BuildKernelCreateInfo<class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 13, 13, Reshape)>,
-    BuildKernelCreateInfo<class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 14, 18, Reshape)>,
-    BuildKernelCreateInfo<class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 19, 20, Reshape)>,
-    BuildKernelCreateInfo<class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 21, 22, Reshape)>,
-    BuildKernelCreateInfo<class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 23, 24, Reshape)>,
-    BuildKernelCreateInfo<class ONNX_OPERATOR_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 25, Reshape)>,
 
     BuildKernelCreateInfo<class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 1, 12, Identity)>,
     BuildKernelCreateInfo<class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 13, 13, Identity)>,
@@ -486,6 +479,15 @@ std::unique_ptr<KernelRegistry> RegisterKernels(bool enable_graph_capture, bool 
   // Register Expand kernels with conditional int64 support
   ORT_THROW_IF_ERROR(kernel_registry->Register(CreateExpandVersionedKernelInfo<8, 12>(enable_int64)));
   ORT_THROW_IF_ERROR(kernel_registry->Register(CreateExpandKernelInfo<13>(enable_int64)));
+
+  // Register Reshape kernels with conditional int64 support
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateReshapeVersionedKernelInfo<5, 12>(enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateReshapeVersionedKernelInfo<13, 13>(enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateReshapeVersionedKernelInfo<14, 18>(enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateReshapeVersionedKernelInfo<19, 20>(enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateReshapeVersionedKernelInfo<21, 22>(enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateReshapeVersionedKernelInfo<23, 24>(enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateReshapeKernelInfo<25>(enable_int64)));
 
   // Register Equal kernels with conditional int64 support
   ORT_THROW_IF_ERROR(kernel_registry->Register(CreateEqualVersionedKernelInfo<7, 10>(enable_int64)));

--- a/onnxruntime/test/providers/cpu/tensor/tensor_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/tensor_op_test.cc
@@ -5,6 +5,9 @@
 
 #include "gtest/gtest.h"
 #include "core/providers/cpu/tensor/reshape_helper.h"
+#ifdef USE_WEBGPU
+#include "core/providers/webgpu/webgpu_provider_options.h"
+#endif
 #include "test/providers/provider_test_utils.h"
 #include "test/common/dnnl_op_test_utils.h"
 #include "test/common/tensor_op_test_utils.h"
@@ -82,6 +85,22 @@ TEST(TensorOpTest, ReshapeWithInitializer) {
   test.AddOutput<float>("reshaped", {1, 3, 2}, std::vector<float>(6, 1.0f));
   test.Run();
 }
+
+#ifdef USE_WEBGPU
+TEST(TensorOpTest, Reshape_int64_webgpu) {
+  OpTester test("Reshape", 14);
+
+  test.AddInput<int64_t>("data", {2, 3}, {1, 2, 3, 4, 5, 6});
+  test.AddInput<int64_t>("shape", {3}, {3, 1, 2});
+  test.AddOutput<int64_t>("reshaped", {3, 1, 2}, {1, 2, 3, 4, 5, 6});
+
+  ConfigOptions config_options{};
+  ASSERT_STATUS_OK(config_options.AddConfigEntry(webgpu::options::kEnableInt64, "1"));
+  auto provider = WebGpuExecutionProviderWithOptions(config_options);
+  test.ConfigEp(std::move(provider))
+      .RunWithConfig();
+}
+#endif
 
 TEST(TensorOpTest, Reshape_WithOutAllowZero) {
   OpTester test("Reshape", 14);

--- a/onnxruntime/test/providers/cpu/tensor/tensor_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/tensor_op_test.cc
@@ -88,7 +88,7 @@ TEST(TensorOpTest, ReshapeWithInitializer) {
 
 #ifdef USE_WEBGPU
 TEST(TensorOpTest, Reshape_int64_webgpu) {
-  OpTester test("Reshape", 14);
+  OpTester test("Reshape", 25);
 
   test.AddInput<int64_t>("data", {2, 3}, {1, 2, 3, 4, 5, 6});
   test.AddInput<int64_t>("shape", {3}, {3, 1, 2});


### PR DESCRIPTION
### Description
This updates WebGPU `Reshape` to follow the existing `enable_int64` factory-registration pattern (used by `Unsqueeze`/`Expand`/etc.) instead of static macro registration, and adds explicit int64 WebGPU test coverage for `Reshape`.



### Motivation and Context
PR [microsoft/onnxruntime#27478](https://github.com/microsoft/onnxruntime/pull/27478) added int64 support for the Expand and Unsqueeze (Squeeze) operators in the WebGPU EP. However, the WebNN EP maps a number of those shape-manipulation operators — including Squeeze/Unsqueeze — onto Reshape (WebNN spec doesn't support Squeeze/Unsqueeze). As a result, when a model uses int64 data through these WebNN-mapped ops, execution falls back because Reshape itself does not yet accept int64 tensors, undermining the int64 coverage that #27478 was intended to enable.

Fix #29756