### PR TITLE
[Build] update build flags of cuda plugin CI to avoid OOM

### DIFF
--- a/.github/workflows/linux_cuda_plugin_ci.yml
+++ b/.github/workflows/linux_cuda_plugin_ci.yml
@@ -32,13 +32,13 @@ jobs:
         --use_binskim_compliant_compile_flags
         --build_wheel
         --parallel
-        --nvcc_threads 4
-        --flash_nvcc_threads 4
+        --nvcc_threads 2
+        --flash_nvcc_threads 2
         --cuda_version=13.0
         --cuda_home=/usr/local/cuda-13.0
         --cudnn_home=/usr/local/cuda-13.0
         --enable_cuda_profiling
-        --cmake_extra_defines 'CMAKE_CUDA_ARCHITECTURES=86-real;120-real;120-virtual'
+        --cmake_extra_defines 'CMAKE_CUDA_ARCHITECTURES=86-real;120-real'
         --cmake_extra_defines onnxruntime_BUILD_UNIT_TESTS=ON
         --cmake_extra_defines onnxruntime_QUICK_BUILD=ON
         --cmake_extra_defines onnxruntime_BUILD_CUDA_EP_AS_PLUGIN=ON


### PR DESCRIPTION
https://github.com/microsoft/onnxruntime/pull/31616 adds more cuda arch, but did not reduce nvcc_threads. That might cause out of memory.


