### PR TITLE
[CXX Lora] Reject string parameters in adapters

### DIFF
--- a/onnxruntime/lora/adapter_format_utils.cc
+++ b/onnxruntime/lora/adapter_format_utils.cc
@@ -159,6 +159,8 @@ std::pair<std::string, OrtValue> CreateOrtValueOverLoraParameter(const Parameter
   const auto data_type = param.data_type();
   ORT_ENFORCE(data_type != TensorDataType::UNDEFINED,
               "Lora Param '", name, "': data_type is UNDEFINED");
+  ORT_ENFORCE(data_type != TensorDataType::STRING,
+              "Lora Param '", name, "': STRING data_type is not supported");
 
   const auto* dims = param.dims();
   ORT_ENFORCE(dims != nullptr && dims->size() > 0,

--- a/onnxruntime/test/lora/lora_test.cc
+++ b/onnxruntime/test/lora/lora_test.cc
@@ -416,6 +416,21 @@ TEST(LoraAdapterTest, CreateOrtValueOverLoraParameter_UndefinedDataType) {
   ASSERT_THROW(adapters::utils::CreateOrtValueOverLoraParameter(*param), OnnxRuntimeException);
 }
 
+TEST(LoraAdapterTest, CreateOrtValueOverLoraParameter_StringDataType) {
+  flatbuffers::FlatBufferBuilder fbb;
+
+  std::vector<int64_t> dims = {1};
+  std::vector<uint8_t> raw_data(sizeof(std::string), 0);
+  auto param_offset = adapters::CreateParameterDirect(
+      fbb, "string_type_param", &dims, adapters::TensorDataType::STRING, &raw_data);
+
+  const auto* param = BuildAdapterAndGetParam(fbb, param_offset);
+  ASSERT_NE(param, nullptr);
+  ASSERT_EQ(param->raw_data()->size(), sizeof(std::string));
+
+  ASSERT_THROW(adapters::utils::CreateOrtValueOverLoraParameter(*param), OnnxRuntimeException);
+}
+
 #endif  // ORT_NO_EXCEPTIONS
 
 #ifdef USE_CUDA


### PR DESCRIPTION
### Description
Rejects `STRING`-typed LoRA adapter parameters during loading. Adds a regression test using an exactly sized string payload.



### Motivation and Context
`LoRA` adapter tensors use zero-copy loading, where an `OrtValue` directly references the adapter’s raw data buffer. This is appropriate for numeric tensor types, but not for `STRING`: ONNX Runtime represents string elements as constructed C++ `std::string` objects containing implementation-specific internal state.

A malformed adapter could previously declare raw bytes as a string tensor. If later consumed as `std::string` objects, those bytes could be interpreted as invalid pointers and lengths, resulting in unsafe memory access.

This change rejects string parameters before resolving the tensor element type or constructing the zero-copy tensor. Numeric LoRA parameters continue to use the existing zero-copy path unchanged.
