### PR TITLE
Fix shape mismatch

### DIFF
--- a/include/onnxruntime/core/framework/tensor.h
+++ b/include/onnxruntime/core/framework/tensor.h
@@ -269,18 +269,18 @@ class Tensor final {
    * @warning this function is NOT thread-safe.
    */
   inline void Reshape(const TensorShape& new_shape) {
-      ORT_ENFORCE(shape_.Size() == new_shape.Size(),
-          "Tensor size (" + std::to_string(shape_.Size()) +
-          ") != new size (" + std::to_string(new_shape.Size()) + ")");
+    ORT_ENFORCE(shape_.Size() == new_shape.Size(),
+                "Tensor size (" + std::to_string(shape_.Size()) +
+                    ") != new size (" + std::to_string(new_shape.Size()) + ")");
 
 #ifdef ENABLE_STRIDED_TENSORS
-      ORT_ENFORCE(is_contiguous_,
-          "Reshape is only supported for contiguous tensors.");
-      shape_ = new_shape;
-      strides_.clear();  // lazily recomputed by Strides() for the new shape
-      is_contiguous_ = true;
+    ORT_ENFORCE(is_contiguous_,
+                "Reshape is only supported for contiguous tensors.");
+    shape_ = new_shape;
+    strides_.clear();  // lazily recomputed by Strides() for the new shape
+    is_contiguous_ = true;
 #else
-      shape_ = new_shape;
+    shape_ = new_shape;
 #endif
   }
 

--- a/include/onnxruntime/core/framework/tensor.h
+++ b/include/onnxruntime/core/framework/tensor.h
@@ -269,10 +269,19 @@ class Tensor final {
    * @warning this function is NOT thread-safe.
    */
   inline void Reshape(const TensorShape& new_shape) {
-    ORT_ENFORCE(shape_.Size() == new_shape.Size(),
-                "Tensor size (" + std::to_string(shape_.Size()) +
-                    ") != new size (" + std::to_string(new_shape.Size()) + ")");
-    shape_ = new_shape;
+      ORT_ENFORCE(shape_.Size() == new_shape.Size(),
+          "Tensor size (" + std::to_string(shape_.Size()) +
+          ") != new size (" + std::to_string(new_shape.Size()) + ")");
+
+#ifdef ENABLE_STRIDED_TENSORS
+      ORT_ENFORCE(is_contiguous_,
+          "Reshape is only supported for contiguous tensors.");
+      shape_ = new_shape;
+      strides_.clear();  // lazily recomputed by Strides() for the new shape
+      is_contiguous_ = true;
+#else
+      shape_ = new_shape;
+#endif
   }
 
   /**

--- a/onnxruntime/core/framework/execution_frame.cc
+++ b/onnxruntime/core/framework/execution_frame.cc
@@ -197,7 +197,6 @@ Status IExecutionFrame::GetOrCreateNodeOutputMLValue(const int output_index, int
 #else
                                                 : *shape;  // unreachable, but satisfies compiler
 #endif
-        bool reused_caller_buffer = false;
         LOGS_DEFAULT(VERBOSE) << "Output shape mismatch for pre-allocated fetch buffer.";
         auto& tensor = *p_ort_value->GetMutable<Tensor>();
         // Keep caller-provided buffers for dynamic outputs when only the runtime
@@ -210,7 +209,6 @@ Status IExecutionFrame::GetOrCreateNodeOutputMLValue(const int output_index, int
           LOGS_DEFAULT(VERBOSE) << "Reusing caller buffer by reshape. old_num_elements="
                                 << tensor.Shape().Size() << " new_num_elements=" << shape->Size();
           tensor.Reshape(*shape);
-          reused_caller_buffer = true;
         } else {
           return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
                                  "The output OrtValue provided for output '",

--- a/onnxruntime/core/framework/execution_frame.cc
+++ b/onnxruntime/core/framework/execution_frame.cc
@@ -17,6 +17,7 @@
 #include "core/framework/session_state.h"
 #include "core/framework/TensorSeq.h"
 #include "core/framework/utils.h"
+#include "core/common/logging/logging.h"
 #if !defined(ORT_MINIMAL_BUILD) && defined(ORT_MEMORY_PROFILE)
 #include "core/framework/memory_info.h"
 #endif
@@ -189,23 +190,29 @@ Status IExecutionFrame::GetOrCreateNodeOutputMLValue(const int output_index, int
       }
 
       if (!shape_matched) {
-        const TensorShape& existing_shape = p_ort_value->IsTensor()
-                                                ? p_ort_value->Get<Tensor>().Shape()
-#if !defined(DISABLE_SPARSE_TENSORS)
-                                                : p_ort_value->Get<SparseTensor>().DenseShape();
-#else
-                                                : *shape;  // unreachable, but satisfies compiler
-#endif
-        return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
-                               "The output OrtValue provided for output '",
-                               node.OutputDefs()[output_index]->Name(),
-                               "' of node '", node.Name(),
-                               "' (", node.OpType(), ") has shape ", existing_shape,
-                               " but the computed output shape for this run is ", *shape,
-                               ". When calling Run() with pre-allocated output OrtValues on a model "
-                               "with dynamic output shapes, either supply unallocated output OrtValues "
-                               "or ensure the pre-allocated shapes match the expected output shapes "
-                               "for each run.");
+        bool reused_caller_buffer = false;
+        LOGS_DEFAULT(VERBOSE) << "Output shape mismatch for pre-allocated fetch buffer.";
+        if (p_ort_value->IsTensor()) {
+          ORT_RETURN_IF_NOT(shape != nullptr, "shape must not be null for tensor output that is already allocated");
+          auto& tensor = *p_ort_value->GetMutable<Tensor>();
+          // Keep caller-provided buffers for dynamic outputs when only the runtime
+          // dimensions changed and the total element count is unchanged.
+          LOGS_DEFAULT(VERBOSE) << "Trying in-place reshape for caller-provided output buffer.";
+          if (tensor.Shape().Size() == shape->Size()) {
+            LOGS_DEFAULT(VERBOSE) << "Reusing caller buffer by reshape. old_num_elements="
+                                  << tensor.Shape().Size() << " new_num_elements=" << shape->Size();
+            tensor.Reshape(*shape);
+            reused_caller_buffer = true;
+          }
+        }
+
+        if (!reused_caller_buffer) {
+          // For dynamic outputs where the caller-provided buffer cannot represent
+          // the runtime shape, replace with a newly allocated OrtValue.
+          LOGS_DEFAULT(VERBOSE) << "Caller buffer cannot be reused; allocating fresh output OrtValue.";
+          *p_ort_value = OrtValue();
+          status = CreateNodeOutputMLValueImpl(*p_ort_value, ort_value_idx, shape);
+        }
       }
     } else {
       // shape is nullptr for traditional ML output values

--- a/onnxruntime/core/framework/execution_frame.cc
+++ b/onnxruntime/core/framework/execution_frame.cc
@@ -191,11 +191,11 @@ Status IExecutionFrame::GetOrCreateNodeOutputMLValue(const int output_index, int
 
       if (!shape_matched) {
           const TensorShape& existing_shape = p_ort_value->IsTensor()
-              ? p_ort_value->Get<Tensor>().Shape()
+                                                  ? p_ort_value->Get<Tensor>().Shape()
 #if !defined(DISABLE_SPARSE_TENSORS)
-              : p_ort_value->Get<SparseTensor>().DenseShape();
+                                                  : p_ort_value->Get<SparseTensor>().DenseShape();
 #else
-              : *shape;  // unreachable, but satisfies compiler
+                                                  : *shape;  // unreachable, but satisfies compiler
 #endif
           bool reused_caller_buffer = false;
           LOGS_DEFAULT(VERBOSE) << "Output shape mismatch for pre-allocated fetch buffer.";
@@ -214,15 +214,15 @@ Status IExecutionFrame::GetOrCreateNodeOutputMLValue(const int output_index, int
           }
           else {
               return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
-                  "The output OrtValue provided for output '",
-                  node.OutputDefs()[output_index]->Name(),
-                  "' of node '", node.Name(),
-                  "' (", node.OpType(), ") has shape ", existing_shape,
-                  " but the computed output shape for this run is ", *shape,
-                  ". When calling Run() with pre-allocated output OrtValues on a model "
-                  "with dynamic output shapes, either supply unallocated output OrtValues "
-                  "or ensure the pre-allocated shapes match the expected output shapes "
-                  "for each run.");
+                                    "The output OrtValue provided for output '",
+                                    node.OutputDefs()[output_index]->Name(),
+                                    "' of node '", node.Name(),
+                                    "' (", node.OpType(), ") has shape ", existing_shape,
+                                    " but the computed output shape for this run is ", *shape,
+                                    ". When calling Run() with pre-allocated output OrtValues on a model "
+                                    "with dynamic output shapes, either supply unallocated output OrtValues "
+                                    "or ensure the pre-allocated shapes match the expected output shapes "
+                                    "for each run.");
           }
       }
     } else {

--- a/onnxruntime/core/framework/execution_frame.cc
+++ b/onnxruntime/core/framework/execution_frame.cc
@@ -190,40 +190,39 @@ Status IExecutionFrame::GetOrCreateNodeOutputMLValue(const int output_index, int
       }
 
       if (!shape_matched) {
-          const TensorShape& existing_shape = p_ort_value->IsTensor()
-                                                  ? p_ort_value->Get<Tensor>().Shape()
+        const TensorShape& existing_shape = p_ort_value->IsTensor()
+                                                ? p_ort_value->Get<Tensor>().Shape()
 #if !defined(DISABLE_SPARSE_TENSORS)
-                                                  : p_ort_value->Get<SparseTensor>().DenseShape();
+                                                : p_ort_value->Get<SparseTensor>().DenseShape();
 #else
-                                                  : *shape;  // unreachable, but satisfies compiler
+                                                : *shape;  // unreachable, but satisfies compiler
 #endif
-          bool reused_caller_buffer = false;
-          LOGS_DEFAULT(VERBOSE) << "Output shape mismatch for pre-allocated fetch buffer.";
-          auto& tensor = *p_ort_value->GetMutable<Tensor>();
-          // Keep caller-provided buffers for dynamic outputs when only the runtime
-          // dimensions changed and the total element count is unchanged.
-          LOGS_DEFAULT(VERBOSE) << "Trying in-place reshape for caller-provided output buffer.";
-          const bool old_shape_is_singleton_vector = shape->NumDimensions() == 1 && shape->AsShapeVector()[0] == 1;  // {1}
-          const bool new_shape_is_scalar = tensor.Shape().NumDimensions() == 0; // {}
-          const bool can_reshape_in_place = (old_shape_is_singleton_vector && new_shape_is_scalar);
-          if (can_reshape_in_place) {
-              LOGS_DEFAULT(VERBOSE) << "Reusing caller buffer by reshape. old_num_elements="
-                  << tensor.Shape().Size() << " new_num_elements=" << shape->Size();
-              tensor.Reshape(*shape);
-              reused_caller_buffer = true;
-          }
-          else {
-              return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
-                                    "The output OrtValue provided for output '",
-                                    node.OutputDefs()[output_index]->Name(),
-                                    "' of node '", node.Name(),
-                                    "' (", node.OpType(), ") has shape ", existing_shape,
-                                    " but the computed output shape for this run is ", *shape,
-                                    ". When calling Run() with pre-allocated output OrtValues on a model "
-                                    "with dynamic output shapes, either supply unallocated output OrtValues "
-                                    "or ensure the pre-allocated shapes match the expected output shapes "
-                                    "for each run.");
-          }
+        bool reused_caller_buffer = false;
+        LOGS_DEFAULT(VERBOSE) << "Output shape mismatch for pre-allocated fetch buffer.";
+        auto& tensor = *p_ort_value->GetMutable<Tensor>();
+        // Keep caller-provided buffers for dynamic outputs when only the runtime
+        // dimensions changed and the total element count is unchanged.
+        LOGS_DEFAULT(VERBOSE) << "Trying in-place reshape for caller-provided output buffer.";
+        const bool old_shape_is_singleton_vector = shape->NumDimensions() == 1 && shape->AsShapeVector()[0] == 1;  // {1}
+        const bool new_shape_is_scalar = tensor.Shape().NumDimensions() == 0;                                      // {}
+        const bool can_reshape_in_place = (old_shape_is_singleton_vector && new_shape_is_scalar);
+        if (can_reshape_in_place) {
+          LOGS_DEFAULT(VERBOSE) << "Reusing caller buffer by reshape. old_num_elements="
+                                << tensor.Shape().Size() << " new_num_elements=" << shape->Size();
+          tensor.Reshape(*shape);
+          reused_caller_buffer = true;
+        } else {
+          return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                                 "The output OrtValue provided for output '",
+                                 node.OutputDefs()[output_index]->Name(),
+                                 "' of node '", node.Name(),
+                                 "' (", node.OpType(), ") has shape ", existing_shape,
+                                 " but the computed output shape for this run is ", *shape,
+                                 ". When calling Run() with pre-allocated output OrtValues on a model "
+                                 "with dynamic output shapes, either supply unallocated output OrtValues "
+                                 "or ensure the pre-allocated shapes match the expected output shapes "
+                                 "for each run.");
+        }
       }
     } else {
       // shape is nullptr for traditional ML output values

--- a/onnxruntime/core/framework/execution_frame.cc
+++ b/onnxruntime/core/framework/execution_frame.cc
@@ -190,29 +190,42 @@ Status IExecutionFrame::GetOrCreateNodeOutputMLValue(const int output_index, int
       }
 
       if (!shape_matched) {
-        bool reused_caller_buffer = false;
-        LOGS_DEFAULT(VERBOSE) << "Output shape mismatch for pre-allocated fetch buffer.";
-        if (p_ort_value->IsTensor()) {
-          ORT_RETURN_IF_NOT(shape != nullptr, "shape must not be null for tensor output that is already allocated");
+          const TensorShape& existing_shape = p_ort_value->IsTensor()
+              ? p_ort_value->Get<Tensor>().Shape()
+#if !defined(DISABLE_SPARSE_TENSORS)
+              : p_ort_value->Get<SparseTensor>().DenseShape();
+#else
+              : *shape;  // unreachable, but satisfies compiler
+#endif
+          bool reused_caller_buffer = false;
+          LOGS_DEFAULT(VERBOSE) << "Output shape mismatch for pre-allocated fetch buffer.";
+          std::cout << "Output shape mismatch for pre-allocated fetch buffer." << std::endl;
+
           auto& tensor = *p_ort_value->GetMutable<Tensor>();
           // Keep caller-provided buffers for dynamic outputs when only the runtime
           // dimensions changed and the total element count is unchanged.
           LOGS_DEFAULT(VERBOSE) << "Trying in-place reshape for caller-provided output buffer.";
-          if (tensor.Shape().Size() == shape->Size()) {
-            LOGS_DEFAULT(VERBOSE) << "Reusing caller buffer by reshape. old_num_elements="
-                                  << tensor.Shape().Size() << " new_num_elements=" << shape->Size();
-            tensor.Reshape(*shape);
-            reused_caller_buffer = true;
+          const bool old_shape_is_singleton_vector = shape->NumDimensions() == 1 && shape->AsShapeVector()[0] == 1;  // {1}
+          const bool new_shape_is_scalar = tensor.Shape().NumDimensions() == 0; // {}
+          const bool can_reshape_in_place = (old_shape_is_singleton_vector && new_shape_is_scalar);
+          if (can_reshape_in_place) {
+              LOGS_DEFAULT(VERBOSE) << "Reusing caller buffer by reshape. old_num_elements="
+                  << tensor.Shape().Size() << " new_num_elements=" << shape->Size();
+              tensor.Reshape(*shape);
+              reused_caller_buffer = true;
           }
-        }
-
-        if (!reused_caller_buffer) {
-          // For dynamic outputs where the caller-provided buffer cannot represent
-          // the runtime shape, replace with a newly allocated OrtValue.
-          LOGS_DEFAULT(VERBOSE) << "Caller buffer cannot be reused; allocating fresh output OrtValue.";
-          *p_ort_value = OrtValue();
-          status = CreateNodeOutputMLValueImpl(*p_ort_value, ort_value_idx, shape);
-        }
+          else {
+              return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                  "The output OrtValue provided for output '",
+                  node.OutputDefs()[output_index]->Name(),
+                  "' of node '", node.Name(),
+                  "' (", node.OpType(), ") has shape ", existing_shape,
+                  " but the computed output shape for this run is ", *shape,
+                  ". When calling Run() with pre-allocated output OrtValues on a model "
+                  "with dynamic output shapes, either supply unallocated output OrtValues "
+                  "or ensure the pre-allocated shapes match the expected output shapes "
+                  "for each run.");
+          }
       }
     } else {
       // shape is nullptr for traditional ML output values

--- a/onnxruntime/core/framework/execution_frame.cc
+++ b/onnxruntime/core/framework/execution_frame.cc
@@ -199,8 +199,6 @@ Status IExecutionFrame::GetOrCreateNodeOutputMLValue(const int output_index, int
 #endif
           bool reused_caller_buffer = false;
           LOGS_DEFAULT(VERBOSE) << "Output shape mismatch for pre-allocated fetch buffer.";
-          std::cout << "Output shape mismatch for pre-allocated fetch buffer." << std::endl;
-
           auto& tensor = *p_ort_value->GetMutable<Tensor>();
           // Keep caller-provided buffers for dynamic outputs when only the runtime
           // dimensions changed and the total element count is unchanged.

--- a/onnxruntime/core/framework/execution_frame.cc
+++ b/onnxruntime/core/framework/execution_frame.cc
@@ -185,7 +185,6 @@ Status IExecutionFrame::GetOrCreateNodeOutputMLValue(const int output_index, int
         LOGS_DEFAULT(INFO) << "existing_shape: " << existing_shape.ToString() << ", computed_shape: " << (shape ? shape->ToString() : "<null>");
         ORT_RETURN_IF_NOT(shape != nullptr, "shape must not be null for tensor output that is already allocated");
         const Tensor& tensor = p_ort_value->Get<Tensor>();
-        shape_matched = (tensor.Shape() == *shape);
         LOGS_DEFAULT(INFO) << "existing_shape size: " << existing_shape.Size() << ", computed_shape size: " << shape->Size() << std::endl;
         // Compare number of elements
         if (existing_shape.Size() == shape->Size()) {

--- a/onnxruntime/core/framework/execution_frame.cc
+++ b/onnxruntime/core/framework/execution_frame.cc
@@ -177,14 +177,13 @@ Status IExecutionFrame::GetOrCreateNodeOutputMLValue(const int output_index, int
       bool shape_matched = true;
 
       if (p_ort_value->IsTensor()) {
-        const TensorShape& existing_shape = p_ort_value->IsTensor()
-                                                ? p_ort_value->Get<Tensor>().Shape()
-#if !defined(DISABLE_SPARSE_TENSORS)
-                                                : p_ort_value->Get<SparseTensor>().DenseShape();
-#endif
-        LOGS_DEFAULT(INFO) << "existing_shape: " << existing_shape.ToString() << ", computed_shape: " << (shape ? shape->ToString() : "<null>");
+      
         ORT_RETURN_IF_NOT(shape != nullptr, "shape must not be null for tensor output that is already allocated");
         const Tensor& tensor = p_ort_value->Get<Tensor>();
+        const TensorShape& existing_shape = tensor.Shape();
+
+        LOGS_DEFAULT(INFO) << "existing_shape: " << existing_shape.ToString() << ", computed_shape: " << (shape ? shape->ToString() : "<null>");
+        ORT_RETURN_IF_NOT(shape != nullptr, "shape must not be null for tensor output that is already allocated");
         LOGS_DEFAULT(INFO) << "existing_shape size: " << existing_shape.Size() << ", computed_shape size: " << shape->Size() << std::endl;
         // Compare number of elements
         if (existing_shape.Size() == shape->Size()) {

--- a/onnxruntime/core/framework/execution_frame.cc
+++ b/onnxruntime/core/framework/execution_frame.cc
@@ -17,7 +17,6 @@
 #include "core/framework/session_state.h"
 #include "core/framework/TensorSeq.h"
 #include "core/framework/utils.h"
-#include "core/common/logging/logging.h"
 #if !defined(ORT_MINIMAL_BUILD) && defined(ORT_MEMORY_PROFILE)
 #include "core/framework/memory_info.h"
 #endif
@@ -178,9 +177,24 @@ Status IExecutionFrame::GetOrCreateNodeOutputMLValue(const int output_index, int
       bool shape_matched = true;
 
       if (p_ort_value->IsTensor()) {
+        const TensorShape& existing_shape = p_ort_value->IsTensor()
+                                                ? p_ort_value->Get<Tensor>().Shape()
+#if !defined(DISABLE_SPARSE_TENSORS)
+                                                : p_ort_value->Get<SparseTensor>().DenseShape();
+#endif
+        LOGS_DEFAULT(INFO) << "existing_shape: " << existing_shape.ToString() << ", computed_shape: " << (shape ? shape->ToString() : "<null>");
         ORT_RETURN_IF_NOT(shape != nullptr, "shape must not be null for tensor output that is already allocated");
         const Tensor& tensor = p_ort_value->Get<Tensor>();
         shape_matched = (tensor.Shape() == *shape);
+        LOGS_DEFAULT(INFO) << "existing_shape size: " << existing_shape.Size() << ", computed_shape size: " << shape->Size() << std::endl;
+        // Compare number of elements
+        if (existing_shape.Size() == shape->Size()) {
+          // Reuse buffer, update shape in-place
+          const_cast<Tensor&>(tensor).Reshape(*shape);
+          shape_matched = true;
+        } else {
+          shape_matched = false;
+        }
       } else if (p_ort_value->IsSparseTensor()) {
 #if !defined(DISABLE_SPARSE_TENSORS)
         ORT_RETURN_IF_NOT(shape != nullptr, "shape must not be null for sparse tensor output that is already allocated");
@@ -197,30 +211,16 @@ Status IExecutionFrame::GetOrCreateNodeOutputMLValue(const int output_index, int
 #else
                                                 : *shape;  // unreachable, but satisfies compiler
 #endif
-        LOGS_DEFAULT(VERBOSE) << "Output shape mismatch for pre-allocated fetch buffer.";
-        auto& tensor = *p_ort_value->GetMutable<Tensor>();
-        // Keep caller-provided buffers for dynamic outputs when only the runtime
-        // dimensions changed and the total element count is unchanged.
-        LOGS_DEFAULT(VERBOSE) << "Trying in-place reshape for caller-provided output buffer.";
-        const bool old_shape_is_singleton_vector = shape->NumDimensions() == 1 && shape->AsShapeVector()[0] == 1;  // {1}
-        const bool new_shape_is_scalar = tensor.Shape().NumDimensions() == 0;                                      // {}
-        const bool can_reshape_in_place = (old_shape_is_singleton_vector && new_shape_is_scalar);
-        if (can_reshape_in_place) {
-          LOGS_DEFAULT(VERBOSE) << "Reusing caller buffer by reshape. old_num_elements="
-                                << tensor.Shape().Size() << " new_num_elements=" << shape->Size();
-          tensor.Reshape(*shape);
-        } else {
-          return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
-                                 "The output OrtValue provided for output '",
-                                 node.OutputDefs()[output_index]->Name(),
-                                 "' of node '", node.Name(),
-                                 "' (", node.OpType(), ") has shape ", existing_shape,
-                                 " but the computed output shape for this run is ", *shape,
-                                 ". When calling Run() with pre-allocated output OrtValues on a model "
-                                 "with dynamic output shapes, either supply unallocated output OrtValues "
-                                 "or ensure the pre-allocated shapes match the expected output shapes "
-                                 "for each run.");
-        }
+        return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                               "The output OrtValue provided for output '",
+                               node.OutputDefs()[output_index]->Name(),
+                               "' of node '", node.Name(),
+                               "' (", node.OpType(), ") has shape ", existing_shape,
+                               " but the computed output shape for this run is ", *shape,
+                               ". When calling Run() with pre-allocated output OrtValues on a model "
+                               "with dynamic output shapes, either supply unallocated output OrtValues "
+                               "or ensure the pre-allocated shapes match the expected output shapes "
+                               "for each run.");
       }
     } else {
       // shape is nullptr for traditional ML output values

--- a/onnxruntime/core/framework/execution_frame.cc
+++ b/onnxruntime/core/framework/execution_frame.cc
@@ -177,11 +177,9 @@ Status IExecutionFrame::GetOrCreateNodeOutputMLValue(const int output_index, int
       bool shape_matched = true;
 
       if (p_ort_value->IsTensor()) {
-      
         ORT_RETURN_IF_NOT(shape != nullptr, "shape must not be null for tensor output that is already allocated");
         const Tensor& tensor = p_ort_value->Get<Tensor>();
         const TensorShape& existing_shape = tensor.Shape();
-
         LOGS_DEFAULT(INFO) << "existing_shape: " << existing_shape.ToString() << ", computed_shape: " << (shape ? shape->ToString() : "<null>");
         ORT_RETURN_IF_NOT(shape != nullptr, "shape must not be null for tensor output that is already allocated");
         LOGS_DEFAULT(INFO) << "existing_shape size: " << existing_shape.Size() << ", computed_shape size: " << shape->Size() << std::endl;

--- a/onnxruntime/core/framework/execution_frame.cc
+++ b/onnxruntime/core/framework/execution_frame.cc
@@ -180,11 +180,10 @@ Status IExecutionFrame::GetOrCreateNodeOutputMLValue(const int output_index, int
         ORT_RETURN_IF_NOT(shape != nullptr, "shape must not be null for tensor output that is already allocated");
         const Tensor& tensor = p_ort_value->Get<Tensor>();
         const TensorShape& existing_shape = tensor.Shape();
-        LOGS_DEFAULT(INFO) << "existing_shape: " << existing_shape.ToString() << ", computed_shape: " << (shape ? shape->ToString() : "<null>");
-        ORT_RETURN_IF_NOT(shape != nullptr, "shape must not be null for tensor output that is already allocated");
-        LOGS_DEFAULT(INFO) << "existing_shape size: " << existing_shape.Size() << ", computed_shape size: " << shape->Size() << std::endl;
         // Compare number of elements
-        if (existing_shape.Size() == shape->Size()) {
+        if (existing_shape == *shape) {
+          shape_matched = true;
+        } else if (existing_shape.Size() == shape->Size()) {
           // Reuse buffer, update shape in-place
           const_cast<Tensor&>(tensor).Reshape(*shape);
           shape_matched = true;

--- a/onnxruntime/test/framework/execution_frame_test.cc
+++ b/onnxruntime/test/framework/execution_frame_test.cc
@@ -743,5 +743,56 @@ TEST(ExecutionFrameTestInit, SparseInitializerAsOutput) {
 }
 #endif  // !defined(DISABLE_SPARSE_TENSORS)
 
+TEST(ExecutionFrameTestInit, FetchReusesPreallocatedScalarOutputForSingleElementVector) {
+    SessionOptions so;
+    so.enable_mem_pattern = true;
+
+    InferenceSession session(so, GetEnvironment());
+
+    onnxruntime::Model model("scalar_to_vector1_output_test", false, ModelMetaData(), PathString(),
+        IOnnxRuntimeOpSchemaRegistryList(),
+        { {kOnnxDomain, 12} }, {}, DefaultLoggingManager().DefaultLogger());
+    auto& graph = model.MainGraph();
+
+    TypeProto float_tensor;
+    float_tensor.mutable_tensor_type()->set_elem_type(TensorProto_DataType_FLOAT);
+
+    auto& input_arg = graph.GetOrCreateNodeArg("X", &float_tensor);
+    auto& output_arg = graph.GetOrCreateNodeArg("Y", &float_tensor);
+    graph.AddNode("identity", "Identity", "identity", { &input_arg }, { &output_arg });
+    graph.SetInputs({ &input_arg });
+    graph.SetOutputs({ &output_arg });
+    ASSERT_STATUS_OK(graph.Resolve());
+
+    std::string serialized;
+    ASSERT_TRUE(model.ToProto().SerializeToString(&serialized));
+    std::istringstream model_stream(serialized);
+    ASSERT_STATUS_OK(session.Load(model_stream));
+    ASSERT_STATUS_OK(session.Initialize());
+
+    auto allocator = test::AllocatorManager::Instance().GetAllocator(CPU);
+
+    std::array<float, 1> input_data = { 5.0f };
+    OrtValue input;
+    Tensor::InitOrtValue(DataTypeImpl::GetType<float>(), TensorShape({ 1 }), input_data.data(), allocator->Info(), input);
+
+    // Pre-allocate scalar output ({}). Runtime output for this run is {1}.
+    OrtValue preallocated_output;
+    Tensor::InitOrtValue(DataTypeImpl::GetType<float>(), TensorShape({}), allocator, preallocated_output);
+    const void* preallocated_buffer = preallocated_output.Get<Tensor>().DataRaw();
+    std::vector<OrtValue> results = { preallocated_output };
+
+    RunOptions ro;
+    ASSERT_STATUS_OK(session.Run(ro,
+        AsSpan({ std::string("X") }), AsSpan({ input }),
+        AsSpan({ std::string("Y") }), &results, nullptr));
+
+    ASSERT_EQ(results.size(), 1u);
+    ASSERT_TRUE(results[0].IsTensor());
+    EXPECT_EQ(results[0].Get<Tensor>().Shape(), TensorShape({ 1 }));
+    EXPECT_EQ(results[0].Get<Tensor>().DataRaw(), preallocated_buffer);
+    EXPECT_EQ(results[0].Get<Tensor>().DataAsSpan<float>()[0], 5.0f);
+}
+
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/framework/execution_frame_test.cc
+++ b/onnxruntime/test/framework/execution_frame_test.cc
@@ -751,7 +751,7 @@ TEST(ExecutionFrameTestInit, FetchReusesPreallocatedScalarOutputForSingleElement
 
     onnxruntime::Model model("scalar_to_vector1_output_test", false, ModelMetaData(), PathString(),
         IOnnxRuntimeOpSchemaRegistryList(),
-        { {kOnnxDomain, 12} }, {}, DefaultLoggingManager().DefaultLogger());
+        {{kOnnxDomain, 12}}, {}, DefaultLoggingManager().DefaultLogger());
     auto& graph = model.MainGraph();
 
     TypeProto float_tensor;
@@ -759,9 +759,9 @@ TEST(ExecutionFrameTestInit, FetchReusesPreallocatedScalarOutputForSingleElement
 
     auto& input_arg = graph.GetOrCreateNodeArg("X", &float_tensor);
     auto& output_arg = graph.GetOrCreateNodeArg("Y", &float_tensor);
-    graph.AddNode("identity", "Identity", "identity", { &input_arg }, { &output_arg });
-    graph.SetInputs({ &input_arg });
-    graph.SetOutputs({ &output_arg });
+    graph.AddNode("identity", "Identity", "identity", {&input_arg}, {&output_arg});
+    graph.SetInputs({&input_arg});
+    graph.SetOutputs({&output_arg});
     ASSERT_STATUS_OK(graph.Resolve());
 
     std::string serialized;
@@ -772,9 +772,9 @@ TEST(ExecutionFrameTestInit, FetchReusesPreallocatedScalarOutputForSingleElement
 
     auto allocator = test::AllocatorManager::Instance().GetAllocator(CPU);
 
-    std::array<float, 1> input_data = { 5.0f };
+    std::array<float, 1> input_data = {5.0f};
     OrtValue input;
-    Tensor::InitOrtValue(DataTypeImpl::GetType<float>(), TensorShape({ 1 }), input_data.data(), allocator->Info(), input);
+    Tensor::InitOrtValue(DataTypeImpl::GetType<float>(), TensorShape({1}), input_data.data(), allocator->Info(), input);
 
     // Pre-allocate scalar output ({}). Runtime output for this run is {1}.
     OrtValue preallocated_output;
@@ -784,12 +784,12 @@ TEST(ExecutionFrameTestInit, FetchReusesPreallocatedScalarOutputForSingleElement
 
     RunOptions ro;
     ASSERT_STATUS_OK(session.Run(ro,
-        AsSpan({ std::string("X") }), AsSpan({ input }),
-        AsSpan({ std::string("Y") }), &results, nullptr));
+                                    AsSpan({std::string("X")}), AsSpan({input}),
+                                    AsSpan({std::string("Y")}), &results, nullptr));
 
     ASSERT_EQ(results.size(), 1u);
     ASSERT_TRUE(results[0].IsTensor());
-    EXPECT_EQ(results[0].Get<Tensor>().Shape(), TensorShape({ 1 }));
+    EXPECT_EQ(results[0].Get<Tensor>().Shape(), TensorShape({1}));
     EXPECT_EQ(results[0].Get<Tensor>().DataRaw(), preallocated_buffer);
     EXPECT_EQ(results[0].Get<Tensor>().DataAsSpan<float>()[0], 5.0f);
 }

--- a/onnxruntime/test/framework/execution_frame_test.cc
+++ b/onnxruntime/test/framework/execution_frame_test.cc
@@ -744,54 +744,54 @@ TEST(ExecutionFrameTestInit, SparseInitializerAsOutput) {
 #endif  // !defined(DISABLE_SPARSE_TENSORS)
 
 TEST(ExecutionFrameTestInit, FetchReusesPreallocatedScalarOutputForSingleElementVector) {
-    SessionOptions so;
-    so.enable_mem_pattern = true;
+  SessionOptions so;
+  so.enable_mem_pattern = true;
 
-    InferenceSession session(so, GetEnvironment());
+  InferenceSession session(so, GetEnvironment());
 
-    onnxruntime::Model model("scalar_to_vector1_output_test", false, ModelMetaData(), PathString(),
-        IOnnxRuntimeOpSchemaRegistryList(),
-        {{kOnnxDomain, 12}}, {}, DefaultLoggingManager().DefaultLogger());
-    auto& graph = model.MainGraph();
+  onnxruntime::Model model("scalar_to_vector1_output_test", false, ModelMetaData(), PathString(),
+                           IOnnxRuntimeOpSchemaRegistryList(),
+                           {{kOnnxDomain, 12}}, {}, DefaultLoggingManager().DefaultLogger());
+  auto& graph = model.MainGraph();
 
-    TypeProto float_tensor;
-    float_tensor.mutable_tensor_type()->set_elem_type(TensorProto_DataType_FLOAT);
+  TypeProto float_tensor;
+  float_tensor.mutable_tensor_type()->set_elem_type(TensorProto_DataType_FLOAT);
 
-    auto& input_arg = graph.GetOrCreateNodeArg("X", &float_tensor);
-    auto& output_arg = graph.GetOrCreateNodeArg("Y", &float_tensor);
-    graph.AddNode("identity", "Identity", "identity", {&input_arg}, {&output_arg});
-    graph.SetInputs({&input_arg});
-    graph.SetOutputs({&output_arg});
-    ASSERT_STATUS_OK(graph.Resolve());
+  auto& input_arg = graph.GetOrCreateNodeArg("X", &float_tensor);
+  auto& output_arg = graph.GetOrCreateNodeArg("Y", &float_tensor);
+  graph.AddNode("identity", "Identity", "identity", {&input_arg}, {&output_arg});
+  graph.SetInputs({&input_arg});
+  graph.SetOutputs({&output_arg});
+  ASSERT_STATUS_OK(graph.Resolve());
 
-    std::string serialized;
-    ASSERT_TRUE(model.ToProto().SerializeToString(&serialized));
-    std::istringstream model_stream(serialized);
-    ASSERT_STATUS_OK(session.Load(model_stream));
-    ASSERT_STATUS_OK(session.Initialize());
+  std::string serialized;
+  ASSERT_TRUE(model.ToProto().SerializeToString(&serialized));
+  std::istringstream model_stream(serialized);
+  ASSERT_STATUS_OK(session.Load(model_stream));
+  ASSERT_STATUS_OK(session.Initialize());
 
-    auto allocator = test::AllocatorManager::Instance().GetAllocator(CPU);
+  auto allocator = test::AllocatorManager::Instance().GetAllocator(CPU);
 
-    std::array<float, 1> input_data = {5.0f};
-    OrtValue input;
-    Tensor::InitOrtValue(DataTypeImpl::GetType<float>(), TensorShape({1}), input_data.data(), allocator->Info(), input);
+  std::array<float, 1> input_data = {5.0f};
+  OrtValue input;
+  Tensor::InitOrtValue(DataTypeImpl::GetType<float>(), TensorShape({1}), input_data.data(), allocator->Info(), input);
 
-    // Pre-allocate scalar output ({}). Runtime output for this run is {1}.
-    OrtValue preallocated_output;
-    Tensor::InitOrtValue(DataTypeImpl::GetType<float>(), TensorShape({}), allocator, preallocated_output);
-    const void* preallocated_buffer = preallocated_output.Get<Tensor>().DataRaw();
-    std::vector<OrtValue> results = { preallocated_output };
+  // Pre-allocate scalar output ({}). Runtime output for this run is {1}.
+  OrtValue preallocated_output;
+  Tensor::InitOrtValue(DataTypeImpl::GetType<float>(), TensorShape({}), allocator, preallocated_output);
+  const void* preallocated_buffer = preallocated_output.Get<Tensor>().DataRaw();
+  std::vector<OrtValue> results = {preallocated_output};
 
-    RunOptions ro;
-    ASSERT_STATUS_OK(session.Run(ro,
-                                    AsSpan({std::string("X")}), AsSpan({input}),
-                                    AsSpan({std::string("Y")}), &results, nullptr));
+  RunOptions ro;
+  ASSERT_STATUS_OK(session.Run(ro,
+                               AsSpan({std::string("X")}), AsSpan({input}),
+                               AsSpan({std::string("Y")}), &results, nullptr));
 
-    ASSERT_EQ(results.size(), 1u);
-    ASSERT_TRUE(results[0].IsTensor());
-    EXPECT_EQ(results[0].Get<Tensor>().Shape(), TensorShape({1}));
-    EXPECT_EQ(results[0].Get<Tensor>().DataRaw(), preallocated_buffer);
-    EXPECT_EQ(results[0].Get<Tensor>().DataAsSpan<float>()[0], 5.0f);
+  ASSERT_EQ(results.size(), 1u);
+  ASSERT_TRUE(results[0].IsTensor());
+  EXPECT_EQ(results[0].Get<Tensor>().Shape(), TensorShape({1}));
+  EXPECT_EQ(results[0].Get<Tensor>().DataRaw(), preallocated_buffer);
+  EXPECT_EQ(results[0].Get<Tensor>().DataAsSpan<float>()[0], 5.0f);
 }
 
 }  // namespace test


### PR DESCRIPTION
### Description
There are some webNN applications/test cases like below which failed due to mismatch shape {1} vs {}
**softsign positive float32 0D tensor**
The change I made is to reuse the buffer by reshaping the buffer if the existing shape number of elements are matching with shape number of elements. Working example is {4,5} vs {2,10} while {4,5} vs {2,3} should not work.

The change also works for the case where we have {1} vs {} --> current_shape {1} vs requested shape {}








