### PR TITLE
[CUDA] Serve quantized KV caches with XQA: attention sinks, independent and per-channel scales

### DIFF
--- a/docs/contrib_ops/cuda/gqa.md
+++ b/docs/contrib_ops/cuda/gqa.md
@@ -175,16 +175,28 @@ Supported storage types (`T_CACHE`) and their formula:
 
 - `k_scale` / `v_scale` (inputs 12, 13) are **always FP32**. For `PER_TENSOR` they are scalars; for
   `PER_CHANNEL` they have shape `(kv_num_heads, 1, head_size)`.
-- New keys/values are quantized as they are appended to the present cache; the attention kernel
-  dequantizes on the fly while computing scores.
+- New keys/values are quantized as they are appended to the present cache. For `PER_TENSOR`, XQA
+  applies the K and V dequantization scales inside the attention kernel. For `PER_CHANNEL`, the
+  decode path folds the K scale into Q before attention and applies the V scale to the output
+  afterward, avoiding full-cache dequantization.
 - Registered type combinations are `T ∈ {float16, bfloat16}` × `T_CACHE ∈ {same as T, int8, FP8E4M3, uint8 (int4)}`.
 
 ### How quantized decode is served
 
-The quantized KV-cache path is handled by the **XQA** decode kernel (see §7). XQA requires
-`PER_TENSOR` scaling with `k_scale` and `v_scale` pointing to the **same** FP32 tensor,
-`head_size ∈ {64, 128, 256}`, and a query/KV group size in `{4, 8, 16, 32}`. FP8 additionally
+The INT8 and FP8 quantized KV-cache paths are handled by the **XQA** decode kernel when its other
+decode constraints are met (see §7). K and V may independently use `PER_TENSOR` or `PER_CHANNEL`
+quantization, and `k_scale` and `v_scale` may be distinct tensors. Quantized XQA also requires
+`head_size ∈ {64, 128, 256}` and a query/KV group size in `{4, 8, 16, 32}`. FP8 additionally
 requires SM89+ (Ada) or SM90+.
+
+For per-tensor scaling, XQA applies `k_scale` to the QK scores before softmax and `v_scale` to the
+attention-value accumulator. For per-channel scaling, dequantization remains linear but cannot be
+represented by scalar kernel parameters: the decode path multiplies Q by the per-channel K scale
+and multiplies the attention output by the per-channel V scale. These two
+`O(num_heads * head_size)` passes avoid dequantizing the entire cache on every decode step.
+
+INT4 caches are not supported by XQA. Quantized configurations that are ineligible for XQA use the
+dequantize-then-Flash-Attention fallback when available.
 
 INT8 cache kernels are always built; FP8 (`onnxruntime_USE_FP8_KV_CACHE`, default ON) and INT4
 (`onnxruntime_USE_INT4_KV_CACHE`, default OFF) are gated by build options (see §11).
@@ -215,7 +227,7 @@ order and the first eligible backend wins:
 
 | Priority | Backend | Selected when (summary) |
 |----------|---------|-------------------------|
-| 1 | **XQA** | Single-token decode (`seq_len == 1`), shared KV buffer. Supports sliding-window attention on both the non-quantized and quantized (INT8/FP8) paths (attention sink remains non-quantized-only). Fastest decode path; the only backend that serves a quantized KV cache. |
+| 1 | **XQA** | Single-token decode (`seq_len == 1`), shared KV buffer. Supports sliding-window attention and attention sinks on both the non-quantized and quantized (INT8/FP8) paths. Fastest decode path; supports per-tensor and per-channel quantized caches. |
 | 2 | **cuDNN SDPA** | Non-quantized FP16/BF16 causal attention. Auto-preferred on SM≥90 (Hopper/Blackwell). |
 | 3 | **Flash Attention** | General FP16/BF16 prompt and decode, including local window, softcap, and packed QKV. |
 | 4 | **Memory Efficient Attention (MEA)** | Fallback for FP16/FP32 (and BF16 on SM80+). |
@@ -233,9 +245,10 @@ enabled (see §10).
 
 ### 6.1 XQA
 
-Checked first. Used only for single-token decode under the conditions detailed in §7 (global or
-sliding-window decode; sliding window is supported on both the non-quantized and quantized paths).
-When XQA is selected, no other backend is considered.
+Checked first. Used only for single-token decode under the conditions detailed in §7. Global and
+sliding-window decode, with or without an attention sink, are supported on both the non-quantized
+and quantized paths. When XQA is selected, no other backend is considered. An XQA-ineligible
+quantized cache uses the dequantize-then-Flash-Attention fallback when available.
 
 ### 6.2 cuDNN SDPA
 
@@ -294,14 +307,19 @@ XQA (a highly optimized cross/decode attention kernel) is used only when **all**
 3. `kv_sequence_length > 0` (there is a new K/V to append).
 4. Past and present KV cache share the same buffer.
 5. No softcap.
-6. Standard softmax, **or** smooth softmax expressed via a `head_sink` tensor (non-quantized KV cache).
+6. Standard softmax, **or** smooth softmax expressed via a `head_sink` tensor.
 7. Global attention, **or** local (sliding) window attention (`local_window_size > 0`), supported on
    both the non-quantized and quantized (INT8/FP8) paths.
-8. Supported `head_size` (64, 128, or 256) and group size.
+8. Supported `head_size` (64, 128, or 256) and query/KV group size:
+   - Non-quantized: `{1, 2, 4, 5, 8, 16, 32}`.
+   - INT8/FP8: `{4, 8, 16, 32}`, with both K and V using `PER_TENSOR` or `PER_CHANNEL`
+     quantization. K and V may use different modes and distinct scale tensors.
+9. For FP8, SM89+ (Ada) or SM90+ and an FP8-enabled build.
+10. The selected XQA kernel's dynamic shared-memory requirement fits the device limit.
 
-`head_sink` (attention sink) is supported on the non-quantized XQA path only. Quantized KV cache
-(int8 / fp8) paths explicitly reject a non-null attention sink, so a GQA node with both `head_sink`
-and a quantized cache falls back to Flash/Flash-Decoding.
+`head_sink` (attention sink) is supported on both the non-quantized and quantized INT8/FP8 XQA
+paths, including local-window and multi-block decode. INT4 caches and quantized-cache QK-Norm are
+not supported by XQA.
 
 XQA selection is on by default. Setting `ORT_ENABLE_XQA=0` disables XQA.
 
@@ -432,6 +450,12 @@ CUDA parity tests live in
 
 - `TestXQAQuantizedParity` — XQA per-tensor int8 quantized decode parity.
 - `TestXQAHeadSinkParity` — non-quantized XQA decode parity with a `head_sink` (attention sink) input.
+- `TestXQAQuantizedHeadSinkParity` — INT8/FP8 XQA decode with runtime or prepacked attention sinks,
+  including global, local-window, and multi-block decode.
+- `TestXQASeparateKVScaleParity` — INT8/FP8 XQA parity with independently calibrated per-tensor K
+  and V scales.
+- `TestXQAPerChannelScaleParity` — INT8/FP8 XQA parity with per-channel K/V scales folded into Q
+  and the output.
 - `TestGQAQKNorm` — fused per-head Q/K RMSNorm (QK-Norm) parity for prompt and decode (past), FP16 and
   BF16, across packed/unpacked Q/K/V and with/without RoPE.
 
@@ -452,11 +476,9 @@ popular LLMs. Listed roughly by impact.
    fused per-head RMSNorm to Q and K before RoPE when `q_norm_weight` / `k_norm_weight` are provided
     (see §3), matching **Qwen3, Gemma 2/3, OLMo2, SmolLM3**, etc. Remaining limitation: QK-Norm
     disables Flash-Decoding, and quantized-cache QK-Norm does not yet get the XQA fast path.
-2. **Sliding-window on the quantized fused decode path.** *Implemented.* The XQA decode path now
-   serves sliding-window attention (`local_window_size > 0`) on both the non-quantized and the
-   quantized (INT8/FP8) paths. Remaining limitation: the attention sink (`head_sink`) is still
-   non-quantized-only, so quantized **GPT-OSS / Mistral / Gemma 2** sliding-window layers that also
-   use an attention sink fall back to Flash / Flash-Decoding.
+2. **Sliding-window and attention sinks on the quantized fused decode path.** *Implemented.* The
+  XQA decode path serves sliding-window attention (`local_window_size > 0`) and `head_sink` on both
+  the non-quantized and quantized (INT8/FP8) paths, including when both features are enabled.
 3. **Softcap on the fastest kernels.** Logit soft-capping (**Gemma 2**) disables both XQA and cuDNN
    SDPA, forcing the Flash / MEA / unfused paths. Adding softcap support to XQA and cuDNN would
    recover decode throughput.
@@ -465,10 +487,10 @@ popular LLMs. Listed roughly by impact.
 
 ### Medium impact
 
-5. **Quantized KV cache coverage.** Quantized decode is XQA-only and narrow: `PER_TENSOR` with
-   `k_scale == v_scale`, `head_size ∈ {64, 128, 256}`, group size `{4, 8, 16, 32}`. Gaps worth
-   filling: `PER_CHANNEL` serving, prompt-phase quantized attention, INT4 enabled by default, and
-   `head_sink` combined with a quantized cache (currently rejected).
+5. **Quantized KV cache coverage.** INT8/FP8 XQA decode supports independent `PER_TENSOR` or
+  `PER_CHANNEL` K/V scales, `head_sink`, `head_size ∈ {64, 128, 256}`, and group size
+  `{4, 8, 16, 32}`. Remaining gaps include fused prompt-phase quantized attention, INT4 XQA,
+  INT4 enabled by default, and quantized-cache QK-Norm on XQA.
 6. **Paged KV cache / continuous batching.** GQA uses a contiguous shared buffer; there is a
    separate `PagedAttention` op, but GQA itself has no paged-cache path. Paged KV is what
    high-throughput serving (vLLM-style) needs.

--- a/onnxruntime/contrib_ops/cuda/bert/group_query_attention.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/group_query_attention.cc
@@ -448,7 +448,12 @@ Status GroupQueryAttention<T, U>::ComputeInternal(OpKernelContext* context) cons
   // Q and the appended cache. Keep quantized QK-Norm off the XQA route until scale correctness is
   // validated for normalized K before quantized-cache append.
   const bool xqa_qk_norm_ok = !parameters.use_qk_norm || !is_inputs_quantized;
-  const bool use_xqa_attention_sinks = head_sink != nullptr && !is_inputs_quantized;
+  // Attention sinks (smooth softmax) work on the quantized INT8/FP8 XQA paths as well: the sink
+  // term is folded into the softmax row sum by the same kernel code, and the KV dequant scale is
+  // already applied to the QK scores (qkScale) before the row max/sum are computed, so sink and
+  // score live in the same dequantized domain. This holds for both the single-block and the
+  // multi-block (Flash Decoding) reductions, where the sink is added to the merged row sum.
+  const bool use_xqa_attention_sinks = head_sink != nullptr;
   const bool is_xqa_smooth_softmax_supported = !parameters.use_smooth_softmax || use_xqa_attention_sinks;
   // XQA is enabled when enable_xqa_=true; ineligible shapes/group sizes fall back via data.use_xqa below.
   // The XQA kernel has no attention_bias input.

--- a/onnxruntime/contrib_ops/cuda/bert/group_query_attention.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/group_query_attention.cc
@@ -471,10 +471,11 @@ Status GroupQueryAttention<T, U>::ComputeInternal(OpKernelContext* context) cons
 
     // Sliding window (local_window_size > 0) is wired through to the quantized XQA kernels as well,
     // so the INT8/FP8 variants no longer need to be restricted to global attention.
+    // K and V may use different per-tensor scales: the kernel folds k_scale into qkScale (applied to
+    // Q*K.T before softmax) and v_scale into voScale (applied to the P*V accumulator).
     bool is_int8_quantized_supported = is_int8 &&
                                        (k_quant_type_ == KVQuantizationType::PER_TENSOR &&
                                         v_quant_type_ == KVQuantizationType::PER_TENSOR &&
-                                        data.k_scale == data.v_scale &&  // XQA requires k_scale and v_scale to be the same. Here requires k_scale and v_scale are same tensor.
                                         (parameters.head_size == 256 || parameters.head_size == 128 || parameters.head_size == 64) &&
                                         (group_size == 4 || group_size == 8 || group_size == 16 || group_size == 32));
 
@@ -482,7 +483,6 @@ Status GroupQueryAttention<T, U>::ComputeInternal(OpKernelContext* context) cons
     bool is_fp8_quantized_supported = is_fp8 &&
                                       (k_quant_type_ == KVQuantizationType::PER_TENSOR &&
                                        v_quant_type_ == KVQuantizationType::PER_TENSOR &&
-                                       data.k_scale == data.v_scale &&
                                        (parameters.head_size == 256 || parameters.head_size == 128 || parameters.head_size == 64) &&
                                        (group_size == 4 || group_size == 8 || group_size == 16 || group_size == 32) &&
                                        (device_prop.major >= 9 || (device_prop.major == 8 && device_prop.minor == 9)));  // FP8 requires SM89+ (Ada Lovelace)

--- a/onnxruntime/contrib_ops/cuda/bert/group_query_attention.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/group_query_attention.cc
@@ -471,18 +471,24 @@ Status GroupQueryAttention<T, U>::ComputeInternal(OpKernelContext* context) cons
 
     // Sliding window (local_window_size > 0) is wired through to the quantized XQA kernels as well,
     // so the INT8/FP8 variants no longer need to be restricted to global attention.
-    // K and V may use different per-tensor scales: the kernel folds k_scale into qkScale (applied to
-    // Q*K.T before softmax) and v_scale into voScale (applied to the P*V accumulator).
+    // K and V may use different scales: for PER_TENSOR the kernel folds k_scale into qkScale (applied
+    // to Q*K.T before softmax) and v_scale into voScale (applied to the P*V accumulator). PER_CHANNEL
+    // scales cannot be scalars inside the kernel, so ExtremeDecoding folds them into Q and into the
+    // attention output instead, which is exact and costs two O(num_heads * head_size) passes -- far
+    // cheaper than the alternative of dequantizing the whole cache on every decode step.
+    auto is_supported_quant_type = [](KVQuantizationType t) {
+      return t == KVQuantizationType::PER_TENSOR || t == KVQuantizationType::PER_CHANNEL;
+    };
     bool is_int8_quantized_supported = is_int8 &&
-                                       (k_quant_type_ == KVQuantizationType::PER_TENSOR &&
-                                        v_quant_type_ == KVQuantizationType::PER_TENSOR &&
+                                       (is_supported_quant_type(k_quant_type_) &&
+                                        is_supported_quant_type(v_quant_type_) &&
                                         (parameters.head_size == 256 || parameters.head_size == 128 || parameters.head_size == 64) &&
                                         (group_size == 4 || group_size == 8 || group_size == 16 || group_size == 32));
 
 #ifdef USE_FP8_KV_CACHE
     bool is_fp8_quantized_supported = is_fp8 &&
-                                      (k_quant_type_ == KVQuantizationType::PER_TENSOR &&
-                                       v_quant_type_ == KVQuantizationType::PER_TENSOR &&
+                                      (is_supported_quant_type(k_quant_type_) &&
+                                       is_supported_quant_type(v_quant_type_) &&
                                        (parameters.head_size == 256 || parameters.head_size == 128 || parameters.head_size == 64) &&
                                        (group_size == 4 || group_size == 8 || group_size == 16 || group_size == 32) &&
                                        (device_prop.major >= 9 || (device_prop.major == 8 && device_prop.minor == 9)));  // FP8 requires SM89+ (Ada Lovelace)

--- a/onnxruntime/contrib_ops/cuda/bert/group_query_attention_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/group_query_attention_impl.cu
@@ -974,17 +974,22 @@ Status DequantizeFlashAttentionFallback(
 
   // Step 2: Dequantize Entire Cache
   // We now have the updated quantized cache in data.present_key/value. We need to dequantize it to k_dequant/v_dequant.
+  // Only the rows that belong to the sequence are dequantized: flash attention below is given the
+  // same total_seq_lens and never reads the padding tail of the cache, so dequantizing the full
+  // (max_length sized) capacity on every decode step is pure memory traffic.
   bool is_bsnh = (parameters.past_kv_format == AttentionQkvFormat::Q_K_V_BSNH);
 
   ORT_RETURN_IF_ERROR((LaunchDequantizeKV<T, U, float>(
       stream, k_dequant, reinterpret_cast<const U*>(data.present_key), data.k_scale,
       nullptr, parameters.batch_size, parameters.kv_num_heads, parameters.seqlen_present_kv_cache,
-      parameters.head_size, parameters.kv_cache_bit_width, parameters.k_quant_type, is_bsnh)));
+      parameters.head_size, parameters.kv_cache_bit_width, parameters.k_quant_type, is_bsnh,
+      data.total_seq_lens)));
 
   ORT_RETURN_IF_ERROR((LaunchDequantizeKV<T, U, float>(
       stream, v_dequant, reinterpret_cast<const U*>(data.present_value), data.v_scale,
       nullptr, parameters.batch_size, parameters.kv_num_heads, parameters.seqlen_present_kv_cache,
-      parameters.head_size, parameters.kv_cache_bit_width, parameters.v_quant_type, is_bsnh)));
+      parameters.head_size, parameters.kv_cache_bit_width, parameters.v_quant_type, is_bsnh,
+      data.total_seq_lens)));
 
   // Step 3: Run Flash Attention on dequantized k/v
   bool is_causal = parameters.is_unidirectional;

