### PR TITLE
Update CUDA plugin package outputs

### DIFF
--- a/plugin-ep-cuda/README.md
+++ b/plugin-ep-cuda/README.md
@@ -15,7 +15,8 @@ For more information about plugin EPs, see the documentation
 - [`paths.txt`](paths.txt) - Specifies directories and paths related to the CUDA EP. These paths are used to filter the
   commits considered when identifying changes between releases, e.g., for generating release notes.
 - [`python/`](python/) - Sources and build script for the `onnxruntime-ep-cuda12`/`onnxruntime-ep-cuda13` Python wheels.
-- [`csharp/`](csharp/) - Sources and packaging script for the `Microsoft.ML.OnnxRuntime.EP.Cuda` NuGet package.
+- [`csharp/`](csharp/) - Sources and packaging script for the per-RID
+  `Microsoft.ML.OnnxRuntime.EP.Cuda{12,13}.<rid>` NuGet packages.
 
 ## Usage
 

--- a/plugin-ep-cuda/csharp/Microsoft.ML.OnnxRuntime.EP.Cuda/Microsoft.ML.OnnxRuntime.EP.Cuda.csproj
+++ b/plugin-ep-cuda/csharp/Microsoft.ML.OnnxRuntime.EP.Cuda/Microsoft.ML.OnnxRuntime.EP.Cuda.csproj
@@ -6,6 +6,8 @@
     <Nullable>enable</Nullable>
 
     <!-- Package info -->
+        <!-- Sentinel default; CI packs one package per RID and overrides this via
+          -p:PackageId=Microsoft.ML.OnnxRuntime.EP.Cuda<major>.<rid> (see pack_nuget.py). -->
     <PackageId>Microsoft.ML.OnnxRuntime.EP.Cuda</PackageId>
     <!-- Sentinel default; overridden via -p:Version=<x.y.z> when packing (see pack_nuget.py). -->
     <Version>0.0.0-dev</Version>

