### PR TITLE
[Plugin EP Python package] Add `get_build_commit()` Python API

### DIFF
--- a/plugin-ep-cuda/python/README.md
+++ b/plugin-ep-cuda/python/README.md
@@ -17,7 +17,17 @@ python build_wheel.py \
   --binary_dir <path-to-built-binaries> \
   --version <PEP-440-version> \
   --package_name <onnxruntime-ep-cuda12-or-onnxruntime-ep-cuda13> \
+  --build_commit <git-commit> \
   --output_dir <output-directory>
 ```
 
 The script combines pre-built CUDA plugin EP binaries with the package source to produce a platform-specific wheel.
+
+The commit is omitted from the PEP 440 package version, even for development builds. Retrieve it with
+`get_build_commit()`:
+
+```python
+import onnxruntime_ep_cuda
+
+print(onnxruntime_ep_cuda.get_build_commit())
+```

--- a/plugin-ep-cuda/python/build_wheel.py
+++ b/plugin-ep-cuda/python/build_wheel.py
@@ -5,6 +5,7 @@ import argparse
 import platform
 import re
 import shutil
+import string
 import subprocess
 import sys
 import tempfile
@@ -41,7 +42,16 @@ AUDITWHEEL_EXCLUDE = [
 ]
 
 
-def prepare_staging_dir(staging_dir: Path, binary_dir: Path, version: str, package_name: str) -> None:
+def validate_build_commit(build_commit: str) -> None:
+    """Validate that build_commit is a non-empty hexadecimal Git object ID."""
+    if not build_commit or not all(character in string.hexdigits for character in build_commit):
+        raise ValueError("Build commit must be a non-empty hexadecimal Git object ID")
+
+
+def prepare_staging_dir(
+    staging_dir: Path, binary_dir: Path, version: str, package_name: str, build_commit: str
+) -> None:
+    validate_build_commit(build_commit)
     staging_dir.mkdir(parents=True, exist_ok=True)
     shutil.copy2(SCRIPT_DIR / "setup.py", staging_dir / "setup.py")
     shutil.copytree(SCRIPT_DIR / "onnxruntime_ep_cuda", staging_dir / "onnxruntime_ep_cuda")
@@ -74,6 +84,12 @@ def prepare_staging_dir(staging_dir: Path, binary_dir: Path, version: str, packa
         SCRIPT_DIR / "pyproject.toml.in",
         staging_dir / "pyproject.toml",
         {"package_name": package_name, "version": version},
+    )
+
+    gen_file_from_template(
+        package_dir / "_build_info.py",
+        package_dir / "_build_info.py",
+        {"build_commit": build_commit},
     )
 
 
@@ -136,6 +152,7 @@ def main() -> None:
     parser.add_argument("--binary_dir", required=True, type=Path, help="Directory containing built plugin EP binaries")
     parser.add_argument("--version", required=True, help="Package version string (PEP 440 format)")
     parser.add_argument("--package_name", required=True, help="Python distribution name to write into pyproject.toml")
+    parser.add_argument("--build_commit", required=True, help="Git commit used to build the plugin binaries")
     parser.add_argument("--output_dir", required=True, type=Path, help="Directory to place the built wheel")
     args = parser.parse_args()
 
@@ -149,7 +166,7 @@ def main() -> None:
     with tempfile.TemporaryDirectory(prefix="ort_cuda_wheel_") as tmp:
         staging_dir = Path(tmp) / "package"
         wheel_dir = Path(tmp) / "wheels"
-        prepare_staging_dir(staging_dir, args.binary_dir, args.version, args.package_name)
+        prepare_staging_dir(staging_dir, args.binary_dir, args.version, args.package_name, args.build_commit)
         build_wheel(staging_dir, wheel_dir)
         auditwheel_repair(wheel_dir, wheel_name_prefix)
         collect_wheels(wheel_dir, args.output_dir, wheel_name_prefix)

--- a/plugin-ep-cuda/python/onnxruntime_ep_cuda/__init__.py
+++ b/plugin-ep-cuda/python/onnxruntime_ep_cuda/__init__.py
@@ -4,13 +4,21 @@ from __future__ import annotations
 
 import pathlib
 
+from ._build_info import BUILD_COMMIT
+
 __all__ = [
+    "get_build_commit",
     "get_ep_name",
     "get_ep_names",
     "get_library_path",
 ]
 
 _module_dir = pathlib.Path(__file__).parent
+
+
+def get_build_commit() -> str:
+    """Return the Git commit used to build this package."""
+    return BUILD_COMMIT
 
 
 def get_library_path() -> str:

--- a/plugin-ep-cuda/python/onnxruntime_ep_cuda/_build_info.py
+++ b/plugin-ep-cuda/python/onnxruntime_ep_cuda/_build_info.py
@@ -1,0 +1,3 @@
+"""Build metadata generated when packaging the wheel. Not a public module."""
+
+BUILD_COMMIT = "@build_commit@"

--- a/plugin-ep-cuda/python/test/test_cuda_plugin_ep.py
+++ b/plugin-ep-cuda/python/test/test_cuda_plugin_ep.py
@@ -17,6 +17,7 @@ import sys
 import tempfile
 import traceback
 from contextlib import suppress
+from importlib import metadata
 from pathlib import Path
 
 # On Windows, Python 3.8+ no longer searches PATH when loading DLLs. Add each
@@ -76,13 +77,18 @@ def print_environment_info():
             print(f"  ENV {var}={os.environ[var]}")
 
 
-def test_import_and_library_path():
-    """Test that the package imports and the library path is valid."""
+def test_import_and_accessors():
+    """Test that the package imports and that the accessors work."""
     import onnxruntime_ep_cuda as cuda_ep  # noqa: PLC0415
 
     debug_print(f"  Package location: {cuda_ep.__file__}")
     pkg_dir = Path(cuda_ep.__file__).parent
     debug_print(f"  Package directory contents: {sorted(p.name for p in pkg_dir.iterdir())}")
+
+    package_names = metadata.packages_distributions().get("onnxruntime_ep_cuda", [])
+    assert len(package_names) == 1, f"Expected one CUDA plugin distribution, found: {package_names}"
+    print(f"Package version: {metadata.version(package_names[0])}")
+    print(f"Build commit: {cuda_ep.get_build_commit()}")
 
     lib_path = cuda_ep.get_library_path()
     assert Path(lib_path).is_file(), f"Library path does not exist: {lib_path}"
@@ -165,8 +171,8 @@ def main():
         print("\n--- Environment ---")
         print_environment_info()
 
-    print("\n--- Test 1: Import and library path ---")
-    test_import_and_library_path()
+    print("\n--- Test 1: Import and accessors ---")
+    test_import_and_accessors()
 
     print("\n--- Test 2: Registration and inference ---")
     test_registration_and_inference()

--- a/plugin-ep-webgpu/python/README.md
+++ b/plugin-ep-webgpu/python/README.md
@@ -23,13 +23,21 @@ The wheel is platform-specific. Each platform's wheel is built from binaries pro
 [bundled wheel readme](onnxruntime_ep_webgpu/README.md#supported-platforms) for the list of supported platforms.
 
 ```bash
