### PR TITLE
[MLAS] Extend the fp16 direct C output to the 4 bit CompFp32 path

### DIFF
--- a/onnxruntime/contrib_ops/cpu/quantization/matmul_nbits.cc
+++ b/onnxruntime/contrib_ops/cpu/quantization/matmul_nbits.cc
@@ -1138,11 +1138,12 @@ Status MatMulNBits<MLFloat16>::ComputeBPacked(const Tensor* a,
   }
 
   const size_t c_size = static_cast<size_t>(y->Shape().Size());
-  // When the int8 path can emit fp16 directly, skip the full fp32 copy of the result:
+  // When the compute path can emit fp16 directly, skip the full fp32 copy of the result:
   // each worker converts its own output tile to fp16 in place. Otherwise compute into an
   // fp32 buffer and convert once at the end. No zero-init: the GEMM writes every element.
   const bool output_fp16_direct =
-      compute_type_ == SQNBIT_CompInt8 && MlasQNBitGemmFp16DirectCOutputSupported(nbits_);
+      (compute_type_ == SQNBIT_CompInt8 || compute_type_ == SQNBIT_CompFp32) &&
+      MlasQNBitGemmFp16DirectCOutputSupported(nbits_, compute_type_);
   IAllocatorUniquePtr<float> c_v;
   if (!output_fp16_direct) {
     c_v = IAllocator::MakeUniquePtr<float>(allocator, c_size, true);

--- a/onnxruntime/core/mlas/inc/mlas_qnbit.h
+++ b/onnxruntime/core/mlas/inc/mlas_qnbit.h
@@ -150,15 +150,16 @@ bool MLASCALL
 MlasQNBitGemmFp16DirectQuantASupported();
 
 /**
- * @brief Whether the CompInt8 path can write its result directly as fp16 for the given
- *        weight bit width. When true, a fp16 MatMulNBits can set
- *        MLAS_QNBIT_GEMM_DATA_PARAMS::CFp16 and point `C` at a small per-worker scratch
- *        instead of a full fp32 copy of the result; each worker converts its output tile
- *        to fp16 in place. The fp16 result is bit-identical to computing in fp32 and
- *        converting with MlasConvertFloatToHalfBuffer.
+ * @brief Whether the given compute path can write its result directly as fp16 for the
+ *        given weight bit width. When true, a fp16 MatMulNBits can set
+ *        MLAS_QNBIT_GEMM_DATA_PARAMS::CFp16 instead of allocating a full fp32 copy of
+ *        the result; each worker converts its output strip to fp16 in place. The fp16
+ *        result is bit-identical to computing in fp32 and converting with
+ *        MlasConvertFloatToHalfBuffer. Supported for CompInt8 (2, 4 and 8 bit) and for
+ *        the 4 bit CompFp32 path.
  */
 bool MLASCALL
-MlasQNBitGemmFp16DirectCOutputSupported(size_t BlkBitWidth);
+MlasQNBitGemmFp16DirectCOutputSupported(size_t BlkBitWidth, MLAS_QNBIT_GEMM_COMPUTE_TYPE ComputeType);
 
 /**
  * @brief Gets the size in bytes of the intermediate workspace buffer required by the float32/quantized n-bit int GEMM

--- a/onnxruntime/core/mlas/lib/qnbitgemm.cpp
+++ b/onnxruntime/core/mlas/lib/qnbitgemm.cpp
@@ -186,13 +186,29 @@ MlasQNBitGemmFp16DirectQuantASupported()
 }
 
 bool MLASCALL
-MlasQNBitGemmFp16DirectCOutputSupported(size_t BlkBitWidth)
+MlasQNBitGemmFp16DirectCOutputSupported(size_t BlkBitWidth, MLAS_QNBIT_GEMM_COMPUTE_TYPE ComputeType)
 {
-    // Wired for the 2, 4 and 8 bit CompInt8 compute ops on x64, where the fp16 A quantizer
-    // is also present.
     const auto* Dispatch = GetMlasPlatform().QNBitGemmDispatch;
-    const bool supported_bit_width = BlkBitWidth == 2 || BlkBitWidth == 4 || BlkBitWidth == 8;
-    return supported_bit_width && Dispatch != nullptr && Dispatch->QuantizeARowComputeBlkSum_CompInt8_Fp16 != nullptr;
+    if (Dispatch == nullptr) {
+        return false;
+    }
+
+    if (ComputeType == SQNBIT_CompInt8) {
+        // Wired for the 2, 4 and 8 bit CompInt8 compute ops on x64, where the fp16 A
+        // quantizer is also present.
+        const bool supported_bit_width = BlkBitWidth == 2 || BlkBitWidth == 4 || BlkBitWidth == 8;
+        return supported_bit_width && Dispatch->QuantizeARowComputeBlkSum_CompInt8_Fp16 != nullptr;
+    }
+
+    if (ComputeType == SQNBIT_CompFp32) {
+        // The strip conversion in SQ4BitGemm_CompFp32 is portable, so it only needs the
+        // CompFp32 kernels themselves.
+        return BlkBitWidth == 4 &&
+               Dispatch->SQ4BitGemmM1Kernel_CompFp32 != nullptr &&
+               Dispatch->SQ4BitBlkDequantBForSgemm_CompFp32 != nullptr;
+    }
+
+    return false;
 }
 
 namespace
@@ -507,6 +523,43 @@ AddBiasForGemm(const float* Bias, float* C, size_t CountM, size_t CountN, size_t
     }
 }
 
+// fp32 scratch for the fp16 output path below. One buffer per thread, shared by every bit
+// width and compute type, grown to the largest strip that thread has computed. Only threads
+// that take the fp16 path ever allocate.
+float*
+GetStripCFp16Scratch(size_t Elements)
+{
+    static thread_local std::vector<float> c_scratch;
+    if (c_scratch.size() < Elements) {
+        c_scratch.resize(Elements);
+    }
+    return c_scratch.data();
+}
+
+// Runs one GEMM kernel pass into that scratch and converts the strip to fp16, so the full
+// fp32 result never lands in a caller buffer. RunKernel is handed the scratch and its
+// leading dimension and must produce the strip over the whole M range exactly as the fp32
+// branch does, which is what keeps the converted values bitwise identical to the fp32
+// path. CFp16Strip points at the first element of the strip.
+template <typename KernelFn>
+void
+StripCToFp16(
+    KernelFn&& RunKernel,
+    MLAS_FP16* CFp16Strip,
+    size_t RangeCountM,
+    size_t CountN,
+    size_t ldc
+)
+{
+    float* scratch = GetStripCFp16Scratch(RangeCountM * CountN);
+
+    RunKernel(scratch, CountN);
+
+    for (size_t m = 0; m < RangeCountM; ++m) {
+        MlasConvertFloatToHalfBuffer(scratch + m * CountN, CFp16Strip + m * ldc, CountN);
+    }
+}
+
 void
 SQ4BitGemm_CompFp32(
     const size_t BlkLen,
@@ -541,7 +594,9 @@ SQ4BitGemm_CompFp32(
             ? nullptr
             : static_cast<const std::byte*>(DataParams->QuantBZeroPoint) + RangeStartN * k_blks_zp_bytes;
 
-    float* C = DataParams->C + RangeStartM * ldc + RangeStartN;
+    const bool to_fp16 = DataParams->CFp16 != nullptr;
+    MLAS_FP16* CFp16 = to_fp16 ? DataParams->CFp16 + RangeStartM * ldc + RangeStartN : nullptr;
+    float* C = (DataParams->C == nullptr) ? nullptr : DataParams->C + RangeStartM * ldc + RangeStartN;
 
     const float* Bias = (DataParams->Bias == nullptr) ? nullptr : DataParams->Bias + RangeStartN;
 
@@ -555,8 +610,24 @@ SQ4BitGemm_CompFp32(
             const float* b_col_scale = QuantBScale + n * k_blks;
             const std::byte* b_col_zp =
                 (QuantBZeroPoint == nullptr) ? nullptr : QuantBZeroPoint + n * k_blks_zp_bytes;
-            float* c_blk = C + n;
+            float* c_blk = (C == nullptr) ? nullptr : C + n;
             const float* bias = (Bias == nullptr) ? nullptr : Bias + n;
+
+            if (to_fp16) {
+                // fp16 output and a post-processor are never set together by the operator;
+                // assert rather than silently drop it.
+                assert(DataParams->PostProcessor == nullptr);
+                StripCToFp16(
+                    [&](float* c_out, size_t /*c_out_ldc*/) {
+                        GetMlasPlatform().QNBitGemmDispatch->SQ4BitGemmM1Kernel_CompFp32(
+                            BlkLen,
+                            a_row, b_col, b_col_scale, b_col_zp, c_out, CountN, K, k_blks, bias
+                        );
+                    },
+                    CFp16 + n, RangeCountM, CountN, ldc
+                );
+                continue;
+            }
 
             GetMlasPlatform().QNBitGemmDispatch->SQ4BitGemmM1Kernel_CompFp32(
                 BlkLen,
@@ -593,13 +664,45 @@ SQ4BitGemm_CompFp32(
         const float* b_col_scale = QuantBScale + n * k_blks;
         const std::byte* b_col_zp =
             (QuantBZeroPoint == nullptr) ? nullptr : QuantBZeroPoint + n * k_blks_zp_bytes;
-        float* c_blk = C + n;
+        float* c_blk = (C == nullptr) ? nullptr : C + n;
         const float* bias = (Bias == nullptr) ? nullptr : Bias + n;
 
         GetMlasPlatform().QNBitGemmDispatch->SQ4BitBlkDequantBForSgemm_CompFp32(
             BlkLen,
             dequant_b, b_col, b_col_scale, b_col_zp, CountN, K, k_blks
         );
+
+        if (to_fp16) {
+            // fp16 output and a post-processor are never set together by the operator;
+            // assert rather than silently drop it.
+            assert(DataParams->PostProcessor == nullptr);
+            StripCToFp16(
+                [&](float* c_out, size_t c_out_ldc) {
+                    const float* a_strip = a_row;
+                    float* c_strip = c_out;
+                    size_t RowsRemaining = RangeCountM;
+                    while (RowsRemaining > 0) {
+#if defined(MLAS_TARGET_AMD64_IX86) || defined(MLAS_TARGET_POWER) || defined(MLAS_TARGET_S390X) || defined(MLAS_TARGET_LARCH64)
+                        auto RowsHandled = GetMlasPlatform().GemmFloatKernel(
+                            a_strip, dequant_b, c_strip, K, RowsRemaining, CountN, lda, c_out_ldc, 1.f, true
+                        );
+#else
+                        auto RowsHandled = MlasSgemmKernelZero(a_strip, dequant_b, c_strip, K, RowsRemaining, CountN, lda, c_out_ldc, 1.f);
+#endif
+
+                        if (bias) {
+                            AddBiasForGemm(bias, c_strip, RowsHandled, CountN, c_out_ldc);
+                        }
+
+                        c_strip += c_out_ldc * RowsHandled;
+                        a_strip += lda * RowsHandled;
+                        RowsRemaining -= RowsHandled;
+                    }
+                },
+                CFp16 + n, RangeCountM, CountN, ldc
+            );
+            continue;
+        }
 
         size_t RowsRemaining = RangeCountM;
         while (RowsRemaining > 0) {
@@ -777,43 +880,6 @@ HQ8BitGemm_CompFp16(
     }
 }
 
-// fp32 scratch for the fp16 output path below. One buffer per thread, shared by every bit
-// width, grown to the largest strip that thread has computed. Only threads that take the
-// fp16 path ever allocate.
-float*
-GetCompInt8Fp16Scratch(size_t Elements)
-{
-    static thread_local std::vector<float> c_scratch;
-    if (c_scratch.size() < Elements) {
-        c_scratch.resize(Elements);
-    }
-    return c_scratch.data();
-}
-
-// Runs one int8 GEMM kernel call into that scratch and converts the strip to fp16, so the
-// full fp32 result never lands in a caller buffer. RunKernel is handed the scratch and its
-// leading dimension and must call the kernel once over the whole M range, exactly as the
-// fp32 branch does, which is what keeps the converted values bitwise identical to the fp32
-// path. CFp16Strip points at the first element of the strip.
-template <typename KernelFn>
-void
-CompInt8StripToFp16(
-    KernelFn&& RunKernel,
-    MLAS_FP16* CFp16Strip,
-    size_t RangeCountM,
-    size_t CountN,
-    size_t ldc
-)
-{
-    float* scratch = GetCompInt8Fp16Scratch(RangeCountM * CountN);
-
-    RunKernel(scratch, CountN);
-
-    for (size_t m = 0; m < RangeCountM; ++m) {
-        MlasConvertFloatToHalfBuffer(scratch + m * CountN, CFp16Strip + m * ldc, CountN);
-    }
-}
-
 void
 SQ4BitGemm_CompInt8(
     const size_t BlkLen,
@@ -967,7 +1033,7 @@ SQ4BitGemm_CompInt8(
                 // fp32-branch post-processing does not apply here; assert rather than silently
                 // drop it.
                 assert(DataParams->PostProcessor == nullptr);
-                CompInt8StripToFp16(
+                StripCToFp16(
                     [&](float* c_out, size_t c_out_ldc) {
                         GetMlasPlatform().QNBitGemmDispatch->SQ4BitGemmKernel_BlkSum_CompInt8(
                             BlkLen,
@@ -1082,7 +1148,7 @@ SQ8BitGemm_CompInt8(
                 BlkUnsignedQuantAZeroPointCorrection + n * k_blks : nullptr;
             if (to_fp16) {
                 assert(DataParams->PostProcessor == nullptr);
-                CompInt8StripToFp16(
+                StripCToFp16(
                     [&](float* c_out, size_t c_out_ldc) {
                         GetMlasPlatform().QNBitGemmDispatch->SQ8BitGemmKernel_BlkSum_CompInt8(
                             BlkLen,
@@ -1219,7 +1285,7 @@ SQ2BitGemm_CompInt8(
 
         if (to_fp16) {
             assert(DataParams->PostProcessor == nullptr);
-            CompInt8StripToFp16(
+            StripCToFp16(
                 [&](float* c_out, size_t c_out_ldc) {
                     Dispatch->SQ2BitGemmKernel_BlkSum_CompInt8(
                         BlkLen,

--- a/onnxruntime/test/mlas/unittest/test_sqnbitgemm_fp16_c_fp32path.cpp
+++ b/onnxruntime/test/mlas/unittest/test_sqnbitgemm_fp16_c_fp32path.cpp
@@ -1,0 +1,153 @@
+/*++
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the MIT License.
+
+Module Name:
+
+    test_sqnbitgemm_fp16_c_fp32path.cpp
+
+Abstract:
+
+    Tests for the fp16 direct C output of the 4-bit CompFp32 MatMulNBits path.
+    The fp16 result must be bit-identical to computing the fp32 result and
+    converting it with MlasConvertFloatToHalfBuffer.
+
+--*/
+
+#ifndef ORT_MINIMAL_BUILD
+
+#include "test_util.h"
+#include "mlas_qnbit.h"
+#include "mlas_q4.h"
+#include "core/common/float16.h"
+
+class MlasSQNBitGemmFp16CFp32PathTest : public MlasTestBase {
+ private:
+  MatrixGuardBuffer<float> BufferA;
+  MatrixGuardBuffer<float> BufferB;
+  MatrixGuardBuffer<uint8_t> BufferQuantBData;
+  MatrixGuardBuffer<float> BufferQuantBScale;
+  MatrixGuardBuffer<uint8_t> BufferQuantBZeroPoint;
+  MatrixGuardBuffer<std::byte> BufferPackedQuantBData;
+  MatrixGuardBuffer<float> BufferBias;
+  MatrixGuardBuffer<float> BufferCFp32;
+  MatrixGuardBuffer<MLAS_FP16> BufferCFp16;
+  MatrixGuardBuffer<MLAS_FP16> BufferCFp16Ref;
+
+  void RunOne(size_t M, size_t N, size_t K, size_t BlkLen,
+              bool Symmetric, bool WithBias, bool WithThreadpool) {
+    constexpr size_t BlkBitWidth = 4;
+
+    if (!MlasIsQNBitGemmAvailable(BlkBitWidth, BlkLen, SQNBIT_CompFp32) ||
+        !MlasQNBitGemmFp16DirectCOutputSupported(BlkBitWidth, SQNBIT_CompFp32)) {
+      GTEST_SKIP() << "fp16 direct C for CompFp32 is not available on this platform.";
+    }
+
+    MLAS_THREADPOOL* Threadpool = WithThreadpool ? GetMlasThreadPool() : nullptr;
+
+    float* A = BufferA.GetBuffer(M * K);
+    float* B = BufferB.GetBuffer(K * N);
+    for (size_t i = 0; i < M * K; ++i) {
+      A[i] = static_cast<float>(static_cast<int>((i * 7919u + 13u) % 2001u) - 1000) / 967.0f;
+    }
+    for (size_t i = 0; i < K * N; ++i) {
+      B[i] = static_cast<float>(static_cast<int>((i * 104729u + 31u) % 2001u) - 1000) / 1013.0f;
+    }
+
+    size_t QuantBDataSizeInBytes, QuantBScaleSize, QuantBZeroPointSizeInBytes;
+    MlasBlockwiseQuantizedBufferSizes<BlkBitWidth>(static_cast<int>(BlkLen), /* columnwise */ true,
+                                                   static_cast<int>(K), static_cast<int>(N),
+                                                   QuantBDataSizeInBytes, QuantBScaleSize,
+                                                   &QuantBZeroPointSizeInBytes);
+
+    uint8_t* QuantBData = BufferQuantBData.GetBuffer(QuantBDataSizeInBytes);
+    float* QuantBScale = BufferQuantBScale.GetBuffer(QuantBScaleSize);
+    uint8_t* QuantBZeroPoint = Symmetric ? nullptr : BufferQuantBZeroPoint.GetBuffer(QuantBZeroPointSizeInBytes);
+
+    MlasQuantizeBlockwise<float, BlkBitWidth>(QuantBData, QuantBScale, QuantBZeroPoint, B,
+                                              static_cast<int>(BlkLen), /* columnwise */ true,
+                                              static_cast<int>(K), static_cast<int>(N),
+                                              static_cast<int>(N), GetMlasThreadPool());
+
+    void* PackedQuantBData = nullptr;
+    if (const auto PackedQuantBDataSize = MlasQNBitGemmPackQuantBDataSize(
+            N, K, BlkBitWidth, BlkLen, !Symmetric, SQNBIT_CompFp32, nullptr);
+        PackedQuantBDataSize > 0) {
+      PackedQuantBData = BufferPackedQuantBData.GetBuffer(PackedQuantBDataSize);
+      MlasQNBitGemmPackQuantBData(N, K, BlkBitWidth, BlkLen, SQNBIT_CompFp32, QuantBData,
+                                  PackedQuantBData, QuantBScale, !Symmetric, QuantBZeroPoint,
+                                  GetMlasThreadPool(), nullptr);
+    }
+
+    float* Bias = WithBias ? BufferBias.GetBuffer(N) : nullptr;
+    if (Bias != nullptr) {
+      for (size_t n = 0; n < N; ++n) {
+        Bias[n] = static_cast<float>(static_cast<int>((n * 379u + 3u) % 201u) - 100) / 100.0f;
+      }
+    }
+
+    float* CFp32 = BufferCFp32.GetBuffer(M * N, true);
+    MLAS_FP16* CFp16 = BufferCFp16.GetBuffer(M * N, true);
+    MLAS_FP16* CFp16Ref = BufferCFp16Ref.GetBuffer(M * N, true);
+
+    auto call_gemm = [&](float* c, MLAS_FP16* c_fp16) {
+      MLAS_QNBIT_GEMM_DATA_PARAMS<float> params;
+      params.A = A;
+      params.lda = K;
+      params.QuantBDataWorkspace = QuantBData;
+      params.PackedQuantBData = static_cast<const std::byte*>(
+          PackedQuantBData != nullptr ? PackedQuantBData : static_cast<const void*>(QuantBData));
+      params.QuantBScale = QuantBScale;
+      params.QuantBZeroPoint = QuantBZeroPoint;
+      params.Bias = Bias;
+      params.C = c;
+      params.CFp16 = c_fp16;
+      params.ldc = N;
+      MlasQNBitGemmBatch(M, N, K, 1, BlkBitWidth, BlkLen, SQNBIT_CompFp32, &params,
+                         nullptr, Threadpool, nullptr);
+    };
+
+    // fp32 reference pass, then the fp16 direct pass over the same inputs.
+    call_gemm(CFp32, nullptr);
+    call_gemm(nullptr, CFp16);
+
+    MlasConvertFloatToHalfBuffer(CFp32, CFp16Ref, M * N);
+
+    for (size_t i = 0; i < M * N; ++i) {
+      ASSERT_EQ(CFp16[i].val, CFp16Ref[i].val)
+          << "mismatch @" << i << " M=" << M << " N=" << N << " K=" << K
+          << " BlkLen=" << BlkLen << " sym=" << Symmetric << " bias=" << WithBias
+          << " tp=" << WithThreadpool;
+    }
+  }
+
+ public:
+  static const char* GetTestSuiteName() {
+    return "SQNBitGemmFp16CFp32Path";
+  }
+
+  void ExecuteShort(void) override {
+    for (size_t BlkLen : {16, 32, 64, 128}) {
+      // M == 1 takes the M1 kernel, M > 1 the dequant-strip SGEMM loop; N values
+      // cover the 128 and 32 column chunkings and their remainders.
+      RunOne(1, 128, 256, BlkLen, false, false, false);
+      RunOne(1, 130, 129, BlkLen, true, true, false);
+      RunOne(4, 32, 128, BlkLen, false, true, false);
+      RunOne(7, 129, 257, BlkLen, true, false, false);
+      RunOne(33, 63, 512, BlkLen, false, true, true);
+      RunOne(129, 257, 1031, BlkLen, true, true, true);
+    }
+  }
+};
+
+static UNUSED_VARIABLE bool added_to_main = AddTestRegister([](bool is_short_execute) {
+  size_t count = 0;
+  if (is_short_execute) {
+    count += MlasDirectShortExecuteTests<MlasSQNBitGemmFp16CFp32PathTest>::RegisterShortExecute();
+  }
+  return count;
+});
+
+#endif  // ORT_MINIMAL_BUILD

--- a/onnxruntime/test/mlas/unittest/test_sqnbitgemm_fp16_quant_a.cpp
+++ b/onnxruntime/test/mlas/unittest/test_sqnbitgemm_fp16_quant_a.cpp
@@ -152,7 +152,7 @@ class MlasQNBitGemmFp16QuantATest : public MlasTestBase {
     }
 
     // fp16 output path: the direct fp16 C must equal the fp32 reference converted to fp16.
-    if (MlasQNBitGemmFp16DirectCOutputSupported(BlkBitWidth)) {
+    if (MlasQNBitGemmFp16DirectCOutputSupported(BlkBitWidth, SQNBIT_CompInt8)) {
       MLFloat16* CRefFp16 = BufferCRefFp16.GetBuffer(M * N, true);
       MLFloat16* CTestFp16 = BufferCTestFp16.GetBuffer(M * N, true);
       MlasConvertFloatToHalfBuffer(CRef, CRefFp16, M * N);


### PR DESCRIPTION
### Description
#29791 and #29864 gave the CompInt8 compute path a direct fp16 C output: each worker runs the kernel into a small per thread fp32 scratch and converts its strip, so a fp16 `MatMulNBits` never allocates a full `M x N` fp32 copy of the result. The CompFp32 path still did: a 4 bit fp16 model at `accuracy_level` 0, 1, 2 or 3, which includes the schema default of 0, computed into a full fp32 output buffer and then ran a separate conversion pass over it.

This closes that hole for the 4 bit CompFp32 path. `SQ4BitGemm_CompFp32` gains the same strip conversion the CompInt8 wrappers use, in both of its shapes: the `M == 1` GEMV loop converts each 128 column chunk after the kernel call, and the `M > 1` loop runs its dequant strip SGEMM into the scratch and converts after the rows of a strip are done, bias included. Since both loops fully finish a strip before moving on (the SGEMM runs with `ZeroMode` over the whole `K`), the conversion slots in without touching the compute structure, and the fp16 values are bitwise identical to converting the fp32 result.

The shared helpers move above `SQ4BitGemm_CompFp32` and lose the misleading `CompInt8` prefix (`StripCToFp16`, `GetStripCFp16Scratch`) since they now serve both compute types. `MlasQNBitGemmFp16DirectCOutputSupported` takes the compute type so the operator can ask per path; the CompInt8 answer is unchanged, and CompFp32 answers true for 4 bit wherever its kernels exist. The operator side is the same three lines as before, now also taken when `compute_type_` is `SQNBIT_CompFp32`: skip the fp32 result buffer, set `CFp16`, skip the final conversion pass.

### Motivation and Context
Follow up to #29791/#29864, which noted the C epilogue is portable. `accuracy_level=0` is what an export gets when the attribute is not set at all, so this is the default path for a 4 bit fp16 model on x64, and it was the last `MatMulNBits` configuration still paying the `M x N` fp32 output buffer plus a full extra conversion pass at compute time.

Validation: a new MLAS test (`test_sqnbitgemm_fp16_c_fp32path.cpp`) checks the fp16 output against the fp32 result converted with `MlasConvertFloatToHalfBuffer` for byte equality across BlkLen 16/32/64/128, both loop shapes (`M == 1` and `M > 1`), column remainders against both the 128 and 32 column chunkings, symmetric and asymmetric B, bias on and off, and with and without a thread pool; all pass. An AddressSanitizer build of the full suite is clean. The existing fp16 operator tests (`MatMulNBits.Float16_4b_Accuracy0`) run through the new branches, verified with temporary probes on both branches during development and then removed. Full MLAS suite green.
