### PR TITLE
[WebGPU EP] Support int64 for Min and Max

### DIFF
--- a/onnxruntime/core/providers/webgpu/math/binary_elementwise_ops.cc
+++ b/onnxruntime/core/providers/webgpu/math/binary_elementwise_ops.cc
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include <memory>
+#include <optional>
 
 #include "core/common/inlined_containers.h"
 #include "core/providers/common.h"
@@ -484,10 +485,11 @@ Status CreateBinaryOpKernel(FuncManager&, const OpKernelInfo& info, std::unique_
   return Status::OK();
 }
 
-// A single opset version range for an op registration. end <= 0 means "since start" (open-ended).
+// A single opset version range for an op registration, inclusive on both ends: [begin, end].
+// A nullopt end means "since begin" (open-ended, no upper opset bound).
 struct VersionRange {
-  int start;
-  int end;
+  int begin;
+  std::optional<int> end;
 };
 
 // Registers every opset version range of one binary elementwise op. Passing a non-null
@@ -507,10 +509,10 @@ void RegisterBinaryOp(KernelRegistry& kernel_registry,
     if (t1_type_constraints != nullptr) {
       builder.TypeConstraint("T1", *t1_type_constraints);
     }
-    if (r.end > 0) {
-      builder.SinceVersion(r.start, r.end);
+    if (r.end.has_value()) {
+      builder.SinceVersion(r.begin, *r.end);
     } else {
-      builder.SinceVersion(r.start);
+      builder.SinceVersion(r.begin);
     }
     ORT_THROW_IF_ERROR(kernel_registry.Register({builder.Build(), kernel_create_fn}));
   }
@@ -532,24 +534,24 @@ void RegisterBinaryElementwiseKernels(KernelRegistry& kernel_registry, bool enab
   static const std::vector<MLDataType> bool_type{DataTypeImpl::GetTensorType<bool>()};
 
   // Arithmetic + comparison ops: int64 is meaningful, so gate it on enable_int64.
-  RegisterBinaryOp(kernel_registry, "Add", CreateBinaryOpKernel<Add>, int64_capable, {{7, 12}, {13, 13}, {14, 0}});
-  RegisterBinaryOp(kernel_registry, "Sub", CreateBinaryOpKernel<Sub>, int64_capable, {{7, 12}, {13, 13}, {14, 0}});
-  RegisterBinaryOp(kernel_registry, "Mul", CreateBinaryOpKernel<Mul>, int64_capable, {{7, 12}, {13, 13}, {14, 0}});
-  RegisterBinaryOp(kernel_registry, "Div", CreateBinaryOpKernel<Div>, int64_capable, {{7, 12}, {13, 13}, {14, 0}});
-  RegisterBinaryOp(kernel_registry, "Max", CreateBinaryOpKernel<Max>, int64_capable, {{8, 11}, {12, 12}, {13, 0}});
-  RegisterBinaryOp(kernel_registry, "Min", CreateBinaryOpKernel<Min>, int64_capable, {{8, 11}, {12, 12}, {13, 0}});
-  RegisterBinaryOp(kernel_registry, "Equal", CreateBinaryOpKernel<Equal>, int64_capable, {{7, 10}, {11, 12}, {13, 18}, {19, 0}});
-  RegisterBinaryOp(kernel_registry, "Greater", CreateBinaryOpKernel<Greater>, int64_capable, {{7, 8}, {9, 12}, {13, 0}});
-  RegisterBinaryOp(kernel_registry, "Less", CreateBinaryOpKernel<Less>, int64_capable, {{7, 8}, {9, 12}, {13, 0}});
-  RegisterBinaryOp(kernel_registry, "GreaterOrEqual", CreateBinaryOpKernel<GreaterOrEqual>, int64_capable, {{12, 15}, {16, 0}});
-  RegisterBinaryOp(kernel_registry, "LessOrEqual", CreateBinaryOpKernel<LessOrEqual>, int64_capable, {{12, 15}, {16, 0}});
+  RegisterBinaryOp(kernel_registry, "Add", CreateBinaryOpKernel<Add>, int64_capable, {{7, 12}, {13, 13}, {14, std::nullopt}});
+  RegisterBinaryOp(kernel_registry, "Sub", CreateBinaryOpKernel<Sub>, int64_capable, {{7, 12}, {13, 13}, {14, std::nullopt}});
+  RegisterBinaryOp(kernel_registry, "Mul", CreateBinaryOpKernel<Mul>, int64_capable, {{7, 12}, {13, 13}, {14, std::nullopt}});
+  RegisterBinaryOp(kernel_registry, "Div", CreateBinaryOpKernel<Div>, int64_capable, {{7, 12}, {13, 13}, {14, std::nullopt}});
+  RegisterBinaryOp(kernel_registry, "Max", CreateBinaryOpKernel<Max>, int64_capable, {{8, 11}, {12, 12}, {13, std::nullopt}});
+  RegisterBinaryOp(kernel_registry, "Min", CreateBinaryOpKernel<Min>, int64_capable, {{8, 11}, {12, 12}, {13, std::nullopt}});
+  RegisterBinaryOp(kernel_registry, "Equal", CreateBinaryOpKernel<Equal>, int64_capable, {{7, 10}, {11, 12}, {13, 18}, {19, std::nullopt}});
+  RegisterBinaryOp(kernel_registry, "Greater", CreateBinaryOpKernel<Greater>, int64_capable, {{7, 8}, {9, 12}, {13, std::nullopt}});
+  RegisterBinaryOp(kernel_registry, "Less", CreateBinaryOpKernel<Less>, int64_capable, {{7, 8}, {9, 12}, {13, std::nullopt}});
+  RegisterBinaryOp(kernel_registry, "GreaterOrEqual", CreateBinaryOpKernel<GreaterOrEqual>, int64_capable, {{12, 15}, {16, std::nullopt}});
+  RegisterBinaryOp(kernel_registry, "LessOrEqual", CreateBinaryOpKernel<LessOrEqual>, int64_capable, {{12, 15}, {16, std::nullopt}});
 
   // Ops for which int64 is not meaningful, registered through the same path for consistency.
   // Pow gains a second "T1" (exponent) type constraint from opset 12.
   RegisterBinaryOp(kernel_registry, "Pow", CreateBinaryOpKernel<Pow>, number_types, {{7, 11}});
-  RegisterBinaryOp(kernel_registry, "Pow", CreateBinaryOpKernel<Pow>, number_types, {{12, 12}, {13, 14}, {15, 0}}, &number_types);
-  RegisterBinaryOp(kernel_registry, "PRelu", CreateBinaryOpKernel<PRelu>, float_types, {{7, 8}, {9, 15}, {16, 0}});
-  RegisterBinaryOp(kernel_registry, "And", CreateBinaryOpKernel<And>, bool_type, {{7, 0}});
+  RegisterBinaryOp(kernel_registry, "Pow", CreateBinaryOpKernel<Pow>, number_types, {{12, 12}, {13, 14}, {15, std::nullopt}}, &number_types);
+  RegisterBinaryOp(kernel_registry, "PRelu", CreateBinaryOpKernel<PRelu>, float_types, {{7, 8}, {9, 15}, {16, std::nullopt}});
+  RegisterBinaryOp(kernel_registry, "And", CreateBinaryOpKernel<And>, bool_type, {{7, std::nullopt}});
 }
 
 }  // namespace webgpu

--- a/onnxruntime/core/providers/webgpu/math/binary_elementwise_ops.cc
+++ b/onnxruntime/core/providers/webgpu/math/binary_elementwise_ops.cc
@@ -562,14 +562,74 @@ static std::string GetMinImpl(int lhs_element_type, int /* rhs_element_type */) 
 }
 
 WEBGPU_VARIADIC_IMPL(Max, "max_v(vec4<input_a_element_t>(a), vec4<input_b_element_t>(b))", GetMaxImpl)
-WEBGPU_BINARY_VERSIONED_KERNEL(Max, 8, 11, Max, WebGpuSupportedNumberTypes())
-WEBGPU_BINARY_VERSIONED_KERNEL(Max, 12, 12, Max, WebGpuSupportedNumberTypes())
-WEBGPU_BINARY_KERNEL(Max, 13, Max, WebGpuSupportedNumberTypes())
-
 WEBGPU_VARIADIC_IMPL(Min, "min_v(vec4<input_a_element_t>(a), vec4<input_b_element_t>(b))", GetMinImpl)
-WEBGPU_BINARY_VERSIONED_KERNEL(Min, 8, 11, Min, WebGpuSupportedNumberTypes())
-WEBGPU_BINARY_VERSIONED_KERNEL(Min, 12, 12, Min, WebGpuSupportedNumberTypes())
-WEBGPU_BINARY_KERNEL(Min, 13, Min, WebGpuSupportedNumberTypes())
+
+// NOTE: int64 min/max in the WebGPU shader compares the low 32 bits only (i32 element type).
+// Values outside the int32 range [-2^31, 2^31-1] will produce incorrect results.
+// This matches the same limitation documented in Add/Sub and is acceptable for token-position workloads.
+KernelCreateInfo CreateMaxVersionedKernelInfo(int start_version, int end_version, bool enable_int64) {
+  const auto& type_constraints = GetOpTypeConstraints(enable_int64, false);
+  KernelCreatePtrFn kernel_create_fn = [](FuncManager&, const OpKernelInfo& info, std::unique_ptr<OpKernel>& out) -> Status {
+    out = std::make_unique<Max>(info);
+    return Status::OK();
+  };
+  return {KernelDefBuilder()
+              .SetName("Max")
+              .SetDomain(kOnnxDomain)
+              .SinceVersion(start_version, end_version)
+              .Provider(kWebGpuExecutionProvider)
+              .TypeConstraint("T", type_constraints)
+              .Build(),
+          kernel_create_fn};
+}
+
+KernelCreateInfo CreateMaxKernelInfo(int since_version, bool enable_int64) {
+  const auto& type_constraints = GetOpTypeConstraints(enable_int64, false);
+  KernelCreatePtrFn kernel_create_fn = [](FuncManager&, const OpKernelInfo& info, std::unique_ptr<OpKernel>& out) -> Status {
+    out = std::make_unique<Max>(info);
+    return Status::OK();
+  };
+  return {KernelDefBuilder()
+              .SetName("Max")
+              .SetDomain(kOnnxDomain)
+              .SinceVersion(since_version)
+              .Provider(kWebGpuExecutionProvider)
+              .TypeConstraint("T", type_constraints)
+              .Build(),
+          kernel_create_fn};
+}
+
+KernelCreateInfo CreateMinVersionedKernelInfo(int start_version, int end_version, bool enable_int64) {
+  const auto& type_constraints = GetOpTypeConstraints(enable_int64, false);
+  KernelCreatePtrFn kernel_create_fn = [](FuncManager&, const OpKernelInfo& info, std::unique_ptr<OpKernel>& out) -> Status {
+    out = std::make_unique<Min>(info);
+    return Status::OK();
+  };
+  return {KernelDefBuilder()
+              .SetName("Min")
+              .SetDomain(kOnnxDomain)
+              .SinceVersion(start_version, end_version)
+              .Provider(kWebGpuExecutionProvider)
+              .TypeConstraint("T", type_constraints)
+              .Build(),
+          kernel_create_fn};
+}
+
+KernelCreateInfo CreateMinKernelInfo(int since_version, bool enable_int64) {
+  const auto& type_constraints = GetOpTypeConstraints(enable_int64, false);
+  KernelCreatePtrFn kernel_create_fn = [](FuncManager&, const OpKernelInfo& info, std::unique_ptr<OpKernel>& out) -> Status {
+    out = std::make_unique<Min>(info);
+    return Status::OK();
+  };
+  return {KernelDefBuilder()
+              .SetName("Min")
+              .SetDomain(kOnnxDomain)
+              .SinceVersion(since_version)
+              .Provider(kWebGpuExecutionProvider)
+              .TypeConstraint("T", type_constraints)
+              .Build(),
+          kernel_create_fn};
+}
 
 std::string GetPowImpl(int lhs_element_type, int /* rhs_element_type */) {
   SS(s, 1024);

--- a/onnxruntime/core/providers/webgpu/math/binary_elementwise_ops.cc
+++ b/onnxruntime/core/providers/webgpu/math/binary_elementwise_ops.cc
@@ -519,9 +519,11 @@ void RegisterBinaryOp(KernelRegistry& kernel_registry,
 }
 }  // namespace
 
