### PR TITLE
docs: document SessionOptions add_initializer

### DIFF
--- a/docs/python/api_summary.rst
+++ b/docs/python/api_summary.rst
@@ -301,6 +301,32 @@ SessionOptions
 .. autoclass:: onnxruntime.SessionOptions
     :members:
 
+Preload initializers
+""""""""""""""""""""
+
+Use ``SessionOptions.add_initializer(name, ort_value)`` to provide an initializer value when
+creating a session. The name must match an initializer in the model graph. Call the method once
+for each initializer that should be supplied.
+
+When creating values with the public ``onnxruntime.OrtValue`` wrapper, pass its underlying C value
+to ``SessionOptions.add_initializer``. Keep the wrapper objects alive for as long as any session
+created with these options is still in scope.
+
+::
+
+    import numpy as np
+    import onnxruntime as ort
+
+    sess_options = ort.SessionOptions()
+
+    weight = ort.OrtValue.ortvalue_from_numpy(np.array([1.0], dtype=np.float32))
+    bias = ort.OrtValue.ortvalue_from_numpy(np.array([0.0], dtype=np.float32))
+
+    sess_options.add_initializer("weight", weight._get_c_value())
+    sess_options.add_initializer("bias", bias._get_c_value())
+
+    session = ort.InferenceSession("model.onnx", sess_options)
+
 .. autoclass:: onnxruntime.ExecutionMode
     :members:
 

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -2579,14 +2579,25 @@ Applies to session load, initialization, etc. Default is 0.)pbdoc")
           },
           R"pbdoc(Specify the path to the shared library containing the custom op kernels required to run a model.)pbdoc")
       .def(
-          "add_initializer", [](PySessionOptions* options, const char* name, py::object& ml_value_pyobject) -> void {
+          "add_initializer",
+          [](PySessionOptions* options, const char* name, py::object& ml_value_pyobject) -> void {
             ORT_ENFORCE(strcmp(Py_TYPE(ml_value_pyobject.ptr())->tp_name, PYTHON_ORTVALUE_OBJECT_NAME) == 0, "The provided Python object must be an OrtValue");
             // The user needs to ensure that the python OrtValue being provided as an overriding initializer
             // is not destructed as long as any session that uses the provided OrtValue initializer is still in scope
             // This is no different than the native APIs
             const OrtValue* ml_value = ml_value_pyobject.attr(PYTHON_ORTVALUE_NATIVE_OBJECT_ATTR).cast<OrtValue*>();
             ORT_THROW_IF_ERROR(options->value.AddInitializer(name, ml_value));
-          })
+          },
+          R"pbdoc(
+Add a pre-constructed OrtValue as an initializer for the session.
+
+Args:
+  name: initializer name. This must match the initializer name in the model graph.
+  ml_value: OrtValue that supplies the initializer tensor.
+
+Call once for each initializer that should be supplied. The provided OrtValue must remain alive for as long
+as any session created with these SessionOptions is still in scope.
+)pbdoc")
       .def("add_external_initializers", [](PySessionOptions* options, py::list& names, const py::list& ort_values) -> void {
 #if !defined(ORT_MINIMAL_BUILD) && !defined(DISABLE_EXTERNAL_INITIALIZERS)
         const auto init_num = ort_values.size();


### PR DESCRIPTION
## Summary
- Add a Python API docstring for `SessionOptions.add_initializer`.
- Add a Python API docs example showing multiple initializers and the required OrtValue lifetime.

Fixes #13387

## Test Plan
- `python -c` static check that the `add_initializer` binding includes the new pbdoc text
- `python -c` dependency-free RST structure check for the new example block
- `git diff --check`