### PR TITLE
[CUDA] Optimize MatMulBlockScaledFp8 GEMV decode

### DIFF
--- a/docs/contrib_ops/cuda/matmul_block_scaled_fp8_experiments.md
+++ b/docs/contrib_ops/cuda/matmul_block_scaled_fp8_experiments.md
@@ -17,7 +17,7 @@ Related documentation:
 2. [Baseline Latency Profile](#2-baseline-latency-profile)
 3. [Prefill Bottleneck - Weight Dequantization](#3-prefill-bottleneck---weight-dequantization)
 4. [Optimization - Vectorized Dequantization Kernel](#4-optimization---vectorized-dequantization-kernel)
-5. [Decode GEMV - Kept As Is](#5-decode-gemv---kept-as-is)
+5. [Decode GEMV - Memory-Level Parallelism](#5-decode-gemv---memory-level-parallelism)
 6. [Benchmark Commands](#6-benchmark-commands)
 7. [Lessons](#7-lessons)
 
@@ -26,6 +26,7 @@ Related documentation:
 ## 1. Test Environment
 
 - GPU: NVIDIA GeForce RTX 5060 Ti, SM120 (Blackwell), 36 SMs, about 448 GB/s memory bandwidth.
+  Section 5 was measured separately on an NVIDIA H200, SM90 (Hopper), 132 SMs, about 4.8 TB/s.
 - CUDA toolkit: 13.0.
 - CUTLASS: 4.4.2.
 - Build directory: `build/cu130/Release`.
@@ -156,16 +157,99 @@ This optimization is kept.
 
 ---
 
-## 5. Decode GEMV - Kept As Is
+## 5. Decode GEMV - Memory-Level Parallelism
 
-The decode GEMV `MatMulBlockScaledFp8GemvKernel` is already well tuned and was
-not changed. It groups all rows of an `M <= 8` tile into one warp
-(`RowsPerWarp` = 1, 2, 4, or 8) so each weight row streams exactly once, uses
-`uint4` vectorized FP8 loads, folds one `b_scale` value per 16-element chunk
-(valid because `block_size % 16 == 0` on this path), and reduces with warp
-shuffles. Decode latency (0.076-0.145 ms for `M = 1..8`) is far below the
-prefill dequant floor, so it is not the optimization target. Its numbers are
-unchanged by the dequant kernel work, as expected.
+An earlier round of this document concluded the decode GEMV was "already well
+tuned and not the optimization target". That conclusion came from measurements
+taken through the ORT Python API without CUDA graphs, which on a fast GPU are
+dominated by per-node host overhead rather than by the kernel. Re-measuring on
+H200 (SM90) with the launches captured in a CUDA graph changed the picture.
+
+### 5.1 What the measurement was actually reporting
+
+At `N = 8192, K = 2048, M = 1` the op-level measurement reported 21.0 us while
+the kernel itself takes 7.2 us. The difference is ORT per-node host work; the
+host, not the GPU, was the limiter in that harness. Two rules follow:
+
+- Measure kernels standalone, or with the launches captured in a CUDA graph.
+- On H200 an empty kernel costs **1.79 us** as a stream launch and **0.68 us**
+  as a CUDA graph node. That 0.68 us is a floor no kernel optimization can go
+  below, and it dominates any op whose useful work is smaller.
+
+### 5.2 Nsight Compute diagnosis
+
+`ncu --section SpeedOfLight --section MemoryWorkloadAnalysis --section Occupancy
+--section WarpStateStats` on the original kernel at `N = 8192, K = 2048, M = 1`:
+
+| Metric | Value | Reading |
+|---|---|---|
+| DRAM throughput | 35.3% | not bandwidth bound |
+| Compute (SM) throughput | 52.3% | not compute bound either |
+| Waves | 1.0 | grid barely fills the GPU once |
+| L1/TEX hit rate | 79.6% | the `A` row is already resident in L1 |
+| L2 hit rate | 5.2% | `A` re-reads never reach L2 |
+| Block limit (registers) | 8 blocks/SM | occupancy already register capped |
+| Achieved occupancy | 71.0% | vs 100% theoretical |
+| Warp cycles / issued instr | 16.7, of which 5.5 on L1TEX | latency bound |
+
+The kernel is short of **outstanding loads**, not of bandwidth or instructions.
+Each thread moves only `K / 32 = 64` bytes of `B`, and because `k` is a runtime
+value the K loop does not unroll, so a thread has exactly one `B` load in flight
+and pays full L1 latency every iteration.
+
+Two hypotheses were tested and rejected:
+
+- *Reduce conversion instructions.* Replacing the 16 scalar `static_cast<float>`
+  FP8 converts with `__nv_cvt_fp8x2_to_halfraw2` (one `cvt.rn.f16x2.e4m3x2` per
+  pair) is bit-exact and worth only 0-15%. Instruction count was not the limit.
+- *Stage `A` in shared memory.* The concern was that all `N` warps re-read the
+  whole `A` row. The 79.6% L1 hit rate shows L1 already absorbs this; a shared
+  memory variant was neutral to slower except at very small `N`.
+
+### 5.3 Change
+
+`MatMulBlockScaledFp8GemvKernel` is now templated on
+`<RowsPerWarp, ColsPerWarp, Unroll, AType>`, where `<R, 1, 1, A>` reproduces the
+original geometry exactly:
+
+- `Unroll` pre-issues `Unroll` independent `B`/`A` loads before consuming any of
+  them, so several requests are in flight per thread.
+- `ColsPerWarp` gives one warp several output columns, so each `A` load feeds
+  several independent FMA chains.
+
+Both trade occupancy - already register capped, and irrelevant at one wave - for
+per-thread memory-level parallelism. The FP8 to FP16 conversion is also
+vectorized. FP32 accumulation is unchanged, so results are **bit-identical** to
+the previous kernel.
+
+Dispatch (only `M == 1`, the batch-1 decode case, uses wide tiles):
+
+| Condition | Config |
+|---|---|
+| `M == 1, N >= 8192` | `<1, 4, 2>` |
+| `M == 1, N >= 4096` | `<1, 2, 2>` |
+| otherwise | `<RowsPerWarp, 1, 1>` (unchanged) |
+
+Below `N = 4096` the wider tiles leave too few warps to fill the GPU, and for
+`M > 1` the extra live registers (accumulators plus pre-issued loads) cost more
+than the added parallelism returns. Both measured slower, hence the guards.
+
+### 5.4 Results (H200, `M = 1`, CUDA graph, us, includes 0.68 us node overhead)
+
+| Shape (N x K) | cuBLAS FP16 | GEMV before | GEMV after | vs before | vs cuBLAS |
+|---|---|---|---|---|---|
+| 8192 x 2048 | 10.2 | 7.2 | **5.4** | 1.33x | 1.89x |
+| 4096 x 2048 | 7.1 | 4.4 | **4.0** | 1.10x | 1.78x |
+| 4096 x 4096 | 9.2 | 7.1 | **6.0** | 1.18x | 1.53x |
+| 2048 x 4096 | 7.6 | 4.6 | 4.6 | 1.00x | 1.65x |
+| 512 x 2048 | 5.4 | 2.7 | 2.7 | 1.00x | 2.00x |
+
+At `8192 x 2048` this is 3.1 TB/s of the 4.8 TB/s HBM peak, up from 2.3 TB/s.
+
+Note the last column: the weight-only FP8 GEMV is **1.5-2.0x faster than cuBLAS
+FP16** at `M = 1`, so quantizing a projection to FP8 is a decode win on latency
+as well as on footprint. At `M >= 4` cuBLAS wins and the GEMV path should not be
+preferred on speed alone.
 
 ---
 
@@ -236,5 +320,22 @@ CUDA_VISIBLE_DEVICES=0 "$ORT_BUILD/onnxruntime_provider_test" \
 - Keep the scalar dequant kernel as a correctness fallback for `K % 16 != 0`; the
   vectorized kernel requires the 16-element alignment that `K % 16 == 0`
   guarantees.
-- The decode GEMV already streams weights once per tile and is well below the
-  prefill floor, so it was left unchanged.
+- Never benchmark a fast kernel through the ORT Python API without CUDA graphs.
+  At `8192 x 2048, M = 1` that harness reported 21.0 us for a 7.2 us kernel; the
+  measurement was host bound and led to the wrong conclusion that the decode
+  GEMV was fine and that FP8 was slower than FP16.
+- A decode GEMV runs one wave and is usually starved of *outstanding loads*, not
+  of bandwidth or instructions. When SOL shows both DRAM and SM well under 60%
+  with a large L1TEX stall share, add per-thread memory-level parallelism
+  (unroll to pre-issue loads, widen the tile) rather than cutting instructions
+  or adding shared memory staging. Trading register-capped occupancy for ILP is
+  the right move at one wave.
+- Do not pass an array by reference (`__half2 (&)[8]`) to a `__device__` helper.
+  It is placed in local memory; inlining the same code via a macro was about 2x
+  faster here and much more at `RowsPerWarp > 1`.
+- Know the launch floor before optimizing: on H200 an empty kernel costs 0.68 us
+  as a CUDA graph node. Ops cheaper than that are launch bound and should be
+  fused, not tuned.
+- The FP8 weight-only GEMV is 1.5-2.0x faster than cuBLAS FP16 at `M = 1`, so
+  quantizing a projection is a decode latency win, not just a footprint win. The
+  ordering reverses by `M = 4`.

--- a/onnxruntime/contrib_ops/cuda/math/matmul_block_scaled_fp8.cu
+++ b/onnxruntime/contrib_ops/cuda/math/matmul_block_scaled_fp8.cu
@@ -152,50 +152,79 @@ __global__ void QuantizeDequantizeActivationFp8Kernel(T* __restrict__ out,
 // -----------------------------------------------------------------------------
 // Fused FP8 weight-only GEMV fast path for the decode phase (small M).
 //
-// Each warp computes RowsPerWarp output elements Y[row, col]. The 32 lanes of the
-// warp cooperatively reduce over K using 16-wide vectorized loads, so the FP8
-// weight B is streamed exactly once with fully coalesced warp transactions. Block
-// scales are applied once per K-block (not per element): a lane's 16-element chunk
-// is guaranteed to lie inside a single K-block whenever block_size is a multiple of
-// 16, so weight_scale is folded in per chunk. Runs on any architecture (SM80+).
-template <typename AType>
-__device__ __forceinline__ void LoadFp8Gemv16A(const AType* ptr, float (&out)[16]);
+// Each warp computes RowsPerWarp x ColsPerWarp output elements Y[row, col]. The 32
+// lanes of the warp cooperatively reduce over K using 16-wide vectorized loads, so
+// the FP8 weight B is streamed exactly once with fully coalesced warp transactions.
+// Block scales are applied once per K-block (not per element): a lane's 16-element
+// chunk is guaranteed to lie inside a single K-block whenever block_size is a
+// multiple of 16, so weight_scale is folded in per chunk. Runs on SM80+.
+//
+// ColsPerWarp / Unroll exist because the decode GEMV is bound by the number of
+// *outstanding* loads, not by bandwidth or by instruction count. Nsight Compute on
+// an 8192x2048 decode GEMV (H200) reports only 1.0 full waves, L1 hit rate 79.6%
+// (the A row is already resident, so staging it in shared memory buys nothing), and
+// a third of the warp stall cycles waiting on L1TEX. With one 16-element B chunk in
+// flight per thread, each thread only moves K/32 bytes of B and eats the full L1
+// latency every iteration.
+//
+//   * Unroll      issues `Unroll` independent B/A loads before consuming any of them.
+//   * ColsPerWarp lets one A load feed `ColsPerWarp` independent FMA chains, which
+//                 both raises arithmetic intensity and adds independent B streams.
+//
+// Both trade occupancy (already register-capped at 8 blocks/SM) for per-thread
+// memory-level parallelism, which is the right trade when there is only one wave.
+// <RowsPerWarp, 1, 1> reproduces the original one-column-per-warp geometry.
 
+// Vector-2 companion type and float2 widening for the accumulate type.
+template <typename T>
+struct Fp8GemvVec2;
 template <>
-__device__ __forceinline__ void LoadFp8Gemv16A<half>(const half* ptr, float (&out)[16]) {
-  const uint4* p = reinterpret_cast<const uint4*>(ptr);
-  const uint4 lo = p[0];
-  const uint4 hi = p[1];
-  const half* vlo = reinterpret_cast<const half*>(&lo);
-  const half* vhi = reinterpret_cast<const half*>(&hi);
-#pragma unroll
-  for (int i = 0; i < 8; ++i) {
-    out[i] = __half2float(vlo[i]);
-  }
-#pragma unroll
-  for (int i = 0; i < 8; ++i) {
-    out[8 + i] = __half2float(vhi[i]);
-  }
-}
-
+struct Fp8GemvVec2<half> {
+  using type = __half2;
+};
 template <>
-__device__ __forceinline__ void LoadFp8Gemv16A<__nv_bfloat16>(const __nv_bfloat16* ptr, float (&out)[16]) {
-  const uint4* p = reinterpret_cast<const uint4*>(ptr);
-  const uint4 lo = p[0];
-  const uint4 hi = p[1];
-  const __nv_bfloat16* vlo = reinterpret_cast<const __nv_bfloat16*>(&lo);
-  const __nv_bfloat16* vhi = reinterpret_cast<const __nv_bfloat16*>(&hi);
-#pragma unroll
-  for (int i = 0; i < 8; ++i) {
-    out[i] = __bfloat162float(vlo[i]);
-  }
-#pragma unroll
-  for (int i = 0; i < 8; ++i) {
-    out[8 + i] = __bfloat162float(vhi[i]);
-  }
-}
+struct Fp8GemvVec2<__nv_bfloat16> {
+  using type = __nv_bfloat162;
+};
 
-template <int RowsPerWarp, typename AType>
+__device__ __forceinline__ float2 Fp8GemvToFloat2(const __half2& v) { return __half22float2(v); }
+__device__ __forceinline__ float2 Fp8GemvToFloat2(const __nv_bfloat162& v) { return __bfloat1622float2(v); }
+
+// Convert 16 packed FP8 bytes into 8 half2 (one `cvt.rn.f16x2.e4m3x2` per pair
+// instead of 16 scalar converts). FP8 E4M3 is exactly representable in FP16, so
+// this is lossless for both the half and the bfloat16 instantiation.
+//
+// Written as a macro rather than a helper taking `__half2 (&)[8]`: an array passed
+// by reference is placed in local memory, which costs ~2x here and much more at
+// RowsPerWarp > 1 where the spill lands in the inner loop.
+#define ORT_FP8_GEMV_CVT16(raw, bh)                                                         \
+  do {                                                                                      \
+    const __nv_fp8x2_storage_t* _p = reinterpret_cast<const __nv_fp8x2_storage_t*>(&(raw)); \
+    _Pragma("unroll") for (int _i = 0; _i < 8; ++_i) {                                      \
+      (bh)[_i] = __half2(__nv_cvt_fp8x2_to_halfraw2(_p[_i], __NV_E4M3));                    \
+    }                                                                                       \
+  } while (0)
+
+// acc += dot(A[0:16], B[0:16]) with FP32 accumulation, matching the scalar version bit for bit.
+#define ORT_FP8_GEMV_DOT16(a0, a1, bh, acc)                   \
+  do {                                                        \
+    const AVec2* _a0 = reinterpret_cast<const AVec2*>(&(a0)); \
+    const AVec2* _a1 = reinterpret_cast<const AVec2*>(&(a1)); \
+    _Pragma("unroll") for (int _i = 0; _i < 4; ++_i) {        \
+      const float2 _av = Fp8GemvToFloat2(_a0[_i]);            \
+      const float2 _bv = __half22float2((bh)[_i]);            \
+      (acc) = fmaf(_av.x, _bv.x, (acc));                      \
+      (acc) = fmaf(_av.y, _bv.y, (acc));                      \
+    }                                                         \
+    _Pragma("unroll") for (int _i = 0; _i < 4; ++_i) {        \
+      const float2 _av = Fp8GemvToFloat2(_a1[_i]);            \
+      const float2 _bv = __half22float2((bh)[4 + _i]);        \
+      (acc) = fmaf(_av.x, _bv.x, (acc));                      \
+      (acc) = fmaf(_av.y, _bv.y, (acc));                      \
+    }                                                         \
+  } while (0)
+
+template <int RowsPerWarp, int ColsPerWarp, int Unroll, typename AType>
 __global__ void MatMulBlockScaledFp8GemvKernel(AType* __restrict__ output,
                                                const AType* __restrict__ input_a,
                                                const __nv_fp8_e4m3* __restrict__ input_b,
@@ -206,59 +235,106 @@ __global__ void MatMulBlockScaledFp8GemvKernel(AType* __restrict__ output,
                                                int k,
                                                int block_size,
                                                int k_blocks) {
-  const int lane = threadIdx.x;                           // 0..31
-  const int col = blockIdx.x * blockDim.y + threadIdx.y;  // n
-  const int row_base = blockIdx.y * RowsPerWarp;          // m
-  if (row_base >= m || col >= n) {
+  using AVec2 = typename Fp8GemvVec2<AType>::type;
+
+  constexpr int kElemsPerLane = 16;
+  constexpr int kStride = 32 * kElemsPerLane;  // 512 elements per warp sub-chunk
+
+  const int lane = threadIdx.x;  // 0..31
+  const int col_base = (blockIdx.x * blockDim.y + threadIdx.y) * ColsPerWarp;
+  const int row_base = blockIdx.y * RowsPerWarp;
+  if (row_base >= m || col_base >= n) {
     return;
   }
 
-  const __nv_fp8_e4m3* b_row = input_b + static_cast<size_t>(col) * k;
-  const float* sb_row = weight_scale + static_cast<size_t>(col) * k_blocks;
+  float acc[RowsPerWarp][ColsPerWarp] = {};
 
-  constexpr int kElemsPerLane = 16;
-  const int stride = 32 * kElemsPerLane;  // 512 elements per warp iteration
-
-  float acc[RowsPerWarp] = {};
-  for (int base = 0; base < k; base += stride) {
-    const int koff = base + lane * kElemsPerLane;
-    if (koff < k) {
-      const uint4 b_raw = *reinterpret_cast<const uint4*>(b_row + koff);
-      const __nv_fp8_e4m3* bp = reinterpret_cast<const __nv_fp8_e4m3*>(&b_raw);
-      const int kb = koff / block_size;
-      const float b_scale = sb_row[kb];
+  for (int base = 0; base < k; base += kStride * Unroll) {
+    // Phase 1: issue every load for this iteration back to back. Nothing here consumes a
+    // loaded value, so all Unroll * (ColsPerWarp + 2 * RowsPerWarp) requests are in flight
+    // at once instead of one at a time.
+    uint4 b_raw[Unroll][ColsPerWarp];
+    uint4 a_lo[Unroll][RowsPerWarp];
+    uint4 a_hi[Unroll][RowsPerWarp];
+    int koff[Unroll];
 #pragma unroll
-      for (int row_offset = 0; row_offset < RowsPerWarp; ++row_offset) {
-        const int row = row_base + row_offset;
-        if (row < m) {
-          const AType* a_row = input_a + static_cast<size_t>(row) * k;
-          float a_vals[16];
-          LoadFp8Gemv16A<AType>(a_row + koff, a_vals);
-
-          float partial = 0.0f;
+    for (int u = 0; u < Unroll; ++u) {
+      koff[u] = base + u * kStride + lane * kElemsPerLane;
+      const bool k_ok = koff[u] < k;
 #pragma unroll
-          for (int i = 0; i < kElemsPerLane; ++i) {
-            partial += a_vals[i] * static_cast<float>(bp[i]);
+      for (int c = 0; c < ColsPerWarp; ++c) {
+        const int col = col_base + c;
+        b_raw[u][c] = (k_ok && col < n)
+                          ? *reinterpret_cast<const uint4*>(input_b + static_cast<size_t>(col) * k + koff[u])
+                          : make_uint4(0, 0, 0, 0);
+      }
+#pragma unroll
+      for (int r = 0; r < RowsPerWarp; ++r) {
+        const int row = row_base + r;
+        if (k_ok && row < m) {
+          const uint4* ap = reinterpret_cast<const uint4*>(input_a + static_cast<size_t>(row) * k + koff[u]);
+          a_lo[u][r] = ap[0];
+          a_hi[u][r] = ap[1];
+        } else {
+          a_lo[u][r] = make_uint4(0, 0, 0, 0);
+          a_hi[u][r] = make_uint4(0, 0, 0, 0);
+        }
+      }
+    }
+
+    // Phase 2: consume.
+#pragma unroll
+    for (int u = 0; u < Unroll; ++u) {
+      if (koff[u] >= k) {
+        continue;
+      }
+      const int kb = koff[u] / block_size;
+#pragma unroll
+      for (int c = 0; c < ColsPerWarp; ++c) {
+        const int col = col_base + c;
+        if (col >= n) {
+          continue;
+        }
+        __half2 b_half[8];
+        ORT_FP8_GEMV_CVT16(b_raw[u][c], b_half);
+        const float b_scale = weight_scale[static_cast<size_t>(col) * k_blocks + kb];
+#pragma unroll
+        for (int r = 0; r < RowsPerWarp; ++r) {
+          if (row_base + r >= m) {
+            continue;
           }
-          acc[row_offset] += partial * b_scale;
+          float partial = 0.0f;
+          ORT_FP8_GEMV_DOT16(a_lo[u][r], a_hi[u][r], b_half, partial);
+          acc[r][c] += partial * b_scale;
         }
       }
     }
   }
 
 #pragma unroll
-  for (int row_offset = 0; row_offset < RowsPerWarp; ++row_offset) {
+  for (int r = 0; r < RowsPerWarp; ++r) {
 #pragma unroll
-    for (int offset = 16; offset > 0; offset >>= 1) {
-      acc[row_offset] += __shfl_down_sync(0xffffffffu, acc[row_offset], offset);
+    for (int c = 0; c < ColsPerWarp; ++c) {
+#pragma unroll
+      for (int offset = 16; offset > 0; offset >>= 1) {
+        acc[r][c] += __shfl_down_sync(0xffffffffu, acc[r][c], offset);
+      }
     }
   }
   if (lane == 0) {
 #pragma unroll
-    for (int row_offset = 0; row_offset < RowsPerWarp; ++row_offset) {
-      const int row = row_base + row_offset;
-      if (row < m) {
-        float result = acc[row_offset];
+    for (int r = 0; r < RowsPerWarp; ++r) {
+      const int row = row_base + r;
+      if (row >= m) {
+        continue;
+      }
+#pragma unroll
+      for (int c = 0; c < ColsPerWarp; ++c) {
+        const int col = col_base + c;
+        if (col >= n) {
+          continue;
+        }
+        float result = acc[r][c];
         if (bias != nullptr) {
           result += ToFloat<AType>(bias[col]);
         }
@@ -420,28 +496,42 @@ Status LaunchMatMulBlockScaledFp8Gemv(void* y,
   constexpr int kWarpsPerBlock = 8;
   const dim3 threads{32, kWarpsPerBlock};
   const auto* b = reinterpret_cast<const __nv_fp8_e4m3*>(b_fp8);
-  const auto launch = [&]<int RowsPerWarp>() {
-    const dim3 blocks{static_cast<unsigned int>((n + kWarpsPerBlock - 1) / kWarpsPerBlock),
+  const auto launch = [&]<int RowsPerWarp, int ColsPerWarp, int Unroll>() {
+    const int cols_per_block = kWarpsPerBlock * ColsPerWarp;
+    const dim3 blocks{static_cast<unsigned int>((n + cols_per_block - 1) / cols_per_block),
                       static_cast<unsigned int>((m + RowsPerWarp - 1) / RowsPerWarp)};
     if (is_bf16) {
-      MatMulBlockScaledFp8GemvKernel<RowsPerWarp><<<blocks, threads, 0, stream>>>(
+      MatMulBlockScaledFp8GemvKernel<RowsPerWarp, ColsPerWarp, Unroll><<<blocks, threads, 0, stream>>>(
           reinterpret_cast<__nv_bfloat16*>(y), reinterpret_cast<const __nv_bfloat16*>(a), b,
           weight_scale, reinterpret_cast<const __nv_bfloat16*>(bias), m, n, k, block_size, k_blocks);
     } else {
-      MatMulBlockScaledFp8GemvKernel<RowsPerWarp><<<blocks, threads, 0, stream>>>(
+      MatMulBlockScaledFp8GemvKernel<RowsPerWarp, ColsPerWarp, Unroll><<<blocks, threads, 0, stream>>>(
           reinterpret_cast<half*>(y), reinterpret_cast<const half*>(a), b,
           weight_scale, reinterpret_cast<const half*>(bias), m, n, k, block_size, k_blocks);
     }
   };
 
+  // M == 1 is the decode-with-batch-1 case and by far the hottest. There the grid is a
+  // single wave, so widening each warp (ColsPerWarp) and pre-issuing loads (Unroll) buys
+  // memory-level parallelism at no real occupancy cost. It only pays once N is large
+  // enough that dividing the column count still leaves the GPU full -- below N == 4096
+  // the wider tiles measured slower than one column per warp on H200, and for M > 1 the
+  // extra live registers per warp (RowsPerWarp * ColsPerWarp accumulators plus the
+  // pre-issued loads) cost more than the extra parallelism is worth.
   if (m == 1) {
-    launch.template operator()<1>();
+    if (n >= 8192) {
+      launch.template operator()<1, 4, 2>();
+    } else if (n >= 4096) {
+      launch.template operator()<1, 2, 2>();
+    } else {
+      launch.template operator()<1, 1, 1>();
+    }
   } else if (m <= 2) {
-    launch.template operator()<2>();
+    launch.template operator()<2, 1, 1>();
   } else if (m <= 4) {
-    launch.template operator()<4>();
+    launch.template operator()<4, 1, 1>();
   } else {
-    launch.template operator()<8>();
+    launch.template operator()<8, 1, 1>();
   }
   return CUDA_CALL(cudaGetLastError());
 #else

--- a/onnxruntime/test/contrib_ops/matmul_block_scaled_fp8_test.cc
+++ b/onnxruntime/test/contrib_ops/matmul_block_scaled_fp8_test.cc
@@ -7,6 +7,12 @@
 #include "test/providers/provider_test_utils.h"
 #include "test/unittest_util/conversion.h"
 
+#if defined(USE_CUDA)
+// CUDA_VERSION comes from cuda.h. Without this include the guard below silently
+// evaluates to false and every test in this file is compiled out.
+#include <cuda.h>
+#endif
+
 namespace onnxruntime::test {
 
 #if defined(USE_CUDA) && !defined(DISABLE_FLOAT8_TYPES) && defined(CUDA_VERSION) && CUDA_VERSION >= 11080
@@ -187,6 +193,52 @@ TEST(MatMulBlockQuantizedFp8WeightOpTest, GemvW8A8ActivationScaleBf16) {
   std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
   execution_providers.push_back(DefaultCudaExecutionProvider());
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+}
+
+// Covers the M == 1 wide-tile GEMV dispatch, where one warp computes several output columns
+// (ColsPerWarp 2 for N >= 4096 and 4 for N >= 8192) and pre-issues loads. N is deliberately not a
+// multiple of the block's column tile so the per-column bounds predication is exercised, and the
+// weights vary per row so a mis-mapped column cannot pass by accident.
+TEST(MatMulBlockQuantizedFp8WeightOpTest, GemvDecodeWideTilesFp16) {
+  if (!HasCudaEnvironment(800)) {
+    GTEST_SKIP() << "CUDA device is required for MatMulBlockQuantizedFp8Weight.";
+  }
+
+  // n = 4098 selects ColsPerWarp 2, n = 8194 selects ColsPerWarp 4; both leave a ragged tail.
+  for (const int64_t n : {4098, 8194}) {
+    constexpr int64_t m = 1;
+    constexpr int64_t k = 64;  // K % 16 == 0 -> GEMV path; two 32-element K blocks
+    constexpr int64_t block_size = 32;
+    constexpr int64_t k_blocks = k / block_size;
+
+    // Row r weight value cycles through {1, 2, -1, -2} so each column has a distinct expectation.
+    static const float kRowValues[] = {1.0f, 2.0f, -1.0f, -2.0f};
+    std::vector<float> row_value(static_cast<size_t>(n));
+    for (int64_t r = 0; r < n; ++r) {
+      row_value[static_cast<size_t>(r)] = kRowValues[r % 4];
+    }
+    std::vector<Float8E4M3FN> b = MakeConstRowWeight(row_value, k);
+    std::vector<float> b_scale(static_cast<size_t>(n * k_blocks), 1.0f);
+
+    // A = 1.0 everywhere -> sum_k A = k, so Y[0, col] = row_value[col] * k.
+    std::vector<float> a(static_cast<size_t>(m * k), 1.0f);
+    std::vector<float> expected(static_cast<size_t>(n));
+    for (int64_t col = 0; col < n; ++col) {
+      expected[static_cast<size_t>(col)] = row_value[static_cast<size_t>(col)] * static_cast<float>(k);
+    }
+
+    OpTester test("MatMulBlockQuantizedFp8Weight", 1, onnxruntime::kMSDomain);
+    test.AddAttribute<int64_t>("block_size", block_size);
+    test.AddInput<MLFloat16>("A", {m, k}, FloatsToMLFloat16s(a));
+    test.AddInput<Float8E4M3FN>("B", {n, k}, b);
+    test.AddInput<float>("b_scale", {n, k_blocks}, b_scale);
+    test.AddOutput<MLFloat16>("Y", {m, n}, FloatsToMLFloat16s(expected));
+    test.SetOutputTolerance(0.5f);
+
+    std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+    execution_providers.push_back(DefaultCudaExecutionProvider());
+    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+  }
 }
 
 #endif  // USE_CUDA && !DISABLE_FLOAT8_TYPES && defined(CUDA_VERSION) && CUDA_VERSION >= 11080


### PR DESCRIPTION
## Description
This PR optimizes the CUDA MatMulBlockScaledFp8 GEMV decode path by increasing memory-level parallelism and widening per-warp column work when N is large. The kernel now issues grouped global loads ahead of compute, uses vectorized FP8-to-half2 conversion for B tiles, and keeps FP32 accumulation semantics unchanged. The change improves decode performance for long-output shapes while preserving correctness through targeted coverage for wide-tile and ragged-tail dispatch.

## Summary of Changes

### CUDA Kernel Optimization

| File | Change |
|------|--------|
| `onnxruntime/contrib_ops/cuda/math/matmul_block_scaled_fp8.cu` | Reworked GEMV kernel loop into load-first/consume-second phases to increase in-flight memory requests and improve overlap. |
| `onnxruntime/contrib_ops/cuda/math/matmul_block_scaled_fp8.cu` | Added vectorized macros for FP8 decode (`fp8x2 -> half2`) and fused 16-element dot-product accumulation in FP32. |
| `onnxruntime/contrib_ops/cuda/math/matmul_block_scaled_fp8.cu` | Extended kernel shape with `ColsPerWarp` and `Unroll` template parameters plus per-column predication for ragged N tails. |
| `onnxruntime/contrib_ops/cuda/math/matmul_block_scaled_fp8.cu` | Updated GEMV dispatch heuristic to select wider tiles for large N and to launch the corresponding specialized kernels. |

### Test Coverage

| File | Change |
|------|--------|
| `onnxruntime/test/contrib_ops/matmul_block_scaled_fp8_test.cc` | Included `<cuda.h>` under CUDA guards to ensure `CUDA_VERSION` is available for test compilation gating. |
| `onnxruntime/test/contrib_ops/matmul_block_scaled_fp8_test.cc` | Added `GemvDecodeWideTilesFp16` to validate wide-tile (`ColsPerWarp` 2/4) decode paths and ragged-tail column predication. |

### Documentation

| File | Change |
|------|--------|
| `docs/contrib_ops/cuda/matmul_block_scaled_fp8_experiments.md` | Documented decode GEMV MLP optimization rationale, measurements, and tuning notes (including H200 section updates). |

## Testing
- Targeted CUDA unit test coverage added in `MatMulBlockQuantizedFp8WeightOpTest.GemvDecodeWideTilesFp16`.
- Existing MatMulBlockScaledFp8 CUDA tests remain in place for regression coverage.
- Full local test execution was not run in this step.

## Motivation and Context
The previous decode GEMV structure consumed loads immediately, which limited memory-level parallelism on large-N decode shapes. By restructuring to pre-issue loads and increasing columns processed per warp for large outputs, this change better utilizes memory bandwidth and reduces decode latency while keeping numerical behavior aligned with the prior FP32 accumulation flow.

## Checklist
- [x] Tests added/updated
- [x] No breaking changes
- [x] Documentation updated (if applicable)
