### PR TITLE
PagedAttention: add CPU/WebGPU interfaces and tune CUDA validation/launch

### DIFF
--- a/onnxruntime/contrib_ops/cpu/bert/paged_attention.cc
+++ b/onnxruntime/contrib_ops/cpu/bert/paged_attention.cc
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "contrib_ops/cpu/bert/paged_attention.h"
+
+namespace onnxruntime {
+namespace contrib {
+
+#define REGISTER_KERNEL_TYPED(T)                                        \
+  ONNX_OPERATOR_TYPED_KERNEL_EX(                                        \
+      PagedAttention,                                                   \
+      kMSDomain,                                                        \
+      1,                                                                \
+      T,                                                                \
+      kCpuExecutionProvider,                                            \
+      (*KernelDefBuilder::Create())                                     \
+          .TypeConstraint("T", DataTypeImpl::GetTensorType<T>())        \
+          .TypeConstraint("S", DataTypeImpl::GetTensorType<int32_t>()), \
+      PagedAttention<T>);
+
+REGISTER_KERNEL_TYPED(MLFloat16)
+REGISTER_KERNEL_TYPED(BFloat16)
+
+template <typename T>
+PagedAttention<T>::PagedAttention(const OpKernelInfo& info)
+    : OpKernel(info) {
+  int64_t num_heads = 0;
+  int64_t kv_num_heads = 0;
+  ORT_ENFORCE(info.GetAttr("num_heads", &num_heads).IsOK() && num_heads > 0);
+  ORT_ENFORCE(info.GetAttr("kv_num_heads", &kv_num_heads).IsOK() && kv_num_heads > 0 && num_heads % kv_num_heads == 0);
+
+  num_heads_ = static_cast<int>(num_heads);
+  kv_num_heads_ = static_cast<int>(kv_num_heads);
+  do_rotary_ = info.GetAttrOrDefault<int64_t>("do_rotary", 0) == 1;
+  scale_ = info.GetAttrOrDefault<float>("scale", 0.0f);
+  softcap_ = info.GetAttrOrDefault<float>("softcap", 0.0f);
+}
+
+template <typename T>
+Status PagedAttention<T>::Compute(OpKernelContext* context) const {
+  ORT_UNUSED_PARAMETER(context);
+
+  return ORT_MAKE_STATUS(ONNXRUNTIME, NOT_IMPLEMENTED,
+                         "PagedAttention execution is not implemented on CPU. "
+                         "Use CUDA Execution Provider for runtime execution.");
+}
+
+template class PagedAttention<MLFloat16>;
+template class PagedAttention<BFloat16>;
+
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cpu/bert/paged_attention.h
+++ b/onnxruntime/contrib_ops/cpu/bert/paged_attention.h
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/framework/op_kernel.h"
+
+namespace onnxruntime {
+namespace contrib {
+
+template <typename T>
+class PagedAttention final : public OpKernel {
+ public:
+  explicit PagedAttention(const OpKernelInfo& info);
+  Status Compute(OpKernelContext* context) const override;
+
+ private:
+  int num_heads_;
+  int kv_num_heads_;
+  bool do_rotary_;
+  float scale_;
+  float softcap_;
+};
+
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cpu/cpu_contrib_kernels.cc
+++ b/onnxruntime/contrib_ops/cpu/cpu_contrib_kernels.cc
@@ -30,6 +30,8 @@ class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1,
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, MultiHeadAttention);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, GroupQueryAttention);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, MLFloat16, GroupQueryAttention);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, MLFloat16, PagedAttention);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, BFloat16, PagedAttention);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, SparseAttention);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, MLFloat16, SparseAttention);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, LinearAttention);
@@ -326,6 +328,8 @@ Status RegisterCpuContribKernels(KernelRegistry& kernel_registry) {
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, MultiHeadAttention)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, GroupQueryAttention)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, MLFloat16, GroupQueryAttention)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, MLFloat16, PagedAttention)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, BFloat16, PagedAttention)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, SparseAttention)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, MLFloat16, SparseAttention)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSDomain, 1, float, LinearAttention)>,

--- a/onnxruntime/contrib_ops/cuda/bert/paged_attention.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/paged_attention.cc
@@ -91,6 +91,7 @@ Status PagedAttention<T>::ComputeInternal(OpKernelContext* context) const {
                                                           scale_,
                                                           softcap_,
                                                           device_prop.maxThreadsPerBlock));
