### PR TITLE
Fix documented defaults in convert_tensor_float_to_float16 docstring

### DIFF
--- a/onnxruntime/python/tools/transformers/float16.py
+++ b/onnxruntime/python/tools/transformers/float16.py
@@ -75,8 +75,8 @@ def convert_tensor_float_to_float16(tensor, min_positive_val=5.96e-08, max_finit
 
     Args:
         tensor (TensorProto): the tensor to convert.
-        min_positive_val (float, optional): minimal positive value. Defaults to 1e-7.
-        max_finite_val (float, optional): maximal finite value. Defaults to 1e4.
+        min_positive_val (float, optional): minimal positive value. Defaults to 5.96e-08.
+        max_finite_val (float, optional): maximal finite value. Defaults to 65504.
 
     Raises:
         ValueError: input type is not TensorProto.


### PR DESCRIPTION
### Description

`convert_tensor_float_to_float16` documents two default values that its own signature contradicts.

- `onnxruntime/python/tools/transformers/float16.py:78` reads `min_positive_val (float, optional): minimal positive value. Defaults to 1e-7.`, while the signature at `float16.py:73` binds `min_positive_val=5.96e-08`.
- `onnxruntime/python/tools/transformers/float16.py:79` reads `max_finite_val (float, optional): maximal finite value. Defaults to 1e4.`, while the same signature at `float16.py:73` binds `max_finite_val=65504.0`.

Which of the two is correct is settled inside this same file, without running anything: the sibling function `convert_float_to_float16` binds the identical defaults at `float16.py:169-170` (`min_positive_val=5.96e-08`, `max_finite_val=65504.0`) and documents them correctly at `float16.py:183-184` as `Defaults to 5.96e-08.` and `Defaults to 65504.`. This PR copies those two values into the docstring at `float16.py:78-79`.

The change is two lines inside one docstring. No signature, no behaviour and no call site is touched.

### Motivation and Context

`max_finite_val` is the float16 saturation bound applied at `float16.py:68`; the same value is the default of `convert_np_to_float16` at `float16.py:39` and of `float_to_float16_max_diff` at `float16.py:491`. Documenting it as `1e4` understates the actual clamp of `65504.0` by a factor of about 6.5, which misleads anyone reading the docstring to choose an override.

I have not compiled or executed anything for this change, and I have not run the test suite; it is a docstring correction established by reading `float16.py` alone.

### Spotted, not fixed

`onnxruntime/python/tools/quantization/README.md:78` documents the runnable command `python -m onnxruntime.quantization.static_quantize_runner -i ... -o ... --activation_type qint16 --weight_type qint16 --quantize_bias`, but `--quantize_bias` is declared nowhere in `onnxruntime/python/tools/quantization/static_quantize_runner.py`. That parser declares the opposite-sense `--disable_quantize_bias` at `static_quantize_runner.py:116`, consumes it as `"QuantizeBias": not args.disable_quantize_bias` at `static_quantize_runner.py:219`, and parses with `parser.parse_args()` at `static_quantize_runner.py:178`. The file has only two commits, and the first one (`4b9e26d`, "Add static quantization runner") already declared `--disable_quantize_bias`, so that documented command appears never to have been runnable — though I have not executed it to confirm. I left it out to keep this PR to a single class of change, and I am happy to send it separately if you would like it.
