### PR TITLE
fix(dml): cap graph partition node size to prevent DirectML VRAM descriptor thrashing

### DIFF
--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/GraphPartitioner.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/GraphPartitioner.cpp
@@ -506,6 +506,19 @@ namespace Dml
 
             std::vector<GraphPartition*> inputNonFinalPartitions = GetNonFinalizedInputPartitions(node, nodeNameToPartitionMap);
 
+            // Cap partition node count to prevent massive monolithic fusion graphs (e.g. 24,000+ nodes)
+            // that cause DirectML descriptor thrashing and extreme VRAM pre-allocation.
+            constexpr size_t kMaxDmlGraphPartitionNodeCount = 1000;
+            if (!inputNonFinalPartitions.empty())
+            {
+                GraphPartition* rootPart = inputNonFinalPartitions[0]->GetRootMergedPartition();
+                if (rootPart->GetNodeIndices().size() >= kMaxDmlGraphPartitionNodeCount)
+                {
+                    rootPart->SetFinalized();
+                    inputNonFinalPartitions = GetNonFinalizedInputPartitions(node, nodeNameToPartitionMap);
+                }
+            }
+
             if (inputNonFinalPartitions.empty())
             {
                 partitions.push_back(CreateNewPartitionWithFinalizedInputPartitions(node, graphOutputs, nodeNameToPartitionMap));


### PR DESCRIPTION
Fixes #31482

### Problem
When executing large ONNX models (e.g. HT-Demucs with ~24,917 nodes) using DmlExecutionProvider on Windows, BuildPartitions() in GraphPartitioner.cpp accumulates all ~24,917 nodes into a single monolithic DmlGraphPartition.

During DirectML graph compilation (DML_GRAPH_DESC), attempting to allocate descriptor heaps and intermediate tensor workspace for 24,917 nodes at once causes massive VRAM pre-allocation (~31.8 GB on RTX 5090) and extreme latency (~167 seconds for a 7.8 second audio input).

### Solution
Enforce a partition node threshold (kMaxDmlGraphPartitionNodeCount = 1000) in BuildPartitions() (GraphPartitioner.cpp). When a partition reaches 1,000 nodes, it is finalized so subsequent nodes create clean sub-graph partitions with explicit input/output boundaries. This prevents monolithic fusion graph formation, eliminating VRAM descriptor thrashing and massive intermediate allocation.