-// Registers every binary elementwise op through a single path so int64 support (behind the
-// enableInt64 provider option) is applied and maintained consistently. int64 is enabled only
-// for ops whose low-32-bit i32 shader semantics are meaningful (arithmetic + comparison).
+// Registers the binary elementwise ops through a single path so int64 support (behind the
+// enableInt64 provider option) is applied and maintained consistently. int64 is currently enabled
+// for the arithmetic and comparison ops whose low-32-bit i32 shader semantics are meaningful and
+// implemented (Add, Sub, Mul, Div, Max, Min, Equal, Greater, Less, GreaterOrEqual, LessOrEqual).
+// Pow is a known gap (see the TODO below); PRelu/And have no int64 form.
 //
 // NOTE: int64 in the WebGPU shader operates on the low 32 bits only (i32 element type). Values
 // outside the int32 range [-2^31, 2^31-1] produce incorrect results. This is acceptable for the
@@ -546,10 +548,14 @@ void RegisterBinaryElementwiseKernels(KernelRegistry& kernel_registry, bool enab
   RegisterBinaryOp(kernel_registry, "GreaterOrEqual", CreateBinaryOpKernel<GreaterOrEqual>, int64_capable, {{12, 15}, {16, std::nullopt}});
   RegisterBinaryOp(kernel_registry, "LessOrEqual", CreateBinaryOpKernel<LessOrEqual>, int64_capable, {{12, 15}, {16, std::nullopt}});
 
-  // Ops for which int64 is not meaningful, registered through the same path for consistency.
+  // TODO: the ONNX Pow schema allows int64 inputs, but the WebGPU Pow shader does not handle int64
+  // yet, so Pow stays on the non-int64 numeric constraints. Add schema-supported int64 Pow in a
+  // follow-up and move it up to the int64-capable group above.
   // Pow gains a second "T1" (exponent) type constraint from opset 12.
   RegisterBinaryOp(kernel_registry, "Pow", CreateBinaryOpKernel<Pow>, number_types, {{7, 11}});
   RegisterBinaryOp(kernel_registry, "Pow", CreateBinaryOpKernel<Pow>, number_types, {{12, 12}, {13, 14}, {15, std::nullopt}}, &number_types);
+
+  // PRelu (float) and And (bool) have no int64 form, so they keep their existing type constraints.
   RegisterBinaryOp(kernel_registry, "PRelu", CreateBinaryOpKernel<PRelu>, float_types, {{7, 8}, {9, 15}, {16, std::nullopt}});
   RegisterBinaryOp(kernel_registry, "And", CreateBinaryOpKernel<And>, bool_type, {{7, std::nullopt}});
 }

