### PR TITLE
Fix LayerNorm fusion selecting the Div output as scale or bias

### DIFF
--- a/onnxruntime/core/optimizer/layer_norm_fusion.cc
+++ b/onnxruntime/core/optimizer/layer_norm_fusion.cc
@@ -464,9 +464,13 @@ Status LayerNormFusion::ApplyImpl(Graph& graph, bool& modified, int graph_level,
     // can be removed. This is one possible place a Cast Op can exist, that is between Div and Mul nodes.
     // div --> mul or div --> cast --> mul
     Node* next_node = graph.GetNode(div_node.OutputNodesBegin()->Index());
+    // The Mul input fed by the matched subgraph (Div output, or Cast output if a Cast follows Div).
+    // Its producer is removed by the fusion, so it is not a valid scale candidate.
+    const NodeArg* p_div_output = div_node.MutableOutputDefs()[0];
     if (graph_utils::IsSupportedOptypeVersionAndDomain(*next_node, "Cast", {9, 13, 19, 21, 23, 24, 25}) &&
         optimizer_utils::CheckOutputEdges(graph, *next_node, 1)) {
       nodes_to_remove.push_back(*next_node);
+      p_div_output = next_node->MutableOutputDefs()[0];
       next_node = graph.GetNode(next_node->OutputNodesBegin()->Index());
     }
     // Apex O2 pattern specific match ends...
@@ -522,7 +526,8 @@ Status LayerNormFusion::ApplyImpl(Graph& graph, bool& modified, int graph_level,
     NodeArg* scale = nullptr;
     NodeArg* bias = nullptr;
     for (size_t i = 0; i < mul_node.MutableInputDefs().size(); i++) {
-      if (mul_node.MutableInputDefs()[i]->Shape() == nullptr) {
+      if (mul_node.MutableInputDefs()[i]->Shape() == nullptr ||
+          mul_node.MutableInputDefs()[i] == p_div_output) {
         continue;
       }
       if (mul_node.MutableInputDefs()[i]->Shape()->dim_size() == static_cast<int>(axes_values.size())) {
@@ -531,7 +536,9 @@ Status LayerNormFusion::ApplyImpl(Graph& graph, bool& modified, int graph_level,
     }
 
     for (size_t i = 0; i < last_add_node.MutableInputDefs().size(); i++) {
-      if (last_add_node.MutableInputDefs()[i]->Shape() == nullptr) {
+      // The Mul output is removed by the fusion, so it is not a valid bias candidate.
+      if (last_add_node.MutableInputDefs()[i]->Shape() == nullptr ||
+          last_add_node.MutableInputDefs()[i] == mul_node.MutableOutputDefs()[0]) {
         continue;
       }
       if (last_add_node.MutableInputDefs()[i]->Shape()->dim_size() == static_cast<int>(axes_values.size())) {
@@ -752,10 +759,14 @@ Status SimplifiedLayerNormFusion::ApplyImpl(Graph& graph, bool& modified, int gr
 
     // div --> mul or div --> cast --> mul
     Node* next_node = graph.GetNode(div_node.OutputNodesBegin()->Index());
+    // The Mul input fed by the matched subgraph (Div output, or Cast output if a Cast follows Div).
+    // Its producer is removed by the fusion, so it is not a valid scale candidate.
+    const NodeArg* p_div_output = div_node.MutableOutputDefs()[0];
     if (graph_utils::IsSupportedOptypeVersionAndDomain(*next_node, "Cast", {9, 13, 19, 21, 23, 24, 25}) &&
         optimizer_utils::CheckOutputEdges(graph, *next_node, 1)) {
       if (!is_gpu_ep) continue;
       nodes_to_remove.push_back(*next_node);
+      p_div_output = next_node->MutableOutputDefs()[0];
       next_node = graph.GetNode(next_node->OutputNodesBegin()->Index());
     }
 
@@ -792,7 +803,8 @@ Status SimplifiedLayerNormFusion::ApplyImpl(Graph& graph, bool& modified, int gr
     // because SkipLayerNorm kernel, for example, has dependency on single dim size
     NodeArg* scale = nullptr;
     for (size_t i = 0; i < mul_node.MutableInputDefs().size(); i++) {
-      if (mul_node.MutableInputDefs()[i]->Shape() == nullptr) {
+      if (mul_node.MutableInputDefs()[i]->Shape() == nullptr ||
+          mul_node.MutableInputDefs()[i] == p_div_output) {
         continue;
       }
 #ifdef ENABLE_TRAINING_CORE

--- a/onnxruntime/test/optimizer/graph_transform_test_layernorm.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test_layernorm.cc
@@ -466,6 +466,61 @@ TEST_F(GraphTransformationTests, LayerNormWithCastFusionTest_9) {
                                         TransformerLevel::Level2, 1, nullptr, post_graph_checker));
 }
 
+// Regression test for GitHub issue #30513. The Div output is rank-1 while the real Mul operand is 2-D,
+// so scale selection by rank used to pick the Div output as scale. Div is removed by the fusion, which
+// left the fused node with a dangling input and failed graph resolve. keepdims=1 shows the defect is
+// independent of the keepdims=0 mis-fusion issue.
+TEST_F(GraphTransformationTests, LayerNormFusionSkipsDivOutputAsScale) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    auto* input = builder.MakeInput<float>({{4}});
+    auto* mul_operand = builder.MakeInput<float>({{4, 1}});
+    auto* bias = builder.MakeInput<float>({{4}});
+    auto* pow_exponent = builder.MakeInitializer<float>({}, {2.0f});
+    auto* epsilon = builder.MakeInitializer<float>({}, {1e-5f});
+
+    auto* reduce_mean_out = builder.MakeIntermediate();
+    auto* sub_out = builder.MakeIntermediate();
+    auto* pow_out = builder.MakeIntermediate();
+    auto* reduce_mean2_out = builder.MakeIntermediate();
+    auto* add_out = builder.MakeIntermediate();
+    auto* sqrt_out = builder.MakeIntermediate();
+    auto* div_out = builder.MakeIntermediate();
+    auto* mul_out = builder.MakeIntermediate();
+    auto* output = builder.MakeOutput();
+
+    builder.AddNode("ReduceMean", {input}, {reduce_mean_out})
+        .AddAttribute("axes", std::vector<int64_t>{-1})
+        .AddAttribute("keepdims", static_cast<int64_t>(1));
+    builder.AddNode("Sub", {input, reduce_mean_out}, {sub_out});
+    builder.AddNode("Pow", {sub_out, pow_exponent}, {pow_out});
+    builder.AddNode("ReduceMean", {pow_out}, {reduce_mean2_out})
+        .AddAttribute("axes", std::vector<int64_t>{-1})
+        .AddAttribute("keepdims", static_cast<int64_t>(1));
+    builder.AddNode("Add", {reduce_mean2_out, epsilon}, {add_out});
+    builder.AddNode("Sqrt", {add_out}, {sqrt_out});
+    builder.AddNode("Div", {sub_out, sqrt_out}, {div_out});
+    builder.AddNode("Mul", {div_out, mul_operand}, {mul_out});
+    builder.AddNode("Add", {mul_out, bias}, {output});
+  };
+
+  auto post_graph_checker = [](Graph& graph) {
+    ORT_RETURN_IF_ERROR(graph.Resolve());
+    auto op_to_count = CountOpsInGraph(graph);
+    TEST_RETURN_IF_NOT(op_to_count["LayerNormalization"] == 0);
+    TEST_RETURN_IF_NOT(op_to_count["Div"] == 1);
+    TEST_RETURN_IF_NOT(op_to_count["Mul"] == 1);
+    return Status::OK();
+  };
+
+  const InlinedHashSet<std::string_view> no_limit_empty_ep_list = {};
+  ASSERT_STATUS_OK(TestGraphTransformer(build_test_case, 17, *logger_, std::make_unique<LayerNormFusion>(),
+                                        TransformerLevel::Level1, 1, nullptr, post_graph_checker));
+  ASSERT_STATUS_OK(TestGraphTransformer(
+      build_test_case, 14, *logger_,
+      std::make_unique<LayerNormFusion>(no_limit_empty_ep_list, TransformerLevel::Level2),
+      TransformerLevel::Level2, 1, nullptr, post_graph_checker));
+}
+
 TEST_F(GraphTransformationTests, SimplifiedLayerNormFusionTest) {
   constexpr const ORTCHAR_T* model_uri = MODEL_FOLDER "fusion/layer_norm_t5.onnx";
   std::shared_ptr<Model> p_model;
@@ -730,6 +785,49 @@ TEST_F(GraphTransformationTests, SimplifiedLayerNormFusionRequiresPowExponentTwo
         std::make_unique<SimplifiedLayerNormFusion>(),
         TransformerLevel::Level2, 1, nullptr, post_graph_checker));
   }
+}
+
+// Regression test for GitHub issue #30513. The Div output is rank-1 while the real Mul operand is 2-D,
+// so scale selection by rank used to pick the Div output as scale. Div is removed by the fusion, which
+// left the fused node with a dangling input and failed graph resolve. keepdims=1 shows the defect is
+// independent of the keepdims=0 mis-fusion issue.
+TEST_F(GraphTransformationTests, SimplifiedLayerNormFusionSkipsDivOutputAsScale) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    auto* input = builder.MakeInput<float>({{4}});
+    auto* mul_operand = builder.MakeInput<float>({{4, 1}});
+    auto* pow_exponent = builder.MakeInitializer<float>({}, {2.0f});
+    auto* epsilon = builder.MakeInitializer<float>({}, {1e-5f});
+
+    auto* pow_out = builder.MakeIntermediate();
+    auto* reduce_mean_out = builder.MakeIntermediate();
+    auto* add_out = builder.MakeIntermediate();
+    auto* sqrt_out = builder.MakeIntermediate();
+    auto* div_out = builder.MakeIntermediate();
+    auto* output = builder.MakeOutput();
+
+    builder.AddNode("Pow", {input, pow_exponent}, {pow_out});
+    builder.AddNode("ReduceMean", {pow_out}, {reduce_mean_out})
+        .AddAttribute("axes", std::vector<int64_t>{-1})
+        .AddAttribute("keepdims", static_cast<int64_t>(1));
+    builder.AddNode("Add", {reduce_mean_out, epsilon}, {add_out});
+    builder.AddNode("Sqrt", {add_out}, {sqrt_out});
+    builder.AddNode("Div", {input, sqrt_out}, {div_out});
+    builder.AddNode("Mul", {div_out, mul_operand}, {output});
+  };
+
+  auto post_graph_checker = [](Graph& graph) {
+    ORT_RETURN_IF_ERROR(graph.Resolve());
+    auto op_to_count = CountOpsInGraph(graph);
+    TEST_RETURN_IF_NOT(op_to_count["SimplifiedLayerNormalization"] == 0);
+    TEST_RETURN_IF_NOT(op_to_count["Div"] == 1);
+    TEST_RETURN_IF_NOT(op_to_count["Mul"] == 1);
+    return Status::OK();
+  };
+
+  ASSERT_STATUS_OK(TestGraphTransformer(
+      build_test_case, 17, *logger_,
+      std::make_unique<SimplifiedLayerNormFusion>(),
+      TransformerLevel::Level2, 1, nullptr, post_graph_checker));
 }
 
 TEST_F(GraphTransformationTests, SimplifiedLayerNormFusionOptimizationLoopSharedPowExponent) {


### PR DESCRIPTION
Fixes #31147.

The scale selection in LayerNormFusion and SimplifiedLayerNormFusion picks a Mul input by rank alone, so a rank-1 Div output can be chosen as scale. The fusion removes the Div and the fused node references a dangling input, failing session creation with "Node input 'nm' is not a graph input, initializer, or output of a previous node". The bias loop can pick the Mul output the same way. This reproduces with keepdims=1, so it is separate from #31144.

The fix excludes operands produced inside the matched subgraph from scale and bias candidacy; when none remain, the fusion is skipped. Valid fusions are unaffected because a real scale always comes from outside the chain. Two negative tests added, one per fusion class; both fail before the change. No local C++ build available, so CI is the executable check.
