### PR TITLE
Fix Whisper encoder input diagnostic

### DIFF
--- a/onnxruntime/contrib_ops/cpu/transformers/subgraph_whisper_encoder.cc
+++ b/onnxruntime/contrib_ops/cpu/transformers/subgraph_whisper_encoder.cc
@@ -14,6 +14,14 @@ namespace onnxruntime {
 namespace contrib {
 namespace transformers {
 
+Status ValidateWhisperEncoderInputNames(const NodeArg& encoder_input, const NodeArg& decoder_input) {
+  ORT_RETURN_IF(encoder_input.Name() != "encoder_input_ids",
+                "encoder subgraph input 0 shall be named as encoder_input_ids, got: ", encoder_input.Name());
+  ORT_RETURN_IF(decoder_input.Name() != "decoder_input_ids",
+                "encoder subgraph input 1 shall be named as decoder_input_ids, got: ", decoder_input.Name());
+  return Status::OK();
+}
+
 /* Whisper Encoder Subgraph (It also contains decoder initialization for decoder_input_ids).
 
    Inputs:
@@ -46,10 +54,7 @@ Status WhisperEncoderSubgraph::Validate(const std::vector<const NodeArg*>& subgr
   ORT_RETURN_IF((static_cast<int>(subgraph_outputs.size()) - first_present_output_index_) % 4 != 0,
                 "number of outputs expected to be 2 + 4 * layers, got:", num_subgraph_outputs);
 
-  ORT_RETURN_IF(subgraph_inputs[0]->Name() != "encoder_input_ids",
-                "encoder subgraph input 0 shall be named as encoder_input_ids, got: ", subgraph_inputs[0]->Name());
-  ORT_RETURN_IF(subgraph_inputs[1]->Name() != "decoder_input_ids",
-                "encoder subgraph input 2 shall be named as decoder_input_ids, got: ", subgraph_inputs[2]->Name());
+  ORT_RETURN_IF_ERROR(ValidateWhisperEncoderInputNames(*subgraph_inputs[0], *subgraph_inputs[1]));
 
   ORT_RETURN_IF(subgraph_outputs[0]->Name() != "logits",
                 "encoder subgraph output 0 shall be named as logits, got: ", subgraph_outputs[0]->Name());

--- a/onnxruntime/contrib_ops/cpu/transformers/subgraph_whisper_encoder.h
+++ b/onnxruntime/contrib_ops/cpu/transformers/subgraph_whisper_encoder.h
@@ -10,6 +10,8 @@ namespace onnxruntime {
 namespace contrib {
 namespace transformers {
 
+Status ValidateWhisperEncoderInputNames(const NodeArg& encoder_input, const NodeArg& decoder_input);
+
 // A class for whisper encoder subgraph with validation to support float inputs.
 class WhisperEncoderSubgraph : public T5EncoderSubgraph {
  public:

--- a/onnxruntime/test/contrib_ops/beam_search_test.cc
+++ b/onnxruntime/test/contrib_ops/beam_search_test.cc
@@ -3,6 +3,7 @@
 
 #include <memory>
 #include <vector>
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include <gsl/gsl>
 #include "core/session/onnxruntime_cxx_api.h"
@@ -12,6 +13,7 @@
 #include "test/util/include/scoped_env_vars.h"
 #include "contrib_ops/cpu/transformers/generation_shared.h"
 #include "contrib_ops/cpu/transformers/beam_search_parameters.h"
+#include "contrib_ops/cpu/transformers/subgraph_whisper_encoder.h"
 
 #ifdef USE_CUDA
 #include "core/providers/cuda/cuda_provider_options.h"
@@ -21,6 +23,16 @@ extern std::unique_ptr<Ort::Env> ort_env;
 
 namespace onnxruntime {
 namespace test {
+
+TEST(WhisperEncoderSubgraphTest, ReportsInvalidSecondInputName) {
+  NodeArg encoder_input("encoder_input_ids", nullptr);
+  NodeArg invalid_decoder_input("wrong_name", nullptr);
+
+  const auto status = contrib::transformers::ValidateWhisperEncoderInputNames(encoder_input, invalid_decoder_input);
+
+  ASSERT_FALSE(status.IsOK());
+  EXPECT_THAT(status.ErrorMessage(), testing::HasSubstr("got: wrong_name"));
+}
 
 TEST(BeamSearchParametersTest, SetSubgraphParametersRejectsOversizedVocabSize) {
   contrib::transformers::BeamSearchParameters parameters;


### PR DESCRIPTION
This pull request introduces a small refactor to the Whisper encoder subgraph validation logic and adds a new unit test to improve code clarity and test coverage. The main changes are the extraction of input name validation into a dedicated function and the addition of a test to check for invalid input names.

**Refactoring and validation improvements:**

* Extracted the input name validation logic from `WhisperEncoderSubgraph::Validate` into a new helper function `ValidateWhisperEncoderInputNames` in `subgraph_whisper_encoder.cc` and declared it in the header file `subgraph_whisper_encoder.h` for improved code reuse and readability. [[1]](diffhunk://#diff-1c7fc3b879a5909572c7a602415544b6b8a37c15efdec3b1b417bdb3dc47a491R17-R24) [[2]](diffhunk://#diff-ca786f63a9d798e56cbc0905436e0c7c675e30d2a88144f77721ecbdff1d329cR13-R14)
* Updated `WhisperEncoderSubgraph::Validate` to use the new `ValidateWhisperEncoderInputNames` function, simplifying the validation code and fixing an error in the previous input name check for the decoder input.

**Testing improvements:**

* Added a new unit test `WhisperEncoderSubgraphTest.ReportsInvalidSecondInputName` in `beam_search_test.cc` to verify that the validation function correctly reports an error when the decoder input name is incorrect. This increases test coverage for the new validation logic. [[1]](diffhunk://#diff-782b3e352d8957cd1226d1b87f2127c58efd5ba7a6472528afbdd6baa8232198R6) [[2]](diffhunk://#diff-782b3e352d8957cd1226d1b87f2127c58efd5ba7a6472528afbdd6baa8232198R16) [[3]](diffhunk://#diff-782b3e352d8957cd1226d1b87f2127c58efd5ba7a6472528afbdd6baa8232198R27-R36)