### PR TITLE
[OpenVINO EP] Fix constant output mis-routing for names containing '/'

### DIFF
--- a/onnxruntime/core/providers/openvino/backend_utils.cc
+++ b/onnxruntime/core/providers/openvino/backend_utils.cc
@@ -96,14 +96,20 @@ GetOutputTensor(Ort::KernelContext& context,
                 std::string output_name,
                 const SubGraphContext::string_index_map_t& output_names,
                 std::shared_ptr<ov::Node> node) {
-  // Find position of '/' in the output_name
-  auto pos = output_name.find("/");
-  // Copy the substring from start to pos
-  output_name = output_name.substr(0, pos);
-
+  // OpenVINO appends a single '/'-separated suffix (e.g. "/sink_port_0") to the
+  // output name. ONNX output names may themselves contain '/', so match the full
+  // name first and only strip the trailing suffix (from the LAST '/') if that
+  // fails. Truncating at the FIRST '/' instead would alias e.g.
+  // "D/x/sink_port_0" onto a different output named "D".
   auto it = output_names.find(output_name);
   if (it == output_names.end()) {
-    ORT_THROW(log_tag + "Output names mismatch between OpenVINO and ONNX");
+    auto pos = output_name.rfind('/');
+    if (pos != std::string::npos) {
+      it = output_names.find(output_name.substr(0, pos));
+    }
+    if (it == output_names.end()) {
+      ORT_THROW(log_tag + "Output names mismatch between OpenVINO and ONNX");
+    }
   }
   int index = it->second;
   auto output_shape = ParameterShape::ToOrtShape(node->get_shape());
@@ -203,6 +209,16 @@ void FillOutputsWithConstantData(std::shared_ptr<ov::Node> node, Ort::UnownedVal
 template <typename T>
 void FillOutputHelper(Ort::UnownedValue& out_tensor, std::shared_ptr<ov::Node> node) {
   auto const_node = std::dynamic_pointer_cast<ov::op::v0::Constant>(node);
+  // Bounds-check in bytes before materializing the data: std::copy below writes
+  // (element count) * sizeof(T) bytes, which must match the output buffer size.
+  // Throw rather than overrun.
+  const size_t bytes_to_write = ov::shape_size(const_node->get_shape()) * sizeof(T);
+  const size_t out_bytes = out_tensor.GetTensorSizeInBytes();
+  if (bytes_to_write != out_bytes) {
+    ORT_THROW(log_tag + "Constant output size (" + std::to_string(bytes_to_write) +
+              " bytes) does not match bound output tensor size (" +
+              std::to_string(out_bytes) + " bytes)");
+  }
   auto res = const_node->cast_vector<T>();
   T* tensor_data = out_tensor.GetTensorMutableData<T>();
   std::copy(res.begin(), res.end(), tensor_data);

--- a/onnxruntime/test/providers/openvino/openvino_ep_context_test.cc
+++ b/onnxruntime/test/providers/openvino/openvino_ep_context_test.cc
@@ -33,6 +33,8 @@ extern std::unique_ptr<Ort::Env> ort_env;
 
 namespace {
 
+using onnxruntime::MLFloat16;
+
 // Returns true only on Intel CPUs.
 //
 // The OVIR EP context tests are gated on this because that path is currently
@@ -66,6 +68,110 @@ void RunAndValidate(Ort::Session& session) {
   const float* out_data = output_tensors[0].GetTensorData<float>();
   EXPECT_THAT(std::vector<float>(out_data, out_data + 6),
               ::testing::ElementsAre(2.f, 4.f, 6.f, 8.f, 10.f, 12.f));
+}
+
+void AddFloat16Initializer(ONNX_NAMESPACE::GraphProto* graph,
+                           const std::string& name,
+                           const std::vector<int64_t>& shape,
+                           const std::vector<float>& values) {
+  auto* init = graph->add_initializer();
+  init->set_name(name);
+  init->set_data_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT16);
+  for (int64_t d : shape) {
+    init->add_dims(d);
+  }
+  std::vector<uint16_t> bits;
+  bits.reserve(values.size());
+  for (float v : values) {
+    bits.push_back(MLFloat16(v).val);
+  }
+  init->set_raw_data(bits.data(), bits.size() * sizeof(uint16_t));
+}
+
+void AddValueInfo(ONNX_NAMESPACE::ValueInfoProto* vi,
+                  const std::string& name,
+                  ONNX_NAMESPACE::TensorProto_DataType elem_type,
+                  const std::vector<int64_t>& shape) {
+  vi->set_name(name);
+  auto* type = vi->mutable_type()->mutable_tensor_type();
+  type->set_elem_type(elem_type);
+  auto* vi_shape = type->mutable_shape();
+  for (int64_t d : shape) {
+    vi_shape->add_dim()->set_dim_value(d);
+  }
+}
+
+ONNX_NAMESPACE::NodeProto* AddNode(ONNX_NAMESPACE::GraphProto* graph,
+                                   const std::string& op_type,
+                                   const std::string& name,
+                                   const std::vector<std::string>& inputs,
+                                   const std::string& output) {
+  auto* n = graph->add_node();
+  n->set_op_type(op_type);
+  n->set_name(name);
+  for (const auto& in : inputs) {
+    n->add_input(in);
+  }
+  n->add_output(output);
+  return n;
+}
+
+// Adds a RandomUniformLike sink so the graph is not wholly supported by OVEP;
+// this forces partitioning, which is what runs the constant folding pass that
+// populates the constant-output map exercised by tests.
+void AddUnsupportedSink(ONNX_NAMESPACE::GraphProto* graph, const std::string& input) {
+  auto* n = AddNode(graph, "RandomUniformLike", "unsupported_sink", {input}, "Z");
+  auto* attr = n->add_attribute();
+  attr->set_name("dtype");
+  attr->set_type(ONNX_NAMESPACE::AttributeProto_AttributeType_INT);
+  attr->set_i(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+}
+
+// Runs an OVEP constant-output model and returns the requested f16 output as
+// floats. Uses "AUTO:CPU" (not plain "CPU"): plain "CPU" takes OVEP's unified-
+// compile fast path and never reaches CreateOVModel where the folding lives.
+// ORT-side optimizations are disabled so OVEP (not ORT) folds the constants,
+// which is what routes them through the constant-output fill path under test.
+// The runtime input's values never affect the constant outputs, so it is fed
+// as an all-zero tensor of the given shape. Asserts the output is f16.
+std::vector<float> RunConstantOutput(const std::string& model_data,
+                                     const std::string& input_name,
+                                     const std::vector<int64_t>& input_shape,
+                                     const char* output_name,
+                                     size_t& out_element_count) {
+  Ort::SessionOptions session_options;
+  session_options.SetGraphOptimizationLevel(ORT_DISABLE_ALL);
+  std::unordered_map<std::string, std::string> ov_options = {{"device_type", "AUTO:CPU"}};
+  session_options.AppendExecutionProvider_OpenVINO_V2(ov_options);
+  Ort::Session session(*ort_env, model_data.data(), model_data.size(), session_options);
+
+  int64_t input_count = 1;
+  for (int64_t d : input_shape) {
+    input_count *= d;
+  }
+  Ort::MemoryInfo mem_info = Ort::MemoryInfo::CreateCpu(OrtAllocatorType::OrtDeviceAllocator, OrtMemTypeDefault);
+  std::vector<uint16_t> input_bits(static_cast<size_t>(input_count), MLFloat16(0.0f).val);
+  Ort::Value input_tensor = Ort::Value::CreateTensor(
+      mem_info, input_bits.data(), input_bits.size() * sizeof(uint16_t),
+      input_shape.data(), input_shape.size(), ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16);
+
+  const std::array<const char*, 1> input_names = {input_name.c_str()};
+  const std::array<const char*, 1> output_names = {output_name};
+  std::vector<Ort::Value> output_tensors(1);
+  session.Run(Ort::RunOptions{nullptr}, input_names.data(), &input_tensor, 1,
+              output_names.data(), output_tensors.data(), 1);
+
+  EXPECT_TRUE(output_tensors[0].IsTensor());
+  auto type_shape = output_tensors[0].GetTensorTypeAndShapeInfo();
+  EXPECT_EQ(type_shape.GetElementType(), ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16);
+  out_element_count = type_shape.GetElementCount();
+  const MLFloat16* out_data = output_tensors[0].GetTensorData<MLFloat16>();
+  std::vector<float> result;
+  result.reserve(out_element_count);
+  for (size_t i = 0; i < out_element_count; ++i) {
+    result.push_back(out_data[i].ToFloat());
+  }
+  return result;
 }
 
 }  // namespace
@@ -336,113 +442,149 @@ TEST(OVEPConstantOutputTests, FillsFloat16ConstantOutput) {
   auto* graph = model.mutable_graph();
   graph->set_name("const_f16_add");
 
-  auto add_f16_initializer = [&](const std::string& name, const std::vector<float>& values) {
-    auto* init = graph->add_initializer();
-    init->set_name(name);
-    init->set_data_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT16);
-    for (int64_t d : shape) {
-      init->add_dims(d);
-    }
-    std::vector<uint16_t> bits;
-    for (float v : values) {
-      bits.push_back(MLFloat16(v).val);
-    }
-    init->set_raw_data(bits.data(), bits.size() * sizeof(uint16_t));
-  };
-  add_f16_initializer("A", a_f);
-  add_f16_initializer("B", b_f);
-
-  auto add_tensor_value_info = [&](const std::string& name,
-                                   ONNX_NAMESPACE::TensorProto_DataType elem_type,
-                                   ONNX_NAMESPACE::ValueInfoProto* vi) {
-    vi->set_name(name);
-    auto* type = vi->mutable_type()->mutable_tensor_type();
-    type->set_elem_type(elem_type);
-    auto* vi_shape = type->mutable_shape();
-    for (int64_t d : shape) {
-      vi_shape->add_dim()->set_dim_value(d);
-    }
-  };
+  AddFloat16Initializer(graph, "A", shape, a_f);
+  AddFloat16Initializer(graph, "B", shape, b_f);
 
   // Runtime input; only exists so the constant branch shares a cluster with a
   // non-initializer input. Its values do not affect C.
-  add_tensor_value_info("X", ONNX_NAMESPACE::TensorProto_DataType_FLOAT16, graph->add_input());
+  AddValueInfo(graph->add_input(), "X", ONNX_NAMESPACE::TensorProto_DataType_FLOAT16, shape);
 
   // Constant branch: OpenVINO folds Add(A, B) into the f16 Constant output C.
-  {
-    auto* n = graph->add_node();
-    n->set_op_type("Add");
-    n->set_name("add_const");
-    n->add_input("A");
-    n->add_input("B");
-    n->add_output("C");
-  }
+  AddNode(graph, "Add", "add_const", {"A", "B"}, "C");
   // Pulls C into a cluster that has a runtime input (X), so it isn't dropped.
-  {
-    auto* n = graph->add_node();
-    n->set_op_type("Add");
-    n->set_name("add_runtime");
-    n->add_input("X");
-    n->add_input("C");
-    n->add_output("Y");
-  }
+  AddNode(graph, "Add", "add_runtime", {"X", "C"}, "Y");
   // Unsupported by OVEP -> forces partitioning so the folding pass runs.
-  // dtype=float selects the CPU fallback kernel; the values are unused.
-  {
-    auto* n = graph->add_node();
-    n->set_op_type("RandomUniformLike");
-    n->set_name("unsupported_sink");
-    n->add_input("X");
-    n->add_output("Z");
-    auto* attr = n->add_attribute();
-    attr->set_name("dtype");
-    attr->set_type(ONNX_NAMESPACE::AttributeProto_AttributeType_INT);
-    attr->set_i(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
-  }
+  AddUnsupportedSink(graph, "X");
 
-  add_tensor_value_info("C", ONNX_NAMESPACE::TensorProto_DataType_FLOAT16, graph->add_output());
-  add_tensor_value_info("Y", ONNX_NAMESPACE::TensorProto_DataType_FLOAT16, graph->add_output());
-  add_tensor_value_info("Z", ONNX_NAMESPACE::TensorProto_DataType_FLOAT, graph->add_output());
+  AddValueInfo(graph->add_output(), "C", ONNX_NAMESPACE::TensorProto_DataType_FLOAT16, shape);
+  AddValueInfo(graph->add_output(), "Y", ONNX_NAMESPACE::TensorProto_DataType_FLOAT16, shape);
+  AddValueInfo(graph->add_output(), "Z", ONNX_NAMESPACE::TensorProto_DataType_FLOAT, shape);
 
   std::string model_data;
   model.SerializeToString(&model_data);
 
-  Ort::SessionOptions session_options;
-  // Disable ORT-side graph optimizations so Add(A, B) is not constant-folded by
-  // ORT before the OpenVINO EP sees it; OVEP must be the one that folds it, which
-  // is what routes C through the constant-output fill path.
-  session_options.SetGraphOptimizationLevel(ORT_DISABLE_ALL);
-  std::unordered_map<std::string, std::string> ov_options = {{"device_type", "AUTO:CPU"}};
-  session_options.AppendExecutionProvider_OpenVINO_V2(ov_options);
+  size_t count_c = 0;
+  std::vector<float> actual = RunConstantOutput(model_data, "X", shape, "C", count_c);
+  EXPECT_EQ(count_c, expected.size());
+  EXPECT_THAT(actual, ::testing::ElementsAreArray(expected));
+}
 
-  Ort::Session session(*ort_env, model_data.data(), model_data.size(), session_options);
+// Two same-shape constant outputs "D" and "D/x" whose names collide under
+// '/'-truncation. Before the fix, "D/x"'s constant landed in "D"'s slot, so "D"
+// returned Mul(A, B) instead of Add(A, B).
+TEST(OVEPConstantOutputTests, RoutesConstantToCorrectOutputOnNameCollision) {
+  const std::vector<int64_t> shape = {3};
+  const std::vector<float> a = {1.0f, 2.0f, 3.0f};
+  const std::vector<float> b = {10.0f, 20.0f, 30.0f};
+  const std::vector<float> expected_d = {11.0f, 22.0f, 33.0f};   // Add(A, B)
+  const std::vector<float> expected_dx = {10.0f, 40.0f, 90.0f};  // Mul(A, B)
 
-  // Provide the runtime input X; its values are irrelevant to C.
-  const std::array<int64_t, 2> x_shape = {3, 2};
-  std::vector<uint16_t> x_bits(6, MLFloat16(0.0f).val);
-  Ort::MemoryInfo mem_info = Ort::MemoryInfo::CreateCpu(OrtAllocatorType::OrtDeviceAllocator, OrtMemTypeDefault);
-  Ort::Value x_tensor = Ort::Value::CreateTensor(
-      mem_info, x_bits.data(), x_bits.size() * sizeof(uint16_t), x_shape.data(), x_shape.size(),
-      ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16);
+  ONNX_NAMESPACE::ModelProto model;
+  model.set_ir_version(ONNX_NAMESPACE::IR_VERSION);
+  auto* opset = model.add_opset_import();
+  opset->set_domain("");
+  opset->set_version(13);
 
-  const std::array<const char*, 1> input_names = {"X"};
-  const std::array<const char*, 1> output_names = {"C"};
-  std::vector<Ort::Value> output_tensors(1);
-  session.Run(Ort::RunOptions{nullptr}, input_names.data(), &x_tensor, 1,
-              output_names.data(), output_tensors.data(), 1);
+  auto* graph = model.mutable_graph();
+  graph->set_name("const_name_collision");
 
-  ASSERT_TRUE(output_tensors[0].IsTensor());
-  auto type_shape = output_tensors[0].GetTensorTypeAndShapeInfo();
-  ASSERT_EQ(type_shape.GetElementType(), ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16);
-  ASSERT_EQ(type_shape.GetElementCount(), expected.size());
+  AddFloat16Initializer(graph, "A", shape, a);
+  AddFloat16Initializer(graph, "B", shape, b);
+  AddValueInfo(graph->add_input(), "X", ONNX_NAMESPACE::TensorProto_DataType_FLOAT16, shape);
 
-  const MLFloat16* out_data = output_tensors[0].GetTensorData<MLFloat16>();
-  std::vector<float> actual;
-  for (size_t i = 0; i < expected.size(); ++i) {
-    actual.push_back(out_data[i].ToFloat());
+  // Two constants whose output names collide once truncated at the first '/'.
+  AddNode(graph, "Add", "add_const", {"A", "B"}, "D");
+  AddNode(graph, "Mul", "mul_const", {"A", "B"}, "D/x");
+  // Pull both constants into a cluster that has a runtime input (X) so they are
+  // not dropped as an all-initializer cluster.
+  AddNode(graph, "Add", "add_runtime_d", {"X", "D"}, "XD");
+  AddNode(graph, "Add", "add_runtime_dx", {"XD", "D/x"}, "Y");
+  AddUnsupportedSink(graph, "X");
+
+  AddValueInfo(graph->add_output(), "D", ONNX_NAMESPACE::TensorProto_DataType_FLOAT16, shape);
+  AddValueInfo(graph->add_output(), "D/x", ONNX_NAMESPACE::TensorProto_DataType_FLOAT16, shape);
+  AddValueInfo(graph->add_output(), "Y", ONNX_NAMESPACE::TensorProto_DataType_FLOAT16, shape);
+  AddValueInfo(graph->add_output(), "Z", ONNX_NAMESPACE::TensorProto_DataType_FLOAT, shape);
+
+  std::string model_data;
+  model.SerializeToString(&model_data);
+
+  size_t count_d = 0;
+  std::vector<float> actual_d = RunConstantOutput(model_data, "X", shape, "D", count_d);
+  EXPECT_EQ(count_d, expected_d.size());
+  // This is the assertion that fails before the fix: output "D" carries the
+  // "D/x" (Mul) constant instead of its own (Add) constant.
+  EXPECT_THAT(actual_d, ::testing::ElementsAreArray(expected_d));
+
+  size_t count_dx = 0;
+  std::vector<float> actual_dx = RunConstantOutput(model_data, "X", shape, "D/x", count_dx);
+  EXPECT_EQ(count_dx, expected_dx.size());
+  EXPECT_THAT(actual_dx, ::testing::ElementsAreArray(expected_dx));
+}
+
+// Same name collision but with DIFFERENT shapes ("D" is [1], "D/x" is [8]).
+// Before the fix, the 8-element "D/x" constant was routed to the 1-element "D"
+// slot; with a pre-bound fixed-size buffer that is a heap overrun, caught by
+// ASan. With the fix, "D" keeps its own [1] value. The FillOutputHelper size
+// check is the in-EP backstop for any residual mis-route, turning an overrun
+// into a thrown error.
+TEST(OVEPConstantOutputTests, KeepsConstantOutputShapeOnNameCollision) {
+  const std::vector<int64_t> small_shape = {1};
+  const std::vector<int64_t> large_shape = {8};
+  const std::vector<float> a1 = {1.0f};
+  const std::vector<float> b1 = {10.0f};
+  const std::vector<float> expected_d = {11.0f};  // Add(A1, B1)
+
+  const std::vector<float> a8 = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f};
+  const std::vector<float> b8 = {10.0f, 20.0f, 30.0f, 40.0f, 50.0f, 60.0f, 70.0f, 80.0f};
+  std::vector<float> expected_dx;  // Mul(A8, B8)
+  for (size_t i = 0; i < a8.size(); ++i) {
+    expected_dx.push_back(a8[i] * b8[i]);
   }
 
-  EXPECT_THAT(actual, ::testing::ElementsAreArray(expected));
+  ONNX_NAMESPACE::ModelProto model;
+  model.set_ir_version(ONNX_NAMESPACE::IR_VERSION);
+  auto* opset = model.add_opset_import();
+  opset->set_domain("");
+  opset->set_version(13);
+
+  auto* graph = model.mutable_graph();
+  graph->set_name("const_name_collision_mismatched");
+
+  AddFloat16Initializer(graph, "A1", small_shape, a1);
+  AddFloat16Initializer(graph, "B1", small_shape, b1);
+  AddFloat16Initializer(graph, "A8", large_shape, a8);
+  AddFloat16Initializer(graph, "B8", large_shape, b8);
+  AddValueInfo(graph->add_input(), "X8", ONNX_NAMESPACE::TensorProto_DataType_FLOAT16, large_shape);
+
+  // Small [1] constant named "D"; large [8] constant named "D/x".
+  AddNode(graph, "Add", "add_const", {"A1", "B1"}, "D");
+  AddNode(graph, "Mul", "mul_const", {"A8", "B8"}, "D/x");
+  // Keep both constants in a cluster that has the runtime input X8. "D" is
+  // broadcast-added to X8 only to anchor it to the runtime cluster; its own
+  // output value is unaffected.
+  AddNode(graph, "Add", "add_runtime_dx", {"X8", "D/x"}, "Y8");
+  AddNode(graph, "Add", "add_runtime_d", {"Y8", "D"}, "Y");
+  AddUnsupportedSink(graph, "X8");
+
+  AddValueInfo(graph->add_output(), "D", ONNX_NAMESPACE::TensorProto_DataType_FLOAT16, small_shape);
+  AddValueInfo(graph->add_output(), "D/x", ONNX_NAMESPACE::TensorProto_DataType_FLOAT16, large_shape);
+  AddValueInfo(graph->add_output(), "Y", ONNX_NAMESPACE::TensorProto_DataType_FLOAT16, large_shape);
+  AddValueInfo(graph->add_output(), "Z", ONNX_NAMESPACE::TensorProto_DataType_FLOAT, large_shape);
+
+  std::string model_data;
+  model.SerializeToString(&model_data);
+
+  size_t count_d = 0;
+  std::vector<float> actual_d = RunConstantOutput(model_data, "X8", large_shape, "D", count_d);
+  // Before the fix, output "D" is overrun / reshaped by the [8] "D/x" constant.
+  EXPECT_EQ(count_d, expected_d.size());
+  EXPECT_THAT(actual_d, ::testing::ElementsAreArray(expected_d));
+
+  size_t count_dx = 0;
+  std::vector<float> actual_dx = RunConstantOutput(model_data, "X8", large_shape, "D/x", count_dx);
+  EXPECT_EQ(count_dx, expected_dx.size());
+  EXPECT_THAT(actual_dx, ::testing::ElementsAreArray(expected_dx));
 }
 
 }  // namespace test

--- a/onnxruntime/test/providers/openvino/openvino_ep_context_test.cc
+++ b/onnxruntime/test/providers/openvino/openvino_ep_context_test.cc
@@ -4,6 +4,7 @@
 #include <array>
 #include <filesystem>
 #include <fstream>
+#include <span>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -72,8 +73,8 @@ void RunAndValidate(Ort::Session& session) {
 
 void AddFloat16Initializer(ONNX_NAMESPACE::GraphProto* graph,
                            const std::string& name,
-                           const std::vector<int64_t>& shape,
-                           const std::vector<float>& values) {
+                           std::span<const int64_t> shape,
+                           std::span<const float> values) {
   auto* init = graph->add_initializer();
   init->set_name(name);
   init->set_data_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT16);
@@ -91,7 +92,7 @@ void AddFloat16Initializer(ONNX_NAMESPACE::GraphProto* graph,
 void AddValueInfo(ONNX_NAMESPACE::ValueInfoProto* vi,
                   const std::string& name,
                   ONNX_NAMESPACE::TensorProto_DataType elem_type,
-                  const std::vector<int64_t>& shape) {
+                  std::span<const int64_t> shape) {
   vi->set_name(name);
   auto* type = vi->mutable_type()->mutable_tensor_type();
   type->set_elem_type(elem_type);
@@ -136,7 +137,7 @@ void AddUnsupportedSink(ONNX_NAMESPACE::GraphProto* graph, const std::string& in
 // as an all-zero tensor of the given shape. Asserts the output is f16.
 std::vector<float> RunConstantOutput(const std::string& model_data,
                                      const std::string& input_name,
-                                     const std::vector<int64_t>& input_shape,
+                                     std::span<const int64_t> input_shape,
                                      const char* output_name,
                                      size_t& out_element_count) {
   Ort::SessionOptions session_options;


### PR DESCRIPTION
### Description

`GetOutputTensor` in the OpenVINO EP resolved a constant-folded output's OpenVINO friendly name back to an ONNX output by truncating at the first `/` and doing an exact-string lookup. OpenVINO appends a `/sink_port_0` suffix to the friendly name, and ONNX output names may themselves contain `/`, so a name like `D/x/sink_port_0` was truncated to `D` and matched different output named `D`. The constant was then written into the wrong output's slot; with a pre-bound fixed-size output buffer this is an out-of-bounds write.

This PR:
- Matches the full friendly name first, and only strips the single trailing `/`-suffix if that fails, so names containing `/` resolve correctly.
- Adds a byte-size bounds check in `FillOutputHelper` before the `std::copy`, so any residual size mismatch throws instead of overrunning the buffer.
- Adds regression tests covering the same-shape mis-route and the mismatched-shape overrun.


