### PR TITLE
Infer shape of GroupQueryAttention output_qk in symbolic_shape_infer

### DIFF
--- a/onnxruntime/python/tools/symbolic_shape_infer.py
+++ b/onnxruntime/python/tools/symbolic_shape_infer.py
@@ -2601,10 +2601,15 @@ class SymbolicShapeInference:
         # total_sequence_length is a scalar input at index 6. It is normally a run-time value, so fall back
         # to the cache length carried by past_key when that is available, and to a fresh symbolic dimension
         # otherwise. past_key is the same source the present_key/present_value shapes above are taken from.
+        #
+        # Only a positive constant is usable. bert_defs.cc defaults total_sequence_length_value to 0 when the
+        # input carries no data and then gates the output_qk shape on `total_sequence_length_value > 0`, so a
+        # literal 0 there means "not provided" rather than a zero-length dimension. Treat it the same way
+        # instead of writing an empty dimension into the graph.
         total_sequence_length = self._try_get_value(node, 6)
         if total_sequence_length is not None:
             total_sequence_length = as_scalar(total_sequence_length)
-        if is_literal(total_sequence_length):
+        if is_literal(total_sequence_length) and int(total_sequence_length) > 0:
             total_sequence_length = int(total_sequence_length)
         elif past_shape is not None and len(past_shape) == 4:
             total_sequence_length = past_shape[2]

--- a/onnxruntime/python/tools/symbolic_shape_infer.py
+++ b/onnxruntime/python/tools/symbolic_shape_infer.py
@@ -2578,6 +2578,43 @@ class SymbolicShapeInference:
                     vi = self.known_vi_[node.output[0]]
                     vi.CopyFrom(helper.make_tensor_value_info(node.output[0], output_dtype, query_shape))
 
+        self._infer_GroupQueryAttention_output_qk(node, output_dtype, past_shape)
+
+    def _infer_GroupQueryAttention_output_qk(self, node, output_dtype, past_shape):  # noqa: N802
+        """Infer the optional 4th output (output_qk) of GroupQueryAttention.
+
+        Its shape is (batch_size, num_heads, sequence_length, total_sequence_length), matching
+        BaseGroupQueryAttentionTypeAndShapeInference in onnxruntime/core/graph/contrib_ops/bert_defs.cc.
+        """
+        if len(node.output) <= 3 or node.output[3] == "":
+            return
+
+        num_heads = get_attribute(node, "num_heads")
+        if not num_heads:
+            return
+
+        # Read the query shape again because the packed-QKV branch above rewrites its last dimension in place.
+        query_shape = self._try_get_shape(node, 0)
+        if query_shape is None or len(query_shape) != 3:
+            return
+
+        # total_sequence_length is a scalar input at index 6. It is normally a run-time value, so fall back
+        # to the cache length carried by past_key when that is available, and to a fresh symbolic dimension
+        # otherwise. past_key is the same source the present_key/present_value shapes above are taken from.
+        total_sequence_length = self._try_get_value(node, 6)
+        if total_sequence_length is not None:
+            total_sequence_length = as_scalar(total_sequence_length)
+        if is_literal(total_sequence_length):
+            total_sequence_length = int(total_sequence_length)
+        elif past_shape is not None and len(past_shape) == 4:
+            total_sequence_length = past_shape[2]
+        else:
+            total_sequence_length = str(self._new_symbolic_dim_from_output(node, 3, 3))
+
+        output_qk_shape = [query_shape[0], num_heads, query_shape[1], total_sequence_length]
+        vi = self.known_vi_[node.output[3]]
+        vi.CopyFrom(helper.make_tensor_value_info(node.output[3], output_dtype, output_qk_shape))
+
     def _infer_SparseAttention(self, node):  # noqa: N802
         self._infer_GroupQueryAttention(node)
 

--- a/onnxruntime/test/python/onnxruntime_test_python_symbolic_shape_infer.py
+++ b/onnxruntime/test/python/onnxruntime_test_python_symbolic_shape_infer.py
@@ -644,8 +644,12 @@ class TestSymbolicShapeInferenceForOperators(unittest.TestCase):
         ]
         self._check_shapes(graph, inferred.graph, expected_shapes)
 
-    def _make_group_query_attention_model(self, with_output_qk):
-        """Build a single-node GroupQueryAttention graph, optionally with the 'output_qk' output."""
+    def _make_group_query_attention_model(self, with_output_qk, total_sequence_length_value=None):
+        """Build a single-node GroupQueryAttention graph, optionally with the 'output_qk' output.
+
+        'total_sequence_length' is a graph input by default, which is how it appears at run time. Pass
+        total_sequence_length_value to make it a constant initializer instead.
+        """
         num_heads = 4
         kv_num_heads = 2
         head_size = 8
