### PR TITLE
Fix NuGet packaging to include .inc files alongside .h headers

### DIFF
--- a/tools/nuget/generate_nuspec_for_native_nuget.py
+++ b/tools/nuget/generate_nuspec_for_native_nuget.py
@@ -469,6 +469,14 @@ def generate_files(line_list, args):
         files_list.append(
             "<file src="
             + '"'
+            + os.path.join(args.sources_path, "include\\onnxruntime\\core\\session\\onnxruntime_*.inc")
+            + '" target="'
+            + include_dir
+            + '" />'
+        )
+        files_list.append(
+            "<file src="
+            + '"'
             + os.path.join(args.sources_path, "include\\onnxruntime\\core\\framework\\provider_options.h")
             + '" target="'
             + include_dir

--- a/tools/nuget/validate_package.py
+++ b/tools/nuget/validate_package.py
@@ -29,6 +29,8 @@ gpu_related_header_files = [
     "onnxruntime_cxx_api.h",
     "onnxruntime_float16.h",
     "onnxruntime_cxx_inline.h",
+    "onnxruntime_experimental_c_api.h",
+    "onnxruntime_experimental_c_api.inc",
 ]
 dmlep_related_header_files = [
     "cpu_provider_factory.h",
@@ -37,6 +39,8 @@ dmlep_related_header_files = [
     "onnxruntime_float16.h",
     "onnxruntime_cxx_inline.h",
     "dml_provider_factory.h",
+    "onnxruntime_experimental_c_api.h",
+    "onnxruntime_experimental_c_api.inc",
 ]
 training_related_header_files = [
     "onnxruntime_c_api.h",
@@ -46,6 +50,8 @@ training_related_header_files = [
     "onnxruntime_training_c_api.h",
     "onnxruntime_training_cxx_api.h",
     "onnxruntime_training_cxx_inline.h",
+    "onnxruntime_experimental_c_api.h",
+    "onnxruntime_experimental_c_api.inc",
 ]
 
 


### PR DESCRIPTION
This chery pick #29866 to 1.28 release