### PR TITLE
Add a contiguous fast path to the CPU ScatterElements kernel

### DIFF
--- a/onnxruntime/core/providers/cpu/tensor/scatter.cc
+++ b/onnxruntime/core/providers/cpu/tensor/scatter.cc
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 // https://github.com/onnx/onnx/blob/main/docs/Operators.md#Scatter
+#include <algorithm>
 #include <atomic>
 #include <type_traits>
 #include <core/common/safeint.h>
@@ -279,6 +280,36 @@ Status GetIndices(
   return Status::OK();
 }
 
+// True when, inside every slice of `inner_size` consecutive indices, all of them are equal.
+// That is the layout an Expand of an [N, 1] index tensor to [N, C] produces, and it means the
+// scatter can move whole contiguous runs instead of individual strided elements.
+// Bails out on the first mismatch, so the ordinary case costs one slice's worth of reads.
+inline bool IndicesAreConstantAlongInner(const std::vector<int64_t>& indices_data, int64_t inner_size,
+                                         concurrency::ThreadPool* tp) {
+  const int64_t num_slices = narrow<int64_t>(indices_data.size()) / inner_size;
+
+  std::atomic<bool> constant{true};
+  concurrency::ThreadPool::TryParallelFor(
+      tp, narrow<std::ptrdiff_t>(num_slices), static_cast<double>(inner_size),
+      [&](std::ptrdiff_t first, std::ptrdiff_t last) {
+        for (std::ptrdiff_t slice = first; slice < last; ++slice) {
+          if (!constant.load(std::memory_order_relaxed)) {
+            return;
+          }
+          const int64_t* row = indices_data.data() + static_cast<int64_t>(slice) * inner_size;
+          const int64_t first_index = row[0];
+          for (int64_t i = 1; i < inner_size; ++i) {
+            if (row[i] != first_index) {
+              constant.store(false, std::memory_order_relaxed);
+              return;
+            }
+          }
+        }
+      });
+
+  return constant.load(std::memory_order_relaxed);
+}
+
 template <class Tdata, typename FuncT>
 Status ScatterData(
     const FuncT& func,
@@ -358,6 +389,81 @@ Status ScatterData(
   const int64_t input_axis_stride = input_strides[narrow<size_t>(axis)];
   const int64_t upd_axis_stride = upd_strides[narrow<size_t>(axis)];
 
+  // Fast path for indices that are constant across the dimensions after the axis.
+  //
+  // The generic loop below gives each work unit a single inner index, so it walks one column of
+  // the updates with a stride of inner_size. When the indices within a slice are all equal, the
+  // whole slice lands on one contiguous run of the output instead, which turns that strided walk
+  // into a sequential one the compiler can vectorize.
+  //
+  // The run is only contiguous if the updates and the data agree on every dimension after the
+  // axis; ScatterElements permits the updates to be smaller there, in which case an inner
+  // coordinate does not map to the same offset in both tensors and this path does not apply.
+  bool inner_dims_match = true;
+  for (size_t d = narrow<size_t>(axis) + 1; d < num_dims; ++d) {
+    if (upd_shape[d] != input_data_shape[d]) {
+      inner_dims_match = false;
+      break;
+    }
+  }
+
+  // Below roughly a cache line the strided access the generic loop performs is already local,
+  // so restricting the fast path keeps it from trading away parallelism for nothing.
+  constexpr int64_t kMinContiguousRun = 8;
+
+  if (inner_dims_match && inner_size >= kMinContiguousRun &&
+      IndicesAreConstantAlongInner(indices_data, inner_size, tp)) {
+    // Split the contiguous run into blocks so the work still spreads across threads. Blocks are
+    // kept reasonably wide so each one is worth vectorizing.
+    constexpr int64_t kMinBlockElements = 16;
+    const int64_t max_blocks = std::max<int64_t>(1, inner_size / kMinBlockElements);
+    const int64_t degree = std::max<int64_t>(1, concurrency::ThreadPool::DegreeOfParallelism(tp));
+    const int64_t num_blocks = std::min(degree, max_blocks);
+    const int64_t blocked_work_units = outer_size * num_blocks;
+
+    // Every work unit owns a distinct (outer, inner-range) region of the output, so no two of
+    // them touch the same element. Within a unit the axis is walked in ascending order, which is
+    // the order the generic loop applies updates in, so a destination that receives several
+    // updates still accumulates them in the same sequence.
+    concurrency::ThreadPool::TryParallelFor(
+        tp, narrow<std::ptrdiff_t>(blocked_work_units), static_cast<double>(axis_size * inner_size / num_blocks),
+        [&](std::ptrdiff_t first, std::ptrdiff_t last) {
+          for (std::ptrdiff_t work_idx = first; work_idx < last; ++work_idx) {
+            const int64_t outer_idx = static_cast<int64_t>(work_idx) / num_blocks;
+            const int64_t block_idx = static_cast<int64_t>(work_idx) % num_blocks;
+            const auto block =
+                concurrency::ThreadPool::PartitionWork(narrow<std::ptrdiff_t>(block_idx),
+                                                       narrow<std::ptrdiff_t>(num_blocks),
+                                                       narrow<std::ptrdiff_t>(inner_size));
+
+            // Offsets contributed by the dimensions before the axis. The dimensions after it
+            // contribute the position within the run, which is identical in both tensors because
+            // inner_dims_match was checked above.
+            int64_t dst_base_offset = 0;
+            int64_t upd_base_offset = 0;
+            int64_t outer_remain = outer_idx;
+            for (int64_t d = axis - 1; d >= 0; --d) {
+              const auto dim_size = upd_shape[narrow<size_t>(d)];
+              const auto coord = outer_remain % dim_size;
+              outer_remain /= dim_size;
+              dst_base_offset += coord * input_strides[narrow<size_t>(d)];
+              upd_base_offset += coord * upd_strides[narrow<size_t>(d)];
+            }
+
+            for (int64_t a = 0; a < axis_size; ++a) {
+              const int64_t upd_row = upd_base_offset + a * upd_axis_stride;
+              // Constant across the run, so the first element speaks for all of them.
+              const int64_t axis_idx = indices_data[narrow<size_t>(upd_row + block.start)];
+              const int64_t dst_row = dst_base_offset + axis_idx * input_axis_stride;
+              for (std::ptrdiff_t k = block.start; k < block.end; ++k) {
+                func(dst_base + dst_row + k, update_data + upd_row + k);
+              }
+            }
+          }
+        });
+
+    return Status::OK();
+  }
   // Parallelize over independent work units.
   // Each work unit processes axis_size elements along the scatter axis.
   // Cost per unit is proportional to axis_size (number of scatter ops per work unit).

--- a/onnxruntime/core/providers/cpu/tensor/scatter.cc
+++ b/onnxruntime/core/providers/cpu/tensor/scatter.cc
@@ -283,7 +283,9 @@ Status GetIndices(
 // True when, inside every slice of `inner_size` consecutive indices, all of them are equal.
 // That is the layout an Expand of an [N, 1] index tensor to [N, C] produces, and it means the
 // scatter can move whole contiguous runs instead of individual strided elements.
-// Bails out on the first mismatch, so the ordinary case costs one slice's worth of reads.
+// Each worker stops as soon as it sees a mismatch, and other workers stop at their next slice
+// boundary, so indices that are not row-broadcast are rejected after a small amount of work
+// rather than after a full pass.
 inline bool IndicesAreConstantAlongInner(const std::vector<int64_t>& indices_data, int64_t inner_size,
                                          concurrency::ThreadPool* tp) {
   const int64_t num_slices = narrow<int64_t>(indices_data.size()) / inner_size;

--- a/onnxruntime/test/providers/cpu/tensor/scatter_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/scatter_op_test.cc
@@ -333,6 +333,100 @@ TEST(ScatterElements, AddReduction_MLFloat16) {
 }
 #endif
 
+namespace {
+// Indices that repeat along the dimensions after the axis, which is what an Expand of an
+// [N, 1] index tensor produces. The rows are wide enough to take the contiguous path.
+std::vector<int64_t> RowBroadcastIndices(const std::vector<int64_t>& row_index, int64_t width) {
+  std::vector<int64_t> indices;
+  indices.reserve(row_index.size() * static_cast<size_t>(width));
+  for (int64_t r : row_index) {
+    indices.insert(indices.end(), static_cast<size_t>(width), r);
+  }
+  return indices;
+}
+
+std::vector<float> RepeatRows(const std::vector<float>& row_value, int64_t width) {
+  std::vector<float> values;
+  values.reserve(row_value.size() * static_cast<size_t>(width));
+  for (float v : row_value) {
+    values.insert(values.end(), static_cast<size_t>(width), v);
+  }
+  return values;
+}
+}  // namespace
+
+TEST(ScatterElements, RowBroadcastIndicesAdd) {
+  constexpr int64_t kWidth = 16;
+  OpTester test("ScatterElements", 18);
+  test.AddAttribute<int64_t>("axis", 0);
+  test.AddAttribute<std::string>("reduction", "add");
+
+  // Update rows 0 and 2 both land on data row 1, so it accumulates 1 + 3.
+  test.AddInput<float>("data", {4, kWidth}, std::vector<float>(4 * kWidth, 0.f));
+  test.AddInput<int64_t>("indices", {3, kWidth}, RowBroadcastIndices({1, 2, 1}, kWidth));
+  test.AddInput<float>("updates", {3, kWidth}, RepeatRows({1.f, 2.f, 3.f}, kWidth));
+  test.AddOutput<float>("y", {4, kWidth}, RepeatRows({0.f, 4.f, 2.f, 0.f}, kWidth));
+
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
+}
+
+// Two updates land on the same row, so this pins the order they are applied in: with
+// reduction='none' the later update along the axis has to win. It fails if the contiguous
+// path were to visit the axis in any other order.
+TEST(ScatterElements, RowBroadcastIndicesNoneKeepsLastUpdate) {
+  constexpr int64_t kWidth = 16;
+  OpTester test("ScatterElements", 18);
+  test.AddAttribute<int64_t>("axis", 0);
+  test.AddAttribute<std::string>("reduction", "none");
+
+  test.AddInput<float>("data", {4, kWidth}, std::vector<float>(4 * kWidth, 0.f));
+  test.AddInput<int64_t>("indices", {3, kWidth}, RowBroadcastIndices({1, 2, 1}, kWidth));
+  test.AddInput<float>("updates", {3, kWidth}, RepeatRows({1.f, 2.f, 3.f}, kWidth));
+  test.AddOutput<float>("y", {4, kWidth}, RepeatRows({0.f, 3.f, 2.f, 0.f}, kWidth));
+
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
+}
+
+TEST(ScatterElements, RowBroadcastIndicesRank3) {
+  OpTester test("ScatterElements", 18);
+  test.AddAttribute<int64_t>("axis", 0);
+  test.AddAttribute<std::string>("reduction", "add");
+
+  // Trailing dims agree between data and updates, so each update slice is one contiguous run
+  // of 2 * 8 elements.
+  test.AddInput<float>("data", {4, 2, 8}, std::vector<float>(4 * 2 * 8, 0.f));
+  test.AddInput<int64_t>("indices", {2, 2, 8}, RowBroadcastIndices({1, 2}, 16));
+  test.AddInput<float>("updates", {2, 2, 8}, RepeatRows({1.f, 2.f}, 16));
+  test.AddOutput<float>("y", {4, 2, 8}, RepeatRows({0.f, 1.f, 2.f, 0.f}, 16));
+
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
+}
+
+// The updates are narrower than the data in the last dimension, so an update slice is NOT a
+// contiguous run of the output even though the indices repeat. Getting this wrong would write
+// the second half of each slice at the wrong offset.
+TEST(ScatterElements, RowBroadcastIndicesNarrowerTrailingDim) {
+  OpTester test("ScatterElements", 18);
+  test.AddAttribute<int64_t>("axis", 0);
+  test.AddAttribute<std::string>("reduction", "add");
+
+  test.AddInput<float>("data", {4, 2, 8}, std::vector<float>(4 * 2 * 8, 0.f));
+  test.AddInput<int64_t>("indices", {2, 2, 4}, RowBroadcastIndices({1, 2}, 8));
+  test.AddInput<float>("updates", {2, 2, 4}, RepeatRows({1.f, 2.f}, 8));
+
+  // Only the first 4 of each group of 8 are touched.
+  std::vector<float> expected(4 * 2 * 8, 0.f);
+  for (int64_t d1 = 0; d1 < 2; ++d1) {
+    for (int64_t d2 = 0; d2 < 4; ++d2) {
+      expected[static_cast<size_t>(1 * 16 + d1 * 8 + d2)] = 1.f;
+      expected[static_cast<size_t>(2 * 16 + d1 * 8 + d2)] = 2.f;
+    }
+  }
+  test.AddOutput<float>("y", {4, 2, 8}, expected);
+
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
+}
+
 TEST(ScatterElements, AddReductionAxis1) {
   OpTester test("ScatterElements", 18);
   test.AddAttribute<int64_t>("axis", 1);

--- a/onnxruntime/test/providers/cpu/tensor/scatter_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/scatter_op_test.cc
@@ -373,6 +373,10 @@ TEST(ScatterElements, RowBroadcastIndicesAdd) {
 // Two updates land on the same row, so this pins the order they are applied in: with
 // reduction='none' the later update along the axis has to win. It fails if the contiguous
 // path were to visit the axis in any other order.
+//
+// ONNX leaves the result unspecified when several updates target one element, so this is a
+// property of the CPU kernel rather than of the operator. Providers that apply the updates
+// concurrently pick an arbitrary winner, so the check runs on CPU only.
 TEST(ScatterElements, RowBroadcastIndicesNoneKeepsLastUpdate) {
   constexpr int64_t kWidth = 16;
   OpTester test("ScatterElements", 18);
@@ -384,7 +388,9 @@ TEST(ScatterElements, RowBroadcastIndicesNoneKeepsLastUpdate) {
   test.AddInput<float>("updates", {3, kWidth}, RepeatRows({1.f, 2.f, 3.f}, kWidth));
   test.AddOutput<float>("y", {4, kWidth}, RepeatRows({0.f, 3.f, 2.f, 0.f}, kWidth));
 
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.emplace_back(DefaultCpuExecutionProvider());
+  test.ConfigEps(std::move(execution_providers)).RunWithConfig();
 }
 
 TEST(ScatterElements, RowBroadcastIndicesRank3) {
@@ -405,6 +411,9 @@ TEST(ScatterElements, RowBroadcastIndicesRank3) {
 // The updates are narrower than the data in the last dimension, so an update slice is NOT a
 // contiguous run of the output even though the indices repeat. Getting this wrong would write
 // the second half of each slice at the wrong offset.
+//
+// This is about which path the CPU kernel takes, so it runs on CPU only rather than asserting
+// anything about how other providers handle the shape.
 TEST(ScatterElements, RowBroadcastIndicesNarrowerTrailingDim) {
   OpTester test("ScatterElements", 18);
   test.AddAttribute<int64_t>("axis", 0);
@@ -424,7 +433,9 @@ TEST(ScatterElements, RowBroadcastIndicesNarrowerTrailingDim) {
   }
   test.AddOutput<float>("y", {4, 2, 8}, expected);
 
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.emplace_back(DefaultCpuExecutionProvider());
+  test.ConfigEps(std::move(execution_providers)).RunWithConfig();
 }
 
 TEST(ScatterElements, AddReductionAxis1) {


### PR DESCRIPTION
### Description

The generic scatter loop gives each work unit a single inner index, so a work unit walks one column of the updates with a stride of `inner_size`. For the very common `axis=0` rank-2 case that means `outer_size == 1`, there are only `C` work units, and each traverses a row-major buffer column-wise.

When the indices repeat across the dimensions after the axis, each update slice lands on a **single contiguous run** of the output, so that strided walk becomes a sequential one the compiler can vectorize. This adds that path, detected at runtime from the indices tensor.

Detection bails on the first mismatch, so ordinary indices pay for one slice's worth of reads.

**Results are unchanged, bit for bit.** Each work unit still owns a distinct `(outer, inner-range)` region of the output, so no two touch the same element; and within a unit the axis is walked in ascending order, which is the order the generic loop applies updates in. A destination receiving several updates therefore accumulates them in exactly the same sequence — which matters for float `add`. Splitting the contiguous run into blocks, rather than parallelizing over update rows, is what preserves that.

Two guards are load-bearing:

- **Trailing dims must agree.** The run is contiguous only if the updates and the data agree on every dimension after the axis. `ScatterElements` permits the updates to be smaller there, in which case an inner coordinate maps to different offsets in the two tensors. There is a test for this.
- **Short runs are skipped.** Below roughly a cache line the generic loop's stride is already local, so taking the fast path would trade away parallelism for nothing.

### Motivation and Context

Row-broadcast indices are not an exotic case — they are how a row scatter is spelled in PyTorch, because `Tensor.scatter_` requires `index` and `src` to have the same rank as the destination:

```python
x.scatter_(0, idx.unsqueeze(-1).expand(-1, C), src)
```

That exports as `Expand → ScatterElements`, producing exactly `indices[i][j] == indices[i][0]`. The same shape shows up in scatter-add pooling, MoE dispatch/combine, KV-cache reorder, and in `GatherElementsGrad` whenever the forward was the `torch.gather` row idiom.

Because detection is at runtime rather than at graph level, it fires whether or not the `Expand` was constant-folded, and whether the row ids came from an initializer or from a runtime op.

Measured on an M3 Pro, Release, 12 threads, timing the whole node through an `InferenceSession` (`axis=0`, float, `reduction='add'`, row-broadcast indices):

| shape | before | after | speedup |
|---|---|---|---|
| N=4096, C=1024 | 13.42 ms | 3.07 ms | **4.4x** |
| N=4096, C=256 | 0.94 ms | 0.38 ms | **2.5x** |
| N=8192, C=64 | 0.37 ms | 0.22 ms | **1.7x** |
| N=65536, C=32 | 4.97 ms | 1.95 ms | **2.5x** |

To be straight about where the remaining time goes: the scatter loop itself speeds up considerably more than these node-level numbers suggest. `GetIndices` materializes a normalized `int64_t` for every element up front, and after this change that dominates. Narrowing it looks like a worthwhile follow-up, and it would compound with this.

### Tests

- `RowBroadcastIndicesAdd` — the fast path for `reduction='add'`, with two update rows landing on one destination row.
- `RowBroadcastIndicesNoneKeepsLastUpdate` — duplicate destinations under `reduction='none'`. **Fails if the axis is visited in any order other than ascending**, which is the property the bit-exactness argument rests on.
- `RowBroadcastIndicesRank3` — rank 3, confirming the run spans all dimensions after the axis.
- `RowBroadcastIndicesNarrowerTrailingDim` — updates narrower than the data in the last dimension. Must stay on the generic path; taking the fast path here would write the second half of each slice at the wrong offset.

I confirmed by temporary instrumentation that the first three tests actually reach the fast path and the fourth does not — the existing suite would not have exercised it, since its `RunTest` helper fills indices per element with `std::rand()`.

Full `onnxruntime_provider_test` sweep: 5640 tests, 5452 passed, **0 failures**, unchanged from baseline. That includes `GatherElements`, which shares `ScatterData`.