### PR TITLE
Reject non-finite CPU RoiAlign coordinates

### DIFF
--- a/onnxruntime/core/providers/cpu/object_detection/roialign.cc
+++ b/onnxruntime/core/providers/cpu/object_detection/roialign.cc
@@ -277,12 +277,18 @@ Status RoiAlign<T>::Compute(OpKernelContext* context) const {
     return status;
   }
 
+  const T* rois_data = rois_ptr->Data<T>();
+  const int64_t rois_size = rois_ptr->Shape().Size();
+  for (int64_t i = 0; i < rois_size; ++i) {
+    ORT_RETURN_IF_NOT(std::isfinite(rois_data[i]), "All 'rois' values must be finite.");
+  }
+
   auto& Y = *context->Output(0, {num_rois, num_channels, this->output_height_, this->output_width_});
 
   RoiAlignForward<T>(Y.Shape(), X_ptr->Data<T>(), this->spatial_scale_,
                      x_dims[2],  // height
                      x_dims[3],  // width
-                     this->sampling_ratio_, rois_ptr->Data<T>(), num_roi_cols, Y.template MutableData<T>(), this->mode_, this->half_pixel_,
+                     this->sampling_ratio_, rois_data, num_roi_cols, Y.template MutableData<T>(), this->mode_, this->half_pixel_,
                      batch_indices_ptr->Data<int64_t>(), context->GetOperatorThreadPool());
 
   return Status::OK();

--- a/onnxruntime/core/providers/cpu/object_detection/roialign.cc
+++ b/onnxruntime/core/providers/cpu/object_detection/roialign.cc
@@ -280,7 +280,9 @@ Status RoiAlign<T>::Compute(OpKernelContext* context) const {
   const T* rois_data = rois_ptr->Data<T>();
   const int64_t rois_size = rois_ptr->Shape().Size();
   for (int64_t i = 0; i < rois_size; ++i) {
-    ORT_RETURN_IF_NOT(std::isfinite(rois_data[i]), "All 'rois' values must be finite.");
+    if (!std::isfinite(rois_data[i])) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "All 'rois' values must be finite.");
+    }
   }
 
   auto& Y = *context->Output(0, {num_rois, num_channels, this->output_height_, this->output_width_});

--- a/onnxruntime/test/providers/cpu/object_detection/roialign_test.cc
+++ b/onnxruntime/test/providers/cpu/object_detection/roialign_test.cc
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <limits>
+
 #include "gtest/gtest.h"
 #include "test/common/tensor_op_test_utils.h"
 #include "test/providers/provider_test_utils.h"
@@ -854,6 +856,24 @@ TEST(RoiAlignTest, BatchIndicesNegative) {
   std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
   execution_providers.push_back(DefaultCpuExecutionProvider());
   test.Run(OpTester::ExpectResult::kExpectFailure, "batch_indices value -1 at index 0 is out of range [0, 1)", {}, nullptr, &execution_providers);
+}
+
+TEST(RoiAlignTest, RoiCoordinatesMustBeFinite) {
+  OpTester test("RoiAlign", 16);
+  test.AddAttribute<int64_t>("output_height", 2);
+  test.AddAttribute<int64_t>("output_width", 2);
+  test.AddAttribute<int64_t>("sampling_ratio", 1);
+  test.AddAttribute<float>("spatial_scale", 1.0f);
+
+  test.AddInput<float>("X", {1, 1, 2, 2}, {0.f, 1.f, 2.f, 3.f});
+  test.AddInput<float>("rois", {1, 4}, {0.f, std::numeric_limits<float>::quiet_NaN(), 1.f, 1.f});
+  test.AddInput<int64_t>("batch_indices", {1}, {0});
+  test.AddOutput<float>("Y", {1, 1, 2, 2}, {0.f, 0.f, 0.f, 0.f});
+
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(DefaultCpuExecutionProvider());
+  test.Run(OpTester::ExpectResult::kExpectFailure, "All 'rois' values must be finite.",
+           {}, nullptr, &execution_providers);
 }
 
 TEST(RoiAlignTest, BatchIndicesOutOfRange_CUDA) {


### PR DESCRIPTION
This pull request adds input validation to the `RoiAlign` operator to ensure that all Region of Interest (ROI) coordinate values are finite, improving robustness and error reporting. It also introduces a corresponding unit test to verify this behavior.

**Input validation improvements:**

* Added a check in `roialign.cc` to ensure all values in the `rois` input tensor are finite (i.e., not NaN or infinity), returning an error if any non-finite value is found.

**Testing enhancements:**

* Added a new test case `RoiCoordinatesMustBeFinite` in `roialign_test.cc` to verify that the operator fails with an appropriate error message when the `rois` input contains a NaN value.
* Included `<limits>` header in `roialign_test.cc` to support the use of `std::numeric_limits` for generating NaN values in tests.