### PR TITLE
Check for a null output tensor in the CPU Split kernel

### DIFF
--- a/onnxruntime/core/providers/cpu/tensor/split.cc
+++ b/onnxruntime/core/providers/cpu/tensor/split.cc
@@ -106,6 +106,7 @@ Status SplitImpl::Compute(OpKernelContext* context) const {
     output_dimensions[narrow<size_t>(axis)] = split_size;
 
     Tensor* output = context->Output(i, TensorShape{output_dimensions});
+    ORT_RETURN_IF(output == nullptr, "Split: output ", i, " is not available");
     const auto output_strides = StridesForTensor(*output);
 
     ORT_RETURN_IF_ERROR(DispatchStridedCopy<EnabledSplitDataTypes>(context->GetOperatorThreadPool(),


### PR DESCRIPTION
`SplitImpl::Compute` takes the `Tensor*` from `OpKernelContext::Output()` and passes it straight to `StridesForTensor`:

```cpp
Tensor* output = context->Output(i, TensorShape{output_dimensions});
const auto output_strides = StridesForTensor(*output);
```

`Output()` can return `nullptr`, and `StridesForTensor` (`core/framework/copy.cc:10`) calls `tensor.Shape()` immediately, so the process faults reading the shape's span rather than returning an error.

Adds the same `ORT_RETURN_IF` guard the surrounding code already uses for other failure paths:

```cpp
ORT_RETURN_IF(output == nullptr, "Split: output ", i, " is not available");
```

I found this with a fuzzer running crafted ONNX models through session run. The 88-byte model is attached if it is useful for a test; I did not add it as a fixture because I was not sure whether you prefer generated models or checked-in binaries in `onnxruntime/test/`.

Happy to add a unit test in `split_op_test.cc` if you would rather have one, though I could not find an existing pattern for provoking a null `Output()` from the OpTester harness, which is why the check is defensive rather than test-driven.

### Checked

- Rebuilt `onnxruntime_providers` and re-ran the reproducer: no longer faults, returns a status instead.
- Ran 300 valid ONNX models from my corpus before and after: identical results, no behaviour change.

### Related

`split.cc` has had similar hardening recently, #31149 for the negative axis case. This is the same shape of fix for the output pointer.