### PR TITLE
Add CUDA opset 20 ReduceMax int8 tests

### DIFF
--- a/onnxruntime/test/providers/cpu/reduction/reduction_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/reduction/reduction_ops_test.cc
@@ -6682,6 +6682,34 @@ TEST(ReductionOpTest, ReduceMax_int64_Opset20_Cuda) {
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
 }
 
+TEST(ReductionOpTest, ReduceMax_int8_Opset20_Cuda) {
+  OpTester test("ReduceMax", 20);
+  test.AddAttribute("keepdims", (int64_t)1);
+  test.AddInput<int8_t>("data", {3, 2, 2},
+                        {-8, -3, -7, -1,
+                         -5, -2, -6, -4,
+                         -9, -12, -10, -11});
+  test.AddInput<int64_t>("axes", {2}, {1, 2});
+  test.AddOutput<int8_t>("reduced", {3, 1, 1}, {-1, -2, -9});
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(DefaultCudaExecutionProvider());
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+}
+
+TEST(ReductionOpTest, ReduceMax_uint8_Opset20_Cuda) {
+  OpTester test("ReduceMax", 20);
+  test.AddAttribute("keepdims", (int64_t)1);
+  test.AddInput<uint8_t>("data", {3, 2, 2},
+                         {1, 200, 3, 255,
+                          5, 6, 250, 8,
+                          9, 10, 11, 12});
+  test.AddInput<int64_t>("axes", {2}, {1, 2});
+  test.AddOutput<uint8_t>("reduced", {3, 1, 1}, {255, 250, 12});
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(DefaultCudaExecutionProvider());
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+}
+
 TEST(ReductionOpTest, ReduceMin_float_Opset20_Cuda) {
   OpTester test("ReduceMin", 20);
   test.AddAttribute("keepdims", (int64_t)1);

--- a/onnxruntime/test/providers/cpu/reduction/reduction_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/reduction/reduction_ops_test.cc
@@ -11,6 +11,7 @@
 #include "test/providers/provider_test_utils.h"
 #include "test/providers/cpu/reduction/reduction_test_cases.h"
 #include "core/providers/cpu/reduction/reduction_ops.h"
+#include "core/session/onnxruntime_session_options_config_keys.h"
 #include "test/util/include/default_providers.h"
 
 #ifdef USE_WEBGPU
@@ -6691,9 +6692,12 @@ TEST(ReductionOpTest, ReduceMax_int8_Opset20_Cuda) {
                          -9, -12, -10, -11});
   test.AddInput<int64_t>("axes", {2}, {1, 2});
   test.AddOutput<int8_t>("reduced", {3, 1, 1}, {-1, -2, -9});
+  SessionOptions session_options;
+  ASSERT_STATUS_OK(session_options.config_options.AddConfigEntry(
+      kOrtSessionOptionsDisableCPUEPFallback, "1"));
   std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
   execution_providers.push_back(DefaultCudaExecutionProvider());
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+  test.Run(session_options, OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
 }
 
 TEST(ReductionOpTest, ReduceMax_uint8_Opset20_Cuda) {
@@ -6705,9 +6709,12 @@ TEST(ReductionOpTest, ReduceMax_uint8_Opset20_Cuda) {
                           9, 10, 11, 12});
   test.AddInput<int64_t>("axes", {2}, {1, 2});
   test.AddOutput<uint8_t>("reduced", {3, 1, 1}, {255, 250, 12});
+  SessionOptions session_options;
+  ASSERT_STATUS_OK(session_options.config_options.AddConfigEntry(
+      kOrtSessionOptionsDisableCPUEPFallback, "1"));
   std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
   execution_providers.push_back(DefaultCudaExecutionProvider());
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+  test.Run(session_options, OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
 }
 
 TEST(ReductionOpTest, ReduceMin_float_Opset20_Cuda) {


### PR DESCRIPTION
### Description

Add CUDA EP opset 20 `ReduceMax` coverage for `int8_t` and `uint8_t`. The tests use negative signed inputs and high unsigned values, and explicitly run with `DefaultCudaExecutionProvider()`.

Validation:

- Built the `onnxruntime_provider_test` target with CUDA 13.0 and cuDNN 9.24 for SM86.
- Ran both new tests successfully on each of two RTX 3090 GPUs.
- Ran all eight related opset 20 `ReduceMax` CUDA tests successfully.
- Ran `lintrunner` on the changed file with no issues.

### Motivation and Context

Complete the remaining test TODO in #27729 after the opset 20 CUDA registrations added by #27755. This is test-only and does not change kernels or public APIs.