--- a/onnxruntime/contrib_ops/cuda/bert/group_query_attention_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/group_query_attention_impl.cu
@@ -776,7 +776,8 @@ Status ExtremeDecoding(
       past_bsnh,
       data.past_seq_lens,
       data.xqa_head_sink,
-      data.k_scale,  // kv_cache_scale
+      data.k_scale,  // k_cache_scale
+      data.v_scale,  // v_cache_scale (may differ from k_scale)
       // Map cache type to XqaQuantType: NONE->kNone, Float8E4M3FN->kFp8, int8->kInt8
       (parameters.k_quant_type == KVQuantizationType::NONE) ? XqaQuantType::kNone : (is_fp8 ? XqaQuantType::kFp8 : XqaQuantType::kInt8),
       xqa_workspace,

--- a/onnxruntime/contrib_ops/cuda/bert/group_query_attention_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/group_query_attention_impl.cu
@@ -749,6 +749,23 @@ Status ExtremeDecoding(
   void* xqa_workspace = data.xqa_buffer;
   size_t xqa_workspace_size = data.xqa_buffer_bytes;
 
+  // XQA only understands a scalar dequantization scale. Per-channel scales are folded out of the
+  // kernel instead: sk into Q (the channel dim is contracted by Q*K.T) and sv into the attention
+  // output (the channel dim is free in P*V). Both are exact -- see the derivation next to
+  // LaunchScaleHeadsByChannelScale in group_query_attention_qdq.cuh.
+  const bool fold_k_scale_into_q = parameters.k_quant_type == KVQuantizationType::PER_CHANNEL;
+  const bool fold_v_scale_into_output = parameters.v_quant_type == KVQuantizationType::PER_CHANNEL;
+
+  if (fold_k_scale_into_q) {
+    // GQABufferRequirements reserves qkv_buffer for this case, whether or not Q was rotated.
+    T* scaled_q = reinterpret_cast<T*>(data.qkv_buffer);
+    ORT_ENFORCE(scaled_q != nullptr, "Per-channel XQA requires a scratch buffer for the scaled Q.");
+    ORT_RETURN_IF_ERROR((LaunchScaleHeadsByChannelScale<T>(
+        stream, scaled_q, q_input_for_xqa, data.k_scale,
+        batch_size, sequence_length, num_heads, kv_num_heads, head_size)));
+    q_input_for_xqa = scaled_q;
+  }
+
   if (data.xqa_head_sink_needs_conversion) {
     ORT_ENFORCE(data.xqa_head_sink != nullptr, "XQA head_sink conversion buffer was not allocated.");
     ORT_ENFORCE(data.head_sink != nullptr, "XQA head_sink input was not available for conversion.");
@@ -776,8 +793,8 @@ Status ExtremeDecoding(
       past_bsnh,
       data.past_seq_lens,
       data.xqa_head_sink,
-      data.k_scale,  // k_cache_scale
-      data.v_scale,  // v_cache_scale (may differ from k_scale)
+      fold_k_scale_into_q ? nullptr : data.k_scale,       // k_cache_scale (null: already folded into Q)
+      fold_v_scale_into_output ? nullptr : data.v_scale,  // v_cache_scale (null: applied to the output below)
       // Map cache type to XqaQuantType: NONE->kNone, Float8E4M3FN->kFp8, int8->kInt8
       (parameters.k_quant_type == KVQuantizationType::NONE) ? XqaQuantType::kNone : (is_fp8 ? XqaQuantType::kFp8 : XqaQuantType::kInt8),
       xqa_workspace,
@@ -785,7 +802,15 @@ Status ExtremeDecoding(
 
   // If XQA launch fails, debugging info
 
-  return status;
+  ORT_RETURN_IF_ERROR(status);
+
+  if (fold_v_scale_into_output) {
+    ORT_RETURN_IF_ERROR((LaunchScaleHeadsByChannelScale<T>(
+        stream, data.output, data.output, data.v_scale,
+        batch_size, sequence_length, num_heads, kv_num_heads, head_size)));
+  }
+
+  return Status::OK();
 }
 
 ////////// Kernels (supports right padding but not left padding)

--- a/onnxruntime/contrib_ops/cuda/bert/group_query_attention_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/group_query_attention_impl.cu
@@ -252,7 +252,7 @@ Status PrepareQKV(
         parameters.is_packed_qkv ? nullptr : reinterpret_cast<const T*>(data.query),
         parameters.is_packed_qkv ? nullptr : reinterpret_cast<const T*>(data.key),
         parameters.is_packed_qkv ? nullptr : reinterpret_cast<const T*>(data.value),
-        q_out, k, v, data.k_scale, data.v_scale,
+        q_out, k, v, data.k_scale, data.v_scale, nullptr /* q_fold_scale */,
         num_heads, kv_num_heads, head_size, sequence_length, batch_size,
         max_cache_length, data.past_seq_lens,
         reinterpret_cast<const T*>(data.cos_cache), reinterpret_cast<const T*>(data.sin_cache),
@@ -709,6 +709,15 @@ Status ExtremeDecoding(
 
   bool past_bsnh = (past_kv_format == AttentionQkvFormat::Q_K_V_BSNH);
 
+  // XQA only understands a scalar dequantization scale. Per-channel scales are folded out of the
+  // kernel instead: sk into Q (the channel dim is contracted by Q*K.T) and sv into the attention
+  // output (the channel dim is free in P*V). Both are exact -- see the derivation next to
+  // LaunchScaleHeadsByChannelScale in group_query_attention_qdq.cuh.
+  // The Q side is folded into the preprocess kernel below, which already loads and stores Q, so it
+  // costs no extra pass; the V side needs one elementwise pass over the output after XQA returns.
+  const bool fold_k_scale_into_q = parameters.k_quant_type == KVQuantizationType::PER_CHANNEL;
+  const bool fold_v_scale_into_output = parameters.v_quant_type == KVQuantizationType::PER_CHANNEL;
+
   // Ultimate Fused Preprocessing: Unpack, RoPE Q, RoPE K, Quantize K/V, Append K/V
   // This replaces all manual steps (Rotate Q, Rotate K, Quantize, StridedCopy)
   T* q_rot_ptr = reinterpret_cast<T*>(data.qkv_buffer);
@@ -716,6 +725,10 @@ Status ExtremeDecoding(
   if (q_rot_ptr == nullptr) {
     q_input_for_xqa = reinterpret_cast<const T*>(data.query);
   }
+  // GQABufferRequirements reserves qkv_buffer whenever the K scale has to be folded into Q, so the
+  // preprocess kernel always has somewhere to write the scaled Q (rotated or not).
+  ORT_ENFORCE(!fold_k_scale_into_q || q_rot_ptr != nullptr,
+              "Per-channel XQA requires a scratch buffer for the scaled Q.");
 
   ORT_RETURN_IF_ERROR((LaunchUnpackRoPEAppend<T, U>(
       parameters.is_packed_qkv ? reinterpret_cast<const T*>(data.query) : nullptr,
@@ -727,6 +740,7 @@ Status ExtremeDecoding(
       reinterpret_cast<U*>(data.present_value),
       data.k_scale,
       data.v_scale,
+      fold_k_scale_into_q ? data.k_scale : nullptr,  // q_fold_scale
       num_heads,
       kv_num_heads,
       head_size,
@@ -748,23 +762,6 @@ Status ExtremeDecoding(
   // Determine workspace size for XQA
   void* xqa_workspace = data.xqa_buffer;
   size_t xqa_workspace_size = data.xqa_buffer_bytes;
-
-  // XQA only understands a scalar dequantization scale. Per-channel scales are folded out of the
-  // kernel instead: sk into Q (the channel dim is contracted by Q*K.T) and sv into the attention
-  // output (the channel dim is free in P*V). Both are exact -- see the derivation next to
-  // LaunchScaleHeadsByChannelScale in group_query_attention_qdq.cuh.
-  const bool fold_k_scale_into_q = parameters.k_quant_type == KVQuantizationType::PER_CHANNEL;
-  const bool fold_v_scale_into_output = parameters.v_quant_type == KVQuantizationType::PER_CHANNEL;
-
-  if (fold_k_scale_into_q) {
-    // GQABufferRequirements reserves qkv_buffer for this case, whether or not Q was rotated.
-    T* scaled_q = reinterpret_cast<T*>(data.qkv_buffer);
-    ORT_ENFORCE(scaled_q != nullptr, "Per-channel XQA requires a scratch buffer for the scaled Q.");
-    ORT_RETURN_IF_ERROR((LaunchScaleHeadsByChannelScale<T>(
-        stream, scaled_q, q_input_for_xqa, data.k_scale,
-        batch_size, sequence_length, num_heads, kv_num_heads, head_size)));
-    q_input_for_xqa = scaled_q;
-  }
 
   if (data.xqa_head_sink_needs_conversion) {
     ORT_ENFORCE(data.xqa_head_sink != nullptr, "XQA head_sink conversion buffer was not allocated.");
@@ -988,7 +985,7 @@ Status DequantizeFlashAttentionFallback(
       parameters.is_packed_qkv ? nullptr : reinterpret_cast<const T*>(data.key),
       parameters.is_packed_qkv ? nullptr : reinterpret_cast<const T*>(data.value),
       q_rot, reinterpret_cast<U*>(data.present_key), reinterpret_cast<U*>(data.present_value),
-      data.k_scale, data.v_scale,
+      data.k_scale, data.v_scale, nullptr /* q_fold_scale: this path dequantizes the cache itself */,
       parameters.num_heads, parameters.kv_num_heads, parameters.head_size, parameters.sequence_length, parameters.batch_size,
       parameters.seqlen_present_kv_cache, data.past_seq_lens,
       reinterpret_cast<const T*>(data.cos_cache), reinterpret_cast<const T*>(data.sin_cache),
@@ -1078,7 +1075,7 @@ Status FlashAttentionAndQuantizeKV(
       parameters.is_packed_qkv ? nullptr : reinterpret_cast<const T*>(data.query),
       parameters.is_packed_qkv ? nullptr : reinterpret_cast<const T*>(data.key),
       parameters.is_packed_qkv ? nullptr : reinterpret_cast<const T*>(data.value),
-      q_final, k_final, v_final, nullptr, nullptr,
+      q_final, k_final, v_final, nullptr, nullptr, nullptr /* q_fold_scale */,
       num_heads, kv_num_heads, head_size, sequence_length, batch_size,
       sequence_length, data.past_seq_lens,
       reinterpret_cast<const T*>(data.cos_cache), reinterpret_cast<const T*>(data.sin_cache),

--- a/onnxruntime/contrib_ops/cuda/bert/group_query_attention_impl.h
+++ b/onnxruntime/contrib_ops/cuda/bert/group_query_attention_impl.h
@@ -76,9 +76,11 @@ struct GQABufferRequirements {
     const size_t v_elements = k_elements;
 
     if (use_xqa) {
-      if (params.do_rotary || params.is_packed_qkv || params.use_qk_norm) {
-        // XQA needs scratch for rotated/unpacked/normalized Q.
-        // RoPE/QK-Norm K is written directly to cache by the fused preprocess kernel.
+      // XQA needs scratch for rotated/unpacked/normalized Q.
+      // RoPE/QK-Norm K is written directly to cache by the fused preprocess kernel.
+      // A per-channel K scale also needs it: the scale is folded into Q before the kernel runs.
+      if (params.do_rotary || params.is_packed_qkv || params.use_qk_norm ||
+          params.k_quant_type == KVQuantizationType::PER_CHANNEL) {
         req.qkv_buffer_bytes = elem_size * q_elements;
       }
       return req;

--- a/onnxruntime/contrib_ops/cuda/bert/group_query_attention_qdq.cuh
+++ b/onnxruntime/contrib_ops/cuda/bert/group_query_attention_qdq.cuh
@@ -377,7 +377,7 @@ Status LaunchDequantizeKV(cudaStream_t stream, T* dequantized_data,
             batch_size, num_heads, cache_sequence_length, head_size, quant_type, is_input_bsnh);
       }
 
-      assert(head_size % 8 == 0); // GQA has validated head_size that is a multiple of 8 in CheckInputs.
+      assert(head_size % 8 == 0);  // GQA has validated head_size that is a multiple of 8 in CheckInputs.
       return LaunchDequantizeKVVectorized<T, T_QUANT, T_SCALE, 8>(
           stream, dequantized_data, quantized_data, scale, valid_seq_lens,
           batch_size, num_heads, cache_sequence_length, head_size, quant_type, is_input_bsnh);
@@ -392,6 +392,60 @@ Status LaunchDequantizeKV(cudaStream_t stream, T* dequantized_data,
       batch_size, num_heads, cache_sequence_length,
       head_size, bit_width, quant_type, is_input_bsnh);
 
+  return CUDA_CALL(cudaGetLastError());
+}
+
+// ============================================================================
+// Folding per-channel KV dequantization scales into Q and into the attention output.
+//
+// The XQA decode kernel only understands a *scalar* dequantization scale: it folds k_scale into
+// qkScale (applied to the Q*K.T accumulator) and v_scale into voScale (applied to the P*V
+// accumulator). That is why per-channel quantized caches used to be disqualified from XQA and had
+// to fall back to "dequantize the whole cache, then run flash attention", which costs O(context)
+// memory traffic on every decode step.
+//
+// Per-channel scales can be moved out of the kernel exactly, because dequantization is linear and
+// the channel index is the *contraction* dim for K and the *free* dim for V:
+//
+//   scores_t = sum_d q_d * (k_td * sk_d)          = sum_d (q_d * sk_d) * k_td
+//   out_d    = sum_t p_t   * (v_td * sv_d)        = (sum_t p_t * v_td) * sv_d
+//
+// So pre-scaling Q by sk (per kv-head, per channel) and post-scaling the attention output by sv
+// produces exactly the same result as dequantizing the cache, with two elementwise passes over
+// tensors of shape [batch, seq, num_heads, head_size] -- i.e. O(1) in context length.
+//
+// p_t is unaffected because the softmax only sees the (already correct) scores, so attention sinks,
+// sliding window and the multi-block (Flash Decoding) reduction all stay valid: every step after
+// the P*V accumulation is linear in the accumulator.
+// ============================================================================
+template <typename T>
+__global__ void ScaleHeadsByChannelScaleKernel(T* __restrict__ dst,
+                                               const T* __restrict__ src,
+                                               const float* __restrict__ channel_scale,
+                                               int num_heads, int head_size, int group_size,
+                                               int64_t total_elements) {
+  const int64_t i = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (i >= total_elements) {
+    return;
+  }
+  const int h = static_cast<int>(i / head_size) % num_heads;  // q head, layout is [..., num_heads, head_size]
+  const int d = static_cast<int>(i % head_size);
+  const float scale = channel_scale[(h / group_size) * head_size + d];  // scale is [kv_num_heads, head_size]
+  dst[i] = static_cast<T>(static_cast<float>(src[i]) * scale);
+}
+
+// dst may alias src (the common case: scale the rotated Q in place, or the output in place).
+template <typename T>
+Status LaunchScaleHeadsByChannelScale(cudaStream_t stream, T* dst, const T* src,
+                                      const float* channel_scale, int batch_size, int sequence_length,
+                                      int num_heads, int kv_num_heads, int head_size) {
+  const int64_t total_elements = static_cast<int64_t>(batch_size) * sequence_length * num_heads * head_size;
+  if (total_elements == 0) {
+    return Status::OK();
+  }
+  const int blocks = static_cast<int>((total_elements + kThreadsPerBlock - 1) / kThreadsPerBlock);
+  ScaleHeadsByChannelScaleKernel<T><<<blocks, kThreadsPerBlock, 0, stream>>>(
+      dst, src, channel_scale, num_heads, head_size, num_heads / kv_num_heads, total_elements);
   return CUDA_CALL(cudaGetLastError());
 }
 

--- a/onnxruntime/contrib_ops/cuda/bert/group_query_attention_qdq.cuh
+++ b/onnxruntime/contrib_ops/cuda/bert/group_query_attention_qdq.cuh
@@ -5,6 +5,7 @@
 // Enable quantized KV cache support for INT8/INT4/FP8
 #define KV_QUANT_SUPPORTED 1
 
+#include <algorithm>
 #include <cuda_fp16.h>
 #include <cuda_fp8.h>
 
@@ -96,12 +97,28 @@ struct TypeConverter<__nv_bfloat16> {
 //   - Conversion: Native CUDA cast via __nv_cvt_float_to_fp8/fp8_to_float
 // ============================================================================
 
+// Number of cache rows that have to be dequantized for a sequence of `valid_len` tokens.
+// Rounded up to kDequantRowAlign so that a consumer which loads whole KV tiles (flash attention
+// pads the final tile) still sees the exact same values the full-cache dequantization produced.
+constexpr int kDequantRowAlign = 128;
+
+__device__ __forceinline__ int ValidRowLimit(int valid_len, int cache_sequence_length) {
+  const int rounded = (valid_len + kDequantRowAlign - 1) / kDequantRowAlign * kDequantRowAlign;
+  return rounded < cache_sequence_length ? rounded : cache_sequence_length;
+}
+
 // Dequantization Kernel: Converts Quantized (Int8/Int4/FP8) KV cache back to Floating Point (T).
 // Iterates over every individual element with one thread per element.
+//
+// `valid_seq_lens` (optional) is the per-batch total KV length. Rows at or beyond it are padding
+// that the consumer (flash attention, which is given the same lengths) never reads, so they are
+// left untouched instead of being dequantized. See DequantizeKVVectorizedKernel below for the fast
+// path used by 8-bit caches.
 template <typename T, typename T_QUANT, typename T_SCALE>
 __global__ void DequantizeKernel(T* dequantized_data,
                                  const T_QUANT* quantized_data,
                                  const T_SCALE* scale, const int* past_seq_lens,
+                                 const int* valid_seq_lens,
                                  int batch_size, int num_heads,
                                  int cache_sequence_length,
                                  int head_size, int bit_width,
@@ -117,6 +134,11 @@ __global__ void DequantizeKernel(T* dequantized_data,
     int s = static_cast<int>((i / head_size) % cache_sequence_length);
     int n = static_cast<int>((i / (head_size * cache_sequence_length)) % num_heads);
     int b = static_cast<int>((i / (num_heads * head_size * cache_sequence_length)));
+
+    // Skip the padding tail of the cache: it is not part of the attended window.
+    if (valid_seq_lens != nullptr && s >= ValidRowLimit(valid_seq_lens[b], cache_sequence_length)) {
+      continue;
+    }
 
     // Correctly identify padding in the past_kv cache.
     // In the decoding case, `seqlens` contains `past_len + new_len - 1`.
@@ -174,6 +196,161 @@ __global__ void DequantizeKernel(T* dequantized_data,
   }
 }
 
+// ============================================================================
+// Vectorized dequantization fast path for 8-bit caches (INT8 / FP8 E4M3).
+//
+// During decoding the whole KV cache is dequantized on every step, which makes this the dominant
+// cost of the quantized-KV decode path. The generic kernel above spends it on scalar 1-byte loads,
+// scalar 2-byte stores and four 64-bit div/mod per element. This variant instead
+//   * gives each thread kVecSize contiguous head-size elements so loads and stores are 8/16 bytes,
+//   * maps (batch, head) to blockIdx.y so the inner loop only does 32-bit address arithmetic,
+//   * hoists the per-channel scales out of the sequence loop (they only depend on head/channel), and
+//   * walks only the rows that are actually part of the sequence instead of the padded capacity.
+//
+// The grid is derived from the cache capacity only (never from a host-side sequence length) so the
+// launch stays valid when the decode step is captured into a CUDA graph and replayed at other
+// sequence lengths; the per-batch row limit is read from device memory inside the kernel.
+// ============================================================================
+template <int kBytes>
+struct DequantVecType;
+template <>
+struct DequantVecType<4> {
+  using type = uint32_t;
+};
+template <>
+struct DequantVecType<8> {
+  using type = uint2;
+};
+template <>
+struct DequantVecType<16> {
+  using type = uint4;
+};
+// 32 bytes is not a native load width; the compiler lowers this to two independent 16-byte loads,
+// which keeps more memory requests in flight per thread.
+struct alignas(16) DequantVec32 {
+  uint4 lo;
+  uint4 hi;
+};
+template <>
+struct DequantVecType<32> {
+  using type = DequantVec32;
+};
+
+template <typename T, typename T_QUANT, typename T_SCALE, int kVecSize>
+__global__ void DequantizeKVVectorizedKernel(T* __restrict__ dequantized_data,
+                                             const T_QUANT* __restrict__ quantized_data,
+                                             const T_SCALE* __restrict__ scale,
+                                             const int* __restrict__ valid_seq_lens,
+                                             int num_heads,
+                                             int cache_sequence_length,
+                                             int head_size,
+                                             KVQuantizationType quant_type,
+                                             bool is_input_bsnh) {
+  static_assert(sizeof(T_QUANT) == 1, "Vectorized dequantization only supports 8-bit caches.");
+  static_assert(sizeof(T) == 2, "Vectorized dequantization only supports 16-bit outputs.");
+
+  using LoadVec = typename DequantVecType<kVecSize>::type;
+  constexpr int kStoreBytes = (kVecSize * 2 >= 16) ? 16 : kVecSize * 2;
+  using StoreVec = typename DequantVecType<kStoreBytes>::type;
+  constexpr int kStoresPerVec = (kVecSize * 2) / kStoreBytes;
+  constexpr int kElemsPerStore = kVecSize / kStoresPerVec;
+
+  const int vecs_per_row = head_size / kVecSize;
+  const int rows_per_block = blockDim.x / vecs_per_row;
+  const int vec_in_row = threadIdx.x % vecs_per_row;
+  const int row_in_block = threadIdx.x / vecs_per_row;
+  if (row_in_block >= rows_per_block) {
+    return;  // blockDim.x is not an exact multiple of vecs_per_row
+  }
+
+  const int bn = blockIdx.y;  // b * num_heads + n
+  const int n = bn % num_heads;
+  const int b = bn / num_heads;
+
+  const int limit = (valid_seq_lens == nullptr)
+                        ? cache_sequence_length
+                        : ValidRowLimit(valid_seq_lens[b], cache_sequence_length);
+
+  const int h0 = vec_in_row * kVecSize;
+
+  float scales[kVecSize];
+  if (quant_type == KVQuantizationType::PER_TENSOR) {
+    const float s0 = static_cast<float>(scale[0]);
+#pragma unroll
+    for (int i = 0; i < kVecSize; i++) {
+      scales[i] = s0;
+    }
+  } else {
+    const T_SCALE* channel_scale = scale + static_cast<int64_t>(n) * head_size + h0;
+#pragma unroll
+    for (int i = 0; i < kVecSize; i++) {
+      scales[i] = static_cast<float>(channel_scale[i]);
+    }
+  }
+
+  // The output is always BNSH; only the input row stride differs between BNSH and BSNH.
+  const int64_t out_base = static_cast<int64_t>(bn) * cache_sequence_length * head_size + h0;
+  const int64_t in_base = is_input_bsnh
+                              ? (static_cast<int64_t>(b) * cache_sequence_length * num_heads * head_size +
+                                 static_cast<int64_t>(n) * head_size + h0)
+                              : (static_cast<int64_t>(bn) * cache_sequence_length * head_size + h0);
+  const int in_row_stride = is_input_bsnh ? (num_heads * head_size) : head_size;
+
+  const int row_step = rows_per_block * gridDim.x;
+  for (int s = blockIdx.x * rows_per_block + row_in_block; s < limit; s += row_step) {
+    const LoadVec packed = *reinterpret_cast<const LoadVec*>(
+        quantized_data + in_base + static_cast<int64_t>(s) * in_row_stride);
+    const auto* raw = reinterpret_cast<const T_QUANT*>(&packed);
+
+    alignas(16) T out[kVecSize];
+#pragma unroll
+    for (int i = 0; i < kVecSize; i++) {
+      float value;
+#ifdef USE_FP8_KV_CACHE
+      if constexpr (std::is_same<T_QUANT, __nv_fp8_e4m3>::value) {
+        value = static_cast<float>(raw[i]);
+      } else
+#endif
+      {
+        value = static_cast<float>(reinterpret_cast<const int8_t*>(raw)[i]);
+      }
+      out[i] = static_cast<T>(value * scales[i]);
+    }
+
+    StoreVec* dst = reinterpret_cast<StoreVec*>(dequantized_data + out_base +
+                                                static_cast<int64_t>(s) * head_size);
+#pragma unroll
+    for (int i = 0; i < kStoresPerVec; i++) {
+      dst[i] = *reinterpret_cast<const StoreVec*>(&out[i * kElemsPerStore]);
+    }
+  }
+}
+
+template <typename T, typename T_QUANT, typename T_SCALE, int kVecSize>
+Status LaunchDequantizeKVVectorized(cudaStream_t stream, T* dequantized_data,
+                                    const T_QUANT* quantized_data, const T_SCALE* scale,
+                                    const int* valid_seq_lens, int batch_size, int num_heads,
+                                    int cache_sequence_length, int head_size,
+                                    KVQuantizationType quant_type, bool is_input_bsnh) {
+  const int vecs_per_row = head_size / kVecSize;
+  const int rows_per_block = kThreadsPerBlock / vecs_per_row;
+  const int row_chunks = (cache_sequence_length + rows_per_block - 1) / rows_per_block;
+
+  // Cap the grid so that a short sequence in a large cache does not launch a wave of blocks that
+  // immediately exit; the kernel loops over the remaining chunks. The cap only depends on shapes,
+  // so the launch configuration stays constant across decode steps (CUDA graph replay safe).
+  const int grid_y = batch_size * num_heads;
+  const int max_chunks = std::max(1, 1024 / grid_y);
+  const dim3 grid(static_cast<unsigned>(std::min(row_chunks, max_chunks)),
+                  static_cast<unsigned>(grid_y));
+
+  DequantizeKVVectorizedKernel<T, T_QUANT, T_SCALE, kVecSize><<<grid, kThreadsPerBlock, 0, stream>>>(
+      dequantized_data, quantized_data, scale, valid_seq_lens,
+      num_heads, cache_sequence_length, head_size, quant_type, is_input_bsnh);
+
+  return CUDA_CALL(cudaGetLastError());
+}
+
 template <typename T, typename T_QUANT, typename T_SCALE>
 Status LaunchDequantizeKV(cudaStream_t stream, T* dequantized_data,
                           const T_QUANT* quantized_data, const T_SCALE* scale,
@@ -181,14 +358,42 @@ Status LaunchDequantizeKV(cudaStream_t stream, T* dequantized_data,
                           int cache_sequence_length,
                           int head_size, int bit_width,
                           KVQuantizationType quant_type,
-                          bool is_input_bsnh) {
+                          bool is_input_bsnh,
+                          const int* valid_seq_lens = nullptr) {
   if (cache_sequence_length == 0) return Status::OK();
+
+  // Fast path: 8-bit caches (INT8 / FP8) whose head size can be split into aligned vectors.
+  // past_seq_lens (zero-fill semantics) is only used by callers that do not have valid_seq_lens.
+  if constexpr (sizeof(T_QUANT) == 1 && sizeof(T) == 2) {
+    if (bit_width == 8 && past_seq_lens == nullptr) {
+      if (head_size % 32 == 0) {
+        return LaunchDequantizeKVVectorized<T, T_QUANT, T_SCALE, 32>(
+            stream, dequantized_data, quantized_data, scale, valid_seq_lens,
+            batch_size, num_heads, cache_sequence_length, head_size, quant_type, is_input_bsnh);
+      }
+      if (head_size % 16 == 0) {
+        return LaunchDequantizeKVVectorized<T, T_QUANT, T_SCALE, 16>(
+            stream, dequantized_data, quantized_data, scale, valid_seq_lens,
+            batch_size, num_heads, cache_sequence_length, head_size, quant_type, is_input_bsnh);
+      }
+      if (head_size % 8 == 0) {
+        return LaunchDequantizeKVVectorized<T, T_QUANT, T_SCALE, 8>(
+            stream, dequantized_data, quantized_data, scale, valid_seq_lens,
+            batch_size, num_heads, cache_sequence_length, head_size, quant_type, is_input_bsnh);
+      }
+      if (head_size % 4 == 0) {
+        return LaunchDequantizeKVVectorized<T, T_QUANT, T_SCALE, 4>(
+            stream, dequantized_data, quantized_data, scale, valid_seq_lens,
+            batch_size, num_heads, cache_sequence_length, head_size, quant_type, is_input_bsnh);
+      }
+    }
+  }
 
   // Output buffer uses cache_sequence_length stride
   int64_t total_elements = static_cast<int64_t>(batch_size) * num_heads * cache_sequence_length * head_size;
   const int blocks = static_cast<int>((total_elements + kThreadsPerBlock - 1) / kThreadsPerBlock);
   DequantizeKernel<T, T_QUANT, T_SCALE><<<blocks, kThreadsPerBlock, 0, stream>>>(
-      dequantized_data, quantized_data, scale, past_seq_lens,
+      dequantized_data, quantized_data, scale, past_seq_lens, valid_seq_lens,
       batch_size, num_heads, cache_sequence_length,
       head_size, bit_width, quant_type, is_input_bsnh);
 

--- a/onnxruntime/contrib_ops/cuda/bert/group_query_attention_qdq.cuh
+++ b/onnxruntime/contrib_ops/cuda/bert/group_query_attention_qdq.cuh
@@ -376,16 +376,11 @@ Status LaunchDequantizeKV(cudaStream_t stream, T* dequantized_data,
             stream, dequantized_data, quantized_data, scale, valid_seq_lens,
             batch_size, num_heads, cache_sequence_length, head_size, quant_type, is_input_bsnh);
       }
-      if (head_size % 8 == 0) {
-        return LaunchDequantizeKVVectorized<T, T_QUANT, T_SCALE, 8>(
-            stream, dequantized_data, quantized_data, scale, valid_seq_lens,
-            batch_size, num_heads, cache_sequence_length, head_size, quant_type, is_input_bsnh);
-      }
-      if (head_size % 4 == 0) {
-        return LaunchDequantizeKVVectorized<T, T_QUANT, T_SCALE, 4>(
-            stream, dequantized_data, quantized_data, scale, valid_seq_lens,
-            batch_size, num_heads, cache_sequence_length, head_size, quant_type, is_input_bsnh);
-      }
+
+      assert(head_size % 8 == 0); // GQA has validated head_size that is a multiple of 8 in CheckInputs.
+      return LaunchDequantizeKVVectorized<T, T_QUANT, T_SCALE, 8>(
+          stream, dequantized_data, quantized_data, scale, valid_seq_lens,
+          batch_size, num_heads, cache_sequence_length, head_size, quant_type, is_input_bsnh);
     }
   }
 

--- a/onnxruntime/contrib_ops/cuda/bert/group_query_attention_qkv.cuh
+++ b/onnxruntime/contrib_ops/cuda/bert/group_query_attention_qkv.cuh
@@ -31,7 +31,8 @@ namespace cuda {
 // 3. Appends K and V to the KV cache at the correct sequence index (past_seq_len + s).
 //    - Performs on-the-fly quantization (Int8 or Int4) if configured (BIT_WIDTH < 16).
 //    - Supports both BNSH and BSNH layouts for the KV cache.
-// 4. Writes the rotated Q back to global memory (unpacked_q) for the subsequent attention kernel.
+// 4. Writes the rotated Q back to global memory (unpacked_q) for the subsequent attention kernel,
+//    optionally pre-scaled by a per-channel K dequantization scale (q_fold_scale).
 //
 // Template Parameters:
 // - T: The floating point type for query (half or __nv_bfloat16).
@@ -49,6 +50,11 @@ __global__ void UnpackRoPEAppend(
     U* v_cache,
     const float* k_scale,
     const float* v_scale,
+    // Per-channel K dequantization scale of shape (kv_num_heads, head_size) to fold into the stored
+    // Q, or nullptr. Used by the XQA per-channel decode path: XQA only accepts a scalar dequant
+    // scale, and because the channel dim is contracted by Q*K.T, scaling Q by the K scale is exactly
+    // equivalent to dequantizing K. Folding it here is free -- this kernel already loads and stores Q.
+    const float* q_fold_scale,
     const int num_heads,
     const int kv_num_heads,
     const int head_size,
@@ -222,6 +228,15 @@ __global__ void UnpackRoPEAppend(
   if (valid) {
     if (head_type == QUERY) {
       if (unpacked_q != nullptr) {
+        if (q_fold_scale != nullptr) {
+          // Q head n attends to KV head n / group_size, whose per-channel K scale we fold in here.
+          const float* sc = q_fold_scale +
+                            static_cast<int64_t>(n / (num_heads / kv_num_heads)) * head_size + h;
+#pragma unroll
+          for (int i = 0; i < elements_per_thread; ++i) {
+            vals[i] = static_cast<T>(static_cast<float>(vals[i]) * sc[i]);
+          }
+        }
         // Store rotated Q to global memory for the Attention kernel
         const int64_t q_out_idx = static_cast<int64_t>(b) * sequence_length * q_hidden +
                                   static_cast<int64_t>(s) * q_hidden +
@@ -320,7 +335,7 @@ Status DispatchUnpackRoPEAppendHeadSize(
     const dim3& grid, const dim3& block, cudaStream_t stream,
     const T* packed_qkv, const T* query, const T* key, const T* value,
     T* unpacked_q, U* k_cache, U* v_cache,
-    const float* k_scale, const float* v_scale,
+    const float* k_scale, const float* v_scale, const float* q_fold_scale,
     const int num_heads, const int kv_num_heads, const int head_size, const int d,
     const int max_seqlen, const int* past_seq_lens,
     const T* cos_cache, const T* sin_cache, const int rotary_dim,
@@ -328,25 +343,25 @@ Status DispatchUnpackRoPEAppendHeadSize(
     const T* q_norm_weight, const T* k_norm_weight, const float qk_norm_epsilon) {
   if (head_size <= 64) {
     UnpackRoPEAppend<T, U, BIT_WIDTH, 64><<<grid, block, 0, stream>>>(
-        packed_qkv, query, key, value, unpacked_q, k_cache, v_cache, k_scale, v_scale,
+        packed_qkv, query, key, value, unpacked_q, k_cache, v_cache, k_scale, v_scale, q_fold_scale,
         num_heads, kv_num_heads, head_size, d, max_seqlen, past_seq_lens,
         cos_cache, sin_cache, rotary_dim, position_ids, interleaved, is_cache_bnsh, per_channel,
         q_norm_weight, k_norm_weight, qk_norm_epsilon);
   } else if (head_size <= 128) {
     UnpackRoPEAppend<T, U, BIT_WIDTH, 128><<<grid, block, 0, stream>>>(
-        packed_qkv, query, key, value, unpacked_q, k_cache, v_cache, k_scale, v_scale,
+        packed_qkv, query, key, value, unpacked_q, k_cache, v_cache, k_scale, v_scale, q_fold_scale,
         num_heads, kv_num_heads, head_size, d, max_seqlen, past_seq_lens,
         cos_cache, sin_cache, rotary_dim, position_ids, interleaved, is_cache_bnsh, per_channel,
         q_norm_weight, k_norm_weight, qk_norm_epsilon);
   } else if (head_size <= 256) {
     UnpackRoPEAppend<T, U, BIT_WIDTH, 256><<<grid, block, 0, stream>>>(
-        packed_qkv, query, key, value, unpacked_q, k_cache, v_cache, k_scale, v_scale,
+        packed_qkv, query, key, value, unpacked_q, k_cache, v_cache, k_scale, v_scale, q_fold_scale,
         num_heads, kv_num_heads, head_size, d, max_seqlen, past_seq_lens,
         cos_cache, sin_cache, rotary_dim, position_ids, interleaved, is_cache_bnsh, per_channel,
         q_norm_weight, k_norm_weight, qk_norm_epsilon);
   } else if (head_size <= 512) {
     UnpackRoPEAppend<T, U, BIT_WIDTH, 512><<<grid, block, 0, stream>>>(
-        packed_qkv, query, key, value, unpacked_q, k_cache, v_cache, k_scale, v_scale,
+        packed_qkv, query, key, value, unpacked_q, k_cache, v_cache, k_scale, v_scale, q_fold_scale,
         num_heads, kv_num_heads, head_size, d, max_seqlen, past_seq_lens,
         cos_cache, sin_cache, rotary_dim, position_ids, interleaved, is_cache_bnsh, per_channel,
         q_norm_weight, k_norm_weight, qk_norm_epsilon);
@@ -365,7 +380,7 @@ template <typename T, typename U>
 Status LaunchUnpackRoPEAppend(
     const T* packed_qkv, const T* query, const T* key, const T* value,
     T* unpacked_q, U* k_cache, U* v_cache,
-    const float* k_scale, const float* v_scale,
+    const float* k_scale, const float* v_scale, const float* q_fold_scale,
     const int num_heads, const int kv_num_heads, const int head_size,
     const int sequence_length, const int batch_size, const int max_seqlen,
     const int* past_seq_lens, const T* cos_cache, const T* sin_cache,
@@ -418,7 +433,7 @@ Status LaunchUnpackRoPEAppend(
     // No quantization: cache type same as input type
     return DispatchUnpackRoPEAppendHeadSize<T, U, 16>(
         grid, block, stream, packed_qkv, query, key, value, unpacked_q, k_cache, v_cache,
-        k_scale, v_scale, num_heads, kv_num_heads, head_size, d, max_seqlen, past_seq_lens,
+        k_scale, v_scale, q_fold_scale, num_heads, kv_num_heads, head_size, d, max_seqlen, past_seq_lens,
         cos_cache, sin_cache, rotary_dim, position_ids, interleaved, is_cache_bnsh, per_channel,
         q_norm_weight, k_norm_weight, qk_norm_epsilon);
   } else if constexpr (std::is_same<U, int8_t>::value
@@ -429,7 +444,7 @@ Status LaunchUnpackRoPEAppend(
     // INT8 or FP8 quantization (both 8-bit, distinguished inside kernel by type check)
     return DispatchUnpackRoPEAppendHeadSize<T, U, 8>(
         grid, block, stream, packed_qkv, query, key, value, unpacked_q, k_cache, v_cache,
-        k_scale, v_scale, num_heads, kv_num_heads, head_size, d, max_seqlen, past_seq_lens,
+        k_scale, v_scale, q_fold_scale, num_heads, kv_num_heads, head_size, d, max_seqlen, past_seq_lens,
         cos_cache, sin_cache, rotary_dim, position_ids, interleaved, is_cache_bnsh, per_channel,
         q_norm_weight, k_norm_weight, qk_norm_epsilon);
 #ifdef USE_INT4_KV_CACHE
@@ -437,7 +452,7 @@ Status LaunchUnpackRoPEAppend(
     // INT4 quantization (packed 2 elements per byte)
     return DispatchUnpackRoPEAppendHeadSize<T, U, 4>(
         grid, block, stream, packed_qkv, query, key, value, unpacked_q, k_cache, v_cache,
-        k_scale, v_scale, num_heads, kv_num_heads, head_size, d, max_seqlen, past_seq_lens,
+        k_scale, v_scale, q_fold_scale, num_heads, kv_num_heads, head_size, d, max_seqlen, past_seq_lens,
         cos_cache, sin_cache, rotary_dim, position_ids, interleaved, is_cache_bnsh, per_channel,
         q_norm_weight, k_norm_weight, qk_norm_epsilon);
 #endif

--- a/onnxruntime/contrib_ops/cuda/bert/xqa/mha_impl.cuh
+++ b/onnxruntime/contrib_ops/cuda/bert/xqa/mha_impl.cuh
@@ -1267,8 +1267,11 @@ CUBIN_EXPORT __global__
 #endif
 #endif
         uint32_t const batchSize,
-        float const* __restrict__ kvCacheScale,  // Device memory scalar. Same scale for K and V cache. Used only for
-                                                 // int8/fp8 KV cache.
+        // Device memory scalars, used only for int8/fp8 KV cache. K and V have independent scales:
+        // kCacheScale is folded into qkScale (applied to Q*K.T before softmax) and vCacheScale into
+        // voScale (applied to the P*V accumulator). Both are read once per CTA, outside the K/V loop.
+        float const* __restrict__ kCacheScale,
+        float const* __restrict__ vCacheScale,
         uint32_t* __restrict__ semaphores = nullptr, void* __restrict__ scratch = nullptr) {
   assert(allowMultiBlockMode || gridDim.x == 1);
   bool const isMultiBlock = allowMultiBlockMode && (gridDim.x != 1);
@@ -1466,7 +1469,7 @@ CUBIN_EXPORT __global__
 #endif
   };
   if (warpIdx.z == 0) {
-    float const qkScale = qScale * (isKVCacheQuantized ? kvCacheScale[0] : 1.f);  // qkScale is applied onto Q*K.T before softmax.
+    float const qkScale = qScale * (isKVCacheQuantized ? kCacheScale[0] : 1.f);  // qkScale is applied onto Q*K.T before softmax.
     CircIdx<nbKBuffers> idxCurrSMemKBuf{nbKBuffers - 1};
     auto const getSMemKTile = [&](uint32_t idx) -> SharedMem::KSmemBuffer& { return smem.k[warpIdx.x][idx]; };
 #if BEAM_WIDTH > 1
@@ -2147,7 +2150,7 @@ CUBIN_EXPORT __global__
       }
     }
 
-    float voScale = (isKVCacheQuantized ? kvCacheScale[0] : 1.F);
+    float voScale = (isKVCacheQuantized ? vCacheScale[0] : 1.F);
     if (seqIterInit < nbSeqIters) {  // otherwise rcpRowSum will be NAN.
       // The attention sinks are moved to the multi-block reduction part if the multi-block is enabled.
       if (!isMultiBlock && attentionSinks != nullptr) {
@@ -2388,8 +2391,9 @@ CUBIN_EXPORT __global__ __launch_bounds__(256, nbCtaPerSM) void kernel_mha(
     BeamSearchParams const beamSearchParams,
 #endif
     uint32_t const batchSize,
-    float const* __restrict__ kvCacheScale,  // Device memory scalar. Same scale for K and V cache. Used only for
-                                             // int8/fp8 KV cache.
+    // Device memory scalars, used only for int8/fp8 KV cache. See kernel_mha_impl.
+    float const* __restrict__ kCacheScale,
+    float const* __restrict__ vCacheScale,
     uint32_t* __restrict__ semaphores = nullptr, void* __restrict__ scratch = nullptr) {
 #if SPEC_DEC
   kernel_mha_impl(qSeqLen, nbKHeads, headGrpSize, qCuSeqLens,
@@ -2411,7 +2415,7 @@ CUBIN_EXPORT __global__ __launch_bounds__(256, nbCtaPerSM) void kernel_mha(
 #if BEAM_WIDTH > 1
                   beamSearchParams,
 #endif
-                  batchSize, kvCacheScale, semaphores, scratch);
+                  batchSize, kCacheScale, vCacheScale, semaphores, scratch);
 }
 #else
 static constexpr auto kernel_mha = kernel_mha_impl;
@@ -2468,8 +2472,10 @@ void launchMHA(cudaDeviceProp const& prop, uint32_t nbKHeads,
                BeamSearchParams const& beamSearchParams,
 #endif
                uint32_t batchSize,
-               float const* __restrict__ kvCacheScale,  // Device memory scalar. Same scale for K and V cache. Used only for
-                                                        // int8/fp8 KV cache.
+               // Device memory scalars, used only for int8/fp8 KV cache. K and V may have different
+               // scales; both are per-tensor (a single float each).
+               float const* __restrict__ kCacheScale,
+               float const* __restrict__ vCacheScale,
 #if SPEC_DEC
                SpecDecParams const& specDecParams,
 #endif
@@ -2556,7 +2562,7 @@ void launchMHA(cudaDeviceProp const& prop, uint32_t nbKHeads,
 #if BEAM_WIDTH > 1
                      beamSearchParams,
 #endif
-                     batchSize, kvCacheScale, semaphores, scratch);
+                     batchSize, kCacheScale, vCacheScale, semaphores, scratch);
 #else
   KVCacheList<false> const cacheList{kCacheData, vCacheData, seqLen, maxSeqLen, isBSNH, 1};
 #ifndef NDEBUG
@@ -2584,7 +2590,7 @@ void launchMHA(cudaDeviceProp const& prop, uint32_t nbKHeads,
 #if BEAM_WIDTH > 1
       beamSearchParams,
 #endif
-      batchSize, kvCacheScale, semaphores, scratch);
+      batchSize, kCacheScale, vCacheScale, semaphores, scratch);
 #endif
   checkCuda(cudaPeekAtLastError());
 #endif  // USE_INPUT_KV

--- a/onnxruntime/contrib_ops/cuda/bert/xqa/mha_impl.cuh
+++ b/onnxruntime/contrib_ops/cuda/bert/xqa/mha_impl.cuh
@@ -1270,6 +1270,9 @@ CUBIN_EXPORT __global__
         // Device memory scalars, used only for int8/fp8 KV cache. K and V have independent scales:
         // kCacheScale is folded into qkScale (applied to Q*K.T before softmax) and vCacheScale into
         // voScale (applied to the P*V accumulator). Both are read once per CTA, outside the K/V loop.
+        // Either may be null, meaning "scale is 1": the caller has already folded a non-scalar
+        // (per-channel) scale into Q / into the output, which is exact because dequantization is
+        // linear and the channel dim is contracted for K and free for V.
         float const* __restrict__ kCacheScale,
         float const* __restrict__ vCacheScale,
         uint32_t* __restrict__ semaphores = nullptr, void* __restrict__ scratch = nullptr) {
@@ -1469,7 +1472,8 @@ CUBIN_EXPORT __global__
 #endif
   };
   if (warpIdx.z == 0) {
-    float const qkScale = qScale * (isKVCacheQuantized ? kCacheScale[0] : 1.f);  // qkScale is applied onto Q*K.T before softmax.
+    // qkScale is applied onto Q*K.T before softmax. A null kCacheScale means the scale is already in Q.
+    float const qkScale = qScale * ((isKVCacheQuantized && kCacheScale != nullptr) ? kCacheScale[0] : 1.f);
     CircIdx<nbKBuffers> idxCurrSMemKBuf{nbKBuffers - 1};
     auto const getSMemKTile = [&](uint32_t idx) -> SharedMem::KSmemBuffer& { return smem.k[warpIdx.x][idx]; };
 #if BEAM_WIDTH > 1
@@ -2150,7 +2154,8 @@ CUBIN_EXPORT __global__
       }
     }
 
-    float voScale = (isKVCacheQuantized ? vCacheScale[0] : 1.F);
+    // A null vCacheScale means the caller rescales the output itself (per-channel V scale).
+    float voScale = ((isKVCacheQuantized && vCacheScale != nullptr) ? vCacheScale[0] : 1.F);
     if (seqIterInit < nbSeqIters) {  // otherwise rcpRowSum will be NAN.
       // The attention sinks are moved to the multi-block reduction part if the multi-block is enabled.
       if (!isMultiBlock && attentionSinks != nullptr) {

--- a/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_impl_gen.cuh
+++ b/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_impl_gen.cuh
@@ -57,7 +57,8 @@ inline Status Launch(
     [[maybe_unused]] const bool is_bsnh,
     [[maybe_unused]] const int* past_seq_lens,
     [[maybe_unused]] const float* attention_sinks,
-    [[maybe_unused]] const float* kv_cache_scale,
+    [[maybe_unused]] const float* k_cache_scale,
+    [[maybe_unused]] const float* v_cache_scale,
     [[maybe_unused]] void* workspace,
     [[maybe_unused]] size_t workspace_size,
     // No default: every caller must thread local_window_size through explicitly so a future
@@ -125,9 +126,10 @@ inline Status Launch(
       static_cast<uint32_t>(max_seq_len),
       reinterpret_cast<const uint32_t*>(past_seq_lens),
       static_cast<uint32_t>(batch_size),
-      kv_cache_scale,  // Pass kv_cache_scale for INT8 dequantization
-      semaphores,      // semaphores
-      scratch,         // scratch
+      k_cache_scale,  // K dequantization scale (INT8/FP8 KV cache only)
+      v_cache_scale,  // V dequantization scale (INT8/FP8 KV cache only)
+      semaphores,     // semaphores
+      scratch,        // scratch
       stream);
   return Status::OK();
 #else

--- a/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_loader.h
+++ b/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_loader.h
@@ -40,6 +40,8 @@ Status LaunchXQAKernel(
     const float* attention_sinks,  // Attention sink per query head, nullptr if not used
     const float* k_cache_scale,    // K cache dequant scale (nullptr for FP16/BF16, per-tensor float for INT8/FP8)
     const float* v_cache_scale,    // V cache dequant scale; may differ from k_cache_scale
+                                   // For a quantized cache, a null scale means "1": the caller has folded a
+                                   // per-channel scale into Q (for K) or rescales the output itself (for V).
     const XqaQuantType kv_quant_type,
     void* workspace = nullptr,  // Scratch memory
     size_t workspace_size = 0   // Size of scratch memory

--- a/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_loader.h
+++ b/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_loader.h
@@ -38,7 +38,8 @@ Status LaunchXQAKernel(
     const bool is_bsnh,            // Layout of KV cache
     const int* past_seq_lens,      // Past sequence lengths [BatchSize]
     const float* attention_sinks,  // Attention sink per query head, nullptr if not used
-    const float* kv_cache_scale,   // KV cache dequant scale (nullptr for FP16/BF16, per-tensor float for INT8)
+    const float* k_cache_scale,    // K cache dequant scale (nullptr for FP16/BF16, per-tensor float for INT8/FP8)
+    const float* v_cache_scale,    // V cache dequant scale; may differ from k_cache_scale
     const XqaQuantType kv_quant_type,
     void* workspace = nullptr,  // Scratch memory
     size_t workspace_size = 0   // Size of scratch memory

--- a/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_loader_bf16.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_loader_bf16.cu
@@ -28,7 +28,8 @@ Status LaunchXQAKernelImpl(
     const bool is_bsnh,
     const int* past_seq_lens,
     const float* attention_sinks,
-    const float* kv_cache_scale,
+    const float* k_cache_scale,
+    const float* v_cache_scale,
     const XqaQuantType kv_quant_type,
     void* workspace,
     size_t workspace_size);
@@ -53,7 +54,8 @@ Status LaunchXQAKernelImpl(
     const bool is_bsnh,
     const int* past_seq_lens,
     const float* attention_sinks,
-    const float* kv_cache_scale,
+    const float* k_cache_scale,
+    const float* v_cache_scale,
     const XqaQuantType kv_quant_type,
     void* workspace,
     size_t workspace_size);
@@ -78,7 +80,8 @@ Status LaunchXQAKernelImpl(
     const bool is_bsnh,
     const int* past_seq_lens,
     const float* attention_sinks,
-    const float* kv_cache_scale,
+    const float* k_cache_scale,
+    const float* v_cache_scale,
     const XqaQuantType kv_quant_type,
     void* workspace,
     size_t workspace_size);
@@ -102,7 +105,8 @@ Status LaunchXQAInt8KernelBF16(
     const bool is_bsnh,
     const int* past_seq_lens,
     const float* attention_sinks,
-    const float* kv_cache_scale,
+    const float* k_cache_scale,
+    const float* v_cache_scale,
     void* workspace,
     size_t workspace_size);
 
@@ -128,7 +132,8 @@ Status LaunchXQAKernel<__nv_bfloat16>(
     const bool is_bsnh,
     const int* past_seq_lens,
     const float* attention_sinks,
-    const float* kv_cache_scale,
+    const float* k_cache_scale,
+    const float* v_cache_scale,
     const XqaQuantType kv_quant_type,
     void* workspace,
     size_t workspace_size) {
@@ -136,22 +141,22 @@ Status LaunchXQAKernel<__nv_bfloat16>(
   // term is folded into the softmax row sum, and the KV dequant scale is already applied to the QK
   // scores before the row max/sum are computed, so both are in the same dequantized domain.
   if (kv_quant_type == XqaQuantType::kInt8) {
-    return LaunchXQAInt8KernelBF16(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, local_window_size, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size);
+    return LaunchXQAInt8KernelBF16(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, local_window_size, is_bsnh, past_seq_lens, attention_sinks, k_cache_scale, v_cache_scale, workspace, workspace_size);
   }
 
   // Dispatch based on head_size
   if (head_size == 256) {
     return H256::LaunchXQAKernelImpl<__nv_bfloat16>(
         device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size,
-        max_seq_len, scale, local_window_size, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, kv_quant_type, workspace, workspace_size);
+        max_seq_len, scale, local_window_size, is_bsnh, past_seq_lens, attention_sinks, k_cache_scale, v_cache_scale, kv_quant_type, workspace, workspace_size);
   } else if (head_size == 128) {
     return H128::LaunchXQAKernelImpl<__nv_bfloat16>(
         device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size,
-        max_seq_len, scale, local_window_size, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, kv_quant_type, workspace, workspace_size);
+        max_seq_len, scale, local_window_size, is_bsnh, past_seq_lens, attention_sinks, k_cache_scale, v_cache_scale, kv_quant_type, workspace, workspace_size);
   } else if (head_size == 64) {
     return H64::LaunchXQAKernelImpl<__nv_bfloat16>(
         device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size,
-        max_seq_len, scale, local_window_size, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, kv_quant_type, workspace, workspace_size);
+        max_seq_len, scale, local_window_size, is_bsnh, past_seq_lens, attention_sinks, k_cache_scale, v_cache_scale, kv_quant_type, workspace, workspace_size);
   } else {
     return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "XQA only supports head_size=64, 128, or 256. Input has ", head_size);
   }

--- a/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_loader_bf16.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_loader_bf16.cu
@@ -101,6 +101,7 @@ Status LaunchXQAInt8KernelBF16(
     const int local_window_size,
     const bool is_bsnh,
     const int* past_seq_lens,
+    const float* attention_sinks,
     const float* kv_cache_scale,
     void* workspace,
     size_t workspace_size);
@@ -131,10 +132,11 @@ Status LaunchXQAKernel<__nv_bfloat16>(
     const XqaQuantType kv_quant_type,
     void* workspace,
     size_t workspace_size) {
-  // Dispatch to INT8 path if requested
+  // Dispatch to INT8 path if requested. Attention sinks (smooth softmax) are supported: the sink
+  // term is folded into the softmax row sum, and the KV dequant scale is already applied to the QK
+  // scores before the row max/sum are computed, so both are in the same dequantized domain.
   if (kv_quant_type == XqaQuantType::kInt8) {
-    ORT_RETURN_IF(attention_sinks != nullptr, "XQA attention sinks are not supported with INT8 KV cache.");
-    return LaunchXQAInt8KernelBF16(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, local_window_size, is_bsnh, past_seq_lens, kv_cache_scale, workspace, workspace_size);
+    return LaunchXQAInt8KernelBF16(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, local_window_size, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size);
   }
 
   // Dispatch based on head_size

--- a/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_loader_bf16_128.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_loader_bf16_128.cu
@@ -28,7 +28,8 @@ template Status HEAD_DIM_NAMESPACE::LaunchXQAKernelImpl<__nv_bfloat16>(
     const bool is_bsnh,
     const int* past_seq_lens,
     const float* attention_sinks,
-    const float* kv_cache_scale,
+    const float* k_cache_scale,
+    const float* v_cache_scale,
     const XqaQuantType kv_quant_type,
     void* workspace,
     size_t workspace_size);

--- a/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_loader_bf16_256.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_loader_bf16_256.cu
@@ -28,7 +28,8 @@ template Status HEAD_DIM_NAMESPACE::LaunchXQAKernelImpl<__nv_bfloat16>(
     const bool is_bsnh,
     const int* past_seq_lens,
     const float* attention_sinks,
-    const float* kv_cache_scale,
+    const float* k_cache_scale,
+    const float* v_cache_scale,
     const XqaQuantType kv_quant_type,
     void* workspace,
     size_t workspace_size);

--- a/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_loader_bf16_64.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_loader_bf16_64.cu
@@ -28,7 +28,8 @@ template Status HEAD_DIM_NAMESPACE::LaunchXQAKernelImpl<__nv_bfloat16>(
     const bool is_bsnh,
     const int* past_seq_lens,
     const float* attention_sinks,
-    const float* kv_cache_scale,
+    const float* k_cache_scale,
+    const float* v_cache_scale,
     const XqaQuantType kv_quant_type,
     void* workspace,
     size_t workspace_size);

--- a/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_loader_bf16_fp8_impl.cuh
+++ b/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_loader_bf16_fp8_impl.cuh
@@ -101,19 +101,20 @@ Status LaunchXQAFp8KernelBF16(
     const int local_window_size,
     const bool is_bsnh,
     const int* past_seq_lens,
+    const float* attention_sinks,
     const float* kv_cache_scale,
     void* workspace,
     size_t workspace_size) {
   int group_size = num_heads / kv_num_heads;
   switch (group_size) {
     case 4:
-      return grp4_bf16_fp8::Launch<__nv_bfloat16>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, nullptr, kv_cache_scale, workspace, workspace_size, local_window_size);
+      return grp4_bf16_fp8::Launch<__nv_bfloat16>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size, local_window_size);
     case 8:
-      return grp8_bf16_fp8::Launch<__nv_bfloat16>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, nullptr, kv_cache_scale, workspace, workspace_size, local_window_size);
+      return grp8_bf16_fp8::Launch<__nv_bfloat16>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size, local_window_size);
     case 16:
-      return grp16_bf16_fp8::Launch<__nv_bfloat16>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, nullptr, kv_cache_scale, workspace, workspace_size, local_window_size);
+      return grp16_bf16_fp8::Launch<__nv_bfloat16>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size, local_window_size);
     case 32:
-      return grp32_bf16_fp8::Launch<__nv_bfloat16>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, nullptr, kv_cache_scale, workspace, workspace_size, local_window_size);
+      return grp32_bf16_fp8::Launch<__nv_bfloat16>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size, local_window_size);
     default:
       return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "XQA FP8 only supports group_size 4, 8, 16, 32. Input has ", group_size);
   }

--- a/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_loader_bf16_fp8_impl.cuh
+++ b/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_loader_bf16_fp8_impl.cuh
@@ -102,19 +102,20 @@ Status LaunchXQAFp8KernelBF16(
     const bool is_bsnh,
     const int* past_seq_lens,
     const float* attention_sinks,
-    const float* kv_cache_scale,
+    const float* k_cache_scale,
+    const float* v_cache_scale,
     void* workspace,
     size_t workspace_size) {
   int group_size = num_heads / kv_num_heads;
   switch (group_size) {
     case 4:
-      return grp4_bf16_fp8::Launch<__nv_bfloat16>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size, local_window_size);
+      return grp4_bf16_fp8::Launch<__nv_bfloat16>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, k_cache_scale, v_cache_scale, workspace, workspace_size, local_window_size);
     case 8:
-      return grp8_bf16_fp8::Launch<__nv_bfloat16>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size, local_window_size);
+      return grp8_bf16_fp8::Launch<__nv_bfloat16>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, k_cache_scale, v_cache_scale, workspace, workspace_size, local_window_size);
     case 16:
-      return grp16_bf16_fp8::Launch<__nv_bfloat16>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size, local_window_size);
+      return grp16_bf16_fp8::Launch<__nv_bfloat16>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, k_cache_scale, v_cache_scale, workspace, workspace_size, local_window_size);
     case 32:
-      return grp32_bf16_fp8::Launch<__nv_bfloat16>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size, local_window_size);
+      return grp32_bf16_fp8::Launch<__nv_bfloat16>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, k_cache_scale, v_cache_scale, workspace, workspace_size, local_window_size);
     default:
       return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "XQA FP8 only supports group_size 4, 8, 16, 32. Input has ", group_size);
   }

--- a/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_loader_bf16_impl.cuh
+++ b/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_loader_bf16_impl.cuh
@@ -126,6 +126,7 @@ Status LaunchXQAInt8KernelBF16(
     const int local_window_size,
     const bool is_bsnh,
     const int* past_seq_lens,
+    const float* attention_sinks,
     const float* kv_cache_scale,
     void* workspace,
     size_t workspace_size);
@@ -148,6 +149,7 @@ Status LaunchXQAFp8KernelBF16(
     const int local_window_size,
     const bool is_bsnh,
     const int* past_seq_lens,
+    const float* attention_sinks,
     const float* kv_cache_scale,
     void* workspace,
     size_t workspace_size);
@@ -204,22 +206,23 @@ Status LaunchXQAKernelImpl<__nv_bfloat16>(
     size_t workspace_size) {
   // Head size check in global dispatcher
 
-  // Dispatch to INT8 path if requested
+  // Dispatch to INT8 path if requested. Attention sinks (smooth softmax) are supported here:
+  // the sink term is folded into the softmax row sum, and the KV dequant scale is already
+  // applied to the QK scores (qkScale) before the row max/sum are computed, so the sink and the
+  // score are in the same (dequantized) domain -- exactly as in the non-quantized kernel.
   if (kv_quant_type == XqaQuantType::kInt8) {
-    ORT_RETURN_IF(attention_sinks != nullptr, "XQA attention sinks are not supported with INT8 KV cache.");
     return LaunchXQAInt8KernelBF16(device_prop, stream, query, key_cache, value_cache, output,
                                    batch_size, num_heads, kv_num_heads, head_size, max_seq_len,
-                                   scale, local_window_size, is_bsnh, past_seq_lens, kv_cache_scale, workspace,
+                                   scale, local_window_size, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace,
                                    workspace_size);
   }
 
 #ifdef USE_FP8_KV_CACHE
   // Dispatch to FP8 path if requested
   if (kv_quant_type == XqaQuantType::kFp8) {
-    ORT_RETURN_IF(attention_sinks != nullptr, "XQA attention sinks are not supported with FP8 KV cache.");
     return LaunchXQAFp8KernelBF16(device_prop, stream, query, key_cache, value_cache, output,
                                   batch_size, num_heads, kv_num_heads, head_size, max_seq_len,
-                                  scale, local_window_size, is_bsnh, past_seq_lens, kv_cache_scale, workspace,
+                                  scale, local_window_size, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace,
                                   workspace_size);
   }
 #endif

--- a/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_loader_bf16_impl.cuh
+++ b/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_loader_bf16_impl.cuh
@@ -127,7 +127,8 @@ Status LaunchXQAInt8KernelBF16(
     const bool is_bsnh,
     const int* past_seq_lens,
     const float* attention_sinks,
-    const float* kv_cache_scale,
+    const float* k_cache_scale,
+    const float* v_cache_scale,
     void* workspace,
     size_t workspace_size);
 
@@ -150,7 +151,8 @@ Status LaunchXQAFp8KernelBF16(
     const bool is_bsnh,
     const int* past_seq_lens,
     const float* attention_sinks,
-    const float* kv_cache_scale,
+    const float* k_cache_scale,
+    const float* v_cache_scale,
     void* workspace,
     size_t workspace_size);
 #endif
@@ -177,7 +179,8 @@ Status LaunchXQAKernelImpl(
     const bool is_bsnh,
     const int* past_seq_lens,
     const float* attention_sinks,
-    const float* kv_cache_scale,
+    const float* k_cache_scale,
+    const float* v_cache_scale,
     const XqaQuantType kv_quant_type,
     void* workspace,
     size_t workspace_size);
@@ -200,7 +203,8 @@ Status LaunchXQAKernelImpl<__nv_bfloat16>(
     const bool is_bsnh,
     const int* past_seq_lens,
     const float* attention_sinks,
-    const float* kv_cache_scale,
+    const float* k_cache_scale,
+    const float* v_cache_scale,
     const XqaQuantType kv_quant_type,
     void* workspace,
     size_t workspace_size) {
@@ -213,7 +217,7 @@ Status LaunchXQAKernelImpl<__nv_bfloat16>(
   if (kv_quant_type == XqaQuantType::kInt8) {
     return LaunchXQAInt8KernelBF16(device_prop, stream, query, key_cache, value_cache, output,
                                    batch_size, num_heads, kv_num_heads, head_size, max_seq_len,
-                                   scale, local_window_size, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace,
+                                   scale, local_window_size, is_bsnh, past_seq_lens, attention_sinks, k_cache_scale, v_cache_scale, workspace,
                                    workspace_size);
   }
 
@@ -222,7 +226,7 @@ Status LaunchXQAKernelImpl<__nv_bfloat16>(
   if (kv_quant_type == XqaQuantType::kFp8) {
     return LaunchXQAFp8KernelBF16(device_prop, stream, query, key_cache, value_cache, output,
                                   batch_size, num_heads, kv_num_heads, head_size, max_seq_len,
-                                  scale, local_window_size, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace,
+                                  scale, local_window_size, is_bsnh, past_seq_lens, attention_sinks, k_cache_scale, v_cache_scale, workspace,
                                   workspace_size);
   }
 #endif
@@ -230,19 +234,19 @@ Status LaunchXQAKernelImpl<__nv_bfloat16>(
   int group_size = num_heads / kv_num_heads;
   switch (group_size) {
     case 1:
-      return grp1_bf16::Launch<__nv_bfloat16>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size, local_window_size);
+      return grp1_bf16::Launch<__nv_bfloat16>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, k_cache_scale, v_cache_scale, workspace, workspace_size, local_window_size);
     case 2:
-      return grp2_bf16::Launch<__nv_bfloat16>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size, local_window_size);
+      return grp2_bf16::Launch<__nv_bfloat16>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, k_cache_scale, v_cache_scale, workspace, workspace_size, local_window_size);
     case 4:
-      return grp4_bf16::Launch<__nv_bfloat16>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size, local_window_size);
+      return grp4_bf16::Launch<__nv_bfloat16>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, k_cache_scale, v_cache_scale, workspace, workspace_size, local_window_size);
     case 5:
-      return grp5_bf16::Launch<__nv_bfloat16>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size, local_window_size);
+      return grp5_bf16::Launch<__nv_bfloat16>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, k_cache_scale, v_cache_scale, workspace, workspace_size, local_window_size);
     case 8:
-      return grp8_bf16::Launch<__nv_bfloat16>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size, local_window_size);
+      return grp8_bf16::Launch<__nv_bfloat16>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, k_cache_scale, v_cache_scale, workspace, workspace_size, local_window_size);
     case 16:
-      return grp16_bf16::Launch<__nv_bfloat16>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size, local_window_size);
+      return grp16_bf16::Launch<__nv_bfloat16>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, k_cache_scale, v_cache_scale, workspace, workspace_size, local_window_size);
     case 32:
-      return grp32_bf16::Launch<__nv_bfloat16>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size, local_window_size);
+      return grp32_bf16::Launch<__nv_bfloat16>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, k_cache_scale, v_cache_scale, workspace, workspace_size, local_window_size);
     default:
       return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "XQA supports group_size 1, 2, 4, 5, 8, 16, 32. Input has ", group_size);
   }

--- a/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_loader_bf16_int8.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_loader_bf16_int8.cu
@@ -27,7 +27,8 @@ Status LaunchXQAInt8KernelBF16(
     const bool is_bsnh,
     const int* past_seq_lens,
     const float* attention_sinks,
-    const float* kv_cache_scale,
+    const float* k_cache_scale,
+    const float* v_cache_scale,
     void* workspace,
     size_t workspace_size);
 }  // namespace H64
@@ -50,7 +51,8 @@ Status LaunchXQAInt8KernelBF16(
     const bool is_bsnh,
     const int* past_seq_lens,
     const float* attention_sinks,
-    const float* kv_cache_scale,
+    const float* k_cache_scale,
+    const float* v_cache_scale,
     void* workspace,
     size_t workspace_size);
 }  // namespace H128
@@ -73,7 +75,8 @@ Status LaunchXQAInt8KernelBF16(
     const bool is_bsnh,
     const int* past_seq_lens,
     const float* attention_sinks,
-    const float* kv_cache_scale,
+    const float* k_cache_scale,
+    const float* v_cache_scale,
     void* workspace,
     size_t workspace_size);
 }  // namespace H256
@@ -96,15 +99,16 @@ Status LaunchXQAInt8KernelBF16(
     const bool is_bsnh,
     const int* past_seq_lens,
     const float* attention_sinks,
-    const float* kv_cache_scale,
+    const float* k_cache_scale,
+    const float* v_cache_scale,
     void* workspace,
     size_t workspace_size) {
   if (head_size == 256) {
-    return H256::LaunchXQAInt8KernelBF16(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, local_window_size, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size);
+    return H256::LaunchXQAInt8KernelBF16(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, local_window_size, is_bsnh, past_seq_lens, attention_sinks, k_cache_scale, v_cache_scale, workspace, workspace_size);
   } else if (head_size == 128) {
-    return H128::LaunchXQAInt8KernelBF16(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, local_window_size, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size);
+    return H128::LaunchXQAInt8KernelBF16(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, local_window_size, is_bsnh, past_seq_lens, attention_sinks, k_cache_scale, v_cache_scale, workspace, workspace_size);
   } else if (head_size == 64) {
-    return H64::LaunchXQAInt8KernelBF16(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, local_window_size, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size);
+    return H64::LaunchXQAInt8KernelBF16(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, local_window_size, is_bsnh, past_seq_lens, attention_sinks, k_cache_scale, v_cache_scale, workspace, workspace_size);
   } else {
     return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "XQA INT8 BF16 only supports head_size=64, 128, or 256. Input has ", head_size);
   }

--- a/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_loader_bf16_int8.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_loader_bf16_int8.cu
@@ -26,6 +26,7 @@ Status LaunchXQAInt8KernelBF16(
     const int local_window_size,
     const bool is_bsnh,
     const int* past_seq_lens,
+    const float* attention_sinks,
     const float* kv_cache_scale,
     void* workspace,
     size_t workspace_size);
@@ -48,6 +49,7 @@ Status LaunchXQAInt8KernelBF16(
     const int local_window_size,
     const bool is_bsnh,
     const int* past_seq_lens,
+    const float* attention_sinks,
     const float* kv_cache_scale,
     void* workspace,
     size_t workspace_size);
@@ -70,6 +72,7 @@ Status LaunchXQAInt8KernelBF16(
     const int local_window_size,
     const bool is_bsnh,
     const int* past_seq_lens,
+    const float* attention_sinks,
     const float* kv_cache_scale,
     void* workspace,
     size_t workspace_size);
@@ -92,15 +95,16 @@ Status LaunchXQAInt8KernelBF16(
     const int local_window_size,
     const bool is_bsnh,
     const int* past_seq_lens,
+    const float* attention_sinks,
     const float* kv_cache_scale,
     void* workspace,
     size_t workspace_size) {
   if (head_size == 256) {
-    return H256::LaunchXQAInt8KernelBF16(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, local_window_size, is_bsnh, past_seq_lens, kv_cache_scale, workspace, workspace_size);
+    return H256::LaunchXQAInt8KernelBF16(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, local_window_size, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size);
   } else if (head_size == 128) {
-    return H128::LaunchXQAInt8KernelBF16(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, local_window_size, is_bsnh, past_seq_lens, kv_cache_scale, workspace, workspace_size);
+    return H128::LaunchXQAInt8KernelBF16(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, local_window_size, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size);
   } else if (head_size == 64) {
-    return H64::LaunchXQAInt8KernelBF16(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, local_window_size, is_bsnh, past_seq_lens, kv_cache_scale, workspace, workspace_size);
+    return H64::LaunchXQAInt8KernelBF16(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, local_window_size, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size);
   } else {
     return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "XQA INT8 BF16 only supports head_size=64, 128, or 256. Input has ", head_size);
   }

--- a/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_loader_bf16_int8_impl.cuh
+++ b/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_loader_bf16_int8_impl.cuh
@@ -102,19 +102,20 @@ Status LaunchXQAInt8KernelBF16(
     const bool is_bsnh,
     const int* past_seq_lens,
     const float* attention_sinks,
-    const float* kv_cache_scale,
+    const float* k_cache_scale,
+    const float* v_cache_scale,
     void* workspace,
     size_t workspace_size) {
   int group_size = num_heads / kv_num_heads;
   switch (group_size) {
     case 4:
-      return grp4_bf16_int8::Launch<__nv_bfloat16>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size, local_window_size);
+      return grp4_bf16_int8::Launch<__nv_bfloat16>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, k_cache_scale, v_cache_scale, workspace, workspace_size, local_window_size);
     case 8:
-      return grp8_bf16_int8::Launch<__nv_bfloat16>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size, local_window_size);
+      return grp8_bf16_int8::Launch<__nv_bfloat16>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, k_cache_scale, v_cache_scale, workspace, workspace_size, local_window_size);
     case 16:
