### PR TITLE
docs: fix wasmPaths object syntax

### DIFF
--- a/docs/tutorials/web/env-flags-and-session-options.md
+++ b/docs/tutorials/web/env-flags-and-session-options.md
@@ -113,12 +113,12 @@ The `env.wasm.wasmPaths` flag is used to override the WebAssembly binary file pa
   ort.env.wasm.wasmPaths = 'https://cdn.jsdelivr.net/npm/onnxruntime-web@1.17.3/dist/';
   ```
 
-- Set `env.wasm.wasmPaths` to an object with keys as the WebAssembly binary file name and values as the path to the WebAssembly binary file.
+- Set `env.wasm.wasmPaths` to an object with optional `wasm` and `mjs` properties. Each property accepts an absolute URL string or a `URL` object for the corresponding file.
   ```js
-  // Set separate WebAssembly binary file paths
+  // Set separate WebAssembly module and binary file paths
   ort.env.wasm.wasmPaths = {
-    'ort-wasm-simd.jsep.wasm': 'https://example.com/path/to/ort-wasm-simd.jsep.wasm'
-    'ort-wasm-simd-threaded.jsep.wasm': 'https://example.com/path/to/ort-wasm-simd-threaded.jsep.wasm',
+    mjs: 'https://example.com/path/to/ort-wasm-simd-threaded.jsep.mjs',
+    wasm: 'https://example.com/path/to/ort-wasm-simd-threaded.jsep.wasm',
   };
   ```
 


### PR DESCRIPTION
## Summary

Update the WebAssembly environment flag guide to document the current `wasmPaths` object shape. The example now uses the supported `mjs` and `wasm` properties and notes that each accepts an absolute URL string or a `URL` object.

Fixes #25072.

## Validation

- `git diff --check`
- Verified balanced Markdown code fences and resolving relative links
- Verified the updated JavaScript example parses

The Jekyll build was not available locally because the installed Ruby is 4.0, while the repository workflow uses Ruby 3.3. The draft PR's `gh-pages` checks will run the supported environment.
