### PR TITLE
[perftest][QNN] Enable perf_test QnnHtpShared zero-copy input on plugin-EP path

### DIFF
--- a/onnxruntime/test/perftest/ort_test_session.cc
+++ b/onnxruntime/test/perftest/ort_test_session.cc
@@ -110,6 +110,23 @@ OnnxRuntimeTestSession::OnnxRuntimeTestSession(Ort::Env& env, std::random_device
         device_memory_name_.empty()) {
       device_memory_name_ = CUDA;
     }
+
+    if (device_memory_name_.empty()) {
+#ifdef _MSC_VER
+      const std::string qnn_opt_string = ToUTF8String(performance_test_config.run_config.ep_runtime_config_string);
+#else
+      const std::string qnn_opt_string = performance_test_config.run_config.ep_runtime_config_string;
+#endif
+      std::unordered_map<std::string, std::string> qnn_plugin_options;
+      ParseSessionConfigs(qnn_opt_string, qnn_plugin_options);
+      const auto htp_option = qnn_plugin_options.find("enable_htp_shared_memory_allocator");
+      const auto dx12_option = qnn_plugin_options.find("enable_dx12_shared_memory_allocator");
+      // The QNN HTP and DX12 shared allocators currently use the same memory info name.
+      if ((htp_option != qnn_plugin_options.end() && htp_option->second == "1") ||
+          (dx12_option != qnn_plugin_options.end() && dx12_option->second == "1")) {
+        device_memory_name_ = "QnnHtpShared";
+      }
+    }
   }
 
   provider_name_ = performance_test_config.machine_config.provider_type_name;
@@ -979,6 +996,8 @@ select from 'TF8', 'TF16', 'UINT8', 'FLOAT', 'ITENSOR'. \n)");
     Ort::MemoryInfo memory_info(nullptr);  // Default initialize, will be overwritten
     if (device_memory_name_ == CUDA) {
       memory_info = Ort::MemoryInfo(device_memory_name_.data(), OrtArenaAllocator, 0, OrtMemTypeDefault);
+    } else if (device_memory_name_ == "QnnHtpShared") {
+      memory_info = Ort::MemoryInfo(device_memory_name_.data(), OrtDeviceAllocator, 0, OrtMemTypeCPUOutput);
     } else {
       memory_info = Ort::MemoryInfo(device_memory_name_.data(), OrtArenaAllocator, 0, OrtMemTypeCPUOutput);
     }

--- a/onnxruntime/test/perftest/ort_test_session.cc
+++ b/onnxruntime/test/perftest/ort_test_session.cc
@@ -5,6 +5,7 @@
 
 #include "ort_test_session.h"
 #include <algorithm>
+#include <cstring>
 #include <limits>
 #include <fstream>
 #include <set>
@@ -109,6 +110,17 @@ OnnxRuntimeTestSession::OnnxRuntimeTestSession(Ort::Env& env, std::random_device
         perftest::utils::UsesNvidiaDevice(env, performance_test_config) &&
         device_memory_name_.empty()) {
       device_memory_name_ = CUDA;
+    }
+
+    if (device_memory_name_.empty()) {
+#ifdef _MSC_VER
+      const std::string qnn_opt_string = ToUTF8String(performance_test_config.run_config.ep_runtime_config_string);
+#else
+      const std::string qnn_opt_string = performance_test_config.run_config.ep_runtime_config_string;
+#endif
+      if (qnn_opt_string.find("enable_htp_shared_memory_allocator|1") != std::string::npos) {
+        device_memory_name_ = "QnnHtpShared";
+      }
     }
   }
 
@@ -979,6 +991,8 @@ select from 'TF8', 'TF16', 'UINT8', 'FLOAT', 'ITENSOR'. \n)");
     Ort::MemoryInfo memory_info(nullptr);  // Default initialize, will be overwritten
     if (device_memory_name_ == CUDA) {
       memory_info = Ort::MemoryInfo(device_memory_name_.data(), OrtArenaAllocator, 0, OrtMemTypeDefault);
+    } else if (device_memory_name_ == "QnnHtpShared") {
+      memory_info = Ort::MemoryInfo(device_memory_name_.data(), OrtDeviceAllocator, 0, OrtMemTypeCPUOutput);
     } else {
       memory_info = Ort::MemoryInfo(device_memory_name_.data(), OrtArenaAllocator, 0, OrtMemTypeCPUOutput);
     }
