### PR TITLE
Validate TreeEnsemble v5 node references

### DIFF
--- a/onnxruntime/core/providers/cpu/ml/tree_ensemble_attribute.h
+++ b/onnxruntime/core/providers/cpu/ml/tree_ensemble_attribute.h
@@ -490,7 +490,7 @@ struct TreeEnsembleAttributesV5 {
                       nodes_falseleafs[tree_root_size_t] && nodes_trueleafs[tree_root_size_t]);
       const int64_t root_reference = is_leaf ? nodes_falsenodeids[tree_root_size_t] : tree_root;
       ORT_ENFORCE(root_reference >= 0,
-          "TreeEnsemble tree root ", tree_root, " references negative leaf index ", root_reference, ".");
+                  "TreeEnsemble tree root ", tree_root, " references negative leaf index ", root_reference, ".");
       transformInputOneTree(onnxruntime::narrow<size_t>(root_reference), curr_treeid, 0,
                             is_leaf,
                             membership_values_by_id, output);

--- a/onnxruntime/core/providers/cpu/ml/tree_ensemble_attribute.h
+++ b/onnxruntime/core/providers/cpu/ml/tree_ensemble_attribute.h
@@ -244,7 +244,8 @@ struct TreeEnsembleAttributesV5 {
     size_t curr_id = 0;
     for (const auto node_mode : nodes_modes) {
       membership_values_by_id.emplace_back();
-      if (node_mode != NODE_MODE_ONNX::BRANCH_MEMBER) {
+      if (node_mode != NODE_MODE_ONNX::BRANCH_MEMBER &&
+          node_mode != NODE_MODE_ONNX::BRANCH_MEMBER_BIGSET) {
         continue;
       }
 
@@ -338,6 +339,10 @@ struct TreeEnsembleAttributesV5 {
         visited_nodes[curr_id] = true;
 
         const auto mode = nodes_modes[curr_id];
+        ORT_ENFORCE((mode != NODE_MODE_ONNX::BRANCH_MEMBER &&
+                     mode != NODE_MODE_ONNX::BRANCH_MEMBER_BIGSET) ||
+                        !membership_values_by_id[curr_id].empty(),
+                    "TreeEnsemble membership node ", curr_id, " must have at least one membership value.");
         ORT_ENFORCE(mode == NODE_MODE_ONNX::BRANCH_MEMBER ||
                         mode == NODE_MODE_ONNX::BRANCH_MEMBER_BIGSET ||
                         curr_id < nodes_splits.size(),
@@ -472,15 +477,21 @@ struct TreeEnsembleAttributesV5 {
     int64_t curr_treeid = 0;
     for (const int64_t& tree_root : tree_roots) {
       ORT_ENFORCE(tree_root >= 0 &&
+                      static_cast<uint64_t>(tree_root) < nodes_modes.size() &&
+                      static_cast<uint64_t>(tree_root) < nodes_featureids.size() &&
                       static_cast<uint64_t>(tree_root) < nodes_falsenodeids.size() &&
                       static_cast<uint64_t>(tree_root) < nodes_falseleafs.size() &&
                       static_cast<uint64_t>(tree_root) < nodes_truenodeids.size() &&
-                      static_cast<uint64_t>(tree_root) < nodes_trueleafs.size(),
+                      static_cast<uint64_t>(tree_root) < nodes_trueleafs.size() &&
+                      static_cast<uint64_t>(tree_root) < membership_values_by_id.size(),
                   "TreeEnsemble tree_roots contains out-of-range node index ", tree_root, ".");
       const size_t tree_root_size_t = static_cast<size_t>(tree_root);
       bool is_leaf = (nodes_falsenodeids[tree_root_size_t] == nodes_truenodeids[tree_root_size_t] &&
                       nodes_falseleafs[tree_root_size_t] && nodes_trueleafs[tree_root_size_t]);
-      transformInputOneTree(tree_root_size_t, curr_treeid, 0,
+      const int64_t root_reference = is_leaf ? nodes_falsenodeids[tree_root_size_t] : tree_root;
+      ORT_ENFORCE(root_reference >= 0,
+          "TreeEnsemble tree root ", tree_root, " references negative leaf index ", root_reference, ".");
+      transformInputOneTree(onnxruntime::narrow<size_t>(root_reference), curr_treeid, 0,
                             is_leaf,
                             membership_values_by_id, output);
       curr_treeid++;

--- a/onnxruntime/core/providers/cpu/ml/tree_ensemble_attribute.h
+++ b/onnxruntime/core/providers/cpu/ml/tree_ensemble_attribute.h
@@ -306,6 +306,7 @@ struct TreeEnsembleAttributesV5 {
 
     std::stack<StackFrame> stack;
     std::unordered_map<int64_t, int64_t> false_nodeid_update_pos;
+    std::vector<bool> visited_nodes(nodes_modes.size(), false);
     int64_t last_curr_nodeid = root_nodeid;
 
     stack.push({root_id, root_nodeid, root_is_leaf, -1});
@@ -319,6 +320,35 @@ struct TreeEnsembleAttributesV5 {
       const int64_t placeholder_to_update = frame.placeholder_to_update;
 
       stack.pop();
+
+      if (is_leaf) {
+        ORT_ENFORCE(curr_id < leaf_targetids.size() && curr_id < leaf_weights.size(),
+                    "TreeEnsemble references out-of-range leaf index ", curr_id, ".");
+      } else {
+        ORT_ENFORCE(curr_id < nodes_modes.size() &&
+                        curr_id < nodes_featureids.size() &&
+                        curr_id < nodes_falsenodeids.size() &&
+                        curr_id < nodes_falseleafs.size() &&
+                        curr_id < nodes_truenodeids.size() &&
+                        curr_id < nodes_trueleafs.size() &&
+                        curr_id < membership_values_by_id.size(),
+                    "TreeEnsemble references out-of-range node index ", curr_id, ".");
+        ORT_ENFORCE(!visited_nodes[curr_id],
+                    "TreeEnsemble contains a cycle or shared internal node at index ", curr_id, ".");
+        visited_nodes[curr_id] = true;
+
+        const auto mode = nodes_modes[curr_id];
+        ORT_ENFORCE(mode == NODE_MODE_ONNX::BRANCH_MEMBER ||
+                        mode == NODE_MODE_ONNX::BRANCH_MEMBER_BIGSET ||
+                        curr_id < nodes_splits.size(),
+                    "TreeEnsemble nodes_splits is missing node index ", curr_id, ".");
+        ORT_ENFORCE(nodes_hitrates.empty() || curr_id < nodes_hitrates.size(),
+                    "TreeEnsemble nodes_hitrates is missing node index ", curr_id, ".");
+        ORT_ENFORCE(nodes_missing_value_tracks_true.empty() ||
+                        curr_id < nodes_missing_value_tracks_true.size(),
+                    "TreeEnsemble nodes_missing_value_tracks_true is missing node index ", curr_id, ".");
+      }
+
       if (curr_nodeid == -1) {
         curr_nodeid = last_curr_nodeid + 1;
       }
@@ -441,7 +471,13 @@ struct TreeEnsembleAttributesV5 {
                               std::vector<std::vector<ThresholdType>>& membership_values_by_id) const {
     int64_t curr_treeid = 0;
     for (const int64_t& tree_root : tree_roots) {
-      size_t tree_root_size_t = onnxruntime::narrow<size_t>(tree_root);
+      ORT_ENFORCE(tree_root >= 0 &&
+                      static_cast<uint64_t>(tree_root) < nodes_falsenodeids.size() &&
+                      static_cast<uint64_t>(tree_root) < nodes_falseleafs.size() &&
+                      static_cast<uint64_t>(tree_root) < nodes_truenodeids.size() &&
+                      static_cast<uint64_t>(tree_root) < nodes_trueleafs.size(),
+                  "TreeEnsemble tree_roots contains out-of-range node index ", tree_root, ".");
+      const size_t tree_root_size_t = static_cast<size_t>(tree_root);
       bool is_leaf = (nodes_falsenodeids[tree_root_size_t] == nodes_truenodeids[tree_root_size_t] &&
                       nodes_falseleafs[tree_root_size_t] && nodes_trueleafs[tree_root_size_t]);
       transformInputOneTree(tree_root_size_t, curr_treeid, 0,

--- a/onnxruntime/test/providers/cpu/ml/tree_ensembler_test.cc
+++ b/onnxruntime/test/providers/cpu/ml/tree_ensembler_test.cc
@@ -139,10 +139,11 @@ static void RunInvalidLeafTargetIdsTest(int64_t aggregate_function,
 static void RunInvalidTreeStructureTest(int64_t tree_root,
                                         int64_t true_node_id,
                                         int64_t true_leaf,
-                                        const std::string& expected_error) {
+                                        const std::string& expected_error,
+                                        uint8_t node_mode = 0) {
   OpTester test("TreeEnsemble", 5, onnxruntime::kMLDomain);
 
-  auto nodes_modes = make_tensor(std::vector<uint8_t>{0}, "nodes_modes");
+  auto nodes_modes = make_tensor(std::vector<uint8_t>{node_mode}, "nodes_modes");
   auto nodes_splits = make_tensor(std::vector<float>{0.0f}, "nodes_splits");
   auto leaf_weights = make_tensor(std::vector<float>{1.0f}, "leaf_weights");
 
@@ -322,17 +323,17 @@ TEST(MLOpTest, TreeEnsembleLeafOnly) {
 
   int64_t aggregate_function = 1;
   int64_t post_transform = 0;
-  std::vector<int64_t> tree_roots = {0};
-  std::vector<uint8_t> nodes_modes = {0};
-  std::vector<int64_t> nodes_featureids = {0};
-  std::vector<double> nodes_splits = {0.f};
-  std::vector<int64_t> nodes_truenodeids = {0};
-  std::vector<int64_t> nodes_trueleafs = {1};
-  std::vector<int64_t> nodes_falsenodeids = {0};
-  std::vector<int64_t> nodes_falseleafs = {1};
+  std::vector<int64_t> tree_roots = {0, 2};
+  std::vector<uint8_t> nodes_modes = {0, 0, 0};
+  std::vector<int64_t> nodes_featureids = {0, 0, 0};
+  std::vector<double> nodes_splits = {0.f, 0.f, 0.f};
+  std::vector<int64_t> nodes_truenodeids = {0, 0, 1};
+  std::vector<int64_t> nodes_trueleafs = {1, 1, 1};
+  std::vector<int64_t> nodes_falsenodeids = {0, 0, 1};
+  std::vector<int64_t> nodes_falseleafs = {1, 1, 1};
 
-  std::vector<int64_t> leaf_targetids = {0};
-  std::vector<double> leaf_weights = {6.23f};
+  std::vector<int64_t> leaf_targetids = {0, 0};
+  std::vector<double> leaf_weights = {6.23f, 1.77f};
 
   auto nodes_modes_as_tensor = make_tensor(nodes_modes, "nodes_modes");
   auto nodes_splits_as_tensor = make_tensor(nodes_splits, "nodes_splits");
@@ -355,7 +356,7 @@ TEST(MLOpTest, TreeEnsembleLeafOnly) {
 
   // fill input data
   std::vector<double> X = {1.f, 4.f};
-  std::vector<double> Y = {6.23f, 6.23f};
+  std::vector<double> Y = {8.0f, 8.0f};
 
   test.AddInput<double>("X", {2, 1}, X);
   test.AddOutput<double>("Y", {2, 1}, Y);
@@ -396,6 +397,11 @@ TEST(MLOpTest, TreeEnsembleRejectsOutOfRangeChild) {
 
 TEST(MLOpTest, TreeEnsembleRejectsCycle) {
   RunInvalidTreeStructureTest(0, 0, 0, "contains a cycle or shared internal node at index 0");
+}
+
+TEST(MLOpTest, TreeEnsembleRejectsEmptyMembershipValues) {
+  RunInvalidTreeStructureTest(0, 1, 1, "must have at least one membership value", 6);
+  RunInvalidTreeStructureTest(0, 1, 1, "must have at least one membership value", 8);
 }
 
 TEST(MLOpTest, TreeEnsembleZeroTargets) {

--- a/onnxruntime/test/providers/cpu/ml/tree_ensembler_test.cc
+++ b/onnxruntime/test/providers/cpu/ml/tree_ensembler_test.cc
@@ -136,6 +136,35 @@ static void RunInvalidLeafTargetIdsTest(int64_t aggregate_function,
   test.Run(OpTester::ExpectResult::kExpectFailure, expected_error);
 }
 
+static void RunInvalidTreeStructureTest(int64_t tree_root,
+                                        int64_t true_node_id,
+                                        int64_t true_leaf,
+                                        const std::string& expected_error) {
+  OpTester test("TreeEnsemble", 5, onnxruntime::kMLDomain);
+
+  auto nodes_modes = make_tensor(std::vector<uint8_t>{0}, "nodes_modes");
+  auto nodes_splits = make_tensor(std::vector<float>{0.0f}, "nodes_splits");
+  auto leaf_weights = make_tensor(std::vector<float>{1.0f}, "leaf_weights");
+
+  test.AddAttribute("n_targets", static_cast<int64_t>(1));
+  test.AddAttribute("aggregate_function", static_cast<int64_t>(1));
+  test.AddAttribute("post_transform", static_cast<int64_t>(0));
+  test.AddAttribute("tree_roots", std::vector<int64_t>{tree_root});
+  test.AddAttribute("nodes_modes", nodes_modes);
+  test.AddAttribute("nodes_featureids", std::vector<int64_t>{0});
+  test.AddAttribute("nodes_splits", nodes_splits);
+  test.AddAttribute("nodes_truenodeids", std::vector<int64_t>{true_node_id});
+  test.AddAttribute("nodes_trueleafs", std::vector<int64_t>{true_leaf});
+  test.AddAttribute("nodes_falsenodeids", std::vector<int64_t>{0});
+  test.AddAttribute("nodes_falseleafs", std::vector<int64_t>{1});
+  test.AddAttribute("leaf_targetids", std::vector<int64_t>{0});
+  test.AddAttribute("leaf_weights", leaf_weights);
+
+  test.AddInput<float>("X", {1, 1}, {0.0f});
+  test.AddOutput<float>("Y", {1, 1}, {0.0f});
+  test.Run(OpTester::ExpectResult::kExpectFailure, expected_error);
+}
+
 template <typename T>
 void GenTreeAndRunTest(const std::vector<T>& X, const std::vector<T>& Y, const int64_t& aggregate_function, int n_trees = 1) {
   OpTester test("TreeEnsemble", 5, onnxruntime::kMLDomain);
@@ -355,6 +384,18 @@ TEST(MLOpTest, TreeEnsembleNegativeLeafTargetIds) {
       2,
       {-1},
       "target/class ids cannot have negative values (-1)");
+}
+
+TEST(MLOpTest, TreeEnsembleRejectsOutOfRangeRoot) {
+  RunInvalidTreeStructureTest(1, 0, 1, "tree_roots contains out-of-range node index 1");
+}
+
+TEST(MLOpTest, TreeEnsembleRejectsOutOfRangeChild) {
+  RunInvalidTreeStructureTest(0, 1, 0, "references out-of-range node index 1");
+}
+
+TEST(MLOpTest, TreeEnsembleRejectsCycle) {
+  RunInvalidTreeStructureTest(0, 0, 0, "contains a cycle or shared internal node at index 0");
 }
 
 TEST(MLOpTest, TreeEnsembleZeroTargets) {


### PR DESCRIPTION
This pull request improves the robustness and error handling of the TreeEnsemble implementation in ONNX Runtime. It introduces stricter validation for tree structure attributes, adds cycle detection, and expands the test suite to cover more invalid input scenarios.

**Validation and error handling improvements:**

* Added checks to ensure `tree_roots` only contains valid node indices, preventing out-of-range root references.
* Added comprehensive validation for node and leaf indices within the tree traversal, including checks for out-of-range indices and missing required node data.
* Introduced cycle and shared node detection by tracking visited nodes during traversal, enforcing that each internal node is only visited once. [[1]](diffhunk://#diff-2b4c3aa0fba01debf9814c19f34ee80759e62f8ea9ce4a28fa05bdd27ebd4e7eR309) [[2]](diffhunk://#diff-2b4c3aa0fba01debf9814c19f34ee80759e62f8ea9ce4a28fa05bdd27ebd4e7eR323-R351)

**Test coverage enhancements:**

* Added the `RunInvalidTreeStructureTest` helper and new test cases to verify the operator correctly rejects out-of-range roots, out-of-range child nodes, and cycles in the tree structure. [[1]](diffhunk://#diff-9bce50df70fddc092ce6fc5351812c621343f682a15ca178c34e6dd9415e9a39R139-R167) [[2]](diffhunk://#diff-9bce50df70fddc092ce6fc5351812c621343f682a15ca178c34e6dd9415e9a39R389-R400)