### PR TITLE
Validate CUDA QDQ element counts

### DIFF
--- a/onnxruntime/core/providers/cuda/tensor/quantize_linear.cc
+++ b/onnxruntime/core/providers/cuda/tensor/quantize_linear.cc
@@ -190,10 +190,11 @@ Status QuantizeLinear<T, U>::ComputeInternal(OpKernelContext* ctx) const {
   auto& y_scale = *ctx->Input<Tensor>(1);
   auto* y_zero_point = ctx->Input<Tensor>(2);
 
-  auto& y = *ctx->Output(0, x.Shape());
-
   const auto& x_shape = x.Shape();
   const auto num_of_elements = x_shape.Size();
+  ORT_RETURN_IF_ERROR(ValidateQDQElementCount(num_of_elements));
+
+  auto& y = *ctx->Output(0, x_shape);
 
   const CudaU* input = reinterpret_cast<const CudaU*>(x.Data<U>());
   T* output = y.MutableData<T>();
@@ -407,6 +408,7 @@ Status DequantizeLinear<T, U>::ComputeInternal(OpKernelContext* ctx) const {
 
   const auto& x_shape = x.Shape();
   const auto num_of_elements = x_shape.Size();
+  ORT_RETURN_IF_ERROR(ValidateQDQElementCount(num_of_elements));
 
   auto& y = *ctx->Output(0, x_shape);
 

--- a/onnxruntime/core/providers/cuda/tensor/quantize_linear.cc
+++ b/onnxruntime/core/providers/cuda/tensor/quantize_linear.cc
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include "quantize_linear.h"
+#include "quantize_linear_common.h"
 #include "quantize_linear.cuh"
 
 namespace onnxruntime {
@@ -192,7 +193,7 @@ Status QuantizeLinear<T, U>::ComputeInternal(OpKernelContext* ctx) const {
 
   const auto& x_shape = x.Shape();
   const auto num_of_elements = x_shape.Size();
-  ORT_RETURN_IF_ERROR(ValidateQDQElementCount(num_of_elements));
+  ORT_RETURN_IF_NOT(IsQDQElementCountSupported(num_of_elements), QDQElementCountErrorMessage());
 
   auto& y = *ctx->Output(0, x_shape);
 
@@ -408,7 +409,7 @@ Status DequantizeLinear<T, U>::ComputeInternal(OpKernelContext* ctx) const {
 
   const auto& x_shape = x.Shape();
   const auto num_of_elements = x_shape.Size();
-  ORT_RETURN_IF_ERROR(ValidateQDQElementCount(num_of_elements));
+  ORT_RETURN_IF_NOT(IsQDQElementCountSupported(num_of_elements), QDQElementCountErrorMessage());
 
   auto& y = *ctx->Output(0, x_shape);
 

--- a/onnxruntime/core/providers/cuda/tensor/quantize_linear.h
+++ b/onnxruntime/core/providers/cuda/tensor/quantize_linear.h
@@ -3,11 +3,19 @@
 
 #pragma once
 
+#include <limits>
+
 #include "core/providers/shared_library/provider_api.h"
 #include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {
 namespace cuda {
+
+inline Status ValidateQDQElementCount(size_t element_count) {
+  ORT_RETURN_IF(element_count > static_cast<size_t>(std::numeric_limits<int32_t>::max()),
+                "CUDA QuantizeLinear and DequantizeLinear support at most INT32_MAX elements.");
+  return Status::OK();
+}
 
 template <class T, class U>
 class QuantizeLinear final : public CudaKernel {

--- a/onnxruntime/core/providers/cuda/tensor/quantize_linear.h
+++ b/onnxruntime/core/providers/cuda/tensor/quantize_linear.h
@@ -3,19 +3,11 @@
 
 #pragma once
 
-#include <limits>
-
 #include "core/providers/shared_library/provider_api.h"
 #include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime {
 namespace cuda {
-
-inline Status ValidateQDQElementCount(size_t element_count) {
-  ORT_RETURN_IF(element_count > static_cast<size_t>(std::numeric_limits<int32_t>::max()),
-                "CUDA QuantizeLinear and DequantizeLinear support at most INT32_MAX elements.");
-  return Status::OK();
-}
 
 template <class T, class U>
 class QuantizeLinear final : public CudaKernel {

--- a/onnxruntime/core/providers/cuda/tensor/quantize_linear_common.h
+++ b/onnxruntime/core/providers/cuda/tensor/quantize_linear_common.h
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <cstdint>
+#include <limits>
+#include <string>
+
+namespace onnxruntime::cuda {
+
+constexpr int64_t kQDQMaxElementCount = std::numeric_limits<int32_t>::max();
+
+constexpr bool IsQDQElementCountSupported(int64_t element_count) {
+  return element_count >= 0 && element_count <= kQDQMaxElementCount;
+}
+
+inline std::string QDQElementCountErrorMessage() {
+  return "CUDA QuantizeLinear and DequantizeLinear support at most INT32_MAX elements.";
+}
+
+}  // namespace onnxruntime::cuda

--- a/onnxruntime/test/providers/cpu/tensor/quantize_linear_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/quantize_linear_test.cc
@@ -12,7 +12,7 @@
 #include "core/session/onnxruntime_session_options_config_keys.h"
 
 #ifdef USE_CUDA
-#include "core/providers/cuda/tensor/quantize_linear.h"
+#include "core/providers/cuda/tensor/quantize_linear_common.h"
 #endif
 
 namespace onnxruntime {
@@ -20,8 +20,11 @@ namespace test {
 
 #ifdef USE_CUDA
 TEST(QuantizeLinearOpTest, CudaElementCountRange) {
-  EXPECT_STATUS_OK(cuda::ValidateQDQElementCount(static_cast<size_t>(std::numeric_limits<int32_t>::max())));
-  EXPECT_FALSE(cuda::ValidateQDQElementCount(static_cast<size_t>(std::numeric_limits<int32_t>::max()) + 1).IsOK());
+  EXPECT_TRUE(cuda::IsQDQElementCountSupported(0));
+  EXPECT_TRUE(cuda::IsQDQElementCountSupported(std::numeric_limits<int32_t>::max()));
+  EXPECT_FALSE(cuda::IsQDQElementCountSupported(static_cast<int64_t>(std::numeric_limits<int32_t>::max()) + 1));
+  EXPECT_FALSE(cuda::IsQDQElementCountSupported(-1));
+  EXPECT_NE(cuda::QDQElementCountErrorMessage().find("INT32_MAX"), std::string::npos);
 }
 
 static void RunQDQOp25CudaOnly(OpTester& test) {

--- a/onnxruntime/test/providers/cpu/tensor/quantize_linear_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/quantize_linear_test.cc
@@ -9,10 +9,19 @@
 #include "core/framework/int2.h"
 #include "core/session/onnxruntime_session_options_config_keys.h"
 
+#ifdef USE_CUDA
+#include "core/providers/cuda/tensor/quantize_linear.h"
+#endif
+
 namespace onnxruntime {
 namespace test {
 
 #ifdef USE_CUDA
+TEST(QuantizeLinearOpTest, CudaElementCountRange) {
+  EXPECT_STATUS_OK(cuda::ValidateQDQElementCount(static_cast<size_t>(std::numeric_limits<int32_t>::max())));
+  EXPECT_FALSE(cuda::ValidateQDQElementCount(static_cast<size_t>(std::numeric_limits<int32_t>::max()) + 1).IsOK());
+}
+
 static void RunQDQOp25CudaOnly(OpTester& test) {
   auto cuda_ep = DefaultCudaExecutionProvider();
   if (cuda_ep == nullptr) {

--- a/onnxruntime/test/providers/cpu/tensor/quantize_linear_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/quantize_linear_test.cc
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <limits>
+
 #include "gtest/gtest.h"
 #include "test/common/cuda_op_test_utils.h"
 #include "test/providers/provider_test_utils.h"


### PR DESCRIPTION
This pull request introduces an element count validation for CUDA `QuantizeLinear` and `DequantizeLinear` operators to ensure they do not process more than `INT32_MAX` elements, preventing potential overflows and undefined behavior. It also adds corresponding unit tests to verify this constraint.

**Element Count Validation:**

* Added a new function `ValidateQDQElementCount` in `quantize_linear.h` to check that the number of elements does not exceed `INT32_MAX`, returning an error if the limit is exceeded.
* Integrated `ValidateQDQElementCount` into both `QuantizeLinear<T, U>::ComputeInternal` and `DequantizeLinear<T, U>::ComputeInternal` to enforce the element count constraint during operator execution. [[1]](diffhunk://#diff-2fc9bd2dcb3b392eb85409ae26189d0a290ba6d8261cbeda4a92f83434b113c2L193-R197) [[2]](diffhunk://#diff-2fc9bd2dcb3b392eb85409ae26189d0a290ba6d8261cbeda4a92f83434b113c2R411)

**Testing:**

* Added a unit test `CudaElementCountRange` in `quantize_linear_test.cc` to confirm that `ValidateQDQElementCount` accepts the maximum allowed value and rejects values above the limit.