### PR TITLE
WebGPU: Support int32 and uint32 for CumSum

### DIFF
--- a/onnxruntime/core/providers/webgpu/math/cum_sum.cc
+++ b/onnxruntime/core/providers/webgpu/math/cum_sum.cc
@@ -14,7 +14,7 @@ ONNX_OPERATOR_VERSIONED_KERNEL_EX(
     11, 13,
     kWebGpuExecutionProvider,
     (*KernelDefBuilder::Create())
-        .TypeConstraint("T", WebGpuSupportedFloatTypes())
+        .TypeConstraint("T", WebGpuSupportedNumberTypes())
         .TypeConstraint("T2", {DataTypeImpl::GetTensorType<int32_t>(),
                                DataTypeImpl::GetTensorType<int64_t>()})
         .InputMemoryType(OrtMemTypeCPU, 1),
@@ -26,7 +26,7 @@ ONNX_OPERATOR_KERNEL_EX(
     14,
     kWebGpuExecutionProvider,
     (*KernelDefBuilder::Create())
-        .TypeConstraint("T", WebGpuSupportedFloatTypes())
+        .TypeConstraint("T", WebGpuSupportedNumberTypes())
         .TypeConstraint("T2", {DataTypeImpl::GetTensorType<int32_t>(),
                                DataTypeImpl::GetTensorType<int64_t>()})
         .InputMemoryType(OrtMemTypeCPU, 1),

--- a/onnxruntime/test/providers/cpu/math/cumsum_test.cc
+++ b/onnxruntime/test/providers/cpu/math/cumsum_test.cc
@@ -2,6 +2,10 @@
 // Licensed under the MIT License.
 
 #include "gtest/gtest.h"
+#ifdef USE_WEBGPU
+#include "core/providers/webgpu/webgpu_provider_options.h"
+#include "core/session/onnxruntime_session_options_config_keys.h"
+#endif
 #include "test/providers/provider_test_utils.h"
 #include "test/util/include/default_providers.h"
 #include "core/util/math.h"
@@ -252,6 +256,26 @@ TEST(CumSumTest, _1DTestInt32) {
   test.AddOutput<int32_t>("y", {5}, {1, 3, 6, 10, 15});
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
 }
+#ifdef USE_WEBGPU
+// uint32 is only exercised on the WebGPU EP here.
+TEST(CumSumTest, _1DTestUint32_webgpu) {
+  auto provider = WebGpuExecutionProviderWithOptions(ConfigOptions{});
+  if (provider == nullptr) {
+    GTEST_SKIP() << "WebGPU EP is not available";
+  }
+
+  OpTester test("CumSum", 11, onnxruntime::kOnnxDomain);
+  test.AddInput<uint32_t>("x", {5}, {1, 2, 3, 4, 5});
+  test.AddInput<int32_t>("axis", {}, {0});
+  test.AddOutput<uint32_t>("y", {5}, {1, 3, 6, 10, 15});
+
+  SessionOptions so;
+  ASSERT_STATUS_OK(so.config_options.AddConfigEntry(kOrtSessionOptionsDisableCPUEPFallback, "1"));
+  test.Config(so)
+      .ConfigEp(std::move(provider))
+      .RunWithConfig();
+}
+#endif  // USE_WEBGPU
 TEST(CumSumTest, _1DTestInt64) {
   OpTester test("CumSum", 11, onnxruntime::kOnnxDomain);
   test.AddInput<int64_t>("x", {5}, {1, 2, 3, 4, 5});


### PR DESCRIPTION
### Description

Adds int32 and uint32 data type support to the Cumsum operator in the WebGPU execution provider. The op is used by [Phi-4-mini](https://huggingface.co/webnn/Phi-4-mini-instruct-onnx-webnn/blob/main/onnx/model.onnx) (GQA decomposition).

CumSum's WebGPU kernel only advertised float types (float16/float32), so int32/uint32 inputs silently fell back to the CPU EP. Widen the T type constraint to WebGpuSupportedNumberTypes() (adds int32/uint32).

### Motivation and Context

No shader or C++ dispatch change is needed. The kernel is not templated and the shader is written entirely against the generic value-type alias (output_value_t): the accumulator is `var sum : output_value_t = 0` and the reduction is a plain `sum = sum + ...`. WGSL resolves the `0` literal and `+` for i32/u32 exactly as for the float case (integer add wraps, matching the CPU CumSum reference), and the loop bounds/indices are already i32/u32 and independent of the element type. So enabling the two integer types is purely a matter of relaxing the type-constraint whitelist.


