### PR TITLE
[CUDA] Fix ScatterElements reduction dispatch by element type

### DIFF
--- a/onnxruntime/core/providers/cuda/atomic/common.cuh
+++ b/onnxruntime/core/providers/cuda/atomic/common.cuh
@@ -17,6 +17,9 @@
 /* Modifications Copyright (c) Microsoft. */
 
 #pragma once
+#include <cuda/std/bit>
+#include <cuda/std/type_traits>
+
 #include "cuda.h"
 #include "cuda_fp16.h"
 #include "cuda_runtime.h"
@@ -401,6 +404,16 @@ __device__ __forceinline__ void atomic_binary_func(ValueType* address, ValueType
 struct AddFunc {
   template <typename T>
   __device__ __forceinline__ T operator()(T a, T b) const {
+    if constexpr (::cuda::std::is_integral_v<T> && !::cuda::std::is_same_v<T, bool>) {
+      using UnsignedT = ::cuda::std::make_unsigned_t<T>;
+      using ArithmeticT =
+          ::cuda::std::conditional_t<(sizeof(UnsignedT) < sizeof(unsigned int)), unsigned int, UnsignedT>;
+      const auto result = static_cast<UnsignedT>(
+          static_cast<ArithmeticT>(static_cast<UnsignedT>(a)) +
+          static_cast<ArithmeticT>(static_cast<UnsignedT>(b)));
+      return ::cuda::std::bit_cast<T>(result);
+    }
+
     return a + b;
   }
 };
@@ -408,6 +421,16 @@ struct AddFunc {
 struct MulFunc {
   template <typename T>
   __device__ __forceinline__ T operator()(T a, T b) const {
+    if constexpr (::cuda::std::is_integral_v<T> && !::cuda::std::is_same_v<T, bool>) {
+      using UnsignedT = ::cuda::std::make_unsigned_t<T>;
+      using ArithmeticT =
+          ::cuda::std::conditional_t<(sizeof(UnsignedT) < sizeof(unsigned int)), unsigned int, UnsignedT>;
+      const auto result = static_cast<UnsignedT>(
+          static_cast<ArithmeticT>(static_cast<UnsignedT>(a)) *
+          static_cast<ArithmeticT>(static_cast<UnsignedT>(b)));
+      return ::cuda::std::bit_cast<T>(result);
+    }
+
     return a * b;
   }
 };

--- a/onnxruntime/core/providers/cuda/atomic/common.cuh
+++ b/onnxruntime/core/providers/cuda/atomic/common.cuh
@@ -136,7 +136,42 @@ class AtomicCasType<int8_t> {
 };
 
 template <>
+class AtomicCasType<uint8_t> {
+ public:
+  using type = unsigned short int;
+  static const unsigned int mask = 0xffu;
+};
+
+template <>
+class AtomicCasType<bool> {
+ public:
+  using type = unsigned short int;
+  static const unsigned int mask = 0xffu;
+};
+
+template <>
+class AtomicCasType<int16_t> {
+ public:
+  using type = unsigned short int;
+  static const unsigned int mask = 0xffffu;
+};
+
+template <>
+class AtomicCasType<uint16_t> {
+ public:
+  using type = unsigned short int;
+  static const unsigned int mask = 0xffffu;
+};
+
+template <>
 class AtomicCasType<half> {
+ public:
+  using type = unsigned short int;
+  static const unsigned int mask = 0xffffu;
+};
+
+template <>
+class AtomicCasType<BFloat16> {
  public:
   using type = unsigned short int;
   static const unsigned int mask = 0xffffu;
@@ -164,7 +199,21 @@ class AtomicCasType<int> {
 };
 
 template <>
+class AtomicCasType<uint32_t> {
+ public:
+  using type = unsigned int;
+  static const unsigned int mask = 0xffffffffu;
+};
+
+template <>
 class AtomicCasType<int64_t> {
+ public:
+  using type = unsigned long long int;
+  static const unsigned int mask = 0xffffffffu;
+};
+
+template <>
+class AtomicCasType<uint64_t> {
  public:
   using type = unsigned long long int;
   static const unsigned int mask = 0xffffffffu;
@@ -377,6 +426,18 @@ struct MinFunc {
   }
 };
 
+struct BoolOrFunc {
+  __device__ __forceinline__ bool operator()(bool a, bool b) const {
+    return a || b;
+  }
+};
+
+struct BoolAndFunc {
+  __device__ __forceinline__ bool operator()(bool a, bool b) const {
+    return a && b;
+  }
+};
+
 __device__ __forceinline__ void atomic_add(int8_t* address, int8_t value) {
   atomic_byte_func_with_unit32_cas(address, value, AddFunc());
 }
@@ -388,6 +449,110 @@ __device__ __forceinline__ void atomic_max(int8_t* address, int8_t value) {
 }
 __device__ __forceinline__ void atomic_min(int8_t* address, int8_t value) {
   atomic_byte_func_with_unit32_cas(address, value, MinFunc());
+}
+
+__device__ __forceinline__ void atomic_add(uint8_t* address, uint8_t value) {
+  atomic_byte_func_with_unit32_cas(address, value, AddFunc());
+}
+__device__ __forceinline__ void atomic_mul(uint8_t* address, uint8_t value) {
+  atomic_byte_func_with_unit32_cas(address, value, MulFunc());
+}
+__device__ __forceinline__ void atomic_max(uint8_t* address, uint8_t value) {
+  atomic_byte_func_with_unit32_cas(address, value, MaxFunc());
+}
+__device__ __forceinline__ void atomic_min(uint8_t* address, uint8_t value) {
+  atomic_byte_func_with_unit32_cas(address, value, MinFunc());
+}
+
+__device__ __forceinline__ void atomic_add(bool* address, bool value) {
+  atomic_byte_func_with_unit32_cas(address, value, BoolOrFunc());
+}
+__device__ __forceinline__ void atomic_mul(bool* address, bool value) {
+  atomic_byte_func_with_unit32_cas(address, value, BoolAndFunc());
+}
+__device__ __forceinline__ void atomic_max(bool* address, bool value) {
+  atomic_byte_func_with_unit32_cas(address, value, BoolOrFunc());
+}
+__device__ __forceinline__ void atomic_min(bool* address, bool value) {
+  atomic_byte_func_with_unit32_cas(address, value, BoolAndFunc());
+}
+
+__device__ __forceinline__ void atomic_add(int16_t* address, int16_t value) {
+  atomic_byte_func_with_unit32_cas(address, value, AddFunc());
+}
+__device__ __forceinline__ void atomic_mul(int16_t* address, int16_t value) {
+  atomic_byte_func_with_unit32_cas(address, value, MulFunc());
+}
+__device__ __forceinline__ void atomic_max(int16_t* address, int16_t value) {
+  atomic_byte_func_with_unit32_cas(address, value, MaxFunc());
+}
+__device__ __forceinline__ void atomic_min(int16_t* address, int16_t value) {
+  atomic_byte_func_with_unit32_cas(address, value, MinFunc());
+}
+
+__device__ __forceinline__ void atomic_add(uint16_t* address, uint16_t value) {
+  atomic_byte_func_with_unit32_cas(address, value, AddFunc());
+}
+__device__ __forceinline__ void atomic_mul(uint16_t* address, uint16_t value) {
+  atomic_byte_func_with_unit32_cas(address, value, MulFunc());
+}
+__device__ __forceinline__ void atomic_max(uint16_t* address, uint16_t value) {
+  atomic_byte_func_with_unit32_cas(address, value, MaxFunc());
+}
+__device__ __forceinline__ void atomic_min(uint16_t* address, uint16_t value) {
+  atomic_byte_func_with_unit32_cas(address, value, MinFunc());
+}
+
+__device__ __forceinline__ void atomic_add(int32_t* address, int32_t value) {
+  atomic_binary_func(address, value, AddFunc());
+}
+__device__ __forceinline__ void atomic_mul(int32_t* address, int32_t value) {
+  atomic_binary_func(address, value, MulFunc());
+}
+__device__ __forceinline__ void atomic_max(int32_t* address, int32_t value) {
+  atomic_binary_func(address, value, MaxFunc());
+}
+__device__ __forceinline__ void atomic_min(int32_t* address, int32_t value) {
+  atomic_binary_func(address, value, MinFunc());
+}
+
+__device__ __forceinline__ void atomic_add(uint32_t* address, uint32_t value) {
+  atomic_binary_func(address, value, AddFunc());
+}
+__device__ __forceinline__ void atomic_mul(uint32_t* address, uint32_t value) {
+  atomic_binary_func(address, value, MulFunc());
+}
+__device__ __forceinline__ void atomic_max(uint32_t* address, uint32_t value) {
+  atomic_binary_func(address, value, MaxFunc());
+}
+__device__ __forceinline__ void atomic_min(uint32_t* address, uint32_t value) {
+  atomic_binary_func(address, value, MinFunc());
+}
+
+__device__ __forceinline__ void atomic_add(int64_t* address, int64_t value) {
+  atomic_binary_func(address, value, AddFunc());
+}
+__device__ __forceinline__ void atomic_mul(int64_t* address, int64_t value) {
+  atomic_binary_func(address, value, MulFunc());
+}
+__device__ __forceinline__ void atomic_max(int64_t* address, int64_t value) {
+  atomic_binary_func(address, value, MaxFunc());
+}
+__device__ __forceinline__ void atomic_min(int64_t* address, int64_t value) {
+  atomic_binary_func(address, value, MinFunc());
+}
+
+__device__ __forceinline__ void atomic_add(uint64_t* address, uint64_t value) {
+  atomic_binary_func(address, value, AddFunc());
+}
+__device__ __forceinline__ void atomic_mul(uint64_t* address, uint64_t value) {
+  atomic_binary_func(address, value, MulFunc());
+}
+__device__ __forceinline__ void atomic_max(uint64_t* address, uint64_t value) {
+  atomic_binary_func(address, value, MaxFunc());
+}
+__device__ __forceinline__ void atomic_min(uint64_t* address, uint64_t value) {
+  atomic_binary_func(address, value, MinFunc());
 }
 
 __device__ __forceinline__ void atomic_mul(half* address, half value) {
@@ -410,6 +575,16 @@ __device__ __forceinline__ void atomic_min(half* address, half value) {
 #else
   atomic_byte_func_with_unit32_cas(address, value, MinFunc());
 #endif
+}
+
+__device__ __forceinline__ void atomic_mul(BFloat16* address, BFloat16 value) {
+  atomic_byte_func_with_unit32_cas(address, value, MulFunc());
+}
+__device__ __forceinline__ void atomic_max(BFloat16* address, BFloat16 value) {
+  atomic_byte_func_with_unit32_cas(address, value, MaxFunc());
+}
+__device__ __forceinline__ void atomic_min(BFloat16* address, BFloat16 value) {
+  atomic_byte_func_with_unit32_cas(address, value, MinFunc());
 }
 
 __device__ __forceinline__ void atomic_mul(float* address, float value) {

--- a/onnxruntime/core/providers/cuda/tensor/gather_elements_impl.cu
+++ b/onnxruntime/core/providers/cuda/tensor/gather_elements_impl.cu
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <type_traits>
+
 #include "core/providers/cuda/tensor/gather_elements_impl.h"
 #include "core/providers/cuda/tensor/scatter_elements_impl.h"
 #ifdef ENABLE_TRAINING_OPS
@@ -264,46 +266,73 @@ Status ScatterElementsImplInternal(cudaStream_t stream, const T* input_data, con
 template <typename T, typename TIndex>
 Status ScatterElementsImpl(cudaStream_t stream, const T* input_data, const TIndex* indices_data, const T* updates_data,
                            T* output_data, const GatherScatterElementsArgs& args) {
-  if (args.operation == GatherScatterElementsArgs::Operation::NONE) {
-    return ScatterElementsImplInternal(stream, input_data, indices_data, updates_data, output_data, args,
-                                       FuncAssignment<T>());
-  } else if (args.operation == GatherScatterElementsArgs::Operation::ADD) {
+  if constexpr (std::is_same_v<T, int8_t> || std::is_same_v<T, half> || std::is_same_v<T, float> ||
+                std::is_same_v<T, double>) {
+    if (args.operation == GatherScatterElementsArgs::Operation::NONE) {
+      return ScatterElementsImplInternal(stream, input_data, indices_data, updates_data, output_data, args,
+                                         FuncAssignment<T>());
+    }
+  }
+
+  if (args.operation == GatherScatterElementsArgs::Operation::ADD) {
     return ScatterElementsImplInternal(stream, input_data, indices_data, updates_data, output_data, args,
                                        FuncAdd<T>());
-  } else if (args.operation == GatherScatterElementsArgs::Operation::MUL) {
+  }
+  if (args.operation == GatherScatterElementsArgs::Operation::MUL) {
     return ScatterElementsImplInternal(stream, input_data, indices_data, updates_data, output_data, args,
                                        FuncMul<T>());
-  } else if (args.operation == GatherScatterElementsArgs::Operation::MAX) {
+  }
+  if (args.operation == GatherScatterElementsArgs::Operation::MAX) {
     return ScatterElementsImplInternal(stream, input_data, indices_data, updates_data, output_data, args,
                                        FuncMax<T>());
-  } else if (args.operation == GatherScatterElementsArgs::Operation::MIN) {
+  }
+  if (args.operation == GatherScatterElementsArgs::Operation::MIN) {
     return ScatterElementsImplInternal(stream, input_data, indices_data, updates_data, output_data, args,
                                        FuncMin<T>());
-  } else {
-    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Unsupported reduction operator.");
   }
+
+  return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Unsupported reduction operator.");
 }
 
-#define GATHER_SCATTER_ELEMENTS_SPECIALIZED_TINDEX_IMPL(T, TIndex)                                                     \
-  template void GatherElementsImpl<T, TIndex>(cudaStream_t stream, const T* input_data, const TIndex* indices_data,    \
-                                              T* output_data, const GatherScatterElementsArgs& args);                  \
+#define GATHER_ELEMENTS_SPECIALIZED_TINDEX_IMPL(T, TIndex)                                                          \
+  template void GatherElementsImpl<T, TIndex>(cudaStream_t stream, const T* input_data, const TIndex* indices_data, \
+                                              T* output_data, const GatherScatterElementsArgs& args);
+
+#define SCATTER_ELEMENTS_SPECIALIZED_TINDEX_IMPL(T, TIndex)                                                            \
   template Status ScatterElementsImpl<T, TIndex>(cudaStream_t stream, const T* input_data, const TIndex* indices_data, \
                                                  const T* updates_data, T* output_data,                                \
                                                  const GatherScatterElementsArgs& args);
 
-#define GATHER_SCATTER_ELEMENTS_SPECIALIZED_IMPL(T)           \
-  GATHER_SCATTER_ELEMENTS_SPECIALIZED_TINDEX_IMPL(T, int32_t) \
-  GATHER_SCATTER_ELEMENTS_SPECIALIZED_TINDEX_IMPL(T, int64_t)
+#define GATHER_SCATTER_ELEMENTS_SPECIALIZED_IMPL(T)    \
+  GATHER_ELEMENTS_SPECIALIZED_TINDEX_IMPL(T, int32_t)  \
+  GATHER_ELEMENTS_SPECIALIZED_TINDEX_IMPL(T, int64_t)  \
+  SCATTER_ELEMENTS_SPECIALIZED_TINDEX_IMPL(T, int32_t) \
+  SCATTER_ELEMENTS_SPECIALIZED_TINDEX_IMPL(T, int64_t)
 
-// GatherElementsGrad needs atomic_add which supports float types only, so use half, float and double for 16, 32, and 64
-// bits data respectively.
+#define SCATTER_ELEMENTS_SPECIALIZED_IMPL(T)           \
+  SCATTER_ELEMENTS_SPECIALIZED_TINDEX_IMPL(T, int32_t) \
+  SCATTER_ELEMENTS_SPECIALIZED_TINDEX_IMPL(T, int64_t)
+
+// Keep GatherElements limited to the existing representative types.
+// Instantiate additional semantic types for ScatterElements only.
 GATHER_SCATTER_ELEMENTS_SPECIALIZED_IMPL(int8_t)
 GATHER_SCATTER_ELEMENTS_SPECIALIZED_IMPL(half)
 GATHER_SCATTER_ELEMENTS_SPECIALIZED_IMPL(float)
 GATHER_SCATTER_ELEMENTS_SPECIALIZED_IMPL(double)
+SCATTER_ELEMENTS_SPECIALIZED_IMPL(int32_t)
+SCATTER_ELEMENTS_SPECIALIZED_IMPL(uint8_t)
+SCATTER_ELEMENTS_SPECIALIZED_IMPL(int16_t)
+SCATTER_ELEMENTS_SPECIALIZED_IMPL(uint16_t)
+SCATTER_ELEMENTS_SPECIALIZED_IMPL(uint32_t)
+SCATTER_ELEMENTS_SPECIALIZED_IMPL(int64_t)
+SCATTER_ELEMENTS_SPECIALIZED_IMPL(uint64_t)
+SCATTER_ELEMENTS_SPECIALIZED_IMPL(BFloat16)
+SCATTER_ELEMENTS_SPECIALIZED_IMPL(bool)
 
+#undef SCATTER_ELEMENTS_SPECIALIZED_IMPL
 #undef GATHER_SCATTER_ELEMENTS_SPECIALIZED_IMPL
-#undef GATHER_SCATTER_ELEMENTS_SPECIALIZED_TINDEX_IMPL
+#undef SCATTER_ELEMENTS_SPECIALIZED_TINDEX_IMPL
+#undef GATHER_ELEMENTS_SPECIALIZED_TINDEX_IMPL
 
 #ifdef ENABLE_TRAINING_OPS
 

--- a/onnxruntime/core/providers/cuda/tensor/scatter_elements.cc
+++ b/onnxruntime/core/providers/cuda/tensor/scatter_elements.cc
@@ -136,13 +136,22 @@ Status ScatterElements::ComputeInternal(OpKernelContext* context) const {
     ORT_THROW("Unsupported reduction type for ScatterElements.");
   }
 
-  // Use element size instead of concrete types so we can specialize less template functions to reduce binary size.
-  int dtype = GetElementType(input_tensor->DataType()->Size());
-  if (dtype == ONNX_NAMESPACE::TensorProto_DataType_UNDEFINED) {
-    ORT_THROW("Unsupported element size by the ScatterElements CUDA kernel");
+  if (args.operation == GatherScatterElementsArgs::Operation::NONE) {
+    // Use element size for raw assignment so we can specialize fewer template functions to reduce binary size.
+    int dtype = GetElementType(input_tensor->DataType()->Size());
+    if (dtype == ONNX_NAMESPACE::TensorProto_DataType_UNDEFINED) {
+      ORT_THROW("Unsupported element size by the ScatterElements CUDA kernel");
+    }
+
+    utils::MLTypeCallDispatcher<int8_t, MLFloat16, float, double> t_disp(dtype);
+    return t_disp.InvokeRet<Status, ComputeImpl>(Stream(context), input_tensor->DataRaw(), updates_tensor->DataRaw(),
+                                                 indices_tensor->DataRaw(), output_tensor->MutableDataRaw(),
+                                                 indices_tensor->DataType()->Size(), args);
   }
 
-  utils::MLTypeCallDispatcher<int8_t, MLFloat16, float, double> t_disp(dtype);
+  utils::MLTypeCallDispatcher<bool, int8_t, uint8_t, int16_t, uint16_t, int32_t, uint32_t, int64_t, uint64_t,
+                              MLFloat16, BFloat16, float, double>
+      t_disp(input_tensor->GetElementType());
   return t_disp.InvokeRet<Status, ComputeImpl>(Stream(context), input_tensor->DataRaw(), updates_tensor->DataRaw(),
                                                indices_tensor->DataRaw(), output_tensor->MutableDataRaw(),
                                                indices_tensor->DataType()->Size(), args);

--- a/onnxruntime/test/providers/cpu/tensor/scatter_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/scatter_op_test.cc
@@ -1,8 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include <ctime>
+#include <algorithm>
 #include <cstdlib>
+#include <ctime>
+#include <memory>
 
 #include "gtest/gtest.h"
 #include "test/providers/provider_test_utils.h"
@@ -360,6 +362,58 @@ TEST(ScatterElements, MulReduction) {
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
 }
 
+TEST(ScatterElements, MulReductionInt32) {
+  OpTester test("ScatterElements", 18);
+  test.AddAttribute<int64_t>("axis", 0);
+  test.AddAttribute<std::string>("reduction", "mul");
+
+  test.AddInput<int32_t>("data", {1}, {2});
+  test.AddInput<int64_t>("indices", {1}, {0});
+  test.AddInput<int32_t>("updates", {1}, {3});
+  test.AddOutput<int32_t>("y", {1}, {6});
+
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
+}
+
+TEST(ScatterElements, AddReductionInt32SemanticDispatch) {
+  OpTester test("ScatterElements", 18);
+  test.AddAttribute<int64_t>("axis", 0);
+  test.AddAttribute<std::string>("reduction", "add");
+
+  test.AddInput<int32_t>("data", {1}, {0x3f800000});
+  test.AddInput<int64_t>("indices", {1}, {0});
+  test.AddInput<int32_t>("updates", {1}, {0x3f800000});
+  test.AddOutput<int32_t>("y", {1}, {0x7f000000});
+
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
+}
+
+TEST(ScatterElements, AddReductionInt32DuplicateIndices) {
+  OpTester test("ScatterElements", 18);
+  test.AddAttribute<int64_t>("axis", 0);
+  test.AddAttribute<std::string>("reduction", "add");
+
+  test.AddInput<int32_t>("data", {1}, {1});
+  test.AddInput<int64_t>("indices", {2}, {0, 0});
+  test.AddInput<int32_t>("updates", {2}, {2, 3});
+  test.AddOutput<int32_t>("y", {1}, {6});
+
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
+}
+
+TEST(ScatterElements, NoneReductionInt32) {
+  OpTester test("ScatterElements", 18);
+  test.AddAttribute<int64_t>("axis", 0);
+  test.AddAttribute<std::string>("reduction", "none");
+
+  test.AddInput<int32_t>("data", {1}, {2});
+  test.AddInput<int64_t>("indices", {1}, {0});
+  test.AddInput<int32_t>("updates", {1}, {3});
+  test.AddOutput<int32_t>("y", {1}, {3});
+
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
+}
+
 TEST(ScatterElements, MulReductionAxis1) {
   OpTester test("ScatterElements", 18);
   test.AddAttribute<int64_t>("axis", 1);
@@ -450,6 +504,206 @@ TEST(ScatterElements, MinReduction_Double) {
   test.AddOutput<double>("y", {2, 3}, {-9.f, -4.f, -1.f, 1.f, -3.f, 3.f});
 
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
+}
+
+namespace {
+
+template <typename T, typename TIndex = int64_t>
+void RunCudaScatterElementsReduction(const char* dtype_name, const char* reduction, T data, T update, T expected,
+                                     int opset = 18) {
+  SCOPED_TRACE(testing::Message() << "dtype=" << dtype_name << ", reduction=" << reduction << ", opset=" << opset);
+  OpTester test("ScatterElements", opset);
+  test.AddAttribute<int64_t>("axis", 0);
+  test.AddAttribute<std::string>("reduction", reduction);
+  test.AddInput<T>("data", {1}, {data});
+  test.AddInput<TIndex>("indices", {1}, {0});
+  test.AddInput<T>("updates", {1}, {update});
+  test.AddOutput<T>("y", {1}, {expected});
+#if defined(USE_CUDA)
+  auto cuda_ep = DefaultCudaExecutionProvider();
+  ASSERT_NE(cuda_ep, nullptr);
+  test.ConfigEp(std::move(cuda_ep)).RunWithConfig();
+#else
+  GTEST_SKIP() << "CUDA is required for CUDA ScatterElements dtype coverage.";
+#endif
+}
+
+template <typename T, typename TIndex = int64_t>
+void RunCudaScatterElementsAddContention(const char* dtype_name, T data, T update, T expected,
+                                         size_t update_count) {
+  SCOPED_TRACE(testing::Message() << "dtype=" << dtype_name << ", updates=" << update_count);
+  OpTester test("ScatterElements", 18);
+  test.AddAttribute<int64_t>("axis", 0);
+  test.AddAttribute<std::string>("reduction", "add");
+  test.AddInput<T>("data", {1}, {data});
+  test.AddInput<TIndex>("indices", {static_cast<int64_t>(update_count)}, std::vector<TIndex>(update_count, 0));
+  test.AddInput<T>("updates", {static_cast<int64_t>(update_count)}, std::vector<T>(update_count, update));
+  test.AddOutput<T>("y", {1}, {expected});
+#if defined(USE_CUDA)
+  auto cuda_ep = DefaultCudaExecutionProvider();
+  ASSERT_NE(cuda_ep, nullptr);
+  test.ConfigEp(std::move(cuda_ep)).RunWithConfig();
+#else
+  GTEST_SKIP() << "CUDA is required for CUDA ScatterElements contention coverage.";
+#endif
+}
+
+void RunCudaScatterElementsBoolReduction(const char* reduction, bool data, bool update, bool expected) {
+  SCOPED_TRACE(testing::Message() << "dtype=bool, reduction=" << reduction);
+  OpTester test("ScatterElements", 18);
+  test.AddAttribute<int64_t>("axis", 0);
+  test.AddAttribute<std::string>("reduction", reduction);
+  test.AddInput<bool>("data", {1}, {data});
+  test.AddInput<int64_t>("indices", {1}, {0});
+  test.AddInput<bool>("updates", {1}, {update});
+  test.AddOutput<bool>("y", {1}, {expected});
+  test.SetCustomOutputVerifier([expected](const std::vector<OrtValue>& fetches, const std::string& provider_type) {
+    ASSERT_EQ(provider_type, kCudaExecutionProvider);
+    ASSERT_EQ(fetches.size(), 1u);
+    ASSERT_TRUE(fetches[0].IsTensor());
+    const auto& output = fetches[0].Get<Tensor>();
+    ASSERT_EQ(output.Shape().Size(), 1);
+    EXPECT_EQ(output.Data<bool>()[0], expected);
+    EXPECT_EQ(static_cast<const uint8_t*>(output.DataRaw())[0], expected ? 1u : 0u);
+  });
+#if defined(USE_CUDA)
+  auto cuda_ep = DefaultCudaExecutionProvider();
+  ASSERT_NE(cuda_ep, nullptr);
+  test.ConfigEp(std::move(cuda_ep)).RunWithConfig();
+#else
+  GTEST_SKIP() << "CUDA is required for CUDA ScatterElements bool coverage.";
+#endif
+}
+
+}  // namespace
+
+TEST(ScatterElements, FullDTypeInt8Smoke) {
+  RunCudaScatterElementsReduction<int8_t>("int8", "max", -5, 3, 3);
+}
+
+TEST(ScatterElements, FullDTypeUInt8) {
+  RunCudaScatterElementsReduction<uint8_t>("uint8", "add", 200, 20, 220);
+  RunCudaScatterElementsReduction<uint8_t>("uint8", "mul", 12, 11, 132);
+  RunCudaScatterElementsReduction<uint8_t>("uint8", "min", 200, 100, 100);
+  RunCudaScatterElementsReduction<uint8_t>("uint8", "max", 200, 100, 200);
+}
+
+TEST(ScatterElements, FullDTypeInt16) {
+  RunCudaScatterElementsReduction<int16_t>("int16", "add", 0x3c00, 0x3c00, 0x7800);
+  RunCudaScatterElementsReduction<int16_t>("int16", "mul", 2, 3, 6);
+  RunCudaScatterElementsReduction<int16_t>("int16", "min", -17408, -16384, -17408);
+  RunCudaScatterElementsReduction<int16_t>("int16", "max", -17408, -16384, -16384);
+}
+
+TEST(ScatterElements, FullDTypeUInt16) {
+  RunCudaScatterElementsReduction<uint16_t>("uint16", "add", 0x3c00, 0x3c00, 0x7800);
+  RunCudaScatterElementsReduction<uint16_t>("uint16", "mul", 2, 3, 6);
+  RunCudaScatterElementsReduction<uint16_t>("uint16", "min", 0xbc00, 0xc000, 0xbc00);
+  RunCudaScatterElementsReduction<uint16_t>("uint16", "max", 0xbc00, 0xc000, 0xc000);
+}
+
+TEST(ScatterElements, FullDTypeInt32) {
+  RunCudaScatterElementsReduction<int32_t>("int32", "add", 0x3f800000, 0x3f800000, 0x7f000000);
+  RunCudaScatterElementsReduction<int32_t>("int32", "mul", 2, 3, 6);
+  RunCudaScatterElementsReduction<int32_t>("int32", "min", -1082130432, -1073741824, -1082130432);
+  RunCudaScatterElementsReduction<int32_t>("int32", "max", -1082130432, -1073741824, -1073741824);
+}
+
+TEST(ScatterElements, FullDTypeUInt32) {
+  RunCudaScatterElementsReduction<uint32_t>("uint32", "add", 0x3f800000u, 0x3f800000u, 0x7f000000u);
+  RunCudaScatterElementsReduction<uint32_t>("uint32", "mul", 2u, 3u, 6u);
+  RunCudaScatterElementsReduction<uint32_t>("uint32", "min", 0xbf800000u, 0x3f800000u, 0x3f800000u);
+  RunCudaScatterElementsReduction<uint32_t>("uint32", "max", 0xbf800000u, 0x3f800000u, 0xbf800000u);
+}
+
+TEST(ScatterElements, FullDTypeInt64) {
+  RunCudaScatterElementsReduction<int64_t>("int64", "add", 0x3ff0000000000000LL, 0x3ff0000000000000LL,
+                                           0x7fe0000000000000LL);
+  RunCudaScatterElementsReduction<int64_t>("int64", "mul", 2, 3, 6);
+  RunCudaScatterElementsReduction<int64_t>("int64", "min", -4616189618054758400LL, -4611686018427387904LL,
+                                           -4616189618054758400LL);
+  RunCudaScatterElementsReduction<int64_t>("int64", "max", -4616189618054758400LL, -4611686018427387904LL,
+                                           -4611686018427387904LL);
+}
+
+TEST(ScatterElements, FullDTypeUInt64) {
+  RunCudaScatterElementsReduction<uint64_t>("uint64", "add", 0x3ff0000000000000ULL, 0x3ff0000000000000ULL,
+                                            0x7fe0000000000000ULL);
+  RunCudaScatterElementsReduction<uint64_t>("uint64", "mul", 2, 3, 6);
+  RunCudaScatterElementsReduction<uint64_t>("uint64", "min", 0xbff0000000000000ULL, 0xc000000000000000ULL,
+                                            0xbff0000000000000ULL);
+  RunCudaScatterElementsReduction<uint64_t>("uint64", "max", 0xbff0000000000000ULL, 0xc000000000000000ULL,
+                                            0xc000000000000000ULL);
+}
+
+TEST(ScatterElements, FullDTypeBFloat16) {
+  RunCudaScatterElementsReduction<BFloat16>("BFloat16", "add", BFloat16::FromBits(0x3f80),
+                                            BFloat16::FromBits(0x3f80), BFloat16::FromBits(0x4000));
+  RunCudaScatterElementsReduction<BFloat16>("BFloat16", "mul", BFloat16::FromBits(0x4000),
+                                            BFloat16::FromBits(0x4040), BFloat16::FromBits(0x40c0));
+  RunCudaScatterElementsReduction<BFloat16>("BFloat16", "min", BFloat16::FromBits(0x7f80),
+                                            BFloat16::FromBits(0x3f80), BFloat16::FromBits(0x3f80));
+  RunCudaScatterElementsReduction<BFloat16>("BFloat16", "max", BFloat16::FromBits(0x3f80),
+                                            BFloat16::FromBits(0x7f80), BFloat16::FromBits(0x7f80));
+}
+
+TEST(ScatterElements, BoolReductionsAndCanonicalStorage) {
+  RunCudaScatterElementsBoolReduction("add", false, true, true);
+  RunCudaScatterElementsBoolReduction("add", true, true, true);
+  RunCudaScatterElementsBoolReduction("mul", true, false, false);
+  RunCudaScatterElementsBoolReduction("min", true, false, false);
+  RunCudaScatterElementsBoolReduction("min", true, true, true);
+  RunCudaScatterElementsBoolReduction("max", false, true, true);
+  RunCudaScatterElementsBoolReduction("max", false, false, false);
+}
+
+TEST(ScatterElements, Opset16Int32IndicesAdd) {
+  RunCudaScatterElementsReduction<uint32_t, int32_t>("uint32", "add", 0x3f800000u, 0x3f800000u, 0x7f000000u, 16);
+}
+
+TEST(ScatterElements, Opset17Int64IndicesMul) {
+  RunCudaScatterElementsReduction<int64_t, int64_t>("int64", "mul", 2, 3, 6, 17);
+}
+
+TEST(ScatterElements, ContentionPacked8Bit) {
+  RunCudaScatterElementsAddContention<uint8_t>("uint8", 1, 1, 201, 200);
+}
+
+TEST(ScatterElements, ContentionPacked16Bit) {
+  RunCudaScatterElementsAddContention<uint16_t>("uint16", 1, 1, 513, 512);
+}
+
+TEST(ScatterElements, ContentionNative32Bit) {
+  RunCudaScatterElementsAddContention<int32_t>("int32", 1, 1, 4097, 4096);
+}
+
+TEST(ScatterElements, ContentionNative64Bit) {
+  RunCudaScatterElementsAddContention<uint64_t>("uint64", 1, 1, 4097, 4096);
+}
+
+TEST(ScatterElements, ContentionBFloat16) {
+  RunCudaScatterElementsAddContention<BFloat16>("BFloat16", BFloat16(0.0f), BFloat16(1.0f), BFloat16(128.0f), 128);
+}
+
+TEST(ScatterElements, ContentionBoolLogical) {
+  constexpr size_t update_count = 512;
+  OpTester test("ScatterElements", 18);
+  test.AddAttribute<int64_t>("axis", 0);
+  test.AddAttribute<std::string>("reduction", "mul");
+  test.AddInput<bool>("data", {1}, {true});
+  test.AddInput<int64_t>("indices", {static_cast<int64_t>(update_count)}, std::vector<int64_t>(update_count, 0));
+  auto updates = std::make_unique<bool[]>(update_count);
+  std::fill_n(updates.get(), update_count, true);
+  updates[update_count / 2] = false;
+  test.AddInput<bool>("updates", {static_cast<int64_t>(update_count)}, updates.get(), update_count);
+  test.AddOutput<bool>("y", {1}, {false});
+#if defined(USE_CUDA)
+  auto cuda_ep = DefaultCudaExecutionProvider();
+  ASSERT_NE(cuda_ep, nullptr);
+  test.ConfigEp(std::move(cuda_ep)).RunWithConfig();
+#else
+  GTEST_SKIP() << "CUDA is required for CUDA ScatterElements contention coverage.";
+#endif
 }
 
 }  // namespace test

--- a/onnxruntime/test/providers/cpu/tensor/scatter_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/scatter_op_test.cc
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <cstdlib>
 #include <ctime>
+#include <limits>
 #include <memory>
 
 #include "gtest/gtest.h"
@@ -511,6 +512,9 @@ namespace {
 template <typename T, typename TIndex = int64_t>
 void RunCudaScatterElementsReduction(const char* dtype_name, const char* reduction, T data, T update, T expected,
                                      int opset = 18) {
+#if !defined(USE_CUDA)
+  GTEST_SKIP() << "CUDA is required for CUDA ScatterElements dtype coverage.";
+#endif
   SCOPED_TRACE(testing::Message() << "dtype=" << dtype_name << ", reduction=" << reduction << ", opset=" << opset);
   OpTester test("ScatterElements", opset);
   test.AddAttribute<int64_t>("axis", 0);
@@ -523,14 +527,15 @@ void RunCudaScatterElementsReduction(const char* dtype_name, const char* reducti
   auto cuda_ep = DefaultCudaExecutionProvider();
   ASSERT_NE(cuda_ep, nullptr);
   test.ConfigEp(std::move(cuda_ep)).RunWithConfig();
-#else
-  GTEST_SKIP() << "CUDA is required for CUDA ScatterElements dtype coverage.";
 #endif
 }
 
 template <typename T, typename TIndex = int64_t>
 void RunCudaScatterElementsAddContention(const char* dtype_name, T data, T update, T expected,
                                          size_t update_count) {
+#if !defined(USE_CUDA)
+  GTEST_SKIP() << "CUDA is required for CUDA ScatterElements contention coverage.";
+#endif
   SCOPED_TRACE(testing::Message() << "dtype=" << dtype_name << ", updates=" << update_count);
   OpTester test("ScatterElements", 18);
   test.AddAttribute<int64_t>("axis", 0);
@@ -543,12 +548,13 @@ void RunCudaScatterElementsAddContention(const char* dtype_name, T data, T updat
   auto cuda_ep = DefaultCudaExecutionProvider();
   ASSERT_NE(cuda_ep, nullptr);
   test.ConfigEp(std::move(cuda_ep)).RunWithConfig();
-#else
-  GTEST_SKIP() << "CUDA is required for CUDA ScatterElements contention coverage.";
 #endif
 }
 
 void RunCudaScatterElementsBoolReduction(const char* reduction, bool data, bool update, bool expected) {
+#if !defined(USE_CUDA)
+  GTEST_SKIP() << "CUDA is required for CUDA ScatterElements bool coverage.";
+#endif
   SCOPED_TRACE(testing::Message() << "dtype=bool, reduction=" << reduction);
   OpTester test("ScatterElements", 18);
   test.AddAttribute<int64_t>("axis", 0);
@@ -570,8 +576,6 @@ void RunCudaScatterElementsBoolReduction(const char* reduction, bool data, bool 
   auto cuda_ep = DefaultCudaExecutionProvider();
   ASSERT_NE(cuda_ep, nullptr);
   test.ConfigEp(std::move(cuda_ep)).RunWithConfig();
-#else
-  GTEST_SKIP() << "CUDA is required for CUDA ScatterElements bool coverage.";
 #endif
 }
 
@@ -598,12 +602,16 @@ TEST(ScatterElements, FullDTypeInt16) {
 TEST(ScatterElements, FullDTypeUInt16) {
   RunCudaScatterElementsReduction<uint16_t>("uint16", "add", 0x3c00, 0x3c00, 0x7800);
   RunCudaScatterElementsReduction<uint16_t>("uint16", "mul", 2, 3, 6);
+  RunCudaScatterElementsReduction<uint16_t>("uint16", "mul", 50000, 2, 34464);
   RunCudaScatterElementsReduction<uint16_t>("uint16", "min", 0xbc00, 0xc000, 0xbc00);
   RunCudaScatterElementsReduction<uint16_t>("uint16", "max", 0xbc00, 0xc000, 0xc000);
 }
 
+// These IEEE 1.0 bit patterns are intentional: they detect accidental float/double representative dispatch.
 TEST(ScatterElements, FullDTypeInt32) {
   RunCudaScatterElementsReduction<int32_t>("int32", "add", 0x3f800000, 0x3f800000, 0x7f000000);
+  RunCudaScatterElementsReduction<int32_t>("int32", "add", std::numeric_limits<int32_t>::max(), 1,
+                                           std::numeric_limits<int32_t>::min());
   RunCudaScatterElementsReduction<int32_t>("int32", "mul", 2, 3, 6);
   RunCudaScatterElementsReduction<int32_t>("int32", "min", -1082130432, -1073741824, -1082130432);
   RunCudaScatterElementsReduction<int32_t>("int32", "max", -1082130432, -1073741824, -1073741824);
@@ -620,6 +628,7 @@ TEST(ScatterElements, FullDTypeInt64) {
   RunCudaScatterElementsReduction<int64_t>("int64", "add", 0x3ff0000000000000LL, 0x3ff0000000000000LL,
                                            0x7fe0000000000000LL);
   RunCudaScatterElementsReduction<int64_t>("int64", "mul", 2, 3, 6);
+  RunCudaScatterElementsReduction<int64_t>("int64", "mul", std::numeric_limits<int64_t>::max(), 2, -2);
   RunCudaScatterElementsReduction<int64_t>("int64", "min", -4616189618054758400LL, -4611686018427387904LL,
                                            -4616189618054758400LL);
   RunCudaScatterElementsReduction<int64_t>("int64", "max", -4616189618054758400LL, -4611686018427387904LL,
@@ -669,6 +678,35 @@ TEST(ScatterElements, ContentionPacked8Bit) {
   RunCudaScatterElementsAddContention<uint8_t>("uint8", 1, 1, 201, 200);
 }
 
+TEST(ScatterElements, ContentionAdjacentPacked8BitLanes) {
+#if !defined(USE_CUDA)
+  GTEST_SKIP() << "CUDA is required for CUDA ScatterElements contention coverage.";
+#endif
+  constexpr size_t updates_per_lane = 64;
+  constexpr size_t lane_count = 4;
+  std::vector<int64_t> indices;
+  indices.reserve(updates_per_lane * lane_count);
+  for (size_t i = 0; i < updates_per_lane; ++i) {
+    for (size_t lane = 0; lane < lane_count; ++lane) {
+      indices.push_back(static_cast<int64_t>(lane));
+    }
+  }
+
+  OpTester test("ScatterElements", 18);
+  test.AddAttribute<int64_t>("axis", 0);
+  test.AddAttribute<std::string>("reduction", "add");
+  test.AddInput<uint8_t>("data", {4}, {1, 2, 3, 4});
+  test.AddInput<int64_t>("indices", {static_cast<int64_t>(indices.size())}, indices);
+  test.AddInput<uint8_t>("updates", {static_cast<int64_t>(indices.size())},
+                         std::vector<uint8_t>(indices.size(), 1));
+  test.AddOutput<uint8_t>("y", {4}, {65, 66, 67, 68});
+#if defined(USE_CUDA)
+  auto cuda_ep = DefaultCudaExecutionProvider();
+  ASSERT_NE(cuda_ep, nullptr);
+  test.ConfigEp(std::move(cuda_ep)).RunWithConfig();
+#endif
+}
+
 TEST(ScatterElements, ContentionPacked16Bit) {
   RunCudaScatterElementsAddContention<uint16_t>("uint16", 1, 1, 513, 512);
 }
@@ -686,6 +724,9 @@ TEST(ScatterElements, ContentionBFloat16) {
 }
 
 TEST(ScatterElements, ContentionBoolLogical) {
+#if !defined(USE_CUDA)
+  GTEST_SKIP() << "CUDA is required for CUDA ScatterElements contention coverage.";
+#endif
   constexpr size_t update_count = 512;
   OpTester test("ScatterElements", 18);
   test.AddAttribute<int64_t>("axis", 0);
@@ -701,8 +742,6 @@ TEST(ScatterElements, ContentionBoolLogical) {
   auto cuda_ep = DefaultCudaExecutionProvider();
   ASSERT_NE(cuda_ep, nullptr);
   test.ConfigEp(std::move(cuda_ep)).RunWithConfig();
-#else
-  GTEST_SKIP() << "CUDA is required for CUDA ScatterElements contention coverage.";
 #endif
 }
 


### PR DESCRIPTION
### Description

This PR fixes incorrect CUDA `ScatterElements` results for arithmetic reductions on element types that share the same byte width but have different numeric semantics.

The current CUDA implementation selects representative template types by element size:

* 1 byte → `int8_t`
* 2 bytes → `half`
* 4 bytes → `float`
* 8 bytes → `double`

This is valid for `reduction="none"`, where values are copied without numeric interpretation. It is incorrect for `add`, `mul`, `min`, and `max`, which must operate using the tensor's actual element type.

This change preserves byte-width dispatch for `reduction="none"` and uses actual element-type dispatch for arithmetic reductions.

### Motivation and Context

The existing dispatch can silently evaluate one numeric type using another type's semantics.

For example:

```text
data type: int32
data:      [2]
indices:   [0]
updates:   [3]
reduction: mul

expected:             [6]
previous CUDA result: [0]
```

Because `int32` is four bytes wide, the previous dispatcher selected the `float` specialization. The input and update bit patterns were therefore interpreted and multiplied as floating-point values rather than integers.

The byte-width dispatch was originally used to reduce template specializations for the assignment path. When CUDA arithmetic reductions were later added, the same representative-type dispatch remained in place.

Byte width is sufficient when only the stored bits matter. It is not sufficient when the operation depends on the numeric meaning of those bits.

The CUDA kernel is registered for all fixed-size tensor types and accepts these reductions, so returning incorrect values for the affected combinations is a correctness issue in the existing supported path.

### Implementation

* Keep the existing representative-type dispatch for `reduction="none"`.
* Dispatch `add`, `mul`, `min`, and `max` using the input tensor's actual element type.
* Add the concrete `ScatterElements` template instantiations required by the corrected dispatch.
* Extend the existing CAS-based atomic helper pattern with overloads for the additional registered types.
* Add regression tests for the affected dtype and reduction combinations.

`GatherElements` and `ScatterElements` previously shared one explicit-instantiation macro because both used the same representative types.

Arithmetic `ScatterElements` now requires semantic element types, while `GatherElements` still only copies values and can retain the existing representative instantiations. The macros are therefore separated so that the additional instantiations are limited to `ScatterElements` rather than unnecessarily expanding the Gather path.

Multiple updates may target the same output element, so arithmetic reductions require atomic updates. The new overloads reuse the existing generic CAS implementations instead of introducing separate atomic algorithms for each type.

For `bool`, the corrected dispatch matches the ONNX reference semantics:

* `add` and `max` use logical OR;
* `mul` and `min` use logical AND.

Boolean results are stored canonically as `0` or `1`, correcting the previous one-byte representative path's possible non-canonical result for `add(true, true)`.

This change does not modify the ONNX schema, public API, registered element types, CPU provider, ROCm provider, or the existing `reduction="none"` behavior.

### Validation

The regression coverage includes:

* `add`, `mul`, `min`, and `max`;
* signed and unsigned integer types;
* floating-point types and `BFloat16`;
* `bool` reductions and canonical `0`/`1` storage;
* both `int32` and `int64` indices;
* duplicate-index contention paths;
* representative types that were already correct;
* preservation of `reduction="none"` behavior.

Local validation results:

* Release CUDA `onnxruntime_provider_test` build: passed
* Focused `ScatterElements` regression tests: 19/19 passed
* Focused dtype-dispatch regression cases: 5/5 passed
* `Scatter.*:ScatterElements.*`: 46/46 passed
* Repeated contention stress cases: 600/600 passed
* Lintrunner on the four modified files: passed
* `git diff --check`: passed

Validation environment:

```text
WSL2 Ubuntu 24.04
NVIDIA RTX 4060 Laptop GPU (SM89)
CUDA 12.8
cuDNN 9.7.1
Release configuration
```
