### PR TITLE
Improve MLAS NCHWc conv thread utilization via cost-weighted work par…

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
+++ b/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
@@ -509,6 +509,15 @@ static const char* const kOrtSessionOptionsMlasDisableKleidiAi = "mlas.disable_k
 // This option exists for perf experimentation; the default may be retuned in future ORT releases.
 static const char* const kOrtSessionOptionsMlasKleidiAiConvIgemmMaxWork = "mlas.kleidiai.conv_igemm_max_work";
 
+// Power-user tuning option for the MLAS NCHWc pointwise (1x1) convolution algorithm.
+// Controls the maximum number of input channels accumulated per kernel invocation before
+// intermediate results are flushed to the output tensor. Values are rounded up to a multiple
+// of the NCHWc block size. Larger values reduce output read/write round trips for deep-input
+// convolutions at the cost of a larger cache working set.
+// "0" or unset uses the MLAS default (128).
+// This option exists for perf experimentation; the default may be retuned in future releases.
+static const char* const kOrtSessionOptionsMlasNchwcConvMaxInputChannelBatch = "mlas.nchwc_conv_max_input_channel_batch";
+
 // When converting DQ + MatMul -> MatMulNBits, the accuracy level of the MatMulNBits is controlled by this option.
 // Refer to MatMulNBits op schema for more details.
 // If not provided, default is 4.

--- a/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
+++ b/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
@@ -516,7 +516,7 @@ static const char* const kOrtSessionOptionsMlasKleidiAiConvIgemmMaxWork = "mlas.
 // convolutions at the cost of a larger cache working set.
 // "0" or unset uses the MLAS default (128).
 // This option exists for perf experimentation; the default may be retuned in future releases.
-static const char* const kOrtSessionOptionsMlasNchwcConvMaxInputChannelBatch = "mlas.nchwc_conv_max_input_channel_batch";
+static const char* const kOrtSessionOptionsMlasNchwcPointwiseConvMaxInputChannelBatch = "mlas.nchwc_pointwise_conv_max_input_channel_batch";
 
 // When converting DQ + MatMul -> MatMulNBits, the accuracy level of the MatMulNBits is controlled by this option.
 // Refer to MatMulNBits op schema for more details.

