### PR TITLE
[WebGPU EP] Gate int64 Clip kernel behind enable_int64

### DIFF
--- a/onnxruntime/core/providers/webgpu/math/unary_elementwise_ops.cc
+++ b/onnxruntime/core/providers/webgpu/math/unary_elementwise_ops.cc
@@ -375,6 +375,17 @@ WEBGPU_CLIP_KERNEL_FROM_12(uint32_t)
 // dedicated ClipInt64 kernel above; the 4-byte templated Clip cannot cover int64.
 WEBGPU_CLIP_INT64_KERNEL()
 
+void RegisterClipInt64Kernels(KernelRegistry& kernel_registry, bool enable_int64) {
+  // int64 Clip is opt-in: register the dedicated ClipInt64 kernels only when int64 support is
+  // enabled, consistent with the other int64 kernels (Cast, Expand, Range, ...).
+  if (enable_int64) {
+    ORT_THROW_IF_ERROR(kernel_registry.Register(
+        BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 12, 12, int64_t, Clip)>()));
+    ORT_THROW_IF_ERROR(kernel_registry.Register(
+        BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 13, int64_t, Clip)>()));
+  }
+}
+
 //
 // activation
 //

--- a/onnxruntime/core/providers/webgpu/math/unary_elementwise_ops.h
+++ b/onnxruntime/core/providers/webgpu/math/unary_elementwise_ops.h
@@ -3,12 +3,16 @@
 
 #pragma once
 
+#include "core/framework/kernel_registry.h"
 #include "core/providers/webgpu/webgpu_kernel.h"
 #include "core/providers/webgpu/shader_helper.h"
 #include "core/providers/webgpu/program.h"
 
 namespace onnxruntime {
 namespace webgpu {
+
+// Register int64 Clip kernels (dedicated ClipInt64 kernel) with conditional int64 support.
+void RegisterClipInt64Kernels(KernelRegistry& kernel_registry, bool enable_int64);
 
 class UnaryElementwiseProgram final : public Program<UnaryElementwiseProgram> {
  public:

--- a/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
@@ -37,6 +37,7 @@
 #include "core/providers/webgpu/tensor/trilu.h"
 #include "core/providers/webgpu/tensor/unsqueeze.h"
 #include "core/providers/webgpu/math/binary_elementwise_ops.h"
+#include "core/providers/webgpu/math/unary_elementwise_ops.h"
 #include "core/providers/webgpu/tensor/where.h"
 #include "core/providers/webgpu/reduction/reduction_ops.h"
 
@@ -153,8 +154,7 @@ static const BuildKernelCreateInfoFn build_kernel_create_info_function_table[] =
     BuildKernelCreateInfo<class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 13, int32_t, Clip)>,
     BuildKernelCreateInfo<class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 12, 12, uint32_t, Clip)>,
     BuildKernelCreateInfo<class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 13, uint32_t, Clip)>,
-    BuildKernelCreateInfo<class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 12, 12, int64_t, Clip)>,
-    BuildKernelCreateInfo<class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 13, int64_t, Clip)>,
+    // int64 Clip is registered conditionally in RegisterKernels (gated on enable_int64).
     KERNEL_CREATE_INFO(6, Elu),
     KERNEL_CREATE_INFO_VERSIONED(6, 12, Relu),
     KERNEL_CREATE_INFO_VERSIONED(13, 13, Relu),
