### PR TITLE
Support models of 2GB or more in make_dynamic_shape_fixed

### DIFF
--- a/tools/python/util/make_dynamic_shape_fixed.py
+++ b/tools/python/util/make_dynamic_shape_fixed.py
@@ -10,7 +10,7 @@ import sys
 
 import onnx
 
-from .onnx_model_utils import fix_output_shapes, make_dim_param_fixed, make_input_shape_fixed
+from .onnx_model_utils import PROTOBUF_SIZE_LIMIT, fix_output_shapes, make_dim_param_fixed, make_input_shape_fixed
 
 
 def make_dynamic_shape_fixed_helper():
@@ -41,6 +41,13 @@ def make_dynamic_shape_fixed_helper():
         "All values must be > 0. e.g. --input_shape 1,3,256,256",
     )
 
+    parser.add_argument(
+        "--use_external_data_format",
+        action="store_true",
+        help="Write the initializers to a separate '<output_model>.data' file. This is required for models "
+        "of 2GB or more, and is enabled automatically for them.",
+    )
+
     parser.add_argument("input_model", type=pathlib.Path, help="Provide path to ONNX model to update.")
     parser.add_argument("output_model", type=pathlib.Path, help="Provide path to write updated ONNX model to.")
 
@@ -66,7 +73,17 @@ def make_dynamic_shape_fixed_helper():
     # update the output shapes to make them fixed if possible.
     fix_output_shapes(model)
 
-    onnx.save(model, str(args.output_model.resolve()))
+    output_model = args.output_model.resolve()
+    if args.use_external_data_format or model.ByteSize() >= PROTOBUF_SIZE_LIMIT:
+        onnx.save_model(
+            model,
+            str(output_model),
+            save_as_external_data=True,
+            all_tensors_to_one_file=True,
+            location=f"{output_model.name}.data",
+        )
+    else:
+        onnx.save(model, str(output_model))
 
 
 if __name__ == "__main__":

--- a/tools/python/util/onnx_model_utils.py
+++ b/tools/python/util/onnx_model_utils.py
@@ -4,11 +4,16 @@ from __future__ import annotations
 
 import logging
 import pathlib
+import tempfile
 
 import onnx
 from onnx import version_converter
 
 import onnxruntime as ort
+
+# A serialized ModelProto must stay under the 2GB protobuf message limit. Models at or above it can only
+# be handled by the onnx APIs that take file paths and keep the initializer data outside the proto.
+PROTOBUF_SIZE_LIMIT = 2147483648
 
 
 def iterate_graph_per_node_func(graph, per_node_func, **func_args):
@@ -231,6 +236,33 @@ def make_input_shape_fixed(graph: onnx.GraphProto, input_name: str, fixed_shape:
     )
 
 
+def _infer_shapes(model: onnx.ModelProto) -> onnx.ModelProto:
+    """
+    Run shape inference on a model and check the result.
+    :param model: Model to run shape inference on. It is not modified.
+    :return: A copy of the model with shape inferencing info added.
+    """
+
+    if model.ByteSize() < PROTOBUF_SIZE_LIMIT:
+        m2 = onnx.shape_inference.infer_shapes(model)
+        onnx.checker.check_model(m2)
+        return m2
+
+    # onnx.shape_inference.infer_shapes and onnx.checker.check_model both serialize the model into a single
+    # protobuf, which a model of this size cannot fit into. Their path based counterparts write the initializer
+    # data to a separate file instead, so round trip through a temporary directory to reach them.
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = pathlib.Path(temp_dir)
+        model_path = temp_path / "model.onnx"
+        inferred_path = temp_path / "model.inferred.onnx"
+        onnx.save_model(model, str(model_path), save_as_external_data=True, location="model.onnx.data")
+        onnx.shape_inference.infer_shapes_path(str(model_path), str(inferred_path))
+        onnx.checker.check_model(str(inferred_path))
+
+        # only the shapes are needed, so leave the initializer data on disk rather than doubling memory usage.
+        return onnx.load_model(str(inferred_path), load_external_data=False)
+
+
 def fix_output_shapes(model: onnx.ModelProto):
     """
     Update the output shapesof a model where the input shape/s were made fixed, if possible.
@@ -239,8 +271,7 @@ def fix_output_shapes(model: onnx.ModelProto):
     """
 
     # get a version of the model with shape inferencing info in it. this will provide fixed output shapes if possible.
-    m2 = onnx.shape_inference.infer_shapes(model)
-    onnx.checker.check_model(m2)
+    m2 = _infer_shapes(model)
 
     for idx, o in enumerate(model.graph.output):
         if not is_fixed_size_tensor(o):

--- a/tools/python/util/test/test_onnx_model_utils.py
+++ b/tools/python/util/test/test_onnx_model_utils.py
@@ -2,11 +2,15 @@
 # Licensed under the MIT License.
 
 import pathlib
