### PR TITLE
Add --disable_types double build option to drop double CUDA kernels (Stage 1)

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -184,6 +184,7 @@ option(onnxruntime_DISABLE_SPARSE_TENSORS "Disable sparse tensors data types" OF
 option(onnxruntime_DISABLE_OPTIONAL_TYPE "Disable optional type" OFF)
 option(onnxruntime_DISABLE_FLOAT8_TYPES "Disable float 8 types" OFF)
 option(onnxruntime_DISABLE_FLOAT4_TYPES "Disable float 4 types" OFF)
+option(onnxruntime_DISABLE_DOUBLE_TYPE "Disable double (float64) CUDA kernels" OFF)
 option(onnxruntime_DISABLE_STRING_TYPE "Disable string type" OFF)
 option(onnxruntime_MINIMAL_BUILD "Exclude as much as possible from the build. Support ORT format models. No support for ONNX format models." OFF)
 option(onnxruntime_CLIENT_PACKAGE_BUILD "Enables default settings that are more appropriate for client/on-device workloads." OFF)
@@ -1119,6 +1120,10 @@ function(onnxruntime_set_compile_flags target_name)
 
     if (onnxruntime_DISABLE_FLOAT4_TYPES)
       target_compile_definitions(${target_name} PRIVATE DISABLE_FLOAT4_TYPES)
+    endif()
+
+    if (onnxruntime_DISABLE_DOUBLE_TYPE)
+      target_compile_definitions(${target_name} PRIVATE DISABLE_DOUBLE_TYPE)
     endif()
 
     if (onnxruntime_DISABLE_STRING_TYPE)

--- a/cmake/onnxruntime_providers_cuda_plugin.cmake
+++ b/cmake/onnxruntime_providers_cuda_plugin.cmake
@@ -444,6 +444,11 @@ if (onnxruntime_USE_CUDA_NHWC_OPS)
     target_compile_definitions(onnxruntime_providers_cuda_plugin PRIVATE ENABLE_CUDA_NHWC_OPS)
 endif()
 
+if (onnxruntime_DISABLE_DOUBLE_TYPE)
+    # Skip registering double (float64) CUDA kernels via the adapter KernelDefBuilder.
+    target_compile_definitions(onnxruntime_providers_cuda_plugin PRIVATE DISABLE_DOUBLE_TYPE)
+endif()
+
 if(WIN32)
   # Windows: use .def file for symbol exports
   set(CUDA_PLUGIN_DEF_FILE ${CUDA_PLUGIN_EP_DIR}/cuda_plugin_ep_symbols.def)

--- a/include/onnxruntime/ep/adapter/kernel_def_builder.h
+++ b/include/onnxruntime/ep/adapter/kernel_def_builder.h
@@ -105,6 +105,14 @@ struct KernelDefBuilder {
     std::vector<const OrtDataType*> ort_types;
     ort_types.reserve(types.size());
     for (const auto& type : types) {
+#if defined(DISABLE_DOUBLE_TYPE)
+      // `double` CUDA kernels are disabled in this build (--disable_types double).
+      // Drop double from the advertised type set; if it was the only type, the
+      // constraint becomes empty below and the kernel is skipped.
+      if (type == DataTypeImpl::GetTensorType<double>()) {
+        continue;
+      }
+#endif
       const OrtDataType* ort_type = TryMLDataTypeToOrtDataType(type);
       if (ort_type != nullptr) {
         ort_types.push_back(ort_type);
@@ -119,6 +127,14 @@ struct KernelDefBuilder {
   }
 
   KernelDefBuilder& TypeConstraint(const char* arg_name, MLDataType type) {
+#if defined(DISABLE_DOUBLE_TYPE)
+    // A `double`-only constraint cannot be satisfied when double is disabled, so
+    // the whole kernel is skipped (Build() returns a null KernelDef).
+    if (type == DataTypeImpl::GetTensorType<double>()) {
+      valid_ = false;
+      return *this;
+    }
+#endif
     const OrtDataType* ort_type = TryMLDataTypeToOrtDataType(type);
     if (ort_type != nullptr) {
       builder_.AddTypeConstraint(arg_name, ort_type);

--- a/onnxruntime/contrib_ops/cuda/cuda_contrib_kernels.cc
+++ b/onnxruntime/contrib_ops/cuda/cuda_contrib_kernels.cc
@@ -3,6 +3,7 @@
 
 #include "core/providers/shared_library/provider_api.h"
 #include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel_build_config.h"
 
 using namespace onnxruntime::common;
 
@@ -554,7 +555,8 @@ Status RegisterCudaContribKernels(KernelRegistry& kernel_registry) {
 
   for (auto& function_table_entry : function_table) {
     KernelCreateInfo info = function_table_entry();
-    if (info.kernel_def != nullptr) {  // filter disabled entries where type is void
+    if (info.kernel_def != nullptr &&  // filter disabled entries where type is void
+        !::onnxruntime::cuda::IsCudaKernelDisabledByType(*info.kernel_def)) {
       ORT_RETURN_IF_ERROR(kernel_registry.Register(std::move(info)));
     }
   }

--- a/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
+++ b/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
@@ -12,6 +12,7 @@
 #include "core/platform/env_var_utils.h"
 #include "core/providers/cuda/cuda_execution_provider.h"
 #include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_kernel_build_config.h"
 #include "core/providers/cuda/cuda_nhwc_ops.h"
 #include "core/providers/cuda/cuda_allocator.h"
 #include "core/providers/cuda/cuda_fwd.h"
@@ -592,7 +593,8 @@ Status RegisterOnnxMLOperatorKernels(KernelRegistry& kernel_registry) {
 
   for (auto& function_table_entry : function_table) {
     KernelCreateInfo info = function_table_entry();
-    if (info.kernel_def != nullptr) {  // filter disabled entries where type is void
+    if (info.kernel_def != nullptr &&  // filter disabled entries where type is void
+        !::onnxruntime::cuda::IsCudaKernelDisabledByType(*info.kernel_def)) {
       ORT_RETURN_IF_ERROR(kernel_registry.Register(std::move(info)));
     }
   }
@@ -3182,7 +3184,8 @@ static Status RegisterCudaKernels(KernelRegistry& kernel_registry) {
 
   for (auto& function_table_entry : function_table) {
     KernelCreateInfo info = function_table_entry();
-    if (info.kernel_def != nullptr) {  // filter disabled entries where type is void
+    if (info.kernel_def != nullptr &&  // filter disabled entries where type is void
+        !::onnxruntime::cuda::IsCudaKernelDisabledByType(*info.kernel_def)) {
       ORT_RETURN_IF_ERROR(kernel_registry.Register(std::move(info)));
     }
   }

--- a/onnxruntime/core/providers/cuda/cuda_kernel_build_config.h
+++ b/onnxruntime/core/providers/cuda/cuda_kernel_build_config.h
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <vector>
+
+// This header is only used by the in-tree CUDA EP kernel registration tables,
+// which are compiled with the shared-provider bridge. Use the bridged types via
+// provider_api.h (KernelDef, MLDataType, DataTypeImpl) rather than the real
+// framework headers. The CUDA plugin EP does not use this header.
+#include "core/providers/shared_library/provider_api.h"
+
+namespace onnxruntime {
+namespace cuda {
+
+// Stage 1 build-time data-type filter for CUDA kernels.
+//
+// When a floating point element type is disabled at build time (currently only
+// `double`, enabled via the `--disable_types double` build option which defines
+// the DISABLE_DOUBLE_TYPE macro), CUDA kernels that can only run in that type are
+// skipped at registration time, so the type becomes unavailable on the CUDA EP.
+//
+// This helper is used by the in-tree CUDA EP kernel registration tables. The CUDA
+// plugin EP achieves the same effect inside its adapter KernelDefBuilder (which
+// returns a null KernelDef for disabled-type kernels), because the plugin's
+// registration loop only sees an opaque KernelDef that does not expose kernel type
+// constraints.
+//
+// Note: this removes the kernel *registration* only. Reclaiming the disabled
+// kernels' device code additionally relies on linker dead-code elimination
+// (--gc-sections) or on excluding the kernel sources from compilation.
+inline bool IsCudaKernelDisabledByType([[maybe_unused]] const KernelDef& kernel_def) {
+#if defined(DISABLE_DOUBLE_TYPE)
+  const MLDataType disabled_type = DataTypeImpl::GetTensorType<double>();
+
+  // Drop the kernel if any of its type constraints can only be satisfied by a
+  // disabled type (e.g. a `double`-only kernel instantiation). Kernels that allow
+  // the disabled type among other still-enabled types are kept.
+  for (const auto& type_constraint : kernel_def.TypeConstraints()) {
+    const std::vector<MLDataType>& allowed_types = type_constraint.second;
+    if (allowed_types.empty()) {
+      continue;
+    }
+
+    bool all_disabled = true;
+    for (const MLDataType allowed_type : allowed_types) {
+      if (allowed_type != disabled_type) {
+        all_disabled = false;
+        break;
+      }
+    }
+
+    if (all_disabled) {
+      return true;
+    }
+  }
+#endif
+  return false;
+}
+
+}  // namespace cuda
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cuda/cuda_nhwc_kernels.cc
+++ b/onnxruntime/core/providers/cuda/cuda_nhwc_kernels.cc
@@ -10,6 +10,7 @@
 #include "core/providers/cuda/cuda_fwd.h"
 
 #include "core/providers/cuda/cuda_nhwc_kernels.h"
+#include "core/providers/cuda/cuda_kernel_build_config.h"
 
 // Macros to avoid long line length
 #define CUDA_NHWC_OP_CLASS_NAME(ver, name) \
@@ -165,7 +166,8 @@ Status RegisterCudaNhwcKernels(KernelRegistry& kernel_registry) {
 
   for (auto& function_table_entry : nhwc_function_table) {
     KernelCreateInfo info = function_table_entry();
-    if (info.kernel_def != nullptr) {  // filter disabled entries where type is void
+    if (info.kernel_def != nullptr &&  // filter disabled entries where type is void
+        !::onnxruntime::cuda::IsCudaKernelDisabledByType(*info.kernel_def)) {
       ORT_RETURN_IF_ERROR(kernel_registry.Register(std::move(info)));
     }
   }
@@ -191,7 +193,8 @@ onnxruntime::common::Status RegisterCudaNhwcContribKernels(KernelRegistry& kerne
 
   for (auto& function_table_entry : nhwc_function_table) {
     KernelCreateInfo info = function_table_entry();
-    if (info.kernel_def != nullptr) {  // filter disabled entries where type is void
+    if (info.kernel_def != nullptr &&  // filter disabled entries where type is void
+        !::onnxruntime::cuda::IsCudaKernelDisabledByType(*info.kernel_def)) {
       ORT_RETURN_IF_ERROR(kernel_registry.Register(std::move(info)));
     }
   }

--- a/onnxruntime/core/providers/shared_library/provider_interfaces.h
+++ b/onnxruntime/core/providers/shared_library/provider_interfaces.h
@@ -704,6 +704,7 @@ struct ProviderHost {
   virtual void KernelDef__SinceVersion(const KernelDef* p, int* start, int* end) = 0;
   virtual const std::string& KernelDef__Domain(const KernelDef* p) = 0;
   virtual const std::string& KernelDef__OpName(const KernelDef* p) = 0;
+  virtual const std::unordered_map<std::string, std::vector<MLDataType>>& KernelDef__TypeConstraints(const KernelDef* p) = 0;
 
   // KernelDefBuilder
   virtual std::unique_ptr<KernelDefBuilder> KernelDefBuilder__construct() = 0;

--- a/onnxruntime/core/providers/shared_library/provider_wrappedtypes.h
+++ b/onnxruntime/core/providers/shared_library/provider_wrappedtypes.h
@@ -627,6 +627,9 @@ struct KernelDef final {
   void SinceVersion(/*out*/ int* start, /*out*/ int* end) const { g_host->KernelDef__SinceVersion(this, start, end); }
   const std::string& Domain() const { return g_host->KernelDef__Domain(this); }
   const std::string& OpName() const { return g_host->KernelDef__OpName(this); }
+  const std::unordered_map<std::string, std::vector<MLDataType>>& TypeConstraints() const {
+    return g_host->KernelDef__TypeConstraints(this);
+  }
 
   KernelDef() = delete;
   KernelDef(const KernelDef*) = delete;

--- a/onnxruntime/core/session/provider_bridge_ort.cc
+++ b/onnxruntime/core/session/provider_bridge_ort.cc
@@ -936,6 +936,9 @@ struct ProviderHostImpl : ProviderHost {
   void KernelDef__SinceVersion(const KernelDef* p, int* start, int* end) override { return p->SinceVersion(start, end); }
   const std::string& KernelDef__Domain(const KernelDef* p) override { return p->Domain(); }
   const std::string& KernelDef__OpName(const KernelDef* p) override { return p->OpName(); }
+  const std::unordered_map<std::string, std::vector<MLDataType>>& KernelDef__TypeConstraints(const KernelDef* p) override {
+    return p->TypeConstraints();
+  }
   int KernelDef__ExecQueueId(const KernelDef* p) override { return p->ExecQueueId(); }
 
   // KernelDefBuilder (wrapped)

--- a/orttraining/orttraining/training_ops/cuda/cuda_training_kernels.cc
+++ b/orttraining/orttraining/training_ops/cuda/cuda_training_kernels.cc
@@ -3,6 +3,7 @@
 
 #include "core/providers/shared_library/provider_api.h"
 #include "core/providers/cuda/cuda_fwd.h"
+#include "core/providers/cuda/cuda_kernel_build_config.h"
 #include "core/providers/cuda/cuda_pch.h"
 
 using namespace onnxruntime::common;
@@ -529,7 +530,8 @@ Status RegisterCudaTrainingKernels(KernelRegistry& kernel_registry) {
 
   for (auto& function_table_entry : function_table) {
     KernelCreateInfo info = function_table_entry();
-    if (info.kernel_def != nullptr) {  // filter disabled entries where type is void
+    if (info.kernel_def != nullptr &&  // filter disabled entries where type is void
+        !::onnxruntime::cuda::IsCudaKernelDisabledByType(*info.kernel_def)) {
       ORT_RETURN_IF_ERROR(kernel_registry.Register(std::move(info)));
     }
   }

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -391,6 +391,8 @@ def generate_build_tree(
     disable_optional_type = "optional" in types_to_disable
     disable_sparse_tensors = "sparsetensor" in types_to_disable
     disable_string_type = "string" in types_to_disable
+    # enable/disable double (float64) CUDA kernels
+    disable_double_type = "double" in types_to_disable
     if is_windows():
         cmake_args += [
             "-Donnxruntime_USE_DML=" + ("ON" if args.use_dml else "OFF"),
@@ -528,6 +530,7 @@ def generate_build_tree(
         "-Donnxruntime_USE_CANN=" + ("ON" if args.use_cann else "OFF"),
         "-Donnxruntime_DISABLE_FLOAT8_TYPES=" + ("ON" if disable_float8_types else "OFF"),
         "-Donnxruntime_DISABLE_FLOAT4_TYPES=" + ("ON" if disable_float4_types else "OFF"),
+        "-Donnxruntime_DISABLE_DOUBLE_TYPE=" + ("ON" if disable_double_type else "OFF"),
         "-Donnxruntime_DISABLE_SPARSE_TENSORS=" + ("ON" if disable_sparse_tensors else "OFF"),
         "-Donnxruntime_DISABLE_OPTIONAL_TYPE=" + ("ON" if disable_optional_type else "OFF"),
         "-Donnxruntime_DISABLE_STRING_TYPE=" + ("ON" if disable_string_type else "OFF"),

--- a/tools/ci_build/build_args.py
+++ b/tools/ci_build/build_args.py
@@ -562,7 +562,7 @@ def add_size_reduction_args(parser: argparse.ArgumentParser) -> None:
         "--disable_types",
         nargs="+",
         default=[],
-        choices=["float4", "float8", "optional", "sparsetensor", "string"],
+        choices=["float4", "float8", "double", "optional", "sparsetensor", "string"],
         help="Disable selected data types.",
     )
     parser.add_argument(


### PR DESCRIPTION
# Add `--disable_types double` build option to drop double (float64) CUDA kernels

## Summary

Adds a build-time data-type filter that removes `double` (float64) kernels from the CUDA Execution Provider to reduce binary size. The new `--disable_types double` option works for **both** the in-tree CUDA EP and the CUDA plugin EP through a registration-time filter, so no per-kernel source edits are required. This is **Stage 1** of a two-stage effort (Stage 2 will add an operator allow-list).

## Motivation

CUDA EP binary size is dominated by many typed kernel instantiations. `double` is rarely needed for GPU inference, so making it a configurable build option lets size-sensitive deployments drop those kernels. The existing `--enable_reduced_operator_type_support` path is model-config driven and does not apply to the plugin EP, which auto-registers kernels; a simple, model-independent build switch is needed that covers both EP flavors.

## Key Changes

| Area | File(s) | Change |
|---|---|---|
| Build args | `tools/ci_build/build_args.py` | Add `double` to `--disable_types` choices |
| Build wiring | `tools/ci_build/build.py` | Map `double` → `-Donnxruntime_DISABLE_DOUBLE_TYPE` |
| CMake option | `cmake/CMakeLists.txt` | New `onnxruntime_DISABLE_DOUBLE_TYPE` option; define `DISABLE_DOUBLE_TYPE` for in-tree targets |
| CMake (plugin) | `cmake/onnxruntime_providers_cuda_plugin.cmake` | Define `DISABLE_DOUBLE_TYPE` for the plugin target |
| In-tree filter | `onnxruntime/core/providers/cuda/cuda_kernel_build_config.h` (new) | `IsCudaKernelDisabledByType()` — drops kernels whose type constraint is satisfiable only by `double` |
| In-tree hooks | `cuda_execution_provider.cc`, `cuda_contrib_kernels.cc`, `cuda_nhwc_kernels.cc`, `cuda_training_kernels.cc` | Apply the filter in every kernel-registration loop |
| Provider bridge | `provider_interfaces.h`, `provider_wrappedtypes.h`, `provider_bridge_ort.cc` | Expose `KernelDef::TypeConstraints()` across the shared-provider bridge |
| Plugin filter | `include/onnxruntime/ep/adapter/kernel_def_builder.h` | `double`-only `TypeConstraint` sets the def invalid → `Build()` returns null → skipped |

## Mechanism

- **In-tree CUDA EP** (shared-provider bridge): the wrapped `KernelDef` previously exposed only `OpName`/`Domain`/`SinceVersion`, so `TypeConstraints()` was added to the bridge. The registration loops now skip any kernel whose type constraint can only be satisfied by `double`.
- **CUDA plugin EP**: its registration loop only sees an opaque `Ort::KernelDef`, so the filter lives in the adapter `KernelDefBuilder`. A `double`-only constraint marks the def invalid and `Build()` returns a null `KernelDef`, which the existing loop already skips. (A compile-time gate on the macro token was intentionally avoided because tokens like `double_double` in `ONNX_OPERATOR_TYPED_KERNEL_EX` are not valid C++ types.)

When `DISABLE_DOUBLE_TYPE` is not defined (default builds), the filter is a no-op and behavior is unchanged.

## Scope / Follow-up

- This removes the kernel **registration/dispatch** uniformly across both EPs. Reclaiming the dropped kernels' **device code** additionally relies on linker dead-code elimination (`--gc-sections`) or source exclusion; that size optimization is intentionally out of scope for Stage 1.
- **Stage 2** (separate PR): operator allow-list (same registration filter keyed on op name/domain, plus plugin CMake source exclusion) and fusion-awareness (skip CUDA graph transformers that produce excluded ops).

## Testing Notes

- Build with `--use_cuda --disable_types double` and confirm the build succeeds and a `double` CUDA op falls back to CPU (i.e., is no longer claimed by the CUDA EP).
- Default builds (without the flag) are unaffected — the filter compiles out.
- Recommended: add a CI leg exercising `--disable_types double` for both the in-tree and plugin CUDA builds.