--- a/onnxruntime/core/providers/webgpu/math/binary_elementwise_ops.cc
+++ b/onnxruntime/core/providers/webgpu/math/binary_elementwise_ops.cc
@@ -390,141 +390,10 @@ Status VariadicElementwise::ComputeInternal(ComputeContext& context) const {
     OP_TYPE(const OpKernelInfo& info) : VariadicElementwise{info, #OP_TYPE, __VA_ARGS__} {} \
   };
 
-#define WEBGPU_BINARY_KERNEL(OP_TYPE, VERSION, KERNEL_CLASS, TYPE) \
-  ONNX_OPERATOR_KERNEL_EX(                                         \
-      OP_TYPE,                                                     \
-      kOnnxDomain,                                                 \
-      VERSION,                                                     \
-      kWebGpuExecutionProvider,                                    \
-      KernelDefBuilder().TypeConstraint("T", TYPE),                \
-      KERNEL_CLASS);
-
-#define WEBGPU_BINARY_VERSIONED_KERNEL(OP_TYPE, VERSION_FROM, VERSION_TO, KERNEL_CLASS, TYPE) \
-  ONNX_OPERATOR_VERSIONED_KERNEL_EX(                                                          \
-      OP_TYPE,                                                                                \
-      kOnnxDomain,                                                                            \
-      VERSION_FROM, VERSION_TO,                                                               \
-      kWebGpuExecutionProvider,                                                               \
-      KernelDefBuilder().TypeConstraint("T", TYPE),                                           \
-      KERNEL_CLASS);
-
-#define WEBGPU_BINARY_KERNEL_2(OP_TYPE, VERSION, KERNEL_CLASS, TYPE, TYPE1) \
-  ONNX_OPERATOR_KERNEL_EX(                                                  \
-      OP_TYPE,                                                              \
-      kOnnxDomain,                                                          \
-      VERSION,                                                              \
-      kWebGpuExecutionProvider,                                             \
-      KernelDefBuilder()                                                    \
-          .TypeConstraint("T", TYPE)                                        \
-          .TypeConstraint("T1", TYPE1),                                     \
-      KERNEL_CLASS);
-
-#define WEBGPU_BINARY_VERSIONED_KERNEL_2(OP_TYPE, VERSION_FROM, VERSION_TO, KERNEL_CLASS, TYPE, TYPE1) \
-  ONNX_OPERATOR_VERSIONED_KERNEL_EX(                                                                   \
-      OP_TYPE,                                                                                         \
-      kOnnxDomain,                                                                                     \
-      VERSION_FROM, VERSION_TO,                                                                        \
-      kWebGpuExecutionProvider,                                                                        \
-      KernelDefBuilder()                                                                               \
-          .TypeConstraint("T", TYPE)                                                                   \
-          .TypeConstraint("T1", TYPE1),                                                                \
-      KERNEL_CLASS);
-
 WEBGPU_BINARY_IMPL(Add, "a + b")
-
-// NOTE: int64 arithmetic in the WebGPU shader operates on the low 32 bits only (i32 element type).
-// Values outside the int32 range [-2^31, 2^31-1] will produce incorrect results.
-// This matches the same limitation documented in Range/Sub and is acceptable for token-position workloads.
-template <int StartVersion, int EndVersion>
-KernelCreateInfo CreateAddVersionedKernelInfo(bool enable_int64) {
-  const auto& type_constraints = GetOpTypeConstraints(enable_int64, false);
-  KernelCreatePtrFn kernel_create_fn = [](FuncManager&, const OpKernelInfo& info, std::unique_ptr<OpKernel>& out) -> Status {
-    out = std::make_unique<Add>(info);
-    return Status::OK();
-  };
-  return {KernelDefBuilder()
-              .SetName("Add")
-              .SetDomain(kOnnxDomain)
-              .SinceVersion(StartVersion, EndVersion)
-              .Provider(kWebGpuExecutionProvider)
-              .TypeConstraint("T", type_constraints)
-              .Build(),
-          kernel_create_fn};
-}
-
-template <int SinceVersion>
-KernelCreateInfo CreateAddKernelInfo(bool enable_int64) {
-  const auto& type_constraints = GetOpTypeConstraints(enable_int64, false);
-  KernelCreatePtrFn kernel_create_fn = [](FuncManager&, const OpKernelInfo& info, std::unique_ptr<OpKernel>& out) -> Status {
-    out = std::make_unique<Add>(info);
-    return Status::OK();
-  };
-  return {KernelDefBuilder()
-              .SetName("Add")
-              .SetDomain(kOnnxDomain)
-              .SinceVersion(SinceVersion)
-              .Provider(kWebGpuExecutionProvider)
-              .TypeConstraint("T", type_constraints)
-              .Build(),
-          kernel_create_fn};
-}
-
-template KernelCreateInfo CreateAddVersionedKernelInfo<7, 12>(bool);
-template KernelCreateInfo CreateAddVersionedKernelInfo<13, 13>(bool);
-template KernelCreateInfo CreateAddKernelInfo<14>(bool);
-
 WEBGPU_BINARY_IMPL(Div, "a / b")
-WEBGPU_BINARY_VERSIONED_KERNEL(Div, 7, 12, Div, WebGpuSupportedNumberTypes())
-WEBGPU_BINARY_VERSIONED_KERNEL(Div, 13, 13, Div, WebGpuSupportedNumberTypes())
-WEBGPU_BINARY_KERNEL(Div, 14, Div, WebGpuSupportedNumberTypes())
-
 WEBGPU_BINARY_IMPL(Mul, "a * b")
-WEBGPU_BINARY_VERSIONED_KERNEL(Mul, 7, 12, Mul, WebGpuSupportedNumberTypes())
-WEBGPU_BINARY_VERSIONED_KERNEL(Mul, 13, 13, Mul, WebGpuSupportedNumberTypes())
-WEBGPU_BINARY_KERNEL(Mul, 14, Mul, WebGpuSupportedNumberTypes())
-
 WEBGPU_BINARY_IMPL(Sub, "a - b")
-
-// NOTE: int64 arithmetic in the WebGPU shader operates on the low 32 bits only (i32 element type).
-// Values outside the int32 range [-2^31, 2^31-1] will produce incorrect results.
-// This matches the same limitation documented in Range and is acceptable for token-position workloads.
-template <int StartVersion, int EndVersion>
-KernelCreateInfo CreateSubVersionedKernelInfo(bool enable_int64) {
-  const auto& type_constraints = GetOpTypeConstraints(enable_int64, false);
-  KernelCreatePtrFn kernel_create_fn = [](FuncManager&, const OpKernelInfo& info, std::unique_ptr<OpKernel>& out) -> Status {
-    out = std::make_unique<Sub>(info);
-    return Status::OK();
-  };
-  return {KernelDefBuilder()
-              .SetName("Sub")
-              .SetDomain(kOnnxDomain)
-              .SinceVersion(StartVersion, EndVersion)
-              .Provider(kWebGpuExecutionProvider)
-              .TypeConstraint("T", type_constraints)
-              .Build(),
-          kernel_create_fn};
-}
-
-template <int SinceVersion>
-KernelCreateInfo CreateSubKernelInfo(bool enable_int64) {
-  const auto& type_constraints = GetOpTypeConstraints(enable_int64, false);
-  KernelCreatePtrFn kernel_create_fn = [](FuncManager&, const OpKernelInfo& info, std::unique_ptr<OpKernel>& out) -> Status {
-    out = std::make_unique<Sub>(info);
-    return Status::OK();
-  };
-  return {KernelDefBuilder()
-              .SetName("Sub")
-              .SetDomain(kOnnxDomain)
-              .SinceVersion(SinceVersion)
-              .Provider(kWebGpuExecutionProvider)
-              .TypeConstraint("T", type_constraints)
-              .Build(),
-          kernel_create_fn};
-}
-
-template KernelCreateInfo CreateSubVersionedKernelInfo<7, 12>(bool);
-template KernelCreateInfo CreateSubVersionedKernelInfo<13, 13>(bool);
-template KernelCreateInfo CreateSubKernelInfo<14>(bool);
 
 // ONNX Max/Min (opset 12+) propagate NaN: if either operand is NaN the result is NaN.
 // The WGSL `max`/`min` builtins do not guarantee this, so wrap them so that a NaN operand is
@@ -564,73 +433,6 @@ static std::string GetMinImpl(int lhs_element_type, int /* rhs_element_type */) 
 WEBGPU_VARIADIC_IMPL(Max, "max_v(vec4<input_a_element_t>(a), vec4<input_b_element_t>(b))", GetMaxImpl)
 WEBGPU_VARIADIC_IMPL(Min, "min_v(vec4<input_a_element_t>(a), vec4<input_b_element_t>(b))", GetMinImpl)
 
-// NOTE: int64 min/max in the WebGPU shader compares the low 32 bits only (i32 element type).
-// Values outside the int32 range [-2^31, 2^31-1] will produce incorrect results.
-// This matches the same limitation documented in Add/Sub and is acceptable for token-position workloads.
-KernelCreateInfo CreateMaxVersionedKernelInfo(int start_version, int end_version, bool enable_int64) {
-  const auto& type_constraints = GetOpTypeConstraints(enable_int64, false);
-  KernelCreatePtrFn kernel_create_fn = [](FuncManager&, const OpKernelInfo& info, std::unique_ptr<OpKernel>& out) -> Status {
-    out = std::make_unique<Max>(info);
-    return Status::OK();
-  };
-  return {KernelDefBuilder()
-              .SetName("Max")
-              .SetDomain(kOnnxDomain)
-              .SinceVersion(start_version, end_version)
-              .Provider(kWebGpuExecutionProvider)
-              .TypeConstraint("T", type_constraints)
-              .Build(),
-          kernel_create_fn};
-}
-
-KernelCreateInfo CreateMaxKernelInfo(int since_version, bool enable_int64) {
-  const auto& type_constraints = GetOpTypeConstraints(enable_int64, false);
-  KernelCreatePtrFn kernel_create_fn = [](FuncManager&, const OpKernelInfo& info, std::unique_ptr<OpKernel>& out) -> Status {
-    out = std::make_unique<Max>(info);
-    return Status::OK();
-  };
-  return {KernelDefBuilder()
-              .SetName("Max")
-              .SetDomain(kOnnxDomain)
-              .SinceVersion(since_version)
-              .Provider(kWebGpuExecutionProvider)
-              .TypeConstraint("T", type_constraints)
-              .Build(),
-          kernel_create_fn};
-}
-
-KernelCreateInfo CreateMinVersionedKernelInfo(int start_version, int end_version, bool enable_int64) {
-  const auto& type_constraints = GetOpTypeConstraints(enable_int64, false);
-  KernelCreatePtrFn kernel_create_fn = [](FuncManager&, const OpKernelInfo& info, std::unique_ptr<OpKernel>& out) -> Status {
-    out = std::make_unique<Min>(info);
-    return Status::OK();
-  };
-  return {KernelDefBuilder()
-              .SetName("Min")
-              .SetDomain(kOnnxDomain)
-              .SinceVersion(start_version, end_version)
-              .Provider(kWebGpuExecutionProvider)
-              .TypeConstraint("T", type_constraints)
-              .Build(),
-          kernel_create_fn};
-}
-
-KernelCreateInfo CreateMinKernelInfo(int since_version, bool enable_int64) {
-  const auto& type_constraints = GetOpTypeConstraints(enable_int64, false);
-  KernelCreatePtrFn kernel_create_fn = [](FuncManager&, const OpKernelInfo& info, std::unique_ptr<OpKernel>& out) -> Status {
-    out = std::make_unique<Min>(info);
-    return Status::OK();
-  };
-  return {KernelDefBuilder()
-              .SetName("Min")
-              .SetDomain(kOnnxDomain)
-              .SinceVersion(since_version)
-              .Provider(kWebGpuExecutionProvider)
-              .TypeConstraint("T", type_constraints)
-              .Build(),
-          kernel_create_fn};
-}
-
 std::string GetPowImpl(int lhs_element_type, int /* rhs_element_type */) {
   SS(s, 1024);
   std::string round_str;
@@ -665,80 +467,90 @@ std::string GetPowImpl(int lhs_element_type, int /* rhs_element_type */) {
 }
 
 WEBGPU_BINARY_IMPL(Pow, "pow_v(a, b)", GetPowImpl)
-WEBGPU_BINARY_VERSIONED_KERNEL(Pow, 7, 11, Pow, WebGpuSupportedNumberTypes())
-WEBGPU_BINARY_VERSIONED_KERNEL_2(Pow, 12, 12, Pow, WebGpuSupportedNumberTypes(), WebGpuSupportedNumberTypes())
-WEBGPU_BINARY_VERSIONED_KERNEL_2(Pow, 13, 14, Pow, WebGpuSupportedNumberTypes(), WebGpuSupportedNumberTypes())
-WEBGPU_BINARY_KERNEL_2(Pow, 15, Pow, WebGpuSupportedNumberTypes(), WebGpuSupportedNumberTypes())
-
 WEBGPU_BINARY_IMPL(PRelu, "select(b * a, a, a >= vec4<input_a_element_t>(0))")
-WEBGPU_BINARY_VERSIONED_KERNEL(PRelu, 7, 8, PRelu, WebGpuSupportedFloatTypes())
-WEBGPU_BINARY_VERSIONED_KERNEL(PRelu, 9, 15, PRelu, WebGpuSupportedFloatTypes())
-WEBGPU_BINARY_KERNEL(PRelu, 16, PRelu, WebGpuSupportedFloatTypes())
-
 WEBGPU_BINARY_IMPL(Equal, "vec4<u32>(vec4<input_a_element_t>(a) == vec4<input_b_element_t>(b))")
-
-// NOTE: int64 comparison in the WebGPU shader uses i32 element type (low 32 bits only).
-// Values outside the int32 range will produce incorrect results.
-template <int StartVersion, int EndVersion>
-KernelCreateInfo CreateEqualVersionedKernelInfo(bool enable_int64) {
-  const auto& type_constraints = GetOpTypeConstraints(enable_int64, false);
-  KernelCreatePtrFn kernel_create_fn = [](FuncManager&, const OpKernelInfo& info, std::unique_ptr<OpKernel>& out) -> Status {
-    out = std::make_unique<Equal>(info);
-    return Status::OK();
-  };
-  return {KernelDefBuilder()
-              .SetName("Equal")
-              .SetDomain(kOnnxDomain)
-              .SinceVersion(StartVersion, EndVersion)
-              .Provider(kWebGpuExecutionProvider)
-              .TypeConstraint("T", type_constraints)
-              .Build(),
-          kernel_create_fn};
-}
-
-template <int SinceVersion>
-KernelCreateInfo CreateEqualKernelInfo(bool enable_int64) {
-  const auto& type_constraints = GetOpTypeConstraints(enable_int64, false);
-  KernelCreatePtrFn kernel_create_fn = [](FuncManager&, const OpKernelInfo& info, std::unique_ptr<OpKernel>& out) -> Status {
-    out = std::make_unique<Equal>(info);
-    return Status::OK();
-  };
-  return {KernelDefBuilder()
-              .SetName("Equal")
-              .SetDomain(kOnnxDomain)
-              .SinceVersion(SinceVersion)
-              .Provider(kWebGpuExecutionProvider)
-              .TypeConstraint("T", type_constraints)
-              .Build(),
-          kernel_create_fn};
-}
-
-template KernelCreateInfo CreateEqualVersionedKernelInfo<7, 10>(bool);
-template KernelCreateInfo CreateEqualVersionedKernelInfo<11, 12>(bool);
-template KernelCreateInfo CreateEqualVersionedKernelInfo<13, 18>(bool);
-template KernelCreateInfo CreateEqualKernelInfo<19>(bool);
-
 WEBGPU_BINARY_IMPL(Greater, "vec4<u32>(vec4<input_a_element_t>(a) > vec4<input_b_element_t>(b))")
-WEBGPU_BINARY_VERSIONED_KERNEL(Greater, 7, 8, Greater, WebGpuSupportedNumberTypes())
-WEBGPU_BINARY_VERSIONED_KERNEL(Greater, 9, 12, Greater, WebGpuSupportedNumberTypes())
-WEBGPU_BINARY_KERNEL(Greater, 13, Greater, WebGpuSupportedNumberTypes())
-
 WEBGPU_BINARY_IMPL(Less, "vec4<u32>(vec4<input_a_element_t>(a) < vec4<input_b_element_t>(b))")
-WEBGPU_BINARY_VERSIONED_KERNEL(Less, 7, 8, Less, WebGpuSupportedNumberTypes())
-WEBGPU_BINARY_VERSIONED_KERNEL(Less, 9, 12, Less, WebGpuSupportedNumberTypes())
-WEBGPU_BINARY_KERNEL(Less, 13, Less, WebGpuSupportedNumberTypes())
-
 WEBGPU_BINARY_IMPL(GreaterOrEqual, "vec4<u32>(vec4<input_a_element_t>(a) >= vec4<input_b_element_t>(b))")
-WEBGPU_BINARY_VERSIONED_KERNEL(GreaterOrEqual, 12, 15, GreaterOrEqual, WebGpuSupportedNumberTypes())
-WEBGPU_BINARY_KERNEL(GreaterOrEqual, 16, GreaterOrEqual, WebGpuSupportedNumberTypes())
-
 WEBGPU_BINARY_IMPL(LessOrEqual, "vec4<u32>(vec4<input_a_element_t>(a) <= vec4<input_b_element_t>(b))")
-WEBGPU_BINARY_VERSIONED_KERNEL(LessOrEqual, 12, 15, LessOrEqual, WebGpuSupportedNumberTypes())
-WEBGPU_BINARY_KERNEL(LessOrEqual, 16, LessOrEqual, WebGpuSupportedNumberTypes())
-
 // And operator only supports tensor(bool).
 WEBGPU_BINARY_IMPL(And, "(vec4<input_a_element_t>(a) & vec4<input_b_element_t>(b))")
-WEBGPU_BINARY_KERNEL(And, 7, And, DataTypeImpl::GetTensorType<bool>())
+
+namespace {
+// Generic kernel-create fn for any binary/variadic elementwise op class.
+template <typename OpKernelT>
+Status CreateBinaryOpKernel(FuncManager&, const OpKernelInfo& info, std::unique_ptr<OpKernel>& out) {
+  out = std::make_unique<OpKernelT>(info);
+  return Status::OK();
+}
+
+// A single opset version range for an op registration. end <= 0 means "since start" (open-ended).
+struct VersionRange {
+  int start;
+  int end;
+};
+
+// Registers every opset version range of one binary elementwise op. Passing a non-null
+// t1_types adds a "T1" type constraint (only Pow, from opset 12, has a second constraint).
+void RegisterBinaryOp(KernelRegistry& kernel_registry,
+                      const char* name,
+                      KernelCreatePtrFn kernel_create_fn,
+                      const std::vector<MLDataType>& type_constraints,
+                      std::initializer_list<VersionRange> ranges,
+                      const std::vector<MLDataType>* t1_type_constraints = nullptr) {
+  for (const auto& r : ranges) {
+    KernelDefBuilder builder;
+    builder.SetName(name)
+        .SetDomain(kOnnxDomain)
+        .Provider(kWebGpuExecutionProvider)
+        .TypeConstraint("T", type_constraints);
+    if (t1_type_constraints != nullptr) {
+      builder.TypeConstraint("T1", *t1_type_constraints);
+    }
+    if (r.end > 0) {
+      builder.SinceVersion(r.start, r.end);
+    } else {
+      builder.SinceVersion(r.start);
+    }
+    ORT_THROW_IF_ERROR(kernel_registry.Register({builder.Build(), kernel_create_fn}));
+  }
+}
+}  // namespace
+
+// Registers every binary elementwise op through a single path so int64 support (behind the
+// enableInt64 provider option) is applied and maintained consistently. int64 is enabled only
+// for ops whose low-32-bit i32 shader semantics are meaningful (arithmetic + comparison).
+//
+// NOTE: int64 in the WebGPU shader operates on the low 32 bits only (i32 element type). Values
+// outside the int32 range [-2^31, 2^31-1] produce incorrect results. This is acceptable for the
+// token-position / index workloads that need it, and matches the prior per-op documentation.
+void RegisterBinaryElementwiseKernels(KernelRegistry& kernel_registry, bool enable_int64) {
+  // int64-capable ops share this constraint list (adds int64 only when enable_int64 is set).
+  const auto& int64_capable = GetOpTypeConstraints(enable_int64, /*enable_bool=*/false);
+  const auto& number_types = WebGpuSupportedNumberTypes();
+  const auto& float_types = WebGpuSupportedFloatTypes();
+  static const std::vector<MLDataType> bool_type{DataTypeImpl::GetTensorType<bool>()};
+
+  // Arithmetic + comparison ops: int64 is meaningful, so gate it on enable_int64.
+  RegisterBinaryOp(kernel_registry, "Add", CreateBinaryOpKernel<Add>, int64_capable, {{7, 12}, {13, 13}, {14, 0}});
+  RegisterBinaryOp(kernel_registry, "Sub", CreateBinaryOpKernel<Sub>, int64_capable, {{7, 12}, {13, 13}, {14, 0}});
+  RegisterBinaryOp(kernel_registry, "Mul", CreateBinaryOpKernel<Mul>, int64_capable, {{7, 12}, {13, 13}, {14, 0}});
+  RegisterBinaryOp(kernel_registry, "Div", CreateBinaryOpKernel<Div>, int64_capable, {{7, 12}, {13, 13}, {14, 0}});
+  RegisterBinaryOp(kernel_registry, "Max", CreateBinaryOpKernel<Max>, int64_capable, {{8, 11}, {12, 12}, {13, 0}});
+  RegisterBinaryOp(kernel_registry, "Min", CreateBinaryOpKernel<Min>, int64_capable, {{8, 11}, {12, 12}, {13, 0}});
+  RegisterBinaryOp(kernel_registry, "Equal", CreateBinaryOpKernel<Equal>, int64_capable, {{7, 10}, {11, 12}, {13, 18}, {19, 0}});
+  RegisterBinaryOp(kernel_registry, "Greater", CreateBinaryOpKernel<Greater>, int64_capable, {{7, 8}, {9, 12}, {13, 0}});
+  RegisterBinaryOp(kernel_registry, "Less", CreateBinaryOpKernel<Less>, int64_capable, {{7, 8}, {9, 12}, {13, 0}});
+  RegisterBinaryOp(kernel_registry, "GreaterOrEqual", CreateBinaryOpKernel<GreaterOrEqual>, int64_capable, {{12, 15}, {16, 0}});
+  RegisterBinaryOp(kernel_registry, "LessOrEqual", CreateBinaryOpKernel<LessOrEqual>, int64_capable, {{12, 15}, {16, 0}});
+
+  // Ops for which int64 is not meaningful, registered through the same path for consistency.
+  // Pow gains a second "T1" (exponent) type constraint from opset 12.
+  RegisterBinaryOp(kernel_registry, "Pow", CreateBinaryOpKernel<Pow>, number_types, {{7, 11}});
+  RegisterBinaryOp(kernel_registry, "Pow", CreateBinaryOpKernel<Pow>, number_types, {{12, 12}, {13, 14}, {15, 0}}, &number_types);
+  RegisterBinaryOp(kernel_registry, "PRelu", CreateBinaryOpKernel<PRelu>, float_types, {{7, 8}, {9, 15}, {16, 0}});
+  RegisterBinaryOp(kernel_registry, "And", CreateBinaryOpKernel<And>, bool_type, {{7, 0}});
+}
 
 }  // namespace webgpu
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/webgpu/math/binary_elementwise_ops.h
+++ b/onnxruntime/core/providers/webgpu/math/binary_elementwise_ops.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "core/framework/kernel_registry.h"
 #include "core/providers/webgpu/webgpu_kernel.h"
 #include "core/providers/webgpu/shader_helper.h"
 #include "core/providers/webgpu/program.h"
@@ -73,27 +74,10 @@ class BinaryElementwise : public WebGpuKernel {
   const GetAdditionalImplementationFunction get_additional_impl_;
 };
 
-// Factory functions for ops with conditional int64 support (registered via RegisterKernels).
-template <int StartVersion, int EndVersion>
-KernelCreateInfo CreateAddVersionedKernelInfo(bool enable_int64);
-template <int SinceVersion>
-KernelCreateInfo CreateAddKernelInfo(bool enable_int64);
-
-template <int StartVersion, int EndVersion>
-KernelCreateInfo CreateEqualVersionedKernelInfo(bool enable_int64);
-template <int SinceVersion>
-KernelCreateInfo CreateEqualKernelInfo(bool enable_int64);
-
-template <int StartVersion, int EndVersion>
-KernelCreateInfo CreateSubVersionedKernelInfo(bool enable_int64);
-template <int SinceVersion>
-KernelCreateInfo CreateSubKernelInfo(bool enable_int64);
-
-KernelCreateInfo CreateMaxVersionedKernelInfo(int start_version, int end_version, bool enable_int64);
-KernelCreateInfo CreateMaxKernelInfo(int since_version, bool enable_int64);
-
-KernelCreateInfo CreateMinVersionedKernelInfo(int start_version, int end_version, bool enable_int64);
-KernelCreateInfo CreateMinKernelInfo(int since_version, bool enable_int64);
+// Registers every binary elementwise op (Add, Sub, Mul, Div, Max, Min, Equal, Greater, Less,
+// GreaterOrEqual, LessOrEqual, Pow, PRelu, And) through a single path. int64 support (behind the
+// enableInt64 provider option) is enabled for the ops whose i32 shader semantics are meaningful.
+void RegisterBinaryElementwiseKernels(KernelRegistry& kernel_registry, bool enable_int64);
 
 // Variadic element-wise operator (e.g. Max, Min) that accepts 1..N inputs with
 // multidirectional (NumPy-style) broadcasting. The inputs are folded pairwise using the

--- a/onnxruntime/core/providers/webgpu/math/binary_elementwise_ops.h
+++ b/onnxruntime/core/providers/webgpu/math/binary_elementwise_ops.h
@@ -89,6 +89,12 @@ KernelCreateInfo CreateSubVersionedKernelInfo(bool enable_int64);
 template <int SinceVersion>
 KernelCreateInfo CreateSubKernelInfo(bool enable_int64);
 
+KernelCreateInfo CreateMaxVersionedKernelInfo(int start_version, int end_version, bool enable_int64);
+KernelCreateInfo CreateMaxKernelInfo(int since_version, bool enable_int64);
+
+KernelCreateInfo CreateMinVersionedKernelInfo(int start_version, int end_version, bool enable_int64);
+KernelCreateInfo CreateMinKernelInfo(int since_version, bool enable_int64);
+
 // Variadic element-wise operator (e.g. Max, Min) that accepts 1..N inputs with
 // multidirectional (NumPy-style) broadcasting. The inputs are folded pairwise using the
 // two-input binary element-wise program, reusing its broadcasting and vectorization paths.

--- a/onnxruntime/core/providers/webgpu/math/binary_elementwise_ops.h
+++ b/onnxruntime/core/providers/webgpu/math/binary_elementwise_ops.h
@@ -74,9 +74,10 @@ class BinaryElementwise : public WebGpuKernel {
   const GetAdditionalImplementationFunction get_additional_impl_;
 };
 
-// Registers every binary elementwise op (Add, Sub, Mul, Div, Max, Min, Equal, Greater, Less,
+// Registers the binary elementwise ops (Add, Sub, Mul, Div, Max, Min, Equal, Greater, Less,
 // GreaterOrEqual, LessOrEqual, Pow, PRelu, And) through a single path. int64 support (behind the
-// enableInt64 provider option) is enabled for the ops whose i32 shader semantics are meaningful.
+// enableInt64 provider option) is enabled for the arithmetic/comparison ops whose i32 shader
+// semantics are meaningful; Pow int64 is a known gap (TODO) and PRelu/And have no int64 form.
 void RegisterBinaryElementwiseKernels(KernelRegistry& kernel_registry, bool enable_int64);
 
 // Variadic element-wise operator (e.g. Max, Min) that accepts 1..N inputs with

--- a/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
@@ -169,35 +169,9 @@ static const BuildKernelCreateInfoFn build_kernel_create_info_function_table[] =
     KERNEL_CREATE_INFO(22, Softplus),
 
     // // binary - math
-    // Add: registered via RegisterKernels with conditional int64 support
-    // Sub: registered via RegisterKernels with conditional int64 support
-    KERNEL_CREATE_INFO_VERSIONED(7, 12, Mul),
-    KERNEL_CREATE_INFO_VERSIONED(13, 13, Mul),
-    KERNEL_CREATE_INFO(14, Mul),
-    KERNEL_CREATE_INFO_VERSIONED(7, 12, Div),
-    KERNEL_CREATE_INFO_VERSIONED(13, 13, Div),
-    KERNEL_CREATE_INFO(14, Div),
-    // Max: registered via RegisterKernels with conditional int64 support
-    // Min: registered via RegisterKernels with conditional int64 support
-    KERNEL_CREATE_INFO_VERSIONED(7, 11, Pow),
-    KERNEL_CREATE_INFO_VERSIONED(12, 12, Pow),
-    KERNEL_CREATE_INFO_VERSIONED(13, 14, Pow),
-    KERNEL_CREATE_INFO(15, Pow),
-    KERNEL_CREATE_INFO_VERSIONED(7, 8, PRelu),
-    KERNEL_CREATE_INFO_VERSIONED(9, 15, PRelu),
-    KERNEL_CREATE_INFO(16, PRelu),
-    // Equal: registered via RegisterKernels with conditional int64 support
-    KERNEL_CREATE_INFO_VERSIONED(7, 8, Greater),
-    KERNEL_CREATE_INFO_VERSIONED(9, 12, Greater),
-    KERNEL_CREATE_INFO(13, Greater),
-    KERNEL_CREATE_INFO_VERSIONED(12, 15, GreaterOrEqual),
-    KERNEL_CREATE_INFO(16, GreaterOrEqual),
-    KERNEL_CREATE_INFO_VERSIONED(7, 8, Less),
-    KERNEL_CREATE_INFO_VERSIONED(9, 12, Less),
-    KERNEL_CREATE_INFO(13, Less),
-    KERNEL_CREATE_INFO_VERSIONED(12, 15, LessOrEqual),
-    KERNEL_CREATE_INFO(16, LessOrEqual),
-    KERNEL_CREATE_INFO(7, And),
+    // All binary elementwise ops (Add, Sub, Mul, Div, Max, Min, Equal, Greater, Less,
+    // GreaterOrEqual, LessOrEqual, Pow, PRelu, And) are registered via RegisterKernels
+    // through RegisterBinaryElementwiseKernels, with conditional int64 support.
 
     BuildKernelCreateInfo<class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 1, 12, Shape)>,
     BuildKernelCreateInfo<class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 13, 14, Shape)>,
