### PR TITLE
Make telemetry opt-out explicit

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -7,4 +7,4 @@ setlocal
 set PATH=C:\Program Files\Git\usr\bin;%PATH%
 
 rem Requires a Python install to be available in your PATH
-python "%~dp0\tools\ci_build\build.py" --build_dir "%~dp0\build\Windows" %*
+python "%~dp0\tools\ci_build\build.py" --build_dir "%~dp0\build\Windows" --no_telemetry %*

--- a/build.sh
+++ b/build.sh
@@ -18,12 +18,4 @@ elif [[ "$*" == *"--android"* ]]; then
     DIR_OS="Android"
 fi
 
-# Telemetry uses the 1DS SDK, which is not supported for WebAssembly/Emscripten builds.
-# Only request it for native builds so that `./build.sh --build_wasm` keeps working without
-# the user having to override the wrapper's default.
-TELEMETRY_ARG="--use_telemetry"
-if [[ "$*" == *"--build_wasm"* ]]; then
-    TELEMETRY_ARG=""
-fi
-
-python3 $DIR/tools/ci_build/build.py --build_dir $DIR/build/$DIR_OS $TELEMETRY_ARG "$@"
+python3 $DIR/tools/ci_build/build.py --build_dir $DIR/build/$DIR_OS "$@"

--- a/build_arm64x.bat
+++ b/build_arm64x.bat
@@ -7,5 +7,5 @@ setlocal
 set PATH=C:\Program Files\Git\usr\bin;%PATH%
 
 rem Requires a Python install to be available in your PATH
-python "%~dp0\tools\ci_build\build.py" --arm64 --buildasx  --build_dir "%~dp0\build\arm64-x" %*
-python "%~dp0\tools\ci_build\build.py" --arm64ec --buildasx --build_dir "%~dp0\build\arm64ec-x" %*
+python "%~dp0\tools\ci_build\build.py" --arm64 --buildasx --build_dir "%~dp0\build\arm64-x" --no_telemetry %*
+python "%~dp0\tools\ci_build\build.py" --arm64ec --buildasx --build_dir "%~dp0\build\arm64ec-x" --no_telemetry %*

--- a/cmake/onnxruntime_common.cmake
+++ b/cmake/onnxruntime_common.cmake
@@ -164,7 +164,13 @@ endif()
 
 if (onnxruntime_USE_TELEMETRY)
   if(WIN32)
-    set_target_properties(onnxruntime_common PROPERTIES COMPILE_FLAGS "/FI${ONNXRUNTIME_INCLUDE_DIR}/core/platform/windows/TraceLoggingConfigPrivate.h")
+    set(ONNXRUNTIME_TELEMETRY_CONFIG_HEADER
+        "${ONNXRUNTIME_INCLUDE_DIR}/core/platform/windows/TraceLoggingConfigPrivate.h")
+    if(EXISTS "${ONNXRUNTIME_TELEMETRY_CONFIG_HEADER}")
+      set_target_properties(
+        onnxruntime_common
+        PROPERTIES COMPILE_FLAGS "/FI${ONNXRUNTIME_TELEMETRY_CONFIG_HEADER}")
+    endif()
   else()
     target_compile_definitions(onnxruntime_common PRIVATE USE_POSIX_TELEMETRY)
     # Optional tenant-token override written into a generated header in the build tree (kept off the

