### PR TITLE
Fix SM120 FP8xFP4 MoE undefined symbol when both FP8 and FP4 QMoE enabled

### DIFF
--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemm_template_dispatch_tma_ws.h
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemm_template_dispatch_tma_ws.h
@@ -189,8 +189,18 @@ constexpr bool are_tile_shapes_supported_sm120() {
   constexpr auto TileN = size<1>(CtaShape{});
   constexpr auto TileK = size<2>(CtaShape{});
 
+  // FP8xFP4 (WFP4AFP8): only the 128x128x128 tile is instantiated. It is the
+  // only shape that fits in shared memory with >=2 pipeline stages (see the
+  // launcher generator generate_moe_gemm_tma_ws_sm120_fp4.py) and the only
+  // config the SM120 heuristic (get_candidate_configs_sm120) ever selects.
+  // Restricting the compile-time dispatch here avoids referencing launcher
+  // symbols that are never generated, which otherwise breaks linking when both
+  // FP8 and FP4 QMoE are enabled.
+  if constexpr (std::is_same_v<DataType, __nv_fp8_e4m3>) {
+    return TileM == 128 && TileN == 128 && TileK == 128;
+  }
+
   // FP4xFP4 element counts: K=128 (64B) or K=256 (128B)
-  // FP8xFP4 element counts: K=128 (128B)
   // Byte-based: 64B, 128B, 256B tile K supported
   return (TileM == 128 && TileN == 128 && (TileK == 64 || TileK == 128 || TileK == 256)) ||
          (TileM == 128 && TileN == 256 && (TileK == 64 || TileK == 128)) ||


### PR DESCRIPTION
### Description

Fixes an undefined-symbol link failure that occurs when **both** `--enable_fp8_qmoe` and `--enable_fp4_qmoe` are enabled together (the FP8+FP4 CUDA build config). The build only breaks in that combined config because it is the only one that instantiates `MoeGemmRunner<__nv_fp8_e4m3, __nv_fp4_e2m1, ...>`.

### Root cause

The SM120 compile-time tile-shape gate `are_tile_shapes_supported_sm120()` in `moe_gemm_template_dispatch_tma_ws.h` allowed several extra tile shapes (128×128×64/256, 128×256×64/128, 256×128×64/128) for an FP8 activation type. However, the launcher generator `generate_moe_gemm_tma_ws_sm120_fp4.py` emits **only** the `128×128×128` tile for FP8×FP4 — that is the only shape that fits in shared memory with ≥2 pipeline stages. The dispatch cascade therefore referenced launcher template instantiations that were never generated, producing undefined symbols at link time.

### Fix

Restrict the SM120 compile-time dispatch to `128×128×128` when the activation type is `__nv_fp8_e4m3`, matching both the generator and the runtime heuristic:

- On SM120, `isValidSM120MOESpecialisation` only supports FP4×FP4 and FP8×FP4, so `DataType == __nv_fp8_e4m3` always means FP8×FP4.
- The runtime config heuristic `get_candidate_configs_sm120()` only ever selects `CtaShape128x128x128B`.

So the prune causes **no functional loss** — the removed tiles were never generated nor selected. FP4×FP4 tiles are unchanged.

### Validation

Object-level verification on `build/cu130_fp8_fp4` (`nm -Cu` on `moe_gemm_kernels_fp8_fp4.cu.o`):

- **Before:** 12 undefined SM120 FP8×FP4 launcher references (the extra tiles) → link failure.
- **After:** only 2 remaining references, both `<128,128,128>` (fp16 + bf16). Both are defined (weak) by the generated launcher objects `moe_gemm_tma_ws_sm120_fp4_fp8_{fp16,bf16}_m128_n128_k128.generated.cu.o`, so the link resolves.

### Motivation and Context

Unblocks building ONNX Runtime with FP8 and FP4 QMoE enabled simultaneously. Delivered as a standalone change independent of the FP8/FP4 QMoE feature PRs.
