### PR TITLE
[CUDA] Speed up the NVFP4 QMoE decode GEMV and enable it for MTP verify

### DIFF
--- a/docs/contrib_ops/cuda/qmoe_gemv_experiments.md
+++ b/docs/contrib_ops/cuda/qmoe_gemv_experiments.md
@@ -1399,3 +1399,132 @@ cd ~/onnxruntime/build/cu130/Release
 ```
 
 Result: graph transformer tests `3 passed`; provider test `1 passed`.
+
+## 2026-06-21: NVFP4 GEMV Packed E2M1 Dequantize (`prmt` Quad Decode)
+
+### Change Under Test
+
+- Scope: `Fp4I2FConverter` in
+  `onnxruntime/contrib_ops/cuda/llm/fpA_intB_gemv/details.h`, i.e. every MXFP4 /
+  NVFP4 QMoE GEMV kernel instantiated from `moe_gemv_fp4.cu` (`moe_gemv_kernel`
+  and `moe_gemv_interleaved_swiglu_kernel`). INT4/INT8 use `I2FConverter` and are
+  untouched.
+- `Fp4I2FConverter::convert<N>()` previously decoded one E2M1 code at a time.
+  Even though `decode()` was already branchless (a `prmt.b32` byte-select into a
+  packed magnitude table), the surrounding per-element mask / shift / or / pack
+  sequence dominated: ~53 ALU instructions per 8 codes.
+- New packed path (`decode_quad`) taken whenever `N % 8 == 0`, which covers both
+  live FP4 configurations (`ColumnMajor` `StepK=8` used by NVFP4, and the opt-in
+  `ColumnMajorInterleaved` `StepK=32` used by MXFP4):
+  - Load the weights a whole 32-bit word (eight codes) at a time.
+  - `mag = w & 0x77777777` keeps the three magnitude bits per nibble and clears
+    bit 3 so `prmt` stays in byte-select mode instead of sign-replicate mode.
+  - `sgn = (w >> 3) & 0x11111111` becomes `0x00`/`0x80` sign bytes with one
+    `prmt`.
+  - One further `prmt` performs **four** magnitude table lookups at once, and one
+    or two more expand the bytes into two packed `half2` / `bfloat16x2` words.
+- Numerically this is a pure instruction-count change: the magnitude constants
+  are the same exact `half`/`bf16` encodings of `{0, 0.5, 1, 1.5, 2, 3, 4, 6}`,
+  and nibble `i` still maps to output element `i`, so `pack_to_vec2`/`mma` need
+  no changes. There is no env var; the packed path is unconditional on device.
+
+### Bit-Exactness
+
+A standalone harness compared `decode_quad` against the per-element reference for
+both `half` and `__nv_bfloat16` over 256x256x64 randomized 32-bit words
+(every code value in every nibble position):
+
+```
+cuda=no error mismatches=0
+```
+
+### SASS Instruction Count (sm_90, CUDA 13.0)
+
+Same object (`moe_gemv_fp4.cu.o`), built with and without the change:
+
+| Kernel (fp16, `ColumnMajor`, CtaN=8, Threads=128, GroupSize=16) | Before | After | Delta |
+|---|---:|---:|---:|
+| `moe_gemv_interleaved_swiglu_kernel` (fc1) | 1088 | 760 | -30.1% |
+| `moe_gemv_kernel` (fc2) | 960 | 640 | -33.3% |
+| whole object, all FP4 instantiations | 300552 | 180112 | -40.1% |
+
+### Repro Notes
+
+Model: `qwen3.6_nvfp4_fp8dense_statscale_mtp_int8head_fp8kv_v10_w4`
+(hidden 2048, inter 512, 256 experts, top_k 8, NVFP4 block_size 16, 40 layers),
+H200 SXM, single GPU.
+
+```bash
+source ~/git/venv/bin/activate
+export CUDA_HOME=/home/tianlei/cuda13.0 CUDNN_HOME=/home/tianlei/cudnn_9.23_cuda13
+export LD_LIBRARY_PATH=/home/tianlei/ort_home_cu130_fp4_bench/lib:$CUDA_HOME/lib64:$CUDNN_HOME/lib:$LD_LIBRARY_PATH
+export CUDA_VISIBLE_DEVICES=0 ORT_ENABLE_FP4_GEMV=1 ORT_MTP_DIRECT_ARENA_COMMIT=1 ORT_FP4_GEMV_AUTOTUNE=0
+# per-kernel timing: CUDA graph OFF so nsys reports real per-launch durations
+nsys profile -t cuda --capture-range=cudaProfilerApi --capture-range-end=stop \
+  -o /tmp/qmoe --force-overwrite true --export=sqlite \
+  python scripts/h200_18/profile_mtp_decode.py $MODEL $HEAD off 3 20 10
+nsys stats --report cuda_gpu_kern_sum --format csv /tmp/qmoe.sqlite | grep moe_gemv
+# end-to-end: CUDA graph ON
+python scripts/h200_18/profile_mtp_decode.py $MODEL $HEAD on 3 200 50
+```
+
+Caveat that cost time here: this workspace has **three** copies of
+`libonnxruntime_providers_cuda.so` (`onnxruntime/capi`, `onnxruntime_genai`, and
+the `ort_home` lib dir). A/B swaps must replace all three, otherwise both arms
+silently load the same library and report identical numbers.
+
+### Nsight Systems Per-Kernel Results (CUDA graph OFF, 800 launches each)
+
+Interleaved base/new reps, `ORT_FP4_GEMV_AUTOTUNE=0` (shipping default tiling):
+
+| Kernel | Before (us) | After (us) | Delta |
+|---|---:|---:|---:|
+| `moe_gemv_interleaved_swiglu_kernel` (fc1) | 33.14 / 33.24 | 26.34 / 26.13 | **-20.9%** |
+| `moe_gemv_kernel` (fc2) | 30.21 / 30.19 | 22.22 / 22.20 | **-26.5%** |
+
+40 launches of each per decode step, so about `-0.60 ms/step` of GPU time.
+
+### Model-Level Decode Benchmark (CUDA graph ON, 200 steps, 50 warmup)
+
+Interleaved reps; `ms/step` is the clean metric because `tok/s` also moves with
+the MTP acceptance rate.
+
+| Rep | Before ms/step | After ms/step |
+|---|---:|---:|
+| 1 | 11.663 | 11.061 |
+| 2 | 11.572 | 11.032 |
+| 3 | 11.594 | 11.035 |
+| mean | 11.610 | 11.043 |
+
+**-4.9% step time (+5.1% step rate).** Every "after" rep beat every "before" rep.
+
+### Validation
+
+```bash
+cd onnxruntime/test/python/transformers
+ORT_ENABLE_FP4_GEMV=1 python -m pytest -q test_qmoe_nvfp4_cuda.py   # 22 passed
+ORT_ENABLE_FP4_GEMV=0 python -m pytest -q test_qmoe_nvfp4_cuda.py   # 22 passed
+```
+
+### Decision
+
+- Keep the change. It is bit-exact, has no env gate, and is the largest single
+  QMoE NVFP4 GEMV win measured so far.
+- After this change the kernels are no longer dominated by dequantize. The next
+  FP4 GEMV lever is **tiling**, not the converter.
+
+### Follow-Up: Tiling Default Is Still Wrong For These Shapes
+
+`moe_gemv_fp4.cu` defaults to `Threads=128` with `StepK=8`, so `CtaK = 1024`.
+For fc2 (`k = 512`) half the threads in every block do no work at all. Enabling
+the existing autotuner picks `CtaN=8, Threads=64` for **both** GEMVs:
+
+| Config | fc1 (us) | fc2 (us) | ms/step |
+|---|---:|---:|---:|
+| `ORT_FP4_GEMV_AUTOTUNE=0` (default) | 26.2 | 22.2 | 11.028 / 11.004 |
+| `ORT_FP4_GEMV_AUTOTUNE=1` | 23.9 | 17.5 | 10.787 / 10.751 |
+
+Another `-0.24 ms/step` (`-2.2%`) is available. `ORT_FP4_GEMV_AUTOTUNE` is off by
+default because it synchronizes the inference stream, and it is skipped during
+CUDA-graph capture, so the fix should be an analytic default (at minimum, drop to
+`Threads=64` when `StepK * Threads > k`) rather than relying on the autotuner.

--- a/docs/contrib_ops/cuda/qmoe_gemv_experiments.md
+++ b/docs/contrib_ops/cuda/qmoe_gemv_experiments.md
@@ -1431,8 +1431,10 @@ Result: graph transformer tests `3 passed`; provider test `1 passed`.
 ### Bit-Exactness
 
 A standalone harness compared `decode_quad` against the per-element reference for
-both `half` and `__nv_bfloat16` over 256x256x64 randomized 32-bit words
-(every code value in every nibble position):
+both `half` and `__nv_bfloat16`. The reachable input space is only 2^16 wide (a
+`decode_quad` call is fully described by its 4x3-bit magnitude selector plus its
+4x1-bit sign selector), so the sweep of 256x256x64 randomized 32-bit words covers
+every reachable pattern -- this is an exhaustive check, not a sample:
 
 ```
 cuda=no error mismatches=0
@@ -1546,8 +1548,11 @@ New `gemv::Fp4MoeGemvDefaultConfig(expanded_num_rows, n, k)` in
 now seeds `fc1_config` / `fc2_config` from it rather than from `kDefault`; the
 autotuner, when enabled, still overrides it and the per-shape cache is unchanged.
 Only `Threads` is derived. `CtaN` stays at `kDefaultCtaN`, so the analytic config
-never changes which shapes `is_moe_gemv_fp4_supported` accepts, and `Threads` is a
-pure tiling knob so the result stays bit-exact.
+never changes which shapes `is_moe_gemv_fp4_supported` accepts. Note that
+`Threads` is a tiling knob but **not** a bit-exact one: a block walks K in strides
+of `CtaK = StepK * Threads` and the epilogue reduces across `Threads / 32` warps,
+so changing it changes the floating-point summation order and the low bits of the
+result can move.
 
 Two clauses, both about the fact that the grid is `(expanded_num_rows, n / CtaN)`
 and therefore does **not** depend on `Threads`:
@@ -1619,9 +1624,11 @@ ORT_ENABLE_FP4_GEMV=1 ORT_FP4_GEMV_DEFAULT_TILING=0 \
 
 ### Decision
 
-- Keep. The tiling is bit-exact, so this is purely about picking the faster
-  launch shape, and it now happens without a stream sync and works under CUDA
-  graph capture.
+- Keep. Every config computes the same dot products with the same accumulation
+  dtype, so this is purely about picking the faster launch shape, and it now
+  happens without a stream sync and works under CUDA graph capture. The summation
+  order does depend on `Threads`, so the choice is not bit-neutral; the tests
+  cover both clauses of the heuristic and the `=0` opt-out.
 - Clause (a) is unconditional and carries most of the win (fc2: 22.2 -> 17.5 us).
   Clause (b) adds the fc1 win (26.2 -> 23.9 us) and is the part that generalizes
   least, hence the deliberately conservative occupancy-derived threshold and the

--- a/docs/contrib_ops/cuda/qmoe_gemv_experiments.md
+++ b/docs/contrib_ops/cuda/qmoe_gemv_experiments.md
@@ -1528,3 +1528,103 @@ Another `-0.24 ms/step` (`-2.2%`) is available. `ORT_FP4_GEMV_AUTOTUNE` is off b
 default because it synchronizes the inference stream, and it is skipped during
 CUDA-graph capture, so the fix should be an analytic default (at minimum, drop to
 `Threads=64` when `StepK * Threads > k`) rather than relying on the autotuner.
