### PR TITLE
Fix TfIdfVectorizer weights indexing and validate skip/index attributes

### DIFF
--- a/onnxruntime/core/providers/cpu/nn/tfidfvectorizer.cc
+++ b/onnxruntime/core/providers/cpu/nn/tfidfvectorizer.cc
@@ -11,6 +11,7 @@
 #include "core/platform/threadpool.h"
 
 #include <functional>
+#include <limits>
 #include <string_view>
 
 namespace onnxruntime {
@@ -69,9 +70,11 @@ struct NgramPart<std::string> {
 };
 
 // Returns next ngram_id
+// ngram_indexes_size bounds the ids handed out here to the size of the ngram_indexes attribute, since an
+// assigned id is later used as a 1-based index into ngram_indexes_ (and, transitively, weights_).
 template <class K, class ForwardIter, class Map>
 inline size_t PopulateGrams(ForwardIter first, size_t ngrams, size_t ngram_size, size_t ngram_id,
-                            Map& c) {
+                            size_t ngram_indexes_size, Map& c) {
   for (; ngrams > 0; --ngrams) {
     size_t n = 1;
     Map* m = &c;
@@ -80,6 +83,8 @@ inline size_t PopulateGrams(ForwardIter first, size_t ngrams, size_t ngram_size,
       ++first;
       if (n == ngram_size) {
         ORT_ENFORCE(p.first->second->id_ == 0, "Duplicate ngram detected, size: ", ngram_size, " id: ", ngram_id);
+        ORT_ENFORCE(ngram_id <= ngram_indexes_size,
+                    "ngram id ", ngram_id, " is out of bounds for ngram_indexes of size ", ngram_indexes_size);
         p.first->second->id_ = ngram_id;
         ++ngram_id;
         break;
@@ -134,6 +139,9 @@ struct TfIdfVectorizer::Impl {
   // Contains output indexes
   // represents ngram_indexes output
   gsl::span<const int64_t> ngram_indexes_;
+  // Optional per-n-gram weights, indexed by 0-based n-gram POOL position (ngram_id - 1), i.e. the
+  // n-gram's position within the pool_* attribute -- NOT by its output coordinate (ngram_indexes_[pos]).
+  // The two only coincide when ngram_indexes_ happens to be the identity permutation.
   gsl::span<const float> weights_;
 
   // This map contains references to pool_string_ entries
@@ -200,8 +208,12 @@ TfIdfVectorizer::TfIdfVectorizer(const OpKernelInfo& info) : OpKernel(info), imp
     ORT_ENFORCE(std::all_of(impl_->ngram_indexes_.begin(), impl_->ngram_indexes_.end(),
                             [](int64_t i) { return i >= 0; }),
                 "Negative ngram_indexes values are not allowed");
-    // Set output size to max output index + 1;
+    // Set output size to max output index + 1. The output shape is stored as int64_t (TensorShapeVector),
+    // so the incremented value must still fit in int64_t to avoid producing a negative/invalid dimension.
     auto greatest_hit = std::max_element(impl_->ngram_indexes_.begin(), impl_->ngram_indexes_.end());
+    ORT_ENFORCE(*greatest_hit < std::numeric_limits<int64_t>::max(),
+                "ngram_indexes contains a value that is too large to represent an output dimension: ",
+                std::to_string(*greatest_hit));
     impl_->output_size_ = SafeInt<size_t>(*greatest_hit) + 1;
   }
 
@@ -243,9 +255,11 @@ TfIdfVectorizer::TfIdfVectorizer(const OpKernelInfo& info) : OpKernel(info), imp
       // Skip loading into hash_set ngrams that are not in the range of [min_gram_length-max_gram_length]
       if (ngram_size >= min_gram_length && ngram_size <= max_gram_length) {
         if (pool_strings.empty()) {
-          ngram_id = PopulateGrams<int64_t>(pool_int64s.begin() + start_idx, ngrams, ngram_size, ngram_id, impl_->int64_map_);
+          ngram_id = PopulateGrams<int64_t>(pool_int64s.begin() + start_idx, ngrams, ngram_size, ngram_id,
+                                            impl_->ngram_indexes_.size(), impl_->int64_map_);
         } else {
-          ngram_id = PopulateGrams<std::string>(pool_strings.begin() + start_idx, ngrams, ngram_size, ngram_id, impl_->str_map_);
+          ngram_id = PopulateGrams<std::string>(pool_strings.begin() + start_idx, ngrams, ngram_size, ngram_id,
+                                                impl_->ngram_indexes_.size(), impl_->str_map_);
         }
       } else {
         ngram_id += ngrams;
@@ -259,17 +273,20 @@ TfIdfVectorizer::~TfIdfVectorizer() = default;
 
 void TfIdfVectorizer::ComputeImpl(const void* x_data_raw, size_t elem_size, ptrdiff_t row_num, size_t row_size,
                                   bool is_input_string, gsl::span<float> output_data,
-                                  std::function<void(size_t, gsl::span<float>&)>& fn_weight) const {
+                                  std::function<void(size_t, size_t, gsl::span<float>&)>& fn_weight) const {
   const void* const row_begin = AdvanceElementPtr(x_data_raw, row_num * row_size, elem_size);
   const void* const row_end = AdvanceElementPtr(row_begin, row_size, elem_size);
 
   const auto& impl = *impl_;
   const auto max_gram_length = impl.max_gram_length_;
-  const auto max_skip_distance = impl.max_skip_count_ + 1;  // Convert to distance
+  // A skip distance at or beyond the row size can never yield an n-gram of length >= 2 (unigrams do not
+  // use skip distance at all), so clamp to row_size to bound the loop below and avoid overflow when
+  // max_skip_count_ is an attacker-controlled, very large attribute value.
+  const auto max_skip_distance = std::min<int64_t>(impl.max_skip_count_, static_cast<int64_t>(row_size)) + 1;
   auto start_ngram_size = impl.min_gram_length_;
   size_t output_idx;
 
-  for (auto skip_distance = 1; skip_distance <= max_skip_distance; ++skip_distance) {
+  for (int64_t skip_distance = 1; skip_distance <= max_skip_distance; ++skip_distance) {
     auto ngram_start = row_begin;
     auto const ngram_row_end = row_end;
 
@@ -295,7 +312,8 @@ void TfIdfVectorizer::ComputeImpl(const void* x_data_raw, size_t elem_size, ptrd
           }
           if (ngram_size >= start_ngram_size && hit->second->id_ != 0) {
             output_idx = impl.OutputIdToIncrement(hit->second->id_);
-            fn_weight(output_idx, output_data);
+            // hit->second->id_ is 1-based; see the pool-position/output-coordinate comment on weights_.
+            fn_weight(hit->second->id_ - 1, output_idx, output_data);
           }
           str_map = &hit->second->leafs_;
         }
@@ -313,7 +331,8 @@ void TfIdfVectorizer::ComputeImpl(const void* x_data_raw, size_t elem_size, ptrd
           }
           if (ngram_size >= start_ngram_size && hit->second->id_ != 0) {
             output_idx = impl.OutputIdToIncrement(hit->second->id_);
-            fn_weight(output_idx, output_data);
+            // See the corresponding comment in the string branch above.
+            fn_weight(hit->second->id_ - 1, output_idx, output_data);
           }
           int_map = &hit->second->leafs_;
         }
@@ -391,24 +410,27 @@ Status TfIdfVectorizer::Compute(OpKernelContext* ctx) const {
   int32_t num_batches = std::min<int32_t>(concurrency::ThreadPool::DegreeOfParallelism(ctx->GetOperatorThreadPool()) * 2, num_rows);
 
   const auto& w = impl.weights_;
-  std::function<void(size_t, gsl::span<float>&)> fn_weight;
+  // fn_weight receives (pool_position, output_idx, out): pool_position is the 0-based position of the
+  // matched n-gram in the pool (bounds weights_, per its size == ngram_indexes_.size() invariant), and
+  // output_idx is the n-gram's coordinate in the output tensor (bounds out).
+  std::function<void(size_t, size_t, gsl::span<float>&)> fn_weight;
 
   switch (impl.weighting_criteria_) {
     case kTF:
-      fn_weight = [](size_t i, gsl::span<float>& out) { out[i] += 1.0f; };
+      fn_weight = [](size_t /*pool_position*/, size_t output_idx, gsl::span<float>& out) { out[output_idx] += 1.0f; };
       break;
     case kIDF:
       if (!w.empty()) {
-        fn_weight = [&w](size_t i, gsl::span<float>& out) { out[i] = w[i]; };
+        fn_weight = [&w](size_t pool_position, size_t output_idx, gsl::span<float>& out) { out[output_idx] = w[pool_position]; };
       } else {
-        fn_weight = [](size_t i, gsl::span<float>& out) { out[i] = 1.0f; };
+        fn_weight = [](size_t /*pool_position*/, size_t output_idx, gsl::span<float>& out) { out[output_idx] = 1.0f; };
       }
       break;
     case kTFIDF:
       if (!w.empty()) {
-        fn_weight = [&w](size_t i, gsl::span<float>& out) { out[i] += w[i]; };
+        fn_weight = [&w](size_t pool_position, size_t output_idx, gsl::span<float>& out) { out[output_idx] += w[pool_position]; };
       } else {
-        fn_weight = [](size_t i, gsl::span<float>& out) { out[i] += 1.0f; };
+        fn_weight = [](size_t /*pool_position*/, size_t output_idx, gsl::span<float>& out) { out[output_idx] += 1.0f; };
       }
       break;
     case kNone:  // fall-through

--- a/onnxruntime/core/providers/cpu/nn/tfidfvectorizer.cc
+++ b/onnxruntime/core/providers/cpu/nn/tfidfvectorizer.cc
@@ -323,7 +323,7 @@ void TfIdfVectorizer::ComputeImpl(const void* x_data_raw, size_t elem_size, ptrd
              !int_map->empty() &&
              ngram_size <= max_gram_length &&
              ngram_item < ngram_row_end;
-             ++ngram_size, ngram_item = AdvanceElementPtr(ngram_item, skip_distance, elem_size)) {
+             ++ngram_size, ngram_item = AdvanceElementPtr(ngram_item, SafeInt<size_t>(skip_distance), elem_size)) {
           int64_t val = (elem_size == 4) ? int64_t{*reinterpret_cast<const int32_t*>(ngram_item)} : *reinterpret_cast<const int64_t*>(ngram_item);
           auto hit = int_map->find(val);
           if (hit == int_map->end()) {

--- a/onnxruntime/core/providers/cpu/nn/tfidfvectorizer.h
+++ b/onnxruntime/core/providers/cpu/nn/tfidfvectorizer.h
@@ -22,7 +22,8 @@ class TfIdfVectorizer final : public OpKernel {
 
  private:
   void ComputeImpl(const void* x_data_raw, size_t elem_size, ptrdiff_t row_num, size_t row_size, bool is_input_string,
-                   gsl::span<float> output_data, std::function<void(size_t, gsl::span<float>&)>& fn_weight) const;
+                   gsl::span<float> output_data,
+                   std::function<void(size_t, size_t, gsl::span<float>&)>& fn_weight) const;
 
   struct Impl;
   std::unique_ptr<Impl> impl_;

--- a/onnxruntime/test/providers/cpu/nn/tfidfvectorizer_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/tfidfvectorizer_test.cc
@@ -5,6 +5,7 @@
 #include "test/providers/provider_test_utils.h"
 
 #include <stdint.h>
+#include <limits>
 #include <random>
 
 namespace onnxruntime {
@@ -685,6 +686,119 @@ TEST(TfIdfVectorizerTest, String_TFIDFWeights_onlyBigrams_Skip5_2rows) {
 
   test.AddOutput<float>("Y", {2, 7}, {0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f,  // No bi-grams in the first row
                                       0.f, 0.f, 0.f, 0.f, 2.f, 3.f, 2.f});
+
+  test.Run(OpTester::ExpectResult::kExpectSuccess);
+}
+
+// The following two tests guard against a class of index-confusion issue: the ngram_indexes attribute
+// maps each n-gram's position in the pool to its coordinate in the output tensor, and is not
+// necessarily a monotonic or identity mapping. weights must remain indexed by pool position (per the
+// ONNX spec: "the i-th element in weights is the weight of the i-th n-gram in pool"), not by the
+// output coordinate that the same n-gram happens to be assigned. All prior tests above use an
+// identity ngram_indexes ({0, 1, 2, ...}), under which pool position and output coordinate coincide
+// and therefore cannot detect this class of bug.
+TEST(TfIdfVectorizerTest, Int32_IDFWeights_NonIdentityNgramIndexes) {
+  OpTester test("TfIdfVectorizer", opset_ver);
+  // Two unigrams "10" (pool position 0) and "20" (pool position 1). ngram_indexes swaps their output
+  // coordinates relative to their pool position, so a pool-position/output-coordinate mix-up in the
+  // weight lookup would swap the two weights in the output.
+  InitTestAttr(test, "IDF", 1, 1, 0,
+               {0},
+               {1, 0},        // ngram_indexes: pool position 0 -> output coord 1, position 1 -> output coord 0
+               {5.0f, 7.0f},  // weights: indexed by pool position, not by output coordinate
+               {10, 20},
+               {});
+
+  std::vector<int64_t> dims{2};
+  std::vector<int32_t> input = {10, 20};
+  test.AddInput<int32_t>("T", dims, input);
+
+  std::vector<int64_t> out_dims{2};
+  // "10" (pool position 0, weight 5.0) lands at output coordinate 1; "20" (pool position 1, weight
+  // 7.0) lands at output coordinate 0.
+  std::vector<float> output = {7.0f, 5.0f};
+  test.AddOutput<float>("Y", out_dims, output);
+
+  test.Run(OpTester::ExpectResult::kExpectSuccess);
+}
+
+#if !defined(ORT_NO_EXCEPTIONS)
+// Test that a pool containing more n-grams (within the accepted gram-length range) than entries in
+// ngram_indexes is rejected at construction time, rather than assigning ids that later index out of
+// bounds of ngram_indexes/weights during Compute. ORT_ENFORCE throws in this constructor; in
+// no-exceptions builds this would abort, so this test is skipped there.
+TEST(TfIdfVectorizerTest, Int32_PoolLargerThanNgramIndexes_Fail) {
+  OpTester test("TfIdfVectorizer", opset_ver);
+  // Three distinct unigrams are present in the pool, but ngram_indexes only has one entry.
+  InitTestAttr(test, "TF", 1, 1, 0,
+               {0},
+               {0},  // ngram_indexes: only 1 entry, but the pool below yields 3 distinct unigram ids
+               {},
+               {10, 20, 30},
+               {});
+
+  std::vector<int64_t> dims{3};
+  std::vector<int32_t> input = {10, 20, 30};
+  test.AddInput<int32_t>("T", dims, input);
+
+  std::vector<int64_t> out_dims{1};
+  std::vector<float> output = {0.0f};
+  test.AddOutput<float>("Y", out_dims, output);
+
+  test.Run(OpTester::ExpectResult::kExpectFailure, "is out of bounds for ngram_indexes");
+}
+
+// ngram_indexes values must fit as an output tensor dimension (int64_t) once incremented by one to
+// derive output_size_; a value of INT64_MAX would silently produce an invalid dimension, so it must be
+// rejected before use. In this configuration, ONNX's own shape inference already flags the resulting
+// dimension mismatch during graph resolution (before the kernel is even constructed), but the
+// constructor-level guard added to this kernel provides a second, independent line of defense in case
+// shape inference is bypassed or produces no conflicting declared shape to compare against.
+TEST(TfIdfVectorizerTest, Int32_NgramIndexesTooLarge_Fail) {
+  OpTester test("TfIdfVectorizer", opset_ver);
+  InitTestAttr(test, "TF", 1, 1, 0,
+               {0},
+               {std::numeric_limits<int64_t>::max()},
+               {},
+               {10},
+               {});
+
+  std::vector<int64_t> dims{1};
+  std::vector<int32_t> input = {10};
+  test.AddInput<int32_t>("T", dims, input);
+
+  std::vector<int64_t> out_dims{1};
+  std::vector<float> output = {0.0f};
+  test.AddOutput<float>("Y", out_dims, output);
+
+  test.Run(OpTester::ExpectResult::kExpectFailure);
+}
+#endif  // !defined(ORT_NO_EXCEPTIONS)
+
+// max_skip_count is only meaningfully bounded above by the input row size: any larger value can never
+// produce an n-gram of length >= 2, so the kernel must clamp its internal loop bound to the row size
+// instead of iterating up to the (attacker-controlled) attribute value directly. This test uses a
+// max_skip_count far larger than the row so this completes quickly and produces the same result as an
+// equivalent, much smaller max_skip_count.
+TEST(TfIdfVectorizerTest, Int32_TF_onlyBigrams_HugeMaxSkipCount) {
+  OpTester test("TfIdfVectorizer", opset_ver);
+  InitTestAttr(test, "TF", 2, 2, std::numeric_limits<int64_t>::max() - 1,
+               {0, 4},
+               {0, 1, 2, 3, 4, 5, 6},  // 7 output indexes
+               {},
+               {2, 3, 5, 4,         // 1-grams
+                5, 6, 7, 8, 6, 7},  // bi-grams
+               {});
+
+  std::vector<int64_t> dims{12};
+  std::vector<int32_t> input = {1, 1, 3, 3, 3, 7, 8, 6, 7, 5, 6, 8};
+  test.AddInput<int32_t>("T", dims, input);
+
+  std::vector<int64_t> out_dims{7};
+  // Same expected result as Int32_TF_onlyBigrams_Skip5 above, since a skip distance beyond the row
+  // size can never match another bigram.
+  std::vector<float> output = {0, 0, 0, 0, 1, 3, 1};
+  test.AddOutput<float>("Y", out_dims, output);
 
   test.Run(OpTester::ExpectResult::kExpectSuccess);
 }


### PR DESCRIPTION
## Description

`TfIdfVectorizer`'s weighting functor indexed the optional `weights` attribute by the n-gram's **output coordinate** rather than by its **pool position**. Per the operator spec, `weights` is parallel to the n-gram pool (indexed by the n-gram's position among all pool entries), while `ngram_indexes` maps that same n-gram to its coordinate in the output tensor. These two only coincide when `ngram_indexes` happens to be the identity permutation — which is the case for every existing test in this repo, explaining why this had gone unnoticed.

When `ngram_indexes` is *not* the identity permutation, the previous code could read past the end of the `weights` buffer.

While investigating, a few related gaps in attribute/input validation were also addressed in this same operator:

- The only bound preventing an internally assigned n-gram id from exceeding the size of `ngram_indexes` was a debug-only `assert` (compiled out in release builds). Added an explicit check at pool-construction time.
- `ngram_indexes` values large enough to overflow the derived output dimension (stored as `int64_t`) are now rejected at construction time.
- `max_skip_count` had no upper bound, and the internal skip-distance loop used a narrower loop counter than the bound it was compared against. A sufficiently large attribute value could cause integer overflow or make the kernel iterate an enormous number of times for no benefit (skip distances at or beyond the row length can never produce an n-gram of length >= 2). The internal loop bound is now clamped to the input row size, which does not change behavior for any legitimate model.

## Testing

Added regression tests to `onnxruntime/test/providers/cpu/nn/tfidfvectorizer_test.cc`:
- Non-identity `ngram_indexes` with `weights`, verifying the corrected (spec-compliant) output.
- A pool larger than `ngram_indexes` is rejected at construction (guarded by `#if !defined(ORT_NO_EXCEPTIONS)`, since it relies on a throwing `ORT_ENFORCE`).
- An `ngram_indexes` value too large to represent as an output dimension is rejected.
- A very large `max_skip_count` completes quickly and produces the same result as an equivalent small one.

All existing tests continue to pass unchanged, since they all use an identity `ngram_indexes`.

`TfIdfVectorizer` is CPU-only; no other execution provider implements this operator.

## Note on divergence from the ONNX reference implementation

For the specific combination of a non-identity `ngram_indexes` with `weights`, this fix causes ORT's output to differ from `onnx.reference.ReferenceEvaluator`'s current Python implementation, which has the same pool-position/output-coordinate confusion this PR fixes. None of ONNX's own conformance tests exercise `weights` together with a non-identity `ngram_indexes`, so there is no conformance-test risk.