### PR TITLE
Skip redundant present_key/value copy when aliased to external KV cache (follow-up to #29715)

### DIFF
--- a/onnxruntime/core/providers/cuda/llm/attention.cc
+++ b/onnxruntime/core/providers/cuda/llm/attention.cc
@@ -51,6 +51,28 @@ bool HasOutput(const NodeType& node, size_t output_index) {
 // A stable, greppable log tag for tests to detect that the redundant present-copy was skipped.
 constexpr const char* kPresentCopySkippedTag = "present_copy_skipped";
 
+// Returns the SESSION logger for a kernel, so kernel logging honours this session's
+// log_severity_level / logid instead of the process-global default logger.
+//
+// OpKernelContext::Logger() is not reachable from an execution provider compiled as a shared
+// provider (the bridged OpKernelContext in core/providers/shared_library/provider_wrappedtypes.h
+// does not expose it), so the logger is taken from the kernel's execution provider instead:
+// InferenceSession::RegisterExecutionProvider calls IExecutionProvider::SetLogger with the session
+// logger, so this is the same logger the session's own log severity configures. Falls back to the
+// default logger only if the EP has no logger set (not expected during Compute).
+//
+// Known limitation: this assumes the EP instance is exclusively owned by one session's lifetime.
+// That holds for the standard CUDA EP registration path — CUDAProviderFactory::CreateProvider()
+// (core/providers/cuda/cuda_provider_factory.cc) constructs a fresh provider per session — but it
+// would not hold if a raw IExecutionProvider instance were manually shared across sessions (as
+// e.g. the XNNPACK EP supports), since IExecutionProvider::SetLogger stores an unsynchronized raw
+// pointer that each RegisterExecutionProvider call overwrites. Closing that gap would require
+// exposing OpKernelContext::Logger() through the shared-library provider bridge.
+inline const logging::Logger& KernelSessionLogger(const OpKernelInfo& info) {
+  const logging::Logger* logger = info.GetExecutionProvider()->GetLogger();
+  return logger != nullptr ? *logger : logging::LoggingManager::DefaultLogger();
+}
+
 // Copies a 4-D BNSH KV tensor into the corresponding present_* output, unless the two
 // tensors already point at the SAME device buffer.
 //
@@ -76,21 +98,22 @@ constexpr const char* kPresentCopySkippedTag = "present_copy_skipped";
 // NOT applicable to 3-D BSNH inputs: those need a layout-changing transpose, so src and dst
 // can never alias there and the transpose must always run. Callers must only use this helper
 // from the !is_bsnh (4-D BNSH) branches, and only where past_sequence_length == 0 is already
-// guaranteed; the ORT_ENFORCE below is a defensive check against a future caller (e.g. a
+// guaranteed; the ORT_RETURN_IF_NOT below is a defensive check against a future caller (e.g. a
 // revived internal-cache/Phase-2 cuDNN decode path) using this helper outside that precondition,
 // where present_key/value can be strictly larger than K/V and a bare pointer-equality check
 // would otherwise silently under-copy or wrongly skip.
 //
 // `dst == nullptr` (present output not requested by the caller) is a no-op.
-inline Status CopyKVToPresent(const Tensor* src, Tensor* dst, cudaStream_t stream) {
+inline Status CopyKVToPresent(const Tensor* src, Tensor* dst, cudaStream_t stream,
+                              const logging::Logger& logger) {
   if (dst == nullptr) {
     return Status::OK();
   }
-  ORT_ENFORCE(src->SizeInBytes() == dst->SizeInBytes(),
-              "CopyKVToPresent requires identical src/dst sizes; this only holds when "
-              "past_sequence_length == 0 (see callers' gating).");
+  ORT_RETURN_IF_NOT(src->SizeInBytes() == dst->SizeInBytes(),
+                    "CopyKVToPresent requires identical src/dst sizes; this only holds when "
+                    "past_sequence_length == 0 (see callers' gating).");
   if (src->DataRaw() == dst->MutableDataRaw()) {
-    LOGS_DEFAULT(VERBOSE) << "Attention: " << kPresentCopySkippedTag
+    LOGS(logger, VERBOSE) << "Attention: " << kPresentCopySkippedTag
                           << " (present output aliases the input KV cache buffer).";
     return Status::OK();
   }
@@ -558,6 +581,7 @@ Status Attention<T>::RunFlashAttention(
 
   // --- Populate present_key/value (BNSH) from K/V (BSNH or BNSH) ---
   // Skip for decode path where mha_fwd_kvcache already populated present buffers.
+  const logging::Logger& kv_copy_logger = llm_attention_detail::KernelSessionLogger(Info());
   if (!present_kv_already_populated) {
     if (present_key != nullptr && is_bsnh) {
       ORT_RETURN_IF_ERROR(TransposeBSNHtoBNSH<T>(
@@ -567,7 +591,7 @@ Status Attention<T>::RunFlashAttention(
           cuda_stream, device_prop.maxThreadsPerBlock));
     } else if (present_key != nullptr && !is_bsnh) {
       // present output may alias the cache buffer; see CopyKVToPresent.
-      ORT_RETURN_IF_ERROR(llm_attention_detail::CopyKVToPresent(K, present_key, cuda_stream));
+      ORT_RETURN_IF_ERROR(llm_attention_detail::CopyKVToPresent(K, present_key, cuda_stream, kv_copy_logger));
     }
     if (present_value != nullptr && is_bsnh) {
       ORT_RETURN_IF_ERROR(TransposeBSNHtoBNSH<T>(
@@ -577,7 +601,7 @@ Status Attention<T>::RunFlashAttention(
           cuda_stream, device_prop.maxThreadsPerBlock));
     } else if (present_value != nullptr && !is_bsnh) {
       // present output may alias the cache buffer; see CopyKVToPresent.
-      ORT_RETURN_IF_ERROR(llm_attention_detail::CopyKVToPresent(V, present_value, cuda_stream));
+      ORT_RETURN_IF_ERROR(llm_attention_detail::CopyKVToPresent(V, present_value, cuda_stream, kv_copy_logger));
     }
   }
 
@@ -787,6 +811,7 @@ Status Attention<T>::RunCudnnSdpaAttention(
   // K/V are the full external cache after TensorScatter; mirror RunFlashAttention's Path-1/prompt
   // population (transpose BSNH→BNSH for 3D inputs, D2D copy for 4D BNSH inputs). For 4D BNSH the
   // copy is skipped when present_* aliases the K/V buffer (see CopyKVToPresent). ---
+  const logging::Logger& kv_copy_logger = llm_attention_detail::KernelSessionLogger(Info());
   if (present_key != nullptr && is_bsnh) {
     ORT_RETURN_IF_ERROR(TransposeBSNHtoBNSH<T>(
         parameters.batch_size, parameters.kv_sequence_length,
@@ -794,7 +819,7 @@ Status Attention<T>::RunCudnnSdpaAttention(
         K->Data<T>(), present_key->MutableData<T>(),
         cuda_stream, device_prop.maxThreadsPerBlock));
   } else if (present_key != nullptr && !is_bsnh) {
-    ORT_RETURN_IF_ERROR(llm_attention_detail::CopyKVToPresent(K, present_key, cuda_stream));
+    ORT_RETURN_IF_ERROR(llm_attention_detail::CopyKVToPresent(K, present_key, cuda_stream, kv_copy_logger));
   }
   if (present_value != nullptr && is_bsnh) {
     ORT_RETURN_IF_ERROR(TransposeBSNHtoBNSH<T>(
@@ -803,7 +828,7 @@ Status Attention<T>::RunCudnnSdpaAttention(
         V->Data<T>(), present_value->MutableData<T>(),
         cuda_stream, device_prop.maxThreadsPerBlock));
   } else if (present_value != nullptr && !is_bsnh) {
-    ORT_RETURN_IF_ERROR(llm_attention_detail::CopyKVToPresent(V, present_value, cuda_stream));
+    ORT_RETURN_IF_ERROR(llm_attention_detail::CopyKVToPresent(V, present_value, cuda_stream, kv_copy_logger));
   }
 
   return Status::OK();
@@ -1228,6 +1253,7 @@ Status Attention<T>::RunMemoryEfficientAttention(
 
   // Populate present_key/present_value (BNSH) if requested.
   // Skip for decode path where LaunchConcatNewToPastKV already populated present buffers.
+  const logging::Logger& kv_copy_logger = llm_attention_detail::KernelSessionLogger(Info());
   if (!present_kv_already_populated) {
     if (present_key != nullptr && is_bsnh) {
       ORT_RETURN_IF_ERROR(TransposeBSNHtoBNSH<T>(
@@ -1237,7 +1263,7 @@ Status Attention<T>::RunMemoryEfficientAttention(
           cuda_stream, device_prop.maxThreadsPerBlock));
     } else if (present_key != nullptr && !is_bsnh) {
       // present output may alias the cache buffer; see CopyKVToPresent.
-      ORT_RETURN_IF_ERROR(llm_attention_detail::CopyKVToPresent(K, present_key, cuda_stream));
+      ORT_RETURN_IF_ERROR(llm_attention_detail::CopyKVToPresent(K, present_key, cuda_stream, kv_copy_logger));
     }
     if (present_value != nullptr && is_bsnh) {
       ORT_RETURN_IF_ERROR(TransposeBSNHtoBNSH<T>(
@@ -1247,7 +1273,7 @@ Status Attention<T>::RunMemoryEfficientAttention(
           cuda_stream, device_prop.maxThreadsPerBlock));
     } else if (present_value != nullptr && !is_bsnh) {
       // present output may alias the cache buffer; see CopyKVToPresent.
-      ORT_RETURN_IF_ERROR(llm_attention_detail::CopyKVToPresent(V, present_value, cuda_stream));
+      ORT_RETURN_IF_ERROR(llm_attention_detail::CopyKVToPresent(V, present_value, cuda_stream, kv_copy_logger));
     }
   }
 
@@ -1523,6 +1549,7 @@ Status Attention<T>::RunUnfusedAttention(
   }
 
   // -------- Populate present_key/present_value if requested ------------------
+  const logging::Logger& kv_copy_logger = llm_attention_detail::KernelSessionLogger(Info());
   if (!present_already_populated) {
     if (present_key != nullptr) {
       if (is_bsnh) {
@@ -1531,7 +1558,7 @@ Status Attention<T>::RunUnfusedAttention(
                                                    cuda_stream, max_threads));
       } else {
         // present output may alias the cache buffer; see CopyKVToPresent.
-        ORT_RETURN_IF_ERROR(llm_attention_detail::CopyKVToPresent(K, present_key, cuda_stream));
+        ORT_RETURN_IF_ERROR(llm_attention_detail::CopyKVToPresent(K, present_key, cuda_stream, kv_copy_logger));
       }
     }
     if (present_value != nullptr) {
@@ -1541,7 +1568,7 @@ Status Attention<T>::RunUnfusedAttention(
                                                    cuda_stream, max_threads));
       } else {
         // present output may alias the cache buffer; see CopyKVToPresent.
-        ORT_RETURN_IF_ERROR(llm_attention_detail::CopyKVToPresent(V, present_value, cuda_stream));
+        ORT_RETURN_IF_ERROR(llm_attention_detail::CopyKVToPresent(V, present_value, cuda_stream, kv_copy_logger));
       }
     }
   }
@@ -1725,61 +1752,18 @@ Status Attention<T>::ComputeInternal(OpKernelContext* context) const {
   }
 
   // NOTE (Phase 2 — internal past_key/present_key decode cache — investigated and abandoned):
-  // A cuDNN SDPA dispatch for the internal-cache contract (past_key/past_value in, present_key/
-  // present_value out, no nonpad_kv_seqlen) was prototyped on branch copilot/cudnn-sdpa-decode-phase2
-  // and reviewed, but deliberately NOT merged. Root cause: unlike Path 1's nonpad_kv_seqlen (an
-  // opset-24 EXTERNAL cache with a caller-owned, fixed-capacity buffer) or the contrib
-  // GroupQueryAttention op (whose present_key/value ARE the same fixed-capacity buffer as past_key/
-  // value, reused in place across decode steps, with the valid length passed separately via a
-  // seqlens tensor), the standard ONNX Attention op's INTERNAL cache has no capacity concept: the
-  // spec defines present_key/present_value shape as exactly past_sequence_length + kv_sequence_length,
-  // growing by exactly one token every decode step. cuDNN's frontend graph API is a "build once, run
-  // many times" model — cudnn_flash_attention.cc's mha_graph_cache is keyed (among other fields) on
-  // sequence_length_kv, so a per-step-growing shape produces a cache miss on every single call,
-  // forcing a full graph rebuild (heuristic search + plan build) every decode step instead of reusing
-  // a cached plan. Measured on A100/cuDNN 9.8: ~260-330ms per decode step for this cuDNN path vs.
-  // ~165-175us/step for Flash/MEA in the same realistic, single-session, growing-past_key loop — a
-  // ~1600x regression, and this tier is dispatched ABOVE Flash/MEA in the cascade. Making this path
-  // viable would require reproducing the GQA pattern here too (over-allocate present_key/value to a
-  // fixed capacity bucket, pass a per-batch valid-length mask to cuDNN, then copy the exact
-  // spec-sized region back out) — a nontrivial redesign, not attempted. See issue #29714 for the
-  // full writeup and benchmark data before reviving this path.
+  // A cuDNN SDPA dispatch for the internal (past_key/present_key) cache was prototyped and rejected:
+  // the ONNX spec grows present_key by one token per decode step, which misses cuDNN's
+  // sequence_length_kv-keyed graph-plan cache every call and forces a full graph rebuild (~1600x
+  // slower per step than Flash/MEA). See issue #29714 for the full investigation writeup and
+  // benchmark data.
 
   // NOTE (Phase 3 — cuDNN SDPA prefill via fixed-size query-row chunking — investigated and
-  // abandoned): A cuDNN SDPA dispatch for prefill (q_sequence_length > 1) was prototyped on branch
-  // copilot/cudnn-sdpa-decode-phase3, splitting the query rows into fixed-size, left-padded chunks
-  // (a configurable, session-lifetime-constant size) so every chunk presents cuDNN's frontend with a
-  // stable sequence_length_q, preserving the graph-plan-cache-key stability Path 1's decode dispatch
-  // and Phase 2's investigation both depend on. Passing the real, varying prompt length directly
-  // (mirroring the contrib GroupQueryAttention op's un-chunked cuDNN prefill path) was measured to
-  // cost ~575-590us EVERY call with a distinct shape on A100/cuDNN 9.8 (no amortization — a
-  // one-time-per-request cost paid directly against time-to-first-token), a ~300-500x regression
-  // versus the chunked design's ~1.2-2ms warm cost, confirming chunking is necessary, not
-  // over-engineering, for any cuDNN-prefill design on this hardware/cuDNN version.
-  //
-  // The chunked design itself passed two full independent review rounds (readability, code, critical,
-  // deep spec-adherence incl. a 2246-configuration sweep of the causal-frontier algebra, cross-module
-  // integration, and QA/compute-sanitizer) with zero correctness defects found across both rounds.
-  // It was deliberately NOT merged for a value-proposition reason, not a correctness reason:
-  //   * Measured speedup over the existing MATH fallback (the path this shape class already uses
-  //     without this tier) was only ~0.94x-1.15x on A100 — within noise for short prompts (<=256
-  //     query rows, actually slightly SLOWER than MATH there) and a modest ~10-15% win only for long
-  //     prompts (>=512-1000 rows). Against Flash Attention on symmetric head_size shapes, cuDNN
-  //     prefill was roughly at parity, not a win.
-  //   * GroupQueryAttention's own cuDNN prefill path — and this prototype, which mirrored GQA's
-  //     dispatch gate for consistency — is only auto-enabled on SM>=90 (Hopper/Blackwell); it is
-  //     inert by default on SM80 (A100), the only hardware this investigation had available. The
-  //     benefit case for the hardware where this tier would actually activate by default was never
-  //     validated.
-  //   * The chunking algorithm's cache-key-stability invariants (fixed chunk size as a proxy for a
-  //     real, per-call-varying prompt length; the s_q>=chunk/2 floor bounding wasted compute/memory
-  //     to <=2x; the first_chunk skip bound) are subtle, proven correct by exhaustive sweep, but
-  //     nontrivial for future maintainers to preserve without re-deriving the same algebra.
-  // Net: a correctness-safe but performance-marginal feature, gated behind hardware this
-  // investigation could not confirm the benefit on. Revive only alongside H200/Hopper+ validation of
-  // the auto-enable default path, and re-evaluate the value proposition against then-current
-  // MATH/Flash/MEA baselines. See issue #29714 for the full writeup, chunk-size sweep, and benchmark
-  // data before reviving this path.
+  // abandoned): A chunked cuDNN prefill dispatch (fixed-size, left-padded query-row chunks, needed
+  // to keep cuDNN's graph-plan cache key stable) was prototyped and found correct, but measured only
+  // ~0.94x-1.15x versus the existing MATH fallback on A100, and the auto-enable gate only fires on
+  // SM>=90 hardware unavailable for this investigation — not worth the complexity. See issue #29714
+  // for the full investigation writeup and benchmark data.
 
 #if USE_FLASH_ATTENTION
   {

--- a/onnxruntime/core/providers/cuda/llm/attention.cc
+++ b/onnxruntime/core/providers/cuda/llm/attention.cc
@@ -54,25 +54,41 @@ constexpr const char* kPresentCopySkippedTag = "present_copy_skipped";
 // Copies a 4-D BNSH KV tensor into the corresponding present_* output, unless the two
 // tensors already point at the SAME device buffer.
 //
+// This helper is only ever reached with past_sequence_length == 0 (see the callers'
+// present_kv_already_populated / ORT_ENFORCE(past_sequence_length == 0) gating), which by
+// ComputeOutputShapeForAttention (onnxruntime/core/providers/cpu/llm/attention_helper.h)
+// forces present_key/value's shape to be IDENTICAL to K/V's shape, not merely equal in byte
+// count. That is also the case ONNX's own Attention-24 reference semantics require
+// present_key == Identity(K) (and present_value == Identity(V)) when there is no past — so
+// skipping a self-copy here isn't just an optimization, it is a faithful in-place identity.
+//
 // On the external-KV-cache path (nonpad_kv_seqlen), TensorScatter declares .MayInplace(0, 0)
 // and its own ComputeInternal explicitly skips the analogous self-copy (see
-// onnxruntime/core/providers/cuda/llm/tensorscatter.cc). The recommended production pattern
-// binds one device buffer as the cache input, the TensorScatter output, AND the Attention
-// present_* output (mirroring GroupQueryAttention's past_key==present_key shared-buffer
-// pattern, contrib_ops/cuda/bert/group_query_attention.cc:423). In that case `src` and `dst`
-// are literally the same allocation: the data is already correct in place, and copying it is
-// a full-cache self-copy — wasted bandwidth, and technically UB (cudaMemcpyAsync requires
-// non-overlapping src/dst). Skip it.
+// onnxruntime/core/providers/cuda/llm/tensorscatter.cc). An ORT-specific production pattern
+// (a superset of what the ONNX spec documents for this combination) binds one device buffer
+// as the cache input, the TensorScatter output, AND the Attention present_* output (mirroring
+// GroupQueryAttention's past_key==present_key shared-buffer pattern, see the past_key_shared
+// aliasing check in GroupQueryAttention::ComputeInternal). In that case `src` and `dst` are
+// literally the same allocation: the data is already correct in place, and copying it is a
+// full-cache self-copy — wasted bandwidth, and technically UB (cudaMemcpyAsync requires
+// non-overlapping src/dst).
 //
 // NOT applicable to 3-D BSNH inputs: those need a layout-changing transpose, so src and dst
 // can never alias there and the transpose must always run. Callers must only use this helper
-// from the !is_bsnh (4-D BNSH) branches.
+// from the !is_bsnh (4-D BNSH) branches, and only where past_sequence_length == 0 is already
+// guaranteed; the ORT_ENFORCE below is a defensive check against a future caller (e.g. a
+// revived internal-cache/Phase-2 cuDNN decode path) using this helper outside that precondition,
+// where present_key/value can be strictly larger than K/V and a bare pointer-equality check
+// would otherwise silently under-copy or wrongly skip.
 //
 // `dst == nullptr` (present output not requested by the caller) is a no-op.
 inline Status CopyKVToPresent(const Tensor* src, Tensor* dst, cudaStream_t stream) {
   if (dst == nullptr) {
     return Status::OK();
   }
+  ORT_ENFORCE(src->SizeInBytes() == dst->SizeInBytes(),
+              "CopyKVToPresent requires identical src/dst sizes; this only holds when "
+              "past_sequence_length == 0 (see callers' gating).");
   if (src->DataRaw() == dst->MutableDataRaw()) {
     LOGS_DEFAULT(VERBOSE) << "Attention: " << kPresentCopySkippedTag
                           << " (present output aliases the input KV cache buffer).";
@@ -550,8 +566,7 @@ Status Attention<T>::RunFlashAttention(
           K->Data<T>(), present_key->MutableData<T>(),
           cuda_stream, device_prop.maxThreadsPerBlock));
     } else if (present_key != nullptr && !is_bsnh) {
-      // 4D BNSH: K is already BNSH, so a D2D copy to present suffices — but skip it entirely
-      // when present_key IS the K cache buffer (external-cache path with an aliased output).
+      // present output may alias the cache buffer; see CopyKVToPresent.
       ORT_RETURN_IF_ERROR(llm_attention_detail::CopyKVToPresent(K, present_key, cuda_stream));
     }
     if (present_value != nullptr && is_bsnh) {
@@ -561,8 +576,7 @@ Status Attention<T>::RunFlashAttention(
           V->Data<T>(), present_value->MutableData<T>(),
           cuda_stream, device_prop.maxThreadsPerBlock));
     } else if (present_value != nullptr && !is_bsnh) {
-      // 4D BNSH: V is already BNSH, so a D2D copy to present suffices — but skip it entirely
-      // when present_value IS the V cache buffer (external-cache path with an aliased output).
+      // present output may alias the cache buffer; see CopyKVToPresent.
       ORT_RETURN_IF_ERROR(llm_attention_detail::CopyKVToPresent(V, present_value, cuda_stream));
     }
   }
@@ -1222,8 +1236,7 @@ Status Attention<T>::RunMemoryEfficientAttention(
           K->Data<T>(), present_key->MutableData<T>(),
           cuda_stream, device_prop.maxThreadsPerBlock));
     } else if (present_key != nullptr && !is_bsnh) {
-      // 4D BNSH: K is already BNSH, so a D2D copy to present suffices — but skip it entirely
-      // when present_key IS the K cache buffer (external-cache path with an aliased output).
+      // present output may alias the cache buffer; see CopyKVToPresent.
       ORT_RETURN_IF_ERROR(llm_attention_detail::CopyKVToPresent(K, present_key, cuda_stream));
     }
     if (present_value != nullptr && is_bsnh) {
@@ -1233,8 +1246,7 @@ Status Attention<T>::RunMemoryEfficientAttention(
           V->Data<T>(), present_value->MutableData<T>(),
           cuda_stream, device_prop.maxThreadsPerBlock));
     } else if (present_value != nullptr && !is_bsnh) {
-      // 4D BNSH: V is already BNSH, so a D2D copy to present suffices — but skip it entirely
-      // when present_value IS the V cache buffer (external-cache path with an aliased output).
+      // present output may alias the cache buffer; see CopyKVToPresent.
       ORT_RETURN_IF_ERROR(llm_attention_detail::CopyKVToPresent(V, present_value, cuda_stream));
     }
   }
@@ -1518,6 +1530,7 @@ Status Attention<T>::RunUnfusedAttention(
                                                    K->Data<T>(), present_key->MutableData<T>(),
                                                    cuda_stream, max_threads));
       } else {
+        // present output may alias the cache buffer; see CopyKVToPresent.
         ORT_RETURN_IF_ERROR(llm_attention_detail::CopyKVToPresent(K, present_key, cuda_stream));
       }
     }
@@ -1527,6 +1540,7 @@ Status Attention<T>::RunUnfusedAttention(
                                                    V->Data<T>(), present_value->MutableData<T>(),
                                                    cuda_stream, max_threads));
       } else {
+        // present output may alias the cache buffer; see CopyKVToPresent.
         ORT_RETURN_IF_ERROR(llm_attention_detail::CopyKVToPresent(V, present_value, cuda_stream));
       }
     }

