### PR TITLE
Fix NodeAttrHelper string default lifetime

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/onnx_ctx_model_helper.cc
+++ b/onnxruntime/core/providers/qnn/builder/onnx_ctx_model_helper.cc
@@ -91,7 +91,8 @@ Status GetEpContextFromMainNode(const onnxruntime::Node& main_context_node,
   NodeAttrHelper node_helper(main_context_node);
   bool is_embed_mode = node_helper.Get(EMBED_MODE, true);
   if (is_embed_mode) {
-    const std::string& context_binary = node_helper.Get(EP_CACHE_CONTEXT, "");
+    static const std::string empty_context_binary;
+    const std::string& context_binary = node_helper.Get(EP_CACHE_CONTEXT, empty_context_binary);
     return qnn_backend_manager->LoadCachedQnnContextFromBuffer(const_cast<char*>(context_binary.c_str()),
                                                                static_cast<uint64_t>(context_binary.length()),
                                                                "",

--- a/onnxruntime/core/providers/qnn/ort_api.cc
+++ b/onnxruntime/core/providers/qnn/ort_api.cc
@@ -102,6 +102,22 @@ const std::string& NodeAttrHelper::Get(const std::string& key, const std::string
   return def_val;
 }
 
+std::string NodeAttrHelper::Get(const std::string& key, std::string&& def_val) const {
+  if (auto entry = node_attributes_.find(key); entry != node_attributes_.end()) {
+    return NODE_ATTR_ITER_VAL(entry).s();
+  }
+
+  return std::move(def_val);
+}
+
+std::string NodeAttrHelper::Get(const std::string& key, const char* def_val) const {
+  if (auto entry = node_attributes_.find(key); entry != node_attributes_.end()) {
+    return NODE_ATTR_ITER_VAL(entry).s();
+  }
+
+  return def_val;
+}
+
 std::vector<std::string> NodeAttrHelper::Get(const std::string& key, const std::vector<std::string>& def_val) const {
   if (auto entry = node_attributes_.find(key); entry != node_attributes_.end()) {
     std::vector<std::string> res;

--- a/onnxruntime/core/providers/qnn/ort_api.h
+++ b/onnxruntime/core/providers/qnn/ort_api.h
@@ -150,7 +150,10 @@ class NodeAttrHelper {
   int64_t Get(const std::string& key, int64_t def_val) const;
   std::vector<int64_t> Get(const std::string& key, const std::vector<int64_t>& def_val) const;
 
+  // Lvalue defaults may be returned by reference; temporary and literal defaults return owned strings.
   const std::string& Get(const std::string& key, const std::string& def_val) const;
+  std::string Get(const std::string& key, std::string&& def_val) const;
+  std::string Get(const std::string& key, const char* def_val) const;
   std::vector<std::string> Get(const std::string& key, const std::vector<std::string>& def_val) const;
 
   // Convert the i() or ints() of the attribute from int64_t to int32_t

--- a/onnxruntime/core/providers/shared/utils/utils.cc
+++ b/onnxruntime/core/providers/shared/utils/utils.cc
@@ -4,6 +4,8 @@
 
 #include "utils.h"
 
+#include <utility>
+
 #include "core/common/safeint.h"
 #include "core/framework/node_unit.h"
 #include "core/framework/tensorprotoutils.h"
@@ -139,6 +141,22 @@ int64_t NodeAttrHelper::Get(const std::string& key, int64_t def_val) const {
 }
 
 const std::string& NodeAttrHelper::Get(const std::string& key, const std::string& def_val) const {
+  if (auto entry = node_attributes_.find(key); entry != node_attributes_.end()) {
+    return entry->second.s();
+  }
+
+  return def_val;
+}
+
+std::string NodeAttrHelper::Get(const std::string& key, std::string&& def_val) const {
+  if (auto entry = node_attributes_.find(key); entry != node_attributes_.end()) {
+    return entry->second.s();
+  }
+
+  return std::move(def_val);
+}
+
+std::string NodeAttrHelper::Get(const std::string& key, const char* def_val) const {
   if (auto entry = node_attributes_.find(key); entry != node_attributes_.end()) {
     return entry->second.s();
   }

--- a/onnxruntime/core/providers/shared/utils/utils.h
+++ b/onnxruntime/core/providers/shared/utils/utils.h
@@ -50,7 +50,10 @@ class NodeAttrHelper {
   int64_t Get(const std::string& key, int64_t def_val) const;
   std::vector<int64_t> Get(const std::string& key, const std::vector<int64_t>& def_val) const;
 
+  // Lvalue defaults may be returned by reference; temporary and literal defaults return owned strings.
   const std::string& Get(const std::string& key, const std::string& def_val) const;
+  std::string Get(const std::string& key, std::string&& def_val) const;
+  std::string Get(const std::string& key, const char* def_val) const;
   std::vector<std::string> Get(const std::string& key, const std::vector<std::string>& def_val) const;
 
   // Convert the i() or ints() of the attribute from int64_t to int32_t

--- a/onnxruntime/core/providers/vsinpu/builders/impl/resize_op_builder.h
+++ b/onnxruntime/core/providers/vsinpu/builders/impl/resize_op_builder.h
@@ -69,7 +69,7 @@ class ResizeOpBuilder : public BaseOpBuilder {
       LOGS_DEFAULT(WARNING) << "Antialias attribute is not supported.";
       return false;
     }
-    auto& cooridinate = helper.Get("coordinate_transoformation_mode", "half_pixel");
+    auto cooridinate = helper.Get("coordinate_transoformation_mode", "half_pixel");
     if (cooridinate != "align_corners" && cooridinate != "half_pixel") {
       LOGS_DEFAULT(WARNING) << "Only support half_pixel and align_corners attributes now.";
       return false;


### PR DESCRIPTION
This pull request enhances the `NodeAttrHelper` utility by adding overloads for retrieving string attributes with different types of default values, improving safety and flexibility when handling attribute lookups. It also updates usages to leverage these new overloads and clarifies ownership semantics for returned strings.

**Node attribute retrieval improvements:**

* Added two new overloads to `NodeAttrHelper::Get` for string attributes: one that accepts an rvalue (`std::string&&`) and one that accepts a C-style string (`const char*`). These overloads return owned strings, ensuring safe return of temporaries or literals. The documentation was updated to clarify that lvalue defaults may be returned by reference, while temporaries and literals are returned as owned strings. (`onnxruntime/core/providers/qnn/ort_api.h` [[1]](diffhunk://#diff-125d3340e34fbe06f276d3161fd4e0c4d95d9350ebfc828126c46d5444f30fa6R153-R156) `onnxruntime/core/providers/shared/utils/utils.h` [[2]](diffhunk://#diff-a5c52f37e0543b71a1adac09c86efa27c3e2220dc471e976cc6d2f302e0cc215R53-R56)
* Implemented the new overloads in both QNN and shared utility implementations of `NodeAttrHelper`. (`onnxruntime/core/providers/qnn/ort_api.cc` [[1]](diffhunk://#diff-248fa3f7ee4456683dd0c16f459f2af7464410682d158604ed221e70d9bb1623R105-R120) `onnxruntime/core/providers/shared/utils/utils.cc` [[2]](diffhunk://#diff-610114cf2945da83d16585d09457c3220b11bfbf494d961d6dd60c38360d59c9R151-R166)
* Included `<utility>` header for `std::move` usage. (`onnxruntime/core/providers/shared/utils/utils.cc` [onnxruntime/core/providers/shared/utils/utils.ccR7-R8](diffhunk://#diff-610114cf2945da83d16585d09457c3220b11bfbf494d961d6dd60c38360d59c9R7-R8))

**Usage updates and bug fixes:**

* Updated code to use the new overloads, such as switching from a reference to a temporary `std::string` for the default value in context binary retrieval, preventing potential dangling reference issues. (`onnxruntime/core/providers/qnn/builder/onnx_ctx_model_helper.cc` [onnxruntime/core/providers/qnn/builder/onnx_ctx_model_helper.ccL94-R95](diffhunk://#diff-5704c965da458a23d9f15a196058ac9ca6afebde41b3c68956fb8f32a049aaffL94-R95))
* Fixed a usage in the VSINPU provider to use an owned string when retrieving the `coordinate_transoformation_mode` attribute, aligning with the new overloads and preventing reference issues. (`onnxruntime/core/providers/vsinpu/builders/impl/resize_op_builder.h` [onnxruntime/core/providers/vsinpu/builders/impl/resize_op_builder.hL72-R72](diffhunk://#diff-5d9e3ac9e2001465c159c39ef2b9a3dd1d69f05663b390d0c128c576615add53L72-R72))