### PR TITLE
[Build] Exclude sm120 TMA in Windows Cuda 13 plugin 

### DIFF
--- a/cmake/onnxruntime_providers_cuda.cmake
+++ b/cmake/onnxruntime_providers_cuda.cmake
@@ -577,7 +577,9 @@
         endif()
       endif()
 
-      if(onnxruntime_cuda_sm120_tma_srcs)
+      # CUDA 13 generates host stubs with 128-byte aligned by-value CUTLASS parameters for these
+      # native SM120 TMA kernels. MSVC rejects those stubs with C2719, so retain the portable path.
+      if(onnxruntime_cuda_sm120_tma_srcs AND (NOT MSVC OR CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 13.0))
         onnxruntime_filter_cuda_archs(_ort_sm120_cuda_architectures MIN_SM 120)
         if(_ort_sm120_cuda_architectures)
           onnxruntime_add_cuda_object_library(

--- a/cmake/onnxruntime_providers_cuda_plugin.cmake
+++ b/cmake/onnxruntime_providers_cuda_plugin.cmake
@@ -324,7 +324,9 @@ if(NOT onnxruntime_DISABLE_CONTRIB_OPS)
     endif()
   endif()
 
-  if(_cuda_plugin_sm120_tma_srcs)
+  # CUDA 13 generates host stubs with 128-byte aligned by-value CUTLASS parameters for these
+  # native SM120 TMA kernels. MSVC rejects those stubs with C2719, so retain the portable path.
+  if(_cuda_plugin_sm120_tma_srcs AND (NOT MSVC OR CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 13.0))
     onnxruntime_filter_cuda_archs(_plugin_sm120_cuda_architectures MIN_SM 120)
     if(_plugin_sm120_cuda_architectures)
       onnxruntime_add_cuda_plugin_object_library(


### PR DESCRIPTION
To avoid build error like
```
C:\Users\cloudtest\AppData\Local\Temp\tmpxft_00000bec_00000000-7_matmul_block_scaled_fp4_sm120.compute_120.cudafe1.stub.c(93): error C2719: 'unnamed-parameter': formal parameter with requested alignment of 128 won't be aligned 
```