### PR TITLE
[WebGPU EP] Support uint8 for Expand

### DIFF
--- a/onnxruntime/core/providers/webgpu/tensor/expand.cc
+++ b/onnxruntime/core/providers/webgpu/tensor/expand.cc
@@ -14,11 +14,38 @@ Status ExpandProgram::GenerateShaderCode(ShaderHelper& shader) const {
   const auto& input = shader.AddInput("input", ShaderUsage::UseUniform | ShaderUsage::UseValueTypeAlias);
   const auto& output = shader.AddOutput("output", ShaderUsage::UseUniform);
   shader.MainFunctionBody() << shader.GuardAgainstOutOfBoundsWorkgroupSizes("uniforms.data_size");
-  if (Inputs()[0].var_type == ProgramVariableDataType::Boolx4) {
+  // bool and uint8 are both 1-byte-per-element types that are packed 4-per-u32 in the storage buffer,
+  // so they share the same broadcast logic and differ only in how a single element is extracted from
+  // and assembled into the packed word.
+  const bool is_bool = Inputs()[0].var_type == ProgramVariableDataType::Boolx4;
+  const bool is_uint8 = Inputs()[0].var_type == ProgramVariableDataType::Uint8x4;
+  if (is_bool || is_uint8) {
     const auto& input_indices = shader.AddIndices("input_indices");
     const auto& output_indices = shader.AddIndices("output_indices");
+
+    // Extract the single element located at element offset "off".
+    auto get_element = [&](const std::string& off) -> std::string {
+      if (is_bool) {
+        return input.GetByOffset(off + " / 4") + "[" + off + " % 4]";
+      }
+      // Shift the byte at "off % 4" down to the low 8 bits of the packed u32.
+      return "((" + input.GetByOffset(off + " / 4") + " >> ((" + off + " % 4) * 8u)) & 0xFFu)";
+    };
+    // Broadcast a single element into all 4 lanes of a packed word.
+    auto splat_element = [&](const std::string& e) -> std::string {
+      return is_bool ? ("vec4<bool>(" + e + ")") : ("(" + e + " * 0x01010101u)");
+    };
+    // Assemble a packed word from 4 elements.
+    auto pack_elements = [&](const std::string& e0, const std::string& e1, const std::string& e2, const std::string& e3) -> std::string {
+      if (is_bool) {
+        return "vec4<bool>(" + e0 + ", " + e1 + ", " + e2 + ", " + e3 + ")";
+      }
+      return "(" + e0 + " | (" + e1 + " << 8u) | (" + e2 + " << 16u) | (" + e3 + " << 24u))";
+    };
+
     if (input_last_dim_divisible_by_4_) {
-      // The last dims of input shape and output shape are all divisible by 4.
+      // The last dims of input shape and output shape are all divisible by 4, so a whole packed word
+      // maps directly to a whole packed word.
       shader.MainFunctionBody() << "  let output_indices = " << output_indices.OffsetToIndices("global_idx * 4") << ";\n"
                                 << "  let input_offset = " << input_indices.BroadcastedIndicesToOffset("output_indices", output_indices) << ";\n"
                                 << output.SetByOffset("global_idx", input.GetByOffset("input_offset / 4"));
@@ -26,7 +53,7 @@ Status ExpandProgram::GenerateShaderCode(ShaderHelper& shader) const {
       // The last dim of output shape is divisible by 4, and the last dim of input shape is 1.
       shader.MainFunctionBody() << "  let output_indices = " << output_indices.OffsetToIndices("global_idx * 4") << ";\n"
                                 << "  let input_offset = " << input_indices.BroadcastedIndicesToOffset("output_indices", output_indices) << ";\n"
-                                << "  let value = vec4<bool>(" << input.GetByOffset("input_offset / 4") << "[input_offset % 4]);\n"
+                                << "  let value = " << splat_element(get_element("input_offset")) << ";\n"
                                 << "  " << output.SetByOffset("global_idx", "value");
     } else {
       shader.MainFunctionBody() << "  var output_indices = " << output_indices.OffsetToIndices("global_idx * 4") << ";\n"
@@ -37,11 +64,10 @@ Status ExpandProgram::GenerateShaderCode(ShaderHelper& shader) const {
                                 << "  let input_offset_2 = " << input_indices.BroadcastedIndicesToOffset("output_indices", output_indices) << ";\n"
                                 << "  output_indices = " << output_indices.OffsetToIndices("global_idx * 4 + 3") << ";\n"
                                 << "  let input_offset_3 = " << input_indices.BroadcastedIndicesToOffset("output_indices", output_indices) << ";\n"
-                                << "  let value = vec4<bool>("
-                                << input.GetByOffset("input_offset_0 / 4") << "[input_offset_0 % 4], "
-                                << input.GetByOffset("input_offset_1 / 4") << "[input_offset_1 % 4], "
-                                << input.GetByOffset("input_offset_2 / 4") << "[input_offset_2 % 4], "
-                                << input.GetByOffset("input_offset_3 / 4") << "[input_offset_3 % 4]);\n"
+                                << "  let value = "
+                                << pack_elements(get_element("input_offset_0"), get_element("input_offset_1"),
+                                                 get_element("input_offset_2"), get_element("input_offset_3"))
+                                << ";\n"
                                 << output.SetByOffset("global_idx", "value");
     }
     return Status::OK();
@@ -72,14 +98,15 @@ Status Expand::ComputeInternal(ComputeContext& context) const {
   auto* output_tensor = context.Output(0, output_shape);
 
   bool is_int64 = input_tensor->DataType() == DataTypeImpl::GetType<int64_t>();
-  // Check if either input is boolean
-  // For boolean inputs, we need to handle them differently in the shader. This is because `bool` is not a valid type in
-  // storage buffer. We have to use a `u32` to represent 4 boolean values.
+  // bool and uint8 are 1-byte-per-element types that are not valid storage buffer types, so we pack
+  // 4 of them into a single `u32` and handle them with a dedicated shader path.
   bool is_bool = input_tensor->DataType() == DataTypeImpl::GetType<bool>();
+  bool is_uint8 = input_tensor->DataType() == DataTypeImpl::GetType<uint8_t>();
+  bool is_packed_byte = is_bool || is_uint8;
   bool input_last_dim_divisible_by_4 = (!(input_shape.IsScalar() || is_int64)) && (input_shape[input_shape.NumDimensions() - 1] % 4 == 0);
   bool output_last_dim_divisible_by_4 = (!(output_shape.IsScalar() || is_int64)) && (output_shape[output_shape.NumDimensions() - 1] % 4 == 0);
-  const int components_i = (is_bool || input_last_dim_divisible_by_4) ? 4 : 1;
-  const int components_o = (is_bool || output_last_dim_divisible_by_4) ? 4 : 1;
+  const int components_i = (is_packed_byte || input_last_dim_divisible_by_4) ? 4 : 1;
+  const int components_o = (is_packed_byte || output_last_dim_divisible_by_4) ? 4 : 1;
   uint32_t data_size = onnxruntime::narrow<uint32_t>((output_shape.Size() + components_o - 1) / components_o);
   if (data_size == 0) {
     return Status::OK();
@@ -89,7 +116,7 @@ Status Expand::ComputeInternal(ComputeContext& context) const {
       .AddUniformVariables({
           {data_size},
       });
-  if (is_bool) {
+  if (is_packed_byte) {
     program.CacheHint(std::to_string(static_cast<int>(input_last_dim_divisible_by_4)), std::to_string(static_cast<int>(output_last_dim_divisible_by_4)))
         .AddInputs({{input_tensor, ProgramTensorMetadataDependency::TypeAndRank, ProgramInput::Flatten, components_i}})
         .AddOutputs({{output_tensor, ProgramTensorMetadataDependency::TypeAndRank, {data_size}, components_o}})
@@ -98,7 +125,7 @@ Status Expand::ComputeInternal(ComputeContext& context) const {
     program.AddInputs({{input_tensor, ProgramTensorMetadataDependency::TypeAndRank, components_i}})
         .AddOutputs({{output_tensor, ProgramTensorMetadataDependency::TypeAndRank, components_o}});
   }
-  if (is_bool || components_i != components_o) {
+  if (is_packed_byte || components_i != components_o) {
     program.AddIndices(std::move(output_shape));
   }
   return context.RunProgram(program);
@@ -106,7 +133,8 @@ Status Expand::ComputeInternal(ComputeContext& context) const {
 
 template <int StartVersion, int EndVersion>
 KernelCreateInfo CreateExpandVersionedKernelInfo(bool enable_int64) {
-  const auto& type_constraints = GetOpTypeConstraints(enable_int64, true);
+  std::vector<MLDataType> type_constraints = GetOpTypeConstraints(enable_int64, true);
+  type_constraints.push_back(DataTypeImpl::GetTensorType<uint8_t>());
 
   KernelCreatePtrFn kernel_create_fn = [](FuncManager&, const OpKernelInfo& info, std::unique_ptr<OpKernel>& out) -> Status {
     out = std::make_unique<Expand>(info);
@@ -127,7 +155,8 @@ KernelCreateInfo CreateExpandVersionedKernelInfo(bool enable_int64) {
 
 template <int SinceVersion>
 KernelCreateInfo CreateExpandKernelInfo(bool enable_int64) {
-  const auto& type_constraints = GetOpTypeConstraints(enable_int64, true);
+  std::vector<MLDataType> type_constraints = GetOpTypeConstraints(enable_int64, true);
+  type_constraints.push_back(DataTypeImpl::GetTensorType<uint8_t>());
 
   KernelCreatePtrFn kernel_create_fn = [](FuncManager&, const OpKernelInfo& info, std::unique_ptr<OpKernel>& out) -> Status {
     out = std::make_unique<Expand>(info);

--- a/onnxruntime/core/providers/webgpu/tensor/expand.cc
+++ b/onnxruntime/core/providers/webgpu/tensor/expand.cc
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <string>
+
 #include "core/providers/common.h"
 
 #include "core/providers/webgpu/tensor/expand.h"
@@ -23,7 +25,12 @@ Status ExpandProgram::GenerateShaderCode(ShaderHelper& shader) const {
     const auto& input_indices = shader.AddIndices("input_indices");
     const auto& output_indices = shader.AddIndices("output_indices");
 
-    // Extract the single element located at element offset "off".
+    // SetByOffset for both Boolx4 and Uint8x4 expects the value as a 4-lane vector (one element per
+    // lane) and packs it into the storage word itself, so every branch below builds such a vector:
+    // vec4<bool> for bool, vec4<u32> for uint8. Never hand SetByOffset a pre-packed word.
+    const std::string vec4_type = is_bool ? "vec4<bool>" : "vec4<u32>";
+
+    // Extract the single element located at element offset "off" as a scalar lane value.
     auto get_element = [&](const std::string& off) -> std::string {
       if (is_bool) {
         return input.GetByOffset(off + " / 4") + "[" + off + " % 4]";
@@ -31,16 +38,18 @@ Status ExpandProgram::GenerateShaderCode(ShaderHelper& shader) const {
       // Shift the byte at "off % 4" down to the low 8 bits of the packed u32.
       return "((" + input.GetByOffset(off + " / 4") + " >> ((" + off + " % 4) * 8u)) & 0xFFu)";
     };
-    // Broadcast a single element into all 4 lanes of a packed word.
+    // Broadcast a single element into all 4 lanes.
     auto splat_element = [&](const std::string& e) -> std::string {
-      return is_bool ? ("vec4<bool>(" + e + ")") : ("(" + e + " * 0x01010101u)");
+      return vec4_type + "(" + e + ")";
     };
-    // Assemble a packed word from 4 elements.
+    // Assemble a 4-lane vector from 4 elements.
     auto pack_elements = [&](const std::string& e0, const std::string& e1, const std::string& e2, const std::string& e3) -> std::string {
-      if (is_bool) {
-        return "vec4<bool>(" + e0 + ", " + e1 + ", " + e2 + ", " + e3 + ")";
-      }
-      return "(" + e0 + " | (" + e1 + " << 8u) | (" + e2 + " << 16u) | (" + e3 + " << 24u))";
+      return vec4_type + "(" + e0 + ", " + e1 + ", " + e2 + ", " + e3 + ")";
+    };
+    // Expand a whole storage word into its 4 lanes. GetByOffset already returns vec4<bool> for bool,
+    // but the raw packed u32 for uint8, which must be unpacked with unpack4xU8.
+    auto unpack_word = [&](const std::string& word_offset) -> std::string {
+      return is_bool ? input.GetByOffset(word_offset) : ("unpack4xU8(" + input.GetByOffset(word_offset) + ")");
     };
 
     if (input_last_dim_divisible_by_4_) {
@@ -48,7 +57,7 @@ Status ExpandProgram::GenerateShaderCode(ShaderHelper& shader) const {
       // maps directly to a whole packed word.
       shader.MainFunctionBody() << "  let output_indices = " << output_indices.OffsetToIndices("global_idx * 4") << ";\n"
                                 << "  let input_offset = " << input_indices.BroadcastedIndicesToOffset("output_indices", output_indices) << ";\n"
-                                << output.SetByOffset("global_idx", input.GetByOffset("input_offset / 4"));
+                                << output.SetByOffset("global_idx", unpack_word("input_offset / 4"));
     } else if (output_last_dim_divisible_by_4_) {
       // The last dim of output shape is divisible by 4, and the last dim of input shape is 1.
       shader.MainFunctionBody() << "  let output_indices = " << output_indices.OffsetToIndices("global_idx * 4") << ";\n"

--- a/onnxruntime/test/providers/cpu/tensor/expand_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/expand_test.cc
@@ -324,6 +324,67 @@ TEST(ExpandOpTest, Expand_4x1_bool) {
   test.Run();
 }
 
+// uint8 is a 1-byte-per-element type packed 4-per-u32 in the WebGPU storage buffer, like bool.
+// These cases cover the three packed-byte shader paths: per-element assembly (output last dim not
+// divisible by 4), splat (output last dim divisible by 4, input last dim 1), and whole-word copy
+// (input last dim divisible by 4). Some cases vary values within each packed u32 to catch
+// byte-position bugs.
+TEST(ExpandOpTest, Expand_3x3_uint8) {
+  OpTester test("Expand", 8);
+  test.AddInput<uint8_t>("data_0", {1}, {5});
+  test.AddInput<int64_t>("data_1", {2}, {3, 3});
+  test.AddOutput<uint8_t>("result", {3, 3},
+                          {5, 5, 5,
+                           5, 5, 5,
+                           5, 5, 5});
+  test.Run();
+}
+
+TEST(ExpandOpTest, Expand_3x1_uint8) {
+  OpTester test("Expand", 8);
+  test.AddInput<uint8_t>("data_0", {3}, {11, 22, 33});
+  test.AddInput<int64_t>("data_1", {2}, {3, 1});
+  test.AddOutput<uint8_t>("result", {3, 3},
+                          {11, 22, 33,
+                           11, 22, 33,
+                           11, 22, 33});
+  test.Run();
+}
+
+TEST(ExpandOpTest, Expand_1x3_uint8) {
+  OpTester test("Expand", 8);
+  test.AddInput<uint8_t>("data_0", {3, 1}, {11, 22, 33});
+  test.AddInput<int64_t>("data_1", {2}, {1, 3});
+  test.AddOutput<uint8_t>("result", {3, 3},
+                          {11, 11, 11,
+                           22, 22, 22,
+                           33, 33, 33});
+  test.Run();
+}
+
+TEST(ExpandOpTest, Expand_1x4_uint8) {
+  OpTester test("Expand", 8);
+  test.AddInput<uint8_t>("data_0", {3, 1}, {11, 22, 33});
+  test.AddInput<int64_t>("data_1", {2}, {1, 4});
+  test.AddOutput<uint8_t>("result", {3, 4},
+                          {11, 11, 11, 11,
+                           22, 22, 22, 22,
+                           33, 33, 33, 33});
+  test.Run();
+}
+
+TEST(ExpandOpTest, Expand_4x1_uint8) {
+  OpTester test("Expand", 8);
+  test.AddInput<uint8_t>("data_0", {1, 4}, {10, 20, 30, 40});
+  test.AddInput<int64_t>("data_1", {2}, {4, 1});
+  test.AddOutput<uint8_t>("result", {4, 4},
+                          {10, 20, 30, 40,
+                           10, 20, 30, 40,
+                           10, 20, 30, 40,
+                           10, 20, 30, 40});
+  test.Run();
+}
+
 #ifndef USE_TENSORRT
 TEST(ExpandOpTest, Expand_scalar_float) {
   OpTester test("Expand", 8);


### PR DESCRIPTION
uint8 is a 1-byte-per-element type that cannot be stored directly in a WebGPU storage buffer, so it is packed 4-per-u32 just like bool. Extend the existing bool-only packed path to also handle uint8: route it through the same flatten/4-component/broadcast-indices setup, and generalize the shader so the three broadcast branches (whole-word copy, splat, and per-element pack) differ only in how a single element is extracted from and assembled into the packed word. bool keeps using vec4<bool>; uint8 uses byte shift/mask extraction and reassembly.

Add uint8 to the Expand kernel type constraints and cover all three shader branches with tests.

This is to fix part of https://github.com/microsoft/onnxruntime/issues/29756

