### PR TITLE
[Build] Reduce nvcc_threads to 1 for linux cuda plugin ci

### DIFF
--- a/.github/workflows/linux_cuda_plugin_ci.yml
+++ b/.github/workflows/linux_cuda_plugin_ci.yml
@@ -32,8 +32,8 @@ jobs:
         --use_binskim_compliant_compile_flags
         --build_wheel
         --parallel
-        --nvcc_threads 2
-        --flash_nvcc_threads 2
+        --nvcc_threads 1
+        --flash_nvcc_threads 1
         --cuda_version=13.0
         --cuda_home=/usr/local/cuda-13.0
         --cudnn_home=/usr/local/cuda-13.0


### PR DESCRIPTION
Linux cuda plugin CI failed sometime due to OOM. This reduce nvcc_threads to 1 to avoid the issue.

Example failed jobs:
https://github.com/microsoft/onnxruntime/actions/runs/31229218069/job/93029489524?pr=31704

It seems that runner has no log after the following (looks like OOM):
```
[1133/1762] Building CUDA object CMakeFiles/onnxruntime_providers_cuda_plugin_sm90_tma.dir/onnxruntime_src/onnxruntime/contrib_ops/cuda/llm/fpA_intB_gemm/launchers/fpA_intB_gemm_launcher_7.generated.cu.o
[1134/1762] Building CUDA object CMakeFiles/onnxruntime_providers_cuda_plugin_sm90_tma.dir/onnxruntime_src/onnxruntime/contrib_ops/cuda/llm/fpA_intB_gemm/launchers/fpA_intB_gemm_launcher_8.generated.cu.o
[1135/1762] Building CUDA object CMakeFiles/onnxruntime_providers_cuda_plugin_sm90_tma.dir/onnxruntime_src/onnxruntime/contrib_ops/cuda/llm/fpA_intB_gemm/launchers/fpA_intB_gemm_launcher_9.generated.cu.o
```
