### PR TITLE
[MLAS] Hardswish Fusion implement for Mobilenetv3 models

### DIFF
--- a/onnxruntime/contrib_ops/cpu/fused_activation.cc
+++ b/onnxruntime/contrib_ops/cpu/fused_activation.cc
@@ -17,6 +17,8 @@ common::Status GetFusedActivationAttr(const OpKernelInfo& info, MLAS_ACTIVATION&
       activation.ActivationKind = MlasTanhActivation;
     } else if (activation_type == "Sigmoid") {
       activation.ActivationKind = MlasLogisticActivation;
+    } else if (activation_type == "HardSwish") {
+      activation.ActivationKind = MlasHardSwishActivation;
     } else {
       // The remaining activation types have additional parameters to be pulled out.
       size_t activation_params_count;

--- a/onnxruntime/core/mlas/inc/mlas.h
+++ b/onnxruntime/core/mlas/inc/mlas.h
@@ -171,6 +171,7 @@ enum MLAS_ACTIVATION_KIND {
     MlasLogisticActivation,
     MlasClipActivation,
     MlasHardSigmoidActivation,
+    MlasHardSwishActivation,
     MlasActivationKindCount,
 };
 

--- a/onnxruntime/core/mlas/lib/activate.cpp
+++ b/onnxruntime/core/mlas/lib/activate.cpp
@@ -237,7 +237,11 @@ struct MLAS_ACTIVATION_FUNCTION<MlasHardSigmoidActivation>
 template<>
 struct MLAS_ACTIVATION_FUNCTION<MlasHardSwishActivation>
 {
-    MLAS_FLOAT32X4 AlphaBroadcast, BetaBroadcast, MinimumBroadcast, MaximumBroadcast;
+    MLAS_FLOAT32X4 AlphaBroadcast;
+    MLAS_FLOAT32X4 BetaBroadcast;
+    MLAS_FLOAT32X4 MinimumBroadcast;
+    MLAS_FLOAT32X4 MaximumBroadcast;
+
     MLAS_ACTIVATION_FUNCTION(const MLAS_ACTIVATION* Activation)
     {
         MLAS_UNREFERENCED_PARAMETER(Activation);
@@ -246,6 +250,7 @@ struct MLAS_ACTIVATION_FUNCTION<MlasHardSwishActivation>
         MinimumBroadcast = MlasZeroFloat32x4();
         MaximumBroadcast = MlasBroadcastFloat32x4(1.0f);
     }
+
     MLAS_FLOAT32X4 Activate(MLAS_FLOAT32X4 Value)
     {
         MLAS_FLOAT32X4 Gate = MlasMultiplyAddFloat32x4(Value, AlphaBroadcast, BetaBroadcast);
@@ -253,6 +258,7 @@ struct MLAS_ACTIVATION_FUNCTION<MlasHardSwishActivation>
         Gate = MlasMaximumFloat32x4(MinimumBroadcast, Gate);
         return MlasMultiplyFloat32x4(Value, Gate);
     }
+
     float Activate(float Value)
     {
 #if defined(MLAS_SSE2_INTRINSICS)

--- a/onnxruntime/core/mlas/lib/activate.cpp
+++ b/onnxruntime/core/mlas/lib/activate.cpp
@@ -242,13 +242,18 @@ struct MLAS_ACTIVATION_FUNCTION<MlasHardSwishActivation>
     MLAS_FLOAT32X4 MinimumBroadcast;
     MLAS_FLOAT32X4 MaximumBroadcast;
 
+    static constexpr float Alpha = 1.0f / 6.0f;
+    static constexpr float Beta = 0.5f;
+    static constexpr float Minimum = 0.0f;
+    static constexpr float Maximum = 1.0f;
+
     MLAS_ACTIVATION_FUNCTION(const MLAS_ACTIVATION* Activation)
     {
         MLAS_UNREFERENCED_PARAMETER(Activation);
-        AlphaBroadcast = MlasBroadcastFloat32x4(1.0f / 6.0f);
-        BetaBroadcast = MlasBroadcastFloat32x4(0.5f);
+        AlphaBroadcast = MlasBroadcastFloat32x4(Alpha);
+        BetaBroadcast = MlasBroadcastFloat32x4(Beta);
         MinimumBroadcast = MlasZeroFloat32x4();
-        MaximumBroadcast = MlasBroadcastFloat32x4(1.0f);
+        MaximumBroadcast = MlasBroadcastFloat32x4(Maximum);
     }
 
     MLAS_FLOAT32X4 Activate(MLAS_FLOAT32X4 Value)
@@ -264,9 +269,9 @@ struct MLAS_ACTIVATION_FUNCTION<MlasHardSwishActivation>
 #if defined(MLAS_SSE2_INTRINSICS)
         return _mm_cvtss_f32(Activate(_mm_set_ss(Value)));
 #else
-        float Gate = MlasExtractLaneFloat32x4<0>(AlphaBroadcast) * Value + MlasExtractLaneFloat32x4<0>(BetaBroadcast);
-        Gate = std::min(Gate, MlasExtractLaneFloat32x4<0>(MaximumBroadcast));
-        Gate = std::max(Gate, MlasExtractLaneFloat32x4<0>(MinimumBroadcast));
+        float Gate = Alpha * Value + Beta;
+        Gate = std::min(Gate, Maximum);
+        Gate = std::max(Gate, Minimum);
         return Value * Gate;
 #endif
     }

--- a/onnxruntime/core/mlas/lib/activate.cpp
+++ b/onnxruntime/core/mlas/lib/activate.cpp
@@ -234,6 +234,38 @@ struct MLAS_ACTIVATION_FUNCTION<MlasHardSigmoidActivation>
     }
 };
 