-      return grp16_bf16_int8::Launch<__nv_bfloat16>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size, local_window_size);
+      return grp16_bf16_int8::Launch<__nv_bfloat16>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, k_cache_scale, v_cache_scale, workspace, workspace_size, local_window_size);
     case 32:
-      return grp32_bf16_int8::Launch<__nv_bfloat16>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size, local_window_size);
+      return grp32_bf16_int8::Launch<__nv_bfloat16>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, k_cache_scale, v_cache_scale, workspace, workspace_size, local_window_size);
     default:
       return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "XQA INT8 only supports group_size 4, 8, 16, 32. Input has ", group_size);
   }

--- a/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_loader_bf16_int8_impl.cuh
+++ b/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_loader_bf16_int8_impl.cuh
@@ -101,19 +101,20 @@ Status LaunchXQAInt8KernelBF16(
     const int local_window_size,
     const bool is_bsnh,
     const int* past_seq_lens,
+    const float* attention_sinks,
     const float* kv_cache_scale,
     void* workspace,
     size_t workspace_size) {
   int group_size = num_heads / kv_num_heads;
   switch (group_size) {
     case 4:
-      return grp4_bf16_int8::Launch<__nv_bfloat16>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, nullptr, kv_cache_scale, workspace, workspace_size, local_window_size);
+      return grp4_bf16_int8::Launch<__nv_bfloat16>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size, local_window_size);
     case 8:
