### PR TITLE
[CUDA] Add build option for TensorRT fused attention cubins

### DIFF
--- a/.github/workflows/windows_cuda_no_cudnn.yml
+++ b/.github/workflows/windows_cuda_no_cudnn.yml
@@ -121,6 +121,7 @@ jobs:
             --use_vcpkg `
             --use_vcpkg_ms_internal_asset_cache `
             --enable_cuda_profiling `
+            --cmake_extra_defines onnxruntime_USE_TRT_FUSED_ATTENTION=OFF `
             --cmake_extra_defines onnxruntime_QUICK_BUILD=ON `
             --cmake_extra_defines CMAKE_CUDA_ARCHITECTURES=86 `
             --cmake_extra_defines onnxruntime_BUILD_CUDA_EP_AS_PLUGIN=ON

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -123,6 +123,10 @@ option(onnxruntime_USE_VSINPU "Build with VSINPU support" OFF)
 cmake_dependent_option(onnxruntime_USE_FLASH_ATTENTION "Build flash attention kernel for scaled dot product attention" ON "onnxruntime_USE_CUDA" OFF)
 option(onnxruntime_USE_LEAN_ATTENTION "Build lean attention kernel for scaled dot product attention" OFF)
 cmake_dependent_option(onnxruntime_USE_MEMORY_EFFICIENT_ATTENTION "Build memory efficient attention kernel for scaled dot product attention" ON "onnxruntime_USE_CUDA" OFF)
+# The TensorRT fused MHA kernels are prebuilt cubins for sm70-sm89 that mainly benefit BERT-style
+# encoder models. Turning this OFF drops ~14MB of embedded cubin data; attention falls back to
+# flash / memory efficient / cuDNN / unfused kernels.
+cmake_dependent_option(onnxruntime_USE_TRT_FUSED_ATTENTION "Build TensorRT fused multi-head attention cubin kernels" ON "onnxruntime_USE_CUDA" OFF)
 option(onnxruntime_USE_FP4_QMOE "Build CUDA QMoE FP4 kernels" OFF)
 option(onnxruntime_USE_FP8_QMOE "Build CUDA QMoE FP8 kernels" OFF)
 cmake_dependent_option(onnxruntime_USE_FPA_INTB_GEMM "Build FpA IntB gemm cuda kernels" ON "onnxruntime_USE_CUDA" OFF)
@@ -788,6 +792,7 @@ else()
   set(onnxruntime_USE_FLASH_ATTENTION OFF)
   set(onnxruntime_USE_LEAN_ATTENTION OFF)
   set(onnxruntime_USE_MEMORY_EFFICIENT_ATTENTION OFF)
+  set(onnxruntime_USE_TRT_FUSED_ATTENTION OFF)
 endif()
 
 if (onnxruntime_USE_CUDA)
@@ -807,6 +812,11 @@ if (onnxruntime_USE_CUDA)
     if (onnxruntime_USE_MEMORY_EFFICIENT_ATTENTION)
       message( STATUS "Enable memory efficient attention for CUDA EP")
       list(APPEND ORT_PROVIDER_FLAGS -DUSE_MEMORY_EFFICIENT_ATTENTION=1)
+    endif()
+
+    if (onnxruntime_USE_TRT_FUSED_ATTENTION)
+      message( STATUS "Enable TensorRT fused multi-head attention for CUDA EP")
+      list(APPEND ORT_PROVIDER_FLAGS -DUSE_TRT_FUSED_ATTENTION=1)
     endif()
 
     if (onnxruntime_USE_FPA_INTB_GEMM)

--- a/cmake/onnxruntime_providers_cuda.cmake
+++ b/cmake/onnxruntime_providers_cuda.cmake
@@ -67,6 +67,14 @@
 
   include(onnxruntime_cuda_source_filters.cmake)
   onnxruntime_filter_cuda_cu_sources(onnxruntime_cuda_contrib_ops_cu_srcs)
