### PR TITLE
Fix typo COS -> COLS in QuantizeWithOrder/DequantizeWithOrder input doc

### DIFF
--- a/docs/ContribOperators.md
+++ b/docs/ContribOperators.md
@@ -1477,7 +1477,7 @@ This version of the operator has been available since version 1 of the 'com.micr
 
 <dl>
 <dt><tt>input</tt> : Q</dt>
-<dd>TODO: input tensor of (ROWS, COLS). if less than 2d, will broadcast to (1, X). If 3d, it is treated as (B, ROWS, COS)</dd>
+<dd>TODO: input tensor of (ROWS, COLS). if less than 2d, will broadcast to (1, X). If 3d, it is treated as (B, ROWS, COLS)</dd>
 <dt><tt>scale_input</tt> : S</dt>
 <dd>scale of the input</dd>
 </dl>
@@ -5752,7 +5752,7 @@ This version of the operator has been available since version 1 of the 'com.micr
 
 <dl>
 <dt><tt>input</tt> : F</dt>
-<dd>TODO: input tensor of (ROWS, COLS). if less than 2d, will broadcast to (1, X). If 3d, it is treated as (B, ROWS, COS)</dd>
+<dd>TODO: input tensor of (ROWS, COLS). if less than 2d, will broadcast to (1, X). If 3d, it is treated as (B, ROWS, COLS)</dd>
 <dt><tt>scale_input</tt> : S</dt>
 <dd>scale of the input</dd>
 </dl>

--- a/onnxruntime/core/graph/contrib_ops/quantization_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/quantization_defs.cc
@@ -1057,7 +1057,7 @@ ONNX_MS_OPERATOR_SET_SCHEMA(
         .Attr("order_output", "cublasLt order of output matrix.", AttributeProto::INT)
         .Input(0, "input",
                "TODO: input tensor of (ROWS, COLS). if less than 2d, will broadcast to (1, X). If 3d, it is treated as "
-               "(B, ROWS, COS)",
+               "(B, ROWS, COLS)",
                "F")
         .Input(1, "scale_input", "scale of the input", "S")
         .Output(0, "output", "output tensor", "Q")
@@ -1085,7 +1085,7 @@ ONNX_MS_OPERATOR_SET_SCHEMA(
               AttributeProto::INT)
         .Input(0, "input",
                "TODO: input tensor of (ROWS, COLS). if less than 2d, will broadcast to (1, X). If 3d, it is treated as "
-               "(B, ROWS, COS)",
+               "(B, ROWS, COLS)",
                "Q")
         .Input(1, "scale_input", "scale of the input", "S")
         .Output(0, "output", "output tensor", "F")


### PR DESCRIPTION
### Description

Fixes a typo in the input documentation for the `com.microsoft.QuantizeWithOrder` and `com.microsoft.DequantizeWithOrder` contrib operators: `COS` -> `COLS` in the `(B, ROWS, COLS)` 3D shape description.

### Motivation and Context

The operator `input` doc reads `input tensor of (ROWS, COLS)` but the 3D case was mistakenly written `(B, ROWS, COS)`. This corrects it to `(B, ROWS, COLS)` for consistency.

Changes:
- `onnxruntime/core/graph/contrib_ops/quantization_defs.cc` — schema doc strings for both ops.
- `docs/ContribOperators.md` — regenerated doc content for both ops.

Documentation-only change; no functional impact.