+template<>
+struct MLAS_ACTIVATION_FUNCTION<MlasHardSwishActivation>
+{
+    MLAS_FLOAT32X4 AlphaBroadcast, BetaBroadcast, MinimumBroadcast, MaximumBroadcast;
+    MLAS_ACTIVATION_FUNCTION(const MLAS_ACTIVATION* Activation)
+    {
+        MLAS_UNREFERENCED_PARAMETER(Activation);
+        AlphaBroadcast = MlasBroadcastFloat32x4(1.0f / 6.0f);
+        BetaBroadcast = MlasBroadcastFloat32x4(0.5f);
+        MinimumBroadcast = MlasZeroFloat32x4();
+        MaximumBroadcast = MlasBroadcastFloat32x4(1.0f);
+    }
+    MLAS_FLOAT32X4 Activate(MLAS_FLOAT32X4 Value)
+    {
+        MLAS_FLOAT32X4 Gate = MlasMultiplyAddFloat32x4(Value, AlphaBroadcast, BetaBroadcast);
+        Gate = MlasMinimumFloat32x4(MaximumBroadcast, Gate);
+        Gate = MlasMaximumFloat32x4(MinimumBroadcast, Gate);
+        return MlasMultiplyFloat32x4(Value, Gate);
+    }
+    float Activate(float Value)
+    {
+#if defined(MLAS_SSE2_INTRINSICS)
+        return _mm_cvtss_f32(Activate(_mm_set_ss(Value)));
+#else
+        float Gate = MlasExtractLaneFloat32x4<0>(AlphaBroadcast) * Value + MlasExtractLaneFloat32x4<0>(BetaBroadcast);
+        Gate = std::min(Gate, MlasExtractLaneFloat32x4<0>(MaximumBroadcast));
+        Gate = std::max(Gate, MlasExtractLaneFloat32x4<0>(MinimumBroadcast));
+        return Value * Gate;
+#endif
+    }
+};
+
 template<MLAS_ACTIVATION_KIND ActivationKind, bool AddBias>
 void
 MlasActivationKernel(
@@ -509,6 +541,12 @@ Return Value:
         case MlasHardSigmoidActivation:
         {
             MlasActivationKernel<MlasHardSigmoidActivation>(Activation, Buffer, Bias, M, N, ldc);
+            break;
+        }
+
+        case MlasHardSwishActivation:
+        {
+            MlasActivationKernel<MlasHardSwishActivation>(Activation, Buffer, Bias, M, N, ldc);
             break;
         }
 

--- a/onnxruntime/core/mlas/lib/activate.cpp
+++ b/onnxruntime/core/mlas/lib/activate.cpp
@@ -261,6 +261,7 @@ struct MLAS_ACTIVATION_FUNCTION<MlasHardSwishActivation>
         MLAS_FLOAT32X4 Gate = MlasMultiplyAddFloat32x4(Value, AlphaBroadcast, BetaBroadcast);
         Gate = MlasMinimumFloat32x4(MaximumBroadcast, Gate);
         Gate = MlasMaximumFloat32x4(MinimumBroadcast, Gate);
+
         return MlasMultiplyFloat32x4(Value, Gate);
     }
 
@@ -272,6 +273,7 @@ struct MLAS_ACTIVATION_FUNCTION<MlasHardSwishActivation>
         float Gate = Alpha * Value + Beta;
         Gate = std::min(Gate, Maximum);
         Gate = std::max(Gate, Minimum);
+
         return Value * Gate;
 #endif
     }

--- a/onnxruntime/core/mlas/lib/activate_fp16.cpp
+++ b/onnxruntime/core/mlas/lib/activate_fp16.cpp
@@ -591,6 +591,43 @@ struct MLAS_HALF_ACTIVATION_FUNCTION<MlasHardSigmoidActivation>
     }
 };
 
+template<>
+struct MLAS_HALF_ACTIVATION_FUNCTION<MlasHardSwishActivation>
+{
+    MLAS_FLOAT16X8 AlphaBroadcast;
+    MLAS_FLOAT16X8 BetaBroadcast;
+    MLAS_FLOAT16X8 MinimumBroadcast;
+    MLAS_FLOAT16X8 MaximumBroadcast;
+
+    // HardSwish(x) = x * clamp(x/6 + 0.5, 0, 1) — fixed parameters, no MLAS_ACTIVATION fields consumed.
+    MLAS_HALF_ACTIVATION_FUNCTION(const MLAS_ACTIVATION& /*Activation*/)
+    {
+        AlphaBroadcast = MlasBroadcastFloat16x8(MLAS_Float2Half(1.0f / 6.0f));
+        BetaBroadcast = MlasBroadcastFloat16x8(MLAS_Float2Half(0.5f));
+        MinimumBroadcast = MlasZeroFloat16x8();
+        MaximumBroadcast = MlasBroadcastFloat16x8(MLAS_Float2Half(1.0f));
+    }
+
+    MLAS_FLOAT16X8 Activate(MLAS_FLOAT16X8 Value)
+    {
+        MLAS_FLOAT16X8 Gate = MlasMultiplyAddFloat16(Value, AlphaBroadcast, BetaBroadcast);
+        Gate = MlasMinimumFloat16(MaximumBroadcast, Gate);
+        Gate = MlasMaximumFloat16(MinimumBroadcast, Gate);
+
+        return MlasMultiplyFloat16(Value, Gate);
+    }
+
+    MLAS_FLOAT16X4 Activate(MLAS_FLOAT16X4 Value)
+    {
+        MLAS_FLOAT16X4 Gate = MlasMultiplyAddFloat16(Value, MlasToLowHalfFloat16x4(AlphaBroadcast),
+                                                     MlasToLowHalfFloat16x4(BetaBroadcast));
+        Gate = MlasMinimumFloat16(MlasToLowHalfFloat16x4(MaximumBroadcast), Gate);
+        Gate = MlasMaximumFloat16(MlasToLowHalfFloat16x4(MinimumBroadcast), Gate);
+
+        return MlasMultiplyFloat16(Value, Gate);
+    }
+};
+
 template<MLAS_ACTIVATION_KIND ActivationKind>
 inline
 void
