### PR TITLE
Validate whisper beginning_timestamp_token_id bounds

### DIFF
--- a/onnxruntime/contrib_ops/cpu/transformers/beam_search_parameters.cc
+++ b/onnxruntime/contrib_ops/cpu/transformers/beam_search_parameters.cc
@@ -124,6 +124,7 @@ void BeamSearchParameters::ParseFromInputs(OpKernelContext* context) {
   logits_processor = logits_processor_tensor ? static_cast<int>(*logits_processor_tensor->Data<int32_t>()) : 0;
   ORT_ENFORCE(logits_processor >= 0,
               "logits_processor shall be a non-negative integer, got ", logits_processor);
+  ValidateWhisperTimestampTokenId();
 
   if (this->model_type == IGenerationParameters::kModelTypeWhisper) {
     auto* temperature_tensor = context->Input<Tensor>(14);
@@ -153,18 +154,18 @@ void BeamSearchParameters::SetSubgraphParameters(int vocabulary_size, int heads,
               ") cannot exceed decoder subgraph logits width (", vocabulary_size, ")");
   }
 
-  // Whisper timestamp logits processing indexes token-score spans by
-  // beginning_timestamp_token_id. Reject out-of-range ids up front.
+  num_heads = heads;
+  head_size = hidden_size_per_head;
+  num_layers = layers;
+}
+
+void BeamSearchParameters::ValidateWhisperTimestampTokenId() const {
   if (model_type == IGenerationParameters::kModelTypeWhisper &&
       logits_processor == IGenerationParameters::kLogitsProcessorTypeWhisper) {
     ORT_ENFORCE(beginning_timestamp_token_id > 0 && beginning_timestamp_token_id < vocab_size,
                 "beginning_timestamp_token_id is out of range, it is ", beginning_timestamp_token_id,
                 ", vocab_size is ", vocab_size);
   }
-
-  num_heads = heads;
-  head_size = hidden_size_per_head;
-  num_layers = layers;
 }
 
 void WhisperBeamSearchParameters::ParseFromAttributes(const OpKernelInfo& info) {

--- a/onnxruntime/contrib_ops/cpu/transformers/beam_search_parameters.cc
+++ b/onnxruntime/contrib_ops/cpu/transformers/beam_search_parameters.cc
@@ -157,7 +157,7 @@ void BeamSearchParameters::SetSubgraphParameters(int vocabulary_size, int heads,
   // beginning_timestamp_token_id. Reject out-of-range ids up front.
   if (model_type == IGenerationParameters::kModelTypeWhisper &&
       logits_processor == IGenerationParameters::kLogitsProcessorTypeWhisper) {
-    ORT_ENFORCE(beginning_timestamp_token_id >= 0 && beginning_timestamp_token_id < vocab_size,
+    ORT_ENFORCE(beginning_timestamp_token_id > 0 && beginning_timestamp_token_id < vocab_size,
                 "beginning_timestamp_token_id is out of range, it is ", beginning_timestamp_token_id,
                 ", vocab_size is ", vocab_size);
   }

--- a/onnxruntime/contrib_ops/cpu/transformers/beam_search_parameters.cc
+++ b/onnxruntime/contrib_ops/cpu/transformers/beam_search_parameters.cc
@@ -152,6 +152,16 @@ void BeamSearchParameters::SetSubgraphParameters(int vocabulary_size, int heads,
     ORT_THROW("vocab_size attribute (", vocab_size,
               ") cannot exceed decoder subgraph logits width (", vocabulary_size, ")");
   }
+
+  // Whisper timestamp logits processing indexes token-score spans by
+  // beginning_timestamp_token_id. Reject out-of-range ids up front.
+  if (model_type == IGenerationParameters::kModelTypeWhisper &&
+      logits_processor == IGenerationParameters::kLogitsProcessorTypeWhisper) {
+    ORT_ENFORCE(beginning_timestamp_token_id >= 0 && beginning_timestamp_token_id < vocab_size,
+                "beginning_timestamp_token_id is out of range, it is ", beginning_timestamp_token_id,
+                ", vocab_size is ", vocab_size);
+  }
+
   num_heads = heads;
   head_size = hidden_size_per_head;
   num_layers = layers;

--- a/onnxruntime/contrib_ops/cpu/transformers/beam_search_parameters.h
+++ b/onnxruntime/contrib_ops/cpu/transformers/beam_search_parameters.h
@@ -22,6 +22,8 @@ struct BeamSearchParameters : public IGenerationParameters {
   void ParseFromInputs(OpKernelContext* context);
 
   void SetSubgraphParameters(int vocab_size, int num_heads, int head_size, int num_layers);
+
+  void ValidateWhisperTimestampTokenId() const;
 };
 
 struct WhisperBeamSearchParameters : public BeamSearchParameters {

--- a/onnxruntime/contrib_ops/cpu/transformers/logits_processor.h
+++ b/onnxruntime/contrib_ops/cpu/transformers/logits_processor.h
@@ -182,6 +182,9 @@ class TimestampLogitsProcessor : public ILogitsProcessor<T> {
                NextTokenScores<T>& next_token_scores) override {
     const int batch_beam_size = next_token_scores.batch_beam_size;
     const int vocab_size = next_token_scores.vocab_size;
+    ORT_ENFORCE(beginning_timestamp_token_id_ >= 0 && beginning_timestamp_token_id_ < vocab_size,
+                "beginning_timestamp_token_id is out of range, it is ", beginning_timestamp_token_id_,
+                ", vocab_size is ", vocab_size);
     for (int i = 0; i < batch_beam_size; i++) {
       gsl::span<T> beam_token_scores = next_token_scores.GetScores(i);
       gsl::span<const int32_t> sequence = sequences->GetSequence(i);

--- a/onnxruntime/contrib_ops/cpu/transformers/logits_processor.h
+++ b/onnxruntime/contrib_ops/cpu/transformers/logits_processor.h
@@ -182,7 +182,7 @@ class TimestampLogitsProcessor : public ILogitsProcessor<T> {
                NextTokenScores<T>& next_token_scores) override {
     const int batch_beam_size = next_token_scores.batch_beam_size;
     const int vocab_size = next_token_scores.vocab_size;
-    ORT_ENFORCE(beginning_timestamp_token_id_ >= 0 && beginning_timestamp_token_id_ < vocab_size,
+    ORT_ENFORCE(beginning_timestamp_token_id_ > 0 && beginning_timestamp_token_id_ < vocab_size,
                 "beginning_timestamp_token_id is out of range, it is ", beginning_timestamp_token_id_,
                 ", vocab_size is ", vocab_size);
     for (int i = 0; i < batch_beam_size; i++) {

--- a/onnxruntime/test/contrib_ops/beam_search_test.cc
+++ b/onnxruntime/test/contrib_ops/beam_search_test.cc
@@ -49,35 +49,44 @@ TEST(BeamSearchParametersTest, SetSubgraphParametersUsesSubgraphSizeWhenAttribut
   EXPECT_EQ(parameters.num_heads, 2);
 }
 
-TEST(BeamSearchParametersTest, SetSubgraphParametersRejectsNegativeWhisperBeginningTimestampTokenId) {
+TEST(BeamSearchParametersTest, RejectsNegativeWhisperBeginningTimestampTokenId) {
   contrib::transformers::BeamSearchParameters parameters;
-  parameters.vocab_size = -1;
+  parameters.vocab_size = 128;
   parameters.model_type = contrib::transformers::IGenerationParameters::kModelTypeWhisper;
   parameters.logits_processor = contrib::transformers::IGenerationParameters::kLogitsProcessorTypeWhisper;
   parameters.beginning_timestamp_token_id = -1;
 
-  EXPECT_THROW(parameters.SetSubgraphParameters(128, 2, 4, 6), OnnxRuntimeException);
+  EXPECT_THROW(parameters.ValidateWhisperTimestampTokenId(), OnnxRuntimeException);
 }
 
-TEST(BeamSearchParametersTest, SetSubgraphParametersRejectsWhisperBeginningTimestampTokenIdEqualToVocabSize) {
+TEST(BeamSearchParametersTest, RejectsZeroWhisperBeginningTimestampTokenId) {
   contrib::transformers::BeamSearchParameters parameters;
-  parameters.vocab_size = -1;
+  parameters.vocab_size = 128;
+  parameters.model_type = contrib::transformers::IGenerationParameters::kModelTypeWhisper;
+  parameters.logits_processor = contrib::transformers::IGenerationParameters::kLogitsProcessorTypeWhisper;
+  parameters.beginning_timestamp_token_id = 0;
+
+  EXPECT_THROW(parameters.ValidateWhisperTimestampTokenId(), OnnxRuntimeException);
+}
+
+TEST(BeamSearchParametersTest, RejectsWhisperBeginningTimestampTokenIdEqualToVocabSize) {
+  contrib::transformers::BeamSearchParameters parameters;
+  parameters.vocab_size = 128;
   parameters.model_type = contrib::transformers::IGenerationParameters::kModelTypeWhisper;
   parameters.logits_processor = contrib::transformers::IGenerationParameters::kLogitsProcessorTypeWhisper;
   parameters.beginning_timestamp_token_id = 128;
 
-  EXPECT_THROW(parameters.SetSubgraphParameters(128, 2, 4, 6), OnnxRuntimeException);
+  EXPECT_THROW(parameters.ValidateWhisperTimestampTokenId(), OnnxRuntimeException);
 }
 
-TEST(BeamSearchParametersTest, SetSubgraphParametersAcceptsValidWhisperBeginningTimestampTokenId) {
+TEST(BeamSearchParametersTest, AcceptsValidWhisperBeginningTimestampTokenId) {
   contrib::transformers::BeamSearchParameters parameters;
-  parameters.vocab_size = -1;
+  parameters.vocab_size = 128;
   parameters.model_type = contrib::transformers::IGenerationParameters::kModelTypeWhisper;
   parameters.logits_processor = contrib::transformers::IGenerationParameters::kLogitsProcessorTypeWhisper;
   parameters.beginning_timestamp_token_id = 1;
 
-  EXPECT_NO_THROW(parameters.SetSubgraphParameters(128, 2, 4, 6));
-  EXPECT_EQ(parameters.vocab_size, 128);
+  EXPECT_NO_THROW(parameters.ValidateWhisperTimestampTokenId());
 }
 
 void RunGptBeamSearchFp32() {

--- a/onnxruntime/test/contrib_ops/beam_search_test.cc
+++ b/onnxruntime/test/contrib_ops/beam_search_test.cc
@@ -49,6 +49,34 @@ TEST(BeamSearchParametersTest, SetSubgraphParametersUsesSubgraphSizeWhenAttribut
   EXPECT_EQ(parameters.num_heads, 2);
 }
 
+TEST(BeamSearchParametersTest, SetSubgraphParametersRejectsNegativeWhisperBeginningTimestampTokenId) {
+  contrib::transformers::BeamSearchParameters parameters;
+  parameters.model_type = contrib::transformers::IGenerationParameters::kModelTypeWhisper;
+  parameters.logits_processor = contrib::transformers::IGenerationParameters::kLogitsProcessorTypeWhisper;
+  parameters.beginning_timestamp_token_id = -1;
+
+  EXPECT_THROW(parameters.SetSubgraphParameters(128, 2, 4, 6), OnnxRuntimeException);
+}
+
+TEST(BeamSearchParametersTest, SetSubgraphParametersRejectsWhisperBeginningTimestampTokenIdEqualToVocabSize) {
+  contrib::transformers::BeamSearchParameters parameters;
+  parameters.model_type = contrib::transformers::IGenerationParameters::kModelTypeWhisper;
+  parameters.logits_processor = contrib::transformers::IGenerationParameters::kLogitsProcessorTypeWhisper;
+  parameters.beginning_timestamp_token_id = 128;
+
+  EXPECT_THROW(parameters.SetSubgraphParameters(128, 2, 4, 6), OnnxRuntimeException);
+}
+
+TEST(BeamSearchParametersTest, SetSubgraphParametersAcceptsValidWhisperBeginningTimestampTokenId) {
+  contrib::transformers::BeamSearchParameters parameters;
+  parameters.model_type = contrib::transformers::IGenerationParameters::kModelTypeWhisper;
+  parameters.logits_processor = contrib::transformers::IGenerationParameters::kLogitsProcessorTypeWhisper;
+  parameters.beginning_timestamp_token_id = 0;
+
+  EXPECT_NO_THROW(parameters.SetSubgraphParameters(128, 2, 4, 6));
+  EXPECT_EQ(parameters.vocab_size, 128);
+}
+
 void RunGptBeamSearchFp32() {
   std::vector<int64_t> input_ids_shape{3, 12};
   std::vector<int32_t> input_ids{

--- a/onnxruntime/test/contrib_ops/beam_search_test.cc
+++ b/onnxruntime/test/contrib_ops/beam_search_test.cc
@@ -51,6 +51,7 @@ TEST(BeamSearchParametersTest, SetSubgraphParametersUsesSubgraphSizeWhenAttribut
 
 TEST(BeamSearchParametersTest, SetSubgraphParametersRejectsNegativeWhisperBeginningTimestampTokenId) {
   contrib::transformers::BeamSearchParameters parameters;
+  parameters.vocab_size = -1;
   parameters.model_type = contrib::transformers::IGenerationParameters::kModelTypeWhisper;
   parameters.logits_processor = contrib::transformers::IGenerationParameters::kLogitsProcessorTypeWhisper;
   parameters.beginning_timestamp_token_id = -1;
@@ -60,6 +61,7 @@ TEST(BeamSearchParametersTest, SetSubgraphParametersRejectsNegativeWhisperBeginn
 
 TEST(BeamSearchParametersTest, SetSubgraphParametersRejectsWhisperBeginningTimestampTokenIdEqualToVocabSize) {
   contrib::transformers::BeamSearchParameters parameters;
+  parameters.vocab_size = -1;
   parameters.model_type = contrib::transformers::IGenerationParameters::kModelTypeWhisper;
   parameters.logits_processor = contrib::transformers::IGenerationParameters::kLogitsProcessorTypeWhisper;
   parameters.beginning_timestamp_token_id = 128;
@@ -69,9 +71,10 @@ TEST(BeamSearchParametersTest, SetSubgraphParametersRejectsWhisperBeginningTimes
 
 TEST(BeamSearchParametersTest, SetSubgraphParametersAcceptsValidWhisperBeginningTimestampTokenId) {
   contrib::transformers::BeamSearchParameters parameters;
+  parameters.vocab_size = -1;
   parameters.model_type = contrib::transformers::IGenerationParameters::kModelTypeWhisper;
   parameters.logits_processor = contrib::transformers::IGenerationParameters::kLogitsProcessorTypeWhisper;
-  parameters.beginning_timestamp_token_id = 0;
+  parameters.beginning_timestamp_token_id = 1;
 
   EXPECT_NO_THROW(parameters.SetSubgraphParameters(128, 2, 4, 6));
   EXPECT_EQ(parameters.vocab_size, 128);


### PR DESCRIPTION
This pull request improves validation for the Whisper model's `beginning_timestamp_token_id` parameter in both runtime and test code. The main focus is to ensure that invalid values for this parameter are caught early, preventing out-of-range errors during inference and processing.

**Validation improvements for Whisper timestamp token ID:**

* Added a check in `BeamSearchParameters::SetSubgraphParameters` to enforce that `beginning_timestamp_token_id` is within the valid range `[0, vocab_size)` for Whisper models, throwing an error if not.
* Added a similar runtime check in `TimestampLogitsProcessor` to ensure `beginning_timestamp_token_id_` is within bounds before processing logits.

**Unit test enhancements:**

* Introduced new tests in `beam_search_test.cc` to verify that `SetSubgraphParameters` correctly rejects negative or out-of-range `beginning_timestamp_token_id` values and accepts valid ones.