### PR TITLE
Validate CUDA GatherElements count

### DIFF
--- a/onnxruntime/core/providers/cuda/tensor/gather_elements.cc
+++ b/onnxruntime/core/providers/cuda/tensor/gather_elements.cc
@@ -162,6 +162,7 @@ Status GatherElements::ComputeInternal(OpKernelContext* context) const {
   // Validate input shapes and ranks (invoke the static method in the CPU GatherElements kernel that hosts the shared
   // checks)
   ORT_RETURN_IF_ERROR(onnxruntime::GatherElements::ValidateInputShapes(input_shape, indices_shape, axis));
+  ORT_RETURN_IF_ERROR(ValidateGatherElementsElementCount(indices_size));
 
   // create output tensor
   auto* output_tensor = context->Output(0, indices_shape);

--- a/onnxruntime/core/providers/cuda/tensor/gather_elements.cc
+++ b/onnxruntime/core/providers/cuda/tensor/gather_elements.cc
@@ -3,6 +3,7 @@
 
 #include "core/providers/cuda/tensor/gather_elements.h"
 
+#include "core/providers/cuda/tensor/gather_elements_common.h"
 #include "core/providers/cuda/tensor/gather_elements_impl.h"
 #include "core/providers/cpu/tensor/utils.h"
 
@@ -162,7 +163,8 @@ Status GatherElements::ComputeInternal(OpKernelContext* context) const {
   // Validate input shapes and ranks (invoke the static method in the CPU GatherElements kernel that hosts the shared
   // checks)
   ORT_RETURN_IF_ERROR(onnxruntime::GatherElements::ValidateInputShapes(input_shape, indices_shape, axis));
-  ORT_RETURN_IF_ERROR(ValidateGatherElementsElementCount(indices_size));
+  ORT_RETURN_IF_NOT(IsGatherElementsElementCountSupported(indices_size),
+                    GatherElementsElementCountErrorMessage(indices_size));
 
   // create output tensor
   auto* output_tensor = context->Output(0, indices_shape);

--- a/onnxruntime/core/providers/cuda/tensor/gather_elements.h
+++ b/onnxruntime/core/providers/cuda/tensor/gather_elements.h
@@ -13,8 +13,10 @@ namespace cuda {
 struct GatherScatterElementsArgs;
 
 inline Status ValidateGatherElementsElementCount(int64_t element_count) {
-  ORT_RETURN_IF(element_count < 0 || element_count > std::numeric_limits<int32_t>::max(),
-                "CUDA GatherElements supports at most INT32_MAX output elements.");
+  constexpr int64_t max_element_count = std::numeric_limits<int32_t>::max();
+  ORT_RETURN_IF(element_count < 0 || element_count > max_element_count,
+                "CUDA GatherElements output element count ", element_count,
+                " is outside the supported range [0, ", max_element_count, "].");
   return Status::OK();
 }
 

--- a/onnxruntime/core/providers/cuda/tensor/gather_elements.h
+++ b/onnxruntime/core/providers/cuda/tensor/gather_elements.h
@@ -2,8 +2,6 @@
 // Licensed under the MIT License.
 #pragma once
 
-#include <limits>
-
 #include "core/providers/cuda/cuda_kernel.h"
 #include "core/providers/shared_library/provider_api.h"
 
@@ -11,14 +9,6 @@ namespace onnxruntime {
 namespace cuda {
 
 struct GatherScatterElementsArgs;
-
-inline Status ValidateGatherElementsElementCount(int64_t element_count) {
-  constexpr int64_t max_element_count = std::numeric_limits<int32_t>::max();
-  ORT_RETURN_IF(element_count < 0 || element_count > max_element_count,
-                "CUDA GatherElements output element count ", element_count,
-                " is outside the supported range [0, ", max_element_count, "].");
-  return Status::OK();
-}
 
 // Coalesce those contiguous axes that have same dim values for both input and indices (exclude the gather/scatter axis)
 // so that we will have less divmod to compute during the kernels.

--- a/onnxruntime/core/providers/cuda/tensor/gather_elements.h
+++ b/onnxruntime/core/providers/cuda/tensor/gather_elements.h
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 #pragma once
 
+#include <limits>
+
 #include "core/providers/cuda/cuda_kernel.h"
 #include "core/providers/shared_library/provider_api.h"
 
@@ -9,6 +11,12 @@ namespace onnxruntime {
 namespace cuda {
 
 struct GatherScatterElementsArgs;
+
+inline Status ValidateGatherElementsElementCount(int64_t element_count) {
+  ORT_RETURN_IF(element_count < 0 || element_count > std::numeric_limits<int32_t>::max(),
+                "CUDA GatherElements supports at most INT32_MAX output elements.");
+  return Status::OK();
+}
 
 // Coalesce those contiguous axes that have same dim values for both input and indices (exclude the gather/scatter axis)
 // so that we will have less divmod to compute during the kernels.

--- a/onnxruntime/core/providers/cuda/tensor/gather_elements_common.h
+++ b/onnxruntime/core/providers/cuda/tensor/gather_elements_common.h
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <cstdint>
+#include <limits>
+#include <string>
+
+namespace onnxruntime::cuda {
+
+constexpr int64_t kGatherElementsMaxElementCount = std::numeric_limits<int32_t>::max();
+
+constexpr bool IsGatherElementsElementCountSupported(int64_t element_count) {
+  return element_count >= 0 && element_count <= kGatherElementsMaxElementCount;
+}
+
+inline std::string GatherElementsElementCountErrorMessage(int64_t element_count) {
+  return "CUDA GatherElements output element count " + std::to_string(element_count) +
+         " is outside the supported range [0, " + std::to_string(kGatherElementsMaxElementCount) + "].";
+}
+
+}  // namespace onnxruntime::cuda

--- a/onnxruntime/test/providers/cpu/tensor/gather_elements_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/gather_elements_op_test.cc
@@ -10,6 +10,8 @@
 #include "test/util/include/default_providers.h"
 
 #ifdef USE_CUDA
+#include <limits>
+
 #include "core/providers/cuda/tensor/gather_elements.h"
 #endif
 
@@ -26,7 +28,10 @@ TEST(GatherElementsOpTest, CudaElementCountRange) {
   EXPECT_FALSE(cuda::ValidateGatherElementsElementCount(
                    static_cast<int64_t>(std::numeric_limits<int32_t>::max()) + 1)
                    .IsOK());
-  EXPECT_FALSE(cuda::ValidateGatherElementsElementCount(4294967301LL).IsOK());
+  const auto status = cuda::ValidateGatherElementsElementCount(4294967301LL);
+  EXPECT_FALSE(status.IsOK());
+  EXPECT_NE(status.ErrorMessage().find("4294967301"), std::string::npos);
+  EXPECT_NE(status.ErrorMessage().find("2147483647"), std::string::npos);
 }
 #endif
 

--- a/onnxruntime/test/providers/cpu/tensor/gather_elements_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/gather_elements_op_test.cc
@@ -9,12 +9,26 @@
 #include "test/providers/provider_test_utils.h"
 #include "test/util/include/default_providers.h"
 
+#ifdef USE_CUDA
+#include "core/providers/cuda/tensor/gather_elements.h"
+#endif
+
 #if defined(ENABLE_STRIDED_TENSORS) && defined(USE_CUDA)
 #include "test/providers/kernel_compute_test_utils.h"
 #endif
 
 namespace onnxruntime {
 namespace test {
+
+#ifdef USE_CUDA
+TEST(GatherElementsOpTest, CudaElementCountRange) {
+  EXPECT_STATUS_OK(cuda::ValidateGatherElementsElementCount(std::numeric_limits<int32_t>::max()));
+  EXPECT_FALSE(cuda::ValidateGatherElementsElementCount(
+                   static_cast<int64_t>(std::numeric_limits<int32_t>::max()) + 1)
+                   .IsOK());
+  EXPECT_FALSE(cuda::ValidateGatherElementsElementCount(4294967301LL).IsOK());
+}
+#endif
 
 namespace {
 

--- a/onnxruntime/test/providers/cpu/tensor/gather_elements_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/gather_elements_op_test.cc
@@ -12,7 +12,7 @@
 #ifdef USE_CUDA
 #include <limits>
 
-#include "core/providers/cuda/tensor/gather_elements.h"
+#include "core/providers/cuda/tensor/gather_elements_common.h"
 #endif
 
 #if defined(ENABLE_STRIDED_TENSORS) && defined(USE_CUDA)
@@ -24,14 +24,15 @@ namespace test {
 
 #ifdef USE_CUDA
 TEST(GatherElementsOpTest, CudaElementCountRange) {
-  EXPECT_STATUS_OK(cuda::ValidateGatherElementsElementCount(std::numeric_limits<int32_t>::max()));
-  EXPECT_FALSE(cuda::ValidateGatherElementsElementCount(
-                   static_cast<int64_t>(std::numeric_limits<int32_t>::max()) + 1)
-                   .IsOK());
-  const auto status = cuda::ValidateGatherElementsElementCount(4294967301LL);
-  EXPECT_FALSE(status.IsOK());
-  EXPECT_NE(status.ErrorMessage().find("4294967301"), std::string::npos);
-  EXPECT_NE(status.ErrorMessage().find("2147483647"), std::string::npos);
+  EXPECT_TRUE(cuda::IsGatherElementsElementCountSupported(0));
+  EXPECT_TRUE(cuda::IsGatherElementsElementCountSupported(std::numeric_limits<int32_t>::max()));
+  EXPECT_FALSE(cuda::IsGatherElementsElementCountSupported(
+      static_cast<int64_t>(std::numeric_limits<int32_t>::max()) + 1));
+  EXPECT_FALSE(cuda::IsGatherElementsElementCountSupported(4294967301LL));
+  EXPECT_FALSE(cuda::IsGatherElementsElementCountSupported(-1));
+  const auto error = cuda::GatherElementsElementCountErrorMessage(4294967301LL);
+  EXPECT_NE(error.find("4294967301"), std::string::npos);
+  EXPECT_NE(error.find("2147483647"), std::string::npos);
 }
 #endif
 


### PR DESCRIPTION
This pull request adds a validation step to the CUDA `GatherElements` kernel to ensure the number of output elements does not exceed the supported limit, preventing potential overflows or runtime errors. It also introduces a corresponding utility function and unit tests for this validation.

**CUDA GatherElements Kernel Improvements:**

* Added a call to `ValidateGatherElementsElementCount` in `gather_elements.cc` to check that the number of output elements does not exceed `INT32_MAX`, ensuring CUDA kernel compatibility and preventing overflows.

* Implemented the inline function `ValidateGatherElementsElementCount` in `gather_elements.h` to encapsulate the element count validation logic.

* Included `<limits>` in `gather_elements.h` to support numeric boundary checks.

**Testing:**

* Added unit tests in `gather_elements_op_test.cc` to verify that `ValidateGatherElementsElementCount` correctly accepts valid counts and rejects counts exceeding `INT32_MAX`.