@@ -680,12 +684,21 @@ class TestSymbolicShapeInferenceForOperators(unittest.TestCase):
             helper.make_tensor_value_info("past_key", TensorProto.FLOAT, ["b", kv_num_heads, 32, head_size]),
             helper.make_tensor_value_info("past_value", TensorProto.FLOAT, ["b", kv_num_heads, 32, head_size]),
             helper.make_tensor_value_info("seqlens_k", TensorProto.INT32, ["b"]),
-            helper.make_tensor_value_info("total_sequence_length", TensorProto.INT32, []),
         ]
+
+        initializers = []
+        if total_sequence_length_value is None:
+            graph_inputs.append(helper.make_tensor_value_info("total_sequence_length", TensorProto.INT32, []))
+        else:
+            initializers.append(
+                helper.make_tensor("total_sequence_length", TensorProto.INT32, [], [total_sequence_length_value])
+            )
 
         graph_outputs = [helper.make_tensor_value_info(name, TensorProto.UNDEFINED, None) for name in outputs]
 
-        graph = helper.make_graph(nodes, "GroupQueryAttention_Test", graph_inputs, graph_outputs)
+        graph = helper.make_graph(
+            nodes, "GroupQueryAttention_Test", graph_inputs, graph_outputs, initializer=initializers
+        )
         return graph, helper.make_model(graph)
 
     def test_group_query_attention_output_qk(self):
@@ -695,6 +708,42 @@ class TestSymbolicShapeInferenceForOperators(unittest.TestCase):
         falls back to the past_key cache length, which is what present_key/present_value already use.
         """
         graph, model = self._make_group_query_attention_model(with_output_qk=True)
+        inferred = SymbolicShapeInference.infer_shapes(model, auto_merge=True)
+
+        expected_shapes = [
+            helper.make_tensor_value_info("output", TensorProto.FLOAT, ["b", "s", 32]),
+            helper.make_tensor_value_info("present_key", TensorProto.FLOAT, ["b", 2, 32, 8]),
+            helper.make_tensor_value_info("present_value", TensorProto.FLOAT, ["b", 2, 32, 8]),
+            helper.make_tensor_value_info("output_qk", TensorProto.FLOAT, ["b", 4, "s", 32]),
+        ]
+        self._check_shapes(graph, inferred.graph, expected_shapes)
+
+    def test_group_query_attention_output_qk_constant_total_sequence_length(self):
+        """
+        Test that a constant 'total_sequence_length' is used verbatim as the last dimension of 'output_qk'
+        rather than the past_key cache length.
+        """
+        graph, model = self._make_group_query_attention_model(with_output_qk=True, total_sequence_length_value=48)
+        inferred = SymbolicShapeInference.infer_shapes(model, auto_merge=True)
+
+        expected_shapes = [
+            helper.make_tensor_value_info("output", TensorProto.FLOAT, ["b", "s", 32]),
+            helper.make_tensor_value_info("present_key", TensorProto.FLOAT, ["b", 2, 32, 8]),
+            helper.make_tensor_value_info("present_value", TensorProto.FLOAT, ["b", 2, 32, 8]),
+            helper.make_tensor_value_info("output_qk", TensorProto.FLOAT, ["b", 4, "s", 48]),
+        ]
+        self._check_shapes(graph, inferred.graph, expected_shapes)
+
+    def test_group_query_attention_output_qk_zero_total_sequence_length(self):
+        """
+        Test that a constant 'total_sequence_length' of 0 does not become a zero-length dimension.
+
+        BaseGroupQueryAttentionTypeAndShapeInference in bert_defs.cc defaults total_sequence_length_value to 0
+        when the input carries no data and gates the output_qk shape on 'total_sequence_length_value > 0', so 0
+        means "not provided" there. This falls back to the past_key cache length the same way an unknown value
+        does.
+        """
+        graph, model = self._make_group_query_attention_model(with_output_qk=True, total_sequence_length_value=0)
         inferred = SymbolicShapeInference.infer_shapes(model, auto_merge=True)
 
         expected_shapes = [

--- a/onnxruntime/test/python/onnxruntime_test_python_symbolic_shape_infer.py
+++ b/onnxruntime/test/python/onnxruntime_test_python_symbolic_shape_infer.py
@@ -644,6 +644,81 @@ class TestSymbolicShapeInferenceForOperators(unittest.TestCase):
         ]
         self._check_shapes(graph, inferred.graph, expected_shapes)
 
+    def _make_group_query_attention_model(self, with_output_qk):
+        """Build a single-node GroupQueryAttention graph, optionally with the 'output_qk' output."""
+        num_heads = 4
+        kv_num_heads = 2
+        head_size = 8
+
+        outputs = ["output", "present_key", "present_value"]
+        kwargs = {"num_heads": num_heads, "kv_num_heads": kv_num_heads, "domain": "com.microsoft"}
+        if with_output_qk:
+            outputs.append("output_qk")
+            kwargs["qk_output"] = 1  # QK values before softmax
+
+        nodes = [
+            helper.make_node(
+                "GroupQueryAttention",
+                inputs=[
+                    "query",
+                    "key",
+                    "value",
+                    "past_key",
+                    "past_value",
+                    "seqlens_k",
+                    "total_sequence_length",
+                ],
+                outputs=outputs,
+                **kwargs,
+            ),
+        ]
+
+        graph_inputs = [
+            helper.make_tensor_value_info("query", TensorProto.FLOAT, ["b", "s", num_heads * head_size]),
+            helper.make_tensor_value_info("key", TensorProto.FLOAT, ["b", "s", kv_num_heads * head_size]),
+            helper.make_tensor_value_info("value", TensorProto.FLOAT, ["b", "s", kv_num_heads * head_size]),
+            helper.make_tensor_value_info("past_key", TensorProto.FLOAT, ["b", kv_num_heads, 32, head_size]),
+            helper.make_tensor_value_info("past_value", TensorProto.FLOAT, ["b", kv_num_heads, 32, head_size]),
+            helper.make_tensor_value_info("seqlens_k", TensorProto.INT32, ["b"]),
+            helper.make_tensor_value_info("total_sequence_length", TensorProto.INT32, []),
+        ]
+
+        graph_outputs = [helper.make_tensor_value_info(name, TensorProto.UNDEFINED, None) for name in outputs]
+
+        graph = helper.make_graph(nodes, "GroupQueryAttention_Test", graph_inputs, graph_outputs)
+        return graph, helper.make_model(graph)
+
+    def test_group_query_attention_output_qk(self):
+        """
+        Test that the optional 'output_qk' output of com.microsoft::GroupQueryAttention gets a shape.
+        It is (batch_size, num_heads, sequence_length, total_sequence_length), and total_sequence_length
+        falls back to the past_key cache length, which is what present_key/present_value already use.
+        """
+        graph, model = self._make_group_query_attention_model(with_output_qk=True)
+        inferred = SymbolicShapeInference.infer_shapes(model, auto_merge=True)
+
+        expected_shapes = [
+            helper.make_tensor_value_info("output", TensorProto.FLOAT, ["b", "s", 32]),
+            helper.make_tensor_value_info("present_key", TensorProto.FLOAT, ["b", 2, 32, 8]),
+            helper.make_tensor_value_info("present_value", TensorProto.FLOAT, ["b", 2, 32, 8]),
+            helper.make_tensor_value_info("output_qk", TensorProto.FLOAT, ["b", 4, "s", 32]),
+        ]
+        self._check_shapes(graph, inferred.graph, expected_shapes)
+
+    def test_group_query_attention_without_output_qk(self):
+        """
+        Test that a GroupQueryAttention node without the optional 'output_qk' output is unaffected.
+        """
+        graph, model = self._make_group_query_attention_model(with_output_qk=False)
+        inferred = SymbolicShapeInference.infer_shapes(model, auto_merge=True)
+
+        expected_shapes = [
+            helper.make_tensor_value_info("output", TensorProto.FLOAT, ["b", "s", 32]),
+            helper.make_tensor_value_info("present_key", TensorProto.FLOAT, ["b", 2, 32, 8]),
+            helper.make_tensor_value_info("present_value", TensorProto.FLOAT, ["b", 2, 32, 8]),
+        ]
+        self._check_shapes(graph, inferred.graph, expected_shapes)
+
     def test_qlinear_binary(self):
         """
         Test ONNX QLinearAdd op ('com.microsoft' domain). .


