### PR TITLE
Fix prepacked weight reference lifetime

### DIFF
--- a/onnxruntime/core/framework/prepacked_weights_container.cc
+++ b/onnxruntime/core/framework/prepacked_weights_container.cc
@@ -108,4 +108,15 @@ std::optional<PrePackedWeights> PrepackedWeightsForGraph::ReplaceWithReferenceIf
   return result;
 }
 
+void PrepackedWeightsForGraph::DiscardAndReplaceWithReferenceIfSaving(
+    const std::string& weight_name,
+    const std::string& key,
+    const PrePackedWeights& refer_to) {
+  if (save_mode_on_) {
+    WritePackedMaybeForSave(weight_name, key, refer_to.CreateReferringCopy());
+  } else {
+    key_to_blobs_.erase(key);
+  }
+}
+
 }  // namespace onnxruntime

--- a/onnxruntime/core/framework/prepacked_weights_container.h
+++ b/onnxruntime/core/framework/prepacked_weights_container.h
@@ -121,6 +121,12 @@ class PrepackedWeightsForGraph {
                                                                const std::string& key,
                                                                const PrePackedWeights& refer_to_if_absent);
 
+  // Discards any existing entry. In save mode, replaces it with a non-owning reference to refer_to;
+  // otherwise, removes it from the container.
+  void DiscardAndReplaceWithReferenceIfSaving(const std::string& weight_name,
+                                              const std::string& key,
+                                              const PrePackedWeights& refer_to);
+
   bool IsSaveModeOn() const noexcept {
     return save_mode_on_;
   }

--- a/onnxruntime/core/framework/session_state.cc
+++ b/onnxruntime/core/framework/session_state.cc
@@ -580,9 +580,8 @@ Status SessionState::PrepackConstantInitializedTensors(
 
                       // Write references to what is stored in the shared container
                       // and release memory mapped entries this container may have loaded from disk
-                      std::ignore = prepacked_for_graph->ReplaceWithReferenceIfSaving(input_name,
-                                                                                      prepacked_weights_container_key,
-                                                                                      prepacked_shared);
+                      prepacked_for_graph->DiscardAndReplaceWithReferenceIfSaving(
+                          input_name, prepacked_weights_container_key, prepacked_shared);
 
                     } else {
                       // container doesn't contain the pre-packed weight - so write into it for sharing across

--- a/onnxruntime/test/framework/tensorutils_test.cc
+++ b/onnxruntime/test/framework/tensorutils_test.cc
@@ -213,6 +213,55 @@ TEST(TensorProtoUtilsTest, SetExternalDataInformation) {
   ASSERT_EQ(final_offset, external_offset);
 }
 
+TEST(PrepackedWeightsForGraphTest, DiscardReferencesProvidedWeightWhenSaving) {
+  constexpr const char* weight_name = "weight";
+  constexpr const char* key = "key";
+  std::array<uint8_t, 1> discarded_data{1};
+  std::array<uint8_t, 1> shared_data{2};
+
+  PrePackedWeights discarded_weights;
+  discarded_weights.buffers_.emplace_back(discarded_data.data(), BufferDeleter(nullptr));
+  discarded_weights.buffer_sizes_.push_back(discarded_data.size());
+
+  PrePackedWeights shared_weights;
+  shared_weights.buffers_.emplace_back(shared_data.data(), BufferDeleter(nullptr));
+  shared_weights.buffer_sizes_.push_back(shared_data.size());
+
+  PrepackedKeyToBlobMap key_to_blob;
+  PrepackedWeightsForGraph prepacked_for_graph(key_to_blob, true);
+  prepacked_for_graph.InsertPrepackedWeights(key, std::move(discarded_weights));
+
+  prepacked_for_graph.DiscardAndReplaceWithReferenceIfSaving(weight_name, key, shared_weights);
+
+  const auto* retained_weights = prepacked_for_graph.GetPrepackedWeights(key);
+  ASSERT_NE(retained_weights, nullptr);
+  ASSERT_EQ(retained_weights->buffers_.size(), 1U);
+  EXPECT_EQ(retained_weights->buffers_[0].get(), shared_data.data());
+  const auto* keys_for_weight = prepacked_for_graph.GetKeysForWeightForSaving(weight_name);
+  ASSERT_NE(keys_for_weight, nullptr);
+  EXPECT_EQ(keys_for_weight->count(key), 1U);
+}
+
+TEST(PrepackedWeightsForGraphTest, DiscardRemovesWeightWhenNotSaving) {
+  constexpr const char* key = "key";
+  std::array<uint8_t, 1> discarded_data{1};
+  std::array<uint8_t, 1> shared_data{2};
+
+  PrePackedWeights discarded_weights;
+  discarded_weights.buffers_.emplace_back(discarded_data.data(), BufferDeleter(nullptr));
+
+  PrePackedWeights shared_weights;
+  shared_weights.buffers_.emplace_back(shared_data.data(), BufferDeleter(nullptr));
+
+  PrepackedKeyToBlobMap key_to_blob;
+  PrepackedWeightsForGraph prepacked_for_graph(key_to_blob, false);
+  prepacked_for_graph.InsertPrepackedWeights(key, std::move(discarded_weights));
+
+  prepacked_for_graph.DiscardAndReplaceWithReferenceIfSaving("weight", key, shared_weights);
+
+  EXPECT_EQ(prepacked_for_graph.GetPrepackedWeights(key), nullptr);
+}
+
 // T must be float for double, and it must match with the 'type' argument
 template <typename T>
 void TestUnpackFloatTensor(TensorProto_DataType type, const std::filesystem::path& model_path) {


### PR DESCRIPTION
This pull request introduces a new method to the `PrepackedWeightsForGraph` class to improve how prepacked weights are managed, particularly when saving models. The main change is the addition of a `DiscardAndReplaceWithReferenceIfSaving` method, which either replaces a prepacked weight with a reference or removes it, depending on whether the save mode is enabled. Corresponding updates are made to usage sites and comprehensive unit tests are added to verify the new behavior.

**Enhancements to prepacked weights management:**

* Added the `DiscardAndReplaceWithReferenceIfSaving` method to the `PrepackedWeightsForGraph` class. This method replaces an existing entry with a reference to another weight when in save mode, or removes it from the container otherwise. [[1]](diffhunk://#diff-beaf819b642665d791baf27f6931969a7ed44776f27939c16660038b2b76e760R111-R121) [[2]](diffhunk://#diff-8f7cf3c97f7f9c93fd52a849ade7a4da4375b05f0debe357a8e52dd2090c8e2cR124-R129)
* Updated the call site in `SessionState::PrepackConstantInitializedTensors` to use the new method, ensuring correct handling of prepacked weights during model save operations.

**Testing improvements:**

* Added new unit tests in `tensorutils_test.cc` to verify the behavior of `DiscardAndReplaceWithReferenceIfSaving` in both save mode and non-save mode, ensuring correct reference replacement and removal of weights as appropriate.