### PR TITLE
Fix WebGPU data transfer callbacks on Windows x86

### DIFF
--- a/onnxruntime/core/providers/webgpu/webgpu_provider_factory.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_provider_factory.cc
@@ -354,9 +354,10 @@ struct WebGpuDataTransferImpl : OrtDataTransferImpl {
     Release = ReleaseImpl;          // OrtDataTransferImpl::Release callback
   }
 
-  static bool CanCopyImpl(const OrtDataTransferImpl* this_ptr,
-                          const OrtMemoryDevice* src_memory_device,
-                          const OrtMemoryDevice* dst_memory_device) noexcept {
+  static bool ORT_API_CALL CanCopyImpl(
+      const OrtDataTransferImpl* this_ptr,
+      const OrtMemoryDevice* src_memory_device,
+      const OrtMemoryDevice* dst_memory_device) noexcept {
     const auto& impl = *static_cast<const WebGpuDataTransferImpl*>(this_ptr);
     OrtMemoryInfoDeviceType src_type = impl.ep_api.MemoryDevice_GetDeviceType(src_memory_device);
     OrtMemoryInfoDeviceType dst_type = impl.ep_api.MemoryDevice_GetDeviceType(dst_memory_device);
@@ -398,11 +399,12 @@ struct WebGpuDataTransferImpl : OrtDataTransferImpl {
            (src_type == OrtMemoryInfoDeviceType_CPU && dst_type == OrtMemoryInfoDeviceType_GPU);
   }
 
-  static OrtStatus* CopyTensorsImpl(OrtDataTransferImpl* this_ptr,
-                                    const OrtValue** src_tensors,
-                                    OrtValue** dst_tensors,
-                                    OrtSyncStream** /*streams*/,
-                                    size_t num_tensors) noexcept {
+  static OrtStatus* ORT_API_CALL CopyTensorsImpl(
+      OrtDataTransferImpl* this_ptr,
+      const OrtValue** src_tensors,
+      OrtValue** dst_tensors,
+      OrtSyncStream** /*streams*/,
+      size_t num_tensors) noexcept {
     auto& impl = *static_cast<WebGpuDataTransferImpl*>(this_ptr);
 
     if (num_tensors == 0) {
@@ -461,7 +463,8 @@ struct WebGpuDataTransferImpl : OrtDataTransferImpl {
     return nullptr;
   }
 
-  static void ReleaseImpl(OrtDataTransferImpl* this_ptr) noexcept {
+  static void ORT_API_CALL ReleaseImpl(
+      OrtDataTransferImpl* this_ptr) noexcept {
     auto* p_impl = static_cast<WebGpuDataTransferImpl*>(this_ptr);
     int context_id = p_impl->context_id_;
     bool data_transfer_initialized = false;


### PR DESCRIPTION
### Description
Add `ORT_API_CALL` to WebGPU data-transfer callbacks so their calling convention matches OrtDataTransferImpl.

### Motivation and Context
On Windows x86, ORT_API_CALL expands to __stdcall. Without it, assigning CanCopyImpl, CopyTensorsImpl, and ReleaseImpl to the C API callback table fails due to incompatible function-pointer types.

This is ABI-neutral on Windows x64/ARM64 and non-Windows platforms.

Validated by building ONNX Runtime with WebGPU for Windows x86 and running DLL loading, environment creation, WebGPU registration, and Win32k sandbox tests.