### PR TITLE
Widen the fp16 direct C output to 2 and 8 bit MatMulNBits CompInt8

### DIFF
--- a/onnxruntime/core/mlas/lib/qnbitgemm.cpp
+++ b/onnxruntime/core/mlas/lib/qnbitgemm.cpp
@@ -188,11 +188,11 @@ MlasQNBitGemmFp16DirectQuantASupported()
 bool MLASCALL
 MlasQNBitGemmFp16DirectCOutputSupported(size_t BlkBitWidth)
 {
-    // Wired for the 4-bit CompInt8 compute op on x64 (where the fp16 A quantizer is also
-    // present). The C epilogue itself is portable, so this widens as other bit widths
-    // gain the branch.
+    // Wired for the 2, 4 and 8 bit CompInt8 compute ops on x64, where the fp16 A quantizer
+    // is also present.
     const auto* Dispatch = GetMlasPlatform().QNBitGemmDispatch;
-    return BlkBitWidth == 4 && Dispatch != nullptr && Dispatch->QuantizeARowComputeBlkSum_CompInt8_Fp16 != nullptr;
+    const bool supported_bit_width = BlkBitWidth == 2 || BlkBitWidth == 4 || BlkBitWidth == 8;
+    return supported_bit_width && Dispatch != nullptr && Dispatch->QuantizeARowComputeBlkSum_CompInt8_Fp16 != nullptr;
 }
 
 namespace
@@ -777,6 +777,43 @@ HQ8BitGemm_CompFp16(
     }
 }
 
