### PR TITLE
build: avoid GCC 15 array-bounds false positive failures

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -751,6 +751,12 @@ else()
     # Specifically, the code was tuned based on the build machine's CPU cache line size, which can vary a lot.
     list(APPEND ORT_WARNING_FLAGS -Wno-interference-size)
   endif()
+  if(HAS_ARRAY_BOUNDS AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 15)
+    # GCC 15+ can emit false positive -Warray-bounds diagnostics for Eigen vectorized half conversions when
+    # distro builds add CPU-specific flags such as -march=broadwell. Keep the diagnostic enabled, but do not
+    # promote those system-header warnings to errors under ORT's global -Werror policy.
+    list(APPEND ORT_WARNING_FLAGS -Wno-error=array-bounds)
+  endif()
   # enable warning(s) that may not be on by default
   if (HAS_SHORTEN_64_TO_32)
     list(APPEND ORT_WARNING_FLAGS -Wshorten-64-to-32)


### PR DESCRIPTION
## Summary
- For GNU C++ compilers 15 and newer, keep `-Warray-bounds` enabled but do not promote it to an error.
- This avoids Fedora/GCC 15+ builds failing under ORT global `-Werror` on Eigen vectorized half conversion false positives when CPU-specific flags such as `-march=broadwell` are used.

Fixes #29664

## Test Plan
- Downloaded the issue build log and confirmed the failure is GCC 15/16 `-Werror=array-bounds` from Eigen half vectorization with `-march=broadwell`
- Static CMake check for the existing `HAS_ARRAY_BOUNDS` probe, GNU 15+ guard, and `-Wno-error=array-bounds` append
- `cmake --version` available locally
- `git diff --check`
- diff secret/conflict/debug scan

Note: this local environment does not have GCC 15/16, so the exact Fedora reproduction build could not be run here.