### PR TITLE
[CUDA] Skip FP4 QMoE fc1 activation expansion

### DIFF
--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemv_device.cuh
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemv_device.cuh
@@ -257,7 +257,8 @@ __global__ void moe_gemv_interleaved_swiglu_kernel(
     TypeA* act, uint8_t* weight, TypeA* scales, TypeA* bias, TypeA* out,
     const int64_t* expert_first_token_offset, const int* permuted_row_to_expert, int num_experts,
     int64_t weight_expert_stride, int64_t scale_expert_stride, int inter_size, int k,
-    cutlass_kernels::ActivationParams activation_params) {
+    cutlass_kernels::ActivationParams activation_params,
+    const int* permuted_row_to_source_row, int num_rows) {
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 750))
   using AccessTypeA = typename Details::AccessTypeA;
   using AccessTypeW = typename Details::AccessTypeW;
@@ -310,8 +311,9 @@ __global__ void moe_gemv_interleaved_swiglu_kernel(
       (tid * StepK / (Details::kInterleave * Details::LayoutDetails::kTileSize)) * Details::LayoutDetails::kTileSize +
       ((tid * StepK) % Details::LayoutDetails::kTileSize);
 
+  const int source_row = permuted_row_to_source_row ? permuted_row_to_source_row[row] % num_rows : offset_m;
   GMemIterator<Mandatory, AccessTypeA, CtaM, Details::kAccessNumA, TypeA> act_iterator(
-      act, offset_m * origin_k + real_offset_k, CtaK / Details::kInterleave, origin_k);
+      act, source_row * origin_k + real_offset_k, CtaK / Details::kInterleave, origin_k);
   GMemIterator<Mandatory, AccessTypeW, CtaN, Details::kAccessNumW, uint8_t> weight_iterator(
       weight, (interleaved_offset_n * interleaved_k + tid * StepK) / Details::kElemsPerByteW,
       CtaK / Details::kElemsPerByteW, interleaved_k / Details::kElemsPerByteW);
@@ -395,7 +397,8 @@ static void launch_moe_gemv_interleaved_swiglu(
     TypeA* act, uint8_t* weight, TypeA* scales, TypeA* bias, TypeA* out,
     const int64_t* expert_first_token_offset, const int* permuted_row_to_expert, int num_experts,
     int64_t expanded_num_rows, int64_t inter_size, int64_t k,
-    cutlass_kernels::ActivationParams activation_params, cudaStream_t stream) {
+    cutlass_kernels::ActivationParams activation_params,
+    const int* permuted_row_to_source_row, int num_rows, cudaStream_t stream) {
   const int64_t n = inter_size * 2;
   const int64_t weight_expert_stride = n * k / Details::kElemsPerByteW;
   const int64_t scale_expert_stride = GroupSize == 0 ? n : ((k + GroupSize - 1) / GroupSize) * n;
@@ -404,11 +407,13 @@ static void launch_moe_gemv_interleaved_swiglu(
   if (bias != nullptr) {
     moe_gemv_interleaved_swiglu_kernel<Details, CtaN, Threads, GroupSize, true, TypeA, AccT><<<grid, block, 0, stream>>>(
         act, weight, scales, bias, out, expert_first_token_offset, permuted_row_to_expert, num_experts,
-        weight_expert_stride, scale_expert_stride, static_cast<int>(inter_size), static_cast<int>(k), activation_params);
+        weight_expert_stride, scale_expert_stride, static_cast<int>(inter_size), static_cast<int>(k), activation_params,
+        permuted_row_to_source_row, num_rows);
   } else {
     moe_gemv_interleaved_swiglu_kernel<Details, CtaN, Threads, GroupSize, false, TypeA, AccT><<<grid, block, 0, stream>>>(
         act, weight, scales, bias, out, expert_first_token_offset, permuted_row_to_expert, num_experts,
-        weight_expert_stride, scale_expert_stride, static_cast<int>(inter_size), static_cast<int>(k), activation_params);
+        weight_expert_stride, scale_expert_stride, static_cast<int>(inter_size), static_cast<int>(k), activation_params,
+        permuted_row_to_source_row, num_rows);
   }
 }
 
