### PR TITLE
Guard three graph-optimizer passes against unbounded model-supplied indices

### DIFF
--- a/onnxruntime/core/optimizer/gather_fusion.cc
+++ b/onnxruntime/core/optimizer/gather_fusion.cc
@@ -197,6 +197,11 @@ Status GatherSliceToSplitFusion::ApplyImpl(Graph& graph, bool& modified, int gra
     if (condidate_consumers.size() < 2) continue;
     int64_t axis = 0;
     if (!GetAxis(graph, *condidate_consumers[0], rank, axis)) continue;
+    // The 'axis' attribute/input read above comes from the consumer node as declared in the model and is
+    // only range-checked against this node_arg's rank here, not by ONNX shape inference (which may have
+    // skipped its own axis check if it lacked one of the input shapes needed to run it). Reject anything
+    // outside the valid dimension range before indexing 'shape' with it.
+    if (axis < 0 || axis >= rank) continue;
     auto dim = shape->dim(static_cast<int>(axis));
     if (!utils::HasDimValue(dim)) continue;
     int64_t dim_size = dim.dim_value();

--- a/onnxruntime/core/optimizer/qdq_transformer/where_dummy_dq.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/where_dummy_dq.cc
@@ -72,10 +72,12 @@ Status WhereDummyDq::InsertDummyDQ(Node& node, Graph& graph, bool& modified, con
   const int const_idx = parent_node_1 ? 2 : 1;
 
   // DequantizeLinear's zero-point input (index 2) is optional per the ONNX spec, so a DQ node with
-  // only 2 inputs (x, x_scale) is valid (e.g. common symmetric-quantization models) and must be
-  // skipped here rather than indexed below. This isn't an error, so log at VERBOSE rather than
-  // WARNING to avoid noisy logs for an otherwise ordinary, spec-conforming model.
-  if (dq_node->InputDefs().size() < 3) {
+  // only 2 inputs (x, x_scale), or a 3rd input given as an empty/missing NodeArg placeholder, is
+  // valid (e.g. common symmetric-quantization models) and must be skipped here rather than indexed
+  // below. This isn't an error, so log at VERBOSE rather than WARNING to avoid noisy logs for an
+  // otherwise ordinary, spec-conforming model.
+  const auto& dq_inputs = dq_node->InputDefs();
+  if (dq_inputs.size() < 3 || !dq_inputs[2]->Exists()) {
     LOGS(logger, VERBOSE) << "WhereDummyDq: skip inserting dummy DQ because the dq branch has no "
                              "zero point input (optional per spec). DQ: "
                           << dq_node->Name();

--- a/onnxruntime/core/optimizer/qdq_transformer/where_dummy_dq.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/where_dummy_dq.cc
@@ -71,6 +71,14 @@ Status WhereDummyDq::InsertDummyDQ(Node& node, Graph& graph, bool& modified, con
   const Node* dq_node = parent_node_1 ? parent_node_1 : parent_node_2;
   const int const_idx = parent_node_1 ? 2 : 1;
 
+  // DequantizeLinear's zero-point input (index 2) is optional per the ONNX spec, so a DQ node with
+  // only 2 inputs (x, x_scale) is valid and must be skipped here rather than indexed below.
+  if (dq_node->InputDefs().size() < 3) {
+    LOGS(logger, WARNING) << "WhereDummyDq expects dq branch to have a zero point input. "
+                          << "DQ: " << dq_node->Name();
+    return Status::OK();
+  }
+
   // Guardrail: only insert dummy DQ when the quantized dtype matches the output Q's dtype.
   // If they differ, we cannot safely synthesize quantization parameters.
   const int32_t dt_input = dq_node->InputDefs()[0]->TypeAsProto()->tensor_type().elem_type();

--- a/onnxruntime/core/optimizer/qdq_transformer/where_dummy_dq.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/where_dummy_dq.cc
@@ -72,10 +72,13 @@ Status WhereDummyDq::InsertDummyDQ(Node& node, Graph& graph, bool& modified, con
   const int const_idx = parent_node_1 ? 2 : 1;
 
   // DequantizeLinear's zero-point input (index 2) is optional per the ONNX spec, so a DQ node with
-  // only 2 inputs (x, x_scale) is valid and must be skipped here rather than indexed below.
+  // only 2 inputs (x, x_scale) is valid (e.g. common symmetric-quantization models) and must be
+  // skipped here rather than indexed below. This isn't an error, so log at VERBOSE rather than
+  // WARNING to avoid noisy logs for an otherwise ordinary, spec-conforming model.
   if (dq_node->InputDefs().size() < 3) {
-    LOGS(logger, WARNING) << "WhereDummyDq expects dq branch to have a zero point input. "
-                          << "DQ: " << dq_node->Name();
+    LOGS(logger, VERBOSE) << "WhereDummyDq: skip inserting dummy DQ because the dq branch has no "
+                             "zero point input (optional per spec). DQ: "
+                          << dq_node->Name();
     return Status::OK();
   }
 

--- a/onnxruntime/core/optimizer/transpose_optimization/onnx_transpose_optimization.cc
+++ b/onnxruntime/core/optimizer/transpose_optimization/onnx_transpose_optimization.cc
@@ -2290,7 +2290,15 @@ static bool HandleTile(HandlerArgs& args) {
   size_t rank = args.perm.size();
   std::vector<int64_t> perm_shape{gsl::narrow_cast<int64_t>(rank)};
 
-  std::string_view repeats_inp = args.node.Inputs()[1];
+  // Tile has 2 required inputs ('input' and 'repeats') per the ONNX spec; this is normally
+  // guaranteed by schema validation during Graph::Resolve, but that validation can be skipped
+  // for some build configurations (e.g. ORT-format models), so check explicitly here too, as
+  // the sibling Gather handler above does for its own required second input.
+  auto tile_inputs = args.node.Inputs();
+  if (tile_inputs.size() < 2) {
+    return false;
+  }
+  std::string_view repeats_inp = tile_inputs[1];
   std::unique_ptr<api::TensorRef> repeats_const = args.ctx.graph.GetConstant(repeats_inp);
   if (repeats_const != nullptr) {
     // Case 1: Repeats is constant. Shuffle order.

--- a/onnxruntime/core/optimizer/transpose_optimization/onnx_transpose_optimization.cc
+++ b/onnxruntime/core/optimizer/transpose_optimization/onnx_transpose_optimization.cc
@@ -2295,6 +2295,14 @@ static bool HandleTile(HandlerArgs& args) {
   if (repeats_const != nullptr) {
     // Case 1: Repeats is constant. Shuffle order.
     const std::vector<int64_t>& repeats = DataInt64(*repeats_const);
+    // 'repeats' is required by the Tile spec to have one entry per dimension of the preceding
+    // Transpose's input, i.e. the same length as 'rank' derived from that Transpose's 'perm'. That
+    // isn't necessarily verified ahead of this point (e.g. shape inference may not have been able to
+    // validate it if the data input's rank wasn't statically known), so re-check it here before using
+    // values from 'perm_inv' (which are all < rank) to index into 'repeats'.
+    if (repeats.size() != rank) {
+      return false;
+    }
     std::vector<int64_t> new_repeats;
     new_repeats.reserve(rank);
     for (int64_t p : args.perm_inv) {

--- a/onnxruntime/test/optimizer/graph_transform_test.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test.cc
@@ -10973,6 +10973,50 @@ TEST_F(GraphTransformationTests, GatherSliceToSplitFusion_Invalid) {
   }
 }
 
+// The fusion reads the 'axis' attribute/input straight from the model, and needs to reject a value
+// that falls outside [0, rank) for the shared input's known rank rather than indexing its shape with it.
+TEST_F(GraphTransformationTests, GatherSliceToSplitFusion_OutOfRangeAxis) {
+  auto pre_graph_checker = [&](Graph& graph) {
+    TEST_RETURN_IF_NOT(CountOpsInGraph(graph)["Gather"] == 2);
+    return Status::OK();
+  };
+  auto post_graph_checker = [&](Graph& graph) {
+    TEST_RETURN_IF_NOT(CountOpsInGraph(graph)["Gather"] == 2);
+    TEST_RETURN_IF_NOT(CountOpsInGraph(graph)["Split"] == 0);
+    return Status::OK();
+  };
+
+  auto build_test_case = [&](ModelTestBuilder& builder) {
+    auto* data_arg = builder.MakeInput<float>({{54}});
+    auto* shape_arg = builder.MakeInput<int64_t>({{4}});
+    auto* reshape_out = builder.MakeIntermediate<float>({{2, 3, 3, 3}});
+    // gather_index_1 is a graph input with no static shape, so ONNX's own Gather shape inference
+    // (which requires both the data AND indices shapes to be known before range-checking 'axis')
+    // cannot validate 'axis' here and silently skips that check, matching how this can be reached
+    // in a real model without ONNX itself already rejecting it at load.
+    auto* gather_index_1 = builder.MakeInput<int64_t>(std::nullopt);
+    auto* gather_index_2 = builder.MakeInitializer<int64_t>({}, {static_cast<int64_t>(1)});
+    auto* gather_out_1 = builder.MakeIntermediate();
+    auto* gather_out_2 = builder.MakeIntermediate();
+    auto* transpose_out_1 = builder.MakeOutput();
+    auto* transpose_out_2 = builder.MakeOutput();
+
+    builder.AddNode("Reshape", {data_arg, shape_arg}, {reshape_out});
+    // 'axis' is well outside the reshape output's rank of 4; the fusion must reject this before
+    // indexing the shape with it, rather than crashing.
+    builder.AddNode("Gather", {reshape_out, gather_index_1}, {gather_out_1})
+        .AddAttribute("axis", static_cast<int64_t>(100));
+    builder.AddNode("Gather", {reshape_out, gather_index_2}, {gather_out_2})
+        .AddAttribute("axis", static_cast<int64_t>(1));
+    builder.AddNode("Transpose", {gather_out_1}, {transpose_out_1}).AddAttribute("perm", std::vector<int64_t>{0, 2, 1});
+    builder.AddNode("Transpose", {gather_out_2}, {transpose_out_2}).AddAttribute("perm", std::vector<int64_t>{0, 2, 1});
+  };
+
+  std::unique_ptr<GraphTransformer> transformer = std::make_unique<GatherSliceToSplitFusion>();
+  ASSERT_STATUS_OK(TestGraphTransformer(build_test_case, 14, *logger_, std::move(transformer),
+                                        TransformerLevel::Level1, 1, pre_graph_checker, post_graph_checker));
+}
+
 TEST_F(GraphTransformationTests, GatherToSliceFusion) {
   auto pre_graph_checker = [&](Graph& graph) {
     auto op_count_map = CountOpsInGraph(graph);

--- a/onnxruntime/test/optimizer/qdq_transformer_test.cc
+++ b/onnxruntime/test/optimizer/qdq_transformer_test.cc
@@ -3538,6 +3538,47 @@ TEST(QDQTransformerTests, WhereDummyDqTest) {
   TestWhereWithDqInput<float, uint8_t, uint16_t>(false, true, 1, 1, 1, false);
 }
 
+// DequantizeLinear's zero-point input is optional per the ONNX spec, so a DQ node with only 2 inputs
+// (x, x_scale) is valid. The optimizer must recognize this and skip inserting a dummy DQ rather than
+// indexing an absent zero-point input.
+TEST(QDQTransformerTests, WhereDummyDqTest_DqWithoutZeroPoint) {
+  auto& logger = DefaultLoggingManager().DefaultLogger();
+  Model model("WhereDummyDqNoZpTester", false, logger);
+  Graph& graph = model.MainGraph();
+  ModelTestBuilder builder(graph);
+
+  // DQ branch with only 2 inputs: no zero-point.
+  auto* dq_input = builder.MakeInput<uint8_t>({4, 3, 32}, 0, 1);
+  auto* dq_scale = builder.MakeInitializer<float>({}, 0.0, 1.0);
+  auto* where_in1 = builder.MakeIntermediate();
+  builder.AddNode("DequantizeLinear", {dq_input, dq_scale}, {where_in1});
+
+  // Other branch is a scalar initializer, matching WhereDummyDq's target pattern.
+  auto* where_in2 = builder.MakeInitializer<float>({}, 0.0, 1.0);
+
+  auto* where_cond = builder.MakeInputBool({4, 3, 32});
+  auto* where_out = builder.MakeIntermediate();
+  builder.AddNode("Where", {where_cond, where_in1, where_in2}, {where_out});
+
+  auto* q_scale = builder.MakeInitializer<float>({}, 0.0, 1.0);
+  auto* q_zp = builder.MakeInitializer<uint8_t>({}, 0.0, 1.0);
+  auto* q_out = builder.MakeOutput();
+  builder.AddNode("QuantizeLinear", {where_out, q_scale, q_zp}, {q_out});
+
+  builder.SetGraphOutputs();
+  ASSERT_STATUS_OK(graph.Resolve());
+
+  auto where_optimizer = std::make_unique<WhereDummyDq>();
+  bool modified = false;
+  ASSERT_STATUS_OK(where_optimizer->Apply(graph, modified, logger));
+
+  std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
+  ASSERT_EQ(op_to_count["Where"], 1);
+  ASSERT_EQ(op_to_count["DequantizeLinear"], 1);  // no dummy DQ inserted
+  ASSERT_EQ(op_to_count["QuantizeLinear"], 1);
+  ASSERT_FALSE(modified);
+}
+
 // Tests WhereDummyDq with non-QuantizeLinear consumers.
 // The optimizer should NOT add dummy DQ nodes when the Where output is not consumed by a QuantizeLinear.
 template <typename ScaleType, typename ZpTypeDq>

--- a/onnxruntime/test/optimizer/qdq_transformer_test.cc
+++ b/onnxruntime/test/optimizer/qdq_transformer_test.cc
@@ -3579,6 +3579,48 @@ TEST(QDQTransformerTests, WhereDummyDqTest_DqWithoutZeroPoint) {
   ASSERT_FALSE(modified);
 }
 
+// Same as WhereDummyDqTest_DqWithoutZeroPoint, but the zero-point input is present as an explicit
+// empty/missing NodeArg placeholder (as ONNX allows for trailing optional inputs) rather than being
+// omitted from the input list entirely. The optimizer must recognize this form too.
+TEST(QDQTransformerTests, WhereDummyDqTest_DqWithMissingZeroPointPlaceholder) {
+  auto& logger = DefaultLoggingManager().DefaultLogger();
+  Model model("WhereDummyDqMissingZpPlaceholderTester", false, logger);
+  Graph& graph = model.MainGraph();
+  ModelTestBuilder builder(graph);
+
+  // DQ branch with 3 inputs, but the 3rd (zero-point) is an empty placeholder, not a real NodeArg.
+  auto* dq_input = builder.MakeInput<uint8_t>({4, 3, 32}, 0, 1);
+  auto* dq_scale = builder.MakeInitializer<float>({}, 0.0, 1.0);
+  auto* dq_zp_placeholder = builder.MakeEmptyInput();
+  auto* where_in1 = builder.MakeIntermediate();
+  builder.AddNode("DequantizeLinear", {dq_input, dq_scale, dq_zp_placeholder}, {where_in1});
+
+  // Other branch is a scalar initializer, matching WhereDummyDq's target pattern.
+  auto* where_in2 = builder.MakeInitializer<float>({}, 0.0, 1.0);
+
+  auto* where_cond = builder.MakeInputBool({4, 3, 32});
+  auto* where_out = builder.MakeIntermediate();
+  builder.AddNode("Where", {where_cond, where_in1, where_in2}, {where_out});
+
+  auto* q_scale = builder.MakeInitializer<float>({}, 0.0, 1.0);
+  auto* q_zp = builder.MakeInitializer<uint8_t>({}, 0.0, 1.0);
+  auto* q_out = builder.MakeOutput();
+  builder.AddNode("QuantizeLinear", {where_out, q_scale, q_zp}, {q_out});
+
+  builder.SetGraphOutputs();
+  ASSERT_STATUS_OK(graph.Resolve());
+
+  auto where_optimizer = std::make_unique<WhereDummyDq>();
+  bool modified = false;
+  ASSERT_STATUS_OK(where_optimizer->Apply(graph, modified, logger));
+
+  std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
+  ASSERT_EQ(op_to_count["Where"], 1);
+  ASSERT_EQ(op_to_count["DequantizeLinear"], 1);  // no dummy DQ inserted
+  ASSERT_EQ(op_to_count["QuantizeLinear"], 1);
+  ASSERT_FALSE(modified);
+}
+
 // Tests WhereDummyDq with non-QuantizeLinear consumers.
 // The optimizer should NOT add dummy DQ nodes when the Where output is not consumed by a QuantizeLinear.
 template <typename ScaleType, typename ZpTypeDq>

--- a/onnxruntime/test/optimizer/transpose_optimizer_test.cc
+++ b/onnxruntime/test/optimizer/transpose_optimizer_test.cc
@@ -15,6 +15,7 @@
 #include "core/optimizer/transpose_optimization/onnx_transpose_optimization.h"
 #include "core/optimizer/transpose_optimization/optimizer_api.h"
 #include "core/optimizer/transpose_optimization/ort_optimizer_utils.h"
+#include "core/optimizer/transpose_optimizer.h"
 #include "core/session/onnxruntime_session_options_config_keys.h"
 
 #include "test/internal_testing_ep/internal_testing_execution_provider.h"
@@ -2552,6 +2553,46 @@ TEST(TransposeOptimizerTests, TestTileNonconstReps) {
                     TransformerLevel::Default,
                     TransformerLevel::Level1,
                     /*opset_version*/ {15, 18, 23});
+}
+
+// A constant 'repeats' initializer shorter than the preceding Transpose's rank is invalid per the
+// Tile spec (repeats must have one entry per input dimension), but the handler must not index into
+// it past its own length. It should bail out and leave both transposes untouched. The Transpose's
+// input is left without a static shape/rank so that ONNX's own Tile shape inference (which requires
+// the data input's shape to validate repeats.size() against the rank) cannot catch the mismatch
+// ahead of time, matching how the handler can be reached with an unvalidated 'repeats' length.
+TEST(TransposeOptimizerTests, TestTileRepeatsRankMismatchNoOpt) {
+  auto pre_graph_checker = [&](Graph& graph) {
+    TEST_RETURN_IF_NOT(CountOpsInGraph(graph)["Transpose"] == 2);
+    TEST_RETURN_IF_NOT(CountOpsInGraph(graph)["Tile"] == 1);
+    return Status::OK();
+  };
+  auto post_graph_checker = [&](Graph& graph) {
+    TEST_RETURN_IF_NOT(CountOpsInGraph(graph)["Transpose"] == 2);
+    TEST_RETURN_IF_NOT(CountOpsInGraph(graph)["Tile"] == 1);
+    return Status::OK();
+  };
+
+  auto build_test_case = [&](ModelTestBuilder& builder) {
+    auto* input0_arg = MakeInput<float>(builder, std::nullopt, {2, 4, 6, 3}, 0.0f, 1.0f);
+    // Only 2 entries although the Transpose's perm below implies rank 4.
+    auto* const_1 = builder.MakeInitializer<int64_t>({2}, {1, 2});
+    auto* transpose_1_out_0 = builder.MakeIntermediate();
+    auto* tile_1_out_0 = builder.MakeIntermediate();
+    auto* transpose_2_out_0 = builder.MakeOutput();
+
+    auto& transpose_1 = builder.AddNode("Transpose", {input0_arg}, {transpose_1_out_0});
+    transpose_1.AddAttribute("perm", std::vector<int64_t>{0, 3, 1, 2});
+    builder.AddNode("Tile", {transpose_1_out_0, const_1}, {tile_1_out_0});
+    auto& transpose_2 = builder.AddNode("Transpose", {tile_1_out_0}, {transpose_2_out_0});
+    transpose_2.AddAttribute("perm", std::vector<int64_t>{0, 2, 3, 1});
+  };
+
+  AllocatorPtr cpu_allocator = TestCPUExecutionProvider()->CreatePreferredAllocators()[0];
+  std::unique_ptr<GraphTransformer> transformer = std::make_unique<TransposeOptimizer>(std::move(cpu_allocator));
+  ASSERT_STATUS_OK(TestGraphTransformer(build_test_case, 18, DefaultLoggingManager().DefaultLogger(),
+                                        std::move(transformer), TransformerLevel::Level1, 1,
+                                        pre_graph_checker, post_graph_checker));
 }
 
 TEST(TransposeOptimizerTests, TestArgMinNoAxisKeepdimsTrue) {


### PR DESCRIPTION
## Description

Three graph-optimizer passes that run at model load time index into a vector using a
count/axis/index taken directly from the model graph, without validating it against the
bounds of the vector being indexed:

1. **`GatherSliceToSplitFusion`** (`onnxruntime/core/optimizer/gather_fusion.cc`): reads an
   `axis` from a candidate `Gather`/`Slice` consumer and indexes the shared input's shape
   with it (`shape->dim(axis)`). ONNX's own shape inference for `Gather`/`Slice` only range-checks
   `axis` when it can resolve the shapes of all relevant inputs; if it cannot (e.g. an unresolvable
   indices/axis input shape), that check is skipped, and this fusion pass previously had no
   independent bounds check of its own.

2. **Transpose optimizer's `HandleTile`** (`onnxruntime/core/optimizer/transpose_optimization/onnx_transpose_optimization.cc`):
   assumes a constant `Tile` `repeats` initializer has one entry per dimension of the
   preceding `Transpose`'s rank (taken from that node's `perm` attribute), and indexes it
   accordingly. Similarly, ONNX's own `Tile` shape inference only validates `repeats.size()`
   against the input rank when it can resolve the data input's shape; if it cannot, this
   validation is skipped, and there was no independent check before indexing `repeats`.

3. **`WhereDummyDq`** (`onnxruntime/core/optimizer/qdq_transformer/where_dummy_dq.cc`):
   unconditionally reads `DequantizeLinear`'s 3rd input (`x_zero_point`, at index 2) to
   fetch its initializer. Per the ONNX spec, `x_zero_point` is an **optional** input, so a
   valid `DequantizeLinear` node can have only 2 inputs (`x`, `x_scale`), making this an
   out-of-bounds read on `InputDefs()`.

## Fix

Each pass now validates the model-supplied value against the actual bound before using it
to index, and safely skips the optimization (rather than asserting/crashing) when the value
is out of range:

- `GatherSliceToSplitFusion`: skip fusing this candidate if `axis < 0 || axis >= rank`.
- `HandleTile`: return `false` (leave the node alone) if `repeats.size() != rank`.
- `WhereDummyDq`: log a warning and skip inserting a dummy DQ if the DQ node has fewer than
  3 inputs.

## Other execution providers

All three passes are execution-provider-agnostic graph transformations that run before EP
partitioning, so no EP-specific (e.g. CUDA) equivalent exists or needs a separate fix.

## Testing

Added regression tests, using `TestGraphTransformer` (which applies the transformer and
inspects the resulting graph without executing the model, since some of the malformed
inputs used to reach these code paths are not valid inputs to actually run):

- `graph_transform_test.cc`: `GatherSliceToSplitFusion_OutOfRangeAxis` — a `Gather` node
  with an out-of-range `axis`, where the sibling indices input has no static shape so
  ONNX's own inference cannot catch it ahead of time. Verifies the fusion pass leaves the
  graph unchanged.
- `transpose_optimizer_test.cc`: `TestTileRepeatsRankMismatchNoOpt` — a `Transpose -> Tile
  -> Transpose` pattern where `repeats` is shorter than the rank implied by the
  `Transpose`'s `perm`, with the data input's shape left unresolved. Verifies both
  Transposes and the Tile remain untouched.
- `qdq_transformer_test.cc`: `WhereDummyDqTest_DqWithoutZeroPoint` — a `DequantizeLinear`
  with only 2 inputs (no zero-point) feeding a `Where` node. Verifies no dummy DQ is
  inserted and the graph is otherwise unmodified.

All three new tests were confirmed to fail (or crash) when the corresponding fix was
temporarily reverted, and pass cleanly with the fix in place. The full
`GraphTransformationTests`, `TransposeOptimizerTests`, and `QDQTransformerTests` suites
were also run locally with no regressions.

## Motivation

These three passes run by default during `CreateSession` (default optimization level),
processing whatever graph structure the model declares. Guarding the indexing operations
against out-of-range model-supplied values makes these passes resilient to malformed or
adversarial models without changing behavior for well-formed ones.