### PR TITLE
Allowlist safe LoRA adapter parameter data types

### DIFF
--- a/onnxruntime/lora/adapter_format_utils.cc
+++ b/onnxruntime/lora/adapter_format_utils.cc
@@ -157,8 +157,16 @@ std::pair<std::string, OrtValue> CreateOrtValueOverLoraParameter(const Parameter
   LoadStringFromLoraFormat(name, param_name);
 
   const auto data_type = param.data_type();
-  ORT_ENFORCE(data_type != TensorDataType::UNDEFINED,
-              "Lora Param '", name, "': data_type is UNDEFINED");
+  // STRING is enumerated in the flatbuffer schema but explicitly not supported as a LoRA
+  // parameter type (see adapter_schema.fbs: "We do not foresee strings as parameters").
+  // Allowing STRING would create a non-owning Tensor over raw file bytes without running
+  // placement-new, leaving fake std::string objects whose internal pointers are controlled
+  // by the file contents. Any subsequent string copy via CPUDataTransfer would write to
+  // those attacker-supplied addresses.
+  ORT_ENFORCE(data_type != TensorDataType::UNDEFINED &&
+                  data_type != TensorDataType::STRING,
+              "Lora Param '", name, "': data_type '", static_cast<int32_t>(data_type),
+              "' is not supported for LoRA parameters (UNDEFINED and STRING are not valid)");
 
   const auto* dims = param.dims();
   ORT_ENFORCE(dims != nullptr && dims->size() > 0,

--- a/onnxruntime/lora/adapter_format_utils.cc
+++ b/onnxruntime/lora/adapter_format_utils.cc
@@ -21,6 +21,34 @@ namespace onnxruntime {
 namespace adapters {
 namespace utils {
 
+namespace {
+
+constexpr bool IsSupportedLoraParameterType(TensorDataType data_type) {
+  switch (data_type) {
+    case TensorDataType::FLOAT:
+    case TensorDataType::UINT8:
+    case TensorDataType::INT8:
+    case TensorDataType::UINT16:
+    case TensorDataType::INT16:
+    case TensorDataType::INT32:
+    case TensorDataType::INT64:
+    case TensorDataType::FLOAT16:
+    case TensorDataType::DOUBLE:
+    case TensorDataType::UINT32:
+    case TensorDataType::UINT64:
+    case TensorDataType::BFLOAT16:
+    case TensorDataType::FLOAT8E4M3FN:
+    case TensorDataType::FLOAT8E4M3FNUZ:
+    case TensorDataType::FLOAT8E5M2:
+    case TensorDataType::FLOAT8E5M2FNUZ:
+      return true;
+    default:
+      return false;
+  }
+}
+
+}  // namespace
+
 bool IsAdapterFormatModelBytes(const void* bytes, size_t num_bytes) {
   return num_bytes > 8 &&  // check buffer is large enough to contain identifier so we don't read random memory
          AdapterBufferHasIdentifier(bytes);
@@ -157,16 +185,12 @@ std::pair<std::string, OrtValue> CreateOrtValueOverLoraParameter(const Parameter
   LoadStringFromLoraFormat(name, param_name);
 
   const auto data_type = param.data_type();
-  // STRING is enumerated in the flatbuffer schema but explicitly not supported as a LoRA
-  // parameter type (see adapter_schema.fbs: "We do not foresee strings as parameters").
-  // Allowing STRING would create a non-owning Tensor over raw file bytes without running
-  // placement-new, leaving fake std::string objects whose internal pointers are controlled
-  // by the file contents. Any subsequent string copy via CPUDataTransfer would write to
-  // those attacker-supplied addresses.
-  ORT_ENFORCE(data_type != TensorDataType::UNDEFINED &&
-                  data_type != TensorDataType::STRING,
+  // The raw-byte size calculation below is valid only for fixed-size, unpacked scalar types.
+  // An allowlist also rejects undeclared enum values because FlatBuffers verifies the field
+  // representation but not membership in TensorDataType.
+  ORT_ENFORCE(IsSupportedLoraParameterType(data_type),
               "Lora Param '", name, "': data_type '", static_cast<int32_t>(data_type),
-              "' is not supported for LoRA parameters (UNDEFINED and STRING are not valid)");
+              "' is not a supported LoRA parameter type");
 
   const auto* dims = param.dims();
   ORT_ENFORCE(dims != nullptr && dims->size() > 0,

--- a/onnxruntime/test/lora/lora_test.cc
+++ b/onnxruntime/test/lora/lora_test.cc
@@ -253,6 +253,15 @@ const adapters::Parameter* BuildAdapterAndGetParam(flatbuffers::FlatBufferBuilde
   const auto* adapter = adapters::GetAdapter(fbb.GetBufferPointer());
   return adapter->parameters()->Get(0);
 }
+
+void ExpectUnsupportedLoraParameterType(const adapters::Parameter& param) {
+  try {
+    adapters::utils::CreateOrtValueOverLoraParameter(param);
+    FAIL() << "Expected unsupported LoRA parameter data_type to be rejected";
+  } catch (const OnnxRuntimeException& ex) {
+    EXPECT_NE(std::string(ex.what()).find("not a supported LoRA parameter type"), std::string::npos);
+  }
+}
 }  // namespace
 
 TEST(LoraAdapterTest, CreateOrtValueOverLoraParameter_RawDataSizeMismatch) {
@@ -413,20 +422,16 @@ TEST(LoraAdapterTest, CreateOrtValueOverLoraParameter_UndefinedDataType) {
   ASSERT_NE(param, nullptr);
   ASSERT_EQ(param->data_type(), adapters::TensorDataType::UNDEFINED);
 
-  ASSERT_THROW(adapters::utils::CreateOrtValueOverLoraParameter(*param), OnnxRuntimeException);
+  ExpectUnsupportedLoraParameterType(*param);
 }
 
 TEST(LoraAdapterTest, CreateOrtValueOverLoraParameter_StringDataType) {
-  // Parameter with STRING data_type must be rejected. STRING is present in the flatbuffer
-  // schema enum but explicitly not supported as a LoRA parameter type. Allowing it would
-  // create a non-owning Tensor over raw file bytes without placement-new, producing fake
-  // std::string objects whose internal pointers are controlled by the file contents.
   flatbuffers::FlatBufferBuilder fbb;
 
-  // Provide raw_data sized to pass the size check: shape [2] * sizeof(std::string) = 64 bytes.
+  // Provide raw_data sized to pass the old size check: shape [2] * sizeof(std::string).
   // The guard must reject the type before reaching the size check.
   std::vector<int64_t> dims = {2};
-  std::vector<uint8_t> raw_data(2 * sizeof(std::string), 0x41);  // 0x41 ('A') fills fake pointers
+  std::vector<uint8_t> raw_data(2 * sizeof(std::string), 0x41);
 
   auto param_offset = adapters::CreateParameterDirect(
       fbb, "string_type_param", &dims, adapters::TensorDataType::STRING, &raw_data);
@@ -435,7 +440,41 @@ TEST(LoraAdapterTest, CreateOrtValueOverLoraParameter_StringDataType) {
   ASSERT_NE(param, nullptr);
   ASSERT_EQ(param->data_type(), adapters::TensorDataType::STRING);
 
-  ASSERT_THROW(adapters::utils::CreateOrtValueOverLoraParameter(*param), OnnxRuntimeException);
+  ExpectUnsupportedLoraParameterType(*param);
+}
+
+TEST(LoraAdapterTest, CreateOrtValueOverLoraParameter_UndeclaredDataType) {
+  flatbuffers::FlatBufferBuilder fbb;
+
+  std::vector<int64_t> dims = {2};
+  std::vector<uint8_t> raw_data(2, 0);
+  constexpr int32_t undeclared_data_type = 21;
+  const auto data_type = static_cast<adapters::TensorDataType>(undeclared_data_type);
+
+  auto param_offset = adapters::CreateParameterDirect(
+      fbb, "undeclared_type_param", &dims, data_type, &raw_data);
+
+  const auto* param = BuildAdapterAndGetParam(fbb, param_offset);
+  ASSERT_NE(param, nullptr);
+  ASSERT_EQ(static_cast<int32_t>(param->data_type()), undeclared_data_type);
+
+  ExpectUnsupportedLoraParameterType(*param);
+}
+
+TEST(LoraAdapterTest, CreateOrtValueOverLoraParameter_BoolDataType) {
+  flatbuffers::FlatBufferBuilder fbb;
+
+  std::vector<int64_t> dims = {1};
+  std::vector<uint8_t> raw_data = {2};
+
+  auto param_offset = adapters::CreateParameterDirect(
+      fbb, "bool_type_param", &dims, adapters::TensorDataType::BOOL, &raw_data);
+
+  const auto* param = BuildAdapterAndGetParam(fbb, param_offset);
+  ASSERT_NE(param, nullptr);
+  ASSERT_EQ(param->data_type(), adapters::TensorDataType::BOOL);
+
+  ExpectUnsupportedLoraParameterType(*param);
 }
 
 #endif  // ORT_NO_EXCEPTIONS

--- a/onnxruntime/test/lora/lora_test.cc
+++ b/onnxruntime/test/lora/lora_test.cc
@@ -416,6 +416,28 @@ TEST(LoraAdapterTest, CreateOrtValueOverLoraParameter_UndefinedDataType) {
   ASSERT_THROW(adapters::utils::CreateOrtValueOverLoraParameter(*param), OnnxRuntimeException);
 }
 
+TEST(LoraAdapterTest, CreateOrtValueOverLoraParameter_StringDataType) {
+  // Parameter with STRING data_type must be rejected. STRING is present in the flatbuffer
+  // schema enum but explicitly not supported as a LoRA parameter type. Allowing it would
+  // create a non-owning Tensor over raw file bytes without placement-new, producing fake
+  // std::string objects whose internal pointers are controlled by the file contents.
+  flatbuffers::FlatBufferBuilder fbb;
+
+  // Provide raw_data sized to pass the size check: shape [2] * sizeof(std::string) = 64 bytes.
+  // The guard must reject the type before reaching the size check.
+  std::vector<int64_t> dims = {2};
+  std::vector<uint8_t> raw_data(2 * sizeof(std::string), 0x41);  // 0x41 ('A') fills fake pointers
+
+  auto param_offset = adapters::CreateParameterDirect(
+      fbb, "string_type_param", &dims, adapters::TensorDataType::STRING, &raw_data);
+
+  const auto* param = BuildAdapterAndGetParam(fbb, param_offset);
+  ASSERT_NE(param, nullptr);
+  ASSERT_EQ(param->data_type(), adapters::TensorDataType::STRING);
+
+  ASSERT_THROW(adapters::utils::CreateOrtValueOverLoraParameter(*param), OnnxRuntimeException);
+}
+
 #endif  // ORT_NO_EXCEPTIONS
 
 #ifdef USE_CUDA


### PR DESCRIPTION
This pull request hardens LoRA adapter parameter loading by accepting only fixed-size, unpacked scalar data types that are safe to expose through a non-owning tensor over raw FlatBuffer bytes.

**Data-type validation:**

* Replaces the `UNDEFINED`/`STRING` denylist with an explicit allowlist.
* Accepts supported floating-point and integer scalar types, including FP16, BF16, and supported FP8 formats.
* Rejects `STRING`, `BOOL`, complex types, packed sub-byte types, `UNDEFINED`, and undeclared enum values.
* Performs validation before ONNX type lookup or raw-data size calculation.

FlatBuffers validates the enum field's representation but not that its value is a declared `TensorDataType` member. The allowlist therefore preserves the loader's invariant that storage size equals logical element count multiplied by element size, and remains safe if new schema values are added later.

**Tests:**

* Verifies rejection of `STRING` with correctly platform-sized raw data.
* Verifies rejection of `UNDEFINED`, `BOOL`, and an undeclared enum value.
* Asserts the specific unsupported-data-type error so tests cannot pass through an unrelated validation failure.