### PR TITLE
[WebGPU EP] Support int64 Clip via a dedicated ClipInt64 kernel

### DIFF
--- a/onnxruntime/core/providers/webgpu/math/unary_elementwise_ops.cc
+++ b/onnxruntime/core/providers/webgpu/math/unary_elementwise_ops.cc
@@ -229,6 +229,80 @@ class Clip final : public UnaryElementwise {
   // uniforms.attr[0] is clip_min, uniforms.attr[1] is clip_max
   constexpr static const char ClipImpl[] = "clamp(a, vec4<x_element_t>(bitcast<x_element_t>(uniforms.attr[0])), vec4<x_element_t>(bitcast<x_element_t>(uniforms.attr[1])))";
 };
+
+// Clip for int64 tensors. WebGPU has no native 64-bit integer type; the EP stores int64 as
+// vec2<u32> but, by convention, reads/writes it as the truncated low 32 bits interpreted as i32
+// (see shader_variable.cc GetByOffset/SetByOffset for Int64). Because Clip is monotonic, clamping
+// the truncated value and sign-extending on write is consistent with that existing int64 handling
+// and correct for the index/position ranges that use int64 Clip in practice. The 4-byte-only
+// templated Clip above (sizeof(T)==sizeof(float) static_assert) cannot cover int64, so it gets a
+// dedicated one-element-per-invocation program here.
+class ClipInt64Program final : public Program<ClipInt64Program> {
+ public:
+  ClipInt64Program() : Program{"ClipInt64"} {}
+
+  Status GenerateShaderCode(ShaderHelper& sh) const override {
+    const auto& input = sh.AddInput("x", ShaderUsage::UseUniform);
+    const auto& output = sh.AddOutput("y", ShaderUsage::UseUniform);
+    sh.MainFunctionBody() << sh.GuardAgainstOutOfBoundsWorkgroupSizes("uniforms.vec_size")
+                          << "  let a = " << input.GetByOffset("global_idx") << ";\n"
+                          << "  let clamped = min(max(a, uniforms.clip_min), uniforms.clip_max);\n  "
+                          << output.SetByOffset("global_idx", "clamped");
+    return Status::OK();
+  }
+
+  WEBGPU_PROGRAM_DEFINE_UNIFORM_VARIABLES({"vec_size", ProgramUniformVariableDataType::Uint32},
+                                          {"clip_min", ProgramUniformVariableDataType::Int32},
+                                          {"clip_max", ProgramUniformVariableDataType::Int32});
+};
+
+class ClipInt64 final : public WebGpuKernel {
+ public:
+  ClipInt64(const OpKernelInfo& info) : WebGpuKernel{info} {}
+
+  Status ComputeInternal(ComputeContext& context) const override {
+    const auto* input_tensor = context.Input(0);
+    auto* output_tensor = context.Output(0, input_tensor->Shape());
+    int64_t size = input_tensor->Shape().Size();
+    if (size == 0) {
+      return Status::OK();
+    }
+
+    // min/max arrive as CPU scalar inputs (see InputMemoryType below). Saturate them into the i32
+    // range that the shader operates on: values live in the low 32 bits, so an out-of-i32-range
+    // bound simply means "no clamp on that side".
+    constexpr int64_t kI32Min = std::numeric_limits<int32_t>::lowest();
+    constexpr int64_t kI32Max = std::numeric_limits<int32_t>::max();
+    const auto* clip_min_tensor = context.Input<Tensor>(1);
+    const auto* clip_max_tensor = context.Input<Tensor>(2);
+    auto saturate_to_i32 = [](int64_t v) -> int32_t {
+      return static_cast<int32_t>(v < kI32Min ? kI32Min : (v > kI32Max ? kI32Max : v));
+    };
+    int32_t clip_min = clip_min_tensor ? saturate_to_i32(clip_min_tensor->Data<int64_t>()[0])
+                                       : static_cast<int32_t>(kI32Min);
+    int32_t clip_max = clip_max_tensor ? saturate_to_i32(clip_max_tensor->Data<int64_t>()[0])
+                                       : static_cast<int32_t>(kI32Max);
+
+    // The shader carries the element count in a u32 uniform, so validate the range explicitly and
+    // return INVALID_ARGUMENT rather than letting narrow<uint32_t> hard-terminate the process in
+    // ORT_NO_EXCEPTIONS builds (as the WebGPU EP is typically built).
+    if (size > static_cast<int64_t>(std::numeric_limits<uint32_t>::max())) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "ClipInt64 input has ", size,
+                             " elements, which exceeds the WebGPU supported maximum of ",
+                             std::numeric_limits<uint32_t>::max(), ".");
+    }
+    uint32_t data_size = static_cast<uint32_t>(size);
+    ClipInt64Program program{};
+    // Uniform values are positional: this order must match the WEBGPU_PROGRAM_DEFINE_UNIFORM_VARIABLES
+    // declaration on ClipInt64Program (vec_size, clip_min, clip_max).
+    program.AddInput({input_tensor, ProgramTensorMetadataDependency::Type, {size}, 1})
+        .AddOutput({output_tensor, ProgramTensorMetadataDependency::None, {size}, 1})
+        .SetDispatchGroupSize((data_size + WORKGROUP_SIZE - 1) / WORKGROUP_SIZE)
+        .AddUniformVariables({{data_size}, {clip_min}, {clip_max}});
+    return context.RunProgram(program);
+  }
+};
+
 #define WEBGPU_CLIP_KERNEL(TYPE)                                                                        \
   ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(Clip, kOnnxDomain, 11, 11, TYPE, kWebGpuExecutionProvider,    \
                                           KernelDefBuilder()                                            \
@@ -248,8 +322,29 @@ class Clip final : public UnaryElementwise {
                                     .InputMemoryType(OrtMemTypeCPU, 1)                                  \
                                     .InputMemoryType(OrtMemTypeCPU, 2),                                 \
                                 Clip<TYPE>);
+
+// int64 Clip uses the dedicated ClipInt64 kernel (defined above), not the 4-byte templated Clip.
+// int64 (like all integer types) is only a valid Clip element type from opset 12 on -- the opset-11
+// Clip schema constrains T to float types only -- so there is no 11-11 registration here.
+#define WEBGPU_CLIP_INT64_KERNEL()                                                                         \
+  ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(Clip, kOnnxDomain, 12, 12, int64_t, kWebGpuExecutionProvider,    \
+                                          KernelDefBuilder()                                               \
+                                              .TypeConstraint("T", DataTypeImpl::GetTensorType<int64_t>()) \
+                                              .InputMemoryType(OrtMemTypeCPU, 1)                           \
+                                              .InputMemoryType(OrtMemTypeCPU, 2),                          \
+                                          ClipInt64)                                                       \
+  ONNX_OPERATOR_TYPED_KERNEL_EX(Clip, kOnnxDomain, 13, int64_t, kWebGpuExecutionProvider,                  \
+                                KernelDefBuilder()                                                         \
+                                    .TypeConstraint("T", DataTypeImpl::GetTensorType<int64_t>())           \
+                                    .InputMemoryType(OrtMemTypeCPU, 1)                                     \
+                                    .InputMemoryType(OrtMemTypeCPU, 2),                                    \
+                                ClipInt64);
+
 WEBGPU_CLIP_KERNEL(float)
 WEBGPU_CLIP_KERNEL(MLFloat16)
+// int64 Clip (e.g. an int64 Clip on an index/position path feeding ArgMax) is handled by the
+// dedicated ClipInt64 kernel above; the 4-byte templated Clip cannot cover int64.
+WEBGPU_CLIP_INT64_KERNEL()
 
 //
 // activation

--- a/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
@@ -147,6 +147,8 @@ static const BuildKernelCreateInfoFn build_kernel_create_info_function_table[] =
     BuildKernelCreateInfo<class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 11, 11, MLFloat16, Clip)>,
     BuildKernelCreateInfo<class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 12, 12, MLFloat16, Clip)>,
     BuildKernelCreateInfo<class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 13, MLFloat16, Clip)>,