+import tempfile
 import unittest
+from unittest import mock
 
 import onnx
 from onnx import TensorProto, helper, shape_inference
 
+from .. import onnx_model_utils
+from ..make_dynamic_shape_fixed import make_dynamic_shape_fixed_helper
 from ..mobile_helpers.usability_checker import check_shapes
 from ..onnx_model_utils import (
     fix_output_shapes,
@@ -237,6 +241,65 @@ class TestDynamicDimReplacement(unittest.TestCase):
         self.assertFalse(is_fixed_size_tensor(model.graph.output[0]))
         fix_output_shapes(model)
         self.assertTrue(is_fixed_size_tensor(model.graph.output[0]))
+
+    def test_fix_output_shape_for_large_model(self):
+        """
+        A model of 2GB or more can't be serialized into a single protobuf, so shape inference has to go via
+        the path based onnx APIs. Drop the size limit rather than building a 2GB model to exercise that path.
+        """
+        model_path = ort_root / "onnxruntime" / "test" / "testdata" / "transform" / "fusion" / "bias_gelu_fusion.onnx"
+        model = onnx.load_model(str(model_path))
+
+        make_input_shape_fixed(model.graph, "A", [2, 2, 3072])
+
+        self.assertFalse(is_fixed_size_tensor(model.graph.output[0]))
+        with mock.patch.object(onnx_model_utils, "PROTOBUF_SIZE_LIMIT", 0):
+            fix_output_shapes(model)
+        self.assertTrue(is_fixed_size_tensor(model.graph.output[0]))
+
+    def test_make_dynamic_shape_fixed_with_external_data(self):
+        """
+        Check the command line tool can write the initializers to a separate file, which is the only way to
+        save a model of 2GB or more.
+        """
+        # raw data, because that is what the onnx external data writer moves out of the model file
+        weight_bytes = b"\x00\x00\x00\x3f" * (4 * 512)  # 0.5 as little endian float32
+        weight = helper.make_tensor("W", TensorProto.FLOAT, [4, 512], weight_bytes, raw=True)
+        node = helper.make_node("MatMul", ["input", "W"], ["output"])
+        graph = helper.make_graph(
+            [node],
+            "test",
+            [helper.make_tensor_value_info("input", TensorProto.FLOAT, ["batch", 4])],
+            [helper.make_tensor_value_info("output", TensorProto.FLOAT, ["batch", 512])],
+            [weight],
+        )
+        model = helper.make_model(graph)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = pathlib.Path(temp_dir)
+            input_model = temp_path / "dynamic.onnx"
+            output_model = temp_path / "fixed.onnx"
+            onnx.save_model(model, str(input_model))
+
+            args = [
+                "make_dynamic_shape_fixed",
+                "--input_name",
+                "input",
+                "--input_shape",
+                "2,4",
+                "--use_external_data_format",
+                str(input_model),
+                str(output_model),
+            ]
+            with mock.patch("sys.argv", args):
+                make_dynamic_shape_fixed_helper()
+
+            self.assertTrue(output_model.exists())
+            self.assertTrue(output_model.with_name("fixed.onnx.data").exists())
+
+            fixed = onnx.load_model(str(output_model))
+            self.assertTrue(is_fixed_size_tensor(fixed.graph.input[0]))
+            self.assertTrue(is_fixed_size_tensor(fixed.graph.output[0]))
 
     def test_invalid_replace_input_shape(self):
         model_path = ort_root / "onnxruntime" / "test" / "testdata" / "sklearn_bin_voting_classifier_soft.onnx"


### PR DESCRIPTION
Fixes #16773

onnxruntime.tools.make_dynamic_shape_fixed fails on any model at or above the protobuf message limit. fix_output_shapes calls onnx.shape_inference.infer_shapes, which serializes the model into a single protobuf, so the run dies with "Message onnx.ModelProto exceeds maximum protobuf size of 2GB" before anything is written. Saving the result has the same problem.

Shape inference now goes through onnx.shape_inference.infer_shapes_path for models of that size. It keeps the initializer data in a separate file, so the 2GB limit applies to the graph alone. Only the inferred output shapes are read back, so the initializer data stays on disk rather than being loaded a second time. Models below the limit keep taking the existing in-memory path, so nothing changes for them.

This also adds --use_external_data_format so the fixed model can be written with its initializers in a separate file. It turns on automatically for models of 2GB or more, since those cannot be saved any other way.

Verification: added two tests to tools/python/util/test/test_onnx_model_utils.py. One drops PROTOBUF_SIZE_LIMIT to exercise the path based shape inference branch without building a 2GB model, the other drives the command line tool end to end and checks the .data file is written and the shapes are fixed. All 8 tests in that file pass, and both new tests fail against the unmodified code. ruff check and ruff format are clean on the changed files, the two remaining ruff findings in onnx_model_utils.py predate this change.
