### PR TITLE
Delay load shell32

### DIFF
--- a/cmake/onnxruntime.cmake
+++ b/cmake/onnxruntime.cmake
@@ -297,7 +297,9 @@ else()
   )
 endif()
 
-if(WIN32)
+# In a static build the onnxruntime target is an INTERFACE library, which rejects
+# the PRIVATE keyword.
+if(WIN32 AND onnxruntime_BUILD_SHARED_LIB)
   target_link_options(onnxruntime PRIVATE ${onnxruntime_DELAYLOAD_FLAGS})
 endif()
 #See: https://cmake.org/cmake/help/latest/prop_tgt/SOVERSION.html

--- a/cmake/onnxruntime_common.cmake
+++ b/cmake/onnxruntime_common.cmake
@@ -155,7 +155,9 @@ if(WIN32)
     # shell32.dll statically imports user32.dll, which is unavailable under Win32k lockdown. Delay-load
     # shell32.dll so the load-time dependency on user32.dll is deferred until the call is actually made,
     # letting onnxruntime.dll load in lockdown processes.
-    list(APPEND onnxruntime_DELAYLOAD_FLAGS "/DELAYLOAD:shell32.dll")
+    if(onnxruntime_ENABLE_DELAY_LOADING_WIN_DLLS)
+      list(APPEND onnxruntime_DELAYLOAD_FLAGS "/DELAYLOAD:shell32.dll")
+    endif()
   endif()
 endif()
 

--- a/cmake/onnxruntime_common.cmake
+++ b/cmake/onnxruntime_common.cmake
@@ -152,6 +152,10 @@ if(WIN32)
   # /NODEFAULTLIB), and non-desktop partitions (UWP/WindowsStore) neither use nor ship it.
   if(NOT GDK_PLATFORM AND NOT CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
     target_link_libraries(onnxruntime_common PRIVATE shell32)
+    # shell32.dll statically imports user32.dll, which is unavailable under Win32k lockdown. Delay-load
+    # shell32.dll so the load-time dependency on user32.dll is deferred until the call is actually made,
+    # letting onnxruntime.dll load in lockdown processes.
+    list(APPEND onnxruntime_DELAYLOAD_FLAGS "/DELAYLOAD:shell32.dll")
   endif()
 endif()
 


### PR DESCRIPTION
### Description
PR https://github.com/microsoft/onnxruntime/pull/27379 introduced a static dependency on shell32.dll. Since shell32.dll depends on user32.dll, this prevents loading onnxruntime.dll in processes that enabled the mitigation PROCESS_MITIGATION_SYSTEM_CALL_DISABLE_POLICY.DisallowWin32kSystemCalls (Win32k lockdown), causing an ERROR_INTERNAL_ERROR (1359).

The use of shell32.dll is only for svchost processes, so it's okay to just delay load it.

### Motivation and Context
WebNN is migrating ORT graph compilation to a sandboxed process with Win32k lockdown. Dependency on shell32.dll will cause onnxruntime.dll to fail to get loaded in that process.
