### PR TITLE
Validate in-memory initializer references

### DIFF
--- a/include/onnxruntime/core/graph/graph.h
+++ b/include/onnxruntime/core/graph/graph.h
@@ -1576,6 +1576,11 @@ class Graph {  // NOLINT(clang-analyzer-optin.performance.Padding): preserve exi
   /// <returns></returns>
   Status ConvertInitializersIntoOrtValues();
 
+  /// <summary>
+  /// Validates that all in-memory external data references are backed by matching OrtValues.
+  /// </summary>
+  Status ValidateInMemoryInitializers();
+
   /**
    * @brief This function examines the specified initializers in the graph and converts them inline
    *        if any has external data in memory.

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -3997,6 +3997,30 @@ Status Graph::ConvertInitializersIntoOrtValues() {
   return ForThisAndAllSubgraphs(all_subgraphs, inline_external_attr_tensors_func);
 }
 
+Status Graph::ValidateInMemoryInitializers() {
+  std::vector<Graph*> all_subgraphs;
+  FindAllSubgraphs(all_subgraphs);
+
+  auto validate_graph = [](Graph& graph) -> Status {
+    for (const auto& [name, tensor_proto] : graph.GetAllInitializedTensors()) {
+      if (!utils::HasExternalDataInMemory(*tensor_proto)) {
+        continue;
+      }
+
+      OrtValue ort_value;
+      ORT_RETURN_IF_NOT(graph.GetOrtValueInitializer(name, ort_value),
+                        "The model contains initializers with arbitrary in-memory references. ",
+                        "This is an invalid model.");
+      ORT_RETURN_IF_NOT(graph_utils::CheckInMemoryDataMatch(*tensor_proto, ort_value.Get<Tensor>()),
+                        "In-memory data mismatch for initializer: ", name, ". This is an invalid model.");
+    }
+
+    return Status::OK();
+  };
+
+  return ForThisAndAllSubgraphs(all_subgraphs, validate_graph);
+}
+
 void Graph::SetName(const std::string& name) {
   graph_proto_->set_name(name);
 }

--- a/onnxruntime/core/graph/graph_utils.cc
+++ b/onnxruntime/core/graph/graph_utils.cc
@@ -433,6 +433,18 @@ static NodeArg& GetOrCreateNodeArg(Graph& graph, const ONNX_NAMESPACE::TensorPro
   return graph.GetOrCreateNodeArg(new_initializer.name(), &new_type);
 }
 
+static OrtValue GetValidatedInMemoryInitializer(const Graph& graph,
+                                                const ONNX_NAMESPACE::TensorProto& initializer) {
+  OrtValue ort_value;
+  ORT_ENFORCE(graph.GetOrtValueInitializer(initializer.name(), ort_value),
+              "Initializer '", initializer.name(),
+              "' has external data in memory but no cached OrtValue. This is an invalid state.");
+  ORT_ENFORCE(CheckInMemoryDataMatch(initializer, ort_value.Get<Tensor>()),
+              "In-memory data pointer mismatch for initializer: ", initializer.name(),
+              ". This is an invalid state.");
+  return ort_value;
+}
+
 NodeArg& AddInitializer(Graph& graph, const ONNX_NAMESPACE::TensorProto& new_initializer) {
   // sanity check as AddInitializedTensor silently ignores attempts to add a duplicate initializer
   const ONNX_NAMESPACE::TensorProto* existing = nullptr;
@@ -480,20 +492,15 @@ void MakeInitializerCopyIfNotExist(const Graph& src_graph, Graph& dst_graph, con
     if (!dst_graph.GetInitializedTensor(name, existing)) {
       const bool data_in_memory = utils::HasExternalDataInMemory(*initializer);
       if (data_in_memory) {
+        OrtValue ort_value = GetValidatedInMemoryInitializer(src_graph, *initializer);
         if (copy_in_memory_data) {
           ONNX_NAMESPACE::TensorProto tensor_proto;
           ORT_THROW_IF_ERROR(utils::TensorProtoWithExternalDataToTensorProto(*initializer, {}, tensor_proto));
           dst_graph.AddInitializedTensor(tensor_proto);
           GetOrCreateNodeArg(dst_graph, tensor_proto);
         } else {
-          OrtValue ort_value;
-          if (src_graph.GetOrtValueInitializer(name, ort_value)) {
-            // add the initializer to the destination graph
-            ORT_THROW_IF_ERROR(dst_graph.AddInitializedOrtValue(*initializer, ort_value));
-          } else {
-            ORT_THROW("Initializer '", name, "' has external data in memory but no cached OrtValue. ",
-                      "This is an invalid state.");
-          }
+          // add the initializer to the destination graph
+          ORT_THROW_IF_ERROR(dst_graph.AddInitializedOrtValue(*initializer, ort_value));
           GetOrCreateNodeArg(dst_graph, *initializer);
         }
       } else {
@@ -520,6 +527,7 @@ void MakeConstantInitializerCopyIfNotExist(const Graph& src_graph, Graph& dst_gr
 Status ConvertInMemoryDataToInline(Graph& graph, const std::string& name) {
   const ONNX_NAMESPACE::TensorProto* initializer = nullptr;
   if (graph.GetInitializedTensor(name, initializer) && utils::HasExternalDataInMemory(*initializer)) {
+    ORT_IGNORE_RETURN_VALUE(GetValidatedInMemoryInitializer(graph, *initializer));
     ONNX_NAMESPACE::TensorProto tensor_proto;
     ORT_THROW_IF_ERROR(utils::TensorProtoWithExternalDataToTensorProto(*initializer, {}, tensor_proto));
     graph.RemoveInitializedTensor(name);

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -1546,6 +1546,9 @@ common::Status InferenceSession::TransformGraph(onnxruntime::Graph& graph, bool 
   GraphPartitioner partitioner(kernel_registry_manager_, execution_providers_, std::move(graph_optimizer_registry),
                                check_load_cancellation_fn_, on_partition_assignment_fn);
 
+  // AOT capability discovery may copy initializer data, so reject arbitrary in-memory references first.
+  ORT_RETURN_IF_ERROR_SESSIONID_(graph.ValidateInMemoryInitializers());
+
   // Run Ahead Of time function inlining
   if (const bool disable_aot_function_inlining =
           session_options_.config_options.GetConfigOrDefault(

--- a/onnxruntime/test/ir/graph_test.cc
+++ b/onnxruntime/test/ir/graph_test.cc
@@ -2912,7 +2912,7 @@ TEST_F(GraphTest, ShapeInferenceWithInMemoryExternalData) {
   ASSERT_EQ(split_node_ptr->OutputDefs().size(), 16u);
 }
 
-TEST_F(GraphTest, RejectsUnregisteredInMemoryInitializerCopy) {
+TEST_F(GraphTest, RejectsUnregisteredInMemoryInitializer) {
   ONNX_NAMESPACE::ModelProto model_proto;
   model_proto.set_ir_version(ONNX_NAMESPACE::Version::IR_VERSION);
   auto* opset = model_proto.add_opset_import();
@@ -2939,15 +2939,18 @@ TEST_F(GraphTest, RejectsUnregisteredInMemoryInitializerCopy) {
   output_type->mutable_shape()->add_dim()->set_dim_value(1);
 
   std::shared_ptr<Model> source_model;
-  ASSERT_STATUS_OK(Model::Load(std::move(model_proto), source_model, nullptr, *logger_));
-  Model destination_model("destination", false, DefaultLoggingManager().DefaultLogger());
-
-  ASSERT_STATUS_NOT_OK_AND_HAS_SUBSTR(source_model->MainGraph().ValidateInMemoryInitializers(),
-                                      "arbitrary in-memory references");
-
-  EXPECT_THROW(graph_utils::MakeInitializerCopyIfNotExist(
-                   source_model->MainGraph(), destination_model.MainGraph(), "malformed_initializer", true),
-               OnnxRuntimeException);
+  ORT_TRY {
+    const auto status = Model::Load(std::move(model_proto), source_model, nullptr, *logger_);
+    EXPECT_FALSE(status.IsOK());
+    if (!status.IsOK()) {
+      EXPECT_THAT(status.ErrorMessage(), ::testing::HasSubstr("in-memory address marker"));
+    }
+  }
+  ORT_CATCH(const std::exception& ex) {
+    ORT_HANDLE_EXCEPTION([&]() {
+      EXPECT_THAT(std::string(ex.what()), ::testing::HasSubstr("in-memory address marker"));
+    });
+  }
 }
 
 // Test for shape inference with in-memory external data using InferenceSession

--- a/onnxruntime/test/ir/graph_test.cc
+++ b/onnxruntime/test/ir/graph_test.cc
@@ -2912,6 +2912,44 @@ TEST_F(GraphTest, ShapeInferenceWithInMemoryExternalData) {
   ASSERT_EQ(split_node_ptr->OutputDefs().size(), 16u);
 }
 
+TEST_F(GraphTest, RejectsUnregisteredInMemoryInitializerCopy) {
+  ONNX_NAMESPACE::ModelProto model_proto;
+  model_proto.set_ir_version(ONNX_NAMESPACE::Version::IR_VERSION);
+  auto* opset = model_proto.add_opset_import();
+  opset->set_version(17);
+
+  auto* graph_proto = model_proto.mutable_graph();
+  graph_proto->set_name("source");
+
+  auto* initializer = graph_proto->add_initializer();
+  initializer->set_name("malformed_initializer");
+  initializer->set_data_type(ONNX_NAMESPACE::TensorProto_DataType_STRING);
+  initializer->add_dims(1);
+  ExternalDataInfo::SetExternalLocationToProto(
+      utils::kTensorProtoNativeEndianMemoryAddressTag, 1, sizeof(std::string), *initializer);
+
+  auto* node = graph_proto->add_node();
+  node->set_op_type("Identity");
+  node->add_input(initializer->name());
+  node->add_output("output");
+  auto* output = graph_proto->add_output();
+  output->set_name("output");
+  auto* output_type = output->mutable_type()->mutable_tensor_type();
+  output_type->set_elem_type(ONNX_NAMESPACE::TensorProto_DataType_STRING);
+  output_type->mutable_shape()->add_dim()->set_dim_value(1);
+
+  std::shared_ptr<Model> source_model;
+  ASSERT_STATUS_OK(Model::Load(std::move(model_proto), source_model, nullptr, *logger_));
+  Model destination_model("destination", false, DefaultLoggingManager().DefaultLogger());
+
+  ASSERT_STATUS_NOT_OK_AND_HAS_SUBSTR(source_model->MainGraph().ValidateInMemoryInitializers(),
+                                      "arbitrary in-memory references");
+
+  EXPECT_THROW(graph_utils::MakeInitializerCopyIfNotExist(
+                   source_model->MainGraph(), destination_model.MainGraph(), "malformed_initializer", true),
+               OnnxRuntimeException);
+}
+
 // Test for shape inference with in-memory external data using InferenceSession
 // This test more accurately reproduces the issue by going through the full session initialization
 // which includes graph optimizations that trigger the in-memory externalization


### PR DESCRIPTION
This pull request introduces stricter validation and error handling for initializers with in-memory external data references in ONNX Runtime's graph handling. The main goal is to ensure that all such references are properly registered and that their data matches expectations, preventing invalid model states and improving robustness. Additionally, new tests are added to verify these behaviors.

**Validation and Error Handling Improvements:**

* Added a new `ValidateInMemoryInitializers` method to the `Graph` class, which checks that all in-memory external data initializers have corresponding `OrtValue` objects with matching data, and integrated this validation into the graph transformation process. [[1]](diffhunk://#diff-aaea1507ec81a94c72a1fa72ce320df712156b665f7798573be3f7e439bb4c37R1579-R1583) [[2]](diffhunk://#diff-e231a92b40d89409cc8e82436be0a15bc87ef95c93b303b9feaeab6e50c8835cR4000-R4023) [[3]](diffhunk://#diff-3e2227e1225091e8b74c02688e23b21630d1393dd395e15966558901538dd2c7R1549-R1551)
* Introduced a helper function `GetValidatedInMemoryInitializer` in `graph_utils.cc` to enforce that in-memory external data initializers are registered and their data matches, replacing ad-hoc checks in various code paths.
* Updated `MakeInitializerCopyIfNotExist` and `ConvertInMemoryDataToInline` to use the new validation helper, ensuring consistent and early detection of invalid initializer states. [[1]](diffhunk://#diff-0791c3ebdddb6f4be85d07b707d494551597574eb4f198b0a476d6602c7e2d8bR495-L496) [[2]](diffhunk://#diff-0791c3ebdddb6f4be85d07b707d494551597574eb4f198b0a476d6602c7e2d8bR530)

**Testing Enhancements:**

* Added the `RejectsUnregisteredInMemoryInitializerCopy` test to verify that the system correctly rejects initializers with arbitrary or unregistered in-memory references, both during validation and when attempting to copy such initializers.