@@ -443,27 +448,28 @@ static void dispatch_moe_gemv_interleaved_swiglu_group_size(
     TypeA* act, uint8_t* weight, TypeA* scales, TypeA* bias, TypeA* out,
     const int64_t* expert_first_token_offset, const int* permuted_row_to_expert, int num_experts,
     int64_t expanded_num_rows, int64_t inter_size, int64_t k, int group_size,
-    cutlass_kernels::ActivationParams activation_params, cudaStream_t stream) {
+    cutlass_kernels::ActivationParams activation_params,
+    const int* permuted_row_to_source_row, int num_rows, cudaStream_t stream) {
   if (group_size <= 0) {
     launch_moe_gemv_interleaved_swiglu<Details, CtaN, Threads, 0, TypeA, AccT>(
         act, weight, scales, bias, out, expert_first_token_offset, permuted_row_to_expert, num_experts,
-        expanded_num_rows, inter_size, k, activation_params, stream);
+        expanded_num_rows, inter_size, k, activation_params, permuted_row_to_source_row, num_rows, stream);
   } else if (group_size == 16) {
     launch_moe_gemv_interleaved_swiglu<Details, CtaN, Threads, 16, TypeA, AccT>(
         act, weight, scales, bias, out, expert_first_token_offset, permuted_row_to_expert, num_experts,
-        expanded_num_rows, inter_size, k, activation_params, stream);
+        expanded_num_rows, inter_size, k, activation_params, permuted_row_to_source_row, num_rows, stream);
   } else if (group_size == 32) {
     launch_moe_gemv_interleaved_swiglu<Details, CtaN, Threads, 32, TypeA, AccT>(
         act, weight, scales, bias, out, expert_first_token_offset, permuted_row_to_expert, num_experts,
-        expanded_num_rows, inter_size, k, activation_params, stream);
+        expanded_num_rows, inter_size, k, activation_params, permuted_row_to_source_row, num_rows, stream);
   } else if (group_size == 64) {
     launch_moe_gemv_interleaved_swiglu<Details, CtaN, Threads, 64, TypeA, AccT>(
         act, weight, scales, bias, out, expert_first_token_offset, permuted_row_to_expert, num_experts,
-        expanded_num_rows, inter_size, k, activation_params, stream);
+        expanded_num_rows, inter_size, k, activation_params, permuted_row_to_source_row, num_rows, stream);
   } else if (group_size == 128) {
     launch_moe_gemv_interleaved_swiglu<Details, CtaN, Threads, 128, TypeA, AccT>(
         act, weight, scales, bias, out, expert_first_token_offset, permuted_row_to_expert, num_experts,
-        expanded_num_rows, inter_size, k, activation_params, stream);
+        expanded_num_rows, inter_size, k, activation_params, permuted_row_to_source_row, num_rows, stream);
   } else {
     ORT_THROW("unsupported MoE GEMV group_size: ", group_size);
   }

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemv_fp4.cu
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemv_fp4.cu
@@ -295,7 +295,7 @@ void launch_moe_gemv_fp4_symmetric_interleaved_swiglu(
     const int64_t* expert_first_token_offset, const int* permuted_row_to_expert, int num_experts,
     int64_t expanded_num_rows, int64_t inter_size, int64_t k, int group_size, int sm,
     cutlass_kernels::ActivationParams activation_params, MoeGemvConfig config, bool sm80_pair_interleaved,
-    cudaStream_t stream) {
+    const int* permuted_row_to_source_row, int64_t num_rows, cudaStream_t stream) {
   ORT_UNUSED_PARAMETER(sm);
   // Interleaved path: ColumnMajorInterleaved layout + dtype-conditional accumulation + smaller
   // CtaN, fusing SwiGLU. Taken either via the opt-in env knob or because the caller pre-packed a
@@ -312,13 +312,13 @@ void launch_moe_gemv_fp4_symmetric_interleaved_swiglu(
         fiv::dispatch_moe_gemv_interleaved_swiglu_group_size<DetailsI, kInterleavedCtaN, kInterleavedThreads, T, T>(
             const_cast<T*>(act), const_cast<uint8_t*>(weight), const_cast<T*>(scales), const_cast<T*>(bias), out,
             expert_first_token_offset, permuted_row_to_expert, num_experts, expanded_num_rows, inter_size, k,
-            group_size, activation_params, stream);
+            group_size, activation_params, permuted_row_to_source_row, static_cast<int>(num_rows), stream);
       } else {
         fiv::dispatch_moe_gemv_interleaved_swiglu_group_size<DetailsI, kInterleavedCtaN, kInterleavedThreads, T,
                                                              Fp4GemvAccT<T>>(
             const_cast<T*>(act), const_cast<uint8_t*>(weight), const_cast<T*>(scales), const_cast<T*>(bias), out,
             expert_first_token_offset, permuted_row_to_expert, num_experts, expanded_num_rows, inter_size, k,
-            group_size, activation_params, stream);
+            group_size, activation_params, permuted_row_to_source_row, static_cast<int>(num_rows), stream);
       }
     };
     if (sm80_pair_interleaved) {
@@ -336,7 +336,7 @@ void launch_moe_gemv_fp4_symmetric_interleaved_swiglu(
     fiv::dispatch_moe_gemv_interleaved_swiglu_group_size<Details, cta_n(), threads(), T, Fp4GemvAccT<T>>(
         const_cast<T*>(act), const_cast<uint8_t*>(weight), const_cast<T*>(scales), const_cast<T*>(bias), out,
         expert_first_token_offset, permuted_row_to_expert, num_experts, expanded_num_rows, inter_size, k, group_size,
-        activation_params, stream);
+        activation_params, permuted_row_to_source_row, static_cast<int>(num_rows), stream);
   };
   if (config == MoeGemvConfig::kCtaN16) {
     launch([] { return kCtaN16; }, [] { return kDefaultThreads; });
@@ -352,7 +352,8 @@ template void launch_moe_gemv_fp4_symmetric<half>(
     int64_t, int64_t, int64_t, int, int, MoeGemvConfig, bool, cudaStream_t);
 template void launch_moe_gemv_fp4_symmetric_interleaved_swiglu<half>(
     const half*, const uint8_t*, const half*, const half*, half*, const int64_t*, const int*, int,
-    int64_t, int64_t, int64_t, int, int, cutlass_kernels::ActivationParams, MoeGemvConfig, bool, cudaStream_t);
+    int64_t, int64_t, int64_t, int, int, cutlass_kernels::ActivationParams, MoeGemvConfig, bool,
+    const int*, int64_t, cudaStream_t);
 #ifdef ENABLE_BF16
 template void launch_moe_gemv_fp4_symmetric<__nv_bfloat16>(
     const __nv_bfloat16*, const uint8_t*, const __nv_bfloat16*, const __nv_bfloat16*, __nv_bfloat16*,
@@ -360,7 +361,7 @@ template void launch_moe_gemv_fp4_symmetric<__nv_bfloat16>(
 template void launch_moe_gemv_fp4_symmetric_interleaved_swiglu<__nv_bfloat16>(
     const __nv_bfloat16*, const uint8_t*, const __nv_bfloat16*, const __nv_bfloat16*, __nv_bfloat16*,
     const int64_t*, const int*, int, int64_t, int64_t, int64_t, int, int, cutlass_kernels::ActivationParams,
-    MoeGemvConfig, bool, cudaStream_t);
+    MoeGemvConfig, bool, const int*, int64_t, cudaStream_t);
 #endif
 
 }  // namespace moe_gemv

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemv_fp4.h
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemv_fp4.h
@@ -97,7 +97,8 @@ void launch_moe_gemv_fp4_symmetric_interleaved_swiglu(
     const T* act, const uint8_t* weight, const T* scales, const T* bias, T* out,
     const int64_t* expert_first_token_offset, const int* permuted_row_to_expert, int num_experts, int64_t expanded_num_rows,
     int64_t inter_size, int64_t k, int group_size, int sm, cutlass_kernels::ActivationParams activation_params,
-    MoeGemvConfig config, bool sm80_pair_interleaved, cudaStream_t stream);
+    MoeGemvConfig config, bool sm80_pair_interleaved,
+    const int* permuted_row_to_source_row, int64_t num_rows, cudaStream_t stream);
 
 }  // namespace moe_gemv
 }  // namespace kernels

