### PR TITLE
Fix TfIdfVectorizer weight indexing semantics

### DIFF
--- a/onnxruntime/core/providers/cpu/nn/tfidfvectorizer.cc
+++ b/onnxruntime/core/providers/cpu/nn/tfidfvectorizer.cc
@@ -259,7 +259,7 @@ TfIdfVectorizer::~TfIdfVectorizer() = default;
 
 void TfIdfVectorizer::ComputeImpl(const void* x_data_raw, size_t elem_size, ptrdiff_t row_num, size_t row_size,
                                   bool is_input_string, gsl::span<float> output_data,
-                                  std::function<void(size_t, gsl::span<float>&)>& fn_weight) const {
+                                  std::function<void(size_t, size_t, gsl::span<float>&)>& fn_weight) const {
   const void* const row_begin = AdvanceElementPtr(x_data_raw, row_num * row_size, elem_size);
   const void* const row_end = AdvanceElementPtr(row_begin, row_size, elem_size);
 
@@ -294,8 +294,9 @@ void TfIdfVectorizer::ComputeImpl(const void* x_data_raw, size_t elem_size, ptrd
             break;
           }
           if (ngram_size >= start_ngram_size && hit->second->id_ != 0) {
-            output_idx = impl.OutputIdToIncrement(hit->second->id_);
-            fn_weight(output_idx, output_data);
+            const size_t ngram_id = hit->second->id_;
+            output_idx = impl.OutputIdToIncrement(ngram_id);
+            fn_weight(ngram_id - 1, output_idx, output_data);
           }
           str_map = &hit->second->leafs_;
         }
@@ -312,8 +313,9 @@ void TfIdfVectorizer::ComputeImpl(const void* x_data_raw, size_t elem_size, ptrd
             break;
           }
           if (ngram_size >= start_ngram_size && hit->second->id_ != 0) {
-            output_idx = impl.OutputIdToIncrement(hit->second->id_);
-            fn_weight(output_idx, output_data);
+            const size_t ngram_id = hit->second->id_;
+            output_idx = impl.OutputIdToIncrement(ngram_id);
+            fn_weight(ngram_id - 1, output_idx, output_data);
           }
           int_map = &hit->second->leafs_;
         }
