### PR TITLE
[CUDA] Fix Abs signed zero handling

### DIFF
--- a/onnxruntime/core/providers/cuda/cu_inc/common.cuh
+++ b/onnxruntime/core/providers/cuda/cu_inc/common.cuh
@@ -430,7 +430,13 @@ __device__ __inline__ BFloat16 _Max(BFloat16 a, BFloat16 b) {
 #undef NAN_BFLOAT16
 
 template <typename T>
-__device__ __inline__ T _Abs(T a) { return a > (T)0 ? a : -a; }
+__device__ __inline__ T _Abs(T a) {
+  if (a == (T)0) {
+    return (T)0;
+  }
+
+  return a > (T)0 ? a : -a;
+}
 
 template <typename T>
 __device__ __inline__ T _Signum(T a, std::false_type /* is_signed */) { return T(0) < a; }

--- a/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
@@ -1024,6 +1024,27 @@ TEST(MathOpTest, Abs) {
   test.Run();
 }
 
+#ifdef USE_CUDA
+TEST(MathOpTest, Abs_Cuda_CanonicalizesSignedZero) {
+  OpTester test("Abs");
+  test.AddInput<float>("X", {2}, {0.0f, -0.0f});
+  test.AddOutput<float>("Y", {2}, {0.0f, 0.0f});
+  test.SetCustomOutputVerifier([](const std::vector<OrtValue>& fetches,
+                                  const std::string& /*provider_type*/) {
+    ASSERT_EQ(fetches.size(), 1u);
+    ASSERT_TRUE(fetches[0].IsTensor());
+
+    const auto* output = fetches[0].Get<Tensor>().Data<float>();
+    EXPECT_FALSE(std::signbit(output[0])) << "Abs(+0.0f) must be +0.0f";
+    EXPECT_FALSE(std::signbit(output[1])) << "Abs(-0.0f) must be +0.0f";
+  });
+
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(DefaultCudaExecutionProvider());
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+}
+#endif  // USE_CUDA
+
 #if defined(USE_CUDA) || defined(USE_DNNL)
 TEST(MathOpTest, Abs_bfloat16) {
 #ifdef USE_CUDA


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Ensure CUDA `Abs` returns `+0.0` for both `+0.0` and `-0.0`, with a regression test checking the output sign bits.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

The existing implementation negates `+0.0`, producing `-0.0` instead. This fixes the signed-zero behavior.

Fixes #31162
