### PR TITLE
[MIGraphX EP] Fix Segfault that occurs when using IOBind in combination with the MIGraphX EP.

### DIFF
--- a/onnxruntime/core/session/provider_bridge_ort.cc
+++ b/onnxruntime/core/session/provider_bridge_ort.cc
@@ -2076,7 +2076,11 @@ static ProviderLibrary s_library_tensorrt(LIBRARY_PREFIX ORT_TSTR("onnxruntime_p
 #endif
 );
 static ProviderLibrary s_library_nv(LIBRARY_PREFIX ORT_TSTR("onnxruntime_providers_nv_tensorrt_rtx") LIBRARY_EXTENSION);
-static ProviderLibrary s_library_migraphx(LIBRARY_PREFIX ORT_TSTR("onnxruntime_providers_migraphx") LIBRARY_EXTENSION);
+static ProviderLibrary s_library_migraphx(LIBRARY_PREFIX ORT_TSTR("onnxruntime_providers_migraphx") LIBRARY_EXTENSION
+#ifndef _WIN32
+                                        ,
+                                        false /* unload - On Linux if we unload the migraphx shared provider we crash */
+#endif);
 
 // QNN EP can be built either as a static library or a shared library. Can safely define s_library_qnn even if static.
 static ProviderLibrary s_library_qnn(LIBRARY_PREFIX ORT_TSTR("onnxruntime_providers_qnn") LIBRARY_EXTENSION);

--- a/onnxruntime/core/session/provider_bridge_ort.cc
+++ b/onnxruntime/core/session/provider_bridge_ort.cc
@@ -2078,8 +2078,8 @@ static ProviderLibrary s_library_tensorrt(LIBRARY_PREFIX ORT_TSTR("onnxruntime_p
 static ProviderLibrary s_library_nv(LIBRARY_PREFIX ORT_TSTR("onnxruntime_providers_nv_tensorrt_rtx") LIBRARY_EXTENSION);
 static ProviderLibrary s_library_migraphx(LIBRARY_PREFIX ORT_TSTR("onnxruntime_providers_migraphx") LIBRARY_EXTENSION
 #ifndef _WIN32
-                                        ,
-                                        false /* unload - On Linux if we unload the migraphx shared provider we crash */
+                                          ,
+                                          false /* unload - On Linux if we unload the migraphx shared provider we crash */
 #endif
 );
 

--- a/onnxruntime/core/session/provider_bridge_ort.cc
+++ b/onnxruntime/core/session/provider_bridge_ort.cc
@@ -2080,7 +2080,8 @@ static ProviderLibrary s_library_migraphx(LIBRARY_PREFIX ORT_TSTR("onnxruntime_p
 #ifndef _WIN32
                                         ,
                                         false /* unload - On Linux if we unload the migraphx shared provider we crash */
-#endif);
+#endif
+);
 
 // QNN EP can be built either as a static library or a shared library. Can safely define s_library_qnn even if static.
 static ProviderLibrary s_library_qnn(LIBRARY_PREFIX ORT_TSTR("onnxruntime_providers_qnn") LIBRARY_EXTENSION);


### PR DESCRIPTION
### Description
Stop unloading the MIGraphX EP library (onnxruntime_providers_migraphx) in the OrtEnv destructor on Linux, matching the existing behavior of the CUDA, TensorRT, CANN and VitisAI EPs.


### Motivation and Context
On Linux, destroying OrtEnv dlcloses the MIGraphX EP and its ROCm dependency chain, but thread-local data from the GPU run is only destroyed at thread exit — after the code implementing those destructors has been unmapped, causing a segfault (observed with IOBinding). This applies the same unload=false exemption already used for the CUDA, TensorRT, CANN and VitisAI EPs.


