### PR TITLE
docs: clarify OpenVINO load_config value

### DIFF
--- a/docs/execution-providers/OpenVINO-ExecutionProvider.md
+++ b/docs/execution-providers/OpenVINO-ExecutionProvider.md
@@ -510,7 +510,7 @@ options[num_streams] = "8";
 options[cache_dir] = "";
 options[context] = "0x123456ff";
 options[enable_qdq_optimizer] = "True";
-options[load_config] = "config_path.json";
+options[load_config] = R"({"GPU":{"PERFORMANCE_HINT":"LATENCY"}})";
 session_options.AppendExecutionProvider_OpenVINO_V2(options);
 ```
 ---


### PR DESCRIPTION
## Summary
- Update the OpenVINO EP C/C++ provider-options example to pass `load_config` as a JSON string instead of a JSON filename.
- Keep the example consistent with the documented provider option type and Python examples on the same page.

Fixes #26562

## Test Plan
- `python` residual check that `config_path.json` is no longer used for `load_config`
- `git diff --check`
- staged diff secret/conflict scan