### PR TITLE
Handle empty CPU LpNormalization inputs

### DIFF
--- a/onnxruntime/core/providers/cpu/nn/lp_norm.cc
+++ b/onnxruntime/core/providers/cpu/nn/lp_norm.cc
@@ -83,6 +83,10 @@ Status LpNorm<T>::Compute(OpKernelContext* p_op_kernel_context) const {
   Tensor* output = p_op_kernel_context->Output(0, input_shape);
 
   const auto canonical_axis = HandleNegativeAxis(axis_, static_cast<int64_t>(input_shape.NumDimensions()));
+  if (input_shape.Size() == 0) {
+    return Status::OK();
+  }
+
   const int64_t m = input_shape.GetDims()[onnxruntime::narrow<size_t>(canonical_axis)];
   const int64_t n = input_shape.Size() / m;
   const int64_t sf = input_shape.SizeFromDimension(SafeInt<size_t>(canonical_axis) + 1);

--- a/onnxruntime/test/providers/cpu/nn/lp_norm_op_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/lp_norm_op_test.cc
@@ -76,6 +76,27 @@ TEST(LpNormalizationTest, L2Normalization) {
 }
 
 template <typename T>
+void LpNormalizationZeroExtentAxis(int64_t p) {
+  OpTester test("LpNormalization");
+  test.AddAttribute("axis", static_cast<int64_t>(1));
+  test.AddAttribute("p", p);
+  const vector<int64_t> dims = {2, 0, 3};
+  test.AddInput<T>("input", dims, {});
+  test.AddOutput<T>("Y", dims, {});
+
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(DefaultCpuExecutionProvider());
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+}
+
+TEST(LpNormalizationTest, ZeroExtentAxis) {
+  LpNormalizationZeroExtentAxis<float>(1);
+  LpNormalizationZeroExtentAxis<float>(2);
+  LpNormalizationZeroExtentAxis<double>(1);
+  LpNormalizationZeroExtentAxis<double>(2);
+}
+
+template <typename T>
 void LpNormalizationDefaultAxisAndP() {
   OpTester test("LpNormalization");
   vector<T> input = {


### PR DESCRIPTION
This pull request adds handling and tests for cases where the `LpNormalization` operator receives input tensors with zero elements along the normalization axis. The main changes include an early return in the implementation to avoid unnecessary computation and a new test to verify correct behavior for zero-extent axes.

**LpNormalization operator improvements:**

* Added an early return in `LpNorm<T>::Compute` to immediately return success when the input tensor has zero elements, preventing unnecessary computation for empty inputs.

**Testing enhancements:**

* Introduced the `LpNormalizationZeroExtentAxis` test, which checks that the operator correctly handles input tensors with a zero-extent axis for both `p=1` and `p=2`, and for both `float` and `double` types.