### PR TITLE
Fix/qdq optional zero point input

### DIFF
--- a/onnxruntime/core/graph/graph_utils.cc
+++ b/onnxruntime/core/graph/graph_utils.cc
@@ -1001,28 +1001,33 @@ void AddNodeInput(Node& target, int target_input_idx, NodeArg& new_input) {
 }
 
 void SetOptionalNodeInput(Graph& graph, Node& target, size_t target_input_idx, NodeArg& new_input) {
-  auto& definitions = target.MutableDefinitions();
-  auto& input_defs = definitions.input_defs;
-  auto& input_arg_counts = definitions.input_arg_count;
+  auto& input_defs = target.MutableInputDefs();
+  auto& input_arg_counts = target.MutableInputArgsCount();
   ORT_ENFORCE(input_arg_counts.size() > target_input_idx,
               "Missing input metadata for optional input ", target_input_idx,
               " of node ", target.Name(), " (", target.OpType(), ").");
 
   const size_t original_size = input_defs.size();
   if (original_size <= target_input_idx) {
-    NodeArg& empty_input = graph.GetOrCreateNodeArg("", nullptr);
-    input_defs.resize(target_input_idx + 1, &empty_input);
-
     for (size_t index = original_size; index <= target_input_idx; ++index) {
       ORT_ENFORCE(input_arg_counts[index] == 0,
                   "Expected omitted optional input ", index,
                   " of node ", target.Name(), " (", target.OpType(), ").");
-      input_arg_counts[index] = 1;
     }
   } else if (input_defs[target_input_idx] == nullptr || !input_defs[target_input_idx]->Exists()) {
     ORT_ENFORCE(input_arg_counts[target_input_idx] == 0 || input_arg_counts[target_input_idx] == 1,
                 "Expected omitted optional input ", target_input_idx,
                 " of node ", target.Name(), " (", target.OpType(), ").");
+  }
+
+  graph.SetGraphResolveNeeded().SetGraphProtoSyncNeeded();
+  if (original_size <= target_input_idx) {
+    NodeArg& empty_input = graph.GetOrCreateNodeArg("", nullptr);
+    input_defs.resize(target_input_idx + 1, &empty_input);
+    for (size_t index = original_size; index <= target_input_idx; ++index) {
+      input_arg_counts[index] = 1;
+    }
+  } else if (input_defs[target_input_idx] == nullptr || !input_defs[target_input_idx]->Exists()) {
     input_arg_counts[target_input_idx] = 1;
   }
 

--- a/onnxruntime/core/graph/graph_utils.cc
+++ b/onnxruntime/core/graph/graph_utils.cc
@@ -1000,6 +1000,35 @@ void AddNodeInput(Node& target, int target_input_idx, NodeArg& new_input) {
   target.MutableInputArgsCount()[target_input_idx] = 1;
 }
 
+void SetOptionalNodeInput(Graph& graph, Node& target, size_t target_input_idx, NodeArg& new_input) {
+  auto& definitions = target.MutableDefinitions();
+  auto& input_defs = definitions.input_defs;
+  auto& input_arg_counts = definitions.input_arg_count;
+  ORT_ENFORCE(input_arg_counts.size() > target_input_idx,
+              "Missing input metadata for optional input ", target_input_idx,
+              " of node ", target.Name(), " (", target.OpType(), ").");
+
+  const size_t original_size = input_defs.size();
+  if (original_size <= target_input_idx) {
+    NodeArg& empty_input = graph.GetOrCreateNodeArg("", nullptr);
+    input_defs.resize(target_input_idx + 1, &empty_input);
+
+    for (size_t index = original_size; index <= target_input_idx; ++index) {
+      ORT_ENFORCE(input_arg_counts[index] == 0,
+                  "Expected omitted optional input ", index,
+                  " of node ", target.Name(), " (", target.OpType(), ").");
+      input_arg_counts[index] = 1;
+    }
+  } else if (input_defs[target_input_idx] == nullptr || !input_defs[target_input_idx]->Exists()) {
+    ORT_ENFORCE(input_arg_counts[target_input_idx] == 0 || input_arg_counts[target_input_idx] == 1,
+                "Expected omitted optional input ", target_input_idx,
+                " of node ", target.Name(), " (", target.OpType(), ").");
+    input_arg_counts[target_input_idx] = 1;
+  }
+
+  input_defs[target_input_idx] = &new_input;
+}
+
 void FinalizeNodeFusion(Graph& graph, Node& first_node, Node& second_node) {
   // move the outputs from second_node to first_node
   RemoveNodeOutputEdges(graph, first_node);

--- a/onnxruntime/core/graph/graph_utils.h
+++ b/onnxruntime/core/graph/graph_utils.h
@@ -350,6 +350,12 @@ void ReplaceNodeInput(Node& target, int target_input_idx, NodeArg& new_input);
 */
 void AddNodeInput(Node& target, int target_input_idx, NodeArg& new_input);
 
+/** Set a non-variadic optional node input, materializing omitted slots up to target_input_idx.
+@remarks Existing empty slots retain their argument count. Newly materialized slots must correspond to omitted
+         optional inputs with argument count zero. There is no edge between an initializer or graph input and a Node.
+*/
+void SetOptionalNodeInput(Graph& graph, Node& target, size_t target_input_idx, NodeArg& new_input);
+
 /** Finalize the fusion of second_node into first_node.
     The output definitions and edges from the second_node are moved to first_node. second_node is deleted.
     e.g. Conv + Add fusion fuses the 'Add' into the Conv.

--- a/onnxruntime/core/optimizer/qdq_transformer/avx2_weight_s8_to_u8.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/avx2_weight_s8_to_u8.cc
@@ -87,7 +87,7 @@ static bool TryConvertDynamicQuantizeLSTM(Node& op_node, Graph& graph, const log
   const auto* rzp_def = input_defs.size() <= r_zp_idx ? nullptr : input_defs[r_zp_idx];
   if (nullptr != rzp_def && rzp_def->Exists()) {
     if (!graph_utils::NodeArgIsConstant(graph, *rzp_def) ||
-      !graph.GetInitializedTensor(rzp_def->Name(), r_zp_tensor_proto) ||
+        !graph.GetInitializedTensor(rzp_def->Name(), r_zp_tensor_proto) ||
         r_zp_tensor_proto->data_type() != ONNX_NAMESPACE::TensorProto_DataType_INT8) {
       LOGS(logger, WARNING) << "Unable transforming DynamicQuantizeLSTM operator,"
                             << " unable to locate recurrence tensor or its zero point value,"

--- a/onnxruntime/core/optimizer/qdq_transformer/avx2_weight_s8_to_u8.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/avx2_weight_s8_to_u8.cc
@@ -73,30 +73,31 @@ static bool TryConvertDynamicQuantizeLSTM(Node& op_node, Graph& graph, const log
 
   const ONNX_NAMESPACE::TensorProto* weight_zp_tensor_proto = nullptr;
   const auto* zp_def = input_defs.size() <= w_zp_idx ? nullptr : input_defs[w_zp_idx];
-  if (nullptr != zp_def && zp_def->Exists()) {
-    if (!graph_utils::NodeArgIsConstant(graph, *zp_def) ||
-        !graph.GetInitializedTensor(zp_def->Name(), weight_zp_tensor_proto) ||
-        weight_zp_tensor_proto->data_type() != ONNX_NAMESPACE::TensorProto_DataType_INT8) {
-      return false;
-    }
-    ORT_ENFORCE(nullptr != weight_zp_tensor_proto,
-                "Internal Error: weight zero point must be const int8 for Avx2WeightS8ToU8Transformer.");
+  if (nullptr == zp_def || !zp_def->Exists() ||
+      !graph_utils::NodeArgIsConstant(graph, *zp_def) ||
+      !graph.GetInitializedTensor(zp_def->Name(), weight_zp_tensor_proto) ||
+      weight_zp_tensor_proto->data_type() != ONNX_NAMESPACE::TensorProto_DataType_INT8) {
+    LOGS(logger, WARNING) << "Unable transforming DynamicQuantizeLSTM operator,"
+                          << " unable to locate required weight zero point of const int8 type,"
+                          << " int8 overflow might impact precision !";
+    return false;
   }
+  ORT_ENFORCE(nullptr != weight_zp_tensor_proto,
+              "Internal Error: weight zero point must be const int8 for Avx2WeightS8ToU8Transformer.");
 
   const ONNX_NAMESPACE::TensorProto* r_zp_tensor_proto = nullptr;
   const auto* rzp_def = input_defs.size() <= r_zp_idx ? nullptr : input_defs[r_zp_idx];
-  if (nullptr != rzp_def && rzp_def->Exists()) {
-    if (!graph_utils::NodeArgIsConstant(graph, *rzp_def) ||
-        !graph.GetInitializedTensor(rzp_def->Name(), r_zp_tensor_proto) ||
-        r_zp_tensor_proto->data_type() != ONNX_NAMESPACE::TensorProto_DataType_INT8) {
-      LOGS(logger, WARNING) << "Unable transforming DynamicQuantizeLSTM operator,"
-                            << " unable to locate recurrence tensor or its zero point value,"
-                            << " int8 overflow might impact precision !";
-      return false;
-    }
-    ORT_ENFORCE(nullptr != r_zp_tensor_proto,
-                "Internal Error: recurrence zero point must be const int8 for Avx2WeightS8ToU8Transformer.");
+  if (nullptr == rzp_def || !rzp_def->Exists() ||
+      !graph_utils::NodeArgIsConstant(graph, *rzp_def) ||
+      !graph.GetInitializedTensor(rzp_def->Name(), r_zp_tensor_proto) ||
+      r_zp_tensor_proto->data_type() != ONNX_NAMESPACE::TensorProto_DataType_INT8) {
+    LOGS(logger, WARNING) << "Unable transforming DynamicQuantizeLSTM operator,"
+                          << " unable to locate required recurrence zero point of const int8 type,"
+                          << " int8 overflow might impact precision !";
+    return false;
   }
+  ORT_ENFORCE(nullptr != r_zp_tensor_proto,
+              "Internal Error: recurrence zero point must be const int8 for Avx2WeightS8ToU8Transformer.");
 
   bool should_convert = false;
   Initializer w_temp(graph, *weight_tensor_proto, graph.ModelPath());
@@ -133,24 +134,23 @@ static bool TryConvertDynamicQuantizeLSTM(Node& op_node, Graph& graph, const log
   weights_proto_u8.set_name(weight_tensor_proto->name() + "_s8_2_u8");
   weights_proto_u8.mutable_dims()->CopyFrom(weight_tensor_proto->dims());
   utils::SetRawDataInTensorProto(weights_proto_u8, w_temp.data<int8_t>(), static_cast<size_t>(w_temp.size()));
-  input_defs[w_idx] = &graph_utils::AddInitializerWithOrtValue(graph, weights_proto_u8);
+  auto& mutable_input_defs = op_node.MutableDefinitions().input_defs;
+  mutable_input_defs[w_idx] = &graph_utils::AddInitializerWithOrtValue(graph, weights_proto_u8);
 
   ONNX_NAMESPACE::TensorProto weight_zp_proto_u8;
   QDQ::Int8TensorProto2Uint8(weight_zp_tensor_proto, weight_zp_proto_u8, graph, true);
-  QDQ::SetOptionalInput(graph, op_node, w_zp_idx,
-                        graph_utils::AddInitializerWithOrtValue(graph, weight_zp_proto_u8));
+  mutable_input_defs[w_zp_idx] = &graph_utils::AddInitializerWithOrtValue(graph, weight_zp_proto_u8);
 
   ONNX_NAMESPACE::TensorProto r_proto_u8;
   r_proto_u8.set_data_type(ONNX_NAMESPACE::TensorProto_DataType_UINT8);
   r_proto_u8.set_name(r_tensor_proto->name() + "_s8_2_u8");
   r_proto_u8.mutable_dims()->CopyFrom(r_tensor_proto->dims());
   utils::SetRawDataInTensorProto(r_proto_u8, r_temp.data<int8_t>(), static_cast<size_t>(r_temp.size()));
-  input_defs[r_idx] = &graph_utils::AddInitializerWithOrtValue(graph, r_proto_u8);
+  mutable_input_defs[r_idx] = &graph_utils::AddInitializerWithOrtValue(graph, r_proto_u8);
 
   ONNX_NAMESPACE::TensorProto r_zp_proto_u8;
   QDQ::Int8TensorProto2Uint8(r_zp_tensor_proto, r_zp_proto_u8, graph, true);
-  QDQ::SetOptionalInput(graph, op_node, r_zp_idx,
-                        graph_utils::AddInitializerWithOrtValue(graph, r_zp_proto_u8));
+  mutable_input_defs[r_zp_idx] = &graph_utils::AddInitializerWithOrtValue(graph, r_zp_proto_u8);
 
   return true;
 }

--- a/onnxruntime/core/optimizer/qdq_transformer/avx2_weight_s8_to_u8.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/avx2_weight_s8_to_u8.cc
@@ -134,7 +134,8 @@ static bool TryConvertDynamicQuantizeLSTM(Node& op_node, Graph& graph, const log
   weights_proto_u8.set_name(weight_tensor_proto->name() + "_s8_2_u8");
   weights_proto_u8.mutable_dims()->CopyFrom(weight_tensor_proto->dims());
   utils::SetRawDataInTensorProto(weights_proto_u8, w_temp.data<int8_t>(), static_cast<size_t>(w_temp.size()));
-  auto& mutable_input_defs = op_node.MutableDefinitions().input_defs;
+  graph.SetGraphResolveNeeded().SetGraphProtoSyncNeeded();
+  auto& mutable_input_defs = op_node.MutableInputDefs();
   mutable_input_defs[w_idx] = &graph_utils::AddInitializerWithOrtValue(graph, weights_proto_u8);
 
   ONNX_NAMESPACE::TensorProto weight_zp_proto_u8;

--- a/onnxruntime/core/optimizer/qdq_transformer/avx2_weight_s8_to_u8.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/avx2_weight_s8_to_u8.cc
@@ -73,7 +73,7 @@ static bool TryConvertDynamicQuantizeLSTM(Node& op_node, Graph& graph, const log
 
   const ONNX_NAMESPACE::TensorProto* weight_zp_tensor_proto = nullptr;
   const auto* zp_def = input_defs.size() <= w_zp_idx ? nullptr : input_defs[w_zp_idx];
-  if (nullptr != zp_def) {
+  if (nullptr != zp_def && zp_def->Exists()) {
     if (!graph_utils::NodeArgIsConstant(graph, *zp_def) ||
         !graph.GetInitializedTensor(zp_def->Name(), weight_zp_tensor_proto) ||
         weight_zp_tensor_proto->data_type() != ONNX_NAMESPACE::TensorProto_DataType_INT8) {
@@ -85,9 +85,9 @@ static bool TryConvertDynamicQuantizeLSTM(Node& op_node, Graph& graph, const log
 
   const ONNX_NAMESPACE::TensorProto* r_zp_tensor_proto = nullptr;
   const auto* rzp_def = input_defs.size() <= r_zp_idx ? nullptr : input_defs[r_zp_idx];
-  if (nullptr != rzp_def) {
-    if (!graph_utils::NodeArgIsConstant(graph, *input_defs[r_zp_idx]) ||
-        !graph.GetInitializedTensor(input_defs[r_zp_idx]->Name(), r_zp_tensor_proto) ||
+  if (nullptr != rzp_def && rzp_def->Exists()) {
+    if (!graph_utils::NodeArgIsConstant(graph, *rzp_def) ||
+      !graph.GetInitializedTensor(rzp_def->Name(), r_zp_tensor_proto) ||
         r_zp_tensor_proto->data_type() != ONNX_NAMESPACE::TensorProto_DataType_INT8) {
       LOGS(logger, WARNING) << "Unable transforming DynamicQuantizeLSTM operator,"
                             << " unable to locate recurrence tensor or its zero point value,"
@@ -137,7 +137,8 @@ static bool TryConvertDynamicQuantizeLSTM(Node& op_node, Graph& graph, const log
 
   ONNX_NAMESPACE::TensorProto weight_zp_proto_u8;
   QDQ::Int8TensorProto2Uint8(weight_zp_tensor_proto, weight_zp_proto_u8, graph, true);
-  input_defs[w_zp_idx] = &graph_utils::AddInitializerWithOrtValue(graph, weight_zp_proto_u8);
+  QDQ::SetOptionalInput(graph, op_node, w_zp_idx,
+                        graph_utils::AddInitializerWithOrtValue(graph, weight_zp_proto_u8));
 
   ONNX_NAMESPACE::TensorProto r_proto_u8;
   r_proto_u8.set_data_type(ONNX_NAMESPACE::TensorProto_DataType_UINT8);
@@ -148,7 +149,8 @@ static bool TryConvertDynamicQuantizeLSTM(Node& op_node, Graph& graph, const log
 
   ONNX_NAMESPACE::TensorProto r_zp_proto_u8;
   QDQ::Int8TensorProto2Uint8(r_zp_tensor_proto, r_zp_proto_u8, graph, true);
-  input_defs[r_zp_idx] = &graph_utils::AddInitializerWithOrtValue(graph, r_zp_proto_u8);
+  QDQ::SetOptionalInput(graph, op_node, r_zp_idx,
+                        graph_utils::AddInitializerWithOrtValue(graph, r_zp_proto_u8));
 
   return true;
 }

--- a/onnxruntime/core/optimizer/qdq_transformer/qdq_s8_to_u8.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/qdq_s8_to_u8.cc
@@ -80,8 +80,9 @@ static bool QDQ_S8_to_U8(Graph& graph, Node& q_node, Node& dq_node) {
   auto q_output_node_arg_name = graph.GenerateNodeArgName("qdq_s8_to_u8_quant");
   NodeArg* q_output_arg = &graph.GetOrCreateNodeArg(q_output_node_arg_name, nullptr);
 
-  q_node.MutableDefinitions().output_defs[0] = q_output_arg;
-  dq_node.MutableDefinitions().input_defs[0] = q_output_arg;
+  graph.SetGraphResolveNeeded().SetGraphProtoSyncNeeded();
+  q_node.MutableOutputDefs()[0] = q_output_arg;
+  dq_node.MutableInputDefs()[0] = q_output_arg;
   graph_utils::SetOptionalNodeInput(graph, q_node, zp_idx, *zp_u8_arg);
   graph_utils::SetOptionalNodeInput(graph, dq_node, zp_idx, *zp_u8_arg);
   return true;

--- a/onnxruntime/core/optimizer/qdq_transformer/qdq_s8_to_u8.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/qdq_s8_to_u8.cc
@@ -20,56 +20,70 @@ namespace onnxruntime {
  * @return whether conversion happened
  */
 static bool QDQ_S8_to_U8(Graph& graph, Node& q_node, Node& dq_node) {
-  auto& q_input_defs = q_node.MutableInputDefs();
-  auto& dq_input_defs = dq_node.MutableInputDefs();
+  const auto q_input_defs = q_node.InputDefs();
+  const auto dq_input_defs = dq_node.InputDefs();
 
-  constexpr size_t input_cnt_required = 3;
-  if (q_input_defs.size() != input_cnt_required ||
-      dq_input_defs.size() != input_cnt_required) {
+  constexpr size_t input_cnt_with_zero_point = 3;
+  constexpr size_t input_cnt_without_zero_point = 2;
+  if (q_input_defs.size() != input_cnt_with_zero_point ||
+      (dq_input_defs.size() != input_cnt_with_zero_point &&
+       dq_input_defs.size() != input_cnt_without_zero_point)) {
     return false;
   }
 
   constexpr size_t zp_idx = 2;
   const ONNX_NAMESPACE::TensorProto* q_zp_tensor_proto = nullptr;
   const ONNX_NAMESPACE::TensorProto* dq_zp_tensor_proto = nullptr;
-  if (!graph_utils::NodeArgIsConstant(graph, *q_input_defs[zp_idx]) ||
-      !graph_utils::NodeArgIsConstant(graph, *dq_input_defs[zp_idx]) ||
-      !graph.GetInitializedTensor(q_input_defs[zp_idx]->Name(), q_zp_tensor_proto) ||
-      !graph.GetInitializedTensor(dq_input_defs[zp_idx]->Name(), dq_zp_tensor_proto)) {
+  const NodeArg* q_zp_def = q_input_defs[zp_idx];
+  const NodeArg* dq_zp_def = dq_input_defs.size() > zp_idx ? dq_input_defs[zp_idx] : nullptr;
+  const bool dq_zp_exists = dq_zp_def != nullptr && dq_zp_def->Exists();
+  if (q_zp_def == nullptr || !q_zp_def->Exists() ||
+      !graph_utils::NodeArgIsConstant(graph, *q_zp_def) ||
+      !graph.GetInitializedTensor(q_zp_def->Name(), q_zp_tensor_proto) ||
+      (dq_zp_exists &&
+       (!graph_utils::NodeArgIsConstant(graph, *dq_zp_def) ||
+        !graph.GetInitializedTensor(dq_zp_def->Name(), dq_zp_tensor_proto)))) {
     return false;
   }
 
   // TODO(fuchen): need to augment this when we support per row quantization
   using ONNX_TENSOR_ELEM_TYPE = ONNX_NAMESPACE::TensorProto::DataType;
   Initializer q_zero_point(graph, *q_zp_tensor_proto, graph.ModelPath());
-  Initializer dq_zero_point(graph, *dq_zp_tensor_proto, graph.ModelPath());
   if (q_zero_point.size() != 1 ||
-      dq_zero_point.size() != 1 ||
-      q_zero_point.data_type() != ONNX_TENSOR_ELEM_TYPE::TensorProto_DataType_INT8 ||
-      dq_zero_point.data_type() != ONNX_TENSOR_ELEM_TYPE::TensorProto_DataType_INT8) {
+      q_zero_point.data_type() != ONNX_TENSOR_ELEM_TYPE::TensorProto_DataType_INT8) {
     return false;
   }
 
-  uint8_t q_zp_value = *q_zero_point.data<int8_t>() + 128;
-  uint8_t dq_zp_value = *dq_zero_point.data<int8_t>() + 128;
+  const int8_t q_zp_s8 = *q_zero_point.data<int8_t>();
+  int8_t dq_zp_s8 = 0;
+  if (dq_zp_exists) {
+    Initializer dq_zero_point(graph, *dq_zp_tensor_proto, graph.ModelPath());
+    if (dq_zero_point.size() != 1 ||
+        dq_zero_point.data_type() != ONNX_TENSOR_ELEM_TYPE::TensorProto_DataType_INT8) {
+      return false;
+    }
+    dq_zp_s8 = *dq_zero_point.data<int8_t>();
+  }
 
-  if (q_zp_value != dq_zp_value) {
+  if (q_zp_s8 != dq_zp_s8) {
     return false;  // zero points for Q and DQ are expected to be same
   }
+
+  const uint8_t zp_value_u8 = static_cast<uint8_t>(static_cast<int16_t>(q_zp_s8) + 128);
 
   ONNX_NAMESPACE::TensorProto zp_tensor_proto_u8;
   zp_tensor_proto_u8.set_data_type(ONNX_NAMESPACE::TensorProto_DataType_UINT8);
   zp_tensor_proto_u8.set_name(graph.GenerateNodeArgName("qdq_s8_to_u8_zp_conversion"));
-  utils::SetRawDataInTensorProto(zp_tensor_proto_u8, &q_zp_value, sizeof(uint8_t));
+  utils::SetRawDataInTensorProto(zp_tensor_proto_u8, &zp_value_u8, sizeof(uint8_t));
   NodeArg* zp_u8_arg = &graph_utils::AddInitializerWithOrtValue(graph, zp_tensor_proto_u8);
 
   auto q_output_node_arg_name = graph.GenerateNodeArgName("qdq_s8_to_u8_quant");
   NodeArg* q_output_arg = &graph.GetOrCreateNodeArg(q_output_node_arg_name, nullptr);
 
-  q_node.MutableOutputDefs()[0] = q_output_arg;
-  dq_input_defs[0] = q_output_arg;
-  q_input_defs[zp_idx] = zp_u8_arg;
-  dq_input_defs[zp_idx] = zp_u8_arg;
+  q_node.MutableDefinitions().output_defs[0] = q_output_arg;
+  dq_node.MutableDefinitions().input_defs[0] = q_output_arg;
+  graph_utils::SetOptionalNodeInput(graph, q_node, zp_idx, *zp_u8_arg);
+  graph_utils::SetOptionalNodeInput(graph, dq_node, zp_idx, *zp_u8_arg);
   return true;
 }
 

--- a/onnxruntime/core/optimizer/qdq_transformer/s8_to_u8.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/s8_to_u8.cc
@@ -5,31 +5,6 @@
 
 namespace onnxruntime::QDQ {
 
-void SetOptionalInput(Graph& graph, Node& node, size_t input_idx, NodeArg& input) {
-  auto& input_defs = node.MutableInputDefs();
-  auto& input_arg_counts = node.MutableInputArgsCount();
-  ORT_ENFORCE(input_arg_counts.size() > input_idx,
-              "Missing input metadata for optional input ", input_idx, " of node ", node.Name(), ".");
-
-  const size_t original_size = input_defs.size();
-  if (original_size <= input_idx) {
-    NodeArg& empty_input = graph.GetOrCreateNodeArg("", nullptr);
-    input_defs.resize(input_idx + 1, &empty_input);
-
-    for (size_t index = original_size; index <= input_idx; ++index) {
-      ORT_ENFORCE(input_arg_counts[index] == 0,
-                  "Expected omitted optional input ", index, " of node ", node.Name(), ".");
-      input_arg_counts[index] = 1;
-    }
-  } else if (input_defs[input_idx] == nullptr || !input_defs[input_idx]->Exists()) {
-    ORT_ENFORCE(input_arg_counts[input_idx] == 0,
-                "Expected omitted optional input ", input_idx, " of node ", node.Name(), ".");
-    input_arg_counts[input_idx] = 1;
-  }
-
-  input_defs[input_idx] = &input;
-}
-
 bool ConvertS8WeightToU8(Graph& graph, Node& op_node,
                          size_t weights_idx, size_t weight_zp_idx) {
   auto& input_defs = op_node.MutableInputDefs();
@@ -68,13 +43,14 @@ bool ConvertS8WeightToU8(Graph& graph, Node& op_node,
     // The weights fits into S7, overflow is not a problem, no need to convert to U8
     return false;
   }
-  input_defs[weights_idx] = &graph_utils::AddInitializerWithOrtValue(graph, weights_proto_u8);
+  op_node.MutableDefinitions().input_defs[weights_idx] =
+      &graph_utils::AddInitializerWithOrtValue(graph, weights_proto_u8);
 
   // Convert weight zero point to uint8
   ONNX_NAMESPACE::TensorProto weight_zp_proto_u8;
   Int8TensorProto2Uint8(weight_zp_tensor_proto, weight_zp_proto_u8, graph, true);
-  SetOptionalInput(graph, op_node, weight_zp_idx,
-                   graph_utils::AddInitializerWithOrtValue(graph, weight_zp_proto_u8));
+  graph_utils::SetOptionalNodeInput(graph, op_node, weight_zp_idx,
+                                    graph_utils::AddInitializerWithOrtValue(graph, weight_zp_proto_u8));
 
   return true;
 }

--- a/onnxruntime/core/optimizer/qdq_transformer/s8_to_u8.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/s8_to_u8.cc
@@ -5,6 +5,31 @@
 
 namespace onnxruntime::QDQ {
 
+void SetOptionalInput(Graph& graph, Node& node, size_t input_idx, NodeArg& input) {
+  auto& input_defs = node.MutableInputDefs();
+  auto& input_arg_counts = node.MutableInputArgsCount();
+  ORT_ENFORCE(input_arg_counts.size() > input_idx,
+              "Missing input metadata for optional input ", input_idx, " of node ", node.Name(), ".");
+
+  const size_t original_size = input_defs.size();
+  if (original_size <= input_idx) {
+    NodeArg& empty_input = graph.GetOrCreateNodeArg("", nullptr);
+    input_defs.resize(input_idx + 1, &empty_input);
+
+    for (size_t index = original_size; index <= input_idx; ++index) {
+      ORT_ENFORCE(input_arg_counts[index] == 0,
+                  "Expected omitted optional input ", index, " of node ", node.Name(), ".");
+      input_arg_counts[index] = 1;
+    }
+  } else if (!input_defs[input_idx]->Exists()) {
+    ORT_ENFORCE(input_arg_counts[input_idx] == 0,
+                "Expected omitted optional input ", input_idx, " of node ", node.Name(), ".");
+    input_arg_counts[input_idx] = 1;
+  }
+
+  input_defs[input_idx] = &input;
+}
+
 bool ConvertS8WeightToU8(Graph& graph, Node& op_node,
                          size_t weights_idx, size_t weight_zp_idx) {
   auto& input_defs = op_node.MutableInputDefs();
@@ -26,7 +51,7 @@ bool ConvertS8WeightToU8(Graph& graph, Node& op_node,
   // Weight zero point must be either const int8_t or null tensor
   const ONNX_NAMESPACE::TensorProto* weight_zp_tensor_proto = nullptr;
   const auto* zp_def = input_defs.size() <= weight_zp_idx ? nullptr : input_defs[weight_zp_idx];
-  if (nullptr != zp_def) {
+  if (nullptr != zp_def && zp_def->Exists()) {
     if (!graph_utils::NodeArgIsConstant(graph, *zp_def) ||
         !graph.GetInitializedTensor(zp_def->Name(), weight_zp_tensor_proto) ||
         weight_zp_tensor_proto->data_type() != ONNX_NAMESPACE::TensorProto_DataType_INT8) {
@@ -48,7 +73,8 @@ bool ConvertS8WeightToU8(Graph& graph, Node& op_node,
   // Convert weight zero point to uint8
   ONNX_NAMESPACE::TensorProto weight_zp_proto_u8;
   Int8TensorProto2Uint8(weight_zp_tensor_proto, weight_zp_proto_u8, graph, true);
-  input_defs[weight_zp_idx] = &graph_utils::AddInitializerWithOrtValue(graph, weight_zp_proto_u8);
+  SetOptionalInput(graph, op_node, weight_zp_idx,
+                   graph_utils::AddInitializerWithOrtValue(graph, weight_zp_proto_u8));
 
   return true;
 }

--- a/onnxruntime/core/optimizer/qdq_transformer/s8_to_u8.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/s8_to_u8.cc
@@ -43,8 +43,8 @@ bool ConvertS8WeightToU8(Graph& graph, Node& op_node,
     // The weights fits into S7, overflow is not a problem, no need to convert to U8
     return false;
   }
-  op_node.MutableDefinitions().input_defs[weights_idx] =
-      &graph_utils::AddInitializerWithOrtValue(graph, weights_proto_u8);
+  graph.SetGraphResolveNeeded().SetGraphProtoSyncNeeded();
+  op_node.MutableInputDefs()[weights_idx] = &graph_utils::AddInitializerWithOrtValue(graph, weights_proto_u8);
 
   // Convert weight zero point to uint8
   ONNX_NAMESPACE::TensorProto weight_zp_proto_u8;

--- a/onnxruntime/core/optimizer/qdq_transformer/s8_to_u8.cc
+++ b/onnxruntime/core/optimizer/qdq_transformer/s8_to_u8.cc
@@ -21,7 +21,7 @@ void SetOptionalInput(Graph& graph, Node& node, size_t input_idx, NodeArg& input
                   "Expected omitted optional input ", index, " of node ", node.Name(), ".");
       input_arg_counts[index] = 1;
     }
-  } else if (!input_defs[input_idx]->Exists()) {
+  } else if (input_defs[input_idx] == nullptr || !input_defs[input_idx]->Exists()) {
     ORT_ENFORCE(input_arg_counts[input_idx] == 0,
                 "Expected omitted optional input ", input_idx, " of node ", node.Name(), ".");
     input_arg_counts[input_idx] = 1;

--- a/onnxruntime/core/optimizer/qdq_transformer/s8_to_u8.h
+++ b/onnxruntime/core/optimizer/qdq_transformer/s8_to_u8.h
@@ -75,4 +75,6 @@ inline bool Int8TensorProto2Uint8(
 extern bool ConvertS8WeightToU8(Graph& graph, Node& op_node,
                                 size_t weights_idx, size_t weight_zp_idx);
 
+void SetOptionalInput(Graph& graph, Node& node, size_t input_idx, NodeArg& input);
+
 }  // namespace onnxruntime::QDQ

--- a/onnxruntime/core/optimizer/qdq_transformer/s8_to_u8.h
+++ b/onnxruntime/core/optimizer/qdq_transformer/s8_to_u8.h
@@ -75,6 +75,4 @@ inline bool Int8TensorProto2Uint8(
 extern bool ConvertS8WeightToU8(Graph& graph, Node& op_node,
                                 size_t weights_idx, size_t weight_zp_idx);
 
-void SetOptionalInput(Graph& graph, Node& node, size_t input_idx, NodeArg& input);
-
 }  // namespace onnxruntime::QDQ

--- a/onnxruntime/test/optimizer/avx2_weight_s8_to_u8_test.cc
+++ b/onnxruntime/test/optimizer/avx2_weight_s8_to_u8_test.cc
@@ -54,6 +54,45 @@ static Status RunModel(ModelTestBuilder& helper, const std::string& model_data,
   return Status::OK();
 }
 
+TEST(CPU_U8S8_Precision_Tests, MatMulIntegerOmittedZeroPoints) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    auto* input_a = builder.MakeInput<uint8_t>({1, 2}, {1, 2});
+    auto* input_b = builder.MakeInitializer<int8_t>({2, 1}, {-128, 127});
+    auto* output = builder.MakeOutput();
+    builder.AddNode("MatMulInteger", {input_a, input_b}, {output});
+  };
+
+  auto pre_graph_checker = [](Graph&) { return Status::OK(); };
+  auto post_graph_checker = [](Graph& graph) {
+    const Node* matmul = nullptr;
+    for (const auto& node : graph.Nodes()) {
+      if (node.OpType() == "MatMulInteger") {
+        matmul = &node;
+        break;
+      }
+    }
+
+    ORT_RETURN_IF_NOT(matmul != nullptr, "MatMulInteger node was not found");
+    const auto& input_defs = matmul->InputDefs();
+    ORT_RETURN_IF_NOT(input_defs.size() == 4, "Expected all MatMulInteger optional input slots");
+    ORT_RETURN_IF_NOT(!input_defs[2]->Exists(), "Expected omitted A zero point input");
+    ORT_RETURN_IF_NOT(matmul->InputArgCount() == std::vector<int>({1, 1, 1, 1}),
+              "Expected synchronized MatMulInteger input counts");
+
+    const ONNX_NAMESPACE::TensorProto* weight_zp = nullptr;
+    ORT_RETURN_IF_NOT(input_defs[3]->Exists() &&
+                          graph.GetInitializedTensor(input_defs[3]->Name(), weight_zp) &&
+                          weight_zp->data_type() == ONNX_NAMESPACE::TensorProto_DataType_UINT8,
+                      "Expected generated uint8 B zero point input");
+    return Status::OK();
+  };
+
+  std::unique_ptr<GraphTransformer> transformer = std::make_unique<Avx2WeightS8ToU8Transformer>();
+  ASSERT_STATUS_OK(TestGraphTransformer(build_test_case, 10, DefaultLoggingManager().DefaultLogger(),
+                                        std::move(transformer), TransformerLevel::Level1, 1,
+                                        pre_graph_checker, post_graph_checker));
+}
+
 template <typename WeightType>
 void BuildMatMulIntegerToFloatGraph(ModelTestBuilder& helper,
                                     const std::vector<int64_t> A_dims, const std::vector<int64_t> B_dims,

--- a/onnxruntime/test/optimizer/avx2_weight_s8_to_u8_test.cc
+++ b/onnxruntime/test/optimizer/avx2_weight_s8_to_u8_test.cc
@@ -101,7 +101,7 @@ static void RunMatMulIntegerOmittedZeroPointsTest(bool use_explicit_empty_inputs
                           mutable_matmul.InputArgCount()[3] == 1,
                       "Expected null optional slot to be restored");
     ORT_RETURN_IF_NOT(graph.GraphResolveNeeded() && graph.GraphProtoSyncNeeded(),
-              "Expected optional input update to mark graph synchronization needed");
+                      "Expected optional input update to mark graph synchronization needed");
     return Status::OK();
   };
 

--- a/onnxruntime/test/optimizer/avx2_weight_s8_to_u8_test.cc
+++ b/onnxruntime/test/optimizer/avx2_weight_s8_to_u8_test.cc
@@ -93,6 +93,7 @@ static void RunMatMulIntegerOmittedZeroPointsTest(bool use_explicit_empty_inputs
 
     const NodeIndex matmul_index = matmul->Index();
     ORT_RETURN_IF_ERROR(graph.Resolve());
+    ORT_IGNORE_RETURN_VALUE(graph.ToGraphProto());
     ORT_RETURN_IF(graph.GraphResolveNeeded() || graph.GraphProtoSyncNeeded(),
                   "Expected resolved graph synchronization flags to be clear");
     Node& mutable_matmul = *graph.GetNode(matmul_index);

--- a/onnxruntime/test/optimizer/avx2_weight_s8_to_u8_test.cc
+++ b/onnxruntime/test/optimizer/avx2_weight_s8_to_u8_test.cc
@@ -93,7 +93,7 @@ static void RunMatMulIntegerOmittedZeroPointsTest(bool use_explicit_empty_inputs
 
     Node& mutable_matmul = *graph.GetNode(matmul->Index());
     NodeArg* generated_weight_zp = mutable_matmul.MutableInputDefs()[3];
-    mutable_matmul.MutableDefinitions().input_defs[3] = nullptr;
+    mutable_matmul.MutableInputDefs()[3] = nullptr;
     graph.GraphResolveNeeded(false);
     graph.GraphProtoSyncNeeded(false);
     graph_utils::SetOptionalNodeInput(graph, mutable_matmul, 3, *generated_weight_zp);
@@ -780,7 +780,7 @@ static void RunDynamicQuantizeLSTMMissingRequiredZeroPointTest(size_t missing_in
   auto pre_graph_checker = [missing_input_idx](Graph& graph) {
     for (auto& node : graph.Nodes()) {
       if (node.OpType() == "DynamicQuantizeLSTM") {
-        node.MutableDefinitions().input_defs[missing_input_idx] = &graph.GetOrCreateNodeArg("", nullptr);
+        node.MutableInputDefs()[missing_input_idx] = &graph.GetOrCreateNodeArg("", nullptr);
         return Status::OK();
       }
     }

--- a/onnxruntime/test/optimizer/avx2_weight_s8_to_u8_test.cc
+++ b/onnxruntime/test/optimizer/avx2_weight_s8_to_u8_test.cc
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include "core/optimizer/qdq_transformer/avx2_weight_s8_to_u8.h"
+#include "core/optimizer/qdq_transformer/s8_to_u8.h"
 
 #include <functional>
 #include <string>
@@ -84,6 +85,15 @@ TEST(CPU_U8S8_Precision_Tests, MatMulIntegerOmittedZeroPoints) {
                           graph.GetInitializedTensor(input_defs[3]->Name(), weight_zp) &&
                           weight_zp->data_type() == ONNX_NAMESPACE::TensorProto_DataType_UINT8,
                       "Expected generated uint8 B zero point input");
+
+    Node& mutable_matmul = *graph.GetNode(matmul->Index());
+    NodeArg* generated_weight_zp = mutable_matmul.MutableInputDefs()[3];
+    mutable_matmul.MutableInputDefs()[3] = nullptr;
+    mutable_matmul.MutableInputArgsCount()[3] = 0;
+    QDQ::SetOptionalInput(graph, mutable_matmul, 3, *generated_weight_zp);
+    ORT_RETURN_IF_NOT(mutable_matmul.InputDefs()[3] == generated_weight_zp &&
+                          mutable_matmul.InputArgCount()[3] == 1,
+                      "Expected null optional slot to be restored");
     return Status::OK();
   };
 

--- a/onnxruntime/test/optimizer/avx2_weight_s8_to_u8_test.cc
+++ b/onnxruntime/test/optimizer/avx2_weight_s8_to_u8_test.cc
@@ -77,7 +77,7 @@ TEST(CPU_U8S8_Precision_Tests, MatMulIntegerOmittedZeroPoints) {
     ORT_RETURN_IF_NOT(input_defs.size() == 4, "Expected all MatMulInteger optional input slots");
     ORT_RETURN_IF_NOT(!input_defs[2]->Exists(), "Expected omitted A zero point input");
     ORT_RETURN_IF_NOT(matmul->InputArgCount() == std::vector<int>({1, 1, 1, 1}),
-              "Expected synchronized MatMulInteger input counts");
+                      "Expected synchronized MatMulInteger input counts");
 
     const ONNX_NAMESPACE::TensorProto* weight_zp = nullptr;
     ORT_RETURN_IF_NOT(input_defs[3]->Exists() &&

--- a/onnxruntime/test/optimizer/avx2_weight_s8_to_u8_test.cc
+++ b/onnxruntime/test/optimizer/avx2_weight_s8_to_u8_test.cc
@@ -2,13 +2,13 @@
 // Licensed under the MIT License.
 
 #include "core/optimizer/qdq_transformer/avx2_weight_s8_to_u8.h"
-#include "core/optimizer/qdq_transformer/s8_to_u8.h"
 
 #include <functional>
 #include <string>
 #include <vector>
 
 #include "core/common/span_utils.h"
+#include "core/graph/graph_utils.h"
 #include "core/graph/model.h"
 #include "core/session/inference_session.h"
 #include "core/util/math_cpuonly.h"
@@ -55,12 +55,17 @@ static Status RunModel(ModelTestBuilder& helper, const std::string& model_data,
   return Status::OK();
 }
 
-TEST(CPU_U8S8_Precision_Tests, MatMulIntegerOmittedZeroPoints) {
-  auto build_test_case = [](ModelTestBuilder& builder) {
+static void RunMatMulIntegerOmittedZeroPointsTest(bool use_explicit_empty_inputs) {
+  auto build_test_case = [use_explicit_empty_inputs](ModelTestBuilder& builder) {
     auto* input_a = builder.MakeInput<uint8_t>({1, 2}, {1, 2});
     auto* input_b = builder.MakeInitializer<int8_t>({2, 1}, {-128, 127});
     auto* output = builder.MakeOutput();
-    builder.AddNode("MatMulInteger", {input_a, input_b}, {output});
+    std::vector<NodeArg*> inputs{input_a, input_b};
+    if (use_explicit_empty_inputs) {
+      inputs.push_back(builder.MakeEmptyInput());
+      inputs.push_back(builder.MakeEmptyInput());
+    }
+    builder.AddNode("MatMulInteger", inputs, {output});
   };
 
   auto pre_graph_checker = [](Graph&) { return Status::OK(); };
@@ -88,12 +93,15 @@ TEST(CPU_U8S8_Precision_Tests, MatMulIntegerOmittedZeroPoints) {
 
     Node& mutable_matmul = *graph.GetNode(matmul->Index());
     NodeArg* generated_weight_zp = mutable_matmul.MutableInputDefs()[3];
-    mutable_matmul.MutableInputDefs()[3] = nullptr;
-    mutable_matmul.MutableInputArgsCount()[3] = 0;
-    QDQ::SetOptionalInput(graph, mutable_matmul, 3, *generated_weight_zp);
+    mutable_matmul.MutableDefinitions().input_defs[3] = nullptr;
+    graph.GraphResolveNeeded(false);
+    graph.GraphProtoSyncNeeded(false);
+    graph_utils::SetOptionalNodeInput(graph, mutable_matmul, 3, *generated_weight_zp);
     ORT_RETURN_IF_NOT(mutable_matmul.InputDefs()[3] == generated_weight_zp &&
                           mutable_matmul.InputArgCount()[3] == 1,
                       "Expected null optional slot to be restored");
+    ORT_RETURN_IF_NOT(graph.GraphResolveNeeded() && graph.GraphProtoSyncNeeded(),
+              "Expected optional input update to mark graph synchronization needed");
     return Status::OK();
   };
 
@@ -101,6 +109,14 @@ TEST(CPU_U8S8_Precision_Tests, MatMulIntegerOmittedZeroPoints) {
   ASSERT_STATUS_OK(TestGraphTransformer(build_test_case, 10, DefaultLoggingManager().DefaultLogger(),
                                         std::move(transformer), TransformerLevel::Level1, 1,
                                         pre_graph_checker, post_graph_checker));
+}
+
+TEST(CPU_U8S8_Precision_Tests, MatMulIntegerTruncatedOptionalZeroPoints) {
+  RunMatMulIntegerOmittedZeroPointsTest(false);
+}
+
+TEST(CPU_U8S8_Precision_Tests, MatMulIntegerExplicitEmptyZeroPoints) {
+  RunMatMulIntegerOmittedZeroPointsTest(true);
 }
 
 template <typename WeightType>
@@ -733,6 +749,75 @@ void BuildDynamicQuantizeLSTMGraph(
   node.AddAttribute("input_forget", int64_t(0));
 
   helper.SetGraphOutputs();
+}
+
+static void RunDynamicQuantizeLSTMMissingRequiredZeroPointTest(size_t missing_input_idx) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    BuildDynamicQuantizeLSTMGraph<int8_t>(
+        builder,
+        1,
+        1,
+        {1, 1, 1},
+        {0.0f},
+        {1, 1, 4},
+        {-128, 0, 0, 0},
+        0.5f,
+        0,
+        {1, 1, 4},
+        {-128, 0, 0, 0},
+        0.5f,
+        0,
+        {1, 8},
+        std::vector<float>(8),
+        {1, 1, 1},
+        {0.0f},
+        {1, 1, 1},
+        {0.0f},
+        {1, 3},
+        std::vector<float>(3));
+  };
+
+  auto pre_graph_checker = [missing_input_idx](Graph& graph) {
+    for (auto& node : graph.Nodes()) {
+      if (node.OpType() == "DynamicQuantizeLSTM") {
+        node.MutableDefinitions().input_defs[missing_input_idx] = &graph.GetOrCreateNodeArg("", nullptr);
+        return Status::OK();
+      }
+    }
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "DynamicQuantizeLSTM node was not found");
+  };
+
+  auto post_graph_checker = [missing_input_idx](Graph& graph) {
+    for (const auto& node : graph.Nodes()) {
+      if (node.OpType() != "DynamicQuantizeLSTM") {
+        continue;
+      }
+
+      ORT_RETURN_IF_NOT(!node.InputDefs()[missing_input_idx]->Exists(),
+                        "Expected required zero point to remain omitted");
+      for (const size_t weight_idx : {size_t{1}, size_t{2}}) {
+        const ONNX_NAMESPACE::TensorProto* weight = nullptr;
+        ORT_RETURN_IF_NOT(graph.GetInitializedTensor(node.InputDefs()[weight_idx]->Name(), weight) &&
+                              weight->data_type() == ONNX_NAMESPACE::TensorProto_DataType_INT8,
+                          "Expected int8 weights to remain unconverted");
+      }
+      return Status::OK();
+    }
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "DynamicQuantizeLSTM node was not found");
+  };
+
+  std::unique_ptr<GraphTransformer> transformer = std::make_unique<Avx2WeightS8ToU8Transformer>();
+  ASSERT_STATUS_OK(TestGraphTransformer(build_test_case, 12, DefaultLoggingManager().DefaultLogger(),
+                                        std::move(transformer), TransformerLevel::Level1, 1,
+                                        pre_graph_checker, post_graph_checker));
+}
+
+TEST(CPU_U8S8_Precision_Tests, DynamicQuantizeLSTMMissingWeightZeroPointNoConversion) {
+  RunDynamicQuantizeLSTMMissingRequiredZeroPointTest(9);
+}
+
+TEST(CPU_U8S8_Precision_Tests, DynamicQuantizeLSTMMissingRecurrenceZeroPointNoConversion) {
+  RunDynamicQuantizeLSTMMissingRequiredZeroPointTest(11);
 }
 
 TEST(CPU_U8S8_Precision_Tests, DynamicQuantizeLSTM) {

--- a/onnxruntime/test/optimizer/avx2_weight_s8_to_u8_test.cc
+++ b/onnxruntime/test/optimizer/avx2_weight_s8_to_u8_test.cc
@@ -91,11 +91,13 @@ static void RunMatMulIntegerOmittedZeroPointsTest(bool use_explicit_empty_inputs
                           weight_zp->data_type() == ONNX_NAMESPACE::TensorProto_DataType_UINT8,
                       "Expected generated uint8 B zero point input");
 
-    Node& mutable_matmul = *graph.GetNode(matmul->Index());
+    const NodeIndex matmul_index = matmul->Index();
+    ORT_RETURN_IF_ERROR(graph.Resolve());
+    ORT_RETURN_IF(graph.GraphResolveNeeded() || graph.GraphProtoSyncNeeded(),
+                  "Expected resolved graph synchronization flags to be clear");
+    Node& mutable_matmul = *graph.GetNode(matmul_index);
     NodeArg* generated_weight_zp = mutable_matmul.MutableInputDefs()[3];
     mutable_matmul.MutableInputDefs()[3] = nullptr;
-    graph.GraphResolveNeeded(false);
-    graph.GraphProtoSyncNeeded(false);
     graph_utils::SetOptionalNodeInput(graph, mutable_matmul, 3, *generated_weight_zp);
     ORT_RETURN_IF_NOT(mutable_matmul.InputDefs()[3] == generated_weight_zp &&
                           mutable_matmul.InputArgCount()[3] == 1,

--- a/onnxruntime/test/optimizer/qdq_transformer_test.cc
+++ b/onnxruntime/test/optimizer/qdq_transformer_test.cc
@@ -11,10 +11,12 @@
 #include "core/graph/onnx_protobuf.h"
 #include "core/mlas/inc/mlas.h"
 #include "core/optimizer/double_qdq_pairs_remover.h"
+#include "core/optimizer/initializer.h"
 #include "core/optimizer/qdq_transformer/weight_bias_quantization.h"
 #include "core/optimizer/qdq_transformer/where_dummy_dq.h"
 #include "core/optimizer/qdq_transformer/qdq_final_cleanup.h"
 #include "core/optimizer/qdq_transformer/qdq_propagation.h"
+#include "core/optimizer/qdq_transformer/qdq_s8_to_u8.h"
 #include "core/optimizer/qdq_transformer/selectors_actions/qdq_selectors.h"
 #include "core/optimizer/qdq_transformer/selectors_actions/qdq_selector_action_transformer.h"
 #include "core/optimizer/qdq_transformer/selectors_actions/shared/utils.h"
@@ -282,6 +284,66 @@ TEST(QDQTransformerTests, ConvMaxPoolReshape_Int8) {
 }
 
 #if (defined(_M_AMD64) && !defined(_M_ARM64EC)) || defined(_M_IX86) || defined(__x86_64__) || defined(__i386__) || !defined(DISABLE_CONTRIB_OPS)
+
+static void RunQDQOmittedDQZeroPointTest(bool use_explicit_empty_input) {
+  auto build_test_case = [use_explicit_empty_input](ModelTestBuilder& builder) {
+    auto* input = builder.MakeInput<float>({1}, {1.0f});
+    auto* q_scale = builder.MakeScalarInitializer<float>(0.5f);
+    auto* q_zero_point = builder.MakeScalarInitializer<int8_t>(0);
+    auto* q_output = builder.MakeIntermediate();
+    builder.AddNode("QuantizeLinear", {input, q_scale, q_zero_point}, {q_output});
+
+    auto* dq_scale = builder.MakeScalarInitializer<float>(0.5f);
+    auto* output = builder.MakeOutput();
+    std::vector<NodeArg*> dq_inputs{q_output, dq_scale};
+    if (use_explicit_empty_input) {
+      dq_inputs.push_back(builder.MakeEmptyInput());
+    }
+    builder.AddNode("DequantizeLinear", dq_inputs, {output});
+  };
+
+  auto pre_graph_checker = [](Graph&) { return Status::OK(); };
+  auto post_graph_checker = [](Graph& graph) {
+    const Node* q_node = nullptr;
+    const Node* dq_node = nullptr;
+    for (const auto& node : graph.Nodes()) {
+      if (node.OpType() == "QuantizeLinear") {
+        q_node = &node;
+      } else if (node.OpType() == "DequantizeLinear") {
+        dq_node = &node;
+      }
+    }
+
+    ORT_RETURN_IF_NOT(q_node != nullptr && dq_node != nullptr, "Expected Q-DQ node pair");
+    ORT_RETURN_IF_NOT(q_node->InputDefs().size() == 3 && dq_node->InputDefs().size() == 3,
+                      "Expected materialized zero-point inputs");
+    ORT_RETURN_IF_NOT(q_node->InputDefs()[2] == dq_node->InputDefs()[2],
+                      "Expected shared converted zero point");
+
+    const ONNX_NAMESPACE::TensorProto* zero_point = nullptr;
+    ORT_RETURN_IF_NOT(graph.GetInitializedTensor(q_node->InputDefs()[2]->Name(), zero_point) &&
+                zero_point->data_type() == ONNX_NAMESPACE::TensorProto_DataType_UINT8,
+              "Expected generated uint8 zero point");
+    Initializer zero_point_initializer(graph, *zero_point, graph.ModelPath());
+    ORT_RETURN_IF_NOT(zero_point_initializer.size() == 1 &&
+                *zero_point_initializer.data<uint8_t>() == 128,
+              "Expected generated uint8 zero point value 128");
+    return Status::OK();
+  };
+
+  std::unique_ptr<GraphTransformer> transformer = std::make_unique<QDQS8ToU8Transformer>(false);
+  ASSERT_STATUS_OK(TestGraphTransformer(build_test_case, 13, DefaultLoggingManager().DefaultLogger(),
+                                        std::move(transformer), TransformerLevel::Level1, 1,
+                                        pre_graph_checker, post_graph_checker));
+}
+
+TEST(QDQTransformerTests, QDQ_S8_to_U8_TruncatedDQZeroPoint) {
+  RunQDQOmittedDQZeroPointTest(false);
+}
+
+TEST(QDQTransformerTests, QDQ_S8_to_U8_ExplicitEmptyDQZeroPoint) {
+  RunQDQOmittedDQZeroPointTest(true);
+}
 
 TEST(QDQTransformerTests, DQ_S8_to_U8) {
   auto test_case = [](bool use_contrib_qdq) {

--- a/onnxruntime/test/optimizer/qdq_transformer_test.cc
+++ b/onnxruntime/test/optimizer/qdq_transformer_test.cc
@@ -322,12 +322,12 @@ static void RunQDQOmittedDQZeroPointTest(bool use_explicit_empty_input) {
 
     const ONNX_NAMESPACE::TensorProto* zero_point = nullptr;
     ORT_RETURN_IF_NOT(graph.GetInitializedTensor(q_node->InputDefs()[2]->Name(), zero_point) &&
-                zero_point->data_type() == ONNX_NAMESPACE::TensorProto_DataType_UINT8,
-              "Expected generated uint8 zero point");
+                          zero_point->data_type() == ONNX_NAMESPACE::TensorProto_DataType_UINT8,
+                      "Expected generated uint8 zero point");
     Initializer zero_point_initializer(graph, *zero_point, graph.ModelPath());
     ORT_RETURN_IF_NOT(zero_point_initializer.size() == 1 &&
-                *zero_point_initializer.data<uint8_t>() == 128,
-              "Expected generated uint8 zero point value 128");
+                          *zero_point_initializer.data<uint8_t>() == 128,
+                      "Expected generated uint8 zero point value 128");
     return Status::OK();
   };
 


### PR DESCRIPTION
This pull request enhances the handling of optional inputs for quantized operators, ensuring correctness when optional zero point inputs are omitted and improving code robustness. The most important changes are grouped below:

**Core Functionality Improvements:**

* Added a new utility function `SetOptionalInput` in `s8_to_u8.cc` to correctly set optional input slots in a node, updating both input definitions and input argument counts, and handling omitted inputs gracefully. [[1]](diffhunk://#diff-f1ed8d1a3ceb3229c24831a98c511aa862d535a8ba3c486bd7ca47a2244b4fe4R8-R32) [[2]](diffhunk://#diff-b6b2ee740008dfb1616c212a5fe976a30a489e83e7da3f5389d63487025fc0f7R78-R79)
* Updated logic in both `TryConvertDynamicQuantizeLSTM` and `ConvertS8WeightToU8` to use `SetOptionalInput` when assigning new initializers for zero point inputs, ensuring proper handling of optional inputs. [[1]](diffhunk://#diff-9082e1a8710cae2bf43315ecca905dc65fb8e13956287506b7f71134c777803bL140-R141) [[2]](diffhunk://#diff-9082e1a8710cae2bf43315ecca905dc65fb8e13956287506b7f71134c777803bL151-R153) [[3]](diffhunk://#diff-f1ed8d1a3ceb3229c24831a98c511aa862d535a8ba3c486bd7ca47a2244b4fe4L51-R77)

**Bug Fixes and Robustness:**

* Modified checks for zero point input existence to require both non-null and `.Exists()`, preventing errors when optional inputs are omitted. [[1]](diffhunk://#diff-9082e1a8710cae2bf43315ecca905dc65fb8e13956287506b7f71134c777803bL76-R76) [[2]](diffhunk://#diff-9082e1a8710cae2bf43315ecca905dc65fb8e13956287506b7f71134c777803bL88-R90) [[3]](diffhunk://#diff-f1ed8d1a3ceb3229c24831a98c511aa862d535a8ba3c486bd7ca47a2244b4fe4L29-R54)

**Testing Improvements:**

* Added a new unit test `MatMulIntegerOmittedZeroPoints` to verify that the transformer correctly handles omitted zero point inputs, fills in optional input slots, and generates the expected uint8 initializer.