@@ -1081,6 +1095,32 @@ static void InitializeTensorWithSeed(int32_t seed, Ort::Value& tensor) {
   }
 
 #undef CASE_FOR_TYPE
+}
+
+Ort::Value OnnxRuntimeTestSession::CopyToSharedAllocator(Ort::Value&& src) {
+  if (!src.IsTensor()) {
+    return std::move(src);
+  }
+
+  if (src.GetTensorMemoryInfo().GetDeviceMemoryType() == OrtDeviceMemoryType_HOST_ACCESSIBLE) {
+    return std::move(src);
+  }
+
+  const auto type_and_shape = src.GetTensorTypeAndShapeInfo();
+  const ONNXTensorElementDataType elem_type = type_and_shape.GetElementType();
+  if (elem_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_STRING) {
+    return std::move(src);
+  }
+
+  const std::vector<int64_t> shape = type_and_shape.GetShape();
+  const size_t num_bytes = src.GetTensorSizeInBytes();
+  const void* src_data = src.GetTensorRawData();
+
+  Ort::Value shared = Ort::Value::CreateTensor(allocator_, shape.data(), shape.size(), elem_type);
+  if (num_bytes > 0) {
+    memcpy(shared.GetTensorMutableRawData(), src_data, num_bytes);
+  }
+  return shared;
 }
 
 bool OnnxRuntimeTestSession::PopulateGeneratedInputTestData(int32_t seed) {

--- a/onnxruntime/test/perftest/ort_test_session.h
+++ b/onnxruntime/test/perftest/ort_test_session.h
@@ -20,6 +20,9 @@ class OnnxRuntimeTestSession : public TestSession {
                          const TestModelInfo& m);
 
   void PreLoadTestData(size_t test_data_id, size_t input_id, Ort::Value&& value) override {
+    if (allocator_.GetInfo().GetDeviceMemoryType() == OrtDeviceMemoryType_HOST_ACCESSIBLE) {
+      value = CopyToSharedAllocator(std::move(value));
+    }
     if (test_inputs_.size() < test_data_id + 1) {
       test_inputs_.resize(test_data_id + 1);
     }
@@ -39,6 +42,8 @@ class OnnxRuntimeTestSession : public TestSession {
   ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(OnnxRuntimeTestSession);
 
  private:
+  Ort::Value CopyToSharedAllocator(Ort::Value&& src);
+
   Ort::Session session_{nullptr};
   std::mt19937 rand_engine_;
   std::uniform_int_distribution<int> dist_;


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

**Fix:**
1. In the plugin-EP branch, **detect enable_htp_shared_memory_allocator|1** in the EP runtime config string and set device_memory_name_ = "QnnHtpShared".
2. Build the QnnHtpShared OrtMemoryInfo with OrtDeviceAllocator, matching how the QNN EP registers the shared allocator, so inputs take the zero-copy memHandle path.
3. Intercept in PreLoadTestData (the common sink for generated and real .pb inputs) and re-wrap CPU-backed input tensors onto the shared allocator via a new CopyToSharedAllocator helper. Tensors already HOST_ACCESSIBLE, non-tensors, and string tensors are left unchanged.



### Motivation and Context
<!-- - Why is this change required? What problem does it solve? If it fixes an open issue, please link to the issue here. -->
* When onnxruntime_perf_test registers the QNN EP via --plugin_eps, provider_name_ is not kQnnExecutionProvider, so the QNN "-i" option-parsing branch that sets device_memory_name_ = "QnnHtpShared" is skipped and every input stays CPU-backed (clientBuf, per-frame copy). 
* Separately, real .pb test data is loaded onto plain CPU memory by the shared TestCase infrastructure, so only generated (-I) inputs could reach zero-copy.

