### PR TITLE
[WebGPU] Add MRotaryEmbedding support

### DIFF
--- a/onnxruntime/contrib_ops/webgpu/bert/mrotary_embedding.cc
+++ b/onnxruntime/contrib_ops/webgpu/bert/mrotary_embedding.cc
@@ -28,71 +28,19 @@ ONNX_OPERATOR_KERNEL_EX(
 
 Status MRotaryEmbeddingProgram::GenerateShaderCode(ShaderHelper& shader) const {
   const auto& input = shader.AddInput("input", ShaderUsage::UseElementTypeAlias);
-  const auto& position_ids = shader.AddInput("position_ids", ShaderUsage::None);
+  shader.AddInput("position_ids", ShaderUsage::None);
   const auto& cos_cache = shader.AddInput("cos_cache", ShaderUsage::None);
   const auto& sin_cache = shader.AddInput("sin_cache", ShaderUsage::None);
   const auto& output = shader.AddOutput("output", ShaderUsage::None);
 
-  auto& body = shader.MainFunctionBody();
-  body << "  if (global_idx >= uniforms.output_size) { return; }\n"
-          "  let channel = global_idx % uniforms.head_size;\n";
-
-  if (transposed_) {
-    body << "  let sequence = (global_idx / uniforms.head_size) % uniforms.sequence_length;\n"
-            "  let batch = global_idx / (uniforms.head_size * uniforms.sequence_length * uniforms.num_heads);\n";
-  } else {
-    body << "  let sequence = (global_idx / (uniforms.head_size * uniforms.num_heads)) % uniforms.sequence_length;\n"
-            "  let batch = global_idx / (uniforms.head_size * uniforms.num_heads * uniforms.sequence_length);\n";
-  }
-
-  body << "  if (channel >= uniforms.rotary_embedding_dim) {\n"
-       << "    " << output.SetByOffset("global_idx", input.GetByOffset("global_idx")) << "\n"
-       << "    return;\n"
-          "  }\n"
-          "  let half_rotary_embedding_dim = uniforms.rotary_embedding_dim / 2u;\n";
-
-  if (interleaved_) {
-    body << "  let cache_idx = channel / 2u;\n"
-            "  let pair_idx = select(channel - 1u, channel + 1u, channel % 2u == 0u);\n"
-            "  let sign = select(input_element_t(1.0), input_element_t(-1.0), channel % 2u == 0u);\n";
-  } else {
-    body << "  let cache_idx = channel % half_rotary_embedding_dim;\n"
-            "  let pair_idx = (channel + half_rotary_embedding_dim) % uniforms.rotary_embedding_dim;\n"
-            "  let sign = select(input_element_t(1.0), input_element_t(-1.0), channel < half_rotary_embedding_dim);\n";
-  }
-
-  body << "  var stream = 0u;\n";
-  if (mrope_layout_ == MRopeLayout::kSectioned) {
-    body << "  if (cache_idx >= uniforms.mrope_section[0] &&\n"
-            "      cache_idx < uniforms.mrope_section[0] + uniforms.mrope_section[1]) {\n"
-            "    stream = 1u;\n"
-            "  } else if (cache_idx >= uniforms.mrope_section[0] + uniforms.mrope_section[1]) {\n"
-            "    stream = 2u;\n"
-            "  }\n";
-  } else {
-    body << "  if (cache_idx % 3u == 1u && cache_idx / 3u < uniforms.mrope_section[1]) {\n"
-            "    stream = 1u;\n"
-            "  } else if (cache_idx % 3u == 2u && cache_idx / 3u < uniforms.mrope_section[2]) {\n"
-            "    stream = 2u;\n"
-            "  }\n";
-  }
-
-  body << "  let position_ids_idx = (stream * uniforms.batch_size + batch) * uniforms.sequence_length + sequence;\n"
-       << "  let position_id_bits = " << position_ids.GetByOffset("position_ids_idx", true) << ";\n"
-       << "  if (position_id_bits.y != 0u || position_id_bits.x >= uniforms.max_sequence_length) {\n"
-       << "    " << output.SetByOffset("global_idx", input.GetByOffset("global_idx")) << "\n"
-       << "    return;\n"
-          "  }\n"
-          "  let cache_offset = position_id_bits.x * half_rotary_embedding_dim + cache_idx;\n"
-          "  let scale = input_element_t(uniforms.scale);\n"
-       << "  let cos_value = " << cos_cache.GetByOffset("cache_offset") << " * scale;\n"
-       << "  let sin_value = " << sin_cache.GetByOffset("cache_offset") << " * scale;\n"
-       << "  let head_offset = global_idx - channel;\n"
-       << "  let value = " << input.GetByOffset("global_idx") << " * cos_value + sign * "
-       << input.GetByOffset("head_offset + pair_idx") << " * sin_value;\n"
-       << "  " << output.SetByOffset("global_idx", "value") << "\n";
-
-  return Status::OK();
+  return WGSL_TEMPLATE_APPLY(shader, "bert/mrotary_embedding.wgsl.template",
+                             WGSL_TEMPLATE_PARAMETER(interleaved, interleaved_),
+                             WGSL_TEMPLATE_PARAMETER(sectioned, mrope_layout_ == MRopeLayout::kSectioned),
+                             WGSL_TEMPLATE_PARAMETER(transposed, transposed_),
+                             WGSL_TEMPLATE_VARIABLE(cos_cache, cos_cache),
+                             WGSL_TEMPLATE_VARIABLE(input, input),
+                             WGSL_TEMPLATE_VARIABLE(output, output),
+                             WGSL_TEMPLATE_VARIABLE(sin_cache, sin_cache));
 }
 
 MRotaryEmbedding::MRotaryEmbedding(const OpKernelInfo& info) : WebGpuKernel(info) {

--- a/onnxruntime/contrib_ops/webgpu/bert/mrotary_embedding.cc
+++ b/onnxruntime/contrib_ops/webgpu/bert/mrotary_embedding.cc
@@ -28,18 +28,20 @@ ONNX_OPERATOR_KERNEL_EX(
 
 Status MRotaryEmbeddingProgram::GenerateShaderCode(ShaderHelper& shader) const {
   const auto& input = shader.AddInput("input", ShaderUsage::UseElementTypeAlias);
-  shader.AddInput("position_ids", ShaderUsage::None);
+  const auto& position_ids = shader.AddInput("position_ids", ShaderUsage::None);
   const auto& cos_cache = shader.AddInput("cos_cache", ShaderUsage::None);
   const auto& sin_cache = shader.AddInput("sin_cache", ShaderUsage::None);
   const auto& output = shader.AddOutput("output", ShaderUsage::None);
 
   return WGSL_TEMPLATE_APPLY(shader, "bert/mrotary_embedding.wgsl.template",
                              WGSL_TEMPLATE_PARAMETER(interleaved, interleaved_),
+                             WGSL_TEMPLATE_PARAMETER(position_ids_use_storage_type, true),
                              WGSL_TEMPLATE_PARAMETER(sectioned, mrope_layout_ == MRopeLayout::kSectioned),
                              WGSL_TEMPLATE_PARAMETER(transposed, transposed_),
                              WGSL_TEMPLATE_VARIABLE(cos_cache, cos_cache),
                              WGSL_TEMPLATE_VARIABLE(input, input),
                              WGSL_TEMPLATE_VARIABLE(output, output),
+                             WGSL_TEMPLATE_VARIABLE(position_ids, position_ids),
                              WGSL_TEMPLATE_VARIABLE(sin_cache, sin_cache));
 }
 

--- a/onnxruntime/contrib_ops/webgpu/bert/mrotary_embedding.cc
+++ b/onnxruntime/contrib_ops/webgpu/bert/mrotary_embedding.cc
@@ -1,0 +1,170 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "contrib_ops/webgpu/bert/mrotary_embedding.h"
+
+#include <array>
+#include <limits>
+
+#include "contrib_ops/webgpu/webgpu_contrib_kernels.h"
+#include "core/providers/webgpu/shader_helper.h"
+#include "core/providers/webgpu/webgpu_supported_types.h"
+
+namespace onnxruntime {
+namespace contrib {
+namespace webgpu {
+
+using namespace mrotary_embedding_helper;
+
+ONNX_OPERATOR_KERNEL_EX(
+    MRotaryEmbedding,
+    kMSDomain,
+    1,
+    kWebGpuExecutionProvider,
+    (*KernelDefBuilder::Create())
+        .TypeConstraint("T", WebGpuSupportedFloatTypes())
+        .TypeConstraint("M", DataTypeImpl::GetTensorType<int64_t>()),
+    MRotaryEmbedding);
+
+Status MRotaryEmbeddingProgram::GenerateShaderCode(ShaderHelper& shader) const {
+  const auto& input = shader.AddInput("input", ShaderUsage::UseElementTypeAlias);
+  const auto& position_ids = shader.AddInput("position_ids", ShaderUsage::None);
+  const auto& cos_cache = shader.AddInput("cos_cache", ShaderUsage::None);
+  const auto& sin_cache = shader.AddInput("sin_cache", ShaderUsage::None);
+  const auto& output = shader.AddOutput("output", ShaderUsage::None);
+
+  auto& body = shader.MainFunctionBody();
+  body << "  if (global_idx >= uniforms.output_size) { return; }\n"
+          "  let channel = global_idx % uniforms.head_size;\n";
+
+  if (transposed_) {
+    body << "  let sequence = (global_idx / uniforms.head_size) % uniforms.sequence_length;\n"
+            "  let batch = global_idx / (uniforms.head_size * uniforms.sequence_length * uniforms.num_heads);\n";
+  } else {
+    body << "  let sequence = (global_idx / (uniforms.head_size * uniforms.num_heads)) % uniforms.sequence_length;\n"
+            "  let batch = global_idx / (uniforms.head_size * uniforms.num_heads * uniforms.sequence_length);\n";
+  }
+
+  body << "  if (channel >= uniforms.rotary_embedding_dim) {\n"
+       << "    " << output.SetByOffset("global_idx", input.GetByOffset("global_idx")) << "\n"
+       << "    return;\n"
+          "  }\n"
+          "  let half_rotary_embedding_dim = uniforms.rotary_embedding_dim / 2u;\n";
+
+  if (interleaved_) {
+    body << "  let cache_idx = channel / 2u;\n"
+            "  let pair_idx = select(channel - 1u, channel + 1u, channel % 2u == 0u);\n"
+            "  let sign = select(input_element_t(1.0), input_element_t(-1.0), channel % 2u == 0u);\n";
+  } else {
+    body << "  let cache_idx = channel % half_rotary_embedding_dim;\n"
+            "  let pair_idx = (channel + half_rotary_embedding_dim) % uniforms.rotary_embedding_dim;\n"
+            "  let sign = select(input_element_t(1.0), input_element_t(-1.0), channel < half_rotary_embedding_dim);\n";
+  }
+
+  body << "  var stream = 0u;\n";
+  if (mrope_layout_ == MRopeLayout::kSectioned) {
+    body << "  if (cache_idx >= uniforms.mrope_section[0] &&\n"
+            "      cache_idx < uniforms.mrope_section[0] + uniforms.mrope_section[1]) {\n"
+            "    stream = 1u;\n"
+            "  } else if (cache_idx >= uniforms.mrope_section[0] + uniforms.mrope_section[1]) {\n"
+            "    stream = 2u;\n"
+            "  }\n";
+  } else {
+    body << "  if (cache_idx % 3u == 1u && cache_idx / 3u < uniforms.mrope_section[1]) {\n"
+            "    stream = 1u;\n"
+            "  } else if (cache_idx % 3u == 2u && cache_idx / 3u < uniforms.mrope_section[2]) {\n"
+            "    stream = 2u;\n"
+            "  }\n";
+  }
+
+  body << "  let position_ids_idx = (stream * uniforms.batch_size + batch) * uniforms.sequence_length + sequence;\n"
+       << "  let position_id_bits = " << position_ids.GetByOffset("position_ids_idx", true) << ";\n"
+       << "  if (position_id_bits.y != 0u || position_id_bits.x >= uniforms.max_sequence_length) {\n"
+       << "    " << output.SetByOffset("global_idx", input.GetByOffset("global_idx")) << "\n"
+       << "    return;\n"
+          "  }\n"
+          "  let cache_offset = position_id_bits.x * half_rotary_embedding_dim + cache_idx;\n"
+          "  let scale = input_element_t(uniforms.scale);\n"
+       << "  let cos_value = " << cos_cache.GetByOffset("cache_offset") << " * scale;\n"
+       << "  let sin_value = " << sin_cache.GetByOffset("cache_offset") << " * scale;\n"
+       << "  let head_offset = global_idx - channel;\n"
+       << "  let value = " << input.GetByOffset("global_idx") << " * cos_value + sign * "
+       << input.GetByOffset("head_offset + pair_idx") << " * sin_value;\n"
+       << "  " << output.SetByOffset("global_idx", "value") << "\n";
+
+  return Status::OK();
+}
+
+MRotaryEmbedding::MRotaryEmbedding(const OpKernelInfo& info) : WebGpuKernel(info) {
+  scale_ = info.GetAttrOrDefault<float>("scale", 1.0f);
+  const int64_t rotary_embedding_dim = info.GetAttrOrDefault<int64_t>("rotary_embedding_dim", 0);
+  const int64_t num_heads = info.GetAttrOrDefault<int64_t>("num_heads", 0);
+  ORT_ENFORCE(rotary_embedding_dim >= 0 && rotary_embedding_dim <= std::numeric_limits<int>::max(),
+              "rotary_embedding_dim must be in range [0, ", std::numeric_limits<int>::max(),
+              "]. Actual value: ", rotary_embedding_dim);
+  ORT_ENFORCE(num_heads >= 0 && num_heads <= std::numeric_limits<int>::max(),
+              "num_heads must be in range [0, ", std::numeric_limits<int>::max(),
+              "]. Actual value: ", num_heads);
+  rotary_embedding_dim_ = static_cast<int>(rotary_embedding_dim);
+  num_heads_ = static_cast<int>(num_heads);
+  interleaved_ = info.GetAttrOrDefault<int64_t>("interleaved", 0) == 1;
+  is_packed_batching_ = info.GetAttrOrDefault<int64_t>("is_packed_batching", 0) == 1;
+  mrope_layout_ = info.GetAttrOrDefault<int64_t>("mrope_layout", 0);
+  ORT_ENFORCE(info.GetAttrs<int64_t>("mrope_section", mrope_section_).IsOK(),
+              "MRotaryEmbedding: 'mrope_section' attribute is required");
+
+  if (rotary_embedding_dim_ > 0) {
+    ORT_ENFORCE(num_heads_ > 0, "num_heads must be provided if rotary_embedding_dim is specified");
+  }
+}
+
+Status MRotaryEmbedding::ComputeInternal(onnxruntime::webgpu::ComputeContext& context) const {
+  const auto* input = context.Input<Tensor>(0);
+  const auto* position_ids = context.Input<Tensor>(1);
+  const auto* cos_cache = context.Input<Tensor>(2);
+  const auto* sin_cache = context.Input<Tensor>(3);
+
+  MRotaryParameters parameters{};
+  ORT_RETURN_IF_ERROR(CheckInputs<Tensor>(input, position_ids, cos_cache, sin_cache,
+                                          num_heads_, rotary_embedding_dim_, mrope_section_,
+                                          mrope_layout_, &parameters));
+
+  auto* output = context.Output(0, input->Shape());
+  if (input->Shape().Size() == 0) {
+    return Status::OK();
+  }
+
+  if (!is_packed_batching_ && parameters.sequence_length > parameters.max_sequence_length) {
+    ORT_NOT_IMPLEMENTED("Updating cos_cache and sin_cache in MRotaryEmbedding is not currently supported");
+  }
+
+  const uint32_t output_size = onnxruntime::narrow<uint32_t>(input->Shape().Size());
+  const std::array<uint32_t, 3> mrope_section{
+      static_cast<uint32_t>(parameters.mrope_section[0]),
+      static_cast<uint32_t>(parameters.mrope_section[1]),
+      static_cast<uint32_t>(parameters.mrope_section[2])};
+
+  MRotaryEmbeddingProgram program{interleaved_, parameters.transposed, parameters.mrope_layout};
+  program.CacheHint(interleaved_, parameters.transposed, static_cast<int>(parameters.mrope_layout))
+      .AddInputs({{input, ProgramTensorMetadataDependency::TypeAndRank},
+                  {position_ids, ProgramTensorMetadataDependency::TypeAndRank},
+                  {cos_cache, ProgramTensorMetadataDependency::TypeAndRank},
+                  {sin_cache, ProgramTensorMetadataDependency::TypeAndRank}})
+      .AddOutput({output, ProgramTensorMetadataDependency::TypeAndRank})
+      .SetDispatchGroupSize((output_size + WORKGROUP_SIZE - 1) / WORKGROUP_SIZE)
+      .AddUniformVariables({{scale_},
+                            {output_size},
+                            {static_cast<uint32_t>(parameters.batch_size)},
+                            {static_cast<uint32_t>(parameters.sequence_length)},
+                            {static_cast<uint32_t>(parameters.num_heads)},
+                            {static_cast<uint32_t>(parameters.head_size)},
+                            {static_cast<uint32_t>(parameters.rotary_embedding_dim)},
+                            {static_cast<uint32_t>(parameters.max_sequence_length)},
+                            {gsl::make_span(mrope_section)}});
+
+  return context.RunProgram(program);
+}
+
+}  // namespace webgpu
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/webgpu/bert/mrotary_embedding.h
+++ b/onnxruntime/contrib_ops/webgpu/bert/mrotary_embedding.h
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <vector>
+
+#include "contrib_ops/cpu/bert/mrotary_embedding_helper.h"
+#include "core/providers/webgpu/program.h"
+#include "core/providers/webgpu/webgpu_kernel.h"
+
+namespace onnxruntime {
+namespace contrib {
+namespace webgpu {
+
+using namespace onnxruntime::webgpu;
+
+class MRotaryEmbeddingProgram final : public Program<MRotaryEmbeddingProgram> {
+ public:
+  MRotaryEmbeddingProgram(bool interleaved, bool transposed,
+                          mrotary_embedding_helper::MRopeLayout mrope_layout)
+      : Program{"MRotaryEmbedding"},
+        interleaved_{interleaved},
+        transposed_{transposed},
+        mrope_layout_{mrope_layout} {}
+
+  Status GenerateShaderCode(ShaderHelper& shader) const override;
+
+  WEBGPU_PROGRAM_DEFINE_UNIFORM_VARIABLES(
+      {"scale", ProgramUniformVariableDataType::Float32},
+      {"output_size", ProgramUniformVariableDataType::Uint32},
+      {"batch_size", ProgramUniformVariableDataType::Uint32},
+      {"sequence_length", ProgramUniformVariableDataType::Uint32},
+      {"num_heads", ProgramUniformVariableDataType::Uint32},
+      {"head_size", ProgramUniformVariableDataType::Uint32},
+      {"rotary_embedding_dim", ProgramUniformVariableDataType::Uint32},
+      {"max_sequence_length", ProgramUniformVariableDataType::Uint32},
+      {"mrope_section", ProgramUniformVariableDataType::Uint32});
+
+ private:
+  const bool interleaved_;
+  const bool transposed_;
+  const mrotary_embedding_helper::MRopeLayout mrope_layout_;
+};
+
+class MRotaryEmbedding final : public WebGpuKernel {
+ public:
+  explicit MRotaryEmbedding(const OpKernelInfo& info);
+  Status ComputeInternal(onnxruntime::webgpu::ComputeContext& context) const override;
+
+ private:
+  float scale_;
+  int num_heads_;
+  int rotary_embedding_dim_;
+  bool interleaved_;
+  bool is_packed_batching_;
+  int64_t mrope_layout_;
+  std::vector<int64_t> mrope_section_;
+};
+
+}  // namespace webgpu
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/webgpu/bert/mrotary_embedding.wgsl.template
+++ b/onnxruntime/contrib_ops/webgpu/bert/mrotary_embedding.wgsl.template
@@ -1,0 +1,74 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#param interleaved
+#param sectioned
+#param transposed
+
+#use .getByOffset .setByOffset
+
+$MAIN {
+  if (global_idx >= uniforms.output_size) {
+    return;
+  }
+
+  let channel = global_idx % uniforms.head_size;
+#if transposed
+  let sequence = (global_idx / uniforms.head_size) % uniforms.sequence_length;
+  let batch = global_idx / (uniforms.head_size * uniforms.sequence_length * uniforms.num_heads);
+#else
+  let sequence = (global_idx / (uniforms.head_size * uniforms.num_heads)) % uniforms.sequence_length;
+  let batch = global_idx / (uniforms.head_size * uniforms.num_heads * uniforms.sequence_length);
+#endif
+
+  if (channel >= uniforms.rotary_embedding_dim) {
+    output.setByOffset(global_idx, input.getByOffset(global_idx));
+    return;
+  }
+
+  let half_rotary_embedding_dim = uniforms.rotary_embedding_dim / 2u;
+#if interleaved
+  let cache_idx = channel / 2u;
+  let pair_idx = select(channel - 1u, channel + 1u, channel % 2u == 0u);
+  let sign = select(input_element_t(1.0), input_element_t(-1.0), channel % 2u == 0u);
+#else
+  let cache_idx = channel % half_rotary_embedding_dim;
+  let pair_idx = (channel + half_rotary_embedding_dim) % uniforms.rotary_embedding_dim;
+  let sign = select(input_element_t(1.0), input_element_t(-1.0), channel < half_rotary_embedding_dim);
+#endif
+
+  var stream = 0u;
+#if sectioned
+  if (cache_idx >= uniforms.mrope_section[0] &&
+      cache_idx < uniforms.mrope_section[0] + uniforms.mrope_section[1]) {
+    stream = 1u;
+  } else if (cache_idx >= uniforms.mrope_section[0] + uniforms.mrope_section[1]) {
+    stream = 2u;
+  }
+#else
+  if (cache_idx % 3u == 1u && cache_idx / 3u < uniforms.mrope_section[1]) {
+    stream = 1u;
+  } else if (cache_idx % 3u == 2u && cache_idx / 3u < uniforms.mrope_section[2]) {
+    stream = 2u;
+  }
+#endif
+
+  let position_ids_idx =
+      (stream * uniforms.batch_size + batch) * uniforms.sequence_length + sequence;
+  // int64 values are stored as vec2<u32>; read both words so negative and
+  // otherwise out-of-range values pass through unchanged.
+  let position_id_bits = position_ids[position_ids_idx];
+  if (position_id_bits.y != 0u || position_id_bits.x >= uniforms.max_sequence_length) {
+    output.setByOffset(global_idx, input.getByOffset(global_idx));
+    return;
+  }
+
+  let cache_offset = position_id_bits.x * half_rotary_embedding_dim + cache_idx;
+  let scale = input_element_t(uniforms.scale);
+  let cos_value = cos_cache.getByOffset(cache_offset) * scale;
+  let sin_value = sin_cache.getByOffset(cache_offset) * scale;
+  let head_offset = global_idx - channel;
+  let value = input.getByOffset(global_idx) * cos_value +
+              sign * input.getByOffset(head_offset + pair_idx) * sin_value;
+  output.setByOffset(global_idx, value);
+}  // MAIN

--- a/onnxruntime/contrib_ops/webgpu/bert/mrotary_embedding.wgsl.template
+++ b/onnxruntime/contrib_ops/webgpu/bert/mrotary_embedding.wgsl.template
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #param interleaved
+#param position_ids_use_storage_type
 #param sectioned
 #param transposed
 
@@ -57,7 +58,7 @@ $MAIN {
       (stream * uniforms.batch_size + batch) * uniforms.sequence_length + sequence;
   // int64 values are stored as vec2<u32>; read both words so negative and
   // otherwise out-of-range values pass through unchanged.
-  let position_id_bits = position_ids[position_ids_idx];
+  let position_id_bits = position_ids.getByOffset(position_ids_idx, position_ids_use_storage_type);
   if (position_id_bits.y != 0u || position_id_bits.x >= uniforms.max_sequence_length) {
     output.setByOffset(global_idx, input.getByOffset(global_idx));
     return;

--- a/onnxruntime/contrib_ops/webgpu/webgpu_contrib_kernels.cc
+++ b/onnxruntime/contrib_ops/webgpu/webgpu_contrib_kernels.cc
@@ -35,6 +35,7 @@ static const BuildKernelCreateInfoFn build_kernel_create_info_function_table[] =
     BuildKernelCreateInfo<class ONNX_OPERATOR_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kMSDomain, 1, MatMulNBits)>,
     BuildKernelCreateInfo<class ONNX_OPERATOR_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kMSDomain, 1, MatMulNBitsQkv)>,
     BuildKernelCreateInfo<class ONNX_OPERATOR_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kMSDomain, 1, MatMulNBitsMlp)>,
+    BuildKernelCreateInfo<class ONNX_OPERATOR_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kMSDomain, 1, MRotaryEmbedding)>,
     BuildKernelCreateInfo<class ONNX_OPERATOR_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kMSDomain, 1, MultiHeadAttention)>,
     BuildKernelCreateInfo<class ONNX_OPERATOR_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kMSDomain, 1, PagedAttention)>,
     BuildKernelCreateInfo<class ONNX_OPERATOR_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kMSDomain, 1, QuickGelu)>,

--- a/onnxruntime/test/contrib_ops/mrotary_embedding_op_test.cc
+++ b/onnxruntime/test/contrib_ops/mrotary_embedding_op_test.cc
@@ -53,8 +53,17 @@ std::vector<std::unique_ptr<IExecutionProvider>> GetAvailableGpuExecutionProvide
 }
 
 std::unique_ptr<IExecutionProvider> CreateGpuExecutionProvider(const std::string& provider_type) {
-  return provider_type == kCudaExecutionProvider ? DefaultCudaExecutionProvider()
-                                                 : DefaultWebGpuExecutionProvider();
+  if (provider_type == kCudaExecutionProvider) {
+    return DefaultCudaExecutionProvider();
+  }
+  if (provider_type == kWebGpuExecutionProvider) {
+    return DefaultWebGpuExecutionProvider();
+  }
+  return nullptr;
+}
+
+TEST(ContribOpMRotaryEmbeddingTest, UnknownGpuExecutionProviderReturnsNull) {
+  EXPECT_EQ(CreateGpuExecutionProvider("UnknownExecutionProvider"), nullptr);
 }
 
 void RunMRotaryEmbeddingTest(const std::vector<int64_t>& input_shape,

--- a/onnxruntime/test/contrib_ops/mrotary_embedding_op_test.cc
+++ b/onnxruntime/test/contrib_ops/mrotary_embedding_op_test.cc
@@ -19,6 +19,44 @@ enum class TensorType {
   kFloat16,
 };
 
+class WebGpuOpTester final : public OpTester {
+ public:
+  WebGpuOpTester() : OpTester("MRotaryEmbedding", 1, kMSDomain) {}
+
+ private:
+  void AddNodes(Graph& graph,
+                std::vector<NodeArg*>& graph_input_defs,
+                std::vector<NodeArg*>& graph_output_defs,
+                std::vector<std::function<void(Node&)>>& add_attribute_funcs) override {
+    OpTester::AddNodes(graph, graph_input_defs, graph_output_defs, add_attribute_funcs);
+    for (auto& node : graph.Nodes()) {
+      node.SetExecutionProviderType(kWebGpuExecutionProvider);
+    }
+  }
+};
+
+std::unique_ptr<OpTester> CreateMRotaryEmbeddingTester(const IExecutionProvider& execution_provider) {
+  return execution_provider.Type() == kWebGpuExecutionProvider
+             ? std::make_unique<WebGpuOpTester>()
+             : std::make_unique<OpTester>("MRotaryEmbedding", 1, kMSDomain);
+}
+
+std::vector<std::unique_ptr<IExecutionProvider>> GetAvailableGpuExecutionProviders() {
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  if (HasCudaEnvironment(0)) {
+    execution_providers.push_back(DefaultCudaExecutionProvider());
+  }
+  if (auto webgpu_ep = DefaultWebGpuExecutionProvider()) {
+    execution_providers.push_back(std::move(webgpu_ep));
+  }
+  return execution_providers;
+}
+
+std::unique_ptr<IExecutionProvider> CreateGpuExecutionProvider(const std::string& provider_type) {
+  return provider_type == kCudaExecutionProvider ? DefaultCudaExecutionProvider()
+                                                 : DefaultWebGpuExecutionProvider();
+}
+
 void RunMRotaryEmbeddingTest(const std::vector<int64_t>& input_shape,
                              const std::vector<float>& input_data,
                              const std::vector<int64_t>& position_ids,
@@ -40,34 +78,37 @@ void RunMRotaryEmbeddingTest(const std::vector<int64_t>& input_shape,
     execution_providers.push_back(DefaultCudaExecutionProvider());
   }
   execution_providers.push_back(DefaultCpuExecutionProvider());
+  if (auto webgpu_ep = DefaultWebGpuExecutionProvider()) {
+    execution_providers.push_back(std::move(webgpu_ep));
+  }
 
   for (auto& ep : execution_providers) {
-    OpTester test("MRotaryEmbedding", 1, kMSDomain);
-    test.AddAttribute<int64_t>("num_heads", num_heads);
-    test.AddAttribute<int64_t>("rotary_embedding_dim", rotary_embedding_dim);
-    test.AddAttribute<int64_t>("mrope_layout", mrope_layout);
-    test.AddAttribute<int64_t>("interleaved", interleaved);
-    test.AddAttribute<float>("scale", scale);
-    test.AddAttribute<std::vector<int64_t>>("mrope_section", mrope_section);
+    auto test = CreateMRotaryEmbeddingTester(*ep);
+    test->AddAttribute<int64_t>("num_heads", num_heads);
+    test->AddAttribute<int64_t>("rotary_embedding_dim", rotary_embedding_dim);
+    test->AddAttribute<int64_t>("mrope_layout", mrope_layout);
+    test->AddAttribute<int64_t>("interleaved", interleaved);
+    test->AddAttribute<float>("scale", scale);
+    test->AddAttribute<std::vector<int64_t>>("mrope_section", mrope_section);
 
     if (tensor_type == TensorType::kFloat) {
-      test.AddInput<float>("input", input_shape, input_data);
-      test.AddInput<int64_t>("position_ids", position_ids_shape, position_ids);
-      test.AddInput<float>("cos_cache", cache_shape, cos_cache);
-      test.AddInput<float>("sin_cache", cache_shape, sin_cache);
-      test.AddOutput<float>("output", input_shape, expected_output);
+      test->AddInput<float>("input", input_shape, input_data);
+      test->AddInput<int64_t>("position_ids", position_ids_shape, position_ids);
+      test->AddInput<float>("cos_cache", cache_shape, cos_cache);
+      test->AddInput<float>("sin_cache", cache_shape, sin_cache);
+      test->AddOutput<float>("output", input_shape, expected_output);
     } else {
-      test.AddInput<MLFloat16>("input", input_shape, ToFloat16(input_data));
-      test.AddInput<int64_t>("position_ids", position_ids_shape, position_ids);
-      test.AddInput<MLFloat16>("cos_cache", cache_shape, ToFloat16(cos_cache));
-      test.AddInput<MLFloat16>("sin_cache", cache_shape, ToFloat16(sin_cache));
-      test.AddOutput<MLFloat16>("output", input_shape, ToFloat16(expected_output));
-      test.SetOutputAbsErr("output", 0.01f);
+      test->AddInput<MLFloat16>("input", input_shape, ToFloat16(input_data));
+      test->AddInput<int64_t>("position_ids", position_ids_shape, position_ids);
+      test->AddInput<MLFloat16>("cos_cache", cache_shape, ToFloat16(cos_cache));
+      test->AddInput<MLFloat16>("sin_cache", cache_shape, ToFloat16(sin_cache));
+      test->AddOutput<MLFloat16>("output", input_shape, ToFloat16(expected_output));
+      test->SetOutputAbsErr("output", 0.01f);
     }
 
     std::vector<std::unique_ptr<IExecutionProvider>> test_execution_providers;
     test_execution_providers.push_back(std::move(ep));
-    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &test_execution_providers);
+    test->Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &test_execution_providers);
   }
 }
 
