### PR TITLE
Use checked rounding for BFC arena allocations

### DIFF
--- a/onnxruntime/core/framework/bfc_arena.cc
+++ b/onnxruntime/core/framework/bfc_arena.cc
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include "core/common/safeint.h"
 #include "core/framework/allocator.h"
 #include "core/framework/bfc_arena.h"
 #include <type_traits>
@@ -260,9 +261,9 @@ void BFCArena::DeallocateChunk(ChunkHandle h) {
 
 // static
 size_t BFCArena::RoundedBytes(size_t bytes) {
-  size_t rounded_bytes =
-      (kMinAllocationSize *
-       ((bytes + kMinAllocationSize - 1) / kMinAllocationSize));
+  SafeInt<size_t> rounded_bytes =
+      kMinAllocationSize *
+      ((SafeInt<size_t>(bytes) + kMinAllocationSize - 1) / kMinAllocationSize);
   ORT_ENFORCE(size_t{0} == rounded_bytes % kMinAllocationSize);
   return rounded_bytes;
 }

--- a/onnxruntime/test/framework/bfc_arena_test.cc
+++ b/onnxruntime/test/framework/bfc_arena_test.cc
@@ -7,6 +7,7 @@
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
 #include <cstdlib>
+#include <limits>
 #include "core/framework/stream_handles.h"
 
 namespace onnxruntime {
@@ -157,6 +158,14 @@ TEST(BFCArenaTest, AllocateZeroBufSize) {
   BFCArena a(std::unique_ptr<IAllocator>(new CPUAllocator()), 1 << 30);
   void* ptr = a.Alloc(0);
   EXPECT_EQ(nullptr, ptr);
+}
+
+TEST(BFCArenaTest, RoundedBytesOverflowThrows) {
+  BFCArena a(std::unique_ptr<IAllocator>(new CPUAllocator()), 1 << 30);
+  void* ptr = a.Alloc(256);
+  a.Free(ptr);
+
+  EXPECT_THROW(a.Alloc(std::numeric_limits<size_t>::max()), OnnxRuntimeException);
 }
 
 TEST(BFCArenaTest, AllocatedVsRequested) {


### PR DESCRIPTION
This pull request improves the safety and robustness of memory allocation in the `BFCArena` allocator by adding overflow protection and corresponding tests. The most important changes are:

**Overflow Protection and Safety:**

* Updated the `BFCArena::RoundedBytes` function in `bfc_arena.cc` to use `SafeInt<size_t>` for arithmetic operations, preventing integer overflows during memory rounding calculations.
* Included the `safeint.h` header to enable safe integer operations in `bfc_arena.cc`.

**Testing:**

* Added a new test, `RoundedBytesOverflowThrows`, in `bfc_arena_test.cc` to verify that an overflow during allocation throws an `OnnxRuntimeException`.
* Included the `<limits>` header in `bfc_arena_test.cc` to support boundary value tests.