### PR TITLE
Validate GQA fusion projection shapes

### DIFF
--- a/onnxruntime/core/optimizer/group_query_attention_fusion.cc
+++ b/onnxruntime/core/optimizer/group_query_attention_fusion.cc
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <limits>
+
 #include "core/optimizer/initializer.h"
 #include "core/optimizer/group_query_attention_fusion.h"
 #include "core/graph/graph_utils.h"
@@ -252,6 +254,30 @@ static bool NodeArgExists(const NodeArg* node_arg) {
   return node_arg != nullptr && node_arg->Exists();
 }
 
+static bool ProjectionTensorShapesMatch(bool quantization_used,
+                                        int64_t q_hidden_size,
+                                        int64_t kv_hidden_size,
+                                        const TensorProto& q_tensor,
+                                        const TensorProto& k_tensor,
+                                        const TensorProto& v_tensor) {
+  const int expected_rank = quantization_used ? 3 : 2;
+  if (q_tensor.dims_size() != expected_rank || k_tensor.dims_size() != expected_rank ||
+      v_tensor.dims_size() != expected_rank) {
+    return false;
+  }
+
+  if (quantization_used) {
+    return q_tensor.dims(0) == q_hidden_size && k_tensor.dims(0) == kv_hidden_size &&
+           v_tensor.dims(0) == kv_hidden_size && q_tensor.dims(1) == k_tensor.dims(1) &&
+           q_tensor.dims(1) == v_tensor.dims(1) && q_tensor.dims(2) == k_tensor.dims(2) &&
+           q_tensor.dims(2) == v_tensor.dims(2);
+  }
+
+  return q_tensor.dims(1) == q_hidden_size && k_tensor.dims(1) == kv_hidden_size &&
+         v_tensor.dims(1) == kv_hidden_size && q_tensor.dims(0) == k_tensor.dims(0) &&
+         q_tensor.dims(0) == v_tensor.dims(0);
+}
+
 struct RotaryEmbeddingArgs {
   NodeArg* cos_cache_arg = nullptr;
   NodeArg* sin_cache_arg = nullptr;
@@ -481,9 +507,29 @@ Status GroupQueryAttentionFusion::ApplyImpl(
     int64_t head_size = past_key_values_key_arg->Shape()->dim(3).dim_value();
     int64_t num_heads = node.GetAttributes().at("num_heads").i();
     int64_t kv_num_heads = node.GetAttributes().at("kv_num_heads").i();
-    int64_t q_hidden_size = num_heads * head_size;
-    int64_t kv_hidden_size = kv_num_heads * head_size;
-    int64_t output_hidden_size = q_hidden_size + 2 * kv_hidden_size;
+    if (head_size <= 0 || num_heads <= 0 || kv_num_heads <= 0) {
+      DEBUG_LOG("GQA head attributes and cache head size must be positive");
+      continue;
+    }
+
+    constexpr int64_t max_int64 = std::numeric_limits<int64_t>::max();
+    if (num_heads > max_int64 / head_size || kv_num_heads > max_int64 / head_size) {
+      DEBUG_LOG("GQA hidden size calculation overflowed");
+      continue;
+    }
+    const int64_t q_hidden_size = num_heads * head_size;
+    const int64_t kv_hidden_size = kv_num_heads * head_size;
+    if (kv_hidden_size > (max_int64 - q_hidden_size) / 2) {
+      DEBUG_LOG("GQA output hidden size calculation overflowed");
+      continue;
+    }
+    const int64_t output_hidden_size = q_hidden_size + 2 * kv_hidden_size;
+
+    if (!ProjectionTensorShapesMatch(quantization_used, q_hidden_size, kv_hidden_size,
+                                     *q_proj_tensor, *k_proj_tensor, *v_proj_tensor)) {
+      DEBUG_LOG("GQA projection tensor shapes do not match the head attributes");
+      continue;
+    }
 
     // Ensure the output shape has 3 dimensions [batch_size, sequence_length, hidden_size]
     if (matmul_or_nbits_output_shape->dim_size() == 3) {

--- a/onnxruntime/core/optimizer/group_query_attention_fusion.cc
+++ b/onnxruntime/core/optimizer/group_query_attention_fusion.cc
@@ -147,8 +147,9 @@ static std::vector<NodeArg*> MergeQkvWeightsForMatMulNBits(
 
     TensorProto qkv_zp_initializer;
 
-    // We use 4 bit quantization, hence dividing by 2 since we need 1/2 of the bytes.
-    int64_t zp_elements_count = output_hidden_size * blocks / 2;
+    // We use 4 bit quantization, so each byte stores two block zero points per output row.
+    const int64_t zero_point_blocks = blocks / 2 + blocks % 2;
+    int64_t zp_elements_count = output_hidden_size * zero_point_blocks;
 
     qkv_zp_initializer.set_name(graph.GenerateNodeArgName("qkv_zp"));
     qkv_zp_initializer.add_dims(zp_elements_count);
@@ -158,7 +159,7 @@ static std::vector<NodeArg*> MergeQkvWeightsForMatMulNBits(
     merged_qkv_zp.reserve(gsl::narrow<size_t>(zp_elements_count));
 
     optimizer_utils::MergeMatMulWeightsByBlocks(q_zero_points_data, k_zero_points_data, v_zero_points_data,
-                                                merged_qkv_zp, q_hidden_size, kv_hidden_size, blocks / 2, 1);
+                                                merged_qkv_zp, q_hidden_size, kv_hidden_size, zero_point_blocks, 1);
 
     utils::SetRawDataInTensorProto(qkv_zp_initializer, merged_qkv_zp.data(), zp_elements_count * sizeof(uint8_t));
 
@@ -270,12 +271,54 @@ static bool ProjectionTensorShapesMatch(bool quantization_used,
     return q_tensor.dims(0) == q_hidden_size && k_tensor.dims(0) == kv_hidden_size &&
            v_tensor.dims(0) == kv_hidden_size && q_tensor.dims(1) == k_tensor.dims(1) &&
            q_tensor.dims(1) == v_tensor.dims(1) && q_tensor.dims(2) == k_tensor.dims(2) &&
-           q_tensor.dims(2) == v_tensor.dims(2);
+           q_tensor.dims(2) == v_tensor.dims(2) && q_tensor.dims(1) > 0 && q_tensor.dims(2) > 0;
   }
 
   return q_tensor.dims(1) == q_hidden_size && k_tensor.dims(1) == kv_hidden_size &&
          v_tensor.dims(1) == kv_hidden_size && q_tensor.dims(0) == k_tensor.dims(0) &&
          q_tensor.dims(0) == v_tensor.dims(0);
+}
+
+static bool TensorShapeMatchesRowsAndBlocks(const TensorProto& tensor, int64_t rows, int64_t blocks) {
+  if (tensor.dims_size() == 2) {
+    return tensor.dims(0) == rows && tensor.dims(1) == blocks;
+  }
+
+  if (tensor.dims_size() != 1 || blocks <= 0 || tensor.dims(0) < 0 || tensor.dims(0) % blocks != 0) {
+    return false;
+  }
+
+  return tensor.dims(0) / blocks == rows;
+}
+
+static bool QuantizedAuxiliaryTensorShapesMatch(int64_t q_hidden_size,
+                                                int64_t kv_hidden_size,
+                                                int64_t blocks,
+                                                const TensorProto& q_scale_tensor,
+                                                const TensorProto& k_scale_tensor,
+                                                const TensorProto& v_scale_tensor,
+                                                const TensorProto* q_zero_point_tensor,
+                                                const TensorProto* k_zero_point_tensor,
+                                                const TensorProto* v_zero_point_tensor) {
+  const int scale_rank = q_scale_tensor.dims_size();
+  if (k_scale_tensor.dims_size() != scale_rank || v_scale_tensor.dims_size() != scale_rank ||
+      !TensorShapeMatchesRowsAndBlocks(q_scale_tensor, q_hidden_size, blocks) ||
+      !TensorShapeMatchesRowsAndBlocks(k_scale_tensor, kv_hidden_size, blocks) ||
+      !TensorShapeMatchesRowsAndBlocks(v_scale_tensor, kv_hidden_size, blocks)) {
+    return false;
+  }
+
+  if (q_zero_point_tensor == nullptr || k_zero_point_tensor == nullptr || v_zero_point_tensor == nullptr) {
+    return q_zero_point_tensor == nullptr && k_zero_point_tensor == nullptr && v_zero_point_tensor == nullptr;
+  }
+
+  const int64_t zero_point_blocks = blocks / 2 + blocks % 2;
+  const int zero_point_rank = q_zero_point_tensor->dims_size();
+  return k_zero_point_tensor->dims_size() == zero_point_rank &&
+         v_zero_point_tensor->dims_size() == zero_point_rank &&
+         TensorShapeMatchesRowsAndBlocks(*q_zero_point_tensor, q_hidden_size, zero_point_blocks) &&
+         TensorShapeMatchesRowsAndBlocks(*k_zero_point_tensor, kv_hidden_size, zero_point_blocks) &&
+         TensorShapeMatchesRowsAndBlocks(*v_zero_point_tensor, kv_hidden_size, zero_point_blocks);
 }
 
 struct RotaryEmbeddingArgs {
@@ -528,6 +571,14 @@ Status GroupQueryAttentionFusion::ApplyImpl(
     if (!ProjectionTensorShapesMatch(quantization_used, q_hidden_size, kv_hidden_size,
                                      *q_proj_tensor, *k_proj_tensor, *v_proj_tensor)) {
       DEBUG_LOG("GQA projection tensor shapes do not match the head attributes");
+      continue;
+    }
+
+    if (quantization_used &&
+        !QuantizedAuxiliaryTensorShapesMatch(q_hidden_size, kv_hidden_size, q_proj_tensor->dims(1),
+                                             *q_scale_tensor, *k_scale_tensor, *v_scale_tensor,
+                                             q_zero_points_tensor, k_zero_points_tensor, v_zero_points_tensor)) {
+      DEBUG_LOG("GQA quantized auxiliary tensor shapes do not match the projection tensors");
       continue;
     }
 

--- a/onnxruntime/test/optimizer/graph_transform_test_layernorm.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test_layernorm.cc
@@ -1098,6 +1098,26 @@ static Status CheckOnnxRotaryEmbeddingGQANotFused(Graph& graph) {
   return Status::OK();
 }
 
+static Status CheckMsRotaryEmbeddingGQANotFused(Graph& graph) {
+  const auto op_to_count = CountOpsInGraph(graph);
+  TEST_RETURN_IF_NOT(OpCount(op_to_count, "com.microsoft.RotaryEmbedding") == 2);
+  TEST_RETURN_IF_NOT(OpCount(op_to_count, "MatMul") == 3);
+  TEST_RETURN_IF_NOT(OpCount(op_to_count, "com.microsoft.GroupQueryAttention") == 1);
+
+  for (const Node& node : graph.Nodes()) {
+    if (node.OpType() != "GroupQueryAttention") {
+      continue;
+    }
+
+    TEST_RETURN_IF_NOT(node.InputDefs().size() == 7);
+    const auto& attrs = node.GetAttributes();
+    const auto do_rotary_attr = attrs.find("do_rotary");
+    TEST_RETURN_IF_NOT(do_rotary_attr == attrs.end() || do_rotary_attr->second.i() == 0);
+  }
+
+  return Status::OK();
+}
+
 static Status CheckMsRotaryEmbeddingGQAFused(Graph& graph, int64_t expected_interleaved) {
   const auto op_to_count = CountOpsInGraph(graph);
   TEST_RETURN_IF_NOT(OpCount(op_to_count, "com.microsoft.RotaryEmbedding") == 0);
@@ -1390,7 +1410,7 @@ TEST_F(GraphTransformationTests, GroupQueryAttentionFusionSkipsMismatchedProject
   ASSERT_STATUS_OK(TestGraphTransformer(build_test_case, 23, *logger_,
                                         std::make_unique<GroupQueryAttentionFusion>(),
                                         TransformerLevel::Level2, 3, nullptr,
-                                        CheckOnnxRotaryEmbeddingGQANotFused));
+                                        CheckMsRotaryEmbeddingGQANotFused));
 }
 
 TEST_F(GraphTransformationTests, GroupQueryAttentionFusionSkipsMismatchedScaleShape) {

--- a/onnxruntime/test/optimizer/graph_transform_test_layernorm.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test_layernorm.cc
@@ -952,6 +952,32 @@ static void TestGQAFusion(const std::basic_string<ORTCHAR_T>& file_path, int mat
   ASSERT_TRUE(op_to_count["com.microsoft.GroupQueryAttention"] == 1);
 }
 
+static void TestQuantizedGQAFusionRejectsInitializerShape(const std::string& initializer_name,
+                                                          logging::Logger* logger) {
+  constexpr const ORTCHAR_T* model_uri = MODEL_FOLDER "fusion/gqa_fusion_quantized_simple.onnx";
+  std::shared_ptr<Model> model;
+  ASSERT_STATUS_OK(Model::Load(model_uri, model, nullptr, *logger));
+  Graph& graph = model->MainGraph();
+
+  const TensorProto* initializer = nullptr;
+  ASSERT_TRUE(graph.GetInitializedTensor(initializer_name, initializer));
+  TensorProto malformed_initializer = *initializer;
+  malformed_initializer.clear_dims();
+  malformed_initializer.add_dims(1);
+  graph.RemoveInitializedTensor(initializer_name);
+  graph.AddInitializedTensor(malformed_initializer);
+
+  GraphTransformerManager graph_transformation_mgr{3};
+  ASSERT_STATUS_OK(graph_transformation_mgr.Register(std::make_unique<GroupQueryAttentionFusion>(),
+                                                     TransformerLevel::Level2));
+  ASSERT_STATUS_OK(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, *logger));
+
+  const auto op_to_count = CountOpsInGraph(graph);
+  EXPECT_EQ(op_to_count.at("com.microsoft.MatMulNBits"), 3);
+  EXPECT_EQ(op_to_count.at("com.microsoft.RotaryEmbedding"), 2);
+  EXPECT_EQ(op_to_count.at("com.microsoft.GroupQueryAttention"), 1);
+}
+
 enum class RotaryEmbeddingDomain {
   kOnnx,
   kMS,
@@ -1365,6 +1391,14 @@ TEST_F(GraphTransformationTests, GroupQueryAttentionFusionSkipsMismatchedProject
                                         std::make_unique<GroupQueryAttentionFusion>(),
                                         TransformerLevel::Level2, 3, nullptr,
                                         CheckOnnxRotaryEmbeddingGQANotFused));
+}
+
+TEST_F(GraphTransformationTests, GroupQueryAttentionFusionSkipsMismatchedScaleShape) {
+  TestQuantizedGQAFusionRejectsInitializerShape("scales_q", logger_.get());
+}
+
+TEST_F(GraphTransformationTests, GroupQueryAttentionFusionSkipsMismatchedZeroPointShape) {
+  TestQuantizedGQAFusionRejectsInitializerShape("zero_points_q", logger_.get());
 }
 
 TEST_F(GraphTransformationTests, SkipLayerNormFusionWithCastTest) {

--- a/onnxruntime/test/optimizer/graph_transform_test_layernorm.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test_layernorm.cc
@@ -962,7 +962,8 @@ static void BuildRotaryEmbeddingGQAFusionGraph(ModelTestBuilder& builder,
                                                bool include_position_ids,
                                                int64_t q_interleaved = 0,
                                                int64_t k_interleaved = 0,
-                                               int64_t rotary_embedding_dim = 0) {
+                                               int64_t rotary_embedding_dim = 0,
+                                               int64_t gqa_num_heads = 2) {
   constexpr int64_t batch_size = 1;
   constexpr int64_t sequence_length = 2;
   constexpr int64_t input_hidden_size = 8;
@@ -1047,7 +1048,7 @@ static void BuildRotaryEmbeddingGQAFusionGraph(ModelTestBuilder& builder,
                                seqlens_k, total_sequence_length},
                               {gqa_output},
                               kMSDomain);
-  gqa.AddAttribute("num_heads", num_heads);
+  gqa.AddAttribute("num_heads", gqa_num_heads);
   gqa.AddAttribute("kv_num_heads", kv_num_heads);
 }
 
@@ -1353,6 +1354,17 @@ TEST_F(GraphTransformationTests, GroupQueryAttentionFusionMsRotaryEmbeddingForwa
                                         std::make_unique<GroupQueryAttentionFusion>(),
                                         TransformerLevel::Level2, 3, nullptr,
                                         check_fused_graph));
+}
+
+TEST_F(GraphTransformationTests, GroupQueryAttentionFusionSkipsMismatchedProjectionSizesTest) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    BuildRotaryEmbeddingGQAFusionGraph(builder, RotaryEmbeddingDomain::kMS, true, 0, 0, 0, 3);
+  };
+
+  ASSERT_STATUS_OK(TestGraphTransformer(build_test_case, 23, *logger_,
+                                        std::make_unique<GroupQueryAttentionFusion>(),
+                                        TransformerLevel::Level2, 3, nullptr,
+                                        CheckOnnxRotaryEmbeddingGQANotFused));
 }
 
 TEST_F(GraphTransformationTests, SkipLayerNormFusionWithCastTest) {


### PR DESCRIPTION
This pull request strengthens the validation logic for Group Query Attention (GQA) fusion in ONNX Runtime by adding stricter shape checks for projection tensors and guarding against integer overflows in hidden size calculations. It also introduces a new unit test to ensure that the fusion is skipped when projection tensor shapes do not match the expected configuration.

### Improved validation and error handling:
* Added the `ProjectionTensorShapesMatch` function to verify that the Q, K, and V projection tensor shapes match the expected dimensions based on quantization and head attributes. The fusion is skipped if the shapes do not match. [[1]](diffhunk://#diff-0e6d8470d28199117b315d0bbb3324d532555e0861f8fe088565cc1944450208R257-R280) [[2]](diffhunk://#diff-0e6d8470d28199117b315d0bbb3324d532555e0861f8fe088565cc1944450208L484-R532)
* Added checks to prevent integer overflows when calculating `q_hidden_size`, `kv_hidden_size`, and `output_hidden_size`, ensuring all head attributes are positive and calculations are safe.
* Included `<limits>` for use of `std::numeric_limits` in overflow checks.

### Testing enhancements:
* Added a new test, `GroupQueryAttentionFusionSkipsMismatchedProjectionSizesTest`, to verify that fusion is correctly skipped when projection tensor sizes do not match the head attributes.
* Updated the GQA fusion test builder to allow specifying the number of GQA heads, supporting more flexible test scenarios. [[1]](diffhunk://#diff-7a86cd9c3c03984228cbb6918b82e9dda0f1de51b505dbc25d323cc413d89028L965-R966) [[2]](diffhunk://#diff-7a86cd9c3c03984228cbb6918b82e9dda0f1de51b505dbc25d323cc413d89028L1050-R1051)