### PR TITLE
[DML EP] Fix wide string handling in OpKernelInfoWrapper::GetWideName

### DIFF
--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/MLOperatorAuthorImpl.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/MLOperatorAuthorImpl.cpp
@@ -1360,7 +1360,10 @@ namespace Windows::AI::MachineLearning::Adapter
         {
             // The return value is only > 0 if ALL characters copied successfully.
             // Write null terminator at the end of copied chars, which may not be at the end of the buffer.
-            outputName[charsCopiedIfSucceeded] = L'\0';
+            // MultiByteToWideChar does not append a null terminator when the source length is given
+            // explicitly, so the converted chars may exactly fill the buffer. Clamp the index to leave
+            // room for the null terminator, truncating the last char in that case.
+            outputName[std::min<uint32_t>(charsCopiedIfSucceeded, bufferSizeInChars - 1)] = L'\0';
             return S_OK;
         }
 


### PR DESCRIPTION


### Description

`GetWideName` passes the source length explicitly to `MultiByteToWideChar`, so the API never appends a null terminator. When the converted node name needs exactly as many code units as the caller's buffer holds, the call succeeds, returns `bufferSizeInChars`, and does not set `ERROR_INSUFFICIENT_BUFFER`, so writing the terminator at `outputName[charsCopiedIfSucceeded]` lands one wchar_t past the end of the buffer.

### Motivation and Context

Clamp the index so the terminator stays in bounds, truncating the last converted char in that case. Truncation is already part of the contract: both in-tree callers in DmlOperator.cpp use a fixed wchar_t[512] and note  "might truncate name", and the ERROR_INSUFFICIENT_BUFFER branch below  already writes to bufferSizeInChars - 1. The sibling GetUtf8Name reserves room the same way via bufferSizeInBytes - 1.


