### PR TITLE
[XNNPACK EP] Read Gemm M from the input tensor at Compute time

### DIFF
--- a/onnxruntime/core/providers/xnnpack/math/gemm.cc
+++ b/onnxruntime/core/providers/xnnpack/math/gemm.cc
@@ -121,12 +121,11 @@ Gemm::Gemm(const OpKernelInfo& info) : GemmBase(info), XnnpackKernel(info, /*ena
 
   C_matrix_exists_ = C_arg && C_arg->Exists();
 
-  // A - MxK
+  // A - MxK. M is not cached here: it can be a dynamic dimension that is only known at
+  // Compute() time, so it is read from the input tensor shape instead.
   if (trans_A_ == CblasNoTrans) {
-    M_ = shapeA->dim(0).dim_value() > 1 ? shapeA->dim(0).dim_value() : 1;
     K_ = shapeA->dim(1).dim_value();
   } else {
-    M_ = shapeA->dim(1).dim_value();
     K_ = shapeA->dim(0).dim_value() > 1 ? shapeA->dim(0).dim_value() : 1;
   }
   // B - KxN
@@ -208,10 +207,11 @@ Status Gemm::PrePack(const Tensor& tensor, int input_idx, AllocatorPtr,
 Status Gemm::Compute(OpKernelContext* context) const {
   pthreadpool_t threadpool = GetThreadPool();
   const auto* A = context->Input<Tensor>(0);
-  auto Y = context->Output(0, {M_, N_});
+  const int64_t M = trans_A_ == CblasNoTrans ? A->Shape()[0] : A->Shape()[1];
+  auto Y = context->Output(0, {M, N_});
 
   // if input is empty tensor, return as nothing need to be calculated and we've set the shape for the output
-  if (M_ == 0 || N_ == 0) {
+  if (M == 0 || N_ == 0) {
     return Status::OK();
   }
 
@@ -221,7 +221,7 @@ Status Gemm::Compute(OpKernelContext* context) const {
   }
   xnn_status status = reshape_func(op0_.get(),
                                    // Number of rows to multiply
-                                   trans_A_ == CblasNoTrans ? M_ : K_,
+                                   trans_A_ == CblasNoTrans ? M : K_,
                                    threadpool);
 
   if (status != xnn_status_success) {

--- a/onnxruntime/core/providers/xnnpack/math/gemm.h
+++ b/onnxruntime/core/providers/xnnpack/math/gemm.h
@@ -29,7 +29,6 @@ class Gemm : protected GemmBase, public XnnpackKernel {
  private:
   const Tensor* B_{nullptr};
 
-  int64_t M_ = -1;
   int64_t K_ = -1;
   int64_t N_ = -1;
 

--- a/onnxruntime/test/providers/xnnpack/xnnpack_basic_test.cc
+++ b/onnxruntime/test/providers/xnnpack/xnnpack_basic_test.cc
@@ -692,6 +692,39 @@ TEST(XnnpackEP, TestGemm_EmptyC_NoSegfault) {
                });
 }
 
+// Regression test for https://github.com/microsoft/onnxruntime/issues/31153.
+// A Gemm whose M dimension is symbolic used to have M cached as 1 by the kernel
+// constructor (dim_value() returns 0 for a symbolic dim), so Compute() produced a
+// [1, N] output and only multiplied the first row. M must come from the input tensor
+// at Compute() time.
+TEST(XnnpackEP, TestGemm_DynamicM) {
+  // a_shape is the runtime shape fed for the symbolic M; it must have M > 1 to catch the bug.
+  const std::vector<int64_t> a_shape = {10, 3};
+  const std::vector<int64_t> b_shape = {3, 4};
+  auto modelBuilder = [&](ModelTestBuilder& builder) {
+    auto* input_a = builder.MakeSymbolicInput<float>({std::string("dynamic_m"), b_shape[0]});
+    auto* input_b = builder.MakeInitializer<float>(b_shape, -1.f, 1.f);
+    auto* input_c = builder.MakeInitializer<float>({b_shape[1]}, -1.f, 1.f);
+    auto* output_arg = builder.MakeOutput();
+    auto& gemm_node = builder.AddNode("Gemm", {input_a, input_b, input_c}, {output_arg});
+    gemm_node.AddAttribute("alpha", 1.0f);
+    gemm_node.AddAttribute("beta", 1.0f);
+    gemm_node.AddAttribute("transA", static_cast<int64_t>(0));
+    gemm_node.AddAttribute("transB", static_cast<int64_t>(0));
+
+    // MakeSymbolicInput doesn't register a feed, so add one ourselves.
+    OrtValue input_value;
+    CreateMLValue<float>(TestCPUExecutionProvider()->CreatePreferredAllocators()[0], a_shape,
+                         builder.rand_gen_.Uniform<float>(a_shape, -1.f, 1.f), &input_value);
+    builder.feeds_.insert(std::make_pair(input_a->Name(), input_value));
+  };
+  RunModelTest(modelBuilder, "xnnpack_test_graph_gemm_dynamic_m",
+               {
+                   ExpectedEPNodeAssignment::All,
+                   1e-4f /* fp32_abs_err */,
+               });
+}
+
 #endif
 
 }  // namespace test


### PR DESCRIPTION
Fixes #31153

`Gemm::Gemm` cached the row count from the static `NodeArg` shape, and `dim_value()` returns 0
for a symbolic dim, so `M_ = dim(0).dim_value() > 1 ? dim(0).dim_value() : 1` turned a dynamic
M into 1. `Compute()` then used that cached `M_` for both the output shape and the
`xnn_reshape_fully_connected_nc_*` row count, so the kernel produced a `[1, N]` output and
multiplied only the first row.

`Compute()` now reads M from `A->Shape()`, which is what the XNNPACK reshape API wants anyway.
`M_` is removed since nothing else used it. The `transA = 1` path is unchanged: M still comes
from `A->Shape()[1]` and `K_` is still passed as the row count.

Verified on x86_64 Linux (Ubuntu 20.04, gcc 13, Release, `--use_xnnpack`):

- The reporter's repro script fails on `Reshape` with `Input shape:{1,16}` before the change
  and runs clean after.
- New `XnnpackEP.TestGemm_DynamicM` fails before and passes after. It feeds `[10, 3]` to a
  symbolic-M Gemm and compares against the CPU EP.
- `onnx_test_runner -e xnnpack` on a symbolic-M Gemm with four data sets (M = 10, 1, 7, 32)
  against numpy-computed outputs: 3 of 4 fail before, 4 of 4 pass after. This covers
  re-reshaping the cached operator across runs, not just one M.
- Full `onnxruntime_provider_test`: 5587 ran, 5461 passed, rest skipped, exit 0.

Not verified: Android ARM64 (the reporter's platform, no device here), and the fp16 branch,
which has no test coverage before or after. Both take the same one line of row-count plumbing.

Two adjacent things I left alone because they are out of scope for this issue, but reviewers
may want to know: `IsOnnxNodeSupported` still accepts `transA = 1`, which looks broken
independently of M (for a `[K, M]` A the kernel passes `K_` as the row count against a
K-input-channel operator, which only lines up when `M == K`), and it still accepts rank-1 A
while the constructor indexes `shapeA->dim(1)`.

Thanks to @whousemyname for the report, which pinpointed the exact line and both candidate
fixes.