### PR TITLE
[WebNN EP] Support LpNormalization op

### DIFF
--- a/js/web/docs/webnn-operators.md
+++ b/js/web/docs/webnn-operators.md
@@ -66,6 +66,7 @@ platforms. Check the [WebNN status](https://webmachinelearning.github.io/webnn-s
 | Less | ai.onnx(7-8, 9-12, 13+) | lesser | |
 | LessOrEqual | ai.onnx(12-15, 16+) | lesserOrEqual | |
 | Log | ai.onnx(7-12, 13+) | log | |
+| LpNormalization | ai.onnx(7-21, 22+) | div, max, reduceL1, reduceL2 | |
 | LpPool | ai.onnx(7-10, 11-17, 18+) | l2Pool2d | Only supports 4-D input, 2-D 'kernel_shape', 'p' value is 2 |
 | LRN | ai.onnx(7-12, 13+) | pad, averagePool2d, transpose, add, mul, pow, div | |
 | LSTM | ai.onnx(7-13, 14-21, 22+) | lstm | Only supports 'layout' == 0, 'input_forget' == 0. 'clip' is not supported. The activation functions in 'activations' must be one of 'Relu', 'Tanh', 'Sigmoid'. Forward and backward activations must be the same if bidirectional. 'sequence_lens' if present should be constant with values equal to the first dimension length of input 'X' |

--- a/onnxruntime/core/providers/webnn/builders/impl/lpNormalization_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/lpNormalization_op_builder.cc
@@ -1,0 +1,139 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Intel Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/common.h"
+#include "core/providers/shared/utils/utils.h"
+#include "core/providers/webnn/builders/helper.h"
+#include "core/providers/webnn/builders/model_builder.h"
+#include "core/providers/webnn/builders/op_builder_factory.h"
+
+#include "base_op_builder.h"
+
+namespace onnxruntime {
+namespace webnn {
+
+class LpNormalizationOpBuilder : public BaseOpBuilder {
+  // Add operator related.
+ private:
+  Status AddToModelBuilderImpl(ModelBuilder& model_builder, const Node& node,
+                               const logging::Logger& logger) const override ORT_MUST_USE_RESULT;
+
+  // Operator support related.
+ private:
+  bool HasSupportedInputsImpl(const GraphViewer&, const Node& node,
+                              const emscripten::val& wnn_limits, const logging::Logger& logger) const override;
+  bool HasSupportedOutputsImpl(const Node& node, const emscripten::val& wnn_limits,
+                               const logging::Logger& logger) const override;
+};
+
+Status LpNormalizationOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
+                                                       const Node& node,
+                                                       const logging::Logger& logger) const {
+  const auto& input_defs = node.InputDefs();
+  const auto& output_defs = node.OutputDefs();
+  emscripten::val input = model_builder.GetOperand(input_defs[0]->Name());
+  emscripten::val wnn_builder = model_builder.GetBuilder();
+
+  int32_t input_type;
+  ORT_RETURN_IF_NOT(GetType(*input_defs[0], input_type, logger), "Cannot get input type");
+  std::vector<int64_t> input_shape;
+  ORT_RETURN_IF_NOT(GetShape(*input_defs[0], input_shape, logger), "Cannot get input shape");
+  const auto rank = input_shape.size();
+
+  NodeAttrHelper helper(node);
+  const int64_t p = helper.Get("p", static_cast<int64_t>(2));
+  int64_t axis = helper.Get("axis", static_cast<int64_t>(-1));
+  axis = HandleNegativeAxis(axis, rank);
+  std::vector<uint32_t> axes{SafeInt<uint32_t>(axis)};
+
+  // WebNN has no dedicated LpNormalization operator, so decompose it into:
+  //   output = input / max(Lp_norm(input, axis), eps)
+  //   p==2: norm = reduceL2(input, {axis});  p==1: norm = reduceL1(input, {axis})
+  // keepDimensions=true so the division broadcasts back over the reduced axis. The max(., eps) guard
+  // avoids divide-by-zero; because input==0 along the axis implies norm==0, 0/eps == 0, which matches
+  // the ONNX "when the Lp norm is zero, the output is zero" rule.
+  emscripten::val reduce_options = emscripten::val::object();
+  reduce_options.set("axes", emscripten::val::array(axes));
+  reduce_options.set("keepDimensions", true);
+  reduce_options.set("label", node.Name() + "_reduce");
+  const char* reduce_op = (p == 1) ? "reduceL1" : "reduceL2";
+  emscripten::val norm = wnn_builder.call<emscripten::val>(reduce_op, input, reduce_options);
+
+  // The epsilon must be representable in the input's data type. 1e-12 underflows to 0 in float16
+  // (smallest subnormal ~6e-8), which would defeat the divide-by-zero guard, so use a larger value
+  // for float16. float32 has enough exponent range for 1e-12.
+  const float eps = (input_type == ONNX_NAMESPACE::TensorProto_DataType_FLOAT16) ? 1e-6f : 1e-12f;
+  emscripten::val eps_constant = model_builder.CreateOrGetConstant<float>(input_type, eps);
+  emscripten::val common_options = emscripten::val::object();
+  common_options.set("label", node.Name() + "_max");
+  emscripten::val denom = wnn_builder.call<emscripten::val>("max", norm, eps_constant, common_options);
+
+  common_options.set("label", node.Name() + "_div");
+  emscripten::val output = wnn_builder.call<emscripten::val>("div", input, denom, common_options);
+
+  model_builder.AddOperand(output_defs[0]->Name(), std::move(output));
+  return Status::OK();
+}
+
+// Operator support related.
+
+bool LpNormalizationOpBuilder::HasSupportedInputsImpl(const GraphViewer&, const Node& node,
+                                                      const emscripten::val& wnn_limits,
+                                                      const logging::Logger& logger) const {
+  const auto& input_defs = node.InputDefs();
+  const std::string_view op_type = node.OpType();
+
+  int32_t input_type = 0;
+  if (!GetType(*input_defs[0], input_type, logger)) {
+    return false;
+  }
+
+  // LpNormalization is decomposed into reduceL1/reduceL2 + max + div. Check each decomposed WebNN op
+  // supports the input data type.
+  for (const std::string_view decomposed_op_type : decomposed_op_map.at(op_type)) {
+    const std::string_view webnn_op_type = GetWebNNOpType(decomposed_op_type);
+    const std::string_view webnn_input_name = GetWebNNOpFirstInputName(decomposed_op_type);
+    if (!IsDataTypeSupportedByWebNNOp(
+            op_type, webnn_op_type, input_type, wnn_limits, webnn_input_name, "input", logger)) {
+      return false;
+    }
+  }
+
+  std::vector<int64_t> input_shape;
+  if (!GetShape(*input_defs[0], input_shape, logger)) {
+    return false;
+  }
+  // reduceL2 consumes the input; div consumes the input as its first operand ("a").
+  return IsInputRankSupported(wnn_limits, "reduceL2", "input", input_shape.size(), node.Name(), logger) &&
+         IsInputRankSupported(wnn_limits, "div", "a", input_shape.size(), node.Name(), logger);
+}
+
+bool LpNormalizationOpBuilder::HasSupportedOutputsImpl(const Node& node,
+                                                       const emscripten::val& wnn_limits,
+                                                       const logging::Logger& logger) const {
+  const auto& output_defs = node.OutputDefs();
+  const std::string_view op_type = node.OpType();
+  int32_t output_type = 0;
+  if (!GetType(*output_defs[0], output_type, logger)) {
+    return false;
+  }
+
+  // Check if the output data type is supported by every decomposed WebNN op.
+  for (const std::string_view decomposed_op_type : decomposed_op_map.at(op_type)) {
+    const std::string_view webnn_op_type = GetWebNNOpType(decomposed_op_type);
+    if (!IsDataTypeSupportedByWebNNOp(op_type, webnn_op_type, output_type, wnn_limits, "output", "output", logger)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+void CreateLpNormalizationOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations) {
+  op_registrations.builders.push_back(std::make_unique<LpNormalizationOpBuilder>());
+  op_registrations.op_builder_map.emplace(op_type, op_registrations.builders.back().get());
+}
+
+}  // namespace webnn
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/webnn/builders/impl/lpNormalization_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/lpNormalization_op_builder.cc
@@ -60,10 +60,11 @@ Status LpNormalizationOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_build
   const char* reduce_op = (p == 1) ? "reduceL1" : "reduceL2";
   emscripten::val norm = wnn_builder.call<emscripten::val>(reduce_op, input, reduce_options);
 
-  // The epsilon must be representable in the input's data type. 1e-12 underflows to 0 in float16
-  // (smallest subnormal ~6e-8), which would defeat the divide-by-zero guard, so use a larger value
-  // for float16. float32 has enough exponent range for 1e-12.
-  const float eps = (input_type == ONNX_NAMESPACE::TensorProto_DataType_FLOAT16) ? 1e-6f : 1e-12f;
+  // The epsilon must be representable in the input's data type. Use the smallest positive normalized
+  // value for each type to avoid divide-by-zero while preserving maximum numeric range.
+  const float eps = (input_type == ONNX_NAMESPACE::TensorProto_DataType_FLOAT16)
+                        ? std::numeric_limits<MLFloat16>::min().ToFloat()
+                        : std::numeric_limits<float>::min();
   emscripten::val eps_constant = model_builder.CreateOrGetConstant<float>(input_type, eps);
   emscripten::val common_options = emscripten::val::object();
   common_options.set("label", node.Name() + "_max");

--- a/onnxruntime/core/providers/webnn/builders/map_info.h
+++ b/onnxruntime/core/providers/webnn/builders/map_info.h
@@ -56,6 +56,7 @@ const std::map<std::string_view, std::vector<std::string_view>> decomposed_op_ma
      {"Add", "Cast", "Concat", "CumSum", "Div", "Expand", "Less", "MatMul", "Reshape", "ScatterND",
       "Softmax", "Transpose", "Where"}},
     {"LRN", {"Add", "AveragePool", "Div", "Mul", "Pad", "Pow", "Transpose"}},
+    {"LpNormalization", {"Div", "Max", "ReduceL1", "ReduceL2"}},
     {"MatMulInteger", {"Cast", "DequantizeLinear", "MatMul"}},
     {"MatMulNBits", {"Add", "DequantizeLinear", "MatMul", "Reshape", "Transpose"}},
     {"MultiHeadAttention", {"Add", "Cast", "Concat", "Div", "MatMul", "Reshape", "Softmax", "Transpose"}},

--- a/onnxruntime/core/providers/webnn/builders/op_builder_factory.cc
+++ b/onnxruntime/core/providers/webnn/builders/op_builder_factory.cc
@@ -160,6 +160,10 @@ static OpBuilderRegistrations CreateOpBuilderRegistrations() {
     CreateLRNOpBuilder("LRN", op_registrations);
   }
 
+  {  // LpNormalization
+    CreateLpNormalizationOpBuilder("LpNormalization", op_registrations);
+  }
+
   {  // LSTM
     CreateLstmOpBuilder("LSTM", op_registrations);
   }

--- a/onnxruntime/core/providers/webnn/builders/op_builder_factory.h
+++ b/onnxruntime/core/providers/webnn/builders/op_builder_factory.h
@@ -42,6 +42,7 @@ void CreateGroupQueryAttentionOpBuilder(const std::string& op_type, OpBuilderReg
 void CreateGruOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateLogicalOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateLRNOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
+void CreateLpNormalizationOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateLstmOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateMatMulNBitsOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateMaxMinOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);


### PR DESCRIPTION
WebNN has no dedicated `LpNormalization` operator, so decompose it into: `output = input / max(Lp_norm(input, axis), eps)`

- p==1: `norm = reduceL1(input, {axis})`
- p==2: `norm = reduceL2(input, {axis})`


