### PR TITLE
Use authenticated package feeds in packaging pipelines

### DIFF
--- a/tools/ci_build/github/azure-pipelines/npm-packaging-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/npm-packaging-pipeline.yml
@@ -96,6 +96,7 @@ extends:
         pool: 'onnxruntime-Win-CPU-VS2022-Latest'
         variables:
           runCodesignValidationInjection: false
+          skipComponentGovernanceDetection: true
         timeoutInMinutes: 10
         steps:
     #    This pipeline is triggered by the Nuget - Packaging - CUDA13 pipeline.

--- a/tools/ci_build/github/azure-pipelines/nuget/templates/dml-vs-2022.yml
+++ b/tools/ci_build/github/azure-pipelines/nuget/templates/dml-vs-2022.yml
@@ -84,12 +84,6 @@ stages:
          @echo ##vso[task.setvariable variable=Configuration]$(BuildConfig)
         displayName: 'Set Configuration variable'
 
-
-      - task: NuGetToolInstaller@0
-        displayName: Use Nuget 6.10.x
-        inputs:
-          versionSpec: 6.10.x
-
       # Nuget packaging if needed
       - ${{ if eq(parameters['DoNugetPack'], 'true') }}:
         # Esrp signing. Requires older .net SDK currently (ESRP v5.1.1)

--- a/tools/ci_build/github/azure-pipelines/stages/nuget-win-cuda-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/nuget-win-cuda-packaging-stage.yml
@@ -122,6 +122,7 @@ stages:
     variables:
       CUDA_MODULE_LOADINGL: 'LAZY'
       GRADLE_OPTS: '-Dorg.gradle.daemon=false'
+      skipComponentGovernanceDetection: true
       ${{ if eq(parameters.CudaVersion, '13.0') }}:
         CUDA_VERSION_MAJOR: '13'
       ${{ if eq(parameters.CudaVersion, '12.8') }}:

--- a/tools/ci_build/github/azure-pipelines/stages/nuget-win-cuda-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/nuget-win-cuda-packaging-stage.yml
@@ -120,7 +120,7 @@ stages:
     pool:
       name: 'onnxruntime-Win2022-GPU-A10'
     variables:
-      CUDA_MODULE_LOADINGL: 'LAZY'
+      CUDA_MODULE_LOADING: 'LAZY'
       GRADLE_OPTS: '-Dorg.gradle.daemon=false'
       skipComponentGovernanceDetection: true
       ${{ if eq(parameters.CudaVersion, '13.0') }}:

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
@@ -387,8 +387,8 @@ stages:
     - task: MSBuild@1
       displayName: 'Restore NuGet Packages and create project.assets.json'
       inputs:
-        solution: '$(Build.SourcesDirectory)\csharp\OnnxRuntime.CSharp.sln'
-        platform: 'Any CPU'
+        solution: '$(Build.SourcesDirectory)\csharp\src\Microsoft.ML.OnnxRuntime\Microsoft.ML.OnnxRuntime.csproj'
+        platform: 'AnyCPU'
         configuration: RelWithDebInfo
         msbuildArguments: '-t:restore -p:OrtPackageId=$(OrtPackageId)'
         workingDirectory: '$(Build.SourcesDirectory)\csharp'
@@ -396,8 +396,8 @@ stages:
     - task: MSBuild@1
       displayName: 'Build C# bindings'
       inputs:
-        solution: '$(Build.SourcesDirectory)\csharp\OnnxRuntime.CSharp.sln'
-        platform: 'Any CPU'
+        solution: '$(Build.SourcesDirectory)\csharp\src\Microsoft.ML.OnnxRuntime\Microsoft.ML.OnnxRuntime.csproj'
+        platform: 'AnyCPU'
         configuration: RelWithDebInfo
         msbuildArguments: '-p:OnnxRuntimeBuildDirectory="$(Build.BinariesDirectory)" -p:OrtPackageId=$(OrtPackageId) -p:IsReleaseBuild=${{ parameters.IsReleaseBuild }} -p:ReleaseVersionSuffix=$(ReleaseVersionSuffix) -p:PackageVersion=$(OnnxRuntimeVersion)'
         workingDirectory: '$(Build.SourcesDirectory)\csharp'

