### PR TITLE
[Shape Inference] Add shape inference for MatMulIntegerToFloat op

### DIFF
--- a/onnxruntime/python/tools/symbolic_shape_infer.py
+++ b/onnxruntime/python/tools/symbolic_shape_infer.py
@@ -217,6 +217,7 @@ class SymbolicShapeInference:
             "GroupQueryAttention": self._infer_GroupQueryAttention,
             "LayerNormalization": self._infer_LayerNormalization,
             "LongformerAttention": self._infer_LongformerAttention,
+            "MatMulIntegerToFloat": self._infer_MatMulIntegerToFloat,
             "MatMulNBits": self._infer_MatMulNBits,
             "MultiHeadAttention": self._infer_MultiHeadAttention,
             "NhwcConv": self._infer_NhwcConv,
@@ -1294,6 +1295,10 @@ class SymbolicShapeInference:
 
     def _infer_MatMulInteger(self, node):  # noqa: N802
         self._compute_matmul_shape(node, onnx.TensorProto.INT32)
+
+    def _infer_MatMulIntegerToFloat(self, node):  # noqa: N802
+        output_dtype = self.known_vi_[node.input[2]].type.tensor_type.elem_type
+        self._compute_matmul_shape(node, output_dtype)
 
     def _infer_MatMulNBits(self, node):  # noqa: N802
         lhs_shape = self._get_shape(node, 0)

--- a/onnxruntime/test/python/onnxruntime_test_python_symbolic_shape_infer.py
+++ b/onnxruntime/test/python/onnxruntime_test_python_symbolic_shape_infer.py
@@ -595,6 +595,55 @@ class TestSymbolicShapeInferenceForOperators(unittest.TestCase):
         ]
         self._check_shapes(graph, inferred.graph, expected_shapes)
 
+    def test_matmulintegertofloat(self):
+        """
+        Test ORT MatMulIntegerToFloat op ('com.microsoft' domain).
+        Check that the output shape is propagated from the first two inputs and that the
+        output data type comes from the a_scale input, which float16 scales make visible.
+        """
+        initializers = [
+            helper.make_tensor("b", TensorProto.INT8, [10, 4], [0] * 40),
+            helper.make_tensor("a_scale", TensorProto.FLOAT16, [], [0.03]),
+            helper.make_tensor("b_scale", TensorProto.FLOAT16, [4], [0.02] * 4),
+            helper.make_tensor("a_zero_point", TensorProto.UINT8, [], [128]),
+            helper.make_tensor("b_zero_point", TensorProto.INT8, [4], [0] * 4),
+        ]
+
+        nodes = [
+            helper.make_node(
+                "MatMulIntegerToFloat",
+                inputs=[
+                    "a",
+                    "b",
+                    "a_scale",
+                    "b_scale",
+                    "a_zero_point",
+                    "b_zero_point",
+                ],
+                outputs=["output_f16"],
+                domain="com.microsoft",
+            ),
+        ]
+
+        inputs = [
+            helper.make_tensor_value_info("a", TensorProto.UINT8, ["x", 2, 3, 10]),
+        ]
+
+        outputs = [
+            helper.make_tensor_value_info("output_f16", TensorProto.UNDEFINED, None),
+        ]
+
+        graph = helper.make_graph(nodes, "MatMulIntegerToFloat_Test", inputs, outputs, initializers)
+        model = helper.make_model(graph)
+        model.opset_import.append(helper.make_opsetid("com.microsoft", 1))
+
+        inferred = SymbolicShapeInference.infer_shapes(model, auto_merge=True)
+
+        expected_shapes = [
+            helper.make_tensor_value_info("output_f16", TensorProto.FLOAT16, ["x", 2, 3, 4]),
+        ]
+        self._check_shapes(graph, inferred.graph, expected_shapes)
+
     def test_matmulnbits(self):
         """
         Test ORT MatMulNBits op.


### PR DESCRIPTION
### Description

Add a shape inference rule for `MatMulIntegerToFloat` to `symbolic_shape_infer.py`. The output type comes from `a_scale` and the shape from the first two inputs, same as the op's schema does.

### Motivation and Context

`MatMulIntegerToFloat` is a `com.microsoft` op, so `onnx.shape_inference` cannot infer it on its own. Without a rule the output type stays `UNDEFINED`. `infer_shapes()` then stops at the first `MatMulIntegerToFloat` node and raises `Incomplete symbolic shape inference`.