### PR TITLE
Add FunctionExtractor reverse function-inliner utility

### DIFF
--- a/include/onnxruntime/core/optimizer/function_extractor.h
+++ b/include/onnxruntime/core/optimizer/function_extractor.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <cstddef>
+#include <memory>
+
+#include "core/common/common.h"
+#include "core/common/status.h"
+#include "core/graph/basic_types.h"
+
+namespace onnxruntime {
+
+class Graph;
+class Model;
+
+#if !defined(ORT_MINIMAL_BUILD)
+
+struct FunctionExtractorOptions {
+  size_t max_pattern_nodes{1024};
+  size_t max_target_nodes{1'000'000};
+  size_t max_output_root_tuples{100'000};
+  size_t max_worklist_bindings{1'000'000};
+  size_t max_literal_bytes{64U * 1024U * 1024U};
+};
+
+struct FunctionExtractionResult {
+  common::Status status{common::Status::OK()};
+  size_t replacements_applied{0};
+};
+
+class FunctionExtractor final {
+ public:
+  explicit FunctionExtractor(
+      const ONNX_NAMESPACE::FunctionProto& function_proto,
+      FunctionExtractorOptions options = {});
+  ~FunctionExtractor();
+
+  FunctionExtractionResult Extract(Model& model);
+  FunctionExtractionResult Extract(Graph& graph);
+
+ private:
+  struct Impl;
+  std::unique_ptr<Impl> impl_;
+
+  ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(FunctionExtractor);
+};
+
+#endif  // !defined(ORT_MINIMAL_BUILD)
+
+}  // namespace onnxruntime

--- a/include/onnxruntime/core/optimizer/function_extractor.h
+++ b/include/onnxruntime/core/optimizer/function_extractor.h
@@ -27,7 +27,7 @@ struct FunctionExtractorOptions {
   size_t max_target_nodes{1'000'000};
   /** Maximum candidate-root entries and output-root tuples per discovery pass. */
   size_t max_output_root_tuples{100'000};
-  /** Maximum aggregate matcher scheduling and boundary-traversal work per pass. */
+  /** Maximum pattern-slot normalization and aggregate matcher work per pass. */
   size_t max_worklist_bindings{1'000'000};
   /** Maximum aggregate literal bytes normalized or compared per pass. */
   size_t max_literal_bytes{64U * 1024U * 1024U};

--- a/include/onnxruntime/core/optimizer/function_extractor.h
+++ b/include/onnxruntime/core/optimizer/function_extractor.h
@@ -14,14 +14,31 @@ class Model;
 
 #if !defined(ORT_MINIMAL_BUILD)
 
+/**
+ * Resource limits for one FunctionExtractor call.
+ *
+ * A zero limit permits no corresponding work and returns an error before the
+ * current replacement batch mutates the graph.
+ */
 struct FunctionExtractorOptions {
+  /** Maximum total FunctionProto body nodes, including Constant nodes. */
   size_t max_pattern_nodes{1024};
+  /** Maximum nodes in the single target Graph scope being searched. */
   size_t max_target_nodes{1'000'000};
+  /** Maximum candidate-root entries and output-root tuples per discovery pass. */
   size_t max_output_root_tuples{100'000};
+  /** Maximum aggregate matcher scheduling and boundary-traversal work per pass. */
   size_t max_worklist_bindings{1'000'000};
+  /** Maximum aggregate literal bytes normalized or compared per pass. */
   size_t max_literal_bytes{64U * 1024U * 1024U};
 };
 
+/**
+ * Result of extraction.
+ *
+ * replacements_applied includes calls added before a later post-mutation
+ * failure. Such a failure may leave the graph modified and unresolved.
+ */
 struct FunctionExtractionResult {
   common::Status status{common::Status::OK()};
   size_t replacements_applied{0};
@@ -29,12 +46,35 @@ struct FunctionExtractionResult {
 
 class FunctionExtractor final {
  public:
+  /**
+   * Copies and validates function_proto. The caller may destroy the source
+   * proto after construction.
+   *
+   * V1 supports connected, acyclic, pure tensor DAGs with fixed attributes,
+   * positional optional/variadic slots, and dense Constant literals. It does
+   * not support function attribute references, required call attributes,
+   * control-flow bodies, or provider-assigned matches.
+   */
   explicit FunctionExtractor(
       const ONNX_NAMESPACE::FunctionProto& function_proto,
       FunctionExtractorOptions options = {});
   ~FunctionExtractor();
 
+  /**
+   * Extracts to fixpoint from model.MainGraph(). The identical function
+   * definition must already be registered in the model.
+   */
   FunctionExtractionResult Extract(Model& model);
+
+  /**
+   * Extracts to fixpoint from one graph scope.
+   *
+   * The graph must already be resolved, with a schema on every node, and its
+   * owning model must pre-register an identical function definition. Success
+   * guarantees a resolved graph at fixpoint. Validation/discovery failures do
+   * not mutate the current batch; failures after mutation are non-atomic and
+   * are reported with the exact replacements_applied count.
+   */
   FunctionExtractionResult Extract(Graph& graph);
 
  private:

--- a/onnxruntime/core/optimizer/function_extractor.cc
+++ b/onnxruntime/core/optimizer/function_extractor.cc
@@ -77,6 +77,117 @@ common::Status ApplyReplacementPlan(
 
 }  // namespace
 
+namespace function_extractor_internal {
+
+FunctionExtractionResult ExtractGraph(
+    Graph& graph,
+    const NormalizedFunctionPattern& normalized_pattern,
+    const FunctionExtractorOptions& options,
+    const ExtractionControls& controls) {
+  FunctionExtractionResult result;
+  if (!normalized_pattern.construction_status.IsOK()) {
+    result.status = normalized_pattern.construction_status;
+    return result;
+  }
+  if (graph.GraphResolveNeeded()) {
+    result.status = ORT_MAKE_STATUS(
+        ONNXRUNTIME, INVALID_ARGUMENT,
+        "FunctionExtractor requires a resolved graph; GraphResolveNeeded() is true.");
+    return result;
+  }
+  for (const auto& node : graph.Nodes()) {
+    if (node.Op() == nullptr) {
+      result.status = ORT_MAKE_STATUS(
+          ONNXRUNTIME, INVALID_ARGUMENT,
+          "FunctionExtractor requires every target node to have a resolved schema.");
+      return result;
+    }
+  }
+
+  result.status = ValidateRegisteredFunction(normalized_pattern, graph);
+  if (!result.status.IsOK()) return result;
+
+  CompiledFunctionPattern compiled_pattern;
+  result.status = CompileFunctionPattern(normalized_pattern, graph, compiled_pattern);
+  if (!result.status.IsOK()) return result;
+
+  const size_t pass_cap =
+      controls.maximum_passes.value_or(static_cast<size_t>(graph.NumberOfNodes()));
+  std::unordered_set<std::string> literal_initializers_to_preserve;
+  for (size_t pass = 0; pass <= pass_cap; ++pass) {
+    std::vector<ReplacementPlan> selected_plans;
+    {
+      TargetGraphSnapshot snapshot;
+      result.status = BuildTargetGraphSnapshot(graph, compiled_pattern, options, snapshot);
+      if (!result.status.IsOK()) return result;
+
+      std::vector<ReplacementPlan> discovered_plans;
+      result.status = DiscoverReplacementPlans(
+          compiled_pattern, snapshot, options, discovered_plans);
+      if (!result.status.IsOK()) return result;
+
+      std::vector<size_t> selected_indices;
+      result.status = SelectNonConflictingPlans(discovered_plans, selected_indices);
+      if (!result.status.IsOK()) return result;
+      if (selected_indices.empty()) {
+        result.status = common::Status::OK();
+        return result;
+      }
+      selected_plans.reserve(selected_indices.size());
+      for (const auto index : selected_indices) {
+        selected_plans.push_back(std::move(discovered_plans[index]));
+      }
+      for (auto& plan : selected_plans) {
+        plan.generated_call_name = graph.GenerateNodeName(normalized_pattern.function_proto.name());
+      }
+      result.status = PrevalidatePlans(graph, compiled_pattern, selected_plans);
+      if (!result.status.IsOK()) return result;
+    }
+
+    if (pass >= pass_cap) {
+      result.status = ORT_MAKE_STATUS(
+          ONNXRUNTIME, FAIL,
+          "FunctionExtractor reached its defensive pass cap despite strict node-count decrease.");
+      return result;
+    }
+
+    std::sort(selected_plans.begin(), selected_plans.end(),
+              [](const ReplacementPlan& lhs, const ReplacementPlan& rhs) {
+                return lhs.primary_root_topological_position > rhs.primary_root_topological_position;
+              });
+    for (const auto& plan : selected_plans) {
+      for (const auto& witness : plan.literal_witnesses) {
+        if (witness.is_initializer) {
+          literal_initializers_to_preserve.insert(witness.target_value->Name());
+        }
+      }
+      bool call_added = false;
+      result.status =
+          ApplyReplacementPlan(graph, normalized_pattern.function_proto, plan, call_added);
+      if (call_added) ++result.replacements_applied;
+      if (!result.status.IsOK()) return result;
+    }
+
+    graph.SetGraphResolveNeeded().SetGraphProtoSyncNeeded();
+    Graph::ResolveOptions resolve_options;
+    resolve_options.initializer_names_to_preserve = &literal_initializers_to_preserve;
+    result.status = controls.resolve_graph != nullptr
+                        ? controls.resolve_graph(graph, resolve_options)
+                        : graph.Resolve(resolve_options);
+    if (!result.status.IsOK()) return result;
+
+    result.status = ValidateRegisteredFunction(normalized_pattern, graph);
+    if (!result.status.IsOK()) return result;
+    result.status = CompileFunctionPattern(normalized_pattern, graph, compiled_pattern);
+    if (!result.status.IsOK()) return result;
+  }
+
+  result.status = ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "FunctionExtractor pass invariant failure.");
+  return result;
+}
+
+}  // namespace function_extractor_internal
+
 struct FunctionExtractor::Impl {
   Impl(const ONNX_NAMESPACE::FunctionProto& function_proto, FunctionExtractorOptions extractor_options)
       : owned_function_proto(function_proto),
@@ -103,109 +214,8 @@ FunctionExtractionResult FunctionExtractor::Extract(Model& model) {
 }
 
 FunctionExtractionResult FunctionExtractor::Extract(Graph& graph) {
-  FunctionExtractionResult result;
-  if (!impl_->construction_status.IsOK()) {
-    result.status = impl_->construction_status;
-    return result;
-  }
-  if (graph.GraphResolveNeeded()) {
-    result.status = ORT_MAKE_STATUS(
-        ONNXRUNTIME, INVALID_ARGUMENT,
-        "FunctionExtractor requires a resolved graph; GraphResolveNeeded() is true.");
-    return result;
-  }
-  for (const auto& node : graph.Nodes()) {
-    if (node.Op() == nullptr) {
-      result.status = ORT_MAKE_STATUS(
-          ONNXRUNTIME, INVALID_ARGUMENT,
-          "FunctionExtractor requires every target node to have a resolved schema.");
-      return result;
-    }
-  }
-
-  result.status =
-      function_extractor_internal::ValidateRegisteredFunction(impl_->normalized_pattern, graph);
-  if (!result.status.IsOK()) return result;
-
-  CompiledFunctionPattern compiled_pattern;
-  result.status = function_extractor_internal::CompileFunctionPattern(
-      impl_->normalized_pattern, graph, compiled_pattern);
-  if (!result.status.IsOK()) return result;
-
-  const size_t pass_cap = static_cast<size_t>(graph.NumberOfNodes());
-  std::unordered_set<std::string> literal_initializers_to_preserve;
-  for (size_t pass = 0; pass <= pass_cap; ++pass) {
-    std::vector<ReplacementPlan> selected_plans;
-    {
-      function_extractor_internal::TargetGraphSnapshot snapshot;
-      result.status = function_extractor_internal::BuildTargetGraphSnapshot(
-          graph, compiled_pattern, impl_->options, snapshot);
-      if (!result.status.IsOK()) return result;
-
-      std::vector<ReplacementPlan> discovered_plans;
-      result.status = function_extractor_internal::DiscoverReplacementPlans(
-          compiled_pattern, snapshot, impl_->options, discovered_plans);
-      if (!result.status.IsOK()) return result;
-
-      std::vector<size_t> selected_indices;
-      result.status = function_extractor_internal::SelectNonConflictingPlans(
-          discovered_plans, selected_indices);
-      if (!result.status.IsOK()) return result;
-      if (selected_indices.empty()) {
-        result.status = common::Status::OK();
-        return result;
-      }
-      selected_plans.reserve(selected_indices.size());
-      for (const auto index : selected_indices) {
-        selected_plans.push_back(std::move(discovered_plans[index]));
-      }
-      for (auto& plan : selected_plans) {
-        plan.generated_call_name = graph.GenerateNodeName(impl_->owned_function_proto.name());
-      }
-      result.status = function_extractor_internal::PrevalidatePlans(
-          graph, compiled_pattern, selected_plans);
-      if (!result.status.IsOK()) return result;
-    }
-
-    if (pass >= pass_cap) {
-      result.status = ORT_MAKE_STATUS(
-          ONNXRUNTIME, FAIL,
-          "FunctionExtractor reached its defensive pass cap despite strict node-count decrease.");
-      return result;
-    }
-
-    std::sort(selected_plans.begin(), selected_plans.end(),
-              [](const ReplacementPlan& lhs, const ReplacementPlan& rhs) {
-                return lhs.primary_root_topological_position > rhs.primary_root_topological_position;
-              });
-    for (const auto& plan : selected_plans) {
-      for (const auto& witness : plan.literal_witnesses) {
-        if (witness.is_initializer) {
-          literal_initializers_to_preserve.insert(witness.target_value->Name());
-        }
-      }
-      bool call_added = false;
-      result.status = ApplyReplacementPlan(graph, impl_->owned_function_proto, plan, call_added);
-      if (call_added) ++result.replacements_applied;
-      if (!result.status.IsOK()) return result;
-    }
-
-    graph.SetGraphResolveNeeded().SetGraphProtoSyncNeeded();
-    Graph::ResolveOptions resolve_options;
-    resolve_options.initializer_names_to_preserve = &literal_initializers_to_preserve;
-    result.status = graph.Resolve(resolve_options);
-    if (!result.status.IsOK()) return result;
-
-    result.status =
-        function_extractor_internal::ValidateRegisteredFunction(impl_->normalized_pattern, graph);
-    if (!result.status.IsOK()) return result;
-    result.status = function_extractor_internal::CompileFunctionPattern(
-        impl_->normalized_pattern, graph, compiled_pattern);
-    if (!result.status.IsOK()) return result;
-  }
-
-  result.status = ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "FunctionExtractor pass invariant failure.");
-  return result;
+  return function_extractor_internal::ExtractGraph(
+      graph, impl_->normalized_pattern, impl_->options);
 }
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/optimizer/function_extractor.cc
+++ b/onnxruntime/core/optimizer/function_extractor.cc
@@ -27,6 +27,9 @@ common::Status ApplyReplacementPlan(
   InlinedHashSet<NodeIndex> removable(plan.removable_node_indices.begin(),
                                       plan.removable_node_indices.end());
 
+  // PrevalidatePlans proves the complete batch is semantically stable. From
+  // this first edge removal onward ORT has no rollback, so failures are
+  // deliberately reported with the graph possibly modified and unresolved.
   for (auto node_index = plan.removable_node_indices.rbegin();
        node_index != plan.removable_node_indices.rend(); ++node_index) {
     Node* node = graph.GetNode(*node_index);
@@ -193,13 +196,11 @@ struct FunctionExtractor::Impl {
       : owned_function_proto(function_proto),
         options(std::move(extractor_options)),
         normalized_pattern(
-            function_extractor_internal::NormalizeFunctionPattern(owned_function_proto, options)),
-        construction_status(normalized_pattern.construction_status) {}
+            function_extractor_internal::NormalizeFunctionPattern(owned_function_proto, options)) {}
 
   ONNX_NAMESPACE::FunctionProto owned_function_proto;
   FunctionExtractorOptions options;
   function_extractor_internal::NormalizedFunctionPattern normalized_pattern;
-  common::Status construction_status;
 };
 
 FunctionExtractor::FunctionExtractor(

--- a/onnxruntime/core/optimizer/function_extractor.cc
+++ b/onnxruntime/core/optimizer/function_extractor.cc
@@ -1,0 +1,213 @@
+#include "core/optimizer/function_extractor.h"
+
+#if !defined(ORT_MINIMAL_BUILD)
+
+#include <algorithm>
+#include <unordered_set>
+#include <vector>
+
+#include "core/graph/graph.h"
+#include "core/graph/graph_utils.h"
+#include "core/graph/model.h"
+#include "core/optimizer/function_extractor_matcher.h"
+#include "core/optimizer/function_extractor_pattern.h"
+
+namespace onnxruntime {
+namespace {
+
+using function_extractor_internal::CompiledFunctionPattern;
+using function_extractor_internal::ReplacementPlan;
+
+common::Status ApplyReplacementPlan(
+    Graph& graph,
+    const ONNX_NAMESPACE::FunctionProto& function_proto,
+    const ReplacementPlan& plan,
+    bool& call_added) {
+  call_added = false;
+  InlinedHashSet<NodeIndex> removable(plan.removable_node_indices.begin(),
+                                      plan.removable_node_indices.end());
+
+  for (auto node_index = plan.removable_node_indices.rbegin();
+       node_index != plan.removable_node_indices.rend(); ++node_index) {
+    Node* node = graph.GetNode(*node_index);
+    ORT_RETURN_IF(node == nullptr, "FunctionExtractor replacement plan became stale during application.");
+    graph_utils::RemoveNodeOutputEdges(graph, *node);
+  }
+  for (auto node_index = plan.removable_node_indices.rbegin();
+       node_index != plan.removable_node_indices.rend(); ++node_index) {
+    ORT_RETURN_IF_NOT(graph.RemoveNode(*node_index),
+                      "FunctionExtractor failed to remove a planned node.");
+  }
+
+  Node& call = graph.AddNode(plan.generated_call_name,
+                             function_proto.name(),
+                             "Function call created by FunctionExtractor",
+                             plan.call_inputs,
+                             plan.call_outputs,
+                             nullptr,
+                             function_proto.domain());
+  call_added = true;
+  call.SetOverload(function_proto.overload());
+  call.SetLayeringAnnotation(plan.layering_annotation);
+
+  for (size_t input_index = 0; input_index < plan.call_inputs.size(); ++input_index) {
+    const auto* input = plan.call_inputs[input_index];
+    const auto producer_edge = std::find_if(
+        plan.explicit_input_edges.begin(), plan.explicit_input_edges.end(),
+        [&](const graph_utils::GraphEdge& edge) { return edge.arg_name == input->Name(); });
+    if (producer_edge != plan.explicit_input_edges.end() &&
+        removable.find(producer_edge->src_node) == removable.end()) {
+      graph.AddEdge(producer_edge->src_node, call.Index(), producer_edge->src_arg_index,
+                    static_cast<int>(input_index));
+    }
+  }
+
+  for (const auto& edge : plan.explicit_output_edges) {
+    const auto output = std::find_if(
+        plan.call_outputs.begin(), plan.call_outputs.end(),
+        [&](const NodeArg* value) { return value->Name() == edge.arg_name; });
+    ORT_RETURN_IF(output == plan.call_outputs.end(),
+                  "FunctionExtractor plan contains an edge from a private output.");
+    graph.AddEdge(call.Index(), edge.dst_node,
+                  static_cast<int>(std::distance(plan.call_outputs.begin(), output)),
+                  edge.dst_arg_index);
+  }
+  return common::Status::OK();
+}
+
+}  // namespace
+
+struct FunctionExtractor::Impl {
+  Impl(const ONNX_NAMESPACE::FunctionProto& function_proto, FunctionExtractorOptions extractor_options)
+      : owned_function_proto(function_proto),
+        options(std::move(extractor_options)),
+        normalized_pattern(
+            function_extractor_internal::NormalizeFunctionPattern(owned_function_proto, options)),
+        construction_status(normalized_pattern.construction_status) {}
+
+  ONNX_NAMESPACE::FunctionProto owned_function_proto;
+  FunctionExtractorOptions options;
+  function_extractor_internal::NormalizedFunctionPattern normalized_pattern;
+  common::Status construction_status;
+};
+
+FunctionExtractor::FunctionExtractor(
+    const ONNX_NAMESPACE::FunctionProto& function_proto,
+    FunctionExtractorOptions options)
+    : impl_(std::make_unique<Impl>(function_proto, std::move(options))) {}
+
+FunctionExtractor::~FunctionExtractor() = default;
+
+FunctionExtractionResult FunctionExtractor::Extract(Model& model) {
+  return Extract(model.MainGraph());
+}
+
+FunctionExtractionResult FunctionExtractor::Extract(Graph& graph) {
+  FunctionExtractionResult result;
+  if (!impl_->construction_status.IsOK()) {
+    result.status = impl_->construction_status;
+    return result;
+  }
+  if (graph.GraphResolveNeeded()) {
+    result.status = ORT_MAKE_STATUS(
+        ONNXRUNTIME, INVALID_ARGUMENT,
+        "FunctionExtractor requires a resolved graph; GraphResolveNeeded() is true.");
+    return result;
+  }
+  for (const auto& node : graph.Nodes()) {
+    if (node.Op() == nullptr) {
+      result.status = ORT_MAKE_STATUS(
+          ONNXRUNTIME, INVALID_ARGUMENT,
+          "FunctionExtractor requires every target node to have a resolved schema.");
+      return result;
+    }
+  }
+
+  result.status =
+      function_extractor_internal::ValidateRegisteredFunction(impl_->normalized_pattern, graph);
+  if (!result.status.IsOK()) return result;
+
+  CompiledFunctionPattern compiled_pattern;
+  result.status = function_extractor_internal::CompileFunctionPattern(
+      impl_->normalized_pattern, graph, compiled_pattern);
+  if (!result.status.IsOK()) return result;
+
+  const size_t pass_cap = static_cast<size_t>(graph.NumberOfNodes());
+  std::unordered_set<std::string> literal_initializers_to_preserve;
+  for (size_t pass = 0; pass <= pass_cap; ++pass) {
+    std::vector<ReplacementPlan> selected_plans;
+    {
+      function_extractor_internal::TargetGraphSnapshot snapshot;
+      result.status = function_extractor_internal::BuildTargetGraphSnapshot(
+          graph, compiled_pattern, impl_->options, snapshot);
+      if (!result.status.IsOK()) return result;
+
+      std::vector<ReplacementPlan> discovered_plans;
+      result.status = function_extractor_internal::DiscoverReplacementPlans(
+          compiled_pattern, snapshot, impl_->options, discovered_plans);
+      if (!result.status.IsOK()) return result;
+
+      std::vector<size_t> selected_indices;
+      result.status = function_extractor_internal::SelectNonConflictingPlans(
+          discovered_plans, selected_indices);
+      if (!result.status.IsOK()) return result;
+      if (selected_indices.empty()) {
+        result.status = common::Status::OK();
+        return result;
+      }
+      selected_plans.reserve(selected_indices.size());
+      for (const auto index : selected_indices) {
+        selected_plans.push_back(std::move(discovered_plans[index]));
+      }
+      for (auto& plan : selected_plans) {
+        plan.generated_call_name = graph.GenerateNodeName(impl_->owned_function_proto.name());
+      }
+      result.status = function_extractor_internal::PrevalidatePlans(
+          graph, compiled_pattern, selected_plans);
+      if (!result.status.IsOK()) return result;
+    }
+
+    if (pass >= pass_cap) {
+      result.status = ORT_MAKE_STATUS(
+          ONNXRUNTIME, FAIL,
+          "FunctionExtractor reached its defensive pass cap despite strict node-count decrease.");
+      return result;
+    }
+
+    std::sort(selected_plans.begin(), selected_plans.end(),
+              [](const ReplacementPlan& lhs, const ReplacementPlan& rhs) {
+                return lhs.primary_root_topological_position > rhs.primary_root_topological_position;
+              });
+    for (const auto& plan : selected_plans) {
+      for (const auto& witness : plan.literal_witnesses) {
+        if (witness.is_initializer) {
+          literal_initializers_to_preserve.insert(witness.target_value->Name());
+        }
+      }
+      bool call_added = false;
+      result.status = ApplyReplacementPlan(graph, impl_->owned_function_proto, plan, call_added);
+      if (call_added) ++result.replacements_applied;
+      if (!result.status.IsOK()) return result;
+    }
+
+    graph.SetGraphResolveNeeded().SetGraphProtoSyncNeeded();
+    Graph::ResolveOptions resolve_options;
+    resolve_options.initializer_names_to_preserve = &literal_initializers_to_preserve;
+    result.status = graph.Resolve(resolve_options);
+    if (!result.status.IsOK()) return result;
+
+    result.status =
+        function_extractor_internal::ValidateRegisteredFunction(impl_->normalized_pattern, graph);
+    if (!result.status.IsOK()) return result;
+    result.status = function_extractor_internal::CompileFunctionPattern(
+        impl_->normalized_pattern, graph, compiled_pattern);
+    if (!result.status.IsOK()) return result;
+  }
+
+  result.status = ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "FunctionExtractor pass invariant failure.");
+  return result;
+}
+
+}  // namespace onnxruntime
+
+#endif  // !defined(ORT_MINIMAL_BUILD)

--- a/onnxruntime/core/optimizer/function_extractor_matcher.cc
+++ b/onnxruntime/core/optimizer/function_extractor_matcher.cc
@@ -1,0 +1,731 @@
+#include "core/optimizer/function_extractor_matcher.h"
+
+#if !defined(ORT_MINIMAL_BUILD)
+
+#include <algorithm>
+#include <deque>
+#include <functional>
+#include <tuple>
+
+#include "core/common/safeint.h"
+
+namespace onnxruntime {
+namespace function_extractor_internal {
+namespace {
+
+using common::Status;
+
+Status MatcherError(const std::string& message) {
+  return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "FunctionExtractor matcher: ", message);
+}
+
+bool PatternTypeCompatible(const PatternValue& pattern_value, const NodeArg& target_value) {
+  if (!pattern_value.has_type || target_value.TypeAsProto() == nullptr) return true;
+  const auto& lhs = pattern_value.type;
+  const auto& rhs = *target_value.TypeAsProto();
+  if (lhs.value_case() != rhs.value_case()) return false;
+  if (!lhs.has_tensor_type() || !rhs.has_tensor_type()) return false;
+  const auto& lhs_tensor = lhs.tensor_type();
+  const auto& rhs_tensor = rhs.tensor_type();
+  if (lhs_tensor.elem_type() != 0 && rhs_tensor.elem_type() != 0 &&
+      lhs_tensor.elem_type() != rhs_tensor.elem_type()) {
+    return false;
+  }
+  if (!lhs_tensor.has_shape() || !rhs_tensor.has_shape()) return true;
+  if (lhs_tensor.shape().dim_size() != rhs_tensor.shape().dim_size()) return false;
+  for (int i = 0; i < lhs_tensor.shape().dim_size(); ++i) {
+    const auto& lhs_dim = lhs_tensor.shape().dim(i);
+    const auto& rhs_dim = rhs_tensor.shape().dim(i);
+    if (lhs_dim.has_dim_value() && rhs_dim.has_dim_value() &&
+        lhs_dim.dim_value() != rhs_dim.dim_value()) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool NodeSignatureMatches(const ResolvedPatternNode& pattern_node, const Node& target_node) {
+  return target_node.Op() != nullptr &&
+         pattern_node.canonical_domain == target_node.Domain() &&
+         pattern_node.op_type == target_node.OpType() &&
+         pattern_node.overload == target_node.Overload() &&
+         pattern_node.since_version == target_node.SinceVersion() &&
+         pattern_node.input_arity == target_node.InputDefs().size() &&
+         pattern_node.output_arity == target_node.OutputDefs().size() &&
+         AreAttributesSemanticallyEqual(pattern_node.effective_attributes, target_node.GetAttributes());
+}
+
+bool HasControlRelationship(const TargetGraphSnapshot& snapshot, const Node& node) {
+  if (!node.ControlInputs().empty()) return true;
+  for (const auto node_index : snapshot.topological_node_indices) {
+    const auto* other = snapshot.graph_viewer->GetNode(node_index);
+    if (other != nullptr && other->ControlInputs().find(node.Name()) != other->ControlInputs().end()) {
+      return true;
+    }
+  }
+  return false;
+}
+
+Status MatchLiteral(const PatternValue& pattern_value,
+                    const NodeArg& target_value,
+                    const TargetGraphSnapshot& snapshot,
+                    const FunctionExtractorOptions& options,
+                    size_t& literal_bytes_compared,
+                    LiteralWitness& witness,
+                    bool& matched) {
+  matched = false;
+  witness.pattern_value_id = kMissingPatternValue;
+  witness.target_value = &target_value;
+
+  const auto initializer = snapshot.constant_initializers.find(target_value.Name());
+  const ONNX_NAMESPACE::TensorProto* target_tensor = nullptr;
+  ONNX_NAMESPACE::TensorProto normalized_constant;
+  if (initializer != snapshot.constant_initializers.end()) {
+    target_tensor = initializer->second;
+    witness.is_initializer = true;
+  } else {
+    const auto producer = snapshot.producers.find(&target_value);
+    if (producer == snapshot.producers.end()) return Status::OK();
+    const auto* node = snapshot.graph_viewer->GetNode(producer->second.node_index);
+    if (node == nullptr || node->Domain() != kOnnxDomain || node->OpType() != "Constant") {
+      return Status::OK();
+    }
+    const auto status = NormalizeConstantAttributes(node->GetAttributes(), normalized_constant);
+    if (!status.IsOK()) return Status::OK();
+    target_tensor = &normalized_constant;
+    witness.constant_node_index = node->Index();
+  }
+
+  literal_bytes_compared =
+      SafeInt<size_t>(literal_bytes_compared) + pattern_value.literal.byte_count;
+  ORT_RETURN_IF(literal_bytes_compared > options.max_literal_bytes,
+                "FunctionExtractor literal comparison byte budget exceeded.");
+  const auto& model_path = snapshot.graph->ModelPath();
+  ORT_RETURN_IF_ERROR(CompareTensorLiterals(pattern_value.literal.tensor, *target_tensor,
+                                            options.max_literal_bytes, matched, &model_path));
+  if (matched) witness.fingerprint = pattern_value.literal.fingerprint;
+  return Status::OK();
+}
+
+struct CandidateMatcher {
+  const CompiledFunctionPattern& compiled;
+  const TargetGraphSnapshot& snapshot;
+  const FunctionExtractorOptions& options;
+  MatcherDiagnostics* diagnostics;
+  size_t& literal_bytes_compared;
+  size_t primary_output_group;
+  MatchState state;
+
+  Status Schedule(PatternValueId pattern_value_id, const NodeArg* target_value, bool& matched) {
+    if (target_value == nullptr || !target_value->Exists()) {
+      matched = false;
+      return Status::OK();
+    }
+    if (!PatternTypeCompatible(compiled.normalized_pattern->values[pattern_value_id], *target_value)) {
+      matched = false;
+      return Status::OK();
+    }
+    auto& visit_state = state.value_visit_states[pattern_value_id];
+    if (visit_state != ValueVisitState::Unseen) {
+      matched = state.pattern_value_to_target[pattern_value_id] == target_value;
+      return Status::OK();
+    }
+    ORT_RETURN_IF(state.processed_binding_count >= options.max_worklist_bindings,
+                  "FunctionExtractor worklist binding budget exceeded.");
+    state.pattern_value_to_target[pattern_value_id] = target_value;
+    visit_state = ValueVisitState::Scheduled;
+    ++state.processed_binding_count;
+    if (diagnostics != nullptr) ++diagnostics->worklist_bindings_scheduled;
+    return Status::OK();
+  }
+
+  PatternValueId NextScheduledValue() const {
+    const auto& normalized = *compiled.normalized_pattern;
+    for (const auto node_id : normalized.reverse_topological_node_ids) {
+      for (const auto output_id : normalized.nodes[node_id].output_value_ids) {
+        if (state.value_visit_states[output_id] == ValueVisitState::Scheduled) return output_id;
+      }
+      for (const auto input_id : normalized.nodes[node_id].input_value_ids) {
+        if (input_id != kMissingPatternValue &&
+            state.value_visit_states[input_id] == ValueVisitState::Scheduled) {
+          return input_id;
+        }
+      }
+    }
+    for (PatternValueId value_id = 0; value_id < state.value_visit_states.size(); ++value_id) {
+      if (state.value_visit_states[value_id] == ValueVisitState::Scheduled) return value_id;
+    }
+    return kMissingPatternValue;
+  }
+
+  Status BindProducer(PatternValueId value_id, const NodeArg& target_value, bool& matched) {
+    const auto& normalized = *compiled.normalized_pattern;
+    const auto& pattern_value = normalized.values[value_id];
+    const auto target_producer = snapshot.producers.find(&target_value);
+    if (target_producer == snapshot.producers.end() ||
+        target_producer->second.output_index != pattern_value.producer_output_index) {
+      matched = false;
+      return Status::OK();
+    }
+
+    const auto pattern_node_id = pattern_value.producer_node_id;
+    const auto target_node_index = target_producer->second.node_index;
+    const auto* target_node = snapshot.graph_viewer->GetNode(target_node_index);
+    if (target_node == nullptr ||
+        !NodeSignatureMatches(compiled.resolved_nodes[pattern_node_id], *target_node) ||
+        !target_node->GetExecutionProviderType().empty() ||
+        HasControlRelationship(snapshot, *target_node)) {
+      matched = false;
+      return Status::OK();
+    }
+
+    auto& mapped_target = state.pattern_node_to_target[pattern_node_id];
+    if (mapped_target != std::numeric_limits<NodeIndex>::max()) {
+      matched = mapped_target == target_node_index;
+      if (!matched) return Status::OK();
+    } else {
+      if (state.target_node_to_pattern.find(target_node_index) != state.target_node_to_pattern.end()) {
+        matched = false;
+        return Status::OK();
+      }
+      mapped_target = target_node_index;
+      state.target_node_to_pattern.emplace(target_node_index, pattern_node_id);
+    }
+
+    const auto& pattern_node = normalized.nodes[pattern_node_id];
+    for (size_t output_index = 0; output_index < pattern_node.output_value_ids.size(); ++output_index) {
+      const auto pattern_output = pattern_node.output_value_ids[output_index];
+      const auto* target_output = target_node->OutputDefs()[output_index];
+      if (pattern_output == kMissingPatternValue) {
+        if (target_output != nullptr && target_output->Exists()) {
+          matched = false;
+          return Status::OK();
+        }
+        continue;
+      }
+      if (target_output == nullptr || !target_output->Exists()) {
+        matched = false;
+        return Status::OK();
+      }
+      ORT_RETURN_IF_ERROR(Schedule(pattern_output, target_output, matched));
+      if (!matched) return Status::OK();
+    }
+    for (size_t input_index = 0; input_index < pattern_node.input_value_ids.size(); ++input_index) {
+      const auto pattern_input = pattern_node.input_value_ids[input_index];
+      const auto* target_input = target_node->InputDefs()[input_index];
+      if (pattern_input == kMissingPatternValue) {
+        if (target_input != nullptr && target_input->Exists()) {
+          matched = false;
+          return Status::OK();
+        }
+        continue;
+      }
+      if (target_input == nullptr || !target_input->Exists()) {
+        matched = false;
+        return Status::OK();
+      }
+      ORT_RETURN_IF_ERROR(Schedule(pattern_input, target_input, matched));
+      if (!matched) return Status::OK();
+    }
+    return Status::OK();
+  }
+
+  Status Run(gsl::span<const NodeIndex> output_root_nodes, ReplacementPlan& plan, bool& matched) {
+    const auto& normalized = *compiled.normalized_pattern;
+    state.pattern_node_to_target.assign(normalized.nodes.size(), std::numeric_limits<NodeIndex>::max());
+    state.pattern_value_to_target.assign(normalized.values.size(), nullptr);
+    state.value_visit_states.assign(normalized.values.size(), ValueVisitState::Unseen);
+    state.formal_input_bindings.assign(normalized.formal_input_value_ids.size(), nullptr);
+    matched = true;
+
+    for (size_t group_index = 0; group_index < compiled.formal_output_producer_groups.size(); ++group_index) {
+      const auto& group = compiled.formal_output_producer_groups[group_index];
+      const auto* target_node = snapshot.graph_viewer->GetNode(output_root_nodes[group_index]);
+      if (target_node == nullptr) {
+        matched = false;
+        return Status::OK();
+      }
+      for (size_t i = 0; i < group.formal_output_indices.size(); ++i) {
+        const auto formal_output_index = group.formal_output_indices[i];
+        const auto target_output_index = group.producer_output_indices[i];
+        if (target_output_index >= target_node->OutputDefs().size()) {
+          matched = false;
+          return Status::OK();
+        }
+        bool scheduled = true;
+        ORT_RETURN_IF_ERROR(Schedule(normalized.formal_output_value_ids[formal_output_index],
+                                     target_node->OutputDefs()[target_output_index], scheduled));
+        if (!scheduled) {
+          matched = false;
+          return Status::OK();
+        }
+      }
+    }
+
+    while (true) {
+      const auto value_id = NextScheduledValue();
+      if (value_id == kMissingPatternValue) break;
+      state.value_visit_states[value_id] = ValueVisitState::Processed;
+      if (diagnostics != nullptr) ++diagnostics->worklist_bindings_processed;
+      const auto& pattern_value = normalized.values[value_id];
+      const auto* target_value = state.pattern_value_to_target[value_id];
+
+      if (pattern_value.is_formal_input) {
+        const auto formal_it =
+            std::find(normalized.formal_input_value_ids.begin(), normalized.formal_input_value_ids.end(), value_id);
+        state.formal_input_bindings[static_cast<size_t>(
+            std::distance(normalized.formal_input_value_ids.begin(), formal_it))] = target_value;
+        continue;
+      }
+      if (pattern_value.is_literal) {
+        LiteralWitness witness;
+        ORT_RETURN_IF_ERROR(MatchLiteral(pattern_value, *target_value, snapshot, options,
+                                         literal_bytes_compared, witness, matched));
+        if (!matched) return Status::OK();
+        witness.pattern_value_id = value_id;
+        state.literal_witnesses.push_back(std::move(witness));
+        continue;
+      }
+      ORT_RETURN_IF_ERROR(BindProducer(value_id, *target_value, matched));
+      if (!matched) return Status::OK();
+    }
+
+    for (const auto mapped_node : state.pattern_node_to_target) {
+      if (mapped_node == std::numeric_limits<NodeIndex>::max()) {
+        matched = false;
+        return Status::OK();
+      }
+    }
+    InlinedHashSet<const NodeArg*> formal_inputs(state.formal_input_bindings.begin(),
+                                                 state.formal_input_bindings.end());
+    for (const auto& witness : state.literal_witnesses) {
+      if (formal_inputs.find(witness.target_value) != formal_inputs.end()) {
+        matched = false;
+        return Status::OK();
+      }
+    }
+
+    return BuildPlan(plan, matched);
+  }
+
+  Status BuildPlan(ReplacementPlan& plan, bool& matched) {
+    const auto& normalized = *compiled.normalized_pattern;
+    plan = ReplacementPlan{};
+    plan.removable_node_indices.assign(state.pattern_node_to_target.begin(), state.pattern_node_to_target.end());
+    std::sort(plan.removable_node_indices.begin(), plan.removable_node_indices.end(),
+              [&](NodeIndex lhs, NodeIndex rhs) {
+                return snapshot.topological_positions.at(lhs) < snapshot.topological_positions.at(rhs);
+              });
+    if (plan.removable_node_indices.size() <= 1) {
+      matched = false;
+      return Status::OK();
+    }
+    const InlinedHashSet<NodeIndex> removable(plan.removable_node_indices.begin(),
+                                              plan.removable_node_indices.end());
+
+    for (const auto* formal_input : state.formal_input_bindings) {
+      const auto producer = snapshot.producers.find(formal_input);
+      if (producer != snapshot.producers.end() &&
+          removable.find(producer->second.node_index) != removable.end()) {
+        matched = false;
+        return Status::OK();
+      }
+    }
+
+    std::string annotation;
+    bool first_node = true;
+    for (const auto node_index : plan.removable_node_indices) {
+      const auto* node = snapshot.graph_viewer->GetNode(node_index);
+      if (first_node) {
+        annotation = node->GetLayeringAnnotation();
+        first_node = false;
+      } else if (node->GetLayeringAnnotation() != annotation) {
+        matched = false;
+        return Status::OK();
+      }
+    }
+    plan.layering_annotation = std::move(annotation);
+
+    for (PatternValueId value_id = 0; value_id < normalized.values.size(); ++value_id) {
+      const auto& pattern_value = normalized.values[value_id];
+      if (pattern_value.producer_node_id == kNoPatternNode || pattern_value.is_formal_output) continue;
+      const auto* target_value = state.pattern_value_to_target[value_id];
+      if (target_value == nullptr) continue;
+      if (snapshot.graph_outputs.find(target_value) != snapshot.graph_outputs.end()) {
+        matched = false;
+        return Status::OK();
+      }
+      const auto explicit_consumers = snapshot.explicit_consumers.find(target_value);
+      if (explicit_consumers != snapshot.explicit_consumers.end()) {
+        for (const auto& consumer : explicit_consumers->second) {
+          if (removable.find(consumer.node_index) == removable.end()) {
+            matched = false;
+            return Status::OK();
+          }
+        }
+      }
+      const auto implicit_consumers = snapshot.implicit_consumers.find(target_value);
+      if (implicit_consumers != snapshot.implicit_consumers.end()) {
+        for (const auto consumer : implicit_consumers->second) {
+          if (removable.find(consumer) == removable.end()) {
+            matched = false;
+            return Status::OK();
+          }
+        }
+      }
+    }
+
+    InlinedHashSet<NodeIndex> visited_outside;
+    std::deque<NodeIndex> pending;
+    auto enqueue_consumers = [&](const NodeArg* value) {
+      const auto explicit_consumers = snapshot.explicit_consumers.find(value);
+      if (explicit_consumers != snapshot.explicit_consumers.end()) {
+        for (const auto& consumer : explicit_consumers->second) {
+          if (removable.find(consumer.node_index) == removable.end()) {
+            pending.push_back(consumer.node_index);
+          }
+        }
+      }
+      const auto implicit_consumers = snapshot.implicit_consumers.find(value);
+      if (implicit_consumers != snapshot.implicit_consumers.end()) {
+        for (const auto consumer : implicit_consumers->second) {
+          if (removable.find(consumer) == removable.end()) pending.push_back(consumer);
+        }
+      }
+    };
+    for (const auto node_index : plan.removable_node_indices) {
+      const auto* node = snapshot.graph_viewer->GetNode(node_index);
+      for (const auto* output : node->OutputDefs()) {
+        if (output == nullptr || !output->Exists()) continue;
+        enqueue_consumers(output);
+      }
+    }
+    while (!pending.empty()) {
+      const auto outside = pending.front();
+      pending.pop_front();
+      if (!visited_outside.insert(outside).second) continue;
+      const auto* node = snapshot.graph_viewer->GetNode(outside);
+      if (node == nullptr) continue;
+      for (const auto* output : node->OutputDefs()) {
+        if (output == nullptr || !output->Exists()) continue;
+        const auto explicit_consumers = snapshot.explicit_consumers.find(output);
+        if (explicit_consumers != snapshot.explicit_consumers.end()) {
+          for (const auto& consumer : explicit_consumers->second) {
+            if (removable.find(consumer.node_index) != removable.end()) {
+              matched = false;
+              return Status::OK();
+            }
+          }
+        }
+        const auto implicit_consumers = snapshot.implicit_consumers.find(output);
+        if (implicit_consumers != snapshot.implicit_consumers.end()) {
+          for (const auto consumer : implicit_consumers->second) {
+            if (removable.find(consumer) != removable.end()) {
+              matched = false;
+              return Status::OK();
+            }
+          }
+        }
+        enqueue_consumers(output);
+      }
+    }
+
+    for (const auto* input : state.formal_input_bindings) {
+      plan.call_inputs.push_back(const_cast<NodeArg*>(input));
+    }
+    for (const auto output_id : normalized.formal_output_value_ids) {
+      plan.call_outputs.push_back(const_cast<NodeArg*>(state.pattern_value_to_target[output_id]));
+    }
+    plan.literal_witnesses = state.literal_witnesses;
+    plan.primary_root_topological_position =
+        snapshot.topological_positions.at(
+            state.pattern_node_to_target[compiled.formal_output_producer_groups[primary_output_group].producer_node_id]);
+
+    for (const auto node_index : plan.removable_node_indices) {
+      const auto* node = snapshot.graph_viewer->GetNode(node_index);
+      const auto input_edges = graph_utils::GraphEdge::GetNodeInputEdges(*node);
+      plan.matched_input_edges.insert(plan.matched_input_edges.end(), input_edges.begin(), input_edges.end());
+      for (const auto& edge : input_edges) {
+        if (removable.find(edge.src_node) == removable.end()) plan.explicit_input_edges.push_back(edge);
+      }
+      for (const auto& edge : graph_utils::GraphEdge::GetNodeOutputEdges(*node)) {
+        if (removable.find(edge.dst_node) == removable.end()) plan.explicit_output_edges.push_back(edge);
+      }
+      for (const auto* output : node->OutputDefs()) {
+        const auto implicit = snapshot.implicit_consumers.find(output);
+        if (implicit != snapshot.implicit_consumers.end()) {
+          plan.implicit_consumers.emplace(output, implicit->second);
+        }
+      }
+    }
+    return Status::OK();
+  }
+};
+
+bool PlansConflict(const ReplacementPlan& lhs, const ReplacementPlan& rhs) {
+  InlinedHashSet<NodeIndex> lhs_nodes(lhs.removable_node_indices.begin(), lhs.removable_node_indices.end());
+  for (const auto node : rhs.removable_node_indices) {
+    if (lhs_nodes.find(node) != lhs_nodes.end()) return true;
+  }
+  InlinedHashSet<const NodeArg*> lhs_inputs(lhs.call_inputs.begin(), lhs.call_inputs.end());
+  InlinedHashSet<const NodeArg*> rhs_inputs(rhs.call_inputs.begin(), rhs.call_inputs.end());
+  for (const auto* output : lhs.call_outputs) {
+    if (rhs_inputs.find(output) != rhs_inputs.end()) return true;
+  }
+  for (const auto* output : rhs.call_outputs) {
+    if (lhs_inputs.find(output) != lhs_inputs.end()) return true;
+  }
+  return false;
+}
+
+}  // namespace
+
+Status BuildTargetGraphSnapshot(
+    const Graph& graph,
+    const CompiledFunctionPattern&,
+    const FunctionExtractorOptions& options,
+    TargetGraphSnapshot& snapshot) {
+  snapshot = TargetGraphSnapshot{};
+  snapshot.graph = &graph;
+  snapshot.graph_viewer = std::make_unique<GraphViewer>(graph);
+  ORT_RETURN_IF(static_cast<size_t>(snapshot.graph_viewer->NumberOfNodes()) > options.max_target_nodes,
+                "FunctionExtractor target node budget exceeded.");
+  const auto& topological_order = snapshot.graph_viewer->GetNodesInTopologicalOrder();
+  snapshot.topological_node_indices.assign(topological_order.begin(), topological_order.end());
+  for (size_t position = 0; position < snapshot.topological_node_indices.size(); ++position) {
+    const auto node_index = snapshot.topological_node_indices[position];
+    snapshot.topological_positions.emplace(node_index, position);
+    const auto* node = snapshot.graph_viewer->GetNode(node_index);
+    ORT_RETURN_IF(node == nullptr || node->Op() == nullptr,
+                  "FunctionExtractor requires a resolved target graph.");
+    for (size_t output_index = 0; output_index < node->OutputDefs().size(); ++output_index) {
+      const auto* output = node->OutputDefs()[output_index];
+      if (output != nullptr && output->Exists()) {
+        snapshot.producers.emplace(output, ProducerSlot{node_index, output_index});
+      }
+    }
+    for (size_t input_index = 0; input_index < node->InputDefs().size(); ++input_index) {
+      const auto* input = node->InputDefs()[input_index];
+      if (input != nullptr && input->Exists()) {
+        snapshot.explicit_consumers[input].push_back(ConsumerSlot{node_index, input_index});
+      }
+    }
+    for (const auto* implicit_input : node->ImplicitInputDefs()) {
+      if (implicit_input != nullptr && implicit_input->Exists()) {
+        snapshot.implicit_consumers[implicit_input].push_back(node_index);
+      }
+    }
+  }
+  for (const auto* output : snapshot.graph_viewer->GetOutputs()) {
+    snapshot.graph_outputs.insert(output);
+  }
+  for (const auto& [name, tensor] : snapshot.graph_viewer->GetAllInitializedTensors()) {
+    if (graph.GetConstantInitializer(name, false) != nullptr) {
+      snapshot.constant_initializers.emplace(name, tensor);
+    }
+  }
+  return Status::OK();
+}
+
+Status DiscoverReplacementPlans(
+    const CompiledFunctionPattern& compiled_pattern,
+    const TargetGraphSnapshot& snapshot,
+    const FunctionExtractorOptions& options,
+    std::vector<ReplacementPlan>& plans,
+    MatcherDiagnostics* diagnostics) {
+  plans.clear();
+  const auto& groups = compiled_pattern.formal_output_producer_groups;
+  ORT_RETURN_IF(groups.empty(), "FunctionExtractor pattern has no formal output producer.");
+  InlinedVector<InlinedVector<NodeIndex>> candidates(groups.size());
+  for (size_t group_index = 0; group_index < groups.size(); ++group_index) {
+    const auto& resolved = compiled_pattern.resolved_nodes[groups[group_index].producer_node_id];
+    for (const auto node_index : snapshot.topological_node_indices) {
+      const auto* node = snapshot.graph_viewer->GetNode(node_index);
+      if (node != nullptr && NodeSignatureMatches(resolved, *node)) {
+        candidates[group_index].push_back(node_index);
+      }
+    }
+  }
+
+  size_t tuple_count = 0;
+  size_t literal_bytes_compared = 0;
+  InlinedVector<NodeIndex> tuple(groups.size(), std::numeric_limits<NodeIndex>::max());
+  InlinedVector<size_t> group_order(groups.size());
+  for (size_t i = 0; i < group_order.size(); ++i) group_order[i] = i;
+  std::sort(group_order.begin(), group_order.end(), [&](size_t lhs, size_t rhs) {
+    return std::pair{candidates[lhs].size(), lhs} < std::pair{candidates[rhs].size(), rhs};
+  });
+  const size_t primary_output_group = group_order.front();
+  InlinedHashSet<NodeIndex> chosen_nodes;
+  Status enumeration_status = Status::OK();
+  std::function<void(size_t)> enumerate = [&](size_t order_index) {
+    if (!enumeration_status.IsOK()) return;
+    if (order_index == groups.size()) {
+      ++tuple_count;
+      if (tuple_count > options.max_output_root_tuples) {
+        enumeration_status =
+            MatcherError("output-root tuple budget exceeded");
+        return;
+      }
+      if (diagnostics != nullptr) ++diagnostics->output_root_tuples_considered;
+      CandidateMatcher matcher{compiled_pattern, snapshot, options, diagnostics,
+                               literal_bytes_compared, primary_output_group};
+      ReplacementPlan plan;
+      bool matched = false;
+      enumeration_status = matcher.Run(tuple, plan, matched);
+      if (!enumeration_status.IsOK() || !matched) return;
+      if (diagnostics != nullptr) {
+        ++diagnostics->structurally_matched_candidates;
+        ++diagnostics->accepted_candidates;
+      }
+      plans.push_back(std::move(plan));
+      return;
+    }
+    const size_t group_index = group_order[order_index];
+    for (const auto candidate : candidates[group_index]) {
+      if (!chosen_nodes.insert(candidate).second) continue;
+      tuple[group_index] = candidate;
+      enumerate(order_index + 1);
+      chosen_nodes.erase(candidate);
+    }
+  };
+  enumerate(0);
+  ORT_RETURN_IF_ERROR(enumeration_status);
+
+  std::sort(plans.begin(), plans.end(), [](const ReplacementPlan& lhs, const ReplacementPlan& rhs) {
+    return std::tie(lhs.primary_root_topological_position, lhs.removable_node_indices) <
+           std::tie(rhs.primary_root_topological_position, rhs.removable_node_indices);
+  });
+  return Status::OK();
+}
+
+Status SelectNonConflictingPlans(
+    gsl::span<const ReplacementPlan> plans,
+    std::vector<size_t>& selected_plan_indices) {
+  selected_plan_indices.clear();
+  for (size_t candidate_index = 0; candidate_index < plans.size(); ++candidate_index) {
+    bool conflict = false;
+    for (const auto selected_index : selected_plan_indices) {
+      if (PlansConflict(plans[candidate_index], plans[selected_index])) {
+        conflict = true;
+        break;
+      }
+    }
+    if (!conflict) selected_plan_indices.push_back(candidate_index);
+  }
+  return Status::OK();
+}
+
+Status PrevalidatePlans(
+    const Graph& graph,
+    const CompiledFunctionPattern& compiled_pattern,
+    gsl::span<const ReplacementPlan> plans) {
+  ORT_RETURN_IF_ERROR(ValidateRegisteredFunction(*compiled_pattern.normalized_pattern, graph));
+  FunctionExtractorOptions snapshot_options;
+  snapshot_options.max_target_nodes = std::numeric_limits<size_t>::max();
+  TargetGraphSnapshot snapshot;
+  ORT_RETURN_IF_ERROR(BuildTargetGraphSnapshot(graph, compiled_pattern, snapshot_options, snapshot));
+
+  auto edge_less = [](const graph_utils::GraphEdge& lhs, const graph_utils::GraphEdge& rhs) {
+    return std::tie(lhs.src_node, lhs.dst_node, lhs.src_arg_index, lhs.dst_arg_index, lhs.arg_name) <
+           std::tie(rhs.src_node, rhs.dst_node, rhs.src_arg_index, rhs.dst_arg_index, rhs.arg_name);
+  };
+  auto edges_equal = [&](std::vector<graph_utils::GraphEdge> lhs,
+                         std::vector<graph_utils::GraphEdge> rhs) {
+    std::sort(lhs.begin(), lhs.end(), edge_less);
+    std::sort(rhs.begin(), rhs.end(), edge_less);
+    if (lhs.size() != rhs.size()) return false;
+    for (size_t i = 0; i < lhs.size(); ++i) {
+      if (edge_less(lhs[i], rhs[i]) || edge_less(rhs[i], lhs[i])) return false;
+    }
+    return true;
+  };
+
+  for (size_t plan_index = 0; plan_index < plans.size(); ++plan_index) {
+    const auto& plan = plans[plan_index];
+    ORT_RETURN_IF(plan.removable_node_indices.size() <= 1,
+                  "Replacement plan does not strictly reduce the graph node count.");
+    for (const auto node_index : plan.removable_node_indices) {
+      const auto* node = graph.GetNode(node_index);
+      ORT_RETURN_IF(node == nullptr, "Replacement plan references a removed node.");
+      ORT_RETURN_IF(node->GetLayeringAnnotation() != plan.layering_annotation,
+                    "Replacement plan layering annotation changed.");
+    }
+    std::vector<graph_utils::GraphEdge> current_input_edges;
+    std::vector<graph_utils::GraphEdge> current_output_edges;
+    InlinedHashSet<NodeIndex> removable(plan.removable_node_indices.begin(),
+                                        plan.removable_node_indices.end());
+    for (const auto node_index : plan.removable_node_indices) {
+      const auto node_edges = graph_utils::GraphEdge::GetNodeInputEdges(*graph.GetNode(node_index));
+      current_input_edges.insert(current_input_edges.end(), node_edges.begin(), node_edges.end());
+      for (const auto& edge : graph_utils::GraphEdge::GetNodeOutputEdges(*graph.GetNode(node_index))) {
+        if (removable.find(edge.dst_node) == removable.end()) current_output_edges.push_back(edge);
+      }
+    }
+    ORT_RETURN_IF_NOT(edges_equal(current_input_edges, plan.matched_input_edges),
+                      "Replacement plan input edges changed.");
+    ORT_RETURN_IF_NOT(edges_equal(current_output_edges, plan.explicit_output_edges),
+                      "Replacement plan output edges changed.");
+    for (const auto* input : plan.call_inputs) {
+      ORT_RETURN_IF(input == nullptr || !input->Exists(), "Replacement plan has a stale call input.");
+    }
+    for (const auto* output : plan.call_outputs) {
+      ORT_RETURN_IF(output == nullptr || !output->Exists(), "Replacement plan has a stale call output.");
+    }
+    for (size_t other_index = 0; other_index < plan_index; ++other_index) {
+      ORT_RETURN_IF(PlansConflict(plan, plans[other_index]),
+                    "Selected replacement plans conflict.");
+    }
+    for (const auto& [value, expected_consumers] : plan.implicit_consumers) {
+      const auto current = snapshot.implicit_consumers.find(value);
+      InlinedVector<NodeIndex> current_consumers;
+      if (current != snapshot.implicit_consumers.end()) current_consumers = current->second;
+      auto expected = expected_consumers;
+      std::sort(current_consumers.begin(), current_consumers.end());
+      std::sort(expected.begin(), expected.end());
+      ORT_RETURN_IF(current_consumers != expected,
+                    "Replacement plan implicit consumers changed.");
+    }
+    if (!plan.generated_call_name.empty()) {
+      for (const auto& node : graph.Nodes()) {
+        ORT_RETURN_IF(node.Name() == plan.generated_call_name,
+                      "Replacement plan call node name is no longer unique.");
+      }
+    }
+    for (const auto& witness : plan.literal_witnesses) {
+      ORT_RETURN_IF(witness.target_value == nullptr || !witness.target_value->Exists(),
+                    "Replacement plan has a stale literal witness.");
+      if (witness.is_initializer) {
+        const auto* tensor = graph.GetConstantInitializer(witness.target_value->Name(), false);
+        ORT_RETURN_IF(tensor == nullptr,
+                      "Replacement plan initializer witness is no longer constant.");
+        bool equal = false;
+        const auto& pattern_value =
+            compiled_pattern.normalized_pattern->values[witness.pattern_value_id];
+        const auto& model_path = graph.ModelPath();
+        ORT_RETURN_IF_ERROR(CompareTensorLiterals(pattern_value.literal.tensor, *tensor,
+                                                  pattern_value.literal.byte_count, equal, &model_path));
+        ORT_RETURN_IF_NOT(equal, "Replacement plan initializer literal changed.");
+      } else {
+        const auto* constant = graph.GetNode(witness.constant_node_index);
+        ORT_RETURN_IF(constant == nullptr,
+                      "Replacement plan Constant witness was removed.");
+        ONNX_NAMESPACE::TensorProto normalized_constant;
+        ORT_RETURN_IF_ERROR(
+            NormalizeConstantAttributes(constant->GetAttributes(), normalized_constant));
+        bool equal = false;
+        const auto& pattern_value =
+            compiled_pattern.normalized_pattern->values[witness.pattern_value_id];
+        ORT_RETURN_IF_ERROR(CompareTensorLiterals(pattern_value.literal.tensor, normalized_constant,
+                                                  pattern_value.literal.byte_count, equal));
+        ORT_RETURN_IF_NOT(equal, "Replacement plan Constant literal changed.");
+      }
+    }
+  }
+  return Status::OK();
+}
+
+}  // namespace function_extractor_internal
+}  // namespace onnxruntime
+
+#endif  // !defined(ORT_MINIMAL_BUILD)

--- a/onnxruntime/core/optimizer/function_extractor_matcher.cc
+++ b/onnxruntime/core/optimizer/function_extractor_matcher.cc
@@ -55,15 +55,59 @@ bool NodeSignatureMatches(const ResolvedPatternNode& pattern_node, const Node& t
          AreAttributesSemanticallyEqual(pattern_node.effective_attributes, target_node.GetAttributes());
 }
 
-bool HasControlRelationship(const TargetGraphSnapshot& snapshot, const Node& node) {
-  if (!node.ControlInputs().empty()) return true;
-  for (const auto node_index : snapshot.topological_node_indices) {
-    const auto* other = snapshot.graph_viewer->GetNode(node_index);
-    if (other != nullptr && other->ControlInputs().find(node.Name()) != other->ControlInputs().end()) {
-      return true;
-    }
+void AppendKeyPart(std::string_view part, std::string& key) {
+  key += std::to_string(part.size());
+  key.push_back(':');
+  key.append(part);
+  key.push_back(';');
+}
+
+std::string AttributeFingerprint(const NodeAttributes& attributes) {
+  InlinedVector<std::string_view> names;
+  names.reserve(attributes.size());
+  for (const auto& [name, unused] : attributes) {
+    ORT_UNUSED_PARAMETER(unused);
+    names.push_back(name);
   }
-  return false;
+  std::sort(names.begin(), names.end());
+  std::string fingerprint;
+  for (const auto name : names) {
+    AppendKeyPart(name, fingerprint);
+    auto attribute = attributes.at(std::string{name});
+    attribute.clear_doc_string();
+    AppendKeyPart(attribute.SerializeAsString(), fingerprint);
+  }
+  return fingerprint;
+}
+
+std::string SignatureKey(std::string_view domain,
+                         std::string_view op_type,
+                         std::string_view overload,
+                         int since_version,
+                         size_t input_arity,
+                         size_t output_arity,
+                         const NodeAttributes& attributes) {
+  std::string key;
+  AppendKeyPart(domain, key);
+  AppendKeyPart(op_type, key);
+  AppendKeyPart(overload, key);
+  AppendKeyPart(std::to_string(since_version), key);
+  AppendKeyPart(std::to_string(input_arity), key);
+  AppendKeyPart(std::to_string(output_arity), key);
+  AppendKeyPart(AttributeFingerprint(attributes), key);
+  return key;
+}
+
+std::string SignatureKey(const ResolvedPatternNode& node) {
+  return SignatureKey(node.canonical_domain, node.op_type, node.overload,
+                      node.since_version, node.input_arity, node.output_arity,
+                      node.effective_attributes);
+}
+
+std::string SignatureKey(const Node& node) {
+  return SignatureKey(node.Domain(), node.OpType(), node.Overload(),
+                      node.SinceVersion(), node.InputDefs().size(),
+                      node.OutputDefs().size(), node.GetAttributes());
 }
 
 Status MatchLiteral(const PatternValue& pattern_value,
@@ -103,7 +147,6 @@ Status MatchLiteral(const PatternValue& pattern_value,
   const auto& model_path = snapshot.graph->ModelPath();
   ORT_RETURN_IF_ERROR(CompareTensorLiterals(pattern_value.literal.tensor, *target_tensor,
                                             options.max_literal_bytes, matched, &model_path));
-  if (matched) witness.fingerprint = pattern_value.literal.fingerprint;
   return Status::OK();
 }
 
@@ -113,8 +156,16 @@ struct CandidateMatcher {
   const FunctionExtractorOptions& options;
   MatcherDiagnostics* diagnostics;
   size_t& literal_bytes_compared;
+  size_t& aggregate_work_units;
   size_t primary_output_group;
   MatchState state;
+
+  Status ConsumeWork() {
+    ORT_RETURN_IF(aggregate_work_units >= options.max_worklist_bindings,
+                  "FunctionExtractor aggregate matcher work budget exceeded.");
+    ++aggregate_work_units;
+    return Status::OK();
+  }
 
   Status Schedule(PatternValueId pattern_value_id, const NodeArg* target_value, bool& matched) {
     if (target_value == nullptr || !target_value->Exists()) {
@@ -130,11 +181,10 @@ struct CandidateMatcher {
       matched = state.pattern_value_to_target[pattern_value_id] == target_value;
       return Status::OK();
     }
-    ORT_RETURN_IF(state.processed_binding_count >= options.max_worklist_bindings,
-                  "FunctionExtractor worklist binding budget exceeded.");
+    ORT_RETURN_IF_ERROR(ConsumeWork());
     state.pattern_value_to_target[pattern_value_id] = target_value;
     visit_state = ValueVisitState::Scheduled;
-    ++state.processed_binding_count;
+    ++state.scheduled_binding_count;
     if (diagnostics != nullptr) ++diagnostics->worklist_bindings_scheduled;
     return Status::OK();
   }
@@ -143,6 +193,7 @@ struct CandidateMatcher {
     const auto& normalized = *compiled.normalized_pattern;
     for (const auto node_id : normalized.reverse_topological_node_ids) {
       for (const auto output_id : normalized.nodes[node_id].output_value_ids) {
+        if (output_id == kMissingPatternValue) continue;
         if (state.value_visit_states[output_id] == ValueVisitState::Scheduled) return output_id;
       }
       for (const auto input_id : normalized.nodes[node_id].input_value_ids) {
@@ -174,7 +225,7 @@ struct CandidateMatcher {
     if (target_node == nullptr ||
         !NodeSignatureMatches(compiled.resolved_nodes[pattern_node_id], *target_node) ||
         !target_node->GetExecutionProviderType().empty() ||
-        HasControlRelationship(snapshot, *target_node)) {
+        snapshot.control_edge_nodes.find(target_node_index) != snapshot.control_edge_nodes.end()) {
       matched = false;
       return Status::OK();
     }
@@ -252,10 +303,10 @@ struct CandidateMatcher {
           matched = false;
           return Status::OK();
         }
-        bool scheduled = true;
+        bool binding_matches = true;
         ORT_RETURN_IF_ERROR(Schedule(normalized.formal_output_value_ids[formal_output_index],
-                                     target_node->OutputDefs()[target_output_index], scheduled));
-        if (!scheduled) {
+                                     target_node->OutputDefs()[target_output_index], binding_matches));
+        if (!binding_matches) {
           matched = false;
           return Status::OK();
         }
@@ -305,10 +356,10 @@ struct CandidateMatcher {
       }
     }
 
-    return BuildPlan(plan, matched);
+    return ValidateCandidateAndBuildPlan(plan, matched);
   }
 
-  Status BuildPlan(ReplacementPlan& plan, bool& matched) {
+  Status ValidateCandidateAndBuildPlan(ReplacementPlan& plan, bool& matched) {
     const auto& normalized = *compiled.normalized_pattern;
     plan = ReplacementPlan{};
     plan.removable_node_indices.assign(state.pattern_node_to_target.begin(), state.pattern_node_to_target.end());
@@ -323,6 +374,7 @@ struct CandidateMatcher {
     const InlinedHashSet<NodeIndex> removable(plan.removable_node_indices.begin(),
                                               plan.removable_node_indices.end());
 
+    // Boundary closure and scheduling constraints.
     for (const auto* formal_input : state.formal_input_bindings) {
       const auto producer = snapshot.producers.find(formal_input);
       if (producer != snapshot.producers.end() &&
@@ -347,6 +399,7 @@ struct CandidateMatcher {
     plan.layering_annotation = std::move(annotation);
 
     for (PatternValueId value_id = 0; value_id < normalized.values.size(); ++value_id) {
+      ORT_RETURN_IF_ERROR(ConsumeWork());
       const auto& pattern_value = normalized.values[value_id];
       if (pattern_value.producer_node_id == kNoPatternNode || pattern_value.is_formal_output) continue;
       const auto* target_value = state.pattern_value_to_target[value_id];
@@ -358,6 +411,7 @@ struct CandidateMatcher {
       const auto explicit_consumers = snapshot.explicit_consumers.find(target_value);
       if (explicit_consumers != snapshot.explicit_consumers.end()) {
         for (const auto& consumer : explicit_consumers->second) {
+          ORT_RETURN_IF_ERROR(ConsumeWork());
           if (removable.find(consumer.node_index) == removable.end()) {
             matched = false;
             return Status::OK();
@@ -367,6 +421,7 @@ struct CandidateMatcher {
       const auto implicit_consumers = snapshot.implicit_consumers.find(target_value);
       if (implicit_consumers != snapshot.implicit_consumers.end()) {
         for (const auto consumer : implicit_consumers->second) {
+          ORT_RETURN_IF_ERROR(ConsumeWork());
           if (removable.find(consumer) == removable.end()) {
             matched = false;
             return Status::OK();
@@ -375,12 +430,14 @@ struct CandidateMatcher {
       }
     }
 
+    // Convexity: no path may leave R and later re-enter it.
     InlinedHashSet<NodeIndex> visited_outside;
     std::deque<NodeIndex> pending;
-    auto enqueue_consumers = [&](const NodeArg* value) {
+    auto enqueue_consumers = [&](const NodeArg* value) -> Status {
       const auto explicit_consumers = snapshot.explicit_consumers.find(value);
       if (explicit_consumers != snapshot.explicit_consumers.end()) {
         for (const auto& consumer : explicit_consumers->second) {
+          ORT_RETURN_IF_ERROR(ConsumeWork());
           if (removable.find(consumer.node_index) == removable.end()) {
             pending.push_back(consumer.node_index);
           }
@@ -389,18 +446,21 @@ struct CandidateMatcher {
       const auto implicit_consumers = snapshot.implicit_consumers.find(value);
       if (implicit_consumers != snapshot.implicit_consumers.end()) {
         for (const auto consumer : implicit_consumers->second) {
+          ORT_RETURN_IF_ERROR(ConsumeWork());
           if (removable.find(consumer) == removable.end()) pending.push_back(consumer);
         }
       }
+      return Status::OK();
     };
     for (const auto node_index : plan.removable_node_indices) {
       const auto* node = snapshot.graph_viewer->GetNode(node_index);
       for (const auto* output : node->OutputDefs()) {
         if (output == nullptr || !output->Exists()) continue;
-        enqueue_consumers(output);
+        ORT_RETURN_IF_ERROR(enqueue_consumers(output));
       }
     }
     while (!pending.empty()) {
+      ORT_RETURN_IF_ERROR(ConsumeWork());
       const auto outside = pending.front();
       pending.pop_front();
       if (!visited_outside.insert(outside).second) continue;
@@ -411,6 +471,7 @@ struct CandidateMatcher {
         const auto explicit_consumers = snapshot.explicit_consumers.find(output);
         if (explicit_consumers != snapshot.explicit_consumers.end()) {
           for (const auto& consumer : explicit_consumers->second) {
+            ORT_RETURN_IF_ERROR(ConsumeWork());
             if (removable.find(consumer.node_index) != removable.end()) {
               matched = false;
               return Status::OK();
@@ -420,16 +481,18 @@ struct CandidateMatcher {
         const auto implicit_consumers = snapshot.implicit_consumers.find(output);
         if (implicit_consumers != snapshot.implicit_consumers.end()) {
           for (const auto consumer : implicit_consumers->second) {
+            ORT_RETURN_IF_ERROR(ConsumeWork());
             if (removable.find(consumer) != removable.end()) {
               matched = false;
               return Status::OK();
             }
           }
         }
-        enqueue_consumers(output);
+        ORT_RETURN_IF_ERROR(enqueue_consumers(output));
       }
     }
 
+    // Materialize the immutable replacement recipe only after validation.
     for (const auto* input : state.formal_input_bindings) {
       plan.call_inputs.push_back(const_cast<NodeArg*>(input));
     }
@@ -437,6 +500,7 @@ struct CandidateMatcher {
       plan.call_outputs.push_back(const_cast<NodeArg*>(state.pattern_value_to_target[output_id]));
     }
     plan.literal_witnesses = state.literal_witnesses;
+    plan.pattern_node_to_target = state.pattern_node_to_target;
     plan.primary_root_topological_position =
         snapshot.topological_positions.at(
             state.pattern_node_to_target[compiled.formal_output_producer_groups[primary_output_group].producer_node_id]);
@@ -452,9 +516,15 @@ struct CandidateMatcher {
         if (removable.find(edge.dst_node) == removable.end()) plan.explicit_output_edges.push_back(edge);
       }
       for (const auto* output : node->OutputDefs()) {
+        if (output == nullptr || !output->Exists()) continue;
         const auto implicit = snapshot.implicit_consumers.find(output);
         if (implicit != snapshot.implicit_consumers.end()) {
           plan.implicit_consumers.emplace(output, implicit->second);
+        } else {
+          plan.implicit_consumers.emplace(output, InlinedVector<NodeIndex>{});
+        }
+        if (snapshot.graph_outputs.find(output) != snapshot.graph_outputs.end()) {
+          plan.graph_outputs.insert(output);
         }
       }
     }
@@ -482,7 +552,7 @@ bool PlansConflict(const ReplacementPlan& lhs, const ReplacementPlan& rhs) {
 
 Status BuildTargetGraphSnapshot(
     const Graph& graph,
-    const CompiledFunctionPattern&,
+    const CompiledFunctionPattern& compiled_pattern,
     const FunctionExtractorOptions& options,
     TargetGraphSnapshot& snapshot) {
   snapshot = TargetGraphSnapshot{};
@@ -492,12 +562,38 @@ Status BuildTargetGraphSnapshot(
                 "FunctionExtractor target node budget exceeded.");
   const auto& topological_order = snapshot.graph_viewer->GetNodesInTopologicalOrder();
   snapshot.topological_node_indices.assign(topological_order.begin(), topological_order.end());
+  snapshot.root_candidates_by_group.resize(
+      compiled_pattern.formal_output_producer_groups.size());
+  InlinedHashMap<std::string, InlinedVector<size_t>> groups_by_signature;
+  for (size_t group_index = 0;
+       group_index < compiled_pattern.formal_output_producer_groups.size();
+       ++group_index) {
+    const auto pattern_node_id =
+        compiled_pattern.formal_output_producer_groups[group_index].producer_node_id;
+    groups_by_signature[SignatureKey(compiled_pattern.resolved_nodes[pattern_node_id])]
+        .push_back(group_index);
+  }
+  InlinedHashMap<std::string, NodeIndex> node_indices_by_name;
+  for (const auto node_index : snapshot.topological_node_indices) {
+    const auto* node = snapshot.graph_viewer->GetNode(node_index);
+    ORT_RETURN_IF(node == nullptr || node->Op() == nullptr,
+                  "FunctionExtractor requires a resolved target graph.");
+    node_indices_by_name.emplace(node->Name(), node_index);
+  }
+  size_t candidate_entry_count = 0;
   for (size_t position = 0; position < snapshot.topological_node_indices.size(); ++position) {
     const auto node_index = snapshot.topological_node_indices[position];
     snapshot.topological_positions.emplace(node_index, position);
     const auto* node = snapshot.graph_viewer->GetNode(node_index);
-    ORT_RETURN_IF(node == nullptr || node->Op() == nullptr,
-                  "FunctionExtractor requires a resolved target graph.");
+    if (!node->ControlInputs().empty()) {
+      snapshot.control_edge_nodes.insert(node_index);
+      for (const auto& control_input : node->ControlInputs()) {
+        const auto source = node_indices_by_name.find(control_input);
+        if (source != node_indices_by_name.end()) {
+          snapshot.control_edge_nodes.insert(source->second);
+        }
+      }
+    }
     for (size_t output_index = 0; output_index < node->OutputDefs().size(); ++output_index) {
       const auto* output = node->OutputDefs()[output_index];
       if (output != nullptr && output->Exists()) {
@@ -513,6 +609,15 @@ Status BuildTargetGraphSnapshot(
     for (const auto* implicit_input : node->ImplicitInputDefs()) {
       if (implicit_input != nullptr && implicit_input->Exists()) {
         snapshot.implicit_consumers[implicit_input].push_back(node_index);
+      }
+    }
+    const auto compatible_groups = groups_by_signature.find(SignatureKey(*node));
+    if (compatible_groups != groups_by_signature.end()) {
+      for (const auto group_index : compatible_groups->second) {
+        ORT_RETURN_IF(candidate_entry_count >= options.max_output_root_tuples,
+                      "FunctionExtractor root candidate-entry budget exceeded.");
+        snapshot.root_candidates_by_group[group_index].push_back(node_index);
+        ++candidate_entry_count;
       }
     }
   }
@@ -536,19 +641,11 @@ Status DiscoverReplacementPlans(
   plans.clear();
   const auto& groups = compiled_pattern.formal_output_producer_groups;
   ORT_RETURN_IF(groups.empty(), "FunctionExtractor pattern has no formal output producer.");
-  InlinedVector<InlinedVector<NodeIndex>> candidates(groups.size());
-  for (size_t group_index = 0; group_index < groups.size(); ++group_index) {
-    const auto& resolved = compiled_pattern.resolved_nodes[groups[group_index].producer_node_id];
-    for (const auto node_index : snapshot.topological_node_indices) {
-      const auto* node = snapshot.graph_viewer->GetNode(node_index);
-      if (node != nullptr && NodeSignatureMatches(resolved, *node)) {
-        candidates[group_index].push_back(node_index);
-      }
-    }
-  }
+  const auto& candidates = snapshot.root_candidates_by_group;
 
   size_t tuple_count = 0;
   size_t literal_bytes_compared = 0;
+  size_t aggregate_work_units = 0;
   InlinedVector<NodeIndex> tuple(groups.size(), std::numeric_limits<NodeIndex>::max());
   InlinedVector<size_t> group_order(groups.size());
   for (size_t i = 0; i < group_order.size(); ++i) group_order[i] = i;
@@ -569,7 +666,8 @@ Status DiscoverReplacementPlans(
       }
       if (diagnostics != nullptr) ++diagnostics->output_root_tuples_considered;
       CandidateMatcher matcher{compiled_pattern, snapshot, options, diagnostics,
-                               literal_bytes_compared, primary_output_group};
+                               literal_bytes_compared, aggregate_work_units,
+                               primary_output_group};
       ReplacementPlan plan;
       bool matched = false;
       enumeration_status = matcher.Run(tuple, plan, matched);
@@ -583,6 +681,12 @@ Status DiscoverReplacementPlans(
     }
     const size_t group_index = group_order[order_index];
     for (const auto candidate : candidates[group_index]) {
+      if (aggregate_work_units >= options.max_worklist_bindings) {
+        enumeration_status =
+            MatcherError("aggregate output-root enumeration budget exceeded");
+        return;
+      }
+      ++aggregate_work_units;
       if (!chosen_nodes.insert(candidate).second) continue;
       tuple[group_index] = candidate;
       enumerate(order_index + 1);
@@ -624,7 +728,9 @@ Status PrevalidatePlans(
   FunctionExtractorOptions snapshot_options;
   snapshot_options.max_target_nodes = std::numeric_limits<size_t>::max();
   TargetGraphSnapshot snapshot;
-  ORT_RETURN_IF_ERROR(BuildTargetGraphSnapshot(graph, compiled_pattern, snapshot_options, snapshot));
+  CompiledFunctionPattern snapshot_pattern;
+  snapshot_pattern.normalized_pattern = compiled_pattern.normalized_pattern;
+  ORT_RETURN_IF_ERROR(BuildTargetGraphSnapshot(graph, snapshot_pattern, snapshot_options, snapshot));
 
   auto edge_less = [](const graph_utils::GraphEdge& lhs, const graph_utils::GraphEdge& rhs) {
     return std::tie(lhs.src_node, lhs.dst_node, lhs.src_arg_index, lhs.dst_arg_index, lhs.arg_name) <
@@ -650,6 +756,20 @@ Status PrevalidatePlans(
       ORT_RETURN_IF(node == nullptr, "Replacement plan references a removed node.");
       ORT_RETURN_IF(node->GetLayeringAnnotation() != plan.layering_annotation,
                     "Replacement plan layering annotation changed.");
+    }
+    ORT_RETURN_IF(plan.pattern_node_to_target.size() != compiled_pattern.resolved_nodes.size(),
+                  "Replacement plan pattern mapping changed.");
+    for (PatternNodeId pattern_node_id = 0;
+         pattern_node_id < plan.pattern_node_to_target.size();
+         ++pattern_node_id) {
+      const auto target_node_index = plan.pattern_node_to_target[pattern_node_id];
+      const auto* node = graph.GetNode(target_node_index);
+      ORT_RETURN_IF(node == nullptr ||
+                        !NodeSignatureMatches(compiled_pattern.resolved_nodes[pattern_node_id], *node) ||
+                        !node->GetExecutionProviderType().empty() ||
+                        snapshot.control_edge_nodes.find(target_node_index) !=
+                            snapshot.control_edge_nodes.end(),
+                    "Replacement plan node semantics changed.");
     }
     std::vector<graph_utils::GraphEdge> current_input_edges;
     std::vector<graph_utils::GraphEdge> current_output_edges;
@@ -685,6 +805,61 @@ Status PrevalidatePlans(
       std::sort(expected.begin(), expected.end());
       ORT_RETURN_IF(current_consumers != expected,
                     "Replacement plan implicit consumers changed.");
+      const bool currently_graph_output =
+          snapshot.graph_outputs.find(value) != snapshot.graph_outputs.end();
+      const bool expected_graph_output =
+          plan.graph_outputs.find(value) != plan.graph_outputs.end();
+      ORT_RETURN_IF(currently_graph_output != expected_graph_output,
+                    "Replacement plan graph-output membership changed.");
+    }
+
+    InlinedHashSet<NodeIndex> visited_outside;
+    std::deque<NodeIndex> pending;
+    for (const auto node_index : plan.removable_node_indices) {
+      const auto* node = graph.GetNode(node_index);
+      for (const auto* output : node->OutputDefs()) {
+        if (output == nullptr || !output->Exists()) continue;
+        const auto explicit_consumers = snapshot.explicit_consumers.find(output);
+        if (explicit_consumers != snapshot.explicit_consumers.end()) {
+          for (const auto& consumer : explicit_consumers->second) {
+            if (removable.find(consumer.node_index) == removable.end()) {
+              pending.push_back(consumer.node_index);
+            }
+          }
+        }
+        const auto implicit_consumers = snapshot.implicit_consumers.find(output);
+        if (implicit_consumers != snapshot.implicit_consumers.end()) {
+          for (const auto consumer : implicit_consumers->second) {
+            if (removable.find(consumer) == removable.end()) pending.push_back(consumer);
+          }
+        }
+      }
+    }
+    while (!pending.empty()) {
+      const auto outside = pending.front();
+      pending.pop_front();
+      if (!visited_outside.insert(outside).second) continue;
+      const auto* node = graph.GetNode(outside);
+      ORT_RETURN_IF(node == nullptr, "Replacement plan outside dependency changed.");
+      for (const auto* output : node->OutputDefs()) {
+        if (output == nullptr || !output->Exists()) continue;
+        const auto explicit_consumers = snapshot.explicit_consumers.find(output);
+        if (explicit_consumers != snapshot.explicit_consumers.end()) {
+          for (const auto& consumer : explicit_consumers->second) {
+            ORT_RETURN_IF(removable.find(consumer.node_index) != removable.end(),
+                          "Replacement plan is no longer convex.");
+            pending.push_back(consumer.node_index);
+          }
+        }
+        const auto implicit_consumers = snapshot.implicit_consumers.find(output);
+        if (implicit_consumers != snapshot.implicit_consumers.end()) {
+          for (const auto consumer : implicit_consumers->second) {
+            ORT_RETURN_IF(removable.find(consumer) != removable.end(),
+                          "Replacement plan is no longer convex.");
+            pending.push_back(consumer);
+          }
+        }
+      }
     }
     if (!plan.generated_call_name.empty()) {
       for (const auto& node : graph.Nodes()) {
@@ -708,7 +883,8 @@ Status PrevalidatePlans(
         ORT_RETURN_IF_NOT(equal, "Replacement plan initializer literal changed.");
       } else {
         const auto* constant = graph.GetNode(witness.constant_node_index);
-        ORT_RETURN_IF(constant == nullptr,
+        ORT_RETURN_IF(constant == nullptr || constant->Domain() != kOnnxDomain ||
+                          constant->OpType() != "Constant",
                       "Replacement plan Constant witness was removed.");
         ONNX_NAMESPACE::TensorProto normalized_constant;
         ORT_RETURN_IF_ERROR(

--- a/onnxruntime/core/optimizer/function_extractor_matcher.cc
+++ b/onnxruntime/core/optimizer/function_extractor_matcher.cc
@@ -189,24 +189,35 @@ struct CandidateMatcher {
     return Status::OK();
   }
 
-  PatternValueId NextScheduledValue() const {
+  Status NextScheduledValue(PatternValueId& scheduled_value_id) {
     const auto& normalized = *compiled.normalized_pattern;
     for (const auto node_id : normalized.reverse_topological_node_ids) {
       for (const auto output_id : normalized.nodes[node_id].output_value_ids) {
+        ORT_RETURN_IF_ERROR(ConsumeWork());
         if (output_id == kMissingPatternValue) continue;
-        if (state.value_visit_states[output_id] == ValueVisitState::Scheduled) return output_id;
+        if (state.value_visit_states[output_id] == ValueVisitState::Scheduled) {
+          scheduled_value_id = output_id;
+          return Status::OK();
+        }
       }
       for (const auto input_id : normalized.nodes[node_id].input_value_ids) {
+        ORT_RETURN_IF_ERROR(ConsumeWork());
         if (input_id != kMissingPatternValue &&
             state.value_visit_states[input_id] == ValueVisitState::Scheduled) {
-          return input_id;
+          scheduled_value_id = input_id;
+          return Status::OK();
         }
       }
     }
     for (PatternValueId value_id = 0; value_id < state.value_visit_states.size(); ++value_id) {
-      if (state.value_visit_states[value_id] == ValueVisitState::Scheduled) return value_id;
+      ORT_RETURN_IF_ERROR(ConsumeWork());
+      if (state.value_visit_states[value_id] == ValueVisitState::Scheduled) {
+        scheduled_value_id = value_id;
+        return Status::OK();
+      }
     }
-    return kMissingPatternValue;
+    scheduled_value_id = kMissingPatternValue;
+    return Status::OK();
   }
 
   Status BindProducer(PatternValueId value_id, const NodeArg& target_value, bool& matched) {
@@ -245,6 +256,7 @@ struct CandidateMatcher {
 
     const auto& pattern_node = normalized.nodes[pattern_node_id];
     for (size_t output_index = 0; output_index < pattern_node.output_value_ids.size(); ++output_index) {
+      ORT_RETURN_IF_ERROR(ConsumeWork());
       const auto pattern_output = pattern_node.output_value_ids[output_index];
       const auto* target_output = target_node->OutputDefs()[output_index];
       if (pattern_output == kMissingPatternValue) {
@@ -262,6 +274,7 @@ struct CandidateMatcher {
       if (!matched) return Status::OK();
     }
     for (size_t input_index = 0; input_index < pattern_node.input_value_ids.size(); ++input_index) {
+      ORT_RETURN_IF_ERROR(ConsumeWork());
       const auto pattern_input = pattern_node.input_value_ids[input_index];
       const auto* target_input = target_node->InputDefs()[input_index];
       if (pattern_input == kMissingPatternValue) {
@@ -297,6 +310,7 @@ struct CandidateMatcher {
         return Status::OK();
       }
       for (size_t i = 0; i < group.formal_output_indices.size(); ++i) {
+        ORT_RETURN_IF_ERROR(ConsumeWork());
         const auto formal_output_index = group.formal_output_indices[i];
         const auto target_output_index = group.producer_output_indices[i];
         if (target_output_index >= target_node->OutputDefs().size()) {
@@ -314,7 +328,8 @@ struct CandidateMatcher {
     }
 
     while (true) {
-      const auto value_id = NextScheduledValue();
+      PatternValueId value_id;
+      ORT_RETURN_IF_ERROR(NextScheduledValue(value_id));
       if (value_id == kMissingPatternValue) break;
       state.value_visit_states[value_id] = ValueVisitState::Processed;
       if (diagnostics != nullptr) ++diagnostics->worklist_bindings_processed;

--- a/onnxruntime/core/optimizer/function_extractor_matcher.h
+++ b/onnxruntime/core/optimizer/function_extractor_matcher.h
@@ -1,0 +1,113 @@
+#pragma once
+
+#if !defined(ORT_MINIMAL_BUILD)
+
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "core/common/inlined_containers.h"
+#include "core/common/status.h"
+#include "core/graph/graph_utils.h"
+#include "core/graph/graph_viewer.h"
+#include "core/optimizer/function_extractor_pattern.h"
+#include "gsl/gsl"
+
+namespace onnxruntime {
+namespace function_extractor_internal {
+
+struct ProducerSlot {
+  NodeIndex node_index{};
+  size_t output_index{};
+};
+
+struct ConsumerSlot {
+  NodeIndex node_index{};
+  size_t input_index{};
+};
+
+struct TargetGraphSnapshot {
+  const Graph* graph{};
+  std::unique_ptr<GraphViewer> graph_viewer;
+  InlinedVector<NodeIndex> topological_node_indices;
+  InlinedHashMap<NodeIndex, size_t> topological_positions;
+  InlinedHashMap<const NodeArg*, ProducerSlot> producers;
+  InlinedHashMap<const NodeArg*, InlinedVector<ConsumerSlot>> explicit_consumers;
+  InlinedHashMap<const NodeArg*, InlinedVector<NodeIndex>> implicit_consumers;
+  InlinedHashSet<const NodeArg*> graph_outputs;
+  InlinedHashMap<std::string, const ONNX_NAMESPACE::TensorProto*> constant_initializers;
+};
+
+enum class ValueVisitState : uint8_t {
+  Unseen,
+  Scheduled,
+  Processed,
+};
+
+struct LiteralWitness {
+  PatternValueId pattern_value_id{kMissingPatternValue};
+  const NodeArg* target_value{};
+  NodeIndex constant_node_index{};
+  bool is_initializer{};
+  std::string fingerprint;
+};
+
+struct MatchState {
+  InlinedVector<NodeIndex> pattern_node_to_target;
+  InlinedHashMap<NodeIndex, PatternNodeId> target_node_to_pattern;
+  InlinedVector<const NodeArg*> pattern_value_to_target;
+  InlinedVector<ValueVisitState> value_visit_states;
+  InlinedVector<const NodeArg*> formal_input_bindings;
+  InlinedVector<LiteralWitness> literal_witnesses;
+  size_t processed_binding_count{};
+};
+
+struct ReplacementPlan {
+  size_t primary_root_topological_position{};
+  InlinedVector<NodeIndex> removable_node_indices;
+  InlinedVector<NodeArg*> call_inputs;
+  InlinedVector<NodeArg*> call_outputs;
+  InlinedVector<LiteralWitness> literal_witnesses;
+  std::vector<graph_utils::GraphEdge> matched_input_edges;
+  std::vector<graph_utils::GraphEdge> explicit_input_edges;
+  std::vector<graph_utils::GraphEdge> explicit_output_edges;
+  InlinedHashMap<const NodeArg*, InlinedVector<NodeIndex>> implicit_consumers;
+  std::string layering_annotation;
+  std::string generated_call_name;
+};
+
+struct MatcherDiagnostics {
+  size_t output_root_tuples_considered{};
+  size_t worklist_bindings_scheduled{};
+  size_t worklist_bindings_processed{};
+  size_t structurally_matched_candidates{};
+  size_t accepted_candidates{};
+};
+
+common::Status BuildTargetGraphSnapshot(
+    const Graph& graph,
+    const CompiledFunctionPattern& compiled_pattern,
+    const FunctionExtractorOptions& options,
+    TargetGraphSnapshot& snapshot);
+
+common::Status DiscoverReplacementPlans(
+    const CompiledFunctionPattern& compiled_pattern,
+    const TargetGraphSnapshot& snapshot,
+    const FunctionExtractorOptions& options,
+    std::vector<ReplacementPlan>& plans,
+    MatcherDiagnostics* diagnostics = nullptr);
+
+common::Status SelectNonConflictingPlans(
+    gsl::span<const ReplacementPlan> plans,
+    std::vector<size_t>& selected_plan_indices);
+
+common::Status PrevalidatePlans(
+    const Graph& graph,
+    const CompiledFunctionPattern& compiled_pattern,
+    gsl::span<const ReplacementPlan> plans);
+
+}  // namespace function_extractor_internal
+}  // namespace onnxruntime
+
+#endif  // !defined(ORT_MINIMAL_BUILD)

--- a/onnxruntime/core/optimizer/function_extractor_matcher.h
+++ b/onnxruntime/core/optimizer/function_extractor_matcher.h
@@ -4,6 +4,7 @@
 
 #include <cstddef>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -106,6 +107,19 @@ common::Status PrevalidatePlans(
     const Graph& graph,
     const CompiledFunctionPattern& compiled_pattern,
     gsl::span<const ReplacementPlan> plans);
+
+using GraphResolveFunction = common::Status (*)(Graph&, const Graph::ResolveOptions&);
+
+struct ExtractionControls {
+  std::optional<size_t> maximum_passes;
+  GraphResolveFunction resolve_graph{};
+};
+
+FunctionExtractionResult ExtractGraph(
+    Graph& graph,
+    const NormalizedFunctionPattern& normalized_pattern,
+    const FunctionExtractorOptions& options,
+    const ExtractionControls& controls = {});
 
 }  // namespace function_extractor_internal
 }  // namespace onnxruntime

--- a/onnxruntime/core/optimizer/function_extractor_matcher.h
+++ b/onnxruntime/core/optimizer/function_extractor_matcher.h
@@ -28,6 +28,8 @@ struct ConsumerSlot {
   size_t input_index{};
 };
 
+// Immutable, scope-local indexes over one resolved Graph. Both explicit uses
+// and nested-subgraph captures are indexed because either affects closure.
 struct TargetGraphSnapshot {
   const Graph* graph{};
   std::unique_ptr<GraphViewer> graph_viewer;
@@ -37,7 +39,10 @@ struct TargetGraphSnapshot {
   InlinedHashMap<const NodeArg*, InlinedVector<ConsumerSlot>> explicit_consumers;
   InlinedHashMap<const NodeArg*, InlinedVector<NodeIndex>> implicit_consumers;
   InlinedHashSet<const NodeArg*> graph_outputs;
+  InlinedHashSet<NodeIndex> control_edge_nodes;
   InlinedHashMap<std::string, const ONNX_NAMESPACE::TensorProto*> constant_initializers;
+  // One bounded candidate list per formal-output producer group.
+  InlinedVector<InlinedVector<NodeIndex>> root_candidates_by_group;
 };
 
 enum class ValueVisitState : uint8_t {
@@ -51,9 +56,10 @@ struct LiteralWitness {
   const NodeArg* target_value{};
   NodeIndex constant_node_index{};
   bool is_initializer{};
-  std::string fingerprint;
 };
 
+// Schedule binds each pattern value once; Processed values are never expanded
+// again. The two node maps maintain an injective operation-node mapping.
 struct MatchState {
   InlinedVector<NodeIndex> pattern_node_to_target;
   InlinedHashMap<NodeIndex, PatternNodeId> target_node_to_pattern;
@@ -61,19 +67,23 @@ struct MatchState {
   InlinedVector<ValueVisitState> value_visit_states;
   InlinedVector<const NodeArg*> formal_input_bindings;
   InlinedVector<LiteralWitness> literal_witnesses;
-  size_t processed_binding_count{};
+  size_t scheduled_binding_count{};
 };
 
+// Immutable mutation recipe. Every NodeArg is borrowed from the target Graph
+// and is valid only until that graph is mutated.
 struct ReplacementPlan {
   size_t primary_root_topological_position{};
   InlinedVector<NodeIndex> removable_node_indices;
   InlinedVector<NodeArg*> call_inputs;
   InlinedVector<NodeArg*> call_outputs;
+  InlinedVector<NodeIndex> pattern_node_to_target;
   InlinedVector<LiteralWitness> literal_witnesses;
   std::vector<graph_utils::GraphEdge> matched_input_edges;
   std::vector<graph_utils::GraphEdge> explicit_input_edges;
   std::vector<graph_utils::GraphEdge> explicit_output_edges;
   InlinedHashMap<const NodeArg*, InlinedVector<NodeIndex>> implicit_consumers;
+  InlinedHashSet<const NodeArg*> graph_outputs;
   std::string layering_annotation;
   std::string generated_call_name;
 };

--- a/onnxruntime/core/optimizer/function_extractor_matcher.h
+++ b/onnxruntime/core/optimizer/function_extractor_matcher.h
@@ -66,7 +66,7 @@ struct MatchState {
   InlinedVector<const NodeArg*> pattern_value_to_target;
   InlinedVector<ValueVisitState> value_visit_states;
   InlinedVector<const NodeArg*> formal_input_bindings;
-  InlinedVector<LiteralWitness> literal_witnesses;
+  InlinedVector<LiteralWitness, 1> literal_witnesses;
   size_t scheduled_binding_count{};
 };
 
@@ -78,7 +78,7 @@ struct ReplacementPlan {
   InlinedVector<NodeArg*> call_inputs;
   InlinedVector<NodeArg*> call_outputs;
   InlinedVector<NodeIndex> pattern_node_to_target;
-  InlinedVector<LiteralWitness> literal_witnesses;
+  InlinedVector<LiteralWitness, 1> literal_witnesses;
   std::vector<graph_utils::GraphEdge> matched_input_edges;
   std::vector<graph_utils::GraphEdge> explicit_input_edges;
   std::vector<graph_utils::GraphEdge> explicit_output_edges;

--- a/onnxruntime/core/optimizer/function_extractor_pattern.cc
+++ b/onnxruntime/core/optimizer/function_extractor_pattern.cc
@@ -146,7 +146,7 @@ void AddSchemaDefaults(const ONNX_NAMESPACE::OpSchema& schema, NodeAttributes& a
 bool IsAllowedOnnxPureOp(std::string_view op_type) {
   static const InlinedHashSet<std::string> pure_ops{
       "Identity", "Add", "Sub", "Mul", "Div", "Relu", "Cast", "MatMul",
-      "Transpose", "Reshape", "Clip", "Concat"};
+      "Transpose", "Reshape", "Clip", "Concat", "MaxPool"};
   return pure_ops.find(op_type) != pure_ops.end();
 }
 
@@ -328,12 +328,10 @@ NormalizedFunctionPattern NormalizeFunctionPattern(
   status = add_formals(function_proto.output(), false);
   if (!status.IsOK()) return fail(InvalidPattern(status.ErrorMessage()));
 
-  InlinedHashSet<std::string> declared_attributes;
-  for (const auto& name : function_proto.attribute()) {
-    if (name.empty() || !declared_attributes.insert(name).second) {
-      return fail(InvalidPattern("function attribute declarations must be non-empty and unique"));
-    }
+  if (function_proto.attribute_size() != 0) {
+    return fail(InvalidPattern("required function attributes are not supported in v1"));
   }
+  InlinedHashSet<std::string> declared_attributes;
   for (const auto& attribute : function_proto.attribute_proto()) {
     if (attribute.name().empty() || !declared_attributes.insert(attribute.name()).second) {
       return fail(InvalidPattern("function attribute defaults must be non-empty and non-duplicated"));
@@ -393,8 +391,11 @@ NormalizedFunctionPattern NormalizeFunctionPattern(
   }
 
   for (const auto& value_info : function_proto.value_info()) {
+    if (!value_info.has_type() || !value_info.type().has_tensor_type()) {
+      return fail(InvalidPattern("only tensor value_info entries are supported"));
+    }
     const auto value = value_ids.find(value_info.name());
-    if (value != value_ids.end() && value_info.has_type()) {
+    if (value != value_ids.end()) {
       result.values[value->second].type = value_info.type();
       result.values[value->second].has_type = true;
     }
@@ -468,6 +469,37 @@ NormalizedFunctionPattern NormalizeFunctionPattern(
     return fail(ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Function literal byte budget exceeded."));
   }
 
+  InlinedVector<InlinedVector<PatternNodeId>> weak_neighbors(result.nodes.size());
+  for (const auto& value : result.values) {
+    InlinedVector<PatternNodeId> incident_nodes;
+    if (value.producer_node_id != kNoPatternNode) {
+      incident_nodes.push_back(value.producer_node_id);
+    }
+    for (const auto& consumer : value.consumers) {
+      if (std::find(incident_nodes.begin(), incident_nodes.end(), consumer.node_id) ==
+          incident_nodes.end()) {
+        incident_nodes.push_back(consumer.node_id);
+      }
+    }
+    for (size_t i = 1; i < incident_nodes.size(); ++i) {
+      weak_neighbors[incident_nodes.front()].push_back(incident_nodes[i]);
+      weak_neighbors[incident_nodes[i]].push_back(incident_nodes.front());
+    }
+  }
+  InlinedHashSet<PatternNodeId> connected_nodes;
+  InlinedVector<PatternNodeId> connectivity_pending{PatternNodeId{0}};
+  while (!connectivity_pending.empty()) {
+    const auto node_id = connectivity_pending.back();
+    connectivity_pending.pop_back();
+    if (!connected_nodes.insert(node_id).second) continue;
+    connectivity_pending.insert(connectivity_pending.end(),
+                                weak_neighbors[node_id].begin(),
+                                weak_neighbors[node_id].end());
+  }
+  if (connected_nodes.size() != result.nodes.size()) {
+    return fail(InvalidPattern("function operation and leaf data flow must form one connected component"));
+  }
+
   InlinedVector<size_t> indegree(result.nodes.size(), 0);
   InlinedVector<InlinedVector<PatternNodeId>> successors(result.nodes.size());
   for (PatternNodeId node_id = 0; node_id < result.nodes.size(); ++node_id) {
@@ -532,8 +564,6 @@ Status CompileFunctionPattern(
   ORT_RETURN_IF_ERROR(normalized_pattern.construction_status);
   compiled_pattern = CompiledFunctionPattern{};
   compiled_pattern.normalized_pattern = &normalized_pattern;
-  compiled_pattern.canonical_function_fingerprint =
-      CanonicalFunctionFingerprint(normalized_pattern.function_proto);
   compiled_pattern.resolved_nodes.resize(normalized_pattern.nodes.size());
 
   for (PatternNodeId node_id = 0; node_id < normalized_pattern.nodes.size(); ++node_id) {
@@ -560,7 +590,6 @@ Status CompileFunctionPattern(
     group.formal_output_indices.push_back(formal_output_index);
     group.producer_output_indices.push_back(value.producer_output_index);
   }
-  compiled_pattern.primary_output_producer_group = 0;
   return Status::OK();
 }
 
@@ -610,31 +639,6 @@ bool AreAttributesSemanticallyEqual(const NodeAttributes& lhs, const NodeAttribu
   for (const auto& [name, attribute] : lhs) {
     const auto other = rhs.find(name);
     if (other == rhs.end() || !AttributeEqual(attribute, other->second)) return false;
-  }
-  return true;
-}
-
-bool AreTypesCompatible(const NodeArg& pattern_value, const NodeArg& target_value) {
-  const auto* lhs = pattern_value.TypeAsProto();
-  const auto* rhs = target_value.TypeAsProto();
-  if (lhs == nullptr || rhs == nullptr) return true;
-  if (lhs->value_case() != rhs->value_case()) return false;
-  if (!lhs->has_tensor_type() || !rhs->has_tensor_type()) return false;
-  const auto& lhs_tensor = lhs->tensor_type();
-  const auto& rhs_tensor = rhs->tensor_type();
-  if (lhs_tensor.elem_type() != 0 && rhs_tensor.elem_type() != 0 &&
-      lhs_tensor.elem_type() != rhs_tensor.elem_type()) {
-    return false;
-  }
-  if (!lhs_tensor.has_shape() || !rhs_tensor.has_shape()) return true;
-  if (lhs_tensor.shape().dim_size() != rhs_tensor.shape().dim_size()) return false;
-  for (int i = 0; i < lhs_tensor.shape().dim_size(); ++i) {
-    const auto& lhs_dim = lhs_tensor.shape().dim(i);
-    const auto& rhs_dim = rhs_tensor.shape().dim(i);
-    if (lhs_dim.has_dim_value() && rhs_dim.has_dim_value() &&
-        lhs_dim.dim_value() != rhs_dim.dim_value()) {
-      return false;
-    }
   }
   return true;
 }

--- a/onnxruntime/core/optimizer/function_extractor_pattern.cc
+++ b/onnxruntime/core/optimizer/function_extractor_pattern.cc
@@ -1,0 +1,742 @@
+#include "core/optimizer/function_extractor_pattern.h"
+
+#if !defined(ORT_MINIMAL_BUILD)
+
+#include <algorithm>
+#include <cstring>
+#include <deque>
+#include <type_traits>
+
+#include "core/common/safeint.h"
+#include "core/framework/tensorprotoutils.h"
+#include "core/graph/function_template.h"
+#include "core/graph/function_utils.h"
+#include "core/graph/model.h"
+#include "onnx/checker.h"
+
+namespace onnxruntime {
+namespace function_extractor_internal {
+namespace {
+
+using common::Status;
+
+Status InvalidPattern(const std::string& message) {
+  return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Invalid function extraction pattern: ", message);
+}
+
+std::string CanonicalDomain(std::string_view domain) {
+  return domain.empty() || domain == kOnnxDomainAlias ? std::string{kOnnxDomain} : std::string{domain};
+}
+
+template <typename T>
+Status AppendTensorData(const ONNX_NAMESPACE::TensorProto& tensor,
+                        size_t element_count,
+                        size_t max_bytes,
+                        const std::filesystem::path* model_path,
+                        std::string& data) {
+  const size_t bytes = SafeInt<size_t>(element_count) * sizeof(T);
+  ORT_RETURN_IF_NOT(bytes <= max_bytes, "Tensor literal byte budget exceeded.");
+  InlinedVector<T> values(element_count);
+  if (tensor.data_location() == ONNX_NAMESPACE::TensorProto_DataLocation_EXTERNAL) {
+    ORT_RETURN_IF_NOT(model_path != nullptr, "External tensor data requires a model path.");
+    ORT_RETURN_IF_ERROR(utils::UnpackTensor(tensor, *model_path, values.data(), element_count));
+  } else {
+    const void* raw_data = tensor.has_raw_data() ? tensor.raw_data().data() : nullptr;
+    const size_t raw_data_size = tensor.has_raw_data() ? tensor.raw_data().size() : 0;
+    ORT_RETURN_IF_ERROR(utils::UnpackTensor(tensor, raw_data, raw_data_size, values.data(), element_count));
+  }
+  data.append(reinterpret_cast<const char*>(values.data()), bytes);
+  return Status::OK();
+}
+
+Status TensorLogicalBytes(const ONNX_NAMESPACE::TensorProto& tensor,
+                          size_t max_bytes,
+                          const std::filesystem::path* model_path,
+                          std::string& data) {
+  size_t element_count = 1;
+  for (const int64_t dim : tensor.dims()) {
+    ORT_RETURN_IF_NOT(dim >= 0, "Tensor literal has a negative dimension.");
+    element_count = SafeInt<size_t>(element_count) * static_cast<size_t>(dim);
+  }
+
+  data.clear();
+  switch (tensor.data_type()) {
+    case ONNX_NAMESPACE::TensorProto_DataType_FLOAT:
+      ORT_RETURN_IF_ERROR(AppendTensorData<float>(tensor, element_count, max_bytes, model_path, data));
+      break;
+    case ONNX_NAMESPACE::TensorProto_DataType_DOUBLE:
+      ORT_RETURN_IF_ERROR(AppendTensorData<double>(tensor, element_count, max_bytes, model_path, data));
+      break;
+    case ONNX_NAMESPACE::TensorProto_DataType_FLOAT16:
+    case ONNX_NAMESPACE::TensorProto_DataType_BFLOAT16:
+    case ONNX_NAMESPACE::TensorProto_DataType_UINT16:
+      ORT_RETURN_IF_ERROR(AppendTensorData<uint16_t>(tensor, element_count, max_bytes, model_path, data));
+      break;
+    case ONNX_NAMESPACE::TensorProto_DataType_INT16:
+      ORT_RETURN_IF_ERROR(AppendTensorData<int16_t>(tensor, element_count, max_bytes, model_path, data));
+      break;
+    case ONNX_NAMESPACE::TensorProto_DataType_INT8:
+      ORT_RETURN_IF_ERROR(AppendTensorData<int8_t>(tensor, element_count, max_bytes, model_path, data));
+      break;
+    case ONNX_NAMESPACE::TensorProto_DataType_UINT8:
+    case ONNX_NAMESPACE::TensorProto_DataType_BOOL:
+      ORT_RETURN_IF_ERROR(AppendTensorData<uint8_t>(tensor, element_count, max_bytes, model_path, data));
+      break;
+    case ONNX_NAMESPACE::TensorProto_DataType_INT32:
+      ORT_RETURN_IF_ERROR(AppendTensorData<int32_t>(tensor, element_count, max_bytes, model_path, data));
+      break;
+    case ONNX_NAMESPACE::TensorProto_DataType_UINT32:
+      ORT_RETURN_IF_ERROR(AppendTensorData<uint32_t>(tensor, element_count, max_bytes, model_path, data));
+      break;
+    case ONNX_NAMESPACE::TensorProto_DataType_INT64:
+      ORT_RETURN_IF_ERROR(AppendTensorData<int64_t>(tensor, element_count, max_bytes, model_path, data));
+      break;
+    case ONNX_NAMESPACE::TensorProto_DataType_UINT64:
+      ORT_RETURN_IF_ERROR(AppendTensorData<uint64_t>(tensor, element_count, max_bytes, model_path, data));
+      break;
+    case ONNX_NAMESPACE::TensorProto_DataType_STRING:
+      for (const auto& value : tensor.string_data()) {
+        const uint64_t length = value.size();
+        ORT_RETURN_IF_NOT(SafeInt<size_t>(data.size()) + sizeof(length) + value.size() <= max_bytes,
+                          "Tensor literal byte budget exceeded.");
+        data.append(reinterpret_cast<const char*>(&length), sizeof(length));
+        data.append(value);
+      }
+      break;
+    default:
+      return InvalidPattern("unsupported tensor literal data type " + std::to_string(tensor.data_type()));
+  }
+
+  ORT_RETURN_IF_NOT(data.size() <= max_bytes, "Tensor literal byte budget exceeded.");
+  return Status::OK();
+}
+
+Status MakeLiteralDescriptor(const ONNX_NAMESPACE::NodeProto& node, size_t max_bytes, LiteralDescriptor& literal) {
+  NodeAttributes attributes;
+  for (const auto& attribute : node.attribute()) {
+    if (!attribute.ref_attr_name().empty()) {
+      return InvalidPattern("Constant attributes may not use ref_attr_name");
+    }
+    attributes.emplace(attribute.name(), attribute);
+  }
+
+  ORT_RETURN_IF_ERROR(NormalizeConstantAttributes(attributes, literal.tensor));
+  ORT_RETURN_IF(literal.tensor.data_location() == ONNX_NAMESPACE::TensorProto_DataLocation_EXTERNAL,
+                "Function body literals may not use external tensor data.");
+  std::string bytes;
+  ORT_RETURN_IF_ERROR(TensorLogicalBytes(literal.tensor, max_bytes, nullptr, bytes));
+  literal.byte_count = bytes.size();
+  literal.fingerprint = std::to_string(literal.tensor.data_type()) + ":";
+  for (const int64_t dim : literal.tensor.dims()) {
+    literal.fingerprint += std::to_string(dim) + ",";
+  }
+  literal.fingerprint.push_back(':');
+  literal.fingerprint.append(bytes);
+  return Status::OK();
+}
+
+void AddSchemaDefaults(const ONNX_NAMESPACE::OpSchema& schema, NodeAttributes& attributes) {
+  for (const auto& [name, definition] : schema.attributes()) {
+    if (attributes.find(name) == attributes.end() && utils::HasName(definition.default_value)) {
+      attributes.emplace(name, definition.default_value);
+    }
+  }
+}
+
+bool IsAllowedOnnxPureOp(std::string_view op_type) {
+  static const InlinedHashSet<std::string> pure_ops{
+      "Identity", "Add", "Sub", "Mul", "Div", "Relu", "Cast", "MatMul",
+      "Transpose", "Reshape", "Clip", "Concat"};
+  return pure_ops.find(op_type) != pure_ops.end();
+}
+
+Status ValidateTransitivePurity(const ONNX_NAMESPACE::FunctionProto& function,
+                                const Graph& graph,
+                                InlinedHashSet<std::string>& visiting) {
+  const auto identity =
+      function_utils::GetFunctionIdentifier(CanonicalDomain(function.domain()), function.name(), function.overload());
+  ORT_RETURN_IF_NOT(visiting.insert(identity).second,
+                    "Recursive model-local functions are not supported by FunctionExtractor.");
+
+  for (const auto& node : function.node()) {
+    for (const auto& attribute : node.attribute()) {
+      ORT_RETURN_IF(!attribute.ref_attr_name().empty() ||
+                        attribute.type() == ONNX_NAMESPACE::AttributeProto_AttributeType_GRAPH ||
+                        attribute.type() == ONNX_NAMESPACE::AttributeProto_AttributeType_GRAPHS,
+                    "Nested functions with attribute references or graph attributes are not supported.");
+    }
+    const auto domain = CanonicalDomain(node.domain());
+    if (domain == kOnnxDomain && IsAllowedOnnxPureOp(node.op_type())) continue;
+
+    const auto function_id = function_utils::GetFunctionIdentifier(domain, node.op_type(), node.overload());
+    const auto& local_functions = graph.GetModel().GetModelLocalFunctionTemplates();
+    const auto local = local_functions.find(function_id);
+    if (local != local_functions.end()) {
+      ORT_RETURN_IF_ERROR(ValidateTransitivePurity(*local->second->onnx_func_proto_, graph, visiting));
+      continue;
+    }
+
+    int version = -1;
+    for (const auto& import : function.opset_import()) {
+      if (CanonicalDomain(import.domain()) == domain) {
+        version = static_cast<int>(import.version());
+        break;
+      }
+    }
+    ORT_RETURN_IF_NOT(version >= 0, "Nested function has no opset import for domain '", domain, "'.");
+    const auto* schema = graph.GetSchemaRegistry()->GetSchema(node.op_type(), version, domain);
+    ORT_RETURN_IF(schema == nullptr || schema->HasContextDependentFunction() || !schema->HasFunction(),
+                  "Nested function contains an unknown or impure operation: ", domain, ":", node.op_type());
+    const auto* nested = schema->GetFunction(version, domain == kOnnxDomain);
+    ORT_RETURN_IF_NOT(nested != nullptr, "Nested schema function body is unavailable.");
+    ORT_RETURN_IF_ERROR(ValidateTransitivePurity(*nested, graph, visiting));
+  }
+
+  visiting.erase(identity);
+  return Status::OK();
+}
+
+Status ResolveNode(const PatternNode& pattern_node,
+                   const NormalizedFunctionPattern& normalized_pattern,
+                   const Graph& graph,
+                   ResolvedPatternNode& resolved_node) {
+  const auto& node_proto = normalized_pattern.function_proto.node(
+      static_cast<int>(pattern_node.source_node_proto_index));
+  resolved_node.canonical_domain = CanonicalDomain(node_proto.domain());
+  resolved_node.op_type = node_proto.op_type();
+  resolved_node.overload = node_proto.overload();
+  resolved_node.input_arity = pattern_node.input_value_ids.size();
+  resolved_node.output_arity = pattern_node.output_value_ids.size();
+  for (const auto& attribute : node_proto.attribute()) {
+    resolved_node.effective_attributes.emplace(attribute.name(), attribute);
+  }
+
+  const auto function_id =
+      function_utils::GetFunctionIdentifier(resolved_node.canonical_domain, resolved_node.op_type,
+                                            resolved_node.overload);
+  const auto& local_functions = graph.GetModel().GetModelLocalFunctionTemplates();
+  const auto local_function = local_functions.find(function_id);
+  if (local_function != local_functions.end()) {
+    resolved_node.schema = local_function->second->op_schema_.get();
+    resolved_node.since_version = resolved_node.schema->since_version();
+    resolved_node.function_fingerprint =
+        CanonicalFunctionFingerprint(*local_function->second->onnx_func_proto_);
+    InlinedHashSet<std::string> visiting;
+    ORT_RETURN_IF_ERROR(
+        ValidateTransitivePurity(*local_function->second->onnx_func_proto_, graph, visiting));
+    resolved_node.transitively_pure = true;
+    AddSchemaDefaults(*resolved_node.schema, resolved_node.effective_attributes);
+    return Status::OK();
+  }
+
+  int version = -1;
+  for (const auto& import : normalized_pattern.function_proto.opset_import()) {
+    if (CanonicalDomain(import.domain()) == resolved_node.canonical_domain) {
+      version = static_cast<int>(import.version());
+      break;
+    }
+  }
+  if (version < 0) {
+    const auto graph_import = graph.DomainToVersionMap().find(resolved_node.canonical_domain);
+    if (graph_import != graph.DomainToVersionMap().end()) {
+      version = graph_import->second;
+    }
+  }
+  ORT_RETURN_IF_NOT(version >= 0, "No opset import for pattern node domain '",
+                    resolved_node.canonical_domain, "'.");
+
+  resolved_node.schema =
+      graph.GetSchemaRegistry()->GetSchema(resolved_node.op_type, version, resolved_node.canonical_domain);
+  ORT_RETURN_IF_NOT(resolved_node.schema != nullptr, "No schema for pattern node ",
+                    resolved_node.canonical_domain, ":", resolved_node.op_type, " at opset ", version, ".");
+  resolved_node.since_version = resolved_node.schema->since_version();
+  AddSchemaDefaults(*resolved_node.schema, resolved_node.effective_attributes);
+  return Status::OK();
+}
+
+bool AttributeEqual(const ONNX_NAMESPACE::AttributeProto& lhs, const ONNX_NAMESPACE::AttributeProto& rhs) {
+  ONNX_NAMESPACE::AttributeProto normalized_lhs = lhs;
+  ONNX_NAMESPACE::AttributeProto normalized_rhs = rhs;
+  normalized_lhs.clear_doc_string();
+  normalized_rhs.clear_doc_string();
+  return normalized_lhs.SerializeAsString() == normalized_rhs.SerializeAsString();
+}
+
+}  // namespace
+
+NormalizedFunctionPattern NormalizeFunctionPattern(
+    const ONNX_NAMESPACE::FunctionProto& function_proto,
+    const FunctionExtractorOptions& options) {
+  NormalizedFunctionPattern result;
+  auto fail = [&result](Status status) -> NormalizedFunctionPattern {
+    result.construction_status = std::move(status);
+    return std::move(result);
+  };
+
+  if (static_cast<size_t>(function_proto.node_size()) > options.max_pattern_nodes) {
+    return fail(ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Function pattern node budget exceeded."));
+  }
+  result.function_proto = function_proto;
+
+  try {
+    ONNX_NAMESPACE::checker::CheckerContext checker_context;
+    checker_context.set_ir_version(ONNX_NAMESPACE::Version::IR_VERSION);
+    InlinedHashMap<std::string, int> imports;
+    for (const auto& import : function_proto.opset_import()) {
+      imports[CanonicalDomain(import.domain())] = static_cast<int>(import.version());
+    }
+    checker_context.set_opset_imports(
+        std::unordered_map<std::string, int>(imports.begin(), imports.end()));
+    ONNX_NAMESPACE::checker::LexicalScopeContext lexical_scope;
+    ONNX_NAMESPACE::checker::check_function(function_proto, checker_context, lexical_scope);
+  } catch (const ONNX_NAMESPACE::checker::ValidationError& error) {
+    return fail(InvalidPattern(error.what()));
+  }
+
+  if (function_proto.name().empty()) {
+    return fail(InvalidPattern("function name must not be empty"));
+  }
+
+  InlinedHashMap<std::string, PatternValueId> value_ids;
+  InlinedHashSet<std::string> formal_names;
+  auto add_formals = [&](const auto& names, bool input) -> Status {
+    for (const auto& name : names) {
+      ORT_RETURN_IF(name.empty(), "Formal ", input ? "input" : "output", " name must not be empty.");
+      ORT_RETURN_IF(!formal_names.insert(name).second, "Formal names must be distinct and disjoint: ", name);
+      PatternValueId value_id;
+      const auto existing = value_ids.find(name);
+      if (existing == value_ids.end()) {
+        value_id = result.values.size();
+        value_ids.emplace(name, value_id);
+        result.values.push_back(PatternValue{});
+        result.values.back().name = name;
+      } else {
+        value_id = existing->second;
+      }
+      if (input) {
+        result.values[value_id].is_formal_input = true;
+        result.formal_input_value_ids.push_back(value_id);
+      } else {
+        result.values[value_id].is_formal_output = true;
+        result.formal_output_value_ids.push_back(value_id);
+      }
+    }
+    return Status::OK();
+  };
+  Status status = add_formals(function_proto.input(), true);
+  if (!status.IsOK()) return fail(InvalidPattern(status.ErrorMessage()));
+  status = add_formals(function_proto.output(), false);
+  if (!status.IsOK()) return fail(InvalidPattern(status.ErrorMessage()));
+
+  InlinedHashSet<std::string> declared_attributes;
+  for (const auto& name : function_proto.attribute()) {
+    if (name.empty() || !declared_attributes.insert(name).second) {
+      return fail(InvalidPattern("function attribute declarations must be non-empty and unique"));
+    }
+  }
+  for (const auto& attribute : function_proto.attribute_proto()) {
+    if (attribute.name().empty() || !declared_attributes.insert(attribute.name()).second) {
+      return fail(InvalidPattern("function attribute defaults must be non-empty and non-duplicated"));
+    }
+  }
+
+  InlinedVector<bool> constant_nodes(function_proto.node_size(), false);
+  InlinedHashSet<std::string> produced_names;
+  for (int node_index = 0; node_index < function_proto.node_size(); ++node_index) {
+    const auto& node = function_proto.node(node_index);
+    InlinedHashSet<std::string> attribute_names;
+    for (const auto& attribute : node.attribute()) {
+      if (!attribute_names.insert(attribute.name()).second) {
+        return fail(InvalidPattern("duplicate node attribute '" + attribute.name() + "'"));
+      }
+      if (!attribute.ref_attr_name().empty()) {
+        return fail(InvalidPattern("ref_attr_name is not supported"));
+      }
+      if (attribute.type() == ONNX_NAMESPACE::AttributeProto_AttributeType_GRAPH ||
+          attribute.type() == ONNX_NAMESPACE::AttributeProto_AttributeType_GRAPHS) {
+        return fail(InvalidPattern("graph-valued attributes are not supported"));
+      }
+    }
+
+    const bool is_constant = CanonicalDomain(node.domain()) == kOnnxDomain && node.op_type() == "Constant";
+    constant_nodes[node_index] = is_constant;
+    if (is_constant && node.output_size() != 1) {
+      return fail(InvalidPattern("Constant nodes must have exactly one output"));
+    }
+    for (int output_index = 0; output_index < node.output_size(); ++output_index) {
+      const std::string& output = node.output(output_index);
+      if (output.empty()) {
+        continue;
+      }
+      if (!produced_names.insert(output).second) {
+        return fail(InvalidPattern("value '" + output + "' has multiple producers"));
+      }
+      PatternValueId value_id;
+      const auto existing = value_ids.find(output);
+      if (existing == value_ids.end()) {
+        value_id = result.values.size();
+        value_ids.emplace(output, value_id);
+        result.values.push_back(PatternValue{});
+        result.values.back().name = output;
+      } else {
+        value_id = existing->second;
+      }
+      if (result.values[value_id].is_formal_input) {
+        return fail(InvalidPattern("formal input '" + output + "' is produced by a body node"));
+      }
+      if (is_constant) {
+        result.values[value_id].is_literal = true;
+        status = MakeLiteralDescriptor(node, options.max_literal_bytes, result.values[value_id].literal);
+        if (!status.IsOK()) return fail(std::move(status));
+      }
+    }
+  }
+
+  for (const auto& value_info : function_proto.value_info()) {
+    const auto value = value_ids.find(value_info.name());
+    if (value != value_ids.end() && value_info.has_type()) {
+      result.values[value->second].type = value_info.type();
+      result.values[value->second].has_type = true;
+    }
+  }
+
+  InlinedVector<PatternNodeId> source_to_pattern(function_proto.node_size(), kNoPatternNode);
+  for (int source_index = 0; source_index < function_proto.node_size(); ++source_index) {
+    if (constant_nodes[source_index]) continue;
+    if (function_proto.node(source_index).output_size() == 0) {
+      return fail(InvalidPattern("function operation nodes must have outputs"));
+    }
+    source_to_pattern[source_index] = result.nodes.size();
+    result.nodes.push_back(PatternNode{static_cast<size_t>(source_index)});
+  }
+  if (result.nodes.size() > options.max_pattern_nodes) {
+    return fail(ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Function pattern node budget exceeded."));
+  }
+  if (result.nodes.size() <= 1) {
+    return fail(InvalidPattern("function pattern must contain more than one operation node"));
+  }
+
+  for (int source_index = 0; source_index < function_proto.node_size(); ++source_index) {
+    const auto& source = function_proto.node(source_index);
+    const PatternNodeId pattern_node_id = source_to_pattern[source_index];
+    for (int output_index = 0; output_index < source.output_size(); ++output_index) {
+      const auto& output = source.output(output_index);
+      if (output.empty()) {
+        if (!constant_nodes[source_index]) {
+          result.nodes[pattern_node_id].output_value_ids.push_back(kMissingPatternValue);
+        }
+        continue;
+      }
+      auto& value = result.values[value_ids.at(output)];
+      if (!constant_nodes[source_index]) {
+        value.producer_node_id = pattern_node_id;
+        value.producer_output_index = static_cast<size_t>(output_index);
+        result.nodes[pattern_node_id].output_value_ids.push_back(value_ids.at(output));
+      }
+    }
+    if (constant_nodes[source_index]) continue;
+
+    for (int input_index = 0; input_index < source.input_size(); ++input_index) {
+      const auto& input = source.input(input_index);
+      if (input.empty()) {
+        result.nodes[pattern_node_id].input_value_ids.push_back(kMissingPatternValue);
+        continue;
+      }
+      const auto value = value_ids.find(input);
+      if (value == value_ids.end()) {
+        return fail(InvalidPattern("input value '" + input + "' is undefined"));
+      }
+      result.nodes[pattern_node_id].input_value_ids.push_back(value->second);
+      result.values[value->second].consumers.push_back(
+          PatternValueConsumer{pattern_node_id, static_cast<size_t>(input_index)});
+    }
+  }
+
+  size_t total_literal_bytes = 0;
+  for (const auto& value : result.values) {
+    if (value.is_literal) {
+      total_literal_bytes = SafeInt<size_t>(total_literal_bytes) + value.literal.byte_count;
+      if (value.is_formal_output) {
+        return fail(InvalidPattern("formal outputs may not be produced by Constant nodes"));
+      }
+    }
+    if ((value.is_formal_input || value.is_literal) && value.consumers.empty()) {
+      return fail(InvalidPattern("formal inputs and literals must participate in the function body"));
+    }
+  }
+  if (total_literal_bytes > options.max_literal_bytes) {
+    return fail(ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Function literal byte budget exceeded."));
+  }
+
+  InlinedVector<size_t> indegree(result.nodes.size(), 0);
+  InlinedVector<InlinedVector<PatternNodeId>> successors(result.nodes.size());
+  for (PatternNodeId node_id = 0; node_id < result.nodes.size(); ++node_id) {
+    for (const auto input_id : result.nodes[node_id].input_value_ids) {
+      if (input_id == kMissingPatternValue) continue;
+      const auto producer = result.values[input_id].producer_node_id;
+      if (producer != kNoPatternNode) {
+        ++indegree[node_id];
+        successors[producer].push_back(node_id);
+      }
+    }
+  }
+  std::deque<PatternNodeId> ready;
+  for (PatternNodeId node_id = 0; node_id < indegree.size(); ++node_id) {
+    if (indegree[node_id] == 0) ready.push_back(node_id);
+  }
+  InlinedVector<PatternNodeId> topological;
+  while (!ready.empty()) {
+    const auto node_id = ready.front();
+    ready.pop_front();
+    topological.push_back(node_id);
+    for (const auto successor : successors[node_id]) {
+      if (--indegree[successor] == 0) ready.push_back(successor);
+    }
+  }
+  if (topological.size() != result.nodes.size()) {
+    return fail(InvalidPattern("operation body must be acyclic"));
+  }
+  result.reverse_topological_node_ids.assign(topological.rbegin(), topological.rend());
+
+  InlinedHashSet<PatternNodeId> reachable;
+  InlinedVector<PatternNodeId> pending;
+  for (const auto output_id : result.formal_output_value_ids) {
+    const auto& value = result.values[output_id];
+    if (value.producer_node_id == kNoPatternNode) {
+      return fail(InvalidPattern("formal output '" + value.name + "' is not produced by an operation node"));
+    }
+    pending.push_back(value.producer_node_id);
+  }
+  while (!pending.empty()) {
+    const auto node_id = pending.back();
+    pending.pop_back();
+    if (!reachable.insert(node_id).second) continue;
+    for (const auto input_id : result.nodes[node_id].input_value_ids) {
+      if (input_id == kMissingPatternValue) continue;
+      const auto producer = result.values[input_id].producer_node_id;
+      if (producer != kNoPatternNode) pending.push_back(producer);
+    }
+  }
+  if (reachable.size() != result.nodes.size()) {
+    return fail(InvalidPattern("every operation must be backward-reachable from a formal output"));
+  }
+
+  result.construction_status = Status::OK();
+  return result;
+}
+
+Status CompileFunctionPattern(
+    const NormalizedFunctionPattern& normalized_pattern,
+    const Graph& graph,
+    CompiledFunctionPattern& compiled_pattern) {
+  ORT_RETURN_IF_ERROR(normalized_pattern.construction_status);
+  compiled_pattern = CompiledFunctionPattern{};
+  compiled_pattern.normalized_pattern = &normalized_pattern;
+  compiled_pattern.canonical_function_fingerprint =
+      CanonicalFunctionFingerprint(normalized_pattern.function_proto);
+  compiled_pattern.resolved_nodes.resize(normalized_pattern.nodes.size());
+
+  for (PatternNodeId node_id = 0; node_id < normalized_pattern.nodes.size(); ++node_id) {
+    auto& resolved = compiled_pattern.resolved_nodes[node_id];
+    resolved.pattern_node_id = node_id;
+    ORT_RETURN_IF_ERROR(ResolveNode(normalized_pattern.nodes[node_id], normalized_pattern, graph, resolved));
+    ORT_RETURN_IF_NOT(IsV1PureOperator(resolved), "Function pattern contains an impure or unsupported operator: ",
+                      resolved.canonical_domain, ":", resolved.op_type);
+  }
+
+  InlinedHashMap<PatternNodeId, size_t> group_by_producer;
+  for (size_t formal_output_index = 0;
+       formal_output_index < normalized_pattern.formal_output_value_ids.size();
+       ++formal_output_index) {
+    const auto& value =
+        normalized_pattern.values[normalized_pattern.formal_output_value_ids[formal_output_index]];
+    auto [group_it, inserted] =
+        group_by_producer.emplace(value.producer_node_id, compiled_pattern.formal_output_producer_groups.size());
+    if (inserted) {
+      compiled_pattern.formal_output_producer_groups.push_back(
+          FormalOutputProducerGroup{value.producer_node_id});
+    }
+    auto& group = compiled_pattern.formal_output_producer_groups[group_it->second];
+    group.formal_output_indices.push_back(formal_output_index);
+    group.producer_output_indices.push_back(value.producer_output_index);
+  }
+  compiled_pattern.primary_output_producer_group = 0;
+  return Status::OK();
+}
+
+Status ValidateRegisteredFunction(
+    const NormalizedFunctionPattern& normalized_pattern,
+    const Graph& graph) {
+  const auto& function = normalized_pattern.function_proto;
+  const auto function_id =
+      function_utils::GetFunctionIdentifier(CanonicalDomain(function.domain()), function.name(), function.overload());
+  const auto& local_functions = graph.GetModel().GetModelLocalFunctionTemplates();
+  const auto local_function = local_functions.find(function_id);
+  if (local_function != local_functions.end()) {
+    ORT_RETURN_IF_NOT(
+        CanonicalFunctionFingerprint(*local_function->second->onnx_func_proto_) ==
+            CanonicalFunctionFingerprint(function),
+        "The registered model-local function definition differs from the extraction pattern.");
+    return Status::OK();
+  }
+
+  const auto domain = CanonicalDomain(function.domain());
+  const auto import = graph.DomainToVersionMap().find(domain);
+  ORT_RETURN_IF(import == graph.DomainToVersionMap().end(),
+                "The extraction function is not registered in the target model.");
+  const auto* schema = graph.GetSchemaRegistry()->GetSchema(function.name(), import->second, domain);
+  ORT_RETURN_IF(schema == nullptr, "The extraction function is not registered in the target model.");
+  ORT_RETURN_IF(schema->HasContextDependentFunction(),
+                "Context-dependent schema functions are not supported by FunctionExtractor.");
+  ORT_RETURN_IF_NOT(schema->HasFunction(),
+                    "The registered schema does not provide a function body.");
+  const auto* registered_function = schema->GetFunction(import->second, domain == kOnnxDomain);
+  ORT_RETURN_IF_NOT(registered_function != nullptr, "The registered schema function body is unavailable.");
+  ORT_RETURN_IF_NOT(CanonicalFunctionFingerprint(*registered_function) ==
+                        CanonicalFunctionFingerprint(function),
+                    "The registered schema function definition differs from the extraction pattern.");
+  return Status::OK();
+}
+
+bool IsV1PureOperator(const ResolvedPatternNode& node) {
+  if (node.canonical_domain != kOnnxDomain) {
+    return !node.function_fingerprint.empty() && node.transitively_pure;
+  }
+  return IsAllowedOnnxPureOp(node.op_type);
+}
+
+bool AreAttributesSemanticallyEqual(const NodeAttributes& lhs, const NodeAttributes& rhs) {
+  if (lhs.size() != rhs.size()) return false;
+  for (const auto& [name, attribute] : lhs) {
+    const auto other = rhs.find(name);
+    if (other == rhs.end() || !AttributeEqual(attribute, other->second)) return false;
+  }
+  return true;
+}
+
+bool AreTypesCompatible(const NodeArg& pattern_value, const NodeArg& target_value) {
+  const auto* lhs = pattern_value.TypeAsProto();
+  const auto* rhs = target_value.TypeAsProto();
+  if (lhs == nullptr || rhs == nullptr) return true;
+  if (lhs->value_case() != rhs->value_case()) return false;
+  if (!lhs->has_tensor_type() || !rhs->has_tensor_type()) return false;
+  const auto& lhs_tensor = lhs->tensor_type();
+  const auto& rhs_tensor = rhs->tensor_type();
+  if (lhs_tensor.elem_type() != 0 && rhs_tensor.elem_type() != 0 &&
+      lhs_tensor.elem_type() != rhs_tensor.elem_type()) {
+    return false;
+  }
+  if (!lhs_tensor.has_shape() || !rhs_tensor.has_shape()) return true;
+  if (lhs_tensor.shape().dim_size() != rhs_tensor.shape().dim_size()) return false;
+  for (int i = 0; i < lhs_tensor.shape().dim_size(); ++i) {
+    const auto& lhs_dim = lhs_tensor.shape().dim(i);
+    const auto& rhs_dim = rhs_tensor.shape().dim(i);
+    if (lhs_dim.has_dim_value() && rhs_dim.has_dim_value() &&
+        lhs_dim.dim_value() != rhs_dim.dim_value()) {
+      return false;
+    }
+  }
+  return true;
+}
+
+Status NormalizeConstantAttributes(
+    const NodeAttributes& attributes,
+    ONNX_NAMESPACE::TensorProto& tensor) {
+  ORT_RETURN_IF_NOT(attributes.size() == 1,
+                    "Constant nodes must specify exactly one supported value attribute.");
+  const auto& [name, attribute] = *attributes.begin();
+  tensor.Clear();
+  if (name == "value" && attribute.type() == ONNX_NAMESPACE::AttributeProto_AttributeType_TENSOR) {
+    tensor = attribute.t();
+    return Status::OK();
+  }
+  if (name == "value_float" && attribute.type() == ONNX_NAMESPACE::AttributeProto_AttributeType_FLOAT) {
+    tensor.set_data_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+    tensor.add_float_data(attribute.f());
+    return Status::OK();
+  }
+  if (name == "value_floats" && attribute.type() == ONNX_NAMESPACE::AttributeProto_AttributeType_FLOATS) {
+    tensor.set_data_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+    tensor.add_dims(attribute.floats_size());
+    for (const auto value : attribute.floats()) tensor.add_float_data(value);
+    return Status::OK();
+  }
+  if (name == "value_int" && attribute.type() == ONNX_NAMESPACE::AttributeProto_AttributeType_INT) {
+    tensor.set_data_type(ONNX_NAMESPACE::TensorProto_DataType_INT64);
+    tensor.add_int64_data(attribute.i());
+    return Status::OK();
+  }
+  if (name == "value_ints" && attribute.type() == ONNX_NAMESPACE::AttributeProto_AttributeType_INTS) {
+    tensor.set_data_type(ONNX_NAMESPACE::TensorProto_DataType_INT64);
+    tensor.add_dims(attribute.ints_size());
+    for (const auto value : attribute.ints()) tensor.add_int64_data(value);
+    return Status::OK();
+  }
+  if (name == "value_string" && attribute.type() == ONNX_NAMESPACE::AttributeProto_AttributeType_STRING) {
+    tensor.set_data_type(ONNX_NAMESPACE::TensorProto_DataType_STRING);
+    tensor.add_string_data(attribute.s());
+    return Status::OK();
+  }
+  if (name == "value_strings" && attribute.type() == ONNX_NAMESPACE::AttributeProto_AttributeType_STRINGS) {
+    tensor.set_data_type(ONNX_NAMESPACE::TensorProto_DataType_STRING);
+    tensor.add_dims(attribute.strings_size());
+    for (const auto& value : attribute.strings()) tensor.add_string_data(value);
+    return Status::OK();
+  }
+  return InvalidPattern("unsupported Constant value attribute");
+}
+
+Status CompareTensorLiterals(
+    const ONNX_NAMESPACE::TensorProto& lhs,
+    const ONNX_NAMESPACE::TensorProto& rhs,
+    size_t max_literal_bytes,
+    bool& equal,
+    const std::filesystem::path* rhs_model_path) {
+  equal = false;
+  if (lhs.data_type() != rhs.data_type() || lhs.dims_size() != rhs.dims_size()) return Status::OK();
+  for (int i = 0; i < lhs.dims_size(); ++i) {
+    if (lhs.dims(i) != rhs.dims(i)) return Status::OK();
+  }
+  std::string lhs_bytes;
+  std::string rhs_bytes;
+  ORT_RETURN_IF_ERROR(TensorLogicalBytes(lhs, max_literal_bytes, nullptr, lhs_bytes));
+  ORT_RETURN_IF_ERROR(TensorLogicalBytes(rhs, max_literal_bytes, rhs_model_path, rhs_bytes));
+  equal = lhs_bytes == rhs_bytes;
+  return Status::OK();
+}
+
+std::string CanonicalFunctionFingerprint(const ONNX_NAMESPACE::FunctionProto& function_proto) {
+  ONNX_NAMESPACE::FunctionProto canonical = function_proto;
+  canonical.clear_doc_string();
+  for (auto& value_info : *canonical.mutable_value_info()) {
+    value_info.clear_doc_string();
+  }
+  for (auto& node : *canonical.mutable_node()) {
+    node.clear_name();
+    node.clear_doc_string();
+    std::vector<ONNX_NAMESPACE::AttributeProto> attributes(node.attribute().begin(), node.attribute().end());
+    std::sort(attributes.begin(), attributes.end(),
+              [](const auto& lhs, const auto& rhs) { return lhs.name() < rhs.name(); });
+    node.clear_attribute();
+    for (auto& attribute : attributes) {
+      attribute.clear_doc_string();
+      *node.add_attribute() = std::move(attribute);
+    }
+  }
+  std::vector<ONNX_NAMESPACE::OperatorSetIdProto> imports(
+      canonical.opset_import().begin(), canonical.opset_import().end());
+  std::sort(imports.begin(), imports.end(), [](const auto& lhs, const auto& rhs) {
+    return CanonicalDomain(lhs.domain()) < CanonicalDomain(rhs.domain());
+  });
+  canonical.clear_opset_import();
+  for (auto& import : imports) {
+    import.set_domain(CanonicalDomain(import.domain()));
+    *canonical.add_opset_import() = std::move(import);
+  }
+  return canonical.SerializeAsString();
+}
+
+}  // namespace function_extractor_internal
+}  // namespace onnxruntime
+
+#endif  // !defined(ORT_MINIMAL_BUILD)

--- a/onnxruntime/core/optimizer/function_extractor_pattern.cc
+++ b/onnxruntime/core/optimizer/function_extractor_pattern.cc
@@ -276,6 +276,29 @@ NormalizedFunctionPattern NormalizeFunctionPattern(
   if (static_cast<size_t>(function_proto.node_size()) > options.max_pattern_nodes) {
     return fail(ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Function pattern node budget exceeded."));
   }
+
+  size_t pattern_slot_units = 0;
+  auto consume_pattern_slots = [&](size_t units) {
+    if (pattern_slot_units > options.max_worklist_bindings ||
+        units > options.max_worklist_bindings - pattern_slot_units) {
+      return false;
+    }
+    pattern_slot_units += units;
+    return true;
+  };
+  for (const auto& node : function_proto.node()) {
+    const size_t input_slots = static_cast<size_t>(node.input_size());
+    const size_t output_slots = static_cast<size_t>(node.output_size());
+    // Count every input conservatively as both a body slot and a consumer incidence.
+    if (!consume_pattern_slots(input_slots) ||
+        !consume_pattern_slots(input_slots) ||
+        !consume_pattern_slots(output_slots)) {
+      return fail(ORT_MAKE_STATUS(
+          ONNXRUNTIME, FAIL,
+          "Function extraction invariant/resource limit exceeded: pattern slot budget."));
+    }
+  }
+
   result.function_proto = function_proto;
 
   try {

--- a/onnxruntime/core/optimizer/function_extractor_pattern.h
+++ b/onnxruntime/core/optimizer/function_extractor_pattern.h
@@ -31,6 +31,8 @@ struct LiteralDescriptor {
   size_t byte_count{};
 };
 
+// Flags are independent: a value may be both produced and formal output, while
+// formal inputs and normalized literals are terminal leaves with no producer.
 struct PatternValue {
   std::string name;
   ONNX_NAMESPACE::TypeProto type;
@@ -50,6 +52,8 @@ struct PatternNode {
   InlinedVector<PatternValueId> output_value_ids;
 };
 
+// Owns the context-free validated pattern. Values use stable numeric IDs, and
+// every operation is connected, acyclic, and backward-reachable from an output.
 struct NormalizedFunctionPattern {
   ONNX_NAMESPACE::FunctionProto function_proto;
   InlinedVector<PatternValueId> formal_input_value_ids;
@@ -60,6 +64,8 @@ struct NormalizedFunctionPattern {
   common::Status construction_status{common::Status::OK()};
 };
 
+// Per-Graph semantic resolution of a pattern node. Schema pointers are borrowed
+// from the Graph/model registry and remain valid only while that context lives.
 struct ResolvedPatternNode {
   PatternNodeId pattern_node_id{kNoPatternNode};
   std::string canonical_domain;
@@ -81,11 +87,10 @@ struct FormalOutputProducerGroup {
 };
 
 struct CompiledFunctionPattern {
+  // Non-owning. The referenced normalized pattern must outlive this object.
   const NormalizedFunctionPattern* normalized_pattern{};
   InlinedVector<ResolvedPatternNode> resolved_nodes;
   InlinedVector<FormalOutputProducerGroup> formal_output_producer_groups;
-  size_t primary_output_producer_group{};
-  std::string canonical_function_fingerprint;
 };
 
 NormalizedFunctionPattern NormalizeFunctionPattern(
@@ -104,8 +109,6 @@ common::Status ValidateRegisteredFunction(
 bool IsV1PureOperator(const ResolvedPatternNode& node);
 
 bool AreAttributesSemanticallyEqual(const NodeAttributes& lhs, const NodeAttributes& rhs);
-
-bool AreTypesCompatible(const NodeArg& pattern_value, const NodeArg& target_value);
 
 common::Status NormalizeConstantAttributes(
     const NodeAttributes& attributes,

--- a/onnxruntime/core/optimizer/function_extractor_pattern.h
+++ b/onnxruntime/core/optimizer/function_extractor_pattern.h
@@ -1,0 +1,126 @@
+#pragma once
+
+#if !defined(ORT_MINIMAL_BUILD)
+
+#include <cstddef>
+#include <filesystem>
+#include <limits>
+#include <string>
+
+#include "core/common/inlined_containers.h"
+#include "core/common/status.h"
+#include "core/graph/graph.h"
+#include "core/optimizer/function_extractor.h"
+
+namespace onnxruntime {
+namespace function_extractor_internal {
+
+using PatternNodeId = size_t;
+using PatternValueId = size_t;
+constexpr PatternValueId kMissingPatternValue = std::numeric_limits<PatternValueId>::max();
+constexpr PatternNodeId kNoPatternNode = std::numeric_limits<PatternNodeId>::max();
+
+struct PatternValueConsumer {
+  PatternNodeId node_id{kNoPatternNode};
+  size_t input_index{};
+};
+
+struct LiteralDescriptor {
+  ONNX_NAMESPACE::TensorProto tensor;
+  std::string fingerprint;
+  size_t byte_count{};
+};
+
+struct PatternValue {
+  std::string name;
+  ONNX_NAMESPACE::TypeProto type;
+  PatternNodeId producer_node_id{kNoPatternNode};
+  size_t producer_output_index{};
+  InlinedVector<PatternValueConsumer> consumers;
+  bool has_type{};
+  bool is_formal_input{};
+  bool is_formal_output{};
+  bool is_literal{};
+  LiteralDescriptor literal;
+};
+
+struct PatternNode {
+  size_t source_node_proto_index{};
+  InlinedVector<PatternValueId> input_value_ids;
+  InlinedVector<PatternValueId> output_value_ids;
+};
+
+struct NormalizedFunctionPattern {
+  ONNX_NAMESPACE::FunctionProto function_proto;
+  InlinedVector<PatternValueId> formal_input_value_ids;
+  InlinedVector<PatternValueId> formal_output_value_ids;
+  InlinedVector<PatternValue, 1> values;
+  InlinedVector<PatternNode> nodes;
+  InlinedVector<PatternNodeId> reverse_topological_node_ids;
+  common::Status construction_status{common::Status::OK()};
+};
+
+struct ResolvedPatternNode {
+  PatternNodeId pattern_node_id{kNoPatternNode};
+  std::string canonical_domain;
+  std::string op_type;
+  std::string overload;
+  int since_version{-1};
+  const ONNX_NAMESPACE::OpSchema* schema{};
+  NodeAttributes effective_attributes;
+  size_t input_arity{};
+  size_t output_arity{};
+  std::string function_fingerprint;
+  bool transitively_pure{};
+};
+
+struct FormalOutputProducerGroup {
+  PatternNodeId producer_node_id{kNoPatternNode};
+  InlinedVector<size_t> formal_output_indices;
+  InlinedVector<size_t> producer_output_indices;
+};
+
+struct CompiledFunctionPattern {
+  const NormalizedFunctionPattern* normalized_pattern{};
+  InlinedVector<ResolvedPatternNode> resolved_nodes;
+  InlinedVector<FormalOutputProducerGroup> formal_output_producer_groups;
+  size_t primary_output_producer_group{};
+  std::string canonical_function_fingerprint;
+};
+
+NormalizedFunctionPattern NormalizeFunctionPattern(
+    const ONNX_NAMESPACE::FunctionProto& function_proto,
+    const FunctionExtractorOptions& options);
+
+common::Status CompileFunctionPattern(
+    const NormalizedFunctionPattern& normalized_pattern,
+    const Graph& graph,
+    CompiledFunctionPattern& compiled_pattern);
+
+common::Status ValidateRegisteredFunction(
+    const NormalizedFunctionPattern& normalized_pattern,
+    const Graph& graph);
+
+bool IsV1PureOperator(const ResolvedPatternNode& node);
+
+bool AreAttributesSemanticallyEqual(const NodeAttributes& lhs, const NodeAttributes& rhs);
+
+bool AreTypesCompatible(const NodeArg& pattern_value, const NodeArg& target_value);
+
+common::Status NormalizeConstantAttributes(
+    const NodeAttributes& attributes,
+    ONNX_NAMESPACE::TensorProto& tensor);
+
+common::Status CompareTensorLiterals(
+    const ONNX_NAMESPACE::TensorProto& lhs,
+    const ONNX_NAMESPACE::TensorProto& rhs,
+    size_t max_literal_bytes,
+    bool& equal,
+    const std::filesystem::path* rhs_model_path = nullptr);
+
+std::string CanonicalFunctionFingerprint(const ONNX_NAMESPACE::FunctionProto& function_proto);
+
+}  // namespace function_extractor_internal
+}  // namespace onnxruntime
+
+#endif  // !defined(ORT_MINIMAL_BUILD)

--- a/onnxruntime/core/optimizer/function_extractor_pattern.h
+++ b/onnxruntime/core/optimizer/function_extractor_pattern.h
@@ -59,7 +59,7 @@ struct NormalizedFunctionPattern {
   InlinedVector<PatternValueId> formal_input_value_ids;
   InlinedVector<PatternValueId> formal_output_value_ids;
   InlinedVector<PatternValue, 1> values;
-  InlinedVector<PatternNode> nodes;
+  InlinedVector<PatternNode, 1> nodes;
   InlinedVector<PatternNodeId> reverse_topological_node_ids;
   common::Status construction_status{common::Status::OK()};
 };
@@ -89,8 +89,8 @@ struct FormalOutputProducerGroup {
 struct CompiledFunctionPattern {
   // Non-owning. The referenced normalized pattern must outlive this object.
   const NormalizedFunctionPattern* normalized_pattern{};
-  InlinedVector<ResolvedPatternNode> resolved_nodes;
-  InlinedVector<FormalOutputProducerGroup> formal_output_producer_groups;
+  InlinedVector<ResolvedPatternNode, 1> resolved_nodes;
+  InlinedVector<FormalOutputProducerGroup, 1> formal_output_producer_groups;
 };
 
 NormalizedFunctionPattern NormalizeFunctionPattern(

--- a/onnxruntime/test/optimizer/function_extractor_test.cc
+++ b/onnxruntime/test/optimizer/function_extractor_test.cc
@@ -1125,23 +1125,31 @@ TEST_F(FunctionExtractorTest, RejectsDownstreamFormalInputBinding) {
   const FunctionProto function_proto =
       MakeFunction("DownstreamInput", nodes, std::vector<std::string>{"x", "y"},
                    std::vector<std::string>{"out"});
-  auto model = MakeModel(function_proto);
-  Graph& graph = model->MainGraph();
-  ModelTestBuilder builder(graph);
-  NodeArg* x = builder.MakeInput<float>({2}, 0.0f, 1.0f);
-  NodeArg* activated = builder.MakeIntermediate<float>({2});
-  NodeArg* downstream = builder.MakeIntermediate<float>({2});
-  NodeArg* output = builder.MakeOutput<float>({2});
-  builder.AddNode("Relu", {x}, {activated});
-  builder.AddNode("Identity", {activated}, {downstream});
-  builder.AddNode("Add", {activated, downstream}, {output});
-  builder.SetGraphOutputs();
-  ASSERT_STATUS_OK(graph.Resolve());
+  for (const bool bind_formal_directly_to_matched_output : {false, true}) {
+    SCOPED_TRACE(bind_formal_directly_to_matched_output);
+    auto model = MakeModel(function_proto);
+    Graph& graph = model->MainGraph();
+    ModelTestBuilder builder(graph);
+    NodeArg* x = builder.MakeInput<float>({2}, 0.0f, 1.0f);
+    NodeArg* activated = builder.MakeIntermediate<float>({2});
+    NodeArg* output = builder.MakeOutput<float>({2});
+    builder.AddNode("Relu", {x}, {activated});
 
-  FunctionExtractor extractor(function_proto);
-  const FunctionExtractionResult result = extractor.Extract(graph);
-  ASSERT_STATUS_OK(result.status);
-  EXPECT_EQ(result.replacements_applied, 0u);
+    NodeArg* formal_input_binding = activated;
+    if (!bind_formal_directly_to_matched_output) {
+      formal_input_binding = builder.MakeIntermediate<float>({2});
+      builder.AddNode("Identity", {activated}, {formal_input_binding});
+    }
+
+    builder.AddNode("Add", {activated, formal_input_binding}, {output});
+    builder.SetGraphOutputs();
+    ASSERT_STATUS_OK(graph.Resolve());
+
+    FunctionExtractor extractor(function_proto);
+    const FunctionExtractionResult result = extractor.Extract(graph);
+    ASSERT_STATUS_OK(result.status);
+    EXPECT_EQ(result.replacements_applied, 0u);
+  }
 }
 
 TEST_F(FunctionExtractorTest, RejectsNonConvexLeaveAndReenterPath) {

--- a/onnxruntime/test/optimizer/function_extractor_test.cc
+++ b/onnxruntime/test/optimizer/function_extractor_test.cc
@@ -223,6 +223,10 @@ Node& AddCapturingIf(ModelTestBuilder& builder, NodeArg& captured,
   return if_node;
 }
 
+common::Status FailGraphResolve(Graph&, const Graph::ResolveOptions&) {
+  return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "injected resolve failure");
+}
+
 }  // namespace
 
 class FunctionExtractorTest : public ::testing::Test {
@@ -1344,6 +1348,62 @@ TEST_F(FunctionExtractorTest, RejectsStalePlanBeforeMutation) {
   ASSERT_TRUE(graph.RemoveNode(stale_node_index));
   EXPECT_FALSE(PrevalidatePlans(graph, compiled, plans).IsOK());
   EXPECT_EQ(CountOp(graph, kFunctionDomain, function_proto.name()), 0u);
+}
+
+TEST_F(FunctionExtractorTest, ReturnsInvariantErrorAtPassCap) {
+  const FunctionProto function_proto = MakeLinearFunction();
+  auto model = MakeModel(function_proto);
+  Graph& graph = model->MainGraph();
+  NodeArg* x;
+  NodeArg* y;
+  NodeArg* sum;
+  NodeArg* output;
+  BuildLinearTarget(graph, x, y, sum, output);
+  ASSERT_STATUS_OK(graph.Resolve());
+  const size_t original_node_count = graph.NumberOfNodes();
+
+  using namespace function_extractor_internal;
+  const NormalizedFunctionPattern normalized =
+      NormalizeFunctionPattern(function_proto, FunctionExtractorOptions{});
+  ASSERT_STATUS_OK(normalized.construction_status);
+  ExtractionControls controls;
+  controls.maximum_passes = 0;
+
+  const FunctionExtractionResult result =
+      ExtractGraph(graph, normalized, FunctionExtractorOptions{}, controls);
+  EXPECT_FALSE(result.status.IsOK());
+  EXPECT_NE(result.status.ErrorMessage().find("defensive pass cap"), std::string::npos);
+  EXPECT_EQ(result.replacements_applied, 0u);
+  EXPECT_EQ(graph.NumberOfNodes(), original_node_count);
+  AssertResolved(graph);
+}
+
+TEST_F(FunctionExtractorTest, ReportsAppliedCountOnResolveFailure) {
+  const FunctionProto function_proto = MakeLinearFunction();
+  auto model = MakeModel(function_proto);
+  Graph& graph = model->MainGraph();
+  NodeArg* x;
+  NodeArg* y;
+  NodeArg* sum;
+  NodeArg* output;
+  BuildLinearTarget(graph, x, y, sum, output);
+  ASSERT_STATUS_OK(graph.Resolve());
+
+  using namespace function_extractor_internal;
+  const NormalizedFunctionPattern normalized =
+      NormalizeFunctionPattern(function_proto, FunctionExtractorOptions{});
+  ASSERT_STATUS_OK(normalized.construction_status);
+  ExtractionControls controls;
+  controls.resolve_graph = FailGraphResolve;
+
+  const FunctionExtractionResult result =
+      ExtractGraph(graph, normalized, FunctionExtractorOptions{}, controls);
+  EXPECT_FALSE(result.status.IsOK());
+  EXPECT_NE(result.status.ErrorMessage().find("injected resolve failure"), std::string::npos);
+  EXPECT_EQ(result.replacements_applied, 1u);
+  EXPECT_TRUE(graph.GraphResolveNeeded());
+  EXPECT_EQ(graph.NumberOfNodes(), 1u);
+  EXPECT_EQ(CountOp(graph, kFunctionDomain, function_proto.name()), 1u);
 }
 
 TEST_F(FunctionExtractorTest, StrictlyDecreasesNodeCountPerReplacement) {

--- a/onnxruntime/test/optimizer/function_extractor_test.cc
+++ b/onnxruntime/test/optimizer/function_extractor_test.cc
@@ -269,6 +269,10 @@ TEST_F(FunctionExtractorTest, RejectsInvalidFormalNames) {
 }
 
 TEST_F(FunctionExtractorTest, RejectsInvalidAttributes) {
+  FunctionProto required_attribute = MakeLinearFunction("RequiredAttribute");
+  required_attribute.add_attribute("axis");
+  ExpectConstructionRejected(std::move(required_attribute));
+
   FunctionProto duplicate_declaration = MakeLinearFunction("DuplicateAttribute");
   duplicate_declaration.add_attribute("axis");
   duplicate_declaration.add_attribute("axis");
@@ -307,6 +311,15 @@ TEST_F(FunctionExtractorTest, RejectsMalformedDataflow) {
     ExpectConstructionRejected(MakeFunction("Malformed" + std::to_string(i),
                                             invalid_bodies[i], inputs, outputs));
   }
+
+  const std::vector<NodeDef> disconnected_body{
+      {{"left"}, "Add", {"x", "y"}},
+      {{"right"}, "Mul", {"z", "w"}},
+  };
+  ExpectConstructionRejected(
+      MakeFunction("DisconnectedOutputs", disconnected_body,
+                   std::vector<std::string>{"x", "y", "z", "w"},
+                   std::vector<std::string>{"left", "right"}));
 }
 
 TEST_F(FunctionExtractorTest, RejectsOutputUnreachableOperations) {
@@ -806,31 +819,61 @@ TEST_F(FunctionExtractorTest, RequiresExactEffectiveAttributes) {
 }
 
 TEST_F(FunctionExtractorTest, MatchesOptionalAndVariadicSlotsPositionally) {
-  const std::vector<NodeDef> nodes{
-      {{"clipped"}, "Clip", {"x", "", ""}},
-      {{"out"}, "Concat", {"clipped", "y"}, {ONNX_NAMESPACE::MakeAttribute("axis", int64_t{0})}},
-  };
-  const FunctionProto function_proto =
-      MakeFunction("OptionalVariadic", nodes, std::vector<std::string>{"x", "y"},
-                   std::vector<std::string>{"out"});
-  auto model = MakeModel(function_proto);
-  Graph& graph = model->MainGraph();
-  ModelTestBuilder builder(graph);
-  NodeArg* x = builder.MakeInput<float>({1}, 0.0f, 1.0f);
-  NodeArg* y = builder.MakeInput<float>({1}, 0.0f, 1.0f);
-  NodeArg* empty = builder.MakeEmptyInput();
-  NodeArg* clipped = builder.MakeIntermediate<float>({1});
-  NodeArg* output = builder.MakeOutput<float>({2});
-  builder.AddNode("Clip", {x, empty, empty}, {clipped});
-  NodeAttributes attributes{{"axis", ONNX_NAMESPACE::MakeAttribute("axis", int64_t{0})}};
-  builder.AddNode("Concat", {clipped, y}, {output}, kOnnxDomain, &attributes);
-  builder.SetGraphOutputs();
-  ASSERT_STATUS_OK(graph.Resolve());
+  {
+    const std::vector<NodeDef> nodes{
+        {{"clipped"}, "Clip", {"x", "", ""}},
+        {{"out"}, "Concat", {"clipped", "y"}, {ONNX_NAMESPACE::MakeAttribute("axis", int64_t{0})}},
+    };
+    const FunctionProto function_proto =
+        MakeFunction("OptionalVariadic", nodes, std::vector<std::string>{"x", "y"},
+                     std::vector<std::string>{"out"});
+    auto model = MakeModel(function_proto);
+    Graph& graph = model->MainGraph();
+    ModelTestBuilder builder(graph);
+    NodeArg* x = builder.MakeInput<float>({1}, 0.0f, 1.0f);
+    NodeArg* y = builder.MakeInput<float>({1}, 0.0f, 1.0f);
+    NodeArg* empty = builder.MakeEmptyInput();
+    NodeArg* clipped = builder.MakeIntermediate<float>({1});
+    NodeArg* output = builder.MakeOutput<float>({2});
+    builder.AddNode("Clip", {x, empty, empty}, {clipped});
+    NodeAttributes attributes{{"axis", ONNX_NAMESPACE::MakeAttribute("axis", int64_t{0})}};
+    builder.AddNode("Concat", {clipped, y}, {output}, kOnnxDomain, &attributes);
+    builder.SetGraphOutputs();
+    ASSERT_STATUS_OK(graph.Resolve());
 
-  FunctionExtractor extractor(function_proto);
-  const FunctionExtractionResult result = extractor.Extract(graph);
-  ASSERT_STATUS_OK(result.status);
-  EXPECT_EQ(result.replacements_applied, 1u);
+    FunctionExtractor extractor(function_proto);
+    const FunctionExtractionResult result = extractor.Extract(graph);
+    ASSERT_STATUS_OK(result.status);
+    EXPECT_EQ(result.replacements_applied, 1u);
+  }
+
+  {
+    const std::vector<NodeDef> nodes{
+        {{"pooled"}, "MaxPool", {"x"}, {ONNX_NAMESPACE::MakeAttribute("kernel_shape", std::vector<int64_t>{2, 2})}},
+        {{"out"}, "Identity", {"pooled"}},
+    };
+    const FunctionProto function_proto =
+        MakeFunction("OmittedOptionalOutput", nodes, std::vector<std::string>{"x"},
+                     std::vector<std::string>{"out"});
+    auto model = MakeModel(function_proto);
+    Graph& graph = model->MainGraph();
+    ModelTestBuilder builder(graph);
+    NodeArg* x = builder.MakeInput<float>({1, 1, 4, 4}, 0.0f, 1.0f);
+    NodeArg* pooled = builder.MakeIntermediate<float>({1, 1, 3, 3});
+    NodeArg* output = builder.MakeOutput<float>({1, 1, 3, 3});
+    NodeAttributes attributes{
+        {"kernel_shape", ONNX_NAMESPACE::MakeAttribute(
+                             "kernel_shape", std::vector<int64_t>{2, 2})}};
+    builder.AddNode("MaxPool", {x}, {pooled}, kOnnxDomain, &attributes);
+    builder.AddNode("Identity", {pooled}, {output});
+    builder.SetGraphOutputs();
+    ASSERT_STATUS_OK(graph.Resolve());
+
+    FunctionExtractor extractor(function_proto);
+    const FunctionExtractionResult result = extractor.Extract(graph);
+    ASSERT_STATUS_OK(result.status);
+    EXPECT_EQ(result.replacements_applied, 1u);
+  }
 }
 
 TEST_F(FunctionExtractorTest, AppliesKnownTypeCompatibilityRules) {

--- a/onnxruntime/test/optimizer/function_extractor_test.cc
+++ b/onnxruntime/test/optimizer/function_extractor_test.cc
@@ -569,7 +569,27 @@ TEST_F(FunctionExtractorTest, RejectsHighArityPatternBeforeMutation) {
       MakeFunction("HighArity", nodes, inputs, std::vector<std::string>{"out"});
   auto model = MakeModel(function_proto);
   Graph& graph = model->MainGraph();
+  FunctionExtractorGraphBuilder builder(graph);
+  std::vector<NodeArg*> target_inputs;
+  target_inputs.reserve(input_count);
+  for (size_t i = 0; i < input_count; ++i) {
+    target_inputs.push_back(builder.MakeInput<float>({1}, 0.0f, 1.0f));
+  }
+  NodeArg* joined = builder.MakeIntermediate<float>({static_cast<int64_t>(input_count)});
+  NodeArg* output = builder.MakeOutput<float>({static_cast<int64_t>(input_count)});
+  NodeAttributes attributes{{"axis", ONNX_NAMESPACE::MakeAttribute("axis", int64_t{0})}};
+  builder.AddNode("Concat", target_inputs, {joined}, kOnnxDomain, &attributes);
+  builder.AddNode("Identity", {joined}, {output});
+  builder.SetGraphOutputs();
   ASSERT_STATUS_OK(graph.Resolve());
+
+  const size_t node_count_before = graph.NumberOfNodes();
+  std::vector<std::pair<NodeIndex, const Node*>> node_identities_before;
+  for (const Node& node : graph.Nodes()) {
+    node_identities_before.emplace_back(node.Index(), &node);
+  }
+  const std::string graph_proto_before = graph.ToGraphProto().SerializeAsString();
+  ASSERT_FALSE(graph.GraphResolveNeeded());
 
   FunctionExtractorOptions options;
   options.max_worklist_bindings = 16;
@@ -577,7 +597,16 @@ TEST_F(FunctionExtractorTest, RejectsHighArityPatternBeforeMutation) {
   const FunctionExtractionResult result = extractor.Extract(graph);
   EXPECT_FALSE(result.status.IsOK());
   EXPECT_EQ(result.replacements_applied, 0u);
-  EXPECT_EQ(graph.NumberOfNodes(), 0u);
+  EXPECT_EQ(graph.NumberOfNodes(), node_count_before);
+  EXPECT_EQ(CountOp(graph, kFunctionDomain, function_proto.name()), 0u);
+  EXPECT_FALSE(graph.GraphResolveNeeded());
+  EXPECT_EQ(graph.ToGraphProto().SerializeAsString(), graph_proto_before);
+
+  std::vector<std::pair<NodeIndex, const Node*>> node_identities_after;
+  for (const Node& node : graph.Nodes()) {
+    node_identities_after.emplace_back(node.Index(), &node);
+  }
+  EXPECT_EQ(node_identities_after, node_identities_before);
 }
 
 // Deterministic structural matching.

--- a/onnxruntime/test/optimizer/function_extractor_test.cc
+++ b/onnxruntime/test/optimizer/function_extractor_test.cc
@@ -881,7 +881,7 @@ TEST_F(FunctionExtractorTest, MatchesOptionalAndVariadicSlotsPositionally) {
 
 TEST_F(FunctionExtractorTest, MatchesOperatorWithOmittedOptionalOutput) {
   const std::vector<NodeDef> nodes{
-      {{"pooled"}, "MaxPool", {"x"}, {ONNX_NAMESPACE::MakeAttribute("kernel_shape", std::vector<int64_t>{2, 2})}},
+      {{"pooled", ""}, "MaxPool", {"x"}, {ONNX_NAMESPACE::MakeAttribute("kernel_shape", std::vector<int64_t>{2, 2})}},
       {{"out"}, "Identity", {"pooled"}},
   };
   const FunctionProto function_proto =
@@ -892,11 +892,13 @@ TEST_F(FunctionExtractorTest, MatchesOperatorWithOmittedOptionalOutput) {
   FunctionExtractorGraphBuilder builder(graph);
   NodeArg* x = builder.MakeInput<float>({1, 1, 4, 4}, 0.0f, 1.0f);
   NodeArg* pooled = builder.MakeIntermediate<float>({1, 1, 3, 3});
+  NodeArg* missing_indices = builder.MakeEmptyInput();
   NodeArg* output = builder.MakeOutput<float>({1, 1, 3, 3});
   NodeAttributes attributes{
       {"kernel_shape", ONNX_NAMESPACE::MakeAttribute(
                            "kernel_shape", std::vector<int64_t>{2, 2})}};
-  builder.AddNode("MaxPool", {x}, {pooled}, kOnnxDomain, &attributes);
+  builder.AddNode("MaxPool", {x}, {pooled, missing_indices}, kOnnxDomain,
+                  &attributes);
   builder.AddNode("Identity", {pooled}, {output});
   builder.SetGraphOutputs();
   ASSERT_STATUS_OK(graph.Resolve());
@@ -965,6 +967,19 @@ TEST_F(FunctionExtractorTest, AppliesKnownTypeCompatibilityRules) {
   const FunctionExtractionResult result = extractor.Extract(graph);
   ASSERT_STATUS_OK(result.status);
   EXPECT_EQ(result.replacements_applied, 0u);
+}
+
+TEST_F(FunctionExtractorTest, RejectsNonTensorValueInfo) {
+  FunctionProto function_proto = MakeLinearFunction("NonTensorValueInfo");
+  auto& value_info = *function_proto.add_value_info();
+  value_info.set_name("sum");
+  value_info.mutable_type()
+      ->mutable_sequence_type()
+      ->mutable_elem_type()
+      ->mutable_tensor_type()
+      ->set_elem_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+
+  ExpectConstructionRejected(std::move(function_proto));
 }
 
 // Literal matching and preservation.

--- a/onnxruntime/test/optimizer/function_extractor_test.cc
+++ b/onnxruntime/test/optimizer/function_extractor_test.cc
@@ -1,0 +1,1476 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "gtest/gtest.h"
+
+#include <cstring>
+
+#include "core/common/logging/logging.h"
+#include "core/graph/model.h"
+#include "core/graph/node_attr_utils.h"
+#include "core/optimizer/function_extractor.h"
+#include "core/optimizer/function_extractor_matcher.h"
+#include "core/optimizer/function_extractor_pattern.h"
+#include "onnx/defs/function.h"
+#include "test/unittest_util/framework_test_utils.h"
+#include "test/unittest_util/graph_transform_test_builder.h"
+
+namespace onnxruntime {
+namespace test {
+
+namespace {
+
+using FunctionProto = ONNX_NAMESPACE::FunctionProto;
+using NodeDef = ONNX_NAMESPACE::FunctionBodyHelper::NodeDef;
+
+constexpr const char* kFunctionDomain = "test.function";
+constexpr int kFunctionOpset = 1;
+constexpr int kOnnxOpset = 13;
+
+class FunctionExtractorGraphBuilder final : public ::onnxruntime::test::ModelTestBuilder {
+ public:
+  using ::onnxruntime::test::ModelTestBuilder::MakeIntermediate;
+  using ::onnxruntime::test::ModelTestBuilder::MakeOutput;
+  using ::onnxruntime::test::ModelTestBuilder::ModelTestBuilder;
+
+  template <typename T>
+  NodeArg* MakeIntermediate(std::initializer_list<int64_t> shape) {
+    return ::onnxruntime::test::ModelTestBuilder::MakeIntermediate<T>(
+        std::vector<int64_t>{shape});
+  }
+
+  template <typename T>
+  NodeArg* MakeOutput(std::initializer_list<int64_t> shape) {
+    return ::onnxruntime::test::ModelTestBuilder::MakeOutput<T>(
+        std::vector<int64_t>{shape});
+  }
+};
+
+#define ModelTestBuilder FunctionExtractorGraphBuilder
+
+FunctionProto MakeFunction(std::string name,
+                           gsl::span<const NodeDef> node_defs,
+                           gsl::span<const std::string> inputs,
+                           gsl::span<const std::string> outputs) {
+  FunctionProto function_proto;
+  function_proto.set_domain(kFunctionDomain);
+  function_proto.set_name(std::move(name));
+
+  for (const auto& input : inputs) {
+    function_proto.add_input(input);
+  }
+
+  for (const auto& output : outputs) {
+    function_proto.add_output(output);
+  }
+
+  const std::vector<NodeDef> node_defs_copy{node_defs.begin(), node_defs.end()};
+  for (const auto& node : ONNX_NAMESPACE::FunctionBodyHelper::BuildNodes(node_defs_copy)) {
+    function_proto.add_node()->CopyFrom(node);
+  }
+
+  auto& opset_import = *function_proto.add_opset_import();
+  opset_import.set_domain(kOnnxDomain);
+  opset_import.set_version(kOnnxOpset);
+  return function_proto;
+}
+
+FunctionProto MakeLinearFunction(std::string name = "Linear") {
+  const std::vector<NodeDef> nodes{
+      {{"sum"}, "Add", {"x", "y"}},
+      {{"out"}, "Relu", {"sum"}},
+  };
+  const std::vector<std::string> inputs{"x", "y"};
+  const std::vector<std::string> outputs{"out"};
+  return MakeFunction(std::move(name), nodes, inputs, outputs);
+}
+
+FunctionProto MakeLiteralFunction(std::string name = "Literal") {
+  const std::vector<NodeDef> nodes{
+      ONNX_NAMESPACE::FunctionBodyHelper::Const<float>("one", 1.0f),
+      {{"sum"}, "Add", {"x", "one"}},
+      {{"out"}, "Relu", {"sum"}},
+  };
+  const std::vector<std::string> inputs{"x"};
+  const std::vector<std::string> outputs{"out"};
+  return MakeFunction(std::move(name), nodes, inputs, outputs);
+}
+
+std::unique_ptr<Model> MakeModel(std::vector<FunctionProto> function_protos) {
+  const std::unordered_map<std::string, int> imports{
+      {kOnnxDomain, kOnnxOpset},
+      {kFunctionDomain, kFunctionOpset},
+  };
+  return std::make_unique<Model>(
+      "FunctionExtractorTest", false, ModelMetaData(), PathString(),
+      IOnnxRuntimeOpSchemaRegistryList(), imports,
+      function_protos,
+      DefaultLoggingManager().DefaultLogger());
+}
+
+std::unique_ptr<Model> MakeModel(const FunctionProto& function_proto) {
+  return MakeModel(std::vector<FunctionProto>{function_proto});
+}
+
+size_t CountOp(const Graph& graph, std::string_view domain, std::string_view op_type) {
+  size_t count = 0;
+  for (const auto& node : graph.Nodes()) {
+    if (node.Domain() == domain && node.OpType() == op_type) {
+      ++count;
+    }
+  }
+  return count;
+}
+
+Node& FindOnlyOp(Graph& graph, std::string_view domain, std::string_view op_type) {
+  Node* result = nullptr;
+  for (auto& node : graph.Nodes()) {
+    if (node.Domain() == domain && node.OpType() == op_type) {
+      EXPECT_EQ(result, nullptr) << "Expected exactly one " << domain << "." << op_type;
+      result = &node;
+    }
+  }
+
+  EXPECT_NE(result, nullptr) << "Expected one " << domain << "." << op_type;
+  return *result;
+}
+
+void AssertResolved(const Graph& graph) {
+  ASSERT_FALSE(graph.GraphResolveNeeded());
+  for (const auto& node : graph.Nodes()) {
+    ASSERT_NE(node.Op(), nullptr) << node.Name();
+  }
+}
+
+void AssertCallIO(const Node& node,
+                  gsl::span<const std::string> expected_inputs,
+                  gsl::span<const std::string> expected_outputs) {
+  ASSERT_EQ(node.InputDefs().size(), expected_inputs.size());
+  ASSERT_EQ(node.OutputDefs().size(), expected_outputs.size());
+  for (size_t i = 0; i < expected_inputs.size(); ++i) {
+    EXPECT_EQ(node.InputDefs()[i]->Name(), expected_inputs[i]);
+  }
+  for (size_t i = 0; i < expected_outputs.size(); ++i) {
+    EXPECT_EQ(node.OutputDefs()[i]->Name(), expected_outputs[i]);
+  }
+}
+
+std::shared_ptr<Model> SerializeAndReload(Model& model) {
+  std::string serialized_model;
+  EXPECT_TRUE(model.ToProto().SerializeToString(&serialized_model));
+
+  ONNX_NAMESPACE::ModelProto model_proto;
+  EXPECT_TRUE(model_proto.ParseFromString(serialized_model));
+
+  std::shared_ptr<Model> reloaded_model;
+  EXPECT_STATUS_OK(Model::Load(std::move(model_proto), reloaded_model, nullptr,
+                               DefaultLoggingManager().DefaultLogger()));
+  return reloaded_model;
+}
+
+void BuildLinearTarget(Graph& graph,
+                       NodeArg*& x,
+                       NodeArg*& y,
+                       NodeArg*& sum,
+                       NodeArg*& output) {
+  ModelTestBuilder builder(graph);
+  x = builder.MakeInput<float>({2}, 0.0f, 1.0f);
+  y = builder.MakeInput<float>({2}, 0.0f, 1.0f);
+  sum = builder.MakeIntermediate<float>({2});
+  output = builder.MakeOutput<float>({2});
+  builder.AddNode("Add", {x, y}, {sum});
+  builder.AddNode("Relu", {sum}, {output});
+  builder.SetGraphOutputs();
+}
+
+void AddLinearTarget(ModelTestBuilder& builder,
+                     NodeArg* x,
+                     NodeArg* y,
+                     NodeArg* output) {
+  NodeArg* sum = builder.MakeIntermediate<float>({2});
+  builder.AddNode("Add", {x, y}, {sum});
+  builder.AddNode("Relu", {sum}, {output});
+}
+
+ONNX_NAMESPACE::GraphProto MakeCaptureSubgraph(
+    const std::string& captured_name,
+    const ONNX_NAMESPACE::TypeProto& captured_type,
+    std::string_view op_type = "Identity") {
+  Model subgraph_model("CaptureSubgraph", false, ModelMetaData(), PathString(),
+                       IOnnxRuntimeOpSchemaRegistryList(),
+                       {{kOnnxDomain, kOnnxOpset}}, {},
+                       DefaultLoggingManager().DefaultLogger());
+  Graph& subgraph = subgraph_model.MainGraph();
+  NodeArg& captured = subgraph.GetOrCreateNodeArg(captured_name, &captured_type);
+  subgraph.AddOuterScopeNodeArg(captured_name);
+  NodeArg& output = subgraph.GetOrCreateNodeArg("subgraph_output", &captured_type);
+  subgraph.AddNode("capture", std::string{op_type}, "capture outer-scope value",
+                   {&captured}, {&output});
+  subgraph.SetOutputs({&output});
+  EXPECT_STATUS_OK(subgraph.Resolve());
+  return subgraph.ToGraphProto();
+}
+
+Node& AddCapturingIf(ModelTestBuilder& builder, NodeArg& captured,
+                     std::string_view op_type = "Identity") {
+  NodeArg* condition = builder.MakeInput<bool>({}, std::vector<bool>{true});
+  NodeArg* if_output = builder.MakeOutput<float>({2});
+  Node& if_node = builder.AddNode("If", {condition}, {if_output});
+  const ONNX_NAMESPACE::GraphProto branch =
+      MakeCaptureSubgraph(captured.Name(), *captured.TypeAsProto(), op_type);
+  if_node.AddAttribute("then_branch", branch);
+  if_node.AddAttribute("else_branch", branch);
+  return if_node;
+}
+
+}  // namespace
+
+class FunctionExtractorTest : public ::testing::Test {
+ protected:
+  static void ExpectConstructionRejected(FunctionProto function_proto) {
+    Model model("InvalidFunctionExtractorTest", false,
+                DefaultLoggingManager().DefaultLogger());
+    ASSERT_STATUS_OK(model.MainGraph().Resolve());
+
+    FunctionExtractor extractor(function_proto);
+    const FunctionExtractionResult result = extractor.Extract(model.MainGraph());
+    EXPECT_FALSE(result.status.IsOK());
+    EXPECT_EQ(result.replacements_applied, 0u);
+    EXPECT_EQ(model.MainGraph().NumberOfNodes(), 0u);
+  }
+};
+
+TEST_F(FunctionExtractorTest, RejectsInvalidFormalNames) {
+  const std::vector<NodeDef> nodes{
+      {{"sum"}, "Add", {"x", "y"}},
+      {{"out"}, "Relu", {"sum"}},
+  };
+
+  for (const auto& inputs : std::vector<std::vector<std::string>>{
+           {"", "y"}, {"x", "x"}, {"x", "out"}}) {
+    SCOPED_TRACE(::testing::PrintToString(inputs));
+    ExpectConstructionRejected(MakeFunction("InvalidInputs", nodes, inputs, std::vector<std::string>{"out"}));
+  }
+
+  for (const auto& outputs : std::vector<std::vector<std::string>>{
+           {""}, {"out", "out"}}) {
+    SCOPED_TRACE(::testing::PrintToString(outputs));
+    ExpectConstructionRejected(MakeFunction("InvalidOutputs", nodes, std::vector<std::string>{"x", "y"}, outputs));
+  }
+
+  FunctionProto internally_produced_input =
+      MakeFunction("ProducedInput", nodes, std::vector<std::string>{"sum", "y"},
+                   std::vector<std::string>{"out"});
+  ExpectConstructionRejected(std::move(internally_produced_input));
+}
+
+TEST_F(FunctionExtractorTest, RejectsInvalidAttributes) {
+  FunctionProto duplicate_declaration = MakeLinearFunction("DuplicateAttribute");
+  duplicate_declaration.add_attribute("axis");
+  duplicate_declaration.add_attribute("axis");
+  ExpectConstructionRejected(std::move(duplicate_declaration));
+
+  FunctionProto duplicate_default = MakeLinearFunction("DuplicateDefault");
+  duplicate_default.add_attribute("axis");
+  duplicate_default.add_attribute_proto()->CopyFrom(
+      ONNX_NAMESPACE::MakeAttribute("axis", int64_t{0}));
+  duplicate_default.add_attribute_proto()->CopyFrom(
+      ONNX_NAMESPACE::MakeAttribute("axis", int64_t{1}));
+  ExpectConstructionRejected(std::move(duplicate_default));
+
+  FunctionProto referenced_attribute = MakeLinearFunction("ReferencedAttribute");
+  auto& attribute = *referenced_attribute.mutable_node(0)->add_attribute();
+  attribute.set_name("axis");
+  attribute.set_ref_attr_name("axis");
+  attribute.set_type(ONNX_NAMESPACE::AttributeProto_AttributeType_INT);
+  ExpectConstructionRejected(std::move(referenced_attribute));
+}
+
+TEST_F(FunctionExtractorTest, RejectsMalformedDataflow) {
+  const std::vector<std::string> inputs{"x", "y"};
+  const std::vector<std::string> outputs{"out"};
+
+  const std::vector<std::vector<NodeDef>> invalid_bodies{
+      {{{"sum"}, "Add", {"x", "undefined"}}, {{"out"}, "Relu", {"sum"}}},
+      {{{"sum"}, "Add", {"x", "y"}}, {{"sum"}, "Mul", {"x", "y"}}, {{"out"}, "Relu", {"sum"}}},
+      {{{"a"}, "Add", {"b", "x"}}, {{"b"}, "Mul", {"a", "y"}}, {{"out"}, "Relu", {"a"}}},
+      {{{"sum"}, "Add", {"x", "y"}}, {{"dead"}, "Mul", {"x", "y"}}, {{"out"}, "Relu", {"sum"}}},
+      {{{"sum"}, "Add", {"x", ""}}, {{"out"}, "Relu", {"sum"}}},
+  };
+
+  for (size_t i = 0; i < invalid_bodies.size(); ++i) {
+    SCOPED_TRACE(i);
+    ExpectConstructionRejected(MakeFunction("Malformed" + std::to_string(i),
+                                            invalid_bodies[i], inputs, outputs));
+  }
+}
+
+TEST_F(FunctionExtractorTest, RejectsOutputUnreachableOperations) {
+  const std::vector<std::string> inputs{"x", "y"};
+  const std::vector<std::string> outputs{"out"};
+  const std::vector<std::vector<NodeDef>> invalid_bodies{
+      {{{"out"}, "Add", {"x", "y"}}, {{"after"}, "Relu", {"out"}}},
+      {{{"sum"}, "Add", {"x", "y"}}, {{"out"}, "Relu", {"sum"}}, {{"dead"}, "Mul", {"x", "y"}}},
+  };
+
+  for (size_t i = 0; i < invalid_bodies.size(); ++i) {
+    SCOPED_TRACE(i);
+    ExpectConstructionRejected(MakeFunction("Unreachable" + std::to_string(i),
+                                            invalid_bodies[i], inputs, outputs));
+  }
+}
+
+TEST_F(FunctionExtractorTest, RejectsConstantFormalOutput) {
+  const std::vector<std::string> no_inputs;
+  const std::vector<std::string> outputs{"out"};
+  const std::vector<NodeDef> constant_body{
+      ONNX_NAMESPACE::FunctionBodyHelper::Const<float>("literal", 1.0f),
+      {{"out"}, "Identity", {"literal"}},
+  };
+  FunctionProto function_proto = MakeFunction("ConstantOutput", constant_body, no_inputs, outputs);
+  function_proto.mutable_output(0)->assign("literal");
+  ExpectConstructionRejected(std::move(function_proto));
+}
+
+TEST_F(FunctionExtractorTest, RejectsSingleOperationPattern) {
+  const std::vector<NodeDef> nodes{{{"out"}, "Relu", {"x"}}};
+  ExpectConstructionRejected(MakeFunction(
+      "Single", nodes, std::vector<std::string>{"x"}, std::vector<std::string>{"out"}));
+}
+
+TEST_F(FunctionExtractorTest, RejectsUnsupportedBodyFeatures) {
+  ONNX_NAMESPACE::GraphProto subgraph;
+  subgraph.set_name("body");
+  const std::vector<NodeDef> nodes{
+      {{"branch"}, "If", {"condition"}, {ONNX_NAMESPACE::MakeAttribute("then_branch", subgraph), ONNX_NAMESPACE::MakeAttribute("else_branch", subgraph)}},
+      {{"out"}, "Identity", {"branch"}},
+  };
+  ExpectConstructionRejected(
+      MakeFunction("ControlFlow", nodes, std::vector<std::string>{"condition"},
+                   std::vector<std::string>{"out"}));
+}
+
+TEST_F(FunctionExtractorTest, RejectsUnregisteredFunction) {
+  FunctionProto function_proto = MakeLinearFunction();
+  Model model("UnregisteredFunction", false, DefaultLoggingManager().DefaultLogger());
+  Graph& graph = model.MainGraph();
+  NodeArg* x;
+  NodeArg* y;
+  NodeArg* sum;
+  NodeArg* output;
+  BuildLinearTarget(graph, x, y, sum, output);
+  ASSERT_STATUS_OK(graph.Resolve());
+  const size_t original_node_count = graph.NumberOfNodes();
+
+  FunctionExtractor extractor(function_proto);
+  const FunctionExtractionResult result = extractor.Extract(graph);
+  EXPECT_FALSE(result.status.IsOK());
+  EXPECT_EQ(result.replacements_applied, 0u);
+  EXPECT_EQ(graph.NumberOfNodes(), original_node_count);
+}
+
+TEST_F(FunctionExtractorTest, RejectsDifferentRegisteredDefinition) {
+  const FunctionProto registered_function = MakeLinearFunction();
+  FunctionProto requested_function = MakeLinearFunction();
+  requested_function.mutable_node(0)->set_op_type("Sub");
+  auto model = MakeModel(registered_function);
+  Graph& graph = model->MainGraph();
+  NodeArg* x;
+  NodeArg* y;
+  NodeArg* sum;
+  NodeArg* output;
+  BuildLinearTarget(graph, x, y, sum, output);
+  ASSERT_STATUS_OK(graph.Resolve());
+
+  FunctionExtractor extractor(requested_function);
+  const FunctionExtractionResult result = extractor.Extract(graph);
+  EXPECT_FALSE(result.status.IsOK());
+  EXPECT_EQ(result.replacements_applied, 0u);
+  EXPECT_EQ(graph.NumberOfNodes(), 2u);
+}
+
+TEST_F(FunctionExtractorTest, RejectsContextDependentSchemaFunction) {
+  const std::vector<NodeDef> nodes{
+      {{"scaled"}, "Mul", {"x", "x"}},
+      {{"out"}, "Relu", {"scaled"}},
+  };
+  FunctionProto function_proto =
+      MakeFunction("Celu", nodes, std::vector<std::string>{"x"},
+                   std::vector<std::string>{"out"});
+  function_proto.set_domain(kOnnxDomain);
+
+  Model model("ContextDependentFunction", false, ModelMetaData(), PathString(),
+              IOnnxRuntimeOpSchemaRegistryList(), {{kOnnxDomain, kOnnxOpset}}, {},
+              DefaultLoggingManager().DefaultLogger());
+  ASSERT_STATUS_OK(model.MainGraph().Resolve());
+  FunctionExtractor extractor(function_proto);
+  const FunctionExtractionResult result = extractor.Extract(model);
+  EXPECT_FALSE(result.status.IsOK());
+  EXPECT_EQ(result.replacements_applied, 0u);
+}
+
+TEST_F(FunctionExtractorTest, ResolvesNestedLocalFunctionIdentity) {
+  const FunctionProto nested_function = MakeLinearFunction("Nested");
+  const std::vector<NodeDef> outer_nodes{
+      {{"nested_out"}, "Nested", {"x", "y"}, {}, kFunctionDomain},
+      {{"out"}, "Identity", {"nested_out"}},
+  };
+  FunctionProto outer_function =
+      MakeFunction("Outer", outer_nodes, std::vector<std::string>{"x", "y"},
+                   std::vector<std::string>{"out"});
+  auto& function_import = *outer_function.add_opset_import();
+  function_import.set_domain(kFunctionDomain);
+  function_import.set_version(kFunctionOpset);
+
+  auto model = MakeModel(std::vector<FunctionProto>{nested_function, outer_function});
+  Graph& graph = model->MainGraph();
+  ModelTestBuilder builder(graph);
+  NodeArg* x = builder.MakeInput<float>({2}, 0.0f, 1.0f);
+  NodeArg* y = builder.MakeInput<float>({2}, 0.0f, 1.0f);
+  NodeArg* nested_output = builder.MakeIntermediate<float>({2});
+  NodeArg* output = builder.MakeOutput<float>({2});
+  builder.AddNode("Nested", {x, y}, {nested_output}, kFunctionDomain);
+  builder.AddNode("Identity", {nested_output}, {output});
+  builder.SetGraphOutputs();
+  ASSERT_STATUS_OK(graph.Resolve());
+
+  FunctionExtractor extractor(outer_function);
+  const FunctionExtractionResult result = extractor.Extract(graph);
+  ASSERT_STATUS_OK(result.status);
+  EXPECT_EQ(result.replacements_applied, 1u);
+  EXPECT_EQ(CountOp(graph, kFunctionDomain, outer_function.name()), 1u);
+}
+
+TEST_F(FunctionExtractorTest, RejectsUnresolvedTargetGraph) {
+  const FunctionProto function_proto = MakeLinearFunction();
+  auto model = MakeModel(function_proto);
+  Graph& graph = model->MainGraph();
+  NodeArg* x;
+  NodeArg* y;
+  NodeArg* sum;
+  NodeArg* output;
+  BuildLinearTarget(graph, x, y, sum, output);
+  ASSERT_TRUE(graph.GraphResolveNeeded());
+
+  FunctionExtractor extractor(function_proto);
+  const FunctionExtractionResult result = extractor.Extract(graph);
+  EXPECT_FALSE(result.status.IsOK());
+  EXPECT_EQ(result.replacements_applied, 0u);
+  EXPECT_EQ(graph.NumberOfNodes(), 2u);
+}
+
+TEST_F(FunctionExtractorTest, RejectsImpureOrUnknownOperation) {
+  const std::vector<std::string> inputs{"x", "y"};
+  const std::vector<std::string> outputs{"out"};
+  const std::vector<std::vector<NodeDef>> bodies{
+      {{{"random"}, "RandomNormal", {}}, {{"out"}, "Add", {"x", "random"}}},
+      {{{"custom"}, "Unknown", {"x"}}, {{"out"}, "Add", {"custom", "y"}}},
+  };
+
+  for (size_t i = 0; i < bodies.size(); ++i) {
+    SCOPED_TRACE(i);
+    FunctionProto function_proto = MakeFunction("Impure" + std::to_string(i), bodies[i], inputs, outputs);
+    auto model = MakeModel(function_proto);
+    ASSERT_STATUS_OK(model->MainGraph().Resolve());
+    FunctionExtractor extractor(function_proto);
+    const FunctionExtractionResult result = extractor.Extract(model->MainGraph());
+    EXPECT_FALSE(result.status.IsOK());
+    EXPECT_EQ(result.replacements_applied, 0u);
+  }
+}
+
+TEST_F(FunctionExtractorTest, EnforcesResourceBudgetsBeforeMutation) {
+  const FunctionProto function_proto = MakeLinearFunction();
+  const std::vector<FunctionExtractorOptions> options{
+      FunctionExtractorOptions{1, 1'000'000, 100'000, 1'000'000, 64U * 1024U * 1024U},
+      FunctionExtractorOptions{1024, 1, 100'000, 1'000'000, 64U * 1024U * 1024U},
+      FunctionExtractorOptions{1024, 1'000'000, 0, 1'000'000, 64U * 1024U * 1024U},
+      FunctionExtractorOptions{1024, 1'000'000, 100'000, 0, 64U * 1024U * 1024U},
+  };
+
+  for (const auto& option : options) {
+    auto model = MakeModel(function_proto);
+    Graph& graph = model->MainGraph();
+    NodeArg* x;
+    NodeArg* y;
+    NodeArg* sum;
+    NodeArg* output;
+    BuildLinearTarget(graph, x, y, sum, output);
+    ASSERT_STATUS_OK(graph.Resolve());
+
+    FunctionExtractor extractor(function_proto, option);
+    const FunctionExtractionResult result = extractor.Extract(graph);
+    EXPECT_FALSE(result.status.IsOK());
+    EXPECT_EQ(result.replacements_applied, 0u);
+    EXPECT_EQ(graph.NumberOfNodes(), 2u);
+  }
+}
+
+TEST_F(FunctionExtractorTest, ExtractsLinearPattern) {
+  const FunctionProto function_proto = MakeLinearFunction();
+  auto model = MakeModel(function_proto);
+  Graph& graph = model->MainGraph();
+  NodeArg* x;
+  NodeArg* y;
+  NodeArg* sum;
+  NodeArg* output;
+  BuildLinearTarget(graph, x, y, sum, output);
+  ASSERT_STATUS_OK(graph.Resolve());
+  const std::vector<std::string> expected_inputs{x->Name(), y->Name()};
+  const std::vector<std::string> expected_outputs{output->Name()};
+
+  FunctionExtractor extractor(function_proto);
+  const FunctionExtractionResult result = extractor.Extract(*model);
+  ASSERT_STATUS_OK(result.status);
+  EXPECT_EQ(result.replacements_applied, 1u);
+  EXPECT_EQ(CountOp(graph, kOnnxDomain, "Add"), 0u);
+  EXPECT_EQ(CountOp(graph, kOnnxDomain, "Relu"), 0u);
+  const Node& call = FindOnlyOp(graph, kFunctionDomain, function_proto.name());
+  AssertCallIO(call, expected_inputs, expected_outputs);
+  AssertResolved(graph);
+}
+
+TEST_F(FunctionExtractorTest, ExtractsBranchedMultiOutputPattern) {
+  const std::vector<NodeDef> nodes{
+      {{"sum"}, "Add", {"x", "y"}},
+      {{"scaled"}, "Mul", {"sum", "y"}},
+      {{"activated"}, "Relu", {"sum"}},
+  };
+  const FunctionProto function_proto =
+      MakeFunction("Branched", nodes, std::vector<std::string>{"x", "y"},
+                   std::vector<std::string>{"scaled", "activated"});
+  auto model = MakeModel(function_proto);
+  Graph& graph = model->MainGraph();
+  ModelTestBuilder builder(graph);
+  NodeArg* x = builder.MakeInput<float>({2}, 0.0f, 1.0f);
+  NodeArg* y = builder.MakeInput<float>({2}, 0.0f, 1.0f);
+  NodeArg* sum = builder.MakeIntermediate<float>({2});
+  NodeArg* scaled = builder.MakeOutput<float>({2});
+  NodeArg* activated = builder.MakeOutput<float>({2});
+  builder.AddNode("Add", {x, y}, {sum});
+  builder.AddNode("Mul", {sum, y}, {scaled});
+  builder.AddNode("Relu", {sum}, {activated});
+  builder.SetGraphOutputs();
+  ASSERT_STATUS_OK(graph.Resolve());
+
+  FunctionExtractor extractor(function_proto);
+  const FunctionExtractionResult result = extractor.Extract(graph);
+  ASSERT_STATUS_OK(result.status);
+  ASSERT_EQ(result.replacements_applied, 1u);
+  const Node& call = FindOnlyOp(graph, kFunctionDomain, function_proto.name());
+  AssertCallIO(call, std::vector<std::string>{x->Name(), y->Name()},
+               std::vector<std::string>{scaled->Name(), activated->Name()});
+}
+
+TEST_F(FunctionExtractorTest, ExtractsDiamondAndProcessesSharedValueOnce) {
+  const std::vector<NodeDef> nodes{
+      {{"sum"}, "Add", {"x", "y"}},
+      {{"left"}, "Relu", {"sum"}},
+      {{"right"}, "Identity", {"sum"}},
+      {{"out"}, "Mul", {"left", "right"}},
+  };
+  const FunctionProto function_proto =
+      MakeFunction("Diamond", nodes, std::vector<std::string>{"x", "y"},
+                   std::vector<std::string>{"out"});
+  auto model = MakeModel(function_proto);
+  Graph& graph = model->MainGraph();
+  ModelTestBuilder builder(graph);
+  NodeArg* x = builder.MakeInput<float>({2}, 0.0f, 1.0f);
+  NodeArg* y = builder.MakeInput<float>({2}, 0.0f, 1.0f);
+  NodeArg* sum = builder.MakeIntermediate<float>({2});
+  NodeArg* left = builder.MakeIntermediate<float>({2});
+  NodeArg* right = builder.MakeIntermediate<float>({2});
+  NodeArg* output = builder.MakeOutput<float>({2});
+  builder.AddNode("Add", {x, y}, {sum});
+  builder.AddNode("Relu", {sum}, {left});
+  builder.AddNode("Identity", {sum}, {right});
+  builder.AddNode("Mul", {left, right}, {output});
+  builder.SetGraphOutputs();
+  ASSERT_STATUS_OK(graph.Resolve());
+
+  using namespace function_extractor_internal;
+  const NormalizedFunctionPattern normalized =
+      NormalizeFunctionPattern(function_proto, FunctionExtractorOptions{});
+  ASSERT_STATUS_OK(normalized.construction_status);
+  CompiledFunctionPattern compiled;
+  ASSERT_STATUS_OK(CompileFunctionPattern(normalized, graph, compiled));
+  TargetGraphSnapshot snapshot;
+  ASSERT_STATUS_OK(BuildTargetGraphSnapshot(graph, compiled, FunctionExtractorOptions{}, snapshot));
+  std::vector<ReplacementPlan> plans;
+  MatcherDiagnostics diagnostics;
+  ASSERT_STATUS_OK(DiscoverReplacementPlans(
+      compiled, snapshot, FunctionExtractorOptions{}, plans, &diagnostics));
+  ASSERT_EQ(plans.size(), 1u);
+  EXPECT_EQ(diagnostics.worklist_bindings_processed, normalized.values.size());
+  EXPECT_EQ(diagnostics.worklist_bindings_scheduled, normalized.values.size());
+}
+
+TEST_F(FunctionExtractorTest, RejectsInconsistentMultiOutputRootTuple) {
+  const std::vector<NodeDef> nodes{
+      {{"sum"}, "Add", {"x", "y"}},
+      {{"left"}, "Relu", {"sum"}},
+      {{"right"}, "Identity", {"sum"}},
+  };
+  const FunctionProto function_proto =
+      MakeFunction("TwoRoots", nodes, std::vector<std::string>{"x", "y"},
+                   std::vector<std::string>{"left", "right"});
+  auto model = MakeModel(function_proto);
+  Graph& graph = model->MainGraph();
+  ModelTestBuilder builder(graph);
+  NodeArg* x = builder.MakeInput<float>({2}, 0.0f, 1.0f);
+  NodeArg* y = builder.MakeInput<float>({2}, 0.0f, 1.0f);
+  NodeArg* other = builder.MakeInput<float>({2}, 0.0f, 1.0f);
+  NodeArg* sum_a = builder.MakeIntermediate<float>({2});
+  NodeArg* sum_b = builder.MakeIntermediate<float>({2});
+  NodeArg* left = builder.MakeOutput<float>({2});
+  NodeArg* right = builder.MakeOutput<float>({2});
+  builder.AddNode("Add", {x, y}, {sum_a});
+  builder.AddNode("Add", {x, other}, {sum_b});
+  builder.AddNode("Relu", {sum_a}, {left});
+  builder.AddNode("Identity", {sum_b}, {right});
+  builder.SetGraphOutputs();
+  ASSERT_STATUS_OK(graph.Resolve());
+
+  FunctionExtractor extractor(function_proto);
+  const FunctionExtractionResult result = extractor.Extract(graph);
+  ASSERT_STATUS_OK(result.status);
+  EXPECT_EQ(result.replacements_applied, 0u);
+  EXPECT_EQ(CountOp(graph, kFunctionDomain, function_proto.name()), 0u);
+}
+
+TEST_F(FunctionExtractorTest, EnumeratesOutputRootsDeterministically) {
+  const FunctionProto function_proto = MakeLinearFunction();
+  auto model = MakeModel(function_proto);
+  Graph& graph = model->MainGraph();
+  ModelTestBuilder builder(graph);
+  NodeArg* x = builder.MakeInput<float>({2}, 0.0f, 1.0f);
+  NodeArg* y = builder.MakeInput<float>({2}, 0.0f, 1.0f);
+  NodeArg* first = builder.MakeOutput<float>({2});
+  NodeArg* second = builder.MakeOutput<float>({2});
+  AddLinearTarget(builder, x, y, first);
+  AddLinearTarget(builder, x, y, second);
+  builder.SetGraphOutputs();
+  ASSERT_STATUS_OK(graph.Resolve());
+
+  using namespace function_extractor_internal;
+  const NormalizedFunctionPattern normalized =
+      NormalizeFunctionPattern(function_proto, FunctionExtractorOptions{});
+  CompiledFunctionPattern compiled;
+  ASSERT_STATUS_OK(CompileFunctionPattern(normalized, graph, compiled));
+  TargetGraphSnapshot snapshot;
+  ASSERT_STATUS_OK(BuildTargetGraphSnapshot(graph, compiled, FunctionExtractorOptions{}, snapshot));
+  std::vector<ReplacementPlan> plans;
+  ASSERT_STATUS_OK(DiscoverReplacementPlans(compiled, snapshot, FunctionExtractorOptions{}, plans));
+  ASSERT_EQ(plans.size(), 2u);
+  EXPECT_LT(plans[0].primary_root_topological_position,
+            plans[1].primary_root_topological_position);
+}
+
+TEST_F(FunctionExtractorTest, MatchesRepeatedAndAliasedFormalInputs) {
+  const std::vector<NodeDef> nodes{
+      {{"sum"}, "Add", {"x", "x"}},
+      {{"out"}, "Mul", {"sum", "y"}},
+  };
+  const FunctionProto function_proto =
+      MakeFunction("AliasedInputs", nodes, std::vector<std::string>{"x", "y"},
+                   std::vector<std::string>{"out"});
+  auto model = MakeModel(function_proto);
+  Graph& graph = model->MainGraph();
+  ModelTestBuilder builder(graph);
+  NodeArg* input = builder.MakeInput<float>({2}, 0.0f, 1.0f);
+  NodeArg* sum = builder.MakeIntermediate<float>({2});
+  NodeArg* output = builder.MakeOutput<float>({2});
+  builder.AddNode("Add", {input, input}, {sum});
+  builder.AddNode("Mul", {sum, input}, {output});
+  builder.SetGraphOutputs();
+  ASSERT_STATUS_OK(graph.Resolve());
+
+  FunctionExtractor extractor(function_proto);
+  const FunctionExtractionResult result = extractor.Extract(graph);
+  ASSERT_STATUS_OK(result.status);
+  ASSERT_EQ(result.replacements_applied, 1u);
+  const Node& call = FindOnlyOp(graph, kFunctionDomain, function_proto.name());
+  AssertCallIO(call, std::vector<std::string>{input->Name(), input->Name()},
+               std::vector<std::string>{output->Name()});
+}
+
+TEST_F(FunctionExtractorTest, RejectsReversedInternalOperands) {
+  const std::vector<NodeDef> nodes{
+      {{"difference"}, "Sub", {"x", "y"}},
+      {{"out"}, "Div", {"difference", "y"}},
+  };
+  const FunctionProto function_proto =
+      MakeFunction("Positional", nodes, std::vector<std::string>{"x", "y"},
+                   std::vector<std::string>{"out"});
+  auto model = MakeModel(function_proto);
+  Graph& graph = model->MainGraph();
+  ModelTestBuilder builder(graph);
+  NodeArg* x = builder.MakeInput<float>({2}, 0.0f, 1.0f);
+  NodeArg* y = builder.MakeInput<float>({2}, 0.0f, 1.0f);
+  NodeArg* difference = builder.MakeIntermediate<float>({2});
+  NodeArg* output = builder.MakeOutput<float>({2});
+  builder.AddNode("Sub", {x, y}, {difference});
+  builder.AddNode("Div", {y, difference}, {output});
+  builder.SetGraphOutputs();
+  ASSERT_STATUS_OK(graph.Resolve());
+
+  FunctionExtractor extractor(function_proto);
+  const FunctionExtractionResult result = extractor.Extract(graph);
+  ASSERT_STATUS_OK(result.status);
+  EXPECT_EQ(result.replacements_applied, 0u);
+}
+
+TEST_F(FunctionExtractorTest, RootIndexAllowsExternalProducerAndOutputFanout) {
+  const FunctionProto function_proto = MakeLinearFunction();
+  auto model = MakeModel(function_proto);
+  Graph& graph = model->MainGraph();
+  ModelTestBuilder builder(graph);
+  NodeArg* source = builder.MakeInput<float>({2}, -1.0f, 1.0f);
+  NodeArg* x = builder.MakeIntermediate<float>({2});
+  NodeArg* y = builder.MakeInput<float>({2}, 0.0f, 1.0f);
+  NodeArg* sum = builder.MakeIntermediate<float>({2});
+  NodeArg* matched_output = builder.MakeIntermediate<float>({2});
+  NodeArg* output_a = builder.MakeOutput<float>({2});
+  NodeArg* output_b = builder.MakeOutput<float>({2});
+  builder.AddNode("Abs", {source}, {x});
+  builder.AddNode("Add", {x, y}, {sum});
+  builder.AddNode("Relu", {sum}, {matched_output});
+  builder.AddNode("Identity", {matched_output}, {output_a});
+  builder.AddNode("Neg", {matched_output}, {output_b});
+  builder.SetGraphOutputs();
+  ASSERT_STATUS_OK(graph.Resolve());
+
+  FunctionExtractor extractor(function_proto);
+  const FunctionExtractionResult result = extractor.Extract(graph);
+  ASSERT_STATUS_OK(result.status);
+  EXPECT_EQ(result.replacements_applied, 1u);
+  EXPECT_EQ(graph.GetConsumerNodes(matched_output->Name()).size(), 2u);
+}
+
+TEST_F(FunctionExtractorTest, RequiresExactOperatorIdentityAndArity) {
+  const FunctionProto function_proto = MakeLinearFunction();
+  for (const std::string& second_op : {"Sigmoid", "Neg"}) {
+    SCOPED_TRACE(second_op);
+    auto model = MakeModel(function_proto);
+    Graph& graph = model->MainGraph();
+    ModelTestBuilder builder(graph);
+    NodeArg* x = builder.MakeInput<float>({2}, 0.0f, 1.0f);
+    NodeArg* y = builder.MakeInput<float>({2}, 0.0f, 1.0f);
+    NodeArg* sum = builder.MakeIntermediate<float>({2});
+    NodeArg* output = builder.MakeOutput<float>({2});
+    builder.AddNode("Add", {x, y}, {sum});
+    builder.AddNode(second_op, {sum}, {output});
+    builder.SetGraphOutputs();
+    ASSERT_STATUS_OK(graph.Resolve());
+
+    FunctionExtractor extractor(function_proto);
+    const FunctionExtractionResult result = extractor.Extract(graph);
+    ASSERT_STATUS_OK(result.status);
+    EXPECT_EQ(result.replacements_applied, 0u);
+  }
+}
+
+TEST_F(FunctionExtractorTest, RequiresExactEffectiveAttributes) {
+  const std::vector<NodeDef> nodes{
+      {{"transposed"}, "Transpose", {"x"}, {ONNX_NAMESPACE::MakeAttribute("perm", std::vector<int64_t>{1, 0})}},
+      {{"out"}, "Relu", {"transposed"}},
+  };
+  const FunctionProto function_proto =
+      MakeFunction("Attributes", nodes, std::vector<std::string>{"x"},
+                   std::vector<std::string>{"out"});
+
+  for (const std::vector<int64_t>& perm :
+       {std::vector<int64_t>{1, 0}, std::vector<int64_t>{0, 1}}) {
+    SCOPED_TRACE(::testing::PrintToString(perm));
+    auto model = MakeModel(function_proto);
+    Graph& graph = model->MainGraph();
+    ModelTestBuilder builder(graph);
+    NodeArg* input = builder.MakeInput<float>({2, 2}, 0.0f, 1.0f);
+    NodeArg* transposed = builder.MakeIntermediate<float>({2, 2});
+    NodeArg* output = builder.MakeOutput<float>({2, 2});
+    NodeAttributes attributes{{"perm", ONNX_NAMESPACE::MakeAttribute("perm", perm)}};
+    builder.AddNode("Transpose", {input}, {transposed}, kOnnxDomain, &attributes);
+    builder.AddNode("Relu", {transposed}, {output});
+    builder.SetGraphOutputs();
+    ASSERT_STATUS_OK(graph.Resolve());
+
+    FunctionExtractor extractor(function_proto);
+    const FunctionExtractionResult result = extractor.Extract(graph);
+    ASSERT_STATUS_OK(result.status);
+    EXPECT_EQ(result.replacements_applied, perm == std::vector<int64_t>({1, 0}) ? 1u : 0u);
+  }
+}
+
+TEST_F(FunctionExtractorTest, MatchesOptionalAndVariadicSlotsPositionally) {
+  const std::vector<NodeDef> nodes{
+      {{"clipped"}, "Clip", {"x", "", ""}},
+      {{"out"}, "Concat", {"clipped", "y"}, {ONNX_NAMESPACE::MakeAttribute("axis", int64_t{0})}},
+  };
+  const FunctionProto function_proto =
+      MakeFunction("OptionalVariadic", nodes, std::vector<std::string>{"x", "y"},
+                   std::vector<std::string>{"out"});
+  auto model = MakeModel(function_proto);
+  Graph& graph = model->MainGraph();
+  ModelTestBuilder builder(graph);
+  NodeArg* x = builder.MakeInput<float>({1}, 0.0f, 1.0f);
+  NodeArg* y = builder.MakeInput<float>({1}, 0.0f, 1.0f);
+  NodeArg* empty = builder.MakeEmptyInput();
+  NodeArg* clipped = builder.MakeIntermediate<float>({1});
+  NodeArg* output = builder.MakeOutput<float>({2});
+  builder.AddNode("Clip", {x, empty, empty}, {clipped});
+  NodeAttributes attributes{{"axis", ONNX_NAMESPACE::MakeAttribute("axis", int64_t{0})}};
+  builder.AddNode("Concat", {clipped, y}, {output}, kOnnxDomain, &attributes);
+  builder.SetGraphOutputs();
+  ASSERT_STATUS_OK(graph.Resolve());
+
+  FunctionExtractor extractor(function_proto);
+  const FunctionExtractionResult result = extractor.Extract(graph);
+  ASSERT_STATUS_OK(result.status);
+  EXPECT_EQ(result.replacements_applied, 1u);
+}
+
+TEST_F(FunctionExtractorTest, AppliesKnownTypeCompatibilityRules) {
+  const FunctionProto function_proto = MakeLinearFunction();
+  for (const std::vector<int64_t>& shape :
+       {std::vector<int64_t>{2}, std::vector<int64_t>{2, 1}}) {
+    SCOPED_TRACE(::testing::PrintToString(shape));
+    auto model = MakeModel(function_proto);
+    Graph& graph = model->MainGraph();
+    ModelTestBuilder builder(graph);
+    NodeArg* x = builder.MakeInput<float>(shape, 0.0f, 1.0f);
+    NodeArg* y = builder.MakeInput<float>(shape, 0.0f, 1.0f);
+    NodeArg* sum = builder.MakeIntermediate<float>(shape);
+    NodeArg* output = builder.MakeOutput<float>(shape);
+    builder.AddNode("Add", {x, y}, {sum});
+    builder.AddNode("Relu", {sum}, {output});
+    builder.SetGraphOutputs();
+    ASSERT_STATUS_OK(graph.Resolve());
+
+    FunctionExtractor extractor(function_proto);
+    const FunctionExtractionResult result = extractor.Extract(graph);
+    ASSERT_STATUS_OK(result.status);
+    EXPECT_EQ(result.replacements_applied, 1u);
+  }
+}
+
+TEST_F(FunctionExtractorTest, ComparesFloatingAndTensorBitsExactly) {
+  auto make_float_tensor = [](uint32_t bits) {
+    ONNX_NAMESPACE::TensorProto tensor;
+    tensor.set_data_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+    tensor.add_dims(1);
+    tensor.set_raw_data(&bits, sizeof(bits));
+    return tensor;
+  };
+
+  using function_extractor_internal::CompareTensorLiterals;
+  bool equal = true;
+  ASSERT_STATUS_OK(CompareTensorLiterals(
+      make_float_tensor(0x00000000u), make_float_tensor(0x80000000u), 1024, equal));
+  EXPECT_FALSE(equal);
+  ASSERT_STATUS_OK(CompareTensorLiterals(
+      make_float_tensor(0x7fc00001u), make_float_tensor(0x7fc00002u), 1024, equal));
+  EXPECT_FALSE(equal);
+  ASSERT_STATUS_OK(CompareTensorLiterals(
+      make_float_tensor(0x7fc00001u), make_float_tensor(0x7fc00001u), 1024, equal));
+  EXPECT_TRUE(equal);
+}
+
+TEST_F(FunctionExtractorTest, MatchesLiteralFromInitializer) {
+  const FunctionProto function_proto = MakeLiteralFunction();
+  auto model = MakeModel(function_proto);
+  Graph& graph = model->MainGraph();
+  ModelTestBuilder builder(graph);
+  NodeArg* input = builder.MakeInput<float>({2}, 0.0f, 1.0f);
+  NodeArg* literal = builder.MakeScalarInitializer<float>(1.0f);
+  NodeArg* sum = builder.MakeIntermediate<float>({2});
+  NodeArg* output = builder.MakeOutput<float>({2});
+  builder.AddNode("Add", {input, literal}, {sum});
+  builder.AddNode("Relu", {sum}, {output});
+  builder.SetGraphOutputs();
+  ASSERT_STATUS_OK(graph.Resolve());
+  const std::string literal_name = literal->Name();
+
+  FunctionExtractor extractor(function_proto);
+  const FunctionExtractionResult result = extractor.Extract(graph);
+  ASSERT_STATUS_OK(result.status);
+  ASSERT_EQ(result.replacements_applied, 1u);
+  const ONNX_NAMESPACE::TensorProto* retained_literal = nullptr;
+  EXPECT_TRUE(graph.GetInitializedTensor(literal_name, retained_literal));
+  EXPECT_NE(retained_literal, nullptr);
+  const Node& call = FindOnlyOp(graph, kFunctionDomain, function_proto.name());
+  AssertCallIO(call, std::vector<std::string>{input->Name()},
+               std::vector<std::string>{output->Name()});
+}
+
+TEST_F(FunctionExtractorTest, MatchesLiteralFromConstantNode) {
+  const FunctionProto function_proto = MakeLiteralFunction();
+  auto model = MakeModel(function_proto);
+  Graph& graph = model->MainGraph();
+  ModelTestBuilder builder(graph);
+  NodeArg* input = builder.MakeInput<float>({2}, 0.0f, 1.0f);
+  NodeArg* literal = builder.MakeIntermediate<float>({});
+  NodeArg* sum = builder.MakeIntermediate<float>({2});
+  NodeArg* output = builder.MakeOutput<float>({2});
+  NodeAttributes constant_attributes{
+      {"value", ONNX_NAMESPACE::MakeAttribute(
+                    "value", ONNX_NAMESPACE::ToTensor<float>(1.0f))}};
+  builder.AddNode("Constant", {}, {literal}, kOnnxDomain, &constant_attributes);
+  builder.AddNode("Add", {input, literal}, {sum});
+  builder.AddNode("Relu", {sum}, {output});
+  builder.SetGraphOutputs();
+  ASSERT_STATUS_OK(graph.Resolve());
+
+  FunctionExtractor extractor(function_proto);
+  const FunctionExtractionResult result = extractor.Extract(graph);
+  ASSERT_STATUS_OK(result.status);
+  ASSERT_EQ(result.replacements_applied, 1u);
+  EXPECT_EQ(CountOp(graph, kOnnxDomain, "Constant"), 1u);
+}
+
+TEST_F(FunctionExtractorTest, LeavesSharedAndDeadLiteralWitnesses) {
+  const FunctionProto function_proto = MakeLiteralFunction();
+  auto model = MakeModel(function_proto);
+  Graph& graph = model->MainGraph();
+  ModelTestBuilder builder(graph);
+  NodeArg* input = builder.MakeInput<float>({2}, 0.0f, 1.0f);
+  NodeArg* literal = builder.MakeScalarInitializer<float>(1.0f);
+  NodeArg* sum = builder.MakeIntermediate<float>({2});
+  NodeArg* matched_output = builder.MakeIntermediate<float>({2});
+  NodeArg* graph_output = builder.MakeOutput<float>({2});
+  builder.AddNode("Add", {input, literal}, {sum});
+  builder.AddNode("Relu", {sum}, {matched_output});
+  builder.AddNode("Add", {matched_output, literal}, {graph_output});
+  builder.SetGraphOutputs();
+  ASSERT_STATUS_OK(graph.Resolve());
+  const std::string literal_name = literal->Name();
+
+  FunctionExtractor extractor(function_proto);
+  const FunctionExtractionResult result = extractor.Extract(graph);
+  ASSERT_STATUS_OK(result.status);
+  ASSERT_EQ(result.replacements_applied, 1u);
+  const ONNX_NAMESPACE::TensorProto* retained_literal = nullptr;
+  EXPECT_TRUE(graph.GetInitializedTensor(literal_name, retained_literal));
+  EXPECT_NE(retained_literal, nullptr);
+}
+
+TEST_F(FunctionExtractorTest, RejectsOverridableInitializerLiteral) {
+  const FunctionProto function_proto = MakeLiteralFunction();
+  auto model = MakeModel(function_proto);
+  Graph& graph = model->MainGraph();
+  ModelTestBuilder builder(graph);
+  NodeArg* input = builder.MakeInput<float>({2}, 0.0f, 1.0f);
+  NodeArg* literal = builder.MakeScalarInitializer<float>(1.0f);
+  NodeArg* sum = builder.MakeIntermediate<float>({2});
+  NodeArg* output = builder.MakeOutput<float>({2});
+  builder.AddNode("Add", {input, literal}, {sum});
+  builder.AddNode("Relu", {sum}, {output});
+  builder.SetGraphOutputs();
+  graph.SetInputs({input, literal});
+  ASSERT_STATUS_OK(graph.Resolve());
+
+  FunctionExtractor extractor(function_proto);
+  const FunctionExtractionResult result = extractor.Extract(graph);
+  ASSERT_STATUS_OK(result.status);
+  EXPECT_EQ(result.replacements_applied, 0u);
+}
+
+TEST_F(FunctionExtractorTest, RejectsLiteralFormalInputAlias) {
+  const FunctionProto function_proto = MakeLiteralFunction();
+  auto model = MakeModel(function_proto);
+  Graph& graph = model->MainGraph();
+  ModelTestBuilder builder(graph);
+  NodeArg* literal = builder.MakeScalarInitializer<float>(1.0f);
+  NodeArg* sum = builder.MakeIntermediate<float>({2});
+  NodeArg* output = builder.MakeOutput<float>({2});
+  builder.AddNode("Add", {literal, literal}, {sum});
+  builder.AddNode("Relu", {sum}, {output});
+  builder.SetGraphOutputs();
+  ASSERT_STATUS_OK(graph.Resolve());
+
+  FunctionExtractor extractor(function_proto);
+  const FunctionExtractionResult result = extractor.Extract(graph);
+  ASSERT_STATUS_OK(result.status);
+  EXPECT_EQ(result.replacements_applied, 0u);
+}
+
+TEST_F(FunctionExtractorTest, AllowsEqualLiteralsToShareWitness) {
+  const std::vector<NodeDef> nodes{
+      ONNX_NAMESPACE::FunctionBodyHelper::Const<float>("one_a", 1.0f),
+      ONNX_NAMESPACE::FunctionBodyHelper::Const<float>("one_b", 1.0f),
+      {{"sum"}, "Add", {"x", "one_a"}},
+      {{"out"}, "Mul", {"sum", "one_b"}},
+  };
+  const FunctionProto function_proto =
+      MakeFunction("SharedLiteral", nodes, std::vector<std::string>{"x"},
+                   std::vector<std::string>{"out"});
+  auto model = MakeModel(function_proto);
+  Graph& graph = model->MainGraph();
+  ModelTestBuilder builder(graph);
+  NodeArg* input = builder.MakeInput<float>({2}, 0.0f, 1.0f);
+  NodeArg* literal = builder.MakeScalarInitializer<float>(1.0f);
+  NodeArg* sum = builder.MakeIntermediate<float>({2});
+  NodeArg* output = builder.MakeOutput<float>({2});
+  builder.AddNode("Add", {input, literal}, {sum});
+  builder.AddNode("Mul", {sum, literal}, {output});
+  builder.SetGraphOutputs();
+  ASSERT_STATUS_OK(graph.Resolve());
+
+  FunctionExtractor extractor(function_proto);
+  const FunctionExtractionResult result = extractor.Extract(graph);
+  ASSERT_STATUS_OK(result.status);
+  EXPECT_EQ(result.replacements_applied, 1u);
+}
+
+TEST_F(FunctionExtractorTest, RejectsPrivateIntermediateExternalConsumer) {
+  const FunctionProto function_proto = MakeLinearFunction();
+  auto model = MakeModel(function_proto);
+  Graph& graph = model->MainGraph();
+  ModelTestBuilder builder(graph);
+  NodeArg* x = builder.MakeInput<float>({2}, 0.0f, 1.0f);
+  NodeArg* y = builder.MakeInput<float>({2}, 0.0f, 1.0f);
+  NodeArg* sum = builder.MakeIntermediate<float>({2});
+  NodeArg* matched_output = builder.MakeOutput<float>({2});
+  NodeArg* side_output = builder.MakeOutput<float>({2});
+  builder.AddNode("Add", {x, y}, {sum});
+  builder.AddNode("Relu", {sum}, {matched_output});
+  builder.AddNode("Neg", {sum}, {side_output});
+  builder.SetGraphOutputs();
+  ASSERT_STATUS_OK(graph.Resolve());
+
+  FunctionExtractor extractor(function_proto);
+  const FunctionExtractionResult result = extractor.Extract(graph);
+  ASSERT_STATUS_OK(result.status);
+  EXPECT_EQ(result.replacements_applied, 0u);
+}
+
+TEST_F(FunctionExtractorTest, RejectsPrivateIntermediateGraphOutput) {
+  const FunctionProto function_proto = MakeLinearFunction();
+  auto model = MakeModel(function_proto);
+  Graph& graph = model->MainGraph();
+  ModelTestBuilder builder(graph);
+  NodeArg* x = builder.MakeInput<float>({2}, 0.0f, 1.0f);
+  NodeArg* y = builder.MakeInput<float>({2}, 0.0f, 1.0f);
+  NodeArg* sum = builder.MakeOutput<float>({2});
+  NodeArg* matched_output = builder.MakeOutput<float>({2});
+  builder.AddNode("Add", {x, y}, {sum});
+  builder.AddNode("Relu", {sum}, {matched_output});
+  builder.SetGraphOutputs();
+  ASSERT_STATUS_OK(graph.Resolve());
+
+  FunctionExtractor extractor(function_proto);
+  const FunctionExtractionResult result = extractor.Extract(graph);
+  ASSERT_STATUS_OK(result.status);
+  EXPECT_EQ(result.replacements_applied, 0u);
+}
+
+TEST_F(FunctionExtractorTest, RejectsPrivateIntermediateImplicitCapture) {
+  const FunctionProto function_proto = MakeLinearFunction();
+  auto model = MakeModel(function_proto);
+  Graph& graph = model->MainGraph();
+  ModelTestBuilder builder(graph);
+  NodeArg* x = builder.MakeInput<float>({2}, 0.0f, 1.0f);
+  NodeArg* y = builder.MakeInput<float>({2}, 0.0f, 1.0f);
+  NodeArg* sum = builder.MakeIntermediate<float>({2});
+  NodeArg* matched_output = builder.MakeOutput<float>({2});
+  builder.AddNode("Add", {x, y}, {sum});
+  builder.AddNode("Relu", {sum}, {matched_output});
+  Node& if_node = AddCapturingIf(builder, *sum);
+  builder.SetGraphOutputs();
+  ASSERT_STATUS_OK(graph.Resolve());
+  ASSERT_EQ(if_node.ImplicitInputDefs().size(), 1u);
+  ASSERT_EQ(if_node.ImplicitInputDefs()[0]->Name(), sum->Name());
+
+  FunctionExtractor extractor(function_proto);
+  const FunctionExtractionResult result = extractor.Extract(graph);
+  ASSERT_STATUS_OK(result.status);
+  EXPECT_EQ(result.replacements_applied, 0u);
+}
+
+TEST_F(FunctionExtractorTest, PreservesFormalOutputConsumersAndImplicitCaptures) {
+  const FunctionProto function_proto = MakeLinearFunction();
+  auto model = MakeModel(function_proto);
+  Graph& graph = model->MainGraph();
+  ModelTestBuilder builder(graph);
+  NodeArg* x = builder.MakeInput<float>({2}, 0.0f, 1.0f);
+  NodeArg* y = builder.MakeInput<float>({2}, 0.0f, 1.0f);
+  NodeArg* sum = builder.MakeIntermediate<float>({2});
+  NodeArg* matched_output = builder.MakeIntermediate<float>({2});
+  NodeArg* explicit_output = builder.MakeOutput<float>({2});
+  builder.AddNode("Add", {x, y}, {sum});
+  builder.AddNode("Relu", {sum}, {matched_output});
+  builder.AddNode("Identity", {matched_output}, {explicit_output});
+  Node& if_node = AddCapturingIf(builder, *matched_output);
+  builder.SetGraphOutputs();
+  ASSERT_STATUS_OK(graph.Resolve());
+  ASSERT_EQ(if_node.ImplicitInputDefs().size(), 1u);
+
+  FunctionExtractor extractor(function_proto);
+  const FunctionExtractionResult result = extractor.Extract(graph);
+  ASSERT_STATUS_OK(result.status);
+  ASSERT_EQ(result.replacements_applied, 1u);
+  AssertResolved(graph);
+  const Node& remaining_if = FindOnlyOp(graph, kOnnxDomain, "If");
+  ASSERT_EQ(remaining_if.ImplicitInputDefs().size(), 1u);
+  EXPECT_EQ(remaining_if.ImplicitInputDefs()[0]->Name(), matched_output->Name());
+  EXPECT_EQ(graph.GetConsumerNodes(matched_output->Name()).size(), 2u);
+}
+
+TEST_F(FunctionExtractorTest, RejectsDownstreamFormalInputBinding) {
+  const std::vector<NodeDef> nodes{{{"activated"}, "Relu", {"x"}},
+                                   {{"out"}, "Add", {"activated", "y"}}};
+  const FunctionProto function_proto =
+      MakeFunction("DownstreamInput", nodes, std::vector<std::string>{"x", "y"},
+                   std::vector<std::string>{"out"});
+  auto model = MakeModel(function_proto);
+  Graph& graph = model->MainGraph();
+  ModelTestBuilder builder(graph);
+  NodeArg* x = builder.MakeInput<float>({2}, 0.0f, 1.0f);
+  NodeArg* activated = builder.MakeIntermediate<float>({2});
+  NodeArg* downstream = builder.MakeIntermediate<float>({2});
+  NodeArg* output = builder.MakeOutput<float>({2});
+  builder.AddNode("Relu", {x}, {activated});
+  builder.AddNode("Identity", {activated}, {downstream});
+  builder.AddNode("Add", {activated, downstream}, {output});
+  builder.SetGraphOutputs();
+  ASSERT_STATUS_OK(graph.Resolve());
+
+  FunctionExtractor extractor(function_proto);
+  const FunctionExtractionResult result = extractor.Extract(graph);
+  ASSERT_STATUS_OK(result.status);
+  EXPECT_EQ(result.replacements_applied, 0u);
+}
+
+TEST_F(FunctionExtractorTest, RejectsNonConvexLeaveAndReenterPath) {
+  const std::vector<NodeDef> nodes{{{"activated"}, "Relu", {"x"}},
+                                   {{"out"}, "Add", {"activated", "y"}}};
+  const FunctionProto function_proto =
+      MakeFunction("NonConvex", nodes, std::vector<std::string>{"x", "y"},
+                   std::vector<std::string>{"out"});
+  auto model = MakeModel(function_proto);
+  Graph& graph = model->MainGraph();
+  ModelTestBuilder builder(graph);
+  NodeArg* x = builder.MakeInput<float>({2}, 0.0f, 1.0f);
+  NodeArg* activated = builder.MakeIntermediate<float>({2});
+  NodeArg* outside = builder.MakeIntermediate<float>({2});
+  NodeArg* output = builder.MakeOutput<float>({2});
+  builder.AddNode("Relu", {x}, {activated});
+  builder.AddNode("Identity", {activated}, {outside});
+  builder.AddNode("Add", {activated, outside}, {output});
+  builder.SetGraphOutputs();
+  ASSERT_STATUS_OK(graph.Resolve());
+
+  FunctionExtractor extractor(function_proto);
+  const FunctionExtractionResult result = extractor.Extract(graph);
+  ASSERT_STATUS_OK(result.status);
+  EXPECT_EQ(result.replacements_applied, 0u);
+}
+
+TEST_F(FunctionExtractorTest, RejectsProviderControlOrAnnotationMismatch) {
+  const FunctionProto function_proto = MakeLinearFunction();
+  for (size_t variant = 0; variant < 2; ++variant) {
+    SCOPED_TRACE(variant);
+    auto model = MakeModel(function_proto);
+    Graph& graph = model->MainGraph();
+    NodeArg* x;
+    NodeArg* y;
+    NodeArg* sum;
+    NodeArg* output;
+    BuildLinearTarget(graph, x, y, sum, output);
+    ASSERT_STATUS_OK(graph.Resolve());
+    auto nodes = graph.Nodes();
+    auto node_it = nodes.begin();
+    Node& first = *node_it;
+    Node& second = *++node_it;
+    if (variant == 0) {
+      first.SetExecutionProviderType(kCpuExecutionProvider);
+    } else {
+      first.SetLayeringAnnotation("layer-a");
+      second.SetLayeringAnnotation("layer-b");
+    }
+
+    FunctionExtractor extractor(function_proto);
+    const FunctionExtractionResult result = extractor.Extract(graph);
+    ASSERT_STATUS_OK(result.status);
+    EXPECT_EQ(result.replacements_applied, 0u);
+  }
+}
+
+TEST_F(FunctionExtractorTest, DoesNotCrossGraphScopes) {
+  const FunctionProto function_proto = MakeLinearFunction();
+  auto model = MakeModel(function_proto);
+  Graph& graph = model->MainGraph();
+  ModelTestBuilder builder(graph);
+  NodeArg* x = builder.MakeInput<float>({2}, 0.0f, 1.0f);
+  NodeArg* y = builder.MakeInput<float>({2}, 0.0f, 1.0f);
+  NodeArg* sum = builder.MakeIntermediate<float>({2});
+  builder.AddNode("Add", {x, y}, {sum});
+  AddCapturingIf(builder, *sum, "Relu");
+  builder.SetGraphOutputs();
+  ASSERT_STATUS_OK(graph.Resolve());
+
+  FunctionExtractor extractor(function_proto);
+  const FunctionExtractionResult result = extractor.Extract(graph);
+  ASSERT_STATUS_OK(result.status);
+  EXPECT_EQ(result.replacements_applied, 0u);
+  EXPECT_EQ(CountOp(graph, kOnnxDomain, "Add"), 1u);
+  EXPECT_EQ(CountOp(graph, kFunctionDomain, function_proto.name()), 0u);
+}
+
+TEST_F(FunctionExtractorTest, AppliesDisjointMatchesInOneBatch) {
+  const FunctionProto function_proto = MakeLinearFunction();
+  auto model = MakeModel(function_proto);
+  Graph& graph = model->MainGraph();
+  ModelTestBuilder builder(graph);
+  NodeArg* x = builder.MakeInput<float>({2}, 0.0f, 1.0f);
+  NodeArg* y = builder.MakeInput<float>({2}, 0.0f, 1.0f);
+  NodeArg* first = builder.MakeOutput<float>({2});
+  NodeArg* second = builder.MakeOutput<float>({2});
+  AddLinearTarget(builder, x, y, first);
+  AddLinearTarget(builder, x, y, second);
+  builder.SetGraphOutputs();
+  ASSERT_STATUS_OK(graph.Resolve());
+
+  FunctionExtractor extractor(function_proto);
+  const FunctionExtractionResult result = extractor.Extract(graph);
+  ASSERT_STATUS_OK(result.status);
+  EXPECT_EQ(result.replacements_applied, 2u);
+  EXPECT_EQ(CountOp(graph, kFunctionDomain, function_proto.name()), 2u);
+  EXPECT_EQ(graph.NumberOfNodes(), 2u);
+}
+
+TEST_F(FunctionExtractorTest, SelectsOverlappingMatchesDeterministically) {
+  const std::vector<NodeDef> nodes{
+      {{"sum"}, "Add", {"x", "y"}},
+      {{"out"}, "Relu", {"sum"}},
+  };
+  const FunctionProto function_proto =
+      MakeFunction("Overlapping", nodes, std::vector<std::string>{"x", "y"},
+                   std::vector<std::string>{"sum", "out"});
+  auto model = MakeModel(function_proto);
+  Graph& graph = model->MainGraph();
+  ModelTestBuilder builder(graph);
+  NodeArg* x = builder.MakeInput<float>({2}, 0.0f, 1.0f);
+  NodeArg* y = builder.MakeInput<float>({2}, 0.0f, 1.0f);
+  NodeArg* sum = builder.MakeIntermediate<float>({2});
+  NodeArg* first = builder.MakeOutput<float>({2});
+  NodeArg* second = builder.MakeOutput<float>({2});
+  builder.AddNode("Add", {x, y}, {sum});
+  builder.AddNode("Relu", {sum}, {first});
+  builder.AddNode("Relu", {sum}, {second});
+  builder.SetGraphOutputs();
+  ASSERT_STATUS_OK(graph.Resolve());
+
+  FunctionExtractor extractor(function_proto);
+  const FunctionExtractionResult result = extractor.Extract(graph);
+  ASSERT_STATUS_OK(result.status);
+  ASSERT_EQ(result.replacements_applied, 1u);
+  const Node& call = FindOnlyOp(graph, kFunctionDomain, function_proto.name());
+  ASSERT_EQ(call.OutputDefs().size(), 2u);
+  EXPECT_EQ(call.OutputDefs()[0]->Name(), sum->Name());
+  EXPECT_EQ(call.OutputDefs()[1]->Name(), first->Name());
+  EXPECT_EQ(CountOp(graph, kOnnxDomain, "Relu"), 1u);
+}
+
+TEST_F(FunctionExtractorTest, DefersBoundaryAdjacentMatchToNextPass) {
+  const FunctionProto function_proto = MakeLinearFunction();
+  auto model = MakeModel(function_proto);
+  Graph& graph = model->MainGraph();
+  ModelTestBuilder builder(graph);
+  NodeArg* x = builder.MakeInput<float>({2}, 0.0f, 1.0f);
+  NodeArg* y = builder.MakeInput<float>({2}, 0.0f, 1.0f);
+  NodeArg* z = builder.MakeInput<float>({2}, 0.0f, 1.0f);
+  NodeArg* first_sum = builder.MakeIntermediate<float>({2});
+  NodeArg* boundary = builder.MakeIntermediate<float>({2});
+  NodeArg* second_sum = builder.MakeIntermediate<float>({2});
+  NodeArg* output = builder.MakeOutput<float>({2});
+  builder.AddNode("Add", {x, y}, {first_sum});
+  builder.AddNode("Relu", {first_sum}, {boundary});
+  builder.AddNode("Add", {boundary, z}, {second_sum});
+  builder.AddNode("Relu", {second_sum}, {output});
+  builder.SetGraphOutputs();
+  ASSERT_STATUS_OK(graph.Resolve());
+
+  FunctionExtractor extractor(function_proto);
+  const FunctionExtractionResult result = extractor.Extract(graph);
+  ASSERT_STATUS_OK(result.status);
+  EXPECT_EQ(result.replacements_applied, 2u);
+  EXPECT_EQ(CountOp(graph, kFunctionDomain, function_proto.name()), 2u);
+  AssertResolved(graph);
+}
+
+TEST_F(FunctionExtractorTest, AllowsSharedUnrelatedBoundaryValues) {
+  const FunctionProto function_proto = MakeLinearFunction();
+  auto model = MakeModel(function_proto);
+  Graph& graph = model->MainGraph();
+  ModelTestBuilder builder(graph);
+  NodeArg* shared = builder.MakeInput<float>({2}, 0.0f, 1.0f);
+  NodeArg* first = builder.MakeOutput<float>({2});
+  NodeArg* second = builder.MakeOutput<float>({2});
+  AddLinearTarget(builder, shared, shared, first);
+  AddLinearTarget(builder, shared, shared, second);
+  builder.SetGraphOutputs();
+  ASSERT_STATUS_OK(graph.Resolve());
+
+  FunctionExtractor extractor(function_proto);
+  const FunctionExtractionResult result = extractor.Extract(graph);
+  ASSERT_STATUS_OK(result.status);
+  EXPECT_EQ(result.replacements_applied, 2u);
+}
+
+TEST_F(FunctionExtractorTest, RejectsStalePlanBeforeMutation) {
+  const FunctionProto function_proto = MakeLinearFunction();
+  auto model = MakeModel(function_proto);
+  Graph& graph = model->MainGraph();
+  NodeArg* x;
+  NodeArg* y;
+  NodeArg* sum;
+  NodeArg* output;
+  BuildLinearTarget(graph, x, y, sum, output);
+  ASSERT_STATUS_OK(graph.Resolve());
+
+  using namespace function_extractor_internal;
+  const NormalizedFunctionPattern normalized =
+      NormalizeFunctionPattern(function_proto, FunctionExtractorOptions{});
+  CompiledFunctionPattern compiled;
+  ASSERT_STATUS_OK(CompileFunctionPattern(normalized, graph, compiled));
+  TargetGraphSnapshot snapshot;
+  ASSERT_STATUS_OK(BuildTargetGraphSnapshot(graph, compiled, FunctionExtractorOptions{}, snapshot));
+  std::vector<ReplacementPlan> plans;
+  ASSERT_STATUS_OK(DiscoverReplacementPlans(compiled, snapshot, FunctionExtractorOptions{}, plans));
+  ASSERT_EQ(plans.size(), 1u);
+  snapshot.graph_viewer.reset();
+
+  const NodeIndex stale_node_index = plans[0].removable_node_indices.back();
+  ASSERT_TRUE(graph.RemoveNode(stale_node_index));
+  EXPECT_FALSE(PrevalidatePlans(graph, compiled, plans).IsOK());
+  EXPECT_EQ(CountOp(graph, kFunctionDomain, function_proto.name()), 0u);
+}
+
+TEST_F(FunctionExtractorTest, StrictlyDecreasesNodeCountPerReplacement) {
+  const FunctionProto function_proto = MakeLinearFunction();
+  auto model = MakeModel(function_proto);
+  Graph& graph = model->MainGraph();
+  NodeArg* x;
+  NodeArg* y;
+  NodeArg* sum;
+  NodeArg* output;
+  BuildLinearTarget(graph, x, y, sum, output);
+  ASSERT_STATUS_OK(graph.Resolve());
+  const size_t original_node_count = graph.NumberOfNodes();
+
+  FunctionExtractor extractor(function_proto);
+  const FunctionExtractionResult result = extractor.Extract(graph);
+  ASSERT_STATUS_OK(result.status);
+  ASSERT_EQ(result.replacements_applied, 1u);
+  EXPECT_LT(graph.NumberOfNodes(), original_node_count);
+  EXPECT_EQ(graph.NumberOfNodes(), 1u);
+}
+
+TEST_F(FunctionExtractorTest, PreservesOutputIdentityAndFanout) {
+  const FunctionProto function_proto = MakeLinearFunction();
+  auto model = MakeModel(function_proto);
+  Graph& graph = model->MainGraph();
+  ModelTestBuilder builder(graph);
+  NodeArg* x = builder.MakeInput<float>({2}, 0.0f, 1.0f);
+  NodeArg* y = builder.MakeInput<float>({2}, 0.0f, 1.0f);
+  NodeArg* sum = builder.MakeIntermediate<float>({2});
+  NodeArg* pattern_output = builder.MakeIntermediate<float>({2});
+  NodeArg* output_a = builder.MakeOutput<float>({2});
+  NodeArg* output_b = builder.MakeOutput<float>({2});
+  builder.AddNode("Add", {x, y}, {sum});
+  builder.AddNode("Relu", {sum}, {pattern_output});
+  builder.AddNode("Identity", {pattern_output}, {output_a});
+  builder.AddNode("Neg", {pattern_output}, {output_b});
+  builder.SetGraphOutputs();
+  ASSERT_STATUS_OK(graph.Resolve());
+  const std::string pattern_output_name = pattern_output->Name();
+  const ONNX_NAMESPACE::TypeProto pattern_output_type = *pattern_output->TypeAsProto();
+
+  FunctionExtractor extractor(function_proto);
+  const FunctionExtractionResult result = extractor.Extract(graph);
+  ASSERT_STATUS_OK(result.status);
+  ASSERT_EQ(result.replacements_applied, 1u);
+  const Node& call = FindOnlyOp(graph, kFunctionDomain, function_proto.name());
+  ASSERT_EQ(call.OutputDefs()[0]->Name(), pattern_output_name);
+  EXPECT_EQ(call.OutputDefs()[0]->TypeAsProto()->SerializeAsString(),
+            pattern_output_type.SerializeAsString());
+  EXPECT_EQ(graph.GetOutputs()[0]->Name(), output_a->Name());
+  EXPECT_EQ(graph.GetOutputs()[1]->Name(), output_b->Name());
+  EXPECT_EQ(graph.GetConsumerNodes(pattern_output_name).size(), 2u);
+}
+
+TEST_F(FunctionExtractorTest, ReturnsResolvedGraphAtFixpoint) {
+  const FunctionProto function_proto = MakeLinearFunction();
+  auto model = MakeModel(function_proto);
+  Graph& graph = model->MainGraph();
+  NodeArg* x;
+  NodeArg* y;
+  NodeArg* sum;
+  NodeArg* output;
+  BuildLinearTarget(graph, x, y, sum, output);
+  ASSERT_STATUS_OK(graph.Resolve());
+
+  FunctionExtractor extractor(function_proto);
+  const FunctionExtractionResult first = extractor.Extract(graph);
+  ASSERT_STATUS_OK(first.status);
+  EXPECT_EQ(first.replacements_applied, 1u);
+  AssertResolved(graph);
+
+  const FunctionExtractionResult second = extractor.Extract(graph);
+  ASSERT_STATUS_OK(second.status);
+  EXPECT_EQ(second.replacements_applied, 0u);
+  AssertResolved(graph);
+}
+
+TEST_F(FunctionExtractorTest, PersistsRegisteredCallAfterSerializeReload) {
+  const FunctionProto function_proto = MakeLinearFunction();
+  auto model = MakeModel(function_proto);
+  Graph& graph = model->MainGraph();
+  NodeArg* x;
+  NodeArg* y;
+  NodeArg* sum;
+  NodeArg* output;
+  BuildLinearTarget(graph, x, y, sum, output);
+  ASSERT_STATUS_OK(graph.Resolve());
+
+  FunctionExtractor extractor(function_proto);
+  const FunctionExtractionResult result = extractor.Extract(graph);
+  ASSERT_STATUS_OK(result.status);
+  ASSERT_EQ(result.replacements_applied, 1u);
+
+  std::shared_ptr<Model> reloaded_model = SerializeAndReload(*model);
+  ASSERT_NE(reloaded_model, nullptr);
+  AssertResolved(reloaded_model->MainGraph());
+  EXPECT_EQ(CountOp(reloaded_model->MainGraph(), kFunctionDomain, function_proto.name()), 1u);
+  EXPECT_EQ(reloaded_model->ToProto().functions_size(), 1);
+}
+
+TEST_F(FunctionExtractorTest, RoundTripsThroughInlineFunction) {
+  const FunctionProto function_proto = MakeLinearFunction();
+  auto model = MakeModel(function_proto);
+  Graph& graph = model->MainGraph();
+  NodeArg* x;
+  NodeArg* y;
+  NodeArg* sum;
+  NodeArg* output;
+  BuildLinearTarget(graph, x, y, sum, output);
+  ASSERT_STATUS_OK(graph.Resolve());
+
+  FunctionExtractor extractor(function_proto);
+  const FunctionExtractionResult result = extractor.Extract(graph);
+  ASSERT_STATUS_OK(result.status);
+  ASSERT_EQ(result.replacements_applied, 1u);
+  Node& call = FindOnlyOp(graph, kFunctionDomain, function_proto.name());
+  ASSERT_STATUS_OK(graph.InlineFunction(call));
+  ASSERT_STATUS_OK(graph.Resolve());
+  EXPECT_EQ(CountOp(graph, kFunctionDomain, function_proto.name()), 0u);
+  EXPECT_EQ(CountOp(graph, kOnnxDomain, "Add"), 1u);
+  EXPECT_EQ(CountOp(graph, kOnnxDomain, "Relu"), 1u);
+  EXPECT_EQ(graph.GetOutputs()[0]->Name(), output->Name());
+  AssertResolved(graph);
+}
+
+#undef ModelTestBuilder
+
+}  // namespace test
+}  // namespace onnxruntime

--- a/onnxruntime/test/optimizer/function_extractor_test.cc
+++ b/onnxruntime/test/optimizer/function_extractor_test.cc
@@ -282,10 +282,6 @@ TEST_F(FunctionExtractorTest, RejectsInvalidFormalNames) {
 }
 
 TEST_F(FunctionExtractorTest, RejectsInvalidAttributes) {
-  FunctionProto required_attribute = MakeLinearFunction("RequiredAttribute");
-  required_attribute.add_attribute("axis");
-  ExpectConstructionRejected(std::move(required_attribute));
-
   FunctionProto duplicate_declaration = MakeLinearFunction("DuplicateAttribute");
   duplicate_declaration.add_attribute("axis");
   duplicate_declaration.add_attribute("axis");
@@ -307,6 +303,12 @@ TEST_F(FunctionExtractorTest, RejectsInvalidAttributes) {
   ExpectConstructionRejected(std::move(referenced_attribute));
 }
 
+TEST_F(FunctionExtractorTest, RejectsUnusedRequiredFunctionAttribute) {
+  FunctionProto function_proto = MakeLinearFunction("RequiredAttribute");
+  function_proto.add_attribute("axis");
+  ExpectConstructionRejected(std::move(function_proto));
+}
+
 TEST_F(FunctionExtractorTest, RejectsMalformedDataflow) {
   const std::vector<std::string> inputs{"x", "y"};
   const std::vector<std::string> outputs{"out"};
@@ -324,13 +326,15 @@ TEST_F(FunctionExtractorTest, RejectsMalformedDataflow) {
     ExpectConstructionRejected(MakeFunction("Malformed" + std::to_string(i),
                                             invalid_bodies[i], inputs, outputs));
   }
+}
 
-  const std::vector<NodeDef> disconnected_body{
+TEST_F(FunctionExtractorTest, RejectsDisconnectedMultiOutputBody) {
+  const std::vector<NodeDef> nodes{
       {{"left"}, "Add", {"x", "y"}},
       {{"right"}, "Mul", {"z", "w"}},
   };
   ExpectConstructionRejected(
-      MakeFunction("DisconnectedOutputs", disconnected_body,
+      MakeFunction("DisconnectedOutputs", nodes,
                    std::vector<std::string>{"x", "y", "z", "w"},
                    std::vector<std::string>{"left", "right"}));
 }
@@ -848,61 +852,59 @@ TEST_F(FunctionExtractorTest, RequiresExactEffectiveAttributes) {
 }
 
 TEST_F(FunctionExtractorTest, MatchesOptionalAndVariadicSlotsPositionally) {
-  {
-    const std::vector<NodeDef> nodes{
-        {{"clipped"}, "Clip", {"x", "", ""}},
-        {{"out"}, "Concat", {"clipped", "y"}, {ONNX_NAMESPACE::MakeAttribute("axis", int64_t{0})}},
-    };
-    const FunctionProto function_proto =
-        MakeFunction("OptionalVariadic", nodes, std::vector<std::string>{"x", "y"},
-                     std::vector<std::string>{"out"});
-    auto model = MakeModel(function_proto);
-    Graph& graph = model->MainGraph();
-    FunctionExtractorGraphBuilder builder(graph);
-    NodeArg* x = builder.MakeInput<float>({1}, 0.0f, 1.0f);
-    NodeArg* y = builder.MakeInput<float>({1}, 0.0f, 1.0f);
-    NodeArg* empty = builder.MakeEmptyInput();
-    NodeArg* clipped = builder.MakeIntermediate<float>({1});
-    NodeArg* output = builder.MakeOutput<float>({2});
-    builder.AddNode("Clip", {x, empty, empty}, {clipped});
-    NodeAttributes attributes{{"axis", ONNX_NAMESPACE::MakeAttribute("axis", int64_t{0})}};
-    builder.AddNode("Concat", {clipped, y}, {output}, kOnnxDomain, &attributes);
-    builder.SetGraphOutputs();
-    ASSERT_STATUS_OK(graph.Resolve());
+  const std::vector<NodeDef> nodes{
+      {{"clipped"}, "Clip", {"x", "", ""}},
+      {{"out"}, "Concat", {"clipped", "y"}, {ONNX_NAMESPACE::MakeAttribute("axis", int64_t{0})}},
+  };
+  const FunctionProto function_proto =
+      MakeFunction("OptionalVariadic", nodes, std::vector<std::string>{"x", "y"},
+                   std::vector<std::string>{"out"});
+  auto model = MakeModel(function_proto);
+  Graph& graph = model->MainGraph();
+  FunctionExtractorGraphBuilder builder(graph);
+  NodeArg* x = builder.MakeInput<float>({1}, 0.0f, 1.0f);
+  NodeArg* y = builder.MakeInput<float>({1}, 0.0f, 1.0f);
+  NodeArg* empty = builder.MakeEmptyInput();
+  NodeArg* clipped = builder.MakeIntermediate<float>({1});
+  NodeArg* output = builder.MakeOutput<float>({2});
+  builder.AddNode("Clip", {x, empty, empty}, {clipped});
+  NodeAttributes attributes{{"axis", ONNX_NAMESPACE::MakeAttribute("axis", int64_t{0})}};
+  builder.AddNode("Concat", {clipped, y}, {output}, kOnnxDomain, &attributes);
+  builder.SetGraphOutputs();
+  ASSERT_STATUS_OK(graph.Resolve());
 
-    FunctionExtractor extractor(function_proto);
-    const FunctionExtractionResult result = extractor.Extract(graph);
-    ASSERT_STATUS_OK(result.status);
-    EXPECT_EQ(result.replacements_applied, 1u);
-  }
+  FunctionExtractor extractor(function_proto);
+  const FunctionExtractionResult result = extractor.Extract(graph);
+  ASSERT_STATUS_OK(result.status);
+  EXPECT_EQ(result.replacements_applied, 1u);
+}
 
-  {
-    const std::vector<NodeDef> nodes{
-        {{"pooled"}, "MaxPool", {"x"}, {ONNX_NAMESPACE::MakeAttribute("kernel_shape", std::vector<int64_t>{2, 2})}},
-        {{"out"}, "Identity", {"pooled"}},
-    };
-    const FunctionProto function_proto =
-        MakeFunction("OmittedOptionalOutput", nodes, std::vector<std::string>{"x"},
-                     std::vector<std::string>{"out"});
-    auto model = MakeModel(function_proto);
-    Graph& graph = model->MainGraph();
-    FunctionExtractorGraphBuilder builder(graph);
-    NodeArg* x = builder.MakeInput<float>({1, 1, 4, 4}, 0.0f, 1.0f);
-    NodeArg* pooled = builder.MakeIntermediate<float>({1, 1, 3, 3});
-    NodeArg* output = builder.MakeOutput<float>({1, 1, 3, 3});
-    NodeAttributes attributes{
-        {"kernel_shape", ONNX_NAMESPACE::MakeAttribute(
-                             "kernel_shape", std::vector<int64_t>{2, 2})}};
-    builder.AddNode("MaxPool", {x}, {pooled}, kOnnxDomain, &attributes);
-    builder.AddNode("Identity", {pooled}, {output});
-    builder.SetGraphOutputs();
-    ASSERT_STATUS_OK(graph.Resolve());
+TEST_F(FunctionExtractorTest, MatchesOperatorWithOmittedOptionalOutput) {
+  const std::vector<NodeDef> nodes{
+      {{"pooled"}, "MaxPool", {"x"}, {ONNX_NAMESPACE::MakeAttribute("kernel_shape", std::vector<int64_t>{2, 2})}},
+      {{"out"}, "Identity", {"pooled"}},
+  };
+  const FunctionProto function_proto =
+      MakeFunction("OmittedOptionalOutput", nodes, std::vector<std::string>{"x"},
+                   std::vector<std::string>{"out"});
+  auto model = MakeModel(function_proto);
+  Graph& graph = model->MainGraph();
+  FunctionExtractorGraphBuilder builder(graph);
+  NodeArg* x = builder.MakeInput<float>({1, 1, 4, 4}, 0.0f, 1.0f);
+  NodeArg* pooled = builder.MakeIntermediate<float>({1, 1, 3, 3});
+  NodeArg* output = builder.MakeOutput<float>({1, 1, 3, 3});
+  NodeAttributes attributes{
+      {"kernel_shape", ONNX_NAMESPACE::MakeAttribute(
+                           "kernel_shape", std::vector<int64_t>{2, 2})}};
+  builder.AddNode("MaxPool", {x}, {pooled}, kOnnxDomain, &attributes);
+  builder.AddNode("Identity", {pooled}, {output});
+  builder.SetGraphOutputs();
+  ASSERT_STATUS_OK(graph.Resolve());
 
-    FunctionExtractor extractor(function_proto);
-    const FunctionExtractionResult result = extractor.Extract(graph);
-    ASSERT_STATUS_OK(result.status);
-    EXPECT_EQ(result.replacements_applied, 1u);
-  }
+  FunctionExtractor extractor(function_proto);
+  const FunctionExtractionResult result = extractor.Extract(graph);
+  ASSERT_STATUS_OK(result.status);
+  EXPECT_EQ(result.replacements_applied, 1u);
 }
 
 TEST_F(FunctionExtractorTest, AppliesKnownTypeCompatibilityRules) {

--- a/onnxruntime/test/optimizer/function_extractor_test.cc
+++ b/onnxruntime/test/optimizer/function_extractor_test.cc
@@ -46,8 +46,6 @@ class FunctionExtractorGraphBuilder final : public ::onnxruntime::test::ModelTes
   }
 };
 
-#define ModelTestBuilder FunctionExtractorGraphBuilder
-
 FunctionProto MakeFunction(std::string name,
                            gsl::span<const NodeDef> node_defs,
                            gsl::span<const std::string> inputs,
@@ -94,6 +92,19 @@ FunctionProto MakeLiteralFunction(std::string name = "Literal") {
   const std::vector<std::string> inputs{"x"};
   const std::vector<std::string> outputs{"out"};
   return MakeFunction(std::move(name), nodes, inputs, outputs);
+}
+
+void AddTensorValueInfo(FunctionProto& function_proto,
+                        std::string_view name,
+                        int32_t element_type,
+                        gsl::span<const int64_t> dimensions) {
+  auto& value_info = *function_proto.add_value_info();
+  value_info.set_name(std::string{name});
+  auto& tensor_type = *value_info.mutable_type()->mutable_tensor_type();
+  tensor_type.set_elem_type(element_type);
+  for (const int64_t dimension : dimensions) {
+    tensor_type.mutable_shape()->add_dim()->set_dim_value(dimension);
+  }
 }
 
 std::unique_ptr<Model> MakeModel(std::vector<FunctionProto> function_protos) {
@@ -173,7 +184,7 @@ void BuildLinearTarget(Graph& graph,
                        NodeArg*& y,
                        NodeArg*& sum,
                        NodeArg*& output) {
-  ModelTestBuilder builder(graph);
+  FunctionExtractorGraphBuilder builder(graph);
   x = builder.MakeInput<float>({2}, 0.0f, 1.0f);
   y = builder.MakeInput<float>({2}, 0.0f, 1.0f);
   sum = builder.MakeIntermediate<float>({2});
@@ -183,7 +194,7 @@ void BuildLinearTarget(Graph& graph,
   builder.SetGraphOutputs();
 }
 
-void AddLinearTarget(ModelTestBuilder& builder,
+void AddLinearTarget(FunctionExtractorGraphBuilder& builder,
                      NodeArg* x,
                      NodeArg* y,
                      NodeArg* output) {
@@ -211,7 +222,7 @@ ONNX_NAMESPACE::GraphProto MakeCaptureSubgraph(
   return subgraph.ToGraphProto();
 }
 
-Node& AddCapturingIf(ModelTestBuilder& builder, NodeArg& captured,
+Node& AddCapturingIf(FunctionExtractorGraphBuilder& builder, NodeArg& captured,
                      std::string_view op_type = "Identity") {
   NodeArg* condition = builder.MakeInput<bool>({}, std::vector<bool>{true});
   NodeArg* if_output = builder.MakeOutput<float>({2});
@@ -243,6 +254,8 @@ class FunctionExtractorTest : public ::testing::Test {
     EXPECT_EQ(model.MainGraph().NumberOfNodes(), 0u);
   }
 };
+
+// Pattern validation and registration.
 
 TEST_F(FunctionExtractorTest, RejectsInvalidFormalNames) {
   const std::vector<NodeDef> nodes{
@@ -441,7 +454,7 @@ TEST_F(FunctionExtractorTest, ResolvesNestedLocalFunctionIdentity) {
 
   auto model = MakeModel(std::vector<FunctionProto>{nested_function, outer_function});
   Graph& graph = model->MainGraph();
-  ModelTestBuilder builder(graph);
+  FunctionExtractorGraphBuilder builder(graph);
   NodeArg* x = builder.MakeInput<float>({2}, 0.0f, 1.0f);
   NodeArg* y = builder.MakeInput<float>({2}, 0.0f, 1.0f);
   NodeArg* nested_output = builder.MakeIntermediate<float>({2});
@@ -498,14 +511,28 @@ TEST_F(FunctionExtractorTest, RejectsImpureOrUnknownOperation) {
 
 TEST_F(FunctionExtractorTest, EnforcesResourceBudgetsBeforeMutation) {
   const FunctionProto function_proto = MakeLinearFunction();
-  const std::vector<FunctionExtractorOptions> options{
-      FunctionExtractorOptions{1, 1'000'000, 100'000, 1'000'000, 64U * 1024U * 1024U},
-      FunctionExtractorOptions{1024, 1, 100'000, 1'000'000, 64U * 1024U * 1024U},
-      FunctionExtractorOptions{1024, 1'000'000, 0, 1'000'000, 64U * 1024U * 1024U},
-      FunctionExtractorOptions{1024, 1'000'000, 100'000, 0, 64U * 1024U * 1024U},
+  struct BudgetCase {
+    const char* name;
+    FunctionExtractorOptions options;
   };
 
-  for (const auto& option : options) {
+  FunctionExtractorOptions pattern_node_limit;
+  pattern_node_limit.max_pattern_nodes = 1;
+  FunctionExtractorOptions target_node_limit;
+  target_node_limit.max_target_nodes = 1;
+  FunctionExtractorOptions root_tuple_limit;
+  root_tuple_limit.max_output_root_tuples = 0;
+  FunctionExtractorOptions worklist_limit;
+  worklist_limit.max_worklist_bindings = 0;
+  const std::vector<BudgetCase> budget_cases{
+      {"pattern node limit", pattern_node_limit},
+      {"target node limit", target_node_limit},
+      {"output root tuple limit", root_tuple_limit},
+      {"worklist binding limit", worklist_limit},
+  };
+
+  for (const auto& budget_case : budget_cases) {
+    SCOPED_TRACE(budget_case.name);
     auto model = MakeModel(function_proto);
     Graph& graph = model->MainGraph();
     NodeArg* x;
@@ -515,13 +542,15 @@ TEST_F(FunctionExtractorTest, EnforcesResourceBudgetsBeforeMutation) {
     BuildLinearTarget(graph, x, y, sum, output);
     ASSERT_STATUS_OK(graph.Resolve());
 
-    FunctionExtractor extractor(function_proto, option);
+    FunctionExtractor extractor(function_proto, budget_case.options);
     const FunctionExtractionResult result = extractor.Extract(graph);
     EXPECT_FALSE(result.status.IsOK());
     EXPECT_EQ(result.replacements_applied, 0u);
     EXPECT_EQ(graph.NumberOfNodes(), 2u);
   }
 }
+
+// Deterministic structural matching.
 
 TEST_F(FunctionExtractorTest, ExtractsLinearPattern) {
   const FunctionProto function_proto = MakeLinearFunction();
@@ -558,7 +587,7 @@ TEST_F(FunctionExtractorTest, ExtractsBranchedMultiOutputPattern) {
                    std::vector<std::string>{"scaled", "activated"});
   auto model = MakeModel(function_proto);
   Graph& graph = model->MainGraph();
-  ModelTestBuilder builder(graph);
+  FunctionExtractorGraphBuilder builder(graph);
   NodeArg* x = builder.MakeInput<float>({2}, 0.0f, 1.0f);
   NodeArg* y = builder.MakeInput<float>({2}, 0.0f, 1.0f);
   NodeArg* sum = builder.MakeIntermediate<float>({2});
@@ -591,7 +620,7 @@ TEST_F(FunctionExtractorTest, ExtractsDiamondAndProcessesSharedValueOnce) {
                    std::vector<std::string>{"out"});
   auto model = MakeModel(function_proto);
   Graph& graph = model->MainGraph();
-  ModelTestBuilder builder(graph);
+  FunctionExtractorGraphBuilder builder(graph);
   NodeArg* x = builder.MakeInput<float>({2}, 0.0f, 1.0f);
   NodeArg* y = builder.MakeInput<float>({2}, 0.0f, 1.0f);
   NodeArg* sum = builder.MakeIntermediate<float>({2});
@@ -633,7 +662,7 @@ TEST_F(FunctionExtractorTest, RejectsInconsistentMultiOutputRootTuple) {
                    std::vector<std::string>{"left", "right"});
   auto model = MakeModel(function_proto);
   Graph& graph = model->MainGraph();
-  ModelTestBuilder builder(graph);
+  FunctionExtractorGraphBuilder builder(graph);
   NodeArg* x = builder.MakeInput<float>({2}, 0.0f, 1.0f);
   NodeArg* y = builder.MakeInput<float>({2}, 0.0f, 1.0f);
   NodeArg* other = builder.MakeInput<float>({2}, 0.0f, 1.0f);
@@ -659,7 +688,7 @@ TEST_F(FunctionExtractorTest, EnumeratesOutputRootsDeterministically) {
   const FunctionProto function_proto = MakeLinearFunction();
   auto model = MakeModel(function_proto);
   Graph& graph = model->MainGraph();
-  ModelTestBuilder builder(graph);
+  FunctionExtractorGraphBuilder builder(graph);
   NodeArg* x = builder.MakeInput<float>({2}, 0.0f, 1.0f);
   NodeArg* y = builder.MakeInput<float>({2}, 0.0f, 1.0f);
   NodeArg* first = builder.MakeOutput<float>({2});
@@ -693,7 +722,7 @@ TEST_F(FunctionExtractorTest, MatchesRepeatedAndAliasedFormalInputs) {
                    std::vector<std::string>{"out"});
   auto model = MakeModel(function_proto);
   Graph& graph = model->MainGraph();
-  ModelTestBuilder builder(graph);
+  FunctionExtractorGraphBuilder builder(graph);
   NodeArg* input = builder.MakeInput<float>({2}, 0.0f, 1.0f);
   NodeArg* sum = builder.MakeIntermediate<float>({2});
   NodeArg* output = builder.MakeOutput<float>({2});
@@ -721,7 +750,7 @@ TEST_F(FunctionExtractorTest, RejectsReversedInternalOperands) {
                    std::vector<std::string>{"out"});
   auto model = MakeModel(function_proto);
   Graph& graph = model->MainGraph();
-  ModelTestBuilder builder(graph);
+  FunctionExtractorGraphBuilder builder(graph);
   NodeArg* x = builder.MakeInput<float>({2}, 0.0f, 1.0f);
   NodeArg* y = builder.MakeInput<float>({2}, 0.0f, 1.0f);
   NodeArg* difference = builder.MakeIntermediate<float>({2});
@@ -741,7 +770,7 @@ TEST_F(FunctionExtractorTest, RootIndexAllowsExternalProducerAndOutputFanout) {
   const FunctionProto function_proto = MakeLinearFunction();
   auto model = MakeModel(function_proto);
   Graph& graph = model->MainGraph();
-  ModelTestBuilder builder(graph);
+  FunctionExtractorGraphBuilder builder(graph);
   NodeArg* source = builder.MakeInput<float>({2}, -1.0f, 1.0f);
   NodeArg* x = builder.MakeIntermediate<float>({2});
   NodeArg* y = builder.MakeInput<float>({2}, 0.0f, 1.0f);
@@ -770,7 +799,7 @@ TEST_F(FunctionExtractorTest, RequiresExactOperatorIdentityAndArity) {
     SCOPED_TRACE(second_op);
     auto model = MakeModel(function_proto);
     Graph& graph = model->MainGraph();
-    ModelTestBuilder builder(graph);
+    FunctionExtractorGraphBuilder builder(graph);
     NodeArg* x = builder.MakeInput<float>({2}, 0.0f, 1.0f);
     NodeArg* y = builder.MakeInput<float>({2}, 0.0f, 1.0f);
     NodeArg* sum = builder.MakeIntermediate<float>({2});
@@ -801,7 +830,7 @@ TEST_F(FunctionExtractorTest, RequiresExactEffectiveAttributes) {
     SCOPED_TRACE(::testing::PrintToString(perm));
     auto model = MakeModel(function_proto);
     Graph& graph = model->MainGraph();
-    ModelTestBuilder builder(graph);
+    FunctionExtractorGraphBuilder builder(graph);
     NodeArg* input = builder.MakeInput<float>({2, 2}, 0.0f, 1.0f);
     NodeArg* transposed = builder.MakeIntermediate<float>({2, 2});
     NodeArg* output = builder.MakeOutput<float>({2, 2});
@@ -829,7 +858,7 @@ TEST_F(FunctionExtractorTest, MatchesOptionalAndVariadicSlotsPositionally) {
                      std::vector<std::string>{"out"});
     auto model = MakeModel(function_proto);
     Graph& graph = model->MainGraph();
-    ModelTestBuilder builder(graph);
+    FunctionExtractorGraphBuilder builder(graph);
     NodeArg* x = builder.MakeInput<float>({1}, 0.0f, 1.0f);
     NodeArg* y = builder.MakeInput<float>({1}, 0.0f, 1.0f);
     NodeArg* empty = builder.MakeEmptyInput();
@@ -857,7 +886,7 @@ TEST_F(FunctionExtractorTest, MatchesOptionalAndVariadicSlotsPositionally) {
                      std::vector<std::string>{"out"});
     auto model = MakeModel(function_proto);
     Graph& graph = model->MainGraph();
-    ModelTestBuilder builder(graph);
+    FunctionExtractorGraphBuilder builder(graph);
     NodeArg* x = builder.MakeInput<float>({1, 1, 4, 4}, 0.0f, 1.0f);
     NodeArg* pooled = builder.MakeIntermediate<float>({1, 1, 3, 3});
     NodeArg* output = builder.MakeOutput<float>({1, 1, 3, 3});
@@ -877,28 +906,66 @@ TEST_F(FunctionExtractorTest, MatchesOptionalAndVariadicSlotsPositionally) {
 }
 
 TEST_F(FunctionExtractorTest, AppliesKnownTypeCompatibilityRules) {
-  const FunctionProto function_proto = MakeLinearFunction();
-  for (const std::vector<int64_t>& shape :
-       {std::vector<int64_t>{2}, std::vector<int64_t>{2, 1}}) {
-    SCOPED_TRACE(::testing::PrintToString(shape));
+  const std::vector<NodeDef> nodes{
+      {{"intermediate"}, "Identity", {"x"}},
+      {{"out"}, "Identity", {"intermediate"}},
+  };
+  FunctionProto function_proto =
+      MakeFunction("KnownTypes", nodes, std::vector<std::string>{"x"},
+                   std::vector<std::string>{"out"});
+  for (const std::string_view value_name : {"x", "intermediate", "out"}) {
+    AddTensorValueInfo(function_proto, value_name,
+                       ONNX_NAMESPACE::TensorProto_DataType_FLOAT,
+                       std::vector<int64_t>{2});
+  }
+
+  struct FloatShapeCase {
+    const char* name;
+    std::vector<int64_t> shape;
+    size_t expected_replacements;
+  };
+  const std::vector<FloatShapeCase> float_shape_cases{
+      {"compatible", {2}, 1},
+      {"rank mismatch", {2, 1}, 0},
+      {"dimension mismatch", {3}, 0},
+  };
+  for (const auto& test_case : float_shape_cases) {
+    SCOPED_TRACE(test_case.name);
     auto model = MakeModel(function_proto);
     Graph& graph = model->MainGraph();
-    ModelTestBuilder builder(graph);
-    NodeArg* x = builder.MakeInput<float>(shape, 0.0f, 1.0f);
-    NodeArg* y = builder.MakeInput<float>(shape, 0.0f, 1.0f);
-    NodeArg* sum = builder.MakeIntermediate<float>(shape);
-    NodeArg* output = builder.MakeOutput<float>(shape);
-    builder.AddNode("Add", {x, y}, {sum});
-    builder.AddNode("Relu", {sum}, {output});
+    FunctionExtractorGraphBuilder builder(graph);
+    NodeArg* x = builder.MakeInput<float>(test_case.shape, 0.0f, 1.0f);
+    NodeArg* intermediate = builder.MakeIntermediate<float>(test_case.shape);
+    NodeArg* output = builder.MakeOutput<float>(test_case.shape);
+    builder.AddNode("Identity", {x}, {intermediate});
+    builder.AddNode("Identity", {intermediate}, {output});
     builder.SetGraphOutputs();
     ASSERT_STATUS_OK(graph.Resolve());
 
     FunctionExtractor extractor(function_proto);
     const FunctionExtractionResult result = extractor.Extract(graph);
     ASSERT_STATUS_OK(result.status);
-    EXPECT_EQ(result.replacements_applied, 1u);
+    EXPECT_EQ(result.replacements_applied, test_case.expected_replacements);
   }
+
+  auto model = MakeModel(function_proto);
+  Graph& graph = model->MainGraph();
+  FunctionExtractorGraphBuilder builder(graph);
+  NodeArg* x = builder.MakeInput<int32_t>({2}, 0, 10);
+  NodeArg* intermediate = builder.MakeIntermediate<int32_t>({2});
+  NodeArg* output = builder.MakeOutput<int32_t>({2});
+  builder.AddNode("Identity", {x}, {intermediate});
+  builder.AddNode("Identity", {intermediate}, {output});
+  builder.SetGraphOutputs();
+  ASSERT_STATUS_OK(graph.Resolve());
+
+  FunctionExtractor extractor(function_proto);
+  const FunctionExtractionResult result = extractor.Extract(graph);
+  ASSERT_STATUS_OK(result.status);
+  EXPECT_EQ(result.replacements_applied, 0u);
 }
+
+// Literal matching and preservation.
 
 TEST_F(FunctionExtractorTest, ComparesFloatingAndTensorBitsExactly) {
   auto make_float_tensor = [](uint32_t bits) {
@@ -926,7 +993,7 @@ TEST_F(FunctionExtractorTest, MatchesLiteralFromInitializer) {
   const FunctionProto function_proto = MakeLiteralFunction();
   auto model = MakeModel(function_proto);
   Graph& graph = model->MainGraph();
-  ModelTestBuilder builder(graph);
+  FunctionExtractorGraphBuilder builder(graph);
   NodeArg* input = builder.MakeInput<float>({2}, 0.0f, 1.0f);
   NodeArg* literal = builder.MakeScalarInitializer<float>(1.0f);
   NodeArg* sum = builder.MakeIntermediate<float>({2});
@@ -953,7 +1020,7 @@ TEST_F(FunctionExtractorTest, MatchesLiteralFromConstantNode) {
   const FunctionProto function_proto = MakeLiteralFunction();
   auto model = MakeModel(function_proto);
   Graph& graph = model->MainGraph();
-  ModelTestBuilder builder(graph);
+  FunctionExtractorGraphBuilder builder(graph);
   NodeArg* input = builder.MakeInput<float>({2}, 0.0f, 1.0f);
   NodeArg* literal = builder.MakeIntermediate<float>({});
   NodeArg* sum = builder.MakeIntermediate<float>({2});
@@ -978,7 +1045,7 @@ TEST_F(FunctionExtractorTest, LeavesSharedAndDeadLiteralWitnesses) {
   const FunctionProto function_proto = MakeLiteralFunction();
   auto model = MakeModel(function_proto);
   Graph& graph = model->MainGraph();
-  ModelTestBuilder builder(graph);
+  FunctionExtractorGraphBuilder builder(graph);
   NodeArg* input = builder.MakeInput<float>({2}, 0.0f, 1.0f);
   NodeArg* literal = builder.MakeScalarInitializer<float>(1.0f);
   NodeArg* sum = builder.MakeIntermediate<float>({2});
@@ -1004,7 +1071,7 @@ TEST_F(FunctionExtractorTest, RejectsOverridableInitializerLiteral) {
   const FunctionProto function_proto = MakeLiteralFunction();
   auto model = MakeModel(function_proto);
   Graph& graph = model->MainGraph();
-  ModelTestBuilder builder(graph);
+  FunctionExtractorGraphBuilder builder(graph);
   NodeArg* input = builder.MakeInput<float>({2}, 0.0f, 1.0f);
   NodeArg* literal = builder.MakeScalarInitializer<float>(1.0f);
   NodeArg* sum = builder.MakeIntermediate<float>({2});
@@ -1025,7 +1092,7 @@ TEST_F(FunctionExtractorTest, RejectsLiteralFormalInputAlias) {
   const FunctionProto function_proto = MakeLiteralFunction();
   auto model = MakeModel(function_proto);
   Graph& graph = model->MainGraph();
-  ModelTestBuilder builder(graph);
+  FunctionExtractorGraphBuilder builder(graph);
   NodeArg* literal = builder.MakeScalarInitializer<float>(1.0f);
   NodeArg* sum = builder.MakeIntermediate<float>({2});
   NodeArg* output = builder.MakeOutput<float>({2});
@@ -1052,7 +1119,7 @@ TEST_F(FunctionExtractorTest, AllowsEqualLiteralsToShareWitness) {
                    std::vector<std::string>{"out"});
   auto model = MakeModel(function_proto);
   Graph& graph = model->MainGraph();
-  ModelTestBuilder builder(graph);
+  FunctionExtractorGraphBuilder builder(graph);
   NodeArg* input = builder.MakeInput<float>({2}, 0.0f, 1.0f);
   NodeArg* literal = builder.MakeScalarInitializer<float>(1.0f);
   NodeArg* sum = builder.MakeIntermediate<float>({2});
@@ -1068,11 +1135,13 @@ TEST_F(FunctionExtractorTest, AllowsEqualLiteralsToShareWitness) {
   EXPECT_EQ(result.replacements_applied, 1u);
 }
 
+// Boundary closure, convexity, and graph scopes.
+
 TEST_F(FunctionExtractorTest, RejectsPrivateIntermediateExternalConsumer) {
   const FunctionProto function_proto = MakeLinearFunction();
   auto model = MakeModel(function_proto);
   Graph& graph = model->MainGraph();
-  ModelTestBuilder builder(graph);
+  FunctionExtractorGraphBuilder builder(graph);
   NodeArg* x = builder.MakeInput<float>({2}, 0.0f, 1.0f);
   NodeArg* y = builder.MakeInput<float>({2}, 0.0f, 1.0f);
   NodeArg* sum = builder.MakeIntermediate<float>({2});
@@ -1094,7 +1163,7 @@ TEST_F(FunctionExtractorTest, RejectsPrivateIntermediateGraphOutput) {
   const FunctionProto function_proto = MakeLinearFunction();
   auto model = MakeModel(function_proto);
   Graph& graph = model->MainGraph();
-  ModelTestBuilder builder(graph);
+  FunctionExtractorGraphBuilder builder(graph);
   NodeArg* x = builder.MakeInput<float>({2}, 0.0f, 1.0f);
   NodeArg* y = builder.MakeInput<float>({2}, 0.0f, 1.0f);
   NodeArg* sum = builder.MakeOutput<float>({2});
@@ -1114,7 +1183,7 @@ TEST_F(FunctionExtractorTest, RejectsPrivateIntermediateImplicitCapture) {
   const FunctionProto function_proto = MakeLinearFunction();
   auto model = MakeModel(function_proto);
   Graph& graph = model->MainGraph();
-  ModelTestBuilder builder(graph);
+  FunctionExtractorGraphBuilder builder(graph);
   NodeArg* x = builder.MakeInput<float>({2}, 0.0f, 1.0f);
   NodeArg* y = builder.MakeInput<float>({2}, 0.0f, 1.0f);
   NodeArg* sum = builder.MakeIntermediate<float>({2});
@@ -1137,7 +1206,7 @@ TEST_F(FunctionExtractorTest, PreservesFormalOutputConsumersAndImplicitCaptures)
   const FunctionProto function_proto = MakeLinearFunction();
   auto model = MakeModel(function_proto);
   Graph& graph = model->MainGraph();
-  ModelTestBuilder builder(graph);
+  FunctionExtractorGraphBuilder builder(graph);
   NodeArg* x = builder.MakeInput<float>({2}, 0.0f, 1.0f);
   NodeArg* y = builder.MakeInput<float>({2}, 0.0f, 1.0f);
   NodeArg* sum = builder.MakeIntermediate<float>({2});
@@ -1172,7 +1241,7 @@ TEST_F(FunctionExtractorTest, RejectsDownstreamFormalInputBinding) {
     SCOPED_TRACE(bind_formal_directly_to_matched_output);
     auto model = MakeModel(function_proto);
     Graph& graph = model->MainGraph();
-    ModelTestBuilder builder(graph);
+    FunctionExtractorGraphBuilder builder(graph);
     NodeArg* x = builder.MakeInput<float>({2}, 0.0f, 1.0f);
     NodeArg* activated = builder.MakeIntermediate<float>({2});
     NodeArg* output = builder.MakeOutput<float>({2});
@@ -1203,7 +1272,7 @@ TEST_F(FunctionExtractorTest, RejectsNonConvexLeaveAndReenterPath) {
                    std::vector<std::string>{"out"});
   auto model = MakeModel(function_proto);
   Graph& graph = model->MainGraph();
-  ModelTestBuilder builder(graph);
+  FunctionExtractorGraphBuilder builder(graph);
   NodeArg* x = builder.MakeInput<float>({2}, 0.0f, 1.0f);
   NodeArg* activated = builder.MakeIntermediate<float>({2});
   NodeArg* outside = builder.MakeIntermediate<float>({2});
@@ -1222,8 +1291,16 @@ TEST_F(FunctionExtractorTest, RejectsNonConvexLeaveAndReenterPath) {
 
 TEST_F(FunctionExtractorTest, RejectsProviderControlOrAnnotationMismatch) {
   const FunctionProto function_proto = MakeLinearFunction();
-  for (size_t variant = 0; variant < 2; ++variant) {
-    SCOPED_TRACE(variant);
+  enum class RejectionReason {
+    ProviderAssignment,
+    ControlEdge,
+    LayeringAnnotation,
+  };
+  for (const RejectionReason reason :
+       {RejectionReason::ProviderAssignment,
+        RejectionReason::ControlEdge,
+        RejectionReason::LayeringAnnotation}) {
+    SCOPED_TRACE(static_cast<int>(reason));
     auto model = MakeModel(function_proto);
     Graph& graph = model->MainGraph();
     NodeArg* x;
@@ -1231,14 +1308,49 @@ TEST_F(FunctionExtractorTest, RejectsProviderControlOrAnnotationMismatch) {
     NodeArg* sum;
     NodeArg* output;
     BuildLinearTarget(graph, x, y, sum, output);
+    NodeIndex control_source_index = 0;
+    NodeIndex control_target_index = 0;
+    if (reason == RejectionReason::ControlEdge) {
+      Node* add_node = nullptr;
+      for (Node& node : graph.Nodes()) {
+        if (node.OpType() == "Add") {
+          add_node = &node;
+          break;
+        }
+      }
+      ASSERT_NE(add_node, nullptr);
+      FunctionExtractorGraphBuilder builder(graph);
+      NodeArg* control_output = builder.MakeIntermediate<float>({2});
+      Node& control_source = builder.AddNode("Identity", {x}, {control_output});
+      control_source_index = control_source.Index();
+      control_target_index = add_node->Index();
+    }
     ASSERT_STATUS_OK(graph.Resolve());
+    if (reason == RejectionReason::ControlEdge) {
+      ASSERT_TRUE(graph.AddControlEdge(control_source_index, control_target_index));
+      using namespace function_extractor_internal;
+      const NormalizedFunctionPattern normalized =
+          NormalizeFunctionPattern(function_proto, FunctionExtractorOptions{});
+      ASSERT_STATUS_OK(normalized.construction_status);
+      CompiledFunctionPattern compiled;
+      ASSERT_STATUS_OK(CompileFunctionPattern(normalized, graph, compiled));
+      TargetGraphSnapshot snapshot;
+      ASSERT_STATUS_OK(
+          BuildTargetGraphSnapshot(graph, compiled, FunctionExtractorOptions{},
+                                   snapshot));
+      std::vector<ReplacementPlan> plans;
+      ASSERT_STATUS_OK(DiscoverReplacementPlans(
+          compiled, snapshot, FunctionExtractorOptions{}, plans));
+      EXPECT_TRUE(plans.empty());
+      continue;
+    }
     auto nodes = graph.Nodes();
     auto node_it = nodes.begin();
     Node& first = *node_it;
     Node& second = *++node_it;
-    if (variant == 0) {
+    if (reason == RejectionReason::ProviderAssignment) {
       first.SetExecutionProviderType(kCpuExecutionProvider);
-    } else {
+    } else if (reason == RejectionReason::LayeringAnnotation) {
       first.SetLayeringAnnotation("layer-a");
       second.SetLayeringAnnotation("layer-b");
     }
@@ -1254,7 +1366,7 @@ TEST_F(FunctionExtractorTest, DoesNotCrossGraphScopes) {
   const FunctionProto function_proto = MakeLinearFunction();
   auto model = MakeModel(function_proto);
   Graph& graph = model->MainGraph();
-  ModelTestBuilder builder(graph);
+  FunctionExtractorGraphBuilder builder(graph);
   NodeArg* x = builder.MakeInput<float>({2}, 0.0f, 1.0f);
   NodeArg* y = builder.MakeInput<float>({2}, 0.0f, 1.0f);
   NodeArg* sum = builder.MakeIntermediate<float>({2});
@@ -1271,11 +1383,13 @@ TEST_F(FunctionExtractorTest, DoesNotCrossGraphScopes) {
   EXPECT_EQ(CountOp(graph, kFunctionDomain, function_proto.name()), 0u);
 }
 
+// Batching, application, fixpoint, and persistence.
+
 TEST_F(FunctionExtractorTest, AppliesDisjointMatchesInOneBatch) {
   const FunctionProto function_proto = MakeLinearFunction();
   auto model = MakeModel(function_proto);
   Graph& graph = model->MainGraph();
-  ModelTestBuilder builder(graph);
+  FunctionExtractorGraphBuilder builder(graph);
   NodeArg* x = builder.MakeInput<float>({2}, 0.0f, 1.0f);
   NodeArg* y = builder.MakeInput<float>({2}, 0.0f, 1.0f);
   NodeArg* first = builder.MakeOutput<float>({2});
@@ -1303,7 +1417,7 @@ TEST_F(FunctionExtractorTest, SelectsOverlappingMatchesDeterministically) {
                    std::vector<std::string>{"sum", "out"});
   auto model = MakeModel(function_proto);
   Graph& graph = model->MainGraph();
-  ModelTestBuilder builder(graph);
+  FunctionExtractorGraphBuilder builder(graph);
   NodeArg* x = builder.MakeInput<float>({2}, 0.0f, 1.0f);
   NodeArg* y = builder.MakeInput<float>({2}, 0.0f, 1.0f);
   NodeArg* sum = builder.MakeIntermediate<float>({2});
@@ -1330,7 +1444,7 @@ TEST_F(FunctionExtractorTest, DefersBoundaryAdjacentMatchToNextPass) {
   const FunctionProto function_proto = MakeLinearFunction();
   auto model = MakeModel(function_proto);
   Graph& graph = model->MainGraph();
-  ModelTestBuilder builder(graph);
+  FunctionExtractorGraphBuilder builder(graph);
   NodeArg* x = builder.MakeInput<float>({2}, 0.0f, 1.0f);
   NodeArg* y = builder.MakeInput<float>({2}, 0.0f, 1.0f);
   NodeArg* z = builder.MakeInput<float>({2}, 0.0f, 1.0f);
@@ -1357,7 +1471,7 @@ TEST_F(FunctionExtractorTest, AllowsSharedUnrelatedBoundaryValues) {
   const FunctionProto function_proto = MakeLinearFunction();
   auto model = MakeModel(function_proto);
   Graph& graph = model->MainGraph();
-  ModelTestBuilder builder(graph);
+  FunctionExtractorGraphBuilder builder(graph);
   NodeArg* shared = builder.MakeInput<float>({2}, 0.0f, 1.0f);
   NodeArg* first = builder.MakeOutput<float>({2});
   NodeArg* second = builder.MakeOutput<float>({2});
@@ -1371,6 +1485,8 @@ TEST_F(FunctionExtractorTest, AllowsSharedUnrelatedBoundaryValues) {
   ASSERT_STATUS_OK(result.status);
   EXPECT_EQ(result.replacements_applied, 2u);
 }
+
+// Failure semantics and mutation invariants.
 
 TEST_F(FunctionExtractorTest, RejectsStalePlanBeforeMutation) {
   const FunctionProto function_proto = MakeLinearFunction();
@@ -1481,7 +1597,7 @@ TEST_F(FunctionExtractorTest, PreservesOutputIdentityAndFanout) {
   const FunctionProto function_proto = MakeLinearFunction();
   auto model = MakeModel(function_proto);
   Graph& graph = model->MainGraph();
-  ModelTestBuilder builder(graph);
+  FunctionExtractorGraphBuilder builder(graph);
   NodeArg* x = builder.MakeInput<float>({2}, 0.0f, 1.0f);
   NodeArg* y = builder.MakeInput<float>({2}, 0.0f, 1.0f);
   NodeArg* sum = builder.MakeIntermediate<float>({2});
@@ -1580,8 +1696,6 @@ TEST_F(FunctionExtractorTest, RoundTripsThroughInlineFunction) {
   EXPECT_EQ(graph.GetOutputs()[0]->Name(), output->Name());
   AssertResolved(graph);
 }
-
-#undef ModelTestBuilder
 
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/optimizer/function_extractor_test.cc
+++ b/onnxruntime/test/optimizer/function_extractor_test.cc
@@ -554,6 +554,32 @@ TEST_F(FunctionExtractorTest, EnforcesResourceBudgetsBeforeMutation) {
   }
 }
 
+TEST_F(FunctionExtractorTest, RejectsHighArityPatternBeforeMutation) {
+  constexpr size_t input_count = 128;
+  std::vector<std::string> inputs;
+  inputs.reserve(input_count);
+  for (size_t i = 0; i < input_count; ++i) {
+    inputs.push_back("x" + std::to_string(i));
+  }
+  const std::vector<NodeDef> nodes{
+      {{"joined"}, "Concat", inputs, {ONNX_NAMESPACE::MakeAttribute("axis", int64_t{0})}},
+      {{"out"}, "Identity", {"joined"}},
+  };
+  const FunctionProto function_proto =
+      MakeFunction("HighArity", nodes, inputs, std::vector<std::string>{"out"});
+  auto model = MakeModel(function_proto);
+  Graph& graph = model->MainGraph();
+  ASSERT_STATUS_OK(graph.Resolve());
+
+  FunctionExtractorOptions options;
+  options.max_worklist_bindings = 16;
+  FunctionExtractor extractor(function_proto, options);
+  const FunctionExtractionResult result = extractor.Extract(graph);
+  EXPECT_FALSE(result.status.IsOK());
+  EXPECT_EQ(result.replacements_applied, 0u);
+  EXPECT_EQ(graph.NumberOfNodes(), 0u);
+}
+
 // Deterministic structural matching.
 
 TEST_F(FunctionExtractorTest, ExtractsLinearPattern) {


### PR DESCRIPTION
## Purpose

Adds `FunctionExtractor`, a reverse function-inliner utility for the optimizer. Given a `const ONNX_NAMESPACE::FunctionProto& F`, it finds occurrences of F's body in a `Graph` and replaces each occurrence with one node that calls F, simplifying downstream fusion and graph rewriting.

The implementation follows the design and matching algorithm documented in `algorithm1.md`.

## Implementation

The change adds the six production files spanning `include/onnxruntime/core/optimizer/function_extractor.h` and `onnxruntime/core/optimizer/function_extractor{,_pattern,_matcher}.{h,cc}`, plus the 58-test suite in `onnxruntime/test/optimizer/function_extractor_test.cc`.

Key v1 invariants include:

- deterministic reverse-topological matching with no backtracking
- closure through both explicit and implicit consumers
- convexity and connectedness enforcement
- rejection of constant-derived formal outputs
- a bounded aggregate work budget, including construction-time high-arity input/output/consumer incidence accounting
- non-atomic application semantics with an accurate `replacements_applied` count after post-mutation failures

The feature is guarded by `#if !defined(ORT_MINIMAL_BUILD)`.

## Validation

- Debug and Release validation: `[  PASSED  ] 58 tests.`
- Targeted lint: clean
- Triple-reviewed with focused follow-up reviews
- Independent QA: PASS at `e7877aad5721cb7cf56c3ed9e57b73124a5e1a0e`

A Release-link failure encountered on one host was pre-existing environmental contamination: a 2023 MDd `libprotobuf-lited` under `C:\repos\protobuf_build`, unrelated to this feature. Validation avoided that host artifact by using the pinned FetchContent protobuf dependency.