### PR TITLE
fix: normalize binary package CMake paths

### DIFF
--- a/tools/ci_build/github/linux/copy_strip_binary.sh
+++ b/tools/ci_build/github/linux/copy_strip_binary.sh
@@ -15,6 +15,20 @@ done
 
 EXIT_CODE=1
 
+fix_exported_cmake_package_paths() {
+    local package_dir=$1
+    local cmake_dir="$package_dir/lib/cmake"
+
+    if [[ ! -d "$cmake_dir" ]]
+    then
+        return
+    fi
+
+    find "$cmake_dir" -type f -name "*.cmake" -print0 | xargs -0 -r sed -i \
+        -e 's#${_IMPORT_PREFIX}/include/onnxruntime#${_IMPORT_PREFIX}/include#g' \
+        -e 's#${_IMPORT_PREFIX}/lib64/#${_IMPORT_PREFIX}/lib/#g'
+}
+
 uname -a
 cd "$BINARY_DIR"
 mv installed/usr/local $ARTIFACT_NAME
@@ -44,6 +58,8 @@ else
    # Linux
    mv $ARTIFACT_NAME/lib64 $ARTIFACT_NAME/lib
 fi
+
+fix_exported_cmake_package_paths "$BINARY_DIR/$ARTIFACT_NAME"
 
 # copy the README, licence and TPN
 cp $SOURCE_DIR/README.md $BINARY_DIR/$ARTIFACT_NAME/README.md


### PR DESCRIPTION
## Summary
- Update Linux binary package post-processing to rewrite exported CMake package paths after flattening headers and moving `lib64` to `lib`.
- Keep `onnxruntimeTargets.cmake` aligned with the shipped archive layout so `find_package(onnxruntime)` does not reference missing include/lib64 paths.

Fixes #25242
Fixes #25279

## Test Plan
- Hermetic fake installed package repro through `tools/ci_build/github/linux/copy_strip_binary.sh`; verified exported CMake file rewrites `${_IMPORT_PREFIX}/include/onnxruntime` to `${_IMPORT_PREFIX}/include` and `${_IMPORT_PREFIX}/lib64/` to `${_IMPORT_PREFIX}/lib/`
- `bash -n tools/ci_build/github/linux/copy_strip_binary.sh`
- `git diff --check`
- diff secret/conflict/debug scan