### PR TITLE
[WebGPU] Support odd-N subgroup matrix MatMul weights

### DIFF
--- a/onnxruntime/core/providers/webgpu/math/matmul.h
+++ b/onnxruntime/core/providers/webgpu/math/matmul.h
@@ -50,9 +50,18 @@ class MatMul final : public WebGpuKernel {
     const MatMul& parent_;
   };
 
-  MatMul(const OpKernelInfo& info) : WebGpuKernel{info} {}
+  MatMul(const OpKernelInfo& info) : WebGpuKernel{info} {
+    // Whether the B (weight) input is a constant initializer. The subgroup-matrix
+    // opt impl uses this to decide it can safely pad B once and cache the result
+    // (odd-N handling); a non-constant B changes per run and must not be cached.
+    const Tensor* b = nullptr;
+    b_is_constant_ = info.TryGetConstantInput(1, &b);
+  }
 
   Status ComputeInternal(ComputeContext& context) const override;
+
+  // True when input 1 (B) is a constant initializer. See b_is_constant_.
+  bool IsBConstant() const { return b_is_constant_; }
 
   constexpr static uint32_t MATMUL_PACKED_WORKGROUP_SIZE_X = 8;
   constexpr static uint32_t MATMUL_PACKED_WORKGROUP_SIZE_Y = 8;
