### PR TITLE
[MLAS] Quantize fp16 activations directly on the AVX-512 MatMulNBits CompInt8 path

### DIFF
--- a/onnxruntime/core/mlas/lib/sqnbitgemm_kernel_avx512.cpp
+++ b/onnxruntime/core/mlas/lib/sqnbitgemm_kernel_avx512.cpp
@@ -425,6 +425,105 @@ QuantizeARow_CompInt8_avx512(
     }
 }
 
+// Load n (<= 16) fp16 values and widen to float, zero-filling the unused lanes so the
+// max-abs and block-sum reductions see the same trailing zeros a float A row would. This
+// is the 16-wide sibling of load_fp16_n_avx2 used by the AVX-512 quantizer below.
+MLAS_FORCEINLINE __m512
+load_fp16_16_avx512(const MLAS_FP16* data, int n)
+{
+    assert(n <= 16);
+    if (n <= 0) {
+        return _mm512_setzero_ps();
+    }
+    if (n == 16) {
+        return _mm512_cvtph_ps(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(data)));
+    }
+    uint16_t bits[16] = {};
+    memcpy(bits, data, static_cast<size_t>(n) * sizeof(uint16_t));
+    return _mm512_cvtph_ps(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(bits)));
+}
+
+// fp16-input twin of QuantizeARow_CompInt8_avx512. Widens each fp16 A element to float
+// and runs the identical quantize + block-sum arithmetic, so the output (int8 data,
+// per-block scale, scale * sum(a_i)) is bit-for-bit what the float quantizer produces
+// from the same values converted fp16 -> fp32 first. Lets the fp16 MatMulNBits path
+// quantize A in one pass with no fp32 activation copy.
+void MLASCALL
+QuantizeARow_CompInt8_Fp16_avx512(
+    size_t BlkLen,
+    const MLAS_FP16* A,
+    size_t CountK,
+    std::byte* QuantA,
+    float* QuantAScale,
+    float* AScaledBlkSum  // scale_k * Sum_blklen(a_i)
+)
+{
+    assert(BlkLen % 16 == 0);
+    const __m512 signBit = _mm512_set1_ps(-0.0f);
+    const __m256i one_16_epi16 = _mm256_set1_epi16(1);
+    int8_t* blob = reinterpret_cast<int8_t*>(QuantA);
+    float* scale_ptr = QuantAScale;
+    for (size_t k = 0; k < CountK; k += BlkLen) {
+        const size_t step = std::min(BlkLen, CountK - k);
+
+        __m512 maxAbs = _mm512_setzero_ps();
+        for (size_t kk = 0; kk < step; kk += 16) {
+            const size_t klen = std::min(size_t(16), step - kk);
+
+            __m512 v0 = load_fp16_16_avx512(A + k + kk, static_cast<int>(klen));
+
+            // Compute max(abs(e)) for the block
+            maxAbs = _mm512_max_ps(maxAbs, _mm512_andnot_ps(signBit, v0));
+        }
+
+        __m256 max8 =
+            _mm256_max_ps(_mm512_extractf32x8_ps(maxAbs, 1), _mm512_extractf32x8_ps(maxAbs, 0));
+        __m128 max4 = _mm_max_ps(_mm256_extractf128_ps(max8, 1), _mm256_castps256_ps128(max8));
+        max4 = _mm_max_ps(max4, _mm_movehl_ps(max4, max4));
+        max4 = _mm_max_ss(max4, _mm_movehdup_ps(max4));
+        const float maxScalar = _mm_cvtss_f32(max4);
+
+        // Quantize these floats
+        const float scale = maxScalar / 127.f;
+        *scale_ptr = scale;
+        scale_ptr++;
+
+        const float inverse_scale = (maxScalar != 0.0f) ? 127.f / maxScalar : 0.0f;
+        const __m512 mul = _mm512_set1_ps(inverse_scale);
+        __m128i* dst = reinterpret_cast<__m128i*>(blob);
+
+        __m256i sum_16_epi16 = _mm256_setzero_si256();
+        for (size_t kk = 0; kk < step; kk += 16) {
+            const size_t klen = std::min(size_t(16), step - kk);
+
+            __m512 v0 = load_fp16_16_avx512(A + k + kk, static_cast<int>(klen));
+            v0 = _mm512_mul_ps(v0, mul);
+
+            // Round to nearest integer
+            v0 = _mm512_roundscale_ps(v0, _MM_ROUND_NEAREST);
+
+            // Convert floats to integers
+            __m512i i0 = _mm512_cvtps_epi32(v0);
+
+            // Convert int32 to int8
+            __m128i i0_8 = _mm512_cvtepi32_epi8(i0);
+            _mm_storeu_si128(dst++, i0_8);
+
+            // accumulate Sum(a_i)
+            __m256i i_16_epi16 = _mm256_cvtepi8_epi16(i0_8);
+            sum_16_epi16 = _mm256_hadds_epi16(sum_16_epi16, i_16_epi16);
+        }
+        if (step < BlkLen) {
+            memset(blob + step, 0, BlkLen - step);
+        }
+
+        const __m256i sum_8_epi32 = _mm256_madd_epi16(one_16_epi16, sum_16_epi16);
+        *AScaledBlkSum = scale * hsum_8_epi32(sum_8_epi32);
+        AScaledBlkSum++;
+        blob += BlkLen;
+    }
+}
+
 static void
 SQ4BitGemmPackQuantBDataAndBlkSum512(
     size_t N,
@@ -538,6 +637,7 @@ const MLAS_QNBIT_GEMM_DISPATCH MlasSQNBitGemmDispatchAvx512 = []() {
     d.SQ4BitGemmKernel_BlkSum_CompInt8 = SQ4BitGemmKernel_BlkSum_CompInt8_avx512;
     d.SQ8BitGemmKernel_BlkSum_CompInt8 = SQ8BitGemmKernel_BlkSum_CompInt8_avx512;
     d.QuantizeARowComputeBlkSum_CompInt8 = QuantizeARow_CompInt8_avx512;
+    d.QuantizeARowComputeBlkSum_CompInt8_Fp16 = QuantizeARow_CompInt8_Fp16_avx512;
 
     // 2-bit native CompInt8 path. Single dispatch entry (W2):
     // 64-byte ZMM load + four fixed shift/mask pairs to unpack 4 K-blocks at

--- a/onnxruntime/core/mlas/lib/sqnbitgemm_kernel_avx512vnni.cpp
+++ b/onnxruntime/core/mlas/lib/sqnbitgemm_kernel_avx512vnni.cpp
@@ -407,6 +407,16 @@ QuantizeARow_CompInt8_avx512(
     float* AScaledBlkSum  // scale_k * Sum_blklen(a_i)
 );
 
+void MLASCALL
+QuantizeARow_CompInt8_Fp16_avx512(
+    size_t BlkLen,
+    const MLAS_FP16* A,
+    size_t CountK,
+    std::byte* QuantA,
+    float* QuantAScale,
+    float* AScaledBlkSum  // scale_k * Sum_blklen(a_i)
+);
+
 static void
 SQ4BitGemmPackQuantBDataAndBlkSum512vnni(
     size_t N,
@@ -523,6 +533,7 @@ const MLAS_QNBIT_GEMM_DISPATCH MlasSQNBitGemmDispatchAvx512vnni = []() {
     d.SQ4BitGemmKernel_BlkSum_CompInt8 = SQ4BitGemmKernel_BlkSum_CompInt8_avx512vnni;
     d.SQ8BitGemmKernel_BlkSum_CompInt8 = SQ8BitGemmKernel_BlkSum_CompInt8_avx512vnni;
     d.QuantizeARowComputeBlkSum_CompInt8 = QuantizeARow_CompInt8_avx512;
+    d.QuantizeARowComputeBlkSum_CompInt8_Fp16 = QuantizeARow_CompInt8_Fp16_avx512;
 
     // 2-bit native CompInt8 path. Single dispatch entry (W2):
     // 64-byte ZMM load + four fixed shift/mask pairs to unpack 4 K-blocks at


### PR DESCRIPTION
### Description
Adds `QuantizeARow_CompInt8_Fp16_avx512`, the fp16-input twin of `QuantizeARow_CompInt8_avx512`: it loads 16 fp16 elements and widens them with `_mm512_cvtph_ps`, then runs the identical max-abs, scale, round, and block-sum arithmetic. It uses no intrinsic beyond what the float quantizer already uses on this tier, so its output (block int8 data, per-block scale, and `scale * sum(a_i)`) is bit-for-bit what the float quantizer produces from the same values converted fp16 to fp32 first. It is wired into both `MlasSQNBitGemmDispatchAvx512` and `MlasSQNBitGemmDispatchAvx512vnni`; the VNNI table reuses the same function, the way it already reuses the float quantizer. `test_sqnbitgemm_fp16_quant_a.cpp` already covers this: it self-gates on `MlasQNBitGemmFp16DirectQuantASupported()`, so with this change it runs on AVX-512 and checks that the fp16 `A` path gives byte-identical GEMM output to the fp32-first path across 2, 4, and 8 bit, block lengths 16 through 256, M through 129 (the threaded and the single-threaded quantize paths), symmetric and asymmetric, with and without bias.

### Motivation and Context
#29791 let the CompInt8 `MatMulNBits` path quantize a fp16 `A` in one pass instead of first materializing a full fp32 copy of `A`, but wired it only for the AVX2 and AVX-VNNI dispatch tables. On AVX-512 and AVX-512-VNNI hosts `QuantizeARowComputeBlkSum_CompInt8_Fp16` was left null, so `MlasQNBitGemmFp16DirectQuantASupported()` returned false and the fp16 path fell back to converting all of `A` to fp32 with `MlasConvertHalfToFloatBufferInParallel` into a separate `M*K` float buffer before the float quantizer ran. This wires the same single-pass path for AVX-512, so those hosts skip that extra full conversion of `A` and the fp32 `A` allocation.
