### PR TITLE
xnnpack: validate kernel registration table at compile time

### DIFF
--- a/onnxruntime/core/providers/xnnpack/xnnpack_execution_provider.cc
+++ b/onnxruntime/core/providers/xnnpack/xnnpack_execution_provider.cc
@@ -13,6 +13,7 @@
 #include "core/session/onnxruntime_session_options_config_keys.h"
 #include "core/optimizer/qdq_transformer/selectors_actions/qdq_selectors.h"
 #include "core/optimizer/qdq_transformer/selectors_actions/shared/utils.h"
+#include "core/providers/kernel_registration_validation.h"
 #include "core/providers/xnnpack/xnnpack_execution_provider.h"
 #include "core/providers/xnnpack/detail/utils.h"
 #include "core/providers/xnnpack/detail/node_support_checker.h"
@@ -89,7 +90,7 @@ class ONNX_OPERATOR_KERNEL_CLASS_NAME(kXnnpackExecutionProvider, kDynamicDomainB
 std::unique_ptr<KernelRegistry> RegisterKernels() {
   auto kernel_registry = std::make_unique<onnxruntime::KernelRegistry>();
 
-  static const BuildKernelCreateInfoFn function_table[] = {
+  static constexpr BuildKernelCreateInfoFn function_table[] = {
       BuildKernelCreateInfo<void>,  // default entry to avoid the list becoming empty after ops-reducing
 
       // layout sensitive. nodes will be moved to kMSInternalNHWCDomain by layout transformation
@@ -139,6 +140,8 @@ std::unique_ptr<KernelRegistry> RegisterKernels() {
 
       KERNEL_CREATE_INFO(1, QLinearSoftmax, kDynamicDomainByCreate),
   };
+
+  static_assert(registration_internal::IsKernelRegistrationTableValid(function_table, BuildKernelCreateInfo<void>));
 
   for (auto& function_table_entry : function_table) {
     KernelCreateInfo info = function_table_entry();


### PR DESCRIPTION
Description
Applies compile-time kernel registration table validation for the XNNPACK execution provider.
Related to #31348


Motivation and Context
This PR adds compile-time validation for the kernel registration table in the XNNPACK Execution Provider.
By switching function_table to constexpr and applying static_assert(registration_internal::IsKernelRegistrationTableValid(...)), any typos, duplicate kernel registrations, or invalid entries in the XNNPACK provider will now trigger a compile-time error rather than a runtime failure or unexpected behavior.
Fixes #31348


