### PR TITLE
Use stream-aware scratch buffer in CUDA DeformConv

### DIFF
--- a/onnxruntime/core/providers/cuda/nn/deform_conv.cc
+++ b/onnxruntime/core/providers/cuda/nn/deform_conv.cc
@@ -164,7 +164,7 @@ Status DeformConv<T>::ComputeInternal(OpKernelContext* context) const {
   const int64_t col_stride = static_cast<int64_t>(n_parallel_imgs) * output_image_size;
   const int64_t col_buffer_size = (C * kernel_size) * col_stride;
 
-  auto col_buffer = GetScratchBuffer<T>(SafeInt<size_t>(col_buffer_size), context->GetComputeStream());
+  auto col_buffer = GetScratchBuffer<T>(SafeInt<size_t>(col_buffer_size), context->GetGPUComputeStream());
 
   const T* Xdata = X->Data<T>();
   const T* Wdata = W->Data<T>();

--- a/onnxruntime/core/providers/cuda/nn/deform_conv.cc
+++ b/onnxruntime/core/providers/cuda/nn/deform_conv.cc
@@ -164,7 +164,7 @@ Status DeformConv<T>::ComputeInternal(OpKernelContext* context) const {
   const int64_t col_stride = static_cast<int64_t>(n_parallel_imgs) * output_image_size;
   const int64_t col_buffer_size = (C * kernel_size) * col_stride;
 
-  auto col_buffer = GetScratchBuffer<T>(SafeInt<size_t>(col_buffer_size), context->GetComputeStream());
+  auto col_buffer = GetScratchBuffer<T>(SafeInt<size_t>(col_buffer_size), GetComputeStream(context));
 
   const T* Xdata = X->Data<T>();
   const T* Wdata = W->Data<T>();

--- a/onnxruntime/core/providers/cuda/nn/deform_conv.cc
+++ b/onnxruntime/core/providers/cuda/nn/deform_conv.cc
@@ -164,7 +164,7 @@ Status DeformConv<T>::ComputeInternal(OpKernelContext* context) const {
   const int64_t col_stride = static_cast<int64_t>(n_parallel_imgs) * output_image_size;
   const int64_t col_buffer_size = (C * kernel_size) * col_stride;
 
-  auto col_buffer = GetScratchBuffer<T>(SafeInt<size_t>(col_buffer_size), context->GetGPUComputeStream());
+  auto col_buffer = GetScratchBuffer<T>(SafeInt<size_t>(col_buffer_size), context->GetComputeStream());
 
   const T* Xdata = X->Data<T>();
   const T* Wdata = W->Data<T>();

--- a/onnxruntime/core/providers/cuda/nn/deform_conv.cc
+++ b/onnxruntime/core/providers/cuda/nn/deform_conv.cc
@@ -164,9 +164,7 @@ Status DeformConv<T>::ComputeInternal(OpKernelContext* context) const {
   const int64_t col_stride = static_cast<int64_t>(n_parallel_imgs) * output_image_size;
   const int64_t col_buffer_size = (C * kernel_size) * col_stride;
 
-  AllocatorPtr alloc;
-  ORT_RETURN_IF_ERROR(context->GetTempSpaceAllocator(&alloc));
-  auto col_buffer = IAllocator::MakeUniquePtr<T>(alloc, SafeInt<size_t>(col_buffer_size));
+  auto col_buffer = GetScratchBuffer<T>(SafeInt<size_t>(col_buffer_size), context->GetComputeStream());
 
   const T* Xdata = X->Data<T>();
   const T* Wdata = W->Data<T>();


### PR DESCRIPTION
This pull request updates the scratch buffer allocation method in the `DeformConv` CUDA kernel implementation. The main change is a switch from using a generic allocator interface to a more specialized scratch buffer utility, which may improve performance and code clarity.

**Memory allocation improvements:**

* Replaced the use of `IAllocator::MakeUniquePtr<T>` and manual allocator retrieval with `GetScratchBuffer<T>` for allocating the `col_buffer` in `deform_conv.cc`. This streamlines temporary buffer allocation and ensures the buffer is tied to the compute stream.