--- a/onnxruntime/core/providers/cuda/llm/attention.cc
+++ b/onnxruntime/core/providers/cuda/llm/attention.cc
@@ -48,6 +48,41 @@ bool HasOutput(const NodeType& node, size_t output_index) {
   }
 }
 
+// A stable, greppable log tag for tests to detect that the redundant present-copy was skipped.
+constexpr const char* kPresentCopySkippedTag = "present_copy_skipped";
+
+// Copies a 4-D BNSH KV tensor into the corresponding present_* output, unless the two
+// tensors already point at the SAME device buffer.
+//
+// On the external-KV-cache path (nonpad_kv_seqlen), TensorScatter declares .MayInplace(0, 0)
+// and its own ComputeInternal explicitly skips the analogous self-copy (see
+// onnxruntime/core/providers/cuda/llm/tensorscatter.cc). The recommended production pattern
+// binds one device buffer as the cache input, the TensorScatter output, AND the Attention
+// present_* output (mirroring GroupQueryAttention's past_key==present_key shared-buffer
+// pattern, contrib_ops/cuda/bert/group_query_attention.cc:423). In that case `src` and `dst`
+// are literally the same allocation: the data is already correct in place, and copying it is
+// a full-cache self-copy — wasted bandwidth, and technically UB (cudaMemcpyAsync requires
+// non-overlapping src/dst). Skip it.
+//
+// NOT applicable to 3-D BSNH inputs: those need a layout-changing transpose, so src and dst
+// can never alias there and the transpose must always run. Callers must only use this helper
+// from the !is_bsnh (4-D BNSH) branches.
+//
+// `dst == nullptr` (present output not requested by the caller) is a no-op.
+inline Status CopyKVToPresent(const Tensor* src, Tensor* dst, cudaStream_t stream) {
+  if (dst == nullptr) {
+    return Status::OK();
+  }
+  if (src->DataRaw() == dst->MutableDataRaw()) {
+    LOGS_DEFAULT(VERBOSE) << "Attention: " << kPresentCopySkippedTag
+                          << " (present output aliases the input KV cache buffer).";
+    return Status::OK();
+  }
+  CUDA_RETURN_IF_ERROR(cudaMemcpyAsync(dst->MutableDataRaw(), src->DataRaw(),
+                                       src->SizeInBytes(), cudaMemcpyDeviceToDevice, stream));
+  return Status::OK();
+}
+
 }  // namespace llm_attention_detail
 
 #define REGISTER_KERNEL_TYPED(T)                                      \
