### PR TITLE
[CUDA] Update cuda archs in packaging pipelines

### DIFF
--- a/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines-cuda13.yml
+++ b/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines-cuda13.yml
@@ -76,8 +76,9 @@ variables:
   value: $(Agent.TempDirectory)\v13.0
 - name: win_cudnn_home
   value: $(Agent.TempDirectory)\9.14.0.64_cuda13
+# Windows x64 CUDA architectures. Keep in sync with plugin-cuda-pipeline.yml.
 - name: CudaArchs
-  value: '75-real;80-real;86-real;89-real;90-real;100-real;120-real;120-virtual'
+  value: '75-real;80-real;86-real;89-real;120-real'
 
 extends:
   # The pipeline extends the 1ES PT which will inject different SDL and compliance tasks.

--- a/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines.yml
+++ b/tools/ci_build/github/azure-pipelines/c-api-noopenmp-packaging-pipelines.yml
@@ -93,11 +93,12 @@ variables:
     value: ''
   ${{ if eq(parameters.CudaVersion, '13.0') }}:
     value: $(Agent.TempDirectory)\9.14.0.64_cuda13
+# Windows x64 CUDA architectures. Keep in sync with plugin-cuda-pipeline.yml.
 - name: CudaArchs
   ${{ if eq(parameters.CudaVersion, '12.8') }}:
-    value: '61-real;75-real;86-real;89-real;120-real;120-virtual'
+    value: '61-real;75-real;86-real;89-real;120-real'
   ${{ if eq(parameters.CudaVersion, '13.0') }}:
-    value: '75-real;80-real;86-real;89-real;90-real;100-real;120-real;120-virtual'
+    value: '75-real;80-real;86-real;89-real;120-real'
 
 extends:
   # The pipeline extends the 1ES PT which will inject different SDL and compliance tasks.

--- a/tools/ci_build/github/azure-pipelines/py-cuda-packaging-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/py-cuda-packaging-pipeline.yml
@@ -64,5 +64,6 @@ extends:
           cmake_build_type: ${{ parameters.cmake_build_type }}
           cuda_version: '12.8'
           cudnn_folder: ''
-          cmake_cuda_archs: '61-real;75-real;86-real;89-real;120-real;120-virtual'
+          cmake_windows_x64_cuda_archs: '61-real;75-real;86-real;89-real;120-real'
+          cmake_linux_x64_cuda_archs: '60-real;70-real;75-real;80-real;86-real;89-real;90-real;120-real'
           docker_base_image: 'onnxruntimebuildcache.azurecr.io/internal/azureml/onnxruntime/build/cuda12_x64_almalinux8_gcc14:20251017.1'

--- a/tools/ci_build/github/azure-pipelines/py-cuda13-packaging-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/py-cuda13-packaging-pipeline.yml
@@ -64,7 +64,9 @@ extends:
           cmake_build_type: ${{ parameters.cmake_build_type }}
           cuda_version: '13.0'
           cudnn_folder: '9.14.0.64_cuda13'
-          cmake_cuda_archs: '75-real;80-real;86-real;89-real;90-real;100-real;120-real;120-virtual'
+          cmake_windows_x64_cuda_archs: '75-real;80-real;86-real;89-real;120-real'
+          cmake_linux_x64_cuda_archs: '75-real;80-real;86-real;89-real;90-real;120-real'
+          cmake_linux_aarch64_cuda_archs: '89-real;90-real;120-real;121-real'
           docker_base_image: 'onnxruntimebuildcache.azurecr.io/internal/azureml/onnxruntime/build/cuda13_x64_almalinux8_gcc14:20251107.1'
           docker_base_image_aarch64: 'onnxruntimebuildcache.azurecr.io/public/azureml/onnxruntime_build_cuda13_aarch64_almalinux9_gcc14:20260323.1'
           AArch64LinuxPythonConfigurations:

--- a/tools/ci_build/github/azure-pipelines/stages/py-gpu-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/py-gpu-packaging-stage.yml
@@ -54,9 +54,18 @@ parameters:
   - python_version: '3.14t'
     docker_python_exe_path: '/opt/python/cp314-cp314t/bin/python3.14'
 
-- name: cmake_cuda_archs
+- name: cmake_windows_x64_cuda_archs
   type: string
-  displayName: 'CMAKE_CUDA_ARCHITECTURES for Windows'
+  displayName: 'CMAKE_CUDA_ARCHITECTURES for Windows x64'
+
+- name: cmake_linux_x64_cuda_archs
+  type: string
+  displayName: 'CMAKE_CUDA_ARCHITECTURES for Linux x86_64'
+
+- name: cmake_linux_aarch64_cuda_archs
+  type: string
+  displayName: 'CMAKE_CUDA_ARCHITECTURES for Linux aarch64'
+  default: ''
 
 - name: docker_base_image
   type: string
