### PR TITLE
Fix stale ContribOperators.md for MRotaryEmbedding

### DIFF
--- a/docs/ContribOperators.md
+++ b/docs/ContribOperators.md
@@ -3038,7 +3038,7 @@ This version of the operator has been available since version 1 of the 'com.micr
   
   For text-only tokens, T == H == W (all three position streams collapse to the ordinary sequential position),
   so this op is a strict superset of RotaryEmbedding: setting `mrope_section` to a single full-width section
-  (or omitting it) reduces this op to standard RoPE.
+  reduces this op to standard RoPE.
   
   `mrope_layout` selects how the three sections are combined:
     - 0 (Sectioned / Chunked): the half_rotary_embedding_dim axis is split into 3 contiguous chunks according to


### PR DESCRIPTION
## Summary

`docs/ContribOperators.md` disagrees with the schema that generates it for the `MRotaryEmbedding` operator, causing the **Windows GPU Kernel Documentation Validation** CI check to fail on every PR merged to `main`.

## Root cause

PR #31728 (`e415ef9afd`) added the fused `MRotaryEmbedding` contrib op. The checked-in doc contains:

```
setting `mrope_section` to a single full-width section
(or omitting it) reduces this op to standard RoPE.
```

but the schema in `onnxruntime/core/graph/contrib_ops/bert_defs.cc` (and correspondingly the output of `gen_contrib_doc.py`) says:

```
setting `mrope_section` to a single full-width section
reduces this op to standard RoPE.
```

The parenthetical `(or omitting it)` is also semantically incorrect — `mrope_section` is declared as a **required** attribute (`AttributeProto::INTS` with no default), so it cannot be omitted.

## Fix

Remove the inaccurate parenthetical from the checked-in doc to match the schema/generator output.

```diff
-  (or omitting it) reduces this op to standard RoPE.
+  reduces this op to standard RoPE.
```

This is a hand-edit matching exactly what the generator (`tools/ci_build/gen_contrib_doc.py --domains com.microsoft`) produces. I did not run the generator because it requires built Python bindings.

## Impact

Unblocks the documentation validation CI check for all open PRs targeting `main`.