### PR TITLE
[WebGPU] Optimize MatMulNBits wide-tile with subgroup shuffle

### DIFF
--- a/onnxruntime/contrib_ops/webgpu/quantization/matmul_nbits.cc
+++ b/onnxruntime/contrib_ops/webgpu/quantization/matmul_nbits.cc
@@ -45,7 +45,7 @@ Status MatMulNBitsWideTileProgram::GenerateShaderCode(ShaderHelper& shader) cons
   }
   const auto& output = shader.AddOutput("output", ShaderUsage::UseValueTypeAlias | ShaderUsage::UseElementTypeAlias);
 
-  const uint32_t workgroup_size = WorkgroupSizeX() * WorkgroupSizeY();
+  const uint32_t workgroup_size = WorkgroupSizeX() * WorkgroupSizeY() * WorkgroupSizeZ();
   ORT_ENFORCE(tile_n_ == workgroup_size, "tile_n must be workgroup_size.");
   ORT_ENFORCE(tile_m_ % (workgroup_size / 8) == 0, "tile_m must be a multiple of workgroup_size / 8.");
   ORT_ENFORCE(nbits_ == 4 || nbits_ == 8, "Only 4/8 bits are supported for webgpu matmulnbits.");

--- a/onnxruntime/contrib_ops/webgpu/quantization/matmul_nbits.cc
+++ b/onnxruntime/contrib_ops/webgpu/quantization/matmul_nbits.cc
@@ -46,8 +46,8 @@ Status MatMulNBitsWideTileProgram::GenerateShaderCode(ShaderHelper& shader) cons
   const auto& output = shader.AddOutput("output", ShaderUsage::UseValueTypeAlias | ShaderUsage::UseElementTypeAlias);
 
   const uint32_t workgroup_size = WorkgroupSizeX() * WorkgroupSizeY();
-  ORT_ENFORCE(tile_m_ == workgroup_size / 8, "tile_m must be workgroup_size / 8.");
   ORT_ENFORCE(tile_n_ == workgroup_size, "tile_n must be workgroup_size.");
