### PR TITLE
Pin C# RunAsync arguments until completion

### DIFF
--- a/csharp/src/Microsoft.ML.OnnxRuntime/InferenceSession.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/InferenceSession.shared.cs
@@ -1132,6 +1132,7 @@ namespace Microsoft.ML.OnnxRuntime
             }
             finally
             {
+                host.Dispose();
                 hostHdl.Free();
             }
         }
@@ -1143,8 +1144,10 @@ namespace Microsoft.ML.OnnxRuntime
 
         private delegate void UserCallbackDelegate(IReadOnlyCollection<OrtValue> outputs, IntPtr status);
 
-        private class CallbackHost
+        private class CallbackHost : IDisposable
         {
+            public InferenceSession session { get; }
+            public RunOptions options { get; }
             public IReadOnlyCollection<string> inputNames { get; }
             public IReadOnlyCollection<OrtValue> inputValues { get; }
             public IReadOnlyCollection<string> outputNames { get; }
@@ -1156,14 +1159,21 @@ namespace Microsoft.ML.OnnxRuntime
             public IntPtr[] rawOutputNames { get; }
             public IntPtr[] rawOutputValues { get; }
 
+            public IntPtr rawInputNamesPointer => GetPinnedPointer(rawInputNamesHandle);
+            public IntPtr rawInputValuesPointer => GetPinnedPointer(rawInputValuesHandle);
+            public IntPtr rawOutputNamesPointer => GetPinnedPointer(rawOutputNamesHandle);
+            public IntPtr rawOutputValuesPointer => GetPinnedPointer(rawOutputValuesHandle);
+
             public CallbackHost(InferenceSession session,
+                                RunOptions options,
                                 IReadOnlyCollection<string> cbInputNames,
                                 IReadOnlyCollection<OrtValue> cbinputValues,
                                 IReadOnlyCollection<string> cbOutputNames,
                                 IReadOnlyCollection<OrtValue> cbOutputValues,
                                 UserCallbackDelegate userCallback)
             {
-
+                this.session = session;
+                this.options = options;
                 inputNames = cbInputNames;
                 inputValues = cbinputValues;
                 outputNames = cbOutputNames;
@@ -1175,7 +1185,52 @@ namespace Microsoft.ML.OnnxRuntime
 
                 rawOutputNames = LookupUtf8Names(outputNames, n => n, session.LookupOutputMetadata);
                 rawOutputValues = outputValues.Select(v => v.Handle).ToArray();
+
+                // Native RunAsync retains these array addresses after the P/Invoke call returns.
+                try
+                {
+                    rawInputNamesHandle = PinArray(rawInputNames);
+                    rawInputValuesHandle = PinArray(rawInputValues);
+                    rawOutputNamesHandle = PinArray(rawOutputNames);
+                    rawOutputValuesHandle = PinArray(rawOutputValues);
+                }
+                catch
+                {
+                    Dispose();
+                    throw;
+                }
             }
+
+            public void Dispose()
+            {
+                FreeHandle(ref rawInputNamesHandle);
+                FreeHandle(ref rawInputValuesHandle);
+                FreeHandle(ref rawOutputNamesHandle);
+                FreeHandle(ref rawOutputValuesHandle);
+            }
+
+            private static GCHandle PinArray(IntPtr[] array)
+            {
+                return array.Length == 0 ? default : GCHandle.Alloc(array, GCHandleType.Pinned);
+            }
+
+            private static IntPtr GetPinnedPointer(GCHandle handle)
+            {
+                return handle.IsAllocated ? handle.AddrOfPinnedObject() : IntPtr.Zero;
+            }
+
+            private static void FreeHandle(ref GCHandle handle)
+            {
+                if (handle.IsAllocated)
+                {
+                    handle.Free();
+                }
+            }
+
+            private GCHandle rawInputNamesHandle = default;
+            private GCHandle rawInputValuesHandle = default;
+            private GCHandle rawOutputNamesHandle = default;
+            private GCHandle rawOutputValuesHandle = default;
         }
 
         private void RunAsyncInternal(RunOptions options,
@@ -1185,27 +1240,32 @@ namespace Microsoft.ML.OnnxRuntime
                                       IReadOnlyCollection<OrtValue> outputValues,
                                       UserCallbackDelegate callback)
         {
-            CallbackHost host = new CallbackHost(this, inputNames, inputValues, outputNames, outputValues, callback);
-            var host_hdl = GCHandle.Alloc(host, GCHandleType.Normal);
+            CallbackHost host = new CallbackHost(this, options, inputNames, inputValues, outputNames, outputValues, callback);
+            GCHandle host_hdl = default;
 
             try
             {
+                host_hdl = GCHandle.Alloc(host, GCHandleType.Normal);
                 NativeApiStatus.VerifySuccess(NativeMethods.OrtRunAsync(
                                                     _nativeHandle,
                                                     options == null ? (IntPtr)null : options.Handle,
-                                                    host.rawInputNames,
-                                                    host.rawInputValues,
+                                                    host.rawInputNamesPointer,
+                                                    host.rawInputValuesPointer,
                                                     (UIntPtr)host.rawInputNames.Length,
-                                                    host.rawOutputNames,
+                                                    host.rawOutputNamesPointer,
                                                     (UIntPtr)host.rawOutputNames.Length,
-                                                    host.rawOutputValues,
+                                                    host.rawOutputValuesPointer,
                                                     Marshal.GetFunctionPointerForDelegate(ortCallback),
                                                     GCHandle.ToIntPtr(host_hdl)
                                                     ));
             }
-            catch (OnnxRuntimeException)
+            catch
             {
-                host_hdl.Free();
+                host.Dispose();
+                if (host_hdl.IsAllocated)
+                {
+                    host_hdl.Free();
+                }
                 throw;
             }
         }

