### PR TITLE
[TensorRT EP] Support multiple optimization profiles

### DIFF
--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -4077,6 +4077,11 @@ Status TensorrtExecutionProvider::CreateNodeComputeInfoFromGraph(const GraphView
       }
     }
 
+    // A cached multi-profile engine was built from explicit profiles. Use those profiles as-is instead of
+    // treating the first profile as an implicit profile that can be expanded from runtime input shapes.
+    const bool has_multi_profile_engine =
+        trt_engine != nullptr && trt_engine->getNbOptimizationProfiles() > 1;
+
     // Check and update shape ranges for dynamic shape inputs.
     for (int i = 0, end = num_inputs; i < end; ++i) {
       auto input = trt_state->network->get()->getInput(i);
@@ -4085,7 +4090,7 @@ Status TensorrtExecutionProvider::CreateNodeComputeInfoFromGraph(const GraphView
 
       // If there is any input tensor in shape_ranges, it means this input tensor has dynamic shape and its profile shape values have not yet resolved.
       // TRT EP will help determine the min/max/opt profile values based on current input tensor value.
-      if (shape_ranges.find(input_name) != shape_ranges.end()) {
+      if (!has_multi_profile_engine && shape_ranges.find(input_name) != shape_ranges.end()) {
         auto status = ApplyProfileShapesFromInputTensorValue(trt_profiles, ctx, input, shape_ranges, input_indexes, shape_tensor_values, shape_tensor_values_int64, stream, &engine_update);
         if (status != Status::OK()) {
           return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL, "TensorRT EP failed to parse input tensor and generate optimization profiles.");

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider.cc
@@ -874,6 +874,104 @@ Status ApplyProfileShapesFromInputTensorValue(std::vector<nvinfer1::IOptimizatio
     break;                                                                                                                                        \
   }
 
+Status SelectOptimizationProfile(Ort::KernelContext& ctx,
+                                 nvinfer1::ICudaEngine* trt_engine,
+                                 nvinfer1::IExecutionContext* trt_context,
+                                 gsl::span<const char* const> input_binding_names,
+                                 const std::unordered_map<std::string, size_t>& input_indexes,
+                                 cudaStream_t stream) {
+  const int32_t num_profiles = trt_engine->getNbOptimizationProfiles();
+  if (num_profiles <= 1) {
+    return Status::OK();
+  }
+
+  struct RuntimeInputShape {
+    const char* name;
+    std::vector<int64_t> shape;
+  };
+
+  std::vector<RuntimeInputShape> runtime_input_shapes;
+  runtime_input_shapes.reserve(input_binding_names.size());
+
+  for (const char* input_name : input_binding_names) {
+    if (trt_engine->isShapeInferenceIO(input_name)) {
+      return ORT_MAKE_STATUS(
+          ONNXRUNTIME, EP_FAIL,
+          "TensorRT EP does not support multiple optimization profiles for engines with shape-tensor input '",
+          input_name, "'.");
+    }
+
+    const auto input_iter = input_indexes.find(input_name);
+    if (input_iter == input_indexes.end()) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
+                             "TensorRT EP could not find ORT input index for engine input '", input_name, "'.");
+    }
+
+    auto input_tensor = ctx.GetInput(input_iter->second);
+    runtime_input_shapes.push_back(
+        RuntimeInputShape{input_name, input_tensor.GetTensorTypeAndShapeInfo().GetShape()});
+  }
+
+  const auto profile_matches = [&](int32_t profile_index) {
+    for (const auto& runtime_input : runtime_input_shapes) {
+      const auto min_dims =
+          trt_engine->getProfileShape(runtime_input.name, profile_index, nvinfer1::OptProfileSelector::kMIN);
+      const auto max_dims =
+          trt_engine->getProfileShape(runtime_input.name, profile_index, nvinfer1::OptProfileSelector::kMAX);
+
+      if (min_dims.nbDims < 0 || max_dims.nbDims < 0) {
+        return false;
+      }
+
+      if (static_cast<size_t>(min_dims.nbDims) != runtime_input.shape.size() ||
+          min_dims.nbDims != max_dims.nbDims) {
+        return false;
+      }
+
+      for (int32_t dimension = 0; dimension < min_dims.nbDims; ++dimension) {
+        const auto actual = runtime_input.shape[dimension];
+        if (actual < min_dims.d[dimension] || actual > max_dims.d[dimension]) {
+          return false;
+        }
+      }
+    }
+
+    return true;
+  };
+
+  const int32_t current_profile = trt_context->getOptimizationProfile();
+  if (current_profile >= 0 && current_profile < num_profiles && profile_matches(current_profile)) {
+    LOGS_DEFAULT(VERBOSE) << "[TensorRT EP] Selected optimization profile " << current_profile;
+    return Status::OK();
+  }
+
+  int32_t selected_profile = -1;
+  for (int32_t profile_index = 0; profile_index < num_profiles; ++profile_index) {
+    if (profile_index == current_profile) {
+      continue;
+    }
+
+    if (profile_matches(profile_index)) {
+      selected_profile = profile_index;
+      break;
+    }
+  }
+
+  if (selected_profile < 0) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
+                           "TensorRT EP could not find an optimization profile for the runtime input shapes.");
+  }
+
+  if (!trt_context->setOptimizationProfileAsync(selected_profile, stream)) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
+                           "TensorRT EP failed to select optimization profile ", selected_profile, ".");
+  }
+  LOGS_DEFAULT(VERBOSE) << "[TensorRT EP] Switched optimization profile from "
+                        << current_profile << " to " << selected_profile;
+
+  return Status::OK();
+}
+
 /*
  * Set TensorRT execution context input.
  *
@@ -4262,6 +4360,9 @@ Status TensorrtExecutionProvider::CreateNodeComputeInfoFromGraph(const GraphView
     /*
      * Set input shapes and bind input buffers
      */
