### PR TITLE
[MLAS] Integrate symmetric Q4 SME2 kernels in MatMulNBits

### DIFF
--- a/onnxruntime/core/mlas/lib/kai_ukernel_interface.cpp
+++ b/onnxruntime/core/mlas/lib/kai_ukernel_interface.cpp
@@ -380,6 +380,8 @@ const KaiQnbitGemmKernel& GetKleidiAIGemmUKernel() {
 }
 
 const KaiQnbitGemmKernel& GetKleidiAIGemvUKernel() {
+    // The `sme2_dot` kernel uses SME2 SDOT instructions; `dot` here does not refer to
+    // the separate FEAT_DotProd feature.
     if (MLAS_CPUIDINFO::GetCPUIDInfo().HasArm_SME2()) {
         return kai_matmul_clamp_f32_qai8dxp1x4_qsi4c32p4vlx4_1x4vl_sme2_dot;
     } else if (MLAS_CPUIDINFO::GetCPUIDInfo().HasArmNeon_I8MM()) {

--- a/onnxruntime/core/mlas/lib/kai_ukernel_interface.cpp
+++ b/onnxruntime/core/mlas/lib/kai_ukernel_interface.cpp
@@ -17,6 +17,8 @@
 #include "kai/ukernels/matmul/matmul_clamp_f32_qai8dxp_qsi4c32p/kai_matmul_clamp_f32_qai8dxp1x8_qsi4c32p4x8_1x4x32_neon_dotprod.h"
 #include "kai/ukernels/matmul/matmul_clamp_f32_qai8dxp_qsi4c32p/kai_matmul_clamp_f32_qai8dxp4x4_qsi4c32p4x4_16x4_neon_dotprod.h"
 #include "kai/ukernels/matmul/matmul_clamp_f32_qai8dxp_qsi4c32p/kai_matmul_clamp_f32_qai8dxp4x8_qsi4c32p4x8_16x4x32_neon_i8mm.h"
+#include "kai/ukernels/matmul/matmul_clamp_f32_qai8dxp_qsi4c32p/kai_matmul_clamp_f32_qai8dxp1vlx4_qsi4c32p4vlx4_1vlx4vl_sme2_mopa.h"
+#include "kai/ukernels/matmul/matmul_clamp_f32_qai8dxp_qsi4c32p/kai_matmul_clamp_f32_qai8dxp1x4_qsi4c32p4vlx4_1x4vl_sme2_dot.h"
 #include "kai/ukernels/matmul/matmul_clamp_f32_qsi8d32p_qai4c32p/kai_matmul_clamp_f32_qsi8d32p1x4_qai4c32p4x4_1x4_neon_dotprod.h"
 #include "kai/ukernels/matmul/matmul_clamp_f32_qsi8d32p_qai4c32p/kai_matmul_clamp_f32_qsi8d32p1x8_qai4c32p4x8_1x4_neon_dotprod.h"
 #include "kai/ukernels/matmul/matmul_clamp_f32_qsi8d32p_qai4c32p/kai_matmul_clamp_f32_qsi8d32p4x4_qai4c32p4x4_8x4_neon_dotprod.h"
@@ -252,6 +254,14 @@ const KaiQnbitGemmKernel kai_matmul_clamp_f32_qai8dxp4x8_qsi4c32p4x8_16x4x32_neo
     KAI_WRAP_Q4_UKERNEL_RUN_MATMUL_11(matmul_clamp_f32_qai8dxp4x8_qsi4c32p4x8_16x4x32_neon_i8mm,
                                       KaiQ4RhsPackLayout::SymmetricNxK);
 
+const KaiQnbitGemmKernel kai_matmul_clamp_f32_qai8dxp1vlx4_qsi4c32p4vlx4_1vlx4vl_sme2_mopa =
+    KAI_WRAP_Q4_UKERNEL_RUN_MATMUL_11(matmul_clamp_f32_qai8dxp1vlx4_qsi4c32p4vlx4_1vlx4vl_sme2_mopa,
+                                      KaiQ4RhsPackLayout::SymmetricNxKInterleavedNrx4);
+
+const KaiQnbitGemmKernel kai_matmul_clamp_f32_qai8dxp1x4_qsi4c32p4vlx4_1x4vl_sme2_dot =
+    KAI_WRAP_Q4_UKERNEL_RUN_MATMUL_11(matmul_clamp_f32_qai8dxp1x4_qsi4c32p4vlx4_1x4vl_sme2_dot,
+                                      KaiQ4RhsPackLayout::SymmetricNxKInterleavedNrx4);
+
 const KaiQnbitAsymGemmKernel kai_matmul_clamp_f32_qsi8d32p1x4_qai4c32p4x4_1x4_neon_dotprod =
     KAI_WRAP_Q4_UKERNEL_RUN_MATMUL_11(matmul_clamp_f32_qsi8d32p1x4_qai4c32p4x4_1x4_neon_dotprod,
                                       KaiQ4RhsPackLayout::AsymmetricNxK);
@@ -360,7 +370,9 @@ const KaiF32SgemvKernel sgemm_gemv_sme2 =
 
 
 const KaiQnbitGemmKernel& GetKleidiAIGemmUKernel() {
-    if (MLAS_CPUIDINFO::GetCPUIDInfo().HasArmNeon_I8MM()) {
+    if (MLAS_CPUIDINFO::GetCPUIDInfo().HasArm_SME2()) {
+        return kai_matmul_clamp_f32_qai8dxp1vlx4_qsi4c32p4vlx4_1vlx4vl_sme2_mopa;
+    } else if (MLAS_CPUIDINFO::GetCPUIDInfo().HasArmNeon_I8MM()) {
         return kai_matmul_clamp_f32_qai8dxp4x8_qsi4c32p4x8_16x4x32_neon_i8mm;
     } else {
         return kai_matmul_clamp_f32_qai8dxp4x4_qsi4c32p4x4_16x4_neon_dotprod;
@@ -368,7 +380,9 @@ const KaiQnbitGemmKernel& GetKleidiAIGemmUKernel() {
 }
 
 const KaiQnbitGemmKernel& GetKleidiAIGemvUKernel() {
-    if (MLAS_CPUIDINFO::GetCPUIDInfo().HasArmNeon_I8MM()) {
+    if (MLAS_CPUIDINFO::GetCPUIDInfo().HasArm_SME2()) {
+        return kai_matmul_clamp_f32_qai8dxp1x4_qsi4c32p4vlx4_1x4vl_sme2_dot;
+    } else if (MLAS_CPUIDINFO::GetCPUIDInfo().HasArmNeon_I8MM()) {
         return kai_matmul_clamp_f32_qai8dxp1x8_qsi4c32p4x8_1x4x32_neon_dotprod;
     } else {
         return kai_matmul_clamp_f32_qai8dxp1x4_qsi4c32p4x4_1x4_neon_dotprod;

--- a/onnxruntime/core/mlas/lib/kai_ukernel_interface.h
+++ b/onnxruntime/core/mlas/lib/kai_ukernel_interface.h
@@ -34,6 +34,7 @@ struct KaiMatmulKernel {
 
 enum class KaiQ4RhsPackLayout {
     SymmetricNxK,
+    SymmetricNxKInterleavedNrx4,
     AsymmetricNxK,
     AsymmetricNxKInterleavedNrx4,
 };

--- a/onnxruntime/core/mlas/lib/qnbitgemm_kernel_neon.cpp
+++ b/onnxruntime/core/mlas/lib/qnbitgemm_kernel_neon.cpp
@@ -37,6 +37,7 @@ Abstract:
 #ifdef USE_KLEIDIAI
 #include "kai/kai_common.h"
 #include "kai/ukernels/matmul/pack/kai_rhs_pack_nxk_qsi4c32p_qsu4c32s1s0.h"
+#include "kai/ukernels/matmul/pack/kai_rhs_pack_nxk_qsi4c32ps1s0nrx4_qsu4c32s1s0_neon.h"
 #include "kai/ukernels/matmul/pack/kai_lhs_quant_pack_qai8dxp_f32.h"
 #include "kai/ukernels/matmul/pack/kai_rhs_pack_nxk_qai4c32p_qau4c32s0s1_f32_f32_f32_neon.h"
 #include "kai/ukernels/matmul/pack/kai_rhs_pack_nxk_qai4c32ps1s0nrx4_qau4c32s0s1_f32_f32_f32_neon.h"
@@ -86,7 +87,21 @@ QNBitGemmPackQuantBDataSize(
                     const size_t nr = ukernel.get_nr();
                     const size_t kr = ukernel.get_kr();
                     const size_t sr = ukernel.get_sr();
-                    size_t packed_size = kai_get_rhs_packed_size_rhs_pack_nxk_qsi4c32p_qsu4c32s1s0(N, K, nr, kr, sr, BlkLen, kai_dt_bf16);
+                    size_t packed_size;
+                    switch (k.rhs_layout) {
+                        case KaiQ4RhsPackLayout::SymmetricNxK:
+                            packed_size = kai_get_rhs_packed_size_rhs_pack_nxk_qsi4c32p_qsu4c32s1s0(
+                                N, K, nr, kr, sr, BlkLen, kai_dt_bf16);
+                            break;
+                        case KaiQ4RhsPackLayout::SymmetricNxKInterleavedNrx4:
+                            packed_size =
+                                kai_get_rhs_packed_size_rhs_pack_nxk_qsi4c32ps1s0nrx4_qsu4c32s1s0_neon(
+                                    N, K, nr, kr, sr, BlkLen, kai_dt_bf16);
+                            break;
+                        default:
+                            assert(false);
+                            return 0;
+                    }
                     if (HasZeroPoint) {
                         // Align so that BZpCorrection starts at a float-aligned offset
                         constexpr size_t FloatAlignment = alignof(float);
@@ -276,10 +291,23 @@ SQ4BitGemmPackQuantBDataAndBlkSum(
                         scales[i] = static_cast<uint16_t>(bits >> 16);
                     }
 
-                    kai_run_rhs_pack_nxk_qsi4c32p_qsu4c32s1s0(1, N, K, nr, kr, sr, BlkLen,
-                            reinterpret_cast<const uint8_t*>(QuantBDataBegin), BlockCountK * BlkLen / 2,
-                            nullptr, scales.data(), BlockCountK * sizeof(uint16_t),
-                            PackedQuantBDataBegin, 0, &params);
+                    const auto* rhs = reinterpret_cast<const uint8_t*>(QuantBDataBegin);
+                    const size_t rhs_stride = BlockCountK * BlkLen / 2;
+                    const size_t scale_stride = BlockCountK * sizeof(uint16_t);
+                    switch (k.rhs_layout) {
+                        case KaiQ4RhsPackLayout::SymmetricNxK:
+                            kai_run_rhs_pack_nxk_qsi4c32p_qsu4c32s1s0(
+                                1, N, K, nr, kr, sr, BlkLen, rhs, rhs_stride, nullptr, scales.data(), scale_stride,
+                                PackedQuantBDataBegin, 0, &params);
+                            break;
+                        case KaiQ4RhsPackLayout::SymmetricNxKInterleavedNrx4:
+                            kai_run_rhs_pack_nxk_qsi4c32ps1s0nrx4_qsu4c32s1s0_neon(
+                                1, N, K, nr, kr, sr, BlkLen, rhs, rhs_stride, nullptr, scales.data(), scale_stride,
+                                PackedQuantBDataBegin, 0, &params);
+                            break;
+                        default:
+                            assert(false);
+                    }
 
                     break;
                 }
@@ -678,12 +706,24 @@ SelectKleidiAIQ4Backend(size_t K, size_t BlkLen, bool HasZp, const MLAS_BACKEND_
         return KleidiAIQ4Backend::Qsi8d32pQai4c32p;
     }
 
-    if (!HasZp && has_neon_q4) {
+    if (!HasZp && (cpuid.HasArm_SME2() || has_neon_q4)) {
         return KleidiAIQ4Backend::Qai8dxpQsi4c32p;
     }
 
     return KleidiAIQ4Backend::None;
 }
+
+#if defined(MLAS_ENABLE_TEST_HOOKS) && defined(USE_KLEIDIAI)
+const char* GetKleidiAIQ4GemmKernelNameForTesting()
+{
+    return GetKleidiAIGemmUKernel().name;
+}
+
+const char* GetKleidiAIQ4GemvKernelNameForTesting()
+{
+    return GetKleidiAIGemvUKernel().name;
+}
+#endif
 
 template<bool QuantAUnsigned>
 size_t

--- a/onnxruntime/core/mlas/lib/qnbitgemm_kernel_neon.cpp
+++ b/onnxruntime/core/mlas/lib/qnbitgemm_kernel_neon.cpp
@@ -99,8 +99,8 @@ QNBitGemmPackQuantBDataSize(
                                     N, K, nr, kr, sr, BlkLen, kai_dt_bf16);
                             break;
                         default:
-                            assert(false);
-                            return 0;
+                            MLAS_THROW_EX(std::runtime_error,
+                                          "Unexpected RHS layout for symmetric Q4 backend.");
                     }
                     if (HasZeroPoint) {
                         // Align so that BZpCorrection starts at a float-aligned offset
@@ -125,9 +125,8 @@ QNBitGemmPackQuantBDataSize(
                         case KaiQ4RhsPackLayout::AsymmetricNxKInterleavedNrx4:
                             return kai_get_rhs_packed_size_rhs_pack_nxk_qai4c32ps1s0nrx4_qau4c32s0s1_f32_f32_f32_neon(N, K, nr, kr, BlkLen);
                         default:
-                            // Invalid layout for the asymmetric Q4 backend.
-                            assert(false);
-                            return 0;
+                            MLAS_THROW_EX(std::runtime_error,
+                                          "Unexpected RHS layout for asymmetric Q4 backend.");
                     }
                 }
                 case KleidiAIQ4Backend::None:
@@ -306,7 +305,8 @@ SQ4BitGemmPackQuantBDataAndBlkSum(
                                 PackedQuantBDataBegin, 0, &params);
                             break;
                         default:
-                            assert(false);
+                            MLAS_THROW_EX(std::runtime_error,
+                                          "Unexpected RHS layout for symmetric Q4 backend.");
                     }
 
                     break;
@@ -397,7 +397,8 @@ SQ4BitGemmPackQuantBDataAndBlkSum(
                                 break;
                             }
                             default:
-                                assert(false);
+                                MLAS_THROW_EX(std::runtime_error,
+                                              "Unexpected RHS layout for asymmetric Q4 backend.");
                         }
                     }
                     break;

--- a/onnxruntime/core/mlas/lib/qnbitgemm_kernel_neon.h
+++ b/onnxruntime/core/mlas/lib/qnbitgemm_kernel_neon.h
@@ -296,6 +296,11 @@ enum class KleidiAIQ4Backend {
 KleidiAIQ4Backend
 SelectKleidiAIQ4Backend(size_t K, size_t BlkLen, bool HasZp, const MLAS_BACKEND_KERNEL_SELECTOR_CONFIG* BackendKernelSelectorConfig);
 
+#if defined(MLAS_ENABLE_TEST_HOOKS) && defined(USE_KLEIDIAI)
+const char* GetKleidiAIQ4GemmKernelNameForTesting();
+const char* GetKleidiAIQ4GemvKernelNameForTesting();
+#endif
+
 //
 // General helpers.
 //

--- a/onnxruntime/test/mlas/unittest/test_sqnbitgemm.cpp
+++ b/onnxruntime/test/mlas/unittest/test_sqnbitgemm.cpp
@@ -18,6 +18,11 @@ Abstract:
 #include "mlas_q4.h"
 #include "mlas_qnbit.h"
 
+#if defined(MLAS_TARGET_ARM64) && defined(USE_KLEIDIAI) && defined(MLAS_ENABLE_TEST_HOOKS)
+#include "core/mlas/lib/mlasi.h"
+#include "core/mlas/lib/qnbitgemm_kernel_neon.h"
+#endif
+
 static constexpr const char* ComputeTypeName(MLAS_QNBIT_GEMM_COMPUTE_TYPE ComputeType) {
   switch (ComputeType) {
     case SQNBIT_CompFp32:
@@ -343,6 +348,57 @@ class MlasSQNBitGemmTest : public MlasTestBase {
 #endif
   }
 
+  void TestSymmetricKleidiAICompInt8(size_t M, size_t N, size_t K, bool WithThreadpool, bool WithBias) {
+#if defined(MLAS_TARGET_ARM64) && defined(USE_KLEIDIAI) && defined(MLAS_ENABLE_TEST_HOOKS)
+    const auto& cpuid = MLAS_CPUIDINFO::GetCPUIDInfo();
+    if (!cpuid.HasArm_SME2() && !cpuid.HasArmNeon_I8MM() && !cpuid.HasArmNeonDot()) {
+      GTEST_SKIP() << "KleidiAI symmetric Q4 tests require SME2, I8MM, or DotProd.";
+    }
+
+    MLAS_BACKEND_KERNEL_SELECTOR_CONFIG config;
+    config.use_kleidiai = true;
+    constexpr bool HasZeroPoint = false;
+
+    ASSERT_TRUE(MlasIsQNBitGemmAvailable(BlkBitWidth, BlkLen, SQNBIT_CompInt8));
+    ASSERT_TRUE(MlasQNBitGemmScalesPacked(K, BlkBitWidth, BlkLen, SQNBIT_CompInt8, HasZeroPoint, &config));
+
+    const char* selected_kernel = M == 1
+                                      ? sqnbitgemm_neon::GetKleidiAIQ4GemvKernelNameForTesting()
+                                      : sqnbitgemm_neon::GetKleidiAIQ4GemmKernelNameForTesting();
+    const char* expected_kernel;
+    if (cpuid.HasArm_SME2()) {
+      expected_kernel = M == 1
+                            ? "kai_run_matmul_clamp_f32_qai8dxp1x4_qsi4c32p4vlx4_1x4vl_sme2_dot"
+                            : "kai_run_matmul_clamp_f32_qai8dxp1vlx4_qsi4c32p4vlx4_1vlx4vl_sme2_mopa";
+    } else if (cpuid.HasArmNeon_I8MM()) {
+      expected_kernel = M == 1
+                            ? "kai_run_matmul_clamp_f32_qai8dxp1x8_qsi4c32p4x8_1x4x32_neon_dotprod"
+                            : "kai_run_matmul_clamp_f32_qai8dxp4x8_qsi4c32p4x8_16x4x32_neon_i8mm";
+    } else {
+      expected_kernel = M == 1
+                            ? "kai_run_matmul_clamp_f32_qai8dxp1x4_qsi4c32p4x4_1x4_neon_dotprod"
+                            : "kai_run_matmul_clamp_f32_qai8dxp4x4_qsi4c32p4x4_16x4_neon_dotprod";
+    }
+    ASSERT_STREQ(selected_kernel, expected_kernel);
+
+    ASSERT_GT(MlasQNBitGemmPackQuantBDataSize(N, K, BlkBitWidth, BlkLen, HasZeroPoint,
+                                              SQNBIT_CompInt8, &config),
+              0u);
+    ASSERT_GT(MlasQNBitGemmBatchWorkspaceSize(M, N, K, 1, BlkBitWidth, BlkLen, HasZeroPoint,
+                                              SQNBIT_CompInt8, &config),
+              0u);
+
+    Test(M, N, K, SQNBIT_CompInt8, WithThreadpool, /*Symmetric=*/true, WithBias, &config);
+#else
+    (void)M;
+    (void)N;
+    (void)K;
+    (void)WithThreadpool;
+    (void)WithBias;
+    GTEST_SKIP() << "KleidiAI symmetric Q4 tests require an ARM64 KleidiAI test-hook build.";
+#endif
+  }
+
  public:
   static const char* GetTestSuiteName() {
     static std::string suite_name = std::string("SQNBitGemm") +
@@ -458,21 +514,27 @@ class SQNBitGemmShortExecuteTest : public MlasTestFixture<MlasSQNBitGemmTest<Blk
 class SQNBitGemmKleidiAIShortExecuteTest : public MlasTestFixture<MlasSQNBitGemmTest<4, 128>> {
  public:
   explicit SQNBitGemmKleidiAIShortExecuteTest(size_t M, size_t N, size_t K,
-                                              bool WithThreadpool, bool WithBias)
+                                              bool WithThreadpool, bool Symmetric, bool WithBias)
       : M_(M),
         N_(N),
         K_(K),
         WithThreadpool_(WithThreadpool),
+        Symmetric_(Symmetric),
         WithBias_(WithBias) {
   }
 
   void TestBody() override {
-    MlasTestFixture<MlasSQNBitGemmTest<4, 128>>::mlas_tester->TestAsymmetricKleidiAICompInt8(
-        M_, N_, K_, WithThreadpool_, WithBias_);
+    if (Symmetric_) {
+      MlasTestFixture<MlasSQNBitGemmTest<4, 128>>::mlas_tester->TestSymmetricKleidiAICompInt8(
+          M_, N_, K_, WithThreadpool_, WithBias_);
+    } else {
+      MlasTestFixture<MlasSQNBitGemmTest<4, 128>>::mlas_tester->TestAsymmetricKleidiAICompInt8(
+          M_, N_, K_, WithThreadpool_, WithBias_);
+    }
   }
 
   static size_t RegisterSingleTest(const char* test_name, size_t M, size_t N, size_t K,
-                                   bool WithThreadpool, bool WithBias) {
+                                   bool WithThreadpool, bool Symmetric, bool WithBias) {
     testing::RegisterTest(
         MlasSQNBitGemmTest<4, 128>::GetTestSuiteName(),
         test_name,
@@ -481,7 +543,7 @@ class SQNBitGemmKleidiAIShortExecuteTest : public MlasTestFixture<MlasSQNBitGemm
         __FILE__,
         __LINE__,
         [=]() -> MlasTestFixture<MlasSQNBitGemmTest<4, 128>>* {
-          return new SQNBitGemmKleidiAIShortExecuteTest(M, N, K, WithThreadpool, WithBias);
+          return new SQNBitGemmKleidiAIShortExecuteTest(M, N, K, WithThreadpool, Symmetric, WithBias);
         });
 
     return 1;
@@ -491,18 +553,27 @@ class SQNBitGemmKleidiAIShortExecuteTest : public MlasTestFixture<MlasSQNBitGemm
     size_t tests_registered = 0;
 
     tests_registered += RegisterSingleTest(
-        "KleidiAIAsymGemv_M1_N257_K128", 1, 257, 128, /*WithThreadpool=*/false, /*WithBias=*/true);
+        "KleidiAIAsymGemv_M1_N257_K128", 1, 257, 128,
+        /*WithThreadpool=*/false, /*Symmetric=*/false, /*WithBias=*/true);
     tests_registered += RegisterSingleTest(
-        "KleidiAIAsymGemm_M5_N257_K128", 5, 257, 128, /*WithThreadpool=*/true, /*WithBias=*/true);
+        "KleidiAIAsymGemm_M5_N257_K128", 5, 257, 128,
+        /*WithThreadpool=*/true, /*Symmetric=*/false, /*WithBias=*/true);
     tests_registered += RegisterSingleTest(
-        "KleidiAIAsymGemv_M1_N288_K1024_NoBias", 1, 288, 1024, /*WithThreadpool=*/false, /*WithBias=*/false);
+        "KleidiAIAsymGemv_M1_N288_K1024_NoBias", 1, 288, 1024,
+        /*WithThreadpool=*/false, /*Symmetric=*/false, /*WithBias=*/false);
+    tests_registered += RegisterSingleTest(
+        "KleidiAISymGemv_M1_N257_K128_NoBias", 1, 257, 128,
+        /*WithThreadpool=*/false, /*Symmetric=*/true, /*WithBias=*/false);
+    tests_registered += RegisterSingleTest(
+        "KleidiAISymGemm_M5_N257_K1024", 5, 257, 1024,
+        /*WithThreadpool=*/true, /*Symmetric=*/true, /*WithBias=*/true);
 
     return tests_registered;
   }
 
  private:
   size_t M_, N_, K_;
-  bool WithThreadpool_, WithBias_;
+  bool WithThreadpool_, Symmetric_, WithBias_;
 };
 
 static size_t SQNBitGemmRegisterAllShortExecuteTests() {


### PR DESCRIPTION
### Description

This change integrates the Arm® KleidiAI™ symmetric Q4 SME2 kernels into the existing symmetric-quantized Q4 MatMulNBits path. The preexisting kernels and fallback behavior is preserved and is used wherever SME2 is not available.

The accompanying MLAS tests cover symmetric Q4 correctness and verify feature-based kernel selection.

### Motivation and Context

The new kernel integrations reduce latency on SME2-equipped hardware. The benchmarks below were run on a Mac Mini with M4 Pro.

End-to-end testing using a symmetric Q4 Phi-4 model produced the following result:

| Patch | Base | No KleidiAI | Patch vs base |
|---:|---:|---:|---:|
| 31.416 ms | 46.041 ms | 69.120 ms | **31.8% faster** |

The numbers are the median of the mean inference times of 3 benchmark runs, each with 100 timed inferences.

Synthetic MatMulNBits shapes representative of common LLM tensors show similar improvement (with `b` denoting quantization block size):

| Shape | Patch | Base | No KleidiAI | Patch vs base |
|---|---:|---:|---:|---:|
| M1 K3072 N3072, b32 | 0.0637 ms | 0.1334 ms | 0.1943 ms | **52.2% faster** |
| M1 K3072 N8192, b32 | 0.1693 ms | 0.2990 ms | 0.4503 ms | **43.4% faster** |
| M1 K8192 N3072, b32 | 0.1752 ms | 0.3008 ms | 0.4488 ms | **41.7% faster** |
| M1 K4096 N4096, b128 | 0.0840 ms | 0.1884 ms | 0.2737 ms | **55.4% faster** |

The synthetic shape numbers were obtained as the arithmetic mean of 2 benchmark runs with 200 timed inferences each.

The built-in MLAS benchmark across 10 repetitions also shows consistent kernel-level improvement:

| Case | Patch | Base | No KleidiAI |
|---|---:|---:|---:|
| Hidden M1 b32 | 61.84 µs | 110.23 µs | 167.03 µs |
| Up M1 b32 | 170.61 µs | 297.93 µs | 447.89 µs |
| Common M1 b128 | 81.62 µs | 187.73 µs | 272.33 µs |