### PR TITLE
Validate the axis of Gather/Slice

### DIFF
--- a/onnxruntime/core/optimizer/gather_fusion.cc
+++ b/onnxruntime/core/optimizer/gather_fusion.cc
@@ -10,8 +10,8 @@
 namespace onnxruntime {
 
 namespace {
-static int64_t GetGatherAxis(const Node& node, int64_t rank) {
-  int64_t axis = 0;
+static bool GetGatherAxis(const Node& node, int64_t rank, int64_t& axis) {
+  axis = 0;
   auto& attrs = node.GetAttributes();
   if (attrs.find("axis") != attrs.end()) {
     auto& axis_attr = attrs.at("axis");
@@ -20,7 +20,7 @@ static int64_t GetGatherAxis(const Node& node, int64_t rank) {
       if (axis < 0) axis += rank;
     }
   }
-  return axis;
+  return axis >= 0 && axis < rank;
 }
 
 static bool GetScalarInt64Initializer(const Graph& graph, const NodeArg& node_arg, int64_t& value, int64_t& rank) {
@@ -38,13 +38,12 @@ static bool GetSliceAxis(const Graph& graph, const Node& node, int64_t rank, int
   int64_t unused = 0;
   if (!GetScalarInt64Initializer(graph, *node.InputDefs()[3], axis, unused)) return false;
   if (axis < 0) axis += rank;
-  return true;
+  return axis >= 0 && axis < rank;
 }
 
 static bool GetAxis(const Graph& graph, const Node& node, int64_t rank, int64_t& axis) {
   if (node.OpType() == "Gather") {
-    axis = GetGatherAxis(node, rank);
-    return true;
+    return GetGatherAxis(node, rank, axis);
   }
   if (node.OpType() == "Slice") {
     return GetSliceAxis(graph, node, rank, axis);
@@ -62,7 +61,8 @@ bool GatherSliceToSplitFusion::IsSupportedGather(const Graph& graph, const Node&
     return false;
   }
 
-  if (GetGatherAxis(node, rank) != target_axis) return false;
+  int64_t gather_axis = 0;
+  if (!GetGatherAxis(node, rank, gather_axis) || gather_axis != target_axis) return false;
   // Require the indices input to be a scalar tensor for now. Normally if not, the exporter will choose Slice.
   // We can relax this later if needed.
   int64_t indices_n_dims = 0;

--- a/onnxruntime/test/optimizer/graph_transform_test.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test.cc
@@ -10971,6 +10971,26 @@ TEST_F(GraphTransformationTests, GatherSliceToSplitFusion_Invalid) {
     ASSERT_STATUS_OK(TestGraphTransformer(build_test_case, 14, *logger_, std::move(transformer),
                                           TransformerLevel::Level1, 1, pre_graph_checker, post_graph_checker));
   }
+
+  // Out-of-range axis.
+  {
+    auto build_test_case = [&](ModelTestBuilder& builder) {
+      auto* data_arg = builder.MakeInput<float>({{2, 3, 3, 3}});        // rank 4, valid axes are [0, 4)
+      auto* gather_index_1 = builder.MakeInput<int64_t>(std::nullopt);  // typed but no shape -> skips axis check
+      auto* gather_index_2 = builder.MakeInput<int64_t>(std::nullopt);
+      auto* gather_out_1 = builder.MakeOutput();
+      auto* gather_out_2 = builder.MakeOutput();
+
+      builder.AddNode("Gather", {data_arg, gather_index_1}, {gather_out_1})
+          .AddAttribute("axis", static_cast<int64_t>(100));
+      builder.AddNode("Gather", {data_arg, gather_index_2}, {gather_out_2})
+          .AddAttribute("axis", static_cast<int64_t>(100));
+    };
+
+    std::unique_ptr<GraphTransformer> transformer = std::make_unique<GatherSliceToSplitFusion>();
+    ASSERT_STATUS_OK(TestGraphTransformer(build_test_case, 14, *logger_, std::move(transformer),
+                                          TransformerLevel::Level1, 1, pre_graph_checker, post_graph_checker));
+  }
 }
 
 TEST_F(GraphTransformationTests, GatherToSliceFusion) {


### PR DESCRIPTION
### Description
Validate the axis of Gather/Slice consumers against the input rank in `GatherSliceToSplitFusion()` before it is used to index the shape's dimensions.

`GetGatherAxis` and `GetSliceAxis` previously only normalized a negative axis (axis += rank) and returned it unchecked. `ApplyImpl()` then did `shape->dim(static_cast<int>(axis))` without any bounds check, so an out-of-range axis can lead to an out-of-bounds read of the `TensorShapeProto`'s `dim_`.