+    BuildKernelCreateInfo<class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 12, 12, int64_t, Clip)>,
+    BuildKernelCreateInfo<class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 13, int64_t, Clip)>,
     KERNEL_CREATE_INFO(6, Elu),
     KERNEL_CREATE_INFO_VERSIONED(6, 12, Relu),
     KERNEL_CREATE_INFO_VERSIONED(13, 13, Relu),

--- a/onnxruntime/test/providers/cpu/math/clip_test.cc
+++ b/onnxruntime/test/providers/cpu/math/clip_test.cc
@@ -219,6 +219,125 @@ TEST(MathOpTest, Clip_uint32) {
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
 }
 
+// int64 Clip, run explicitly on the WebGPU EP. WebGPU has no native 64-bit integer type; the EP
+// stores int64 as vec2<u32> and the dedicated ClipInt64 kernel clamps on the truncated low 32 bits
+// (interpreted as i32), then sign-extends on write. Values are kept within the int32 range -- the
+// realistic index/position case and where the truncated clamp matches the reference result.
+TEST(MathOpTest, Clip_int64_WebGpu) {
+  auto webgpu_ep = DefaultWebGpuExecutionProvider();
+  if (webgpu_ep == nullptr) {
+    GTEST_SKIP() << "WebGPU EP is not available in this build.";
+  }
+
+  OpTester test("Clip", 13);
+
+  std::vector<int64_t> dims{3, 3};
+  test.AddInput<int64_t>("X", dims,
+                         {-1, 0, 1,
+                          -16, 12, -6,
+                          -5, 2, 16});
+  test.AddInput<int64_t>("min", {}, {-10});
+  test.AddInput<int64_t>("max", {}, {10});
+  test.AddOutput<int64_t>("Y", dims,
+                          {-1, 0, 1,
+                           -10, 10, -6,
+                           -5, 2, 10});
+
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(std::move(webgpu_ep));
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+}
+
+// int64 Clip on WebGPU with min/max OUTSIDE the int32 range. ClipInt64 saturates the bounds into
+// the i32 range the shader operates on, so an out-of-i32-range min/max means "no clamp on that
+// side" -- the data (all within int32 range here) must pass through unchanged. Without saturation
+// the raw int64 bounds would be truncated to bogus i32 values and clamp incorrectly, so this pins
+// the saturate_to_i32 behavior.
+TEST(MathOpTest, Clip_int64_saturate_WebGpu) {
+  auto webgpu_ep = DefaultWebGpuExecutionProvider();
+  if (webgpu_ep == nullptr) {
+    GTEST_SKIP() << "WebGPU EP is not available in this build.";
+  }
+
+  OpTester test("Clip", 13);
+
+  std::vector<int64_t> dims{3, 3};
+  test.AddInput<int64_t>("X", dims,
+                         {-2147483648, -1000, -1,
+                          0, 1, 1000,
+                          2147483647, 42, -42});
+  // -5000000000 < INT32_MIN and 5000000000 > INT32_MAX; both saturate to the i32 limits.
+  test.AddInput<int64_t>("min", {}, {-5000000000LL});
+  test.AddInput<int64_t>("max", {}, {5000000000LL});
+  test.AddOutput<int64_t>("Y", dims,
+                          {-2147483648, -1000, -1,
+                           0, 1, 1000,
+                           2147483647, 42, -42});
+
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(std::move(webgpu_ep));
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+}
+
+// int64 Clip on WebGPU at opset 12 with only the optional `min` input present (max omitted). This
+// exercises two paths the opset-13 tests above do not: the opset 12-12 kernel registration, and the
+// clip_max_tensor == nullptr branch in ClipInt64 (a missing bound means "no clamp on that side", so
+// max defaults to INT32_MAX). Only the lower bound is applied; values above min pass through.
+// (Opset 12 is the earliest at which integer Clip is valid; opset 11 constrains T to float types.)
+TEST(MathOpTest, Clip_int64_min_only_opset12_WebGpu) {
+  auto webgpu_ep = DefaultWebGpuExecutionProvider();
+  if (webgpu_ep == nullptr) {
+    GTEST_SKIP() << "WebGPU EP is not available in this build.";
+  }
+
+  OpTester test("Clip", 12);
+
+  std::vector<int64_t> dims{3, 3};
+  test.AddInput<int64_t>("X", dims,
+                         {-1, 0, 1,
+                          -16, 12, -6,
+                          -5, 2, 16});
+  test.AddInput<int64_t>("min", {}, {-10});
+  // max omitted: no upper clamp.
+  test.AddOutput<int64_t>("Y", dims,
+                          {-1, 0, 1,
+                           -10, 12, -6,
+                           -5, 2, 16});
+
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(std::move(webgpu_ep));
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+}
+
+// Symmetric to the min-only test above: int64 Clip on WebGPU at opset 12 with only the optional
+// `max` input present (min omitted). This covers the clip_min_tensor == nullptr branch in ClipInt64
+// (a missing lower bound means "no clamp on that side", so min defaults to INT32_MIN). Only the
+// upper bound is applied; values below max pass through.
+TEST(MathOpTest, Clip_int64_max_only_opset12_WebGpu) {
+  auto webgpu_ep = DefaultWebGpuExecutionProvider();
+  if (webgpu_ep == nullptr) {
+    GTEST_SKIP() << "WebGPU EP is not available in this build.";
+  }
+
+  OpTester test("Clip", 12);
+
+  std::vector<int64_t> dims{3, 3};
+  test.AddInput<int64_t>("X", dims,
+                         {-1, 0, 1,
+                          -16, 12, -6,
+                          -5, 2, 16});
+  test.AddOptionalInputEdge<int64_t>();  // no min
+  test.AddInput<int64_t>("max", {}, {10});
+  test.AddOutput<int64_t>("Y", dims,
+                          {-1, 0, 1,
+                           -16, 10, -6,
+                           -5, 2, 10});
+
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(std::move(webgpu_ep));
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+}
+
 TEST(MathOpTest, Clip) {
   // To test NNAPI EP, we need the min/max to be in initializers
   auto run_test = [](bool min_max_are_initializer) {


### PR DESCRIPTION
Add a ClipInt64 kernel/shader for opsets 12-12 and 13, so int64 Clip stops falling back to the CPU EP (which aborts session init under the compile-only flow). int64 (like all integer types) is only a valid Clip element type from opset 12 on -- the opset-11 Clip schema constrains T to float types -- so there is no 11-11 registration.

The WebNN-inserted index Clip before ArgMax in the SD-Turbo text encoder is int64. The 4-byte templated Clip cannot cover it (sizeof(T)==sizeof(float) static_assert). WebGPU has no native 64-bit integer type; the EP stores int64 as vec2<u32> and operates on the truncated low 32 bits as i32 (shader_variable.cc GetByOffset/SetByOffset). Because Clip is monotonic, ClipInt64 clamps that i32 value (min/max saturated into the i32 range) and sign-extends on write, consistent with the EP's existing int64 semantics.

This is a split CL from https://github.com/microsoft/onnxruntime/pull/29682 to fix part of  https://github.com/microsoft/onnxruntime/issues/29756

