### PR TITLE
Add BFloat16 support for PackedAttention, PackedMultiHeadAttention, ShardedMoE (CUDA EP)

### DIFF
--- a/onnxruntime/contrib_ops/cuda/bert/attention_softmax.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/attention_softmax.cu
@@ -1028,6 +1028,18 @@ template Status ComputeSoftmaxWithCumSeqLength<half>(
     const int num_heads,
     half* output, cudaStream_t stream);
 
+template Status ComputeSoftmaxWithCumSeqLength<BFloat16>(
+    const BFloat16* input,
+    const BFloat16* attn_bias,
+    const bool broadcast_attn_bias_dim_0,
+    const bool broadcast_attn_bias_dim_1,
+    const int32_t* cum_seq_length,
+    const int batch_size,
+    const int sequence_length,
+    const int total_sequence_length,
+    const int num_heads,
+    BFloat16* output, cudaStream_t stream);
+
 template Status ComputeSoftmaxWithMask1D<float>(cudaStream_t stream,
                                                 const int total_sequence_length,
                                                 const int sequence_length,

--- a/onnxruntime/contrib_ops/cuda/bert/packed_attention.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/packed_attention.cc
@@ -32,13 +32,15 @@ namespace cuda {
 
 REGISTER_KERNEL_TYPED(float)
 REGISTER_KERNEL_TYPED(MLFloat16)
+REGISTER_KERNEL_TYPED(BFloat16)
 
 template <typename T>
 TrtFusedAttention<T>::TrtFusedAttention(const OpKernelInfo& info)
     : CudaKernel(info) {
   kernel_options_ = this->GetAttentionKernelOptions();
-  disable_fused_runner_ = sizeof(T) != 2 || !kernel_options_->UseTrtFusedAttention();
-  enable_trt_flash_attention_ = sizeof(T) == 2 && kernel_options_->UseTrtFlashAttention();
+  // TRT fused runner (FusedMHARunnerFP16v2) only supports fp16; bf16 must fall back to flash/cutlass/unfused.
+  disable_fused_runner_ = !std::is_same<T, MLFloat16>::value || !kernel_options_->UseTrtFusedAttention();
+  enable_trt_flash_attention_ = std::is_same<T, MLFloat16>::value && kernel_options_->UseTrtFlashAttention();
 }
 
 template <typename T>
@@ -84,6 +86,7 @@ MHARunner* TrtFusedAttention<T>::GetFusedRunner(const cudaDeviceProp& device_pro
 // template class instantiation
 template class TrtFusedAttention<float>;
 template class TrtFusedAttention<MLFloat16>;
+template class TrtFusedAttention<BFloat16>;
 
 template <typename T>
 PackedAttention<T>::PackedAttention(const OpKernelInfo& info)
@@ -259,7 +262,7 @@ Status PackedAttention<T>::ComputeInternal(OpKernelContext* context) const {
     int sm = device_prop.major * 10 + device_prop.minor;
     use_memory_efficient_attention =
         (attention_bias == nullptr || parameters.sequence_length % (4 * sizeof(T)) == 0) &&
-        sizeof(T) == 2 &&  // only enable for fp16
+        sizeof(T) == 2 &&  // enable for fp16 and bf16
         has_memory_efficient_attention(sm, std::is_same<T, MLFloat16>::value, std::is_same<T, BFloat16>::value, parameters.head_size, parameters.v_head_size);
   }
 #endif

--- a/onnxruntime/contrib_ops/cuda/bert/packed_attention_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/packed_attention_impl.cu
@@ -447,6 +447,42 @@ Status LaunchTransposeRemovePadding(
   return CUDA_CALL(cudaGetLastError());
 }
 
+// input: [batch_size, number_heads, seq_len, head_size]
+// output: [token_count, number_heads * head_size]
+template <>
+Status LaunchTransposeRemovePadding(
+    BFloat16* output, const BFloat16* input,
+    const int* token_offset, const int token_count,
+    const int batch_size, const int seq_len, const int number_heads, const int head_size,
+    cudaStream_t stream) {
+  // Make sure memory is aligned to 128 bit
+  ORT_ENFORCE(!(reinterpret_cast<size_t>(input) & 0xF) && !(reinterpret_cast<size_t>(output) & 0xF), "alignment");
+
+  if (head_size % 8 == 0) {
+    const int4* input2 = reinterpret_cast<const int4*>(input);
+    int4* output2 = reinterpret_cast<int4*>(output);
+    TransposeRemovePadding<int4><<<token_count, kMAX_THREADS_PER_BLOCK, 0, stream>>>(
+        output2, input2, token_offset, batch_size, seq_len, number_heads, head_size / 8);
+  } else if (head_size % 4 == 0) {
+    const int64_t* input2 = reinterpret_cast<const int64_t*>(input);
+    int64_t* output2 = reinterpret_cast<int64_t*>(output);
+    TransposeRemovePadding<int64_t><<<token_count, kMAX_THREADS_PER_BLOCK, 0, stream>>>(
+        output2, input2, token_offset, batch_size, seq_len, number_heads, head_size / 4);
+  } else if (head_size % 2 == 0) {
+    const int32_t* input2 = reinterpret_cast<const int32_t*>(input);
+    int32_t* output2 = reinterpret_cast<int32_t*>(output);
+    TransposeRemovePadding<int32_t><<<token_count, kMAX_THREADS_PER_BLOCK, 0, stream>>>(
+        output2, input2, token_offset, batch_size, seq_len, number_heads, head_size / 2);
+  } else {
+    const int16_t* input2 = reinterpret_cast<const int16_t*>(input);
+    int16_t* output2 = reinterpret_cast<int16_t*>(output);
+    TransposeRemovePadding<int16_t><<<token_count, kMAX_THREADS_PER_BLOCK, 0, stream>>>(
+        output2, input2, token_offset, batch_size, seq_len, number_heads, head_size);
+  }
+
+  return CUDA_CALL(cudaGetLastError());
+}
+
 template <typename T>
 Status FusedScaledDotProductAttention(
     const cudaDeviceProp& /*device_prop*/,
@@ -726,6 +762,12 @@ template Status LaunchTransposeRemovePadding<float>(
 
 template Status LaunchTransposeRemovePadding<half>(
     half* output, const half* input,
+    const int* token_offset, const int token_count,
+    const int batch_size, const int seq_len, const int number_heads, const int head_size,
+    cudaStream_t stream);
+
+template Status LaunchTransposeRemovePadding<BFloat16>(
+    BFloat16* output, const BFloat16* input,
     const int* token_offset, const int token_count,
     const int batch_size, const int seq_len, const int number_heads, const int head_size,
     cudaStream_t stream);

--- a/onnxruntime/contrib_ops/cuda/bert/packed_attention_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/packed_attention_impl.cu
@@ -711,6 +711,13 @@ template Status QkvToContext<half>(
     PackedAttentionParameters& parameters,
     PackedAttentionData<half>& data);
 
+template Status QkvToContext<BFloat16>(
+    const cudaDeviceProp& device_prop,
+    cublasHandle_t& cublas,
+    cudaStream_t stream,
+    PackedAttentionParameters& parameters,
+    PackedAttentionData<BFloat16>& data);
+
 template Status LaunchTransposeRemovePadding<float>(
     float* output, const float* input,
     const int* token_offset, const int token_count,

--- a/onnxruntime/contrib_ops/cuda/bert/packed_multihead_attention.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/packed_multihead_attention.cc
@@ -33,6 +33,7 @@ namespace cuda {
 
 REGISTER_KERNEL_TYPED(float)
 REGISTER_KERNEL_TYPED(MLFloat16)
+REGISTER_KERNEL_TYPED(BFloat16)
 
 template <typename T>
 PackedMultiHeadAttention<T>::PackedMultiHeadAttention(const OpKernelInfo& info)

--- a/onnxruntime/contrib_ops/cuda/bert/packed_multihead_attention_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/packed_multihead_attention_impl.cu
@@ -905,6 +905,13 @@ template Status QkvToContext<half>(
     PackedAttentionParameters& parameters,
     PackedMultiHeadAttentionData<half>& data);
 
+template Status QkvToContext<BFloat16>(
+    const cudaDeviceProp& device_prop,
+    cublasHandle_t& cublas,
+    cudaStream_t stream,
+    PackedAttentionParameters& parameters,
+    PackedMultiHeadAttentionData<BFloat16>& data);
+
 }  // namespace cuda
 }  // namespace contrib
 }  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cuda/collective/sharded_moe.cc
+++ b/onnxruntime/contrib_ops/cuda/collective/sharded_moe.cc
@@ -1,12 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include <thread>
-#include <utility>
-
 #include "core/common/safeint.h"
 #include "core/providers/cuda/cuda_common.h"
-#include "contrib_ops/cuda/bert/transformer_cuda_common.h"
+#include "core/providers/cuda/cuda_type_conversion.h"
+#include "contrib_ops/cuda/moe/qmoe_kernels.h"
+#include "contrib_ops/cuda/llm/moe_gemm/moe_kernels.h"
 #include "sharded_moe.h"
 
 using namespace onnxruntime::cuda;
@@ -19,18 +18,6 @@ namespace cuda {
 
 #if defined(ORT_USE_NCCL)
 
-#define CHECK_CUDA(res)     \
-  if (res != cudaSuccess) { \
-    cuda_result = res;      \
-    return;                 \
-  }
-
-#define CHECK_NCCL(res)     \
-  if (res != ncclSuccess) { \
-    nccl_result = res;      \
-    return;                 \
-  }
-
 #define REGISTER_KERNEL_TYPED(T)                                                                            \
   ONNX_OPERATOR_TYPED_KERNEL_EX(                                                                            \
       ShardedMoE, kMSDomain, 1, T, kCudaExecutionProvider,                                                  \
@@ -39,27 +26,23 @@ namespace cuda {
 
 REGISTER_KERNEL_TYPED(float)
 REGISTER_KERNEL_TYPED(MLFloat16)
+REGISTER_KERNEL_TYPED(BFloat16)
 
 template <typename T>
-ShardedMoE<T>::ShardedMoE(const OpKernelInfo& op_kernel_info) : NcclKernel(op_kernel_info), MoEBase(op_kernel_info) {
+ShardedMoE<T>::ShardedMoE(const OpKernelInfo& op_kernel_info)
+    : NcclKernel(op_kernel_info), MoEBase(op_kernel_info, GetDeviceProp()) {
   ORT_ENFORCE(op_kernel_info.GetAttr<int64_t>("tensor_shards", &tensor_shards_).IsOK());
   ORT_ENFORCE(op_kernel_info.GetAttr<int64_t>("local_experts_start_index", &local_experts_start_index_).IsOK());
-  rank_to_experts_start_index_.resize(nccl_->Size());
-
-  auto allocator = op_kernel_info.GetAllocator(OrtMemTypeDefault);
-  ORT_ENFORCE(SynchronizeExpertsStartIndex(allocator) == Status::OK());
 }
 
 template <typename T>
 Status ShardedMoE<T>::ComputeInternal(OpKernelContext* context) const {
-  typedef typename ToCudaType<T>::MappedType CudaT;
-  auto stream = context->GetComputeStream();
+  using CudaT = typename OrtToCudaType<T>::type;
+  using onnxruntime::llm::kernels::cutlass_kernels::ActivationType;
+  using onnxruntime::llm::kernels::cutlass_kernels::MOEParallelismConfig;
 
-  auto& device_prop = GetDeviceProp();
-  const int sm = device_prop.major * 10 + device_prop.minor;
-
-  AllocatorPtr allocator;
-  ORT_RETURN_IF_ERROR(context->GetTempSpaceAllocator(&allocator));
+  cudaStream_t stream = Stream(context);
+  void* stream_obj = GetComputeStream(context);
 
   const Tensor* input = context->Input<Tensor>(0);
   const Tensor* router_probs = context->Input<Tensor>(1);
@@ -70,6 +53,18 @@ Status ShardedMoE<T>::ComputeInternal(OpKernelContext* context) const {
   const Tensor* fc3_experts_weights_optional = context->Input<Tensor>(6);
   const Tensor* fc3_experts_bias_optional = context->Input<Tensor>(7);
 
+  // Backward compatibility: see MoE::ComputeInternal (moe.cc) for the full rationale. Legacy
+  // exports leave swiglu_fusion at its default of 0 with FC1/FC3 pre-fused (interleaved).
+  int swiglu_fusion = swiglu_fusion_;
+  if (activation_type_ == ActivationType::Swiglu && swiglu_fusion == 0 &&
+      fc3_experts_weights_optional == nullptr) {
+    swiglu_fusion = 1;
+  }
+
+  bool is_fused_swiglu = (activation_type_ == ActivationType::Swiglu) &&
+                         (swiglu_fusion != 0) &&
+                         (fc3_experts_weights_optional == nullptr);
+
   MoEParameters moe_params(tensor_shards_);
   ORT_RETURN_IF_ERROR(::onnxruntime::contrib::moe_helper::CheckInputs<Tensor>(
       moe_params, input, router_probs,
@@ -77,140 +72,202 @@ Status ShardedMoE<T>::ComputeInternal(OpKernelContext* context) const {
       fc2_experts_weights, fc2_experts_bias_optional, nullptr, nullptr,
       fc3_experts_weights_optional, fc3_experts_bias_optional, nullptr, nullptr,
       1,  // no quantization so pack size is 1
-      activation_type_ == ort_fastertransformer::ActivationType::SwiGLU,
+      is_fused_swiglu,
       0));  // no block-wise quantization for sharded MoE
 
-  ORT_RETURN_IF_NOT(moe_params.num_experts % nccl_->Size() == 0, "num_experts should be divisible by world_size");
-
-  ort_fastertransformer::CutlassMoeFCRunner<CudaT, CudaT> moe_runner(sm,
-                                                                     activation_type_,
-                                                                     fc3_experts_weights_optional != nullptr,
-                                                                     normalize_routing_weights_,
-                                                                     use_sparse_mixer_);
-
-  size_t ws_size = moe_runner.getWorkspaceSize(
-      static_cast<size_t>(moe_params.num_rows), static_cast<size_t>(moe_params.hidden_size),
-      static_cast<size_t>(moe_params.inter_size), static_cast<size_t>(moe_params.num_experts), static_cast<size_t>(k_));
-
-  size_t fc2_output_size = k_ * moe_params.num_rows * moe_params.hidden_size * sizeof(CudaT);
-  size_t expert_scales_size = k_ * moe_params.num_rows * sizeof(CudaT);
-  size_t expanded_source_row_to_expanded_dest_row_size = k_ * moe_params.num_rows * sizeof(int);
-  size_t expert_for_source_row_size = k_ * moe_params.num_rows * sizeof(int);
-
-  // TODO: allocate one buffer and reuse it.
-  IAllocatorUniquePtr<void> work_space = IAllocator::MakeUniquePtr<void>(allocator, ws_size, false, stream);
-  IAllocatorUniquePtr<void> fc2_output = IAllocator::MakeUniquePtr<void>(allocator, fc2_output_size, false, stream);
-  IAllocatorUniquePtr<void> fc2_output_bc = IAllocator::MakeUniquePtr<void>(allocator, fc2_output_size, false, stream);
-  IAllocatorUniquePtr<void> expert_scales =
-      IAllocator::MakeUniquePtr<void>(allocator, expert_scales_size, false, stream);
-  IAllocatorUniquePtr<void> expanded_source_row_to_expanded_dest_row =
-      IAllocator::MakeUniquePtr<void>(allocator, expanded_source_row_to_expanded_dest_row_size, false, stream);
-  IAllocatorUniquePtr<void> expert_for_source_row =
-      IAllocator::MakeUniquePtr<void>(allocator, expert_for_source_row_size, false, stream);
-
-  const CudaT* fc_scales_ptr = nullptr;
-
-  moe_runner.run_moe_fc(
-      reinterpret_cast<const CudaT*>(input->template Data<T>()),
-      reinterpret_cast<const CudaT*>(router_probs->template Data<T>()),
-      reinterpret_cast<const CudaT*>(fc1_experts_weights->template Data<T>()), std::move(fc_scales_ptr),
-      fc1_experts_bias_optional == nullptr
-          ? nullptr
-          : reinterpret_cast<const CudaT*>(fc1_experts_bias_optional->template Data<T>()),
-      activation_type_,
-      fc3_experts_weights_optional == nullptr
-          ? nullptr
-          : reinterpret_cast<const CudaT*>(fc3_experts_weights_optional->template Data<T>()),
-      std::move(fc_scales_ptr),
-      fc3_experts_bias_optional == nullptr
-          ? nullptr
-          : reinterpret_cast<const CudaT*>(fc3_experts_bias_optional->template Data<T>()),
-      reinterpret_cast<const CudaT*>(fc2_experts_weights->template Data<T>()), std::move(fc_scales_ptr),
-      static_cast<int>(moe_params.num_rows), static_cast<int>(moe_params.hidden_size),
-      static_cast<int>(moe_params.inter_size), static_cast<int>(moe_params.num_experts),
-      static_cast<int>(moe_params.local_num_experts), static_cast<int>(local_experts_start_index_),
-      static_cast<int>(k_), reinterpret_cast<char*>(work_space.get()), reinterpret_cast<CudaT*>(fc2_output.get()),
-      reinterpret_cast<CudaT*>(expert_scales.get()),
-      reinterpret_cast<int*>(expanded_source_row_to_expanded_dest_row.get()),
-      reinterpret_cast<int*>(expert_for_source_row.get()), Stream(context));
-
-  Tensor* output = context->Output(0, input->Shape());
-
-  if (moe_params.parallel_type == MoEParallelType::None) {
-    fc2_output_bc = std::move(fc2_output);
-  }
-
-  if (moe_params.parallel_type == MoEParallelType::EPAndTP) {
+  MOEParallelismConfig parallelism_config;
+  if (moe_params.parallel_type == MoEParallelType::TP) {
+    ORT_ENFORCE(moe_params.tensor_shards == nccl_->Size());
+    parallelism_config = MOEParallelismConfig(nccl_->Size(), nccl_->Rank(), /*ep_size*/ 1, /*ep_rank*/ 0);
+  } else if (moe_params.parallel_type == MoEParallelType::EP) {
+    ORT_RETURN_IF_NOT(moe_params.num_experts % nccl_->Size() == 0, "num_experts should be divisible by world_size");
+    int64_t const ep_rank = local_experts_start_index_ / moe_params.local_num_experts;
+    ORT_ENFORCE(ep_rank * moe_params.local_num_experts == local_experts_start_index_,
+                "ShardedMoE requires experts to be split contiguously and evenly across ranks");
+    parallelism_config = MOEParallelismConfig(/*tp_size*/ 1, /*tp_rank*/ 0,
+                                              static_cast<int>(nccl_->Size()), static_cast<int>(ep_rank));
+  } else if (moe_params.parallel_type == MoEParallelType::EPAndTP) {
     return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Expert and Tensor Parallelism is not supported yet");
   }
 
-  if (moe_params.parallel_type == MoEParallelType::TP) {
-    ORT_ENFORCE(moe_params.tensor_shards == nccl_->Size());
-
-    ORT_RETURN_IF_ERROR(FuncCustomAllReduce(nccl_,
-                                            Stream(context),
-                                            fc2_output.get(),
-                                            fc2_output_bc.get(),
-                                            static_cast<int64_t>(fc2_output_size / sizeof(CudaT)),
-                                            input->DataType(),
-                                            collective::IPCMemoryResourcePack::GetGlobalInstance()));
-  }
-
-  if (moe_params.parallel_type == MoEParallelType::EP) {
-    size_t stride_count = moe_params.hidden_size;
-    size_t stride_bytes = stride_count * sizeof(CudaT);
-    int64_t total_past_rows = 0;
-    int64_t total_covered_rows = 0;
-
-    NCCL_RETURN_IF_ERROR(ncclGroupStart());
-    for (int rank = 0; rank < nccl_->Size(); ++rank) {
-      int64_t experts_start_index = rank_to_experts_start_index_[rank];
-      moe_runner.get_total_rows_info(experts_start_index, moe_params.local_num_experts, total_past_rows,
-                                     total_covered_rows);
-      const char* src = reinterpret_cast<const char*>(fc2_output.get()) + total_past_rows * stride_bytes;
-      char* dst = reinterpret_cast<char*>(fc2_output_bc.get()) + total_past_rows * stride_bytes;
-      NCCL_RETURN_IF_ERROR(ncclBroadcast(src, dst, total_covered_rows * stride_count,
-                                         GetNcclDataType(input->DataType()), rank, nccl_->Comm(), Stream(context)));
+  auto& device_prop = GetDeviceProp();
+  int sm = device_prop.major * 10 + device_prop.minor;
+  // SM90 TMA WS kernels only support f16/bf16, not float32. Force SM80 path for float32.
+  if constexpr (std::is_same_v<T, float>) {
+    if (sm >= 90) {
+      sm = 80;
     }
-    NCCL_RETURN_IF_ERROR(ncclGroupEnd());
   }
 
-  ort_fastertransformer::finalize_moe_routing_kernelLauncher(
-      reinterpret_cast<CudaT*>(fc2_output_bc.get()), reinterpret_cast<CudaT*>(output->template MutableData<T>()),
+  {
+    constexpr int min_dim = 16;
+    ORT_RETURN_IF(moe_params.hidden_size < min_dim,
+                  "MoE CUDA kernel requires hidden_size >= ", min_dim, " for SM", sm,
+                  ", got ", moe_params.hidden_size);
+    ORT_RETURN_IF(moe_params.inter_size < min_dim,
+                  "MoE CUDA kernel requires inter_size >= ", min_dim, " for SM", sm,
+                  ", got ", moe_params.inter_size);
+  }
+
+  onnxruntime::llm::kernels::cutlass_kernels::ActivationType kernel_activation_type = activation_type_;
+  if (activation_type_ == ActivationType::Silu && fc3_experts_weights_optional != nullptr) {
+    // Mixtral case: SiLU activation with separate FC3 mapped onto SwiGLU (Linear * SiLU(Gate)).
+    kernel_activation_type = ActivationType::Swiglu;
+  }
+
+  onnxruntime::llm::kernels::cutlass_kernels::CutlassMoeFCRunner<CudaT, CudaT> moe_runner(
+      sm, kernel_activation_type, normalize_routing_weights_, use_sparse_mixer_);
+
+  size_t ws_size = moe_runner.getWorkspaceSize(
+      static_cast<size_t>(moe_params.num_rows), static_cast<size_t>(moe_params.hidden_size),
+      static_cast<size_t>(moe_params.inter_size), static_cast<size_t>(moe_params.num_experts),
+      static_cast<size_t>(k_), kernel_activation_type, parallelism_config, /*use_awq*/ false);
+
+  size_t expanded_rows = SafeInt<size_t>(moe_params.num_rows) * SafeInt<size_t>(k_);
+  size_t scales_bytes = expanded_rows * sizeof(float);
+  size_t indices_bytes = expanded_rows * sizeof(int);
+  size_t permutation_bytes = expanded_rows * sizeof(int);
+  size_t total_scratch_bytes = SafeInt<size_t>(ws_size) + scales_bytes + indices_bytes + permutation_bytes;
+
+  auto work_space = GetScratchBuffer<void>(total_scratch_bytes, stream_obj);
+  char* workspace_ptr = reinterpret_cast<char*>(work_space.get());
+  float* expert_scales = reinterpret_cast<float*>(workspace_ptr + ws_size);
+  int* expert_indices = reinterpret_cast<int*>(workspace_ptr + ws_size + scales_bytes);
+  int* unpermuted_row_to_permuted_row = reinterpret_cast<int*>(workspace_ptr + ws_size + scales_bytes + indices_bytes);
+
+  // Perform Softmax + TopK. router_probs shares type T with input, so BFloat16 needs its own
+  // branch: reinterpreting it as float32 (as a naive is_fp16-only check would) reads garbage.
+  bool is_fp16 = input->IsDataType<MLFloat16>();
+  bool is_bf16 = input->IsDataType<BFloat16>();
+
+  if (use_sparse_mixer_) {
+    ORT_ENFORCE(k_ == 2, "Sparse mixer only supports k=2");
+    ORT_ENFORCE(moe_params.num_experts == 8 || moe_params.num_experts == 16,
+                "Sparse mixer only supports 8 or 16 experts, got ", moe_params.num_experts);
+
+    if (is_fp16) {
+      LaunchSparseMixerTop2(
+          reinterpret_cast<const half*>(router_probs->DataRaw()), expert_scales, expert_indices,
+          unpermuted_row_to_permuted_row, static_cast<int>(moe_params.num_rows),
+          static_cast<int>(moe_params.num_experts), stream);
+    } else if (is_bf16) {
+      LaunchSparseMixerTop2(
+          reinterpret_cast<const __nv_bfloat16*>(router_probs->DataRaw()), expert_scales, expert_indices,
+          unpermuted_row_to_permuted_row, static_cast<int>(moe_params.num_rows),
+          static_cast<int>(moe_params.num_experts), stream);
+    } else {
+      LaunchSparseMixerTop2(
+          reinterpret_cast<const float*>(router_probs->DataRaw()), expert_scales, expert_indices,
+          unpermuted_row_to_permuted_row, static_cast<int>(moe_params.num_rows),
+          static_cast<int>(moe_params.num_experts), stream);
+    }
+  } else {
+    if (is_fp16) {
+      LaunchSoftmaxTopK(
+          reinterpret_cast<const half*>(router_probs->DataRaw()), expert_scales, expert_indices,
+          static_cast<int>(moe_params.num_rows), static_cast<int>(moe_params.num_experts),
+          static_cast<int>(k_), normalize_routing_weights_, stream);
+    } else if (is_bf16) {
+      LaunchSoftmaxTopK(
+          reinterpret_cast<const __nv_bfloat16*>(router_probs->DataRaw()), expert_scales, expert_indices,
+          static_cast<int>(moe_params.num_rows), static_cast<int>(moe_params.num_experts),
+          static_cast<int>(k_), normalize_routing_weights_, stream);
+    } else {
+      LaunchSoftmaxTopK(
+          reinterpret_cast<const float*>(router_probs->DataRaw()), expert_scales, expert_indices,
+          static_cast<int>(moe_params.num_rows), static_cast<int>(moe_params.num_experts),
+          static_cast<int>(k_), normalize_routing_weights_, stream);
+    }
+  }
+
+  Tensor* output = context->Output(0, input->Shape());
+
+  // FC1/FC2 weight packing: identical to MoE::ComputeInternal (moe.cc) — the runner expects FC1
+  // fused as [E, 2*I, H] when a gated activation ships gate/value as separate FC1/FC3 weights.
+  size_t fc1_block_size = static_cast<size_t>(moe_params.inter_size) * static_cast<size_t>(moe_params.hidden_size);
+  int E = static_cast<int>(moe_params.num_experts);
+
+  const CudaT* fc1_input_ptr = reinterpret_cast<const CudaT*>(fc1_experts_weights->DataRaw());
+  const CudaT* fc1_processed_ptr = fc1_input_ptr;
+  IAllocatorUniquePtr<void> fc1_processed_buffer;
+
+  if (fc3_experts_weights_optional != nullptr) {
+    const CudaT* fc3_input_ptr = reinterpret_cast<const CudaT*>(fc3_experts_weights_optional->DataRaw());
+    size_t fc1_total_size = E * 2 * fc1_block_size * sizeof(CudaT);
+    fc1_processed_buffer = GetScratchBuffer<void>(fc1_total_size, stream_obj);
+    CudaT* fc1_fc3_processed_ptr = reinterpret_cast<CudaT*>(fc1_processed_buffer.get());
+    fc1_processed_ptr = fc1_fc3_processed_ptr;
+
+    for (int e = 0; e < E; ++e) {
+      CudaT* dest_fc1 = fc1_fc3_processed_ptr + e * 2 * fc1_block_size;
+      CudaT* dest_fc3 = fc1_fc3_processed_ptr + e * 2 * fc1_block_size + fc1_block_size;
+
+      CUDA_RETURN_IF_ERROR(cudaMemcpyAsync(dest_fc1, fc1_input_ptr + e * fc1_block_size,
+                                           fc1_block_size * sizeof(CudaT), cudaMemcpyDeviceToDevice, stream));
+      CUDA_RETURN_IF_ERROR(cudaMemcpyAsync(dest_fc3, fc3_input_ptr + e * fc1_block_size,
+                                           fc1_block_size * sizeof(CudaT), cudaMemcpyDeviceToDevice, stream));
+    }
+  }
+
+  const CudaT* fc2_processed_ptr = reinterpret_cast<const CudaT*>(fc2_experts_weights->DataRaw());
+
+  // finalizeMoeRoutingKernelLauncher (invoked inside runMoe) already zero-fills tokens that don't
+  // route to a rank-local expert (EP) and only applies fc2 bias on tp_rank == 0 (TP), so summing
+  // the per-rank finalized output across ranks is equivalent to the pre-finalize reduce+finalize
+  // ordering the old ft_moe runner used, without needing a separate collective buffer per rank.
+  bool needs_all_reduce = moe_params.parallel_type == MoEParallelType::TP ||
+                          moe_params.parallel_type == MoEParallelType::EP;
+
+  IAllocatorUniquePtr<void> local_output_buffer;
+  void* final_output_ptr;
+  if (needs_all_reduce) {
+    size_t output_bytes = static_cast<size_t>(moe_params.num_rows) * static_cast<size_t>(moe_params.hidden_size) * sizeof(CudaT);
+    local_output_buffer = GetScratchBuffer<void>(output_bytes, stream_obj);
+    final_output_ptr = local_output_buffer.get();
+  } else {
+    final_output_ptr = output->MutableDataRaw();
+  }
+
+  moe_runner.runMoe(
+      reinterpret_cast<const CudaT*>(input->template Data<T>()),
+      nullptr,  // input_sf
+      expert_indices,
+      expert_scales,
+      fc1_processed_ptr,
+      fc1_experts_bias_optional == nullptr
+          ? nullptr
+          : reinterpret_cast<const CudaT*>(fc1_experts_bias_optional->template Data<T>()),
+      kernel_activation_type,
+      fc2_processed_ptr,
       fc2_experts_bias_optional == nullptr
           ? nullptr
           : reinterpret_cast<const CudaT*>(fc2_experts_bias_optional->template Data<T>()),
-      reinterpret_cast<CudaT*>(expert_scales.get()),
-      reinterpret_cast<int*>(expanded_source_row_to_expanded_dest_row.get()),
-      reinterpret_cast<int*>(expert_for_source_row.get()), static_cast<int>(moe_params.num_rows),
-      static_cast<int>(moe_params.hidden_size), static_cast<int>(k_), Stream(context));
+      onnxruntime::llm::kernels::cutlass_kernels::QuantParams{},
+      static_cast<int64_t>(moe_params.num_rows), static_cast<int64_t>(moe_params.hidden_size),
+      static_cast<int64_t>(moe_params.inter_size), static_cast<int>(moe_params.num_experts),
+      static_cast<int>(k_), workspace_ptr, final_output_ptr,
+      unpermuted_row_to_permuted_row, parallelism_config,
+      [&]() {
+        onnxruntime::llm::kernels::cutlass_kernels::ActivationParams params(kernel_activation_type);
+        params.alpha = activation_alpha_;
+        params.beta = activation_beta_;
+        params.swiglu_fusion = swiglu_fusion;
+        params.limit = swiglu_limit_;
+        return params;
+      }(),
+      stream);
+
+  if (needs_all_reduce) {
+    ORT_RETURN_IF_ERROR(FuncCustomAllReduce(
+        nccl_, stream, final_output_ptr, output->MutableDataRaw(),
+        static_cast<int64_t>(moe_params.num_rows) * static_cast<int64_t>(moe_params.hidden_size),
+        input->DataType(),
+        collective::IPCMemoryResourcePack::GetGlobalInstance()));
+  }
 
   return Status::OK();
 }
 
-template <typename T>
-Status ShardedMoE<T>::SynchronizeExpertsStartIndex(AllocatorPtr& allocator) const {
-  using IndexType = int64_t;
-  size_t IndexTypeSize = sizeof(IndexType);
-
-  IAllocatorUniquePtr<IndexType> experts_start_index_d =
-      IAllocator::MakeUniquePtr<IndexType>(allocator, 1, false);
-  IAllocatorUniquePtr<IndexType> rank_to_experts_start_index_d =
-      IAllocator::MakeUniquePtr<IndexType>(allocator, nccl_->Size(), false);
-
-  CUDA_RETURN_IF_ERROR(cudaMemcpy(experts_start_index_d.get(), &local_experts_start_index_, IndexTypeSize,
-                                  cudaMemcpyHostToDevice));
-  NCCL_RETURN_IF_ERROR(ncclAllGather(reinterpret_cast<const char*>(experts_start_index_d.get()),
-                                     reinterpret_cast<char*>(rank_to_experts_start_index_d.get()), 1,
-                                     GetNcclDataType(DataTypeImpl::GetType<IndexType>()), nccl_->Comm(),
-                                     nullptr));
-
-  CUDA_RETURN_IF_ERROR(cudaMemcpy(const_cast<int64_t*>(rank_to_experts_start_index_.data()),
-                                  rank_to_experts_start_index_d.get(), nccl_->Size() * IndexTypeSize,
-                                  cudaMemcpyDeviceToHost));
-
-  return Status::OK();
-}
 #endif
 
 }  // namespace cuda

--- a/onnxruntime/contrib_ops/cuda/collective/sharded_moe.h
+++ b/onnxruntime/contrib_ops/cuda/collective/sharded_moe.h
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "contrib_ops/cuda/moe/ft_moe/moe_kernel.h"
 #include "contrib_ops/cuda/moe/moe_base.h"
 #include "core/common/common.h"
 #include "nccl_kernels.h"
@@ -23,11 +22,8 @@ class ShardedMoE final : public NcclKernel, public MoEBase {
   Status ComputeInternal(OpKernelContext* ctx) const override;
 
  private:
-  Status SynchronizeExpertsStartIndex(AllocatorPtr& alloc) const;
-
   int64_t local_experts_start_index_;
   int64_t tensor_shards_;
-  InlinedVector<int64_t> rank_to_experts_start_index_;
 };
 
 #endif

--- a/onnxruntime/contrib_ops/cuda/cuda_contrib_kernels.cc
+++ b/onnxruntime/contrib_ops/cuda/cuda_contrib_kernels.cc
@@ -87,8 +87,10 @@ class CUDA_MS_OP_TYPED_CLASS_NAME(1, MLFloat16, Attention);
 class CUDA_MS_OP_TYPED_CLASS_NAME(1, BFloat16, Attention);
 class CUDA_MS_OP_TYPED_CLASS_NAME(1, float, PackedAttention);
 class CUDA_MS_OP_TYPED_CLASS_NAME(1, MLFloat16, PackedAttention);
+class CUDA_MS_OP_TYPED_CLASS_NAME(1, BFloat16, PackedAttention);
 class CUDA_MS_OP_TYPED_CLASS_NAME(1, float, PackedMultiHeadAttention);
 class CUDA_MS_OP_TYPED_CLASS_NAME(1, MLFloat16, PackedMultiHeadAttention);
+class CUDA_MS_OP_TYPED_CLASS_NAME(1, BFloat16, PackedMultiHeadAttention);
 #if !defined(DISABLE_GENERATION_OPS)
 class CUDA_MS_OP_CLASS_NAME(1, BeamSearch);
 class CUDA_MS_OP_CLASS_NAME(1, WhisperBeamSearch);
@@ -252,6 +254,7 @@ class CUDA_MS_OP_CLASS_NAME(1, AllToAll);
 
 class CUDA_MS_OP_TYPED_CLASS_NAME(1, float, ShardedMoE);
 class CUDA_MS_OP_TYPED_CLASS_NAME(1, MLFloat16, ShardedMoE);
+class CUDA_MS_OP_TYPED_CLASS_NAME(1, BFloat16, ShardedMoE);
 
 class CUDA_MS_OP_TYPED_CLASS_NAME(1, float, DistributedMatMul);
 class CUDA_MS_OP_TYPED_CLASS_NAME(1, MLFloat16, DistributedMatMul);
@@ -348,8 +351,10 @@ Status RegisterCudaContribKernels(KernelRegistry& kernel_registry) {
       BuildKernelCreateInfo<CUDA_MS_OP_TYPED_CLASS_NAME(1, BFloat16, Attention)>,
       BuildKernelCreateInfo<CUDA_MS_OP_TYPED_CLASS_NAME(1, float, PackedAttention)>,
       BuildKernelCreateInfo<CUDA_MS_OP_TYPED_CLASS_NAME(1, MLFloat16, PackedAttention)>,
+      BuildKernelCreateInfo<CUDA_MS_OP_TYPED_CLASS_NAME(1, BFloat16, PackedAttention)>,
       BuildKernelCreateInfo<CUDA_MS_OP_TYPED_CLASS_NAME(1, float, PackedMultiHeadAttention)>,
       BuildKernelCreateInfo<CUDA_MS_OP_TYPED_CLASS_NAME(1, MLFloat16, PackedMultiHeadAttention)>,
+      BuildKernelCreateInfo<CUDA_MS_OP_TYPED_CLASS_NAME(1, BFloat16, PackedMultiHeadAttention)>,
 #if !defined(DISABLE_GENERATION_OPS)
       BuildKernelCreateInfo<CUDA_MS_OP_CLASS_NAME(1, BeamSearch)>,
       BuildKernelCreateInfo<CUDA_MS_OP_CLASS_NAME(1, WhisperBeamSearch)>,
@@ -518,6 +523,7 @@ Status RegisterCudaContribKernels(KernelRegistry& kernel_registry) {
 
       BuildKernelCreateInfo<CUDA_MS_OP_TYPED_CLASS_NAME(1, float, ShardedMoE)>,
       BuildKernelCreateInfo<CUDA_MS_OP_TYPED_CLASS_NAME(1, MLFloat16, ShardedMoE)>,
+      BuildKernelCreateInfo<CUDA_MS_OP_TYPED_CLASS_NAME(1, BFloat16, ShardedMoE)>,
 
       BuildKernelCreateInfo<CUDA_MS_OP_TYPED_CLASS_NAME(1, float, DistributedMatMul)>,
       BuildKernelCreateInfo<CUDA_MS_OP_TYPED_CLASS_NAME(1, MLFloat16, DistributedMatMul)>,

--- a/onnxruntime/contrib_ops/cuda/moe/moe.cc
+++ b/onnxruntime/contrib_ops/cuda/moe/moe.cc
@@ -223,6 +223,7 @@ Status MoE<T>::ComputeInternal(OpKernelContext* context) const {
 
   // Perform Softmax + TopK
   bool is_fp16 = input->IsDataType<MLFloat16>();
+  bool is_bf16 = input->IsDataType<BFloat16>();
 
   if (use_sparse_mixer_) {
     ORT_ENFORCE(k_ == 2, "Sparse mixer only supports k=2");
@@ -235,6 +236,15 @@ Status MoE<T>::ComputeInternal(OpKernelContext* context) const {
           expert_scales,
           expert_indices,
           unpermuted_row_to_permuted_row,  // source_rows
+          static_cast<int>(moe_params.num_rows),
+          static_cast<int>(moe_params.num_experts),
+          stream);
+    } else if (is_bf16) {
+      LaunchSparseMixerTop2(
+          reinterpret_cast<const __nv_bfloat16*>(router_probs->DataRaw()),
+          expert_scales,
+          expert_indices,
+          unpermuted_row_to_permuted_row,
           static_cast<int>(moe_params.num_rows),
           static_cast<int>(moe_params.num_experts),
           stream);
@@ -253,6 +263,16 @@ Status MoE<T>::ComputeInternal(OpKernelContext* context) const {
     if (is_fp16) {
       LaunchSoftmaxTopK(
           reinterpret_cast<const half*>(router_probs->DataRaw()),
+          expert_scales,
+          expert_indices,
+          static_cast<int>(moe_params.num_rows),
+          static_cast<int>(moe_params.num_experts),
+          static_cast<int>(k_),
+          normalize_routing_weights_,
+          stream);
+    } else if (is_bf16) {
+      LaunchSoftmaxTopK(
+          reinterpret_cast<const __nv_bfloat16*>(router_probs->DataRaw()),
           expert_scales,
           expert_indices,
           static_cast<int>(moe_params.num_rows),

--- a/onnxruntime/core/graph/contrib_ops/bert_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/bert_defs.cc
@@ -699,7 +699,7 @@ ONNX_MS_OPERATOR_SET_SCHEMA(
                 "2D output tensor with shape (token_count, v_hidden_size)",
                 "T")
         .TypeConstraint("T",
-                        {"tensor(float)", "tensor(float16)"},
+                        {"tensor(float)", "tensor(float16)", "tensor(bfloat16)"},
                         "Constrain input and output types to float tensors.")
         .TypeConstraint("M",
                         {"tensor(int32)"},
@@ -831,7 +831,7 @@ ONNX_MS_OPERATOR_SET_SCHEMA(
                 "output",
                 "output tensor with shape (token_count, v_hidden_size)",
                 "T")
-        .TypeConstraint("T", {"tensor(float)", "tensor(float16)"}, "Constrain input and output to float tensors.")
+        .TypeConstraint("T", {"tensor(float)", "tensor(float16)", "tensor(bfloat16)"}, "Constrain input and output to float tensors.")
         .TypeConstraint("M", {"tensor(int32)"}, "Constrain mask, offset and sequence length to integer types")
         .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
           PackedMultiHeadAttentionTypeAndShapeInference(ctx);

--- a/onnxruntime/test/contrib_ops/packed_attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/packed_attention_op_test.cc
@@ -501,6 +501,66 @@ TEST(PackedAttentionTest, TestWithRandomDataWithRBP) {
   }
 }
 
+// CUDA only for BFloat16 type.
+#if defined(USE_CUDA)
+TEST(PackedAttentionTest, NoPack_BFloat16) {
+  int min_cuda_architecture = 800;
+  if (!HasCudaEnvironment(min_cuda_architecture)) {
+    LOGS_DEFAULT(WARNING) << "Hardware NOT support BF16";
+    return;
+  }
+
+  int batch_size = 1;
+  int sequence_length = 2;
+  int hidden_size = 4;
+  int number_of_heads = 2;
+
+  std::vector<float> input_data = {
+      0.8f, -0.5f, 0.0f, 1.f,
+      0.5f, 0.2f, 0.3f, -0.6f};
+
+  std::vector<float> weight_data = {
+      0.1f, -0.2f, 0.3f, 1.0f, 1.1f, 0.3f, 0.5f, 0.2f, 0.3f, -0.6f, 1.5f, 2.0f,
+      0.5f, 0.1f, 0.4f, 1.6f, 1.0f, 2.0f, 0.4f, 0.8f, 0.9f, 0.1f, -1.3f, 0.7f,
+      0.3f, 0.2f, 4.0f, 2.2f, 1.6f, 1.1f, 0.7f, 0.2f, 0.4f, 1.0f, 1.2f, 0.5f,
+      0.2f, 0.1f, 0.4f, 1.6f, 2.4f, 3.3f, 2.1f, 4.2f, 8.4f, 0.0f, 2.1f, 3.2f};
+
+  std::vector<float> bias_data = {
+      -0.5f, 0.6f, 1.2f, 2.1f, 0.5f, 0.7f, 0.2f, 1.2f, 0.5f, 0.4f, 0.3f, 1.2f};
+
+  std::vector<int32_t> token_offset{0, 1};
+  std::vector<int32_t> cum_seq_len{0, 2};
+
+  std::vector<float> output_data = {
+      3.1495983600616455f, 0.10843668878078461f, 4.25f, 5.6499996185302734f,
+      3.9696791172027588f, 0.073143675923347473f, 4.2499995231628418f, 5.6499991416931152f};
+
+  int token_count = batch_size * sequence_length;
+
+  OpTester tester("PackedAttention", 1, onnxruntime::kMSDomain);
+  tester.AddAttribute<int64_t>("num_heads", static_cast<int64_t>(number_of_heads));
+
+  std::vector<int64_t> input_dims = {token_count, hidden_size};
+  std::vector<int64_t> weights_dims = {hidden_size, 3 * hidden_size};
+  std::vector<int64_t> bias_dims = {3 * hidden_size};
+  std::vector<int64_t> token_offset_dims = {batch_size, sequence_length};
+  std::vector<int64_t> cum_seq_len_dims = {batch_size + 1};
+  std::vector<int64_t> output_dims = {token_count, hidden_size};
+
+  tester.AddInput<BFloat16>("input", input_dims, FloatsToBFloat16s(input_data));
+  tester.AddInput<BFloat16>("weight", weights_dims, FloatsToBFloat16s(weight_data));
+  tester.AddInput<BFloat16>("bias", bias_dims, FloatsToBFloat16s(bias_data));
+  tester.AddInput<int32_t>("token_offset", token_offset_dims, token_offset);
+  tester.AddInput<int32_t>("cumulative_sequence_length", cum_seq_len_dims, cum_seq_len);
+  tester.AddOutput<BFloat16>("output", output_dims, FloatsToBFloat16s(output_data));
+  tester.SetOutputTolerance(0.02f);
+
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(DefaultCudaExecutionProvider());
+  tester.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+}
+#endif
+
 TEST(PackedAttentionTest, TestWithRandomDataLargeSeq) {
   int batch_size = 2;
   int sequence_length = 1152;  // > 1024

--- a/onnxruntime/test/contrib_ops/packed_multihead_attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/packed_multihead_attention_op_test.cc
@@ -524,5 +524,53 @@ TEST(PackedMultiHeadAttentionTest, PackedQKV_Padding_NoBias_BroadcastAttnBias_un
       data.broadcast_attention_bias);
 }
 
+// CUDA only for BFloat16 type. Runs through the unfused (cuBLAS GEMM + softmax) path only,
+// since the TRT fused runner is fp16-hardware-specific and never selected for bf16 inputs.
+#if defined(USE_CUDA)
+TEST(PackedMultiHeadAttentionTest, PackedQKV_NoPadding_NoBias_BFloat16_unfused) {
+  int min_cuda_architecture = 800;
+  if (!HasCudaEnvironment(min_cuda_architecture)) {
+    LOGS_DEFAULT(WARNING) << "Hardware NOT support BF16";
+    return;
+  }
+
+  AttentionTestData data;
+  GetSelfAttentionData_Batch2_HeadSize32_NoBias_NoMask_PackedQKV(data);
+  std::vector<int32_t> token_offset{0, 1, 2, 3};
+  std::vector<int32_t> cum_seq_len{0, 2, 4};
+  int token_count = data.batch_size * data.sequence_length;
+  int64_t head_size = static_cast<int64_t>(data.hidden_size / data.num_heads);
+
+  ScopedEnvironmentVariables scoped_env_vars{
+      EnvVarMap{
+          {onnxruntime::contrib::attention::kDisableFlashAttention, "1"},
+          {onnxruntime::contrib::attention::kDisableTrtFlashAttention, "1"},
+          {onnxruntime::contrib::attention::kDisableFusedSelfAttention, "1"},
+          {onnxruntime::contrib::attention::kDisableFusedCrossAttention, "1"},
+          {onnxruntime::contrib::attention::kDisableMemoryEfficientAttention, "1"}}};
+
+  OpTester tester("PackedMultiHeadAttention", 1, onnxruntime::kMSDomain);
+  tester.AddAttribute<int64_t>("num_heads", static_cast<int64_t>(data.num_heads));
+
+  std::vector<int64_t> packed_qkv_dims = {token_count, data.num_heads, 3, head_size};
+  std::vector<int64_t> token_offset_dims = {data.batch_size, data.sequence_length};
+  std::vector<int64_t> cum_seq_len_dims = {data.batch_size + 1};
+  std::vector<int64_t> output_dims = {token_count, data.v_hidden_size};
+
+  tester.AddInput<BFloat16>("query", packed_qkv_dims, FloatsToBFloat16s(data.qkv_data));
+  tester.AddOptionalInputEdge<BFloat16>();
+  tester.AddOptionalInputEdge<BFloat16>();
+  tester.AddOptionalInputEdge<BFloat16>();  // bias
+  tester.AddInput<int32_t>("token_offset", token_offset_dims, token_offset);
+  tester.AddInput<int32_t>("cumulative_sequence_length", cum_seq_len_dims, cum_seq_len);
+  tester.AddOutput<BFloat16>("output", output_dims, FloatsToBFloat16s(data.fp16_output_data));
+  tester.SetOutputTolerance(0.02f);
+
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(DefaultCudaExecutionProvider());
+  tester.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+}
+#endif
+
 }  // namespace test
 }  // namespace onnxruntime


### PR DESCRIPTION
## Purpose

#28768. Add BFloat16 support to PackedAttention, PackedMultiHeadAttention, ShardedMoE (CUDA EP)
- Extend schema `TypeConstraint` to accept bf16 on all three ops
- Fix TRT fused-attention runner type guard misidentifying bf16 sessions as fp16-fusable
- Add missing bf16 template instantiations: `QkvToContext`, `ComputeSoftmaxWithCumSeqLength`, `LaunchTransposeRemovePadding`

## Test Plan

```bash
# CUDA (RTX 5090, CUDA 13.0)
./onnxruntime_provider_test --gtest_filter='PackedAttentionTest.*'
./onnxruntime_provider_test --gtest_filter='PackedMultiHeadAttentionTest.*'
./onnxruntime_provider_test --gtest_filter='*Moe*:*MoE*'
```