-      return grp8_bf16_int8::Launch<__nv_bfloat16>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, nullptr, kv_cache_scale, workspace, workspace_size, local_window_size);
+      return grp8_bf16_int8::Launch<__nv_bfloat16>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size, local_window_size);
     case 16:
-      return grp16_bf16_int8::Launch<__nv_bfloat16>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, nullptr, kv_cache_scale, workspace, workspace_size, local_window_size);
+      return grp16_bf16_int8::Launch<__nv_bfloat16>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size, local_window_size);
     case 32:
-      return grp32_bf16_int8::Launch<__nv_bfloat16>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, nullptr, kv_cache_scale, workspace, workspace_size, local_window_size);
+      return grp32_bf16_int8::Launch<__nv_bfloat16>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size, local_window_size);
     default:
       return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "XQA INT8 only supports group_size 4, 8, 16, 32. Input has ", group_size);
   }

--- a/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_loader_fp16.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_loader_fp16.cu
@@ -30,7 +30,8 @@ Status LaunchXQAKernelImpl(
     const bool is_bsnh,
     const int* past_seq_lens,
     const float* attention_sinks,
-    const float* kv_cache_scale,
+    const float* k_cache_scale,
+    const float* v_cache_scale,
     const XqaQuantType kv_quant_type,
     void* workspace,
     size_t workspace_size);
