### PR TITLE
[OpenVINO EP] Fix get/set_float_initializer_data for raw_data backed float initializers

### DIFF
--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -1148,6 +1148,11 @@ endif()
 
 partition_provider_test_srcs(all_tests onnxruntime_provider_test_srcs onnxruntime_test_all_srcs)
 
+if (onnxruntime_USE_OPENVINO)
+  list(APPEND onnxruntime_provider_test_srcs
+       ${ONNXRUNTIME_ROOT}/core/providers/openvino/ov_protobuf_utils.cpp)
+endif()
+
 # Workarounds for onnxruntime test targets.
 function(onnxruntime_apply_test_target_workarounds target)
   if (MSVC)

--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -1149,6 +1149,10 @@ endif()
 partition_provider_test_srcs(all_tests onnxruntime_provider_test_srcs onnxruntime_test_all_srcs)
 
 if (onnxruntime_USE_OPENVINO)
+  # ov_protobuf_utils.cpp lives under core/providers (not test/), so partition_provider_test_srcs
+  # would route it to onnxruntime_test_all. Append it here after the partition so it is compiled into
+  # onnxruntime_provider_test alongside openvino_ov_protobuf_utils_test.cc, because the OpenVINO EP
+  # is a dynamically-loaded module and is not statically linked into the test binary.
   list(APPEND onnxruntime_provider_test_srcs
        ${ONNXRUNTIME_ROOT}/core/providers/openvino/ov_protobuf_utils.cpp)
 endif()