@@ -500,10 +474,9 @@ std::unique_ptr<KernelRegistry> RegisterKernels(bool enable_graph_capture, bool 
   ORT_THROW_IF_ERROR(kernel_registry->Register(CreateExpandVersionedKernelInfo<8, 12>(enable_int64)));
   ORT_THROW_IF_ERROR(kernel_registry->Register(CreateExpandKernelInfo<13>(enable_int64)));
 
-  // Register Add kernels with conditional int64 support
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateAddVersionedKernelInfo<7, 12>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateAddVersionedKernelInfo<13, 13>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateAddKernelInfo<14>(enable_int64)));
+  // Register all binary elementwise kernels (Add, Sub, Mul, Div, Max, Min, Equal, Greater,
+  // Less, GreaterOrEqual, LessOrEqual, Pow, PRelu, And) with conditional int64 support.
+  RegisterBinaryElementwiseKernels(*kernel_registry, enable_int64);
 
   // Register Reshape kernels with conditional int64 support
   ORT_THROW_IF_ERROR(kernel_registry->Register(CreateReshapeVersionedKernelInfo<5, 12>(enable_int64)));
@@ -519,27 +492,6 @@ std::unique_ptr<KernelRegistry> RegisterKernels(bool enable_graph_capture, bool 
   ORT_THROW_IF_ERROR(kernel_registry->Register(CreateConcatVersionedKernelInfo<4, 10>(enable_int64)));
   ORT_THROW_IF_ERROR(kernel_registry->Register(CreateConcatVersionedKernelInfo<11, 12>(enable_int64)));
   ORT_THROW_IF_ERROR(kernel_registry->Register(CreateConcatKernelInfo<13>(enable_int64)));
-
-  // Register Equal kernels with conditional int64 support
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateEqualVersionedKernelInfo<7, 10>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateEqualVersionedKernelInfo<11, 12>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateEqualVersionedKernelInfo<13, 18>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateEqualKernelInfo<19>(enable_int64)));
-
-  // Register Sub kernels with conditional int64 support
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateSubVersionedKernelInfo<7, 12>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateSubVersionedKernelInfo<13, 13>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateSubKernelInfo<14>(enable_int64)));
-
-  // Register Max kernels with conditional int64 support
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateMaxVersionedKernelInfo(8, 11, enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateMaxVersionedKernelInfo(12, 12, enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateMaxKernelInfo(13, enable_int64)));
-
-  // Register Min kernels with conditional int64 support
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateMinVersionedKernelInfo(8, 11, enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateMinVersionedKernelInfo(12, 12, enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateMinKernelInfo(13, enable_int64)));
 
   // Register Where kernels with conditional int64 support
   ORT_THROW_IF_ERROR(kernel_registry->Register(CreateWhereVersionedKernelInfo<9, 15>(enable_int64)));

--- a/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
@@ -177,12 +177,8 @@ static const BuildKernelCreateInfoFn build_kernel_create_info_function_table[] =
     KERNEL_CREATE_INFO_VERSIONED(7, 12, Div),
     KERNEL_CREATE_INFO_VERSIONED(13, 13, Div),
     KERNEL_CREATE_INFO(14, Div),
-    KERNEL_CREATE_INFO_VERSIONED(8, 11, Max),
-    KERNEL_CREATE_INFO_VERSIONED(12, 12, Max),
-    KERNEL_CREATE_INFO(13, Max),
-    KERNEL_CREATE_INFO_VERSIONED(8, 11, Min),
-    KERNEL_CREATE_INFO_VERSIONED(12, 12, Min),
-    KERNEL_CREATE_INFO(13, Min),
+    // Max: registered via RegisterKernels with conditional int64 support
+    // Min: registered via RegisterKernels with conditional int64 support
     KERNEL_CREATE_INFO_VERSIONED(7, 11, Pow),
     KERNEL_CREATE_INFO_VERSIONED(12, 12, Pow),
     KERNEL_CREATE_INFO_VERSIONED(13, 14, Pow),
