### PR TITLE
[CUDA] Support bfloat16 in AllReduce, AllGather and AllToAll

### DIFF
--- a/onnxruntime/contrib_ops/cuda/collective/nccl_kernels.cc
+++ b/onnxruntime/contrib_ops/cuda/collective/nccl_kernels.cc
@@ -38,6 +38,8 @@ ncclDataType_t GetNcclDataType(onnxruntime::MLDataType type) {
     return ncclInt64;
   } else if (type == DataTypeImpl::GetType<MLFloat16>()) {
     return ncclFloat16;
+  } else if (type == DataTypeImpl::GetType<BFloat16>()) {
+    return ncclBfloat16;
   } else if (type == DataTypeImpl::GetType<float>()) {
     return ncclFloat32;
   } else if (type == DataTypeImpl::GetType<double>()) {
@@ -382,7 +384,10 @@ ONNX_OPERATOR_KERNEL_EX(
     (*KernelDefBuilder::Create())
         .VariadicAlias(0, 0)  // outputs and inputs are mapped one to one
         .AllocateInputsContiguously()
-        .TypeConstraint("T", DataTypeImpl::AllIEEEFloatTensorTypes()),
+        .TypeConstraint("T", {DataTypeImpl::GetTensorType<float>(),
+                              DataTypeImpl::GetTensorType<double>(),
+                              DataTypeImpl::GetTensorType<MLFloat16>(),
+                              DataTypeImpl::GetTensorType<BFloat16>()}),
     AllReduce);
 
 ONNX_OPERATOR_KERNEL_EX(

--- a/onnxruntime/core/graph/contrib_ops/collective_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/collective_defs.cc
@@ -21,8 +21,8 @@ void RegisterCollectiveOps() {
       .Output(0, "output", "reduced tensors", "T", OpSchema::Variadic)
       .TypeConstraint(
           "T",
-          {"tensor(float16)", "tensor(float)", "tensor(double)"},
-          "Constrain to float, float16 and double tensors.")
+          {"tensor(float16)", "tensor(bfloat16)", "tensor(float)", "tensor(double)"},
+          "Constrain to float, float16, bfloat16 and double tensors.")
       .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
         propagateShapeAndTypeFromFirstInput(ctx);
       });
@@ -42,8 +42,9 @@ void RegisterCollectiveOps() {
       .Output(0, "output", "gathered tensors", "T", OpSchema::Variadic)
       .TypeConstraint(
           "T",
-          {"tensor(float16)", "tensor(float)", "tensor(double)", "tensor(int64)", "tensor(bool)"},
-          "Constrain to bool, float, float16 and double tensors.")
+          {"tensor(float16)", "tensor(bfloat16)", "tensor(float)", "tensor(double)", "tensor(int64)",
+           "tensor(bool)"},
+          "Constrain to bool, float, float16, bfloat16 and double tensors.")
       .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
         auto group_size = getAttribute(ctx, "group_size", 1);
         auto axis = getAttribute(ctx, "axis", 0);
@@ -74,8 +75,9 @@ void RegisterCollectiveOps() {
       .Output(0, "output", "collected tensors", "T", OpSchema::Variadic)
       .TypeConstraint(
           "T",
-          {"tensor(float16)", "tensor(float)", "tensor(double)", "tensor(int64)", "tensor(bool)"},
-          "Constrain to bool, float, float16 and double tensors.")
+          {"tensor(float16)", "tensor(bfloat16)", "tensor(float)", "tensor(double)", "tensor(int64)",
+           "tensor(bool)"},
+          "Constrain to bool, float, float16, bfloat16 and double tensors.")
       .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
         propagateShapeAndTypeFromFirstInput(ctx);
       });


### PR DESCRIPTION
### Description

Adds bfloat16 support to the CUDA collective ops `AllReduce`, `AllGather` and `AllToAll`.

Three things blocked bf16 today:

1. **`GetNcclDataType` had no `BFloat16` case**, so any bf16 tensor reaching a collective failed at runtime with `Tensor type not supported in NCCL`. Now mapped to `ncclBfloat16`.
2. **The `AllReduce` CUDA kernel used `DataTypeImpl::AllIEEEFloatTensorTypes()`**, which excludes `BFloat16` because bf16 is not an IEEE format. Replaced with an explicit `float` / `double` / `MLFloat16` / `BFloat16` list.
3. **The op schemas did not list `tensor(bfloat16)`.** Added to all three. Note that the `AllGather` and `AllToAll` kernels already register `DataTypeImpl::AllTensorTypes()`, so for those two the schema was the *only* thing rejecting bf16 — no kernel change was needed.

### Motivation and Context

bf16 is the native dtype of most current LLMs, so a tensor-parallel graph built from one is bf16 end to end. Hitting an fp32-or-fp16-only `AllReduce` at every layer boundary forces either a cast pair around each collective (extra kernels and bandwidth on the critical path, twice per layer) or exporting the whole model in fp16.

This came up while bringing up a tensor-parallel + expert-parallel DeepSeek-V4 export on 8×H200, where each of the 43 layers issues two `AllReduce` on bf16 activations.

### Testing

Validated end to end rather than by unit test, since the distributed collective tests require a multi-GPU host and are opt-in:

- 8-rank TP=8 / EP=8 inference of a 284B bf16 model, 2 × bf16 `AllReduce` per layer × 43 layers, producing correct token sequences.
- A full 800-sample MMLU-Pro run over that deployment.

Happy to add a bf16 case to the existing distributed collective test if reviewers would like it in this PR.

### Note for reviewers

`ncclBfloat16` requires **NCCL ≥ 2.10** (mid-2021). CMake currently only version-checks NCCL for the `USE_NCCL_P2P` define (`≥ 2.7`) and does not enforce a floor, so in principle a build against NCCL 2.7–2.9 would now fail to compile this file. Every CUDA 12/13 toolchain ships far newer NCCL, so I left it unguarded rather than adding `#if NCCL_VERSION_CODE >= NCCL_VERSION(2,10,0)` clutter — but let me know if you would prefer the guard or a hard CMake floor.