@@ -214,6 +255,18 @@ TEST(ContribOpMRotaryEmbeddingTest, InterleavedRank4) {
                            {1, 1, 1}, 1, 1, 0.5f);
 }
 
+TEST(ContribOpMRotaryEmbeddingTest, PartialRotaryDimensionCopiesTail) {
+  const std::vector<float> input_data = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f};
+  const std::vector<float> cos_cache(12, 0.0f);
+  const std::vector<float> sin_cache(12, 1.0f);
+  const std::vector<float> expected_output = {-4.0f, -5.0f, -6.0f, 1.0f, 2.0f, 3.0f, 7.0f, 8.0f};
+
+  for (const auto tensor_type : {TensorType::kFloat, TensorType::kFloat16}) {
+    RunMRotaryEmbeddingTest({1, 1, 8}, input_data, {0, 0, 0}, cos_cache, sin_cache, expected_output,
+                            {1, 1, 1}, 0, 0, 1.0f, 1, 6, tensor_type);
+  }
+}
+
 TEST(ContribOpMRotaryEmbeddingTest, RejectsOddRotaryEmbeddingDim) {
   OpTester test("MRotaryEmbedding", 1, kMSDomain);
   test.AddAttribute<int64_t>("num_heads", static_cast<int64_t>(1));
@@ -257,115 +310,139 @@ TEST(ContribOpMRotaryEmbeddingTest, RejectsMropeSectionSumOverflow) {
            {}, nullptr, &execution_providers);
 }
 