+  ORT_ENFORCE(tile_m_ % (workgroup_size / 8) == 0, "tile_m must be a multiple of workgroup_size / 8.");
   ORT_ENFORCE(nbits_ == 4 || nbits_ == 8, "Only 4/8 bits are supported for webgpu matmulnbits.");
 
   return WGSL_TEMPLATE_APPLY(shader, "quantization/matmul_nbits_wide_tile.wgsl.template",
@@ -56,6 +56,7 @@ Status MatMulNBitsWideTileProgram::GenerateShaderCode(ShaderHelper& shader) cons
                              WGSL_TEMPLATE_PARAMETER(has_weight_idx_indirect, has_weight_idx_indirect_),
                              WGSL_TEMPLATE_PARAMETER(has_zero_points, has_zero_points_),
                              WGSL_TEMPLATE_PARAMETER(nbits, nbits_),
+                             WGSL_TEMPLATE_PARAMETER(subgroup_min_size, subgroup_min_size_),
                              WGSL_TEMPLATE_PARAMETER(tile_m, tile_m_),
                              WGSL_TEMPLATE_PARAMETER(tile_n, tile_n_),
                              WGSL_TEMPLATE_VARIABLE(a, a),
@@ -247,7 +248,7 @@ Status ApplyMatMulNBits(const Tensor* a, const Tensor* b, const Tensor* scales, 
   }
 
   // WideTileProgram
-  // This program is optimized for Block32 prefill using Tile16x128.
+  // This program is optimized for Block32 prefill.
   const bool use_wide_tile_program = CanApplyWideTileMatMulNBits(M,
                                                                  K,
                                                                  block_size,
@@ -261,12 +262,20 @@ Status ApplyMatMulNBits(const Tensor* a, const Tensor* b, const Tensor* scales, 
     components = 1;
 
     constexpr uint32_t workgroup_size = 128;
-    constexpr uint32_t tile_m = workgroup_size / 8;
     constexpr uint32_t tile_n = workgroup_size;
+    const bool is_f16 = a->DataType() == DataTypeImpl::GetType<MLFloat16>();
+    const uint32_t tile_m = is_f16 ? 2 * workgroup_size / 8 : workgroup_size / 8;
     const uint32_t num_N_tile = CeilDiv(N, tile_n);
     const uint32_t num_M_tile = CeilDiv(dispatch_M, tile_m);
 
-    MatMulNBitsWideTileProgram program{has_zero_points, has_bias, has_weight_idx, has_weight_idx_indirect, tile_m, tile_n, static_cast<uint32_t>(nbits)};
+    // The template shuffles tile_m lanes in bands of subgroup_min_size when that's a
+    // width it supports; otherwise (including when Subgroups isn't supported) it falls
+    // back to a direct reduction.
+    const uint32_t subgroup_min_size = context.HasFeature(wgpu::FeatureName::Subgroups)
+                                           ? context.AdapterInfo().subgroupMinSize
+                                           : 0u;
+
+    MatMulNBitsWideTileProgram program{has_zero_points, has_bias, has_weight_idx, has_weight_idx_indirect, tile_m, tile_n, static_cast<uint32_t>(nbits), subgroup_min_size};
     program.SetWorkgroupSize(workgroup_size);
     program.SetDispatchGroupSize(num_N_tile, num_M_tile, batch_count);
 
@@ -307,7 +316,7 @@ Status ApplyMatMulNBits(const Tensor* a, const Tensor* b, const Tensor* scales, 
                                  {num_N_tile},
                                  {num_M_tile},
                                  {weight_index}});
-    program.CacheHint(nbits, has_zero_points, has_bias, has_weight_idx, has_weight_idx_indirect);
+    program.CacheHint(nbits, has_zero_points, has_bias, has_weight_idx, has_weight_idx_indirect, subgroup_min_size);
 
     return context.RunProgram(program);
   }

--- a/onnxruntime/contrib_ops/webgpu/quantization/matmul_nbits.cc
+++ b/onnxruntime/contrib_ops/webgpu/quantization/matmul_nbits.cc
@@ -268,10 +268,13 @@ Status ApplyMatMulNBits(const Tensor* a, const Tensor* b, const Tensor* scales, 
     const uint32_t num_N_tile = CeilDiv(N, tile_n);
     const uint32_t num_M_tile = CeilDiv(dispatch_M, tile_m);
 
+    bool is_nvidia = context.AdapterInfo().vendor == std::string_view{"nvidia"};
+
     // The template shuffles tile_m lanes in bands of subgroup_min_size when that's a
     // width it supports; otherwise (including when Subgroups isn't supported) it falls
     // back to a direct reduction.
-    const uint32_t subgroup_min_size = context.HasFeature(wgpu::FeatureName::Subgroups)
+    // NOTE: NVIDIA GPUs prefer direct reduction.
+    const uint32_t subgroup_min_size = (context.HasFeature(wgpu::FeatureName::Subgroups) && !is_nvidia)
                                            ? context.AdapterInfo().subgroupMinSize
                                            : 0u;
 

--- a/onnxruntime/contrib_ops/webgpu/quantization/matmul_nbits.h
+++ b/onnxruntime/contrib_ops/webgpu/quantization/matmul_nbits.h
@@ -14,8 +14,8 @@ using namespace onnxruntime::webgpu;
 
 class MatMulNBitsWideTileProgram final : public Program<MatMulNBitsWideTileProgram> {
  public:
-  MatMulNBitsWideTileProgram(bool has_zero_points, bool has_bias, bool has_weight_idx, bool has_weight_idx_indirect, uint32_t tile_m, uint32_t tile_n, uint32_t nbits)
-      : Program{"MatMulNBitsWideTile"}, has_zero_points_{has_zero_points}, has_bias_{has_bias}, has_weight_idx_{has_weight_idx}, has_weight_idx_indirect_{has_weight_idx_indirect}, tile_m_(tile_m), tile_n_(tile_n), nbits_(nbits) {}
+  MatMulNBitsWideTileProgram(bool has_zero_points, bool has_bias, bool has_weight_idx, bool has_weight_idx_indirect, uint32_t tile_m, uint32_t tile_n, uint32_t nbits, uint32_t subgroup_min_size)
+      : Program{"MatMulNBitsWideTile"}, has_zero_points_{has_zero_points}, has_bias_{has_bias}, has_weight_idx_{has_weight_idx}, has_weight_idx_indirect_{has_weight_idx_indirect}, tile_m_(tile_m), tile_n_(tile_n), nbits_(nbits), subgroup_min_size_(subgroup_min_size) {}
 
   Status GenerateShaderCode(ShaderHelper& sh) const override;
   WEBGPU_PROGRAM_DEFINE_UNIFORM_VARIABLES({"Batch", ProgramUniformVariableDataType::Uint32},
@@ -37,6 +37,7 @@ class MatMulNBitsWideTileProgram final : public Program<MatMulNBitsWideTileProgr
   uint32_t tile_m_;
   uint32_t tile_n_;
   uint32_t nbits_;
+  uint32_t subgroup_min_size_;
 };
 
 class MatMulNBitsProgram final : public Program<MatMulNBitsProgram> {

--- a/onnxruntime/contrib_ops/webgpu/quantization/matmul_nbits_wide_tile.wgsl.template
+++ b/onnxruntime/contrib_ops/webgpu/quantization/matmul_nbits_wide_tile.wgsl.template
@@ -196,8 +196,10 @@ $MAIN {
   let row = ((workgroup_idx / uniforms.num_N_tile) % uniforms.num_M_tile) * kTileM;
   let col = (workgroup_idx % uniforms.num_N_tile) * kTileN;
 
-#if subgroup_min_size >= tile_m || (subgroup_min_size > 0 && tile_m % subgroup_min_size == 0)
+#if subgroup_min_size >= tile_m
   let capped_sg_id = min(sg_id, kTileM - 1u);
+#elif subgroup_min_size > 0 && tile_m % subgroup_min_size == 0
+  let capped_sg_id = min(sg_id, subgroup_min_size - 1u);
 #endif
 
   var results : array<output_element_t, kTileM>;

--- a/onnxruntime/contrib_ops/webgpu/quantization/matmul_nbits_wide_tile.wgsl.template
+++ b/onnxruntime/contrib_ops/webgpu/quantization/matmul_nbits_wide_tile.wgsl.template
@@ -6,12 +6,14 @@
 #param has_weight_idx
 #param has_weight_idx_indirect
 #param nbits
+#param subgroup_min_size
 #param tile_m
 #param tile_n
 
 #use .getByOffset .setByOffset
 
 // Only support Block32 at the moment.
+// A block of 32 elements maps to 8 vec4 (input_a_value_t) vectors along K.
 const KAVecSizeForBlock32 = 8u;
 
 const kTileM : u32 = tile_m;
@@ -185,21 +187,31 @@ fn dequantize(packed_data : vec2<u32>,
 }
 #endif
 
-var<workgroup> a_data_tile : array<array<input_a_value_t, KAVecSizeForBlock32>, kTileM>;
+// The KAVecSizeForBlock32 vectors along K are stored as KAVecSizeForBlock32/2 pairs so the two
+// vecs consumed per dequantized weight column can be read in one access.
+var<workgroup> a_data_tile : array<array<array<input_a_value_t, 2u>, kTileM>, KAVecSizeForBlock32 / 2u>;
 
 $MAIN {
   let batch = workgroup_idx / (uniforms.num_M_tile * uniforms.num_N_tile);
   let row = ((workgroup_idx / uniforms.num_N_tile) % uniforms.num_M_tile) * kTileM;
   let col = (workgroup_idx % uniforms.num_N_tile) * kTileN;
 
+#if subgroup_min_size >= tile_m || (subgroup_min_size > 0 && tile_m % subgroup_min_size == 0)
+  let capped_sg_id = min(sg_id, kTileM - 1u);
+#endif
+
   var results : array<output_element_t, kTileM>;
   for (var block_idx = 0u; block_idx < uniforms.n_blocks_per_col; block_idx++) {
-    // Load `a` elements into workgroup memory, TileM x KAVecSizeForBlock32 (block32)
-    let a_row_idx = local_idx / KAVecSizeForBlock32;
-    let a_col_idx = local_idx % KAVecSizeForBlock32;
-    a_data_tile[a_row_idx][a_col_idx] = load_a(batch,
-                                               row + a_row_idx,
-                                               block_idx * KAVecSizeForBlock32 + a_col_idx);
+    // Load `a` elements into workgroup memory, kTileM x KAVecSizeForBlock32 (block32),
+    // stored as pairs of vecs along K. One pass covers workgroup_size_x / KAVecSizeForBlock32
+    // rows, so loop when kTileM is wider than that.
+    for (var a_row_base = 0u; a_row_base < kTileM; a_row_base += workgroup_size_x / KAVecSizeForBlock32) {
+      let a_row_idx = a_row_base + local_idx / KAVecSizeForBlock32;
+      let a_col_idx = local_idx % KAVecSizeForBlock32;
+      a_data_tile[a_col_idx / 2u][a_row_idx][a_col_idx % 2u] = load_a(batch,
+                                                                      row + a_row_idx,
+                                                                      block_idx * KAVecSizeForBlock32 + a_col_idx);
+    }
     workgroupBarrier();
 
     let b_row = col + local_idx;
@@ -207,15 +219,33 @@ $MAIN {
     let zero_point = load_zero(b_row, block_idx, uniforms.N, uniforms.zero_blocks_per_col);
     let b_data = load_b(b_row, block_idx);
 
-    for (var b_idx = 0u; b_idx < 4u; b_idx++) {
+    for (var b_idx = 0u; b_idx < KAVecSizeForBlock32 / 2u; b_idx++) {
       let b_dequantized = dequantize(b_data[b_idx], zero_point, scale);
+#if subgroup_min_size >= tile_m
+      // Adapter guarantees a subgroup wide enough to shuffle the full kTileM band at once.
+      let a = a_data_tile[b_idx][capped_sg_id];
       for (var m_idx = 0u; m_idx < kTileM; m_idx++) {
-        let a_data0 = a_data_tile[m_idx][b_idx * 2u];
-        let a_data1 = a_data_tile[m_idx][b_idx * 2u + 1u];
-
-        results[m_idx] += dot(a_data0, b_dequantized[0]) +
-                          dot(a_data1, b_dequantized[1]);
+        results[m_idx] += dot(subgroupShuffle(a[0], m_idx), b_dequantized[0]) +
+                          dot(subgroupShuffle(a[1], m_idx), b_dequantized[1]);
       }
+#elif subgroup_min_size > 0 && tile_m % subgroup_min_size == 0
+      // kTileM is wider than a single subgroup can shuffle, so it's split into
+      // subgroup_min_size-wide bands, each shuffled within its own subgroup.
+      for (var chunk = 0u; chunk < kTileM / subgroup_min_size; chunk++) {
+        let m_offset = chunk * subgroup_min_size;
+        let a = a_data_tile[b_idx][capped_sg_id + m_offset];
+        for (var m_idx = 0u; m_idx < subgroup_min_size; m_idx++) {
+          results[m_idx + m_offset] += dot(subgroupShuffle(a[0], m_idx), b_dequantized[0]) +
+                                       dot(subgroupShuffle(a[1], m_idx), b_dequantized[1]);
+        }
+      }
+#else
+      // No guaranteed subgroup support wide enough for shuffles: read each row directly.
+      for (var m_idx = 0u; m_idx < kTileM; m_idx++) {
+        let a = a_data_tile[b_idx][m_idx];
+        results[m_idx] += dot(a[0], b_dequantized[0]) + dot(a[1], b_dequantized[1]);
+      }
+#endif
     }
     workgroupBarrier();
   }

--- a/onnxruntime/contrib_ops/webgpu/quantization/matmul_nbits_wide_tile.wgsl.template
+++ b/onnxruntime/contrib_ops/webgpu/quantization/matmul_nbits_wide_tile.wgsl.template
@@ -6,12 +6,14 @@
 #param has_weight_idx
 #param has_weight_idx_indirect
 #param nbits
+#param subgroup_min_size
 #param tile_m
 #param tile_n
 
 #use .getByOffset .setByOffset
 
 // Only support Block32 at the moment.
+// A block of 32 elements maps to 8 vec4 (input_a_value_t) vectors along K.
 const KAVecSizeForBlock32 = 8u;
 
 const kTileM : u32 = tile_m;
@@ -185,7 +187,9 @@ fn dequantize(packed_data : vec2<u32>,
 }
 #endif
 
-var<workgroup> a_data_tile : array<array<input_a_value_t, KAVecSizeForBlock32>, kTileM>;
+// The KAVecSizeForBlock32 vectors along K are stored as KAVecSizeForBlock32/2 pairs so the two
+// vecs consumed per dequantized weight column can be read in one access.
+var<workgroup> a_data_tile : array<array<array<input_a_value_t, 2u>, kTileM>, KAVecSizeForBlock32 / 2u>;
 
 $MAIN {
   let batch = workgroup_idx / (uniforms.num_M_tile * uniforms.num_N_tile);
@@ -194,12 +198,16 @@ $MAIN {
 
   var results : array<output_element_t, kTileM>;
   for (var block_idx = 0u; block_idx < uniforms.n_blocks_per_col; block_idx++) {
-    // Load `a` elements into workgroup memory, TileM x KAVecSizeForBlock32 (block32)
-    let a_row_idx = local_idx / KAVecSizeForBlock32;
-    let a_col_idx = local_idx % KAVecSizeForBlock32;
-    a_data_tile[a_row_idx][a_col_idx] = load_a(batch,
-                                               row + a_row_idx,
-                                               block_idx * KAVecSizeForBlock32 + a_col_idx);
+    // Load `a` elements into workgroup memory, kTileM x KAVecSizeForBlock32 (block32),
+    // stored as pairs of vecs along K. One pass covers workgroup_size_x / KAVecSizeForBlock32
+    // rows, so loop when kTileM is wider than that.
+    for (var a_row_base = 0u; a_row_base < kTileM; a_row_base += workgroup_size_x / KAVecSizeForBlock32) {
+      let a_row_idx = a_row_base + local_idx / KAVecSizeForBlock32;
+      let a_col_idx = local_idx % KAVecSizeForBlock32;
+      a_data_tile[a_col_idx / 2u][a_row_idx][a_col_idx % 2u] = load_a(batch,
+                                                                      row + a_row_idx,
+                                                                      block_idx * KAVecSizeForBlock32 + a_col_idx);
+    }
     workgroupBarrier();
 
     let b_row = col + local_idx;
@@ -207,15 +215,33 @@ $MAIN {
     let zero_point = load_zero(b_row, block_idx, uniforms.N, uniforms.zero_blocks_per_col);
     let b_data = load_b(b_row, block_idx);
 
-    for (var b_idx = 0u; b_idx < 4u; b_idx++) {
+    for (var b_idx = 0u; b_idx < KAVecSizeForBlock32 / 2u; b_idx++) {
       let b_dequantized = dequantize(b_data[b_idx], zero_point, scale);
+#if subgroup_min_size >= tile_m
+      // Adapter guarantees a subgroup wide enough to shuffle the full kTileM band at once.
+      let a = a_data_tile[b_idx][sg_id];
       for (var m_idx = 0u; m_idx < kTileM; m_idx++) {
-        let a_data0 = a_data_tile[m_idx][b_idx * 2u];
-        let a_data1 = a_data_tile[m_idx][b_idx * 2u + 1u];
-
-        results[m_idx] += dot(a_data0, b_dequantized[0]) +
-                          dot(a_data1, b_dequantized[1]);
+        results[m_idx] += dot(subgroupShuffle(a[0], m_idx), b_dequantized[0]) +
+                          dot(subgroupShuffle(a[1], m_idx), b_dequantized[1]);
       }
+#elif subgroup_min_size == 8 || subgroup_min_size == 16
+      // kTileM is wider than a single subgroup can shuffle, so it's split into
+      // subgroup_min_size-wide bands, each shuffled within its own subgroup.
+      for (var chunk = 0u; chunk < kTileM / subgroup_min_size; chunk++) {
+        let m_offset = chunk * subgroup_min_size;
+        let a = a_data_tile[b_idx][sg_id + m_offset];
+        for (var m_idx = 0u; m_idx < subgroup_min_size; m_idx++) {
+          results[m_idx + m_offset] += dot(subgroupShuffle(a[0], m_idx), b_dequantized[0]) +
+                                       dot(subgroupShuffle(a[1], m_idx), b_dequantized[1]);
+        }
+      }
+#else
+      // No guaranteed subgroup support wide enough for shuffles: read each row directly.
+      for (var m_idx = 0u; m_idx < kTileM; m_idx++) {
+        let a = a_data_tile[b_idx][m_idx];
+        results[m_idx] += dot(a[0], b_dequantized[0]) + dot(a[1], b_dequantized[1]);
+      }
+#endif
     }
     workgroupBarrier();
   }


### PR DESCRIPTION
### Description

Broadcast each lane's A vecs across the subgroup via `subgroupShuffle` instead of having every lane re-read the full A tile from workgroup memory. Each lane loads its own row once and shuffles it to the other rows that need it. The workgroup tile is stored as `[KAVecSizeForBlock32/2][kTileM][2]` pairs so the two vecs consumed per dequantized weight column are read in one contiguous access.

`tile_m` now adapts to the element size (16 for f32, 32 for f16, since f16 packs twice as many elements per register), and the compute-stage reduction strategy is chosen from the adapter's guaranteed minimum subgroup size:

- `subgroup_min_size >= tile_m`: single full-tile `subgroupShuffle` band
- `tile_m % subgroup_min_size == 0` (subgroup_min_size > 0): chunked `subgroupShuffle` bands
- otherwise (including when Subgroups isn't supported): direct reduction, no shuffle

The actual runtime subgroup size can exceed the adapter's guaranteed minimum, so a raw `sg_id` can index `a_data_tile` out of bounds in both shuffle branches. Cap it via `capped_sg_id = min(sg_id, kTileM - 1u)` before the main loop and use it in place of `sg_id` in both branches.

Reduces redundant workgroup-memory reads for the A operand in the MatMulNBits wide-tile prefill kernel, and lets it run correctly with the best available strategy across adapters with varying or no subgroup support.

| max_length = 8K | Prefill Length | Default Prefill TPS | Opt TileM-16 Prefill TPS | Opt TileM-32 Prefill TPS | Improvement |
| :----------- | -------------: | ------------------: | -----------------------: | -----------------------: | ----------: |
| Panther Lake |            128 |              221.01 |                   242.49 |                   243.02 |        110% |
| Panther Lake |           1024 |              594.20 |                   644.74 |                   696.70 |        117% |
| Panther Lake |           4096 |              596.47 |                   667.17 |                   727.84 |        122% |
| Alder Lake   |            128 |               46.76 |                    86.13 |                   113.09 |        242% |
| Alder Lake   |           1024 |               44.72 |                    94.43 |                   129.06 |        289% |

[1] https://huggingface.co/onnx-community/Phi-4-mini-instruct-ONNX

### Motivation and Context
See above.