@@ -81,7 +90,7 @@ stages:
             PYTHON_VERSION: ${{ python_version }}
             EP_NAME: gpu
             CudaVersion: ${{ parameters.cuda_version }}
-            EP_BUILD_FLAGS: --enable_lto --use_cuda --cuda_home=$(Agent.TempDirectory)\v${{ parameters.cuda_version }} --cudnn_home=$(Agent.TempDirectory)\${{ parameters.cudnn_folder }} --cmake_extra_defines "CMAKE_CUDA_ARCHITECTURES=${{ parameters.cmake_cuda_archs }}"
+            EP_BUILD_FLAGS: --enable_lto --use_cuda --cuda_home=$(Agent.TempDirectory)\v${{ parameters.cuda_version }} --cudnn_home=$(Agent.TempDirectory)\${{ parameters.cudnn_folder }} --cmake_extra_defines "CMAKE_CUDA_ARCHITECTURES=${{ parameters.cmake_windows_x64_cuda_archs }}"
             use_tensorrt: True
 
     - ${{ if eq(parameters.cuda_version, '12.8') }}:
@@ -91,7 +100,7 @@ stages:
             PYTHON_VERSION: ${{ python_version }}
             EP_NAME: gpu
             CudaVersion: ${{ parameters.cuda_version }}
-            EP_BUILD_FLAGS: --enable_lto --use_cuda --cuda_home=$(Agent.TempDirectory)\v${{ parameters.cuda_version }} --cmake_extra_defines "CMAKE_CUDA_ARCHITECTURES=${{ parameters.cmake_cuda_archs }}"
+            EP_BUILD_FLAGS: --enable_lto --use_cuda --cuda_home=$(Agent.TempDirectory)\v${{ parameters.cuda_version }} --cmake_extra_defines "CMAKE_CUDA_ARCHITECTURES=${{ parameters.cmake_windows_x64_cuda_archs }}"
             use_tensorrt: True
 
     # Linux: one parallel stage per Python version
@@ -104,6 +113,7 @@ stages:
           extra_build_arg: ${{ parameters.build_py_parameters }}
           cmake_build_type: ${{ parameters.cmake_build_type }}
           cuda_version: ${{ parameters.cuda_version }}
+          cmake_cuda_archs: ${{ parameters.cmake_linux_x64_cuda_archs }}
           docker_base_image: ${{ parameters.docker_base_image }}
           python_version: ${{ config.python_version }}
           docker_python_exe_path: ${{ config.docker_python_exe_path }}
@@ -122,6 +132,7 @@ stages:
           extra_build_arg: ${{ parameters.build_py_parameters }}
           cmake_build_type: ${{ parameters.cmake_build_type }}
           cuda_version: ${{ parameters.cuda_version }}
+          cmake_cuda_archs: ${{ parameters.cmake_linux_aarch64_cuda_archs }}
           docker_base_image: ${{ parameters.docker_base_image_aarch64 }}
           python_version: ${{ config.python_version }}
           docker_python_exe_path: ${{ config.docker_python_exe_path }}

--- a/tools/ci_build/github/azure-pipelines/stages/py-linux-gpu-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/py-linux-gpu-stage.yml
@@ -28,6 +28,11 @@ parameters:
    - 12.8
    - 13.0
 
+- name: cmake_cuda_archs
+  type: string
+  default: ''
+  displayName: 'CMAKE_CUDA_ARCHITECTURES. Empty means the build script default.'
+
 - name: python_version
   type: string
   displayName: 'Python version label (e.g. 3.12, 3.13t)'
@@ -122,6 +127,7 @@ stages:
             -d "GPU"
             -c ${{ parameters.cmake_build_type }}
             -p "${{ parameters.docker_python_exe_path }}"
+            -a "${{ parameters.cmake_cuda_archs }}"
             $(extra_build_args)
         env:
           CUDA_VERSION: ${{ parameters.cuda_version }}

--- a/tools/ci_build/github/linux/build_cuda_c_api_package.sh
+++ b/tools/ci_build/github/linux/build_cuda_c_api_package.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 set -e -x
 
+# Keep in sync with plugin-cuda-pipeline.yml (cmake_linux_x64_cuda_archs).
 if [ "$CUDA_VERSION" == "12.8" ]; then
