### PR TITLE
[MIGraphX] Fix handling of Loop/If/Scan subgraphs and Loops with non-constant / huge maximum iteration count

### DIFF
--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -658,6 +658,43 @@ void SubgraphPostProcessing(const onnxruntime::GraphViewer& graph_viewer, std::v
   clusters.erase(it, clusters.end());
 }
 
+// Control-flow operators whose bodies MIGraphX parses natively
+// (parse_loop.cpp / parse_if.cpp / parse_scan.cpp). We must NOT fuse nodes
+// inside these bodies, because MIGraphX's parser recurses into the serialized
+// body attribute and expects to find real ONNX operators, not synthetic
+// MGXKernel_* operators that GetSubGraph would otherwise produce for the body
+// (see onnx_parser.cpp "Unknown operator" error).
+static const std::set<std::string> mgx_control_flow_ops = {"If", "Loop", "Scan"};
+
+static bool IsNodeSupported(const std::set<std::string>& op_set,
+                            const onnxruntime::GraphViewer& graph_viewer,
+                            const NodeIndex node_idx,
+                            const logging::Logger& logger);
+
+// Check whether every node in a (sub)graph is supported by MIGraphX.
+static bool IsSubGraphFullySupported(const GraphViewer& graph_viewer,
+                                     const std::set<std::string>& op_set,
+                                     const logging::Logger& logger) {
+  for (const auto& node_idx : graph_viewer.GetNodesInTopologicalOrder()) {
+    if (!IsNodeSupported(op_set, graph_viewer, node_idx, logger)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+static bool IsControlFlowOpBodySupported(const Node& node,
+                                         const std::set<std::string>& op_set,
+                                         const logging::Logger& logger) {
+  for (const auto& subgraph : node.GetSubgraphs()) {
+    auto sub_viewer = subgraph->CreateGraphViewer();
+    if (!IsSubGraphFullySupported(*sub_viewer, op_set, logger)) {
+      return false;
+    }
+  }
+  return true;
+}
+
 static bool IsNodeSupported(const std::set<std::string>& op_set,
                             const onnxruntime::GraphViewer& graph_viewer,
                             const NodeIndex node_idx,
@@ -693,6 +730,14 @@ static bool IsNodeSupported(const std::set<std::string>& op_set,
     // not supported, then check the constant folding capability of migraphx
     // to see whether it is supported
     return false;
+  }
+
+  // handle control-flow operators that are directly supported by MIGraphX, but
+  // only if every node in the body is supported too.
+  if (mgx_control_flow_ops.count(optype) != 0) {
+    if (!IsControlFlowOpBodySupported(*node, op_set, logger)) {
+      return false;
+    }
   }
 
   return true;
@@ -1079,6 +1124,17 @@ MIGraphXExecutionProvider::GetCapability(const onnxruntime::GraphViewer& graph_v
                                          const GraphOptimizerRegistry& /* graph_optimizer_registry */,
                                          IResourceAccountant* /* resource_accountant */) const {
   std::vector<std::unique_ptr<ComputeCapability>> result;
+
+  // MIGraphX supports Loop/If/Scan control-flow operations natively and recurses into their body
+  // subgraphs when parsing the serialized model. Don't partition them below
+  // but pass them as-is to MIGraphX. See also IsNodeSupported() above.
+  if (graph_viewer.IsSubgraph()) {
+    const Node* parent = graph_viewer.ParentNode();
+    if (parent != nullptr && mgx_control_flow_ops.count(parent->OpType()) != 0) {
+      return result;
+    }
+  }
+
   auto model = graph_viewer.CreateModel(*GetLogger());
   auto model_proto = model->ToProto();
   graph_viewer.ToProto(*model_proto->mutable_graph(), true, true);

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -29,6 +29,7 @@
 #include "core/providers/migraphx/gpu_data_transfer.h"
 #include "core/providers/migraphx/migraphx_call.h"
 #include "core/providers/migraphx/migraphx_stream_handle.h"
+#include "core/framework/tensorprotoutils.h"
 
 #if defined(_MSC_VER)
 #pragma warning(disable : 4244 4245)
@@ -374,6 +375,27 @@ std::vector<int> toVector(const ONNX_NAMESPACE::int64s& nums) {
   return result;
 }
 
+static std::pair<const void*, size_t> GetRawData(const ONNX_NAMESPACE::TensorProto& tensor_proto) {
+  if (onnxruntime::utils::HasRawData(tensor_proto)) {
+    const auto& raw = tensor_proto.raw_data();
+    return {raw.data(), raw.size()};
+  }
+  return {nullptr, 0};
+}
+
+// Read a scalar int64 value from a graph initializer. Returns false if the named
+// input is not an int64 initializer or holds no scalar value.
+static bool GetConstantInt64Scalar(const GraphViewer& graph_viewer,
+                                   const std::string& name, int64_t& out) {
+  const ONNX_NAMESPACE::TensorProto* t = nullptr;
+  if (!graph_viewer.GetInitializedTensor(name, t) || t == nullptr) {
+    return false;
+  }
+  const auto [raw_data, raw_data_len] = GetRawData(*t);
+  auto status = onnxruntime::utils::UnpackTensor<int64_t>(*t, raw_data, raw_data_len, &out, 1);
+  return status.IsOK();
+}
+
 static bool IsUnsupportedOpMode(const onnxruntime::GraphViewer& graph_viewer, const Node* node) {
   std::vector<NodeIndex> input_nodes;
   const auto& optype = node->OpType();
@@ -575,6 +597,18 @@ static bool IsUnsupportedOpMode(const onnxruntime::GraphViewer& graph_viewer, co
   } else if (optype == "TopK") {
     if (!canEvalNodeArgument(graph_viewer, node, {1}, input_nodes)) {
       return true;
+    }
+  } else if (optype == "Loop") {
+    // MIGraphX only supports a constant number of loop iterations and clamps
+    // to 65535 iterations. Consider any other loops as unsupported.
+    const auto& args = node->InputDefs();
+    if (args.empty() || args[0]->Name().empty()) {
+      return true;  // no maximum number of iterations
+    }
+    const std::string& m_name = args[0]->Name();
+    int64_t m_val = 0;
+    if (!GetConstantInt64Scalar(graph_viewer, m_name, m_val) || m_val > 65535) {
+      return true;  // not a readable constant or too many iterations
     }
   } else if (optype == "Unsqueeze" || optype == "Squeeze") {
     const auto& args = node->InputDefs();

--- a/onnxruntime/test/providers/migraphx/migraphx_basic_test.cc
+++ b/onnxruntime/test/providers/migraphx/migraphx_basic_test.cc
@@ -4,6 +4,7 @@
 #include "core/session/inference_session.h"
 #include "test/providers/provider_test_utils.h"
 #include "test/unittest_util/framework_test_utils.h"
+#include "test/util/include/test_utils.h"
 #include "gtest/gtest.h"
 #include "test/util/include/default_providers.h"
 #include "test/util/include/scoped_env_vars.h"
@@ -231,6 +232,683 @@ TEST(MIGraphXExecutionProviderTest, AutoEp_PreferGpu) {
   env.UnregisterExecutionProviderLibrary(kMIGraphXExecutionProvider);
 }
 #endif
+
+// Create a minimal Loop body subgraph (identity pass-through).
+static GraphProto CreateSimpleLoopBody() {
+  Model model("loop_body", true, DefaultLoggingManager().DefaultLogger());
+  auto& graph = model.MainGraph();
+
+  TypeProto int64_scalar;
+  int64_scalar.mutable_tensor_type()->set_elem_type(TensorProto_DataType_INT64);
+  int64_scalar.mutable_tensor_type()->mutable_shape();
+
+  TypeProto bool_scalar;
+  bool_scalar.mutable_tensor_type()->set_elem_type(TensorProto_DataType_BOOL);
+  bool_scalar.mutable_tensor_type()->mutable_shape();
+
+  TypeProto float_tensor_1d;
+  float_tensor_1d.mutable_tensor_type()->set_elem_type(TensorProto_DataType_FLOAT);
+  float_tensor_1d.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(1);
+
+  // Body inputs
+  auto& iter_num = graph.GetOrCreateNodeArg("i", &int64_scalar);
+  auto& cond_in = graph.GetOrCreateNodeArg("body_cond", &bool_scalar);
+  auto& v_in = graph.GetOrCreateNodeArg("body_v", &float_tensor_1d);
+
+  // Body outputs
+  auto& cond_out = graph.GetOrCreateNodeArg("cond_out", &bool_scalar);
+  auto& v_out = graph.GetOrCreateNodeArg("v_out", &float_tensor_1d);
+
+  graph.AddNode("cond_id", "Identity", "", {&cond_in}, {&cond_out});
+  graph.AddNode("v_id", "Identity", "", {&v_in}, {&v_out});
+
+  graph.SetInputs({&iter_num, &cond_in, &v_in});
+  graph.SetOutputs({&cond_out, &v_out});
+
+  ORT_ENFORCE(graph.Resolve().IsOK(), "Graph resolve failed");
+  return graph.ToGraphProto();
+}
+
+// Create a Loop model with a trip-count initializer.
+static Model BuildLoopModel(const char* model_name, const char* m_name, int64_t m_value,
+                            std::function<void(Graph&, const char*, int64_t)> add_initializer) {
+  Model model(model_name, false, DefaultLoggingManager().DefaultLogger());
+  auto& graph = model.MainGraph();
+
+  TypeProto int64_scalar;
+  int64_scalar.mutable_tensor_type()->set_elem_type(TensorProto_DataType_INT64);
+  int64_scalar.mutable_tensor_type()->mutable_shape();
+
+  TypeProto bool_scalar;
+  bool_scalar.mutable_tensor_type()->set_elem_type(TensorProto_DataType_BOOL);
+  bool_scalar.mutable_tensor_type()->mutable_shape();
+
+  TypeProto float_tensor_1d;
+  float_tensor_1d.mutable_tensor_type()->set_elem_type(TensorProto_DataType_FLOAT);
+  float_tensor_1d.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(1);
+
+  // Trip count
+  auto& m_arg = graph.GetOrCreateNodeArg(m_name, &int64_scalar);
+  add_initializer(graph, m_name, m_value);
+
+  // cond input
+  auto& cond = graph.GetOrCreateNodeArg("cond", &bool_scalar);
+
+  // v_init (loop carried dependency)
+  auto& v_init = graph.GetOrCreateNodeArg("v_init", &float_tensor_1d);
+
+  // v_final (loop output)
+  auto& v_final = graph.GetOrCreateNodeArg("v_final", &float_tensor_1d);
+
+  auto& loop_node = graph.AddNode("loop", "Loop", "",
+                                   {&m_arg, &cond, &v_init}, {&v_final});
+  loop_node.AddAttribute("body", CreateSimpleLoopBody());
+
+  graph.SetInputs({&cond, &v_init});
+  graph.SetOutputs({&v_final});
+
+  ORT_ENFORCE(graph.Resolve().IsOK(), "Graph resolve failed");
+  return model;
+}
+
+// Run a model with MIGraphX EP and verify the graph via the callback.
+static void RunLoopTest(Model&& model, std::function<void(const Graph&)> verify,
+                        ExpectedEPNodeAssignment expected = ExpectedEPNodeAssignment::Some,
+                        NameMLValMap extra_feeds = {},
+                        std::vector<int64_t> cond_shape = {}) {
+  std::string model_data;
+  model.ToProto().SerializeToString(&model_data);
+  const auto model_data_span = AsByteSpan(model_data.data(), model_data.size());
+
+  // Feeds: cond (bool) and v_init (float[1])
+  auto cpu_alloc = TestCPUExecutionProvider()->CreatePreferredAllocators()[0];
+
+  OrtValue cond_value;
+  std::vector<bool> cond_data{true};
+  CreateMLValue<bool>(cpu_alloc, cond_shape, cond_data, &cond_value);
+
+  OrtValue v_init_value;
+  std::vector<float> v_init_data{0.f};
+  CreateMLValue<float>(cpu_alloc, std::vector<int64_t>{1}, v_init_data, &v_init_value);
+
+  NameMLValMap feeds;
+  feeds.insert(std::make_pair("cond", cond_value));
+  feeds.insert(std::make_pair("v_init", v_init_value));
+  feeds.insert(extra_feeds.begin(), extra_feeds.end());
+
+  EPVerificationParams params;
+  params.ep_node_assignment = expected;
+  params.graph_verifier = &verify;
+
+  RunAndVerifyOutputsWithEP(model_data_span, "MIGraphX.LoopTest",
+                            DefaultMIGraphXExecutionProvider(), feeds, params);
+}
+
+TEST(MIGraphXExecutionProviderTest, LoopSmallRawData) {
+  auto add_raw = [](Graph& g, const char* name, int64_t value) {
+    TensorProto tp;
+    tp.set_name(name);
+    tp.set_data_type(TensorProto_DataType_INT64);
+    tp.set_raw_data(&value, sizeof(int64_t));
+    g.AddInitializedTensor(tp);
+  };
+  auto model = BuildLoopModel("loop_small_raw", "m", 100, add_raw);
+  std::function<void(const Graph&)> verify = [](const Graph& g) {
+    for (const auto& node : g.Nodes()) {
+      if (node.OpType() == "Loop") {
+        EXPECT_EQ(node.GetExecutionProviderType(), kMIGraphXExecutionProvider)
+            << "Loop with m=100 (raw_data) should be assigned to MIGraphX";
+      }
+    }
+  };
+  RunLoopTest(std::move(model), verify);
+}
+
+TEST(MIGraphXExecutionProviderTest, LoopBoundaryRawData) {
+  auto add_raw = [](Graph& g, const char* name, int64_t value) {
+    TensorProto tp;
+    tp.set_name(name);
+    tp.set_data_type(TensorProto_DataType_INT64);
+    tp.set_raw_data(&value, sizeof(int64_t));
+    g.AddInitializedTensor(tp);
+  };
+  auto model = BuildLoopModel("loop_boundary_raw", "m", 65535, add_raw);
+  std::function<void(const Graph&)> verify = [](const Graph& g) {
+    for (const auto& node : g.Nodes()) {
+      if (node.OpType() == "Loop") {
+        EXPECT_EQ(node.GetExecutionProviderType(), kMIGraphXExecutionProvider)
+            << "Loop with m=65535 (raw_data) should be assigned to MIGraphX";
+      }
+    }
+  };
+  RunLoopTest(std::move(model), verify);
+}
+
+TEST(MIGraphXExecutionProviderTest, LoopOverLimitRawData) {
+  auto add_raw = [](Graph& g, const char* name, int64_t value) {
+    TensorProto tp;
+    tp.set_name(name);
+    tp.set_data_type(TensorProto_DataType_INT64);
+    tp.set_raw_data(&value, sizeof(int64_t));
+    g.AddInitializedTensor(tp);
+  };
+  auto model = BuildLoopModel("loop_overlimit_raw", "m", 65536, add_raw);
+  std::function<void(const Graph&)> verify = [](const Graph& g) {
+    for (const auto& node : g.Nodes()) {
+      if (node.OpType() == "Loop") {
+        EXPECT_EQ(node.GetExecutionProviderType(), kCpuExecutionProvider)
+            << "Loop with m=65536 (raw_data) should fall back to CPU";
+      }
+    }
+  };
+  RunLoopTest(std::move(model), verify, ExpectedEPNodeAssignment::None);
+}
+
+TEST(MIGraphXExecutionProviderTest, LoopSmallInt64Data) {
+  auto add_typed = [](Graph& g, const char* name, int64_t value) {
+    TensorProto tp;
+    tp.set_name(name);
+    tp.set_data_type(TensorProto_DataType_INT64);
+    tp.add_int64_data(value);
+    g.AddInitializedTensor(tp);
+  };
+  auto model = BuildLoopModel("loop_small_typed", "m", 100, add_typed);
+  std::function<void(const Graph&)> verify = [](const Graph& g) {
+    for (const auto& node : g.Nodes()) {
+      if (node.OpType() == "Loop") {
+        EXPECT_EQ(node.GetExecutionProviderType(), kMIGraphXExecutionProvider)
+            << "Loop with m=100 (int64_data) should be assigned to MIGraphX";
+      }
+    }
+  };
+  RunLoopTest(std::move(model), verify);
+}
+
+TEST(MIGraphXExecutionProviderTest, LoopOverLimitInt64Data) {
+  auto add_typed = [](Graph& g, const char* name, int64_t value) {
+    TensorProto tp;
+    tp.set_name(name);
+    tp.set_data_type(TensorProto_DataType_INT64);
+    tp.add_int64_data(value);
+    g.AddInitializedTensor(tp);
+  };
+  auto model = BuildLoopModel("loop_overlimit_typed", "m", 100000, add_typed);
+  std::function<void(const Graph&)> verify = [](const Graph& g) {
+    for (const auto& node : g.Nodes()) {
+      if (node.OpType() == "Loop") {
+        EXPECT_EQ(node.GetExecutionProviderType(), kCpuExecutionProvider)
+            << "Loop with m=100000 (int64_data) should fall back to CPU";
+      }
+    }
+  };
+  RunLoopTest(std::move(model), verify, ExpectedEPNodeAssignment::None);
+}
+
+TEST(MIGraphXExecutionProviderTest, LoopDynamicTripCount) {
+  // Trip count is a graph input, not an initializer.
+  Model model("loop_dynamic", false, DefaultLoggingManager().DefaultLogger());
+  auto& graph = model.MainGraph();
+
+  TypeProto int64_scalar;
+  int64_scalar.mutable_tensor_type()->set_elem_type(TensorProto_DataType_INT64);
+  int64_scalar.mutable_tensor_type()->mutable_shape();
+
+  TypeProto bool_scalar;
+  bool_scalar.mutable_tensor_type()->set_elem_type(TensorProto_DataType_BOOL);
+  bool_scalar.mutable_tensor_type()->mutable_shape();
+
+  TypeProto float_tensor_1d;
+  float_tensor_1d.mutable_tensor_type()->set_elem_type(TensorProto_DataType_FLOAT);
+  float_tensor_1d.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(1);
+
+  auto& m_arg = graph.GetOrCreateNodeArg("m", &int64_scalar);
+  auto& cond = graph.GetOrCreateNodeArg("cond", &bool_scalar);
+  auto& v_init = graph.GetOrCreateNodeArg("v_init", &float_tensor_1d);
+  auto& v_final = graph.GetOrCreateNodeArg("v_final", &float_tensor_1d);
+
+  auto& loop_node = graph.AddNode("loop", "Loop", "",
+                                   {&m_arg, &cond, &v_init}, {&v_final});
+  loop_node.AddAttribute("body", CreateSimpleLoopBody());
+
+  graph.SetInputs({&m_arg, &cond, &v_init});
+  graph.SetOutputs({&v_final});
+  ASSERT_TRUE(graph.Resolve().IsOK());
+
+  std::function<void(const Graph&)> verify = [](const Graph& g) {
+    for (const auto& node : g.Nodes()) {
+      if (node.OpType() == "Loop") {
+        EXPECT_EQ(node.GetExecutionProviderType(), kCpuExecutionProvider)
+            << "Loop with dynamic trip count should fall back to CPU";
+      }
+    }
+  };
+  NameMLValMap extra_feeds;
+  {
+    auto cpu_alloc = TestCPUExecutionProvider()->CreatePreferredAllocators()[0];
+    OrtValue m_value;
+    std::vector<int64_t> m_data{10};
+    CreateMLValue<int64_t>(cpu_alloc, std::vector<int64_t>{}, m_data, &m_value);
+    extra_feeds.insert(std::make_pair("m", m_value));
+  }
+  RunLoopTest(std::move(model), verify, ExpectedEPNodeAssignment::None, std::move(extra_feeds));
+}
+
+// Loop body that contains a nested Loop.
+static GraphProto CreateLoopBodyWithNestedLoop() {
+  Model model("loop_body_nested", true, DefaultLoggingManager().DefaultLogger());
+  auto& graph = model.MainGraph();
+
+  TypeProto int64_scalar;
+  int64_scalar.mutable_tensor_type()->set_elem_type(TensorProto_DataType_INT64);
+  int64_scalar.mutable_tensor_type()->mutable_shape();
+
+  TypeProto bool_scalar;
+  bool_scalar.mutable_tensor_type()->set_elem_type(TensorProto_DataType_BOOL);
+  bool_scalar.mutable_tensor_type()->mutable_shape();
+
+  TypeProto float_tensor_1d;
+  float_tensor_1d.mutable_tensor_type()->set_elem_type(TensorProto_DataType_FLOAT);
+  float_tensor_1d.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(1);
+
+  // Body inputs
+  auto& cond_in = graph.GetOrCreateNodeArg("outer_cond", &bool_scalar);
+  auto& v_in = graph.GetOrCreateNodeArg("outer_v", &float_tensor_1d);
+
+  // Nested loop trip count (constant)
+  TensorProto m_proto;
+  m_proto.set_name("inner_m");
+  m_proto.set_data_type(TensorProto_DataType_INT64);
+  m_proto.add_int64_data(1);
+  graph.AddInitializedTensor(m_proto);
+  auto& inner_m = graph.GetOrCreateNodeArg("inner_m", &int64_scalar);
+
+  // Nested loop inputs/outputs
+  auto& inner_v_final = graph.GetOrCreateNodeArg("inner_v_final", &float_tensor_1d);
+
+  // Wire cond_in and v_in directly to the inner loop
+  auto& inner_loop = graph.AddNode("inner_loop", "Loop", "",
+                                    {&inner_m, &cond_in, &v_in}, {&inner_v_final});
+  inner_loop.AddAttribute("body", CreateSimpleLoopBody());
+
+  // Body outputs
+  auto& cond_out = graph.GetOrCreateNodeArg("cond_out", &bool_scalar);
+  auto& v_out = graph.GetOrCreateNodeArg("v_out", &float_tensor_1d);
+
+  graph.AddNode("cond_id", "Identity", "", {&cond_in}, {&cond_out});
+  graph.AddNode("v_id", "Identity", "", {&inner_v_final}, {&v_out});
+
+  graph.SetInputs({&cond_in, &v_in});
+  graph.SetOutputs({&cond_out, &v_out});
+
+  ORT_ENFORCE(graph.Resolve().IsOK(), "Graph resolve failed");
+  return graph.ToGraphProto();
+}
+
+// Loop body that contains an If.
+static GraphProto CreateLoopBodyWithNestedIf() {
+  Model model("loop_body_nested_if", true, DefaultLoggingManager().DefaultLogger());
+  auto& graph = model.MainGraph();
+
+  TypeProto bool_scalar;
+  bool_scalar.mutable_tensor_type()->set_elem_type(TensorProto_DataType_BOOL);
+  bool_scalar.mutable_tensor_type()->mutable_shape();
+
+  TypeProto float_tensor_1d;
+  float_tensor_1d.mutable_tensor_type()->set_elem_type(TensorProto_DataType_FLOAT);
+  float_tensor_1d.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(1);
+
+  // Body inputs
+  auto& cond_in = graph.GetOrCreateNodeArg("loop_cond", &bool_scalar);
+
+  // Minimal then/else branches (no inputs; produce output via initializer).
+  auto make_branch = [&]() -> GraphProto {
+    Model branch("if_branch", true, DefaultLoggingManager().DefaultLogger());
+    auto& bgraph = branch.MainGraph();
+    TensorProto const_proto;
+    const_proto.set_name("branch_out");
+    const_proto.set_data_type(TensorProto_DataType_FLOAT);
+    const_proto.add_dims(1);
+    const_proto.add_float_data(1.f);
+    bgraph.AddInitializedTensor(const_proto);
+    auto& b_out = *bgraph.GetNodeArg("branch_out");
+    bgraph.SetOutputs({&b_out});
+    ORT_ENFORCE(bgraph.Resolve().IsOK(), "Graph resolve failed");
+    return bgraph.ToGraphProto();
+  };
+
+  // If node takes only the condition as input.
+  auto& if_v_out = graph.GetOrCreateNodeArg("if_v_out", &float_tensor_1d);
+
+  auto& if_node = graph.AddNode("inner_if", "If", "", {&cond_in}, {&if_v_out});
+  if_node.AddAttribute("then_branch", make_branch());
+  if_node.AddAttribute("else_branch", make_branch());
+
+  // Body outputs
+  auto& cond_out = graph.GetOrCreateNodeArg("cond_out", &bool_scalar);
+  auto& v_out = graph.GetOrCreateNodeArg("v_out", &float_tensor_1d);
+
+  graph.AddNode("cond_id", "Identity", "", {&cond_in}, {&cond_out});
+  graph.AddNode("v_id", "Identity", "", {&if_v_out}, {&v_out});
+
+  graph.SetInputs({&cond_in});
+  graph.SetOutputs({&cond_out, &v_out});
+
+  ORT_ENFORCE(graph.Resolve().IsOK(), "Graph resolve failed");
+  return graph.ToGraphProto();
+}
+
+TEST(MIGraphXExecutionProviderTest, LoopWithNestedLoop) {
+  auto add_typed = [](Graph& g, const char* name, int64_t value) {
+    TensorProto tp;
+    tp.set_name(name);
+    tp.set_data_type(TensorProto_DataType_INT64);
+    tp.add_int64_data(value);
+    g.AddInitializedTensor(tp);
+  };
+  auto model = BuildLoopModel("loop_nested_loop", "m", 10, add_typed);
+  // Replace the simple body with one that contains a nested Loop
+  auto& graph = model.MainGraph();
+  for (auto& node : graph.Nodes()) {
+    if (node.OpType() == "Loop") {
+      node.AddAttribute("body", CreateLoopBodyWithNestedLoop());
+    }
+  }
+  ASSERT_TRUE(graph.Resolve().IsOK());
+
+  std::function<void(const Graph&)> verify = [](const Graph& g) {
+    for (const auto& node : g.Nodes()) {
+      if (node.OpType() == "Loop") {
+        EXPECT_EQ(node.GetExecutionProviderType(), kMIGraphXExecutionProvider)
+            << "Loop with nested Loop body should be assigned to MIGraphX";
+      }
+    }
+  };
+  RunLoopTest(std::move(model), verify);
+}
+
+TEST(MIGraphXExecutionProviderTest, LoopWithNestedIf) {
+  auto add_typed = [](Graph& g, const char* name, int64_t value) {
+    TensorProto tp;
+    tp.set_name(name);
+    tp.set_data_type(TensorProto_DataType_INT64);
+    tp.add_int64_data(value);
+    g.AddInitializedTensor(tp);
+  };
+  auto model = BuildLoopModel("loop_nested_if", "m", 10, add_typed);
+  // Replace the simple body with one that contains an If
+  auto& graph = model.MainGraph();
+  for (auto& node : graph.Nodes()) {
+    if (node.OpType() == "Loop") {
+      node.AddAttribute("body", CreateLoopBodyWithNestedIf());
+    }
+  }
+  ASSERT_TRUE(graph.Resolve().IsOK());
+
+  std::function<void(const Graph&)> verify = [](const Graph& g) {
+    for (const auto& node : g.Nodes()) {
+      if (node.OpType() == "Loop") {
+        EXPECT_EQ(node.GetExecutionProviderType(), kMIGraphXExecutionProvider)
+            << "Loop with nested If body should be assigned to MIGraphX";
+      }
+    }
+  };
+  RunLoopTest(std::move(model), verify);
+}
+// Loop body with an unsupported op.
+static GraphProto CreateLoopBodyWithUnsupportedOp() {
+  Model model("loop_body_unsupported", true, DefaultLoggingManager().DefaultLogger());
+  auto& graph = model.MainGraph();
+
+  TypeProto int64_scalar;
+  int64_scalar.mutable_tensor_type()->set_elem_type(TensorProto_DataType_INT64);
+  int64_scalar.mutable_tensor_type()->mutable_shape();
+
+  TypeProto bool_tensor_1d;
+  bool_tensor_1d.mutable_tensor_type()->set_elem_type(TensorProto_DataType_BOOL);
+  bool_tensor_1d.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(1);
+
+  TypeProto float_tensor_1d;
+  float_tensor_1d.mutable_tensor_type()->set_elem_type(TensorProto_DataType_FLOAT);
+  float_tensor_1d.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(1);
+
+  // Body inputs (required by Loop body schema, even if not consumed)
+  auto& iter_num = graph.GetOrCreateNodeArg("i", &int64_scalar);
+  auto& cond_in = graph.GetOrCreateNodeArg("body_cond", &bool_tensor_1d);
+  auto& v_in = graph.GetOrCreateNodeArg("body_v", &float_tensor_1d);
+
+  // Body outputs
+  auto& cond_out = graph.GetOrCreateNodeArg("cond_out", &bool_tensor_1d);
+  auto& v_out = graph.GetOrCreateNodeArg("v_out", &float_tensor_1d);
+
+  // IsInf is not in mgx_supported_ops.
+  graph.AddNode("isinf", "IsInf", "", {&v_in}, {&cond_out});
+  graph.AddNode("v_id", "Identity", "", {&v_in}, {&v_out});
+
+  graph.SetInputs({&iter_num, &cond_in, &v_in});
+  graph.SetOutputs({&cond_out, &v_out});
+
+  ORT_ENFORCE(graph.Resolve().IsOK(), "Graph resolve failed");
+  return graph.ToGraphProto();
+}
+
+// Build a Loop model for the unsupported body test.
+static Model BuildLoopModelWithUnsupportedBody(int64_t m_value) {
+  Model model("loop_unsupported_body", false, DefaultLoggingManager().DefaultLogger());
+  auto& graph = model.MainGraph();
+
+  TypeProto int64_scalar;
+  int64_scalar.mutable_tensor_type()->set_elem_type(TensorProto_DataType_INT64);
+  int64_scalar.mutable_tensor_type()->mutable_shape();
+
+  TypeProto bool_tensor_1d;
+  bool_tensor_1d.mutable_tensor_type()->set_elem_type(TensorProto_DataType_BOOL);
+  bool_tensor_1d.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(1);
+
+  TypeProto float_tensor_1d;
+  float_tensor_1d.mutable_tensor_type()->set_elem_type(TensorProto_DataType_FLOAT);
+  float_tensor_1d.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(1);
+
+  // Trip count
+  TensorProto m_proto;
+  m_proto.set_name("m");
+  m_proto.set_data_type(TensorProto_DataType_INT64);
+  m_proto.add_int64_data(m_value);
+  graph.AddInitializedTensor(m_proto);
+  auto& m_arg = graph.GetOrCreateNodeArg("m", &int64_scalar);
+
+  // Condition
+  auto& cond = graph.GetOrCreateNodeArg("cond", &bool_tensor_1d);
+
+  // Loop carried dependency
+  auto& v_init = graph.GetOrCreateNodeArg("v_init", &float_tensor_1d);
+  auto& v_final = graph.GetOrCreateNodeArg("v_final", &float_tensor_1d);
+
+  auto& loop_node = graph.AddNode("loop", "Loop", "",
+                                   {&m_arg, &cond, &v_init}, {&v_final});
+  loop_node.AddAttribute("body", CreateLoopBodyWithUnsupportedOp());
+
+  graph.SetInputs({&cond, &v_init});
+  graph.SetOutputs({&v_final});
+  ORT_ENFORCE(graph.Resolve().IsOK(), "Graph resolve failed");
+  return model;
+}
+
+TEST(MIGraphXExecutionProviderTest, LoopWithUnsupportedBody) {
+  auto model = BuildLoopModelWithUnsupportedBody(10);
+
+  std::function<void(const Graph&)> verify = [](const Graph& g) {
+    for (const auto& node : g.Nodes()) {
+      if (node.OpType() == "Loop") {
+        EXPECT_EQ(node.GetExecutionProviderType(), kCpuExecutionProvider)
+            << "Loop with unsupported body op (IsInf) should fall back to CPU";
+      }
+    }
+  };
+  RunLoopTest(std::move(model), verify, ExpectedEPNodeAssignment::None, {}, {1});
+}
+
+// If operator tests.
+static GraphProto CreateSimpleIfBranch(const char* branch_name) {
+  Model model(branch_name, true, DefaultLoggingManager().DefaultLogger());
+  auto& graph = model.MainGraph();
+
+  TypeProto float_tensor_1d;
+  float_tensor_1d.mutable_tensor_type()->set_elem_type(TensorProto_DataType_FLOAT);
+  float_tensor_1d.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(1);
+
+  // Outer scope value.
+  auto& outer_in = graph.GetOrCreateNodeArg("if_v", &float_tensor_1d);
+  graph.AddOuterScopeNodeArg("if_v");
+
+  auto& b_out = graph.GetOrCreateNodeArg("branch_out", &float_tensor_1d);
+
+  graph.AddNode("id", "Identity", "", {&outer_in}, {&b_out});
+  graph.SetOutputs({&b_out});
+
+  ORT_ENFORCE(graph.Resolve().IsOK(), "Graph resolve failed");
+  return graph.ToGraphProto();
+}
+
+// If branch with an unsupported op.
+static GraphProto CreateIfBranchWithUnsupportedOp(const char* branch_name) {
+  Model model(branch_name, true, DefaultLoggingManager().DefaultLogger());
+  auto& graph = model.MainGraph();
+
+  TypeProto float_tensor_1d;
+  float_tensor_1d.mutable_tensor_type()->set_elem_type(TensorProto_DataType_FLOAT);
+  float_tensor_1d.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(1);
+
+  TypeProto bool_tensor_1d;
+  bool_tensor_1d.mutable_tensor_type()->set_elem_type(TensorProto_DataType_BOOL);
+  bool_tensor_1d.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(1);
+
+  // Outer scope value.
+  auto& outer_in = graph.GetOrCreateNodeArg("if_v", &float_tensor_1d);
+  graph.AddOuterScopeNodeArg("if_v");
+
+  auto& b_out = graph.GetOrCreateNodeArg("branch_out", &bool_tensor_1d);
+
+  // IsInf is not in mgx_supported_ops.
+  graph.AddNode("isinf", "IsInf", "", {&outer_in}, {&b_out});
+  graph.SetOutputs({&b_out});
+
+  ORT_ENFORCE(graph.Resolve().IsOK(), "Graph resolve failed");
+  return graph.ToGraphProto();
+}
+
+// Run an If model with MIGraphX EP and verify the graph via the callback.
+static void RunIfTest(Model&& model, std::function<void(const Graph&)> verify,
+                      ExpectedEPNodeAssignment expected = ExpectedEPNodeAssignment::Some) {
+  std::string model_data;
+  model.ToProto().SerializeToString(&model_data);
+  const auto model_data_span = AsByteSpan(model_data.data(), model_data.size());
+
+  auto cpu_alloc = TestCPUExecutionProvider()->CreatePreferredAllocators()[0];
+
+  OrtValue cond_value;
+  std::vector<bool> cond_data{true};
+  CreateMLValue<bool>(cpu_alloc, std::vector<int64_t>{}, cond_data, &cond_value);
+
+  // Outer scope value.
+  OrtValue v_value;
+  std::vector<float> v_data{1.0f};
+  CreateMLValue<float>(cpu_alloc, std::vector<int64_t>{1}, v_data, &v_value);
+
+  NameMLValMap feeds;
+  feeds.insert(std::make_pair("if_cond", cond_value));
+  feeds.insert(std::make_pair("v_in", v_value));
+
+  EPVerificationParams params;
+  params.ep_node_assignment = expected;
+  params.graph_verifier = &verify;
+
+  RunAndVerifyOutputsWithEP(model_data_span, "MIGraphX.IfTest",
+                            DefaultMIGraphXExecutionProvider(), feeds, params);
+}
+
+TEST(MIGraphXExecutionProviderTest, IfSimple) {
+  Model model("if_simple", false, DefaultLoggingManager().DefaultLogger());
+  auto& graph = model.MainGraph();
+
+  TypeProto bool_scalar;
+  bool_scalar.mutable_tensor_type()->set_elem_type(TensorProto_DataType_BOOL);
+  bool_scalar.mutable_tensor_type()->mutable_shape();
+
+  TypeProto float_tensor_1d;
+  float_tensor_1d.mutable_tensor_type()->set_elem_type(TensorProto_DataType_FLOAT);
+  float_tensor_1d.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(1);
+
+  // Create outer scope variable.
+  auto& v_in = graph.GetOrCreateNodeArg("v_in", &float_tensor_1d);
+  auto& if_v = graph.GetOrCreateNodeArg("if_v", &float_tensor_1d);
+  graph.AddNode("v_id", "Identity", "", {&v_in}, {&if_v});
+
+  // If node.
+  auto& if_cond = graph.GetOrCreateNodeArg("if_cond", &bool_scalar);
+  auto& v_out = graph.GetOrCreateNodeArg("v_out", &float_tensor_1d);
+
+  auto& if_node = graph.AddNode("if_op", "If", "", {&if_cond}, {&v_out});
+  if_node.AddAttribute("then_branch", CreateSimpleIfBranch("then"));
+  if_node.AddAttribute("else_branch", CreateSimpleIfBranch("else"));
+
+  graph.SetInputs({&if_cond, &v_in});
+  graph.SetOutputs({&v_out});
+  ASSERT_TRUE(graph.Resolve().IsOK());
+
+  std::function<void(const Graph&)> verify = [](const Graph& g) {
+    for (const auto& node : g.Nodes()) {
+      if (node.OpType() == "If") {
+        EXPECT_EQ(node.GetExecutionProviderType(), kMIGraphXExecutionProvider)
+            << "Simple If should be assigned to MIGraphX";
+      }
+    }
+  };
+  RunIfTest(std::move(model), verify);
+}
+
+TEST(MIGraphXExecutionProviderTest, IfWithUnsupportedBody) {
+  Model model("if_unsupported", false, DefaultLoggingManager().DefaultLogger());
+  auto& graph = model.MainGraph();
+
+  TypeProto bool_scalar;
+  bool_scalar.mutable_tensor_type()->set_elem_type(TensorProto_DataType_BOOL);
+  bool_scalar.mutable_tensor_type()->mutable_shape();
+
+  TypeProto float_tensor_1d;
+  float_tensor_1d.mutable_tensor_type()->set_elem_type(TensorProto_DataType_FLOAT);
+  float_tensor_1d.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(1);
+
+  // Create outer scope variable.
+  auto& v_in = graph.GetOrCreateNodeArg("v_in", &float_tensor_1d);
+  auto& if_v = graph.GetOrCreateNodeArg("if_v", &float_tensor_1d);
+  graph.AddNode("v_id", "Identity", "", {&v_in}, {&if_v});
+
+  // If node.
+  TypeProto bool_tensor_1d;
+  bool_tensor_1d.mutable_tensor_type()->set_elem_type(TensorProto_DataType_BOOL);
+  bool_tensor_1d.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(1);
+
+  auto& if_cond = graph.GetOrCreateNodeArg("if_cond", &bool_scalar);
+  auto& v_out = graph.GetOrCreateNodeArg("v_out", &bool_tensor_1d);
+
+  auto& if_node = graph.AddNode("if_op", "If", "", {&if_cond}, {&v_out});
+  if_node.AddAttribute("then_branch", CreateIfBranchWithUnsupportedOp("then"));
+  if_node.AddAttribute("else_branch", CreateIfBranchWithUnsupportedOp("else"));
+
+  graph.SetInputs({&if_cond, &v_in});
+  graph.SetOutputs({&v_out});
+  ASSERT_TRUE(graph.Resolve().IsOK());
+
+  std::function<void(const Graph&)> verify = [](const Graph& g) {
+    for (const auto& node : g.Nodes()) {
+      if (node.OpType() == "If") {
+        EXPECT_EQ(node.GetExecutionProviderType(), kCpuExecutionProvider)
+            << "If with unsupported body op (IsInf) should fall back to CPU";
+      }
+    }
+  };
+  RunIfTest(std::move(model), verify, ExpectedEPNodeAssignment::None);
+}
 
 }  // namespace test
 }  // namespace onnxruntime


### PR DESCRIPTION
### Description

See individual commits. This fixes two separate issues in the MIGraphX execution provider:

1. Fix handling of Loop with non-constant, dynamic or huge iterations in MIGraphX execution provider
    
    Consider such cases as unsupported ops, as MIGraphX clamps them to
    65535 iterations, which a) does not work for non-constant iterations, b)
    doesn't give the desired result for higher iteration counts, and c) uses
    huge amounts of memory.

2. Fix handling of Loop/If/Scan subgraphs in MIGraphX execution provider
    
    The `GraphPartitioner` is recursing bottom-up into Loop/If/Scan
    subgraphs, and the EP then creates new `MGXKernel_subgraph_*` ops for
    them inside the body. Later during compilation, MIGraphX's parser
    recurses into the body, finds the new unknown ops and fails with
    
      Unknown operator: MGXKernel_subgraph_tf2onnx_...
    
    To avoid that, early return in these cases and consider them
    unsupported, falling back to the CPU instead for them.

### Motivation and Context

This fixes https://github.com/microsoft/onnxruntime/issues/31713 but the model there still does not load correctly because of what I think is a bug in MIGraphX itself (https://github.com/ROCm/AMDMIGraphX/issues/5126).