### PR TITLE
[CUDA] Parallelize ArgMax/ArgMin over the reduction axis

### DIFF
--- a/onnxruntime/core/providers/cuda/reduction/reduction_functions.cu
+++ b/onnxruntime/core/providers/cuda/reduction/reduction_functions.cu
@@ -700,6 +700,21 @@ INSTANTIATE_REDUCE_SUM_ND(int64_t);
 #undef INSTANTIATE_REDUCE_SUM_ND
 
 namespace detail {
+// ArgMax/ArgMin keep the first occurrence of the extremum: the CUDA op rejects
+// select_last_index == 1, so ties resolve to the lower index.
+template <typename TIn, bool IsArgMax>
+__device__ __forceinline__ bool arg_is_better(TIn candidate, int64_t candidate_index,
+                                              TIn best, int64_t best_index) {
+  if constexpr (IsArgMax) {
+    if (candidate > best) return true;
+    if (best > candidate) return false;
+  } else {
+    if (candidate < best) return true;
+    if (best < candidate) return false;
+  }
+  return candidate_index < best_index;
+}
+
 template <typename TIn, bool IsArgMax>
 __global__ void arg_min_max_last_axis_kernel(const TIn* input, int64_t* output, int m, int n) {
   const int row = blockIdx.x * blockDim.x + threadIdx.x;
@@ -725,6 +740,48 @@ __global__ void arg_min_max_last_axis_kernel(const TIn* input, int64_t* output, 
 
   output[row] = best_index;
 }
+
+// One block per row. Threads stride the reduction axis so the loads coalesce, then the
+// per-thread candidates are combined in shared memory. Every thread seeds with element 0,
+// which is always a valid candidate and never wins over a strictly better one, so rows
+// shorter than the block are handled without a separate guard.
+template <typename TIn, bool IsArgMax, int BlockSize>
+__global__ void arg_min_max_last_axis_block_kernel(const TIn* input, int64_t* output, int n) {
+  __shared__ TIn shared_value[BlockSize];
+  __shared__ int64_t shared_index[BlockSize];
+
+  const int64_t row_offset = static_cast<int64_t>(blockIdx.x) * n;
+  const int tid = threadIdx.x;
+
+  TIn best_value = input[row_offset];
+  int64_t best_index = 0;
+  for (int i = tid; i < n; i += BlockSize) {
+    const TIn value = input[row_offset + i];
+    if (arg_is_better<TIn, IsArgMax>(value, i, best_value, best_index)) {
+      best_value = value;
+      best_index = i;
+    }
+  }
+
+  shared_value[tid] = best_value;
+  shared_index[tid] = best_index;
+  __syncthreads();
+
+  for (int stride = BlockSize / 2; stride > 0; stride >>= 1) {
+    if (tid < stride) {
+      if (arg_is_better<TIn, IsArgMax>(shared_value[tid + stride], shared_index[tid + stride],
+                                       shared_value[tid], shared_index[tid])) {
+        shared_value[tid] = shared_value[tid + stride];
+        shared_index[tid] = shared_index[tid + stride];
+      }
+    }
+    __syncthreads();
+  }
+
+  if (tid == 0) {
+    output[blockIdx.x] = shared_index[0];
+  }
+}
 }  // namespace detail
 
 template <typename TIn, bool IsArgMax>
@@ -732,6 +789,14 @@ Status arg_min_max_last_axis(cudaStream_t stream, const TIn* input, int64_t* out
   // The kernel reads input[row_offset] unconditionally, so a non-empty reduction axis is required.
   if (m == 0 || n <= 0) return Status::OK();
   constexpr int block_size = 256;
+  // The thread-per-row kernel walks the reduction axis with a single thread, which serializes a
+  // long axis (e.g. a vocabulary-sized ArgMax) behind one lane. Once the axis is at least a full
+  // block wide, reducing it across the block is both parallel and coalesced.
+  if (n >= block_size) {
+    detail::arg_min_max_last_axis_block_kernel<TIn, IsArgMax, block_size>
+        <<<m, block_size, 0, stream>>>(input, output, n);
+    return CUDA_CALL(cudaGetLastError());
+  }
   const int grid_size = (m + block_size - 1) / block_size;
   detail::arg_min_max_last_axis_kernel<TIn, IsArgMax><<<grid_size, block_size, 0, stream>>>(input, output, m, n);
   return CUDA_CALL(cudaGetLastError());

--- a/onnxruntime/test/providers/cpu/reduction/reduction_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/reduction/reduction_ops_test.cc
@@ -3618,6 +3618,30 @@ TEST(ReductionOpTest, ArgMax_float_first_index_random) {
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
 }
 
+// 300 is wider than the CUDA block-reduction width (256) and not a multiple of it, so the
+// strided per-thread loop leaves a remainder, and several rows exercise the grid mapping.
+TEST(ReductionOpTest, ArgMax_float_long_axis_multiple_rows) {
+  OpTester test("ArgMax", 12);
+  test.AddAttribute("axis", static_cast<int64_t>(-1));
+  test.AddAttribute("keepdims", static_cast<int64_t>(0));
+  test.AddAttribute("select_last_index", static_cast<int64_t>(0));
+
+  constexpr int64_t rows = 4;
+  constexpr int64_t cols = 300;
+  std::vector<float> data(rows * cols, 1.0f);
+
+  data[0 * cols + 0] = 9.0f;         // maximum at the first element
+  data[1 * cols + cols - 1] = 9.0f;  // maximum in the remainder of the strided loop
+  data[2 * cols + 5] = 9.0f;         // duplicate maxima must resolve to the lower index
+  data[2 * cols + 250] = 9.0f;
+  // Row 3 stays constant, so every element ties and index 0 must win.
+
+  test.AddInput<float>("data", {rows, cols}, data);
+  test.AddOutput<int64_t>("reduced", {rows}, {0, 299, 5, 0});
+
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
+}
+
 TEST(ReductionOpTest, ArgMax_int32_neg_axis) {
   OpTester test("ArgMax");
   test.AddAttribute("axis", (int64_t)(-2));
@@ -3914,6 +3938,29 @@ TEST(ReductionOpTest, ArgMin_int32_select_last) {
                            0, 0});
 
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+}
+
+// Mirror of ArgMax_float_long_axis_multiple_rows for the minimum, covering the same
+// block-reduction path and lowest-index tie-break.
+TEST(ReductionOpTest, ArgMin_float_long_axis_multiple_rows) {
+  OpTester test("ArgMin", 12);
+  test.AddAttribute("axis", static_cast<int64_t>(-1));
+  test.AddAttribute("keepdims", static_cast<int64_t>(0));
+  test.AddAttribute("select_last_index", static_cast<int64_t>(0));
+
+  constexpr int64_t rows = 4;
+  constexpr int64_t cols = 300;
+  std::vector<float> data(rows * cols, 1.0f);
+
+  data[0 * cols + 0] = -9.0f;
+  data[1 * cols + cols - 1] = -9.0f;
+  data[2 * cols + 5] = -9.0f;
+  data[2 * cols + 250] = -9.0f;
+
+  test.AddInput<float>("data", {rows, cols}, data);
+  test.AddOutput<int64_t>("reduced", {rows}, {0, 299, 5, 0});
+
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
 }
 
 TEST(ReductionOpTest, ArgMin_int32_neg_axis) {


### PR DESCRIPTION
### Description

`arg_min_max_last_axis_kernel` parallelizes only across rows, so a single thread walks the entire reduction axis. When the axis is long and there are few rows, the GPU is almost entirely idle.

This adds `arg_min_max_last_axis_block_kernel`, which assigns one block per row, strides the reduction axis across the block so the loads coalesce, and combines the per-thread candidates with a shared-memory tree reduction. The launcher picks it once the axis is at least a full block wide (256) and keeps the existing thread-per-row kernel for short axes, where that mapping is still the better one.

### Motivation and Context

An `ArgMax` over a 129280-wide axis with a single row currently launches:

```
grid = (1, 1, 1)   block = (256, 1, 1)
```

with **exactly one active thread**, issuing 129280 dependent global loads — about **3.10 ms per call**, roughly 0.17 GB/s of achieved bandwidth.

That shape is common at decode time, where a model takes an `ArgMax` over the vocabulary to pick the next token. It was found while profiling a speculative-decoding workload on 8×H200, where five such `ArgMax` calls per step accounted for **90.4%** of the drafter's GPU kernel time.

### Performance

Measured on H200 (sm90), one row, 129280-wide axis:

| | per call |
|---|---|
| thread-per-row (before) | 3098 µs |
| block-per-row (after) | 46 µs |
| | **67× faster** |

In the speculative-decoding workload that motivated the change, the affected model's kernel time dropped from 448.71 ms to 6.73 ms and end-to-end decode throughput improved by 52.6%, with unchanged output.

### Semantics

Ties continue to resolve to the **lowest** index, matching ONNX's first-occurrence rule. Each thread seeds with element 0, which is always a valid candidate and can never displace a strictly better one, so rows shorter than the block need no separate guard. The CUDA EP already rejects `select_last_index == 1`, so only first-occurrence behavior has to be preserved.

Short axes (`n < 256`) keep the original kernel, since one thread per row is the better mapping when there are many rows and little to reduce.

### Testing

- Compared the CUDA EP against the CPU EP over **396 configurations** — float / MLFloat16 / double × ArgMax / ArgMin × `keepdims` 0/1 × random, tied, and all-equal inputs, across axis lengths spanning both sides of the 256 threshold (1, 2, 255, 256, 257, 1000, 129280) and row counts 1–300. All matched.
- Added `ArgMax_float_long_axis_multiple_rows` and `ArgMin_float_long_axis_multiple_rows` to `reduction_ops_test.cc`. They use a 300-wide axis — wider than the block and not a multiple of it — over 4 rows, covering the strided-loop remainder, the grid mapping across rows, a maximum in the first position, a maximum in the remainder region, duplicate extrema (must return the lower index), and a fully constant row.
- The existing `ArgMax_float_first_index_random` test already exercises this path (1 row, 65536-wide axis, duplicate `+inf` values expecting the lowest index) and continues to pass.
