### PR TITLE
[QNN EP] Accept htp_arch 79 (v79, Snapdragon 8 Elite)

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -4264,6 +4264,7 @@ struct OrtApi {
    *      -# "69"
    *      -# "73"
    *      -# "75"
+   *      -# "79"
    *      -# "81"
    *   "device_id": The ID of the device to use when setting 'htp_arch'. Defaults to "0" (for single device).
    *   "enable_htp_fp16_precision": Used for float32 model for HTP backend.

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -176,6 +176,8 @@ static void ParseHtpArchitecture(const std::string& htp_arch_string, QnnHtpDevic
     qnn_htp_arch = QNN_HTP_DEVICE_ARCH_V73;
   } else if (htp_arch_string == "75") {
     qnn_htp_arch = QNN_HTP_DEVICE_ARCH_V75;
+  } else if (htp_arch_string == "79") {
+    qnn_htp_arch = QNN_HTP_DEVICE_ARCH_V79;
   } else if (htp_arch_string == "81") {
     qnn_htp_arch = QNN_HTP_DEVICE_ARCH_V81;
   } else {

--- a/onnxruntime/test/onnx/main.cc
+++ b/onnxruntime/test/onnx/main.cc
@@ -614,7 +614,7 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
             ORT_THROW("Wrong value for htp_graph_finalization_optimization_mode. select from: " + str);
           }
         } else if (key == "htp_arch") {
-          std::unordered_set<std::string> supported_htp_archs = {"0", "68", "69", "73", "75", "81"};
+          std::unordered_set<std::string> supported_htp_archs = {"0", "68", "69", "73", "75", "79", "81"};
           if (supported_htp_archs.find(value) == supported_htp_archs.end()) {
             std::ostringstream str_stream;
             std::copy(supported_htp_archs.begin(), supported_htp_archs.end(),

--- a/onnxruntime/test/perftest/ort_test_session.cc
+++ b/onnxruntime/test/perftest/ort_test_session.cc
@@ -337,7 +337,7 @@ OnnxRuntimeTestSession::OnnxRuntimeTestSession(Ort::Env& env, std::random_device
           ORT_THROW("Supported qnn_context_priority: low, normal, normal_high, high");
         }
       } else if (key == "htp_arch") {
-        std::set<std::string> supported_htp_archs = {"0", "68", "69", "73", "75", "81"};
+        std::set<std::string> supported_htp_archs = {"0", "68", "69", "73", "75", "79", "81"};
         if (supported_htp_archs.find(value) == supported_htp_archs.end()) {
           std::ostringstream str_stream;
           std::copy(supported_htp_archs.begin(), supported_htp_archs.end(),

--- a/onnxruntime/test/providers/qnn/qnn_basic_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_basic_test.cc
@@ -1029,6 +1029,31 @@ TEST_F(QnnHTPBackendTests, HTPArchValues) {
   }
 }
 
+static void ORT_API_CALL AppendToString(void* param, OrtLoggingLevel, const char*, const char*, const char*,
+                                        const char* message) noexcept {
+  *reinterpret_cast<std::string*>(param) += message;
+}
+
+// Test that "79" is accepted as an HTP architecture (v79, e.g. Snapdragon 8 Elite / SM8750).
+TEST_F(QnnHTPBackendTests, HTPArchV79) {
+  onnxruntime::ProviderOptions options;
+  options["backend_type"] = "htp";
+  options["htp_arch"] = "79";
+
+  std::string logs;
+  ortenv_teardown();  // Destroy Env so we can create one that captures log messages.
+  {
+    Ort::Env env(ORT_LOGGING_LEVEL_WARNING, "HTPArchV79", AppendToString, &logs);
+    Ort::SessionOptions so;
+    so.AppendExecutionProvider("QNN", options);
+
+    EXPECT_NO_THROW(Ort::Session session(env, ORT_MODEL_FOLDER "nhwc_resize_sizes_opset18.quant.onnx", so));
+  }
+  ortenv_setup();
+
+  EXPECT_EQ(logs.find("Invalid HTP architecture"), std::string::npos) << logs;
+}
+
 // Test that models run with high QNN context priority.
 TEST_F(QnnHTPBackendTests, QnnContextPriorityHigh) {
   RunNHWCResizeModel(ORT_MODEL_FOLDER "nhwc_resize_sizes_opset18.quant.onnx",


### PR DESCRIPTION
Fixes #31353

`ParseHtpArchitecture()` handles `0/68/69/73/75/81` and has no case for `79`, so `htp_arch=79` is
logged as `Invalid HTP architecture: 79` and silently downgraded to `QNN_HTP_DEVICE_ARCH_NONE`. v79 is
the HTP architecture of SM8750 (Snapdragon 8 Elite), and `QNN_HTP_DEVICE_ARCH_V79 = 79` has been in
`QNN/HTP/QnnHtpDevice.h` for several QAIRT releases, so this is just a missing branch. The two
hardcoded `supported_htp_archs` sets in `onnx_test_runner` and `onnxruntime_perf_test`, and the
`htp_arch` list in the C API docs, had the same gap.

Scope note: this makes `htp_arch=79` work on 8 Elite class parts, which is the workaround the
reporter tried and could not use. I could not confirm it resolves the
`QNN_DEVICE_ERROR_INVALID_CONFIG` they see with no provider options set - that comes back from
`deviceCreate()` with an empty config list, which points at SoC detection inside the QNN HTP backend
rather than at ORT.

Verified on Linux x86_64 with QAIRT 2.42.0.251225, the SDK version the Linux QNN CI leg pins:

- New `QnnHTPBackendTests.HTPArchV79` fails before the change (`Invalid HTP architecture: 79` in the
  captured EP log) and passes after.
- `onnxruntime_perf_test -i "htp_arch|79"` threw `Wrong value for htp_arch. select from:
  0,68,69,73,75,81` before, and is accepted after.
- `onnxruntime_provider_test --gtest_filter='Qnn*'` gives an identical result set before and after.
- `lintrunner -m HEAD` clean.

Not verified: no Snapdragon device was available, and the QAIRT x86_64 HTP library needs a newer
glibc than this host has, so `deviceCreate()` was never actually called with a v79 arch config. Only
the ORT side parsing was exercised. Windows, Android arm64 and the static_lib QNN build were not
compiled.

Thanks to @ivaylo681-dev for the detailed report, including the logcat that pinned the rejected
value to `ParseHtpArchitecture`.