### PR TITLE
Handle zero-sized outputs in CUDA random generator kernels

### DIFF
--- a/onnxruntime/core/providers/cuda/generator/random_impl.cu
+++ b/onnxruntime/core/providers/cuda/generator/random_impl.cu
@@ -101,6 +101,12 @@ template <typename T, typename DistFuncT, typename TransformFuncT>
 void RandomKernelImpl(const cudaDeviceProp& prop, cudaStream_t stream, const int64_t N, const DistFuncT& dist_func,
                       const TransformFuncT& transform_func, float alpha, float beta, PhiloxGenerator& generator,
                       T* Y_data) {
+  // Zero-sized output tensors are legal in ONNX. Bail out before computing grid_size, which would otherwise be
+  // zero and make the counter_offset division below divide by zero.
+  if (N == 0) {
+    return;
+  }
+
   const int block_size = 256;
   const int blocks_per_sm = prop.maxThreadsPerMultiProcessor / block_size;
   const int grid_size =

--- a/onnxruntime/test/providers/cpu/generator/random_test.cc
+++ b/onnxruntime/test/providers/cpu/generator/random_test.cc
@@ -567,6 +567,22 @@ TEST(Random, RandomUniformGpu) {
   RunRandomUniformGpuTest(dims2, -5.f, 5.f, 312.f, TensorProto_DataType::TensorProto_DataType_FLOAT16, true, false);
   RunRandomUniformGpuTest(dims2, 0.f, 8.f, 456.f, TensorProto_DataType::TensorProto_DataType_BFLOAT16, false, false, 22);
 }
+
+// A zero-sized output is legal in ONNX. The CUDA kernel must not divide by the resulting zero grid size.
+TEST(Random, RandomEmptyOutputGpu) {
+  auto run_test = [](const char* op) {
+    OpTester test(op, 7);
+    test.AddAttribute("seed", 123.f);
+    test.AddAttribute<int64_t>("dtype", TensorProto_DataType::TensorProto_DataType_FLOAT);
+    std::vector<int64_t> dims{0, 4};
+    test.AddAttribute("shape", dims);
+    test.AddOutput<float>("Y", dims, {});
+    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kCpuExecutionProvider, kTensorrtExecutionProvider});
+  };
+
+  run_test("RandomNormal");
+  run_test("RandomUniform");
+}
 #endif
 
 }  // namespace test


### PR DESCRIPTION
RandomKernelImpl computed grid_size from CeilDiv(N, block_size * UNROLL), which is zero when the output tensor has no elements. The counter_offset expression then divided by block_size * grid_size * UNROLL, a host-side division by zero that traps before the kernel is launched. Zero-sized tensors are legal in ONNX, so return early when there is nothing to fill.

