### PR TITLE
Validate CUDA NMS mask size

### DIFF
--- a/onnxruntime/core/providers/cuda/object_detection/non_max_suppression_impl.cu
+++ b/onnxruntime/core/providers/cuda/object_detection/non_max_suppression_impl.cu
@@ -16,11 +16,14 @@ limitations under the License.
 
 #include "core/providers/cuda/cu_inc/common.cuh"
 
+#include <limits>
+
 #include <thrust/count.h>
 #include <thrust/device_vector.h>
 #include <thrust/execution_policy.h>
 
 #include "non_max_suppression_impl.h"
+#include "core/common/safeint.h"
 #include "core/providers/cpu/object_detection/non_max_suppression_helper.h"
 #include "core/providers/cuda/cuda_common.h"
 
@@ -241,15 +244,18 @@ Status NmsGpu(cudaStream_t stream,
   auto iptr = reinterpret_cast<std::uintptr_t>(d_sorted_boxes_float_ptr);
   ORT_ENFORCE((iptr & 15) == 0);
 
-  const int bit_mask_len =
-      (num_boxes + kNmsBoxesPerThread - 1) / kNmsBoxesPerThread;
-  int max_nms_mask_size = num_boxes * bit_mask_len;
+  const int bit_mask_len = num_boxes == 0 ? 0 : 1 + (num_boxes - 1) / kNmsBoxesPerThread;
+  const size_t max_nms_mask_size = SafeInt<size_t>(num_boxes) * bit_mask_len;
+  ORT_RETURN_IF_NOT(max_nms_mask_size <= static_cast<size_t>(std::numeric_limits<int>::max()),
+                    "CUDA NonMaxSuppression mask size exceeds the int index range.");
+  const int max_nms_mask_size_int = static_cast<int>(max_nms_mask_size);
 
-  IAllocatorUniquePtr<void> d_nms_mask_ptr{allocator(max_nms_mask_size * sizeof(int))};
+  IAllocatorUniquePtr<void> d_nms_mask_ptr{allocator(SafeInt<size_t>(max_nms_mask_size) * sizeof(int))};
   auto* d_nms_mask = static_cast<int*>(d_nms_mask_ptr.get());
 
-  int blocksPerGrid = (int)(ceil(static_cast<float>(max_nms_mask_size) / GridDim::maxThreadsPerBlock));
-  SetZero<int><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0, stream>>>(max_nms_mask_size, d_nms_mask);
+  int blocksPerGrid = static_cast<int>((max_nms_mask_size + GridDim::maxThreadsPerBlock - 1) /
+                                       GridDim::maxThreadsPerBlock);
+  SetZero<int><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0, stream>>>(max_nms_mask_size_int, d_nms_mask);
 
   int* d_delete_mask = d_nms_mask;
   int* h_selected_count = h_nkeep;

--- a/onnxruntime/test/providers/cpu/object_detection/non_max_suppression_test.cc
+++ b/onnxruntime/test/providers/cpu/object_detection/non_max_suppression_test.cc
@@ -4,6 +4,10 @@
 #include "gtest/gtest.h"
 #include "test/providers/provider_test_utils.h"
 
+#ifdef USE_CUDA
+#include "test/util/include/default_providers.h"
+#endif
+
 namespace onnxruntime {
 namespace test {
 
@@ -403,6 +407,29 @@ TEST(NonMaxSuppressionOpTest, WithIOUThresholdOpset11) {
                            0L, 0L, 5L});
   test.Run();
 }
+
+#ifdef USE_CUDA
+TEST(NonMaxSuppressionOpTest, CudaRejectsMaskSizeOutsideIntRange) {
+  auto cuda_provider = DefaultCudaExecutionProvider();
+  if (cuda_provider == nullptr) {
+    GTEST_SKIP() << "CUDA execution provider is not available.";
+  }
+
+  constexpr int64_t num_boxes = 262144;
+  OpTester test("NonMaxSuppression", 11, kOnnxDomain);
+  test.AddInput<float>("boxes", {1, num_boxes, 4}, std::vector<float>(num_boxes * 4));
+  test.AddInput<float>("scores", {1, 1, num_boxes}, std::vector<float>(num_boxes));
+  test.AddInput<int64_t>("max_output_boxes_per_class", {}, {1});
+  test.AddInput<float>("iou_threshold", {}, {0.5f});
+  test.AddOptionalInputEdge<float>();
+  test.AddOutput<int64_t>("selected_indices", {0, 3}, {});
+
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(std::move(cuda_provider));
+  test.Run(OpTester::ExpectResult::kExpectFailure, "mask size exceeds the int index range",
+           {}, nullptr, &execution_providers);
+}
+#endif
 
 }  // namespace test
 }  // namespace onnxruntime


### PR DESCRIPTION
This pull request improves the robustness and error handling of the CUDA NonMaxSuppression (NMS) implementation in ONNX Runtime. The changes ensure that large input sizes which could exceed the range of supported integer indices are properly checked and handled, preventing potential overflows or crashes. Additionally, a new CUDA-specific test has been added to verify this behavior.

Error handling and robustness improvements:

* Updated the calculation of `max_nms_mask_size` in `non_max_suppression_impl.cu` to use `SafeInt<size_t>` for safer arithmetic and added a check to ensure the mask size does not exceed the maximum value of an `int`. If the limit is exceeded, an error is returned. (`onnxruntime/core/providers/cuda/object_detection/non_max_suppression_impl.cu`)
* Included necessary headers for safe integer operations and numeric limits (`<limits>`, `core/common/safeint.h>`) to support the above changes. (`onnxruntime/core/providers/cuda/object_detection/non_max_suppression_impl.cu`)

Testing enhancements:

* Added a CUDA-specific unit test that verifies the operator correctly rejects inputs that would require a mask size outside the supported integer range, ensuring the new error handling works as intended. (`onnxruntime/test/providers/cpu/object_detection/non_max_suppression_test.cc`)
* Included conditional compilation and necessary CUDA test utilities to enable the new test only when CUDA is available. (`onnxruntime/test/providers/cpu/object_detection/non_max_suppression_test.cc`)