### PR TITLE
Validate QLinearConv bias size against output channels

### DIFF
--- a/onnxruntime/core/providers/cpu/quantization/qlinearconv.cc
+++ b/onnxruntime/core/providers/cpu/quantization/qlinearconv.cc
@@ -58,6 +58,15 @@ class QLinearConv : public OpKernel {
     return (shape.NumDimensions() == 0 || (shape.NumDimensions() == 1 && (shape[0] == 1 || shape[0] == N)));
   }
 
+  inline static bool IsValidBiasParam(const Tensor* bias, int64_t output_channels) {
+    if (bias == nullptr) {
+      return true;
+    }
+
+    const auto& shape = bias->Shape();
+    return shape.NumDimensions() == 1 && shape[0] == output_channels;
+  }
+
   static void ComputeOffset(OpKernelContext* context,
                             ActType& X_zero_point_value,
                             ActType& Y_zero_point_value) {
@@ -186,6 +195,9 @@ class QLinearConv : public OpKernel {
     if (packed_size != 0) {
       const Tensor* B = nullptr;
       Info().TryGetConstantInput(8, &B);
+      ORT_ENFORCE(IsValidBiasParam(B, static_cast<int64_t>(output_channels)),
+                  "QLinearConv : bias shape invalid. bias must be a 1D tensor of size output_channels (",
+                  output_channels, ")");
       const auto* Bdata = B != nullptr ? B->Data<int32_t>() : nullptr;
 
       column_sums_.resize(output_channels);
@@ -540,6 +552,8 @@ Status QLinearConv<ActType>::Compute(OpKernelContext* context) const {
   const uint8_t W_zero_point_value = W_zero_point_data[0];
 
   const Tensor* B = context->Input<Tensor>(InputTensors::IN_BIAS);
+  ORT_ENFORCE(IsValidBiasParam(B, M),
+              "QLinearConv : bias shape invalid. bias must be a 1D tensor of size output_channels (", M, ")");
 
   ORT_RETURN_IF_ERROR(conv_attrs_.ValidateInputShape(X->Shape(), W_shape, channels_last_));
 

--- a/onnxruntime/core/providers/cpu/quantization/qlinearconv.cc
+++ b/onnxruntime/core/providers/cpu/quantization/qlinearconv.cc
@@ -190,21 +190,18 @@ class QLinearConv : public OpKernel {
       return false;
     }
 
+    const Tensor* B = nullptr;
+    const auto& input_defs = Info().node().InputDefs();
+    const bool has_bias_input = input_defs.size() > static_cast<size_t>(InputTensors::IN_BIAS) &&
+                                input_defs[InputTensors::IN_BIAS]->Exists();
+    const bool runtime_bias = has_bias_input && !Info().TryGetConstantInput(InputTensors::IN_BIAS, &B);
+
     // Try indirect conv packing
     size_t packed_size = MlasConvSymPackWSize(group_count, group_input_channels, group_output_channels, kernel_size, std::is_signed<ActType>::value);
-    if (packed_size != 0) {
-      const Tensor* B = nullptr;
-      const auto& input_defs = Info().node().InputDefs();
-      const bool has_bias_input = input_defs.size() > static_cast<size_t>(InputTensors::IN_BIAS) &&
-                                  input_defs[InputTensors::IN_BIAS]->Exists();
-      if (has_bias_input && !Info().TryGetConstantInput(InputTensors::IN_BIAS, &B)) {
-        // The symmetric prepack path bakes bias into column_sums_; runtime bias
-        // must use the non-prepacked execution path so values are not dropped.
+    if (packed_size != 0 && !runtime_bias) {
+      if (!IsValidBiasParam(B, static_cast<int64_t>(output_channels))) {
         return false;
       }
-      ORT_ENFORCE(IsValidBiasParam(B, static_cast<int64_t>(output_channels)),
-                  "QLinearConv : bias shape invalid. bias must be a 1D tensor of size output_channels (",
-                  output_channels, ")");
       const auto* Bdata = B != nullptr ? B->Data<int32_t>() : nullptr;
 
       column_sums_.resize(output_channels);
@@ -559,8 +556,8 @@ Status QLinearConv<ActType>::Compute(OpKernelContext* context) const {
   const uint8_t W_zero_point_value = W_zero_point_data[0];
 
   const Tensor* B = context->Input<Tensor>(InputTensors::IN_BIAS);
-  ORT_ENFORCE(IsValidBiasParam(B, M),
-              "QLinearConv : bias shape invalid. bias must be a 1D tensor of size output_channels (", M, ")");
+  ORT_RETURN_IF_NOT(IsValidBiasParam(B, M),
+                    "QLinearConv : bias shape invalid. bias must be a 1D tensor of size output_channels (", M, ")");
 
   ORT_RETURN_IF_ERROR(conv_attrs_.ValidateInputShape(X->Shape(), W_shape, channels_last_));
 

--- a/onnxruntime/core/providers/cpu/quantization/qlinearconv.cc
+++ b/onnxruntime/core/providers/cpu/quantization/qlinearconv.cc
@@ -194,7 +194,14 @@ class QLinearConv : public OpKernel {
     size_t packed_size = MlasConvSymPackWSize(group_count, group_input_channels, group_output_channels, kernel_size, std::is_signed<ActType>::value);
     if (packed_size != 0) {
       const Tensor* B = nullptr;
-      Info().TryGetConstantInput(8, &B);
+      const auto& input_defs = Info().node().InputDefs();
+      const bool has_bias_input = input_defs.size() > static_cast<size_t>(InputTensors::IN_BIAS) &&
+                                  input_defs[InputTensors::IN_BIAS]->Exists();
+      if (has_bias_input && !Info().TryGetConstantInput(InputTensors::IN_BIAS, &B)) {
+        // The symmetric prepack path bakes bias into column_sums_; runtime bias
+        // must use the non-prepacked execution path so values are not dropped.
+        return false;
+      }
       ORT_ENFORCE(IsValidBiasParam(B, static_cast<int64_t>(output_channels)),
                   "QLinearConv : bias shape invalid. bias must be a 1D tensor of size output_channels (",
                   output_channels, ")");

--- a/onnxruntime/test/providers/cpu/nn/qlinearconv_op_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/qlinearconv_op_test.cc
@@ -1547,6 +1547,35 @@ TEST(QLinearConvTest, Conv2D_U8U8_InvalidWeightZeroPointSize) {
   test.Run(OpTester::ExpectResult::kExpectFailure, "filter zero point shape invalid", {}, nullptr, &execution_providers);
 }
 
+// Negative test: bias tensor must have one int32 value per output channel (M).
+TEST(QLinearConvTest, Conv2D_U8U8_InvalidBiasSize) {
+  OpTester test("QLinearConv", 10);
+
+  // 4 output channels (M=4), input: 1x2x3x3, weight: 4x2x1x1
+  std::vector<uint8_t> X_data(1 * 2 * 3 * 3, 128);
+  std::vector<uint8_t> W_data(4 * 2 * 1 * 1, 128);
+
+  test.AddInput<uint8_t>("x", {1, 2, 3, 3}, X_data);
+  test.AddInput<float>("x_scale", {}, {0.1f}, true);
+  test.AddInput<uint8_t>("x_zero_point", {}, {128}, true);
+
+  test.AddInput<uint8_t>("w", {4, 2, 1, 1}, W_data, true);
+  test.AddInput<float>("w_scale", {4}, {0.1f, 0.1f, 0.1f, 0.1f}, true);
+  test.AddInput<uint8_t>("w_zero_point", {}, {128}, true);
+
+  test.AddInput<float>("y_scale", {}, {0.5f}, true);
+  test.AddInput<uint8_t>("y_zero_point", {}, {128}, true);
+
+  // Invalid: bias has 1 value but M=4.
+  test.AddInput<int32_t>("b", {1}, {7}, true);
+
+  test.AddOutput<uint8_t>("y", {1, 4, 3, 3}, std::vector<uint8_t>(4 * 3 * 3, 128));
+
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(DefaultCpuExecutionProvider());
+  test.Run(OpTester::ExpectResult::kExpectFailure, "bias shape invalid", {}, nullptr, &execution_providers);
+}
+
 // Tests per-channel weight zero points with different values (the fix for the reported bug).
 TEST(QLinearConvTest, Conv2D_U8U8_PerChannelZeroPoints) {
   // TODO: Unskip when fixed #41968513

--- a/onnxruntime/test/providers/cpu/nn/qlinearconv_op_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/qlinearconv_op_test.cc
@@ -1576,6 +1576,31 @@ TEST(QLinearConvTest, Conv2D_U8U8_InvalidBiasSize) {
   test.Run(OpTester::ExpectResult::kExpectFailure, "bias shape invalid", {}, nullptr, &execution_providers);
 }
 
+TEST(QLinearConvTest, Conv2D_U8S8_RuntimeBiasPreservedWhenSymmetricWeights) {
+  OpTester test("QLinearConv", 10);
+
+  test.AddInput<uint8_t>("x", {1, 1, 1, 1}, {10});
+  test.AddInput<float>("x_scale", {}, {1.0f}, true);
+  test.AddInput<uint8_t>("x_zero_point", {}, {0}, true);
+
+  test.AddInput<int8_t>("w", {1, 1, 1, 1}, {2}, true);
+  test.AddInput<float>("w_scale", {}, {1.0f}, true);
+  test.AddInput<int8_t>("w_zero_point", {}, {0}, true);
+
+  test.AddInput<float>("y_scale", {}, {1.0f}, true);
+  test.AddInput<uint8_t>("y_zero_point", {}, {0}, true);
+
+  // Keep bias as a runtime input (non-initializer) so the symmetric prepack
+  // path must be skipped and bias is applied during Compute.
+  test.AddInput<int32_t>("b", {1}, {5});
+
+  test.AddOutput<uint8_t>("y", {1, 1, 1, 1}, {25});
+
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(DefaultCpuExecutionProvider());
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+}
+
 // Tests per-channel weight zero points with different values (the fix for the reported bug).
 TEST(QLinearConvTest, Conv2D_U8U8_PerChannelZeroPoints) {
   // TODO: Unskip when fixed #41968513

--- a/onnxruntime/test/providers/cpu/nn/qlinearconv_op_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/qlinearconv_op_test.cc
@@ -1576,25 +1576,46 @@ TEST(QLinearConvTest, Conv2D_U8U8_InvalidBiasSize) {
   test.Run(OpTester::ExpectResult::kExpectFailure, "bias shape invalid", {}, nullptr, &execution_providers);
 }
 
-TEST(QLinearConvTest, Conv2D_U8S8_RuntimeBiasPreservedWhenSymmetricWeights) {
+TEST(QLinearConvTest, Conv2D_U8S8_InvalidConstantBiasSize) {
   OpTester test("QLinearConv", 10);
 
-  test.AddInput<uint8_t>("x", {1, 1, 1, 1}, {10});
+  test.AddInput<uint8_t>("x", {1, 4, 3, 3}, std::vector<uint8_t>(4 * 3 * 3, 1));
   test.AddInput<float>("x_scale", {}, {1.0f}, true);
   test.AddInput<uint8_t>("x_zero_point", {}, {0}, true);
 
-  test.AddInput<int8_t>("w", {1, 1, 1, 1}, {2}, true);
-  test.AddInput<float>("w_scale", {}, {1.0f}, true);
+  test.AddInput<int8_t>("w", {4, 4, 3, 3}, std::vector<int8_t>(4 * 4 * 3 * 3, 0), true);
+  test.AddInput<float>("w_scale", {4}, {1.0f, 1.0f, 1.0f, 1.0f}, true);
+  test.AddInput<int8_t>("w_zero_point", {}, {0}, true);
+
+  test.AddInput<float>("y_scale", {}, {1.0f}, true);
+  test.AddInput<uint8_t>("y_zero_point", {}, {0}, true);
+  test.AddInput<int32_t>("b", {1}, {1}, true);
+  test.AddOutput<uint8_t>("y", {1, 4, 1, 1}, {0, 0, 0, 0});
+
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(DefaultCpuExecutionProvider());
+  test.Run(OpTester::ExpectResult::kExpectFailure, "bias shape invalid", {}, nullptr, &execution_providers);
+}
+
+TEST(QLinearConvTest, Conv2D_U8S8_RuntimeBiasPreservedWhenSymmetricWeights) {
+  OpTester test("QLinearConv", 10);
+
+  test.AddInput<uint8_t>("x", {1, 4, 3, 3}, std::vector<uint8_t>(4 * 3 * 3, 1));
+  test.AddInput<float>("x_scale", {}, {1.0f}, true);
+  test.AddInput<uint8_t>("x_zero_point", {}, {0}, true);
+
+  test.AddInput<int8_t>("w", {4, 4, 3, 3}, std::vector<int8_t>(4 * 4 * 3 * 3, 0), true);
+  test.AddInput<float>("w_scale", {4}, {1.0f, 1.0f, 1.0f, 1.0f}, true);
   test.AddInput<int8_t>("w_zero_point", {}, {0}, true);
 
   test.AddInput<float>("y_scale", {}, {1.0f}, true);
   test.AddInput<uint8_t>("y_zero_point", {}, {0}, true);
 
-  // Keep bias as a runtime input (non-initializer) so the symmetric prepack
-  // path must be skipped and bias is applied during Compute.
-  test.AddInput<int32_t>("b", {1}, {5});
+  // Runtime bias skips ConvSym, which bakes constant bias into column sums, but can still use
+  // the symmetric-GEMM path where bias is applied during requantization.
+  test.AddInput<int32_t>("b", {4}, {1, 2, 3, 4});
 
-  test.AddOutput<uint8_t>("y", {1, 1, 1, 1}, {25});
+  test.AddOutput<uint8_t>("y", {1, 4, 1, 1}, {1, 2, 3, 4});
 
   std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
   execution_providers.push_back(DefaultCpuExecutionProvider());


### PR DESCRIPTION
This pull request validates that an optional QLinearConv bias is a one-dimensional `int32` tensor with one value per output channel, preventing out-of-bounds bias reads.

**Bias validation:**

* Validates bias shape in `Compute()` and returns a normal failure `Status`, including in exception-disabled builds.
* Checks constant bias before ConvSym prepacking; malformed constant bias safely disables that prepack path and is subsequently rejected by `Compute()`.
* Detects runtime bias during prepacking and skips only ConvSym, which bakes constant bias into `column_sums_`.
* Still allows the symmetric-GEMM prepack path for runtime bias, where bias is applied during requantization.

**Regression coverage:**

* Verifies invalid bias length for unsigned weights.
* Verifies invalid constant bias with signed symmetric weights.
* Uses a non-depthwise `4x4x3x3` signed-weight convolution to verify runtime bias is preserved on architectures supporting ConvSym/symmetric GEMM.

This keeps malformed models non-fatal and avoids silently dropping runtime bias without unnecessarily falling back to generic GEMM.