+Resolved by the next section.
+
+## 2026-07-28: Analytic Default Tiling For The FP4 GEMV
+
+### Change Under Test
+
+Follow-up to the previous section, which showed the shipping FP4 GEMV tiling
+(`CtaN=8, Threads=128`) is not the best choice for the NVFP4 decode shapes but
+that the only way to get the better one was `ORT_FP4_GEMV_AUTOTUNE=1`. The
+autotuner is off by default because it synchronizes the inference stream, and it
+is skipped during CUDA-graph capture, so in practice it never runs in the
+configuration that matters.
+
+New `gemv::Fp4MoeGemvDefaultConfig(expanded_num_rows, n, k)` in
+`moe_gemv_fp4.cu` derives the tiling from the shape instead. `moe_quantization.cc`
+now seeds `fc1_config` / `fc2_config` from it rather than from `kDefault`; the
+autotuner, when enabled, still overrides it and the per-shape cache is unchanged.
+Only `Threads` is derived. `CtaN` stays at `kDefaultCtaN`, so the analytic config
+never changes which shapes `is_moe_gemv_fp4_supported` accepts, and `Threads` is a
+pure tiling knob so the result stays bit-exact.
+
+Two clauses, both about the fact that the grid is `(expanded_num_rows, n / CtaN)`
+and therefore does **not** depend on `Threads`:
+
+- **(a) Idle threads.** A block walks K in strides of `CtaK = StepK * Threads`
+  (`StepK = 8` for the ColumnMajor FP4 layout). When `CtaK > k` the tail of every
+  block never enters the K loop. NVFP4 fc2 has `k = inter_size = 512` against
+  `CtaK = 1024`, i.e. half of every block does nothing. `k < 1024 -> Threads=64`.
+- **(b) Epilogue width.** MAC work per block is fixed by `(CtaN, k)` regardless of
+  `Threads`, but the epilogue reduces partials across `Threads/32` warps through
+  shared memory. A narrower block does the same math with half the barriers and a
+  shallower reduction tree. This is gated on the grid being large enough that the
+  SM still fills: these kernels use ~72 registers/thread on sm_90 (~900 resident
+  threads/SM), which a 128-thread block reaches with ~7 resident blocks and a
+  64-thread block only with ~14, so the threshold is **16 blocks/SM**
+  (`expanded_num_rows * (n / CtaN) >= 16 * multiProcessorCount`).
+
+`ORT_FP4_GEMV_DEFAULT_TILING=0` restores the fixed `kDefault` tiling.
+
+### Selected Configs
+
+Qwen3.6-35B-A3B-NVFP4 MTP decode (hidden 2048, inter 512, 256 experts, top_k 8,
+expanded 32), H200, 132 SMs:
+
+| GEMV | n | k | blocks | Clause | Chosen |
+|---|---:|---:|---:|---|---|
+| fc1 (swiglu) | 1024 | 2048 | 4096 (31/SM) | (b) | `Threads=64` |
+| fc2 | 2048 | 512 | 8192 (62/SM) | (a) | `Threads=64` |
+
+Single-token decode (expanded 8) keeps `Threads=128` for fc1 (1024 blocks, 7.8/SM,
+below the clause (b) threshold) and still takes `Threads=64` for fc2 via clause
+(a), which is the intended behavior.
+
+The analytic choice reproduces the autotuner's pick exactly:
+
+| Kernel | `AUTOTUNE=1` (us) | Analytic default (us) |
+|---|---:|---:|
+| `moe_gemv_interleaved_swiglu_kernel` (fc1) | 23.93 | 23.89 / 24.05 |
+| `moe_gemv_kernel` (fc2) | 17.46 | 17.48 / 17.52 |
+
+### Model-Level Decode Benchmark (CUDA graph ON, 200 steps, 50 warmup)
+
+Same binary for both arms, toggled with `ORT_FP4_GEMV_DEFAULT_TILING`, interleaved
+reps. Final threshold (16 blocks/SM):
+
+| Rep | Fixed default ms/step | Analytic default ms/step |
+|---|---:|---:|
+| 1 | 10.986 | 10.739 |
+| 2 | 11.002 | 10.725 |
+| 3 | 11.061 | 10.742 |
+| mean | 11.016 | 10.735 |
+
+**-2.6% step time.** Every analytic rep beat every fixed-default rep. An earlier
+build with the threshold at 8 blocks/SM measured -2.3% on the same shapes; the
+16 blocks/SM threshold is the more conservative choice and loses nothing here.
+
+Combined with the packed E2M1 decode from the previous section, decode goes from
+11.610 ms/step to 10.735 ms/step, **-7.5%**.
+
+### Validation
+
+```bash
+cd onnxruntime/test/python/transformers
+ORT_ENABLE_FP4_GEMV=1 python -m pytest -q test_qmoe_nvfp4_cuda.py   # 22 passed
+ORT_ENABLE_FP4_GEMV=0 python -m pytest -q test_qmoe_nvfp4_cuda.py   # 22 passed
+ORT_ENABLE_FP4_GEMV=1 ORT_FP4_GEMV_DEFAULT_TILING=0 \
+  python -m pytest -q test_qmoe_nvfp4_cuda.py                       # 22 passed
+```
+
+### Decision
+
+- Keep. The tiling is bit-exact, so this is purely about picking the faster
+  launch shape, and it now happens without a stream sync and works under CUDA
+  graph capture.
+- Clause (a) is unconditional and carries most of the win (fc2: 22.2 -> 17.5 us).
+  Clause (b) adds the fc1 win (26.2 -> 23.9 us) and is the part that generalizes
+  least, hence the deliberately conservative occupancy-derived threshold and the
+  `ORT_FP4_GEMV_DEFAULT_TILING=0` opt-out.
+- The autotuner is still the right tool for shapes the heuristic gets wrong; it
+  now starts from a better default and overrides it only when it measures a win.

--- a/onnxruntime/contrib_ops/cuda/llm/fpA_intB_gemv/details.h
+++ b/onnxruntime/contrib_ops/cuda/llm/fpA_intB_gemv/details.h
@@ -74,6 +74,47 @@ class GMemIterator {
   int stride_;
 };
 
