### PR TITLE
Make the tellg failure check explicit and document the EPContext write gate error handling

### DIFF
--- a/onnxruntime/test/autoep/library/ep_context_data_utils.h
+++ b/onnxruntime/test/autoep/library/ep_context_data_utils.h
@@ -191,6 +191,10 @@ inline OrtStatus* EnsureRegularFileForRead(const OrtApi& api, const std::filesys
 // link with its target before this runs, so containment is what constrains those writes. This check is what covers
 // the dangling case, and trusted (graph == nullptr) paths, which skip resolution altogether.
 inline OrtStatus* EnsureRegularFileForWrite(const OrtApi& api, const std::filesystem::path& data_path) {
+  // A set error_code here means the type could not be determined, which for the common new-file case is just "does
+  // not exist" (MSVC reports a missing target through error_code, not only through file_type::not_found), so these
+  // checks fall through to allow the write rather than rejecting the normal path; an undetectable target fails at the
+  // open below anyway.
   std::error_code symlink_ec;
   const std::filesystem::file_status link_status = std::filesystem::symlink_status(data_path, symlink_ec);
   if (!symlink_ec && std::filesystem::is_symlink(link_status)) {
@@ -386,7 +390,8 @@ inline OrtStatus* ReadEpContextDataFromFileWithAllocator(const OrtApi& api, cons
     return api.CreateStatus(ORT_FAIL, message.c_str());
   }
 
-  const std::streampos end_pos = input_stream.tellg();
+  // tellg() reports failure as pos_type(-1); hold it as a streamoff so that is a plain integral comparison.
+  const std::streamoff end_pos = input_stream.tellg();
   if (end_pos < 0) {
     const std::string message = "Failed to determine EPContext data file size: " +
                                 PathToUtf8StringForMessage(data_path);


### PR DESCRIPTION
### Description

Two follow-ups from automated review of the EPContext sample helper, both no-functional-change.

**1. `tellg()` failure check.** The file-size read held the result in a `std::streampos` and compared it with `0`, which works only through the implicit `fpos` to `streamoff` conversion. Holding it in a `std::streamoff` makes it a plain integral comparison against the documented `pos_type(-1)` failure value.

**2. Documented the `error_code` handling in `EnsureRegularFileForWrite`.** A reviewer flagged that a failing `symlink_status` falls through and skips the symlink check, and suggested failing closed. I verified the behavior before changing anything, and did **not** apply that fix, because it would break the common path:

| case | `error_code` | `file_type` |
| --- | --- | --- |
| missing file in an existing dir (normal new-file write) | **set** (2) | `not_found` |
| missing parent directory | **set** (3) | `not_found` |
| invalid name (a genuine error) | **set** (123) | `not_found` |
| existing regular file | clear | `regular` |

On MSVC a simply-missing target sets `error_code`, so failing closed on any error would reject ordinary new-file writes. Comparing against `std::errc::no_such_file_or_directory` does not separate the cases either: `ERROR_INVALID_NAME` maps to that same condition, so a genuine error is indistinguishable from a benign absent path by either the code or the type.

The residual exposure is small: a target whose type cannot be determined fails at the `ofstream` open anyway. So the existing fall-through is deliberate, and this adds a short comment recording that rather than changing the guard.

### Motivation and Context

This file is sample/reference code EP authors are expected to copy, so a subtly non-obvious guard is worth documenting, and a comparison that relies on an implicit conversion is worth making explicit.

Follow-up to #29294. Raised by automated review on #31195, where the comments landed on a stale diff.

Verified: `clang-format` clean, within 120 columns, `onnxruntime_autoep_test` builds, and the `EpContextDataUtils` tests pass (11 passed, 2 skipped - both symlink tests, which need privileges on Windows).
