### PR TITLE
[WebNN EP] Reuse shared WASM loader for Blob-backed external data

### DIFF
--- a/js/web/lib/wasm/jsep/backend-webnn.ts
+++ b/js/web/lib/wasm/jsep/backend-webnn.ts
@@ -12,7 +12,7 @@ import { DataType, tensorDataTypeStringToEnum } from '../wasm-common';
 import { getInstance } from '../wasm-factory';
 
 import { createView } from './tensor-view';
-import { TensorId, createTensorManager, convertDataToInt32 } from './webnn/tensor-manager';
+import { TensorId, createTensorManager } from './webnn/tensor-manager';
 import { configureLogger, LOG_DEBUG } from './log';
 
 /*
@@ -305,85 +305,6 @@ export class WebNNBackend {
         }} -> {tensorId: ${id}}`,
     );
     return id;
-  }
-
-  // Register a WebNN Constant operand from external data.
-  public registerMLConstant(
-    externalFilePath: string,
-    dataOffset: number,
-    dataLength: number,
-    builder: MLGraphBuilder,
-    desc: MLOperandDescriptor,
-    mountedFiles: Map<string, Uint8Array> | undefined,
-    shouldConvertInt64ToInt32 = false,
-  ): MLOperand {
-    // If available, "Module.MountedFiles" is a Map for all preloaded files.
-    if (!mountedFiles) {
-      throw new Error('External mounted files are not available.');
-    }
-
-    let filePath = externalFilePath;
-    if (externalFilePath.startsWith('./')) {
-      filePath = externalFilePath.substring(2);
-    }
-    const fileData = mountedFiles.get(filePath);
-    if (!fileData) {
-      throw new Error(`File with name ${filePath} not found in preloaded files.`);
-    }
-
-    if (dataOffset + dataLength > fileData.byteLength) {
-      throw new Error('Out of bounds: data offset and length exceed the external file data size.');
-    }
-
-    const buffer = fileData.slice(dataOffset, dataOffset + dataLength).buffer;
-    let bufferView: ArrayBufferView;
-    switch (desc.dataType) {
-      case 'float32':
-        bufferView = new Float32Array(buffer);
-        break;
-      case 'float16':
-        bufferView = typeof Float16Array !== 'undefined' ? new Float16Array(buffer) : new Uint16Array(buffer);
-        break;
-      case 'int32':
-        bufferView = new Int32Array(buffer);
-        break;
-      case 'uint32':
-        bufferView = new Uint32Array(buffer);
-        break;
-      case 'int64':
-        if (shouldConvertInt64ToInt32) {
-          // Int64 is not supported by current context, use int32 instead.
-          const int32Buffer = convertDataToInt32(new Uint8Array(buffer), 'int64');
-          bufferView = new Int32Array(int32Buffer.buffer);
-          desc.dataType = 'int32';
-        } else {
-          bufferView = new BigInt64Array(buffer);
-        }
-        break;
-      case 'uint64':
-        bufferView = new BigUint64Array(buffer);
-        break;
-      case 'int8':
-        bufferView = new Int8Array(buffer);
-        break;
-      case 'int4':
-      case 'uint4':
-      case 'uint8':
-        bufferView = new Uint8Array(buffer);
-        break;
-      default:
-        throw new Error(`Unsupported data type: ${desc.dataType} in creating WebNN Constant from external data.`);
-    }
-
-    LOG_DEBUG(
-      'verbose',
-      () =>
-        `[WebNN] registerMLConstant {dataType: ${desc.dataType}, shape: ${desc.shape}}} ${
-          shouldConvertInt64ToInt32 ? '(Note: it was int64 data type and registered to int32 as workaround)' : ''
-        }`,
-    );
-
-    return builder.constant(desc, bufferView);
   }
 
   public registerGraphInput(inputName: string): void {

--- a/js/web/lib/wasm/wasm-types.ts
+++ b/js/web/lib/wasm/wasm-types.ts
@@ -294,25 +294,6 @@ export declare namespace WebNN {
     webnnCreateMLContext(optionsOrGpuDevice?: MLContextOptions | GPUDevice): Promise<MLContext>;
 
     /**
-     * [exported from pre-jsep.js] Register a WebNN Constant operand from external data.
-     * @param externalFilePath - specify the external file path.
-     * @param dataOffset - specify the external data offset.
-     * @param dataLength - specify the external data length.
-     * @param builder - specify the MLGraphBuilder used for constructing the Constant.
-     * @param desc - specify the MLOperandDescriptor of the Constant.
-     * @param shouldConvertInt64ToInt32 - specify whether to convert int64 to int32.
-     * @returns the WebNN Constant operand for the specified external data.
-     */
-    webnnRegisterMLConstant(
-      externalFilePath: string,
-      dataOffset: number,
-      dataLength: number,
-      builder: MLGraphBuilder,
-      desc: MLOperandDescriptor,
-      shouldConvertInt64ToInt32: boolean,
-    ): MLOperand;
-
-    /**
      * [exported from pre-jsep.js] Register a WebNN graph input.
      * @param inputName - specify the input name.
      */

