### PR TITLE
[Build] Disable SM120 TMA kernels with MSVC and CUDA 13

### DIFF
--- a/cmake/onnxruntime_providers_cuda.cmake
+++ b/cmake/onnxruntime_providers_cuda.cmake
@@ -577,7 +577,9 @@
         endif()
       endif()
 
-      if(onnxruntime_cuda_sm120_tma_srcs)
+      # CUDA 13 generates host stubs with 128-byte aligned by-value CUTLASS parameters for these
+      # native SM120 TMA kernels. MSVC rejects those stubs with C2719, so retain the portable path.
+      if(onnxruntime_cuda_sm120_tma_srcs AND (NOT MSVC OR CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 13.0))
         onnxruntime_filter_cuda_archs(_ort_sm120_cuda_architectures MIN_SM 120)
         if(_ort_sm120_cuda_architectures)
           onnxruntime_add_cuda_object_library(

--- a/cmake/onnxruntime_providers_cuda_plugin.cmake
+++ b/cmake/onnxruntime_providers_cuda_plugin.cmake
@@ -324,7 +324,9 @@ if(NOT onnxruntime_DISABLE_CONTRIB_OPS)
     endif()
   endif()
 
-  if(_cuda_plugin_sm120_tma_srcs)
+  # CUDA 13 generates host stubs with 128-byte aligned by-value CUTLASS parameters for these
+  # native SM120 TMA kernels. MSVC rejects those stubs with C2719, so retain the portable path.
+  if(_cuda_plugin_sm120_tma_srcs AND (NOT MSVC OR CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 13.0))
     onnxruntime_filter_cuda_archs(_plugin_sm120_cuda_architectures MIN_SM 120)
     if(_plugin_sm120_cuda_architectures)
       onnxruntime_add_cuda_plugin_object_library(


### PR DESCRIPTION
## Description

CUDA 13 generates host stubs with 128-byte aligned by-value CUTLASS parameters for the native SM120 TMA kernels. MSVC rejects those stubs with C2719.

Skip the SM120 TMA object libraries only for MSVC builds using CUDA 13 or newer. Non-MSVC builds and MSVC builds with older CUDA versions retain native SM120 support.

The MatMulBlockQuantizedFp4Weight native calls are guarded by ORT_ENABLE_BLOCKQUANT_SM120, which is defined only when the object library is created. Windows SM120 therefore uses the existing fused GEMV or dequantize-plus-cuBLAS fallback rather than referencing missing kernels. SM120 grouped MoE dispatch separately checks whether its TMA implementation was compiled.

## Validation

Built the CUDA plugin target on Windows with MSVC 14.44 and CUDA 13.0:

    cmake --build build_plugin/Release --config Release --target onnxruntime_providers_cuda_plugin --parallel 4

The build completed and produced onnxruntime_providers_cuda.dll without compiling the SM120 TMA object target.