### PR TITLE
[CUDA] MatMul: add an opt-in split-K GEMV for small-N fp16 shapes

### DIFF
--- a/onnxruntime/core/providers/cuda/math/matmul.cc
+++ b/onnxruntime/core/providers/cuda/math/matmul.cc
@@ -3,14 +3,34 @@
 
 #include "core/providers/cuda/math/matmul.h"
 
+#include "core/platform/env_var_utils.h"
 #include "core/providers/cuda/shared_inc/fpgeneric.h"
 #include "core/providers/cuda/cuda_allocator.h"
+#include "core/providers/cuda/math/matmul_small_n_gemv.h"
 #ifndef BUILD_CUDA_EP_AS_PLUGIN
 #include "core/providers/cuda/tunable/math/matmul.h"
 #endif
 
 namespace onnxruntime {
 namespace cuda {
+
+// Opt-in: the split-K GEMV path beats cuBLAS on the decode shapes measured so
+// far (M<=8, N<=1024, K>=128) but has not been swept over the whole shape space.
+static bool SmallNGemvEnabled() {
+  static const bool enabled = ParseEnvironmentVariableWithDefault<bool>("ORT_ENABLE_SMALL_N_GEMV", false);
+  return enabled;
+}
+
+template <typename T>
+Status MatMul<T>::EnsureGemvCounter(size_t count) const {
+  std::lock_guard<std::mutex> guard(gemv_counter_mutex_);
+  if (gemv_counter_ && gemv_counter_count_ >= count) return Status::OK();
+  auto buffer = GetScratchBuffer<unsigned int>(count, nullptr);
+  CUDA_RETURN_IF_ERROR(cudaMemset(buffer.get(), 0, count * sizeof(unsigned int)));
+  gemv_counter_ = std::move(buffer);
+  gemv_counter_count_ = count;
+  return Status::OK();
+}
 
 #define REGISTER_KERNEL_TYPED(T)                                  \
   ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(                        \
@@ -322,6 +342,26 @@ Status MatMul<T>::ComputeDefault(OpKernelContext* ctx, MatMulComputeHelper& help
   auto& device_prop = GetDeviceProp();
 
   if (helper.OutputOffsets().size() == 1) {
+    if constexpr (std::is_same<T, MLFloat16>::value) {
+      // cuBLAS tiles this class of shape onto a handful of CTAs and spends
+      // several microseconds on a few hundred KiB of weights.
+      if (SmallNGemvEnabled() && !transa && !transb && alpha_ == 1.0f &&
+          lda == static_cast<int>(helper.K()) && ldb == static_cast<int>(helper.N()) &&
+          ldc == static_cast<int>(helper.N()) &&
+          CanUseSmallNGemv(helper.M(), helper.N(), helper.K(), left_X->DataRaw(), right_X->DataRaw(),
+                           Y->MutableDataRaw())) {
+        const int m = static_cast<int>(helper.M());
+        const int n = static_cast<int>(helper.N());
+        const int k = static_cast<int>(helper.K());
+        ORT_RETURN_IF_ERROR(EnsureGemvCounter(SmallNGemvCounterElements(n)));
+        auto workspace = GetScratchBuffer<float>(SmallNGemvWorkspaceElements(m, n, k), ctx->GetComputeStream());
+        return LaunchSmallNGemv(Stream(ctx),
+                                reinterpret_cast<const half*>(left_X->Data<T>()),
+                                reinterpret_cast<const half*>(right_X->Data<T>()),
+                                reinterpret_cast<half*>(Y->MutableData<T>()),
+                                m, n, k, workspace.get(), gemv_counter_.get());
+      }
+    }
     CUBLAS_RETURN_IF_ERROR(cublasGemmHelper(
         GetCublasHandle(ctx),
         transB,

--- a/onnxruntime/core/providers/cuda/math/matmul.cc
+++ b/onnxruntime/core/providers/cuda/math/matmul.cc
@@ -21,17 +21,6 @@ static bool SmallNGemvEnabled() {
   return enabled;
 }
 
-template <typename T>
-Status MatMul<T>::EnsureGemvCounter(size_t count) const {
-  std::lock_guard<std::mutex> guard(gemv_counter_mutex_);
-  if (gemv_counter_ && gemv_counter_count_ >= count) return Status::OK();
-  auto buffer = GetScratchBuffer<unsigned int>(count, nullptr);
-  CUDA_RETURN_IF_ERROR(cudaMemset(buffer.get(), 0, count * sizeof(unsigned int)));
-  gemv_counter_ = std::move(buffer);
-  gemv_counter_count_ = count;
-  return Status::OK();
-}
-
 #define REGISTER_KERNEL_TYPED(T)                                  \
   ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_EX(                        \
       MatMul,                                                     \
@@ -341,6 +330,7 @@ Status MatMul<T>::ComputeDefault(OpKernelContext* ctx, MatMulComputeHelper& help
   int64_t stride_A, stride_B, stride_C, batch_count;
   auto& device_prop = GetDeviceProp();
 
+  onnxruntime::Stream* stream = this->GetComputeStream(ctx);
   if (helper.OutputOffsets().size() == 1) {
     if constexpr (std::is_same<T, MLFloat16>::value) {
       // cuBLAS tiles this class of shape onto a handful of CTAs and spends
@@ -353,13 +343,15 @@ Status MatMul<T>::ComputeDefault(OpKernelContext* ctx, MatMulComputeHelper& help
         const int m = static_cast<int>(helper.M());
         const int n = static_cast<int>(helper.N());
         const int k = static_cast<int>(helper.K());
-        ORT_RETURN_IF_ERROR(EnsureGemvCounter(SmallNGemvCounterElements(n)));
-        auto workspace = GetScratchBuffer<float>(SmallNGemvWorkspaceElements(m, n, k), ctx->GetComputeStream());
+        const size_t counter_elements = SmallNGemvCounterElements(n);
+        auto counter = GetScratchBuffer<unsigned int>(counter_elements, stream);
+        CUDA_RETURN_IF_ERROR(cudaMemsetAsync(counter.get(), 0, counter_elements * sizeof(unsigned int), Stream(ctx)));
+        auto workspace = GetScratchBuffer<float>(SmallNGemvWorkspaceElements(m, n, k), stream);
         return LaunchSmallNGemv(Stream(ctx),
                                 reinterpret_cast<const half*>(left_X->Data<T>()),
                                 reinterpret_cast<const half*>(right_X->Data<T>()),
                                 reinterpret_cast<half*>(Y->MutableData<T>()),
-                                m, n, k, workspace.get(), gemv_counter_.get());
+                                m, n, k, workspace.get(), counter.get());
       }
     }
     CUBLAS_RETURN_IF_ERROR(cublasGemmHelper(
@@ -414,9 +406,9 @@ Status MatMul<T>::ComputeDefault(OpKernelContext* ctx, MatMulComputeHelper& help
   MatMulComputeHelper::OffsetToArrays(reinterpret_cast<const CudaT*>(left_X->Data<T>()), helper.LeftOffsets(), left_arrays.CpuSpan());
   MatMulComputeHelper::OffsetToArrays(reinterpret_cast<const CudaT*>(right_X->Data<T>()), helper.RightOffsets(), right_arrays.CpuSpan());
   MatMulComputeHelper::OffsetToArrays(reinterpret_cast<CudaT*>(Y->MutableData<T>()), helper.OutputOffsets(), output_arrays.CpuSpan());
-  ORT_RETURN_IF_ERROR(left_arrays.CopyToGpu(this->GetComputeStream(ctx)));
-  ORT_RETURN_IF_ERROR(right_arrays.CopyToGpu(this->GetComputeStream(ctx)));
-  ORT_RETURN_IF_ERROR(output_arrays.CopyToGpu(this->GetComputeStream(ctx)));
+  ORT_RETURN_IF_ERROR(left_arrays.CopyToGpu(stream));
+  ORT_RETURN_IF_ERROR(right_arrays.CopyToGpu(stream));
+  ORT_RETURN_IF_ERROR(output_arrays.CopyToGpu(stream));
 
   // TF32 provides a huge performance gain for training and inference while preserving FP32 levels of accuracy.
   // It requires Ampere or newer GPU, and pointers of matrices shall be aligned (ideal alignment is 16-byte).

--- a/onnxruntime/core/providers/cuda/math/matmul.cc
+++ b/onnxruntime/core/providers/cuda/math/matmul.cc
@@ -330,7 +330,6 @@ Status MatMul<T>::ComputeDefault(OpKernelContext* ctx, MatMulComputeHelper& help
   int64_t stride_A, stride_B, stride_C, batch_count;
   auto& device_prop = GetDeviceProp();
 
-  onnxruntime::Stream* stream = this->GetComputeStream(ctx);
   if (helper.OutputOffsets().size() == 1) {
     if constexpr (std::is_same<T, MLFloat16>::value) {
       // cuBLAS tiles this class of shape onto a handful of CTAs and spends
@@ -344,9 +343,9 @@ Status MatMul<T>::ComputeDefault(OpKernelContext* ctx, MatMulComputeHelper& help
         const int n = static_cast<int>(helper.N());
         const int k = static_cast<int>(helper.K());
         const size_t counter_elements = SmallNGemvCounterElements(n);
-        auto counter = GetScratchBuffer<unsigned int>(counter_elements, stream);
+        auto counter = GetScratchBuffer<unsigned int>(counter_elements, this->GetComputeStream(ctx));
         CUDA_RETURN_IF_ERROR(cudaMemsetAsync(counter.get(), 0, counter_elements * sizeof(unsigned int), Stream(ctx)));
-        auto workspace = GetScratchBuffer<float>(SmallNGemvWorkspaceElements(m, n, k), stream);
+        auto workspace = GetScratchBuffer<float>(SmallNGemvWorkspaceElements(m, n, k), this->GetComputeStream(ctx));
         return LaunchSmallNGemv(Stream(ctx),
                                 reinterpret_cast<const half*>(left_X->Data<T>()),
                                 reinterpret_cast<const half*>(right_X->Data<T>()),
@@ -406,9 +405,9 @@ Status MatMul<T>::ComputeDefault(OpKernelContext* ctx, MatMulComputeHelper& help
   MatMulComputeHelper::OffsetToArrays(reinterpret_cast<const CudaT*>(left_X->Data<T>()), helper.LeftOffsets(), left_arrays.CpuSpan());
   MatMulComputeHelper::OffsetToArrays(reinterpret_cast<const CudaT*>(right_X->Data<T>()), helper.RightOffsets(), right_arrays.CpuSpan());
   MatMulComputeHelper::OffsetToArrays(reinterpret_cast<CudaT*>(Y->MutableData<T>()), helper.OutputOffsets(), output_arrays.CpuSpan());
-  ORT_RETURN_IF_ERROR(left_arrays.CopyToGpu(stream));
-  ORT_RETURN_IF_ERROR(right_arrays.CopyToGpu(stream));
-  ORT_RETURN_IF_ERROR(output_arrays.CopyToGpu(stream));
+  ORT_RETURN_IF_ERROR(left_arrays.CopyToGpu(this->GetComputeStream(ctx)));
+  ORT_RETURN_IF_ERROR(right_arrays.CopyToGpu(this->GetComputeStream(ctx)));
+  ORT_RETURN_IF_ERROR(output_arrays.CopyToGpu(this->GetComputeStream(ctx)));
 
   // TF32 provides a huge performance gain for training and inference while preserving FP32 levels of accuracy.
   // It requires Ampere or newer GPU, and pointers of matrices shall be aligned (ideal alignment is 16-byte).

--- a/onnxruntime/core/providers/cuda/math/matmul.cc
+++ b/onnxruntime/core/providers/cuda/math/matmul.cc
@@ -14,8 +14,8 @@
 namespace onnxruntime {
 namespace cuda {
 
-// Opt-in: the split-K GEMV path beats cuBLAS on the decode shapes measured so
-// far (M<=8, N<=1024, K>=128) but has not been swept over the whole shape space.
+// Experimental opt-in: this path is currently slower than cuBLAS in-model, but
+// remains available for further tuning of small-N decode shapes.
 static bool SmallNGemvEnabled() {
   static const bool enabled = ParseEnvironmentVariableWithDefault<bool>("ORT_ENABLE_SMALL_N_GEMV", false);
   return enabled;

--- a/onnxruntime/core/providers/cuda/math/matmul.cc
+++ b/onnxruntime/core/providers/cuda/math/matmul.cc
@@ -14,11 +14,8 @@
 namespace onnxruntime {
 namespace cuda {
 
-// Experimental opt-in: this path is currently slower than cuBLAS in-model, but
-// remains available for further tuning of small-N decode shapes.
-static bool SmallNGemvEnabled() {
-  static const bool enabled = ParseEnvironmentVariableWithDefault<bool>("ORT_ENABLE_SMALL_N_GEMV", false);
-  return enabled;
+bool SmallNGemvEnabledFromEnvironment() {
+  return ParseEnvironmentVariableWithDefault<bool>("ORT_ENABLE_SMALL_N_GEMV", false);
 }
 
 #define REGISTER_KERNEL_TYPED(T)                                  \
@@ -334,9 +331,9 @@ Status MatMul<T>::ComputeDefault(OpKernelContext* ctx, MatMulComputeHelper& help
     if constexpr (std::is_same<T, MLFloat16>::value) {
       // cuBLAS tiles this class of shape onto a handful of CTAs and spends
       // several microseconds on a few hundred KiB of weights.
-      if (SmallNGemvEnabled() && !transa && !transb && alpha_ == 1.0f &&
-          lda == static_cast<int>(helper.K()) && ldb == static_cast<int>(helper.N()) &&
-          ldc == static_cast<int>(helper.N()) &&
+      if (small_n_gemv_enabled_ && !transa && !transb && alpha_ == 1.0f &&
+          static_cast<int64_t>(lda) == helper.K() && static_cast<int64_t>(ldb) == helper.N() &&
+          static_cast<int64_t>(ldc) == helper.N() &&
           CanUseSmallNGemv(helper.M(), helper.N(), helper.K(), left_X->DataRaw(), right_X->DataRaw(),
                            Y->MutableDataRaw())) {
         const int m = static_cast<int>(helper.M());

--- a/onnxruntime/core/providers/cuda/math/matmul.h
+++ b/onnxruntime/core/providers/cuda/math/matmul.h
@@ -8,6 +8,9 @@
 
 namespace onnxruntime {
 namespace cuda {
+
+bool SmallNGemvEnabledFromEnvironment();
+
 template <typename T>
 class MatMul final : public CudaKernel {
   using Base = CudaKernel;
@@ -19,7 +22,8 @@ class MatMul final : public CudaKernel {
         trans_A_{info.GetAttrOrDefault<int64_t>("transA", 0) != 0},
         trans_B_{info.GetAttrOrDefault<int64_t>("transB", 0) != 0},
         trans_batch_a_{info.GetAttrOrDefault<int64_t>("transBatchA", 0) != 0},
-        trans_batch_b_{info.GetAttrOrDefault<int64_t>("transBatchB", 0) != 0} {}
+        trans_batch_b_{info.GetAttrOrDefault<int64_t>("transBatchB", 0) != 0},
+        small_n_gemv_enabled_{SmallNGemvEnabledFromEnvironment()} {}
 
   Status ComputeInternal(OpKernelContext* context) const override;
   Status ComputeDefault(OpKernelContext* context, MatMulComputeHelper& helper) const;
@@ -30,6 +34,7 @@ class MatMul final : public CudaKernel {
   const bool trans_B_;
   const bool trans_batch_a_;
   const bool trans_batch_b_;
+  const bool small_n_gemv_enabled_;
 };
 
 template <typename T>

--- a/onnxruntime/core/providers/cuda/math/matmul.h
+++ b/onnxruntime/core/providers/cuda/math/matmul.h
@@ -3,8 +3,6 @@
 
 #pragma once
 
-#include <mutex>
-
 #include "core/providers/cuda/cuda_kernel.h"
 #include "core/providers/cpu/math/matmul_helper.h"
 
@@ -27,18 +25,11 @@ class MatMul final : public CudaKernel {
   Status ComputeDefault(OpKernelContext* context, MatMulComputeHelper& helper) const;
 
  private:
-  // Arrival counters for the split-K small-N GEMV path. The kernel leaves them
-  // zeroed, so they are allocated and cleared once and then reused.
-  Status EnsureGemvCounter(size_t count) const;
-
   const float alpha_;
   const bool trans_A_;
   const bool trans_B_;
   const bool trans_batch_a_;
   const bool trans_batch_b_;
-  mutable std::mutex gemv_counter_mutex_;
-  mutable IAllocatorUniquePtr<unsigned int> gemv_counter_;
-  mutable size_t gemv_counter_count_{0};
 };
 
 template <typename T>

--- a/onnxruntime/core/providers/cuda/math/matmul.h
+++ b/onnxruntime/core/providers/cuda/math/matmul.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <mutex>
+
 #include "core/providers/cuda/cuda_kernel.h"
 #include "core/providers/cpu/math/matmul_helper.h"
 
@@ -25,11 +27,18 @@ class MatMul final : public CudaKernel {
   Status ComputeDefault(OpKernelContext* context, MatMulComputeHelper& helper) const;
 
  private:
+  // Arrival counters for the split-K small-N GEMV path. The kernel leaves them
+  // zeroed, so they are allocated and cleared once and then reused.
+  Status EnsureGemvCounter(size_t count) const;
+
   const float alpha_;
   const bool trans_A_;
   const bool trans_B_;
   const bool trans_batch_a_;
   const bool trans_batch_b_;
+  mutable std::mutex gemv_counter_mutex_;
+  mutable IAllocatorUniquePtr<unsigned int> gemv_counter_;
+  mutable size_t gemv_counter_count_{0};
 };
 
 template <typename T>

--- a/onnxruntime/core/providers/cuda/math/matmul_small_n_gemv.cu
+++ b/onnxruntime/core/providers/cuda/math/matmul_small_n_gemv.cu
@@ -1,0 +1,156 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/cuda/math/matmul_small_n_gemv.h"
+
+#include "core/providers/cuda/cu_inc/common.cuh"
+
+namespace onnxruntime {
+namespace cuda {
+namespace {
+
+constexpr int kMaxM = 8;
+constexpr int kMaxN = 1024;
+constexpr int kMinK = 128;
+constexpr int kThreads = 256;
+constexpr int kTx = 32;  // one warp-wide column tile -> fully coalesced B reads
+constexpr int kMaxSplitK = 32;
+
+// grid = (ceil(n / kTx), split_k). Block (x, y) accumulates the K-slice
+// [y * k_per, (y+1) * k_per) for columns [x * kTx, x * kTx + kTx) and stores the
+// fp32 partials in `ws`. The last block to finish a column tile reduces the
+// partials in slice order (deterministic) and writes the half output.
+template <int M>
+__global__ void SmallNGemvSplitKKernel(const half* __restrict__ a, const half* __restrict__ b,
+                                       half* __restrict__ c, int n, int k,
+                                       float* __restrict__ ws, unsigned int* __restrict__ counter,
+                                       int split_k) {
+  constexpr int TY = kThreads / kTx;
+  const int tx = static_cast<int>(threadIdx.x) % kTx;
+  const int ty = static_cast<int>(threadIdx.x) / kTx;
+  const int col = static_cast<int>(blockIdx.x) * kTx + tx;
+  const bool active = col < n;
+
+  const int k_per = (k + split_k - 1) / split_k;
+  const int k0 = static_cast<int>(blockIdx.y) * k_per;
+  const int k1 = min(k, k0 + k_per);
+
+  float acc[M];
+#pragma unroll
+  for (int m = 0; m < M; ++m) acc[m] = 0.0f;
+
+  if (active) {
+    for (int kk = k0 + ty; kk < k1; kk += TY) {
+      const float bv = __half2float(b[static_cast<size_t>(kk) * n + col]);
+#pragma unroll
+      for (int m = 0; m < M; ++m) {
+        acc[m] = fmaf(__half2float(a[static_cast<size_t>(m) * k + kk]), bv, acc[m]);
+      }
+    }
+  }
+
+  __shared__ float smem[kThreads * M];
+#pragma unroll
+  for (int m = 0; m < M; ++m) smem[threadIdx.x * M + m] = acc[m];
+  __syncthreads();
+#pragma unroll
+  for (int s = TY / 2; s > 0; s >>= 1) {
+    if (ty < s) {
+      const int partner = ((ty + s) * kTx + tx) * M;
+#pragma unroll
+      for (int m = 0; m < M; ++m) smem[threadIdx.x * M + m] += smem[partner + m];
+    }
+    __syncthreads();
+  }
+
+  if (ty == 0 && active) {
+#pragma unroll
+    for (int m = 0; m < M; ++m) {
+      ws[(static_cast<size_t>(blockIdx.y) * M + m) * n + col] = smem[threadIdx.x * M + m];
+    }
+  }
+
+  // Make the partials visible before announcing this block is done.
+  __threadfence();
+  __syncthreads();
+
+  __shared__ bool is_last;
+  if (threadIdx.x == 0) {
+    is_last = (atomicAdd(&counter[blockIdx.x], 1u) == static_cast<unsigned int>(split_k - 1));
+  }
+  __syncthreads();
+  if (!is_last) return;
+  if (threadIdx.x == 0) counter[blockIdx.x] = 0u;  // leave it ready for the next launch
+
+  if (ty == 0 && active) {
+#pragma unroll
+    for (int m = 0; m < M; ++m) {
+      float sum = 0.0f;
+      for (int s = 0; s < split_k; ++s) sum += ws[(static_cast<size_t>(s) * M + m) * n + col];
+      c[static_cast<size_t>(m) * n + col] = __float2half(sum);
+    }
+  }
+}
+
+template <int M>
+Status Launch(cudaStream_t stream, const half* a, const half* b, half* c, int n, int k,
+              float* ws, unsigned int* counter, int split_k) {
+  const dim3 grid(static_cast<unsigned>((n + kTx - 1) / kTx), static_cast<unsigned>(split_k));
+  SmallNGemvSplitKKernel<M><<<grid, kThreads, 0, stream>>>(a, b, c, n, k, ws, counter, split_k);
+  return CUDA_CALL(cudaGetLastError());
+}
+
+}  // namespace
+
+int SmallNGemvSplitK(int n, int k) {
+  const int tiles = (n + kTx - 1) / kTx;
+  int split_k = 1;
+  while (split_k < kMaxSplitK && split_k * tiles < 128) split_k <<= 1;
+  // Every slice must own at least one warp's worth of K rows.
+  while (split_k > 1 && k / split_k < kThreads / kTx) split_k >>= 1;
+  return split_k;
+}
+
+size_t SmallNGemvWorkspaceElements(int m, int n, int k) {
+  return static_cast<size_t>(SmallNGemvSplitK(n, k)) * m * n;
+}
+
+size_t SmallNGemvCounterElements(int n) {
+  return static_cast<size_t>((n + kTx - 1) / kTx);
+}
+
+bool CanUseSmallNGemv(int64_t m, int64_t n, int64_t k, const void* a, const void* b, const void* c) {
+  if (m < 1 || m > kMaxM || n < 1 || n > kMaxN || k < kMinK) return false;
+  if (k > (1 << 20)) return false;
+  const uintptr_t align = reinterpret_cast<uintptr_t>(a) | reinterpret_cast<uintptr_t>(b) |
+                          reinterpret_cast<uintptr_t>(c);
+  return (align % 8) == 0;
+}
+
+Status LaunchSmallNGemv(cudaStream_t stream, const half* a, const half* b, half* c,
+                        int m, int n, int k, float* ws, unsigned int* counter) {
+  const int split_k = SmallNGemvSplitK(n, k);
+  switch (m) {
+    case 1:
+      return Launch<1>(stream, a, b, c, n, k, ws, counter, split_k);
+    case 2:
+      return Launch<2>(stream, a, b, c, n, k, ws, counter, split_k);
+    case 3:
+      return Launch<3>(stream, a, b, c, n, k, ws, counter, split_k);
+    case 4:
+      return Launch<4>(stream, a, b, c, n, k, ws, counter, split_k);
+    case 5:
+      return Launch<5>(stream, a, b, c, n, k, ws, counter, split_k);
+    case 6:
+      return Launch<6>(stream, a, b, c, n, k, ws, counter, split_k);
+    case 7:
+      return Launch<7>(stream, a, b, c, n, k, ws, counter, split_k);
+    case 8:
+      return Launch<8>(stream, a, b, c, n, k, ws, counter, split_k);
+    default:
+      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "SmallNGemv: unsupported M ", m);
+  }
+}
+
+}  // namespace cuda
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cuda/math/matmul_small_n_gemv.cu
+++ b/onnxruntime/core/providers/cuda/math/matmul_small_n_gemv.cu
@@ -23,7 +23,7 @@ constexpr int kMaxSplitK = 32;
 template <int M>
 __global__ void SmallNGemvSplitKKernel(const half* __restrict__ a, const half* __restrict__ b,
                                        half* __restrict__ c, int n, int k,
-                                       float* __restrict__ ws, unsigned int* __restrict__ counter,
+                                       volatile float* __restrict__ ws, unsigned int* __restrict__ counter,
                                        int split_k) {
   constexpr int TY = kThreads / kTx;
   const int tx = static_cast<int>(threadIdx.x) % kTx;
@@ -80,7 +80,6 @@ __global__ void SmallNGemvSplitKKernel(const half* __restrict__ a, const half* _
   }
   __syncthreads();
   if (!is_last) return;
-  if (threadIdx.x == 0) counter[blockIdx.x] = 0u;  // leave it ready for the next launch
 
   if (ty == 0 && active) {
 #pragma unroll

--- a/onnxruntime/core/providers/cuda/math/matmul_small_n_gemv.h
+++ b/onnxruntime/core/providers/cuda/math/matmul_small_n_gemv.h
@@ -26,9 +26,8 @@ size_t SmallNGemvCounterElements(int n);
 // deterministic.
 //
 // `workspace` must hold SmallNGemvWorkspaceElements() floats. `counter` must
-// hold SmallNGemvCounterElements() unsigned ints and must be zeroed before the
-// first launch -- every launch leaves it zeroed again for the next one, so a
-// single memset at allocation time is enough.
+// hold SmallNGemvCounterElements() zeroed unsigned ints. Both buffers are
+// exclusive to this launch.
 Status LaunchSmallNGemv(cudaStream_t stream, const half* a, const half* b, half* c,
                         int m, int n, int k, float* workspace, unsigned int* counter);
 

--- a/onnxruntime/core/providers/cuda/math/matmul_small_n_gemv.h
+++ b/onnxruntime/core/providers/cuda/math/matmul_small_n_gemv.h
@@ -26,8 +26,8 @@ size_t SmallNGemvCounterElements(int n);
 // deterministic.
 //
 // `workspace` must hold SmallNGemvWorkspaceElements() floats. `counter` must
-// hold SmallNGemvCounterElements() zeroed unsigned ints. Both buffers are
-// exclusive to this launch.
+// hold SmallNGemvCounterElements() unsigned ints and be zeroed before each
+// launch. Both buffers are exclusive to the launch.
 Status LaunchSmallNGemv(cudaStream_t stream, const half* a, const half* b, half* c,
                         int m, int n, int k, float* workspace, unsigned int* counter);
 

--- a/onnxruntime/core/providers/cuda/math/matmul_small_n_gemv.h
+++ b/onnxruntime/core/providers/cuda/math/matmul_small_n_gemv.h
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/providers/cuda/cuda_common.h"
+
+namespace onnxruntime {
+namespace cuda {
+
+// Returns true when the shape/layout is eligible for LaunchSmallNGemv.
+bool CanUseSmallNGemv(int64_t m, int64_t n, int64_t k, const void* a, const void* b, const void* c);
+
+// Number of K-slices the launch will use, and the derived scratch sizes the
+// caller has to provide to LaunchSmallNGemv.
+int SmallNGemvSplitK(int n, int k);
+size_t SmallNGemvWorkspaceElements(int m, int n, int k);
+size_t SmallNGemvCounterElements(int n);
+
+// C[m, n] = sum_k A[m, k] * B[k, n], all row-major half, no transpose.
+// Targets decode-time projections whose N is far too small to keep a cuBLAS
+// tile kernel busy (router 2048x256, linear-attention gates 2048x32,
+// shared-expert gate 2048x1). The K axis is split across `SmallNGemvSplitK`
+// blocks so the read of B spreads over many SMs; the last block to finish a
+// column tile reduces the fp32 partials in slice order, so the result is
+// deterministic.
+//
+// `workspace` must hold SmallNGemvWorkspaceElements() floats. `counter` must
+// hold SmallNGemvCounterElements() unsigned ints and must be zeroed before the
+// first launch -- every launch leaves it zeroed again for the next one, so a
+// single memset at allocation time is enough.
+Status LaunchSmallNGemv(cudaStream_t stream, const half* a, const half* b, half* c,
+                        int m, int n, int k, float* workspace, unsigned int* counter);
+
+}  // namespace cuda
+}  // namespace onnxruntime

--- a/onnxruntime/test/providers/cuda/test_cases/matmul_small_n_gemv_op_test.cc
+++ b/onnxruntime/test/providers/cuda/test_cases/matmul_small_n_gemv_op_test.cc
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "gtest/gtest.h"
+
+#include <vector>
+
+#include "core/common/float16.h"
+#include "test/providers/provider_test_utils.h"
+#include "test/util/include/default_providers.h"
+#include "test/util/include/scoped_env_vars.h"
+
+namespace onnxruntime {
+namespace test {
+namespace {
+
+void RunMatMulOperatorCase(int m, int n, int k) {
+  std::vector<MLFloat16> a(static_cast<size_t>(m) * k);
+  std::vector<MLFloat16> b(static_cast<size_t>(k) * n);
+  std::vector<MLFloat16> expected(static_cast<size_t>(m) * n);
+  for (size_t index = 0; index < a.size(); ++index) {
+    a[index] = MLFloat16(static_cast<float>((index * 7 + 1) % 23) / 16.0f - 0.6875f);
+  }
+  for (size_t index = 0; index < b.size(); ++index) {
+    b[index] = MLFloat16(static_cast<float>((index * 11 + 2) % 19) / 16.0f - 0.5625f);
+  }
+  for (int row = 0; row < m; ++row) {
+    for (int col = 0; col < n; ++col) {
+      float sum = 0.0f;
+      for (int kk = 0; kk < k; ++kk) {
+        sum += a[static_cast<size_t>(row) * k + kk].ToFloat() *
+               b[static_cast<size_t>(kk) * n + col].ToFloat();
+      }
+      expected[static_cast<size_t>(row) * n + col] = MLFloat16(sum);
+    }
+  }
+
+  ScopedEnvironmentVariables scoped_env_vars{EnvVarMap{{"ORT_ENABLE_SMALL_N_GEMV", "1"}}};
+  OpTester test("MatMul", 14);
+  test.AddInput<MLFloat16>("A", {m, k}, a);
+  test.AddInput<MLFloat16>("B", {k, n}, b);
+  test.AddOutput<MLFloat16>("Y", {m, n}, expected);
+  test.SetOutputAbsErr("Y", 0.05f);
+  test.ConfigEp(DefaultCudaExecutionProvider()).RunWithConfig();
+}
+
+TEST(MatMulSmallNGemvOpTest, DispatchesEligibleShapesWhenEnabled) {
+  RunMatMulOperatorCase(8, 1, 128);
+  RunMatMulOperatorCase(8, 1024, 128);
+}
+
+TEST(MatMulSmallNGemvOpTest, FallsBackForIneligibleShapeWhenEnabled) {
+  RunMatMulOperatorCase(8, 32, 127);
+}
+
+}  // namespace
+}  // namespace test
+}  // namespace onnxruntime

--- a/onnxruntime/test/providers/cuda/test_cases/matmul_small_n_gemv_test.cc
+++ b/onnxruntime/test/providers/cuda/test_cases/matmul_small_n_gemv_test.cc
@@ -34,14 +34,11 @@ void RunSmallNGemvCase(int m, int n, int k) {
   SCOPED_TRACE("m=" + std::to_string(m) + ", n=" + std::to_string(n) + ", k=" + std::to_string(k));
   std::vector<MLFloat16> a(static_cast<size_t>(m) * k);
   std::vector<MLFloat16> b(static_cast<size_t>(k) * n);
-  for (int row = 0; row < m; ++row) {
-    std::fill_n(a.begin() + static_cast<size_t>(row) * k, k, MLFloat16(static_cast<float>(row + 1)));
+  for (size_t index = 0; index < a.size(); ++index) {
+    a[index] = MLFloat16(static_cast<float>((index * 17 + 3) % 29) / 16.0f - 0.875f);
   }
-  for (int col = 0; col < n; ++col) {
-    const MLFloat16 value(col % 2 == 0 ? 1.0f : 0.5f);
-    for (int row = 0; row < k; ++row) {
-      b[static_cast<size_t>(row) * n + col] = value;
-    }
+  for (size_t index = 0; index < b.size(); ++index) {
+    b[index] = MLFloat16(static_cast<float>((index * 13 + 5) % 31) / 16.0f - 0.9375f);
   }
 
   auto device_a = AllocateDeviceMemory<MLFloat16>(a.size());
@@ -51,9 +48,9 @@ void RunSmallNGemvCase(int m, int n, int k) {
   auto counter = AllocateDeviceMemory<unsigned int>(SmallNGemvCounterElements(n));
   CUDA_CALL_THROW(cudaMemcpy(device_a.get(), a.data(), a.size() * sizeof(MLFloat16), cudaMemcpyHostToDevice));
   CUDA_CALL_THROW(cudaMemcpy(device_b.get(), b.data(), b.size() * sizeof(MLFloat16), cudaMemcpyHostToDevice));
-  CUDA_CALL_THROW(cudaMemset(counter.get(), 0, SmallNGemvCounterElements(n) * sizeof(unsigned int)));
 
   for (int iteration = 0; iteration < 2; ++iteration) {
+    CUDA_CALL_THROW(cudaMemset(counter.get(), 0, SmallNGemvCounterElements(n) * sizeof(unsigned int)));
     ASSERT_STATUS_OK(LaunchSmallNGemv(nullptr,
                                       reinterpret_cast<const half*>(device_a.get()),
                                       reinterpret_cast<const half*>(device_b.get()),
@@ -66,14 +63,18 @@ void RunSmallNGemvCase(int m, int n, int k) {
                                cudaMemcpyDeviceToHost));
     for (int row = 0; row < m; ++row) {
       for (int col = 0; col < n; ++col) {
-        const float scale = col % 2 == 0 ? 1.0f : 0.5f;
-        EXPECT_EQ(output[static_cast<size_t>(row) * n + col].ToFloat(), k * (row + 1) * scale);
+        float expected = 0.0f;
+        for (int kk = 0; kk < k; ++kk) {
+          expected += a[static_cast<size_t>(row) * k + kk].ToFloat() *
+                      b[static_cast<size_t>(kk) * n + col].ToFloat();
+        }
+        EXPECT_NEAR(output[static_cast<size_t>(row) * n + col].ToFloat(), expected, 0.05f);
       }
     }
   }
 }
 
-TEST(MatMulSmallNGemvTest, HandlesAllMVariantsAndResetsCounters) {
+TEST(MatMulSmallNGemvTest, HandlesAllMVariants) {
   for (int m = 1; m <= 8; ++m) {
     RunSmallNGemvCase(m, 37, 133);
   }

--- a/onnxruntime/test/providers/cuda/test_cases/matmul_small_n_gemv_test.cc
+++ b/onnxruntime/test/providers/cuda/test_cases/matmul_small_n_gemv_test.cc
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "gtest/gtest.h"
+
+#include <memory>
+#include <vector>
+
+#include "core/framework/float16.h"
+#include "core/providers/cuda/math/matmul_small_n_gemv.h"
+#include "test/util/include/asserts.h"
+
+namespace onnxruntime {
+namespace cuda {
+namespace test {
+namespace {
+
+struct CudaDeviceMemoryDeleter {
+  template <typename T>
+  void operator()(T* p) const {
+    cudaFree(p);
+  }
+};
+
+template <typename T>
+std::unique_ptr<T, CudaDeviceMemoryDeleter> AllocateDeviceMemory(size_t count) {
+  T* buffer{};
+  CUDA_CALL_THROW(cudaMalloc(&buffer, count * sizeof(T)));
+  return std::unique_ptr<T, CudaDeviceMemoryDeleter>(buffer);
+}
+
+TEST(MatMulSmallNGemvTest, HandlesUnevenSplitsAndResetsCounters) {
+  constexpr int m = 3;
+  constexpr int n = 37;
+  constexpr int k = 133;
+
+  std::vector<MLFloat16> a(static_cast<size_t>(m) * k);
+  std::vector<MLFloat16> b(static_cast<size_t>(k) * n);
+  for (int row = 0; row < m; ++row) {
+    std::fill_n(a.begin() + static_cast<size_t>(row) * k, k, MLFloat16(static_cast<float>(row + 1)));
+  }
+  for (int col = 0; col < n; ++col) {
+    const MLFloat16 value(col % 2 == 0 ? 1.0f : 0.5f);
+    for (int row = 0; row < k; ++row) {
+      b[static_cast<size_t>(row) * n + col] = value;
+    }
+  }
+
+  auto device_a = AllocateDeviceMemory<MLFloat16>(a.size());
+  auto device_b = AllocateDeviceMemory<MLFloat16>(b.size());
+  auto device_c = AllocateDeviceMemory<MLFloat16>(static_cast<size_t>(m) * n);
+  auto workspace = AllocateDeviceMemory<float>(SmallNGemvWorkspaceElements(m, n, k));
+  auto counter = AllocateDeviceMemory<unsigned int>(SmallNGemvCounterElements(n));
+  CUDA_CALL_THROW(cudaMemcpy(device_a.get(), a.data(), a.size() * sizeof(MLFloat16), cudaMemcpyHostToDevice));
+  CUDA_CALL_THROW(cudaMemcpy(device_b.get(), b.data(), b.size() * sizeof(MLFloat16), cudaMemcpyHostToDevice));
+  CUDA_CALL_THROW(cudaMemset(counter.get(), 0, SmallNGemvCounterElements(n) * sizeof(unsigned int)));
+
+  for (int iteration = 0; iteration < 2; ++iteration) {
+    ASSERT_STATUS_OK(LaunchSmallNGemv(nullptr,
+                                      reinterpret_cast<const half*>(device_a.get()),
+                                      reinterpret_cast<const half*>(device_b.get()),
+                                      reinterpret_cast<half*>(device_c.get()),
+                                      m, n, k, workspace.get(), counter.get()));
+    CUDA_CALL_THROW(cudaDeviceSynchronize());
+
+    std::vector<MLFloat16> output(static_cast<size_t>(m) * n);
+    CUDA_CALL_THROW(cudaMemcpy(output.data(), device_c.get(), output.size() * sizeof(MLFloat16),
+                               cudaMemcpyDeviceToHost));
+    for (int row = 0; row < m; ++row) {
+      for (int col = 0; col < n; ++col) {
+        const float scale = col % 2 == 0 ? 1.0f : 0.5f;
+        EXPECT_EQ(output[static_cast<size_t>(row) * n + col].ToFloat(), k * (row + 1) * scale);
+      }
+    }
+  }
+}
+
+}  // namespace
+}  // namespace test
+}  // namespace cuda
+}  // namespace onnxruntime

--- a/onnxruntime/test/providers/cuda/test_cases/matmul_small_n_gemv_test.cc
+++ b/onnxruntime/test/providers/cuda/test_cases/matmul_small_n_gemv_test.cc
@@ -4,9 +4,10 @@
 #include "gtest/gtest.h"
 
 #include <memory>
+#include <string>
 #include <vector>
 
-#include "core/framework/float16.h"
+#include "core/common/float16.h"
 #include "core/providers/cuda/math/matmul_small_n_gemv.h"
 #include "test/util/include/asserts.h"
 
@@ -29,11 +30,8 @@ std::unique_ptr<T, CudaDeviceMemoryDeleter> AllocateDeviceMemory(size_t count) {
   return std::unique_ptr<T, CudaDeviceMemoryDeleter>(buffer);
 }
 
-TEST(MatMulSmallNGemvTest, HandlesUnevenSplitsAndResetsCounters) {
-  constexpr int m = 3;
-  constexpr int n = 37;
-  constexpr int k = 133;
-
+void RunSmallNGemvCase(int m, int n, int k) {
+  SCOPED_TRACE("m=" + std::to_string(m) + ", n=" + std::to_string(n) + ", k=" + std::to_string(k));
   std::vector<MLFloat16> a(static_cast<size_t>(m) * k);
   std::vector<MLFloat16> b(static_cast<size_t>(k) * n);
   for (int row = 0; row < m; ++row) {
@@ -72,6 +70,18 @@ TEST(MatMulSmallNGemvTest, HandlesUnevenSplitsAndResetsCounters) {
         EXPECT_EQ(output[static_cast<size_t>(row) * n + col].ToFloat(), k * (row + 1) * scale);
       }
     }
+  }
+}
+
+TEST(MatMulSmallNGemvTest, HandlesAllMVariantsAndResetsCounters) {
+  for (int m = 1; m <= 8; ++m) {
+    RunSmallNGemvCase(m, 37, 133);
+  }
+}
+
+TEST(MatMulSmallNGemvTest, HandlesColumnTileBoundaries) {
+  for (const int n : {1, 32, 1024}) {
+    RunSmallNGemvCase(1, n, 128);
   }
 }
 


### PR DESCRIPTION
## Description

Decode-time projections in hybrid / MoE LLMs are GEMVs with an `N` that is too small to fill a cuBLAS tile kernel. On the Qwen3.6-35B-A3B NVFP4 decode loop, router, linear-attention, and shared-expert gate projections repeatedly launch with `M <= 8`, `N <= 1024`, and `K >= 128`.

This PR adds an experimental split-K GEMV kernel for that corner of the shape space. The path remains off by default because real-model measurements are currently slower than cuBLAS.

## Summary of Changes

### Kernel and dispatch

- Adds a row-major FP16 split-K GEMV for `M <= 8`, `N <= 1024`, and `K >= 128`.
- Gates dispatch with `ORT_ENABLE_SMALL_N_GEMV=1`; all ineligible layouts, shapes, transpose modes, and alpha values fall through to cuBLAS.
- Reads the opt-in setting once when each MatMul kernel instance is created, keeping environment parsing out of `Compute()`.
- Compares leading dimensions in `int64_t` so large shape values are not narrowed before eligibility checks.

### Cross-block reduction

- Uses a grid of `(ceil(N / 32), split_k)` so K slices can run across multiple SMs.
- Publishes FP32 partials through volatile global workspace accesses before `__threadfence()` and the completion atomic, following CUDA's last-block reduction visibility pattern.
- Reduces partials in fixed slice order for deterministic output.
- Uses per-invocation scratch for both workspace and completion counters. The caller clears counters before every launch; the kernel does not reset them.

### Tests

- Direct-kernel tests cover every `M` specialization, `N = 1`, `N = 32`, `N = 1024`, uneven K splits, and repeated launches with explicit counter initialization.
- Inputs vary along K and results are checked against an FP32 CPU reference.
- Operator-level MatMul tests enable the feature and cover eligible `M = 8, N = 1` and `M = 8, N = 1024` dispatches plus an ineligible `K = 127` cuBLAS fallback.

## Current Status

The path is default-off because it is currently slower than cuBLAS in the real model. On H200 (SM90) for the target decode shapes:

| | us / call | us / decode step |
|---|---:|---:|
| cuBLAS | 5.0 | 671 |
| this kernel | 10.6 | 1491 |

A standalone microbenchmark had suggested approximately 2.1 us/call after subtracting the back-to-back launch floor. That result kept the small weight matrix resident in H200's L2, while the model reads cold weights. Keeping the implementation behind an opt-in flag preserves it for follow-up work that addresses that cold-read cost.

## Validation

- Compiled `matmul.cc`, `matmul_small_n_gemv.cu`, and both small-N GEMV test translation units with the CUDA 13.0 Release build.
- Ran scoped `lintrunner` checks for all changed source and test files.
- Full `onnxruntime_test_all` linking is currently blocked by an unrelated `-Werror=unused-variable` in `contrib_ops/cuda/bert/paged_attention.cc` on the rebased main branch.

## Checklist

- [x] No behavior change by default
- [x] Cache-safe cross-block workspace publication
- [x] Deterministic fixed-order reduction
- [x] Operator-level enabled dispatch and fallback coverage
- [ ] Enabled by default; blocked on closing the real-model performance gap against cuBLAS