--- a/onnxruntime/core/providers/webnn/builders/model_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/model_builder.cc
@@ -9,7 +9,9 @@
 #include "helper.h"
 #include "op_builder_factory.h"
 
+#include "core/framework/external_data_loader.h"
 #include "core/framework/tensorprotoutils.h"
+#include "core/platform/env.h"
 #include "core/providers/common.h"
 #include "core/providers/shared/utils/utils.h"
 
@@ -99,31 +101,34 @@ Status ModelBuilder::RegisterConstant(const onnx::TensorProto& tensor, emscripte
   emscripten::val wnn_builder = GetBuilder();
   const auto data_type = tensor.data_type();
 
-  // A flag to indicate if we should convert int64 constant to int32.
-  const bool should_convert_int64_to_int32 = !IsInt64Supported() &&
-                                             data_type == ONNX_NAMESPACE::TensorProto_DataType_INT64;
-
-  if (utils::HasExternalData(tensor) && !utils::HasExternalDataInMemory(tensor)) {
-    // Create WebNN Constant from external data.
-    std::basic_string<ORTCHAR_T> external_file_path;
-    onnxruntime::FileOffsetType data_offset;
-    SafeInt<size_t> tensor_byte_size;
-    ORT_RETURN_IF_ERROR(utils::GetExternalDataInfo(
-        tensor, graph_viewer_.ModelPath(), external_file_path, data_offset, tensor_byte_size));
-
-    auto webnnRegisterMLConstant = emscripten::val::module_property("webnnRegisterMLConstant");
-    operand = webnnRegisterMLConstant(emscripten::val(external_file_path),
-                                      static_cast<int32_t>(data_offset),
-                                      static_cast<int32_t>(tensor_byte_size),
-                                      wnn_builder,
-                                      desc,
-                                      should_convert_int64_to_int32);
-  } else {
+  {
     std::byte* tensor_ptr = nullptr;
     std::vector<uint8_t> unpacked_tensor;
     emscripten::val view = emscripten::val::undefined();
 
-    if (tensor.has_raw_data()) {
+    if (utils::HasExternalData(tensor) && !utils::HasExternalDataInMemory(tensor)) {
+      // The initializer's data lives on disk (an external data file). Stream just this
+      // initializer's byte range into a scratch buffer via the shared WebAssembly external data
+      // loader, then build the WebNN constant from it below - identical to the in-memory path.
+      // In JSPI builds the loader reads the range from a Blob on demand and releases it right after
+      // this copy, so the whole file is never materialized in the JS heap; other builds fall back to
+      // reading from the fully-materialized file. Using the shared loader also lifts the old
+      // int32 offset/size limit (it takes a double offset and SafeInt<size_t> length).
+      std::basic_string<ORTCHAR_T> external_file_path;
+      onnxruntime::FileOffsetType data_offset;
+      SafeInt<size_t> tensor_byte_size;
+      ORT_RETURN_IF_ERROR(utils::GetExternalDataInfo(
+          tensor, graph_viewer_.ModelPath(), external_file_path, data_offset, tensor_byte_size));
+
+      unpacked_tensor.resize(static_cast<size_t>(tensor_byte_size));
+      ORT_RETURN_IF_ERROR(LoadWebAssemblyExternalData(Env::Default(),
+                                                      external_file_path,
+                                                      data_offset,
+                                                      tensor_byte_size,
+                                                      ExternalDataLoadType::CPU,
+                                                      unpacked_tensor.data()));
+      tensor_ptr = reinterpret_cast<std::byte*>(unpacked_tensor.data());
+    } else if (tensor.has_raw_data()) {
       tensor_ptr = reinterpret_cast<std::byte*>(const_cast<char*>(tensor.raw_data().c_str()));
     } else {
       ORT_RETURN_IF_NOT(UnpackInitializerData(tensor, unpacked_tensor, graph_viewer_, logger),
@@ -181,7 +186,7 @@ Status ModelBuilder::RegisterConstant(const onnx::TensorProto& tensor, emscripte
 
     // If int64 is not supported, convert int64 to int32.
     std::vector<int32_t> int32_data;
-    if (should_convert_int64_to_int32) {
+    if (!IsInt64Supported() && data_type == ONNX_NAMESPACE::TensorProto_DataType_INT64) {
       try {
         int32_data = GetNarrowedIntFromInt64<int32_t>(
             gsl::span<const int64_t>(reinterpret_cast<int64_t*>(tensor_ptr), num_elements));

--- a/onnxruntime/wasm/post-webnn.js
+++ b/onnxruntime/wasm/post-webnn.js
@@ -50,24 +50,6 @@ Module["webnnInit"] = (params) => {
   Module["webnnCreateMLContext"] = (optionsOrGpuDevice) => {
     return backend["createMLContext"](optionsOrGpuDevice);
   };
-  Module["webnnRegisterMLConstant"] = (
-    externalFilePath,
-    dataOffset,
-    dataLength,
-    builder,
-    desc,
-    shouldConvertInt64ToInt32
-  ) => {
-    return backend["registerMLConstant"](
-      externalFilePath,
-      dataOffset,
-      dataLength,
-      builder,
-      desc,
-      Module.MountedFiles,
-      shouldConvertInt64ToInt32
-    );
-  };
   Module["webnnRegisterGraphInput"] =
     backend["registerGraphInput"].bind(backend);
   Module["webnnIsGraphInput"] = backend["isGraphInput"].bind(backend);

--- a/onnxruntime/wasm/pre-jsep.js
+++ b/onnxruntime/wasm/pre-jsep.js
@@ -130,24 +130,6 @@ Module["jsepInit"] = (name, params) => {
     Module["webnnCreateMLContext"] = (optionsOrGpuDevice) => {
       return backend["createMLContext"](optionsOrGpuDevice);
     };
-    Module["webnnRegisterMLConstant"] = (
-      externalFilePath,
-      dataOffset,
-      dataLength,
-      builder,
-      desc,
-      shouldConvertInt64ToInt32,
-    ) => {
-      return backend["registerMLConstant"](
-        externalFilePath,
-        dataOffset,
-        dataLength,
-        builder,
-        desc,
-        Module.MountedFiles,
-        shouldConvertInt64ToInt32,
-      );
-    };
     Module["webnnRegisterGraphInput"] =
       backend["registerGraphInput"].bind(backend);
     Module["webnnIsGraphInput"] = backend["isGraphInput"].bind(backend);


### PR DESCRIPTION
### Description
Extend the Blob-backed on-demand external data loading (#29477) from CPU / WebGPU EP to the WebNN EP. Route WebNN external initializers through `LoadWebAssemblyExternalData` instead of the custom `webnnRegisterMLConstant` path: `RegisterConstant` streams each initializer's byte range into a scratch buffer and builds the constant via the existing in-memory path.


### Motivation and Context
- Load-time memory (JSPI): the range is read from the mounted Blob on demand and released right after copy, so JS heap peak drops from full model size to the largest single initializer (same win as #29477).
- Fixes int32 offset/size truncation (loader uses `double/SafeInt<size_t>`), so big models split across multiple `.data` files load correctly.
- Removes the WebNN constant glue (`webnnRegisterMLConstant`, `registerMLConstant`, etc.).