@@ -221,8 +256,14 @@ Status Attention<T>::ConvertAttnMaskToBias(
 // PERFORMANCE NOTE: ONNX Attention's internal-cache decode path (past_key/past_value)
 // is ~15-30% slower than contrib GQA's decode path for grouped-query attention workloads.
 // When using external KV cache via TensorScatter + nonpad_kv_seqlen (opset 24), the
-// copy overhead (point 1) is eliminated. The remaining ~5-15% gap is from the missing
-// XQA kernel (point 2).
+// concat/copy overhead (point 1) is eliminated: there is no past→present concat at all, and
+// for 4-D BNSH inputs the present_key/present_value population itself is also skipped when the
+// caller binds present_key/present_value to the SAME device buffer as key/value (e.g. via
+// IOBinding, mirroring TensorScatter's own .MayInplace(0, 0) pattern). If the caller does NOT
+// alias them, a D2D copy of the cache into the separate present_* buffers still happens — that
+// is required for correctness, not overhead that can be removed. (3-D BSNH inputs always pay a
+// layout-changing BSNH→BNSH transpose into present_*, which can never be aliased away.)
+// The remaining ~5-15% gap is from the missing XQA kernel (point 2).
 //
 // The internal-cache overhead comes from:
 //
@@ -509,10 +550,9 @@ Status Attention<T>::RunFlashAttention(
           K->Data<T>(), present_key->MutableData<T>(),
           cuda_stream, device_prop.maxThreadsPerBlock));
     } else if (present_key != nullptr && !is_bsnh) {
-      // 4D BNSH prompt: K is already BNSH, just D2D copy to present
-      CUDA_RETURN_IF_ERROR(cudaMemcpyAsync(
-          present_key->MutableData<T>(), K->Data<T>(),
-          K->SizeInBytes(), cudaMemcpyDeviceToDevice, cuda_stream));
+      // 4D BNSH: K is already BNSH, so a D2D copy to present suffices — but skip it entirely
+      // when present_key IS the K cache buffer (external-cache path with an aliased output).
+      ORT_RETURN_IF_ERROR(llm_attention_detail::CopyKVToPresent(K, present_key, cuda_stream));
     }
     if (present_value != nullptr && is_bsnh) {
       ORT_RETURN_IF_ERROR(TransposeBSNHtoBNSH<T>(
@@ -521,10 +561,9 @@ Status Attention<T>::RunFlashAttention(
           V->Data<T>(), present_value->MutableData<T>(),
           cuda_stream, device_prop.maxThreadsPerBlock));
     } else if (present_value != nullptr && !is_bsnh) {
-      // 4D BNSH prompt: V is already BNSH, just D2D copy to present
-      CUDA_RETURN_IF_ERROR(cudaMemcpyAsync(
-          present_value->MutableData<T>(), V->Data<T>(),
-          V->SizeInBytes(), cudaMemcpyDeviceToDevice, cuda_stream));
+      // 4D BNSH: V is already BNSH, so a D2D copy to present suffices — but skip it entirely
+      // when present_value IS the V cache buffer (external-cache path with an aliased output).
+      ORT_RETURN_IF_ERROR(llm_attention_detail::CopyKVToPresent(V, present_value, cuda_stream));
     }
   }
 
@@ -568,7 +607,10 @@ Status Attention<T>::RunFlashAttention(
 //   * Fully-masked batch (nonpad_kv_seqlen[b] == 0): cuDNN softmax over an all -inf row is
 //     unspecified (likely NaN), while every other tier defines output = 0. Apply
 //     LaunchZeroOutputForFullyMaskedBatches after run() to restore spec equivalence.
-//   * present_key/value are separate outputs populated from the input K/V cache (not aliases).
+//   * present_key/value are populated from the input K/V cache, EXCEPT when the caller has
+//     bound the present_* output to the very same device buffer as the K/V cache input (the
+//     recommended TensorScatter + IOBinding pattern). In that aliased case the data is already
+//     in place and the copy is skipped — see llm_attention_detail::CopyKVToPresent.
 //
 // CUDA-graph safety: no host read of valid length; the converter is a device kernel and the
 // cuDNN plan cache is keyed on capacity (stable across decode steps). The plan must be built
@@ -727,9 +769,10 @@ Status Attention<T>::RunCudnnSdpaAttention(
     }
   }
 
-  // --- Populate present_key/value (BNSH) from the input K/V cache (separate outputs, not aliases).
+  // --- Populate present_key/value (BNSH) from the input K/V cache.
   // K/V are the full external cache after TensorScatter; mirror RunFlashAttention's Path-1/prompt
-  // population (transpose BSNH→BNSH for 3D inputs, D2D copy for 4D BNSH inputs). ---
+  // population (transpose BSNH→BNSH for 3D inputs, D2D copy for 4D BNSH inputs). For 4D BNSH the
+  // copy is skipped when present_* aliases the K/V buffer (see CopyKVToPresent). ---
   if (present_key != nullptr && is_bsnh) {
     ORT_RETURN_IF_ERROR(TransposeBSNHtoBNSH<T>(
         parameters.batch_size, parameters.kv_sequence_length,
@@ -737,9 +780,7 @@ Status Attention<T>::RunCudnnSdpaAttention(
         K->Data<T>(), present_key->MutableData<T>(),
         cuda_stream, device_prop.maxThreadsPerBlock));
   } else if (present_key != nullptr && !is_bsnh) {
-    CUDA_RETURN_IF_ERROR(cudaMemcpyAsync(
-        present_key->MutableData<T>(), K->Data<T>(),
-        K->SizeInBytes(), cudaMemcpyDeviceToDevice, cuda_stream));
+    ORT_RETURN_IF_ERROR(llm_attention_detail::CopyKVToPresent(K, present_key, cuda_stream));
   }
   if (present_value != nullptr && is_bsnh) {
     ORT_RETURN_IF_ERROR(TransposeBSNHtoBNSH<T>(
@@ -748,9 +789,7 @@ Status Attention<T>::RunCudnnSdpaAttention(
         V->Data<T>(), present_value->MutableData<T>(),
         cuda_stream, device_prop.maxThreadsPerBlock));
   } else if (present_value != nullptr && !is_bsnh) {
-    CUDA_RETURN_IF_ERROR(cudaMemcpyAsync(
-        present_value->MutableData<T>(), V->Data<T>(),
-        V->SizeInBytes(), cudaMemcpyDeviceToDevice, cuda_stream));
+    ORT_RETURN_IF_ERROR(llm_attention_detail::CopyKVToPresent(V, present_value, cuda_stream));
   }
 
   return Status::OK();
@@ -1183,10 +1222,9 @@ Status Attention<T>::RunMemoryEfficientAttention(
           K->Data<T>(), present_key->MutableData<T>(),
           cuda_stream, device_prop.maxThreadsPerBlock));
     } else if (present_key != nullptr && !is_bsnh) {
-      // 4D BNSH prompt: K is already BNSH, just D2D copy to present
-      CUDA_RETURN_IF_ERROR(cudaMemcpyAsync(
-          present_key->MutableData<T>(), K->Data<T>(),
-          K->SizeInBytes(), cudaMemcpyDeviceToDevice, cuda_stream));
+      // 4D BNSH: K is already BNSH, so a D2D copy to present suffices — but skip it entirely
+      // when present_key IS the K cache buffer (external-cache path with an aliased output).
+      ORT_RETURN_IF_ERROR(llm_attention_detail::CopyKVToPresent(K, present_key, cuda_stream));
     }
     if (present_value != nullptr && is_bsnh) {
       ORT_RETURN_IF_ERROR(TransposeBSNHtoBNSH<T>(
@@ -1195,10 +1233,9 @@ Status Attention<T>::RunMemoryEfficientAttention(
           V->Data<T>(), present_value->MutableData<T>(),
           cuda_stream, device_prop.maxThreadsPerBlock));
     } else if (present_value != nullptr && !is_bsnh) {
-      // 4D BNSH prompt: V is already BNSH, just D2D copy to present
-      CUDA_RETURN_IF_ERROR(cudaMemcpyAsync(
-          present_value->MutableData<T>(), V->Data<T>(),
-          V->SizeInBytes(), cudaMemcpyDeviceToDevice, cuda_stream));
+      // 4D BNSH: V is already BNSH, so a D2D copy to present suffices — but skip it entirely
+      // when present_value IS the V cache buffer (external-cache path with an aliased output).
+      ORT_RETURN_IF_ERROR(llm_attention_detail::CopyKVToPresent(V, present_value, cuda_stream));
     }
   }
 
