### PR TITLE
fix: use process architecture for CUDA DLL paths

### DIFF
--- a/onnxruntime/__init__.py
+++ b/onnxruntime/__init__.py
@@ -199,10 +199,16 @@ def _get_cufft_version(cuda_major_version: str) -> str:
     return "12" if int(cuda_major_version) >= 13 else "11"
 
 
-def _get_nvidia_dll_paths(is_windows: bool, cuda: bool = True, cudnn: bool = True):
+def _get_nvidia_dll_paths(
+    is_windows: bool,
+    cuda: bool = True,
+    cudnn: bool = True,
+    build_cuda_version: str | None = None,
+    arch: str | None = None,
+):
     # Dynamically determine CUDA major version from build info.
     # build_cuda_version defaults to the version this package was built with; it is a parameter for testability.
-    cuda_major_version = _extract_cuda_major_version(cuda_version)
+    cuda_major_version = _extract_cuda_major_version(build_cuda_version or cuda_version)
     cufft_version = _get_cufft_version(cuda_major_version)
 
     # Starting with CUDA 13, NVIDIA consolidated the per-component CUDA Toolkit wheels
@@ -216,9 +222,10 @@ def _get_nvidia_dll_paths(is_windows: bool, cuda: bool = True, cudnn: bool = Tru
     if use_consolidated_layout:
         cuda_dir = f"cu{cuda_major_version}"
         if is_windows:
-            import platform  # noqa: PLC0415
+            import sysconfig  # noqa: PLC0415
 
-            arch = "arm64" if platform.machine().lower() in ("arm64", "aarch64") else "x86_64"
+            process_platform = sysconfig.get_platform().lower()
+            arch = arch or ("arm64" if process_platform in ("win-arm64", "mingw-arm64") else "x86_64")
             cuda_dll_paths = [
                 ("nvidia", cuda_dir, "bin", arch, f"cublasLt64_{cuda_major_version}.dll"),
                 ("nvidia", cuda_dir, "bin", arch, f"cublas64_{cuda_major_version}.dll"),

--- a/onnxruntime/test/python/onnxruntime_test_python_preload_dlls.py
+++ b/onnxruntime/test/python/onnxruntime_test_python_preload_dlls.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 # pylint: disable=C0114,C0115,C0116,W0212
 import unittest
+from unittest.mock import patch
 
 import onnxruntime
 
@@ -43,6 +44,15 @@ class TestGetNvidiaDllPaths(unittest.TestCase):
         self.assertIn(("nvidia", "cu13", "bin", "x86_64", "cublas64_13.dll"), paths)
         self.assertIn(("nvidia", "cu13", "bin", "x86_64", "cufft64_12.dll"), paths)
         self.assertIn(("nvidia", "cu13", "bin", "x86_64", "cudart64_13.dll"), paths)
+
+    @patch("platform.machine", return_value="ARM64")
+    @patch("sysconfig.get_platform", return_value="win-amd64")
+    def test_cuda13_windows_uses_process_architecture(self, get_platform, machine):
+        paths = self._paths(is_windows=True, build_cuda_version="13.2", cudnn=False)
+        self.assertIn(("nvidia", "cu13", "bin", "x86_64", "cudart64_13.dll"), paths)
+        self.assertNotIn(("nvidia", "cu13", "bin", "arm64", "cudart64_13.dll"), paths)
+        get_platform.assert_called_once()
+        machine.assert_not_called()
 
     def test_cuda13_windows_arch_override(self):
         paths = self._paths(is_windows=True, build_cuda_version="13.2", cudnn=False, arch="arm64")


### PR DESCRIPTION
## Summary
- Use `sysconfig.get_platform()` to select the CUDA 13 Windows DLL architecture directory from the running Python process.
- Keep an explicit test hook for deterministic CUDA 12/13 path coverage.
- Add a regression test for x64 Python running on an ARM64 machine, where `platform.machine()` reports the host architecture.

Fixes #29809

## Test Plan
- Importless execution of `onnxruntime_test_python_preload_dlls.py`: 8 tests passed
- `python -m py_compile onnxruntime/__init__.py onnxruntime/test/python/onnxruntime_test_python_preload_dlls.py`
- `python -m ruff check onnxruntime/__init__.py onnxruntime/test/python/onnxruntime_test_python_preload_dlls.py`
- `git diff --check`
- diff secret/conflict/debug scan

Note: direct local execution of `onnxruntime/test/python/onnxruntime_test_python_preload_dlls.py` from the source tree is blocked in this environment because `onnxruntime.capi` is not built/available.