--- a/onnxruntime/core/mlas/inc/mlas.h
+++ b/onnxruntime/core/mlas/inc/mlas.h
@@ -208,7 +208,7 @@ MlasActivation(
 struct MLAS_BACKEND_KERNEL_SELECTOR_CONFIG {
     bool use_kleidiai = true; /**< Flag to use KleidiAI backend kernels if available */
     size_t kleidiai_conv_igemm_max_work = 0; /**< Optional SME IGEMM route threshold override; 0 uses default */
-    size_t nchwc_conv_max_input_channel_batch = 0; /**< Optional NCHWc pointwise conv input channel batch override; 0 uses default (128) */
+    size_t nchwc_pointwise_conv_max_input_channel_batch = 0; /**< Optional NCHWc pointwise conv input channel batch override; 0 uses default (128) */
 };
 
 //

--- a/onnxruntime/core/mlas/inc/mlas.h
+++ b/onnxruntime/core/mlas/inc/mlas.h
@@ -208,6 +208,7 @@ MlasActivation(
 struct MLAS_BACKEND_KERNEL_SELECTOR_CONFIG {
     bool use_kleidiai = true; /**< Flag to use KleidiAI backend kernels if available */
     size_t kleidiai_conv_igemm_max_work = 0; /**< Optional SME IGEMM route threshold override; 0 uses default */
+    size_t nchwc_conv_max_input_channel_batch = 0; /**< Optional NCHWc pointwise conv input channel batch override; 0 uses default (128) */
 };
 
 //

--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -1947,6 +1947,70 @@ MlasPartitionWork(
 }
 
 //
+// Map a cost boundary to a work item index for the NCHWc grouped convolution
+// algorithms.
+//
+// Work items are output rows of a filter set, indexed row-fastest as
+// ((BatchGroup * FilterSetCount) + FilterSet) * OutputHeight + Row. Cost is
+// measured in block-rows: one NCHWc output block of one output row. Items in a
+// full filter set cost FilterSetSize block-rows; items in the ragged last set
+// cost LastSetFilterCount. Returns the index of the first work item whose
+// starting cumulative cost is greater than or equal to Cost, so partitioning a
+// cost interval and converting both endpoints yields work ranges that tile
+// [0, TotalWork) with no gap and no overlap.
+//
+// Worked example, OutputChannels = 96 with BlockSize = 16 and FilterSetSize = 4:
+// TotalBlockedFilters = 96 / 16 = 6 blocked filters, so FilterSetCount = 2 and
+// LastSetFilterCount = 6 - 1 * 4 = 2. Per (batch, group) segment the two sets
+// cost 4 * OutputHeight and 2 * OutputHeight block-rows respectively — the
+// imbalance a uniform split by item index would ignore, since both sets contain
+// OutputHeight items while the first does twice the work.
+//
+
+inline
+size_t
+MlasNchwcCostToWorkIndex(
+    size_t Cost,
+    size_t OutputHeight,
+    size_t FilterSetCount,
+    size_t FilterSetSize,
+    size_t TotalBlockedFilters,
+    size_t LastSetFilterCount
+    )
+{
+    const size_t CostPerBatchGroup = TotalBlockedFilters * OutputHeight;
+
+    size_t BatchGroup = Cost / CostPerBatchGroup;
+    const size_t Remainder = Cost - BatchGroup * CostPerBatchGroup;
+
+    const size_t FullSetCost = FilterSetSize * OutputHeight;
+
+    size_t Set = Remainder / FullSetCost;
+    size_t SetFilterCount = FilterSetSize;
+
+    if (Set >= FilterSetCount - 1) {
+        Set = FilterSetCount - 1;
+        SetFilterCount = LastSetFilterCount;
+    }
+
+    const size_t SetRemainder = Remainder - Set * FullSetCost;
+
+    size_t Row = (SetRemainder + SetFilterCount - 1) / SetFilterCount;
+
+    if (Row >= OutputHeight) {
+
+        Row = 0;
+
+        if (++Set == FilterSetCount) {
+            Set = 0;
+            BatchGroup += 1;
+        }
+    }
+
+    return (BatchGroup * FilterSetCount + Set) * OutputHeight + Row;
+}
+
+//
 // Define the minimum floating point value (and its bit value equivalent) that
 // has no fractional bits. This number can be used for fast rounding of floating
 // point numbers to integers.

--- a/onnxruntime/core/mlas/lib/snchwc.cpp
+++ b/onnxruntime/core/mlas/lib/snchwc.cpp
@@ -551,14 +551,8 @@ struct MLAS_NCHWC_GROUPED_CONV_ALGORITHM : MLAS_NCHWC_CONV_ALGORITHM
         FilterCount = std::min(FilterSetSize, (OutputChannels / BlockSize) - FilterSet * FilterSetSize);
     }
 
-    void PrepareWork(ptrdiff_t Index)
+    void SeekToWork(size_t WorkIndex)
     {
-        const size_t TotalWork = BatchCount * GroupCount * FilterSetCount * OutputHeight;
-
-        size_t WorkIndex;
-
-        MlasPartitionWork(Index, WorkBlock->tids, TotalWork, &WorkIndex, &WorkRemaining);
-
         //
         // Extract the current batch, group, filter cluster, and output line
         // from the starting work index.
@@ -595,6 +589,17 @@ struct MLAS_NCHWC_GROUPED_CONV_ALGORITHM : MLAS_NCHWC_CONV_ALGORITHM
         //
 
         ComputeFilterCount();
+    }
+
+    void PrepareWork(ptrdiff_t Index)
+    {
+        const size_t TotalWork = BatchCount * GroupCount * FilterSetCount * OutputHeight;
+
+        size_t WorkIndex;
+
+        MlasPartitionWork(Index, WorkBlock->tids, TotalWork, &WorkIndex, &WorkRemaining);
+
+        SeekToWork(WorkIndex);
     }
 
     void CompleteWork(size_t WorkThisIteration)
@@ -645,6 +650,78 @@ struct MLAS_NCHWC_GROUPED_CONV_ALGORITHM : MLAS_NCHWC_CONV_ALGORITHM
             ph = 0;
         }
     }
+
+    //
+    // Map a cost boundary (measured in block-rows: one NCHWc output block of one
+    // output row) to the index of the first work item whose starting cumulative
+    // cost is greater than or equal to that boundary. Within each (batch, group)
+    // segment, filter sets 0..FilterSetCount-2 cost FilterSetSize block-rows per
+    // output row and the last set costs LastSetFilterCount block-rows per row.
+    //
+
+    size_t CostToWorkIndex(size_t Cost, size_t TotalBlockedFilters, size_t LastSetFilterCount) const
+    {
+        const size_t CostPerBatchGroup = TotalBlockedFilters * OutputHeight;
+
+        size_t BatchGroup = Cost / CostPerBatchGroup;
+        const size_t Remainder = Cost - BatchGroup * CostPerBatchGroup;
+
+        const size_t FullSetCost = FilterSetSize * OutputHeight;
+
+        size_t Set = Remainder / FullSetCost;
+        size_t SetFilterCount = FilterSetSize;
+
+        if (Set >= FilterSetCount - 1) {
+            Set = FilterSetCount - 1;
+            SetFilterCount = LastSetFilterCount;
+        }
+
+        const size_t SetRemainder = Remainder - Set * FullSetCost;
+
+        size_t Row = (SetRemainder + SetFilterCount - 1) / SetFilterCount;
+
+        if (Row >= OutputHeight) {
+
+            Row = 0;
+
+            if (++Set == FilterSetCount) {
+                Set = 0;
+                BatchGroup += 1;
+            }
+        }
+
+        return (BatchGroup * FilterSetCount + Set) * OutputHeight + Row;
+    }
+
+    //
+    // Partition proportionally to FLOP cost rather than uniformly by work item.
+    // Work items belonging to a ragged last filter set (FilterCount less than
+    // FilterSetSize) cost proportionally less than items of full sets, so a
+    // uniform index split leaves threads with unequal amounts of compute.
+    //
+
+    void PrepareWorkWeighted(ptrdiff_t Index)
+    {
+        const size_t TotalBlockedFilters = OutputChannels / BlockSize;
+        const size_t LastSetFilterCount =
+            TotalBlockedFilters - (FilterSetCount - 1) * FilterSetSize;
+
+        const size_t TotalCost = BatchCount * GroupCount * TotalBlockedFilters * OutputHeight;
+
+        size_t CostStart;
+        size_t CostCount;
+
+        MlasPartitionWork(Index, WorkBlock->tids, TotalCost, &CostStart, &CostCount);
+
+        const size_t WorkIndexBegin =
+            CostToWorkIndex(CostStart, TotalBlockedFilters, LastSetFilterCount);
+        const size_t WorkIndexEnd =
+            CostToWorkIndex(CostStart + CostCount, TotalBlockedFilters, LastSetFilterCount);
+
+        WorkRemaining = WorkIndexEnd - WorkIndexBegin;
+
+        SeekToWork(WorkIndexBegin);
+    }
 };
 
 constexpr size_t MLAS_NCHWC_GROUPED_CONV_ALGORITHM::FilterSetSize;
