### PR TITLE
[Webgpu] Avoid mappedAtCreation staging upload

### DIFF
--- a/js/web/lib/wasm/jsep/webgpu/gpu-data-manager.ts
+++ b/js/web/lib/wasm/jsep/webgpu/gpu-data-manager.ts
@@ -237,9 +237,14 @@ class GpuDataManagerImpl implements GpuDataManager {
       throw new Error(`inconsistent data size. gpu data size=${gpuDataCache.originalSize}, data size=${srcLength}`);
     }
 
-    const uploadData = new Uint8Array(size);
-    uploadData.set(new Uint8Array(srcArrayBuffer, srcOffset, srcLength));
-    this.backend.device.queue.writeBuffer(gpuDataCache.gpuData.buffer, 0, uploadData, 0, size);
+    if (size === srcLength && srcOffset % 4 === 0) {
+      // Fast path: already aligned; avoid allocating/copying a padded buffer.
+      this.backend.device.queue.writeBuffer(gpuDataCache.gpuData.buffer, 0, srcArrayBuffer, srcOffset, srcLength);
+    } else {
+      const uploadData = new Uint8Array(size);
+      uploadData.set(data);
+      this.backend.device.queue.writeBuffer(gpuDataCache.gpuData.buffer, 0, uploadData, 0, size);
+    }
 
     LOG_DEBUG('verbose', () => `[WebGPU] GpuDataManager.upload(id=${id})`);
   }

--- a/js/web/lib/wasm/jsep/webgpu/gpu-data-manager.ts
+++ b/js/web/lib/wasm/jsep/webgpu/gpu-data-manager.ts
@@ -237,22 +237,9 @@ class GpuDataManagerImpl implements GpuDataManager {
       throw new Error(`inconsistent data size. gpu data size=${gpuDataCache.originalSize}, data size=${srcLength}`);
     }
 
-    // create gpu buffer
-    const gpuBufferForUploading = this.backend.device.createBuffer(
-      // eslint-disable-next-line no-bitwise
-      { mappedAtCreation: true, size, usage: GPUBufferUsage.MAP_WRITE | GPUBufferUsage.COPY_SRC },
-    );
-
-    // copy (upload) data
-    const arrayBuffer = gpuBufferForUploading.getMappedRange();
-    new Uint8Array(arrayBuffer).set(new Uint8Array(srcArrayBuffer, srcOffset, srcLength));
-    gpuBufferForUploading.unmap();
-
-    // GPU copy
-    const commandEncoder = this.backend.device.createCommandEncoder();
-    commandEncoder.copyBufferToBuffer(gpuBufferForUploading, 0, gpuDataCache.gpuData.buffer, 0, size);
-    this.backend.device.queue.submit([commandEncoder.finish()]);
-    gpuBufferForUploading.destroy();
+    const uploadData = new Uint8Array(size);
+    uploadData.set(new Uint8Array(srcArrayBuffer, srcOffset, srcLength));
+    this.backend.device.queue.writeBuffer(gpuDataCache.gpuData.buffer, 0, uploadData, 0, size);
 
     LOG_DEBUG('verbose', () => `[WebGPU] GpuDataManager.upload(id=${id})`);
   }


### PR DESCRIPTION
Fix CI failures like https://github.com/microsoft/onnxruntime/actions/runs/29993467798/job/89171381036

## Root cause

* The failing WebGPU Where tests were tripping GpuDataManager.upload().
* That path created a fresh mappedAtCreation: true staging buffer for each CPU→GPU upload.
* On the Windows Chrome/WebGPU runner, even a 16-byte upload hit createBuffer failed ... mappedAtCreation == true, which caused the first test to hang and the rest to cascade with Session already started.

## Change

* Replaced the staging-buffer upload path in /home/runner/work/onnxruntime/onnxruntime/js/web/lib/wasm/jsep/webgpu/gpu-data-manager.ts
* Now uploads use device.queue.writeBuffer() directly, preserving the existing zero-padded aligned write behavior.

## Validation

* npm ci in js, js/common, and js/web
* npx eslint web/lib/wasm/jsep/webgpu/gpu-data-manager.ts
* npm run prebuild in js/web
* CodeQL: 0 JavaScript alerts