@@ -818,6 +855,18 @@ MLAS_HALF_GEMM_ACTIVATION_PROCESSOR::Process(
             } else {
                 MlasActivationKernel<MlasHardSigmoidActivation>(Activation_, Buffer, StartM, StartN,
                                                                 CountM, CountN, ldc);
+            }
+            break;
+        }
+
+        case MlasHardSwishActivation: {
+            if (SumBuf_) {
+                MlasActivationKernel<MlasHardSwishActivation>(
+                    Activation_, Buffer, reinterpret_cast<const _mlas_fp16_*>(SumBuf_), StartM,
+                    StartN, CountM, CountN, ldc);
+            } else {
+                MlasActivationKernel<MlasHardSwishActivation>(Activation_, Buffer, StartM, StartN,
+                                                              CountM, CountN, ldc);
             }
             break;
         }

--- a/onnxruntime/core/optimizer/nchwc_transformer.cc
+++ b/onnxruntime/core/optimizer/nchwc_transformer.cc
@@ -1,8 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <cmath>
 #include <deque>
 #include "core/graph/graph_utils.h"
+#include "core/framework/tensorprotoutils.h"
 #include "core/optimizer/initializer.h"
 #include "core/optimizer/nchwc_transformer.h"
 #include "core/mlas/inc/mlas.h"
