### PR TITLE
[MLAS] Add ARM64 NEON fp32 RoPE kernel

### DIFF
--- a/onnxruntime/core/mlas/lib/rotary_embedding_kernel_neon.cpp
+++ b/onnxruntime/core/mlas/lib/rotary_embedding_kernel_neon.cpp
@@ -14,14 +14,127 @@ Abstract:
 
 --*/
 
+#include <cassert>
+
 #include "rotary_embedding.h"
 #include "rotary_embedding_kernel_neon.h"
+
+namespace {
+
+template <bool interleaved>
+void
+RopeKernel_Fp32_Impl(
+    const float* input,
+    const float* sin,
+    const float* cos,
+    size_t dim,
+    float* output
+);
+
+template <>
+void
+RopeKernel_Fp32_Impl<false>(
+    const float* input,
+    const float* sin,
+    const float* cos,
+    size_t dim,
+    float* output
+) {
+    const size_t half_dim = dim >> 1;
+    size_t i = 0, j = half_dim;
+
+    for (; i + 3 < half_dim; i += 4, j += 4) {
+        float32x4_t real = vld1q_f32(input + i);
+        float32x4_t imag = vld1q_f32(input + j);
+        float32x4_t sin_val = vld1q_f32(sin + i);
+        float32x4_t cos_val = vld1q_f32(cos + i);
+
+        float32x4_t real_out = vfmsq_f32(vmulq_f32(real, cos_val), imag, sin_val);
+        float32x4_t imag_out = vfmaq_f32(vmulq_f32(real, sin_val), imag, cos_val);
+
+        vst1q_f32(output + i, real_out);
+        vst1q_f32(output + j, imag_out);
+    }
+
+    for (; i < half_dim; i++, j++) {
+        float real = input[i];
+        float imag = input[j];
+        float sin_val = sin[i];
+        float cos_val = cos[i];
+        output[i] = real * cos_val - imag * sin_val;
+        output[j] = real * sin_val + imag * cos_val;
+    }
+}
+
+template <>
+void
+RopeKernel_Fp32_Impl<true>(
+    const float* input,
+    const float* sin,
+    const float* cos,
+    size_t dim,
+    float* output
+) {
+    size_t i = 0;
+
+    for (; i + 7 < dim; i += 8) {
+        float32x4x2_t v = vld2q_f32(input + i);
+        float32x4_t real = v.val[0];
+        float32x4_t imag = v.val[1];
+
+        float32x4_t sin_val = vld1q_f32(sin + i / 2);
+        float32x4_t cos_val = vld1q_f32(cos + i / 2);
+
+        float32x4_t real_out = vfmsq_f32(vmulq_f32(real, cos_val), imag, sin_val);
+        float32x4_t imag_out = vfmaq_f32(vmulq_f32(real, sin_val), imag, cos_val);
+
+        float32x4x2_t out;
+        out.val[0] = real_out;
+        out.val[1] = imag_out;
+        vst2q_f32(output + i, out);
+    }
+
+    for (; i + 1 < dim; i += 2) {
+        size_t cache_idx = i / 2;
+        float in0 = input[i];
+        float in1 = input[i + 1];
+        float sin_val = sin[cache_idx];
+        float cos_val = cos[cache_idx];
+        output[i] = in0 * cos_val - in1 * sin_val;
+        output[i + 1] = in0 * sin_val + in1 * cos_val;
+    }
+}
+
+}  // namespace
+
+namespace rope_neon {
+
+void
+RopeKernel_Fp32(
+    const float* input,
+    const float* sin,
+    const float* cos,
+    size_t dim,
+    bool interleaved,
+    float* output
+) {
+    assert(dim % 2 == 0);
+    if (interleaved) {
+        RopeKernel_Fp32_Impl<true>(input, sin, cos, dim, output);
+    } else {
+        RopeKernel_Fp32_Impl<false>(input, sin, cos, dim, output);
+    }
+}
+
+}  // namespace rope_neon
 
 //
 // Kernel dispatch structure definition.
 //
 const MLAS_ROPE_DISPATCH MlasRopeDispatchNeon = []() {
     MLAS_ROPE_DISPATCH d;
+
+    d.SRope = rope_neon::RopeKernel_Fp32;
 
 #if defined(MLAS_F16VEC_INTRINSICS_SUPPORTED) && defined(MLAS_TARGET_ARM64)
     if (MlasFp16AccelerationSupported()) {

--- a/onnxruntime/core/mlas/lib/rotary_embedding_kernel_neon.h
+++ b/onnxruntime/core/mlas/lib/rotary_embedding_kernel_neon.h
@@ -23,6 +23,17 @@ Abstract:
 
 namespace rope_neon {
 
+// Rotary embedding kernel for fp32. Embed one hidden state vector.
+void
+RopeKernel_Fp32(
+    const float* input,
+    const float* sin,
+    const float* cos,
+    size_t dim,
+    bool interleaved,
+    float* output
+);
+
 // Rotary embedding kernel for fp16. Embed one hidden state vector.
 void
 RopeKernel_Fp16(

--- a/onnxruntime/test/mlas/unittest/test_rope.cpp
+++ b/onnxruntime/test/mlas/unittest/test_rope.cpp
@@ -128,7 +128,7 @@ class RoPEShortExecuteTest : public MlasTestFixture<MlasRoPETest<T>> {
 #if defined(MLAS_TARGET_AMD64) || (defined(MLAS_TARGET_RISCV64) && defined(MLAS_USE_RVV)) || defined(MLAS_TARGET_ARM64)
 static size_t RoPERegisterAllShortExecuteTests() {
   size_t tests_registered = RoPEShortExecuteTest<float>::RegisterShortExecuteTests();
-// fp16 RoPE on ARM64 already has dedicated coverage in test_rope_neon_fp16.cpp.
+  // fp16 RoPE on ARM64 already has dedicated coverage in test_rope_neon_fp16.cpp.
 #if defined(MLAS_TARGET_AMD64) || (defined(MLAS_TARGET_RISCV64) && defined(MLAS_USE_RVV))
   tests_registered += RoPEShortExecuteTest<MLFloat16>::RegisterShortExecuteTests();
 #endif

--- a/onnxruntime/test/mlas/unittest/test_rope.cpp
+++ b/onnxruntime/test/mlas/unittest/test_rope.cpp
@@ -125,9 +125,14 @@ class RoPEShortExecuteTest : public MlasTestFixture<MlasRoPETest<T>> {
 };
 
 // Enable RoPE tests on platforms where RopeDispatch is assigned.
-#if defined(MLAS_TARGET_AMD64) || (defined(MLAS_TARGET_RISCV64) && defined(MLAS_USE_RVV))
+#if defined(MLAS_TARGET_AMD64) || (defined(MLAS_TARGET_RISCV64) && defined(MLAS_USE_RVV)) || defined(MLAS_TARGET_ARM64)
 static size_t RoPERegisterAllShortExecuteTests() {
-  return RoPEShortExecuteTest<float>::RegisterShortExecuteTests() + RoPEShortExecuteTest<MLFloat16>::RegisterShortExecuteTests();
+  size_t tests_registered = RoPEShortExecuteTest<float>::RegisterShortExecuteTests();
+// fp16 RoPE on ARM64 already has dedicated coverage in test_rope_neon_fp16.cpp.
+#if defined(MLAS_TARGET_AMD64) || (defined(MLAS_TARGET_RISCV64) && defined(MLAS_USE_RVV))
+  tests_registered += RoPEShortExecuteTest<MLFloat16>::RegisterShortExecuteTests();
+#endif
+  return tests_registered;
 }
 
 static UNUSED_VARIABLE bool added_to_main = AddTestRegister(


### PR DESCRIPTION
## Summary

ARM64 has no NEON implementation for fp32 rotary embedding. `MlasRopeDispatchNeon` only ever assigns `HRope`, and only when FP16 vector acceleration is available; `SRope` is never assigned, so `MlasRotaryEmbedOneRow<float>` always falls back to the scalar reference implementation on ARM64 regardless of hardware. `test_rope.cpp`'s shared test registration guard reflects this too, excluding `MLAS_TARGET_ARM64` entirely.

This adds a NEON fp32 kernel (`RopeKernel_Fp32`, non-interleaved and interleaved variants) to `rotary_embedding_kernel_neon.cpp`/`.h` and assigns it to `d.SRope` unconditionally in `MlasRopeDispatchNeon`, outside the `MlasFp16AccelerationSupported()` guard since fp32 doesn't depend on FP16 vector support. The interleaved path uses `vld2q_f32`/`vst2q_f32` to deinterleave/reinterleave the real/imag pairs directly, instead of the shuffle/permute sequence the AVX2 implementation uses for the same case.

`test_rope.cpp`'s ARM64 guard now registers the existing 14 fp32 cases (dim 6/16/24/32/42/64/70 x interleaved). The fp16 half of that guard is left AMD64/RVV-only, since ARM64 fp16 already has its own dedicated coverage in `test_rope_neon_fp16.cpp` — this change is scoped to fp32 only.

## Testing

`onnxruntime_mlas_test`, full suite, no regressions:
- Apple M1 (macOS): 27975/27975 passed
- Neoverse-N1 (Oracle Cloud A1, Ubuntu): 34769/34769 passed

`RoPE_fp32/*`: 14/14 passed on both.

## Benchmark (Neoverse-N1, Oracle Cloud A1, median of 3 runs, `RoPE<float>`)

| dim  | interleaved | before (scalar) | after (NEON) | speedup |
|------|-------------|-----------------|--------------|---------|
| 128  | no  | 514 ns  | 24.4 ns | 21.1x |
| 256  | no  | 1028 ns | 43.1 ns | 23.9x |
| 512  | no  | 2067 ns | 80.6 ns | 25.6x |
| 1024 | no  | 4161 ns | 156 ns  | 26.7x |
| 128  | yes | 264 ns  | 44.4 ns | 5.9x  |
| 256  | yes | 521 ns  | 85.0 ns | 6.1x  |
| 512  | yes | 1035 ns | 165 ns  | 6.3x  |
| 1024 | yes | 2064 ns | 329 ns  | 6.3x  |

Numbers are from Neoverse-N1 only; it's a dedicated instance and gives a cleaner signal than a shared laptop.