@@ -1481,9 +1518,7 @@ Status Attention<T>::RunUnfusedAttention(
                                                    K->Data<T>(), present_key->MutableData<T>(),
                                                    cuda_stream, max_threads));
       } else {
-        CUDA_RETURN_IF_ERROR(cudaMemcpyAsync(
-            present_key->MutableData<T>(), K->Data<T>(),
-            K->SizeInBytes(), cudaMemcpyDeviceToDevice, cuda_stream));
+        ORT_RETURN_IF_ERROR(llm_attention_detail::CopyKVToPresent(K, present_key, cuda_stream));
       }
     }
     if (present_value != nullptr) {
@@ -1492,9 +1527,7 @@ Status Attention<T>::RunUnfusedAttention(
                                                    V->Data<T>(), present_value->MutableData<T>(),
                                                    cuda_stream, max_threads));
       } else {
-        CUDA_RETURN_IF_ERROR(cudaMemcpyAsync(
-            present_value->MutableData<T>(), V->Data<T>(),
-            V->SizeInBytes(), cudaMemcpyDeviceToDevice, cuda_stream));
+        ORT_RETURN_IF_ERROR(llm_attention_detail::CopyKVToPresent(V, present_value, cuda_stream));
       }
     }
   }

--- a/onnxruntime/core/providers/cuda/llm/attention.cc
+++ b/onnxruntime/core/providers/cuda/llm/attention.cc
@@ -1698,6 +1698,42 @@ Status Attention<T>::ComputeInternal(OpKernelContext* context) const {
   // spec-sized region back out) — a nontrivial redesign, not attempted. See issue #29714 for the
   // full writeup and benchmark data before reviving this path.
 
+  // NOTE (Phase 3 — cuDNN SDPA prefill via fixed-size query-row chunking — investigated and
+  // abandoned): A cuDNN SDPA dispatch for prefill (q_sequence_length > 1) was prototyped on branch
+  // copilot/cudnn-sdpa-decode-phase3, splitting the query rows into fixed-size, left-padded chunks
+  // (a configurable, session-lifetime-constant size) so every chunk presents cuDNN's frontend with a
+  // stable sequence_length_q, preserving the graph-plan-cache-key stability Path 1's decode dispatch
+  // and Phase 2's investigation both depend on. Passing the real, varying prompt length directly
+  // (mirroring the contrib GroupQueryAttention op's un-chunked cuDNN prefill path) was measured to
+  // cost ~575-590us EVERY call with a distinct shape on A100/cuDNN 9.8 (no amortization — a
+  // one-time-per-request cost paid directly against time-to-first-token), a ~300-500x regression
+  // versus the chunked design's ~1.2-2ms warm cost, confirming chunking is necessary, not
+  // over-engineering, for any cuDNN-prefill design on this hardware/cuDNN version.
+  //
+  // The chunked design itself passed two full independent review rounds (readability, code, critical,
+  // deep spec-adherence incl. a 2246-configuration sweep of the causal-frontier algebra, cross-module
+  // integration, and QA/compute-sanitizer) with zero correctness defects found across both rounds.
+  // It was deliberately NOT merged for a value-proposition reason, not a correctness reason:
+  //   * Measured speedup over the existing MATH fallback (the path this shape class already uses
+  //     without this tier) was only ~0.94x-1.15x on A100 — within noise for short prompts (<=256
+  //     query rows, actually slightly SLOWER than MATH there) and a modest ~10-15% win only for long
+  //     prompts (>=512-1000 rows). Against Flash Attention on symmetric head_size shapes, cuDNN
+  //     prefill was roughly at parity, not a win.
+  //   * GroupQueryAttention's own cuDNN prefill path — and this prototype, which mirrored GQA's
+  //     dispatch gate for consistency — is only auto-enabled on SM>=90 (Hopper/Blackwell); it is
+  //     inert by default on SM80 (A100), the only hardware this investigation had available. The
+  //     benefit case for the hardware where this tier would actually activate by default was never
+  //     validated.
+  //   * The chunking algorithm's cache-key-stability invariants (fixed chunk size as a proxy for a
+  //     real, per-call-varying prompt length; the s_q>=chunk/2 floor bounding wasted compute/memory
+  //     to <=2x; the first_chunk skip bound) are subtle, proven correct by exhaustive sweep, but
+  //     nontrivial for future maintainers to preserve without re-deriving the same algebra.
+  // Net: a correctness-safe but performance-marginal feature, gated behind hardware this
+  // investigation could not confirm the benefit on. Revive only alongside H200/Hopper+ validation of
+  // the auto-enable default path, and re-evaluate the value proposition against then-current
+  // MATH/Flash/MEA baselines. See issue #29714 for the full writeup, chunk-size sweep, and benchmark
+  // data before reviving this path.
+
 #if USE_FLASH_ATTENTION
   {
     auto& device_prop = GetDeviceProp();

--- a/onnxruntime/core/providers/cuda/llm/attention.cc
+++ b/onnxruntime/core/providers/cuda/llm/attention.cc
@@ -1626,7 +1626,9 @@ Status Attention<T>::ComputeInternal(OpKernelContext* context) const {
   // external-KV-cache single-token decode path — its actual value proposition — so it cannot steal
   // traffic from currently-correct paths:
   //   * nonpad_kv_seqlen != nullptr  (opset-24 external cache)
-  //   * past_key == nullptr          (external cache, not internal past/present — Path 2 is Phase 2)
+  //   * past_key == nullptr          (external cache only; internal past_key/present_key decode is
+  //                                    intentionally NOT dispatched to cuDNN — investigated and
+  //                                    abandoned, see NOTE below and issue #29714.)
   //   * q_sequence_length == 1       (decode: the only unconditionally-safe case for this tier.
   //                                    For s_q==1 cuDNN drops causal masking entirely
   //                                    (cudnn_flash_attention.cc:430), so is_causal=0 and
@@ -1674,6 +1676,27 @@ Status Attention<T>::ComputeInternal(OpKernelContext* context) const {
                                    Y, present_key, present_value, parameters);
     }
   }
+
+  // NOTE (Phase 2 — internal past_key/present_key decode cache — investigated and abandoned):
+  // A cuDNN SDPA dispatch for the internal-cache contract (past_key/past_value in, present_key/
+  // present_value out, no nonpad_kv_seqlen) was prototyped on branch copilot/cudnn-sdpa-decode-phase2
+  // and reviewed, but deliberately NOT merged. Root cause: unlike Path 1's nonpad_kv_seqlen (an
+  // opset-24 EXTERNAL cache with a caller-owned, fixed-capacity buffer) or the contrib
+  // GroupQueryAttention op (whose present_key/value ARE the same fixed-capacity buffer as past_key/
+  // value, reused in place across decode steps, with the valid length passed separately via a
+  // seqlens tensor), the standard ONNX Attention op's INTERNAL cache has no capacity concept: the
+  // spec defines present_key/present_value shape as exactly past_sequence_length + kv_sequence_length,
+  // growing by exactly one token every decode step. cuDNN's frontend graph API is a "build once, run
+  // many times" model — cudnn_flash_attention.cc's mha_graph_cache is keyed (among other fields) on
+  // sequence_length_kv, so a per-step-growing shape produces a cache miss on every single call,
+  // forcing a full graph rebuild (heuristic search + plan build) every decode step instead of reusing
+  // a cached plan. Measured on A100/cuDNN 9.8: ~260-330ms per decode step for this cuDNN path vs.
+  // ~165-175us/step for Flash/MEA in the same realistic, single-session, growing-past_key loop — a
+  // ~1600x regression, and this tier is dispatched ABOVE Flash/MEA in the cascade. Making this path
+  // viable would require reproducing the GQA pattern here too (over-allocate present_key/value to a
+  // fixed capacity bucket, pass a per-batch valid-length mask to cuDNN, then copy the exact
+  // spec-sized region back out) — a nontrivial redesign, not attempted. See issue #29714 for the
+  // full writeup and benchmark data before reviving this path.
 
 #if USE_FLASH_ATTENTION
   {

--- a/onnxruntime/test/python/transformers/test_onnx_attention/test_tensorscatter_attention.py
+++ b/onnxruntime/test/python/transformers/test_onnx_attention/test_tensorscatter_attention.py
@@ -57,7 +57,13 @@ import torch
 from onnx import TensorProto, helper
 from parameterized import parameterized
 
-from onnxruntime import InferenceSession, OrtValue, SessionOptions, get_available_providers
+from onnxruntime import (
+    InferenceSession,
+    OrtValue,
+    SessionOptions,
+    get_available_providers,
+    set_default_logger_severity,
+)
 
 # #################################################################################################
 #  Helper Functions
@@ -2180,6 +2186,233 @@ class TestCausalTensorScatterBottomRight(unittest.TestCase):
             torch_type=torch.float16,
             ort_type=TensorProto.FLOAT16,
             is_causal=1,
+        )
+        numpy.testing.assert_allclose(output, ref_output, rtol=rtol["fp16"], atol=atol["fp16"])
+        numpy.testing.assert_allclose(present_k, ref_present_k, rtol=rtol["fp16"], atol=atol["fp16"])
+        numpy.testing.assert_allclose(present_v, ref_present_v, rtol=rtol["fp16"], atol=atol["fp16"])
+
+
+# #################################################################################################
+#  present_key/present_value redundant-copy skip (external-cache 4-D BNSH aliasing)
+# #################################################################################################
+# Attention::Run{Flash,CudnnSdpa,MemoryEfficient,Unfused}Attention populate present_key/present_value
+# for 4-D BNSH external-cache inputs via llm_attention_detail::CopyKVToPresent (attention.cc), which
+# skips the D2D copy entirely when present_key/present_value is bound to the SAME device buffer as
+# the K/V cache input (mirroring TensorScatter's own .MayInplace(0, 0) self-copy skip). These tests:
+#   1. Prove the skip actually fires when present_* aliases the cache buffer, via the greppable
+#      "present_copy_skipped" log tag emitted at VERBOSE severity — without this, a regression that
+#      re-introduced the unconditional copy would still pass on output correctness alone (the copy
+#      is redundant, not wrong, when src == dst).
+#   2. Prove the non-aliased path still runs the copy (tag absent) and both paths remain correct,
+#      across all four backends (Flash, cuDNN, Memory-Efficient, unfused/MATH).
+#
+# Only reachable for 4-D BNSH inputs (use_4d=True): the 3-D BSNH path always needs a
+# layout-changing transpose into present_*, so src and dst can never alias there.
+_PRESENT_COPY_SKIPPED_TAG = "present_copy_skipped"
+_ORT_LOG_SEVERITY_VERBOSE = 0
+_ORT_LOG_SEVERITY_WARNING = 2
+
+_SDPA_KERNEL_FLASH_ATTENTION = 1
+_SDPA_KERNEL_EFFICIENT_ATTENTION = 2
+
+
+def _run_tensorscatter_attention_4d(
+    batch_size,
+    total_kv_seq_len,
+    q_seq_len,
+    q_num_heads,
+    kv_num_heads,
+    head_size,
+    nonpad_seqlens,
+    scatter_positions,
+    provider_options,
+    alias_present,
+):
+    """4-D BNSH TensorScatter + Attention, with present_key/value optionally aliased to the K/V
+    cache buffer (the pattern llm_attention_detail::CopyKVToPresent's skip targets).
+
+    Runs at VERBOSE log severity and captures native stderr so callers can assert on
+    _PRESENT_COPY_SKIPPED_TAG. Returns (output, present_k, present_v, ref_output, ref_present_k,
+    ref_present_v, log_text).
+    """
+    torch.manual_seed(123)
+    std = 0.2
+    key_cache_t = torch.randn(batch_size, kv_num_heads, total_kv_seq_len, head_size, dtype=torch.float16) * std
+    value_cache_t = torch.randn(batch_size, kv_num_heads, total_kv_seq_len, head_size, dtype=torch.float16) * std
+    for b in range(batch_size):
+        old_valid = max(0, nonpad_seqlens[b] - q_seq_len)
+        if old_valid < total_kv_seq_len:
+            key_cache_t[b, :, old_valid:, :] = 0
+            value_cache_t[b, :, old_valid:, :] = 0
+    new_k_t = torch.randn(batch_size, kv_num_heads, q_seq_len, head_size, dtype=torch.float16) * std
+    new_v_t = torch.randn(batch_size, kv_num_heads, q_seq_len, head_size, dtype=torch.float16) * std
+    query_t = torch.randn(batch_size, q_num_heads, q_seq_len, head_size, dtype=torch.float16) * std
+
+    key_cache_ref = key_cache_t.float().cpu().numpy().copy()
+    value_cache_ref = value_cache_t.float().cpu().numpy().copy()
+    new_k_ref = new_k_t.float().cpu().numpy()
+    new_v_ref = new_v_t.float().cpu().numpy()
+    for b in range(batch_size):
+        pos = scatter_positions[b]
+        for t in range(q_seq_len):
+            key_cache_ref[b, :, pos + t, :] = new_k_ref[b, :, t, :]
+            value_cache_ref[b, :, pos + t, :] = new_v_ref[b, :, t, :]
+    q_ref = query_t.float().cpu().numpy().transpose(0, 2, 1, 3)
+    k_ref = key_cache_ref.transpose(0, 2, 1, 3)
+    v_ref = value_cache_ref.transpose(0, 2, 1, 3)
+    ref_output_bsnh = numpy_attention_ref(q_ref, k_ref, v_ref, nonpad_seqlens, is_causal=False)
+    ref_output = ref_output_bsnh.transpose(0, 2, 1, 3)
+    ref_present_k = key_cache_ref
+    ref_present_v = value_cache_ref
+
+    onnx_model_str = build_tensorscatter_attention_graph(
+        batch_size=batch_size,
+        total_kv_seq_len=total_kv_seq_len,
+        q_seq_len=q_seq_len,
+        q_num_heads=q_num_heads,
+        kv_num_heads=kv_num_heads,
+        head_size=head_size,
+        ort_type=TensorProto.FLOAT16,
+        is_causal=0,
+        use_4d=True,
+    )
+    # llm_attention_detail::CopyKVToPresent logs via LOGS_DEFAULT(VERBOSE), which goes through
+    # the process-wide DEFAULT logger (LoggingManager::DefaultLogger()), not the per-session
+    # logger session_options.log_severity_level configures. Both must be set to VERBOSE.
+    set_default_logger_severity(_ORT_LOG_SEVERITY_VERBOSE)
+    session_options = SessionOptions()
+    session_options.log_severity_level = _ORT_LOG_SEVERITY_VERBOSE
+    session = InferenceSession(
+        onnx_model_str,
+        session_options,
+        providers=["CUDAExecutionProvider"],
+        provider_options=[provider_options],
+    )
+
+    key_cache_ort = OrtValue.ortvalue_from_numpy(key_cache_t.cpu().numpy(), "cuda", 0)
+    value_cache_ort = OrtValue.ortvalue_from_numpy(value_cache_t.cpu().numpy(), "cuda", 0)
+    new_k_ort = OrtValue.ortvalue_from_numpy(new_k_t.cpu().numpy(), "cuda", 0)
+    new_v_ort = OrtValue.ortvalue_from_numpy(new_v_t.cpu().numpy(), "cuda", 0)
+    write_indices_ort = OrtValue.ortvalue_from_numpy(numpy.array(scatter_positions, dtype=numpy.int64), "cuda", 0)
+    query_ort = OrtValue.ortvalue_from_numpy(query_t.cpu().numpy(), "cuda", 0)
+    nonpad_ort = OrtValue.ortvalue_from_numpy(numpy.array(nonpad_seqlens, dtype=numpy.int64), "cuda", 0)
+
+    output_shape = [batch_size, q_num_heads, q_seq_len, head_size]
+    output_ort = OrtValue.ortvalue_from_shape_and_type(output_shape, numpy.float16, "cuda", 0)
+
+    io_binding = session.io_binding()
+    io_binding.bind_ortvalue_input("key_cache", key_cache_ort)
+    io_binding.bind_ortvalue_input("value_cache", value_cache_ort)
+    io_binding.bind_ortvalue_input("new_k", new_k_ort)
+    io_binding.bind_ortvalue_input("new_v", new_v_ort)
+    io_binding.bind_ortvalue_input("write_indices", write_indices_ort)
+    io_binding.bind_ortvalue_input("query", query_ort)
+    io_binding.bind_ortvalue_input("nonpad_kv_seqlen", nonpad_ort)
+    io_binding.bind_ortvalue_output("output", output_ort)
+    # In-place TensorScatter: the updated cache always aliases the cache input buffer.
+    io_binding.bind_ortvalue_output("updated_key_cache", key_cache_ort)
+    io_binding.bind_ortvalue_output("updated_value_cache", value_cache_ort)
+    if alias_present:
+        # Full 3-way alias: key_cache input == updated_key_cache output == present_key output.
+        # This is the production pattern CopyKVToPresent's skip targets.
+        io_binding.bind_ortvalue_output("present_key", key_cache_ort)
+        io_binding.bind_ortvalue_output("present_value", value_cache_ort)
+    else:
+        present_shape = [batch_size, kv_num_heads, total_kv_seq_len, head_size]
+        present_k_ort = OrtValue.ortvalue_from_shape_and_type(present_shape, numpy.float16, "cuda", 0)
+        present_v_ort = OrtValue.ortvalue_from_shape_and_type(present_shape, numpy.float16, "cuda", 0)
+        io_binding.bind_ortvalue_output("present_key", present_k_ort)
+        io_binding.bind_ortvalue_output("present_value", present_v_ort)
+
+    try:
+        with _CaptureNativeFd(_STDERR_FD) as captured_log:
+            io_binding.synchronize_inputs()
+            session.run_with_iobinding(io_binding)
+            io_binding.synchronize_outputs()
+    finally:
+        set_default_logger_severity(_ORT_LOG_SEVERITY_WARNING)
+
+    output = output_ort.numpy()
+    if alias_present:
+        present_k = key_cache_ort.numpy()
+        present_v = value_cache_ort.numpy()
+    else:
+        present_k = io_binding.get_outputs()[1].numpy()
+        present_v = io_binding.get_outputs()[2].numpy()
+
+    del io_binding, session
+    gc.collect()
+    return output, present_k, present_v, ref_output, ref_present_k, ref_present_v, captured_log.text
+
+
+@unittest.skipIf(not has_cuda_device(53), "CUDA device not available, skipping tests.")
+class TestAttentionPresentKVCopySkip(unittest.TestCase):
+    """present_key/present_value D2D-copy skip when aliased to the external KV cache buffer."""
+
+    _CASES = (
+        ("flash", {"sdpa_kernel": str(_SDPA_KERNEL_FLASH_ATTENTION | _SDPA_KERNEL_MATH)}),
+        ("efficient", {"sdpa_kernel": str(_SDPA_KERNEL_EFFICIENT_ATTENTION | _SDPA_KERNEL_MATH)}),
+        ("cudnn", {"sdpa_kernel": str(_SDPA_KERNEL_CUDNN_WITH_MATH_FALLBACK)}),
+        ("math", {"sdpa_kernel": str(_SDPA_KERNEL_MATH)}),
+    )
+
+    @parameterized.expand(_CASES)
+    def test_copy_skipped_when_present_aliases_cache(self, name, provider_options):
+        batch, total_kv, q_seq, q_heads, kv_heads, head_size = 2, 8, 1, 8, 2, 64
+        nonpad_seqlens = [4, 6]
+        scatter_positions = [3, 5]
+
+        output, present_k, present_v, ref_output, ref_present_k, ref_present_v, log_text = (
+            _run_tensorscatter_attention_4d(
+                batch,
+                total_kv,
+                q_seq,
+                q_heads,
+                kv_heads,
+                head_size,
+                nonpad_seqlens,
+                scatter_positions,
+                provider_options,
+                alias_present=True,
+            )
+        )
+
+        self.assertIn(
+            _PRESENT_COPY_SKIPPED_TAG,
+            log_text,
+            f"[{name}] present_key/value aliased the cache buffer but the redundant-copy skip "
+            "log tag never appeared — the D2D self-copy may have run unconditionally again.",
+        )
+        numpy.testing.assert_allclose(output, ref_output, rtol=rtol["fp16"], atol=atol["fp16"])
+        numpy.testing.assert_allclose(present_k, ref_present_k, rtol=rtol["fp16"], atol=atol["fp16"])
+        numpy.testing.assert_allclose(present_v, ref_present_v, rtol=rtol["fp16"], atol=atol["fp16"])
+
+    @parameterized.expand(_CASES)
+    def test_copy_still_runs_when_present_not_aliased(self, name, provider_options):
+        batch, total_kv, q_seq, q_heads, kv_heads, head_size = 2, 8, 1, 8, 2, 64
+        nonpad_seqlens = [4, 6]
+        scatter_positions = [3, 5]
+
+        output, present_k, present_v, ref_output, ref_present_k, ref_present_v, log_text = (
+            _run_tensorscatter_attention_4d(
+                batch,
+                total_kv,
+                q_seq,
+                q_heads,
+                kv_heads,
+                head_size,
+                nonpad_seqlens,
+                scatter_positions,
+                provider_options,
+                alias_present=False,
+            )
+        )
+
+        self.assertNotIn(
+            _PRESENT_COPY_SKIPPED_TAG,
+            log_text,
+            f"[{name}] present_key/value used SEPARATE buffers from the cache, but the skip tag "
+            "fired anyway — the aliasing check may have a false positive.",
         )
         numpy.testing.assert_allclose(output, ref_output, rtol=rtol["fp16"], atol=atol["fp16"])
         numpy.testing.assert_allclose(present_k, ref_present_k, rtol=rtol["fp16"], atol=atol["fp16"])

--- a/onnxruntime/test/python/transformers/test_onnx_attention/test_tensorscatter_attention.py
+++ b/onnxruntime/test/python/transformers/test_onnx_attention/test_tensorscatter_attention.py
@@ -1032,6 +1032,8 @@ _CUDNN_DECODE_TOTAL_KV = 8
 
 # sdpa_kernel bitmask (AttentionBackend in attention_common.h): select cuDNN and keep the unfused
 # kernel as a fallback for configs where cuDNN is unsupported.
+_SDPA_KERNEL_FLASH_ATTENTION = 1
+_SDPA_KERNEL_EFFICIENT_ATTENTION = 2
 _SDPA_KERNEL_CUDNN_FLASH_ATTENTION = 8
 _SDPA_KERNEL_MATH = 16
 _SDPA_KERNEL_CUDNN_WITH_MATH_FALLBACK = _SDPA_KERNEL_CUDNN_FLASH_ATTENTION | _SDPA_KERNEL_MATH
@@ -2212,9 +2214,6 @@ _PRESENT_COPY_SKIPPED_TAG = "present_copy_skipped"
 _ORT_LOG_SEVERITY_VERBOSE = 0
 _ORT_LOG_SEVERITY_WARNING = 2
 
-_SDPA_KERNEL_FLASH_ATTENTION = 1
-_SDPA_KERNEL_EFFICIENT_ATTENTION = 2
-
 
 def _run_tensorscatter_attention_4d(
     batch_size,
@@ -2231,9 +2230,10 @@ def _run_tensorscatter_attention_4d(
     """4-D BNSH TensorScatter + Attention, with present_key/value optionally aliased to the K/V
     cache buffer (the pattern llm_attention_detail::CopyKVToPresent's skip targets).
 
-    Runs at VERBOSE log severity and captures native stderr so callers can assert on
-    _PRESENT_COPY_SKIPPED_TAG. Returns (output, present_k, present_v, ref_output, ref_present_k,
-    ref_present_v, log_text).
+    Runs at VERBOSE log severity and captures native stderr (present_copy_skipped tag) and
+    stdout (SdpaKernel=... dispatch tier, via ORT_ENABLE_ATTENTION_KERNEL_DEBUG_INFO) so callers
+    can assert on both. Returns (output, present_k, present_v, ref_output, ref_present_k,
+    ref_present_v, log_text, sdpa_kernel).
     """
     torch.manual_seed(123)
     std = 0.2
@@ -2276,93 +2276,140 @@ def _run_tensorscatter_attention_4d(
         is_causal=0,
         use_4d=True,
     )
+
     # llm_attention_detail::CopyKVToPresent logs via LOGS_DEFAULT(VERBOSE), which goes through
     # the process-wide DEFAULT logger (LoggingManager::DefaultLogger()), not the per-session
-    # logger session_options.log_severity_level configures. Both must be set to VERBOSE.
+    # logger session_options.log_severity_level configures. Both must be set to VERBOSE, and
+    # BOTH global-state mutations (default logger severity, ORT_ENABLE_ATTENTION_KERNEL_DEBUG_INFO)
+    # must be restored even if session creation itself throws — everything from here to the run
+    # is wrapped in one try/finally so no failure path can leak process-wide state to later tests.
     set_default_logger_severity(_ORT_LOG_SEVERITY_VERBOSE)
-    session_options = SessionOptions()
-    session_options.log_severity_level = _ORT_LOG_SEVERITY_VERBOSE
-    session = InferenceSession(
-        onnx_model_str,
-        session_options,
-        providers=["CUDAExecutionProvider"],
-        provider_options=[provider_options],
-    )
-
-    key_cache_ort = OrtValue.ortvalue_from_numpy(key_cache_t.cpu().numpy(), "cuda", 0)
-    value_cache_ort = OrtValue.ortvalue_from_numpy(value_cache_t.cpu().numpy(), "cuda", 0)
-    new_k_ort = OrtValue.ortvalue_from_numpy(new_k_t.cpu().numpy(), "cuda", 0)
-    new_v_ort = OrtValue.ortvalue_from_numpy(new_v_t.cpu().numpy(), "cuda", 0)
-    write_indices_ort = OrtValue.ortvalue_from_numpy(numpy.array(scatter_positions, dtype=numpy.int64), "cuda", 0)
-    query_ort = OrtValue.ortvalue_from_numpy(query_t.cpu().numpy(), "cuda", 0)
-    nonpad_ort = OrtValue.ortvalue_from_numpy(numpy.array(nonpad_seqlens, dtype=numpy.int64), "cuda", 0)
-
-    output_shape = [batch_size, q_num_heads, q_seq_len, head_size]
-    output_ort = OrtValue.ortvalue_from_shape_and_type(output_shape, numpy.float16, "cuda", 0)
-
-    io_binding = session.io_binding()
-    io_binding.bind_ortvalue_input("key_cache", key_cache_ort)
-    io_binding.bind_ortvalue_input("value_cache", value_cache_ort)
-    io_binding.bind_ortvalue_input("new_k", new_k_ort)
-    io_binding.bind_ortvalue_input("new_v", new_v_ort)
-    io_binding.bind_ortvalue_input("write_indices", write_indices_ort)
-    io_binding.bind_ortvalue_input("query", query_ort)
-    io_binding.bind_ortvalue_input("nonpad_kv_seqlen", nonpad_ort)
-    io_binding.bind_ortvalue_output("output", output_ort)
-    # In-place TensorScatter: the updated cache always aliases the cache input buffer.
-    io_binding.bind_ortvalue_output("updated_key_cache", key_cache_ort)
-    io_binding.bind_ortvalue_output("updated_value_cache", value_cache_ort)
-    if alias_present:
-        # Full 3-way alias: key_cache input == updated_key_cache output == present_key output.
-        # This is the production pattern CopyKVToPresent's skip targets.
-        io_binding.bind_ortvalue_output("present_key", key_cache_ort)
-        io_binding.bind_ortvalue_output("present_value", value_cache_ort)
-    else:
-        present_shape = [batch_size, kv_num_heads, total_kv_seq_len, head_size]
-        present_k_ort = OrtValue.ortvalue_from_shape_and_type(present_shape, numpy.float16, "cuda", 0)
-        present_v_ort = OrtValue.ortvalue_from_shape_and_type(present_shape, numpy.float16, "cuda", 0)
-        io_binding.bind_ortvalue_output("present_key", present_k_ort)
-        io_binding.bind_ortvalue_output("present_value", present_v_ort)
-
+    previous_debug_info_env = os.environ.get("ORT_ENABLE_ATTENTION_KERNEL_DEBUG_INFO")
+    os.environ["ORT_ENABLE_ATTENTION_KERNEL_DEBUG_INFO"] = "1"
+    session = None
+    io_binding = None
     try:
-        with _CaptureNativeFd(_STDERR_FD) as captured_log:
+        session_options = SessionOptions()
+        session_options.log_severity_level = _ORT_LOG_SEVERITY_VERBOSE
+        session = InferenceSession(
+            onnx_model_str,
+            session_options,
+            providers=["CUDAExecutionProvider"],
+            provider_options=[provider_options],
+        )
+
+        key_cache_ort = OrtValue.ortvalue_from_numpy(key_cache_t.cpu().numpy(), "cuda", 0)
+        value_cache_ort = OrtValue.ortvalue_from_numpy(value_cache_t.cpu().numpy(), "cuda", 0)
+        new_k_ort = OrtValue.ortvalue_from_numpy(new_k_t.cpu().numpy(), "cuda", 0)
+        new_v_ort = OrtValue.ortvalue_from_numpy(new_v_t.cpu().numpy(), "cuda", 0)
+        write_indices_ort = OrtValue.ortvalue_from_numpy(numpy.array(scatter_positions, dtype=numpy.int64), "cuda", 0)
+        query_ort = OrtValue.ortvalue_from_numpy(query_t.cpu().numpy(), "cuda", 0)
+        nonpad_ort = OrtValue.ortvalue_from_numpy(numpy.array(nonpad_seqlens, dtype=numpy.int64), "cuda", 0)
+
+        output_shape = [batch_size, q_num_heads, q_seq_len, head_size]
+        output_ort = OrtValue.ortvalue_from_shape_and_type(output_shape, numpy.float16, "cuda", 0)
+
+        io_binding = session.io_binding()
+        io_binding.bind_ortvalue_input("key_cache", key_cache_ort)
+        io_binding.bind_ortvalue_input("value_cache", value_cache_ort)
+        io_binding.bind_ortvalue_input("new_k", new_k_ort)
+        io_binding.bind_ortvalue_input("new_v", new_v_ort)
+        io_binding.bind_ortvalue_input("write_indices", write_indices_ort)
+        io_binding.bind_ortvalue_input("query", query_ort)
+        io_binding.bind_ortvalue_input("nonpad_kv_seqlen", nonpad_ort)
+        io_binding.bind_ortvalue_output("output", output_ort)
+        # In-place TensorScatter: the updated cache always aliases the cache input buffer.
+        io_binding.bind_ortvalue_output("updated_key_cache", key_cache_ort)
+        io_binding.bind_ortvalue_output("updated_value_cache", value_cache_ort)
+        if alias_present:
+            # Full 3-way alias: key_cache input == updated_key_cache output == present_key output.
+            # This is the production pattern CopyKVToPresent's skip targets.
+            io_binding.bind_ortvalue_output("present_key", key_cache_ort)
+            io_binding.bind_ortvalue_output("present_value", value_cache_ort)
+        else:
+            present_shape = [batch_size, kv_num_heads, total_kv_seq_len, head_size]
+            present_k_ort = OrtValue.ortvalue_from_shape_and_type(present_shape, numpy.float16, "cuda", 0)
+            present_v_ort = OrtValue.ortvalue_from_shape_and_type(present_shape, numpy.float16, "cuda", 0)
+            io_binding.bind_ortvalue_output("present_key", present_k_ort)
+            io_binding.bind_ortvalue_output("present_value", present_v_ort)
+
+        # fd 2 (stderr) carries the present_copy_skipped VERBOSE tag; fd 1 (stdout) carries the
+        # AttentionKernelDebugInfo SdpaKernel=... dispatch tier. Both fds are redirected
+        # independently, so nesting (as elsewhere in this file) is safe.
+        with (
+            _CaptureNativeFd(_STDERR_FD) as captured_log,
+            _CaptureNativeFd(_STDOUT_FD) as captured_stdout,
+        ):
             io_binding.synchronize_inputs()
             session.run_with_iobinding(io_binding)
             io_binding.synchronize_outputs()
+        log_text = captured_log.text
+        sdpa_kernel = _parse_sdpa_kernel(captured_stdout.text)
+
+        output = output_ort.numpy()
+        if alias_present:
+            present_k = key_cache_ort.numpy()
+            present_v = value_cache_ort.numpy()
+        else:
+            present_k = io_binding.get_outputs()[1].numpy()
+            present_v = io_binding.get_outputs()[2].numpy()
     finally:
         set_default_logger_severity(_ORT_LOG_SEVERITY_WARNING)
-
-    output = output_ort.numpy()
-    if alias_present:
-        present_k = key_cache_ort.numpy()
-        present_v = value_cache_ort.numpy()
-    else:
-        present_k = io_binding.get_outputs()[1].numpy()
-        present_v = io_binding.get_outputs()[2].numpy()
+        if previous_debug_info_env is None:
+            os.environ.pop("ORT_ENABLE_ATTENTION_KERNEL_DEBUG_INFO", None)
+        else:
+            os.environ["ORT_ENABLE_ATTENTION_KERNEL_DEBUG_INFO"] = previous_debug_info_env
 
     del io_binding, session
     gc.collect()
-    return output, present_k, present_v, ref_output, ref_present_k, ref_present_v, captured_log.text
+    return output, present_k, present_v, ref_output, ref_present_k, ref_present_v, log_text, sdpa_kernel
 
 
 @unittest.skipIf(not has_cuda_device(53), "CUDA device not available, skipping tests.")
 class TestAttentionPresentKVCopySkip(unittest.TestCase):
     """present_key/present_value D2D-copy skip when aliased to the external KV cache buffer."""
 
+    # (name, provider_options, expected SdpaKernel=... tier, "is this tier expected to be
+    # available on this HW/build" predicate). The predicate gates the dispatch assertion the
+    # same way the existing cuDNN decode tests do (see cudnn_decode_supported/
+    # require_cudnn_sdpa): a "PASSED" on numeric correctness alone does NOT prove which backend
+    # ran, since flash/efficient/cudnn all OR in a MATH fallback bit — without this assertion a
+    # regression that broke 3 of the 4 backends' call sites while leaving unfused/MATH intact
+    # would still pass all 8 tests green.
     _CASES = (
-        ("flash", {"sdpa_kernel": str(_SDPA_KERNEL_FLASH_ATTENTION | _SDPA_KERNEL_MATH)}),
-        ("efficient", {"sdpa_kernel": str(_SDPA_KERNEL_EFFICIENT_ATTENTION | _SDPA_KERNEL_MATH)}),
-        ("cudnn", {"sdpa_kernel": str(_SDPA_KERNEL_CUDNN_WITH_MATH_FALLBACK)}),
-        ("math", {"sdpa_kernel": str(_SDPA_KERNEL_MATH)}),
+        (
+            "flash",
+            {"sdpa_kernel": str(_SDPA_KERNEL_FLASH_ATTENTION | _SDPA_KERNEL_MATH)},
+            "FLASH_ATTENTION",
+            has_flash_attention,
+        ),
+        (
+            "efficient",
+            {"sdpa_kernel": str(_SDPA_KERNEL_EFFICIENT_ATTENTION | _SDPA_KERNEL_MATH)},
+            "EFFICIENT_ATTENTION",
+            lambda: True,  # cutlass memory-efficient attention supports this class's SM53+ floor.
+        ),
+        (
+            "cudnn",
+            {"sdpa_kernel": str(_SDPA_KERNEL_CUDNN_WITH_MATH_FALLBACK)},
+            "CUDNN_FLASH_ATTENTION",
+            lambda: require_cudnn_sdpa() or cudnn_decode_supported(8, 2, 64),
+        ),
+        (
+            "math",
+            {"sdpa_kernel": str(_SDPA_KERNEL_MATH)},
+            "MATH",
+            lambda: True,  # the unfused/MATH kernel has no HW/build gating.
+        ),
     )
 
     @parameterized.expand(_CASES)
-    def test_copy_skipped_when_present_aliases_cache(self, name, provider_options):
+    def test_copy_skipped_when_present_aliases_cache(self, name, provider_options, expected_kernel, is_supported):
         batch, total_kv, q_seq, q_heads, kv_heads, head_size = 2, 8, 1, 8, 2, 64
         nonpad_seqlens = [4, 6]
         scatter_positions = [3, 5]
 
-        output, present_k, present_v, ref_output, ref_present_k, ref_present_v, log_text = (
+        output, present_k, present_v, ref_output, ref_present_k, ref_present_v, log_text, sdpa_kernel = (
             _run_tensorscatter_attention_4d(
                 batch,
                 total_kv,
@@ -2377,6 +2424,13 @@ class TestAttentionPresentKVCopySkip(unittest.TestCase):
             )
         )
 
+        if is_supported():
+            self.assertEqual(
+                expected_kernel,
+                sdpa_kernel,
+                f"[{name}] expected the {expected_kernel} tier to dispatch on this HW/build, "
+                f"got {sdpa_kernel} — the per-backend coverage this test claims is not real.",
+            )
         self.assertIn(
             _PRESENT_COPY_SKIPPED_TAG,
             log_text,
@@ -2388,12 +2442,12 @@ class TestAttentionPresentKVCopySkip(unittest.TestCase):
         numpy.testing.assert_allclose(present_v, ref_present_v, rtol=rtol["fp16"], atol=atol["fp16"])
 
     @parameterized.expand(_CASES)
-    def test_copy_still_runs_when_present_not_aliased(self, name, provider_options):
+    def test_copy_still_runs_when_present_not_aliased(self, name, provider_options, expected_kernel, is_supported):
         batch, total_kv, q_seq, q_heads, kv_heads, head_size = 2, 8, 1, 8, 2, 64
         nonpad_seqlens = [4, 6]
         scatter_positions = [3, 5]
 
-        output, present_k, present_v, ref_output, ref_present_k, ref_present_v, log_text = (
+        output, present_k, present_v, ref_output, ref_present_k, ref_present_v, log_text, sdpa_kernel = (
             _run_tensorscatter_attention_4d(
                 batch,
                 total_kv,
@@ -2408,6 +2462,13 @@ class TestAttentionPresentKVCopySkip(unittest.TestCase):
             )
         )
 
+        if is_supported():
+            self.assertEqual(
+                expected_kernel,
+                sdpa_kernel,
+                f"[{name}] expected the {expected_kernel} tier to dispatch on this HW/build, "
+                f"got {sdpa_kernel} — the per-backend coverage this test claims is not real.",
+            )
         self.assertNotIn(
             _PRESENT_COPY_SKIPPED_TAG,
             log_text,

--- a/onnxruntime/test/python/transformers/test_onnx_attention/test_tensorscatter_attention.py
+++ b/onnxruntime/test/python/transformers/test_onnx_attention/test_tensorscatter_attention.py
@@ -51,6 +51,7 @@ import sys
 import threading
 import unittest
 import warnings
+from unittest.mock import patch
 
 import numpy
 import torch
@@ -62,7 +63,6 @@ from onnxruntime import (
     OrtValue,
     SessionOptions,
     get_available_providers,
-    set_default_logger_severity,
 )
 
 # #################################################################################################
@@ -2212,7 +2212,40 @@ class TestCausalTensorScatterBottomRight(unittest.TestCase):
 # layout-changing transpose into present_*, so src and dst can never alias there.
 _PRESENT_COPY_SKIPPED_TAG = "present_copy_skipped"
 _ORT_LOG_SEVERITY_VERBOSE = 0
-_ORT_LOG_SEVERITY_WARNING = 2
+
+# CopyKVToPresent logs through this SESSION's logger (llm_attention_detail::KernelSessionLogger,
+# which returns the logger InferenceSession hands the execution provider), so the tag is controlled
+# purely by session_options.log_severity_level — no process-global logger mutation is needed.
+# Every ORT log line carries its session's logid, so a unique logid lets the assertions below
+# require BOTH the tag AND this test's own logid on the SAME line. fd 2 is a process-global
+# descriptor: without the logid anchor, a concurrently running session (e.g. a parallel test
+# worker) emitting the same tag during the redirected window would satisfy a bare substring match
+# for the wrong session — which would make the negative (tag-absent) assertion racy.
+_PRESENT_COPY_SKIP_TEST_LOGID = "test_attention_present_kv_copy_skip"
+
+# Matches a captured log line that carries BOTH this test's session logid and the skip tag.
+# OStreamSink writes "<timestamp> [<severity>:<category>:<logger_id>, <location>] <message>"
+# (onnxruntime/core/common/logging/sinks/ostream_sink.cc), so the logid is delimited by ':' before
+# and ', ' after. Matching those delimiters (rather than a bare substring) keeps a different
+# session whose logid merely CONTAINS this one from false-matching.
+_PRESENT_COPY_SKIPPED_LINE = re.compile(
+    rf"^.*:{re.escape(_PRESENT_COPY_SKIP_TEST_LOGID)}, .*{re.escape(_PRESENT_COPY_SKIPPED_TAG)}.*$",
+    re.MULTILINE,
+)
+
+
+# Env overrides applied (per backend case) before the session — and therefore
+# AttentionKernelOptions — is created, so an observed MATH fallback cannot be caused by an ambient
+# ORT_DISABLE_* env var and TestAttentionPresentKVCopySkip._check_dispatched_tier's skip stays as
+# narrow as possible. (These cases also pass an explicit sdpa_kernel provider option, which already
+# bypasses the env vars in AttentionKernelOptions::Initialize; this is defense-in-depth against an
+# ambient environment.) cuDNN has no ORT_DISABLE_* switch in this cascade (only the opt-in
+# ORT_ENABLE_CUDNN_FLASH_ATTENTION, superseded by the sdpa_kernel option), and the unfused/MATH
+# kernel cannot be disabled at all, so those two cases need no override.
+_FORCE_ENABLE_ENV = {
+    "flash": {"ORT_DISABLE_FLASH_ATTENTION": "0"},
+    "efficient": {"ORT_DISABLE_MEMORY_EFFICIENT_ATTENTION": "0"},
+}
 
 
 def _run_tensorscatter_attention_4d(
@@ -2277,13 +2310,12 @@ def _run_tensorscatter_attention_4d(
         use_4d=True,
     )
 
-    # llm_attention_detail::CopyKVToPresent logs via LOGS_DEFAULT(VERBOSE), which goes through
-    # the process-wide DEFAULT logger (LoggingManager::DefaultLogger()), not the per-session
-    # logger session_options.log_severity_level configures. Both must be set to VERBOSE, and
-    # BOTH global-state mutations (default logger severity, ORT_ENABLE_ATTENTION_KERNEL_DEBUG_INFO)
-    # must be restored even if session creation itself throws — everything from here to the run
-    # is wrapped in one try/finally so no failure path can leak process-wide state to later tests.
-    set_default_logger_severity(_ORT_LOG_SEVERITY_VERBOSE)
+    # llm_attention_detail::CopyKVToPresent logs via LOGS(KernelSessionLogger(...), VERBOSE), i.e.
+    # through this session's own logger, so session_options.log_severity_level alone controls it and a
+    # unique session logid anchors the assertions to this session (see _PRESENT_COPY_SKIP_TEST_LOGID).
+    # ORT_ENABLE_ATTENTION_KERNEL_DEBUG_INFO is still process-global state and must be restored even
+    # if session creation itself throws, so everything from here to the run is wrapped in one
+    # try/finally.
     previous_debug_info_env = os.environ.get("ORT_ENABLE_ATTENTION_KERNEL_DEBUG_INFO")
     os.environ["ORT_ENABLE_ATTENTION_KERNEL_DEBUG_INFO"] = "1"
     session = None
@@ -2291,6 +2323,7 @@ def _run_tensorscatter_attention_4d(
     try:
         session_options = SessionOptions()
         session_options.log_severity_level = _ORT_LOG_SEVERITY_VERBOSE
+        session_options.logid = _PRESENT_COPY_SKIP_TEST_LOGID
         session = InferenceSession(
             onnx_model_str,
             session_options,
@@ -2351,10 +2384,9 @@ def _run_tensorscatter_attention_4d(
             present_k = key_cache_ort.numpy()
             present_v = value_cache_ort.numpy()
         else:
-            present_k = io_binding.get_outputs()[1].numpy()
-            present_v = io_binding.get_outputs()[2].numpy()
+            present_k = present_k_ort.numpy()
+            present_v = present_v_ort.numpy()
     finally:
-        set_default_logger_severity(_ORT_LOG_SEVERITY_WARNING)
         if previous_debug_info_env is None:
             os.environ.pop("ORT_ENABLE_ATTENTION_KERNEL_DEBUG_INFO", None)
         else:
@@ -2375,7 +2407,9 @@ class TestAttentionPresentKVCopySkip(unittest.TestCase):
     # require_cudnn_sdpa): a "PASSED" on numeric correctness alone does NOT prove which backend
     # ran, since flash/efficient/cudnn all OR in a MATH fallback bit — without this assertion a
     # regression that broke 3 of the 4 backends' call sites while leaving unfused/MATH intact
-    # would still pass all 8 tests green.
+    # would still pass all 8 tests green. The predicates only see HW capability, so a tier that is
+    # compiled out of this build is detected from the observed MATH fallback instead and turned
+    # into a skip (see _check_dispatched_tier and _FORCE_ENABLE_ENV).
     _CASES = (
         (
             "flash",
@@ -2403,39 +2437,63 @@ class TestAttentionPresentKVCopySkip(unittest.TestCase):
         ),
     )
 
+    def _check_dispatched_tier(self, name, expected_kernel, sdpa_kernel, is_supported):
+        """Assert the expected backend actually dispatched, skipping when it is not available.
+
+        Numeric correctness alone does NOT prove which backend ran (flash/efficient/cudnn all OR in
+        a MATH fallback bit), hence the assertion. But a fused tier can also be compiled out
+        (onnxruntime_USE_FLASH_ATTENTION / onnxruntime_USE_MEMORY_EFFICIENT_ATTENTION), which the
+        HW-only predicates above cannot see. The runtime ORT_DISABLE_* switches are already ruled
+        out by _FORCE_ENABLE_ENV, so observing MATH where a fused tier was expected means "this
+        tier is not compiled into this build": skip instead of failing, since the aliasing logic
+        under test is backend-independent and the "math" case still covers it. (Residual
+        ambiguity: a genuine backend regression would also surface as MATH here. That limitation
+        is shared with the other backend-gated tests in this file and is accepted.)
+        """
+        if not is_supported():
+            return
+        if expected_kernel != "MATH" and sdpa_kernel == "MATH":
+            self.skipTest(
+                f"[{name}] the {expected_kernel} tier fell back to MATH even with its "
+                "ORT_DISABLE_* override forced off, so it is not compiled into this build."
+            )
+        self.assertEqual(
+            expected_kernel,
+            sdpa_kernel,
+            f"[{name}] expected the {expected_kernel} tier to dispatch on this HW/build, "
+            f"got {sdpa_kernel} — the per-backend coverage this test claims is not real.",
+        )
+
     @parameterized.expand(_CASES)
     def test_copy_skipped_when_present_aliases_cache(self, name, provider_options, expected_kernel, is_supported):
         batch, total_kv, q_seq, q_heads, kv_heads, head_size = 2, 8, 1, 8, 2, 64
         nonpad_seqlens = [4, 6]
         scatter_positions = [3, 5]
 
-        output, present_k, present_v, ref_output, ref_present_k, ref_present_v, log_text, sdpa_kernel = (
-            _run_tensorscatter_attention_4d(
-                batch,
-                total_kv,
-                q_seq,
-                q_heads,
-                kv_heads,
-                head_size,
-                nonpad_seqlens,
-                scatter_positions,
-                provider_options,
-                alias_present=True,
+        with patch.dict(os.environ, _FORCE_ENABLE_ENV.get(name, {})):
+            output, present_k, present_v, ref_output, ref_present_k, ref_present_v, log_text, sdpa_kernel = (
+                _run_tensorscatter_attention_4d(
+                    batch,
+                    total_kv,
+                    q_seq,
+                    q_heads,
+                    kv_heads,
+                    head_size,
+                    nonpad_seqlens,
+                    scatter_positions,
+                    provider_options,
+                    alias_present=True,
+                )
             )
-        )
 
-        if is_supported():
-            self.assertEqual(
-                expected_kernel,
-                sdpa_kernel,
-                f"[{name}] expected the {expected_kernel} tier to dispatch on this HW/build, "
-                f"got {sdpa_kernel} — the per-backend coverage this test claims is not real.",
-            )
-        self.assertIn(
-            _PRESENT_COPY_SKIPPED_TAG,
+        self._check_dispatched_tier(name, expected_kernel, sdpa_kernel, is_supported)
+        self.assertRegex(
             log_text,
-            f"[{name}] present_key/value aliased the cache buffer but the redundant-copy skip "
-            "log tag never appeared — the D2D self-copy may have run unconditionally again.",
+            _PRESENT_COPY_SKIPPED_LINE,
+            f"[{name}] present_key/value aliased the cache buffer but no captured log line carries "
+            f"both this session's logid ('{_PRESENT_COPY_SKIP_TEST_LOGID}') and the "
+            f"'{_PRESENT_COPY_SKIPPED_TAG}' tag — the D2D self-copy may have run "
+            "unconditionally again.",
         )
         numpy.testing.assert_allclose(output, ref_output, rtol=rtol["fp16"], atol=atol["fp16"])
         numpy.testing.assert_allclose(present_k, ref_present_k, rtol=rtol["fp16"], atol=atol["fp16"])
@@ -2447,33 +2505,29 @@ class TestAttentionPresentKVCopySkip(unittest.TestCase):
         nonpad_seqlens = [4, 6]
         scatter_positions = [3, 5]
 
-        output, present_k, present_v, ref_output, ref_present_k, ref_present_v, log_text, sdpa_kernel = (
-            _run_tensorscatter_attention_4d(
-                batch,
-                total_kv,
-                q_seq,
-                q_heads,
-                kv_heads,
-                head_size,
-                nonpad_seqlens,
-                scatter_positions,
-                provider_options,
-                alias_present=False,
+        with patch.dict(os.environ, _FORCE_ENABLE_ENV.get(name, {})):
+            output, present_k, present_v, ref_output, ref_present_k, ref_present_v, log_text, sdpa_kernel = (
+                _run_tensorscatter_attention_4d(
+                    batch,
+                    total_kv,
+                    q_seq,
+                    q_heads,
+                    kv_heads,
+                    head_size,
+                    nonpad_seqlens,
+                    scatter_positions,
+                    provider_options,
+                    alias_present=False,
+                )
             )
-        )
 
-        if is_supported():
-            self.assertEqual(
-                expected_kernel,
-                sdpa_kernel,
-                f"[{name}] expected the {expected_kernel} tier to dispatch on this HW/build, "
-                f"got {sdpa_kernel} — the per-backend coverage this test claims is not real.",
-            )
-        self.assertNotIn(
-            _PRESENT_COPY_SKIPPED_TAG,
+        self._check_dispatched_tier(name, expected_kernel, sdpa_kernel, is_supported)
+        self.assertNotRegex(
             log_text,
-            f"[{name}] present_key/value used SEPARATE buffers from the cache, but the skip tag "
-            "fired anyway — the aliasing check may have a false positive.",
+            _PRESENT_COPY_SKIPPED_LINE,
+            f"[{name}] present_key/value used SEPARATE buffers from the cache, but a log line with "
+            f"this session's logid ('{_PRESENT_COPY_SKIP_TEST_LOGID}') still carries the "
+            f"'{_PRESENT_COPY_SKIPPED_TAG}' tag — the aliasing check may have a false positive.",
         )
         numpy.testing.assert_allclose(output, ref_output, rtol=rtol["fp16"], atol=atol["fp16"])
         numpy.testing.assert_allclose(present_k, ref_present_k, rtol=rtol["fp16"], atol=atol["fp16"])


### PR DESCRIPTION
## Summary

Follow-up to #29715 (cuDNN SDPA decode tier for the ONNX standard `Attention` CUDA kernel).

On the external-KV-cache path (4-D BNSH, `nonpad_kv_seqlen`), all four CUDA attention backends
(Flash, cuDNN SDPA, Memory-Efficient, unfused) unconditionally `cudaMemcpyAsync`'d the entire K/V
cache into `present_key`/`present_value`, even when the caller IOBinds `present_key`/`present_value`
to the SAME device buffer as the K/V cache input — the documented `TensorScatter` + IOBinding
production pattern (mirroring `TensorScatter`'s own `.MayInplace(0, 0)` self-copy skip and
`GroupQueryAttention`'s `past_key`==`present_key` aliasing). This contradicted the file's own
PERFORMANCE NOTE and was technically undefined behavior (`cudaMemcpyAsync` requires non-overlapping
src/dst; a full self-copy is maximal overlap).

## What changed

- Added `llm_attention_detail::CopyKVToPresent(src, dst, stream)`, a shared helper that skips the
  D2D copy via a pointer-equality check when `present_*` aliases the K/V cache buffer, with a
  greppable VERBOSE log tag (`present_copy_skipped`) for test observability. Applied at all 8 call
  sites (K+V × 4 backends), only in the 4-D BNSH branches (3-D BSNH always needs a layout-changing
  transpose and can never alias).
- Added a defensive size-equality `ORT_ENFORCE` inside the helper: proven safe today (present
  shape only equals K/V's shape when `past_sequence_length == 0`), but guards against a future
  caller reusing this helper outside that precondition.
- `TestAttentionPresentKVCopySkip` (8 parameterized tests) covers all 4 backends × aliased/
  non-aliased, asserting both the copy-skip fires (or doesn't) via the log tag AND that the
  intended backend actually dispatched (not a silent MATH fallback), plus output/present_key/
  present_value correctness in both cases.

## Notes

Also includes (unpushed until now) a NOTE documenting the Phase 3 (cuDNN SDPA prefill chunking)
investigation and its abandonment — chunking added complexity without a clear latency win at the
shapes profiled, so it was not pursued further.

## Testing

- Full `test_onnx_attention` suite: 342/342 passed (334 pre-existing + 8 new).
- New test class re-verified individually with `-v`; confirmed via dispatch-log scraping that
  flash/efficient/cudnn/math parameterizations each hit their intended backend on an A100 (SM80),
  not a MATH fallback.
- `lintrunner` clean.

This PR went through an internal multi-agent review pass (readability, correctness, adversarial,
spec/invariant, cross-module integration, and QA execution) before being opened; findings from
that pass are already incorporated.