@@ -667,7 +744,7 @@ struct MLAS_NCHWC_CONV_NCHWC_ALGORITHM : MLAS_NCHWC_GROUPED_CONV_ALGORITHM
         // Setup the convolution state based on the thread index.
         //
 
-        PrepareWork(Index);
+        PrepareWorkWeighted(Index);
 
         //
         // Loop until all of the work has been completed.
@@ -903,7 +980,7 @@ struct MLAS_NCHWC_CONV_POINTWISE_ALGORITHM : MLAS_NCHWC_GROUPED_CONV_ALGORITHM
         // Setup the convolution state based on the thread index.
         //
 
-        PrepareWork(Index);
+        PrepareWorkWeighted(Index);
 
         //
         // Loop until all of the work has been completed.
@@ -913,6 +990,25 @@ struct MLAS_NCHWC_CONV_POINTWISE_ALGORITHM : MLAS_NCHWC_GROUPED_CONV_ALGORITHM
         const size_t InputStrideBytes = BlockSize * InputSize * sizeof(float);
         const size_t FilterStrideBytes = BlockSize * InputChannels * sizeof(float);
         const size_t OutputStrideBytes = BlockSize * OutputSize * sizeof(float);
+
+        //
+        // Determine the maximum number of input channels to accumulate per kernel
+        // invocation. Shrinking the batch size causes a slowdown from additional
+        // flushing of intermediate results to the output tensor. Extending the
+        // batch size causes a slowdown from processor cache thrashing. The default
+        // may be overridden via session configuration for tuning; the value is
+        // rounded up to a multiple of the block size expected by the kernel.
+        //
+
+        size_t MaximumInputChannelBatch = 128;
+
+        if (WorkBlock->BackendKernelSelectorConfig != nullptr &&
+            WorkBlock->BackendKernelSelectorConfig->nchwc_conv_max_input_channel_batch != 0) {
+            const size_t RequestedBatch =
+                WorkBlock->BackendKernelSelectorConfig->nchwc_conv_max_input_channel_batch;
+            MaximumInputChannelBatch =
+                ((RequestedBatch + BlockSize - 1) / BlockSize) * BlockSize;
+        }
 
 #if defined(MLAS_TARGET_AMD64) || defined(MLAS_TARGET_LARCH64) || (defined(MLAS_TARGET_ARM64) && defined(MLAS_USE_ARM_NEON_NCHWC)) || (defined(MLAS_TARGET_RISCV64) && defined(MLAS_USE_RVV))
         MLAS_CONV_POINTWISE_FLOAT_KERNEL* Kernel = GetMlasPlatform().ConvPointwiseFloatKernel;
@@ -953,10 +1049,6 @@ struct MLAS_NCHWC_CONV_POINTWISE_ALGORITHM : MLAS_NCHWC_GROUPED_CONV_ALGORITHM
             //
             // Apply the convolution kernel to batches of the input tensor.
             //
-            // Shrinking the batch size causes a slowdown from additional
-            // flushing of intermediate results to the output tensor. Extending
-            // the batch sizes causes a slowdown from processor cache thrashing.
-            //
 
             const float* input = Input + BlockSize * (ph * StrideHeight * InputWidth);
             const float* filter = Filter;
@@ -964,8 +1056,6 @@ struct MLAS_NCHWC_CONV_POINTWISE_ALGORITHM : MLAS_NCHWC_GROUPED_CONV_ALGORITHM
 
             size_t InputChannelBatch = 0;
             for (size_t ic = 0; ic < InputChannels; ) {
-
-                constexpr size_t MaximumInputChannelBatch = 128;
 
                 InputChannelBatch = std::min(InputChannels - ic, MaximumInputChannelBatch);
 

--- a/onnxruntime/core/mlas/lib/snchwc.cpp
+++ b/onnxruntime/core/mlas/lib/snchwc.cpp
@@ -654,45 +654,15 @@ struct MLAS_NCHWC_GROUPED_CONV_ALGORITHM : MLAS_NCHWC_CONV_ALGORITHM
     }
 
     //
