### PR TITLE
[Web] Clarify RunOptions terminate behavior

### DIFF
--- a/js/common/lib/inference-session.ts
+++ b/js/common/lib/inference-session.ts
@@ -472,7 +472,11 @@ export declare namespace InferenceSession {
     logVerbosityLevel?: number;
 
     /**
-     * Terminate all incomplete OrtRun calls as soon as possible if true
+     * Whether to terminate the inference run that receives these options as soon as possible.
+     *
+     * This option does not cancel other in-progress or queued inference runs. The JavaScript API does not currently
+     * support changing a run's options after it has started, so setting this to true terminates the run that receives
+     * these options.
      *
      * This setting is available only in WebAssembly backend. Will support Node.js binding and react-native later
      */


### PR DESCRIPTION
### Description

Clarify the JavaScript semantics of `InferenceSession.RunOptions.terminate`.

The WebAssembly backend creates a separate native run-options handle for each inference call. Setting `terminate` to true therefore terminates the run receiving those options. It does not cancel another in-progress or queued run, and the JavaScript API does not currently expose a way to mutate an active run's options.

### Motivation and Context

The existing text says that the option terminates all incomplete `OrtRun` calls, which describes the native mutable-handle API rather than the JavaScript per-call configuration API. In the reproduction from #29041, runs 1 through 3 complete and only run 4, which receives `{terminate: true}`, is terminated. I reproduced that ordering twice with the WebAssembly proxy enabled.

This change documents the behavior without adding or changing a cancellation API.

Fixes #29041

### Validation

- `npm test` in `js/common` (82 passing, 3 pending)
- `npx eslint common/lib/inference-session.ts`
- `npx prettier --check common/lib/inference-session.ts`
- `npx typedoc --options typedoc.json`
- Verified the corrected text in the generated `InferenceSession.RunOptions` reference
