### PR TITLE
Fix GPU discovery error

### DIFF
--- a/onnxruntime/core/platform/linux/device_discovery.cc
+++ b/onnxruntime/core/platform/linux/device_discovery.cc
@@ -78,6 +78,14 @@ Status DetectGpuSysfsPaths(std::vector<GpuSysfsPathInfo>& gpu_sysfs_paths_out) {
     const auto& dir_item_path = dir_item.path();
 
     if (size_t card_idx{}; detect_card_path(dir_item_path, card_idx)) {
+      // Skip non-PCI DRM cards. On systems with AMD GPU compute partitioning
+      // (XCP), the amdgpu driver creates virtual platform sub-devices
+      // (e.g., amdgpu_xcp_*) that lack standard PCI sysfs attributes.
+      if (!fs::exists(dir_item_path / "device" / "vendor")) {
+        LOGS_DEFAULT(VERBOSE) << "Skipping non-PCI DRM card: " << dir_item_path;
+        continue;
+      }
+
       GpuSysfsPathInfo path_info{};
       path_info.card_idx = card_idx;
       path_info.path = dir_item_path;

--- a/onnxruntime/core/platform/linux/device_discovery.cc
+++ b/onnxruntime/core/platform/linux/device_discovery.cc
@@ -81,7 +81,11 @@ Status DetectGpuSysfsPaths(std::vector<GpuSysfsPathInfo>& gpu_sysfs_paths_out) {
       // Skip non-PCI DRM cards. On systems with AMD GPU compute partitioning
       // (XCP), the amdgpu driver creates virtual platform sub-devices
       // (e.g., amdgpu_xcp_*) that lack standard PCI sysfs attributes.
-      if (!fs::exists(dir_item_path / "device" / "vendor")) {
+      const auto vendor_path = dir_item_path / "device" / "vendor";
+      const bool vendor_path_exists = fs::exists(vendor_path, error_code);
+      ORT_RETURN_IF_ERROR(ErrorCodeToStatus(error_code, vendor_path, "Checking existence of DRM card vendor sysfs attribute"));
+
+      if (!vendor_path_exists) {
         LOGS_DEFAULT(VERBOSE) << "Skipping non-PCI DRM card: " << dir_item_path;
         continue;
       }


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Fix for device discovery for cards which allow for node and compute partitioning. 

Currently device discovery  relies on pcie device attributes that dont populate sysfs items for certain cards.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Need this to support cards that support XCP functionality. 
