### PR TITLE
Handle empty tensors in CUDA InstanceNormalization

### DIFF
--- a/onnxruntime/core/providers/cuda/nn/instance_norm.cc
+++ b/onnxruntime/core/providers/cuda/nn/instance_norm.cc
@@ -46,6 +46,12 @@ Status InstanceNorm<T>::ComputeInternal(OpKernelContext* p_op_kernel_context) co
   const TensorShape& x_shape = X->Shape();
   Tensor* Y = p_op_kernel_context->Output(0, x_shape);
 
+  // Empty inputs are valid in ONNX and should produce empty outputs.
+  // Early return avoids stats_count == 0 in the N != 1 path.
+  if (x_shape.Size() == 0) {
+    return Status::OK();
+  }
+
   auto* y_data = reinterpret_cast<CudaT*>(Y->MutableData<T>());
   const auto* x_data = reinterpret_cast<const CudaT*>(X->Data<T>());
   const auto* scale_data = reinterpret_cast<const CudaT*>(scale->Data<T>());
@@ -173,6 +179,12 @@ Status InstanceNorm<MLFloat16>::ComputeInternal(OpKernelContext* p_op_kernel_con
 
   const TensorShape& x_shape = X->Shape();
   Tensor* Y = p_op_kernel_context->Output(0, x_shape);
+
+  // Empty inputs are valid in ONNX and should produce empty outputs.
+  // Early return avoids stats_count == 0 in the N != 1 path.
+  if (x_shape.Size() == 0) {
+    return Status::OK();
+  }
 
   auto* y_data = reinterpret_cast<CudaT*>(Y->MutableData<MLFloat16>());
   const auto* x_data = reinterpret_cast<const CudaT*>(X->Data<MLFloat16>());

--- a/onnxruntime/test/providers/cpu/nn/instance_norm_op_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/instance_norm_op_test.cc
@@ -6,6 +6,10 @@
 #include "test/common/tensor_op_test_utils.h"
 #include "test/util/include/default_providers.h"
 
+#if defined(USE_CUDA)
+#include "test/common/cuda_op_test_utils.h"
+#endif
+
 using namespace std;
 namespace onnxruntime {
 namespace test {

--- a/onnxruntime/test/providers/cpu/nn/instance_norm_op_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/instance_norm_op_test.cc
@@ -224,6 +224,45 @@ TEST(InstanceNormalizationOpTest, InstanceNormBatch2_fp16) {
 }
 
 #endif
+
+#ifdef USE_CUDA
+TEST(InstanceNormalizationOpTest, InstanceNormEmptyChannel_Cuda) {
+  if (!HasCudaEnvironment(0)) {
+    GTEST_SKIP() << "CUDA not available";
+  }
+
+  OpTester test("InstanceNormalization");
+  test.AddAttribute("epsilon", 0.3F);
+
+  test.AddInput<float>("input", {2, 0, 4, 4}, {});
+  test.AddInput<float>("scale", {0}, {});
+  test.AddInput<float>("B", {0}, {});
+  test.AddOutput<float>("Y", {2, 0, 4, 4}, {});
+
+  std::vector<std::unique_ptr<IExecutionProvider>> cuda_only_ep;
+  cuda_only_ep.push_back(DefaultCudaExecutionProvider());
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &cuda_only_ep);
+}
+
+TEST(InstanceNormalizationOpTest, InstanceNormEmptyBatch_Cuda) {
+  if (!HasCudaEnvironment(0)) {
+    GTEST_SKIP() << "CUDA not available";
+  }
+
+  OpTester test("InstanceNormalization");
+  test.AddAttribute("epsilon", 0.3F);
+
+  test.AddInput<float>("input", {0, 3, 4, 4}, {});
+  test.AddInput<float>("scale", {3}, {1.0f, 1.0f, 1.0f});
+  test.AddInput<float>("B", {3}, {0.0f, 0.0f, 0.0f});
+  test.AddOutput<float>("Y", {0, 3, 4, 4}, {});
+
+  std::vector<std::unique_ptr<IExecutionProvider>> cuda_only_ep;
+  cuda_only_ep.push_back(DefaultCudaExecutionProvider());
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &cuda_only_ep);
+}
+#endif
+
 TEST(InstanceNormalizationOpTest, InstanceNorm_2) {
   OpTester test("InstanceNormalization");
   test.AddAttribute("epsilon", 0.3F);


### PR DESCRIPTION
This pull request improves the handling of empty input tensors in the CUDA implementation of the `InstanceNormalization` operator and adds corresponding unit tests to ensure correct behavior. The main focus is to ensure compliance with the ONNX specification, which allows empty inputs and expects empty outputs.

**CUDA Implementation Improvements:**

* Updated `InstanceNorm<T>::ComputeInternal` and `InstanceNorm<MLFloat16>::ComputeInternal` in `instance_norm.cc` to check for empty input tensors and return early, ensuring that empty inputs produce empty outputs as required by ONNX. This prevents unnecessary computation and potential errors when the input size is zero. [[1]](diffhunk://#diff-73a0784b2867dc534a1ee23c7e624c87fd59cdbe0996dc1df8684191244ac688R49-R54) [[2]](diffhunk://#diff-73a0784b2867dc534a1ee23c7e624c87fd59cdbe0996dc1df8684191244ac688R183-R188)

**Unit Test Additions:**

* Added two CUDA-specific tests in `instance_norm_op_test.cc`:
  * `InstanceNormEmptyChannel_Cuda` verifies correct handling when the channel dimension is zero.
  * `InstanceNormEmptyBatch_Cuda` verifies correct handling when the batch dimension is zero.
  These tests confirm that the operator returns empty outputs without error for these edge cases.