### PR TITLE
Use dynamic shape storage in BeamSearch ExpandBuffer

### DIFF
--- a/onnxruntime/contrib_ops/cpu/transformers/generation_device_helper.cc
+++ b/onnxruntime/contrib_ops/cpu/transformers/generation_device_helper.cc
@@ -82,15 +82,14 @@ Status ExpandBuffer(Stream* stream,
   const int64_t& batch_size = input_shape[0];
   int64_t sequence_length = 0;
 
-  int64_t dims[4] = {0};
-  input_shape.CopyDims(dims, input_shape.NumDimensions());
+  TensorShapeVector dims(input_shape.GetDims().begin(), input_shape.GetDims().end());
   dims[0] = batch_size * num_beams;
   bool is_kv_cache = input_shape.NumDimensions() == 4;
   if (max_sequence_length > 0 && is_kv_cache) {
     sequence_length = input_shape[2];
     dims[2] = max_sequence_length;
   }
-  TensorShape expanded_shape(&dims[0], input_shape.NumDimensions());
+  TensorShape expanded_shape(dims);
 
   MLDataType element_type = input.Get<Tensor>().DataType();
   ORT_ENFORCE(element_type == DataTypeImpl::GetType<T>());

--- a/onnxruntime/test/contrib_ops/beam_search_test.cc
+++ b/onnxruntime/test/contrib_ops/beam_search_test.cc
@@ -10,6 +10,7 @@
 #include "test/util/include/current_test_name.h"
 #include "test/unittest_util/model_tester.h"
 #include "test/util/include/scoped_env_vars.h"
+#include "contrib_ops/cpu/transformers/generation_device_helper.h"
 #include "contrib_ops/cpu/transformers/generation_shared.h"
 #include "contrib_ops/cpu/transformers/beam_search_parameters.h"
 
@@ -87,6 +88,18 @@ TEST(BeamSearchParametersTest, AcceptsValidWhisperBeginningTimestampTokenId) {
   parameters.beginning_timestamp_token_id = 1;
 
   EXPECT_NO_THROW(parameters.ValidateWhisperTimestampTokenId());
+}
+
+TEST(BeamSearchTest, ExpandBufferSupportsRankGreaterThanFour) {
+  AllocatorPtr allocator = CPUAllocator::DefaultInstance();
+  OrtValue input;
+  Tensor::InitOrtValue(DataTypeImpl::GetType<float>(), TensorShape({1, 2, 3, 4, 5}), allocator, input);
+
+  OrtValue expanded;
+  ASSERT_STATUS_OK(contrib::GenerationCpuDeviceHelper::ExpandBuffer<float>(
+      nullptr, input, 2, allocator, expanded, true, 0));
+
+  EXPECT_EQ(expanded.Get<Tensor>().Shape(), TensorShape({2, 2, 3, 4, 5}));
 }
 
 void RunGptBeamSearchFp32() {


### PR DESCRIPTION
This pull request improves the `ExpandBuffer` function in the generation device helper to better support tensors with rank greater than four, and adds a new test to verify this behavior. The main changes are as follows:

**Support for high-rank tensors in `ExpandBuffer`:**
* Refactored the `ExpandBuffer` implementation in `generation_device_helper.cc` to use a dynamic `TensorShapeVector` instead of a fixed-size array, allowing support for input tensors with more than four dimensions.

**Testing enhancements:**
* Added an explicit test, `ExpandBufferSupportsRankGreaterThanFour`, to `beam_search_test.cc` to ensure that `ExpandBuffer` correctly handles tensors with rank greater than four.
* Included the necessary header import for `generation_device_helper.h` in the test file.