-    // Map a cost boundary (measured in block-rows: one NCHWc output block of one
-    // output row) to the index of the first work item whose starting cumulative
-    // cost is greater than or equal to that boundary. Within each (batch, group)
-    // segment, filter sets 0..FilterSetCount-2 cost FilterSetSize block-rows per
-    // output row and the last set costs LastSetFilterCount block-rows per row.
+    // Map a cost boundary to a work item index. See MlasNchwcCostToWorkIndex in
+    // mlasi.h, which holds the mapping and its worked example; it lives there so
+    // the partitioning math can be unit tested independently of a convolution.
     //
 
     size_t CostToWorkIndex(size_t Cost, size_t TotalBlockedFilters, size_t LastSetFilterCount) const
     {
-        const size_t CostPerBatchGroup = TotalBlockedFilters * OutputHeight;
-
-        size_t BatchGroup = Cost / CostPerBatchGroup;
-        const size_t Remainder = Cost - BatchGroup * CostPerBatchGroup;
-
-        const size_t FullSetCost = FilterSetSize * OutputHeight;
-
-        size_t Set = Remainder / FullSetCost;
-        size_t SetFilterCount = FilterSetSize;
-
-        if (Set >= FilterSetCount - 1) {
-            Set = FilterSetCount - 1;
-            SetFilterCount = LastSetFilterCount;
-        }
-
-        const size_t SetRemainder = Remainder - Set * FullSetCost;
-
-        size_t Row = (SetRemainder + SetFilterCount - 1) / SetFilterCount;
-
-        if (Row >= OutputHeight) {
-
-            Row = 0;
-
-            if (++Set == FilterSetCount) {
-                Set = 0;
-                BatchGroup += 1;
-            }
-        }
-
-        return (BatchGroup * FilterSetCount + Set) * OutputHeight + Row;
+        return MlasNchwcCostToWorkIndex(Cost, OutputHeight, FilterSetCount, FilterSetSize,
+                                        TotalBlockedFilters, LastSetFilterCount);
     }
 
     //
@@ -722,7 +692,16 @@ struct MLAS_NCHWC_GROUPED_CONV_ALGORITHM : MLAS_NCHWC_CONV_ALGORITHM
 
         WorkRemaining = WorkIndexEnd - WorkIndexBegin;
 
-        SeekToWork(WorkIndexBegin);
+        //
+        // Skip the seek when this thread received no work. TotalCost below tids
+        // leaves surplus threads with an empty cost interval starting at
+        // TotalCost, which maps to WorkIndexBegin == TotalWork; seeking there
+        // would advance the buffer pointers past the end of their tensors.
+        //
+
+        if (WorkRemaining > 0) {
+            SeekToWork(WorkIndexBegin);
+        }
     }
 };
 
@@ -1005,9 +984,9 @@ struct MLAS_NCHWC_CONV_POINTWISE_ALGORITHM : MLAS_NCHWC_GROUPED_CONV_ALGORITHM
         size_t MaximumInputChannelBatch = 128;
 
         if (WorkBlock->BackendKernelSelectorConfig != nullptr &&
-            WorkBlock->BackendKernelSelectorConfig->nchwc_conv_max_input_channel_batch != 0) {
+            WorkBlock->BackendKernelSelectorConfig->nchwc_pointwise_conv_max_input_channel_batch != 0) {
             const size_t RequestedBatch =
-                WorkBlock->BackendKernelSelectorConfig->nchwc_conv_max_input_channel_batch;
+                WorkBlock->BackendKernelSelectorConfig->nchwc_pointwise_conv_max_input_channel_batch;
             MaximumInputChannelBatch =
                 ((RequestedBatch + BlockSize - 1) / BlockSize) * BlockSize;
         }

--- a/onnxruntime/core/mlas/lib/snchwc.cpp
+++ b/onnxruntime/core/mlas/lib/snchwc.cpp
@@ -599,7 +599,9 @@ struct MLAS_NCHWC_GROUPED_CONV_ALGORITHM : MLAS_NCHWC_CONV_ALGORITHM
 
         MlasPartitionWork(Index, WorkBlock->tids, TotalWork, &WorkIndex, &WorkRemaining);
 
-        SeekToWork(WorkIndex);
+        if (WorkRemaining > 0) {
+            SeekToWork(WorkIndex);
+        }
     }
 
     void CompleteWork(size_t WorkThisIteration)

--- a/onnxruntime/core/mlas/lib/x86_64/SconvKernelAvx512F.S
+++ b/onnxruntime/core/mlas/lib/x86_64/SconvKernelAvx512F.S
@@ -470,15 +470,15 @@ MlasConvPostProcessFloatAvx512FFilter\FilterCount\()Output\OutputCount\():
         EmitIfCount2GE \FilterCount\(), 3, \OutputCount\(), 1, "vmaxps zmm2,zmm24,zmm2"
         EmitIfCount2GE \FilterCount\(), 3, \OutputCount\(), 2, "vmaxps zmm6,zmm24,zmm6"
         EmitIfCount2GE \FilterCount\(), 3, \OutputCount\(), 3, "vmaxps zmm10,zmm24,zmm10"
