### PR TITLE
[Build] Install complete Perl runtime in Linux packaging images

### DIFF
--- a/tools/ci_build/github/linux/build_linux_python_package.sh
+++ b/tools/ci_build/github/linux/build_linux_python_package.sh
@@ -124,7 +124,12 @@ do
   # like xnnpack's cmakefile, it uses pythone3 to run a external command
   python3_dir=$(dirname "$PYTHON_EXE")
   ls "$python3_dir"
-  ${PYTHON_EXE} -m pip install -r /onnxruntime_src/tools/ci_build/github/linux/python/requirements.txt
+  PIP_REQUIREMENTS=(-r /onnxruntime_src/tools/ci_build/github/linux/python/requirements.txt)
+  if [[ "${PYTHON_EXE}" == */cp313-cp313t/* ]]; then
+    # mypy 1.19+ dependencies do not support free-threaded CPython 3.13.
+    PIP_REQUIREMENTS+=("mypy<1.19")
+  fi
+  "${PYTHON_EXE}" -m pip install "${PIP_REQUIREMENTS[@]}"
   PATH=$python3_dir:$PATH ${PYTHON_EXE} /onnxruntime_src/tools/ci_build/build.py "${BUILD_ARGS[@]}"
   cp /build/"$BUILD_CONFIG"/dist/*.whl /build/dist
 done

--- a/tools/ci_build/github/linux/docker/inference/aarch64/default/cpu/Dockerfile
+++ b/tools/ci_build/github/linux/docker/inference/aarch64/default/cpu/Dockerfile
@@ -10,7 +10,9 @@ ENV LC_ALL=en_US.UTF-8
 
 RUN dnf install -y perl-core && dnf clean all
 
-RUN python3 -m pip install flatbuffers
+RUN --mount=type=secret,id=PIP_INDEX_URL,required=false \
+	if [ -f /run/secrets/PIP_INDEX_URL ]; then export PIP_INDEX_URL=$(cat /run/secrets/PIP_INDEX_URL); fi && \
+	python3 -m pip install flatbuffers
 
 ARG BUILD_UID=1001
 ARG BUILD_USER=onnxruntimedev

--- a/tools/ci_build/github/linux/docker/inference/aarch64/default/cpu/Dockerfile
+++ b/tools/ci_build/github/linux/docker/inference/aarch64/default/cpu/Dockerfile
@@ -8,6 +8,8 @@ FROM $BASEIMAGE
 ENV LANG=en_US.UTF-8
 ENV LC_ALL=en_US.UTF-8
 
+RUN dnf install -y perl-IPC-Cmd && dnf clean all
+
 RUN python3 -m pip install flatbuffers
 
 ARG BUILD_UID=1001

--- a/tools/ci_build/github/linux/docker/inference/aarch64/default/cpu/Dockerfile
+++ b/tools/ci_build/github/linux/docker/inference/aarch64/default/cpu/Dockerfile
@@ -8,7 +8,7 @@ FROM $BASEIMAGE
 ENV LANG=en_US.UTF-8
 ENV LC_ALL=en_US.UTF-8
 
-RUN dnf install -y perl-IPC-Cmd && dnf clean all
+RUN dnf install -y perl-core && dnf clean all
 
 RUN python3 -m pip install flatbuffers
 

--- a/tools/ci_build/github/linux/docker/inference/aarch64/python/cpu/scripts/install_centos.sh
+++ b/tools/ci_build/github/linux/docker/inference/aarch64/python/cpu/scripts/install_centos.sh
@@ -4,7 +4,7 @@ set -e
 os_major_version=$(tr -dc '0-9.' </etc/redhat-release | cut -d \. -f1)
 
 echo "installing for os major version : $os_major_version"
-dnf install -y glibc-langpack-\* which redhat-lsb-core expat-devel tar unzip zlib-devel make bzip2 bzip2-devel perl-IPC-Cmd openssl-devel wget
+dnf install -y glibc-langpack-\* which redhat-lsb-core expat-devel tar unzip zlib-devel make bzip2 bzip2-devel perl-core openssl-devel wget
 
 if ! command -v ccache &>/dev/null; then
   dnf install -y ccache # FIXME: base image should already have ccache installed

--- a/tools/ci_build/github/linux/docker/inference/aarch64/python/cpu/scripts/install_deps.sh
+++ b/tools/ci_build/github/linux/docker/inference/aarch64/python/cpu/scripts/install_deps.sh
@@ -12,5 +12,10 @@ export CMAKE_ARGS="-DONNX_GEN_PB_TYPE_STUBS=ON -DONNX_WERROR=OFF"
 
 for PYTHON_EXE in "${PYTHON_EXES[@]}"
 do
-  ${PYTHON_EXE} -m pip install -r requirements.txt
+  PIP_REQUIREMENTS=(-r requirements.txt)
+  if [[ "${PYTHON_EXE}" == */cp313-cp313t/* ]]; then
+    # mypy 1.19+ dependencies do not support free-threaded CPython 3.13.
+    PIP_REQUIREMENTS+=("mypy<1.19")
+  fi
+  "${PYTHON_EXE}" -m pip install "${PIP_REQUIREMENTS[@]}"
 done

--- a/tools/ci_build/github/linux/docker/inference/aarch64/python/cuda/scripts/install_centos.sh
+++ b/tools/ci_build/github/linux/docker/inference/aarch64/python/cuda/scripts/install_centos.sh
@@ -5,7 +5,7 @@ os_major_version=$(tr -dc '0-9.' < /etc/redhat-release |cut -d \. -f1)
 
 echo "installing for os major version : $os_major_version"
 if [ "$os_major_version" -ge 9 ]; then
-  dnf install -y glibc-langpack-\* which expat-devel tar unzip zlib-devel make bzip2 bzip2-devel perl-IPC-Cmd openssl-devel wget
+  dnf install -y glibc-langpack-\* which expat-devel tar unzip zlib-devel make bzip2 bzip2-devel perl openssl-devel wget
 else
-  dnf install -y glibc-langpack-\* which redhat-lsb-core expat-devel tar unzip zlib-devel make bzip2 bzip2-devel perl-IPC-Cmd openssl-devel wget
+  dnf install -y glibc-langpack-\* which redhat-lsb-core expat-devel tar unzip zlib-devel make bzip2 bzip2-devel perl-core openssl-devel wget
 fi

--- a/tools/ci_build/github/linux/docker/inference/x86_64/default/cpu/Dockerfile
+++ b/tools/ci_build/github/linux/docker/inference/x86_64/default/cpu/Dockerfile
@@ -8,6 +8,8 @@ FROM $BASEIMAGE
 ENV LANG=en_US.UTF-8
 ENV LC_ALL=en_US.UTF-8
 
+RUN dnf install -y perl-IPC-Cmd && dnf clean all
+
 ADD scripts /tmp/scripts
 RUN --mount=type=secret,id=PIP_INDEX_URL,required=false \
     if [ -f /run/secrets/PIP_INDEX_URL ]; then export PIP_INDEX_URL=$(cat /run/secrets/PIP_INDEX_URL); fi && \

--- a/tools/ci_build/github/linux/docker/inference/x86_64/default/cpu/Dockerfile
+++ b/tools/ci_build/github/linux/docker/inference/x86_64/default/cpu/Dockerfile
@@ -8,7 +8,7 @@ FROM $BASEIMAGE
 ENV LANG=en_US.UTF-8
 ENV LC_ALL=en_US.UTF-8
 
-RUN dnf install -y perl-IPC-Cmd && dnf clean all
+RUN dnf install -y perl-core && dnf clean all
 
 ADD scripts /tmp/scripts
 RUN --mount=type=secret,id=PIP_INDEX_URL,required=false \

--- a/tools/ci_build/github/linux/docker/inference/x86_64/default/cuda12/Dockerfile
+++ b/tools/ci_build/github/linux/docker/inference/x86_64/default/cuda12/Dockerfile
@@ -5,7 +5,7 @@
 ARG BASEIMAGE=onnxruntimebuildcache.azurecr.io/internal/azureml/onnxruntime/build/cuda12_x64_almalinux8_gcc14_dotnet:20251017.1
 FROM $BASEIMAGE
 
-RUN dnf install -y perl-IPC-Cmd && dnf clean all
+RUN dnf install -y perl-core && dnf clean all
 
 ARG TRT_VERSION
 

--- a/tools/ci_build/github/linux/docker/inference/x86_64/default/cuda12/Dockerfile
+++ b/tools/ci_build/github/linux/docker/inference/x86_64/default/cuda12/Dockerfile
@@ -4,6 +4,9 @@
 # This file is used by Zip-Nuget Packaging NoContribOps Pipeline,Zip-Nuget-Java Packaging Pipeline
 ARG BASEIMAGE=onnxruntimebuildcache.azurecr.io/internal/azureml/onnxruntime/build/cuda12_x64_almalinux8_gcc14_dotnet:20251017.1
 FROM $BASEIMAGE
+
+RUN dnf install -y perl-IPC-Cmd && dnf clean all
+
 ARG TRT_VERSION
 
 #Install TensorRT only if TRT_VERSION is not empty

--- a/tools/ci_build/github/linux/docker/inference/x86_64/default/cuda13/Dockerfile
+++ b/tools/ci_build/github/linux/docker/inference/x86_64/default/cuda13/Dockerfile
@@ -4,6 +4,9 @@
 # This file is used by Zip-Nuget Packaging NoContribOps Pipeline,Zip-Nuget-Java Packaging Pipeline
 ARG BASEIMAGE=onnxruntimebuildcache.azurecr.io/internal/azureml/onnxruntime/build/cuda13_x64_almalinux8_gcc14_dotnet:20251107.1
 FROM $BASEIMAGE
+
+RUN dnf install -y perl-IPC-Cmd && dnf clean all
+
 ARG TRT_VERSION
 
 #Install TensorRT only if TRT_VERSION is not empty

--- a/tools/ci_build/github/linux/docker/inference/x86_64/default/cuda13/Dockerfile
+++ b/tools/ci_build/github/linux/docker/inference/x86_64/default/cuda13/Dockerfile
@@ -5,7 +5,7 @@
 ARG BASEIMAGE=onnxruntimebuildcache.azurecr.io/internal/azureml/onnxruntime/build/cuda13_x64_almalinux8_gcc14_dotnet:20251107.1
 FROM $BASEIMAGE
 
-RUN dnf install -y perl-IPC-Cmd && dnf clean all
+RUN dnf install -y perl-core && dnf clean all
 
 ARG TRT_VERSION
 

--- a/tools/ci_build/github/linux/docker/inference/x86_64/python/cpu/scripts/install_centos.sh
+++ b/tools/ci_build/github/linux/docker/inference/x86_64/python/cpu/scripts/install_centos.sh
@@ -4,4 +4,4 @@ set -e
 os_major_version=$(tr -dc '0-9.' < /etc/redhat-release |cut -d \. -f1)
 
 echo "installing for os major version : $os_major_version"
-dnf install -y glibc-langpack-\* which redhat-lsb-core expat-devel tar unzip zlib-devel make bzip2 bzip2-devel perl-IPC-Cmd openssl-devel wget
+dnf install -y glibc-langpack-\* which redhat-lsb-core expat-devel tar unzip zlib-devel make bzip2 bzip2-devel perl-core openssl-devel wget

--- a/tools/ci_build/github/linux/docker/inference/x86_64/python/cuda/scripts/install_centos.sh
+++ b/tools/ci_build/github/linux/docker/inference/x86_64/python/cuda/scripts/install_centos.sh
@@ -4,4 +4,4 @@ set -e
 os_major_version=$(tr -dc '0-9.' < /etc/redhat-release |cut -d \. -f1)
 
 echo "installing for os major version : $os_major_version"
-dnf install -y glibc-langpack-\* which redhat-lsb-core expat-devel tar unzip zlib-devel make bzip2 bzip2-devel perl-IPC-Cmd openssl-devel wget
+dnf install -y glibc-langpack-\* which redhat-lsb-core expat-devel tar unzip zlib-devel make bzip2 bzip2-devel perl-core openssl-devel wget

--- a/tools/ci_build/github/linux/docker/inference/x86_64/python/webgpu/scripts/install_centos.sh
+++ b/tools/ci_build/github/linux/docker/inference/x86_64/python/webgpu/scripts/install_centos.sh
@@ -4,4 +4,4 @@ set -e
 os_major_version=$(tr -dc '0-9.' < /etc/redhat-release |cut -d \. -f1)
 
 echo "installing for os major version : $os_major_version"
-dnf install -y glibc-langpack-\* which redhat-lsb-core expat-devel tar unzip zlib-devel make bzip2 bzip2-devel perl-IPC-Cmd openssl-devel wget
+dnf install -y glibc-langpack-\* which redhat-lsb-core expat-devel tar unzip zlib-devel make bzip2 bzip2-devel perl-core openssl-devel wget

--- a/tools/ci_build/github/linux/docker/scripts/manylinux/install_centos.sh
+++ b/tools/ci_build/github/linux/docker/scripts/manylinux/install_centos.sh
@@ -8,9 +8,9 @@ PACKAGE_MANAGER="yum"
 if [ "$os_major_version" -gt 7 ]; then
     PACKAGE_MANAGER="dnf"
     if [ "$os_major_version" -ge 9 ]; then
-        "${PACKAGE_MANAGER}" install -y which expat-devel tar unzip zlib-devel make bzip2 bzip2-devel perl-IPC-Cmd openssl-devel wget
+        "${PACKAGE_MANAGER}" install -y which expat-devel tar unzip zlib-devel make bzip2 bzip2-devel perl openssl-devel wget
     else
-        "${PACKAGE_MANAGER}" install -y which redhat-lsb-core expat-devel tar unzip zlib-devel make bzip2 bzip2-devel perl-IPC-Cmd openssl-devel wget
+        "${PACKAGE_MANAGER}" install -y which redhat-lsb-core expat-devel tar unzip zlib-devel make bzip2 bzip2-devel perl-core openssl-devel wget
     fi
 fi
 


### PR DESCRIPTION
## Description

Minimal AlmaLinux packaging images do not include all Perl standard-library modules required by vcpkg's OpenSSL build. This change installs the complete Perl runtime in the affected Linux images instead of only `perl-IPC-Cmd`.

Rebuilding the ARM64 Python image also exposed an independent compatibility issue: current unpinned `mypy` releases pull native dependencies that cannot be built for free-threaded CPython 3.13 on ARM64. The change therefore constrains mypy to `<1.19` only for the `cp313t` environment, while leaving all other Python environments unconstrained.

The rebuilt ARM64 C API packaging image also revealed that its `flatbuffers` install did not consume the `PIP_INDEX_URL` secret supplied by the pipeline. The Dockerfile now mounts and exports that optional secret, matching the existing x64 packaging image while preserving public PyPI fallback for local builds.

## Summary of Changes

### Complete Perl runtime

| Image paths | Change |
|---|---|
| Default x64 CPU, CUDA 12, and CUDA 13 | Install `perl-core` and clean the dnf cache |
| Default ARM64 CPU | Install `perl-core` and clean the dnf cache |
| Python CPU, CUDA, and WebGPU install scripts | Replace the narrow module RPM with a complete Perl runtime |
| Shared manylinux install script | Use `perl-core` on AlmaLinux 8 and `perl` on AlmaLinux 9 |

AlmaLinux 8 provides `perl-core` as the complete upstream Perl metapackage. On AlmaLinux 9, the `perl` package brings in required modules including `perl-FindBin`, `perl-IPC-Cmd`, and `perl-lib`.

### CPython 3.13t compatibility

| File | Change |
|---|---|
| `tools/ci_build/github/linux/docker/inference/aarch64/python/cpu/scripts/install_deps.sh` | Apply `mypy<1.19` when populating the ARM64 `cp313t` image environment |
| `tools/ci_build/github/linux/build_linux_python_package.sh` | Apply the same constraint when installing wheel-build requirements for `cp313t` |

`mypy 1.18.2` does not depend on `librt` or `ast-serialize`. The constraint therefore avoids both unsupported native packages rather than pinning their transitive versions directly.

### ARM64 package-index configuration

| File | Change |
|---|---|
| `tools/ci_build/github/linux/docker/inference/aarch64/default/cpu/Dockerfile` | Mount and export the optional `PIP_INDEX_URL` BuildKit secret before installing `flatbuffers` |

The C API packaging template already passes `--secret id=PIP_INDEX_URL` to both x64 and ARM64 image builds. Previously, only the x64 Dockerfile consumed it, causing the ARM64 build to fall back to public PyPI and fail after repeated connection timeouts.

## Testing

- Ran `bash -n` on the modified shell scripts.
- Verified official AlmaLinux 8 AppStream metadata publishes `perl-core` as the complete upstream Perl metapackage.
- Verified official AlmaLinux 9 AppStream metadata shows `perl` requires `perl-FindBin`, `perl-IPC-Cmd`, and `perl-lib`.
- Verified the `cp313t` resolver selects `mypy 1.18.2` without `librt` or `ast-serialize`.
- Verified the ARM64 default CPU Dockerfile consumes the `PIP_INDEX_URL` secret supplied by the C API packaging template.
- Audited all Dockerfiles changed by this PR: x64 CPU already handles `PIP_INDEX_URL`, and the CUDA 12 and CUDA 13 images do not invoke pip.
- Ran `lintrunner -a`.
- Ran `git diff --check` against the complete PR diff.
- Linux ARM64 Release and `Linux_C_API_Packaging_CPU_aarch64` CI are in progress to validate the rebuilt image and wheel-build paths.

## Motivation and Context

Installing only `perl-IPC-Cmd` satisfies vcpkg's initial OpenSSL prerequisite check, but OpenSSL's `Configure` script later fails when other core modules such as `FindBin` and `lib` are unavailable. Installing the complete Perl runtime provides the module set expected by the build.

The Perl change did not cause the Python dependency failure. The Docker image action hashes the Dockerfile and its complete build context; changing the ARM64 `install_centos.sh` produced a new image tag and forced a clean build. That build resolved recently published `ast-serialize 0.8.0` and `librt 0.15.0`, neither of which provides an ARM64 `cp313t` wheel, and their source builds failed against free-threaded CPython 3.13. Other PRs using the previous image tag remained green because the action pulled the cached image and skipped dependency installation.

The subsequent C API packaging failure was also unrelated to Perl semantics. Pip timed out on every request to public `pypi.org`; its final "No matching distribution found" message reflected an unavailable package index, not a missing `flatbuffers` release. Consuming the pipeline-provided package-index secret routes CI through its configured feed and avoids that public-network dependency.

## Checklist

- [x] No source tests are required for these build-image dependency changes
- [x] Documentation is not applicable
- [x] No breaking changes
- [ ] CI passes