### PR TITLE
[WebGPU] Fix ARM64 builds shipping the x64 dxil.dll, which silently disables the WebGPU EP

### DIFF
--- a/cmake/external/onnxruntime_external_deps.cmake
+++ b/cmake/external/onnxruntime_external_deps.cmake
@@ -785,6 +785,18 @@ if (onnxruntime_USE_WEBGPU)
           #
           ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${PROJECT_SOURCE_DIR}/patches/dawn/dawn_dxc_output_dir.patch &&
 
+          # The dawn_dxil_arch.patch contains the following changes:
+          #
+          # - (private) Copy the Windows SDK DLLs matching the target architecture
+          #   AddCopyWindowsSDKDLLTarget() hardcodes the "x64" Windows SDK bin subdirectory, so an
+          #   ARM64 build gets an x64 dxil.dll (and an x64 d3dcompiler_47.dll) next to otherwise
+          #   correct ARM64 binaries. dxil.dll is loaded in-process by dxcompiler.dll, so on Windows
+          #   on ARM the load fails with "DynamicLib.Open: dxil.dll Windows Error: 87", Dawn cannot
+          #   create a D3D12 device, and the WebGPU EP silently falls back to CPU. This patch selects
+          #   the SDK subdirectory from the target architecture instead. x64 builds are unaffected.
+          #
+          ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${PROJECT_SOURCE_DIR}/patches/dawn/dawn_dxil_arch.patch &&
+
           # The dawn_parallel_build_fix.patch contains the following changes:
           #
           # - (private) Fix parallel build race condition in emdawnwebgpu header copy

--- a/cmake/patches/dawn/dawn_dxil_arch.patch
+++ b/cmake/patches/dawn/dawn_dxil_arch.patch
@@ -1,0 +1,62 @@
+diff --git a/third_party/CopyWindowsSDKDLL.cmake b/third_party/CopyWindowsSDKDLL.cmake
+--- a/third_party/CopyWindowsSDKDLL.cmake
++++ b/third_party/CopyWindowsSDKDLL.cmake
+@@ -69,6 +69,42 @@ function(DetectWindowsSDK out_sdk_path out_sdk_version)
+     set(${out_sdk_version} ${sdk_version} PARENT_SCOPE)
+ endfunction()
+ 
++# Function to detect the Windows SDK binary subdirectory to use
++# The DLLs copied by AddCopyWindowsSDKDLLTarget are loaded in-process at runtime, so they must
++# match the architecture Dawn is built for, not the architecture of the build host.
++# Returns "x86", "x64" or "arm64" via the output parameter.
++function(DetectWindowsSDKArch out_sdk_arch)
++    if (CMAKE_VS_PLATFORM_NAME)
++        # Visual Studio generators: Win32, x64, ARM64 or ARM64EC.
++        set(target_arch "${CMAKE_VS_PLATFORM_NAME}")
++    elseif (CMAKE_CXX_COMPILER_ARCHITECTURE_ID)
++        # MSVC with other generators (e.g. Ninja): X86, x64, ARM64 or ARM64EC.
++        set(target_arch "${CMAKE_CXX_COMPILER_ARCHITECTURE_ID}")
++    elseif (CMAKE_C_COMPILER_ARCHITECTURE_ID)
++        set(target_arch "${CMAKE_C_COMPILER_ARCHITECTURE_ID}")
++    else()
++        # Last resort for toolchains that do not set the compiler architecture id.
++        set(target_arch "${CMAKE_SYSTEM_PROCESSOR}")
++    endif()
++
++    string(TOLOWER "${target_arch}" target_arch_lower)
++    if (target_arch_lower MATCHES "^(win32|x86|i386|i686)$")
++        set(sdk_arch "x86")
++    elseif (target_arch_lower MATCHES "^(x64|amd64|x86_64)$")
++        set(sdk_arch "x64")
++    elseif (target_arch_lower MATCHES "^(arm64|arm64ec|aarch64)$")
++        # ARM64EC code runs inside an ARM64 process, so it uses the ARM64 SDK binaries.
++        set(sdk_arch "arm64")
++    else()
++        # Keep the previous behavior for anything unrecognized.
++        message(WARNING "Unrecognized target architecture '${target_arch}', assuming the x64 Windows SDK binaries")
++        set(sdk_arch "x64")
++    endif()
++
++    message(STATUS "Using the ${sdk_arch} Windows SDK binaries for target architecture '${target_arch}'")
++    set(${out_sdk_arch} ${sdk_arch} PARENT_SCOPE)
++endfunction()
++
+ # Function to add a target that copies a DLL from Windows SDK to main build directory
+ # Parameters:
+ #   - target_name: Name of the custom target to create
+@@ -79,8 +115,14 @@ function(AddCopyWindowsSDKDLLTarget target_name dll_name)
+     endif()
+ 
+     DetectWindowsSDK(WIN10_SDK_PATH WIN10_SDK_VERSION)
++    DetectWindowsSDKArch(WIN10_SDK_ARCH)
+ 
+-    set(DLL_PATH "${WIN10_SDK_PATH}/bin/${WIN10_SDK_VERSION}/x64/${dll_name}")
++    set(DLL_PATH "${WIN10_SDK_PATH}/bin/${WIN10_SDK_VERSION}/${WIN10_SDK_ARCH}/${dll_name}")
++
++    if (NOT EXISTS "${DLL_PATH}")
++        message(WARNING "${dll_name} was not found at '${DLL_PATH}'. Check that the "
++                        "${WIN10_SDK_ARCH} binaries of Windows SDK ${WIN10_SDK_VERSION} are installed.")
++    endif()
+ 
+     # Copy directly to main build directory
+     get_property(isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)