-        EmitIfCount2GE \FilterCount\(), 2, \OutputCount\(), 4, "vmaxps zmm14,zmm24,zmm14"
-        EmitIfCount2GE \FilterCount\(), 2, \OutputCount\(), 5, "vmaxps zmm18,zmm24,zmm18"
-        EmitIfCount2GE \FilterCount\(), 2, \OutputCount\(), 6, "vmaxps zmm22,zmm24,zmm22"
+        EmitIfCount2GE \FilterCount\(), 3, \OutputCount\(), 4, "vmaxps zmm14,zmm24,zmm14"
+        EmitIfCount2GE \FilterCount\(), 3, \OutputCount\(), 5, "vmaxps zmm18,zmm24,zmm18"
+        EmitIfCount2GE \FilterCount\(), 3, \OutputCount\(), 6, "vmaxps zmm22,zmm24,zmm22"
         EmitIfCount2GE \FilterCount\(), 4, \OutputCount\(), 1, "vmaxps zmm3,zmm24,zmm3"
         EmitIfCount2GE \FilterCount\(), 4, \OutputCount\(), 2, "vmaxps zmm7,zmm24,zmm7"
         EmitIfCount2GE \FilterCount\(), 4, \OutputCount\(), 3, "vmaxps zmm11,zmm24,zmm11"
-        EmitIfCount2GE \FilterCount\(), 2, \OutputCount\(), 4, "vmaxps zmm15,zmm24,zmm15"
-        EmitIfCount2GE \FilterCount\(), 2, \OutputCount\(), 5, "vmaxps zmm19,zmm24,zmm19"
-        EmitIfCount2GE \FilterCount\(), 2, \OutputCount\(), 6, "vmaxps zmm23,zmm24,zmm23"
+        EmitIfCount2GE \FilterCount\(), 4, \OutputCount\(), 4, "vmaxps zmm15,zmm24,zmm15"
+        EmitIfCount2GE \FilterCount\(), 4, \OutputCount\(), 5, "vmaxps zmm19,zmm24,zmm19"
+        EmitIfCount2GE \FilterCount\(), 4, \OutputCount\(), 6, "vmaxps zmm23,zmm24,zmm23"
 
 .LPostProcessBlock.\FilterCount\().\OutputCount\().SkipReluActivation:
 

--- a/onnxruntime/core/providers/cpu/mlas_backend_kernel_selector_config_utils.h
+++ b/onnxruntime/core/providers/cpu/mlas_backend_kernel_selector_config_utils.h
@@ -26,6 +26,14 @@ inline void SetupMlasBackendKernelSelectorFromConfigOptions(MLAS_BACKEND_KERNEL_
                 "Invalid value for ", kOrtSessionOptionsMlasKleidiAiConvIgemmMaxWork,
                 ": ", *conv_igemm_max_work, ". Expected a non-negative integer.");
   }
+
+  if (auto nchwc_conv_max_input_channel_batch =
+          config_options.GetConfigEntry(kOrtSessionOptionsMlasNchwcConvMaxInputChannelBatch)) {
+    ORT_ENFORCE(TryParseStringWithClassicLocale<size_t>(*nchwc_conv_max_input_channel_batch,
+                                                        config.nchwc_conv_max_input_channel_batch),
+                "Invalid value for ", kOrtSessionOptionsMlasNchwcConvMaxInputChannelBatch,
+                ": ", *nchwc_conv_max_input_channel_batch, ". Expected a non-negative integer.");
+  }
 }
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/cpu/mlas_backend_kernel_selector_config_utils.h
+++ b/onnxruntime/core/providers/cpu/mlas_backend_kernel_selector_config_utils.h
@@ -27,12 +27,12 @@ inline void SetupMlasBackendKernelSelectorFromConfigOptions(MLAS_BACKEND_KERNEL_
                 ": ", *conv_igemm_max_work, ". Expected a non-negative integer.");
   }
 
-  if (auto nchwc_conv_max_input_channel_batch =
-          config_options.GetConfigEntry(kOrtSessionOptionsMlasNchwcConvMaxInputChannelBatch)) {
-    ORT_ENFORCE(TryParseStringWithClassicLocale<size_t>(*nchwc_conv_max_input_channel_batch,
-                                                        config.nchwc_conv_max_input_channel_batch),
-                "Invalid value for ", kOrtSessionOptionsMlasNchwcConvMaxInputChannelBatch,
-                ": ", *nchwc_conv_max_input_channel_batch, ". Expected a non-negative integer.");
+  if (auto nchwc_pointwise_conv_max_input_channel_batch =
+          config_options.GetConfigEntry(kOrtSessionOptionsMlasNchwcPointwiseConvMaxInputChannelBatch)) {
+    ORT_ENFORCE(TryParseStringWithClassicLocale<size_t>(*nchwc_pointwise_conv_max_input_channel_batch,
+                                                        config.nchwc_pointwise_conv_max_input_channel_batch),
+                "Invalid value for ", kOrtSessionOptionsMlasNchwcPointwiseConvMaxInputChannelBatch,
+                ": ", *nchwc_pointwise_conv_max_input_channel_batch, ". Expected a non-negative integer.");
   }
 }
 

