### PR TITLE
[WebGPU] Make MatMulNaiveProgram's pipeline cache key cover everything it bakes into WGSL

### DIFF
--- a/onnxruntime/core/providers/webgpu/math/matmul.cc
+++ b/onnxruntime/core/providers/webgpu/math/matmul.cc
@@ -161,15 +161,11 @@ Status MatMul::ComputeInternal(ComputeContext& context) const {
     const int64_t a_rows = a->Shape().NumDimensions() > 1 ? a->Shape()[a->Shape().NumDimensions() - 2] : 1;
     TensorShape output_shape_shader({batch_size, a_rows, helper.N() / components});
 
-    // Standalone MatMul has no channels-last notion; the bias is indexed as bias[row + i].
-    // Named so the constructor argument and the cache hint below cannot drift apart.
+    // Standalone MatMul uses channels first notation, which indexes bias as bias[row + i].
     constexpr bool is_channels_last = false;
     MatMulNaiveProgram program{Activation(), output_rank, output_number, has_bias, is_channels_last};
 
     program
-        // Always None here, but MatMulNaiveProgram bakes the activation into its WGSL and is shared
-        // with the fused-conv path, so the activation belongs in the cache key at every call site.
-        // Same for is_channels_last, which selects between bias[col] and bias[row + i].
         .CacheHint(Activation().ToString(), std::to_string(components), std::to_string(a_components), std::to_string(output_number), std::to_string(is_channels_last))
         .AddInputs({{a, ProgramTensorMetadataDependency::TypeAndRank, a_components},
                     {b, ProgramTensorMetadataDependency::TypeAndRank, components}});

--- a/onnxruntime/core/providers/webgpu/math/matmul.cc
+++ b/onnxruntime/core/providers/webgpu/math/matmul.cc
@@ -161,10 +161,16 @@ Status MatMul::ComputeInternal(ComputeContext& context) const {
     const int64_t a_rows = a->Shape().NumDimensions() > 1 ? a->Shape()[a->Shape().NumDimensions() - 2] : 1;
     TensorShape output_shape_shader({batch_size, a_rows, helper.N() / components});
 
-    MatMulNaiveProgram program{Activation(), output_rank, output_number, has_bias};
+    // Standalone MatMul has no channels-last notion; the bias is indexed as bias[row + i].
+    // Named so the constructor argument and the cache hint below cannot drift apart.
+    constexpr bool is_channels_last = false;
+    MatMulNaiveProgram program{Activation(), output_rank, output_number, has_bias, is_channels_last};
 
     program
-        .CacheHint(std::to_string(components), std::to_string(a_components), std::to_string(output_number))
+        // Always None here, but MatMulNaiveProgram bakes the activation into its WGSL and is shared
+        // with the fused-conv path, so the activation belongs in the cache key at every call site.
+        // Same for is_channels_last, which selects between bias[col] and bias[row + i].
+        .CacheHint(Activation().ToString(), std::to_string(components), std::to_string(a_components), std::to_string(output_number), std::to_string(is_channels_last))
         .AddInputs({{a, ProgramTensorMetadataDependency::TypeAndRank, a_components},
                     {b, ProgramTensorMetadataDependency::TypeAndRank, components}});
 

--- a/onnxruntime/core/providers/webgpu/nn/conv.cc
+++ b/onnxruntime/core/providers/webgpu/nn/conv.cc
@@ -249,6 +249,10 @@ Status Conv<is_channels_last, is_fused>::ComputeInternal(ComputeContext& context
     auto N = matmul_output_shape[2];
     auto matmul_first_input_numdims = matmul_input_reshapes[0].NumDimensions();
     auto K = matmul_input_reshapes[0].GetDims()[matmul_first_input_numdims - 1];
+    // This threshold is what routes a 1x1 convolution to MatMulNaiveProgram, and
+    // WebGpuSmallMatMulConvDistinguishesActivationsInPipelineCache shapes its convolutions to land
+    // here. Changing it leaves that test green while it silently stops exercising MatMulNaive, so
+    // re-check the test's shapes alongside any change to this condition.
     if (N < 8 && K < 8) {
       const auto components = GetMaxComponents(N);
       const auto a_components = GetMaxComponents(K);
@@ -258,7 +262,10 @@ Status Conv<is_channels_last, is_fused>::ComputeInternal(ComputeContext& context
       TensorShape outer_dims = output_rank > 2 ? matmul_output_shape.Slice(0, output_rank - 2) : TensorShape({});
       MatMulNaiveProgram program(activation_, output_rank, output_number, has_bias, is_channels_last);
       program
-          .CacheHint(std::to_string(components), std::to_string(a_components), std::to_string(output_number))
+          // The activation is baked into this program's WGSL, so it must be part of the cache key.
+          // is_channels_last selects between bias[col] and bias[row + i] in the same WGSL, and it
+          // varies across calls here, so it belongs in the key too.
+          .CacheHint(activation_.ToString(), std::to_string(components), std::to_string(a_components), std::to_string(output_number), std::to_string(is_channels_last))
           .AddInputs({{matmul_inputs[0], ProgramTensorMetadataDependency::TypeAndRank, ReduceShapeByComponents(matmul_input_reshapes[0], a_components), int(a_components)},
                       {matmul_inputs[1], ProgramTensorMetadataDependency::TypeAndRank, ReduceShapeByComponents(matmul_input_reshapes[1], components), int(components)}});
       if (has_bias) {

--- a/onnxruntime/core/providers/webgpu/nn/conv.cc
+++ b/onnxruntime/core/providers/webgpu/nn/conv.cc
@@ -249,10 +249,6 @@ Status Conv<is_channels_last, is_fused>::ComputeInternal(ComputeContext& context
     auto N = matmul_output_shape[2];
     auto matmul_first_input_numdims = matmul_input_reshapes[0].NumDimensions();
     auto K = matmul_input_reshapes[0].GetDims()[matmul_first_input_numdims - 1];
-    // This threshold is what routes a 1x1 convolution to MatMulNaiveProgram, and
-    // WebGpuSmallMatMulConvDistinguishesActivationsInPipelineCache shapes its convolutions to land
-    // here. Changing it leaves that test green while it silently stops exercising MatMulNaive, so
-    // re-check the test's shapes alongside any change to this condition.
     if (N < 8 && K < 8) {
       const auto components = GetMaxComponents(N);
       const auto a_components = GetMaxComponents(K);
@@ -262,9 +258,6 @@ Status Conv<is_channels_last, is_fused>::ComputeInternal(ComputeContext& context
       TensorShape outer_dims = output_rank > 2 ? matmul_output_shape.Slice(0, output_rank - 2) : TensorShape({});
       MatMulNaiveProgram program(activation_, output_rank, output_number, has_bias, is_channels_last);
       program
-          // The activation is baked into this program's WGSL, so it must be part of the cache key.
-          // is_channels_last selects between bias[col] and bias[row + i] in the same WGSL, and it
-          // varies across calls here, so it belongs in the key too.
           .CacheHint(activation_.ToString(), std::to_string(components), std::to_string(a_components), std::to_string(output_number), std::to_string(is_channels_last))
           .AddInputs({{matmul_inputs[0], ProgramTensorMetadataDependency::TypeAndRank, ReduceShapeByComponents(matmul_input_reshapes[0], a_components), int(a_components)},
                       {matmul_inputs[1], ProgramTensorMetadataDependency::TypeAndRank, ReduceShapeByComponents(matmul_input_reshapes[1], components), int(components)}});

--- a/onnxruntime/core/providers/webgpu/nn/fuse_utils.h
+++ b/onnxruntime/core/providers/webgpu/nn/fuse_utils.h
@@ -28,9 +28,9 @@ using Activation = struct Activation {
   std::string ToString() const {
     std::stringstream oss;
     oss << "ActivationKind: " << static_cast<int>(activation_kind_) << ";";
-  // Increase the serialization precision so that activation_params_.values_ are captured with
-  // max_digits10 significant digits rather than the default 6. This ensures that WGSL shaders
-  // embedding different activation constants receive distinct cache keys.
+    // Increase the serialization precision so that activation_params_.values_ are captured with
+    // max_digits10 significant digits rather than the default 6. This ensures that WGSL shaders
+    // embedding different activation constants receive distinct cache keys.
     oss << std::setprecision(std::numeric_limits<float>::max_digits10);
     oss << "ActivationParams: " << activation_params_.values_[0] << ";";
     oss << "ActivationParams: " << activation_params_.values_[1] << ";";

--- a/onnxruntime/core/providers/webgpu/nn/fuse_utils.h
+++ b/onnxruntime/core/providers/webgpu/nn/fuse_utils.h
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+#include <iomanip>
+#include <limits>
 #include <string>
 #include <sstream>
 
@@ -26,6 +28,10 @@ using Activation = struct Activation {
   std::string ToString() const {
     std::stringstream oss;
     oss << "ActivationKind: " << static_cast<int>(activation_kind_) << ";";
+    // The parameters are baked into the generated WGSL, so distinct floats must produce distinct
+    // keys. max_digits10 round-trips exactly; the stream default of 6 significant digits does not
+    // -- 1234567.5 and 1234567.625 both format as 1.23457e+06 while emitting different WGSL.
+    oss << std::setprecision(std::numeric_limits<float>::max_digits10);
     oss << "ActivationParams: " << activation_params_.values_[0] << ";";
     oss << "ActivationParams: " << activation_params_.values_[1] << ";";
     return oss.str();

--- a/onnxruntime/core/providers/webgpu/nn/fuse_utils.h
+++ b/onnxruntime/core/providers/webgpu/nn/fuse_utils.h
@@ -28,9 +28,9 @@ using Activation = struct Activation {
   std::string ToString() const {
     std::stringstream oss;
     oss << "ActivationKind: " << static_cast<int>(activation_kind_) << ";";
-    // The parameters are baked into the generated WGSL, so distinct floats must produce distinct
-    // keys. max_digits10 round-trips exactly; the stream default of 6 significant digits does not
-    // -- 1234567.5 and 1234567.625 both format as 1.23457e+06 while emitting different WGSL.
+  // Increase the serialization precision so that activation_params_.values_ are captured with
+  // max_digits10 significant digits rather than the default 6. This ensures that WGSL shaders
+  // embedding different activation constants receive distinct cache keys.
     oss << std::setprecision(std::numeric_limits<float>::max_digits10);
     oss << "ActivationParams: " << activation_params_.values_[0] << ";";
     oss << "ActivationParams: " << activation_params_.values_[1] << ";";

--- a/onnxruntime/test/optimizer/graph_transform_test.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test.cc
@@ -92,6 +92,7 @@
 #include "test/optimizer/graph_transform_test_fixture.h"
 #include "test/providers/provider_test_utils.h"
 #include "test/test_environment.h"
+#include "test/optimizer/webgpu_fusion_test_util.h"
 #include "test/unittest_util/graph_transform_test_builder.h"
 #include "test/util/include/asserts.h"
 #include "test/util/include/default_providers.h"
@@ -3166,6 +3167,324 @@ TEST_F(GraphTransformationTests, FuseConvActivation) {
 #endif
   }
 }
+
+// Regression test for a pipeline-cache key collision on the small-matmul conv path.
+//
+// A 1x1 convolution with fewer than 8 channels on each side is lowered to MatMulNaiveProgram, which
+// bakes the activation expression directly into its WGSL. That program's cache hint omitted the
+// activation entirely, so two convolutions with identical shapes but different activations hashed
+// to the same key: whichever compiled first was served to both, and the second silently computed
+// the wrong activation. The collision this test covers is on the activation *kind*. Parameter-valued
+// collisions -- two activations of the same kind whose float parameters format identically in the
+// key -- are a separate mechanism, addressed by the max_digits10 setprecision in Activation::ToString
+// and covered here by WebGpuSmallMatMulConvDistinguishesActivationParamsInPipelineCache (end to end)
+// and by ActivationCacheKeyTest (the formatter itself).
+//
+// Deliberately self-contained rather than built on the Conv+activation parity helper below, so the
+// fix and its regression test can travel as a single commit.
+#if defined(USE_WEBGPU)
+namespace {
+// Runs a model containing two 1x1 convolutions that differ *only* in their activation, and
+// requires the fused results to match the unfused baseline.
+//
+// Both convolutions live in the same graph, so at Level2 both fused shaders are compiled inside a
+// single session against a single pipeline cache. That is what makes the collision observable: a
+// test that ran one activation per session would not catch it, because each session would only
+// ever need one MatMulNaive variant.
+void RunWebGpuSmallMatMulConvActivationPairTest(const std::string& activation_a,
+                                                const std::string& activation_b) {
+  if (!DefaultWebGpuExecutionProvider()) {
+    GTEST_SKIP() << "WebGPU EP unavailable in this build.";
+  }
+
+  auto build_test_case = [&](ModelTestBuilder& builder) {
+    // C_in = 4 and C_out = 6 put both matmul dimensions under the < 8 threshold that selects
+    // MatMulNaiveProgram; the 1x1 kernel with unit stride and no padding is what routes there.
+    auto* input = builder.MakeInput<float>({1, 4, 8, 8}, -3.0f, 3.0f);
+
+    // Distinct weights so the two branches cannot be collapsed into one by common subexpression
+    // elimination. The shapes are identical, so both convolutions produce the same cache key for
+    // everything except the activation.
+    auto* weight_a = builder.MakeInitializer<float>({6, 4, 1, 1}, -0.5f, 0.5f);
+    auto* bias_a = builder.MakeInitializer<float>({6}, -0.5f, 0.5f);
+    auto* weight_b = builder.MakeInitializer<float>({6, 4, 1, 1}, -0.5f, 0.5f);
+    auto* bias_b = builder.MakeInitializer<float>({6}, -0.5f, 0.5f);
+
+    auto* conv_a_out = builder.MakeIntermediate();
+    auto* conv_b_out = builder.MakeIntermediate();
+    auto* output_a = builder.MakeOutput();
+    auto* output_b = builder.MakeOutput();
+
+    builder.AddNode("Conv", {input, weight_a, bias_a}, {conv_a_out});
+    builder.AddNode(activation_a, {conv_a_out}, {output_a});
+    builder.AddNode("Conv", {input, weight_b, bias_b}, {conv_b_out});
+    builder.AddNode(activation_b, {conv_b_out}, {output_b});
+  };
+
+  auto check_transformed_graph = [&](InferenceSessionWrapper& session) {
+    std::set<std::string> fused_activations;
+    for (const auto& node : session.GetGraph().Nodes()) {
+      const auto* activation_attr = graph_utils::GetNodeAttribute(node, "activation");
+      if (activation_attr != nullptr) {
+        fused_activations.insert(activation_attr->s());
+      }
+    }
+    // Without this the test could pass trivially if fusion ever stopped firing, because an unfused
+    // graph matches the unfused baseline by construction.
+    ASSERT_THAT(fused_activations, ::testing::UnorderedElementsAre(activation_a, activation_b))
+        << "expected both convolutions to absorb their activation, so that two MatMulNaive "
+           "variants are compiled in one session";
+  };
+
+  RunWebGpuFusionTransformerTest(build_test_case,
+                                 check_transformed_graph,
+                                 TransformerLevel::Level1,
+                                 TransformerLevel::Level2,
+                                 /*opset_version=*/17,
+                                 /*per_sample_tolerance=*/2e-3,
+                                 /*relative_per_sample_tolerance=*/2e-3,
+                                 /*transformer=*/nullptr,
+                                 []() { return DefaultWebGpuExecutionProvider(); });
+}
+
+// Companion to the helper above, for a collision on the activation *parameters* rather than the
+// kind. Two HardSigmoid activations of the same kind whose alphas differ are still distinct shaders,
+// so they must still be distinct cache entries.
+//
+// Picking the parameters is the whole difficulty. The key was written by an unconfigured
+// std::stringstream (6 *significant* digits) while the WGSL is written by std::to_string (6 *decimal
+// places*), so a collision needs two alphas that agree to 6 significant digits yet differ as floats.
+// That bounds their relative difference at ~1e-5, which is far below the tolerance any float32
+// comparison can use -- so with an activation like LeakyRelu, whose output is alpha*x, the wrong
+// shader produces a difference too small to detect end to end at any input scale.
+//
+// HardSigmoid is what makes it observable, because clamp(alpha * value + beta, 0, 1) pins the output
+// to [0, 1] regardless of how large alpha is. A tiny relative difference in alpha becomes a large
+// absolute difference in the intermediate, and the clamp turns that into a full-scale 0-vs-1 swing:
+//
+//   conv output = 8.0 exactly
+//   alpha_a * 8 + beta = 8000120 - 8000160 = -40 -> clamp -> 0.0
+//   alpha_b * 8 + beta = 8000200 - 8000160 = +40 -> clamp -> 1.0
+//
+// Every intermediate above is an exactly representable float32 (all are integers well inside the
+// range where the spacing is 0.5), so the outcome does not depend on rounding, and evaluating
+// alpha * value + beta as a fused multiply-add cannot change it either. The convolutions are shaped
+// so their output is exactly 8.0 for the same reason.
+//
+// The output channel count is deliberately 5, which makes GetMaxComponents(N) == 1. Do not raise it
+// to 6 for tidiness: at N == 6 the components become 2, and MatMulNaiveProgram then indexes its
+// component-reduced bias array with an element-unit `col` (bias[col], versus the output's
+// col / components on the next line). Two of the six channels would read past the end of the bias,
+// pick up no bias, and land on 4.0 instead of 8.0 -- and 4.0 clamps to 0.0 under both alphas, so
+// those channels would silently stop discriminating. Keeping components == 1 keeps every channel on
+// exactly 8.0 and every element of the output sensitive to the collision.
+void RunWebGpuSmallMatMulConvHardSigmoidParamPairTest(float alpha_first, float alpha_second) {
+  if (!DefaultWebGpuExecutionProvider()) {
+    GTEST_SKIP() << "WebGPU EP unavailable in this build.";
+  }
+
+  // Chosen so that alpha * 8 lands 40 below / 40 above the clamp's lower edge.
+  constexpr float kBeta = -8000160.0f;
+
+  auto build_test_case = [&](ModelTestBuilder& builder) {
+    // N = 5 output channels and K = 4 input channels, so N < 8 && K < 8 routes to
+    // MatMulNaiveProgram, and GetMaxComponents(5) == 1 keeps the bias indexing in bounds.
+    auto* input = builder.MakeInput<float>({1, 4, 8, 8}, std::vector<float>(1 * 4 * 8 * 8, 1.0f));
+
+    // Both convolutions output exactly 8.0, by different routes: 4 * (1.0 * 1.0) + 4.0 and
+    // 4 * (1.0 * 0.5) + 6.0. The weights have to differ, or common subexpression elimination folds
+    // the two convolutions into one and only a single MatMulNaive variant is ever compiled.
+    auto* weight_a = builder.MakeInitializer<float>({5, 4, 1, 1}, std::vector<float>(5 * 4, 1.0f));
+    auto* bias_a = builder.MakeInitializer<float>({5}, std::vector<float>(5, 4.0f));
+    auto* weight_b = builder.MakeInitializer<float>({5, 4, 1, 1}, std::vector<float>(5 * 4, 0.5f));
+    auto* bias_b = builder.MakeInitializer<float>({5}, std::vector<float>(5, 6.0f));
+
+    auto* conv_a_out = builder.MakeIntermediate();
+    auto* conv_b_out = builder.MakeIntermediate();
+    auto* output_a = builder.MakeOutput();
+    auto* output_b = builder.MakeOutput();
+
+    builder.AddNode("Conv", {input, weight_a, bias_a}, {conv_a_out});
+    Node& activation_a = builder.AddNode("HardSigmoid", {conv_a_out}, {output_a});
+    activation_a.AddAttribute("alpha", alpha_first);
+    activation_a.AddAttribute("beta", kBeta);
+
+    builder.AddNode("Conv", {input, weight_b, bias_b}, {conv_b_out});
+    Node& activation_b = builder.AddNode("HardSigmoid", {conv_b_out}, {output_b});
+    activation_b.AddAttribute("alpha", alpha_second);
+    activation_b.AddAttribute("beta", kBeta);
+  };
+
+  auto check_transformed_graph = [&](InferenceSessionWrapper& session) {
+    std::vector<float> fused_alphas;
+    for (const auto& node : session.GetGraph().Nodes()) {
+      const auto* activation_attr = graph_utils::GetNodeAttribute(node, "activation");
+      if (activation_attr == nullptr || activation_attr->s() != "HardSigmoid") {
+        continue;
+      }
+      const auto* params_attr = graph_utils::GetNodeAttribute(node, "activation_params");
+      ASSERT_NE(params_attr, nullptr) << "fused HardSigmoid must carry its parameters";
+      ASSERT_GT(params_attr->floats_size(), 0);
+      fused_alphas.push_back(params_attr->floats(0));
+    }
+    // Without this the test could pass trivially if fusion stopped firing: unfused, both branches
+    // run the standalone HardSigmoid kernel, which takes its parameters as uniforms and so has no
+    // collision to expose in the first place.
+    ASSERT_THAT(fused_alphas, ::testing::UnorderedElementsAre(alpha_first, alpha_second))
+        << "expected both convolutions to absorb their HardSigmoid, so that two MatMulNaive "
+           "variants differing only in activation parameters are compiled in one session";
+  };
+
+  RunWebGpuFusionTransformerTest(build_test_case,
+                                 check_transformed_graph,
+                                 TransformerLevel::Level1,
+                                 TransformerLevel::Level2,
+                                 /*opset_version=*/17,
+                                 /*per_sample_tolerance=*/2e-3,
+                                 /*relative_per_sample_tolerance=*/2e-3,
+                                 /*transformer=*/nullptr,
+                                 []() { return DefaultWebGpuExecutionProvider(); });
+}
+
+// The channels-last and channels-first convolution paths share MatMulNaiveProgram but index the
+// bias differently -- bias[col] versus bias[row + i]. Unlike the activation, is_channels_last cannot
+// be made to vary inside a single session, because a session's preferred layout is fixed by its EP.
+//
+// The pipeline cache is not per-session, though. WebGpuContextFactory keeps its contexts in a
+// process-global map keyed by context id and reference counted, so two sessions that are alive at
+// the same time share one context and therefore one program cache. (Sequentially created sessions
+// do not: the refcount drops to zero in between and the context, cache included, is destroyed.)
+// Two concurrent sessions with opposite preferred layouts is therefore the configuration in which
+// this collision is reachable, and it is what this test builds.
+//
+// Both sessions run the same model, shaped so that every other component of the cache key agrees
+// between the two layouts:
+//
+//   input {1, C=3, H=3, W=1}, kernel {M=3, C=3, 1, 1}, bias {3}
+//
+//                     channels-last     channels-first
+//     N (matmul)      M     = 3         H*W   = 3
+//     K (matmul)      C     = 3         C     = 3
+//     components      1                 1
+//     output_number   1                 1
+//     input ranks     3, 3              3, 3
+//
+// leaving is_channels_last as the only difference. components == 1 matters for a second reason: it
+// keeps both bias indexings in bounds, so the sole difference between the two shaders is which bias
+// element each output element receives.
+//
+// The two layouts transpose the roles of row and col, so serving one shader for both indexes the
+// bias by the spatial position instead of the channel (or vice versa). With well separated bias
+// values that is wrong on 6 of the 9 output elements.
+void RunWebGpuConcurrentLayoutConvCacheTest(bool channels_last_first) {
+  if (!DefaultWebGpuExecutionProvider()) {
+    GTEST_SKIP() << "WebGPU EP unavailable in this build.";
+  }
+
+  std::unordered_map<std::string, int> domain_to_version;
+  domain_to_version[kOnnxDomain] = 17;
+  Model model("WebGpuLayoutCacheTester", false, ModelMetaData(), PathString(),
+              IOnnxRuntimeOpSchemaRegistryList(), domain_to_version, {},
+              DefaultLoggingManager().DefaultLogger());
+  ModelTestBuilder builder(model.MainGraph());
+
+  auto* input = builder.MakeInput<float>({1, 3, 3, 1},
+                                         std::vector<float>{1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f});
+  auto* weight = builder.MakeInitializer<float>({3, 3, 1, 1},
+                                                std::vector<float>{1.0f, 0.0f, 0.0f,
+                                                                   0.0f, 1.0f, 0.0f,
+                                                                   0.0f, 0.0f, 1.0f});
+  // Separated by far more than any tolerance, so receiving the wrong element is unmistakable.
+  auto* bias = builder.MakeInitializer<float>({3}, std::vector<float>{100.0f, 200.0f, 300.0f});
+  auto* output = builder.MakeOutput();
+  builder.AddNode("Conv", {input, weight, bias}, {output});
+  builder.SetGraphOutputs();
+  ASSERT_STATUS_OK(model.MainGraph().Resolve());
+
+  std::string model_data;
+  model.ToProto().SerializeToString(&model_data);
+
+  SessionOptions session_options;
+  session_options.graph_optimization_level = TransformerLevel::Level2;
+  RunOptions run_options;
+
+  // Reference values from the CPU EP, which has no such cache and no layout-dependent indexing.
+  std::vector<OrtValue> expected_fetches;
+  {
+    InferenceSessionWrapper cpu_session{session_options, GetEnvironment()};
+    ASSERT_STATUS_OK(cpu_session.Load(model_data.data(), static_cast<int>(model_data.size())));
+    ASSERT_STATUS_OK(cpu_session.Initialize());
+    ASSERT_STATUS_OK(cpu_session.Run(run_options, builder.feeds_, builder.output_names_, &expected_fetches));
+  }
+
+  // Both sessions must be constructed before either runs, and both must stay alive until both have
+  // run: that is what holds the shared context's reference count above zero and keeps one program
+  // cache in play for the whole test.
+  InferenceSessionWrapper session_first{session_options, GetEnvironment()};
+  ASSERT_STATUS_OK(session_first.RegisterExecutionProvider(DefaultWebGpuExecutionProvider(channels_last_first)));
+  ASSERT_STATUS_OK(session_first.Load(model_data.data(), static_cast<int>(model_data.size())));
+  ASSERT_STATUS_OK(session_first.Initialize());
+
+  InferenceSessionWrapper session_second{session_options, GetEnvironment()};
+  ASSERT_STATUS_OK(session_second.RegisterExecutionProvider(DefaultWebGpuExecutionProvider(!channels_last_first)));
+  ASSERT_STATUS_OK(session_second.Load(model_data.data(), static_cast<int>(model_data.size())));
+  ASSERT_STATUS_OK(session_second.Initialize());
+
+  // A convolution that fell back to the CPU EP would agree with the reference no matter what the
+  // cache did, so check the assignment rather than assume it.
+  for (const auto* session : {&session_first, &session_second}) {
+    bool saw_webgpu_conv = false;
+    for (const auto& node : session->GetGraph().Nodes()) {
+      if (node.OpType() == "Conv" || node.OpType() == "NhwcConv" || node.OpType() == "FusedConv") {
+        EXPECT_EQ(node.GetExecutionProviderType(), kWebGpuExecutionProvider);
+        saw_webgpu_conv = node.GetExecutionProviderType() == kWebGpuExecutionProvider;
+      }
+    }
+    ASSERT_TRUE(saw_webgpu_conv) << "expected the convolution to run on the WebGPU EP";
+  }
+
+  std::vector<OrtValue> fetches_first;
+  ASSERT_STATUS_OK(session_first.Run(run_options, builder.feeds_, builder.output_names_, &fetches_first));
+  std::vector<OrtValue> fetches_second;
+  ASSERT_STATUS_OK(session_second.Run(run_options, builder.feeds_, builder.output_names_, &fetches_second));
+
+  ASSERT_EQ(expected_fetches.size(), fetches_first.size());
+  ASSERT_EQ(expected_fetches.size(), fetches_second.size());
+  for (size_t i = 0; i < expected_fetches.size(); ++i) {
+    auto first = CompareOrtValue(fetches_first[i], expected_fetches[i], 2e-3, 2e-3, false);
+    EXPECT_EQ(first.first, COMPARE_RESULT::SUCCESS)
+        << "first session (channels_last=" << channels_last_first << "): " << first.second;
+    auto second = CompareOrtValue(fetches_second[i], expected_fetches[i], 2e-3, 2e-3, false);
+    EXPECT_EQ(second.first, COMPARE_RESULT::SUCCESS)
+        << "second session (channels_last=" << !channels_last_first << "): " << second.second;
+  }
+}
+
+}  // namespace
+
+// Relu and Sigmoid disagree on every input, so if one shader is served for both the mismatch is
+// unmissable. Both orderings run so a collision in either direction fails.
+TEST_F(GraphTransformationTests, WebGpuSmallMatMulConvDistinguishesActivationsInPipelineCache) {
+  RunWebGpuSmallMatMulConvActivationPairTest("Relu", "Sigmoid");
+  RunWebGpuSmallMatMulConvActivationPairTest("Sigmoid", "Relu");
+}
+
+// 1000015 and 1000025 are 160 float32 ULPs apart, yet both format as "1.00002e+06" at the
+// stringstream default of 6 significant digits -- so before the fix they produced one cache key and
+// two different shaders. Both orderings run so a collision in either direction fails.
+TEST_F(GraphTransformationTests, WebGpuSmallMatMulConvDistinguishesActivationParamsInPipelineCache) {
+  RunWebGpuSmallMatMulConvHardSigmoidParamPairTest(1000015.0f, 1000025.0f);
+  RunWebGpuSmallMatMulConvHardSigmoidParamPairTest(1000025.0f, 1000015.0f);
+}
+
+// Two concurrent sessions with opposite preferred layouts share one process-global pipeline cache,
+// so the shader's choice between bias[col] and bias[row + i] has to be part of the key. Both
+// orderings run so a collision in either direction fails.
+TEST_F(GraphTransformationTests, WebGpuConcurrentLayoutConvsDistinguishedInPipelineCache) {
+  RunWebGpuConcurrentLayoutConvCacheTest(/*channels_last_first=*/true);
+  RunWebGpuConcurrentLayoutConvCacheTest(/*channels_last_first=*/false);
+}
+#endif  // defined(USE_WEBGPU)
 
 TEST_F(GraphTransformationTests, FuseConvClip11Activation) {
   constexpr const ORTCHAR_T* model_uri = MODEL_FOLDER "fusion/conv_clip11.onnx";

--- a/onnxruntime/test/optimizer/graph_transform_test.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test.cc
@@ -3168,29 +3168,8 @@ TEST_F(GraphTransformationTests, FuseConvActivation) {
   }
 }
 
-// Regression test for a pipeline-cache key collision on the small-matmul conv path.
-//
-// A 1x1 convolution with fewer than 8 channels on each side is lowered to MatMulNaiveProgram, which
-// bakes the activation expression directly into its WGSL. That program's cache hint omitted the
-// activation entirely, so two convolutions with identical shapes but different activations hashed
-// to the same key: whichever compiled first was served to both, and the second silently computed
-// the wrong activation. The collision this test covers is on the activation *kind*. Parameter-valued
-// collisions -- two activations of the same kind whose float parameters format identically in the
-// key -- are a separate mechanism, addressed by the max_digits10 setprecision in Activation::ToString
-// and covered here by WebGpuSmallMatMulConvDistinguishesActivationParamsInPipelineCache (end to end)
-// and by ActivationCacheKeyTest (the formatter itself).
-//
-// Deliberately self-contained rather than built on the Conv+activation parity helper below, so the
-// fix and its regression test can travel as a single commit.
 #if defined(USE_WEBGPU)
 namespace {
-// Runs a model containing two 1x1 convolutions that differ *only* in their activation, and
-// requires the fused results to match the unfused baseline.
-//
-// Both convolutions live in the same graph, so at Level2 both fused shaders are compiled inside a
-// single session against a single pipeline cache. That is what makes the collision observable: a
-// test that ran one activation per session would not catch it, because each session would only
-// ever need one MatMulNaive variant.
 void RunWebGpuSmallMatMulConvActivationPairTest(const std::string& activation_a,
                                                 const std::string& activation_b) {
   if (!DefaultWebGpuExecutionProvider()) {
@@ -3198,13 +3177,10 @@ void RunWebGpuSmallMatMulConvActivationPairTest(const std::string& activation_a,
   }
 
   auto build_test_case = [&](ModelTestBuilder& builder) {
-    // C_in = 4 and C_out = 6 put both matmul dimensions under the < 8 threshold that selects
-    // MatMulNaiveProgram; the 1x1 kernel with unit stride and no padding is what routes there.
+    // Keep N and K below 8 to select MatMulNaiveProgram.
     auto* input = builder.MakeInput<float>({1, 4, 8, 8}, -3.0f, 3.0f);
 
-    // Distinct weights so the two branches cannot be collapsed into one by common subexpression
-    // elimination. The shapes are identical, so both convolutions produce the same cache key for
-    // everything except the activation.
+    // Use distinct weights to prevent common subexpression elimination.
     auto* weight_a = builder.MakeInitializer<float>({6, 4, 1, 1}, -0.5f, 0.5f);
     auto* bias_a = builder.MakeInitializer<float>({6}, -0.5f, 0.5f);
     auto* weight_b = builder.MakeInitializer<float>({6, 4, 1, 1}, -0.5f, 0.5f);
@@ -3229,8 +3205,8 @@ void RunWebGpuSmallMatMulConvActivationPairTest(const std::string& activation_a,
         fused_activations.insert(activation_attr->s());
       }
     }
-    // Without this the test could pass trivially if fusion ever stopped firing, because an unfused
-    // graph matches the unfused baseline by construction.
+    // Ensure both activations are fused into Conv; otherwise this test would not exercise
+    // the activation-specific MatMulNaiveProgram path.
     ASSERT_THAT(fused_activations, ::testing::UnorderedElementsAre(activation_a, activation_b))
         << "expected both convolutions to absorb their activation, so that two MatMulNaive "
            "variants are compiled in one session";
@@ -3247,53 +3223,19 @@ void RunWebGpuSmallMatMulConvActivationPairTest(const std::string& activation_a,
                                  []() { return DefaultWebGpuExecutionProvider(); });
 }
 
-// Companion to the helper above, for a collision on the activation *parameters* rather than the
-// kind. Two HardSigmoid activations of the same kind whose alphas differ are still distinct shaders,
-// so they must still be distinct cache entries.
-//
-// Picking the parameters is the whole difficulty. The key was written by an unconfigured
-// std::stringstream (6 *significant* digits) while the WGSL is written by std::to_string (6 *decimal
-// places*), so a collision needs two alphas that agree to 6 significant digits yet differ as floats.
-// That bounds their relative difference at ~1e-5, which is far below the tolerance any float32
-// comparison can use -- so with an activation like LeakyRelu, whose output is alpha*x, the wrong
-// shader produces a difference too small to detect end to end at any input scale.
-//
-// HardSigmoid is what makes it observable, because clamp(alpha * value + beta, 0, 1) pins the output
-// to [0, 1] regardless of how large alpha is. A tiny relative difference in alpha becomes a large
-// absolute difference in the intermediate, and the clamp turns that into a full-scale 0-vs-1 swing:
-//
-//   conv output = 8.0 exactly
-//   alpha_a * 8 + beta = 8000120 - 8000160 = -40 -> clamp -> 0.0
-//   alpha_b * 8 + beta = 8000200 - 8000160 = +40 -> clamp -> 1.0
-//
-// Every intermediate above is an exactly representable float32 (all are integers well inside the
-// range where the spacing is 0.5), so the outcome does not depend on rounding, and evaluating
-// alpha * value + beta as a fused multiply-add cannot change it either. The convolutions are shaped
-// so their output is exactly 8.0 for the same reason.
-//
-// The output channel count is deliberately 5, which makes GetMaxComponents(N) == 1. Do not raise it
-// to 6 for tidiness: at N == 6 the components become 2, and MatMulNaiveProgram then indexes its
-// component-reduced bias array with an element-unit `col` (bias[col], versus the output's
-// col / components on the next line). Two of the six channels would read past the end of the bias,
-// pick up no bias, and land on 4.0 instead of 8.0 -- and 4.0 clamps to 0.0 under both alphas, so
-// those channels would silently stop discriminating. Keeping components == 1 keeps every channel on
-// exactly 8.0 and every element of the output sensitive to the collision.
 void RunWebGpuSmallMatMulConvHardSigmoidParamPairTest(float alpha_first, float alpha_second) {
   if (!DefaultWebGpuExecutionProvider()) {
     GTEST_SKIP() << "WebGPU EP unavailable in this build.";
   }
 
-  // Chosen so that alpha * 8 lands 40 below / 40 above the clamp's lower edge.
+  // Choose beta so the alpha values clamp to different outputs when Conv produces 8.
   constexpr float kBeta = -8000160.0f;
 
   auto build_test_case = [&](ModelTestBuilder& builder) {
-    // N = 5 output channels and K = 4 input channels, so N < 8 && K < 8 routes to
-    // MatMulNaiveProgram, and GetMaxComponents(5) == 1 keeps the bias indexing in bounds.
+    // Keep N and K below 8 to select MatMulNaiveProgram; N = 5 keeps its bias indexing in bounds.
     auto* input = builder.MakeInput<float>({1, 4, 8, 8}, std::vector<float>(1 * 4 * 8 * 8, 1.0f));
 
-    // Both convolutions output exactly 8.0, by different routes: 4 * (1.0 * 1.0) + 4.0 and
-    // 4 * (1.0 * 0.5) + 6.0. The weights have to differ, or common subexpression elimination folds
-    // the two convolutions into one and only a single MatMulNaive variant is ever compiled.
+    // Produce 8 with distinct weights to prevent common subexpression elimination.
     auto* weight_a = builder.MakeInitializer<float>({5, 4, 1, 1}, std::vector<float>(5 * 4, 1.0f));
     auto* bias_a = builder.MakeInitializer<float>({5}, std::vector<float>(5, 4.0f));
     auto* weight_b = builder.MakeInitializer<float>({5, 4, 1, 1}, std::vector<float>(5 * 4, 0.5f));
@@ -3327,9 +3269,7 @@ void RunWebGpuSmallMatMulConvHardSigmoidParamPairTest(float alpha_first, float a
       ASSERT_GT(params_attr->floats_size(), 0);
       fused_alphas.push_back(params_attr->floats(0));
     }
-    // Without this the test could pass trivially if fusion stopped firing: unfused, both branches
-    // run the standalone HardSigmoid kernel, which takes its parameters as uniforms and so has no
-    // collision to expose in the first place.
+    // Ensure both activations are fused into Conv to exercise the parameter-specific MatMulNaiveProgram path.
     ASSERT_THAT(fused_alphas, ::testing::UnorderedElementsAre(alpha_first, alpha_second))
         << "expected both convolutions to absorb their HardSigmoid, so that two MatMulNaive "
            "variants differing only in activation parameters are compiled in one session";
@@ -3346,36 +3286,6 @@ void RunWebGpuSmallMatMulConvHardSigmoidParamPairTest(float alpha_first, float a
                                  []() { return DefaultWebGpuExecutionProvider(); });
 }
 
-// The channels-last and channels-first convolution paths share MatMulNaiveProgram but index the
-// bias differently -- bias[col] versus bias[row + i]. Unlike the activation, is_channels_last cannot
-// be made to vary inside a single session, because a session's preferred layout is fixed by its EP.
-//
-// The pipeline cache is not per-session, though. WebGpuContextFactory keeps its contexts in a
-// process-global map keyed by context id and reference counted, so two sessions that are alive at
-// the same time share one context and therefore one program cache. (Sequentially created sessions
-// do not: the refcount drops to zero in between and the context, cache included, is destroyed.)
-// Two concurrent sessions with opposite preferred layouts is therefore the configuration in which
-// this collision is reachable, and it is what this test builds.
-//
-// Both sessions run the same model, shaped so that every other component of the cache key agrees
-// between the two layouts:
-//
-//   input {1, C=3, H=3, W=1}, kernel {M=3, C=3, 1, 1}, bias {3}
-//
-//                     channels-last     channels-first
-//     N (matmul)      M     = 3         H*W   = 3
-//     K (matmul)      C     = 3         C     = 3
-//     components      1                 1
-//     output_number   1                 1
-//     input ranks     3, 3              3, 3
-//
-// leaving is_channels_last as the only difference. components == 1 matters for a second reason: it
-// keeps both bias indexings in bounds, so the sole difference between the two shaders is which bias
-// element each output element receives.
-//
-// The two layouts transpose the roles of row and col, so serving one shader for both indexes the
-// bias by the spatial position instead of the channel (or vice versa). With well separated bias
-// values that is wrong on 6 of the 9 output elements.
 void RunWebGpuConcurrentLayoutConvCacheTest(bool channels_last_first) {
   if (!DefaultWebGpuExecutionProvider()) {
     GTEST_SKIP() << "WebGPU EP unavailable in this build.";
@@ -3388,13 +3298,14 @@ void RunWebGpuConcurrentLayoutConvCacheTest(bool channels_last_first) {
               DefaultLoggingManager().DefaultLogger());
   ModelTestBuilder builder(model.MainGraph());
 
+  // Keep N, K, and components equal across the channels-first and channels-last paths.
   auto* input = builder.MakeInput<float>({1, 3, 3, 1},
                                          std::vector<float>{1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f});
   auto* weight = builder.MakeInitializer<float>({3, 3, 1, 1},
                                                 std::vector<float>{1.0f, 0.0f, 0.0f,
                                                                    0.0f, 1.0f, 0.0f,
                                                                    0.0f, 0.0f, 1.0f});
-  // Separated by far more than any tolerance, so receiving the wrong element is unmistakable.
+  // Use distinct bias values to expose layout-dependent indexing.
   auto* bias = builder.MakeInitializer<float>({3}, std::vector<float>{100.0f, 200.0f, 300.0f});
   auto* output = builder.MakeOutput();
   builder.AddNode("Conv", {input, weight, bias}, {output});
@@ -3408,7 +3319,6 @@ void RunWebGpuConcurrentLayoutConvCacheTest(bool channels_last_first) {
   session_options.graph_optimization_level = TransformerLevel::Level2;
   RunOptions run_options;
 
-  // Reference values from the CPU EP, which has no such cache and no layout-dependent indexing.
   std::vector<OrtValue> expected_fetches;
   {
     InferenceSessionWrapper cpu_session{session_options, GetEnvironment()};
@@ -3417,9 +3327,7 @@ void RunWebGpuConcurrentLayoutConvCacheTest(bool channels_last_first) {
     ASSERT_STATUS_OK(cpu_session.Run(run_options, builder.feeds_, builder.output_names_, &expected_fetches));
   }
 
-  // Both sessions must be constructed before either runs, and both must stay alive until both have
-  // run: that is what holds the shared context's reference count above zero and keeps one program
-  // cache in play for the whole test.
+  // Keep both sessions alive so they share the WebGPU program cache.
   InferenceSessionWrapper session_first{session_options, GetEnvironment()};
   ASSERT_STATUS_OK(session_first.RegisterExecutionProvider(DefaultWebGpuExecutionProvider(channels_last_first)));
   ASSERT_STATUS_OK(session_first.Load(model_data.data(), static_cast<int>(model_data.size())));
@@ -3430,8 +3338,7 @@ void RunWebGpuConcurrentLayoutConvCacheTest(bool channels_last_first) {
   ASSERT_STATUS_OK(session_second.Load(model_data.data(), static_cast<int>(model_data.size())));
   ASSERT_STATUS_OK(session_second.Initialize());
 
-  // A convolution that fell back to the CPU EP would agree with the reference no matter what the
-  // cache did, so check the assignment rather than assume it.
+  // Ensure both convolutions run on the WebGPU EP.
   for (const auto* session : {&session_first, &session_second}) {
     bool saw_webgpu_conv = false;
     for (const auto& node : session->GetGraph().Nodes()) {
@@ -3462,24 +3369,17 @@ void RunWebGpuConcurrentLayoutConvCacheTest(bool channels_last_first) {
 
 }  // namespace
 
-// Relu and Sigmoid disagree on every input, so if one shader is served for both the mismatch is
-// unmissable. Both orderings run so a collision in either direction fails.
 TEST_F(GraphTransformationTests, WebGpuSmallMatMulConvDistinguishesActivationsInPipelineCache) {
   RunWebGpuSmallMatMulConvActivationPairTest("Relu", "Sigmoid");
   RunWebGpuSmallMatMulConvActivationPairTest("Sigmoid", "Relu");
 }
 
-// 1000015 and 1000025 are 160 float32 ULPs apart, yet both format as "1.00002e+06" at the
-// stringstream default of 6 significant digits -- so before the fix they produced one cache key and
-// two different shaders. Both orderings run so a collision in either direction fails.
+// Use distinct alpha values that match at the stringstream default precision.
 TEST_F(GraphTransformationTests, WebGpuSmallMatMulConvDistinguishesActivationParamsInPipelineCache) {
   RunWebGpuSmallMatMulConvHardSigmoidParamPairTest(1000015.0f, 1000025.0f);
   RunWebGpuSmallMatMulConvHardSigmoidParamPairTest(1000025.0f, 1000015.0f);
 }
 
-// Two concurrent sessions with opposite preferred layouts share one process-global pipeline cache,
-// so the shader's choice between bias[col] and bias[row + i] has to be part of the key. Both
-// orderings run so a collision in either direction fails.
 TEST_F(GraphTransformationTests, WebGpuConcurrentLayoutConvsDistinguishedInPipelineCache) {
   RunWebGpuConcurrentLayoutConvCacheTest(/*channels_last_first=*/true);
   RunWebGpuConcurrentLayoutConvCacheTest(/*channels_last_first=*/false);

--- a/onnxruntime/test/optimizer/webgpu_fusion_test_util.h
+++ b/onnxruntime/test/optimizer/webgpu_fusion_test_util.h
@@ -85,9 +85,9 @@ inline void RunWebGpuFusionTransformerTest(
     }
   };
 
-// ASSERT_NO_FATAL_FAILURE is load-bearing, even though run_model returns void.
-// It propagates fatal assertion failures from run_model and its nested calls,
-// preventing the test from continuing after a failure.
+  // ASSERT_NO_FATAL_FAILURE is load-bearing, even though run_model returns void.
+  // It propagates fatal assertion failures from run_model and its nested calls,
+  // preventing the test from continuing after a failure.
   std::vector<OrtValue> baseline_fetches;
   ASSERT_NO_FATAL_FAILURE(run_model(baseline_level, baseline_fetches, /*level_transformer=*/nullptr));
 

--- a/onnxruntime/test/optimizer/webgpu_fusion_test_util.h
+++ b/onnxruntime/test/optimizer/webgpu_fusion_test_util.h
@@ -85,10 +85,9 @@ inline void RunWebGpuFusionTransformerTest(
     }
   };
 
-  // ASSERT_NO_FATAL_FAILURE here is load-bearing. run_model returns void, so a failed ASSERT_*
-  // inside it -- including any inside check_transformed_graph -- only returns from the lambda.
-  // These wrappers are what propagate such a failure and stop the test; replacing them with bare
-  // calls would let execution continue past a failed assertion.
+// ASSERT_NO_FATAL_FAILURE is load-bearing, even though run_model returns void.
+// It propagates fatal assertion failures from run_model and its nested calls,
+// preventing the test from continuing after a failure.
   std::vector<OrtValue> baseline_fetches;
   ASSERT_NO_FATAL_FAILURE(run_model(baseline_level, baseline_fetches, /*level_transformer=*/nullptr));
 

--- a/onnxruntime/test/optimizer/webgpu_fusion_test_util.h
+++ b/onnxruntime/test/optimizer/webgpu_fusion_test_util.h
@@ -85,6 +85,10 @@ inline void RunWebGpuFusionTransformerTest(
     }
   };
 
+  // ASSERT_NO_FATAL_FAILURE here is load-bearing. run_model returns void, so a failed ASSERT_*
+  // inside it -- including any inside check_transformed_graph -- only returns from the lambda.
+  // These wrappers are what propagate such a failure and stop the test; replacing them with bare
+  // calls would let execution continue past a failed assertion.
   std::vector<OrtValue> baseline_fetches;
   ASSERT_NO_FATAL_FAILURE(run_model(baseline_level, baseline_fetches, /*level_transformer=*/nullptr));
 

--- a/onnxruntime/test/providers/webgpu/activation_cache_key_test.cc
+++ b/onnxruntime/test/providers/webgpu/activation_cache_key_test.cc
@@ -1,0 +1,97 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <string>
+
+#include "gtest/gtest.h"
+
+#include "core/providers/webgpu/nn/fuse_utils.h"
+
+namespace onnxruntime {
+namespace test {
+namespace {
+
+webgpu::Activation MakeActivation(webgpu::ActivationKind kind, float value0, float value1 = 0.0f) {
+  webgpu::Activation activation;
+  activation.activation_kind_ = kind;
+  activation.activation_params_.values_[0] = value0;
+  activation.activation_params_.values_[1] = value1;
+  return activation;
+}
+
+}  // namespace
+
+// Activation::ToString() is the cache hint used by every program that bakes the activation into its
+// WGSL, and GetActivationSnippet() writes those same parameters into the shader text with
+// std::to_string. The two formatters must agree on what counts as a distinct parameter: if the key
+// collapses two values that the shader distinguishes, the first program compiled is served for both
+// and the second silently runs with the wrong parameter.
+//
+// They did not agree. std::to_string is 6 *decimal places*, while an unconfigured std::stringstream
+// is 6 *significant* digits, so the pairs below -- all exactly representable in float32 -- produced
+// one key and two different shaders. Activation::ToString() now sets max_digits10, which is by
+// definition the shortest precision that round-trips every float.
+//
+// These assertions are on the formatter alone, so the test needs no GPU and runs on any CI agent,
+// including those where the WebGPU end-to-end tests skip for want of an adapter.
+//
+// A graph-level test covers this too -- see
+// WebGpuSmallMatMulConvDistinguishesActivationParamsInPipelineCache -- but only for activations that
+// can amplify the difference. Colliding under 6 significant digits bounds the two parameters to
+// within about 1e-5 relative, so for an activation whose output is proportional to the parameter
+// (LeakyRelu: alpha * x) the outputs stay within 1e-5 relative too, against a 2e-3 relative
+// tolerance. That test therefore uses HardSigmoid, where clamping to [0, 1] turns the same 1e-5 into
+// a full 0-versus-1 swing.
+
+TEST(ActivationCacheKeyTest, DistinctLeakyReluAlphasProduceDistinctKeys) {
+  constexpr float kAlphaA = 1234567.5f;
+  constexpr float kAlphaB = 1234567.625f;
+  // Guards the premise: if these ever became the same float the assertion below would be vacuous.
+  ASSERT_NE(kAlphaA, kAlphaB);
+
+  const auto activation_a = MakeActivation(webgpu::ActivationKind::LeakyRelu, kAlphaA);
+  const auto activation_b = MakeActivation(webgpu::ActivationKind::LeakyRelu, kAlphaB);
+
+  EXPECT_NE(activation_a.ToString(), activation_b.ToString())
+      << "two LeakyRelu alphas that emit different WGSL hashed to the same pipeline cache key";
+}
+
+TEST(ActivationCacheKeyTest, DistinctClipBoundsProduceDistinctKeys) {
+  constexpr float kMaxA = 1000000.0f;
+  constexpr float kMaxB = 1000000.0625f;
+  ASSERT_NE(kMaxA, kMaxB);
+
+  // Clip stores {minimum, maximum}, so this exercises the second parameter as well as the first.
+  const auto activation_a = MakeActivation(webgpu::ActivationKind::Clip, 0.0f, kMaxA);
+  const auto activation_b = MakeActivation(webgpu::ActivationKind::Clip, 0.0f, kMaxB);
+
+  EXPECT_NE(activation_a.ToString(), activation_b.ToString())
+      << "two Clip bounds that emit different WGSL hashed to the same pipeline cache key";
+}
+
+// Positive control. Without this the two tests above would still pass if ToString() returned
+// something unconditionally unique, which would defeat the cache rather than key it correctly.
+TEST(ActivationCacheKeyTest, IdenticalActivationsProduceIdenticalKeys) {
+  const auto activation_a = MakeActivation(webgpu::ActivationKind::LeakyRelu, 0.01f);
+  const auto activation_b = MakeActivation(webgpu::ActivationKind::LeakyRelu, 0.01f);
+
+  EXPECT_EQ(activation_a.ToString(), activation_b.ToString())
+      << "identical activations must share a cache entry";
+
+  const auto clip_a = MakeActivation(webgpu::ActivationKind::Clip, -6.0f, 6.0f);
+  const auto clip_b = MakeActivation(webgpu::ActivationKind::Clip, -6.0f, 6.0f);
+
+  EXPECT_EQ(clip_a.ToString(), clip_b.ToString());
+}
+
+// The activation kind must remain part of the key independently of the parameters: Relu and Sigmoid
+// carry no parameters at all, so only the kind can separate them.
+TEST(ActivationCacheKeyTest, DistinctActivationKindsProduceDistinctKeys) {
+  const auto relu = MakeActivation(webgpu::ActivationKind::Relu, 0.0f);
+  const auto sigmoid = MakeActivation(webgpu::ActivationKind::Sigmoid, 0.0f);
+
+  EXPECT_NE(relu.ToString(), sigmoid.ToString());
+}
+
+}  // namespace test
+}  // namespace onnxruntime

--- a/onnxruntime/test/providers/webgpu/activation_cache_key_test.cc
+++ b/onnxruntime/test/providers/webgpu/activation_cache_key_test.cc
@@ -21,32 +21,9 @@ webgpu::Activation MakeActivation(webgpu::ActivationKind kind, float value0, flo
 
 }  // namespace
 
-// Activation::ToString() is the cache hint used by every program that bakes the activation into its
-// WGSL, and GetActivationSnippet() writes those same parameters into the shader text with
-// std::to_string. The two formatters must agree on what counts as a distinct parameter: if the key
-// collapses two values that the shader distinguishes, the first program compiled is served for both
-// and the second silently runs with the wrong parameter.
-//
-// They did not agree. std::to_string is 6 *decimal places*, while an unconfigured std::stringstream
-// is 6 *significant* digits, so the pairs below -- all exactly representable in float32 -- produced
-// one key and two different shaders. Activation::ToString() now sets max_digits10, which is by
-// definition the shortest precision that round-trips every float.
-//
-// These assertions are on the formatter alone, so the test needs no GPU and runs on any CI agent,
-// including those where the WebGPU end-to-end tests skip for want of an adapter.
-//
-// A graph-level test covers this too -- see
-// WebGpuSmallMatMulConvDistinguishesActivationParamsInPipelineCache -- but only for activations that
-// can amplify the difference. Colliding under 6 significant digits bounds the two parameters to
-// within about 1e-5 relative, so for an activation whose output is proportional to the parameter
-// (LeakyRelu: alpha * x) the outputs stay within 1e-5 relative too, against a 2e-3 relative
-// tolerance. That test therefore uses HardSigmoid, where clamping to [0, 1] turns the same 1e-5 into
-// a full 0-versus-1 swing.
-
 TEST(ActivationCacheKeyTest, DistinctLeakyReluAlphasProduceDistinctKeys) {
   constexpr float kAlphaA = 1234567.5f;
   constexpr float kAlphaB = 1234567.625f;
-  // Guards the premise: if these ever became the same float the assertion below would be vacuous.
   ASSERT_NE(kAlphaA, kAlphaB);
 
   const auto activation_a = MakeActivation(webgpu::ActivationKind::LeakyRelu, kAlphaA);
@@ -61,7 +38,7 @@ TEST(ActivationCacheKeyTest, DistinctClipBoundsProduceDistinctKeys) {
   constexpr float kMaxB = 1000000.0625f;
   ASSERT_NE(kMaxA, kMaxB);
 
-  // Clip stores {minimum, maximum}, so this exercises the second parameter as well as the first.
+  // Exercise the second activation parameter.
   const auto activation_a = MakeActivation(webgpu::ActivationKind::Clip, 0.0f, kMaxA);
   const auto activation_b = MakeActivation(webgpu::ActivationKind::Clip, 0.0f, kMaxB);
 
@@ -69,8 +46,6 @@ TEST(ActivationCacheKeyTest, DistinctClipBoundsProduceDistinctKeys) {
       << "two Clip bounds that emit different WGSL hashed to the same pipeline cache key";
 }
 
-// Positive control. Without this the two tests above would still pass if ToString() returned
-// something unconditionally unique, which would defeat the cache rather than key it correctly.
 TEST(ActivationCacheKeyTest, IdenticalActivationsProduceIdenticalKeys) {
   const auto activation_a = MakeActivation(webgpu::ActivationKind::LeakyRelu, 0.01f);
   const auto activation_b = MakeActivation(webgpu::ActivationKind::LeakyRelu, 0.01f);
@@ -84,8 +59,6 @@ TEST(ActivationCacheKeyTest, IdenticalActivationsProduceIdenticalKeys) {
   EXPECT_EQ(clip_a.ToString(), clip_b.ToString());
 }
 
-// The activation kind must remain part of the key independently of the parameters: Relu and Sigmoid
-// carry no parameters at all, so only the kind can separate them.
 TEST(ActivationCacheKeyTest, DistinctActivationKindsProduceDistinctKeys) {
   const auto relu = MakeActivation(webgpu::ActivationKind::Relu, 0.0f);
   const auto sigmoid = MakeActivation(webgpu::ActivationKind::Sigmoid, 0.0f);


### PR DESCRIPTION
### Description

`MatMulNaiveProgram` bakes three things into its generated WGSL that its pipeline cache hint did not
declare. Any of them can serve a shader compiled for one configuration to a different one, which
produces wrong results with no error and no warning.

**1. The activation kind.** Two convolutions with identical shapes and different activations hashed to
the same key, so the first shader compiled was reused for the second.

**2. Activation parameters, via a formatting mismatch.** `Activation::ToString()` streamed floats
through an unconfigured `std::stringstream` ( 6 significant digits)  while `GetActivationSnippet()`
emits them with `std::to_string` (6 decimal places). Values agreeing to 6 significant digits but
differing as floats therefore produced one key and two different shaders. The maximally separated
colliding pair is `1000015.0` / `1000025.0`, 160 float32 ULPs apart, both keyed as `1.00002e+06`.
Fixed centrally in `ToString()` with `std::setprecision(std::numeric_limits<float>::max_digits10)`,
so all six call sites that use it as a hint are corrected at once.

**3. `is_channels_last`.** It selects between `bias[col]` and `bias[row + i]` in the same program, and
`conv.cc` varies it, but it was absent from the hint. Added at both `MatMulNaiveProgram` call sites.

Defects 1 and 3 are the same omission: five of the six programs on `main` that bake an activation into
WGSL already declared it in their key, and four of those five also declared `is_channels_last`.
`MatMulNaiveProgram` was the sole holdout on both counts. Defect 2 is pre-existing and shared
(`main`'s `ToString()` is byte-identical) which is why the fix is in `ToString()` rather than at the
call site.

### Motivation and Context

Reachable from Conv today: a 1x1 kernel with unit stride and no padding lowers to a matmul, and when N
and K are both under 8 it dispatches `MatMulNaiveProgram`.

The regression tests put both convolutions in a **single graph** on purpose. Sequentially created
sessions each get a fresh pipeline cache `WebGpuContextFactory` refcounts its contexts and destroys
one at refcount zero) so running one activation per session cannot reproduce the bug. Concurrent
sessions are different: contexts are held in a process-global map keyed by `context_id`, so two live
sessions share one cache. That is what makes defect 3 reachable, and the layout test builds exactly
that configuration.