### PR TITLE
Validate SkipLayerNorm prepacked input shapes

### DIFF
--- a/onnxruntime/contrib_ops/cpu/skip_layer_norm.cc
+++ b/onnxruntime/contrib_ops/cpu/skip_layer_norm.cc
@@ -114,6 +114,9 @@ template <typename T, bool simplified>
 SkipLayerNorm<T, simplified>::SkipLayerNorm(const OpKernelInfo& op_kernel_info)
     : OpKernel(op_kernel_info),
       prepacked_skip_fp32_size_(0),
+      prepacked_gamma_fp32_size_(0),
+      prepacked_beta_fp32_size_(0),
+      prepacked_bias_fp32_size_(0),
       prepacked_skip_fp32_data_(nullptr),
       prepacked_gamma_fp32_data_(nullptr),
       prepacked_beta_fp32_data_(nullptr),
@@ -136,6 +139,32 @@ Status SkipLayerNorm<T, simplified>::Compute(OpKernelContext* p_ctx) const {
   const auto& input_dims = input->Shape().GetDims();
   size_t input_dims_size = input_dims.size();
   int hidden_size = static_cast<int>(input_dims[input_dims_size - 1]);
+  const size_t hidden_size_size = static_cast<size_t>(hidden_size);
+  ORT_RETURN_IF(hidden_size <= 0, "hidden_size must be positive.");
+
+  if (prepacked_skip_fp32_data_) {
+    ORT_RETURN_IF(prepacked_skip_fp32_size_ < hidden_size_size || (prepacked_skip_fp32_size_ % hidden_size_size) != 0,
+                  "Prepacked skip length does not match hidden_size. hidden_size=", hidden_size,
+                  ", prepacked skip length=", prepacked_skip_fp32_size_, ".");
+  }
+
+  if (prepacked_gamma_fp32_data_) {
+    ORT_RETURN_IF(prepacked_gamma_fp32_size_ != hidden_size_size,
+                  "Prepacked gamma length does not match hidden_size. hidden_size=", hidden_size,
+                  ", prepacked gamma length=", prepacked_gamma_fp32_size_, ".");
+  }
+
+  if (prepacked_beta_fp32_data_) {
+    ORT_RETURN_IF(prepacked_beta_fp32_size_ != hidden_size_size,
+                  "Prepacked beta length does not match hidden_size. hidden_size=", hidden_size,
+                  ", prepacked beta length=", prepacked_beta_fp32_size_, ".");
+  }
+
+  if (prepacked_bias_fp32_data_) {
+    ORT_RETURN_IF(prepacked_bias_fp32_size_ != hidden_size_size,
+                  "Prepacked bias length does not match hidden_size. hidden_size=", hidden_size,
+                  ", prepacked bias length=", prepacked_bias_fp32_size_, ".");
+  }
 
   ORT_RETURN_IF_ERROR(skip_layer_norm_helper::CheckPotentiallyPrepackedInputs<Tensor>(input,
                                                                                       skip,
@@ -259,17 +288,21 @@ Status SkipLayerNorm<T, simplified>::PrePack(const Tensor& tensor, int input_idx
     prepacked_skip_fp32_size_ = tensor.Shape().Size();
     ConvertMLFloat16ToFloatIfNeeded(tensor, alloc, prepacked_skip_fp32_data_, is_packed);
   } else if (input_idx == 2) {  // gamma
+    prepacked_gamma_fp32_size_ = tensor.Shape().Size();
     ConvertMLFloat16ToFloatIfNeeded(tensor, alloc, prepacked_gamma_fp32_data_, is_packed);
   } else if (input_idx == 3) {
     if constexpr (simplified) {
       // bias
+      prepacked_bias_fp32_size_ = tensor.Shape().Size();
       ConvertMLFloat16ToFloatIfNeeded(tensor, alloc, prepacked_bias_fp32_data_, is_packed);
     } else {
       // beta
+      prepacked_beta_fp32_size_ = tensor.Shape().Size();
       ConvertMLFloat16ToFloatIfNeeded(tensor, alloc, prepacked_beta_fp32_data_, is_packed);
     }
   } else if (input_idx == 4) {  // bias
     ORT_ENFORCE(!simplified, "SkipSimplifiedLayerNormalization should only has 4 inputs (input, skip, gamma, and beta). Got 5.");
+    prepacked_bias_fp32_size_ = tensor.Shape().Size();
     ConvertMLFloat16ToFloatIfNeeded(tensor, alloc, prepacked_bias_fp32_data_, is_packed);
   }
 

--- a/onnxruntime/contrib_ops/cpu/skip_layer_norm.cc
+++ b/onnxruntime/contrib_ops/cpu/skip_layer_norm.cc
@@ -141,7 +141,6 @@ Status SkipLayerNorm<T, simplified>::Compute(OpKernelContext* p_ctx) const {
   const int64_t hidden_size_i64 = input_dims[input_dims_size - 1];
   ORT_RETURN_IF(hidden_size_i64 <= 0, "hidden_size must be positive.");
   const int hidden_size = static_cast<int>(hidden_size_i64);
-  const size_t hidden_size_size = static_cast<size_t>(hidden_size_i64);
 
   if (prepacked_skip_fp32_data_) {
     ORT_RETURN_IF(prepacked_skip_fp32_size_ < hidden_size_i64 || (prepacked_skip_fp32_size_ % hidden_size_i64) != 0,
@@ -150,19 +149,19 @@ Status SkipLayerNorm<T, simplified>::Compute(OpKernelContext* p_ctx) const {
   }
 
   if (prepacked_gamma_fp32_data_) {
-    ORT_RETURN_IF(prepacked_gamma_fp32_size_ != hidden_size_size,
+    ORT_RETURN_IF(prepacked_gamma_fp32_size_ != hidden_size_i64,
                   "Prepacked gamma length does not match hidden_size. hidden_size=", hidden_size,
                   ", prepacked gamma length=", prepacked_gamma_fp32_size_, ".");
   }
 
   if (prepacked_beta_fp32_data_) {
-    ORT_RETURN_IF(prepacked_beta_fp32_size_ != hidden_size_size,
+    ORT_RETURN_IF(prepacked_beta_fp32_size_ != hidden_size_i64,
                   "Prepacked beta length does not match hidden_size. hidden_size=", hidden_size,
                   ", prepacked beta length=", prepacked_beta_fp32_size_, ".");
   }
 
   if (prepacked_bias_fp32_data_) {
-    ORT_RETURN_IF(prepacked_bias_fp32_size_ != hidden_size_size,
+    ORT_RETURN_IF(prepacked_bias_fp32_size_ != hidden_size_i64,
                   "Prepacked bias length does not match hidden_size. hidden_size=", hidden_size,
                   ", prepacked bias length=", prepacked_bias_fp32_size_, ".");
   }

--- a/onnxruntime/contrib_ops/cpu/skip_layer_norm.cc
+++ b/onnxruntime/contrib_ops/cpu/skip_layer_norm.cc
@@ -138,13 +138,14 @@ Status SkipLayerNorm<T, simplified>::Compute(OpKernelContext* p_ctx) const {
 
   const auto& input_dims = input->Shape().GetDims();
   size_t input_dims_size = input_dims.size();
-  int hidden_size = static_cast<int>(input_dims[input_dims_size - 1]);
-  const size_t hidden_size_size = static_cast<size_t>(hidden_size);
-  ORT_RETURN_IF(hidden_size <= 0, "hidden_size must be positive.");
+  const int64_t hidden_size_i64 = input_dims[input_dims_size - 1];
+  ORT_RETURN_IF(hidden_size_i64 <= 0, "hidden_size must be positive.");
+  const int hidden_size = static_cast<int>(hidden_size_i64);
+  const size_t hidden_size_size = static_cast<size_t>(hidden_size_i64);
 
   if (prepacked_skip_fp32_data_) {
-    ORT_RETURN_IF(prepacked_skip_fp32_size_ < hidden_size_size || (prepacked_skip_fp32_size_ % hidden_size_size) != 0,
-                  "Prepacked skip length does not match hidden_size. hidden_size=", hidden_size,
+    ORT_RETURN_IF(prepacked_skip_fp32_size_ < hidden_size_i64 || (prepacked_skip_fp32_size_ % hidden_size_i64) != 0,
+                  "Prepacked skip length does not match hidden_size. hidden_size=", hidden_size_i64,
                   ", prepacked skip length=", prepacked_skip_fp32_size_, ".");
   }
 

--- a/onnxruntime/contrib_ops/cpu/skip_layer_norm.cc
+++ b/onnxruntime/contrib_ops/cpu/skip_layer_norm.cc
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <limits>
+
 #include "core/framework/tensor.h"
 #include "core/mlas/inc/mlas.h"
 #include "core/util/math_cpuonly.h"
@@ -102,7 +104,9 @@ void ConvertMLFloat16ToFloatIfNeeded(const Tensor& tensor, AllocatorPtr alloc, I
     auto tensor_size = static_cast<size_t>(tensor.Shape().Size());
     auto float_ptr = IAllocator::MakeUniquePtr<float>(alloc, tensor_size, true);
 
-    MlasConvertHalfToFloatBuffer(tensor_data_ptr, float_ptr.get(), tensor_size);
+    if (tensor_size > 0) {
+      MlasConvertHalfToFloatBuffer(tensor_data_ptr, float_ptr.get(), tensor_size);
+    }
     dest = std::move(float_ptr);
     is_packed = true;
   }
@@ -113,10 +117,10 @@ void ConvertMLFloat16ToFloatIfNeeded(const Tensor& tensor, AllocatorPtr alloc, I
 template <typename T, bool simplified>
 SkipLayerNorm<T, simplified>::SkipLayerNorm(const OpKernelInfo& op_kernel_info)
     : OpKernel(op_kernel_info),
-      prepacked_skip_fp32_size_(0),
-      prepacked_gamma_fp32_size_(0),
-      prepacked_beta_fp32_size_(0),
-      prepacked_bias_fp32_size_(0),
+      has_prepacked_skip_(false),
+      has_prepacked_gamma_(false),
+      has_prepacked_beta_(false),
+      has_prepacked_bias_(false),
       prepacked_skip_fp32_data_(nullptr),
       prepacked_gamma_fp32_data_(nullptr),
       prepacked_beta_fp32_data_(nullptr),
@@ -128,42 +132,40 @@ SkipLayerNorm<T, simplified>::SkipLayerNorm(const OpKernelInfo& op_kernel_info)
 template <typename T, bool simplified>
 Status SkipLayerNorm<T, simplified>::Compute(OpKernelContext* p_ctx) const {
   const Tensor* input = p_ctx->Input<Tensor>(0);
-  const Tensor* skip = prepacked_skip_fp32_data_ ? nullptr : p_ctx->Input<Tensor>(1);
-  const Tensor* gamma = prepacked_gamma_fp32_data_ ? nullptr : p_ctx->Input<Tensor>(2);
-  const Tensor* beta = simplified ? nullptr : (prepacked_beta_fp32_data_ ? nullptr : p_ctx->Input<Tensor>(3));
-  const Tensor* bias = prepacked_bias_fp32_data_ ? nullptr : p_ctx->Input<Tensor>(simplified ? 3 : 4);
-  Tensor* output = p_ctx->Output(0, input->Shape());
-  // For inferencing, we support one more optional output which is the sum of the input and skip tensors
-  Tensor* skip_input_bias_add_output = p_ctx->Output(3, input->Shape());
+  const Tensor* skip = has_prepacked_skip_ ? nullptr : p_ctx->Input<Tensor>(1);
+  const Tensor* gamma = has_prepacked_gamma_ ? nullptr : p_ctx->Input<Tensor>(2);
+  const Tensor* beta = simplified ? nullptr : (has_prepacked_beta_ ? nullptr : p_ctx->Input<Tensor>(3));
+  const Tensor* bias = has_prepacked_bias_ ? nullptr : p_ctx->Input<Tensor>(simplified ? 3 : 4);
 
   const auto& input_dims = input->Shape().GetDims();
   size_t input_dims_size = input_dims.size();
+  if (input_dims_size != 3 && input_dims_size != 2) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                           "input is expected to have 3 or 2 dimensions, got ", input_dims_size);
+  }
+
   const int64_t hidden_size_i64 = input_dims[input_dims_size - 1];
-  ORT_RETURN_IF(hidden_size_i64 <= 0, "hidden_size must be positive.");
+  if (hidden_size_i64 <= 0 || hidden_size_i64 > std::numeric_limits<int>::max()) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                           "hidden_size must be positive and no greater than ", std::numeric_limits<int>::max(),
+                           ". Got ", hidden_size_i64, ".");
+  }
   const int hidden_size = static_cast<int>(hidden_size_i64);
 
-  if (prepacked_skip_fp32_data_) {
-    ORT_RETURN_IF(prepacked_skip_fp32_size_ < hidden_size_i64 || (prepacked_skip_fp32_size_ % hidden_size_i64) != 0,
-                  "Prepacked skip length does not match hidden_size. hidden_size=", hidden_size_i64,
-                  ", prepacked skip length=", prepacked_skip_fp32_size_, ".");
+  if (has_prepacked_skip_) {
+    ORT_RETURN_IF_ERROR(skip_layer_norm_helper::CheckSkipShape(input->Shape(), prepacked_skip_shape_));
   }
 
-  if (prepacked_gamma_fp32_data_) {
-    ORT_RETURN_IF(prepacked_gamma_fp32_size_ != hidden_size_i64,
-                  "Prepacked gamma length does not match hidden_size. hidden_size=", hidden_size,
-                  ", prepacked gamma length=", prepacked_gamma_fp32_size_, ".");
+  if (has_prepacked_gamma_) {
+    ORT_RETURN_IF_ERROR(skip_layer_norm_helper::CheckGammaShape(prepacked_gamma_shape_, hidden_size));
   }
 
-  if (prepacked_beta_fp32_data_) {
-    ORT_RETURN_IF(prepacked_beta_fp32_size_ != hidden_size_i64,
-                  "Prepacked beta length does not match hidden_size. hidden_size=", hidden_size,
-                  ", prepacked beta length=", prepacked_beta_fp32_size_, ".");
+  if (has_prepacked_beta_) {
+    ORT_RETURN_IF_ERROR(skip_layer_norm_helper::CheckBetaShape(prepacked_beta_shape_, hidden_size));
   }
 
-  if (prepacked_bias_fp32_data_) {
-    ORT_RETURN_IF(prepacked_bias_fp32_size_ != hidden_size_i64,
-                  "Prepacked bias length does not match hidden_size. hidden_size=", hidden_size,
-                  ", prepacked bias length=", prepacked_bias_fp32_size_, ".");
+  if (has_prepacked_bias_) {
+    ORT_RETURN_IF_ERROR(skip_layer_norm_helper::CheckBiasShape(prepacked_bias_shape_, hidden_size));
   }
 
   ORT_RETURN_IF_ERROR(skip_layer_norm_helper::CheckPotentiallyPrepackedInputs<Tensor>(input,
@@ -173,8 +175,12 @@ Status SkipLayerNorm<T, simplified>::Compute(OpKernelContext* p_ctx) const {
                                                                                       bias,
                                                                                       hidden_size,
                                                                                       input_dims_size,
-                                                                                      prepacked_skip_fp32_data_ != nullptr,
-                                                                                      prepacked_gamma_fp32_data_ != nullptr));
+                                                                                      has_prepacked_skip_,
+                                                                                      has_prepacked_gamma_));
+
+  Tensor* output = p_ctx->Output(0, input->Shape());
+  // For inferencing, we support one more optional output which is the sum of the input and skip tensors
+  Tensor* skip_input_bias_add_output = p_ctx->Output(3, input->Shape());
 
   int64_t task_count = input->Shape().SizeToDimension(input_dims_size - 1);
 
@@ -188,7 +194,7 @@ Status SkipLayerNorm<T, simplified>::Compute(OpKernelContext* p_ctx) const {
 
   // For inferencing, we support one more optional output which is the sum of the input and skip tensors
   T* skip_input_bias_add_output_data = skip_input_bias_add_output == nullptr ? nullptr : skip_input_bias_add_output->MutableData<T>();
-  const int64_t skip_size = skip ? skip->Shape().Size() : prepacked_skip_fp32_size_;
+  const int64_t skip_size = skip ? skip->Shape().Size() : prepacked_skip_shape_.Size();
 
   if constexpr (std::is_same_v<T, MLFloat16>) {
     const size_t total_data_size = static_cast<size_t>(input->Shape().Size());
@@ -228,7 +234,7 @@ Status SkipLayerNorm<T, simplified>::Compute(OpKernelContext* p_ctx) const {
       skip_fp32 = IAllocator::MakeUniquePtr<float>(alloc, static_cast<size_t>(skip_size));
       MlasConvertHalfToFloatBuffer(skip_data, skip_fp32.get(), static_cast<size_t>(skip_size));
       skip_data_f = skip_fp32.get();
-    } else if (prepacked_skip_fp32_data_) {
+    } else if (has_prepacked_skip_) {
       skip_data_f = prepacked_skip_fp32_data_.get();
     }
 
@@ -236,7 +242,7 @@ Status SkipLayerNorm<T, simplified>::Compute(OpKernelContext* p_ctx) const {
       gamma_fp32 = IAllocator::MakeUniquePtr<float>(alloc, num_elems);
       MlasConvertHalfToFloatBuffer(gamma_data, gamma_fp32.get(), num_elems);
       gamma_data_f = gamma_fp32.get();
-    } else if (prepacked_gamma_fp32_data_) {
+    } else if (has_prepacked_gamma_) {
       gamma_data_f = prepacked_gamma_fp32_data_.get();
     }
 
@@ -244,7 +250,7 @@ Status SkipLayerNorm<T, simplified>::Compute(OpKernelContext* p_ctx) const {
       beta_fp32 = IAllocator::MakeUniquePtr<float>(alloc, num_elems);
       MlasConvertHalfToFloatBuffer(beta_data, beta_fp32.get(), num_elems);
       beta_data_f = beta_fp32.get();
-    } else if (prepacked_beta_fp32_data_) {
+    } else if (has_prepacked_beta_) {
       beta_data_f = prepacked_beta_fp32_data_.get();
     }
 
@@ -252,7 +258,7 @@ Status SkipLayerNorm<T, simplified>::Compute(OpKernelContext* p_ctx) const {
       bias_fp32 = IAllocator::MakeUniquePtr<float>(alloc, num_elems);
       MlasConvertHalfToFloatBuffer(bias_data, bias_fp32.get(), num_elems);
       bias_data_f = bias_fp32.get();
-    } else if (prepacked_bias_fp32_data_) {
+    } else if (has_prepacked_bias_) {
       bias_data_f = prepacked_bias_fp32_data_.get();
     }
 
@@ -285,25 +291,40 @@ Status SkipLayerNorm<T, simplified>::PrePack(const Tensor& tensor, int input_idx
   ORT_UNUSED_PARAMETER(prepacked_weights);
   is_packed = false;
   if (input_idx == 1) {  // skip
-    prepacked_skip_fp32_size_ = tensor.Shape().Size();
     ConvertMLFloat16ToFloatIfNeeded(tensor, alloc, prepacked_skip_fp32_data_, is_packed);
+    if (is_packed) {
+      prepacked_skip_shape_ = tensor.Shape();
+      has_prepacked_skip_ = true;
+    }
   } else if (input_idx == 2) {  // gamma
-    prepacked_gamma_fp32_size_ = tensor.Shape().Size();
     ConvertMLFloat16ToFloatIfNeeded(tensor, alloc, prepacked_gamma_fp32_data_, is_packed);
+    if (is_packed) {
+      prepacked_gamma_shape_ = tensor.Shape();
+      has_prepacked_gamma_ = true;
+    }
   } else if (input_idx == 3) {
     if constexpr (simplified) {
       // bias
-      prepacked_bias_fp32_size_ = tensor.Shape().Size();
       ConvertMLFloat16ToFloatIfNeeded(tensor, alloc, prepacked_bias_fp32_data_, is_packed);
+      if (is_packed) {
+        prepacked_bias_shape_ = tensor.Shape();
+        has_prepacked_bias_ = true;
+      }
     } else {
       // beta
-      prepacked_beta_fp32_size_ = tensor.Shape().Size();
       ConvertMLFloat16ToFloatIfNeeded(tensor, alloc, prepacked_beta_fp32_data_, is_packed);
+      if (is_packed) {
+        prepacked_beta_shape_ = tensor.Shape();
+        has_prepacked_beta_ = true;
+      }
     }
   } else if (input_idx == 4) {  // bias
     ORT_ENFORCE(!simplified, "SkipSimplifiedLayerNormalization should only has 4 inputs (input, skip, gamma, and beta). Got 5.");
-    prepacked_bias_fp32_size_ = tensor.Shape().Size();
     ConvertMLFloat16ToFloatIfNeeded(tensor, alloc, prepacked_bias_fp32_data_, is_packed);
+    if (is_packed) {
+      prepacked_bias_shape_ = tensor.Shape();
+      has_prepacked_bias_ = true;
+    }
   }
 
   return Status::OK();

--- a/onnxruntime/contrib_ops/cpu/skip_layer_norm.h
+++ b/onnxruntime/contrib_ops/cpu/skip_layer_norm.h
@@ -22,9 +22,9 @@ class SkipLayerNorm final : public OpKernel {
  private:
   float epsilon_;
   int64_t prepacked_skip_fp32_size_;
-  size_t prepacked_gamma_fp32_size_;
-  size_t prepacked_beta_fp32_size_;
-  size_t prepacked_bias_fp32_size_;
+  int64_t prepacked_gamma_fp32_size_;
+  int64_t prepacked_beta_fp32_size_;
+  int64_t prepacked_bias_fp32_size_;
   IAllocatorUniquePtr<float> prepacked_skip_fp32_data_;
   IAllocatorUniquePtr<float> prepacked_gamma_fp32_data_;
   IAllocatorUniquePtr<float> prepacked_beta_fp32_data_;

--- a/onnxruntime/contrib_ops/cpu/skip_layer_norm.h
+++ b/onnxruntime/contrib_ops/cpu/skip_layer_norm.h
@@ -22,6 +22,9 @@ class SkipLayerNorm final : public OpKernel {
  private:
   float epsilon_;
   int64_t prepacked_skip_fp32_size_;
+  size_t prepacked_gamma_fp32_size_;
+  size_t prepacked_beta_fp32_size_;
+  size_t prepacked_bias_fp32_size_;
   IAllocatorUniquePtr<float> prepacked_skip_fp32_data_;
   IAllocatorUniquePtr<float> prepacked_gamma_fp32_data_;
   IAllocatorUniquePtr<float> prepacked_beta_fp32_data_;

--- a/onnxruntime/contrib_ops/cpu/skip_layer_norm.h
+++ b/onnxruntime/contrib_ops/cpu/skip_layer_norm.h
@@ -21,10 +21,14 @@ class SkipLayerNorm final : public OpKernel {
 
  private:
   float epsilon_;
-  int64_t prepacked_skip_fp32_size_;
-  int64_t prepacked_gamma_fp32_size_;
-  int64_t prepacked_beta_fp32_size_;
-  int64_t prepacked_bias_fp32_size_;
+  TensorShape prepacked_skip_shape_;
+  TensorShape prepacked_gamma_shape_;
+  TensorShape prepacked_beta_shape_;
+  TensorShape prepacked_bias_shape_;
+  bool has_prepacked_skip_;
+  bool has_prepacked_gamma_;
+  bool has_prepacked_beta_;
+  bool has_prepacked_bias_;
   IAllocatorUniquePtr<float> prepacked_skip_fp32_data_;
   IAllocatorUniquePtr<float> prepacked_gamma_fp32_data_;
   IAllocatorUniquePtr<float> prepacked_beta_fp32_data_;

--- a/onnxruntime/contrib_ops/cpu/skip_layer_norm_helper.h
+++ b/onnxruntime/contrib_ops/cpu/skip_layer_norm_helper.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "core/common/common.h"
+#include "core/framework/tensor_shape.h"
 #include "core/providers/common.h"
 
 namespace onnxruntime {
@@ -12,10 +13,10 @@ namespace skip_layer_norm_helper {
 
 namespace {
 
-template <typename T>
-Status CheckSkip(const T* input, const T* skip, size_t input_dims_size_check) {
-  const auto& input_dims_check = input->Shape().GetDims();
-  const auto& skip_dims_check = skip->Shape().GetDims();
+inline Status CheckSkipShape(const TensorShape& input_shape, const TensorShape& skip_shape) {
+  const auto& input_dims_check = input_shape.GetDims();
+  const auto& skip_dims_check = skip_shape.GetDims();
+  const size_t input_dims_size_check = input_dims_check.size();
   size_t skip_dims_size_check = skip_dims_check.size();
 
   if (skip_dims_size_check != 3 && skip_dims_size_check != 2) {
@@ -23,7 +24,7 @@ Status CheckSkip(const T* input, const T* skip, size_t input_dims_size_check) {
                            "skip is expected to have 3 or 2 dimensions, got ", skip_dims_size_check);
   }
 
-  if ((input->Shape() != skip->Shape()) && ((skip_dims_check[0] != 1 || skip_dims_size_check != 2) && input_dims_size_check != 3)) {
+  if ((input_shape != skip_shape) && ((skip_dims_check[0] != 1 || skip_dims_size_check != 2) && input_dims_size_check != 3)) {
     return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
                            "skip is expected to have same shape as input or, a batch size of 1 or no batch size when input has 3 dimensions");
   }
@@ -37,8 +38,12 @@ Status CheckSkip(const T* input, const T* skip, size_t input_dims_size_check) {
 }
 
 template <typename T>
-Status CheckGamma(const T* gamma, int hidden_size_check) {
-  const auto& gamma_dims = gamma->Shape().GetDims();
+Status CheckSkip(const T* input, const T* skip) {
+  return CheckSkipShape(input->Shape(), skip->Shape());
+}
+
+inline Status CheckGammaShape(const TensorShape& gamma_shape, int hidden_size_check) {
+  const auto& gamma_dims = gamma_shape.GetDims();
 
   if (gamma_dims.size() != 1) {
     return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
@@ -54,19 +59,42 @@ Status CheckGamma(const T* gamma, int hidden_size_check) {
 }
 
 template <typename T>
+Status CheckGamma(const T* gamma, int hidden_size_check) {
+  return CheckGammaShape(gamma->Shape(), hidden_size_check);
+}
+
+inline Status CheckBetaShape(const TensorShape& beta_shape, int hidden_size_check) {
+  const auto& beta_dims = beta_shape.GetDims();
+
+  if (beta_dims.size() != 1) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                           "beta is expected to have 1 dimension, got ", beta_dims.size());
+  }
+
+  if (beta_dims[0] != hidden_size_check) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                           "Last dimension of beta and input does not match");
+  }
+
+  return Status::OK();
+}
+
+template <typename T>
 Status CheckBeta(const T* beta, int hidden_size_check) {
-  if (nullptr != beta) {
-    const auto& beta_dims = beta->Shape().GetDims();
+  return beta == nullptr ? Status::OK() : CheckBetaShape(beta->Shape(), hidden_size_check);
+}
 
-    if (beta_dims.size() != 1) {
-      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
-                             "beta is expected to have 1 dimension, got ", beta_dims.size());
-    }
+inline Status CheckBiasShape(const TensorShape& bias_shape, int hidden_size_check) {
+  const auto& bias_dims = bias_shape.GetDims();
 
-    if (beta_dims[0] != hidden_size_check) {
-      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
-                             "Last dimension of beta and input does not match");
-    }
+  if (bias_dims.size() != 1) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                           "bias is expected to have 1 dimension, got ", bias_dims.size());
+  }
+
+  if (bias_dims[0] != hidden_size_check) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                           "Last dimension of bias and input does not match");
   }
 
   return Status::OK();
@@ -74,21 +102,7 @@ Status CheckBeta(const T* beta, int hidden_size_check) {
 
 template <typename T>
 Status CheckBias(const T* bias, int hidden_size_check) {
-  if (nullptr != bias) {
-    const auto& bias_dims = bias->Shape().GetDims();
-
-    if (bias_dims.size() != 1) {
-      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
-                             "bias is expected to have 1 dimension, got ", bias_dims.size());
-    }
-
-    if (bias_dims[0] != hidden_size_check) {
-      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
-                             "Last dimension of bias and input does not match");
-    }
-  }
-
-  return Status::OK();
+  return bias == nullptr ? Status::OK() : CheckBiasShape(bias->Shape(), hidden_size_check);
 }
 
 }  // anonymous namespace
@@ -106,7 +120,7 @@ Status CheckInputs(const T* input,
                            "input is expected to have 3 or 2 dimensions, got ", input_dims_size_check);
   }
 
-  auto status = CheckSkip<T>(input, skip, input_dims_size_check);
+  auto status = CheckSkip<T>(input, skip);
   if (status != Status::OK()) {
     return status;
   }
@@ -145,7 +159,7 @@ Status CheckPotentiallyPrepackedInputs(const T* input,
   }
 
   if (nullptr != skip) {
-    auto status = CheckSkip<T>(input, skip, input_dims_size_check);
+    auto status = CheckSkip<T>(input, skip);
     if (status != Status::OK()) {
       return status;
     }

--- a/onnxruntime/test/contrib_ops/skiplayernorm_op_test.cc
+++ b/onnxruntime/test/contrib_ops/skiplayernorm_op_test.cc
@@ -252,7 +252,7 @@ TEST(SkipLayerNormTest, SkipLayerNormPrePackRejectsShortGamma) {
 
   std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
   execution_providers.push_back(std::move(cpu));
-  test.Run(OpTester::ExpectResult::kExpectFailure, "Prepacked gamma length does not match hidden_size.",
+  test.Run(OpTester::ExpectResult::kExpectFailure, "Last dimension of gamma and input does not match",
            {}, nullptr, &execution_providers);
 }
 
@@ -272,7 +272,7 @@ TEST(SkipLayerNormTest, SkipLayerNormPrePackRejectsShortSkip) {
 
   std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
   execution_providers.push_back(std::move(cpu));
-  test.Run(OpTester::ExpectResult::kExpectFailure, "Prepacked skip length does not match hidden_size.",
+  test.Run(OpTester::ExpectResult::kExpectFailure, "last two dimensions of skip needs to be same as input",
            {}, nullptr, &execution_providers);
 }
 
@@ -292,7 +292,7 @@ TEST(SkipLayerNormTest, SkipLayerNormPrePackRejectsShortBeta) {
 
   std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
   execution_providers.push_back(std::move(cpu));
-  test.Run(OpTester::ExpectResult::kExpectFailure, "Prepacked beta length does not match hidden_size.",
+  test.Run(OpTester::ExpectResult::kExpectFailure, "Last dimension of beta and input does not match",
            {}, nullptr, &execution_providers);
 }
 
@@ -313,7 +313,7 @@ TEST(SkipLayerNormTest, SkipLayerNormPrePackRejectsShortBias) {
 
   std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
   execution_providers.push_back(std::move(cpu));
-  test.Run(OpTester::ExpectResult::kExpectFailure, "Prepacked bias length does not match hidden_size.",
+  test.Run(OpTester::ExpectResult::kExpectFailure, "Last dimension of bias and input does not match",
            {}, nullptr, &execution_providers);
 }
 
@@ -333,8 +333,47 @@ TEST(SkipLayerNormTest, SkipSimplifiedLayerNormPrePackRejectsShortBias) {
 
   std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
   execution_providers.push_back(std::move(cpu));
-  test.Run(OpTester::ExpectResult::kExpectFailure, "Prepacked bias length does not match hidden_size.",
+  test.Run(OpTester::ExpectResult::kExpectFailure, "Last dimension of bias and input does not match",
            {}, nullptr, &execution_providers);
+}
+
+TEST(SkipLayerNormTest, SkipLayerNormPrePackRejectsMismatchedSkipShape) {
+  auto cpu = DefaultCpuExecutionProvider();
+  ASSERT_NE(cpu, nullptr);
+
+  OpTester test("SkipLayerNormalization", 1, onnxruntime::kMSDomain);
+  test.AddAttribute<float>("epsilon", 1e-05f);
+
+  const std::vector<int64_t> input_output_dims = {1, 5, 2};
+  test.AddInput<MLFloat16>("input", input_output_dims, ToFloat16(std::vector<float>(10, 1.f)));
+  test.AddInput<MLFloat16>("skip", std::vector<int64_t>{1, 3, 2}, ToFloat16(std::vector<float>(6, 1.f)), true);
+  test.AddInput<MLFloat16>("gamma", std::vector<int64_t>{2}, ToFloat16({1.f, 1.f}), true);
+  test.AddInput<MLFloat16>("beta", std::vector<int64_t>{2}, ToFloat16({0.f, 0.f}), true);
+  test.AddOutput<MLFloat16>("output", input_output_dims, ToFloat16(std::vector<float>(10)));
+
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(std::move(cpu));
+  test.Run(OpTester::ExpectResult::kExpectFailure, "last two dimensions of skip needs to be same as input",
+           {}, nullptr, &execution_providers);
+}
+
+TEST(SkipLayerNormTest, SkipLayerNormPrePackAllowsEmptySkip) {
+  auto cpu = DefaultCpuExecutionProvider();
+  ASSERT_NE(cpu, nullptr);
+
+  OpTester test("SkipLayerNormalization", 1, onnxruntime::kMSDomain);
+  test.AddAttribute<float>("epsilon", 1e-05f);
+
+  const std::vector<int64_t> empty_dims = {1, 0, 2};
+  test.AddInput<MLFloat16>("input", empty_dims, {});
+  test.AddInput<MLFloat16>("skip", empty_dims, {}, true);
+  test.AddInput<MLFloat16>("gamma", std::vector<int64_t>{2}, ToFloat16({1.f, 1.f}), true);
+  test.AddInput<MLFloat16>("beta", std::vector<int64_t>{2}, ToFloat16({0.f, 0.f}), true);
+  test.AddOutput<MLFloat16>("output", empty_dims, {});
+
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(std::move(cpu));
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
 }
 
 TEST(SkipLayerNormTest, SkipLayerNormNullInput) {

--- a/onnxruntime/test/contrib_ops/skiplayernorm_op_test.cc
+++ b/onnxruntime/test/contrib_ops/skiplayernorm_op_test.cc
@@ -276,6 +276,67 @@ TEST(SkipLayerNormTest, SkipLayerNormPrePackRejectsShortSkip) {
            {}, nullptr, &execution_providers);
 }
 
+TEST(SkipLayerNormTest, SkipLayerNormPrePackRejectsShortBeta) {
+  auto cpu = DefaultCpuExecutionProvider();
+  ASSERT_NE(cpu, nullptr);
+
+  OpTester test("SkipLayerNormalization", 1, onnxruntime::kMSDomain);
+  test.AddAttribute<float>("epsilon", 1e-05f);
+
+  std::vector<int64_t> input_skip_output_dims = {1, 1, 2};
+  test.AddInput<MLFloat16>("input", input_skip_output_dims, ToFloat16({1.f, 2.f}));
+  test.AddInput<MLFloat16>("skip", input_skip_output_dims, ToFloat16({3.f, 4.f}), true);
+  test.AddInput<MLFloat16>("gamma", std::vector<int64_t>{2}, ToFloat16({1.f, 1.f}), true);
+  test.AddInput<MLFloat16>("beta", std::vector<int64_t>{1}, ToFloat16({0.f}), true);
+  test.AddOutput<MLFloat16>("output", input_skip_output_dims, ToFloat16({0.f, 0.f}));
+
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(std::move(cpu));
+  test.Run(OpTester::ExpectResult::kExpectFailure, "Prepacked beta length does not match hidden_size.",
+           {}, nullptr, &execution_providers);
+}
+
+TEST(SkipLayerNormTest, SkipLayerNormPrePackRejectsShortBias) {
+  auto cpu = DefaultCpuExecutionProvider();
+  ASSERT_NE(cpu, nullptr);
+
+  OpTester test("SkipLayerNormalization", 1, onnxruntime::kMSDomain);
+  test.AddAttribute<float>("epsilon", 1e-05f);
+
+  std::vector<int64_t> input_skip_output_dims = {1, 1, 2};
+  test.AddInput<MLFloat16>("input", input_skip_output_dims, ToFloat16({1.f, 2.f}));
+  test.AddInput<MLFloat16>("skip", input_skip_output_dims, ToFloat16({3.f, 4.f}), true);
+  test.AddInput<MLFloat16>("gamma", std::vector<int64_t>{2}, ToFloat16({1.f, 1.f}), true);
+  test.AddInput<MLFloat16>("beta", std::vector<int64_t>{2}, ToFloat16({0.f, 0.f}), true);
+  test.AddInput<MLFloat16>("bias", std::vector<int64_t>{1}, ToFloat16({0.f}), true);
+  test.AddOutput<MLFloat16>("output", input_skip_output_dims, ToFloat16({0.f, 0.f}));
+
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(std::move(cpu));
+  test.Run(OpTester::ExpectResult::kExpectFailure, "Prepacked bias length does not match hidden_size.",
+           {}, nullptr, &execution_providers);
+}
+
+TEST(SkipLayerNormTest, SkipSimplifiedLayerNormPrePackRejectsShortBias) {
+  auto cpu = DefaultCpuExecutionProvider();
+  ASSERT_NE(cpu, nullptr);
+
+  OpTester test("SkipSimplifiedLayerNormalization", 1, onnxruntime::kMSDomain);
+  test.AddAttribute<float>("epsilon", 1e-05f);
+
+  std::vector<int64_t> input_skip_output_dims = {1, 1, 2};
+  test.AddInput<MLFloat16>("input", input_skip_output_dims, ToFloat16({1.f, 2.f}));
+  test.AddInput<MLFloat16>("skip", input_skip_output_dims, ToFloat16({3.f, 4.f}), true);
+  test.AddInput<MLFloat16>("gamma", std::vector<int64_t>{2}, ToFloat16({1.f, 1.f}), true);
+  test.AddInput<MLFloat16>("bias", std::vector<int64_t>{1}, ToFloat16({0.f}), true);
+  test.AddOutput<MLFloat16>("output", input_skip_output_dims, ToFloat16({0.f, 0.f}));
+
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(std::move(cpu));
+  test.Run(OpTester::ExpectResult::kExpectFailure, "Prepacked bias length does not match hidden_size.",
+           {}, nullptr, &execution_providers);
+}
+
 TEST(SkipLayerNormTest, SkipLayerNormNullInput) {
   int batch_size = 1;
   int sequence_length = 0;

--- a/onnxruntime/test/contrib_ops/skiplayernorm_op_test.cc
+++ b/onnxruntime/test/contrib_ops/skiplayernorm_op_test.cc
@@ -236,6 +236,46 @@ TEST(SkipLayerNormTest, SkipLayerNormPrePack) {
             kNnapiExecutionProvider, kQnnExecutionProvider});
 }
 
+TEST(SkipLayerNormTest, SkipLayerNormPrePackRejectsShortGamma) {
+  auto cpu = DefaultCpuExecutionProvider();
+  ASSERT_NE(cpu, nullptr);
+
+  OpTester test("SkipLayerNormalization", 1, onnxruntime::kMSDomain);
+  test.AddAttribute<float>("epsilon", 1e-05f);
+
+  std::vector<int64_t> input_skip_output_dims = {1, 1, 2};
+  test.AddInput<MLFloat16>("input", input_skip_output_dims, ToFloat16({1.f, 2.f}));
+  test.AddInput<MLFloat16>("skip", input_skip_output_dims, ToFloat16({3.f, 4.f}));
+  test.AddInput<MLFloat16>("gamma", std::vector<int64_t>{1}, ToFloat16({1.f}), true);
+  test.AddInput<MLFloat16>("beta", std::vector<int64_t>{2}, ToFloat16({0.f, 0.f}), true);
+  test.AddOutput<MLFloat16>("output", input_skip_output_dims, ToFloat16({0.f, 0.f}));
+
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(std::move(cpu));
+  test.Run(OpTester::ExpectResult::kExpectFailure, "Prepacked gamma length does not match hidden_size.",
+           {}, nullptr, &execution_providers);
+}
+
+TEST(SkipLayerNormTest, SkipLayerNormPrePackRejectsShortSkip) {
+  auto cpu = DefaultCpuExecutionProvider();
+  ASSERT_NE(cpu, nullptr);
+
+  OpTester test("SkipLayerNormalization", 1, onnxruntime::kMSDomain);
+  test.AddAttribute<float>("epsilon", 1e-05f);
+
+  std::vector<int64_t> input_skip_output_dims = {1, 1, 2};
+  test.AddInput<MLFloat16>("input", input_skip_output_dims, ToFloat16({1.f, 2.f}));
+  test.AddInput<MLFloat16>("skip", std::vector<int64_t>{1, 1, 1}, ToFloat16({3.f}), true);
+  test.AddInput<MLFloat16>("gamma", std::vector<int64_t>{2}, ToFloat16({1.f, 1.f}), true);
+  test.AddInput<MLFloat16>("beta", std::vector<int64_t>{2}, ToFloat16({0.f, 0.f}), true);
+  test.AddOutput<MLFloat16>("output", input_skip_output_dims, ToFloat16({0.f, 0.f}));
+
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(std::move(cpu));
+  test.Run(OpTester::ExpectResult::kExpectFailure, "Prepacked skip length does not match hidden_size.",
+           {}, nullptr, &execution_providers);
+}
+
 TEST(SkipLayerNormTest, SkipLayerNormNullInput) {
   int batch_size = 1;
   int sequence_length = 0;


### PR DESCRIPTION
This pull request makes SkipLayerNorm prepacking preserve the same input-shape validation semantics as the non-prepacked path.

**Prepacked input validation:**

* Records the full shape of each successfully prepacked MLFloat16 input instead of retaining only its element count.
* Reuses the existing skip, gamma, beta, and bias shape validators, including their `INVALID_ARGUMENT` status codes.
* Rejects prepacked skip tensors whose last two dimensions do not match the input, preventing incorrect modulo-based wrapping.
* Validates that the hidden dimension fits in `int` before narrowing.
* Tracks packed state independently from allocation pointers so zero-element prepacked skips remain valid no-op inputs.

**Unit test coverage:**

* Covers short prepacked gamma, beta, and bias inputs, including simplified-layer-normalization bias input 3.
* Covers short and shape-mismatched prepacked skip tensors.
* Covers a valid zero-element prepacked skip.

Packed shape metadata is populated only when conversion actually succeeds, keeping data and metadata state synchronized.