### PR TITLE
[WebNN EP] Add output rank validation

### DIFF
--- a/onnxruntime/core/providers/webnn/builders/helper.cc
+++ b/onnxruntime/core/providers/webnn/builders/helper.cc
@@ -99,15 +99,15 @@ bool IsTensorShapeSupported(const NodeArg& node_arg, const std::string& parent_n
   return true;
 }
 
-// Check if a single input's rank of an ONNX op is supported by corresponding WebNN op.
-bool IsInputRankSupported(const emscripten::val& wnn_limits,
-                          const std::string_view webnn_op_type,
-                          const std::string_view input_name,
-                          const size_t input_rank,
-                          const std::string_view node_name,
-                          const logging::Logger& logger) {
+// Check if a single input/output's rank of an ONNX op is supported by the corresponding WebNN op.
+bool IsRankSupportedByWebNNOp(const emscripten::val& wnn_limits,
+                              const std::string_view webnn_op_type,
+                              const std::string_view param_name,
+                              const size_t rank,
+                              const std::string_view node_name,
+                              const logging::Logger& logger) {
   const std::string webnn_op_type_str(webnn_op_type);
-  const std::string input_name_str(input_name);
+  const std::string param_name_str(param_name);
 
   if (wnn_limits[webnn_op_type_str].isUndefined()) {
     LOGS(logger, VERBOSE) << "WebNN op type: [" << webnn_op_type
@@ -115,20 +115,20 @@ bool IsInputRankSupported(const emscripten::val& wnn_limits,
     return false;
   }
 
-  const emscripten::val input_limits = wnn_limits[webnn_op_type_str][input_name_str];
+  const emscripten::val param_limits = wnn_limits[webnn_op_type_str][param_name_str];
 
-  if (input_limits.isUndefined()) {
+  if (param_limits.isUndefined()) {
     LOGS(logger, VERBOSE) << "Node name: [" << node_name
                           << "], WebNN op type: [" << webnn_op_type
-                          << "], input [" << input_name
+                          << "], parameter [" << param_name
                           << "]: limits are not defined in WebNN MLOpSupportLimits.";
     return false;
   }
 
-  const emscripten::val rank_range = input_limits["rankRange"];
+  const emscripten::val rank_range = param_limits["rankRange"];
   if (rank_range.isUndefined()) {
     LOGS(logger, VERBOSE) << "WebNN op type [" << webnn_op_type
-                          << "] input [" << input_name
+                          << "] parameter [" << param_name
                           << "]: missing 'rankRange' attribute.";
     return false;
   }
@@ -137,17 +137,17 @@ bool IsInputRankSupported(const emscripten::val& wnn_limits,
   const emscripten::val max_val = rank_range["max"];
   if (min_val.isUndefined() || max_val.isUndefined()) {
     LOGS(logger, VERBOSE) << "WebNN op type [" << webnn_op_type
-                          << "] input [" << input_name
+                          << "] parameter [" << param_name
                           << "]: its 'rankRange' limits is missing valid 'min' or 'max' attributes.";
     return false;
   }
 
   size_t min_rank = min_val.as<size_t>();
   size_t max_rank = max_val.as<size_t>();
-  if (input_rank < min_rank || input_rank > max_rank) {
+  if (rank < min_rank || rank > max_rank) {
     LOGS(logger, VERBOSE) << "Node name: [" << node_name
                           << "] WebNN op type [" << webnn_op_type
-                          << "] input [" << input_name << "] rank " << input_rank
+                          << "] parameter [" << param_name << "] rank " << rank
                           << " is not in supported range [" << min_rank << ", " << max_rank << "]";
     return false;
   }
@@ -179,14 +179,29 @@ bool IsInputRankSupportedByOp(const Node& node, const emscripten::val& wnn_limit
 
     std::vector<int64_t> shape;
     if (!GetShape(*input_defs[input.index], shape, logger) ||
-        !IsInputRankSupported(wnn_limits, webnn_op_type, input.name,
-                              shape.size(),
-                              node.Name(), logger)) {
+        !IsRankSupportedByWebNNOp(wnn_limits, webnn_op_type, input.name,
+                                  shape.size(),
+                                  node.Name(), logger)) {
       return false;
     }
   }
 
   return true;
+}
+
+// Check the rank of output 0 against the corresponding WebNN op's "output" parameter limits.
+// This covers the common single-output case; ops with multiple outputs or non-"output"
+// parameter names should call IsRankSupportedByWebNNOp directly with the proper name(s).
+bool IsOutputRankSupportedByOp(const Node& node, const emscripten::val& wnn_limits,
+                               const logging::Logger& logger) {
+  std::vector<int64_t> shape;
+  if (!GetShape(*node.OutputDefs()[0], shape, logger)) {
+    return false;
+  }
+
+  const std::string_view webnn_op_type = GetWebNNOpType(node.OpType());
+  return IsRankSupportedByWebNNOp(wnn_limits, webnn_op_type, "output", shape.size(),
+                                  node.Name(), logger);
 }
 
 std::unordered_set<const Node*> GetSupportedNodes(const GraphViewer& graph_viewer,

--- a/onnxruntime/core/providers/webnn/builders/helper.cc
+++ b/onnxruntime/core/providers/webnn/builders/helper.cc
@@ -99,55 +99,57 @@ bool IsTensorShapeSupported(const NodeArg& node_arg, const std::string& parent_n
   return true;
 }
 
-// Check if a single input's rank of an ONNX op is supported by corresponding WebNN op.
-bool IsInputRankSupported(const emscripten::val& wnn_limits,
-                          const std::string_view webnn_op_type,
-                          const std::string_view input_name,
-                          const size_t input_rank,
-                          const std::string_view node_name,
-                          const logging::Logger& logger) {
+// Check if a single input/output's rank of an ONNX op is supported by the corresponding WebNN op.
+// When the WebNN op/parameter or its 'rankRange' is not defined in MLOpSupportLimits, the rank
+// check is skipped (treated as supported).
+bool IsRankSupportedByWebNNOp(const emscripten::val& wnn_limits,
+                              const std::string_view webnn_op_type,
+                              const std::string_view param_name,
+                              const size_t rank,
+                              const std::string_view node_name,
+                              const logging::Logger& logger) {
   const std::string webnn_op_type_str(webnn_op_type);
-  const std::string input_name_str(input_name);
+  const std::string param_name_str(param_name);
 
   if (wnn_limits[webnn_op_type_str].isUndefined()) {
     LOGS(logger, VERBOSE) << "WebNN op type: [" << webnn_op_type
-                          << "] is not defined in WebNN MLOpSupportLimits.";
-    return false;
+                          << "] is not defined in WebNN MLOpSupportLimits, skip rank check.";
+    return true;
   }
 
-  const emscripten::val input_limits = wnn_limits[webnn_op_type_str][input_name_str];
+  const emscripten::val param_limits = wnn_limits[webnn_op_type_str][param_name_str];
 
-  if (input_limits.isUndefined()) {
+  if (param_limits.isUndefined()) {
     LOGS(logger, VERBOSE) << "Node name: [" << node_name
                           << "], WebNN op type: [" << webnn_op_type
-                          << "], input [" << input_name
-                          << "]: limits are not defined in WebNN MLOpSupportLimits.";
-    return false;
+                          << "], parameter [" << param_name
+                          << "]: limits are not defined in WebNN MLOpSupportLimits, skip rank check.";
+    return true;
   }
 
-  const emscripten::val rank_range = input_limits["rankRange"];
+  const emscripten::val rank_range = param_limits["rankRange"];
   if (rank_range.isUndefined()) {
     LOGS(logger, VERBOSE) << "WebNN op type [" << webnn_op_type
-                          << "] input [" << input_name
-                          << "]: missing 'rankRange' attribute.";
-    return false;
+                          << "] parameter [" << param_name
+                          << "]: missing 'rankRange' attribute, skip rank check.";
+    return true;
   }
 
   const emscripten::val min_val = rank_range["min"];
   const emscripten::val max_val = rank_range["max"];
   if (min_val.isUndefined() || max_val.isUndefined()) {
     LOGS(logger, VERBOSE) << "WebNN op type [" << webnn_op_type
-                          << "] input [" << input_name
-                          << "]: its 'rankRange' limits is missing valid 'min' or 'max' attributes.";
-    return false;
+                          << "] parameter [" << param_name
+                          << "]: its 'rankRange' limits is missing valid 'min' or 'max' attributes, skip rank check.";
+    return true;
   }
 
   size_t min_rank = min_val.as<size_t>();
   size_t max_rank = max_val.as<size_t>();
-  if (input_rank < min_rank || input_rank > max_rank) {
+  if (rank < min_rank || rank > max_rank) {
     LOGS(logger, VERBOSE) << "Node name: [" << node_name
                           << "] WebNN op type [" << webnn_op_type
-                          << "] input [" << input_name << "] rank " << input_rank
+                          << "] parameter [" << param_name << "] rank " << rank
                           << " is not in supported range [" << min_rank << ", " << max_rank << "]";
     return false;
   }
@@ -179,14 +181,29 @@ bool IsInputRankSupportedByOp(const Node& node, const emscripten::val& wnn_limit
 
     std::vector<int64_t> shape;
     if (!GetShape(*input_defs[input.index], shape, logger) ||
-        !IsInputRankSupported(wnn_limits, webnn_op_type, input.name,
-                              shape.size(),
-                              node.Name(), logger)) {
+        !IsRankSupportedByWebNNOp(wnn_limits, webnn_op_type, input.name,
+                                  shape.size(),
+                                  node.Name(), logger)) {
       return false;
     }
   }
 
   return true;
+}
+
+// Check the rank of output 0 against the corresponding WebNN op's "output" parameter limits.
+// This covers the common single-output case; ops with multiple outputs or non-"output"
+// parameter names should call IsRankSupportedByWebNNOp directly with the proper name(s).
+bool IsOutputRankSupportedByOp(const Node& node, const emscripten::val& wnn_limits,
+                               const logging::Logger& logger) {
+  std::vector<int64_t> shape;
+  if (!GetShape(*node.OutputDefs()[0], shape, logger)) {
+    return false;
+  }
+
+  const std::string_view webnn_op_type = GetWebNNOpType(node.OpType());
+  return IsRankSupportedByWebNNOp(wnn_limits, webnn_op_type, "output", shape.size(),
+                                  node.Name(), logger);
 }
 
 std::unordered_set<const Node*> GetSupportedNodes(const GraphViewer& graph_viewer,

--- a/onnxruntime/core/providers/webnn/builders/helper.h
+++ b/onnxruntime/core/providers/webnn/builders/helper.h
@@ -202,13 +202,15 @@ bool IsTensorShapeSupported(const NodeArg& node_arg, const std::string& parent_n
                             const logging::Logger& logger, bool allow_empty_input = false);
 
 bool IsInputRankSupportedByOp(const Node& node, const emscripten::val& wnn_limits, const logging::Logger& logger);
+bool IsOutputRankSupportedByOp(const Node& node, const emscripten::val& wnn_limits, const logging::Logger& logger);
 
-bool IsInputRankSupported(const emscripten::val& wnn_limits,
-                          const std::string_view webnn_op_type,
-                          const std::string_view input_name,
-                          const size_t input_rank,
-                          const std::string_view node_name,
-                          const logging::Logger& logger);
+// Check if a single input/output tensor's rank is supported by the corresponding WebNN op.
+bool IsRankSupportedByWebNNOp(const emscripten::val& wnn_limits,
+                              const std::string_view webnn_op_type,
+                              const std::string_view param_name,
+                              const size_t rank,
+                              const std::string_view node_name,
+                              const logging::Logger& logger);
 
 // Get a set of nodes supported by WebNN EP.
 std::unordered_set<const Node*> GetSupportedNodes(const GraphViewer& graph_viewer,

--- a/onnxruntime/core/providers/webnn/builders/helper.h
+++ b/onnxruntime/core/providers/webnn/builders/helper.h
@@ -202,13 +202,17 @@ bool IsTensorShapeSupported(const NodeArg& node_arg, const std::string& parent_n
                             const logging::Logger& logger, bool allow_empty_input = false);
 
 bool IsInputRankSupportedByOp(const Node& node, const emscripten::val& wnn_limits, const logging::Logger& logger);
+bool IsOutputRankSupportedByOp(const Node& node, const emscripten::val& wnn_limits, const logging::Logger& logger);
 
-bool IsInputRankSupported(const emscripten::val& wnn_limits,
-                          const std::string_view webnn_op_type,
-                          const std::string_view input_name,
-                          const size_t input_rank,
-                          const std::string_view node_name,
-                          const logging::Logger& logger);
+// Check if a single input/output tensor's rank is supported by the corresponding WebNN op.
+// The rank check is skipped (treated as supported) when the WebNN op/parameter or its
+// 'rankRange' is not defined in MLOpSupportLimits.
+bool IsRankSupportedByWebNNOp(const emscripten::val& wnn_limits,
+                              const std::string_view webnn_op_type,
+                              const std::string_view param_name,
+                              const size_t rank,
+                              const std::string_view node_name,
+                              const logging::Logger& logger);
 
 // Get a set of nodes supported by WebNN EP.
 std::unordered_set<const Node*> GetSupportedNodes(const GraphViewer& graph_viewer,

--- a/onnxruntime/core/providers/webnn/builders/impl/base_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/base_op_builder.cc
@@ -85,14 +85,15 @@ bool BaseOpBuilder::HasSupportedOutputs(const Node& node, const emscripten::val&
 bool BaseOpBuilder::HasSupportedOutputsImpl(const Node& node,
                                             const emscripten::val& wnn_limits,
                                             const logging::Logger& logger) const {
-  // We only check the type of output 0 by default, specific op builder can override this.
+  // We only check the type and rank of output 0 by default, specific op builder can override this.
   const auto& output = *node.OutputDefs()[0];
   const std::string_view op_type = node.OpType();
   int32_t output_type;
   if (!GetType(output, output_type, logger))
     return false;
 
-  return IsDataTypeSupportedByOp(op_type, output_type, wnn_limits, "output", "Output", logger);
+  return IsDataTypeSupportedByOp(op_type, output_type, wnn_limits, "output", "Output", logger) &&
+         IsOutputRankSupportedByOp(node, wnn_limits, logger);
 }
 
 bool BaseOpBuilder::HasSupportedOpSet(const Node& node,

--- a/onnxruntime/core/providers/webnn/builders/impl/conv_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/conv_op_builder.cc
@@ -333,9 +333,10 @@ bool ConvOpBuilder::HasSupportedOutputsImpl(const Node& node, const emscripten::
     // The last decomposed op of ConvInteger is Cast, and so
     // we only need to ensure it supports the output_type.
     return IsDataTypeSupportedByOp("Cast", output_type, wnn_limits, "output", "Output", logger);
-  } else {
-    return IsDataTypeSupportedByOp(op_type, output_type, wnn_limits, "output", "Output", logger);
   }
+
+  return IsDataTypeSupportedByOp(op_type, output_type, wnn_limits, "output", "Output", logger) &&
+         IsOutputRankSupportedByOp(node, wnn_limits, logger);
 }
 
 void CreateConvOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations) {

--- a/onnxruntime/core/providers/webnn/builders/impl/dynamicQuantizeLinear_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/dynamicQuantizeLinear_op_builder.cc
@@ -172,7 +172,7 @@ bool DynamicQuantizeLinearOpBuilder::HasSupportedInputsImpl(const GraphViewer&, 
   // (reduceMax, reduceMin and quantizeLinear accept the first input).
   const std::array<std::string_view, 3> operations = {"reduceMax", "reduceMin", "quantizeLinear"};
   for (const auto& op : operations) {
-    if (!IsInputRankSupported(wnn_limits, op, "input", input_shape.size(), node.Name(), logger)) {
+    if (!IsRankSupportedByWebNNOp(wnn_limits, op, "input", input_shape.size(), node.Name(), logger)) {
       return false;
     }
   }

--- a/onnxruntime/core/providers/webnn/builders/impl/einsum_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/einsum_op_builder.cc
@@ -789,7 +789,7 @@ bool EinsumOpBuilder::HasSupportedInputsImpl(const GraphViewer&, const Node& nod
   if (decompose_wnn_op_type.empty() ||
       !IsDataTypeSupportedByWebNNOp(op_type, decompose_wnn_op_type, input0_type,
                                     wnn_limits, wnn_input0_name, "inputs", logger) ||
-      !IsInputRankSupported(wnn_limits, decompose_wnn_op_type, wnn_input0_name,
+      !IsRankSupportedByWebNNOp(wnn_limits, decompose_wnn_op_type, wnn_input0_name,
                             input0_shape.size(), node.Name(), logger)) {
     return false;
   }
@@ -798,7 +798,7 @@ bool EinsumOpBuilder::HasSupportedInputsImpl(const GraphViewer&, const Node& nod
     const std::string_view wnn_input1_name = GetWebNNInputName(decomposed_op_type, 1);
     return IsDataTypeSupportedByWebNNOp(op_type, decompose_wnn_op_type, input1_type,
                                         wnn_limits, wnn_input1_name, "inputs", logger) &&
-           IsInputRankSupported(wnn_limits, decompose_wnn_op_type, wnn_input1_name,
+           IsRankSupportedByWebNNOp(wnn_limits, decompose_wnn_op_type, wnn_input1_name,
                                 input1_shape.size(), node.Name(), logger);
   }
 

--- a/onnxruntime/core/providers/webnn/builders/impl/einsum_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/einsum_op_builder.cc
@@ -790,7 +790,7 @@ bool EinsumOpBuilder::HasSupportedInputsImpl(const GraphViewer&, const Node& nod
       !IsDataTypeSupportedByWebNNOp(op_type, decompose_wnn_op_type, input0_type,
                                     wnn_limits, wnn_input0_name, "inputs", logger) ||
       !IsRankSupportedByWebNNOp(wnn_limits, decompose_wnn_op_type, wnn_input0_name,
-                            input0_shape.size(), node.Name(), logger)) {
+                                input0_shape.size(), node.Name(), logger)) {
     return false;
   }
 
@@ -799,7 +799,7 @@ bool EinsumOpBuilder::HasSupportedInputsImpl(const GraphViewer&, const Node& nod
     return IsDataTypeSupportedByWebNNOp(op_type, decompose_wnn_op_type, input1_type,
                                         wnn_limits, wnn_input1_name, "inputs", logger) &&
            IsRankSupportedByWebNNOp(wnn_limits, decompose_wnn_op_type, wnn_input1_name,
-                                input1_shape.size(), node.Name(), logger);
+                                    input1_shape.size(), node.Name(), logger);
   }
 
   return true;

--- a/onnxruntime/core/providers/webnn/builders/impl/gemm_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/gemm_op_builder.cc
@@ -302,7 +302,7 @@ bool GemmOpBuilder::HasSupportedInputsImpl(const GraphViewer&, const Node& node,
       }
 
       // For DequantizeLinear, input indices: 0 (x), 1 (scale), 2 (zero_point)
-      if (!IsInputRankSupported(wnn_limits, "dequantizeLinear",
+      if (!IsRankSupportedByWebNNOp(wnn_limits, "dequantizeLinear",
                                 (i < 2) ? "input" : "zeroPoint",
                                 shape.size(), node.Name(), logger)) {
         return false;
@@ -320,7 +320,7 @@ bool GemmOpBuilder::HasSupportedInputsImpl(const GraphViewer&, const Node& node,
         continue;
       }
 
-      if (!IsInputRankSupported(wnn_limits, "matmul", (i == 0) ? "a" : "b", shape.size(), node.Name(), logger)) {
+      if (!IsRankSupportedByWebNNOp(wnn_limits, "matmul", (i == 0) ? "a" : "b", shape.size(), node.Name(), logger)) {
         return false;
       }
     }
@@ -341,9 +341,10 @@ bool GemmOpBuilder::HasSupportedOutputsImpl(const Node& node, const emscripten::
     // The last decomposed op of MatMulInteger is Cast, and so
     // we only need to ensure it supports the output_type.
     return IsDataTypeSupportedByOp("Cast", output_type, wnn_limits, "output", "Output", logger);
-  } else {
-    return IsDataTypeSupportedByOp(op_type, output_type, wnn_limits, "output", "Output", logger);
   }
+
+  return IsDataTypeSupportedByOp(op_type, output_type, wnn_limits, "output", "Output", logger) &&
+         IsOutputRankSupportedByOp(node, wnn_limits, logger);
 }
 
 void CreateGemmOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations) {

--- a/onnxruntime/core/providers/webnn/builders/impl/gemm_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/gemm_op_builder.cc
@@ -303,8 +303,8 @@ bool GemmOpBuilder::HasSupportedInputsImpl(const GraphViewer&, const Node& node,
 
       // For DequantizeLinear, input indices: 0 (x), 1 (scale), 2 (zero_point)
       if (!IsRankSupportedByWebNNOp(wnn_limits, "dequantizeLinear",
-                                (i < 2) ? "input" : "zeroPoint",
-                                shape.size(), node.Name(), logger)) {
+                                    (i < 2) ? "input" : "zeroPoint",
+                                    shape.size(), node.Name(), logger)) {
         return false;
       }
     }

--- a/onnxruntime/core/providers/webnn/builders/impl/gru_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/gru_op_builder.cc
@@ -236,16 +236,28 @@ bool GruOpBuilder::HasSupportedOutputsImpl(const Node& node,
   bool Y_supported = has_Y && GetType(*output_defs[0], Y_type, logger);
   bool Y_h_supported = has_Y_h && GetType(*output_defs[1], Y_h_type, logger);
 
+  // WebNN gru output names: output0 -> Y_h, output1 -> Y.
   if (Y_supported && !Y_h_supported) {
-    return IsDataTypeSupportedByOp(op_type, Y_type, wnn_limits, "output1", "Y", logger);
+    std::vector<int64_t> Y_shape;
+    return IsDataTypeSupportedByOp(op_type, Y_type, wnn_limits, "output1", "Y", logger) &&
+           GetShape(*output_defs[0], Y_shape, logger) &&
+           IsRankSupportedByWebNNOp(wnn_limits, "gru", "output1", Y_shape.size(), node.Name(), logger);
   } else if (!Y_supported && Y_h_supported) {
-    return IsDataTypeSupportedByOp(op_type, Y_h_type, wnn_limits, "output0", "Y_h", logger);
+    std::vector<int64_t> Y_h_shape;
+    return IsDataTypeSupportedByOp(op_type, Y_h_type, wnn_limits, "output0", "Y_h", logger) &&
+           GetShape(*output_defs[1], Y_h_shape, logger) &&
+           IsRankSupportedByWebNNOp(wnn_limits, "gru", "output0", Y_h_shape.size(), node.Name(), logger);
   } else if (Y_supported && Y_h_supported) {
     if (Y_type != Y_h_type) {
       LOGS(logger, VERBOSE) << "[GRU] Output data types must be the same.";
       return false;
     }
-    return IsDataTypeSupportedByOp(op_type, Y_type, wnn_limits, "output1", "Y", logger);
+    std::vector<int64_t> Y_shape, Y_h_shape;
+    return IsDataTypeSupportedByOp(op_type, Y_type, wnn_limits, "output1", "Y", logger) &&
+           GetShape(*output_defs[0], Y_shape, logger) &&
+           IsRankSupportedByWebNNOp(wnn_limits, "gru", "output1", Y_shape.size(), node.Name(), logger) &&
+           GetShape(*output_defs[1], Y_h_shape, logger) &&
+           IsRankSupportedByWebNNOp(wnn_limits, "gru", "output0", Y_h_shape.size(), node.Name(), logger);
   } else {
     LOGS(logger, VERBOSE) << "[GRU] No output found.";
     return false;

--- a/onnxruntime/core/providers/webnn/builders/impl/lpNormalization_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/lpNormalization_op_builder.cc
@@ -106,8 +106,8 @@ bool LpNormalizationOpBuilder::HasSupportedInputsImpl(const GraphViewer&, const 
     return false;
   }
   // reduceL2 consumes the input; div consumes the input as its first operand ("a").
-  return IsInputRankSupported(wnn_limits, "reduceL2", "input", input_shape.size(), node.Name(), logger) &&
-         IsInputRankSupported(wnn_limits, "div", "a", input_shape.size(), node.Name(), logger);
+  return IsRankSupportedByWebNNOp(wnn_limits, "reduceL2", "input", input_shape.size(), node.Name(), logger) &&
+         IsRankSupportedByWebNNOp(wnn_limits, "div", "a", input_shape.size(), node.Name(), logger);
 }
 
 bool LpNormalizationOpBuilder::HasSupportedOutputsImpl(const Node& node,

--- a/onnxruntime/core/providers/webnn/builders/impl/lstm_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/lstm_op_builder.cc
@@ -258,14 +258,24 @@ bool LstmOpBuilder::HasSupportedOutputsImpl(const Node& node,
   bool has_Y_h = TensorExists(output_defs, 1);
   bool has_Y_c = TensorExists(output_defs, 2);
 
+  // WebNN lstm output names: output0 -> Y_h, output1 -> Y_c, output2 -> Y.
   if (has_Y && GetType(*output_defs[0], Y_type, logger)) {
-    return IsDataTypeSupportedByOp(op_type, Y_type, wnn_limits, "output2", "Y", logger);
+    std::vector<int64_t> Y_shape;
+    return IsDataTypeSupportedByOp(op_type, Y_type, wnn_limits, "output2", "Y", logger) &&
+           GetShape(*output_defs[0], Y_shape, logger) &&
+           IsRankSupportedByWebNNOp(wnn_limits, "lstm", "output2", Y_shape.size(), node.Name(), logger);
   }
   if (has_Y_h && GetType(*output_defs[1], Y_h_type, logger)) {
-    return IsDataTypeSupportedByOp(op_type, Y_h_type, wnn_limits, "output0", "Y_h", logger);
+    std::vector<int64_t> Y_h_shape;
+    return IsDataTypeSupportedByOp(op_type, Y_h_type, wnn_limits, "output0", "Y_h", logger) &&
+           GetShape(*output_defs[1], Y_h_shape, logger) &&
+           IsRankSupportedByWebNNOp(wnn_limits, "lstm", "output0", Y_h_shape.size(), node.Name(), logger);
   }
   if (has_Y_c && GetType(*output_defs[2], Y_c_type, logger)) {
-    return IsDataTypeSupportedByOp(op_type, Y_c_type, wnn_limits, "output1", "Y_c", logger);
+    std::vector<int64_t> Y_c_shape;
+    return IsDataTypeSupportedByOp(op_type, Y_c_type, wnn_limits, "output1", "Y_c", logger) &&
+           GetShape(*output_defs[2], Y_c_shape, logger) &&
+           IsRankSupportedByWebNNOp(wnn_limits, "lstm", "output1", Y_c_shape.size(), node.Name(), logger);
   }
 
   return false;

--- a/onnxruntime/core/providers/webnn/builders/impl/matMulNBits_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/matMulNBits_op_builder.cc
@@ -293,7 +293,7 @@ bool MatMulNBitsBuilder::HasSupportedInputsImpl(const GraphViewer&,
                                  wnn_limits, "input", "x", logger) &&
          IsDataTypeSupportedByOp("DequantizeLinear", dq_input_type,
                                  wnn_limits, "zeroPoint", "x_zero_point", logger) &&
-         IsInputRankSupported(wnn_limits, "matmul", "a", input_shape.size(), node.Name(), logger);
+         IsRankSupportedByWebNNOp(wnn_limits, "matmul", "a", input_shape.size(), node.Name(), logger);
 }
 
 bool MatMulNBitsBuilder::HasSupportedOutputsImpl(const Node& node, const emscripten::val& wnn_limits,

--- a/onnxruntime/core/providers/webnn/builders/impl/normalization_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/normalization_op_builder.cc
@@ -293,8 +293,8 @@ bool NormalizationOpBuilder::HasSupportedInputsImpl(const GraphViewer&, const No
     }
     // It's complicated to check all the decomposed ops' input rank support.
     // Ensure at least the first input rank is supported by the decomposed ops (pow and div accept the first input).
-    return IsInputRankSupported(wnn_limits, "pow", "a", input_shape.size(), node.Name(), logger) &&
-           IsInputRankSupported(wnn_limits, "div", "a", input_shape.size(), node.Name(), logger);
+    return IsRankSupportedByWebNNOp(wnn_limits, "pow", "a", input_shape.size(), node.Name(), logger) &&
+           IsRankSupportedByWebNNOp(wnn_limits, "div", "a", input_shape.size(), node.Name(), logger);
   } else {
     bool is_data_type_supported = IsDataTypeSupportedByOp(op_type, input_types[0], wnn_limits, "input", "X", logger);
     if (op_type == "InstanceNormalization") {
@@ -328,7 +328,8 @@ bool NormalizationOpBuilder::HasSupportedOutputsImpl(const Node& node,
     }
     return true;
   } else {
-    return IsDataTypeSupportedByOp(op_type, output_type, wnn_limits, "output", "Output", logger);
+    return IsDataTypeSupportedByOp(op_type, output_type, wnn_limits, "output", "Output", logger) &&
+           IsOutputRankSupportedByOp(node, wnn_limits, logger);
   }
 }
 

--- a/onnxruntime/core/providers/webnn/builders/impl/slice_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/slice_op_builder.cc
@@ -182,7 +182,7 @@ bool SliceOpBuilder::HasSupportedInputsImpl(const GraphViewer& graph_viewer, con
       return false;
     if (std::any_of(steps.begin(), steps.end(), [](int64_t step) { return step < 0; })) {
       if (!IsDataTypeSupportedByWebNNOp(op_type, "reverse", input_type, wnn_limits, "input", "data", logger) ||
-          !IsInputRankSupported(wnn_limits, "reverse", "input", input_shape.size(), node.Name(), logger)) {
+          !IsRankSupportedByWebNNOp(wnn_limits, "reverse", "input", input_shape.size(), node.Name(), logger)) {
         return false;
       }
     }

--- a/onnxruntime/core/providers/webnn/builders/impl/split_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/split_op_builder.cc
@@ -176,7 +176,14 @@ bool SplitOpBuilder::HasSupportedOutputsImpl(const Node& node,
     // Chromium has changed the output name of split from 'output' to 'outputs',
     // to avoid breaking the existing API, we need to check both names.
     const std::string_view wnn_output_name = wnn_limits["split"]["output"].isUndefined() ? "outputs" : "output";
-    return IsDataTypeSupportedByOp(op_type, output_type, wnn_limits, wnn_output_name, "outputs", logger);
+    if (!IsDataTypeSupportedByOp(op_type, output_type, wnn_limits, wnn_output_name, "outputs", logger)) {
+      return false;
+    }
+
+    // All of split's outputs share the same rank; checking output 0 is sufficient.
+    std::vector<int64_t> output_shape;
+    return GetShape(*output_defs[0], output_shape, logger) &&
+           IsRankSupportedByWebNNOp(wnn_limits, "split", wnn_output_name, output_shape.size(), node.Name(), logger);
   }
 
   return false;

--- a/onnxruntime/core/providers/webnn/builders/impl/split_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/split_op_builder.cc
@@ -176,7 +176,17 @@ bool SplitOpBuilder::HasSupportedOutputsImpl(const Node& node,
     // Chromium has changed the output name of split from 'output' to 'outputs',
     // to avoid breaking the existing API, we need to check both names.
     const std::string_view wnn_output_name = wnn_limits["split"]["output"].isUndefined() ? "outputs" : "output";
-    return IsDataTypeSupportedByOp(op_type, output_type, wnn_limits, wnn_output_name, "outputs", logger);
+    if (!IsDataTypeSupportedByOp(op_type, output_type, wnn_limits, wnn_output_name, "outputs", logger)) {
+      return false;
+    }
+
+    // All of split's outputs share the same rank; checking output 0 is sufficient.
+    std::vector<int64_t> output_shape;
+    if (!GetShape(*output_defs[0], output_shape, logger)) {
+      return false;
+    }
+    return IsRankSupportedByWebNNOp(wnn_limits, "split", wnn_output_name, output_shape.size(),
+                                    node.Name(), logger);
   }
 
   return false;


### PR DESCRIPTION
Mirror the existing input rank check by validating each node's output rank against the WebNN `opSupportLimits`'s `rankRange`.

- Rename `IsInputRankSupported` -> `IsRankSupportedByWebNNOp`.
- Add `IsOutputRankSupportedByOp` for the common single-"output" case.
- Add output rank checks to multi-output ops (gru, lstm, split) using their specific output parameter names.
- Skip decomposed ops (their type checks loop over sub-ops whose ranks differ from the final output).