### PR DESCRIPTION
### Description

On Windows on ARM, a `--use_webgpu` build ships an **x64 `dxil.dll`** inside an otherwise-ARM64 package. `dxcompiler.dll` loads it in-process, so the load fails with `DynamicLib.Open: dxil.dll Windows Error: 87`, Dawn cannot create a D3D12 device, and the WebGPU EP silently falls back to CPU.

The cause is in Dawn's `third_party/CopyWindowsSDKDLL.cmake`, where `AddCopyWindowsSDKDLLTarget()` hardcodes the SDK's `x64` subdirectory regardless of target:

```cmake
set(DLL_PATH "${WIN10_SDK_PATH}/bin/${WIN10_SDK_VERSION}/x64/${dll_name}")
```

This adds `cmake/patches/dawn/dawn_dxil_arch.patch`, which selects that subdirectory from the target architecture instead. **x64 builds resolve to the same path as before and are unaffected.** The same function is also used for `d3dcompiler_47.dll`, which had the same problem, so both are fixed.

### Motivation and Context

The failure is easy to miss: `get_available_providers()` lists providers compiled into the binary, so it still reports `WebGpuExecutionProvider` after the fallback. Only `session.get_providers()` on a real `InferenceSession` reveals it — users can believe they are measuring the GPU while running entirely on CPU.

Windows on ARM is not covered by CI, which is why this has gone unnoticed. The hardcoded `x64` is still present in Dawn `main`; upstreaming via Gerrit is a follow-up, after which this patch can be dropped. ORT already carries six Dawn patches in `cmake/patches/dawn/`, so this follows the established pattern.

<details>
<summary><b>Validation</b> (6 build configurations, real ARM64 hardware)</summary>

Each case configures and builds the `copy_dxil_dll` target, then reads the PE machine type of the file actually copied.

| Case | Generator / target | Resolved | Copied `dxil.dll` |
| --- | --- | --- | --- |
| unpatched, ARM64 | VS 2022, `-A ARM64` | `x64` (hardcoded) | 1,509,760 — `0x8664` AMD64 (**the bug**) |
| patched, ARM64 | VS 2022, `-A ARM64` | `arm64` | 3,350,880 — `0xAA64` **ARM64** |
| patched, x64 | VS 2022, `-A x64` | `x64` | 1,509,760 — `0x8664` AMD64 (**unchanged**) |
| patched, Win32 | VS 2022, `-A Win32` | `x86` | 1,106,776 — `0x014C` I386 |
| patched, ARM64 | Ninja, `vcvarsarm64` | `arm64` | 3,350,880 — `0xAA64` **ARM64** |
| patched, ARM64 host → x64 target | Ninja, `vcvarsarm64_amd64` | `x64` | 1,509,760 — `0x8664` AMD64 |

The last row is the cross-compile case: `CMAKE_SYSTEM_PROCESSOR` was `ARM64` while the target was x64, so a host-based check would have picked the wrong DLL. Architecture is resolved from `CMAKE_VS_PLATFORM_NAME`, then `CMAKE_{CXX,C}_COMPILER_ARCHITECTURE_ID`, with `CMAKE_SYSTEM_PROCESSOR` only as a last resort.

Also verified: the patch applies cleanly against the pinned Dawn `v20260714.215939` with ORT's exact `patch --binary --ignore-whitespace -p1` invocation; a 14-case architecture normalization table; and the configure-time warning when the resolved DLL is missing.

**Not covered:** a full ARM64 `--use_webgpu` build and a runtime `InferenceSession` check were not run with this patch applied. The runtime evidence comes from manually substituting the ARM64 DLL into an existing build, which restores `['WebGpuExecutionProvider', 'CPUExecutionProvider']` and runs models on the GPU.

</details>

### Follow-ups (not in this PR)

- Upstream to Dawn via Gerrit, then drop this patch.
- `tools/ci_build/build.py`: `--no_kleidiai` is a no-op — the negative case emits nothing, so it cannot override a cached `onnxruntime_USE_KLEIDIAI=ON`.
- `cmake/onnxruntime_python.cmake`: applies `onnxruntime_DELAYLOAD_FLAGS` to the pybind MODULE without linking `delayimp.lib`, unlike every other DELAYLOAD site, causing unresolved `__delayLoadHelper2` on ARM64.