+// Access shape for the CtaN per-column scales a GEMV block loads for one K tile.
+//
+// The scales of the CtaN columns owned by a block sit `Interleave` elements apart, so for the
+// non-interleaved ColumnMajor layout (Interleave == 1) the whole CtaN-wide scale vector is
+// contiguous and can be fetched with one wide access instead of CtaN scalar ones.
+//
+// This matters far more than the byte count suggests. With a groupwise scale (e.g. NVFP4's
+// GroupSize = 16) and StepK = 8, a warp's 32 lanes cover 16 distinct scale rows that are `n`
+// elements apart, so *every* scale load touches 16 different sectors. Issuing CtaN of them costs
+// CtaN * 16 sectors while using only 2 bytes out of each 32-byte sector; a single vector load
+// costs 16 sectors and uses CtaN * 2 bytes of each. On the Qwen3.6 NVFP4 MoE decode shape
+// (CtaN = 8) that is 128 of the 176 L1 sectors a warp requests per K iteration.
+//
+// The vector form needs the scale row base to be 16-byte aligned. Callers guarantee
+// n % CtaN == 0, and kVectorized implies CtaN * sizeof(TypeA) % 16 == 0, so both the row stride
+// (a multiple of n) and the column offset (a multiple of CtaN) are 16-byte aligned.
+template <typename T, int CtaN, int Interleave>
+struct ScalesAccess {
+  static constexpr int kBytes = CtaN * static_cast<int>(sizeof(T));
+  static constexpr bool kVectorized = (Interleave == 1) && (kBytes % 16 == 0);
+  // GMemIterator<..., TVec, Strided, Continuous, T>: the vector form loads all CtaN scales in
+  // `Continuous` 16-byte chunks at ii = 0, the scalar form keeps one element per `ii`.
+  using TVec = std::conditional_t<kVectorized, float4, T>;
+  static constexpr int kStrided = kVectorized ? 1 : CtaN;
+  static constexpr int kContinuous = kVectorized ? kBytes / 16 : 1;
+};
+
+// Loads the CtaN scales for K tile `iter` into `vec_scale`, using the access shape `Access`
+// describes. `scales_iterator` must have been declared with that same shape.
+template <typename Access, int CtaN, typename Iterator, typename T>
+__device__ __forceinline__ void load_scales(Iterator& scales_iterator, T* vec_scale, int iter) {
+  if constexpr (Access::kVectorized) {
+    scales_iterator.load(vec_scale, iter);
+  } else {
+#pragma unroll
+    for (int i = 0; i < CtaN; ++i) {
+      scales_iterator.load(vec_scale + i, iter, i);
+    }
+  }
+}
+
 struct FP16DetailsA {
   using Type = half;
   using Type2 = half2;

--- a/onnxruntime/contrib_ops/cuda/llm/fpA_intB_gemv/details.h
+++ b/onnxruntime/contrib_ops/cuda/llm/fpA_intB_gemv/details.h
@@ -358,8 +358,6 @@ struct Fp4I2FConverter {
 
   template <int N>
   __device__ __forceinline__ static void convert(void* src, void* dst) {
-    uint8_t const* s = reinterpret_cast<uint8_t const*>(src);
-    AType* d = reinterpret_cast<AType*>(dst);
     if constexpr (!PairInterleaved) {
       static_assert(N % 2 == 0);
 #if defined(__CUDA_ARCH__)
@@ -382,16 +380,21 @@ struct Fp4I2FConverter {
           decode_quad(mag, sgn, dw[i * 4 + 0], dw[i * 4 + 1]);
           decode_quad(mag >> 16, sgn >> 16, dw[i * 4 + 2], dw[i * 4 + 3]);
         }
-        return;
-      }
+      } else
 #endif
+      {
+        uint8_t const* s = reinterpret_cast<uint8_t const*>(src);
+        AType* d = reinterpret_cast<AType*>(dst);
 #pragma unroll
-      for (int i = 0; i < N; i += 2) {
-        uint8_t byte = s[i >> 1];
-        d[i] = decode(static_cast<uint8_t>(byte & 0x0F));
-        d[i + 1] = decode(static_cast<uint8_t>((byte >> 4) & 0x0F));
+        for (int i = 0; i < N; i += 2) {
+          uint8_t byte = s[i >> 1];
+          d[i] = decode(static_cast<uint8_t>(byte & 0x0F));
+          d[i + 1] = decode(static_cast<uint8_t>((byte >> 4) & 0x0F));
+        }
       }
     } else {
+      uint8_t const* s = reinterpret_cast<uint8_t const*>(src);
+      AType* d = reinterpret_cast<AType*>(dst);
       // The pair-interleave permutes whole 32-bit words, so N must cover complete words.
       static_assert(N % 8 == 0, "Pair-interleaved FP4 decode needs a multiple of 8 elements");
       // Packing writes element i to nibble slot (i even ? i/2 : (i - 1)/2 + 4), so logical

--- a/onnxruntime/contrib_ops/cuda/llm/fpA_intB_gemv/details.h
+++ b/onnxruntime/contrib_ops/cuda/llm/fpA_intB_gemv/details.h
@@ -282,12 +282,68 @@ struct Fp4I2FConverter {
 #endif
   }
 
+#if defined(__CUDA_ARCH__)
+  // Decodes four consecutive E2M1 codes into two packed AType2 words.
+  //
+  // `mag_sel` holds the four 3-bit magnitudes as the four low nibbles (bit 3 cleared so prmt
+  // stays in byte-select mode rather than sign-replicate mode) and `sgn_sel` holds the four sign
+  // bits as 0/1 nibbles. One prmt then performs *four* magnitude table lookups at once, which is
+  // where this beats the per-element `decode()` above: prmt selects four bytes per instruction,
+  // so the whole 4-element lookup costs one instruction instead of four.
+  __device__ __forceinline__ static void decode_quad(uint32_t mag_sel, uint32_t sgn_sel,
+                                                     uint32_t& lo2, uint32_t& hi2) {
+    uint32_t sb;
+    // Sign bytes: nibble 0 -> 0x00, nibble 1 -> 0x80 (bit 7 of the AType high byte).
+    asm("prmt.b32 %0, %1, %2, %3;" : "=r"(sb) : "r"(0x00008000u), "r"(0u), "r"(sgn_sel));
+    if constexpr (std::is_same_v<AType, half>) {
+      uint32_t hb;
+      asm("prmt.b32 %0, %1, %2, %3;" : "=r"(hb) : "r"(0x3E3C3800u), "r"(0x46444240u), "r"(mag_sel));
+      hb |= sb;
+      // half low byte is always 0, so expand {b0,b1,b2,b3} to {0,b0,0,b1} and {0,b2,0,b3} by
+      // pulling the zero bytes from the second (all-zero) prmt operand.
+      asm("prmt.b32 %0, %1, %2, %3;" : "=r"(lo2) : "r"(hb), "r"(0u), "n"(0x1404));
+      asm("prmt.b32 %0, %1, %2, %3;" : "=r"(hi2) : "r"(hb), "r"(0u), "n"(0x3424));
+    } else {
+      uint32_t hb, lb;
+      asm("prmt.b32 %0, %1, %2, %3;" : "=r"(hb) : "r"(0x3F3F3F00u), "r"(0x40404040u), "r"(mag_sel));
+      asm("prmt.b32 %0, %1, %2, %3;" : "=r"(lb) : "r"(0xC0800000u), "r"(0xC0804000u), "r"(mag_sel));
+      hb |= sb;
+      // bf16 needs both bytes: interleave low/high bytes of elements 0,1 and 2,3.
+      asm("prmt.b32 %0, %1, %2, %3;" : "=r"(lo2) : "r"(lb), "r"(hb), "n"(0x5140));
+      asm("prmt.b32 %0, %1, %2, %3;" : "=r"(hi2) : "r"(lb), "r"(hb), "n"(0x7362));
+    }
+  }
+#endif
+
   template <int N>
   __device__ __forceinline__ static void convert(void* src, void* dst) {
     uint8_t const* s = reinterpret_cast<uint8_t const*>(src);
     AType* d = reinterpret_cast<AType*>(dst);
     if constexpr (!PairInterleaved) {
       static_assert(N % 2 == 0);
+#if defined(__CUDA_ARCH__)
+      if constexpr (N % 8 == 0) {
+        // Packed path: decode a whole 32-bit weight word (eight codes) at a time. Bit-identical
+        // to the scalar path below, but ~3x fewer instructions, which matters because the QMoE
+        // FP4 GEMV is instruction-issue bound (ncu on Qwen3.6-35B-A3B NVFP4 decode: ~74% SM
+        // throughput at ~12% DRAM throughput, with the dequantize sequence about half of all
+        // issued instructions). Measured on H200/sm_90: FP4 GEMV kernel SASS shrinks ~30% and
+        // the two QMoE GEMVs drop 33.2 -> 26.2 us (fc1 swiglu) and 30.2 -> 22.2 us (fc2).
+        // Only valid for the plain (non pair-interleaved) nibble order: nibble j of the word
+        // is logical element j, which is exactly what the prmt selectors below assume.
+        uint32_t const* sw = reinterpret_cast<uint32_t const*>(src);
+        uint32_t* dw = reinterpret_cast<uint32_t*>(dst);
+#pragma unroll
+        for (int i = 0; i < N / 8; ++i) {
+          uint32_t const w = sw[i];
+          uint32_t const mag = w & 0x77777777u;
+          uint32_t const sgn = (w >> 3) & 0x11111111u;
+          decode_quad(mag, sgn, dw[i * 4 + 0], dw[i * 4 + 1]);
+          decode_quad(mag >> 16, sgn >> 16, dw[i * 4 + 2], dw[i * 4 + 3]);
+        }
+        return;
+      }
+#endif
 #pragma unroll
       for (int i = 0; i < N; i += 2) {
         uint8_t byte = s[i >> 1];

--- a/onnxruntime/contrib_ops/cuda/llm/fpA_intB_gemv/details.h
+++ b/onnxruntime/contrib_ops/cuda/llm/fpA_intB_gemv/details.h
@@ -331,26 +331,40 @@ struct Fp4I2FConverter {
   // bits as 0/1 nibbles. One prmt then performs *four* magnitude table lookups at once, which is
   // where this beats the per-element `decode()` above: prmt selects four bytes per instruction,
   // so the whole 4-element lookup costs one instruction instead of four.
+  //
+  // Selector notation below: `prmt.b32 d, a, b, c` views {a0,a1,a2,a3,b0,b1,b2,b3} as source
+  // bytes 0..7 and uses nibble j of `c` (nibble 0 is the least significant) to pick source byte
+  // for result byte j. All the selectors here are written most-significant nibble first, i.e.
+  // 0x1404 means d3=src1, d2=src4, d1=src0, d0=src4.
   __device__ __forceinline__ static void decode_quad(uint32_t mag_sel, uint32_t sgn_sel,
                                                      uint32_t& lo2, uint32_t& hi2) {
     uint32_t sb;
-    // Sign bytes: nibble 0 -> 0x00, nibble 1 -> 0x80 (bit 7 of the AType high byte).
+    // Sign bytes. Source bytes are {0x00,0x80,0x00,0x00, 0,0,0,0}, so a `sgn_sel` nibble of 0
+    // picks 0x00 and 1 picks 0x80 -- bit 7 of the AType high byte, i.e. the float sign bit.
     asm("prmt.b32 %0, %1, %2, %3;" : "=r"(sb) : "r"(0x00008000u), "r"(0u), "r"(sgn_sel));
     if constexpr (std::is_same_v<AType, half>) {
       uint32_t hb;
+      // Same magnitude table as decode(): codes 0..3 -> {0x00,0x38,0x3C,0x3E},
+      // codes 4..7 -> {0x40,0x42,0x44,0x46}. hb byte j is element j's half high byte.
       asm("prmt.b32 %0, %1, %2, %3;" : "=r"(hb) : "r"(0x3E3C3800u), "r"(0x46444240u), "r"(mag_sel));
       hb |= sb;
       // half low byte is always 0, so expand {b0,b1,b2,b3} to {0,b0,0,b1} and {0,b2,0,b3} by
       // pulling the zero bytes from the second (all-zero) prmt operand.
+      // 0x1404: d = {hb1, 0, hb0, 0} (byte 3..0) = half2{elem0, elem1}.
       asm("prmt.b32 %0, %1, %2, %3;" : "=r"(lo2) : "r"(hb), "r"(0u), "n"(0x1404));
+      // 0x3424: d = {hb3, 0, hb2, 0} = half2{elem2, elem3}.
       asm("prmt.b32 %0, %1, %2, %3;" : "=r"(hi2) : "r"(hb), "r"(0u), "n"(0x3424));
     } else {
       uint32_t hb, lb;
+      // Same two bf16 tables as decode(): high byte {0x00,0x3F,0x3F,0x3F, 0x40,0x40,0x40,0x40}
+      // and low byte {0x00,0x00,0x80,0xC0, 0x00,0x40,0x80,0xC0}. Byte j is element j.
       asm("prmt.b32 %0, %1, %2, %3;" : "=r"(hb) : "r"(0x3F3F3F00u), "r"(0x40404040u), "r"(mag_sel));
       asm("prmt.b32 %0, %1, %2, %3;" : "=r"(lb) : "r"(0xC0800000u), "r"(0xC0804000u), "r"(mag_sel));
       hb |= sb;
-      // bf16 needs both bytes: interleave low/high bytes of elements 0,1 and 2,3.
+      // bf16 needs both bytes, so source bytes are {lb0..lb3, hb0..hb3}.
+      // 0x5140: d = {hb1, lb1, hb0, lb0} = bfloat162{elem0, elem1}.
       asm("prmt.b32 %0, %1, %2, %3;" : "=r"(lo2) : "r"(lb), "r"(hb), "n"(0x5140));
+      // 0x7362: d = {hb3, lb3, hb2, lb2} = bfloat162{elem2, elem3}.
       asm("prmt.b32 %0, %1, %2, %3;" : "=r"(hi2) : "r"(lb), "r"(hb), "n"(0x7362));
     }
   }
@@ -370,6 +384,9 @@ struct Fp4I2FConverter {
         // the two QMoE GEMVs drop 33.2 -> 26.2 us (fc1 swiglu) and 30.2 -> 22.2 us (fc2).
         // Only valid for the plain (non pair-interleaved) nibble order: nibble j of the word
         // is logical element j, which is exactly what the prmt selectors below assume.
+        //
+        // Both operands are re-typed to uint32_t, so callers must supply 4-byte-aligned
+        // buffers; the GEMV kernels declare their tiles `alignas(alignof(uint32_t))`.
         uint32_t const* sw = reinterpret_cast<uint32_t const*>(src);
         uint32_t* dw = reinterpret_cast<uint32_t*>(dst);
 #pragma unroll

--- a/onnxruntime/contrib_ops/cuda/llm/fpA_intB_gemv/dispatcher.h
+++ b/onnxruntime/contrib_ops/cuda/llm/fpA_intB_gemv/dispatcher.h
@@ -309,6 +309,9 @@ __global__ void kernel(TypeA* act, TypeA* act_scale, uint8_t* weight, TypeA* sca
       (interleaved_offset_n * interleaved_k + tid * StepK) / Details::kElemsPerByteW, CtaK / Details::kElemsPerByteW,
       interleaved_k / Details::kElemsPerByteW);
 
+  // Kept as CtaN scalar loads rather than the vectorized ScalesAccess/load_scales form used by
+  // the FP4 MoE GEMV: that form needs kInterleave == 1 to make the CtaN scales contiguous, and
+  // every layout reaching this dense kernel is ColumnMajorInterleaved (kInterleave 2 or 4).
   GMemIterator<Mandatory, TypeA, CtaN, 1, TypeA> scales_iterator(
       scales,
       (GroupSize != 0 ? real_offset_k / GroupSize * n : 0) + real_offset_n,

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemv.h
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemv.h
@@ -18,7 +18,9 @@ namespace onnxruntime::llm {
 namespace kernels {
 namespace moe_gemv {
 
-inline constexpr int64_t kMaxProfiledExpandedRows = 8;
+// Cover Qwen-style top_k=8 MTP decode. An (N+1)-token verification for
+// num_speculative_tokens=N expands to (N+1)*8 rows, up to 64 for N=7.
+inline constexpr int64_t kMaxProfiledExpandedRows = 64;
 inline constexpr int64_t kMaxProfiledExpandedRowsForSmallProblemDim = 4;
 inline constexpr int64_t kMinProfiledProblemDim = 512;
 // Lowered from 704 to 512 so block-wise decode shapes (e.g. Qwen top_k=8,

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemv.h
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemv.h
@@ -18,9 +18,7 @@ namespace onnxruntime::llm {
 namespace kernels {
 namespace moe_gemv {
 
-// Cover Qwen-style top_k=8 MTP decode. An (N+1)-token verification for
-// num_speculative_tokens=N expands to (N+1)*8 rows, up to 64 for N=7.
-inline constexpr int64_t kMaxProfiledExpandedRows = 64;
+inline constexpr int64_t kMaxProfiledExpandedRows = 8;
 inline constexpr int64_t kMaxProfiledExpandedRowsForSmallProblemDim = 4;
 inline constexpr int64_t kMinProfiledProblemDim = 512;
 // Lowered from 704 to 512 so block-wise decode shapes (e.g. Qwen top_k=8,

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemv_device.cuh
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemv_device.cuh
@@ -18,6 +18,66 @@ namespace onnxruntime::llm {
 namespace kernels {
 namespace fpA_intB_gemv {
 
+// Accumulator element of the K-paired inner loop, see accumulate_column_tile below. 16-bit
+// accumulation keeps the two k lanes of the vec2 apart until the epilogue so that folding in the
+// group scale costs a single fma2; fp32 accumulation reduces each tile to one float right away.
+template <typename Details, typename AccT>
+using TileAccType =
+    std::conditional_t<std::is_same_v<AccT, float>, float,
+                       typename MathWrapper<typename Details::TypeDetailsA>::Type2>;
+
+// Accumulates the K tile of one output column into `acc`.
+//
+// This replaces the dequantize/pack_to_vec2/mma sequence of the dense fpA_intB GEMV, which pairs
+// the products across two *columns* so that one hfma2 serves both. That pairing needs the decoded
+// weights shuffled into column-major register pairs, costing one prmt per weight pair -- about a
+// ninth of the QMoE decode GEMV's issued instructions. Pairing along K instead needs no shuffle at
+// all: the activation tile is already in k order and the converters emit k pairs contiguously
+// (Mapper sends a logical pair to a physical pair, and to an even physical index, so the vec2 load
+// stays aligned).
+//
+// The group scale is applied once to the tile sum instead of to every decoded weight, turning four
+// fma2 per column and K tile into one. This is the same product either way: the caller loads a
+// single scale per column and K tile, so it already required the tile to sit inside one scale
+// group (StepK <= GroupSize), which every launched configuration satisfies.
+template <typename Details, int K, typename TileAccT, typename TypeA>
+__device__ __forceinline__ void accumulate_column_tile(TileAccT& acc, void const* w, void const* act, TypeA scale) {
+  using Math = MathWrapper<typename Details::TypeDetailsA>;
+  using Type = typename Math::Type;
+  using Type2 = typename Math::Type2;
+  static_assert(K % 2 == 0);
+  typename Details::LayoutDetails::Mapper mapper;
+
+  Type2 partial = Math::to_vec2(static_cast<Type>(0.f));
+#pragma unroll
+  for (int j = 0; j < K / 2; ++j) {
+    Type2 const w2 = *reinterpret_cast<Type2 const*>(reinterpret_cast<Type const*>(w) + mapper(2 * j));
+    partial = Math::fma2(w2, reinterpret_cast<Type2 const*>(act)[j], partial);
+  }
+
+  if constexpr (std::is_same_v<TileAccT, float>) {
+    float2 const p = Math::to_float2(partial);
+    acc += static_cast<float>(scale) * (p.x + p.y);
+  } else {
+    acc = Math::fma2(partial, Math::to_vec2(scale), acc);
+  }
+}
+
+// Collapses the K-paired accumulators into the one-value-per-column form the epilogues expect.
+template <typename Details, int CtaN, typename AccT, typename TileAccT>
+__device__ __forceinline__ void collapse_tile_acc(AccT* tile_acc, TileAccT const* tile_k_acc) {
+  using Math = MathWrapper<typename Details::TypeDetailsA>;
+#pragma unroll
+  for (int i = 0; i < CtaN; ++i) {
+    if constexpr (std::is_same_v<TileAccT, float>) {
+      tile_acc[i] = tile_k_acc[i];
+    } else {
+      float2 const p = Math::to_float2(tile_k_acc[i]);
+      tile_acc[i] = static_cast<AccT>(p.x + p.y);
+    }
+  }
+}
+
 template <typename Details, int CtaN, int Threads, int GroupSize, bool EnableBias,
           typename TypeA = typename Details::TypeDetailsA::Type, typename AccT = TypeA>
 __global__ void moe_gemv_kernel(TypeA* act, uint8_t* weight, TypeA* scales, TypeA* bias, TypeA* out,
@@ -73,48 +133,57 @@ __global__ void moe_gemv_kernel(TypeA* act, uint8_t* weight, TypeA* scales, Type
   GMemIterator<Mandatory, AccessTypeW, CtaN, Details::kAccessNumW, uint8_t> weight_iterator(
       weight, (interleaved_offset_n * interleaved_k + tid * StepK) / Details::kElemsPerByteW,
       CtaK / Details::kElemsPerByteW, interleaved_k / Details::kElemsPerByteW);
-  GMemIterator<Mandatory, TypeA, CtaN, 1, TypeA> scales_iterator(
-      scales,
-      (GroupSize != 0 ? real_offset_k / GroupSize * n : 0) + real_offset_n,
-      (GroupSize != 0 ? CtaK / Details::kInterleave / GroupSize * n : 0), Details::kInterleave);
+  using ScalesAccessT = ScalesAccess<TypeA, CtaN, Details::kInterleave>;
+  GMemIterator<Mandatory, typename ScalesAccessT::TVec, ScalesAccessT::kStrided, ScalesAccessT::kContinuous, TypeA>
+      scales_iterator(
+          scales,
+          (GroupSize != 0 ? real_offset_k / GroupSize * n : 0) + real_offset_n,
+          (GroupSize != 0 ? CtaK / Details::kInterleave / GroupSize * n : 0), Details::kInterleave);
 
   out += offset_m * n + tile_id_n * CtaN * Details::kInterleave;
   if constexpr (EnableBias) {
     bias += tile_id_n * CtaN * Details::kInterleave;
   }
 
-  AccT tile_acc[CtaM * CtaN];
-  fill<CtaM * CtaN>(tile_acc, static_cast<AccT>(0.f));
+  using Converter = typename ConverterWrapper<Details>::Converter;
+  using TileAccT = TileAccType<Details, AccT>;
+  using Math = MathWrapper<typename Details::TypeDetailsA>;
+
+  TileAccT tile_k_acc[CtaN];
+  if constexpr (std::is_same_v<TileAccT, float>) {
+    fill<CtaN>(tile_k_acc, 0.f);
+  } else {
+    fill<CtaN>(tile_k_acc, Math::to_vec2(static_cast<typename Math::Type>(0.f)));
+  }
 
   TypeA vec_scale[CtaN];
   if constexpr (GroupSize == 0) {
-#pragma unroll
-    for (int i = 0; i < CtaN; ++i) {
-      scales_iterator.load(vec_scale + i, 0, i);
-    }
+    load_scales<ScalesAccessT, CtaN>(scales_iterator, vec_scale, 0);
   }
 
   for (int idx_k = tid * StepK, iter = 0; idx_k < interleaved_k; idx_k += CtaK, ++iter) {
-    TypeA tile_a[StepK], tile_w[StepK], tile_w_pack2[CtaN * StepK];
-    uint8_t tile_w_quantized[StepK / Details::kElemsPerByteW];
+    TypeA tile_a[StepK];
+    // Issue all CtaN weight loads before consuming any of them: interleaving a load with its own
+    // decode leaves a single load in flight and makes the kernel long-scoreboard bound.
+    AccessTypeW tile_w_quantized[CtaN * Details::kAccessNumW];
     if constexpr (GroupSize != 0) {
+      load_scales<ScalesAccessT, CtaN>(scales_iterator, vec_scale, iter);
+    }
+    act_iterator.load(tile_a, iter, 0);
 #pragma unroll
-      for (int i = 0; i < CtaN; ++i) {
-        scales_iterator.load(vec_scale + i, iter, i);
-      }
+    for (int i = 0; i < CtaN; ++i) {
+      weight_iterator.load(tile_w_quantized + i * Details::kAccessNumW, iter, i);
     }
 #pragma unroll
     for (int i = 0; i < CtaN; ++i) {
-      weight_iterator.load(tile_w_quantized, iter, i);
-      dequantize<Details, 1, StepK, false, false>(tile_w, tile_w_quantized, vec_scale + i, nullptr, 1.0f);
-      pack_to_vec2<Details, StepK>(tile_w_pack2, tile_w, i);
-    }
-#pragma unroll
-    for (int i = 0; i < CtaM; ++i) {
-      act_iterator.load(tile_a, iter, i);
-      mma<Details, 1, CtaN, StepK, AccT>(tile_acc + i * CtaN, tile_w_pack2, tile_a);
+      TypeA tile_w[StepK];
+      Converter::template convert<StepK>(tile_w_quantized + i * Details::kAccessNumW, tile_w);
+      accumulate_column_tile<Details, StepK>(tile_k_acc[i], tile_w, tile_a, vec_scale[i]);
     }
   }
+
+  AccT tile_acc[CtaM * CtaN];
+  collapse_tile_acc<Details, CtaN>(tile_acc, tile_k_acc);
   epilogue<Details, CtaM, CtaN, Threads, EnableBias, false, AccT>(out, n, tile_acc, bias, 1.0f);
 #endif
 }
@@ -234,48 +303,56 @@ __global__ void moe_gemv_interleaved_swiglu_kernel(
   GMemIterator<Mandatory, AccessTypeW, CtaN, Details::kAccessNumW, uint8_t> weight_iterator(
       weight, (interleaved_offset_n * interleaved_k + tid * StepK) / Details::kElemsPerByteW,
       CtaK / Details::kElemsPerByteW, interleaved_k / Details::kElemsPerByteW);
-  GMemIterator<Mandatory, TypeA, CtaN, 1, TypeA> scales_iterator(
-      scales,
-      (GroupSize != 0 ? real_offset_k / GroupSize * n : 0) + real_offset_n,
-      (GroupSize != 0 ? CtaK / Details::kInterleave / GroupSize * n : 0), Details::kInterleave);
+  using ScalesAccessT = ScalesAccess<TypeA, CtaN, Details::kInterleave>;
+  GMemIterator<Mandatory, typename ScalesAccessT::TVec, ScalesAccessT::kStrided, ScalesAccessT::kContinuous, TypeA>
+      scales_iterator(
+          scales,
+          (GroupSize != 0 ? real_offset_k / GroupSize * n : 0) + real_offset_n,
+          (GroupSize != 0 ? CtaK / Details::kInterleave / GroupSize * n : 0), Details::kInterleave);
 
   out += offset_m * inter_size + tile_id_n * CtaN * Details::kInterleave / 2;
   if constexpr (EnableBias) {
     bias += tile_id_n * CtaN * Details::kInterleave;
   }
 
-  AccT tile_acc[CtaM * CtaN];
-  fill<CtaM * CtaN>(tile_acc, static_cast<AccT>(0.f));
+  using Converter = typename ConverterWrapper<Details>::Converter;
+  using TileAccT = TileAccType<Details, AccT>;
+  using Math = MathWrapper<typename Details::TypeDetailsA>;
+
+  TileAccT tile_k_acc[CtaN];
+  if constexpr (std::is_same_v<TileAccT, float>) {
+    fill<CtaN>(tile_k_acc, 0.f);
+  } else {
+    fill<CtaN>(tile_k_acc, Math::to_vec2(static_cast<typename Math::Type>(0.f)));
+  }
 
   TypeA vec_scale[CtaN];
   if constexpr (GroupSize == 0) {
-#pragma unroll
-    for (int i = 0; i < CtaN; ++i) {
-      scales_iterator.load(vec_scale + i, 0, i);
-    }
+    load_scales<ScalesAccessT, CtaN>(scales_iterator, vec_scale, 0);
   }
 
   for (int idx_k = tid * StepK, iter = 0; idx_k < interleaved_k; idx_k += CtaK, ++iter) {
-    TypeA tile_a[StepK], tile_w[StepK], tile_w_pack2[CtaN * StepK];
-    uint8_t tile_w_quantized[StepK / Details::kElemsPerByteW];
+    TypeA tile_a[StepK];
+    // See moe_gemv_kernel: keep all CtaN weight loads in flight at once.
+    AccessTypeW tile_w_quantized[CtaN * Details::kAccessNumW];
     if constexpr (GroupSize != 0) {
+      load_scales<ScalesAccessT, CtaN>(scales_iterator, vec_scale, iter);
+    }
+    act_iterator.load(tile_a, iter, 0);
 #pragma unroll
-      for (int i = 0; i < CtaN; ++i) {
-        scales_iterator.load(vec_scale + i, iter, i);
-      }
+    for (int i = 0; i < CtaN; ++i) {
+      weight_iterator.load(tile_w_quantized + i * Details::kAccessNumW, iter, i);
     }
 #pragma unroll
     for (int i = 0; i < CtaN; ++i) {
-      weight_iterator.load(tile_w_quantized, iter, i);
-      dequantize<Details, 1, StepK, false, false>(tile_w, tile_w_quantized, vec_scale + i, nullptr, 1.0f);
-      pack_to_vec2<Details, StepK>(tile_w_pack2, tile_w, i);
-    }
-#pragma unroll
-    for (int i = 0; i < CtaM; ++i) {
-      act_iterator.load(tile_a, iter, i);
-      mma<Details, 1, CtaN, StepK, AccT>(tile_acc + i * CtaN, tile_w_pack2, tile_a);
+      TypeA tile_w[StepK];
+      Converter::template convert<StepK>(tile_w_quantized + i * Details::kAccessNumW, tile_w);
+      accumulate_column_tile<Details, StepK>(tile_k_acc[i], tile_w, tile_a, vec_scale[i]);
     }
   }
+
+  AccT tile_acc[CtaM * CtaN];
+  collapse_tile_acc<Details, CtaN>(tile_acc, tile_k_acc);
   swiglu_epilogue<Details, CtaM, CtaN, Threads, EnableBias, TypeA, AccT>(out, tile_acc, bias, activation_params);
 #endif
 }

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemv_device.cuh
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemv_device.cuh
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <cuda_fp16.h>
+#include <cstdint>
 #include <type_traits>
 
 #include "core/common/common.h"
@@ -156,13 +157,16 @@ __global__ void moe_gemv_kernel(TypeA* act, uint8_t* weight, TypeA* scales, Type
     fill<CtaN>(tile_k_acc, Math::to_vec2(static_cast<typename Math::Type>(0.f)));
   }
 
-  TypeA vec_scale[CtaN];
+  // load_scales() writes through a ScalesAccessT::TVec* (float4 when vectorized), and the
+  // iterators/converters below write tile_a through AccessTypeA* and tile_w through uint32_t*,
+  // so these arrays need the alignment of the widest access, not just of TypeA.
+  alignas(alignof(typename ScalesAccessT::TVec)) TypeA vec_scale[CtaN];
   if constexpr (GroupSize == 0) {
     load_scales<ScalesAccessT, CtaN>(scales_iterator, vec_scale, 0);
   }
 
   for (int idx_k = tid * StepK, iter = 0; idx_k < interleaved_k; idx_k += CtaK, ++iter) {
-    TypeA tile_a[StepK];
+    alignas(alignof(AccessTypeA)) TypeA tile_a[StepK];
     // Issue all CtaN weight loads before consuming any of them: interleaving a load with its own
     // decode leaves a single load in flight and makes the kernel long-scoreboard bound.
     AccessTypeW tile_w_quantized[CtaN * Details::kAccessNumW];
@@ -176,7 +180,7 @@ __global__ void moe_gemv_kernel(TypeA* act, uint8_t* weight, TypeA* scales, Type
     }
 #pragma unroll
     for (int i = 0; i < CtaN; ++i) {
-      TypeA tile_w[StepK];
+      alignas(alignof(uint32_t)) TypeA tile_w[StepK];
       Converter::template convert<StepK>(tile_w_quantized + i * Details::kAccessNumW, tile_w);
       accumulate_column_tile<Details, StepK>(tile_k_acc[i], tile_w, tile_a, vec_scale[i]);
     }
@@ -326,13 +330,14 @@ __global__ void moe_gemv_interleaved_swiglu_kernel(
     fill<CtaN>(tile_k_acc, Math::to_vec2(static_cast<typename Math::Type>(0.f)));
   }
 
-  TypeA vec_scale[CtaN];
+  // See moe_gemv_kernel: these are written through wider pointer casts than TypeA.
+  alignas(alignof(typename ScalesAccessT::TVec)) TypeA vec_scale[CtaN];
   if constexpr (GroupSize == 0) {
     load_scales<ScalesAccessT, CtaN>(scales_iterator, vec_scale, 0);
   }
 
   for (int idx_k = tid * StepK, iter = 0; idx_k < interleaved_k; idx_k += CtaK, ++iter) {
-    TypeA tile_a[StepK];
+    alignas(alignof(AccessTypeA)) TypeA tile_a[StepK];
     // See moe_gemv_kernel: keep all CtaN weight loads in flight at once.
     AccessTypeW tile_w_quantized[CtaN * Details::kAccessNumW];
     if constexpr (GroupSize != 0) {
@@ -345,7 +350,7 @@ __global__ void moe_gemv_interleaved_swiglu_kernel(
     }
 #pragma unroll
     for (int i = 0; i < CtaN; ++i) {
-      TypeA tile_w[StepK];
+      alignas(alignof(uint32_t)) TypeA tile_w[StepK];
       Converter::template convert<StepK>(tile_w_quantized + i * Details::kAccessNumW, tile_w);
       accumulate_column_tile<Details, StepK>(tile_k_acc[i], tile_w, tile_a, vec_scale[i]);
     }

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemv_device.cuh
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemv_device.cuh
@@ -41,6 +41,12 @@ using TileAccType =
 // matching the original dequantize-then-mma order, this prevents an unscaled fp16 product from
 // overflowing even when the final scaled product is representable. The fp32 policy converts each
 // scaled pair before multiplying so BF16 products are not accumulated in BF16 first.
+//
+// Numerics: this is a reassociation, not a rewrite. The 16-bit policy keeps the even-k and odd-k
+// partial sums in the two halves of one vec2 and only adds them together in collapse_tile_acc,
+// where the previous code summed a column's K terms in one serial chain. Floating-point addition
+// is not associative, so results are close but not bit-identical to that order; the per-thread
+// chain is now half as long, which if anything reduces accumulated rounding error.
 template <typename Details, int K, typename TileAccT, typename TypeA>
 __device__ __forceinline__ void accumulate_column_tile(TileAccT& acc, void const* w, void const* act, TypeA scale) {
   using Math = MathWrapper<typename Details::TypeDetailsA>;

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemv_device.cuh
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemv_device.cuh
@@ -20,8 +20,8 @@ namespace kernels {
 namespace fpA_intB_gemv {
 
 // Accumulator element of the K-paired inner loop, see accumulate_column_tile below. 16-bit
-// accumulation keeps the two k lanes of the vec2 apart until the epilogue so that folding in the
-// group scale costs a single fma2; fp32 accumulation reduces each tile to one float right away.
+// accumulation keeps the two k lanes of the vec2 apart until the epilogue; fp32 accumulation
+// reduces each pair to one float right away.
 template <typename Details, typename AccT>
 using TileAccType =
     std::conditional_t<std::is_same_v<AccT, float>, float,
@@ -37,10 +37,10 @@ using TileAccType =
 // (Mapper sends a logical pair to a physical pair, and to an even physical index, so the vec2 load
 // stays aligned).
 //
-// The group scale is applied once to the tile sum instead of to every decoded weight, turning four
-// fma2 per column and K tile into one. This is the same product either way: the caller loads a
-// single scale per column and K tile, so it already required the tile to sit inside one scale
-// group (StepK <= GroupSize), which every launched configuration satisfies.
+// Apply the group scale to each decoded weight before multiplying by the activation. Besides
+// matching the original dequantize-then-mma order, this prevents an unscaled fp16 product from
+// overflowing even when the final scaled product is representable. The fp32 policy converts each
+// scaled pair before multiplying so BF16 products are not accumulated in BF16 first.
 template <typename Details, int K, typename TileAccT, typename TypeA>
 __device__ __forceinline__ void accumulate_column_tile(TileAccT& acc, void const* w, void const* act, TypeA scale) {
   using Math = MathWrapper<typename Details::TypeDetailsA>;
@@ -49,18 +49,20 @@ __device__ __forceinline__ void accumulate_column_tile(TileAccT& acc, void const
   static_assert(K % 2 == 0);
   typename Details::LayoutDetails::Mapper mapper;
 
-  Type2 partial = Math::to_vec2(static_cast<Type>(0.f));
+  Type2 const zero = Math::to_vec2(static_cast<Type>(0.f));
+  Type2 const scale2 = Math::to_vec2(scale);
 #pragma unroll
   for (int j = 0; j < K / 2; ++j) {
     Type2 const w2 = *reinterpret_cast<Type2 const*>(reinterpret_cast<Type const*>(w) + mapper(2 * j));
-    partial = Math::fma2(w2, reinterpret_cast<Type2 const*>(act)[j], partial);
-  }
-
-  if constexpr (std::is_same_v<TileAccT, float>) {
-    float2 const p = Math::to_float2(partial);
-    acc += static_cast<float>(scale) * (p.x + p.y);
-  } else {
-    acc = Math::fma2(partial, Math::to_vec2(scale), acc);
+    Type2 const scaled_w2 = Math::fma2(w2, scale2, zero);
+    Type2 const a2 = reinterpret_cast<Type2 const*>(act)[j];
+    if constexpr (std::is_same_v<TileAccT, float>) {
+      float2 const scaled_w_f2 = Math::to_float2(scaled_w2);
+      float2 const a_f2 = Math::to_float2(a2);
+      acc += scaled_w_f2.x * a_f2.x + scaled_w_f2.y * a_f2.y;
+    } else {
+      acc = Math::fma2(scaled_w2, a2, acc);
+    }
   }
 }
 

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemv_fp4.cu
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemv_fp4.cu
@@ -273,7 +273,8 @@ void launch_moe_gemv_fp4_symmetric(const T* act, const uint8_t* weight, const T*
   // AccT follows the Fp4GemvAccT policy (fp16->fp16 accum, bf16->fp32 accum): bf16 has only 7
   // mantissa bits, so 16-bit accumulation over K loses too much precision and fails tolerance
   // (e.g. NVFP4 block-16 decode at k=512). CtaN/Threads remain pure parallelization/tiling knobs
-  // and the accumulation dtype is identical for every config, so this sweep stays bit-exact.
+  // and the accumulation dtype is identical for every config, so every config computes the same
+  // dot products; Threads additionally sets the K partition, so it perturbs the summation order.
   auto launch = [&](auto cta_n, auto threads) {
     fiv::dispatch_moe_gemv_group_size<Details, cta_n(), threads(), T, Fp4GemvAccT<T>>(
         const_cast<T*>(act), const_cast<uint8_t*>(weight), const_cast<T*>(scales), const_cast<T*>(bias), out,
@@ -329,7 +330,8 @@ void launch_moe_gemv_fp4_symmetric_interleaved_swiglu(
   }
   using Details = Fp4KernelDetails<T>;
   // AccT follows the Fp4GemvAccT policy (fp16->fp16, bf16->fp32); see launch_moe_gemv_fp4_symmetric.
-  // The CtaN/Threads sweep stays bit-exact across configs since the accumulation dtype is fixed.
+  // The accumulation dtype is fixed across the CtaN/Threads sweep; Threads still changes the K
+  // partition, so it is a tiling knob, not a bit-exact one.
   auto launch = [&](auto cta_n, auto threads) {
     fiv::dispatch_moe_gemv_interleaved_swiglu_group_size<Details, cta_n(), threads(), T, Fp4GemvAccT<T>>(
         const_cast<T*>(act), const_cast<uint8_t*>(weight), const_cast<T*>(scales), const_cast<T*>(bias), out,

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemv_fp4.cu
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemv_fp4.cu
@@ -10,6 +10,7 @@
 #include "contrib_ops/cuda/llm/moe_gemm/moe_gemv.h"
 // Shared device-side kernels + launch/dispatch helpers (fpA_intB_gemv namespace).
 #include "contrib_ops/cuda/llm/moe_gemm/moe_gemv_device.cuh"
+#include "contrib_ops/cuda/llm/common/cuda_runtime_utils.h"
 #include "core/platform/env_var_utils.h"
 
 namespace onnxruntime::llm {
@@ -53,6 +54,50 @@ bool Fp4MoeGemvInterleavedHalfAccum() {
 // divisor that keeps n % (CtaN*kInterleave) == 0 for the target shapes. kInterleave = 4 here.
 static constexpr int kInterleavedCtaN = 4;
 static constexpr int kInterleavedThreads = 128;
+
+// Opt-out for the shape-derived default tiling (env ORT_FP4_GEMV_DEFAULT_TILING=0), which
+// restores the fixed kDefaultCtaN/kDefaultThreads tiling for every shape.
+static bool Fp4MoeGemvUseDefaultTilingHeuristic() {
+  static bool const enabled =
+      onnxruntime::ParseEnvironmentVariableWithDefault<int>("ORT_FP4_GEMV_DEFAULT_TILING", 1) == 1;
+  return enabled;
+}
+
+// Blocks per SM required before a 64-thread block is worth it. The grid is fixed by
+// (expanded_num_rows, n / CtaN) and does not depend on Threads, so halving the block size halves
+// the threads each block contributes to residency. These kernels are register-limited (about 72
+// registers/thread on sm_90, so roughly 900 resident threads/SM), which a 128-thread block reaches
+// with ~7 resident blocks and a 64-thread block only with ~14. Requiring 16 blocks/SM therefore
+// keeps the SM just as full while halving the epilogue's reduction width.
+static constexpr int64_t kMinBlocksPerSmForThreads64 = 16;
+
+MoeGemvConfig Fp4MoeGemvDefaultConfig(int64_t expanded_num_rows, int64_t n, int64_t k) {
+  // The interleaved path pins its own CtaN/Threads and ignores `config`.
+  if (Fp4MoeGemvUseInterleaved() || !Fp4MoeGemvUseDefaultTilingHeuristic()) {
+    return MoeGemvConfig::kDefault;
+  }
+  // Each block walks K in strides of CtaK = StepK * Threads, with StepK = 128 / activation_bits.
+  constexpr int64_t kStepK = 128 / 16;
+  constexpr int64_t kDefaultCtaK = kStepK * kDefaultThreads;
+
+  // (a) Idle threads. When CtaK > k the tail of every block never enters the K loop at all, so a
+  //     128-thread block leaves half its threads doing nothing (NVFP4 fc2 has k = inter_size,
+  //     e.g. 512 against CtaK = 1024). Narrowing the block is a pure win here.
+  if (kDefaultCtaK > k) {
+    return MoeGemvConfig::kThreads64;
+  }
+
+  // (b) Epilogue cost. The MAC work per block is fixed by (CtaN, k) regardless of Threads, but the
+  //     epilogue reduces partial sums across Threads/32 warps through shared memory. A narrower
+  //     block does the same math with half the barriers and a shallower reduction tree, so prefer
+  //     it whenever the grid is large enough that the SM still fills up (see the constant above).
+  static int const sm_count = common::getMultiProcessorCount();
+  const int64_t blocks = expanded_num_rows * (n / kDefaultCtaN);
+  if (blocks >= kMinBlocksPerSmForThreads64 * sm_count) {
+    return MoeGemvConfig::kThreads64;
+  }
+  return MoeGemvConfig::kDefault;
+}
 
 // --- MXFP4 (e2m1) GEMV: non-interleaved ColumnMajor layout (kInterleave = 1) ---
 // Weights are the QMoERepackFP4ColToRow output ([experts, n, k/2] row-major, two e2m1

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemv_fp4.cu
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemv_fp4.cu
@@ -71,7 +71,8 @@ static bool Fp4MoeGemvUseDefaultTilingHeuristic() {
 // keeps the SM just as full while halving the epilogue's reduction width.
 static constexpr int64_t kMinBlocksPerSmForThreads64 = 16;
 
-MoeGemvConfig Fp4MoeGemvDefaultConfig(int64_t expanded_num_rows, int64_t n, int64_t k) {
+MoeGemvConfig Fp4MoeGemvDefaultConfig(int64_t expanded_num_rows, int64_t n, int64_t k,
+                                      int multi_processor_count) {
   // The interleaved path pins its own CtaN/Threads and ignores `config`.
   if (Fp4MoeGemvUseInterleaved() || !Fp4MoeGemvUseDefaultTilingHeuristic()) {
     return MoeGemvConfig::kDefault;
@@ -91,9 +92,8 @@ MoeGemvConfig Fp4MoeGemvDefaultConfig(int64_t expanded_num_rows, int64_t n, int6
   //     epilogue reduces partial sums across Threads/32 warps through shared memory. A narrower
   //     block does the same math with half the barriers and a shallower reduction tree, so prefer
   //     it whenever the grid is large enough that the SM still fills up (see the constant above).
-  static int const sm_count = common::getMultiProcessorCount();
   const int64_t blocks = expanded_num_rows * (n / kDefaultCtaN);
-  if (blocks >= kMinBlocksPerSmForThreads64 * sm_count) {
+  if (blocks >= kMinBlocksPerSmForThreads64 * multi_processor_count) {
     return MoeGemvConfig::kThreads64;
   }
   return MoeGemvConfig::kDefault;
@@ -176,7 +176,7 @@ bool is_moe_gemv_fp4_supported(int sm, int64_t expanded_num_rows, int64_t n, int
   if (k % group_size != 0) {
     return false;
   }
-  if (expanded_num_rows <= 0 || expanded_num_rows > kMaxProfiledExpandedRows) {
+  if (expanded_num_rows <= 0 || expanded_num_rows > kMaxProfiledExpandedRowsFp4) {
     return false;
   }
   if (n < kMinProfiledProblemDim || k < kMinProfiledProblemDim) {

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemv_fp4.h
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemv_fp4.h
@@ -33,6 +33,14 @@ enum class MoeGemvConfig {
 // compute dispatch query this so the prepacked weights and the kernel always agree.
 bool Fp4MoeGemvUseInterleaved();
 
+// Shape-derived default tiling for the non-interleaved ColumnMajor FP4 GEMV. Used whenever the
+// runtime does not have a profiled result for the shape, which is the shipping default because
+// ORT_FP4_GEMV_AUTOTUNE is off (it synchronizes the inference stream) and is skipped entirely
+// during CUDA-graph capture. Only Threads is derived; CtaN stays at the default, so the result
+// never changes which shapes is_moe_gemv_fp4_supported accepts. Set ORT_FP4_GEMV_DEFAULT_TILING=0
+// to fall back to the fixed default tiling.
+MoeGemvConfig Fp4MoeGemvDefaultConfig(int64_t expanded_num_rows, int64_t n, int64_t k);
+
 // FP4 GEMV shape support for the non-interleaved ColumnMajor layout (kInterleave = 1). Shared by
 // both MXFP4 (group_size == 32) and NVFP4 (group_size == 16). Requires sm >= 80, n divisible by
 // the kernel tile width (kCtaN) selected by `config`, and the profiled small-decode row/dim

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemv_fp4.h
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemv_fp4.h
@@ -16,8 +16,11 @@ namespace onnxruntime::llm {
 namespace kernels {
 namespace moe_gemv {
 
-// Tiling/parallelization knob selected by the FP4 GEMV autotuner. CtaN/Threads are pure
-// tiling knobs (numerically bit-exact), so the sweep only picks the fastest.
+// Tiling/parallelization knob selected by the FP4 GEMV autotuner. Every config computes the same
+// dot products with the same accumulation dtype, so the sweep only picks the fastest. CtaN is
+// bit-exact (it only changes how many output columns a block owns). Threads is *not*: a block
+// walks K in strides of StepK * Threads and the epilogue reduces across Threads/32 warps, so
+// changing it changes the summation order and the low bits of the result can move.
 enum class MoeGemvConfig {
   kDefault,
   kCtaN16,
@@ -41,8 +44,9 @@ bool Fp4MoeGemvUseInterleaved();
 // runtime does not have a profiled result for the shape, which is the shipping default because
 // ORT_FP4_GEMV_AUTOTUNE is off (it synchronizes the inference stream) and is skipped entirely
 // during CUDA-graph capture. Only Threads is derived; CtaN stays at the default, so the result
-// never changes which shapes is_moe_gemv_fp4_supported accepts. Set ORT_FP4_GEMV_DEFAULT_TILING=0
-// to fall back to the fixed default tiling.
+// never changes which shapes is_moe_gemv_fp4_supported accepts. Note that Threads sets the K
+// partition, so the choice moves the last bits of the output (see MoeGemvConfig above). Set
+// ORT_FP4_GEMV_DEFAULT_TILING=0 to fall back to the fixed default tiling.
 MoeGemvConfig Fp4MoeGemvDefaultConfig(int64_t expanded_num_rows, int64_t n, int64_t k,
                                       int multi_processor_count);
 

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemv_fp4.h
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemv_fp4.h
@@ -24,6 +24,10 @@ enum class MoeGemvConfig {
   kThreads64,
 };
 
+// Cover Qwen-style top_k=8 MTP decode. An (N+1)-token verification for
+// num_speculative_tokens=N expands to (N+1)*8 rows, up to 64 for N=7.
+inline constexpr int64_t kMaxProfiledExpandedRowsFp4 = 64;
+
 // True when the opt-in interleaved MXFP4 GEMV path is enabled (env ORT_FP4_GEMV_INTERLEAVED=1).
 // It combines three changes over the default path: (a) the INT4-style ColumnMajorInterleaved FP4
 // weight layout (kInterleave=4, kStepK=32) for 4x fewer K-trips, (b) dtype-conditional accumulation
@@ -39,7 +43,8 @@ bool Fp4MoeGemvUseInterleaved();
 // during CUDA-graph capture. Only Threads is derived; CtaN stays at the default, so the result
 // never changes which shapes is_moe_gemv_fp4_supported accepts. Set ORT_FP4_GEMV_DEFAULT_TILING=0
 // to fall back to the fixed default tiling.
-MoeGemvConfig Fp4MoeGemvDefaultConfig(int64_t expanded_num_rows, int64_t n, int64_t k);
+MoeGemvConfig Fp4MoeGemvDefaultConfig(int64_t expanded_num_rows, int64_t n, int64_t k,
+                                      int multi_processor_count);
 
 // FP4 GEMV shape support for the non-interleaved ColumnMajor layout (kInterleave = 1). Shared by
 // both MXFP4 (group_size == 32) and NVFP4 (group_size == 16). Requires sm >= 80, n divisible by

--- a/onnxruntime/contrib_ops/cuda/moe/moe_quantization.cc
+++ b/onnxruntime/contrib_ops/cuda/moe/moe_quantization.cc
@@ -1438,8 +1438,11 @@ Status QMoE::ComputeInternal(OpKernelContext* context) const {
       // analytic default and, when autotune is on, profile on a non-captured (warmup) call
       // and freeze the choice for CUDA-graph replay. During capture (or when autotune is
       // off, which is the shipping default) the analytic default is what actually runs.
-      MoeGemvConfig fc1_config = gemv::Fp4MoeGemvDefaultConfig(expanded, fc1_n, hidden);
-      MoeGemvConfig fc2_config = gemv::Fp4MoeGemvDefaultConfig(expanded, hidden, inter);
+        const int multi_processor_count = GetDeviceProp().multiProcessorCount;
+        MoeGemvConfig fc1_config =
+          gemv::Fp4MoeGemvDefaultConfig(expanded, fc1_n, hidden, multi_processor_count);
+        MoeGemvConfig fc2_config =
+          gemv::Fp4MoeGemvDefaultConfig(expanded, hidden, inter, multi_processor_count);
 
       const int64_t row_bucket =
           onnxruntime::llm::kernels::cutlass_kernels::MoeGemmProfiler::bucketM(expanded);

--- a/onnxruntime/contrib_ops/cuda/moe/moe_quantization.cc
+++ b/onnxruntime/contrib_ops/cuda/moe/moe_quantization.cc
@@ -1438,10 +1438,10 @@ Status QMoE::ComputeInternal(OpKernelContext* context) const {
       // analytic default and, when autotune is on, profile on a non-captured (warmup) call
       // and freeze the choice for CUDA-graph replay. During capture (or when autotune is
       // off, which is the shipping default) the analytic default is what actually runs.
-        const int multi_processor_count = GetDeviceProp().multiProcessorCount;
-        MoeGemvConfig fc1_config =
+      const int multi_processor_count = GetDeviceProp().multiProcessorCount;
+      MoeGemvConfig fc1_config =
           gemv::Fp4MoeGemvDefaultConfig(expanded, fc1_n, hidden, multi_processor_count);
-        MoeGemvConfig fc2_config =
+      MoeGemvConfig fc2_config =
           gemv::Fp4MoeGemvDefaultConfig(expanded, hidden, inter, multi_processor_count);
 
       const int64_t row_bucket =

--- a/onnxruntime/contrib_ops/cuda/moe/moe_quantization.cc
+++ b/onnxruntime/contrib_ops/cuda/moe/moe_quantization.cc
@@ -1432,12 +1432,14 @@ Status QMoE::ComputeInternal(OpKernelContext* context) const {
 
       using MoeGemvConfig = gemv::MoeGemvConfig;
 
-      // Choose the fc1 (SwiGLU) and fc2 GEMV tiling configs. CtaN/Threads are pure tiling
-      // knobs (numerically bit-exact), so the only goal is picking the fastest. Reuse a
-      // cached per-shape result when available; otherwise start from the shape-derived
-      // analytic default and, when autotune is on, profile on a non-captured (warmup) call
-      // and freeze the choice for CUDA-graph replay. During capture (or when autotune is
-      // off, which is the shipping default) the analytic default is what actually runs.
+      // Choose the fc1 (SwiGLU) and fc2 GEMV tiling configs. Every config computes the same
+      // dot products with the same accumulation dtype, so the only goal is picking the
+      // fastest; Threads does set the K partition, so the low bits of the output can move
+      // between configs (see MoeGemvConfig). Reuse a cached per-shape result when available;
+      // otherwise start from the shape-derived analytic default and, when autotune is on,
+      // profile on a non-captured (warmup) call and freeze the choice for CUDA-graph replay.
+      // During capture (or when autotune is off, which is the shipping default) the analytic
+      // default is what actually runs.
       const int multi_processor_count = GetDeviceProp().multiProcessorCount;
       MoeGemvConfig fc1_config =
           gemv::Fp4MoeGemvDefaultConfig(expanded, fc1_n, hidden, multi_processor_count);

--- a/onnxruntime/contrib_ops/cuda/moe/moe_quantization.cc
+++ b/onnxruntime/contrib_ops/cuda/moe/moe_quantization.cc
@@ -1434,11 +1434,12 @@ Status QMoE::ComputeInternal(OpKernelContext* context) const {
 
       // Choose the fc1 (SwiGLU) and fc2 GEMV tiling configs. CtaN/Threads are pure tiling
       // knobs (numerically bit-exact), so the only goal is picking the fastest. Reuse a
-      // cached per-shape result when available; otherwise profile on a non-captured (warmup)
-      // call and freeze the choice for CUDA-graph replay. During capture (or when autotune is
-      // off) fall back to the default tiling.
-      MoeGemvConfig fc1_config = MoeGemvConfig::kDefault;
-      MoeGemvConfig fc2_config = MoeGemvConfig::kDefault;
+      // cached per-shape result when available; otherwise start from the shape-derived
+      // analytic default and, when autotune is on, profile on a non-captured (warmup) call
+      // and freeze the choice for CUDA-graph replay. During capture (or when autotune is
+      // off, which is the shipping default) the analytic default is what actually runs.
+      MoeGemvConfig fc1_config = gemv::Fp4MoeGemvDefaultConfig(expanded, fc1_n, hidden);
+      MoeGemvConfig fc2_config = gemv::Fp4MoeGemvDefaultConfig(expanded, hidden, inter);
 
       const int64_t row_bucket =
           onnxruntime::llm::kernels::cutlass_kernels::MoeGemmProfiler::bucketM(expanded);

--- a/onnxruntime/test/python/transformers/test_qmoe_nvfp4_cuda.py
+++ b/onnxruntime/test/python/transformers/test_qmoe_nvfp4_cuda.py
@@ -19,6 +19,8 @@
 # --------------------------------------------------------------------------
 
 import os
+import subprocess
+import sys
 import unittest
 
 import numpy
@@ -640,6 +642,9 @@ class TestQMoENVFP4(unittest.TestCase):
     # decode-shaped SwiGLU cases route through the NVFP4 GEMV kernel (gemv_mode="1"). The
     # gemv_mode="0" companion forces the dequant fallback on the identical shape; both must
     # match the exact dequantized reference.
+    #
+    # "MTP" below is multi-token prediction (speculative decode): verifying N speculative
+    # tokens runs N+1 tokens at once, so a top_k=8 model expands to (N+1)*8 rows.
     # ================================================================
 
     def test_nvfp4_fp16_gemv_decode_swiglu(self):
@@ -667,6 +672,13 @@ class TestQMoENVFP4(unittest.TestCase):
         )
 
     def test_nvfp4_fp16_gemv_scales_weights_before_multiply(self):
+        # Overflow guard for accumulate_column_tile(): it must apply the group scale to the
+        # decoded weight *before* multiplying by the activation. FP4 codes reach 6.0 and the
+        # group scales are well below 1, so multiplying first can overflow FP16 (max 65504)
+        # even when the scaled product is representable. Driving the activations to ~1e4 puts
+        # the unscaled products past that limit, which the isfinite() check in the helper
+        # catches. atol is raised because the outputs themselves are ~1e4 times larger; 3.0
+        # there is ~3e-4 relative, i.e. far tighter than the default 0.12 at unit scale.
         self._run_nvfp4_moe_test(
             hidden_size=512,
             inter_size=512,
@@ -721,6 +733,90 @@ class TestQMoENVFP4(unittest.TestCase):
             onnx_dtype=TensorProto.FLOAT16,
             use_swiglu=True,
             gemv_mode="0",
+        )
+
+    def test_nvfp4_fp16_gemv_expanded_rows_at_window_limit(self):
+        # 8 tokens x top_k 8 = 64 expanded rows, exactly kMaxProfiledExpandedRowsFp4, so this
+        # is the largest shape is_moe_gemv_fp4_supported still accepts onto the GEMV path.
+        self._run_nvfp4_moe_test(
+            hidden_size=512,
+            inter_size=512,
+            num_experts=8,
+            top_k=8,
+            num_tokens=8,
+            onnx_dtype=TensorProto.FLOAT16,
+            use_swiglu=True,
+            gemv_mode="1",
+        )
+
+    def test_nvfp4_fp16_gemv_expanded_rows_above_window_limit(self):
+        # 9 tokens x top_k 8 = 72 > kMaxProfiledExpandedRowsFp4, so the GEMV path is rejected
+        # even with gemv_mode="1" and the run must still be correct on the dequant fallback.
+        self._run_nvfp4_moe_test(
+            hidden_size=512,
+            inter_size=512,
+            num_experts=8,
+            top_k=8,
+            num_tokens=9,
+            onnx_dtype=TensorProto.FLOAT16,
+            use_swiglu=True,
+            gemv_mode="1",
+        )
+
+    def test_nvfp4_fp16_gemv_long_k_tiling(self):
+        # Two gaps in one case.
+        # (a) Tiling: every other GEMV test uses k = 512 < kDefaultCtaK (StepK 8 * 128 threads),
+        #     which only exercises the "idle threads" clause of Fp4MoeGemvDefaultConfig. k = 1024
+        #     reaches the second clause, where the choice is driven by blocks-per-SM instead; 64
+        #     expanded rows keep the grid large enough to actually take the 64-thread branch.
+        # (b) Accumulation order: the GEMV keeps even-k and odd-k partial sums apart until the
+        #     epilogue, so it does not sum a column in the same order as the dequant fallback.
+        #     Comparing the two ORT outputs directly at twice the K of the other parity test
+        #     bounds that reordering drift where it has the most terms to cancel against.
+        shape = dict(
+            hidden_size=1024,
+            inter_size=1024,
+            num_experts=8,
+            top_k=8,
+            num_tokens=8,
+            onnx_dtype=TensorProto.FLOAT16,
+            use_swiglu=True,
+        )
+        gemv_out = self._run_nvfp4_moe_test(**shape, gemv_mode="1")
+        fallback_out = self._run_nvfp4_moe_test(**shape, gemv_mode="0")
+        max_diff = (gemv_out.float() - fallback_out.float()).abs().max().item()
+        print(f"NVFP4 GEMV-vs-fallback parity (k=1024): FP16 SwiGLU max_diff={max_diff:.6f}")
+        self.assertLess(
+            max_diff,
+            0.12,
+            f"NVFP4 fused GEMV diverged from dequant fallback at k=1024: max_diff={max_diff:.6f}",
+        )
+
+    def test_nvfp4_gemv_default_tiling_optout(self):
+        # ORT_FP4_GEMV_DEFAULT_TILING=0 restores the fixed kDefault tiling. The kernel latches
+        # it in a function-local static on first use, so it can only be exercised in a fresh
+        # process; re-run one GEMV test there with the opt-out set.
+        self._skip_if_no_fp4()
+        env = dict(os.environ)
+        env["ORT_FP4_GEMV_DEFAULT_TILING"] = "0"
+        proc = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "unittest",
+                "-v",
+                f"{os.path.splitext(os.path.basename(__file__))[0]}.TestQMoENVFP4.test_nvfp4_fp16_gemv_long_k_tiling",
+            ],
+            cwd=os.path.dirname(os.path.abspath(__file__)),
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(
+            proc.returncode,
+            0,
+            f"ORT_FP4_GEMV_DEFAULT_TILING=0 run failed:\n{proc.stdout}\n{proc.stderr}",
         )
 
     def test_nvfp4_fp16_gemv_vs_fallback_parity(self):

--- a/onnxruntime/test/python/transformers/test_qmoe_nvfp4_cuda.py
+++ b/onnxruntime/test/python/transformers/test_qmoe_nvfp4_cuda.py
@@ -308,6 +308,8 @@ class TestQMoENVFP4(unittest.TestCase):
         use_swiglu=False,
         block_size=NVFP4_BLOCK_SIZE,
         gemv_mode=None,
+        input_scale=1.0,
+        atol_override=None,
     ):
         self._skip_if_no_fp4()
 
@@ -389,7 +391,7 @@ class TestQMoENVFP4(unittest.TestCase):
                 else:
                     os.environ["ORT_ENABLE_FP4_GEMV"] = prev_gemv_env
 
-        input_tensor = torch.randn(num_tokens, hidden_size, device=device, dtype=torch_dtype)
+        input_tensor = torch.randn(num_tokens, hidden_size, device=device, dtype=torch_dtype) * input_scale
         router_logits = torch.randn(num_tokens, num_experts, device=device, dtype=torch_dtype)
         output_tensor = torch.zeros(num_tokens, hidden_size, device=device, dtype=torch_dtype)
 
@@ -409,6 +411,7 @@ class TestQMoENVFP4(unittest.TestCase):
         iobinding.synchronize_outputs()
 
         ort_output = output_tensor.clone()
+        self.assertTrue(torch.isfinite(ort_output).all().item(), "NVFP4 MoE output contains NaN or infinity")
 
         ref_output = self._compute_reference(
             input_tensor,
@@ -432,6 +435,8 @@ class TestQMoENVFP4(unittest.TestCase):
         )
 
         atol = 0.15 if torch_dtype == torch.bfloat16 else 0.12
+        if atol_override is not None:
+            atol = atol_override
         # The native block-scaled FP4xFP4 CUTLASS prefill kernel (Blackwell / SM120+, taken
         # only when the per-run token count reaches the prefill threshold) additionally
         # quantizes the *activations* to 4-bit NVFP4 (block-16 with E4M3 block scales). The
@@ -659,6 +664,20 @@ class TestQMoENVFP4(unittest.TestCase):
             onnx_dtype=TensorProto.BFLOAT16,
             use_swiglu=True,
             gemv_mode="1",
+        )
+
+    def test_nvfp4_fp16_gemv_scales_weights_before_multiply(self):
+        self._run_nvfp4_moe_test(
+            hidden_size=512,
+            inter_size=512,
+            num_experts=4,
+            top_k=2,
+            num_tokens=1,
+            onnx_dtype=TensorProto.FLOAT16,
+            use_swiglu=True,
+            gemv_mode="1",
+            input_scale=10000.0,
+            atol_override=3.0,
         )
 
     def test_nvfp4_fp16_gemv_disabled_swiglu(self):

--- a/onnxruntime/test/python/transformers/test_qmoe_nvfp4_cuda.py
+++ b/onnxruntime/test/python/transformers/test_qmoe_nvfp4_cuda.py
@@ -631,7 +631,7 @@ class TestQMoENVFP4(unittest.TestCase):
 
     # ================================================================
     # Fused FP4 GEMV decode fast path (block size 16). The GEMV support window requires
-    # n, k >= 512 and expanded rows (num_tokens * top_k) <= 8, plus SwiGLU fusion, so these
+    # n, k >= 512 and expanded rows (num_tokens * top_k) <= 64, plus SwiGLU fusion, so these
     # decode-shaped SwiGLU cases route through the NVFP4 GEMV kernel (gemv_mode="1"). The
     # gemv_mode="0" companion forces the dequant fallback on the identical shape; both must
     # match the exact dequantized reference.
@@ -668,6 +668,37 @@ class TestQMoENVFP4(unittest.TestCase):
             num_experts=4,
             top_k=2,
             num_tokens=2,
+            onnx_dtype=TensorProto.FLOAT16,
+            use_swiglu=True,
+            gemv_mode="0",
+        )
+
+    @parameterized.expand(
+        [
+            (TensorProto.FLOAT16, 2),
+            (TensorProto.BFLOAT16, 2),
+            (TensorProto.FLOAT16, 3),
+        ]
+    )
+    def test_nvfp4_gemv_mtp_swiglu(self, onnx_dtype, num_tokens):
+        self._run_nvfp4_moe_test(
+            hidden_size=512,
+            inter_size=512,
+            num_experts=8,
+            top_k=8,
+            num_tokens=num_tokens,
+            onnx_dtype=onnx_dtype,
+            use_swiglu=True,
+            gemv_mode="1",
+        )
+
+    def test_nvfp4_fp16_gemv_mtp_fallback_swiglu(self):
+        self._run_nvfp4_moe_test(
+            hidden_size=512,
+            inter_size=512,
+            num_experts=8,
+            top_k=8,
+            num_tokens=3,
             onnx_dtype=TensorProto.FLOAT16,
             use_swiglu=True,
             gemv_mode="0",


### PR DESCRIPTION
### Description

Four changes to the fused NVFP4 QMoE decode GEMV. Stacked on #31154 — **review only the top four
commits**; the base branch is that PR.

1. **Packed E2M1 dequantize** (`Fp4I2FConverter::decode_quad`) — decode a whole 32-bit weight
   word (eight codes) per step instead of one code at a time.
2. **`ORT_FP4_GEMV_DEFAULT_TILING`** — env switch to bypass the autotuner and take the default
   tiling, for A/B and for avoiding autotune cost in short runs.
3. **Cut memory and ALU traffic in the decode GEMV.**
4. **`kMaxProfiledExpandedRows` 8 -> 64** so MTP verify steps stay on the GEMV path.

### Motivation and Context

Prior profiling established that this kernel is **ALU-pipeline bound**, not memory- or
tiling-bound. On the actual Qwen3.6 decode shapes (`hidden=2048`, `inter=512`, `E=256`,
`top_k=8`, bf16, SwiGLU), ncu reported for the FC1 SwiGLU-fused GEMV:

> ALU 78.9%, DRAM 7.3%, occupancy 21% (register-limited)

That is why the levers here are instruction-count levers. Two things were measured and
explicitly **dropped** because of it: smaller `CtaN` tiling (the autotuner still picks
`threads64`/`CtaN=8`; `CtaN=4` never wins because the kernel is compute-bound, not
occupancy-bound), and halving scale bandwidth by storing combined scales as 1-byte e4m3 (DRAM is
only ~7%, so it cannot move the needle).

All numbers below: 1x H200 SXM (SM90, 132 SM, ~4.8 TB/s HBM), CUDA 13.0, Qwen3.6-35B-A3B-NVFP4
+ MTP `N=3` (verify batch `M=4`).

### 1. Packed E2M1 dequantize

`prmt` selects four bytes per instruction, so a 4-element magnitude lookup costs one instruction
instead of four. Bit-identical to the per-element path (same magnitude tables, same sign
handling). The FP4 GEMV kernel SASS shrinks ~30%, and the two QMoE GEMVs drop:

| kernel | before | after |
|---|---:|---:|
| fc1 (SwiGLU-fused) | 33.2 µs | **26.2 µs** |
| fc2 | 30.2 µs | **22.2 µs** |

### 2. Cut memory and ALU traffic — −0.46 ms/step (−5.1%)

The scales of the `CtaN` columns a block owns sit `Interleave` elements apart, so for the
non-interleaved ColumnMajor layout (`Interleave == 1`) the whole `CtaN`-wide scale vector is
contiguous and can be fetched with one wide access instead of `CtaN` scalar ones. This matters
far more than the byte count suggests: with a groupwise scale (NVFP4 `GroupSize = 16`) and
`StepK = 8`, a warp's 32 lanes cover 16 distinct scale rows that are `n` elements apart, so
*every* scale load touches 16 different sectors — `CtaN * 16` sectors, using 2 bytes out of each
32-byte sector.

Per-kernel (graph OFF, 40 launches/step each):

| kernel | before | after |
|---|---:|---:|
| `moe_gemv_interleaved_swiglu_kernel` | 0.956 ms/step | **0.678 ms/step** |
| `moe_gemv_kernel` | 0.700 ms/step | **0.494 ms/step** |
| **family total** | **1.657 ms/step** | **1.174 ms/step** |

End-to-end (4 interleaved `.so`-swap reps per arm):

* before: 8.973 / 9.009 / 8.992 / 9.017
* after: 8.567 / 8.508 / 8.498 / 8.583

**8.998 -> 8.539 ms/step.** No overlap between the two sets.

### 3. `kMaxProfiledExpandedRows` 8 -> 64

The fused GEMV rejects `expanded_num_rows > kMaxProfiledExpandedRows`. Qwen3.6 is top-8, so
single-token decode expands to 8 rows (accepted), but an MTP verify does not: an `(N+1)`-token
verify for `num_speculative_tokens = N` expands to `(N+1) * 8` rows, i.e. **up to 64 for N=7**.
Those steps fell out of the window and back onto the dequantize + CUTLASS grouped-GEMM path,
which re-dequantizes all 256 experts per token.

The impact of that fallback is large: with the limit at 8, the 2-token verify (expanded 16)
dropped MTP to **~2.4 tok/s**; raising the limit put it at **~30–55 tok/s (12–23x)**. 64 covers
the `N=3` shape used today with headroom to `N=7`.

### Tests

* `onnxruntime_provider_test` FP4/FP8/QMoE: 18/18 pass.
* `onnxruntime/test/python/transformers/test_qmoe_nvfp4_cuda.py`: 22/22 pass, including new
  multi-token GEMV cases and a `gemv_mode="0"` dequant-fallback companion on the identical shape,
  so both must match the same exact dequantized reference.

### Methodology note

End-to-end deltas are quoted as **ms/step** from a fixed-step measurement, never tok/s: any
numerics change alters the generated sequence and therefore the MTP acceptance rate, which swamps
the speed delta. Per-kernel durations are taken with CUDA graphs **off** —
`nsys --cuda-graph-trace=node` inflates durations ~35% globally and up to 3.8x for large-grid
kernels.

> [!IMPORTANT]
> `Fp4I2FConverter::convert()` gained a `PairInterleaved` template parameter in #31154. The
> packed path added here assumes the **plain** nibble order (nibble `j` of the word is logical
> element `j`), which is what its `prmt` selectors encode, so it is nested inside
> `if constexpr (!PairInterleaved)`. Please check that guard carefully during review — applied
> without it, the pair-interleaved SM80 layout would silently decode to the wrong values.
