### PR TITLE
docs: add custom web build guidance

### DIFF
--- a/docs/build/custom.md
+++ b/docs/build/custom.md
@@ -161,7 +161,21 @@ In this section, `ops.config` is a [configuration file](../reference/operators/r
 
 ### Web
 
-_[This section is coming soon]_
+Custom ONNX Runtime Web builds use the same reduced-operator configuration file described in
+[Reduce operator kernels](#reduce-operator-kernels). Pass that file with `--include_ops_by_config`
+when building the WebAssembly artifacts, then build the `onnxruntime-web` NPM package from those
+artifacts as described in [Build for web](web.md).
+
+For example:
+
+```bash
+./build.sh --build_wasm --config Release --skip_tests \
+  --include_ops_by_config /path/to/ops.config
+```
+
+Add the WebAssembly feature flags required by your target, such as `--enable_wasm_simd`,
+`--enable_wasm_threads`, `--use_jsep`, or `--use_webnn`, using the guidance in
+[Build ONNX Runtime Webassembly artifacts](web.md#build-onnx-runtime-webassembly-artifacts).
 
 ### iOS
 

--- a/docs/build/inferencing.md
+++ b/docs/build/inferencing.md
@@ -186,7 +186,7 @@ To initiate build, run the below command
 |-----------|:------------:|:------------:|:------------:|:------------:|:-------:|:-------:| :------:|:-----:|
 |Windows    | YES          | YES          |  YES         | YES          | NO      | NO      | NO      | NO    |
 |Linux      | YES          | YES          |  YES         | YES          | YES     | YES     | NO      | YES   |
-|macOS      | NO           | YES          |  NO          | NO           | NO      | NO      | NO      | NO    |
+|macOS      | NO           | YES          |  NO          | YES          | NO      | NO      | NO      | NO    |
 |Android      | NO           | NO          |  YES          | YES           | NO      | NO      | NO     | NO    |
 |iOS      | NO           | NO          |  NO          | YES           | NO      | NO      |  NO     | NO    |
 |AIX        | NO           | NO          |  NO          | NO           | NO      | NO      |  YES     | NO    |


### PR DESCRIPTION
## Summary
- Replace the placeholder Web section in the custom build page with reduced-operator WebAssembly guidance.
- Link the custom Web build flow to the existing Build for web page and relevant WebAssembly feature flags.
- Mark macOS ARM64 as supported in the build architecture table, matching the macOS cross-compilation guidance on the same page.

Fixes #18961

## Test Plan
- `python` focused check for the custom Web guidance, command block, macOS ARM64 row, and target web page heading
- `git diff --check`
- diff secret/conflict scan