--- a/cmake/winml.cmake
+++ b/cmake/winml.cmake
@@ -165,7 +165,13 @@ onnxruntime_add_static_library(winml_lib_telemetry
 target_compile_features(winml_lib_telemetry PRIVATE cxx_std_17)
 target_compile_options(winml_lib_telemetry PRIVATE /GR- /await /wd4238)
 if (onnxruntime_USE_TELEMETRY)
-  set_target_properties(winml_lib_telemetry PROPERTIES COMPILE_FLAGS "/FI${ONNXRUNTIME_INCLUDE_DIR}/core/platform/windows/TraceLoggingConfigPrivate.h")
+  set(ONNXRUNTIME_TELEMETRY_CONFIG_HEADER
+      "${ONNXRUNTIME_INCLUDE_DIR}/core/platform/windows/TraceLoggingConfigPrivate.h")
+  if(EXISTS "${ONNXRUNTIME_TELEMETRY_CONFIG_HEADER}")
+    set_target_properties(
+      winml_lib_telemetry
+      PROPERTIES COMPILE_FLAGS "/FI${ONNXRUNTIME_TELEMETRY_CONFIG_HEADER}")
+  endif()
 endif()
 
 # Compiler flags

--- a/docs/Privacy.md
+++ b/docs/Privacy.md
@@ -6,7 +6,7 @@ The software may collect information about you and your use of the software and 
 ***
 
 ### Official Builds
-ONNX Runtime collects trace events with the goal of improving product quality. On Windows, it uses the platform's built-in ETW telemetry system; on Linux, macOS, Android, and iOS, it uses the cross-platform 1DS telemetry SDK that is built into ONNX Runtime. Targets without a supported telemetry provider, including WebAssembly, tvOS, visionOS, and Mac Catalyst, do not include telemetry. In all cases, collection is subject to user consent and handled following Microsoft's privacy practices.
+ONNX Runtime collects trace events with the goal of improving product quality. On Windows, it uses the platform's built-in ETW telemetry system; on supported Linux architectures, macOS, Android, and iOS, it uses the cross-platform 1DS telemetry SDK that is built into ONNX Runtime. Targets without a supported telemetry provider, including WebAssembly, tvOS, visionOS, Mac Catalyst, AIX, and RISC-V, do not include telemetry. In all cases, collection is subject to user consent and handled following Microsoft's privacy practices.
 
 Telemetry is turned **ON** by default in the official builds ([see here](../README.md#binaries)). Both providers are accessed through ONNX Runtime's common telemetry interface (see [telemetry.h](../onnxruntime/core/platform/telemetry.h)).
 

--- a/docs/Privacy.md
+++ b/docs/Privacy.md
@@ -6,12 +6,12 @@ The software may collect information about you and your use of the software and 
 ***
 
 ### Official Builds
-ONNX Runtime collects trace events with the goal of improving product quality. On Windows, it uses the platform's built-in ETW telemetry system; on non-Windows platforms, it uses the cross-platform 1DS telemetry SDK that is built into ONNX Runtime. WebAssembly builds do not include telemetry. In all cases, collection is subject to user consent and handled following Microsoft's privacy practices.
+ONNX Runtime collects trace events with the goal of improving product quality. On Windows, it uses the platform's built-in ETW telemetry system; on Linux, macOS, Android, and iOS, it uses the cross-platform 1DS telemetry SDK that is built into ONNX Runtime. Targets without a supported telemetry provider, including WebAssembly, tvOS, visionOS, and Mac Catalyst, do not include telemetry. In all cases, collection is subject to user consent and handled following Microsoft's privacy practices.
 
 Telemetry is turned **ON** by default in the official builds ([see here](../README.md#binaries)). Both providers are accessed through ONNX Runtime's common telemetry interface (see [telemetry.h](../onnxruntime/core/platform/telemetry.h)).
 
 ### Private Builds
-On Windows, private builds compiled from source perform no data collection. On non-Windows platforms besides WebAssembly, the standard `build.sh` wrapper enables telemetry for native builds. For information on how to disable telemetry, see [Disabling Telemetry](#disabling-telemetry) below.
+The build driver enables telemetry by default for supported native platforms. The standard Windows `build.bat` wrapper explicitly passes `--no_telemetry`, so private builds made with that wrapper perform no data collection. Targets without a supported provider and builds that disable C++ exceptions automatically exclude telemetry. For information on how to disable telemetry in other builds, see [Disabling Telemetry](#disabling-telemetry) below.
 
 #### Technical Details
 
@@ -25,6 +25,6 @@ For ways to disable telemetry, see the [Disabling Telemetry](#disabling-telemetr
 
 Telemetry can be disabled in any of these ways:
 
-- **Don't build it in.** The telemetry provider is only compiled when configuring with `--use_telemetry`, so a build configured without it collects no data.
+- **Disable it at build time.** Pass `--no_telemetry` to `build.py` or `build.sh`. This omits the 1DS provider from non-Windows builds and disables the Microsoft telemetry configuration on Windows. The standard Windows `build.bat` wrapper does this automatically. Unsupported targets and exception-free builds never include telemetry.
 - **Disable all telemetry at runtime (non-Windows).** Set `ORT_DISABLE_TELEMETRY=1` before ONNX Runtime initializes. This prevents the uploader, events, and persistent device identifier from being created for the process lifetime.
 - **Disable non-essential events via the API.** The C API (and the C#, Python, and Java bindings) can suppress non-essential telemetry. ONNX Runtime may already have emitted a minimal initialization event before the API can be called. On **Windows**, ETW events are recorded only when an external trace session is collecting.

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -394,12 +394,7 @@ def generate_build_tree(
     disable_sparse_tensors = "sparsetensor" in types_to_disable
     disable_string_type = "string" in types_to_disable
 
-    # Telemetry: On Windows uses ETW, on non-Windows uses 1DS. Telemetry is unsupported on
-    # WebAssembly/Emscripten (the 1DS vcpkg feature excludes it), so fail fast on that combination.
-    if args.use_telemetry and args.build_wasm:
-        raise BuildError(
-            "Telemetry is not supported for WebAssembly (Emscripten) builds; omit --use_telemetry when using --build_wasm."
-        )
+    # Telemetry uses ETW on Windows and 1DS on other supported native platforms.
     cmake_args.append("-Donnxruntime_USE_TELEMETRY=" + ("ON" if args.use_telemetry else "OFF"))
     if is_windows():
         cmake_args += [

--- a/tools/ci_build/build_args.py
+++ b/tools/ci_build/build_args.py
@@ -870,9 +870,10 @@ def add_other_feature_args(parser: argparse.ArgumentParser) -> None:
     )
     # Telemetry arguments (cross-platform)
     parser.add_argument(
-        "--use_telemetry",
-        action="store_true",
-        help="Enable telemetry (not supported for WebAssembly or external Windows builds).",
+        "--no_telemetry",
+        dest="use_telemetry",
+        action="store_false",
+        help="Disable telemetry. Telemetry is enabled by default for supported native builds.",
     )
 
 
@@ -893,6 +894,17 @@ def is_cross_compiling(args: argparse.Namespace) -> bool:
             args.build_wasm,
             getattr(args, "use_gdk", False),  # GDK args added conditionally
         ]
+    )
+
+
+def target_supports_telemetry(args: argparse.Namespace) -> bool:
+    """Returns whether the selected build target has a telemetry provider."""
+    return not (
+        args.build_wasm
+        or getattr(args, "disable_exceptions", False)
+        or getattr(args, "visionos", False)
+        or getattr(args, "tvos", False)
+        or getattr(args, "macos", None) == "Catalyst"
     )
 
 
@@ -980,6 +992,9 @@ def parse_arguments() -> argparse.Namespace:
     # Treat --build_wasm_static_lib as implying --build_wasm
     if args.build_wasm_static_lib:
         args.build_wasm = True
+
+    if not target_supports_telemetry(args):
+        args.use_telemetry = False
 
     # Handle WASM exception logic
     if args.enable_wasm_api_exception_catching:

--- a/tools/ci_build/build_args.py
+++ b/tools/ci_build/build_args.py
@@ -8,6 +8,7 @@ import sys
 import warnings
 
 from util import (
+    is_linux,
     is_macOS,
     is_windows,
 )
@@ -899,13 +900,35 @@ def is_cross_compiling(args: argparse.Namespace) -> bool:
 
 def target_supports_telemetry(args: argparse.Namespace) -> bool:
     """Returns whether the selected build target has a telemetry provider."""
-    return not (
+    if (
         args.build_wasm
         or getattr(args, "disable_exceptions", False)
+        or getattr(args, "rv64", False)
         or getattr(args, "visionos", False)
         or getattr(args, "tvos", False)
         or getattr(args, "macos", None) == "Catalyst"
-    )
+    ):
+        return False
+
+    if getattr(args, "android", False) or is_windows() or is_macOS():
+        return True
+
+    if not is_linux():
+        return False
+
+    return platform.machine().lower() in {
+        "aarch64",
+        "amd64",
+        "arm",
+        "arm64",
+        "armv6l",
+        "armv7l",
+        "armv8l",
+        "i386",
+        "i686",
+        "x86",
+        "x86_64",
+    }
 
 
 # --- Main Argument Parsing Function ---

--- a/tools/ci_build/github/android/build_aar_package.py
+++ b/tools/ci_build/github/android/build_aar_package.py
@@ -68,8 +68,8 @@ def _parse_build_settings(args):
         )
 
     build_settings["build_params"] = build_params
-    build_settings["use_telemetry"] = any(
-        build_param.split("=", 1)[0] == "--use_telemetry" for build_param in build_params
+    build_settings["use_telemetry"] = not any(
+        build_param.split("=", 1)[0] in {"--no_telemetry", "--disable_exceptions"} for build_param in build_params
     )
 
     return build_settings

--- a/tools/ci_build/github/android/default_full_aar_build_settings.json
+++ b/tools/ci_build/github/android/default_full_aar_build_settings.json
@@ -17,7 +17,6 @@
         "--use_nnapi",
         "--use_xnnpack",
         "--use_webgpu",
-        "--skip_tests",
-        "--use_telemetry"
+        "--skip_tests"
     ]
 }

--- a/tools/ci_build/github/apple/default_full_apple_framework_build_settings.json
+++ b/tools/ci_build/github/apple/default_full_apple_framework_build_settings.json
@@ -20,8 +20,7 @@
             "--use_coreml",
             "--use_xnnpack",
             "--skip_tests",
-            "--cmake_extra_defines=onnxruntime_BUILD_UNIT_TESTS=OFF",
-            "--use_telemetry"
+            "--cmake_extra_defines=onnxruntime_BUILD_UNIT_TESTS=OFF"
         ],
         "macosx": [
             "--macos=MacOSX",

--- a/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines-cuda13.yml
+++ b/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines-cuda13.yml
@@ -163,7 +163,6 @@ extends:
           --enable_wcos
           --skip_submodule_sync
           --use_dml
-          --use_telemetry
           --use_webgpu
         BuildArch: 'x64'
         sln_platform: 'x64'
@@ -185,7 +184,6 @@ extends:
           --enable_wcos
           --skip_submodule_sync
           --use_dml
-          --use_telemetry
           --use_webgpu
         BuildArch: 'x64'
         sln_platform: 'arm64'

--- a/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines.yml
+++ b/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines.yml
@@ -183,7 +183,7 @@ extends:
         IsReleaseBuild: ${{ parameters.IsReleaseBuild }}
         ArtifactName: 'drop-onnxruntime-nodejs-win-x64'
         StageName: 'Windows_Nodejs_Packaging_x64'
-        BuildCommand: --skip_submodule_sync --build_shared_lib --enable_onnx_tests --enable_wcos --use_telemetry --use_dml --use_webgpu --build_nodejs --cmake_generator "Visual Studio 17 2022" --enable_generic_interface
+        BuildCommand: --skip_submodule_sync --build_shared_lib --enable_onnx_tests --enable_wcos --use_dml --use_webgpu --build_nodejs --cmake_generator "Visual Studio 17 2022" --enable_generic_interface
         BuildArch: 'x64'
         EnvSetupScript: 'setup_env.bat'
         sln_platform: 'x64'
@@ -195,7 +195,7 @@ extends:
         IsReleaseBuild: ${{ parameters.IsReleaseBuild }}
         ArtifactName: 'drop-onnxruntime-nodejs-win-arm64'
         StageName: 'Windows_Nodejs_Packaging_arm64'
-        BuildCommand: --arm64 --skip_submodule_sync --build_shared_lib --enable_onnx_tests --enable_wcos --use_telemetry --use_dml --use_webgpu --build_nodejs --cmake_generator "Visual Studio 17 2022" --enable_generic_interface
+        BuildCommand: --arm64 --skip_submodule_sync --build_shared_lib --enable_onnx_tests --enable_wcos --use_dml --use_webgpu --build_nodejs --cmake_generator "Visual Studio 17 2022" --enable_generic_interface
         BuildArch: 'x64'
         EnvSetupScript: 'setup_env.bat'
         sln_platform: 'arm64'

--- a/tools/ci_build/github/azure-pipelines/dml-nuget-packaging.yml
+++ b/tools/ci_build/github/azure-pipelines/dml-nuget-packaging.yml
@@ -70,7 +70,7 @@ extends:
         IsReleaseBuild: ${{ parameters.IsReleaseBuild }}
         ArtifactName: 'drop-nuget-dml'
         StageName: 'Windows_CI_GPU_DML_Dev'
-        BuildCommand: --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --build_shared_lib --enable_onnx_tests --enable_wcos --use_telemetry --use_dml --enable_generic_interface --build_nodejs --cmake_generator "Visual Studio 17 2022" --use_vcpkg --use_vcpkg_ms_internal_asset_cache
+        BuildCommand: --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --build_shared_lib --enable_onnx_tests --enable_wcos --use_dml --enable_generic_interface --build_nodejs --cmake_generator "Visual Studio 17 2022" --use_vcpkg --use_vcpkg_ms_internal_asset_cache
         msbuildArchitecture: 'amd64'
         EnvSetupScript: 'setup_env.bat'
         sln_platform: 'x64'
@@ -93,7 +93,7 @@ extends:
         IsReleaseBuild: ${{ parameters.IsReleaseBuild }}
         ArtifactName: 'drop-win-dml-arm64-zip'
         StageName: 'Windows_CI_GPU_DML_Dev_arm64'
-        BuildCommand: --build_dir $(Build.BinariesDirectory) --arm64 --skip_submodule_sync --build_shared_lib --enable_onnx_tests --enable_wcos --use_telemetry --use_dml --enable_generic_interface --build_nodejs --cmake_generator "Visual Studio 17 2022" --use_vcpkg --use_vcpkg_ms_internal_asset_cache
+        BuildCommand: --build_dir $(Build.BinariesDirectory) --arm64 --skip_submodule_sync --build_shared_lib --enable_onnx_tests --enable_wcos --use_dml --enable_generic_interface --build_nodejs --cmake_generator "Visual Studio 17 2022" --use_vcpkg --use_vcpkg_ms_internal_asset_cache
         EnvSetupScript: 'setup_env.bat'
         sln_platform: 'arm64'
         DoDebugBuild: 'false'

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-linux-cpu.yml
@@ -81,7 +81,7 @@ jobs:
         --volume $HOME/.gradle:/home/onnxruntimedev/.gradle \
         --volume $HOME/.onnx:/home/onnxruntimedev/.onnx -e NIGHTLY_BUILD onnxruntimecpubuildcentos8${{parameters.OnnxruntimeArch}}_packaging /bin/bash -c "python3 \
         /onnxruntime_src/tools/ci_build/build.py --enable_lto --build_java --build_nodejs --build_dir /build --config Release \
-        --skip_submodule_sync --parallel --use_vcpkg --use_vcpkg_ms_internal_asset_cache --use_binskim_compliant_compile_flags --build_shared_lib --use_telemetry ${{ parameters.AdditionalBuildFlags }} && cd /build/Release && make install DESTDIR=/build/installed"
+        --skip_submodule_sync --parallel --use_vcpkg --use_vcpkg_ms_internal_asset_cache --use_binskim_compliant_compile_flags --build_shared_lib ${{ parameters.AdditionalBuildFlags }} && cd /build/Release && make install DESTDIR=/build/installed"
         mkdir $(Build.ArtifactStagingDirectory)/testdata
         cp $(Build.BinariesDirectory)/Release/libcustom_op_library.so* $(Build.ArtifactStagingDirectory)/testdata
         ls -al $(Build.ArtifactStagingDirectory)

--- a/tools/ci_build/github/azure-pipelines/templates/mac-cpu-packaging-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/mac-cpu-packaging-steps.yml
@@ -14,7 +14,7 @@ steps:
 - script: |
       set -e -x
       rm -rf $(Build.BinariesDirectory)/Release
-      python3 $(Build.SourcesDirectory)/tools/ci_build/build.py --update --build ${{ parameters.AdditionalBuildFlags }} --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --parallel --use_vcpkg --use_vcpkg_ms_internal_asset_cache --use_binskim_compliant_compile_flags --build_shared_lib --config Release --use_telemetry
+      python3 $(Build.SourcesDirectory)/tools/ci_build/build.py --update --build ${{ parameters.AdditionalBuildFlags }} --build_dir $(Build.BinariesDirectory) --skip_submodule_sync --parallel --use_vcpkg --use_vcpkg_ms_internal_asset_cache --use_binskim_compliant_compile_flags --build_shared_lib --config Release
       cd $(Build.BinariesDirectory)/Release
       make install DESTDIR=$(Build.BinariesDirectory)/installed
   displayName: 'Build ${{ parameters.MacosArch }}'

--- a/tools/ci_build/github/azure-pipelines/templates/py-macos.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/py-macos.yml
@@ -62,7 +62,7 @@ jobs:
         --build_wheel \
         --use_coreml ${{ parameters.extra_build_arg }} \
         --cmake_extra_defines CMAKE_OSX_ARCHITECTURES=${{ parameters.arch }} \
-        --update --skip_submodule_sync --build --parallel --use_telemetry
+        --update --skip_submodule_sync --build --parallel
       python -m pip install --upgrade delocate
       cd '$(Build.SourcesDirectory)/build/Release/dist'
       ls

--- a/tools/ci_build/github/linux/build_linux_python_package.sh
+++ b/tools/ci_build/github/linux/build_linux_python_package.sh
@@ -38,7 +38,7 @@ c) BUILD_CONFIG=${OPTARG};;
 esac
 done
 
-BUILD_ARGS=("--build_dir" "/build" "--config" "$BUILD_CONFIG" "--update" "--build" "--skip_submodule_sync" "--parallel" "--use_binskim_compliant_compile_flags" "--build_wheel" "--use_telemetry" "--use_vcpkg" "--use_vcpkg_ms_internal_asset_cache")
+BUILD_ARGS=("--build_dir" "/build" "--config" "$BUILD_CONFIG" "--update" "--build" "--skip_submodule_sync" "--parallel" "--use_binskim_compliant_compile_flags" "--build_wheel" "--use_vcpkg" "--use_vcpkg_ms_internal_asset_cache")
 
 if [ "$BUILD_CONFIG" != "Debug" ]; then
     BUILD_ARGS+=("--enable_lto")

--- a/tools/ci_build/github/windows/set_telemetry_var.ps1
+++ b/tools/ci_build/github/windows/set_telemetry_var.ps1
@@ -7,9 +7,9 @@ if (-not [string]::IsNullOrEmpty( $Env:TELEMETRYGUID) -and $Env:TELEMETRYGUID.St
     $fileContent = "#define TraceLoggingOptionMicrosoftTelemetry() \
       TraceLoggingOptionGroup("+$Env:TELEMETRYGUID.substring(1, $length-2)+")"
     New-Item -Path "include\onnxruntime\core\platform\windows\TraceLoggingConfigPrivate.h" -ItemType "file" -Value "$fileContent" -Force
-    Write-Host "##vso[task.setvariable variable=TelemetryOption]--use_telemetry"
+    Write-Host "##vso[task.setvariable variable=TelemetryOption]"
     Write-Host "Telemetry is enabled."
 } else {
-    Write-Host "##vso[task.setvariable variable=TelemetryOption]"
+    Write-Host "##vso[task.setvariable variable=TelemetryOption]--no_telemetry"
     Write-Host "Telemetry is disabled."
 }

--- a/tools/ci_build/test_build_args.py
+++ b/tools/ci_build/test_build_args.py
@@ -17,10 +17,9 @@ sys.path.insert(0, str(TOOLS_DIR / "python"))
 sys.path.insert(0, str(SCRIPT_DIR))
 sys.path.insert(0, str(SCRIPT_DIR / "github" / "android"))
 
+import build  # noqa: E402
 import build_aar_package  # noqa: E402
 from build_args import parse_arguments, target_supports_telemetry  # noqa: E402
-
-import build  # noqa: E402
 
 
 class TelemetryBuildArgsTest(unittest.TestCase):

--- a/tools/ci_build/test_build_args.py
+++ b/tools/ci_build/test_build_args.py
@@ -8,6 +8,7 @@ import pathlib
 import sys
 import tempfile
 import unittest
+from types import SimpleNamespace
 from unittest import mock
 
 SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
@@ -23,6 +24,20 @@ from build_args import parse_arguments, target_supports_telemetry  # noqa: E402
 
 
 class TelemetryBuildArgsTest(unittest.TestCase):
+    @staticmethod
+    def _target(**overrides):
+        values = {
+            "android": False,
+            "build_wasm": False,
+            "disable_exceptions": False,
+            "macos": None,
+            "rv64": False,
+            "tvos": False,
+            "visionos": False,
+        }
+        values.update(overrides)
+        return SimpleNamespace(**values)
+
     def _parse(self, *build_args):
         with (
             mock.patch.object(
@@ -84,17 +99,14 @@ class TelemetryBuildArgsTest(unittest.TestCase):
         self.assertEqual(self._generated_telemetry_value("--build_wasm"), "OFF")
 
     def test_unsupported_apple_targets_disable_telemetry(self):
-        for target in (
-            mock.Mock(build_wasm=False, disable_exceptions=False, visionos=False, tvos=False, macos=None),
-            mock.Mock(build_wasm=False, disable_exceptions=False, visionos=True, tvos=False, macos=None),
-            mock.Mock(build_wasm=False, disable_exceptions=False, visionos=False, tvos=True, macos=None),
-            mock.Mock(build_wasm=False, disable_exceptions=False, visionos=False, tvos=False, macos="Catalyst"),
+        for target, expected in (
+            (self._target(), True),
+            (self._target(visionos=True), False),
+            (self._target(tvos=True), False),
+            (self._target(macos="Catalyst"), False),
         ):
             with self.subTest(target=target):
-                self.assertEqual(
-                    target_supports_telemetry(target),
-                    not (target.visionos or target.tvos or target.macos == "Catalyst"),
-                )
+                self.assertEqual(target_supports_telemetry(target), expected)
 
     def test_exception_free_build_disables_telemetry(self):
         self.assertFalse(self._parse("--minimal_build", "--disable_exceptions").use_telemetry)
@@ -102,6 +114,26 @@ class TelemetryBuildArgsTest(unittest.TestCase):
             self._generated_telemetry_value("--minimal_build", "--disable_exceptions"),
             "OFF",
         )
+
+    def test_riscv_and_unsupported_hosts_disable_telemetry(self):
+        self.assertFalse(self._parse("--rv64").use_telemetry)
+        with (
+            mock.patch("build_args.is_windows", return_value=False),
+            mock.patch("build_args.is_macOS", return_value=False),
+            mock.patch("build_args.is_linux", return_value=False),
+        ):
+            self.assertFalse(target_supports_telemetry(self._target()))
+
+    def test_linux_telemetry_architecture_allowlist(self):
+        with (
+            mock.patch("build_args.is_windows", return_value=False),
+            mock.patch("build_args.is_macOS", return_value=False),
+            mock.patch("build_args.is_linux", return_value=True),
+        ):
+            with mock.patch("build_args.platform.machine", return_value="x86_64"):
+                self.assertTrue(target_supports_telemetry(self._target()))
+            with mock.patch("build_args.platform.machine", return_value="riscv64"):
+                self.assertFalse(target_supports_telemetry(self._target()))
 
     def test_build_wrappers_use_platform_defaults(self):
         self.assertIn("--no_telemetry", (REPO_DIR / "build.bat").read_text(encoding="utf-8"))

--- a/tools/ci_build/test_build_args.py
+++ b/tools/ci_build/test_build_args.py
@@ -1,0 +1,132 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+import contextlib
+import io
+import json
+import pathlib
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
+TOOLS_DIR = SCRIPT_DIR.parent
+REPO_DIR = TOOLS_DIR.parent
+sys.path.insert(0, str(TOOLS_DIR / "python"))
+sys.path.insert(0, str(SCRIPT_DIR))
+sys.path.insert(0, str(SCRIPT_DIR / "github" / "android"))
+
+import build_aar_package  # noqa: E402
+from build_args import parse_arguments, target_supports_telemetry  # noqa: E402
+
+import build  # noqa: E402
+
+
+class TelemetryBuildArgsTest(unittest.TestCase):
+    def _parse(self, *build_args):
+        with (
+            mock.patch.object(
+                sys, "argv", ["build.py", "--build_dir", "build", "--skip_tests", "--update", *build_args]
+            ),
+            contextlib.redirect_stdout(io.StringIO()),
+        ):
+            return parse_arguments()
+
+    def _generated_telemetry_value(self, *build_args):
+        args = self._parse(*build_args)
+        cmake_commands = []
+        with (
+            tempfile.TemporaryDirectory() as build_dir,
+            mock.patch.object(
+                build, "run_subprocess", side_effect=lambda command, **kwargs: cmake_commands.append(command)
+            ),
+        ):
+            build.generate_build_tree(
+                cmake_path="cmake",
+                source_dir=str(REPO_DIR),
+                build_dir=build_dir,
+                cuda_home="",
+                cudnn_home="",
+                nccl_home="",
+                tensorrt_home="",
+                tensorrt_rtx_home="",
+                migraphx_home="",
+                acl_home="",
+                acl_libs="",
+                qnn_home="",
+                snpe_root="",
+                cann_home="",
+                path_to_protoc_exe="",
+                configs=["Release"],
+                cmake_extra_defines=[],
+                args=args,
+                cmake_extra_args=[],
+            )
+
+        self.assertEqual(len(cmake_commands), 1)
+        return next(
+            argument.rsplit("=", 1)[1]
+            for argument in cmake_commands[0]
+            if argument.startswith("-Donnxruntime_USE_TELEMETRY=")
+        )
+
+    def test_telemetry_enabled_by_default(self):
+        self.assertTrue(self._parse().use_telemetry)
+        self.assertEqual(self._generated_telemetry_value(), "ON")
+
+    def test_no_telemetry_disables_telemetry(self):
+        self.assertFalse(self._parse("--no_telemetry").use_telemetry)
+        self.assertEqual(self._generated_telemetry_value("--no_telemetry"), "OFF")
+
+    def test_webassembly_disables_telemetry(self):
+        self.assertFalse(self._parse("--build_wasm").use_telemetry)
+        self.assertFalse(self._parse("--build_wasm_static_lib").use_telemetry)
+        self.assertEqual(self._generated_telemetry_value("--build_wasm"), "OFF")
+
+    def test_unsupported_apple_targets_disable_telemetry(self):
+        for target in (
+            mock.Mock(build_wasm=False, disable_exceptions=False, visionos=False, tvos=False, macos=None),
+            mock.Mock(build_wasm=False, disable_exceptions=False, visionos=True, tvos=False, macos=None),
+            mock.Mock(build_wasm=False, disable_exceptions=False, visionos=False, tvos=True, macos=None),
+            mock.Mock(build_wasm=False, disable_exceptions=False, visionos=False, tvos=False, macos="Catalyst"),
+        ):
+            with self.subTest(target=target):
+                self.assertEqual(
+                    target_supports_telemetry(target),
+                    not (target.visionos or target.tvos or target.macos == "Catalyst"),
+                )
+
+    def test_exception_free_build_disables_telemetry(self):
+        self.assertFalse(self._parse("--minimal_build", "--disable_exceptions").use_telemetry)
+        self.assertEqual(
+            self._generated_telemetry_value("--minimal_build", "--disable_exceptions"),
+            "OFF",
+        )
+
+    def test_build_wrappers_use_platform_defaults(self):
+        self.assertIn("--no_telemetry", (REPO_DIR / "build.bat").read_text(encoding="utf-8"))
+        arm64x_build_bat = (REPO_DIR / "build_arm64x.bat").read_text(encoding="utf-8")
+        self.assertEqual(arm64x_build_bat.count("--no_telemetry"), 2)
+        build_sh = (REPO_DIR / "build.sh").read_text(encoding="utf-8")
+        self.assertNotIn("--use_telemetry", build_sh)
+        self.assertNotIn("--no_telemetry", build_sh)
+
+    def test_android_aar_telemetry_defaults_on_and_can_be_disabled(self):
+        for build_params, expected in (
+            (["--android"], True),
+            (["--android", "--no_telemetry"], False),
+            (["--android", "--minimal_build", "--disable_exceptions"], False),
+        ):
+            with self.subTest(build_params=build_params), tempfile.TemporaryDirectory() as temp_dir:
+                settings_file = pathlib.Path(temp_dir) / "build-settings.json"
+                settings_file.write_text(
+                    json.dumps({"build_params": build_params}),
+                    encoding="utf-8",
+                )
+                settings = build_aar_package._parse_build_settings(mock.Mock(build_settings_file=settings_file))
+                self.assertEqual(settings["use_telemetry"], expected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Description

- Replace the opt-in `--use_telemetry` build flag with the opt-out `--no_telemetry` flag.
- Enable telemetry by default only on supported native targets.
- Keep Windows convenience wrappers, WebAssembly, AIX, RISC-V, unsupported Apple targets, and exception-free builds telemetry-free.
- Update Android/Apple packaging, Azure pipeline callers, Windows ETW configuration fallback, privacy documentation, and focused build-argument tests.

### Motivation and Context

Telemetry is expected in supported official native builds, so the build interface should make the privacy-preserving opt-out explicit while avoiding unsupported platforms and preserving private Windows wrapper behavior.