### PR TITLE
Handle zero-element input/bias in BiasGelu and FastGelu as a no-op

### DIFF
--- a/onnxruntime/contrib_ops/cpu/bert/bias_gelu.cc
+++ b/onnxruntime/contrib_ops/cpu/bert/bias_gelu.cc
@@ -39,6 +39,12 @@ Status BiasGelu<T, use_approximation>::Compute(OpKernelContext* context) const {
   Tensor* output = context->Output(0, input->Shape());
   T* output_data = output->MutableData<T>();
 
+  // An empty input (and, correspondingly, an empty bias) is a legal degenerate case per the
+  // ONNX shape model; treat it as a no-op rather than let elem_count / bias_len divide by zero below.
+  if (elem_count == 0) {
+    return Status::OK();
+  }
+
   const Tensor* bias = context->Input<Tensor>(1);
   if (nullptr == bias) {
     // FastGelu allows optional bias. Here we split input data into chunks. Each chunk

--- a/onnxruntime/contrib_ops/cuda/math/bias_gelu.cc
+++ b/onnxruntime/contrib_ops/cuda/math/bias_gelu.cc
@@ -32,12 +32,19 @@ Status BiasGelu::ComputeInternal(OpKernelContext* context) const {
 
   const auto& input_shape = X->Shape();
   const auto& bias_shape = B->Shape();
-  ORT_ENFORCE(input_shape.NumDimensions() >= 1 && bias_shape.NumDimensions() == 1 &&
-                  input_shape.GetDims().back() == bias_shape.GetDims().back(),
-              "B must be 1-dimensional and match the last dimension of X.");
+  ORT_RETURN_IF_NOT(input_shape.NumDimensions() >= 1 && bias_shape.NumDimensions() == 1 &&
+                        input_shape.GetDims().back() == bias_shape.GetDims().back(),
+                    "B must be 1-dimensional and match the last dimension of X.");
 
   auto* Y = context->Output(0, input_shape);
   ORT_ENFORCE(Y);
+
+  // An empty input (and, correspondingly, an empty bias) is a legal degenerate case per the
+  // ONNX shape model; treat it as a no-op rather than let the launch grid computation
+  // (which divides input_size by bias_size) divide by zero below.
+  if (input_shape.Size() == 0) {
+    return Status::OK();
+  }
 
   const auto input_size = input_shape.Size();
   const auto bias_size = bias_shape.Size();

--- a/onnxruntime/test/contrib_ops/element_wise_ops_test.cc
+++ b/onnxruntime/test/contrib_ops/element_wise_ops_test.cc
@@ -109,6 +109,17 @@ TEST(BiasGeluTest, Float) {
   RunBiasGeluTestFloat({2, 2333}, {2333});
 }
 
+// An empty input (with a correspondingly empty bias) is a legal degenerate case per the ONNX
+// shape model. The CPU/CUDA kernels must treat it as a no-op rather than divide the (zero) input
+// element count by the (zero) bias length.
+TEST(BiasGeluTest, ZeroLengthBiasIsNoOp) {
+  OpTester tester("BiasGelu", 1, onnxruntime::kMSDomain);
+  tester.AddInput<float>("A", {2, 0}, {});
+  tester.AddInput<float>("B", {0}, {});
+  tester.AddOutput<float>("C", {2, 0}, {});
+  tester.Run();
+}
+
 #if defined(USE_CUDA) || defined(USE_DML) || defined(USE_WEBGPU)
 static void RunBiasGeluTestHalf(const std::vector<int64_t>& input_dims, const std::vector<int64_t>& bias_dims) {
   RandomValueGenerator random{2333};

--- a/onnxruntime/test/contrib_ops/fastgelu_op_test.cc
+++ b/onnxruntime/test/contrib_ops/fastgelu_op_test.cc
@@ -160,6 +160,18 @@ TEST(FastGeluTest, FastGeluWithNullInput) {
 
   RunFastGeluTest(input_data, bias_data, batch_size, sequence_length, hidden_size);
 }
+
+// An empty input (with a correspondingly empty bias) is a legal degenerate case per the ONNX
+// shape model. The CPU/CUDA kernels must treat it as a no-op rather than divide the (zero) input
+// element count by the (zero) bias length.
+TEST(FastGeluTest, ZeroLengthBiasIsNoOp) {
+  OpTester tester("FastGelu", 1, onnxruntime::kMSDomain);
+  tester.AddInput<float>("X", {2, 0}, {});
+  tester.AddInput<float>("bias", {0}, {});
+  tester.AddOutput<float>("Y", {2, 0}, {});
+  tester.Run();
+}
+
 #if defined(USE_DNNL)
 TEST(FastGeluTest, FastGeluWithBias_bfloat16) {
 #ifdef USE_DNNL


### PR DESCRIPTION
### Description
An empty input (with a correspondingly empty bias, per the existing shape-matching validation in `bias_gelu_helper::CheckInputs`) is a legal degenerate case under the ONNX shape model. The CPU `BiasGelu`/`FastGelu` kernel and the CUDA `BiasGelu` kernel previously computed a divisor from the bias length before checking for this case, causing an integer division by zero when both input and bias have zero elements.

This adds an early return for the zero-element case in both kernels, matching the existing no-op behavior already used by:
- the standard ONNX `Gelu` CPU kernel (`core/providers/cpu/tensor/gelu.cc`)
- CUDA `FastGelu` (`contrib_ops/cuda/bert/fast_gelu.cc`)
- WebGPU `BiasGelu`/`FastGelu`

This also closes a second, independent division-by-zero that only affects the CUDA `BiasGelu` launch-grid computation, which wasn't guarded by the existing shape-equality check.

### Motivation and Context
A model with a `BiasGelu`/`FastGelu` node whose input's last dimension (and bias length) is 0 could previously trigger a crash at inference on CPU or CUDA. Rather than rejecting this input outright (which would make CPU/CUDA diverge from WebGPU's and the standard `Gelu` kernel's existing behavior of treating it as a no-op), this fix makes all paths consistent.

### Testing
Added `BiasGeluTest.ZeroLengthBiasIsNoOp` and `FastGeluTest.ZeroLengthBiasIsNoOp` regression tests verifying the zero-element case completes successfully with an empty output, rather than asserting on an EP-specific error message string, so the tests remain valid across execution providers.