+
   parameters.local_window_size = local_window_size_;
   parameters.do_rotary = do_rotary_;
   parameters.rotary_interleaved = rotary_interleaved_;

--- a/onnxruntime/contrib_ops/cuda/bert/paged_attention_helper.h
+++ b/onnxruntime/contrib_ops/cuda/bert/paged_attention_helper.h
@@ -23,6 +23,11 @@ Status Check_Q_K_V(const T* query, const T* key, const T* value, const int num_h
   }
   token_count = static_cast<int>(query_dims[0]);
   q_hidden_size = static_cast<int>(query_dims[1]);
+  if (q_hidden_size % num_heads != 0) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                           "q_hidden_size must be a multiple of num_heads. Got q_hidden_size % num_heads == ",
+                           q_hidden_size % num_heads);
+  }
   head_size = static_cast<int>(q_hidden_size) / num_heads;
   if (head_size % 8 != 0) {
     return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
@@ -73,7 +78,18 @@ Status Check_QKV(const T* packed_qkv, const T* value, const int num_heads, const
                            packed_dims.size());
   }
   token_count = static_cast<int>(packed_dims[0]);
-  head_size = static_cast<int>(static_cast<int>(packed_dims[1])) / (num_heads + 2 * kv_num_heads);
+  const int packed_hidden_size = static_cast<int>(packed_dims[1]);
+  if (packed_hidden_size <= 0) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                           "Input 'query' packed hidden size must be positive.");
+  }
+  const int packed_divisor = num_heads + 2 * kv_num_heads;
+  if (packed_hidden_size % packed_divisor != 0) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                           "Input 'query' packed hidden size must be divisible by (num_heads + 2 * kv_num_heads). Got ",
+                           packed_hidden_size, " and ", packed_divisor, ".");
+  }
+  head_size = packed_hidden_size / packed_divisor;
   if (head_size % 8 != 0) {
     return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
                            "head_size must be a multiple of 8. Got head_size % 8 == ",
@@ -106,7 +122,7 @@ Status CheckKVCache(const T* key_cache, const T* value_cache, const int kv_num_h
 
   num_blocks = static_cast<int>(key_cache_dims[0]);
   block_size = static_cast<int>(key_cache_dims[1]);
-  // TODO(aciddelgado): block size multiple of 8
+  // CUDA PagedAttention kernels currently require block_size alignment of 256.
   if (block_size % 256 != 0) {
     return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
                            "block_size must be a multiple of 256. Got block_size % 256 == ",
@@ -119,7 +135,7 @@ Status CheckKVCache(const T* key_cache, const T* value_cache, const int kv_num_h
   } else if (value_cache_dims[1] != block_size) {
     return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
                            "Input 'value_cache' dimension 1 should be block_size, got ",
-                           value_cache_dims[0]);
+                           value_cache_dims[1]);
   }
 
   if (key_cache_dims[2] != value_cache_dims[2]) {
@@ -166,7 +182,7 @@ Status CheckSequenceLengthTensors(const T* cumulative_sequence_length, const T* 
   batch_size = static_cast<int>(cumulative_seqlen_dim[0]) - 1;
 
   const auto& seqlens_dim = seqlens->Shape().GetDims();
-  if (seqlens_dim.size() != 1 && seqlens_dim[0] != batch_size) {
+  if (seqlens_dim.size() != 1 || seqlens_dim[0] != batch_size) {
     return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
                            "seqlens must be shape (batch_size).");
   }
@@ -206,7 +222,8 @@ Status CheckInputs(const T* query,
                    float softcap,
                    int max_threads_per_block) {
   if (max_threads_per_block > 0 && num_heads > max_threads_per_block) {
-    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "num_heads should be no larger than ", max_threads_per_block);
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                           "num_heads should be no larger than ", max_threads_per_block);
   }
   if (num_heads % kv_num_heads != 0) {
     return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,

--- a/onnxruntime/contrib_ops/cuda/bert/paged_attention_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/paged_attention_impl.cu
@@ -204,13 +204,22 @@ __global__ void ReshapeAndCache(const T* __restrict__ key, const T* __restrict__
   }
   const int token_id = tid / kv_hidden_size;
   const int hidden_offset = tid % kv_hidden_size;
-  int batch_id = 0;
-  for (int i = 0; i < batch_size; ++i) {
-    if (token_id < cumulative_seqlens_q[i + 1]) {
-      batch_id = i;
-      break;
+
+  // Find sequence owner for token_id using binary search over cumulative boundaries.
+  // This replaces a linear scan over batch entries and lowers lookup cost from O(batch)
+  // to O(log batch) per token.
+  int left = 0;
+  int right = batch_size;
+  while (left < right) {
+    const int mid = (left + right) >> 1;
+    if (token_id < cumulative_seqlens_q[mid + 1]) {
+      right = mid;
+    } else {
+      left = mid + 1;
     }
   }
+  const int batch_id = left;
+
   const int token_offset = token_id - cumulative_seqlens_q[batch_id];
   const int past_length = past_seqlens[batch_id];
   const int block_id = block_table[batch_id * max_num_blocks_per_seq + (past_length + token_offset) / block_size];
@@ -230,7 +239,12 @@ Status LaunchReshapeAndCache(const T* key, const T* value, T* key_cache, T* valu
                              const int block_size, const int key_stride, const int value_stride, cudaStream_t stream,
                              const int max_threads_per_block) {
   const int total_size = token_count * kv_hidden_size;
-  const int threads(std::min(total_size, max_threads_per_block));
+  if (total_size == 0) {
+    return Status::OK();
+  }
+  // Prefer 256 threads for better occupancy/latency tradeoff on most GPUs.
+  const int preferred_threads = std::min(256, max_threads_per_block);
+  const int threads = std::min(total_size, preferred_threads);
   const int blocks((total_size + threads - 1) / threads);
   ReshapeAndCache<T><<<blocks, threads, 0, stream>>>(key, value, key_cache, value_cache, block_table, past_seqlens,
                                                      cumulative_seqlens_q, batch_size, max_num_blocks_per_seq,
@@ -323,7 +337,8 @@ Status LaunchGatherAndExpandPagedKVCache(const T* key_cache, const T* value_cach
   // within int range for any realistic input, so no explicit clamp is needed. The kernel
   // uses a grid-stride loop so launching fewer blocks than total_elems / threads would
   // also be correct — we don't need an artificial "keep SMs busy" cap.
-  const int threads = static_cast<int>(std::min<int64_t>(max_threads_per_block, total_elems));
+  const int preferred_threads = std::min(256, max_threads_per_block);
+  const int threads = static_cast<int>(std::min<int64_t>(preferred_threads, total_elems));
   const int blocks = static_cast<int>((total_elems + threads - 1) / threads);
   GatherAndExpandPagedKVCache<T><<<blocks, threads, 0, stream>>>(
       key_cache, value_cache, gathered_key, gathered_value,

--- a/onnxruntime/contrib_ops/webgpu/bert/paged_attention.cc
+++ b/onnxruntime/contrib_ops/webgpu/bert/paged_attention.cc
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "contrib_ops/webgpu/bert/paged_attention.h"
+
+#include "contrib_ops/webgpu/webgpu_contrib_kernels.h"
+
+namespace onnxruntime {
+namespace contrib {
+namespace webgpu {
+
+ONNX_OPERATOR_KERNEL_EX(
+    PagedAttention,
+    kMSDomain,
+    1,
+    kWebGpuExecutionProvider,
+    (*KernelDefBuilder::Create())
+        .TypeConstraint("T", DataTypeImpl::GetTensorType<MLFloat16>())
+        .TypeConstraint("S", DataTypeImpl::GetTensorType<int32_t>()),
+    PagedAttention);
+
+PagedAttention::PagedAttention(const OpKernelInfo& info)
+    : WebGpuKernel(info) {
+  int64_t num_heads = 0;
+  int64_t kv_num_heads = 0;
+  ORT_ENFORCE(info.GetAttr("num_heads", &num_heads).IsOK() && num_heads > 0);
+  ORT_ENFORCE(info.GetAttr("kv_num_heads", &kv_num_heads).IsOK() && kv_num_heads > 0 && num_heads % kv_num_heads == 0);
+
+  num_heads_ = static_cast<int>(num_heads);
+  kv_num_heads_ = static_cast<int>(kv_num_heads);
+  do_rotary_ = info.GetAttrOrDefault<int64_t>("do_rotary", 0) == 1;
+  scale_ = info.GetAttrOrDefault<float>("scale", 0.0f);
+  softcap_ = info.GetAttrOrDefault<float>("softcap", 0.0f);
+}
+
+Status PagedAttention::ComputeInternal(onnxruntime::webgpu::ComputeContext& context) const {
+  ORT_UNUSED_PARAMETER(context);
+
+  return ORT_MAKE_STATUS(ONNXRUNTIME, NOT_IMPLEMENTED,
+                         "PagedAttention execution is not implemented on WebGPU.");
+}
+
+}  // namespace webgpu
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/webgpu/bert/paged_attention.h
+++ b/onnxruntime/contrib_ops/webgpu/bert/paged_attention.h
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/providers/webgpu/compute_context.h"
+#include "core/providers/webgpu/webgpu_kernel.h"
+
+namespace onnxruntime {
+namespace contrib {
+namespace webgpu {
+
+using namespace onnxruntime::webgpu;
+
+class PagedAttention final : public WebGpuKernel {
+ public:
+  explicit PagedAttention(const OpKernelInfo& info);
+  Status ComputeInternal(onnxruntime::webgpu::ComputeContext& context) const override;
+
+ private:
+  int num_heads_;
+  int kv_num_heads_;
+  bool do_rotary_;
+  float scale_;
+  float softcap_;
+};
+
+}  // namespace webgpu
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/webgpu/webgpu_contrib_kernels.cc
+++ b/onnxruntime/contrib_ops/webgpu/webgpu_contrib_kernels.cc
@@ -35,6 +35,7 @@ static const BuildKernelCreateInfoFn build_kernel_create_info_function_table[] =
     BuildKernelCreateInfo<class ONNX_OPERATOR_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kMSDomain, 1, MatMulNBitsQkv)>,
     BuildKernelCreateInfo<class ONNX_OPERATOR_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kMSDomain, 1, MatMulNBitsMlp)>,
     BuildKernelCreateInfo<class ONNX_OPERATOR_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kMSDomain, 1, MultiHeadAttention)>,
+    BuildKernelCreateInfo<class ONNX_OPERATOR_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kMSDomain, 1, PagedAttention)>,
     BuildKernelCreateInfo<class ONNX_OPERATOR_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kMSDomain, 1, QuickGelu)>,
     BuildKernelCreateInfo<class ONNX_OPERATOR_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kMSDomain, 1, RotaryEmbedding)>,
     BuildKernelCreateInfo<class ONNX_OPERATOR_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kMSDomain, 1, SkipLayerNormalization)>,

--- a/onnxruntime/core/graph/contrib_ops/bert_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/bert_defs.cc
@@ -1391,6 +1391,9 @@ This packing omits padding tokens.
 The query, key and value tensors contain result of hidden embedding of real tokens after input projections.
 cumulative_sequence_length records cumulated length of each sequence length.
 
+Provider-specific execution constraints (for example, alignment and backend availability)
+are validated by each Execution Provider implementation.
+
 )DOC";
 
 // Shape inference for PagedAttention. Here are the shapes of inputs and output:
@@ -1544,7 +1547,7 @@ ONNX_MS_OPERATOR_SET_SCHEMA(
                OpSchema::Optional)
         .Output(0,
                 "output",
-                "3D output tensor with shape (num_tokens, hidden_size)",
+          "2D output tensor with shape (num_tokens, hidden_size)",
                 "T")
         .Output(1,
                 "key_cache_out",

--- a/onnxruntime/core/graph/contrib_ops/bert_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/bert_defs.cc
@@ -1547,7 +1547,7 @@ ONNX_MS_OPERATOR_SET_SCHEMA(
                OpSchema::Optional)
         .Output(0,
                 "output",
-          "2D output tensor with shape (num_tokens, hidden_size)",
+                "2D output tensor with shape (num_tokens, hidden_size)",
                 "T")
         .Output(1,
                 "key_cache_out",


### PR DESCRIPTION
This pull request adds initial CPU and WebGPU support for the `PagedAttention` operator, improves input validation and error messages for CUDA, and optimizes CUDA kernels for better performance. The CPU and WebGPU implementations are stubs that return a "not implemented" error, but they register the operator and validate attributes. CUDA-side changes focus on stricter shape checks, clearer error reporting, and more efficient kernel launches.

**New Operator Implementations and Registration:**

* Added CPU implementation for `PagedAttention` (`onnxruntime/contrib_ops/cpu/bert/paged_attention.h`, `onnxruntime/contrib_ops/cpu/bert/paged_attention.cc`) and registered it for `MLFloat16` and `BFloat16`, with a stubbed compute method. [[1]](diffhunk://#diff-11058f3d3a8db6af49be844c6b94f01bd690bf3062d005270d1ddc5bfaf84978R1-R52) [[2]](diffhunk://#diff-8662ce8c1ae13bfb074292f2ab02215fabfb3bc2c0af936635b4974df9a71b96R1-R26) [[3]](diffhunk://#diff-fd949b2a9885f634c37c2048da9e35d227ed20adf1d7baf5de488f304a78bde9R33-R34) [[4]](diffhunk://#diff-fd949b2a9885f634c37c2048da9e35d227ed20adf1d7baf5de488f304a78bde9R331-R332)
* Added WebGPU implementation for `PagedAttention` (`onnxruntime/contrib_ops/webgpu/bert/paged_attention.h`, `onnxruntime/contrib_ops/webgpu/bert/paged_attention.cc`) and registered it, with a stubbed compute method. [[1]](diffhunk://#diff-f57101a49d0ec8d4d6b1a8ef3bb281896200e631b0b00a0f3c2f0a4a534ed90cR1-R45) [[2]](diffhunk://#diff-f2b1edcb44edfdad6958d505ccd14e7d55b0483097ab84dc0f452610aaab75beR1-R30) [[3]](diffhunk://#diff-7eba9188de5d326cefe12398c96909a9ed415073052f9e7ef7ab52ac916023f9R38)

**CUDA Input Validation and Error Handling Improvements:**

* Improved input validation in CUDA helpers: now checks that `q_hidden_size` is a multiple of `num_heads`, packed QKV hidden size is positive and divisible by `(num_heads + 2 * kv_num_heads)`, and `block_size` is a multiple of 256. Error messages are more descriptive. [[1]](diffhunk://#diff-74ab7a323533132c1981c57529405df7d9e89810c6653eefdd46df60801cf6f5R26-R30) [[2]](diffhunk://#diff-74ab7a323533132c1981c57529405df7d9e89810c6653eefdd46df60801cf6f5L76-R92) [[3]](diffhunk://#diff-74ab7a323533132c1981c57529405df7d9e89810c6653eefdd46df60801cf6f5L109-R125) [[4]](diffhunk://#diff-74ab7a323533132c1981c57529405df7d9e89810c6653eefdd46df60801cf6f5L122-R138) [[5]](diffhunk://#diff-74ab7a323533132c1981c57529405df7d9e89810c6653eefdd46df60801cf6f5L169-R185) [[6]](diffhunk://#diff-74ab7a323533132c1981c57529405df7d9e89810c6653eefdd46df60801cf6f5L209-R226)

**CUDA Kernel Performance Optimizations:**

* Optimized CUDA kernels by switching from a linear scan to binary search for sequence owner lookup in `ReshapeAndCache` and preferring 256 threads per block for better GPU occupancy. [[1]](diffhunk://#diff-db3626a57f2a12a3ba5ef39444fb9ef7d23ba9c76d9530303e54dd48c81cebd1L207-R222) [[2]](diffhunk://#diff-db3626a57f2a12a3ba5ef39444fb9ef7d23ba9c76d9530303e54dd48c81cebd1L233-R247) [[3]](diffhunk://#diff-db3626a57f2a12a3ba5ef39444fb9ef7d23ba9c76d9530303e54dd48c81cebd1L326-R341)
* Minor update to parameter assignment in CUDA implementation.

**Documentation and Schema Updates:**

* Updated the PagedAttention operator schema documentation to clarify that provider-specific constraints are validated per backend, and fixed the output tensor shape description. [[1]](diffhunk://#diff-8bf31275168b1e4a2aecd6760acf0ef92347134b003dfdc687c5d3cec4a178ecR1394-R1396) [[2]](diffhunk://#diff-8bf31275168b1e4a2aecd6760acf0ef92347134b003dfdc687c5d3cec4a178ecL1547-R1550)