--- a/onnxruntime/test/mlas/unittest/test_snchwc_partition.cpp
+++ b/onnxruntime/test/mlas/unittest/test_snchwc_partition.cpp
@@ -1,0 +1,295 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+/*++
+
+Module Name:
+
+    test_snchwc_partition.cpp
+
+Abstract:
+
+    Tests the cost-to-work-index mapping used by the NCHWc grouped convolution
+    algorithms to partition work proportionally to FLOP cost.
+
+    The mapping is exercised directly rather than through a convolution so that
+    the two properties the partitioning depends on -- exact tiling of the work
+    space, and balanced cost per thread -- can be asserted across shapes that
+    would be expensive to convolve.
+
+--*/
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <vector>
+
+#include "core/mlas/lib/mlasi.h"
+
+namespace {
+
+//
+// Mirrors the derived quantities computed by MLAS_NCHWC_GROUPED_CONV_ALGORITHM
+// and PrepareWorkWeighted for a given convolution shape.
+//
+
+struct PartitionShape {
+  size_t BlockSize;
+  size_t FilterSetSize;
+  size_t OutputChannels;
+  size_t OutputHeight;
+  size_t BatchGroupCount;  // BatchCount * GroupCount
+
+  size_t TotalBlockedFilters() const { return OutputChannels / BlockSize; }
+
+  size_t FilterSetCount() const {
+    return (OutputChannels + (BlockSize * FilterSetSize) - 1) / (BlockSize * FilterSetSize);
+  }
+
+  size_t LastSetFilterCount() const {
+    return TotalBlockedFilters() - (FilterSetCount() - 1) * FilterSetSize;
+  }
+
+  size_t TotalCost() const { return BatchGroupCount * TotalBlockedFilters() * OutputHeight; }
+
+  size_t TotalWork() const { return BatchGroupCount * FilterSetCount() * OutputHeight; }
+
+  size_t CostToWorkIndex(size_t Cost) const {
+    return MlasNchwcCostToWorkIndex(Cost, OutputHeight, FilterSetCount(), FilterSetSize,
+                                    TotalBlockedFilters(), LastSetFilterCount());
+  }
+
+  //
+  // Cost of a single work item: items of the ragged last filter set of each
+  // (batch, group) segment cost less than items of full sets.
+  //
+
+  size_t WorkItemCost(size_t WorkIndex) const {
+    const size_t Set = (WorkIndex / OutputHeight) % FilterSetCount();
+    return (Set + 1 == FilterSetCount()) ? LastSetFilterCount() : FilterSetSize;
+  }
+
+  size_t RangeCost(size_t Begin, size_t End) const {
+    size_t Cost = 0;
+    for (size_t i = Begin; i < End; i++) {
+      Cost += WorkItemCost(i);
+    }
+    return Cost;
+  }
+
+  std::string Describe() const {
+    return "OutputChannels=" + std::to_string(OutputChannels) +
+           " OutputHeight=" + std::to_string(OutputHeight) +
+           " BatchGroupCount=" + std::to_string(BatchGroupCount) +
+           " FilterSetCount=" + std::to_string(FilterSetCount()) +
+           " LastSetFilterCount=" + std::to_string(LastSetFilterCount());
+  }
+};
+
+//
+// The shape grid. Output channel counts are chosen to cover every ragged tail
+// the mapping has to handle: 16 and 32 are shorter than one filter set, 64 and
+// 256 divide evenly, and 48/96/144/208 leave last sets of 3, 2, 1 and 1 blocks.
+//
+
+std::vector<PartitionShape> AllShapes() {
+  const size_t OutputChannelValues[] = {16, 32, 48, 64, 96, 144, 208, 256};
+  const size_t OutputHeightValues[] = {1, 2, 7, 13, 52};
+  const size_t BatchGroupValues[] = {1, 2, 8};
+
+  std::vector<PartitionShape> Shapes;
+
+  for (size_t OutputChannels : OutputChannelValues) {
+    for (size_t OutputHeight : OutputHeightValues) {
+      for (size_t BatchGroupCount : BatchGroupValues) {
+        Shapes.push_back(PartitionShape{16, 4, OutputChannels, OutputHeight, BatchGroupCount});
+      }
+    }
+  }
+
+  return Shapes;
+}
+
+const ptrdiff_t ThreadCounts[] = {1, 2, 3, 4, 5, 8, 16, 32};
+
+}  // namespace
+
+//
+// Partitioning a cost interval and converting both endpoints must produce work
+// ranges that exactly tile [0, TotalWork): no gap, no overlap, nothing dropped.
+// The convolution's correctness rests entirely on this property -- a gap would
+// silently leave output rows uncomputed.
+//
+
+TEST(SnchwcPartition, RangesTileWorkSpace) {
+  for (const PartitionShape& Shape : AllShapes()) {
+    for (ptrdiff_t tids : ThreadCounts) {
+      size_t Expected = 0;
+
+      for (ptrdiff_t Index = 0; Index < tids; Index++) {
+        size_t CostStart;
+        size_t CostCount;
+        MlasPartitionWork(Index, tids, Shape.TotalCost(), &CostStart, &CostCount);
+
+        const size_t Begin = Shape.CostToWorkIndex(CostStart);
+        const size_t End = Shape.CostToWorkIndex(CostStart + CostCount);
+
+        ASSERT_LE(Begin, End) << Shape.Describe() << " tids=" << tids << " Index=" << Index;
+        ASSERT_EQ(Begin, Expected) << "gap or overlap; " << Shape.Describe()
+                                   << " tids=" << tids << " Index=" << Index;
+        Expected = End;
+      }
+
+      ASSERT_EQ(Expected, Shape.TotalWork())
+          << "work space not fully covered; " << Shape.Describe() << " tids=" << tids;
+    }
+  }
+}
+
+//
+// The mapping must be monotone and bounded over the whole cost domain, which is
+// what lets the tiling above hold for any partition MlasPartitionWork produces.
+//
+
+TEST(SnchwcPartition, MonotoneAndBounded) {
+  for (const PartitionShape& Shape : AllShapes()) {
+    size_t Previous = 0;
+
+    for (size_t Cost = 0; Cost <= Shape.TotalCost(); Cost++) {
+      const size_t WorkIndex = Shape.CostToWorkIndex(Cost);
+
+      ASSERT_GE(WorkIndex, Previous) << "not monotone at Cost=" << Cost << "; " << Shape.Describe();
+      ASSERT_LE(WorkIndex, Shape.TotalWork())
+          << "out of bounds at Cost=" << Cost << "; " << Shape.Describe();
+
+      Previous = WorkIndex;
+    }
+
+    ASSERT_EQ(Shape.CostToWorkIndex(0), size_t{0}) << Shape.Describe();
+    ASSERT_EQ(Shape.CostToWorkIndex(Shape.TotalCost()), Shape.TotalWork()) << Shape.Describe();
+  }
+}
+
+//
+// The point of the weighted split: each thread's share of the actual work --
+// measured in block-rows, not work items -- must land near TotalCost/tids.
+// A uniform split by work index fails this whenever the last filter set is
+// ragged, which is the regression this guards.
+//
+
+TEST(SnchwcPartition, CostIsBalancedAcrossThreads) {
+  for (const PartitionShape& Shape : AllShapes()) {
+    for (ptrdiff_t tids : ThreadCounts) {
+      if (Shape.TotalCost() < static_cast<size_t>(tids)) {
+        continue;  // covered by EmptyPartitionsAreWellFormed
+      }
+
+      const size_t Ideal = Shape.TotalCost() / static_cast<size_t>(tids);
+
+      //
+      // A thread's range boundary can only fall on a work item, so its cost can
+      // deviate from ideal by at most the cost of one item at each end.
+      //
+
+      const size_t Tolerance = 2 * Shape.FilterSetSize;
+
+      for (ptrdiff_t Index = 0; Index < tids; Index++) {
+        size_t CostStart;
+        size_t CostCount;
+        MlasPartitionWork(Index, tids, Shape.TotalCost(), &CostStart, &CostCount);
+
+        const size_t Begin = Shape.CostToWorkIndex(CostStart);
+        const size_t End = Shape.CostToWorkIndex(CostStart + CostCount);
+        const size_t ActualCost = Shape.RangeCost(Begin, End);
+
+        const size_t Deviation = (ActualCost > Ideal) ? (ActualCost - Ideal) : (Ideal - ActualCost);
+
+        ASSERT_LE(Deviation, Tolerance)
+            << "thread " << Index << " of " << tids << " got " << ActualCost
+            << " block-rows, ideal " << Ideal << "; " << Shape.Describe();
+      }
+    }
+  }
+}
+
+//
+// When there is less cost than there are threads, the surplus threads receive an
+// empty interval starting at TotalCost. That must map to TotalWork so the caller
+// computes WorkRemaining == 0 and skips SeekToWork -- seeking to TotalWork would
+// advance the convolution buffer pointers past the end of their tensors.
+//
+
+TEST(SnchwcPartition, EmptyPartitionsAreWellFormed) {
+  for (const PartitionShape& Shape : AllShapes()) {
+    for (ptrdiff_t tids : ThreadCounts) {
+      if (Shape.TotalCost() >= static_cast<size_t>(tids)) {
+        continue;
+      }
+
+      bool SawEmpty = false;
+
+      for (ptrdiff_t Index = 0; Index < tids; Index++) {
+        size_t CostStart;
+        size_t CostCount;
+        MlasPartitionWork(Index, tids, Shape.TotalCost(), &CostStart, &CostCount);
+
+        const size_t Begin = Shape.CostToWorkIndex(CostStart);
+        const size_t End = Shape.CostToWorkIndex(CostStart + CostCount);
+
+        if (CostCount == 0) {
+          SawEmpty = true;
+          ASSERT_EQ(Begin, End) << "empty cost interval produced work; " << Shape.Describe()
+                                << " tids=" << tids << " Index=" << Index;
+          ASSERT_LE(Begin, Shape.TotalWork())
+              << "empty partition seeks out of bounds; " << Shape.Describe()
+              << " tids=" << tids << " Index=" << Index;
+        }
+      }
+
+      ASSERT_TRUE(SawEmpty) << "expected surplus threads; " << Shape.Describe()
+                            << " tids=" << tids;
+    }
+  }
+}
+
+//
+// The worked example from the mapping's documentation: 96 output channels give
+// 6 blocked filters, so two filter sets costing 4 and 2 block-rows per output
+// row. With 4 threads a uniform split by work index would hand two threads the
+// 4-block set and two the 2-block set -- a 2x imbalance -- while the weighted
+// split moves the boundary into the cheaper set to even the cost out.
+//
+
+TEST(SnchwcPartition, WorkedExampleFromDocumentation) {
+  const PartitionShape Shape{16, 4, 96, 52, 1};
+
+  ASSERT_EQ(Shape.TotalBlockedFilters(), size_t{6});
+  ASSERT_EQ(Shape.FilterSetCount(), size_t{2});
+  ASSERT_EQ(Shape.LastSetFilterCount(), size_t{2});
+  ASSERT_EQ(Shape.TotalCost(), size_t{6 * 52});
+  ASSERT_EQ(Shape.TotalWork(), size_t{2 * 52});
+
+  const ptrdiff_t tids = 4;
+  const size_t Ideal = Shape.TotalCost() / tids;  // 78 block-rows
+
+  size_t Worst = 0;
+
+  for (ptrdiff_t Index = 0; Index < tids; Index++) {
+    size_t CostStart;
+    size_t CostCount;
+    MlasPartitionWork(Index, tids, Shape.TotalCost(), &CostStart, &CostCount);
+
+    const size_t ActualCost = Shape.RangeCost(Shape.CostToWorkIndex(CostStart),
+                                              Shape.CostToWorkIndex(CostStart + CostCount));
+    Worst = std::max(Worst, ActualCost);
+  }
+
+  //
+  // Scheduling efficiency is Ideal/Worst. The uniform split gives 4*52/(2*52*... )
+  // -- concretely, its worst thread takes 104 block-rows against an ideal of 78,
+  // i.e. 75%. The weighted split must stay within one work item of ideal.
+  //
+
+  ASSERT_LE(Worst, Ideal + Shape.FilterSetSize)
+      << "worst thread took " << Worst << " block-rows against ideal " << Ideal;
+}


