### PR TITLE
Prevent LayerNorm fusion from selecting removed outputs

### DIFF
--- a/onnxruntime/core/optimizer/layer_norm_fusion.cc
+++ b/onnxruntime/core/optimizer/layer_norm_fusion.cc
@@ -520,22 +520,30 @@ Status LayerNormFusion::ApplyImpl(Graph& graph, bool& modified, int graph_level,
     // scale and bias could be multi-dims; we only support it for training at the moment
     // because SkipLayerNorm kernel, for example, has dependency on single dim size
     NodeArg* scale = nullptr;
+    const auto is_produced_by_removed_node = [&graph, &nodes_to_remove](const NodeArg* node_arg) {
+      const Node* producer = graph.GetProducerNode(node_arg->Name());
+      return producer != nullptr &&
+             std::any_of(nodes_to_remove.begin(), nodes_to_remove.end(),
+                         [producer](const auto& node) { return node.get().Index() == producer->Index(); });
+    };
     NodeArg* bias = nullptr;
     for (size_t i = 0; i < mul_node.MutableInputDefs().size(); i++) {
-      if (mul_node.MutableInputDefs()[i]->Shape() == nullptr) {
+      NodeArg* input = mul_node.MutableInputDefs()[i];
+      if (input->Shape() == nullptr || is_produced_by_removed_node(input)) {
         continue;
       }
-      if (mul_node.MutableInputDefs()[i]->Shape()->dim_size() == static_cast<int>(axes_values.size())) {
-        scale = mul_node.MutableInputDefs()[i];
+      if (input->Shape()->dim_size() == static_cast<int>(axes_values.size())) {
+        scale = input;
       }
     }
 
     for (size_t i = 0; i < last_add_node.MutableInputDefs().size(); i++) {
-      if (last_add_node.MutableInputDefs()[i]->Shape() == nullptr) {
+      NodeArg* input = last_add_node.MutableInputDefs()[i];
+      if (input->Shape() == nullptr || is_produced_by_removed_node(input)) {
         continue;
       }
-      if (last_add_node.MutableInputDefs()[i]->Shape()->dim_size() == static_cast<int>(axes_values.size())) {
-        bias = last_add_node.MutableInputDefs()[i];
+      if (input->Shape()->dim_size() == static_cast<int>(axes_values.size())) {
+        bias = input;
       }
     }
     if (scale == nullptr || bias == nullptr) {
@@ -791,19 +799,26 @@ Status SimplifiedLayerNormFusion::ApplyImpl(Graph& graph, bool& modified, int gr
     // scale and bias could be multi-dims; we only support it for training at the moment
     // because SkipLayerNorm kernel, for example, has dependency on single dim size
     NodeArg* scale = nullptr;
+    const auto is_produced_by_removed_node = [&graph, &nodes_to_remove](const NodeArg* node_arg) {
+      const Node* producer = graph.GetProducerNode(node_arg->Name());
+      return producer != nullptr &&
+             std::any_of(nodes_to_remove.begin(), nodes_to_remove.end(),
+                         [producer](const auto& node) { return node.get().Index() == producer->Index(); });
+    };
     for (size_t i = 0; i < mul_node.MutableInputDefs().size(); i++) {
-      if (mul_node.MutableInputDefs()[i]->Shape() == nullptr) {
+      NodeArg* input = mul_node.MutableInputDefs()[i];
+      if (input->Shape() == nullptr || is_produced_by_removed_node(input)) {
         continue;
       }
 #ifdef ENABLE_TRAINING_CORE
       if (axes_values.empty() ||
-          mul_node.MutableInputDefs()[i]->Shape()->dim_size() == static_cast<int>(axes_values.size())) {
-        scale = mul_node.MutableInputDefs()[i];
+          input->Shape()->dim_size() == static_cast<int>(axes_values.size())) {
+        scale = input;
       }
 #else
       // Scale must be 1d.
-      if (mul_node.MutableInputDefs()[i]->Shape()->dim_size() == 1) {
-        scale = mul_node.MutableInputDefs()[i];
+      if (input->Shape()->dim_size() == 1) {
+        scale = input;
       }
 #endif
     }

--- a/onnxruntime/test/optimizer/graph_transform_test_layernorm.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test_layernorm.cc
@@ -1193,6 +1193,51 @@ TEST_F(GraphTransformationTests, LayerNormFusionCurrentOpsetTest) {
                                         ModelOptions{kAllowReleasedOpsetsOnly, /*strict_shape_type_inference*/ false}));
 }
 
+TEST_F(GraphTransformationTests, LayerNormFusionDoesNotUseIntermediateAsScale) {
+  int current_opset = GetCurrentOnnxOpset();
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    auto* input = builder.MakeInput<float>({2});
+    auto* scale = builder.MakeInput<float>({2, 1});
+    auto* bias = builder.MakeInput<float>({2});
+    auto* exponent = builder.MakeInitializer<float>({}, {2.0f});
+    auto* epsilon = builder.MakeInitializer<float>({}, {1.0e-5f});
+    auto* axes = builder.MakeInitializer<int64_t>({1}, {-1});
+    auto* mean = builder.MakeIntermediate();
+    auto* centered = builder.MakeIntermediate();
+    auto* squared = builder.MakeIntermediate();
+    auto* variance = builder.MakeIntermediate();
+    auto* variance_epsilon = builder.MakeIntermediate();
+    auto* standard_deviation = builder.MakeIntermediate();
+    auto* normalized = builder.MakeIntermediate();
+    auto* multiplied = builder.MakeIntermediate();
+    auto* output = builder.MakeOutput();
+
+    builder.AddNode("ReduceMean", {input, axes}, {mean});
+    builder.AddNode("Sub", {input, mean}, {centered});
+    builder.AddNode("Pow", {centered, exponent}, {squared});
+    builder.AddNode("ReduceMean", {squared, axes}, {variance});
+    builder.AddNode("Add", {variance, epsilon}, {variance_epsilon});
+    builder.AddNode("Sqrt", {variance_epsilon}, {standard_deviation});
+    builder.AddNode("Div", {centered, standard_deviation}, {normalized});
+    builder.AddNode("Mul", {normalized, scale}, {multiplied});
+    builder.AddNode("Add", {multiplied, bias}, {output});
+  };
+
+  auto post_graph_checker = [](Graph& graph) {
+    const auto op_to_count = CountOpsInGraph(graph);
+    TEST_RETURN_IF_NOT(op_to_count.find("LayerNormalization") == op_to_count.end());
+    TEST_RETURN_IF_NOT(op_to_count.find("Div") != op_to_count.end() && op_to_count.at("Div") == 1);
+    return Status::OK();
+  };
+
+  const InlinedHashSet<std::string_view> no_limit_empty_ep_list = {};
+  ASSERT_STATUS_OK(TestGraphTransformer(
+      build_test_case, current_opset, *logger_,
+      std::make_unique<LayerNormFusion>(no_limit_empty_ep_list, TransformerLevel::Level1),
+      TransformerLevel::Level1, 1, nullptr, post_graph_checker,
+      ModelOptions{kAllowReleasedOpsetsOnly, /*strict_shape_type_inference*/ false}));
+}
+
 TEST_F(GraphTransformationTests, SkipLayerNormFusionCurrentOpsetTest) {
   // SkipLayerNorm pattern: Add(input, skip) -> LayerNormalization(gamma, beta)
   int current_opset = GetCurrentOnnxOpset();

--- a/onnxruntime/test/optimizer/graph_transform_test_layernorm.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test_layernorm.cc
@@ -1196,9 +1196,9 @@ TEST_F(GraphTransformationTests, LayerNormFusionCurrentOpsetTest) {
 TEST_F(GraphTransformationTests, LayerNormFusionDoesNotUseIntermediateAsScale) {
   int current_opset = GetCurrentOnnxOpset();
   auto build_test_case = [](ModelTestBuilder& builder) {
-    auto* input = builder.MakeInput<float>({2});
-    auto* scale = builder.MakeInput<float>({2, 1});
-    auto* bias = builder.MakeInput<float>({2});
+    auto* input = builder.MakeInput<float>({{2}});
+    auto* scale = builder.MakeInput<float>({{2, 1}});
+    auto* bias = builder.MakeInput<float>({{2}});
     auto* exponent = builder.MakeInitializer<float>({}, {2.0f});
     auto* epsilon = builder.MakeInitializer<float>({}, {1.0e-5f});
     auto* axes = builder.MakeInitializer<int64_t>({1}, {-1});
@@ -1241,9 +1241,9 @@ TEST_F(GraphTransformationTests, LayerNormFusionDoesNotUseIntermediateAsScale) {
 TEST_F(GraphTransformationTests, LayerNormFusionDoesNotUseIntermediateAsBias) {
   int current_opset = GetCurrentOnnxOpset();
   auto build_test_case = [](ModelTestBuilder& builder) {
-    auto* input = builder.MakeInput<float>({2});
-    auto* scale = builder.MakeInput<float>({2});
-    auto* bias = builder.MakeInput<float>({2, 1});
+    auto* input = builder.MakeInput<float>({{2}});
+    auto* scale = builder.MakeInput<float>({{2}});
+    auto* bias = builder.MakeInput<float>({{2, 1}});
     auto* exponent = builder.MakeInitializer<float>({}, {2.0f});
     auto* epsilon = builder.MakeInitializer<float>({}, {1.0e-5f});
     auto* axes = builder.MakeInitializer<int64_t>({1}, {-1});
@@ -1287,8 +1287,8 @@ TEST_F(GraphTransformationTests, LayerNormFusionDoesNotUseIntermediateAsBias) {
 
 TEST_F(GraphTransformationTests, SimplifiedLayerNormFusionDoesNotUseIntermediateAsScale) {
   auto build_test_case = [](ModelTestBuilder& builder) {
-    auto* input = builder.MakeInput<float>({2});
-    auto* scale = builder.MakeInput<float>({2, 1});
+    auto* input = builder.MakeInput<float>({{2}});
+    auto* scale = builder.MakeInput<float>({{2, 1}});
     auto* exponent = builder.MakeInitializer<float>({}, {2.0f});
     auto* epsilon = builder.MakeInitializer<float>({}, {1.0e-5f});
     auto* squared = builder.MakeIntermediate();

--- a/onnxruntime/test/optimizer/graph_transform_test_layernorm.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test_layernorm.cc
@@ -1238,6 +1238,89 @@ TEST_F(GraphTransformationTests, LayerNormFusionDoesNotUseIntermediateAsScale) {
       ModelOptions{kAllowReleasedOpsetsOnly, /*strict_shape_type_inference*/ false}));
 }
 
+TEST_F(GraphTransformationTests, LayerNormFusionDoesNotUseIntermediateAsBias) {
+  int current_opset = GetCurrentOnnxOpset();
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    auto* input = builder.MakeInput<float>({2});
+    auto* scale = builder.MakeInput<float>({2});
+    auto* bias = builder.MakeInput<float>({2, 1});
+    auto* exponent = builder.MakeInitializer<float>({}, {2.0f});
+    auto* epsilon = builder.MakeInitializer<float>({}, {1.0e-5f});
+    auto* axes = builder.MakeInitializer<int64_t>({1}, {-1});
+    auto* mean = builder.MakeIntermediate();
+    auto* centered = builder.MakeIntermediate();
+    auto* squared = builder.MakeIntermediate();
+    auto* variance = builder.MakeIntermediate();
+    auto* variance_epsilon = builder.MakeIntermediate();
+    auto* standard_deviation = builder.MakeIntermediate();
+    auto* normalized = builder.MakeIntermediate();
+    auto* multiplied = builder.MakeIntermediate();
+    auto* output = builder.MakeOutput();
+
+    builder.AddNode("ReduceMean", {input, axes}, {mean});
+    builder.AddNode("Sub", {input, mean}, {centered});
+    builder.AddNode("Pow", {centered, exponent}, {squared});
+    builder.AddNode("ReduceMean", {squared, axes}, {variance});
+    builder.AddNode("Add", {variance, epsilon}, {variance_epsilon});
+    builder.AddNode("Sqrt", {variance_epsilon}, {standard_deviation});
+    builder.AddNode("Div", {centered, standard_deviation}, {normalized});
+    builder.AddNode("Mul", {normalized, scale}, {multiplied});
+    // Reverse the Add operands so the removed Mul output is the final candidate
+    // visited by the bias-selection loop.
+    builder.AddNode("Add", {bias, multiplied}, {output});
+  };
+
+  auto post_graph_checker = [](Graph& graph) {
+    const auto op_to_count = CountOpsInGraph(graph);
+    TEST_RETURN_IF_NOT(op_to_count.find("LayerNormalization") == op_to_count.end());
+    TEST_RETURN_IF_NOT(op_to_count.find("Div") != op_to_count.end() && op_to_count.at("Div") == 1);
+    return Status::OK();
+  };
+
+  const InlinedHashSet<std::string_view> no_limit_empty_ep_list = {};
+  ASSERT_STATUS_OK(TestGraphTransformer(
+      build_test_case, current_opset, *logger_,
+      std::make_unique<LayerNormFusion>(no_limit_empty_ep_list, TransformerLevel::Level1),
+      TransformerLevel::Level1, 1, nullptr, post_graph_checker,
+      ModelOptions{kAllowReleasedOpsetsOnly, /*strict_shape_type_inference*/ false}));
+}
+
+TEST_F(GraphTransformationTests, SimplifiedLayerNormFusionDoesNotUseIntermediateAsScale) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    auto* input = builder.MakeInput<float>({2});
+    auto* scale = builder.MakeInput<float>({2, 1});
+    auto* exponent = builder.MakeInitializer<float>({}, {2.0f});
+    auto* epsilon = builder.MakeInitializer<float>({}, {1.0e-5f});
+    auto* squared = builder.MakeIntermediate();
+    auto* variance = builder.MakeIntermediate();
+    auto* variance_epsilon = builder.MakeIntermediate();
+    auto* standard_deviation = builder.MakeIntermediate();
+    auto* normalized = builder.MakeIntermediate();
+    auto* output = builder.MakeOutput();
+
+    builder.AddNode("Pow", {input, exponent}, {squared});
+    builder.AddNode("ReduceMean", {squared}, {variance})
+        .AddAttribute("axes", std::vector<int64_t>{-1});
+    builder.AddNode("Add", {variance, epsilon}, {variance_epsilon});
+    builder.AddNode("Sqrt", {variance_epsilon}, {standard_deviation});
+    builder.AddNode("Div", {input, standard_deviation}, {normalized});
+    // The invalid rank-1 Div output is visited last by the scale-selection loop.
+    builder.AddNode("Mul", {scale, normalized}, {output});
+  };
+
+  auto post_graph_checker = [](Graph& graph) {
+    const auto op_to_count = CountOpsInGraph(graph);
+    TEST_RETURN_IF_NOT(op_to_count.find("SimplifiedLayerNormalization") == op_to_count.end());
+    TEST_RETURN_IF_NOT(op_to_count.find("Div") != op_to_count.end() && op_to_count.at("Div") == 1);
+    return Status::OK();
+  };
+
+  ASSERT_STATUS_OK(TestGraphTransformer(
+      build_test_case, 17, *logger_,
+      std::make_unique<SimplifiedLayerNormFusion>(),
+      TransformerLevel::Level2, 1, nullptr, post_graph_checker));
+}
+
 TEST_F(GraphTransformationTests, SkipLayerNormFusionCurrentOpsetTest) {
   // SkipLayerNorm pattern: Add(input, skip) -> LayerNormalization(gamma, beta)
   int current_opset = GetCurrentOnnxOpset();


### PR DESCRIPTION
## Description

LayerNorm and SimplifiedLayerNorm fusion select scale and bias operands solely by rank. When the normalized input is rank 1, the output of the `Div` node has the same rank as a valid scale, so the fusion can select that intermediate output. The `Div` node is then removed as part of the fusion, leaving the fused graph with an input that has no producer and causing session creation to fail.

Only operands that are not produced by nodes already selected for removal are eligible as scale or bias. This preserves valid producer-backed scale and bias inputs while preventing the fusion from referencing an output that it deletes.

Fixes #31147.

## Tests

- Added a graph-transform regression test using the issue's rank-1 reproducer shape. It verifies that the invalid fusion is skipped and the original `Div` remains in the graph.
- `git diff --check`

A native ONNX Runtime C++ build was not available in the Windows environment used to prepare this pull request; the regression is intended for the repository's native CI test target.

## AI assistance disclosure

I identified and reproduced the issue, then used OpenAI Codex to assist with the implementation and regression-test work. I personally reviewed the resulting diff and ran the validation commands listed above to verify the fix. Any full-suite or local-environment limitations are documented in the validation section.
### Review follow-up

Addressed the Copilot review feedback in commit `5a2779f18`:

- added LayerNorm bias-selection coverage with reversed `Add` operands;
- added SimplifiedLayerNorm scale-selection coverage with reversed `Mul` operands; and
- both tests assert the fusion is skipped and the `Div` remains when the only valid-looking candidate is produced by a node removed by the match.

`git diff --check` passes. The native C++ graph-transformer test requires the repository build toolchain and is left to CI on this Windows host.