### PR TITLE
Add AzureContainerRegistry network isolation policy to WebGPU/CUDA plugin EP package test pipelines

### DIFF
--- a/tools/ci_build/github/azure-pipelines/plugin-cuda-test-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/plugin-cuda-test-pipeline.yml
@@ -49,7 +49,7 @@ extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
   parameters:
     settings:
-      networkIsolationPolicy: Permissive
+      networkIsolationPolicy: Permissive,AzureContainerRegistry
     sdl:
       # No top-level `pool:` is declared for this pipeline (each stage
       # template pins its own pool), so source analysis needs an

--- a/tools/ci_build/github/azure-pipelines/plugin-webgpu-test-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/plugin-webgpu-test-pipeline.yml
@@ -60,7 +60,7 @@ extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
   parameters:
     settings:
-      networkIsolationPolicy: Permissive
+      networkIsolationPolicy: Permissive,AzureContainerRegistry
     sdl:
       # No top-level `pool:` is declared for this pipeline (each stage
       # template pins its own pool), so source analysis needs an


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Add AzureContainerRegistry network isolation policy to WebGPU/CUDA plugin EP package test pipelines.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Fix pipeline failures. The step to login to the container registry was failing.