### PR TITLE
Expose ORT C API from the Python extension

### DIFF
--- a/onnxruntime/python/pybind.def
+++ b/onnxruntime/python/pybind.def
@@ -1,3 +1,4 @@
 LIBRARY "onnxruntime_pybind11_state.pyd"
 EXPORTS
  PyInit_onnxruntime_pybind11_state @1
+ OrtGetApiBase @2

--- a/onnxruntime/test/python/onnxruntime_test_python.py
+++ b/onnxruntime/test/python/onnxruntime_test_python.py
@@ -18,6 +18,7 @@ import numpy as np
 from helper import get_name
 
 import onnxruntime as onnxrt
+import onnxruntime.capi.onnxruntime_pybind11_state as ort_state
 from onnxruntime.capi import _pybind_state as C
 from onnxruntime.capi.onnxruntime_pybind11_state import Fail, OrtValueVector, RunOptions
 
@@ -112,6 +113,13 @@ class TestInferenceSession(unittest.TestCase):
     def test_get_build_info(self):
         self.assertIsNot(onnxrt.get_build_info(), None)
         self.assertIn("Build Info", onnxrt.get_build_info())
+
+    @unittest.skipUnless(sys.platform == "win32", "Windows DLL export test")
+    def test_get_api_base_export(self):
+        module = ctypes.WinDLL(ort_state.__file__)
+        get_api_base = module.OrtGetApiBase
+        get_api_base.restype = ctypes.c_void_p
+        self.assertTrue(get_api_base())
 
     def test_model_serialization(self):
         try:


### PR DESCRIPTION
## Summary
- export `OrtGetApiBase` from `onnxruntime_pybind11_state.pyd`
- keep Python and native consumers in one process on the same statically linked ORT instance
- add a Windows test that calls the exported API base

## Validation
- production ARM64 CPython 3.14 wheel built from ORT v1.28.0
- staged and final-wheel exports have a concrete, non-forwarded RVA
- provider registration and unregister are visible across independent `OrtEnv` handles

## Related draft PRs
- Infra packaging: https://dev.azure.com/WSSI/COMPUTE/_git/WCR.Infra.Production/pullrequest/13209
- Windows ML integration: https://dev.azure.com/microsoft/ProjectOxford/_git/windows-ml/pullrequest/16467219