### PR TITLE
Fix Windows CUDA DLL process architecture

### DIFF
--- a/onnxruntime/__init__.py
+++ b/onnxruntime/__init__.py
@@ -199,10 +199,12 @@ def _get_cufft_version(cuda_major_version: str) -> str:
     return "12" if int(cuda_major_version) >= 13 else "11"
 
 
-def _get_nvidia_dll_paths(is_windows: bool, cuda: bool = True, cudnn: bool = True):
+def _get_nvidia_dll_paths(
+    is_windows: bool, cuda: bool = True, cudnn: bool = True, build_cuda_version: str | None = None
+):
     # Dynamically determine CUDA major version from build info.
     # build_cuda_version defaults to the version this package was built with; it is a parameter for testability.
-    cuda_major_version = _extract_cuda_major_version(cuda_version)
+    cuda_major_version = _extract_cuda_major_version(build_cuda_version or cuda_version)
     cufft_version = _get_cufft_version(cuda_major_version)
 
     # Starting with CUDA 13, NVIDIA consolidated the per-component CUDA Toolkit wheels
@@ -216,9 +218,9 @@ def _get_nvidia_dll_paths(is_windows: bool, cuda: bool = True, cudnn: bool = Tru
     if use_consolidated_layout:
         cuda_dir = f"cu{cuda_major_version}"
         if is_windows:
-            import platform  # noqa: PLC0415
+            import sysconfig  # noqa: PLC0415
 
-            arch = "arm64" if platform.machine().lower() in ("arm64", "aarch64") else "x86_64"
+            arch = "arm64" if sysconfig.get_platform().lower() == "win-arm64" else "x86_64"
             cuda_dll_paths = [
                 ("nvidia", cuda_dir, "bin", arch, f"cublasLt64_{cuda_major_version}.dll"),
                 ("nvidia", cuda_dir, "bin", arch, f"cublas64_{cuda_major_version}.dll"),

--- a/onnxruntime/test/python/onnxruntime_test_python_preload_dlls.py
+++ b/onnxruntime/test/python/onnxruntime_test_python_preload_dlls.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 # pylint: disable=C0114,C0115,C0116,W0212
 import unittest
+from unittest import mock
 
 import onnxruntime
 
@@ -38,14 +39,16 @@ class TestGetNvidiaDllPaths(unittest.TestCase):
 
     # ---- CUDA 13 (consolidated "cu13" layout) ---------------------------------------
     def test_cuda13_windows_x86_64(self):
-        paths = self._paths(is_windows=True, build_cuda_version="13.2", cudnn=False, arch="x86_64")
+        with mock.patch("sysconfig.get_platform", return_value="win-amd64"):
+            paths = self._paths(is_windows=True, build_cuda_version="13.2", cudnn=False)
         self.assertIn(("nvidia", "cu13", "bin", "x86_64", "cublasLt64_13.dll"), paths)
         self.assertIn(("nvidia", "cu13", "bin", "x86_64", "cublas64_13.dll"), paths)
         self.assertIn(("nvidia", "cu13", "bin", "x86_64", "cufft64_12.dll"), paths)
         self.assertIn(("nvidia", "cu13", "bin", "x86_64", "cudart64_13.dll"), paths)
 
-    def test_cuda13_windows_arch_override(self):
-        paths = self._paths(is_windows=True, build_cuda_version="13.2", cudnn=False, arch="arm64")
+    def test_cuda13_windows_uses_process_architecture(self):
+        with mock.patch("sysconfig.get_platform", return_value="win-arm64"):
+            paths = self._paths(is_windows=True, build_cuda_version="13.2", cudnn=False)
         self.assertIn(("nvidia", "cu13", "bin", "arm64", "cudart64_13.dll"), paths)
 
     def test_cuda13_linux_is_flat(self):


### PR DESCRIPTION
### Description

Use `sysconfig.get_platform()` instead of `platform.machine()` when selecting the CUDA 13 Windows architecture directory. This makes the selected DLL path follow the architecture of the running Python process rather than the underlying machine.

The existing preload helper tests now exercise both `win-amd64` and `win-arm64` process platforms. The helper's existing build-version test hook is also wired into the implementation so the CUDA 12 and CUDA 13 path cases are deterministic.

### Motivation and Context

On an ARM64 machine, an x64 Python process reports an ARM64 machine architecture through `platform.machine()`. That causes ONNX Runtime to search `bin/arm64` even though the process needs the x86-64 DLLs. `sysconfig.get_platform()` reports the process platform and selects the matching wheel directory.

Fixes #29809.

### Validation

- Targeted `onnxruntime_test_python_preload_dlls.py` suite: 7 tests passed
- Ruff lint: passed
- Ruff format check: passed
- Python compile check: passed
- Before/after process-architecture reproduction: `arm64` before, `x86_64` after for an ARM64 host with a `win-amd64` Python process
