### PR TITLE
[JS/WebGPU] Preserve attention scale attributes

### DIFF
--- a/js/web/test/data/ops/attention.jsonc
+++ b/js/web/test/data/ops/attention.jsonc
@@ -1,5 +1,27 @@
 [
   {
+    "name": "Attention with explicit scale",
+    "operator": "Attention",
+    "opset": { "domain": "com.microsoft", "version": 1 },
+    "attributes": [
+      { "name": "num_heads", "data": 1, "type": "int" },
+      { "name": "scale", "data": 0.5, "type": "float" }
+    ],
+    "cases": [
+      {
+        "name": "scale=0.5",
+        "inputs": [
+          { "data": [1, 0, 0, 1], "dims": [1, 2, 2], "type": "float32" },
+          { "data": [1, 0, 1, 0, 10, 0, 0, 1, 0, 2, 0, 20], "dims": [2, 6], "type": "float32" },
+          { "data": [0, 0, 0, 0, 0, 0], "dims": [6], "type": "float32" }
+        ],
+        "outputs": [
+          { "data": [6.224593, 7.550813, 2.689414, 14.621172], "dims": [1, 2, 2], "type": "float32" }
+        ]
+      }
+    ]
+  },
+  {
     "name": "Attention Basic",
     "operator": "Attention",
     "opset": { "domain": "com.microsoft", "version": 1 },

--- a/js/web/test/data/ops/multihead-attention.jsonc
+++ b/js/web/test/data/ops/multihead-attention.jsonc
@@ -1,5 +1,31 @@
 [
   {
+    "name": "MultiHeadAttention with explicit scale",
+    "operator": "MultiHeadAttention",
+    "opset": { "domain": "com.microsoft", "version": 1 },
+    "attributes": [
+      { "name": "num_heads", "data": 1, "type": "int" },
+      { "name": "scale", "data": 0.5, "type": "float" }
+    ],
+    "cases": [
+      {
+        "name": "scale=0.5",
+        "inputs": [
+          { "data": [1, 0, 0, 1], "dims": [1, 2, 2], "type": "float32" },
+          { "data": [1, 0, 0, 2], "dims": [1, 2, 2], "type": "float32" },
+          { "data": [10, 0, 0, 20], "dims": [1, 2, 2], "type": "float32" }
+        ],
+        "outputs": [
+          {
+            "data": [6.224593, 7.550813, 2.689414, 14.621172],
+            "dims": [1, 2, 2],
+            "type": "float32"
+          }
+        ]
+      }
+    ]
+  },
+  {
     "name": "MultiHeadAttention Basic, one head",
     "operator": "MultiHeadAttention",
     "opset": { "domain": "com.microsoft", "version": 1 },

--- a/onnxruntime/contrib_ops/js/bert/attention.h
+++ b/onnxruntime/contrib_ops/js/bert/attention.h
@@ -34,7 +34,7 @@ class Attention : public JsKernel, AttentionBase {
                                static_cast<int32_t>(num_heads_),
                                static_cast<int32_t>(is_unidirectional_),
                                static_cast<int32_t>(mask_filter_value_),
-                               static_cast<int32_t>(scale_),
+                               static_cast<float>(scale_),
                                static_cast<int32_t>(do_rotary_),
                                static_cast<int32_t>(qkv_hidden_sizes_.size()),
                                reinterpret_cast<uintptr_t>((qkv_sizes.size() > 0) ? qkv_sizes.data() : nullptr) >> 2,

--- a/onnxruntime/contrib_ops/js/bert/multihead_attention.h
+++ b/onnxruntime/contrib_ops/js/bert/multihead_attention.h
@@ -26,7 +26,7 @@ class MultiHeadAttention : public JsKernel, AttentionBase {
                                static_cast<int32_t>(num_heads_),
                                static_cast<int32_t>(is_unidirectional_),
                                static_cast<int32_t>(mask_filter_value_),
-                               static_cast<int32_t>(scale_),
+                               static_cast<float>(scale_),
                                static_cast<int32_t>(do_rotary_));
   }
 };


### PR DESCRIPTION
### Description

Preserve the floating-point `scale` attribute for `Attention` and `MultiHeadAttention` when forwarding their attributes to the JavaScript implementation.

### Motivation and Context

`AttentionBase` reads the `scale` attribute as a float and stores it in the floating-point `scale_` member. However, the JS bridges for `Attention` and `MultiHeadAttention` cast `scale_` to `int32_t` when forwarding it to JavaScript.

This truncates fractional scales before they reach the WebGPU implementation.

For example, `0.5` becomes `0`, which is interpreted as an unspecified scale and replaced by the default `1 / sqrt(head_size)`. This produces incorrect results.

Forward `scale_` as a float, preserving the type and value stored by the shared `AttentionBase`.

[`AttentionBase::scale_` is declared as a `float`.](https://github.com/microsoft/onnxruntime/blob/v1.28.0/onnxruntime/contrib_ops/cpu/bert/attention_base.h#L105)

Add operator tests for both `Attention` and `MultiHeadAttention` with `scale = 0.5`.
Before this fix, both tests produce the result for the default `1 / sqrt(head_size)` scale instead.