### PR TITLE
Fix/winml image dimension overflow

### DIFF
--- a/winml/lib/Api.Image/VideoFrameToTensorConverter.cpp
+++ b/winml/lib/Api.Image/VideoFrameToTensorConverter.cpp
@@ -604,9 +604,7 @@ void VideoFrameToTensorConverter::ConvertSoftwareBitmapToGPUTensor(
   const UINT64 tensorElementSize = tensorDesc.dataType == kImageTensorDataTypeFloat32 ? 4 : 2;
   UINT64 bufferSize = tensorElementSize;
   for (UINT index = 1; index < kImageTensorDimensionCountMax; ++index) {
-    WINML_THROW_HR_IF_FALSE_MSG(
-      E_INVALIDARG, tensorDesc.sizes[index] > 0, "Image tensor dimensions must be positive."
-    );
+    WINML_THROW_HR_IF_FALSE_MSG(E_INVALIDARG, tensorDesc.sizes[index] > 0, "Image tensor dimensions must be positive.");
     WINML_THROW_IF_FAILED(ULongLongMult(bufferSize, static_cast<UINT64>(tensorDesc.sizes[index]), &bufferSize));
   }
 

--- a/winml/lib/Api.Image/VideoFrameToTensorConverter.cpp
+++ b/winml/lib/Api.Image/VideoFrameToTensorConverter.cpp
@@ -7,6 +7,7 @@
 #include <TraceLoggingProvider.h>
 #include <TraceloggingConfig.h>
 #include <evntrace.h>
+#include <limits>
 #include <MemoryBuffer.h>
 
 #include "inc/VideoFrameToTensorConverter.h"
@@ -600,9 +601,27 @@ void VideoFrameToTensorConverter::ConvertSoftwareBitmapToGPUTensor(
 
   D3D12_RESOURCE_DESC outputDesc = pOutputResource->GetDesc();
 
-  uint32_t tensorElementSize = tensorDesc.dataType == kImageTensorDataTypeFloat32 ? 4 : 2;
-  uint32_t bufferSize =
-    static_cast<uint32_t>(tensorDesc.sizes[1] * tensorDesc.sizes[2] * tensorDesc.sizes[3] * tensorElementSize);
+  const UINT64 tensorElementSize = tensorDesc.dataType == kImageTensorDataTypeFloat32 ? 4 : 2;
+  UINT64 bufferSize = tensorElementSize;
+  for (UINT index = 1; index < kImageTensorDimensionCountMax; ++index) {
+    WINML_THROW_HR_IF_FALSE_MSG(
+      E_INVALIDARG, tensorDesc.sizes[index] > 0, "Image tensor dimensions must be positive."
+    );
+    WINML_THROW_IF_FAILED(ULongLongMult(bufferSize, static_cast<UINT64>(tensorDesc.sizes[index]), &bufferSize));
+  }
+
+  UINT64 outputOffset = 0;
+  UINT64 outputEnd = 0;
+  WINML_THROW_IF_FAILED(ULongLongMult(bufferSize, batchIdx, &outputOffset));
+  WINML_THROW_IF_FAILED(ULongLongAdd(outputOffset, bufferSize, &outputEnd));
+  WINML_THROW_HR_IF_FALSE_MSG(
+    E_INVALIDARG,
+    outputDesc.Dimension == D3D12_RESOURCE_DIMENSION_BUFFER && outputDesc.Height == 1 && outputDesc.Width >= outputEnd,
+    "Output tensor resource is too small for the requested image batch."
+  );
+  WINML_THROW_HR_IF_FALSE_MSG(
+    E_INVALIDARG, bufferSize <= std::numeric_limits<SIZE_T>::max(), "Image tensor upload size is too large."
+  );
 
   // TODO: Make an allocator for upload heaps
   if (!upload_heap_ || upload_heap_->GetDesc().Width < bufferSize) {
@@ -624,7 +643,7 @@ void VideoFrameToTensorConverter::ConvertSoftwareBitmapToGPUTensor(
   // instead of the initial input bounds
   ConvertSoftwareBitmapToCPUTensor(convertedSoftwareBitmap, tensorDesc, scaledBounds, pCPUTensorBuffer);
 
-  upload_heap_->Unmap(0, unmove_ptr(CD3DX12_RANGE(0, bufferSize)));
+  upload_heap_->Unmap(0, unmove_ptr(CD3DX12_RANGE(0, static_cast<SIZE_T>(bufferSize))));
 
   ResetCommandList(device_cache);
 
@@ -633,7 +652,7 @@ void VideoFrameToTensorConverter::ConvertSoftwareBitmapToGPUTensor(
   );
   command_list_->ResourceBarrier(1, &barrier);
 
-  command_list_->CopyBufferRegion(pOutputResource, bufferSize * batchIdx, upload_heap_.Get(), 0, bufferSize);
+  command_list_->CopyBufferRegion(pOutputResource, outputOffset, upload_heap_.Get(), 0, bufferSize);
 
   WINML_THROW_IF_FAILED(command_list_->Close());
   ID3D12CommandList* ppCommandLists[] = {command_list_.Get()};

--- a/winml/lib/Api.Ort/OnnxruntimeDescriptorConverter.cpp
+++ b/winml/lib/Api.Ort/OnnxruntimeDescriptorConverter.cpp
@@ -4,6 +4,7 @@
 #include "lib/Api.Ort/pch.h"
 
 #include <evntrace.h>
+#include <limits>
 
 #include "OnnxruntimeDescriptorConverter.h"
 #include "ImageFeatureDescriptor.h"
@@ -447,6 +448,14 @@ static winml::ILearningModelFeatureDescriptor CreateImageFeatureDescriptor(
   // Should the model metadata be read instead???
   const int c_height_dimension = 2;
   const int c_width_dimension = 3;
+  WINML_THROW_HR_IF_FALSE_MSG(
+    E_INVALIDARG,
+    shape.size() > static_cast<size_t>(c_width_dimension) && shape[c_height_dimension] > 0 &&
+      shape[c_width_dimension] > 0 &&
+      shape[c_height_dimension] <= std::numeric_limits<int32_t>::max() &&
+      shape[c_width_dimension] <= std::numeric_limits<int32_t>::max(),
+    "Image tensor height and width must be positive and no greater than INT32_MAX."
+  );
   auto height = static_cast<uint32_t>(shape[c_height_dimension]);
   auto width = static_cast<uint32_t>(shape[c_width_dimension]);
   auto descriptor = winrt::make<winmlp::ImageFeatureDescriptor>(

--- a/winml/lib/Api.Ort/OnnxruntimeDescriptorConverter.cpp
+++ b/winml/lib/Api.Ort/OnnxruntimeDescriptorConverter.cpp
@@ -451,8 +451,7 @@ static winml::ILearningModelFeatureDescriptor CreateImageFeatureDescriptor(
   WINML_THROW_HR_IF_FALSE_MSG(
     E_INVALIDARG,
     shape.size() > static_cast<size_t>(c_width_dimension) && shape[c_height_dimension] > 0 &&
-      shape[c_width_dimension] > 0 &&
-      shape[c_height_dimension] <= std::numeric_limits<int32_t>::max() &&
+      shape[c_width_dimension] > 0 && shape[c_height_dimension] <= std::numeric_limits<int32_t>::max() &&
       shape[c_width_dimension] <= std::numeric_limits<int32_t>::max(),
     "Image tensor height and width must be positive and no greater than INT32_MAX."
   );

--- a/winml/test/api/LearningModelAPITest.cpp
+++ b/winml/test/api/LearningModelAPITest.cpp
@@ -277,10 +277,7 @@ static void CheckLearningModelPixelRange() {
 static void RejectOversizedImageDimensions() {
   WINML_EXPECT_THROW_SPECIFIC(
     ProtobufHelpers::CreateModel(
-      TensorKind::Float,
-      {1, 3, static_cast<int64_t>(std::numeric_limits<int32_t>::max()) + 1, 1},
-      1,
-      true
+      TensorKind::Float, {1, 3, static_cast<int64_t>(std::numeric_limits<int32_t>::max()) + 1, 1}, 1, true
     ),
     winrt::hresult_error,
     [](const winrt::hresult_error& e) -> bool { return e.code() == E_INVALIDARG; }

--- a/winml/test/api/LearningModelAPITest.cpp
+++ b/winml/test/api/LearningModelAPITest.cpp
@@ -5,6 +5,8 @@
 #include "LearningModelAPITest.h"
 #include "APITest.h"
 
+#include <limits>
+
 using namespace winrt;
 using namespace winml;
 using namespace wfc;
@@ -272,6 +274,19 @@ static void CheckLearningModelPixelRange() {
   }
 }
 
+static void RejectOversizedImageDimensions() {
+  WINML_EXPECT_THROW_SPECIFIC(
+    ProtobufHelpers::CreateModel(
+      TensorKind::Float,
+      {1, 3, static_cast<int64_t>(std::numeric_limits<int32_t>::max()) + 1, 1},
+      1,
+      true
+    ),
+    winrt::hresult_error,
+    [](const winrt::hresult_error& e) -> bool { return e.code() == E_INVALIDARG; }
+  );
+}
+
 static void CloseModelCheckEval() {
   LearningModel learningModel = nullptr;
   WINML_EXPECT_NO_THROW(APITest::LoadModel(L"model.onnx", learningModel));
@@ -330,6 +345,7 @@ const LearningModelApiTestsApi& getapi() {
     EnumerateOutputs,
     CloseModelCheckMetadata,
     CheckLearningModelPixelRange,
+    RejectOversizedImageDimensions,
     CloseModelCheckEval,
     CloseModelNoNewSessions,
     CheckMetadataCaseInsensitive,

--- a/winml/test/api/LearningModelAPITest.h
+++ b/winml/test/api/LearningModelAPITest.h
@@ -19,6 +19,7 @@ struct LearningModelApiTestsApi {
   VoidTest EnumerateOutputs;
   VoidTest CloseModelCheckMetadata;
   VoidTest CheckLearningModelPixelRange;
+  VoidTest RejectOversizedImageDimensions;
   VoidTest CloseModelCheckEval;
   VoidTest CloseModelNoNewSessions;
   VoidTest CheckMetadataCaseInsensitive;
@@ -44,6 +45,7 @@ WINML_TEST(LearningModelAPITests, EnumerateInputs)
 WINML_TEST(LearningModelAPITests, EnumerateOutputs)
 WINML_TEST(LearningModelAPITests, CloseModelCheckMetadata)
 WINML_TEST(LearningModelAPITests, CheckLearningModelPixelRange)
+WINML_TEST(LearningModelAPITests, RejectOversizedImageDimensions)
 WINML_TEST(LearningModelAPITests, CloseModelNoNewSessions)
 WINML_TEST(LearningModelAPITests, CloseModelCheckEval)
 WINML_TEST(LearningModelAPITests, CheckMetadataCaseInsensitive)

--- a/winml/test/common/protobufHelpers.cpp
+++ b/winml/test/common/protobufHelpers.cpp
@@ -209,7 +209,7 @@ TensorFloat16Bit ProtobufHelpers::LoadTensorFloat16FromProtobufFile(const std::w
 }
 
 winml::LearningModel ProtobufHelpers::CreateModel(
-  winml::TensorKind kind, const std::vector<int64_t>& shape, uint32_t num_elements
+  winml::TensorKind kind, const std::vector<int64_t>& shape, uint32_t num_elements, bool image_input
 ) {
   onnx::ModelProto model;
   model.set_ir_version(onnx::Version::IR_VERSION);
@@ -292,6 +292,9 @@ winml::LearningModel ProtobufHelpers::CreateModel(
     onnx::ValueInfoProto& variable = *graph.add_input();
     variable.set_name("input");
     variable.mutable_type()->mutable_tensor_type()->set_elem_type(dataType);
+    if (image_input) {
+      variable.mutable_type()->set_denotation("IMAGE");
+    }
     for (auto dim : shape) {
       if (dim == -1) {
         variable.mutable_type()->mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_param(&dim_param, 1);

--- a/winml/test/common/protobufHelpers.h
+++ b/winml/test/common/protobufHelpers.h
@@ -21,7 +21,12 @@ winml::ITensor LoadTensorFromProtobufFile(const std::wstring& filePath, bool isF
 // LoadTensorFloat16FromProtobufFile takes a path to a FP16 data file and loads it into a 16bit array
 winml::TensorFloat16Bit LoadTensorFloat16FromProtobufFile(const std::wstring& filePath);
 
-winml::LearningModel CreateModel(winml::TensorKind kind, const std::vector<int64_t>& shape, uint32_t num_elements = 1);
+winml::LearningModel CreateModel(
+	winml::TensorKind kind,
+	const std::vector<int64_t>& shape,
+	uint32_t num_elements = 1,
+	bool image_input = false
+);
 
 // Populates TensorProto with tensor from protobuf file
 bool LoadOnnxTensorFromProtobufFile(onnx::TensorProto& tensor, std::wstring filePath);

--- a/winml/test/common/protobufHelpers.h
+++ b/winml/test/common/protobufHelpers.h
@@ -22,10 +22,7 @@ winml::ITensor LoadTensorFromProtobufFile(const std::wstring& filePath, bool isF
 winml::TensorFloat16Bit LoadTensorFloat16FromProtobufFile(const std::wstring& filePath);
 
 winml::LearningModel CreateModel(
-	winml::TensorKind kind,
-	const std::vector<int64_t>& shape,
-	uint32_t num_elements = 1,
-	bool image_input = false
+  winml::TensorKind kind, const std::vector<int64_t>& shape, uint32_t num_elements = 1, bool image_input = false
 );
 
 // Populates TensorProto with tensor from protobuf file


### PR DESCRIPTION
This pull request strengthens validation for image tensor dimensions and improves robustness in both the core library and test code. The main focus is to ensure that image tensor height and width are always positive and do not exceed the maximum allowed integer size, preventing potential overflows or invalid memory access. It also updates related tests and utility functions to cover these cases.

**Validation Improvements:**

* Added explicit checks in `CreateImageFeatureDescriptor` to ensure image tensor height and width are positive and no greater than `INT32_MAX`, throwing `E_INVALIDARG` if not (`winml/lib/Api.Ort/OnnxruntimeDescriptorConverter.cpp`).
* In `ConvertSoftwareBitmapToGPUTensor`, changed buffer size calculations to use `UINT64`, added validation for positive tensor dimensions, and ensured the upload size does not exceed `SIZE_T` limits. Also, verified output resource bounds and used safe arithmetic functions to prevent overflows (`winml/lib/Api.Image/VideoFrameToTensorConverter.cpp`). [[1]](diffhunk://#diff-0433ecea41bd9c8ac8df1cc801435820b985a89b7175992149d9846d1640103cL603-R622) [[2]](diffhunk://#diff-0433ecea41bd9c8ac8df1cc801435820b985a89b7175992149d9846d1640103cL636-R653) [[3]](diffhunk://#diff-0433ecea41bd9c8ac8df1cc801435820b985a89b7175992149d9846d1640103cL627-R644)

**Test Enhancements:**

* Added a new test, `RejectOversizedImageDimensions`, to verify that models with image dimensions exceeding `INT32_MAX` are correctly rejected (`winml/test/api/LearningModelAPITest.cpp`, `LearningModelAPITest.h`). [[1]](diffhunk://#diff-333193022bf7c1f14c1cd007c564615f78d18d7e5131dcaaf381f6a7abadd3faR277-R286) [[2]](diffhunk://#diff-333193022bf7c1f14c1cd007c564615f78d18d7e5131dcaaf381f6a7abadd3faR345) [[3]](diffhunk://#diff-ac423ebe6007e7e5068341e624f86aad1e761b541fe6ff074a48f84e05fcfe9fR22) [[4]](diffhunk://#diff-ac423ebe6007e7e5068341e624f86aad1e761b541fe6ff074a48f84e05fcfe9fR48)
* Updated the `CreateModel` utility to support an `image_input` flag, allowing creation of image-typed model inputs for testing validation logic (`winml/test/common/protobufHelpers.cpp`, `protobufHelpers.h`). [[1]](diffhunk://#diff-a950cbbe1cffe6d8654c7b52f4e2a26ba7b47f44e7e51483909d585c68d3f073L212-R212) [[2]](diffhunk://#diff-a950cbbe1cffe6d8654c7b52f4e2a26ba7b47f44e7e51483909d585c68d3f073R295-R297) [[3]](diffhunk://#diff-60f379241dc17a8d28e628bd8b85bff62c0accbfbcf01aaa282bd922a785a37eL24-R26)

**General Code Quality:**

* Included `<limits>` where needed to support the new validation checks and ensure portability and correctness. [[1]](diffhunk://#diff-0433ecea41bd9c8ac8df1cc801435820b985a89b7175992149d9846d1640103cR10) [[2]](diffhunk://#diff-ea694b0a467611dec54406349f03f521ba2f946422b7bf9c7e2de3b71444c749R7) [[3]](diffhunk://#diff-333193022bf7c1f14c1cd007c564615f78d18d7e5131dcaaf381f6a7abadd3faR8-R9)

These changes help prevent invalid image tensor shapes from being processed, improving the reliability and safety of the codebase.