### PR TITLE
Guard CUDA LayerNorm/RMSNorm int32 offset range

### DIFF
--- a/onnxruntime/core/providers/cuda/nn/layer_norm.cc
+++ b/onnxruntime/core/providers/cuda/nn/layer_norm.cc
@@ -89,9 +89,17 @@ Status LayerNorm<T, U, V, simplified>::ComputeInternal(OpKernelContext* ctx) con
     return Status::OK();
   }
 
+  // Validate that norm_size won't cause integer overflow in host-side arithmetic.
+  // HostApplyLayerNorm computes: (n2 + 4 * warp_size - 1) where warp_size is typically 32.
+  // Maximum safe value: INT_MAX - (4 * max_warp_size) to prevent overflow.
+  // Using 256 as a conservative upper bound for 4 * warp_size.
+  constexpr int MAX_WARP_FACTOR = 256;
+  const int MAX_NORM_SIZE = std::numeric_limits<int>::max() - MAX_WARP_FACTOR;
+  
   ORT_RETURN_IF(params.num_rows > 0 &&
-                    params.norm_size > std::numeric_limits<int>::max() / params.num_rows,
-                "LayerNormalization input is too large for CUDA kernel indexing: num_rows * norm_size exceeds INT_MAX");
+                    (params.norm_size > MAX_NORM_SIZE ||
+                     params.norm_size > std::numeric_limits<int>::max() / params.num_rows),
+                "LayerNormalization input is too large for CUDA kernel indexing: norm_size exceeds safe limits or num_rows * norm_size exceeds INT_MAX");
 
   HostApplyLayerNorm<CudaT, CudaU, CudaV, simplified>(
       GetDeviceProp(), Stream(ctx), Y_data, mean_data, inv_var_data, X_data,

--- a/onnxruntime/core/providers/cuda/nn/layer_norm.cc
+++ b/onnxruntime/core/providers/cuda/nn/layer_norm.cc
@@ -95,7 +95,7 @@ Status LayerNorm<T, U, V, simplified>::ComputeInternal(OpKernelContext* ctx) con
   // Using 256 as a conservative upper bound for 4 * warp_size.
   constexpr int MAX_WARP_FACTOR = 256;
   const int MAX_NORM_SIZE = std::numeric_limits<int>::max() - MAX_WARP_FACTOR;
-  
+
   ORT_RETURN_IF(params.num_rows > 0 &&
                     (params.norm_size > MAX_NORM_SIZE ||
                      params.norm_size > std::numeric_limits<int>::max() / params.num_rows),

--- a/onnxruntime/core/providers/cuda/nn/layer_norm.cc
+++ b/onnxruntime/core/providers/cuda/nn/layer_norm.cc
@@ -6,6 +6,7 @@
 #include "core/providers/cuda/nn/layer_norm_impl.h"
 #include "core/providers/cpu/nn/layer_norm_helper.h"
 #include "core/providers/cuda/cuda_common.h"
+#include <limits>
 
 namespace onnxruntime {
 namespace cuda {
@@ -87,6 +88,10 @@ Status LayerNorm<T, U, V, simplified>::ComputeInternal(OpKernelContext* ctx) con
   if (x_shape.Size() == 0) {
     return Status::OK();
   }
+
+  ORT_RETURN_IF(params.num_rows > 0 &&
+                    params.norm_size > std::numeric_limits<int>::max() / params.num_rows,
+                "LayerNormalization input is too large for CUDA kernel indexing: num_rows * norm_size exceeds INT_MAX");
 
   HostApplyLayerNorm<CudaT, CudaU, CudaV, simplified>(
       GetDeviceProp(), Stream(ctx), Y_data, mean_data, inv_var_data, X_data,

--- a/onnxruntime/core/providers/cuda/nn/rms_norm.cc
+++ b/onnxruntime/core/providers/cuda/nn/rms_norm.cc
@@ -83,7 +83,7 @@ Status RMSNorm<T, U, V>::ComputeInternal(OpKernelContext* ctx) const {
   // Using 256 as a conservative upper bound for 4 * warp_size.
   constexpr int MAX_WARP_FACTOR = 256;
   const int MAX_NORM_SIZE = std::numeric_limits<int>::max() - MAX_WARP_FACTOR;
-  
+
   ORT_RETURN_IF(params.num_rows > 0 &&
                     (params.norm_size > MAX_NORM_SIZE ||
                      params.norm_size > std::numeric_limits<int>::max() / params.num_rows),

--- a/onnxruntime/core/providers/cuda/nn/rms_norm.cc
+++ b/onnxruntime/core/providers/cuda/nn/rms_norm.cc
@@ -6,6 +6,7 @@
 #include "core/providers/cuda/nn/layer_norm_impl.h"
 #include "core/providers/cuda/cuda_common.h"
 #include "core/providers/cpu/nn/layer_norm_helper.h"
+#include <limits>
 #include <vector>
 
 namespace onnxruntime {
@@ -75,6 +76,10 @@ Status RMSNorm<T, U, V>::ComputeInternal(OpKernelContext* ctx) const {
   if (x_shape.Size() == 0) {
     return Status::OK();
   }
+
+  ORT_RETURN_IF(params.num_rows > 0 &&
+                    params.norm_size > std::numeric_limits<int>::max() / params.num_rows,
+                "RMSNormalization input is too large for CUDA kernel indexing: num_rows * norm_size exceeds INT_MAX");
 
   // For RMSNorm, we don't need mean and inv_var data, so we can pass nullptr.
   CudaU* mean_data = nullptr;

--- a/onnxruntime/core/providers/cuda/nn/rms_norm.cc
+++ b/onnxruntime/core/providers/cuda/nn/rms_norm.cc
@@ -77,9 +77,17 @@ Status RMSNorm<T, U, V>::ComputeInternal(OpKernelContext* ctx) const {
     return Status::OK();
   }
 
+  // Validate that norm_size won't cause integer overflow in host-side arithmetic.
+  // HostApplyLayerNorm computes: (n2 + 4 * warp_size - 1) where warp_size is typically 32.
+  // Maximum safe value: INT_MAX - (4 * max_warp_size) to prevent overflow.
+  // Using 256 as a conservative upper bound for 4 * warp_size.
+  constexpr int MAX_WARP_FACTOR = 256;
+  const int MAX_NORM_SIZE = std::numeric_limits<int>::max() - MAX_WARP_FACTOR;
+  
   ORT_RETURN_IF(params.num_rows > 0 &&
-                    params.norm_size > std::numeric_limits<int>::max() / params.num_rows,
-                "RMSNormalization input is too large for CUDA kernel indexing: num_rows * norm_size exceeds INT_MAX");
+                    (params.norm_size > MAX_NORM_SIZE ||
+                     params.norm_size > std::numeric_limits<int>::max() / params.num_rows),
+                "RMSNormalization input is too large for CUDA kernel indexing: norm_size exceeds safe limits or num_rows * norm_size exceeds INT_MAX");
 
   // For RMSNorm, we don't need mean and inv_var data, so we can pass nullptr.
   CudaU* mean_data = nullptr;


### PR DESCRIPTION
This pull request adds input validation checks to prevent integer overflow issues during CUDA kernel indexing in the LayerNorm and RMSNorm CUDA operators. The main goal is to ensure that the product of `num_rows` and `norm_size` does not exceed `INT_MAX`, which could lead to incorrect behavior or crashes.

Input validation for CUDA kernel indexing:

* Added a check in `LayerNorm::ComputeInternal` (in `layer_norm.cc`) to return an error if `num_rows * norm_size` exceeds `INT_MAX`, preventing integer overflow during CUDA kernel indexing.
* Added a similar check in `RMSNorm::ComputeInternal` (in `rms_norm.cc`) to ensure the input size does not exceed CUDA kernel indexing limits.

Code maintenance:

* Included the `<limits>` header in both `layer_norm.cc` and `rms_norm.cc` to support the new input validation logic. [[1]](diffhunk://#diff-ebda3d3b7054f5d14c679ebe8e6520a2c84a5a558d8fdcc0798c08e7032345feR9) [[2]](diffhunk://#diff-adebea99f15800767eb7b84d40be4873e81ca4df99ffe9dc7f849eabe0a3c563R9)