### PR TITLE
[MIGraphX EP] Fix output-edge lookup for implicit inputs

### DIFF
--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -752,7 +752,7 @@ std::unique_ptr<IndexedSubGraph> MIGraphXExecutionProvider::GetSubGraph(const st
     if (node->GetOutputEdgesCount() > node->OutputDefs().size()) {
       for (auto it = node->OutputEdgesBegin(), end = node->OutputEdgesEnd(); it != end; ++it) {
         const auto& node_idx = it->GetNode().Index();
-        const auto& output = (it->GetNode()).InputDefs()[it->GetDstArgIndex()];
+        const auto* output = GetOutputNodeArgForEdge(*node, *it);
         if (node_set.find(node_idx) != node_set.end()) {
           const auto& iter = fused_inputs.find(output);
           if (iter != fused_inputs.end()) {

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider_utils.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider_utils.h
@@ -57,6 +57,13 @@ inline std::size_t getNodeInputNum(const Node& node) {
   return node_num;
 }
 
+template <typename EdgeEnd>
+inline const NodeArg* GetOutputNodeArgForEdge(const Node& node, const EdgeEnd& edge) {
+  const auto src_arg_index = edge.GetSrcArgIndex();
+  ORT_ENFORCE(src_arg_index >= 0);
+  return node.OutputDefs().at(static_cast<size_t>(src_arg_index));
+}
+
 inline bool isInputNode(const Node* node, const std::string& name) {
   auto outputs = node->OutputDefs();
   return std::any_of(outputs.begin(), outputs.end(), [&](auto out) {

--- a/onnxruntime/test/providers/migraphx/migraphx_basic_test.cc
+++ b/onnxruntime/test/providers/migraphx/migraphx_basic_test.cc
@@ -188,6 +188,38 @@ TEST(MIGraphXExecutionProviderTest, canEvalArgument) {
   ASSERT_EQ(canEvalNodeArgument(gv, node2, {1}, input_nodes), true);
 }
 
+TEST(MIGraphXExecutionProviderTest, OutputEdgeWithImplicitInputConsumer) {
+  Model model("migraphx_implicit_input_test", false, DefaultLoggingManager().DefaultLogger());
+  auto& graph = model.MainGraph();
+
+  TypeProto float_tensor;
+  float_tensor.mutable_tensor_type()->set_elem_type(TensorProto_DataType_FLOAT);
+  float_tensor.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(1);
+
+  auto& graph_input = graph.GetOrCreateNodeArg("X", &float_tensor);
+  auto& shared_value = graph.GetOrCreateNodeArg("shared", &float_tensor);
+  auto& explicit_output = graph.GetOrCreateNodeArg("explicit_output", &float_tensor);
+  auto& implicit_output = graph.GetOrCreateNodeArg("implicit_output", &float_tensor);
+
+  auto& source = graph.AddNode("source", "Identity", "", {&graph_input}, {&shared_value});
+  graph.AddNode("explicit_consumer", "Identity", "", {&shared_value}, {&explicit_output});
+  auto& implicit_consumer =
+      graph.AddNode("implicit_consumer", "Identity", "", {&graph_input}, {&implicit_output});
+  graph.SetOutputs({&explicit_output, &implicit_output});
+  ASSERT_TRUE(graph.Resolve().IsOK());
+
+  implicit_consumer.MutableImplicitInputDefs().push_back(&shared_value);
+  graph.AddEdge(source.Index(), implicit_consumer.Index(), 0,
+                static_cast<int>(implicit_consumer.InputDefs().size()));
+
+  const auto edge = std::find_if(source.OutputEdgesBegin(), source.OutputEdgesEnd(),
+                                 [&](const Node::EdgeEnd& edge_end) {
+                                   return edge_end.GetNode().Index() == implicit_consumer.Index();
+                                 });
+  ASSERT_NE(edge, source.OutputEdgesEnd());
+  EXPECT_EQ(GetOutputNodeArgForEdge(source, *edge), &shared_value);
+}
+
 #if defined(WIN32)
 static bool SessionHasEp(Ort::Session& session, const char* ep_name) {
   // Access the underlying InferenceSession.


### PR DESCRIPTION
### Description

Fixes #31607.

The MIGraphX EP used a destination argument index to look up an explicit
consumer input when classifying multi-consumer outputs. Destination argument
indices span both explicit and implicit inputs, so a control-flow capture can
make that lookup go past `InputDefs()` and produce an invalid `NodeArg` pointer.

Resolve each edge value from the source node's `OutputDefs()` using
`GetSrcArgIndex()` instead. A small helper validates the source index and uses
bounds-checked access. A focused unit test covers a multi-consumer source whose
second consumer captures the value as an implicit input.

### Motivation and Context

The SSD MobileNet v1 model from #31607 reliably crashed the MIGraphX EP in
`NodeArg::Name()` during session initialization, while the CPU EP initialized
the same model successfully. The same failure reproduced with ROCm 7.2.1 and
MIGraphX 2.15, so it is not limited to the newer stack in the report.

Validation on Radeon RX 9070 / gfx1201:

- Before: CPU EP initialized the model; MIGraphX EP exited with `SIGSEGV`/139.
- After: CPU and MIGraphX EP both initialized the exact model successfully.
- `onnxruntime_provider_test --gtest_filter=MIGraphXExecutionProviderTest.*`:
  6/6 tests passed, including the new implicit-input regression test.
- The three-file patch applies cleanly to current `main`; `git diff --check`
  passes.

The reported ROCm 7.15/MIGraphX `rocm-7.14` combination has not been tested
directly.

---
*This is an experimental, AI-generated code change, reviewed by AMD engineers before submission.*