@@ -534,6 +530,16 @@ std::unique_ptr<KernelRegistry> RegisterKernels(bool enable_graph_capture, bool 
   ORT_THROW_IF_ERROR(kernel_registry->Register(CreateSubVersionedKernelInfo<7, 12>(enable_int64)));
   ORT_THROW_IF_ERROR(kernel_registry->Register(CreateSubVersionedKernelInfo<13, 13>(enable_int64)));
   ORT_THROW_IF_ERROR(kernel_registry->Register(CreateSubKernelInfo<14>(enable_int64)));
+
+  // Register Max kernels with conditional int64 support
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateMaxVersionedKernelInfo(8, 11, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateMaxVersionedKernelInfo(12, 12, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateMaxKernelInfo(13, enable_int64)));
+
+  // Register Min kernels with conditional int64 support
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateMinVersionedKernelInfo(8, 11, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateMinVersionedKernelInfo(12, 12, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateMinKernelInfo(13, enable_int64)));
 
   // Register Where kernels with conditional int64 support
   ORT_THROW_IF_ERROR(kernel_registry->Register(CreateWhereVersionedKernelInfo<9, 15>(enable_int64)));

--- a/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
@@ -2704,6 +2704,84 @@ TEST(MathOpTest, Min_12_Int64_WebGpu_Variadic) {
   test.AddOutput<int64_t>("min", {1, 3}, {-1, -2, 3});
   RunWebGpuNoCpuFallback(test, std::move(provider));
 }
+
+// The ops below share the same int64-capable registration path as Add/Sub/Max/Min. One element-wise
+// case each (size not divisible by 4, so the int64 lane guards are exercised) is enough to confirm
+// the int64 kernel is selected; the shader paths themselves are covered by the Max/Min cases above.
+// Values stay within the int32 range (the documented low-32-bit limitation) and include the all-ones
+// -1 pattern.
+TEST(MathOpTest, Mul_Int64_WebGpu) {
+  auto provider = MakeWebGpuInt64Provider();
+  if (provider == nullptr) {
+    GTEST_SKIP() << "WebGPU EP is not available";
+  }
+  OpTester test("Mul", 14);
+  test.AddInput<int64_t>("A", {3}, {-1LL, 100, 7});
+  test.AddInput<int64_t>("B", {3}, {5, 3, -2});
+  test.AddOutput<int64_t>("C", {3}, {-5, 300, -14});
+  RunWebGpuNoCpuFallback(test, std::move(provider));
+}
+
+TEST(MathOpTest, Div_Int64_WebGpu) {
+  auto provider = MakeWebGpuInt64Provider();
+  if (provider == nullptr) {
+    GTEST_SKIP() << "WebGPU EP is not available";
+  }
+  OpTester test("Div", 14);
+  test.AddInput<int64_t>("A", {3}, {-1LL, 100, -20});
+  test.AddInput<int64_t>("B", {3}, {1, 5, 4});
+  test.AddOutput<int64_t>("C", {3}, {-1, 20, -5});  // integer division truncates toward zero
+  RunWebGpuNoCpuFallback(test, std::move(provider));
+}
+
+// Comparison ops take int64 inputs and produce a bool output (T = int64 constraint only).
+TEST(MathOpTest, Greater_Int64_WebGpu) {
+  auto provider = MakeWebGpuInt64Provider();
+  if (provider == nullptr) {
+    GTEST_SKIP() << "WebGPU EP is not available";
+  }
+  OpTester test("Greater", 13);
+  test.AddInput<int64_t>("A", {3}, {5, -1LL, 2147483647LL});
+  test.AddInput<int64_t>("B", {3}, {3, 0, -100});
+  test.AddOutput<bool>("C", {3}, {true, false, true});
+  RunWebGpuNoCpuFallback(test, std::move(provider));
+}
+
+TEST(MathOpTest, Less_Int64_WebGpu) {
+  auto provider = MakeWebGpuInt64Provider();
+  if (provider == nullptr) {
+    GTEST_SKIP() << "WebGPU EP is not available";
+  }
+  OpTester test("Less", 13);
+  test.AddInput<int64_t>("A", {3}, {5, -1LL, 100});
+  test.AddInput<int64_t>("B", {3}, {3, 0, 200});
+  test.AddOutput<bool>("C", {3}, {false, true, true});
+  RunWebGpuNoCpuFallback(test, std::move(provider));
+}
+
+TEST(MathOpTest, GreaterOrEqual_Int64_WebGpu) {
+  auto provider = MakeWebGpuInt64Provider();
+  if (provider == nullptr) {
+    GTEST_SKIP() << "WebGPU EP is not available";
+  }
+  OpTester test("GreaterOrEqual", 16);
+  test.AddInput<int64_t>("A", {3}, {5, 5, -1LL});
+  test.AddInput<int64_t>("B", {3}, {5, 3, 0});
+  test.AddOutput<bool>("C", {3}, {true, true, false});
+  RunWebGpuNoCpuFallback(test, std::move(provider));
+}
+
+TEST(MathOpTest, LessOrEqual_Int64_WebGpu) {
+  auto provider = MakeWebGpuInt64Provider();
+  if (provider == nullptr) {
+    GTEST_SKIP() << "WebGPU EP is not available";
+  }
+  OpTester test("LessOrEqual", 16);
+  test.AddInput<int64_t>("A", {3}, {5, 5, -1LL});
+  test.AddInput<int64_t>("B", {3}, {5, 3, 0});
+  test.AddOutput<bool>("C", {3}, {true, false, true});
+  RunWebGpuNoCpuFallback(test, std::move(provider));
+}
 #endif  // USE_WEBGPU
 
 TEST(MathOpTest, Max_6) {

--- a/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
@@ -24,6 +24,7 @@
 // onnxruntime_provider_test in every build configuration, e.g. the plugin build). See issue #28969.
 #include "core/providers/webgpu/math/binary_elementwise_broadcast_utils.h"
 #include "core/providers/webgpu/webgpu_provider_options.h"
+#include "core/session/onnxruntime_session_options_config_keys.h"
 #endif
 
 namespace onnxruntime {
@@ -2550,6 +2551,160 @@ TEST(MathOpTest, Max_12_Float16_Nan_WebGpu) {
   execution_providers.push_back(std::move(webgpu_ep));
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
 }
+
+#if defined(USE_WEBGPU)
+// int64 support on the WebGPU EP is gated behind the enableInt64 provider option, so it is not
+// exercised by the generic Max_12_Int64/Min_12_Int64 tests (which run with int64 disabled and fall
+// back to CPU). The tests below build a WebGPU EP with int64 enabled and disable CPU-EP fallback so
+// the node must run on the WebGPU kernel. They mirror the path coverage of the Add int64 tests
+// (element-wise, size divisible by 4, scalar operand, broadcast) and add the variadic (>2 input)
+// fold that is unique to Min/Max.
+namespace {
+// Builds a WebGPU EP with int64 enabled; returns nullptr if the EP is unavailable in this build.
+std::unique_ptr<IExecutionProvider> MakeWebGpuInt64Provider() {
+  ConfigOptions provider_options{};
+  EXPECT_STATUS_OK(provider_options.AddConfigEntry(webgpu::options::kEnableInt64, "1"));
+  return WebGpuExecutionProviderWithOptions(provider_options);
+}
+
+// Runs the tester on `provider`, forcing the node onto the WebGPU kernel (no CPU-EP fallback).
+void RunWebGpuNoCpuFallback(OpTester& test, std::unique_ptr<IExecutionProvider> provider) {
+  SessionOptions so;
+  ASSERT_STATUS_OK(so.config_options.AddConfigEntry(kOrtSessionOptionsDisableCPUEPFallback, "1"));
+  test.Config(so)
+      .ConfigEp(std::move(provider))
+      .RunWithConfig();
+}
+}  // namespace
+
+// Element-wise, size not divisible by 4: exercises the int64 OOB lane guards. The values cover the
+// edges of the supported range -- -1 (0xFFFFFFFFFFFFFFFF), INT32_MIN, INT32_MAX -- so both the
+// all-ones negative and the range boundaries are checked.
+TEST(MathOpTest, Max_12_Int64_WebGpu) {
+  auto provider = MakeWebGpuInt64Provider();
+  if (provider == nullptr) {
+    GTEST_SKIP() << "WebGPU EP is not available";
+  }
+  OpTester test("Max", 12);
+  test.AddInput<int64_t>("data_0", {3}, {-1LL, -2147483648LL, 2147483647LL});  // -1 (0xFF..FF), INT32_MIN, INT32_MAX
+  test.AddInput<int64_t>("data_1", {3}, {5, 7, -100});
+  test.AddOutput<int64_t>("max", {3}, {5, 7, 2147483647LL});
+  RunWebGpuNoCpuFallback(test, std::move(provider));
+}
+
+// Size divisible by 4: full vec4 assembly with no lane truncation.
+TEST(MathOpTest, Max_12_Int64_WebGpu_SizeDiv4) {
+  auto provider = MakeWebGpuInt64Provider();
+  if (provider == nullptr) {
+    GTEST_SKIP() << "WebGPU EP is not available";
+  }
+  OpTester test("Max", 12);
+  test.AddInput<int64_t>("data_0", {8}, {10, 20, 30, 40, 50, 60, 70, 80});
+  test.AddInput<int64_t>("data_1", {8}, {1, 2, 3, 4, 500, 6, 7, 800});
+  test.AddOutput<int64_t>("max", {8}, {10, 20, 30, 40, 500, 60, 70, 800});
+  RunWebGpuNoCpuFallback(test, std::move(provider));
+}
+
+// Scalar RHS: exercises the is_rhs_scalar_ int64 path.
+TEST(MathOpTest, Max_12_Int64_WebGpu_ScalarRhs) {
+  auto provider = MakeWebGpuInt64Provider();
+  if (provider == nullptr) {
+    GTEST_SKIP() << "WebGPU EP is not available";
+  }
+  OpTester test("Max", 12);
+  test.AddInput<int64_t>("data_0", {5}, {10, -5, 30, 40, 50});
+  test.AddInput<int64_t>("data_1", {1}, {7});
+  test.AddOutput<int64_t>("max", {5}, {10, 7, 30, 40, 50});
+  RunWebGpuNoCpuFallback(test, std::move(provider));
+}
+
+// Shape broadcast: A [1,3] against B [3,1] -> [3,3].
+TEST(MathOpTest, Max_12_Int64_WebGpu_Broadcast) {
+  auto provider = MakeWebGpuInt64Provider();
+  if (provider == nullptr) {
+    GTEST_SKIP() << "WebGPU EP is not available";
+  }
+  OpTester test("Max", 12);
+  test.AddInput<int64_t>("data_0", {1, 3}, {10, 20, 30});
+  test.AddInput<int64_t>("data_1", {3, 1}, {1, -2, 300});
+  test.AddOutput<int64_t>("max", {3, 3},
+                          {10, 20, 30,
+                           10, 20, 30,
+                           300, 300, 300});
+  RunWebGpuNoCpuFallback(test, std::move(provider));
+}
+
+// Variadic 3-input fold (unique to Min/Max): allocates an int64 intermediate GPU tensor.
+TEST(MathOpTest, Max_12_Int64_WebGpu_Variadic) {
+  auto provider = MakeWebGpuInt64Provider();
+  if (provider == nullptr) {
+    GTEST_SKIP() << "WebGPU EP is not available";
+  }
+  OpTester test("Max", 12);
+  test.AddInput<int64_t>("data_0", {1, 3}, {1, 2, 3});
+  test.AddInput<int64_t>("data_1", {1, 3}, {10, 0, 5});
+  test.AddInput<int64_t>("data_2", {1, 3}, {-1, -2, 4});
+  test.AddOutput<int64_t>("max", {1, 3}, {10, 2, 5});
+  RunWebGpuNoCpuFallback(test, std::move(provider));
+}
+
+// Element-wise, size not divisible by 4: same edge values as the Max case -- -1 (all ones),
+// INT32_MIN, INT32_MAX -- verifying the min side of full-width negative/sign handling.
+TEST(MathOpTest, Min_12_Int64_WebGpu) {
+  auto provider = MakeWebGpuInt64Provider();
+  if (provider == nullptr) {
+    GTEST_SKIP() << "WebGPU EP is not available";
+  }
+  OpTester test("Min", 12);
+  test.AddInput<int64_t>("data_0", {3}, {-1LL, -2147483648LL, 2147483647LL});  // -1 (0xFF..FF), INT32_MIN, INT32_MAX
+  test.AddInput<int64_t>("data_1", {3}, {5, 7, -100});
+  test.AddOutput<int64_t>("min", {3}, {-1LL, -2147483648LL, -100});
+  RunWebGpuNoCpuFallback(test, std::move(provider));
+}
+
+// Scalar LHS: exercises the is_lhs_scalar_ int64 path.
+TEST(MathOpTest, Min_12_Int64_WebGpu_ScalarLhs) {
+  auto provider = MakeWebGpuInt64Provider();
+  if (provider == nullptr) {
+    GTEST_SKIP() << "WebGPU EP is not available";
+  }
+  OpTester test("Min", 12);
+  test.AddInput<int64_t>("data_0", {1}, {100});
+  test.AddInput<int64_t>("data_1", {5}, {1, 2, 3, 4, 5});
+  test.AddOutput<int64_t>("min", {5}, {1, 2, 3, 4, 5});
+  RunWebGpuNoCpuFallback(test, std::move(provider));
+}
+
+// Shape broadcast: A [1,3] against B [3,1] -> [3,3].
+TEST(MathOpTest, Min_12_Int64_WebGpu_Broadcast) {
+  auto provider = MakeWebGpuInt64Provider();
+  if (provider == nullptr) {
+    GTEST_SKIP() << "WebGPU EP is not available";
+  }
+  OpTester test("Min", 12);
+  test.AddInput<int64_t>("data_0", {1, 3}, {10, 20, 30});
+  test.AddInput<int64_t>("data_1", {3, 1}, {1, -2, 300});
+  test.AddOutput<int64_t>("min", {3, 3},
+                          {1, 1, 1,
+                           -2, -2, -2,
+                           10, 20, 30});
+  RunWebGpuNoCpuFallback(test, std::move(provider));
+}
+
+// Variadic 3-input fold (unique to Min/Max): allocates an int64 intermediate GPU tensor.
+TEST(MathOpTest, Min_12_Int64_WebGpu_Variadic) {
+  auto provider = MakeWebGpuInt64Provider();
+  if (provider == nullptr) {
+    GTEST_SKIP() << "WebGPU EP is not available";
+  }
+  OpTester test("Min", 12);
+  test.AddInput<int64_t>("data_0", {1, 3}, {1, 2, 3});
+  test.AddInput<int64_t>("data_1", {1, 3}, {10, 0, 5});
+  test.AddInput<int64_t>("data_2", {1, 3}, {-1, -2, 4});
+  test.AddOutput<int64_t>("min", {1, 3}, {-1, -2, 3});
+  RunWebGpuNoCpuFallback(test, std::move(provider));
+}
+#endif  // USE_WEBGPU
 
 TEST(MathOpTest, Max_6) {
   OpTester test("Max", 6);

--- a/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
@@ -2563,7 +2563,12 @@ namespace {
 // Builds a WebGPU EP with int64 enabled; returns nullptr if the EP is unavailable in this build.
 std::unique_ptr<IExecutionProvider> MakeWebGpuInt64Provider() {
   ConfigOptions provider_options{};
-  EXPECT_STATUS_OK(provider_options.AddConfigEntry(webgpu::options::kEnableInt64, "1"));
+  const auto status = provider_options.AddConfigEntry(webgpu::options::kEnableInt64, "1");
+  if (!status.IsOK()) {
+    ADD_FAILURE() << "Failed to set WebGPU provider option '" << webgpu::options::kEnableInt64
+                  << "': " << status.ErrorMessage();
+    return nullptr;
+  }
   return WebGpuExecutionProviderWithOptions(provider_options);
 }
 

--- a/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
@@ -23,8 +23,6 @@
 // and adds no link dependency on the webgpu provider library (which is not linked into
 // onnxruntime_provider_test in every build configuration, e.g. the plugin build). See issue #28969.
 #include "core/providers/webgpu/math/binary_elementwise_broadcast_utils.h"
-#include "core/providers/webgpu/webgpu_provider_options.h"
-#include "core/session/onnxruntime_session_options_config_keys.h"
 #endif
 
 namespace onnxruntime {
@@ -2552,243 +2550,61 @@ TEST(MathOpTest, Max_12_Float16_Nan_WebGpu) {
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
 }
 
-#if defined(USE_WEBGPU)
-// int64 support on the WebGPU EP is gated behind the enableInt64 provider option, so it is not
-// exercised by the generic Max_12_Int64/Min_12_Int64 tests (which run with int64 disabled and fall
-// back to CPU). The tests below build a WebGPU EP with int64 enabled and disable CPU-EP fallback so
-// the node must run on the WebGPU kernel. They mirror the path coverage of the Add int64 tests
-// (element-wise, size divisible by 4, scalar operand, broadcast) and add the variadic (>2 input)
-// fold that is unique to Min/Max.
-namespace {
-// Builds a WebGPU EP with int64 enabled; returns nullptr if the EP is unavailable in this build.
-std::unique_ptr<IExecutionProvider> MakeWebGpuInt64Provider() {
-  ConfigOptions provider_options{};
-  const auto status = provider_options.AddConfigEntry(webgpu::options::kEnableInt64, "1");
-  if (!status.IsOK()) {
-    ADD_FAILURE() << "Failed to set WebGPU provider option '" << webgpu::options::kEnableInt64
-                  << "': " << status.ErrorMessage();
-    return nullptr;
-  }
-  return WebGpuExecutionProviderWithOptions(provider_options);
-}
-
-// Runs the tester on `provider`, forcing the node onto the WebGPU kernel (no CPU-EP fallback).
-void RunWebGpuNoCpuFallback(OpTester& test, std::unique_ptr<IExecutionProvider> provider) {
-  SessionOptions so;
-  ASSERT_STATUS_OK(so.config_options.AddConfigEntry(kOrtSessionOptionsDisableCPUEPFallback, "1"));
-  test.Config(so)
-      .ConfigEp(std::move(provider))
-      .RunWithConfig();
-}
-}  // namespace
-
-// Element-wise, size not divisible by 4: exercises the int64 OOB lane guards. The values cover the
-// edges of the supported range -- -1 (0xFFFFFFFFFFFFFFFF), INT32_MIN, INT32_MAX -- so both the
-// all-ones negative and the range boundaries are checked.
-TEST(MathOpTest, Max_12_Int64_WebGpu) {
-  auto provider = MakeWebGpuInt64Provider();
-  if (provider == nullptr) {
-    GTEST_SKIP() << "WebGPU EP is not available";
-  }
-  OpTester test("Max", 12);
-  test.AddInput<int64_t>("data_0", {3}, {-1LL, -2147483648LL, 2147483647LL});  // -1 (0xFF..FF), INT32_MIN, INT32_MAX
-  test.AddInput<int64_t>("data_1", {3}, {5, 7, -100});
-  test.AddOutput<int64_t>("max", {3}, {5, 7, 2147483647LL});
-  RunWebGpuNoCpuFallback(test, std::move(provider));
-}
-
-// Size divisible by 4: full vec4 assembly with no lane truncation.
-TEST(MathOpTest, Max_12_Int64_WebGpu_SizeDiv4) {
-  auto provider = MakeWebGpuInt64Provider();
-  if (provider == nullptr) {
-    GTEST_SKIP() << "WebGPU EP is not available";
-  }
-  OpTester test("Max", 12);
-  test.AddInput<int64_t>("data_0", {8}, {10, 20, 30, 40, 50, 60, 70, 80});
-  test.AddInput<int64_t>("data_1", {8}, {1, 2, 3, 4, 500, 6, 7, 800});
-  test.AddOutput<int64_t>("max", {8}, {10, 20, 30, 40, 500, 60, 70, 800});
-  RunWebGpuNoCpuFallback(test, std::move(provider));
-}
-
-// Scalar RHS: exercises the is_rhs_scalar_ int64 path.
-TEST(MathOpTest, Max_12_Int64_WebGpu_ScalarRhs) {
-  auto provider = MakeWebGpuInt64Provider();
-  if (provider == nullptr) {
-    GTEST_SKIP() << "WebGPU EP is not available";
-  }
-  OpTester test("Max", 12);
-  test.AddInput<int64_t>("data_0", {5}, {10, -5, 30, 40, 50});
-  test.AddInput<int64_t>("data_1", {1}, {7});
-  test.AddOutput<int64_t>("max", {5}, {10, 7, 30, 40, 50});
-  RunWebGpuNoCpuFallback(test, std::move(provider));
-}
-
-// Shape broadcast: A [1,3] against B [3,1] -> [3,3].
-TEST(MathOpTest, Max_12_Int64_WebGpu_Broadcast) {
-  auto provider = MakeWebGpuInt64Provider();
-  if (provider == nullptr) {
-    GTEST_SKIP() << "WebGPU EP is not available";
-  }
-  OpTester test("Max", 12);
-  test.AddInput<int64_t>("data_0", {1, 3}, {10, 20, 30});
-  test.AddInput<int64_t>("data_1", {3, 1}, {1, -2, 300});
-  test.AddOutput<int64_t>("max", {3, 3},
-                          {10, 20, 30,
-                           10, 20, 30,
-                           300, 300, 300});
-  RunWebGpuNoCpuFallback(test, std::move(provider));
-}
-
-// Variadic 3-input fold (unique to Min/Max): allocates an int64 intermediate GPU tensor.
-TEST(MathOpTest, Max_12_Int64_WebGpu_Variadic) {
-  auto provider = MakeWebGpuInt64Provider();
-  if (provider == nullptr) {
-    GTEST_SKIP() << "WebGPU EP is not available";
-  }
-  OpTester test("Max", 12);
-  test.AddInput<int64_t>("data_0", {1, 3}, {1, 2, 3});
-  test.AddInput<int64_t>("data_1", {1, 3}, {10, 0, 5});
-  test.AddInput<int64_t>("data_2", {1, 3}, {-1, -2, 4});
-  test.AddOutput<int64_t>("max", {1, 3}, {10, 2, 5});
-  RunWebGpuNoCpuFallback(test, std::move(provider));
-}
-
-// Element-wise, size not divisible by 4: same edge values as the Max case -- -1 (all ones),
-// INT32_MIN, INT32_MAX -- verifying the min side of full-width negative/sign handling.
-TEST(MathOpTest, Min_12_Int64_WebGpu) {
-  auto provider = MakeWebGpuInt64Provider();
-  if (provider == nullptr) {
-    GTEST_SKIP() << "WebGPU EP is not available";
-  }
-  OpTester test("Min", 12);
-  test.AddInput<int64_t>("data_0", {3}, {-1LL, -2147483648LL, 2147483647LL});  // -1 (0xFF..FF), INT32_MIN, INT32_MAX
-  test.AddInput<int64_t>("data_1", {3}, {5, 7, -100});
-  test.AddOutput<int64_t>("min", {3}, {-1LL, -2147483648LL, -100});
-  RunWebGpuNoCpuFallback(test, std::move(provider));
-}
-
-// Scalar LHS: exercises the is_lhs_scalar_ int64 path.
-TEST(MathOpTest, Min_12_Int64_WebGpu_ScalarLhs) {
-  auto provider = MakeWebGpuInt64Provider();
-  if (provider == nullptr) {
-    GTEST_SKIP() << "WebGPU EP is not available";
-  }
-  OpTester test("Min", 12);
-  test.AddInput<int64_t>("data_0", {1}, {100});
-  test.AddInput<int64_t>("data_1", {5}, {1, 2, 3, 4, 5});
-  test.AddOutput<int64_t>("min", {5}, {1, 2, 3, 4, 5});
-  RunWebGpuNoCpuFallback(test, std::move(provider));
-}
-
-// Shape broadcast: A [1,3] against B [3,1] -> [3,3].
-TEST(MathOpTest, Min_12_Int64_WebGpu_Broadcast) {
-  auto provider = MakeWebGpuInt64Provider();
-  if (provider == nullptr) {
-    GTEST_SKIP() << "WebGPU EP is not available";
-  }
-  OpTester test("Min", 12);
-  test.AddInput<int64_t>("data_0", {1, 3}, {10, 20, 30});
-  test.AddInput<int64_t>("data_1", {3, 1}, {1, -2, 300});
-  test.AddOutput<int64_t>("min", {3, 3},
-                          {1, 1, 1,
-                           -2, -2, -2,
-                           10, 20, 30});
-  RunWebGpuNoCpuFallback(test, std::move(provider));
-}
-
-// Variadic 3-input fold (unique to Min/Max): allocates an int64 intermediate GPU tensor.
-TEST(MathOpTest, Min_12_Int64_WebGpu_Variadic) {
-  auto provider = MakeWebGpuInt64Provider();
-  if (provider == nullptr) {
-    GTEST_SKIP() << "WebGPU EP is not available";
-  }
-  OpTester test("Min", 12);
-  test.AddInput<int64_t>("data_0", {1, 3}, {1, 2, 3});
-  test.AddInput<int64_t>("data_1", {1, 3}, {10, 0, 5});
-  test.AddInput<int64_t>("data_2", {1, 3}, {-1, -2, 4});
-  test.AddOutput<int64_t>("min", {1, 3}, {-1, -2, 3});
-  RunWebGpuNoCpuFallback(test, std::move(provider));
-}
-
-// The ops below share the same int64-capable registration path as Add/Sub/Max/Min. One element-wise
-// case each (size not divisible by 4, so the int64 lane guards are exercised) is enough to confirm
-// the int64 kernel is selected; the shader paths themselves are covered by the Max/Min cases above.
-// Values stay within the int32 range (the documented low-32-bit limitation) and include the all-ones
-// -1 pattern.
-TEST(MathOpTest, Mul_Int64_WebGpu) {
-  auto provider = MakeWebGpuInt64Provider();
-  if (provider == nullptr) {
-    GTEST_SKIP() << "WebGPU EP is not available";
-  }
+// EP-agnostic int64 coverage for the binary ops this change newly gates on the WebGPU enableInt64
+// option (Mul, Div, Greater, Less, GreaterOrEqual, LessOrEqual). Running through the default
+// providers exercises every capable EP -- including WebGPU, for which the test harness enables
+// int64 (see DefaultWebGpuExecutionProvider and the dynamic plugin EP config in test_main.cc), so
+// no WebGPU-specific operator cases are needed. Values stay within the int32 range and include the
+// -1 (all-ones) pattern, so EPs that implement int64 on 32-bit lanes (e.g. WebGPU) still produce
+// correct results. Min/Max int64 are already covered by the generic Min_12_Int64/Max_12_Int64
+// cases above. TensorRT/OpenVINO are excluded to match those existing int64 element-wise cases.
+TEST(MathOpTest, Mul_Int64) {
   OpTester test("Mul", 14);
-  test.AddInput<int64_t>("A", {3}, {-1LL, 100, 7});
+  test.AddInput<int64_t>("A", {3}, {-1, 100, 7});
   test.AddInput<int64_t>("B", {3}, {5, 3, -2});
   test.AddOutput<int64_t>("C", {3}, {-5, 300, -14});
-  RunWebGpuNoCpuFallback(test, std::move(provider));
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
 }
 
-TEST(MathOpTest, Div_Int64_WebGpu) {
-  auto provider = MakeWebGpuInt64Provider();
-  if (provider == nullptr) {
-    GTEST_SKIP() << "WebGPU EP is not available";
-  }
+TEST(MathOpTest, Div_Int64) {
   OpTester test("Div", 14);
-  test.AddInput<int64_t>("A", {3}, {-1LL, 100, -20});
+  test.AddInput<int64_t>("A", {3}, {-1, 100, -20});
   test.AddInput<int64_t>("B", {3}, {1, 5, 4});
   test.AddOutput<int64_t>("C", {3}, {-1, 20, -5});  // integer division truncates toward zero
-  RunWebGpuNoCpuFallback(test, std::move(provider));
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
 }
 
-// Comparison ops here use int64 inputs and produce a bool output. These
-// cases validate int64 kernel selection on WebGPU (with CPU fallback disabled).
-TEST(MathOpTest, Greater_Int64_WebGpu) {
-  auto provider = MakeWebGpuInt64Provider();
-  if (provider == nullptr) {
-    GTEST_SKIP() << "WebGPU EP is not available";
-  }
+TEST(MathOpTest, Greater_Int64) {
   OpTester test("Greater", 13);
-  test.AddInput<int64_t>("A", {3}, {5, -1LL, 2147483647LL});
+  test.AddInput<int64_t>("A", {3}, {5, -1, 2147483647});
   test.AddInput<int64_t>("B", {3}, {3, 0, -100});
   test.AddOutput<bool>("C", {3}, {true, false, true});
-  RunWebGpuNoCpuFallback(test, std::move(provider));
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
 }
 
-TEST(MathOpTest, Less_Int64_WebGpu) {
-  auto provider = MakeWebGpuInt64Provider();
-  if (provider == nullptr) {
-    GTEST_SKIP() << "WebGPU EP is not available";
-  }
+TEST(MathOpTest, Less_Int64) {
   OpTester test("Less", 13);
-  test.AddInput<int64_t>("A", {3}, {5, -1LL, 100});
+  test.AddInput<int64_t>("A", {3}, {5, -1, 100});
   test.AddInput<int64_t>("B", {3}, {3, 0, 200});
   test.AddOutput<bool>("C", {3}, {false, true, true});
-  RunWebGpuNoCpuFallback(test, std::move(provider));
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
 }
 
-TEST(MathOpTest, GreaterOrEqual_Int64_WebGpu) {
-  auto provider = MakeWebGpuInt64Provider();
-  if (provider == nullptr) {
-    GTEST_SKIP() << "WebGPU EP is not available";
-  }
+TEST(MathOpTest, GreaterOrEqual_Int64) {
   OpTester test("GreaterOrEqual", 16);
-  test.AddInput<int64_t>("A", {3}, {5, 5, -1LL});
+  test.AddInput<int64_t>("A", {3}, {5, 5, -1});
   test.AddInput<int64_t>("B", {3}, {5, 3, 0});
   test.AddOutput<bool>("C", {3}, {true, true, false});
-  RunWebGpuNoCpuFallback(test, std::move(provider));
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
 }
 
-TEST(MathOpTest, LessOrEqual_Int64_WebGpu) {
-  auto provider = MakeWebGpuInt64Provider();
-  if (provider == nullptr) {
-    GTEST_SKIP() << "WebGPU EP is not available";
-  }
+TEST(MathOpTest, LessOrEqual_Int64) {
   OpTester test("LessOrEqual", 16);
-  test.AddInput<int64_t>("A", {3}, {5, 5, -1LL});
+  test.AddInput<int64_t>("A", {3}, {5, 5, -1});
   test.AddInput<int64_t>("B", {3}, {5, 3, 0});
   test.AddOutput<bool>("C", {3}, {true, false, true});
-  RunWebGpuNoCpuFallback(test, std::move(provider));
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
 }
-#endif  // USE_WEBGPU
 
 TEST(MathOpTest, Max_6) {
   OpTester test("Max", 6);
@@ -5407,240 +5223,170 @@ TEST(MathOpTest, BitwiseNot_uint8) {
   test.Run();
 }
 
-#ifdef USE_WEBGPU
-TEST(MathOpTest, Sub_webgpu_int64) {
+// EP-agnostic int64 coverage for Sub/Equal/Add. These run on every capable EP (including WebGPU,
+// for which the test harness enables int64). The shapes are chosen to exercise WebGPU's int64
+// shader paths (element-wise, broadcast, size divisible by 4, scalar operands); values stay within
+// the int32 range so 32-bit-lane int64 implementations (e.g. WebGPU) stay correct.
+TEST(MathOpTest, Sub_Int64) {
   OpTester test("Sub", 14);
   test.AddInput<int64_t>("A", {4}, {10, 5, -3, 0});
   test.AddInput<int64_t>("B", {4}, {3, 5, 1, -7});
   test.AddOutput<int64_t>("C", {4}, {7, 0, -4, 7});
-  ConfigOptions config_options{};
-  ASSERT_STATUS_OK(config_options.AddConfigEntry(webgpu::options::kEnableInt64, "1"));
-  auto provider = WebGpuExecutionProviderWithOptions(config_options);
-  test.ConfigEp(std::move(provider))
-      .RunWithConfig();
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
 }
 
 // INT64 Sub with broadcast: A [1,3] broadcasts against B [2,3] -> output [2,3].
-TEST(MathOpTest, Sub_webgpu_int64_broadcast) {
+TEST(MathOpTest, Sub_Int64_broadcast) {
   OpTester test("Sub", 14);
   test.AddInput<int64_t>("A", {1, 3}, {10, 20, 30});
   test.AddInput<int64_t>("B", {2, 3}, {1, 2, 3, 4, 5, 6});
   test.AddOutput<int64_t>("C", {2, 3}, {9, 18, 27, 6, 15, 24});
-  ConfigOptions config_options{};
-  ASSERT_STATUS_OK(config_options.AddConfigEntry(webgpu::options::kEnableInt64, "1"));
-  auto provider = WebGpuExecutionProviderWithOptions(config_options);
-  test.ConfigEp(std::move(provider))
-      .RunWithConfig();
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
 }
 
 // Size divisible by 4: catches future vec4 optimizations that might break INT64.
-TEST(MathOpTest, Sub_webgpu_int64_size_div4) {
+TEST(MathOpTest, Sub_Int64_size_div4) {
   OpTester test("Sub", 14);
   test.AddInput<int64_t>("A", {8}, {10, 20, 30, 40, 50, 60, 70, 80});
   test.AddInput<int64_t>("B", {8}, {1, 2, 3, 4, 5, 6, 7, 8});
   test.AddOutput<int64_t>("C", {8}, {9, 18, 27, 36, 45, 54, 63, 72});
-  ConfigOptions config_options{};
-  ASSERT_STATUS_OK(config_options.AddConfigEntry(webgpu::options::kEnableInt64, "1"));
-  auto provider = WebGpuExecutionProviderWithOptions(config_options);
-  test.ConfigEp(std::move(provider))
-      .RunWithConfig();
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
 }
 
 // Scalar LHS: exercises is_lhs_scalar_ path for INT64 Sub.
-TEST(MathOpTest, Sub_webgpu_int64_lhs_scalar) {
+TEST(MathOpTest, Sub_Int64_lhs_scalar) {
   OpTester test("Sub", 14);
   test.AddInput<int64_t>("A", {1}, {100});
   test.AddInput<int64_t>("B", {5}, {1, 2, 3, 4, 5});
   test.AddOutput<int64_t>("C", {5}, {99, 98, 97, 96, 95});
-  ConfigOptions config_options{};
-  ASSERT_STATUS_OK(config_options.AddConfigEntry(webgpu::options::kEnableInt64, "1"));
-  auto provider = WebGpuExecutionProviderWithOptions(config_options);
-  test.ConfigEp(std::move(provider))
-      .RunWithConfig();
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
 }
 
 // Scalar RHS: exercises is_rhs_scalar_ path for INT64 Sub.
-TEST(MathOpTest, Sub_webgpu_int64_rhs_scalar) {
+TEST(MathOpTest, Sub_Int64_rhs_scalar) {
   OpTester test("Sub", 14);
   test.AddInput<int64_t>("A", {5}, {10, 20, 30, 40, 50});
   test.AddInput<int64_t>("B", {1}, {7});
   test.AddOutput<int64_t>("C", {5}, {3, 13, 23, 33, 43});
-  ConfigOptions config_options{};
-  ASSERT_STATUS_OK(config_options.AddConfigEntry(webgpu::options::kEnableInt64, "1"));
-  auto provider = WebGpuExecutionProviderWithOptions(config_options);
-  test.ConfigEp(std::move(provider))
-      .RunWithConfig();
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
 }
 
 // Shape broadcast, size divisible by 4: A [1,4] broadcasts against B [2,4] -> output [2,4].
-TEST(MathOpTest, Sub_webgpu_int64_broadcast_size_div4) {
+TEST(MathOpTest, Sub_Int64_broadcast_size_div4) {
   OpTester test("Sub", 14);
   test.AddInput<int64_t>("A", {1, 4}, {10, 20, 30, 40});
   test.AddInput<int64_t>("B", {2, 4}, {1, 2, 3, 4, 5, 6, 7, 8});
   test.AddOutput<int64_t>("C", {2, 4}, {9, 18, 27, 36, 5, 14, 23, 32});
-  ConfigOptions config_options{};
-  ASSERT_STATUS_OK(config_options.AddConfigEntry(webgpu::options::kEnableInt64, "1"));
-  auto provider = WebGpuExecutionProviderWithOptions(config_options);
-  test.ConfigEp(std::move(provider))
-      .RunWithConfig();
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
 }
 
-TEST(MathOpTest, Equal_webgpu_int64) {
+TEST(MathOpTest, Equal_Int64) {
   OpTester test("Equal", 13);
   test.AddInput<int64_t>("A", {5}, {1, 0, -1, -1, 3});
   test.AddInput<int64_t>("B", {5}, {1, 1, 2, -1, 3});
   test.AddOutput<bool>("C", {5}, {true, false, false, true, true});
-  ConfigOptions config_options{};
-  ASSERT_STATUS_OK(config_options.AddConfigEntry(webgpu::options::kEnableInt64, "1"));
-  auto provider = WebGpuExecutionProviderWithOptions(config_options);
-  test.ConfigEp(std::move(provider))
-      .RunWithConfig();
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
 }
 
 // Size divisible by 4: exercises the packed-bool path without tail padding.
-TEST(MathOpTest, Equal_webgpu_int64_size_div4) {
+TEST(MathOpTest, Equal_Int64_size_div4) {
   OpTester test("Equal", 13);
   test.AddInput<int64_t>("A", {8}, {1, 2, 3, 4, 5, 6, 7, 8});
   test.AddInput<int64_t>("B", {8}, {1, 0, 3, 0, 5, 0, 7, 0});
   test.AddOutput<bool>("C", {8}, {true, false, true, false, true, false, true, false});
-  ConfigOptions config_options{};
-  ASSERT_STATUS_OK(config_options.AddConfigEntry(webgpu::options::kEnableInt64, "1"));
-  auto provider = WebGpuExecutionProviderWithOptions(config_options);
-  test.ConfigEp(std::move(provider))
-      .RunWithConfig();
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
 }
 
 // Scalar LHS: lhs is a scalar, rhs is a vector; exercises is_lhs_scalar_ path.
-TEST(MathOpTest, Equal_webgpu_int64_lhs_scalar) {
+TEST(MathOpTest, Equal_Int64_lhs_scalar) {
   OpTester test("Equal", 13);
   test.AddInput<int64_t>("A", {1}, {3});
   test.AddInput<int64_t>("B", {5}, {1, 2, 3, 4, 3});
   test.AddOutput<bool>("C", {5}, {false, false, true, false, true});
-  ConfigOptions config_options{};
-  ASSERT_STATUS_OK(config_options.AddConfigEntry(webgpu::options::kEnableInt64, "1"));
-  auto provider = WebGpuExecutionProviderWithOptions(config_options);
-  test.ConfigEp(std::move(provider))
-      .RunWithConfig();
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
 }
 
 // Scalar RHS: rhs is a scalar, lhs is a vector; exercises is_rhs_scalar_ path.
-TEST(MathOpTest, Equal_webgpu_int64_rhs_scalar) {
+TEST(MathOpTest, Equal_Int64_rhs_scalar) {
   OpTester test("Equal", 13);
   test.AddInput<int64_t>("A", {5}, {1, 2, 3, 4, 3});
   test.AddInput<int64_t>("B", {1}, {3});
   test.AddOutput<bool>("C", {5}, {false, false, true, false, true});
-  ConfigOptions config_options{};
-  ASSERT_STATUS_OK(config_options.AddConfigEntry(webgpu::options::kEnableInt64, "1"));
-  auto provider = WebGpuExecutionProviderWithOptions(config_options);
-  test.ConfigEp(std::move(provider))
-      .RunWithConfig();
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
 }
 
 // Shape broadcast, size not divisible by 4: A [1,3] broadcasts against B [2,3] -> output [2,3].
 // Exercises the INT64 broadcast path with tail padding in the packed-bool output.
-TEST(MathOpTest, Equal_webgpu_int64_broadcast) {
+TEST(MathOpTest, Equal_Int64_broadcast) {
   OpTester test("Equal", 13);
   test.AddInput<int64_t>("A", {1, 3}, {1, 2, 3});
   test.AddInput<int64_t>("B", {2, 3}, {1, 0, 3, 1, 2, 3});
   test.AddOutput<bool>("C", {2, 3}, {true, false, true, true, true, true});
-  ConfigOptions config_options{};
-  ASSERT_STATUS_OK(config_options.AddConfigEntry(webgpu::options::kEnableInt64, "1"));
-  auto provider = WebGpuExecutionProviderWithOptions(config_options);
-  test.ConfigEp(std::move(provider))
-      .RunWithConfig();
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
 }
 
 // Shape broadcast, size divisible by 4: A [1,4] broadcasts against B [2,4] -> output [2,4].
 // Exercises the INT64 broadcast path without tail padding.
-TEST(MathOpTest, Equal_webgpu_int64_broadcast_size_div4) {
+TEST(MathOpTest, Equal_Int64_broadcast_size_div4) {
   OpTester test("Equal", 13);
   test.AddInput<int64_t>("A", {1, 4}, {1, 2, 3, 4});
   test.AddInput<int64_t>("B", {2, 4}, {1, 0, 3, 0, 1, 2, 3, 4});
   test.AddOutput<bool>("C", {2, 4}, {true, false, true, false, true, true, true, true});
-  ConfigOptions config_options{};
-  ASSERT_STATUS_OK(config_options.AddConfigEntry(webgpu::options::kEnableInt64, "1"));
-  auto provider = WebGpuExecutionProviderWithOptions(config_options);
-  test.ConfigEp(std::move(provider))
-      .RunWithConfig();
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
 }
 
-TEST(MathOpTest, Add_webgpu_int64) {
+TEST(MathOpTest, Add_Int64) {
   OpTester test("Add", 14);
   test.AddInput<int64_t>("A", {4}, {10, 5, -3, 0});
   test.AddInput<int64_t>("B", {4}, {3, 5, 1, -7});
   test.AddOutput<int64_t>("C", {4}, {13, 10, -2, -7});
-  ConfigOptions config_options{};
-  ASSERT_STATUS_OK(config_options.AddConfigEntry(webgpu::options::kEnableInt64, "1"));
-  auto provider = WebGpuExecutionProviderWithOptions(config_options);
-  test.ConfigEp(std::move(provider))
-      .RunWithConfig();
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
 }
 
 // INT64 Add with broadcast: A [1,3] broadcasts against B [2,3] -> output [2,3].
-TEST(MathOpTest, Add_webgpu_int64_broadcast) {
+TEST(MathOpTest, Add_Int64_broadcast) {
   OpTester test("Add", 14);
   test.AddInput<int64_t>("A", {1, 3}, {10, 20, 30});
   test.AddInput<int64_t>("B", {2, 3}, {1, 2, 3, 4, 5, 6});
   test.AddOutput<int64_t>("C", {2, 3}, {11, 22, 33, 14, 25, 36});
-  ConfigOptions config_options{};
-  ASSERT_STATUS_OK(config_options.AddConfigEntry(webgpu::options::kEnableInt64, "1"));
-  auto provider = WebGpuExecutionProviderWithOptions(config_options);
-  test.ConfigEp(std::move(provider))
-      .RunWithConfig();
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
 }
 
 // Size divisible by 4: catches future vec4 optimizations that might break INT64.
-TEST(MathOpTest, Add_webgpu_int64_size_div4) {
+TEST(MathOpTest, Add_Int64_size_div4) {
   OpTester test("Add", 14);
   test.AddInput<int64_t>("A", {8}, {10, 20, 30, 40, 50, 60, 70, 80});
   test.AddInput<int64_t>("B", {8}, {1, 2, 3, 4, 5, 6, 7, 8});
   test.AddOutput<int64_t>("C", {8}, {11, 22, 33, 44, 55, 66, 77, 88});
-  ConfigOptions config_options{};
-  ASSERT_STATUS_OK(config_options.AddConfigEntry(webgpu::options::kEnableInt64, "1"));
-  auto provider = WebGpuExecutionProviderWithOptions(config_options);
-  test.ConfigEp(std::move(provider))
-      .RunWithConfig();
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
 }
 
 // Scalar LHS: exercises is_lhs_scalar_ path for INT64 Add.
-TEST(MathOpTest, Add_webgpu_int64_lhs_scalar) {
+TEST(MathOpTest, Add_Int64_lhs_scalar) {
   OpTester test("Add", 14);
   test.AddInput<int64_t>("A", {1}, {100});
   test.AddInput<int64_t>("B", {5}, {1, 2, 3, 4, 5});
   test.AddOutput<int64_t>("C", {5}, {101, 102, 103, 104, 105});
-  ConfigOptions config_options{};
-  ASSERT_STATUS_OK(config_options.AddConfigEntry(webgpu::options::kEnableInt64, "1"));
-  auto provider = WebGpuExecutionProviderWithOptions(config_options);
-  test.ConfigEp(std::move(provider))
-      .RunWithConfig();
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
 }
 
 // Scalar RHS: exercises is_rhs_scalar_ path for INT64 Add.
-TEST(MathOpTest, Add_webgpu_int64_rhs_scalar) {
+TEST(MathOpTest, Add_Int64_rhs_scalar) {
   OpTester test("Add", 14);
   test.AddInput<int64_t>("A", {5}, {10, 20, 30, 40, 50});
   test.AddInput<int64_t>("B", {1}, {7});
   test.AddOutput<int64_t>("C", {5}, {17, 27, 37, 47, 57});
-  ConfigOptions config_options{};
-  ASSERT_STATUS_OK(config_options.AddConfigEntry(webgpu::options::kEnableInt64, "1"));
-  auto provider = WebGpuExecutionProviderWithOptions(config_options);
-  test.ConfigEp(std::move(provider))
-      .RunWithConfig();
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
 }
 
 // Shape broadcast, size divisible by 4: A [1,4] broadcasts against B [2,4] -> output [2,4].
-TEST(MathOpTest, Add_webgpu_int64_broadcast_size_div4) {
+TEST(MathOpTest, Add_Int64_broadcast_size_div4) {
   OpTester test("Add", 14);
   test.AddInput<int64_t>("A", {1, 4}, {10, 20, 30, 40});
   test.AddInput<int64_t>("B", {2, 4}, {1, 2, 3, 4, 5, 6, 7, 8});
   test.AddOutput<int64_t>("C", {2, 4}, {11, 22, 33, 44, 15, 26, 37, 48});
-  ConfigOptions config_options{};
-  ASSERT_STATUS_OK(config_options.AddConfigEntry(webgpu::options::kEnableInt64, "1"));
-  auto provider = WebGpuExecutionProviderWithOptions(config_options);
-  test.ConfigEp(std::move(provider))
-      .RunWithConfig();
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
 }
-#endif
 
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
@@ -2739,7 +2739,8 @@ TEST(MathOpTest, Div_Int64_WebGpu) {
   RunWebGpuNoCpuFallback(test, std::move(provider));
 }
 
-// Comparison ops take int64 inputs and produce a bool output (T = int64 constraint only).
+// Comparison ops here use int64 inputs and produce a bool output. These
+// cases validate int64 kernel selection on WebGPU (with CPU fallback disabled).
 TEST(MathOpTest, Greater_Int64_WebGpu) {
   auto provider = MakeWebGpuInt64Provider();
   if (provider == nullptr) {

--- a/onnxruntime/test/unittest_main/test_main.cc
+++ b/onnxruntime/test/unittest_main/test_main.cc
@@ -133,6 +133,10 @@ extern "C" void ortenv_setup() {
             "  \"ep_library_registration_name\": \"WebGpuExecutionProvider.virtual\",\n"
             "  \"ep_library_path\": \"" ORT_UNIT_TEST_WEBGPU_PLUGIN_EP_LIBRARY_PATH
             "\",\n"
+            // Enable int64 so the generic (EP-agnostic) int64 operator tests exercise the WebGPU
+            // int64 kernels on the plugin path too (mirrors DefaultWebGpuExecutionProvider on the
+            // static path). The key is the un-prefixed provider option name for plugin EPs.
+            "  \"default_ep_options\": { \"enableInt64\": \"1\" },\n"
             "  \"selected_ep_name\": \"WebGpuExecutionProvider\"\n"
             "}");
       }

--- a/onnxruntime/test/util/default_providers.cc
+++ b/onnxruntime/test/util/default_providers.cc
@@ -342,6 +342,14 @@ std::unique_ptr<IExecutionProvider> DefaultWebGpuExecutionProvider(bool is_nhwc)
   // Disable storage buffer cache
   ORT_THROW_IF_ERROR(config_options.AddConfigEntry(normalize_config_key(webgpu::options::kStorageBufferCacheMode).c_str(),
                                                    webgpu::options::kBufferCacheMode_Disabled));
+  // Enable int64 so the generic (EP-agnostic) int64 operator tests exercise the WebGPU int64
+  // kernels instead of silently falling back to CPU. Kept on by default for the test harness so
+  // operator tests don't have to build a bespoke WebGPU EP just to reach the int64 path.
+  //
+  // NOTE: this enables int64 for ALL WebGPU tests, not just the binary elementwise ops.
+  // TODO: migrate the other int64-gated ops' WebGPU-only int64 tests to EP-agnostic form too.
+  ORT_THROW_IF_ERROR(config_options.AddConfigEntry(normalize_config_key(webgpu::options::kEnableInt64).c_str(),
+                                                   webgpu::options::kEnableInt64_ON));
   if (!is_nhwc) {
     // Enable NCHW support
     ORT_THROW_IF_ERROR(config_options.AddConfigEntry(normalize_config_key(webgpu::options::kPreferredLayout).c_str(),


### PR DESCRIPTION
### Description
Registers the WebGPU Min and Max kernels with conditional int64 support, mirroring the existing Add/Sub/Equal int64 mechanism. The kernels were previously registered with `WebGpuSupportedNumberTypes()` (float/fp16/ int32/uint32 only), causing int64 tensors to fall back to CPU.

### Motivation and Context
Min/Max are arithmetic/comparison ops, so they reuse the existing low-32-bit i32 shader path (like Add/Sub). Values outside the int32 range produce incorrect results, which is acceptable for token-position workloads and consistent with the other arithmetic int64 kernels.

`int64` support is gated behind the enableInt64 provider option, so the generic `Min_12_Int64`/`Max_12_Int64` tests do not exercise it. Added WebGPU int64 tests (int64 enabled, CPU-EP fallback disabled) mirroring the Add int64 path coverage, element-wise, size divisible by 4, scalar operand, broadcast, plus the variadic (>2 input) fold unique to Min/Max, with INT32_MIN/INT32_MAX exercising the supported range edges.


