### PR TITLE
Validate MLAS blockwise QDQ index ranges

### DIFF
--- a/onnxruntime/core/mlas/inc/mlas_q4.h
+++ b/onnxruntime/core/mlas/inc/mlas_q4.h
@@ -25,6 +25,8 @@ Abstract:
 
 #include <math.h>
 #include <algorithm>
+#include <cstdint>
+#include <limits>
 
 /**
  * @brief Define types of block quantization
@@ -425,6 +427,52 @@ MlasQDQQuantizeBlockwise(
     int quant_block_size,
     MLAS_THREADPOOL* thread_pool
 );
+
+/**
+ * @brief Check that QDQ blockwise quantization index arithmetic fits in int32.
+ */
+inline bool
+MlasQDQBlockwiseShapeIsValid(
+    int64_t rows,
+    int64_t columns,
+    int64_t quant_block_size,
+    int64_t qbits,
+    bool transpose
+    )
+{
+    constexpr int64_t kMaxIndex = std::numeric_limits<int32_t>::max();
+    constexpr int64_t kThreadBlockSize = 128;
+    if (rows <= 0 || columns <= 0 || quant_block_size <= 0 ||
+        (qbits != 2 && qbits != 4 && qbits != 8) ||
+        rows > kMaxIndex || columns > kMaxIndex || quant_block_size > kMaxIndex) {
+        return false;
+    }
+
+    const int64_t pack_size = 8 / qbits;
+    const int64_t max_column_addend = transpose ? pack_size - 1 : kThreadBlockSize - 1;
+    if (rows > kMaxIndex - (quant_block_size - 1) ||
+        columns > kMaxIndex - max_column_addend ||
+        quant_block_size > (kMaxIndex - 7) / qbits ||
+        rows > kMaxIndex / columns) {
+        return false;
+    }
+
+    const int64_t block_count = (rows + quant_block_size - 1) / quant_block_size;
+    if (block_count > kMaxIndex - (pack_size - 1) ||
+        block_count > kMaxIndex / columns) {
+        return false;
+    }
+
+    if (transpose) {
+        const int64_t packed_block_bytes = (quant_block_size * qbits + 7) / 8;
+        if (block_count > kMaxIndex / packed_block_bytes ||
+            block_count * packed_block_bytes > kMaxIndex / columns) {
+            return false;
+        }
+    }
+
+    return true;
+}
 
 /**
  * @brief Transpose blockwise quantized tensors. The src tensors are row major. src weights and zero

--- a/onnxruntime/core/mlas/inc/mlas_q4.h
+++ b/onnxruntime/core/mlas/inc/mlas_q4.h
@@ -437,6 +437,7 @@ MlasQDQBlockwiseShapeIsValid(
     int64_t columns,
     int64_t quant_block_size,
     int64_t qbits,
+    bool columnwise,
     bool transpose
     )
 {
@@ -450,7 +451,12 @@ MlasQDQBlockwiseShapeIsValid(
 
     const int64_t pack_size = 8 / qbits;
     const int64_t max_column_addend = transpose ? pack_size - 1 : kThreadBlockSize - 1;
-    if (rows > kMaxIndex - (quant_block_size - 1) ||
+    const bool uses_unaligned_quantize = !transpose && columnwise && (columns & 1) != 0;
+    if (uses_unaligned_quantize && quant_block_size > kMaxIndex / 2) {
+        return false;
+    }
+    const int64_t row_block_size = uses_unaligned_quantize ? quant_block_size * 2 : quant_block_size;
+    if (rows > kMaxIndex - (row_block_size - 1) ||
         columns > kMaxIndex - max_column_addend ||
         quant_block_size > (kMaxIndex - 7) / qbits ||
         rows > kMaxIndex / columns) {

--- a/onnxruntime/core/mlas/lib/q4_dq.cpp
+++ b/onnxruntime/core/mlas/lib/q4_dq.cpp
@@ -2278,7 +2278,7 @@ MlasQDQQuantizeBlockwise(
     MLAS_THREADPOOL* thread_pool
 )
 {
-    ORT_ENFORCE(MlasQDQBlockwiseShapeIsValid(rows, columns, quant_block_size, qbits, false),
+    ORT_ENFORCE(MlasQDQBlockwiseShapeIsValid(rows, columns, quant_block_size, qbits, columnwise, false),
                 "QDQ blockwise quantization shape exceeds the int32 index range.");
     if (columnwise) {
         if (zero_points) {
@@ -2365,7 +2365,7 @@ MlasQDQTransposeBlockwiseQuantized(
     MLAS_THREADPOOL* thread_pool
 )
 {
-    ORT_ENFORCE(MlasQDQBlockwiseShapeIsValid(rows, columns, quant_block_size, qbits, true),
+    ORT_ENFORCE(MlasQDQBlockwiseShapeIsValid(rows, columns, quant_block_size, qbits, columnwise, true),
                 "QDQ blockwise quantization shape exceeds the int32 index range.");
     if (columnwise) {
         BlockwiseQDQQuantizer<Tin, qbits, signed_quant>::TransposeColumnWiseQuantized(

--- a/onnxruntime/core/mlas/lib/q4_dq.cpp
+++ b/onnxruntime/core/mlas/lib/q4_dq.cpp
@@ -2278,6 +2278,8 @@ MlasQDQQuantizeBlockwise(
     MLAS_THREADPOOL* thread_pool
 )
 {
+    ORT_ENFORCE(MlasQDQBlockwiseShapeIsValid(rows, columns, quant_block_size, qbits, false),
+                "QDQ blockwise quantization shape exceeds the int32 index range.");
     if (columnwise) {
         if (zero_points) {
             BlockwiseQDQQuantizer<Tin, qbits, false>::QuantizeColumnWise(
@@ -2363,6 +2365,8 @@ MlasQDQTransposeBlockwiseQuantized(
     MLAS_THREADPOOL* thread_pool
 )
 {
+    ORT_ENFORCE(MlasQDQBlockwiseShapeIsValid(rows, columns, quant_block_size, qbits, true),
+                "QDQ blockwise quantization shape exceeds the int32 index range.");
     if (columnwise) {
         BlockwiseQDQQuantizer<Tin, qbits, signed_quant>::TransposeColumnWiseQuantized(
             src_weights, src_scales, src_zero_points, dst_weights, dst_scales, dst_zero_points,

--- a/onnxruntime/core/optimizer/qdq_transformer/selectors_actions/qdq_actions.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/selectors_actions/qdq_actions.cc
@@ -148,7 +148,7 @@ Status TransposeDQWeightsForMatMulNBits(
   auto block_size = effective_block_size;
   int32_t dt_weight = weight_arg->TypeAsProto()->tensor_type().elem_type();
   auto bits = DQWeightBits(dt_weight);
-  ORT_RETURN_IF_NOT(MlasQDQBlockwiseShapeIsValid(K, N, block_size, bits, true),
+  ORT_RETURN_IF_NOT(MlasQDQBlockwiseShapeIsValid(K, N, block_size, bits, true, true),
                     "QDQ blockwise quantization shape exceeds the MLAS int32 index range.");
   auto quant_num = (K + block_size - 1) / block_size;
   auto blob_bytes = (block_size * bits + 7) / 8;

--- a/onnxruntime/core/optimizer/qdq_transformer/selectors_actions/qdq_actions.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/selectors_actions/qdq_actions.cc
@@ -148,6 +148,8 @@ Status TransposeDQWeightsForMatMulNBits(
   auto block_size = effective_block_size;
   int32_t dt_weight = weight_arg->TypeAsProto()->tensor_type().elem_type();
   auto bits = DQWeightBits(dt_weight);
+  ORT_RETURN_IF_NOT(MlasQDQBlockwiseShapeIsValid(K, N, block_size, bits, true),
+                    "QDQ blockwise quantization shape exceeds the MLAS int32 index range.");
   auto quant_num = (K + block_size - 1) / block_size;
   auto blob_bytes = (block_size * bits + 7) / 8;
 

--- a/onnxruntime/test/mlas/unittest/test_blockq4.cpp
+++ b/onnxruntime/test/mlas/unittest/test_blockq4.cpp
@@ -245,7 +245,8 @@ TEST(MlasBlockwiseQdqTest, RejectsShapesOutsideInt32IndexDomain) {
   float value = 0.0f;
   uint8_t packed_value = 0;
 
-  EXPECT_FALSE(MlasQDQBlockwiseShapeIsValid(2147483648LL, 1, 16, 4, false));
+  EXPECT_FALSE(MlasQDQBlockwiseShapeIsValid(2147483648LL, 1, 16, 4, false, false));
+  EXPECT_FALSE(MlasQDQBlockwiseShapeIsValid(2147483632LL, 1, 16, 4, true, false));
   EXPECT_THROW((MlasQDQQuantizeBlockwise<float, 4>(
                    &value, &value, nullptr, &packed_value, true, 46341, 46341, 16, nullptr)),
                onnxruntime::OnnxRuntimeException);

--- a/onnxruntime/test/mlas/unittest/test_blockq4.cpp
+++ b/onnxruntime/test/mlas/unittest/test_blockq4.cpp
@@ -241,4 +241,18 @@ static UNUSED_VARIABLE bool added_to_main = AddTestRegister([](bool is_short_exe
   return count;
 });
 
+TEST(MlasBlockwiseQdqTest, RejectsShapesOutsideInt32IndexDomain) {
+  float value = 0.0f;
+  uint8_t packed_value = 0;
+
+  EXPECT_FALSE(MlasQDQBlockwiseShapeIsValid(2147483648LL, 1, 16, 4, false));
+  EXPECT_THROW(MlasQDQQuantizeBlockwise<float, 4>(
+                   &value, &value, nullptr, &packed_value, true, 46341, 46341, 16, nullptr),
+               onnxruntime::OnnxRuntimeException);
+  EXPECT_THROW(MlasQDQTransposeBlockwiseQuantized<float, 4, true>(
+                   &packed_value, &value, nullptr, &packed_value, &value, nullptr,
+                   true, 1, 16777216, 256, nullptr),
+               onnxruntime::OnnxRuntimeException);
+}
+
 #endif  // ORT_MINIMAL_BUILD

--- a/onnxruntime/test/mlas/unittest/test_blockq4.cpp
+++ b/onnxruntime/test/mlas/unittest/test_blockq4.cpp
@@ -246,12 +246,12 @@ TEST(MlasBlockwiseQdqTest, RejectsShapesOutsideInt32IndexDomain) {
   uint8_t packed_value = 0;
 
   EXPECT_FALSE(MlasQDQBlockwiseShapeIsValid(2147483648LL, 1, 16, 4, false));
-  EXPECT_THROW(MlasQDQQuantizeBlockwise<float, 4>(
-                   &value, &value, nullptr, &packed_value, true, 46341, 46341, 16, nullptr),
+  EXPECT_THROW((MlasQDQQuantizeBlockwise<float, 4>(
+                   &value, &value, nullptr, &packed_value, true, 46341, 46341, 16, nullptr)),
                onnxruntime::OnnxRuntimeException);
-  EXPECT_THROW(MlasQDQTransposeBlockwiseQuantized<float, 4, true>(
+  EXPECT_THROW((MlasQDQTransposeBlockwiseQuantized<float, 4, true>(
                    &packed_value, &value, nullptr, &packed_value, &value, nullptr,
-                   true, 1, 16777216, 256, nullptr),
+                   true, 1, 16777216, 256, nullptr)),
                onnxruntime::OnnxRuntimeException);
 }
 


### PR DESCRIPTION
This pull request introduces important safety checks to the quantization code in ONNX Runtime to ensure that blockwise quantization shapes do not exceed the valid `int32_t` index range, preventing potential overflows and runtime errors. The main changes include the addition of a validation function, integration of this check into quantization and transpose routines, and new unit tests to verify the behavior.

**Shape validation and enforcement:**

* Added `MlasQDQBlockwiseShapeIsValid` function in `mlas_q4.h` to validate that quantization shape parameters fit within the `int32_t` index domain, guarding against arithmetic overflows.
* Updated `MlasQDQQuantizeBlockwise` and `MlasQDQTransposeBlockwiseQuantized` in `q4_dq.cpp` to enforce this validation using `ORT_ENFORCE`, throwing an exception if the shape is invalid. [[1]](diffhunk://#diff-c0645466d0d24ab96ae69729371fba6cc1b2ff971b7e92971d32d647d0925171R2281-R2282) [[2]](diffhunk://#diff-c0645466d0d24ab96ae69729371fba6cc1b2ff971b7e92971d32d647d0925171R2368-R2369)
* Added a similar check in `TransposeDQWeightsForMatMulNBits` to return an error if the shape is invalid.

**Testing and code hygiene:**

* Added a new unit test `RejectsShapesOutsideInt32IndexDomain` in `test_blockq4.cpp` to verify that invalid shapes are correctly rejected and exceptions are thrown as expected.
* Included missing headers `<cstdint>` and `<limits>` in `mlas_q4.h` to support the new validation logic.