### PR TITLE
docs: clarify extended graph optimization targets

### DIFF
--- a/docs/performance/model-optimizations/graph-optimizations.md
+++ b/docs/performance/model-optimizations/graph-optimizations.md
@@ -56,7 +56,13 @@ These are semantics-preserving graph rewrites which remove redundant nodes and r
 
 ### Extended Graph Optimizations
 
-These optimizations include complex node fusions. They are run after graph partitioning and are only applied to the nodes assigned to the CPU or CUDA or ROCm execution provider. Available extended graph optimizations are as follows:
+These optimizations include complex node fusions. They are run after graph partitioning and are only applied
+to the nodes assigned to the CPU or CUDA or ROCm execution provider. Because extended optimizations run after
+graph partitioning, their results depend on the execution providers selected for the session. If you serialize
+an optimized model in offline mode with extended optimizations enabled, generate that model with the same
+execution providers and target hardware used for inference.
+
+Available extended graph optimizations are as follows:
 
 | Optimization                    | Execution Provider | Comment                                                                     |
 |---------------------------------|--------------------|-----------------------------------------------------------------------------|


### PR DESCRIPTION
## Summary
- Clarify that extended graph optimizations run after graph partitioning.
- Note that offline optimized models created with extended optimizations should use the same execution providers and target hardware as inference.

Fixes #15529

## Test Plan
- `python` focused check for the new extended-optimization hardware/EP note
- `git diff --check`
- diff secret/conflict scan