### PR TITLE
Register the BFloat16 IsNaN CPU kernel for opsets 13 to 19

### DIFF
--- a/docs/OperatorKernels.md
+++ b/docs/OperatorKernels.md
@@ -222,7 +222,7 @@ The **OpSet Version** column uses the following notation:
 |IsInf|*in* X:**T1**<br> *out* Y:**T2**|20+|**T1** = tensor(bfloat16), tensor(double), tensor(float), tensor(float16), tensor(float8e4m3fn), tensor(float8e4m3fnuz), tensor(float8e5m2), tensor(float8e5m2fnuz)<br/> **T2** = tensor(bool)|
 |||[10, 19]|**T1** = tensor(double), tensor(float)<br/> **T2** = tensor(bool)|
 |IsNaN|*in* X:**T1**<br> *out* Y:**T2**|20+|**T1** = tensor(bfloat16), tensor(double), tensor(float), tensor(float16), tensor(float8e4m3fn), tensor(float8e4m3fnuz), tensor(float8e5m2), tensor(float8e5m2fnuz)<br/> **T2** = tensor(bool)|
-|||[13, 19]|**T1** = tensor(double), tensor(float), tensor(float16)<br/> **T2** = tensor(bool)|
+|||[13, 19]|**T1** = tensor(bfloat16), tensor(double), tensor(float), tensor(float16)<br/> **T2** = tensor(bool)|
 |||[9, 12]|**T1** = tensor(double), tensor(float), tensor(float16)<br/> **T2** = tensor(bool)|
 |LRN|*in* X:**T**<br> *out* Y:**T**|13+|**T** = tensor(float)|
 |||[1, 12]|**T** = tensor(float)|

--- a/onnxruntime/core/providers/cpu/cpu_execution_provider.cc
+++ b/onnxruntime/core/providers/cpu/cpu_execution_provider.cc
@@ -2789,6 +2789,8 @@ Status RegisterOnnxOperatorKernels(KernelRegistry& kernel_registry) {
                                                                             double, IsNaN)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 13, 19,
                                                                             MLFloat16, IsNaN)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 13, 19,
+                                                                            BFloat16, IsNaN)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 13, bool, NonZero)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 13, float,
                                                                   NonZero)>,

--- a/onnxruntime/test/providers/cpu/tensor/isnan_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/isnan_test.cc
@@ -56,6 +56,13 @@ TEST(IsNaNOpTest, IsNaNFloat16_20) {
   run_is_nan_test(20, dims, input, output);
 }
 
+TEST(IsNaNOpTest, IsNaNBFloat16_13) {
+  std::vector<int64_t> dims{2, 2};
+  std::initializer_list<BFloat16> input = {BFloat16::One, BFloat16::NaN, BFloat16(2.0f), BFloat16::NaN};
+  std::initializer_list<bool> output = {false, true, false, true};
+  run_is_nan_test(13, dims, input, output, true);  // Skip as TRT10 supports BF16 but T4 GPU run on TRT CIs doesn't
+}
+
 TEST(IsNaNOpTest, IsNaNBFloat16_20) {
   std::vector<int64_t> dims{2, 2};
   std::initializer_list<BFloat16> input = {BFloat16::One, BFloat16::NaN, BFloat16(2.0f), BFloat16::NaN};


### PR DESCRIPTION
### Description
The BFloat16 IsNaN kernel for the 13 to 19 opset range is declared (`cpu_execution_provider.cc`) and its implementation is compiled in (`isnan.cc` expands `ADD_TYPED_ISNAN_OP_13(BFloat16)`, and the opset 20 registration of the same specialization exists and works), but the `BuildKernelCreateInfo` entry for the range was missing from the registration table. `IsNaN` on a bfloat16 tensor therefore failed kernel lookup at opsets 13 to 19 with `Could not find an implementation`, while working at opset 20 and up.

Adds the missing registration, a test at opset 13 mirroring the existing opset 20 BFloat16 test, and the corresponding OperatorKernels.md line.

### Motivation and Context
Found while auditing bfloat16 support on the CPU EP for #28768: this is the only case in the CPU EP of a compiled bf16 kernel that is unreachable purely for lack of a registration line.