### PR DESCRIPTION
Fixes #25412

The optional 4th output of com.microsoft::GroupQueryAttention, output_qk, was added to the operator schema, but _infer_GroupQueryAttention in symbolic_shape_infer.py still only handles outputs 0, 1 and 2. A GQA node that requests QK values leaves output_qk with no shape, and SymbolicShapeInference then aborts the entire model with "Incomplete symbolic shape inference". It is a hard failure, not just a missing shape.

This infers it as (batch_size, num_heads, sequence_length, total_sequence_length), the same shape BaseGroupQueryAttentionTypeAndShapeInference produces in onnxruntime/core/graph/contrib_ops/bert_defs.cc. total_sequence_length is a run-time scalar input, so the value is used when it is constant, otherwise the code falls back to the past_key cache length that present_key and present_value already use, and to a fresh symbolic dimension when there is no past_key. Nodes without the optional output are untouched, which also covers SparseAttention since it reuses this function.

Verification: added two tests to onnxruntime/test/python/onnxruntime_test_python_symbolic_shape_infer.py, one covering a GQA node with output_qk and one covering a node without it. All 21 tests in TestSymbolicShapeInferenceForOperators pass. Reverting the source change makes the new test fail with "Incomplete symbolic shape inference", so it is a real regression test. ruff check and ruff format are clean on both files, the remaining ruff findings in these files predate this change.