-python build_wheel.py --binary_dir <path-to-built-binaries> --version <PEP-440-version> --output_dir <output-directory>
+python build_wheel.py \
+	--binary_dir <path-to-built-binaries> \
+	--version <PEP-440-version> \
+	--build_commit <git-commit> \
+	--output_dir <output-directory>
 ```
 
 Example:
 
 ```bash
-python build_wheel.py --binary_dir ./build/Release --version 0.1.0.devYYYYMMDD --output_dir ./dist
+python build_wheel.py \
+	--binary_dir ./build/Release \
+	--version 0.1.0.devYYYYMMDD \
+	--build_commit "$(git rev-parse --short=8 HEAD)" \
+	--output_dir ./dist
 ```
 
 The script combines the pre-built plugin EP binaries with the package source to produce a platform-specific wheel.
@@ -47,8 +55,7 @@ python test/test_webgpu_plugin_ep.py
 ```
 
 `onnx` and `numpy` are required only by the smoke test, not by the `onnxruntime-ep-webgpu` wheel itself. The wheel's
-only runtime dependency is a compatible `onnxruntime` (see
-[`../MIN_ONNXRUNTIME_VERSION`](../MIN_ONNXRUNTIME_VERSION)).
+only runtime dependency is a compatible `onnxruntime` (see [`../MIN_ONNXRUNTIME_VERSION`](../MIN_ONNXRUNTIME_VERSION)).
 
 The test validates import, EP registration, device discovery, and inference (requires WebGPU-capable hardware for the
 inference portion). Set the environment variable `ORT_TEST_VERBOSE=1` to print additional diagnostic information