--- a/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/c-api-cpu.yml
@@ -351,6 +351,8 @@ stages:
     - checkout: self
       submodules: true
 
+    - template: setup-feeds-and-python-steps.yml
+
     - script: |
         dir
       workingDirectory: '$(Build.BinariesDirectory)/nuget-artifact'
@@ -405,8 +407,6 @@ stages:
         FolderPath: '$(Build.SourcesDirectory)\csharp\src\Microsoft.ML.OnnxRuntime\bin\RelWithDebInfo'
         DisplayName: 'ESRP - Sign C# dlls'
         DoEsrp: true
-
-    - template: setup-feeds-and-python-steps.yml
 
     - task: MSBuild@1
       displayName: 'Build Nuget Packages'

--- a/tools/ci_build/github/azure-pipelines/templates/publish-symbolrequestprod-api.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/publish-symbolrequestprod-api.yml
@@ -26,11 +26,6 @@ parameters:
     type: string
 
 steps:
-  - powershell: |-
-      Get-PackageProvider -Name NuGet -ForceBootstrap
-      Install-Module -Verbose -AllowClobber -Force Az.Accounts, Az.Storage, Az.Network, Az.Resources, Az.Compute
-    displayName: Install Azure Module Dependencies
-
   - task: PublishSymbols@2
     displayName: Publish Symbols (to current Azure DevOps tenant)
     continueOnError: True

--- a/tools/ci_build/github/azure-pipelines/templates/setup-feeds-and-python-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/setup-feeds-and-python-steps.yml
@@ -47,7 +47,7 @@ steps:
       Set-Content -Force -Path $npmrcPath -Value @"
       registry=https://aiinfra.pkgs.visualstudio.com/_packaging/${env:artifact_feed}/npm/registry/
       always-auth=true
-      replace-registry-host=always
+      replace-registry-host=npmjs
       "@
 
       Write-Host "Generated npmrc contents:"

--- a/tools/ci_build/github/azure-pipelines/templates/setup-feeds-and-python-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/setup-feeds-and-python-steps.yml
@@ -47,6 +47,7 @@ steps:
       Set-Content -Force -Path $npmrcPath -Value @"
       registry=https://aiinfra.pkgs.visualstudio.com/_packaging/${env:artifact_feed}/npm/registry/
       always-auth=true
+      replace-registry-host=always
       "@
 
       Write-Host "Generated npmrc contents:"
@@ -219,9 +220,9 @@ steps:
     targetType: 'inline'
     script: |
       # NuGet appears to fail if any of the pkg sources are unreachable.
-      # Replace the NuGet.config w/ one that only has the internal feed.
+      # Replace NuGet configs w/ one that only has the internal feed.
       # HACK: We'd rather splice the structure, not override the file.
-      Set-Content -Path "NuGet.config" -Value @"
+      $nugetConfig = @"
       <?xml version="1.0" encoding="utf-8"?>
       <configuration>
         <solution>
@@ -236,3 +237,11 @@ steps:
         </disabledPackageSources>
       </configuration>
       "@
+
+      Set-Content -Path "NuGet.config" -Value $nugetConfig
+
+      # C# builds explicitly pass this config file to dotnet/msbuild restore.
+      $csharpNugetConfigPath = "csharp/NuGet.CSharp.config"
+      if (Test-Path $csharpNugetConfigPath) {
+        Set-Content -Path $csharpNugetConfigPath -Value $nugetConfig
+      }


### PR DESCRIPTION
## Description

- Route npm lockfile downloads and C# package restores through authenticated package feeds.
- Configure package feeds before restore and build steps.
- Skip redundant dependency scans in artifact-only packaging jobs.
- Remove unnecessary package bootstrap steps that can contact public registries.

## Motivation and Context

These changes keep packaging workflows compatible with network-isolated build agents and prevent package tools from bypassing the configured authenticated sources.

## Validation

- Parsed the modified Azure Pipelines YAML files.
- Checked the changes for whitespace errors.