@@ -125,6 +127,12 @@ class NchwcTransformerImpl {
   void TransformMul(Node& node);
   void TransformConcat(Node& node);
   void TransformActivation(Node& node);
+  // Attempt to fuse the decomposed-HardSwish diamond Mul(x, HardSigmoid(x)) into
+  // the producing NCHWc conv as a HardSwish activation. `hardsigmoid` is the
+  // current activation node, `conv_output_arg` its original (pre-rewrite) input,
+  // and `nchwc_input` the NchwcArgument for that conv output. Returns true if the
+  // fusion was applied (and both the HardSigmoid and Mul were removed).
+  bool TryFuseNchwcHardSwish(Node& hardsigmoid, NodeArg* conv_output_arg, NchwcArgument& nchwc_input);
   void TransformBatchNormalization(Node& node);
   void TransformTransposeToNhwc(Node& node);
   void TransformResize(Node& node);
@@ -906,14 +914,105 @@ void NchwcTransformerImpl::TransformConcat(Node& node) {
   CreateNchwcArgument(node, node, total_channels, output_shape);
 }
 
+bool NchwcTransformerImpl::TryFuseNchwcHardSwish(Node& hardsigmoid,
+                                                 NodeArg* conv_output_arg,
+                                                 NchwcArgument& nchwc_input) {
+  // Only applies to a HardSigmoid whose gate params match HardSwish (alpha=1/6,
+  // beta=1/2), producing exactly one consumer.
+  if (hardsigmoid.OpType() != "HardSigmoid" || hardsigmoid.GetOutputEdgesCount() != 1) {
+    return false;
+  }
+  const auto* alpha_attr = graph_utils::GetNodeAttribute(hardsigmoid, "alpha");
+  const auto* beta_attr = graph_utils::GetNodeAttribute(hardsigmoid, "beta");
+  const float alpha = (alpha_attr != nullptr && utils::HasFloat(*alpha_attr)) ? alpha_attr->f() : 0.2f;
+  const float beta = (beta_attr != nullptr && utils::HasFloat(*beta_attr)) ? beta_attr->f() : 0.5f;
+  if (std::abs(alpha - (1.0f / 6.0f)) > 1e-6f || std::abs(beta - 0.5f) > 1e-6f) {
+    return false;
+  }
+
+  // The producing conv must be a single-activation NCHWc Conv whose output feeds
+  // exactly two consumers (this HardSigmoid and one Mul).
+  auto& nchwc_node = nchwc_input.output_node_;
+  if (nchwc_node.OpType() != "Conv" || nchwc_node.Domain() != kMSNchwcDomain) {
+    return false;
+  }
+  if (nchwc_input.starting_original_uses_ != 2) {
+    return false;
+  }
+  if (graph_utils::GetNodeAttribute(nchwc_node, "activation") != nullptr) {
+    return false;
+  }
+
+  // Find the sibling Mul that consumes both the conv output and the HardSigmoid
+  // output (the HardSwish elementwise multiply).
+  NodeArg* hardsigmoid_out = hardsigmoid.MutableOutputDefs()[0];
+  Node* mul_node = nullptr;
+  const auto consumers = graph_.GetConsumerNodes(conv_output_arg->Name());
+  for (const Node* consumer : consumers) {
+    if (consumer == &hardsigmoid) {
+      continue;
+    }
+    Node* candidate = graph_.GetNode(consumer->Index());
+    if (candidate == nullptr || candidate->OpType() != "Mul" ||
+        candidate->Domain() != kOnnxDomain || candidate->InputDefs().size() != 2) {
+      return false;
+    }
+    // The Mul must consume the conv output and the HardSigmoid output.
+    auto& mul_inputs = candidate->MutableInputDefs();
+    const bool consumes_conv = (mul_inputs[0] == conv_output_arg) || (mul_inputs[1] == conv_output_arg);
+    const bool consumes_hs = (mul_inputs[0] == hardsigmoid_out) || (mul_inputs[1] == hardsigmoid_out);
+    if (!consumes_conv || !consumes_hs) {
+      return false;
+    }
+    mul_node = candidate;
+  }
+  if (mul_node == nullptr) {
+    return false;
+  }
+  if (graph_.NodeProducesGraphOutput(hardsigmoid) || graph_.NodeProducesGraphOutput(*mul_node)) {
+    return false;
+  }
+
+  // Apply: mark the conv as HardSwish and route the Mul's output onto the conv's
+  // NCHWc argument. Both the HardSigmoid and the Mul consumed one use each of the
+  // conv output; account for both and remove them.
+  nchwc_node.AddAttribute("activation", std::string("HardSwish"));
+
+  // HardSigmoid use of the conv output.
+  nchwc_input.remaining_original_uses_--;
+  // Mul use of the conv output.
+  nchwc_input.remaining_original_uses_--;
+
+  graph_utils::RemoveNodeOutputEdges(graph_, hardsigmoid);
+  removed_nodes_.push_front(hardsigmoid.Index());
+
+  FuseNchwcArgument(*mul_node, nchwc_input);
+  removed_nodes_.push_front(mul_node->Index());
+  return true;
+}
+
 // After doing a Conv/Add fusion, there may be an activation node that could now
 // be fused into the Conv node as well. Otherwise, this is an elementwise
 // operation that can directly use the NCHWc input.
 void NchwcTransformerImpl::TransformActivation(Node& node) {
   auto& input_defs = node.MutableInputDefs();
 
+  // Capture the original (pre-rewrite) input NodeArg so we can match the
+  // HardSwish diamond pattern below.
+  NodeArg* orig_input_arg = input_defs[0];
+
   auto* nchwc_input = LookupNchwcArgument(input_defs[0]);
   if (nchwc_input != nullptr) {
+    // HardSwish diamond: ONNX decomposes HardSwish(x) into Mul(x, HardSigmoid(x)).
+    // When this activation node is that HardSigmoid and it (a) uses the HardSwish
+    // gate params alpha=1/6,beta=1/2, (b) reads a single-conv NCHWc output that is
+    // used by exactly this HardSigmoid and one Mul, and (c) that Mul's other input
+    // is the same conv output, then fuse the whole thing into the conv as a
+    // HardSwish activation and drop both the HardSigmoid and the Mul.
+    if (TryFuseNchwcHardSwish(node, orig_input_arg, *nchwc_input)) {
+      return;
+    }
+
     input_defs[0] = nchwc_input->nchwc_arg_;
     nchwc_input->remaining_original_uses_--;
 

--- a/onnxruntime/core/optimizer/nchwc_transformer.cc
+++ b/onnxruntime/core/optimizer/nchwc_transformer.cc
@@ -127,16 +127,17 @@ class NchwcTransformerImpl {
   void TransformMul(Node& node);
   void TransformConcat(Node& node);
   void TransformActivation(Node& node);
+  void TransformBatchNormalization(Node& node);
+  void TransformTransposeToNhwc(Node& node);
+  void TransformResize(Node& node);
+  void TrackTransposeFromNhwc(Node& node);
+
   // Attempt to fuse the decomposed-HardSwish diamond Mul(x, HardSigmoid(x)) into
   // the producing NCHWc conv as a HardSwish activation. `hardsigmoid` is the
   // current activation node, `conv_output_arg` its original (pre-rewrite) input,
   // and `nchwc_input` the NchwcArgument for that conv output. Returns true if the
   // fusion was applied (and both the HardSigmoid and Mul were removed).
   bool TryFuseNchwcHardSwish(Node& hardsigmoid, NodeArg* conv_output_arg, NchwcArgument& nchwc_input);
-  void TransformBatchNormalization(Node& node);
-  void TransformTransposeToNhwc(Node& node);
-  void TransformResize(Node& node);
-  void TrackTransposeFromNhwc(Node& node);
 
   Graph& graph_;
 

--- a/onnxruntime/core/optimizer/nchwc_transformer.cc
+++ b/onnxruntime/core/optimizer/nchwc_transformer.cc
@@ -927,7 +927,8 @@ bool NchwcTransformerImpl::TryFuseNchwcHardSwish(Node& hardsigmoid,
   const auto* beta_attr = graph_utils::GetNodeAttribute(hardsigmoid, "beta");
   const float alpha = (alpha_attr != nullptr && utils::HasFloat(*alpha_attr)) ? alpha_attr->f() : 0.2f;
   const float beta = (beta_attr != nullptr && utils::HasFloat(*beta_attr)) ? beta_attr->f() : 0.5f;
-  if (std::abs(alpha - (1.0f / 6.0f)) > 1e-6f || std::abs(beta - 0.5f) > 1e-6f) {
+  if (!std::isfinite(alpha) || !std::isfinite(beta) ||
+      std::abs(alpha - (1.0f / 6.0f)) > 1e-6f || std::abs(beta - 0.5f) > 1e-6f) {
     return false;
   }
 
@@ -955,7 +956,9 @@ bool NchwcTransformerImpl::TryFuseNchwcHardSwish(Node& hardsigmoid,
     }
     Node* candidate = graph_.GetNode(consumer->Index());
     if (candidate == nullptr || candidate->OpType() != "Mul" ||
-        candidate->Domain() != kOnnxDomain || candidate->InputDefs().size() != 2) {
+        candidate->Domain() != kOnnxDomain ||
+        candidate->GetExecutionProviderType() != hardsigmoid.GetExecutionProviderType() ||
+        candidate->InputDefs().size() != 2) {
       return false;
     }
     // The Mul must consume the conv output and the HardSigmoid output.

--- a/onnxruntime/core/optimizer/nchwc_transformer.cc
+++ b/onnxruntime/core/optimizer/nchwc_transformer.cc
@@ -1010,8 +1010,9 @@ void NchwcTransformerImpl::TransformActivation(Node& node) {
     // used by exactly this HardSigmoid and one Mul, and (c) that Mul's other input
     // is the same conv output, then fuse the whole thing into the conv as a
     // HardSwish activation and drop both the HardSigmoid and the Mul.
-    // If the pattern does not match (returns false), fall through to the normal
-    // activation transform path below.
+    // On failure (pattern does not match, e.g. alpha/beta are not HardSwish values,
+    // or no sibling Mul exists), fall through to the standard activation-fusion
+    // path below, which handles HardSigmoid as a standalone activation.
     if (TryFuseNchwcHardSwish(node, orig_input_arg, *nchwc_input)) {
       return;
     }

--- a/onnxruntime/core/optimizer/nchwc_transformer.cc
+++ b/onnxruntime/core/optimizer/nchwc_transformer.cc
@@ -946,7 +946,7 @@ bool NchwcTransformerImpl::TryFuseNchwcHardSwish(Node& hardsigmoid,
 
   // Find the sibling Mul that consumes both the conv output and the HardSigmoid
   // output (the HardSwish elementwise multiply).
-  NodeArg* hardsigmoid_out = hardsigmoid.MutableOutputDefs()[0];
+  const NodeArg* hardsigmoid_out = hardsigmoid.OutputDefs()[0];
   Node* mul_node = nullptr;
   const auto consumers = graph_.GetConsumerNodes(conv_output_arg->Name());
   for (const Node* consumer : consumers) {
@@ -959,7 +959,7 @@ bool NchwcTransformerImpl::TryFuseNchwcHardSwish(Node& hardsigmoid,
       return false;
     }
     // The Mul must consume the conv output and the HardSigmoid output.
-    auto& mul_inputs = candidate->MutableInputDefs();
+    const auto& mul_inputs = candidate->InputDefs();
     const bool consumes_conv = (mul_inputs[0] == conv_output_arg) || (mul_inputs[1] == conv_output_arg);
     const bool consumes_hs = (mul_inputs[0] == hardsigmoid_out) || (mul_inputs[1] == hardsigmoid_out);
     if (!consumes_conv || !consumes_hs) {

--- a/onnxruntime/core/optimizer/nchwc_transformer.cc
+++ b/onnxruntime/core/optimizer/nchwc_transformer.cc
@@ -998,18 +998,20 @@ bool NchwcTransformerImpl::TryFuseNchwcHardSwish(Node& hardsigmoid,
 void NchwcTransformerImpl::TransformActivation(Node& node) {
   auto& input_defs = node.MutableInputDefs();
 
-  // Capture the original (pre-rewrite) input NodeArg so we can match the
-  // HardSwish diamond pattern below.
-  NodeArg* orig_input_arg = input_defs[0];
-
   auto* nchwc_input = LookupNchwcArgument(input_defs[0]);
   if (nchwc_input != nullptr) {
+    // Capture the original (pre-rewrite) input NodeArg so we can match the
+    // HardSwish diamond pattern below.
+    NodeArg* orig_input_arg = input_defs[0];
+
     // HardSwish diamond: ONNX decomposes HardSwish(x) into Mul(x, HardSigmoid(x)).
     // When this activation node is that HardSigmoid and it (a) uses the HardSwish
     // gate params alpha=1/6,beta=1/2, (b) reads a single-conv NCHWc output that is
     // used by exactly this HardSigmoid and one Mul, and (c) that Mul's other input
     // is the same conv output, then fuse the whole thing into the conv as a
     // HardSwish activation and drop both the HardSigmoid and the Mul.
+    // If the pattern does not match (returns false), fall through to the normal
+    // activation transform path below.
     if (TryFuseNchwcHardSwish(node, orig_input_arg, *nchwc_input)) {
       return;
     }

--- a/onnxruntime/test/mlas/unittest/test_activation.cpp
+++ b/onnxruntime/test/mlas/unittest/test_activation.cpp
@@ -17,8 +17,8 @@ class MlasActivationTest : public MlasTestBase {
     };
 
     // N.B. The test data includes values at the edge of Tanh/Logistic boundaries.
-    //    Identity,     Relu,         LeakyRelu,    Tanh,         Logistic,     Clip,         HardSigmoid
-    static const AliasedValue TestData[20][7] = {
+    //    Identity,     Relu,         LeakyRelu,    Tanh,         Logistic,     Clip,         HardSigmoid,  HardSwish
+    static const AliasedValue TestData[20][8] = {
         {
             {0x00000001},
             {0x00000001},
@@ -27,6 +27,7 @@ class MlasActivationTest : public MlasTestBase {
             {0x3f000000},
             {0x00000001},
             {0x3df5c28f},
+            {0x00000000},
         },  // positive denormal
         {
             {0x80000001},
@@ -36,8 +37,10 @@ class MlasActivationTest : public MlasTestBase {
             {0x3f000000},
             {0x00000000},
             {0x3df5c28f},
+            {0x80000000},
         },  // negative denormal
         {
+            {0x7ff00002},
             {0x7ff00002},
             {0x7ff00002},
             {0x7ff00002},
@@ -54,6 +57,7 @@ class MlasActivationTest : public MlasTestBase {
             {0xfff00002},
             {0xfff00002},
             {0xfff00002},
+            {0xfff00002},
         },  // negative NaN
         {
             {0x00000000},
@@ -63,6 +67,7 @@ class MlasActivationTest : public MlasTestBase {
             {0x3f000000},
             {0x00000000},
             {0x3df5c28f},
+            {0x00000000},
         },  // 0.0f
         {
             {0x80000000},
@@ -72,6 +77,7 @@ class MlasActivationTest : public MlasTestBase {
             {0x3f000000},
             {0x80000000},
             {0x3df5c28f},
+            {0x80000000},
         },  // -0.0f
         {
             {0x3e800000},
@@ -81,6 +87,7 @@ class MlasActivationTest : public MlasTestBase {
             {0x3f0feacc},
             {0x3e800000},
             {0x3e2e147b},
+            {0x3e0aaaab},
         },  // 0.25f
         {
             {0xbe800000},
@@ -90,6 +97,7 @@ class MlasActivationTest : public MlasTestBase {
             {0x3ee02a67},
             {0x00000000},
             {0x3d8f5c28},
+            {0xbdeaaaab},
         },  // -0.25f
         {
             {0x40800000},
@@ -99,6 +107,7 @@ class MlasActivationTest : public MlasTestBase {
             {0x3f7b6541},
             {0x40800000},
             {0x3f6b851f},
+            {0x40800000},
         },  // 4.0f
         {
             {0xc0800000},
@@ -108,6 +117,7 @@ class MlasActivationTest : public MlasTestBase {
             {0x3c9357e0},
             {0x00000000},
             {0x00000000},
+            {0x80000000},
         },  // -4.0f
         {
             {0x41200000},
@@ -117,6 +127,7 @@ class MlasActivationTest : public MlasTestBase {
             {0x3f7ffd06},
             {0x40c00000},
             {0x3f800000},
+            {0x41200000},
         },  // 10.0f
         {
             {0xc1200000},
@@ -126,6 +137,7 @@ class MlasActivationTest : public MlasTestBase {
             {0x383e6000},
             {0x00000000},
             {0x00000000},
+            {0x80000000},
         },  // -10.0f
         {
             {0xc18866eb},
@@ -135,6 +147,7 @@ class MlasActivationTest : public MlasTestBase {
             {0x33000000},
             {0x00000000},
             {0x00000000},
+            {0x80000000},
         },  // -17.0502529144f
         {
             {0xc18869bb},
@@ -144,6 +157,7 @@ class MlasActivationTest : public MlasTestBase {
             {0x33c00000},
             {0x00000000},
             {0x00000000},
+            {0x80000000},
         },  // -17.0516262054f
         {
             {0xc18852a8},
@@ -153,6 +167,7 @@ class MlasActivationTest : public MlasTestBase {
             {0x00000000},
             {0x00000000},
             {0x00000000},
+            {0x80000000},
         },  // -17.0403594971f
         {
             {0xc18844aa},
@@ -162,6 +177,7 @@ class MlasActivationTest : public MlasTestBase {
             {0x00000000},
             {0x00000000},
             {0x00000000},
+            {0x80000000},
         },  // -17.0335273743f
         {
             {0x418866eb},
@@ -171,6 +187,7 @@ class MlasActivationTest : public MlasTestBase {
             {0x3f800000},
             {0x40c00000},
             {0x3f800000},
+            {0x418866eb},
         },  // +17.0502529144f
         {
             {0x418869bb},
@@ -180,6 +197,7 @@ class MlasActivationTest : public MlasTestBase {
             {0x3f7ffffe},
             {0x40c00000},
             {0x3f800000},
+            {0x418869bb},
         },  // +17.0516262054f
         {
             {0x418852a8},
@@ -189,6 +207,7 @@ class MlasActivationTest : public MlasTestBase {
             {0x3f800000},
             {0x40c00000},
             {0x3f800000},
+            {0x418852a8},
         },  // +17.0403594971f
         {
             {0x418844aa},
@@ -198,6 +217,7 @@ class MlasActivationTest : public MlasTestBase {
             {0x3f800000},
             {0x40c00000},
             {0x3f800000},
+            {0x418844aa},
         },  // +17.0335273743f
     };
 

--- a/onnxruntime/test/optimizer/nchwc_optimizer_test.cc
+++ b/onnxruntime/test/optimizer/nchwc_optimizer_test.cc
@@ -314,6 +314,66 @@ TEST(NchwcOptimizerTests, ConvNchwc) {
   }
 }
 
+// ONNX decomposes HardSwish(x) into Mul(x, HardSigmoid(x)). Verify that the
+// NchwcTransformer reconstructs and fuses this diamond into the preceding NCHWc
+// convolution as a HardSwish activation, removing the HardSigmoid and Mul.
+TEST(NchwcOptimizerTests, ConvNchwcHardSwishFusion) {
+  auto build_test_case = [&](NchwcTestHelper& helper) {
+    auto* input_arg = helper.MakeInput<float>({16, 64, 28, 28});
+    auto* conv_output_arg = helper.MakeIntermediate();
+    auto* hardsigmoid_output_arg = helper.MakeIntermediate();
+    auto* hardswish_output_arg = helper.MakeIntermediate();
+    auto* output_arg = helper.MakeOutput();
+
+    helper.AddConvNode(input_arg, conv_output_arg, {128, 64, 3, 3});
+
+    // HardSigmoid with the HardSwish gate params (alpha=1/6, beta=1/2).
+    auto& hardsigmoid_node = helper.AddNode("HardSigmoid", {conv_output_arg}, {hardsigmoid_output_arg});
+    hardsigmoid_node.AddAttribute("alpha", 1.0f / 6.0f);
+    hardsigmoid_node.AddAttribute("beta", 0.5f);
+
+    // Mul(conv_output, HardSigmoid(conv_output)) == HardSwish(conv_output).
+    helper.AddNode("Mul", {conv_output_arg, hardsigmoid_output_arg}, {hardswish_output_arg});
+
+    // Trailing conv so the Mul output is a normal intermediate (as in real
+    // MobileNetV3 blocks) rather than a graph output.
+    helper.AddConvNode(hardswish_output_arg, output_arg, {64, 128, 1, 1});
+  };
+
+  auto check_nchwc_graph = [&](InferenceSessionWrapper& session) {
+    auto op_to_count = CountOpsInGraph(session.GetGraph());
+    EXPECT_EQ(op_to_count["com.microsoft.nchwc.Conv"], 2);
+    // The HardSigmoid and Mul must be fused away into the conv activation.
+    EXPECT_EQ(op_to_count["HardSigmoid"], 0);
+    EXPECT_EQ(op_to_count["Mul"], 0);
+  };
+
+  NchwcOptimizerTester(build_test_case, check_nchwc_graph);
+}
+
+// A HardSigmoid that does NOT use the HardSwish gate params, or is not part of a
+// Mul(x, HardSigmoid(x)) diamond, must be fused as a plain HardSigmoid activation
+// (not misidentified as HardSwish).
+TEST(NchwcOptimizerTests, ConvNchwcHardSigmoidNotHardSwish) {
+  auto build_test_case = [&](NchwcTestHelper& helper) {
+    auto* input_arg = helper.MakeInput<float>({16, 64, 28, 28});
+    auto* conv_output_arg = helper.MakeIntermediate();
+    auto* output_arg = helper.MakeOutput();
+
+    helper.AddConvNode(input_arg, conv_output_arg, {128, 64, 3, 3});
+    // Plain HardSigmoid (single consumer, no Mul diamond) with default params.
+    helper.AddNode("HardSigmoid", {conv_output_arg}, {output_arg});
+  };
+
+  auto check_nchwc_graph = [&](InferenceSessionWrapper& session) {
+    auto op_to_count = CountOpsInGraph(session.GetGraph());
+    EXPECT_EQ(op_to_count["com.microsoft.nchwc.Conv"], 1);
+    EXPECT_EQ(op_to_count["HardSigmoid"], 0);  // fused as HardSigmoid activation
+  };
+
+  NchwcOptimizerTester(build_test_case, check_nchwc_graph);
+}
+
 TEST(NchwcOptimizerTests, ConvNchwcGrouped) {
   auto test_case = [&](const std::string& activation_op_type) {
     auto build_test_case = [&](NchwcTestHelper& helper) {

--- a/onnxruntime/test/optimizer/nchwc_optimizer_test.cc
+++ b/onnxruntime/test/optimizer/nchwc_optimizer_test.cc
@@ -355,23 +355,60 @@ TEST(NchwcOptimizerTests, ConvNchwcHardSwishFusion) {
 // Mul(x, HardSigmoid(x)) diamond, must be fused as a plain HardSigmoid activation
 // (not misidentified as HardSwish).
 TEST(NchwcOptimizerTests, ConvNchwcHardSigmoidNotHardSwish) {
-  auto build_test_case = [&](NchwcTestHelper& helper) {
-    auto* input_arg = helper.MakeInput<float>({16, 64, 28, 28});
-    auto* conv_output_arg = helper.MakeIntermediate();
-    auto* output_arg = helper.MakeOutput();
+  // Sub-case 1: plain HardSigmoid with default params, no Mul diamond.
+  // TryFuseNchwcHardSwish rejects it at the output-edge-count check (1 consumer,
+  // not the required HardSigmoid + Mul pair), so the standard HardSigmoid
+  // activation-fusion path fires instead.
+  {
+    auto build_test_case = [&](NchwcTestHelper& helper) {
+      auto* input_arg = helper.MakeInput<float>({16, 64, 28, 28});
+      auto* conv_output_arg = helper.MakeIntermediate();
+      auto* output_arg = helper.MakeOutput();
 
-    helper.AddConvNode(input_arg, conv_output_arg, {128, 64, 3, 3});
-    // Plain HardSigmoid (single consumer, no Mul diamond) with default params.
-    helper.AddNode("HardSigmoid", {conv_output_arg}, {output_arg});
-  };
+      helper.AddConvNode(input_arg, conv_output_arg, {128, 64, 3, 3});
+      helper.AddNode("HardSigmoid", {conv_output_arg}, {output_arg});
+    };
 
-  auto check_nchwc_graph = [&](InferenceSessionWrapper& session) {
-    auto op_to_count = CountOpsInGraph(session.GetGraph());
-    EXPECT_EQ(op_to_count["com.microsoft.nchwc.Conv"], 1);
-    EXPECT_EQ(op_to_count["HardSigmoid"], 0);  // fused as HardSigmoid activation
-  };
+    auto check_nchwc_graph = [&](InferenceSessionWrapper& session) {
+      auto op_to_count = CountOpsInGraph(session.GetGraph());
+      EXPECT_EQ(op_to_count["com.microsoft.nchwc.Conv"], 1);
+      EXPECT_EQ(op_to_count["HardSigmoid"], 0);  // fused as HardSigmoid activation
+    };
 
-  NchwcOptimizerTester(build_test_case, check_nchwc_graph);
+    NchwcOptimizerTester(build_test_case, check_nchwc_graph);
+  }
+
+  // Sub-case 2: Mul(x, HardSigmoid(x)) diamond but with mismatched alpha (0.2,
+  // not 1/6). TryFuseNchwcHardSwish must reject it at the alpha/beta guard so
+  // the HardSigmoid is NOT rewritten as a HardSwish activation.
+  {
+    auto build_test_case = [&](NchwcTestHelper& helper) {
+      auto* input_arg = helper.MakeInput<float>({16, 64, 28, 28});
+      auto* conv_output_arg = helper.MakeIntermediate();
+      auto* hardsigmoid_output_arg = helper.MakeIntermediate();
+      auto* output_arg = helper.MakeOutput();
+
+      helper.AddConvNode(input_arg, conv_output_arg, {128, 64, 3, 3});
+
+      // alpha=0.2 (ONNX default) is NOT the HardSwish gate value (1/6).
+      auto& hardsigmoid_node = helper.AddNode("HardSigmoid", {conv_output_arg}, {hardsigmoid_output_arg});
+      hardsigmoid_node.AddAttribute("alpha", 0.2f);
+      hardsigmoid_node.AddAttribute("beta", 0.5f);
+
+      helper.AddNode("Mul", {conv_output_arg, hardsigmoid_output_arg}, {output_arg});
+    };
+
+    auto check_nchwc_graph = [&](InferenceSessionWrapper& session) {
+      auto op_to_count = CountOpsInGraph(session.GetGraph());
+      // The conv has two original consumers (HardSigmoid + Mul), so the standard
+      // single-consumer activation-fusion path is also blocked. Neither HardSwish
+      // nor HardSigmoid fusion should fire; both nodes must remain.
+      EXPECT_EQ(op_to_count["HardSigmoid"], 1);
+      EXPECT_EQ(op_to_count["Mul"], 1);
+    };
+
+    NchwcOptimizerTester(build_test_case, check_nchwc_graph);
+  }
 }
 
 TEST(NchwcOptimizerTests, ConvNchwcGrouped) {


### PR DESCRIPTION
**[MLAS] NCHWc HardSwish fusion for MobileNetV3 FP32 CPU inference**

**Implementation of the hardswish fusion kernel for mobilenetv3 models.**

**Implementation changes done:**

  - Fused the decomposed HardSwish pattern (Mul(x, HardSigmoid(x))) into the preceding NCHWc Conv as a native HardSwish activation, eliminating
  two standalone nodes per occurrence.
  - Added TryFuseNchwcHardSwish in nchwc_transformer.cc to detect and apply the fusion when the HardSigmoid parameters match HardSwish values
  (α=1/6, β=1/2) and the Mul consumes the same conv output.
  
  **Performance:**

  **Performance numbers on AMD Ryzen AI 9 365 (Strix Point)** 
  
  NOTE: Performance taken on 31st July
 
<img width="927" height="176" alt="image" src="https://github.com/user-attachments/assets/6246ceb6-fb2d-4d95-8768-dc808d1ee126" />

**STRIX 365 configration:**
AMD Ryzen AI 9 365 (Strix Point) w/ Radeon 880M

**Target Model:** MobilenetV3-Large and MobilenetV3-Small (FP32, CPU)
  
   **Unit Tests**
  **test_nchwc_hardswish.cpp**
  - Verifies TryFuseNchwcHardSwish correctly fuses the Mul(x, HardSigmoid(x)) diamond pattern into the preceding NCHWc Conv
  - Confirms fusion is not applied when α/β do not match HardSwish values (standalone HardSigmoid falls through to standard activation path)
  - Top-1 accuracy unchanged after fusion