### PR TITLE
[Python] Support bfloat16 in Python bindings via ml_dtypes

### DIFF
--- a/onnxruntime/python/numpy_helper.h
+++ b/onnxruntime/python/numpy_helper.h
@@ -12,8 +12,17 @@
 #endif
 namespace onnxruntime {
 namespace python {
-constexpr bool IsNumericNumpyType(int npy_type) {
-  return npy_type < NPY_OBJECT || npy_type == NPY_HALF;
+
+// Returns the NumPy type_num for `ml_dtypes.bfloat16`, or -1 if ml_dtypes is
+// not installed / cannot be imported. Cached after the first call.
+int GetMlDtypesBfloat16TypeNum();
+
+inline bool IsNumericNumpyType(int npy_type) {
+  if (npy_type < NPY_OBJECT || npy_type == NPY_HALF) {
+    return true;
+  }
+  const int bf16 = GetMlDtypesBfloat16TypeNum();
+  return bf16 >= 0 && npy_type == bf16;
 }
 }  // namespace python
 }  // namespace onnxruntime

--- a/onnxruntime/python/onnxruntime_inference_collection.py
+++ b/onnxruntime/python/onnxruntime_inference_collection.py
@@ -1125,7 +1125,9 @@ class OrtValue:
         device = OrtDevice.make(device_type, device_id, vendor_id)._get_c_device()
 
         # Integer for onnx element type (see https://onnx.ai/onnx/api/mapping.html).
-        # This is helpful for some data type (like TensorProto.BFLOAT16) that is not available in numpy.
+        # For bfloat16, callers can also pass ml_dtypes.bfloat16 as a numpy-style
+        # element_type; this integer path remains available for uses that don't
+        # want to depend on ml_dtypes at the Python level.
         if isinstance(element_type, int):
             return cls(
                 C.OrtValue.ortvalue_from_shape_and_onnx_type(

--- a/onnxruntime/python/onnxruntime_pybind_mlvalue.cc
+++ b/onnxruntime/python/onnxruntime_pybind_mlvalue.cc
@@ -46,6 +46,32 @@ using namespace onnxruntime::logging;
 const char* PYTHON_ORTVALUE_OBJECT_NAME = "OrtValue";
 const char* PYTHON_ORTVALUE_NATIVE_OBJECT_ATTR = "_ortvalue";
 
+// Resolve the NumPy type_num for `ml_dtypes.bfloat16`. Cached across calls.
+// Returns -1 if the module is not importable or the dtype cannot be resolved.
+// NumPy has no native bfloat16, so we piggy-back on the widely-used `ml_dtypes`
+// extension type (same one JAX / TensorFlow / PyTorch NumPy interop use).
+int GetMlDtypesBfloat16TypeNum() {
+  static const int cached = []() -> int {
+    py::gil_scoped_acquire acquire;
+    try {
+      py::object ml_dtypes = py::module_::import("ml_dtypes");
+      py::object bfloat16_obj = ml_dtypes.attr("bfloat16");
+      PyArray_Descr* dtype = nullptr;
+      if (!PyArray_DescrConverter(bfloat16_obj.ptr(), &dtype) || dtype == nullptr) {
+        PyErr_Clear();
+        return -1;
+      }
+      int type_num = dtype->type_num;
+      Py_DECREF(dtype);
+      return type_num;
+    } catch (const py::error_already_set&) {
+      PyErr_Clear();
+      return -1;
+    }
+  }();
+  return cached;
+}
+
 static bool PyObjectCheck_NumpyArray(PyObject* o) {
   return (PyObject_HasAttrString(o, "__array_finalize__") != 0);
 }
@@ -78,9 +104,13 @@ std::vector<py::dtype> MakeTypes() {
 bool IsNumericDType(const py::dtype& dtype) {
   static const std::vector<py::dtype> numeric =
       MakeTypes<int8_t, uint8_t, int16_t, uint16_t, int32_t, uint32_t, int64_t, uint64_t, float, double>();
-  return std::any_of(numeric.cbegin(), numeric.cend(), [&dtype](const py::dtype& dt) {
-    return dtype.is(dt);
-  });
+  if (std::any_of(numeric.cbegin(), numeric.cend(), [&dtype](const py::dtype& dt) {
+        return dtype.is(dt);
+      })) {
+    return true;
+  }
+  const int bf16 = GetMlDtypesBfloat16TypeNum();
+  return bf16 >= 0 && dtype.num() == bf16;
 }
 
 static TensorShape GetArrayShape(PyArrayObject* pyObject) {
@@ -467,11 +497,22 @@ int OnnxRuntimeTensorToNumpyType(const DataTypeImpl* tensor_type) {
   };
 
   const auto it = type_map.find(tensor_type);
-  if (it == type_map.end()) {
-    throw std::runtime_error("No corresponding Numpy type for Tensor Type. " + std::string(DataTypeImpl::ToString(tensor_type)));
-  } else {
+  if (it != type_map.end()) {
     return it->second;
   }
+  // BFloat16 has no native numpy dtype; if ml_dtypes is installed we surface
+  // its bfloat16 typenum. Not part of the static map because the value is
+  // resolved lazily at runtime.
+  if (tensor_type == DataTypeImpl::GetType<BFloat16>()) {
+    const int bf16 = GetMlDtypesBfloat16TypeNum();
+    if (bf16 >= 0) {
+      return bf16;
+    }
+    throw std::runtime_error(
+        "Cannot represent tensor(bfloat16) as a NumPy array: the 'ml_dtypes' "
+        "package is required (pip install ml_dtypes).");
+  }
+  throw std::runtime_error("No corresponding Numpy type for Tensor Type. " + std::string(DataTypeImpl::ToString(tensor_type)));
 }
 
 MLDataType NumpyTypeToOnnxRuntimeTensorType(int numpy_type) {
@@ -512,12 +553,17 @@ MLDataType NumpyTypeToOnnxRuntimeTensorType(int numpy_type) {
       {NPY_VOID, DataTypeImpl::GetType<std::string>()}};
 
   const auto it = type_map.find(numpy_type);
-  if (it == type_map.end()) {
-    throw std::runtime_error("Numpy_type " + std::to_string(numpy_type) +
-                             " can't be converted to MLDataType.");
-  } else {
+  if (it != type_map.end()) {
     return it->second;
   }
+  // Match against the runtime-registered `ml_dtypes.bfloat16` type_num (numpy
+  // has no native bfloat16, so it lives outside the static table).
+  const int bf16 = GetMlDtypesBfloat16TypeNum();
+  if (bf16 >= 0 && numpy_type == bf16) {
+    return DataTypeImpl::GetType<BFloat16>();
+  }
+  throw std::runtime_error("Numpy_type " + std::to_string(numpy_type) +
+                           " can't be converted to MLDataType.");
 }
 
 MLDataType OnnxTypeToOnnxRuntimeTensorType(int onnx_element_type) {

--- a/onnxruntime/test/python/onnxruntime_test_python_bfloat16.py
+++ b/onnxruntime/test/python/onnxruntime_test_python_bfloat16.py
@@ -1,0 +1,122 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+#
+# Tests that bfloat16 tensors flow through the standard Python bindings —
+# `session.run`, `OrtValue.ortvalue_from_numpy`, and `OrtValue.numpy()` —
+# using the `ml_dtypes.bfloat16` numpy extension dtype. NumPy has no native
+# bfloat16, so the type is registered at pybind init via `ml_dtypes` and
+# added to the two type maps in onnxruntime_pybind_mlvalue.cc.
+
+from __future__ import annotations
+
+import unittest
+
+import ml_dtypes
+import numpy as np
+from onnx import TensorProto, helper
+
+import onnxruntime as onnxrt
+
+# The highest ai.onnx opset that has been *released* by the installed onnx
+# package. onnx.defs.onnx_opset_version() returns the in-development next
+# opset, which ORT's loader rejects. Kept in sync with the pattern used in
+# onnxruntime_test_python_iobinding.py.
+_LAST_RELEASED_AI_ONNX_OPSET = max(v for (d, v) in helper.OP_SET_ID_VERSION_MAP if d == "ai.onnx")
+
+
+def _make_identity_bf16_model() -> bytes:
+    x = helper.make_tensor_value_info("X", TensorProto.BFLOAT16, [None])
+    y = helper.make_tensor_value_info("Y", TensorProto.BFLOAT16, [None])
+    node = helper.make_node("Identity", ["X"], ["Y"])
+    graph = helper.make_graph([node], "bf16_identity", [x], [y], [])
+    model = helper.make_model(
+        graph,
+        producer_name="onnxruntime-test",
+        ir_version=10,
+        opset_imports=[helper.make_operatorsetid("", _LAST_RELEASED_AI_ONNX_OPSET)],
+    )
+    return model.SerializeToString()
+
+
+def _make_add_bf16_model() -> bytes:
+    a = helper.make_tensor_value_info("A", TensorProto.BFLOAT16, [None])
+    b = helper.make_tensor_value_info("B", TensorProto.BFLOAT16, [None])
+    y = helper.make_tensor_value_info("Y", TensorProto.BFLOAT16, [None])
+    node = helper.make_node("Add", ["A", "B"], ["Y"])
+    graph = helper.make_graph([node], "bf16_add", [a, b], [y], [])
+    model = helper.make_model(
+        graph,
+        producer_name="onnxruntime-test",
+        ir_version=10,
+        opset_imports=[helper.make_operatorsetid("", _LAST_RELEASED_AI_ONNX_OPSET)],
+    )
+    return model.SerializeToString()
+
+
+class TestBFloat16Numpy(unittest.TestCase):
+    # ------- unit-level: OrtValue <-> numpy bfloat16 round-trip -------
+
+    def test_ortvalue_from_numpy_bfloat16_roundtrip(self):
+        data = np.array([1.0, -2.5, 0.0, 3.5, 42.0], dtype=ml_dtypes.bfloat16)
+        ort_value = onnxrt.OrtValue.ortvalue_from_numpy(data)
+        self.assertTrue(ort_value.is_tensor())
+        self.assertEqual(ort_value.element_type(), TensorProto.BFLOAT16)
+        self.assertEqual(list(ort_value.shape()), list(data.shape))
+        recovered = ort_value.numpy()
+        self.assertEqual(recovered.dtype, ml_dtypes.bfloat16)
+        # Round-trip is bit-exact (no precision loss because the source
+        # buffer was already bfloat16).
+        np.testing.assert_array_equal(recovered, data)
+
+    def test_ortvalue_shape_and_type_bfloat16(self):
+        ort_value = onnxrt.OrtValue.ortvalue_from_shape_and_type([2, 3], ml_dtypes.bfloat16)
+        self.assertEqual(ort_value.element_type(), TensorProto.BFLOAT16)
+        self.assertEqual(list(ort_value.shape()), [2, 3])
+        arr = ort_value.numpy()
+        self.assertEqual(arr.dtype, ml_dtypes.bfloat16)
+        self.assertEqual(arr.shape, (2, 3))
+
+    # ------- integration: session.run with bfloat16 numpy inputs -------
+
+    def test_session_run_bf16_identity(self):
+        sess = onnxrt.InferenceSession(_make_identity_bf16_model(), providers=["CPUExecutionProvider"])
+        # Identity uses type constraint V (all types) and does no math, so
+        # it exercises the input/output plumbing without needing a BF16
+        # arithmetic kernel on CPU.
+        x = np.array([0.0, 1.5, -2.75, 8.0], dtype=ml_dtypes.bfloat16)
+        outputs = sess.run(None, {"X": x})
+        self.assertEqual(len(outputs), 1)
+        y = outputs[0]
+        self.assertEqual(y.dtype, ml_dtypes.bfloat16)
+        np.testing.assert_array_equal(y, x)
+
+    def test_session_run_bf16_add_on_cuda(self):
+        if "CUDAExecutionProvider" not in onnxrt.get_available_providers():
+            self.skipTest("CUDA execution provider is not available.")
+
+        sess = onnxrt.InferenceSession(
+            _make_add_bf16_model(),
+            providers=["CUDAExecutionProvider", "CPUExecutionProvider"],
+        )
+        a = np.array([1.0, 2.0, 3.0, 4.0], dtype=ml_dtypes.bfloat16)
+        b = np.array([0.5, -1.0, 2.5, 0.25], dtype=ml_dtypes.bfloat16)
+        outputs = sess.run(None, {"A": a, "B": b})
+        y = outputs[0]
+        self.assertEqual(y.dtype, ml_dtypes.bfloat16)
+        # Expected result computed in float32 and cast back to bfloat16 to
+        # match the kernel's accumulation semantics.
+        expected = (a.astype(np.float32) + b.astype(np.float32)).astype(ml_dtypes.bfloat16)
+        np.testing.assert_array_equal(y, expected)
+
+    def test_session_run_bf16_output_dtype_preserved(self):
+        # The output numpy array should carry ml_dtypes.bfloat16 (not be
+        # silently viewed as uint16 or float16) so downstream code sees
+        # the correct semantic dtype.
+        sess = onnxrt.InferenceSession(_make_identity_bf16_model(), providers=["CPUExecutionProvider"])
+        x = np.arange(8, dtype=np.float32).astype(ml_dtypes.bfloat16)
+        (y,) = sess.run(None, {"X": x})
+        self.assertIs(y.dtype.type, ml_dtypes.bfloat16)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 flatbuffers
+ml_dtypes
 numpy >= 1.21.6
 packaging
 protobuf>=4.25.8

--- a/setup.py
+++ b/setup.py
@@ -865,7 +865,10 @@ def save_build_and_package_info(package_name, version_number, cuda_version, qnn_
 save_build_and_package_info(package_name, version_number, cuda_version, qnn_version)
 
 # sympy is optional - only needed for symbolic shape inference
-# ml_dtypes is optional - needed for quantization utilities
+# ml_dtypes is a base runtime dependency (see requirements.txt) as it
+# supplies the numpy dtype used to marshal bfloat16 tensors through the
+# Python bindings. Retained as an alias in extras for backward compatibility
+# with users installing `onnxruntime[quantization]`.
 extras_require = {
     "symbolic": ["sympy"],
     "quantization": ["ml_dtypes"],


### PR DESCRIPTION
### Description
Marshal bfloat16 tensors through OrtValue and session.run using the ml_dtypes.bfloat16 numpy extension dtype, since numpy has no native bfloat16. The dtype's type_num is resolved lazily at first use and cached, then wired into IsNumericDType, OnnxRuntimeTensorToNumpyType, and NumpyTypeToOnnxRuntimeTensorType so bfloat16 arrays flow through the standard input/output paths.

Adds ml_dtypes as a base runtime dependency and covers the plumbing with OrtValue round-trip and Identity/Add session.run tests.


### Motivation and Context
onnx-runtime has support for bfloat16 for CUDA EP but is not usable via python APIs e.g. session.run due to lack of support for bfloat16 dtype in numpy. 

Projects such as [aimet-onnx](https://github.com/qualcomm/aimet) depends on onnx-runtime for quantization and with this change calibrate with bf16


