### PR TITLE
Harden CUDA fp16 transpose index math against int overflow

### DIFF
--- a/onnxruntime/core/providers/cuda/fpgeneric.cu
+++ b/onnxruntime/core/providers/cuda/fpgeneric.cu
@@ -75,12 +75,12 @@ dim3 cublasTransposeHelperDimGrid(int m, int n) {
 
 // cublasTransposeHelper can only be used if it won't overflow the 65536 grid y dimension size
 __host__ bool CanUse_cublasTransposeHelper_MLFloat16(int m, int n) {
-  if (m < 0 || n < 0) {
+  if (m <= 0 || n <= 0) {
     return false;
   }
 
-  // transposeNoOverlap uses row * stride + col addressing in device code.
-  // Keep fallback disabled when total element count would overflow int32 indexing.
+  // transposeNoOverlap uses int64_t row * stride + col addressing in device code.
+  // Keep fallback disabled when total element count would overflow 32-bit launch/indexing assumptions.
   if (static_cast<int64_t>(m) * static_cast<int64_t>(n) > std::numeric_limits<int>::max()) {
     return false;
   }
@@ -90,6 +90,7 @@ __host__ bool CanUse_cublasTransposeHelper_MLFloat16(int m, int n) {
 }
 
 cublasStatus_t cublasTransposeHelper(cudaStream_t stream, cublasHandle_t, cublasOperation_t, cublasOperation_t, int m, int n, const half*, const half* A, int, const half*, const half*, int, half* C, int) {
+  ORT_ENFORCE(m > 0 && n > 0);
   if (C != A) {
     dim3 dimGrid = cublasTransposeHelperDimGrid(m, n);
     dim3 dimBlock(TRANS_TILE_DIM, BLOCK_ROWS, 1);

--- a/onnxruntime/core/providers/cuda/fpgeneric.cu
+++ b/onnxruntime/core/providers/cuda/fpgeneric.cu
@@ -13,6 +13,8 @@
 #include "core/providers/cuda/curand_wrapper.h"
 #include "core/providers/cuda/cu_inc/common.cuh"
 
+#include <limits>
+
 #define TRANS_TILE_DIM 32
 #define BLOCK_ROWS 8
 #define COPY_TILE_DIM 1024
@@ -31,7 +33,8 @@ __global__ void transposeNoOverlap(half* odata, const half* idata, const int m, 
   if (x < m) {
     for (int j = 0; j < TRANS_TILE_DIM; j += BLOCK_ROWS) {
       if (j >= (n - y)) continue;
-      tile[threadIdx.y + j][threadIdx.x] = idata[(y + j) * m + x];
+      const int64_t input_offset = static_cast<int64_t>(y + j) * m + x;
+      tile[threadIdx.y + j][threadIdx.x] = idata[input_offset];
     }
   }
 
@@ -44,7 +47,8 @@ __global__ void transposeNoOverlap(half* odata, const half* idata, const int m, 
 
   for (int j = 0; j < TRANS_TILE_DIM; j += BLOCK_ROWS) {
     if ((y + j) >= m) return;
-    odata[(y + j) * n + x] = tile[threadIdx.x][threadIdx.y + j];
+    const int64_t output_offset = static_cast<int64_t>(y + j) * n + x;
+    odata[output_offset] = tile[threadIdx.x][threadIdx.y + j];
   }
 }
 
@@ -64,11 +68,23 @@ __global__ void CopyVectorBFloat16(const onnxruntime::BFloat16* x, int incx, onn
 }  // namespace
 
 dim3 cublasTransposeHelperDimGrid(int m, int n) {
-  return dim3((n + TRANS_TILE_DIM - 1) / TRANS_TILE_DIM, (m + TRANS_TILE_DIM - 1) / TRANS_TILE_DIM, 1);
+  const auto grid_x = static_cast<unsigned int>((static_cast<int64_t>(n) + TRANS_TILE_DIM - 1) / TRANS_TILE_DIM);
+  const auto grid_y = static_cast<unsigned int>((static_cast<int64_t>(m) + TRANS_TILE_DIM - 1) / TRANS_TILE_DIM);
+  return dim3(grid_x, grid_y, 1);
 }
 
 // cublasTransposeHelper can only be used if it won't overflow the 65536 grid y dimension size
 __host__ bool CanUse_cublasTransposeHelper_MLFloat16(int m, int n) {
+  if (m < 0 || n < 0) {
+    return false;
+  }
+
+  // transposeNoOverlap uses row * stride + col addressing in device code.
+  // Keep fallback disabled when total element count would overflow int32 indexing.
+  if (static_cast<int64_t>(m) * static_cast<int64_t>(n) > std::numeric_limits<int>::max()) {
+    return false;
+  }
+
   dim3 dimGrid = cublasTransposeHelperDimGrid(m, n);
   return dimGrid.y < 65536;
 }
@@ -78,6 +94,7 @@ cublasStatus_t cublasTransposeHelper(cudaStream_t stream, cublasHandle_t, cublas
     dim3 dimGrid = cublasTransposeHelperDimGrid(m, n);
     dim3 dimBlock(TRANS_TILE_DIM, BLOCK_ROWS, 1);
 
+    ORT_ENFORCE(static_cast<int64_t>(m) * static_cast<int64_t>(n) <= std::numeric_limits<int>::max());
     ORT_ENFORCE(dimGrid.y < 65536);  // To prevent this, call CanUse_cublasTransposeHelper_MLFloat16 first
     transposeNoOverlap<<<dimGrid, dimBlock, 0, stream>>>(C, A, n, m);
   } else {

--- a/onnxruntime/test/providers/cuda/test_cases/cuda_utils_test.cc
+++ b/onnxruntime/test/providers/cuda/test_cases/cuda_utils_test.cc
@@ -8,6 +8,7 @@
 
 #include "core/common/common.h"
 #include "core/providers/cuda/shared_inc/cuda_call.h"
+#include "core/providers/cuda/shared_inc/fpgeneric.h"
 #include "core/providers/cuda/shared_inc/cuda_utils.h"
 
 namespace onnxruntime {
@@ -46,6 +47,16 @@ TEST(CudaUtilsTest, FillCorrectness) {
   TestFillCorrectness<int32_t>(1 << 20, 3);
   TestFillCorrectness<float>(1 << 20, 4.0f);
   TestFillCorrectness<double>(1 << 20, 5.0);
+}
+
+TEST(CudaUtilsTest, CanUseTransposeHelperRejectsOverflowingElementCount) {
+  EXPECT_TRUE(CanUse_cublasTransposeHelper_MLFloat16(100, 100));
+  EXPECT_FALSE(CanUse_cublasTransposeHelper_MLFloat16(100, 25000000));
+}
+
+TEST(CudaUtilsTest, CanUseTransposeHelperRejectsGridYOverflow) {
+  // For TRANS_TILE_DIM=32, m=2097152 yields grid_y=65536, which is out of range.
+  EXPECT_FALSE(CanUse_cublasTransposeHelper_MLFloat16(2097152, 1));
 }
 
 }  // namespace test

--- a/onnxruntime/test/providers/cuda/test_cases/cuda_utils_test.cc
+++ b/onnxruntime/test/providers/cuda/test_cases/cuda_utils_test.cc
@@ -54,6 +54,13 @@ TEST(CudaUtilsTest, CanUseTransposeHelperRejectsOverflowingElementCount) {
   EXPECT_FALSE(CanUse_cublasTransposeHelper_MLFloat16(100, 25000000));
 }
 
+TEST(CudaUtilsTest, CanUseTransposeHelperRejectsNonPositiveDimensions) {
+  EXPECT_FALSE(CanUse_cublasTransposeHelper_MLFloat16(0, 100));
+  EXPECT_FALSE(CanUse_cublasTransposeHelper_MLFloat16(100, 0));
+  EXPECT_FALSE(CanUse_cublasTransposeHelper_MLFloat16(-1, 100));
+  EXPECT_FALSE(CanUse_cublasTransposeHelper_MLFloat16(100, -1));
+}
+
 TEST(CudaUtilsTest, CanUseTransposeHelperRejectsGridYOverflow) {
   // For TRANS_TILE_DIM=32, m=2097152 yields grid_y=65536, which is out of range.
   EXPECT_FALSE(CanUse_cublasTransposeHelper_MLFloat16(2097152, 1));


### PR DESCRIPTION
This pull request improves the safety and robustness of CUDA-based matrix transposition in ONNX Runtime by adding overflow checks, using safer integer types for indexing, and expanding test coverage. The main focus is on preventing integer overflows and ensuring correct grid dimension calculations for large matrices.

**Safety and overflow prevention:**

* Updated all indexing calculations in the `transposeNoOverlap` CUDA kernel to use `int64_t` for offsets, preventing integer overflows when handling large matrices (`onnxruntime/core/providers/cuda/fpgeneric.cu`). [[1]](diffhunk://#diff-bb68f0e3a6d648920a66e44ec86b7263ddfc8efeae7884f6cfd257cba1fdac6fL34-R37) [[2]](diffhunk://#diff-bb68f0e3a6d648920a66e44ec86b7263ddfc8efeae7884f6cfd257cba1fdac6fL47-R51)
* Modified `cublasTransposeHelperDimGrid` to use `int64_t` for grid size calculations, then safely cast to `unsigned int` (`onnxruntime/core/providers/cuda/fpgeneric.cu`).
* Added explicit checks in `CanUse_cublasTransposeHelper_MLFloat16` and `cublasTransposeHelper` to reject cases where the element count would overflow a 32-bit integer, or where grid dimensions would exceed CUDA limits (`onnxruntime/core/providers/cuda/fpgeneric.cu`). [[1]](diffhunk://#diff-bb68f0e3a6d648920a66e44ec86b7263ddfc8efeae7884f6cfd257cba1fdac6fL67-R87) [[2]](diffhunk://#diff-bb68f0e3a6d648920a66e44ec86b7263ddfc8efeae7884f6cfd257cba1fdac6fR97)

**Testing improvements:**

* Added unit tests to verify that `CanUse_cublasTransposeHelper_MLFloat16` correctly rejects overflowing element counts and grid dimensions (`onnxruntime/test/providers/cuda/test_cases/cuda_utils_test.cc`).
* Included the appropriate header for the tested functions in the test file (`onnxruntime/test/providers/cuda/test_cases/cuda_utils_test.cc`).

**Other:**

* Included `<limits>` to support overflow checks (`onnxruntime/core/providers/cuda/fpgeneric.cu`).