### PR DESCRIPTION
…titioning

The NCHWc convolution algorithms (pointwise and direct) partition work uniformly by item index over FilterSetCount x OutputHeight items, but the cost of an item is proportional to its FilterSet's FilterCount: full sets process FilterSetSize (4) NCHWc blocks while a ragged last set (when Cout/16 % 4 != 0) processes as few as 1. Threads landing on full sets do up to 4x the FLOPs of threads on the tail set, capping scheduling efficiency at 62-75% for common shapes (e.g. Cout=96: sets of 4+2 blocks -> 0.75 efficiency at 4 threads).

Replace the uniform index split with a split proportional to FLOP cost, measured in block-rows (one NCHWc output block x one output row): MlasPartitionWork distributes cost intervals, and CostToWorkIndex maps cost boundaries back to work-item boundaries with exact coverage and no overlap. Applied to both MLAS_NCHWC_CONV_POINTWISE_ALGORITHM and MLAS_NCHWC_CONV_NCHWC_ALGORITHM; the NCHW first-layer, depthwise, and pooling algorithms keep the uniform split (no imbalance there).

Outputs are bitwise identical: repartitioning moves whole output-row items between threads without changing any element's accumulation order.

Also:
- Add session config "mlas.nchwc_conv_max_input_channel_batch" to override the pointwise algorithm's input-channel batch (default 128, rounded up to a BlockSize multiple; 0/unset keeps the default) via MLAS_BACKEND_KERNEL_SELECTOR_CONFIG, for perf experimentation.
- Fix copy-paste guards in the SconvKernelAvx512F.S ReLU post-process (FilterCount 2 -> 3/4 for the zmm14/18/22 and zmm15/19/23 rows); behavior was accidentally correct but the FilterCount=2/OutputCount=6 variant emitted 6 vmaxps on dead registers.

Measured on AMD Ryzen AI MAX+ 395 (Zen 5, AVX-512), batch=1 fp32, intra_op=4, 512-iteration medians vs unmodified main:

  yolox_tiny  8.009 -> 7.149 ms  (-10.7%)  3x3-conv heavy, 86% of its
                                           3x3 time in ragged shapes
  mv3_large   0.962 -> 0.922 ms  (-4.2%)
  mv3_small   0.458 -> 0.455 ms  (-1% noise)
  mobileclip  unchanged (+/-1% noise; its conv shapes are 64-aligned)

Hottest yolox shape (96->96 3x3 @52x52): 939 -> 1167 GFLOP/s (91% of machine peak). All 29,910 onnxruntime_mlas_test cases pass.

### Description
<!-- Describe your changes. -->



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