--- a/onnxruntime/core/providers/openvino/ov_protobuf_utils.cpp
+++ b/onnxruntime/core/providers/openvino/ov_protobuf_utils.cpp
@@ -41,7 +41,7 @@ void set_float_initializer_data(const void* initializer, float data) {
 
   ORT_ENFORCE(tp->has_raw_data() && tp->raw_data().size() >= sizeof(float),
               "FLOAT initializer has neither float_data nor sufficient raw_data to write a value");
-  std::memcpy(tp->mutable_raw_data()->data(), &data, sizeof(float));
+  tp->set_raw_data(&data, sizeof(float));
 }
 }  // namespace openvino_ep
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/openvino/ov_protobuf_utils.cpp
+++ b/onnxruntime/core/providers/openvino/ov_protobuf_utils.cpp
@@ -16,7 +16,7 @@ float get_float_initializer_data(const void* initializer) {
 
   // A FLOAT scalar/tensor may store its value either in the typed float_data
   // field or in raw_data. Indexing float_data(0) when it is empty is undefined
-  // behaviour, so pick the field that actually holds the data.
+  // behavior, so pick the field that actually holds the data.
   if (tp->float_data_size() > 0) {
     return tp->float_data(0);
   }

--- a/onnxruntime/core/providers/openvino/ov_protobuf_utils.cpp
+++ b/onnxruntime/core/providers/openvino/ov_protobuf_utils.cpp
@@ -3,6 +3,8 @@
 
 #include "ov_protobuf_utils.h"
 
+#include <cstring>
+
 #include "core/graph/onnx_protobuf.h"
 #include "core/common/common.h"
 
@@ -11,14 +13,35 @@ namespace openvino_ep {
 float get_float_initializer_data(const void* initializer) {
   const auto* tp = reinterpret_cast<const ONNX_NAMESPACE::TensorProto*>(initializer);
   ORT_ENFORCE((tp->has_data_type() && (tp->data_type() == ONNX_NAMESPACE::TensorProto_DataType_FLOAT)));
-  // ORT_ENFORCE(initializer.dims_size() == 1);
-  return tp->float_data(0);
+
+  // A FLOAT scalar/tensor may store its value either in the typed float_data
+  // field or in raw_data. Indexing float_data(0) when it is empty is undefined
+  // behaviour, so pick the field that actually holds the data.
+  if (tp->float_data_size() > 0) {
+    return tp->float_data(0);
+  }
+
+  ORT_ENFORCE(tp->has_raw_data() && tp->raw_data().size() >= sizeof(float),
+              "FLOAT initializer has neither float_data nor sufficient raw_data to read a value");
+  float value;
+  std::memcpy(&value, tp->raw_data().data(), sizeof(float));
+  return value;
 }
 void set_float_initializer_data(const void* initializer, float data) {
   auto* tp = (ONNX_NAMESPACE::TensorProto*)(initializer);
   ORT_ENFORCE((tp->has_data_type() && (tp->data_type() == ONNX_NAMESPACE::TensorProto_DataType_FLOAT)));
-  // ORT_ENFORCE(initializer.dims_size() == 1);
-  tp->set_float_data(0, data);
+
+  // Mirror get_float_initializer_data: write back into whichever storage the
+  // initializer actually uses. set_float_data(0, data) on an empty float_data
+  // field is an out-of-bounds write.
+  if (tp->float_data_size() > 0) {
+    tp->set_float_data(0, data);
+    return;
+  }
+
+  ORT_ENFORCE(tp->has_raw_data() && tp->raw_data().size() >= sizeof(float),
+              "FLOAT initializer has neither float_data nor sufficient raw_data to write a value");
+  std::memcpy(tp->mutable_raw_data()->data(), &data, sizeof(float));
 }
 }  // namespace openvino_ep
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/openvino/openvino_ov_protobuf_utils_test.cc
+++ b/onnxruntime/test/providers/openvino/openvino_ov_protobuf_utils_test.cc
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <cstring>
+
+#include "core/graph/onnx_protobuf.h"
+#include "core/providers/openvino/ov_protobuf_utils.h"
+
+#include "gtest/gtest.h"
+
+using namespace ONNX_NAMESPACE;
+
+namespace onnxruntime {
+namespace test {
+
+// Builds a FLOAT scalar whose value lives in raw_data, with an empty float_data
+// field.
+static TensorProto MakeRawDataFloatScalar(float value) {
+  TensorProto tp;
+  tp.set_data_type(TensorProto_DataType_FLOAT);
+  tp.set_raw_data(&value, sizeof(float));
+  return tp;
+}
+
+// Builds a FLOAT scalar whose value lives in the typed float_data field.
+static TensorProto MakeFloatDataScalar(float value) {
+  TensorProto tp;
+  tp.set_data_type(TensorProto_DataType_FLOAT);
+  tp.add_float_data(value);
+  return tp;
+}
+
+TEST(OpenVINO_OvProtobufUtils, GetFromRawData) {
+  TensorProto tp = MakeRawDataFloatScalar(4.0f);
+  ASSERT_EQ(tp.float_data_size(), 0);  // value is only in raw_data
+
+  EXPECT_FLOAT_EQ(openvino_ep::get_float_initializer_data(&tp), 4.0f);
+}
+
+TEST(OpenVINO_OvProtobufUtils, SetIntoRawData) {
+  TensorProto tp = MakeRawDataFloatScalar(4.0f);
+  ASSERT_EQ(tp.float_data_size(), 0);
+
+  openvino_ep::set_float_initializer_data(&tp, 0.5f);
+
+  // The write must land in raw_data (the field that actually holds the value),
+  // and must be readable back through the getter.
+  ASSERT_GE(tp.raw_data().size(), sizeof(float));
+  float stored;
+  std::memcpy(&stored, tp.raw_data().data(), sizeof(float));
+  EXPECT_FLOAT_EQ(stored, 0.5f);
+  EXPECT_FLOAT_EQ(openvino_ep::get_float_initializer_data(&tp), 0.5f);
+}
+
+TEST(OpenVINO_OvProtobufUtils, GetFromFloatData) {
+  TensorProto tp = MakeFloatDataScalar(3.0f);
+  EXPECT_FLOAT_EQ(openvino_ep::get_float_initializer_data(&tp), 3.0f);
+}
+
+TEST(OpenVINO_OvProtobufUtils, SetIntoFloatData) {
+  TensorProto tp = MakeFloatDataScalar(3.0f);
+  openvino_ep::set_float_initializer_data(&tp, 7.0f);
+  EXPECT_FLOAT_EQ(tp.float_data(0), 7.0f);
+  EXPECT_FLOAT_EQ(openvino_ep::get_float_initializer_data(&tp), 7.0f);
+}
+
+}  // namespace test
+}  // namespace onnxruntime


### PR DESCRIPTION
### Description

`get_float_initializer_data` / `set_float_initializer_data` assumed a float initializer always stores its value in the typed `float_data` field. When the value lives in `raw_data` instead, `float_data(0)` reads out of bounds and `set_float_data(0, ...)` writes out of bounds — both undefined behaviour.

Both functions now select the field that actually holds the data: use `float_data` when it is non-empty, otherwise read/write `raw_data` (guarded by size checks).

### Testing

Adds `openvino_ov_protobuf_utils_test.cc` covering get/set against both `float_data` and `raw_data` backed float scalars. Because the OpenVINO EP is built as a shared-library module with hidden symbols, `ov_protobuf_utils.cpp` is compiled directly into `onnxruntime_provider_test` so the tests can link.

