### PR TITLE
[WebGPU plugin EP] Update Python package test to only pass one WebGPU EP device

### DIFF
--- a/plugin-ep-webgpu/README.md
+++ b/plugin-ep-webgpu/README.md
@@ -52,9 +52,13 @@ import onnxruntime_ep_webgpu as webgpu_ep
 
 ort.register_execution_provider_library("webgpu", webgpu_ep.get_library_path())
 
-devices = [d for d in ort.get_ep_devices() if d.ep_name == webgpu_ep.get_ep_name()]
+# The WebGPU EP currently accepts one EP device and selects the physical GPU independently.
+webgpu_ep_device = next((d for d in ort.get_ep_devices() if d.ep_name == webgpu_ep.get_ep_name()), None)
+if webgpu_ep_device is None:
+    raise RuntimeError("No WebGPU EP device found.")
+
 sess_options = ort.SessionOptions()
-sess_options.add_provider_for_devices(devices, {})
+sess_options.add_provider_for_devices([webgpu_ep_device], {})
 session = ort.InferenceSession("model.onnx", sess_options=sess_options)
 ```
 

--- a/plugin-ep-webgpu/python/onnxruntime_ep_webgpu/README.md
+++ b/plugin-ep-webgpu/python/onnxruntime_ep_webgpu/README.md
@@ -38,15 +38,15 @@ import onnxruntime_ep_webgpu as webgpu_ep
 # Register the plugin EP library with ONNX Runtime
 ort.register_execution_provider_library("webgpu", webgpu_ep.get_library_path())
 
-# Discover WebGPU devices
-all_devices = ort.get_ep_devices()
-webgpu_devices = [d for d in all_devices if d.ep_name == webgpu_ep.get_ep_name()]
-if not webgpu_devices:
-    raise RuntimeError("No WebGPU device found.")
+# Discover WebGPU EP devices
+# The WebGPU EP currently accepts one EP device and selects the physical GPU independently.
+webgpu_ep_device = next((d for d in ort.get_ep_devices() if d.ep_name == webgpu_ep.get_ep_name()), None)
+if webgpu_ep_device is None:
+    raise RuntimeError("No WebGPU EP device found.")
 
 # Create a session using the WebGPU EP
 sess_options = ort.SessionOptions()
-sess_options.add_provider_for_devices(webgpu_devices, {})
+sess_options.add_provider_for_devices([webgpu_ep_device], {})
 session = ort.InferenceSession("model.onnx", sess_options=sess_options)
 
 # Run inference (replace shape/dtype/name to match your model)
@@ -56,7 +56,7 @@ output = session.run(None, {"input": input_data})
 
 ## Troubleshooting
 
-- **`No WebGPU device found`** — the plugin EP loaded but no compatible adapter was discovered. On Linux this
+- **`No WebGPU EP device found`** — the plugin EP loaded but no compatible adapter was discovered. On Linux this
   usually means the Vulkan loader (`libvulkan.so.1`) is not installed; install it via your distribution's package
   manager. On Windows it may indicate a missing or outdated GPU driver.
 - **`ORT runtime version "..." is below the minimum required version "@min_onnxruntime_version@"`** — the

--- a/plugin-ep-webgpu/python/test/test_webgpu_plugin_ep.py
+++ b/plugin-ep-webgpu/python/test/test_webgpu_plugin_ep.py
@@ -37,22 +37,20 @@ def debug_print(*args, **kwargs):
         print(*args, **kwargs)
 
 
-def debug_print_ep_devices(ep_devices):
+def print_ep_devices(ep_devices):
     """Print the EP and hardware properties for each discovered device."""
-    if not VERBOSE:
-        return
 
     for index, ep_device in enumerate(ep_devices):
         device = ep_device.device
-        debug_print(f"  EP device [{index}]:")
-        debug_print(f"    EP: name={ep_device.ep_name!r}, vendor={ep_device.ep_vendor!r}")
-        debug_print(f"    EP metadata: {ep_device.ep_metadata!r}")
-        debug_print(f"    EP options: {ep_device.ep_options!r}")
-        debug_print(
+        print(f"  EP device [{index}]:")
+        print(f"    EP: name={ep_device.ep_name!r}, vendor={ep_device.ep_vendor!r}")
+        print(f"    EP metadata: {ep_device.ep_metadata!r}")
+        print(f"    EP options: {ep_device.ep_options!r}")
+        print(
             f"    Hardware: type={device.type!r}, vendor_id={device.vendor_id}, "
             f"vendor={device.vendor!r}, device_id={device.device_id}"
         )
-        debug_print(f"    Hardware metadata: {device.metadata!r}")
+        print(f"    Hardware metadata: {device.metadata!r}")
 
 
 def create_mul_model(output_dir: Path) -> Path:
@@ -123,20 +121,27 @@ def test_registration_and_inference():
     print(f"OK: Registered EP library as '{registration_name}'")
 
     try:
-        # Discover devices
-        all_devices = ort.get_ep_devices()
-        debug_print_ep_devices(all_devices)
-        webgpu_devices = [d for d in all_devices if d.ep_name == ep_name]
-        print(f"Found {len(webgpu_devices)} WebGPU device(s)")
+        # Get EP devices
+        all_ep_devices = ort.get_ep_devices()
 
-        if not webgpu_devices:
-            print("SKIP: No WebGPU devices available — skipping inference test")
+        if VERBOSE:
+            print("\n--- ORT EP devices ---")
+            print_ep_devices(all_ep_devices)
+
+        webgpu_ep_devices = [d for d in all_ep_devices if d.ep_name == ep_name]
+        print(f"Found {len(webgpu_ep_devices)} WebGPU EP device(s)")
+
+        if not webgpu_ep_devices:
+            print("SKIP: No WebGPU EP devices available — skipping inference test")
             return
+
+        # Use the first WebGPU EP device.
+        webgpu_ep_device = webgpu_ep_devices[0]
 
         # Create session with WebGPU EP
         sess_options = ort.SessionOptions()
         sess_options.add_session_config_entry("session.disable_cpu_ep_fallback", "1")
-        sess_options.add_provider_for_devices(webgpu_devices, {})
+        sess_options.add_provider_for_devices([webgpu_ep_device], {})
         assert sess_options.has_providers(), "SessionOptions should have providers after add_provider_for_devices"
         print("OK: Session options configured with WebGPU EP")
 

--- a/plugin-ep-webgpu/python/test/test_webgpu_plugin_ep.py
+++ b/plugin-ep-webgpu/python/test/test_webgpu_plugin_ep.py
@@ -135,7 +135,7 @@ def test_registration_and_inference():
             print("SKIP: No WebGPU EP devices available — skipping inference test")
             return
 
-        # Use the first WebGPU EP device.
+        # WebGPU selects the GPU independently, so any non-virtual WebGPU EP device is sufficient here.
         webgpu_ep_device = webgpu_ep_devices[0]
 
         # Create session with WebGPU EP

--- a/plugin-ep-webgpu/python/test/test_webgpu_plugin_ep.py
+++ b/plugin-ep-webgpu/python/test/test_webgpu_plugin_ep.py
@@ -37,6 +37,24 @@ def debug_print(*args, **kwargs):
         print(*args, **kwargs)
 
 
+def debug_print_ep_devices(ep_devices):
+    """Print the EP and hardware properties for each discovered device."""
+    if not VERBOSE:
+        return
+
+    for index, ep_device in enumerate(ep_devices):
+        device = ep_device.device
+        debug_print(f"  EP device [{index}]:")
+        debug_print(f"    EP: name={ep_device.ep_name!r}, vendor={ep_device.ep_vendor!r}")
+        debug_print(f"    EP metadata: {ep_device.ep_metadata!r}")
+        debug_print(f"    EP options: {ep_device.ep_options!r}")
+        debug_print(
+            f"    Hardware: type={device.type!r}, vendor_id={device.vendor_id}, "
+            f"vendor={device.vendor!r}, device_id={device.device_id}"
+        )
+        debug_print(f"    Hardware metadata: {device.metadata!r}")
+
+
 def create_mul_model(output_dir: Path) -> Path:
     """Create a simple Mul model in `output_dir` and return the path to the saved .onnx file."""
     x = helper.make_tensor_value_info("x", TensorProto.FLOAT, [2, 3])
@@ -107,7 +125,7 @@ def test_registration_and_inference():
     try:
         # Discover devices
         all_devices = ort.get_ep_devices()
-        debug_print(f"  All devices: {[(d.ep_name, getattr(d, 'device_id', 'N/A')) for d in all_devices]}")
+        debug_print_ep_devices(all_devices)
         webgpu_devices = [d for d in all_devices if d.ep_name == ep_name]
         print(f"Found {len(webgpu_devices)} WebGPU device(s)")
 


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Update Python package test to only pass one WebGPU EP device to `SessionOptions.add_provider_for_devices()`. Also update the documentation usage examples to do the same.

Add debugging output to show more information about EP devices.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Fix packaging test pipeline failure on machine where there are two WebGPU EP devices.