### PR TITLE
Serialize CPU ScatterND string updates

### DIFF
--- a/onnxruntime/core/providers/cpu/tensor/scatter_nd.cc
+++ b/onnxruntime/core/providers/cpu/tensor/scatter_nd.cc
@@ -343,7 +343,7 @@ struct ScatterNDDispatchTarget {
         } break;
       }
     };
-    if constexpr (std::is_same_v<TData, std::string>) {
+    if (context->Input<Tensor>(0)->IsDataTypeString()) {
       tp = nullptr;
     }
     concurrency::ThreadPool::TryParallelFor(

--- a/onnxruntime/core/providers/cpu/tensor/scatter_nd.cc
+++ b/onnxruntime/core/providers/cpu/tensor/scatter_nd.cc
@@ -343,6 +343,9 @@ struct ScatterNDDispatchTarget {
         } break;
       }
     };
+    if constexpr (std::is_same_v<TData, std::string>) {
+      tp = nullptr;
+    }
     concurrency::ThreadPool::TryParallelFor(
         tp, prepare.element_offsets.size(), static_cast<double>(prepare.element_to_copy),
         [&lambda](ptrdiff_t first, ptrdiff_t last) {

--- a/onnxruntime/test/providers/cpu/tensor/scatter_nd_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/scatter_nd_op_test.cc
@@ -157,6 +157,29 @@ TEST(ScatterNDOpTest, ScatterND_sliced_index_string_int64) {
   test.Run();
 }
 
+TEST(ScatterNDOpTest, ScatterND_string_duplicate_indices) {
+  OpTester test("ScatterND", 18);
+  test.AddInput<std::string>("data", {2}, {"original", "untouched"});
+  test.AddInput<int64_t>("indices", {3, 1}, {0, 0, 0});
+  test.AddInput<std::string>("updates", {3},
+                             {"first value longer than the small string optimization",
+                              "second value longer than the small string optimization",
+                              "last value longer than the small string optimization"});
+  test.AddOutput<std::string>("output", {2},
+                              {"last value longer than the small string optimization", "untouched"});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kOpenVINOExecutionProvider});
+}
+
+TEST(ScatterNDOpTest, ScatterND_string_add_duplicate_indices) {
+  OpTester test("ScatterND", 18);
+  test.AddAttribute("reduction", "add");
+  test.AddInput<std::string>("data", {2}, {"base", "untouched"});
+  test.AddInput<int64_t>("indices", {3, 1}, {0, 0, 0});
+  test.AddInput<std::string>("updates", {3}, {"-first", "-second", "-last"});
+  test.AddOutput<std::string>("output", {2}, {"base-first-second-last", "untouched"});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kOpenVINOExecutionProvider});
+}
+
 TEST(ScatterNDOpTest, ScatterND_batched_3tensor_int64) {
   OpTester test1("ScatterND", 11);
   test1.AddInput<uint32_t>("data", {2, 2, 2}, {0, 0, 0, 0, 0, 0, 0, 0});


### PR DESCRIPTION
This pull request introduces improvements to the handling and testing of string data in the `ScatterND` operator. The main changes include a fix to disable parallelization for string data types and the addition of new test cases to verify correct behavior with duplicate indices and string concatenation.

Improvements to string data handling:

* Disabled parallel execution (`tp = nullptr`) for `std::string` data types in the `ScatterNDDispatchTarget` struct to prevent potential issues with concurrent string operations.

Expanded test coverage:

* Added `ScatterND_string_duplicate_indices` test to verify that when duplicate indices are present, the last update value is used for string data.
* Added `ScatterND_string_add_duplicate_indices` test to verify that when the reduction attribute is set to `"add"`, updates to the same string index are concatenated in order.