@@ -58,7 +59,8 @@ Status LaunchXQAKernelImpl(
     const bool is_bsnh,
     const int* past_seq_lens,
     const float* attention_sinks,
-    const float* kv_cache_scale,
+    const float* k_cache_scale,
+    const float* v_cache_scale,
     const XqaQuantType kv_quant_type,
     void* workspace,
     size_t workspace_size);
@@ -86,7 +88,8 @@ Status LaunchXQAKernelImpl(
     const bool is_bsnh,
     const int* past_seq_lens,
     const float* attention_sinks,
-    const float* kv_cache_scale,
+    const float* k_cache_scale,
+    const float* v_cache_scale,
     const XqaQuantType kv_quant_type,
     void* workspace,
     size_t workspace_size);
@@ -115,7 +118,8 @@ Status LaunchXQAKernel(
     const bool is_bsnh,
     const int* past_seq_lens,
     const float* attention_sinks,
-    const float* kv_cache_scale,
+    const float* k_cache_scale,
+    const float* v_cache_scale,
     const XqaQuantType kv_quant_type,
     void* workspace,
     size_t workspace_size) {
@@ -126,15 +130,15 @@ Status LaunchXQAKernel(
   if (head_size == 256) {
     return H256::LaunchXQAKernelImpl<T>(
         device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size,
-        max_seq_len, scale, local_window_size, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, kv_quant_type, workspace, workspace_size);
+        max_seq_len, scale, local_window_size, is_bsnh, past_seq_lens, attention_sinks, k_cache_scale, v_cache_scale, kv_quant_type, workspace, workspace_size);
   } else if (head_size == 128) {
     return H128::LaunchXQAKernelImpl<T>(
         device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size,
-        max_seq_len, scale, local_window_size, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, kv_quant_type, workspace, workspace_size);
+        max_seq_len, scale, local_window_size, is_bsnh, past_seq_lens, attention_sinks, k_cache_scale, v_cache_scale, kv_quant_type, workspace, workspace_size);
   } else if (head_size == 64) {
     return H64::LaunchXQAKernelImpl<T>(
         device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size,
-        max_seq_len, scale, local_window_size, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, kv_quant_type, workspace, workspace_size);
+        max_seq_len, scale, local_window_size, is_bsnh, past_seq_lens, attention_sinks, k_cache_scale, v_cache_scale, kv_quant_type, workspace, workspace_size);
   } else {
     return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "XQA only supports head_size=64, 128, or 256. Input has ", head_size);
   }
