### PR TITLE
Bound TreeEnsemble subtree comparison

### DIFF
--- a/onnxruntime/core/providers/cpu/ml/tree_ensemble_common.h
+++ b/onnxruntime/core/providers/cpu/ml/tree_ensemble_common.h
@@ -5,6 +5,7 @@
 
 #include <limits>
 #include <mutex>
+#include <set>
 #include "core/platform/threadpool.h"
 #include "tree_ensemble_helper.h"
 #include "tree_ensemble_attribute.h"
@@ -112,7 +113,7 @@ class TreeEnsembleCommon : public TreeEnsembleCommonAttributes {
   }
 
  private:
-  bool CheckIfSubtreesAreEqual(const size_t left_id, const size_t right_id, const int64_t tree_id, const InlinedVector<NODE_MODE_ONNX>& cmodes,
+  bool CheckIfSubtreesAreEqual(const size_t left_id, const size_t right_id, const InlinedVector<NODE_MODE_ONNX>& cmodes,
                                const InlinedVector<size_t>& truenode_ids, const InlinedVector<size_t>& falsenode_ids, gsl::span<const int64_t> nodes_featureids,
                                gsl::span<const ThresholdType> nodes_values_as_tensor, gsl::span<const float> node_values,
                                gsl::span<const float> target_class_weights, gsl::span<const ThresholdType> target_class_weights_as_tensor,
@@ -408,36 +409,57 @@ Status TreeEnsembleCommon<InputType, ThresholdType, OutputType>::Init(
 
 template <typename InputType, typename ThresholdType, typename OutputType>
 bool TreeEnsembleCommon<InputType, ThresholdType, OutputType>::CheckIfSubtreesAreEqual(
-    const size_t left_id, const size_t right_id, const int64_t tree_id, const InlinedVector<NODE_MODE_ONNX>& cmodes,
+    const size_t left_id, const size_t right_id, const InlinedVector<NODE_MODE_ONNX>& cmodes,
     const InlinedVector<size_t>& truenode_ids, const InlinedVector<size_t>& falsenode_ids, gsl::span<const int64_t> nodes_featureids,
     gsl::span<const ThresholdType> nodes_values_as_tensor, gsl::span<const float> node_values,
     gsl::span<const float> target_class_weights, gsl::span<const ThresholdType> target_class_weights_as_tensor,
     const InlinedVector<TreeNodeElementId>& node_tree_ids, const InlinedVector<std::pair<TreeNodeElementId, uint32_t>>& indices) {
-  if (left_id == right_id) {
-    return true;
-  }
-  // Leaves have values set at 0
-  if (cmodes[left_id] != cmodes[right_id] || nodes_featureids[left_id] != nodes_featureids[right_id] ||
-      (!nodes_values_as_tensor.empty() && nodes_values_as_tensor[left_id] != nodes_values_as_tensor[right_id]) ||
-      (nodes_values_as_tensor.empty() && node_values[left_id] != node_values[right_id])) {
-    return false;
-  }
+  std::vector<std::pair<size_t, size_t>> pending{{left_id, right_id}};
+  std::set<std::pair<size_t, size_t>> visited;
 
-  if (cmodes[left_id] == NODE_MODE_ONNX::LEAF) {
-    const auto left_target_node = std::lower_bound(indices.begin(), indices.end(), std::make_pair(node_tree_ids[left_id], uint32_t(0)))->second;
-    const auto right_target_node = std::lower_bound(indices.begin(), indices.end(), std::make_pair(node_tree_ids[right_id], uint32_t(0)))->second;
+  while (!pending.empty()) {
+    const auto [current_left_id, current_right_id] = pending.back();
+    pending.pop_back();
 
-    if (target_class_weights_as_tensor.empty()) {
-      return target_class_weights[left_target_node] == target_class_weights[right_target_node];
-    } else {
-      return target_class_weights_as_tensor[left_target_node] == target_class_weights_as_tensor[right_target_node];
+    if (current_left_id == current_right_id ||
+        !visited.emplace(current_left_id, current_right_id).second) {
+      continue;
     }
+
+    // Leaves have values set at 0
+    if (cmodes[current_left_id] != cmodes[current_right_id] ||
+        nodes_featureids[current_left_id] != nodes_featureids[current_right_id] ||
+        (!nodes_values_as_tensor.empty() &&
+         nodes_values_as_tensor[current_left_id] != nodes_values_as_tensor[current_right_id]) ||
+        (nodes_values_as_tensor.empty() && node_values[current_left_id] != node_values[current_right_id])) {
+      return false;
+    }
+
+    if (cmodes[current_left_id] == NODE_MODE_ONNX::LEAF) {
+      const auto left_target_node =
+          std::lower_bound(indices.begin(), indices.end(),
+                           std::make_pair(node_tree_ids[current_left_id], uint32_t(0)))
+              ->second;
+      const auto right_target_node =
+          std::lower_bound(indices.begin(), indices.end(),
+                           std::make_pair(node_tree_ids[current_right_id], uint32_t(0)))
+              ->second;
+
+      const bool weights_equal = target_class_weights_as_tensor.empty()
+                                     ? target_class_weights[left_target_node] == target_class_weights[right_target_node]
+                                     : target_class_weights_as_tensor[left_target_node] ==
+                                           target_class_weights_as_tensor[right_target_node];
+      if (!weights_equal) {
+        return false;
+      }
+      continue;
+    }
+
+    pending.emplace_back(falsenode_ids[current_left_id], falsenode_ids[current_right_id]);
+    pending.emplace_back(truenode_ids[current_left_id], truenode_ids[current_right_id]);
   }
 
-  return CheckIfSubtreesAreEqual(falsenode_ids[left_id], falsenode_ids[right_id], tree_id, cmodes, truenode_ids, falsenode_ids, nodes_featureids,
-                                 nodes_values_as_tensor, node_values, target_class_weights, target_class_weights_as_tensor, node_tree_ids, indices) &&
-         CheckIfSubtreesAreEqual(truenode_ids[left_id], truenode_ids[right_id], tree_id, cmodes, truenode_ids, falsenode_ids, nodes_featureids,
-                                 nodes_values_as_tensor, node_values, target_class_weights, target_class_weights_as_tensor, node_tree_ids, indices);
+  return true;
 }
 
 inline void UpdateThreshold(double val, double& mask) {
@@ -512,11 +534,14 @@ size_t TreeEnsembleCommon<InputType, ThresholdType, OutputType>::AddNodes(
     // Beware that if a category is bigger than the threshold type, the node stays as `EQ` and no combination is done
     if (nodes_[node_pos].flags == NODE_MODE_ORT::BRANCH_MEMBER) {
       ThresholdType falsenode_threshold = nodes_values_as_tensor.empty() ? static_cast<ThresholdType>(node_values[falsenode_id]) : nodes_values_as_tensor[falsenode_id];
+      std::unordered_set<size_t> categorical_nodes;
 
       while (cmodes[falsenode_id] == NODE_MODE_ONNX::BRANCH_EQ && nodes_[node_pos].feature_id == nodes_featureids[falsenode_id] &&
              CANMASK(falsenode_threshold, ThresholdType) &&
-             CheckIfSubtreesAreEqual(truenode_ids[i], truenode_ids[falsenode_id], tree_id, cmodes, truenode_ids, falsenode_ids,
+             CheckIfSubtreesAreEqual(truenode_ids[i], truenode_ids[falsenode_id], cmodes, truenode_ids, falsenode_ids,
                                      nodes_featureids, nodes_values_as_tensor, node_values, target_class_weights, target_class_weights_as_tensor, node_tree_ids, indices)) {
+        ORT_ENFORCE(categorical_nodes.insert(falsenode_id).second,
+                    "Cycle detected while folding categorical nodes in tree ", tree_id, ".");
         UpdateThreshold(falsenode_threshold, nodes_[node_pos].value_or_unique_weight);
         falsenode_id = falsenode_ids[falsenode_id];
         falsenode_threshold = nodes_values_as_tensor.empty() ? static_cast<ThresholdType>(node_values[falsenode_id]) : nodes_values_as_tensor[falsenode_id];

--- a/onnxruntime/test/providers/cpu/ml/treeregressor_test.cc
+++ b/onnxruntime/test/providers/cpu/ml/treeregressor_test.cc
@@ -765,6 +765,28 @@ TEST(MLOpTest, TreeRegressorCategoricalsFolding) {
   test.Run();
 }
 
+TEST(MLOpTest, TreeRegressorRejectsCategoricalCycle) {
+  OpTester test("TreeEnsembleRegressor", 3, onnxruntime::kMLDomain);
+
+  test.AddAttribute("nodes_truenodeids", std::vector<int64_t>{1, 0, 0});
+  test.AddAttribute("nodes_falsenodeids", std::vector<int64_t>{1, 0, 0});
+  test.AddAttribute("nodes_treeids", std::vector<int64_t>{0, 0, 0});
+  test.AddAttribute("nodes_nodeids", std::vector<int64_t>{0, 1, 2});
+  test.AddAttribute("nodes_featureids", std::vector<int64_t>{0, 0, 0});
+  test.AddAttribute("nodes_values", std::vector<float>{1.0f, 1.0f, 0.0f});
+  test.AddAttribute("nodes_modes", std::vector<std::string>{"BRANCH_EQ", "BRANCH_EQ", "LEAF"});
+  test.AddAttribute("target_treeids", std::vector<int64_t>{0});
+  test.AddAttribute("target_nodeids", std::vector<int64_t>{2});
+  test.AddAttribute("target_ids", std::vector<int64_t>{0});
+  test.AddAttribute("target_weights", std::vector<float>{1.0f});
+  test.AddAttribute("n_targets", static_cast<int64_t>(1));
+
+  test.AddInput<float>("X", {1, 1}, {0.0f});
+  test.AddOutput<float>("Y", {1, 1}, {0.0f});
+  test.Run(OpTester::ExpectResult::kExpectFailure,
+           "Cycle detected while folding categorical nodes");
+}
+
 TEST(MLOpTest, TreeRegressorTrueNodeBeforeNode) {
   OpTester test("TreeEnsembleRegressor", 3, onnxruntime::kMLDomain);
 


### PR DESCRIPTION
This pull request improves the robustness and correctness of categorical node folding in the tree ensemble implementation by refactoring the subtree comparison logic to prevent infinite loops caused by cycles, and by adding a test to ensure cycles are properly detected and rejected.

**Categorical Node Folding and Cycle Detection Improvements:**

* Refactored the `CheckIfSubtreesAreEqual` method in `tree_ensemble_common.h` to use an iterative approach with explicit cycle detection, replacing the previous recursive implementation. This prevents stack overflows and infinite loops when cycles are present in the tree structure. (`onnxruntime/core/providers/cpu/ml/tree_ensemble_common.h`, [[1]](diffhunk://#diff-098f04f4ce424d09171371b1dc5893d29e38c42a0f880639775de9e0fec67241L115-R116) [[2]](diffhunk://#diff-098f04f4ce424d09171371b1dc5893d29e38c42a0f880639775de9e0fec67241L411-R462)
* Modified the categorical node folding logic in `AddNodes` to maintain a set of visited categorical nodes and enforce that no node is revisited, raising an error if a cycle is detected. (`onnxruntime/core/providers/cpu/ml/tree_ensemble_common.h`, [onnxruntime/core/providers/cpu/ml/tree_ensemble_common.hR537-R544](diffhunk://#diff-098f04f4ce424d09171371b1dc5893d29e38c42a0f880639775de9e0fec67241R537-R544))
* Added `#include <set>` to support the new cycle detection logic. (`onnxruntime/core/providers/cpu/ml/tree_ensemble_common.h`, [onnxruntime/core/providers/cpu/ml/tree_ensemble_common.hR8](diffhunk://#diff-098f04f4ce424d09171371b1dc5893d29e38c42a0f880639775de9e0fec67241R8))

**Testing:**

* Added a new unit test `TreeRegressorRejectsCategoricalCycle` to verify that the implementation correctly detects and rejects cycles in categorical nodes, ensuring the model fails gracefully with an appropriate error message. (`onnxruntime/test/providers/cpu/ml/treeregressor_test.cc`, [onnxruntime/test/providers/cpu/ml/treeregressor_test.ccR768-R789](diffhunk://#diff-08b3495816c68f145657ecff63d7b5f3d56813586ec62f7324c22977e70e336bR768-R789))