### PR TITLE
WebGPU: Add Trilu kernel

### DIFF
--- a/onnxruntime/core/providers/webgpu/tensor/trilu.cc
+++ b/onnxruntime/core/providers/webgpu/tensor/trilu.cc
@@ -80,9 +80,9 @@ Status Trilu::ComputeInternal(ComputeContext& context) const {
 
   const int64_t matrix_h = input_shape[input_shape.NumDimensions() - 2];
   const int64_t matrix_w = input_shape[input_shape.NumDimensions() - 1];
-  ORT_RETURN_IF_NOT(matrix_h > 0 && matrix_h <= static_cast<int64_t>(std::numeric_limits<uint32_t>::max()),
+  ORT_RETURN_IF_NOT(matrix_h > 0 && matrix_h <= static_cast<int64_t>(std::numeric_limits<int32_t>::max()),
                     "Trilu matrix height is out of supported range.");
-  ORT_RETURN_IF_NOT(matrix_w > 0 && matrix_w <= static_cast<int64_t>(std::numeric_limits<uint32_t>::max()),
+  ORT_RETURN_IF_NOT(matrix_w > 0 && matrix_w <= static_cast<int64_t>(std::numeric_limits<int32_t>::max()),
                     "Trilu matrix width is out of supported range.");
 
   int32_t k = 0;

--- a/onnxruntime/core/providers/webgpu/tensor/trilu.cc
+++ b/onnxruntime/core/providers/webgpu/tensor/trilu.cc
@@ -1,0 +1,106 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <limits>
+
+#include "core/providers/common.h"
+#include "core/providers/cpu/tensor/utils.h"
+#include "core/providers/webgpu/shader_helper.h"
+#include "core/providers/webgpu/tensor/trilu.h"
+#include "core/providers/webgpu/webgpu_supported_types.h"
+
+namespace onnxruntime {
+namespace webgpu {
+
+ONNX_OPERATOR_KERNEL_EX(
+    Trilu,
+    kOnnxDomain,
+    14,
+    kWebGpuExecutionProvider,
+    (*KernelDefBuilder::Create())
+        .TypeConstraint("T", WebGpuSupportedNumberTypes())
+        .InputMemoryType(OrtMemTypeCPU, 1),
+    Trilu);
+
+Status TriluProgram::GenerateShaderCode(ShaderHelper& shader) const {
+  const auto& input = shader.AddInput("input", ShaderUsage::UseUniform | ShaderUsage::UseValueTypeAlias);
+  const auto& output = shader.AddOutput("output", ShaderUsage::UseUniform | ShaderUsage::UseValueTypeAlias);
+  shader.MainFunctionBody() << shader.GuardAgainstOutOfBoundsWorkgroupSizes("uniforms.output_size")
+                            << "let row = i32((global_idx / uniforms.matrix_w) % uniforms.matrix_h);\n"
+                            << "let col = i32(global_idx % uniforms.matrix_w);\n"
+                            << "let input_value = " << input.GetByOffset("global_idx") << ";\n";
+  if (upper_) {
+    shader.MainFunctionBody() << "let value = select(input_value_t(0), input_value, (row + uniforms.k) <= col);\n";
+  } else {
+    shader.MainFunctionBody() << "let value = select(input_value_t(0), input_value, (row + uniforms.k) >= col);\n";
+  }
+  shader.MainFunctionBody() << output.SetByOffset("global_idx", "value");
+  return Status::OK();
+}
+
+static Status GetTriluK(const Tensor* k_tensor, int32_t& k) {
+  if (k_tensor == nullptr) {
+    k = 0;
+    return Status::OK();
+  }
+
+  ORT_RETURN_IF_NOT(IsScalarOr1ElementVector(k_tensor), "k should be a 1-D or 0-D tensor.");
+
+  int64_t k_value = 0;
+  if (k_tensor->IsDataType<int64_t>()) {
+    k_value = *(k_tensor->Data<int64_t>());
+  } else if (k_tensor->IsDataType<int32_t>()) {
+    k_value = *(k_tensor->Data<int32_t>());
+  } else {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "k should be of type int32 or int64.");
+  }
+
+  ORT_RETURN_IF_NOT(k_value >= std::numeric_limits<int32_t>::min() &&
+                        k_value <= std::numeric_limits<int32_t>::max(),
+                    "k is out of range for WebGPU Trilu.");
+  k = static_cast<int32_t>(k_value);
+  return Status::OK();
+}
+
+Status Trilu::ComputeInternal(ComputeContext& context) const {
+  const auto* input_tensor = context.Input(0);
+  const auto* k_tensor = context.InputCount() > 1 ? context.Input(1) : nullptr;
+
+  const TensorShape& input_shape = input_tensor->Shape();
+  ORT_RETURN_IF_NOT(input_shape.NumDimensions() >= 2, "Input tensor should have a rank of at least 2.");
+
+  auto* output_tensor = context.Output(0, input_shape);
+  const int64_t output_size = output_tensor->Shape().Size();
+  if (output_size == 0) {
+    return Status::OK();
+  }
+
+  ORT_RETURN_IF_NOT(output_size <= static_cast<int64_t>(std::numeric_limits<uint32_t>::max()),
+                    "Trilu output size exceeds WebGPU supported maximum.");
+
+  const int64_t matrix_h = input_shape[input_shape.NumDimensions() - 2];
+  const int64_t matrix_w = input_shape[input_shape.NumDimensions() - 1];
+  ORT_RETURN_IF_NOT(matrix_h > 0 && matrix_h <= static_cast<int64_t>(std::numeric_limits<uint32_t>::max()),
+                    "Trilu matrix height is out of supported range.");
+  ORT_RETURN_IF_NOT(matrix_w > 0 && matrix_w <= static_cast<int64_t>(std::numeric_limits<uint32_t>::max()),
+                    "Trilu matrix width is out of supported range.");
+
+  int32_t k = 0;
+  ORT_RETURN_IF_ERROR(GetTriluK(k_tensor, k));
+
+  TriluProgram program{upper_};
+  program
+      .CacheHint(upper_)
+      .AddInput({input_tensor, ProgramTensorMetadataDependency::Type})
+      .AddOutput({output_tensor, ProgramTensorMetadataDependency::Type})
+      .SetDispatchGroupSize((static_cast<uint32_t>(output_size) + WORKGROUP_SIZE - 1) / WORKGROUP_SIZE)
+      .AddUniformVariables({{static_cast<uint32_t>(output_size)},
+                            {static_cast<uint32_t>(matrix_h)},
+                            {static_cast<uint32_t>(matrix_w)},
+                            {k}});
+
+  return context.RunProgram(program);
+}
+
+}  // namespace webgpu
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/webgpu/tensor/trilu.h
+++ b/onnxruntime/core/providers/webgpu/tensor/trilu.h
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/providers/webgpu/program.h"
+#include "core/providers/webgpu/webgpu_kernel.h"
+
+namespace onnxruntime {
+namespace webgpu {
+
+class TriluProgram final : public Program<TriluProgram> {
+ public:
+  explicit TriluProgram(bool upper) : Program{"Trilu"}, upper_{upper} {}
+
+  Status GenerateShaderCode(ShaderHelper& sh) const override;
+
+  WEBGPU_PROGRAM_DEFINE_UNIFORM_VARIABLES({"output_size", ProgramUniformVariableDataType::Uint32},
+                                          {"matrix_h", ProgramUniformVariableDataType::Uint32},
+                                          {"matrix_w", ProgramUniformVariableDataType::Uint32},
+                                          {"k", ProgramUniformVariableDataType::Int32});
+
+ private:
+  bool upper_;
+};
+
+class Trilu final : public WebGpuKernel {
+ public:
+  explicit Trilu(const OpKernelInfo& info)
+      : WebGpuKernel(info), upper_(info.GetAttrOrDefault<int64_t>("upper", 1) != 0) {}
+
+  Status ComputeInternal(ComputeContext& context) const override;
+
+ private:
+  bool upper_;
+};
+
+}  // namespace webgpu
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
@@ -33,6 +33,7 @@
 #include "core/providers/webgpu/tensor/expand.h"
 #include "core/providers/webgpu/tensor/grid_sample.h"
 #include "core/providers/webgpu/generator/range.h"
+#include "core/providers/webgpu/tensor/trilu.h"
 #include "core/providers/webgpu/tensor/unsqueeze.h"
 #include "core/providers/webgpu/math/binary_elementwise_ops.h"
 #include "core/providers/webgpu/tensor/where.h"
@@ -382,6 +383,7 @@ static const BuildKernelCreateInfoFn build_kernel_create_info_function_table[] =
     BuildKernelCreateInfo<class ONNX_OPERATOR_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 21, Flatten)>,
     BuildKernelCreateInfo<class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 6, 12, Tile)>,
     BuildKernelCreateInfo<class ONNX_OPERATOR_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 13, Tile)>,
+    BuildKernelCreateInfo<class ONNX_OPERATOR_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 14, Trilu)>,
 
     BuildKernelCreateInfo<class ONNX_OPERATOR_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 17, LayerNormalization)>,
     BuildKernelCreateInfo<class ONNX_OPERATOR_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 23, RMSNormalization)>,

