### PR TITLE
Fix uninterpolated error messages in per-channel TensorQuantOverrides validation

### DIFF
--- a/onnxruntime/python/tools/quantization/tensor_quant_overrides.py
+++ b/onnxruntime/python/tools/quantization/tensor_quant_overrides.py
@@ -311,22 +311,22 @@ class TensorQuantOverridesHelper(MutableMapping):
             if "quant_type" in quant_overrides and quant_type != quant_overrides["quant_type"]:
                 return (
                     False,
-                    "Channel quantization types for tensor '{tensor_name}' do not match at index {index}.",
+                    f"Channel quantization types for tensor '{tensor_name}' do not match at index {index}.",
                 )
             if "axis" in quant_overrides and axis != quant_overrides["axis"] and norm_axis != quant_overrides["axis"]:
                 return (
                     False,
-                    "Channel axis for tensor '{tensor_name}' does not match at index {index}.",
+                    f"Channel axis for tensor '{tensor_name}' does not match at index {index}.",
                 )
             if "symmetric" in quant_overrides and symmetric != quant_overrides["symmetric"]:
                 return (
                     False,
-                    "Channel symmetric value for tensor '{tensor_name}' does not match at index {index}.",
+                    f"Channel symmetric value for tensor '{tensor_name}' does not match at index {index}.",
                 )
             if "reduce_range" in quant_overrides and reduce_range != quant_overrides["reduce_range"]:
                 return (
                     False,
-                    "Channel reduce_range value for tensor '{tensor_name}' does not match at index {index}.",
+                    f"Channel reduce_range value for tensor '{tensor_name}' does not match at index {index}.",
                 )
 
             # If override scale/zp, must do so for all channels.

--- a/onnxruntime/test/python/quantization/test_tensor_quant_overrides_option.py
+++ b/onnxruntime/test/python/quantization/test_tensor_quant_overrides_option.py
@@ -662,6 +662,28 @@ class TestTensorQuantOverridesOption(unittest.TestCase):
 
         self.assertIn("option(s) [reduce_range] are invalid with 'scale' and 'zero_point'", str(context.exception))
 
+    def test_override_validation_per_channel_mismatch(self):
+        """
+        Test that per-channel overrides that disagree between channels produce an
+        error message with the tensor name and channel index actually filled in
+        (and not the literal, uninterpolated `{tensor_name}`/`{index}` placeholders).
+        """
+        with self.assertRaises(ValueError) as context:
+            self.perform_qdq_quantization(
+                "model_validation.onnx",
+                extra_options={
+                    "TensorQuantOverrides": {
+                        "WGT": [
+                            {"axis": 0, "symmetric": True},
+                            {"symmetric": False},
+                        ]
+                    }
+                },
+                per_channel=True,
+            )
+
+        self.assertIn("Channel symmetric value for tensor 'WGT' does not match at index 0.", str(context.exception))
+
     def test_get_qnn_qdq_config_sigmoid(self):
         """
         Test that the QNN-specific configs override the scale and zero-point of 16-bit Sigmoid.


### PR DESCRIPTION
Reopens #29551, which @xadupre had already approved. I accidentally killed that PR by deleting my fork while cleaning up old repos, and GitHub won't let a PR reopen once the head repo is gone. Same commit, cherry-picked onto current main (clean, no conflicts).

For context from the original PR:

Four error messages in `TensorQuantOverridesHelper._is_valid_per_channel` were built as plain strings instead of f-strings, so users hitting per-channel validation errors saw literal `{tensor_name}` and `{index}` placeholders instead of the actual tensor and channel index. The fix adds the missing `f` prefixes and a regression test.

Re-verified after the rebase: installed the published onnxruntime wheel, swapped in the patched `tensor_quant_overrides.py`, and ran `test_tensor_quant_overrides_option.py`: 22 passed, 47 subtests passed. Also did the negative control again, against the unpatched wheel the new test fails with the literal placeholder message, with the patch it passes.

The one failing check on the old PR (web_Debug / build_onnxruntime_web) was an unrelated WebGPU flake in the browser test suite, this change only touches the Python quantization tooling.