--- a/onnxruntime/contrib_ops/cuda/moe/moe_quantization.cc
+++ b/onnxruntime/contrib_ops/cuda/moe/moe_quantization.cc
@@ -63,6 +63,10 @@ bool Fp4GemvAutotuneLogEnabled() {
   return onnxruntime::ParseEnvironmentVariableWithDefault<int>("ORT_FP4_GEMV_AUTOTUNE_LOG", 0) == 1;
 }
 
+bool Fp4GemvSkipExpandDisabled() {
+  return onnxruntime::ParseEnvironmentVariableWithDefault<int>("ORT_DISABLE_FP4_GEMV_SKIP_EXPAND", 0) == 1;
+}
+
 const char* QMoEGemvConfigName(onnxruntime::llm::kernels::moe_gemv::MoeGemvConfig config) {
   using onnxruntime::llm::kernels::moe_gemv::MoeGemvConfig;
   if (config == MoeGemvConfig::kCtaN16) {
@@ -1467,19 +1471,22 @@ Status QMoE::ComputeInternal(OpKernelContext* context) const {
 
       auto run_fused = [&](auto* t_ptr) {
         using T = std::remove_pointer_t<decltype(t_ptr)>;
-        ck::expandInputRowsKernelLauncher<T, T>(
-            static_cast<const T*>(input->DataRaw()), static_cast<T*>(p_act_buf.get()),
-            nullptr, nullptr, p_r2u, num_rows, hidden, static_cast<int>(k_), num_experts,
-            quant_params, false, p_efto, nullptr, nullptr, nullptr, stream);
+        const bool skip_expand = !Fp4GemvSkipExpandDisabled();
+        if (!skip_expand) {
+          ck::expandInputRowsKernelLauncher<T, T>(
+              static_cast<const T*>(input->DataRaw()), static_cast<T*>(p_act_buf.get()),
+              nullptr, nullptr, p_r2u, num_rows, hidden, static_cast<int>(k_), num_experts,
+              quant_params, false, p_efto, nullptr, nullptr, nullptr, stream);
+        }
 
         auto launch_fc1 = [&](MoeGemvConfig cfg) {
           gemv::launch_moe_gemv_fp4_symmetric_interleaved_swiglu<T>(
-              static_cast<const T*>(p_act_buf.get()),
+              skip_expand ? static_cast<const T*>(input->DataRaw()) : static_cast<const T*>(p_act_buf.get()),
               gemv_fc1_weight,
               static_cast<const T*>(gemv_fp4_fc1_scales_.get()),
               static_cast<const T*>(fc1_bias), static_cast<T*>(p_fc1_buf.get()),
               p_efto, p_exp, num_experts, expanded, inter, hidden, gemv_group_size, sm_, act_params, cfg,
-              fc1_gemv_sm80_layout, stream);
+              fc1_gemv_sm80_layout, skip_expand ? p_r2u : nullptr, num_rows, stream);
         };
         auto launch_fc2 = [&](MoeGemvConfig cfg) {
           gemv::launch_moe_gemv_fp4_symmetric<T>(

--- a/onnxruntime/contrib_ops/cuda/moe/moe_quantization.cc
+++ b/onnxruntime/contrib_ops/cuda/moe/moe_quantization.cc
@@ -313,6 +313,7 @@ QMoE::QMoE(const OpKernelInfo& op_kernel_info) : CudaKernel(op_kernel_info), MoE
       // ORT_FP4_SM80_GEMM constructor-plumbed decision below).
       enable_fp4_gemv_autotune_ = Fp4GemvAutotuneEnabled();
       enable_fp4_gemv_autotune_log_ = Fp4GemvAutotuneLogEnabled();
+      fp4_gemv_skip_expand_ = !Fp4GemvSkipExpandDisabled();
 #else
       use_fp4_dequant_fallback_ = true;
 #endif
@@ -355,6 +356,7 @@ QMoE::QMoE(const OpKernelInfo& op_kernel_info) : CudaKernel(op_kernel_info), MoE
       }
       enable_fp4_gemv_autotune_ = Fp4GemvAutotuneEnabled();
       enable_fp4_gemv_autotune_log_ = Fp4GemvAutotuneLogEnabled();
+      fp4_gemv_skip_expand_ = !Fp4GemvSkipExpandDisabled();
 #endif
     } else if (quant_type_ == "wfp4afp8") {
       ORT_ENFORCE(expert_weight_bits_ == 4, "WFP4AFP8 (W4A8) quantization requires expert_weight_bits=4");
@@ -1471,7 +1473,7 @@ Status QMoE::ComputeInternal(OpKernelContext* context) const {
 
       auto run_fused = [&](auto* t_ptr) {
         using T = std::remove_pointer_t<decltype(t_ptr)>;
-        const bool skip_expand = !Fp4GemvSkipExpandDisabled();
+        const bool skip_expand = fp4_gemv_skip_expand_;
         if (!skip_expand) {
           ck::expandInputRowsKernelLauncher<T, T>(
               static_cast<const T*>(input->DataRaw()), static_cast<T*>(p_act_buf.get()),
@@ -1527,7 +1529,8 @@ Status QMoE::ComputeInternal(OpKernelContext* context) const {
             return elapsed_ms;
           };
 
-          // fc1 reads p_act_buf (populated by the expand above).
+          // fc1 reads the original input through p_r2u when skip-expand is enabled; otherwise
+          // it reads p_act_buf populated by the expand above.
           const bool log_tune = enable_fp4_gemv_autotune_log_;
           float best_fc1 = std::numeric_limits<float>::max();
           for (MoeGemvConfig cfg : kCandidates) {

--- a/onnxruntime/contrib_ops/cuda/moe/moe_quantization.h
+++ b/onnxruntime/contrib_ops/cuda/moe/moe_quantization.h
@@ -140,6 +140,9 @@ class QMoE final : public CudaKernel, public MoEBase {
   // fc2 GEMV -> finalize) instead of dequantizing to dense weights. Falls back to the
   // dequant path for unsupported shapes (prefill / large batch).
   bool enable_fp4_gemv_ = false;
+  // Read once during op construction so ORT_DISABLE_FP4_GEMV_SKIP_EXPAND follows the same
+  // session-scoped configuration model as the other FP4 GEMV environment options.
+  bool fp4_gemv_skip_expand_ = true;
   bool enable_fp4_cutlass_gemm_ = false;
   // Native block-scaled CUTLASS FP4xFP4 grouped GEMM for NVFP4 (e2m1 weight + e2m1 activation,
   // block size 16, E4M3 block scales). Blackwell SM120+. When enabled, prefill routes through the

--- a/onnxruntime/test/python/transformers/test_qmoe_fp4_cuda.py
+++ b/onnxruntime/test/python/transformers/test_qmoe_fp4_cuda.py
@@ -355,6 +355,7 @@ class TestQMoEFP4(unittest.TestCase):
         use_swiglu=False,
         block_size=32,
         gemv_mode=None,
+        router_logits_override=None,
     ):
         self._skip_if_no_fp4()
 
@@ -440,7 +441,11 @@ class TestQMoEFP4(unittest.TestCase):
 
         # ── run inference ──────────────────────────────────────────
         input_tensor = torch.randn(num_tokens, hidden_size, device=device, dtype=torch_dtype)
-        router_logits = torch.randn(num_tokens, num_experts, device=device, dtype=torch_dtype)
+        if router_logits_override is None:
+            router_logits = torch.randn(num_tokens, num_experts, device=device, dtype=torch_dtype)
+        else:
+            router_logits = torch.tensor(router_logits_override, device=device, dtype=torch_dtype)
+            self.assertEqual(tuple(router_logits.shape), (num_tokens, num_experts))
         output_tensor = torch.zeros(num_tokens, hidden_size, device=device, dtype=torch_dtype)
 
         iobinding = session.io_binding()
@@ -496,6 +501,8 @@ class TestQMoEFP4(unittest.TestCase):
             atol,
             f"FP4 MoE parity check failed: max_diff={max_diff:.6f} > atol={atol}",
         )
+
+        return ort_output
 
     # ----------------------------------------------------------------
     # Reference implementation
@@ -735,6 +742,41 @@ class TestQMoEFP4(unittest.TestCase):
             onnx_dtype=onnx_dtype,
             use_swiglu=True,
             gemv_mode="0",
+        )
+
+    def test_fp4_fp16_gemv_skip_expand_parity(self):
+        router_logits = [
+            [0.1, 3.0, -2.0, 1.0, -3.0, 2.0, -4.0, 4.0],
+            [3.0, -4.0, 4.0, -3.0, -2.0, -1.0, 1.0, 2.0],
+            [-4.0, 1.0, 3.0, -3.0, 2.0, 4.0, -2.0, -1.0],
+        ]
+        shape = dict(
+            hidden_size=512,
+            inter_size=512,
+            num_experts=8,
+            top_k=4,
+            num_tokens=3,
+            onnx_dtype=TensorProto.FLOAT16,
+            use_swiglu=True,
+            gemv_mode="1",
+            router_logits_override=router_logits,
+        )
+        env_name = "ORT_DISABLE_FP4_GEMV_SKIP_EXPAND"
+        previous_value = os.environ.get(env_name)
+        try:
+            os.environ[env_name] = "1"
+            expanded_output = self._run_fp4_moe_test(**shape)
+            os.environ[env_name] = "0"
+            skip_expand_output = self._run_fp4_moe_test(**shape)
+        finally:
+            if previous_value is None:
+                os.environ.pop(env_name, None)
+            else:
+                os.environ[env_name] = previous_value
+
+        self.assertTrue(
+            torch.equal(expanded_output, skip_expand_output),
+            "FP4 GEMV skip-expand output differs from the expanded-activation path",
         )
 
     def test_fp4_native_cutlass_row_varying_scales(self):

--- a/onnxruntime/test/python/transformers/test_qmoe_nvfp4_cuda.py
+++ b/onnxruntime/test/python/transformers/test_qmoe_nvfp4_cuda.py
@@ -312,6 +312,7 @@ class TestQMoENVFP4(unittest.TestCase):
         gemv_mode=None,
         input_scale=1.0,
         atol_override=None,
+        router_logits_override=None,
     ):
         self._skip_if_no_fp4()
 
@@ -394,7 +395,11 @@ class TestQMoENVFP4(unittest.TestCase):
                     os.environ["ORT_ENABLE_FP4_GEMV"] = prev_gemv_env
 
         input_tensor = torch.randn(num_tokens, hidden_size, device=device, dtype=torch_dtype) * input_scale
-        router_logits = torch.randn(num_tokens, num_experts, device=device, dtype=torch_dtype)
+        if router_logits_override is None:
+            router_logits = torch.randn(num_tokens, num_experts, device=device, dtype=torch_dtype)
+        else:
+            router_logits = torch.tensor(router_logits_override, device=device, dtype=torch_dtype)
+            self.assertEqual(tuple(router_logits.shape), (num_tokens, num_experts))
         output_tensor = torch.zeros(num_tokens, hidden_size, device=device, dtype=torch_dtype)
 
         iobinding = session.io_binding()
@@ -819,16 +824,28 @@ class TestQMoENVFP4(unittest.TestCase):
             f"ORT_FP4_GEMV_DEFAULT_TILING=0 run failed:\n{proc.stdout}\n{proc.stderr}",
         )
 
-    def test_nvfp4_fp16_gemv_skip_expand_parity(self):
+    @parameterized.expand(
+        [
+            (TensorProto.FLOAT16,),
+            (TensorProto.BFLOAT16,),
+        ]
+    )
+    def test_nvfp4_gemv_skip_expand_parity(self, onnx_dtype):
+        router_logits = [
+            [0.1, 3.0, -2.0, 1.0, -3.0, 2.0, -4.0, 4.0],
+            [3.0, -4.0, 4.0, -3.0, -2.0, -1.0, 1.0, 2.0],
+            [-4.0, 1.0, 3.0, -3.0, 2.0, 4.0, -2.0, -1.0],
+        ]
         shape = dict(
             hidden_size=512,
             inter_size=512,
             num_experts=8,
-            top_k=8,
+            top_k=4,
             num_tokens=3,
-            onnx_dtype=TensorProto.FLOAT16,
+            onnx_dtype=onnx_dtype,
             use_swiglu=True,
             gemv_mode="1",
+            router_logits_override=router_logits,
         )
         env_name = "ORT_DISABLE_FP4_GEMV_SKIP_EXPAND"
         previous_value = os.environ.get(env_name)
@@ -843,6 +860,8 @@ class TestQMoENVFP4(unittest.TestCase):
             else:
                 os.environ[env_name] = previous_value
 
+        # Each helper call has already checked its output against the dequantized PyTorch
+        # reference. Exact equality here isolates the activation-row addressing difference.
         self.assertTrue(
             torch.equal(expanded_output, skip_expand_output),
             "FP4 GEMV skip-expand output differs from the expanded-activation path",

--- a/onnxruntime/test/python/transformers/test_qmoe_nvfp4_cuda.py
+++ b/onnxruntime/test/python/transformers/test_qmoe_nvfp4_cuda.py
@@ -819,6 +819,35 @@ class TestQMoENVFP4(unittest.TestCase):
             f"ORT_FP4_GEMV_DEFAULT_TILING=0 run failed:\n{proc.stdout}\n{proc.stderr}",
         )
 
+    def test_nvfp4_fp16_gemv_skip_expand_parity(self):
+        shape = dict(
+            hidden_size=512,
+            inter_size=512,
+            num_experts=8,
+            top_k=8,
+            num_tokens=3,
+            onnx_dtype=TensorProto.FLOAT16,
+            use_swiglu=True,
+            gemv_mode="1",
+        )
+        env_name = "ORT_DISABLE_FP4_GEMV_SKIP_EXPAND"
+        previous_value = os.environ.get(env_name)
+        try:
+            os.environ[env_name] = "1"
+            expanded_output = self._run_nvfp4_moe_test(**shape)
+            os.environ[env_name] = "0"
+            skip_expand_output = self._run_nvfp4_moe_test(**shape)
+        finally:
+            if previous_value is None:
+                os.environ.pop(env_name, None)
+            else:
+                os.environ[env_name] = previous_value
+
+        self.assertTrue(
+            torch.equal(expanded_output, skip_expand_output),
+            "FP4 GEMV skip-expand output differs from the expanded-activation path",
+        )
+
     def test_nvfp4_fp16_gemv_vs_fallback_parity(self):
         # Dispatch-equivalence regression: run the identical decode-shaped NVFP4 case twice — once
         # forcing the fused FP4 GEMV path (ORT_ENABLE_FP4_GEMV=1) and once forcing the dequant


### PR DESCRIPTION
## Description

Stacked on #31159; review only the top commit.

This removes the standalone FP4 QMoE fc1 activation expansion during GEMV decode. Instead, fc1 maps each permuted row back to its source token with `permuted_row_to_source_row[row] % num_rows`; fc2 remains unchanged because it consumes the expanded fc1 output.

## Summary of Changes

- Pass the permuted-row-to-source-row mapping through all FP4 interleaved SwiGLU GEMV launch variants.
- Read fc1 activations directly from the original input while preserving PR 31159's SM80 pair-interleaved weight layout.
- Keep the legacy path available with `ORT_DISABLE_FP4_GEMV_SKIP_EXPAND=1` for same-binary comparison.
- Add an exact-output parity test for the MTP shape (`num_tokens=3`, `top_k=8`) with skip-expand enabled and disabled.

## Performance

H200, Qwen3.6 35B A3B NVFP4, MTP N=3, paired same-binary A/B:

- Removes 40 `expandInputRows` launches per decoding step.
- Removes 94.651 us/step of activation expansion.
- Adds 10.377 us/step to fc1 source-row lookup.
- Saves 84.274 us/step across named kernels.
- Saves 0.097695 ms/step median end-to-end (1.314%).

## Testing

- `lintrunner -a` on the five changed files.
- Compiled `moe_gemv_fp4.cu` and `moe_quantization.cc` against the exact #31159 head.
- New expanded-vs-skip-expand regression passes with exact tensor equality.
- 23 NVFP4 QMoE CUDA tests pass locally; the separately isolated large-input scaling test fails identically with skip-expand enabled and disabled on the pre-existing integration binary.

## Checklist

- [x] Tests added/updated
- [x] No breaking changes
- [x] No documentation changes required