@@ -476,6 +476,9 @@ std::unique_ptr<KernelRegistry> RegisterKernels(bool enable_graph_capture, bool 
   ORT_THROW_IF_ERROR(kernel_registry->Register(CreateCastKernelInfo<21, 22>(enable_int64)));
   ORT_THROW_IF_ERROR(kernel_registry->Register(CreateCastKernelInfo<23, 23>(enable_int64)));
   ORT_THROW_IF_ERROR(kernel_registry->Register(CreateCastKernelInfo<24>(enable_int64)));
+
+  // Register int64 Clip kernels with conditional int64 support
+  RegisterClipInt64Kernels(*kernel_registry, enable_int64);
 
   // Register Range kernels with conditional int64 support
   RegisterRangeKernels(*kernel_registry, enable_int64);

--- a/onnxruntime/test/providers/cpu/math/clip_test.cc
+++ b/onnxruntime/test/providers/cpu/math/clip_test.cc
@@ -278,7 +278,10 @@ TEST(MathOpTest, Clip_uint32_WebGpu) {
 // (interpreted as i32), then sign-extends on write. Values are kept within the int32 range -- the
 // realistic index/position case and where the truncated clamp matches the reference result.
 TEST(MathOpTest, Clip_int64_WebGpu) {
-  auto webgpu_ep = DefaultWebGpuExecutionProvider();
+  // int64 Clip is gated behind the enableInt64 option, so build the EP with it enabled.
+  ConfigOptions config_options{};
+  ASSERT_STATUS_OK(config_options.AddConfigEntry(webgpu::options::kEnableInt64, "1"));
+  auto webgpu_ep = WebGpuExecutionProviderWithOptions(config_options);
   if (webgpu_ep == nullptr) {
     GTEST_SKIP() << "WebGPU EP is not available in this build.";
   }
@@ -308,7 +311,10 @@ TEST(MathOpTest, Clip_int64_WebGpu) {
 // the raw int64 bounds would be truncated to bogus i32 values and clamp incorrectly, so this pins
 // the saturate_to_i32 behavior.
 TEST(MathOpTest, Clip_int64_saturate_WebGpu) {
-  auto webgpu_ep = DefaultWebGpuExecutionProvider();
+  // int64 Clip is gated behind the enableInt64 option, so build the EP with it enabled.
+  ConfigOptions config_options{};
+  ASSERT_STATUS_OK(config_options.AddConfigEntry(webgpu::options::kEnableInt64, "1"));
+  auto webgpu_ep = WebGpuExecutionProviderWithOptions(config_options);
   if (webgpu_ep == nullptr) {
     GTEST_SKIP() << "WebGPU EP is not available in this build.";
   }
@@ -339,7 +345,10 @@ TEST(MathOpTest, Clip_int64_saturate_WebGpu) {
 // max defaults to INT32_MAX). Only the lower bound is applied; values above min pass through.
 // (Opset 12 is the earliest at which integer Clip is valid; opset 11 constrains T to float types.)
 TEST(MathOpTest, Clip_int64_min_only_opset12_WebGpu) {
-  auto webgpu_ep = DefaultWebGpuExecutionProvider();
+  // int64 Clip is gated behind the enableInt64 option, so build the EP with it enabled.
+  ConfigOptions config_options{};
+  ASSERT_STATUS_OK(config_options.AddConfigEntry(webgpu::options::kEnableInt64, "1"));
+  auto webgpu_ep = WebGpuExecutionProviderWithOptions(config_options);
   if (webgpu_ep == nullptr) {
     GTEST_SKIP() << "WebGPU EP is not available in this build.";
   }
@@ -368,7 +377,10 @@ TEST(MathOpTest, Clip_int64_min_only_opset12_WebGpu) {
 // (a missing lower bound means "no clamp on that side", so min defaults to INT32_MIN). Only the
 // upper bound is applied; values below max pass through.
 TEST(MathOpTest, Clip_int64_max_only_opset12_WebGpu) {
-  auto webgpu_ep = DefaultWebGpuExecutionProvider();
+  // int64 Clip is gated behind the enableInt64 option, so build the EP with it enabled.
+  ConfigOptions config_options{};
+  ASSERT_STATUS_OK(config_options.AddConfigEntry(webgpu::options::kEnableInt64, "1"));
+  auto webgpu_ep = WebGpuExecutionProviderWithOptions(config_options);
   if (webgpu_ep == nullptr) {
     GTEST_SKIP() << "WebGPU EP is not available in this build.";
   }

--- a/onnxruntime/test/providers/cpu/math/clip_test.cc
+++ b/onnxruntime/test/providers/cpu/math/clip_test.cc
@@ -273,6 +273,7 @@ TEST(MathOpTest, Clip_uint32_WebGpu) {
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
 }
 
+#ifdef USE_WEBGPU
 // int64 Clip, run explicitly on the WebGPU EP. WebGPU has no native 64-bit integer type; the EP
 // stores int64 as vec2<u32> and the dedicated ClipInt64 kernel clamps on the truncated low 32 bits
 // (interpreted as i32), then sign-extends on write. Values are kept within the int32 range -- the
@@ -403,6 +404,7 @@ TEST(MathOpTest, Clip_int64_max_only_opset12_WebGpu) {
   execution_providers.push_back(std::move(webgpu_ep));
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
 }
+#endif  // USE_WEBGPU
 
 TEST(MathOpTest, Clip) {
   // To test NNAPI EP, we need the min/max to be in initializers


### PR DESCRIPTION
The int64 Clip kernel was registered unconditionally via the static kernel table, unlike every other int64 kernel (Cast, Expand, Equal, Sub, Where, ReduceSum, Reshape, Unsqueeze, Range), which register their int64 variant only when the enable_int64 option is set. As a result an int64 Clip node was claimed by the EP even when int64 support was left disabled.

Remove the int64 Clip entries from the static kernel table and register the dedicated ClipInt64 kernels conditionally in RegisterKernels, gated on enable_int64. The int64 Clip WebGPU tests now build the EP with the option enabled.

This is an enhancement for landed PR https://github.com/microsoft/onnxruntime/pull/29834