### PR TITLE
ci: pin cpplint reviewdog action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -110,7 +110,7 @@ jobs:
             --cmake_extra_defines CMAKE_EXPORT_COMPILE_COMMANDS=ON
       - name: Generate ONNX protobuf files
         run: cmake --build build/Debug --config Debug --target onnx_proto
-      - uses: reviewdog/action-cpplint@master
+      - uses: reviewdog/action-cpplint@8d74e96ce85957959865cd9d7e5d63bdbf2d37f4
         continue-on-error: true
         with:
           github_token: ${{ secrets.github_token }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -110,7 +110,7 @@ jobs:
             --cmake_extra_defines CMAKE_EXPORT_COMPILE_COMMANDS=ON
       - name: Generate ONNX protobuf files
         run: cmake --build build/Debug --config Debug --target onnx_proto
-      - uses: reviewdog/action-cpplint@8d74e96ce85957959865cd9d7e5d63bdbf2d37f4
+      - uses: reviewdog/action-cpplint@9552c62f4bd516c1e3a6f84eae56bd864cc304c6 # v1.11.0
         continue-on-error: true
         with:
           github_token: ${{ secrets.github_token }}


### PR DESCRIPTION
## Summary
- Pin `reviewdog/action-cpplint` to a full commit SHA instead of the mutable `master` branch.
- Keep the existing lint-cpp step configuration unchanged.

Fixes #29710

## Test Plan
- `python` check that `reviewdog/action-cpplint@master` is removed and the action is pinned to a 40-character SHA
- `python` YAML parse check that the cpplint step and `github_token` configuration are unchanged apart from the action ref
- `git diff --check`
- diff secret/conflict scan (`github_token` line is unchanged and expected)