### PR TITLE
Avoid joining parent thread pools in forked children

### DIFF
--- a/include/onnxruntime/core/platform/threadpool.h
+++ b/include/onnxruntime/core/platform/threadpool.h
@@ -451,6 +451,7 @@ class ThreadPool {
 
   std::string StopProfiling();
 
+  const unsigned int creator_pid_;
   ThreadOptions thread_options_;
 
   // If a thread pool is created with degree_of_parallelism != 1 then an underlying

--- a/onnxruntime/core/common/threadpool.cc
+++ b/onnxruntime/core/common/threadpool.cc
@@ -20,6 +20,7 @@ limitations under the License.
 #include "core/common/common.h"
 #include "core/common/cpuid_info.h"
 #include "core/common/eigen_common_wrapper.h"
+#include "core/common/logging/logging.h"
 #include "core/platform/EigenNonBlockingThreadPool.h"
 #include <mutex>
 #if !defined(ORT_MINIMAL_BUILD)
@@ -377,7 +378,7 @@ ThreadPool::ThreadPool(Env* env,
                        int spin_duration_us,
                        bool force_hybrid,
                        unsigned int spin_backoff_max)
-    : thread_options_(thread_options), force_hybrid_(force_hybrid) {
+    : creator_pid_(logging::GetProcessId()), thread_options_(thread_options), force_hybrid_(force_hybrid) {
   // In the current implementation, a thread pool with degree_of_parallelism==1 uses
   // the caller as one of the threads for executing work.  Hence we only create
   // additional thread(s) for degree_of_parallelism>=2.
@@ -405,7 +406,14 @@ ThreadPool::ThreadPool(Env* env,
   }
 }
 
-ThreadPool::~ThreadPool() = default;
+ThreadPool::~ThreadPool() {
+  if (creator_pid_ != logging::GetProcessId()) {
+    // Intentionally abandon this copied pool. Its destructor would touch inherited
+    // synchronization state and thread handles owned by the parent. The OS reclaims
+    // the child's copy when the process exits.
+    extended_eigen_threadpool_.release();
+  }
+}
 
 // Base case for parallel loops, running iterations 0..total, divided into blocks
 // of block_size iterations, and calling into a function that takes a start..end

--- a/onnxruntime/test/platform/threadpool_test.cc
+++ b/onnxruntime/test/platform/threadpool_test.cc
@@ -16,6 +16,11 @@
 #include <memory>
 #include <functional>
 
+#if defined(__linux__) && !defined(__ANDROID__)
+#include <sys/wait.h>
+#include <unistd.h>
+#endif
+
 #ifdef _WIN32
 #include <Windows.h>
 #endif
@@ -233,6 +238,24 @@ void TestStagedMultiLoopSections(const std::string& name, int num_threads, int n
 }  // namespace
 
 namespace onnxruntime {
+#if defined(__linux__) && !defined(__ANDROID__)
+TEST(ThreadPoolTest, DestructionAfterForkDoesNotJoinParentThreads) {
+  auto thread_pool = std::make_unique<ThreadPool>(&Env::Default(), ThreadOptions{}, nullptr, 2);
+
+  const pid_t child_pid = fork();
+  ASSERT_NE(child_pid, -1);
+  if (child_pid == 0) {
+    thread_pool.reset();
+    _exit(0);
+  }
+
+  int status = 0;
+  ASSERT_EQ(waitpid(child_pid, &status, 0), child_pid);
+  ASSERT_TRUE(WIFEXITED(status));
+  EXPECT_EQ(WEXITSTATUS(status), 0);
+}
+#endif
+
 TEST(ThreadPoolTest, TestParallelFor_0_Thread_NoTask) {
   TestParallelFor("TestParallelFor_0_Thread_NoTask", 0, 0);
 }


### PR DESCRIPTION
### Description

Record the process ID that creates each thread pool. If the copied pool is
destroyed in a forked child, abandon its inherited low-level state instead of
touching synchronization objects or joining thread handles owned by the parent.

Add a Linux regression test that creates a thread pool, forks, destroys the
copied pool in the child, and verifies that the child exits normally.

This does not make inherited thread pools usable after fork.


### Motivation and Context

Destroying an ONNX Runtime `InferenceSession` inherited across fork can terminate
the child with SIGSEGV in `pthread_join` because the stored worker handles belong
to the parent process.

The issue is reproducible with the CPU Execution Provider and does not require
inference, CUDA, or a particular model. Applications should create sessions
after fork, but accidental cleanup of inherited state should not crash.

Forking a multithreaded process is inherently unsafe. CPython documents this
limitation for `os.fork()` and emits a `DeprecationWarning` when it detects
multiple threads. Applications should avoid carrying a live ONNX Runtime
session across a fork boundary.

At the same time, prefork process models are common in Python web deployments.
For example, Gunicorn forks worker processes from a master process. If
application preloading or module-level initialization creates an
`InferenceSession` in the master, ONNX Runtime's native worker threads are
created before Gunicorn forks. The resulting session and thread handles are
then inherited by each worker.

The application-level fix is to create each `InferenceSession` after the final
fork, such as during worker initialization. However, library-side defensive
handling is still useful. Python object finalization can destroy an accidentally
inherited session during worker shutdown, and that cleanup should not attempt
to synchronize with or join threads owned by the parent process.

This change does not make inherited sessions fork-safe or endorse using them in
a child. It only recognizes that the copied thread pool cannot be safely
destroyed there and prevents that unsupported usage from becoming a process
crash during cleanup.

References
 - [CPython `os.fork()` warning](https://docs.python.org/3.14/library/os.html#os.fork)
 - [Gunicorn pre-fork worker model](https://docs.gunicorn.org/en/stable/design.html)


### Reproducer


```Python
# /// script
# requires-python = "==3.14.6"
# dependencies = [
#   "onnxruntime==1.28.0",
# ]
# ///

import base64
import os
import signal

import onnxruntime as ort


# A 65-byte ONNX model containing one Identity node: float[1] -> float[1].
MODEL = base64.b64decode(
    "CAo6NwoQCgF4EgF5IghJZGVudGl0eRIBZ1oPCgF4EgoKCAgBEgQKAggB"
    "Yg8KAXkSCgoICAESBAoCCAFCBAoAEBU="
)

session = ort.InferenceSession(MODEL, providers=["CPUExecutionProvider"])

pid = os.fork()
if pid == 0:
    # This destroys the copy of the session inherited from the parent.
    del session
    os._exit(0)

_, status = os.waitpid(pid, 0)

if os.WIFSIGNALED(status):
    child_signal = signal.Signals(os.WTERMSIG(status)).name
    print(f"child terminated by {child_signal}")
    raise SystemExit(1)

print(f"child exited with status {os.WEXITSTATUS(status)}")
```

Run:

```shell
uv run --python 3.14.6 repro.py
```

Output with ONNX Runtime 1.28.0:

```text
child terminated by SIGSEGV
```

Confirmed environments:
- Linux x86_64: reproduced on Ubuntu 22.04, glibc 2.35, CPython 3.13 and 3.14, ONNX Runtime 1.26.0 through 1.28.0.
- Linux aarch64: observed in production on Debian 12, glibc 2.36, CPython 3.14.6, ONNX Runtime 1.26.0.

The same failure was reproduced with ONNX Runtime 1.26.0, 1.27.0, and 1.28.0. No inference, CUDA provider, `onnx` package, or external model file is required.
