### PR TITLE
Filter display adapters that are using the Microsoft Basic Render Driver

### DIFF
--- a/onnxruntime/core/platform/windows/device_discovery.cc
+++ b/onnxruntime/core/platform/windows/device_discovery.cc
@@ -348,8 +348,12 @@ std::unordered_map<uint64_t, DeviceInfo> GetDeviceInfoD3D12(bool have_remote_dis
       continue;
     }
 
+    // Microsoft Remote Display Adapter and Microsoft Hyper-V Video display adapters use the basic render driver
+    // but don't set the DXGI_ADAPTER_FLAG_SOFTWARE flag. Filter them out by checking the vendor and device IDs.
+    const bool is_microsoft_basic_render_driver = desc.VendorId == 0x1414 && desc.DeviceId == 0x008c;
     if ((desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE) != 0 ||
-        (desc.Flags & DXGI_ADAPTER_FLAG_REMOTE) != 0) {
+        (desc.Flags & DXGI_ADAPTER_FLAG_REMOTE) != 0 ||
+        is_microsoft_basic_render_driver) {
       // software or remote. skip
       continue;
     }

--- a/onnxruntime/test/platform/device_discovery_test.cc
+++ b/onnxruntime/test/platform/device_discovery_test.cc
@@ -38,5 +38,15 @@ TEST(DeviceDiscoveryTest, GpuDevicesHaveValidProperties) {
   }
 }
 
+#ifdef _WIN32
+TEST(DeviceDiscoveryTest, ExcludesMicrosoftBasicRenderDriver) {
+  const auto gpu_devices = GetDevicesByType(OrtHardwareDeviceType_GPU);
+
+  for (const auto& gpu_device : gpu_devices) {
+    EXPECT_FALSE(gpu_device.vendor_id == 0x1414 && gpu_device.device_id == 0x008c);
+  }
+}
+#endif
+
 }  // namespace onnxruntime::test
 #endif  // !defined(ORT_MINIMAL_BUILD) && !defined(_GAMING_XBOX)


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Filter display adapters that are using the Microsoft Basic Render Driver without the software flag being set.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Prevent WebGPU EP attempting to use software based device.

