### PR TITLE
WebGPU EP: Add uint8 support to Gather kernel

### DIFF
--- a/onnxruntime/core/providers/webgpu/tensor/gather.cc
+++ b/onnxruntime/core/providers/webgpu/tensor/gather.cc
@@ -15,8 +15,9 @@ Status GatherProgram::GenerateShaderCode(ShaderHelper& shader) const {
 
   const auto& data_indices = shader.AddIndices("data_indices", ShaderUsage::UseUniform | ShaderUsage::UseIndicesTypeAlias);
   const auto& output_indices = shader.AddIndices("output_indices", ShaderUsage::UseUniform | ShaderUsage::UseIndicesTypeAlias);
-  bool pack_as_bytes = Inputs()[0].var_type == ProgramVariableDataType::Boolx4 ||
-                       Inputs()[0].var_type == ProgramVariableDataType::Uint8x4;
+  bool is_bool = Inputs()[0].var_type == ProgramVariableDataType::Boolx4;
+  bool is_uint8 = Inputs()[0].var_type == ProgramVariableDataType::Uint8x4;
+  bool pack_as_bytes = is_bool || is_uint8;
   shader.MainFunctionBody() << shader.GuardAgainstOutOfBoundsWorkgroupSizes("uniforms.data_size")
                             << "  var idx : input_indices_value_t;\n"
                             << "  var output_indices : output_indices_indices_t;\n"
@@ -47,8 +48,13 @@ Status GatherProgram::GenerateShaderCode(ShaderHelper& shader) const {
     }
 
     shader.MainFunctionBody() << "  data_offset = " << data_indices.IndicesToOffset("data_indices") << ";\n";
-    if (pack_as_bytes) {
+    if (is_bool) {
       shader.MainFunctionBody() << "  value[" << comp << "] = " << data.GetByOffset("data_offset / 4") << "[data_offset % 4];\n";
+    } else if (is_uint8) {
+      // Extract one byte from the packed u32: shift right by (data_offset % 4) * 8 bits, then mask.
+      // Accumulate into output packed u32 by shifting into the correct byte position.
+      shader.MainFunctionBody() << "  value = value | (((" << data.GetByOffset("data_offset / 4u")
+                                << " >> ((data_offset % 4u) * 8u)) & 0xFFu) << (" << comp << "u * 8u));\n";
     } else {
       shader.MainFunctionBody() << "  value = " << data.GetByOffset("data_offset") << ";\n";
     }
@@ -70,7 +76,7 @@ Status Gather::ComputeInternal(ComputeContext& context) const {
   bool pack_as_bytes = p.input_tensor->DataType() == DataTypeImpl::GetType<bool>() ||
                        p.input_tensor->DataType() == DataTypeImpl::GetType<uint8_t>();
   if (pack_as_bytes) {
-    // Shader will pack four bytes into one uint, so we consider the types of input and output as vec4.
+    // Shader packs four 1-byte elements into one u32 (4 components per thread).
     data_size = (data_size + 3) / 4;
   }
 

--- a/onnxruntime/core/providers/webgpu/tensor/gather.cc
+++ b/onnxruntime/core/providers/webgpu/tensor/gather.cc
@@ -23,12 +23,7 @@ Status GatherProgram::GenerateShaderCode(ShaderHelper& shader) const {
                             << "  var output_indices : output_indices_indices_t;\n"
                             << "  var indices_indices : input_indices_indices_t;\n"
                             << "  var data_indices : data_indices_indices_t;\n"
-                            // The uint8 path accumulates bytes into `value` via OR-shift, so it must
-                            // start at zero. Partial (last) threads only write a subset of the 4 byte
-                            // positions, and an uninitialized accumulator would leave the remaining
-                            // bytes undefined. The bool path assigns each component positionally and
-                            // does not require zero-initialization.
-                            << (is_uint8 ? "  var value : output_value_t = output_value_t(0);\n"
+                            << (is_uint8 ? "  var value : vec4<u32> = vec4<u32>(0u);\n"
                                          : "  var value : output_value_t;\n")
                             << "  var data_offset : u32;\n";
   for (int comp = 0; comp < (pack_as_bytes ? 4 : 1); comp++) {
@@ -60,10 +55,8 @@ Status GatherProgram::GenerateShaderCode(ShaderHelper& shader) const {
     if (is_bool) {
       shader.MainFunctionBody() << "  value[" << comp << "] = " << data.GetByOffset("data_offset / 4") << "[data_offset % 4];\n";
     } else if (is_uint8) {
-      // Extract one byte from the packed u32: shift right by (data_offset % 4) * 8 bits, then mask.
-      // Accumulate into output packed u32 by shifting into the correct byte position.
-      shader.MainFunctionBody() << "  value = value | (((" << data.GetByOffset("data_offset / 4u")
-                                << " >> ((data_offset % 4u) * 8u)) & 0xFFu) << (" << comp << "u * 8u));\n";
+      shader.MainFunctionBody() << "  value[" << comp << "] = unpack4xU8(" << data.GetByOffset("data_offset / 4u")
+                                << ")[data_offset % 4u];\n";
     } else {
       shader.MainFunctionBody() << "  value = " << data.GetByOffset("data_offset") << ";\n";
     }
@@ -72,7 +65,12 @@ Status GatherProgram::GenerateShaderCode(ShaderHelper& shader) const {
     }
   }
 
-  shader.MainFunctionBody() << "  " << output.SetByOffset("global_idx", "value");
+  if (is_uint8) {
+    shader.MainFunctionBody() << "  let packed_value : output_value_t = value[0] | (value[1] << 8u) | (value[2] << 16u) | (value[3] << 24u);\n"
+                              << "  " << output.SetByOffset("global_idx", "packed_value");
+  } else {
+    shader.MainFunctionBody() << "  " << output.SetByOffset("global_idx", "value");
+  }
 
   return Status::OK();
 }

--- a/onnxruntime/core/providers/webgpu/tensor/gather.cc
+++ b/onnxruntime/core/providers/webgpu/tensor/gather.cc
@@ -26,6 +26,9 @@ Status GatherProgram::GenerateShaderCode(ShaderHelper& shader) const {
                             << "  var value : output_value_t;\n"
                             << "  var data_offset : u32;\n";
   for (int comp = 0; comp < (pack_as_bytes ? 4 : 1); comp++) {
+    if (pack_as_bytes) {
+      shader.MainFunctionBody() << "  if (" << comp << "u + 4u * global_idx < uniforms.output_size) {\n";
+    }
     shader.MainFunctionBody() << "  output_indices = " << output_indices.OffsetToIndices(pack_as_bytes ? (std::to_string(comp) + " + 4 * global_idx") : "global_idx") << ";\n";
 
     for (int i = 0; i < indices.Rank(); i++) {
@@ -58,6 +61,9 @@ Status GatherProgram::GenerateShaderCode(ShaderHelper& shader) const {
     } else {
       shader.MainFunctionBody() << "  value = " << data.GetByOffset("data_offset") << ";\n";
     }
+    if (pack_as_bytes) {
+      shader.MainFunctionBody() << "  }\n";
+    }
   }
 
   shader.MainFunctionBody() << "  " << output.SetByOffset("global_idx", "value");
@@ -75,6 +81,7 @@ Status Gather::ComputeInternal(ComputeContext& context) const {
 
   bool pack_as_bytes = p.input_tensor->DataType() == DataTypeImpl::GetType<bool>() ||
                        p.input_tensor->DataType() == DataTypeImpl::GetType<uint8_t>();
+  uint32_t output_size = data_size;
   if (pack_as_bytes) {
     // Shader packs four 1-byte elements into one u32 (4 components per thread).
     data_size = (data_size + 3) / 4;
@@ -90,7 +97,7 @@ Status Gather::ComputeInternal(ComputeContext& context) const {
       .CacheHint(std::to_string(axis))
       .AddIndices(p.input_tensor->Shape())
       .AddIndices(p.output_tensor->Shape())
-      .AddUniformVariables({{data_size}});
+      .AddUniformVariables({{data_size}, {output_size}});
   return context.RunProgram(program);
 }
 

--- a/onnxruntime/core/providers/webgpu/tensor/gather.cc
+++ b/onnxruntime/core/providers/webgpu/tensor/gather.cc
@@ -100,9 +100,9 @@ Status Gather::ComputeInternal(ComputeContext& context) const {
       KernelDefBuilder().TypeConstraint("T", TYPE).TypeConstraint("Tind", BuildKernelDefConstraintsFromTypeList<TypeList<int32_t, int64_t>>()), \
       KERNEL_CLASS);
 
-WEBGPU_GATHER_VERSIONED_KERNEL(Gather, 1, 10, Gather, WebGpuSupportedNumberBoolAndUint8Types())
-WEBGPU_GATHER_VERSIONED_KERNEL(Gather, 11, 12, Gather, WebGpuSupportedNumberBoolAndUint8Types())
-WEBGPU_GATHER_KERNEL(Gather, 13, Gather, WebGpuSupportedNumberBoolAndUint8Types())
+WEBGPU_GATHER_VERSIONED_KERNEL(Gather, 1, 10, Gather, BuildKernelDefConstraintsFromTypeList<TypeList<float, MLFloat16, int32_t, uint32_t, bool, uint8_t>>())
+WEBGPU_GATHER_VERSIONED_KERNEL(Gather, 11, 12, Gather, BuildKernelDefConstraintsFromTypeList<TypeList<float, MLFloat16, int32_t, uint32_t, bool, uint8_t>>())
+WEBGPU_GATHER_KERNEL(Gather, 13, Gather, BuildKernelDefConstraintsFromTypeList<TypeList<float, MLFloat16, int32_t, uint32_t, bool, uint8_t>>())
 
 }  // namespace webgpu
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/webgpu/tensor/gather.cc
+++ b/onnxruntime/core/providers/webgpu/tensor/gather.cc
@@ -20,11 +20,13 @@ Status GatherProgram::GenerateShaderCode(ShaderHelper& shader) const {
   bool pack_as_bytes = is_bool || is_uint8;
   shader.MainFunctionBody() << shader.GuardAgainstOutOfBoundsWorkgroupSizes("uniforms.data_size");
   if (pack_as_bytes) {
-    // For bool/uint8 packed paths, declare the output accumulator outside the per-comp blocks,
-    // but declare ALL intermediate computation variables INSIDE each comp's if-block scope.
-    // This avoids a cross-backend codegen bug (reproduces on both Metal/D3D12) where sequential
-    // if-blocks sharing the same mutable var names (output_indices, idx, etc.) cause comp=1..3
-    // to reuse comp=0's stale variable state, producing wrong results.
+    // bool and uint8 both pack four 1-byte elements per thread into one u32 storage word.
+    // The accumulator holds one element per lane and is handed to SetByOffset unpacked, because
+    // SetByOffset performs the byte packing for Uint8x4 (and Boolx4) itself. Do not pre-pack
+    // into a u32 here: SetByOffset would splat that scalar across all four lanes, mask each to
+    // its low byte and re-pack, so every output word would be element 0's byte repeated four
+    // times. uint8 needs an explicit vec4<u32> because output_value_t for Uint8x4 is the packed
+    // u32 storage type, unlike Boolx4's vec4<bool>.
     shader.MainFunctionBody() << (is_uint8 ? "  var value : vec4<u32> = vec4<u32>(0u);\n"
                                            : "  var value : output_value_t;\n");
     for (int comp = 0; comp < 4; comp++) {
@@ -95,12 +97,7 @@ Status GatherProgram::GenerateShaderCode(ShaderHelper& shader) const {
                               << "  value = " << data.GetByOffset("data_offset") << ";\n";
   }
 
-  if (is_uint8) {
-    shader.MainFunctionBody() << "  let packed_value : output_value_t = value[0] | (value[1] << 8u) | (value[2] << 16u) | (value[3] << 24u);\n"
-                              << "  " << output.SetByOffset("global_idx", "packed_value");
-  } else {
-    shader.MainFunctionBody() << "  " << output.SetByOffset("global_idx", "value");
-  }
+  shader.MainFunctionBody() << "  " << output.SetByOffset("global_idx", "value");
 
   return Status::OK();
 }

--- a/onnxruntime/core/providers/webgpu/tensor/gather.cc
+++ b/onnxruntime/core/providers/webgpu/tensor/gather.cc
@@ -18,19 +18,59 @@ Status GatherProgram::GenerateShaderCode(ShaderHelper& shader) const {
   bool is_bool = Inputs()[0].var_type == ProgramVariableDataType::Boolx4;
   bool is_uint8 = Inputs()[0].var_type == ProgramVariableDataType::Uint8x4;
   bool pack_as_bytes = is_bool || is_uint8;
-  shader.MainFunctionBody() << shader.GuardAgainstOutOfBoundsWorkgroupSizes("uniforms.data_size")
-                            << "  var idx : input_indices_value_t;\n"
-                            << "  var output_indices : output_indices_indices_t;\n"
-                            << "  var indices_indices : input_indices_indices_t;\n"
-                            << "  var data_indices : data_indices_indices_t;\n"
-                            << (is_uint8 ? "  var value : vec4<u32> = vec4<u32>(0u);\n"
-                                         : "  var value : output_value_t;\n")
-                            << "  var data_offset : u32;\n";
-  for (int comp = 0; comp < (pack_as_bytes ? 4 : 1); comp++) {
-    if (pack_as_bytes) {
-      shader.MainFunctionBody() << "  if (" << comp << "u + 4u * global_idx < uniforms.output_size) {\n";
+  shader.MainFunctionBody() << shader.GuardAgainstOutOfBoundsWorkgroupSizes("uniforms.data_size");
+  if (pack_as_bytes) {
+    // For bool/uint8 packed paths, declare the output accumulator outside the per-comp blocks,
+    // but declare ALL intermediate computation variables INSIDE each comp's if-block scope.
+    // This avoids a Metal shader compiler bug where sequential if-blocks sharing the same
+    // mutable var names (output_indices, idx, etc.) cause comp=1..3 to reuse comp=0's stale
+    // variable state, producing wrong results.
+    shader.MainFunctionBody() << (is_uint8 ? "  var value : vec4<u32> = vec4<u32>(0u);\n"
+                                           : "  var value : output_value_t;\n");
+    for (int comp = 0; comp < 4; comp++) {
+      shader.MainFunctionBody() << "  if (" << comp << "u + 4u * global_idx < uniforms.output_size) {\n"
+                                << "    var output_indices : output_indices_indices_t;\n"
+                                << "    var indices_indices : input_indices_indices_t;\n"
+                                << "    var data_indices : data_indices_indices_t;\n"
+                                << "    var idx : input_indices_value_t;\n";
+      shader.MainFunctionBody() << "    output_indices = " << output_indices.OffsetToIndices(std::to_string(comp) + " + 4 * global_idx") << ";\n";
+
+      for (int i = 0; i < indices.Rank(); i++) {
+        shader.MainFunctionBody() << "    " << indices.IndicesSet("indices_indices", i, output_indices.IndicesGet("output_indices", axis_ + i)) << ";\n";
+      }
+
+      shader.MainFunctionBody() << "    idx = " << indices.GetByIndices("indices_indices") << ";\n"
+                                << "    if (idx < 0) {\n"
+                                << "      idx = idx + input_indices_value_t(" << data_indices.IndicesGet("uniforms.data_indices_shape", axis_) << ");\n"
+                                << "    }\n";
+
+      for (int i = 0, j = 0; i < data_indices.Rank(); i++) {
+        if (static_cast<uint32_t>(i) == axis_) {
+          shader.MainFunctionBody() << "    " << data_indices.IndicesSet("data_indices", i, "u32(idx)") << ";\n";
+          j += indices.Rank();
+        } else {
+          shader.MainFunctionBody() << "    " << data_indices.IndicesSet("data_indices", i, output_indices.IndicesGet("output_indices", j)) << ";\n";
+          j++;
+        }
+      }
+
+      shader.MainFunctionBody() << "    let data_offset = " << data_indices.IndicesToOffset("data_indices") << ";\n";
+      if (is_bool) {
+        shader.MainFunctionBody() << "    value[" << comp << "] = " << data.GetByOffset("data_offset / 4") << "[data_offset % 4];\n";
+      } else {
+        shader.MainFunctionBody() << "    value[" << comp << "] = unpack4xU8(" << data.GetByOffset("data_offset / 4u")
+                                  << ")[data_offset % 4u];\n";
+      }
+      shader.MainFunctionBody() << "  }\n";
     }
-    shader.MainFunctionBody() << "  output_indices = " << output_indices.OffsetToIndices(pack_as_bytes ? (std::to_string(comp) + " + 4 * global_idx") : "global_idx") << ";\n";
+  } else {
+    shader.MainFunctionBody() << "  var idx : input_indices_value_t;\n"
+                              << "  var output_indices : output_indices_indices_t;\n"
+                              << "  var indices_indices : input_indices_indices_t;\n"
+                              << "  var data_indices : data_indices_indices_t;\n"
+                              << "  var value : output_value_t;\n"
+                              << "  var data_offset : u32;\n";
+    shader.MainFunctionBody() << "  output_indices = " << output_indices.OffsetToIndices("global_idx") << ";\n";
 
     for (int i = 0; i < indices.Rank(); i++) {
       shader.MainFunctionBody() << "  " << indices.IndicesSet("indices_indices", i, output_indices.IndicesGet("output_indices", axis_ + i)) << ";\n";
@@ -51,18 +91,8 @@ Status GatherProgram::GenerateShaderCode(ShaderHelper& shader) const {
       }
     }
 
-    shader.MainFunctionBody() << "  data_offset = " << data_indices.IndicesToOffset("data_indices") << ";\n";
-    if (is_bool) {
-      shader.MainFunctionBody() << "  value[" << comp << "] = " << data.GetByOffset("data_offset / 4") << "[data_offset % 4];\n";
-    } else if (is_uint8) {
-      shader.MainFunctionBody() << "  value[" << comp << "] = unpack4xU8(" << data.GetByOffset("data_offset / 4u")
-                                << ")[data_offset % 4u];\n";
-    } else {
-      shader.MainFunctionBody() << "  value = " << data.GetByOffset("data_offset") << ";\n";
-    }
-    if (pack_as_bytes) {
-      shader.MainFunctionBody() << "  }\n";
-    }
+    shader.MainFunctionBody() << "  data_offset = " << data_indices.IndicesToOffset("data_indices") << ";\n"
+                              << "  value = " << data.GetByOffset("data_offset") << ";\n";
   }
 
   if (is_uint8) {

--- a/onnxruntime/core/providers/webgpu/tensor/gather.cc
+++ b/onnxruntime/core/providers/webgpu/tensor/gather.cc
@@ -15,7 +15,8 @@ Status GatherProgram::GenerateShaderCode(ShaderHelper& shader) const {
 
   const auto& data_indices = shader.AddIndices("data_indices", ShaderUsage::UseUniform | ShaderUsage::UseIndicesTypeAlias);
   const auto& output_indices = shader.AddIndices("output_indices", ShaderUsage::UseUniform | ShaderUsage::UseIndicesTypeAlias);
-  bool is_bool = Inputs()[0].var_type == ProgramVariableDataType::Boolx4;
+  bool pack_as_bytes = Inputs()[0].var_type == ProgramVariableDataType::Boolx4 ||
+                       Inputs()[0].var_type == ProgramVariableDataType::Uint8x4;
   shader.MainFunctionBody() << shader.GuardAgainstOutOfBoundsWorkgroupSizes("uniforms.data_size")
                             << "  var idx : input_indices_value_t;\n"
                             << "  var output_indices : output_indices_indices_t;\n"
@@ -23,8 +24,8 @@ Status GatherProgram::GenerateShaderCode(ShaderHelper& shader) const {
                             << "  var data_indices : data_indices_indices_t;\n"
                             << "  var value : output_value_t;\n"
                             << "  var data_offset : u32;\n";
-  for (int comp = 0; comp < (is_bool ? 4 : 1); comp++) {
-    shader.MainFunctionBody() << "  output_indices = " << output_indices.OffsetToIndices(is_bool ? (std::to_string(comp) + " + 4 * global_idx") : "global_idx") << ";\n";
+  for (int comp = 0; comp < (pack_as_bytes ? 4 : 1); comp++) {
+    shader.MainFunctionBody() << "  output_indices = " << output_indices.OffsetToIndices(pack_as_bytes ? (std::to_string(comp) + " + 4 * global_idx") : "global_idx") << ";\n";
 
     for (int i = 0; i < indices.Rank(); i++) {
       shader.MainFunctionBody() << "  " << indices.IndicesSet("indices_indices", i, output_indices.IndicesGet("output_indices", axis_ + i)) << ";\n";
@@ -46,7 +47,7 @@ Status GatherProgram::GenerateShaderCode(ShaderHelper& shader) const {
     }
 
     shader.MainFunctionBody() << "  data_offset = " << data_indices.IndicesToOffset("data_indices") << ";\n";
-    if (is_bool) {
+    if (pack_as_bytes) {
       shader.MainFunctionBody() << "  value[" << comp << "] = " << data.GetByOffset("data_offset / 4") << "[data_offset % 4];\n";
     } else {
       shader.MainFunctionBody() << "  value = " << data.GetByOffset("data_offset") << ";\n";
@@ -66,18 +67,19 @@ Status Gather::ComputeInternal(ComputeContext& context) const {
     return Status::OK();
   }
 
-  bool is_bool = p.input_tensor->DataType() == DataTypeImpl::GetType<bool>();
-  if (is_bool) {
-    // Shader will pack four bools into one uint, so we consider the types of input and output as vec4<bool>.
+  bool pack_as_bytes = p.input_tensor->DataType() == DataTypeImpl::GetType<bool>() ||
+                       p.input_tensor->DataType() == DataTypeImpl::GetType<uint8_t>();
+  if (pack_as_bytes) {
+    // Shader will pack four bytes into one uint, so we consider the types of input and output as vec4.
     data_size = (data_size + 3) / 4;
   }
 
   uint32_t axis = static_cast<uint32_t>(p.axis);
   GatherProgram program{axis};
   program
-      .AddInputs({{p.input_tensor, ProgramTensorMetadataDependency::TypeAndRank, ProgramInput::Flatten, (is_bool ? 4 : 1)},
+      .AddInputs({{p.input_tensor, ProgramTensorMetadataDependency::TypeAndRank, ProgramInput::Flatten, (pack_as_bytes ? 4 : 1)},
                   {p.indices_tensor, ProgramTensorMetadataDependency::TypeAndRank}})
-      .AddOutput({p.output_tensor, ProgramTensorMetadataDependency::Rank, {data_size}, (is_bool ? 4 : 1)})
+      .AddOutput({p.output_tensor, ProgramTensorMetadataDependency::Rank, {data_size}, (pack_as_bytes ? 4 : 1)})
       .SetDispatchGroupSize((data_size + WORKGROUP_SIZE - 1) / WORKGROUP_SIZE)
       .CacheHint(std::to_string(axis))
       .AddIndices(p.input_tensor->Shape())
@@ -98,9 +100,9 @@ Status Gather::ComputeInternal(ComputeContext& context) const {
       KernelDefBuilder().TypeConstraint("T", TYPE).TypeConstraint("Tind", BuildKernelDefConstraintsFromTypeList<TypeList<int32_t, int64_t>>()), \
       KERNEL_CLASS);
 
-WEBGPU_GATHER_VERSIONED_KERNEL(Gather, 1, 10, Gather, WebGpuSupportedNumberAndBoolTypes())
-WEBGPU_GATHER_VERSIONED_KERNEL(Gather, 11, 12, Gather, WebGpuSupportedNumberAndBoolTypes())
-WEBGPU_GATHER_KERNEL(Gather, 13, Gather, WebGpuSupportedNumberAndBoolTypes())
+WEBGPU_GATHER_VERSIONED_KERNEL(Gather, 1, 10, Gather, WebGpuSupportedNumberBoolAndUint8Types())
+WEBGPU_GATHER_VERSIONED_KERNEL(Gather, 11, 12, Gather, WebGpuSupportedNumberBoolAndUint8Types())
+WEBGPU_GATHER_KERNEL(Gather, 13, Gather, WebGpuSupportedNumberBoolAndUint8Types())
 
 }  // namespace webgpu
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/webgpu/tensor/gather.cc
+++ b/onnxruntime/core/providers/webgpu/tensor/gather.cc
@@ -113,9 +113,9 @@ Status Gather::ComputeInternal(ComputeContext& context) const {
       KernelDefBuilder().TypeConstraint("T", TYPE).TypeConstraint("Tind", BuildKernelDefConstraintsFromTypeList<TypeList<int32_t, int64_t>>()), \
       KERNEL_CLASS);
 
-WEBGPU_GATHER_VERSIONED_KERNEL(Gather, 1, 10, Gather, BuildKernelDefConstraintsFromTypeList<TypeList<float, MLFloat16, int32_t, uint32_t, bool, uint8_t>>())
-WEBGPU_GATHER_VERSIONED_KERNEL(Gather, 11, 12, Gather, BuildKernelDefConstraintsFromTypeList<TypeList<float, MLFloat16, int32_t, uint32_t, bool, uint8_t>>())
-WEBGPU_GATHER_KERNEL(Gather, 13, Gather, BuildKernelDefConstraintsFromTypeList<TypeList<float, MLFloat16, int32_t, uint32_t, bool, uint8_t>>())
+WEBGPU_GATHER_VERSIONED_KERNEL(Gather, 1, 10, Gather, WebGpuSupportedNumberBoolAndUint8Types())
+WEBGPU_GATHER_VERSIONED_KERNEL(Gather, 11, 12, Gather, WebGpuSupportedNumberBoolAndUint8Types())
+WEBGPU_GATHER_KERNEL(Gather, 13, Gather, WebGpuSupportedNumberBoolAndUint8Types())
 
 }  // namespace webgpu
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/webgpu/tensor/gather.cc
+++ b/onnxruntime/core/providers/webgpu/tensor/gather.cc
@@ -23,7 +23,13 @@ Status GatherProgram::GenerateShaderCode(ShaderHelper& shader) const {
                             << "  var output_indices : output_indices_indices_t;\n"
                             << "  var indices_indices : input_indices_indices_t;\n"
                             << "  var data_indices : data_indices_indices_t;\n"
-                            << "  var value : output_value_t;\n"
+                            // The uint8 path accumulates bytes into `value` via OR-shift, so it must
+                            // start at zero. Partial (last) threads only write a subset of the 4 byte
+                            // positions, and an uninitialized accumulator would leave the remaining
+                            // bytes undefined. The bool path assigns each component positionally and
+                            // does not require zero-initialization.
+                            << (is_uint8 ? "  var value : output_value_t = output_value_t(0);\n"
+                                         : "  var value : output_value_t;\n")
                             << "  var data_offset : u32;\n";
   for (int comp = 0; comp < (pack_as_bytes ? 4 : 1); comp++) {
     if (pack_as_bytes) {

--- a/onnxruntime/core/providers/webgpu/tensor/gather.cc
+++ b/onnxruntime/core/providers/webgpu/tensor/gather.cc
@@ -22,9 +22,9 @@ Status GatherProgram::GenerateShaderCode(ShaderHelper& shader) const {
   if (pack_as_bytes) {
     // For bool/uint8 packed paths, declare the output accumulator outside the per-comp blocks,
     // but declare ALL intermediate computation variables INSIDE each comp's if-block scope.
-    // This avoids a Metal shader compiler bug where sequential if-blocks sharing the same
-    // mutable var names (output_indices, idx, etc.) cause comp=1..3 to reuse comp=0's stale
-    // variable state, producing wrong results.
+    // This avoids a cross-backend codegen bug (reproduces on both Metal/D3D12) where sequential
+    // if-blocks sharing the same mutable var names (output_indices, idx, etc.) cause comp=1..3
+    // to reuse comp=0's stale variable state, producing wrong results.
     shader.MainFunctionBody() << (is_uint8 ? "  var value : vec4<u32> = vec4<u32>(0u);\n"
                                            : "  var value : output_value_t;\n");
     for (int comp = 0; comp < 4; comp++) {

--- a/onnxruntime/core/providers/webgpu/tensor/gather.h
+++ b/onnxruntime/core/providers/webgpu/tensor/gather.h
@@ -16,7 +16,8 @@ class GatherProgram final : public Program<GatherProgram> {
 
   Status GenerateShaderCode(ShaderHelper& sh) const override;
 
-  WEBGPU_PROGRAM_DEFINE_UNIFORM_VARIABLES({"data_size", ProgramUniformVariableDataType::Uint32});
+  WEBGPU_PROGRAM_DEFINE_UNIFORM_VARIABLES({"data_size", ProgramUniformVariableDataType::Uint32},
+                                          {"output_size", ProgramUniformVariableDataType::Uint32});
 
  private:
   uint32_t axis_;

--- a/onnxruntime/core/providers/webgpu/webgpu_supported_types.h
+++ b/onnxruntime/core/providers/webgpu/webgpu_supported_types.h
@@ -28,6 +28,15 @@ using SupportedNumberAndBoolTypes =
         uint32_t,
         bool>;
 
+using SupportedNumberBoolAndUint8Types =
+    TypeList<
+        float,
+        MLFloat16,
+        int32_t,
+        uint32_t,
+        bool,
+        uint8_t>;
+
 inline const std::vector<MLDataType>& WebGpuSupportedNumberTypes() {
   static const std::vector<MLDataType> supportedDataTypes = BuildKernelDefConstraintsFromTypeList<SupportedNumberTypes>();
   return supportedDataTypes;
@@ -40,6 +49,11 @@ inline const std::vector<MLDataType>& WebGpuSupportedFloatTypes() {
 
 inline const std::vector<MLDataType>& WebGpuSupportedNumberAndBoolTypes() {
   static const std::vector<MLDataType> supportedDataTypes = BuildKernelDefConstraintsFromTypeList<SupportedNumberAndBoolTypes>();
+  return supportedDataTypes;
+}
+
+inline const std::vector<MLDataType>& WebGpuSupportedNumberBoolAndUint8Types() {
+  static const std::vector<MLDataType> supportedDataTypes = BuildKernelDefConstraintsFromTypeList<SupportedNumberBoolAndUint8Types>();
   return supportedDataTypes;
 }
 

--- a/onnxruntime/core/providers/webgpu/webgpu_supported_types.h
+++ b/onnxruntime/core/providers/webgpu/webgpu_supported_types.h
@@ -28,15 +28,6 @@ using SupportedNumberAndBoolTypes =
         uint32_t,
         bool>;
 
-using SupportedNumberBoolAndUint8Types =
-    TypeList<
-        float,
-        MLFloat16,
-        int32_t,
-        uint32_t,
-        bool,
-        uint8_t>;
-
 inline const std::vector<MLDataType>& WebGpuSupportedNumberTypes() {
   static const std::vector<MLDataType> supportedDataTypes = BuildKernelDefConstraintsFromTypeList<SupportedNumberTypes>();
   return supportedDataTypes;
@@ -49,11 +40,6 @@ inline const std::vector<MLDataType>& WebGpuSupportedFloatTypes() {
 
 inline const std::vector<MLDataType>& WebGpuSupportedNumberAndBoolTypes() {
   static const std::vector<MLDataType> supportedDataTypes = BuildKernelDefConstraintsFromTypeList<SupportedNumberAndBoolTypes>();
-  return supportedDataTypes;
-}
-
-inline const std::vector<MLDataType>& WebGpuSupportedNumberBoolAndUint8Types() {
-  static const std::vector<MLDataType> supportedDataTypes = BuildKernelDefConstraintsFromTypeList<SupportedNumberBoolAndUint8Types>();
   return supportedDataTypes;
 }
 

--- a/onnxruntime/test/providers/cpu/tensor/gather_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/gather_op_test.cc
@@ -405,6 +405,25 @@ TEST(GatherOpTest, Gather_axis1_indices2d_bool) {
   test.Run();
 }
 
+TEST(GatherOpTest, Gather_axis1_indices2d_uint8) {
+  OpTester test("Gather");
+  test.AddAttribute<int64_t>("axis", 1LL);
+  test.AddInput<uint8_t>("data", {3, 3},
+                         {10, 20, 30,
+                          40, 50, 60,
+                          70, 80, 90});
+  test.AddInput<int32_t>("indices", {2, 2},
+                         {1, 0,
+                          2, 1});
+  test.AddOutput<uint8_t>("output", {3, 2, 2},
+                          {20, 10, 30, 20,
+                           50, 40, 60, 50,
+                           80, 70, 90, 80});
+  // int8 and uint8 are not supported by some EPs for Gather
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "",
+           {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
+}
+
 TEST(GatherOpTest, Gather_perf) {
   OpTester test("Gather");
   test.AddAttribute<int64_t>("axis", 0LL);

--- a/onnxruntime/test/providers/cpu/tensor/gather_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/gather_op_test.cc
@@ -424,6 +424,33 @@ TEST(GatherOpTest, Gather_axis1_indices2d_uint8) {
            {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
 }
 
+#ifdef USE_WEBGPU
+// Validates the WebGPU Gather kernel's packed-byte path for uint8 (bit-shift/mask read,
+// OR-shift assembly write). Without this test, a non-WebGPU build would only exercise
+// the CPU EP path and miss shader regressions.
+TEST(GatherOpTest, Gather_axis1_indices2d_uint8_webgpu) {
+  if (DefaultWebGpuExecutionProvider().get() == nullptr) {
+    GTEST_SKIP() << "WebGPU EP not available";
+  }
+  OpTester test("Gather");
+  test.AddAttribute<int64_t>("axis", 1LL);
+  test.AddInput<uint8_t>("data", {3, 3},
+                         {10, 20, 30,
+                          40, 50, 60,
+                          70, 80, 90});
+  test.AddInput<int32_t>("indices", {2, 2},
+                         {1, 0,
+                          2, 1});
+  test.AddOutput<uint8_t>("output", {3, 2, 2},
+                          {20, 10, 30, 20,
+                           50, 40, 60, 50,
+                           80, 70, 90, 80});
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(DefaultWebGpuExecutionProvider());
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+}
+#endif  // USE_WEBGPU
+
 TEST(GatherOpTest, Gather_perf) {
   OpTester test("Gather");
   test.AddAttribute<int64_t>("axis", 0LL);

--- a/onnxruntime/test/providers/cpu/tensor/gather_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/gather_op_test.cc
@@ -449,6 +449,32 @@ TEST(GatherOpTest, Gather_axis1_indices2d_uint8_webgpu) {
   execution_providers.push_back(DefaultWebGpuExecutionProvider());
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
 }
+
+// Validates the WebGPU uint8 Gather kernel with output_size NOT a multiple of 4.
+// output shape {3,3} = 9 elements: the last packed u32 word holds only 1 valid byte,
+// with the remaining 3 bytes zero-padded (partial-thread boundary path).
+TEST(GatherOpTest, Gather_axis0_uint8_non_multiple_of_4_webgpu) {
+  if (DefaultWebGpuExecutionProvider().get() == nullptr) {
+    GTEST_SKIP() << "WebGPU EP not available";
+  }
+  OpTester test("Gather");
+  test.AddAttribute<int64_t>("axis", 0LL);
+  // 3×3 input with byte-diverse values
+  test.AddInput<uint8_t>("data", {3, 3},
+                         {10, 20, 30,
+                          40, 50, 60,
+                          70, 80, 90});
+  // 1-D indices of length 3: gather rows 1, 2, 0
+  test.AddInput<int32_t>("indices", {3}, {1, 2, 0});
+  // output shape {3,3} = 9 bytes (not a multiple of 4)
+  test.AddOutput<uint8_t>("output", {3, 3},
+                          {40, 50, 60,
+                           70, 80, 90,
+                           10, 20, 30});
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(DefaultWebGpuExecutionProvider());
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+}
 #endif  // USE_WEBGPU
 
 TEST(GatherOpTest, Gather_perf) {


### PR DESCRIPTION
### Description
The WebNN EP maps ONNX BOOL → WebNN uint8. When WebNN uses WebGPU as its backend, a Gather on a bool tensor (e.g., in [detr-resnet-50](https://huggingface.co/Xenova/detr-resnet-50/blob/main/onnx/model_fp16.onnx)) is lowered to WebGPU Gather on uint8, which previously had no matching kernel.



### Motivation and Context
Models such as detr-resnet-50 use Gather on bool tensors. The WebNN EP converts bool to uint8 before dispatching to the WebGPU backend, so the WebGPU Gather kernel must accept uint8 to handle this path end-to-end.


