### PR TITLE
Document get_provider_graph_assignment_info for EP fallback detection

### DIFF
--- a/docs/python/api_summary.rst
+++ b/docs/python/api_summary.rst
@@ -346,6 +346,47 @@ Providers
 
 .. autofunction:: onnxruntime.get_available_providers
 
+Detecting Execution Provider Fallback
+"""""""""""""""""""""""""""""""""""""
+
+When a requested execution provider is not available at runtime (e.g., missing
+shared libraries, incompatible CUDA version), ORT silently falls back to the
+next available provider. This can cause unexpected performance degradation or
+behavioral differences.
+
+To detect which execution providers actually executed nodes in your session,
+use ``get_provider_graph_assignment_info()``:
+
+.. code-block:: python
+
+	options = onnxruntime.SessionOptions()
+	options.add_session_config_entry("session.record_ep_graph_assignment_info", "1")
+
+	session = onnxruntime.InferenceSession(
+		'model.onnx',
+		sess_options=options,
+		providers=['TensorrtExecutionProvider', 'CUDAExecutionProvider', 'CPUExecutionProvider'],
+	)
+
+	for subgraph in session.get_provider_graph_assignment_info():
+		print(f"{subgraph.ep_name}: {len(subgraph.get_nodes())} nodes")
+
+This will show which providers actually received node assignments, allowing you
+to detect if a requested provider was not used. A provider that was requested
+but received zero nodes was not available or could not support any operators in
+the model.
+
+Additionally, setting the session log severity to VERBOSE will print all node
+placements during session initialization:
+
+.. code-block:: python
+
+	options = onnxruntime.SessionOptions()
+	options.log_severity_level = 0  # VERBOSE
+
+ORT also emits a WARNING when nodes are assigned to a non-preferred provider
+(i.e., a provider that was implicitly added rather than explicitly requested).
+
 Build, Version
 ^^^^^^^^^^^^^^
 


### PR DESCRIPTION
## Summary

Adds a "Detecting Execution Provider Fallback" section to the Python API summary, documenting the existing `get_provider_graph_assignment_info()` API and `session.record_ep_graph_assignment_info` config key.

## Motivation

Multiple issues (#23372, #27177, #26073) describe users discovering silent execution provider fallback through performance degradation rather than programmatic detection. ORT already provides `get_provider_graph_assignment_info()` for this purpose, but it is not mentioned in the Python API docs. This PR makes the existing API discoverable.

## Changes

- Added "Detecting Execution Provider Fallback" subsection under "Providers" in `docs/python/api_summary.rst`
- Documents `get_provider_graph_assignment_info()` with code example
- Documents VERBOSE logging as an alternative
- Documents the existing WARNING for non-preferred provider assignment

## Testing

Docs-only change. No code changes, no tests needed.