--- a/onnxruntime/test/providers/cpu/tensor/trilu_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/trilu_op_test.cc
@@ -5,6 +5,10 @@
 #include "test/providers/provider_test_utils.h"
 #include "core/util/math.h"
 
+#ifdef USE_WEBGPU
+#include "test/util/include/default_providers.h"
+#endif
+
 namespace onnxruntime {
 namespace test {
 
@@ -283,6 +287,83 @@ TEST(TriluOpTest, zero_dim_2_lower) {
   test.AddOutput<float>("Y", {2, 0, 0}, {});
   test.Run();
 }
+
+#ifdef USE_WEBGPU
+namespace {
+void RunWithWebGpu(OpTester& test) {
+  if (DefaultWebGpuExecutionProvider().get() == nullptr) {
+    GTEST_SKIP() << "WebGPU EP not available";
+  }
+
+  auto provider = DefaultWebGpuExecutionProvider();
+  test.ConfigEp(std::move(provider)).RunWithConfig();
+}
+}  // namespace
+
+TEST(TriluOpTest, webgpu_upper_default_k) {
+  OpTester test("Trilu", 14, kOnnxDomain);
+  test.AddInput<float>("X", {2, 2}, {4.f, 7.f, 2.f, 6.f});
+  test.AddOutput<float>("Y", {2, 2}, {4.f, 7.f, 0.f, 6.f});
+  RunWithWebGpu(test);
+}
+
+TEST(TriluOpTest, webgpu_lower_default_k) {
+  OpTester test("Trilu", 14, kOnnxDomain);
+  test.AddAttribute<int64_t>("upper", 0);
+  test.AddInput<float>("X", {2, 2}, {4.f, 7.f, 2.f, 6.f});
+  test.AddOutput<float>("Y", {2, 2}, {4.f, 0.f, 2.f, 6.f});
+  RunWithWebGpu(test);
+}
+
+TEST(TriluOpTest, webgpu_upper_positive_k) {
+  OpTester test("Trilu", 14, kOnnxDomain);
+  test.AddInput<float>("X", {3, 4},
+                       {4.f, 1.f, 5.f, 8.f,
+                        4.f, 3.f, 2.f, 4.f,
+                        6.f, 1.f, 2.f, 3.f});
+  test.AddInput<int64_t>("k", {}, {1});
+  test.AddOutput<float>("Y", {3, 4},
+                        {0.f, 1.f, 5.f, 8.f,
+                         0.f, 0.f, 2.f, 4.f,
+                         0.f, 0.f, 0.f, 3.f});
+  RunWithWebGpu(test);
+}
+
+TEST(TriluOpTest, webgpu_lower_negative_k) {
+  OpTester test("Trilu", 14, kOnnxDomain);
+  test.AddAttribute<int64_t>("upper", 0);
+  test.AddInput<float>("X", {3, 4},
+                       {4.f, 1.f, 5.f, 8.f,
+                        4.f, 3.f, 2.f, 4.f,
+                        6.f, 1.f, 2.f, 3.f});
+  test.AddInput<int64_t>("k", {}, {-1});
+  test.AddOutput<float>("Y", {3, 4},
+                        {0.f, 0.f, 0.f, 0.f,
+                         4.f, 0.f, 0.f, 0.f,
+                         6.f, 1.f, 0.f, 0.f});
+  RunWithWebGpu(test);
+}
+
+TEST(TriluOpTest, webgpu_batched_upper) {
+  OpTester test("Trilu", 14, kOnnxDomain);
+  test.AddInput<float>("X", {2, 3, 4},
+                       {4.f, 1.f, 5.f, 8.f,
+                        4.f, 3.f, 2.f, 4.f,
+                        6.f, 1.f, 2.f, 3.f,
+                        1.f, 6.f, 2.f, 1.f,
+                        4.f, 1.f, 5.f, 8.f,
+                        4.f, 3.f, 2.f, 4.f});
+  test.AddInput<int64_t>("k", {}, {1});
+  test.AddOutput<float>("Y", {2, 3, 4},
+                        {0.f, 1.f, 5.f, 8.f,
+                         0.f, 0.f, 2.f, 4.f,
+                         0.f, 0.f, 0.f, 3.f,
+                         0.f, 6.f, 2.f, 1.f,
+                         0.f, 0.f, 5.f, 8.f,
+                         0.f, 0.f, 0.f, 4.f});
+  RunWithWebGpu(test);
+}
+#endif  // USE_WEBGPU
 
 }  // namespace test
 }  // namespace onnxruntime


### PR DESCRIPTION
### Description
`Trilu` was missing in the native C++ WebGPU EP, causing kernel lookup failures for models, e.g. [sd-1.5-text-encoder](https://huggingface.co/microsoft/stable-diffusion-v1.5-webnn/blob/main/text-encoder.onnx).  
This PR adds a WebGPU `Trilu` kernel in `onnxruntime/core/providers/webgpu/` and wires it into EP registration and provider-targeted coverage.



### Motivation and Context
The native C++ WebGPU EP did not implement ONNX `Trilu`, so graphs containing `Trilu` failed provider kernel resolution.  
This change closes that gap in the WebGPU EP (C++ path under `onnxruntime/core/providers/webgpu/`) and enables those models to execute without the previous “kernel not found” failure.


