### PR TITLE
[CPU] Add opt-in MatMulNBits FP32 throughput mode

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
+++ b/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
@@ -495,6 +495,14 @@ static const char* const kOrtSessionOptionsMlasGemmFastMathArm64Bfloat16 = "mlas
 // - "1": Use LUT based GEMM when available.
 static const char* const kOrtSessionOptionsMlasLutGemm = "mlas.use_lut_gemm";
 
+// Force eligible accuracy-level-4 MatMulNBits nodes to use CompFp32 for the entire session.
+// This currently applies to x86/x64 float-input, 4-bit, block-size-32 CPU kernels. Use a dedicated
+// throughput-oriented session when enabling this option so every batch uses the same numerical path.
+// Option values:
+// - "0": Use the compute type selected by accuracy_level for all shapes. [DEFAULT]
+// - "1": Use CompFp32 instead of CompInt8 for eligible accuracy-level-4 nodes.
+static const char* const kOrtSessionOptionsMlasQNBitForceFp32 = "mlas.qnbit.force_fp32";
+
 // Use KleidiAI kernels in MLAS if available.
 // Option values:
 // - "0": Use KleidiAI kernels when available. [DEFAULT]

--- a/onnxruntime/contrib_ops/cpu/quantization/matmul_nbits.cc
+++ b/onnxruntime/contrib_ops/cpu/quantization/matmul_nbits.cc
@@ -112,6 +112,7 @@ class MatMulNBits final : public OpKernel {
         has_g_idx_{info.GetInputCount() > InputIndex::g_idx && info.node().InputDefs()[InputIndex::g_idx]->Exists()},
         has_bias_{info.GetInputCount() > InputIndex::bias && info.node().InputDefs()[InputIndex::bias]->Exists()},
         prefer_lut_gemm_{std::is_same_v<T1, float> &&
+                         info.GetConfigOptions().GetConfigEntry(kOrtSessionOptionsMlasQNBitForceFp32) != "1" &&
                          info.GetConfigOptions().GetConfigEntry(kOrtSessionOptionsMlasLutGemm) == "1" &&
                          MlasIsLutGemmAvailable(narrow<size_t>(info.GetAttr<int64_t>("N")),
                                                 narrow<size_t>(info.GetAttr<int64_t>("K")),

--- a/onnxruntime/contrib_ops/cpu/quantization/matmul_nbits.cc
+++ b/onnxruntime/contrib_ops/cpu/quantization/matmul_nbits.cc
@@ -46,6 +46,12 @@ typedef enum {
   Level4, /*!< input int8, accumulator int32 */
 } ACCURACY_LEVEL;
 
+#if defined(MLAS_TARGET_AMD64_IX86)
+constexpr bool kQNBitForceFp32Supported = true;
+#else
+constexpr bool kQNBitForceFp32Supported = false;
+#endif
+
 // T: A data type.
 template <typename T>
 MLAS_QNBIT_GEMM_COMPUTE_TYPE
@@ -111,7 +117,13 @@ class MatMulNBits final : public OpKernel {
                                                 narrow<size_t>(info.GetAttr<int64_t>("K")),
                                                 narrow<size_t>(info.GetAttr<int64_t>("bits")),
                                                 narrow<size_t>(info.GetAttr<int64_t>("block_size")))},
-        compute_type_{GetComputeType<T1>(nbits_, block_size_, info.GetAttr<int64_t>("accuracy_level"))} {
+        compute_type_{info.GetConfigOptions().GetConfigEntry(kOrtSessionOptionsMlasQNBitForceFp32) == "1" &&
+                              kQNBitForceFp32Supported && std::is_same_v<T1, float> &&
+                              nbits_ == 4 && block_size_ == 32 &&
+                              info.GetAttr<int64_t>("accuracy_level") == static_cast<int64_t>(Level4) &&
+                              MlasIsQNBitGemmAvailable(nbits_, block_size_, SQNBIT_CompFp32)
+                          ? SQNBIT_CompFp32
+                          : GetComputeType<T1>(nbits_, block_size_, info.GetAttr<int64_t>("accuracy_level"))} {
     SetupMlasBackendKernelSelectorFromConfigOptions(mlas_backend_kernel_selector_config_, info.GetConfigOptions());
 
     const auto& node = info.node();

--- a/onnxruntime/test/contrib_ops/matmul_4bits_test.cc
+++ b/onnxruntime/test/contrib_ops/matmul_4bits_test.cc
@@ -301,6 +301,8 @@ void RunTest(const TestOptions& opts,
 
   if (!explicit_eps.empty()) {
     test.ConfigEps(std::move(explicit_eps));
+  } else if (opts.force_fp32) {
+    test.ConfigEp(DefaultCpuExecutionProvider());
   }
 
   if (opts.disable_cpu_ep_fallback || opts.force_fp32) {

--- a/onnxruntime/test/contrib_ops/matmul_4bits_test.cc
+++ b/onnxruntime/test/contrib_ops/matmul_4bits_test.cc
@@ -87,9 +87,11 @@ struct TestOptions {
   int64_t accuracy_level{0};
 
   bool disable_cpu_ep_fallback{false};
+  bool force_fp32{false};
 
   bool has_zero_point{false};
   bool zp_is_4bit{true};
+  bool scales_are_initializers{true};
   bool zero_points_are_initializers{true};
   bool has_g_idx{false};
   bool has_bias{false};
@@ -208,11 +210,11 @@ void RunTest(const TestOptions& opts,
                                         : std::vector<int64_t>{N, k_blocks};
 
   if constexpr (std::is_same<T1, float>::value) {
-    test.AddInput<T1>("scales", scales_shape, scales, true);
+    test.AddInput<T1>("scales", scales_shape, scales, opts.scales_are_initializers);
   } else if constexpr (std::is_same<T1, MLFloat16>::value) {
-    test.AddInput<T1>("scales", scales_shape, FloatsToMLFloat16s(scales), true);
+    test.AddInput<T1>("scales", scales_shape, FloatsToMLFloat16s(scales), opts.scales_are_initializers);
   } else if constexpr (std::is_same<T1, BFloat16>::value) {
-    test.AddInput<T1>("scales", scales_shape, FloatsToBFloat16s(scales), true);
+    test.AddInput<T1>("scales", scales_shape, FloatsToBFloat16s(scales), opts.scales_are_initializers);
   }
 
   if (opts.has_zero_point) {
@@ -292,7 +294,8 @@ void RunTest(const TestOptions& opts,
   if (opts.prepack_sharing_mode.has_value()) {
     // Pre-packed weight sharing is a CPU-EP-only feature; the helper runs the model on the CPU EP
     // in two sessions and validates the sharing counters.
-    CheckSharedPrepackedWeights(test, *opts.prepack_sharing_mode, {N, k_blocks, blob_size}, input1_vals);
+    CheckSharedPrepackedWeights(test, *opts.prepack_sharing_mode, {N, k_blocks, blob_size}, input1_vals,
+                                opts.force_fp32);
     return;
   }
 
@@ -300,10 +303,15 @@ void RunTest(const TestOptions& opts,
     test.ConfigEps(std::move(explicit_eps));
   }
 
-  if (opts.disable_cpu_ep_fallback) {
+  if (opts.disable_cpu_ep_fallback || opts.force_fp32) {
     SessionOptions session_options;
     session_options.use_per_session_threads = false;
-    ASSERT_STATUS_OK(session_options.config_options.AddConfigEntry(kOrtSessionOptionsDisableCPUEPFallback, "1"));
+    if (opts.disable_cpu_ep_fallback) {
+      ASSERT_STATUS_OK(session_options.config_options.AddConfigEntry(kOrtSessionOptionsDisableCPUEPFallback, "1"));
+    }
+    if (opts.force_fp32) {
+      ASSERT_STATUS_OK(session_options.config_options.AddConfigEntry(kOrtSessionOptionsMlasQNBitForceFp32, "1"));
+    }
     test.Config(session_options);
   }
 
@@ -472,6 +480,48 @@ TEST(MatMulNBits, Float32_4b_Accuracy4) {
   TestMatMulNBitsTyped<float, 100, 288, 93, 32, 4>();
   TestMatMulNBitsTyped<float, 100, 288, 93, 128, 4>();
   TestMatMulNBitsTyped<float, 100, 288, 1234, 16, 4>();
+}
+
+TEST(MatMulNBits, Float32_4b_Accuracy4_ForceFp32) {
+#if !defined(MLAS_TARGET_AMD64_IX86)
+  GTEST_SKIP() << "Adaptive QNBit compute is currently supported only on x86/x64.";
+#else
+  TestOptions opts{};
+  opts.N = 256;
+  opts.K = 256;
+  opts.block_size = 32;
+  opts.accuracy_level = 4;
+  opts.force_fp32 = true;
+  opts.output_abs_error = 0.02f;
+  opts.M = 1;
+  RunTest<float>(opts);
+  opts.batch_count = 4;
+  opts.M = 64;
+  RunTest<float>(opts);
+#endif
+}
+
+TEST(MatMulNBits, Float32_4b_Accuracy4_ForceFp32DynamicMetadata) {
+#if !defined(MLAS_TARGET_AMD64_IX86)
+  GTEST_SKIP() << "Adaptive QNBit compute is currently supported only on x86/x64.";
+#else
+  TestOptions opts{};
+  opts.M = 256;
+  opts.N = 64;
+  opts.K = 64;
+  opts.block_size = 32;
+  opts.accuracy_level = 4;
+  opts.force_fp32 = true;
+  opts.output_abs_error = 0.02f;
+
+  opts.scales_are_initializers = false;
+  RunTest<float>(opts);
+
+  opts.scales_are_initializers = true;
+  opts.has_zero_point = true;
+  opts.zero_points_are_initializers = false;
+  RunTest<float>(opts);
+#endif
 }
 
 #if defined(MLAS_TARGET_AMD64_IX86) || defined(MLAS_TARGET_ARM64)
@@ -688,6 +738,20 @@ TEST(MatMulNBits, SharedPrepackedWeights_AsymmetricPackedScales) {
                                      PrepackSharingMode::kAddInitializer);
   opts.M = 1;
   RunTest<float>(opts);
+}
+
+TEST(MatMulNBits, SharedPrepackedWeights_ForceFp32) {
+#if !defined(MLAS_TARGET_AMD64_IX86)
+  GTEST_SKIP() << "Adaptive QNBit compute is currently supported only on x86/x64.";
+#else
+  auto opts = MakeSharingTestOptions(64, 64, /*block_size*/ 32, /*accuracy_level*/ 4,
+                                     /*has_zero_point*/ true, /*has_bias*/ true,
+                                     PrepackSharingMode::kAddInitializer);
+  opts.M = 256;
+  opts.force_fp32 = true;
+  opts.output_abs_error = 0.02f;
+  RunTest<float>(opts);
+#endif
 }
 
 // Uses a KleidiAI-compatible Q4 CompInt8 shape. Runtime zero points must not reuse a B pack

--- a/onnxruntime/test/contrib_ops/matmul_4bits_test.cc
+++ b/onnxruntime/test/contrib_ops/matmul_4bits_test.cc
@@ -486,7 +486,7 @@ TEST(MatMulNBits, Float32_4b_Accuracy4) {
 
 TEST(MatMulNBits, Float32_4b_Accuracy4_ForceFp32) {
 #if !defined(MLAS_TARGET_AMD64_IX86)
-  GTEST_SKIP() << "Adaptive QNBit compute is currently supported only on x86/x64.";
+  GTEST_SKIP() << "Forced QNBit CompFp32 is currently supported only on x86/x64.";
 #else
   TestOptions opts{};
   opts.N = 256;
@@ -505,7 +505,7 @@ TEST(MatMulNBits, Float32_4b_Accuracy4_ForceFp32) {
 
 TEST(MatMulNBits, Float32_4b_Accuracy4_ForceFp32DynamicMetadata) {
 #if !defined(MLAS_TARGET_AMD64_IX86)
-  GTEST_SKIP() << "Adaptive QNBit compute is currently supported only on x86/x64.";
+  GTEST_SKIP() << "Forced QNBit CompFp32 is currently supported only on x86/x64.";
 #else
   TestOptions opts{};
   opts.M = 256;
@@ -744,7 +744,7 @@ TEST(MatMulNBits, SharedPrepackedWeights_AsymmetricPackedScales) {
 
 TEST(MatMulNBits, SharedPrepackedWeights_ForceFp32) {
 #if !defined(MLAS_TARGET_AMD64_IX86)
-  GTEST_SKIP() << "Adaptive QNBit compute is currently supported only on x86/x64.";
+  GTEST_SKIP() << "Forced QNBit CompFp32 is currently supported only on x86/x64.";
 #else
   auto opts = MakeSharingTestOptions(64, 64, /*block_size*/ 32, /*accuracy_level*/ 4,
                                      /*has_zero_point*/ true, /*has_bias*/ true,

--- a/onnxruntime/test/contrib_ops/matmul_nbits_prepack_sharing_test_util.cc
+++ b/onnxruntime/test/contrib_ops/matmul_nbits_prepack_sharing_test_util.cc
@@ -20,9 +20,14 @@ namespace test {
 
 void CheckSharedPrepackedWeights(OpTester& test, PrepackSharingMode mode,
                                  const std::vector<int64_t>& b_dims,
-                                 std::vector<uint8_t>& b_data) {
+                                 std::vector<uint8_t>& b_data,
+                                 bool force_fp32) {
   SessionOptions so;
   OrtValue b_ortvalue;
+
+  if (force_fp32) {
+    ASSERT_STATUS_OK(so.config_options.AddConfigEntry(kOrtSessionOptionsMlasQNBitForceFp32, "1"));
+  }
 
   switch (mode) {
     case PrepackSharingMode::kAddInitializer:

--- a/onnxruntime/test/contrib_ops/matmul_nbits_prepack_sharing_test_util.h
+++ b/onnxruntime/test/contrib_ops/matmul_nbits_prepack_sharing_test_util.h
@@ -29,7 +29,8 @@ enum class PrepackSharingMode {
 // register B as a shared initializer.
 void CheckSharedPrepackedWeights(OpTester& test, PrepackSharingMode mode,
                                  const std::vector<int64_t>& b_dims,
-                                 std::vector<uint8_t>& b_data);
+                                 std::vector<uint8_t>& b_data,
+                                 bool force_fp32 = false);
 
 }  // namespace test
 }  // namespace onnxruntime


### PR DESCRIPTION
### Description

Adds an **opt-in, session-wide** CPU `MatMulNBits` throughput mode.

Set `mlas.qnbit.force_fp32=1` to make eligible x86/x64 float-input, 4-bit, block-size-32, accuracy-level-4 nodes use the existing CompFp32 path instead of CompInt8 for the entire session.

- One compute type and one packed-weight layout are used for every batch shape.
- Dynamic scales and zero points are supported.
- Cross-session prepacked-weight sharing is supported.
- The option is disabled by default, so existing behavior is unchanged.

### Motivation and Context

For Marian translation, CompInt8 provides strong single-sentence latency, but CompFp32 scales much better at large batches. Shape-dependent switching improved throughput but changed the numerical path between serial and batched execution, increasing token mismatches. This version intentionally selects CompFp32 once at session construction so all batch sizes use the same numerical path.

The intended deployment model is two sessions:

- default level-4 session for latency-sensitive requests;
- `mlas.qnbit.force_fp32=1` session for throughput/batched requests.

### End-to-end validation

Rebuilt ONNX Runtime GenAI from landed main commit `53f2379f` (PR #2368), including Extensions pin `60687b12`, against this ORT build.

Five alternating 97-sentence baseline/throughput process pairs used the same GenAI 0.16 binary, ORT DLL, graphs, corpus, and seed:

| Batch | Baseline E2E | FP32 mode E2E | E2E gain | Baseline generation | FP32 mode generation | Generation gain | FP32 mismatches |
|---:|---:|---:|---:|---:|---:|---:|---:|
| 1 | 3.691 s | 6.308 s | 0.59x | 2.213 s | 3.537 s | 0.63x | 0/97 |
| 5 | 2.495 s | 3.510 s | 0.71x | 1.322 s | 2.208 s | 0.60x | 0/97 |
| 10 | 2.391 s | 2.824 s | 0.85x | 1.188 s | 1.607 s | 0.74x | 0/97 |
| 20 | 1.949 s | 1.828 s | 1.07x | 0.957 s | 0.996 s | 0.96x | 0/97 |
| 32 | 1.925 s | 1.654 s | 1.16x | 0.931 s | 0.875 s | 1.06x | 0/97 |

Batch-32 scaling improves from **1.92x to 3.81x E2E** and from **2.38x to 4.04x generation**. Serial/batch parity improves from the existing 2/97 level-4 mismatches to **0/97 at every batch size** in FP32 mode.

The tradeoff is explicit: FP32 mode is about 1.7x slower at batch 1, so it is intended for a separate throughput-oriented session rather than as a default.

Isolated encoder-session private memory decreased from approximately 89.3 MB to 60.6 MB because only the CompFp32 packed layout is retained.

### Validation

- `onnxruntime_provider_test.exe --gtest_filter=MatMulNBits.*`
  - 26 passed
  - 3 expected architecture-specific skips
- Coverage includes small and batched FP32-mode execution, dynamic scales, dynamic zero points, asymmetric zero points, bias, and cross-session prepacked-weight sharing.
- GenAI library and Python extension built successfully against the updated ORT. The aggregate GenAI build later stopped linking `unit_tests.exe` on four existing logging symbols.
- `git diff --check` passes.
