### PR TITLE
Allow forwarding extra CMake arguments from build.py

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -2497,7 +2497,7 @@ def main():
                     is_extended_minimal_build_or_higher=is_extended_minimal_build_or_higher,
                 )
 
-        cmake_extra_args = []
+        cmake_extra_args = list(args.cmake_extra_args)
         path_to_protoc_exe = None
         if args.path_to_protoc_exe:
             path_to_protoc_exe = Path(args.path_to_protoc_exe)
@@ -2514,16 +2514,16 @@ def main():
                         "environment for the target processor (e.g. Cross "
                         "Tools Command Prompt for VS)"
                     )
-                cmake_extra_args = ["-G", args.cmake_generator]
+                cmake_extra_args += ["-G", args.cmake_generator]
             elif args.arm or args.arm64 or args.arm64ec:
                 if args.arm:
-                    cmake_extra_args = ["-A", "ARM"]
+                    cmake_extra_args += ["-A", "ARM"]
                 elif args.arm64:
-                    cmake_extra_args = ["-A", "ARM64"]
+                    cmake_extra_args += ["-A", "ARM64"]
                     if args.buildasx:
                         cmake_extra_args += ["-D", "BUILD_AS_ARM64X=ARM64"]
                 elif args.arm64ec:
-                    cmake_extra_args = ["-A", "ARM64EC"]
+                    cmake_extra_args += ["-A", "ARM64EC"]
                     if args.buildasx:
                         cmake_extra_args += ["-D", "BUILD_AS_ARM64X=ARM64EC"]
                 cmake_extra_args += ["-G", args.cmake_generator]
@@ -2557,7 +2557,7 @@ def main():
                     toolset += ",cuda=" + args.cuda_home
                 if args.windows_sdk_version:
                     target_arch += ",version=" + args.windows_sdk_version
-                cmake_extra_args = ["-A", target_arch, "-T", toolset, "-G", args.cmake_generator]
+                cmake_extra_args += ["-A", target_arch, "-T", toolset, "-G", args.cmake_generator]
             if args.enable_wcos:
                 cmake_extra_defines.append("CMAKE_USER_MAKE_RULES_OVERRIDE=wcos_rules_override.cmake")
 

--- a/tools/ci_build/build_args.py
+++ b/tools/ci_build/build_args.py
@@ -176,6 +176,16 @@ def add_cmake_build_config_args(parser: argparse.ArgumentParser) -> None:
         default=[],
         help="Extra CMake definitions (-D<key>=<value>). Provide as <key>=<value>.",
     )
+    parser.add_argument(
+        "--cmake_extra_args",
+        action="append",
+        default=[],
+        metavar="ARG",
+        help=(
+            "Extra CMake command-line argument. Repeat for multiple arguments. "
+            "Use --cmake_extra_args=<ARG> when ARG starts with '-'."
+        ),
+    )
     parser.add_argument("--cmake_path", default="cmake", help="Path to the CMake executable.")
     parser.add_argument(
         "--cmake_generator",

--- a/tools/ci_build/tests/test_build_args.py
+++ b/tools/ci_build/tests/test_build_args.py
@@ -1,0 +1,34 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+CI_BUILD_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(CI_BUILD_DIR))
+sys.path.insert(0, str(CI_BUILD_DIR.parent / "python"))
+
+from build_args import parse_arguments  # noqa: E402
+
+
+class BuildArgumentsTest(unittest.TestCase):
+    def test_cmake_extra_args(self):
+        argv = [
+            "build.py",
+            "--build_dir",
+            "build",
+            "--update",
+            "--cmake_extra_args=-Wno-dev",
+            "--cmake_extra_args=--warn-uninitialized",
+        ]
+
+        with mock.patch.object(sys, "argv", argv):
+            args = parse_arguments()
+
+        self.assertEqual(args.cmake_extra_args, ["-Wno-dev", "--warn-uninitialized"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Description

- Add a repeatable `--cmake_extra_args=<ARG>` build option for forwarding non-definition arguments to CMake.
- Preserve those arguments when platform-specific generator and toolset arguments are added.
- Add regression coverage for parsing multiple CMake arguments that begin with `-`.

### Motivation and Context

`--cmake_extra_defines` only supports `-D` definitions, so callers currently cannot pass regular CMake options such as `-Wno-dev` through `build.sh` or `build.py`.

Fixes #16364.

### Validation

- `python -m unittest discover -s tools/ci_build/tests -p 'test_*.py'`
- `lintrunner tools/ci_build/build.py tools/ci_build/build_args.py tools/ci_build/tests/test_build_args.py`
- Ran the update phase against a recording CMake stub and verified both `-Wno-dev` and `--warn-uninitialized` were forwarded in order.