### PR TITLE
Prevent overlapping MatMulIntegerToFloat fusions

### DIFF
--- a/onnxruntime/core/optimizer/matmul_integer_to_float.cc
+++ b/onnxruntime/core/optimizer/matmul_integer_to_float.cc
@@ -114,7 +114,8 @@ MatMulIntegerToFloatFusion will fuse subgraph like below into MatMulIntegerToFlo
 Status MatMulIntegerToFloatFusion::ApplyImpl(Graph& graph, bool& modified, int graph_level, const logging::Logger& logger) const {
   GraphViewer graph_viewer(graph);
   const auto& node_topology_list = graph_viewer.GetNodesInTopologicalOrder();
-  InlinedVector<std::reference_wrapper<Node>> nodes_to_remove;
+  InlinedVector<NodeIndex> nodes_to_remove;
+  InlinedHashSet<NodeIndex> node_indices_to_remove;
 
   for (auto node_index : node_topology_list) {
     auto* node_ptr = graph.GetNode(node_index);
@@ -149,6 +150,13 @@ Status MatMulIntegerToFloatFusion::ApplyImpl(Graph& graph, bool& modified, int g
     Node& cast_node = *graph.GetNode(p_cast_node->Index());
     Node& matmulinteger_node = *graph.GetNode(p_matmulinteger_node->Index());
     Node& mul_node_right = *graph.GetNode(p_mul_node_right->Index());
+
+    if (node_indices_to_remove.contains(matmulinteger_node.Index()) ||
+        node_indices_to_remove.contains(cast_node.Index()) ||
+        node_indices_to_remove.contains(mul_node_right.Index()) ||
+        node_indices_to_remove.contains(mul_node.Index())) {
+      continue;
+    }
 
     // Check Nodes' Edges count and Nodes' outputs are not in Graph output
     if (!optimizer_utils::CheckOutputEdges(graph, cast_node, 1) ||
@@ -222,20 +230,23 @@ Status MatMulIntegerToFloatFusion::ApplyImpl(Graph& graph, bool& modified, int g
     // Assign provider to this new node. Provider should be same as the provider for old node.
     fused_node.SetExecutionProviderType(mul_node.GetExecutionProviderType());
 
-    nodes_to_remove.push_back(matmulinteger_node);
-    nodes_to_remove.push_back(cast_node);
-    nodes_to_remove.push_back(mul_node_right);
-    nodes_to_remove.push_back(mul_node);
+    for (Node* node : {&matmulinteger_node, &cast_node, &mul_node_right, &mul_node}) {
+      nodes_to_remove.push_back(node->Index());
+      node_indices_to_remove.insert(node->Index());
+    }
     if (p_add_node != nullptr) {
-      nodes_to_remove.push_back(*p_add_node);
+      nodes_to_remove.push_back(p_add_node->Index());
+      node_indices_to_remove.insert(p_add_node->Index());
     }
   }
 
   modified = modified || !nodes_to_remove.empty();
 
-  for (const auto& node : nodes_to_remove) {
-    graph_utils::RemoveNodeOutputEdges(graph, node);
-    graph.RemoveNode(node.get().Index());
+  for (const auto node_index : nodes_to_remove) {
+    Node* node = graph.GetNode(node_index);
+    ORT_ENFORCE(node != nullptr, "Node scheduled for removal was already removed.");
+    graph_utils::RemoveNodeOutputEdges(graph, *node);
+    graph.RemoveNode(node_index);
   }
 
   return Status::OK();

--- a/onnxruntime/test/optimizer/graph_transform_test.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test.cc
@@ -9631,6 +9631,47 @@ TEST_F(GraphTransformationTests, MatMulIntegerToFloatTest) {
   EXPECT_EQ(op_to_count["Add"], 1);
 }
 
+TEST_F(GraphTransformationTests, MatMulIntegerToFloatFusionRejectsOverlappingPatterns) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    auto* lhs_1 = builder.MakeInput<uint8_t>({{2, 2}});
+    auto* rhs_1 = builder.MakeInput<uint8_t>({{2, 2}});
+    auto* lhs_2 = builder.MakeInput<uint8_t>({{2, 2}});
+    auto* rhs_2 = builder.MakeInput<uint8_t>({{2, 2}});
+    auto* scale_1 = builder.MakeInput<float>({{1}});
+    auto* scale_2 = builder.MakeInput<float>({{1}});
+    auto* matmul_1_out = builder.MakeIntermediate();
+    auto* cast_1_out = builder.MakeIntermediate();
+    auto* scale_product_out = builder.MakeIntermediate();
+    auto* shared_mul_out = builder.MakeIntermediate();
+    auto* matmul_2_out = builder.MakeIntermediate();
+    auto* cast_2_out = builder.MakeIntermediate();
+    auto* output = builder.MakeOutput();
+
+    builder.AddNode("MatMulInteger", {lhs_1, rhs_1}, {matmul_1_out});
+    builder.AddNode("Cast", {matmul_1_out}, {cast_1_out})
+        .AddAttribute("to", static_cast<int64_t>(ONNX_NAMESPACE::TensorProto_DataType_FLOAT));
+    builder.AddNode("Mul", {scale_1, scale_2}, {scale_product_out});
+    builder.AddNode("Mul", {cast_1_out, scale_product_out}, {shared_mul_out});
+    builder.AddNode("MatMulInteger", {lhs_2, rhs_2}, {matmul_2_out});
+    builder.AddNode("Cast", {matmul_2_out}, {cast_2_out})
+        .AddAttribute("to", static_cast<int64_t>(ONNX_NAMESPACE::TensorProto_DataType_FLOAT));
+    builder.AddNode("Mul", {cast_2_out, shared_mul_out}, {output});
+  };
+
+  auto post_graph_checker = [](Graph& graph) {
+    const auto op_to_count = CountOpsInGraph(graph);
+    TEST_RETURN_IF_NOT(op_to_count.at("com.microsoft.MatMulIntegerToFloat") == 1);
+    TEST_RETURN_IF_NOT(op_to_count.at("MatMulInteger") == 1);
+    TEST_RETURN_IF_NOT(op_to_count.at("Cast") == 1);
+    TEST_RETURN_IF_NOT(op_to_count.at("Mul") == 1);
+    return Status::OK();
+  };
+
+  auto transformer = std::make_unique<MatMulIntegerToFloatFusion>();
+  ASSERT_STATUS_OK(TestGraphTransformer(build_test_case, 13, *logger_, std::move(transformer),
+                                        TransformerLevel::Level2, 1, {}, post_graph_checker));
+}
+
 TEST_F(GraphTransformationTests, MatMulIntegerToFloatFusion_Int8Bias_Input0) {
   constexpr const ORTCHAR_T* model_uri = ORT_TSTR("testdata/matmul_integer_to_float_int8_bias_initializer_index1.onnx");
   std::shared_ptr<Model> p_model;


### PR DESCRIPTION
### Description
Prevents `MatMulIntegerToFloat` fusion from processing overlapping patterns and removes scheduled nodes by index. Adds regression coverage for chained overlapping candidates.

### Motivation and Context
Overlapping candidates could schedule the same node for removal more than once, leaving the transformed graph invalid.