### PR TITLE
Make ORT_TELEMETRY_DISABLED a full telemetry opt-out

### DIFF
--- a/docs/Privacy.md
+++ b/docs/Privacy.md
@@ -26,5 +26,5 @@ For ways to disable telemetry, see the [Disabling Telemetry](#disabling-telemetr
 Telemetry can be disabled in any of these ways:
 
 - **Don't build it in.** The telemetry provider is only compiled when configuring with `--use_telemetry`, so a build configured without it collects no data.
-- **At runtime, via environment variable (non-Windows).** Set `ORT_TELEMETRY_DISABLED=1` (also accepts `true`/`yes`/`on`/`y`, case-insensitive) before ONNX Runtime initializes to disable non-essential telemetry. ONNX Runtime may still send a minimal initialization event.
+- **At runtime, via environment variable (non-Windows).** Set `ORT_TELEMETRY_DISABLED=1` (also accepts `true`/`yes`/`on`/`y`, case-insensitive) before ONNX Runtime initializes. This is a full opt-out: the telemetry uploader is never created, no events (including the initialization event) are sent, and no persistent device identifier is written to disk. The opt-out is latched for the lifetime of the process and cannot be re-enabled via the runtime API.
 - **At runtime, via the API.** The C API (and the C#, Python, and Java bindings) expose calls to turn telemetry on/off for non-essential telemetry. For non-Windows platforms, ONNX Runtime may still send a minimal initialization event. On **Windows**, ETW events are still emitted if an external trace session is collecting.

--- a/onnxruntime/core/platform/posix/telemetry.cc
+++ b/onnxruntime/core/platform/posix/telemetry.cc
@@ -388,20 +388,17 @@ void PosixTelemetry::LogEventAsync(Microsoft::Applications::Events::EventPropert
 void PosixTelemetry::Initialize() {
   std::unique_lock<std::shared_mutex> lock(mutex_);
 
-  // In a CI / build-pipeline environment, or inside ORT's own unit-test binaries, collect nothing at
-  // all: skip creating the 1DS uploader entirely so no events (not even ProcessInfo) are emitted and
-  // no device id is written.
-  if (IsRunningInCI() || IsRunningUnitTests()) {
+  // Collect nothing at all — skip creating the 1DS uploader entirely so no events (not even the
+  // one-shot ProcessInfo) are emitted and no device id is written to disk — when telemetry is fully
+  // suppressed for this process: a CI / build-pipeline environment, ORT's own unit-test binaries, or
+  // an explicit ORT_TELEMETRY_DISABLED opt-out. The environment opt-out is additionally latched so the
+  // runtime EnableTelemetryEvents() API cannot re-enable telemetry for the lifetime of the process.
+  if (ShouldSuppressTelemetry()) {
+    if (IsTelemetryDisabledByEnvVar()) {
+      env_disabled_.store(true, std::memory_order_release);
+    }
     enabled_.store(false, std::memory_order_release);
     return;
-  }
-
-  // ORT_TELEMETRY_DISABLED suppresses usage events for the lifetime of the process but still creates
-  // the uploader, so the one-shot ProcessInfo event is emitted. Runtime disable behaves the same way
-  // for ProcessInfo but remains reversible when there was no environment opt-out.
-  if (IsTelemetryDisabledByEnvVar()) {
-    env_disabled_.store(true, std::memory_order_release);
-    enabled_.store(false, std::memory_order_release);
   }
 
   // The official Android AAR initializes the SDK's Java HttpClient before ORT is loaded. Native-only
@@ -763,9 +760,10 @@ uint64_t PosixTelemetry::Keyword() const {
 
 void PosixTelemetry::LogProcessInfo() const {
   RunTelemetryOperation("LogProcessInfo", [&]() {
-    // ProcessInfo fires whenever telemetry is initialized (i.e. not in a CI build), even when the usage
-    // events are disabled via ORT_TELEMETRY_DISABLED or DisableTelemetryEvents(). It only needs a live
-    // logger; CI suppression already prevents one from being created.
+    // ProcessInfo fires whenever a live logger exists, even when usage events are suppressed at
+    // runtime via DisableTelemetryEvents(); it only needs a live logger. An ORT_TELEMETRY_DISABLED
+    // opt-out (as well as CI / unit-test suppression) prevents the uploader from being created at all,
+    // so no logger exists and this returns early.
     if (logger_.load(std::memory_order_acquire) == nullptr) {
       return;
     }

--- a/onnxruntime/core/platform/telemetry_environment.h
+++ b/onnxruntime/core/platform/telemetry_environment.h
@@ -121,10 +121,12 @@ inline constexpr bool CanEnableTelemetryEvents(bool disabled_by_environment) noe
   return !disabled_by_environment;
 }
 
-// True if telemetry should be fully suppressed for this process, including the initialization event.
-// ORT_TELEMETRY_DISABLED is intentionally excluded because it disables only non-essential events.
+// True if telemetry should be fully suppressed for this process, including the initialization event:
+// a CI / build-pipeline environment, ORT's own unit-test binaries, or an explicit
+// ORT_TELEMETRY_DISABLED opt-out. In every case the provider skips creating the uploader entirely, so
+// no events (not even ProcessInfo) are emitted and no persistent device id is written to disk.
 inline bool ShouldSuppressTelemetry() {
-  return IsRunningInCI() || IsRunningUnitTests();
+  return IsRunningInCI() || IsRunningUnitTests() || IsTelemetryDisabledByEnvVar();
 }
 
 }  // namespace onnxruntime

--- a/onnxruntime/test/platform/telemetry_environment_test.cc
+++ b/onnxruntime/test/platform/telemetry_environment_test.cc
@@ -32,10 +32,13 @@ TEST(TelemetryEnvironmentTest, EnvVarOptOut) {
   {
     ScopedEnvironmentVariables env_vars{EnvVarMap{{"ORT_TELEMETRY_DISABLED", "1"}}};
     EXPECT_TRUE(IsTelemetryDisabledByEnvVar());
+    // The environment opt-out fully suppresses telemetry (no uploader, no init event, no device id).
+    EXPECT_TRUE(ShouldSuppressTelemetry());
   }
   {
     ScopedEnvironmentVariables env_vars{EnvVarMap{{"ORT_TELEMETRY_DISABLED", "TRUE"}}};
     EXPECT_TRUE(IsTelemetryDisabledByEnvVar());
+    EXPECT_TRUE(ShouldSuppressTelemetry());
   }
   {
     ScopedEnvironmentVariables env_vars{EnvVarMap{{"ORT_TELEMETRY_DISABLED", "0"}}};


### PR DESCRIPTION
### Description

Makes `ORT_TELEMETRY_DISABLED` a **full** telemetry opt-out on the non-Windows (1DS) provider. Previously, setting the environment variable only flipped `enabled_ = false` while `Initialize()` still created the 1DS uploader, wrote the persistent device-id file to disk, and let `LogProcessInfo()` upload a one-shot `ProcessInfo` event (it only checked `logger_ != nullptr`, not `IsEnabled()`). So a user who explicitly opted out still got an on-disk identifier and a network upload.

With this change, the env-var opt-out is treated like CI / unit-test suppression: the provider returns early before creating the uploader, so **nothing** is initialized, persisted, or sent.

### Key Changes

| File | Change |
|---|---|
| `onnxruntime/core/platform/telemetry_environment.h` | `ShouldSuppressTelemetry()` now also returns true for `IsTelemetryDisabledByEnvVar()`, making it the single "collect nothing" gate. |
| `onnxruntime/core/platform/posix/telemetry.cc` | `Initialize()` collapses the CI/unit-test and env-var checks into one early return on `ShouldSuppressTelemetry()`. When set, no `LogManager`/uploader is created, `DeviceId::GetValue()` is never called (no device-id file), and `LogProcessInfo()` returns early (no upload). `env_disabled_` is still latched so the runtime `EnableTelemetryEvents()` API cannot re-enable it. `LogProcessInfo()` comment updated. |
| `docs/Privacy.md` | Documents the env-var as a full opt-out: no uploader, no init event, no persistent device id, latched for the process lifetime. |
| `onnxruntime/test/platform/telemetry_environment_test.cc` | Adds assertions that `ShouldSuppressTelemetry()` is true when `ORT_TELEMETRY_DISABLED` is set. |

### Motivation and Context

Addresses review feedback on #27379 (the "opt-out asymmetry" thread): an explicit `ORT_TELEMETRY_DISABLED=1` should leave no on-disk identifier and send nothing, rather than only suppressing usage events while still emitting an initialization heartbeat. The runtime API-based disable (`DisableTelemetryEvents()`) is unchanged and may still emit a minimal init event, matching the Windows ETW model.

### Testing

- `TelemetryEnvironmentTest.EnvVarOptOut` now asserts full suppression via `ShouldSuppressTelemetry()`.
- Verify on a non-Windows telemetry build that with `ORT_TELEMETRY_DISABLED=1`: no `onnxruntime.db`/`deviceid` file is created under the cache dir, and no `ProcessInfo` event is uploaded.