@@ -224,7 +228,8 @@ template Status LaunchXQAKernel<half>(
     const bool is_bsnh,
     const int* past_seq_lens,
     const float* attention_sinks,
-    const float* kv_cache_scale,
+    const float* k_cache_scale,
+    const float* v_cache_scale,
     const XqaQuantType kv_quant_type,
     void* workspace,
     size_t workspace_size);

--- a/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_loader_fp16_128.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_loader_fp16_128.cu
@@ -28,7 +28,8 @@ template Status HEAD_DIM_NAMESPACE::LaunchXQAKernelImpl<half>(
     const bool is_bsnh,
     const int* past_seq_lens,
     const float* attention_sinks,
-    const float* kv_cache_scale,
+    const float* k_cache_scale,
+    const float* v_cache_scale,
     const XqaQuantType kv_quant_type,
     void* workspace,
     size_t workspace_size);

--- a/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_loader_fp16_256.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_loader_fp16_256.cu
@@ -28,7 +28,8 @@ template Status HEAD_DIM_NAMESPACE::LaunchXQAKernelImpl<half>(
     const bool is_bsnh,
     const int* past_seq_lens,
     const float* attention_sinks,
-    const float* kv_cache_scale,
+    const float* k_cache_scale,
+    const float* v_cache_scale,
     const XqaQuantType kv_quant_type,
     void* workspace,
     size_t workspace_size);

--- a/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_loader_fp16_64.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_loader_fp16_64.cu
@@ -28,7 +28,8 @@ template Status HEAD_DIM_NAMESPACE::LaunchXQAKernelImpl<half>(
     const bool is_bsnh,
     const int* past_seq_lens,
     const float* attention_sinks,
-    const float* kv_cache_scale,
+    const float* k_cache_scale,
+    const float* v_cache_scale,
     const XqaQuantType kv_quant_type,
     void* workspace,
     size_t workspace_size);

--- a/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_loader_fp16_fp8_impl.cuh
+++ b/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_loader_fp16_fp8_impl.cuh
@@ -100,19 +100,20 @@ Status LaunchXQAFp8Kernel(
     const int local_window_size,
     const bool is_bsnh,
     const int* past_seq_lens,
+    const float* attention_sinks,
     const float* kv_cache_scale,
     void* workspace,
     size_t workspace_size) {
   int group_size = num_heads / kv_num_heads;
   switch (group_size) {
     case 4:
-      return grp4_fp8::Launch<half>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, nullptr, kv_cache_scale, workspace, workspace_size, local_window_size);
+      return grp4_fp8::Launch<half>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size, local_window_size);
     case 8:
-      return grp8_fp8::Launch<half>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, nullptr, kv_cache_scale, workspace, workspace_size, local_window_size);
+      return grp8_fp8::Launch<half>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size, local_window_size);
     case 16:
-      return grp16_fp8::Launch<half>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, nullptr, kv_cache_scale, workspace, workspace_size, local_window_size);
+      return grp16_fp8::Launch<half>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size, local_window_size);
     case 32:
-      return grp32_fp8::Launch<half>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, nullptr, kv_cache_scale, workspace, workspace_size, local_window_size);
+      return grp32_fp8::Launch<half>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size, local_window_size);
     default:
       return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "XQA FP8 only supports group_size 4, 8, 16, 32. Input has ", group_size);
   }

--- a/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_loader_fp16_fp8_impl.cuh
+++ b/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_loader_fp16_fp8_impl.cuh
@@ -101,19 +101,20 @@ Status LaunchXQAFp8Kernel(
     const bool is_bsnh,
     const int* past_seq_lens,
     const float* attention_sinks,
-    const float* kv_cache_scale,
+    const float* k_cache_scale,
+    const float* v_cache_scale,
     void* workspace,
     size_t workspace_size) {
   int group_size = num_heads / kv_num_heads;
   switch (group_size) {
     case 4:
-      return grp4_fp8::Launch<half>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size, local_window_size);
+      return grp4_fp8::Launch<half>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, k_cache_scale, v_cache_scale, workspace, workspace_size, local_window_size);
     case 8:
-      return grp8_fp8::Launch<half>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size, local_window_size);
+      return grp8_fp8::Launch<half>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, k_cache_scale, v_cache_scale, workspace, workspace_size, local_window_size);
     case 16:
-      return grp16_fp8::Launch<half>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size, local_window_size);
+      return grp16_fp8::Launch<half>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, k_cache_scale, v_cache_scale, workspace, workspace_size, local_window_size);
     case 32:
-      return grp32_fp8::Launch<half>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size, local_window_size);
+      return grp32_fp8::Launch<half>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, k_cache_scale, v_cache_scale, workspace, workspace_size, local_window_size);
     default:
       return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "XQA FP8 only supports group_size 4, 8, 16, 32. Input has ", group_size);
   }

--- a/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_loader_fp16_impl.cuh
+++ b/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_loader_fp16_impl.cuh
@@ -126,6 +126,7 @@ Status LaunchXQAInt8Kernel(
     const int local_window_size,
     const bool is_bsnh,
     const int* past_seq_lens,
+    const float* attention_sinks,
     const float* kv_cache_scale,
     void* workspace,
     size_t workspace_size);
@@ -148,6 +149,7 @@ Status LaunchXQAFp8Kernel(
     const int local_window_size,
     const bool is_bsnh,
     const int* past_seq_lens,
+    const float* attention_sinks,
     const float* kv_cache_scale,
     void* workspace,
     size_t workspace_size);
