### PR TITLE
Fix cuda 13 windows cuda plugin build

### DIFF
--- a/cmake/onnxruntime_providers_cuda_plugin.cmake
+++ b/cmake/onnxruntime_providers_cuda_plugin.cmake
@@ -226,6 +226,13 @@ if (CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 12.8)
     endif()
 endif()
 
+  if (CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 13.0 AND MSVC)
+    # Suppress unrecognized __pragma warnings emitted from CUDA headers in device code.
+    list(APPEND _cuda_plugin_shared_compile_options
+        "$<$<COMPILE_LANGUAGE:CUDA>:--diag-suppress=20199>"
+    )
+  endif()
+
 if (MSVC)
     list(APPEND _cuda_plugin_shared_compile_options
             "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /permissive>"


### PR DESCRIPTION
Fix build error:
```
  tmpxft_0000783c_00000000-7_flash_fwd_split_hdim32_bf16_sm80.compute_120.cudafe1.cpp
C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\include\curand_poisson.h(642): error #20199-D: unrecognized #p
ragma in device code [C:\Work\onnxruntime\build_plugin\Release\onnxruntime_providers_cuda_plugin_llm.vcxproj]
        __pragma(warning(push)) __pragma(warning(disable:4996)) __pragma(nv_diagnostic push) __pragma(nv_diag_suppress
  1444)
                 ^
  Remark: The warnings can be suppressed with "-diag-suppress <warning-number>"
```