@@ -391,24 +393,24 @@ Status TfIdfVectorizer::Compute(OpKernelContext* ctx) const {
   int32_t num_batches = std::min<int32_t>(concurrency::ThreadPool::DegreeOfParallelism(ctx->GetOperatorThreadPool()) * 2, num_rows);
 
   const auto& w = impl.weights_;
-  std::function<void(size_t, gsl::span<float>&)> fn_weight;
+  std::function<void(size_t, size_t, gsl::span<float>&)> fn_weight;
 
   switch (impl.weighting_criteria_) {
     case kTF:
-      fn_weight = [](size_t i, gsl::span<float>& out) { out[i] += 1.0f; };
+      fn_weight = [](size_t /*pool_idx*/, size_t out_idx, gsl::span<float>& out) { out[out_idx] += 1.0f; };
       break;
     case kIDF:
       if (!w.empty()) {
-        fn_weight = [&w](size_t i, gsl::span<float>& out) { out[i] = w[i]; };
+        fn_weight = [&w](size_t pool_idx, size_t out_idx, gsl::span<float>& out) { out[out_idx] = w[pool_idx]; };
       } else {
-        fn_weight = [](size_t i, gsl::span<float>& out) { out[i] = 1.0f; };
+        fn_weight = [](size_t /*pool_idx*/, size_t out_idx, gsl::span<float>& out) { out[out_idx] = 1.0f; };
       }
       break;
     case kTFIDF:
       if (!w.empty()) {
-        fn_weight = [&w](size_t i, gsl::span<float>& out) { out[i] += w[i]; };
+        fn_weight = [&w](size_t pool_idx, size_t out_idx, gsl::span<float>& out) { out[out_idx] += w[pool_idx]; };
       } else {
-        fn_weight = [](size_t i, gsl::span<float>& out) { out[i] += 1.0f; };
+        fn_weight = [](size_t /*pool_idx*/, size_t out_idx, gsl::span<float>& out) { out[out_idx] += 1.0f; };
       }
       break;
     case kNone:  // fall-through

--- a/onnxruntime/core/providers/cpu/nn/tfidfvectorizer.h
+++ b/onnxruntime/core/providers/cpu/nn/tfidfvectorizer.h
@@ -22,7 +22,7 @@ class TfIdfVectorizer final : public OpKernel {
 
  private:
   void ComputeImpl(const void* x_data_raw, size_t elem_size, ptrdiff_t row_num, size_t row_size, bool is_input_string,
-                   gsl::span<float> output_data, std::function<void(size_t, gsl::span<float>&)>& fn_weight) const;
+                   gsl::span<float> output_data, std::function<void(size_t, size_t, gsl::span<float>&)>& fn_weight) const;
 
   struct Impl;
   std::unique_ptr<Impl> impl_;

--- a/onnxruntime/test/providers/cpu/nn/tfidfvectorizer_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/tfidfvectorizer_test.cc
@@ -689,6 +689,42 @@ TEST(TfIdfVectorizerTest, String_TFIDFWeights_onlyBigrams_Skip5_2rows) {
   test.Run(OpTester::ExpectResult::kExpectSuccess);
 }
 
+TEST(TfIdfVectorizerTest, Int64_IDFWeights_PermutedNgramIndexes) {
+  OpTester test("TfIdfVectorizer", opset_ver);
+  InitTestAttr(test, "IDF", 1, 1, 0,
+               {0},
+               {0, 100, 1},
+               {1.0f, 2.0f, 3.0f},
+               {7, 8, 9},
+               {});
+
+  test.AddInput<int64_t>("T", {1}, {8});
+
+  std::vector<float> output(101, 0.0f);
+  output[100] = 2.0f;
+  test.AddOutput<float>("Y", {101}, output);
+
+  test.Run(OpTester::ExpectResult::kExpectSuccess);
+}
+
+TEST(TfIdfVectorizerTest, Int64_TFIDFWeights_PermutedNgramIndexes) {
+  OpTester test("TfIdfVectorizer", opset_ver);
+  InitTestAttr(test, "TFIDF", 1, 1, 0,
+               {0},
+               {0, 100, 1},
+               {1.0f, 2.0f, 3.0f},
+               {7, 8, 9},
+               {});
+
+  test.AddInput<int64_t>("T", {3}, {8, 8, 8});
+
+  std::vector<float> output(101, 0.0f);
+  output[100] = 6.0f;
+  test.AddOutput<float>("Y", {101}, output);
+
+  test.Run(OpTester::ExpectResult::kExpectSuccess);
+}
+
 // This test runs the inference 100 times to test the improvement
 // It enables profiling while running inference multiple times.
 // So we can manually inspect the profiling output


### PR DESCRIPTION
This pull request refactors the `TfIdfVectorizer` implementation to improve the handling of n-gram index mapping, especially for cases where n-gram indexes are not sequential or are permuted. The changes also update the weighting callback signature to provide more context, and add new tests to ensure correct behavior for permuted n-gram indexes.

### Refactoring and API Changes

* Updated the signature of the `fn_weight` callback in `TfIdfVectorizer::ComputeImpl` to take both the n-gram id and output index, allowing for more flexible and accurate mapping between n-gram ids and output vector indices.
* Modified all usages of `fn_weight` in `ComputeImpl` to pass both the n-gram id and output index, ensuring the callback has the necessary information to apply weights correctly. [[1]](diffhunk://#diff-e352d009c96e11b341df0ca79aee9195c880751f20faf70a21cf500281d6aad3L297-R299) [[2]](diffhunk://#diff-e352d009c96e11b341df0ca79aee9195c880751f20faf70a21cf500281d6aad3L315-R318)
* Updated the construction of `fn_weight` in the main `Compute` method to match the new signature, and to use the correct values for output assignment based on n-gram id and output index.

### Testing Improvements

* Added new unit tests (`Int64_IDFWeights_PermutedNgramIndexes` and `Int64_TFIDFWeights_PermutedNgramIndexes`) to verify correct behavior when n-gram indexes are permuted, ensuring the output vector is populated at the correct index regardless of n-gram id order.