@@ -181,11 +183,13 @@ Status LaunchXQAKernelImpl(
     size_t workspace_size) {
   // Head size check is done in global dispatcher
 
-  // Dispatch to INT8 path if requested
+  // Dispatch to INT8 path if requested. Attention sinks (smooth softmax) are supported here:
+  // the sink term is folded into the softmax row sum, and the KV dequant scale is already
+  // applied to the QK scores (qkScale) before the row max/sum are computed, so the sink and the
+  // score are in the same (dequantized) domain -- exactly as in the non-quantized kernel.
   if (kv_quant_type == XqaQuantType::kInt8) {
-    ORT_RETURN_IF(attention_sinks != nullptr, "XQA attention sinks are not supported with INT8 KV cache.");
     if constexpr (std::is_same<T, half>::value) {
-      return LaunchXQAInt8Kernel(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, local_window_size, is_bsnh, past_seq_lens, kv_cache_scale, workspace, workspace_size);
+      return LaunchXQAInt8Kernel(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, local_window_size, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size);
     } else {
       // BF16 case is handled in xqa_loader_bf16.cu via specialization
       return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "XQA INT8 path mismatch.");
@@ -195,9 +199,8 @@ Status LaunchXQAKernelImpl(
 #ifdef USE_FP8_KV_CACHE
   // Dispatch to FP8 path if requested
   if (kv_quant_type == XqaQuantType::kFp8) {
-    ORT_RETURN_IF(attention_sinks != nullptr, "XQA attention sinks are not supported with FP8 KV cache.");
     if constexpr (std::is_same<T, half>::value) {
-      return LaunchXQAFp8Kernel(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, local_window_size, is_bsnh, past_seq_lens, kv_cache_scale, workspace, workspace_size);
+      return LaunchXQAFp8Kernel(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, local_window_size, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size);
     } else {
       // BF16 case is handled in xqa_loader_bf16.cu via specialization
       return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "XQA FP8 path mismatch.");

--- a/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_loader_fp16_impl.cuh
+++ b/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_loader_fp16_impl.cuh
@@ -127,7 +127,8 @@ Status LaunchXQAInt8Kernel(
     const bool is_bsnh,
     const int* past_seq_lens,
     const float* attention_sinks,
-    const float* kv_cache_scale,
+    const float* k_cache_scale,
+    const float* v_cache_scale,
     void* workspace,
     size_t workspace_size);
 
@@ -150,7 +151,8 @@ Status LaunchXQAFp8Kernel(
     const bool is_bsnh,
     const int* past_seq_lens,
     const float* attention_sinks,
-    const float* kv_cache_scale,
+    const float* k_cache_scale,
+    const float* v_cache_scale,
     void* workspace,
     size_t workspace_size);
 #endif
@@ -177,7 +179,8 @@ Status LaunchXQAKernelImpl(
     const bool is_bsnh,
     const int* past_seq_lens,
     const float* attention_sinks,
-    const float* kv_cache_scale,
+    const float* k_cache_scale,
+    const float* v_cache_scale,
     const XqaQuantType kv_quant_type,
     void* workspace,
     size_t workspace_size) {
@@ -189,7 +192,7 @@ Status LaunchXQAKernelImpl(
   // score are in the same (dequantized) domain -- exactly as in the non-quantized kernel.
   if (kv_quant_type == XqaQuantType::kInt8) {
     if constexpr (std::is_same<T, half>::value) {
-      return LaunchXQAInt8Kernel(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, local_window_size, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size);
+      return LaunchXQAInt8Kernel(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, local_window_size, is_bsnh, past_seq_lens, attention_sinks, k_cache_scale, v_cache_scale, workspace, workspace_size);
     } else {
       // BF16 case is handled in xqa_loader_bf16.cu via specialization
       return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "XQA INT8 path mismatch.");
@@ -200,7 +203,7 @@ Status LaunchXQAKernelImpl(
   // Dispatch to FP8 path if requested
   if (kv_quant_type == XqaQuantType::kFp8) {
     if constexpr (std::is_same<T, half>::value) {
-      return LaunchXQAFp8Kernel(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, local_window_size, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size);
+      return LaunchXQAFp8Kernel(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, local_window_size, is_bsnh, past_seq_lens, attention_sinks, k_cache_scale, v_cache_scale, workspace, workspace_size);
     } else {
       // BF16 case is handled in xqa_loader_bf16.cu via specialization
       return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "XQA FP8 path mismatch.");
@@ -211,19 +214,19 @@ Status LaunchXQAKernelImpl(
   int group_size = num_heads / kv_num_heads;
   switch (group_size) {
     case 1:
-      return grp1_fp16::Launch<T>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size, local_window_size);
+      return grp1_fp16::Launch<T>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, k_cache_scale, v_cache_scale, workspace, workspace_size, local_window_size);
     case 2:
-      return grp2_fp16::Launch<T>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size, local_window_size);
+      return grp2_fp16::Launch<T>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, k_cache_scale, v_cache_scale, workspace, workspace_size, local_window_size);
     case 4:
-      return grp4_fp16::Launch<T>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size, local_window_size);
+      return grp4_fp16::Launch<T>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, k_cache_scale, v_cache_scale, workspace, workspace_size, local_window_size);
     case 5:
-      return grp5_fp16::Launch<T>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size, local_window_size);
+      return grp5_fp16::Launch<T>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, k_cache_scale, v_cache_scale, workspace, workspace_size, local_window_size);
     case 8:
-      return grp8_fp16::Launch<T>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size, local_window_size);
+      return grp8_fp16::Launch<T>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, k_cache_scale, v_cache_scale, workspace, workspace_size, local_window_size);
     case 16:
-      return grp16_fp16::Launch<T>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size, local_window_size);
+      return grp16_fp16::Launch<T>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, k_cache_scale, v_cache_scale, workspace, workspace_size, local_window_size);
     case 32:
-      return grp32_fp16::Launch<T>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size, local_window_size);
+      return grp32_fp16::Launch<T>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, k_cache_scale, v_cache_scale, workspace, workspace_size, local_window_size);
     default:
       return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "XQA supports group_size 1, 2, 4, 5, 8, 16, 32. Input has ", group_size);
   }

--- a/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_loader_fp16_int8.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_loader_fp16_int8.cu
@@ -27,7 +27,8 @@ Status LaunchXQAInt8Kernel(
     const bool is_bsnh,
     const int* past_seq_lens,
     const float* attention_sinks,
-    const float* kv_cache_scale,
+    const float* k_cache_scale,
+    const float* v_cache_scale,
     void* workspace,
     size_t workspace_size);
 
@@ -51,7 +52,8 @@ Status LaunchXQAInt8Kernel(
     const bool is_bsnh,
     const int* past_seq_lens,
     const float* attention_sinks,
-    const float* kv_cache_scale,
+    const float* k_cache_scale,
+    const float* v_cache_scale,
     void* workspace,
     size_t workspace_size);
 
@@ -75,7 +77,8 @@ Status LaunchXQAInt8Kernel(
     const bool is_bsnh,
     const int* past_seq_lens,
     const float* attention_sinks,
-    const float* kv_cache_scale,
+    const float* k_cache_scale,
+    const float* v_cache_scale,
     void* workspace,
     size_t workspace_size);
 
@@ -99,15 +102,16 @@ Status LaunchXQAInt8Kernel(
     const bool is_bsnh,
     const int* past_seq_lens,
     const float* attention_sinks,
-    const float* kv_cache_scale,
+    const float* k_cache_scale,
+    const float* v_cache_scale,
     void* workspace,
     size_t workspace_size) {
   if (head_size == 256) {
-    return H256::LaunchXQAInt8Kernel(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, local_window_size, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size);
+    return H256::LaunchXQAInt8Kernel(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, local_window_size, is_bsnh, past_seq_lens, attention_sinks, k_cache_scale, v_cache_scale, workspace, workspace_size);
   } else if (head_size == 128) {
-    return H128::LaunchXQAInt8Kernel(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, local_window_size, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size);
+    return H128::LaunchXQAInt8Kernel(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, local_window_size, is_bsnh, past_seq_lens, attention_sinks, k_cache_scale, v_cache_scale, workspace, workspace_size);
   } else if (head_size == 64) {
-    return H64::LaunchXQAInt8Kernel(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, local_window_size, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size);
+    return H64::LaunchXQAInt8Kernel(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, local_window_size, is_bsnh, past_seq_lens, attention_sinks, k_cache_scale, v_cache_scale, workspace, workspace_size);
   } else {
     return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "XQA INT8 only supports head_size=64, 128, or 256. Input has ", head_size);
   }

--- a/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_loader_fp16_int8.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_loader_fp16_int8.cu
@@ -26,6 +26,7 @@ Status LaunchXQAInt8Kernel(
     const int local_window_size,
     const bool is_bsnh,
     const int* past_seq_lens,
+    const float* attention_sinks,
     const float* kv_cache_scale,
     void* workspace,
     size_t workspace_size);
@@ -49,6 +50,7 @@ Status LaunchXQAInt8Kernel(
     const int local_window_size,
     const bool is_bsnh,
     const int* past_seq_lens,
+    const float* attention_sinks,
     const float* kv_cache_scale,
     void* workspace,
     size_t workspace_size);
@@ -72,6 +74,7 @@ Status LaunchXQAInt8Kernel(
     const int local_window_size,
     const bool is_bsnh,
     const int* past_seq_lens,
+    const float* attention_sinks,
     const float* kv_cache_scale,
     void* workspace,
     size_t workspace_size);
@@ -95,15 +98,16 @@ Status LaunchXQAInt8Kernel(
     const int local_window_size,
     const bool is_bsnh,
     const int* past_seq_lens,
+    const float* attention_sinks,
     const float* kv_cache_scale,
     void* workspace,
     size_t workspace_size) {
   if (head_size == 256) {
-    return H256::LaunchXQAInt8Kernel(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, local_window_size, is_bsnh, past_seq_lens, kv_cache_scale, workspace, workspace_size);
+    return H256::LaunchXQAInt8Kernel(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, local_window_size, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size);
   } else if (head_size == 128) {
-    return H128::LaunchXQAInt8Kernel(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, local_window_size, is_bsnh, past_seq_lens, kv_cache_scale, workspace, workspace_size);
+    return H128::LaunchXQAInt8Kernel(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, local_window_size, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size);
   } else if (head_size == 64) {
-    return H64::LaunchXQAInt8Kernel(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, local_window_size, is_bsnh, past_seq_lens, kv_cache_scale, workspace, workspace_size);
+    return H64::LaunchXQAInt8Kernel(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, local_window_size, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size);
   } else {
     return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "XQA INT8 only supports head_size=64, 128, or 256. Input has ", head_size);
   }

--- a/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_loader_fp16_int8_impl.cuh
+++ b/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_loader_fp16_int8_impl.cuh
@@ -101,19 +101,20 @@ Status LaunchXQAInt8Kernel(
     const bool is_bsnh,
     const int* past_seq_lens,
     const float* attention_sinks,
-    const float* kv_cache_scale,
+    const float* k_cache_scale,
+    const float* v_cache_scale,
     void* workspace,
     size_t workspace_size) {
   int group_size = num_heads / kv_num_heads;
   switch (group_size) {
     case 4:
-      return grp4_int8::Launch<half>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size, local_window_size);
+      return grp4_int8::Launch<half>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, k_cache_scale, v_cache_scale, workspace, workspace_size, local_window_size);
     case 8:
-      return grp8_int8::Launch<half>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size, local_window_size);
+      return grp8_int8::Launch<half>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, k_cache_scale, v_cache_scale, workspace, workspace_size, local_window_size);
     case 16:
-      return grp16_int8::Launch<half>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size, local_window_size);
+      return grp16_int8::Launch<half>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, k_cache_scale, v_cache_scale, workspace, workspace_size, local_window_size);
     case 32:
-      return grp32_int8::Launch<half>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size, local_window_size);
+      return grp32_int8::Launch<half>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, k_cache_scale, v_cache_scale, workspace, workspace_size, local_window_size);
     default:
       return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "XQA INT8 only supports group_size 4, 8, 16, 32. Input has ", group_size);
   }

--- a/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_loader_fp16_int8_impl.cuh
+++ b/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_loader_fp16_int8_impl.cuh
@@ -100,19 +100,20 @@ Status LaunchXQAInt8Kernel(
     const int local_window_size,
     const bool is_bsnh,
     const int* past_seq_lens,
+    const float* attention_sinks,
     const float* kv_cache_scale,
     void* workspace,
     size_t workspace_size) {
   int group_size = num_heads / kv_num_heads;
   switch (group_size) {
     case 4:
-      return grp4_int8::Launch<half>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, nullptr, kv_cache_scale, workspace, workspace_size, local_window_size);
+      return grp4_int8::Launch<half>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size, local_window_size);
     case 8:
-      return grp8_int8::Launch<half>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, nullptr, kv_cache_scale, workspace, workspace_size, local_window_size);
+      return grp8_int8::Launch<half>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size, local_window_size);
     case 16:
-      return grp16_int8::Launch<half>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, nullptr, kv_cache_scale, workspace, workspace_size, local_window_size);
+      return grp16_int8::Launch<half>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size, local_window_size);
     case 32:
-      return grp32_int8::Launch<half>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, nullptr, kv_cache_scale, workspace, workspace_size, local_window_size);
+      return grp32_int8::Launch<half>(device_prop, stream, query, key_cache, value_cache, output, batch_size, num_heads, kv_num_heads, head_size, max_seq_len, scale, is_bsnh, past_seq_lens, attention_sinks, kv_cache_scale, workspace, workspace_size, local_window_size);
     default:
       return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "XQA INT8 only supports group_size 4, 8, 16, 32. Input has ", group_size);
   }

--- a/onnxruntime/test/python/transformers/test_gqa.py
+++ b/onnxruntime/test/python/transformers/test_gqa.py
@@ -3043,7 +3043,8 @@ def gqa_xqa_quantized_sliding_window_test_cases():
     # The XQA decode path now supports local_window_size > 0 on the quantized KV-cache paths as
     # well. Quantized XQA selection requires: decode (q_seq=1), a shared KV buffer, per-tensor
     # k/v scales that are the same tensor, head_size in {64, 128, 256} and group_size in
-    # {4, 8, 16, 32}. Attention sinks are not supported with quantized KV cache, so no head_sink.
+    # {4, 8, 16, 32}. Attention sinks are covered separately by
+    # gqa_xqa_quantized_head_sink_test_cases(), so no head_sink here.
     #
     # Two window/past relationships are covered:
     #   past > window  -> the sliding mask drops the oldest keys (the new code path).
@@ -3125,6 +3126,104 @@ class TestXQAQuantizedSlidingWindowParity(unittest.TestCase):
             )
 
         # XQA is enabled by default for fp16/bf16, so the quantized sliding-window path is selected.
+        self.assertEqual("XQA", get_sdpa_kernel_from_debug_info(run_parity_check))
+
+
+def gqa_xqa_quantized_head_sink_test_cases():
+    # Quantized (INT8 / FP8) decode with an attention sink (head_sink / smooth softmax) through
+    # the XQA kernel -- the GPT-OSS style configuration.
+    #
+    # The sink term is folded into the softmax row sum by the same kernel code used on the
+    # non-quantized path, and the KV dequant scale is applied to the QK scores before the row
+    # max/sum are computed, so the sink and the scores live in the same dequantized domain.
+    #
+    # Coverage:
+    #   local_window_size == -1 -> global attention with a sink.
+    #   local_window_size > 0 with past > window -> sliding window composed with a sink.
+    #   past_kv_sequence_length 512 also forces the multi-block (Flash Decoding) reduction, where
+    #   the sink is added to the merged row sum instead of the per-CTA row sum.
+    #   head_sink_as_initializer toggles the PrePack'd FP32 sink buffer vs. the per-launch
+    #   conversion scratch path.
+    kv_cache_types = ["int8"]
+    if has_fp8_kv_cache:
+        kv_cache_types.append("fp8")
+    for kv_cache_type in kv_cache_types:
+        for torch_type, ort_type in [(torch.float16, TensorProto.FLOAT16), (torch.bfloat16, TensorProto.BFLOAT16)]:
+            for head_size in [64, 128]:
+                for group_size in [4, 8]:
+                    for past_kv_sequence_length, local_window_size in [(4, -1), (512, -1), (512, 128)]:
+                        for head_sink_as_initializer in [False, True]:
+                            kv_num_heads = 4
+                            num_heads = kv_num_heads * group_size
+                            config = GQAConfig(
+                                batch_size=2,
+                                q_sequence_length=1,
+                                kv_sequence_length=1,
+                                num_heads=num_heads,
+                                kv_num_heads=kv_num_heads,
+                                head_size=head_size,
+                                past_kv_sequence_length=past_kv_sequence_length,
+                                buffer_sequence_length=past_kv_sequence_length + 128,
+                                local_window_size=local_window_size,
+                                rotary=True,
+                                rotary_interleaved=False,
+                                packed=False,
+                                share_buffer=True,
+                                has_head_sink=True,
+                                head_sink_as_initializer=head_sink_as_initializer,
+                                k_quant_type="PER_TENSOR",
+                                v_quant_type="PER_TENSOR",
+                                kv_cache_type=kv_cache_type,
+                                share_kv_scale=True,
+                            )
+                            type_str = "bf16" if torch_type == torch.bfloat16 else "fp16"
+                            win_str = f"past{past_kv_sequence_length}_win{local_window_size}"
+                            pack_str = "prepack" if head_sink_as_initializer else "runtime"
+                            name = f"{kv_cache_type}_{type_str}_g{group_size}_h{head_size}_{win_str}_{pack_str}"
+                            yield name, config, torch_type, ort_type
+
+
+@unittest.skipIf(not has_xqa(), "XQA is not available, skipping tests.")
+@unittest.skipIf(not has_quantized_kv_cache(), "Quantized KV Cache is not available, skipping tests.")
+class TestXQAQuantizedHeadSinkParity(unittest.TestCase):
+    """Verify the quantized (INT8/FP8) XQA attention-sink decode path matches the reference."""
+
+    def setUp(self):
+        # Force XQA on so the test is hermetic even if ORT_ENABLE_XQA=0 is set in the environment.
+        self._prev_enable_xqa = os.environ.get("ORT_ENABLE_XQA")
+        os.environ["ORT_ENABLE_XQA"] = "1"
+
+    def tearDown(self):
+        """Clear CUDA cache after each test to prevent memory corruption in batch runs."""
+        if self._prev_enable_xqa is None:
+            os.environ.pop("ORT_ENABLE_XQA", None)
+        else:
+            os.environ["ORT_ENABLE_XQA"] = self._prev_enable_xqa
+        if torch.cuda.is_available():
+            torch.cuda.synchronize()
+            torch.cuda.empty_cache()
+        gc.collect()
+
+    @parameterized.expand(gqa_xqa_quantized_head_sink_test_cases())
+    def test_xqa_quantized_head_sink_parity(self, name, config, torch_type, ort_type):
+        """Test XQA quantized parity with an attention sink (head_sink) input."""
+        type_str = "bf16" if torch_type == torch.bfloat16 else "fp16"
+        rtol_key = f"{config.kv_cache_type}_{type_str}"
+
+        def run_parity_check():
+            parity_check_gqa_past(
+                config=config,
+                ep="CUDAExecutionProvider",
+                device="cuda",
+                torch_type=torch_type,
+                ort_type=ort_type,
+                causal=True,
+                rtol=rtol[rtol_key],
+                atol=atol[rtol_key],
+                std=0.1,
+            )
+
+        # Guard against silently falling back: the quantized + sink combination must reach XQA.
         self.assertEqual("XQA", get_sdpa_kernel_from_debug_info(run_parity_check))
 
 