@@ -59,3 +66,12 @@ inference portion). Set the environment variable `ORT_TEST_VERBOSE=1` to print a
 The package version is derived from [`../VERSION_NUMBER`](../VERSION_NUMBER) by the packaging pipeline (see
 [`set-plugin-ep-build-variables-step.yml`](../../tools/ci_build/github/azure-pipelines/templates/set-plugin-ep-build-variables-step.yml)),
 which produces a PEP 440 version string.
+
+The commit is omitted from the PEP 440 package version, even for development builds. Retrieve it with
+`get_build_commit()`:
+
+```python
+import onnxruntime_ep_webgpu
+
+print(onnxruntime_ep_webgpu.get_build_commit())
+```

--- a/plugin-ep-webgpu/python/build_wheel.py
+++ b/plugin-ep-webgpu/python/build_wheel.py
@@ -9,12 +9,13 @@ Combines pre-built plugin EP binaries with the Python package source to produce
 a platform-specific wheel.
 
 Usage:
-    python build_wheel.py --binary_dir <path> --version <ver> --output_dir <path>
+    python build_wheel.py --binary_dir <path> --version <ver> --build_commit <sha> --output_dir <path>
 """
 
 import argparse
 import platform
 import shutil
+import string
 import subprocess
 import sys
 import tempfile
@@ -48,8 +49,15 @@ AUDITWHEEL_EXCLUDE = [
 ]
 
 
-def prepare_staging_dir(staging_dir: Path, binary_dir: Path, version: str):
+def validate_build_commit(build_commit: str) -> None:
+    """Validate that build_commit is a non-empty hexadecimal Git object ID."""
+    if not build_commit or not all(character in string.hexdigits for character in build_commit):
+        raise ValueError("Build commit must be a non-empty hexadecimal Git object ID")
+
+
+def prepare_staging_dir(staging_dir: Path, binary_dir: Path, version: str, build_commit: str):
     """Copy the package source tree into staging_dir, copy binaries, and stamp the version."""
+    validate_build_commit(build_commit)
     staging_dir.mkdir(parents=True, exist_ok=True)
 
     # Copy only the files needed to build the wheel
@@ -95,6 +103,12 @@ def prepare_staging_dir(staging_dir: Path, binary_dir: Path, version: str):
         SCRIPT_DIR / "pyproject.toml.in",
         staging_dir / "pyproject.toml",
         {"version": version},
+    )
+
+    gen_file_from_template(
+        package_dir / "_build_info.py",
+        package_dir / "_build_info.py",
+        {"build_commit": build_commit},
     )
 
 
@@ -166,6 +180,7 @@ def main():
         "--binary_dir", required=True, type=Path, help="Directory containing the built plugin EP binaries"
     )
     parser.add_argument("--version", required=True, help="Package version string (PEP 440 format)")
+    parser.add_argument("--build_commit", required=True, help="Git commit used to build the plugin binaries")
     parser.add_argument("--output_dir", required=True, type=Path, help="Directory to place the built wheel")
     args = parser.parse_args()
 
@@ -176,7 +191,7 @@ def main():
         staging_dir = Path(tmp) / "package"
         wheel_dir = Path(tmp) / "wheels"
 
-        prepare_staging_dir(staging_dir, args.binary_dir, args.version)
+        prepare_staging_dir(staging_dir, args.binary_dir, args.version, args.build_commit)
         build_wheel(staging_dir, wheel_dir)
         auditwheel_repair(wheel_dir)
         collect_wheels(wheel_dir, args.output_dir)

--- a/plugin-ep-webgpu/python/onnxruntime_ep_webgpu/__init__.py
+++ b/plugin-ep-webgpu/python/onnxruntime_ep_webgpu/__init__.py
@@ -11,13 +11,21 @@ from __future__ import annotations
 
 import pathlib
 
+from ._build_info import BUILD_COMMIT
+
 __all__ = [
+    "get_build_commit",
     "get_ep_name",
     "get_ep_names",
     "get_library_path",
 ]
 
 _module_dir = pathlib.Path(__file__).parent
+
+
+def get_build_commit() -> str:
+    """Return the Git commit used to build this package."""
+    return BUILD_COMMIT
 
 
 def get_library_path() -> str:

--- a/plugin-ep-webgpu/python/onnxruntime_ep_webgpu/_build_info.py
+++ b/plugin-ep-webgpu/python/onnxruntime_ep_webgpu/_build_info.py
@@ -1,0 +1,6 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+"""Build metadata generated when packaging the wheel. Not a public module."""
+
+BUILD_COMMIT = "@build_commit@"

--- a/plugin-ep-webgpu/python/test/test_webgpu_plugin_ep.py
+++ b/plugin-ep-webgpu/python/test/test_webgpu_plugin_ep.py
@@ -20,6 +20,7 @@ import platform
 import sys
 import tempfile
 import traceback
+from importlib import metadata
 from pathlib import Path
 
 import numpy as np
@@ -69,13 +70,16 @@ def print_environment_info():
             print(f"  ENV {var}={os.environ[var]}")
 
 
-def test_import_and_library_path():
-    """Test that the package imports and the library path is valid."""
+def test_import_and_accessors():
+    """Test that the package imports and that the accessors work."""
     import onnxruntime_ep_webgpu as webgpu_ep  # noqa: PLC0415  # `import` should be at the top-level of a file.
 
     debug_print(f"  Package location: {webgpu_ep.__file__}")
     pkg_dir = Path(webgpu_ep.__file__).parent
     debug_print(f"  Package directory contents: {sorted(p.name for p in pkg_dir.iterdir())}")
+
+    print(f"Package version: {metadata.version('onnxruntime-ep-webgpu')}")
+    print(f"Build commit: {webgpu_ep.get_build_commit()}")
 
     lib_path = webgpu_ep.get_library_path()
     assert Path(lib_path).is_file(), f"Library path does not exist: {lib_path}"
@@ -158,8 +162,8 @@ def main():
         print("\n--- Environment ---")
         print_environment_info()
 
-    print("\n--- Test 1: Import and library path ---")
-    test_import_and_library_path()
+    print("\n--- Test 1: Import and accessors ---")
+    test_import_and_accessors()
 
     print("\n--- Test 2: Registration and inference ---")
     test_registration_and_inference()

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-linux-cuda-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-linux-cuda-stage.yml
@@ -228,5 +228,6 @@ stages:
             -i onnxruntimecuda${{ replace(parameters.cuda_version, '.', '') }}pluginbuild${{ parameters.arch }} \
             -p ${{ parameters.docker_python_exe_path }} \
             -v "$(PluginPythonPackageVersion)" \
-            -n "${{ parameters.python_package_name }}"
+            -n "${{ parameters.python_package_name }}" \
+            -c "$(PluginBuildCommit)"
         displayName: 'Build Python wheel'

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-linux-webgpu-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-linux-webgpu-stage.yml
@@ -132,5 +132,6 @@ stages:
         set -e -x
         $(Build.SourcesDirectory)/tools/ci_build/github/linux/build_webgpu_plugin_python_package.sh \
           -i onnxruntimewebgpuplugin \
-          -v "$(PluginPythonPackageVersion)"
+          -v "$(PluginPythonPackageVersion)" \
+          -c "$(PluginBuildCommit)"
       displayName: 'Build Python wheel'

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-mac-webgpu-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-mac-webgpu-stage.yml
@@ -161,5 +161,6 @@ stages:
         python3 "$(Build.SourcesDirectory)/plugin-ep-webgpu/python/build_wheel.py" \
           --binary_dir "$(Build.BinariesDirectory)/plugin_artifacts/bin" \
           --version "$(PluginPythonPackageVersion)" \
+          --build_commit "$(PluginBuildCommit)" \
           --output_dir "$(Build.ArtifactStagingDirectory)/python"
       displayName: 'Build Python wheel'

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-win-cuda-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-win-cuda-stage.yml
@@ -386,5 +386,6 @@ stages:
             --binary_dir "$(Build.BinariesDirectory)\plugin_artifacts\bin" `
             --version "$(PluginPythonPackageVersion)" `
             --package_name "${{ parameters.python_package_name }}" `
+            --build_commit "$(PluginBuildCommit)" `
             --output_dir "$(Build.ArtifactStagingDirectory)\python"
         displayName: 'Build Python wheel'

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-win-webgpu-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-win-webgpu-stage.yml
@@ -238,5 +238,6 @@ stages:
           python "$(Build.SourcesDirectory)\plugin-ep-webgpu\python\build_wheel.py" `
             --binary_dir "$(Build.BinariesDirectory)\plugin_artifacts\bin" `
             --version "$(PluginPythonPackageVersion)" `
+            --build_commit "$(PluginBuildCommit)" `
             --output_dir "$(Build.ArtifactStagingDirectory)\python"
         displayName: 'Build Python wheel'

--- a/tools/ci_build/github/linux/build_cuda_plugin_python_package.sh
+++ b/tools/ci_build/github/linux/build_cuda_plugin_python_package.sh
@@ -5,15 +5,17 @@ DOCKER_IMAGE="onnxruntimecuda128pluginbuildx64"
 PYTHON_EXE="/opt/python/cp312-cp312/bin/python3.12"
 VERSION=""
 PACKAGE_NAME=""
+BUILD_COMMIT=""
 
-while getopts "i:p:v:n:" parameter_Option
+while getopts "i:p:v:n:c:" parameter_Option
 do case "${parameter_Option}"
 in
 i) DOCKER_IMAGE=${OPTARG};;
 p) PYTHON_EXE=${OPTARG};;
 v) VERSION=${OPTARG};;
 n) PACKAGE_NAME=${OPTARG};;
-*) echo "Usage: $0 -i <docker_image> -p <python_exe_path> -v <version> -n <package_name>"
+c) BUILD_COMMIT=${OPTARG};;
+*) echo "Usage: $0 -i <docker_image> -p <python_exe_path> -v <version> -n <package_name> -c <build_commit>"
    exit 1;;
 esac
 done
@@ -28,6 +30,11 @@ if [ -z "$PACKAGE_NAME" ]; then
   exit 1
 fi
 
+if [ -z "$BUILD_COMMIT" ]; then
+  echo "ERROR: Build commit is required. Use -c <build_commit>"
+  exit 1
+fi
+
 PYTHON_BIN_DIR=$(dirname "${PYTHON_EXE}")
 
 docker run --rm \
@@ -37,6 +44,7 @@ docker run --rm \
     --env PIP_INDEX_URL \
     --env "ORT_CUDA_PLUGIN_EP_VERSION=${VERSION}" \
     --env "ORT_CUDA_PLUGIN_EP_PACKAGE_NAME=${PACKAGE_NAME}" \
+    --env "ORT_CUDA_PLUGIN_EP_BUILD_COMMIT=${BUILD_COMMIT}" \
     "$DOCKER_IMAGE" \
     /bin/bash -c '
       set -e -x
@@ -46,5 +54,6 @@ docker run --rm \
         --binary_dir /build/plugin_artifacts/bin \
         --version "$ORT_CUDA_PLUGIN_EP_VERSION" \
         --package_name "$ORT_CUDA_PLUGIN_EP_PACKAGE_NAME" \
+        --build_commit "$ORT_CUDA_PLUGIN_EP_BUILD_COMMIT" \
         --output_dir /staging/python
     '

--- a/tools/ci_build/github/linux/build_webgpu_plugin_python_package.sh
+++ b/tools/ci_build/github/linux/build_webgpu_plugin_python_package.sh
@@ -7,13 +7,15 @@ set -e -x
 
 DOCKER_IMAGE="onnxruntimewebgpuplugin"
 VERSION=""
+BUILD_COMMIT=""
 
-while getopts "i:v:" parameter_Option
+while getopts "i:v:c:" parameter_Option
 do case "${parameter_Option}"
 in
 i) DOCKER_IMAGE=${OPTARG};;
 v) VERSION=${OPTARG};;
-*) echo "Usage: $0 -i <docker_image> -v <version>"
+c) BUILD_COMMIT=${OPTARG};;
+*) echo "Usage: $0 -i <docker_image> -v <version> -c <build_commit>"
    exit 1;;
 esac
 done
@@ -23,12 +25,18 @@ if [ -z "$VERSION" ]; then
   exit 1
 fi
 
+if [ -z "$BUILD_COMMIT" ]; then
+  echo "ERROR: Build commit is required. Use -c <build_commit>"
+  exit 1
+fi
+
 docker run --rm \
     --volume "${BUILD_SOURCESDIRECTORY}:/onnxruntime_src" \
     --volume "${BUILD_BINARIESDIRECTORY}:/build" \
     --volume "${BUILD_ARTIFACTSTAGINGDIRECTORY}:/staging" \
     --env "PIP_INDEX_URL=${PIP_INDEX_URL}" \
     --env "ORT_WEBGPU_PLUGIN_EP_VERSION=${VERSION}" \
+    --env "ORT_WEBGPU_PLUGIN_EP_BUILD_COMMIT=${BUILD_COMMIT}" \
     "$DOCKER_IMAGE" \
     /bin/bash -c '
       set -e -x
@@ -37,5 +45,6 @@ docker run --rm \
       python3 /onnxruntime_src/plugin-ep-webgpu/python/build_wheel.py \
         --binary_dir /build/plugin_artifacts/bin \
         --version "$ORT_WEBGPU_PLUGIN_EP_VERSION" \
+        --build_commit "$ORT_WEBGPU_PLUGIN_EP_BUILD_COMMIT" \
         --output_dir /staging/python
     '

--- a/tools/ci_build/set_plugin_ep_build_variables.py
+++ b/tools/ci_build/set_plugin_ep_build_variables.py
@@ -46,6 +46,19 @@ def main():
     print(f"Original version: {original_ver}")
     print(f"Package version type: {package_version}")
 
+    try:
+        commit_sha = (
+            subprocess.check_output(
+                ["git", "rev-parse", "--short=8", "HEAD"],
+                cwd=src_root,
+            )
+            .decode("utf-8")
+            .strip()
+        )
+    except Exception as e:
+        print(f"##vso[task.logissue type=error]Failed to get git commit: {e}")
+        sys.exit(1)
+
     if package_version == "release":
         version_string = original_ver
         python_version = original_ver
@@ -58,14 +71,6 @@ def main():
 
     elif package_version == "dev":
         try:
-            commit_sha = (
-                subprocess.check_output(
-                    ["git", "rev-parse", "--short=8", "HEAD"],
-                    cwd=src_root,
-                )
-                .decode("utf-8")
-                .strip()
-            )
             date_str = (
                 subprocess.check_output(
                     ["git", "show", "-s", "--format=%cd", "--date=format:%Y%m%d", "HEAD"],
@@ -75,7 +80,7 @@ def main():
                 .strip()
             )
         except Exception as e:
-            print(f"##vso[task.logissue type=error]Failed to get git info: {e}")
+            print(f"##vso[task.logissue type=error]Failed to get git commit date: {e}")
             sys.exit(1)
         version_string = f"{original_ver}-dev.{date_str}+{commit_sha}"
         python_version = f"{original_ver}.dev{date_str}"
@@ -104,6 +109,7 @@ def main():
     print(f"##vso[task.setvariable variable=PluginPackageVersion]{version_string}")
     print(f"##vso[task.setvariable variable=PluginPythonPackageVersion]{python_version}")
     print(f"##vso[task.setvariable variable=PluginEpVersionDefine]onnxruntime_PLUGIN_EP_VERSION={version_string}")
+    print(f"##vso[task.setvariable variable=PluginBuildCommit]{commit_sha}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Adds a `get_build_commit()` Python API to retrieve the git commit SHA used to build the plugin EP package.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Provide a way to get the build commit from a nightly plugin EP Python package build.

#### Notes

This is Python-specific since the PEP 440 version spec doesn't allow inclusion of a commit (outside of a local version segment, which is not allowed on PyPI or ADO feeds).

A separate Python package API is one way to provide this information. A more centralized approach would be to allow the plugin EP library to have a standard way to report build info, such as the build commit. It's not clear how to best fit that into the existing plugin EP library API though.