--- a/csharp/src/Microsoft.ML.OnnxRuntime/InferenceSession.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/InferenceSession.shared.cs
@@ -1240,6 +1240,15 @@ namespace Microsoft.ML.OnnxRuntime
                                       IReadOnlyCollection<OrtValue> outputValues,
                                       UserCallbackDelegate callback)
         {
+            if (inputNames.Count != inputValues.Count)
+            {
+                throw new ArgumentException($"Length of {nameof(inputNames)} ({inputNames.Count}) must match that of {nameof(inputValues)} ({inputValues.Count}).");
+            }
+            if (outputNames.Count != outputValues.Count)
+            {
+                throw new ArgumentException($"Length of {nameof(outputNames)} ({outputNames.Count}) must match that of {nameof(outputValues)} ({outputValues.Count}).");
+            }
+
             CallbackHost host = new CallbackHost(this, options, inputNames, inputValues, outputNames, outputValues, callback);
             GCHandle host_hdl = default;
 

--- a/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.shared.cs
@@ -1585,12 +1585,12 @@ namespace Microsoft.ML.OnnxRuntime
         public delegate IntPtr /*(ONNStatus*)*/ DOrtRunAsync(
             IntPtr /*(OrtSession*)*/ session,
             IntPtr /*(OrtSessionRunOptions*)*/ runOptions, // can be null to use the default options
-            IntPtr[] /*(char**)*/ inputNames,
-            IntPtr[] /*(OrtValue*[])*/ inputValues,
+            IntPtr /*(char**)*/ inputNames,
+            IntPtr /*(OrtValue*[])*/ inputValues,
             UIntPtr /*(size_t)*/ inputCount,
-            IntPtr[] /*(char**)*/ outputNames,
+            IntPtr /*(char**)*/ outputNames,
             UIntPtr /*(size_t)*/ outputCount,
-            IntPtr[] /*(OrtValue*[])*/ outputValues,
+            IntPtr /*(OrtValue*[])*/ outputValues,
             IntPtr /*(void (*RunAsyncCallbackFn)(void* user_data, OrtValue** outputs, size_t num_outputs, OrtStatusPtr status))*/ callback, // callback function
             IntPtr /*(void*)*/ user_data);
         public static DOrtRunAsync OrtRunAsync;

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests.Common/InferenceTest.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests.Common/InferenceTest.cs
@@ -1965,7 +1965,12 @@ namespace Microsoft.ML.OnnxRuntime.Tests
                 {
                     try
                     {
-                        var task = session.RunAsync(null, inputNames, inputValues, outputNames, outputValues);
+                        RunOptions runOptions = new RunOptions();
+                        var task = session.RunAsync(runOptions, inputNames, inputValues, outputNames, outputValues);
+                        runOptions = null;
+                        // Exercise the managed argument and RunOptions lifetimes while native work is outstanding.
+                        GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, true, true);
+                        GC.WaitForPendingFinalizers();
                         var outputs = await task;
                         var valueOut = outputs.ElementAt<OrtValue>(0);
                         var float16s = valueOut.GetTensorDataAsSpan<Float16>().ToArray();

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests.Common/InferenceTest.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests.Common/InferenceTest.cs
@@ -1985,6 +1985,34 @@ namespace Microsoft.ML.OnnxRuntime.Tests
         }
 #endif
 
+        [Fact(DisplayName = "TestModelRunAsyncRejectsMismatchedArgumentCounts")]
+        private async Task TestModelRunAsyncRejectsMismatchedArgumentCounts()
+        {
+            Float16[] inputData = { new Float16(15360), new Float16(16384), new Float16(16896), new Float16(17408), new Float16(17664) };
+            long[] shape = { 1, 5 };
+
+            var inputNames = new List<string> { "input" };
+            var outputNames = new List<string> { "output" };
+
+            var model = TestDataLoader.LoadModelFromEmbeddedResource("test_types_FLOAT16.onnx");
+            using (var inputValue = OrtValue.CreateTensorValueFromMemory(inputData, shape))
+            using (var outputValue = OrtValue.CreateAllocatedTensorValue(OrtAllocator.DefaultInstance,
+                    TensorElementType.Float16, shape))
+            using (var session = new InferenceSession(model))
+            {
+                var inputValues = new List<OrtValue> { inputValue };
+                var outputValues = new List<OrtValue> { outputValue };
+
+                var inputException = await Assert.ThrowsAsync<ArgumentException>(() =>
+                    session.RunAsync(null, new List<string>(), inputValues, outputNames, outputValues));
+                Assert.StartsWith("Length of inputNames (0) must match that of inputValues (1).", inputException.Message);
+
+                var outputException = await Assert.ThrowsAsync<ArgumentException>(() =>
+                    session.RunAsync(null, inputNames, inputValues, new List<string>(), outputValues));
+                Assert.StartsWith("Length of outputNames (0) must match that of outputValues (1).", outputException.Message);
+            }
+        }
+
         [Fact(DisplayName = "TestModelRunAsyncTaskFail")]
         private async Task TestModelRunAsyncTaskFail()
         {


### PR DESCRIPTION
This pull request improves the memory management and safety of async inference execution in the ONNX Runtime C# API, particularly around the `RunAsync` method. The main changes ensure that arrays passed to native code are properly pinned and unpinned, reducing the risk of memory errors, and that resources are disposed of correctly in both success and failure scenarios. The test code is also updated to more rigorously exercise object lifetimes.

### Memory management and resource safety improvements

* The `CallbackHost` class now implements `IDisposable` and manages the pinning and unpinning of input and output arrays using `GCHandle`, ensuring that native code receives stable pointers and that handles are freed even on exceptions. [[1]](diffhunk://#diff-622c8600020a433468d4a0e82a320fdc478e0c685c2d92c86c04dac351af4d04L1146-R1150) [[2]](diffhunk://#diff-622c8600020a433468d4a0e82a320fdc478e0c685c2d92c86c04dac351af4d04R1162-R1176) [[3]](diffhunk://#diff-622c8600020a433468d4a0e82a320fdc478e0c685c2d92c86c04dac351af4d04R1188-R1268)
* The `OrtCallback` and `RunAsyncInternal` methods are updated to explicitly dispose of the `CallbackHost` and free handles in all code paths, further strengthening resource safety. [[1]](diffhunk://#diff-622c8600020a433468d4a0e82a320fdc478e0c685c2d92c86c04dac351af4d04R1135) [[2]](diffhunk://#diff-622c8600020a433468d4a0e82a320fdc478e0c685c2d92c86c04dac351af4d04R1188-R1268)

### Native interop changes

* The native P/Invoke signature for `OrtRunAsync` is updated to pass pointers (`IntPtr`) instead of managed arrays, matching the new pinned memory approach.
* Calls to the native API (`OrtRunAsync`) are updated to use the new pointer properties from `CallbackHost` instead of directly passing arrays.

### Test improvements

* The async inference test now explicitly creates and nulls out a `RunOptions` instance and forces garbage collection, testing that managed resources are not prematurely collected while native work is outstanding.

These changes collectively make async inference safer and more robust, especially in scenarios with concurrent or long-running operations.