--- a/plugin-ep-cuda/csharp/Microsoft.ML.OnnxRuntime.EP.Cuda/README.md
+++ b/plugin-ep-cuda/csharp/Microsoft.ML.OnnxRuntime.EP.Cuda/README.md
@@ -1,6 +1,9 @@
-## Microsoft.ML.OnnxRuntime.EP.Cuda
+## ONNX Runtime CUDA Plugin EP
 
 CUDA plugin Execution Provider for [ONNX Runtime](https://github.com/microsoft/onnxruntime).
+
+The plugin EP ships as one package per RID and per CUDA major version, for example
+`Microsoft.ML.OnnxRuntime.EP.Cuda13.win-x64` and `Microsoft.ML.OnnxRuntime.EP.Cuda13.linux-arm64`.
 
 ### Prerequisites
 
@@ -46,11 +49,12 @@ env.UnregisterExecutionProviderLibrary("cuda_ep");
 
 ### Supported Platforms
 
-| Platform | Runtime Identifier |
-|---|---|
-| Windows x64 | `win-x64` |
-| Linux x64 | `linux-x64` |
-| Linux ARM64 | `linux-arm64` |
+| Platform | Runtime Identifier | Package |
+|---|---|---|
+| Windows x64 | `win-x64` | `Microsoft.ML.OnnxRuntime.EP.Cuda<major>.win-x64` |
+| Windows ARM64 | `win-arm64` | `Microsoft.ML.OnnxRuntime.EP.Cuda<major>.win-arm64` |
+| Linux x64 | `linux-x64` | `Microsoft.ML.OnnxRuntime.EP.Cuda<major>.linux-x64` |
+| Linux ARM64 | `linux-arm64` | `Microsoft.ML.OnnxRuntime.EP.Cuda<major>.linux-arm64` |
 
 ### Requirements
 

--- a/plugin-ep-cuda/csharp/README.md
+++ b/plugin-ep-cuda/csharp/README.md
@@ -35,25 +35,38 @@ pass `--staging-dir` to use an explicit one (required when running with `--build
 At least one binary directory (or `--artifacts-dir` with matching subdirectories) must be provided. Platforms without
 a binary directory are skipped. Run `python pack_nuget.py --help` for the full list of options and their defaults.
 
+CI produces one package per RID and per CUDA major version, using `--package-id` to override the `<PackageId>` in the
+.csproj and `--required-platforms` to select the native binary that goes into it:
+
+| Package id | Runtime |
+|---|---|
+| `Microsoft.ML.OnnxRuntime.EP.Cuda13.win-x64` | `win-x64` |
+| `Microsoft.ML.OnnxRuntime.EP.Cuda13.win-arm64` | `win-arm64` |
+| `Microsoft.ML.OnnxRuntime.EP.Cuda13.linux-x64` | `linux-x64` |
+| `Microsoft.ML.OnnxRuntime.EP.Cuda13.linux-arm64` | `linux-arm64` |
+
+The CUDA 12 packages use the same names with `Cuda12` in place of `Cuda13`.
+
 ### Pack with a local build (single platform)
 
 ```powershell
 cd plugin-ep-cuda/csharp
 
 python pack_nuget.py --version 0.1.0-dev `
+  --package-id Microsoft.ML.OnnxRuntime.EP.Cuda13.win-x64 `
+  --required-platforms win_x64 `
   --binary-dir-win-x64 <path-to-win-x64-binaries>
 ```
 
-### Pack multiple platforms
+### Pack another RID
 
-Each `--binary-dir-*` points at the directory containing that platform's already-built native binaries. In practice
-the binaries are produced on different machines and combined in CI; locally you'd typically only set the one(s)
-you have available.
+Each `--binary-dir-*` points at the directory containing that platform's already-built native binaries. The internal
+Linux ARM64 platform name is `linux_aarch64`, while its canonical .NET RID and package suffix are `linux-arm64`.
 
 ```powershell
 python pack_nuget.py --version 0.1.0-dev `
-  --binary-dir-win-x64 <path-to-win-x64-binaries> `
-  --binary-dir-linux-x64 <path-to-linux-x64-binaries> `
+  --package-id Microsoft.ML.OnnxRuntime.EP.Cuda13.linux-arm64 `
+  --required-platforms linux_aarch64 `
   --binary-dir-linux-aarch64 <path-to-linux-aarch64-binaries>
 ```
 
@@ -67,7 +80,7 @@ pre-release version is derived from [`VERSION_NUMBER`](../../VERSION_NUMBER).
 The `.nupkg` is a ZIP file. To verify its contents:
 
 ```powershell
-Expand-Archive nuget_output/Microsoft.ML.OnnxRuntime.EP.Cuda.0.1.0-dev.nupkg `
+Expand-Archive nuget_output/Microsoft.ML.OnnxRuntime.EP.Cuda13.linux-arm64.0.1.0-dev.nupkg `
   -DestinationPath nuget_output/inspect -Force
 
 Get-ChildItem nuget_output/inspect -Recurse | Select-Object FullName
@@ -77,9 +90,6 @@ Expected layout inside the package:
 
 ```
 lib/netstandard2.0/Microsoft.ML.OnnxRuntime.EP.Cuda.dll
-runtimes/win-x64/native/onnxruntime_providers_cuda.dll
-runtimes/win-arm64/native/onnxruntime_providers_cuda.dll
-runtimes/linux-x64/native/libonnxruntime_providers_cuda.so
 runtimes/linux-arm64/native/libonnxruntime_providers_cuda.so
 ```
 
@@ -102,7 +112,8 @@ $localFeed = (Resolve-Path nuget_output).Path
 "@ | Set-Content test/CudaEpNuGetTest/nuget.config
 
 # Build and run
-dotnet run --project test/CudaEpNuGetTest/CudaEpNuGetTest.csproj --configuration Release
+dotnet run --project test/CudaEpNuGetTest/CudaEpNuGetTest.csproj --configuration Release `
+  -p:OrtCudaPackageId=Microsoft.ML.OnnxRuntime.EP.Cuda13.win-x64
 ```
 
 A successful run prints `PASSED: All outputs match expected values.` and exits with code 0.
@@ -122,8 +133,8 @@ The NuGet packaging is integrated into the CUDA plugin pipeline:
 - **Pipeline:** `tools/ci_build/github/azure-pipelines/plugin-cuda-pipeline.yml`
 - **Packaging stage:** `tools/ci_build/github/azure-pipelines/stages/plugin-cuda-nuget-packaging-stage.yml`
 
-The CI stage downloads build artifacts from all enabled platform stages, invokes `pack_nuget.py`, ESRP-signs the
-package, and runs the test app on a GPU agent.
+The CI stage downloads build artifacts from all enabled platform stages, invokes `pack_nuget.py` once per RID,
+ESRP-signs the packages, and runs the test app on a GPU agent.
 
 ## Native Binaries Per Platform
 

--- a/plugin-ep-cuda/csharp/pack_nuget.py
+++ b/plugin-ep-cuda/csharp/pack_nuget.py
@@ -14,11 +14,15 @@ Examples
 Local: pack win-x64 only from a local build:
 
     python pack_nuget.py --version 0.1.0-dev \\
+    --package-id Microsoft.ML.OnnxRuntime.EP.Cuda13.win-x64 \
+    --required-platforms win_x64 \
         --binary-dir-win-x64 ../../build/cuda.plugin/Release/Release
 
-CI: pack all platforms from downloaded artifacts:
+CI: pack linux-arm64 from downloaded artifacts:
 
     python pack_nuget.py --version $(PluginPackageVersion) \\
+    --package-id Microsoft.ML.OnnxRuntime.EP.Cuda13.linux-arm64 \
+    --required-platforms linux_aarch64 \
         --artifacts-dir $(Build.BinariesDirectory)/artifacts \\
         --output-dir $(Build.ArtifactStagingDirectory)/nuget
 """
@@ -64,6 +68,13 @@ def parse_args() -> argparse.Namespace:
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     p.add_argument("--version", required=True, help="Package version (e.g. 0.1.0-dev).")
+    p.add_argument(
+        "--package-id",
+        help=(
+            "NuGet package id. Overrides <PackageId> in the .csproj, which is used when omitted. "
+            "CI packs one package per RID (e.g. Microsoft.ML.OnnxRuntime.EP.Cuda13.win-x64)."
+        ),
+    )
     p.add_argument(
         "--output-dir",
         type=_absolute_path,
@@ -114,8 +125,9 @@ def parse_args() -> argparse.Namespace:
         "--required-platforms",
         default="",
         help=(
-            "Comma-separated list of platforms that MUST be staged successfully. "
-            "When omitted, the script just requires at least one platform to be staged."
+            "Comma-separated list of platforms to stage; all of them MUST be staged successfully "
+            "and no other platform is staged. When omitted, every platform with an available "
+            "binary directory is staged and at least one must succeed."
         ),
     )
 
@@ -174,7 +186,12 @@ def stage_binaries(
 ) -> None:
     staged: set[str] = set()
 
-    for name, (rid, files) in PLATFORMS.items():
+    # An explicit required list also acts as a filter: it is the exact set of platforms that
+    # goes into the package, so a per-OS package does not pick up the other OS's binaries.
+    names = required_platforms or list(PLATFORMS)
+
+    for name in names:
+        rid, files = PLATFORMS[name]
         binary_dir_override: Path | None = getattr(args, f"binary_dir_{name}")
         is_required = name in required_platforms
         source_dir = resolve_platform_source(name, binary_dir_override, args.artifacts_dir, is_required)
@@ -219,6 +236,8 @@ def dotnet_common_args(
         args.configuration,
         f"-p:Version={args.version}",
     ]
+    if args.package_id:
+        common.append(f"-p:PackageId={args.package_id}")
     if args.nuget_config:
         common.extend(["--configfile", str(args.nuget_config)])
         print(f"Using NuGet.config: {args.nuget_config}")
@@ -295,6 +314,11 @@ def run_in_staging(args: argparse.Namespace, staging_dir: Path, min_ort_version_
         if not staged_csproj.is_file():
             raise PackError(f"staged project not found at {staged_csproj}. Run with --build-only first.")
         print(f"Reusing existing staging directory: {staging_dir}")
+        if required_platforms:
+            # Re-stage from scratch so consecutive --pack-only runs against the same staging
+            # directory each produce a package containing only their own platforms.
+            shutil.rmtree(staging_dir / "runtimes", ignore_errors=True)
+            stage_binaries(staging_dir, args, required_platforms)
     else:
         stage_sources(staging_dir)
         stage_binaries(staging_dir, args, required_platforms)

--- a/plugin-ep-cuda/csharp/test/CudaEpNuGetTest/CudaEpNuGetTest.csproj
+++ b/plugin-ep-cuda/csharp/test/CudaEpNuGetTest/CudaEpNuGetTest.csproj
@@ -7,6 +7,11 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <!--
+      Id of the EP package to test. The CUDA plugin EP ships one package per RID and per CUDA
+      major version; CI overrides this with -p:OrtCudaPackageId=<id>.
+    -->
+    <OrtCudaPackageId Condition="'$(OrtCudaPackageId)' == ''">Microsoft.ML.OnnxRuntime.EP.Cuda13.win-x64</OrtCudaPackageId>
+    <!--
       Version of the EP package to test. CI overrides this with the exact version produced by
       pack_nuget.py via -p:OrtCudaPackageVersion=<version> so the test consumes the freshly
       built package deterministically. The floating fallback is for local development against
@@ -25,7 +30,7 @@
     <!-- The plugin EP package does not declare a hard dependency on a core ORT package, so reference
          one explicitly here. -->
     <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="$(OrtCoreTestVersion)" />
-    <PackageReference Include="Microsoft.ML.OnnxRuntime.EP.Cuda" Version="$(OrtCudaPackageVersion)" />
+    <PackageReference Include="$(OrtCudaPackageId)" Version="$(OrtCudaPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/ci_build/github/azure-pipelines/plugin-cuda-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/plugin-cuda-pipeline.yml
@@ -159,11 +159,13 @@ extends:
             enable_cuda_fatbin_size_compression: ${{ parameters.enable_cuda_fatbin_size_compression }}
             enable_fpa_intb_gemm: ${{ parameters.enable_fpa_intb_gemm }}
             ${{ if eq(parameters.cuda_version, '12.8') }}:
+              cuda_major: '12'
               python_package_name: 'onnxruntime-ep-cuda12'
               docker_base_image: 'onnxruntimebuildcache.azurecr.io/internal/azureml/onnxruntime/build/cuda12_x64_almalinux8_gcc14:20251017.1'
               cmake_windows_x64_cuda_archs: '61-real;75-real;86-real;89-real;120-real'
               cmake_linux_x64_cuda_archs: '75-real;80-real;86-real;89-real;90-real;120-real'
             ${{ if eq(parameters.cuda_version, '13.x') }}:
+              cuda_major: '13'
               python_package_name: 'onnxruntime-ep-cuda13'
               docker_base_image: 'onnxruntimebuildcache.azurecr.io/internal/azureml/onnxruntime/build/cuda13_x64_almalinux8_gcc14:20251107.1'
               docker_base_image_aarch64: 'onnxruntimebuildcache.azurecr.io/public/azureml/onnxruntime_build_cuda13_aarch64_almalinux9_gcc14:20260323.1'

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-cuda-nuget-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-cuda-nuget-packaging-stage.yml
@@ -1,12 +1,17 @@
 # NuGet packaging stage for CUDA plugin EP.
-# Downloads platform-specific build artifacts, packs them into a single multi-platform NuGet package,
-# signs it, and publishes the artifact.
+# Downloads platform-specific build artifacts, packs one NuGet package per RID,
+# signs them, and publishes the artifact.
 
 parameters:
 - name: package_version
   type: string
 
 - name: version_file
+  type: string
+
+# CUDA major version (e.g. '12' or '13'). Embedded in the package id so that the CUDA 12 and
+# CUDA 13 packages, which share the same VERSION_NUMBER, are distinct packages.
+- name: cuda_major
   type: string
 
 - name: DoEsrp
@@ -168,15 +173,59 @@ stages:
         DisplayName: 'ESRP - Sign managed DLL'
         DoEsrp: ${{ parameters.DoEsrp }}
 
-    # Pack the (now-signed) managed DLL plus native binaries into the .nupkg.
-    - task: PythonScript@0
-      displayName: 'Pack NuGet package'
-      inputs:
-        scriptSource: filePath
-        scriptPath: '$(Build.SourcesDirectory)\plugin-ep-cuda\csharp\pack_nuget.py'
-        arguments: >-
-          $(CudaPackNuGetCommonArgs)
-          --pack-only
+    # Pack the (now-signed) managed DLL plus one native RID into each .nupkg.
+    # Each invocation re-stages runtimes/ with only its own platform.
+    - ${{ if eq(parameters.platforms.win_x64, true) }}:
+      - task: PythonScript@0
+        displayName: 'Pack win-x64 NuGet package'
+        inputs:
+          scriptSource: filePath
+          scriptPath: '$(Build.SourcesDirectory)\plugin-ep-cuda\csharp\pack_nuget.py'
+          arguments: >-
+            $(CudaPackNuGetCommonArgs)
+            --artifacts-dir "$(Build.BinariesDirectory)\artifacts"
+            --required-platforms win_x64
+            --package-id Microsoft.ML.OnnxRuntime.EP.Cuda${{ parameters.cuda_major }}.win-x64
+            --pack-only
+
+    - ${{ if eq(parameters.platforms.win_arm64, true) }}:
+      - task: PythonScript@0
+        displayName: 'Pack win-arm64 NuGet package'
+        inputs:
+          scriptSource: filePath
+          scriptPath: '$(Build.SourcesDirectory)\plugin-ep-cuda\csharp\pack_nuget.py'
+          arguments: >-
+            $(CudaPackNuGetCommonArgs)
+            --artifacts-dir "$(Build.BinariesDirectory)\artifacts"
+            --required-platforms win_arm64
+            --package-id Microsoft.ML.OnnxRuntime.EP.Cuda${{ parameters.cuda_major }}.win-arm64
+            --pack-only
+
+    - ${{ if eq(parameters.platforms.linux_x64, true) }}:
+      - task: PythonScript@0
+        displayName: 'Pack linux-x64 NuGet package'
+        inputs:
+          scriptSource: filePath
+          scriptPath: '$(Build.SourcesDirectory)\plugin-ep-cuda\csharp\pack_nuget.py'
+          arguments: >-
+            $(CudaPackNuGetCommonArgs)
+            --artifacts-dir "$(Build.BinariesDirectory)\artifacts"
+            --required-platforms linux_x64
+            --package-id Microsoft.ML.OnnxRuntime.EP.Cuda${{ parameters.cuda_major }}.linux-x64
+            --pack-only
+
+    - ${{ if eq(parameters.platforms.linux_aarch64, true) }}:
+      - task: PythonScript@0
+        displayName: 'Pack linux-arm64 NuGet package'
+        inputs:
+          scriptSource: filePath
+          scriptPath: '$(Build.SourcesDirectory)\plugin-ep-cuda\csharp\pack_nuget.py'
+          arguments: >-
+            $(CudaPackNuGetCommonArgs)
+            --artifacts-dir "$(Build.BinariesDirectory)\artifacts"
+            --required-platforms linux_aarch64
+            --package-id Microsoft.ML.OnnxRuntime.EP.Cuda${{ parameters.cuda_major }}.linux-arm64
+            --pack-only
 
     # ESRP sign
     - template: ../templates/esrp_nuget.yml

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-cuda-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-cuda-packaging-stage.yml
@@ -24,6 +24,13 @@ parameters:
   displayName: 'CUDA Version'
   default: '12.8'
 
+# CUDA major version (e.g. '12' or '13'). Used in NuGet package ids and archive file names so
+# that CUDA 12 and CUDA 13 outputs, which share the same VERSION_NUMBER, do not collide.
+- name: cuda_major
+  type: string
+  displayName: 'CUDA major version'
+  default: '12'
+
 - name: arm64_cuda_version
   type: string
   displayName: 'Windows ARM64 CUDA Version'
@@ -154,6 +161,10 @@ stages:
               python_artifact_win_x64 = 'cuda_plugin_python_win_x64_cuda${{ replace(parameters.cuda_version, '.', '') }}'
               python_artifact_win_arm64 = 'cuda_plugin_python_win_arm64_cuda${{ replace(parameters.arm64_cuda_version, '.', '') }}'
               nuget_artifact = 'cuda_plugin_nuget'
+              nuget_package_id_win_x64 = 'Microsoft.ML.OnnxRuntime.EP.Cuda${{ parameters.cuda_major }}.win-x64'
+              nuget_package_id_win_arm64 = 'Microsoft.ML.OnnxRuntime.EP.Cuda${{ parameters.cuda_major }}.win-arm64'
+              nuget_package_id_linux_x64 = 'Microsoft.ML.OnnxRuntime.EP.Cuda${{ parameters.cuda_major }}.linux-x64'
+              nuget_package_id_linux_arm64 = 'Microsoft.ML.OnnxRuntime.EP.Cuda${{ parameters.cuda_major }}.linux-arm64'
             }
 
             $metadata | ConvertTo-Json | Set-Content -Path $metadataPath -Encoding UTF8
@@ -235,6 +246,7 @@ stages:
       parameters:
         package_version: ${{ parameters.package_type }}
         version_file: ${{ parameters.version_file }}
+        cuda_major: ${{ parameters.cuda_major }}
         DoEsrp: true
         platforms:
           win_x64: ${{ parameters.build_windows_x64 }}
@@ -268,6 +280,11 @@ stages:
             - output: pipelineArtifact
               targetPath: $(Build.ArtifactStagingDirectory)/cuda-deps-package
               artifactName: foundry-local-cuda-plugin-ep-zips
+            # Linux release assets are published as .tar.gz in addition to the .zip above.
+            - ${{ if or(eq(parameters.build_linux_x64, true), eq(parameters.build_linux_aarch64, true)) }}:
+              - output: pipelineArtifact
+                targetPath: $(Build.ArtifactStagingDirectory)/cuda-deps-package-targz
+                artifactName: cuda_ep_cuda${{ parameters.cuda_major }}_linux_gz
           steps:
           # The 1ES TSA SDL task expects .config/tsaoptions.json in the source directory.
           # Use a sparse checkout to pull only the .config directory (avoids full repo clone).
@@ -306,17 +323,21 @@ stages:
                 targetPath: $(Build.SourcesDirectory)/cuda-plugin-linux-aarch64
 
           - task: PowerShell@2
-            displayName: 'Create version.json and zip packages for each platform'
+            displayName: 'Create version.json and archives for each platform'
             inputs:
               targetType: inline
               script: |
                 $outputDir = '$(Build.ArtifactStagingDirectory)/cuda-deps-package'
                 New-Item -ItemType Directory -Path $outputDir -Force
 
-                # CUDA major version (e.g. '12' or '13'). Embedded into zip filenames so that
+                # Linux archives are additionally published as .tar.gz for GitHub release assets.
+                $tarOutputDir = '$(Build.ArtifactStagingDirectory)/cuda-deps-package-targz'
+                New-Item -ItemType Directory -Path $tarOutputDir -Force
+
+                # CUDA major version (e.g. '12' or '13'). Embedded into archive filenames so that
                 # CUDA 12 and CUDA 13 packages (which share the same VERSION_NUMBER) do not
                 # collide when published to a shared location downstream.
-                $cudaMajor = '${{ parameters.cuda_version }}'.Split('.')[0]
+                $cudaMajor = '${{ parameters.cuda_major }}'
 
                 # Add new platforms here as they are implemented.
                 # NOTE: macOS arm64 (Apple Silicon) is excluded — no CUDA support since Apple devices do not use Nvidia GPUs.
@@ -390,6 +411,17 @@ stages:
                   } else {
                     throw "No files found to zip for $platformName in $binDir"
                   }
+
+                  if ($platformName.StartsWith('linux')) {
+                    # Same flat contents as the .zip, produced with the bsdtar shipped in Windows.
+                    $tarPath = Join-Path $tarOutputDir "cuda_ep_cuda${cudaMajor}_${filenameVersion}_${platformName}.tar.gz"
+                    $tarArgs = @('-czf', $tarPath, '-C', $binDir) + @($filesToZip | ForEach-Object { $_.Name })
+                    & tar @tarArgs
+                    if ($LASTEXITCODE -ne 0) {
+                      throw "tar failed for $platformName with exit code $LASTEXITCODE"
+                    }
+                    Write-Host "Created tar.gz: $tarPath ($((Get-Item $tarPath).Length) bytes)"
+                  }
                   Write-Host ""
                 }
 
@@ -404,3 +436,8 @@ stages:
                 New-Item -ItemType Directory -Path $versionOutputDir -Force
                 New-Item -ItemType File -Path (Join-Path $versionOutputDir $resolvedVersion) -Force | Out-Null
                 Write-Host "Created version marker: $versionOutputDir/$resolvedVersion"
+
+                $tarVersionOutputDir = Join-Path $tarOutputDir "version"
+                New-Item -ItemType Directory -Path $tarVersionOutputDir -Force
+                New-Item -ItemType File -Path (Join-Path $tarVersionOutputDir $resolvedVersion) -Force | Out-Null
+                Write-Host "Created version marker: $tarVersionOutputDir/$resolvedVersion"

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-cuda-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-cuda-packaging-stage.yml
@@ -158,6 +158,7 @@ stages:
               cuda_version_win_arm64_no_dot = '${{ replace(parameters.arm64_cuda_version, '.', '') }}'
               docker_base_image_linux_x64 = '${{ parameters.docker_base_image }}'
               python_artifact_linux_x64 = 'cuda_plugin_python_linux_x64_cuda${{ replace(parameters.cuda_version, '.', '') }}'
+              python_artifact_linux_aarch64 = 'cuda_plugin_python_linux_aarch64_cuda${{ replace(parameters.cuda_version, '.', '') }}'
               python_artifact_win_x64 = 'cuda_plugin_python_win_x64_cuda${{ replace(parameters.cuda_version, '.', '') }}'
               python_artifact_win_arm64 = 'cuda_plugin_python_win_arm64_cuda${{ replace(parameters.arm64_cuda_version, '.', '') }}'
               nuget_artifact = 'cuda_plugin_nuget'

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-linux-cuda-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-linux-cuda-stage.yml
@@ -172,61 +172,65 @@ stages:
           touch "$(Build.ArtifactStagingDirectory)/version/$(PluginPackageVersion)"
         displayName: 'Create version marker file'
 
-  - ${{ if eq(parameters.arch, 'x64') }}:
-    - job: ${{ parameters.stage_name }}_Python_Package
-      dependsOn: ${{ parameters.stage_name }}
-      timeoutInMinutes: 60
-      workspace:
-        clean: all
-      pool:
-        name: ${{ parameters.machine_pool }}
-        os: linux
-      templateContext:
-        outputs:
-        - output: pipelineArtifact
-          targetPath: $(Build.ArtifactStagingDirectory)/python
+  - job: ${{ parameters.stage_name }}_Python_Package
+    dependsOn: ${{ parameters.stage_name }}
+    timeoutInMinutes: 60
+    workspace:
+      clean: all
+    pool:
+      name: ${{ parameters.machine_pool }}
+      os: linux
+      ${{ if eq(parameters.arch, 'aarch64') }}:
+        hostArchitecture: Arm64
+    templateContext:
+      outputs:
+      - output: pipelineArtifact
+        targetPath: $(Build.ArtifactStagingDirectory)/python
+        ${{ if eq(parameters.arch, 'x64') }}:
           artifactName: cuda_plugin_python_linux_x64_cuda${{ replace(parameters.cuda_version, '.', '') }}
-      variables:
-      - template: ../templates/common-variables.yml
-      steps:
-      - checkout: self
-        clean: true
-        submodules: none
+        ${{ if eq(parameters.arch, 'aarch64') }}:
+          artifactName: cuda_plugin_python_linux_aarch64_cuda${{ replace(parameters.cuda_version, '.', '') }}
+    variables:
+    - template: ../templates/common-variables.yml
+    steps:
+    - checkout: self
+      clean: true
+      submodules: none
 
-      - template: ../templates/set-nightly-build-option-variable-step.yml
+    - template: ../templates/set-nightly-build-option-variable-step.yml
 
-      - template: ../templates/setup-feeds-and-python-steps.yml
-        parameters:
-          architecture: ${{ parameters.arch }}
+    - template: ../templates/setup-feeds-and-python-steps.yml
+      parameters:
+        architecture: ${{ parameters.arch }}
 
-      - template: ../templates/set-plugin-ep-build-variables-step.yml
-        parameters:
-          package_version: ${{ parameters.package_version }}
-          version_file: ${{ parameters.version_file }}
+    - template: ../templates/set-plugin-ep-build-variables-step.yml
+      parameters:
+        package_version: ${{ parameters.package_version }}
+        version_file: ${{ parameters.version_file }}
 
-      - template: ../templates/get-docker-image-steps.yml
-        parameters:
-          Dockerfile: tools/ci_build/github/linux/docker/Dockerfile.manylinux2_28_cuda
-          Context: tools/ci_build/github/linux/docker
-          DockerBuildArgs: >-
-            --network=host
-            --secret id=PIP_INDEX_URL
-            --build-arg BASEIMAGE=${{ parameters.docker_base_image }}
-            --build-arg TRT_VERSION=
-            --build-arg BUILD_UID=$( id -u )
-          Repository: onnxruntimecuda${{ replace(parameters.cuda_version, '.', '') }}pluginbuild${{ parameters.arch }}
+    - template: ../templates/get-docker-image-steps.yml
+      parameters:
+        Dockerfile: tools/ci_build/github/linux/docker/Dockerfile.manylinux2_28_cuda
+        Context: tools/ci_build/github/linux/docker
+        DockerBuildArgs: >-
+          --network=host
+          --secret id=PIP_INDEX_URL
+          --build-arg BASEIMAGE=${{ parameters.docker_base_image }}
+          --build-arg TRT_VERSION=
+          --build-arg BUILD_UID=$( id -u )
+        Repository: onnxruntimecuda${{ replace(parameters.cuda_version, '.', '') }}pluginbuild${{ parameters.arch }}
 
-      - task: DownloadPipelineArtifact@2
-        displayName: 'Download plugin build artifacts'
-        inputs:
-          artifactName: ${{ parameters.artifact_name }}
-          targetPath: '$(Build.BinariesDirectory)/plugin_artifacts'
+    - task: DownloadPipelineArtifact@2
+      displayName: 'Download plugin build artifacts'
+      inputs:
+        artifactName: ${{ parameters.artifact_name }}
+        targetPath: '$(Build.BinariesDirectory)/plugin_artifacts'
 
-      - script: |
-          set -e -x
-          $(Build.SourcesDirectory)/tools/ci_build/github/linux/build_cuda_plugin_python_package.sh \
-            -i onnxruntimecuda${{ replace(parameters.cuda_version, '.', '') }}pluginbuild${{ parameters.arch }} \
-            -p ${{ parameters.docker_python_exe_path }} \
-            -v "$(PluginPythonPackageVersion)" \
-            -n "${{ parameters.python_package_name }}"
-        displayName: 'Build Python wheel'
+    - script: |
+        set -e -x
+        $(Build.SourcesDirectory)/tools/ci_build/github/linux/build_cuda_plugin_python_package.sh \
+          -i onnxruntimecuda${{ replace(parameters.cuda_version, '.', '') }}pluginbuild${{ parameters.arch }} \
+          -p ${{ parameters.docker_python_exe_path }} \
+          -v "$(PluginPythonPackageVersion)" \
+          -n "${{ parameters.python_package_name }}"
+      displayName: 'Build Python wheel'

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-win-cuda-test-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-win-cuda-test-stage.yml
@@ -157,16 +157,17 @@ stages:
         New-Item -ItemType Directory -Path $localFeedDir -Force | Out-Null
 
         # Locate the .nupkg.
-        $nupkg = Get-ChildItem "$(Pipeline.Workspace)\build\$(CudaPluginNuGetArtifactName)\Microsoft.ML.OnnxRuntime.EP.Cuda.*.nupkg" |
+        $packageId = '$(CudaPluginNuGetPackageIdWinX64)'
+        $nupkg = Get-ChildItem "$(Pipeline.Workspace)\build\$(CudaPluginNuGetArtifactName)\$packageId.*.nupkg" |
                  Select-Object -First 1
         if (-not $nupkg) {
-          throw "No matching .nupkg found under $(Pipeline.Workspace)\build\$(CudaPluginNuGetArtifactName)"
+          throw "No $packageId .nupkg found under $(Pipeline.Workspace)\build\$(CudaPluginNuGetArtifactName)"
         }
         Copy-Item $nupkg.FullName $localFeedDir -Force
 
-        # Extract version from filename: Microsoft.ML.OnnxRuntime.EP.Cuda.<version>.nupkg
+        # Extract version from filename: <packageId>.<version>.nupkg
         # The version starts with a digit, which disambiguates from any future filename suffixes.
-        if ($nupkg.BaseName -notmatch '^Microsoft\.ML\.OnnxRuntime\.EP\.Cuda\.(\d.*)$') {
+        if ($nupkg.BaseName -notmatch ('^' + [regex]::Escape($packageId) + '\.(\d.*)$')) {
             throw "Could not extract version from .nupkg filename: $($nupkg.Name)"
         }
         $packageVersion = $Matches[1]
@@ -200,6 +201,7 @@ stages:
         dotnet build `
           "$(CudaTestProject)" `
           --configuration Release `
+          -p:OrtCudaPackageId=$(CudaPluginNuGetPackageIdWinX64) `
           -p:OrtCudaPackageVersion=$(OrtCudaPackageVersion) `
           -p:OrtCoreTestVersion=$(OrtCoreTestVersion)
       displayName: 'Build test project'

--- a/tools/ci_build/github/azure-pipelines/templates/read-cuda-plugin-metadata-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/read-cuda-plugin-metadata-steps.yml
@@ -29,7 +29,11 @@ steps:
         'python_artifact_linux_x64',
         'python_artifact_win_x64',
         'python_artifact_win_arm64',
-        'nuget_artifact'
+        'nuget_artifact',
+        'nuget_package_id_win_x64',
+        'nuget_package_id_win_arm64',
+        'nuget_package_id_linux_x64',
+        'nuget_package_id_linux_arm64'
       )
 
       foreach ($property in $requiredProperties) {
@@ -55,3 +59,7 @@ steps:
       Write-Host "##vso[task.setvariable variable=CudaPluginPythonWinX64ArtifactName]$($metadata.python_artifact_win_x64)"
       Write-Host "##vso[task.setvariable variable=CudaPluginPythonWinArm64ArtifactName]$($metadata.python_artifact_win_arm64)"
       Write-Host "##vso[task.setvariable variable=CudaPluginNuGetArtifactName]$($metadata.nuget_artifact)"
+      Write-Host "##vso[task.setvariable variable=CudaPluginNuGetPackageIdWinX64]$($metadata.nuget_package_id_win_x64)"
+      Write-Host "##vso[task.setvariable variable=CudaPluginNuGetPackageIdWinArm64]$($metadata.nuget_package_id_win_arm64)"
+      Write-Host "##vso[task.setvariable variable=CudaPluginNuGetPackageIdLinuxX64]$($metadata.nuget_package_id_linux_x64)"
+      Write-Host "##vso[task.setvariable variable=CudaPluginNuGetPackageIdLinuxArm64]$($metadata.nuget_package_id_linux_arm64)"

--- a/tools/ci_build/github/azure-pipelines/templates/read-cuda-plugin-metadata-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/read-cuda-plugin-metadata-steps.yml
@@ -27,6 +27,7 @@ steps:
         'cuda_version_win_arm64_no_dot',
         'docker_base_image_linux_x64',
         'python_artifact_linux_x64',
+        'python_artifact_linux_aarch64',
         'python_artifact_win_x64',
         'python_artifact_win_arm64',
         'nuget_artifact',
@@ -55,6 +56,7 @@ steps:
       Write-Host "##vso[task.setvariable variable=CudaVersionWinArm64NoDot]$($metadata.cuda_version_win_arm64_no_dot)"
       Write-Host "##vso[task.setvariable variable=CudaDockerBaseImage]$($metadata.docker_base_image_linux_x64)"
       Write-Host "##vso[task.setvariable variable=CudaPluginPythonLinuxArtifactName]$($metadata.python_artifact_linux_x64)"
+      Write-Host "##vso[task.setvariable variable=CudaPluginPythonLinuxAarch64ArtifactName]$($metadata.python_artifact_linux_aarch64)"
       Write-Host "##vso[task.setvariable variable=CudaPluginPythonWinArtifactName]$($metadata.python_artifact_win_x64)"
       Write-Host "##vso[task.setvariable variable=CudaPluginPythonWinX64ArtifactName]$($metadata.python_artifact_win_x64)"
       Write-Host "##vso[task.setvariable variable=CudaPluginPythonWinArm64ArtifactName]$($metadata.python_artifact_win_arm64)"


### PR DESCRIPTION
## Summary

Update the CUDA plugin pipeline to publish release-ready Linux archives and split NuGet packages by canonical .NET RID.

## Key changes

- Publish Linux `.tar.gz` archives in the `cuda_ep_cuda12_linux_gz` / `cuda_ep_cuda13_linux_gz` artifacts alongside the existing platform zip artifact.
- Generate one NuGet package per enabled RID:
  - `Microsoft.ML.OnnxRuntime.EP.Cuda12/13.win-x64`
  - `Microsoft.ML.OnnxRuntime.EP.Cuda12/13.win-arm64`
  - `Microsoft.ML.OnnxRuntime.EP.Cuda12/13.linux-x64`
  - `Microsoft.ML.OnnxRuntime.EP.Cuda12/13.linux-arm64`
- Keep a shared `.csproj`; `pack_nuget.py` selects the package ID and exact native RID contents at pack time.
- Publish all RID-specific package IDs in pipeline metadata and update the Windows GPU NuGet test to consume the `win-x64` package.
- Update packaging documentation and local examples to use the canonical RID names.

## Validation

- YAML and project XML parsing passed.
- Ruff check and format check passed for `pack_nuget.py`.
- Editor diagnostics reported no errors in touched files.
- End-to-end dry packing produced four packages, each containing only its matching runtime directory.
- PowerShell/tar archive construction was tested locally.

Azure pipeline execution was not run locally.