### PR TITLE
[Build] Fix cuda plugin linux build errors

### DIFF
--- a/.github/workflows/linux_cuda_plugin_ci.yml
+++ b/.github/workflows/linux_cuda_plugin_ci.yml
@@ -38,7 +38,7 @@ jobs:
         --cuda_home=/usr/local/cuda-13.0
         --cudnn_home=/usr/local/cuda-13.0
         --enable_cuda_profiling
-        --cmake_extra_defines CMAKE_CUDA_ARCHITECTURES=86
+        --cmake_extra_defines 'CMAKE_CUDA_ARCHITECTURES=86-real;120-real;120-virtual'
         --cmake_extra_defines onnxruntime_BUILD_UNIT_TESTS=ON
         --cmake_extra_defines onnxruntime_QUICK_BUILD=ON
         --cmake_extra_defines onnxruntime_BUILD_CUDA_EP_AS_PLUGIN=ON

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1198,6 +1198,9 @@ function(onnxruntime_set_compile_flags target_name)
       # Enable warning
       target_compile_options(${target_name} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:--compiler-options -Wall>" "$<$<NOT:$<COMPILE_LANGUAGE:CUDA>>:-Wall>")
       target_compile_options(${target_name} PRIVATE "$<$<NOT:$<COMPILE_LANGUAGE:CUDA>>:-Wextra>")
+      if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND onnxruntime_target_platform STREQUAL "aarch64")
+        target_compile_options(${target_name} PRIVATE "$<$<COMPILE_LANGUAGE:CXX>:-Wno-psabi>")
+      endif()
       if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang" OR CMAKE_CXX_COMPILER_ID STREQUAL "IBMClang")
         #external/protobuf/src/google/protobuf/arena.h:445:18: error: unused parameter 'p'
         target_compile_options(${target_name} PRIVATE "-Wno-unused-parameter")

--- a/onnxruntime/contrib_ops/cuda/math/matmul_block_scaled_fp4.cc
+++ b/onnxruntime/contrib_ops/cuda/math/matmul_block_scaled_fp4.cc
@@ -208,7 +208,7 @@ Status MatMulBlockQuantizedFp4Weight::ComputeImpl(OpKernelContext* context) cons
     const int64_t rounded_m = RoundUp(m_i, 128);
     const int64_t rounded_n = RoundUp(n_i, 128);
 
-    onnxruntime::Stream* stream = GetComputeStream(context);
+    auto* stream = GetComputeStream(context);
     auto a_packed = GetScratchBuffer<uint8_t>(SafeInt<size_t>(m_i) * SafeInt<size_t>(k_i / 2), stream);
     auto a_scale = GetScratchBuffer<uint8_t>(SafeInt<size_t>(rounded_m) * SafeInt<size_t>(k_scale_blocks), stream);
     IAllocatorUniquePtr<uint8_t> b_scale;


### PR DESCRIPTION
Fix build errors in aarch64:
```
/onnxruntime_src/include/onnxruntime/core/framework/float4.h: In member function ‘std::pair<float, float> onnxruntime::Float4E2M1x2::ToFloat2() const’:

/onnxruntime_src/include/onnxruntime/core/framework/float4.h:173:67: note: parameter passing for argument of type ‘std::pair<float, float>’ when C++17 is enabled changed to match C++14 in GCC 10.1

  173 |   inline ORT_HOST_DEVICE std::pair<float, float> ToFloat2() const {

      |                                                                   ^
```

There is another build error in sm120 that data type shall be void* instead of Stream* for cuda plugin. 
Change Stream to auto, also add sm120 to CI pipeline to avoid similar error in the future.