### PR TITLE
[Build] Split matmul_nbits cu files

### DIFF
--- a/onnxruntime/contrib_ops/cuda/quantization/matmul_4bits.cu
+++ b/onnxruntime/contrib_ops/cuda/quantization/matmul_4bits.cu
@@ -9,6 +9,7 @@
 
 #include "core/providers/cuda/cu_inc/common.cuh"
 #include "core/providers/cuda/cuda_common.h"
+#include "contrib_ops/cuda/quantization/matmul_4bits_batched.cuh"
 #include "contrib_ops/cuda/quantization/matmul_nbits.cuh"
 
 // Include env_var_utils.h after cuda_common.h: the latter transitively pulls in provider_api.h,
@@ -995,84 +996,6 @@ bool TryMatMulSmallM4Bits(
   return true;
 }
 
-// Small-M launcher (half/bf16): picks CtaM >= m from {2,4,8,16} so a single block streams the
-// weight once, and CtaN columns/warp (largest of {4,2,1} dividing N/kCols) to reuse each activation
-// load across columns. Returns false for float or out-of-range m so the caller falls back.
-template <class T>
-bool TryMatMulBatched4Bits(
-    T* output,
-    const T* a_data,
-    const uint8_t* b_data_quant,
-    const T* scales_data,
-    const uint8_t* zero_points,
-    int m,
-    int n,
-    int k,
-    int block_size,
-    size_t /*shared_mem_size*/,
-    cudaStream_t stream) {
-  if constexpr (std::is_same<T, float>::value) {
-    return false;
-  } else {
-    if (m < 2 || m > kSmallMMax) {
-      return false;
-    }
-    // CtaM = smallest of {2,4,8,16} >= m, streaming the weight once per block row. Non-power-of-2 CtaM
-    // (10/12/14) compile to materially slower code, so the row-tile is rounded up (M>8 uses CtaM=16).
-    // CtaN = 2 columns/warp where N allows (halves activation L2 traffic); CtaN=4 lost to register
-    // pressure so it is not used by default.
-    const int cta_m = (m <= 2) ? 2 : (m <= 4) ? 4
-                                 : (m <= 8)   ? 8
-                                              : 16;
-    const int cta_n = (n % (kColsPerThreadBlock * 2) == 0) ? 2 : 1;
-    dim3 threads(GPU_WARP_SIZE_HOST, kColsPerThreadBlock);
-    dim3 blocks(n / (kColsPerThreadBlock * cta_n), (m + cta_m - 1) / cta_m);
-
-#define BatchedDispatch(BS, CM, CN)                                                          \
-  if (nullptr != zero_points) {                                                              \
-    MatMulFloat4BatchedKernel<T, BS, true, CM, CN><<<blocks, threads, 0, stream>>>(          \
-        output, a_data, b_data_quant, scales_data, zero_points, m, n, k, (k + BS - 1) / BS); \
-  } else {                                                                                   \
-    MatMulFloat4BatchedKernel<T, BS, false, CM, CN><<<blocks, threads, 0, stream>>>(         \
-        output, a_data, b_data_quant, scales_data, zero_points, m, n, k, (k + BS - 1) / BS); \
-  }
-#define BatchedDispatchN(CM, CN)  \
-  if (16 == block_size) {         \
-    BatchedDispatch(16, CM, CN)   \
-  } else if (32 == block_size) {  \
-    BatchedDispatch(32, CM, CN)   \
-  } else if (64 == block_size) {  \
-    BatchedDispatch(64, CM, CN)   \
-  } else if (128 == block_size) { \
-    BatchedDispatch(128, CM, CN)  \
-  } else {                        \
-    return false;                 \
-  }
-#define BatchedDispatchM(CN)          \
-  switch (cta_m) {                    \
-    case 2:                           \
-      BatchedDispatchN(2, CN) break;  \
-    case 4:                           \
-      BatchedDispatchN(4, CN) break;  \
-    case 8:                           \
-      BatchedDispatchN(8, CN) break;  \
-    default:                          \
-      BatchedDispatchN(16, CN) break; \
-  }
-
-    if (cta_n == 2) {
-      BatchedDispatchM(2)
-    } else {
-      BatchedDispatchM(1)
-    }
-
-#undef BatchedDispatchM
-#undef BatchedDispatchN
-#undef BatchedDispatch
-    return true;
-  }
-}
-
 template <class T>
 bool TryMatMul4Bits(
     T* output,
@@ -1111,10 +1034,12 @@ bool TryMatMul4Bits(
 
   // The register-tiled batched path (half/bf16, 2 <= m <= cap) launches with no shared memory, so try
   // it before the shared-memory budget gate that only constrains the shared-memory kernels below.
-  if (m >= 2) {
-    if (TryMatMulBatched4Bits<T>(output, a_data, b_data_quant, scales_data, zero_points,
-                                 m, n, k, block_size, 0, stream)) {
-      return true;
+  if constexpr (!std::is_same<T, float>::value) {
+    if (m >= 2) {
+      if (TryMatMulBatched4Bits<T>(output, a_data, b_data_quant, scales_data, zero_points,
+                                   m, n, k, block_size, 0, stream)) {
+        return true;
+      }
     }
   }
 

--- a/onnxruntime/contrib_ops/cuda/quantization/matmul_4bits_batched.cuh
+++ b/onnxruntime/contrib_ops/cuda/quantization/matmul_4bits_batched.cuh
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <cuda_runtime_api.h>
+
+#include <cstddef>
+#include <cstdint>
+
+namespace onnxruntime {
+namespace contrib {
+namespace cuda {
+
+template <class T>
+bool TryMatMulBatched4Bits(
+    T* output,
+    const T* a_data,
+    const uint8_t* b_data_quant,
+    const T* scales_data,
+    const uint8_t* zero_points,
+    int m,
+    int n,
+    int k,
+    int block_size,
+    size_t shared_mem_size,
+    cudaStream_t stream);
+
+}  // namespace cuda
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cuda/quantization/matmul_4bits_batched_bfloat16.cu
+++ b/onnxruntime/contrib_ops/cuda/quantization/matmul_4bits_batched_bfloat16.cu
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "contrib_ops/cuda/quantization/matmul_4bits_batched_impl.cuh"
+
+namespace onnxruntime {
+namespace contrib {
+namespace cuda {
+
+template bool TryMatMulBatched4Bits<nv_bfloat16>(
+    nv_bfloat16*, const nv_bfloat16*, const uint8_t*, const nv_bfloat16*, const uint8_t*,
+    int, int, int, int, size_t, cudaStream_t);
+
+}  // namespace cuda
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cuda/quantization/matmul_4bits_batched_half.cu
+++ b/onnxruntime/contrib_ops/cuda/quantization/matmul_4bits_batched_half.cu
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "contrib_ops/cuda/quantization/matmul_4bits_batched_impl.cuh"
+
+namespace onnxruntime {
+namespace contrib {
+namespace cuda {
+
+template bool TryMatMulBatched4Bits<half>(
+    half*, const half*, const uint8_t*, const half*, const uint8_t*,
+    int, int, int, int, size_t, cudaStream_t);
+
+}  // namespace cuda
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cuda/quantization/matmul_4bits_batched_impl.cuh
+++ b/onnxruntime/contrib_ops/cuda/quantization/matmul_4bits_batched_impl.cuh
@@ -1,0 +1,445 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+
+#include "core/providers/cuda/cu_inc/common.cuh"
+#include "contrib_ops/cuda/quantization/matmul_4bits_batched.cuh"
+
+namespace onnxruntime {
+namespace contrib {
+namespace cuda {
+namespace {
+
+constexpr int kColsPerThreadBlock = 8;
+constexpr int kElementsPerThreadPerIteration = 8;
+constexpr int kWarpSize = onnxruntime::cuda::GPU_WARP_SIZE;
+constexpr int kSmallMMax = 16;
+
+template <typename T>
+__device__ __forceinline__ T WarpUniform(T value) {
+  struct {
+    union {
+      T value;
+      uint32_t as_int;
+    };
+  } packed;
+  packed.value = value;
+  packed.as_int = onnxruntime::cuda::WARP_SHFL(packed.as_int, 0);
+  return packed.value;
+}
+
+#if (!defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 530) && !defined(__HIPCC__)
+__device__ __forceinline__ void Convert8xInt4To8xHalfs(uint32_t value, half2* half_2x4) {
+  uint32_t* output = reinterpret_cast<uint32_t*>(half_2x4);
+  constexpr uint32_t kImmLut = (0xf0 & 0xcc) | 0xaa;
+  constexpr uint32_t kBottomMask = 0x000f000f;
+  constexpr uint32_t kTopMask = 0x00f000f0;
+  constexpr uint32_t kI4sToF16sMagicNum = 0x64006400;
+  const uint32_t top_i4s = value >> 8;
+  asm volatile("lop3.b32 %0, %1, %2, %3, %4;\n"
+               : "=r"(output[0])
+               : "r"(value), "n"(kBottomMask), "n"(kI4sToF16sMagicNum), "n"(kImmLut));
+  asm volatile("lop3.b32 %0, %1, %2, %3, %4;\n"
+               : "=r"(output[1])
+               : "r"(value), "n"(kTopMask), "n"(kI4sToF16sMagicNum), "n"(kImmLut));
+  asm volatile("lop3.b32 %0, %1, %2, %3, %4;\n"
+               : "=r"(output[2])
+               : "r"(top_i4s), "n"(kBottomMask), "n"(kI4sToF16sMagicNum), "n"(kImmLut));
+  asm volatile("lop3.b32 %0, %1, %2, %3, %4;\n"
+               : "=r"(output[3])
+               : "r"(top_i4s), "n"(kTopMask), "n"(kI4sToF16sMagicNum), "n"(kImmLut));
+
+  constexpr uint32_t kFp16TopMagicNum = 0x64006400;
+  constexpr uint32_t kOneSixteenth = 0x2c002c00;
+  constexpr uint32_t kNeg64 = 0xd400d400;
+  asm volatile("sub.f16x2 %0, %1, %2;\n" : "=r"(output[0]) : "r"(output[0]), "r"(kFp16TopMagicNum));
+  asm volatile("fma.rn.f16x2 %0, %1, %2, %3;\n" : "=r"(output[1]) : "r"(output[1]), "r"(kOneSixteenth), "r"(kNeg64));
+  asm volatile("sub.f16x2 %0, %1, %2;\n" : "=r"(output[2]) : "r"(output[2]), "r"(kFp16TopMagicNum));
+  asm volatile("fma.rn.f16x2 %0, %1, %2, %3;\n" : "=r"(output[3]) : "r"(output[3]), "r"(kOneSixteenth), "r"(kNeg64));
+}
+#endif
+
+__device__ __forceinline__ void Convert8xInt4To8xBF16s(uint32_t value, __nv_bfloat162* bf16_2x4) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
+  bf16_2x4[0] = __floats2bfloat162_rn(static_cast<float>((value >> 0) & 0xF),
+                                      static_cast<float>((value >> 16) & 0xF));
+  bf16_2x4[1] = __floats2bfloat162_rn(static_cast<float>((value >> 4) & 0xF),
+                                      static_cast<float>((value >> 20) & 0xF));
+  bf16_2x4[2] = __floats2bfloat162_rn(static_cast<float>((value >> 8) & 0xF),
+                                      static_cast<float>((value >> 24) & 0xF));
+  bf16_2x4[3] = __floats2bfloat162_rn(static_cast<float>((value >> 12) & 0xF),
+                                      static_cast<float>((value >> 28) & 0xF));
+#endif
+}
+
+template <class T>
+struct DequantizedEight;
+
+#if (!defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 530) && !defined(__HIPCC__)
+template <>
+struct DequantizedEight<half> {
+  half2 v[4];
+};
+
+__device__ __forceinline__ void DequantizeEight(
+    uint32_t values_quant, half scale, uint8_t zp, DequantizedEight<half>& output) {
+  half2 scale_half2 = {scale, scale};
+  half zp_adjust = -scale * __short2half_rn(zp);
+  half2 zp_adjust2 = {zp_adjust, zp_adjust};
+  half2 elements[4];
+  Convert8xInt4To8xHalfs(values_quant, elements);
+  output.v[0] = elements[0] * scale_half2 + zp_adjust2;
+  output.v[1] = elements[1] * scale_half2 + zp_adjust2;
+  output.v[2] = elements[2] * scale_half2 + zp_adjust2;
+  output.v[3] = elements[3] * scale_half2 + zp_adjust2;
+}
+#else
+template <>
+struct DequantizedEight<half> {
+  half v[8];
+};
+
+__device__ __forceinline__ void DequantizeEight(
+    uint32_t values_quant, half scale, uint8_t zp, DequantizedEight<half>& output) {
+  half zp_adjust = -scale * __short2half_rn(zp);
+#pragma unroll
+  for (int i = 0; i < 8; ++i) {
+    output.v[i] = __uint2half_rn((values_quant >> (4 * i)) & 0xF) * scale + zp_adjust;
+  }
+}
+#endif
+
+template <>
+struct DequantizedEight<nv_bfloat16> {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
+  __nv_bfloat162 v[4];
+#else
+  nv_bfloat16 v[8];
+#endif
+};
+
+__device__ __forceinline__ void DequantizeEight(
+    uint32_t values_quant, nv_bfloat16 scale, uint8_t zp, DequantizedEight<nv_bfloat16>& output) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
+  __nv_bfloat162 scale_bf162 = __bfloat162bfloat162(scale);
+  nv_bfloat16 zp_adjust = -scale * __uint2bfloat16_rn(zp);
+  __nv_bfloat162 zp_adjust2 = __bfloat162bfloat162(zp_adjust);
+  __nv_bfloat162 elements[4];
+  Convert8xInt4To8xBF16s(values_quant, elements);
+  output.v[0] = __hfma2(elements[0], scale_bf162, zp_adjust2);
+  output.v[1] = __hfma2(elements[1], scale_bf162, zp_adjust2);
+  output.v[2] = __hfma2(elements[2], scale_bf162, zp_adjust2);
+  output.v[3] = __hfma2(elements[3], scale_bf162, zp_adjust2);
+#endif
+}
+
+template <class T>
+struct Acc2;
+template <>
+struct Acc2<half> {
+  using type = half2;
+};
+template <>
+struct Acc2<nv_bfloat16> {
+  using type = __nv_bfloat162;
+};
+
+template <class T>
+struct WPack {
+  typename Acc2<T>::type v[4];
+};
+
+__device__ __forceinline__ WPack<half> PackNatural(const DequantizedEight<half>& dequantized) {
+  WPack<half> packed;
+#if (!defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 530) && !defined(__HIPCC__)
+  uint32_t d0 = *reinterpret_cast<const uint32_t*>(&dequantized.v[0]);
+  uint32_t d1 = *reinterpret_cast<const uint32_t*>(&dequantized.v[1]);
+  uint32_t d2 = *reinterpret_cast<const uint32_t*>(&dequantized.v[2]);
+  uint32_t d3 = *reinterpret_cast<const uint32_t*>(&dequantized.v[3]);
+  constexpr uint32_t kLo = 0x5410;
+  constexpr uint32_t kHi = 0x7632;
+  uint32_t value;
+  asm volatile("prmt.b32 %0, %1, %2, %3;\n" : "=r"(value) : "r"(d0), "r"(d1), "r"(kLo));
+  packed.v[0] = *reinterpret_cast<half2*>(&value);
+  asm volatile("prmt.b32 %0, %1, %2, %3;\n" : "=r"(value) : "r"(d2), "r"(d3), "r"(kLo));
+  packed.v[1] = *reinterpret_cast<half2*>(&value);
+  asm volatile("prmt.b32 %0, %1, %2, %3;\n" : "=r"(value) : "r"(d0), "r"(d1), "r"(kHi));
+  packed.v[2] = *reinterpret_cast<half2*>(&value);
+  asm volatile("prmt.b32 %0, %1, %2, %3;\n" : "=r"(value) : "r"(d2), "r"(d3), "r"(kHi));
+  packed.v[3] = *reinterpret_cast<half2*>(&value);
+#endif
+  return packed;
+}
+
+__device__ __forceinline__ void DotAccum(const WPack<half>& weights, const half2* activations, half2& acc) {
+#if (!defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 530) && !defined(__HIPCC__)
+  acc = __hfma2(weights.v[0], activations[0], acc);
+  acc = __hfma2(weights.v[1], activations[1], acc);
+  acc = __hfma2(weights.v[2], activations[2], acc);
+  acc = __hfma2(weights.v[3], activations[3], acc);
+#endif
+}
+
+__device__ __forceinline__ float HorizontalAdd(half2 acc) {
+#if (!defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 530) && !defined(__HIPCC__)
+  return static_cast<float>(acc.x) + static_cast<float>(acc.y);
+#else
+  return 0.0f;
+#endif
+}
+
+__device__ __forceinline__ WPack<nv_bfloat16> PackNatural(
+    const DequantizedEight<nv_bfloat16>& dequantized) {
+  WPack<nv_bfloat16> packed;
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
+  uint32_t d0 = *reinterpret_cast<const uint32_t*>(&dequantized.v[0]);
+  uint32_t d1 = *reinterpret_cast<const uint32_t*>(&dequantized.v[1]);
+  uint32_t d2 = *reinterpret_cast<const uint32_t*>(&dequantized.v[2]);
+  uint32_t d3 = *reinterpret_cast<const uint32_t*>(&dequantized.v[3]);
+  constexpr uint32_t kLo = 0x5410;
+  constexpr uint32_t kHi = 0x7632;
+  uint32_t value;
+  asm volatile("prmt.b32 %0, %1, %2, %3;\n" : "=r"(value) : "r"(d0), "r"(d1), "r"(kLo));
+  packed.v[0] = *reinterpret_cast<__nv_bfloat162*>(&value);
+  asm volatile("prmt.b32 %0, %1, %2, %3;\n" : "=r"(value) : "r"(d2), "r"(d3), "r"(kLo));
+  packed.v[1] = *reinterpret_cast<__nv_bfloat162*>(&value);
+  asm volatile("prmt.b32 %0, %1, %2, %3;\n" : "=r"(value) : "r"(d0), "r"(d1), "r"(kHi));
+  packed.v[2] = *reinterpret_cast<__nv_bfloat162*>(&value);
+  asm volatile("prmt.b32 %0, %1, %2, %3;\n" : "=r"(value) : "r"(d2), "r"(d3), "r"(kHi));
+  packed.v[3] = *reinterpret_cast<__nv_bfloat162*>(&value);
+#endif
+  return packed;
+}
+
+__device__ __forceinline__ void DotAccum(
+    const WPack<nv_bfloat16>& weights, const __nv_bfloat162* activations, __nv_bfloat162& acc) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
+  acc = __hfma2(weights.v[0], activations[0], acc);
+  acc = __hfma2(weights.v[1], activations[1], acc);
+  acc = __hfma2(weights.v[2], activations[2], acc);
+  acc = __hfma2(weights.v[3], activations[3], acc);
+#endif
+}
+
+__device__ __forceinline__ float HorizontalAdd(__nv_bfloat162 acc) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
+  return static_cast<float>(acc.x) + static_cast<float>(acc.y);
+#else
+  return 0.0f;
+#endif
+}
+
+template <class T, int block_size, bool has_zero_point, int CtaM, int CtaN>
+__global__ void __launch_bounds__(kWarpSize* kColsPerThreadBlock, 3) MatMulFloat4BatchedKernel(
+    T* output,
+    const T* a_data,
+    const uint8_t* b_data_quant,
+    const T* scales_data,
+    const uint8_t* zero_points,
+    int m,
+    int n,
+    int k,
+    int blocks_per_K) {
+  using AccT = typename Acc2<T>::type;
+  const int lane_id = threadIdx.x;
+  const int warp_id = WarpUniform(threadIdx.y);
+  const int col_base = (blockIdx.x * kColsPerThreadBlock + warp_id) * CtaN;
+  const int m_base = blockIdx.y * CtaM;
+  const int valid = m - m_base;
+  constexpr int k_per_iter = kWarpSize * kElementsPerThreadPerIteration;
+  const int zp_blocks = (blocks_per_K + 1) / 2;
+
+  const T* a_base = a_data + static_cast<size_t>(m_base) * k + (lane_id << 3);
+  const uint8_t* b_ptr[CtaN];
+#pragma unroll
+  for (int c = 0; c < CtaN; ++c) {
+    b_ptr[c] = b_data_quant + static_cast<size_t>(col_base + c) * blocks_per_K * (block_size / 2) + lane_id * 4;
+  }
+
+  AccT acc[CtaM][CtaN];
+#pragma unroll
+  for (int row = 0; row < CtaM; ++row) {
+#pragma unroll
+    for (int col = 0; col < CtaN; ++col) {
+      acc[row][col] = AccT{};
+    }
+  }
+
+  int k_id = 0;
+  int t_meta_k = lane_id * 8 / block_size;
+  constexpr int kWork = CtaM * CtaN;
+  constexpr int kMainUnroll = (kWork >= 20) ? 1 : (kWork >= 12) ? 2
+                                                                : 4;
+
+#define BATCHED_BODY(i)                                                                                    \
+  do {                                                                                                     \
+    WPack<T> weights[CtaN];                                                                                \
+    const int block_k = t_meta_k + k_per_iter / block_size * (i);                                          \
+    _Pragma("unroll") for (int col = 0; col < CtaN; ++col) {                                               \
+      uint32_t value = *(reinterpret_cast<const uint32_t*>(b_ptr[col] + k_per_iter / 2 * (i)));            \
+      T scale = scales_data[static_cast<size_t>(col_base + col) * blocks_per_K + block_k];                 \
+      uint8_t zero_point = 8;                                                                              \
+      if constexpr (has_zero_point) {                                                                      \
+        uint8_t packed_zp = zero_points[static_cast<size_t>(col_base + col) * zp_blocks + (block_k >> 1)]; \
+        zero_point = (block_k & 1) ? (packed_zp >> 4) : (packed_zp & 0x0f);                                \
+      }                                                                                                    \
+      DequantizedEight<T> dequantized;                                                                     \
+      DequantizeEight(value, scale, zero_point, dequantized);                                              \
+      weights[col] = PackNatural(dequantized);                                                             \
+    }                                                                                                      \
+    _Pragma("unroll") for (int row = 0; row < CtaM; ++row) {                                               \
+      if (row < valid) {                                                                                   \
+        AccT activations[4];                                                                               \
+        *reinterpret_cast<uint4*>(activations) = *reinterpret_cast<const uint4*>(                          \
+            a_base + static_cast<size_t>(row) * k + k_id + (i) * k_per_iter);                              \
+        _Pragma("unroll") for (int col = 0; col < CtaN; ++col) {                                           \
+          DotAccum(weights[col], activations, acc[row][col]);                                              \
+        }                                                                                                  \
+      }                                                                                                    \
+    }                                                                                                      \
+  } while (false)
+
+#define BATCHED_UNROLL(unroll_size)                            \
+  do {                                                         \
+    constexpr int kUnroll = unroll_size;                       \
+    constexpr int kUnrollStep = kUnroll * k_per_iter;          \
+    const int k_unroll_bound = k - k % kUnrollStep;            \
+    for (; k_id < k_unroll_bound; k_id += kUnrollStep) {       \
+      _Pragma("unroll") for (int i = 0; i < kUnroll; ++i) {    \
+        BATCHED_BODY(i);                                       \
+      }                                                        \
+      _Pragma("unroll") for (int col = 0; col < CtaN; ++col) { \
+        b_ptr[col] += k_per_iter / 2 * kUnroll;                \
+      }                                                        \
+      t_meta_k += k_per_iter / block_size * kUnroll;           \
+    }                                                          \
+  } while (false)
+
+  BATCHED_UNROLL(kMainUnroll);
+  BATCHED_UNROLL(1);
+#undef BATCHED_UNROLL
+
+  if (k_id + lane_id * 8 < k) {
+    WPack<T> weights[CtaN];
+    const int block_k = t_meta_k;
+#pragma unroll
+    for (int col = 0; col < CtaN; ++col) {
+      uint32_t value = *reinterpret_cast<const uint32_t*>(b_ptr[col]);
+      T scale = scales_data[static_cast<size_t>(col_base + col) * blocks_per_K + block_k];
+      uint8_t zero_point = 8;
+      if constexpr (has_zero_point) {
+        uint8_t packed_zp = zero_points[static_cast<size_t>(col_base + col) * zp_blocks + (block_k >> 1)];
+        zero_point = (block_k & 1) ? (packed_zp >> 4) : (packed_zp & 0x0f);
+      }
+      DequantizedEight<T> dequantized;
+      DequantizeEight(value, scale, zero_point, dequantized);
+      weights[col] = PackNatural(dequantized);
+    }
+#pragma unroll
+    for (int row = 0; row < CtaM; ++row) {
+      if (row < valid) {
+        AccT activations[4];
+        *reinterpret_cast<uint4*>(activations) =
+            *reinterpret_cast<const uint4*>(a_base + static_cast<size_t>(row) * k + k_id);
+#pragma unroll
+        for (int col = 0; col < CtaN; ++col) {
+          DotAccum(weights[col], activations, acc[row][col]);
+        }
+      }
+    }
+  }
+#undef BATCHED_BODY
+
+#pragma unroll
+  for (int row = 0; row < CtaM; ++row) {
+    if (row >= valid) continue;
+#pragma unroll
+    for (int col = 0; col < CtaN; ++col) {
+      float sum = HorizontalAdd(acc[row][col]);
+      for (int offset = kWarpSize / 2; offset > 0; offset /= 2) {
+        sum += onnxruntime::cuda::WARP_SHFL_DOWN(sum, offset);
+      }
+      if (lane_id == 0) {
+        output[static_cast<size_t>(m_base + row) * n + col_base + col] = static_cast<T>(sum);
+      }
+    }
+  }
+}
+
+}  // namespace
+
+template <class T>
+bool TryMatMulBatched4Bits(
+    T* output,
+    const T* a_data,
+    const uint8_t* b_data_quant,
+    const T* scales_data,
+    const uint8_t* zero_points,
+    int m,
+    int n,
+    int k,
+    int block_size,
+    size_t /*shared_mem_size*/,
+    cudaStream_t stream) {
+  if (m < 2 || m > kSmallMMax) {
+    return false;
+  }
+
+  const int cta_m = (m <= 2) ? 2 : (m <= 4) ? 4
+                               : (m <= 8)   ? 8
+                                            : 16;
+  const int cta_n = (n % (kColsPerThreadBlock * 2) == 0) ? 2 : 1;
+  dim3 threads(onnxruntime::cuda::GPU_WARP_SIZE_HOST, kColsPerThreadBlock);
+  dim3 blocks(n / (kColsPerThreadBlock * cta_n), (m + cta_m - 1) / cta_m);
+
+#define BatchedDispatch(BS, CM, CN)                                                          \
+  if (nullptr != zero_points) {                                                              \
+    MatMulFloat4BatchedKernel<T, BS, true, CM, CN><<<blocks, threads, 0, stream>>>(          \
+        output, a_data, b_data_quant, scales_data, zero_points, m, n, k, (k + BS - 1) / BS); \
+  } else {                                                                                   \
+    MatMulFloat4BatchedKernel<T, BS, false, CM, CN><<<blocks, threads, 0, stream>>>(         \
+        output, a_data, b_data_quant, scales_data, zero_points, m, n, k, (k + BS - 1) / BS); \
+  }
+#define BatchedDispatchN(CM, CN)  \
+  if (16 == block_size) {         \
+    BatchedDispatch(16, CM, CN)   \
+  } else if (32 == block_size) {  \
+    BatchedDispatch(32, CM, CN)   \
+  } else if (64 == block_size) {  \
+    BatchedDispatch(64, CM, CN)   \
+  } else if (128 == block_size) { \
+    BatchedDispatch(128, CM, CN)  \
+  } else {                        \
+    return false;                 \
+  }
+#define BatchedDispatchM(CN)          \
+  switch (cta_m) {                    \
+    case 2:                           \
+      BatchedDispatchN(2, CN) break;  \
+    case 4:                           \
+      BatchedDispatchN(4, CN) break;  \
+    case 8:                           \
+      BatchedDispatchN(8, CN) break;  \
+    default:                          \
+      BatchedDispatchN(16, CN) break; \
+  }
+
+  if (cta_n == 2) {
+    BatchedDispatchM(2)
+  } else {
+    BatchedDispatchM(1)
+  }
+
+#undef BatchedDispatchM
+#undef BatchedDispatchN
+#undef BatchedDispatch
+  return true;
+}
+
+}  // namespace cuda
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cuda/quantization/matmul_8bits.cu
+++ b/onnxruntime/contrib_ops/cuda/quantization/matmul_8bits.cu
@@ -8,6 +8,7 @@
 #include "core/providers/cuda/cu_inc/common.cuh"
 #include "core/providers/cuda/cu_inc/cuda_type_helper.cuh"
 #include "core/providers/cuda/cuda_common.h"
+#include "contrib_ops/cuda/quantization/matmul_8bits_batched.cuh"
 #include "contrib_ops/cuda/quantization/matmul_nbits.cuh"
 
 using namespace onnxruntime::cuda;
@@ -191,210 +192,10 @@ __device__ __forceinline__ void AccumulateEightElements8b(
 #endif
 }
 
-// ===== Small-M batched GEMV (8-bit) =====
-// Same idea as the 4-bit batched kernel: each warp computes CtaN columns x CtaM rows. Lanes split K
-// (8 elems/lane/iter via one uint64 weight load); each column's 8 weights are dequantized once per row
-// group, per-row activations are loaded once and reused across CtaN columns, and a single float
-// accumulator per (row, column) keeps register pressure low while the weight is streamed once. The
-// launch bound pins >=3 blocks per SM. Standard [N, blocks, blob] layout, no prepacking; the 8-bit path
-// accumulates in float, so this stays dtype-agnostic (float/half/bf16).
 constexpr int kSmallMMax8 = 5;
 template <class T>
 __host__ __device__ constexpr int SmallMCap8() {
   return kSmallMMax8;
-}
-
-template <class T>
-__device__ __forceinline__ float ToFloat8b(T v);
-template <>
-__device__ __forceinline__ float ToFloat8b<float>(float v) { return v; }
-template <>
-__device__ __forceinline__ float ToFloat8b<half>(half v) { return __half2float(v); }
-template <>
-__device__ __forceinline__ float ToFloat8b<nv_bfloat16>(nv_bfloat16 v) { return __bfloat162float(v); }
-
-template <class T>
-__device__ __forceinline__ void DequantizeEight8b(uint64_t values_quant, T scale, uint8_t zp, float dq[8]) {
-  float scale_f = ToFloat8b<T>(scale);
-#if (!defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 530)
-  // Magic-half decode of the packed uint8 weights. The half bit pattern (0x6400 | q)
-  // encodes exactly 1024 + q for q in [0, 255] (exponent 2^10, so ulp == 1), so two
-  // weights are materialized per __byte_perm. Subtracting half(1024 + zp) cancels the
-  // bias and leaves the exact integer (q - zp) in [-255, 255], which half represents
-  // exactly -- so this is bit-identical to float(q) - float(zp) while replacing
-  // 8 int->float converts and 8 subtracts with 4 permutes and 4 half2 subtracts.
-  const uint32_t kMagicBytes = 0x64646464u;
-  const uint32_t lo32 = static_cast<uint32_t>(values_quant);
-  const uint32_t hi32 = static_cast<uint32_t>(values_quant >> 32);
-  const half2 bias_h2 = __half2half2(
-      __ushort_as_half(static_cast<uint16_t>(0x6400u | static_cast<uint32_t>(zp))));
-
-  uint32_t packed[4];
-  packed[0] = __byte_perm(lo32, kMagicBytes, 0x4140);  // {q0, q1}
-  packed[1] = __byte_perm(lo32, kMagicBytes, 0x4342);  // {q2, q3}
-  packed[2] = __byte_perm(hi32, kMagicBytes, 0x4140);  // {q4, q5}
-  packed[3] = __byte_perm(hi32, kMagicBytes, 0x4342);  // {q6, q7}
-
-#pragma unroll
-  for (int i = 0; i < 4; ++i) {
-    const float2 d = __half22float2(__hsub2(bit_cast<half2>(packed[i]), bias_h2));
-    dq[2 * i] = d.x * scale_f;
-    dq[2 * i + 1] = d.y * scale_f;
-  }
-#else
-  float zp_f = static_cast<float>(zp);
-#pragma unroll
-  for (int i = 0; i < 8; ++i) {
-    uint8_t q = (values_quant >> (i * 8)) & 0xFF;
-    dq[i] = (static_cast<float>(q) - zp_f) * scale_f;
-  }
-#endif
-}
-
-// Load 8 consecutive activations (one lane's iteration tile) into float[8].
-template <class T>
-__device__ __forceinline__ void LoadEightActivations8b(const T* a, float out[8]) {
-#pragma unroll
-  for (int j = 0; j < 8; ++j) {
-    out[j] = ToFloat8b<T>(a[j]);
-  }
-}
-
-template <class T, int block_size, bool has_zero_point, int CtaM, int CtaN>
-__global__ void __launch_bounds__(kWarpSize* kColsPerThreadBlock, 3) MatMulFloat8bKernelBatched(
-    T* output,
-    const T* a_data,
-    const uint8_t* b_data_quant,
-    const T* scales_data,
-    const uint8_t* zero_points,
-    int m,
-    int n,
-    int k,
-    int blocks_per_K) {
-  const int lane_id = threadIdx.x;
-  const int warp_id = threadIdx.y;
-  const int col_base = (blockIdx.x * kColsPerThreadBlock + warp_id) * CtaN;
-  const int m_base = blockIdx.y * CtaM;
-  const int valid = m - m_base;
-  constexpr int k_per_iter = kWarpSize * kElementsPerThreadPerIteration;  // 256
-  const int lane_offset = lane_id * kElementsPerThreadPerIteration;       // lane_id * 8
-
-  const T* a_base = a_data + static_cast<size_t>(m_base) * k + lane_offset;
-  const uint8_t* b_ptr[CtaN];
-#pragma unroll
-  for (int c = 0; c < CtaN; ++c) {
-    b_ptr[c] = b_data_quant + static_cast<size_t>(col_base + c) * blocks_per_K * block_size + lane_offset;
-  }
-
-  float acc[CtaM][CtaN];
-#pragma unroll
-  for (int r = 0; r < CtaM; ++r) {
-#pragma unroll
-    for (int c = 0; c < CtaN; ++c) {
-      acc[r][c] = 0.0f;
-    }
-  }
-
-  int k_id = 0;
-  int t_meta_k = lane_offset / block_size;
-  constexpr int kWork = CtaM * CtaN;
-  constexpr int kMainUnroll = (kWork >= 20) ? 1 : (kWork >= 12) ? 2
-                                                                : 4;
-
-#define BATCHED8_BODY(i)                                                                              \
-  do {                                                                                                \
-    float dq[CtaN][8];                                                                                \
-    const int bk = t_meta_k + k_per_iter / block_size * (i);                                          \
-    _Pragma("unroll") for (int c = 0; c < CtaN; ++c) {                                                \
-      uint64_t value = *reinterpret_cast<const uint64_t*>(b_ptr[c] + k_per_iter * (i));               \
-      T scale = scales_data[static_cast<size_t>(col_base + c) * blocks_per_K + bk];                   \
-      uint8_t zp = kDefaultZeroPoint;                                                                 \
-      if constexpr (has_zero_point) {                                                                 \
-        zp = zero_points[static_cast<size_t>(col_base + c) * blocks_per_K + bk];                      \
-      }                                                                                               \
-      DequantizeEight8b<T>(value, scale, zp, dq[c]);                                                  \
-    }                                                                                                 \
-    _Pragma("unroll") for (int r = 0; r < CtaM; ++r) {                                                \
-      if (r < valid) {                                                                                \
-        float av[8];                                                                                  \
-        LoadEightActivations8b<T>(a_base + static_cast<size_t>(r) * k + k_id + (i) * k_per_iter, av); \
-        _Pragma("unroll") for (int c = 0; c < CtaN; ++c) {                                            \
-          float s = 0.0f;                                                                             \
-          _Pragma("unroll") for (int j = 0; j < 8; ++j) {                                             \
-            s = fmaf(av[j], dq[c][j], s);                                                             \
-          }                                                                                           \
-          acc[r][c] += s;                                                                             \
-        }                                                                                             \
-      }                                                                                               \
-    }                                                                                                 \
-  } while (false)
-
-#define BATCHED8_UNROLL(unroll_size)                        \
-  do {                                                      \
-    constexpr int kUnroll = unroll_size;                    \
-    constexpr int kUnrollStep = kUnroll * k_per_iter;       \
-    const int k_unroll_bound = k - k % kUnrollStep;         \
-    for (; k_id < k_unroll_bound; k_id += kUnrollStep) {    \
-      _Pragma("unroll") for (int i = 0; i < kUnroll; ++i) { \
-        BATCHED8_BODY(i);                                   \
-      }                                                     \
-      _Pragma("unroll") for (int c = 0; c < CtaN; ++c) {    \
-        b_ptr[c] += kUnrollStep;                            \
-      }                                                     \
-      t_meta_k += k_per_iter / block_size * kUnroll;        \
-    }                                                       \
-  } while (false)
-
-  BATCHED8_UNROLL(kMainUnroll);
-  BATCHED8_UNROLL(1);
-#undef BATCHED8_UNROLL
-
-  if (lane_offset + k_id < k) {
-    float dq[CtaN][8];
-    const int bk = t_meta_k;
-#pragma unroll
-    for (int c = 0; c < CtaN; ++c) {
-      uint64_t value = *reinterpret_cast<const uint64_t*>(b_ptr[c]);
-      T scale = scales_data[static_cast<size_t>(col_base + c) * blocks_per_K + bk];
-      uint8_t zp = kDefaultZeroPoint;
-      if constexpr (has_zero_point) {
-        zp = zero_points[static_cast<size_t>(col_base + c) * blocks_per_K + bk];
-      }
-      DequantizeEight8b<T>(value, scale, zp, dq[c]);
-    }
-#pragma unroll
-    for (int r = 0; r < CtaM; ++r) {
-      if (r < valid) {
-        float av[8];
-        LoadEightActivations8b<T>(a_base + static_cast<size_t>(r) * k + k_id, av);
-#pragma unroll
-        for (int c = 0; c < CtaN; ++c) {
-          float s = 0.0f;
-#pragma unroll
-          for (int j = 0; j < 8; ++j) {
-            s = fmaf(av[j], dq[c][j], s);
-          }
-          acc[r][c] += s;
-        }
-      }
-    }
-  }
-#undef BATCHED8_BODY
-
-#pragma unroll
-  for (int r = 0; r < CtaM; ++r) {
-    if (r >= valid) continue;
-#pragma unroll
-    for (int c = 0; c < CtaN; ++c) {
-      float sum = acc[r][c];
-      for (int off = kWarpSize / 2; off > 0; off /= 2) {
-        sum += WARP_SHFL_DOWN(sum, off);
-      }
-      if (lane_id == 0) {
-        output[static_cast<size_t>(m_base + r) * n + (col_base + c)] = static_cast<T>(sum);
-      }
-    }
-  }
 }
 
 // --- CUDA Kernel: MatMulFloat8bKernel (Optimized for m=1) ---
@@ -595,66 +396,17 @@ bool TryMatMul8Bits(
     return false;
   }
 
+  if (m >= 2) {
+    return TryMatMul8BitsBatched(
+        output, a_data, b_data_quant, scales_data, zero_points, m, n, k, block_size, stream);
+  }
+
   // --- Grid and Thread Block Configuration ---
   dim3 threads(kWarpSize, kColsPerThreadBlock);  // Block dimensions (32, 8)
   dim3 blocks((n + kColsPerThreadBlock - 1) / kColsPerThreadBlock, m);
 
   // Calculate K / block_size (no rounding needed due to k % block_size == 0 check)
   int blocks_per_K = k / block_size;
-
-  // 2 <= m <= cap: batched GEMV. CtaM = smallest of {2,4,8} >= m streams the weight once per block row
-  // (m=5 uses CtaM=8 and skips the unused rows); CtaN = 2 columns/warp where N allows (reuses each
-  // activation load across columns). One float accumulator per (row, column) keeps register pressure
-  // low. 8-bit weights are twice the bytes of 4-bit and the GEMV runs on CUDA cores, so it crosses over
-  // to the dequantize + cuBLAS (tensor-core) fallback at a lower M than the 4-bit path; the cap keeps
-  // only the row counts where it is faster on every matrix shape. This path launches with no shared
-  // memory, so it runs before the shared-memory budget gate that only constrains the m==1 kernel below.
-  if (m >= 2) {
-    const int cta_m = (m <= 2) ? 2 : (m <= 4) ? 4
-                                              : 8;
-    const int cta_n = (n % (kColsPerThreadBlock * 2) == 0) ? 2 : 1;
-    dim3 batched_blocks(n / (kColsPerThreadBlock * cta_n), (m + cta_m - 1) / cta_m);
-#define MatMulFloat8bBatchedDispatch(bs, cm, cn)                                              \
-  if (nullptr != zero_points) {                                                               \
-    MatMulFloat8bKernelBatched<T, bs, true, cm, cn><<<batched_blocks, threads, 0, stream>>>(  \
-        output, a_data, b_data_quant, scales_data, zero_points, m, n, k, blocks_per_K);       \
-  } else {                                                                                    \
-    MatMulFloat8bKernelBatched<T, bs, false, cm, cn><<<batched_blocks, threads, 0, stream>>>( \
-        output, a_data, b_data_quant, scales_data, nullptr, m, n, k, blocks_per_K);           \
-  }
-#define MatMulFloat8bBatchedDispatchN(cm, cn) \
-  if (16 == block_size) {                     \
-    MatMulFloat8bBatchedDispatch(16, cm, cn)  \
-  } else if (32 == block_size) {              \
-    MatMulFloat8bBatchedDispatch(32, cm, cn)  \
-  } else if (64 == block_size) {              \
-    MatMulFloat8bBatchedDispatch(64, cm, cn)  \
-  } else if (128 == block_size) {             \
-    MatMulFloat8bBatchedDispatch(128, cm, cn) \
-  } else if (256 == block_size) {             \
-    MatMulFloat8bBatchedDispatch(256, cm, cn) \
-  } else {                                    \
-    return false;                             \
-  }
-#define MatMulFloat8bBatchedDispatchM(cn)         \
-  switch (cta_m) {                                \
-    case 2:                                       \
-      MatMulFloat8bBatchedDispatchN(2, cn) break; \
-    case 4:                                       \
-      MatMulFloat8bBatchedDispatchN(4, cn) break; \
-    default:                                      \
-      MatMulFloat8bBatchedDispatchN(8, cn) break; \
-  }
-    if (cta_n == 2) {
-      MatMulFloat8bBatchedDispatchM(2)
-    } else {
-      MatMulFloat8bBatchedDispatchM(1)
-    }
-#undef MatMulFloat8bBatchedDispatchM
-#undef MatMulFloat8bBatchedDispatchN
-#undef MatMulFloat8bBatchedDispatch
-    return true;
-  }
 
   // --- Shared Memory Calculation (m == 1) ---
   // Memory for scales + optional zero points for the columns handled by the block

--- a/onnxruntime/contrib_ops/cuda/quantization/matmul_8bits_batched.cuh
+++ b/onnxruntime/contrib_ops/cuda/quantization/matmul_8bits_batched.cuh
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <cuda_runtime_api.h>
+
+#include <cstdint>
+
+namespace onnxruntime {
+namespace contrib {
+namespace cuda {
+
+template <class T>
+bool TryMatMul8BitsBatched(
+    T* output,
+    const T* a_data,
+    const uint8_t* b_data_quant,
+    const T* scales_data,
+    const uint8_t* zero_points,
+    int m,
+    int n,
+    int k,
+    int block_size,
+    cudaStream_t stream);
+
+}  // namespace cuda
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cuda/quantization/matmul_8bits_batched_bfloat16.cu
+++ b/onnxruntime/contrib_ops/cuda/quantization/matmul_8bits_batched_bfloat16.cu
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "contrib_ops/cuda/quantization/matmul_8bits_batched_impl.cuh"
+
+namespace onnxruntime {
+namespace contrib {
+namespace cuda {
+
+template bool TryMatMul8BitsBatched<nv_bfloat16>(
+    nv_bfloat16*, const nv_bfloat16*, const uint8_t*, const nv_bfloat16*, const uint8_t*,
+    int, int, int, int, cudaStream_t);
+
+}  // namespace cuda
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cuda/quantization/matmul_8bits_batched_float.cu
+++ b/onnxruntime/contrib_ops/cuda/quantization/matmul_8bits_batched_float.cu
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "contrib_ops/cuda/quantization/matmul_8bits_batched_impl.cuh"
+
+namespace onnxruntime {
+namespace contrib {
+namespace cuda {
+
+template bool TryMatMul8BitsBatched<float>(
+    float*, const float*, const uint8_t*, const float*, const uint8_t*,
+    int, int, int, int, cudaStream_t);
+
+}  // namespace cuda
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cuda/quantization/matmul_8bits_batched_half.cu
+++ b/onnxruntime/contrib_ops/cuda/quantization/matmul_8bits_batched_half.cu
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "contrib_ops/cuda/quantization/matmul_8bits_batched_impl.cuh"
+
+namespace onnxruntime {
+namespace contrib {
+namespace cuda {
+
+template bool TryMatMul8BitsBatched<half>(
+    half*, const half*, const uint8_t*, const half*, const uint8_t*,
+    int, int, int, int, cudaStream_t);
+
+}  // namespace cuda
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cuda/quantization/matmul_8bits_batched_impl.cuh
+++ b/onnxruntime/contrib_ops/cuda/quantization/matmul_8bits_batched_impl.cuh
@@ -1,0 +1,275 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+
+#include "core/providers/cuda/cu_inc/common.cuh"
+#include "core/providers/cuda/cu_inc/cuda_type_helper.cuh"
+#include "contrib_ops/cuda/quantization/matmul_8bits_batched.cuh"
+
+namespace onnxruntime {
+namespace contrib {
+namespace cuda {
+namespace {
+
+constexpr int kColsPerThreadBlock = 8;
+constexpr int kElementsPerThreadPerIteration = 8;
+constexpr int kWarpSize = onnxruntime::cuda::GPU_WARP_SIZE;
+constexpr uint8_t kDefaultZeroPoint = 128;
+
+template <class T>
+__device__ __forceinline__ float ToFloat8b(T v);
+template <>
+__device__ __forceinline__ float ToFloat8b<float>(float v) { return v; }
+template <>
+__device__ __forceinline__ float ToFloat8b<half>(half v) { return __half2float(v); }
+template <>
+__device__ __forceinline__ float ToFloat8b<nv_bfloat16>(nv_bfloat16 v) { return __bfloat162float(v); }
+
+template <class T>
+__device__ __forceinline__ void DequantizeEight8b(uint64_t values_quant, T scale, uint8_t zp, float dq[8]) {
+  float scale_f = ToFloat8b<T>(scale);
+#if (!defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 530)
+  const uint32_t kMagicBytes = 0x64646464u;
+  const uint32_t lo32 = static_cast<uint32_t>(values_quant);
+  const uint32_t hi32 = static_cast<uint32_t>(values_quant >> 32);
+  const half2 bias_h2 = __half2half2(
+      __ushort_as_half(static_cast<uint16_t>(0x6400u | static_cast<uint32_t>(zp))));
+
+  uint32_t packed[4];
+  packed[0] = __byte_perm(lo32, kMagicBytes, 0x4140);
+  packed[1] = __byte_perm(lo32, kMagicBytes, 0x4342);
+  packed[2] = __byte_perm(hi32, kMagicBytes, 0x4140);
+  packed[3] = __byte_perm(hi32, kMagicBytes, 0x4342);
+
+#pragma unroll
+  for (int i = 0; i < 4; ++i) {
+    const float2 d = __half22float2(__hsub2(bit_cast<half2>(packed[i]), bias_h2));
+    dq[2 * i] = d.x * scale_f;
+    dq[2 * i + 1] = d.y * scale_f;
+  }
+#else
+  float zp_f = static_cast<float>(zp);
+#pragma unroll
+  for (int i = 0; i < 8; ++i) {
+    uint8_t q = (values_quant >> (i * 8)) & 0xFF;
+    dq[i] = (static_cast<float>(q) - zp_f) * scale_f;
+  }
+#endif
+}
+
+template <class T>
+__device__ __forceinline__ void LoadEightActivations8b(const T* a, float out[8]) {
+#pragma unroll
+  for (int j = 0; j < 8; ++j) {
+    out[j] = ToFloat8b<T>(a[j]);
+  }
+}
+
+template <class T, int block_size, bool has_zero_point, int CtaM, int CtaN>
+__global__ void __launch_bounds__(kWarpSize* kColsPerThreadBlock, 3) MatMulFloat8bKernelBatched(
+    T* output,
+    const T* a_data,
+    const uint8_t* b_data_quant,
+    const T* scales_data,
+    const uint8_t* zero_points,
+    int m,
+    int n,
+    int k,
+    int blocks_per_K) {
+  const int lane_id = threadIdx.x;
+  const int warp_id = threadIdx.y;
+  const int col_base = (blockIdx.x * kColsPerThreadBlock + warp_id) * CtaN;
+  const int m_base = blockIdx.y * CtaM;
+  const int valid = m - m_base;
+  constexpr int k_per_iter = kWarpSize * kElementsPerThreadPerIteration;
+  const int lane_offset = lane_id * kElementsPerThreadPerIteration;
+
+  const T* a_base = a_data + static_cast<size_t>(m_base) * k + lane_offset;
+  const uint8_t* b_ptr[CtaN];
+#pragma unroll
+  for (int c = 0; c < CtaN; ++c) {
+    b_ptr[c] = b_data_quant + static_cast<size_t>(col_base + c) * blocks_per_K * block_size + lane_offset;
+  }
+
+  float acc[CtaM][CtaN];
+#pragma unroll
+  for (int r = 0; r < CtaM; ++r) {
+#pragma unroll
+    for (int c = 0; c < CtaN; ++c) {
+      acc[r][c] = 0.0f;
+    }
+  }
+
+  int k_id = 0;
+  int t_meta_k = lane_offset / block_size;
+  constexpr int kWork = CtaM * CtaN;
+  constexpr int kMainUnroll = (kWork >= 20) ? 1 : (kWork >= 12) ? 2
+                                                                : 4;
+
+#define BATCHED8_BODY(i)                                                                              \
+  do {                                                                                                \
+    float dq[CtaN][8];                                                                                \
+    const int bk = t_meta_k + k_per_iter / block_size * (i);                                          \
+    _Pragma("unroll") for (int c = 0; c < CtaN; ++c) {                                                \
+      uint64_t value = *reinterpret_cast<const uint64_t*>(b_ptr[c] + k_per_iter * (i));               \
+      T scale = scales_data[static_cast<size_t>(col_base + c) * blocks_per_K + bk];                   \
+      uint8_t zp = kDefaultZeroPoint;                                                                 \
+      if constexpr (has_zero_point) {                                                                 \
+        zp = zero_points[static_cast<size_t>(col_base + c) * blocks_per_K + bk];                      \
+      }                                                                                               \
+      DequantizeEight8b<T>(value, scale, zp, dq[c]);                                                  \
+    }                                                                                                 \
+    _Pragma("unroll") for (int r = 0; r < CtaM; ++r) {                                                \
+      if (r < valid) {                                                                                \
+        float av[8];                                                                                  \
+        LoadEightActivations8b<T>(a_base + static_cast<size_t>(r) * k + k_id + (i) * k_per_iter, av); \
+        _Pragma("unroll") for (int c = 0; c < CtaN; ++c) {                                            \
+          float s = 0.0f;                                                                             \
+          _Pragma("unroll") for (int j = 0; j < 8; ++j) {                                             \
+            s = fmaf(av[j], dq[c][j], s);                                                             \
+          }                                                                                           \
+          acc[r][c] += s;                                                                             \
+        }                                                                                             \
+      }                                                                                               \
+    }                                                                                                 \
+  } while (false)
+
+#define BATCHED8_UNROLL(unroll_size)                        \
+  do {                                                      \
+    constexpr int kUnroll = unroll_size;                    \
+    constexpr int kUnrollStep = kUnroll * k_per_iter;       \
+    const int k_unroll_bound = k - k % kUnrollStep;         \
+    for (; k_id < k_unroll_bound; k_id += kUnrollStep) {    \
+      _Pragma("unroll") for (int i = 0; i < kUnroll; ++i) { \
+        BATCHED8_BODY(i);                                   \
+      }                                                     \
+      _Pragma("unroll") for (int c = 0; c < CtaN; ++c) {    \
+        b_ptr[c] += kUnrollStep;                            \
+      }                                                     \
+      t_meta_k += k_per_iter / block_size * kUnroll;        \
+    }                                                       \
+  } while (false)
+
+  BATCHED8_UNROLL(kMainUnroll);
+  BATCHED8_UNROLL(1);
+#undef BATCHED8_UNROLL
+
+  if (lane_offset + k_id < k) {
+    float dq[CtaN][8];
+    const int bk = t_meta_k;
+#pragma unroll
+    for (int c = 0; c < CtaN; ++c) {
+      uint64_t value = *reinterpret_cast<const uint64_t*>(b_ptr[c]);
+      T scale = scales_data[static_cast<size_t>(col_base + c) * blocks_per_K + bk];
+      uint8_t zp = kDefaultZeroPoint;
+      if constexpr (has_zero_point) {
+        zp = zero_points[static_cast<size_t>(col_base + c) * blocks_per_K + bk];
+      }
+      DequantizeEight8b<T>(value, scale, zp, dq[c]);
+    }
+#pragma unroll
+    for (int r = 0; r < CtaM; ++r) {
+      if (r < valid) {
+        float av[8];
+        LoadEightActivations8b<T>(a_base + static_cast<size_t>(r) * k + k_id, av);
+#pragma unroll
+        for (int c = 0; c < CtaN; ++c) {
+          float s = 0.0f;
+#pragma unroll
+          for (int j = 0; j < 8; ++j) {
+            s = fmaf(av[j], dq[c][j], s);
+          }
+          acc[r][c] += s;
+        }
+      }
+    }
+  }
+#undef BATCHED8_BODY
+
+#pragma unroll
+  for (int r = 0; r < CtaM; ++r) {
+    if (r >= valid) continue;
+#pragma unroll
+    for (int c = 0; c < CtaN; ++c) {
+      float sum = acc[r][c];
+      for (int off = kWarpSize / 2; off > 0; off /= 2) {
+        sum += onnxruntime::cuda::WARP_SHFL_DOWN(sum, off);
+      }
+      if (lane_id == 0) {
+        output[static_cast<size_t>(m_base + r) * n + (col_base + c)] = static_cast<T>(sum);
+      }
+    }
+  }
+}
+
+}  // namespace
+
+template <class T>
+bool TryMatMul8BitsBatched(
+    T* output,
+    const T* a_data,
+    const uint8_t* b_data_quant,
+    const T* scales_data,
+    const uint8_t* zero_points,
+    int m,
+    int n,
+    int k,
+    int block_size,
+    cudaStream_t stream) {
+  const int cta_m = (m <= 2) ? 2 : (m <= 4) ? 4
+                                            : 8;
+  const int cta_n = (n % (kColsPerThreadBlock * 2) == 0) ? 2 : 1;
+  const int blocks_per_K = k / block_size;
+  dim3 threads(kWarpSize, kColsPerThreadBlock);
+  dim3 blocks(n / (kColsPerThreadBlock * cta_n), (m + cta_m - 1) / cta_m);
+
+#define MatMulFloat8bBatchedDispatch(bs, cm, cn)                                        \
+  if (nullptr != zero_points) {                                                         \
+    MatMulFloat8bKernelBatched<T, bs, true, cm, cn><<<blocks, threads, 0, stream>>>(    \
+        output, a_data, b_data_quant, scales_data, zero_points, m, n, k, blocks_per_K); \
+  } else {                                                                              \
+    MatMulFloat8bKernelBatched<T, bs, false, cm, cn><<<blocks, threads, 0, stream>>>(   \
+        output, a_data, b_data_quant, scales_data, nullptr, m, n, k, blocks_per_K);     \
+  }
+#define MatMulFloat8bBatchedDispatchN(cm, cn) \
+  if (16 == block_size) {                     \
+    MatMulFloat8bBatchedDispatch(16, cm, cn)  \
+  } else if (32 == block_size) {              \
+    MatMulFloat8bBatchedDispatch(32, cm, cn)  \
+  } else if (64 == block_size) {              \
+    MatMulFloat8bBatchedDispatch(64, cm, cn)  \
+  } else if (128 == block_size) {             \
+    MatMulFloat8bBatchedDispatch(128, cm, cn) \
+  } else if (256 == block_size) {             \
+    MatMulFloat8bBatchedDispatch(256, cm, cn) \
+  } else {                                    \
+    return false;                             \
+  }
+#define MatMulFloat8bBatchedDispatchM(cn)         \
+  switch (cta_m) {                                \
+    case 2:                                       \
+      MatMulFloat8bBatchedDispatchN(2, cn) break; \
+    case 4:                                       \
+      MatMulFloat8bBatchedDispatchN(4, cn) break; \
+    default:                                      \
+      MatMulFloat8bBatchedDispatchN(8, cn) break; \
+  }
+  if (cta_n == 2) {
+    MatMulFloat8bBatchedDispatchM(2)
+  } else {
+    MatMulFloat8bBatchedDispatchM(1)
+  }
+#undef MatMulFloat8bBatchedDispatchM
+#undef MatMulFloat8bBatchedDispatchN
+#undef MatMulFloat8bBatchedDispatch
+
+  return true;
+}
+
+}  // namespace cuda
+}  // namespace contrib
+}  // namespace onnxruntime


### PR DESCRIPTION
The Linux AArch64 CUDA 13 packaging build fails while compiling `matmul_8bits.cu` with a `ptxas` segmentation fault:

```text
nvcc error : 'ptxas' died due to signal 11 (Invalid memory reference)
nvcc error : 'ptxas' core dumped
gmake[2]: *** [CMakeFiles/onnxruntime_providers_cuda.dir/build.make:6715: CMakeFiles/onnxruntime_providers_cuda.dir/onnxruntime_src/onnxruntime/contrib_ops/cuda/quantization/matmul_8bits.cu.o] Error 139
```

The affected translation units contain many template-instantiated CUDA kernels and are compiled for multiple GPU architectures. Splitting the template-heavy batched kernels into smaller dtype-specific translation units reduces per-translation-unit compiler memory pressure while preserving the existing architecture coverage and runtime dispatch boundaries.

## Key Changes

- Split the 8-bit batched MatMulNBits kernels into separate translation units for:
  - `float`
  - `half`
  - `nv_bfloat16`
- Split the 4-bit register-tiled batched MatMulNBits kernels into separate translation units for:
  - `half`
  - `nv_bfloat16`
- Added declaration-only headers and private implementation headers so the public `TryMatMul4Bits<T>` and `TryMatMul8Bits<T>` integration boundaries remain unchanged.
- Kept the generic M=1, small-M, router, and bias-add paths in their existing implementation files.
- Kept the CUDA architecture list unchanged, including the CUDA 13 targets:
  `75-real;80-real;86-real;89-real;90-real;100-real;120-real;120-virtual`.
- CMake source discovery requires no explicit source-list update because the provider build uses recursive CUDA source globs.

## Validation

- Compiled all seven affected CUDA objects with CUDA 13 at `-j8`.
- Verified cross-translation-unit symbol resolution with an `ld -r` partial link.
- Ran `clang-format --dry-run --Werror` on the changed CUDA files.
- Ran `lintrunner` successfully on the changed files.
- Ran `git diff --check` successfully.

Full provider/runtime validation and an end-to-end AArch64 package pipeline rerun were not completed in this environment. The broader provider build was blocked by an unrelated `paged_attention.cc` unused-variable warning treated as an error under `-Werror`.