### PR TITLE
Add OrtEp-level conformance checks for plugin EPs

### DIFF
--- a/onnxruntime/test/framework/execution_provider_conformance_test.cc
+++ b/onnxruntime/test/framework/execution_provider_conformance_test.cc
@@ -65,7 +65,12 @@ std::vector<EpConformanceParam> GetEpConformanceParams() {
 #ifdef USE_DML
   params.push_back({"Dml", [] { return DefaultDmlExecutionProvider(); }});
 #endif
-#ifdef USE_WEBGPU
+  // Mirror the guard used by base_tester.cc / default_providers.cc: in
+  // ORT_USE_EP_API_ADAPTERS builds DefaultWebGpuExecutionProvider() ORT_ENFORCEs
+  // (aborting the whole test run) when the dynamic plugin EP is initialized to a
+  // different EP, rather than cleanly returning nullptr. Only list the built-in
+  // WebGPU EP when it is not routed through the EP API adapters.
+#if defined(USE_WEBGPU) && !defined(ORT_USE_EP_API_ADAPTERS)
   params.push_back({"WebGpu", [] { return DefaultWebGpuExecutionProvider(); }});
 #endif
 #ifdef USE_XNNPACK

--- a/onnxruntime/test/framework/execution_provider_conformance_test.cc
+++ b/onnxruntime/test/framework/execution_provider_conformance_test.cc
@@ -48,6 +48,7 @@ namespace {
 struct EpConformanceParam {
   std::string name;
   std::function<std::unique_ptr<IExecutionProvider>()> factory;
+  bool expects_plugin_ep = false;
 };
 
 std::vector<EpConformanceParam> GetEpConformanceParams() {
@@ -60,7 +61,11 @@ std::vector<EpConformanceParam> GetEpConformanceParams() {
   params.push_back({"Cpu_NoArena", [] { return DefaultCpuExecutionProvider(/*enable_arena*/ false); }});
 
 #ifdef USE_CUDA
+#if defined(ORT_UNIT_TEST_HAS_CUDA_PLUGIN_EP) && defined(ORT_UNIT_TEST_ENABLE_DYNAMIC_PLUGIN_EP_USAGE)
+  params.push_back({"Cuda", [] { return DefaultCudaExecutionProvider(); }, true});
+#else
   params.push_back({"Cuda", [] { return DefaultCudaExecutionProvider(); }});
+#endif
 #endif
 #ifdef USE_DML
   params.push_back({"Dml", [] { return DefaultDmlExecutionProvider(); }});
@@ -270,15 +275,20 @@ TEST_P(EpConformanceTest, GraphCaptureNodeAssignmentPolicyIsValid) {
       << "GetGraphCaptureNodeAssignmentPolicy() returned an unknown policy value.";
 }
 
-// Invariant: a built-in EP is not a plugin wrapper, so GetOrtEp() returns nullptr.
-// Only a PluginExecutionProvider wrapping an OrtEp reports a backing OrtEp, and
-// every EP exercised by this suite is built-in.
-TEST_P(EpConformanceTest, GetOrtEpIsNullForBuiltInEp) {
+// Invariant: a built-in EP returns no backing OrtEp. A PluginExecutionProvider
+// returns the same non-null backing OrtEp across repeated queries.
+TEST_P(EpConformanceTest, GetOrtEpMatchesProviderKind) {
   auto ep = MakeEp();
   if (!ep) GTEST_SKIP() << GetParam().name << " EP not available in this environment.";
 
-  EXPECT_EQ(ep->GetOrtEp(), nullptr)
-      << "A built-in EP must not report a backing OrtEp (that is reserved for plugin EPs).";
+  const OrtEp* ort_ep = ep->GetOrtEp();
+  if (GetParam().expects_plugin_ep) {
+    ASSERT_NE(ort_ep, nullptr) << "A plugin EP must report its backing OrtEp.";
+    EXPECT_EQ(ep->GetOrtEp(), ort_ep) << "A plugin EP must report a stable backing OrtEp.";
+  } else {
+    EXPECT_EQ(ort_ep, nullptr)
+        << "A built-in EP must not report a backing OrtEp (that is reserved for plugin EPs).";
+  }
 }
 
 // Invariant: GetEpContextNodes() reports no nodes on a freshly constructed EP.

--- a/onnxruntime/test/framework/execution_provider_conformance_test.cc
+++ b/onnxruntime/test/framework/execution_provider_conformance_test.cc
@@ -140,9 +140,11 @@ TEST_P(EpConformanceTest, PreferredAllocatorsAreNonNullAndRepeatable) {
       << "CreatePreferredAllocators() must be repeatable (documented as stateless).";
 }
 
-// Invariant: each preferred allocator hands back usable memory. A non-zero
-// allocation yields a non-null pointer that can be freed. For CPU-accessible
-// memory we additionally verify the buffer is host-writable and readable.
+// Invariant: each CPU-accessible preferred allocator hands back usable memory:
+// a non-zero allocation yields a non-null, host-writable and -readable pointer
+// that can be freed. Device allocators are intentionally excluded here -- their
+// raw Alloc/Free lifecycle is backend-specific (see body) -- and are covered by
+// PreferredAllocatorsAreNonNullAndRepeatable instead.
 TEST_P(EpConformanceTest, PreferredAllocatorsAllocateUsableMemory) {
   auto ep = MakeEp();
   if (!ep) GTEST_SKIP() << GetParam().name << " EP not available in this environment.";
@@ -153,21 +155,36 @@ TEST_P(EpConformanceTest, PreferredAllocatorsAllocateUsableMemory) {
   }
 
   constexpr size_t kBytes = 256;
+  size_t exercised = 0;
   for (const auto& alloc : allocators) {
     ASSERT_NE(alloc, nullptr);
+
+    // Standalone Alloc()/Free() is only a backend-agnostic contract for
+    // CPU-accessible allocators. A device allocator may hand out memory with a
+    // backend-specific lifecycle that this test cannot drive: e.g. the WebGPU
+    // GpuBufferAllocator creates buffers mapped at creation that must be
+    // unmapped through the buffer manager before Free(), so Free()-ing a
+    // freshly allocated buffer throws. Skip such allocators; they are covered
+    // by PreferredAllocatorsAreNonNullAndRepeatable.
+    if (!alloc->Info().device.UsesCpuMemory()) {
+      continue;
+    }
 
     void* p = alloc->Alloc(kBytes);
     ASSERT_NE(p, nullptr) << "Alloc(" << kBytes << ") returned null for allocator on "
                           << alloc->Info().device.ToString();
 
-    // Only host-accessible memory may be touched from the test (CPU) thread.
-    if (alloc->Info().device.UsesCpuMemory()) {
-      std::memset(p, 0xAB, kBytes);
-      const auto* bytes = static_cast<const unsigned char*>(p);
-      EXPECT_EQ(bytes[0], 0xAB);
-      EXPECT_EQ(bytes[kBytes - 1], 0xAB);
-    }
+    std::memset(p, 0xAB, kBytes);
+    const auto* bytes = static_cast<const unsigned char*>(p);
+    EXPECT_EQ(bytes[0], 0xAB);
+    EXPECT_EQ(bytes[kBytes - 1], 0xAB);
     alloc->Free(p);
+    ++exercised;
+  }
+
+  if (exercised == 0) {
+    GTEST_SKIP() << GetParam().name
+                 << " EP exposes no CPU-accessible preferred allocator to exercise.";
   }
 }
 

--- a/onnxruntime/test/framework/execution_provider_conformance_test.cc
+++ b/onnxruntime/test/framework/execution_provider_conformance_test.cc
@@ -1,0 +1,239 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Execution Provider conformance test suite.
+//
+// These parameterized tests encode invariants that EVERY IExecutionProvider
+// implementation is expected to satisfy, independent of the specific hardware
+// backend. They turn the previously-implicit Liskov-substitutability
+// assumptions of the IExecutionProvider contract into enforced, executable
+// checks, so that a new (or modified) EP cannot silently violate the behavior
+// the framework relies on.
+//
+// Adding an EP to the coverage is a single line: append an entry to
+// GetEpConformanceParams() below, guarded by the appropriate USE_* macro. The
+// stored value is a *factory*, not a constructed provider, so:
+//   - No EP is instantiated during static initialization.
+//   - A factory that returns nullptr (EP compiled but unavailable at runtime,
+//     e.g. no GPU present) causes the affected test to be skipped, not failed.
+//
+// Only documented, backend-agnostic contracts are asserted here. Memory that is
+// not CPU-accessible is never dereferenced from the test thread; such checks are
+// guarded by OrtDevice::UsesCpuMemory().
+
+#include <cstring>
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "core/framework/allocator.h"
+#include "core/framework/data_transfer.h"
+#include "core/framework/data_types.h"
+#include "core/framework/execution_provider.h"
+#include "core/framework/tensor.h"
+
+#include "test/util/include/default_providers.h"
+
+namespace onnxruntime {
+namespace test {
+
+namespace {
+
+// One EP under test: a human-readable name (also used as the gtest parameter
+// suffix, so it must be a valid identifier) plus a factory that constructs a
+// fresh provider instance.
+struct EpConformanceParam {
+  std::string name;
+  std::function<std::unique_ptr<IExecutionProvider>()> factory;
+};
+
+std::vector<EpConformanceParam> GetEpConformanceParams() {
+  std::vector<EpConformanceParam> params;
+
+  // CPU is always available. Cover both the arena and non-arena allocator paths
+  // since they are distinct IAllocator implementations with different Alloc/Free
+  // behavior.
+  params.push_back({"Cpu_Arena", [] { return DefaultCpuExecutionProvider(/*enable_arena*/ true); }});
+  params.push_back({"Cpu_NoArena", [] { return DefaultCpuExecutionProvider(/*enable_arena*/ false); }});
+
+#ifdef USE_CUDA
+  params.push_back({"Cuda", [] { return DefaultCudaExecutionProvider(); }});
+#endif
+#ifdef USE_DML
+  params.push_back({"Dml", [] { return DefaultDmlExecutionProvider(); }});
+#endif
+#ifdef USE_WEBGPU
+  params.push_back({"WebGpu", [] { return DefaultWebGpuExecutionProvider(); }});
+#endif
+#ifdef USE_XNNPACK
+  params.push_back({"Xnnpack", [] { return DefaultXnnpackExecutionProvider(); }});
+#endif
+
+  return params;
+}
+
+}  // namespace
+
+class EpConformanceTest : public testing::TestWithParam<EpConformanceParam> {
+ protected:
+  // Construct the EP under test. Returns nullptr when the EP is compiled but not
+  // available in the current environment; callers should GTEST_SKIP() in that case.
+  std::unique_ptr<IExecutionProvider> MakeEp() const { return GetParam().factory(); }
+};
+
+// Invariant: Type() is non-empty and stable -- both across repeated calls on a
+// single instance and across independent instances from the same factory. The
+// framework keys kernel registries and node assignment on this string.
+TEST_P(EpConformanceTest, TypeIsNonEmptyAndStable) {
+  auto ep = MakeEp();
+  if (!ep) GTEST_SKIP() << GetParam().name << " EP not available in this environment.";
+
+  const std::string type = ep->Type();
+  EXPECT_FALSE(type.empty()) << "IExecutionProvider::Type() must not be empty.";
+  EXPECT_EQ(type, ep->Type()) << "Type() must be stable across calls on the same instance.";
+
+  auto ep2 = MakeEp();
+  ASSERT_NE(ep2, nullptr);
+  EXPECT_EQ(type, ep2->Type()) << "Type() must be identical for instances from the same factory.";
+}
+
+// Invariant: GetPreferredLayout() returns one of the defined DataLayout values.
+// Layout transformation dispatches on this, so an out-of-range value is a bug.
+TEST_P(EpConformanceTest, PreferredLayoutIsValid) {
+  auto ep = MakeEp();
+  if (!ep) GTEST_SKIP() << GetParam().name << " EP not available in this environment.";
+
+  const DataLayout layout = ep->GetPreferredLayout();
+  EXPECT_TRUE(layout == DataLayout::NCHW || layout == DataLayout::NHWC)
+      << "GetPreferredLayout() returned an unknown DataLayout value.";
+}
+
+// Invariant: the CPU mem types always map to CPU-accessible memory. The
+// framework's input/output staging copies depend on this for every EP.
+TEST_P(EpConformanceTest, CpuMemTypesMapToCpuAccessibleDevice) {
+  auto ep = MakeEp();
+  if (!ep) GTEST_SKIP() << GetParam().name << " EP not available in this environment.";
+
+  EXPECT_TRUE(ep->GetOrtDeviceByMemType(OrtMemTypeCPUInput).UsesCpuMemory())
+      << "OrtMemTypeCPUInput must map to CPU-accessible memory.";
+  EXPECT_TRUE(ep->GetOrtDeviceByMemType(OrtMemTypeCPUOutput).UsesCpuMemory())
+      << "OrtMemTypeCPUOutput must map to CPU-accessible memory.";
+}
+
+// Invariant: CreatePreferredAllocators() never yields a null allocator and is
+// repeatable. The header documents it as a stateless factory, so a second call
+// must produce an equivalently-sized set.
+TEST_P(EpConformanceTest, PreferredAllocatorsAreNonNullAndRepeatable) {
+  auto ep = MakeEp();
+  if (!ep) GTEST_SKIP() << GetParam().name << " EP not available in this environment.";
+
+  auto allocators = ep->CreatePreferredAllocators();
+  for (const auto& alloc : allocators) {
+    EXPECT_NE(alloc, nullptr) << "CreatePreferredAllocators() must not return null entries.";
+  }
+
+  auto allocators2 = ep->CreatePreferredAllocators();
+  EXPECT_EQ(allocators.size(), allocators2.size())
+      << "CreatePreferredAllocators() must be repeatable (documented as stateless).";
+}
+
+// Invariant: each preferred allocator hands back usable memory. A non-zero
+// allocation yields a non-null pointer that can be freed. For CPU-accessible
+// memory we additionally verify the buffer is host-writable and readable.
+TEST_P(EpConformanceTest, PreferredAllocatorsAllocateUsableMemory) {
+  auto ep = MakeEp();
+  if (!ep) GTEST_SKIP() << GetParam().name << " EP not available in this environment.";
+
+  auto allocators = ep->CreatePreferredAllocators();
+  if (allocators.empty()) {
+    GTEST_SKIP() << GetParam().name << " EP exposes no preferred allocators.";
+  }
+
+  constexpr size_t kBytes = 256;
+  for (const auto& alloc : allocators) {
+    ASSERT_NE(alloc, nullptr);
+
+    void* p = alloc->Alloc(kBytes);
+    ASSERT_NE(p, nullptr) << "Alloc(" << kBytes << ") returned null for allocator on "
+                          << alloc->Info().device.ToString();
+
+    // Only host-accessible memory may be touched from the test (CPU) thread.
+    if (alloc->Info().device.UsesCpuMemory()) {
+      std::memset(p, 0xAB, kBytes);
+      const auto* bytes = static_cast<const unsigned char*>(p);
+      EXPECT_EQ(bytes[0], 0xAB);
+      EXPECT_EQ(bytes[kBytes - 1], 0xAB);
+    }
+    alloc->Free(p);
+  }
+}
+
+// Invariant: GetDataTransfer() is optional (may be null). When provided, and it
+// advertises the ability to copy within a CPU-accessible device, a CopyTensor
+// round-trip must preserve the data exactly.
+TEST_P(EpConformanceTest, DataTransferCpuRoundTripPreservesData) {
+  auto ep = MakeEp();
+  if (!ep) GTEST_SKIP() << GetParam().name << " EP not available in this environment.";
+
+  auto data_transfer = ep->GetDataTransfer();
+  if (!data_transfer) {
+    GTEST_SKIP() << GetParam().name << " EP provides no IDataTransfer (allowed by the contract).";
+  }
+
+  // Host the tensors on a CPU-accessible preferred allocator.
+  AllocatorPtr cpu_alloc;
+  for (auto& alloc : ep->CreatePreferredAllocators()) {
+    if (alloc && alloc->Info().device.UsesCpuMemory()) {
+      cpu_alloc = alloc;
+      break;
+    }
+  }
+  if (!cpu_alloc) {
+    GTEST_SKIP() << GetParam().name << " EP has no CPU-accessible allocator to drive the round-trip.";
+  }
+
+  const OrtDevice& cpu_device = cpu_alloc->Info().device;
+  if (!data_transfer->CanCopy(cpu_device, cpu_device)) {
+    GTEST_SKIP() << GetParam().name << " EP data transfer does not advertise CPU<->CPU copy.";
+  }
+
+  const TensorShape shape({2, 3});
+  Tensor src(DataTypeImpl::GetType<float>(), shape, cpu_alloc);
+  Tensor dst(DataTypeImpl::GetType<float>(), shape, cpu_alloc);
+
+  const float values[] = {1.f, -2.f, 3.5f, 4.f, 5.f, -6.25f};
+  constexpr size_t kNumValues = sizeof(values) / sizeof(values[0]);
+  ASSERT_EQ(static_cast<size_t>(shape.Size()), kNumValues);
+  std::memcpy(src.MutableDataRaw(), values, sizeof(values));
+  std::memset(dst.MutableDataRaw(), 0, sizeof(values));
+
+  ASSERT_TRUE(data_transfer->CopyTensor(src, dst).IsOK()) << "CopyTensor failed for a CPU<->CPU copy.";
+  EXPECT_EQ(std::memcmp(src.DataRaw(), dst.DataRaw(), sizeof(values)), 0)
+      << "A CPU round-trip CopyTensor must preserve data exactly.";
+}
+
+// Invariant: read-only metadata queries are callable and self-consistent on a
+// freshly constructed EP (no session or logger required), and the device-id
+// accessor agrees with GetDevice().
+TEST_P(EpConformanceTest, MetadataQueriesAreCallable) {
+  auto ep = MakeEp();
+  if (!ep) GTEST_SKIP() << GetParam().name << " EP not available in this environment.";
+
+  EXPECT_EQ(ep->GetDeviceId(), ep->GetDevice().Id())
+      << "GetDeviceId() must agree with GetDevice().Id().";
+
+  // These must simply be callable without crashing on a bare EP instance.
+  (void)ep->ConcurrentRunSupported();
+  (void)ep->GetTuningContext();
+  (void)ep->GetOrtDeviceByMemType(OrtMemTypeDefault);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    EpContract, EpConformanceTest, testing::ValuesIn(GetEpConformanceParams()),
+    [](const testing::TestParamInfo<EpConformanceParam>& info) { return info.param.name; });
+
+}  // namespace test
+}  // namespace onnxruntime

--- a/onnxruntime/test/framework/execution_provider_conformance_test.cc
+++ b/onnxruntime/test/framework/execution_provider_conformance_test.cc
@@ -10,6 +10,11 @@
 // checks, so that a new (or modified) EP cannot silently violate the behavior
 // the framework relies on.
 //
+// The invariant checks themselves live in
+// test/util/include/ep_conformance_invariants.h and are shared with the plugin EP
+// suite (test/providers/ep_conformance_plugin_test.cc), which runs the same
+// invariants against a dynamically-loaded plugin EP.
+//
 // Adding an EP to the coverage is a single line: append an entry to
 // GetEpConformanceParams() below, guarded by the appropriate USE_* macro. The
 // stored value is a *factory*, not a constructed provider, so:
@@ -21,7 +26,6 @@
 // not CPU-accessible is never dereferenced from the test thread; such checks are
 // guarded by OrtDevice::UsesCpuMemory().
 
-#include <cstring>
 #include <functional>
 #include <memory>
 #include <string>
@@ -29,13 +33,10 @@
 
 #include "gtest/gtest.h"
 
-#include "core/framework/allocator.h"
-#include "core/framework/data_transfer.h"
-#include "core/framework/data_types.h"
 #include "core/framework/execution_provider.h"
-#include "core/framework/tensor.h"
 
 #include "test/util/include/default_providers.h"
+#include "test/util/include/ep_conformance_invariants.h"
 
 namespace onnxruntime {
 namespace test {
@@ -101,13 +102,7 @@ TEST_P(EpConformanceTest, TypeIsNonEmptyAndStable) {
   auto ep = MakeEp();
   if (!ep) GTEST_SKIP() << GetParam().name << " EP not available in this environment.";
 
-  const std::string type = ep->Type();
-  EXPECT_FALSE(type.empty()) << "IExecutionProvider::Type() must not be empty.";
-  EXPECT_EQ(type, ep->Type()) << "Type() must be stable across calls on the same instance.";
-
-  auto ep2 = MakeEp();
-  ASSERT_NE(ep2, nullptr);
-  EXPECT_EQ(type, ep2->Type()) << "Type() must be identical for instances from the same factory.";
+  ep_conformance::CheckTypeIsNonEmptyAndStable(*ep, [this] { return MakeEp(); }, GetParam().name);
 }
 
 // Invariant: GetPreferredLayout() returns one of the defined DataLayout values.
@@ -116,9 +111,7 @@ TEST_P(EpConformanceTest, PreferredLayoutIsValid) {
   auto ep = MakeEp();
   if (!ep) GTEST_SKIP() << GetParam().name << " EP not available in this environment.";
 
-  const DataLayout layout = ep->GetPreferredLayout();
-  EXPECT_TRUE(layout == DataLayout::NCHW || layout == DataLayout::NHWC)
-      << "GetPreferredLayout() returned an unknown DataLayout value.";
+  ep_conformance::CheckPreferredLayoutIsValid(*ep, GetParam().name);
 }
 
 // Invariant: the CPU mem types always map to CPU-accessible memory. The
@@ -127,10 +120,7 @@ TEST_P(EpConformanceTest, CpuMemTypesMapToCpuAccessibleDevice) {
   auto ep = MakeEp();
   if (!ep) GTEST_SKIP() << GetParam().name << " EP not available in this environment.";
 
-  EXPECT_TRUE(ep->GetOrtDeviceByMemType(OrtMemTypeCPUInput).UsesCpuMemory())
-      << "OrtMemTypeCPUInput must map to CPU-accessible memory.";
-  EXPECT_TRUE(ep->GetOrtDeviceByMemType(OrtMemTypeCPUOutput).UsesCpuMemory())
-      << "OrtMemTypeCPUOutput must map to CPU-accessible memory.";
+  ep_conformance::CheckCpuMemTypesMapToCpuAccessibleDevice(*ep, GetParam().name);
 }
 
 // Invariant: CreatePreferredAllocators() never yields a null allocator and is
@@ -140,14 +130,7 @@ TEST_P(EpConformanceTest, PreferredAllocatorsAreNonNullAndRepeatable) {
   auto ep = MakeEp();
   if (!ep) GTEST_SKIP() << GetParam().name << " EP not available in this environment.";
 
-  auto allocators = ep->CreatePreferredAllocators();
-  for (const auto& alloc : allocators) {
-    EXPECT_NE(alloc, nullptr) << "CreatePreferredAllocators() must not return null entries.";
-  }
-
-  auto allocators2 = ep->CreatePreferredAllocators();
-  EXPECT_EQ(allocators.size(), allocators2.size())
-      << "CreatePreferredAllocators() must be repeatable (documented as stateless).";
+  ep_conformance::CheckPreferredAllocatorsAreNonNullAndRepeatable(*ep, GetParam().name);
 }
 
 // Invariant: each CPU-accessible preferred allocator hands back usable memory:
@@ -159,43 +142,7 @@ TEST_P(EpConformanceTest, PreferredAllocatorsAllocateUsableMemory) {
   auto ep = MakeEp();
   if (!ep) GTEST_SKIP() << GetParam().name << " EP not available in this environment.";
 
-  auto allocators = ep->CreatePreferredAllocators();
-  if (allocators.empty()) {
-    GTEST_SKIP() << GetParam().name << " EP exposes no preferred allocators.";
-  }
-
-  constexpr size_t kBytes = 256;
-  size_t exercised = 0;
-  for (const auto& alloc : allocators) {
-    ASSERT_NE(alloc, nullptr);
-
-    // Standalone Alloc()/Free() is only a backend-agnostic contract for
-    // CPU-accessible allocators. A device allocator may hand out memory with a
-    // backend-specific lifecycle that this test cannot drive: e.g. the WebGPU
-    // GpuBufferAllocator creates buffers mapped at creation that must be
-    // unmapped through the buffer manager before Free(), so Free()-ing a
-    // freshly allocated buffer throws. Skip such allocators; they are covered
-    // by PreferredAllocatorsAreNonNullAndRepeatable.
-    if (!alloc->Info().device.UsesCpuMemory()) {
-      continue;
-    }
-
-    void* p = alloc->Alloc(kBytes);
-    ASSERT_NE(p, nullptr) << "Alloc(" << kBytes << ") returned null for allocator on "
-                          << alloc->Info().device.ToString();
-
-    std::memset(p, 0xAB, kBytes);
-    const auto* bytes = static_cast<const unsigned char*>(p);
-    EXPECT_EQ(bytes[0], 0xAB);
-    EXPECT_EQ(bytes[kBytes - 1], 0xAB);
-    alloc->Free(p);
-    ++exercised;
-  }
-
-  if (exercised == 0) {
-    GTEST_SKIP() << GetParam().name
-                 << " EP exposes no CPU-accessible preferred allocator to exercise.";
-  }
+  ep_conformance::CheckPreferredAllocatorsAllocateUsableMemory(*ep, GetParam().name);
 }
 
 // Invariant: GetDataTransfer() is optional (may be null). When provided, and it
@@ -205,41 +152,7 @@ TEST_P(EpConformanceTest, DataTransferCpuRoundTripPreservesData) {
   auto ep = MakeEp();
   if (!ep) GTEST_SKIP() << GetParam().name << " EP not available in this environment.";
 
-  auto data_transfer = ep->GetDataTransfer();
-  if (!data_transfer) {
-    GTEST_SKIP() << GetParam().name << " EP provides no IDataTransfer (allowed by the contract).";
-  }
-
-  // Host the tensors on a CPU-accessible preferred allocator.
-  AllocatorPtr cpu_alloc;
-  for (auto& alloc : ep->CreatePreferredAllocators()) {
-    if (alloc && alloc->Info().device.UsesCpuMemory()) {
-      cpu_alloc = alloc;
-      break;
-    }
-  }
-  if (!cpu_alloc) {
-    GTEST_SKIP() << GetParam().name << " EP has no CPU-accessible allocator to drive the round-trip.";
-  }
-
-  const OrtDevice& cpu_device = cpu_alloc->Info().device;
-  if (!data_transfer->CanCopy(cpu_device, cpu_device)) {
-    GTEST_SKIP() << GetParam().name << " EP data transfer does not advertise CPU<->CPU copy.";
-  }
-
-  const TensorShape shape({2, 3});
-  Tensor src(DataTypeImpl::GetType<float>(), shape, cpu_alloc);
-  Tensor dst(DataTypeImpl::GetType<float>(), shape, cpu_alloc);
-
-  const float values[] = {1.f, -2.f, 3.5f, 4.f, 5.f, -6.25f};
-  constexpr size_t kNumValues = sizeof(values) / sizeof(values[0]);
-  ASSERT_EQ(static_cast<size_t>(shape.Size()), kNumValues);
-  std::memcpy(src.MutableDataRaw(), values, sizeof(values));
-  std::memset(dst.MutableDataRaw(), 0, sizeof(values));
-
-  ASSERT_TRUE(data_transfer->CopyTensor(src, dst).IsOK()) << "CopyTensor failed for a CPU<->CPU copy.";
-  EXPECT_EQ(std::memcmp(src.DataRaw(), dst.DataRaw(), sizeof(values)), 0)
-      << "A CPU round-trip CopyTensor must preserve data exactly.";
+  ep_conformance::CheckDataTransferCpuRoundTripPreservesData(*ep, GetParam().name);
 }
 
 // Invariant: read-only metadata queries are callable and self-consistent on a
@@ -249,15 +162,7 @@ TEST_P(EpConformanceTest, MetadataQueriesAreCallable) {
   auto ep = MakeEp();
   if (!ep) GTEST_SKIP() << GetParam().name << " EP not available in this environment.";
 
-  EXPECT_EQ(ep->GetDeviceId(), ep->GetDevice().Id())
-      << "GetDeviceId() must agree with GetDevice().Id().";
-
-  // These must simply be callable without crashing on a bare EP instance.
-  (void)ep->ConcurrentRunSupported();
-  (void)ep->GetTuningContext();
-  (void)ep->GetOrtDeviceByMemType(OrtMemTypeDefault);
-  (void)ep->IsGraphCaptureEnabled();
-  (void)ep->ShouldConvertDataLayoutForOp(/*domain*/ "", /*op_type*/ "Conv", ep->GetPreferredLayout());
+  ep_conformance::CheckMetadataQueriesAreCallable(*ep, GetParam().name);
 }
 
 // Invariant: GetGraphCaptureNodeAssignmentPolicy() returns one of the defined
@@ -269,10 +174,7 @@ TEST_P(EpConformanceTest, GraphCaptureNodeAssignmentPolicyIsValid) {
   auto ep = MakeEp();
   if (!ep) GTEST_SKIP() << GetParam().name << " EP not available in this environment.";
 
-  const OrtGraphCaptureNodeAssignmentPolicy policy = ep->GetGraphCaptureNodeAssignmentPolicy();
-  EXPECT_TRUE(policy == OrtGraphCaptureNodeAssignmentPolicy_ALL_NODES_ON_EP ||
-              policy == OrtGraphCaptureNodeAssignmentPolicy_ALLOW_CPU_FOR_SHAPES)
-      << "GetGraphCaptureNodeAssignmentPolicy() returned an unknown policy value.";
+  ep_conformance::CheckGraphCaptureNodeAssignmentPolicyIsValid(*ep, GetParam().name);
 }
 
 // Invariant: a built-in EP returns no backing OrtEp. A PluginExecutionProvider
@@ -281,14 +183,7 @@ TEST_P(EpConformanceTest, GetOrtEpMatchesProviderKind) {
   auto ep = MakeEp();
   if (!ep) GTEST_SKIP() << GetParam().name << " EP not available in this environment.";
 
-  const OrtEp* ort_ep = ep->GetOrtEp();
-  if (GetParam().expects_plugin_ep) {
-    ASSERT_NE(ort_ep, nullptr) << "A plugin EP must report its backing OrtEp.";
-    EXPECT_EQ(ep->GetOrtEp(), ort_ep) << "A plugin EP must report a stable backing OrtEp.";
-  } else {
-    EXPECT_EQ(ort_ep, nullptr)
-        << "A built-in EP must not report a backing OrtEp (that is reserved for plugin EPs).";
-  }
+  ep_conformance::CheckGetOrtEpMatchesProviderKind(*ep, GetParam().expects_plugin_ep, GetParam().name);
 }
 
 // Invariant: GetEpContextNodes() reports no nodes on a freshly constructed EP.
@@ -298,8 +193,7 @@ TEST_P(EpConformanceTest, EpContextNodesEmptyOnFreshEp) {
   auto ep = MakeEp();
   if (!ep) GTEST_SKIP() << GetParam().name << " EP not available in this environment.";
 
-  EXPECT_TRUE(ep->GetEpContextNodes().empty())
-      << "A fresh EP (no compilation performed) must report no EPContext nodes.";
+  ep_conformance::CheckEpContextNodesEmptyOnFreshEp(*ep, GetParam().name);
 }
 
 // Invariant: every preferred allocator reports self-consistent OrtMemoryInfo --
@@ -310,13 +204,7 @@ TEST_P(EpConformanceTest, PreferredAllocatorInfoIsConsistent) {
   auto ep = MakeEp();
   if (!ep) GTEST_SKIP() << GetParam().name << " EP not available in this environment.";
 
-  for (const auto& alloc : ep->CreatePreferredAllocators()) {
-    ASSERT_NE(alloc, nullptr) << "CreatePreferredAllocators() must not return null entries.";
-    const OrtMemoryInfo& info = alloc->Info();
-    EXPECT_FALSE(info.name.empty()) << "Allocator OrtMemoryInfo.name must not be empty.";
-    EXPECT_NE(info.alloc_type, OrtInvalidAllocator)
-        << "Allocator must report a valid OrtAllocatorType (not OrtInvalidAllocator).";
-  }
+  ep_conformance::CheckPreferredAllocatorInfoIsConsistent(*ep, GetParam().name);
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/onnxruntime/test/framework/execution_provider_conformance_test.cc
+++ b/onnxruntime/test/framework/execution_provider_conformance_test.cc
@@ -251,6 +251,62 @@ TEST_P(EpConformanceTest, MetadataQueriesAreCallable) {
   (void)ep->ConcurrentRunSupported();
   (void)ep->GetTuningContext();
   (void)ep->GetOrtDeviceByMemType(OrtMemTypeDefault);
+  (void)ep->IsGraphCaptureEnabled();
+  (void)ep->ShouldConvertDataLayoutForOp(/*domain*/ "", /*op_type*/ "Conv", ep->GetPreferredLayout());
+}
+
+// Invariant: GetGraphCaptureNodeAssignmentPolicy() returns one of the defined
+// OrtGraphCaptureNodeAssignmentPolicy values. The session dispatches on this
+// while validating a graph for capture, so an out-of-range value is a bug.
+// This is a pure query and is valid to call on every EP regardless of whether
+// graph capture is enabled.
+TEST_P(EpConformanceTest, GraphCaptureNodeAssignmentPolicyIsValid) {
+  auto ep = MakeEp();
+  if (!ep) GTEST_SKIP() << GetParam().name << " EP not available in this environment.";
+
+  const OrtGraphCaptureNodeAssignmentPolicy policy = ep->GetGraphCaptureNodeAssignmentPolicy();
+  EXPECT_TRUE(policy == OrtGraphCaptureNodeAssignmentPolicy_ALL_NODES_ON_EP ||
+              policy == OrtGraphCaptureNodeAssignmentPolicy_ALLOW_CPU_FOR_SHAPES)
+      << "GetGraphCaptureNodeAssignmentPolicy() returned an unknown policy value.";
+}
+
+// Invariant: a built-in EP is not a plugin wrapper, so GetOrtEp() returns nullptr.
+// Only a PluginExecutionProvider wrapping an OrtEp reports a backing OrtEp, and
+// every EP exercised by this suite is built-in.
+TEST_P(EpConformanceTest, GetOrtEpIsNullForBuiltInEp) {
+  auto ep = MakeEp();
+  if (!ep) GTEST_SKIP() << GetParam().name << " EP not available in this environment.";
+
+  EXPECT_EQ(ep->GetOrtEp(), nullptr)
+      << "A built-in EP must not report a backing OrtEp (that is reserved for plugin EPs).";
+}
+
+// Invariant: GetEpContextNodes() reports no nodes on a freshly constructed EP.
+// EPs populate this only when generating an EPContext cache model during
+// compilation; with no compilation performed, the documented default is empty.
+TEST_P(EpConformanceTest, EpContextNodesEmptyOnFreshEp) {
+  auto ep = MakeEp();
+  if (!ep) GTEST_SKIP() << GetParam().name << " EP not available in this environment.";
+
+  EXPECT_TRUE(ep->GetEpContextNodes().empty())
+      << "A fresh EP (no compilation performed) must report no EPContext nodes.";
+}
+
+// Invariant: every preferred allocator reports self-consistent OrtMemoryInfo --
+// a non-empty name and a valid allocator type. This metadata keys allocator
+// lookup in the framework, so it must be well-formed for every EP. Only the
+// backend-agnostic fields are checked; the raw memory is not touched here.
+TEST_P(EpConformanceTest, PreferredAllocatorInfoIsConsistent) {
+  auto ep = MakeEp();
+  if (!ep) GTEST_SKIP() << GetParam().name << " EP not available in this environment.";
+
+  for (const auto& alloc : ep->CreatePreferredAllocators()) {
+    ASSERT_NE(alloc, nullptr) << "CreatePreferredAllocators() must not return null entries.";
+    const OrtMemoryInfo& info = alloc->Info();
+    EXPECT_FALSE(info.name.empty()) << "Allocator OrtMemoryInfo.name must not be empty.";
+    EXPECT_NE(info.alloc_type, OrtInvalidAllocator)
+        << "Allocator must report a valid OrtAllocatorType (not OrtInvalidAllocator).";
+  }
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/onnxruntime/test/framework/execution_provider_conformance_test.cc
+++ b/onnxruntime/test/framework/execution_provider_conformance_test.cc
@@ -10,10 +10,11 @@
 // checks, so that a covered EP cannot silently violate the behavior the
 // framework relies on.
 //
-// Coverage is opt-in per EP: only the providers registered in
-// GetEpConformanceParams() are exercised (currently CPU, plus CUDA, DML, WebGPU
-// and XNNPACK behind their build guards). Listing a provider there extends the
-// guarantee to it; EPs not listed are not checked by this suite.
+// Coverage is enforced, not opt-in: EpConformanceCoverage.EveryAvailableEpIsRegistered
+// cross-checks the registered list below against GetAvailableExecutionProviderNames(),
+// the registry of EPs compiled into this build. An EP that is compiled but neither
+// registered nor explicitly exempted fails that test, so coverage cannot silently
+// regress as EPs are added.
 //
 // The invariant checks themselves live in
 // test/util/include/ep_conformance_invariants.h and are shared with the plugin EP
@@ -21,8 +22,10 @@
 // invariants against a dynamically-loaded plugin EP.
 //
 // Adding an EP to the coverage is a single line: append an entry to
-// GetEpConformanceParams() below, guarded by the appropriate USE_* macro. The
-// stored value is a *factory*, not a constructed provider, so:
+// GetEpConformanceParams() below. No USE_* guard is required -- every
+// Default*ExecutionProvider() is declared unconditionally and returns nullptr when
+// its EP is not compiled in. The stored value is a *factory*, not a constructed
+// provider, so:
 //   - No EP is instantiated during static initialization.
 //   - An EP that is compiled but unavailable at runtime (e.g. no GPU present)
 //     causes the affected test to be skipped, not failed -- whether its factory
@@ -33,15 +36,19 @@
 // not CPU-accessible is never dereferenced from the test thread; such checks are
 // guarded by OrtDevice::UsesCpuMemory().
 
+#include <algorithm>
 #include <exception>
 #include <functional>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "gtest/gtest.h"
 
 #include "core/framework/execution_provider.h"
+#include "core/graph/constants.h"
+#include "core/providers/get_execution_providers.h"
 
 #include "test/util/include/default_providers.h"
 #include "test/util/include/ep_conformance_invariants.h"
@@ -53,13 +60,17 @@ namespace {
 
 // One EP under test:
 //   - name: a human-readable label, also used as the gtest parameter suffix, so it
-//     must be a valid identifier.
+//     must be a valid identifier. Several entries may share an ep_name when one EP is
+//     covered in more than one configuration (e.g. CPU with and without the arena).
+//   - ep_name: the canonical provider name (kXxxExecutionProvider), used to
+//     cross-check this list against the EPs compiled into the build.
 //   - factory: constructs a fresh provider instance (see MakeEp()).
 //   - expects_plugin_ep: true iff this EP is plugin-backed, i.e. GetOrtEp() must
 //     return non-null (see CheckGetOrtEpMatchesProviderKind). Built-in EPs leave it
 //     false.
 struct EpConformanceParam {
   std::string name;
+  std::string_view ep_name;
   std::function<std::unique_ptr<IExecutionProvider>()> factory;
   bool expects_plugin_ep = false;
 };
@@ -70,35 +81,130 @@ std::vector<EpConformanceParam> GetEpConformanceParams() {
   // CPU is always available. Cover both the arena and non-arena allocator paths
   // since they are distinct IAllocator implementations with different Alloc/Free
   // behavior.
-  params.push_back({"Cpu_Arena", [] { return DefaultCpuExecutionProvider(/*enable_arena*/ true); }});
-  params.push_back({"Cpu_NoArena", [] { return DefaultCpuExecutionProvider(/*enable_arena*/ false); }});
+  params.push_back({"Cpu_Arena", kCpuExecutionProvider,
+                    [] { return DefaultCpuExecutionProvider(/*enable_arena*/ true); }});
+  params.push_back({"Cpu_NoArena", kCpuExecutionProvider,
+                    [] { return DefaultCpuExecutionProvider(/*enable_arena*/ false); }});
 
-#ifdef USE_CUDA
 #if defined(ORT_UNIT_TEST_HAS_CUDA_PLUGIN_EP) && defined(ORT_UNIT_TEST_ENABLE_DYNAMIC_PLUGIN_EP_USAGE)
-  params.push_back({"Cuda", [] { return DefaultCudaExecutionProvider(); }, /*expects_plugin_ep=*/true});
+  params.push_back({"Cuda", kCudaExecutionProvider, [] { return DefaultCudaExecutionProvider(); },
+                    /*expects_plugin_ep=*/true});
 #else
-  params.push_back({"Cuda", [] { return DefaultCudaExecutionProvider(); }});
+  params.push_back({"Cuda", kCudaExecutionProvider, [] { return DefaultCudaExecutionProvider(); }});
 #endif
-#endif
-#ifdef USE_DML
-  params.push_back({"Dml", [] { return DefaultDmlExecutionProvider(); }});
-#endif
+
+  params.push_back({"Dml", kDmlExecutionProvider, [] { return DefaultDmlExecutionProvider(); }});
+
   // Mirror the guard used by base_tester.cc / default_providers.cc: in
   // ORT_USE_EP_API_ADAPTERS builds DefaultWebGpuExecutionProvider() ORT_ENFORCEs
   // (aborting the whole test run) when the dynamic plugin EP is initialized to a
   // different EP, rather than cleanly returning nullptr. Only list the built-in
-  // WebGPU EP when it is not routed through the EP API adapters.
+  // WebGPU EP when it is not routed through the EP API adapters. This matches the
+  // guard on kWebGpuExecutionProvider in get_execution_providers.cc, so the coverage
+  // cross-check below stays consistent in both configurations.
 #if defined(USE_WEBGPU) && !defined(ORT_USE_EP_API_ADAPTERS)
-  params.push_back({"WebGpu", [] { return DefaultWebGpuExecutionProvider(); }});
+  params.push_back({"WebGpu", kWebGpuExecutionProvider, [] { return DefaultWebGpuExecutionProvider(); }});
 #endif
-#ifdef USE_XNNPACK
-  params.push_back({"Xnnpack", [] { return DefaultXnnpackExecutionProvider(); }});
-#endif
+
+  params.push_back({"Xnnpack", kXnnpackExecutionProvider, [] { return DefaultXnnpackExecutionProvider(); }});
 
   return params;
 }
 
+// EPs that are compiled into some builds but deliberately not covered above. The two
+// reasons are kept in separate lists so the difference stays visible to reviewers.
+
+// (1) Not conformance-testable from a native gtest binary. These have no
+//     Default*ExecutionProvider() helper and are not expected to grow one.
+constexpr std::string_view kStructurallyExemptEps[] = {
+    kJsExecutionProvider,       // web/emscripten builds only
+    kWebNNExecutionProvider,    // web/emscripten builds only
+    kAzureExecutionProvider,    // remote inference endpoint, not a local compute EP
+    kVitisAIExecutionProvider,  // requires external configuration/runtime to construct
+};
+
+// (2) Not yet vetted. Each of these does have a Default*ExecutionProvider() and is
+//     expected to graduate into GetEpConformanceParams() above. They are parked here
+//     rather than registered so that introducing this cross-check does not start
+//     running eleven never-before-exercised invariants across many CI legs at once.
+//     An EP should be moved out of this list in the same change that validates it and
+//     fixes whatever the invariants surface for it.
+constexpr std::string_view kNotYetVettedEps[] = {
+    kAclExecutionProvider,
+    kCannExecutionProvider,
+    kCoreMLExecutionProvider,
+    kDnnlExecutionProvider,
+    kMIGraphXExecutionProvider,
+    kNnapiExecutionProvider,
+    kNvTensorRTRTXExecutionProvider,
+    kOpenVINOExecutionProvider,
+    kQnnExecutionProvider,
+    kRknpuExecutionProvider,
+    kTensorrtExecutionProvider,
+    kVSINPUExecutionProvider,
+};
+
+bool IsExemptFromConformanceCoverage(std::string_view ep_name) {
+  for (std::string_view exempt : kStructurallyExemptEps) {
+    if (exempt == ep_name) return true;
+  }
+  for (std::string_view exempt : kNotYetVettedEps) {
+    if (exempt == ep_name) return true;
+  }
+  return false;
+}
+
+bool IsRegisteredForConformance(const std::vector<EpConformanceParam>& params, std::string_view ep_name) {
+  return std::any_of(params.begin(), params.end(),
+                     [ep_name](const EpConformanceParam& param) { return param.ep_name == ep_name; });
+}
+
 }  // namespace
+
+// Meta-test: every EP compiled into this build is either exercised by the suite below
+// or explicitly exempted. This is what keeps the conformance guarantee from quietly
+// decaying -- adding a new EP to the build fails here until someone either registers
+// it in GetEpConformanceParams() or records why it cannot be covered.
+//
+// The check is deliberately one-directional: it does not assert the converse (that
+// every registered EP is "available"), because the two lists legitimately differ that
+// way. DefaultSnpeExecutionProvider() exists, for instance, while SNPE has no entry in
+// the availability registry at all.
+TEST(EpConformanceCoverage, EveryAvailableEpIsRegistered) {
+  const auto params = GetEpConformanceParams();
+
+  for (const std::string& available : GetAvailableExecutionProviderNames()) {
+    const std::string_view ep_name{available};
+    if (IsExemptFromConformanceCoverage(ep_name)) continue;
+
+    EXPECT_TRUE(IsRegisteredForConformance(params, ep_name))
+        << available << " is compiled into this build but has no EP conformance coverage. "
+        << "Register it in GetEpConformanceParams(), or add it to kStructurallyExemptEps "
+        << "or kNotYetVettedEps (in this file) with the reason.";
+  }
+}
+
+// Guards the exemption lists themselves. Without this, a typo or a stale entry left
+// behind after an EP is renamed or removed would silently widen the exemption and hide
+// a real coverage gap -- the exact failure mode the check above exists to prevent.
+TEST(EpConformanceCoverage, ExemptionsAreWellFormed) {
+  const auto& all_ep_names = GetAllExecutionProviderNames();
+  const auto params = GetEpConformanceParams();
+
+  const auto check = [&](std::string_view exempt) {
+    EXPECT_TRUE(std::any_of(all_ep_names.begin(), all_ep_names.end(),
+                            [exempt](const std::string& name) { return std::string_view{name} == exempt; }))
+        << exempt << " is listed as exempt from EP conformance coverage but is not a known "
+        << "execution provider name. Fix the typo or drop the stale entry.";
+
+    EXPECT_FALSE(IsRegisteredForConformance(params, exempt))
+        << exempt << " is both registered in GetEpConformanceParams() and listed as exempt. "
+        << "Remove it from the exemption list.";
+  };
+
+  for (std::string_view ep_name : kStructurallyExemptEps) check(ep_name);
+  for (std::string_view ep_name : kNotYetVettedEps) check(ep_name);
+}
 
 class EpConformanceTest : public testing::TestWithParam<EpConformanceParam> {
  protected:

--- a/onnxruntime/test/framework/execution_provider_conformance_test.cc
+++ b/onnxruntime/test/framework/execution_provider_conformance_test.cc
@@ -3,12 +3,17 @@
 
 // Execution Provider conformance test suite.
 //
-// These parameterized tests encode invariants that EVERY IExecutionProvider
+// These parameterized tests encode invariants that every IExecutionProvider
 // implementation is expected to satisfy, independent of the specific hardware
 // backend. They turn the previously-implicit Liskov-substitutability
 // assumptions of the IExecutionProvider contract into enforced, executable
-// checks, so that a new (or modified) EP cannot silently violate the behavior
-// the framework relies on.
+// checks, so that a covered EP cannot silently violate the behavior the
+// framework relies on.
+//
+// Coverage is opt-in per EP: only the providers registered in
+// GetEpConformanceParams() are exercised (currently CPU, plus CUDA, DML, WebGPU
+// and XNNPACK behind their build guards). Listing a provider there extends the
+// guarantee to it; EPs not listed are not checked by this suite.
 //
 // The invariant checks themselves live in
 // test/util/include/ep_conformance_invariants.h and are shared with the plugin EP
@@ -19,13 +24,16 @@
 // GetEpConformanceParams() below, guarded by the appropriate USE_* macro. The
 // stored value is a *factory*, not a constructed provider, so:
 //   - No EP is instantiated during static initialization.
-//   - A factory that returns nullptr (EP compiled but unavailable at runtime,
-//     e.g. no GPU present) causes the affected test to be skipped, not failed.
+//   - An EP that is compiled but unavailable at runtime (e.g. no GPU present)
+//     causes the affected test to be skipped, not failed -- whether its factory
+//     signals that by returning nullptr or by throwing during construction (see
+//     MakeEp()).
 //
 // Only documented, backend-agnostic contracts are asserted here. Memory that is
 // not CPU-accessible is never dereferenced from the test thread; such checks are
 // guarded by OrtDevice::UsesCpuMemory().
 
+#include <exception>
 #include <functional>
 #include <memory>
 #include <string>
@@ -43,9 +51,13 @@ namespace test {
 
 namespace {
 
-// One EP under test: a human-readable name (also used as the gtest parameter
-// suffix, so it must be a valid identifier) plus a factory that constructs a
-// fresh provider instance.
+// One EP under test:
+//   - name: a human-readable label, also used as the gtest parameter suffix, so it
+//     must be a valid identifier.
+//   - factory: constructs a fresh provider instance (see MakeEp()).
+//   - expects_plugin_ep: true iff this EP is plugin-backed, i.e. GetOrtEp() must
+//     return non-null (see CheckGetOrtEpMatchesProviderKind). Built-in EPs leave it
+//     false.
 struct EpConformanceParam {
   std::string name;
   std::function<std::unique_ptr<IExecutionProvider>()> factory;
@@ -63,7 +75,7 @@ std::vector<EpConformanceParam> GetEpConformanceParams() {
 
 #ifdef USE_CUDA
 #if defined(ORT_UNIT_TEST_HAS_CUDA_PLUGIN_EP) && defined(ORT_UNIT_TEST_ENABLE_DYNAMIC_PLUGIN_EP_USAGE)
-  params.push_back({"Cuda", [] { return DefaultCudaExecutionProvider(); }, true});
+  params.push_back({"Cuda", [] { return DefaultCudaExecutionProvider(); }, /*expects_plugin_ep=*/true});
 #else
   params.push_back({"Cuda", [] { return DefaultCudaExecutionProvider(); }});
 #endif
@@ -92,7 +104,20 @@ class EpConformanceTest : public testing::TestWithParam<EpConformanceParam> {
  protected:
   // Construct the EP under test. Returns nullptr when the EP is compiled but not
   // available in the current environment; callers should GTEST_SKIP() in that case.
-  std::unique_ptr<IExecutionProvider> MakeEp() const { return GetParam().factory(); }
+  // Some providers signal unavailability by returning nullptr from their factory;
+  // others (e.g. CUDA, whose constructor calls cudaSetDevice) throw when no device or
+  // driver is present. Both are treated as "unavailable" so the affected test skips
+  // rather than fails; the exception text is logged so a genuine construction
+  // regression stays visible.
+  std::unique_ptr<IExecutionProvider> MakeEp() const {
+    try {
+      return GetParam().factory();
+    } catch (const std::exception& e) {
+      GTEST_LOG_(WARNING) << GetParam().name
+                          << " EP factory threw during construction (treated as unavailable): " << e.what();
+      return nullptr;
+    }
+  }
 };
 
 // Invariant: Type() is non-empty and stable -- both across repeated calls on a
@@ -146,18 +171,18 @@ TEST_P(EpConformanceTest, PreferredAllocatorsAllocateUsableMemory) {
 }
 
 // Invariant: GetDataTransfer() is optional (may be null). When provided, and it
-// advertises the ability to copy within a CPU-accessible device, a CopyTensor
-// round-trip must preserve the data exactly.
-TEST_P(EpConformanceTest, DataTransferCpuRoundTripPreservesData) {
+// advertises the ability to copy within a CPU-accessible device, a CPU-to-CPU
+// CopyTensor must preserve the data exactly.
+TEST_P(EpConformanceTest, DataTransferCpuCopyPreservesData) {
   auto ep = MakeEp();
   if (!ep) GTEST_SKIP() << GetParam().name << " EP not available in this environment.";
 
-  ep_conformance::CheckDataTransferCpuRoundTripPreservesData(*ep, GetParam().name);
+  ep_conformance::CheckDataTransferCpuCopyPreservesData(*ep, GetParam().name);
 }
 
-// Invariant: read-only metadata queries are callable and self-consistent on a
-// freshly constructed EP (no session or logger required), and the device-id
-// accessor agrees with GetDevice().
+// Invariant: read-only metadata queries are callable on a freshly constructed EP (no
+// session or logger required). GetDeviceId() is provider-defined and is not required
+// to equal GetDevice().Id(), so it is only smoke-called.
 TEST_P(EpConformanceTest, MetadataQueriesAreCallable) {
   auto ep = MakeEp();
   if (!ep) GTEST_SKIP() << GetParam().name << " EP not available in this environment.";

--- a/onnxruntime/test/framework/execution_provider_conformance_test.cc
+++ b/onnxruntime/test/framework/execution_provider_conformance_test.cc
@@ -221,9 +221,10 @@ TEST_P(EpConformanceTest, EpContextNodesEmptyOnFreshEp) {
   ep_conformance::CheckEpContextNodesEmptyOnFreshEp(*ep, GetParam().name);
 }
 
-// Invariant: every preferred allocator reports self-consistent OrtMemoryInfo --
-// a non-empty name and a valid allocator type. This metadata keys allocator
-// lookup in the framework, so it must be well-formed for every EP. Only the
+// Invariant: every preferred allocator reports a valid allocator type in its
+// OrtMemoryInfo. This metadata keys allocator lookup in the framework, so it must
+// be well-formed for every EP. The allocator name is intentionally not asserted --
+// an empty OrtMemoryInfo.name is permitted by the contract. Only the
 // backend-agnostic fields are checked; the raw memory is not touched here.
 TEST_P(EpConformanceTest, PreferredAllocatorInfoIsConsistent) {
   auto ep = MakeEp();

--- a/onnxruntime/test/framework/execution_provider_conformance_test.cc
+++ b/onnxruntime/test/framework/execution_provider_conformance_test.cc
@@ -317,6 +317,25 @@ TEST_P(EpConformanceTest, GetOrtEpMatchesProviderKind) {
   ep_conformance::CheckGetOrtEpMatchesProviderKind(*ep, GetParam().expects_plugin_ep, GetParam().name);
 }
 
+// Invariant: an OrtEp implements the functions ORT dereferences without a null check.
+// Skips for a built-in EP, which has no backing OrtEp.
+TEST_P(EpConformanceTest, OrtEpRequiredFunctionsArePresent) {
+  auto ep = MakeEp();
+  if (!ep) GTEST_SKIP() << GetParam().name << " EP not available in this environment.";
+
+  ep_conformance::CheckOrtEpRequiredFunctionsArePresent(*ep, GetParam().name);
+}
+
+// Invariant: an OrtEp declares a coherent execution mode -- it exposes a kernel
+// registry, or it implements both Compile() and ReleaseNodeComputeInfos(). Skips for a
+// built-in EP, which has no backing OrtEp.
+TEST_P(EpConformanceTest, OrtEpDeclaresCompileOrKernelRegistry) {
+  auto ep = MakeEp();
+  if (!ep) GTEST_SKIP() << GetParam().name << " EP not available in this environment.";
+
+  ep_conformance::CheckOrtEpDeclaresCompileOrKernelRegistry(*ep, GetParam().name);
+}
+
 // Invariant: GetEpContextNodes() reports no nodes on a freshly constructed EP.
 // EPs populate this only when generating an EPContext cache model during
 // compilation; with no compilation performed, the documented default is empty.

--- a/onnxruntime/test/providers/ep_conformance_plugin_test.cc
+++ b/onnxruntime/test/providers/ep_conformance_plugin_test.cc
@@ -1,0 +1,141 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Plugin EP conformance test suite.
+//
+// This suite runs the shared Execution Provider conformance invariants
+// (test/util/include/ep_conformance_invariants.h) against a *plugin* EP -- an
+// OrtEp reached through the PluginExecutionProvider wrapper -- rather than against
+// an in-tree IExecutionProvider implementation. Developing an EP as a plugin (the
+// OrtEp / OrtEpFactory ABI) is the recommended path for external EP authors, so the
+// same Liskov-substitutability contract that the built-in suite
+// (test/framework/execution_provider_conformance_test.cc) enforces for the internal
+// interface is enforced here for the plugin interface.
+//
+// The EP under test is whichever plugin EP the dynamic plugin EP infrastructure was
+// initialized with. That is intentionally open-ended so the suite covers arbitrary
+// plugin EPs:
+//   - the in-repo example plugin EP,
+//   - an ORT-owned EP that has been converted to a plugin (e.g. CUDA or WebGPU
+//     routed through the EP API adapters), or
+//   - any plugin EP specified at runtime via the
+//     ORT_UNIT_TEST_MAIN_DYNAMIC_PLUGIN_EP_CONFIG_JSON[_FILE] environment variables.
+//
+// When the infrastructure is not initialized (no plugin EP configured for this run),
+// MakeEp() returns nullptr and every test cleanly skips.
+
+#include <memory>
+#include <string>
+
+#include "gtest/gtest.h"
+
+#include "core/framework/execution_provider.h"
+
+#include "test/unittest_util/test_dynamic_plugin_ep.h"
+#include "test/util/include/ep_conformance_invariants.h"
+
+#if defined(ORT_UNIT_TEST_ENABLE_DYNAMIC_PLUGIN_EP_USAGE)
+
+namespace onnxruntime {
+namespace test {
+namespace {
+
+namespace dynamic_plugin_ep_infra = onnxruntime::test::dynamic_plugin_ep_infra;
+
+// Fixture that constructs the dynamically-loaded plugin EP under test. A null return
+// means the dynamic plugin EP infrastructure was not initialized for this run, in
+// which case the test skips. Each test is the plugin-interface counterpart of the
+// identically-named test in the built-in EP suite.
+class EpPluginConformanceTest : public ::testing::Test {
+ protected:
+  static std::unique_ptr<IExecutionProvider> MakeEp() { return dynamic_plugin_ep_infra::MakeEp(); }
+
+  // Human-readable label for failure messages: the selected plugin EP's name.
+  static std::string EpLabel() { return dynamic_plugin_ep_infra::GetEpName().value_or(std::string{"PluginEp"}); }
+};
+
+TEST_F(EpPluginConformanceTest, TypeIsNonEmptyAndStable) {
+  auto ep = MakeEp();
+  if (!ep) GTEST_SKIP() << "dynamic plugin EP infrastructure is not initialized.";
+
+  ep_conformance::CheckTypeIsNonEmptyAndStable(
+      *ep, [] { return EpPluginConformanceTest::MakeEp(); }, EpLabel());
+}
+
+TEST_F(EpPluginConformanceTest, PreferredLayoutIsValid) {
+  auto ep = MakeEp();
+  if (!ep) GTEST_SKIP() << "dynamic plugin EP infrastructure is not initialized.";
+
+  ep_conformance::CheckPreferredLayoutIsValid(*ep, EpLabel());
+}
+
+TEST_F(EpPluginConformanceTest, CpuMemTypesMapToCpuAccessibleDevice) {
+  auto ep = MakeEp();
+  if (!ep) GTEST_SKIP() << "dynamic plugin EP infrastructure is not initialized.";
+
+  ep_conformance::CheckCpuMemTypesMapToCpuAccessibleDevice(*ep, EpLabel());
+}
+
+TEST_F(EpPluginConformanceTest, PreferredAllocatorsAreNonNullAndRepeatable) {
+  auto ep = MakeEp();
+  if (!ep) GTEST_SKIP() << "dynamic plugin EP infrastructure is not initialized.";
+
+  ep_conformance::CheckPreferredAllocatorsAreNonNullAndRepeatable(*ep, EpLabel());
+}
+
+TEST_F(EpPluginConformanceTest, PreferredAllocatorsAllocateUsableMemory) {
+  auto ep = MakeEp();
+  if (!ep) GTEST_SKIP() << "dynamic plugin EP infrastructure is not initialized.";
+
+  ep_conformance::CheckPreferredAllocatorsAllocateUsableMemory(*ep, EpLabel());
+}
+
+TEST_F(EpPluginConformanceTest, DataTransferCpuRoundTripPreservesData) {
+  auto ep = MakeEp();
+  if (!ep) GTEST_SKIP() << "dynamic plugin EP infrastructure is not initialized.";
+
+  ep_conformance::CheckDataTransferCpuRoundTripPreservesData(*ep, EpLabel());
+}
+
+TEST_F(EpPluginConformanceTest, MetadataQueriesAreCallable) {
+  auto ep = MakeEp();
+  if (!ep) GTEST_SKIP() << "dynamic plugin EP infrastructure is not initialized.";
+
+  ep_conformance::CheckMetadataQueriesAreCallable(*ep, EpLabel());
+}
+
+TEST_F(EpPluginConformanceTest, GraphCaptureNodeAssignmentPolicyIsValid) {
+  auto ep = MakeEp();
+  if (!ep) GTEST_SKIP() << "dynamic plugin EP infrastructure is not initialized.";
+
+  ep_conformance::CheckGraphCaptureNodeAssignmentPolicyIsValid(*ep, EpLabel());
+}
+
+TEST_F(EpPluginConformanceTest, GetOrtEpMatchesProviderKind) {
+  auto ep = MakeEp();
+  if (!ep) GTEST_SKIP() << "dynamic plugin EP infrastructure is not initialized.";
+
+  // A dynamically-loaded plugin EP is always backed by an OrtEp, so unlike a
+  // built-in EP it must report a stable non-null backing OrtEp.
+  ep_conformance::CheckGetOrtEpMatchesProviderKind(*ep, /*expects_plugin_ep*/ true, EpLabel());
+}
+
+TEST_F(EpPluginConformanceTest, EpContextNodesEmptyOnFreshEp) {
+  auto ep = MakeEp();
+  if (!ep) GTEST_SKIP() << "dynamic plugin EP infrastructure is not initialized.";
+
+  ep_conformance::CheckEpContextNodesEmptyOnFreshEp(*ep, EpLabel());
+}
+
+TEST_F(EpPluginConformanceTest, PreferredAllocatorInfoIsConsistent) {
+  auto ep = MakeEp();
+  if (!ep) GTEST_SKIP() << "dynamic plugin EP infrastructure is not initialized.";
+
+  ep_conformance::CheckPreferredAllocatorInfoIsConsistent(*ep, EpLabel());
+}
+
+}  // namespace
+}  // namespace test
+}  // namespace onnxruntime
+
+#endif  // defined(ORT_UNIT_TEST_ENABLE_DYNAMIC_PLUGIN_EP_USAGE)

--- a/onnxruntime/test/providers/ep_conformance_plugin_test.cc
+++ b/onnxruntime/test/providers/ep_conformance_plugin_test.cc
@@ -118,6 +118,20 @@ TEST_F(EpPluginConformanceTest, GetOrtEpMatchesProviderKind) {
   ep_conformance::CheckGetOrtEpMatchesProviderKind(*ep, /*expects_plugin_ep*/ true, EpLabel());
 }
 
+TEST_F(EpPluginConformanceTest, OrtEpRequiredFunctionsArePresent) {
+  auto ep = MakeEp();
+  if (!ep) GTEST_SKIP() << "dynamic plugin EP infrastructure is not initialized.";
+
+  ep_conformance::CheckOrtEpRequiredFunctionsArePresent(*ep, EpLabel());
+}
+
+TEST_F(EpPluginConformanceTest, OrtEpDeclaresCompileOrKernelRegistry) {
+  auto ep = MakeEp();
+  if (!ep) GTEST_SKIP() << "dynamic plugin EP infrastructure is not initialized.";
+
+  ep_conformance::CheckOrtEpDeclaresCompileOrKernelRegistry(*ep, EpLabel());
+}
+
 TEST_F(EpPluginConformanceTest, EpContextNodesEmptyOnFreshEp) {
   auto ep = MakeEp();
   if (!ep) GTEST_SKIP() << "dynamic plugin EP infrastructure is not initialized.";

--- a/onnxruntime/test/providers/ep_conformance_plugin_test.cc
+++ b/onnxruntime/test/providers/ep_conformance_plugin_test.cc
@@ -31,16 +31,14 @@
 
 #include "core/framework/execution_provider.h"
 
+#if defined(ORT_UNIT_TEST_ENABLE_DYNAMIC_PLUGIN_EP_USAGE)
+
 #include "test/unittest_util/test_dynamic_plugin_ep.h"
 #include "test/util/include/ep_conformance_invariants.h"
-
-#if defined(ORT_UNIT_TEST_ENABLE_DYNAMIC_PLUGIN_EP_USAGE)
 
 namespace onnxruntime {
 namespace test {
 namespace {
-
-namespace dynamic_plugin_ep_infra = onnxruntime::test::dynamic_plugin_ep_infra;
 
 // Fixture that constructs the dynamically-loaded plugin EP under test. A null return
 // means the dynamic plugin EP infrastructure was not initialized for this run, in
@@ -59,7 +57,7 @@ TEST_F(EpPluginConformanceTest, TypeIsNonEmptyAndStable) {
   if (!ep) GTEST_SKIP() << "dynamic plugin EP infrastructure is not initialized.";
 
   ep_conformance::CheckTypeIsNonEmptyAndStable(
-      *ep, [] { return EpPluginConformanceTest::MakeEp(); }, EpLabel());
+      *ep, [] { return MakeEp(); }, EpLabel());
 }
 
 TEST_F(EpPluginConformanceTest, PreferredLayoutIsValid) {
@@ -90,11 +88,11 @@ TEST_F(EpPluginConformanceTest, PreferredAllocatorsAllocateUsableMemory) {
   ep_conformance::CheckPreferredAllocatorsAllocateUsableMemory(*ep, EpLabel());
 }
 
-TEST_F(EpPluginConformanceTest, DataTransferCpuRoundTripPreservesData) {
+TEST_F(EpPluginConformanceTest, DataTransferCpuCopyPreservesData) {
   auto ep = MakeEp();
   if (!ep) GTEST_SKIP() << "dynamic plugin EP infrastructure is not initialized.";
 
-  ep_conformance::CheckDataTransferCpuRoundTripPreservesData(*ep, EpLabel());
+  ep_conformance::CheckDataTransferCpuCopyPreservesData(*ep, EpLabel());
 }
 
 TEST_F(EpPluginConformanceTest, MetadataQueriesAreCallable) {

--- a/onnxruntime/test/util/include/ep_conformance_invariants.h
+++ b/onnxruntime/test/util/include/ep_conformance_invariants.h
@@ -1,0 +1,242 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+// Shared Execution Provider conformance invariants.
+//
+// These free functions encode the backend-agnostic invariants that EVERY
+// execution provider is expected to satisfy. They are the single source of truth
+// shared by two suites so the internal-interface and plugin-interface checks
+// cannot drift apart:
+//   - The built-in EP suite (test/framework/execution_provider_conformance_test.cc)
+//     exercises the in-tree IExecutionProvider implementations.
+//   - The plugin EP suite (test/providers/ep_conformance_plugin_test.cc) exercises a
+//     dynamically-loaded plugin EP -- i.e. an OrtEp reached through the
+//     PluginExecutionProvider wrapper -- which is the recommended path for external
+//     EP authors.
+//
+// Only documented, backend-agnostic contracts are asserted here. Memory that is not
+// CPU-accessible is never dereferenced; such checks are guarded by
+// OrtDevice::UsesCpuMemory().
+//
+// Each function issues gtest expectations/assertions directly. Because some of them
+// call GTEST_SKIP() when a backend-agnostic precondition is not met (e.g. the EP
+// exposes no CPU-accessible allocator), a function must be invoked as the LAST
+// statement of a test body so the skip cleanly ends the test.
+
+#include <cstring>
+#include <functional>
+#include <memory>
+#include <string_view>
+
+#include "gtest/gtest.h"
+
+#include "core/framework/allocator.h"
+#include "core/framework/data_transfer.h"
+#include "core/framework/data_types.h"
+#include "core/framework/execution_provider.h"
+#include "core/framework/tensor.h"
+
+namespace onnxruntime {
+namespace test {
+namespace ep_conformance {
+
+// Factory that constructs a fresh EP instance under test. Used by invariants that
+// need to compare independent instances produced by the same source.
+using MakeEpFn = std::function<std::unique_ptr<IExecutionProvider>()>;
+
+// Invariant: Type() is non-empty and stable -- both across repeated calls on a
+// single instance and across independent instances from the same source. The
+// framework keys kernel registries and node assignment on this string.
+inline void CheckTypeIsNonEmptyAndStable(IExecutionProvider& ep, const MakeEpFn& make_ep, std::string_view label) {
+  const std::string type = ep.Type();
+  EXPECT_FALSE(type.empty()) << label << ": IExecutionProvider::Type() must not be empty.";
+  EXPECT_EQ(type, ep.Type()) << label << ": Type() must be stable across calls on the same instance.";
+
+  auto ep2 = make_ep();
+  ASSERT_NE(ep2, nullptr) << label << ": the EP source must produce a second instance.";
+  EXPECT_EQ(type, ep2->Type()) << label << ": Type() must be identical for instances from the same source.";
+}
+
+// Invariant: GetPreferredLayout() returns one of the defined DataLayout values.
+// Layout transformation dispatches on this, so an out-of-range value is a bug.
+inline void CheckPreferredLayoutIsValid(IExecutionProvider& ep, std::string_view label) {
+  const DataLayout layout = ep.GetPreferredLayout();
+  EXPECT_TRUE(layout == DataLayout::NCHW || layout == DataLayout::NHWC)
+      << label << ": GetPreferredLayout() returned an unknown DataLayout value.";
+}
+
+// Invariant: the CPU mem types always map to CPU-accessible memory. The framework's
+// input/output staging copies depend on this for every EP.
+inline void CheckCpuMemTypesMapToCpuAccessibleDevice(IExecutionProvider& ep, std::string_view label) {
+  EXPECT_TRUE(ep.GetOrtDeviceByMemType(OrtMemTypeCPUInput).UsesCpuMemory())
+      << label << ": OrtMemTypeCPUInput must map to CPU-accessible memory.";
+  EXPECT_TRUE(ep.GetOrtDeviceByMemType(OrtMemTypeCPUOutput).UsesCpuMemory())
+      << label << ": OrtMemTypeCPUOutput must map to CPU-accessible memory.";
+}
+
+// Invariant: CreatePreferredAllocators() never yields a null allocator and is
+// repeatable. The header documents it as a stateless factory, so a second call must
+// produce an equivalently-sized set.
+inline void CheckPreferredAllocatorsAreNonNullAndRepeatable(IExecutionProvider& ep, std::string_view label) {
+  auto allocators = ep.CreatePreferredAllocators();
+  for (const auto& alloc : allocators) {
+    EXPECT_NE(alloc, nullptr) << label << ": CreatePreferredAllocators() must not return null entries.";
+  }
+
+  auto allocators2 = ep.CreatePreferredAllocators();
+  EXPECT_EQ(allocators.size(), allocators2.size())
+      << label << ": CreatePreferredAllocators() must be repeatable (documented as stateless).";
+}
+
+// Invariant: each CPU-accessible preferred allocator hands back usable memory: a
+// non-zero allocation yields a non-null, host-writable and -readable pointer that can
+// be freed. Device allocators are intentionally excluded here -- their raw Alloc/Free
+// lifecycle is backend-specific -- and are covered by
+// CheckPreferredAllocatorsAreNonNullAndRepeatable instead.
+inline void CheckPreferredAllocatorsAllocateUsableMemory(IExecutionProvider& ep, std::string_view label) {
+  auto allocators = ep.CreatePreferredAllocators();
+  if (allocators.empty()) {
+    GTEST_SKIP() << label << " EP exposes no preferred allocators.";
+  }
+
+  constexpr size_t kBytes = 256;
+  size_t exercised = 0;
+  for (const auto& alloc : allocators) {
+    ASSERT_NE(alloc, nullptr);
+
+    // Standalone Alloc()/Free() is only a backend-agnostic contract for
+    // CPU-accessible allocators. A device allocator may hand out memory with a
+    // backend-specific lifecycle that this test cannot drive: e.g. the WebGPU
+    // GpuBufferAllocator creates buffers mapped at creation that must be unmapped
+    // through the buffer manager before Free(), so Free()-ing a freshly allocated
+    // buffer throws. Skip such allocators; they are covered by
+    // CheckPreferredAllocatorsAreNonNullAndRepeatable.
+    if (!alloc->Info().device.UsesCpuMemory()) {
+      continue;
+    }
+
+    void* p = alloc->Alloc(kBytes);
+    ASSERT_NE(p, nullptr) << label << ": Alloc(" << kBytes << ") returned null for allocator on "
+                          << alloc->Info().device.ToString();
+
+    std::memset(p, 0xAB, kBytes);
+    const auto* bytes = static_cast<const unsigned char*>(p);
+    EXPECT_EQ(bytes[0], 0xAB);
+    EXPECT_EQ(bytes[kBytes - 1], 0xAB);
+    alloc->Free(p);
+    ++exercised;
+  }
+
+  if (exercised == 0) {
+    GTEST_SKIP() << label << " EP exposes no CPU-accessible preferred allocator to exercise.";
+  }
+}
+
+// Invariant: GetDataTransfer() is optional (may be null). When provided, and it
+// advertises the ability to copy within a CPU-accessible device, a CopyTensor
+// round-trip must preserve the data exactly.
+inline void CheckDataTransferCpuRoundTripPreservesData(IExecutionProvider& ep, std::string_view label) {
+  auto data_transfer = ep.GetDataTransfer();
+  if (!data_transfer) {
+    GTEST_SKIP() << label << " EP provides no IDataTransfer (allowed by the contract).";
+  }
+
+  // Host the tensors on a CPU-accessible preferred allocator.
+  AllocatorPtr cpu_alloc;
+  for (auto& alloc : ep.CreatePreferredAllocators()) {
+    if (alloc && alloc->Info().device.UsesCpuMemory()) {
+      cpu_alloc = alloc;
+      break;
+    }
+  }
+  if (!cpu_alloc) {
+    GTEST_SKIP() << label << " EP has no CPU-accessible allocator to drive the round-trip.";
+  }
+
+  const OrtDevice& cpu_device = cpu_alloc->Info().device;
+  if (!data_transfer->CanCopy(cpu_device, cpu_device)) {
+    GTEST_SKIP() << label << " EP data transfer does not advertise CPU<->CPU copy.";
+  }
+
+  const TensorShape shape({2, 3});
+  Tensor src(DataTypeImpl::GetType<float>(), shape, cpu_alloc);
+  Tensor dst(DataTypeImpl::GetType<float>(), shape, cpu_alloc);
+
+  const float values[] = {1.f, -2.f, 3.5f, 4.f, 5.f, -6.25f};
+  constexpr size_t kNumValues = sizeof(values) / sizeof(values[0]);
+  ASSERT_EQ(static_cast<size_t>(shape.Size()), kNumValues);
+  std::memcpy(src.MutableDataRaw(), values, sizeof(values));
+  std::memset(dst.MutableDataRaw(), 0, sizeof(values));
+
+  ASSERT_TRUE(data_transfer->CopyTensor(src, dst).IsOK()) << label << ": CopyTensor failed for a CPU<->CPU copy.";
+  EXPECT_EQ(std::memcmp(src.DataRaw(), dst.DataRaw(), sizeof(values)), 0)
+      << label << ": a CPU round-trip CopyTensor must preserve data exactly.";
+}
+
+// Invariant: read-only metadata queries are callable and self-consistent on a
+// freshly constructed EP (no session or logger required), and the device-id accessor
+// agrees with GetDevice().
+inline void CheckMetadataQueriesAreCallable(IExecutionProvider& ep, std::string_view label) {
+  EXPECT_EQ(ep.GetDeviceId(), ep.GetDevice().Id()) << label << ": GetDeviceId() must agree with GetDevice().Id().";
+
+  // These must simply be callable without crashing on a bare EP instance.
+  (void)ep.ConcurrentRunSupported();
+  (void)ep.GetTuningContext();
+  (void)ep.GetOrtDeviceByMemType(OrtMemTypeDefault);
+  (void)ep.IsGraphCaptureEnabled();
+  (void)ep.ShouldConvertDataLayoutForOp(/*domain*/ "", /*op_type*/ "Conv", ep.GetPreferredLayout());
+}
+
+// Invariant: GetGraphCaptureNodeAssignmentPolicy() returns one of the defined
+// OrtGraphCaptureNodeAssignmentPolicy values. The session dispatches on this while
+// validating a graph for capture, so an out-of-range value is a bug. This is a pure
+// query and is valid to call on every EP regardless of whether graph capture is
+// enabled.
+inline void CheckGraphCaptureNodeAssignmentPolicyIsValid(IExecutionProvider& ep, std::string_view label) {
+  const OrtGraphCaptureNodeAssignmentPolicy policy = ep.GetGraphCaptureNodeAssignmentPolicy();
+  EXPECT_TRUE(policy == OrtGraphCaptureNodeAssignmentPolicy_ALL_NODES_ON_EP ||
+              policy == OrtGraphCaptureNodeAssignmentPolicy_ALLOW_CPU_FOR_SHAPES)
+      << label << ": GetGraphCaptureNodeAssignmentPolicy() returned an unknown policy value.";
+}
+
+// Invariant: GetOrtEp() reflects the provider kind. A built-in EP returns no backing
+// OrtEp; a PluginExecutionProvider returns the same non-null backing OrtEp across
+// repeated queries.
+inline void CheckGetOrtEpMatchesProviderKind(IExecutionProvider& ep, bool expects_plugin_ep, std::string_view label) {
+  const OrtEp* ort_ep = ep.GetOrtEp();
+  if (expects_plugin_ep) {
+    ASSERT_NE(ort_ep, nullptr) << label << ": a plugin EP must report its backing OrtEp.";
+    EXPECT_EQ(ep.GetOrtEp(), ort_ep) << label << ": a plugin EP must report a stable backing OrtEp.";
+  } else {
+    EXPECT_EQ(ort_ep, nullptr)
+        << label << ": a built-in EP must not report a backing OrtEp (that is reserved for plugin EPs).";
+  }
+}
+
+// Invariant: GetEpContextNodes() reports no nodes on a freshly constructed EP. EPs
+// populate this only when generating an EPContext cache model during compilation;
+// with no compilation performed, the documented default is empty.
+inline void CheckEpContextNodesEmptyOnFreshEp(IExecutionProvider& ep, std::string_view label) {
+  EXPECT_TRUE(ep.GetEpContextNodes().empty())
+      << label << ": a fresh EP (no compilation performed) must report no EPContext nodes.";
+}
+
+// Invariant: every preferred allocator reports self-consistent OrtMemoryInfo -- a
+// non-empty name and a valid allocator type. This metadata keys allocator lookup in
+// the framework, so it must be well-formed for every EP. Only the backend-agnostic
+// fields are checked; the raw memory is not touched here.
+inline void CheckPreferredAllocatorInfoIsConsistent(IExecutionProvider& ep, std::string_view label) {
+  for (const auto& alloc : ep.CreatePreferredAllocators()) {
+    ASSERT_NE(alloc, nullptr) << label << ": CreatePreferredAllocators() must not return null entries.";
+    const OrtMemoryInfo& info = alloc->Info();
+    EXPECT_FALSE(info.name.empty()) << label << ": allocator OrtMemoryInfo.name must not be empty.";
+    EXPECT_NE(info.alloc_type, OrtInvalidAllocator)
+        << label << ": allocator must report a valid OrtAllocatorType (not OrtInvalidAllocator).";
+  }
+}
+
+}  // namespace ep_conformance
+}  // namespace test
+}  // namespace onnxruntime

--- a/onnxruntime/test/util/include/ep_conformance_invariants.h
+++ b/onnxruntime/test/util/include/ep_conformance_invariants.h
@@ -20,6 +20,11 @@
 // CPU-accessible is never dereferenced; such checks are guarded by
 // OrtDevice::UsesCpuMemory().
 //
+// Most invariants are expressed against IExecutionProvider, so they hold for built-in
+// and plugin EPs alike. A few instead inspect the OrtEp behind a plugin EP to assert
+// contracts that only exist at the plugin EP C API level; those skip when the EP under
+// test is a built-in one (IExecutionProvider::GetOrtEp() returns nullptr).
+//
 // Each function issues gtest expectations/assertions directly. Because some of them
 // call GTEST_SKIP() when a backend-agnostic precondition is not met (e.g. the EP
 // exposes no CPU-accessible allocator), a function must be invoked as the LAST
@@ -37,6 +42,10 @@
 #include "core/framework/data_types.h"
 #include "core/framework/execution_provider.h"
 #include "core/framework/tensor.h"
+// Brings in the plugin EP C API (onnxruntime_ep_c_api.h is included at the end of this
+// header and must not be included directly), which the OrtEp-level invariants need in
+// order to inspect OrtEp members rather than just compare pointers.
+#include "core/session/onnxruntime_c_api.h"
 
 namespace onnxruntime {
 namespace test {
@@ -232,6 +241,83 @@ inline void CheckGetOrtEpMatchesProviderKind(IExecutionProvider& ep, bool expect
     EXPECT_EQ(ort_ep, nullptr)
         << label << ": a built-in EP must not report a backing OrtEp (that is reserved for plugin EPs).";
   }
+}
+
+// Invariant: an OrtEp implements every function ORT dereferences without a null check.
+// OrtEp::GetCapability is the only one: PluginExecutionProvider::GetCapability() calls
+// ort_ep_->GetCapability() unconditionally, so a null there faults during graph
+// partitioning instead of producing a diagnosable error. Every other OrtEp entry point
+// ORT invokes is either null-guarded or falls back to the OrtEpFactory implementation
+// (e.g. CreateAllocator, CreateSyncStreamForDevice), and so is genuinely optional.
+//
+// OrtEp::GetName is deliberately not asserted here. SanityCheckOrtEp() already rejects
+// both a null GetName and a null return before an OrtEp can reach an IExecutionProvider,
+// so repeating it could never fail. Its non-empty contract is covered by
+// CheckTypeIsNonEmptyAndStable instead, because a plugin EP's provider type *is* the
+// string returned by OrtEp::GetName().
+//
+// May GTEST_SKIP(): invoke as the LAST statement of the test body (see file header).
+inline void CheckOrtEpRequiredFunctionsArePresent(IExecutionProvider& ep, std::string_view label) {
+  const OrtEp* ort_ep = ep.GetOrtEp();
+  if (ort_ep == nullptr) {
+    GTEST_SKIP() << label << " is not backed by an OrtEp (built-in EP); nothing to check.";
+  }
+
+  // OrtEp::GetCapability is \since ORT 1.23. An OrtEp built against an older ORT
+  // allocated a shorter struct, so reading a newer field would read past it. Gate on
+  // the reported ABI version first, exactly as ORT does before touching versioned
+  // fields (see ep_kernel_registration.cc / ep_plugin_provider_interfaces.cc).
+  if (ort_ep->ort_version_supported < 23) {
+    GTEST_SKIP() << label << ": OrtEp reports ort_version_supported=" << ort_ep->ort_version_supported
+                 << "; GetCapability does not exist in that ABI.";
+  }
+
+  EXPECT_NE(ort_ep->GetCapability, nullptr)
+      << label << ": OrtEp::GetCapability must be implemented -- ORT calls it without a null check "
+      << "while partitioning the graph.";
+}
+
+// Invariant: an OrtEp declares a coherent execution mode. The public contract ties the
+// two modes together through GetKernelRegistry (onnxruntime_ep_c_api.h):
+//   - on GetKernelRegistry: "Implementation of this function is optional. If set to
+//     NULL, ORT assumes the EP compiles nodes."
+//   - on Compile and ReleaseNodeComputeInfos: "implementation of this function is
+//     optional if the EP does not compile nodes and uses a kernel registry instead."
+// So an EP that exposes no kernel registry is compile-based, and a compile-based EP
+// must supply both Compile and ReleaseNodeComputeInfos. ORT does require both, but only
+// on the first actual compilation (PluginExecutionProvider::Compile), which turns a
+// structural mistake into a late failure partway through session initialization.
+// Checking it up front makes it immediate and self-describing.
+//
+// Implementing *both* a kernel registry and Compile is legal and intentionally not
+// flagged: nothing in ORT forbids an EP from registering kernels and also compiling
+// fused nodes.
+//
+// May GTEST_SKIP(): invoke as the LAST statement of the test body (see file header).
+inline void CheckOrtEpDeclaresCompileOrKernelRegistry(IExecutionProvider& ep, std::string_view label) {
+  const OrtEp* ort_ep = ep.GetOrtEp();
+  if (ort_ep == nullptr) {
+    GTEST_SKIP() << label << " is not backed by an OrtEp (built-in EP); nothing to check.";
+  }
+
+  // Compile and ReleaseNodeComputeInfos are \since ORT 1.23; GetKernelRegistry is
+  // \since ORT 1.24. Only read a field once the reported ABI version guarantees the
+  // plugin actually allocated it.
+  if (ort_ep->ort_version_supported < 23) {
+    GTEST_SKIP() << label << ": OrtEp reports ort_version_supported=" << ort_ep->ort_version_supported
+                 << "; Compile does not exist in that ABI.";
+  }
+
+  if (ort_ep->ort_version_supported >= 24 && ort_ep->GetKernelRegistry != nullptr) {
+    return;  // Kernel-registry-based EP: Compile is optional for it.
+  }
+
+  EXPECT_NE(ort_ep->Compile, nullptr)
+      << label << ": OrtEp exposes no kernel registry, so ORT treats it as compile-based, "
+      << "but it does not implement Compile().";
+  EXPECT_NE(ort_ep->ReleaseNodeComputeInfos, nullptr)
+      << label << ": a compile-based OrtEp must implement ReleaseNodeComputeInfos() to free the "
+      << "OrtNodeComputeInfo instances its Compile() allocates.";
 }
 
 // Invariant: GetEpContextNodes() reports no nodes on a freshly constructed EP. EPs

--- a/onnxruntime/test/util/include/ep_conformance_invariants.h
+++ b/onnxruntime/test/util/include/ep_conformance_invariants.h
@@ -5,7 +5,7 @@
 
 // Shared Execution Provider conformance invariants.
 //
-// These free functions encode the backend-agnostic invariants that EVERY
+// These free functions encode the backend-agnostic invariants that every
 // execution provider is expected to satisfy. They are the single source of truth
 // shared by two suites so the internal-interface and plugin-interface checks
 // cannot drift apart:
@@ -78,7 +78,8 @@ inline void CheckCpuMemTypesMapToCpuAccessibleDevice(IExecutionProvider& ep, std
 
 // Invariant: CreatePreferredAllocators() never yields a null allocator and is
 // repeatable. The header documents it as a stateless factory, so a second call must
-// produce an equivalently-sized set.
+// produce the same set of allocators -- same count, and the same OrtMemoryInfo per
+// position -- not merely an equally-sized one.
 inline void CheckPreferredAllocatorsAreNonNullAndRepeatable(IExecutionProvider& ep, std::string_view label) {
   auto allocators = ep.CreatePreferredAllocators();
   for (const auto& alloc : allocators) {
@@ -86,8 +87,20 @@ inline void CheckPreferredAllocatorsAreNonNullAndRepeatable(IExecutionProvider& 
   }
 
   auto allocators2 = ep.CreatePreferredAllocators();
-  EXPECT_EQ(allocators.size(), allocators2.size())
+  for (const auto& alloc : allocators2) {
+    EXPECT_NE(alloc, nullptr)
+        << label << ": CreatePreferredAllocators() must not return null entries on a repeat call.";
+  }
+
+  ASSERT_EQ(allocators.size(), allocators2.size())
       << label << ": CreatePreferredAllocators() must be repeatable (documented as stateless).";
+
+  for (size_t i = 0; i < allocators.size(); ++i) {
+    if (!allocators[i] || !allocators2[i]) continue;
+    EXPECT_TRUE(allocators[i]->Info() == allocators2[i]->Info())
+        << label << ": CreatePreferredAllocators() must report stable OrtMemoryInfo across calls ("
+        << allocators[i]->Info().ToString() << " vs " << allocators2[i]->Info().ToString() << ").";
+  }
 }
 
 // Invariant: each CPU-accessible preferred allocator hands back usable memory: a
@@ -95,6 +108,8 @@ inline void CheckPreferredAllocatorsAreNonNullAndRepeatable(IExecutionProvider& 
 // be freed. Device allocators are intentionally excluded here -- their raw Alloc/Free
 // lifecycle is backend-specific -- and are covered by
 // CheckPreferredAllocatorsAreNonNullAndRepeatable instead.
+//
+// May GTEST_SKIP(): invoke as the LAST statement of the test body (see file header).
 inline void CheckPreferredAllocatorsAllocateUsableMemory(IExecutionProvider& ep, std::string_view label) {
   auto allocators = ep.CreatePreferredAllocators();
   if (allocators.empty()) {
@@ -135,9 +150,11 @@ inline void CheckPreferredAllocatorsAllocateUsableMemory(IExecutionProvider& ep,
 }
 
 // Invariant: GetDataTransfer() is optional (may be null). When provided, and it
-// advertises the ability to copy within a CPU-accessible device, a CopyTensor
-// round-trip must preserve the data exactly.
-inline void CheckDataTransferCpuRoundTripPreservesData(IExecutionProvider& ep, std::string_view label) {
+// advertises the ability to copy within a CPU-accessible device, a CPU-to-CPU
+// CopyTensor must preserve the data exactly.
+//
+// May GTEST_SKIP(): invoke as the LAST statement of the test body (see file header).
+inline void CheckDataTransferCpuCopyPreservesData(IExecutionProvider& ep, std::string_view label) {
   auto data_transfer = ep.GetDataTransfer();
   if (!data_transfer) {
     GTEST_SKIP() << label << " EP provides no IDataTransfer (allowed by the contract).";
@@ -152,7 +169,7 @@ inline void CheckDataTransferCpuRoundTripPreservesData(IExecutionProvider& ep, s
     }
   }
   if (!cpu_alloc) {
-    GTEST_SKIP() << label << " EP has no CPU-accessible allocator to drive the round-trip.";
+    GTEST_SKIP() << label << " EP has no CPU-accessible allocator to drive the copy.";
   }
 
   const OrtDevice& cpu_device = cpu_alloc->Info().device;
@@ -172,16 +189,18 @@ inline void CheckDataTransferCpuRoundTripPreservesData(IExecutionProvider& ep, s
 
   ASSERT_TRUE(data_transfer->CopyTensor(src, dst).IsOK()) << label << ": CopyTensor failed for a CPU<->CPU copy.";
   EXPECT_EQ(std::memcmp(src.DataRaw(), dst.DataRaw(), sizeof(values)), 0)
-      << label << ": a CPU round-trip CopyTensor must preserve data exactly.";
+      << label << ": a CPU-to-CPU CopyTensor must preserve data exactly.";
 }
 
-// Invariant: read-only metadata queries are callable and self-consistent on a
-// freshly constructed EP (no session or logger required), and the device-id accessor
-// agrees with GetDevice().
-inline void CheckMetadataQueriesAreCallable(IExecutionProvider& ep, std::string_view label) {
-  EXPECT_EQ(ep.GetDeviceId(), ep.GetDevice().Id()) << label << ": GetDeviceId() must agree with GetDevice().Id().";
-
+// Invariant: read-only metadata queries are callable on a freshly constructed EP (no
+// session or logger required). GetDeviceId() is a provider-defined identifier that is
+// deliberately NOT required to equal GetDevice().Id() -- e.g. WebGPU returns a
+// configurable context id while its OrtDevice id is fixed at 0 -- so it is only
+// smoke-called here, never asserted against GetDevice().
+inline void CheckMetadataQueriesAreCallable(IExecutionProvider& ep, [[maybe_unused]] std::string_view label) {
   // These must simply be callable without crashing on a bare EP instance.
+  (void)ep.GetDeviceId();
+  (void)ep.GetDevice();
   (void)ep.ConcurrentRunSupported();
   (void)ep.GetTuningContext();
   (void)ep.GetOrtDeviceByMemType(OrtMemTypeDefault);
@@ -223,15 +242,16 @@ inline void CheckEpContextNodesEmptyOnFreshEp(IExecutionProvider& ep, std::strin
       << label << ": a fresh EP (no compilation performed) must report no EPContext nodes.";
 }
 
-// Invariant: every preferred allocator reports self-consistent OrtMemoryInfo -- a
-// non-empty name and a valid allocator type. This metadata keys allocator lookup in
-// the framework, so it must be well-formed for every EP. Only the backend-agnostic
-// fields are checked; the raw memory is not touched here.
+// Invariant: every preferred allocator reports a valid allocator type in its
+// OrtMemoryInfo. This metadata keys allocator lookup in the framework, so it must be
+// well-formed for every EP. The allocator name is intentionally NOT asserted: an
+// empty OrtMemoryInfo.name is permitted by the contract, so requiring a non-empty one
+// would over-state it. Only the backend-agnostic fields are checked; the raw memory
+// is not touched here.
 inline void CheckPreferredAllocatorInfoIsConsistent(IExecutionProvider& ep, std::string_view label) {
   for (const auto& alloc : ep.CreatePreferredAllocators()) {
     ASSERT_NE(alloc, nullptr) << label << ": CreatePreferredAllocators() must not return null entries.";
     const OrtMemoryInfo& info = alloc->Info();
-    EXPECT_FALSE(info.name.empty()) << label << ": allocator OrtMemoryInfo.name must not be empty.";
     EXPECT_NE(info.alloc_type, OrtInvalidAllocator)
         << label << ": allocator must report a valid OrtAllocatorType (not OrtInvalidAllocator).";
   }


### PR DESCRIPTION
### Description

The EP conformance suites added in #28968 assert contracts on `IExecutionProvider`, which is ONNX Runtime's *internal* EP interface. External EP authors implement the *public* plugin EP C API (`OrtEp` / `OrtEpFactory`) instead, and several of its contracts have no `IExecutionProvider` equivalent — so nothing covered them.

This PR adds the first `OrtEp`-level checks, reached through `IExecutionProvider::GetOrtEp()`. They live in the shared invariants header so the built-in and plugin suites stay in lockstep, and they skip for built-in EPs (which have no backing `OrtEp`).

**`CheckOrtEpRequiredFunctionsArePresent`** — asserts `OrtEp::GetCapability` is implemented.

It is the only `OrtEp` function ORT dereferences without a null check ([`ep_plugin_provider_interfaces.cc`](https://github.com/microsoft/onnxruntime/blob/main/onnxruntime/core/session/plugin_ep/ep_plugin_provider_interfaces.cc)), so a null one faults during graph partitioning instead of producing a diagnosable error. Every other entry point ORT calls is either null-guarded or falls back to the `OrtEpFactory` implementation (`CreateAllocator`, `CreateSyncStreamForDevice`), so those are genuinely optional and are deliberately *not* asserted.

**`CheckOrtEpDeclaresCompileOrKernelRegistry`** — asserts the EP declares a coherent execution mode: it either exposes a kernel registry, or implements *both* `Compile` and `ReleaseNodeComputeInfos`.

ORT already requires this, but only on the first actual compilation (`PluginExecutionProvider::Compile`), so a structural mistake surfaces late and partway through session initialization. Checking it at construction makes the failure immediate and self-describing. Implementing *both* a kernel registry and `Compile` is legal and is not flagged.

### ABI versioning

Both checks read `ort_version_supported` before touching any member. A plugin built against an older ORT allocated a *shorter* `OrtEp`, so reading a newer field would read past it. `GetCapability`, `Compile` and `ReleaseNodeComputeInfos` are `\since` 1.23; `GetKernelRegistry` is `\since` 1.24. This mirrors what ORT itself does before touching versioned fields (e.g. `ep_kernel_registration.cc`).

### Notes on what is *not* asserted, and why

These were considered and rejected as already-covered or incorrect:

| Candidate check | Why it is not here |
| --- | --- |
| `OrtEp::GetName()` non-null / non-empty | `SanityCheckOrtEp()` already rejects a null `GetName` **and** a null return before an `OrtEp` can reach an `IExecutionProvider`. Non-emptiness is covered by the existing `TypeIsNonEmptyAndStable`, because a plugin EP's provider type *is* `OrtEp::GetName()`'s return value. |
| `OrtEp::GetName() == OrtEpFactory::GetName()` | Tautological — `PluginExecutionProvider` is constructed with `IExecutionProvider(ep->GetName(...))`. |
| `OrtEp::ort_version_supported >= 22` | Vacuous at this layer: `SanityCheckOrtEp()` enforces it, so an `OrtEp` that failed it never becomes an `IExecutionProvider`. |
| `GetKernelRegistry()` must return a **non-empty** registry | Not the documented contract. The out-param "can be NULL if the EP doesn't use a kernel registry", and `CopyEpKernelRegistry` explicitly returns OK on `nullptr`. |
| `Compile` **xor** `GetKernelRegistry` | Not exclusive. `GetKernelRegistry`'s docs say only that a NULL registry means "ORT assumes the EP compiles nodes"; nothing forbids implementing both. Encoded as an implication, not an xor. |

`OrtEpFactory`-level checks (`CreateEpFactories()` returning ≥ 1 — currently unenforced; `GetVendor()` non-empty; `GetVersion()` valid semver) are real gaps, but they need an `OrtEpFactory` handle rather than an `IExecutionProvider`, so they need separate plumbing and are out of scope here.

### Verification

Built and ran locally on Windows (MSVC, Ninja, Release):

```
onnxruntime_test_all      --gtest_filter=*EpConformance*:*EpContract*
  67 tests ran  |  24 passed  |  43 skipped  |  0 failed     (was 57 tests)
onnxruntime_provider_test --gtest_filter=*EpPluginConformance*
  13 tests ran  |   0 passed  |  13 skipped  |  0 failed     (was 11 tests)
```

No plugin EP is configured in a default local build, so the new tests skip there. To confirm they are not vacuous, each branch was driven with a fabricated `OrtEp` through a temporary local probe (not part of this PR):

| Case | Result |
| --- | --- |
| Well-formed compile-based `OrtEp` | passes |
| `GetCapability == nullptr` | **fails**, as intended |
| `Compile == nullptr`, no kernel registry | **fails**, as intended |
| `ReleaseNodeComputeInfos == nullptr` | **fails**, as intended |
| Kernel-registry-based (`Compile == nullptr`) | passes |
| Kernel registry set but `ort_version_supported == 23` | **fails** — field correctly ignored below ABI 24 |
| `ort_version_supported == 22` | skips |
| Built-in EP (no backing `OrtEp`) | skips |

Every in-tree `OrtEp` implementation was also checked statically and satisfies both invariants: all five set `GetCapability`, the compile-based ones (`example_plugin_ep`, `example_plugin_ep_virt_gpu`) set both `Compile` and `ReleaseNodeComputeInfos`, and the kernel-registry ones (CUDA plugin, per-kernel example) set `GetKernelRegistry` with `Compile = nullptr`.

### Motivation and Context

Third in a series on EP conformance coverage, after #28968 (the suites) and #29915 (registry-driven coverage). Those assert the internal interface; this one starts on the public plugin EP API that external EP authors actually implement.

This is stacked on #29915, so until both merge the diff here also shows their commits. Only the three conformance test files are changed by this PR.