-    CUDA_ARCHS="60-real;70-real;75-real;80-real;86-real;90-real;120-real;120-virtual"
+    CUDA_ARCHS="60-real;70-real;75-real;80-real;86-real;89-real;90-real;120-real"
 elif [ "$CUDA_VERSION" == "13.0" ]; then
-    CUDA_ARCHS="75-real;80-real;86-real;89-real;90-real;100-real;120-real;120-virtual"
+    CUDA_ARCHS="75-real;80-real;86-real;89-real;90-real;120-real"
 else
     echo "Error: Unrecognized CUDA_VERSION: $CUDA_VERSION"
     exit 1

--- a/tools/ci_build/github/linux/build_linux_python_package.sh
+++ b/tools/ci_build/github/linux/build_linux_python_package.sh
@@ -17,7 +17,7 @@ PYTHON_EXES=(
   "/opt/python/cp312-cp312/bin/python3.12"
   )
 
-while getopts "d:p:x:c:" parameter_Option
+while getopts "d:p:x:c:a:" parameter_Option
 do case "${parameter_Option}"
 in
 #GPU|WEBGPU|CPU|NPU.
@@ -33,7 +33,8 @@ p)
   ;;
 x) EXTRA_ARG=${OPTARG};;
 c) BUILD_CONFIG=${OPTARG};;
-*) echo "Usage: $0 -d <GPU|WEBGPU|CPU|NPU> [-p <python_exe_path>] [-x <extra_build_arg>] [-c <build_config>]"
+a) CUDA_ARCHS=${OPTARG};;
+*) echo "Usage: $0 -d <GPU|WEBGPU|CPU|NPU> [-p <python_exe_path>] [-x <extra_build_arg>] [-c <build_config>] [-a <cuda_archs>]"
    exit 1;;
 esac
 done
@@ -73,13 +74,19 @@ if [ "$ARCH" == "x86_64" ]; then
 fi
 
 if [ "$BUILD_DEVICE" == "GPU" ]; then
-    if [ "$CUDA_VERSION" == "12.8" ]; then
-        CUDA_ARCHS="60-real;70-real;75-real;80-real;86-real;90-real;120-real;120-virtual"
-    elif [ "$CUDA_VERSION" == "13.0" ]; then
-        CUDA_ARCHS="75-real;80-real;86-real;89-real;90-real;100-real;120-real;120-virtual"
-    else
-        echo "Error: Unrecognized CUDA_VERSION: $CUDA_VERSION"
-        exit 1
+    # The caller (-a) normally supplies these. Keep in sync with plugin-cuda-pipeline.yml
+    # (cmake_linux_x64_cuda_archs / cmake_linux_aarch64_cuda_archs).
+    if [ -z "${CUDA_ARCHS:-}" ]; then
+        if [ "$CUDA_VERSION" == "13.0" ] && [ "$ARCH" == "aarch64" ]; then
+            CUDA_ARCHS="89-real;90-real;120-real;121-real"
+        elif [ "$CUDA_VERSION" == "12.8" ]; then
+            CUDA_ARCHS="60-real;70-real;75-real;80-real;86-real;89-real;90-real;120-real"
+        elif [ "$CUDA_VERSION" == "13.0" ]; then
+            CUDA_ARCHS="75-real;80-real;86-real;89-real;90-real;120-real"
+        else
+            echo "Error: Unrecognized CUDA_VERSION: $CUDA_VERSION"
+            exit 1
+        fi
     fi
 
     SHORT_CUDA_VERSION=$(echo "$CUDA_VERSION" | sed   's/\([[:digit:]]\+\.[[:digit:]]\+\)\.[[:digit:]]\+/\1/')

--- a/tools/ci_build/github/linux/build_nodejs_package.sh
+++ b/tools/ci_build/github/linux/build_nodejs_package.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 set -e -x
 
+# Keep in sync with plugin-cuda-pipeline.yml (cmake_linux_x64_cuda_archs).
 if [ "$CUDA_VERSION" == "12.8" ]; then
-    CUDA_ARCHS="60-real;70-real;75-real;80-real;86-real;90-real;120-real;120-virtual"
+    CUDA_ARCHS="60-real;70-real;75-real;80-real;86-real;89-real;90-real;120-real"
 elif [ "$CUDA_VERSION" == "13.0" ]; then
-    CUDA_ARCHS="75-real;80-real;86-real;89-real;90-real;100-real;120-real;120-virtual"
+    CUDA_ARCHS="75-real;80-real;86-real;89-real;90-real;120-real"
 else
     echo "Error: Unrecognized CUDA_VERSION: $CUDA_VERSION"
     exit 1

