### PR TITLE
Fix SimplifiedLayerNorm fusion scale validation

### DIFF
--- a/onnxruntime/core/optimizer/layer_norm_fusion.cc
+++ b/onnxruntime/core/optimizer/layer_norm_fusion.cc
@@ -61,6 +61,36 @@ static bool CheckAxesOnReduceMean(std::vector<int64_t>& axes_values, int64_t ran
   return true;
 }
 
+static bool IsShapeProvablyBroadcastableTo(const TensorShapeProto& source_shape,
+                                           const TensorShapeProto& target_shape) {
+  if (source_shape.dim_size() > target_shape.dim_size()) {
+    return false;
+  }
+
+  const int target_offset = target_shape.dim_size() - source_shape.dim_size();
+  for (int i = 0; i < source_shape.dim_size(); ++i) {
+    const auto& source_dim = source_shape.dim(i);
+    const auto& target_dim = target_shape.dim(target_offset + i);
+    if (source_dim.has_dim_value()) {
+      if (source_dim.dim_value() == 1 ||
+          (target_dim.has_dim_value() && source_dim.dim_value() == target_dim.dim_value())) {
+        continue;
+      }
+
+      return false;
+    }
+
+    if (source_dim.has_dim_param() && target_dim.has_dim_param() &&
+        !source_dim.dim_param().empty() && source_dim.dim_param() == target_dim.dim_param()) {
+      continue;
+    }
+
+    return false;
+  }
+
+  return true;
+}
+
 static std::vector<int64_t> GetAxesFromReduceMeanNode(Node& reduce_mean_node, const Graph& graph) {
   const onnxruntime::NodeAttributes& attributes = reduce_mean_node.GetAttributes();
   std::vector<int64_t> axes_values;
@@ -814,6 +844,10 @@ Status SimplifiedLayerNormFusion::ApplyImpl(Graph& graph, bool& modified, int gr
 
     NodeArg* x_input = has_leading_cast ? graph.GetNode(p_pow_input_node->Index())->MutableInputDefs()[0]
                                         : pow_node.MutableInputDefs()[0];
+
+    if (x_input->Shape() == nullptr || !IsShapeProvablyBroadcastableTo(*scale->Shape(), *x_input->Shape())) {
+      continue;
+    }
 
     // CPU doesn't support fp16
     if (reduce_mean_node.GetExecutionProviderType() == kCpuExecutionProvider &&

--- a/onnxruntime/test/optimizer/graph_transform_test_layernorm.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test_layernorm.cc
@@ -497,6 +497,80 @@ TEST_F(GraphTransformationTests, SimplifiedLayerNormFusionTest) {
   }
 }
 
+TEST_F(GraphTransformationTests, SimplifiedLayerNormFusionRejectsIncompatibleScaleShape) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    auto* input = builder.MakeInput<float>({{1, 1}});
+    auto* pow_exponent = builder.MakeInitializer<float>({}, {2.0f});
+    auto* epsilon = builder.MakeInitializer<float>({}, {1e-5f});
+    auto* scale = builder.MakeInitializer<float>({2}, {1.0f, 1.0f});
+
+    auto* pow_out = builder.MakeIntermediate();
+    auto* reduce_mean_out = builder.MakeIntermediate();
+    auto* add_out = builder.MakeIntermediate();
+    auto* sqrt_out = builder.MakeIntermediate();
+    auto* div_out = builder.MakeIntermediate();
+    auto* output = builder.MakeOutput();
+
+    builder.AddNode("Pow", {input, pow_exponent}, {pow_out});
+    builder.AddNode("ReduceMean", {pow_out}, {reduce_mean_out})
+        .AddAttribute("axes", std::vector<int64_t>{-1});
+    builder.AddNode("Add", {reduce_mean_out, epsilon}, {add_out});
+    builder.AddNode("Sqrt", {add_out}, {sqrt_out});
+    builder.AddNode("Div", {input, sqrt_out}, {div_out});
+    builder.AddNode("Mul", {div_out, scale}, {output});
+  };
+
+  auto post_graph_checker = [](Graph& graph) {
+    const auto op_to_count = CountOpsInGraph(graph);
+    TEST_RETURN_IF_NOT(op_to_count.find("SimplifiedLayerNormalization") == op_to_count.end());
+    const auto mul_it = op_to_count.find("Mul");
+    TEST_RETURN_IF_NOT(mul_it != op_to_count.end() && mul_it->second == 1);
+    return Status::OK();
+  };
+
+  ASSERT_STATUS_OK(TestGraphTransformer(
+      build_test_case, 17, *logger_,
+      std::make_unique<SimplifiedLayerNormFusion>(),
+      TransformerLevel::Level2, 1, nullptr, post_graph_checker));
+}
+
+TEST_F(GraphTransformationTests, SimplifiedLayerNormFusionRejectsUnprovenScaleBroadcast) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    auto* input = builder.MakeInput<float>(std::optional<std::vector<int64_t>>{{1, -1}});
+    auto* pow_exponent = builder.MakeInitializer<float>({}, {2.0f});
+    auto* epsilon = builder.MakeInitializer<float>({}, {1e-5f});
+    auto* scale = builder.MakeInitializer<float>({2}, {1.0f, 1.0f});
+
+    auto* pow_out = builder.MakeIntermediate();
+    auto* reduce_mean_out = builder.MakeIntermediate();
+    auto* add_out = builder.MakeIntermediate();
+    auto* sqrt_out = builder.MakeIntermediate();
+    auto* div_out = builder.MakeIntermediate();
+    auto* output = builder.MakeOutput<float>(std::optional<std::vector<int64_t>>{{1, 2}});
+
+    builder.AddNode("Pow", {input, pow_exponent}, {pow_out});
+    builder.AddNode("ReduceMean", {pow_out}, {reduce_mean_out})
+        .AddAttribute("axes", std::vector<int64_t>{-1});
+    builder.AddNode("Add", {reduce_mean_out, epsilon}, {add_out});
+    builder.AddNode("Sqrt", {add_out}, {sqrt_out});
+    builder.AddNode("Div", {input, sqrt_out}, {div_out});
+    builder.AddNode("Mul", {div_out, scale}, {output});
+  };
+
+  auto post_graph_checker = [](Graph& graph) {
+    const auto op_to_count = CountOpsInGraph(graph);
+    TEST_RETURN_IF_NOT(op_to_count.find("SimplifiedLayerNormalization") == op_to_count.end());
+    const auto mul_it = op_to_count.find("Mul");
+    TEST_RETURN_IF_NOT(mul_it != op_to_count.end() && mul_it->second == 1);
+    return Status::OK();
+  };
+
+  ASSERT_STATUS_OK(TestGraphTransformer(
+      build_test_case, 17, *logger_,
+      std::make_unique<SimplifiedLayerNormFusion>(),
+      TransformerLevel::Level2, 1, nullptr, post_graph_checker));
+}
+
 TEST_F(GraphTransformationTests, SimplifiedLayerNormFusionSharedCastPowExponent) {
   for (const bool has_leading_cast : {false, true}) {
     auto build_test_case = [has_leading_cast](ModelTestBuilder& builder) {
@@ -2525,12 +2599,15 @@ TEST_F(GraphTransformationTests, SimplifiedLayerNormFusion_ZeroElementEpsilon) {
   auto* graph_proto = model_proto.mutable_graph();
   graph_proto->set_name("SimplifiedLayerNormFusion_ZeroElem");
 
-  // Input with dynamic shape
+  // Input with a scale-compatible shape
   {
     auto* input = graph_proto->add_input();
     input->set_name("X");
     auto* type = input->mutable_type()->mutable_tensor_type();
     type->set_elem_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+    auto* shape = type->mutable_shape();
+    shape->add_dim()->set_dim_value(1);
+    shape->add_dim()->set_dim_value(0);
   }
 
   // Zero-element epsilon
@@ -2555,8 +2632,8 @@ TEST_F(GraphTransformationTests, SimplifiedLayerNormFusion_ZeroElementEpsilon) {
     auto* init = graph_proto->add_initializer();
     init->set_name("scale");
     init->set_data_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
-    init->add_dims(4);
-    for (int i = 0; i < 4; i++) init->add_float_data(1.0f);
+    init->add_dims(1);
+    init->add_float_data(1.0f);
   }
 
   // Output


### PR DESCRIPTION
### Description

- Require the `SimplifiedLayerNormFusion` scale shape to be provably unidirectionally broadcastable to the input shape.
- Skip the fusion when the input shape is unavailable or an aligned scale dimension cannot be proven safe.
- Add static and dynamic-shape regression coverage, while keeping the zero-element epsilon test on a valid broadcast-compatible graph.

### Motivation and Context

Fixes #31980.

The unfused trailing `Mul` may legally expand its output shape. For example, an input shaped `[1, 1]` multiplied by a scale shaped `[2]` produces `[1, 2]`. `SimplifiedLayerNormalization` instead preserves the input shape and rejects that scale, so applying the fusion changes valid model behavior into a runtime error.

### Testing

- Confirmed both new regression tests fail before the implementation change.
- `lintrunner onnxruntime/core/optimizer/layer_norm_fusion.cc onnxruntime/test/optimizer/graph_transform_test_layernorm.cc`
- `onnxruntime_test_all --gtest_filter='GraphTransformationTests.*LayerNormFusion*'` (49 passed)
- `onnxruntime_test_all` (1933 passed, 17 skipped)

The local GCC 12 build used `--compile_no_warning_as_error`; without it, existing code outside these files triggers a `-Wrestrict` warning treated as an error.

### AI assistance disclosure

Codex assisted with implementation, tests, and verification.