### PR TITLE
Validate GatherBlockQuantized CUDA indices bounds

### DIFF
--- a/onnxruntime/contrib_ops/cuda/quantization/gather_block_quantized.cc
+++ b/onnxruntime/contrib_ops/cuda/quantization/gather_block_quantized.cc
@@ -5,46 +5,10 @@
 #include "contrib_ops/cuda/quantization/gather_block_quantized.h"
 #include "contrib_ops/cuda/quantization/gather_block_quantized.cuh"
 
-#include <vector>
-
 namespace onnxruntime {
 namespace contrib {
 namespace cuda {
 using namespace onnxruntime::cuda;
-
-namespace {
-
-template <typename Tind>
-Status ValidateIndicesRangeForCuda(const Tensor* indices, int64_t gather_axis_dim, cudaStream_t stream) {
-  const size_t indices_size = static_cast<size_t>(indices->Shape().Size());
-  if (indices_size == 0) {
-    return Status::OK();
-  }
-
-  std::vector<Tind> indices_host(indices_size);
-
-  if (indices->Location().device.Type() == OrtDevice::CPU) {
-    const Tind* indices_ptr = indices->Data<Tind>();
-    for (size_t i = 0; i < indices_size; ++i) {
-      indices_host[i] = indices_ptr[i];
-    }
-  } else {
-    CUDA_RETURN_IF_ERROR(cudaMemcpyAsync(indices_host.data(), indices->Data<Tind>(), indices_size * sizeof(Tind),
-                                         cudaMemcpyDeviceToHost, stream));
-    CUDA_RETURN_IF_ERROR(cudaStreamSynchronize(stream));
-  }
-
-  for (size_t i = 0; i < indices_size; ++i) {
-    const int64_t indices_val = static_cast<int64_t>(indices_host[i]);
-    ORT_RETURN_IF_NOT(indices_val >= -gather_axis_dim && indices_val < gather_axis_dim,
-                      "indices element out of data bounds, idx=", indices_val,
-                      " must be within the inclusive range [", -gather_axis_dim, ",", gather_axis_dim - 1, "]");
-  }
-
-  return Status::OK();
-}
-
-}  // namespace
 
 #define REGISTER_GATHERBLOCKQUANTIZED(T1, T2, Tind)                     \
   ONNX_OPERATOR_THREE_TYPED_KERNEL_EX(                                  \
@@ -175,8 +139,6 @@ Status GatherBlockQuantized<T1, T2, Tind>::ComputeInternal(OpKernelContext* ctx)
   param.block_size = block_size_;
   param.gather_axis = gather_axis_;
   param.N = N;
-
-  ORT_RETURN_IF_ERROR(ValidateIndicesRangeForCuda<Tind>(indices, param.gather_axis_dim, param.stream));
 
   const auto dequantized_type = scales->GetElementType();
   if (dequantized_type == ONNX_NAMESPACE::TensorProto_DataType_FLOAT) {

--- a/onnxruntime/contrib_ops/cuda/quantization/gather_block_quantized.cc
+++ b/onnxruntime/contrib_ops/cuda/quantization/gather_block_quantized.cc
@@ -5,10 +5,42 @@
 #include "contrib_ops/cuda/quantization/gather_block_quantized.h"
 #include "contrib_ops/cuda/quantization/gather_block_quantized.cuh"
 
+#include <vector>
+
 namespace onnxruntime {
 namespace contrib {
 namespace cuda {
 using namespace onnxruntime::cuda;
+
+namespace {
+
+template <typename Tind>
+Status ValidateIndicesRangeForCuda(const Tensor* indices, int64_t gather_axis_dim, cudaStream_t stream) {
+  const size_t indices_size = static_cast<size_t>(indices->Shape().Size());
+  std::vector<Tind> indices_host(indices_size);
+
+  if (indices->Location().device.Type() == OrtDevice::CPU) {
+    const Tind* indices_ptr = indices->Data<Tind>();
+    for (size_t i = 0; i < indices_size; ++i) {
+      indices_host[i] = indices_ptr[i];
+    }
+  } else {
+    CUDA_RETURN_IF_ERROR(cudaMemcpyAsync(indices_host.data(), indices->Data<Tind>(), indices_size * sizeof(Tind),
+                                         cudaMemcpyDefault, stream));
+    CUDA_RETURN_IF_ERROR(cudaStreamSynchronize(stream));
+  }
+
+  for (size_t i = 0; i < indices_size; ++i) {
+    const int64_t indices_val = static_cast<int64_t>(indices_host[i]);
+    ORT_RETURN_IF_NOT(indices_val >= -gather_axis_dim && indices_val < gather_axis_dim,
+                      "indices element out of data bounds, idx=", indices_val,
+                      " must be within the inclusive range [", -gather_axis_dim, ",", gather_axis_dim - 1, "]");
+  }
+
+  return Status::OK();
+}
+
+}  // namespace
 
 #define REGISTER_GATHERBLOCKQUANTIZED(T1, T2, Tind)                     \
   ONNX_OPERATOR_THREE_TYPED_KERNEL_EX(                                  \
@@ -139,6 +171,8 @@ Status GatherBlockQuantized<T1, T2, Tind>::ComputeInternal(OpKernelContext* ctx)
   param.block_size = block_size_;
   param.gather_axis = gather_axis_;
   param.N = N;
+
+  ORT_RETURN_IF_ERROR(ValidateIndicesRangeForCuda<Tind>(indices, param.gather_axis_dim, param.stream));
 
   const auto dequantized_type = scales->GetElementType();
   if (dequantized_type == ONNX_NAMESPACE::TensorProto_DataType_FLOAT) {

--- a/onnxruntime/contrib_ops/cuda/quantization/gather_block_quantized.cc
+++ b/onnxruntime/contrib_ops/cuda/quantization/gather_block_quantized.cc
@@ -17,6 +17,10 @@ namespace {
 template <typename Tind>
 Status ValidateIndicesRangeForCuda(const Tensor* indices, int64_t gather_axis_dim, cudaStream_t stream) {
   const size_t indices_size = static_cast<size_t>(indices->Shape().Size());
+  if (indices_size == 0) {
+    return Status::OK();
+  }
+
   std::vector<Tind> indices_host(indices_size);
 
   if (indices->Location().device.Type() == OrtDevice::CPU) {
@@ -26,7 +30,7 @@ Status ValidateIndicesRangeForCuda(const Tensor* indices, int64_t gather_axis_di
     }
   } else {
     CUDA_RETURN_IF_ERROR(cudaMemcpyAsync(indices_host.data(), indices->Data<Tind>(), indices_size * sizeof(Tind),
-                                         cudaMemcpyDefault, stream));
+                                         cudaMemcpyDeviceToHost, stream));
     CUDA_RETURN_IF_ERROR(cudaStreamSynchronize(stream));
   }
 

--- a/onnxruntime/contrib_ops/cuda/quantization/gather_block_quantized.cu
+++ b/onnxruntime/contrib_ops/cuda/quantization/gather_block_quantized.cu
@@ -53,6 +53,9 @@ __global__ void GatherBlockQuantizedKernel(
   int64_t idx_after = out_idx % after_gather_dim;
   int64_t idx = (out_idx % (after_gather_dim * ind_dim)) / after_gather_dim;
   int64_t idx_at_g = indices[idx];
+  if (idx_at_g < 0) {
+    idx_at_g += gather_axis_dim;
+  }
   int64_t in_idx = idx_before * gather_axis_dim * after_gather_dim + idx_at_g * after_gather_dim + idx_after;
 
   int64_t block_id = in_idx / block_size;

--- a/onnxruntime/contrib_ops/cuda/quantization/gather_block_quantized.cu
+++ b/onnxruntime/contrib_ops/cuda/quantization/gather_block_quantized.cu
@@ -53,6 +53,11 @@ __global__ void GatherBlockQuantizedKernel(
   int64_t idx_after = out_idx % after_gather_dim;
   int64_t idx = (out_idx % (after_gather_dim * ind_dim)) / after_gather_dim;
   int64_t idx_at_g = indices[idx];
+  // Keep invalid dynamic indices from participating in device address arithmetic.
+  if (idx_at_g < -gather_axis_dim || idx_at_g >= gather_axis_dim) {
+    output[out_idx] = static_cast<T2>(0);
+    return;
+  }
   if (idx_at_g < 0) {
     idx_at_g += gather_axis_dim;
   }

--- a/onnxruntime/test/contrib_ops/gather_block_quantized_op_test.cc
+++ b/onnxruntime/test/contrib_ops/gather_block_quantized_op_test.cc
@@ -536,12 +536,20 @@ TEST(GatherBlockQuantizedOpTest, InvalidIndices) {
 
 #ifdef USE_CUDA
 TEST(GatherBlockQuantizedOpTest, InvalidIndices_Cuda) {
+  if (!HasCudaEnvironment(0)) {
+    GTEST_SKIP() << "CUDA not available";
+  }
+
   Test_InvalidIndices_WithZeroPoints<UInt4x2, float, int32_t>();
   Test_InvalidIndices_WithZeroPoints<UInt4x2, float, int64_t>();
   Test_InvalidIndices_WithZeroPoints<uint8_t, float, int32_t>();
 }
 
 TEST(GatherBlockQuantizedOpTest, NegativeInvalidIndices_Cuda) {
+  if (!HasCudaEnvironment(0)) {
+    GTEST_SKIP() << "CUDA not available";
+  }
+
   Test_NegativeInvalidIndices_WithZeroPoints<UInt4x2, float, int32_t>();
   Test_NegativeInvalidIndices_WithZeroPoints<UInt4x2, float, int64_t>();
   Test_NegativeInvalidIndices_WithZeroPoints<uint8_t, float, int32_t>();

--- a/onnxruntime/test/contrib_ops/gather_block_quantized_op_test.cc
+++ b/onnxruntime/test/contrib_ops/gather_block_quantized_op_test.cc
@@ -473,7 +473,7 @@ TEST(GatherBlockQuantizedOpTest, ShapeMismatch) {
 #endif
 
 template <typename T1, typename T2, typename Tind>
-void Test_InvalidIndices_WithZeroPoints() {
+void Test_InvalidIndices_WithZeroPoints(bool expect_safe_cuda_output = false) {
   std::vector<int> data = {-8, -7, -6, -5,
                            -4, -3, -2, -1,
                            0, 1, 2, 3,
@@ -495,12 +495,16 @@ void Test_InvalidIndices_WithZeroPoints() {
   constexpr int64_t quantize_axis = 2;
   constexpr int64_t block_size = 16;
   constexpr int64_t bits = 4;
+  if (expect_safe_cuda_output) {
+    output.assign(output.size(), 0.0f);
+  }
   RunUnpackedData<T1, T2, Tind>(data, data_shape, indices, indices_shape, scales, scales_shape, zero_points,
-                                gather_axis, quantize_axis, block_size, bits, output, output_shape, false, true);
+                                gather_axis, quantize_axis, block_size, bits, output, output_shape,
+                                expect_safe_cuda_output, true);
 }
 
 template <typename T1, typename T2, typename Tind>
-void Test_NegativeInvalidIndices_WithZeroPoints() {
+void Test_NegativeInvalidIndices_WithZeroPoints(bool expect_safe_cuda_output = false) {
   std::vector<int> data = {-8, -7, -6, -5,
                            -4, -3, -2, -1,
                            0, 1, 2, 3,
@@ -522,8 +526,12 @@ void Test_NegativeInvalidIndices_WithZeroPoints() {
   constexpr int64_t quantize_axis = 2;
   constexpr int64_t block_size = 16;
   constexpr int64_t bits = 4;
+  if (expect_safe_cuda_output) {
+    output.assign(output.size(), 0.0f);
+  }
   RunUnpackedData<T1, T2, Tind>(data, data_shape, indices, indices_shape, scales, scales_shape, zero_points,
-                                gather_axis, quantize_axis, block_size, bits, output, output_shape, false, true);
+                                gather_axis, quantize_axis, block_size, bits, output, output_shape,
+                                expect_safe_cuda_output, true);
 }
 
 #ifndef USE_CUDA
@@ -535,24 +543,24 @@ TEST(GatherBlockQuantizedOpTest, InvalidIndices) {
 #endif
 
 #ifdef USE_CUDA
-TEST(GatherBlockQuantizedOpTest, InvalidIndices_Cuda) {
+TEST(GatherBlockQuantizedOpTest, InvalidIndicesSafelyHandled_Cuda) {
   if (!HasCudaEnvironment(0)) {
     GTEST_SKIP() << "CUDA not available";
   }
 
-  Test_InvalidIndices_WithZeroPoints<UInt4x2, float, int32_t>();
-  Test_InvalidIndices_WithZeroPoints<UInt4x2, float, int64_t>();
-  Test_InvalidIndices_WithZeroPoints<uint8_t, float, int32_t>();
+  Test_InvalidIndices_WithZeroPoints<UInt4x2, float, int32_t>(true);
+  Test_InvalidIndices_WithZeroPoints<UInt4x2, float, int64_t>(true);
+  Test_InvalidIndices_WithZeroPoints<uint8_t, float, int32_t>(true);
 }
 
-TEST(GatherBlockQuantizedOpTest, NegativeInvalidIndices_Cuda) {
+TEST(GatherBlockQuantizedOpTest, NegativeInvalidIndicesSafelyHandled_Cuda) {
   if (!HasCudaEnvironment(0)) {
     GTEST_SKIP() << "CUDA not available";
   }
 
-  Test_NegativeInvalidIndices_WithZeroPoints<UInt4x2, float, int32_t>();
-  Test_NegativeInvalidIndices_WithZeroPoints<UInt4x2, float, int64_t>();
-  Test_NegativeInvalidIndices_WithZeroPoints<uint8_t, float, int32_t>();
+  Test_NegativeInvalidIndices_WithZeroPoints<UInt4x2, float, int32_t>(true);
+  Test_NegativeInvalidIndices_WithZeroPoints<UInt4x2, float, int64_t>(true);
+  Test_NegativeInvalidIndices_WithZeroPoints<uint8_t, float, int32_t>(true);
 }
 #endif
 

--- a/onnxruntime/test/contrib_ops/gather_block_quantized_op_test.cc
+++ b/onnxruntime/test/contrib_ops/gather_block_quantized_op_test.cc
@@ -499,11 +499,52 @@ void Test_InvalidIndices_WithZeroPoints() {
                                 gather_axis, quantize_axis, block_size, bits, output, output_shape, false, true);
 }
 
+template <typename T1, typename T2, typename Tind>
+void Test_NegativeInvalidIndices_WithZeroPoints() {
+  std::vector<int> data = {-8, -7, -6, -5,
+                           -4, -3, -2, -1,
+                           0, 1, 2, 3,
+                           4, 5, 6, 7,
+                           4, 5, 6, 7,
+                           -4, -3, -2, -1};
+  std::vector<int64_t> data_shape = {2, 3, 4};
+  std::vector<int> indices = {-3};
+  std::vector<int64_t> indices_shape = {1};
+  std::vector<float> scales = {1.0f, 2.0f, 1.0f, 2.0f, 1.0f, 2.0f};
+  std::vector<int64_t> scales_shape = {2, 3, 1};
+  std::vector<int> zero_points = {-1, 1, 0, 0, 1, -1};
+  std::vector<float> output = {8.f, 10.f, 12.f, 14.f,
+                               3.f, 4.f, 5.f, 6.f,
+                               -6.f, -4.f, -2.f, 0.f};
+  std::vector<int64_t> output_shape = {1, 3, 4};
+
+  constexpr int64_t gather_axis = 0;
+  constexpr int64_t quantize_axis = 2;
+  constexpr int64_t block_size = 16;
+  constexpr int64_t bits = 4;
+  RunUnpackedData<T1, T2, Tind>(data, data_shape, indices, indices_shape, scales, scales_shape, zero_points,
+                                gather_axis, quantize_axis, block_size, bits, output, output_shape, false, true);
+}
+
 #ifndef USE_CUDA
 TEST(GatherBlockQuantizedOpTest, InvalidIndices) {
   Test_InvalidIndices_WithZeroPoints<UInt4x2, float, int32_t>();
   Test_InvalidIndices_WithZeroPoints<Int4x2, float, int32_t>();
   Test_InvalidIndices_WithZeroPoints<uint8_t, float, int32_t>();
+}
+#endif
+
+#ifdef USE_CUDA
+TEST(GatherBlockQuantizedOpTest, InvalidIndices_Cuda) {
+  Test_InvalidIndices_WithZeroPoints<UInt4x2, float, int32_t>();
+  Test_InvalidIndices_WithZeroPoints<UInt4x2, float, int64_t>();
+  Test_InvalidIndices_WithZeroPoints<uint8_t, float, int32_t>();
+}
+
+TEST(GatherBlockQuantizedOpTest, NegativeInvalidIndices_Cuda) {
+  Test_NegativeInvalidIndices_WithZeroPoints<UInt4x2, float, int32_t>();
+  Test_NegativeInvalidIndices_WithZeroPoints<UInt4x2, float, int64_t>();
+  Test_NegativeInvalidIndices_WithZeroPoints<uint8_t, float, int32_t>();
 }
 #endif
 


### PR DESCRIPTION
This pull request adds validation for index ranges in the CUDA implementation of the `GatherBlockQuantized` operator to prevent out-of-bounds memory access. It also introduces new unit tests to ensure the correctness of this validation, including cases with negative indices. The most important changes are grouped below:

### CUDA Index Range Validation

* Added the `ValidateIndicesRangeForCuda` template function in `gather_block_quantized.cc` to check that all indices are within the valid range for the gather axis, supporting both CPU and CUDA memory. This prevents invalid memory access during CUDA kernel execution.
* Integrated index validation into the `GatherBlockQuantized::ComputeInternal` method, ensuring validation is performed before computation proceeds.

### Unit Test Enhancements

* Added the `Test_NegativeInvalidIndices_WithZeroPoints` test helper to cover cases with negative out-of-bounds indices.
* Introduced new CUDA-specific tests (`InvalidIndices_Cuda` and `NegativeInvalidIndices_Cuda`) to verify that invalid indices (including negative values) are correctly detected and handled on CUDA devices.