--- a/tools/ci_build/github/linux/build_tensorrt_c_api_package.sh
+++ b/tools/ci_build/github/linux/build_tensorrt_c_api_package.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 set -e -x
 
+# Keep in sync with plugin-cuda-pipeline.yml (cmake_linux_x64_cuda_archs).
 if [ "$CUDA_VERSION" == "12.8" ]; then
-    CUDA_ARCHS="60-real;70-real;75-real;80-real;86-real;90-real;120-real;120-virtual"
+    CUDA_ARCHS="60-real;70-real;75-real;80-real;86-real;89-real;90-real;120-real"
 elif [ "$CUDA_VERSION" == "13.0" ]; then
-    CUDA_ARCHS="75-real;80-real;86-real;89-real;90-real;100-real;120-real;120-virtual"
+    CUDA_ARCHS="75-real;80-real;86-real;89-real;90-real;120-real"
 else
     echo "Error: Unrecognized CUDA_VERSION: $CUDA_VERSION"
     exit 1

--- a/tools/ci_build/github/linux/run_python_dockerbuild.sh
+++ b/tools/ci_build/github/linux/run_python_dockerbuild.sh
@@ -2,7 +2,7 @@
 set -e -x
 BUILD_CONFIG="Release"
 
-while getopts "i:d:x:c:p:" parameter_Option
+while getopts "i:d:x:c:p:a:" parameter_Option
 do case "${parameter_Option}"
 in
 i) DOCKER_IMAGE=${OPTARG};;
@@ -10,7 +10,8 @@ d) DEVICE=${OPTARG};;
 x) BUILD_EXTR_PAR=${OPTARG};;
 c) BUILD_CONFIG=${OPTARG};;
 p) PYTHON_EXES=${OPTARG};;
-*) echo "Usage: $0 -i <docker_image> -d <GPU|CPU> [-x <extra_build_arg>] [-c <build_config>] [-p <python_exe_path>]"
+a) CUDA_ARCHS=${OPTARG};;
+*) echo "Usage: $0 -i <docker_image> -d <GPU|CPU> [-x <extra_build_arg>] [-c <build_config>] [-p <python_exe_path>] [-a <cuda_archs>]"
    exit 1;;
 esac
 done
@@ -21,6 +22,10 @@ DOCKER_SCRIPT_OPTIONS=("-d" "${DEVICE}" "-c" "${BUILD_CONFIG}")
 
 if [ "${PYTHON_EXES}" != "" ] ; then
     DOCKER_SCRIPT_OPTIONS+=("-p" "${PYTHON_EXES}")
+fi
+
+if [ "${CUDA_ARCHS:-}" != "" ] ; then
+    DOCKER_SCRIPT_OPTIONS+=("-a" "${CUDA_ARCHS}")
 fi
 
 if [ "${BUILD_EXTR_PAR}" != "" ] ; then


### PR DESCRIPTION
This change aligns CUDA architecture selections across the CUDA plugin EP and the related Python, C API, TensorRT, and Node.js packaging pipelines. Linux Python packaging now passes architecture lists separately for x64 and aarch64, while the other Linux packaging scripts use the same per-CUDA-version x64 lists.

## CUDA Architecture Matrix

| OS | CUDA | CUDA architectures |
| --- | --- | --- |
| Windows x64 | 12.8 | 61;75;86;89;120a |
| Windows x64 | 13.0 | 75;80;86;89;120a |
| Linux x64 | 12.8 | 60;70;75;80;86;89;90a;120a |
| Linux x64 | 13.0 | 75;80;86;89;90a;120a |
| Linux aarch64 | 13.0 | 89;90a;120a;121a |

The `a` suffix denotes the architecture-specific CMake form such as `90-real` or `120-real`; all entries in the pipelines are emitted with the `-real` suffix. CUDA 12.8 has no Linux aarch64 packaging configuration in these pipelines.

## Key Changes

- Updated `plugin-cuda-pipeline.yml` as the reference architecture matrix.
- Split Python packaging parameters into Windows x64, Linux x64, and Linux aarch64 CUDA architecture settings.
- Forwarded the Linux architecture setting through `py-linux-gpu-stage.yml`, `run_python_dockerbuild.sh`, and `build_linux_python_package.sh`.
- Aligned C API, TensorRT C API, and Node.js Linux packaging scripts with the plugin Linux x64 settings.
- Removed `120-virtual` from the affected packaging configurations so they match the plugin EP configuration.

## Validation

- `bash -n` passes for all modified Linux packaging scripts.
- Modified pipeline YAML files parse successfully with PyYAML.
- `git diff --check` passes.