### PR TITLE
[WebGPU] Support concurrent Session creation and execution

### DIFF
--- a/onnxruntime/core/providers/webgpu/allocator.cc
+++ b/onnxruntime/core/providers/webgpu/allocator.cc
@@ -7,12 +7,14 @@
 #include "core/framework/session_state.h"
 #include "core/providers/webgpu/allocator.h"
 #include "core/providers/webgpu/buffer_manager.h"
+#include "core/providers/webgpu/webgpu_context.h"
 
 namespace onnxruntime {
 namespace webgpu {
 
 GpuBufferAllocator::GpuBufferAllocator(
     std::function<const BufferManager&()> buffer_manager_getter,
+    std::function<CommandRecordingState&()> recording_getter,
     bool is_read_only_allocator,
     std::function<bool()> should_submit_zero_initialize)
     : IAllocator(
@@ -22,6 +24,7 @@ GpuBufferAllocator::GpuBufferAllocator(
                         WebGpuDevice,
                         OrtMemTypeDefault)),
       buffer_manager_getter_{std::move(buffer_manager_getter)},
+      recording_getter_{std::move(recording_getter)},
       should_submit_zero_initialize_{std::move(should_submit_zero_initialize)},
       mapped_at_creation_{is_read_only_allocator && buffer_manager_getter_().SupportsUMA()},
       initialize_to_zero_{!is_read_only_allocator} {
@@ -32,23 +35,70 @@ void* GpuBufferAllocator::Alloc(size_t size) {
     return nullptr;
   }
 
+  auto& recording = recording_getter_();
+  std::lock_guard<std::recursive_mutex> lock{recording.mutex};
   stats_.num_allocs++;
 
   wgpu::BufferUsage usage = mapped_at_creation_ ? wgpu::BufferUsage::Storage | wgpu::BufferUsage::CopySrc | wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::MapWrite
                                                 : wgpu::BufferUsage::Storage | wgpu::BufferUsage::CopySrc | wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::Indirect;
 
   const bool submit_zero_initialize = should_submit_zero_initialize_ && should_submit_zero_initialize_();
-  return buffer_manager_getter_().Create(size, usage, initialize_to_zero_, submit_zero_initialize);
+  return buffer_manager_getter_().Create(recording, size, usage, initialize_to_zero_,
+                                         submit_zero_initialize);
 }
 
 void GpuBufferAllocator::Free(void* p) {
   if (p != nullptr) {
-    buffer_manager_getter_().Release(static_cast<WGPUBuffer>(p));
+    auto& recording = recording_getter_();
+    std::lock_guard<std::recursive_mutex> lock{recording.mutex};
+    buffer_manager_getter_().Release(recording, static_cast<WGPUBuffer>(p));
     stats_.num_allocs--;
   }
 }
 
 void GpuBufferAllocator::GetStats(AllocatorStats* stats) {
+  auto& recording = recording_getter_();
+  std::lock_guard<std::recursive_mutex> lock{recording.mutex};
+  *stats = stats_;
+}
+
+ExternalGpuBufferAllocator::ExternalGpuBufferAllocator(std::shared_ptr<WebGpuContext> context)
+    : IAllocator(OrtMemoryInfo(WEBGPU_BUFFER,
+                               OrtAllocatorType::OrtDeviceAllocator,
+                               WebGpuDevice,
+                               OrtMemTypeDefault)),
+      context_{std::move(context)} {
+}
+
+void* ExternalGpuBufferAllocator::Alloc(size_t size) {
+  if (size == 0) {
+    return nullptr;
+  }
+
+  wgpu::BufferDescriptor descriptor{};
+  descriptor.size = (size + 15) / 16 * 16;
+  descriptor.usage = wgpu::BufferUsage::Storage | wgpu::BufferUsage::CopySrc |
+                     wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::Indirect;
+  WGPUBuffer buffer = context_->Device().CreateBuffer(&descriptor).MoveToCHandle();
+  ORT_ENFORCE(buffer != nullptr, "Failed to create external WebGPU buffer: size=", size, ".");
+
+  std::lock_guard<std::mutex> lock{stats_mutex_};
+  ++stats_.num_allocs;
+  return buffer;
+}
+
+void ExternalGpuBufferAllocator::Free(void* p) {
+  if (p == nullptr) {
+    return;
+  }
+
+  wgpuBufferRelease(static_cast<WGPUBuffer>(p));
+  std::lock_guard<std::mutex> lock{stats_mutex_};
+  --stats_.num_allocs;
+}
+
+void ExternalGpuBufferAllocator::GetStats(AllocatorStats* stats) {
+  std::lock_guard<std::mutex> lock{stats_mutex_};
   *stats = stats_;
 }
 
@@ -70,12 +120,14 @@ void WebGpuNoOpAllocator::Free(void* /*p*/) {
 
 AllocatorPtr CreateWebGpuAllocator(bool device_free,
                                    std::function<const BufferManager&()> buffer_manager_getter,
+                                   std::function<CommandRecordingState&()> recording_getter,
                                    bool is_read_only_allocator,
                                    std::function<bool()> should_submit_zero_initialize) {
   if (device_free) {
     return std::make_shared<WebGpuNoOpAllocator>(is_read_only_allocator);
   }
-  return std::make_shared<GpuBufferAllocator>(std::move(buffer_manager_getter), is_read_only_allocator,
+  return std::make_shared<GpuBufferAllocator>(std::move(buffer_manager_getter), std::move(recording_getter),
+                                              is_read_only_allocator,
                                               std::move(should_submit_zero_initialize));
 }
 

--- a/onnxruntime/core/providers/webgpu/allocator.cc
+++ b/onnxruntime/core/providers/webgpu/allocator.cc
@@ -4,7 +4,6 @@
 #include <memory>
 #include <utility>
 
-#include "core/common/safeint.h"
 #include "core/framework/session_state.h"
 #include "core/providers/webgpu/allocator.h"
 #include "core/providers/webgpu/buffer_manager.h"
@@ -59,45 +58,13 @@ void GpuBufferAllocator::GetStats(AllocatorStats* stats) {
   *stats = stats_;
 }
 
-ExternalGpuBufferAllocator::ExternalGpuBufferAllocator(std::shared_ptr<WebGpuContext> context)
-    : IAllocator(OrtMemoryInfo(WEBGPU_BUFFER,
-                               OrtAllocatorType::OrtDeviceAllocator,
-                               WebGpuDevice,
-                               OrtMemTypeDefault)),
-      context_{std::move(context)} {
-}
-
-ExternalGpuBufferAllocator::~ExternalGpuBufferAllocator() = default;
-
-void* ExternalGpuBufferAllocator::Alloc(size_t size) {
-  if (size == 0) {
-    return nullptr;
-  }
-
-  std::lock_guard<std::mutex> lock{mutex_};
-  wgpu::BufferDescriptor descriptor{};
-  descriptor.size = (SafeInt<size_t>(size) + 15) / 16 * 16;
-  descriptor.usage = wgpu::BufferUsage::Storage | wgpu::BufferUsage::CopySrc |
-                     wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::Indirect;
-  auto buffer = context_->Device().CreateBuffer(&descriptor);
-  ORT_ENFORCE(buffer, "Failed to create external WebGPU buffer: size=", size, ".");
-  ++stats_.num_allocs;
-  return buffer.MoveToCHandle();
-}
-
-void ExternalGpuBufferAllocator::Free(void* p) {
-  if (p == nullptr) {
-    return;
-  }
-
-  std::lock_guard<std::mutex> lock{mutex_};
-  wgpuBufferRelease(static_cast<WGPUBuffer>(p));
-  --stats_.num_allocs;
-}
-
-void ExternalGpuBufferAllocator::GetStats(AllocatorStats* stats) {
-  std::lock_guard<std::mutex> lock{mutex_};
-  *stats = stats_;
+AllocatorPtr CreateSharedWebGpuAllocator(std::shared_ptr<WebGpuContext> context) {
+  auto recording = std::make_shared<CommandRecordingState>();
+  return std::make_shared<GpuBufferAllocator>(
+      [context = std::move(context)]() -> const BufferManager& { return context->BufferManager(); },
+      [recording = std::move(recording)]() -> CommandRecordingState& { return *recording; },
+      false,
+      []() { return true; });
 }
 
 WebGpuNoOpAllocator::WebGpuNoOpAllocator(bool is_read_only_allocator)

--- a/onnxruntime/core/providers/webgpu/allocator.cc
+++ b/onnxruntime/core/providers/webgpu/allocator.cc
@@ -37,7 +37,6 @@ void* GpuBufferAllocator::Alloc(size_t size) {
   }
 
   auto& recording = recording_getter_();
-  std::lock_guard<std::recursive_mutex> lock{recording.mutex};
   stats_.num_allocs++;
 
   wgpu::BufferUsage usage = mapped_at_creation_ ? wgpu::BufferUsage::Storage | wgpu::BufferUsage::CopySrc | wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::MapWrite
@@ -51,15 +50,12 @@ void* GpuBufferAllocator::Alloc(size_t size) {
 void GpuBufferAllocator::Free(void* p) {
   if (p != nullptr) {
     auto& recording = recording_getter_();
-    std::lock_guard<std::recursive_mutex> lock{recording.mutex};
     buffer_manager_getter_().Release(recording, static_cast<WGPUBuffer>(p));
     stats_.num_allocs--;
   }
 }
 
 void GpuBufferAllocator::GetStats(AllocatorStats* stats) {
-  auto& recording = recording_getter_();
-  std::lock_guard<std::recursive_mutex> lock{recording.mutex};
   *stats = stats_;
 }
 

--- a/onnxruntime/core/providers/webgpu/allocator.cc
+++ b/onnxruntime/core/providers/webgpu/allocator.cc
@@ -7,6 +7,7 @@
 #include "core/framework/session_state.h"
 #include "core/providers/webgpu/allocator.h"
 #include "core/providers/webgpu/buffer_manager.h"
+#include "core/providers/webgpu/data_transfer.h"
 #include "core/providers/webgpu/webgpu_context.h"
 
 namespace onnxruntime {
@@ -31,6 +32,12 @@ GpuBufferAllocator::GpuBufferAllocator(
 }
 
 void* GpuBufferAllocator::Alloc(size_t size) {
+  auto& recording = recording_getter_();
+  std::lock_guard<std::recursive_mutex> lock{recording.mutex};
+  return Allocate(size, should_submit_zero_initialize_ && should_submit_zero_initialize_());
+}
+
+void* GpuBufferAllocator::Allocate(size_t size, bool submit_zero_initialize) {
   if (size == 0) {
     return nullptr;
   }
@@ -42,10 +49,65 @@ void* GpuBufferAllocator::Alloc(size_t size) {
   wgpu::BufferUsage usage = mapped_at_creation_ ? wgpu::BufferUsage::Storage | wgpu::BufferUsage::CopySrc | wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::MapWrite
                                                 : wgpu::BufferUsage::Storage | wgpu::BufferUsage::CopySrc | wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::Indirect;
 
-  const bool submit_zero_initialize = should_submit_zero_initialize_ && should_submit_zero_initialize_();
   return buffer_manager_getter_().Create(recording, size, usage, initialize_to_zero_,
                                          submit_zero_initialize);
 }
+
+#if defined(ORT_USE_EP_API_ADAPTERS)
+void* GpuBufferAllocator::AllocOnStream(size_t size, Stream* stream) {
+  if (stream == nullptr) {
+    return Alloc(size);
+  }
+  ORT_ENFORCE(&GetWebGpuStreamCommandState(reinterpret_cast<OrtSyncStream*>(stream)) == &recording_getter_(),
+              "WebGPU allocator and stream belong to different Sessions.");
+  return Allocate(size, false);
+}
+
+namespace {
+
+struct WebGpuSessionAllocator final : OrtAllocator {
+  explicit WebGpuSessionAllocator(AllocatorPtr impl) : OrtAllocator{}, impl_{std::move(impl)} {
+    version = ORT_API_VERSION;
+    Alloc = AllocImpl;
+    Free = [](OrtAllocator* allocator, void* buffer) noexcept {
+      static_cast<WebGpuSessionAllocator*>(allocator)->impl_->Free(buffer);
+    };
+    Info = [](const OrtAllocator* allocator) noexcept -> const OrtMemoryInfo* {
+      return &static_cast<const WebGpuSessionAllocator*>(allocator)->impl_->Info();
+    };
+    if (impl_->IsStreamAware()) {
+      AllocOnStream = [](OrtAllocator* allocator, size_t size, OrtSyncStream* stream) noexcept -> void* {
+        ORT_TRY {
+          return static_cast<WebGpuSessionAllocator*>(allocator)->impl_->AllocOnStream(
+              size, reinterpret_cast<Stream*>(stream));
+        }
+        ORT_CATCH(...) { return nullptr; }
+      };
+    }
+  }
+
+  static void* ORT_API_CALL AllocImpl(OrtAllocator* allocator, size_t size) noexcept {
+    ORT_TRY { return static_cast<WebGpuSessionAllocator*>(allocator)->impl_->Alloc(size); }
+    ORT_CATCH(...) { return nullptr; }
+  }
+
+  AllocatorPtr impl_;
+};
+
+}  // namespace
+
+OrtAllocator* CreateWebGpuSessionAllocator(AllocatorPtr allocator) {
+  return new WebGpuSessionAllocator(std::move(allocator));
+}
+
+bool TryReleaseWebGpuSessionAllocator(OrtAllocator* allocator) {
+  if (allocator->Alloc != WebGpuSessionAllocator::AllocImpl) {
+    return false;
+  }
+  delete static_cast<WebGpuSessionAllocator*>(allocator);
+  return true;
+}
+#endif
 
 void GpuBufferAllocator::Free(void* p) {
   if (p != nullptr) {
@@ -67,24 +129,23 @@ ExternalGpuBufferAllocator::ExternalGpuBufferAllocator(std::shared_ptr<WebGpuCon
                                OrtAllocatorType::OrtDeviceAllocator,
                                WebGpuDevice,
                                OrtMemTypeDefault)),
-      context_{std::move(context)} {
+      context_{std::move(context)},
+      command_state_{std::make_unique<CommandRecordingState>()} {
 }
+
+ExternalGpuBufferAllocator::~ExternalGpuBufferAllocator() = default;
 
 void* ExternalGpuBufferAllocator::Alloc(size_t size) {
   if (size == 0) {
     return nullptr;
   }
 
-  wgpu::BufferDescriptor descriptor{};
-  descriptor.size = (size + 15) / 16 * 16;
-  descriptor.usage = wgpu::BufferUsage::Storage | wgpu::BufferUsage::CopySrc |
-                     wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::Indirect;
-  WGPUBuffer buffer = context_->Device().CreateBuffer(&descriptor).MoveToCHandle();
-  ORT_ENFORCE(buffer != nullptr, "Failed to create external WebGPU buffer: size=", size, ".");
-
-  std::lock_guard<std::mutex> lock{stats_mutex_};
+  std::lock_guard<std::recursive_mutex> lock{command_state_->mutex};
   ++stats_.num_allocs;
-  return buffer;
+  constexpr wgpu::BufferUsage usage = wgpu::BufferUsage::Storage | wgpu::BufferUsage::CopySrc |
+                                      wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::Indirect;
+  return context_->BufferManager().Create(*command_state_, size, usage,
+                                          true, true);
 }
 
 void ExternalGpuBufferAllocator::Free(void* p) {
@@ -92,13 +153,13 @@ void ExternalGpuBufferAllocator::Free(void* p) {
     return;
   }
 
-  wgpuBufferRelease(static_cast<WGPUBuffer>(p));
-  std::lock_guard<std::mutex> lock{stats_mutex_};
+  std::lock_guard<std::recursive_mutex> lock{command_state_->mutex};
+  context_->BufferManager().Release(*command_state_, static_cast<WGPUBuffer>(p));
   --stats_.num_allocs;
 }
 
 void ExternalGpuBufferAllocator::GetStats(AllocatorStats* stats) {
-  std::lock_guard<std::mutex> lock{stats_mutex_};
+  std::lock_guard<std::recursive_mutex> lock{command_state_->mutex};
   *stats = stats_;
 }
 

--- a/onnxruntime/core/providers/webgpu/allocator.cc
+++ b/onnxruntime/core/providers/webgpu/allocator.cc
@@ -4,10 +4,10 @@
 #include <memory>
 #include <utility>
 
+#include "core/common/safeint.h"
 #include "core/framework/session_state.h"
 #include "core/providers/webgpu/allocator.h"
 #include "core/providers/webgpu/buffer_manager.h"
-#include "core/providers/webgpu/data_transfer.h"
 #include "core/providers/webgpu/webgpu_context.h"
 
 namespace onnxruntime {
@@ -32,12 +32,6 @@ GpuBufferAllocator::GpuBufferAllocator(
 }
 
 void* GpuBufferAllocator::Alloc(size_t size) {
-  auto& recording = recording_getter_();
-  std::lock_guard<std::recursive_mutex> lock{recording.mutex};
-  return Allocate(size, should_submit_zero_initialize_ && should_submit_zero_initialize_());
-}
-
-void* GpuBufferAllocator::Allocate(size_t size, bool submit_zero_initialize) {
   if (size == 0) {
     return nullptr;
   }
@@ -49,65 +43,10 @@ void* GpuBufferAllocator::Allocate(size_t size, bool submit_zero_initialize) {
   wgpu::BufferUsage usage = mapped_at_creation_ ? wgpu::BufferUsage::Storage | wgpu::BufferUsage::CopySrc | wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::MapWrite
                                                 : wgpu::BufferUsage::Storage | wgpu::BufferUsage::CopySrc | wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::Indirect;
 
+  const bool submit_zero_initialize = should_submit_zero_initialize_ && should_submit_zero_initialize_();
   return buffer_manager_getter_().Create(recording, size, usage, initialize_to_zero_,
                                          submit_zero_initialize);
 }
-
-#if defined(ORT_USE_EP_API_ADAPTERS)
-void* GpuBufferAllocator::AllocOnStream(size_t size, Stream* stream) {
-  if (stream == nullptr) {
-    return Alloc(size);
-  }
-  ORT_ENFORCE(&GetWebGpuStreamCommandState(reinterpret_cast<OrtSyncStream*>(stream)) == &recording_getter_(),
-              "WebGPU allocator and stream belong to different Sessions.");
-  return Allocate(size, false);
-}
-
-namespace {
-
-struct WebGpuSessionAllocator final : OrtAllocator {
-  explicit WebGpuSessionAllocator(AllocatorPtr impl) : OrtAllocator{}, impl_{std::move(impl)} {
-    version = ORT_API_VERSION;
-    Alloc = AllocImpl;
-    Free = [](OrtAllocator* allocator, void* buffer) noexcept {
-      static_cast<WebGpuSessionAllocator*>(allocator)->impl_->Free(buffer);
-    };
-    Info = [](const OrtAllocator* allocator) noexcept -> const OrtMemoryInfo* {
-      return &static_cast<const WebGpuSessionAllocator*>(allocator)->impl_->Info();
-    };
-    if (impl_->IsStreamAware()) {
-      AllocOnStream = [](OrtAllocator* allocator, size_t size, OrtSyncStream* stream) noexcept -> void* {
-        ORT_TRY {
-          return static_cast<WebGpuSessionAllocator*>(allocator)->impl_->AllocOnStream(
-              size, reinterpret_cast<Stream*>(stream));
-        }
-        ORT_CATCH(...) { return nullptr; }
-      };
-    }
-  }
-
-  static void* ORT_API_CALL AllocImpl(OrtAllocator* allocator, size_t size) noexcept {
-    ORT_TRY { return static_cast<WebGpuSessionAllocator*>(allocator)->impl_->Alloc(size); }
-    ORT_CATCH(...) { return nullptr; }
-  }
-
-  AllocatorPtr impl_;
-};
-
-}  // namespace
-
-OrtAllocator* CreateWebGpuSessionAllocator(AllocatorPtr allocator) {
-  return new WebGpuSessionAllocator(std::move(allocator));
-}
-
-bool TryReleaseWebGpuSessionAllocator(OrtAllocator* allocator) {
-  if (allocator->Alloc != WebGpuSessionAllocator::AllocImpl) {
-    return false;
-  }
-  delete static_cast<WebGpuSessionAllocator*>(allocator);
-  return true;
-}
-#endif
 
 void GpuBufferAllocator::Free(void* p) {
   if (p != nullptr) {
@@ -129,8 +68,7 @@ ExternalGpuBufferAllocator::ExternalGpuBufferAllocator(std::shared_ptr<WebGpuCon
                                OrtAllocatorType::OrtDeviceAllocator,
                                WebGpuDevice,
                                OrtMemTypeDefault)),
-      context_{std::move(context)},
-      command_state_{std::make_unique<CommandRecordingState>()} {
+      context_{std::move(context)} {
 }
 
 ExternalGpuBufferAllocator::~ExternalGpuBufferAllocator() = default;
@@ -140,12 +78,15 @@ void* ExternalGpuBufferAllocator::Alloc(size_t size) {
     return nullptr;
   }
 
-  std::lock_guard<std::recursive_mutex> lock{command_state_->mutex};
+  std::lock_guard<std::mutex> lock{mutex_};
+  wgpu::BufferDescriptor descriptor{};
+  descriptor.size = (SafeInt<size_t>(size) + 15) / 16 * 16;
+  descriptor.usage = wgpu::BufferUsage::Storage | wgpu::BufferUsage::CopySrc |
+                     wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::Indirect;
+  auto buffer = context_->Device().CreateBuffer(&descriptor);
+  ORT_ENFORCE(buffer, "Failed to create external WebGPU buffer: size=", size, ".");
   ++stats_.num_allocs;
-  constexpr wgpu::BufferUsage usage = wgpu::BufferUsage::Storage | wgpu::BufferUsage::CopySrc |
-                                      wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::Indirect;
-  return context_->BufferManager().Create(*command_state_, size, usage,
-                                          true, true);
+  return buffer.MoveToCHandle();
 }
 
 void ExternalGpuBufferAllocator::Free(void* p) {
@@ -153,13 +94,13 @@ void ExternalGpuBufferAllocator::Free(void* p) {
     return;
   }
 
-  std::lock_guard<std::recursive_mutex> lock{command_state_->mutex};
-  context_->BufferManager().Release(*command_state_, static_cast<WGPUBuffer>(p));
+  std::lock_guard<std::mutex> lock{mutex_};
+  wgpuBufferRelease(static_cast<WGPUBuffer>(p));
   --stats_.num_allocs;
 }
 
 void ExternalGpuBufferAllocator::GetStats(AllocatorStats* stats) {
-  std::lock_guard<std::recursive_mutex> lock{command_state_->mutex};
+  std::lock_guard<std::mutex> lock{mutex_};
   *stats = stats_;
 }
 

--- a/onnxruntime/core/providers/webgpu/allocator.cc
+++ b/onnxruntime/core/providers/webgpu/allocator.cc
@@ -59,10 +59,10 @@ void GpuBufferAllocator::GetStats(AllocatorStats* stats) {
 }
 
 AllocatorPtr CreateSharedWebGpuAllocator(std::shared_ptr<WebGpuContext> context) {
-  auto recording = std::make_shared<CommandRecordingState>();
+  auto& recording = context->EnvironmentRecording();
   return std::make_shared<GpuBufferAllocator>(
       [context = std::move(context)]() -> const BufferManager& { return context->BufferManager(); },
-      [recording = std::move(recording)]() -> CommandRecordingState& { return *recording; },
+      [&recording]() -> CommandRecordingState& { return recording; },
       false,
       []() { return true; });
 }

--- a/onnxruntime/core/providers/webgpu/allocator.h
+++ b/onnxruntime/core/providers/webgpu/allocator.h
@@ -4,6 +4,8 @@
 #pragma once
 
 #include <functional>
+#include <memory>
+#include <mutex>
 
 #include "core/framework/allocator.h"
 #include "core/framework/ortdevice.h"
@@ -12,6 +14,8 @@ namespace onnxruntime {
 namespace webgpu {
 
 class BufferManager;
+struct CommandRecordingState;
+class WebGpuContext;
 
 inline constexpr OrtDevice WebGpuDevice{OrtDevice::GPU,
                                         OrtDevice::MemType::DEFAULT,
@@ -24,6 +28,7 @@ class GpuBufferAllocator : public IAllocator {
   // BufferManager. This allows the EP to route allocations to different
   // buffer managers (e.g., per-graph) without explicit refresh calls.
   GpuBufferAllocator(std::function<const BufferManager&()> buffer_manager_getter,
+                     std::function<CommandRecordingState&()> recording_getter,
                      bool is_read_only_allocator,
                      std::function<bool()> should_submit_zero_initialize = {});
 
@@ -34,11 +39,28 @@ class GpuBufferAllocator : public IAllocator {
  private:
   AllocatorStats stats_;
   std::function<const BufferManager&()> buffer_manager_getter_;
+  std::function<CommandRecordingState&()> recording_getter_;
   std::function<bool()> should_submit_zero_initialize_;
   bool mapped_at_creation_;
   // Cached writable buffers are cleared explicitly by BufferManager::Create. Fresh buffers rely on Dawn's
   // "lazy_clear_resource_on_first_use" toggle, which is enabled by WebGpuContext.
   bool initialize_to_zero_;
+};
+
+// Environment-level shared allocator. External tensors are not transient session workspace, so
+// they bypass the context BufferManager and do not participate in a session recording timeline.
+class ExternalGpuBufferAllocator : public IAllocator {
+ public:
+  explicit ExternalGpuBufferAllocator(std::shared_ptr<WebGpuContext> context);
+
+  void* Alloc(size_t size) override;
+  void Free(void* p) override;
+  void GetStats(AllocatorStats* stats) override;
+
+ private:
+  std::shared_ptr<WebGpuContext> context_;
+  std::mutex stats_mutex_;
+  AllocatorStats stats_;
 };
 
 // No-op allocator used for the WebGPU device when the context has no Dawn device (a device-free /
@@ -59,6 +81,7 @@ class WebGpuNoOpAllocator : public IAllocator {
 // allocation ever happens.
 AllocatorPtr CreateWebGpuAllocator(bool device_free,
                                    std::function<const BufferManager&()> buffer_manager_getter,
+                                   std::function<CommandRecordingState&()> recording_getter,
                                    bool is_read_only_allocator,
                                    std::function<bool()> should_submit_zero_initialize = {});
 

--- a/onnxruntime/core/providers/webgpu/allocator.h
+++ b/onnxruntime/core/providers/webgpu/allocator.h
@@ -36,7 +36,13 @@ class GpuBufferAllocator : public IAllocator {
   virtual void Free(void* p) override;
   void GetStats(AllocatorStats* stats) override;
 
+#if defined(ORT_USE_EP_API_ADAPTERS)
+  bool IsStreamAware() const override { return true; }
+  void* AllocOnStream(size_t size, Stream* stream) override;
+#endif
+
  private:
+  void* Allocate(size_t size, bool submit_zero_initialize);
   AllocatorStats stats_;
   std::function<const BufferManager&()> buffer_manager_getter_;
   std::function<CommandRecordingState&()> recording_getter_;
@@ -47,11 +53,12 @@ class GpuBufferAllocator : public IAllocator {
   bool initialize_to_zero_;
 };
 
-// Environment-level shared allocator. External tensors are not transient session workspace, so
-// they bypass the context BufferManager and do not participate in a session recording timeline.
+// Environment-level shared allocator. It uses the context BufferManager with private command state,
+// so it shares the buffer cache without participating in any Session command timeline.
 class ExternalGpuBufferAllocator : public IAllocator {
  public:
   explicit ExternalGpuBufferAllocator(std::shared_ptr<WebGpuContext> context);
+  ~ExternalGpuBufferAllocator() override;
 
   void* Alloc(size_t size) override;
   void Free(void* p) override;
@@ -59,7 +66,7 @@ class ExternalGpuBufferAllocator : public IAllocator {
 
  private:
   std::shared_ptr<WebGpuContext> context_;
-  std::mutex stats_mutex_;
+  std::unique_ptr<CommandRecordingState> command_state_;
   AllocatorStats stats_;
 };
 
@@ -84,6 +91,11 @@ AllocatorPtr CreateWebGpuAllocator(bool device_free,
                                    std::function<CommandRecordingState&()> recording_getter,
                                    bool is_read_only_allocator,
                                    std::function<bool()> should_submit_zero_initialize = {});
+
+#if defined(ORT_USE_EP_API_ADAPTERS)
+OrtAllocator* CreateWebGpuSessionAllocator(AllocatorPtr allocator);
+bool TryReleaseWebGpuSessionAllocator(OrtAllocator* allocator);
+#endif
 
 }  // namespace webgpu
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/webgpu/allocator.h
+++ b/onnxruntime/core/providers/webgpu/allocator.h
@@ -36,13 +36,7 @@ class GpuBufferAllocator : public IAllocator {
   virtual void Free(void* p) override;
   void GetStats(AllocatorStats* stats) override;
 
-#if defined(ORT_USE_EP_API_ADAPTERS)
-  bool IsStreamAware() const override { return true; }
-  void* AllocOnStream(size_t size, Stream* stream) override;
-#endif
-
  private:
-  void* Allocate(size_t size, bool submit_zero_initialize);
   AllocatorStats stats_;
   std::function<const BufferManager&()> buffer_manager_getter_;
   std::function<CommandRecordingState&()> recording_getter_;
@@ -53,8 +47,7 @@ class GpuBufferAllocator : public IAllocator {
   bool initialize_to_zero_;
 };
 
-// Environment-level shared allocator. It uses the context BufferManager with private command state,
-// so it shares the buffer cache without participating in any Session command timeline.
+// Environment-level allocator. Buffers are not cached and do not use Session command state.
 class ExternalGpuBufferAllocator : public IAllocator {
  public:
   explicit ExternalGpuBufferAllocator(std::shared_ptr<WebGpuContext> context);
@@ -66,7 +59,7 @@ class ExternalGpuBufferAllocator : public IAllocator {
 
  private:
   std::shared_ptr<WebGpuContext> context_;
-  std::unique_ptr<CommandRecordingState> command_state_;
+  std::mutex mutex_;
   AllocatorStats stats_;
 };
 
@@ -91,11 +84,6 @@ AllocatorPtr CreateWebGpuAllocator(bool device_free,
                                    std::function<CommandRecordingState&()> recording_getter,
                                    bool is_read_only_allocator,
                                    std::function<bool()> should_submit_zero_initialize = {});
-
-#if defined(ORT_USE_EP_API_ADAPTERS)
-OrtAllocator* CreateWebGpuSessionAllocator(AllocatorPtr allocator);
-bool TryReleaseWebGpuSessionAllocator(OrtAllocator* allocator);
-#endif
 
 }  // namespace webgpu
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/webgpu/allocator.h
+++ b/onnxruntime/core/providers/webgpu/allocator.h
@@ -5,7 +5,6 @@
 
 #include <functional>
 #include <memory>
-#include <mutex>
 
 #include "core/framework/allocator.h"
 #include "core/framework/ortdevice.h"
@@ -47,21 +46,8 @@ class GpuBufferAllocator : public IAllocator {
   bool initialize_to_zero_;
 };
 
-// Environment-level allocator. Buffers are not cached and do not use Session command state.
-class ExternalGpuBufferAllocator : public IAllocator {
- public:
-  explicit ExternalGpuBufferAllocator(std::shared_ptr<WebGpuContext> context);
-  ~ExternalGpuBufferAllocator() override;
-
-  void* Alloc(size_t size) override;
-  void Free(void* p) override;
-  void GetStats(AllocatorStats* stats) override;
-
- private:
-  std::shared_ptr<WebGpuContext> context_;
-  std::mutex mutex_;
-  AllocatorStats stats_;
-};
+// Environment-level cached allocator with private recording; callers serialize its operations.
+AllocatorPtr CreateSharedWebGpuAllocator(std::shared_ptr<WebGpuContext> context);
 
 // No-op allocator used for the WebGPU device when the context has no Dawn device (a device-free /
 // "virtual device" context). A real GpuBufferAllocator cannot be constructed without a device (its ctor

--- a/onnxruntime/core/providers/webgpu/allocator.h
+++ b/onnxruntime/core/providers/webgpu/allocator.h
@@ -46,7 +46,7 @@ class GpuBufferAllocator : public IAllocator {
   bool initialize_to_zero_;
 };
 
-// Environment-level cached allocator with private recording; callers serialize its operations.
+// Environment-level cached allocator sharing the context's Env recording; callers serialize Env operations.
 AllocatorPtr CreateSharedWebGpuAllocator(std::shared_ptr<WebGpuContext> context);
 
 // No-op allocator used for the WebGPU device when the context has no Dawn device (a device-free /

--- a/onnxruntime/core/providers/webgpu/buffer_manager.cc
+++ b/onnxruntime/core/providers/webgpu/buffer_manager.cc
@@ -522,6 +522,7 @@ void BufferManager::Upload(void* src, WGPUBuffer dst, size_t size) const {
   // shader to write the non-aligned remainder.
   staging_buffer.Unmap();
 
+  auto lock = context_.AcquireContextLock();
   auto& command_encoder = context_.GetCommandEncoder();
   context_.EndComputePass();
   command_encoder.CopyBufferToBuffer(staging_buffer, 0, dst, 0, copy_size);
@@ -540,12 +541,16 @@ void BufferManager::MemCpy(WGPUBuffer src, WGPUBuffer dst, size_t size) const {
               "Source and destination buffers must have enough space for the copy operation. src_size=",
               src_size, ", dst_size=", dst_size, ", copy_size=", copy_size, ".");
 
+  auto lock = context_.AcquireContextLock();
   auto& command_encoder = context_.GetCommandEncoder();
   context_.EndComputePass();
   command_encoder.CopyBufferToBuffer(src, 0, dst, 0, copy_size);
 }
 
 WGPUBuffer BufferManager::Create(size_t size, wgpu::BufferUsage usage) const {
+  // Serialize cache access: the context's BufferManagers are shared across all InferenceSessions
+  // that share this WebGpuContext, and the allocator calls Create/Release from any session thread.
+  auto lock = context_.AcquireContextLock();
   auto& cache = GetCacheManager(usage);
   auto buffer_size = cache.CalculateBufferSize(size);
 
@@ -579,6 +584,7 @@ bool BufferManager::SupportsUMA() const {
 }
 
 void BufferManager::Release(WGPUBuffer buffer) const {
+  auto lock = context_.AcquireContextLock();
   EnforceBufferUnmapped(context_, buffer);
   GetCacheManager(buffer).ReleaseBuffer(buffer);
 }
@@ -592,10 +598,13 @@ void BufferManager::Download(WGPUBuffer src, void* dst, size_t size) const {
   desc.usage = wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::MapRead;
 
   auto staging_buffer = context_.Device().CreateBuffer(&desc);
-  auto& command_encoder = context_.GetCommandEncoder();
-  context_.EndComputePass();
-  command_encoder.CopyBufferToBuffer(src, 0, staging_buffer, 0, buffer_size);
-  context_.Flush(*this);
+  {
+    auto lock = context_.AcquireContextLock();
+    auto& command_encoder = context_.GetCommandEncoder();
+    context_.EndComputePass();
+    command_encoder.CopyBufferToBuffer(src, 0, staging_buffer, 0, buffer_size);
+    context_.Flush(*this);
+  }
 
   // TODO: revise wait in whole project
 
@@ -628,6 +637,7 @@ void BufferManager::Download(WGPUBuffer src, void* dst, size_t size) const {
 }
 
 void BufferManager::RefreshPendingBuffers(GraphCaptureState graph_capture_state) const {
+  auto lock = context_.AcquireContextLock();
   storage_cache_->OnRefresh(graph_capture_state);
   uniform_cache_->OnRefresh(graph_capture_state);
   query_resolve_cache_->OnRefresh(graph_capture_state);

--- a/onnxruntime/core/providers/webgpu/buffer_manager.cc
+++ b/onnxruntime/core/providers/webgpu/buffer_manager.cc
@@ -487,8 +487,9 @@ std::ostream& operator<<(std::ostream& os, BufferCacheMode mode) {
   return os;
 }
 
-BufferManager::BufferManager(WebGpuContext& context, BufferCacheMode storage_buffer_cache_mode, BufferCacheMode uniform_buffer_cache_mode, BufferCacheMode query_resolve_buffer_cache_mode, BufferCacheMode default_buffer_cache_mode)
+BufferManager::BufferManager(WebGpuContext& context, CommandRecordingState& recording, BufferCacheMode storage_buffer_cache_mode, BufferCacheMode uniform_buffer_cache_mode, BufferCacheMode query_resolve_buffer_cache_mode, BufferCacheMode default_buffer_cache_mode)
     : context_{context},
+      recording_{recording},
       storage_cache_{CreateBufferCacheManager(storage_buffer_cache_mode)},
       uniform_cache_{CreateBufferCacheManager(uniform_buffer_cache_mode)},
       query_resolve_cache_{CreateBufferCacheManager(query_resolve_buffer_cache_mode)},
@@ -522,9 +523,8 @@ void BufferManager::Upload(void* src, WGPUBuffer dst, size_t size) const {
   // shader to write the non-aligned remainder.
   staging_buffer.Unmap();
 
-  ORT_THROW_IF_ERROR(context_.EncodeDeferredDispatches());
-  auto& command_encoder = context_.GetCommandEncoder();
-  context_.EndComputePass();
+  auto& command_encoder = context_.GetCommandEncoder(recording_);
+  context_.EndComputePass(recording_);
   command_encoder.CopyBufferToBuffer(staging_buffer, 0, dst, 0, copy_size);
   ORT_THROW_IF_ERROR(context_.Flush(*this));
 }
@@ -541,9 +541,8 @@ void BufferManager::MemCpy(WGPUBuffer src, WGPUBuffer dst, size_t size) const {
               "Source and destination buffers must have enough space for the copy operation. src_size=",
               src_size, ", dst_size=", dst_size, ", copy_size=", copy_size, ".");
 
-  ORT_THROW_IF_ERROR(context_.EncodeDeferredDispatches());
-  auto& command_encoder = context_.GetCommandEncoder();
-  context_.EndComputePass();
+  auto& command_encoder = context_.GetCommandEncoder(recording_);
+  context_.EndComputePass(recording_);
   command_encoder.CopyBufferToBuffer(src, 0, dst, 0, copy_size);
 }
 
@@ -559,9 +558,9 @@ WGPUBuffer BufferManager::Create(size_t size, wgpu::BufferUsage usage, bool init
       // whether that clear is submitted before Create returns. Session::Run defers submission to preserve dispatch
       // batching, while allocations made outside Run submit immediately so subsequent queue work observes the clear.
       auto buffer_guard = wgpu::Buffer::Acquire(buffer);
-      ORT_THROW_IF_ERROR(context_.EncodeDeferredDispatches());
-      context_.EndComputePass();
-      context_.GetCommandEncoder().ClearBuffer(buffer, 0, buffer_size);
+      ORT_THROW_IF_ERROR(context_.EncodeDeferredDispatches(*this));
+      context_.EndComputePass(recording_);
+      context_.GetCommandEncoder(recording_).ClearBuffer(buffer, 0, buffer_size);
       if (submit_zero_initialize) {
         ORT_THROW_IF_ERROR(context_.Flush(*this));
       }
@@ -602,7 +601,7 @@ void BufferManager::Release(WGPUBuffer buffer) const {
 void BufferManager::Download(WGPUBuffer src, void* dst, size_t size) const {
   // Encode pending deferred dispatches before recording the readback; the flush below submits both
   // in order.
-  ORT_THROW_IF_ERROR(context_.EncodeDeferredDispatches());
+  ORT_THROW_IF_ERROR(context_.EncodeDeferredDispatches(*this));
 
   EnforceBufferUnmapped(context_, src);
   auto buffer_size = NormalizeBufferSize(size);
@@ -612,8 +611,8 @@ void BufferManager::Download(WGPUBuffer src, void* dst, size_t size) const {
   desc.usage = wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::MapRead;
 
   auto staging_buffer = context_.Device().CreateBuffer(&desc);
-  auto& command_encoder = context_.GetCommandEncoder();
-  context_.EndComputePass();
+  auto& command_encoder = context_.GetCommandEncoder(recording_);
+  context_.EndComputePass(recording_);
   command_encoder.CopyBufferToBuffer(src, 0, staging_buffer, 0, buffer_size);
   ORT_THROW_IF_ERROR(context_.Flush(*this));
 
@@ -671,8 +670,8 @@ IBufferCacheManager& BufferManager::GetCacheManager(WGPUBuffer buffer) const {
   return GetCacheManager(usage);
 }
 
-std::unique_ptr<BufferManager> BufferManagerFactory::Create(WebGpuContext& context, BufferCacheMode storage_buffer_cache_mode, BufferCacheMode uniform_buffer_cache_mode, BufferCacheMode query_resolve_buffer_cache_mode, BufferCacheMode default_buffer_cache_mode) {
-  return std::make_unique<BufferManager>(context, storage_buffer_cache_mode, uniform_buffer_cache_mode, query_resolve_buffer_cache_mode, default_buffer_cache_mode);
+std::unique_ptr<BufferManager> BufferManagerFactory::Create(WebGpuContext& context, CommandRecordingState& recording, BufferCacheMode storage_buffer_cache_mode, BufferCacheMode uniform_buffer_cache_mode, BufferCacheMode query_resolve_buffer_cache_mode, BufferCacheMode default_buffer_cache_mode) {
+  return std::make_unique<BufferManager>(context, recording, storage_buffer_cache_mode, uniform_buffer_cache_mode, query_resolve_buffer_cache_mode, default_buffer_cache_mode);
 }
 
 }  // namespace webgpu

--- a/onnxruntime/core/providers/webgpu/buffer_manager.cc
+++ b/onnxruntime/core/providers/webgpu/buffer_manager.cc
@@ -487,16 +487,15 @@ std::ostream& operator<<(std::ostream& os, BufferCacheMode mode) {
   return os;
 }
 
-BufferManager::BufferManager(WebGpuContext& context, CommandRecordingState& recording, BufferCacheMode storage_buffer_cache_mode, BufferCacheMode uniform_buffer_cache_mode, BufferCacheMode query_resolve_buffer_cache_mode, BufferCacheMode default_buffer_cache_mode)
+BufferManager::BufferManager(WebGpuContext& context, BufferCacheMode storage_buffer_cache_mode, BufferCacheMode uniform_buffer_cache_mode, BufferCacheMode query_resolve_buffer_cache_mode, BufferCacheMode default_buffer_cache_mode)
     : context_{context},
-      recording_{recording},
       storage_cache_{CreateBufferCacheManager(storage_buffer_cache_mode)},
       uniform_cache_{CreateBufferCacheManager(uniform_buffer_cache_mode)},
       query_resolve_cache_{CreateBufferCacheManager(query_resolve_buffer_cache_mode)},
       default_cache_{CreateBufferCacheManager(default_buffer_cache_mode)} {
 }
 
-void BufferManager::Upload(void* src, WGPUBuffer dst, size_t size) const {
+void BufferManager::Upload(CommandRecordingState& recording, void* src, WGPUBuffer dst, size_t size) const {
   // If the buffer is mapped, we can directly write to it.
   void* mapped_data = wgpuBufferGetMappedRange(dst, 0, WGPU_WHOLE_MAP_SIZE);  // ensure the buffer is mapped
   if (mapped_data) {
@@ -523,13 +522,13 @@ void BufferManager::Upload(void* src, WGPUBuffer dst, size_t size) const {
   // shader to write the non-aligned remainder.
   staging_buffer.Unmap();
 
-  auto& command_encoder = context_.GetCommandEncoder(recording_);
-  context_.EndComputePass(recording_);
+  auto& command_encoder = context_.GetCommandEncoder(recording);
+  context_.EndComputePass(recording);
   command_encoder.CopyBufferToBuffer(staging_buffer, 0, dst, 0, copy_size);
-  ORT_THROW_IF_ERROR(context_.Flush(*this));
+  ORT_THROW_IF_ERROR(context_.Flush(*this, recording));
 }
 
-void BufferManager::MemCpy(WGPUBuffer src, WGPUBuffer dst, size_t size) const {
+void BufferManager::MemCpy(CommandRecordingState& recording, WGPUBuffer src, WGPUBuffer dst, size_t size) const {
   ORT_ENFORCE(src != dst, "Source and destination buffers must be different.");
   EnforceBufferUnmapped(context_, src);
   EnforceBufferUnmapped(context_, dst);
@@ -541,28 +540,33 @@ void BufferManager::MemCpy(WGPUBuffer src, WGPUBuffer dst, size_t size) const {
               "Source and destination buffers must have enough space for the copy operation. src_size=",
               src_size, ", dst_size=", dst_size, ", copy_size=", copy_size, ".");
 
-  auto& command_encoder = context_.GetCommandEncoder(recording_);
-  context_.EndComputePass(recording_);
+  auto& command_encoder = context_.GetCommandEncoder(recording);
+  context_.EndComputePass(recording);
   command_encoder.CopyBufferToBuffer(src, 0, dst, 0, copy_size);
 }
 
-WGPUBuffer BufferManager::Create(size_t size, wgpu::BufferUsage usage, bool initialize_to_zero,
+WGPUBuffer BufferManager::Create(CommandRecordingState& recording, size_t size, wgpu::BufferUsage usage,
+                                 bool initialize_to_zero,
                                  bool submit_zero_initialize) const {
-  auto& cache = GetCacheManager(usage);
-  auto buffer_size = cache.CalculateBufferSize(size);
-
-  auto buffer = cache.TryAcquireCachedBuffer(buffer_size);
+  size_t buffer_size;
+  WGPUBuffer buffer;
+  {
+    std::lock_guard<std::mutex> lock{mutex_};
+    auto& cache = GetCacheManager(usage);
+    buffer_size = cache.CalculateBufferSize(size);
+    buffer = cache.TryAcquireCachedBuffer(buffer_size);
+  }
   if (buffer) {
     if (initialize_to_zero) {
       // initialize_to_zero controls whether a cached buffer is cleared. submit_zero_initialize separately controls
       // whether that clear is submitted before Create returns. Session::Run defers submission to preserve dispatch
       // batching, while allocations made outside Run submit immediately so subsequent queue work observes the clear.
       auto buffer_guard = wgpu::Buffer::Acquire(buffer);
-      ORT_THROW_IF_ERROR(context_.EncodeDeferredDispatches(*this));
-      context_.EndComputePass(recording_);
-      context_.GetCommandEncoder(recording_).ClearBuffer(buffer, 0, buffer_size);
+      ORT_THROW_IF_ERROR(context_.EncodeDeferredDispatches(recording));
+      context_.EndComputePass(recording);
+      context_.GetCommandEncoder(recording).ClearBuffer(buffer, 0, buffer_size);
       if (submit_zero_initialize) {
-        ORT_THROW_IF_ERROR(context_.Flush(*this));
+        ORT_THROW_IF_ERROR(context_.Flush(*this, recording));
       }
       return buffer_guard.MoveToCHandle();
     }
@@ -580,7 +584,10 @@ WGPUBuffer BufferManager::Create(size_t size, wgpu::BufferUsage usage, bool init
 
   ORT_ENFORCE(buffer, "Failed to create GPU buffer: size=", buffer_size, ", usage=", uint64_t(usage), ".");
 
-  cache.RegisterBuffer(buffer, size);
+  {
+    std::lock_guard<std::mutex> lock{mutex_};
+    GetCacheManager(usage).RegisterBuffer(buffer, size);
+  }
   return buffer;
 }
 
@@ -593,15 +600,21 @@ bool BufferManager::SupportsUMA() const {
 #endif  // !defined(__wasm__)
 }
 
-void BufferManager::Release(WGPUBuffer buffer) const {
+void BufferManager::Release(CommandRecordingState& recording, WGPUBuffer buffer) const {
   EnforceBufferUnmapped(context_, buffer);
+  if (recording.has_unsubmitted_work) {
+    recording.pending_buffers.emplace_back(wgpu::Buffer::Acquire(buffer));
+    return;
+  }
+
+  std::lock_guard<std::mutex> lock{mutex_};
   GetCacheManager(buffer).ReleaseBuffer(buffer);
 }
 
-void BufferManager::Download(WGPUBuffer src, void* dst, size_t size) const {
+void BufferManager::Download(CommandRecordingState& recording, WGPUBuffer src, void* dst, size_t size) const {
   // Encode pending deferred dispatches before recording the readback; the flush below submits both
   // in order.
-  ORT_THROW_IF_ERROR(context_.EncodeDeferredDispatches(*this));
+  ORT_THROW_IF_ERROR(context_.EncodeDeferredDispatches(recording));
 
   EnforceBufferUnmapped(context_, src);
   auto buffer_size = NormalizeBufferSize(size);
@@ -611,10 +624,10 @@ void BufferManager::Download(WGPUBuffer src, void* dst, size_t size) const {
   desc.usage = wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::MapRead;
 
   auto staging_buffer = context_.Device().CreateBuffer(&desc);
-  auto& command_encoder = context_.GetCommandEncoder(recording_);
-  context_.EndComputePass(recording_);
+  auto& command_encoder = context_.GetCommandEncoder(recording);
+  context_.EndComputePass(recording);
   command_encoder.CopyBufferToBuffer(src, 0, staging_buffer, 0, buffer_size);
-  ORT_THROW_IF_ERROR(context_.Flush(*this));
+  ORT_THROW_IF_ERROR(context_.Flush(*this, recording));
 
   // TODO: revise wait in whole project
 
@@ -646,11 +659,29 @@ void BufferManager::Download(WGPUBuffer src, void* dst, size_t size) const {
   staging_buffer.Unmap();
 }
 
-void BufferManager::RefreshPendingBuffers(GraphCaptureState graph_capture_state) const {
-  storage_cache_->OnRefresh(graph_capture_state);
-  uniform_cache_->OnRefresh(graph_capture_state);
-  query_resolve_cache_->OnRefresh(graph_capture_state);
-  default_cache_->OnRefresh(graph_capture_state);
+void BufferManager::RefreshPendingBuffers(CommandRecordingState& recording) const {
+  std::lock_guard<std::mutex> lock{mutex_};
+  for (auto& buffer : recording.pending_buffers) {
+    GetCacheManager(buffer.Get()).ReleaseBuffer(buffer.MoveToCHandle());
+  }
+  recording.pending_buffers.clear();
+
+  storage_cache_->OnRefresh(recording.graph_capture_state);
+  uniform_cache_->OnRefresh(recording.graph_capture_state);
+  query_resolve_cache_->OnRefresh(recording.graph_capture_state);
+  default_cache_->OnRefresh(recording.graph_capture_state);
+}
+
+std::vector<std::pair<size_t, WGPUBuffer>> BufferManager::ExtractCachedBuffers(wgpu::BufferUsage usage) {
+  std::lock_guard<std::mutex> lock{mutex_};
+  return GetCacheManager(usage).ExtractCachedBuffers();
+}
+
+void BufferManager::AbsorbCachedBuffers(
+    wgpu::BufferUsage usage,
+    std::vector<std::pair<size_t, WGPUBuffer>>&& buffers) {
+  std::lock_guard<std::mutex> lock{mutex_};
+  GetCacheManager(usage).AbsorbCachedBuffers(std::move(buffers));
 }
 
 IBufferCacheManager& BufferManager::GetCacheManager(wgpu::BufferUsage usage) const {
@@ -670,8 +701,8 @@ IBufferCacheManager& BufferManager::GetCacheManager(WGPUBuffer buffer) const {
   return GetCacheManager(usage);
 }
 
-std::unique_ptr<BufferManager> BufferManagerFactory::Create(WebGpuContext& context, CommandRecordingState& recording, BufferCacheMode storage_buffer_cache_mode, BufferCacheMode uniform_buffer_cache_mode, BufferCacheMode query_resolve_buffer_cache_mode, BufferCacheMode default_buffer_cache_mode) {
-  return std::make_unique<BufferManager>(context, recording, storage_buffer_cache_mode, uniform_buffer_cache_mode, query_resolve_buffer_cache_mode, default_buffer_cache_mode);
+std::unique_ptr<BufferManager> BufferManagerFactory::Create(WebGpuContext& context, BufferCacheMode storage_buffer_cache_mode, BufferCacheMode uniform_buffer_cache_mode, BufferCacheMode query_resolve_buffer_cache_mode, BufferCacheMode default_buffer_cache_mode) {
+  return std::make_unique<BufferManager>(context, storage_buffer_cache_mode, uniform_buffer_cache_mode, query_resolve_buffer_cache_mode, default_buffer_cache_mode);
 }
 
 }  // namespace webgpu

--- a/onnxruntime/core/providers/webgpu/buffer_manager.cc
+++ b/onnxruntime/core/providers/webgpu/buffer_manager.cc
@@ -9,10 +9,6 @@ namespace webgpu {
 
 namespace {
 
-constexpr size_t NormalizeBufferSize(size_t size) {
-  return (size + 15) / 16 * 16;
-}
-
 // WebGPU requires that the copy size in CopyBufferToBuffer must be a multiple of 4 bytes.
 constexpr size_t NormalizeCopySize(size_t size) {
   return (size + 3) / 4 * 4;
@@ -136,37 +132,6 @@ class SimpleCacheManager : public IBufferCacheManager {
 };
 
 // TODO: maybe use different bucket size for storage and uniform buffers?
-constexpr std::initializer_list<std::pair<const size_t, size_t>> BUCKET_DEFAULT_LIMIT_TABLE = {
-    {64, 250},
-    {128, 200},
-    {256, 200},
-    {512, 200},
-    {2048, 230},
-    {4096, 200},
-    {8192, 50},
-    {16384, 50},
-    {32768, 50},
-    {65536, 50},
-    {131072, 50},
-    {262144, 50},
-    {524288, 50},
-    {1048576, 50},
-    {2097152, 30},
-    {4194304, 20},
-    {8388608, 10},
-    {12582912, 10},
-    {16777216, 10},
-    {26214400, 15},
-    {33554432, 22},
-    {44236800, 2},
-    {58982400, 6},
-    // we don't want to cache the bucket sizes below but not caching them
-    // results in some major performance hits for models like sd-turbo.
-    {67108864, 6},
-    {134217728, 6},
-    {167772160, 6},
-};
-
 class BucketCacheManager : public IBufferCacheManager {
  public:
   BucketCacheManager(SharedBufferPool& pool, const CommandRecordingState& recording)
@@ -442,83 +407,6 @@ std::unique_ptr<IBufferCacheManager> CreateBufferCacheManager(BufferCacheMode ca
     default:
       ORT_NOT_IMPLEMENTED("Unsupported buffer cache mode");
   }
-}
-
-SharedBufferPool::SharedBufferPool(std::unordered_map<size_t, size_t> limits)
-    : limits_{std::move(limits)} {
-  sorted_sizes_.reserve(limits_.size());
-  for (const auto& [size, limit] : limits_) {
-    sorted_sizes_.push_back(size);
-  }
-  std::sort(sorted_sizes_.begin(), sorted_sizes_.end());
-
-#ifndef NDEBUG  // if debug build
-  ORT_ENFORCE(std::all_of(sorted_sizes_.begin(), sorted_sizes_.end(),
-                          [](size_t size) { return size % 16 == 0; }),
-              "Bucket sizes must be multiples of 16.");
-#endif
-}
-
-SharedBufferPool::~SharedBufferPool() {
-  for (auto& [size, buffers] : free_buffers_) {
-    for (auto* buffer : buffers) {
-      wgpuBufferRelease(buffer);
-    }
-  }
-}
-
-size_t SharedBufferPool::CalculateBufferSize(size_t request_size) const {
-  auto it = std::lower_bound(sorted_sizes_.begin(), sorted_sizes_.end(), request_size);
-  return it == sorted_sizes_.end() ? NormalizeBufferSize(request_size) : *it;
-}
-
-WGPUBuffer SharedBufferPool::TryAcquire(size_t buffer_size) {
-  std::lock_guard<std::mutex> lock(mutex_);
-  auto it = free_buffers_.find(buffer_size);
-  if (it == free_buffers_.end() || it->second.empty()) {
-    return nullptr;
-  }
-  auto buffer = it->second.back();
-  it->second.pop_back();
-  return buffer;
-}
-
-void SharedBufferPool::Return(std::vector<std::pair<WGPUBuffer, size_t>>& buffers) {
-  if (buffers.empty()) {
-    return;
-  }
-
-  // Collected under the lock, released outside it: wgpuBufferRelease is a device call and has no
-  // business inside a critical section that other sessions are waiting on.
-  std::vector<WGPUBuffer> to_release;
-  {
-    std::lock_guard<std::mutex> lock(mutex_);
-    for (auto& [buffer, size] : buffers) {
-      auto& bucket = free_buffers_[size];
-      auto limit = limits_.find(size);
-      const bool bounded = !limits_.empty();
-      if (bounded && (limit == limits_.end() || bucket.size() >= limit->second)) {
-        to_release.push_back(buffer);
-      } else {
-        bucket.push_back(buffer);
-      }
-    }
-  }
-  buffers.clear();
-
-  for (auto* buffer : to_release) {
-    wgpuBufferRelease(buffer);
-  }
-}
-
-std::unique_ptr<SharedBufferPool> CreateDefaultStorageBufferPool() {
-  return std::make_unique<SharedBufferPool>(
-      std::unordered_map<size_t, size_t>{BUCKET_DEFAULT_LIMIT_TABLE});
-}
-
-std::unique_ptr<SharedBufferPool> CreateDefaultUniformBufferPool() {
-  // Unbounded: uniform buffers are tiny and the working set is naturally small.
-  return std::make_unique<SharedBufferPool>(std::unordered_map<size_t, size_t>{});
 }
 
 std::ostream& operator<<(std::ostream& os, BufferCacheMode mode) {

--- a/onnxruntime/core/providers/webgpu/buffer_manager.cc
+++ b/onnxruntime/core/providers/webgpu/buffer_manager.cc
@@ -24,6 +24,11 @@ void EnforceBufferUnmapped(WebGpuContext& context, WGPUBuffer buffer) {
   }
 }
 
+void ReturnOne(SharedBufferPool& pool, WGPUBuffer buffer, size_t size) {
+  std::vector<std::pair<WGPUBuffer, size_t>> one{{buffer, size}};
+  pool.Return(one);
+}
+
 }  // namespace
 
 class DisabledCacheManager : public IBufferCacheManager {
@@ -85,51 +90,49 @@ class LazyReleaseCacheManager : public IBufferCacheManager {
 };
 
 class SimpleCacheManager : public IBufferCacheManager {
+ public:
+  SimpleCacheManager(SharedBufferPool& pool, const CommandRecordingState& recording)
+      : pool_{pool}, recording_{recording} {}
+
   size_t CalculateBufferSize(size_t request_size) override {
     return NormalizeBufferSize(request_size);
   }
 
   WGPUBuffer TryAcquireCachedBuffer(size_t buffer_size) override {
-    auto it = buffers_.find(buffer_size);
-    if (it != buffers_.end() && !it->second.empty()) {
-      auto buffer = it->second.back();
-      it->second.pop_back();
-      return buffer;
-    }
-
-    return nullptr;
+    return pool_.TryAcquire(buffer_size);
   }
 
   void RegisterBuffer(WGPUBuffer /*buffer*/, size_t /*request_size*/) override {
     // no-op
   }
 
+  // Released buffers stay private to this session until OnRefresh, which runs after the
+  // session's commands have been submitted. Publishing them earlier would let another session
+  // write into a buffer that this session has recorded but not yet submitted work for.
   void ReleaseBuffer(WGPUBuffer buffer) override {
-    pending_buffers_.emplace_back(buffer);
+    const size_t size = static_cast<size_t>(wgpuBufferGetSize(buffer));
+    if (!recording_.has_unsubmitted_work.load(std::memory_order_acquire)) {
+      ReturnOne(pool_, buffer, size);
+      return;
+    }
+    pending_buffers_.emplace_back(buffer, size);
   }
 
   void OnRefresh(GraphCaptureState /*graph_capture_state*/) override {
-    for (auto& buffer : pending_buffers_) {
-      buffers_[static_cast<size_t>(wgpuBufferGetSize(buffer))].emplace_back(buffer);
-    }
-    pending_buffers_.clear();
+    pool_.Return(pending_buffers_);
   }
 
  public:
   ~SimpleCacheManager() {
-    for (auto& buffer : pending_buffers_) {
+    for (auto& [buffer, size] : pending_buffers_) {
       wgpuBufferRelease(buffer);
-    }
-    for (auto& pair : buffers_) {
-      for (auto& buffer : pair.second) {
-        wgpuBufferRelease(buffer);
-      }
     }
   }
 
  protected:
-  std::map<size_t, std::vector<WGPUBuffer>> buffers_;
-  std::vector<WGPUBuffer> pending_buffers_;
+  SharedBufferPool& pool_;
+  const CommandRecordingState& recording_;
+  std::vector<std::pair<WGPUBuffer, size_t>> pending_buffers_;
 };
 
 // TODO: maybe use different bucket size for storage and uniform buffers?
@@ -166,31 +169,25 @@ constexpr std::initializer_list<std::pair<const size_t, size_t>> BUCKET_DEFAULT_
 
 class BucketCacheManager : public IBufferCacheManager {
  public:
-  BucketCacheManager() : buckets_limit_{BUCKET_DEFAULT_LIMIT_TABLE} {
-    Initialize();
-  }
-  BucketCacheManager(std::unordered_map<size_t, size_t>&& buckets_limit) : buckets_limit_{buckets_limit} {
-    Initialize();
-  }
+  BucketCacheManager(SharedBufferPool& pool, const CommandRecordingState& recording)
+      : pool_{pool}, recording_{recording} {}
 
   size_t CalculateBufferSize(size_t request_size) override {
-    // binary serch size
-    auto it = std::lower_bound(buckets_keys_.begin(), buckets_keys_.end(), request_size);
-    if (it == buckets_keys_.end()) {
-      return NormalizeBufferSize(request_size);
-    } else {
-      return *it;
-    }
+    return pool_.CalculateBufferSize(request_size);
   }
 
+  // Prefer buffers this session released earlier in the current recording window: reusing them
+  // is safe without any submit because this session's commands execute in the order it recorded
+  // them. Only fall back to the shared pool, which holds buffers other sessions have already
+  // submitted work for.
   WGPUBuffer TryAcquireCachedBuffer(size_t buffer_size) override {
-    auto it = buckets_.find(buffer_size);
-    if (it != buckets_.end() && !it->second.empty()) {
+    auto it = unsubmitted_.find(buffer_size);
+    if (it != unsubmitted_.end() && !it->second.empty()) {
       auto buffer = it->second.back();
       it->second.pop_back();
       return buffer;
     }
-    return nullptr;
+    return pool_.TryAcquire(buffer_size);
   }
 
   void RegisterBuffer(WGPUBuffer /*buffer*/, size_t /*request_size*/) override {
@@ -198,62 +195,43 @@ class BucketCacheManager : public IBufferCacheManager {
   }
 
   void ReleaseBuffer(WGPUBuffer buffer) override {
-    auto buffer_size = static_cast<size_t>(wgpuBufferGetSize(buffer));
-
-    auto it = buckets_.find(buffer_size);
-    if (it != buckets_.end() && it->second.size() < buckets_limit_[buffer_size]) {
-      it->second.emplace_back(buffer);
-    } else {
-      pending_buffers_.emplace_back(buffer, buffer_size);
+    const size_t size = static_cast<size_t>(wgpuBufferGetSize(buffer));
+    // With nothing recorded but unsubmitted, this buffer's last use is already on the queue, so
+    // it is safe to publish immediately. This is the path taken when tensors are dropped outside
+    // a Run; without it every session would sit on its final outputs until its next submit.
+    if (!recording_.has_unsubmitted_work.load(std::memory_order_acquire)) {
+      ReturnOne(pool_, buffer, size);
+      return;
     }
+    unsubmitted_[size].emplace_back(buffer);
   }
 
+  // Called after this session submits, which is the point at which its released buffers become
+  // safe for other sessions to use.
   void OnRefresh(GraphCaptureState /*graph_capture_state*/) override {
-    for (auto& [buffer, buffer_size] : pending_buffers_) {
-      auto it = buckets_.find(buffer_size);
-      if (it != buckets_.end() && it->second.size() < buckets_limit_[buffer_size]) {
-        it->second.emplace_back(buffer);
-      } else {
-        wgpuBufferRelease(buffer);
+    std::vector<std::pair<WGPUBuffer, size_t>> to_return;
+    for (auto& [size, buffers] : unsubmitted_) {
+      for (auto* buffer : buffers) {
+        to_return.emplace_back(buffer, size);
       }
+      buffers.clear();
     }
-    pending_buffers_.clear();
+    pool_.Return(to_return);
   }
 
   ~BucketCacheManager() {
-    for (auto& pair : buckets_) {
-      for (auto& buffer : pair.second) {
+    for (auto& [size, buffers] : unsubmitted_) {
+      for (auto* buffer : buffers) {
         wgpuBufferRelease(buffer);
       }
-    }
-    for (auto& buffer_info : pending_buffers_) {
-      wgpuBufferRelease(buffer_info.first);
     }
   }
 
  protected:
-  void Initialize() {
-    buckets_keys_.reserve(buckets_limit_.size());
-    buckets_.reserve(buckets_limit_.size());
-    for (const auto& pair : buckets_limit_) {
-      buckets_keys_.push_back(pair.first);
-      buckets_.emplace(pair.first, std::vector<WGPUBuffer>());
-    }
-    std::sort(buckets_keys_.begin(), buckets_keys_.end());
-
-#ifndef NDEBUG  // if debug build
-    ORT_ENFORCE(std::all_of(buckets_keys_.begin(), buckets_keys_.end(), [](size_t size) { return size % 16 == 0; }),
-                "Bucket sizes must be multiples of 16.");
-
-    for (size_t i = 1; i < buckets_keys_.size(); ++i) {
-      ORT_ENFORCE(buckets_keys_[i] > buckets_keys_[i - 1], "Bucket sizes must be in increasing order.");
-    }
-#endif
-  }
-  std::unordered_map<size_t, size_t> buckets_limit_;
-  std::unordered_map<size_t, std::vector<WGPUBuffer>> buckets_;
-  std::vector<std::pair<WGPUBuffer, size_t>> pending_buffers_;
-  std::vector<size_t> buckets_keys_;
+  SharedBufferPool& pool_;
+  const CommandRecordingState& recording_;
+  // Released by this session but not yet submitted; private, so no synchronization is needed.
+  std::unordered_map<size_t, std::vector<WGPUBuffer>> unsubmitted_;
 };
 
 class GraphCacheManager : public IBufferCacheManager {
@@ -442,16 +420,21 @@ class GraphSimpleCacheManager : public IBufferCacheManager {
   std::vector<WGPUBuffer> captured_buffers_;
 };
 
-std::unique_ptr<IBufferCacheManager> CreateBufferCacheManager(BufferCacheMode cache_mode) {
+std::unique_ptr<IBufferCacheManager> CreateBufferCacheManager(BufferCacheMode cache_mode,
+                                                             SharedBufferPool& storage_pool,
+                                                             SharedBufferPool& uniform_pool,
+                                                             const CommandRecordingState& recording) {
   switch (cache_mode) {
     case BufferCacheMode::Disabled:
       return std::make_unique<DisabledCacheManager>();
     case BufferCacheMode::LazyRelease:
       return std::make_unique<LazyReleaseCacheManager>();
     case BufferCacheMode::Simple:
-      return std::make_unique<SimpleCacheManager>();
+      return std::make_unique<SimpleCacheManager>(uniform_pool, recording);
     case BufferCacheMode::Bucket:
-      return std::make_unique<BucketCacheManager>();
+      return std::make_unique<BucketCacheManager>(storage_pool, recording);
+    // Graph modes intentionally keep their buffers private: replay reuses bind groups that were
+    // recorded against specific buffers, so those must not be handed to another session.
     case BufferCacheMode::Graph:
       return std::make_unique<GraphCacheManager>();
     case BufferCacheMode::GraphSimple:
@@ -459,6 +442,83 @@ std::unique_ptr<IBufferCacheManager> CreateBufferCacheManager(BufferCacheMode ca
     default:
       ORT_NOT_IMPLEMENTED("Unsupported buffer cache mode");
   }
+}
+
+SharedBufferPool::SharedBufferPool(std::unordered_map<size_t, size_t> limits)
+    : limits_{std::move(limits)} {
+  sorted_sizes_.reserve(limits_.size());
+  for (const auto& [size, limit] : limits_) {
+    sorted_sizes_.push_back(size);
+  }
+  std::sort(sorted_sizes_.begin(), sorted_sizes_.end());
+
+#ifndef NDEBUG  // if debug build
+  ORT_ENFORCE(std::all_of(sorted_sizes_.begin(), sorted_sizes_.end(),
+                          [](size_t size) { return size % 16 == 0; }),
+              "Bucket sizes must be multiples of 16.");
+#endif
+}
+
+SharedBufferPool::~SharedBufferPool() {
+  for (auto& [size, buffers] : free_buffers_) {
+    for (auto* buffer : buffers) {
+      wgpuBufferRelease(buffer);
+    }
+  }
+}
+
+size_t SharedBufferPool::CalculateBufferSize(size_t request_size) const {
+  auto it = std::lower_bound(sorted_sizes_.begin(), sorted_sizes_.end(), request_size);
+  return it == sorted_sizes_.end() ? NormalizeBufferSize(request_size) : *it;
+}
+
+WGPUBuffer SharedBufferPool::TryAcquire(size_t buffer_size) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  auto it = free_buffers_.find(buffer_size);
+  if (it == free_buffers_.end() || it->second.empty()) {
+    return nullptr;
+  }
+  auto buffer = it->second.back();
+  it->second.pop_back();
+  return buffer;
+}
+
+void SharedBufferPool::Return(std::vector<std::pair<WGPUBuffer, size_t>>& buffers) {
+  if (buffers.empty()) {
+    return;
+  }
+
+  // Collected under the lock, released outside it: wgpuBufferRelease is a device call and has no
+  // business inside a critical section that other sessions are waiting on.
+  std::vector<WGPUBuffer> to_release;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    for (auto& [buffer, size] : buffers) {
+      auto& bucket = free_buffers_[size];
+      auto limit = limits_.find(size);
+      const bool bounded = !limits_.empty();
+      if (bounded && (limit == limits_.end() || bucket.size() >= limit->second)) {
+        to_release.push_back(buffer);
+      } else {
+        bucket.push_back(buffer);
+      }
+    }
+  }
+  buffers.clear();
+
+  for (auto* buffer : to_release) {
+    wgpuBufferRelease(buffer);
+  }
+}
+
+std::unique_ptr<SharedBufferPool> CreateDefaultStorageBufferPool() {
+  return std::make_unique<SharedBufferPool>(
+      std::unordered_map<size_t, size_t>{BUCKET_DEFAULT_LIMIT_TABLE});
+}
+
+std::unique_ptr<SharedBufferPool> CreateDefaultUniformBufferPool() {
+  // Unbounded: uniform buffers are tiny and the working set is naturally small.
+  return std::make_unique<SharedBufferPool>(std::unordered_map<size_t, size_t>{});
 }
 
 std::ostream& operator<<(std::ostream& os, BufferCacheMode mode) {
@@ -487,12 +547,13 @@ std::ostream& operator<<(std::ostream& os, BufferCacheMode mode) {
   return os;
 }
 
-BufferManager::BufferManager(WebGpuContext& context, BufferCacheMode storage_buffer_cache_mode, BufferCacheMode uniform_buffer_cache_mode, BufferCacheMode query_resolve_buffer_cache_mode, BufferCacheMode default_buffer_cache_mode)
+BufferManager::BufferManager(WebGpuContext& context, CommandRecordingState& recording, BufferCacheMode storage_buffer_cache_mode, BufferCacheMode uniform_buffer_cache_mode, BufferCacheMode query_resolve_buffer_cache_mode, BufferCacheMode default_buffer_cache_mode)
     : context_{context},
-      storage_cache_{CreateBufferCacheManager(storage_buffer_cache_mode)},
-      uniform_cache_{CreateBufferCacheManager(uniform_buffer_cache_mode)},
-      query_resolve_cache_{CreateBufferCacheManager(query_resolve_buffer_cache_mode)},
-      default_cache_{CreateBufferCacheManager(default_buffer_cache_mode)} {
+      recording_{recording},
+      storage_cache_{CreateBufferCacheManager(storage_buffer_cache_mode, context.SharedStorageBufferPool(), context.SharedUniformBufferPool(), recording)},
+      uniform_cache_{CreateBufferCacheManager(uniform_buffer_cache_mode, context.SharedStorageBufferPool(), context.SharedUniformBufferPool(), recording)},
+      query_resolve_cache_{CreateBufferCacheManager(query_resolve_buffer_cache_mode, context.SharedStorageBufferPool(), context.SharedUniformBufferPool(), recording)},
+      default_cache_{CreateBufferCacheManager(default_buffer_cache_mode, context.SharedStorageBufferPool(), context.SharedUniformBufferPool(), recording)} {
 }
 
 void BufferManager::Upload(void* src, WGPUBuffer dst, size_t size) const {
@@ -522,9 +583,8 @@ void BufferManager::Upload(void* src, WGPUBuffer dst, size_t size) const {
   // shader to write the non-aligned remainder.
   staging_buffer.Unmap();
 
-  auto lock = context_.AcquireContextLock();
-  auto& command_encoder = context_.GetCommandEncoder();
-  context_.EndComputePass();
+  auto& command_encoder = context_.GetCommandEncoder(recording_);
+  context_.EndComputePass(recording_);
   command_encoder.CopyBufferToBuffer(staging_buffer, 0, dst, 0, copy_size);
   context_.Flush(*this);
 }
@@ -541,16 +601,12 @@ void BufferManager::MemCpy(WGPUBuffer src, WGPUBuffer dst, size_t size) const {
               "Source and destination buffers must have enough space for the copy operation. src_size=",
               src_size, ", dst_size=", dst_size, ", copy_size=", copy_size, ".");
 
-  auto lock = context_.AcquireContextLock();
-  auto& command_encoder = context_.GetCommandEncoder();
-  context_.EndComputePass();
+  auto& command_encoder = context_.GetCommandEncoder(recording_);
+  context_.EndComputePass(recording_);
   command_encoder.CopyBufferToBuffer(src, 0, dst, 0, copy_size);
 }
 
 WGPUBuffer BufferManager::Create(size_t size, wgpu::BufferUsage usage) const {
-  // Serialize cache access: the context's BufferManagers are shared across all InferenceSessions
-  // that share this WebGpuContext, and the allocator calls Create/Release from any session thread.
-  auto lock = context_.AcquireContextLock();
   auto& cache = GetCacheManager(usage);
   auto buffer_size = cache.CalculateBufferSize(size);
 
@@ -584,7 +640,6 @@ bool BufferManager::SupportsUMA() const {
 }
 
 void BufferManager::Release(WGPUBuffer buffer) const {
-  auto lock = context_.AcquireContextLock();
   EnforceBufferUnmapped(context_, buffer);
   GetCacheManager(buffer).ReleaseBuffer(buffer);
 }
@@ -598,13 +653,10 @@ void BufferManager::Download(WGPUBuffer src, void* dst, size_t size) const {
   desc.usage = wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::MapRead;
 
   auto staging_buffer = context_.Device().CreateBuffer(&desc);
-  {
-    auto lock = context_.AcquireContextLock();
-    auto& command_encoder = context_.GetCommandEncoder();
-    context_.EndComputePass();
-    command_encoder.CopyBufferToBuffer(src, 0, staging_buffer, 0, buffer_size);
-    context_.Flush(*this);
-  }
+  auto& command_encoder = context_.GetCommandEncoder(recording_);
+  context_.EndComputePass(recording_);
+  command_encoder.CopyBufferToBuffer(src, 0, staging_buffer, 0, buffer_size);
+  context_.Flush(*this);
 
   // TODO: revise wait in whole project
 
@@ -637,7 +689,6 @@ void BufferManager::Download(WGPUBuffer src, void* dst, size_t size) const {
 }
 
 void BufferManager::RefreshPendingBuffers(GraphCaptureState graph_capture_state) const {
-  auto lock = context_.AcquireContextLock();
   storage_cache_->OnRefresh(graph_capture_state);
   uniform_cache_->OnRefresh(graph_capture_state);
   query_resolve_cache_->OnRefresh(graph_capture_state);
@@ -661,8 +712,8 @@ IBufferCacheManager& BufferManager::GetCacheManager(WGPUBuffer buffer) const {
   return GetCacheManager(usage);
 }
 
-std::unique_ptr<BufferManager> BufferManagerFactory::Create(WebGpuContext& context, BufferCacheMode storage_buffer_cache_mode, BufferCacheMode uniform_buffer_cache_mode, BufferCacheMode query_resolve_buffer_cache_mode, BufferCacheMode default_buffer_cache_mode) {
-  return std::make_unique<BufferManager>(context, storage_buffer_cache_mode, uniform_buffer_cache_mode, query_resolve_buffer_cache_mode, default_buffer_cache_mode);
+std::unique_ptr<BufferManager> BufferManagerFactory::Create(WebGpuContext& context, CommandRecordingState& recording, BufferCacheMode storage_buffer_cache_mode, BufferCacheMode uniform_buffer_cache_mode, BufferCacheMode query_resolve_buffer_cache_mode, BufferCacheMode default_buffer_cache_mode) {
+  return std::make_unique<BufferManager>(context, recording, storage_buffer_cache_mode, uniform_buffer_cache_mode, query_resolve_buffer_cache_mode, default_buffer_cache_mode);
 }
 
 }  // namespace webgpu

--- a/onnxruntime/core/providers/webgpu/buffer_manager.cc
+++ b/onnxruntime/core/providers/webgpu/buffer_manager.cc
@@ -111,7 +111,7 @@ class SimpleCacheManager : public IBufferCacheManager {
   // write into a buffer that this session has recorded but not yet submitted work for.
   void ReleaseBuffer(WGPUBuffer buffer) override {
     const size_t size = static_cast<size_t>(wgpuBufferGetSize(buffer));
-    if (!recording_.has_unsubmitted_work.load(std::memory_order_acquire)) {
+    if (!recording_.has_unsubmitted_work) {
       ReturnOne(pool_, buffer, size);
       return;
     }
@@ -199,7 +199,7 @@ class BucketCacheManager : public IBufferCacheManager {
     // With nothing recorded but unsubmitted, this buffer's last use is already on the queue, so
     // it is safe to publish immediately. This is the path taken when tensors are dropped outside
     // a Run; without it every session would sit on its final outputs until its next submit.
-    if (!recording_.has_unsubmitted_work.load(std::memory_order_acquire)) {
+    if (!recording_.has_unsubmitted_work) {
       ReturnOne(pool_, buffer, size);
       return;
     }

--- a/onnxruntime/core/providers/webgpu/buffer_manager.cc
+++ b/onnxruntime/core/providers/webgpu/buffer_manager.cc
@@ -550,11 +550,11 @@ void BufferManager::MemCpy(CommandRecordingState& recording, WGPUBuffer src, WGP
 WGPUBuffer BufferManager::Create(CommandRecordingState& recording, size_t size, wgpu::BufferUsage usage,
                                  bool initialize_to_zero,
                                  bool submit_zero_initialize) const {
+  auto& cache = GetCacheManager(usage);
   size_t buffer_size;
   WGPUBuffer buffer;
   {
     std::lock_guard<std::mutex> lock{mutex_};
-    auto& cache = GetCacheManager(usage);
     buffer_size = cache.CalculateBufferSize(size);
     buffer = cache.TryAcquireCachedBuffer(buffer_size);
   }
@@ -586,7 +586,7 @@ WGPUBuffer BufferManager::Create(CommandRecordingState& recording, size_t size, 
 
   ORT_ENFORCE(buffer, "Failed to create GPU buffer: size=", buffer_size, ", usage=", uint64_t(usage), ".");
 
-  GetCacheManager(usage).RegisterBuffer(buffer, size);
+  cache.RegisterBuffer(buffer, size);
   return buffer;
 }
 

--- a/onnxruntime/core/providers/webgpu/buffer_manager.cc
+++ b/onnxruntime/core/providers/webgpu/buffer_manager.cc
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 #include "core/providers/webgpu/buffer_manager.h"
-#include "core/common/safeint.h"
 #include "core/providers/webgpu/webgpu_context.h"
 
 namespace onnxruntime {
@@ -10,13 +9,13 @@ namespace webgpu {
 
 namespace {
 
-size_t NormalizeBufferSize(size_t size) {
-  return (SafeInt<size_t>(size) + 15) / 16 * 16;
+constexpr size_t NormalizeBufferSize(size_t size) {
+  return (size + 15) / 16 * 16;
 }
 
 // WebGPU requires that the copy size in CopyBufferToBuffer must be a multiple of 4 bytes.
-size_t NormalizeCopySize(size_t size) {
-  return (SafeInt<size_t>(size) + 3) / 4 * 4;
+constexpr size_t NormalizeCopySize(size_t size) {
+  return (size + 3) / 4 * 4;
 }
 
 void EnforceBufferUnmapped(WebGpuContext& context, WGPUBuffer buffer) {
@@ -498,10 +497,8 @@ BufferManager::BufferManager(WebGpuContext& context, BufferCacheMode storage_buf
 
 void BufferManager::Upload(CommandRecordingState& recording, void* src, WGPUBuffer dst, size_t size) const {
   // If the buffer is mapped, we can directly write to it.
-  void* mapped_data = nullptr;
-  if (wgpuBufferGetMapState(dst) == WGPUBufferMapState_Mapped) {
-    mapped_data = wgpuBufferGetMappedRange(dst, 0, WGPU_WHOLE_MAP_SIZE);
-    ORT_ENFORCE(mapped_data, "Failed to access mapped WebGPU upload buffer.");
+  void* mapped_data = wgpuBufferGetMappedRange(dst, 0, WGPU_WHOLE_MAP_SIZE);  // ensure the buffer is mapped
+  if (mapped_data) {
     memcpy(mapped_data, src, size);
     wgpuBufferUnmap(dst);
     return;
@@ -517,11 +514,15 @@ void BufferManager::Upload(CommandRecordingState& recording, void* src, WGPUBuff
 
   auto staging_buffer = context_.Device().CreateBuffer(&desc);
   mapped_data = staging_buffer.GetMappedRange();
-  ORT_ENFORCE(mapped_data, "Failed to map WebGPU copy staging buffer.");
   memcpy(mapped_data, src, size);
-  memset(static_cast<uint8_t*>(mapped_data) + size, 0, copy_size - size);
+  // NOTE: When copy_size != size (due to 4-byte alignment requirement of CopyBufferToBuffer),
+  // the trailing bytes [size, copy_size) in the staging buffer contain uninitialized data.
+  // This dirty data gets copied into the destination buffer and may cause problems.
+  // A possible solution is to use CopyBufferToBuffer for the aligned portion and a compute
+  // shader to write the non-aligned remainder.
   staging_buffer.Unmap();
 
+  ORT_THROW_IF_ERROR(context_.EncodeDeferredDispatches(recording));
   auto& command_encoder = context_.GetCommandEncoder(recording);
   context_.EndComputePass(recording);
   command_encoder.CopyBufferToBuffer(staging_buffer, 0, dst, 0, copy_size);
@@ -540,6 +541,7 @@ void BufferManager::MemCpy(CommandRecordingState& recording, WGPUBuffer src, WGP
               "Source and destination buffers must have enough space for the copy operation. src_size=",
               src_size, ", dst_size=", dst_size, ", copy_size=", copy_size, ".");
 
+  ORT_THROW_IF_ERROR(context_.EncodeDeferredDispatches(recording));
   auto& command_encoder = context_.GetCommandEncoder(recording);
   context_.EndComputePass(recording);
   command_encoder.CopyBufferToBuffer(src, 0, dst, 0, copy_size);
@@ -584,10 +586,7 @@ WGPUBuffer BufferManager::Create(CommandRecordingState& recording, size_t size, 
 
   ORT_ENFORCE(buffer, "Failed to create GPU buffer: size=", buffer_size, ", usage=", uint64_t(usage), ".");
 
-  {
-    std::lock_guard<std::mutex> lock{mutex_};
-    GetCacheManager(usage).RegisterBuffer(buffer, size);
-  }
+  GetCacheManager(usage).RegisterBuffer(buffer, size);
   return buffer;
 }
 
@@ -617,7 +616,7 @@ void BufferManager::Download(CommandRecordingState& recording, WGPUBuffer src, v
   ORT_THROW_IF_ERROR(context_.EncodeDeferredDispatches(recording));
 
   EnforceBufferUnmapped(context_, src);
-  auto buffer_size = NormalizeCopySize(size);
+  auto buffer_size = NormalizeBufferSize(size);
 
   wgpu::BufferDescriptor desc{};
   desc.size = buffer_size;
@@ -670,18 +669,6 @@ void BufferManager::RefreshPendingBuffers(CommandRecordingState& recording) cons
   uniform_cache_->OnRefresh(recording.graph_capture_state);
   query_resolve_cache_->OnRefresh(recording.graph_capture_state);
   default_cache_->OnRefresh(recording.graph_capture_state);
-}
-
-std::vector<std::pair<size_t, WGPUBuffer>> BufferManager::ExtractCachedBuffers(wgpu::BufferUsage usage) {
-  std::lock_guard<std::mutex> lock{mutex_};
-  return GetCacheManager(usage).ExtractCachedBuffers();
-}
-
-void BufferManager::AbsorbCachedBuffers(
-    wgpu::BufferUsage usage,
-    std::vector<std::pair<size_t, WGPUBuffer>>&& buffers) {
-  std::lock_guard<std::mutex> lock{mutex_};
-  GetCacheManager(usage).AbsorbCachedBuffers(std::move(buffers));
 }
 
 IBufferCacheManager& BufferManager::GetCacheManager(wgpu::BufferUsage usage) const {

--- a/onnxruntime/core/providers/webgpu/buffer_manager.cc
+++ b/onnxruntime/core/providers/webgpu/buffer_manager.cc
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include "core/providers/webgpu/buffer_manager.h"
+#include "core/common/safeint.h"
 #include "core/providers/webgpu/webgpu_context.h"
 
 namespace onnxruntime {
@@ -9,13 +10,13 @@ namespace webgpu {
 
 namespace {
 
-constexpr size_t NormalizeBufferSize(size_t size) {
-  return (size + 15) / 16 * 16;
+size_t NormalizeBufferSize(size_t size) {
+  return (SafeInt<size_t>(size) + 15) / 16 * 16;
 }
 
 // WebGPU requires that the copy size in CopyBufferToBuffer must be a multiple of 4 bytes.
-constexpr size_t NormalizeCopySize(size_t size) {
-  return (size + 3) / 4 * 4;
+size_t NormalizeCopySize(size_t size) {
+  return (SafeInt<size_t>(size) + 3) / 4 * 4;
 }
 
 void EnforceBufferUnmapped(WebGpuContext& context, WGPUBuffer buffer) {
@@ -497,8 +498,10 @@ BufferManager::BufferManager(WebGpuContext& context, BufferCacheMode storage_buf
 
 void BufferManager::Upload(CommandRecordingState& recording, void* src, WGPUBuffer dst, size_t size) const {
   // If the buffer is mapped, we can directly write to it.
-  void* mapped_data = wgpuBufferGetMappedRange(dst, 0, WGPU_WHOLE_MAP_SIZE);  // ensure the buffer is mapped
-  if (mapped_data) {
+  void* mapped_data = nullptr;
+  if (wgpuBufferGetMapState(dst) == WGPUBufferMapState_Mapped) {
+    mapped_data = wgpuBufferGetMappedRange(dst, 0, WGPU_WHOLE_MAP_SIZE);
+    ORT_ENFORCE(mapped_data, "Failed to access mapped WebGPU upload buffer.");
     memcpy(mapped_data, src, size);
     wgpuBufferUnmap(dst);
     return;
@@ -514,12 +517,9 @@ void BufferManager::Upload(CommandRecordingState& recording, void* src, WGPUBuff
 
   auto staging_buffer = context_.Device().CreateBuffer(&desc);
   mapped_data = staging_buffer.GetMappedRange();
+  ORT_ENFORCE(mapped_data, "Failed to map WebGPU copy staging buffer.");
   memcpy(mapped_data, src, size);
-  // NOTE: When copy_size != size (due to 4-byte alignment requirement of CopyBufferToBuffer),
-  // the trailing bytes [size, copy_size) in the staging buffer contain uninitialized data.
-  // This dirty data gets copied into the destination buffer and may cause problems.
-  // A possible solution is to use CopyBufferToBuffer for the aligned portion and a compute
-  // shader to write the non-aligned remainder.
+  memset(static_cast<uint8_t*>(mapped_data) + size, 0, copy_size - size);
   staging_buffer.Unmap();
 
   auto& command_encoder = context_.GetCommandEncoder(recording);
@@ -617,7 +617,7 @@ void BufferManager::Download(CommandRecordingState& recording, WGPUBuffer src, v
   ORT_THROW_IF_ERROR(context_.EncodeDeferredDispatches(recording));
 
   EnforceBufferUnmapped(context_, src);
-  auto buffer_size = NormalizeBufferSize(size);
+  auto buffer_size = NormalizeCopySize(size);
 
   wgpu::BufferDescriptor desc{};
   desc.size = buffer_size;

--- a/onnxruntime/core/providers/webgpu/buffer_manager.h
+++ b/onnxruntime/core/providers/webgpu/buffer_manager.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <iosfwd>
+#include <mutex>
 #include <utility>
 #include <vector>
 
@@ -88,30 +89,26 @@ class IBufferCacheManager {
 //
 class BufferManager {
  public:
-  BufferManager(WebGpuContext& context, CommandRecordingState& recording, BufferCacheMode storage_buffer_cache_mode, BufferCacheMode uniform_buffer_cache_mode, BufferCacheMode query_resolve_buffer_cache_mode, BufferCacheMode default_buffer_cache_mode);
-  void Upload(void* src, WGPUBuffer dst, size_t size) const;
-  void MemCpy(WGPUBuffer src, WGPUBuffer dst, size_t size) const;
-  WGPUBuffer Create(size_t size, wgpu::BufferUsage usage, bool initialize_to_zero = false,
+  BufferManager(WebGpuContext& context, BufferCacheMode storage_buffer_cache_mode, BufferCacheMode uniform_buffer_cache_mode, BufferCacheMode query_resolve_buffer_cache_mode, BufferCacheMode default_buffer_cache_mode);
+  void Upload(CommandRecordingState& recording, void* src, WGPUBuffer dst, size_t size) const;
+  void MemCpy(CommandRecordingState& recording, WGPUBuffer src, WGPUBuffer dst, size_t size) const;
+  WGPUBuffer Create(CommandRecordingState& recording, size_t size, wgpu::BufferUsage usage,
+                    bool initialize_to_zero = false,
                     bool submit_zero_initialize = false) const;
   bool SupportsUMA() const;  // Check if CreateUMA is supported (i.e., the device has BufferMapExtendedUsages feature)
-  void Release(WGPUBuffer buffer) const;
-  void Download(WGPUBuffer src, void* dst, size_t size) const;
-  void RefreshPendingBuffers(GraphCaptureState graph_capture_state) const;
+  void Release(CommandRecordingState& recording, WGPUBuffer buffer) const;
+  void Download(CommandRecordingState& recording, WGPUBuffer src, void* dst, size_t size) const;
+  void RefreshPendingBuffers(CommandRecordingState& recording) const;
 
-  // The recording state that commands issued through this manager are encoded into.
-  CommandRecordingState& Recording() const { return recording_; }
-
-  // Direct access to the underlying cache managers. Used by SessionBufferPool to
-  // donate/seed buffers across per-graph BufferManager lifetimes.
-  IBufferCacheManager& StorageCache() { return *storage_cache_; }
-  IBufferCacheManager& UniformCache() { return *uniform_cache_; }
+  std::vector<std::pair<size_t, WGPUBuffer>> ExtractCachedBuffers(wgpu::BufferUsage usage);
+  void AbsorbCachedBuffers(wgpu::BufferUsage usage,
+                           std::vector<std::pair<size_t, WGPUBuffer>>&& buffers);
 
  private:
   IBufferCacheManager& GetCacheManager(wgpu::BufferUsage usage) const;
   IBufferCacheManager& GetCacheManager(WGPUBuffer buffer) const;
-
   WebGpuContext& context_;
-  CommandRecordingState& recording_;
+  mutable std::mutex mutex_;
   std::unique_ptr<IBufferCacheManager> storage_cache_;
   std::unique_ptr<IBufferCacheManager> uniform_cache_;
   std::unique_ptr<IBufferCacheManager> query_resolve_cache_;
@@ -120,7 +117,7 @@ class BufferManager {
 
 class BufferManagerFactory {
  public:
-  static std::unique_ptr<BufferManager> Create(WebGpuContext& context, CommandRecordingState& recording, BufferCacheMode storage_buffer_cache_mode, BufferCacheMode uniform_buffer_cache_mode, BufferCacheMode query_resolve_buffer_cache_mode, BufferCacheMode default_buffer_cache_mode);
+  static std::unique_ptr<BufferManager> Create(WebGpuContext& context, BufferCacheMode storage_buffer_cache_mode, BufferCacheMode uniform_buffer_cache_mode, BufferCacheMode query_resolve_buffer_cache_mode, BufferCacheMode default_buffer_cache_mode);
 
  private:
   BufferManagerFactory() {}

--- a/onnxruntime/core/providers/webgpu/buffer_manager.h
+++ b/onnxruntime/core/providers/webgpu/buffer_manager.h
@@ -15,6 +15,7 @@ namespace onnxruntime {
 namespace webgpu {
 
 class WebGpuContext;
+struct CommandRecordingState;
 
 // For command capture and replay
 enum class GraphCaptureState {
@@ -87,7 +88,7 @@ class IBufferCacheManager {
 //
 class BufferManager {
  public:
-  BufferManager(WebGpuContext& context, BufferCacheMode storage_buffer_cache_mode, BufferCacheMode uniform_buffer_cache_mode, BufferCacheMode query_resolve_buffer_cache_mode, BufferCacheMode default_buffer_cache_mode);
+  BufferManager(WebGpuContext& context, CommandRecordingState& recording, BufferCacheMode storage_buffer_cache_mode, BufferCacheMode uniform_buffer_cache_mode, BufferCacheMode query_resolve_buffer_cache_mode, BufferCacheMode default_buffer_cache_mode);
   void Upload(void* src, WGPUBuffer dst, size_t size) const;
   void MemCpy(WGPUBuffer src, WGPUBuffer dst, size_t size) const;
   WGPUBuffer Create(size_t size, wgpu::BufferUsage usage, bool initialize_to_zero = false,
@@ -96,6 +97,9 @@ class BufferManager {
   void Release(WGPUBuffer buffer) const;
   void Download(WGPUBuffer src, void* dst, size_t size) const;
   void RefreshPendingBuffers(GraphCaptureState graph_capture_state) const;
+
+  // The recording state that commands issued through this manager are encoded into.
+  CommandRecordingState& Recording() const { return recording_; }
 
   // Direct access to the underlying cache managers. Used by SessionBufferPool to
   // donate/seed buffers across per-graph BufferManager lifetimes.
@@ -107,6 +111,7 @@ class BufferManager {
   IBufferCacheManager& GetCacheManager(WGPUBuffer buffer) const;
 
   WebGpuContext& context_;
+  CommandRecordingState& recording_;
   std::unique_ptr<IBufferCacheManager> storage_cache_;
   std::unique_ptr<IBufferCacheManager> uniform_cache_;
   std::unique_ptr<IBufferCacheManager> query_resolve_cache_;
@@ -115,7 +120,7 @@ class BufferManager {
 
 class BufferManagerFactory {
  public:
-  static std::unique_ptr<BufferManager> Create(WebGpuContext& context, BufferCacheMode storage_buffer_cache_mode, BufferCacheMode uniform_buffer_cache_mode, BufferCacheMode query_resolve_buffer_cache_mode, BufferCacheMode default_buffer_cache_mode);
+  static std::unique_ptr<BufferManager> Create(WebGpuContext& context, CommandRecordingState& recording, BufferCacheMode storage_buffer_cache_mode, BufferCacheMode uniform_buffer_cache_mode, BufferCacheMode query_resolve_buffer_cache_mode, BufferCacheMode default_buffer_cache_mode);
 
  private:
   BufferManagerFactory() {}

--- a/onnxruntime/core/providers/webgpu/buffer_manager.h
+++ b/onnxruntime/core/providers/webgpu/buffer_manager.h
@@ -4,14 +4,13 @@
 #pragma once
 
 #include <iosfwd>
-#include <mutex>
-#include <unordered_map>
 #include <utility>
 #include <vector>
 
 #include "core/providers/webgpu/webgpu_external_header.h"
 
 #include "core/framework/execution_provider.h"
+#include "core/providers/webgpu/shared_buffer_pool.h"
 
 namespace onnxruntime {
 namespace webgpu {
@@ -103,52 +102,6 @@ class IBufferCacheManager {
     }
   }
 };
-
-//
-// SharedBufferPool holds the free buffers that sessions hand back to each other.
-//
-// It is deliberately the *only* piece of buffer state shared across sessions. Splitting the
-// cache per session instead would make steady-state GPU memory scale with the number of live
-// sessions (measured: 8 identical sessions went from 241 MB with a shared pool to 1585 MB with
-// per-session pools), because every session would keep its own high-water mark of intermediates.
-//
-// The complementary half - the "released but not yet submitted" list - stays private to each
-// session (see the cache managers), which is what makes sharing safe: a buffer only becomes
-// visible to other sessions once the releasing session has submitted its commands. Handing it
-// over earlier is what previously produced silently wrong results.
-//
-// Thread safety: all methods are internally synchronized. The critical section covers only
-// map/vector operations - no GPU calls, no command encoding, no shader compilation - so it is
-// on the order of 100ns and does not serialize sessions in any meaningful way.
-//
-class SharedBufferPool {
- public:
-  // `limits` maps bucket size -> maximum number of buffers retained for that size. An empty map
-  // means unbounded and accepts any size (the "simple" cache policy).
-  explicit SharedBufferPool(std::unordered_map<size_t, size_t> limits);
-  ~SharedBufferPool();
-
-  // Rounds a request up to the nearest bucket size. Immutable after construction, so no lock.
-  size_t CalculateBufferSize(size_t request_size) const;
-
-  // Takes a buffer of exactly `buffer_size` out of the pool, or nullptr if none is available.
-  WGPUBuffer TryAcquire(size_t buffer_size);
-
-  // Returns buffers to the pool, releasing any that exceed the configured limit. `buffers` is
-  // cleared. Called only after the owning session has submitted the commands using them.
-  void Return(std::vector<std::pair<WGPUBuffer, size_t>>& buffers);
-
- private:
-  const std::unordered_map<size_t, size_t> limits_;
-  std::vector<size_t> sorted_sizes_;  // immutable after construction
-  std::unordered_map<size_t, std::vector<WGPUBuffer>> free_buffers_;
-  std::mutex mutex_;
-};
-
-// Pools shared by every session on a WebGpuContext: bucketed for storage buffers, unbounded for
-// the small uniform buffers.
-std::unique_ptr<SharedBufferPool> CreateDefaultStorageBufferPool();
-std::unique_ptr<SharedBufferPool> CreateDefaultUniformBufferPool();
 
 //
 // BufferManager manages operations on buffers.

--- a/onnxruntime/core/providers/webgpu/buffer_manager.h
+++ b/onnxruntime/core/providers/webgpu/buffer_manager.h
@@ -3,7 +3,10 @@
 
 #pragma once
 
+#include <atomic>
 #include <iosfwd>
+#include <mutex>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -15,6 +18,26 @@ namespace onnxruntime {
 namespace webgpu {
 
 class WebGpuContext;
+
+// Command recording state. Owned by whoever owns the recording timeline - the
+// WebGpuExecutionProvider (i.e. per session), not the shared WebGpuContext.
+//
+// Command encoding is explicitly NOT covered by Dawn's ImplicitDeviceSynchronization, and
+// ORT holds references to these members across calls, so a context-wide encoder lets one
+// session's Flush() finish an encoder another session is still recording into. Per-session
+// ownership removes that race without any lock: InferenceSession already serializes a single
+// session's Run / Initialize under session_mutex_ (the WebGPU EP reports
+// ConcurrentRunSupported() == false), so only one thread records into a given state at a time.
+struct CommandRecordingState {
+  wgpu::CommandEncoder command_encoder;
+  wgpu::ComputePassEncoder compute_pass_encoder;
+  uint32_t num_pending_dispatches = 0;
+
+  // True between the creation of a command encoder and the submit that finishes it. Read from
+  // buffer release, which can happen on a different thread than the one recording (a tensor may
+  // outlive the Run that produced it and be dropped elsewhere), hence atomic.
+  std::atomic<bool> has_unsubmitted_work{false};
+};
 
 // For command capture and replay
 enum class GraphCaptureState {
@@ -83,11 +106,57 @@ class IBufferCacheManager {
 };
 
 //
+// SharedBufferPool holds the free buffers that sessions hand back to each other.
+//
+// It is deliberately the *only* piece of buffer state shared across sessions. Splitting the
+// cache per session instead would make steady-state GPU memory scale with the number of live
+// sessions (measured: 8 identical sessions went from 241 MB with a shared pool to 1585 MB with
+// per-session pools), because every session would keep its own high-water mark of intermediates.
+//
+// The complementary half - the "released but not yet submitted" list - stays private to each
+// session (see the cache managers), which is what makes sharing safe: a buffer only becomes
+// visible to other sessions once the releasing session has submitted its commands. Handing it
+// over earlier is what previously produced silently wrong results.
+//
+// Thread safety: all methods are internally synchronized. The critical section covers only
+// map/vector operations - no GPU calls, no command encoding, no shader compilation - so it is
+// on the order of 100ns and does not serialize sessions in any meaningful way.
+//
+class SharedBufferPool {
+ public:
+  // `limits` maps bucket size -> maximum number of buffers retained for that size. An empty map
+  // means unbounded and accepts any size (the "simple" cache policy).
+  explicit SharedBufferPool(std::unordered_map<size_t, size_t> limits);
+  ~SharedBufferPool();
+
+  // Rounds a request up to the nearest bucket size. Immutable after construction, so no lock.
+  size_t CalculateBufferSize(size_t request_size) const;
+
+  // Takes a buffer of exactly `buffer_size` out of the pool, or nullptr if none is available.
+  WGPUBuffer TryAcquire(size_t buffer_size);
+
+  // Returns buffers to the pool, releasing any that exceed the configured limit. `buffers` is
+  // cleared. Called only after the owning session has submitted the commands using them.
+  void Return(std::vector<std::pair<WGPUBuffer, size_t>>& buffers);
+
+ private:
+  const std::unordered_map<size_t, size_t> limits_;
+  std::vector<size_t> sorted_sizes_;  // immutable after construction
+  std::unordered_map<size_t, std::vector<WGPUBuffer>> free_buffers_;
+  std::mutex mutex_;
+};
+
+// Pools shared by every session on a WebGpuContext: bucketed for storage buffers, unbounded for
+// the small uniform buffers.
+std::unique_ptr<SharedBufferPool> CreateDefaultStorageBufferPool();
+std::unique_ptr<SharedBufferPool> CreateDefaultUniformBufferPool();
+
+//
 // BufferManager manages operations on buffers.
 //
 class BufferManager {
  public:
-  BufferManager(WebGpuContext& context, BufferCacheMode storage_buffer_cache_mode, BufferCacheMode uniform_buffer_cache_mode, BufferCacheMode query_resolve_buffer_cache_mode, BufferCacheMode default_buffer_cache_mode);
+  BufferManager(WebGpuContext& context, CommandRecordingState& recording, BufferCacheMode storage_buffer_cache_mode, BufferCacheMode uniform_buffer_cache_mode, BufferCacheMode query_resolve_buffer_cache_mode, BufferCacheMode default_buffer_cache_mode);
   void Upload(void* src, WGPUBuffer dst, size_t size) const;
   void MemCpy(WGPUBuffer src, WGPUBuffer dst, size_t size) const;
   WGPUBuffer Create(size_t size, wgpu::BufferUsage usage) const;
@@ -95,6 +164,9 @@ class BufferManager {
   void Release(WGPUBuffer buffer) const;
   void Download(WGPUBuffer src, void* dst, size_t size) const;
   void RefreshPendingBuffers(GraphCaptureState graph_capture_state) const;
+
+  // The recording state that commands issued through this manager are encoded into.
+  CommandRecordingState& Recording() const { return recording_; }
 
   // Direct access to the underlying cache managers. Used by SessionBufferPool to
   // donate/seed buffers across per-graph BufferManager lifetimes.
@@ -106,6 +178,7 @@ class BufferManager {
   IBufferCacheManager& GetCacheManager(WGPUBuffer buffer) const;
 
   WebGpuContext& context_;
+  CommandRecordingState& recording_;
   std::unique_ptr<IBufferCacheManager> storage_cache_;
   std::unique_ptr<IBufferCacheManager> uniform_cache_;
   std::unique_ptr<IBufferCacheManager> query_resolve_cache_;
@@ -114,7 +187,7 @@ class BufferManager {
 
 class BufferManagerFactory {
  public:
-  static std::unique_ptr<BufferManager> Create(WebGpuContext& context, BufferCacheMode storage_buffer_cache_mode, BufferCacheMode uniform_buffer_cache_mode, BufferCacheMode query_resolve_buffer_cache_mode, BufferCacheMode default_buffer_cache_mode);
+  static std::unique_ptr<BufferManager> Create(WebGpuContext& context, CommandRecordingState& recording, BufferCacheMode storage_buffer_cache_mode, BufferCacheMode uniform_buffer_cache_mode, BufferCacheMode query_resolve_buffer_cache_mode, BufferCacheMode default_buffer_cache_mode);
 
  private:
   BufferManagerFactory() {}

--- a/onnxruntime/core/providers/webgpu/buffer_manager.h
+++ b/onnxruntime/core/providers/webgpu/buffer_manager.h
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include <atomic>
 #include <iosfwd>
 #include <mutex>
 #include <unordered_map>
@@ -33,10 +32,10 @@ struct CommandRecordingState {
   wgpu::ComputePassEncoder compute_pass_encoder;
   uint32_t num_pending_dispatches = 0;
 
-  // True between the creation of a command encoder and the submit that finishes it. Read from
-  // buffer release, which can happen on a different thread than the one recording (a tensor may
-  // outlive the Run that produced it and be dropped elsewhere), hence atomic.
-  std::atomic<bool> has_unsubmitted_work{false};
+  // True between the creation of a command encoder and the submit that finishes it. Decides
+  // whether a released buffer can be published to the shared pool immediately or has to wait
+  // for this session's submit.
+  bool has_unsubmitted_work = false;
 };
 
 // For command capture and replay

--- a/onnxruntime/core/providers/webgpu/buffer_manager.h
+++ b/onnxruntime/core/providers/webgpu/buffer_manager.h
@@ -100,13 +100,15 @@ class BufferManager {
   void Download(CommandRecordingState& recording, WGPUBuffer src, void* dst, size_t size) const;
   void RefreshPendingBuffers(CommandRecordingState& recording) const;
 
-  std::vector<std::pair<size_t, WGPUBuffer>> ExtractCachedBuffers(wgpu::BufferUsage usage);
-  void AbsorbCachedBuffers(wgpu::BufferUsage usage,
-                           std::vector<std::pair<size_t, WGPUBuffer>>&& buffers);
+  // Direct access to the underlying cache managers. Used by SessionBufferPool to
+  // donate/seed buffers across per-graph BufferManager lifetimes.
+  IBufferCacheManager& StorageCache() { return *storage_cache_; }
+  IBufferCacheManager& UniformCache() { return *uniform_cache_; }
 
  private:
   IBufferCacheManager& GetCacheManager(wgpu::BufferUsage usage) const;
   IBufferCacheManager& GetCacheManager(WGPUBuffer buffer) const;
+
   WebGpuContext& context_;
   mutable std::mutex mutex_;
   std::unique_ptr<IBufferCacheManager> storage_cache_;

--- a/onnxruntime/core/providers/webgpu/compute_context.cc
+++ b/onnxruntime/core/providers/webgpu/compute_context.cc
@@ -20,6 +20,10 @@ const webgpu::BufferManager& ComputeContextBase::BufferManagerAccessor::Get(cons
   return context.ep_.BufferManager();
 }
 
+CommandRecordingState& ComputeContextBase::BufferManagerAccessor::GetRecording(const ComputeContextBase& context) {
+  return context.ep_.Recording();
+}
+
 ComputeContext::ComputeContext(WebGpuContext& webgpu_context,
                                const WebGpuExecutionProvider& ep,
                                const OpKernel& op_kernel,

--- a/onnxruntime/core/providers/webgpu/compute_context.h
+++ b/onnxruntime/core/providers/webgpu/compute_context.h
@@ -230,6 +230,7 @@ class ComputeContext final : public ComputeContextBase {
   // Fill a GPU tensor with zeros.
   //
   inline void FillZero(Tensor& dst) {
+    auto lock = webgpu_context_.AcquireContextLock();
     webgpu_context_.EndComputePass();
     auto& command_encoder = webgpu_context_.GetCommandEncoder();
     WGPUBuffer buffer = reinterpret_cast<WGPUBuffer>(dst.MutableDataRaw());

--- a/onnxruntime/core/providers/webgpu/compute_context.h
+++ b/onnxruntime/core/providers/webgpu/compute_context.h
@@ -228,9 +228,10 @@ class ComputeContext final : public ComputeContextBase {
   // Fill a GPU tensor with zeros.
   //
   inline void FillZero(Tensor& dst) {
-    ORT_THROW_IF_ERROR(webgpu_context_.EncodeDeferredDispatches());
-    webgpu_context_.EndComputePass();
-    auto& command_encoder = webgpu_context_.GetCommandEncoder();
+    ORT_THROW_IF_ERROR(webgpu_context_.EncodeDeferredDispatches(ep_.BufferManager()));
+    auto& recording = ep_.BufferManager().Recording();
+    webgpu_context_.EndComputePass(recording);
+    auto& command_encoder = webgpu_context_.GetCommandEncoder(recording);
     WGPUBuffer buffer = reinterpret_cast<WGPUBuffer>(dst.MutableDataRaw());
     command_encoder.ClearBuffer(buffer, 0, dst.SizeInBytes());
   }

--- a/onnxruntime/core/providers/webgpu/compute_context.h
+++ b/onnxruntime/core/providers/webgpu/compute_context.h
@@ -41,6 +41,7 @@ class ComputeContextBase {
 
    private:
     static const webgpu::BufferManager& Get(const ComputeContextBase& context);
+    static CommandRecordingState& GetRecording(const ComputeContextBase& context);
   };
 
   ComputeContextBase(WebGpuContext& webgpu_context,
@@ -228,8 +229,8 @@ class ComputeContext final : public ComputeContextBase {
   // Fill a GPU tensor with zeros.
   //
   inline void FillZero(Tensor& dst) {
-    ORT_THROW_IF_ERROR(webgpu_context_.EncodeDeferredDispatches(ep_.BufferManager()));
-    auto& recording = ep_.BufferManager().Recording();
+    auto& recording = ep_.Recording();
+    ORT_THROW_IF_ERROR(webgpu_context_.EncodeDeferredDispatches(recording));
     webgpu_context_.EndComputePass(recording);
     auto& command_encoder = webgpu_context_.GetCommandEncoder(recording);
     WGPUBuffer buffer = reinterpret_cast<WGPUBuffer>(dst.MutableDataRaw());

--- a/onnxruntime/core/providers/webgpu/compute_context.h
+++ b/onnxruntime/core/providers/webgpu/compute_context.h
@@ -230,9 +230,9 @@ class ComputeContext final : public ComputeContextBase {
   // Fill a GPU tensor with zeros.
   //
   inline void FillZero(Tensor& dst) {
-    auto lock = webgpu_context_.AcquireContextLock();
-    webgpu_context_.EndComputePass();
-    auto& command_encoder = webgpu_context_.GetCommandEncoder();
+    auto& recording = ep_.BufferManager().Recording();
+    webgpu_context_.EndComputePass(recording);
+    auto& command_encoder = webgpu_context_.GetCommandEncoder(recording);
     WGPUBuffer buffer = reinterpret_cast<WGPUBuffer>(dst.MutableDataRaw());
     command_encoder.ClearBuffer(buffer, 0, dst.SizeInBytes());
   }

--- a/onnxruntime/core/providers/webgpu/data_transfer.cc
+++ b/onnxruntime/core/providers/webgpu/data_transfer.cc
@@ -3,6 +3,7 @@
 
 #include "core/providers/webgpu/data_transfer.h"
 #include "core/providers/webgpu/buffer_manager.h"
+#include "core/providers/webgpu/webgpu_context.h"
 
 namespace onnxruntime {
 namespace webgpu {
@@ -12,22 +13,27 @@ common::Status DataTransferImpl::CopyTensor(void const* src_data,
                                             void* dst_data,
                                             bool dst_is_gpu,
                                             size_t bytes) const {
+  std::lock_guard<std::mutex> lock{mutex_};
+  std::lock_guard<std::recursive_mutex> recording_lock{recording_.mutex};
   if (bytes > 0) {
     if (dst_is_gpu) {
       if (src_is_gpu) {
         // copy from GPU to GPU
-        buffer_manager_.MemCpy(static_cast<WGPUBuffer>(const_cast<void*>(src_data)),
+        buffer_manager_.MemCpy(recording_,
+                               static_cast<WGPUBuffer>(const_cast<void*>(src_data)),
                                static_cast<WGPUBuffer>(dst_data),
                                bytes);
       } else {
         // copy from CPU to GPU
-        buffer_manager_.Upload(const_cast<void*>(src_data),
+        buffer_manager_.Upload(recording_,
+                               const_cast<void*>(src_data),
                                static_cast<WGPUBuffer>(dst_data),
                                bytes);
       }
     } else {
       // copy from GPU to CPU
-      buffer_manager_.Download(static_cast<WGPUBuffer>(const_cast<void*>(src_data)),
+      buffer_manager_.Download(recording_,
+                               static_cast<WGPUBuffer>(const_cast<void*>(src_data)),
                                dst_data,
                                bytes);
     }

--- a/onnxruntime/core/providers/webgpu/data_transfer.cc
+++ b/onnxruntime/core/providers/webgpu/data_transfer.cc
@@ -4,97 +4,25 @@
 #include "core/providers/webgpu/data_transfer.h"
 #include "core/providers/webgpu/buffer_manager.h"
 #include "core/providers/webgpu/webgpu_context.h"
-#include "core/providers/webgpu/webgpu_execution_provider.h"
 
 namespace onnxruntime {
 namespace webgpu {
 
-#if defined(ORT_USE_EP_API_ADAPTERS)
-namespace {
-
-struct WebGpuSyncStream final : OrtSyncStreamImpl {
-  explicit WebGpuSyncStream(WebGpuExecutionProvider& ep) : ep_{ep} {
-    ort_version_supported = ORT_API_VERSION;
-    Release = [](OrtSyncStreamImpl* stream) noexcept { delete static_cast<WebGpuSyncStream*>(stream); };
-    GetHandle = [](OrtSyncStreamImpl* stream) noexcept -> void* { return stream; };
-    CreateNotification = CreateNotificationImpl;
-    Flush = FlushImpl;
-    OnSessionRunEnd = [](OrtSyncStreamImpl*) noexcept -> OrtStatus* { return nullptr; };
-  }
-
-  static const WebGpuSyncStream& From(const OrtSyncStream* stream) {
-    const auto* impl = onnxruntime::ep::Api().ep.SyncStream_GetImpl(stream);
-    ORT_ENFORCE(impl != nullptr && impl->Flush == FlushImpl, "Expected a WebGPU sync stream.");
-    return *static_cast<const WebGpuSyncStream*>(impl);
-  }
-
-  static OrtStatus* ORT_API_CALL FlushImpl(OrtSyncStreamImpl* stream) noexcept {
-    EXCEPTION_TO_RETURNED_STATUS_BEGIN
-    auto& ep = static_cast<WebGpuSyncStream*>(stream)->ep_;
-    auto& context = WebGpuContextFactory::GetContext(ep.GetDeviceId());
-    std::lock_guard<std::recursive_mutex> lock{ep.Recording().mutex};
-    ORT_THROW_IF_ERROR(context.Flush(ep.BufferManager(), ep.Recording()));
-    wgpu::QueueWorkDoneStatus completion = wgpu::QueueWorkDoneStatus::Error;
-    auto future = context.Device().GetQueue().OnSubmittedWorkDone(
-        wgpu::CallbackMode::WaitAnyOnly,
-        [](wgpu::QueueWorkDoneStatus status, wgpu::StringView, wgpu::QueueWorkDoneStatus* result) noexcept {
-          *result = status;
-        },
-        &completion);
-    ORT_THROW_IF_ERROR(context.Wait(future));
-    ORT_ENFORCE(completion == wgpu::QueueWorkDoneStatus::Success, "WebGPU queue completion failed.");
-    return nullptr;
-    EXCEPTION_TO_RETURNED_STATUS_END
-  }
-
-  static OrtStatus* ORT_API_CALL CreateNotificationImpl(
-      OrtSyncStreamImpl* stream, OrtSyncNotificationImpl** notification) noexcept;
-
-  WebGpuExecutionProvider& ep_;
-};
-
-struct WebGpuSyncNotification final : OrtSyncNotificationImpl {
-  explicit WebGpuSyncNotification(WebGpuSyncStream& stream) : stream_{stream} {
-    ort_version_supported = ORT_API_VERSION;
-    Release = [](OrtSyncNotificationImpl* notification) noexcept {
-      delete static_cast<WebGpuSyncNotification*>(notification);
-    };
-    Activate = [](OrtSyncNotificationImpl* notification) noexcept -> OrtStatus* {
-      auto& self = *static_cast<WebGpuSyncNotification*>(notification);
-      return WebGpuSyncStream::FlushImpl(&self.stream_);
-    };
-    WaitOnDevice = [](OrtSyncNotificationImpl*, OrtSyncStream*) noexcept -> OrtStatus* { return nullptr; };
-    WaitOnHost = [](OrtSyncNotificationImpl*) noexcept -> OrtStatus* { return nullptr; };
-  }
-
-  WebGpuSyncStream& stream_;
-};
-
-OrtStatus* ORT_API_CALL WebGpuSyncStream::CreateNotificationImpl(
-    OrtSyncStreamImpl* stream, OrtSyncNotificationImpl** notification) noexcept {
-  EXCEPTION_TO_RETURNED_STATUS_BEGIN
-  *notification = new WebGpuSyncNotification(*static_cast<WebGpuSyncStream*>(stream));
-  return nullptr;
-  EXCEPTION_TO_RETURNED_STATUS_END
+common::Status FlushAndWait(WebGpuContext& context, const BufferManager& buffer_manager,
+                            CommandRecordingState& recording) {
+  std::lock_guard<std::recursive_mutex> lock{recording.mutex};
+  ORT_RETURN_IF_ERROR(context.Flush(buffer_manager, recording));
+  wgpu::QueueWorkDoneStatus completion = wgpu::QueueWorkDoneStatus::Error;
+  auto future = context.Device().GetQueue().OnSubmittedWorkDone(
+      wgpu::CallbackMode::WaitAnyOnly,
+      [](wgpu::QueueWorkDoneStatus status, wgpu::StringView, wgpu::QueueWorkDoneStatus* result) noexcept {
+        *result = status;
+      },
+      &completion);
+  ORT_RETURN_IF_ERROR(context.Wait(future));
+  ORT_RETURN_IF_NOT(completion == wgpu::QueueWorkDoneStatus::Success, "WebGPU queue completion failed.");
+  return Status::OK();
 }
-
-}  // namespace
-
-OrtSyncStreamImpl* CreateWebGpuSyncStream(WebGpuExecutionProvider& ep) {
-  return new WebGpuSyncStream(ep);
-}
-
-CommandRecordingState& GetWebGpuStreamCommandState(const OrtSyncStream* stream) {
-  return WebGpuSyncStream::From(stream).ep_.Recording();
-}
-
-common::Status CopyTensorOnWebGpuStream(const OrtSyncStream* stream, const void* src_data,
-                                      bool src_is_gpu, void* dst_data, bool dst_is_gpu, size_t bytes) {
-  auto& ep = WebGpuSyncStream::From(stream).ep_;
-  DataTransferImpl transfer(ep.BufferManager(), ep.Recording());
-  return transfer.CopyTensor(src_data, src_is_gpu, dst_data, dst_is_gpu, bytes);
-}
-#endif
 
 common::Status DataTransferImpl::CopyTensor(void const* src_data,
                                             bool src_is_gpu,
@@ -102,7 +30,6 @@ common::Status DataTransferImpl::CopyTensor(void const* src_data,
                                             bool dst_is_gpu,
                                             size_t bytes) const {
   auto& command_state = recording_;
-  std::lock_guard<std::mutex> lock{mutex_};
   std::lock_guard<std::recursive_mutex> recording_lock{command_state.mutex};
   if (bytes > 0) {
     if (dst_is_gpu) {

--- a/onnxruntime/core/providers/webgpu/data_transfer.cc
+++ b/onnxruntime/core/providers/webgpu/data_transfer.cc
@@ -2,69 +2,34 @@
 // Licensed under the MIT License.
 
 #include "core/providers/webgpu/data_transfer.h"
-
-#include "core/common/safeint.h"
 #include "core/providers/webgpu/buffer_manager.h"
-#include "core/providers/webgpu/webgpu_context.h"
 
 namespace onnxruntime {
 namespace webgpu {
-
-common::Status FlushAndWait(WebGpuContext& context, const BufferManager& buffer_manager,
-                            CommandRecordingState& recording) {
-  ORT_RETURN_IF_ERROR(context.Flush(buffer_manager, recording));
-  wgpu::QueueWorkDoneStatus completion = wgpu::QueueWorkDoneStatus::Error;
-  auto future = context.Device().GetQueue().OnSubmittedWorkDone(
-      wgpu::CallbackMode::WaitAnyOnly,
-      [](wgpu::QueueWorkDoneStatus status, wgpu::StringView, wgpu::QueueWorkDoneStatus* result) noexcept {
-        *result = status;
-      },
-      &completion);
-  ORT_RETURN_IF_ERROR(context.Wait(future));
-  ORT_RETURN_IF_NOT(completion == wgpu::QueueWorkDoneStatus::Success, "WebGPU queue completion failed.");
-  return Status::OK();
-}
 
 common::Status DataTransferImpl::CopyTensor(void const* src_data,
                                             bool src_is_gpu,
                                             void* dst_data,
                                             bool dst_is_gpu,
                                             size_t bytes) const {
-  auto& command_state = recording_;
   if (bytes > 0) {
-    ORT_RETURN_IF_NOT(src_is_gpu || dst_is_gpu, "Expected a WebGPU copy endpoint.");
-    ORT_RETURN_IF_NOT(src_data && dst_data, "WebGPU copy buffers must not be null.");
-    const size_t copy_size = (SafeInt<size_t>(bytes) + 3) / 4 * 4;
-    WGPUBuffer source = src_is_gpu ? static_cast<WGPUBuffer>(const_cast<void*>(src_data)) : nullptr;
-    WGPUBuffer destination = dst_is_gpu ? static_cast<WGPUBuffer>(dst_data) : nullptr;
-    ORT_RETURN_IF(source && copy_size > wgpuBufferGetSize(source), "WebGPU copy exceeds source buffer size.");
-    ORT_RETURN_IF(destination && copy_size > wgpuBufferGetSize(destination), "WebGPU copy exceeds destination buffer size.");
-    ORT_RETURN_IF(source && source == destination, "Source and destination buffers must be different.");
-    ORT_RETURN_IF(source && wgpuBufferGetMapState(source) != WGPUBufferMapState_Unmapped,
-                  "WebGPU copy source must be unmapped.");
-    if (destination) {
-      const auto map_state = wgpuBufferGetMapState(destination);
-      ORT_RETURN_IF_NOT(map_state == WGPUBufferMapState_Unmapped ||
-                            (!src_is_gpu && map_state == WGPUBufferMapState_Mapped),
-                        "WebGPU copy destination must be unmapped.");
-    }
     if (dst_is_gpu) {
       if (src_is_gpu) {
         // copy from GPU to GPU
-        buffer_manager_.MemCpy(command_state,
+        buffer_manager_.MemCpy(recording_,
                                static_cast<WGPUBuffer>(const_cast<void*>(src_data)),
                                static_cast<WGPUBuffer>(dst_data),
                                bytes);
       } else {
         // copy from CPU to GPU
-        buffer_manager_.Upload(command_state,
+        buffer_manager_.Upload(recording_,
                                const_cast<void*>(src_data),
                                static_cast<WGPUBuffer>(dst_data),
                                bytes);
       }
     } else {
       // copy from GPU to CPU
-      buffer_manager_.Download(command_state,
+      buffer_manager_.Download(recording_,
                                static_cast<WGPUBuffer>(const_cast<void*>(src_data)),
                                dst_data,
                                bytes);

--- a/onnxruntime/core/providers/webgpu/data_transfer.cc
+++ b/onnxruntime/core/providers/webgpu/data_transfer.cc
@@ -3,11 +3,6 @@
 
 #include "core/providers/webgpu/data_transfer.h"
 
-#include <cstdint>
-#include <cstring>
-#include <string>
-#include <string_view>
-
 #include "core/common/safeint.h"
 #include "core/providers/webgpu/buffer_manager.h"
 #include "core/providers/webgpu/webgpu_context.h"
@@ -15,9 +10,9 @@
 namespace onnxruntime {
 namespace webgpu {
 
-namespace {
-
-common::Status WaitForQueue(WebGpuContext& context) {
+common::Status FlushAndWait(WebGpuContext& context, const BufferManager& buffer_manager,
+                            CommandRecordingState& recording) {
+  ORT_RETURN_IF_ERROR(context.Flush(buffer_manager, recording));
   wgpu::QueueWorkDoneStatus completion = wgpu::QueueWorkDoneStatus::Error;
   auto future = context.Device().GetQueue().OnSubmittedWorkDone(
       wgpu::CallbackMode::WaitAnyOnly,
@@ -30,90 +25,6 @@ common::Status WaitForQueue(WebGpuContext& context) {
   return Status::OK();
 }
 
-}  // namespace
-
-common::Status FlushAndWait(WebGpuContext& context, const BufferManager& buffer_manager,
-                            CommandRecordingState& recording) {
-  ORT_RETURN_IF_ERROR(context.Flush(buffer_manager, recording));
-  return WaitForQueue(context);
-}
-
-common::Status CopyTensorWithLocalEncoder(WebGpuContext& context, const void* src_data,
-                                          bool src_is_gpu, void* dst_data, bool dst_is_gpu, size_t bytes) {
-  if (bytes == 0) {
-    return Status::OK();
-  }
-  ORT_RETURN_IF_NOT(src_is_gpu || dst_is_gpu, "Expected a WebGPU copy endpoint.");
-  ORT_RETURN_IF_NOT(src_data && dst_data, "WebGPU copy buffers must not be null.");
-
-  const size_t copy_size = (SafeInt<size_t>(bytes) + 3) / 4 * 4;
-  WGPUBuffer source = src_is_gpu ? static_cast<WGPUBuffer>(const_cast<void*>(src_data)) : nullptr;
-  WGPUBuffer destination = dst_is_gpu ? static_cast<WGPUBuffer>(dst_data) : nullptr;
-  ORT_RETURN_IF(source && copy_size > wgpuBufferGetSize(source), "WebGPU copy exceeds source buffer size.");
-  ORT_RETURN_IF(destination && copy_size > wgpuBufferGetSize(destination), "WebGPU copy exceeds destination buffer size.");
-  ORT_RETURN_IF(source && source == destination, "Source and destination buffers must be different.");
-  ORT_RETURN_IF(source && wgpuBufferGetMapState(source) != WGPUBufferMapState_Unmapped,
-                "WebGPU copy source must be unmapped.");
-
-  if (!src_is_gpu && wgpuBufferGetMapState(destination) == WGPUBufferMapState_Mapped) {
-    void* mapped_data = wgpuBufferGetMappedRange(destination, 0, copy_size);
-    ORT_RETURN_IF_NOT(mapped_data, "Failed to access mapped WebGPU upload buffer.");
-    std::memcpy(mapped_data, src_data, bytes);
-    wgpuBufferUnmap(destination);
-    return Status::OK();
-  }
-  ORT_RETURN_IF(destination && wgpuBufferGetMapState(destination) != WGPUBufferMapState_Unmapped,
-                "WebGPU copy destination must be unmapped.");
-
-  wgpu::Buffer staging_buffer;
-  if (!src_is_gpu || !dst_is_gpu) {
-    wgpu::BufferDescriptor descriptor{};
-    descriptor.size = copy_size;
-    descriptor.usage = src_is_gpu ? wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::MapRead
-                                  : wgpu::BufferUsage::CopySrc | wgpu::BufferUsage::MapWrite;
-    descriptor.mappedAtCreation = !src_is_gpu;
-    staging_buffer = context.Device().CreateBuffer(&descriptor);
-    ORT_RETURN_IF_NOT(staging_buffer, "Failed to create WebGPU copy staging buffer.");
-    if (src_is_gpu) {
-      destination = staging_buffer.Get();
-    } else {
-      auto* mapped_data = static_cast<uint8_t*>(staging_buffer.GetMappedRange());
-      ORT_RETURN_IF_NOT(mapped_data, "Failed to map WebGPU copy staging buffer.");
-      std::memcpy(mapped_data, src_data, bytes);
-      std::memset(mapped_data + bytes, 0, copy_size - bytes);
-      staging_buffer.Unmap();
-      source = staging_buffer.Get();
-    }
-  }
-
-  auto encoder = context.Device().CreateCommandEncoder();
-  encoder.CopyBufferToBuffer(source, 0, destination, 0, copy_size);
-  auto commands = encoder.Finish();
-  context.Device().GetQueue().Submit(1, &commands);
-  if (dst_is_gpu) {
-    return WaitForQueue(context);
-  }
-
-  struct MapResult {
-    wgpu::MapAsyncStatus status = wgpu::MapAsyncStatus::Error;
-    std::string message;
-  } map_result;
-  ORT_RETURN_IF_ERROR(context.Wait(staging_buffer.MapAsync(
-      wgpu::MapMode::Read, 0, copy_size, wgpu::CallbackMode::WaitAnyOnly,
-      [](wgpu::MapAsyncStatus status, wgpu::StringView message, MapResult* result) noexcept {
-        result->status = status;
-        if (auto text = static_cast<std::string_view>(message); !text.empty()) {
-          result->message = text;
-        }
-      },
-      &map_result)));
-  ORT_RETURN_IF_NOT(map_result.status == wgpu::MapAsyncStatus::Success,
-                    "WebGPU copy readback failed: ", map_result.message);
-  std::memcpy(dst_data, staging_buffer.GetConstMappedRange(), bytes);
-  staging_buffer.Unmap();
-  return Status::OK();
-}
-
 common::Status DataTransferImpl::CopyTensor(void const* src_data,
                                             bool src_is_gpu,
                                             void* dst_data,
@@ -121,6 +32,22 @@ common::Status DataTransferImpl::CopyTensor(void const* src_data,
                                             size_t bytes) const {
   auto& command_state = recording_;
   if (bytes > 0) {
+    ORT_RETURN_IF_NOT(src_is_gpu || dst_is_gpu, "Expected a WebGPU copy endpoint.");
+    ORT_RETURN_IF_NOT(src_data && dst_data, "WebGPU copy buffers must not be null.");
+    const size_t copy_size = (SafeInt<size_t>(bytes) + 3) / 4 * 4;
+    WGPUBuffer source = src_is_gpu ? static_cast<WGPUBuffer>(const_cast<void*>(src_data)) : nullptr;
+    WGPUBuffer destination = dst_is_gpu ? static_cast<WGPUBuffer>(dst_data) : nullptr;
+    ORT_RETURN_IF(source && copy_size > wgpuBufferGetSize(source), "WebGPU copy exceeds source buffer size.");
+    ORT_RETURN_IF(destination && copy_size > wgpuBufferGetSize(destination), "WebGPU copy exceeds destination buffer size.");
+    ORT_RETURN_IF(source && source == destination, "Source and destination buffers must be different.");
+    ORT_RETURN_IF(source && wgpuBufferGetMapState(source) != WGPUBufferMapState_Unmapped,
+                  "WebGPU copy source must be unmapped.");
+    if (destination) {
+      const auto map_state = wgpuBufferGetMapState(destination);
+      ORT_RETURN_IF_NOT(map_state == WGPUBufferMapState_Unmapped ||
+                            (!src_is_gpu && map_state == WGPUBufferMapState_Mapped),
+                        "WebGPU copy destination must be unmapped.");
+    }
     if (dst_is_gpu) {
       if (src_is_gpu) {
         // copy from GPU to GPU

--- a/onnxruntime/core/providers/webgpu/data_transfer.cc
+++ b/onnxruntime/core/providers/webgpu/data_transfer.cc
@@ -2,16 +2,22 @@
 // Licensed under the MIT License.
 
 #include "core/providers/webgpu/data_transfer.h"
+
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <string_view>
+
+#include "core/common/safeint.h"
 #include "core/providers/webgpu/buffer_manager.h"
 #include "core/providers/webgpu/webgpu_context.h"
 
 namespace onnxruntime {
 namespace webgpu {
 
-common::Status FlushAndWait(WebGpuContext& context, const BufferManager& buffer_manager,
-                            CommandRecordingState& recording) {
-  std::lock_guard<std::recursive_mutex> lock{recording.mutex};
-  ORT_RETURN_IF_ERROR(context.Flush(buffer_manager, recording));
+namespace {
+
+common::Status WaitForQueue(WebGpuContext& context) {
   wgpu::QueueWorkDoneStatus completion = wgpu::QueueWorkDoneStatus::Error;
   auto future = context.Device().GetQueue().OnSubmittedWorkDone(
       wgpu::CallbackMode::WaitAnyOnly,
@@ -21,6 +27,91 @@ common::Status FlushAndWait(WebGpuContext& context, const BufferManager& buffer_
       &completion);
   ORT_RETURN_IF_ERROR(context.Wait(future));
   ORT_RETURN_IF_NOT(completion == wgpu::QueueWorkDoneStatus::Success, "WebGPU queue completion failed.");
+  return Status::OK();
+}
+
+}  // namespace
+
+common::Status FlushAndWait(WebGpuContext& context, const BufferManager& buffer_manager,
+                            CommandRecordingState& recording) {
+  std::lock_guard<std::recursive_mutex> lock{recording.mutex};
+  ORT_RETURN_IF_ERROR(context.Flush(buffer_manager, recording));
+  return WaitForQueue(context);
+}
+
+common::Status CopyTensorWithLocalEncoder(WebGpuContext& context, const void* src_data,
+                                          bool src_is_gpu, void* dst_data, bool dst_is_gpu, size_t bytes) {
+  if (bytes == 0) {
+    return Status::OK();
+  }
+  ORT_RETURN_IF_NOT(src_is_gpu || dst_is_gpu, "Expected a WebGPU copy endpoint.");
+  ORT_RETURN_IF_NOT(src_data && dst_data, "WebGPU copy buffers must not be null.");
+
+  const size_t copy_size = (SafeInt<size_t>(bytes) + 3) / 4 * 4;
+  WGPUBuffer source = src_is_gpu ? static_cast<WGPUBuffer>(const_cast<void*>(src_data)) : nullptr;
+  WGPUBuffer destination = dst_is_gpu ? static_cast<WGPUBuffer>(dst_data) : nullptr;
+  ORT_RETURN_IF(source && copy_size > wgpuBufferGetSize(source), "WebGPU copy exceeds source buffer size.");
+  ORT_RETURN_IF(destination && copy_size > wgpuBufferGetSize(destination), "WebGPU copy exceeds destination buffer size.");
+  ORT_RETURN_IF(source && source == destination, "Source and destination buffers must be different.");
+  ORT_RETURN_IF(source && wgpuBufferGetMapState(source) != WGPUBufferMapState_Unmapped,
+                "WebGPU copy source must be unmapped.");
+
+  if (!src_is_gpu && wgpuBufferGetMapState(destination) == WGPUBufferMapState_Mapped) {
+    void* mapped_data = wgpuBufferGetMappedRange(destination, 0, copy_size);
+    ORT_RETURN_IF_NOT(mapped_data, "Failed to access mapped WebGPU upload buffer.");
+    std::memcpy(mapped_data, src_data, bytes);
+    wgpuBufferUnmap(destination);
+    return Status::OK();
+  }
+  ORT_RETURN_IF(destination && wgpuBufferGetMapState(destination) != WGPUBufferMapState_Unmapped,
+                "WebGPU copy destination must be unmapped.");
+
+  wgpu::Buffer staging_buffer;
+  if (!src_is_gpu || !dst_is_gpu) {
+    wgpu::BufferDescriptor descriptor{};
+    descriptor.size = copy_size;
+    descriptor.usage = src_is_gpu ? wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::MapRead
+                                  : wgpu::BufferUsage::CopySrc | wgpu::BufferUsage::MapWrite;
+    descriptor.mappedAtCreation = !src_is_gpu;
+    staging_buffer = context.Device().CreateBuffer(&descriptor);
+    ORT_RETURN_IF_NOT(staging_buffer, "Failed to create WebGPU copy staging buffer.");
+    if (src_is_gpu) {
+      destination = staging_buffer.Get();
+    } else {
+      auto* mapped_data = static_cast<uint8_t*>(staging_buffer.GetMappedRange());
+      ORT_RETURN_IF_NOT(mapped_data, "Failed to map WebGPU copy staging buffer.");
+      std::memcpy(mapped_data, src_data, bytes);
+      std::memset(mapped_data + bytes, 0, copy_size - bytes);
+      staging_buffer.Unmap();
+      source = staging_buffer.Get();
+    }
+  }
+
+  auto encoder = context.Device().CreateCommandEncoder();
+  encoder.CopyBufferToBuffer(source, 0, destination, 0, copy_size);
+  auto commands = encoder.Finish();
+  context.Device().GetQueue().Submit(1, &commands);
+  if (dst_is_gpu) {
+    return WaitForQueue(context);
+  }
+
+  struct MapResult {
+    wgpu::MapAsyncStatus status = wgpu::MapAsyncStatus::Error;
+    std::string message;
+  } map_result;
+  ORT_RETURN_IF_ERROR(context.Wait(staging_buffer.MapAsync(
+      wgpu::MapMode::Read, 0, copy_size, wgpu::CallbackMode::WaitAnyOnly,
+      [](wgpu::MapAsyncStatus status, wgpu::StringView message, MapResult* result) noexcept {
+        result->status = status;
+        if (auto text = static_cast<std::string_view>(message); !text.empty()) {
+          result->message = text;
+        }
+      },
+      &map_result)));
+  ORT_RETURN_IF_NOT(map_result.status == wgpu::MapAsyncStatus::Success,
+                    "WebGPU copy readback failed: ", map_result.message);
+  std::memcpy(dst_data, staging_buffer.GetConstMappedRange(), bytes);
+  staging_buffer.Unmap();
   return Status::OK();
 }
 

--- a/onnxruntime/core/providers/webgpu/data_transfer.cc
+++ b/onnxruntime/core/providers/webgpu/data_transfer.cc
@@ -4,35 +4,124 @@
 #include "core/providers/webgpu/data_transfer.h"
 #include "core/providers/webgpu/buffer_manager.h"
 #include "core/providers/webgpu/webgpu_context.h"
+#include "core/providers/webgpu/webgpu_execution_provider.h"
 
 namespace onnxruntime {
 namespace webgpu {
+
+#if defined(ORT_USE_EP_API_ADAPTERS)
+namespace {
+
+struct WebGpuSyncStream final : OrtSyncStreamImpl {
+  explicit WebGpuSyncStream(WebGpuExecutionProvider& ep) : ep_{ep} {
+    ort_version_supported = ORT_API_VERSION;
+    Release = [](OrtSyncStreamImpl* stream) noexcept { delete static_cast<WebGpuSyncStream*>(stream); };
+    GetHandle = [](OrtSyncStreamImpl* stream) noexcept -> void* { return stream; };
+    CreateNotification = CreateNotificationImpl;
+    Flush = FlushImpl;
+    OnSessionRunEnd = [](OrtSyncStreamImpl*) noexcept -> OrtStatus* { return nullptr; };
+  }
+
+  static const WebGpuSyncStream& From(const OrtSyncStream* stream) {
+    const auto* impl = onnxruntime::ep::Api().ep.SyncStream_GetImpl(stream);
+    ORT_ENFORCE(impl != nullptr && impl->Flush == FlushImpl, "Expected a WebGPU sync stream.");
+    return *static_cast<const WebGpuSyncStream*>(impl);
+  }
+
+  static OrtStatus* ORT_API_CALL FlushImpl(OrtSyncStreamImpl* stream) noexcept {
+    EXCEPTION_TO_RETURNED_STATUS_BEGIN
+    auto& ep = static_cast<WebGpuSyncStream*>(stream)->ep_;
+    auto& context = WebGpuContextFactory::GetContext(ep.GetDeviceId());
+    std::lock_guard<std::recursive_mutex> lock{ep.Recording().mutex};
+    ORT_THROW_IF_ERROR(context.Flush(ep.BufferManager(), ep.Recording()));
+    wgpu::QueueWorkDoneStatus completion = wgpu::QueueWorkDoneStatus::Error;
+    auto future = context.Device().GetQueue().OnSubmittedWorkDone(
+        wgpu::CallbackMode::WaitAnyOnly,
+        [](wgpu::QueueWorkDoneStatus status, wgpu::StringView, wgpu::QueueWorkDoneStatus* result) noexcept {
+          *result = status;
+        },
+        &completion);
+    ORT_THROW_IF_ERROR(context.Wait(future));
+    ORT_ENFORCE(completion == wgpu::QueueWorkDoneStatus::Success, "WebGPU queue completion failed.");
+    return nullptr;
+    EXCEPTION_TO_RETURNED_STATUS_END
+  }
+
+  static OrtStatus* ORT_API_CALL CreateNotificationImpl(
+      OrtSyncStreamImpl* stream, OrtSyncNotificationImpl** notification) noexcept;
+
+  WebGpuExecutionProvider& ep_;
+};
+
+struct WebGpuSyncNotification final : OrtSyncNotificationImpl {
+  explicit WebGpuSyncNotification(WebGpuSyncStream& stream) : stream_{stream} {
+    ort_version_supported = ORT_API_VERSION;
+    Release = [](OrtSyncNotificationImpl* notification) noexcept {
+      delete static_cast<WebGpuSyncNotification*>(notification);
+    };
+    Activate = [](OrtSyncNotificationImpl* notification) noexcept -> OrtStatus* {
+      auto& self = *static_cast<WebGpuSyncNotification*>(notification);
+      return WebGpuSyncStream::FlushImpl(&self.stream_);
+    };
+    WaitOnDevice = [](OrtSyncNotificationImpl*, OrtSyncStream*) noexcept -> OrtStatus* { return nullptr; };
+    WaitOnHost = [](OrtSyncNotificationImpl*) noexcept -> OrtStatus* { return nullptr; };
+  }
+
+  WebGpuSyncStream& stream_;
+};
+
+OrtStatus* ORT_API_CALL WebGpuSyncStream::CreateNotificationImpl(
+    OrtSyncStreamImpl* stream, OrtSyncNotificationImpl** notification) noexcept {
+  EXCEPTION_TO_RETURNED_STATUS_BEGIN
+  *notification = new WebGpuSyncNotification(*static_cast<WebGpuSyncStream*>(stream));
+  return nullptr;
+  EXCEPTION_TO_RETURNED_STATUS_END
+}
+
+}  // namespace
+
+OrtSyncStreamImpl* CreateWebGpuSyncStream(WebGpuExecutionProvider& ep) {
+  return new WebGpuSyncStream(ep);
+}
+
+CommandRecordingState& GetWebGpuStreamCommandState(const OrtSyncStream* stream) {
+  return WebGpuSyncStream::From(stream).ep_.Recording();
+}
+
+common::Status CopyTensorOnWebGpuStream(const OrtSyncStream* stream, const void* src_data,
+                                      bool src_is_gpu, void* dst_data, bool dst_is_gpu, size_t bytes) {
+  auto& ep = WebGpuSyncStream::From(stream).ep_;
+  DataTransferImpl transfer(ep.BufferManager(), ep.Recording());
+  return transfer.CopyTensor(src_data, src_is_gpu, dst_data, dst_is_gpu, bytes);
+}
+#endif
 
 common::Status DataTransferImpl::CopyTensor(void const* src_data,
                                             bool src_is_gpu,
                                             void* dst_data,
                                             bool dst_is_gpu,
                                             size_t bytes) const {
+  auto& command_state = recording_;
   std::lock_guard<std::mutex> lock{mutex_};
-  std::lock_guard<std::recursive_mutex> recording_lock{recording_.mutex};
+  std::lock_guard<std::recursive_mutex> recording_lock{command_state.mutex};
   if (bytes > 0) {
     if (dst_is_gpu) {
       if (src_is_gpu) {
         // copy from GPU to GPU
-        buffer_manager_.MemCpy(recording_,
+        buffer_manager_.MemCpy(command_state,
                                static_cast<WGPUBuffer>(const_cast<void*>(src_data)),
                                static_cast<WGPUBuffer>(dst_data),
                                bytes);
       } else {
         // copy from CPU to GPU
-        buffer_manager_.Upload(recording_,
+        buffer_manager_.Upload(command_state,
                                const_cast<void*>(src_data),
                                static_cast<WGPUBuffer>(dst_data),
                                bytes);
       }
     } else {
       // copy from GPU to CPU
-      buffer_manager_.Download(recording_,
+      buffer_manager_.Download(command_state,
                                static_cast<WGPUBuffer>(const_cast<void*>(src_data)),
                                dst_data,
                                bytes);

--- a/onnxruntime/core/providers/webgpu/data_transfer.cc
+++ b/onnxruntime/core/providers/webgpu/data_transfer.cc
@@ -34,7 +34,6 @@ common::Status WaitForQueue(WebGpuContext& context) {
 
 common::Status FlushAndWait(WebGpuContext& context, const BufferManager& buffer_manager,
                             CommandRecordingState& recording) {
-  std::lock_guard<std::recursive_mutex> lock{recording.mutex};
   ORT_RETURN_IF_ERROR(context.Flush(buffer_manager, recording));
   return WaitForQueue(context);
 }
@@ -121,7 +120,6 @@ common::Status DataTransferImpl::CopyTensor(void const* src_data,
                                             bool dst_is_gpu,
                                             size_t bytes) const {
   auto& command_state = recording_;
-  std::lock_guard<std::recursive_mutex> recording_lock{command_state.mutex};
   if (bytes > 0) {
     if (dst_is_gpu) {
       if (src_is_gpu) {

--- a/onnxruntime/core/providers/webgpu/data_transfer.h
+++ b/onnxruntime/core/providers/webgpu/data_transfer.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <mutex>
+
 #include "core/common/status.h"
 #include "core/framework/data_transfer.h"
 #include "core/framework/execution_provider.h"
@@ -11,12 +13,14 @@ namespace onnxruntime {
 namespace webgpu {
 
 class BufferManager;
+struct CommandRecordingState;
 
 // Low-level data transfer implementation that operates on raw pointers.
 // Used by both DataTransfer (IDataTransfer subclass) and the C API data transfer wrapper.
 class DataTransferImpl {
  public:
-  DataTransferImpl(const BufferManager& buffer_manager) : buffer_manager_{buffer_manager} {};
+  DataTransferImpl(const BufferManager& buffer_manager, CommandRecordingState& recording)
+      : buffer_manager_{buffer_manager}, recording_{recording} {}
 
   common::Status CopyTensor(void const* src_data,
                             bool src_is_gpu,
@@ -25,12 +29,15 @@ class DataTransferImpl {
                             size_t bytes) const;
 
  private:
+  mutable std::mutex mutex_;
   const BufferManager& buffer_manager_;
+  CommandRecordingState& recording_;
 };
 
 class DataTransfer : public IDataTransfer {
  public:
-  DataTransfer(const BufferManager& buffer_manager) : impl_{buffer_manager} {};
+  DataTransfer(const BufferManager& buffer_manager, CommandRecordingState& recording)
+      : impl_{buffer_manager, recording} {}
   ~DataTransfer() {};
 
   // Device-compatibility half of CanCopy, split out because it needs no BufferManager and so can

--- a/onnxruntime/core/providers/webgpu/data_transfer.h
+++ b/onnxruntime/core/providers/webgpu/data_transfer.h
@@ -11,11 +11,7 @@ namespace onnxruntime {
 namespace webgpu {
 
 class BufferManager;
-class WebGpuContext;
 struct CommandRecordingState;
-
-common::Status FlushAndWait(WebGpuContext& context, const BufferManager& buffer_manager,
-                            CommandRecordingState& recording);
 
 // Low-level data transfer implementation that operates on raw pointers.
 // Used by both DataTransfer (IDataTransfer subclass) and the C API data transfer wrapper.

--- a/onnxruntime/core/providers/webgpu/data_transfer.h
+++ b/onnxruntime/core/providers/webgpu/data_transfer.h
@@ -17,9 +17,6 @@ struct CommandRecordingState;
 common::Status FlushAndWait(WebGpuContext& context, const BufferManager& buffer_manager,
                             CommandRecordingState& recording);
 
-common::Status CopyTensorWithLocalEncoder(WebGpuContext& context, const void* src_data,
-                                          bool src_is_gpu, void* dst_data, bool dst_is_gpu, size_t bytes);
-
 // Low-level data transfer implementation that operates on raw pointers.
 // Used by both DataTransfer (IDataTransfer subclass) and the C API data transfer wrapper.
 class DataTransferImpl {

--- a/onnxruntime/core/providers/webgpu/data_transfer.h
+++ b/onnxruntime/core/providers/webgpu/data_transfer.h
@@ -3,25 +3,19 @@
 
 #pragma once
 
-#include <mutex>
-
 #include "core/common/status.h"
 #include "core/framework/data_transfer.h"
 #include "core/framework/execution_provider.h"
 
 namespace onnxruntime {
-class WebGpuExecutionProvider;
 namespace webgpu {
 
 class BufferManager;
+class WebGpuContext;
 struct CommandRecordingState;
 
-#if defined(ORT_USE_EP_API_ADAPTERS)
-OrtSyncStreamImpl* CreateWebGpuSyncStream(WebGpuExecutionProvider& ep);
-CommandRecordingState& GetWebGpuStreamCommandState(const OrtSyncStream* stream);
-common::Status CopyTensorOnWebGpuStream(const OrtSyncStream* stream, const void* src_data,
-                                      bool src_is_gpu, void* dst_data, bool dst_is_gpu, size_t bytes);
-#endif
+common::Status FlushAndWait(WebGpuContext& context, const BufferManager& buffer_manager,
+                            CommandRecordingState& recording);
 
 // Low-level data transfer implementation that operates on raw pointers.
 // Used by both DataTransfer (IDataTransfer subclass) and the C API data transfer wrapper.
@@ -37,7 +31,6 @@ class DataTransferImpl {
                             size_t bytes) const;
 
  private:
-  mutable std::mutex mutex_;
   const BufferManager& buffer_manager_;
   CommandRecordingState& recording_;
 };

--- a/onnxruntime/core/providers/webgpu/data_transfer.h
+++ b/onnxruntime/core/providers/webgpu/data_transfer.h
@@ -17,6 +17,9 @@ struct CommandRecordingState;
 common::Status FlushAndWait(WebGpuContext& context, const BufferManager& buffer_manager,
                             CommandRecordingState& recording);
 
+common::Status CopyTensorWithLocalEncoder(WebGpuContext& context, const void* src_data,
+                                          bool src_is_gpu, void* dst_data, bool dst_is_gpu, size_t bytes);
+
 // Low-level data transfer implementation that operates on raw pointers.
 // Used by both DataTransfer (IDataTransfer subclass) and the C API data transfer wrapper.
 class DataTransferImpl {

--- a/onnxruntime/core/providers/webgpu/data_transfer.h
+++ b/onnxruntime/core/providers/webgpu/data_transfer.h
@@ -10,10 +10,18 @@
 #include "core/framework/execution_provider.h"
 
 namespace onnxruntime {
+class WebGpuExecutionProvider;
 namespace webgpu {
 
 class BufferManager;
 struct CommandRecordingState;
+
+#if defined(ORT_USE_EP_API_ADAPTERS)
+OrtSyncStreamImpl* CreateWebGpuSyncStream(WebGpuExecutionProvider& ep);
+CommandRecordingState& GetWebGpuStreamCommandState(const OrtSyncStream* stream);
+common::Status CopyTensorOnWebGpuStream(const OrtSyncStream* stream, const void* src_data,
+                                      bool src_is_gpu, void* dst_data, bool dst_is_gpu, size_t bytes);
+#endif
 
 // Low-level data transfer implementation that operates on raw pointers.
 // Used by both DataTransfer (IDataTransfer subclass) and the C API data transfer wrapper.

--- a/onnxruntime/core/providers/webgpu/ep/README.md
+++ b/onnxruntime/core/providers/webgpu/ep/README.md
@@ -29,9 +29,10 @@ relies on the current ORT calling sequence, not an API guarantee: the first succ
 EP. There may be only one unbound EP per factory/thread. Binding removes the pending entry, and
 the Session can subsequently run on another thread. The factory lock does not cover creation or Run.
 
-Env and Session operations reuse `GpuBufferAllocator` and `DataTransferImpl`, but Env allocation
-owns separate recording and Env copies use local recording. Cached-buffer clears are submitted
-before Env allocation returns. Session allocations submit clears outside Run and batch them during Run.
+Env and Session operations reuse `GpuBufferAllocator` and `DataTransferImpl`. Env allocators and
+transfers share one context-owned recording, separate from every Session's recording. Cached-buffer
+clears are submitted before Env allocation returns. Session allocations submit clears outside Run
+and batch them during Run.
 `CopyTensors` submits pending commands before returning; downloads wait for readback, but uploads and
 device copies do not wait for GPU completion. The existing gap against the no-stream synchronous-copy
 contract is left as a TODO for separate work. Ordinary Run and graph replay submit commands without
@@ -40,16 +41,19 @@ I/O Binding synchronization calls do not guarantee GPU completion; output downlo
 
 There is no recording mutex. Applications must serialize same-Session allocator operations,
 copies, tensor destruction, graph replay, and graph release with that Session's execution. ORT's
-ordinary same-Session Run lock does not cover these external operations. Shared Env allocator
-operations, including Free/GetStats and tensor destruction, also require caller serialization.
-Concurrent profiling and cross-device transfers are outside the supported scope.
+ordinary same-Session Run lock does not cover these external operations. All Env copies and allocator
+operations on the same context, including Free/GetStats and tensor destruction, require caller
+serialization. Explicit concurrent calls to Env or Session allocator APIs, concurrent Env copies,
+concurrent profiling, and cross-device transfers are outside this PR's supported scope. Internal
+allocation and copies during independent Session creation and Run remain part of the supported path.
 
-`PluginEpWebGpuConcurrency` covers concurrent creation/Run, CPU/GPU I/O, and independent Session
-capture/replay. `CpuPartitionBetweenGpuKernels` verifies both the CPU intermediate and final GPU
-result across a forced GPU/CPU/GPU partition. The 12-thread shared-allocator/Run and 16-thread
-same-Session allocator/Run tests remain disabled next-phase targets, along with the other tests
-requiring concurrent access to a shared allocator or recording. Their interleavings are retained
-and must not be enabled until the corresponding support is implemented.
+Enabled `PluginEpWebGpuConcurrency` tests cover concurrent Session creation/Run with CPU I/O and
+sequential external allocation/copy operations. `CpuPartitionBetweenGpuKernels` verifies both the CPU
+intermediate and final GPU result across a forced GPU/CPU/GPU partition. The GPU-I/O concurrent Run,
+capture/replay, and Session allocator tests remain disabled because they also call Env copies or
+external allocators concurrently. The 12-/16-thread mixed targets and the other shared allocator or
+recording targets also remain disabled. These tests retain their original concurrent operations,
+without test-side copy locks, for future support.
 
 ### Missing parts
 

--- a/onnxruntime/core/providers/webgpu/ep/README.md
+++ b/onnxruntime/core/providers/webgpu/ep/README.md
@@ -36,14 +36,17 @@ Entries are removed on successful binding or EP release, even if release uses an
 The factory lock only protects bookkeeping, not EP construction or Session execution.
 Revisit these assumptions if ORT's factory calling sequence changes.
 
-Environment allocators create and release Dawn buffers directly, without using the shared
-buffer cache or Session recording state. Environment transfers also bypass `BufferManager`
-and `CommandRecordingState`: each copy uses a local Dawn encoder and staging buffer as needed,
-submits directly to the device queue, and completes before returning. Downloads wait for
-`MapAsync`; uploads and device copies wait for submitted queue work. Mapped upload targets
-are written and unmapped directly. The shared context is retained only for device lifetime,
-device access, and the platform wait helper, not command recording or cache refresh.
-Environment allocation and copies on independent tensors may run concurrently with Session inference.
+Environment and Session operations reuse `GpuBufferAllocator`, `DataTransferImpl`, and the
+context-level `BufferManager`. The Env allocator retains the context and its own recording;
+cached-buffer clears are always submitted before Alloc returns. Env copies use local recording
+for each CopyTensors call, while Session copies use the owning EP's recording. Both paths
+submit and wait before returning from CopyTensors. There is no separate external allocator or
+local-encoder copy implementation. Sharing implementation and caches does not share Session
+encoders or graph capture state.
+
+Env APIs remain available for sequential use. Applications must serialize operations on the
+shared Env allocator, including Alloc, Free, GetStats, and tensor destruction. Env concurrency
+is outside this revision's validation scope; no Env recording mutex is introduced.
 
 Session allocators still reuse cached buffers. `IsRunActive()` controls clear submission:
 outside Run, cached-buffer clears are submitted before Alloc returns; during Run, clears are
@@ -52,7 +55,9 @@ Session allocator operations do not overlap Run. Applications must serialize all
 GetStats, tensor destruction, Session-bound copies, graph capture/replay, and graph release for
 the same Session with its execution. Sharing a recording or Session allocator across threads
 without this serialization is unsupported. Tensor data and lifetimes also remain the caller's
-responsibility. Different Sessions and independent Env operations may still run concurrently.
+responsibility. The concurrency target is creating/initializing Sessions while other Sessions
+run, along with independent Session creation and execution. Env operations are not part of
+the concurrency acceptance gate.
 
 The plugin does not register synchronization streams or support stream overrides. Session
 data transfers are synchronous and use their owning Session recording. Ordinary Run and graph
@@ -62,36 +67,42 @@ replay still submit pending commands, but do not add a queue-completion wait at 
 GPU completion. Subsequent work on the same queue is ordered by submission; an explicit
 output download waits for CPU-readable results. No ORT stream support is needed for this routing.
 
-AutoEP tests cover CPU I/O, graph-internal CPU/GPU copies, serial and concurrent Session creation,
-execution on other threads after creation, concurrent Sessions with environment copies, and
-Run-external cached-buffer clearing. Environment copy tests include batched zero-sized and
-non-four-byte-aligned tensors with host-side output bounds checks. Graph capture/replay is
-covered for independent Sessions with fixed GPU I/O. Concurrent profiling, graph capture combined with same-Session allocator/Run
-interleaving, and cross-device transfers remain outside the tested contract.
-Performance must be measured separately.
+The current validation is limited to `DifferentSessionsCreateAndRunConcurrently`. Other tests
+are retained for future validation; results obtained before implementation sharing do not
+establish their behavior for this revision. Concurrent profiling, same-Session allocator/Run
+interleaving, and cross-device transfers remain unsupported. Performance must be measured separately.
 
 ### Concurrency test gates
 
-Both mixed-load tests use four threads per operation group, a common start barrier, and
-ten iterations per worker. Run and copy workers verify the returned tensor data.
+The current gate uses four creation workers and four existing-Session Run workers. A barrier
+aligns each of twenty iterations. Creation workers create, initialize, verify, and destroy
+their own Session; Run workers execute independent pre-created Sessions. All runs use CPU
+inputs and outputs with CPU fallback disabled and verify the model's results. No worker uses
+an external allocator or Env copy concurrently with another worker.
 
 | Gate | Test in `PluginEpWebGpuConcurrency` | Concurrent operations |
 | --- | --- | --- |
-| Required baseline, 12 threads | `MixedSessionAndEnvironmentOperationsConcurrently12Threads` | Session creation/destruction, existing Session inference, environment allocation/copies |
+| Current gate, 8 threads | `DifferentSessionsCreateAndRunConcurrently` | New Session creation/initialization and first Run alongside existing Session inference |
+| Future Env concurrency target, 12 threads | `DISABLED_MixedSessionAndEnvironmentOperationsConcurrently12Threads` | Session creation/destruction, existing Session inference, environment allocation/copies |
 | Advanced target, 16 threads | `DISABLED_MixedSessionAndAllocatorOperationsConcurrently16Threads` | The baseline plus allocator operations on the same Sessions that are running inference |
 
-The 12-thread gate runs by default. The 16-thread test retains the unsupported allocator/Run
-interleaving as a future acceptance target and is disabled by default, not removed or serialized.
-It can race or fail with lock-free recording and must not be used to claim current support.
-Earlier passes with a recording mutex and immediate clear submission do not apply to this implementation.
-Enable it explicitly only when developing that future support, with Google Test's `--gtest_also_run_disabled_tests` and
+The 12/16-thread tests are retained as disabled future targets, not removed or serialized.
+The next phase targets shared Env allocator operations concurrent with Session Run (12 threads),
+then adds same-Session allocator/Run concurrency (16 threads). Enable each gate only when its
+corresponding concurrency support is implemented and validated.
+Their concurrent shared-allocator operations can race and must not be used to claim current
+support. Earlier results do not apply to this implementation. Enable the advanced target only
+when developing that future support, with Google Test's `--gtest_also_run_disabled_tests` and
 `--gtest_filter=PluginEpWebGpuConcurrency.DISABLED_MixedSessionAndAllocatorOperationsConcurrently16Threads`.
 A passing baseline does not establish support for the advanced target.
 
 The built-in `WebGpuConcurrentContextTest.DISABLED_SessionAllocatorAndRunConcurrently` and
 `WebGpuConcurrentContextTest.DISABLED_SharedDataTransferMultiThreadCopy` likewise retain
-unsupported same-recording interleavings as disabled targets. Independent Session and
-independent recording tests remain enabled.
+unsupported same-recording interleavings as disabled targets. Concurrent shared Env allocator
+tests are also disabled, including `DISABLED_SharedAllocatorMultiThreadCreateTensor`,
+`DISABLED_SharedAllocatorCreatesAndCopiesConcurrently`, and
+`DISABLED_DifferentSessionsAndEnvironmentCopiesRunConcurrently`. Independent Session and
+independent recording tests remain enabled, but are not all rerun for this revision.
 
 `DifferentSessionsGraphCaptureAndReplayConcurrently` enables graph capture for four Sessions
 using `mul_1.onnx`, each with independent, fixed-address GPU inputs and outputs and the default
@@ -100,6 +111,7 @@ Each worker updates its input and verifies its output for twenty runs. Per-Sessi
 callbacks require at least nineteen entries into ORT's graph replay fast path, so numerical
 correctness alone cannot hide a fallback to ordinary execution. This test runs by default and
 does not enable profiling or overlap external allocator operations with the same Session's Run.
+It is retained but is not included in this revision's create/Run-only validation.
 
 ### Missing parts
 

--- a/onnxruntime/core/providers/webgpu/ep/README.md
+++ b/onnxruntime/core/providers/webgpu/ep/README.md
@@ -19,7 +19,9 @@ To ensure both static library and dynamic library builds work, we need to make a
 ### Session and environment isolation
 
 Different Sessions may run concurrently. Each Session owns its command recording state;
-kernels and its data transfer use that same state without stream-based routing.
+kernels and its data transfer use that same state without stream-based routing or a recording mutex.
+Access to one Session's recording must be serialized by the caller. Ordinary same-Session Run
+calls remain serialized by ORT, but that does not cover external allocation, copies, or graph replay.
 The context-level buffer and pipeline caches remain shared and synchronized. Buffers used by
 unsubmitted commands remain associated with their recording until submission.
 
@@ -43,14 +45,14 @@ are written and unmapped directly. The shared context is retained only for devic
 device access, and the platform wait helper, not command recording or cache refresh.
 Environment allocation and copies on independent tensors may run concurrently with Session inference.
 
-Session allocators still reuse cached buffers. The plugin's Session device allocator submits
-cached-buffer clears before allocation returns, including during `Run`. This orders the clears
-before subsequent environment copies, but also flushes pending Session commands and reduces
-batching. This immediate-submit policy is experimental; performance has not been measured and
-graph capture coverage is limited to the scenario below. Applications should continue to serialize external
-Session allocator operations (`Alloc`, `Free`, and tensor destruction) with that Session's `Run`
-until the advanced contract is established. Tensor data and lifetimes must be synchronized by
-the caller regardless of allocator locking.
+Session allocators still reuse cached buffers. `IsRunActive()` controls clear submission:
+outside Run, cached-buffer clears are submitted before Alloc returns; during Run, clears are
+deferred in the Session recording to preserve batching. This is valid only when external
+Session allocator operations do not overlap Run. Applications must serialize allocation, Free,
+GetStats, tensor destruction, Session-bound copies, graph capture/replay, and graph release for
+the same Session with its execution. Sharing a recording or Session allocator across threads
+without this serialization is unsupported. Tensor data and lifetimes also remain the caller's
+responsibility. Different Sessions and independent Env operations may still run concurrently.
 
 The plugin does not register synchronization streams or support stream overrides. Session
 data transfers are synchronous and use their owning Session recording. Ordinary Run and graph
@@ -78,11 +80,18 @@ ten iterations per worker. Run and copy workers verify the returned tensor data.
 | Required baseline, 12 threads | `MixedSessionAndEnvironmentOperationsConcurrently12Threads` | Session creation/destruction, existing Session inference, environment allocation/copies |
 | Advanced target, 16 threads | `DISABLED_MixedSessionAndAllocatorOperationsConcurrently16Threads` | The baseline plus allocator operations on the same Sessions that are running inference |
 
-The 12-thread gate runs by default. The 16-thread test retains the experimental allocator/Run
-interleaving as an advanced acceptance target and is disabled by default, not removed or
-serialized. Enable it explicitly with Google Test's `--gtest_also_run_disabled_tests` and
+The 12-thread gate runs by default. The 16-thread test retains the unsupported allocator/Run
+interleaving as a future acceptance target and is disabled by default, not removed or serialized.
+It can race or fail with lock-free recording and must not be used to claim current support.
+Earlier passes with a recording mutex and immediate clear submission do not apply to this implementation.
+Enable it explicitly only when developing that future support, with Google Test's `--gtest_also_run_disabled_tests` and
 `--gtest_filter=PluginEpWebGpuConcurrency.DISABLED_MixedSessionAndAllocatorOperationsConcurrently16Threads`.
 A passing baseline does not establish support for the advanced target.
+
+The built-in `WebGpuConcurrentContextTest.DISABLED_SessionAllocatorAndRunConcurrently` and
+`WebGpuConcurrentContextTest.DISABLED_SharedDataTransferMultiThreadCopy` likewise retain
+unsupported same-recording interleavings as disabled targets. Independent Session and
+independent recording tests remain enabled.
 
 `DifferentSessionsGraphCaptureAndReplayConcurrently` enables graph capture for four Sessions
 using `mul_1.onnx`, each with independent, fixed-address GPU inputs and outputs and the default

--- a/onnxruntime/core/providers/webgpu/ep/README.md
+++ b/onnxruntime/core/providers/webgpu/ep/README.md
@@ -18,105 +18,36 @@ To ensure both static library and dynamic library builds work, we need to make a
 
 ### Session and environment isolation
 
-Different Sessions may run concurrently. Each Session owns its command recording state;
-kernels and its data transfer use that same state without stream-based routing or a recording mutex.
-Access to one Session's recording must be serialized by the caller. Ordinary same-Session Run
-calls remain serialized by ORT, but that does not cover external allocation, copies, or graph replay.
-The context-level buffer and pipeline caches remain shared and synchronized. Buffers used by
-unsubmitted commands remain associated with their recording until submission.
+Different Sessions can be created, initialized, and run concurrently, including creation while
+another Session runs. Each Session owns a `CommandRecordingState` used by its kernels and copies.
+The device, buffer caches, and pipeline cache remain shared and synchronized. Released buffers
+remain with their recording until its commands have been submitted.
 
-Sessions may be constructed concurrently, with one WebGPU EP per Session. This implementation
-relies on the current ORT creation order and calling thread, not a public API guarantee:
-the first successful `OrtEpFactory::CreateDataTransfer` call creates the environment transfer,
-and subsequent calls bind to the EP awaiting its Session transfer on the current thread.
-Pending EPs are tracked per factory and creation thread. Each thread may have at most one
-unbound EP for that factory. The two creation callbacks must run on the same thread; once
-bound, the transfer directly references its EP and the Session may run on other threads.
-Entries are removed on successful binding or EP release, even if release uses another thread.
-The factory lock only protects bookkeeping, not EP construction or Session execution.
-Revisit these assumptions if ORT's factory calling sequence changes.
+The plugin binds Session transfers during creation without new EP APIs or stream routing. This
+relies on the current ORT calling sequence, not an API guarantee: the first successful factory
+`CreateDataTransfer` call is for the Env; later calls run on the thread that created the awaiting
+EP. There may be only one unbound EP per factory/thread. Binding removes the pending entry, and
+the Session can subsequently run on another thread. The factory lock does not cover creation or Run.
 
-Environment and Session operations reuse `GpuBufferAllocator`, `DataTransferImpl`, and the
-context-level `BufferManager`. The Env allocator retains the context and its own recording;
-cached-buffer clears are always submitted before Alloc returns. Env copies use local recording
-for each CopyTensors call, while Session copies use the owning EP's recording. Both paths
-submit and wait before returning from CopyTensors. There is no separate external allocator or
-local-encoder copy implementation. Sharing implementation and caches does not share Session
-encoders or graph capture state.
+Env and Session operations reuse `GpuBufferAllocator` and `DataTransferImpl`, but Env allocation
+owns separate recording and Env copies use local recording. Cached-buffer clears are submitted
+before Env allocation returns. Session allocations submit clears outside Run and batch them during Run.
+`CopyTensors` completes synchronously as required for a provider without streams. Ordinary Run and
+graph replay submit commands without an additional completion wait; `OrtEp::Sync` remains a no-op.
+I/O Binding synchronization calls do not guarantee GPU completion; output downloads wait for readback.
 
-Env APIs remain available for sequential use. Applications must serialize operations on the
-shared Env allocator, including Alloc, Free, GetStats, and tensor destruction. Env concurrency
-is outside this revision's validation scope; no Env recording mutex is introduced.
+There is no recording mutex. Applications must serialize same-Session allocator operations,
+copies, tensor destruction, graph replay, and graph release with that Session's execution. ORT's
+ordinary same-Session Run lock does not cover these external operations. Shared Env allocator
+operations, including Free/GetStats and tensor destruction, also require caller serialization.
+Concurrent profiling and cross-device transfers are outside the supported scope.
 
-Session allocators still reuse cached buffers. `IsRunActive()` controls clear submission:
-outside Run, cached-buffer clears are submitted before Alloc returns; during Run, clears are
-deferred in the Session recording to preserve batching. This is valid only when external
-Session allocator operations do not overlap Run. Applications must serialize allocation, Free,
-GetStats, tensor destruction, Session-bound copies, graph capture/replay, and graph release for
-the same Session with its execution. Sharing a recording or Session allocator across threads
-without this serialization is unsupported. Tensor data and lifetimes also remain the caller's
-responsibility. The concurrency target is creating/initializing Sessions while other Sessions
-run, along with independent Session creation and execution. Env operations are not part of
-the concurrency acceptance gate.
-
-The plugin does not register synchronization streams or support stream overrides. Session
-data transfers are synchronous and use their owning Session recording. Ordinary Run and graph
-replay still submit pending commands, but do not add a queue-completion wait at run end.
-`OrtEp::Sync` is not implemented, restoring the earlier WebGPU behavior: I/O Binding's
-`SynchronizeInputs` and `SynchronizeOutputs` use the default no-op Sync and do not guarantee
-GPU completion. Subsequent work on the same queue is ordered by submission; an explicit
-output download waits for CPU-readable results. No ORT stream support is needed for this routing.
-
-All 14 enabled `PluginEpWebGpuConcurrency` tests passed locally on Windows x64 with D3D12,
-both individually and together in one process. The four disabled future targets were also
-explicitly run: one reported a validation failure and three terminated abnormally. They remain
-unsupported and disabled. Concurrent profiling, same-Session allocator/Run interleaving, and
-cross-device transfers remain unsupported. Performance must be measured separately.
-
-`CpuPartitionBetweenGpuKernels` forces `Neg(WebGPU) -> Neg(CPU) -> Neg(WebGPU)` with graph
-optimizations disabled. It asserts EP placement for the input and both outputs and checks
-CPU intermediate and GPU final values across twenty runs with changing inputs. This covers
-in-Run GPU/CPU copy ordering, not concurrent allocator operations.
-
-### Concurrency test gates
-
-The current gate uses four creation workers and four existing-Session Run workers. A barrier
-aligns each of twenty iterations. Creation workers create, initialize, verify, and destroy
-their own Session; Run workers execute independent pre-created Sessions. All runs use CPU
-inputs and outputs with CPU fallback disabled and verify the model's results. No worker uses
-an external allocator or Env copy concurrently with another worker.
-
-| Gate | Test in `PluginEpWebGpuConcurrency` | Concurrent operations |
-| --- | --- | --- |
-| Current gate, 8 threads | `DifferentSessionsCreateAndRunConcurrently` | New Session creation/initialization and first Run alongside existing Session inference |
-| Future Env concurrency target, 12 threads | `DISABLED_MixedSessionAndEnvironmentOperationsConcurrently12Threads` | Session creation/destruction, existing Session inference, environment allocation/copies |
-| Advanced target, 16 threads | `DISABLED_MixedSessionAndAllocatorOperationsConcurrently16Threads` | The baseline plus allocator operations on the same Sessions that are running inference |
-
-The 12/16-thread tests are retained as disabled future targets, not removed or serialized.
-The next phase targets shared Env allocator operations concurrent with Session Run (12 threads),
-then adds same-Session allocator/Run concurrency (16 threads). Enable each gate only when its
-corresponding concurrency support is implemented and validated.
-Their concurrent shared-allocator operations can race and must not be used to claim current
-support. Earlier results do not apply to this implementation. Enable the advanced target only
-when developing that future support, with Google Test's `--gtest_also_run_disabled_tests` and
-`--gtest_filter=PluginEpWebGpuConcurrency.DISABLED_MixedSessionAndAllocatorOperationsConcurrently16Threads`.
-A passing baseline does not establish support for the advanced target.
-
-The built-in `WebGpuConcurrentContextTest.DISABLED_SessionAllocatorAndRunConcurrently` and
-`WebGpuConcurrentContextTest.DISABLED_SharedDataTransferMultiThreadCopy` likewise retain
-unsupported same-recording interleavings as disabled targets. Concurrent shared Env allocator
-tests are also disabled, including `DISABLED_SharedAllocatorMultiThreadCreateTensor`,
-`DISABLED_SharedAllocatorCreatesAndCopiesConcurrently`, and
-`DISABLED_DifferentSessionsAndEnvironmentCopiesRunConcurrently`. The built-in independent Session
-and independent recording tests remain enabled but were not rerun in this validation.
-
-`DifferentSessionsGraphCaptureAndReplayConcurrently` enables graph capture for four Sessions
-using `mul_1.onnx`, each with independent, fixed-address GPU inputs and outputs and the default
-graph ID. A per-iteration barrier aligns their first capture runs and subsequent replay runs.
-Each worker updates its input and verifies its output for twenty runs. Per-Session logging
-callbacks require at least nineteen entries into ORT's graph replay fast path, so numerical
-correctness alone cannot hide a fallback to ordinary execution. This test runs by default and
-does not enable profiling or overlap external allocator operations with the same Session's Run.
+`PluginEpWebGpuConcurrency` covers concurrent creation/Run, CPU/GPU I/O, and independent Session
+capture/replay. `CpuPartitionBetweenGpuKernels` verifies both the CPU intermediate and final GPU
+result across a forced GPU/CPU/GPU partition. The 12-thread shared-allocator/Run and 16-thread
+same-Session allocator/Run tests remain disabled next-phase targets, along with the other tests
+requiring concurrent access to a shared allocator or recording. Their interleavings are retained
+and must not be enabled until the corresponding support is implemented.
 
 ### Missing parts
 

--- a/onnxruntime/core/providers/webgpu/ep/README.md
+++ b/onnxruntime/core/providers/webgpu/ep/README.md
@@ -16,27 +16,72 @@ To ensure both static library and dynamic library builds work, we need to make a
 
   - use a bridge to connect EP ABI and the internal classes
 
-### Session streams
+### Session and environment isolation
 
-The WebGPU plugin implements `OrtEp::CreateSyncStreamForDevice`. Each stream references its
-owning EP's command state; kernels and stream-bearing data transfers use that same state.
-Graph Memcpy kernels access their owning EP directly, avoiding the generic single-tensor
-transfer wrapper that currently drops the stream argument.
+Different Sessions may run concurrently. Each Session owns its command recording state;
+kernels and its data transfer use that same state without stream-based routing.
+The context-level buffer and pipeline caches remain shared and synchronized. Buffers used by
+unsubmitted commands remain associated with their recording until submission.
 
-Session allocators expose the existing `OrtAllocator::AllocOnStream` callback. Allocations
-with a matching Session stream defer cached-buffer clears; plain `Alloc` submits those clears
-before returning. No thread-local Session lookup is needed. External allocations can still
-flush pending Session work, so this is correctness isolation, not a no-contention guarantee.
+Sessions may be constructed concurrently, with one WebGPU EP per Session. This implementation
+relies on the current ORT creation order and calling thread, not a public API guarantee:
+the first successful `OrtEpFactory::CreateDataTransfer` call creates the environment transfer,
+and subsequent calls bind to the EP awaiting its Session transfer on the current thread.
+Pending EPs are tracked per factory and creation thread. Each thread may have at most one
+unbound EP for that factory. The two creation callbacks must run on the same thread; once
+bound, the transfer directly references its EP and the Session may run on other threads.
+Entries are removed on successful binding or EP release, even if release uses another thread.
+The factory lock only protects bookkeeping, not EP construction or Session execution.
+Revisit these assumptions if ORT's factory calling sequence changes.
 
-Environment transfers with no stream use their private command state. GPU-to-GPU copies
-without a stream submit and wait before returning. Stream notifications currently complete
-producer work synchronously during activation; the wait callbacks consequently have no
-remaining work. This conservative implementation prioritizes correctness over overlap.
+Environment allocators create and release Dawn buffers directly, without using the shared
+buffer cache or Session recording state. Each environment `CopyTensors` call uses local
+recording state and completes its copies before returning. Environment allocation and copies
+on independent tensors may run concurrently with Session inference.
 
-The implementation requires an ORT build with stream support. CPU I/O, graph-internal CPU/GPU
-copies, concurrent Sessions, and same-Session allocator concurrency are covered by AutoEP tests.
-Concurrent graph capture, concurrent profiling, cross-device transfer, and arbitrary foreign
-stream overrides are not established by these tests. Performance must be measured separately.
+Session allocators still reuse cached buffers. The plugin's Session device allocator submits
+cached-buffer clears before allocation returns, including during `Run`. This orders the clears
+before subsequent environment copies, but also flushes pending Session commands and reduces
+batching. This immediate-submit policy is experimental; performance has not been measured and
+graph capture coverage is limited to the scenario below. Applications should continue to serialize external
+Session allocator operations (`Alloc`, `Free`, and tensor destruction) with that Session's `Run`
+until the advanced contract is established. Tensor data and lifetimes must be synchronized by
+the caller regardless of allocator locking.
+
+The plugin does not register synchronization streams or support stream overrides. Session
+data transfers are synchronous; `OrtEp::Sync` and the default run-end synchronization submit
+and wait for Session work. No ORT stream support is needed for this routing.
+
+AutoEP tests cover CPU I/O, graph-internal CPU/GPU copies, serial and concurrent Session creation,
+execution on other threads after creation, concurrent Sessions with environment copies, and
+Run-external cached-buffer clearing. Graph capture/replay is covered for independent Sessions
+with fixed GPU I/O. Concurrent profiling, graph capture combined with same-Session allocator/Run
+interleaving, and cross-device transfers remain outside the tested contract.
+Performance must be measured separately.
+
+### Concurrency test gates
+
+Both mixed-load tests use four threads per operation group, a common start barrier, and
+ten iterations per worker. Run and copy workers verify the returned tensor data.
+
+| Gate | Test in `PluginEpWebGpuConcurrency` | Concurrent operations |
+| --- | --- | --- |
+| Required baseline, 12 threads | `MixedSessionAndEnvironmentOperationsConcurrently12Threads` | Session creation/destruction, existing Session inference, environment allocation/copies |
+| Advanced target, 16 threads | `DISABLED_MixedSessionAndAllocatorOperationsConcurrently16Threads` | The baseline plus allocator operations on the same Sessions that are running inference |
+
+The 12-thread gate runs by default. The 16-thread test retains the experimental allocator/Run
+interleaving as an advanced acceptance target and is disabled by default, not removed or
+serialized. Enable it explicitly with Google Test's `--gtest_also_run_disabled_tests` and
+`--gtest_filter=PluginEpWebGpuConcurrency.DISABLED_MixedSessionAndAllocatorOperationsConcurrently16Threads`.
+A passing baseline does not establish support for the advanced target.
+
+`DifferentSessionsGraphCaptureAndReplayConcurrently` enables graph capture for four Sessions
+using `mul_1.onnx`, each with independent, fixed-address GPU inputs and outputs and the default
+graph ID. A per-iteration barrier aligns their first capture runs and subsequent replay runs.
+Each worker updates its input and verifies its output for twenty runs. Per-Session logging
+callbacks require at least nineteen entries into ORT's graph replay fast path, so numerical
+correctness alone cannot hide a fallback to ordinary execution. This test runs by default and
+does not enable profiling or overlap external allocator operations with the same Session's Run.
 
 ### Missing parts
 

--- a/onnxruntime/core/providers/webgpu/ep/README.md
+++ b/onnxruntime/core/providers/webgpu/ep/README.md
@@ -16,6 +16,28 @@ To ensure both static library and dynamic library builds work, we need to make a
 
   - use a bridge to connect EP ABI and the internal classes
 
+### Session streams
+
+The WebGPU plugin implements `OrtEp::CreateSyncStreamForDevice`. Each stream references its
+owning EP's command state; kernels and stream-bearing data transfers use that same state.
+Graph Memcpy kernels access their owning EP directly, avoiding the generic single-tensor
+transfer wrapper that currently drops the stream argument.
+
+Session allocators expose the existing `OrtAllocator::AllocOnStream` callback. Allocations
+with a matching Session stream defer cached-buffer clears; plain `Alloc` submits those clears
+before returning. No thread-local Session lookup is needed. External allocations can still
+flush pending Session work, so this is correctness isolation, not a no-contention guarantee.
+
+Environment transfers with no stream use their private command state. GPU-to-GPU copies
+without a stream submit and wait before returning. Stream notifications currently complete
+producer work synchronously during activation; the wait callbacks consequently have no
+remaining work. This conservative implementation prioritizes correctness over overlap.
+
+The implementation requires an ORT build with stream support. CPU I/O, graph-internal CPU/GPU
+copies, concurrent Sessions, and same-Session allocator concurrency are covered by AutoEP tests.
+Concurrent graph capture, concurrent profiling, cross-device transfer, and arbitrary foreign
+stream overrides are not established by these tests. Performance must be measured separately.
+
 ### Missing parts
 
 This section describes what is missing.

--- a/onnxruntime/core/providers/webgpu/ep/README.md
+++ b/onnxruntime/core/providers/webgpu/ep/README.md
@@ -67,10 +67,16 @@ replay still submit pending commands, but do not add a queue-completion wait at 
 GPU completion. Subsequent work on the same queue is ordered by submission; an explicit
 output download waits for CPU-readable results. No ORT stream support is needed for this routing.
 
-The current validation is limited to `DifferentSessionsCreateAndRunConcurrently`. Other tests
-are retained for future validation; results obtained before implementation sharing do not
-establish their behavior for this revision. Concurrent profiling, same-Session allocator/Run
-interleaving, and cross-device transfers remain unsupported. Performance must be measured separately.
+All 14 enabled `PluginEpWebGpuConcurrency` tests passed locally on Windows x64 with D3D12,
+both individually and together in one process. The four disabled future targets were also
+explicitly run: one reported a validation failure and three terminated abnormally. They remain
+unsupported and disabled. Concurrent profiling, same-Session allocator/Run interleaving, and
+cross-device transfers remain unsupported. Performance must be measured separately.
+
+`CpuPartitionBetweenGpuKernels` forces `Neg(WebGPU) -> Neg(CPU) -> Neg(WebGPU)` with graph
+optimizations disabled. It asserts EP placement for the input and both outputs and checks
+CPU intermediate and GPU final values across twenty runs with changing inputs. This covers
+in-Run GPU/CPU copy ordering, not concurrent allocator operations.
 
 ### Concurrency test gates
 
@@ -101,8 +107,8 @@ The built-in `WebGpuConcurrentContextTest.DISABLED_SessionAllocatorAndRunConcurr
 unsupported same-recording interleavings as disabled targets. Concurrent shared Env allocator
 tests are also disabled, including `DISABLED_SharedAllocatorMultiThreadCreateTensor`,
 `DISABLED_SharedAllocatorCreatesAndCopiesConcurrently`, and
-`DISABLED_DifferentSessionsAndEnvironmentCopiesRunConcurrently`. Independent Session and
-independent recording tests remain enabled, but are not all rerun for this revision.
+`DISABLED_DifferentSessionsAndEnvironmentCopiesRunConcurrently`. The built-in independent Session
+and independent recording tests remain enabled but were not rerun in this validation.
 
 `DifferentSessionsGraphCaptureAndReplayConcurrently` enables graph capture for four Sessions
 using `mul_1.onnx`, each with independent, fixed-address GPU inputs and outputs and the default
@@ -111,7 +117,6 @@ Each worker updates its input and verifies its output for twenty runs. Per-Sessi
 callbacks require at least nineteen entries into ORT's graph replay fast path, so numerical
 correctness alone cannot hide a fallback to ordinary execution. This test runs by default and
 does not enable profiling or overlap external allocator operations with the same Session's Run.
-It is retained but is not included in this revision's create/Run-only validation.
 
 ### Missing parts
 

--- a/onnxruntime/core/providers/webgpu/ep/README.md
+++ b/onnxruntime/core/providers/webgpu/ep/README.md
@@ -32,8 +32,10 @@ the Session can subsequently run on another thread. The factory lock does not co
 Env and Session operations reuse `GpuBufferAllocator` and `DataTransferImpl`, but Env allocation
 owns separate recording and Env copies use local recording. Cached-buffer clears are submitted
 before Env allocation returns. Session allocations submit clears outside Run and batch them during Run.
-`CopyTensors` completes synchronously as required for a provider without streams. Ordinary Run and
-graph replay submit commands without an additional completion wait; `OrtEp::Sync` remains a no-op.
+`CopyTensors` submits pending commands before returning; downloads wait for readback, but uploads and
+device copies do not wait for GPU completion. The existing gap against the no-stream synchronous-copy
+contract is left as a TODO for separate work. Ordinary Run and graph replay submit commands without
+an additional completion wait; `OrtEp::Sync` remains a no-op.
 I/O Binding synchronization calls do not guarantee GPU completion; output downloads wait for readback.
 
 There is no recording mutex. Applications must serialize same-Session allocator operations,

--- a/onnxruntime/core/providers/webgpu/ep/README.md
+++ b/onnxruntime/core/providers/webgpu/ep/README.md
@@ -35,9 +35,13 @@ The factory lock only protects bookkeeping, not EP construction or Session execu
 Revisit these assumptions if ORT's factory calling sequence changes.
 
 Environment allocators create and release Dawn buffers directly, without using the shared
-buffer cache or Session recording state. Each environment `CopyTensors` call uses local
-recording state and completes its copies before returning. Environment allocation and copies
-on independent tensors may run concurrently with Session inference.
+buffer cache or Session recording state. Environment transfers also bypass `BufferManager`
+and `CommandRecordingState`: each copy uses a local Dawn encoder and staging buffer as needed,
+submits directly to the device queue, and completes before returning. Downloads wait for
+`MapAsync`; uploads and device copies wait for submitted queue work. Mapped upload targets
+are written and unmapped directly. The shared context is retained only for device lifetime,
+device access, and the platform wait helper, not command recording or cache refresh.
+Environment allocation and copies on independent tensors may run concurrently with Session inference.
 
 Session allocators still reuse cached buffers. The plugin's Session device allocator submits
 cached-buffer clears before allocation returns, including during `Run`. This orders the clears
@@ -49,13 +53,18 @@ until the advanced contract is established. Tensor data and lifetimes must be sy
 the caller regardless of allocator locking.
 
 The plugin does not register synchronization streams or support stream overrides. Session
-data transfers are synchronous; `OrtEp::Sync` and the default run-end synchronization submit
-and wait for Session work. No ORT stream support is needed for this routing.
+data transfers are synchronous and use their owning Session recording. Ordinary Run and graph
+replay still submit pending commands, but do not add a queue-completion wait at run end.
+`OrtEp::Sync` is not implemented, restoring the earlier WebGPU behavior: I/O Binding's
+`SynchronizeInputs` and `SynchronizeOutputs` use the default no-op Sync and do not guarantee
+GPU completion. Subsequent work on the same queue is ordered by submission; an explicit
+output download waits for CPU-readable results. No ORT stream support is needed for this routing.
 
 AutoEP tests cover CPU I/O, graph-internal CPU/GPU copies, serial and concurrent Session creation,
 execution on other threads after creation, concurrent Sessions with environment copies, and
-Run-external cached-buffer clearing. Graph capture/replay is covered for independent Sessions
-with fixed GPU I/O. Concurrent profiling, graph capture combined with same-Session allocator/Run
+Run-external cached-buffer clearing. Environment copy tests include batched zero-sized and
+non-four-byte-aligned tensors with host-side output bounds checks. Graph capture/replay is
+covered for independent Sessions with fixed GPU I/O. Concurrent profiling, graph capture combined with same-Session allocator/Run
 interleaving, and cross-device transfers remain outside the tested contract.
 Performance must be measured separately.
 

--- a/onnxruntime/core/providers/webgpu/ep/ep.cc
+++ b/onnxruntime/core/providers/webgpu/ep/ep.cc
@@ -9,7 +9,6 @@
 #include "core/framework/kernel_registry.h"
 #include "core/session/onnxruntime_run_options_config_keys.h"
 #include "core/session/plugin_ep/ep_kernel_registration.h"
-#include "core/providers/webgpu/allocator.h"
 #include "core/providers/webgpu/webgpu_execution_provider.h"
 
 #include "ep/get_capability_utils.h"
@@ -38,6 +37,7 @@ Ep::Ep(std::unique_ptr<IExecutionProvider> impl, Factory& factory, const OrtLogg
   OnRunStart = OnRunStartImpl;
   OnRunEnd = OnRunEndImpl;
   CreateAllocator = CreateAllocatorImpl;
+  CreateSyncStreamForDevice = nullptr;          // Not stream aware
   GetCompiledModelCompatibilityInfo = nullptr;  // Not a compiled EP
   IsConcurrentRunSupported = IsConcurrentRunSupportedImpl;
   IsGraphCaptureEnabled = IsGraphCaptureEnabledImpl;

--- a/onnxruntime/core/providers/webgpu/ep/ep.cc
+++ b/onnxruntime/core/providers/webgpu/ep/ep.cc
@@ -9,9 +9,7 @@
 #include "core/framework/kernel_registry.h"
 #include "core/session/onnxruntime_run_options_config_keys.h"
 #include "core/session/plugin_ep/ep_kernel_registration.h"
-#include "core/providers/webgpu/data_transfer.h"
 #include "core/providers/webgpu/allocator.h"
-#include "core/providers/webgpu/webgpu_context.h"
 #include "core/providers/webgpu/webgpu_execution_provider.h"
 
 #include "ep/get_capability_utils.h"
@@ -40,7 +38,6 @@ Ep::Ep(std::unique_ptr<IExecutionProvider> impl, Factory& factory, const OrtLogg
   OnRunStart = OnRunStartImpl;
   OnRunEnd = OnRunEndImpl;
   CreateAllocator = CreateAllocatorImpl;
-  Sync = SyncImpl;
   GetCompiledModelCompatibilityInfo = nullptr;  // Not a compiled EP
   IsConcurrentRunSupported = IsConcurrentRunSupportedImpl;
   IsGraphCaptureEnabled = IsGraphCaptureEnabledImpl;
@@ -252,9 +249,6 @@ OrtStatus* ORT_API_CALL Ep::OnRunEndImpl(_In_ OrtEp* this_ptr,
     return Api().ort.CreateStatus(static_cast<OrtErrorCode>(status.Code()),
                                   status.ErrorMessage().c_str());
   }
-  if (sync_stream) {
-    return SyncImpl(this_ptr);
-  }
   return nullptr;
   EXCEPTION_TO_RETURNED_STATUS_END
 }
@@ -302,14 +296,6 @@ OrtGraphCaptureNodeAssignmentPolicy ORT_API_CALL Ep::GetGraphCaptureNodeAssignme
     _In_ const OrtEp* this_ptr) noexcept {
   auto* ep = static_cast<const Ep*>(this_ptr);
   return ep->EpImpl()->GetGraphCaptureNodeAssignmentPolicy();
-}
-
-OrtStatus* ORT_API_CALL Ep::SyncImpl(OrtEp* this_ptr) noexcept {
-  EXCEPTION_TO_RETURNED_STATUS_BEGIN
-  auto& ep = *static_cast<WebGpuExecutionProvider*>(static_cast<Ep*>(this_ptr)->EpImpl());
-  ORT_THROW_IF_ERROR(FlushAndWait(WebGpuContextFactory::GetContext(ep.GetDeviceId()), ep.BufferManager(), ep.Recording()));
-  return nullptr;
-  EXCEPTION_TO_RETURNED_STATUS_END
 }
 
 OrtStatus* ORT_API_CALL Ep::CreateAllocatorImpl(_In_ OrtEp* this_ptr,

--- a/onnxruntime/core/providers/webgpu/ep/ep.cc
+++ b/onnxruntime/core/providers/webgpu/ep/ep.cc
@@ -9,6 +9,8 @@
 #include "core/framework/kernel_registry.h"
 #include "core/session/onnxruntime_run_options_config_keys.h"
 #include "core/session/plugin_ep/ep_kernel_registration.h"
+#include "core/providers/webgpu/data_transfer.h"
+#include "core/providers/webgpu/allocator.h"
 #include "core/providers/webgpu/webgpu_execution_provider.h"
 
 #include "ep/get_capability_utils.h"
@@ -37,7 +39,7 @@ Ep::Ep(std::unique_ptr<IExecutionProvider> impl, Factory& factory, const OrtLogg
   OnRunStart = OnRunStartImpl;
   OnRunEnd = OnRunEndImpl;
   CreateAllocator = CreateAllocatorImpl;
-  CreateSyncStreamForDevice = nullptr;          // Not stream aware
+  CreateSyncStreamForDevice = CreateSyncStreamForDeviceImpl;
   GetCompiledModelCompatibilityInfo = nullptr;  // Not a compiled EP
   IsConcurrentRunSupported = IsConcurrentRunSupportedImpl;
   IsGraphCaptureEnabled = IsGraphCaptureEnabledImpl;
@@ -298,6 +300,18 @@ OrtGraphCaptureNodeAssignmentPolicy ORT_API_CALL Ep::GetGraphCaptureNodeAssignme
   return ep->EpImpl()->GetGraphCaptureNodeAssignmentPolicy();
 }
 
+OrtStatus* ORT_API_CALL Ep::CreateSyncStreamForDeviceImpl(
+    OrtEp* this_ptr, const OrtMemoryDevice* memory_device, OrtSyncStreamImpl** stream) noexcept {
+  EXCEPTION_TO_RETURNED_STATUS_BEGIN
+  auto& ep = *static_cast<WebGpuExecutionProvider*>(static_cast<Ep*>(this_ptr)->EpImpl());
+  ORT_ENFORCE(Api().ep.MemoryDevice_GetDeviceType(memory_device) == OrtMemoryInfoDeviceType_GPU &&
+            static_cast<int64_t>(Api().ep.MemoryDevice_GetDeviceId(memory_device)) == ep.GetDeviceId(),
+              "Unsupported memory device for WebGPU Session stream.");
+  *stream = CreateWebGpuSyncStream(ep);
+  return nullptr;
+  EXCEPTION_TO_RETURNED_STATUS_END
+}
+
 OrtStatus* ORT_API_CALL Ep::CreateAllocatorImpl(_In_ OrtEp* this_ptr,
                                                 _In_ const OrtMemoryInfo* memory_info,
                                                 _Outptr_result_maybenull_ OrtAllocator** allocator) noexcept {
@@ -305,9 +319,9 @@ OrtStatus* ORT_API_CALL Ep::CreateAllocatorImpl(_In_ OrtEp* this_ptr,
   auto* ep = static_cast<Ep*>(this_ptr);
   Ort::ConstMemoryInfo ort_memory_info{memory_info};
   if (ort_memory_info.GetAllocatorType() == OrtReadOnlyAllocator) {
-    *allocator = new onnxruntime::ep::adapter::Allocator(memory_info, ep->config_.initializer_allocator);
+    *allocator = CreateWebGpuSessionAllocator(ep->config_.initializer_allocator);
   } else {
-    *allocator = new onnxruntime::ep::adapter::Allocator(memory_info, ep->config_.device_allocator);
+    *allocator = CreateWebGpuSessionAllocator(ep->config_.device_allocator);
   }
   return nullptr;
   EXCEPTION_TO_RETURNED_STATUS_END

--- a/onnxruntime/core/providers/webgpu/ep/ep.cc
+++ b/onnxruntime/core/providers/webgpu/ep/ep.cc
@@ -11,6 +11,7 @@
 #include "core/session/plugin_ep/ep_kernel_registration.h"
 #include "core/providers/webgpu/data_transfer.h"
 #include "core/providers/webgpu/allocator.h"
+#include "core/providers/webgpu/webgpu_context.h"
 #include "core/providers/webgpu/webgpu_execution_provider.h"
 
 #include "ep/get_capability_utils.h"
@@ -39,7 +40,7 @@ Ep::Ep(std::unique_ptr<IExecutionProvider> impl, Factory& factory, const OrtLogg
   OnRunStart = OnRunStartImpl;
   OnRunEnd = OnRunEndImpl;
   CreateAllocator = CreateAllocatorImpl;
-  CreateSyncStreamForDevice = CreateSyncStreamForDeviceImpl;
+  Sync = SyncImpl;
   GetCompiledModelCompatibilityInfo = nullptr;  // Not a compiled EP
   IsConcurrentRunSupported = IsConcurrentRunSupportedImpl;
   IsGraphCaptureEnabled = IsGraphCaptureEnabledImpl;
@@ -251,6 +252,9 @@ OrtStatus* ORT_API_CALL Ep::OnRunEndImpl(_In_ OrtEp* this_ptr,
     return Api().ort.CreateStatus(static_cast<OrtErrorCode>(status.Code()),
                                   status.ErrorMessage().c_str());
   }
+  if (sync_stream) {
+    return SyncImpl(this_ptr);
+  }
   return nullptr;
   EXCEPTION_TO_RETURNED_STATUS_END
 }
@@ -300,14 +304,10 @@ OrtGraphCaptureNodeAssignmentPolicy ORT_API_CALL Ep::GetGraphCaptureNodeAssignme
   return ep->EpImpl()->GetGraphCaptureNodeAssignmentPolicy();
 }
 
-OrtStatus* ORT_API_CALL Ep::CreateSyncStreamForDeviceImpl(
-    OrtEp* this_ptr, const OrtMemoryDevice* memory_device, OrtSyncStreamImpl** stream) noexcept {
+OrtStatus* ORT_API_CALL Ep::SyncImpl(OrtEp* this_ptr) noexcept {
   EXCEPTION_TO_RETURNED_STATUS_BEGIN
   auto& ep = *static_cast<WebGpuExecutionProvider*>(static_cast<Ep*>(this_ptr)->EpImpl());
-  ORT_ENFORCE(Api().ep.MemoryDevice_GetDeviceType(memory_device) == OrtMemoryInfoDeviceType_GPU &&
-            static_cast<int64_t>(Api().ep.MemoryDevice_GetDeviceId(memory_device)) == ep.GetDeviceId(),
-              "Unsupported memory device for WebGPU Session stream.");
-  *stream = CreateWebGpuSyncStream(ep);
+  ORT_THROW_IF_ERROR(FlushAndWait(WebGpuContextFactory::GetContext(ep.GetDeviceId()), ep.BufferManager(), ep.Recording()));
   return nullptr;
   EXCEPTION_TO_RETURNED_STATUS_END
 }
@@ -319,9 +319,9 @@ OrtStatus* ORT_API_CALL Ep::CreateAllocatorImpl(_In_ OrtEp* this_ptr,
   auto* ep = static_cast<Ep*>(this_ptr);
   Ort::ConstMemoryInfo ort_memory_info{memory_info};
   if (ort_memory_info.GetAllocatorType() == OrtReadOnlyAllocator) {
-    *allocator = CreateWebGpuSessionAllocator(ep->config_.initializer_allocator);
+    *allocator = new onnxruntime::ep::adapter::Allocator(memory_info, ep->config_.initializer_allocator);
   } else {
-    *allocator = CreateWebGpuSessionAllocator(ep->config_.device_allocator);
+    *allocator = new onnxruntime::ep::adapter::Allocator(memory_info, ep->config_.device_allocator);
   }
   return nullptr;
   EXCEPTION_TO_RETURNED_STATUS_END

--- a/onnxruntime/core/providers/webgpu/ep/ep.h
+++ b/onnxruntime/core/providers/webgpu/ep/ep.h
@@ -48,8 +48,6 @@ class Ep : public onnxruntime::ep::adapter::Ep {
                                                      _In_ const OrtMemoryInfo* memory_info,
                                                      _Outptr_result_maybenull_ OrtAllocator** allocator) noexcept;
 
-  static OrtStatus* ORT_API_CALL SyncImpl(OrtEp* this_ptr) noexcept;
-
   static OrtStatus* ORT_API_CALL GetPreferredDataLayoutImpl(_In_ OrtEp* this_ptr,
                                                             _Out_ OrtEpDataLayout* preferred_data_layout) noexcept;
 

--- a/onnxruntime/core/providers/webgpu/ep/ep.h
+++ b/onnxruntime/core/providers/webgpu/ep/ep.h
@@ -48,6 +48,9 @@ class Ep : public onnxruntime::ep::adapter::Ep {
                                                      _In_ const OrtMemoryInfo* memory_info,
                                                      _Outptr_result_maybenull_ OrtAllocator** allocator) noexcept;
 
+  static OrtStatus* ORT_API_CALL CreateSyncStreamForDeviceImpl(
+      OrtEp* this_ptr, const OrtMemoryDevice* memory_device, OrtSyncStreamImpl** stream) noexcept;
+
   static OrtStatus* ORT_API_CALL GetPreferredDataLayoutImpl(_In_ OrtEp* this_ptr,
                                                             _Out_ OrtEpDataLayout* preferred_data_layout) noexcept;
 

--- a/onnxruntime/core/providers/webgpu/ep/ep.h
+++ b/onnxruntime/core/providers/webgpu/ep/ep.h
@@ -48,8 +48,7 @@ class Ep : public onnxruntime::ep::adapter::Ep {
                                                      _In_ const OrtMemoryInfo* memory_info,
                                                      _Outptr_result_maybenull_ OrtAllocator** allocator) noexcept;
 
-  static OrtStatus* ORT_API_CALL CreateSyncStreamForDeviceImpl(
-      OrtEp* this_ptr, const OrtMemoryDevice* memory_device, OrtSyncStreamImpl** stream) noexcept;
+  static OrtStatus* ORT_API_CALL SyncImpl(OrtEp* this_ptr) noexcept;
 
   static OrtStatus* ORT_API_CALL GetPreferredDataLayoutImpl(_In_ OrtEp* this_ptr,
                                                             _Out_ OrtEpDataLayout* preferred_data_layout) noexcept;

--- a/onnxruntime/core/providers/webgpu/ep/factory.cc
+++ b/onnxruntime/core/providers/webgpu/ep/factory.cc
@@ -212,7 +212,9 @@ OrtStatus* ORT_API_CALL Factory::CreateEpImpl(
   const bool device_free = !WebGpuContextFactory::GetContext(context_id).HasDevice();
   auto device_alloc = webgpu::CreateWebGpuAllocator(
       device_free,
-      [webgpu_ep_ptr]() -> const webgpu::BufferManager& { return webgpu_ep_ptr->BufferManager(); }, false,
+      [webgpu_ep_ptr]() -> const webgpu::BufferManager& { return webgpu_ep_ptr->BufferManager(); },
+      [webgpu_ep_ptr]() -> webgpu::CommandRecordingState& { return webgpu_ep_ptr->Recording(); },
+      false,
       [webgpu_ep_ptr]() { return !webgpu_ep_ptr->IsRunActive(); });
   Ep::Config webgpu_ep_config{
       CPUAllocator::DefaultInstance(),  // CPU allocator
@@ -222,6 +224,7 @@ OrtStatus* ORT_API_CALL Factory::CreateEpImpl(
           [webgpu_ep_ptr]() -> const webgpu::BufferManager& {
             return webgpu_ep_ptr->InitializerBufferManager();
           },
+          [webgpu_ep_ptr]() -> webgpu::CommandRecordingState& { return webgpu_ep_ptr->Recording(); },
           true),  // initializer device allocator
   };
   *ep = new Ep(std::move(webgpu_ep), *factory, *logger, webgpu_ep_config);
@@ -248,16 +251,14 @@ OrtStatus* ORT_API_CALL Factory::CreateAllocatorImpl(
                                   "Unsupported memory info for shared allocator.");
   }
 
-  *allocator = new onnxruntime::ep::adapter::Allocator(memory_info,
-                                                       [](const OrtMemoryInfo&) -> AllocatorPtr {
-                                                         return std::make_shared<webgpu::GpuBufferAllocator>(
-                                                             []() -> const webgpu::BufferManager& {
-                                                               return WebGpuContextFactory::DefaultContext()
-                                                                   .BufferManager();
-                                                             },
-                                                             false,
-                                                             []() { return true; });
-                                                       });
+  *allocator = new onnxruntime::ep::adapter::Allocator(
+      memory_info,
+      [](const OrtMemoryInfo&) -> AllocatorPtr {
+        auto context = std::shared_ptr<WebGpuContext>(
+            &WebGpuContextFactory::DefaultContext(),
+            [](WebGpuContext*) { WebGpuContextFactory::ReleaseContext(0); });
+        return std::make_shared<webgpu::ExternalGpuBufferAllocator>(std::move(context));
+      });
   return nullptr;
   EXCEPTION_TO_RETURNED_STATUS_END
 }

--- a/onnxruntime/core/providers/webgpu/ep/factory.cc
+++ b/onnxruntime/core/providers/webgpu/ep/factory.cc
@@ -219,8 +219,8 @@ OrtStatus* ORT_API_CALL Factory::CreateEpImpl(
       device_alloc,                     // default device allocator
       webgpu::CreateWebGpuAllocator(
           device_free,
-          [context_id]() -> const webgpu::BufferManager& {
-            return WebGpuContextFactory::GetContext(context_id).InitializerBufferManager();
+          [webgpu_ep_ptr]() -> const webgpu::BufferManager& {
+            return webgpu_ep_ptr->InitializerBufferManager();
           },
           true),  // initializer device allocator
   };

--- a/onnxruntime/core/providers/webgpu/ep/factory.cc
+++ b/onnxruntime/core/providers/webgpu/ep/factory.cc
@@ -134,16 +134,18 @@ OrtStatus* ORT_API_CALL Factory::CreateEpImpl(
   auto webgpu_ep = webgpu_ep_factory->CreateProvider(*session_options, *logger);
   static_cast<WebGpuExecutionProvider*>(webgpu_ep.get())->SetEpLogger(logger);
   auto factory = static_cast<Factory*>(this_ptr);
-  const int context_id = webgpu_ep->GetDeviceId();
   auto* webgpu_ep_ptr = static_cast<WebGpuExecutionProvider*>(webgpu_ep.get());
+  // Both allocators go through this EP's own buffer managers. Command recording state is owned
+  // per session, so routing them to the shared context here would let this session's uploads
+  // race with another session's inference.
   auto device_alloc = std::make_shared<webgpu::GpuBufferAllocator>(
       [webgpu_ep_ptr]() -> const webgpu::BufferManager& { return webgpu_ep_ptr->BufferManager(); }, false);
   Ep::Config webgpu_ep_config{
       CPUAllocator::DefaultInstance(),  // CPU allocator
       device_alloc,                     // default device allocator
       std::make_shared<webgpu::GpuBufferAllocator>(
-          [context_id]() -> const webgpu::BufferManager& {
-            return WebGpuContextFactory::GetContext(context_id).InitializerBufferManager();
+          [webgpu_ep_ptr]() -> const webgpu::BufferManager& {
+            return webgpu_ep_ptr->InitializerBufferManager();
           },
           true),  // initializer device allocator
   };

--- a/onnxruntime/core/providers/webgpu/ep/factory.cc
+++ b/onnxruntime/core/providers/webgpu/ep/factory.cc
@@ -218,12 +218,14 @@ OrtStatus* ORT_API_CALL Factory::CreateEpImpl(
   // A device-free context (compile-only session) gets a no-op allocator: a real GpuBufferAllocator
   // needs a device, and such a session stops before finalization and never allocates.
   const bool device_free = !WebGpuContextFactory::GetContext(context_id).HasDevice();
+  // External Session allocations must not overlap Run. Submit clears outside Run so subsequent
+  // Env copies see initialized buffers; defer clears during Run to preserve command batching.
   auto device_alloc = webgpu::CreateWebGpuAllocator(
       device_free,
       [webgpu_ep_ptr]() -> const webgpu::BufferManager& { return webgpu_ep_ptr->BufferManager(); },
       [webgpu_ep_ptr]() -> webgpu::CommandRecordingState& { return webgpu_ep_ptr->Recording(); },
       false,
-        []() { return true; });
+      /*should_submit_zero_initialize=*/[webgpu_ep_ptr]() { return !webgpu_ep_ptr->IsRunActive(); });
   Ep::Config webgpu_ep_config{
       CPUAllocator::DefaultInstance(),  // CPU allocator
       device_alloc,                     // default device allocator
@@ -274,6 +276,8 @@ OrtStatus* ORT_API_CALL Factory::CreateAllocatorImpl(
                                   "Unsupported memory info for shared allocator.");
   }
 
+  // Env allocations can run alongside Session execution. Direct buffer allocation avoids
+  // accessing Session command recording or cached-buffer clear state.
   *allocator = new onnxruntime::ep::adapter::Allocator(
       memory_info,
       [](const OrtMemoryInfo&) -> AllocatorPtr {
@@ -297,10 +301,14 @@ OrtStatus* ORT_API_CALL Factory::CreateDataTransferImpl(
   EXCEPTION_TO_RETURNED_STATUS_BEGIN
   auto* factory = static_cast<Factory*>(this_ptr);
   std::lock_guard<std::mutex> lock{factory->creation_mutex_};
+  // ORT currently creates the Env transfer first for each factory. This ordering is not an
+  // EP API guarantee; the Env transfer uses local encoders and is not bound to a Session.
   if (!factory->env_transfer_created_) {
     *data_transfer = OrtWebGpuCreateDataTransfer();
     factory->env_transfer_created_ = true;
   } else {
+    // Session creation calls both callbacks on the same thread. Bind once to the owning EP;
+    // subsequent copies use its recording regardless of which thread runs the Session.
     auto pending_ep = factory->pending_eps_.find(std::this_thread::get_id());
     ORT_ENFORCE(pending_ep != factory->pending_eps_.end(),
                 "Create the WebGPU Session data transfer on the same thread that created its EP.");
@@ -313,7 +321,19 @@ OrtStatus* ORT_API_CALL Factory::CreateDataTransferImpl(
 }
 
 bool ORT_API_CALL Factory::IsStreamAwareImpl(const OrtEpFactory* /*this_ptr*/) noexcept {
-  return false;
+  return false;  // Default: not stream aware
+}
+
+OrtStatus* ORT_API_CALL Factory::CreateSyncStreamForDeviceImpl(
+    OrtEpFactory* /*this_ptr*/,
+    const OrtMemoryDevice* /*memory_device*/,
+    const OrtKeyValuePairs* /*stream_options*/,
+    OrtSyncStreamImpl** stream) noexcept {
+  EXCEPTION_TO_RETURNED_STATUS_BEGIN
+  *stream = nullptr;
+  return Api().ort.CreateStatus(ORT_NOT_IMPLEMENTED,
+                                "CreateSyncStreamForDevice is not implemented for this EP factory.");
+  EXCEPTION_TO_RETURNED_STATUS_END
 }
 
 }  // namespace ep

--- a/onnxruntime/core/providers/webgpu/ep/factory.cc
+++ b/onnxruntime/core/providers/webgpu/ep/factory.cc
@@ -276,15 +276,15 @@ OrtStatus* ORT_API_CALL Factory::CreateAllocatorImpl(
                                   "Unsupported memory info for shared allocator.");
   }
 
-  // Env allocations can run alongside Session execution. Direct buffer allocation avoids
-  // accessing Session command recording or cached-buffer clear state.
+  // Reuse the cached allocator with independent recording and immediate clear submission.
+  // The Env allocator retains the device context but does not access any Session's recording.
   *allocator = new onnxruntime::ep::adapter::Allocator(
       memory_info,
       [](const OrtMemoryInfo&) -> AllocatorPtr {
         auto context = std::shared_ptr<WebGpuContext>(
             &WebGpuContextFactory::DefaultContext(),
             [](WebGpuContext*) { WebGpuContextFactory::ReleaseContext(0); });
-        return std::make_shared<webgpu::ExternalGpuBufferAllocator>(std::move(context));
+        return webgpu::CreateSharedWebGpuAllocator(std::move(context));
       });
   return nullptr;
   EXCEPTION_TO_RETURNED_STATUS_END
@@ -302,7 +302,7 @@ OrtStatus* ORT_API_CALL Factory::CreateDataTransferImpl(
   auto* factory = static_cast<Factory*>(this_ptr);
   std::lock_guard<std::mutex> lock{factory->creation_mutex_};
   // ORT currently creates the Env transfer first for each factory. This ordering is not an
-  // EP API guarantee; the Env transfer uses local encoders and is not bound to a Session.
+  // EP API guarantee; the Env transfer uses local recording and is not bound to a Session.
   if (!factory->env_transfer_created_) {
     *data_transfer = OrtWebGpuCreateDataTransfer();
     factory->env_transfer_created_ = true;

--- a/onnxruntime/core/providers/webgpu/ep/factory.cc
+++ b/onnxruntime/core/providers/webgpu/ep/factory.cc
@@ -166,6 +166,14 @@ OrtStatus* ORT_API_CALL Factory::CreateEpImpl(
     const OrtLogger* logger,
     OrtEp** ep) noexcept {
   EXCEPTION_TO_RETURNED_STATUS_BEGIN
+  auto* factory = static_cast<Factory*>(this_ptr);
+  const auto thread_id = std::this_thread::get_id();
+  {
+    std::lock_guard<std::mutex> lock{factory->creation_mutex_};
+    ORT_ENFORCE(factory->env_transfer_created_, "Create the WebGPU environment data transfer before creating Sessions.");
+    ORT_ENFORCE(!factory->pending_eps_.contains(thread_id),
+                "A WebGPU EP on this thread is still awaiting its Session data transfer.");
+  }
   if (num_devices != 1) {
     return Api().ort.CreateStatus(ORT_INVALID_ARGUMENT,
                                   "WebGPU EP factory currently only supports one device at a time.");
@@ -205,7 +213,6 @@ OrtStatus* ORT_API_CALL Factory::CreateEpImpl(
   auto webgpu_ep_factory = WebGpuProviderFactoryCreator::Create(config_options);
   auto webgpu_ep = webgpu_ep_factory->CreateProvider(*session_options, *logger);
   static_cast<WebGpuExecutionProvider*>(webgpu_ep.get())->SetEpLogger(logger);
-  auto factory = static_cast<Factory*>(this_ptr);
   const int context_id = webgpu_ep->GetDeviceId();
   auto* webgpu_ep_ptr = static_cast<WebGpuExecutionProvider*>(webgpu_ep.get());
   // A device-free context (compile-only session) gets a no-op allocator: a real GpuBufferAllocator
@@ -216,7 +223,7 @@ OrtStatus* ORT_API_CALL Factory::CreateEpImpl(
       [webgpu_ep_ptr]() -> const webgpu::BufferManager& { return webgpu_ep_ptr->BufferManager(); },
       [webgpu_ep_ptr]() -> webgpu::CommandRecordingState& { return webgpu_ep_ptr->Recording(); },
       false,
-      []() { return true; });
+        []() { return true; });
   Ep::Config webgpu_ep_config{
       CPUAllocator::DefaultInstance(),  // CPU allocator
       device_alloc,                     // default device allocator
@@ -228,12 +235,27 @@ OrtStatus* ORT_API_CALL Factory::CreateEpImpl(
           [webgpu_ep_ptr]() -> webgpu::CommandRecordingState& { return webgpu_ep_ptr->Recording(); },
           true),  // initializer device allocator
   };
-  *ep = new Ep(std::move(webgpu_ep), *factory, *logger, webgpu_ep_config);
+  auto created_ep = std::make_unique<Ep>(std::move(webgpu_ep), *factory, *logger, webgpu_ep_config);
+  {
+    std::lock_guard<std::mutex> lock{factory->creation_mutex_};
+    ORT_ENFORCE(factory->pending_eps_.try_emplace(thread_id, created_ep.get()).second,
+                "A WebGPU EP on this thread is still awaiting its Session data transfer.");
+  }
+  *ep = created_ep.release();
   return nullptr;
   EXCEPTION_TO_RETURNED_STATUS_END
 }
 
-void ORT_API_CALL Factory::ReleaseEpImpl(OrtEpFactory* /*this_ptr*/, OrtEp* ep) noexcept {
+void ORT_API_CALL Factory::ReleaseEpImpl(OrtEpFactory* this_ptr, OrtEp* ep) noexcept {
+  auto* factory = static_cast<Factory*>(this_ptr);
+  {
+    std::lock_guard<std::mutex> lock{factory->creation_mutex_};
+    auto pending_ep = std::find_if(factory->pending_eps_.begin(), factory->pending_eps_.end(),
+                                   [ep](const auto& entry) { return entry.second == ep; });
+    if (pending_ep != factory->pending_eps_.end()) {
+      factory->pending_eps_.erase(pending_ep);
+    }
+  }
   delete static_cast<Ep*>(ep);
 }
 
@@ -265,36 +287,33 @@ OrtStatus* ORT_API_CALL Factory::CreateAllocatorImpl(
 }
 
 void ORT_API_CALL Factory::ReleaseAllocatorImpl(OrtEpFactory* /*this_ptr*/, OrtAllocator* allocator) noexcept {
-  if (TryReleaseWebGpuSessionAllocator(allocator)) {
-    return;
-  }
   onnxruntime::ep::adapter::Allocator* ptr = static_cast<onnxruntime::ep::adapter::Allocator*>(allocator);
   delete ptr;
 }
 
 OrtStatus* ORT_API_CALL Factory::CreateDataTransferImpl(
-    OrtEpFactory* /*this_ptr*/,
+    OrtEpFactory* this_ptr,
     OrtDataTransferImpl** data_transfer) noexcept {
   EXCEPTION_TO_RETURNED_STATUS_BEGIN
-  *data_transfer = OrtWebGpuCreateDataTransfer();  // TODO(fs-eire): pass context id if needed
+  auto* factory = static_cast<Factory*>(this_ptr);
+  std::lock_guard<std::mutex> lock{factory->creation_mutex_};
+  if (!factory->env_transfer_created_) {
+    *data_transfer = OrtWebGpuCreateDataTransfer();
+    factory->env_transfer_created_ = true;
+  } else {
+    auto pending_ep = factory->pending_eps_.find(std::this_thread::get_id());
+    ORT_ENFORCE(pending_ep != factory->pending_eps_.end(),
+                "Create the WebGPU Session data transfer on the same thread that created its EP.");
+    auto* ep = static_cast<WebGpuExecutionProvider*>(pending_ep->second->EpImpl());
+    *data_transfer = OrtWebGpuCreateDataTransfer(ep->GetDeviceId(), ep);
+    factory->pending_eps_.erase(pending_ep);
+  }
   return nullptr;
   EXCEPTION_TO_RETURNED_STATUS_END
 }
 
 bool ORT_API_CALL Factory::IsStreamAwareImpl(const OrtEpFactory* /*this_ptr*/) noexcept {
-  return true;
-}
-
-OrtStatus* ORT_API_CALL Factory::CreateSyncStreamForDeviceImpl(
-    OrtEpFactory* /*this_ptr*/,
-    const OrtMemoryDevice* /*memory_device*/,
-    const OrtKeyValuePairs* /*stream_options*/,
-    OrtSyncStreamImpl** stream) noexcept {
-  EXCEPTION_TO_RETURNED_STATUS_BEGIN
-  *stream = nullptr;
-  return Api().ort.CreateStatus(ORT_NOT_IMPLEMENTED,
-                                "CreateSyncStreamForDevice is not implemented for this EP factory.");
-  EXCEPTION_TO_RETURNED_STATUS_END
+  return false;
 }
 
 }  // namespace ep

--- a/onnxruntime/core/providers/webgpu/ep/factory.cc
+++ b/onnxruntime/core/providers/webgpu/ep/factory.cc
@@ -15,6 +15,7 @@
 #include "core/providers/webgpu/webgpu_execution_provider.h"
 #include "core/providers/webgpu/webgpu_context.h"
 #include "core/providers/webgpu/allocator.h"
+#include "core/providers/webgpu/data_transfer.h"
 #include "core/session/onnxruntime_ep_device_ep_metadata_keys.h"
 #include "core/session/onnxruntime_session_options_config_keys.h"
 
@@ -215,7 +216,7 @@ OrtStatus* ORT_API_CALL Factory::CreateEpImpl(
       [webgpu_ep_ptr]() -> const webgpu::BufferManager& { return webgpu_ep_ptr->BufferManager(); },
       [webgpu_ep_ptr]() -> webgpu::CommandRecordingState& { return webgpu_ep_ptr->Recording(); },
       false,
-      [webgpu_ep_ptr]() { return !webgpu_ep_ptr->IsRunActive(); });
+      []() { return true; });
   Ep::Config webgpu_ep_config{
       CPUAllocator::DefaultInstance(),  // CPU allocator
       device_alloc,                     // default device allocator
@@ -264,6 +265,9 @@ OrtStatus* ORT_API_CALL Factory::CreateAllocatorImpl(
 }
 
 void ORT_API_CALL Factory::ReleaseAllocatorImpl(OrtEpFactory* /*this_ptr*/, OrtAllocator* allocator) noexcept {
+  if (TryReleaseWebGpuSessionAllocator(allocator)) {
+    return;
+  }
   onnxruntime::ep::adapter::Allocator* ptr = static_cast<onnxruntime::ep::adapter::Allocator*>(allocator);
   delete ptr;
 }
@@ -278,7 +282,7 @@ OrtStatus* ORT_API_CALL Factory::CreateDataTransferImpl(
 }
 
 bool ORT_API_CALL Factory::IsStreamAwareImpl(const OrtEpFactory* /*this_ptr*/) noexcept {
-  return false;  // Default: not stream aware
+  return true;
 }
 
 OrtStatus* ORT_API_CALL Factory::CreateSyncStreamForDeviceImpl(

--- a/onnxruntime/core/providers/webgpu/ep/factory.cc
+++ b/onnxruntime/core/providers/webgpu/ep/factory.cc
@@ -217,14 +217,12 @@ OrtStatus* ORT_API_CALL Factory::CreateEpImpl(
   // A device-free context (compile-only session) gets a no-op allocator: a real GpuBufferAllocator
   // needs a device, and such a session stops before finalization and never allocates.
   const bool device_free = !WebGpuContextFactory::GetContext(context_id).HasDevice();
-  // External Session allocations must not overlap Run. Submit clears outside Run so subsequent
-  // Env copies see initialized buffers; defer clears during Run to preserve command batching.
   auto device_alloc = webgpu::CreateWebGpuAllocator(
       device_free,
       [webgpu_ep_ptr]() -> const webgpu::BufferManager& { return webgpu_ep_ptr->BufferManager(); },
       [webgpu_ep_ptr]() -> webgpu::CommandRecordingState& { return webgpu_ep_ptr->Recording(); },
       false,
-      /*should_submit_zero_initialize=*/[webgpu_ep_ptr]() { return !webgpu_ep_ptr->IsRunActive(); });
+      [webgpu_ep_ptr]() { return !webgpu_ep_ptr->IsRunActive(); });
   Ep::Config webgpu_ep_config{
       CPUAllocator::DefaultInstance(),  // CPU allocator
       device_alloc,                     // default device allocator
@@ -301,7 +299,7 @@ OrtStatus* ORT_API_CALL Factory::CreateDataTransferImpl(
   auto* factory = static_cast<Factory*>(this_ptr);
   std::lock_guard<std::mutex> lock{factory->creation_mutex_};
   // ORT currently creates the Env transfer first for each factory. This ordering is not an
-  // EP API guarantee; the Env transfer uses local recording and is not bound to a Session.
+  // EP API guarantee; the Env transfer uses the context's Env recording and is not bound to a Session.
   if (!factory->env_transfer_created_) {
     *data_transfer = OrtWebGpuCreateDataTransfer();
     factory->env_transfer_created_ = true;

--- a/onnxruntime/core/providers/webgpu/ep/factory.cc
+++ b/onnxruntime/core/providers/webgpu/ep/factory.cc
@@ -15,7 +15,6 @@
 #include "core/providers/webgpu/webgpu_execution_provider.h"
 #include "core/providers/webgpu/webgpu_context.h"
 #include "core/providers/webgpu/allocator.h"
-#include "core/providers/webgpu/data_transfer.h"
 #include "core/session/onnxruntime_ep_device_ep_metadata_keys.h"
 #include "core/session/onnxruntime_session_options_config_keys.h"
 
@@ -231,8 +230,8 @@ OrtStatus* ORT_API_CALL Factory::CreateEpImpl(
       device_alloc,                     // default device allocator
       webgpu::CreateWebGpuAllocator(
           device_free,
-          [webgpu_ep_ptr]() -> const webgpu::BufferManager& {
-            return webgpu_ep_ptr->InitializerBufferManager();
+          [context_id]() -> const webgpu::BufferManager& {
+            return WebGpuContextFactory::GetContext(context_id).InitializerBufferManager();
           },
           [webgpu_ep_ptr]() -> webgpu::CommandRecordingState& { return webgpu_ep_ptr->Recording(); },
           true),  // initializer device allocator

--- a/onnxruntime/core/providers/webgpu/ep/factory.h
+++ b/onnxruntime/core/providers/webgpu/ep/factory.h
@@ -4,9 +4,12 @@
 #pragma once
 
 #include <memory>
+#include <mutex>
 #include <string>
+#include <thread>
 #include <type_traits>
 
+#include "core/common/inlined_containers.h"
 #include "ep.h"
 
 namespace onnxruntime {
@@ -71,13 +74,10 @@ class Factory : public OrtEpFactory {
 
   static bool ORT_API_CALL IsStreamAwareImpl(const OrtEpFactory* this_ptr) noexcept;
 
-  static OrtStatus* ORT_API_CALL CreateSyncStreamForDeviceImpl(
-      OrtEpFactory* this_ptr,
-      const OrtMemoryDevice* memory_device,
-      const OrtKeyValuePairs* stream_options,
-      OrtSyncStreamImpl** stream) noexcept;
-
   const Config config_;
+  std::mutex creation_mutex_;
+  bool env_transfer_created_ = false;
+  InlinedHashMap<std::thread::id, Ep*> pending_eps_;
 
   Ort::MemoryInfo default_memory_info_;
   Ort::MemoryInfo readonly_memory_info_;  // used for initializers

--- a/onnxruntime/core/providers/webgpu/ep/factory.h
+++ b/onnxruntime/core/providers/webgpu/ep/factory.h
@@ -74,6 +74,12 @@ class Factory : public OrtEpFactory {
 
   static bool ORT_API_CALL IsStreamAwareImpl(const OrtEpFactory* this_ptr) noexcept;
 
+    static OrtStatus* ORT_API_CALL CreateSyncStreamForDeviceImpl(
+            OrtEpFactory* this_ptr,
+            const OrtMemoryDevice* memory_device,
+            const OrtKeyValuePairs* stream_options,
+            OrtSyncStreamImpl** stream) noexcept;
+
   const Config config_;
   std::mutex creation_mutex_;
   bool env_transfer_created_ = false;

--- a/onnxruntime/core/providers/webgpu/ep/factory.h
+++ b/onnxruntime/core/providers/webgpu/ep/factory.h
@@ -74,11 +74,11 @@ class Factory : public OrtEpFactory {
 
   static bool ORT_API_CALL IsStreamAwareImpl(const OrtEpFactory* this_ptr) noexcept;
 
-    static OrtStatus* ORT_API_CALL CreateSyncStreamForDeviceImpl(
-            OrtEpFactory* this_ptr,
-            const OrtMemoryDevice* memory_device,
-            const OrtKeyValuePairs* stream_options,
-            OrtSyncStreamImpl** stream) noexcept;
+  static OrtStatus* ORT_API_CALL CreateSyncStreamForDeviceImpl(
+      OrtEpFactory* this_ptr,
+      const OrtMemoryDevice* memory_device,
+      const OrtKeyValuePairs* stream_options,
+      OrtSyncStreamImpl** stream) noexcept;
 
   const Config config_;
   std::mutex creation_mutex_;

--- a/onnxruntime/core/providers/webgpu/program_manager.cc
+++ b/onnxruntime/core/providers/webgpu/program_manager.cc
@@ -302,6 +302,7 @@ Status ProgramManager::Build(const ProgramBase& program,
 }
 
 const ProgramArtifact* ProgramManager::Get(const std::string& key) const {
+  std::lock_guard<std::mutex> lock(programs_mutex_);
   auto result = programs_.find(key);
   if (result != programs_.end()) {
     return &result->second;
@@ -311,6 +312,7 @@ const ProgramArtifact* ProgramManager::Get(const std::string& key) const {
 }
 
 const ProgramArtifact* ProgramManager::Set(const std::string& key, ProgramArtifact&& program) {
+  std::lock_guard<std::mutex> lock(programs_mutex_);
   return &(programs_.emplace(key, std::move(program)).first->second);
 }
 

--- a/onnxruntime/core/providers/webgpu/program_manager.cc
+++ b/onnxruntime/core/providers/webgpu/program_manager.cc
@@ -240,6 +240,7 @@ Status ProgramManager::Build(const ProgramBase& program,
 }
 
 const ProgramArtifact* ProgramManager::Get(const std::string& key) const {
+  std::lock_guard<std::mutex> lock(programs_mutex_);
   auto result = programs_.find(key);
   if (result != programs_.end()) {
     return &result->second;
@@ -249,6 +250,7 @@ const ProgramArtifact* ProgramManager::Get(const std::string& key) const {
 }
 
 const ProgramArtifact* ProgramManager::Set(const std::string& key, ProgramArtifact&& program) {
+  std::lock_guard<std::mutex> lock(programs_mutex_);
   return &(programs_.emplace(key, std::move(program)).first->second);
 }
 

--- a/onnxruntime/core/providers/webgpu/program_manager.h
+++ b/onnxruntime/core/providers/webgpu/program_manager.h
@@ -5,6 +5,7 @@
 
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <span>
 #include <string>
 #include <string_view>
@@ -72,6 +73,14 @@ class ProgramManager {
                std::vector<int>& shape_uniform_ranks,
                wgpu::Future& future,
                PipelineCallbackContext& callback_context) const;
+  // Pipeline cache lookup / insert. These are the only members shared across sessions, so both
+  // are serialized. Build() is deliberately not: callers invoke it between Get() and Set(), which
+  // keeps shader compilation - by far the expensive part - outside the lock. Two sessions racing
+  // on the same key therefore compile it twice; Set() keeps the first artifact and the loser is
+  // discarded, so the only cost is the duplicated compile.
+  //
+  // The pointer stays valid after the lock is released: this map is insert-only and
+  // std::unordered_map keeps element references stable across rehash.
   const ProgramArtifact* Get(const std::string& key) const;
   const ProgramArtifact* Set(const std::string& key, ProgramArtifact&& program);
 
@@ -82,6 +91,7 @@ class ProgramManager {
                                             std::span<const int> shape_uniform_ranks,
                                             wgpu::BindGroupLayout& bind_group_layout) const;
 
+  mutable std::mutex programs_mutex_;
   std::unordered_map<std::string, ProgramArtifact> programs_;
   WebGpuContext& webgpu_context_;
 

--- a/onnxruntime/core/providers/webgpu/program_manager.h
+++ b/onnxruntime/core/providers/webgpu/program_manager.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <functional>
+#include <mutex>
 #include <span>
 #include <string>
 #include <string_view>
@@ -53,10 +54,19 @@ class ProgramManager {
                uint32_t normalized_dispatch_z,
                wgpu::ComputePipeline& compute_pipeline,
                std::vector<int>& shape_uniform_ranks) const;
+  // Pipeline cache lookup / insert. These are the only members shared across sessions, so both
+  // are serialized. Build() is deliberately not: callers invoke it between Get() and Set(), which
+  // keeps shader compilation - by far the expensive part - outside the lock. Two sessions racing
+  // on the same key therefore compile it twice; Set() keeps the first artifact and the loser is
+  // discarded, so the only cost is the duplicated compile.
+  //
+  // The pointer stays valid after the lock is released: this map is insert-only and
+  // std::unordered_map keeps element references stable across rehash.
   const ProgramArtifact* Get(const std::string& key) const;
   const ProgramArtifact* Set(const std::string& key, ProgramArtifact&& program);
 
  private:
+  mutable std::mutex programs_mutex_;
   std::unordered_map<std::string, ProgramArtifact> programs_;
   WebGpuContext& webgpu_context_;
 

--- a/onnxruntime/core/providers/webgpu/session_buffer_pool.cc
+++ b/onnxruntime/core/providers/webgpu/session_buffer_pool.cc
@@ -46,8 +46,8 @@ void SessionBufferPool::Donate(BufferManager& retiring_mgr) {
   }
 
   Slot slot;
-  slot.storage = retiring_mgr.StorageCache().ExtractCachedBuffers();
-  slot.uniform = retiring_mgr.UniformCache().ExtractCachedBuffers();
+  slot.storage = retiring_mgr.ExtractCachedBuffers(wgpu::BufferUsage::Storage);
+  slot.uniform = retiring_mgr.ExtractCachedBuffers(wgpu::BufferUsage::Uniform);
 
   // The caches are now empty either way; the retiring manager is about to be
   // destroyed, so the early-exit only avoids pushing an empty slot.
@@ -73,8 +73,8 @@ void SessionBufferPool::SeedInto(BufferManager& new_mgr) {
   }
   Slot slot = std::move(slots_.back());
   slots_.pop_back();
-  new_mgr.StorageCache().AbsorbCachedBuffers(std::move(slot.storage));
-  new_mgr.UniformCache().AbsorbCachedBuffers(std::move(slot.uniform));
+  new_mgr.AbsorbCachedBuffers(wgpu::BufferUsage::Storage, std::move(slot.storage));
+  new_mgr.AbsorbCachedBuffers(wgpu::BufferUsage::Uniform, std::move(slot.uniform));
 }
 
 void SessionBufferPool::Clear() {

--- a/onnxruntime/core/providers/webgpu/session_buffer_pool.cc
+++ b/onnxruntime/core/providers/webgpu/session_buffer_pool.cc
@@ -46,8 +46,8 @@ void SessionBufferPool::Donate(BufferManager& retiring_mgr) {
   }
 
   Slot slot;
-  slot.storage = retiring_mgr.ExtractCachedBuffers(wgpu::BufferUsage::Storage);
-  slot.uniform = retiring_mgr.ExtractCachedBuffers(wgpu::BufferUsage::Uniform);
+  slot.storage = retiring_mgr.StorageCache().ExtractCachedBuffers();
+  slot.uniform = retiring_mgr.UniformCache().ExtractCachedBuffers();
 
   // The caches are now empty either way; the retiring manager is about to be
   // destroyed, so the early-exit only avoids pushing an empty slot.
@@ -73,8 +73,8 @@ void SessionBufferPool::SeedInto(BufferManager& new_mgr) {
   }
   Slot slot = std::move(slots_.back());
   slots_.pop_back();
-  new_mgr.AbsorbCachedBuffers(wgpu::BufferUsage::Storage, std::move(slot.storage));
-  new_mgr.AbsorbCachedBuffers(wgpu::BufferUsage::Uniform, std::move(slot.uniform));
+  new_mgr.StorageCache().AbsorbCachedBuffers(std::move(slot.storage));
+  new_mgr.UniformCache().AbsorbCachedBuffers(std::move(slot.uniform));
 }
 
 void SessionBufferPool::Clear() {

--- a/onnxruntime/core/providers/webgpu/shared_buffer_pool.cc
+++ b/onnxruntime/core/providers/webgpu/shared_buffer_pool.cc
@@ -1,0 +1,91 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/webgpu/shared_buffer_pool.h"
+
+#include <algorithm>
+
+#include "core/common/common.h"
+
+namespace onnxruntime {
+namespace webgpu {
+
+SharedBufferPool::SharedBufferPool(std::unordered_map<size_t, size_t> limits)
+    : limits_{std::move(limits)} {
+  sorted_sizes_.reserve(limits_.size());
+  for (const auto& [size, limit] : limits_) {
+    sorted_sizes_.push_back(size);
+  }
+  std::sort(sorted_sizes_.begin(), sorted_sizes_.end());
+
+#ifndef NDEBUG  // if debug build
+  ORT_ENFORCE(std::all_of(sorted_sizes_.begin(), sorted_sizes_.end(),
+                          [](size_t size) { return size % 16 == 0; }),
+              "Bucket sizes must be multiples of 16.");
+#endif
+}
+
+SharedBufferPool::~SharedBufferPool() {
+  for (auto& [size, buffers] : free_buffers_) {
+    for (auto* buffer : buffers) {
+      wgpuBufferRelease(buffer);
+    }
+  }
+}
+
+size_t SharedBufferPool::CalculateBufferSize(size_t request_size) const {
+  auto it = std::lower_bound(sorted_sizes_.begin(), sorted_sizes_.end(), request_size);
+  return it == sorted_sizes_.end() ? NormalizeBufferSize(request_size) : *it;
+}
+
+WGPUBuffer SharedBufferPool::TryAcquire(size_t buffer_size) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  auto it = free_buffers_.find(buffer_size);
+  if (it == free_buffers_.end() || it->second.empty()) {
+    return nullptr;
+  }
+  auto buffer = it->second.back();
+  it->second.pop_back();
+  return buffer;
+}
+
+void SharedBufferPool::Return(std::vector<std::pair<WGPUBuffer, size_t>>& buffers) {
+  if (buffers.empty()) {
+    return;
+  }
+
+  // Collected under the lock, released outside it: wgpuBufferRelease is a device call and has no
+  // business inside a critical section that other sessions are waiting on.
+  std::vector<WGPUBuffer> to_release;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    for (auto& [buffer, size] : buffers) {
+      auto& bucket = free_buffers_[size];
+      auto limit = limits_.find(size);
+      const bool bounded = !limits_.empty();
+      if (bounded && (limit == limits_.end() || bucket.size() >= limit->second)) {
+        to_release.push_back(buffer);
+      } else {
+        bucket.push_back(buffer);
+      }
+    }
+  }
+  buffers.clear();
+
+  for (auto* buffer : to_release) {
+    wgpuBufferRelease(buffer);
+  }
+}
+
+std::unique_ptr<SharedBufferPool> CreateDefaultStorageBufferPool() {
+  return std::make_unique<SharedBufferPool>(
+      std::unordered_map<size_t, size_t>{BUCKET_DEFAULT_LIMIT_TABLE});
+}
+
+std::unique_ptr<SharedBufferPool> CreateDefaultUniformBufferPool() {
+  // Unbounded: uniform buffers are tiny and the working set is naturally small.
+  return std::make_unique<SharedBufferPool>(std::unordered_map<size_t, size_t>{});
+}
+
+}  // namespace webgpu
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/webgpu/shared_buffer_pool.h
+++ b/onnxruntime/core/providers/webgpu/shared_buffer_pool.h
@@ -1,0 +1,111 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <cstddef>
+#include <initializer_list>
+#include <memory>
+#include <mutex>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "core/providers/webgpu/webgpu_external_header.h"
+
+namespace onnxruntime {
+namespace webgpu {
+
+// WebGPU requires buffer sizes to be a multiple of 16 bytes.
+constexpr size_t NormalizeBufferSize(size_t size) {
+  return (size + 15) / 16 * 16;
+}
+
+// Bucket size -> maximum number of buffers retained for that size.
+//
+// TODO: maybe use different bucket size for storage and uniform buffers?
+constexpr std::initializer_list<std::pair<const size_t, size_t>> BUCKET_DEFAULT_LIMIT_TABLE = {
+    {64, 250},
+    {128, 200},
+    {256, 200},
+    {512, 200},
+    {2048, 230},
+    {4096, 200},
+    {8192, 50},
+    {16384, 50},
+    {32768, 50},
+    {65536, 50},
+    {131072, 50},
+    {262144, 50},
+    {524288, 50},
+    {1048576, 50},
+    {2097152, 30},
+    {4194304, 20},
+    {8388608, 10},
+    {12582912, 10},
+    {16777216, 10},
+    {26214400, 15},
+    {33554432, 22},
+    {44236800, 2},
+    {58982400, 6},
+    // we don't want to cache the bucket sizes below but not caching them
+    // results in some major performance hits for models like sd-turbo.
+    {67108864, 6},
+    {134217728, 6},
+    {167772160, 6},
+};
+
+//
+// SharedBufferPool holds the free buffers that sessions hand back to each other. It is scoped to
+// a WebGpuContext, so its lifetime spans every session using that context.
+//
+// Not to be confused with SessionBufferPool (session_buffer_pool.h), which is scoped per session
+// and moves whole generations of buffers between retiring and incoming per-graph BufferManagers.
+// The two serve disjoint cache managers: Graph / GraphSimple feed SessionBufferPool, while
+// Bucket / Simple feed this one.
+//
+// This is deliberately the *only* piece of buffer state shared across sessions. Splitting the
+// cache per session instead would make steady-state GPU memory scale with the number of live
+// sessions (measured: 8 identical sessions went from 241 MB with a shared pool to 1585 MB with
+// per-session pools), because every session would keep its own high-water mark of intermediates.
+//
+// The complementary half - the "released but not yet submitted" list - stays private to each
+// session (see the cache managers in buffer_manager.cc), which is what makes sharing safe: a
+// buffer only becomes visible to other sessions once the releasing session has submitted its
+// commands. Handing it over earlier is what previously produced silently wrong results.
+//
+// Thread safety: all methods are internally synchronized. The critical section covers only
+// map/vector operations - no GPU calls, no command encoding, no shader compilation - so it is
+// on the order of 100ns and does not serialize sessions in any meaningful way.
+//
+class SharedBufferPool {
+ public:
+  // `limits` maps bucket size -> maximum number of buffers retained for that size. An empty map
+  // means unbounded and accepts any size (the "simple" cache policy).
+  explicit SharedBufferPool(std::unordered_map<size_t, size_t> limits);
+  ~SharedBufferPool();
+
+  // Rounds a request up to the nearest bucket size. Immutable after construction, so no lock.
+  size_t CalculateBufferSize(size_t request_size) const;
+
+  // Takes a buffer of exactly `buffer_size` out of the pool, or nullptr if none is available.
+  WGPUBuffer TryAcquire(size_t buffer_size);
+
+  // Returns buffers to the pool, releasing any that exceed the configured limit. `buffers` is
+  // cleared. Called only after the owning session has submitted the commands using them.
+  void Return(std::vector<std::pair<WGPUBuffer, size_t>>& buffers);
+
+ private:
+  const std::unordered_map<size_t, size_t> limits_;
+  std::vector<size_t> sorted_sizes_;  // immutable after construction
+  std::unordered_map<size_t, std::vector<WGPUBuffer>> free_buffers_;
+  std::mutex mutex_;
+};
+
+// Pools shared by every session on a WebGpuContext: bucketed for storage buffers, unbounded for
+// the small uniform buffers.
+std::unique_ptr<SharedBufferPool> CreateDefaultStorageBufferPool();
+std::unique_ptr<SharedBufferPool> CreateDefaultUniformBufferPool();
+
+}  // namespace webgpu
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/webgpu/webgpu_context.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.cc
@@ -239,6 +239,7 @@ Status WebGpuContext::Wait(wgpu::Future f) {
 }
 
 Status WebGpuContext::Run(ComputeContextBase& context, const ProgramBase& program) {
+  std::lock_guard<std::recursive_mutex> lock(context_mutex_);
   const auto& inputs = program.Inputs();
   const auto& outputs = program.Outputs();
 
@@ -832,6 +833,7 @@ Status WebGpuContext::PopErrorScope() {
 }
 
 void WebGpuContext::Flush(const webgpu::BufferManager& buffer_mgr) {
+  std::lock_guard<std::recursive_mutex> lock(context_mutex_);
   if (!current_command_encoder_) {
     return;
   }
@@ -954,6 +956,7 @@ void WebGpuContext::LaunchComputePipeline(const wgpu::ComputePassEncoder& comput
 }
 
 void WebGpuContext::CaptureBegin(std::vector<webgpu::CapturedCommandInfo>* captured_commands, const webgpu::BufferManager& buffer_manager) {
+  std::lock_guard<std::recursive_mutex> lock(context_mutex_);
   LOGS_DEFAULT(VERBOSE) << "CaptureBegin with external storage";
   // Flush any pending commands before we change the status
   Flush(buffer_manager);
@@ -969,6 +972,7 @@ void WebGpuContext::CaptureBegin(std::vector<webgpu::CapturedCommandInfo>* captu
 }
 
 void WebGpuContext::Replay(const std::vector<webgpu::CapturedCommandInfo>& captured_commands, const webgpu::BufferManager& buffer_manager) {
+  std::lock_guard<std::recursive_mutex> lock(context_mutex_);
   LOGS_DEFAULT(VERBOSE) << "Replay with external storage";
   graph_capture_state_ = GraphCaptureState::Replaying;
   // Replay all captured commands from the provided vector

--- a/onnxruntime/core/providers/webgpu/webgpu_context.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.cc
@@ -228,6 +228,16 @@ void WebGpuContext::Initialize(const WebGpuContextConfig& config) {
     for (size_t i = 0; i < supported_features.featureCount; i++) {
       device_features_.insert(supported_features.features[i]);
     }
+#if !defined(__wasm__)
+    // Without this feature Dawn's device-level entry points (buffer creation, Queue::Submit,
+    // WriteBuffer) are not thread-safe, so sessions sharing this context on different threads
+    // can corrupt Dawn's internal state. Per-session command recording alone does not cover it.
+    if (!DeviceHasFeature(wgpu::FeatureName::ImplicitDeviceSynchronization)) {
+      LOGS_DEFAULT(WARNING) << "WebGPU: ImplicitDeviceSynchronization is not available on this "
+                               "device. Using multiple inference sessions concurrently from "
+                               "different threads is not safe.";
+    }
+#endif
     // cache adapter info
     if (DeviceHasFeature(wgpu::FeatureName::ChromiumExperimentalSubgroupMatrix)) {
       adapter_info_.nextInChain = &subgroup_matrix_configs_;
@@ -235,18 +245,13 @@ void WebGpuContext::Initialize(const WebGpuContextConfig& config) {
     ORT_ENFORCE(Device().GetAdapterInfo(&adapter_info_) == wgpu::Status::Success);
 
     // create buffer manager
+    buffer_cache_config_ = config.buffer_cache_config;
     buffer_mgr_ = BufferManagerFactory::Create(*this,
+                                               default_recording_,
                                                config.buffer_cache_config.storage.mode,
                                                config.buffer_cache_config.uniform.mode,
                                                config.buffer_cache_config.query_resolve.mode,
                                                config.buffer_cache_config.default_entry.mode);
-
-    // create initializer buffer manager.
-    initializer_buffer_mgr_ = BufferManagerFactory::Create(*this,
-                                                           BufferCacheMode::LazyRelease,
-                                                           BufferCacheMode::LazyRelease,
-                                                           BufferCacheMode::Disabled,
-                                                           BufferCacheMode::Disabled);
 
     // create program manager
     program_mgr_ = std::make_unique<ProgramManager>(*this);
@@ -298,8 +303,9 @@ Status WebGpuContext::Wait(wgpu::Future f) {
   return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Failed to wait for the operation:", uint32_t(status));
 }
 
-PendingPipelineBuild* WebGpuContext::FindPendingPipelineBuild(std::string_view key) {
-  for (auto& dispatch : deferred_dispatches_) {
+PendingPipelineBuild* WebGpuContext::FindPendingPipelineBuild(CommandRecordingState& recording,
+                                                              std::string_view key) {
+  for (auto& dispatch : recording.deferred_dispatches) {
     if (dispatch.program_key == key && dispatch.pending_build) {
       return &*dispatch.pending_build;
     }
@@ -308,9 +314,9 @@ PendingPipelineBuild* WebGpuContext::FindPendingPipelineBuild(std::string_view k
   return nullptr;
 }
 
-Status WebGpuContext::WaitForDeferredPipelineBuilds() {
+Status WebGpuContext::WaitForDeferredPipelineBuilds(CommandRecordingState& recording) {
   Status result = Status::OK();
-  for (auto& dispatch : deferred_dispatches_) {
+  for (auto& dispatch : recording.deferred_dispatches) {
     if (dispatch.compute_pipeline) {
       continue;
     }
@@ -360,41 +366,44 @@ Status WebGpuContext::WaitForDeferredPipelineBuilds() {
   return result;
 }
 
-Status WebGpuContext::EncodeDeferredDispatches() {
-  if (deferred_dispatches_.empty()) {
+Status WebGpuContext::EncodeDeferredDispatches(const webgpu::BufferManager& buffer_mgr) {
+  auto& recording = buffer_mgr.Recording();
+  if (recording.deferred_dispatches.empty()) {
     return Status::OK();
   }
 
-  ORT_RETURN_IF_NOT(static_cast<size_t>(num_pending_dispatches_) + deferred_dispatches_.size() <=
+  ORT_RETURN_IF_NOT(static_cast<size_t>(recording.num_pending_dispatches) +
+                            recording.deferred_dispatches.size() <=
                         max_num_pending_dispatches_,
                     "WebGpuContext::EncodeDeferredDispatches: encoded dispatch count (",
-                    num_pending_dispatches_, ") plus deferred dispatch count (", deferred_dispatches_.size(),
+                    recording.num_pending_dispatches, ") plus deferred dispatch count (",
+                    recording.deferred_dispatches.size(),
                     ") exceeds maxNumPendingDispatches (", max_num_pending_dispatches_, ").");
 
-  auto reset_deferred_state = [this]() {
-    deferred_dispatches_.clear();
+  auto reset_deferred_state = [&recording]() {
+    recording.deferred_dispatches.clear();
   };
 
   // Resolve every pipeline before encoding so a failed build cannot leave a partially encoded run.
-  Status result = WaitForDeferredPipelineBuilds();
+  Status result = WaitForDeferredPipelineBuilds(recording);
   if (!result.IsOK()) {
     reset_deferred_state();
     return result;
   }
 
   // Encode the recorded dispatches in order, using the same command objects for graph capture.
-  for (auto& dispatch : deferred_dispatches_) {
+  for (auto& dispatch : recording.deferred_dispatches) {
     // Preserve profiling info in the captured command for future replays. Otherwise, replay it
     // into the current batch so pending_kernels_ stays in sync with num_pending_dispatches_.
     if (is_profiling_ && dispatch.pending_kernel_info.has_value()) {
-      if (graph_capture_state_ != GraphCaptureState::Capturing) {
-        pending_kernels_.emplace_back(std::move(*dispatch.pending_kernel_info));
+      if (recording.graph_capture_state != GraphCaptureState::Capturing) {
+        recording.pending_kernels.emplace_back(std::move(*dispatch.pending_kernel_info));
       }
     }
-    DispatchCommand(dispatch);
-    if (graph_capture_state_ == GraphCaptureState::Capturing) {
-      ORT_ENFORCE(external_captured_commands_ != nullptr);
-      external_captured_commands_->push_back(std::move(dispatch));
+    DispatchCommand(dispatch, recording);
+    if (recording.graph_capture_state == GraphCaptureState::Capturing) {
+      ORT_ENFORCE(recording.external_captured_commands != nullptr);
+      recording.external_captured_commands->push_back(std::move(dispatch));
     }
   }
 
@@ -409,6 +418,9 @@ Status WebGpuContext::Run(ComputeContextBase& context, const ProgramBase& progra
   if (outputs.empty()) {
     return Status::OK();
   }
+
+  const webgpu::BufferManager& buffer_mgr = ComputeContextBase::BufferManagerAccessor::Get(context);
+  CommandRecordingState& recording = buffer_mgr.Recording();
 
   // validate inputs and outputs are on WebGPU buffers
   if (ValidationMode() >= ValidationMode::Basic) {
@@ -522,7 +534,7 @@ Status WebGpuContext::Run(ComputeContextBase& context, const ProgramBase& progra
   const std::vector<int>* deferred_ranks = nullptr;
   const wgpu::BindGroupLayout* bind_group_layout = nullptr;
   if (program_artifact == nullptr) {
-    PendingPipelineBuild* in_flight_build = FindPendingPipelineBuild(key);
+    PendingPipelineBuild* in_flight_build = FindPendingPipelineBuild(recording, key);
 
     // Reuse an in-flight same-key build instead of compiling the shader again.
     if (in_flight_build == nullptr) {
@@ -665,7 +677,6 @@ Status WebGpuContext::Run(ComputeContextBase& context, const ProgramBase& progra
   const size_t uniform_buffer_total_size = (current_offset + max_alignment_of_field - 1) / max_alignment_of_field * max_alignment_of_field;
 
   WGPUBuffer uniform_buffer = nullptr;
-  const webgpu::BufferManager& buffer_mgr = ComputeContextBase::BufferManagerAccessor::Get(context);
   if (uniform_buffer_total_size > 0) {
     std::vector<uint8_t> uniform_data_buffer(uniform_buffer_total_size);
 
@@ -706,6 +717,7 @@ Status WebGpuContext::Run(ComputeContextBase& context, const ProgramBase& progra
   command.bind_group = CreateBindGroup(bind_buffers, bind_buffers_segments,
                                        *bind_group_layout, program.Name());
   command.pending_build = std::move(pending_build);
+  recording.has_unsubmitted_work = true;
   if (uniform_buffer) {
     // The bind group owns a reference now, so return the allocator's reference immediately.
     buffer_mgr.Release(uniform_buffer);
@@ -720,11 +732,11 @@ Status WebGpuContext::Run(ComputeContextBase& context, const ProgramBase& progra
     command.pending_kernel_info.emplace(context.NodeName(), context.OpType(), program.Name(),
                                         key, inputs, outputs);
   }
-  deferred_dispatches_.push_back(std::move(command));
+  recording.deferred_dispatches.push_back(std::move(command));
 
   // Drain and submit a full window to bound both recorded and encoded dispatch state. Partial
   // windows are encoded and submitted by the caller at its execution boundary.
-  if (static_cast<size_t>(num_pending_dispatches_) + deferred_dispatches_.size() >=
+  if (static_cast<size_t>(recording.num_pending_dispatches) + recording.deferred_dispatches.size() >=
       max_num_pending_dispatches_) {
     ORT_RETURN_IF_ERROR(Flush(buffer_mgr));
   }
@@ -795,6 +807,7 @@ std::vector<wgpu::FeatureName> WebGpuContext::GetAvailableRequiredFeatures(const
   constexpr wgpu::FeatureName features[]{
 #if !defined(__wasm__)
       wgpu::FeatureName::ChromiumExperimentalTimestampQueryInsidePasses,
+      wgpu::FeatureName::ImplicitDeviceSynchronization,
 #endif
       wgpu::FeatureName::ChromiumExperimentalSubgroupMatrix,
       wgpu::FeatureName::TimestampQuery,
@@ -839,12 +852,13 @@ wgpu::Limits WebGpuContext::GetRequiredLimits(const wgpu::Adapter& adapter) cons
   return required_limits;
 }
 
-void WebGpuContext::WriteTimestamp(uint32_t query_index) {
-  if (!is_profiling_ || graph_capture_state_ == GraphCaptureState::Capturing || query_type_ != TimestampQueryType::InsidePasses) {
+void WebGpuContext::WriteTimestamp(CommandRecordingState& recording, uint32_t query_index) {
+  if (!is_profiling_ || recording.graph_capture_state == GraphCaptureState::Capturing ||
+      query_type_ != TimestampQueryType::InsidePasses) {
     return;
   }
 
-  const auto& compute_pass_encoder = GetComputePassEncoder();
+  const auto& compute_pass_encoder = GetComputePassEncoder(recording);
   compute_pass_encoder.WriteTimestamp(query_set_, query_index);
 }
 
@@ -973,7 +987,7 @@ void WebGpuContext::EndProfiling(TimePoint /* tp */, profiling::Events& events) 
 
   if (query_type_ != TimestampQueryType::None) {
     // No pending kernels or queries should be present at this point. They should have been collected in CollectProfilingData.
-    ORT_ENFORCE(pending_kernels_.empty() && pending_queries_.empty(), "Pending kernels or queries are not empty.");
+    ORT_ENFORCE(pending_queries_.empty(), "Pending queries are not empty.");
 
     events.insert(events.end(),
                   std::make_move_iterator(events_.begin()),
@@ -1005,17 +1019,19 @@ Status WebGpuContext::PopErrorScope() {
 }
 
 Status WebGpuContext::Flush(const webgpu::BufferManager& buffer_mgr) {
-  Status status = EncodeDeferredDispatches();
-  if (!current_command_encoder_) {
+  Status status = EncodeDeferredDispatches(buffer_mgr);
+  auto& recording = buffer_mgr.Recording();
+  if (!recording.command_encoder) {
     return status;
   }
 
-  EndComputePass();
+  EndComputePass(recording);
 
-  if (is_profiling_ && num_pending_dispatches_ > 0 && graph_capture_state_ != GraphCaptureState::Capturing) {
-    ORT_ENFORCE(num_pending_dispatches_ == pending_kernels_.size(),
-                "Number of pending dispatches (", num_pending_dispatches_,
-                ") does not match pending kernels size (", pending_kernels_.size(), ")");
+  if (is_profiling_ && recording.num_pending_dispatches > 0 &&
+      recording.graph_capture_state != GraphCaptureState::Capturing) {
+    ORT_ENFORCE(recording.num_pending_dispatches == recording.pending_kernels.size(),
+                "Number of pending dispatches (", recording.num_pending_dispatches,
+                ") does not match pending kernels size (", recording.pending_kernels.size(), ")");
 
     // Capture the CPU elapsed time from the ORT profiler's start to this first submit.
     // Used in CollectProfilingData to offset GPU timestamps onto the ORT CPU timeline.
@@ -1023,8 +1039,8 @@ Status WebGpuContext::Flush(const webgpu::BufferManager& buffer_mgr) {
       profiling_first_submit_cpu_offset_us_ = TimeDiffMicroSeconds(profiling_start_time_);
     }
 
-    uint32_t query_count = num_pending_dispatches_ * 2;
-    current_command_encoder_.ResolveQuerySet(
+    uint32_t query_count = recording.num_pending_dispatches * 2;
+    recording.command_encoder.ResolveQuerySet(
         query_set_,
         0,
         query_count,
@@ -1036,23 +1052,24 @@ Status WebGpuContext::Flush(const webgpu::BufferManager& buffer_mgr) {
     bufferDescriptor.usage = wgpu::BufferUsage::MapRead | wgpu::BufferUsage::CopyDst;
     wgpu::Buffer query_read_buffer = device_.CreateBuffer(&bufferDescriptor);
 
-    current_command_encoder_.CopyBufferToBuffer(
+    recording.command_encoder.CopyBufferToBuffer(
         query_resolve_buffer_,
         0,
         query_read_buffer,
         0,
         query_count * sizeof(uint64_t));
 
-    pending_queries_.emplace_back(std::move(pending_kernels_), query_read_buffer);
-    pending_kernels_.clear();
+    pending_queries_.emplace_back(std::move(recording.pending_kernels), query_read_buffer);
+    recording.pending_kernels.clear();
   }
-  auto command_buffer = current_command_encoder_.Finish();
+  auto command_buffer = recording.command_encoder.Finish();
   device_queue_.Submit(1, &command_buffer);
-  if (graph_capture_state_ != GraphCaptureState::Replaying) {
-    buffer_mgr.RefreshPendingBuffers(graph_capture_state_);
+  if (recording.graph_capture_state != GraphCaptureState::Replaying) {
+    buffer_mgr.RefreshPendingBuffers(recording.graph_capture_state);
   }
-  current_command_encoder_ = nullptr;
-  num_pending_dispatches_ = 0;
+  recording.command_encoder = nullptr;
+  recording.num_pending_dispatches = 0;
+  recording.has_unsubmitted_work = false;
   return status;
 }
 
@@ -1098,11 +1115,12 @@ wgpu::BindGroup WebGpuContext::CreateBindGroup(const std::vector<WGPUBuffer>& bi
   return wgpu::BindGroup::Acquire(bind_group);
 }
 
-void WebGpuContext::DispatchCommand(const webgpu::CapturedCommandInfo& command) {
+void WebGpuContext::DispatchCommand(const webgpu::CapturedCommandInfo& command,
+                                    CommandRecordingState& recording) {
   ORT_ENFORCE(command.compute_pipeline.has_value());
   ORT_ENFORCE(command.bind_group != nullptr);
-  const auto& compute_pass_encoder = GetComputePassEncoder();
-  WriteTimestamp(num_pending_dispatches_ * 2);
+  const auto& compute_pass_encoder = GetComputePassEncoder(recording);
+  WriteTimestamp(recording, recording.num_pending_dispatches * 2);
   compute_pass_encoder.SetPipeline(*command.compute_pipeline);
   compute_pass_encoder.SetBindGroup(0, command.bind_group);
 
@@ -1113,11 +1131,11 @@ void WebGpuContext::DispatchCommand(const webgpu::CapturedCommandInfo& command) 
                                             command.dispatch_group[1],
                                             command.dispatch_group[2]);
   }
-  WriteTimestamp(num_pending_dispatches_ * 2 + 1);
-  ++num_pending_dispatches_;
-  if (num_pending_dispatches_ >= max_num_pending_dispatches_ ||
+  WriteTimestamp(recording, recording.num_pending_dispatches * 2 + 1);
+  ++recording.num_pending_dispatches;
+  if (recording.num_pending_dispatches >= max_num_pending_dispatches_ ||
       (is_profiling_ && query_type_ == TimestampQueryType::AtPasses)) {
-    EndComputePass();
+    EndComputePass(recording);
   }
 }
 
@@ -1126,24 +1144,25 @@ void WebGpuContext::CaptureBegin(std::vector<webgpu::CapturedCommandInfo>* captu
   // Flush any pending commands before we change the status
   ORT_THROW_IF_ERROR(Flush(buffer_manager));
 
-  external_captured_commands_ = captured_commands;
+  auto& recording = buffer_manager.Recording();
+  recording.external_captured_commands = captured_commands;
 
   // Make sure the external vector is empty before we start capturing
-  if (external_captured_commands_) {
-    external_captured_commands_->clear();
+  if (recording.external_captured_commands) {
+    recording.external_captured_commands->clear();
   }
 
-  graph_capture_state_ = GraphCaptureState::Capturing;
+  recording.graph_capture_state = GraphCaptureState::Capturing;
 }
 
 void WebGpuContext::Replay(const std::vector<webgpu::CapturedCommandInfo>& captured_commands, const webgpu::BufferManager& buffer_manager) {
   LOGS_DEFAULT(VERBOSE) << "Replay with external storage";
-  graph_capture_state_ = GraphCaptureState::Replaying;
+  auto& recording = buffer_manager.Recording();
+  recording.graph_capture_state = GraphCaptureState::Replaying;
   // Replay all captured commands from the provided vector
   const size_t command_count = captured_commands.size();
   for (size_t i = 0; i < command_count; ++i) {
     auto& command = captured_commands[i];
-
     // Restore profiling info when profiling is enabled. All commands are expected
     // to have profiling data in this mode to keep pending_kernels_ consistent
     // with num_pending_dispatches_.
@@ -1152,11 +1171,11 @@ void WebGpuContext::Replay(const std::vector<webgpu::CapturedCommandInfo>& captu
                   "WebGpuContext::Replay: profiling is enabled but captured command at index ",
                   i,
                   " is missing pending_kernel_info.");
-      pending_kernels_.emplace_back(*command.pending_kernel_info);
+      recording.pending_kernels.emplace_back(*command.pending_kernel_info);
     }
 
-    DispatchCommand(command);
-    if (num_pending_dispatches_ >= max_num_pending_dispatches_) {
+    DispatchCommand(command, recording);
+    if (recording.num_pending_dispatches >= max_num_pending_dispatches_) {
       ORT_THROW_IF_ERROR(Flush(buffer_manager));
     }
   }
@@ -1164,14 +1183,15 @@ void WebGpuContext::Replay(const std::vector<webgpu::CapturedCommandInfo>& captu
   // Flush any remaining commands
   ORT_THROW_IF_ERROR(Flush(buffer_manager));
 
-  graph_capture_state_ = GraphCaptureState::Default;
+  recording.graph_capture_state = GraphCaptureState::Default;
 }
 
-void WebGpuContext::CaptureEnd() {
+void WebGpuContext::CaptureEnd(const webgpu::BufferManager& buffer_manager) {
   LOGS_DEFAULT(VERBOSE) << "CaptureEnd";
 
-  graph_capture_state_ = GraphCaptureState::Default;
-  external_captured_commands_ = nullptr;
+  auto& recording = buffer_manager.Recording();
+  recording.graph_capture_state = GraphCaptureState::Default;
+  recording.external_captured_commands = nullptr;
 }
 
 void WebGpuContext::ReleaseGraphResources(std::vector<webgpu::CapturedCommandInfo>& captured_commands) {

--- a/onnxruntime/core/providers/webgpu/webgpu_context.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.cc
@@ -245,13 +245,16 @@ void WebGpuContext::Initialize(const WebGpuContextConfig& config) {
     ORT_ENFORCE(Device().GetAdapterInfo(&adapter_info_) == wgpu::Status::Success);
 
     // create buffer manager
-    buffer_cache_config_ = config.buffer_cache_config;
     buffer_mgr_ = BufferManagerFactory::Create(*this,
-                                               default_recording_,
                                                config.buffer_cache_config.storage.mode,
                                                config.buffer_cache_config.uniform.mode,
                                                config.buffer_cache_config.query_resolve.mode,
                                                config.buffer_cache_config.default_entry.mode);
+    initializer_buffer_mgr_ = BufferManagerFactory::Create(*this,
+                                                           BufferCacheMode::LazyRelease,
+                                                           BufferCacheMode::LazyRelease,
+                                                           BufferCacheMode::Disabled,
+                                                           BufferCacheMode::Disabled);
 
     // create program manager
     program_mgr_ = std::make_unique<ProgramManager>(*this);
@@ -366,8 +369,7 @@ Status WebGpuContext::WaitForDeferredPipelineBuilds(CommandRecordingState& recor
   return result;
 }
 
-Status WebGpuContext::EncodeDeferredDispatches(const webgpu::BufferManager& buffer_mgr) {
-  auto& recording = buffer_mgr.Recording();
+Status WebGpuContext::EncodeDeferredDispatches(CommandRecordingState& recording) {
   if (recording.deferred_dispatches.empty()) {
     return Status::OK();
   }
@@ -420,7 +422,8 @@ Status WebGpuContext::Run(ComputeContextBase& context, const ProgramBase& progra
   }
 
   const webgpu::BufferManager& buffer_mgr = ComputeContextBase::BufferManagerAccessor::Get(context);
-  CommandRecordingState& recording = buffer_mgr.Recording();
+  CommandRecordingState& recording = ComputeContextBase::BufferManagerAccessor::GetRecording(context);
+  std::lock_guard<std::recursive_mutex> lock{recording.mutex};
 
   // validate inputs and outputs are on WebGPU buffers
   if (ValidationMode() >= ValidationMode::Basic) {
@@ -684,7 +687,8 @@ Status WebGpuContext::Run(ComputeContextBase& context, const ProgramBase& progra
       memcpy(uniform_data_buffer.data() + offset, uniform.data.data(), uniform.data.size());
     }
 
-    uniform_buffer = buffer_mgr.Create(uniform_buffer_total_size, wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::Uniform);
+    uniform_buffer = buffer_mgr.Create(recording, uniform_buffer_total_size,
+                                       wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::Uniform);
     device_queue_.WriteBuffer(uniform_buffer, 0, uniform_data_buffer.data(), uniform_buffer_total_size);
   }
 
@@ -720,7 +724,7 @@ Status WebGpuContext::Run(ComputeContextBase& context, const ProgramBase& progra
   recording.has_unsubmitted_work = true;
   if (uniform_buffer) {
     // The bind group owns a reference now, so return the allocator's reference immediately.
-    buffer_mgr.Release(uniform_buffer);
+    buffer_mgr.Release(recording, uniform_buffer);
   }
   command.dispatch_group = {x, y, z};
   if (program.IndirectDispatchTensor() != nullptr) {
@@ -738,7 +742,7 @@ Status WebGpuContext::Run(ComputeContextBase& context, const ProgramBase& progra
   // windows are encoded and submitted by the caller at its execution boundary.
   if (static_cast<size_t>(recording.num_pending_dispatches) + recording.deferred_dispatches.size() >=
       max_num_pending_dispatches_) {
-    ORT_RETURN_IF_ERROR(Flush(buffer_mgr));
+    ORT_RETURN_IF_ERROR(Flush(buffer_mgr, recording));
   }
   return Status::OK();
 }
@@ -1018,9 +1022,10 @@ Status WebGpuContext::PopErrorScope() {
   return status;
 }
 
-Status WebGpuContext::Flush(const webgpu::BufferManager& buffer_mgr) {
-  Status status = EncodeDeferredDispatches(buffer_mgr);
-  auto& recording = buffer_mgr.Recording();
+Status WebGpuContext::Flush(const webgpu::BufferManager& buffer_mgr,
+                            CommandRecordingState& recording) {
+  std::lock_guard<std::recursive_mutex> lock{recording.mutex};
+  Status status = EncodeDeferredDispatches(recording);
   if (!recording.command_encoder) {
     return status;
   }
@@ -1065,7 +1070,7 @@ Status WebGpuContext::Flush(const webgpu::BufferManager& buffer_mgr) {
   auto command_buffer = recording.command_encoder.Finish();
   device_queue_.Submit(1, &command_buffer);
   if (recording.graph_capture_state != GraphCaptureState::Replaying) {
-    buffer_mgr.RefreshPendingBuffers(recording.graph_capture_state);
+    buffer_mgr.RefreshPendingBuffers(recording);
   }
   recording.command_encoder = nullptr;
   recording.num_pending_dispatches = 0;
@@ -1139,12 +1144,13 @@ void WebGpuContext::DispatchCommand(const webgpu::CapturedCommandInfo& command,
   }
 }
 
-void WebGpuContext::CaptureBegin(std::vector<webgpu::CapturedCommandInfo>* captured_commands, const webgpu::BufferManager& buffer_manager) {
+void WebGpuContext::CaptureBegin(std::vector<webgpu::CapturedCommandInfo>* captured_commands,
+                                 const webgpu::BufferManager& buffer_manager,
+                                 CommandRecordingState& recording) {
+  std::lock_guard<std::recursive_mutex> lock{recording.mutex};
   LOGS_DEFAULT(VERBOSE) << "CaptureBegin with external storage";
   // Flush any pending commands before we change the status
-  ORT_THROW_IF_ERROR(Flush(buffer_manager));
-
-  auto& recording = buffer_manager.Recording();
+  ORT_THROW_IF_ERROR(Flush(buffer_manager, recording));
   recording.external_captured_commands = captured_commands;
 
   // Make sure the external vector is empty before we start capturing
@@ -1155,9 +1161,11 @@ void WebGpuContext::CaptureBegin(std::vector<webgpu::CapturedCommandInfo>* captu
   recording.graph_capture_state = GraphCaptureState::Capturing;
 }
 
-void WebGpuContext::Replay(const std::vector<webgpu::CapturedCommandInfo>& captured_commands, const webgpu::BufferManager& buffer_manager) {
+void WebGpuContext::Replay(const std::vector<webgpu::CapturedCommandInfo>& captured_commands,
+                           const webgpu::BufferManager& buffer_manager,
+                           CommandRecordingState& recording) {
+  std::lock_guard<std::recursive_mutex> lock{recording.mutex};
   LOGS_DEFAULT(VERBOSE) << "Replay with external storage";
-  auto& recording = buffer_manager.Recording();
   recording.graph_capture_state = GraphCaptureState::Replaying;
   // Replay all captured commands from the provided vector
   const size_t command_count = captured_commands.size();
@@ -1176,20 +1184,20 @@ void WebGpuContext::Replay(const std::vector<webgpu::CapturedCommandInfo>& captu
 
     DispatchCommand(command, recording);
     if (recording.num_pending_dispatches >= max_num_pending_dispatches_) {
-      ORT_THROW_IF_ERROR(Flush(buffer_manager));
+      ORT_THROW_IF_ERROR(Flush(buffer_manager, recording));
     }
   }
 
   // Flush any remaining commands
-  ORT_THROW_IF_ERROR(Flush(buffer_manager));
+  ORT_THROW_IF_ERROR(Flush(buffer_manager, recording));
 
   recording.graph_capture_state = GraphCaptureState::Default;
 }
 
-void WebGpuContext::CaptureEnd(const webgpu::BufferManager& buffer_manager) {
+void WebGpuContext::CaptureEnd(CommandRecordingState& recording) {
+  std::lock_guard<std::recursive_mutex> lock{recording.mutex};
   LOGS_DEFAULT(VERBOSE) << "CaptureEnd";
 
-  auto& recording = buffer_manager.Recording();
   recording.graph_capture_state = GraphCaptureState::Default;
   recording.external_captured_commands = nullptr;
 }
@@ -1313,6 +1321,16 @@ WebGpuContext& WebGpuContextFactory::GetContext(int context_id) {
   ORT_ENFORCE(it != contexts_->end(), "WebGPU EP context ID ", context_id, " is not found.");
 
   return *it->second.context;
+}
+
+void WebGpuContextFactory::RetainContext(int context_id) {
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  ORT_ENFORCE(contexts_ != nullptr, "WebGPU contexts have not been initialized or have been cleaned up.");
+  auto it = contexts_->find(context_id);
+  ORT_ENFORCE(it != contexts_->end(), "WebGPU EP context ID ", context_id, " is not found.");
+
+  ++it->second.ref_count;
 }
 
 void WebGpuContextFactory::ReleaseContext(int context_id) {

--- a/onnxruntime/core/providers/webgpu/webgpu_context.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.cc
@@ -889,7 +889,7 @@ void WebGpuContext::Flush(const webgpu::BufferManager& buffer_mgr) {
   }
   recording.command_encoder = nullptr;
   recording.num_pending_dispatches = 0;
-  recording.has_unsubmitted_work.store(false, std::memory_order_release);
+  recording.has_unsubmitted_work = false;
 }
 
 void WebGpuContext::LaunchComputePipeline(const wgpu::ComputePassEncoder& compute_pass_encoder,

--- a/onnxruntime/core/providers/webgpu/webgpu_context.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.cc
@@ -178,6 +178,16 @@ void WebGpuContext::Initialize(const WebGpuContextConfig& config) {
     for (size_t i = 0; i < supported_features.featureCount; i++) {
       device_features_.insert(supported_features.features[i]);
     }
+#if !defined(__wasm__)
+    // Without this feature Dawn's device-level entry points (buffer creation, Queue::Submit,
+    // WriteBuffer) are not thread-safe, so sessions sharing this context on different threads
+    // can corrupt Dawn's internal state. Per-session command recording alone does not cover it.
+    if (!DeviceHasFeature(wgpu::FeatureName::ImplicitDeviceSynchronization)) {
+      LOGS_DEFAULT(WARNING) << "WebGPU: ImplicitDeviceSynchronization is not available on this "
+                               "device. Using multiple inference sessions concurrently from "
+                               "different threads is not safe.";
+    }
+#endif
     // cache adapter info
 #if !defined(__wasm__)
     if (DeviceHasFeature(wgpu::FeatureName::ChromiumExperimentalSubgroupMatrix)) {
@@ -187,18 +197,15 @@ void WebGpuContext::Initialize(const WebGpuContextConfig& config) {
     ORT_ENFORCE(Device().GetAdapterInfo(&adapter_info_));
 
     // create buffer manager
+    buffer_cache_config_ = config.buffer_cache_config;
+    shared_storage_pool_ = CreateDefaultStorageBufferPool();
+    shared_uniform_pool_ = CreateDefaultUniformBufferPool();
     buffer_mgr_ = BufferManagerFactory::Create(*this,
+                                               default_recording_,
                                                config.buffer_cache_config.storage.mode,
                                                config.buffer_cache_config.uniform.mode,
                                                config.buffer_cache_config.query_resolve.mode,
                                                config.buffer_cache_config.default_entry.mode);
-
-    // create initializer buffer manager.
-    initializer_buffer_mgr_ = BufferManagerFactory::Create(*this,
-                                                           BufferCacheMode::LazyRelease,
-                                                           BufferCacheMode::LazyRelease,
-                                                           BufferCacheMode::Disabled,
-                                                           BufferCacheMode::Disabled);
 
     // create program manager
     program_mgr_ = std::make_unique<ProgramManager>(*this);
@@ -239,7 +246,6 @@ Status WebGpuContext::Wait(wgpu::Future f) {
 }
 
 Status WebGpuContext::Run(ComputeContextBase& context, const ProgramBase& program) {
-  std::lock_guard<std::recursive_mutex> lock(context_mutex_);
   const auto& inputs = program.Inputs();
   const auto& outputs = program.Outputs();
 
@@ -492,6 +498,7 @@ Status WebGpuContext::Run(ComputeContextBase& context, const ProgramBase& progra
 
   WGPUBuffer uniform_buffer = nullptr;
   const webgpu::BufferManager& buffer_mgr = ComputeContextBase::BufferManagerAccessor::Get(context);
+  CommandRecordingState& recording = buffer_mgr.Recording();
   if (uniform_buffer_total_size > 0) {
     std::vector<uint8_t> uniform_data_buffer(uniform_buffer_total_size);
 
@@ -503,9 +510,9 @@ Status WebGpuContext::Run(ComputeContextBase& context, const ProgramBase& progra
     device_queue_.WriteBuffer(uniform_buffer, 0, uniform_data_buffer.data(), uniform_buffer_total_size);
   }
 
-  const auto& compute_pass_encoder = GetComputePassEncoder();
+  const auto& compute_pass_encoder = GetComputePassEncoder(recording);
 
-  WriteTimestamp(num_pending_dispatches_ * 2);
+  WriteTimestamp(recording, recording.num_pending_dispatches * 2);
 
   const size_t total_buffer_count = inputs.size() + outputs.size() + (uniform_buffer ? 1 : 0);
 
@@ -531,8 +538,8 @@ Status WebGpuContext::Run(ComputeContextBase& context, const ProgramBase& progra
     buffer_mgr.Release(uniform_buffer);
   }
 
-  WriteTimestamp(num_pending_dispatches_ * 2 + 1);
-  ++num_pending_dispatches_;
+  WriteTimestamp(recording, recording.num_pending_dispatches * 2 + 1);
+  ++recording.num_pending_dispatches;
 
   // Update profiling data after LaunchComputePipeline
   if (is_profiling_) {
@@ -554,13 +561,13 @@ Status WebGpuContext::Run(ComputeContextBase& context, const ProgramBase& progra
     }
   }
 
-  if (num_pending_dispatches_ >= max_num_pending_dispatches_ ||
+  if (recording.num_pending_dispatches >= max_num_pending_dispatches_ ||
       (is_profiling_ && query_type_ == TimestampQueryType::AtPasses)) {
-    EndComputePass();
+    EndComputePass(recording);
   }
-  if (num_pending_dispatches_ >= max_num_pending_dispatches_) {
+  if (recording.num_pending_dispatches >= max_num_pending_dispatches_) {
     Flush(buffer_mgr);
-    num_pending_dispatches_ = 0;
+    recording.num_pending_dispatches = 0;
   }
 
   return Status::OK();
@@ -625,6 +632,7 @@ std::vector<wgpu::FeatureName> WebGpuContext::GetAvailableRequiredFeatures(const
 #if !defined(__wasm__)
       wgpu::FeatureName::ChromiumExperimentalTimestampQueryInsidePasses,
       wgpu::FeatureName::ChromiumExperimentalSubgroupMatrix,
+      wgpu::FeatureName::ImplicitDeviceSynchronization,
 #endif
       wgpu::FeatureName::TimestampQuery,
       wgpu::FeatureName::ShaderF16,
@@ -667,12 +675,12 @@ wgpu::Limits WebGpuContext::GetRequiredLimits(const wgpu::Adapter& adapter) cons
   return required_limits;
 }
 
-void WebGpuContext::WriteTimestamp(uint32_t query_index) {
+void WebGpuContext::WriteTimestamp(CommandRecordingState& recording, uint32_t query_index) {
   if (!is_profiling_ || graph_capture_state_ == GraphCaptureState::Capturing || query_type_ != TimestampQueryType::InsidePasses) {
     return;
   }
 
-  const auto& compute_pass_encoder = GetComputePassEncoder();
+  const auto& compute_pass_encoder = GetComputePassEncoder(recording);
   compute_pass_encoder.WriteTimestamp(query_set_, query_index);
 }
 
@@ -833,16 +841,16 @@ Status WebGpuContext::PopErrorScope() {
 }
 
 void WebGpuContext::Flush(const webgpu::BufferManager& buffer_mgr) {
-  std::lock_guard<std::recursive_mutex> lock(context_mutex_);
-  if (!current_command_encoder_) {
+  auto& recording = buffer_mgr.Recording();
+  if (!recording.command_encoder) {
     return;
   }
 
-  EndComputePass();
+  EndComputePass(recording);
 
-  if (is_profiling_ && num_pending_dispatches_ > 0 && graph_capture_state_ != GraphCaptureState::Capturing) {
-    ORT_ENFORCE(num_pending_dispatches_ == pending_kernels_.size(),
-                "Number of pending dispatches (", num_pending_dispatches_,
+  if (is_profiling_ && recording.num_pending_dispatches > 0 && graph_capture_state_ != GraphCaptureState::Capturing) {
+    ORT_ENFORCE(recording.num_pending_dispatches == pending_kernels_.size(),
+                "Number of pending dispatches (", recording.num_pending_dispatches,
                 ") does not match pending kernels size (", pending_kernels_.size(), ")");
 
     // Capture the CPU elapsed time from the ORT profiler's start to this first submit.
@@ -851,8 +859,8 @@ void WebGpuContext::Flush(const webgpu::BufferManager& buffer_mgr) {
       profiling_first_submit_cpu_offset_us_ = TimeDiffMicroSeconds(profiling_start_time_);
     }
 
-    uint32_t query_count = num_pending_dispatches_ * 2;
-    current_command_encoder_.ResolveQuerySet(
+    uint32_t query_count = recording.num_pending_dispatches * 2;
+    recording.command_encoder.ResolveQuerySet(
         query_set_,
         0,
         query_count,
@@ -864,7 +872,7 @@ void WebGpuContext::Flush(const webgpu::BufferManager& buffer_mgr) {
     bufferDescriptor.usage = wgpu::BufferUsage::MapRead | wgpu::BufferUsage::CopyDst;
     wgpu::Buffer query_read_buffer = device_.CreateBuffer(&bufferDescriptor);
 
-    current_command_encoder_.CopyBufferToBuffer(
+    recording.command_encoder.CopyBufferToBuffer(
         query_resolve_buffer_,
         0,
         query_read_buffer,
@@ -874,13 +882,14 @@ void WebGpuContext::Flush(const webgpu::BufferManager& buffer_mgr) {
     pending_queries_.emplace_back(std::move(pending_kernels_), query_read_buffer);
     pending_kernels_.clear();
   }
-  auto command_buffer = current_command_encoder_.Finish();
+  auto command_buffer = recording.command_encoder.Finish();
   device_queue_.Submit(1, &command_buffer);
   if (graph_capture_state_ != GraphCaptureState::Replaying) {
     buffer_mgr.RefreshPendingBuffers(graph_capture_state_);
   }
-  current_command_encoder_ = nullptr;
-  num_pending_dispatches_ = 0;
+  recording.command_encoder = nullptr;
+  recording.num_pending_dispatches = 0;
+  recording.has_unsubmitted_work.store(false, std::memory_order_release);
 }
 
 void WebGpuContext::LaunchComputePipeline(const wgpu::ComputePassEncoder& compute_pass_encoder,
@@ -956,7 +965,6 @@ void WebGpuContext::LaunchComputePipeline(const wgpu::ComputePassEncoder& comput
 }
 
 void WebGpuContext::CaptureBegin(std::vector<webgpu::CapturedCommandInfo>* captured_commands, const webgpu::BufferManager& buffer_manager) {
-  std::lock_guard<std::recursive_mutex> lock(context_mutex_);
   LOGS_DEFAULT(VERBOSE) << "CaptureBegin with external storage";
   // Flush any pending commands before we change the status
   Flush(buffer_manager);
@@ -972,15 +980,15 @@ void WebGpuContext::CaptureBegin(std::vector<webgpu::CapturedCommandInfo>* captu
 }
 
 void WebGpuContext::Replay(const std::vector<webgpu::CapturedCommandInfo>& captured_commands, const webgpu::BufferManager& buffer_manager) {
-  std::lock_guard<std::recursive_mutex> lock(context_mutex_);
   LOGS_DEFAULT(VERBOSE) << "Replay with external storage";
   graph_capture_state_ = GraphCaptureState::Replaying;
+  auto& recording = buffer_manager.Recording();
   // Replay all captured commands from the provided vector
   const size_t command_count = captured_commands.size();
   for (size_t i = 0; i < command_count; ++i) {
     auto& command = captured_commands[i];
-    const auto& compute_pass_encoder = GetComputePassEncoder();
-    WriteTimestamp(num_pending_dispatches_ * 2);
+    const auto& compute_pass_encoder = GetComputePassEncoder(recording);
+    WriteTimestamp(recording, recording.num_pending_dispatches * 2);
 
     // Restore profiling info when profiling is enabled. All commands are expected
     // to have profiling data in this mode to keep pending_kernels_ consistent
@@ -1004,15 +1012,15 @@ void WebGpuContext::Replay(const std::vector<webgpu::CapturedCommandInfo>& captu
       compute_pass_encoder.DispatchWorkgroups(command.dispatch_group[0], command.dispatch_group[1], command.dispatch_group[2]);
     }
 
-    WriteTimestamp(num_pending_dispatches_ * 2 + 1);
-    ++num_pending_dispatches_;
-    if (num_pending_dispatches_ >= max_num_pending_dispatches_ ||
+    WriteTimestamp(recording, recording.num_pending_dispatches * 2 + 1);
+    ++recording.num_pending_dispatches;
+    if (recording.num_pending_dispatches >= max_num_pending_dispatches_ ||
         (is_profiling_ && query_type_ == TimestampQueryType::AtPasses)) {
-      EndComputePass();
+      EndComputePass(recording);
     }
-    if (num_pending_dispatches_ >= max_num_pending_dispatches_) {
+    if (recording.num_pending_dispatches >= max_num_pending_dispatches_) {
       Flush(buffer_manager);
-      num_pending_dispatches_ = 0;
+      recording.num_pending_dispatches = 0;
     }
   }
 

--- a/onnxruntime/core/providers/webgpu/webgpu_context.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.cc
@@ -250,6 +250,8 @@ void WebGpuContext::Initialize(const WebGpuContextConfig& config) {
                                                config.buffer_cache_config.uniform.mode,
                                                config.buffer_cache_config.query_resolve.mode,
                                                config.buffer_cache_config.default_entry.mode);
+
+    // create initializer buffer manager.
     initializer_buffer_mgr_ = BufferManagerFactory::Create(*this,
                                                            BufferCacheMode::LazyRelease,
                                                            BufferCacheMode::LazyRelease,
@@ -1148,6 +1150,7 @@ void WebGpuContext::CaptureBegin(std::vector<webgpu::CapturedCommandInfo>* captu
   LOGS_DEFAULT(VERBOSE) << "CaptureBegin with external storage";
   // Flush any pending commands before we change the status
   ORT_THROW_IF_ERROR(Flush(buffer_manager, recording));
+
   recording.external_captured_commands = captured_commands;
 
   // Make sure the external vector is empty before we start capturing
@@ -1167,6 +1170,7 @@ void WebGpuContext::Replay(const std::vector<webgpu::CapturedCommandInfo>& captu
   const size_t command_count = captured_commands.size();
   for (size_t i = 0; i < command_count; ++i) {
     auto& command = captured_commands[i];
+
     // Restore profiling info when profiling is enabled. All commands are expected
     // to have profiling data in this mode to keep pending_kernels_ consistent
     // with num_pending_dispatches_.

--- a/onnxruntime/core/providers/webgpu/webgpu_context.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.cc
@@ -423,7 +423,6 @@ Status WebGpuContext::Run(ComputeContextBase& context, const ProgramBase& progra
 
   const webgpu::BufferManager& buffer_mgr = ComputeContextBase::BufferManagerAccessor::Get(context);
   CommandRecordingState& recording = ComputeContextBase::BufferManagerAccessor::GetRecording(context);
-  std::lock_guard<std::recursive_mutex> lock{recording.mutex};
 
   // validate inputs and outputs are on WebGPU buffers
   if (ValidationMode() >= ValidationMode::Basic) {
@@ -1024,7 +1023,6 @@ Status WebGpuContext::PopErrorScope() {
 
 Status WebGpuContext::Flush(const webgpu::BufferManager& buffer_mgr,
                             CommandRecordingState& recording) {
-  std::lock_guard<std::recursive_mutex> lock{recording.mutex};
   Status status = EncodeDeferredDispatches(recording);
   if (!recording.command_encoder) {
     return status;
@@ -1147,7 +1145,6 @@ void WebGpuContext::DispatchCommand(const webgpu::CapturedCommandInfo& command,
 void WebGpuContext::CaptureBegin(std::vector<webgpu::CapturedCommandInfo>* captured_commands,
                                  const webgpu::BufferManager& buffer_manager,
                                  CommandRecordingState& recording) {
-  std::lock_guard<std::recursive_mutex> lock{recording.mutex};
   LOGS_DEFAULT(VERBOSE) << "CaptureBegin with external storage";
   // Flush any pending commands before we change the status
   ORT_THROW_IF_ERROR(Flush(buffer_manager, recording));
@@ -1164,7 +1161,6 @@ void WebGpuContext::CaptureBegin(std::vector<webgpu::CapturedCommandInfo>* captu
 void WebGpuContext::Replay(const std::vector<webgpu::CapturedCommandInfo>& captured_commands,
                            const webgpu::BufferManager& buffer_manager,
                            CommandRecordingState& recording) {
-  std::lock_guard<std::recursive_mutex> lock{recording.mutex};
   LOGS_DEFAULT(VERBOSE) << "Replay with external storage";
   recording.graph_capture_state = GraphCaptureState::Replaying;
   // Replay all captured commands from the provided vector
@@ -1195,7 +1191,6 @@ void WebGpuContext::Replay(const std::vector<webgpu::CapturedCommandInfo>& captu
 }
 
 void WebGpuContext::CaptureEnd(CommandRecordingState& recording) {
-  std::lock_guard<std::recursive_mutex> lock{recording.mutex};
   LOGS_DEFAULT(VERBOSE) << "CaptureEnd";
 
   recording.graph_capture_state = GraphCaptureState::Default;

--- a/onnxruntime/core/providers/webgpu/webgpu_context.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.cc
@@ -423,7 +423,6 @@ Status WebGpuContext::Run(ComputeContextBase& context, const ProgramBase& progra
     return Status::OK();
   }
 
-  const webgpu::BufferManager& buffer_mgr = ComputeContextBase::BufferManagerAccessor::Get(context);
   CommandRecordingState& recording = ComputeContextBase::BufferManagerAccessor::GetRecording(context);
 
   // validate inputs and outputs are on WebGPU buffers
@@ -681,6 +680,7 @@ Status WebGpuContext::Run(ComputeContextBase& context, const ProgramBase& progra
   const size_t uniform_buffer_total_size = (current_offset + max_alignment_of_field - 1) / max_alignment_of_field * max_alignment_of_field;
 
   WGPUBuffer uniform_buffer = nullptr;
+  const webgpu::BufferManager& buffer_mgr = ComputeContextBase::BufferManagerAccessor::Get(context);
   if (uniform_buffer_total_size > 0) {
     std::vector<uint8_t> uniform_data_buffer(uniform_buffer_total_size);
 

--- a/onnxruntime/core/providers/webgpu/webgpu_context.h
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.h
@@ -178,6 +178,7 @@ class WebGpuContext final {
 #endif
 
   const wgpu::CommandEncoder& GetCommandEncoder() {
+    std::lock_guard<std::recursive_mutex> lock(context_mutex_);
     if (!current_command_encoder_) {
       current_command_encoder_ = device_.CreateCommandEncoder();
     }
@@ -185,6 +186,7 @@ class WebGpuContext final {
   }
 
   const wgpu::ComputePassEncoder& GetComputePassEncoder() {
+    std::lock_guard<std::recursive_mutex> lock(context_mutex_);
     if (!current_compute_pass_encoder_) {
       auto& command_encoder = GetCommandEncoder();
 
@@ -205,11 +207,23 @@ class WebGpuContext final {
   }
 
   void EndComputePass() {
+    std::lock_guard<std::recursive_mutex> lock(context_mutex_);
     if (current_compute_pass_encoder_) {
       current_compute_pass_encoder_.End();
       current_compute_pass_encoder_ = nullptr;
     }
   }
+
+  // Acquire the shared-context lock for the duration of a compound sequence that records into
+  // and/or submits the shared command encoder, or that allocates/frees GPU buffers from the
+  // context's shared BufferManager caches (e.g. BufferManager::Upload/MemCpy/Download/Create/
+  // Release and ComputeContext::FillZero). The caller holds the returned lock so that the
+  // individual GetCommandEncoder / EndComputePass / Flush / cache calls in that sequence execute
+  // atomically with respect to other InferenceSessions that share this context.
+  [[nodiscard]] std::unique_lock<std::recursive_mutex> AcquireContextLock() {
+    return std::unique_lock<std::recursive_mutex>(context_mutex_);
+  }
+
   void CaptureBegin(std::vector<webgpu::CapturedCommandInfo>* captured_commands, const webgpu::BufferManager& buffer_manager);
   void CaptureEnd();
   void Replay(const std::vector<webgpu::CapturedCommandInfo>& captured_commands, const webgpu::BufferManager& buffer_manager);
@@ -348,6 +362,17 @@ class WebGpuContext final {
 
   wgpu::CommandEncoder current_command_encoder_;
   wgpu::ComputePassEncoder current_compute_pass_encoder_;
+
+  // Serializes all mutations of shared per-context state: the command encoder / compute pass /
+  // pending-dispatch counters AND the shared BufferManager cache maps (Create/Release/refresh).
+  // Multiple InferenceSessions can share a single context (e.g. the default context_id=0), and
+  // InferenceSession only serializes a single session's Run via its own session_mutex_. Without
+  // this lock, concurrent Run / allocation / initializer-upload from different sessions race on
+  // the single shared command encoder and buffer caches, producing Dawn "CommandEncoder is
+  // already finished" errors, corrupted buffer caches, and device-lost failures. Recursive
+  // because the guarded compound operations (Run, Flush, Replay, CaptureBegin, and the buffer
+  // Upload/MemCpy/Download/Create/Release / FillZero sequences) nest calls into each other.
+  std::recursive_mutex context_mutex_;
 
   std::unique_ptr<webgpu::BufferManager> buffer_mgr_;
   std::unique_ptr<webgpu::BufferManager> initializer_buffer_mgr_;

--- a/onnxruntime/core/providers/webgpu/webgpu_context.h
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.h
@@ -108,6 +108,19 @@ struct CapturedCommandInfo {
   std::optional<PendingKernelInfo> pending_kernel_info;
 };
 
+// State for one session's command recording timeline. WebGpuContext is shared across sessions,
+// but Dawn command encoders and deferred dispatch windows must not be.
+struct CommandRecordingState {
+  wgpu::CommandEncoder command_encoder;
+  wgpu::ComputePassEncoder compute_pass_encoder;
+  uint32_t num_pending_dispatches = 0;
+  bool has_unsubmitted_work = false;
+  std::vector<CapturedCommandInfo> deferred_dispatches;
+  std::vector<PendingKernelInfo> pending_kernels;
+  GraphCaptureState graph_capture_state{GraphCaptureState::Default};
+  std::vector<CapturedCommandInfo>* external_captured_commands = nullptr;
+};
+
 struct WebGpuBufferCacheConfig {
   struct ConfigEntry {
     BufferCacheMode mode;
@@ -226,57 +239,64 @@ class WebGpuContext final {
   bool DeviceHasFeature(wgpu::FeatureName feature) const { return device_features_.contains(feature); }
   const wgpu::AdapterPropertiesSubgroupMatrixConfigs& SubgroupMatrixConfigs() const { return subgroup_matrix_configs_; }
 
-  const wgpu::CommandEncoder& GetCommandEncoder() {
-    if (!current_command_encoder_) {
-      current_command_encoder_ = device_.CreateCommandEncoder();
+  const wgpu::CommandEncoder& GetCommandEncoder(CommandRecordingState& recording) {
+    if (!recording.command_encoder) {
+      recording.command_encoder = device_.CreateCommandEncoder();
+      recording.has_unsubmitted_work = true;
     }
-    return current_command_encoder_;
+    return recording.command_encoder;
   }
 
-  const wgpu::ComputePassEncoder& GetComputePassEncoder() {
-    if (!current_compute_pass_encoder_) {
-      auto& command_encoder = GetCommandEncoder();
+  const wgpu::ComputePassEncoder& GetComputePassEncoder(CommandRecordingState& recording) {
+    if (!recording.compute_pass_encoder) {
+      auto& command_encoder = GetCommandEncoder(recording);
 
       wgpu::ComputePassDescriptor compute_pass_desc{};
 
-      if (is_profiling_ && query_type_ == TimestampQueryType::AtPasses && graph_capture_state_ != GraphCaptureState::Capturing) {
+      if (is_profiling_ && query_type_ == TimestampQueryType::AtPasses &&
+          recording.graph_capture_state != GraphCaptureState::Capturing) {
         wgpu::PassTimestampWrites timestampWrites = {
             nullptr,
             query_set_,
-            num_pending_dispatches_ * 2,
-            num_pending_dispatches_ * 2 + 1};
+            recording.num_pending_dispatches * 2,
+            recording.num_pending_dispatches * 2 + 1};
         compute_pass_desc.timestampWrites = &timestampWrites;
       }
 
-      current_compute_pass_encoder_ = command_encoder.BeginComputePass(&compute_pass_desc);
+      recording.compute_pass_encoder = command_encoder.BeginComputePass(&compute_pass_desc);
     }
-    return current_compute_pass_encoder_;
+    return recording.compute_pass_encoder;
   }
 
-  void EndComputePass() {
-    if (current_compute_pass_encoder_) {
-      current_compute_pass_encoder_.End();
-      current_compute_pass_encoder_ = nullptr;
+  void EndComputePass(CommandRecordingState& recording) {
+    if (recording.compute_pass_encoder) {
+      recording.compute_pass_encoder.End();
+      recording.compute_pass_encoder = nullptr;
     }
   }
   void CaptureBegin(std::vector<webgpu::CapturedCommandInfo>* captured_commands, const webgpu::BufferManager& buffer_manager);
-  void CaptureEnd();
+  void CaptureEnd(const webgpu::BufferManager& buffer_manager);
   void Replay(const std::vector<webgpu::CapturedCommandInfo>& captured_commands, const webgpu::BufferManager& buffer_manager);
   void ReleaseGraphResources(std::vector<webgpu::CapturedCommandInfo>& captured_commands);
 
   Status Flush(const webgpu::BufferManager& buffer_mgr);
 
   /**
-   * Get the buffer manager.
+   * Get the context-level buffer manager.
+   *
+   * This is NOT the manager sessions use - each WebGpuExecutionProvider owns its own (see
+   * WebGpuExecutionProvider::BufferManager). It exists for session-less plugin EP facilities
+   * such as the shared allocator and OrtWebGpuCreateDataTransfer, which have no EP to borrow one
+   * from.
    */
   webgpu::BufferManager& BufferManager() const { return *buffer_mgr_; }
 
   /**
-   * Get the initializer buffer manager.
-   *
-   * This buffer manager is used for read-only buffers (e.g. initializers).
+   * The buffer cache configuration this context was initialized with. Exposed so that each
+   * session can create its own BufferManager with the same policy instead of sharing the
+   * context's caches across threads.
    */
-  webgpu::BufferManager& InitializerBufferManager() const { return *initializer_buffer_mgr_; }
+  const WebGpuBufferCacheConfig& BufferCacheConfig() const { return buffer_cache_config_; }
 
   inline webgpu::ValidationMode ValidationMode() const {
     return validation_mode_;
@@ -359,15 +379,15 @@ class WebGpuContext final {
                                   const std::vector<uint32_t>& bind_buffers_segments,
                                   const wgpu::BindGroupLayout& bind_group_layout,
                                   std::string_view label) const;
-  void DispatchCommand(const webgpu::CapturedCommandInfo& command);
-  Status EncodeDeferredDispatches();
+  void DispatchCommand(const webgpu::CapturedCommandInfo& command, CommandRecordingState& recording);
+  Status EncodeDeferredDispatches(const webgpu::BufferManager& buffer_mgr);
 
   std::vector<const char*> GetEnabledAdapterToggles() const;
   std::vector<const char*> GetEnabledDeviceToggles() const;
   std::vector<const char*> GetDisabledDeviceToggles() const;
   std::vector<wgpu::FeatureName> GetAvailableRequiredFeatures(const wgpu::Adapter& adapter) const;
   wgpu::Limits GetRequiredLimits(const wgpu::Adapter& adapter) const;
-  void WriteTimestamp(uint32_t query_index);
+  void WriteTimestamp(CommandRecordingState& recording, uint32_t query_index);
 
   struct PendingQueryInfo {
     PendingQueryInfo(std::vector<PendingKernelInfo>&& kernels, wgpu::Buffer query_buffer)
@@ -382,8 +402,8 @@ class WebGpuContext final {
   };
 
   // Find the build owner for a cache key in the current deferred window.
-  PendingPipelineBuild* FindPendingPipelineBuild(std::string_view key);
-  Status WaitForDeferredPipelineBuilds();
+  PendingPipelineBuild* FindPendingPipelineBuild(CommandRecordingState& recording, std::string_view key);
+  Status WaitForDeferredPipelineBuilds(CommandRecordingState& recording);
 
   friend class BufferManager;
   friend class ComputeContext;
@@ -404,18 +424,18 @@ class WebGpuContext final {
   std::unordered_set<wgpu::FeatureName> device_features_;
   wgpu::AdapterPropertiesSubgroupMatrixConfigs subgroup_matrix_configs_;
 
-  wgpu::CommandEncoder current_command_encoder_;
-  wgpu::ComputePassEncoder current_compute_pass_encoder_;
+  // Recording state for buffer_mgr_ below. Sessions never touch it: each
+  // WebGpuExecutionProvider owns its own CommandRecordingState. This one exists only for the
+  // session-less plugin EP allocator and data transfer, whose operations are not covered by any
+  // session_mutex_.
+  CommandRecordingState default_recording_;
 
   std::unique_ptr<webgpu::BufferManager> buffer_mgr_;
-  std::unique_ptr<webgpu::BufferManager> initializer_buffer_mgr_;
   std::unique_ptr<ProgramManager> program_mgr_;
 
-  uint32_t num_pending_dispatches_ = 0;
-  uint32_t max_num_pending_dispatches_ = 16;
+  WebGpuBufferCacheConfig buffer_cache_config_{};
 
-  // Owns the active dispatch window and the unique pending builds referenced within that window.
-  std::vector<webgpu::CapturedCommandInfo> deferred_dispatches_;
+  uint32_t max_num_pending_dispatches_ = 16;
 
   std::unique_ptr<SplitKConfig> split_k_config_;
 
@@ -424,8 +444,6 @@ class WebGpuContext final {
   wgpu::QuerySet query_set_;
   wgpu::Buffer query_resolve_buffer_;
 
-  // info of kernels pending submission for a single batch
-  std::vector<PendingKernelInfo> pending_kernels_;
   // info of queries pending appending to profiling events
   std::vector<PendingQueryInfo> pending_queries_;
 
@@ -441,10 +459,6 @@ class WebGpuContext final {
   profiling::Events events_;
   bool preserve_device_;
   uint64_t max_storage_buffer_binding_size_;
-  GraphCaptureState graph_capture_state_{GraphCaptureState::Default};
-
-  // External vector to store captured commands, owned by EP
-  std::vector<webgpu::CapturedCommandInfo>* external_captured_commands_ = nullptr;
 };
 
 }  // namespace webgpu

--- a/onnxruntime/core/providers/webgpu/webgpu_context.h
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.h
@@ -111,10 +111,12 @@ struct CapturedCommandInfo {
 // State for one session's command recording timeline. WebGpuContext is shared across sessions,
 // but Dawn command encoders and deferred dispatch windows must not be.
 struct CommandRecordingState {
+  std::recursive_mutex mutex;
   wgpu::CommandEncoder command_encoder;
   wgpu::ComputePassEncoder compute_pass_encoder;
   uint32_t num_pending_dispatches = 0;
   bool has_unsubmitted_work = false;
+  std::vector<wgpu::Buffer> pending_buffers;
   std::vector<CapturedCommandInfo> deferred_dispatches;
   std::vector<PendingKernelInfo> pending_kernels;
   GraphCaptureState graph_capture_state{GraphCaptureState::Default};
@@ -198,6 +200,11 @@ class WebGpuContextFactory {
   static WebGpuContext& GetContext(int context_id);
 
   /// <summary>
+  /// Retain an existing WebGPU context. (ref-count based)
+  /// </summary>
+  static void RetainContext(int context_id);
+
+  /// <summary>
   /// Release the WebGPU context. (ref-count based)
   /// </summary>
   static void ReleaseContext(int context_id);
@@ -274,29 +281,20 @@ class WebGpuContext final {
       recording.compute_pass_encoder = nullptr;
     }
   }
-  void CaptureBegin(std::vector<webgpu::CapturedCommandInfo>* captured_commands, const webgpu::BufferManager& buffer_manager);
-  void CaptureEnd(const webgpu::BufferManager& buffer_manager);
-  void Replay(const std::vector<webgpu::CapturedCommandInfo>& captured_commands, const webgpu::BufferManager& buffer_manager);
+  void CaptureBegin(std::vector<webgpu::CapturedCommandInfo>* captured_commands,
+                    const webgpu::BufferManager& buffer_manager,
+                    CommandRecordingState& recording);
+  void CaptureEnd(CommandRecordingState& recording);
+  void Replay(const std::vector<webgpu::CapturedCommandInfo>& captured_commands,
+              const webgpu::BufferManager& buffer_manager,
+              CommandRecordingState& recording);
   void ReleaseGraphResources(std::vector<webgpu::CapturedCommandInfo>& captured_commands);
 
-  Status Flush(const webgpu::BufferManager& buffer_mgr);
+  Status Flush(const webgpu::BufferManager& buffer_mgr, CommandRecordingState& recording);
 
-  /**
-   * Get the context-level buffer manager.
-   *
-   * This is NOT the manager sessions use - each WebGpuExecutionProvider owns its own (see
-   * WebGpuExecutionProvider::BufferManager). It exists for session-less plugin EP facilities
-   * such as the shared allocator and OrtWebGpuCreateDataTransfer, which have no EP to borrow one
-   * from.
-   */
+  // Context-level managers are shared by sessions and synchronize their buffer caches internally.
   webgpu::BufferManager& BufferManager() const { return *buffer_mgr_; }
-
-  /**
-   * The buffer cache configuration this context was initialized with. Exposed so that each
-   * session can create its own BufferManager with the same policy instead of sharing the
-   * context's caches across threads.
-   */
-  const WebGpuBufferCacheConfig& BufferCacheConfig() const { return buffer_cache_config_; }
+  webgpu::BufferManager& InitializerBufferManager() const { return *initializer_buffer_mgr_; }
 
   inline webgpu::ValidationMode ValidationMode() const {
     return validation_mode_;
@@ -380,7 +378,7 @@ class WebGpuContext final {
                                   const wgpu::BindGroupLayout& bind_group_layout,
                                   std::string_view label) const;
   void DispatchCommand(const webgpu::CapturedCommandInfo& command, CommandRecordingState& recording);
-  Status EncodeDeferredDispatches(const webgpu::BufferManager& buffer_mgr);
+  Status EncodeDeferredDispatches(CommandRecordingState& recording);
 
   std::vector<const char*> GetEnabledAdapterToggles() const;
   std::vector<const char*> GetEnabledDeviceToggles() const;
@@ -424,16 +422,9 @@ class WebGpuContext final {
   std::unordered_set<wgpu::FeatureName> device_features_;
   wgpu::AdapterPropertiesSubgroupMatrixConfigs subgroup_matrix_configs_;
 
-  // Recording state for buffer_mgr_ below. Sessions never touch it: each
-  // WebGpuExecutionProvider owns its own CommandRecordingState. This one exists only for the
-  // session-less plugin EP allocator and data transfer, whose operations are not covered by any
-  // session_mutex_.
-  CommandRecordingState default_recording_;
-
   std::unique_ptr<webgpu::BufferManager> buffer_mgr_;
+  std::unique_ptr<webgpu::BufferManager> initializer_buffer_mgr_;
   std::unique_ptr<ProgramManager> program_mgr_;
-
-  WebGpuBufferCacheConfig buffer_cache_config_{};
 
   uint32_t max_num_pending_dispatches_ = 16;
 

--- a/onnxruntime/core/providers/webgpu/webgpu_context.h
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.h
@@ -177,18 +177,17 @@ class WebGpuContext final {
   const wgpu::AdapterPropertiesSubgroupMatrixConfigs& SubgroupMatrixConfigs() const { return subgroup_matrix_configs_; }
 #endif
 
-  const wgpu::CommandEncoder& GetCommandEncoder() {
-    std::lock_guard<std::recursive_mutex> lock(context_mutex_);
-    if (!current_command_encoder_) {
-      current_command_encoder_ = device_.CreateCommandEncoder();
+  const wgpu::CommandEncoder& GetCommandEncoder(CommandRecordingState& recording) {
+    if (!recording.command_encoder) {
+      recording.command_encoder = device_.CreateCommandEncoder();
+      recording.has_unsubmitted_work.store(true, std::memory_order_release);
     }
-    return current_command_encoder_;
+    return recording.command_encoder;
   }
 
-  const wgpu::ComputePassEncoder& GetComputePassEncoder() {
-    std::lock_guard<std::recursive_mutex> lock(context_mutex_);
-    if (!current_compute_pass_encoder_) {
-      auto& command_encoder = GetCommandEncoder();
+  const wgpu::ComputePassEncoder& GetComputePassEncoder(CommandRecordingState& recording) {
+    if (!recording.compute_pass_encoder) {
+      auto& command_encoder = GetCommandEncoder(recording);
 
       wgpu::ComputePassDescriptor compute_pass_desc{};
 
@@ -196,34 +195,22 @@ class WebGpuContext final {
         wgpu::PassTimestampWrites timestampWrites = {
             nullptr,
             query_set_,
-            num_pending_dispatches_ * 2,
-            num_pending_dispatches_ * 2 + 1};
+            recording.num_pending_dispatches * 2,
+            recording.num_pending_dispatches * 2 + 1};
         compute_pass_desc.timestampWrites = &timestampWrites;
       }
 
-      current_compute_pass_encoder_ = command_encoder.BeginComputePass(&compute_pass_desc);
+      recording.compute_pass_encoder = command_encoder.BeginComputePass(&compute_pass_desc);
     }
-    return current_compute_pass_encoder_;
+    return recording.compute_pass_encoder;
   }
 
-  void EndComputePass() {
-    std::lock_guard<std::recursive_mutex> lock(context_mutex_);
-    if (current_compute_pass_encoder_) {
-      current_compute_pass_encoder_.End();
-      current_compute_pass_encoder_ = nullptr;
+  void EndComputePass(CommandRecordingState& recording) {
+    if (recording.compute_pass_encoder) {
+      recording.compute_pass_encoder.End();
+      recording.compute_pass_encoder = nullptr;
     }
   }
-
-  // Acquire the shared-context lock for the duration of a compound sequence that records into
-  // and/or submits the shared command encoder, or that allocates/frees GPU buffers from the
-  // context's shared BufferManager caches (e.g. BufferManager::Upload/MemCpy/Download/Create/
-  // Release and ComputeContext::FillZero). The caller holds the returned lock so that the
-  // individual GetCommandEncoder / EndComputePass / Flush / cache calls in that sequence execute
-  // atomically with respect to other InferenceSessions that share this context.
-  [[nodiscard]] std::unique_lock<std::recursive_mutex> AcquireContextLock() {
-    return std::unique_lock<std::recursive_mutex>(context_mutex_);
-  }
-
   void CaptureBegin(std::vector<webgpu::CapturedCommandInfo>* captured_commands, const webgpu::BufferManager& buffer_manager);
   void CaptureEnd();
   void Replay(const std::vector<webgpu::CapturedCommandInfo>& captured_commands, const webgpu::BufferManager& buffer_manager);
@@ -232,16 +219,29 @@ class WebGpuContext final {
   void Flush(const webgpu::BufferManager& buffer_mgr);
 
   /**
-   * Get the buffer manager.
+   * Get the context-level buffer manager.
+   *
+   * This is NOT the manager sessions use - each WebGpuExecutionProvider owns its own (see
+   * WebGpuExecutionProvider::BufferManager). It exists solely for the session-less shared
+   * data transfer created by OrtWebGpuCreateDataTransfer, which has no EP to borrow one from.
    */
   webgpu::BufferManager& BufferManager() const { return *buffer_mgr_; }
 
   /**
-   * Get the initializer buffer manager.
-   *
-   * This buffer manager is used for read-only buffers (e.g. initializers).
+   * The buffer cache configuration this context was initialized with. Exposed so that each
+   * session can create its own BufferManager with the same policy instead of sharing the
+   * context's caches across threads.
    */
-  webgpu::BufferManager& InitializerBufferManager() const { return *initializer_buffer_mgr_; }
+  const WebGpuBufferCacheConfig& BufferCacheConfig() const { return buffer_cache_config_; }
+
+  /**
+   * Free-buffer pools shared by all sessions on this context. Sessions keep their own
+   * BufferManager (and their own "released but not yet submitted" lists), but hand freed buffers
+   * back here so that steady-state GPU memory stays at one session's high-water mark instead of
+   * scaling with the number of live sessions.
+   */
+  webgpu::SharedBufferPool& SharedStorageBufferPool() const { return *shared_storage_pool_; }
+  webgpu::SharedBufferPool& SharedUniformBufferPool() const { return *shared_uniform_pool_; }
 
   inline webgpu::ValidationMode ValidationMode() const {
     return validation_mode_;
@@ -328,7 +328,7 @@ class WebGpuContext final {
   std::vector<const char*> GetDisabledDeviceToggles() const;
   std::vector<wgpu::FeatureName> GetAvailableRequiredFeatures(const wgpu::Adapter& adapter) const;
   wgpu::Limits GetRequiredLimits(const wgpu::Adapter& adapter) const;
-  void WriteTimestamp(uint32_t query_index);
+  void WriteTimestamp(CommandRecordingState& recording, uint32_t query_index);
 
   struct PendingQueryInfo {
     PendingQueryInfo(std::vector<PendingKernelInfo>&& kernels, wgpu::Buffer query_buffer)
@@ -360,25 +360,21 @@ class WebGpuContext final {
   wgpu::AdapterPropertiesSubgroupMatrixConfigs subgroup_matrix_configs_;
 #endif
 
-  wgpu::CommandEncoder current_command_encoder_;
-  wgpu::ComputePassEncoder current_compute_pass_encoder_;
+  // Declared before every BufferManager so that the pools outlive the cache managers holding
+  // references to them (members are destroyed in reverse declaration order).
+  std::unique_ptr<webgpu::SharedBufferPool> shared_storage_pool_;
+  std::unique_ptr<webgpu::SharedBufferPool> shared_uniform_pool_;
 
-  // Serializes all mutations of shared per-context state: the command encoder / compute pass /
-  // pending-dispatch counters AND the shared BufferManager cache maps (Create/Release/refresh).
-  // Multiple InferenceSessions can share a single context (e.g. the default context_id=0), and
-  // InferenceSession only serializes a single session's Run via its own session_mutex_. Without
-  // this lock, concurrent Run / allocation / initializer-upload from different sessions race on
-  // the single shared command encoder and buffer caches, producing Dawn "CommandEncoder is
-  // already finished" errors, corrupted buffer caches, and device-lost failures. Recursive
-  // because the guarded compound operations (Run, Flush, Replay, CaptureBegin, and the buffer
-  // Upload/MemCpy/Download/Create/Release / FillZero sequences) nest calls into each other.
-  std::recursive_mutex context_mutex_;
+  // Recording state for buffer_mgr_ below. Sessions never touch it: each
+  // WebGpuExecutionProvider owns its own CommandRecordingState. This one exists only for the
+  // session-less shared data transfer, whose copies are not covered by any session_mutex_.
+  CommandRecordingState default_recording_;
 
   std::unique_ptr<webgpu::BufferManager> buffer_mgr_;
-  std::unique_ptr<webgpu::BufferManager> initializer_buffer_mgr_;
   std::unique_ptr<ProgramManager> program_mgr_;
 
-  uint32_t num_pending_dispatches_ = 0;
+  WebGpuBufferCacheConfig buffer_cache_config_{};
+
   uint32_t max_num_pending_dispatches_ = 16;
 
   std::unique_ptr<SplitKConfig> split_k_config_;

--- a/onnxruntime/core/providers/webgpu/webgpu_context.h
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.h
@@ -180,7 +180,7 @@ class WebGpuContext final {
   const wgpu::CommandEncoder& GetCommandEncoder(CommandRecordingState& recording) {
     if (!recording.command_encoder) {
       recording.command_encoder = device_.CreateCommandEncoder();
-      recording.has_unsubmitted_work.store(true, std::memory_order_release);
+      recording.has_unsubmitted_work = true;
     }
     return recording.command_encoder;
   }

--- a/onnxruntime/core/providers/webgpu/webgpu_context.h
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.h
@@ -292,8 +292,16 @@ class WebGpuContext final {
 
   Status Flush(const webgpu::BufferManager& buffer_mgr, CommandRecordingState& recording);
 
-  // Context-level managers are shared by sessions and synchronize their buffer caches internally.
+  /**
+   * Get the buffer manager.
+   */
   webgpu::BufferManager& BufferManager() const { return *buffer_mgr_; }
+
+  /**
+   * Get the initializer buffer manager.
+   *
+   * This buffer manager is used for read-only buffers (e.g. initializers).
+   */
   webgpu::BufferManager& InitializerBufferManager() const { return *initializer_buffer_mgr_; }
 
   inline webgpu::ValidationMode ValidationMode() const {

--- a/onnxruntime/core/providers/webgpu/webgpu_context.h
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.h
@@ -83,7 +83,7 @@ struct PendingPipelineBuild {
 //    This command owns the asynchronous build for its program key.
 //
 // 3. Later cache miss for the same key  empty            empty
-//    An earlier command in deferred_dispatches_ owns the build. This command keeps program_key so
+//    An earlier command in the same recording owns the build. This command keeps program_key so
 //    pipeline resolution can obtain the completed pipeline from the program cache.
 //
 // 4. Deferred pipeline resolved         empty             set
@@ -117,9 +117,12 @@ struct CommandRecordingState {
   uint32_t num_pending_dispatches = 0;
   bool has_unsubmitted_work = false;
   std::vector<wgpu::Buffer> pending_buffers;
+  // Owns the active dispatch window and the unique pending builds referenced within that window.
   std::vector<CapturedCommandInfo> deferred_dispatches;
+  // info of kernels pending submission for a single batch
   std::vector<PendingKernelInfo> pending_kernels;
   GraphCaptureState graph_capture_state{GraphCaptureState::Default};
+  // External vector to store captured commands, owned by EP
   std::vector<CapturedCommandInfo>* external_captured_commands = nullptr;
 };
 

--- a/onnxruntime/core/providers/webgpu/webgpu_context.h
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.h
@@ -307,6 +307,9 @@ class WebGpuContext final {
    */
   webgpu::BufferManager& InitializerBufferManager() const { return *initializer_buffer_mgr_; }
 
+  // Env allocators and transfers share this state; callers serialize all Env operations on this context.
+  CommandRecordingState& EnvironmentRecording() { return environment_recording_; }
+
   inline webgpu::ValidationMode ValidationMode() const {
     return validation_mode_;
   }
@@ -436,6 +439,7 @@ class WebGpuContext final {
   std::unique_ptr<webgpu::BufferManager> buffer_mgr_;
   std::unique_ptr<webgpu::BufferManager> initializer_buffer_mgr_;
   std::unique_ptr<ProgramManager> program_mgr_;
+  CommandRecordingState environment_recording_;
 
   uint32_t max_num_pending_dispatches_ = 16;
 

--- a/onnxruntime/core/providers/webgpu/webgpu_context.h
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.h
@@ -109,9 +109,9 @@ struct CapturedCommandInfo {
 };
 
 // State for one session's command recording timeline. WebGpuContext is shared across sessions,
-// but Dawn command encoders and deferred dispatch windows must not be.
+// but Dawn command encoders and deferred dispatch windows must not be. Callers must serialize
+// access to a session's recording, including external allocation, copy, and graph replay operations.
 struct CommandRecordingState {
-  std::recursive_mutex mutex;
   wgpu::CommandEncoder command_encoder;
   wgpu::ComputePassEncoder compute_pass_encoder;
   uint32_t num_pending_dispatches = 0;

--- a/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
@@ -605,22 +605,10 @@ WebGpuExecutionProvider::WebGpuExecutionProvider(int context_id,
       multi_rotary_cache_concat_offset_{config.multi_rotary_cache_concat_offset},
       kv_cache_quantization_bits_{config.kv_cache_quantization_bits},
       recording_{std::make_unique<webgpu::CommandRecordingState>()},
-      session_buffer_mgr_{webgpu::BufferManagerFactory::Create(context_,
-                                                               *recording_,
-                                                               context_.BufferCacheConfig().storage.mode,
-                                                               context_.BufferCacheConfig().uniform.mode,
-                                                               context_.BufferCacheConfig().query_resolve.mode,
-                                                               context_.BufferCacheConfig().default_entry.mode)},
-      session_initializer_buffer_mgr_{webgpu::BufferManagerFactory::Create(
-          context_,
-          *recording_,
-          webgpu::BufferCacheMode::LazyRelease,
-          webgpu::BufferCacheMode::LazyRelease,
-          webgpu::BufferCacheMode::Disabled,
-          webgpu::BufferCacheMode::Disabled)},
       prepack_allocator_{CreateWebGpuAllocator(
           /*device_free=*/!context.HasDevice(),
-          [this]() -> const webgpu::BufferManager& { return InitializerBufferManager(); }, false)} {
+          [this]() -> const webgpu::BufferManager& { return InitializerBufferManager(); },
+          [this]() -> webgpu::CommandRecordingState& { return Recording(); }, false)} {
   if (enable_graph_capture_ && config.session_buffer_pool_generations > 0) {
     session_buffer_pool_ = std::make_unique<webgpu::SessionBufferPool>(
         config.session_buffer_pool_generations);
@@ -633,6 +621,8 @@ WebGpuExecutionProvider::WebGpuExecutionProvider(int context_id,
     ORT_THROW("Support PIX capture requires extra build flags (--enable_pix_capture)");
 #endif  // ENABLE_PIX_FOR_WEBGPU_EP
   }
+
+  WebGpuContextFactory::RetainContext(context_id_);
 }
 
 std::vector<AllocatorPtr> WebGpuExecutionProvider::CreatePreferredAllocators() {
@@ -641,11 +631,14 @@ std::vector<AllocatorPtr> WebGpuExecutionProvider::CreatePreferredAllocators() {
       // allocator for initializers
       CreateWebGpuAllocator(
           device_free,
-          [this]() -> const webgpu::BufferManager& { return InitializerBufferManager(); }, true),
+          [this]() -> const webgpu::BufferManager& { return InitializerBufferManager(); },
+          [this]() -> webgpu::CommandRecordingState& { return Recording(); }, true),
       // default allocator
       CreateWebGpuAllocator(
           device_free,
-          [this]() -> const webgpu::BufferManager& { return BufferManager(); }, false,
+          [this]() -> const webgpu::BufferManager& { return BufferManager(); },
+          [this]() -> webgpu::CommandRecordingState& { return Recording(); },
+          false,
           [this]() { return !IsRunActive(); }),
   };
 }
@@ -754,7 +747,7 @@ std::vector<std::unique_ptr<ComputeCapability>> WebGpuExecutionProvider::GetCapa
 #endif  // !defined(ORT_USE_EP_API_ADAPTERS)
 
 std::unique_ptr<onnxruntime::IDataTransfer> WebGpuExecutionProvider::GetDataTransfer() const {
-  return std::make_unique<webgpu::DataTransfer>(BufferManager());
+  return std::make_unique<webgpu::DataTransfer>(BufferManager(), Recording());
 }
 
 #if defined(__wasm__)
@@ -808,6 +801,13 @@ WebGpuExecutionProvider::~WebGpuExecutionProvider() {
     session_buffer_pool_->Clear();
   }
 
+  prepack_allocator_.reset();
+  session_buffer_pool_.reset();
+  recording_.reset();
+#if defined(ENABLE_PIX_FOR_WEBGPU_EP)
+  pix_frame_generator_.reset();
+#endif
+
   WebGpuContextFactory::ReleaseContext(context_id_);
 }
 
@@ -851,7 +851,6 @@ Status WebGpuExecutionProvider::OnRunStart(const onnxruntime::RunOptions& run_op
       if (inserted) {
         it->second = webgpu::BufferManagerFactory::Create(
             context_,
-            *recording_,
             webgpu::BufferCacheMode::Graph,
             webgpu::BufferCacheMode::GraphSimple,
             webgpu::BufferCacheMode::Disabled,
@@ -864,7 +863,7 @@ Status WebGpuExecutionProvider::OnRunStart(const onnxruntime::RunOptions& run_op
 
       if (IsGraphCaptureAllowed() && !IsGraphCaptured(graph_annotation_id)) {
         auto& commands = captured_graphs_[graph_annotation_id];
-        context_.CaptureBegin(&commands, *it->second);
+        context_.CaptureBegin(&commands, *it->second, *recording_);
       }
     }
   }
@@ -874,15 +873,13 @@ Status WebGpuExecutionProvider::OnRunStart(const onnxruntime::RunOptions& run_op
 }
 
 Status WebGpuExecutionProvider::OnRunEnd(bool /* sync_stream */, const onnxruntime::RunOptions& run_options) {
-  run_active_.store(false);
-
   // When capturing, flushing creates the replay-ready CapturedCommandInfo entries before
   // CaptureEnd() detaches their external storage.
-  Status flush_status = context_.Flush(BufferManager());
+  Status flush_status = context_.Flush(BufferManager(), *recording_);
 
   if (!flush_status.IsOK()) {
     if (IsGraphCaptureEnabled()) {
-      context_.CaptureEnd(BufferManager());
+      context_.CaptureEnd(*recording_);
       auto commands_it = captured_graphs_.find(current_graph_annotation_id_);
       if (commands_it != captured_graphs_.end()) {
         context_.ReleaseGraphResources(commands_it->second);
@@ -893,12 +890,13 @@ Status WebGpuExecutionProvider::OnRunEnd(bool /* sync_stream */, const onnxrunti
     if (context_.ValidationMode() >= ValidationMode::Basic) {
       static_cast<void>(context_.PopErrorScope());
     }
+    run_active_.store(false);
     return flush_status;
   }
 
   if (IsGraphCaptureEnabled() && !IsGraphCaptured(current_graph_annotation_id_)) {
     if (current_graph_annotation_id_ != -1 && IsGraphCaptureAllowed()) {
-      context_.CaptureEnd(BufferManager());
+      context_.CaptureEnd(*recording_);
       captured_graph_ids_.insert(current_graph_annotation_id_);
       ORT_RETURN_IF_ERROR(ReplayGraph(current_graph_annotation_id_));
     } else {
@@ -922,6 +920,7 @@ Status WebGpuExecutionProvider::OnRunEnd(bool /* sync_stream */, const onnxrunti
 
   // Reset buffer manager routing after run completes
   graph_buffer_mgr_active_ = false;
+  run_active_.store(false);
 
   if (context_.ValidationMode() >= ValidationMode::Basic) {
     return context_.PopErrorScope();
@@ -945,7 +944,9 @@ Status WebGpuExecutionProvider::ReplayGraph(int graph_annotation_id, bool /*sync
   if (session_profiler_ && session_profiler_->Enabled()) {
     context_.StartProfiling();
   }
-  context_.Replay(captured_graphs_.at(graph_annotation_id), *per_graph_buffer_mgrs_.at(graph_annotation_id));
+  context_.Replay(captured_graphs_.at(graph_annotation_id),
+                  *per_graph_buffer_mgrs_.at(graph_annotation_id),
+                  *recording_);
   if (session_profiler_ && session_profiler_->Enabled()) {
     // Session-level profiling: collect into profiler's own events storage.
     context_.CollectProfilingData(session_profiler_->GpuEvents());
@@ -988,7 +989,11 @@ webgpu::BufferManager& WebGpuExecutionProvider::BufferManager() const {
       return *it->second;
     }
   }
-  return *session_buffer_mgr_;
+  return context_.BufferManager();
+}
+
+webgpu::BufferManager& WebGpuExecutionProvider::InitializerBufferManager() const {
+  return context_.InitializerBufferManager();
 }
 
 bool WebGpuExecutionProvider::IsGraphCaptureAllowed() const {

--- a/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
@@ -604,9 +604,23 @@ WebGpuExecutionProvider::WebGpuExecutionProvider(int context_id,
       enable_int64_{config.enable_graph_capture || config.enable_int64},
       multi_rotary_cache_concat_offset_{config.multi_rotary_cache_concat_offset},
       kv_cache_quantization_bits_{config.kv_cache_quantization_bits},
+      recording_{std::make_unique<webgpu::CommandRecordingState>()},
+      session_buffer_mgr_{webgpu::BufferManagerFactory::Create(context_,
+                                                               *recording_,
+                                                               context_.BufferCacheConfig().storage.mode,
+                                                               context_.BufferCacheConfig().uniform.mode,
+                                                               context_.BufferCacheConfig().query_resolve.mode,
+                                                               context_.BufferCacheConfig().default_entry.mode)},
+      session_initializer_buffer_mgr_{webgpu::BufferManagerFactory::Create(
+          context_,
+          *recording_,
+          webgpu::BufferCacheMode::LazyRelease,
+          webgpu::BufferCacheMode::LazyRelease,
+          webgpu::BufferCacheMode::Disabled,
+          webgpu::BufferCacheMode::Disabled)},
       prepack_allocator_{CreateWebGpuAllocator(
           /*device_free=*/!context.HasDevice(),
-          [this]() -> const webgpu::BufferManager& { return context_.InitializerBufferManager(); }, false)} {
+          [this]() -> const webgpu::BufferManager& { return InitializerBufferManager(); }, false)} {
   if (enable_graph_capture_ && config.session_buffer_pool_generations > 0) {
     session_buffer_pool_ = std::make_unique<webgpu::SessionBufferPool>(
         config.session_buffer_pool_generations);
@@ -627,7 +641,7 @@ std::vector<AllocatorPtr> WebGpuExecutionProvider::CreatePreferredAllocators() {
       // allocator for initializers
       CreateWebGpuAllocator(
           device_free,
-          [this]() -> const webgpu::BufferManager& { return context_.InitializerBufferManager(); }, true),
+          [this]() -> const webgpu::BufferManager& { return InitializerBufferManager(); }, true),
       // default allocator
       CreateWebGpuAllocator(
           device_free,
@@ -837,6 +851,7 @@ Status WebGpuExecutionProvider::OnRunStart(const onnxruntime::RunOptions& run_op
       if (inserted) {
         it->second = webgpu::BufferManagerFactory::Create(
             context_,
+            *recording_,
             webgpu::BufferCacheMode::Graph,
             webgpu::BufferCacheMode::GraphSimple,
             webgpu::BufferCacheMode::Disabled,
@@ -867,7 +882,7 @@ Status WebGpuExecutionProvider::OnRunEnd(bool /* sync_stream */, const onnxrunti
 
   if (!flush_status.IsOK()) {
     if (IsGraphCaptureEnabled()) {
-      context_.CaptureEnd();
+      context_.CaptureEnd(BufferManager());
       auto commands_it = captured_graphs_.find(current_graph_annotation_id_);
       if (commands_it != captured_graphs_.end()) {
         context_.ReleaseGraphResources(commands_it->second);
@@ -883,7 +898,7 @@ Status WebGpuExecutionProvider::OnRunEnd(bool /* sync_stream */, const onnxrunti
 
   if (IsGraphCaptureEnabled() && !IsGraphCaptured(current_graph_annotation_id_)) {
     if (current_graph_annotation_id_ != -1 && IsGraphCaptureAllowed()) {
-      context_.CaptureEnd();
+      context_.CaptureEnd(BufferManager());
       captured_graph_ids_.insert(current_graph_annotation_id_);
       ORT_RETURN_IF_ERROR(ReplayGraph(current_graph_annotation_id_));
     } else {
@@ -973,7 +988,7 @@ webgpu::BufferManager& WebGpuExecutionProvider::BufferManager() const {
       return *it->second;
     }
   }
-  return context_.BufferManager();
+  return *session_buffer_mgr_;
 }
 
 bool WebGpuExecutionProvider::IsGraphCaptureAllowed() const {

--- a/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
@@ -604,7 +604,22 @@ WebGpuExecutionProvider::WebGpuExecutionProvider(int context_id,
       multi_rotary_cache_concat_offset_{config.multi_rotary_cache_concat_offset},
       kv_cache_quantization_bits_{config.kv_cache_quantization_bits},
       prepack_allocator_{std::make_shared<webgpu::GpuBufferAllocator>(
-          [this]() -> const webgpu::BufferManager& { return context_.InitializerBufferManager(); }, false)} {
+          [this]() -> const webgpu::BufferManager& { return InitializerBufferManager(); }, false)} {
+  // Give this session its own buffer caches and command recording state instead of sharing the
+  // context's. See the comments on recording_ / session_buffer_mgr_ in the header.
+  const auto& cache_config = context_.BufferCacheConfig();
+  session_buffer_mgr_ = webgpu::BufferManagerFactory::Create(context_,
+                                                             recording_,
+                                                             cache_config.storage.mode,
+                                                             cache_config.uniform.mode,
+                                                             cache_config.query_resolve.mode,
+                                                             cache_config.default_entry.mode);
+  session_initializer_buffer_mgr_ = webgpu::BufferManagerFactory::Create(context_,
+                                                                         recording_,
+                                                                         webgpu::BufferCacheMode::LazyRelease,
+                                                                         webgpu::BufferCacheMode::LazyRelease,
+                                                                         webgpu::BufferCacheMode::Disabled,
+                                                                         webgpu::BufferCacheMode::Disabled);
   if (enable_graph_capture_ && config.session_buffer_pool_generations > 0) {
     session_buffer_pool_ = std::make_unique<webgpu::SessionBufferPool>(
         config.session_buffer_pool_generations);
@@ -625,7 +640,7 @@ std::vector<AllocatorPtr> WebGpuExecutionProvider::CreatePreferredAllocators() {
   return {
       // allocator for initializers
       std::make_unique<webgpu::GpuBufferAllocator>(
-          [this]() -> const webgpu::BufferManager& { return context_.InitializerBufferManager(); }, true),
+          [this]() -> const webgpu::BufferManager& { return InitializerBufferManager(); }, true),
       // default allocator
       std::move(device_allocator),
   };
@@ -832,6 +847,7 @@ Status WebGpuExecutionProvider::OnRunStart(const onnxruntime::RunOptions& run_op
       if (inserted) {
         it->second = webgpu::BufferManagerFactory::Create(
             context_,
+            recording_,
             webgpu::BufferCacheMode::Graph,
             webgpu::BufferCacheMode::GraphSimple,
             webgpu::BufferCacheMode::Disabled,
@@ -947,7 +963,7 @@ webgpu::BufferManager& WebGpuExecutionProvider::BufferManager() const {
       return *it->second;
     }
   }
-  return context_.BufferManager();
+  return *session_buffer_mgr_;
 }
 
 bool WebGpuExecutionProvider::IsGraphCaptureAllowed() const {

--- a/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
@@ -801,8 +801,6 @@ WebGpuExecutionProvider::~WebGpuExecutionProvider() {
     session_buffer_pool_->Clear();
   }
 
-  prepack_allocator_.reset();
-  session_buffer_pool_.reset();
   recording_.reset();
 #if defined(ENABLE_PIX_FOR_WEBGPU_EP)
   pix_frame_generator_.reset();

--- a/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
@@ -60,7 +60,9 @@ class Memcpy final : public OpKernel {
   Status Compute(OpKernelContext* ctx) const override {
     const auto* X = ctx->Input<Tensor>(0);
     Tensor* Y = ctx->Output(0, X->Shape());
-    return Info().GetDataTransferManager().CopyTensor(*X, *Y);
+    const auto& ep = *static_cast<const WebGpuExecutionProvider*>(Info().GetExecutionProvider());
+    DataTransfer transfer(ep.BufferManager(), ep.Recording());
+    return transfer.CopyTensor(*X, *Y);
   }
 };
 

--- a/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
@@ -60,9 +60,7 @@ class Memcpy final : public OpKernel {
   Status Compute(OpKernelContext* ctx) const override {
     const auto* X = ctx->Input<Tensor>(0);
     Tensor* Y = ctx->Output(0, X->Shape());
-    const auto& ep = *static_cast<const WebGpuExecutionProvider*>(Info().GetExecutionProvider());
-    DataTransfer transfer(ep.BufferManager(), ep.Recording());
-    return transfer.CopyTensor(*X, *Y);
+    return Info().GetDataTransferManager().CopyTensor(*X, *Y);
   }
 };
 
@@ -609,7 +607,7 @@ WebGpuExecutionProvider::WebGpuExecutionProvider(int context_id,
       recording_{std::make_unique<webgpu::CommandRecordingState>()},
       prepack_allocator_{CreateWebGpuAllocator(
           /*device_free=*/!context.HasDevice(),
-          [this]() -> const webgpu::BufferManager& { return InitializerBufferManager(); },
+          [this]() -> const webgpu::BufferManager& { return context_.InitializerBufferManager(); },
           [this]() -> webgpu::CommandRecordingState& { return Recording(); }, false)} {
   if (enable_graph_capture_ && config.session_buffer_pool_generations > 0) {
     session_buffer_pool_ = std::make_unique<webgpu::SessionBufferPool>(
@@ -633,7 +631,7 @@ std::vector<AllocatorPtr> WebGpuExecutionProvider::CreatePreferredAllocators() {
       // allocator for initializers
       CreateWebGpuAllocator(
           device_free,
-          [this]() -> const webgpu::BufferManager& { return InitializerBufferManager(); },
+          [this]() -> const webgpu::BufferManager& { return context_.InitializerBufferManager(); },
           [this]() -> webgpu::CommandRecordingState& { return Recording(); }, true),
       // default allocator
       CreateWebGpuAllocator(
@@ -875,6 +873,8 @@ Status WebGpuExecutionProvider::OnRunStart(const onnxruntime::RunOptions& run_op
 }
 
 Status WebGpuExecutionProvider::OnRunEnd(bool /* sync_stream */, const onnxruntime::RunOptions& run_options) {
+  run_active_.store(false);
+
   // When capturing, flushing creates the replay-ready CapturedCommandInfo entries before
   // CaptureEnd() detaches their external storage.
   Status flush_status = context_.Flush(BufferManager(), *recording_);
@@ -892,7 +892,6 @@ Status WebGpuExecutionProvider::OnRunEnd(bool /* sync_stream */, const onnxrunti
     if (context_.ValidationMode() >= ValidationMode::Basic) {
       static_cast<void>(context_.PopErrorScope());
     }
-    run_active_.store(false);
     return flush_status;
   }
 
@@ -922,7 +921,6 @@ Status WebGpuExecutionProvider::OnRunEnd(bool /* sync_stream */, const onnxrunti
 
   // Reset buffer manager routing after run completes
   graph_buffer_mgr_active_ = false;
-  run_active_.store(false);
 
   if (context_.ValidationMode() >= ValidationMode::Basic) {
     return context_.PopErrorScope();
@@ -992,10 +990,6 @@ webgpu::BufferManager& WebGpuExecutionProvider::BufferManager() const {
     }
   }
   return context_.BufferManager();
-}
-
-webgpu::BufferManager& WebGpuExecutionProvider::InitializerBufferManager() const {
-  return context_.InitializerBufferManager();
 }
 
 bool WebGpuExecutionProvider::IsGraphCaptureAllowed() const {

--- a/onnxruntime/core/providers/webgpu/webgpu_execution_provider.h
+++ b/onnxruntime/core/providers/webgpu/webgpu_execution_provider.h
@@ -112,7 +112,8 @@ class WebGpuExecutionProvider : public IExecutionProvider {
     return OrtGraphCaptureNodeAssignmentPolicy_ALLOW_CPU_FOR_SHAPES;
   }
   webgpu::BufferManager& BufferManager() const;
-  webgpu::BufferManager& InitializerBufferManager() const { return *session_initializer_buffer_mgr_; }
+  webgpu::BufferManager& InitializerBufferManager() const;
+  webgpu::CommandRecordingState& Recording() const { return *recording_; }
   AllocatorPtr PrepackAllocator() const { return prepack_allocator_; }
   std::span<const std::string> GetForceCpuNodeNames() const { return force_cpu_node_names_; }
   uint32_t MultiRotaryCacheConcatOffset() const { return multi_rotary_cache_concat_offset_; }
@@ -152,24 +153,13 @@ class WebGpuExecutionProvider : public IExecutionProvider {
   std::unique_ptr<WebGpuPIXFrameGenerator> pix_frame_generator_ = nullptr;
 #endif  // ENABLE_PIX_FOR_WEBGPU_EP
 
-  // Command recording state for this session. The WebGpuContext is shared across sessions but
-  // command encoding is not thread-safe (Dawn's ImplicitDeviceSynchronization explicitly does
-  // not cover it), so the encoder / compute pass / pending-dispatch counter live here instead.
-  // InferenceSession serializes this session's Run and Initialize under session_mutex_ (the EP
-  // reports ConcurrentRunSupported() == false), so a single writer is guaranteed without locks.
-  // Declared before the buffer managers below, which hold a reference to it.
+  // Command recording is per session and is passed separately from the context-level BufferManagers.
   std::unique_ptr<webgpu::CommandRecordingState> recording_;
 
   // Per-graph buffer managers keyed by annotation ID.
   // Each captured graph gets its own buffer manager so that buffer caches
   // are isolated between different generators.
   std::unordered_map<int, std::unique_ptr<webgpu::BufferManager>> per_graph_buffer_mgrs_;
-
-  // Per-session buffer managers. The context's caches are plain STL containers, so sharing them
-  // across sessions running on different threads is a data race. Sessions only need to share the
-  // wgpu::Device (so buffers stay interoperable), not the caches in front of it.
-  std::unique_ptr<webgpu::BufferManager> session_buffer_mgr_;
-  std::unique_ptr<webgpu::BufferManager> session_initializer_buffer_mgr_;
 
   // Per-session pool of buffers donated by retired per-graph BufferManagers,
   // seeded into new per-graph BufferManagers to avoid device allocations for

--- a/onnxruntime/core/providers/webgpu/webgpu_execution_provider.h
+++ b/onnxruntime/core/providers/webgpu/webgpu_execution_provider.h
@@ -112,6 +112,7 @@ class WebGpuExecutionProvider : public IExecutionProvider {
     return OrtGraphCaptureNodeAssignmentPolicy_ALLOW_CPU_FOR_SHAPES;
   }
   webgpu::BufferManager& BufferManager() const;
+  webgpu::BufferManager& InitializerBufferManager() const { return *session_initializer_buffer_mgr_; }
   AllocatorPtr PrepackAllocator() const { return prepack_allocator_; }
   std::span<const std::string> GetForceCpuNodeNames() const { return force_cpu_node_names_; }
   uint32_t MultiRotaryCacheConcatOffset() const { return multi_rotary_cache_concat_offset_; }
@@ -151,10 +152,24 @@ class WebGpuExecutionProvider : public IExecutionProvider {
   std::unique_ptr<WebGpuPIXFrameGenerator> pix_frame_generator_ = nullptr;
 #endif  // ENABLE_PIX_FOR_WEBGPU_EP
 
+  // Command recording state for this session. The WebGpuContext is shared across sessions but
+  // command encoding is not thread-safe (Dawn's ImplicitDeviceSynchronization explicitly does
+  // not cover it), so the encoder / compute pass / pending-dispatch counter live here instead.
+  // InferenceSession serializes this session's Run and Initialize under session_mutex_ (the EP
+  // reports ConcurrentRunSupported() == false), so a single writer is guaranteed without locks.
+  // Declared before the buffer managers below, which hold a reference to it.
+  std::unique_ptr<webgpu::CommandRecordingState> recording_;
+
   // Per-graph buffer managers keyed by annotation ID.
   // Each captured graph gets its own buffer manager so that buffer caches
   // are isolated between different generators.
   std::unordered_map<int, std::unique_ptr<webgpu::BufferManager>> per_graph_buffer_mgrs_;
+
+  // Per-session buffer managers. The context's caches are plain STL containers, so sharing them
+  // across sessions running on different threads is a data race. Sessions only need to share the
+  // wgpu::Device (so buffers stay interoperable), not the caches in front of it.
+  std::unique_ptr<webgpu::BufferManager> session_buffer_mgr_;
+  std::unique_ptr<webgpu::BufferManager> session_initializer_buffer_mgr_;
 
   // Per-session pool of buffers donated by retired per-graph BufferManagers,
   // seeded into new per-graph BufferManagers to avoid device allocations for

--- a/onnxruntime/core/providers/webgpu/webgpu_execution_provider.h
+++ b/onnxruntime/core/providers/webgpu/webgpu_execution_provider.h
@@ -110,6 +110,7 @@ class WebGpuExecutionProvider : public IExecutionProvider {
     return OrtGraphCaptureNodeAssignmentPolicy_ALLOW_CPU_FOR_SHAPES;
   }
   webgpu::BufferManager& BufferManager() const;
+  webgpu::BufferManager& InitializerBufferManager() const { return *session_initializer_buffer_mgr_; }
   AllocatorPtr PrepackAllocator() const { return prepack_allocator_; }
   std::span<const std::string> GetForceCpuNodeNames() const { return force_cpu_node_names_; }
   uint32_t MultiRotaryCacheConcatOffset() const { return multi_rotary_cache_concat_offset_; }
@@ -152,6 +153,20 @@ class WebGpuExecutionProvider : public IExecutionProvider {
   // Each captured graph gets its own buffer manager so that buffer caches
   // are isolated between different generators.
   std::unordered_map<int, std::unique_ptr<webgpu::BufferManager>> per_graph_buffer_mgrs_;
+
+  // Command recording state for this session. The WebGpuContext is shared across sessions but
+  // command encoding is not thread-safe (Dawn's ImplicitDeviceSynchronization explicitly does
+  // not cover it), so the encoder / compute pass / pending-dispatch counter live here instead.
+  // InferenceSession serializes this session's Run and Initialize under session_mutex_ (the EP
+  // reports ConcurrentRunSupported() == false), so a single writer is guaranteed without locks.
+  // Declared before the buffer managers below, which hold a reference to it.
+  webgpu::CommandRecordingState recording_;
+
+  // Per-session buffer managers. The context's caches are plain STL containers, so sharing them
+  // across sessions running on different threads is a data race. Sessions only need to share the
+  // wgpu::Device (so buffers stay interoperable), not the caches in front of it.
+  std::unique_ptr<webgpu::BufferManager> session_buffer_mgr_;
+  std::unique_ptr<webgpu::BufferManager> session_initializer_buffer_mgr_;
 
   // Per-session pool of buffers donated by retired per-graph BufferManagers,
   // seeded into new per-graph BufferManagers to avoid device allocations for

--- a/onnxruntime/core/providers/webgpu/webgpu_execution_provider.h
+++ b/onnxruntime/core/providers/webgpu/webgpu_execution_provider.h
@@ -112,7 +112,6 @@ class WebGpuExecutionProvider : public IExecutionProvider {
     return OrtGraphCaptureNodeAssignmentPolicy_ALLOW_CPU_FOR_SHAPES;
   }
   webgpu::BufferManager& BufferManager() const;
-  webgpu::BufferManager& InitializerBufferManager() const;
   webgpu::CommandRecordingState& Recording() const { return *recording_; }
   AllocatorPtr PrepackAllocator() const { return prepack_allocator_; }
   std::span<const std::string> GetForceCpuNodeNames() const { return force_cpu_node_names_; }

--- a/onnxruntime/core/providers/webgpu/webgpu_kernel.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_kernel.cc
@@ -52,7 +52,7 @@ Status WebGpuKernel::PrePack(const Tensor& tensor, int input_idx, AllocatorPtr /
   if (s.IsOK() && is_packed) {
     // PrePack has no OnRunEnd hook, so finish its deferred pipeline builds and submit any encoded
     // GPU work before returning and allowing ORT to release the original initializer tensor.
-    s = webgpu_context_.Flush(ep_.InitializerBufferManager());
+    s = webgpu_context_.Flush(ep_.InitializerBufferManager(), ep_.Recording());
   }
 
   if (webgpu_context_.ValidationMode() >= ValidationMode::Full) {

--- a/onnxruntime/core/providers/webgpu/webgpu_kernel.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_kernel.cc
@@ -52,7 +52,7 @@ Status WebGpuKernel::PrePack(const Tensor& tensor, int input_idx, AllocatorPtr /
   if (s.IsOK() && is_packed) {
     // PrePack has no OnRunEnd hook, so finish its deferred pipeline builds and submit any encoded
     // GPU work before returning and allowing ORT to release the original initializer tensor.
-    s = webgpu_context_.Flush(webgpu_context_.InitializerBufferManager());
+    s = webgpu_context_.Flush(ep_.InitializerBufferManager());
   }
 
   if (webgpu_context_.ValidationMode() >= ValidationMode::Full) {

--- a/onnxruntime/core/providers/webgpu/webgpu_kernel.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_kernel.cc
@@ -52,7 +52,7 @@ Status WebGpuKernel::PrePack(const Tensor& tensor, int input_idx, AllocatorPtr /
   if (is_packed) {
     // Flush pending commands to ensure GPU buffer creations are completed.
     // This allows the initializer buffer manager to release temporary buffers and reduce memory usage.
-    webgpu_context_.Flush(webgpu_context_.InitializerBufferManager());
+    webgpu_context_.Flush(ep_.InitializerBufferManager());
   }
 
   if (webgpu_context_.ValidationMode() >= ValidationMode::Full) {

--- a/onnxruntime/core/providers/webgpu/webgpu_kernel.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_kernel.cc
@@ -52,7 +52,7 @@ Status WebGpuKernel::PrePack(const Tensor& tensor, int input_idx, AllocatorPtr /
   if (s.IsOK() && is_packed) {
     // PrePack has no OnRunEnd hook, so finish its deferred pipeline builds and submit any encoded
     // GPU work before returning and allowing ORT to release the original initializer tensor.
-    s = webgpu_context_.Flush(ep_.InitializerBufferManager(), ep_.Recording());
+    s = webgpu_context_.Flush(webgpu_context_.InitializerBufferManager(), ep_.Recording());
   }
 
   if (webgpu_context_.ValidationMode() >= ValidationMode::Full) {

--- a/onnxruntime/core/providers/webgpu/webgpu_provider_factory.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_provider_factory.cc
@@ -25,8 +25,12 @@ struct WebGpuProviderFactory : IExecutionProviderFactory {
       : context_id_{context_id}, context_{context}, config_{std::move(webgpu_ep_config)} {
   }
 
+  ~WebGpuProviderFactory() override {
+    WebGpuContextFactory::ReleaseContext(context_id_);
+  }
+
   std::unique_ptr<IExecutionProvider> CreateProvider() override {
-    return std::make_unique<WebGpuExecutionProvider>(context_id_, context_, std::move(config_));
+    return std::make_unique<WebGpuExecutionProvider>(context_id_, context_, WebGpuExecutionProviderConfig{config_});
   }
 
  private:
@@ -358,6 +362,7 @@ struct WebGpuDataTransferImpl : OrtDataTransferImpl {
   WebGpuDataTransferImpl(const OrtApi& ort_api_in, int context_id)
       : ort_api{ort_api_in},
         ep_api{*ort_api_in.GetEpApi()},
+        recording_{},
         data_transfer_{nullptr},
         context_id_{context_id},
         init_mutex_{} {
@@ -438,8 +443,7 @@ struct WebGpuDataTransferImpl : OrtDataTransferImpl {
       return nullptr;
     }
 
-    // Lazy initialization: Use double-checked locking to avoid unnecessary lock operations
-    if (impl.data_transfer_ == nullptr) {
+    {
       std::lock_guard<std::mutex> lock(impl.init_mutex_);
       if (impl.data_transfer_ == nullptr) {
         // Always create a new context with context_id 0
@@ -449,15 +453,10 @@ struct WebGpuDataTransferImpl : OrtDataTransferImpl {
 
         auto& context = WebGpuContextFactory::DefaultContext();
 
-        // Create the DataTransferImpl instance
-        // Note: The DataTransferImpl holds a const reference to BufferManager. The BufferManager's lifecycle
-        // is managed by the WebGpuContext, which is stored in a static WebGpuContextFactory and persists
-        // for the lifetime of the application, ensuring the reference remains valid.
-        impl.data_transfer_ = std::make_unique<DataTransferImpl>(context.BufferManager());
+        impl.data_transfer_ = std::make_unique<DataTransferImpl>(context.BufferManager(), impl.recording_);
       }
     }
 
-    // Now perform the actual tensor copy
     for (size_t idx = 0; idx < num_tensors; ++idx) {
 #if defined(ORT_USE_EP_API_ADAPTERS)
       Ort::ConstValue src_value{src_tensors[idx]};
@@ -478,11 +477,7 @@ struct WebGpuDataTransferImpl : OrtDataTransferImpl {
       void* dst_data = dst_tensor.MutableDataRaw();
       bool dst_is_gpu = dst_tensor.Location().device.Type() == OrtDevice::GPU;
 #endif
-      auto status = impl.data_transfer_->CopyTensor(src_data,
-                                                    src_is_gpu,
-                                                    dst_data,
-                                                    dst_is_gpu,
-                                                    size);
+      auto status = impl.data_transfer_->CopyTensor(src_data, src_is_gpu, dst_data, dst_is_gpu, size);
       if (!status.IsOK()) {
         return OrtApis::CreateStatus(ORT_RUNTIME_EXCEPTION, status.ErrorMessage().c_str());
       }
@@ -507,6 +502,7 @@ struct WebGpuDataTransferImpl : OrtDataTransferImpl {
 
   const OrtApi& ort_api;
   const OrtEpApi& ep_api;
+  CommandRecordingState recording_;
   std::unique_ptr<DataTransferImpl> data_transfer_;  // Lazy-initialized
   int context_id_;                                   // Track which context we're using
   std::mutex init_mutex_;                            // Protects lazy initialization

--- a/onnxruntime/core/providers/webgpu/webgpu_provider_factory.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_provider_factory.cc
@@ -456,11 +456,6 @@ struct WebGpuDataTransferImpl : OrtDataTransferImpl {
       }
     });
 
-    CommandRecordingState environment_recording;
-    auto& recording = impl.ep_ ? impl.ep_->Recording() : environment_recording;
-    auto& buffer_manager = impl.ep_ ? impl.ep_->BufferManager() : impl.context_->BufferManager();
-    DataTransferImpl transfer(buffer_manager, recording);
-
     for (size_t idx = 0; idx < num_tensors; ++idx) {
 #if defined(ORT_USE_EP_API_ADAPTERS)
       Ort::ConstValue src_value{src_tensors[idx]};
@@ -481,12 +476,17 @@ struct WebGpuDataTransferImpl : OrtDataTransferImpl {
       void* dst_data = dst_tensor.MutableDataRaw();
       bool dst_is_gpu = dst_tensor.Location().device.Type() == OrtDevice::GPU;
 #endif
-      auto status = transfer.CopyTensor(src_data, src_is_gpu, dst_data, dst_is_gpu, size);
+      auto status = impl.ep_
+                        ? DataTransferImpl(impl.ep_->BufferManager(), impl.ep_->Recording())
+                              .CopyTensor(src_data, src_is_gpu, dst_data, dst_is_gpu, size)
+                        : CopyTensorWithLocalEncoder(*impl.context_, src_data, src_is_gpu, dst_data, dst_is_gpu, size);
       if (!status.IsOK()) {
         return OrtApis::CreateStatus(ORT_RUNTIME_EXCEPTION, status.ErrorMessage().c_str());
       }
     }
-    ORT_THROW_IF_ERROR(FlushAndWait(*impl.context_, buffer_manager, recording));
+    if (impl.ep_) {
+      ORT_THROW_IF_ERROR(FlushAndWait(*impl.context_, impl.ep_->BufferManager(), impl.ep_->Recording()));
+    }
     return nullptr;
   }
 

--- a/onnxruntime/core/providers/webgpu/webgpu_provider_factory.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_provider_factory.cc
@@ -435,7 +435,7 @@ struct WebGpuDataTransferImpl : OrtDataTransferImpl {
       OrtDataTransferImpl* this_ptr,
       const OrtValue** src_tensors,
       OrtValue** dst_tensors,
-      OrtSyncStream** /*streams*/,
+      OrtSyncStream** streams,
       size_t num_tensors) {
     auto& impl = *static_cast<WebGpuDataTransferImpl*>(this_ptr);
 
@@ -477,9 +477,30 @@ struct WebGpuDataTransferImpl : OrtDataTransferImpl {
       void* dst_data = dst_tensor.MutableDataRaw();
       bool dst_is_gpu = dst_tensor.Location().device.Type() == OrtDevice::GPU;
 #endif
+#if defined(ORT_USE_EP_API_ADAPTERS)
+      auto status = streams != nullptr && streams[idx] != nullptr
+                        ? CopyTensorOnWebGpuStream(streams[idx], src_data, src_is_gpu, dst_data, dst_is_gpu, size)
+                        : impl.data_transfer_->CopyTensor(src_data, src_is_gpu, dst_data, dst_is_gpu, size);
+#else
+      ORT_UNUSED_PARAMETER(streams);
       auto status = impl.data_transfer_->CopyTensor(src_data, src_is_gpu, dst_data, dst_is_gpu, size);
+#endif
       if (!status.IsOK()) {
         return OrtApis::CreateStatus(ORT_RUNTIME_EXCEPTION, status.ErrorMessage().c_str());
+      }
+      if (src_is_gpu && dst_is_gpu && (streams == nullptr || streams[idx] == nullptr)) {
+        auto& context = WebGpuContextFactory::GetContext(impl.context_id_);
+        std::lock_guard<std::recursive_mutex> lock{impl.recording_.mutex};
+        ORT_THROW_IF_ERROR(context.Flush(context.BufferManager(), impl.recording_));
+        wgpu::QueueWorkDoneStatus completion = wgpu::QueueWorkDoneStatus::Error;
+        auto future = context.Device().GetQueue().OnSubmittedWorkDone(
+            wgpu::CallbackMode::WaitAnyOnly,
+            [](wgpu::QueueWorkDoneStatus result, wgpu::StringView, wgpu::QueueWorkDoneStatus* completion) noexcept {
+              *completion = result;
+            },
+            &completion);
+        ORT_THROW_IF_ERROR(context.Wait(future));
+        ORT_ENFORCE(completion == wgpu::QueueWorkDoneStatus::Success, "WebGPU copy completion failed.");
       }
     }
     return nullptr;

--- a/onnxruntime/core/providers/webgpu/webgpu_provider_factory.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_provider_factory.cc
@@ -359,13 +359,11 @@ std::shared_ptr<IExecutionProviderFactory> WebGpuProviderFactoryCreator::Create(
 
 // WebGPU DataTransfer implementation wrapper for the C API with lazy initialization
 struct WebGpuDataTransferImpl : OrtDataTransferImpl {
-  WebGpuDataTransferImpl(const OrtApi& ort_api_in, int context_id)
+  WebGpuDataTransferImpl(const OrtApi& ort_api_in, int context_id, WebGpuExecutionProvider* ep)
       : ort_api{ort_api_in},
         ep_api{*ort_api_in.GetEpApi()},
-        recording_{},
-        data_transfer_{nullptr},
         context_id_{context_id},
-        init_mutex_{} {
+        ep_{ep} {
     ort_version_supported = ORT_API_VERSION;
     CanCopy = CanCopyImpl;          // OrtDataTransferImpl::CanCopy callback
     CopyTensors = CopyTensorsImpl;  // OrtDataTransferImpl::CopyTensors callback
@@ -443,19 +441,25 @@ struct WebGpuDataTransferImpl : OrtDataTransferImpl {
       return nullptr;
     }
 
-    {
-      std::lock_guard<std::mutex> lock(impl.init_mutex_);
-      if (impl.data_transfer_ == nullptr) {
-        // Always create a new context with context_id 0
-        if (impl.context_id_ != 0) {
-          return OrtApis::CreateStatus(ORT_RUNTIME_EXCEPTION, "Shared data transfer can only be created for the default device (0).");
-        }
-
-        auto& context = WebGpuContextFactory::DefaultContext();
-
-        impl.data_transfer_ = std::make_unique<DataTransferImpl>(context.BufferManager(), impl.recording_);
-      }
+    for (size_t idx = 0; idx < num_tensors; ++idx) {
+      ORT_ENFORCE(streams == nullptr || streams[idx] == nullptr, "WebGPU data transfers do not support stream overrides.");
     }
+
+    std::call_once(impl.context_init_, [&impl]() {
+      if (impl.ep_ != nullptr) {
+        auto& context = WebGpuContextFactory::GetContext(impl.context_id_);
+        WebGpuContextFactory::RetainContext(impl.context_id_);
+        impl.context_ = &context;
+      } else {
+        ORT_ENFORCE(impl.context_id_ == 0, "Environment data transfer only supports the default WebGPU device.");
+        impl.context_ = &WebGpuContextFactory::DefaultContext();
+      }
+    });
+
+    CommandRecordingState environment_recording;
+    auto& recording = impl.ep_ ? impl.ep_->Recording() : environment_recording;
+    auto& buffer_manager = impl.ep_ ? impl.ep_->BufferManager() : impl.context_->BufferManager();
+    DataTransferImpl transfer(buffer_manager, recording);
 
     for (size_t idx = 0; idx < num_tensors; ++idx) {
 #if defined(ORT_USE_EP_API_ADAPTERS)
@@ -477,32 +481,12 @@ struct WebGpuDataTransferImpl : OrtDataTransferImpl {
       void* dst_data = dst_tensor.MutableDataRaw();
       bool dst_is_gpu = dst_tensor.Location().device.Type() == OrtDevice::GPU;
 #endif
-#if defined(ORT_USE_EP_API_ADAPTERS)
-      auto status = streams != nullptr && streams[idx] != nullptr
-                        ? CopyTensorOnWebGpuStream(streams[idx], src_data, src_is_gpu, dst_data, dst_is_gpu, size)
-                        : impl.data_transfer_->CopyTensor(src_data, src_is_gpu, dst_data, dst_is_gpu, size);
-#else
-      ORT_UNUSED_PARAMETER(streams);
-      auto status = impl.data_transfer_->CopyTensor(src_data, src_is_gpu, dst_data, dst_is_gpu, size);
-#endif
+      auto status = transfer.CopyTensor(src_data, src_is_gpu, dst_data, dst_is_gpu, size);
       if (!status.IsOK()) {
         return OrtApis::CreateStatus(ORT_RUNTIME_EXCEPTION, status.ErrorMessage().c_str());
       }
-      if (src_is_gpu && dst_is_gpu && (streams == nullptr || streams[idx] == nullptr)) {
-        auto& context = WebGpuContextFactory::GetContext(impl.context_id_);
-        std::lock_guard<std::recursive_mutex> lock{impl.recording_.mutex};
-        ORT_THROW_IF_ERROR(context.Flush(context.BufferManager(), impl.recording_));
-        wgpu::QueueWorkDoneStatus completion = wgpu::QueueWorkDoneStatus::Error;
-        auto future = context.Device().GetQueue().OnSubmittedWorkDone(
-            wgpu::CallbackMode::WaitAnyOnly,
-            [](wgpu::QueueWorkDoneStatus result, wgpu::StringView, wgpu::QueueWorkDoneStatus* completion) noexcept {
-              *completion = result;
-            },
-            &completion);
-        ORT_THROW_IF_ERROR(context.Wait(future));
-        ORT_ENFORCE(completion == wgpu::QueueWorkDoneStatus::Success, "WebGPU copy completion failed.");
-      }
     }
+    ORT_THROW_IF_ERROR(FlushAndWait(*impl.context_, buffer_manager, recording));
     return nullptr;
   }
 
@@ -510,11 +494,7 @@ struct WebGpuDataTransferImpl : OrtDataTransferImpl {
       OrtDataTransferImpl* this_ptr) noexcept {
     auto* p_impl = static_cast<WebGpuDataTransferImpl*>(this_ptr);
     int context_id = p_impl->context_id_;
-    bool data_transfer_initialized = false;
-    {
-      std::lock_guard<std::mutex> lock(p_impl->init_mutex_);
-      data_transfer_initialized = (p_impl->data_transfer_ != nullptr);
-    }
+    const bool data_transfer_initialized = p_impl->context_ != nullptr;
     delete p_impl;
     if (data_transfer_initialized) {
       WebGpuContextFactory::ReleaseContext(context_id);
@@ -523,15 +503,15 @@ struct WebGpuDataTransferImpl : OrtDataTransferImpl {
 
   const OrtApi& ort_api;
   const OrtEpApi& ep_api;
-  CommandRecordingState recording_;
-  std::unique_ptr<DataTransferImpl> data_transfer_;  // Lazy-initialized
-  int context_id_;                                   // Track which context we're using
-  std::mutex init_mutex_;                            // Protects lazy initialization
+  const int context_id_;
+  WebGpuExecutionProvider* const ep_;
+  WebGpuContext* context_ = nullptr;
+  std::once_flag context_init_;
 };
 
-OrtDataTransferImpl* OrtWebGpuCreateDataTransfer(int context_id /* = 0 */) {
+OrtDataTransferImpl* OrtWebGpuCreateDataTransfer(int context_id, WebGpuExecutionProvider* ep) {
 #if defined(ORT_USE_EP_API_ADAPTERS)
-  return new WebGpuDataTransferImpl(onnxruntime::ep::Api().ort, context_id);
+  return new WebGpuDataTransferImpl(onnxruntime::ep::Api().ort, context_id, ep);
 #else
   // Validate API version is supported
   const OrtApi* api = OrtApis::GetApi(ORT_API_VERSION);
@@ -539,7 +519,7 @@ OrtDataTransferImpl* OrtWebGpuCreateDataTransfer(int context_id /* = 0 */) {
     // API version not supported - return nullptr to indicate failure
     return nullptr;
   }
-  return new WebGpuDataTransferImpl(*api, context_id);
+  return new WebGpuDataTransferImpl(*api, context_id, ep);
 #endif
 }
 

--- a/onnxruntime/core/providers/webgpu/webgpu_provider_factory.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_provider_factory.cc
@@ -3,6 +3,7 @@
 
 #include <charconv>
 #include <mutex>
+#include <optional>
 
 #include "core/framework/error_code_helper.h"
 #include "core/providers/webgpu/buffer_manager.h"
@@ -362,7 +363,9 @@ struct WebGpuDataTransferImpl : OrtDataTransferImpl {
   WebGpuDataTransferImpl(const OrtApi& ort_api_in, int context_id, WebGpuExecutionProvider* ep)
       : ort_api{ort_api_in},
         ep_api{*ort_api_in.GetEpApi()},
+        data_transfer_{nullptr},
         context_id_{context_id},
+        init_mutex_{},
         ep_{ep} {
     ort_version_supported = ORT_API_VERSION;
     CanCopy = CanCopyImpl;          // OrtDataTransferImpl::CanCopy callback
@@ -441,23 +444,32 @@ struct WebGpuDataTransferImpl : OrtDataTransferImpl {
       return nullptr;
     }
 
-    // Lazily acquire and retain the context once so concurrent copies cannot race initialization.
-    std::call_once(impl.context_init_, [&impl]() {
-      if (impl.ep_ != nullptr) {
-        auto& context = WebGpuContextFactory::GetContext(impl.context_id_);
-        WebGpuContextFactory::RetainContext(impl.context_id_);
-        impl.context_ = &context;
-      } else {
-        ORT_ENFORCE(impl.context_id_ == 0, "Environment data transfer only supports the default WebGPU device.");
-        impl.context_ = &WebGpuContextFactory::DefaultContext();
+    {
+      std::lock_guard<std::mutex> lock(impl.init_mutex_);
+      if (impl.context_ == nullptr) {
+        if (impl.ep_ != nullptr) {
+          auto& context = WebGpuContextFactory::GetContext(impl.context_id_);
+          WebGpuContextFactory::RetainContext(impl.context_id_);
+          impl.context_ = &context;
+        } else {
+          if (impl.context_id_ != 0) {
+            return OrtApis::CreateStatus(ORT_RUNTIME_EXCEPTION, "Shared data transfer can only be created for the default device (0).");
+          }
+          impl.context_ = &WebGpuContextFactory::DefaultContext();
+        }
       }
-    });
+      if (impl.ep_ == nullptr && impl.data_transfer_ == nullptr) {
+        impl.data_transfer_ = std::make_unique<DataTransferImpl>(impl.context_->BufferManager(),
+                                                                 impl.context_->EnvironmentRecording());
+      }
+    }
 
     auto& recording = impl.ep_ ? impl.ep_->Recording() : impl.context_->EnvironmentRecording();
     auto& buffer_manager = impl.ep_ ? impl.ep_->BufferManager() : impl.context_->BufferManager();
     // DataTransferImpl borrows its BufferManager. The retained context owns the Env manager and recording;
     // Session transfers also depend on the owning EP's lifetime for its selected manager and recording.
-    DataTransferImpl transfer(buffer_manager, recording);
+    std::optional<DataTransferImpl> session_transfer;
+    auto& transfer = impl.ep_ ? session_transfer.emplace(buffer_manager, recording) : *impl.data_transfer_;
 
     for (size_t idx = 0; idx < num_tensors; ++idx) {
 #if defined(ORT_USE_EP_API_ADAPTERS)
@@ -496,7 +508,11 @@ struct WebGpuDataTransferImpl : OrtDataTransferImpl {
       OrtDataTransferImpl* this_ptr) noexcept {
     auto* p_impl = static_cast<WebGpuDataTransferImpl*>(this_ptr);
     int context_id = p_impl->context_id_;
-    const bool data_transfer_initialized = p_impl->context_ != nullptr;
+    bool data_transfer_initialized = false;
+    {
+      std::lock_guard<std::mutex> lock(p_impl->init_mutex_);
+      data_transfer_initialized = (p_impl->context_ != nullptr);
+    }
     delete p_impl;
     if (data_transfer_initialized) {
       WebGpuContextFactory::ReleaseContext(context_id);
@@ -505,10 +521,11 @@ struct WebGpuDataTransferImpl : OrtDataTransferImpl {
 
   const OrtApi& ort_api;
   const OrtEpApi& ep_api;
-  const int context_id_;
+  std::unique_ptr<DataTransferImpl> data_transfer_;  // Lazy-initialized
+  int context_id_;                                   // Track which context we're using
+  std::mutex init_mutex_;                            // Protects lazy initialization
   WebGpuExecutionProvider* const ep_;
   WebGpuContext* context_ = nullptr;
-  std::once_flag context_init_;
 };
 
 OrtDataTransferImpl* OrtWebGpuCreateDataTransfer(int context_id, WebGpuExecutionProvider* ep) {

--- a/onnxruntime/core/providers/webgpu/webgpu_provider_factory.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_provider_factory.cc
@@ -3,7 +3,6 @@
 
 #include <charconv>
 #include <mutex>
-#include <optional>
 
 #include "core/framework/error_code_helper.h"
 #include "core/providers/webgpu/buffer_manager.h"
@@ -458,18 +457,16 @@ struct WebGpuDataTransferImpl : OrtDataTransferImpl {
           impl.context_ = &WebGpuContextFactory::DefaultContext();
         }
       }
-      if (impl.ep_ == nullptr && impl.data_transfer_ == nullptr) {
+      if (impl.data_transfer_ == nullptr) {
         impl.data_transfer_ = std::make_unique<DataTransferImpl>(impl.context_->BufferManager(),
-                                                                 impl.context_->EnvironmentRecording());
+                                                                 impl.ep_ ? impl.ep_->Recording() : impl.context_->EnvironmentRecording());
       }
     }
 
     auto& recording = impl.ep_ ? impl.ep_->Recording() : impl.context_->EnvironmentRecording();
     auto& buffer_manager = impl.ep_ ? impl.ep_->BufferManager() : impl.context_->BufferManager();
-    // DataTransferImpl borrows its BufferManager. The retained context owns the Env manager and recording;
-    // Session transfers also depend on the owning EP's lifetime for its selected manager and recording.
-    std::optional<DataTransferImpl> session_transfer;
-    auto& transfer = impl.ep_ ? session_transfer.emplace(buffer_manager, recording) : *impl.data_transfer_;
+    // DataTransferImpl borrows the context's BufferManager. The retained context owns the Env recording;
+    // Session transfers depend on the owning EP's lifetime for their recording.
 
     for (size_t idx = 0; idx < num_tensors; ++idx) {
 #if defined(ORT_USE_EP_API_ADAPTERS)
@@ -491,7 +488,7 @@ struct WebGpuDataTransferImpl : OrtDataTransferImpl {
       void* dst_data = dst_tensor.MutableDataRaw();
       bool dst_is_gpu = dst_tensor.Location().device.Type() == OrtDevice::GPU;
 #endif
-      auto status = transfer.CopyTensor(src_data, src_is_gpu, dst_data, dst_is_gpu, size);
+      auto status = impl.data_transfer_->CopyTensor(src_data, src_is_gpu, dst_data, dst_is_gpu, size);
       if (!status.IsOK()) {
         return OrtApis::CreateStatus(ORT_RUNTIME_EXCEPTION, status.ErrorMessage().c_str());
       }

--- a/onnxruntime/core/providers/webgpu/webgpu_provider_factory.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_provider_factory.cc
@@ -441,6 +441,7 @@ struct WebGpuDataTransferImpl : OrtDataTransferImpl {
       return nullptr;
     }
 
+    // Lazily acquire and retain the context once so concurrent copies cannot race initialization.
     std::call_once(impl.context_init_, [&impl]() {
       if (impl.ep_ != nullptr) {
         auto& context = WebGpuContextFactory::GetContext(impl.context_id_);
@@ -455,6 +456,8 @@ struct WebGpuDataTransferImpl : OrtDataTransferImpl {
     CommandRecordingState environment_recording;
     auto& recording = impl.ep_ ? impl.ep_->Recording() : environment_recording;
     auto& buffer_manager = impl.ep_ ? impl.ep_->BufferManager() : impl.context_->BufferManager();
+    // DataTransferImpl borrows its BufferManager. The retained context owns the Env manager;
+    // Session transfers also depend on the owning EP's lifetime for its selected manager and recording.
     DataTransferImpl transfer(buffer_manager, recording);
 
     for (size_t idx = 0; idx < num_tensors; ++idx) {
@@ -482,16 +485,11 @@ struct WebGpuDataTransferImpl : OrtDataTransferImpl {
         return OrtApis::CreateStatus(ORT_RUNTIME_EXCEPTION, status.ErrorMessage().c_str());
       }
     }
+    // Flush GPU-to-GPU copies, which BufferManager::MemCpy only records. CPU/GPU transfers already handle
+    // any required submission in BufferManager. This also submits copies before the local Env recording is destroyed.
+    // TODO: Only GPU-to-CPU downloads currently guarantee copy completion. Uploads and GPU-to-GPU copies
+    // only guarantee submission and may still be in flight on return; add completion guarantees for these paths.
     ORT_THROW_IF_ERROR(impl.context_->Flush(buffer_manager, recording));
-    wgpu::QueueWorkDoneStatus completion = wgpu::QueueWorkDoneStatus::Error;
-    auto future = impl.context_->Device().GetQueue().OnSubmittedWorkDone(
-        wgpu::CallbackMode::WaitAnyOnly,
-        [](wgpu::QueueWorkDoneStatus status, wgpu::StringView, wgpu::QueueWorkDoneStatus* result) noexcept {
-          *result = status;
-        },
-        &completion);
-    ORT_THROW_IF_ERROR(impl.context_->Wait(future));
-    ORT_ENFORCE(completion == wgpu::QueueWorkDoneStatus::Success, "WebGPU queue completion failed.");
     return nullptr;
   }
 

--- a/onnxruntime/core/providers/webgpu/webgpu_provider_factory.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_provider_factory.cc
@@ -433,16 +433,12 @@ struct WebGpuDataTransferImpl : OrtDataTransferImpl {
       OrtDataTransferImpl* this_ptr,
       const OrtValue** src_tensors,
       OrtValue** dst_tensors,
-      OrtSyncStream** streams,
+      OrtSyncStream** /*streams*/,
       size_t num_tensors) {
     auto& impl = *static_cast<WebGpuDataTransferImpl*>(this_ptr);
 
     if (num_tensors == 0) {
       return nullptr;
-    }
-
-    for (size_t idx = 0; idx < num_tensors; ++idx) {
-      ORT_ENFORCE(streams == nullptr || streams[idx] == nullptr, "WebGPU data transfers do not support stream overrides.");
     }
 
     std::call_once(impl.context_init_, [&impl]() {
@@ -486,7 +482,16 @@ struct WebGpuDataTransferImpl : OrtDataTransferImpl {
         return OrtApis::CreateStatus(ORT_RUNTIME_EXCEPTION, status.ErrorMessage().c_str());
       }
     }
-    ORT_THROW_IF_ERROR(FlushAndWait(*impl.context_, buffer_manager, recording));
+    ORT_THROW_IF_ERROR(impl.context_->Flush(buffer_manager, recording));
+    wgpu::QueueWorkDoneStatus completion = wgpu::QueueWorkDoneStatus::Error;
+    auto future = impl.context_->Device().GetQueue().OnSubmittedWorkDone(
+        wgpu::CallbackMode::WaitAnyOnly,
+        [](wgpu::QueueWorkDoneStatus status, wgpu::StringView, wgpu::QueueWorkDoneStatus* result) noexcept {
+          *result = status;
+        },
+        &completion);
+    ORT_THROW_IF_ERROR(impl.context_->Wait(future));
+    ORT_ENFORCE(completion == wgpu::QueueWorkDoneStatus::Success, "WebGPU queue completion failed.");
     return nullptr;
   }
 

--- a/onnxruntime/core/providers/webgpu/webgpu_provider_factory.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_provider_factory.cc
@@ -453,10 +453,9 @@ struct WebGpuDataTransferImpl : OrtDataTransferImpl {
       }
     });
 
-    CommandRecordingState environment_recording;
-    auto& recording = impl.ep_ ? impl.ep_->Recording() : environment_recording;
+    auto& recording = impl.ep_ ? impl.ep_->Recording() : impl.context_->EnvironmentRecording();
     auto& buffer_manager = impl.ep_ ? impl.ep_->BufferManager() : impl.context_->BufferManager();
-    // DataTransferImpl borrows its BufferManager. The retained context owns the Env manager;
+    // DataTransferImpl borrows its BufferManager. The retained context owns the Env manager and recording;
     // Session transfers also depend on the owning EP's lifetime for its selected manager and recording.
     DataTransferImpl transfer(buffer_manager, recording);
 
@@ -486,7 +485,7 @@ struct WebGpuDataTransferImpl : OrtDataTransferImpl {
       }
     }
     // Flush GPU-to-GPU copies, which BufferManager::MemCpy only records. CPU/GPU transfers already handle
-    // any required submission in BufferManager. This also submits copies before the local Env recording is destroyed.
+    // any required submission in BufferManager. Submit before subsequent Session work uses the buffers.
     // TODO: Only GPU-to-CPU downloads currently guarantee copy completion. Uploads and GPU-to-GPU copies
     // only guarantee submission and may still be in flight on return; add completion guarantees for these paths.
     ORT_THROW_IF_ERROR(impl.context_->Flush(buffer_manager, recording));

--- a/onnxruntime/core/providers/webgpu/webgpu_provider_factory.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_provider_factory.cc
@@ -456,6 +456,11 @@ struct WebGpuDataTransferImpl : OrtDataTransferImpl {
       }
     });
 
+    CommandRecordingState environment_recording;
+    auto& recording = impl.ep_ ? impl.ep_->Recording() : environment_recording;
+    auto& buffer_manager = impl.ep_ ? impl.ep_->BufferManager() : impl.context_->BufferManager();
+    DataTransferImpl transfer(buffer_manager, recording);
+
     for (size_t idx = 0; idx < num_tensors; ++idx) {
 #if defined(ORT_USE_EP_API_ADAPTERS)
       Ort::ConstValue src_value{src_tensors[idx]};
@@ -476,17 +481,12 @@ struct WebGpuDataTransferImpl : OrtDataTransferImpl {
       void* dst_data = dst_tensor.MutableDataRaw();
       bool dst_is_gpu = dst_tensor.Location().device.Type() == OrtDevice::GPU;
 #endif
-      auto status = impl.ep_
-                        ? DataTransferImpl(impl.ep_->BufferManager(), impl.ep_->Recording())
-                              .CopyTensor(src_data, src_is_gpu, dst_data, dst_is_gpu, size)
-                        : CopyTensorWithLocalEncoder(*impl.context_, src_data, src_is_gpu, dst_data, dst_is_gpu, size);
+      auto status = transfer.CopyTensor(src_data, src_is_gpu, dst_data, dst_is_gpu, size);
       if (!status.IsOK()) {
         return OrtApis::CreateStatus(ORT_RUNTIME_EXCEPTION, status.ErrorMessage().c_str());
       }
     }
-    if (impl.ep_) {
-      ORT_THROW_IF_ERROR(FlushAndWait(*impl.context_, impl.ep_->BufferManager(), impl.ep_->Recording()));
-    }
+    ORT_THROW_IF_ERROR(FlushAndWait(*impl.context_, buffer_manager, recording));
     return nullptr;
   }
 

--- a/onnxruntime/core/providers/webgpu/webgpu_provider_factory_creator.h
+++ b/onnxruntime/core/providers/webgpu/webgpu_provider_factory_creator.h
@@ -21,7 +21,7 @@ struct WebGpuProviderFactoryCreator {
 };
 
 // C API to create data transfer for WebGPU EP with lazy initialization.
-// A null EP selects independent environment recording; otherwise the transfer uses the EP's recording.
+// A null EP selects the context's shared Env recording; otherwise the transfer uses the EP's recording.
 // Caller takes ownership of the returned OrtDataTransferImpl*.
 OrtDataTransferImpl* OrtWebGpuCreateDataTransfer(int context_id = 0, WebGpuExecutionProvider* ep = nullptr);
 

--- a/onnxruntime/core/providers/webgpu/webgpu_provider_factory_creator.h
+++ b/onnxruntime/core/providers/webgpu/webgpu_provider_factory_creator.h
@@ -14,14 +14,13 @@ struct OrtDataTransferImpl;
 
 namespace onnxruntime {
 struct ConfigOptions;
+class WebGpuExecutionProvider;
 
 struct WebGpuProviderFactoryCreator {
   static std::shared_ptr<IExecutionProviderFactory> Create(const ConfigOptions& config_options);
 };
 
-// C API to create data transfer for WebGPU EP with lazy initialization
-// Context will be determined from tensors during the first CopyTensors call
-// Caller takes ownership of the returned OrtDataTransferImpl*
-OrtDataTransferImpl* OrtWebGpuCreateDataTransfer(int context_id = 0);
+// Caller owns the transfer. A null EP selects independent, synchronous environment copies.
+OrtDataTransferImpl* OrtWebGpuCreateDataTransfer(int context_id = 0, WebGpuExecutionProvider* ep = nullptr);
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/webgpu/webgpu_provider_factory_creator.h
+++ b/onnxruntime/core/providers/webgpu/webgpu_provider_factory_creator.h
@@ -20,7 +20,9 @@ struct WebGpuProviderFactoryCreator {
   static std::shared_ptr<IExecutionProviderFactory> Create(const ConfigOptions& config_options);
 };
 
-// Caller owns the transfer. A null EP selects independent, synchronous environment copies.
+// C API to create data transfer for WebGPU EP with lazy initialization.
+// A null EP selects independent environment recording; otherwise the transfer uses the EP's recording.
+// Caller takes ownership of the returned OrtDataTransferImpl*.
 OrtDataTransferImpl* OrtWebGpuCreateDataTransfer(int context_id = 0, WebGpuExecutionProvider* ep = nullptr);
 
 }  // namespace onnxruntime

--- a/onnxruntime/test/autoep/test_webgpu_concurrency.cc
+++ b/onnxruntime/test/autoep/test_webgpu_concurrency.cc
@@ -1,0 +1,149 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <array>
+#include <atomic>
+#include <barrier>
+#include <filesystem>
+#include <memory>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "core/graph/constants.h"
+#include "core/session/onnxruntime_cxx_api.h"
+#include "core/session/onnxruntime_session_options_config_keys.h"
+#include "test/autoep/test_autoep_utils.h"
+#include "test/util/include/file_util.h"
+
+extern std::unique_ptr<Ort::Env> ort_env;
+
+namespace onnxruntime {
+namespace test {
+
+#if defined(USE_WEBGPU) && defined(ORT_USE_EP_API_ADAPTERS)
+
+namespace {
+
+class FirstError {
+ public:
+  void Set(std::string message) {
+    bool expected = false;
+    if (failed_.compare_exchange_strong(expected, true)) {
+      std::lock_guard<std::mutex> lock{mutex_};
+      message_ = std::move(message);
+    }
+  }
+
+  bool Failed() const { return failed_.load(); }
+
+  std::string Message() const {
+    std::lock_guard<std::mutex> lock{mutex_};
+    return message_;
+  }
+
+ private:
+  std::atomic<bool> failed_{false};
+  mutable std::mutex mutex_;
+  std::string message_;
+};
+
+void ThrowOnError(OrtStatus* status_ptr) {
+  Ort::Status status{status_ptr};
+  if (!status.IsOK()) {
+    throw std::runtime_error(status.GetErrorMessage());
+  }
+}
+
+}  // namespace
+
+TEST(PluginEpWebGpuConcurrency, MultiSessionRunAndSharedServices) {
+  const Utils::ExamplePluginInfo webgpu_ep_info(
+      GetSharedLibraryFileName(ORT_TSTR("onnxruntime_providers_webgpu")),
+      "webgpu_ep_concurrency_library",
+      kWebGpuExecutionProvider);
+  RegisteredEpDeviceUniquePtr webgpu_ep_device_holder;
+  ASSERT_NO_FATAL_FAILURE(
+      Utils::RegisterAndGetExampleEp(*ort_env, webgpu_ep_info, webgpu_ep_device_holder));
+  Ort::ConstEpDevice webgpu_ep_device{webgpu_ep_device_holder.get()};
+  Ort::ConstMemoryInfo gpu_memory_info = webgpu_ep_device.GetMemoryInfo(OrtDeviceMemoryType_DEFAULT);
+  ASSERT_NE(gpu_memory_info, nullptr);
+  auto gpu_allocator = ort_env->CreateSharedAllocator(
+      webgpu_ep_device_holder.get(), OrtDeviceMemoryType_DEFAULT, OrtDeviceAllocator, nullptr);
+  ASSERT_NE(gpu_allocator, nullptr);
+
+  constexpr int kThreads = 4;
+  constexpr int kIterations = 20;
+  constexpr size_t kElements = 6;
+  const std::array<int64_t, 2> shape{3, 2};
+  FirstError error;
+  std::barrier start{kThreads};
+  std::vector<std::thread> threads;
+  threads.reserve(kThreads);
+
+  for (int thread_id = 0; thread_id < kThreads; ++thread_id) {
+    threads.emplace_back([&, thread_id]() {
+      try {
+        Ort::SessionOptions session_options;
+        session_options.AddConfigEntry(kOrtSessionOptionsDisableCPUEPFallback, "1");
+        std::unordered_map<std::string, std::string> ep_options;
+        session_options.AppendExecutionProvider_V2(*ort_env, {webgpu_ep_device}, ep_options);
+        Ort::Session session(*ort_env, ORT_TSTR("testdata/mul_1.onnx"), session_options);
+
+        Ort::MemoryInfo cpu_memory_info = Ort::MemoryInfo::CreateCpu(OrtDeviceAllocator, OrtMemTypeCPU);
+        start.arrive_and_wait();
+
+        for (int iteration = 0; iteration < kIterations && !error.Failed(); ++iteration) {
+          const float value = static_cast<float>(thread_id * kIterations + iteration + 1);
+          std::array<float, kElements> input_data{};
+          input_data.fill(value);
+          Ort::Value cpu_input = Ort::Value::CreateTensor<float>(
+              cpu_memory_info, input_data.data(), input_data.size(), shape.data(), shape.size());
+
+            Ort::Value gpu_input = Ort::Value::CreateTensor<float>(gpu_allocator, shape.data(), shape.size());
+            Ort::Value gpu_output = Ort::Value::CreateTensor<float>(gpu_allocator, shape.data(), shape.size());
+            ThrowOnError(ort_env->CopyTensor(cpu_input, gpu_input, nullptr));
+
+            Ort::IoBinding io_binding(session);
+            io_binding.BindInput("X", gpu_input);
+            io_binding.BindOutput("Y", gpu_output);
+            io_binding.SynchronizeInputs();
+            session.Run(Ort::RunOptions{nullptr}, io_binding);
+            io_binding.SynchronizeOutputs();
+
+            std::array<float, kElements> output_data{};
+            Ort::Value cpu_output = Ort::Value::CreateTensor<float>(
+              cpu_memory_info, output_data.data(), output_data.size(), shape.data(), shape.size());
+            ThrowOnError(ort_env->CopyTensor(gpu_output, cpu_output, nullptr));
+          for (size_t index = 0; index < kElements; ++index) {
+            const float expected = value * static_cast<float>(index + 1);
+            if (output_data[index] != expected) {
+              throw std::runtime_error(
+                  "Concurrent WebGPU plugin Session::Run returned incorrect data at iteration " +
+                  std::to_string(iteration) + ", index " + std::to_string(index) + ": actual=" +
+                  std::to_string(output_data[index]) + ", expected=" + std::to_string(expected));
+            }
+          }
+        }
+      } catch (const std::exception& ex) {
+        error.Set("thread " + std::to_string(thread_id) + ": " + ex.what());
+      }
+    });
+  }
+
+  for (auto& thread : threads) {
+    thread.join();
+  }
+
+  ASSERT_FALSE(error.Failed()) << error.Message();
+}
+
+#endif  // defined(USE_WEBGPU) && defined(ORT_USE_EP_API_ADAPTERS)
+
+}  // namespace test
+}  // namespace onnxruntime

--- a/onnxruntime/test/autoep/test_webgpu_concurrency.cc
+++ b/onnxruntime/test/autoep/test_webgpu_concurrency.cc
@@ -466,6 +466,9 @@ TEST_F(PluginEpWebGpuConcurrency, CpuPartitionBetweenGpuKernels) {
     node->add_input(values[index]);
     node->add_output(values[index + 1]);
   }
+  auto* cpu_output_info = graph->add_output();
+  cpu_output_info->CopyFrom(graph->output(0));
+  cpu_output_info->set_name("cpu_value");
   const auto model_bytes = model.SerializeAsString();
   Ort::SessionOptions options;
   options.SetGraphOptimizationLevel(GraphOptimizationLevel::ORT_DISABLE_ALL);
@@ -475,22 +478,30 @@ TEST_F(PluginEpWebGpuConcurrency, CpuPartitionBetweenGpuKernels) {
   const auto input_devices = session.GetEpDeviceForInputs();
   const auto output_devices = session.GetEpDeviceForOutputs();
   ASSERT_EQ(input_devices.size(), 1u);
-  ASSERT_EQ(output_devices.size(), 1u);
+  ASSERT_EQ(output_devices.size(), 2u);
   ASSERT_NE(input_devices.front(), nullptr);
   ASSERT_NE(output_devices.front(), nullptr);
-  EXPECT_STREQ(input_devices.front().EpName(), kWebGpuExecutionProvider);
-  EXPECT_STREQ(output_devices.front().EpName(), kWebGpuExecutionProvider);
+  ASSERT_STREQ(input_devices.front().EpName(), kWebGpuExecutionProvider);
+  ASSERT_STREQ(output_devices.front().EpName(), kWebGpuExecutionProvider);
+  ASSERT_NE(output_devices[1], nullptr);
+  ASSERT_STREQ(output_devices[1].EpName(), kCpuExecutionProvider);
   const auto cpu_memory = Ort::MemoryInfo::CreateCpu(OrtDeviceAllocator, OrtMemTypeCPU);
   const std::array<const char*, 1> inputs{"X"};
-  const std::array<const char*, 1> outputs{"Y"};
+  const std::array<const char*, 2> outputs{"Y", "cpu_value"};
   for (int iteration = 0; iteration < kIterations; ++iteration) {
+    SCOPED_TRACE(iteration);
     std::array<float, kElements> data{};
-    data.fill(static_cast<float>(iteration + 1));
+    for (size_t index = 0; index < data.size(); ++index) {
+      data[index] = static_cast<float>((iteration + 1) * (index + 1));
+    }
     auto input = Ort::Value::CreateTensor<float>(cpu_memory, data.data(), data.size(), kShape.data(), kShape.size());
     auto result = session.Run(Ort::RunOptions{nullptr}, inputs.data(), &input, 1, outputs.data(), outputs.size());
+    ASSERT_EQ(result.size(), 2u);
     const auto* actual = result.front().GetTensorData<float>();
+    const auto* cpu_actual = result[1].GetTensorData<float>();
     for (size_t index = 0; index < data.size(); ++index) {
-      EXPECT_EQ(actual[index], -data[index]);
+      EXPECT_EQ(cpu_actual[index], data[index]) << "CPU intermediate at index " << index;
+      EXPECT_EQ(actual[index], -data[index]) << "GPU output at index " << index;
     }
   }
 }

--- a/onnxruntime/test/autoep/test_webgpu_concurrency.cc
+++ b/onnxruntime/test/autoep/test_webgpu_concurrency.cc
@@ -5,7 +5,6 @@
 #include <array>
 #include <atomic>
 #include <barrier>
-#include <filesystem>
 #include <memory>
 #include <mutex>
 #include <stdexcept>

--- a/onnxruntime/test/autoep/test_webgpu_concurrency.cc
+++ b/onnxruntime/test/autoep/test_webgpu_concurrency.cc
@@ -526,6 +526,51 @@ TEST_F(PluginEpWebGpuConcurrency, SharedAllocatorCreatesAndCopiesConcurrently) {
   ASSERT_FALSE(error.Failed()) << error.Message();
 }
 
+TEST_F(PluginEpWebGpuConcurrency, EnvironmentCopiesBatchedEmptyAndUnalignedTensors) {
+  constexpr std::array<int64_t, 7> byte_counts{0, 1, 3, 4, 5, 16, 17};
+  constexpr size_t kCapacity = 20;
+  constexpr uint8_t kSentinel = 0xcc;
+  auto allocator = CreateSharedAllocator();
+  ASSERT_NE(allocator, nullptr);
+  const auto cpu_memory = Ort::MemoryInfo::CreateCpu(OrtDeviceAllocator, OrtMemTypeCPU);
+  std::array<std::array<uint8_t, kCapacity>, byte_counts.size()> input_data{};
+  std::array<std::array<uint8_t, kCapacity>, byte_counts.size()> output_data{};
+  std::vector<Ort::Value> cpu_inputs;
+  std::vector<Ort::Value> gpu_inputs;
+  std::vector<Ort::Value> gpu_outputs;
+  std::vector<Ort::Value> cpu_outputs;
+  cpu_inputs.reserve(byte_counts.size());
+  gpu_inputs.reserve(byte_counts.size());
+  gpu_outputs.reserve(byte_counts.size());
+  cpu_outputs.reserve(byte_counts.size());
+  for (size_t tensor_index = 0; tensor_index < byte_counts.size(); ++tensor_index) {
+    const auto byte_count = static_cast<size_t>(byte_counts[tensor_index]);
+    for (size_t byte_index = 0; byte_index < kCapacity; ++byte_index) {
+      input_data[tensor_index][byte_index] = static_cast<uint8_t>(tensor_index * kCapacity + byte_index + 1);
+    }
+    output_data[tensor_index].fill(kSentinel);
+    cpu_inputs.push_back(Ort::Value::CreateTensor<uint8_t>(
+        cpu_memory, input_data[tensor_index].data(), byte_count, &byte_counts[tensor_index], 1));
+    gpu_inputs.push_back(Ort::Value::CreateTensor<uint8_t>(allocator, &byte_counts[tensor_index], 1));
+    gpu_outputs.push_back(Ort::Value::CreateTensor<uint8_t>(allocator, &byte_counts[tensor_index], 1));
+    cpu_outputs.push_back(Ort::Value::CreateTensor<uint8_t>(
+        cpu_memory, output_data[tensor_index].data(), byte_count, &byte_counts[tensor_index], 1));
+  }
+
+  ThrowOnError(ort_env->CopyTensors(cpu_inputs, gpu_inputs, nullptr));
+  ThrowOnError(ort_env->CopyTensors(gpu_inputs, gpu_outputs, nullptr));
+  ThrowOnError(ort_env->CopyTensors(gpu_outputs, cpu_outputs, nullptr));
+  for (size_t tensor_index = 0; tensor_index < byte_counts.size(); ++tensor_index) {
+    SCOPED_TRACE("byte count " + std::to_string(byte_counts[tensor_index]));
+    for (size_t byte_index = 0; byte_index < kCapacity; ++byte_index) {
+      const auto expected = byte_index < static_cast<size_t>(byte_counts[tensor_index])
+                                ? input_data[tensor_index][byte_index]
+                                : kSentinel;
+      EXPECT_EQ(output_data[tensor_index][byte_index], expected) << "byte " << byte_index;
+    }
+  }
+}
+
 TEST_F(PluginEpWebGpuConcurrency, SharedGpuCopyCompletesBeforeSessionRun) {
   auto session = CreateSession();
   auto allocator = CreateSharedAllocator();

--- a/onnxruntime/test/autoep/test_webgpu_concurrency.cc
+++ b/onnxruntime/test/autoep/test_webgpu_concurrency.cc
@@ -16,6 +16,7 @@
 #include <gtest/gtest.h>
 
 #include "core/graph/constants.h"
+#include "core/graph/onnx_protobuf.h"
 #include "core/session/onnxruntime_cxx_api.h"
 #include "core/session/onnxruntime_session_options_config_keys.h"
 #include "test/autoep/test_autoep_utils.h"
@@ -60,81 +61,415 @@ void ThrowOnError(OrtStatus* status_ptr) {
   }
 }
 
-}  // namespace
+constexpr int kThreads = 4;
+constexpr int kIterations = 20;
+constexpr size_t kElements = 6;
+constexpr std::array<int64_t, 2> kShape{3, 2};
 
-TEST(PluginEpWebGpuConcurrency, MultiSessionRunAndSharedServices) {
-  const Utils::ExamplePluginInfo webgpu_ep_info(
-      GetSharedLibraryFileName(ORT_TSTR("onnxruntime_providers_webgpu")),
-      "webgpu_ep_concurrency_library",
-      kWebGpuExecutionProvider);
-  RegisteredEpDeviceUniquePtr webgpu_ep_device_holder;
-  ASSERT_NO_FATAL_FAILURE(
-      Utils::RegisterAndGetExampleEp(*ort_env, webgpu_ep_info, webgpu_ep_device_holder));
-  Ort::ConstEpDevice webgpu_ep_device{webgpu_ep_device_holder.get()};
-  Ort::ConstMemoryInfo gpu_memory_info = webgpu_ep_device.GetMemoryInfo(OrtDeviceMemoryType_DEFAULT);
-  ASSERT_NE(gpu_memory_info, nullptr);
-  auto gpu_allocator = ort_env->CreateSharedAllocator(
-      webgpu_ep_device_holder.get(), OrtDeviceMemoryType_DEFAULT, OrtDeviceAllocator, nullptr);
-  ASSERT_NE(gpu_allocator, nullptr);
+void VerifyOutput(const std::array<float, kElements>& output_data, float value) {
+  for (size_t index = 0; index < kElements; ++index) {
+    const float expected = value * static_cast<float>(index + 1);
+    if (output_data[index] != expected) {
+      throw std::runtime_error("Incorrect output at index " + std::to_string(index) +
+                               ": actual=" + std::to_string(output_data[index]) +
+                               ", expected=" + std::to_string(expected));
+    }
+  }
+}
 
-  constexpr int kThreads = 4;
-  constexpr int kIterations = 20;
-  constexpr size_t kElements = 6;
-  const std::array<int64_t, 2> shape{3, 2};
-  FirstError error;
+template <typename Work>
+void RunWorkers(FirstError& error, Work work) {
   std::barrier start{kThreads};
   std::vector<std::thread> threads;
   threads.reserve(kThreads);
-
   for (int thread_id = 0; thread_id < kThreads; ++thread_id) {
     threads.emplace_back([&, thread_id]() {
       try {
-        Ort::SessionOptions session_options;
-        session_options.AddConfigEntry(kOrtSessionOptionsDisableCPUEPFallback, "1");
-        std::unordered_map<std::string, std::string> ep_options;
-        session_options.AppendExecutionProvider_V2(*ort_env, {webgpu_ep_device}, ep_options);
-        Ort::Session session(*ort_env, ORT_TSTR("testdata/mul_1.onnx"), session_options);
-
-        Ort::MemoryInfo cpu_memory_info = Ort::MemoryInfo::CreateCpu(OrtDeviceAllocator, OrtMemTypeCPU);
         start.arrive_and_wait();
-
-        for (int iteration = 0; iteration < kIterations && !error.Failed(); ++iteration) {
-          const float value = static_cast<float>(thread_id * kIterations + iteration + 1);
-          std::array<float, kElements> input_data{};
-          input_data.fill(value);
-          Ort::Value cpu_input = Ort::Value::CreateTensor<float>(
-              cpu_memory_info, input_data.data(), input_data.size(), shape.data(), shape.size());
-
-            Ort::Value gpu_input = Ort::Value::CreateTensor<float>(gpu_allocator, shape.data(), shape.size());
-            Ort::Value gpu_output = Ort::Value::CreateTensor<float>(gpu_allocator, shape.data(), shape.size());
-            ThrowOnError(ort_env->CopyTensor(cpu_input, gpu_input, nullptr));
-
-            Ort::IoBinding io_binding(session);
-            io_binding.BindInput("X", gpu_input);
-            io_binding.BindOutput("Y", gpu_output);
-            io_binding.SynchronizeInputs();
-            session.Run(Ort::RunOptions{nullptr}, io_binding);
-            io_binding.SynchronizeOutputs();
-
-            std::array<float, kElements> output_data{};
-            Ort::Value cpu_output = Ort::Value::CreateTensor<float>(
-              cpu_memory_info, output_data.data(), output_data.size(), shape.data(), shape.size());
-            ThrowOnError(ort_env->CopyTensor(gpu_output, cpu_output, nullptr));
-          for (size_t index = 0; index < kElements; ++index) {
-            const float expected = value * static_cast<float>(index + 1);
-            if (output_data[index] != expected) {
-              throw std::runtime_error(
-                  "Concurrent WebGPU plugin Session::Run returned incorrect data at iteration " +
-                  std::to_string(iteration) + ", index " + std::to_string(index) + ": actual=" +
-                  std::to_string(output_data[index]) + ", expected=" + std::to_string(expected));
-            }
-          }
-        }
+        work(thread_id);
       } catch (const std::exception& ex) {
         error.Set("thread " + std::to_string(thread_id) + ": " + ex.what());
       }
     });
   }
+
+  for (auto& thread : threads) {
+    thread.join();
+  }
+}
+
+template <typename Allocator>
+void CopyTensorRoundTrip(Allocator& allocator, float value) {
+  const auto cpu_memory_info = Ort::MemoryInfo::CreateCpu(OrtDeviceAllocator, OrtMemTypeCPU);
+  std::array<float, kElements> input_data{};
+  input_data.fill(value);
+  std::array<float, kElements> output_data{};
+  auto cpu_input = Ort::Value::CreateTensor<float>(
+      cpu_memory_info, input_data.data(), input_data.size(), kShape.data(), kShape.size());
+  auto gpu_tensor = Ort::Value::CreateTensor<float>(allocator, kShape.data(), kShape.size());
+  auto cpu_output = Ort::Value::CreateTensor<float>(
+      cpu_memory_info, output_data.data(), output_data.size(), kShape.data(), kShape.size());
+
+  ThrowOnError(ort_env->CopyTensor(cpu_input, gpu_tensor, nullptr));
+  ThrowOnError(ort_env->CopyTensor(gpu_tensor, cpu_output, nullptr));
+  if (output_data != input_data) {
+    throw std::runtime_error("CopyTensor round trip returned incorrect data");
+  }
+}
+
+}  // namespace
+
+class PluginEpWebGpuConcurrency : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    webgpu_ep_info_ = std::make_unique<Utils::ExamplePluginInfo>(
+        GetSharedLibraryFileName(ORT_TSTR("onnxruntime_providers_webgpu")),
+        "webgpu_ep_concurrency_library",
+        kWebGpuExecutionProvider);
+    ASSERT_NO_FATAL_FAILURE(
+        Utils::RegisterAndGetExampleEp(*ort_env, *webgpu_ep_info_, webgpu_ep_device_holder_));
+    ASSERT_NE(Device().GetMemoryInfo(OrtDeviceMemoryType_DEFAULT), nullptr);
+  }
+
+  Ort::ConstEpDevice Device() const {
+    return Ort::ConstEpDevice{webgpu_ep_device_holder_.get()};
+  }
+
+  Ort::UnownedAllocator CreateSharedAllocator() const {
+    return ort_env->CreateSharedAllocator(
+        webgpu_ep_device_holder_.get(), OrtDeviceMemoryType_DEFAULT, OrtDeviceAllocator, nullptr);
+  }
+
+  std::unique_ptr<Ort::Session> CreateSession() const {
+    Ort::SessionOptions session_options;
+    session_options.AddConfigEntry(kOrtSessionOptionsDisableCPUEPFallback, "1");
+    std::unordered_map<std::string, std::string> ep_options;
+    session_options.AppendExecutionProvider_V2(*ort_env, {Device()}, ep_options);
+    return std::make_unique<Ort::Session>(
+        *ort_env, ORT_TSTR("testdata/mul_1.onnx"), session_options);
+  }
+
+  void RunAndVerify(Ort::Session& session, float value) const {
+    const auto cpu_memory_info = Ort::MemoryInfo::CreateCpu(OrtDeviceAllocator, OrtMemTypeCPU);
+    std::array<float, kElements> input_data{};
+    input_data.fill(value);
+    std::array<float, kElements> output_data{};
+    auto cpu_input = Ort::Value::CreateTensor<float>(
+        cpu_memory_info, input_data.data(), input_data.size(), kShape.data(), kShape.size());
+    auto cpu_output = Ort::Value::CreateTensor<float>(
+        cpu_memory_info, output_data.data(), output_data.size(), kShape.data(), kShape.size());
+
+    Ort::Allocator allocator(session, Device().GetMemoryInfo(OrtDeviceMemoryType_DEFAULT));
+    auto gpu_input = Ort::Value::CreateTensor<float>(allocator, kShape.data(), kShape.size());
+    auto gpu_output = Ort::Value::CreateTensor<float>(allocator, kShape.data(), kShape.size());
+    ThrowOnError(ort_env->CopyTensor(cpu_input, gpu_input, nullptr));
+
+    Ort::IoBinding io_binding(session);
+    io_binding.BindInput("X", gpu_input);
+    io_binding.BindOutput("Y", gpu_output);
+    io_binding.SynchronizeInputs();
+    session.Run(Ort::RunOptions{nullptr}, io_binding);
+    io_binding.SynchronizeOutputs();
+
+    ThrowOnError(ort_env->CopyTensor(gpu_output, cpu_output, nullptr));
+    VerifyOutput(output_data, value);
+  }
+
+  void RunWithCpuInputAndOutput(Ort::Session& session, float value) const {
+    const auto cpu_memory_info = Ort::MemoryInfo::CreateCpu(OrtDeviceAllocator, OrtMemTypeCPU);
+    std::array<float, kElements> input_data{};
+    input_data.fill(value);
+    auto cpu_input = Ort::Value::CreateTensor<float>(
+        cpu_memory_info, input_data.data(), input_data.size(), kShape.data(), kShape.size());
+    const std::array<const char*, 1> input_names{"X"};
+    const std::array<const char*, 1> output_names{"Y"};
+    auto outputs = session.Run(Ort::RunOptions{nullptr}, input_names.data(), &cpu_input, 1,
+                               output_names.data(), output_names.size());
+    const float* output = outputs.front().GetTensorData<float>();
+    std::array<float, kElements> output_data{};
+    std::copy_n(output, output_data.size(), output_data.begin());
+    VerifyOutput(output_data, value);
+  }
+
+  void RunWithCpuInputAndGpuOutput(Ort::Session& session, float value) const {
+    const auto cpu_memory_info = Ort::MemoryInfo::CreateCpu(OrtDeviceAllocator, OrtMemTypeCPU);
+    std::array<float, kElements> input_data{};
+    input_data.fill(value);
+    auto cpu_input = Ort::Value::CreateTensor<float>(
+        cpu_memory_info, input_data.data(), input_data.size(), kShape.data(), kShape.size());
+
+    Ort::Allocator allocator(session, Device().GetMemoryInfo(OrtDeviceMemoryType_DEFAULT));
+    auto gpu_output = Ort::Value::CreateTensor<float>(allocator, kShape.data(), kShape.size());
+    Ort::IoBinding io_binding(session);
+    io_binding.BindInput("X", cpu_input);
+    io_binding.BindOutput("Y", gpu_output);
+    session.Run(Ort::RunOptions{nullptr}, io_binding);
+
+    std::array<float, kElements> output_data{};
+    auto cpu_output = Ort::Value::CreateTensor<float>(
+        cpu_memory_info, output_data.data(), output_data.size(), kShape.data(), kShape.size());
+    ThrowOnError(ort_env->CopyTensor(gpu_output, cpu_output, nullptr));
+    VerifyOutput(output_data, value);
+  }
+
+  void RunWithGpuInputAndCpuOutput(Ort::Session& session, float value) const {
+    const auto cpu_memory_info = Ort::MemoryInfo::CreateCpu(OrtDeviceAllocator, OrtMemTypeCPU);
+    std::array<float, kElements> input_data{};
+    input_data.fill(value);
+    auto cpu_input = Ort::Value::CreateTensor<float>(
+        cpu_memory_info, input_data.data(), input_data.size(), kShape.data(), kShape.size());
+    Ort::Allocator allocator(session, Device().GetMemoryInfo(OrtDeviceMemoryType_DEFAULT));
+    auto gpu_input = Ort::Value::CreateTensor<float>(allocator, kShape.data(), kShape.size());
+    ThrowOnError(ort_env->CopyTensor(cpu_input, gpu_input, nullptr));
+
+    const std::array<const char*, 1> input_names{"X"};
+    const std::array<const char*, 1> output_names{"Y"};
+    auto outputs = session.Run(Ort::RunOptions{nullptr}, input_names.data(), &gpu_input, 1,
+                               output_names.data(), output_names.size());
+    const float* output = outputs.front().GetTensorData<float>();
+    std::array<float, kElements> output_data{};
+    std::copy_n(output, output_data.size(), output_data.begin());
+    VerifyOutput(output_data, value);
+  }
+
+ private:
+  std::unique_ptr<Utils::ExamplePluginInfo> webgpu_ep_info_;
+  RegisteredEpDeviceUniquePtr webgpu_ep_device_holder_;
+};
+
+TEST_F(PluginEpWebGpuConcurrency, DifferentSessionsCreateConcurrently) {
+  std::array<std::unique_ptr<Ort::Session>, kThreads> sessions;
+  FirstError error;
+  RunWorkers(error, [&](int thread_id) {
+    sessions[thread_id] = CreateSession();
+  });
+
+  ASSERT_FALSE(error.Failed()) << error.Message();
+  for (const auto& session : sessions) {
+    ASSERT_NE(session, nullptr);
+  }
+}
+
+TEST_F(PluginEpWebGpuConcurrency, DifferentSessionsRunConcurrently) {
+  std::array<std::unique_ptr<Ort::Session>, kThreads> sessions;
+  for (auto& session : sessions) {
+    session = CreateSession();
+  }
+
+  FirstError error;
+  RunWorkers(error, [&](int thread_id) {
+    for (int iteration = 0; iteration < kIterations && !error.Failed(); ++iteration) {
+      const float value = static_cast<float>(thread_id * kIterations + iteration + 1);
+      RunAndVerify(*sessions[thread_id], value);
+    }
+  });
+
+  ASSERT_FALSE(error.Failed()) << error.Message();
+}
+
+TEST_F(PluginEpWebGpuConcurrency, CpuInputAndOutputRun) {
+  auto session = CreateSession();
+  for (int iteration = 0; iteration < kIterations; ++iteration) {
+    RunWithCpuInputAndOutput(*session, static_cast<float>(iteration + 1));
+  }
+}
+
+TEST_F(PluginEpWebGpuConcurrency, CpuPartitionBetweenGpuKernels) {
+  ONNX_NAMESPACE::ModelProto model;
+  model.set_ir_version(ONNX_NAMESPACE::Version::IR_VERSION);
+  model.add_opset_import()->set_version(18);
+  auto* graph = model.mutable_graph();
+  graph->set_name("webgpu_stream_partition_copy");
+  for (auto* value_info : {graph->add_input(), graph->add_output()}) {
+    value_info->set_name(value_info == &graph->input(0) ? "X" : "Y");
+    auto* tensor_type = value_info->mutable_type()->mutable_tensor_type();
+    tensor_type->set_elem_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+    for (auto dimension : kShape) {
+      tensor_type->mutable_shape()->add_dim()->set_dim_value(dimension);
+    }
+  }
+  const std::array<const char*, 4> values{"X", "gpu_value", "cpu_value", "Y"};
+  const std::array<const char*, 3> nodes{"gpu_first", "cpu_middle", "gpu_last"};
+  for (size_t index = 0; index < nodes.size(); ++index) {
+    auto* node = graph->add_node();
+    node->set_name(nodes[index]);
+    node->set_op_type("Neg");
+    node->add_input(values[index]);
+    node->add_output(values[index + 1]);
+  }
+  const auto model_bytes = model.SerializeAsString();
+  Ort::SessionOptions options;
+  options.SetGraphOptimizationLevel(GraphOptimizationLevel::ORT_DISABLE_ALL);
+  const std::unordered_map<std::string, std::string> ep_options{{"forceCpuNodeNames", "cpu_middle"}};
+  options.AppendExecutionProvider_V2(*ort_env, {Device()}, ep_options);
+  Ort::Session session(*ort_env, model_bytes.data(), model_bytes.size(), options);
+  const auto input_devices = session.GetEpDeviceForInputs();
+  const auto output_devices = session.GetEpDeviceForOutputs();
+  ASSERT_EQ(input_devices.size(), 1u);
+  ASSERT_EQ(output_devices.size(), 1u);
+  ASSERT_NE(input_devices.front(), nullptr);
+  ASSERT_NE(output_devices.front(), nullptr);
+  EXPECT_STREQ(input_devices.front().EpName(), kWebGpuExecutionProvider);
+  EXPECT_STREQ(output_devices.front().EpName(), kWebGpuExecutionProvider);
+  const auto cpu_memory = Ort::MemoryInfo::CreateCpu(OrtDeviceAllocator, OrtMemTypeCPU);
+  const std::array<const char*, 1> inputs{"X"};
+  const std::array<const char*, 1> outputs{"Y"};
+  for (int iteration = 0; iteration < kIterations; ++iteration) {
+    std::array<float, kElements> data{};
+    data.fill(static_cast<float>(iteration + 1));
+    auto input = Ort::Value::CreateTensor<float>(cpu_memory, data.data(), data.size(), kShape.data(), kShape.size());
+    auto result = session.Run(Ort::RunOptions{nullptr}, inputs.data(), &input, 1, outputs.data(), outputs.size());
+    const auto* actual = result.front().GetTensorData<float>();
+    for (size_t index = 0; index < data.size(); ++index) {
+      EXPECT_EQ(actual[index], -data[index]);
+    }
+  }
+}
+
+TEST_F(PluginEpWebGpuConcurrency, CpuInputAndGpuOutputRun) {
+  auto session = CreateSession();
+  RunWithCpuInputAndGpuOutput(*session, 1.0f);
+}
+
+TEST_F(PluginEpWebGpuConcurrency, GpuInputAndCpuOutputRun) {
+  auto session = CreateSession();
+  RunWithGpuInputAndCpuOutput(*session, 1.0f);
+}
+
+TEST_F(PluginEpWebGpuConcurrency, DifferentSessionsWithCpuInputAndOutputRunConcurrently) {
+  std::array<std::unique_ptr<Ort::Session>, kThreads> sessions;
+  for (auto& session : sessions) {
+    session = CreateSession();
+  }
+
+  FirstError error;
+  RunWorkers(error, [&](int thread_id) {
+    for (int iteration = 0; iteration < kIterations && !error.Failed(); ++iteration) {
+      const float value = static_cast<float>(thread_id * kIterations + iteration + 1);
+      RunWithCpuInputAndOutput(*sessions[thread_id], value);
+    }
+  });
+
+  ASSERT_FALSE(error.Failed()) << error.Message();
+}
+
+TEST_F(PluginEpWebGpuConcurrency, SessionAllocatorsCreateAndCopyConcurrently) {
+  std::array<std::unique_ptr<Ort::Session>, kThreads> sessions;
+  for (auto& session : sessions) {
+    session = CreateSession();
+  }
+  const auto gpu_memory_info = Device().GetMemoryInfo(OrtDeviceMemoryType_DEFAULT);
+
+  FirstError error;
+  RunWorkers(error, [&](int thread_id) {
+    Ort::Allocator allocator(*sessions[thread_id], gpu_memory_info);
+    for (int iteration = 0; iteration < kIterations && !error.Failed(); ++iteration) {
+      const float value = static_cast<float>(thread_id * kIterations + iteration + 1);
+      CopyTensorRoundTrip(allocator, value);
+    }
+  });
+
+  ASSERT_FALSE(error.Failed()) << error.Message();
+}
+
+TEST_F(PluginEpWebGpuConcurrency, SharedAllocatorCreatesAndCopiesConcurrently) {
+  auto allocator = CreateSharedAllocator();
+  ASSERT_NE(allocator, nullptr);
+
+  FirstError error;
+  RunWorkers(error, [&](int thread_id) {
+    for (int iteration = 0; iteration < kIterations && !error.Failed(); ++iteration) {
+      const float value = static_cast<float>(thread_id * kIterations + iteration + 1);
+      CopyTensorRoundTrip(allocator, value);
+    }
+  });
+
+  ASSERT_FALSE(error.Failed()) << error.Message();
+}
+
+TEST_F(PluginEpWebGpuConcurrency, SharedGpuCopyCompletesBeforeSessionRun) {
+  auto session = CreateSession();
+  auto allocator = CreateSharedAllocator();
+  const auto cpu_memory = Ort::MemoryInfo::CreateCpu(OrtDeviceAllocator, OrtMemTypeCPU);
+  const std::array<const char*, 1> input_names{"X"};
+  const std::array<const char*, 1> output_names{"Y"};
+  for (int iteration = 0; iteration < kIterations; ++iteration) {
+    const float value = static_cast<float>(iteration + 1);
+    std::array<float, kElements> input_data{};
+    input_data.fill(value);
+    auto input = Ort::Value::CreateTensor<float>(cpu_memory, input_data.data(), input_data.size(),
+                                                kShape.data(), kShape.size());
+    auto source = Ort::Value::CreateTensor<float>(allocator, kShape.data(), kShape.size());
+    auto destination = Ort::Value::CreateTensor<float>(allocator, kShape.data(), kShape.size());
+    ThrowOnError(ort_env->CopyTensor(input, source, nullptr));
+    ThrowOnError(ort_env->CopyTensor(source, destination, nullptr));
+    auto result = session->Run(Ort::RunOptions{nullptr}, input_names.data(), &destination, 1,
+                               output_names.data(), output_names.size());
+    std::array<float, kElements> output{};
+    std::copy_n(result.front().GetTensorData<float>(), output.size(), output.begin());
+    VerifyOutput(output, value);
+  }
+}
+
+TEST_F(PluginEpWebGpuConcurrency, MixedSessionAndAllocatorOperationsConcurrently) {
+  constexpr int kOperationGroups = 4;
+  constexpr int kTotalThreads = kOperationGroups * kThreads;
+  constexpr int kMixedIterations = 10;
+
+  std::array<std::unique_ptr<Ort::Session>, kThreads> run_sessions;
+  for (int thread_id = 0; thread_id < kThreads; ++thread_id) {
+    run_sessions[thread_id] = CreateSession();
+  }
+
+  const auto gpu_memory_info = Device().GetMemoryInfo(OrtDeviceMemoryType_DEFAULT);
+  auto shared_allocator = CreateSharedAllocator();
+  ASSERT_NE(shared_allocator, nullptr);
+
+  FirstError error;
+  std::barrier start{kTotalThreads};
+  std::vector<std::thread> threads;
+  threads.reserve(kTotalThreads);
+
+  const auto add_workers = [&](std::string group_name, auto work) {
+    for (int thread_id = 0; thread_id < kThreads; ++thread_id) {
+      threads.emplace_back([&, group_name, work, thread_id]() {
+        try {
+          start.arrive_and_wait();
+          work(thread_id);
+        } catch (const std::exception& ex) {
+          error.Set(group_name + " thread " + std::to_string(thread_id) + ": " + ex.what());
+        }
+      });
+    }
+  };
+
+  add_workers("create session", [&](int /*thread_id*/) {
+    for (int iteration = 0; iteration < kMixedIterations && !error.Failed(); ++iteration) {
+      auto session = CreateSession();
+    }
+  });
+
+  add_workers("run session", [&](int thread_id) {
+    for (int iteration = 0; iteration < kMixedIterations && !error.Failed(); ++iteration) {
+      const float value = static_cast<float>(thread_id * kMixedIterations + iteration + 1);
+      RunWithCpuInputAndOutput(*run_sessions[thread_id], value);
+    }
+  });
+
+  add_workers("session allocator", [&](int thread_id) {
+    Ort::Allocator allocator(*run_sessions[thread_id], gpu_memory_info);
+    for (int iteration = 0; iteration < kMixedIterations && !error.Failed(); ++iteration) {
+      const float value = static_cast<float>(100 + thread_id * kMixedIterations + iteration);
+      CopyTensorRoundTrip(allocator, value);
+    }
+  });
+
+  add_workers("shared allocator", [&](int thread_id) {
+    for (int iteration = 0; iteration < kMixedIterations && !error.Failed(); ++iteration) {
+      const float value = static_cast<float>(200 + thread_id * kMixedIterations + iteration);
+      CopyTensorRoundTrip(shared_allocator, value);
+    }
+  });
 
   for (auto& thread : threads) {
     thread.join();

--- a/onnxruntime/test/autoep/test_webgpu_concurrency.cc
+++ b/onnxruntime/test/autoep/test_webgpu_concurrency.cc
@@ -353,7 +353,8 @@ TEST_F(PluginEpWebGpuConcurrency, DifferentSessionsCreateAndRunConcurrently) {
   ASSERT_FALSE(error.Failed()) << error.Message();
 }
 
-TEST_F(PluginEpWebGpuConcurrency, DifferentSessionsRunConcurrently) {
+// Future support: workers also create GPU tensors and call Env copies concurrently.
+TEST_F(PluginEpWebGpuConcurrency, DISABLED_DifferentSessionsRunConcurrently) {
   std::array<std::unique_ptr<Ort::Session>, kThreads> sessions;
   for (auto& session : sessions) {
     session = CreateSession();
@@ -370,7 +371,8 @@ TEST_F(PluginEpWebGpuConcurrency, DifferentSessionsRunConcurrently) {
   ASSERT_FALSE(error.Failed()) << error.Message();
 }
 
-TEST_F(PluginEpWebGpuConcurrency, DifferentSessionsGraphCaptureAndReplayConcurrently) {
+// Future support: GPU tensors are allocated serially, but Env uploads and downloads overlap.
+TEST_F(PluginEpWebGpuConcurrency, DISABLED_DifferentSessionsGraphCaptureAndReplayConcurrently) {
   std::array<std::atomic<int>, kThreads> replay_counts{};
   std::array<std::unique_ptr<Ort::Session>, kThreads> sessions;
   auto allocator = CreateSharedAllocator();
@@ -533,7 +535,8 @@ TEST_F(PluginEpWebGpuConcurrency, DifferentSessionsWithCpuInputAndOutputRunConcu
   ASSERT_FALSE(error.Failed()) << error.Message();
 }
 
-TEST_F(PluginEpWebGpuConcurrency, SessionAllocatorsCreateAndCopyConcurrently) {
+// Future support: external Session allocator operations and Env copies are concurrent.
+TEST_F(PluginEpWebGpuConcurrency, DISABLED_SessionAllocatorsCreateAndCopyConcurrently) {
   std::array<std::unique_ptr<Ort::Session>, kThreads> sessions;
   for (auto& session : sessions) {
     session = CreateSession();

--- a/onnxruntime/test/autoep/test_webgpu_concurrency.cc
+++ b/onnxruntime/test/autoep/test_webgpu_concurrency.cc
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <algorithm>
 #include <array>
 #include <atomic>
 #include <barrier>
@@ -9,6 +10,7 @@
 #include <mutex>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <thread>
 #include <unordered_map>
 #include <vector>
@@ -61,6 +63,16 @@ void ThrowOnError(OrtStatus* status_ptr) {
   }
 }
 
+void ORT_API_CALL CountGraphReplays(void* param, OrtLoggingLevel severity, const char*,
+                                    const char*, const char*, const char* message) noexcept {
+  if (severity == ORT_LOGGING_LEVEL_INFO && message != nullptr) {
+    const std::string_view text{message};
+    if (text.starts_with("Replaying the captured ") && text.find(kWebGpuExecutionProvider) != std::string_view::npos) {
+      static_cast<std::atomic<int>*>(param)->fetch_add(1, std::memory_order_relaxed);
+    }
+  }
+}
+
 constexpr int kThreads = 4;
 constexpr int kIterations = 20;
 constexpr size_t kElements = 6;
@@ -78,11 +90,11 @@ void VerifyOutput(const std::array<float, kElements>& output_data, float value) 
 }
 
 template <typename Work>
-void RunWorkers(FirstError& error, Work work) {
-  std::barrier start{kThreads};
+void RunWorkers(FirstError& error, Work work, int num_threads = kThreads) {
+  std::barrier start{num_threads};
   std::vector<std::thread> threads;
-  threads.reserve(kThreads);
-  for (int thread_id = 0; thread_id < kThreads; ++thread_id) {
+  threads.reserve(num_threads);
+  for (int thread_id = 0; thread_id < num_threads; ++thread_id) {
     threads.emplace_back([&, thread_id]() {
       try {
         start.arrive_and_wait();
@@ -107,11 +119,13 @@ void CopyTensorRoundTrip(Allocator& allocator, float value) {
   auto cpu_input = Ort::Value::CreateTensor<float>(
       cpu_memory_info, input_data.data(), input_data.size(), kShape.data(), kShape.size());
   auto gpu_tensor = Ort::Value::CreateTensor<float>(allocator, kShape.data(), kShape.size());
+  auto gpu_copy = Ort::Value::CreateTensor<float>(allocator, kShape.data(), kShape.size());
   auto cpu_output = Ort::Value::CreateTensor<float>(
       cpu_memory_info, output_data.data(), output_data.size(), kShape.data(), kShape.size());
 
   ThrowOnError(ort_env->CopyTensor(cpu_input, gpu_tensor, nullptr));
-  ThrowOnError(ort_env->CopyTensor(gpu_tensor, cpu_output, nullptr));
+  ThrowOnError(ort_env->CopyTensor(gpu_tensor, gpu_copy, nullptr));
+  ThrowOnError(ort_env->CopyTensor(gpu_copy, cpu_output, nullptr));
   if (output_data != input_data) {
     throw std::runtime_error("CopyTensor round trip returned incorrect data");
   }
@@ -232,10 +246,60 @@ class PluginEpWebGpuConcurrency : public ::testing::Test {
     VerifyOutput(output_data, value);
   }
 
+  void RunMixedSessionOperations(bool include_session_allocator) const {
+    constexpr int kMixedIterations = 10;
+    std::array<std::unique_ptr<Ort::Session>, kThreads> run_sessions;
+    for (auto& session : run_sessions) {
+      session = CreateSession();
+    }
+
+    const auto gpu_memory_info = Device().GetMemoryInfo(OrtDeviceMemoryType_DEFAULT);
+    auto shared_allocator = CreateSharedAllocator();
+    ASSERT_NE(shared_allocator, nullptr);
+
+    FirstError error;
+    const int num_threads = (include_session_allocator ? 4 : 3) * kThreads;
+    const auto work = [&](int thread_id) {
+      for (int iteration = 0; iteration < kMixedIterations && !error.Failed(); ++iteration) {
+        const float value = static_cast<float>(thread_id * kMixedIterations + iteration + 1);
+        if (thread_id < kThreads) {
+          auto session = CreateSession();
+        } else if (thread_id < 2 * kThreads) {
+          RunWithCpuInputAndOutput(*run_sessions[thread_id - kThreads], value);
+        } else if (thread_id < 3 * kThreads) {
+          CopyTensorRoundTrip(shared_allocator, value);
+        } else {
+          Ort::Allocator allocator(*run_sessions[thread_id - 3 * kThreads], gpu_memory_info);
+          CopyTensorRoundTrip(allocator, value);
+        }
+      }
+    };
+    RunWorkers(error, work, num_threads);
+
+    ASSERT_FALSE(error.Failed()) << error.Message();
+  }
+
  private:
   std::unique_ptr<Utils::ExamplePluginInfo> webgpu_ep_info_;
   RegisteredEpDeviceUniquePtr webgpu_ep_device_holder_;
 };
+
+TEST_F(PluginEpWebGpuConcurrency, EnvironmentCopiesBeforeAndAfterSerialSessionCreation) {
+  auto allocator = CreateSharedAllocator();
+  CopyTensorRoundTrip(allocator, 1.0f);
+  std::array<std::unique_ptr<Ort::Session>, kThreads> sessions;
+  for (auto& session : sessions) {
+    session = CreateSession();
+    CopyTensorRoundTrip(allocator, 2.0f);
+    RunWithCpuInputAndOutput(*session, 3.0f);
+  }
+  for (auto& session : sessions) {
+    session.reset();
+  }
+  CopyTensorRoundTrip(allocator, 4.0f);
+  auto session = CreateSession();
+  RunWithCpuInputAndOutput(*session, 5.0f);
+}
 
 TEST_F(PluginEpWebGpuConcurrency, DifferentSessionsCreateConcurrently) {
   std::array<std::unique_ptr<Ort::Session>, kThreads> sessions;
@@ -245,9 +309,18 @@ TEST_F(PluginEpWebGpuConcurrency, DifferentSessionsCreateConcurrently) {
   });
 
   ASSERT_FALSE(error.Failed()) << error.Message();
-  for (const auto& session : sessions) {
-    ASSERT_NE(session, nullptr);
+  for (int session_index = 0; session_index < kThreads; ++session_index) {
+    ASSERT_NE(sessions[session_index], nullptr);
+    RunWithCpuInputAndOutput(*sessions[session_index], static_cast<float>(session_index + 1));
   }
+
+  RunWorkers(error, [&](int thread_id) {
+    auto& session = *sessions[(thread_id + 1) % kThreads];
+    for (int iteration = 0; iteration < kIterations && !error.Failed(); ++iteration) {
+      RunWithCpuInputAndOutput(session, static_cast<float>(thread_id * kIterations + iteration + 1));
+    }
+  });
+  ASSERT_FALSE(error.Failed()) << error.Message();
 }
 
 TEST_F(PluginEpWebGpuConcurrency, DifferentSessionsRunConcurrently) {
@@ -267,6 +340,72 @@ TEST_F(PluginEpWebGpuConcurrency, DifferentSessionsRunConcurrently) {
   ASSERT_FALSE(error.Failed()) << error.Message();
 }
 
+TEST_F(PluginEpWebGpuConcurrency, DifferentSessionsGraphCaptureAndReplayConcurrently) {
+  std::array<std::atomic<int>, kThreads> replay_counts{};
+  std::array<std::unique_ptr<Ort::Session>, kThreads> sessions;
+  auto allocator = CreateSharedAllocator();
+  ASSERT_NE(allocator, nullptr);
+  std::vector<Ort::Value> gpu_inputs;
+  std::vector<Ort::Value> gpu_outputs;
+  std::vector<Ort::IoBinding> bindings;
+  gpu_inputs.reserve(kThreads);
+  gpu_outputs.reserve(kThreads);
+  bindings.reserve(kThreads);
+
+  for (int session_index = 0; session_index < kThreads; ++session_index) {
+    Ort::SessionOptions options;
+    options.AddConfigEntry(kOrtSessionOptionsDisableCPUEPFallback, "1");
+    options.SetLogSeverityLevel(ORT_LOGGING_LEVEL_INFO);
+    ThrowOnError(Ort::GetApi().SetUserLoggingFunction(options, CountGraphReplays, &replay_counts[session_index]));
+    const std::unordered_map<std::string, std::string> ep_options{{"enableGraphCapture", "1"}};
+    options.AppendExecutionProvider_V2(*ort_env, {Device()}, ep_options);
+    sessions[session_index] = std::make_unique<Ort::Session>(
+        *ort_env, ORT_TSTR("testdata/mul_1.onnx"), options);
+    gpu_inputs.push_back(Ort::Value::CreateTensor<float>(allocator, kShape.data(), kShape.size()));
+    gpu_outputs.push_back(Ort::Value::CreateTensor<float>(allocator, kShape.data(), kShape.size()));
+    bindings.emplace_back(*sessions[session_index]);
+    bindings.back().BindInput("X", gpu_inputs.back());
+    bindings.back().BindOutput("Y", gpu_outputs.back());
+  }
+
+  FirstError error;
+  std::barrier run_start{kThreads};
+  RunWorkers(error, [&](int thread_id) {
+    try {
+      const auto cpu_memory = Ort::MemoryInfo::CreateCpu(OrtDeviceAllocator, OrtMemTypeCPU);
+      std::array<float, kElements> input_data{};
+      std::array<float, kElements> output_data{};
+      auto cpu_input = Ort::Value::CreateTensor<float>(
+          cpu_memory, input_data.data(), input_data.size(), kShape.data(), kShape.size());
+      auto cpu_output = Ort::Value::CreateTensor<float>(
+          cpu_memory, output_data.data(), output_data.size(), kShape.data(), kShape.size());
+      Ort::RunOptions run_options;
+      auto& binding = bindings[thread_id];
+      for (int iteration = 0; iteration < kIterations; ++iteration) {
+        const float value = static_cast<float>(thread_id * kIterations + iteration + 1);
+        input_data.fill(value);
+        output_data.fill(-1.0f);
+        ThrowOnError(ort_env->CopyTensor(cpu_input, gpu_inputs[thread_id], nullptr));
+        binding.SynchronizeInputs();
+        run_start.arrive_and_wait();
+        sessions[thread_id]->Run(run_options, binding);
+        binding.SynchronizeOutputs();
+        ThrowOnError(ort_env->CopyTensor(gpu_outputs[thread_id], cpu_output, nullptr));
+        VerifyOutput(output_data, value);
+      }
+    } catch (...) {
+      run_start.arrive_and_drop();
+      throw;
+    }
+  });
+
+  ASSERT_FALSE(error.Failed()) << error.Message();
+  for (int session_index = 0; session_index < kThreads; ++session_index) {
+    EXPECT_GE(replay_counts[session_index].load(), kIterations - 1)
+        << "Session " << session_index << " did not execute the graph replay path";
+  }
+}
+
 TEST_F(PluginEpWebGpuConcurrency, CpuInputAndOutputRun) {
   auto session = CreateSession();
   for (int iteration = 0; iteration < kIterations; ++iteration) {
@@ -279,7 +418,7 @@ TEST_F(PluginEpWebGpuConcurrency, CpuPartitionBetweenGpuKernels) {
   model.set_ir_version(ONNX_NAMESPACE::Version::IR_VERSION);
   model.add_opset_import()->set_version(18);
   auto* graph = model.mutable_graph();
-  graph->set_name("webgpu_stream_partition_copy");
+  graph->set_name("webgpu_session_partition_copy");
   for (auto* value_info : {graph->add_input(), graph->add_output()}) {
     value_info->set_name(value_info == &graph->input(0) ? "X" : "Y");
     auto* tensor_type = value_info->mutable_type()->mutable_tensor_type();
@@ -411,71 +550,65 @@ TEST_F(PluginEpWebGpuConcurrency, SharedGpuCopyCompletesBeforeSessionRun) {
   }
 }
 
-TEST_F(PluginEpWebGpuConcurrency, MixedSessionAndAllocatorOperationsConcurrently) {
-  constexpr int kOperationGroups = 4;
-  constexpr int kTotalThreads = kOperationGroups * kThreads;
-  constexpr int kMixedIterations = 10;
-
+TEST_F(PluginEpWebGpuConcurrency, DifferentSessionsAndEnvironmentCopiesRunConcurrently) {
   std::array<std::unique_ptr<Ort::Session>, kThreads> run_sessions;
-  for (int thread_id = 0; thread_id < kThreads; ++thread_id) {
-    run_sessions[thread_id] = CreateSession();
+  for (auto& session : run_sessions) {
+    session = CreateSession();
   }
 
-  const auto gpu_memory_info = Device().GetMemoryInfo(OrtDeviceMemoryType_DEFAULT);
   auto shared_allocator = CreateSharedAllocator();
   ASSERT_NE(shared_allocator, nullptr);
 
   FirstError error;
-  std::barrier start{kTotalThreads};
-  std::vector<std::thread> threads;
-  threads.reserve(kTotalThreads);
-
-  const auto add_workers = [&](std::string group_name, auto work) {
-    for (int thread_id = 0; thread_id < kThreads; ++thread_id) {
-      threads.emplace_back([&, group_name, work, thread_id]() {
-        try {
-          start.arrive_and_wait();
-          work(thread_id);
-        } catch (const std::exception& ex) {
-          error.Set(group_name + " thread " + std::to_string(thread_id) + ": " + ex.what());
-        }
-      });
-    }
-  };
-
-  add_workers("create session", [&](int /*thread_id*/) {
-    for (int iteration = 0; iteration < kMixedIterations && !error.Failed(); ++iteration) {
-      auto session = CreateSession();
-    }
-  });
-
-  add_workers("run session", [&](int thread_id) {
-    for (int iteration = 0; iteration < kMixedIterations && !error.Failed(); ++iteration) {
-      const float value = static_cast<float>(thread_id * kMixedIterations + iteration + 1);
-      RunWithCpuInputAndOutput(*run_sessions[thread_id], value);
-    }
-  });
-
-  add_workers("session allocator", [&](int thread_id) {
-    Ort::Allocator allocator(*run_sessions[thread_id], gpu_memory_info);
-    for (int iteration = 0; iteration < kMixedIterations && !error.Failed(); ++iteration) {
-      const float value = static_cast<float>(100 + thread_id * kMixedIterations + iteration);
-      CopyTensorRoundTrip(allocator, value);
-    }
-  });
-
-  add_workers("shared allocator", [&](int thread_id) {
-    for (int iteration = 0; iteration < kMixedIterations && !error.Failed(); ++iteration) {
-      const float value = static_cast<float>(200 + thread_id * kMixedIterations + iteration);
-      CopyTensorRoundTrip(shared_allocator, value);
-    }
-  });
-
-  for (auto& thread : threads) {
-    thread.join();
-  }
+  RunWorkers(error, [&](int thread_id) {
+               for (int iteration = 0; iteration < kIterations && !error.Failed(); ++iteration) {
+                 const float value = static_cast<float>(thread_id * kIterations + iteration + 1);
+                 if (thread_id < kThreads) {
+                   RunWithCpuInputAndOutput(*run_sessions[thread_id], value);
+                 } else {
+                   CopyTensorRoundTrip(shared_allocator, value);
+                 }
+               } }, 2 * kThreads);
 
   ASSERT_FALSE(error.Failed()) << error.Message();
+}
+
+TEST_F(PluginEpWebGpuConcurrency, MixedSessionAndEnvironmentOperationsConcurrently12Threads) {
+  RunMixedSessionOperations(false);
+}
+
+TEST_F(PluginEpWebGpuConcurrency, DISABLED_MixedSessionAndAllocatorOperationsConcurrently16Threads) {
+  RunMixedSessionOperations(true);
+}
+
+TEST_F(PluginEpWebGpuConcurrency, SessionAllocatorClearsReusedBufferOutsideRun) {
+  auto session = CreateSession();
+  Ort::Allocator allocator(*session, Device().GetMemoryInfo(OrtDeviceMemoryType_DEFAULT));
+  const auto cpu_memory = Ort::MemoryInfo::CreateCpu(OrtDeviceAllocator, OrtMemTypeCPU);
+  std::array<float, kElements> input_data{};
+  input_data.fill(7.0f);
+  auto cpu_input = Ort::Value::CreateTensor<float>(
+      cpu_memory, input_data.data(), input_data.size(), kShape.data(), kShape.size());
+  const void* released_buffer = nullptr;
+  {
+    auto gpu_tensor = Ort::Value::CreateTensor<float>(allocator, kShape.data(), kShape.size());
+    released_buffer = gpu_tensor.GetTensorRawData();
+    ThrowOnError(ort_env->CopyTensor(cpu_input, gpu_tensor, nullptr));
+  }
+
+  auto reused_tensor = Ort::Value::CreateTensor<float>(allocator, kShape.data(), kShape.size());
+  ASSERT_EQ(reused_tensor.GetTensorRawData(), released_buffer);
+  std::array<float, kElements> output_data{};
+  output_data.fill(-1.0f);
+  auto cpu_output = Ort::Value::CreateTensor<float>(
+      cpu_memory, output_data.data(), output_data.size(), kShape.data(), kShape.size());
+  ThrowOnError(ort_env->CopyTensor(reused_tensor, cpu_output, nullptr));
+  const std::array<float, kElements> zeros{};
+  EXPECT_EQ(output_data, zeros);
+
+  ThrowOnError(ort_env->CopyTensor(cpu_input, reused_tensor, nullptr));
+  ThrowOnError(ort_env->CopyTensor(reused_tensor, cpu_output, nullptr));
+  EXPECT_EQ(output_data, input_data);
 }
 
 #endif  // defined(USE_WEBGPU) && defined(ORT_USE_EP_API_ADAPTERS)

--- a/onnxruntime/test/autoep/test_webgpu_concurrency.cc
+++ b/onnxruntime/test/autoep/test_webgpu_concurrency.cc
@@ -582,7 +582,7 @@ TEST_F(PluginEpWebGpuConcurrency, SharedGpuCopyCompletesBeforeSessionRun) {
     std::array<float, kElements> input_data{};
     input_data.fill(value);
     auto input = Ort::Value::CreateTensor<float>(cpu_memory, input_data.data(), input_data.size(),
-                                                kShape.data(), kShape.size());
+                                                 kShape.data(), kShape.size());
     auto source = Ort::Value::CreateTensor<float>(allocator, kShape.data(), kShape.size());
     auto destination = Ort::Value::CreateTensor<float>(allocator, kShape.data(), kShape.size());
     ThrowOnError(ort_env->CopyTensor(input, source, nullptr));

--- a/onnxruntime/test/autoep/test_webgpu_concurrency.cc
+++ b/onnxruntime/test/autoep/test_webgpu_concurrency.cc
@@ -323,6 +323,36 @@ TEST_F(PluginEpWebGpuConcurrency, DifferentSessionsCreateConcurrently) {
   ASSERT_FALSE(error.Failed()) << error.Message();
 }
 
+TEST_F(PluginEpWebGpuConcurrency, DifferentSessionsCreateAndRunConcurrently) {
+  std::array<std::unique_ptr<Ort::Session>, kThreads> run_sessions;
+  for (auto& session : run_sessions) {
+    session = CreateSession();
+  }
+
+  FirstError error;
+  std::barrier iteration_start{2 * kThreads};
+  const auto work = [&](int thread_id) {
+    try {
+      for (int iteration = 0; iteration < kIterations; ++iteration) {
+        iteration_start.arrive_and_wait();
+        const float value = static_cast<float>(thread_id * kIterations + iteration + 1);
+        if (thread_id < kThreads) {
+          auto session = CreateSession();
+          RunWithCpuInputAndOutput(*session, value);
+        } else {
+          RunWithCpuInputAndOutput(*run_sessions[thread_id - kThreads], value);
+        }
+      }
+    } catch (...) {
+      iteration_start.arrive_and_drop();
+      throw;
+    }
+  };
+  RunWorkers(error, work, 2 * kThreads);
+
+  ASSERT_FALSE(error.Failed()) << error.Message();
+}
+
 TEST_F(PluginEpWebGpuConcurrency, DifferentSessionsRunConcurrently) {
   std::array<std::unique_ptr<Ort::Session>, kThreads> sessions;
   for (auto& session : sessions) {
@@ -511,7 +541,7 @@ TEST_F(PluginEpWebGpuConcurrency, SessionAllocatorsCreateAndCopyConcurrently) {
   ASSERT_FALSE(error.Failed()) << error.Message();
 }
 
-TEST_F(PluginEpWebGpuConcurrency, SharedAllocatorCreatesAndCopiesConcurrently) {
+TEST_F(PluginEpWebGpuConcurrency, DISABLED_SharedAllocatorCreatesAndCopiesConcurrently) {
   auto allocator = CreateSharedAllocator();
   ASSERT_NE(allocator, nullptr);
 
@@ -595,7 +625,7 @@ TEST_F(PluginEpWebGpuConcurrency, SharedGpuCopyCompletesBeforeSessionRun) {
   }
 }
 
-TEST_F(PluginEpWebGpuConcurrency, DifferentSessionsAndEnvironmentCopiesRunConcurrently) {
+TEST_F(PluginEpWebGpuConcurrency, DISABLED_DifferentSessionsAndEnvironmentCopiesRunConcurrently) {
   std::array<std::unique_ptr<Ort::Session>, kThreads> run_sessions;
   for (auto& session : run_sessions) {
     session = CreateSession();
@@ -618,10 +648,14 @@ TEST_F(PluginEpWebGpuConcurrency, DifferentSessionsAndEnvironmentCopiesRunConcur
   ASSERT_FALSE(error.Failed()) << error.Message();
 }
 
-TEST_F(PluginEpWebGpuConcurrency, MixedSessionAndEnvironmentOperationsConcurrently12Threads) {
+// Next-phase target: shared Env allocator operations and copies concurrent with Session creation and Run.
+// Keep disabled until shared-allocator concurrency is supported.
+TEST_F(PluginEpWebGpuConcurrency, DISABLED_MixedSessionAndEnvironmentOperationsConcurrently12Threads) {
   RunMixedSessionOperations(false);
 }
 
+// Next-phase target: also exercise a Session's allocator concurrently with that same Session's Run.
+// Keep disabled until both Session and shared-allocator concurrency are supported.
 TEST_F(PluginEpWebGpuConcurrency, DISABLED_MixedSessionAndAllocatorOperationsConcurrently16Threads) {
   RunMixedSessionOperations(true);
 }

--- a/onnxruntime/test/providers/webgpu/concurrent_context_test.cc
+++ b/onnxruntime/test/providers/webgpu/concurrent_context_test.cc
@@ -1,0 +1,302 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Concurrency regression tests for the shared default WebGpuContext (context_id=0) used by
+// multiple InferenceSessions on different threads.
+//
+// Background:
+//   InferenceSession only serializes a single session's Run via its own session_mutex_ (the
+//   WebGPU EP reports ConcurrentRunSupported() == false). It does NOT serialize across
+//   sessions. Multiple sessions with the default WebGPU provider share one WebGpuContext, so
+//   their Run / allocation / initializer-upload paths run concurrently and mutate the
+//   context's single command encoder (current_command_encoder_ / current_compute_pass_encoder_
+//   / num_pending_dispatches_) AND the shared BufferManager cache maps.
+//
+//   Before the fix this produced a data race and Dawn errors such as:
+//     "[CommandEncoder] is already finished. While encoding CopyBufferToBuffer(...)"
+//     "WebGPU validation failed. Command encoding already finished."
+//   or a corrupted buffer cache -> "[Device] is lost", often taking down the GPU process.
+//
+//   The fix serializes all shared-context mutations (command encoder AND buffer caches) with a
+//   per-context recursive mutex (WebGpuContext::context_mutex_ / AcquireContextLock()). With
+//   the fix, the concurrent scenarios below complete cleanly with correct output.
+//
+// The tests cover several distinct multithreaded shapes:
+//   A. one session, run() concurrently from many threads
+//   B. many threads, each with its own pre-created session, running concurrently
+//   C. mixed: some threads create+Initialize+run new sessions while others run existing ones
+//   D. churn: many threads each repeatedly create + run + destroy their own session
+
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "core/graph/onnx_protobuf.h"
+#include "core/graph/model.h"
+#include "core/session/inference_session.h"
+
+#include "test/test_environment.h"
+#include "test/unittest_util/framework_test_utils.h"
+#include "test/util/include/asserts.h"
+#include "test/util/include/default_providers.h"
+
+namespace onnxruntime {
+namespace test {
+
+namespace {
+
+// Builds an in-memory model: Y = ((X + W0) + W1) + ... + W(chain_len-1)
+// where each Wi is a constant initializer of `num_elements` floats. The constant initializers
+// exercise the BufferManager::Upload (CopyBufferToBuffer) path during Initialize, and each Add
+// node produces a compute dispatch during Run.
+void BuildAddChainModel(int chain_len, int64_t num_elements, std::string& model_bytes) {
+  const std::unordered_map<std::string, int> domain_to_version{{"", 13}};
+  Model model("webgpu_concurrent_ctx", false, ModelMetaData(), PathString(),
+              IOnnxRuntimeOpSchemaRegistryList(), domain_to_version,
+              std::vector<ONNX_NAMESPACE::FunctionProto>(),
+              DefaultLoggingManager().DefaultLogger());
+  Graph& graph = model.MainGraph();
+
+  ONNX_NAMESPACE::TypeProto float_1d;
+  float_1d.mutable_tensor_type()->set_elem_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+  float_1d.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(num_elements);
+
+  const std::vector<float> weight_values(static_cast<size_t>(num_elements), 0.5f);
+
+  NodeArg* prev = &graph.GetOrCreateNodeArg("X", &float_1d);
+  for (int i = 0; i < chain_len; ++i) {
+    const std::string w_name = "W" + std::to_string(i);
+    ONNX_NAMESPACE::TensorProto w_tensor;
+    w_tensor.set_name(w_name);
+    w_tensor.set_data_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+    w_tensor.add_dims(num_elements);
+    w_tensor.set_raw_data(weight_values.data(), weight_values.size() * sizeof(float));
+    graph.AddInitializedTensor(w_tensor);
+
+    NodeArg* w_arg = &graph.GetOrCreateNodeArg(w_name, &float_1d);
+    const std::string out_name = (i == chain_len - 1) ? "Y" : ("H" + std::to_string(i));
+    NodeArg* out_arg = &graph.GetOrCreateNodeArg(out_name, &float_1d);
+    std::vector<NodeArg*> inputs{prev, w_arg};
+    std::vector<NodeArg*> outputs{out_arg};
+    graph.AddNode("add" + std::to_string(i), "Add", "", inputs, outputs);
+    prev = out_arg;
+  }
+
+  graph.SetOutputs(std::vector<const NodeArg*>{prev});
+  ASSERT_STATUS_OK(graph.Resolve());
+  ASSERT_TRUE(model.ToProto().SerializeToString(&model_bytes));
+}
+
+// Thread-safe first-error recorder that also acts as a stop flag for the worker loops.
+class ErrorSink {
+ public:
+  void Record(const std::string& message) {
+    bool expected = false;
+    if (failed_.compare_exchange_strong(expected, true)) {
+      std::lock_guard<std::mutex> lock(mutex_);
+      first_error_ = message;
+    }
+  }
+
+  bool Failed() const { return failed_.load(); }
+
+  std::string FirstError() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return first_error_;
+  }
+
+ private:
+  std::atomic<bool> failed_{false};
+  mutable std::mutex mutex_;
+  std::string first_error_;
+};
+
+}  // namespace
+
+// Fixture: builds the shared model once and provides session/feed factories. A long-lived
+// keepalive session pins the shared WebGPU context (ref-count > 0) for the whole test so that
+// churn/destroy in one thread never tears the context down under the others.
+class WebGpuConcurrentContextTest : public ::testing::Test {
+ protected:
+  static constexpr int64_t kNumElements = 256 * 1024;  // 1 MB per initializer
+  static constexpr int kChainLen = 8;                  // 8 uploads + 8 dispatches per session
+  static constexpr float kExpected = 1.0f + 0.5f * kChainLen;
+
+  void SetUp() override {
+    if (DefaultWebGpuExecutionProvider() == nullptr) {
+      GTEST_SKIP() << "WebGPU execution provider is not available.";
+    }
+    ASSERT_NO_FATAL_FAILURE(BuildAddChainModel(kChainLen, kNumElements, model_bytes_));
+    keepalive_ = MakeSession();
+  }
+
+  std::unique_ptr<InferenceSession> MakeSession() {
+    SessionOptions so;
+    so.session_logid = "webgpu_concurrent_ctx";
+    auto session = std::make_unique<InferenceSession>(so, GetEnvironment());
+    ORT_THROW_IF_ERROR(session->RegisterExecutionProvider(DefaultWebGpuExecutionProvider()));
+    ORT_THROW_IF_ERROR(session->Load(model_bytes_.data(), static_cast<int>(model_bytes_.size())));
+    ORT_THROW_IF_ERROR(session->Initialize());
+    return session;
+  }
+
+  NameMLValMap MakeFeeds() const {
+    std::vector<float> x_values(static_cast<size_t>(kNumElements), 1.0f);
+    OrtValue x_value;
+    CreateMLValue<float>(TestCPUExecutionProvider()->CreatePreferredAllocators()[0],
+                         std::vector<int64_t>{kNumElements}, x_values, &x_value);
+    return NameMLValMap{{"X", x_value}};
+  }
+
+  // Runs one inference and validates the numerical result. Records into `sink` on failure.
+  void RunOnce(InferenceSession& session, ErrorSink& sink, const std::string& tag) {
+    std::vector<std::string> output_names{"Y"};
+    std::vector<OrtValue> fetches;
+    Status s = session.Run(RunOptions{}, MakeFeeds(), output_names, &fetches);
+    if (!s.IsOK()) {
+      sink.Record(tag + " Run failed: " + s.ErrorMessage());
+      return;
+    }
+    const Tensor& out = fetches[0].Get<Tensor>();
+    const float* data = out.Data<float>();
+    const int64_t n = out.Shape().Size();
+    for (int64_t i = 0; i < n; i += (n / 8) + 1) {
+      if (std::abs(data[i] - kExpected) > 1e-3f) {
+        sink.Record(tag + " wrong output: " + std::to_string(data[i]));
+        return;
+      }
+    }
+  }
+
+  // Repeatedly runs an existing session until `iters` reached or a failure is recorded.
+  void RunLoop(InferenceSession& session, int iters, ErrorSink& sink, const std::string& tag) {
+    for (int i = 0; i < iters && !sink.Failed(); ++i) {
+      try {
+        RunOnce(session, sink, tag);
+      } catch (const std::exception& e) {
+        sink.Record(tag + " threw: " + e.what());
+        return;
+      }
+    }
+  }
+
+  static void JoinAll(std::vector<std::thread>& threads) {
+    for (auto& t : threads) {
+      t.join();
+    }
+  }
+
+  std::string model_bytes_;
+  std::unique_ptr<InferenceSession> keepalive_;
+};
+
+// Case A: one session, run() concurrently from many threads. InferenceSession serializes these
+// via session_mutex_, but this still must never crash or deadlock on the shared context.
+TEST_F(WebGpuConcurrentContextTest, SingleSessionMultiThreadRun) {
+  constexpr int kThreads = 4;
+  constexpr int kIters = 30;
+
+  auto session = MakeSession();
+  ErrorSink sink;
+  std::vector<std::thread> threads;
+  for (int t = 0; t < kThreads; ++t) {
+    threads.emplace_back([&, t]() { RunLoop(*session, kIters, sink, "A.run" + std::to_string(t)); });
+  }
+  JoinAll(threads);
+
+  ASSERT_FALSE(sink.Failed()) << sink.FirstError();
+}
+
+// Case B: many threads, each with its own pre-created session. All sessions share the default
+// context, so their Run paths hammer the shared command encoder / buffer cache concurrently.
+TEST_F(WebGpuConcurrentContextTest, PerThreadSessionRun) {
+  constexpr int kThreads = 4;
+  constexpr int kIters = 30;
+
+  std::vector<std::unique_ptr<InferenceSession>> sessions(kThreads);
+  for (int t = 0; t < kThreads; ++t) {
+    sessions[t] = MakeSession();
+  }
+
+  ErrorSink sink;
+  std::vector<std::thread> threads;
+  for (int t = 0; t < kThreads; ++t) {
+    threads.emplace_back([&, t]() { RunLoop(*sessions[t], kIters, sink, "B.sess" + std::to_string(t)); });
+  }
+  JoinAll(threads);
+
+  ASSERT_FALSE(sink.Failed()) << sink.FirstError();
+}
+
+// Case C: mixed. Runner threads dispatch on pre-initialized sessions while builder threads keep
+// creating + Initializing (initializer-upload path) + running fresh sessions. This is the
+// closest shape to the original WebNN crash (dispatch racing initializer upload).
+TEST_F(WebGpuConcurrentContextTest, MixedCreateAndRun) {
+  constexpr int kRunners = 3;
+  constexpr int kBuilders = 3;
+  constexpr int kIters = 30;
+
+  std::vector<std::unique_ptr<InferenceSession>> runner_sessions(kRunners);
+  for (int t = 0; t < kRunners; ++t) {
+    runner_sessions[t] = MakeSession();
+  }
+
+  ErrorSink sink;
+  std::vector<std::thread> threads;
+  for (int t = 0; t < kRunners; ++t) {
+    threads.emplace_back([&, t]() { RunLoop(*runner_sessions[t], kIters, sink, "C.runner" + std::to_string(t)); });
+  }
+  for (int t = 0; t < kBuilders; ++t) {
+    threads.emplace_back([&, t]() {
+      const std::string tag = "C.builder" + std::to_string(t);
+      for (int i = 0; i < kIters && !sink.Failed(); ++i) {
+        try {
+          auto session = MakeSession();  // Initialize -> initializer upload
+          RunOnce(*session, sink, tag);
+        } catch (const std::exception& e) {
+          sink.Record(tag + " threw: " + e.what());
+          return;
+        }
+      }
+    });
+  }
+  JoinAll(threads);
+
+  ASSERT_FALSE(sink.Failed()) << sink.FirstError();
+}
+
+// Case D: churn. Many threads each repeatedly create + run + destroy their own session,
+// exercising concurrent allocation and release on the shared buffer caches.
+TEST_F(WebGpuConcurrentContextTest, ChurnCreateRunDestroy) {
+  constexpr int kThreads = 4;
+  constexpr int kIters = 15;
+
+  ErrorSink sink;
+  std::vector<std::thread> threads;
+  for (int t = 0; t < kThreads; ++t) {
+    threads.emplace_back([&, t]() {
+      const std::string tag = "D.churn" + std::to_string(t);
+      for (int i = 0; i < kIters && !sink.Failed(); ++i) {
+        try {
+          auto session = MakeSession();
+          RunOnce(*session, sink, tag);
+          session.reset();  // drop session -> release its resources while others run
+        } catch (const std::exception& e) {
+          sink.Record(tag + " threw: " + e.what());
+          return;
+        }
+      }
+    });
+  }
+  JoinAll(threads);
+
+  ASSERT_FALSE(sink.Failed()) << sink.FirstError();
+}
+
+}  // namespace test
+}  // namespace onnxruntime

--- a/onnxruntime/test/providers/webgpu/concurrent_context_test.cc
+++ b/onnxruntime/test/providers/webgpu/concurrent_context_test.cc
@@ -1,0 +1,596 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Concurrency regression tests for the shared default WebGpuContext (context_id=0) used by
+// multiple InferenceSessions on different threads.
+//
+// Background:
+//   InferenceSession only serializes a single session's Run via its own session_mutex_ (the
+//   WebGPU EP reports ConcurrentRunSupported() == false). It does NOT serialize across
+//   sessions. Multiple sessions with the default WebGPU provider share one WebGpuContext, so
+//   their Run / allocation / initializer-upload paths run concurrently and mutate the
+//   context's single command encoder (current_command_encoder_ / current_compute_pass_encoder_
+//   / num_pending_dispatches_) AND the shared BufferManager cache maps.
+//
+//   Before the fix this produced a data race and Dawn errors such as:
+//     "[CommandEncoder] is already finished. While encoding CopyBufferToBuffer(...)"
+//     "WebGPU validation failed. Command encoding already finished."
+//   a corrupted buffer cache -> "[Device] is lost", or - worst of all - a silently wrong result
+//   when a buffer was recycled before the work referencing it had been submitted.
+//
+//   The fix partitions state by ownership rather than wrapping shared state in locks:
+//     - Command recording state (encoder, compute pass, pending dispatch count) moved from the
+//       shared context onto the EP, i.e. one per session. Dawn's ImplicitDeviceSynchronization
+//       explicitly does not cover command encoding, and InferenceSession already serializes a
+//       single session's Run via session_mutex_, so per-session ownership needs no lock at all.
+//     - Each session owns its BufferManager and buffer caches, so allocation and release never
+//       mutate another session's cache state.
+//
+// The tests cover several distinct multithreaded shapes:
+//   A. one session, run() concurrently from many threads
+//   B. many threads, each with its own pre-created session, running concurrently
+//   C. mixed: some threads create+Initialize+run new sessions while others run existing ones
+//   D. churn: many threads each repeatedly create + run + destroy their own session
+//   E. a cold session compiling many pipelines must not block a warm session's inference
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <iostream>
+#include <iterator>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "core/graph/onnx_protobuf.h"
+#include "core/graph/model.h"
+#include "core/platform/env.h"
+#include "core/providers/webgpu/webgpu_provider_options.h"
+#include "core/session/inference_session.h"
+
+#include "test/test_environment.h"
+#include "test/unittest_util/framework_test_utils.h"
+#include "test/util/include/asserts.h"
+#include "test/util/include/default_providers.h"
+
+namespace onnxruntime {
+namespace test {
+
+namespace {
+
+// Builds an in-memory model: Y = ((X + W0) + W1) + ... + W(chain_len-1)
+// where each Wi is a constant initializer of `num_elements` floats. The constant initializers
+// exercise the BufferManager::Upload (CopyBufferToBuffer) path during Initialize, and each Add
+// node produces a compute dispatch during Run.
+void BuildAddChainModel(int chain_len, int64_t num_elements, std::string& model_bytes) {
+  const std::unordered_map<std::string, int> domain_to_version{{"", 13}};
+  Model model("webgpu_concurrent_ctx", false, ModelMetaData(), PathString(),
+              IOnnxRuntimeOpSchemaRegistryList(), domain_to_version,
+              std::vector<ONNX_NAMESPACE::FunctionProto>(),
+              DefaultLoggingManager().DefaultLogger());
+  Graph& graph = model.MainGraph();
+
+  ONNX_NAMESPACE::TypeProto float_1d;
+  float_1d.mutable_tensor_type()->set_elem_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+  float_1d.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(num_elements);
+
+  const std::vector<float> weight_values(static_cast<size_t>(num_elements), 0.5f);
+
+  NodeArg* prev = &graph.GetOrCreateNodeArg("X", &float_1d);
+  for (int i = 0; i < chain_len; ++i) {
+    const std::string w_name = "W" + std::to_string(i);
+    ONNX_NAMESPACE::TensorProto w_tensor;
+    w_tensor.set_name(w_name);
+    w_tensor.set_data_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+    w_tensor.add_dims(num_elements);
+    w_tensor.set_raw_data(weight_values.data(), weight_values.size() * sizeof(float));
+    graph.AddInitializedTensor(w_tensor);
+
+    NodeArg* w_arg = &graph.GetOrCreateNodeArg(w_name, &float_1d);
+    const std::string out_name = (i == chain_len - 1) ? "Y" : ("H" + std::to_string(i));
+    NodeArg* out_arg = &graph.GetOrCreateNodeArg(out_name, &float_1d);
+    std::vector<NodeArg*> inputs{prev, w_arg};
+    std::vector<NodeArg*> outputs{out_arg};
+    graph.AddNode("add" + std::to_string(i), "Add", "", inputs, outputs);
+    prev = out_arg;
+  }
+
+  graph.SetOutputs(std::vector<const NodeArg*>{prev});
+  ASSERT_STATUS_OK(graph.Resolve());
+  ASSERT_TRUE(model.ToProto().SerializeToString(&model_bytes));
+}
+
+// The distinct unary op types used by BuildUnaryFanOutModel. Each op type maps to its own WebGPU
+// program, so a session using this model has to compile one pipeline per entry.
+constexpr const char* kUnaryOps[] = {
+    "Abs", "Neg", "Floor", "Ceil", "Reciprocal", "Sqrt", "Exp", "Erf", "Sigmoid",
+    "Sin", "Cos", "Tan", "Atan", "Sinh", "Cosh", "Tanh", "HardSigmoid", "HardSwish"};
+
+// Builds an in-memory model that fans one input out to every op in kUnaryOps:
+//   Y0 = Abs(X), Y1 = Neg(X), ...
+//
+// Distinct op types mean distinct programs, so the first Run of a session built from this model
+// compiles std::size(kUnaryOps) pipelines. A fan-out rather than a chain keeps every op inside
+// its valid input domain no matter how many are used.
+void BuildUnaryFanOutModel(int64_t num_elements, std::string& model_bytes) {
+  const std::unordered_map<std::string, int> domain_to_version{{"", 14}};
+  Model model("webgpu_concurrent_ctx_cold", false, ModelMetaData(), PathString(),
+              IOnnxRuntimeOpSchemaRegistryList(), domain_to_version,
+              std::vector<ONNX_NAMESPACE::FunctionProto>(),
+              DefaultLoggingManager().DefaultLogger());
+  Graph& graph = model.MainGraph();
+
+  ONNX_NAMESPACE::TypeProto float_1d;
+  float_1d.mutable_tensor_type()->set_elem_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+  float_1d.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(num_elements);
+
+  NodeArg* x_arg = &graph.GetOrCreateNodeArg("X", &float_1d);
+  std::vector<const NodeArg*> outputs;
+  outputs.reserve(std::size(kUnaryOps));
+
+  for (size_t i = 0; i < std::size(kUnaryOps); ++i) {
+    NodeArg* out_arg = &graph.GetOrCreateNodeArg("Y" + std::to_string(i), &float_1d);
+    std::vector<NodeArg*> node_inputs{x_arg};
+    std::vector<NodeArg*> node_outputs{out_arg};
+    graph.AddNode("op" + std::to_string(i), kUnaryOps[i], "", node_inputs, node_outputs);
+    outputs.push_back(out_arg);
+  }
+
+  graph.SetOutputs(outputs);
+  ASSERT_STATUS_OK(graph.Resolve());
+  ASSERT_TRUE(model.ToProto().SerializeToString(&model_bytes));
+}
+
+// Thread-safe first-error recorder that also acts as a stop flag for the worker loops.
+class ErrorSink {
+ public:
+  void Record(const std::string& message) {
+    bool expected = false;
+    if (failed_.compare_exchange_strong(expected, true)) {
+      std::lock_guard<std::mutex> lock(mutex_);
+      first_error_ = message;
+    }
+  }
+
+  bool Failed() const { return failed_.load(); }
+
+  std::string FirstError() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return first_error_;
+  }
+
+ private:
+  std::atomic<bool> failed_{false};
+  mutable std::mutex mutex_;
+  std::string first_error_;
+};
+
+}  // namespace
+
+// Fixture: builds the shared model once and provides session/feed factories. A long-lived
+// keepalive session pins the shared WebGPU context (ref-count > 0) for the whole test so that
+// churn/destroy in one thread never tears the context down under the others.
+class WebGpuConcurrentContextTest : public ::testing::Test {
+ protected:
+  static constexpr int64_t kNumElements = 256 * 1024;  // 1 MB per initializer
+  static constexpr int kChainLen = 8;                  // 8 uploads + 8 dispatches per session
+  static constexpr float kExpected = 1.0f + 0.5f * kChainLen;
+
+  void SetUp() override {
+    if (DefaultWebGpuExecutionProvider() == nullptr) {
+      GTEST_SKIP() << "WebGPU execution provider is not available.";
+    }
+    ASSERT_NO_FATAL_FAILURE(BuildAddChainModel(kChainLen, kNumElements, model_bytes_));
+    keepalive_ = MakeSession();
+  }
+
+  std::unique_ptr<InferenceSession> MakeSession() {
+    SessionOptions so;
+    so.session_logid = "webgpu_concurrent_ctx";
+    auto session = std::make_unique<InferenceSession>(so, GetEnvironment());
+    ORT_THROW_IF_ERROR(session->RegisterExecutionProvider(DefaultWebGpuExecutionProvider()));
+    ORT_THROW_IF_ERROR(session->Load(model_bytes_.data(), static_cast<int>(model_bytes_.size())));
+    ORT_THROW_IF_ERROR(session->Initialize());
+    return session;
+  }
+
+  NameMLValMap MakeFeeds() const {
+    std::vector<float> x_values(static_cast<size_t>(kNumElements), 1.0f);
+    OrtValue x_value;
+    CreateMLValue<float>(TestCPUExecutionProvider()->CreatePreferredAllocators()[0],
+                         std::vector<int64_t>{kNumElements}, x_values, &x_value);
+    return NameMLValMap{{"X", x_value}};
+  }
+
+  // Runs one inference and validates the numerical result. Records into `sink` on failure.
+  void RunOnce(InferenceSession& session, ErrorSink& sink, const std::string& tag) {
+    std::vector<std::string> output_names{"Y"};
+    std::vector<OrtValue> fetches;
+    Status s = session.Run(RunOptions{}, MakeFeeds(), output_names, &fetches);
+    if (!s.IsOK()) {
+      sink.Record(tag + " Run failed: " + s.ErrorMessage());
+      return;
+    }
+    const Tensor& out = fetches[0].Get<Tensor>();
+    const float* data = out.Data<float>();
+    const int64_t n = out.Shape().Size();
+    for (int64_t i = 0; i < n; i += (n / 8) + 1) {
+      if (std::abs(data[i] - kExpected) > 1e-3f) {
+        sink.Record(tag + " wrong output: " + std::to_string(data[i]));
+        return;
+      }
+    }
+  }
+
+  // Repeatedly runs an existing session until `iters` reached or a failure is recorded.
+  void RunLoop(InferenceSession& session, int iters, ErrorSink& sink, const std::string& tag) {
+    for (int i = 0; i < iters && !sink.Failed(); ++i) {
+      try {
+        RunOnce(session, sink, tag);
+      } catch (const std::exception& e) {
+        sink.Record(tag + " threw: " + e.what());
+        return;
+      }
+    }
+  }
+
+  static void JoinAll(std::vector<std::thread>& threads) {
+    for (auto& t : threads) {
+      t.join();
+    }
+  }
+
+  std::string model_bytes_;
+  std::unique_ptr<InferenceSession> keepalive_;
+};
+
+// Case A: one session, run() concurrently from many threads. InferenceSession serializes these
+// via session_mutex_, but this still must never crash or deadlock on the shared context.
+TEST_F(WebGpuConcurrentContextTest, SingleSessionMultiThreadRun) {
+  constexpr int kThreads = 4;
+  constexpr int kIters = 30;
+
+  auto session = MakeSession();
+  ErrorSink sink;
+  std::vector<std::thread> threads;
+  for (int t = 0; t < kThreads; ++t) {
+    threads.emplace_back([&, t]() { RunLoop(*session, kIters, sink, "A.run" + std::to_string(t)); });
+  }
+  JoinAll(threads);
+
+  ASSERT_FALSE(sink.Failed()) << sink.FirstError();
+}
+
+// Case B: many threads, each with its own pre-created session. All sessions share the default
+// context, so their Run paths execute concurrently against it. Before the fix they also shared a
+// single command encoder, which is what this case exposed.
+TEST_F(WebGpuConcurrentContextTest, PerThreadSessionRun) {
+  constexpr int kThreads = 4;
+  constexpr int kIters = 30;
+
+  std::vector<std::unique_ptr<InferenceSession>> sessions(kThreads);
+  for (int t = 0; t < kThreads; ++t) {
+    sessions[t] = MakeSession();
+  }
+
+  ErrorSink sink;
+  std::vector<std::thread> threads;
+  for (int t = 0; t < kThreads; ++t) {
+    threads.emplace_back([&, t]() { RunLoop(*sessions[t], kIters, sink, "B.sess" + std::to_string(t)); });
+  }
+  JoinAll(threads);
+
+  ASSERT_FALSE(sink.Failed()) << sink.FirstError();
+}
+
+// Case C: mixed. Runner threads dispatch on pre-initialized sessions while builder threads keep
+// creating + Initializing (initializer-upload path) + running fresh sessions. This is the
+// closest shape to the original WebNN crash (dispatch racing initializer upload).
+TEST_F(WebGpuConcurrentContextTest, MixedCreateAndRun) {
+  constexpr int kRunners = 3;
+  constexpr int kBuilders = 3;
+  constexpr int kIters = 30;
+
+  std::vector<std::unique_ptr<InferenceSession>> runner_sessions(kRunners);
+  for (int t = 0; t < kRunners; ++t) {
+    runner_sessions[t] = MakeSession();
+  }
+
+  ErrorSink sink;
+  std::vector<std::thread> threads;
+  for (int t = 0; t < kRunners; ++t) {
+    threads.emplace_back([&, t]() { RunLoop(*runner_sessions[t], kIters, sink, "C.runner" + std::to_string(t)); });
+  }
+  for (int t = 0; t < kBuilders; ++t) {
+    threads.emplace_back([&, t]() {
+      const std::string tag = "C.builder" + std::to_string(t);
+      for (int i = 0; i < kIters && !sink.Failed(); ++i) {
+        try {
+          auto session = MakeSession();  // Initialize -> initializer upload
+          RunOnce(*session, sink, tag);
+        } catch (const std::exception& e) {
+          sink.Record(tag + " threw: " + e.what());
+          return;
+        }
+      }
+    });
+  }
+  JoinAll(threads);
+
+  ASSERT_FALSE(sink.Failed()) << sink.FirstError();
+}
+
+// Case D: churn. Many threads each repeatedly create + run + destroy their own session,
+// exercising concurrent allocation and release against independent per-session buffer managers.
+TEST_F(WebGpuConcurrentContextTest, ChurnCreateRunDestroy) {
+  constexpr int kThreads = 4;
+  constexpr int kIters = 15;
+
+  ErrorSink sink;
+  std::vector<std::thread> threads;
+  for (int t = 0; t < kThreads; ++t) {
+    threads.emplace_back([&, t]() {
+      const std::string tag = "D.churn" + std::to_string(t);
+      for (int i = 0; i < kIters && !sink.Failed(); ++i) {
+        try {
+          auto session = MakeSession();
+          RunOnce(*session, sink, tag);
+          session.reset();  // drop session -> release its resources while others run
+        } catch (const std::exception& e) {
+          sink.Record(tag + " threw: " + e.what());
+          return;
+        }
+      }
+    });
+  }
+  JoinAll(threads);
+
+  ASSERT_FALSE(sink.Failed()) << sink.FirstError();
+}
+
+// Case E: the review concern behind this design - a session that is warming up (compiling
+// pipelines) must not block inference in other sessions sharing the context.
+//
+// A builder thread creates a session over a model with many distinct op types and runs it once,
+// which compiles one pipeline per op. Meanwhile a runner thread keeps dispatching on an already
+// warm session.
+//
+// If shader compilation were performed while holding a shared context lock, the runner would be
+// stalled for most of the builder's window. The assertion is therefore on throughput retained
+// relative to the runner's uncontended rate, which separates the two designs cleanly; worst-case
+// latency is reported as well but is too noisy to assert on.
+TEST_F(WebGpuConcurrentContextTest, ColdSessionDoesNotBlockWarmInference) {
+  using Clock = std::chrono::steady_clock;
+  using Ms = std::chrono::duration<double, std::milli>;
+
+  std::string cold_model_bytes;
+  ASSERT_NO_FATAL_FAILURE(BuildUnaryFanOutModel(kNumElements, cold_model_bytes));
+
+  // Warm session: every pipeline it needs is already compiled and cached on the context.
+  auto warm_session = MakeSession();
+  ErrorSink sink;
+  RunOnce(*warm_session, sink, "E.warmup");
+  ASSERT_FALSE(sink.Failed()) << sink.FirstError();
+
+  // Baseline latency with no other session active.
+  constexpr int kBaselineIters = 20;
+  std::vector<double> baseline_ms;
+  baseline_ms.reserve(kBaselineIters);
+  for (int i = 0; i < kBaselineIters; ++i) {
+    const auto start = Clock::now();
+    RunOnce(*warm_session, sink, "E.baseline");
+    baseline_ms.push_back(Ms(Clock::now() - start).count());
+  }
+  ASSERT_FALSE(sink.Failed()) << sink.FirstError();
+  std::sort(baseline_ms.begin(), baseline_ms.end());
+  const double baseline_median = baseline_ms[baseline_ms.size() / 2];
+
+  std::atomic<bool> builder_done{false};
+  std::vector<double> contended_ms;
+  double builder_ms = 0.0;
+
+  std::thread builder([&]() {
+    const auto start = Clock::now();
+    try {
+      SessionOptions so;
+      so.session_logid = "webgpu_concurrent_ctx_cold";
+      InferenceSession cold_session(so, GetEnvironment());
+      ORT_THROW_IF_ERROR(cold_session.RegisterExecutionProvider(DefaultWebGpuExecutionProvider()));
+      ORT_THROW_IF_ERROR(cold_session.Load(cold_model_bytes.data(), static_cast<int>(cold_model_bytes.size())));
+      ORT_THROW_IF_ERROR(cold_session.Initialize());
+
+      std::vector<std::string> output_names;
+      for (size_t i = 0; i < std::size(kUnaryOps); ++i) {
+        output_names.push_back("Y" + std::to_string(i));
+      }
+      std::vector<OrtValue> fetches;
+      // This Run is what triggers compilation of one pipeline per op type.
+      ORT_THROW_IF_ERROR(cold_session.Run(RunOptions{}, MakeFeeds(), output_names, &fetches));
+    } catch (const std::exception& e) {
+      sink.Record(std::string("E.builder threw: ") + e.what());
+    }
+    builder_ms = Ms(Clock::now() - start).count();
+    builder_done.store(true);
+  });
+
+  // Always take at least one measurement so the loop cannot produce an empty sample set if the
+  // builder happens to finish first.
+  const auto contended_start = Clock::now();
+  do {
+    const auto start = Clock::now();
+    RunOnce(*warm_session, sink, "E.contended");
+    contended_ms.push_back(Ms(Clock::now() - start).count());
+  } while (!builder_done.load() && !sink.Failed());
+  const double contended_window_ms = Ms(Clock::now() - contended_start).count();
+  builder.join();
+
+  ASSERT_FALSE(sink.Failed()) << sink.FirstError();
+
+  const double contended_max = *std::max_element(contended_ms.begin(), contended_ms.end());
+  std::sort(contended_ms.begin(), contended_ms.end());
+  const double contended_median = contended_ms[contended_ms.size() / 2];
+
+  // Fraction of the contended window during which the warm session kept doing useful work, using
+  // its uncontended latency as the reference. 1.0 means the cold session cost it nothing.
+  //
+  // This aggregate is a far better regression signal than worst-case latency, which is dominated
+  // by scheduler noise: when compilation holds a shared lock the warm session loses most of the
+  // window, whereas it stays high once compilation is off the shared path entirely.
+  const double throughput_efficiency =
+      (static_cast<double>(contended_ms.size()) * baseline_median) / contended_window_ms;
+
+  std::cout << "[ WebGPU  ] cold-session warmup: " << builder_ms << " ms for "
+            << std::size(kUnaryOps) << " pipelines\n"
+            << "[ WebGPU  ] warm-session latency: baseline median " << baseline_median
+            << " ms, contended median " << contended_median
+            << " ms, contended max " << contended_max
+            << " ms over " << contended_ms.size() << " runs\n"
+            << "[ WebGPU  ] warm-session throughput efficiency while cold session warmed up: "
+            << throughput_efficiency << std::endl;
+
+  // Only assert when the compile window was long enough relative to a warm run for interference to
+  // be observable; otherwise there is nothing meaningful to measure and asserting would be flaky.
+  //
+  // Measured on Windows/D3D12 (RTX 5080), five runs each: a design that compiles under a shared
+  // context lock yields 0.22-0.42, whereas the per-session design yields 0.81-0.93 - and its
+  // contended median latency is indistinguishable from the uncontended baseline (~1.95 ms both),
+  // i.e. the residual gap is CPU contention from the compiling thread, not blocking. The threshold
+  // sits in the gap so the test fails on a real regression without flaking on a busy CI machine.
+  if (builder_ms > 10.0 * std::max(baseline_median, 1.0)) {
+    EXPECT_GT(throughput_efficiency, 0.5)
+        << "warm inference lost most of the window to the cold session's shader compilation";
+  }
+}
+
+// DIAGNOSTIC (disabled by default): keeps N sessions over an identical model alive and runs them
+// round-robin on one thread, then holds so an external sampler can read steady-state GPU memory.
+// This is the shape that distinguishes a context-wide buffer pool (steady state ~= one session's
+// high-water mark) from per-session pools (~= N times that).
+//
+//   onnxruntime_provider_test.exe --gtest_also_run_disabled_tests \
+//     --gtest_filter=WebGpuPoolMemory.DISABLED_MultiSessionSameShape
+//
+// Tunable via environment variables: ORT_DIAG_SESSIONS, ORT_DIAG_MB, ORT_DIAG_ITERS,
+// ORT_DIAG_HOLD_MS, ORT_DIAG_VARY (1 = give each session a different tensor size),
+// ORT_DIAG_CACHE (storage buffer cache mode; defaults to "bucket", the product default -
+// note DefaultWebGpuExecutionProvider() disables the storage cache, which would hide the
+// very behavior this test measures).
+TEST(WebGpuPoolMemory, DISABLED_MultiSessionSameShape) {
+  if (DefaultWebGpuExecutionProvider() == nullptr) {
+    GTEST_SKIP() << "WebGPU execution provider is not available.";
+  }
+
+  auto env_int = [](const char* name, int fallback) {
+    const std::string value = Env::Default().GetEnvironmentVar(name);
+    return value.empty() ? fallback : std::stoi(value);
+  };
+
+  const int num_sessions = env_int("ORT_DIAG_SESSIONS", 4);
+  const int mb = env_int("ORT_DIAG_MB", 64);
+  const int iters = env_int("ORT_DIAG_ITERS", 10);
+  const int hold_ms = env_int("ORT_DIAG_HOLD_MS", 5000);
+  const bool vary = env_int("ORT_DIAG_VARY", 0) != 0;
+  std::string cache_mode = Env::Default().GetEnvironmentVar("ORT_DIAG_CACHE");
+  if (cache_mode.empty()) {
+    cache_mode = webgpu::options::kBufferCacheMode_Bucket;
+  }
+  constexpr int kChainLen = 8;
+
+  auto make_ep = [&cache_mode]() {
+    ConfigOptions config_options;
+    ORT_THROW_IF_ERROR(config_options.AddConfigEntry(webgpu::options::kStorageBufferCacheMode,
+                                                     cache_mode.c_str()));
+    return WebGpuExecutionProviderWithOptions(config_options);
+  };
+  std::cout << "DIAG_POOL storage_cache=" << cache_mode << "\n";
+
+  std::vector<std::unique_ptr<InferenceSession>> sessions;
+  std::vector<NameMLValMap> feeds;
+  std::vector<std::string> output_names{"Y"};
+
+  // Scalar weights, so GPU memory is dominated by intermediate tensors (which flow through the
+  // buffer pool) rather than by per-session initializers (which never share across sessions and
+  // would otherwise swamp the signal).
+  auto build_scalar_weight_chain = [](int chain_len, int64_t num_elements, std::string& bytes) {
+    const std::unordered_map<std::string, int> domain_to_version{{"", 13}};
+    Model model("webgpu_pool_memory", false, ModelMetaData(), PathString(),
+                IOnnxRuntimeOpSchemaRegistryList(), domain_to_version,
+                std::vector<ONNX_NAMESPACE::FunctionProto>(),
+                DefaultLoggingManager().DefaultLogger());
+    Graph& graph = model.MainGraph();
+
+    ONNX_NAMESPACE::TypeProto float_1d;
+    float_1d.mutable_tensor_type()->set_elem_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+    float_1d.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(num_elements);
+
+    ONNX_NAMESPACE::TypeProto float_scalar;
+    float_scalar.mutable_tensor_type()->set_elem_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+    float_scalar.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(1);
+
+    NodeArg* prev = &graph.GetOrCreateNodeArg("X", &float_1d);
+    for (int i = 0; i < chain_len; ++i) {
+      const std::string w_name = "w" + std::to_string(i);
+      ONNX_NAMESPACE::TensorProto w_tensor;
+      w_tensor.set_name(w_name);
+      w_tensor.set_data_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+      w_tensor.add_dims(1);
+      const float scalar = 1.0f + 0.01f * i;
+      w_tensor.set_raw_data(&scalar, sizeof(float));
+      graph.AddInitializedTensor(w_tensor);
+
+      NodeArg* w_arg = &graph.GetOrCreateNodeArg(w_name, &float_scalar);
+      const std::string out_name = (i == chain_len - 1) ? "Y" : ("h" + std::to_string(i));
+      NodeArg* out_arg = &graph.GetOrCreateNodeArg(out_name, &float_1d);
+      std::vector<NodeArg*> inputs{prev, w_arg};
+      std::vector<NodeArg*> outputs{out_arg};
+      graph.AddNode("op" + std::to_string(i), (i % 2 == 0) ? "Mul" : "Add", "", inputs, outputs);
+      prev = out_arg;
+    }
+
+    graph.SetOutputs(std::vector<const NodeArg*>{prev});
+    ASSERT_STATUS_OK(graph.Resolve());
+    ASSERT_TRUE(model.ToProto().SerializeToString(&bytes));
+  };
+
+  for (int s = 0; s < num_sessions; ++s) {
+    const int64_t num_elements =
+        static_cast<int64_t>(mb) * 1024 * 1024 / 4 + (vary ? s * 4 * 1024 * 1024 : 0);
+
+    std::string model_bytes;
+    ASSERT_NO_FATAL_FAILURE(build_scalar_weight_chain(kChainLen, num_elements, model_bytes));
+
+    SessionOptions so;
+    so.session_logid = "webgpu_pool_memory";
+    auto session = std::make_unique<InferenceSession>(so, GetEnvironment());
+    ASSERT_STATUS_OK(session->RegisterExecutionProvider(make_ep()));
+    ASSERT_STATUS_OK(session->Load(model_bytes.data(), static_cast<int>(model_bytes.size())));
+    ASSERT_STATUS_OK(session->Initialize());
+
+    std::vector<float> x_values(static_cast<size_t>(num_elements), 1.0f);
+    OrtValue x_value;
+    CreateMLValue<float>(TestCPUExecutionProvider()->CreatePreferredAllocators()[0],
+                         std::vector<int64_t>{num_elements}, x_values, &x_value);
+
+    sessions.push_back(std::move(session));
+    feeds.push_back(NameMLValMap{{"X", x_value}});
+  }
+
+  for (int i = 0; i < iters; ++i) {
+    for (int s = 0; s < num_sessions; ++s) {
+      std::vector<OrtValue> fetches;
+      ASSERT_STATUS_OK(sessions[s]->Run(RunOptions{}, feeds[s], output_names, &fetches));
+    }
+  }
+
+  std::cout << "DIAG_POOL sessions=" << num_sessions << " mb=" << mb
+            << " vary=" << (vary ? 1 : 0) << " iters=" << iters << " holding...\n"
+            << std::flush;
+  std::this_thread::sleep_for(std::chrono::milliseconds(hold_ms));
+}
+
+}  // namespace test
+}  // namespace onnxruntime

--- a/onnxruntime/test/providers/webgpu/concurrent_context_test.cc
+++ b/onnxruntime/test/providers/webgpu/concurrent_context_test.cc
@@ -18,23 +18,21 @@
 //   a corrupted buffer cache -> "[Device] is lost", or - worst of all - a silently wrong result
 //   when a buffer was recycled before the work referencing it had been submitted.
 //
-//   The fix partitions state by ownership rather than wrapping shared state in locks:
-//     - Command recording state (encoder, compute pass, pending dispatch count) moved from the
-//       shared context onto the EP, i.e. one per session. Dawn's ImplicitDeviceSynchronization
-//       explicitly does not cover command encoding, and InferenceSession already serializes a
-//       single session's Run via session_mutex_, so per-session ownership needs no lock at all.
-//     - Each session owns its BufferManager and buffer caches, so allocation and release never
-//       mutate another session's cache state.
+//   Context-level BufferManagers protect only their shared buffer-cache containers. Command
+//   recording remains per session and is passed independently to context operations. Graph capture
+//   retains a separate manager per graph so captured resources remain isolated.
 //
 // The tests cover several distinct multithreaded shapes:
 //   A. one session, run() concurrently from many threads
 //   B. many threads, each with its own pre-created session, running concurrently
 //   C. mixed: some threads create+Initialize+run new sessions while others run existing ones
 //   D. churn: many threads each repeatedly create + run + destroy their own session
-//   E. a cold session compiling many pipelines must not block a warm session's inference
+//   E. a cold and a warm session remain correct while running concurrently
 
 #include <algorithm>
+#include <array>
 #include <atomic>
+#include <barrier>
 #include <chrono>
 #include <iostream>
 #include <iterator>
@@ -49,6 +47,10 @@
 #include "core/graph/onnx_protobuf.h"
 #include "core/graph/model.h"
 #include "core/platform/env.h"
+#include "core/providers/webgpu/allocator.h"
+#include "core/providers/webgpu/data_transfer.h"
+#include "core/providers/webgpu/webgpu_context.h"
+#include "core/providers/webgpu/webgpu_external_header.h"
 #include "core/providers/webgpu/webgpu_provider_options.h"
 #include "core/session/inference_session.h"
 
@@ -325,7 +327,7 @@ TEST_F(WebGpuConcurrentContextTest, MixedCreateAndRun) {
 }
 
 // Case D: churn. Many threads each repeatedly create + run + destroy their own session,
-// exercising concurrent allocation and release against independent per-session buffer managers.
+// exercising concurrent allocation and release against the shared context-level buffer manager.
 TEST_F(WebGpuConcurrentContextTest, ChurnCreateRunDestroy) {
   constexpr int kThreads = 4;
   constexpr int kIters = 15;
@@ -352,18 +354,15 @@ TEST_F(WebGpuConcurrentContextTest, ChurnCreateRunDestroy) {
   ASSERT_FALSE(sink.Failed()) << sink.FirstError();
 }
 
-// Case E: the review concern behind this design - a session that is warming up (compiling
-// pipelines) must not block inference in other sessions sharing the context.
+// Case E: a session warming up pipelines concurrently with a warm session must remain correct.
 //
 // A builder thread creates a session over a model with many distinct op types and runs it once,
 // which compiles one pipeline per op. Meanwhile a runner thread keeps dispatching on an already
 // warm session.
 //
-// If shader compilation were performed while holding a shared context lock, the runner would be
-// stalled for most of the builder's window. The assertion is therefore on throughput retained
-// relative to the runner's uncontended rate, which separates the two designs cleanly; worst-case
-// latency is reported as well but is too noisy to assert on.
-TEST_F(WebGpuConcurrentContextTest, ColdSessionDoesNotBlockWarmInference) {
+// Timing is reported to make lock contention visible without imposing a machine-dependent
+// performance threshold on this correctness test.
+TEST_F(WebGpuConcurrentContextTest, ColdAndWarmSessionsRunConcurrently) {
   using Clock = std::chrono::steady_clock;
   using Ms = std::chrono::duration<double, std::milli>;
 
@@ -436,10 +435,6 @@ TEST_F(WebGpuConcurrentContextTest, ColdSessionDoesNotBlockWarmInference) {
 
   // Fraction of the contended window during which the warm session kept doing useful work, using
   // its uncontended latency as the reference. 1.0 means the cold session cost it nothing.
-  //
-  // This aggregate is a far better regression signal than worst-case latency, which is dominated
-  // by scheduler noise: when compilation holds a shared lock the warm session loses most of the
-  // window, whereas it stays high once compilation is off the shared path entirely.
   const double throughput_efficiency =
       (static_cast<double>(contended_ms.size()) * baseline_median) / contended_window_ms;
 
@@ -452,18 +447,163 @@ TEST_F(WebGpuConcurrentContextTest, ColdSessionDoesNotBlockWarmInference) {
             << "[ WebGPU  ] warm-session throughput efficiency while cold session warmed up: "
             << throughput_efficiency << std::endl;
 
-  // Only assert when the compile window was long enough relative to a warm run for interference to
-  // be observable; otherwise there is nothing meaningful to measure and asserting would be flaky.
-  //
-  // Measured on Windows/D3D12 (RTX 5080), five runs each: a design that compiles under a shared
-  // context lock yields 0.22-0.42, whereas the per-session design yields 0.81-0.93 - and its
-  // contended median latency is indistinguishable from the uncontended baseline (~1.95 ms both),
-  // i.e. the residual gap is CPU contention from the compiling thread, not blocking. The threshold
-  // sits in the gap so the test fails on a real regression without flaking on a busy CI machine.
-  if (builder_ms > 10.0 * std::max(baseline_median, 1.0)) {
-    EXPECT_GT(throughput_efficiency, 0.5)
-        << "warm inference lost most of the window to the cold session's shader compilation";
+}
+
+// Case F: the public session allocator wraps this same internal allocator. Allocations made
+// concurrently with Run must not race the session's command recording state.
+TEST_F(WebGpuConcurrentContextTest, SessionAllocatorAndRunConcurrently) {
+  constexpr int kIters = 40;
+  auto session = MakeSession();
+  auto allocator = session->GetAllocator(OrtMemoryInfo(WEBGPU_BUFFER,
+                                                       OrtAllocatorType::OrtDeviceAllocator,
+                                                       webgpu::WebGpuDevice,
+                                                       OrtMemTypeDefault));
+  ASSERT_NE(allocator, nullptr);
+
+  ErrorSink sink;
+  std::barrier start{2};
+  std::thread runner([&]() {
+    start.arrive_and_wait();
+    RunLoop(*session, kIters, sink, "F.run");
+  });
+  std::thread allocator_user([&]() {
+    start.arrive_and_wait();
+    try {
+      for (int i = 0; i < kIters && !sink.Failed(); ++i) {
+        Tensor tensor(DataTypeImpl::GetType<float>(), TensorShape{kNumElements}, allocator);
+        ASSERT_NE(tensor.MutableDataRaw(), nullptr);
+      }
+    } catch (const std::exception& e) {
+      sink.Record(std::string("F.allocator threw: ") + e.what());
+    }
+  });
+  runner.join();
+  allocator_user.join();
+
+  ASSERT_FALSE(sink.Failed()) << sink.FirstError();
+}
+
+// Case G: an environment shared allocator is one object used by all sessions. It creates external
+// buffers directly and must remain thread-safe without a BufferManager or recording timeline.
+TEST_F(WebGpuConcurrentContextTest, SharedAllocatorMultiThreadCreateTensor) {
+  constexpr int kThreads = 4;
+  constexpr int kIters = 60;
+  auto& context = webgpu::WebGpuContextFactory::GetContext(0);
+  auto context_ref = std::shared_ptr<webgpu::WebGpuContext>(&context, [](webgpu::WebGpuContext*) {});
+  auto allocator = std::make_shared<webgpu::ExternalGpuBufferAllocator>(std::move(context_ref));
+
+  ErrorSink sink;
+  std::barrier start{kThreads};
+  std::vector<std::thread> threads;
+  for (int t = 0; t < kThreads; ++t) {
+    threads.emplace_back([&, t]() {
+      start.arrive_and_wait();
+      try {
+        for (int i = 0; i < kIters && !sink.Failed(); ++i) {
+          Tensor tensor(DataTypeImpl::GetType<float>(), TensorShape{1024 + t * 16}, allocator);
+          ASSERT_NE(tensor.MutableDataRaw(), nullptr);
+        }
+      } catch (const std::exception& e) {
+        sink.Record("G.thread" + std::to_string(t) + " threw: " + e.what());
+      }
+    });
   }
+  JoinAll(threads);
+
+  ASSERT_FALSE(sink.Failed()) << sink.FirstError();
+}
+
+// Case H: OrtEnv owns one data-transfer implementation per EP factory. Concurrent CopyTensors
+// calls must not encode and flush through the same recording state simultaneously.
+TEST_F(WebGpuConcurrentContextTest, SharedDataTransferMultiThreadCopy) {
+  constexpr int kThreads = 4;
+  constexpr int kIters = 30;
+  constexpr size_t kElements = 4096;
+  auto& context = webgpu::WebGpuContextFactory::GetContext(0);
+  webgpu::CommandRecordingState recording;
+  webgpu::DataTransferImpl data_transfer(context.BufferManager(), recording);
+
+  std::array<wgpu::Buffer, kThreads> gpu_buffers;
+  for (auto& buffer : gpu_buffers) {
+    wgpu::BufferDescriptor desc{};
+    desc.size = kElements * sizeof(float);
+    desc.usage = wgpu::BufferUsage::Storage | wgpu::BufferUsage::CopySrc | wgpu::BufferUsage::CopyDst;
+    buffer = context.Device().CreateBuffer(&desc);
+  }
+
+  ErrorSink sink;
+  std::barrier start{kThreads};
+  std::vector<std::thread> threads;
+  for (int t = 0; t < kThreads; ++t) {
+    threads.emplace_back([&, t]() {
+      std::vector<float> input(kElements, static_cast<float>(t + 1));
+      std::vector<float> output(kElements);
+      start.arrive_and_wait();
+      try {
+        for (int i = 0; i < kIters && !sink.Failed(); ++i) {
+          ORT_THROW_IF_ERROR(data_transfer.CopyTensor(input.data(), false, gpu_buffers[t].Get(), true,
+                                input.size() * sizeof(float)));
+          ORT_THROW_IF_ERROR(data_transfer.CopyTensor(gpu_buffers[t].Get(), true, output.data(), false,
+                                output.size() * sizeof(float)));
+          if (!std::all_of(output.begin(), output.end(), [&](float value) { return value == input[0]; })) {
+            sink.Record("H.thread" + std::to_string(t) + " copied incorrect data");
+          }
+        }
+      } catch (const std::exception& e) {
+        sink.Record("H.thread" + std::to_string(t) + " threw: " + e.what());
+      }
+    });
+  }
+  JoinAll(threads);
+
+  ASSERT_FALSE(sink.Failed()) << sink.FirstError();
+}
+
+// Case I: separate data-transfer objects share the context-level BufferManager but own distinct
+// command recording timelines. Their command encoders and pending buffers must remain isolated.
+TEST_F(WebGpuConcurrentContextTest, IndependentDataTransfersMultiThreadCopy) {
+  constexpr int kThreads = 4;
+  constexpr int kIters = 30;
+  constexpr size_t kElements = 4096;
+  auto& context = webgpu::WebGpuContextFactory::GetContext(0);
+
+  std::array<webgpu::CommandRecordingState, kThreads> recordings;
+  std::array<std::unique_ptr<webgpu::DataTransferImpl>, kThreads> data_transfers;
+  std::array<wgpu::Buffer, kThreads> gpu_buffers;
+  for (int t = 0; t < kThreads; ++t) {
+    data_transfers[t] = std::make_unique<webgpu::DataTransferImpl>(context.BufferManager(), recordings[t]);
+    wgpu::BufferDescriptor desc{};
+    desc.size = kElements * sizeof(float);
+    desc.usage = wgpu::BufferUsage::Storage | wgpu::BufferUsage::CopySrc | wgpu::BufferUsage::CopyDst;
+    gpu_buffers[t] = context.Device().CreateBuffer(&desc);
+  }
+
+  ErrorSink sink;
+  std::barrier start{kThreads};
+  std::vector<std::thread> threads;
+  for (int t = 0; t < kThreads; ++t) {
+    threads.emplace_back([&, t]() {
+      std::vector<float> input(kElements, static_cast<float>(t + 1));
+      std::vector<float> output(kElements);
+      start.arrive_and_wait();
+      try {
+        for (int i = 0; i < kIters && !sink.Failed(); ++i) {
+          ORT_THROW_IF_ERROR(data_transfers[t]->CopyTensor(input.data(), false, gpu_buffers[t].Get(), true,
+                                   input.size() * sizeof(float)));
+          ORT_THROW_IF_ERROR(data_transfers[t]->CopyTensor(gpu_buffers[t].Get(), true, output.data(), false,
+                                   output.size() * sizeof(float)));
+          if (!std::all_of(output.begin(), output.end(), [&](float value) { return value == input[0]; })) {
+            sink.Record("I.thread" + std::to_string(t) + " copied incorrect data");
+          }
+        }
+      } catch (const std::exception& e) {
+        sink.Record("I.thread" + std::to_string(t) + " threw: " + e.what());
+      }
+    });
+  }
+  JoinAll(threads);
+
+  ASSERT_FALSE(sink.Failed()) << sink.FirstError();
 }
 
 // DIAGNOSTIC (disabled by default): keeps N sessions over an identical model alive and runs them
@@ -512,9 +652,7 @@ TEST(WebGpuPoolMemory, DISABLED_MultiSessionSameShape) {
   std::vector<NameMLValMap> feeds;
   std::vector<std::string> output_names{"Y"};
 
-  // Scalar weights, so GPU memory is dominated by intermediate tensors (which flow through the
-  // buffer pool) rather than by per-session initializers (which never share across sessions and
-  // would otherwise swamp the signal).
+  // Scalar weights keep GPU memory dominated by intermediate tensors rather than initializers.
   auto build_scalar_weight_chain = [](int chain_len, int64_t num_elements, std::string& bytes) {
     const std::unordered_map<std::string, int> domain_to_version{{"", 13}};
     Model model("webgpu_pool_memory", false, ModelMetaData(), PathString(),

--- a/onnxruntime/test/providers/webgpu/concurrent_context_test.cc
+++ b/onnxruntime/test/providers/webgpu/concurrent_context_test.cc
@@ -15,19 +15,33 @@
 //   Before the fix this produced a data race and Dawn errors such as:
 //     "[CommandEncoder] is already finished. While encoding CopyBufferToBuffer(...)"
 //     "WebGPU validation failed. Command encoding already finished."
-//   or a corrupted buffer cache -> "[Device] is lost", often taking down the GPU process.
+//   a corrupted buffer cache -> "[Device] is lost", or - worst of all - a silently wrong result
+//   when a buffer was recycled before the work referencing it had been submitted.
 //
-//   The fix serializes all shared-context mutations (command encoder AND buffer caches) with a
-//   per-context recursive mutex (WebGpuContext::context_mutex_ / AcquireContextLock()). With
-//   the fix, the concurrent scenarios below complete cleanly with correct output.
+//   The fix partitions state by ownership rather than wrapping shared state in locks:
+//     - Command recording state (encoder, compute pass, pending dispatch count) moved from the
+//       shared context onto the EP, i.e. one per session. Dawn's ImplicitDeviceSynchronization
+//       explicitly does not cover command encoding, and InferenceSession already serializes a
+//       single session's Run via session_mutex_, so per-session ownership needs no lock at all.
+//     - Each session keeps its released-but-not-yet-submitted buffers in a private list. They
+//       become visible to other sessions only after that session submits, which is what makes
+//       recycling safe; a lock could not have provided this.
+//     - Only the free-buffer pool stays shared (SharedBufferPool), behind one small mutex that
+//       covers nothing but hash-map lookups - no GPU calls, no command encoding, and above all
+//       no shader compilation, so a session warming up cannot stall inference in other sessions.
 //
 // The tests cover several distinct multithreaded shapes:
 //   A. one session, run() concurrently from many threads
 //   B. many threads, each with its own pre-created session, running concurrently
 //   C. mixed: some threads create+Initialize+run new sessions while others run existing ones
 //   D. churn: many threads each repeatedly create + run + destroy their own session
+//   E. a cold session compiling many pipelines must not block a warm session's inference
 
+#include <algorithm>
 #include <atomic>
+#include <chrono>
+#include <iostream>
+#include <iterator>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -38,6 +52,8 @@
 
 #include "core/graph/onnx_protobuf.h"
 #include "core/graph/model.h"
+#include "core/platform/env.h"
+#include "core/providers/webgpu/webgpu_provider_options.h"
 #include "core/session/inference_session.h"
 
 #include "test/test_environment.h"
@@ -88,6 +104,47 @@ void BuildAddChainModel(int chain_len, int64_t num_elements, std::string& model_
   }
 
   graph.SetOutputs(std::vector<const NodeArg*>{prev});
+  ASSERT_STATUS_OK(graph.Resolve());
+  ASSERT_TRUE(model.ToProto().SerializeToString(&model_bytes));
+}
+
+// The distinct unary op types used by BuildUnaryFanOutModel. Each op type maps to its own WebGPU
+// program, so a session using this model has to compile one pipeline per entry.
+constexpr const char* kUnaryOps[] = {
+    "Abs", "Neg", "Floor", "Ceil", "Reciprocal", "Sqrt", "Exp", "Erf", "Sigmoid",
+    "Sin", "Cos", "Tan", "Atan", "Sinh", "Cosh", "Tanh", "HardSigmoid", "HardSwish"};
+
+// Builds an in-memory model that fans one input out to every op in kUnaryOps:
+//   Y0 = Abs(X), Y1 = Neg(X), ...
+//
+// Distinct op types mean distinct programs, so the first Run of a session built from this model
+// compiles std::size(kUnaryOps) pipelines. A fan-out rather than a chain keeps every op inside
+// its valid input domain no matter how many are used.
+void BuildUnaryFanOutModel(int64_t num_elements, std::string& model_bytes) {
+  const std::unordered_map<std::string, int> domain_to_version{{"", 14}};
+  Model model("webgpu_concurrent_ctx_cold", false, ModelMetaData(), PathString(),
+              IOnnxRuntimeOpSchemaRegistryList(), domain_to_version,
+              std::vector<ONNX_NAMESPACE::FunctionProto>(),
+              DefaultLoggingManager().DefaultLogger());
+  Graph& graph = model.MainGraph();
+
+  ONNX_NAMESPACE::TypeProto float_1d;
+  float_1d.mutable_tensor_type()->set_elem_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+  float_1d.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(num_elements);
+
+  NodeArg* x_arg = &graph.GetOrCreateNodeArg("X", &float_1d);
+  std::vector<const NodeArg*> outputs;
+  outputs.reserve(std::size(kUnaryOps));
+
+  for (size_t i = 0; i < std::size(kUnaryOps); ++i) {
+    NodeArg* out_arg = &graph.GetOrCreateNodeArg("Y" + std::to_string(i), &float_1d);
+    std::vector<NodeArg*> node_inputs{x_arg};
+    std::vector<NodeArg*> node_outputs{out_arg};
+    graph.AddNode("op" + std::to_string(i), kUnaryOps[i], "", node_inputs, node_outputs);
+    outputs.push_back(out_arg);
+  }
+
+  graph.SetOutputs(outputs);
   ASSERT_STATUS_OK(graph.Resolve());
   ASSERT_TRUE(model.ToProto().SerializeToString(&model_bytes));
 }
@@ -213,7 +270,8 @@ TEST_F(WebGpuConcurrentContextTest, SingleSessionMultiThreadRun) {
 }
 
 // Case B: many threads, each with its own pre-created session. All sessions share the default
-// context, so their Run paths hammer the shared command encoder / buffer cache concurrently.
+// context, so their Run paths execute concurrently against it. Before the fix they also shared a
+// single command encoder, which is what this case exposed.
 TEST_F(WebGpuConcurrentContextTest, PerThreadSessionRun) {
   constexpr int kThreads = 4;
   constexpr int kIters = 30;
@@ -271,7 +329,8 @@ TEST_F(WebGpuConcurrentContextTest, MixedCreateAndRun) {
 }
 
 // Case D: churn. Many threads each repeatedly create + run + destroy their own session,
-// exercising concurrent allocation and release on the shared buffer caches.
+// exercising concurrent allocation and release against the shared buffer pool, including the
+// path where a destroyed session hands its buffers back while others are still allocating.
 TEST_F(WebGpuConcurrentContextTest, ChurnCreateRunDestroy) {
   constexpr int kThreads = 4;
   constexpr int kIters = 15;
@@ -296,6 +355,246 @@ TEST_F(WebGpuConcurrentContextTest, ChurnCreateRunDestroy) {
   JoinAll(threads);
 
   ASSERT_FALSE(sink.Failed()) << sink.FirstError();
+}
+
+// Case E: the review concern behind this design - a session that is warming up (compiling
+// pipelines) must not block inference in other sessions sharing the context.
+//
+// A builder thread creates a session over a model with many distinct op types and runs it once,
+// which compiles one pipeline per op. Meanwhile a runner thread keeps dispatching on an already
+// warm session.
+//
+// If shader compilation were performed while holding a shared context lock, the runner would be
+// stalled for most of the builder's window. The assertion is therefore on throughput retained
+// relative to the runner's uncontended rate, which separates the two designs cleanly; worst-case
+// latency is reported as well but is too noisy to assert on.
+TEST_F(WebGpuConcurrentContextTest, ColdSessionDoesNotBlockWarmInference) {
+  using Clock = std::chrono::steady_clock;
+  using Ms = std::chrono::duration<double, std::milli>;
+
+  std::string cold_model_bytes;
+  ASSERT_NO_FATAL_FAILURE(BuildUnaryFanOutModel(kNumElements, cold_model_bytes));
+
+  // Warm session: every pipeline it needs is already compiled and cached on the context.
+  auto warm_session = MakeSession();
+  ErrorSink sink;
+  RunOnce(*warm_session, sink, "E.warmup");
+  ASSERT_FALSE(sink.Failed()) << sink.FirstError();
+
+  // Baseline latency with no other session active.
+  constexpr int kBaselineIters = 20;
+  std::vector<double> baseline_ms;
+  baseline_ms.reserve(kBaselineIters);
+  for (int i = 0; i < kBaselineIters; ++i) {
+    const auto start = Clock::now();
+    RunOnce(*warm_session, sink, "E.baseline");
+    baseline_ms.push_back(Ms(Clock::now() - start).count());
+  }
+  ASSERT_FALSE(sink.Failed()) << sink.FirstError();
+  std::sort(baseline_ms.begin(), baseline_ms.end());
+  const double baseline_median = baseline_ms[baseline_ms.size() / 2];
+
+  std::atomic<bool> builder_done{false};
+  std::vector<double> contended_ms;
+  double builder_ms = 0.0;
+
+  std::thread builder([&]() {
+    const auto start = Clock::now();
+    try {
+      SessionOptions so;
+      so.session_logid = "webgpu_concurrent_ctx_cold";
+      InferenceSession cold_session(so, GetEnvironment());
+      ORT_THROW_IF_ERROR(cold_session.RegisterExecutionProvider(DefaultWebGpuExecutionProvider()));
+      ORT_THROW_IF_ERROR(cold_session.Load(cold_model_bytes.data(), static_cast<int>(cold_model_bytes.size())));
+      ORT_THROW_IF_ERROR(cold_session.Initialize());
+
+      std::vector<std::string> output_names;
+      for (size_t i = 0; i < std::size(kUnaryOps); ++i) {
+        output_names.push_back("Y" + std::to_string(i));
+      }
+      std::vector<OrtValue> fetches;
+      // This Run is what triggers compilation of one pipeline per op type.
+      ORT_THROW_IF_ERROR(cold_session.Run(RunOptions{}, MakeFeeds(), output_names, &fetches));
+    } catch (const std::exception& e) {
+      sink.Record(std::string("E.builder threw: ") + e.what());
+    }
+    builder_ms = Ms(Clock::now() - start).count();
+    builder_done.store(true);
+  });
+
+  // Always take at least one measurement so the loop cannot produce an empty sample set if the
+  // builder happens to finish first.
+  const auto contended_start = Clock::now();
+  do {
+    const auto start = Clock::now();
+    RunOnce(*warm_session, sink, "E.contended");
+    contended_ms.push_back(Ms(Clock::now() - start).count());
+  } while (!builder_done.load() && !sink.Failed());
+  const double contended_window_ms = Ms(Clock::now() - contended_start).count();
+  builder.join();
+
+  ASSERT_FALSE(sink.Failed()) << sink.FirstError();
+
+  const double contended_max = *std::max_element(contended_ms.begin(), contended_ms.end());
+  std::sort(contended_ms.begin(), contended_ms.end());
+  const double contended_median = contended_ms[contended_ms.size() / 2];
+
+  // Fraction of the contended window during which the warm session kept doing useful work, using
+  // its uncontended latency as the reference. 1.0 means the cold session cost it nothing.
+  //
+  // This aggregate is a far better regression signal than worst-case latency, which is dominated
+  // by scheduler noise: when compilation holds a shared lock the warm session loses most of the
+  // window, whereas it stays high once compilation is off the shared path entirely.
+  const double throughput_efficiency =
+      (static_cast<double>(contended_ms.size()) * baseline_median) / contended_window_ms;
+
+  std::cout << "[ WebGPU  ] cold-session warmup: " << builder_ms << " ms for "
+            << std::size(kUnaryOps) << " pipelines\n"
+            << "[ WebGPU  ] warm-session latency: baseline median " << baseline_median
+            << " ms, contended median " << contended_median
+            << " ms, contended max " << contended_max
+            << " ms over " << contended_ms.size() << " runs\n"
+            << "[ WebGPU  ] warm-session throughput efficiency while cold session warmed up: "
+            << throughput_efficiency << std::endl;
+
+  // Only assert when the compile window was long enough relative to a warm run for interference to
+  // be observable; otherwise there is nothing meaningful to measure and asserting would be flaky.
+  //
+  // Measured on Windows/D3D12 (RTX 5080), five runs each: a design that compiles under a shared
+  // context lock yields 0.22-0.42, whereas the per-session design yields 0.81-0.93 - and its
+  // contended median latency is indistinguishable from the uncontended baseline (~1.95 ms both),
+  // i.e. the residual gap is CPU contention from the compiling thread, not blocking. The threshold
+  // sits in the gap so the test fails on a real regression without flaking on a busy CI machine.
+  if (builder_ms > 10.0 * std::max(baseline_median, 1.0)) {
+    EXPECT_GT(throughput_efficiency, 0.5)
+        << "warm inference lost most of the window to the cold session's shader compilation";
+  }
+}
+
+// DIAGNOSTIC (disabled by default): keeps N sessions over an identical model alive and runs them
+// round-robin on one thread, then holds so an external sampler can read steady-state GPU memory.
+// This is the shape that distinguishes a context-wide buffer pool (steady state ~= one session's
+// high-water mark) from per-session pools (~= N times that).
+//
+//   onnxruntime_provider_test.exe --gtest_also_run_disabled_tests \
+//     --gtest_filter=WebGpuPoolMemory.DISABLED_MultiSessionSameShape
+//
+// Tunable via environment variables: ORT_DIAG_SESSIONS, ORT_DIAG_MB, ORT_DIAG_ITERS,
+// ORT_DIAG_HOLD_MS, ORT_DIAG_VARY (1 = give each session a different tensor size),
+// ORT_DIAG_CACHE (storage buffer cache mode; defaults to "bucket", the product default -
+// note DefaultWebGpuExecutionProvider() disables the storage cache, which would hide the
+// very behavior this test measures).
+TEST(WebGpuPoolMemory, DISABLED_MultiSessionSameShape) {
+  if (DefaultWebGpuExecutionProvider() == nullptr) {
+    GTEST_SKIP() << "WebGPU execution provider is not available.";
+  }
+
+  auto env_int = [](const char* name, int fallback) {
+    const std::string value = Env::Default().GetEnvironmentVar(name);
+    return value.empty() ? fallback : std::stoi(value);
+  };
+
+  const int num_sessions = env_int("ORT_DIAG_SESSIONS", 4);
+  const int mb = env_int("ORT_DIAG_MB", 64);
+  const int iters = env_int("ORT_DIAG_ITERS", 10);
+  const int hold_ms = env_int("ORT_DIAG_HOLD_MS", 5000);
+  const bool vary = env_int("ORT_DIAG_VARY", 0) != 0;
+  std::string cache_mode = Env::Default().GetEnvironmentVar("ORT_DIAG_CACHE");
+  if (cache_mode.empty()) {
+    cache_mode = webgpu::options::kBufferCacheMode_Bucket;
+  }
+  constexpr int kChainLen = 8;
+
+  auto make_ep = [&cache_mode]() {
+    ConfigOptions config_options;
+    ORT_THROW_IF_ERROR(config_options.AddConfigEntry(webgpu::options::kStorageBufferCacheMode,
+                                                     cache_mode.c_str()));
+    return WebGpuExecutionProviderWithOptions(config_options);
+  };
+  std::cout << "DIAG_POOL storage_cache=" << cache_mode << "\n";
+
+  std::vector<std::unique_ptr<InferenceSession>> sessions;
+  std::vector<NameMLValMap> feeds;
+  std::vector<std::string> output_names{"Y"};
+
+  // Scalar weights, so GPU memory is dominated by intermediate tensors (which flow through the
+  // buffer pool) rather than by per-session initializers (which never share across sessions and
+  // would otherwise swamp the signal).
+  auto build_scalar_weight_chain = [](int chain_len, int64_t num_elements, std::string& bytes) {
+    const std::unordered_map<std::string, int> domain_to_version{{"", 13}};
+    Model model("webgpu_pool_memory", false, ModelMetaData(), PathString(),
+                IOnnxRuntimeOpSchemaRegistryList(), domain_to_version,
+                std::vector<ONNX_NAMESPACE::FunctionProto>(),
+                DefaultLoggingManager().DefaultLogger());
+    Graph& graph = model.MainGraph();
+
+    ONNX_NAMESPACE::TypeProto float_1d;
+    float_1d.mutable_tensor_type()->set_elem_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+    float_1d.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(num_elements);
+
+    ONNX_NAMESPACE::TypeProto float_scalar;
+    float_scalar.mutable_tensor_type()->set_elem_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+    float_scalar.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(1);
+
+    NodeArg* prev = &graph.GetOrCreateNodeArg("X", &float_1d);
+    for (int i = 0; i < chain_len; ++i) {
+      const std::string w_name = "w" + std::to_string(i);
+      ONNX_NAMESPACE::TensorProto w_tensor;
+      w_tensor.set_name(w_name);
+      w_tensor.set_data_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+      w_tensor.add_dims(1);
+      const float scalar = 1.0f + 0.01f * i;
+      w_tensor.set_raw_data(&scalar, sizeof(float));
+      graph.AddInitializedTensor(w_tensor);
+
+      NodeArg* w_arg = &graph.GetOrCreateNodeArg(w_name, &float_scalar);
+      const std::string out_name = (i == chain_len - 1) ? "Y" : ("h" + std::to_string(i));
+      NodeArg* out_arg = &graph.GetOrCreateNodeArg(out_name, &float_1d);
+      std::vector<NodeArg*> inputs{prev, w_arg};
+      std::vector<NodeArg*> outputs{out_arg};
+      graph.AddNode("op" + std::to_string(i), (i % 2 == 0) ? "Mul" : "Add", "", inputs, outputs);
+      prev = out_arg;
+    }
+
+    graph.SetOutputs(std::vector<const NodeArg*>{prev});
+    ASSERT_STATUS_OK(graph.Resolve());
+    ASSERT_TRUE(model.ToProto().SerializeToString(&bytes));
+  };
+
+  for (int s = 0; s < num_sessions; ++s) {
+    const int64_t num_elements =
+        static_cast<int64_t>(mb) * 1024 * 1024 / 4 + (vary ? s * 4 * 1024 * 1024 : 0);
+
+    std::string model_bytes;
+    ASSERT_NO_FATAL_FAILURE(build_scalar_weight_chain(kChainLen, num_elements, model_bytes));
+
+    SessionOptions so;
+    so.session_logid = "webgpu_pool_memory";
+    auto session = std::make_unique<InferenceSession>(so, GetEnvironment());
+    ASSERT_STATUS_OK(session->RegisterExecutionProvider(make_ep()));
+    ASSERT_STATUS_OK(session->Load(model_bytes.data(), static_cast<int>(model_bytes.size())));
+    ASSERT_STATUS_OK(session->Initialize());
+
+    std::vector<float> x_values(static_cast<size_t>(num_elements), 1.0f);
+    OrtValue x_value;
+    CreateMLValue<float>(TestCPUExecutionProvider()->CreatePreferredAllocators()[0],
+                         std::vector<int64_t>{num_elements}, x_values, &x_value);
+
+    sessions.push_back(std::move(session));
+    feeds.push_back(NameMLValMap{{"X", x_value}});
+  }
+
+  for (int i = 0; i < iters; ++i) {
+    for (int s = 0; s < num_sessions; ++s) {
+      std::vector<OrtValue> fetches;
+      ASSERT_STATUS_OK(sessions[s]->Run(RunOptions{}, feeds[s], output_names, &fetches));
+    }
+  }
+
+  std::cout << "DIAG_POOL sessions=" << num_sessions << " mb=" << mb
+            << " vary=" << (vary ? 1 : 0) << " iters=" << iters << " holding...\n"
+            << std::flush;
+  std::this_thread::sleep_for(std::chrono::milliseconds(hold_ms));
 }
 
 }  // namespace test

--- a/onnxruntime/test/providers/webgpu/concurrent_context_test.cc
+++ b/onnxruntime/test/providers/webgpu/concurrent_context_test.cc
@@ -33,8 +33,6 @@
 #include <array>
 #include <atomic>
 #include <barrier>
-#include <chrono>
-#include <iostream>
 #include <iterator>
 #include <memory>
 #include <mutex>
@@ -46,7 +44,6 @@
 
 #include "core/graph/onnx_protobuf.h"
 #include "core/graph/model.h"
-#include "core/platform/env.h"
 #include "core/providers/webgpu/allocator.h"
 #include "core/providers/webgpu/data_transfer.h"
 #include "core/providers/webgpu/webgpu_context.h"
@@ -368,13 +365,7 @@ TEST_F(WebGpuConcurrentContextTest, ChurnCreateRunDestroy) {
 // A builder thread creates a session over a model with many distinct op types and runs it once,
 // which compiles one pipeline per op. Meanwhile a runner thread keeps dispatching on an already
 // warm session.
-//
-// Timing is reported to make lock contention visible without imposing a machine-dependent
-// performance threshold on this correctness test.
 TEST_F(WebGpuConcurrentContextTest, ColdAndWarmSessionsRunConcurrently) {
-  using Clock = std::chrono::steady_clock;
-  using Ms = std::chrono::duration<double, std::milli>;
-
   std::string cold_model_bytes;
   ASSERT_NO_FATAL_FAILURE(BuildUnaryFanOutModel(kNumElements, cold_model_bytes));
 
@@ -384,25 +375,9 @@ TEST_F(WebGpuConcurrentContextTest, ColdAndWarmSessionsRunConcurrently) {
   RunOnce(*warm_session, sink, "E.warmup");
   ASSERT_FALSE(sink.Failed()) << sink.FirstError();
 
-  // Baseline latency with no other session active.
-  constexpr int kBaselineIters = 20;
-  std::vector<double> baseline_ms;
-  baseline_ms.reserve(kBaselineIters);
-  for (int i = 0; i < kBaselineIters; ++i) {
-    const auto start = Clock::now();
-    RunOnce(*warm_session, sink, "E.baseline");
-    baseline_ms.push_back(Ms(Clock::now() - start).count());
-  }
-  ASSERT_FALSE(sink.Failed()) << sink.FirstError();
-  std::sort(baseline_ms.begin(), baseline_ms.end());
-  const double baseline_median = baseline_ms[baseline_ms.size() / 2];
-
   std::atomic<bool> builder_done{false};
-  std::vector<double> contended_ms;
-  double builder_ms = 0.0;
 
   std::thread builder([&]() {
-    const auto start = Clock::now();
     try {
       SessionOptions so;
       so.session_logid = "webgpu_concurrent_ctx_cold";
@@ -422,40 +397,15 @@ TEST_F(WebGpuConcurrentContextTest, ColdAndWarmSessionsRunConcurrently) {
     } catch (const std::exception& e) {
       sink.Record(std::string("E.builder threw: ") + e.what());
     }
-    builder_ms = Ms(Clock::now() - start).count();
     builder_done.store(true);
   });
 
-  // Always take at least one measurement so the loop cannot produce an empty sample set if the
-  // builder happens to finish first.
-  const auto contended_start = Clock::now();
   do {
-    const auto start = Clock::now();
     RunOnce(*warm_session, sink, "E.contended");
-    contended_ms.push_back(Ms(Clock::now() - start).count());
   } while (!builder_done.load() && !sink.Failed());
-  const double contended_window_ms = Ms(Clock::now() - contended_start).count();
   builder.join();
 
   ASSERT_FALSE(sink.Failed()) << sink.FirstError();
-
-  const double contended_max = *std::max_element(contended_ms.begin(), contended_ms.end());
-  std::sort(contended_ms.begin(), contended_ms.end());
-  const double contended_median = contended_ms[contended_ms.size() / 2];
-
-  // Fraction of the contended window during which the warm session kept doing useful work, using
-  // its uncontended latency as the reference. 1.0 means the cold session cost it nothing.
-  const double throughput_efficiency =
-      (static_cast<double>(contended_ms.size()) * baseline_median) / contended_window_ms;
-
-  std::cout << "[ WebGPU  ] cold-session warmup: " << builder_ms << " ms for "
-            << std::size(kUnaryOps) << " pipelines\n"
-            << "[ WebGPU  ] warm-session latency: baseline median " << baseline_median
-            << " ms, contended median " << contended_median
-            << " ms, contended max " << contended_max
-            << " ms over " << contended_ms.size() << " runs\n"
-            << "[ WebGPU  ] warm-session throughput efficiency while cold session warmed up: "
-            << throughput_efficiency << std::endl;
 }
 
 // Case F (future support): the public session allocator shares Run's recording. Concurrent access
@@ -613,130 +563,6 @@ TEST_F(WebGpuConcurrentContextTest, IndependentDataTransfersMultiThreadCopy) {
   JoinAll(threads);
 
   ASSERT_FALSE(sink.Failed()) << sink.FirstError();
-}
-
-// DIAGNOSTIC (disabled by default): keeps N sessions over an identical model alive and runs them
-// round-robin on one thread, then holds so an external sampler can read steady-state GPU memory.
-// This is the shape that distinguishes a context-wide buffer pool (steady state ~= one session's
-// high-water mark) from per-session pools (~= N times that).
-//
-//   onnxruntime_provider_test.exe --gtest_also_run_disabled_tests \
-//     --gtest_filter=WebGpuPoolMemory.DISABLED_MultiSessionSameShape
-//
-// Tunable via environment variables: ORT_DIAG_SESSIONS, ORT_DIAG_MB, ORT_DIAG_ITERS,
-// ORT_DIAG_HOLD_MS, ORT_DIAG_VARY (1 = give each session a different tensor size),
-// ORT_DIAG_CACHE (storage buffer cache mode; defaults to "bucket", the product default -
-// note DefaultWebGpuExecutionProvider() disables the storage cache, which would hide the
-// very behavior this test measures).
-TEST(WebGpuPoolMemory, DISABLED_MultiSessionSameShape) {
-  if (DefaultWebGpuExecutionProvider() == nullptr) {
-    GTEST_SKIP() << "WebGPU execution provider is not available.";
-  }
-
-  auto env_int = [](const char* name, int fallback) {
-    const std::string value = Env::Default().GetEnvironmentVar(name);
-    return value.empty() ? fallback : std::stoi(value);
-  };
-
-  const int num_sessions = env_int("ORT_DIAG_SESSIONS", 4);
-  const int mb = env_int("ORT_DIAG_MB", 64);
-  const int iters = env_int("ORT_DIAG_ITERS", 10);
-  const int hold_ms = env_int("ORT_DIAG_HOLD_MS", 5000);
-  const bool vary = env_int("ORT_DIAG_VARY", 0) != 0;
-  std::string cache_mode = Env::Default().GetEnvironmentVar("ORT_DIAG_CACHE");
-  if (cache_mode.empty()) {
-    cache_mode = webgpu::options::kBufferCacheMode_Bucket;
-  }
-  constexpr int kChainLen = 8;
-
-  auto make_ep = [&cache_mode]() {
-    ConfigOptions config_options;
-    ORT_THROW_IF_ERROR(config_options.AddConfigEntry(webgpu::options::kStorageBufferCacheMode,
-                                                     cache_mode.c_str()));
-    return WebGpuExecutionProviderWithOptions(config_options);
-  };
-  std::cout << "DIAG_POOL storage_cache=" << cache_mode << "\n";
-
-  std::vector<std::unique_ptr<InferenceSession>> sessions;
-  std::vector<NameMLValMap> feeds;
-  std::vector<std::string> output_names{"Y"};
-
-  // Scalar weights keep GPU memory dominated by intermediate tensors rather than initializers.
-  auto build_scalar_weight_chain = [](int chain_len, int64_t num_elements, std::string& bytes) {
-    const std::unordered_map<std::string, int> domain_to_version{{"", 13}};
-    Model model("webgpu_pool_memory", false, ModelMetaData(), PathString(),
-                IOnnxRuntimeOpSchemaRegistryList(), domain_to_version,
-                std::vector<ONNX_NAMESPACE::FunctionProto>(),
-                DefaultLoggingManager().DefaultLogger());
-    Graph& graph = model.MainGraph();
-
-    ONNX_NAMESPACE::TypeProto float_1d;
-    float_1d.mutable_tensor_type()->set_elem_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
-    float_1d.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(num_elements);
-
-    ONNX_NAMESPACE::TypeProto float_scalar;
-    float_scalar.mutable_tensor_type()->set_elem_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
-    float_scalar.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(1);
-
-    NodeArg* prev = &graph.GetOrCreateNodeArg("X", &float_1d);
-    for (int i = 0; i < chain_len; ++i) {
-      const std::string w_name = "w" + std::to_string(i);
-      ONNX_NAMESPACE::TensorProto w_tensor;
-      w_tensor.set_name(w_name);
-      w_tensor.set_data_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
-      w_tensor.add_dims(1);
-      const float scalar = 1.0f + 0.01f * i;
-      w_tensor.set_raw_data(&scalar, sizeof(float));
-      graph.AddInitializedTensor(w_tensor);
-
-      NodeArg* w_arg = &graph.GetOrCreateNodeArg(w_name, &float_scalar);
-      const std::string out_name = (i == chain_len - 1) ? "Y" : ("h" + std::to_string(i));
-      NodeArg* out_arg = &graph.GetOrCreateNodeArg(out_name, &float_1d);
-      std::vector<NodeArg*> inputs{prev, w_arg};
-      std::vector<NodeArg*> outputs{out_arg};
-      graph.AddNode("op" + std::to_string(i), (i % 2 == 0) ? "Mul" : "Add", "", inputs, outputs);
-      prev = out_arg;
-    }
-
-    graph.SetOutputs(std::vector<const NodeArg*>{prev});
-    ASSERT_STATUS_OK(graph.Resolve());
-    ASSERT_TRUE(model.ToProto().SerializeToString(&bytes));
-  };
-
-  for (int s = 0; s < num_sessions; ++s) {
-    const int64_t num_elements =
-        static_cast<int64_t>(mb) * 1024 * 1024 / 4 + (vary ? s * 4 * 1024 * 1024 : 0);
-
-    std::string model_bytes;
-    ASSERT_NO_FATAL_FAILURE(build_scalar_weight_chain(kChainLen, num_elements, model_bytes));
-
-    SessionOptions so;
-    so.session_logid = "webgpu_pool_memory";
-    auto session = std::make_unique<InferenceSession>(so, GetEnvironment());
-    ASSERT_STATUS_OK(session->RegisterExecutionProvider(make_ep()));
-    ASSERT_STATUS_OK(session->Load(model_bytes.data(), static_cast<int>(model_bytes.size())));
-    ASSERT_STATUS_OK(session->Initialize());
-
-    std::vector<float> x_values(static_cast<size_t>(num_elements), 1.0f);
-    OrtValue x_value;
-    CreateMLValue<float>(TestCPUExecutionProvider()->CreatePreferredAllocators()[0],
-                         std::vector<int64_t>{num_elements}, x_values, &x_value);
-
-    sessions.push_back(std::move(session));
-    feeds.push_back(NameMLValMap{{"X", x_value}});
-  }
-
-  for (int i = 0; i < iters; ++i) {
-    for (int s = 0; s < num_sessions; ++s) {
-      std::vector<OrtValue> fetches;
-      ASSERT_STATUS_OK(sessions[s]->Run(RunOptions{}, feeds[s], output_names, &fetches));
-    }
-  }
-
-  std::cout << "DIAG_POOL sessions=" << num_sessions << " mb=" << mb
-            << " vary=" << (vary ? 1 : 0) << " iters=" << iters << " holding...\n"
-            << std::flush;
-  std::this_thread::sleep_for(std::chrono::milliseconds(hold_ms));
 }
 
 }  // namespace test

--- a/onnxruntime/test/providers/webgpu/concurrent_context_test.cc
+++ b/onnxruntime/test/providers/webgpu/concurrent_context_test.cc
@@ -492,8 +492,8 @@ TEST_F(WebGpuConcurrentContextTest, DISABLED_SessionAllocatorAndRunConcurrently)
   ASSERT_FALSE(sink.Failed()) << sink.FirstError();
 }
 
-// Case G (future support): the shared cached allocator requires caller serialization of its
-// private recording and statistics. Shared cache locking alone does not protect these.
+// Case G (future support): the shared cached allocator requires caller serialization of the
+// Env recording and allocator statistics. Shared cache locking alone does not protect these.
 TEST_F(WebGpuConcurrentContextTest, DISABLED_SharedAllocatorMultiThreadCreateTensor) {
   constexpr int kThreads = 4;
   constexpr int kIters = 60;
@@ -522,8 +522,8 @@ TEST_F(WebGpuConcurrentContextTest, DISABLED_SharedAllocatorMultiThreadCreateTen
   ASSERT_FALSE(sink.Failed()) << sink.FirstError();
 }
 
-// Case H (future support): concurrent use of one recording is unsupported. Env transfers use
-// local encoders instead of this Session-bound DataTransferImpl path.
+// Case H (future support): concurrent use of one recording is unsupported, including the
+// context-owned recording shared by Env allocators and transfers.
 TEST_F(WebGpuConcurrentContextTest, DISABLED_SharedDataTransferMultiThreadCopy) {
   constexpr int kThreads = 4;
   constexpr int kIters = 30;

--- a/onnxruntime/test/providers/webgpu/concurrent_context_test.cc
+++ b/onnxruntime/test/providers/webgpu/concurrent_context_test.cc
@@ -53,6 +53,7 @@
 #include "core/providers/webgpu/webgpu_external_header.h"
 #include "core/providers/webgpu/webgpu_provider_options.h"
 #include "core/session/inference_session.h"
+#include "core/session/onnxruntime_session_options_config_keys.h"
 
 #include "test/test_environment.h"
 #include "test/unittest_util/framework_test_utils.h"
@@ -183,18 +184,26 @@ class WebGpuConcurrentContextTest : public ::testing::Test {
   static constexpr float kExpected = 1.0f + 0.5f * kChainLen;
 
   void SetUp() override {
-    if (DefaultWebGpuExecutionProvider() == nullptr) {
+    if (MakeProvider() == nullptr) {
       GTEST_SKIP() << "WebGPU execution provider is not available.";
     }
     ASSERT_NO_FATAL_FAILURE(BuildAddChainModel(kChainLen, kNumElements, model_bytes_));
     keepalive_ = MakeSession();
   }
 
+  std::unique_ptr<IExecutionProvider> MakeProvider() const {
+    ConfigOptions config_options;
+    ORT_THROW_IF_ERROR(config_options.AddConfigEntry(webgpu::options::kStorageBufferCacheMode,
+                                                     webgpu::options::kBufferCacheMode_Bucket));
+    return WebGpuExecutionProviderWithOptions(config_options);
+  }
+
   std::unique_ptr<InferenceSession> MakeSession() {
     SessionOptions so;
     so.session_logid = "webgpu_concurrent_ctx";
+    ORT_THROW_IF_ERROR(so.config_options.AddConfigEntry(kOrtSessionOptionsDisableCPUEPFallback, "1"));
     auto session = std::make_unique<InferenceSession>(so, GetEnvironment());
-    ORT_THROW_IF_ERROR(session->RegisterExecutionProvider(DefaultWebGpuExecutionProvider()));
+    ORT_THROW_IF_ERROR(session->RegisterExecutionProvider(MakeProvider()));
     ORT_THROW_IF_ERROR(session->Load(model_bytes_.data(), static_cast<int>(model_bytes_.size())));
     ORT_THROW_IF_ERROR(session->Initialize());
     return session;
@@ -397,8 +406,9 @@ TEST_F(WebGpuConcurrentContextTest, ColdAndWarmSessionsRunConcurrently) {
     try {
       SessionOptions so;
       so.session_logid = "webgpu_concurrent_ctx_cold";
+      ORT_THROW_IF_ERROR(so.config_options.AddConfigEntry(kOrtSessionOptionsDisableCPUEPFallback, "1"));
       InferenceSession cold_session(so, GetEnvironment());
-      ORT_THROW_IF_ERROR(cold_session.RegisterExecutionProvider(DefaultWebGpuExecutionProvider()));
+      ORT_THROW_IF_ERROR(cold_session.RegisterExecutionProvider(MakeProvider()));
       ORT_THROW_IF_ERROR(cold_session.Load(cold_model_bytes.data(), static_cast<int>(cold_model_bytes.size())));
       ORT_THROW_IF_ERROR(cold_session.Initialize());
 

--- a/onnxruntime/test/providers/webgpu/concurrent_context_test.cc
+++ b/onnxruntime/test/providers/webgpu/concurrent_context_test.cc
@@ -482,14 +482,14 @@ TEST_F(WebGpuConcurrentContextTest, DISABLED_SessionAllocatorAndRunConcurrently)
   ASSERT_FALSE(sink.Failed()) << sink.FirstError();
 }
 
-// Case G: an environment shared allocator is one object used by all sessions. It uses the context
-// BufferManager with private command state and must remain thread-safe across callers.
-TEST_F(WebGpuConcurrentContextTest, SharedAllocatorMultiThreadCreateTensor) {
+// Case G (future support): the shared cached allocator requires caller serialization of its
+// private recording and statistics. Shared cache locking alone does not protect these.
+TEST_F(WebGpuConcurrentContextTest, DISABLED_SharedAllocatorMultiThreadCreateTensor) {
   constexpr int kThreads = 4;
   constexpr int kIters = 60;
   auto& context = webgpu::WebGpuContextFactory::GetContext(0);
   auto context_ref = std::shared_ptr<webgpu::WebGpuContext>(&context, [](webgpu::WebGpuContext*) {});
-  auto allocator = std::make_shared<webgpu::ExternalGpuBufferAllocator>(std::move(context_ref));
+  auto allocator = webgpu::CreateSharedWebGpuAllocator(std::move(context_ref));
 
   ErrorSink sink;
   std::barrier start{kThreads};

--- a/onnxruntime/test/providers/webgpu/concurrent_context_test.cc
+++ b/onnxruntime/test/providers/webgpu/concurrent_context_test.cc
@@ -483,8 +483,8 @@ TEST_F(WebGpuConcurrentContextTest, SessionAllocatorAndRunConcurrently) {
   ASSERT_FALSE(sink.Failed()) << sink.FirstError();
 }
 
-// Case G: an environment shared allocator is one object used by all sessions. It creates external
-// buffers directly and must remain thread-safe without a BufferManager or recording timeline.
+// Case G: an environment shared allocator is one object used by all sessions. It uses the context
+// BufferManager with private command state and must remain thread-safe across callers.
 TEST_F(WebGpuConcurrentContextTest, SharedAllocatorMultiThreadCreateTensor) {
   constexpr int kThreads = 4;
   constexpr int kIters = 60;

--- a/onnxruntime/test/providers/webgpu/concurrent_context_test.cc
+++ b/onnxruntime/test/providers/webgpu/concurrent_context_test.cc
@@ -446,12 +446,11 @@ TEST_F(WebGpuConcurrentContextTest, ColdAndWarmSessionsRunConcurrently) {
             << " ms over " << contended_ms.size() << " runs\n"
             << "[ WebGPU  ] warm-session throughput efficiency while cold session warmed up: "
             << throughput_efficiency << std::endl;
-
 }
 
-// Case F: the public session allocator wraps this same internal allocator. Allocations made
-// concurrently with Run must not race the session's command recording state.
-TEST_F(WebGpuConcurrentContextTest, SessionAllocatorAndRunConcurrently) {
+// Case F (future support): the public session allocator shares Run's recording. Concurrent access
+// to that recording is unsupported without caller serialization.
+TEST_F(WebGpuConcurrentContextTest, DISABLED_SessionAllocatorAndRunConcurrently) {
   constexpr int kIters = 40;
   auto session = MakeSession();
   auto allocator = session->GetAllocator(OrtMemoryInfo(WEBGPU_BUFFER,
@@ -513,9 +512,9 @@ TEST_F(WebGpuConcurrentContextTest, SharedAllocatorMultiThreadCreateTensor) {
   ASSERT_FALSE(sink.Failed()) << sink.FirstError();
 }
 
-// Case H: OrtEnv owns one data-transfer implementation per EP factory. Concurrent CopyTensors
-// calls must not encode and flush through the same recording state simultaneously.
-TEST_F(WebGpuConcurrentContextTest, SharedDataTransferMultiThreadCopy) {
+// Case H (future support): concurrent use of one recording is unsupported. Env transfers use
+// local encoders instead of this Session-bound DataTransferImpl path.
+TEST_F(WebGpuConcurrentContextTest, DISABLED_SharedDataTransferMultiThreadCopy) {
   constexpr int kThreads = 4;
   constexpr int kIters = 30;
   constexpr size_t kElements = 4096;
@@ -542,9 +541,9 @@ TEST_F(WebGpuConcurrentContextTest, SharedDataTransferMultiThreadCopy) {
       try {
         for (int i = 0; i < kIters && !sink.Failed(); ++i) {
           ORT_THROW_IF_ERROR(data_transfer.CopyTensor(input.data(), false, gpu_buffers[t].Get(), true,
-                                input.size() * sizeof(float)));
+                                                      input.size() * sizeof(float)));
           ORT_THROW_IF_ERROR(data_transfer.CopyTensor(gpu_buffers[t].Get(), true, output.data(), false,
-                                output.size() * sizeof(float)));
+                                                      output.size() * sizeof(float)));
           if (!std::all_of(output.begin(), output.end(), [&](float value) { return value == input[0]; })) {
             sink.Record("H.thread" + std::to_string(t) + " copied incorrect data");
           }
@@ -589,9 +588,9 @@ TEST_F(WebGpuConcurrentContextTest, IndependentDataTransfersMultiThreadCopy) {
       try {
         for (int i = 0; i < kIters && !sink.Failed(); ++i) {
           ORT_THROW_IF_ERROR(data_transfers[t]->CopyTensor(input.data(), false, gpu_buffers[t].Get(), true,
-                                   input.size() * sizeof(float)));
+                                                           input.size() * sizeof(float)));
           ORT_THROW_IF_ERROR(data_transfers[t]->CopyTensor(gpu_buffers[t].Get(), true, output.data(), false,
-                                   output.size() * sizeof(float)));
+                                                           output.size() * sizeof(float)));
           if (!std::all_of(output.begin(), output.end(), [&](float value) { return value == input[0]; })) {
             sink.Record("I.thread" + std::to_string(t) + " copied incorrect data");
           }

--- a/onnxruntime/test/providers/webgpu/webgpu_context_test.cc
+++ b/onnxruntime/test/providers/webgpu/webgpu_context_test.cc
@@ -99,6 +99,7 @@ TEST(WebGpuContextTest, SessionAllocatorSubmitsReusedBufferClearOutsideRun) {
                                        webgpu::BufferCacheMode::Disabled);
   webgpu::GpuBufferAllocator allocator(
       [&buffer_manager]() -> const webgpu::BufferManager& { return buffer_manager; },
+      [webgpu_ep]() -> webgpu::CommandRecordingState& { return webgpu_ep->Recording(); },
       false,
       [webgpu_ep]() { return !webgpu_ep->IsRunActive(); });
 
@@ -107,7 +108,7 @@ TEST(WebGpuContextTest, SessionAllocatorSubmitsReusedBufferClearOutsideRun) {
   void* allocation = allocator.Alloc(sizeof(nonzero_data));
   ASSERT_NE(allocation, nullptr);
   WGPUBuffer dirty_buffer = static_cast<WGPUBuffer>(allocation);
-  buffer_manager.Upload(nonzero_data.data(), dirty_buffer, sizeof(nonzero_data));
+  buffer_manager.Upload(webgpu_ep->Recording(), nonzero_data.data(), dirty_buffer, sizeof(nonzero_data));
   allocator.Free(allocation);
 
   allocation = allocator.Alloc(sizeof(nonzero_data));
@@ -116,7 +117,7 @@ TEST(WebGpuContextTest, SessionAllocatorSubmitsReusedBufferClearOutsideRun) {
   EXPECT_EQ(reused_buffer, dirty_buffer);
 
   const auto downloaded_data = ReadBufferWithExternalCommandEncoder(context, reused_buffer);
-  ASSERT_STATUS_OK(context.Flush(buffer_manager));
+  ASSERT_STATUS_OK(context.Flush(buffer_manager, webgpu_ep->Recording()));
   const std::array<uint32_t, 16> expected_data{};
   EXPECT_EQ(downloaded_data, expected_data);
 
@@ -127,6 +128,7 @@ TEST(WebGpuContextTest, DoesNotCaptureDeviceAllocatorBufferClear) {
   ConfigOptions options;
   auto ep = WebGpuProviderFactoryCreator::Create(options)->CreateProvider();
   ASSERT_NE(ep, nullptr);
+  auto* webgpu_ep = static_cast<WebGpuExecutionProvider*>(ep.get());
 
   auto& context = webgpu::WebGpuContextFactory::GetContext(0);
   webgpu::BufferManager buffer_manager(context,
@@ -137,6 +139,7 @@ TEST(WebGpuContextTest, DoesNotCaptureDeviceAllocatorBufferClear) {
   std::vector<webgpu::CapturedCommandInfo> captured_commands;
   webgpu::GpuBufferAllocator allocator(
       [&buffer_manager]() -> const webgpu::BufferManager& { return buffer_manager; },
+      [webgpu_ep]() -> webgpu::CommandRecordingState& { return webgpu_ep->Recording(); },
       false);
 
   std::array<uint32_t, 16> nonzero_data;
@@ -144,19 +147,19 @@ TEST(WebGpuContextTest, DoesNotCaptureDeviceAllocatorBufferClear) {
   void* allocation = allocator.Alloc(sizeof(nonzero_data));
   ASSERT_NE(allocation, nullptr);
   WGPUBuffer dirty_buffer = static_cast<WGPUBuffer>(allocation);
-  buffer_manager.Upload(nonzero_data.data(), dirty_buffer, sizeof(nonzero_data));
+  buffer_manager.Upload(webgpu_ep->Recording(), nonzero_data.data(), dirty_buffer, sizeof(nonzero_data));
   allocator.Free(allocation);
 
-  context.CaptureBegin(&captured_commands, buffer_manager);
+  context.CaptureBegin(&captured_commands, buffer_manager, webgpu_ep->Recording());
   allocation = allocator.Alloc(sizeof(nonzero_data));
   if (allocation == nullptr) {
-    context.CaptureEnd();
+    context.CaptureEnd(webgpu_ep->Recording());
     FAIL() << "Failed to reacquire a device allocation during graph capture.";
   }
   WGPUBuffer reused_buffer = static_cast<WGPUBuffer>(allocation);
   EXPECT_EQ(reused_buffer, dirty_buffer);
-  const Status flush_status = context.Flush(buffer_manager);
-  context.CaptureEnd();
+  const Status flush_status = context.Flush(buffer_manager, webgpu_ep->Recording());
+  context.CaptureEnd(webgpu_ep->Recording());
   if (!flush_status.IsOK()) {
     allocator.Free(allocation);
     FAIL() << flush_status.ErrorMessage();
@@ -181,6 +184,7 @@ TEST(WebGpuContextTest, SessionAllocatorDefersReusedBufferClearDuringRun) {
                                        webgpu::BufferCacheMode::Disabled);
   webgpu::GpuBufferAllocator allocator(
       [&buffer_manager]() -> const webgpu::BufferManager& { return buffer_manager; },
+      [webgpu_ep]() -> webgpu::CommandRecordingState& { return webgpu_ep->Recording(); },
       false,
       [webgpu_ep]() { return !webgpu_ep->IsRunActive(); });
 
@@ -189,8 +193,8 @@ TEST(WebGpuContextTest, SessionAllocatorDefersReusedBufferClearDuringRun) {
   void* allocation = allocator.Alloc(sizeof(nonzero_data));
   ASSERT_NE(allocation, nullptr);
   WGPUBuffer dirty_buffer = static_cast<WGPUBuffer>(allocation);
-  buffer_manager.Upload(nonzero_data.data(), dirty_buffer, sizeof(nonzero_data));
-  ASSERT_STATUS_OK(context.Flush(buffer_manager));
+  buffer_manager.Upload(webgpu_ep->Recording(), nonzero_data.data(), dirty_buffer, sizeof(nonzero_data));
+  ASSERT_STATUS_OK(context.Flush(buffer_manager, webgpu_ep->Recording()));
   allocator.Free(allocation);
 
   RunOptions run_options;


### PR DESCRIPTION
### Description

Support creating, initializing, and running independent WebGPU Sessions concurrently, including creating one Session while another runs. Isolate Session command recording while retaining shared device, buffer, and pipeline caches.

No new public EP/factory API, runtime TLS routing, synchronization streams, or common ORT framework changes are introduced. The implementation preserves the existing allocator/copy algorithms and keeps changes scoped against `c5ead598c8`.

### Architecture

The diagram shows ordinary, non-capture execution. Solid arrows indicate API/data-flow dependencies; dashed arrows indicate the recording used by allocations and copies. Each Session has its own recording. The Env recording is shared by Env allocators/transfers on the same context and is stored in `WebGpuContext`, not in `OrtEnv`.

```mermaid
flowchart TB
    EnvCreate("CreateTensor") --> EnvAllocator
    EnvCopy("CopyTensor") --> EnvTransfer
    Create1("CreateTensor") --> Allocator1
    Run1("Run Session 1") --> Recording1
    Run1 --> Transfer1
    Create2("CreateTensor") --> Allocator2
    Run2("Run Session 2") --> Recording2
    Run2 --> Transfer2

    subgraph Env["Env API scope"]
        EnvAllocator["SharedAllocator"]
        EnvTransfer["DataTransfer<br/>external CopyTensor API"]
    end

    subgraph Session1["Session 1"]
        Allocator1["Session allocators"]
        Transfer1["DataTransfer<br/>Session-managed copies"]
        Recording1["Recording 1<br/>encoder / deferred work"]
        Allocator1 -.-> Recording1
        Transfer1 -.-> Recording1
    end

    subgraph Session2["Session 2"]
        Allocator2["Session allocators"]
        Transfer2["DataTransfer<br/>Session-managed copies"]
        Recording2["Recording 2<br/>encoder / deferred work"]
        Allocator2 -.-> Recording2
        Transfer2 -.-> Recording2
    end

    subgraph Context["WebGPU Context (shared)"]
        Writable["Writable BufferManager<br/>shared caches"]
        ReadOnly["Read-only / initializer<br/>BufferManager"]
        EnvRecording["Env recording<br/>encoder / deferred work"]
        Device["WebGPU device and queue"]
        Writable --> Device
        ReadOnly --> Device
        EnvRecording --> Device
    end

    EnvAllocator --> Writable
    EnvTransfer --> Writable
    EnvAllocator -.-> EnvRecording
    EnvTransfer -.-> EnvRecording
    Allocator1 --> Writable
    Allocator2 --> Writable
    Allocator1 -->|initializers| ReadOnly
    Allocator2 -->|initializers| ReadOnly
    Transfer1 --> Writable
    Transfer2 --> Writable
    Recording1 --> Device
    Recording2 --> Device

    classDef action fill:#fff2cc,stroke:#d6b656,color:#111;
    classDef manager fill:#e1d5e7,stroke:#9673a6,color:#111;
    class EnvCreate,EnvCopy,Create1,Run1,Create2,Run2 action;
    class Writable,ReadOnly manager;
    style Env fill:#f5f5f5,stroke:#666;
    style Session1 fill:#f5f5f5,stroke:#666;
    style Session2 fill:#f5f5f5,stroke:#666;
    style Context fill:#dae8fc,stroke:#6c8ebf;
```

Graph capture retains the existing per-graph managers for capture allocations and replay; those managers and the shared pipeline cache are omitted from this overview. The arrows do not imply that external allocator or Env-copy operations may be called concurrently.

### Implementation

- Each Session owns its encoder, deferred dispatches, pending buffers, and capture state. Kernels and Session transfers use the same recording so copies can submit preceding computation before CPU readback.
- Shared buffer-cache acquisition, release, and refresh and pipeline-cache lookup/insert are synchronized. Shader compilation stays outside the pipeline-cache lock. Released buffers remain with their recording until submission.
- Request Dawn `ImplicitDeviceSynchronization` for shared-device access. Factories, EPs, Env allocators, and initialized transfers retain the context as needed; provider configuration is copied for each EP instead of repeatedly moved from the factory.
- Env and Session operations reuse `GpuBufferAllocator`, `DataTransferImpl`, and `BufferManager`. Env allocators and transfers share one context-owned Env recording, separate from Session recordings.
- Both Env and plugin Session transfer wrappers start with a null `data_transfer_`. The first nonempty `CopyTensors` batch acquires the context and creates a persistent `std::unique_ptr<DataTransferImpl>` under `init_mutex_`; subsequent copies reuse it. There is no unlocked double-checked initialization, eager plugin helper construction, or per-copy local helper.
- The helper retains the baseline context-level BufferManager binding and uses either the owning Session's recording or the Env recording. Built-in Session transfer construction in `GetDataTransfer()` remains unchanged apart from the explicit recording argument. This is not a redesign or comprehensive validation of kernel-internal copies during graph capture.

Plugin Session transfer binding relies on the current ORT callback sequence: the first successful factory `CreateDataTransfer` call is for the Env; later calls pair with the EP created on the same thread. A per-factory thread-ID map permits concurrent creation, with at most one unbound EP per thread. Entries are removed after binding or EP release. The bookkeeping lock does not cover Session construction or Run; after binding, execution may move to another thread.

**The first-call ordering and same-thread callback pairing are implementation assumptions, not public API guarantees.**

### Copy Submission and Completion

`CopyTensors` retains `Flush` at the end of the callback, primarily to submit GPU-to-GPU copies that `BufferManager::MemCpy` only records. CPU/GPU transfer paths already handle their required submissions in `BufferManager`.

**Only GPU-to-CPU downloads currently guarantee copy completion through readback waiting. Uploads and GPU-to-GPU copies guarantee submission but may still be in flight on return.** The pre-existing gap against the no-stream synchronous `CopyTensors` contract is documented as a TODO for separate work; this PR does not claim to resolve it.

Ordinary Run and graph replay add no queue-completion wait. `OrtEp::Sync` remains a no-op, so I/O Binding synchronization calls do not guarantee GPU completion. Operations on the same queue follow submission order; output downloads wait for readback.

### Scope

- Independent Session creation, initialization, internal allocation/copies, and ordinary Run are supported concurrently when Dawn device synchronization or equivalent protection is available.
- There is no recording mutex. Applications must serialize external operations that access the same Session recording, including allocator operations, tensor destruction, copies, graph replay, and graph release, with that Session's execution. ORT's ordinary same-Session Run lock does not cover all these entry points.
- All Env copies and allocator operations on the same context, including Free/GetStats and tensor destruction, require caller serialization. Concurrent external Env/Session allocator use, concurrent Env copies, concurrent profiling, cross-device transfers, and stream routing are outside scope. This does not claim full GenAI multi-thread generation support.
- Unrelated copy validation, padding/alignment changes, redundant cleanup, and the no-op buffer-registration lock are excluded. An unrelated disabled GPU-memory sampling diagnostic and non-asserted timing output were removed from the new native concurrency test file. All disabled concurrency acceptance tests, including the actual 12-/16-thread workloads, remain intact without test-side operation locks.

### Tests and Validation

Local validation: Windows x64, Visual Studio 2022, RelWithDebInfo, D3D12.

- **Latest plugin build:** rebuilt `onnxruntime_providers_webgpu` and `onnxruntime_autoep_test` for the lazy-transfer change. **12/12 enabled tests passed:** all 11 `PluginEpWebGpuConcurrency` cases plus `PluginEpGraphCapture.WebGpuGraphCaptureAndReplay`. No skipped tests or ORT/WebGPU error log matches. Seven concurrency cases remain disabled and were not run.
- Plugin coverage includes independent concurrent Session creation/Run with CPU I/O, execution on a different thread from creation, creation alongside Run, sequential external allocator/Env copies, reused-buffer clears, and GPU/CPU I/O variants. `CpuPartitionBetweenGpuKernels` verifies GPU/CPU/GPU placement plus intermediate and final values. The separate single-Session capture test changes input values in stable GPU buffers and checks both capture and replay outputs.
- **Built-in EP after the scope cleanup:** rebuilt `onnxruntime_provider_test` with `onnxruntime_USE_EP_API_ADAPTERS=OFF`. **9/9 enabled tests passed:** six `WebGpuConcurrentContextTest` cases plus three affected `WebGpuContextTest` allocator/clear cases. The six native concurrency cases were also rerun successfully. Three unsupported concurrency cases remain disabled. These results precede the final plugin-wrapper-only lazy-helper adjustment; the built-in `GetDataTransfer()` path was not changed by that adjustment.
- Native concurrency coverage: `SingleSessionMultiThreadRun`, `PerThreadSessionRun`, `MixedCreateAndRun`, `ChurnCreateRunDestroy`, `ColdAndWarmSessionsRunConcurrently`, and `IndependentDataTransfersMultiThreadCopy`. Native and plugin coverage is complementary, not one-for-one identical.
- Changed-line clang-format and `git diff --check` pass. Full ORT suites, a separate stream-disabled build, and exhaustive kernel-internal-copy graph-capture scenarios were not run. No performance or concurrent-Env capability claim is made for this revision.