### PR TITLE
[WebGPU] Add Gather int64 support and make kernel version numbers function params

### DIFF
--- a/onnxruntime/core/providers/webgpu/math/binary_elementwise_ops.cc
+++ b/onnxruntime/core/providers/webgpu/math/binary_elementwise_ops.cc
@@ -435,8 +435,7 @@ WEBGPU_BINARY_IMPL(Add, "a + b")
 // NOTE: int64 arithmetic in the WebGPU shader operates on the low 32 bits only (i32 element type).
 // Values outside the int32 range [-2^31, 2^31-1] will produce incorrect results.
 // This matches the same limitation documented in Range/Sub and is acceptable for token-position workloads.
-template <int StartVersion, int EndVersion>
-KernelCreateInfo CreateAddVersionedKernelInfo(bool enable_int64) {
+KernelCreateInfo CreateAddVersionedKernelInfo(int start_version, int end_version, bool enable_int64) {
   const auto& type_constraints = GetOpTypeConstraints(enable_int64, false);
   KernelCreatePtrFn kernel_create_fn = [](FuncManager&, const OpKernelInfo& info, std::unique_ptr<OpKernel>& out) -> Status {
     out = std::make_unique<Add>(info);
@@ -445,15 +444,14 @@ KernelCreateInfo CreateAddVersionedKernelInfo(bool enable_int64) {
   return {KernelDefBuilder()
               .SetName("Add")
               .SetDomain(kOnnxDomain)
-              .SinceVersion(StartVersion, EndVersion)
+              .SinceVersion(start_version, end_version)
               .Provider(kWebGpuExecutionProvider)
               .TypeConstraint("T", type_constraints)
               .Build(),
           kernel_create_fn};
 }
 
-template <int SinceVersion>
-KernelCreateInfo CreateAddKernelInfo(bool enable_int64) {
+KernelCreateInfo CreateAddKernelInfo(int since_version, bool enable_int64) {
   const auto& type_constraints = GetOpTypeConstraints(enable_int64, false);
   KernelCreatePtrFn kernel_create_fn = [](FuncManager&, const OpKernelInfo& info, std::unique_ptr<OpKernel>& out) -> Status {
     out = std::make_unique<Add>(info);
@@ -462,16 +460,12 @@ KernelCreateInfo CreateAddKernelInfo(bool enable_int64) {
   return {KernelDefBuilder()
               .SetName("Add")
               .SetDomain(kOnnxDomain)
-              .SinceVersion(SinceVersion)
+              .SinceVersion(since_version)
               .Provider(kWebGpuExecutionProvider)
               .TypeConstraint("T", type_constraints)
               .Build(),
           kernel_create_fn};
 }
-
-template KernelCreateInfo CreateAddVersionedKernelInfo<7, 12>(bool);
-template KernelCreateInfo CreateAddVersionedKernelInfo<13, 13>(bool);
-template KernelCreateInfo CreateAddKernelInfo<14>(bool);
 
 WEBGPU_BINARY_IMPL(Div, "a / b")
 WEBGPU_BINARY_VERSIONED_KERNEL(Div, 7, 12, Div, WebGpuSupportedNumberTypes())
@@ -488,8 +482,7 @@ WEBGPU_BINARY_IMPL(Sub, "a - b")
 // NOTE: int64 arithmetic in the WebGPU shader operates on the low 32 bits only (i32 element type).
 // Values outside the int32 range [-2^31, 2^31-1] will produce incorrect results.
 // This matches the same limitation documented in Range and is acceptable for token-position workloads.
-template <int StartVersion, int EndVersion>
-KernelCreateInfo CreateSubVersionedKernelInfo(bool enable_int64) {
+KernelCreateInfo CreateSubVersionedKernelInfo(int start_version, int end_version, bool enable_int64) {
   const auto& type_constraints = GetOpTypeConstraints(enable_int64, false);
   KernelCreatePtrFn kernel_create_fn = [](FuncManager&, const OpKernelInfo& info, std::unique_ptr<OpKernel>& out) -> Status {
     out = std::make_unique<Sub>(info);
@@ -498,15 +491,14 @@ KernelCreateInfo CreateSubVersionedKernelInfo(bool enable_int64) {
   return {KernelDefBuilder()
               .SetName("Sub")
               .SetDomain(kOnnxDomain)
-              .SinceVersion(StartVersion, EndVersion)
+              .SinceVersion(start_version, end_version)
               .Provider(kWebGpuExecutionProvider)
               .TypeConstraint("T", type_constraints)
               .Build(),
           kernel_create_fn};
 }
 
-template <int SinceVersion>
-KernelCreateInfo CreateSubKernelInfo(bool enable_int64) {
+KernelCreateInfo CreateSubKernelInfo(int since_version, bool enable_int64) {
   const auto& type_constraints = GetOpTypeConstraints(enable_int64, false);
   KernelCreatePtrFn kernel_create_fn = [](FuncManager&, const OpKernelInfo& info, std::unique_ptr<OpKernel>& out) -> Status {
     out = std::make_unique<Sub>(info);
@@ -515,16 +507,12 @@ KernelCreateInfo CreateSubKernelInfo(bool enable_int64) {
   return {KernelDefBuilder()
               .SetName("Sub")
               .SetDomain(kOnnxDomain)
-              .SinceVersion(SinceVersion)
+              .SinceVersion(since_version)
               .Provider(kWebGpuExecutionProvider)
               .TypeConstraint("T", type_constraints)
               .Build(),
           kernel_create_fn};
 }
-
-template KernelCreateInfo CreateSubVersionedKernelInfo<7, 12>(bool);
-template KernelCreateInfo CreateSubVersionedKernelInfo<13, 13>(bool);
-template KernelCreateInfo CreateSubKernelInfo<14>(bool);
 
 // ONNX Max/Min (opset 12+) propagate NaN: if either operand is NaN the result is NaN.
 // The WGSL `max`/`min` builtins do not guarantee this, so wrap them so that a NaN operand is
@@ -619,8 +607,7 @@ WEBGPU_BINARY_IMPL(Equal, "vec4<u32>(vec4<input_a_element_t>(a) == vec4<input_b_
 
 // NOTE: int64 comparison in the WebGPU shader uses i32 element type (low 32 bits only).
 // Values outside the int32 range will produce incorrect results.
-template <int StartVersion, int EndVersion>
-KernelCreateInfo CreateEqualVersionedKernelInfo(bool enable_int64) {
+KernelCreateInfo CreateEqualVersionedKernelInfo(int start_version, int end_version, bool enable_int64) {
   const auto& type_constraints = GetOpTypeConstraints(enable_int64, false);
   KernelCreatePtrFn kernel_create_fn = [](FuncManager&, const OpKernelInfo& info, std::unique_ptr<OpKernel>& out) -> Status {
     out = std::make_unique<Equal>(info);
@@ -629,15 +616,14 @@ KernelCreateInfo CreateEqualVersionedKernelInfo(bool enable_int64) {
   return {KernelDefBuilder()
               .SetName("Equal")
               .SetDomain(kOnnxDomain)
-              .SinceVersion(StartVersion, EndVersion)
+              .SinceVersion(start_version, end_version)
               .Provider(kWebGpuExecutionProvider)
               .TypeConstraint("T", type_constraints)
               .Build(),
           kernel_create_fn};
 }
 
-template <int SinceVersion>
-KernelCreateInfo CreateEqualKernelInfo(bool enable_int64) {
+KernelCreateInfo CreateEqualKernelInfo(int since_version, bool enable_int64) {
   const auto& type_constraints = GetOpTypeConstraints(enable_int64, false);
   KernelCreatePtrFn kernel_create_fn = [](FuncManager&, const OpKernelInfo& info, std::unique_ptr<OpKernel>& out) -> Status {
     out = std::make_unique<Equal>(info);
@@ -646,17 +632,12 @@ KernelCreateInfo CreateEqualKernelInfo(bool enable_int64) {
   return {KernelDefBuilder()
               .SetName("Equal")
               .SetDomain(kOnnxDomain)
-              .SinceVersion(SinceVersion)
+              .SinceVersion(since_version)
               .Provider(kWebGpuExecutionProvider)
               .TypeConstraint("T", type_constraints)
               .Build(),
           kernel_create_fn};
 }
-
-template KernelCreateInfo CreateEqualVersionedKernelInfo<7, 10>(bool);
-template KernelCreateInfo CreateEqualVersionedKernelInfo<11, 12>(bool);
-template KernelCreateInfo CreateEqualVersionedKernelInfo<13, 18>(bool);
-template KernelCreateInfo CreateEqualKernelInfo<19>(bool);
 
 WEBGPU_BINARY_IMPL(Greater, "vec4<u32>(vec4<input_a_element_t>(a) > vec4<input_b_element_t>(b))")
 WEBGPU_BINARY_VERSIONED_KERNEL(Greater, 7, 8, Greater, WebGpuSupportedNumberTypes())

--- a/onnxruntime/core/providers/webgpu/math/binary_elementwise_ops.h
+++ b/onnxruntime/core/providers/webgpu/math/binary_elementwise_ops.h
@@ -74,20 +74,14 @@ class BinaryElementwise : public WebGpuKernel {
 };
 
 // Factory functions for ops with conditional int64 support (registered via RegisterKernels).
-template <int StartVersion, int EndVersion>
-KernelCreateInfo CreateAddVersionedKernelInfo(bool enable_int64);
-template <int SinceVersion>
-KernelCreateInfo CreateAddKernelInfo(bool enable_int64);
+KernelCreateInfo CreateAddVersionedKernelInfo(int start_version, int end_version, bool enable_int64);
+KernelCreateInfo CreateAddKernelInfo(int since_version, bool enable_int64);
 
-template <int StartVersion, int EndVersion>
-KernelCreateInfo CreateEqualVersionedKernelInfo(bool enable_int64);
-template <int SinceVersion>
-KernelCreateInfo CreateEqualKernelInfo(bool enable_int64);
+KernelCreateInfo CreateEqualVersionedKernelInfo(int start_version, int end_version, bool enable_int64);
+KernelCreateInfo CreateEqualKernelInfo(int since_version, bool enable_int64);
 
-template <int StartVersion, int EndVersion>
-KernelCreateInfo CreateSubVersionedKernelInfo(bool enable_int64);
-template <int SinceVersion>
-KernelCreateInfo CreateSubKernelInfo(bool enable_int64);
+KernelCreateInfo CreateSubVersionedKernelInfo(int start_version, int end_version, bool enable_int64);
+KernelCreateInfo CreateSubKernelInfo(int since_version, bool enable_int64);
 
 // Variadic element-wise operator (e.g. Max, Min) that accepts 1..N inputs with
 // multidirectional (NumPy-style) broadcasting. The inputs are folded pairwise using the

--- a/onnxruntime/core/providers/webgpu/reduction/reduction_ops.cc
+++ b/onnxruntime/core/providers/webgpu/reduction/reduction_ops.cc
@@ -63,8 +63,7 @@ REGISTER_REDUCE_KERNEL(ReduceMin, 20);
 // Factory functions allow conditional int64 support on the T type constraint.
 // NOTE: int64 reduction in the WebGPU shader uses i32 (low 32 bits only); values outside
 // the int32 range will produce incorrect results — same limitation as Range.
-template <int StartVersion, int EndVersion>
-KernelCreateInfo CreateReduceSumVersionedKernelInfo(bool enable_int64) {
+KernelCreateInfo CreateReduceSumVersionedKernelInfo(int start_version, int end_version, bool enable_int64) {
   const auto& type_constraints = GetOpTypeConstraints(enable_int64, false);
   KernelCreatePtrFn kernel_create_fn = [](FuncManager&, const OpKernelInfo& info, std::unique_ptr<OpKernel>& out) -> Status {
     out = std::make_unique<ReduceSum>(info);
@@ -73,15 +72,14 @@ KernelCreateInfo CreateReduceSumVersionedKernelInfo(bool enable_int64) {
   return {KernelDefBuilder()
               .SetName("ReduceSum")
               .SetDomain(kOnnxDomain)
-              .SinceVersion(StartVersion, EndVersion)
+              .SinceVersion(start_version, end_version)
               .Provider(kWebGpuExecutionProvider)
               .TypeConstraint("T", type_constraints)
               .Build(),
           kernel_create_fn};
 }
 
-template <int SinceVersion>
-KernelCreateInfo CreateReduceSumKernelInfo(bool enable_int64) {
+KernelCreateInfo CreateReduceSumKernelInfo(int since_version, bool enable_int64) {
   const auto& type_constraints = GetOpTypeConstraints(enable_int64, false);
   KernelCreatePtrFn kernel_create_fn = [](FuncManager&, const OpKernelInfo& info, std::unique_ptr<OpKernel>& out) -> Status {
     out = std::make_unique<ReduceSum>(info);
@@ -90,17 +88,13 @@ KernelCreateInfo CreateReduceSumKernelInfo(bool enable_int64) {
   return {KernelDefBuilder()
               .SetName("ReduceSum")
               .SetDomain(kOnnxDomain)
-              .SinceVersion(SinceVersion)
+              .SinceVersion(since_version)
               .Provider(kWebGpuExecutionProvider)
               .TypeConstraint("T", type_constraints)
               .InputMemoryType(OrtMemTypeCPUInput, 1)
               .Build(),
           kernel_create_fn};
 }
-
-template KernelCreateInfo CreateReduceSumVersionedKernelInfo<1, 10>(bool);
-template KernelCreateInfo CreateReduceSumVersionedKernelInfo<11, 12>(bool);
-template KernelCreateInfo CreateReduceSumKernelInfo<13>(bool);
 
 REGISTER_REDUCE_VERSIONED_KERNEL(ReduceProd, 1, 10);
 REGISTER_REDUCE_VERSIONED_KERNEL(ReduceProd, 11, 12);

--- a/onnxruntime/core/providers/webgpu/reduction/reduction_ops.h
+++ b/onnxruntime/core/providers/webgpu/reduction/reduction_ops.h
@@ -161,10 +161,8 @@ class ArgMax final : public ReduceKernel<false> {
 };
 
 // Factory functions for ReduceSum with conditional int64 support (registered via RegisterKernels).
-template <int StartVersion, int EndVersion>
-KernelCreateInfo CreateReduceSumVersionedKernelInfo(bool enable_int64);
-template <int SinceVersion>
-KernelCreateInfo CreateReduceSumKernelInfo(bool enable_int64);
+KernelCreateInfo CreateReduceSumVersionedKernelInfo(int start_version, int end_version, bool enable_int64);
+KernelCreateInfo CreateReduceSumKernelInfo(int since_version, bool enable_int64);
 
 }  // namespace webgpu
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/webgpu/tensor/cast.cc
+++ b/onnxruntime/core/providers/webgpu/tensor/cast.cc
@@ -199,8 +199,7 @@ Status CastProgram::GenerateShaderCode(ShaderHelper& sh) const {
   return Status::OK();
 }
 
-template <int StartVersion, int EndVersion>
-KernelCreateInfo CreateCastKernelInfo(bool enable_int64) {
+KernelCreateInfo CreateCastKernelInfo(int start_version, int end_version, bool enable_int64) {
   // Casting to int64 is always supported. Casting *from* int64 (int64 in T1/input) stays guarded by enable_int64.
   std::vector<MLDataType> t1_constraints = GetOpTypeConstraints(/*enable_int64=*/enable_int64, /*enable_bool=*/true);
   // T1 (input): plus uint8, so casts *from* a uint8 tensor (to int32/float/bool/etc.) run on the
@@ -218,12 +217,12 @@ KernelCreateInfo CreateCastKernelInfo(bool enable_int64) {
     return Status::OK();
   };
 
-  if constexpr (StartVersion == EndVersion) {
+  if (start_version == end_version) {
     return {
         KernelDefBuilder()
             .SetName("Cast")
             .SetDomain(kOnnxDomain)
-            .SinceVersion(StartVersion)
+            .SinceVersion(start_version)
             .Provider(kWebGpuExecutionProvider)
             .TypeConstraint("T1", t1_constraints)
             .TypeConstraint("T2", t2_constraints)
@@ -234,7 +233,7 @@ KernelCreateInfo CreateCastKernelInfo(bool enable_int64) {
         KernelDefBuilder()
             .SetName("Cast")
             .SetDomain(kOnnxDomain)
-            .SinceVersion(StartVersion, EndVersion)
+            .SinceVersion(start_version, end_version)
             .Provider(kWebGpuExecutionProvider)
             .TypeConstraint("T1", t1_constraints)
             .TypeConstraint("T2", t2_constraints)
@@ -242,15 +241,6 @@ KernelCreateInfo CreateCastKernelInfo(bool enable_int64) {
         kernel_create_fn};
   }
 }
-
-// Explicit template instantiations
-template KernelCreateInfo CreateCastKernelInfo<6, 8>(bool);
-template KernelCreateInfo CreateCastKernelInfo<9, 12>(bool);
-template KernelCreateInfo CreateCastKernelInfo<13, 18>(bool);
-template KernelCreateInfo CreateCastKernelInfo<19, 20>(bool);
-template KernelCreateInfo CreateCastKernelInfo<21, 22>(bool);
-template KernelCreateInfo CreateCastKernelInfo<23, 23>(bool);
-template KernelCreateInfo CreateCastKernelInfo<24>(bool);
 
 }  // namespace webgpu
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/webgpu/tensor/cast.cc
+++ b/onnxruntime/core/providers/webgpu/tensor/cast.cc
@@ -199,47 +199,56 @@ Status CastProgram::GenerateShaderCode(ShaderHelper& sh) const {
   return Status::OK();
 }
 
-KernelCreateInfo CreateCastKernelInfo(int start_version, int end_version, bool enable_int64) {
-  // Casting to int64 is always supported. Casting *from* int64 (int64 in T1/input) stays guarded by enable_int64.
+namespace {
+// Casting to int64 is always supported. Casting *from* int64 (int64 in T1/input) stays guarded by enable_int64.
+// T1 (input): plus uint8, so casts *from* a uint8 tensor (to int32/float/bool/etc.) run on the
+// WebGPU EP instead of falling back. Reading uint8 input unpacks the packed Uint8x4 storage via
+// GetByOffset.
+std::vector<MLDataType> GetCastT1TypeConstraints(bool enable_int64) {
   std::vector<MLDataType> t1_constraints = GetOpTypeConstraints(/*enable_int64=*/enable_int64, /*enable_bool=*/true);
-  // T1 (input): plus uint8, so casts *from* a uint8 tensor (to int32/float/bool/etc.) run on the
-  // WebGPU EP instead of falling back. Reading uint8 input unpacks the packed Uint8x4 storage via
-  // GetByOffset.
   t1_constraints.push_back(DataTypeImpl::GetTensorType<uint8_t>());
-  // T2 (output): the int64+bool set, plus uint8 so the WebGPU EP can produce uint8 output directly
-  // (e.g. a terminal bool->uint8 cast at a graph output) instead of falling back. Casting *to* uint8
-  // packs via the Uint8x4 SetByOffset.
+  return t1_constraints;
+}
+
+// T2 (output): the int64+bool set, plus uint8 so the WebGPU EP can produce uint8 output directly
+// (e.g. a terminal bool->uint8 cast at a graph output) instead of falling back. Casting *to* uint8
+// packs via the Uint8x4 SetByOffset.
+std::vector<MLDataType> GetCastT2TypeConstraints() {
   std::vector<MLDataType> t2_constraints = GetOpTypeConstraints(/*enable_int64=*/true, /*enable_bool=*/true);
   t2_constraints.push_back(DataTypeImpl::GetTensorType<uint8_t>());
+  return t2_constraints;
+}
 
-  KernelCreatePtrFn kernel_create_fn = [](FuncManager&, const OpKernelInfo& info, std::unique_ptr<OpKernel>& out) -> Status {
-    out = std::make_unique<Cast>(info);
-    return Status::OK();
-  };
+Status CreateCastKernel(FuncManager&, const OpKernelInfo& info, std::unique_ptr<OpKernel>& out) {
+  out = std::make_unique<Cast>(info);
+  return Status::OK();
+}
+}  // namespace
 
-  if (start_version == end_version) {
-    return {
-        KernelDefBuilder()
-            .SetName("Cast")
-            .SetDomain(kOnnxDomain)
-            .SinceVersion(start_version)
-            .Provider(kWebGpuExecutionProvider)
-            .TypeConstraint("T1", t1_constraints)
-            .TypeConstraint("T2", t2_constraints)
-            .Build(),
-        kernel_create_fn};
-  } else {
-    return {
-        KernelDefBuilder()
-            .SetName("Cast")
-            .SetDomain(kOnnxDomain)
-            .SinceVersion(start_version, end_version)
-            .Provider(kWebGpuExecutionProvider)
-            .TypeConstraint("T1", t1_constraints)
-            .TypeConstraint("T2", t2_constraints)
-            .Build(),
-        kernel_create_fn};
-  }
+KernelCreateInfo CreateCastVersionedKernelInfo(int start_version, int end_version, bool enable_int64) {
+  return {
+      KernelDefBuilder()
+          .SetName("Cast")
+          .SetDomain(kOnnxDomain)
+          .SinceVersion(start_version, end_version)
+          .Provider(kWebGpuExecutionProvider)
+          .TypeConstraint("T1", GetCastT1TypeConstraints(enable_int64))
+          .TypeConstraint("T2", GetCastT2TypeConstraints())
+          .Build(),
+      CreateCastKernel};
+}
+
+KernelCreateInfo CreateCastKernelInfo(int since_version, bool enable_int64) {
+  return {
+      KernelDefBuilder()
+          .SetName("Cast")
+          .SetDomain(kOnnxDomain)
+          .SinceVersion(since_version)
+          .Provider(kWebGpuExecutionProvider)
+          .TypeConstraint("T1", GetCastT1TypeConstraints(enable_int64))
+          .TypeConstraint("T2", GetCastT2TypeConstraints())
+          .Build(),
+      CreateCastKernel};
 }
 
 }  // namespace webgpu

--- a/onnxruntime/core/providers/webgpu/tensor/cast.h
+++ b/onnxruntime/core/providers/webgpu/tensor/cast.h
@@ -51,9 +51,8 @@ class Cast final : public WebGpuKernel {
 };
 
 // Create Cast kernel info with appropriate type constraints based on int64 support.
-// start_version == end_version registers an open-ended kernel (SinceVersion(start_version));
-// otherwise a bounded [start_version, end_version] range.
-KernelCreateInfo CreateCastKernelInfo(int start_version, int end_version, bool enable_int64);
+KernelCreateInfo CreateCastVersionedKernelInfo(int start_version, int end_version, bool enable_int64);
+KernelCreateInfo CreateCastKernelInfo(int since_version, bool enable_int64);
 
 }  // namespace webgpu
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/webgpu/tensor/cast.h
+++ b/onnxruntime/core/providers/webgpu/tensor/cast.h
@@ -50,9 +50,10 @@ class Cast final : public WebGpuKernel {
   int32_t to_;
 };
 
-// Create Cast kernel info with appropriate type constraints based on int64 support
-template <int StartVersion, int EndVersion = StartVersion>
-KernelCreateInfo CreateCastKernelInfo(bool enable_int64);
+// Create Cast kernel info with appropriate type constraints based on int64 support.
+// Passing start_version == end_version registers an open-ended kernel (SinceVersion(start_version)),
+// matching the "latest opset" registration; otherwise a bounded [start_version, end_version] range.
+KernelCreateInfo CreateCastKernelInfo(int start_version, int end_version, bool enable_int64);
 
 }  // namespace webgpu
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/webgpu/tensor/cast.h
+++ b/onnxruntime/core/providers/webgpu/tensor/cast.h
@@ -51,8 +51,8 @@ class Cast final : public WebGpuKernel {
 };
 
 // Create Cast kernel info with appropriate type constraints based on int64 support.
-// Passing start_version == end_version registers an open-ended kernel (SinceVersion(start_version)),
-// matching the "latest opset" registration; otherwise a bounded [start_version, end_version] range.
+// start_version == end_version registers an open-ended kernel (SinceVersion(start_version));
+// otherwise a bounded [start_version, end_version] range.
 KernelCreateInfo CreateCastKernelInfo(int start_version, int end_version, bool enable_int64);
 
 }  // namespace webgpu

--- a/onnxruntime/core/providers/webgpu/tensor/concat.cc
+++ b/onnxruntime/core/providers/webgpu/tensor/concat.cc
@@ -17,8 +17,7 @@ namespace webgpu {
 // so enabling int64 is safe. int64 (stored as vec2<u32>) is copied losslessly via the raw
 // storage-word path in AppendAssignOutputDataFunction, preserving the full 64-bit value instead of
 // the truncating i32 value type used by arithmetic kernels.
-template <int StartVersion, int EndVersion>
-KernelCreateInfo CreateConcatVersionedKernelInfo(bool enable_int64) {
+KernelCreateInfo CreateConcatVersionedKernelInfo(int start_version, int end_version, bool enable_int64) {
   std::vector<MLDataType> type_constraints = GetOpTypeConstraints(enable_int64, /*enable_bool=*/false);
 
   KernelCreatePtrFn kernel_create_fn = [](FuncManager&, const OpKernelInfo& info, std::unique_ptr<OpKernel>& out) -> Status {
@@ -30,15 +29,14 @@ KernelCreateInfo CreateConcatVersionedKernelInfo(bool enable_int64) {
       KernelDefBuilder()
           .SetName("Concat")
           .SetDomain(kOnnxDomain)
-          .SinceVersion(StartVersion, EndVersion)
+          .SinceVersion(start_version, end_version)
           .Provider(kWebGpuExecutionProvider)
           .TypeConstraint("T", std::move(type_constraints))
           .Build(),
       kernel_create_fn};
 }
 
-template <int SinceVersion>
-KernelCreateInfo CreateConcatKernelInfo(bool enable_int64) {
+KernelCreateInfo CreateConcatKernelInfo(int since_version, bool enable_int64) {
   std::vector<MLDataType> type_constraints = GetOpTypeConstraints(enable_int64, /*enable_bool=*/false);
 
   KernelCreatePtrFn kernel_create_fn = [](FuncManager&, const OpKernelInfo& info, std::unique_ptr<OpKernel>& out) -> Status {
@@ -50,18 +48,12 @@ KernelCreateInfo CreateConcatKernelInfo(bool enable_int64) {
       KernelDefBuilder()
           .SetName("Concat")
           .SetDomain(kOnnxDomain)
-          .SinceVersion(SinceVersion)
+          .SinceVersion(since_version)
           .Provider(kWebGpuExecutionProvider)
           .TypeConstraint("T", std::move(type_constraints))
           .Build(),
       kernel_create_fn};
 }
-
-// Explicit template instantiations
-template KernelCreateInfo CreateConcatVersionedKernelInfo<1, 3>(bool);
-template KernelCreateInfo CreateConcatVersionedKernelInfo<4, 10>(bool);
-template KernelCreateInfo CreateConcatVersionedKernelInfo<11, 12>(bool);
-template KernelCreateInfo CreateConcatKernelInfo<13>(bool);
 
 void AppendCalculateInputIndexFunction(OStringStream& os, size_t input_count) {
   os << "fn calculate_input_index(global_idx: u32) -> u32 {\n"

--- a/onnxruntime/core/providers/webgpu/tensor/concat.h
+++ b/onnxruntime/core/providers/webgpu/tensor/concat.h
@@ -35,10 +35,8 @@ class Concat final : public WebGpuKernel, public ConcatBase {
 };
 
 // Create Concat kernel info with appropriate type constraints based on int64 support
-template <int StartVersion, int EndVersion>
-KernelCreateInfo CreateConcatVersionedKernelInfo(bool enable_int64);
-template <int SinceVersion>
-KernelCreateInfo CreateConcatKernelInfo(bool enable_int64);
+KernelCreateInfo CreateConcatVersionedKernelInfo(int start_version, int end_version, bool enable_int64);
+KernelCreateInfo CreateConcatKernelInfo(int since_version, bool enable_int64);
 
 }  // namespace webgpu
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/webgpu/tensor/expand.cc
+++ b/onnxruntime/core/providers/webgpu/tensor/expand.cc
@@ -140,8 +140,7 @@ Status Expand::ComputeInternal(ComputeContext& context) const {
   return context.RunProgram(program);
 }
 
-template <int StartVersion, int EndVersion>
-KernelCreateInfo CreateExpandVersionedKernelInfo(bool enable_int64) {
+KernelCreateInfo CreateExpandVersionedKernelInfo(int start_version, int end_version, bool enable_int64) {
   std::vector<MLDataType> type_constraints = GetOpTypeConstraints(enable_int64, true);
   type_constraints.push_back(DataTypeImpl::GetTensorType<uint8_t>());
 
@@ -154,7 +153,7 @@ KernelCreateInfo CreateExpandVersionedKernelInfo(bool enable_int64) {
       KernelDefBuilder()
           .SetName("Expand")
           .SetDomain(kOnnxDomain)
-          .SinceVersion(StartVersion, EndVersion)
+          .SinceVersion(start_version, end_version)
           .Provider(kWebGpuExecutionProvider)
           .TypeConstraint("T", type_constraints)
           .InputMemoryType(OrtMemTypeCPU, 1)
@@ -162,8 +161,7 @@ KernelCreateInfo CreateExpandVersionedKernelInfo(bool enable_int64) {
       kernel_create_fn};
 }
 
-template <int SinceVersion>
-KernelCreateInfo CreateExpandKernelInfo(bool enable_int64) {
+KernelCreateInfo CreateExpandKernelInfo(int since_version, bool enable_int64) {
   std::vector<MLDataType> type_constraints = GetOpTypeConstraints(enable_int64, true);
   type_constraints.push_back(DataTypeImpl::GetTensorType<uint8_t>());
 
@@ -176,17 +174,13 @@ KernelCreateInfo CreateExpandKernelInfo(bool enable_int64) {
       KernelDefBuilder()
           .SetName("Expand")
           .SetDomain(kOnnxDomain)
-          .SinceVersion(SinceVersion)
+          .SinceVersion(since_version)
           .Provider(kWebGpuExecutionProvider)
           .TypeConstraint("T", type_constraints)
           .InputMemoryType(OrtMemTypeCPU, 1)
           .Build(),
       kernel_create_fn};
 }
-
-// Explicit template instantiations
-template KernelCreateInfo CreateExpandVersionedKernelInfo<8, 12>(bool);
-template KernelCreateInfo CreateExpandKernelInfo<13>(bool);
 
 }  // namespace webgpu
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/webgpu/tensor/expand.h
+++ b/onnxruntime/core/providers/webgpu/tensor/expand.h
@@ -32,10 +32,8 @@ class Expand final : public WebGpuKernel {
 };
 
 // Create Expand kernel info with appropriate type constraints based on int64 support
-template <int StartVersion, int EndVersion>
-KernelCreateInfo CreateExpandVersionedKernelInfo(bool enable_int64);
-template <int SinceVersion>
-KernelCreateInfo CreateExpandKernelInfo(bool enable_int64);
+KernelCreateInfo CreateExpandVersionedKernelInfo(int start_version, int end_version, bool enable_int64);
+KernelCreateInfo CreateExpandKernelInfo(int since_version, bool enable_int64);
 
 }  // namespace webgpu
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/webgpu/tensor/gather.cc
+++ b/onnxruntime/core/providers/webgpu/tensor/gather.cc
@@ -67,15 +67,13 @@ Status GatherProgram::GenerateShaderCode(ShaderHelper& shader) const {
       }
       shader.MainFunctionBody() << "  }\n";
     }
+    shader.MainFunctionBody() << "  " << output.SetByOffset("global_idx", "value");
   } else {
     shader.MainFunctionBody() << "  var idx : input_indices_value_t;\n"
                               << "  var output_indices : output_indices_indices_t;\n"
                               << "  var indices_indices : input_indices_indices_t;\n"
-                              << "  var data_indices : data_indices_indices_t;\n";
-    if (!is_int64_) {
-      shader.MainFunctionBody() << "  var value : output_value_t;\n";
-    }
-    shader.MainFunctionBody() << "  var data_offset : u32;\n";
+                              << "  var data_indices : data_indices_indices_t;\n"
+                              << "  var data_offset : u32;\n";
     shader.MainFunctionBody() << "  output_indices = " << output_indices.OffsetToIndices("global_idx") << ";\n";
 
     for (int i = 0; i < indices.Rank(); i++) {
@@ -98,17 +96,11 @@ Status GatherProgram::GenerateShaderCode(ShaderHelper& shader) const {
     }
 
     shader.MainFunctionBody() << "  data_offset = " << data_indices.IndicesToOffset("data_indices") << ";\n";
-    if (is_int64_) {
-      // int64 is stored as vec2<u32>. Copy the raw storage bits so the full 64-bit value is
-      // preserved; the value-type accessors would truncate it to i32.
-      shader.MainFunctionBody() << "  " << output.SetByOffset("global_idx", data.GetByOffset("data_offset", /*use_storage_type=*/true), /*use_storage_type=*/true);
-    } else {
-      shader.MainFunctionBody() << "  value = " << data.GetByOffset("data_offset") << ";\n";
-    }
-  }
-
-  if (!is_int64_) {
-    shader.MainFunctionBody() << "  " << output.SetByOffset("global_idx", "value");
+    // use_storage_type is only honored for Int64/Uint64 by GetByOffset/SetByOffset; for every
+    // other type it is ignored, so passing is_int64_ directly is equivalent to the plain
+    // value-type access when is_int64_ is false. For int64 it copies the raw vec2<u32> storage
+    // bits so the full 64-bit value is preserved instead of being truncated to i32.
+    shader.MainFunctionBody() << "  " << output.SetByOffset("global_idx", data.GetByOffset("data_offset", is_int64_), is_int64_);
   }
 
   return Status::OK();

--- a/onnxruntime/core/providers/webgpu/tensor/gather.cc
+++ b/onnxruntime/core/providers/webgpu/tensor/gather.cc
@@ -3,6 +3,8 @@
 
 #include "core/providers/webgpu/tensor/gather.h"
 #include "core/providers/webgpu/shader_helper.h"
+#include "core/providers/webgpu/webgpu_execution_provider.h"
+#include "core/providers/webgpu/webgpu_kernel.h"
 #include "core/providers/webgpu/webgpu_supported_types.h"
 
 namespace onnxruntime {
@@ -69,9 +71,11 @@ Status GatherProgram::GenerateShaderCode(ShaderHelper& shader) const {
     shader.MainFunctionBody() << "  var idx : input_indices_value_t;\n"
                               << "  var output_indices : output_indices_indices_t;\n"
                               << "  var indices_indices : input_indices_indices_t;\n"
-                              << "  var data_indices : data_indices_indices_t;\n"
-                              << "  var value : output_value_t;\n"
-                              << "  var data_offset : u32;\n";
+                              << "  var data_indices : data_indices_indices_t;\n";
+    if (!is_int64_) {
+      shader.MainFunctionBody() << "  var value : output_value_t;\n";
+    }
+    shader.MainFunctionBody() << "  var data_offset : u32;\n";
     shader.MainFunctionBody() << "  output_indices = " << output_indices.OffsetToIndices("global_idx") << ";\n";
 
     for (int i = 0; i < indices.Rank(); i++) {
@@ -93,11 +97,19 @@ Status GatherProgram::GenerateShaderCode(ShaderHelper& shader) const {
       }
     }
 
-    shader.MainFunctionBody() << "  data_offset = " << data_indices.IndicesToOffset("data_indices") << ";\n"
-                              << "  value = " << data.GetByOffset("data_offset") << ";\n";
+    shader.MainFunctionBody() << "  data_offset = " << data_indices.IndicesToOffset("data_indices") << ";\n";
+    if (is_int64_) {
+      // int64 is stored as vec2<u32>. Copy the raw storage bits so the full 64-bit value is
+      // preserved; the value-type accessors would truncate it to i32.
+      shader.MainFunctionBody() << "  " << output.SetByOffset("global_idx", data.GetByOffset("data_offset", /*use_storage_type=*/true), /*use_storage_type=*/true);
+    } else {
+      shader.MainFunctionBody() << "  value = " << data.GetByOffset("data_offset") << ";\n";
+    }
   }
 
-  shader.MainFunctionBody() << "  " << output.SetByOffset("global_idx", "value");
+  if (!is_int64_) {
+    shader.MainFunctionBody() << "  " << output.SetByOffset("global_idx", "value");
+  }
 
   return Status::OK();
 }
@@ -118,8 +130,9 @@ Status Gather::ComputeInternal(ComputeContext& context) const {
     data_size = (data_size + 3) / 4;
   }
 
+  bool is_int64 = p.input_tensor->DataType() == DataTypeImpl::GetType<int64_t>();
   uint32_t axis = static_cast<uint32_t>(p.axis);
-  GatherProgram program{axis};
+  GatherProgram program{axis, is_int64};
   program
       .AddInputs({{p.input_tensor, ProgramTensorMetadataDependency::TypeAndRank, ProgramInput::Flatten, (pack_as_bytes ? 4 : 1)},
                   {p.indices_tensor, ProgramTensorMetadataDependency::TypeAndRank}})
@@ -132,21 +145,58 @@ Status Gather::ComputeInternal(ComputeContext& context) const {
   return context.RunProgram(program);
 }
 
-#define WEBGPU_GATHER_KERNEL(OP_TYPE, VERSION, KERNEL_CLASS, TYPE)                                                                              \
-  ONNX_OPERATOR_KERNEL_EX(                                                                                                                      \
-      OP_TYPE, kOnnxDomain, VERSION, kWebGpuExecutionProvider,                                                                                  \
-      KernelDefBuilder().TypeConstraint("T", TYPE).TypeConstraint("Tind", BuildKernelDefConstraintsFromTypeList<TypeList<int32_t, int64_t>>()), \
-      KERNEL_CLASS);
+// Gather is a pure data-movement op: elements are copied, never interpreted in shader arithmetic,
+// so enabling int64 is safe. int64 (stored as vec2<u32>) is copied losslessly via the raw
+// storage-word path in GenerateShaderCode, preserving the full 64-bit value instead of the
+// truncating i32 value type used by arithmetic kernels. The base type set already includes bool and
+// uint8 (packed 4-per-u32), which int64 support leaves untouched.
+static std::vector<MLDataType> GetGatherTypeConstraints(bool enable_int64) {
+  std::vector<MLDataType> type_constraints = WebGpuSupportedNumberBoolAndUint8Types();
+  if (enable_int64) {
+    type_constraints.push_back(DataTypeImpl::GetTensorType<int64_t>());
+  }
+  return type_constraints;
+}
 
-#define WEBGPU_GATHER_VERSIONED_KERNEL(OP_TYPE, VERSION_FROM, VERSION_TO, KERNEL_CLASS, TYPE)                                                   \
-  ONNX_OPERATOR_VERSIONED_KERNEL_EX(                                                                                                            \
-      OP_TYPE, kOnnxDomain, VERSION_FROM, VERSION_TO, kWebGpuExecutionProvider,                                                                 \
-      KernelDefBuilder().TypeConstraint("T", TYPE).TypeConstraint("Tind", BuildKernelDefConstraintsFromTypeList<TypeList<int32_t, int64_t>>()), \
-      KERNEL_CLASS);
+KernelCreateInfo CreateGatherVersionedKernelInfo(int start_version, int end_version, bool enable_int64) {
+  std::vector<MLDataType> type_constraints = GetGatherTypeConstraints(enable_int64);
 
-WEBGPU_GATHER_VERSIONED_KERNEL(Gather, 1, 10, Gather, WebGpuSupportedNumberBoolAndUint8Types())
-WEBGPU_GATHER_VERSIONED_KERNEL(Gather, 11, 12, Gather, WebGpuSupportedNumberBoolAndUint8Types())
-WEBGPU_GATHER_KERNEL(Gather, 13, Gather, WebGpuSupportedNumberBoolAndUint8Types())
+  KernelCreatePtrFn kernel_create_fn = [](FuncManager&, const OpKernelInfo& info, std::unique_ptr<OpKernel>& out) -> Status {
+    out = std::make_unique<Gather>(info);
+    return Status::OK();
+  };
+
+  return {
+      KernelDefBuilder()
+          .SetName("Gather")
+          .SetDomain(kOnnxDomain)
+          .SinceVersion(start_version, end_version)
+          .Provider(kWebGpuExecutionProvider)
+          .TypeConstraint("T", std::move(type_constraints))
+          .TypeConstraint("Tind", BuildKernelDefConstraintsFromTypeList<TypeList<int32_t, int64_t>>())
+          .Build(),
+      kernel_create_fn};
+}
+
+KernelCreateInfo CreateGatherKernelInfo(int since_version, bool enable_int64) {
+  std::vector<MLDataType> type_constraints = GetGatherTypeConstraints(enable_int64);
+
+  KernelCreatePtrFn kernel_create_fn = [](FuncManager&, const OpKernelInfo& info, std::unique_ptr<OpKernel>& out) -> Status {
+    out = std::make_unique<Gather>(info);
+    return Status::OK();
+  };
+
+  return {
+      KernelDefBuilder()
+          .SetName("Gather")
+          .SetDomain(kOnnxDomain)
+          .SinceVersion(since_version)
+          .Provider(kWebGpuExecutionProvider)
+          .TypeConstraint("T", std::move(type_constraints))
+          .TypeConstraint("Tind", BuildKernelDefConstraintsFromTypeList<TypeList<int32_t, int64_t>>())
+          .Build(),
+      kernel_create_fn};
+}
 
 }  // namespace webgpu
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/webgpu/tensor/gather.h
+++ b/onnxruntime/core/providers/webgpu/tensor/gather.h
@@ -12,7 +12,7 @@ namespace webgpu {
 
 class GatherProgram final : public Program<GatherProgram> {
  public:
-  GatherProgram(const uint32_t axis) : Program{"Gather"}, axis_{axis} {}
+  GatherProgram(const uint32_t axis, bool is_int64) : Program{"Gather"}, axis_{axis}, is_int64_{is_int64} {}
 
   Status GenerateShaderCode(ShaderHelper& sh) const override;
 
@@ -21,6 +21,7 @@ class GatherProgram final : public Program<GatherProgram> {
 
  private:
   uint32_t axis_;
+  bool is_int64_;
 };
 
 class Gather final : public WebGpuKernel, public GatherBase {
@@ -30,6 +31,10 @@ class Gather final : public WebGpuKernel, public GatherBase {
  protected:
   Status ComputeInternal(ComputeContext& context) const override;
 };
+
+// Create Gather kernel info with appropriate type constraints based on int64 support
+KernelCreateInfo CreateGatherVersionedKernelInfo(int start_version, int end_version, bool enable_int64);
+KernelCreateInfo CreateGatherKernelInfo(int since_version, bool enable_int64);
 
 }  // namespace webgpu
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/webgpu/tensor/reshape.cc
+++ b/onnxruntime/core/providers/webgpu/tensor/reshape.cc
@@ -8,8 +8,7 @@
 namespace onnxruntime {
 namespace webgpu {
 
-template <int StartVersion, int EndVersion>
-KernelCreateInfo CreateReshapeVersionedKernelInfo(bool enable_int64) {
+KernelCreateInfo CreateReshapeVersionedKernelInfo(int start_version, int end_version, bool enable_int64) {
   // Reshape is a pure copy/view op. Enabling int64 and uint8 are safe because element values
   // are never interpreted or used in shader arithmetic.
   std::vector<MLDataType> type_constraints = GetOpTypeConstraints(enable_int64, true);
@@ -24,7 +23,7 @@ KernelCreateInfo CreateReshapeVersionedKernelInfo(bool enable_int64) {
       KernelDefBuilder()
           .SetName("Reshape")
           .SetDomain(kOnnxDomain)
-          .SinceVersion(StartVersion, EndVersion)
+          .SinceVersion(start_version, end_version)
           .Provider(kWebGpuExecutionProvider)
           .TypeConstraint("T", std::move(type_constraints))
           .TypeConstraint("shape", DataTypeImpl::GetTensorType<int64_t>())
@@ -34,8 +33,7 @@ KernelCreateInfo CreateReshapeVersionedKernelInfo(bool enable_int64) {
       kernel_create_fn};
 }
 
-template <int SinceVersion>
-KernelCreateInfo CreateReshapeKernelInfo(bool enable_int64) {
+KernelCreateInfo CreateReshapeKernelInfo(int since_version, bool enable_int64) {
   // Reshape is a pure copy/view op. Enabling int64 and uint8 are safe because element values
   // are never interpreted or used in shader arithmetic.
   std::vector<MLDataType> type_constraints = GetOpTypeConstraints(enable_int64, true);
@@ -50,7 +48,7 @@ KernelCreateInfo CreateReshapeKernelInfo(bool enable_int64) {
       KernelDefBuilder()
           .SetName("Reshape")
           .SetDomain(kOnnxDomain)
-          .SinceVersion(SinceVersion)
+          .SinceVersion(since_version)
           .Provider(kWebGpuExecutionProvider)
           .TypeConstraint("T", std::move(type_constraints))
           .TypeConstraint("shape", DataTypeImpl::GetTensorType<int64_t>())
@@ -59,15 +57,6 @@ KernelCreateInfo CreateReshapeKernelInfo(bool enable_int64) {
           .Build(),
       kernel_create_fn};
 }
-
-// Explicit template instantiations
-template KernelCreateInfo CreateReshapeVersionedKernelInfo<5, 12>(bool);
-template KernelCreateInfo CreateReshapeVersionedKernelInfo<13, 13>(bool);
-template KernelCreateInfo CreateReshapeVersionedKernelInfo<14, 18>(bool);
-template KernelCreateInfo CreateReshapeVersionedKernelInfo<19, 20>(bool);
-template KernelCreateInfo CreateReshapeVersionedKernelInfo<21, 22>(bool);
-template KernelCreateInfo CreateReshapeVersionedKernelInfo<23, 24>(bool);
-template KernelCreateInfo CreateReshapeKernelInfo<25>(bool);
 
 }  // namespace webgpu
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/webgpu/tensor/reshape.h
+++ b/onnxruntime/core/providers/webgpu/tensor/reshape.h
@@ -48,10 +48,8 @@ class Reshape final : public OpKernel {
 };
 
 // Create Reshape kernel info with appropriate type constraints based on int64 support
-template <int StartVersion, int EndVersion>
-KernelCreateInfo CreateReshapeVersionedKernelInfo(bool enable_int64);
-template <int SinceVersion>
-KernelCreateInfo CreateReshapeKernelInfo(bool enable_int64);
+KernelCreateInfo CreateReshapeVersionedKernelInfo(int start_version, int end_version, bool enable_int64);
+KernelCreateInfo CreateReshapeKernelInfo(int since_version, bool enable_int64);
 
 }  // namespace webgpu
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/webgpu/tensor/tile.cc
+++ b/onnxruntime/core/providers/webgpu/tensor/tile.cc
@@ -137,8 +137,7 @@ Status Tile::ComputeInternal(ComputeContext& context) const {
   return context.RunProgram(program);
 }
 
-template <int StartVersion, int EndVersion>
-KernelCreateInfo CreateTileVersionedKernelInfo(bool enable_int64) {
+KernelCreateInfo CreateTileVersionedKernelInfo(int start_version, int end_version, bool enable_int64) {
   const auto& type_constraints = GetOpTypeConstraints(enable_int64, /*enable_bool=*/false);
 
   KernelCreatePtrFn kernel_create_fn = [](FuncManager&, const OpKernelInfo& info, std::unique_ptr<OpKernel>& out) -> Status {
@@ -150,7 +149,7 @@ KernelCreateInfo CreateTileVersionedKernelInfo(bool enable_int64) {
       KernelDefBuilder()
           .SetName("Tile")
           .SetDomain(kOnnxDomain)
-          .SinceVersion(StartVersion, EndVersion)
+          .SinceVersion(start_version, end_version)
           .Provider(kWebGpuExecutionProvider)
           .TypeConstraint("T", type_constraints)
           .InputMemoryType(OrtMemTypeCPU, 1)
@@ -158,8 +157,7 @@ KernelCreateInfo CreateTileVersionedKernelInfo(bool enable_int64) {
       kernel_create_fn};
 }
 
-template <int SinceVersion>
-KernelCreateInfo CreateTileKernelInfo(bool enable_int64) {
+KernelCreateInfo CreateTileKernelInfo(int since_version, bool enable_int64) {
   const auto& type_constraints = GetOpTypeConstraints(enable_int64, /*enable_bool=*/false);
 
   KernelCreatePtrFn kernel_create_fn = [](FuncManager&, const OpKernelInfo& info, std::unique_ptr<OpKernel>& out) -> Status {
@@ -171,17 +169,13 @@ KernelCreateInfo CreateTileKernelInfo(bool enable_int64) {
       KernelDefBuilder()
           .SetName("Tile")
           .SetDomain(kOnnxDomain)
-          .SinceVersion(SinceVersion)
+          .SinceVersion(since_version)
           .Provider(kWebGpuExecutionProvider)
           .TypeConstraint("T", type_constraints)
           .InputMemoryType(OrtMemTypeCPU, 1)
           .Build(),
       kernel_create_fn};
 }
-
-// Explicit template instantiations
-template KernelCreateInfo CreateTileVersionedKernelInfo<6, 12>(bool);
-template KernelCreateInfo CreateTileKernelInfo<13>(bool);
 
 }  // namespace webgpu
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/webgpu/tensor/tile.h
+++ b/onnxruntime/core/providers/webgpu/tensor/tile.h
@@ -32,10 +32,8 @@ class Tile final : public WebGpuKernel {
 // Create Tile kernel info with appropriate type constraints based on int64 support.
 // Tile is a pure data-movement op; int64 is safe because element values are never
 // interpreted or used in shader arithmetic.
-template <int StartVersion, int EndVersion>
-KernelCreateInfo CreateTileVersionedKernelInfo(bool enable_int64);
-template <int SinceVersion>
-KernelCreateInfo CreateTileKernelInfo(bool enable_int64);
+KernelCreateInfo CreateTileVersionedKernelInfo(int start_version, int end_version, bool enable_int64);
+KernelCreateInfo CreateTileKernelInfo(int since_version, bool enable_int64);
 
 }  // namespace webgpu
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/webgpu/tensor/unsqueeze.cc
+++ b/onnxruntime/core/providers/webgpu/tensor/unsqueeze.cc
@@ -8,8 +8,7 @@
 namespace onnxruntime {
 namespace webgpu {
 
-template <int StartVersion, int EndVersion>
-KernelCreateInfo CreateUnsqueezeVersionedKernelInfo(bool enable_int64) {
+KernelCreateInfo CreateUnsqueezeVersionedKernelInfo(int start_version, int end_version, bool enable_int64) {
   const auto& type_constraints = GetOpTypeConstraints(enable_int64, true);
 
   KernelCreatePtrFn kernel_create_fn = [](FuncManager&, const OpKernelInfo& info, std::unique_ptr<OpKernel>& out) -> Status {
@@ -17,12 +16,12 @@ KernelCreateInfo CreateUnsqueezeVersionedKernelInfo(bool enable_int64) {
     return Status::OK();
   };
 
-  if constexpr (StartVersion >= 13) {
+  if (start_version >= 13) {
     return {
         KernelDefBuilder()
             .SetName("Unsqueeze")
             .SetDomain(kOnnxDomain)
-            .SinceVersion(StartVersion, EndVersion)
+            .SinceVersion(start_version, end_version)
             .Provider(kWebGpuExecutionProvider)
             .TypeConstraint("T", type_constraints)
             .Alias(0, 0)
@@ -34,7 +33,7 @@ KernelCreateInfo CreateUnsqueezeVersionedKernelInfo(bool enable_int64) {
         KernelDefBuilder()
             .SetName("Unsqueeze")
             .SetDomain(kOnnxDomain)
-            .SinceVersion(StartVersion, EndVersion)
+            .SinceVersion(start_version, end_version)
             .Provider(kWebGpuExecutionProvider)
             .TypeConstraint("T", type_constraints)
             .Alias(0, 0)
@@ -43,8 +42,7 @@ KernelCreateInfo CreateUnsqueezeVersionedKernelInfo(bool enable_int64) {
   }
 }
 
-template <int SinceVersion>
-KernelCreateInfo CreateUnsqueezeKernelInfo(bool enable_int64) {
+KernelCreateInfo CreateUnsqueezeKernelInfo(int since_version, bool enable_int64) {
   const auto& type_constraints = GetOpTypeConstraints(enable_int64, true);
 
   KernelCreatePtrFn kernel_create_fn = [](FuncManager&, const OpKernelInfo& info, std::unique_ptr<OpKernel>& out) -> Status {
@@ -56,7 +54,7 @@ KernelCreateInfo CreateUnsqueezeKernelInfo(bool enable_int64) {
       KernelDefBuilder()
           .SetName("Unsqueeze")
           .SetDomain(kOnnxDomain)
-          .SinceVersion(SinceVersion)
+          .SinceVersion(since_version)
           .Provider(kWebGpuExecutionProvider)
           .TypeConstraint("T", type_constraints)
           .Alias(0, 0)
@@ -64,15 +62,6 @@ KernelCreateInfo CreateUnsqueezeKernelInfo(bool enable_int64) {
           .Build(),
       kernel_create_fn};
 }
-
-// Explicit template instantiations
-template KernelCreateInfo CreateUnsqueezeVersionedKernelInfo<1, 10>(bool);
-template KernelCreateInfo CreateUnsqueezeVersionedKernelInfo<11, 12>(bool);
-template KernelCreateInfo CreateUnsqueezeVersionedKernelInfo<13, 20>(bool);
-template KernelCreateInfo CreateUnsqueezeVersionedKernelInfo<21, 22>(bool);
-template KernelCreateInfo CreateUnsqueezeVersionedKernelInfo<23, 23>(bool);
-template KernelCreateInfo CreateUnsqueezeVersionedKernelInfo<24, 24>(bool);
-template KernelCreateInfo CreateUnsqueezeKernelInfo<25>(bool);
 
 }  // namespace webgpu
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/webgpu/tensor/unsqueeze.h
+++ b/onnxruntime/core/providers/webgpu/tensor/unsqueeze.h
@@ -49,10 +49,8 @@ class Unsqueeze final : public OpKernel, public UnsqueezeBase {
 };
 
 // Create Unsqueeze kernel info with appropriate type constraints based on int64 support
-template <int StartVersion, int EndVersion>
-KernelCreateInfo CreateUnsqueezeVersionedKernelInfo(bool enable_int64);
-template <int SinceVersion>
-KernelCreateInfo CreateUnsqueezeKernelInfo(bool enable_int64);
+KernelCreateInfo CreateUnsqueezeVersionedKernelInfo(int start_version, int end_version, bool enable_int64);
+KernelCreateInfo CreateUnsqueezeKernelInfo(int since_version, bool enable_int64);
 
 }  // namespace webgpu
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/webgpu/tensor/where.cc
+++ b/onnxruntime/core/providers/webgpu/tensor/where.cc
@@ -185,8 +185,7 @@ Status Where::ComputeInternal(ComputeContext& context) const {
   return context.RunProgram(program);
 }
 
-template <int StartVersion, int EndVersion>
-KernelCreateInfo CreateWhereVersionedKernelInfo(bool enable_int64) {
+KernelCreateInfo CreateWhereVersionedKernelInfo(int start_version, int end_version, bool enable_int64) {
   const auto& type_constraints = GetOpTypeConstraints(enable_int64, /*enable_bool=*/true);
   KernelCreatePtrFn kernel_create_fn = [](FuncManager&, const OpKernelInfo& info, std::unique_ptr<OpKernel>& out) -> Status {
     out = std::make_unique<Where>(info);
@@ -195,15 +194,14 @@ KernelCreateInfo CreateWhereVersionedKernelInfo(bool enable_int64) {
   return {KernelDefBuilder()
               .SetName("Where")
               .SetDomain(kOnnxDomain)
-              .SinceVersion(StartVersion, EndVersion)
+              .SinceVersion(start_version, end_version)
               .Provider(kWebGpuExecutionProvider)
               .TypeConstraint("T", type_constraints)
               .Build(),
           kernel_create_fn};
 }
 
-template <int SinceVersion>
-KernelCreateInfo CreateWhereKernelInfo(bool enable_int64) {
+KernelCreateInfo CreateWhereKernelInfo(int since_version, bool enable_int64) {
   const auto& type_constraints = GetOpTypeConstraints(enable_int64, /*enable_bool=*/true);
   KernelCreatePtrFn kernel_create_fn = [](FuncManager&, const OpKernelInfo& info, std::unique_ptr<OpKernel>& out) -> Status {
     out = std::make_unique<Where>(info);
@@ -212,15 +210,12 @@ KernelCreateInfo CreateWhereKernelInfo(bool enable_int64) {
   return {KernelDefBuilder()
               .SetName("Where")
               .SetDomain(kOnnxDomain)
-              .SinceVersion(SinceVersion)
+              .SinceVersion(since_version)
               .Provider(kWebGpuExecutionProvider)
               .TypeConstraint("T", type_constraints)
               .Build(),
           kernel_create_fn};
 }
-
-template KernelCreateInfo CreateWhereVersionedKernelInfo<9, 15>(bool);
-template KernelCreateInfo CreateWhereKernelInfo<16>(bool);
 
 }  // namespace webgpu
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/webgpu/tensor/where.h
+++ b/onnxruntime/core/providers/webgpu/tensor/where.h
@@ -33,10 +33,8 @@ class Where final : public WebGpuKernel {
 };
 
 // Factory functions for conditional int64 support (registered via RegisterKernels).
-template <int StartVersion, int EndVersion>
-KernelCreateInfo CreateWhereVersionedKernelInfo(bool enable_int64);
-template <int SinceVersion>
-KernelCreateInfo CreateWhereKernelInfo(bool enable_int64);
+KernelCreateInfo CreateWhereVersionedKernelInfo(int start_version, int end_version, bool enable_int64);
+KernelCreateInfo CreateWhereKernelInfo(int since_version, bool enable_int64);
 
 }  // namespace webgpu
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
@@ -446,13 +446,14 @@ std::unique_ptr<KernelRegistry> RegisterKernels(bool enable_graph_capture, bool 
   }
 
   // Register Cast kernels with conditional int64 support
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateCastKernelInfo(6, 8, enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateCastKernelInfo(9, 12, enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateCastKernelInfo(13, 18, enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateCastKernelInfo(19, 20, enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateCastKernelInfo(21, 22, enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateCastKernelInfo(23, 23, enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateCastKernelInfo(24, 24, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateCastVersionedKernelInfo(6, 8, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateCastVersionedKernelInfo(9, 12, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateCastVersionedKernelInfo(13, 18, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateCastVersionedKernelInfo(19, 20, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateCastVersionedKernelInfo(21, 22, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateCastVersionedKernelInfo(23, 23, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateCastVersionedKernelInfo(24, 24, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateCastKernelInfo(25, enable_int64)));
 
   // Register int64 Clip kernels with conditional int64 support
   RegisterClipInt64Kernels(*kernel_registry, enable_int64);

--- a/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
@@ -32,6 +32,7 @@
 #include "core/providers/webgpu/tensor/cast.h"
 #include "core/providers/webgpu/tensor/concat.h"
 #include "core/providers/webgpu/tensor/expand.h"
+#include "core/providers/webgpu/tensor/gather.h"
 #include "core/providers/webgpu/tensor/grid_sample.h"
 #include "core/providers/webgpu/tensor/reshape.h"
 #include "core/providers/webgpu/generator/range.h"
@@ -326,9 +327,7 @@ static const BuildKernelCreateInfoFn build_kernel_create_info_function_table[] =
     BuildKernelCreateInfo<class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 13, 17, Split)>,
     BuildKernelCreateInfo<class ONNX_OPERATOR_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 18, Split)>,
 
-    BuildKernelCreateInfo<class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 1, 10, Gather)>,
-    BuildKernelCreateInfo<class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 11, 12, Gather)>,
-    BuildKernelCreateInfo<class ONNX_OPERATOR_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 13, Gather)>,
+    // Gather: registered via RegisterKernels with conditional int64 support
 
     BuildKernelCreateInfo<class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 11, 12, GatherElements)>,
     BuildKernelCreateInfo<class ONNX_OPERATOR_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 13, GatherElements)>,
@@ -447,13 +446,13 @@ std::unique_ptr<KernelRegistry> RegisterKernels(bool enable_graph_capture, bool 
   }
 
   // Register Cast kernels with conditional int64 support
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateCastKernelInfo<6, 8>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateCastKernelInfo<9, 12>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateCastKernelInfo<13, 18>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateCastKernelInfo<19, 20>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateCastKernelInfo<21, 22>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateCastKernelInfo<23, 23>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateCastKernelInfo<24>(enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateCastKernelInfo(6, 8, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateCastKernelInfo(9, 12, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateCastKernelInfo(13, 18, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateCastKernelInfo(19, 20, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateCastKernelInfo(21, 22, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateCastKernelInfo(23, 23, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateCastKernelInfo(24, 24, enable_int64)));
 
   // Register int64 Clip kernels with conditional int64 support
   RegisterClipInt64Kernels(*kernel_registry, enable_int64);
@@ -462,51 +461,56 @@ std::unique_ptr<KernelRegistry> RegisterKernels(bool enable_graph_capture, bool 
   RegisterRangeKernels(*kernel_registry, enable_int64);
 
   // Register Unsqueeze kernels with conditional int64 support
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateUnsqueezeVersionedKernelInfo<1, 10>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateUnsqueezeVersionedKernelInfo<11, 12>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateUnsqueezeVersionedKernelInfo<13, 20>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateUnsqueezeVersionedKernelInfo<21, 22>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateUnsqueezeVersionedKernelInfo<23, 23>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateUnsqueezeVersionedKernelInfo<24, 24>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateUnsqueezeKernelInfo<25>(enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateUnsqueezeVersionedKernelInfo(1, 10, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateUnsqueezeVersionedKernelInfo(11, 12, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateUnsqueezeVersionedKernelInfo(13, 20, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateUnsqueezeVersionedKernelInfo(21, 22, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateUnsqueezeVersionedKernelInfo(23, 23, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateUnsqueezeVersionedKernelInfo(24, 24, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateUnsqueezeKernelInfo(25, enable_int64)));
 
   // Register Expand kernels with conditional int64 support
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateExpandVersionedKernelInfo<8, 12>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateExpandKernelInfo<13>(enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateExpandVersionedKernelInfo(8, 12, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateExpandKernelInfo(13, enable_int64)));
 
   // Register all binary elementwise kernels (Add, Sub, Mul, Div, Max, Min, Equal, Greater,
   // Less, GreaterOrEqual, LessOrEqual, Pow, PRelu, And) with conditional int64 support.
   RegisterBinaryElementwiseKernels(*kernel_registry, enable_int64);
 
   // Register Reshape kernels with conditional int64 support
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateReshapeVersionedKernelInfo<5, 12>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateReshapeVersionedKernelInfo<13, 13>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateReshapeVersionedKernelInfo<14, 18>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateReshapeVersionedKernelInfo<19, 20>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateReshapeVersionedKernelInfo<21, 22>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateReshapeVersionedKernelInfo<23, 24>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateReshapeKernelInfo<25>(enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateReshapeVersionedKernelInfo(5, 12, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateReshapeVersionedKernelInfo(13, 13, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateReshapeVersionedKernelInfo(14, 18, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateReshapeVersionedKernelInfo(19, 20, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateReshapeVersionedKernelInfo(21, 22, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateReshapeVersionedKernelInfo(23, 24, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateReshapeKernelInfo(25, enable_int64)));
 
   // Register Concat kernels with conditional int64 support
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateConcatVersionedKernelInfo<1, 3>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateConcatVersionedKernelInfo<4, 10>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateConcatVersionedKernelInfo<11, 12>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateConcatKernelInfo<13>(enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateConcatVersionedKernelInfo(1, 3, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateConcatVersionedKernelInfo(4, 10, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateConcatVersionedKernelInfo(11, 12, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateConcatKernelInfo(13, enable_int64)));
+
+  // Register Gather kernels with conditional int64 support
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateGatherVersionedKernelInfo(1, 10, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateGatherVersionedKernelInfo(11, 12, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateGatherKernelInfo(13, enable_int64)));
 
   // Register Where kernels with conditional int64 support
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateWhereVersionedKernelInfo<9, 15>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateWhereKernelInfo<16>(enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateWhereVersionedKernelInfo(9, 15, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateWhereKernelInfo(16, enable_int64)));
 
   // Register Tile kernels with conditional int64 support.
   // Tile is a pure data-movement op; int64 is safe because element values are never
   // interpreted or used in shader arithmetic.
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateTileVersionedKernelInfo<6, 12>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateTileKernelInfo<13>(enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateTileVersionedKernelInfo(6, 12, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateTileKernelInfo(13, enable_int64)));
 
   // Register ReduceSum kernels with conditional int64 support
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateReduceSumVersionedKernelInfo<1, 10>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateReduceSumVersionedKernelInfo<11, 12>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateReduceSumKernelInfo<13>(enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateReduceSumVersionedKernelInfo(1, 10, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateReduceSumVersionedKernelInfo(11, 12, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateReduceSumKernelInfo(13, enable_int64)));
 
 #ifndef DISABLE_CONTRIB_OPS
   Status status = ::onnxruntime::contrib::webgpu::RegisterWebGpuContribKernels(*kernel_registry, enable_graph_capture);

--- a/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
@@ -32,6 +32,7 @@
 #include "core/providers/webgpu/tensor/cast.h"
 #include "core/providers/webgpu/tensor/concat.h"
 #include "core/providers/webgpu/tensor/expand.h"
+#include "core/providers/webgpu/tensor/gather.h"
 #include "core/providers/webgpu/tensor/grid_sample.h"
 #include "core/providers/webgpu/tensor/reshape.h"
 #include "core/providers/webgpu/generator/range.h"
@@ -356,9 +357,7 @@ static const BuildKernelCreateInfoFn build_kernel_create_info_function_table[] =
     BuildKernelCreateInfo<class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 13, 17, Split)>,
     BuildKernelCreateInfo<class ONNX_OPERATOR_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 18, Split)>,
 
-    BuildKernelCreateInfo<class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 1, 10, Gather)>,
-    BuildKernelCreateInfo<class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 11, 12, Gather)>,
-    BuildKernelCreateInfo<class ONNX_OPERATOR_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 13, Gather)>,
+    // Gather: registered via RegisterKernels with conditional int64 support
 
     BuildKernelCreateInfo<class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 11, 12, GatherElements)>,
     BuildKernelCreateInfo<class ONNX_OPERATOR_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 13, GatherElements)>,
@@ -477,13 +476,13 @@ std::unique_ptr<KernelRegistry> RegisterKernels(bool enable_graph_capture, bool 
   }
 
   // Register Cast kernels with conditional int64 support
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateCastKernelInfo<6, 8>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateCastKernelInfo<9, 12>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateCastKernelInfo<13, 18>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateCastKernelInfo<19, 20>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateCastKernelInfo<21, 22>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateCastKernelInfo<23, 23>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateCastKernelInfo<24>(enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateCastKernelInfo(6, 8, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateCastKernelInfo(9, 12, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateCastKernelInfo(13, 18, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateCastKernelInfo(19, 20, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateCastKernelInfo(21, 22, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateCastKernelInfo(23, 23, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateCastKernelInfo(24, 24, enable_int64)));
 
   // Register int64 Clip kernels with conditional int64 support
   RegisterClipInt64Kernels(*kernel_registry, enable_int64);
@@ -492,63 +491,68 @@ std::unique_ptr<KernelRegistry> RegisterKernels(bool enable_graph_capture, bool 
   RegisterRangeKernels(*kernel_registry, enable_int64);
 
   // Register Unsqueeze kernels with conditional int64 support
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateUnsqueezeVersionedKernelInfo<1, 10>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateUnsqueezeVersionedKernelInfo<11, 12>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateUnsqueezeVersionedKernelInfo<13, 20>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateUnsqueezeVersionedKernelInfo<21, 22>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateUnsqueezeVersionedKernelInfo<23, 23>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateUnsqueezeVersionedKernelInfo<24, 24>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateUnsqueezeKernelInfo<25>(enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateUnsqueezeVersionedKernelInfo(1, 10, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateUnsqueezeVersionedKernelInfo(11, 12, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateUnsqueezeVersionedKernelInfo(13, 20, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateUnsqueezeVersionedKernelInfo(21, 22, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateUnsqueezeVersionedKernelInfo(23, 23, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateUnsqueezeVersionedKernelInfo(24, 24, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateUnsqueezeKernelInfo(25, enable_int64)));
 
   // Register Expand kernels with conditional int64 support
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateExpandVersionedKernelInfo<8, 12>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateExpandKernelInfo<13>(enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateExpandVersionedKernelInfo(8, 12, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateExpandKernelInfo(13, enable_int64)));
 
   // Register Add kernels with conditional int64 support
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateAddVersionedKernelInfo<7, 12>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateAddVersionedKernelInfo<13, 13>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateAddKernelInfo<14>(enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateAddVersionedKernelInfo(7, 12, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateAddVersionedKernelInfo(13, 13, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateAddKernelInfo(14, enable_int64)));
 
   // Register Reshape kernels with conditional int64 support
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateReshapeVersionedKernelInfo<5, 12>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateReshapeVersionedKernelInfo<13, 13>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateReshapeVersionedKernelInfo<14, 18>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateReshapeVersionedKernelInfo<19, 20>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateReshapeVersionedKernelInfo<21, 22>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateReshapeVersionedKernelInfo<23, 24>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateReshapeKernelInfo<25>(enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateReshapeVersionedKernelInfo(5, 12, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateReshapeVersionedKernelInfo(13, 13, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateReshapeVersionedKernelInfo(14, 18, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateReshapeVersionedKernelInfo(19, 20, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateReshapeVersionedKernelInfo(21, 22, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateReshapeVersionedKernelInfo(23, 24, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateReshapeKernelInfo(25, enable_int64)));
 
   // Register Concat kernels with conditional int64 support
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateConcatVersionedKernelInfo<1, 3>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateConcatVersionedKernelInfo<4, 10>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateConcatVersionedKernelInfo<11, 12>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateConcatKernelInfo<13>(enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateConcatVersionedKernelInfo(1, 3, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateConcatVersionedKernelInfo(4, 10, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateConcatVersionedKernelInfo(11, 12, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateConcatKernelInfo(13, enable_int64)));
+
+  // Register Gather kernels with conditional int64 support
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateGatherVersionedKernelInfo(1, 10, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateGatherVersionedKernelInfo(11, 12, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateGatherKernelInfo(13, enable_int64)));
 
   // Register Equal kernels with conditional int64 support
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateEqualVersionedKernelInfo<7, 10>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateEqualVersionedKernelInfo<11, 12>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateEqualVersionedKernelInfo<13, 18>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateEqualKernelInfo<19>(enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateEqualVersionedKernelInfo(7, 10, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateEqualVersionedKernelInfo(11, 12, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateEqualVersionedKernelInfo(13, 18, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateEqualKernelInfo(19, enable_int64)));
 
   // Register Sub kernels with conditional int64 support
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateSubVersionedKernelInfo<7, 12>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateSubVersionedKernelInfo<13, 13>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateSubKernelInfo<14>(enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateSubVersionedKernelInfo(7, 12, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateSubVersionedKernelInfo(13, 13, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateSubKernelInfo(14, enable_int64)));
 
   // Register Where kernels with conditional int64 support
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateWhereVersionedKernelInfo<9, 15>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateWhereKernelInfo<16>(enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateWhereVersionedKernelInfo(9, 15, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateWhereKernelInfo(16, enable_int64)));
 
   // Register Tile kernels with conditional int64 support.
   // Tile is a pure data-movement op; int64 is safe because element values are never
   // interpreted or used in shader arithmetic.
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateTileVersionedKernelInfo<6, 12>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateTileKernelInfo<13>(enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateTileVersionedKernelInfo(6, 12, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateTileKernelInfo(13, enable_int64)));
 
   // Register ReduceSum kernels with conditional int64 support
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateReduceSumVersionedKernelInfo<1, 10>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateReduceSumVersionedKernelInfo<11, 12>(enable_int64)));
-  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateReduceSumKernelInfo<13>(enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateReduceSumVersionedKernelInfo(1, 10, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateReduceSumVersionedKernelInfo(11, 12, enable_int64)));
+  ORT_THROW_IF_ERROR(kernel_registry->Register(CreateReduceSumKernelInfo(13, enable_int64)));
 
 #ifndef DISABLE_CONTRIB_OPS
   Status status = ::onnxruntime::contrib::webgpu::RegisterWebGpuContribKernels(*kernel_registry, enable_graph_capture);

--- a/onnxruntime/test/providers/cpu/tensor/gather_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/gather_op_test.cc
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include "core/session/onnxruntime_session_options_config_keys.h"
 #include "gtest/gtest.h"
 #ifdef USE_WEBGPU
 #include "core/providers/webgpu/webgpu_provider_options.h"
-#include "core/session/onnxruntime_session_options_config_keys.h"
 #endif
 #include "test/providers/provider_test_utils.h"
 #include "test/util/include/default_providers.h"

--- a/onnxruntime/test/providers/cpu/tensor/gather_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/gather_op_test.cc
@@ -1,8 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include "core/session/onnxruntime_session_options_config_keys.h"
 #include "gtest/gtest.h"
+#ifdef USE_WEBGPU
+#include "core/providers/webgpu/webgpu_provider_options.h"
+#include "core/session/onnxruntime_session_options_config_keys.h"
+#endif
 #include "test/providers/provider_test_utils.h"
 #include "test/util/include/default_providers.h"
 #include "test/common/tensor_op_test_utils.h"
@@ -474,6 +477,37 @@ TEST(GatherOpTest, Gather_axis0_uint8_non_multiple_of_4_webgpu) {
   std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
   execution_providers.push_back(DefaultWebGpuExecutionProvider());
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+}
+
+// int64 Gather is gated behind the enableInt64 provider option. Disable CPU-EP fallback so the
+// Gather node must run on the WebGPU kernel, and include values outside the int32 range (2^32,
+// 2^33+1, a large negative, INT64_MAX) to prove the full 64-bit value is preserved via a raw
+// vec2<u32> storage copy rather than truncated to i32.
+TEST(GatherOpTest, Gather_int64_webgpu) {
+  ConfigOptions provider_options{};
+  ASSERT_STATUS_OK(provider_options.AddConfigEntry(webgpu::options::kEnableInt64, "1"));
+  auto provider = WebGpuExecutionProviderWithOptions(provider_options);
+  if (provider == nullptr) {
+    GTEST_SKIP() << "WebGPU EP is not available";
+  }
+
+  OpTester test("Gather");
+  test.AddAttribute<int64_t>("axis", 0LL);
+  test.AddInput<int64_t>("data", {3, 2},
+                         {1, 4294967296,                 // 1, 2^32
+                          8589934593, -4294967297,       // 2^33+1, -(2^32+1)
+                          100, 9223372036854775807LL});  // 100, INT64_MAX
+  test.AddInput<int32_t>("indices", {2}, {2, 0});
+  test.AddOutput<int64_t>("output", {2, 2},
+                          {100, 9223372036854775807LL,
+                           1, 4294967296});
+
+  // Disable CPU-EP fallback so the Gather node must run on the WebGPU kernel.
+  SessionOptions so;
+  ASSERT_STATUS_OK(so.config_options.AddConfigEntry(kOrtSessionOptionsDisableCPUEPFallback, "1"));
+  test.Config(so)
+      .ConfigEp(std::move(provider))
+      .RunWithConfig();
 }
 #endif  // USE_WEBGPU
 


### PR DESCRIPTION
Gather is a pure data-movement op (elements are copied, never interpreted in shader arithmetic), so int64 can be supported safely. int64 (stored as vec2<u32>) is copied losslessly via the raw storage-word path, preserving the full 64-bit value instead of the truncating i32 value type used by arithmetic kernels. int64 is only added to the "T" constraint when the enable_int64 provider option is set.

This PR also refactor the int64-migrated kernels' factory functions to take the version range as runtime function parameters instead of template parameters (StartVersion/EndVersion). This removes the explicit template instantiations (reducing binary size) and eliminates the duplication of version ranges between the instantiations and the registrations in webgpu_execution_provider.cc; the ranges now live only at the registration site. (This is a follow up fix of #31049 )


