### PR TITLE
[Build] Fix Windows ARM64 CUDA plugin build

### DIFF
--- a/tools/ci_build/github/azure-pipelines/stages/plugin-win-cuda-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-win-cuda-stage.yml
@@ -250,6 +250,7 @@ stages:
               --skip_tests
               --cmake_extra_defines CMAKE_CUDA_ARCHITECTURES="${{ parameters.cmake_cuda_archs }}"
               --cmake_extra_defines onnxruntime_BUILD_CUDA_EP_AS_PLUGIN=ON
+              --cmake_extra_defines onnxruntime_BUILD_UNIT_TESTS=OFF
               --cmake_extra_defines $(PluginEpVersionDefine)
               $(TelemetryOption)
             workingDirectory: '$(Build.BinariesDirectory)'


### PR DESCRIPTION
The Windows ARM64 CUDA plugin packaging job passes `--skip_tests`, but that option skips test execution only; it does not disable generation and compilation of unit-test targets. Because `onnxruntime_BUILD_UNIT_TESTS` defaults to ON, the job still builds `onnxruntime_mlas_test`.

In the failing CI run, the MLAS library itself compiled and linked successfully, including `sqnbitgemm_kernel_avx512_2bit.cpp`. The later failure was an ARM64 MSVC compiler crash while compiling the unused `onnxruntime_mlas_test` target: `CL.exe` exited with code `57005` (`0xDEAD`) during `test_sqnbitgemm_2bit.cpp`.

This change sets `onnxruntime_BUILD_UNIT_TESTS=OFF` only for the Windows ARM64 CUDA plugin packaging job. The CUDA plugin and MLAS library are still built, and the existing plugin binary verification remains enabled; only unit-test targets that are not run by this packaging job are excluded.

Note: A more complete fix is to split sqnbitgemm_kernel_avx512_2bit.cpp into multiple files.

Validation:
- YAML parsed successfully.
- Confirmed the define is present only in the ARM64 CUDA plugin build block.
- `git diff --check` passed.
- Windows ARM64 CI build remains to be verified by this PR.