--- a/onnxruntime/test/python/transformers/test_gqa.py
+++ b/onnxruntime/test/python/transformers/test_gqa.py
@@ -3321,6 +3321,105 @@ class TestXQASeparateKVScaleParity(unittest.TestCase):
         self.assertEqual("XQA", get_sdpa_kernel_from_debug_info(run_parity_check))
 
 
+def gqa_xqa_per_channel_scale_test_cases():
+    # Quantized (INT8 / FP8) decode with PER_CHANNEL k/v scales on the XQA path.
+    #
+    # XQA only understands a scalar dequant scale, so per-channel scales are folded out of the
+    # kernel: k_scale into Q (the channel dim is contracted by Q*K.T) and v_scale into the
+    # attention output (the channel dim is free in P*V). Both foldings are exact because
+    # dequantization is linear, so these tests are ordinary parity tests -- but they also guard
+    # the dispatch decision, since per-channel used to fall back to
+    # "dequantize the whole cache, then run flash attention" on every decode step.
+    #
+    # Coverage: global attention, sliding window, the multi-block (Flash Decoding) reduction
+    # (past 512), attention sinks, and rotary on/off (rotary decides whether the folded Q lands in
+    # the RoPE scratch buffer or in a scratch buffer allocated only for the folding).
+    kv_cache_types = ["int8"]
+    if has_fp8_kv_cache:
+        kv_cache_types.append("fp8")
+    for kv_cache_type in kv_cache_types:
+        for torch_type, ort_type in [(torch.float16, TensorProto.FLOAT16), (torch.bfloat16, TensorProto.BFLOAT16)]:
+            for head_size in [64, 128]:
+                for group_size in [4, 8]:
+                    for past_kv_sequence_length, local_window_size in [(4, -1), (512, -1), (512, 128)]:
+                        for has_head_sink, rotary in [(False, True), (True, True), (True, False)]:
+                            kv_num_heads = 4
+                            num_heads = kv_num_heads * group_size
+                            config = GQAConfig(
+                                batch_size=2,
+                                q_sequence_length=1,
+                                kv_sequence_length=1,
+                                num_heads=num_heads,
+                                kv_num_heads=kv_num_heads,
+                                head_size=head_size,
+                                past_kv_sequence_length=past_kv_sequence_length,
+                                buffer_sequence_length=past_kv_sequence_length + 128,
+                                local_window_size=local_window_size,
+                                rotary=rotary,
+                                rotary_interleaved=False,
+                                packed=False,
+                                share_buffer=True,
+                                has_head_sink=has_head_sink,
+                                head_sink_as_initializer=True,
+                                k_quant_type="PER_CHANNEL",
+                                v_quant_type="PER_CHANNEL",
+                                kv_cache_type=kv_cache_type,
+                                share_kv_scale=False,
+                            )
+                            type_str = "bf16" if torch_type == torch.bfloat16 else "fp16"
+                            win_str = f"past{past_kv_sequence_length}_win{local_window_size}"
+                            sink_str = "sink" if has_head_sink else "nosink"
+                            rot_str = "rot" if rotary else "norot"
+                            name = (
+                                f"{kv_cache_type}_{type_str}_g{group_size}_h{head_size}_{win_str}_{sink_str}_{rot_str}"
+                            )
+                            yield name, config, torch_type, ort_type
+
+
+@unittest.skipIf(not has_xqa(), "XQA is not available, skipping tests.")
+@unittest.skipIf(not has_quantized_kv_cache(), "Quantized KV Cache is not available, skipping tests.")
+class TestXQAPerChannelScaleParity(unittest.TestCase):
+    """Verify XQA serves PER_CHANNEL quantized KV caches by folding the scales into Q / the output."""
+
+    def setUp(self):
+        # Force XQA on so the test is hermetic even if ORT_ENABLE_XQA=0 is set in the environment.
+        self._prev_enable_xqa = os.environ.get("ORT_ENABLE_XQA")
+        os.environ["ORT_ENABLE_XQA"] = "1"
+
+    def tearDown(self):
+        """Clear CUDA cache after each test to prevent memory corruption in batch runs."""
+        if self._prev_enable_xqa is None:
+            os.environ.pop("ORT_ENABLE_XQA", None)
+        else:
+            os.environ["ORT_ENABLE_XQA"] = self._prev_enable_xqa
+        if torch.cuda.is_available():
+            torch.cuda.synchronize()
+            torch.cuda.empty_cache()
+        gc.collect()
+
+    @parameterized.expand(gqa_xqa_per_channel_scale_test_cases())
+    def test_xqa_per_channel_scale_parity(self, name, config, torch_type, ort_type):
+        """Test XQA quantized parity with per-channel k/v dequantization scales."""
+        type_str = "bf16" if torch_type == torch.bfloat16 else "fp16"
+        rtol_key = f"{config.kv_cache_type}_{type_str}"
+
+        def run_parity_check():
+            parity_check_gqa_past(
+                config=config,
+                ep="CUDAExecutionProvider",
+                device="cuda",
+                torch_type=torch_type,
+                ort_type=ort_type,
+                causal=True,
+                rtol=rtol[rtol_key],
+                atol=atol[rtol_key],
+                std=0.1,
+            )
+
+        # Per-channel scales must reach XQA instead of the dequantize-the-whole-cache fallback.
+        self.assertEqual("XQA", get_sdpa_kernel_from_debug_info(run_parity_check))
+
+
 @unittest.skipIf(not has_flash_attention(), "Flash Attention is not available, skipping tests.")
 @unittest.skipIf(not has_quantized_kv_cache(), "Quantized KV Cache is not available, skipping tests.")
 class TestGQARegressions(unittest.TestCase):

--- a/onnxruntime/test/python/transformers/test_gqa.py
+++ b/onnxruntime/test/python/transformers/test_gqa.py
@@ -3227,6 +3227,100 @@ class TestXQAQuantizedHeadSinkParity(unittest.TestCase):
         self.assertEqual("XQA", get_sdpa_kernel_from_debug_info(run_parity_check))
 
 
+def gqa_xqa_separate_kv_scale_test_cases():
+    # Quantized (INT8 / FP8) decode where K and V use *different* per-tensor scales.
+    #
+    # The XQA kernel keeps the two scales apart: k_scale is folded into qkScale (applied to Q*K.T
+    # before the softmax row max/sum) and v_scale into voScale (applied to the P*V accumulator).
+    # These tests guard both the numerics and the dispatch decision -- XQA used to require the two
+    # scale inputs to be the same tensor, which silently disqualified any model that calibrates K
+    # and V independently.
+    #
+    # Coverage includes global attention, sliding window, the multi-block (Flash Decoding)
+    # reduction (past 512), and attention sinks, since each of those paths touches the rescales.
+    kv_cache_types = ["int8"]
+    if has_fp8_kv_cache:
+        kv_cache_types.append("fp8")
+    for kv_cache_type in kv_cache_types:
+        for torch_type, ort_type in [(torch.float16, TensorProto.FLOAT16), (torch.bfloat16, TensorProto.BFLOAT16)]:
+            for head_size in [64, 128, 256]:
+                for group_size in [4, 8]:
+                    for past_kv_sequence_length, local_window_size in [(4, -1), (512, -1), (512, 128)]:
+                        for has_head_sink in [False, True]:
+                            kv_num_heads = 4
+                            num_heads = kv_num_heads * group_size
+                            config = GQAConfig(
+                                batch_size=2,
+                                q_sequence_length=1,
+                                kv_sequence_length=1,
+                                num_heads=num_heads,
+                                kv_num_heads=kv_num_heads,
+                                head_size=head_size,
+                                past_kv_sequence_length=past_kv_sequence_length,
+                                buffer_sequence_length=past_kv_sequence_length + 128,
+                                local_window_size=local_window_size,
+                                rotary=True,
+                                rotary_interleaved=False,
+                                packed=False,
+                                share_buffer=True,
+                                has_head_sink=has_head_sink,
+                                head_sink_as_initializer=True,
+                                k_quant_type="PER_TENSOR",
+                                v_quant_type="PER_TENSOR",
+                                kv_cache_type=kv_cache_type,
+                                share_kv_scale=False,
+                            )
+                            type_str = "bf16" if torch_type == torch.bfloat16 else "fp16"
+                            win_str = f"past{past_kv_sequence_length}_win{local_window_size}"
+                            sink_str = "sink" if has_head_sink else "nosink"
+                            name = f"{kv_cache_type}_{type_str}_g{group_size}_h{head_size}_{win_str}_{sink_str}"
+                            yield name, config, torch_type, ort_type
+
+
+@unittest.skipIf(not has_xqa(), "XQA is not available, skipping tests.")
+@unittest.skipIf(not has_quantized_kv_cache(), "Quantized KV Cache is not available, skipping tests.")
+class TestXQASeparateKVScaleParity(unittest.TestCase):
+    """Verify XQA handles independent K and V dequantization scales."""
+
+    def setUp(self):
+        # Force XQA on so the test is hermetic even if ORT_ENABLE_XQA=0 is set in the environment.
+        self._prev_enable_xqa = os.environ.get("ORT_ENABLE_XQA")
+        os.environ["ORT_ENABLE_XQA"] = "1"
+
+    def tearDown(self):
+        """Clear CUDA cache after each test to prevent memory corruption in batch runs."""
+        if self._prev_enable_xqa is None:
+            os.environ.pop("ORT_ENABLE_XQA", None)
+        else:
+            os.environ["ORT_ENABLE_XQA"] = self._prev_enable_xqa
+        if torch.cuda.is_available():
+            torch.cuda.synchronize()
+            torch.cuda.empty_cache()
+        gc.collect()
+
+    @parameterized.expand(gqa_xqa_separate_kv_scale_test_cases())
+    def test_xqa_separate_kv_scale_parity(self, name, config, torch_type, ort_type):
+        """Test XQA quantized parity when k_scale and v_scale are distinct tensors."""
+        type_str = "bf16" if torch_type == torch.bfloat16 else "fp16"
+        rtol_key = f"{config.kv_cache_type}_{type_str}"
+
+        def run_parity_check():
+            parity_check_gqa_past(
+                config=config,
+                ep="CUDAExecutionProvider",
+                device="cuda",
+                torch_type=torch_type,
+                ort_type=ort_type,
+                causal=True,
+                rtol=rtol[rtol_key],
+                atol=atol[rtol_key],
+                std=0.1,
+            )
+
+        # Distinct k_scale/v_scale tensors must not disqualify the op from XQA.
+        self.assertEqual("XQA", get_sdpa_kernel_from_debug_info(run_parity_check))
+
+
 @unittest.skipIf(not has_flash_attention(), "Flash Attention is not available, skipping tests.")
 @unittest.skipIf(not has_quantized_kv_cache(), "Quantized KV Cache is not available, skipping tests.")
 class TestGQARegressions(unittest.TestCase):


### PR DESCRIPTION
### Description

Extends the XQA decode kernel to serve the quantized (INT8/FP8) KV-cache configurations that
previously fell back to *dequantize-the-whole-cache-then-Flash-Attention*. Four changes, in
`contrib_ops/cuda/bert/`:

1. **Attention sinks on quantized XQA.** `use_xqa_attention_sinks` no longer requires
   `!is_inputs_quantized`. The sink is folded into the softmax row sum by the same code the
   non-quantized path uses, and the dequant scale is already applied to the scores before the row
   max/sum, so sink and score live in the same domain — true for both the single-block and the
   multi-block (Flash Decoding) reduction, where the sink is added to the merged row sum.

2. **Independent `k_scale` / `v_scale`.** XQA previously required the two scale *tensors to be the
   same pointer*, which no builder-emitted model satisfies. The kernel now keeps them apart:
   `k_scale` → `qkScale` (applied to Q·Kᵀ), `v_scale` → `voScale` (applied to the P·V accumulator).

3. **`PER_CHANNEL` scales folded out of the kernel.** XQA only accepts a *scalar* dequant scale.
   But dequantization is linear and the channel index is the *contracted* dim for K and the *free*
   dim for V:

   ```
   scores_t = sum_d q_d * (k_td * sk_d) = sum_d (q_d * sk_d) * k_td
   out_d    = sum_t p_t * (v_td * sv_d) = (sum_t p_t * v_td) * sv_d
   ```

   so the per-channel scales can be moved **out** of the kernel exactly: pre-scale Q by `sk`,
   post-scale the attention output by `sv`. `p_t` is unchanged because softmax only ever sees the
   (already correct) scores, and every step after the P·V accumulation is linear, so attention
   sinks, sliding window and the multi-block reduction all stay valid. XQA reads a null scale
   pointer as "scale = 1", which is how the caller signals it folded the scale itself.

   The Q side costs nothing extra: `UnpackRoPEAppend` already loads Q, applies RoPE and stores it to
   the very scratch buffer XQA reads, so it takes a `q_fold_scale` argument and applies the multiply
   to the registers it is about to store. Only the V side needs its own pass, since it consumes
   XQA's output. Both are `O(num_heads * head_size)` — **O(1) in context length**, versus the
   O(context) full-cache dequant they replace.

4. **Vectorized / length-aware dequant fallback** for what XQA still cannot serve (INT4,
   unsupported `head_size`/group size). The fallback dequant kernel now uses 32-byte vector loads,
   hoists per-channel scales out of the sequence loop, maps (batch, head) to `blockIdx.y` so the
   inner addressing is 32-bit, and walks only the rows inside the sequence instead of the padded
   cache capacity.

`docs/contrib_ops/cuda/gqa.md` is updated to match: quantized-decode description, XQA eligibility
conditions, backend-selection table, and the parity-test list.

### Motivation and Context

The quantized KV-cache decode path was **~2.8x slower than an FP16 KV cache** at 16k context, and
the gap grew with context length because the fallback rebuilt the entire dequantized K+V cache on
*every* decode step. The binding gate was attention sinks: a model carrying `head_sink` sets
`use_smooth_softmax`, which combined with a quantized cache disqualified XQA regardless of scale
granularity, head size or group size. Scale-granularity workarounds do not help — all quantized
configurations previously landed within 0.5% of each other, because none of them reached XQA.

Decode latency, batch 1, 64 generated tokens, gpt-oss-20b geometry (24 layers, `head_size` 64,
group 8), H200 / SM90, median of 5, idle GPU:

| KV cache | 1k | 4k | **16k** | vs FP16 KV @16k |
|---|--:|--:|--:|--:|
| FP16 *(control)* | 2.38 -> 2.370 | 2.44 -> 2.434 | 2.57 -> 2.573 | — |
| INT8 per-tensor | 3.22 -> 2.421 | 4.04 -> 2.490 | **7.42 -> 2.626** | +2.1% |
| INT8 per-channel | 3.21 -> 2.476 | 4.07 -> 2.542 | **7.42 -> 2.683** | +4.3% |
| FP8 per-tensor | 3.18 -> 2.390 | 4.08 -> 2.449 | **7.39 -> 2.561** | −0.5% |
| FP8 per-channel | — -> 2.443 | — -> 2.492 | — -> **2.611** | +1.5% |

(ms/token, `before -> after`. The FP16 control is unchanged, so the comparison is sound.) Quantized
KV decode goes from **−66% to −4%** versus an FP16 cache at 16k, while keeping its **−26% TTFT**
(749 ms vs 1017 ms @16k). Scale granularity now costs ~0.05 ms/token (2% at 16k), so per-channel —
by far the most accurate INT8 option — no longer has to be traded away for decode speed.

For configurations XQA still cannot serve, change 4 alone gives 7.44 -> 4.61 ms/token @16k (1.61x);
its residual overhead over the FP16 non-XQA Flash path is now 0.44 ms/token (was 3.40), i.e. roughly
75% of theoretical HBM bandwidth for the traffic it must move.

### Testing

- `onnxruntime/test/python/transformers/test_gqa.py`: **865 passed**, 384 of them new. Three new
  classes, each asserting *both* numerics and that the op actually reaches XQA
  (`SdpaKernel == "XQA"`), so a silent fallback fails the test rather than passing quietly:
  - `TestXQAQuantizedHeadSinkParity` (96) — quantized decode with an attention sink.
  - `TestXQASeparateKVScaleParity` (144) — distinct `k_scale` / `v_scale` tensors.
  - `TestXQAPerChannelScaleParity` (144) — per-channel K/V scales folded into Q and the output.

  Combined coverage: INT8 + FP8 x fp16 + bf16 x `head_size` 64/128/256 x group 4/8 x global /
  sliding-window / multi-block (past 512) x sink on/off x rotary on/off x prepacked vs
  runtime-converted sink.
- `onnxruntime_provider_test --gtest_filter='*GroupQueryAttention*'`: 63 passed.
- The `q_fold_scale` fusion in change 3 was verified to be a numerical no-op: op-level max-abs and
  RMS error against the fp32 reference are bit-identical to the unfused two-pass version across
  `head_size` 64/128 x past 4/512.
- End to end, a gpt-oss-20b build with an INT8 per-channel KV cache produces a **token-identical**
  128-token greedy continuation to the same model with an FP16 KV cache.
- `lintrunner` clean.
