### PR TITLE
Make DML runtime fused graph kernel own its model path

### DIFF
--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/DmlGraphFusionHelper.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/DmlGraphFusionHelper.cpp
@@ -694,7 +694,7 @@ namespace DmlGraphFusionHelper
             initializeResourceRefs,
             nullptr);
 
-        // lamda captures for the kernel registration
+        // lambda captures for the kernel registration
         Windows::AI::MachineLearning::Adapter::EdgeShapes outputShapes;
         ORT_THROW_HR_IF(E_UNEXPECTED, !TryGetStaticOutputShapes(fusedNode, outputShapes));
         bool resuableCommandList = graphDesc.reuseCommandList;
@@ -837,7 +837,7 @@ namespace DmlGraphFusionHelper
             kvp.second.first = &ownedInitializers.back();
         }
 
-        // lamda captures for the kernel registration
+        // lambda captures for the kernel registration
         auto fused_kernel_func = [
             indexedSubGraph,
             modelPath,

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/DmlGraphFusionHelper.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/DmlGraphFusionHelper.cpp
@@ -756,7 +756,8 @@ namespace DmlGraphFusionHelper
             *indexedSubGraph,
             std::move(graphNodePropertyMap));
 
-        auto modelPath = graph.ModelPath();
+        // Owned copy: the closure registered below outlives this frame.
+        std::filesystem::path modelPath = graph.ModelPath();
 
         const gsl::span<const std::string> subGraphInputArgNames = indexedSubGraph->GetMetaDef()->inputs;
         const gsl::span<const std::string> subGraphOutputArgNames = indexedSubGraph->GetMetaDef()->outputs;
@@ -839,7 +840,7 @@ namespace DmlGraphFusionHelper
         // lamda captures for the kernel registration
         auto fused_kernel_func = [
             indexedSubGraph,
-            &modelPath,
+            modelPath,
             nodesInfo = std::move(nodesInfo),
             intermediateNodeArgs = std::move(intermediateNodeArgs),
             subgraphInputs = std::move(subgraphInputs),

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/DmlRuntimeFusedGraphKernel.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/DmlRuntimeFusedGraphKernel.cpp
@@ -20,7 +20,7 @@ namespace Dml
         DmlRuntimeFusedGraphKernel(
             const onnxruntime::OpKernelInfo& kernelInfo,
             std::shared_ptr<const onnxruntime::IndexedSubGraph> indexedSubGraph,
-            const std::filesystem::path& modelPath,
+            std::filesystem::path modelPath,
             std::vector<std::shared_ptr<onnxruntime::Node>>&& subgraphNodes,
             std::vector<const onnxruntime::NodeArg*>&& subgraphInputs,
             std::vector<const onnxruntime::NodeArg*>&& subgraphOutputs,
@@ -29,7 +29,7 @@ namespace Dml
             std::vector<ONNX_NAMESPACE::TensorProto>&& ownedInitializers)
         : OpKernel(kernelInfo),
           m_indexedSubGraph(std::move(indexedSubGraph)),
-          m_modelPath(modelPath),
+          m_modelPath(std::move(modelPath)),
           m_subgraphNodes(std::move(subgraphNodes)),
           m_subgraphInputs(std::move(subgraphInputs)),
           m_subgraphOutputs(std::move(subgraphOutputs)),
@@ -314,7 +314,11 @@ namespace Dml
 
         mutable std::optional<DML_BUFFER_BINDING> m_persistentResourceBinding;
         std::shared_ptr<const onnxruntime::IndexedSubGraph> m_indexedSubGraph;
-        const std::filesystem::path& m_modelPath;
+
+        // Owned by value: the caller that registers the kernel-creation callback (see
+        // DmlGraphFusionHelper::RegisterDynamicKernel) returns long before the callback runs, so this
+        // kernel cannot alias the model path owned by that frame.
+        std::filesystem::path m_modelPath;
 
         std::vector<std::shared_ptr<onnxruntime::Node>> m_subgraphNodes;
         std::vector<const onnxruntime::NodeArg*> m_subgraphInputs;
@@ -341,7 +345,7 @@ namespace Dml
     onnxruntime::OpKernel* CreateRuntimeFusedGraphKernel(
         const onnxruntime::OpKernelInfo& info,
         std::shared_ptr<const onnxruntime::IndexedSubGraph> indexedSubGraph,
-        const std::filesystem::path& modelPath,
+        std::filesystem::path modelPath,
         std::vector<std::shared_ptr<onnxruntime::Node>>&& subgraphNodes,
         std::vector<const onnxruntime::NodeArg*>&& subgraphInputs,
         std::vector<const onnxruntime::NodeArg*>&& subgraphOutputs,
@@ -352,7 +356,7 @@ namespace Dml
         return new DmlRuntimeFusedGraphKernel(
             info,
             std::move(indexedSubGraph),
-            modelPath,
+            std::move(modelPath),
             std::move(subgraphNodes),
             std::move(subgraphInputs),
             std::move(subgraphOutputs),

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/DmlRuntimeFusedGraphKernel.h
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/DmlRuntimeFusedGraphKernel.h
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+#pragma once
+
 #include <filesystem>
 #include "core/framework/op_kernel.h"
 #include "GraphDescBuilder.h"
@@ -7,10 +9,13 @@
 
 namespace Dml
 {
+    // `modelPath` is taken by value: the kernel outlives the caller that supplies it (the creation
+    // callback registered by DmlGraphFusionHelper::RegisterDynamicKernel runs after that frame has
+    // returned), so the kernel must own its own copy rather than alias the caller's.
     onnxruntime::OpKernel* CreateRuntimeFusedGraphKernel(
         const onnxruntime::OpKernelInfo& info,
         std::shared_ptr<const onnxruntime::IndexedSubGraph> indexedSubGraph,
-        const std::filesystem::path& modelPath,
+        std::filesystem::path modelPath,
         std::vector<std::shared_ptr<onnxruntime::Node>>&& subgraphNodes,
         std::vector<const onnxruntime::NodeArg*>&& subgraphInputs,
         std::vector<const onnxruntime::NodeArg*>&& subgraphOutputs,


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
`DmlRuntimeFusedGraphKernel` now owns its model path by value instead of holding a reference to a caller's local.

In `DmlGraphFusionHelper::RegisterDynamicKernel`, `modelPath` was a function-local that the kernel-creation lambda captured by reference. That lambda is registered into the `KernelRegistry`, which outlives the enclosing frame, and `DmlRuntimeFusedGraphKernel::m_modelPath` stored a `const std::filesystem::path&` bound to that same local.

- Capture `modelPath` by value in the kernel-creation lambda
- `CreateRuntimeFusedGraphKernel` takes the path by value and forwards it with `std::move`
- `DmlRuntimeFusedGraphKernel::m_modelPath` is now a `std::filesystem::path` held by value
- Added a missing `#pragma once` to `DmlRuntimeFusedGraphKernel.h`


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
DML reliability improvement. 