+
+  if (NOT onnxruntime_USE_TRT_FUSED_ATTENTION)
+    # Drop the prebuilt TensorRT fused MHA cubin blobs. cudaDriverWrapper is kept because
+    # sparse attention depends on it.
+    list(FILTER onnxruntime_cuda_contrib_ops_cc_srcs EXCLUDE REGEX
+      ".*/bert/tensorrt_fused_multihead_attention/.*(\\.cubin\\.cc|_kernel\\.sm[0-9]+\\.cc)$")
+  endif()
+
   onnxruntime_extract_sm_specific_cuda_sources(onnxruntime_cuda_contrib_ops_cu_srcs
     SM90_SOURCES onnxruntime_cuda_sm90_tma_srcs
     SM120_SOURCES onnxruntime_cuda_sm120_tma_srcs

--- a/cmake/onnxruntime_providers_cuda_plugin.cmake
+++ b/cmake/onnxruntime_providers_cuda_plugin.cmake
@@ -44,6 +44,13 @@ list(FILTER CUDA_PLUGIN_EP_CU_SRCS EXCLUDE REGEX "onnxruntime/contrib_ops/cuda/c
 list(FILTER CUDA_PLUGIN_EP_CC_SRCS EXCLUDE REGEX "onnxruntime/contrib_ops/cuda/aten_ops/.*")
 list(FILTER CUDA_PLUGIN_EP_CC_SRCS EXCLUDE REGEX "onnxruntime/contrib_ops/cuda/collective/.*")
 
+if (NOT onnxruntime_USE_TRT_FUSED_ATTENTION)
+  # Drop the prebuilt TensorRT fused MHA cubin blobs. cudaDriverWrapper.cc is kept because
+  # sparse attention depends on it.
+  list(FILTER CUDA_PLUGIN_EP_CC_SRCS EXCLUDE REGEX
+    ".*/bert/tensorrt_fused_multihead_attention/.*(\\.cubin\\.cc|_kernel\\.sm[0-9]+\\.cc)$")
+endif()
+
 # Exclude files that include cuda_execution_provider.h (directly or transitively),
 # which conflicts with the adapter shim CUDAExecutionProvider class.
 list(FILTER CUDA_PLUGIN_EP_CC_SRCS EXCLUDE REGEX ".*/cuda_execution_provider\\.cc$")
@@ -122,6 +129,17 @@ onnxruntime_add_shared_library_module(onnxruntime_providers_cuda_plugin
     ${CUDA_PLUGIN_EP_CC_SRCS}
     ${CUDA_PLUGIN_EP_CU_SRCS}
 )
+
+if(WIN32)
+  # Add version information to the packaged plugin DLL.
+  target_sources(onnxruntime_providers_cuda_plugin PRIVATE
+      "${ONNXRUNTIME_ROOT}/core/providers/cuda/onnxruntime_providers_cuda.rc")
+  target_compile_definitions(onnxruntime_providers_cuda_plugin PRIVATE
+      FILE_NAME=\"onnxruntime_providers_cuda.dll\")
+elseif(UNIX AND NOT APPLE)
+  # The build output is packaged directly, so do not embed the build machine's CUDA path.
+  set_target_properties(onnxruntime_providers_cuda_plugin PROPERTIES SKIP_BUILD_RPATH TRUE)
+endif()
 
 # Mirror directory structure in the Visual Studio solution tree under "onnxruntime".
 source_group(TREE ${ONNXRUNTIME_ROOT} PREFIX "onnxruntime" FILES ${CUDA_EP_CC_SRCS} ${CUDA_EP_CU_SRCS})

--- a/onnxruntime/contrib_ops/cuda/bert/tensorrt_fused_multihead_attention/cross_attention/fmha_cross_attention.h
+++ b/onnxruntime/contrib_ops/cuda/bert/tensorrt_fused_multihead_attention/cross_attention/fmha_cross_attention.h
@@ -116,6 +116,7 @@ struct Fused_multihead_attention_params_mhca {
   }
 };
 
+#if USE_TRT_FUSED_ATTENTION
 extern const unsigned char cubin_fmha_mhca_fp16_128_64_sm75_cu_cubin[];
 extern const unsigned char cubin_fmha_mhca_fp16_128_64_sm80_cu_cubin[];
 extern const unsigned char cubin_fmha_mhca_fp16_128_64_sm86_cu_cubin[];
@@ -141,8 +142,9 @@ extern const uint32_t cubin_fmha_mhca_fp16_128_128_sm89_cu_cubin_len;
 extern const uint32_t cubin_fmha_mhca_fp16_128_256_sm80_cu_cubin_len;
 extern const uint32_t cubin_fmha_mhca_fp16_128_256_sm86_cu_cubin_len;
 extern const uint32_t cubin_fmha_mhca_fp16_128_256_sm89_cu_cubin_len;
+#endif  // USE_TRT_FUSED_ATTENTION
 
-static const struct FusedMultiHeadCrossAttentionKernelMetaInfoV2 {
+struct FusedMultiHeadCrossAttentionKernelMetaInfoV2 {
   Data_type mDataType;
   int32_t mS;
   int32_t mD;
@@ -154,7 +156,10 @@ static const struct FusedMultiHeadCrossAttentionKernelMetaInfoV2 {
   int32_t mThreadsPerCTA;
   int32_t mUnrollStep;
   bool mInterleaved;
-} sMhaKernelMetaInfos[] = {
+};
+
+#if USE_TRT_FUSED_ATTENTION
+static const FusedMultiHeadCrossAttentionKernelMetaInfoV2 sMhaKernelMetaInfos[] = {
     {DATA_TYPE_FP16, 128, 64, kSM_75, cubin_fmha_mhca_fp16_128_64_sm75_cu_cubin, cubin_fmha_mhca_fp16_128_64_sm75_cu_cubin_len, "fmha_mhca_fp16_128_64_sm75_kernel", 40960, 128, 0, false},
     {DATA_TYPE_FP16, 128, 64, kSM_75, cubin_fmha_mhca_fp16_128_64_sm75_cu_cubin, cubin_fmha_mhca_fp16_128_64_sm75_cu_cubin_len, "fmha_mhca_fp16_128_64_sm75_kernel_nl", 36864, 128, 32, false},
 
@@ -178,6 +183,7 @@ static const struct FusedMultiHeadCrossAttentionKernelMetaInfoV2 {
     {DATA_TYPE_FP16, 128, 128, kSM_89, cubin_fmha_mhca_fp16_128_128_sm89_cu_cubin, cubin_fmha_mhca_fp16_128_128_sm89_cu_cubin_len, "fmha_mhca_fp16_128_128_sm89_kernel_nl", 81920, 128, 32, false},
     {DATA_TYPE_FP16, 128, 256, kSM_89, cubin_fmha_mhca_fp16_128_256_sm89_cu_cubin, cubin_fmha_mhca_fp16_128_256_sm89_cu_cubin_len, "fmha_mhca_fp16_128_256_sm89_kernel", 163840, 256, 0, false},
     {DATA_TYPE_FP16, 128, 256, kSM_89, cubin_fmha_mhca_fp16_128_256_sm89_cu_cubin, cubin_fmha_mhca_fp16_128_256_sm89_cu_cubin_len, "fmha_mhca_fp16_128_256_sm89_kernel_nl", 81920, 256, 16, false}};
+#endif  // USE_TRT_FUSED_ATTENTION
 
 static Fused_multihead_attention_params_mhca getMHCAParams(
     // sizes
@@ -273,16 +279,28 @@ using FusedMHACrossKernelFactory = TSharedCubinKernelFactory<FusedMultiHeadCross
 // Below are public interface
 
 inline bool has_fused_cross_attention_kernel(int sm, int head_size, int kv_sequence_length) {
+#if USE_TRT_FUSED_ATTENTION
   constexpr int min_head_size = 0;
   const int max_head_size = (sm == 75 ? 64 : 256);
   return (sm == 75 || sm == 80 || sm == 86 || sm == 89) &&
          (head_size > min_head_size) && (head_size <= max_head_size) &&
          (kv_sequence_length <= 128);  // TODO: shall we remove this constraint on kv_sequence_length?
+#else
+  ORT_UNUSED_PARAMETER(sm);
+  ORT_UNUSED_PARAMETER(head_size);
+  ORT_UNUSED_PARAMETER(kv_sequence_length);
+  return false;
+#endif
 }
 
 inline FusedMultiHeadCrossAttentionKernel const* get_fused_cross_attention_kernels(int32_t sm) {
+#if USE_TRT_FUSED_ATTENTION
   return FusedMHACrossKernelFactory::Get().getCubinKernels(
       sMhaKernelMetaInfos, sizeof(sMhaKernelMetaInfos) / sizeof(sMhaKernelMetaInfos[0]), DATA_TYPE_FP16, sm);
+#else
+  ORT_UNUSED_PARAMETER(sm);
+  return nullptr;
+#endif
 }
 
 inline void run_fused_cross_attention(

--- a/onnxruntime/contrib_ops/cuda/bert/tensorrt_fused_multihead_attention/flash_attention/fmha_flash_attention.h
+++ b/onnxruntime/contrib_ops/cuda/bert/tensorrt_fused_multihead_attention/flash_attention/fmha_flash_attention.h
@@ -25,6 +25,7 @@ namespace onnxruntime {
 namespace contrib {
 namespace cuda {
 
+#if USE_TRT_FUSED_ATTENTION
 extern const unsigned char cubin_fmha_v2_flash_attention_fp16_64_64_S_64_sm70_cu_cubin[];
 extern const unsigned char cubin_fmha_v2_flash_attention_fp16_64_64_S_16_sm75_cu_cubin[];
 extern const unsigned char cubin_fmha_v2_flash_attention_fp16_64_64_S_32_sm75_cu_cubin[];
@@ -129,9 +130,11 @@ extern const uint32_t cubin_fmha_v2_flash_attention_fp16_128_32_S_128_sm89_cu_cu
 extern const uint32_t cubin_fmha_v2_flash_attention_fp16_64_16_S_160_sm89_cu_cubin_len;
 extern const uint32_t cubin_fmha_v2_flash_attention_fp16_64_16_S_256_sm89_cu_cubin_len;
 
+#endif  // USE_TRT_FUSED_ATTENTION
+
 constexpr int32_t S{0};
 
-static const struct FusedMultiHeadFlashAttentionKernelMetaInfoV2 {
+struct FusedMultiHeadFlashAttentionKernelMetaInfoV2 {
   Data_type mDataType;
   int32_t mS;
   int32_t mQStep;
@@ -145,7 +148,10 @@ static const struct FusedMultiHeadFlashAttentionKernelMetaInfoV2 {
   int32_t mThreadsPerCTA;
   int32_t mUnrollStep;
   bool mInterleaved;
-} sMhaKernelMetaInfos[] = {
+};
+
+#if USE_TRT_FUSED_ATTENTION
+static const FusedMultiHeadFlashAttentionKernelMetaInfoV2 sMhaKernelMetaInfos[] = {
     // SM70 kernel is from FasterTransformer
     {DATA_TYPE_FP16, S, 64, 64, 64, kSM_70, cubin_fmha_v2_flash_attention_fp16_64_64_S_64_sm70_cu_cubin, cubin_fmha_v2_flash_attention_fp16_64_64_S_64_sm70_cu_cubin_len, "fmha_v2_flash_attention_fp16_0_64_sm70_kernel", 24576, 128, 0, false},
     {DATA_TYPE_FP16, S, 64, 64, 64, kSM_70, cubin_fmha_v2_flash_attention_fp16_64_64_S_64_sm70_cu_cubin, cubin_fmha_v2_flash_attention_fp16_64_64_S_64_sm70_cu_cubin_len, "fmha_v2_flash_attention_fp16_0_64_sm70_kernel_nl", 24576, 128, 64, false},
@@ -253,6 +259,7 @@ static const struct FusedMultiHeadFlashAttentionKernelMetaInfoV2 {
     {DATA_TYPE_FP16, S, 64, 16, 160, kSM_89, cubin_fmha_v2_flash_attention_fp16_64_16_S_160_sm89_cu_cubin, cubin_fmha_v2_flash_attention_fp16_64_16_S_160_sm89_cu_cubin_len, "fmha_v2_flash_attention_fp16_64_16_S_160_sm89_kernel_nl", 98304, 128, 64, false},
     {DATA_TYPE_FP16, S, 64, 16, 256, kSM_89, cubin_fmha_v2_flash_attention_fp16_64_16_S_256_sm89_cu_cubin, cubin_fmha_v2_flash_attention_fp16_64_16_S_256_sm89_cu_cubin_len, "fmha_v2_flash_attention_fp16_64_16_S_256_sm89_kernel", 98304, 128, 0, false},
     {DATA_TYPE_FP16, S, 64, 16, 256, kSM_89, cubin_fmha_v2_flash_attention_fp16_64_16_S_256_sm89_cu_cubin, cubin_fmha_v2_flash_attention_fp16_64_16_S_256_sm89_cu_cubin_len, "fmha_v2_flash_attention_fp16_64_16_S_256_sm89_kernel_nl", 98304, 128, 64, false}};
+#endif  // USE_TRT_FUSED_ATTENTION
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 class FusedMultiHeadFlashAttentionKernel
@@ -328,16 +335,28 @@ class FusedMultiHeadFlashAttentionKernel
 using FusedMHAFlashKernelFactory = TSharedCubinKernelFactory<FusedMultiHeadFlashAttentionKernel>;
 
 inline FusedMultiHeadFlashAttentionKernel const* get_flash_attention_kernels(Data_type type, int32_t sm) {
+#if USE_TRT_FUSED_ATTENTION
   return FusedMHAFlashKernelFactory::Get().getCubinKernels(
       sMhaKernelMetaInfos, sizeof(sMhaKernelMetaInfos) / sizeof(sMhaKernelMetaInfos[0]), type, sm);
+#else
+  ORT_UNUSED_PARAMETER(type);
+  ORT_UNUSED_PARAMETER(sm);
+  return nullptr;
+#endif
 }
 
 inline bool has_flash_attention_kernel(int sm, int head_size) {
+#if USE_TRT_FUSED_ATTENTION
   return (sm == 70 && head_size == 64) ||
          ((sm == 75 || sm == 80 || sm == 86 || sm == 89) &&
           (head_size == 16 || head_size == 32 || head_size == 40 ||
            head_size == 64 || head_size == 80 || head_size == 128 ||
            head_size == 160 || head_size == 256));
+#else
+  ORT_UNUSED_PARAMETER(sm);
+  ORT_UNUSED_PARAMETER(head_size);
+  return false;
+#endif
 }
 
 }  // namespace cuda

--- a/onnxruntime/contrib_ops/cuda/bert/tensorrt_fused_multihead_attention/fused_multihead_attention_v2.h
+++ b/onnxruntime/contrib_ops/cuda/bert/tensorrt_fused_multihead_attention/fused_multihead_attention_v2.h
@@ -78,6 +78,23 @@ struct Fused_multihead_attention_params_v2 {
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
+struct FusedMultiHeadAttentionKernelMetaInfoV2 {
+  Data_type mDataType;
+  unsigned int mS;
+  unsigned int mD;
+  unsigned int mSM;
+  const unsigned char* mCubin;
+  unsigned int mCubinSize;
+  const char* mFuncName;
+  unsigned int mSharedMemBytes;
+  unsigned int mThreadsPerCTA;
+  unsigned int mUnrollStep;
+  bool mInterleaved;
+  bool mWithRelativePositionBias = false;
+  bool mFlashAttention = false;
+};
+
+#if USE_TRT_FUSED_ATTENTION
 extern const unsigned char cubin_fmha_v2_fp16_384_32_sm80_cu_cubin[];
 extern const unsigned char cubin_fmha_v2_fp16_256_32_sm80_cu_cubin[];
 extern const unsigned char cubin_fmha_v2_fp16_192_32_sm80_cu_cubin[];
@@ -154,21 +171,7 @@ extern const unsigned int fused_multihead_attention_v2_fp16_128_64_kernel_sm70_c
 extern const unsigned int fused_multihead_attention_v2_fp16_256_64_kernel_sm70_cubin_len;
 extern const unsigned int fused_multihead_attention_v2_fp16_384_64_kernel_sm70_cubin_len;
 
-static const struct FusedMultiHeadAttentionKernelMetaInfoV2 {
-  Data_type mDataType;
-  unsigned int mS;
-  unsigned int mD;
-  unsigned int mSM;
-  const unsigned char* mCubin;
-  unsigned int mCubinSize;
-  const char* mFuncName;
-  unsigned int mSharedMemBytes;
-  unsigned int mThreadsPerCTA;
-  unsigned int mUnrollStep;
-  bool mInterleaved;
-  bool mWithRelativePositionBias = false;
-  bool mFlashAttention = false;
-} sMhaKernelMetaInfosV2[] = {
+static const FusedMultiHeadAttentionKernelMetaInfoV2 sMhaKernelMetaInfosV2[] = {
     // Volta
     {DATA_TYPE_FP16,
      64,
@@ -1094,6 +1097,7 @@ static const struct FusedMultiHeadAttentionKernelMetaInfoV2 {
      false},
 #endif
 };
+#endif  // USE_TRT_FUSED_ATTENTION
 
 class FusedMultiHeadAttentionXMMAKernelV2 : public TFusedMultiHeadAttentionXMMAKernel<FusedMultiHeadAttentionKernelMetaInfoV2,
                                                                                       Fused_multihead_attention_params_v2> {
@@ -1230,8 +1234,14 @@ class FusedMultiHeadAttentionXMMAKernelV2 : public TFusedMultiHeadAttentionXMMAK
 using FusedMHAKernelFactoryV2 = TFusedMHAKernelFactory<FusedMultiHeadAttentionXMMAKernelV2>;
 
 inline const FusedMultiHeadAttentionXMMAKernelV2* getXMMAKernelsV2(Data_type type, unsigned int sm) {
+#if USE_TRT_FUSED_ATTENTION
   return FusedMHAKernelFactoryV2::Get().getXMMAKernels(
       sMhaKernelMetaInfosV2, sizeof(sMhaKernelMetaInfosV2) / sizeof(sMhaKernelMetaInfosV2[0]), type, sm);
+#else
+  ORT_UNUSED_PARAMETER(type);
+  ORT_UNUSED_PARAMETER(sm);
+  return nullptr;
+#endif
 }
 
 }  // namespace cuda

--- a/onnxruntime/contrib_ops/cuda/bert/tensorrt_fused_multihead_attention/mha_runner.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/tensorrt_fused_multihead_attention/mha_runner.cu
@@ -199,6 +199,13 @@ FusedMHARunnerFP16v2::FusedMHARunnerFP16v2(int num_heads,
 
 bool FusedMHARunnerFP16v2::IsSupported(int sm, int head_size, int sequence_length,
                                        bool enable_flash_attention) {
+#if !USE_TRT_FUSED_ATTENTION
+  ORT_UNUSED_PARAMETER(sm);
+  ORT_UNUSED_PARAMETER(head_size);
+  ORT_UNUSED_PARAMETER(sequence_length);
+  ORT_UNUSED_PARAMETER(enable_flash_attention);
+  return false;
+#else
   bool use_flash = enable_flash_attention && sequence_length >= kMinSequenceLengthFlashAttention;
   if (use_flash && has_flash_attention_kernel(sm, head_size)) {
     return true;
@@ -219,6 +226,7 @@ bool FusedMHARunnerFP16v2::IsSupported(int sm, int head_size, int sequence_lengt
   // Normal (not flash) fused kernel supports sequence length up to 384.
   constexpr int max_sequence_length = 384;
   return sequence_length <= max_sequence_length;
+#endif
 }
 
 void FusedMHARunnerFP16v2::Run(int batch_size,


### PR DESCRIPTION
This change adds a build option for excluding the prebuilt TensorRT fused multi-head attention cubins from the CUDA Execution Provider. The option is enabled by default to preserve existing behavior; disabling it removes approximately 14 MB of embedded cubin data and leaves attention selection to the other available kernels and unfused fallback paths.

## Key Changes

- Add `onnxruntime_USE_TRT_FUSED_ATTENTION`, dependent on CUDA and enabled by default.
- Propagate the option to CUDA provider compilation and guard TensorRT fused-attention cubin declarations, metadata, and lookup paths.
- Filter the prebuilt TensorRT fused-attention cubin sources from both the regular CUDA provider and CUDA plugin provider when the option is disabled, while retaining the shared driver wrapper needed by sparse attention.
- Add Windows plugin DLL version metadata and suppress build-machine RPATH embedding for packaged Linux plugin binaries.
- Exercise `onnxruntime_USE_TRT_FUSED_ATTENTION=OFF` in the Windows CUDA no-cuDNN plugin build.

## Testing Notes

- `git diff --check origin/main...HEAD` passes.
- The Windows CUDA no-cuDNN workflow now builds the CUDA plugin with TensorRT fused attention disabled, providing CI coverage for the opt-out configuration.
- No local CUDA/Windows build was run in this environment.