-TEST(ContribOpMRotaryEmbeddingTest, CudaRejectsNegativeRotaryEmbeddingDimAttribute) {
-  if (!HasCudaEnvironment(0)) {
-    GTEST_SKIP() << "CUDA execution provider is not available.";
+TEST(ContribOpMRotaryEmbeddingTest, RejectsNegativeRotaryEmbeddingDimAttribute) {
+  auto execution_providers = GetAvailableGpuExecutionProviders();
+  if (execution_providers.empty()) {
+    GTEST_SKIP() << "CUDA and WebGPU execution providers are not available.";
   }
 
-  OpTester test("MRotaryEmbedding", 1, kMSDomain);
-  test.AddAttribute<int64_t>("num_heads", static_cast<int64_t>(1));
-  test.AddAttribute<int64_t>("rotary_embedding_dim", static_cast<int64_t>(-1));
-  test.AddAttribute<int64_t>("mrope_layout", static_cast<int64_t>(0));
-  test.AddAttribute<int64_t>("interleaved", static_cast<int64_t>(0));
-  test.AddAttribute<std::vector<int64_t>>("mrope_section", {1, 0, 0});
+  for (auto& ep : execution_providers) {
+    SCOPED_TRACE("provider=" + ep->Type());
+    auto test = CreateMRotaryEmbeddingTester(*ep);
+    test->AddAttribute<int64_t>("num_heads", static_cast<int64_t>(1));
+    test->AddAttribute<int64_t>("rotary_embedding_dim", static_cast<int64_t>(-1));
+    test->AddAttribute<int64_t>("mrope_layout", static_cast<int64_t>(0));
+    test->AddAttribute<int64_t>("interleaved", static_cast<int64_t>(0));
+    test->AddAttribute<std::vector<int64_t>>("mrope_section", {1, 0, 0});
 
-  test.AddInput<float>("input", {1, 1, 2}, {1.0f, 2.0f});
-  test.AddInput<int64_t>("position_ids", {3, 1, 1}, {0, 0, 0});
-  test.AddInput<float>("cos_cache", {1, 1}, {1.0f});
-  test.AddInput<float>("sin_cache", {1, 1}, {0.0f});
-  test.AddOutput<float>("output", {1, 1, 2}, {0.0f, 0.0f});
+    test->AddInput<float>("input", {1, 1, 2}, {1.0f, 2.0f});
+    test->AddInput<int64_t>("position_ids", {3, 1, 1}, {0, 0, 0});
+    test->AddInput<float>("cos_cache", {1, 1}, {1.0f});
+    test->AddInput<float>("sin_cache", {1, 1}, {0.0f});
+    test->AddOutput<float>("output", {1, 1, 2}, {0.0f, 0.0f});
 
-  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
-  execution_providers.push_back(DefaultCudaExecutionProvider());
-  test.Run(OpTester::ExpectResult::kExpectFailure,
-           "rotary_embedding_dim must be in range",
-           {}, nullptr, &execution_providers);
+    std::vector<std::unique_ptr<IExecutionProvider>> test_execution_providers;
+    test_execution_providers.push_back(std::move(ep));
+    test->Run(OpTester::ExpectResult::kExpectFailure,
+              "rotary_embedding_dim must be in range",
+              {}, nullptr, &test_execution_providers);
+  }
 }
 
-TEST(ContribOpMRotaryEmbeddingTest, CudaPositionIdsOOBPassthroughAllStreams) {
-  if (!HasCudaEnvironment(0)) {
-    GTEST_SKIP() << "CUDA execution provider is not available.";
+TEST(ContribOpMRotaryEmbeddingTest, PositionIdsOOBPassthroughAllStreams) {
+  const auto available_execution_providers = GetAvailableGpuExecutionProviders();
+  if (available_execution_providers.empty()) {
+    GTEST_SKIP() << "CUDA and WebGPU execution providers are not available.";
   }
 
   const std::vector<float> input_data = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
   const std::vector<float> cos_cache = {
-      1.0f, 1.0f, 1.0f,
-      1.0f, 1.0f, 1.0f};
-  const std::vector<float> sin_cache = {
       0.0f, 0.0f, 0.0f,
       0.0f, 0.0f, 0.0f};
+  const std::vector<float> sin_cache = {
+      1.0f, 1.0f, 1.0f,
+      1.0f, 1.0f, 1.0f};
+  const std::vector<std::vector<float>> expected_outputs = {
+      {1.0f, -5.0f, -6.0f, 4.0f, 2.0f, 3.0f},
+      {-4.0f, 2.0f, -6.0f, 1.0f, 5.0f, 3.0f},
+      {-4.0f, -5.0f, 3.0f, 1.0f, 2.0f, 6.0f}};
+  const std::vector<int64_t> invalid_position_ids = {
+      std::numeric_limits<int64_t>::min(), -(int64_t{1} << 32), -1, 2, int64_t{1} << 32};
 
   for (int stream = 0; stream < 3; ++stream) {
-    for (const int64_t invalid_position_id : {-1, 2}) {
-      SCOPED_TRACE("stream=" + std::to_string(stream) +
-                   " invalid_position_id=" + std::to_string(invalid_position_id));
-
+    for (const int64_t invalid_position_id : invalid_position_ids) {
       std::vector<int64_t> position_ids = {0, 0, 0};
       position_ids[static_cast<size_t>(stream)] = invalid_position_id;
 
-      OpTester test("MRotaryEmbedding", 1, kMSDomain);
-      test.AddAttribute<int64_t>("num_heads", static_cast<int64_t>(1));
-      test.AddAttribute<int64_t>("rotary_embedding_dim", static_cast<int64_t>(6));
-      test.AddAttribute<int64_t>("mrope_layout", static_cast<int64_t>(0));
-      test.AddAttribute<int64_t>("interleaved", static_cast<int64_t>(0));
-      test.AddAttribute<std::vector<int64_t>>("mrope_section", {1, 1, 1});
+      for (const auto& available_ep : available_execution_providers) {
+        SCOPED_TRACE("provider=" + available_ep->Type() +
+                     " stream=" + std::to_string(stream) +
+                     " invalid_position_id=" + std::to_string(invalid_position_id));
 
-      test.AddInput<float>("input", {1, 1, 1, 6}, input_data);
-      test.AddInput<int64_t>("position_ids", {3, 1, 1}, position_ids);
-      test.AddInput<float>("cos_cache", {2, 3}, cos_cache);
-      test.AddInput<float>("sin_cache", {2, 3}, sin_cache);
-      test.AddOutput<float>("output", {1, 1, 1, 6}, input_data);
+        auto ep = CreateGpuExecutionProvider(available_ep->Type());
+        ASSERT_NE(ep, nullptr);
+        auto test = CreateMRotaryEmbeddingTester(*ep);
+        test->AddAttribute<int64_t>("num_heads", static_cast<int64_t>(1));
+        test->AddAttribute<int64_t>("rotary_embedding_dim", static_cast<int64_t>(6));
+        test->AddAttribute<int64_t>("mrope_layout", static_cast<int64_t>(0));
+        test->AddAttribute<int64_t>("interleaved", static_cast<int64_t>(0));
+        test->AddAttribute<std::vector<int64_t>>("mrope_section", {1, 1, 1});
 
-      std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
-      execution_providers.push_back(DefaultCudaExecutionProvider());
-      test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+        test->AddInput<float>("input", {1, 1, 1, 6}, input_data);
+        test->AddInput<int64_t>("position_ids", {3, 1, 1}, position_ids);
+        test->AddInput<float>("cos_cache", {2, 3}, cos_cache);
+        test->AddInput<float>("sin_cache", {2, 3}, sin_cache);
+        test->AddOutput<float>("output", {1, 1, 1, 6}, expected_outputs[static_cast<size_t>(stream)]);
+
+        std::vector<std::unique_ptr<IExecutionProvider>> test_execution_providers;
+        test_execution_providers.push_back(std::move(ep));
+        test->Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &test_execution_providers);
+      }
     }
   }
 }
 
-TEST(ContribOpMRotaryEmbeddingTest, CudaEmptyRank3Input) {
-  if (!HasCudaEnvironment(0)) {
-    GTEST_SKIP() << "CUDA execution provider is not available.";
+TEST(ContribOpMRotaryEmbeddingTest, EmptyRank3Input) {
+  auto execution_providers = GetAvailableGpuExecutionProviders();
+  if (execution_providers.empty()) {
+    GTEST_SKIP() << "CUDA and WebGPU execution providers are not available.";
   }
 
-  OpTester test("MRotaryEmbedding", 1, kMSDomain);
-  test.AddAttribute<int64_t>("num_heads", static_cast<int64_t>(1));
-  test.AddAttribute<int64_t>("mrope_layout", static_cast<int64_t>(0));
-  test.AddAttribute<int64_t>("interleaved", static_cast<int64_t>(0));
-  test.AddAttribute<std::vector<int64_t>>("mrope_section", {0, 0, 0});
+  for (auto& ep : execution_providers) {
+    SCOPED_TRACE("provider=" + ep->Type());
+    auto test = CreateMRotaryEmbeddingTester(*ep);
+    test->AddAttribute<int64_t>("num_heads", static_cast<int64_t>(1));
+    test->AddAttribute<int64_t>("mrope_layout", static_cast<int64_t>(0));
+    test->AddAttribute<int64_t>("interleaved", static_cast<int64_t>(0));
+    test->AddAttribute<std::vector<int64_t>>("mrope_section", {0, 0, 0});
 
-  test.AddInput<float>("input", {1, 1, 0}, std::vector<float>{});
-  test.AddInput<int64_t>("position_ids", {3, 1, 1}, {0, 0, 0});
-  test.AddInput<float>("cos_cache", {1, 0}, std::vector<float>{});
-  test.AddInput<float>("sin_cache", {1, 0}, std::vector<float>{});
-  test.AddOutput<float>("output", {1, 1, 0}, std::vector<float>{});
+    test->AddInput<float>("input", {1, 1, 0}, std::vector<float>{});
+    test->AddInput<int64_t>("position_ids", {3, 1, 1}, {0, 0, 0});
+    test->AddInput<float>("cos_cache", {1, 0}, std::vector<float>{});
+    test->AddInput<float>("sin_cache", {1, 0}, std::vector<float>{});
+    test->AddOutput<float>("output", {1, 1, 0}, std::vector<float>{});
 
-  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
-  execution_providers.push_back(DefaultCudaExecutionProvider());
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+    std::vector<std::unique_ptr<IExecutionProvider>> test_execution_providers;
+    test_execution_providers.push_back(std::move(ep));
+    test->Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &test_execution_providers);
+  }
 }
 
-TEST(ContribOpMRotaryEmbeddingTest, CudaEmptyRank4Input) {
-  if (!HasCudaEnvironment(0)) {
-    GTEST_SKIP() << "CUDA execution provider is not available.";
+TEST(ContribOpMRotaryEmbeddingTest, EmptyRank4Input) {
+  auto execution_providers = GetAvailableGpuExecutionProviders();
+  if (execution_providers.empty()) {
+    GTEST_SKIP() << "CUDA and WebGPU execution providers are not available.";
   }
 
-  OpTester test("MRotaryEmbedding", 1, kMSDomain);
-  test.AddAttribute<int64_t>("num_heads", static_cast<int64_t>(2));
-  test.AddAttribute<int64_t>("rotary_embedding_dim", static_cast<int64_t>(6));
-  test.AddAttribute<int64_t>("mrope_layout", static_cast<int64_t>(0));
-  test.AddAttribute<int64_t>("interleaved", static_cast<int64_t>(0));
-  test.AddAttribute<std::vector<int64_t>>("mrope_section", {1, 1, 1});
+  for (auto& ep : execution_providers) {
+    SCOPED_TRACE("provider=" + ep->Type());
+    auto test = CreateMRotaryEmbeddingTester(*ep);
+    test->AddAttribute<int64_t>("num_heads", static_cast<int64_t>(2));
+    test->AddAttribute<int64_t>("rotary_embedding_dim", static_cast<int64_t>(6));
+    test->AddAttribute<int64_t>("mrope_layout", static_cast<int64_t>(0));
+    test->AddAttribute<int64_t>("interleaved", static_cast<int64_t>(0));
+    test->AddAttribute<std::vector<int64_t>>("mrope_section", {1, 1, 1});
 
-  test.AddInput<float>("input", {1, 2, 0, 6}, std::vector<float>{});
-  test.AddInput<int64_t>("position_ids", {3, 1, 0}, std::vector<int64_t>{});
-  test.AddInput<float>("cos_cache", {1, 3}, {1.0f, 1.0f, 1.0f});
-  test.AddInput<float>("sin_cache", {1, 3}, {0.0f, 0.0f, 0.0f});
-  test.AddOutput<float>("output", {1, 2, 0, 6}, std::vector<float>{});
+    test->AddInput<float>("input", {1, 2, 0, 6}, std::vector<float>{});
+    test->AddInput<int64_t>("position_ids", {3, 1, 0}, std::vector<int64_t>{});
+    test->AddInput<float>("cos_cache", {1, 3}, {1.0f, 1.0f, 1.0f});
+    test->AddInput<float>("sin_cache", {1, 3}, {0.0f, 0.0f, 0.0f});
+    test->AddOutput<float>("output", {1, 2, 0, 6}, std::vector<float>{});
 
-  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
-  execution_providers.push_back(DefaultCudaExecutionProvider());
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+    std::vector<std::unique_ptr<IExecutionProvider>> test_execution_providers;
+    test_execution_providers.push_back(std::move(ep));
+    test->Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &test_execution_providers);
+  }
 }
 
 }  // namespace


### PR DESCRIPTION
## Description

Add WebGPU Execution Provider support for the Microsoft-domain MRotaryEmbedding contrib op introduced for CPU and CUDA in #31728.

The WebGPU kernel:

- supports rank-3 BSNH and rank-4 BNSH inputs
- supports sectioned and interleaved mRoPE layouts
- supports interleaved and non-interleaved rotary pairing
- supports float and float16 data, scaling, and partial rotary dimensions
- preserves non-rotary tail values and invalid/out-of-range position IDs
- validates full int64 position IDs by reading both u32 storage words
- implements the shader as a parameterized WGSL template

The operator tests now explicitly exercise WebGPU and extend the formerly CUDA-only negative-attribute, out-of-bounds position ID, and empty-input cases to both GPU providers.

## Testing

- Release WebGPU build of onnxruntime_provider_test
- onnxruntime_provider_test.exe --gtest_filter="ContribOpMRotaryEmbeddingTest.*" (9 tests passed)
- WGSL template generation across the WebGPU source tree (52 templates generated)
- lintrunner on all changed C++, header, test, and WGSL template files
- git diff --check

## Notes

The standalone WGSL template Python suite has two pre-existing golden-file mismatches for core subgroup-matrix templates. That smoke test scans core/providers/webgpu only; this PR adds its template under contrib_ops/webgpu and does not affect those mismatches.