### PR TITLE
[CUDA] Speed up 8-bit MatMulNBits dequantization with byte permutes

### DIFF
--- a/onnxruntime/contrib_ops/cuda/quantization/matmul_8bits.cu
+++ b/onnxruntime/contrib_ops/cuda/quantization/matmul_8bits.cu
@@ -35,21 +35,36 @@ __device__ __forceinline__ void AccumulateEightElements8b(
 #if (!defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 530)
   // --- Dequantization Setup ---
   half2 scale_h2 = __half2half2(scale);  // Broadcast scale
-  half zp_h = __ushort2half_rn(zp);      // Convert zp to half
-  half2 zp_h2 = __half2half2(zp_h);      // Broadcast zp_h
 
-  // --- Extract 8 uint8_t values ---
-  uint8_t q[8];
-#pragma unroll
-  for (int i = 0; i < 8; ++i) {
-    q[i] = (values_quant >> (i * 8)) & 0xFF;
-  }
+  // Fast uint8 -> half conversion via the "magic half" trick. The half bit pattern
+  // (0x6400 | q) encodes exactly 1024 + q for any q in [0, 255] (exponent 2^10, so the
+  // low 10 mantissa bits are integer-valued and ulp == 1). Byte-permuting the packed
+  // weights against the constant 0x64646464 therefore materializes two halves per PRMT,
+  // replacing 8 u16->half converts plus 4 pack ops with 4 instructions.
+  //
+  // Subtracting the matching biased zero point (0x6400 | zp) == 1024 + zp cancels the
+  // 1024 offset exactly: both operands are exact halves and the result (q - zp) lies in
+  // [-255, 255], which is exactly representable, so this is bit-identical to the
+  // straightforward __ushort2half_rn(q) - __ushort2half_rn(zp) formulation.
+  const uint32_t kMagicBytes = 0x64646464u;
+  const uint32_t lo32 = static_cast<uint32_t>(values_quant);
+  const uint32_t hi32 = static_cast<uint32_t>(values_quant >> 32);
 
-  // --- Dequantize 8 values into 4 half2 vectors: b_vec = (q - zp) * scale ---
-  half2 q_01 = __halves2half2(__ushort2half_rn(q[0]), __ushort2half_rn(q[1]));
-  half2 q_23 = __halves2half2(__ushort2half_rn(q[2]), __ushort2half_rn(q[3]));
-  half2 q_45 = __halves2half2(__ushort2half_rn(q[4]), __ushort2half_rn(q[5]));
-  half2 q_67 = __halves2half2(__ushort2half_rn(q[6]), __ushort2half_rn(q[7]));
+  // Selector nibbles (LSB first) pick result bytes from {x[0..3], y[4..7]}:
+  // 0x4140 -> {q0, 0x64, q1, 0x64}; 0x4342 -> {q2, 0x64, q3, 0x64}.
+  const uint32_t b_01 = __byte_perm(lo32, kMagicBytes, 0x4140);
+  const uint32_t b_23 = __byte_perm(lo32, kMagicBytes, 0x4342);
+  const uint32_t b_45 = __byte_perm(hi32, kMagicBytes, 0x4140);
+  const uint32_t b_67 = __byte_perm(hi32, kMagicBytes, 0x4342);
+
+  const half2 q_01 = *reinterpret_cast<const half2*>(&b_01);
+  const half2 q_23 = *reinterpret_cast<const half2*>(&b_23);
+  const half2 q_45 = *reinterpret_cast<const half2*>(&b_45);
+  const half2 q_67 = *reinterpret_cast<const half2*>(&b_67);
+
+  // Biased zero point: 1024 + zp, matching the bias baked into q_* above.
+  const uint16_t zp_biased_bits = static_cast<uint16_t>(0x6400u | static_cast<uint32_t>(zp));
+  const half2 zp_h2 = __half2half2(__ushort_as_half(zp_biased_bits));
 
   half2 diff_01 = __hsub2(q_01, zp_h2);
   half2 diff_23 = __hsub2(q_23, zp_h2);
@@ -200,12 +215,39 @@ __device__ __forceinline__ float ToFloat8b<nv_bfloat16>(nv_bfloat16 v) { return 
 template <class T>
 __device__ __forceinline__ void DequantizeEight8b(uint64_t values_quant, T scale, uint8_t zp, float dq[8]) {
   float scale_f = ToFloat8b<T>(scale);
+#if (!defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 530)
+  // Magic-half decode of the packed uint8 weights. The half bit pattern (0x6400 | q)
+  // encodes exactly 1024 + q for q in [0, 255] (exponent 2^10, so ulp == 1), so two
+  // weights are materialized per __byte_perm. Subtracting half(1024 + zp) cancels the
+  // bias and leaves the exact integer (q - zp) in [-255, 255], which half represents
+  // exactly -- so this is bit-identical to float(q) - float(zp) while replacing
+  // 8 int->float converts and 8 subtracts with 4 permutes and 4 half2 subtracts.
+  const uint32_t kMagicBytes = 0x64646464u;
+  const uint32_t lo32 = static_cast<uint32_t>(values_quant);
+  const uint32_t hi32 = static_cast<uint32_t>(values_quant >> 32);
+  const half2 bias_h2 = __half2half2(
+      __ushort_as_half(static_cast<uint16_t>(0x6400u | static_cast<uint32_t>(zp))));
+
+  uint32_t packed[4];
+  packed[0] = __byte_perm(lo32, kMagicBytes, 0x4140);  // {q0, q1}
+  packed[1] = __byte_perm(lo32, kMagicBytes, 0x4342);  // {q2, q3}
+  packed[2] = __byte_perm(hi32, kMagicBytes, 0x4140);  // {q4, q5}
+  packed[3] = __byte_perm(hi32, kMagicBytes, 0x4342);  // {q6, q7}
+
+#pragma unroll
+  for (int i = 0; i < 4; ++i) {
+    const float2 d = __half22float2(__hsub2(*reinterpret_cast<const half2*>(&packed[i]), bias_h2));
+    dq[2 * i] = d.x * scale_f;
+    dq[2 * i + 1] = d.y * scale_f;
+  }
+#else
   float zp_f = static_cast<float>(zp);
 #pragma unroll
   for (int i = 0; i < 8; ++i) {
     uint8_t q = (values_quant >> (i * 8)) & 0xFF;
     dq[i] = (static_cast<float>(q) - zp_f) * scale_f;
   }
+#endif
 }
 
 // Load 8 consecutive activations (one lane's iteration tile) into float[8].

--- a/onnxruntime/contrib_ops/cuda/quantization/matmul_8bits.cu
+++ b/onnxruntime/contrib_ops/cuda/quantization/matmul_8bits.cu
@@ -6,6 +6,7 @@
 #include <cuda_bf16.h>
 #include <math_constants.h>
 #include "core/providers/cuda/cu_inc/common.cuh"
+#include "core/providers/cuda/cu_inc/cuda_type_helper.cuh"
 #include "core/providers/cuda/cuda_common.h"
 #include "contrib_ops/cuda/quantization/matmul_nbits.cuh"
 
@@ -57,10 +58,10 @@ __device__ __forceinline__ void AccumulateEightElements8b(
   const uint32_t b_45 = __byte_perm(hi32, kMagicBytes, 0x4140);
   const uint32_t b_67 = __byte_perm(hi32, kMagicBytes, 0x4342);
 
-  const half2 q_01 = *reinterpret_cast<const half2*>(&b_01);
-  const half2 q_23 = *reinterpret_cast<const half2*>(&b_23);
-  const half2 q_45 = *reinterpret_cast<const half2*>(&b_45);
-  const half2 q_67 = *reinterpret_cast<const half2*>(&b_67);
+  const half2 q_01 = bit_cast<half2>(b_01);
+  const half2 q_23 = bit_cast<half2>(b_23);
+  const half2 q_45 = bit_cast<half2>(b_45);
+  const half2 q_67 = bit_cast<half2>(b_67);
 
   // Biased zero point: 1024 + zp, matching the bias baked into q_* above.
   const uint16_t zp_biased_bits = static_cast<uint16_t>(0x6400u | static_cast<uint32_t>(zp));
@@ -236,7 +237,7 @@ __device__ __forceinline__ void DequantizeEight8b(uint64_t values_quant, T scale
 
 #pragma unroll
   for (int i = 0; i < 4; ++i) {
-    const float2 d = __half22float2(__hsub2(*reinterpret_cast<const half2*>(&packed[i]), bias_h2));
+    const float2 d = __half22float2(__hsub2(bit_cast<half2>(packed[i]), bias_h2));
     dq[2 * i] = d.x * scale_f;
     dq[2 * i + 1] = d.y * scale_f;
   }


### PR DESCRIPTION
### Description

The uint8 → half/float dequantization in the 8-bit `MatMulNBits` GEMV kernels is **issue-bound, not bandwidth-bound**. Replacing the per-element integer-to-float converts with the "magic half" byte-permute decode makes the M=1 kernel **18% faster**, with **bit-identical** output.

`ncu` on an H200 (SM90), 8-bit `MatMulNBits` with K=2048, N=248320 (an int8 `lm_head`):

| metric | value |
|---|---|
| Compute (SM) Throughput | **86.46 %** |
| DRAM Throughput | 35.02 % |
| L1/TEX Cache Throughput | 66.00 % |
| Achieved Occupancy | 94.51 % |
| Executed Ipc Active | **3.49** inst/cycle (of 4) |

Occupancy is already ~95% and DRAM is only a third utilized, so the kernel is limited by the ALU/convert instructions in the dequantization rather than by weight traffic. The fix is to issue fewer instructions per unpacked weight.

### Approach

The half bit pattern `0x6400 | q` encodes exactly `1024 + q` for any `q ∈ [0, 255]`: the `2^10` exponent makes the low 10 mantissa bits integer-valued with `ulp == 1`. A single `__byte_perm` against the constant `0x64646464` therefore materializes **two halves at once**, so 8 `u16→half` converts plus 4 pack operations collapse into 4 permutes. Subtracting the matching biased zero point `0x6400 | zp` (i.e. `1024 + zp`) cancels the `1024` offset exactly.

This is the same technique already vendored in this repository — see `start_byte_for_fp16 = 0x64646464` in [`onnxruntime/contrib_ops/cuda/llm/cutlass_extensions/interleaved_numeric_conversion.h`](onnxruntime/contrib_ops/cuda/llm/cutlass_extensions/interleaved_numeric_conversion.h#L54) (CUTLASS's `FastInterleavedAndBiasedNumericArrayConverter`) — applied here to the non-interleaved MatMulNBits layout.

**This is bit-identical to the previous code, not an approximation.** Both operands are exact halves and the result `q - zp` lies in `[-255, 255]`, which half represents exactly, so no rounding is introduced anywhere.

### Key Changes

| Function | Used by | Change |
|---|---|---|
| `AccumulateEightElements8b` (half overload) | `MatMulFloat8bKernelM1` | 8 converts + 4 packs → 4 `__byte_perm` |
| `DequantizeEight8b<T>` | `MatMulFloat8bKernelBatched` | 8 int→float converts + 8 subtracts → 4 permutes + 4 `__hsub2` |

The pre-existing scalar loop is retained under `#else` for `__CUDA_ARCH__ < 530`, matching the guard already used by the half accumulate path. No API, kernel-launch, or dispatch changes.

### Results

Measured on H200 (SM90), nsys median over ~60 launches, N=248320, K=2048:

| kernel | before | after | |
|---|---:|---:|---:|
| `MatMulFloat8bKernelM1` | 248.6 µs | **203.0 µs** | **−18%** |
| `MatMulFloat8bKernelBatched` | 301.6 µs | 299.6 µs | −1% |

`ncu` after the change shows Compute SM 87.2% / DRAM 42.9% / L1-TEX 82.5% — the kernel has moved off the instruction-issue limit and toward the L1 limit.

The batched kernel gains little because it is **not** issue-bound: L1/TEX throughput is 98.5% and occupancy is capped at 34.9% (3 blocks, 80 registers/thread). Its bottleneck is activation re-reads — the `[M,K]` activation tile is re-read by every one of the N/16 blocks — which needs shared-memory staging and a register reduction. That is left to a separate change.

### Testing Notes

Existing coverage exercises both modified paths; because the transform is bit-identical, no test changes are required.

```bash
ninja -j32 onnxruntime_provider_test
./onnxruntime_provider_test --gtest_filter='*MatMul8Bits*:*MatMulNBits*:*MatMul8bits*'
```

Result: **74 tests, 71 PASSED, 0 FAILED**, 3 skipped (`DynamicZeroPoints_AsymmetricCompInt8`, `SharedPrepackedWeights_DynamicZeroPoints_AsymmetricCompInt8`, `Float16_Comprehensive` — all skipped on `main` as well).

Reviewers may want to sanity-check the `__byte_perm` selector nibbles: bytes 0-3 come from `x`, bytes 4-7 from `y`, and nibble 0 (LSB) selects result byte 0. So `__byte_perm(lo32, 0x64646464, 0x4140)` yields `{q0, 0x64, q1, 0x64}`, i.e. the two halves `1024+q0` and `1024+q1` (`half2` stores `.x` in the low 16 bits).