+// fp32 scratch for the fp16 output path below. One buffer per thread, shared by every bit
+// width, grown to the largest strip that thread has computed. Only threads that take the
+// fp16 path ever allocate.
+float*
+GetCompInt8Fp16Scratch(size_t Elements)
+{
+    static thread_local std::vector<float> c_scratch;
+    if (c_scratch.size() < Elements) {
+        c_scratch.resize(Elements);
+    }
+    return c_scratch.data();
+}
+
+// Runs one int8 GEMM kernel call into that scratch and converts the strip to fp16, so the
+// full fp32 result never lands in a caller buffer. RunKernel is handed the scratch and its
+// leading dimension and must call the kernel once over the whole M range, exactly as the
+// fp32 branch does, which is what keeps the converted values bitwise identical to the fp32
+// path. CFp16Strip points at the first element of the strip.
+template <typename KernelFn>
+void
+CompInt8StripToFp16(
+    KernelFn&& RunKernel,
+    MLAS_FP16* CFp16Strip,
+    size_t RangeCountM,
+    size_t CountN,
+    size_t ldc
+)
+{
+    float* scratch = GetCompInt8Fp16Scratch(RangeCountM * CountN);
+
+    RunKernel(scratch, CountN);
+
+    for (size_t m = 0; m < RangeCountM; ++m) {
+        MlasConvertFloatToHalfBuffer(scratch + m * CountN, CFp16Strip + m * ldc, CountN);
+    }
+}
+
 void
 SQ4BitGemm_CompInt8(
     const size_t BlkLen,
@@ -861,7 +898,6 @@ SQ4BitGemm_CompInt8(
     // In this mode DataParams->C is not a full result buffer, so leave the fp32 C base null.
     const bool to_fp16 = DataParams->CFp16 != nullptr;
     MLAS_FP16* CFp16 = to_fp16 ? DataParams->CFp16 + RangeStartM * ldc + RangeStartN : nullptr;
-    static thread_local std::vector<float> c_scratch;
     float* C = to_fp16 ? nullptr : DataParams->C + RangeStartM * ldc + RangeStartN;
 
     const float* Bias = (DataParams->Bias == nullptr) ? nullptr : DataParams->Bias + RangeStartN;
@@ -927,37 +963,32 @@ SQ4BitGemm_CompInt8(
         {
             const float* b_blk_sum = QuantBBlkSum + n * k_blks;
             if (to_fp16) {
-                // fp16 output: run the int8 kernel over the whole M range into the fp32 scratch
-                // exactly as the fp32 branch below would (same single call, so the scratch holds
-                // values bitwise-identical to the fp32 path), then convert the strip to fp16. The
-                // single-threaded path passes the whole M here, so size the scratch to it rather
-                // than to a fixed tile. fp16 output and a post-processor are never set together by
-                // the operator, so the fp32-branch post-processing does not apply here; assert
-                // rather than silently drop it.
+                // fp16 output and a post-processor are never set together by the operator, so the
+                // fp32-branch post-processing does not apply here; assert rather than silently
+                // drop it.
                 assert(DataParams->PostProcessor == nullptr);
-                if (c_scratch.size() < RangeCountM * CountN) {
-                    c_scratch.resize(RangeCountM * CountN);
-                }
-                GetMlasPlatform().QNBitGemmDispatch->SQ4BitGemmKernel_BlkSum_CompInt8(
-                    BlkLen,
-                    QuantA,
-                    QuantAScale,
-                    b_col,
-                    b_col_scale,
-                    b_col_zp,
-                    c_scratch.data(),
-                    RangeCountM,
-                    CountN,
-                    K,
-                    k_blks,
-                    bias,
-                    CountN,
-                    ABlockSum,
-                    b_blk_sum
+                CompInt8StripToFp16(
+                    [&](float* c_out, size_t c_out_ldc) {
+                        GetMlasPlatform().QNBitGemmDispatch->SQ4BitGemmKernel_BlkSum_CompInt8(
+                            BlkLen,
+                            QuantA,
+                            QuantAScale,
+                            b_col,
+                            b_col_scale,
+                            b_col_zp,
+                            c_out,
+                            RangeCountM,
+                            CountN,
+                            K,
+                            k_blks,
+                            bias,
+                            c_out_ldc,
+                            ABlockSum,
+                            b_blk_sum
+                        );
+                    },
+                    CFp16 + n, RangeCountM, CountN, ldc
                 );
-                for (size_t m = 0; m < RangeCountM; ++m) {
-                    MlasConvertFloatToHalfBuffer(c_scratch.data() + m * CountN, CFp16 + n + m * ldc, CountN);
-                }
             } else {
                 GetMlasPlatform().QNBitGemmDispatch->SQ4BitGemmKernel_BlkSum_CompInt8(
                     BlkLen,
@@ -1027,7 +1058,10 @@ SQ8BitGemm_CompInt8(
     const float* QuantBBlkSum = DataParams->QuantBBlkSum + RangeStartN * k_blks;
     const float* BlkUnsignedQuantAZeroPointCorrection =
         DataParams->BlkUnsignedQuantAZeroPointCorrection ? DataParams->BlkUnsignedQuantAZeroPointCorrection + RangeStartN * k_blks : nullptr;
-    float* C = DataParams->C + RangeStartM * ldc + RangeStartN;
+
+    const bool to_fp16 = DataParams->CFp16 != nullptr;
+    MLAS_FP16* CFp16 = to_fp16 ? DataParams->CFp16 + RangeStartM * ldc + RangeStartN : nullptr;
+    float* C = to_fp16 ? nullptr : DataParams->C + RangeStartM * ldc + RangeStartN;
 
     const float* Bias = (DataParams->Bias == nullptr) ? nullptr : DataParams->Bias + RangeStartN;
 
@@ -1039,37 +1073,64 @@ SQ8BitGemm_CompInt8(
         const float* b_col_scale = QuantBScale + n * k_blks;
         const std::byte* b_col_zp =
             (QuantBZeroPoint == nullptr) ? nullptr : QuantBZeroPoint + n * k_blks_zp_bytes;
-        float* c_blk = C + n;
+        float* c_blk = (C == nullptr) ? nullptr : C + n;
         const float* bias = (Bias == nullptr) ? nullptr : Bias + n;
 
         if (GetMlasPlatform().QNBitGemmDispatch->SQ8BitGemmKernel_BlkSum_CompInt8 != nullptr) {
             const float* b_blk_sum = QuantBBlkSum + n * k_blks;
             const float* blk_unsigned_quant_A_zp_correction = BlkUnsignedQuantAZeroPointCorrection ?
                 BlkUnsignedQuantAZeroPointCorrection + n * k_blks : nullptr;
-            GetMlasPlatform().QNBitGemmDispatch->SQ8BitGemmKernel_BlkSum_CompInt8(
-                BlkLen,
-                QuantA,
-                QuantAScale,
-                b_col,
-                b_col_scale,
-                b_col_zp,
-                c_blk,
-                RangeCountM,
-                CountN,
-                K,
-                k_blks,
-                bias,
-                ldc,
-                ABlockSum,
-                b_blk_sum,
-                blk_unsigned_quant_A_zp_correction
-            );
-
-            if (DataParams->PostProcessor != nullptr) {
-                DataParams->PostProcessor->Process(
-                    DataParams->C, RangeStartM, RangeStartN + n,
-                    RangeCountM, CountN, ldc
+            if (to_fp16) {
+                assert(DataParams->PostProcessor == nullptr);
+                CompInt8StripToFp16(
+                    [&](float* c_out, size_t c_out_ldc) {
+                        GetMlasPlatform().QNBitGemmDispatch->SQ8BitGemmKernel_BlkSum_CompInt8(
+                            BlkLen,
+                            QuantA,
+                            QuantAScale,
+                            b_col,
+                            b_col_scale,
+                            b_col_zp,
+                            c_out,
+                            RangeCountM,
+                            CountN,
+                            K,
+                            k_blks,
+                            bias,
+                            c_out_ldc,
+                            ABlockSum,
+                            b_blk_sum,
+                            blk_unsigned_quant_A_zp_correction
+                        );
+                    },
+                    CFp16 + n, RangeCountM, CountN, ldc
                 );
+            } else {
+                GetMlasPlatform().QNBitGemmDispatch->SQ8BitGemmKernel_BlkSum_CompInt8(
+                    BlkLen,
+                    QuantA,
+                    QuantAScale,
+                    b_col,
+                    b_col_scale,
+                    b_col_zp,
+                    c_blk,
+                    RangeCountM,
+                    CountN,
+                    K,
+                    k_blks,
+                    bias,
+                    ldc,
+                    ABlockSum,
+                    b_blk_sum,
+                    blk_unsigned_quant_A_zp_correction
+                );
+
+                if (DataParams->PostProcessor != nullptr) {
+                    DataParams->PostProcessor->Process(
+                        DataParams->C, RangeStartM, RangeStartN + n,
+                        RangeCountM, CountN, ldc
+                    );
+                }
             }
         }
     }
@@ -1139,7 +1200,10 @@ SQ2BitGemm_CompInt8(
     const float* QuantBScale = DataParams->QuantBScale + RangeStartN * k_blks_eff;
     const float* ABlockSum = per_gemm_quant_a_workspace->BlockSum + RangeStartM * k_blks;
     const float* QuantBBlkSum = DataParams->QuantBBlkSum + RangeStartN * k_blks;
-    float* C = DataParams->C + RangeStartM * ldc + RangeStartN;
+
+    const bool to_fp16 = DataParams->CFp16 != nullptr;
+    MLAS_FP16* CFp16 = to_fp16 ? DataParams->CFp16 + RangeStartM * ldc + RangeStartN : nullptr;
+    float* C = to_fp16 ? nullptr : DataParams->C + RangeStartM * ldc + RangeStartN;
 
     const float* Bias = (DataParams->Bias == nullptr) ? nullptr : DataParams->Bias + RangeStartN;
 
@@ -1149,9 +1213,36 @@ SQ2BitGemm_CompInt8(
 
         const std::byte* b_col = QuantBData + n * ldb;
         const float* b_col_scale = QuantBScale + n * k_blks_eff;
-        float* c_blk = C + n;
+        float* c_blk = (C == nullptr) ? nullptr : C + n;
         const float* bias = (Bias == nullptr) ? nullptr : Bias + n;
         const float* b_blk_sum = QuantBBlkSum + n * k_blks;
+
+        if (to_fp16) {
+            assert(DataParams->PostProcessor == nullptr);
+            CompInt8StripToFp16(
+                [&](float* c_out, size_t c_out_ldc) {
+                    Dispatch->SQ2BitGemmKernel_BlkSum_CompInt8(
+                        BlkLen,
+                        QuantA,
+                        QuantAScale,
+                        b_col,
+                        b_col_scale,
+                        /*QuantBZeroPoint*/ nullptr,
+                        c_out,
+                        RangeCountM,
+                        CountN,
+                        K,
+                        k_blks,
+                        bias,
+                        c_out_ldc,
+                        ABlockSum,
+                        b_blk_sum
+                    );
+                },
+                CFp16 + n, RangeCountM, CountN, ldc
+            );
+            continue;
+        }
 
         Dispatch->SQ2BitGemmKernel_BlkSum_CompInt8(
             BlkLen,


### PR DESCRIPTION
### Description
Widens the fp16 direct C output path on the CompInt8 `MatMulNBits` compute op from 4 bit only to 2, 4 and 8 bit. #29791 added that path for 4 bit, where the int8 kernel writes each N strip into a small per thread fp32 scratch and the strip is converted straight to fp16, so the full fp32 result never lands in a caller buffer. `SQ8BitGemm_CompInt8` and `SQ2BitGemm_CompInt8` had no such branch, so an 8 bit or 2 bit fp16 model still allocated an `M * N` fp32 output buffer and then ran a separate conversion pass over it.

The scratch handling and the conversion loop are now a single helper, `CompInt8StripToFp16`, which the 4 bit path was changed to use as well, so there is one implementation rather than three copies. The per thread scratch lives in a non template accessor so a thread keeps one buffer regardless of how many bit widths it runs. The helper calls the kernel exactly once over the whole M range with the scratch as a `CountN` strided buffer, which is what the fp32 branch does, so the converted values are bitwise identical to the fp32 path. `MlasQNBitGemmFp16DirectCOutputSupported` now accepts 2, 4 and 8.

### Motivation and Context
Follow up to #29791, which noted in a comment that the C epilogue is portable and would widen as other bit widths gained the branch. This is that change, so 8 bit and 2 bit fp16 models get the same saving 4 bit already has: one fewer `M * N` fp32 allocation and one fewer full conversion pass over the output.

`test_sqnbitgemm_fp16_quant_a.cpp` already checks the fp16 C output against the fp32 result converted to fp16, per bit width, and skips that check when `MlasQNBitGemmFp16DirectCOutputSupported` is false, so widening the gate turns on byte identity coverage for 2 bit and 8 bit without a new test. Locally the fp16 quantize A suite passes 15 of 15, the `*NBitGemm*` tests pass 13535 of 13535, and the full MLAS unit test suite passes 28180 of 28180.
