### PR TITLE
--enable_training_apis --use_cuda` fails to compile: `ctx->GetComputeStream()` passed where `SoftmaxComputeStreamT` (raw `cudaStream_t`) is expected

### DIFF
--- a/orttraining/orttraining/training_ops/cuda/loss/softmax_cross_entropy_loss_impl.cc
+++ b/orttraining/orttraining/training_ops/cuda/loss/softmax_cross_entropy_loss_impl.cc
@@ -110,7 +110,7 @@ Status SoftmaxCrossEntropyLoss<T, TLabel, TOut>::ComputeInternal(OpKernelContext
   }
 
   // Calculate logsoftmax
-  auto status = SoftMaxComputeHelper<T, TOut, true>(ctx->GetComputeStream(), logit_data, logit_reshape, log_prob_data, 1);
+  auto status = SoftMaxComputeHelper<T, TOut, true>(Stream(ctx), logit_data, logit_reshape, log_prob_data, 1);
   ORT_RETURN_IF_ERROR(status);
 
   const T* weight_data = nullptr;

--- a/orttraining/orttraining/training_ops/cuda/loss/softmaxcrossentropy_impl.cc
+++ b/orttraining/orttraining/training_ops/cuda/loss/softmaxcrossentropy_impl.cc
@@ -49,7 +49,7 @@ Status SoftmaxCrossEntropy<T>::ComputeInternal(OpKernelContext* ctx) const {
   T* log_prob_data = log_prob->template MutableData<T>();
 
   // calculate logsoftmax
-  auto status = SoftMaxComputeHelper<T, T, true>(ctx->GetComputeStream(),
+  auto status = SoftMaxComputeHelper<T, T, true>(Stream(ctx),
                                                  logit_data,
                                                  logit_reshape,
                                                  log_prob_data,
@@ -151,7 +151,7 @@ Status SparseSoftmaxCrossEntropy<T, Tin>::ComputeInternal(OpKernelContext* ctx) 
   T* log_prob_data = log_prob->template MutableData<T>();
 
   // calculate logsoftmax
-  auto status = SoftMaxComputeHelper<T, T, true>(ctx->GetComputeStream(),
+  auto status = SoftMaxComputeHelper<T, T, true>(Stream(ctx),
                                                  logit_data,
                                                  logit_reshape,
                                                  log_prob_data,


### PR DESCRIPTION
### Description

`SoftMaxComputeHelper` (`onnxruntime/core/providers/cuda/math/softmax.h`) expects a `SoftmaxComputeStreamT` (`cudaStream_t`), but three call sites in the training softmax/cross-entropy CUDA kernels pass `ctx->GetComputeStream()` directly, which returns `onnxruntime::Stream*`, not the raw handle. This fails to compile:

```
orttraining/orttraining/training_ops/cuda/loss/softmax_cross_entropy_loss_impl.cc:113:74:
error: cannot convert 'onnxruntime::Stream*' to 'onnxruntime::cuda::SoftmaxComputeStreamT'
{aka 'CUstream_st*'}
  auto status = SoftMaxComputeHelper<T, TOut, true>(ctx->GetComputeStream(), logit_data, ...
```

Fix: use the existing `CudaKernel::Stream(ctx)` helper instead, a pattern already used elsewhere in these same functions and in the non-training `onnxruntime/core/providers/cuda/math/softmax.cc`.

### Motivation and Context
`--enable_training_apis --use_cuda` is the officially documented build configuration for on-device training with CUDA (https://onnxruntime.ai/docs/build/training.html), and it currently fails to compile. Verified against v1.28.0 (also present in v1.27.1) on Debian 12, CUDA 13.3, gcc 12.2.0.


