### PR TITLE
docs: fix OpenVINO comparison labels

### DIFF
--- a/docs/tutorials/accelerate-pytorch/resnet-inferencing.md
+++ b/docs/tutorials/accelerate-pytorch/resnet-inferencing.md
@@ -321,8 +321,8 @@ Siamese cat 0.012514038
 plastic bag 0.0056432663
 OpenVINO CPU Inference time = 31.83 ms
 ***** Verifying correctness *****
-PyTorch and ONNX Runtime output 0 are close: True
-PyTorch and ONNX Runtime output 1 are close: True
+OpenVINO and ONNX Runtime output 0 are close: True
+OpenVINO and ONNX Runtime output 1 are close: True
 ```
 
 ## Conclusion


### PR DESCRIPTION
## Summary
- Fix the OpenVINO comparison sample output labels in the PyTorch acceleration tutorial.
- Keep the OpenVINO section labels consistent with the OpenVINO code path instead of the PyTorch section.

Fixes #25661
Fixes #18624

## Test Plan
- `python` focused check for the OpenVINO comparison sample output labels
- `git diff --check`
- diff secret/conflict scan