### PR TITLE
[Build] Fix cuda plugin CI test failure

### DIFF
--- a/onnxruntime/test/python/transformers/test_cuda_plugin_ep.py
+++ b/onnxruntime/test/python/transformers/test_cuda_plugin_ep.py
@@ -1683,10 +1683,12 @@ class TestCudaPluginEP(unittest.TestCase):
         feed = {"data": data, "indices": indices, "scales": scales}
 
         def expected(f):
-            # Gather rows [0, 2], then dequantize: float_val = uint8_val * scale
+            # Gather rows [0, 2], then dequantize. When zero_points is omitted, the default zero point
+            # for uint8 data is 2^(bits - 1), i.e. 128 for bits=8.
+            default_zero_point = np.float32(1 << (8 - 1))
             gathered_data = f["data"][f["indices"]]  # [2, 16]
             gathered_scales = f["scales"][f["indices"]]  # [2, 1]
-            return gathered_data.astype(np.float32) * gathered_scales
+            return (gathered_data.astype(np.float32) - default_zero_point) * gathered_scales
 
         result = _run_model_test(target_device, "GatherBlockQuantized", model, feed, expected, rtol=1e-2, atol=1e-2)
         self.assertEqual(result, TEST_PASS, "GatherBlockQuantized plugin op test failed")

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-win-cuda-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-win-cuda-stage.yml
@@ -381,6 +381,11 @@ stages:
           targetPath: '$(Build.BinariesDirectory)\plugin_artifacts'
 
       - powershell: |
+          if ('${{ parameters.arch }}' -eq 'arm64') {
+            $env:_PYTHON_HOST_PLATFORM = 'win-arm64'
+          } else {
+            $env:_PYTHON_HOST_PLATFORM = 'win-amd64'
+          }
           python -m pip install -r "$(Build.SourcesDirectory)\plugin-ep-cuda\python\requirements-build-wheel.txt"
           python "$(Build.SourcesDirectory)\plugin-ep-cuda\python\build_wheel.py" `
             --binary_dir "$(Build.BinariesDirectory)\plugin_artifacts\bin" `


### PR DESCRIPTION
Fix a cuda plugin test error caused by a recent commit of https://github.com/microsoft/onnxruntime/pull/31693.

There is some change in plugin-win-cuda-stage.yml. That's not needed. It does not change results so leave it as it is.