+    ORT_RETURN_IF_ERROR(SelectOptimizationProfile(
+        ctx, trt_engine, trt_context, input_binding_names, input_indexes, stream));
+
     std::vector<IAllocatorUniquePtr<void>> scratch_buffers;
     for (size_t i = 0, end = input_binding_names.size(); i < end; ++i) {
       char const* input_name = input_binding_names[i];
@@ -4604,6 +4705,9 @@ Status TensorrtExecutionProvider::CreateNodeComputeInfoFromPrecompiledEngine(con
     /*
      * Set input shapes and bind input buffers
      */
+    ORT_RETURN_IF_ERROR(SelectOptimizationProfile(
+        ctx, trt_engine, trt_context, input_binding_names, input_indexes, stream));
+
     std::vector<IAllocatorUniquePtr<void>> scratch_buffers;
     for (size_t i = 0, end = input_binding_names.size(); i < end; ++i) {
       char const* input_name = input_binding_names[i];

--- a/onnxruntime/test/providers/tensorrt/tensorrt_basic_test.cc
+++ b/onnxruntime/test/providers/tensorrt/tensorrt_basic_test.cc
@@ -771,9 +771,13 @@ void RunWithOneSessionMultiProfiles(bool multi_thread) {
   const std::string context_model_name_string = multi_thread
                                                     ? "trt_execution_provider_multi_profile_multithread_ctx.onnx"
                                                     : "trt_execution_provider_multi_profile_ctx.onnx";
+  const std::string cache_directory = multi_thread
+                                          ? "trt_execution_provider_multi_profile_multithread_cache"
+                                          : "trt_execution_provider_multi_profile_cache";
   const PathString context_model_name = ToPathString(context_model_name_string);
   std::filesystem::remove(model_name);
   std::filesystem::remove(context_model_name);
+  std::filesystem::remove_all(cache_directory);
   CreateBaseModel(model_name, "multi_profile_test", {1, -1, -1});
 
   SessionOptions so;
@@ -793,6 +797,9 @@ void RunWithOneSessionMultiProfiles(bool multi_thread) {
   params.trt_dump_ep_context_model = 1;
   params.trt_ep_context_embed_mode = 1;
   params.trt_ep_context_file_path = context_model_name_string.c_str();
+  params.trt_engine_cache_enable = 1;
+  params.trt_engine_cache_path = cache_directory.c_str();
+  params.trt_engine_cache_prefix = "multi_profile";
 
   ASSERT_STATUS_OK(session_object.RegisterExecutionProvider(TensorrtExecutionProviderWithOptions(&params)));
   ASSERT_STATUS_OK(session_object.Load(model_name));
@@ -851,6 +858,27 @@ void RunWithOneSessionMultiProfiles(bool multi_thread) {
 
   run_profiles(session_object);
 
+  const auto engine_cache_files = GetCachesByType(cache_directory, ".engine");
+  const auto profile_cache_files = GetCachesByType(cache_directory, ".profile");
+  ASSERT_EQ(engine_cache_files.size(), 1);
+  ASSERT_EQ(profile_cache_files.size(), 1);
+  const auto engine_cache = ReadFileFromDisk(engine_cache_files[0]);
+  const auto profile_cache = ReadFileFromDisk(profile_cache_files[0]);
+
+  InferenceSession cache_session{so, GetEnvironment()};
+  OrtTensorRTProviderOptionsV2 cache_params;
+  cache_params.trt_engine_cache_enable = 1;
+  cache_params.trt_engine_cache_path = cache_directory.c_str();
+  cache_params.trt_engine_cache_prefix = "multi_profile";
+  ASSERT_STATUS_OK(cache_session.RegisterExecutionProvider(
+      TensorrtExecutionProviderWithOptions(&cache_params)));
+  ASSERT_STATUS_OK(cache_session.Load(model_name));
+  ASSERT_STATUS_OK(cache_session.Initialize());
+
+  run_profiles(cache_session);
+  EXPECT_EQ(ReadFileFromDisk(engine_cache_files[0]), engine_cache);
+  EXPECT_EQ(ReadFileFromDisk(profile_cache_files[0]), profile_cache);
+
   InferenceSession context_session{so, GetEnvironment()};
   OrtTensorRTProviderOptionsV2 context_params;
   context_params.trt_ep_context_embed_mode = 1;
@@ -877,6 +905,7 @@ void RunWithOneSessionMultiProfiles(bool multi_thread) {
 
   std::filesystem::remove(model_name);
   std::filesystem::remove(context_model_name);
+  std::filesystem::remove_all(cache_directory);
 }
 
 TEST(TensorrtExecutionProviderTest, MultiProfilesSingleThread) {

--- a/onnxruntime/test/providers/tensorrt/tensorrt_basic_test.cc
+++ b/onnxruntime/test/providers/tensorrt/tensorrt_basic_test.cc
@@ -764,18 +764,26 @@ TEST(TensorrtExecutionProviderTest, DDSOutputTest) {
   ASSERT_TRUE(status.IsOK());
 }
 
-TEST(TensorrtExecutionProviderTest, SelectOptimizationProfile) {
-  const PathString model_name = ORT_TSTR("trt_execution_provider_multi_profile_test.onnx");
-  const PathString context_model_name = ORT_TSTR("trt_execution_provider_multi_profile_ctx.onnx");
+void RunWithOneSessionMultiProfiles(bool multi_thread) {
+  const PathString model_name = multi_thread
+                                    ? ORT_TSTR("trt_execution_provider_multi_profile_multithread_test.onnx")
+                                    : ORT_TSTR("trt_execution_provider_multi_profile_test.onnx");
+  const std::string context_model_name_string = multi_thread
+                                                    ? "trt_execution_provider_multi_profile_multithread_ctx.onnx"
+                                                    : "trt_execution_provider_multi_profile_ctx.onnx";
+  const PathString context_model_name = ToPathString(context_model_name_string);
   std::filesystem::remove(model_name);
   std::filesystem::remove(context_model_name);
   CreateBaseModel(model_name, "multi_profile_test", {1, -1, -1});
 
   SessionOptions so;
-  so.session_logid = "TensorrtExecutionProviderMultiProfileTest";
+  so.session_logid = multi_thread
+                         ? "TensorrtExecutionProviderMultiProfileMultiThreadTest"
+                         : "TensorrtExecutionProviderMultiProfileTest";
   InferenceSession session_object{so, GetEnvironment()};
 
   OrtTensorRTProviderOptionsV2 params;
+  // Create two optimization profiles with fixed input shapes of 1x2x2 and 1x4x4.
   params.trt_profile_min_shapes =
       "X:1x2x2,X:1x4x4,Y:1x2x2,Y:1x4x4,Z:1x2x2,Z:1x4x4";
   params.trt_profile_opt_shapes =
@@ -784,7 +792,7 @@ TEST(TensorrtExecutionProviderTest, SelectOptimizationProfile) {
       "X:1x2x2,X:1x4x4,Y:1x2x2,Y:1x4x4,Z:1x2x2,Z:1x4x4";
   params.trt_dump_ep_context_model = 1;
   params.trt_ep_context_embed_mode = 1;
-  params.trt_ep_context_file_path = "trt_execution_provider_multi_profile_ctx.onnx";
+  params.trt_ep_context_file_path = context_model_name_string.c_str();
 
   ASSERT_STATUS_OK(session_object.RegisterExecutionProvider(TensorrtExecutionProviderWithOptions(&params)));
   ASSERT_STATUS_OK(session_object.Load(model_name));
@@ -822,10 +830,26 @@ TEST(TensorrtExecutionProviderTest, SelectOptimizationProfile) {
     VerifyOutputs(fetches, input_shape, std::vector<float>(element_count, 3.0f));
   };
 
-  run_and_verify(session_object, {1, 2, 2});
-  run_and_verify(session_object, {1, 4, 4});
-  run_and_verify(session_object, {1, 4, 4});
-  run_and_verify(session_object, {1, 2, 2});
+  const auto run_profiles = [&](InferenceSession& session) {
+    if (multi_thread) {
+      std::vector<std::thread> threads;
+      for (int i = 0; i < 4; ++i) {
+        threads.emplace_back(run_and_verify, std::ref(session),
+                             i % 2 == 0 ? std::vector<int64_t>{1, 2, 2} : std::vector<int64_t>{1, 4, 4});
+      }
+      for (auto& thread : threads) {
+        thread.join();
+      }
+      return;
+    }
+
+    run_and_verify(session, {1, 2, 2});
+    run_and_verify(session, {1, 4, 4});
+    run_and_verify(session, {1, 4, 4});
+    run_and_verify(session, {1, 2, 2});
+  };
+
+  run_profiles(session_object);
 
   InferenceSession context_session{so, GetEnvironment()};
   OrtTensorRTProviderOptionsV2 context_params;
@@ -835,9 +859,7 @@ TEST(TensorrtExecutionProviderTest, SelectOptimizationProfile) {
   ASSERT_STATUS_OK(context_session.Load(context_model_name));
   ASSERT_STATUS_OK(context_session.Initialize());
 
-  run_and_verify(context_session, {1, 2, 2});
-  run_and_verify(context_session, {1, 4, 4});
-  run_and_verify(context_session, {1, 2, 2});
+  run_profiles(context_session);
 
   const std::vector<int64_t> unmatched_shape{1, 3, 3};
   const std::vector<float> unmatched_values(9, 1.0f);
@@ -855,6 +877,14 @@ TEST(TensorrtExecutionProviderTest, SelectOptimizationProfile) {
 
   std::filesystem::remove(model_name);
   std::filesystem::remove(context_model_name);
+}
+
+TEST(TensorrtExecutionProviderTest, MultiProfilesSingleThread) {
+  RunWithOneSessionMultiProfiles(false);
+}
+
+TEST(TensorrtExecutionProviderTest, MultiProfilesMultiThread) {
+  RunWithOneSessionMultiProfiles(true);
 }
 
 TEST_P(TensorrtExecutionProviderCacheTest, Run) {

--- a/onnxruntime/test/providers/tensorrt/tensorrt_basic_test.cc
+++ b/onnxruntime/test/providers/tensorrt/tensorrt_basic_test.cc
@@ -764,6 +764,99 @@ TEST(TensorrtExecutionProviderTest, DDSOutputTest) {
   ASSERT_TRUE(status.IsOK());
 }
 
+TEST(TensorrtExecutionProviderTest, SelectOptimizationProfile) {
+  const PathString model_name = ORT_TSTR("trt_execution_provider_multi_profile_test.onnx");
+  const PathString context_model_name = ORT_TSTR("trt_execution_provider_multi_profile_ctx.onnx");
+  std::filesystem::remove(model_name);
+  std::filesystem::remove(context_model_name);
+  CreateBaseModel(model_name, "multi_profile_test", {1, -1, -1});
+
+  SessionOptions so;
+  so.session_logid = "TensorrtExecutionProviderMultiProfileTest";
+  InferenceSession session_object{so, GetEnvironment()};
+
+  OrtTensorRTProviderOptionsV2 params;
+  params.trt_profile_min_shapes =
+      "X:1x2x2,X:1x4x4,Y:1x2x2,Y:1x4x4,Z:1x2x2,Z:1x4x4";
+  params.trt_profile_opt_shapes =
+      "X:1x2x2,X:1x4x4,Y:1x2x2,Y:1x4x4,Z:1x2x2,Z:1x4x4";
+  params.trt_profile_max_shapes =
+      "X:1x2x2,X:1x4x4,Y:1x2x2,Y:1x4x4,Z:1x2x2,Z:1x4x4";
+  params.trt_dump_ep_context_model = 1;
+  params.trt_ep_context_embed_mode = 1;
+  params.trt_ep_context_file_path = "trt_execution_provider_multi_profile_ctx.onnx";
+
+  ASSERT_STATUS_OK(session_object.RegisterExecutionProvider(TensorrtExecutionProviderWithOptions(&params)));
+  ASSERT_STATUS_OK(session_object.Load(model_name));
+  ASSERT_STATUS_OK(session_object.Initialize());
+  ASSERT_TRUE(std::filesystem::exists(context_model_name));
+
+  bool has_trt_node = false;
+  for (const auto& node : session_object.GetSessionState().GetGraphViewer().Nodes()) {
+    has_trt_node |= node.GetExecutionProviderType() == kTensorrtExecutionProvider;
+  }
+  ASSERT_TRUE(has_trt_node);
+
+  auto cpu_allocator = CPUAllocator::DefaultInstance();
+  RunOptions run_options;
+  run_options.run_tag = so.session_logid;
+  const std::vector<std::string> output_names{"M"};
+
+  const auto run_and_verify = [&](InferenceSession& session, const std::vector<int64_t>& input_shape) {
+    const size_t element_count = narrow<size_t>(TensorShape(input_shape).Size());
+    const std::vector<float> input_values(element_count, 1.0f);
+    OrtValue input_x;
+    OrtValue input_y;
+    OrtValue input_z;
+    CreateMLValue<float>(cpu_allocator, input_shape, input_values, &input_x);
+    CreateMLValue<float>(cpu_allocator, input_shape, input_values, &input_y);
+    CreateMLValue<float>(cpu_allocator, input_shape, input_values, &input_z);
+
+    NameMLValMap feeds;
+    feeds.emplace("X", input_x);
+    feeds.emplace("Y", input_y);
+    feeds.emplace("Z", input_z);
+
+    std::vector<OrtValue> fetches;
+    ASSERT_STATUS_OK(session.Run(run_options, feeds, output_names, &fetches));
+    VerifyOutputs(fetches, input_shape, std::vector<float>(element_count, 3.0f));
+  };
+
+  run_and_verify(session_object, {1, 2, 2});
+  run_and_verify(session_object, {1, 4, 4});
+  run_and_verify(session_object, {1, 4, 4});
+  run_and_verify(session_object, {1, 2, 2});
+
+  InferenceSession context_session{so, GetEnvironment()};
+  OrtTensorRTProviderOptionsV2 context_params;
+  context_params.trt_ep_context_embed_mode = 1;
+  ASSERT_STATUS_OK(context_session.RegisterExecutionProvider(
+      TensorrtExecutionProviderWithOptions(&context_params)));
+  ASSERT_STATUS_OK(context_session.Load(context_model_name));
+  ASSERT_STATUS_OK(context_session.Initialize());
+
+  run_and_verify(context_session, {1, 2, 2});
+  run_and_verify(context_session, {1, 4, 4});
+  run_and_verify(context_session, {1, 2, 2});
+
+  const std::vector<int64_t> unmatched_shape{1, 3, 3};
+  const std::vector<float> unmatched_values(9, 1.0f);
+  OrtValue unmatched_input;
+  CreateMLValue<float>(cpu_allocator, unmatched_shape, unmatched_values, &unmatched_input);
+  NameMLValMap unmatched_feeds;
+  unmatched_feeds.emplace("X", unmatched_input);
+  unmatched_feeds.emplace("Y", unmatched_input);
+  unmatched_feeds.emplace("Z", unmatched_input);
+
+  std::vector<OrtValue> fetches;
+  const auto status = context_session.Run(run_options, unmatched_feeds, output_names, &fetches);
+  ASSERT_FALSE(status.IsOK());
+  EXPECT_NE(status.ErrorMessage().find("could not find an optimization profile"), std::string::npos);
+
+  std::filesystem::remove(model_name);
+  std::filesystem::remove(context_model_name);
+}
+
 TEST_P(TensorrtExecutionProviderCacheTest, Run) {
   // GetParam() returns the parameter of following format:
   // ##cache type##_##input shape type##


### PR DESCRIPTION
### Description
Enable TensorRT EP to select among multiple explicit optimization profiles at runtime.

The change keeps the current profile when it matches; otherwise, it selects the first matching profile and switches asynchronously on the inference stream. Both graph-built and EPContext engines are supported. No public API changes are required.

Added single-threaded and concurrent tests with multiple profiles.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

TensorRT supports multiple optimization profiles within one engine, which is useful for workloads with several distinct input-shape ranges. Using one multi-profile engine avoids maintaining separate engines or sessions for each range, reducing duplicated weights and engine resources and potentially saving substantial memory.

TensorRT EP already parses, builds, and serializes multiple profiles. However, its execution context remained on profile 0, so inputs belonging to other profiles failed. This change adds runtime profile selection and switching, completing the existing multi-profile support.
