### PR TITLE
Avoid eager static initialization in ORT

### DIFF
--- a/model_package/src/manifest_parser.cc
+++ b/model_package/src/manifest_parser.cc
@@ -4,12 +4,14 @@
 #include "manifest_parser.h"
 
 #include <algorithm>
+#include <array>
 #include <cerrno>
 #include <cstring>
 #include <fstream>
 #include <set>
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <system_error>
 
 #include "path_resolver.h"
@@ -55,7 +57,7 @@ constexpr const char* kDeviceKey = "device";
 constexpr const char* kCompatibilityStringKey = "compatibility_string";
 constexpr const char* kExecutorInfoKey = "executor_info";
 
-static const std::set<std::string> kManifestKnownKeys = {
+constexpr std::array<std::string_view, 8> kManifestKnownKeys = {
     kSchemaVersionKey,
     kPackageNameKey,
     kPackageVersionKey,
@@ -66,13 +68,13 @@ static const std::set<std::string> kManifestKnownKeys = {
     kAdditionalMetadataKey,
 };
 
-static const std::set<std::string> kComponentKnownKeys = {
+constexpr std::array<std::string_view, 3> kComponentKnownKeys = {
     kComponentNameKey,
     kVariantsKey,
     kAdditionalMetadataKey,
 };
 
-static const std::set<std::string> kVariantKnownKeys = {
+constexpr std::array<std::string_view, 6> kVariantKnownKeys = {
     kVariantDirectoryKey,
     kEpKey,
     kDeviceKey,
@@ -112,13 +114,14 @@ ModelPackageStatus* ExpectObject(const ordered_json& j, const std::string& where
   return nullptr;
 }
 
+template <size_t N>
 ModelPackageStatus* CheckUnknownFields(const ordered_json& obj,
-                                       const std::set<std::string>& known,
+                                       const std::array<std::string_view, N>& known,
                                        const std::string& where,
                                        bool strict) {
   if (!strict) return nullptr;
   for (auto it = obj.begin(); it != obj.end(); ++it) {
-    if (known.find(it.key()) == known.end()) {
+    if (std::find(known.begin(), known.end(), std::string_view{it.key()}) == known.end()) {
       return MakeStatus(MODEL_PACKAGE_ERR_SCHEMA,
                         where + ": unknown field '" + it.key() + "'.");
     }

--- a/onnxruntime/core/optimizer/qdq_transformer/avx2_weight_s8_to_u8.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/avx2_weight_s8_to_u8.cc
@@ -19,17 +19,20 @@ struct OperatorWeightInfo {
   const size_t weight_zp_idx;
 };
 
-static const std::unordered_map<std::string, struct OperatorWeightInfo> s8_overflow_ops = {
-    {"QAttention", {{1}, kMSDomain, 1, 7}},
-    {"MatMulIntegerToFloat", {{1}, kMSDomain, 1, 5}},
-    {"DynamicQuantizeMatMul", {{1}, kMSDomain, 1, 3}},
-    {"QGemm", {{1}, kMSDomain, 3, 5}},
-    {"MatMulInteger", {{10}, kOnnxDomain, 1, 3}},
-    {"QLinearMatMul", {{10}, kOnnxDomain, 3, 5}},
-    {"QLinearConv", {{10}, kOnnxDomain, 3, 5}},
-    {"DequantizeLinear", {{10, 13}, kMSDomain, 0, 2}},  // already covered in QDQS8ToU8Transformer but does not hurt
-                                                        /* {"ConvInteger", {10}, kOnnxDomain, 1, 3},  // ConvInteger does not support int8_t weight at all */
-};
+static const std::unordered_map<std::string, OperatorWeightInfo>& GetS8OverflowOps() {
+  static const std::unordered_map<std::string, OperatorWeightInfo> s8_overflow_ops = {
+      {"QAttention", {{1}, kMSDomain, 1, 7}},
+      {"MatMulIntegerToFloat", {{1}, kMSDomain, 1, 5}},
+      {"DynamicQuantizeMatMul", {{1}, kMSDomain, 1, 3}},
+      {"QGemm", {{1}, kMSDomain, 3, 5}},
+      {"MatMulInteger", {{10}, kOnnxDomain, 1, 3}},
+      {"QLinearMatMul", {{10}, kOnnxDomain, 3, 5}},
+      {"QLinearConv", {{10}, kOnnxDomain, 3, 5}},
+      {"DequantizeLinear", {{10, 13}, kMSDomain, 0, 2}},  // already covered in QDQS8ToU8Transformer but does not hurt
+                                                          /* {"ConvInteger", {10}, kOnnxDomain, 1, 3},  // ConvInteger does not support int8_t weight at all */
+  };
+  return s8_overflow_ops;
+}
 
 static inline bool MatchesOpSinceVersion(
     const Node& node, const std::vector<ONNX_NAMESPACE::OperatorSetVersion>& versions) {
@@ -153,6 +156,7 @@ static bool TryConvertDynamicQuantizeLSTM(Node& op_node, Graph& graph, const log
 // For QAttention operator, if the weight is const int8, convert it to const uint8
 Status Avx2WeightS8ToU8Transformer::ApplyImpl(Graph& graph, bool& modified, int graph_level,
                                               const logging::Logger& logger) const {
+  const auto& s8_overflow_ops = GetS8OverflowOps();
   GraphViewer graph_viewer(graph);
   const auto& node_topology_list = graph_viewer.GetNodesInTopologicalOrder();
 


### PR DESCRIPTION
## Description

Avoid two eager dynamic initializers in ONNX Runtime:

- Replace the model-package manifest parser's namespace-scope `std::set<std::string>` key tables with constexpr `std::array<std::string_view>` tables.
- Move the AVX2 S8-to-U8 transformer's namespace-scope `std::unordered_map` to a function-local static so it is initialized only if the transformer runs.

This preserves lookup behavior and source membership while removing unnecessary process-startup initialization.

## Motivation and Context

An ARM64 binary-size regression report showed `.CRT$XCU` increasing from 176 to 192 bytes. Exact before/after PDB comparison identified two additional initializer entries:

- `_GLOBAL__sub_I_manifest_parser.cc`
- `_GLOBAL__sub_I_avx2_weight_s8_to_u8.cc`

Each ARM64 `.CRT$XCU` entry is an 8-byte function pointer, accounting for the full 16-byte increase. The issue was isolated to eager initialization.

## Validation

- ARM64 official ONNX Runtime build passed.
- Benchmark-equivalent `dumpbin /headers /Coffgroup` reports `.CRT$XCU = 0xB0` (176 bytes), restoring the baseline from 192 bytes.
- Both causal initializer symbols are absent from the fixed ARM64 PDB.
- x64 official inference-engine E2E suite passed: 11/11.
- Win32k-lockdown sandbox test passed: 1/1.
- `clang-format --dry-run --Werror` passed.
- Local AI code review reported no findings.