### PR TITLE
[CUDA] Fuse MoE softmax/top-k into the expert-map prologue at decode

### DIFF
--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_kernels.cu
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_kernels.cu
@@ -695,7 +695,8 @@ void launchFusedRoutingBuildExpertMaps(T const* router_logits, int* token_select
   }
 }
 
-int64_t computeNumTokensPerBlock(int64_t const num_tokens, int64_t const num_experts_per_node) {  for (int64_t num_tokens_per_block = 32; num_tokens_per_block <= 1024; num_tokens_per_block *= 2) {
+int64_t computeNumTokensPerBlock(int64_t const num_tokens, int64_t const num_experts_per_node) {
+  for (int64_t num_tokens_per_block = 32; num_tokens_per_block <= 1024; num_tokens_per_block *= 2) {
     int64_t const num_blocks_per_seq = onnxruntime::llm::common::ceilDiv(num_tokens, num_tokens_per_block);
     if (num_blocks_per_seq * num_experts_per_node <= num_tokens_per_block) {
       return num_tokens_per_block;

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_kernels.cu
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_kernels.cu
@@ -51,6 +51,7 @@
 #include "core/common/common.h"
 #include "core/common/safeint.h"
 #include "core/providers/cuda/cu_inc/cub.cuh"
+#include "core/providers/cuda/cu_inc/topk_warp_sort.cuh"
 #include "contrib_ops/cuda/llm/common/logger.h"
 #include "contrib_ops/cuda/llm/common/cuda_runtime_utils.h"
 #include "contrib_ops/cuda/llm/common/data_type.h"
@@ -105,6 +106,14 @@ inline bool MoeGemvFusedFinalizeDisabledByEnv() {
 inline bool MoeGemvSkipExpandDisabledByEnv() {
   static bool const disabled =
       onnxruntime::ParseEnvironmentVariableWithDefault<int>("ORT_DISABLE_MOE_GEMV_SKIP_EXPAND", 0) == 1;
+  return disabled;
+}
+
+// Kill switch for folding softmax + top-k routing into the expert-map prologue. Enabled by default;
+// set ORT_DISABLE_MOE_FUSED_ROUTING=1 to run a standalone SoftmaxTopK kernel before runMoe.
+inline bool MoeFusedRoutingDisabledByEnv() {
+  static bool const disabled =
+      onnxruntime::ParseEnvironmentVariableWithDefault<int>("ORT_DISABLE_MOE_FUSED_ROUTING", 0) == 1;
   return disabled;
 }
 
@@ -552,8 +561,141 @@ bool fusedBuildExpertMapsSortFirstToken(int const* token_selected_experts, int* 
   return false;
 }
 
-int64_t computeNumTokensPerBlock(int64_t const num_tokens, int64_t const num_experts_per_node) {
-  for (int64_t num_tokens_per_block = 32; num_tokens_per_block <= 1024; num_tokens_per_block *= 2) {
+// ---------------------------------------------------------------------------
+// Optimization C: fused routing prologue (single token).
+//
+// At decode the MoE op launches a standalone softmax/top-k kernel and then the expert-map prologue.
+// Both are single-block kernels whose cost is launch + drain latency rather than work, so the
+// second launch is nearly pure overhead. This kernel does both in one launch using a single warp:
+// lane e holds expert e's logit, a warp bitonic sort produces the top-k, and for a single token the
+// permutation is simply "the k selected experts ordered by expert id", which every lane can derive
+// with shuffles - no CUB block rank and no shared memory.
+//
+// The softmax/top-k arithmetic uses the very same helpers and warp bitonic sort as
+// SoftmaxTopKWarpBitonicKernel in contrib_ops/cuda/moe/qmoe_kernels.cu (shared through
+// core/providers/cuda/cu_inc/topk_warp_sort.cuh), so the emitted expert scales are bit-identical.
+// ---------------------------------------------------------------------------
+template <typename T>
+__global__ void fusedRoutingBuildExpertMapsSingleTokenKernel(
+    T const* router_logits, int* token_selected_experts, float* token_final_scales,
+    int* permuted_row_to_unpermuted_row, int* unpermuted_row_to_permuted_row,
+    int* permuted_token_selected_experts, int64_t* expert_first_token_offset, int const num_experts,
+    int const experts_per_token, bool const normalize_routing_weights) {
+  namespace topk = onnxruntime::cuda::topk;
+  int const lane = static_cast<int>(threadIdx.x);
+  int const k = experts_per_token;
+
+  // Wait PDL before reading router_logits
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+  asm volatile("griddepcontrol.wait;");
+#endif
+
+  float const logit =
+      (lane < num_experts) ? static_cast<float>(router_logits[lane]) : topk::kNegativeInfinity;
+  float const max_val = topk::WarpReduceMax(logit);
+  float const inv_sum =
+      topk::SafeInvSum(topk::WarpReduceSum((lane < num_experts) ? expf(logit - max_val) : 0.0f));
+
+  // Sorting by logit is equivalent to sorting by softmax probability (monotonic). After the sort
+  // lane r holds the rank-r (score, expert), with ties broken toward the lower expert index.
+  float score = logit;
+  int index = (lane < num_experts) ? lane : INT_MAX;
+  topk::WarpBitonicSortDescending(score, index);
+
+  float prob = (lane < k) ? topk::SoftmaxScale(score, max_val, inv_sum) : 0.0f;
+  if (normalize_routing_weights) {
+    prob /= topk::TopKNormalizeDenom(normalize_routing_weights, topk::WarpReduceSum(prob));
+  }
+
+  // Expanded row i of this token is the rank-i selection, so unpermuted_row == rank (num_tokens is
+  // 1 and unpermuted_row = i * num_tokens + token). The permuted order sorts those k rows by expert
+  // id, ties broken by rank - the same order cub::BlockRadixRank produces in the general kernel.
+  int permuted_row = 0;
+  int selected_below_lane = 0;  // number of selected experts with an id below this lane's id
+  for (int r = 0; r < k; ++r) {
+    int const other = __shfl_sync(0xFFFFFFFF, index, r);
+    permuted_row += (other < index || (other == index && r < lane)) ? 1 : 0;
+    selected_below_lane += (other < lane) ? 1 : 0;
+  }
+
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+  asm volatile("griddepcontrol.launch_dependents;");
+#endif
+
+  if (lane < k) {
+    token_selected_experts[lane] = index;
+    token_final_scales[lane] = prob;
+    permuted_row_to_unpermuted_row[permuted_row] = lane;
+    unpermuted_row_to_permuted_row[lane] = permuted_row;
+    permuted_token_selected_experts[permuted_row] = index;
+  }
+
+  // expert_first_token_offset[e] is the number of selected experts with an id below e, for
+  // e in [0, num_experts]. The last entry is the total number of expanded rows.
+  if (lane < num_experts) {
+    expert_first_token_offset[lane] = selected_below_lane;
+  }
+  if (lane == 0) {
+    expert_first_token_offset[num_experts] = k;
+  }
+}
+
+bool isFusedMoeRoutingSupported(int64_t const num_tokens, int const num_experts,
+                                int const num_experts_per_node, int const experts_per_token,
+                                int const ep_size) {
+  // One warp, one token: lane e owns expert e, so the whole expert count must fit in a warp, and
+  // the permutation shortcut above assumes a single token. Expert parallelism would additionally
+  // need the out-of-node masking that the general prologue does.
+  return !MoeFusedRoutingDisabledByEnv() && num_tokens == 1 && ep_size == 1 &&
+         num_experts == num_experts_per_node && num_experts >= 1 &&
+         num_experts <= onnxruntime::cuda::topk::kWarpBitonicMaxSize && experts_per_token >= 1 &&
+         experts_per_token <= num_experts;
+}
+
+template <typename T>
+void launchFusedRoutingBuildExpertMaps(T const* router_logits, int* token_selected_experts,
+                                       float* token_final_scales, int* permuted_row_to_unpermuted_row,
+                                       int* unpermuted_row_to_permuted_row,
+                                       int* permuted_token_selected_experts,
+                                       int64_t* expert_first_token_offset, int const num_experts,
+                                       int const experts_per_token, bool const normalize_routing_weights,
+                                       cudaStream_t stream) {
+  // The runner is also instantiated for narrow activation types (fp8/fp4) that can never be a
+  // router logit dtype; reject those here so the caller does not have to.
+  if constexpr (std::is_same_v<T, float> || std::is_same_v<T, half> || std::is_same_v<T, __nv_bfloat16>) {
+    cudaLaunchConfig_t config;
+    config.gridDim = 1;
+    config.blockDim = onnxruntime::cuda::topk::kWarpSize;
+    config.dynamicSmemBytes = 0;
+    config.stream = stream;
+    cudaLaunchAttribute attrs[1];
+    attrs[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+    attrs[0].val.programmaticStreamSerializationAllowed = onnxruntime::llm::common::getEnvEnablePDL();
+    config.numAttrs = 1;
+    config.attrs = attrs;
+
+    CUDA_CALL_THROW(cudaLaunchKernelEx(&config, &fusedRoutingBuildExpertMapsSingleTokenKernel<T>, router_logits,
+                                       token_selected_experts, token_final_scales, permuted_row_to_unpermuted_row,
+                                       unpermuted_row_to_permuted_row, permuted_token_selected_experts,
+                                       expert_first_token_offset, num_experts, experts_per_token,
+                                       normalize_routing_weights));
+  } else {
+    (void)router_logits;
+    (void)token_selected_experts;
+    (void)token_final_scales;
+    (void)permuted_row_to_unpermuted_row;
+    (void)unpermuted_row_to_permuted_row;
+    (void)permuted_token_selected_experts;
+    (void)expert_first_token_offset;
+    (void)num_experts;
+    (void)experts_per_token;
+    (void)normalize_routing_weights;
+    (void)stream;
+    ORT_THROW("Fused MoE routing requires float, half or bfloat16 router logits");
+  }
+}
+
+int64_t computeNumTokensPerBlock(int64_t const num_tokens, int64_t const num_experts_per_node) {  for (int64_t num_tokens_per_block = 32; num_tokens_per_block <= 1024; num_tokens_per_block *= 2) {
     int64_t const num_blocks_per_seq = onnxruntime::llm::common::ceilDiv(num_tokens, num_tokens_per_block);
     if (num_blocks_per_seq * num_experts_per_node <= num_tokens_per_block) {
       return num_tokens_per_block;
@@ -2517,7 +2659,7 @@ void CutlassMoeFCRunner<T, WeightType, OutputType, InputType, ScaleBiasType, Ena
     QuantParams quant_params, int64_t const num_rows, int64_t const hidden_size, int64_t const inter_size,
     int const full_num_experts, int const experts_per_token, char* workspace_ptr, void* final_output_void,
     int* unpermuted_row_to_permuted_row, MOEParallelismConfig parallelism_config,
-    ActivationParameters activation_params,
+    ActivationParameters activation_params, FusedRoutingParams fused_routing,
     cudaStream_t stream) {
   static constexpr bool int_scales_required = std::is_same<WeightType, uint8_t>::value || std::is_same<WeightType, cutlass::uint4b_t>::value;
   static constexpr bool fp8_scales_required = std::is_same<WeightType, __nv_fp8_e4m3>::value || std::is_same<WeightType, __nv_fp8_e5m2>::value;
@@ -2639,8 +2781,25 @@ void CutlassMoeFCRunner<T, WeightType, OutputType, InputType, ScaleBiasType, Ena
   auto expanded_num_rows = num_rows * experts_per_token;
 
   {
-    bool fused_prologue_result = false;
-    if (!use_w4afp8) {
+    // Optimization C: when the caller handed us the raw router logits, softmax + top-k has not run
+    // yet and we fold it into the expert-map prologue, saving a kernel launch per MoE layer. The
+    // caller gates on the same predicate, so the two cannot disagree about who computed the routing.
+    bool const use_fused_routing = fused_routing.router_logits != nullptr;
+    bool fused_prologue_result = use_fused_routing;
+    if (use_fused_routing) {
+      ORT_ENFORCE(!use_w4afp8, "Fused MoE routing is not supported for W4AFP8");
+      ORT_ENFORCE(isFusedMoeRoutingSupported(num_rows, full_num_experts, num_experts_per_node,
+                                             experts_per_token, parallelism_config.ep_size),
+                  "Fused MoE routing was requested for an unsupported configuration");
+      ORT_ENFORCE(fused_routing.token_selected_experts && fused_routing.token_final_scales);
+      launchFusedRoutingBuildExpertMaps<InputType>(
+          static_cast<InputType const*>(fused_routing.router_logits), fused_routing.token_selected_experts,
+          fused_routing.token_final_scales, permuted_row_to_unpermuted_row_, unpermuted_row_to_permuted_row,
+          permuted_token_selected_experts_, expert_first_token_offset_, full_num_experts, experts_per_token,
+          fused_routing.normalize_routing_weights, stream);
+      token_selected_experts = fused_routing.token_selected_experts;
+      token_topk_unpermuted_scales = fused_routing.token_final_scales;
+    } else if (!use_w4afp8) {
       // WAR: fusedBuildExpertMapsSortFirstToken kernel will lead to illegal memory access for W4AFP8
       fused_prologue_result = fusedBuildExpertMapsSortFirstToken(token_selected_experts,
                                                                  permuted_row_to_unpermuted_row_, unpermuted_row_to_permuted_row,

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_kernels.h
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_kernels.h
@@ -250,6 +250,30 @@ struct QuantParams {
   }
 };
 
+// Optional fused routing (optimization C). When router_logits is non-null, runMoe computes the
+// softmax + top-k itself, fused into the kernel that builds the expert permutation maps, instead of
+// the caller launching a separate softmax/top-k kernel first. At decode both are single-block
+// kernels dominated by launch latency, so merging them removes close to a full kernel's overhead
+// per layer.
+//
+// The caller must have checked isFusedMoeRoutingSupported() for the same shape parameters, and must
+// pass the same buffers it passes as runMoe's token_selected_experts / token_final_scales arguments
+// (runMoe fills them before reading them). router_logits is [num_rows, num_experts] and its element
+// type must match the runner's InputType.
+struct FusedRoutingParams {
+  void const* router_logits{nullptr};
+  int* token_selected_experts{nullptr};
+  float* token_final_scales{nullptr};
+  bool normalize_routing_weights{false};
+};
+
+// Host-side, deterministic predicate for the fused routing prologue. It must be the single source
+// of truth: the caller uses it to decide whether to skip its own softmax/top-k launch, and runMoe
+// re-checks it, so the two can never disagree about who computed the routing.
+bool isFusedMoeRoutingSupported(int64_t const num_tokens, int const num_experts,
+                                int const num_experts_per_node, int const experts_per_token,
+                                int const ep_size);
+
 class CutlassMoeFCRunnerInterface {
  public:
   virtual ~CutlassMoeFCRunnerInterface() = default;
@@ -272,7 +296,7 @@ class CutlassMoeFCRunnerInterface {
                       QuantParams quant_params, int64_t const num_rows, int64_t const hidden_size, int64_t const inter_size,
                       int const num_experts, int const experts_per_token, char* workspace_ptr, void* final_output,
                       int* unpermuted_row_to_permuted_row, MOEParallelismConfig parallelism_config,
-                      ActivationParameters activation_params,
+                      ActivationParameters activation_params, FusedRoutingParams fused_routing,
                       cudaStream_t stream) = 0;
 
   // Aliases for profiling the gemms
@@ -428,7 +452,7 @@ class CutlassMoeFCRunner : public CutlassMoeFCRunnerInterface {
               QuantParams quant_params, int64_t const num_rows, int64_t const hidden_size, int64_t const inter_size,
               int const num_experts, int const experts_per_token, char* workspace_ptr, void* final_output,
               int* unpermuted_row_to_permuted_row, MOEParallelismConfig parallelism_config,
-              ActivationParameters activation_params,
+              ActivationParameters activation_params, FusedRoutingParams fused_routing,
               cudaStream_t stream) override;
 
   // We make these GEMM1 & GEMM2 static because they need to be stateless for the profiler to work

--- a/onnxruntime/contrib_ops/cuda/moe/moe.cc
+++ b/onnxruntime/contrib_ops/cuda/moe/moe.cc
@@ -355,6 +355,7 @@ Status MoE<T>::ComputeInternal(OpKernelContext* context) const {
         params.limit = swiglu_limit_;
         return params;
       }(),
+      onnxruntime::llm::kernels::cutlass_kernels::FusedRoutingParams{},
       stream);
 
   return Status::OK();

--- a/onnxruntime/contrib_ops/cuda/moe/moe_quantization.cc
+++ b/onnxruntime/contrib_ops/cuda/moe/moe_quantization.cc
@@ -908,7 +908,23 @@ Status QMoE::ComputeInternal(OpKernelContext* context) const {
   // Input router_probs is (num_rows, num_experts)
   bool is_fp16 = input->IsDataType<MLFloat16>();
   bool is_bf16 = input->IsDataType<BFloat16>();
-  if (is_fp16) {
+
+  // Optimization C: at decode the runner can fold softmax + top-k into the kernel that builds the
+  // expert permutation maps, saving a launch per MoE layer. Both are single-block kernels there, so
+  // the launch is most of the cost. The predicate below is the same one runMoe re-checks, so the two
+  // can never disagree about who computed the routing. Excluded for the FP4 family because its
+  // decode fast path below consumes expert_indices/expert_scales itself instead of calling runMoe.
+  onnxruntime::llm::kernels::cutlass_kernels::FusedRoutingParams fused_routing;
+  if (!is_fp4_family &&
+      onnxruntime::llm::kernels::cutlass_kernels::isFusedMoeRoutingSupported(
+          moe_params.num_rows, static_cast<int>(moe_params.num_experts),
+          static_cast<int>(moe_params.num_experts) / parallelism_config.ep_size, static_cast<int>(k_),
+          parallelism_config.ep_size)) {
+    fused_routing.router_logits = router_probs->DataRaw();
+    fused_routing.token_selected_experts = expert_indices;
+    fused_routing.token_final_scales = expert_scales;
+    fused_routing.normalize_routing_weights = normalize_routing_weights_;
+  } else if (is_fp16) {
     LaunchSoftmaxTopK(
         reinterpret_cast<const half*>(router_probs->DataRaw()),
         expert_scales,
@@ -1694,6 +1710,7 @@ Status QMoE::ComputeInternal(OpKernelContext* context) const {
           params.limit = swiglu_limit_;
           return params;
         }(),
+        fused_routing,
         stream);
   }
 

--- a/onnxruntime/contrib_ops/cuda/moe/qmoe_kernels.cu
+++ b/onnxruntime/contrib_ops/cuda/moe/qmoe_kernels.cu
@@ -20,37 +20,15 @@ int Compute1DGridSize(int num_elements, int block_size) {
   return (num_elements + block_size - 1) / block_size;
 }
 
-constexpr float kTopKNormalizeEpsilon = 1e-6f;
+constexpr float kTopKNormalizeEpsilon = onnxruntime::cuda::topk::kTopKNormalizeEpsilon;
 
-__device__ __forceinline__ float SoftmaxScale(float logit, float max_val, float inv_sum) {
-  return (inv_sum > 0.0f) ? expf(logit - max_val) * inv_sum : 0.0f;
-}
-
-__device__ __forceinline__ float SafeInvSum(float sum) {
-  return (sum > 0.0f) ? (1.0f / sum) : 0.0f;
-}
-
-__device__ __forceinline__ float TopKNormalizeDenom(bool normalize_scales, float scale_sum) {
-  return (normalize_scales && scale_sum > kTopKNormalizeEpsilon) ? scale_sum : 1.0f;
-}
-
-__device__ __forceinline__ float WarpReduceMax(float value) {
-  constexpr int kWarpSize = onnxruntime::cuda::topk::kWarpSize;
-#pragma unroll
-  for (int offset = kWarpSize / 2; offset > 0; offset >>= 1) {
-    value = fmaxf(value, __shfl_xor_sync(0xFFFFFFFF, value, offset));
-  }
-  return value;
-}
-
-__device__ __forceinline__ float WarpReduceSum(float value) {
-  constexpr int kWarpSize = onnxruntime::cuda::topk::kWarpSize;
-#pragma unroll
-  for (int offset = kWarpSize / 2; offset > 0; offset >>= 1) {
-    value += __shfl_xor_sync(0xFFFFFFFF, value, offset);
-  }
-  return value;
-}
+// Shared with the fused routing prologue in the LLM MoE runner (moe_kernels.cu); see
+// core/providers/cuda/cu_inc/topk_warp_sort.cuh for why these live in a header.
+using onnxruntime::cuda::topk::SafeInvSum;
+using onnxruntime::cuda::topk::SoftmaxScale;
+using onnxruntime::cuda::topk::TopKNormalizeDenom;
+using onnxruntime::cuda::topk::WarpReduceMax;
+using onnxruntime::cuda::topk::WarpReduceSum;
 
 template <typename BlockReduce>
 __device__ __forceinline__ float BlockReduceMax(float value, typename BlockReduce::TempStorage& temp_storage) {

--- a/onnxruntime/core/providers/cuda/cu_inc/topk_warp_sort.cuh
+++ b/onnxruntime/core/providers/cuda/cu_inc/topk_warp_sort.cuh
@@ -52,6 +52,40 @@ __device__ __forceinline__ int LinearThreadIdInBlock() {
   return threadIdx.x + blockDim.x * (threadIdx.y + blockDim.y * threadIdx.z);
 }
 
+// Softmax / top-k score helpers shared by the MoE routing kernels. They live here (rather than in
+// one of the MoE translation units) because two libraries need bit-identical results: the standalone
+// SoftmaxTopK kernels in contrib_ops/cuda/moe/qmoe_kernels.cu, and the fused routing prologue in
+// contrib_ops/cuda/llm/moe_gemm/moe_kernels.cu. Any divergence would silently change expert scales.
+constexpr float kTopKNormalizeEpsilon = 1e-6f;
+
+__device__ __forceinline__ float SoftmaxScale(float logit, float max_val, float inv_sum) {
+  return (inv_sum > 0.0f) ? expf(logit - max_val) * inv_sum : 0.0f;
+}
+
+__device__ __forceinline__ float SafeInvSum(float sum) {
+  return (sum > 0.0f) ? (1.0f / sum) : 0.0f;
+}
+
+__device__ __forceinline__ float TopKNormalizeDenom(bool normalize_scales, float scale_sum) {
+  return (normalize_scales && scale_sum > kTopKNormalizeEpsilon) ? scale_sum : 1.0f;
+}
+
+__device__ __forceinline__ float WarpReduceMax(float value) {
+#pragma unroll
+  for (int offset = kWarpSize / 2; offset > 0; offset >>= 1) {
+    value = fmaxf(value, __shfl_xor_sync(0xFFFFFFFF, value, offset));
+  }
+  return value;
+}
+
+__device__ __forceinline__ float WarpReduceSum(float value) {
+#pragma unroll
+  for (int offset = kWarpSize / 2; offset > 0; offset >>= 1) {
+    value += __shfl_xor_sync(0xFFFFFFFF, value, offset);
+  }
+  return value;
+}
+
 /**
  * @brief In-register, warp-wide bitonic sort of kWarpSize (32) (score, index)
  *        pairs, producing a descending order.


### PR DESCRIPTION
## Description

At decode (one token per sequence) the MoE/QMoE path launches a standalone softmax/top-k kernel and
then a second single-block kernel that builds the expert permutation maps. Both are one-block
kernels whose cost is launch and drain latency rather than work, so the second launch is nearly pure
overhead. This PR merges them.

`fusedRoutingBuildExpertMapsSingleTokenKernel` handles the single-token case with one warp: lane `e`
owns expert `e`'s logit, warp reductions give the softmax, and `WarpBitonicSortDescending` gives the
top-k. For a single token the permutation is just "the k selected experts ordered by expert id",
which every lane derives with shuffles, so no CUB block rank and no shared memory are needed. The
kernel writes `token_selected_experts`, `token_final_scales` and all three permutation maps.

## Summary of Changes

- **Fused routing prologue.** `launchFusedRoutingBuildExpertMaps` replaces the
  `LaunchSoftmaxTopK` + `fusedBuildExpertMapsSortFirstToken` pair on the supported decode shape.
- **Shared softmax/top-k math.** The routing arithmetic must stay bit-identical to
  `SoftmaxTopKWarpBitonicKernel`, so `SoftmaxScale`, `SafeInvSum`, `TopKNormalizeDenom`,
  `WarpReduceMax` and `WarpReduceSum` move from `qmoe_kernels.cu` into `topk_warp_sort.cuh`, and
  both translation units now share one definition.
- **Single source of truth for the guard.** `isFusedMoeRoutingSupported()` is host-only and
  deterministic. The QMoE op uses it to decide whether to skip its own softmax/top-k launch, and
  `runMoe` re-checks it, so the two can never disagree about who computed the routing. It requires
  one token, no expert parallelism, and `num_experts <= 32`. The FP4 family is excluded in the op
  because its decode fast path consumes `expert_indices`/`expert_scales` itself instead of calling
  `runMoe`.
- **Kill switch:** `ORT_DISABLE_MOE_FUSED_ROUTING=1` restores the two-kernel prologue.

## Performance

The win scales with how large a launch is relative to the rest of the call, so it is much bigger on
a smaller GPU. Isolated QMoE node at the gpt-oss-20b decode shape (hidden 2880, intermediate 2880,
32 experts, top-4, batch 1, fp16, int4), arms interleaved within every pass via the kill switch:

**RTX 3060 (sm_86), per-channel int4, 12 passes x 1000 reps**

| arm | mean | min | vs fused |
|---|---|---|---|
| fused routing | **255.6 us** | 250.1 us | — |
| `ORT_DISABLE_MOE_FUSED_ROUTING=1` | 277.6 us | 262.7 us | +8.6% |

Fused wins **12 of 12** paired passes (median +7.0%).

**RTX 3060 (sm_86), block-wise int4 (`block_size=64`), 8 passes x 1000 reps**

| arm | mean | vs fused |
|---|---|---|
| fused routing | **263.7 us** | — |
| `ORT_DISABLE_MOE_FUSED_ROUTING=1` | 277.7 us | +5.3% |

Fused wins **8 of 8** paired passes (median +5.0%).

On an RTX 5060 Ti (sm_120) the same change measured +0.24% end-to-end decode throughput on
gpt-oss-20b — inside that harness's noise floor. A tripwire build confirmed the fused path really
does engage at decode there, so the sm_120 number is a genuine null result rather than a dead path;
the faster GPU simply amortizes the extra launch better.

## Testing

On the RTX 3060 (sm_86), with and without `ORT_DISABLE_MOE_FUSED_ROUTING=1`:

- `onnxruntime/test/python/transformers/test_qmoe_cuda.py`: 109 passed, 13 skipped
- `onnxruntime/test/python/transformers/test_moe_cuda.py`: 48 passed, 15 skipped