@@ -64,6 +73,8 @@ class MatMul final : public WebGpuKernel {
   // impl_ after initialization means this device has no optimized path.
   mutable std::unique_ptr<MatMulOptImpl> impl_;
   mutable std::once_flag impl_init_flag_;
+
+  bool b_is_constant_ = false;
 };
 
 class MatMulNaiveProgram final : public Program<MatMulNaiveProgram> {

--- a/onnxruntime/core/providers/webgpu/math/subgroup_matrix_matmul.cc
+++ b/onnxruntime/core/providers/webgpu/math/subgroup_matrix_matmul.cc
@@ -18,6 +18,7 @@
 #include "core/providers/webgpu/math/subgroup_matrix_config.h"
 #include "core/providers/webgpu/shader_helper.h"
 #include "core/providers/webgpu/vendor/intel/math/subgroup_matrix_tiling_selector.h"
+#include "core/providers/webgpu/webgpu_utils.h"
 namespace onnxruntime {
 namespace webgpu {
 
@@ -213,12 +214,20 @@ class SubgroupMatrixMatMulImpl final : public MatMul::MatMulOptImpl {
 
     std::call_once(pad_once_, [&]() {
       auto padded = std::make_unique<Tensor>(context.CreateGPUTensor(b.DataType(), padded_shape));
-      SubgroupMatrixMatMulPadBProgram program;
-      program.SetDispatchGroupSize(output_size / 64 + static_cast<uint32_t>(output_size % 64 != 0))
-          .AddInput({&b, ProgramTensorMetadataDependency::TypeAndRank, 1})
-          .AddOutput({padded.get(), ProgramTensorMetadataDependency::TypeAndRank, padded->Shape(), 1})
-          .AddUniformVariables({{output_size}, {N}, {n_b}});
-      if (context.RunProgram(program).IsOK()) {
+      Status s = Status::OK();
+      // A zero-element padded tensor (e.g. a zero-batch or empty constant B) needs no
+      // pad pass - dispatching 0 workgroups is pointless and some drivers reject it.
+      // Just cache the empty tensor; the main kernel dispatches nothing for it.
+      if (output_size != 0) {
+        SubgroupMatrixMatMulPadBProgram program;
+        program.SetWorkgroupSize(WORKGROUP_SIZE)
+            .SetDispatchGroupSize(CeilDiv<uint32_t>(output_size, WORKGROUP_SIZE))
+            .AddInput({&b, ProgramTensorMetadataDependency::TypeAndRank, 1})
+            .AddOutput({padded.get(), ProgramTensorMetadataDependency::TypeAndRank, padded->Shape(), 1})
+            .AddUniformVariables({{output_size}, {N}, {n_b}});
+        s = context.RunProgram(program);
+      }
+      if (s.IsOK()) {
         padded_b_ = std::move(padded);
         padded_b_stride_ = n_b;
       }

--- a/onnxruntime/core/providers/webgpu/math/subgroup_matrix_matmul.cc
+++ b/onnxruntime/core/providers/webgpu/math/subgroup_matrix_matmul.cc
@@ -6,7 +6,9 @@
 #include "core/providers/webgpu/math/subgroup_matrix_matmul.h"
 
 #include <cstdint>
+#include <limits>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <string_view>
 #include <utility>
@@ -25,6 +27,24 @@ namespace {
 // split_k subgroups, so its size is kSubgroupMatrixSubgroupSize * split_k.
 // TODO: use subgroup-size-control to enforce the subgroup size is 32.
 constexpr uint32_t kSubgroupMatrixSubgroupSize = 32;
+
+// Copies a row-major f16 weight B [K, N] into a column-padded [K, N_b] buffer
+// (N_b >= N), zero-filling columns [N, N_b). Gives B an even row stride so the
+// subgroup-matrix f16 load's 4-byte row-start alignment holds for odd N.
+class SubgroupMatrixMatMulPadBProgram final : public Program<SubgroupMatrixMatMulPadBProgram> {
+ public:
+  SubgroupMatrixMatMulPadBProgram() : Program{"SubgroupMatrixMatMulPadB"} {}
+  Status GenerateShaderCode(ShaderHelper& shader) const override {
+    const auto& input_b = shader.AddInput("input_b", ShaderUsage::UseValueTypeAlias);
+    const auto& output = shader.AddOutput("output", ShaderUsage::UseValueTypeAlias);
+    return WGSL_TEMPLATE_APPLY(shader, "math/subgroup_matrix_matmul_pad_b.wgsl.template",
+                               WGSL_TEMPLATE_VARIABLE(input_b, input_b),
+                               WGSL_TEMPLATE_VARIABLE(output, output));
+  }
+  WEBGPU_PROGRAM_DEFINE_UNIFORM_VARIABLES({"output_size", ProgramUniformVariableDataType::Uint32},
+                                          {"N", ProgramUniformVariableDataType::Uint32},
+                                          {"N_b", ProgramUniformVariableDataType::Uint32});
+};
 
 // Subgroup-matrix MatMul implementation. Loads both A and B directly from global
 // memory and runs the subgroup-matrix kernel during Compute. The class is
@@ -104,17 +124,31 @@ class SubgroupMatrixMatMulImpl final : public MatMul::MatMulOptImpl {
     }
 
     // The B right-operand is loaded with subgroupMatrixLoad using a row stride of
-    // N (uniforms.N). Intel's f16 subgroup-matrix load reads columns in 32-bit
-    // (2xf16) pairs and requires each K-row to start 4-byte aligned, i.e. an even
-    // element stride. An odd N offsets every other K-row by 2 bytes and corrupts
-    // the odd output columns. Fall back to the generic MatMul path for odd N.
-    if (N % 2 != 0) {
+    // N_b. Intel's f16 subgroup-matrix load reads columns in 32-bit (2xf16) pairs
+    // and requires each K-row to start 4-byte aligned, i.e. an even element stride.
+    // An odd N would offset every other K-row by 2 bytes and corrupt the odd output
+    // columns. For a constant weight (2D or batched) we can pad B to an even stride
+    // (N_b = N + 1); a non-constant odd-N B falls back here. This is only the cheap
+    // eligibility check - the actual padding is deferred until after tiling selection
+    // so we never allocate/dispatch a padded copy for a problem that will fall back
+    // anyway (e.g. K % 16 != 0, which the tiling selector declines). B has already
+    // been validated as 2D or a well-formed batched shape above.
+    if (N % 2 != 0 && !parent_.IsBConstant()) {
       return Status::OK();
     }
 
     const std::optional<SubgroupMatrixTiling> tiling = tiling_selector_(context, M, N, K, batch);
     if (!tiling) {
       return Status::OK();
+    }
+
+    // The optimized path will run: now materialize the even-strided B for odd N.
+    const Tensor* b_used = b;
+    uint32_t N_b = N;
+    if (N % 2 != 0) {
+      ORT_RETURN_IF_ERROR(EnsurePaddedB(context, *b, N));
+      b_used = padded_b_.get();
+      N_b = padded_b_stride_;
     }
 
     TensorShapeVector output_dims{a_shape.GetDims().begin(), a_shape.GetDims().end()};
@@ -142,9 +176,9 @@ class SubgroupMatrixMatMulImpl final : public MatMul::MatMulOptImpl {
     program.SetDispatchGroupSize(dispatch_x, dispatch_y, batch);
     program.CacheHint(has_bias, config_index_, sg_mat_count_m, sg_mat_count_n, split_k)
         .AddInputs({{a, ProgramTensorMetadataDependency::TypeAndRank, 1},
-                    {b, ProgramTensorMetadataDependency::TypeAndRank, 1}})
+                    {b_used, ProgramTensorMetadataDependency::TypeAndRank, 1}})
         .AddOutput({output, ProgramTensorMetadataDependency::Rank, output->Shape(), 1})
-        .AddUniformVariables({{M}, {N}, {K}, {dispatch_x}});
+        .AddUniformVariables({{M}, {N}, {K}, {dispatch_x}, {N_b}});
     if (has_bias) {
       program.AddInput({bias, ProgramTensorMetadataDependency::None});
     }
@@ -155,8 +189,53 @@ class SubgroupMatrixMatMulImpl final : public MatMul::MatMulOptImpl {
   }
 
  private:
+  // Lazily builds an even-strided copy of a constant weight B [..., K, N] with odd N
+  // by widening its last dim to N_b = N + 1 (zero-filling the extra column) and
+  // caches it, so the per-run pad cost is paid once. Works for a 2D weight [K, N]
+  // and a batched weight [batch, K, N] alike: the pad pass treats B as a flat
+  // [rows, N] -> [rows, N_b] copy over rows = numel / N (= K, or batch*K), which is
+  // exactly the even-stride layout the kernel indexes via N_b. Runs the GPU pad pass
+  // on first use under call_once; the cached tensor is held for the kernel's
+  // lifetime. Only valid when B is a constant initializer (checked by the caller) -
+  // a runtime B changes per run and must not be cached.
+  Status EnsurePaddedB(ComputeContext& context, const Tensor& b, uint32_t N) const {
+    ORT_RETURN_IF_NOT(N < std::numeric_limits<uint32_t>::max(),
+                      "Cannot pad odd-N B because N+1 exceeds uint32_t range.");
+    const uint32_t n_b = N + 1;
+    TensorShapeVector padded_dims{b.Shape().GetDims().begin(), b.Shape().GetDims().end()};
+    padded_dims.back() = static_cast<int64_t>(n_b);
+    const TensorShape padded_shape{padded_dims};
+    const int64_t output_size_i64 = padded_shape.Size();
+    ORT_RETURN_IF_NOT(output_size_i64 <= static_cast<int64_t>(std::numeric_limits<uint32_t>::max()),
+                      "Cannot pad odd-N B because the padded tensor has ", output_size_i64,
+                      " elements, exceeding uint32_t shader indexing range.");
+    const uint32_t output_size = narrow<uint32_t>(output_size_i64);
+
+    std::call_once(pad_once_, [&]() {
+      auto padded = std::make_unique<Tensor>(context.CreateGPUTensor(b.DataType(), padded_shape));
+      SubgroupMatrixMatMulPadBProgram program;
+      program.SetDispatchGroupSize(output_size / 64 + static_cast<uint32_t>(output_size % 64 != 0))
+          .AddInput({&b, ProgramTensorMetadataDependency::TypeAndRank, 1})
+          .AddOutput({padded.get(), ProgramTensorMetadataDependency::TypeAndRank, padded->Shape(), 1})
+          .AddUniformVariables({{output_size}, {N}, {n_b}});
+      if (context.RunProgram(program).IsOK()) {
+        padded_b_ = std::move(padded);
+        padded_b_stride_ = n_b;
+      }
+    });
+    // padded_b_ persists the outcome across calls: call_once runs the body only on
+    // the first call, so a failed pad stays failed (and null) on later calls.
+    return padded_b_ ? Status::OK()
+                     : ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Failed to pad odd-N B for subgroup-matrix MatMul.");
+  }
+
   const int32_t config_index_;
   SubgroupMatrixTilingSelector tiling_selector_;
+
+  // Cached even-strided B for odd N; built once by EnsurePaddedB.
+  mutable std::once_flag pad_once_;
+  mutable std::unique_ptr<Tensor> padded_b_;
+  mutable uint32_t padded_b_stride_ = 0;
 };
 
 Status GenerateShaderCode8x16x16(ShaderHelper& shader, const ShaderVariableHelper& output,

--- a/onnxruntime/core/providers/webgpu/math/subgroup_matrix_matmul.h
+++ b/onnxruntime/core/providers/webgpu/math/subgroup_matrix_matmul.h
@@ -58,10 +58,13 @@ class SubgroupMatrixMatMulProgram final : public Program<SubgroupMatrixMatMulPro
         sg_mat_count_n_(sg_mat_count_n),
         split_k_(split_k) {}
   Status GenerateShaderCode(ShaderHelper& sh) const override;
+  // N is the logical output width; N_b is B's physical row stride (== N unless B
+  // was column-padded to an even stride for odd N).
   WEBGPU_PROGRAM_DEFINE_UNIFORM_VARIABLES({"M", ProgramUniformVariableDataType::Uint32},
                                           {"N", ProgramUniformVariableDataType::Uint32},
                                           {"K", ProgramUniformVariableDataType::Uint32},
-                                          {"num_n_tile", ProgramUniformVariableDataType::Uint32});
+                                          {"num_n_tile", ProgramUniformVariableDataType::Uint32},
+                                          {"N_b", ProgramUniformVariableDataType::Uint32});
 
  private:
   const bool has_bias_;

--- a/onnxruntime/core/providers/webgpu/math/subgroup_matrix_matmul_8x16x16.wgsl.template
+++ b/onnxruntime/core/providers/webgpu/math/subgroup_matrix_matmul_8x16x16.wgsl.template
@@ -11,7 +11,10 @@
 // A: activation, loaded directly from global memory as a left operand
 //    (subgroup_matrix_left<f16, sg_mat_k, sg_mat_m>), row-major with stride K.
 // B: weight, loaded directly from global memory in plain row-major KxN layout as a
-//    right operand (subgroup_matrix_right<f16, sg_mat_n, sg_mat_k>) with stride N.
+//    right operand (subgroup_matrix_right<f16, sg_mat_n, sg_mat_k>) with row stride
+//    N_b. N_b is the padded row stride of the (possibly column-padded) B buffer and
+//    equals N unless the host padded B to an even stride to satisfy the load's
+//    4-byte row-start alignment (see the odd-N handling in subgroup_matrix_matmul.cc).
 //
 // Workgroup: split_k subgroups x 32 lanes (split_k in {1,2,4,8}).
 // Tile: kTileM x kTileN, chosen adaptively by the host config provider. Each
@@ -20,9 +23,11 @@
 // distributed round-robin across the subgroups, each accumulates its own partial
 // tile in shared memory, and the partials are summed at write-out.
 //
-// Preconditions enforced by the host: K % sg_mat_k == 0. M and N may be any
-// size; partial tiles are handled by bounds-checked stores. Out-of-range A/B
-// loads return zero (WebGPU bounds checking).
+// Preconditions enforced by the host: K % sg_mat_k == 0, and B's row stride N_b
+// is even (the load requires 4-byte-aligned row starts). M and N may be any size;
+// partial tiles are handled by bounds-checked stores. Out-of-range A/B loads
+// return zero (WebGPU bounds checking). Output width/stride uses N (not N_b), so
+// any padded B columns in [N, N_b) are read but never written.
 //
 // Batching: the host dispatches one num_n_tile x num_m_tile tile grid per batch
 // slice; the batch slice is recovered from the flattened workgroup_idx (the
@@ -75,7 +80,7 @@ $MAIN {
     // Flat-element offsets into A/B/output for this batch slice, derived from
     // M/N/K. For a shared 2D weight batch_id is 0, so B collapses to its base.
     let a_batch_offset = batch_id * uniforms.M * uniforms.K;
-    let b_batch_offset = batch_id * uniforms.K * uniforms.N;
+    let b_batch_offset = batch_id * uniforms.K * uniforms.N_b;
     let out_batch_offset = batch_id * uniforms.M * uniforms.N;
     let k_blocks = uniforms.K / kSgMatK;
     let sg_index = local_idx / kSubgroupSize;          // which split-K subgroup (0..kSplitK-1)
@@ -179,25 +184,25 @@ $MAIN {
 #endif
 
     for (var kb: u32 = sg_index; kb < k_blocks; kb = kb + kSplitK) {
-        // Load the B right tiles for this K block (KxN row-major, stride N).
-        let b_base = b_batch_offset + kb * kSgMatK * uniforms.N + global_base_n;
+        // Load the B right tiles for this K block (KxN_b row-major, stride N_b).
+        let b_base = b_batch_offset + kb * kSgMatK * uniforms.N_b + global_base_n;
         var sg_mat_b0: subgroup_matrix_right<f16, sg_mat_n, sg_mat_k> =
             subgroupMatrixLoad<subgroup_matrix_right<f16, sg_mat_n, sg_mat_k>>(
-                &input_b, b_base + 0 * kSgMatN, false, uniforms.N);
+                &input_b, b_base + 0 * kSgMatN, false, uniforms.N_b);
 #if sg_mat_count_n >= 2
         var sg_mat_b1: subgroup_matrix_right<f16, sg_mat_n, sg_mat_k> =
             subgroupMatrixLoad<subgroup_matrix_right<f16, sg_mat_n, sg_mat_k>>(
-                &input_b, b_base + 1 * kSgMatN, false, uniforms.N);
+                &input_b, b_base + 1 * kSgMatN, false, uniforms.N_b);
 #endif
 #if sg_mat_count_n >= 3
         var sg_mat_b2: subgroup_matrix_right<f16, sg_mat_n, sg_mat_k> =
             subgroupMatrixLoad<subgroup_matrix_right<f16, sg_mat_n, sg_mat_k>>(
-                &input_b, b_base + 2 * kSgMatN, false, uniforms.N);
+                &input_b, b_base + 2 * kSgMatN, false, uniforms.N_b);
 #endif
 #if sg_mat_count_n >= 4
         var sg_mat_b3: subgroup_matrix_right<f16, sg_mat_n, sg_mat_k> =
             subgroupMatrixLoad<subgroup_matrix_right<f16, sg_mat_n, sg_mat_k>>(
-                &input_b, b_base + 3 * kSgMatN, false, uniforms.N);
+                &input_b, b_base + 3 * kSgMatN, false, uniforms.N_b);
 #endif
 
         // Load the A left tiles (one per M block), row-major with stride K.

--- a/onnxruntime/core/providers/webgpu/math/subgroup_matrix_matmul_pad_b.wgsl.template
+++ b/onnxruntime/core/providers/webgpu/math/subgroup_matrix_matmul_pad_b.wgsl.template
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Copies a row-major f16 weight B [K, N] into a column-padded [K, N_b] buffer
+// (N_b >= N), zero-filling columns [N, N_b). One thread per padded-output element.
+// Gives B an even row stride so the subgroup-matrix f16 load's 4-byte row-start
+// alignment holds for odd N. See EnsurePaddedB in subgroup_matrix_matmul.cc.
+
+#use guardAgainstOutOfBoundsWorkgroupSizes
+#use .getByOffset .setByOffset
+
+$MAIN {
+  guardAgainstOutOfBoundsWorkgroupSizes(uniforms.output_size);
+  let r = global_idx / uniforms.N_b;                 // padded-output row
+  let c = global_idx % uniforms.N_b;                 // padded-output column
+  var v = output_value_t(0);
+  if (c < uniforms.N) {                              // real column -> copy; else zero pad
+    v = output_value_t(input_b.getByOffset(r * uniforms.N + c));
+  }
+  output.setByOffset(global_idx, v);
+}  // MAIN

--- a/onnxruntime/test/providers/cpu/math/matmul_test.cc
+++ b/onnxruntime/test/providers/cpu/math/matmul_test.cc
@@ -784,6 +784,16 @@ TEST(MathOpTest, MatMulSubgroupMatrix) {
       {"SplitKScratchCap (64x64,K=256)", {64, 256}, 256, 64},
       // Batched A folds to M=8; one tile + K=256 -> split_k=8.
       {"SplitKBatched (2*4 -> M=8)", {2, 4, 256}, 256, 16},
+      // Odd N: the subgroup f16 load needs an even B row stride, so a constant odd-N
+      // weight is padded once to N+1 (even) and cached; output is still written at
+      // the real, odd N. Covers small/large odd N, min K, partial M, batched-A fold,
+      // and split-K, all with odd N.
+      {"OddN15 (N=15)", {32, 64}, 64, 15},
+      {"OddN33 (N=33)", {16, 64}, 64, 33},
+      {"OddN MinK (K=16,N=17)", {8, 16}, 16, 17},
+      {"OddN PartialM (M=40,N=31)", {40, 64}, 64, 31},
+      {"OddN BatchedA (2*32 -> M=64,N=63)", {2, 32, 64}, 64, 63},
+      {"OddN SplitK (K=256,N=17)", {8, 256}, 256, 17},
   };
 
   for (const auto& c : cases) {

--- a/onnxruntime/test/providers/webgpu/matmul_large_test.cc
+++ b/onnxruntime/test/providers/webgpu/matmul_large_test.cc
@@ -41,7 +41,8 @@ static void ComputeExpectedResult(const std::vector<float>& a_vals, const std::v
 }
 
 template <typename T, int version = 13>
-void RunTestTyped(std::initializer_list<int64_t> a_dims, std::initializer_list<int64_t> b_dims) {
+void RunTestTyped(std::initializer_list<int64_t> a_dims, std::initializer_list<int64_t> b_dims,
+                  bool b_is_constant = false) {
   static_assert(std::is_same_v<T, float> || std::is_same_v<T, MLFloat16>, "unexpected type for T");
 
   auto webgpu_ep = DefaultWebGpuExecutionProvider();
@@ -68,11 +69,11 @@ void RunTestTyped(std::initializer_list<int64_t> a_dims, std::initializer_list<i
   OpTester test("MatMul", version);
   if constexpr (std::is_same_v<T, float>) {
     test.AddInput<T>("A", a_dims, a_vals);
-    test.AddInput<T>("B", b_dims, b_vals);
+    test.AddInput<T>("B", b_dims, b_vals, b_is_constant);
     test.AddOutput<T>("Y", output_dims, expected_vals);
   } else {
     test.AddInput<T>("A", a_dims, FloatsToMLFloat16s(a_vals));
-    test.AddInput<T>("B", b_dims, FloatsToMLFloat16s(b_vals));
+    test.AddInput<T>("B", b_dims, FloatsToMLFloat16s(b_vals), b_is_constant);
     test.AddOutput<T>("Y", output_dims, FloatsToMLFloat16s(expected_vals));
     test.SetOutputAbsErr("Y", 0.055f);
     test.SetOutputRelErr("Y", 0.02f);
@@ -146,6 +147,23 @@ TEST(MatMul_Large, DISABLED_BatchedB_4D) {
 TEST(MatMul_Large, DISABLED_BatchedB_LargeBatchSmallTile) {
   RunBothTypes({64, 16, 128}, {64, 128, 32});
   RunBothTypes({128, 8, 256}, {128, 256, 16});
+}
+
+// Constant f16 weight with odd N. The Intel f16 subgroup-matrix load needs an
+// even B row stride, so a non-constant odd-N B falls back to the generic path. When
+// B is a constant initializer, the first Compute lazily pads it to an even stride
+// (N+1) and the subgroup kernel consumes the cached copy via the N_b uniform (output
+// is still written at the real, odd N). Marking B constant here exercises that
+// padded path for both shared 2D and batched weights across several odd N (1023,
+// 33, 65), with even K and both aligned and partial M. Results must match the
+// reference. f16 only: the subgroup kernel is f16, so a float B would take the
+// generic path.
+TEST(MatMul_Large, DISABLED_ConstantWeightOddN) {
+  RunTestTyped<MLFloat16>({128, 64}, {64, 1023}, /*b_is_constant=*/true);
+  RunTestTyped<MLFloat16>({127, 64}, {64, 1023}, /*b_is_constant=*/true);
+  RunTestTyped<MLFloat16>({64, 96}, {96, 33}, /*b_is_constant=*/true);
+  RunTestTyped<MLFloat16>({130, 80}, {80, 65}, /*b_is_constant=*/true);
+  RunTestTyped<MLFloat16>({2, 127, 64}, {2, 64, 1023}, /*b_is_constant=*/true);
 }
 
 // Broadcasted batch dims that are NOT identical but share the same batch


### PR DESCRIPTION
Adds odd-N support to WebGPU subgroup-matrix MatMul by padding constant FP16 weights to an even row stride and caching the result.
