### PR TITLE
Read ScatterElements indices in place instead of materializing them

### DIFF
--- a/onnxruntime/core/providers/cpu/tensor/scatter.cc
+++ b/onnxruntime/core/providers/cpu/tensor/scatter.cc
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 // https://github.com/onnx/onnx/blob/main/docs/Operators.md#Scatter
+#include <algorithm>
 #include <atomic>
 #include <type_traits>
 #include <core/common/safeint.h>
@@ -279,6 +280,36 @@ Status GetIndices(
   return Status::OK();
 }
 
+// True when, inside every slice of `inner_size` consecutive indices, all of them are equal.
+// That is the layout an Expand of an [N, 1] index tensor to [N, C] produces, and it means the
+// scatter can move whole contiguous runs instead of individual strided elements.
+// Bails out on the first mismatch, so the ordinary case costs one slice's worth of reads.
+inline bool IndicesAreConstantAlongInner(const std::vector<int64_t>& indices_data, int64_t inner_size,
+                                         concurrency::ThreadPool* tp) {
+  const int64_t num_slices = narrow<int64_t>(indices_data.size()) / inner_size;
+
+  std::atomic<bool> constant{true};
+  concurrency::ThreadPool::TryParallelFor(
+      tp, narrow<std::ptrdiff_t>(num_slices), static_cast<double>(inner_size),
+      [&](std::ptrdiff_t first, std::ptrdiff_t last) {
+        for (std::ptrdiff_t slice = first; slice < last; ++slice) {
+          if (!constant.load(std::memory_order_relaxed)) {
+            return;
+          }
+          const int64_t* row = indices_data.data() + static_cast<int64_t>(slice) * inner_size;
+          const int64_t first_index = row[0];
+          for (int64_t i = 1; i < inner_size; ++i) {
+            if (row[i] != first_index) {
+              constant.store(false, std::memory_order_relaxed);
+              return;
+            }
+          }
+        }
+      });
+
+  return constant.load(std::memory_order_relaxed);
+}
+
 template <class Tdata, typename FuncT>
 Status ScatterData(
     const FuncT& func,
@@ -358,6 +389,81 @@ Status ScatterData(
   const int64_t input_axis_stride = input_strides[narrow<size_t>(axis)];
   const int64_t upd_axis_stride = upd_strides[narrow<size_t>(axis)];
 
+  // Fast path for indices that are constant across the dimensions after the axis.
+  //
+  // The generic loop below gives each work unit a single inner index, so it walks one column of
+  // the updates with a stride of inner_size. When the indices within a slice are all equal, the
+  // whole slice lands on one contiguous run of the output instead, which turns that strided walk
+  // into a sequential one the compiler can vectorize.
+  //
+  // The run is only contiguous if the updates and the data agree on every dimension after the
+  // axis; ScatterElements permits the updates to be smaller there, in which case an inner
+  // coordinate does not map to the same offset in both tensors and this path does not apply.
+  bool inner_dims_match = true;
+  for (size_t d = narrow<size_t>(axis) + 1; d < num_dims; ++d) {
+    if (upd_shape[d] != input_data_shape[d]) {
+      inner_dims_match = false;
+      break;
+    }
+  }
+
+  // Below roughly a cache line the strided access the generic loop performs is already local,
+  // so restricting the fast path keeps it from trading away parallelism for nothing.
+  constexpr int64_t kMinContiguousRun = 8;
+
+  if (inner_dims_match && inner_size >= kMinContiguousRun &&
+      IndicesAreConstantAlongInner(indices_data, inner_size, tp)) {
+    // Split the contiguous run into blocks so the work still spreads across threads. Blocks are
+    // kept reasonably wide so each one is worth vectorizing.
+    constexpr int64_t kMinBlockElements = 16;
+    const int64_t max_blocks = std::max<int64_t>(1, inner_size / kMinBlockElements);
+    const int64_t degree = std::max<int64_t>(1, concurrency::ThreadPool::DegreeOfParallelism(tp));
+    const int64_t num_blocks = std::min(degree, max_blocks);
+    const int64_t blocked_work_units = outer_size * num_blocks;
+
+    // Every work unit owns a distinct (outer, inner-range) region of the output, so no two of
+    // them touch the same element. Within a unit the axis is walked in ascending order, which is
+    // the order the generic loop applies updates in, so a destination that receives several
+    // updates still accumulates them in the same sequence.
+    concurrency::ThreadPool::TryParallelFor(
+        tp, narrow<std::ptrdiff_t>(blocked_work_units), static_cast<double>(axis_size * inner_size / num_blocks),
+        [&](std::ptrdiff_t first, std::ptrdiff_t last) {
+          for (std::ptrdiff_t work_idx = first; work_idx < last; ++work_idx) {
+            const int64_t outer_idx = static_cast<int64_t>(work_idx) / num_blocks;
+            const int64_t block_idx = static_cast<int64_t>(work_idx) % num_blocks;
+            const auto block =
+                concurrency::ThreadPool::PartitionWork(narrow<std::ptrdiff_t>(block_idx),
+                                                       narrow<std::ptrdiff_t>(num_blocks),
+                                                       narrow<std::ptrdiff_t>(inner_size));
+
+            // Offsets contributed by the dimensions before the axis. The dimensions after it
+            // contribute the position within the run, which is identical in both tensors because
+            // inner_dims_match was checked above.
+            int64_t dst_base_offset = 0;
+            int64_t upd_base_offset = 0;
+            int64_t outer_remain = outer_idx;
+            for (int64_t d = axis - 1; d >= 0; --d) {
+              const auto dim_size = upd_shape[narrow<size_t>(d)];
+              const auto coord = outer_remain % dim_size;
+              outer_remain /= dim_size;
+              dst_base_offset += coord * input_strides[narrow<size_t>(d)];
+              upd_base_offset += coord * upd_strides[narrow<size_t>(d)];
+            }
+
+            for (int64_t a = 0; a < axis_size; ++a) {
+              const int64_t upd_row = upd_base_offset + a * upd_axis_stride;
+              // Constant across the run, so the first element speaks for all of them.
+              const int64_t axis_idx = indices_data[narrow<size_t>(upd_row + block.start)];
+              const int64_t dst_row = dst_base_offset + axis_idx * input_axis_stride;
+              for (std::ptrdiff_t k = block.start; k < block.end; ++k) {
+                func(dst_base + dst_row + k, update_data + upd_row + k);
+              }
+            }
+          }
+        });
+
+    return Status::OK();
+  }
   // Parallelize over independent work units.
   // Each work unit processes axis_size elements along the scatter axis.
   // Cost per unit is proportional to axis_size (number of scatter ops per work unit).

--- a/onnxruntime/core/providers/cpu/tensor/scatter.cc
+++ b/onnxruntime/core/providers/cpu/tensor/scatter.cc
@@ -236,17 +236,49 @@ struct Func_Max<BFloat16> {
   }
 };
 
+// Reads indices straight out of the input tensor, widening and normalizing on the way.
+// Keeping the element type here rather than in ScatterData's template arguments avoids
+// instantiating the whole scatter twice; the branch is loop-invariant in practice and costs
+// far less than the int64_t buffer it replaces.
+struct ScatterIndices {
+  const int32_t* as_int32{nullptr};
+  const int64_t* as_int64{nullptr};
+  int64_t axis_dim_limit{0};
+
+  static ScatterIndices Create(const Tensor& indices_input, int64_t axis_dim_limit) {
+    ScatterIndices indices;
+    indices.axis_dim_limit = axis_dim_limit;
+    if (indices_input.GetElementType() == utils::ToTensorProtoElementType<int32_t>()) {
+      indices.as_int32 = indices_input.Data<int32_t>();
+    } else {
+      indices.as_int64 = indices_input.Data<int64_t>();
+    }
+    return indices;
+  }
+
+  // Raw value, for comparing two indices without caring what they normalize to.
+  int64_t Raw(int64_t i) const {
+    return as_int32 != nullptr ? static_cast<int64_t>(as_int32[i]) : as_int64[i];
+  }
+
+  // Only valid once ValidateIndices has accepted the tensor.
+  int64_t operator[](int64_t i) const {
+    const int64_t idx = Raw(i);
+    return idx < 0 ? idx + axis_dim_limit : idx;
+  }
+};
+
+// Checks every index against the axis bound. The normalized values are not stored: the scatter
+// reads the indices tensor directly and normalizes as it goes, which avoids allocating and
+// filling an int64_t per element before any real work starts.
 template <class TIndex>
-Status GetIndices(
+Status ValidateIndices(
     const Tensor& data_input, const Tensor& indices_input, int64_t axis,
-    concurrency::ThreadPool* tp,
-    std::vector<int64_t>& indices_data) {
+    concurrency::ThreadPool* tp) {
   const auto& input_data_shape = data_input.Shape();
   const auto* indices_data_raw = indices_input.Data<TIndex>();
   const auto num_indices = indices_input.Shape().Size();
   const auto axis_dim_limit = input_data_shape[narrow<size_t>(axis)];
-
-  indices_data.resize(narrow<size_t>(num_indices));
 
   // When multiple indices are out-of-bounds, the reported index is nondeterministic
   // (whichever thread wins the CAS). This is acceptable—we only need to report that
@@ -266,7 +298,6 @@ Status GetIndices(
             }
             return;
           }
-          indices_data[narrow<size_t>(i)] = idx < 0 ? idx + axis_dim_limit : idx;
         }
       });
 
@@ -286,9 +317,9 @@ Status GetIndices(
 // Each worker stops as soon as it sees a mismatch, and other workers stop at their next slice
 // boundary, so indices that are not row-broadcast are rejected after a small amount of work
 // rather than after a full pass.
-inline bool IndicesAreConstantAlongInner(const std::vector<int64_t>& indices_data, int64_t inner_size,
-                                         concurrency::ThreadPool* tp) {
-  const int64_t num_slices = narrow<int64_t>(indices_data.size()) / inner_size;
+inline bool IndicesAreConstantAlongInner(const ScatterIndices& indices, int64_t num_indices,
+                                         int64_t inner_size, concurrency::ThreadPool* tp) {
+  const int64_t num_slices = num_indices / inner_size;
 
   std::atomic<bool> constant{true};
   concurrency::ThreadPool::TryParallelFor(
@@ -298,10 +329,10 @@ inline bool IndicesAreConstantAlongInner(const std::vector<int64_t>& indices_dat
           if (!constant.load(std::memory_order_relaxed)) {
             return;
           }
-          const int64_t* row = indices_data.data() + static_cast<int64_t>(slice) * inner_size;
-          const int64_t first_index = row[0];
+          const int64_t base = static_cast<int64_t>(slice) * inner_size;
+          const int64_t first_index = indices.Raw(base);
           for (int64_t i = 1; i < inner_size; ++i) {
-            if (row[i] != first_index) {
+            if (indices.Raw(base + i) != first_index) {
               constant.store(false, std::memory_order_relaxed);
               return;
             }
@@ -315,7 +346,7 @@ inline bool IndicesAreConstantAlongInner(const std::vector<int64_t>& indices_dat
 template <class Tdata, typename FuncT>
 Status ScatterData(
     const FuncT& func,
-    const Tensor* data_input, const std::vector<int64_t>& indices_data, const Tensor* updates_input, int64_t axis,
+    const Tensor* data_input, const Tensor* indices_input, const Tensor* updates_input, int64_t axis,
     concurrency::ThreadPool* tp,
     Tensor* data_output) {
   const TensorShape& input_data_shape = data_input->Shape();
@@ -323,7 +354,7 @@ Status ScatterData(
   const auto input_elements = input_data_shape.Size();
   const auto total_input_bytes = data_input->SizeInBytes();
 
-  const auto num_indices = narrow<int64_t>(indices_data.size());
+  const auto num_indices = indices_input->Shape().Size();
 
   const auto* src_base = static_cast<const Tdata*>(data_input->DataRaw());
   auto* dst_base = static_cast<Tdata*>(data_output->MutableDataRaw());
@@ -388,6 +419,8 @@ Status ScatterData(
   }
 
   const int64_t total_work_units = outer_size * inner_size;
+  const int64_t axis_dim_limit = input_data_shape[narrow<size_t>(axis)];
+  const ScatterIndices indices_data = ScatterIndices::Create(*indices_input, axis_dim_limit);
   const int64_t input_axis_stride = input_strides[narrow<size_t>(axis)];
   const int64_t upd_axis_stride = upd_strides[narrow<size_t>(axis)];
 
@@ -414,7 +447,7 @@ Status ScatterData(
   constexpr int64_t kMinContiguousRun = 8;
 
   if (inner_dims_match && inner_size >= kMinContiguousRun &&
-      IndicesAreConstantAlongInner(indices_data, inner_size, tp)) {
+      IndicesAreConstantAlongInner(indices_data, num_indices, inner_size, tp)) {
     // Split the contiguous run into blocks so the work still spreads across threads. Blocks are
     // kept reasonably wide so each one is worth vectorizing.
     constexpr int64_t kMinBlockElements = 16;
@@ -455,7 +488,7 @@ Status ScatterData(
             for (int64_t a = 0; a < axis_size; ++a) {
               const int64_t upd_row = upd_base_offset + a * upd_axis_stride;
               // Constant across the run, so the first element speaks for all of them.
-              const int64_t axis_idx = indices_data[narrow<size_t>(upd_row + block.start)];
+              const int64_t axis_idx = indices_data[upd_row + block.start];
               const int64_t dst_row = dst_base_offset + axis_idx * input_axis_stride;
               for (std::ptrdiff_t k = block.start; k < block.end; ++k) {
                 func(dst_base + dst_row + k, update_data + upd_row + k);
@@ -516,7 +549,7 @@ Status ScatterData(
           // Process axis_size elements along the axis
           for (int64_t a = 0; a < axis_size; ++a) {
             const int64_t upd_flat_idx = upd_base_offset + a * upd_axis_stride;
-            const int64_t axis_idx = indices_data[narrow<size_t>(upd_flat_idx)];
+            const int64_t axis_idx = indices_data[upd_flat_idx];
             const int64_t dst_offset = dst_base_offset + axis_idx * input_axis_stride;
             func(dst_base + dst_offset, update_data + upd_flat_idx);
           }
@@ -528,23 +561,23 @@ Status ScatterData(
 
 template <typename TData>
 struct ScatterDataDispatchTarget {
-  Status operator()(const Tensor* data_input, const std::vector<int64_t>& indices_data, const Tensor* updates_input, int64_t axis,
+  Status operator()(const Tensor* data_input, const Tensor* indices_input, const Tensor* updates_input, int64_t axis,
                     const std::string& reduction, concurrency::ThreadPool* tp, Tensor* data_output) const {
     if (reduction == "add")
       return ScatterData<TData>(
-          Func_Add<TData>(), data_input, indices_data, updates_input, axis, tp, data_output);
+          Func_Add<TData>(), data_input, indices_input, updates_input, axis, tp, data_output);
     else if (reduction == "mul")
       return ScatterData<TData>(
-          Func_Mul<TData>(), data_input, indices_data, updates_input, axis, tp, data_output);
+          Func_Mul<TData>(), data_input, indices_input, updates_input, axis, tp, data_output);
     else if (reduction == "min")
       return ScatterData<TData>(
-          Func_Min<TData>(), data_input, indices_data, updates_input, axis, tp, data_output);
+          Func_Min<TData>(), data_input, indices_input, updates_input, axis, tp, data_output);
     else if (reduction == "max")
       return ScatterData<TData>(
-          Func_Max<TData>(), data_input, indices_data, updates_input, axis, tp, data_output);
+          Func_Max<TData>(), data_input, indices_input, updates_input, axis, tp, data_output);
     else  // if (reduction == "none")
       return ScatterData<TData>(
-          Func_Assignment<TData>(), data_input, indices_data, updates_input, axis, tp, data_output);
+          Func_Assignment<TData>(), data_input, indices_input, updates_input, axis, tp, data_output);
   }
 };
 
@@ -595,13 +628,13 @@ Status Scatter<EnabledDataTypes>::Compute(OpKernelContext* context) const {
 
   Status status{};
   const auto index_type = indices_input->GetElementType();
-  std::vector<int64_t> indices_data{};
   concurrency::ThreadPool* tp = context->GetOperatorThreadPool();
 
+  // Validate up front so an out-of-range index is reported before the output is touched.
   if (index_type == utils::ToTensorProtoElementType<int32_t>()) {
-    status = GetIndices<int32_t>(*data_input, *indices_input, axis, tp, indices_data);
+    status = ValidateIndices<int32_t>(*data_input, *indices_input, axis, tp);
   } else if (index_type == utils::ToTensorProtoElementType<int64_t>()) {
-    status = GetIndices<int64_t>(*data_input, *indices_input, axis, tp, indices_data);
+    status = ValidateIndices<int64_t>(*data_input, *indices_input, axis, tp);
   } else {
     status = ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Indices type is not supported.");
   }
@@ -615,7 +648,7 @@ Status Scatter<EnabledDataTypes>::Compute(OpKernelContext* context) const {
 
   utils::MLTypeCallDispatcherFromTypeList<EnabledDataTypes> dispatcher{data_type};
   status = dispatcher.template InvokeRet<Status, ScatterDataDispatchTarget>(
-      data_input, indices_data, updates_input, axis, this->reduction_, tp, data_output);
+      data_input, indices_input, updates_input, axis, this->reduction_, tp, data_output);
 
   return status;
 }
@@ -634,9 +667,9 @@ struct Func_Add {
 template <class Tin, class Tdata>
 Status GatherElementsGradImpl(const Tensor* indices_input, const Tensor* updates_input,
                               const int64_t axis, Tensor* data_output) {
-  std::vector<int64_t> indices_data{};
-  ORT_RETURN_IF_ERROR(GetIndices<Tin>(*data_output, *indices_input, axis, nullptr, indices_data));
-  return ScatterData<Tdata>(Func_Add<Tdata>(), data_output, indices_data, updates_input, axis, nullptr, data_output);
+  ORT_RETURN_IF_ERROR(ValidateIndices<Tin>(*data_output, *indices_input, axis, nullptr));
+  return ScatterData<Tdata>(Func_Add<Tdata>(), data_output, indices_input, updates_input, axis, nullptr,
+                            data_output);
 }
 
 #define GATHER_ELEMENTS_GRAD_IMPL_SPECIALIZED(Tin, Tdata) \

--- a/onnxruntime/core/providers/cpu/tensor/scatter.cc
+++ b/onnxruntime/core/providers/cpu/tensor/scatter.cc
@@ -283,7 +283,9 @@ Status GetIndices(
 // True when, inside every slice of `inner_size` consecutive indices, all of them are equal.
 // That is the layout an Expand of an [N, 1] index tensor to [N, C] produces, and it means the
 // scatter can move whole contiguous runs instead of individual strided elements.
-// Bails out on the first mismatch, so the ordinary case costs one slice's worth of reads.
+// Each worker stops as soon as it sees a mismatch, and other workers stop at their next slice
+// boundary, so indices that are not row-broadcast are rejected after a small amount of work
+// rather than after a full pass.
 inline bool IndicesAreConstantAlongInner(const std::vector<int64_t>& indices_data, int64_t inner_size,
                                          concurrency::ThreadPool* tp) {
   const int64_t num_slices = narrow<int64_t>(indices_data.size()) / inner_size;

--- a/onnxruntime/test/providers/cpu/tensor/scatter_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/scatter_op_test.cc
@@ -333,6 +333,100 @@ TEST(ScatterElements, AddReduction_MLFloat16) {
 }
 #endif
 
+namespace {
+// Indices that repeat along the dimensions after the axis, which is what an Expand of an
+// [N, 1] index tensor produces. The rows are wide enough to take the contiguous path.
+std::vector<int64_t> RowBroadcastIndices(const std::vector<int64_t>& row_index, int64_t width) {
+  std::vector<int64_t> indices;
+  indices.reserve(row_index.size() * static_cast<size_t>(width));
+  for (int64_t r : row_index) {
+    indices.insert(indices.end(), static_cast<size_t>(width), r);
+  }
+  return indices;
+}
+
+std::vector<float> RepeatRows(const std::vector<float>& row_value, int64_t width) {
+  std::vector<float> values;
+  values.reserve(row_value.size() * static_cast<size_t>(width));
+  for (float v : row_value) {
+    values.insert(values.end(), static_cast<size_t>(width), v);
+  }
+  return values;
+}
+}  // namespace
+
+TEST(ScatterElements, RowBroadcastIndicesAdd) {
+  constexpr int64_t kWidth = 16;
+  OpTester test("ScatterElements", 18);
+  test.AddAttribute<int64_t>("axis", 0);
+  test.AddAttribute<std::string>("reduction", "add");
+
+  // Update rows 0 and 2 both land on data row 1, so it accumulates 1 + 3.
+  test.AddInput<float>("data", {4, kWidth}, std::vector<float>(4 * kWidth, 0.f));
+  test.AddInput<int64_t>("indices", {3, kWidth}, RowBroadcastIndices({1, 2, 1}, kWidth));
+  test.AddInput<float>("updates", {3, kWidth}, RepeatRows({1.f, 2.f, 3.f}, kWidth));
+  test.AddOutput<float>("y", {4, kWidth}, RepeatRows({0.f, 4.f, 2.f, 0.f}, kWidth));
+
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
+}
+
+// Two updates land on the same row, so this pins the order they are applied in: with
+// reduction='none' the later update along the axis has to win. It fails if the contiguous
+// path were to visit the axis in any other order.
+TEST(ScatterElements, RowBroadcastIndicesNoneKeepsLastUpdate) {
+  constexpr int64_t kWidth = 16;
+  OpTester test("ScatterElements", 18);
+  test.AddAttribute<int64_t>("axis", 0);
+  test.AddAttribute<std::string>("reduction", "none");
+
+  test.AddInput<float>("data", {4, kWidth}, std::vector<float>(4 * kWidth, 0.f));
+  test.AddInput<int64_t>("indices", {3, kWidth}, RowBroadcastIndices({1, 2, 1}, kWidth));
+  test.AddInput<float>("updates", {3, kWidth}, RepeatRows({1.f, 2.f, 3.f}, kWidth));
+  test.AddOutput<float>("y", {4, kWidth}, RepeatRows({0.f, 3.f, 2.f, 0.f}, kWidth));
+
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
+}
+
+TEST(ScatterElements, RowBroadcastIndicesRank3) {
+  OpTester test("ScatterElements", 18);
+  test.AddAttribute<int64_t>("axis", 0);
+  test.AddAttribute<std::string>("reduction", "add");
+
+  // Trailing dims agree between data and updates, so each update slice is one contiguous run
+  // of 2 * 8 elements.
+  test.AddInput<float>("data", {4, 2, 8}, std::vector<float>(4 * 2 * 8, 0.f));
+  test.AddInput<int64_t>("indices", {2, 2, 8}, RowBroadcastIndices({1, 2}, 16));
+  test.AddInput<float>("updates", {2, 2, 8}, RepeatRows({1.f, 2.f}, 16));
+  test.AddOutput<float>("y", {4, 2, 8}, RepeatRows({0.f, 1.f, 2.f, 0.f}, 16));
+
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
+}
+
+// The updates are narrower than the data in the last dimension, so an update slice is NOT a
+// contiguous run of the output even though the indices repeat. Getting this wrong would write
+// the second half of each slice at the wrong offset.
+TEST(ScatterElements, RowBroadcastIndicesNarrowerTrailingDim) {
+  OpTester test("ScatterElements", 18);
+  test.AddAttribute<int64_t>("axis", 0);
+  test.AddAttribute<std::string>("reduction", "add");
+
+  test.AddInput<float>("data", {4, 2, 8}, std::vector<float>(4 * 2 * 8, 0.f));
+  test.AddInput<int64_t>("indices", {2, 2, 4}, RowBroadcastIndices({1, 2}, 8));
+  test.AddInput<float>("updates", {2, 2, 4}, RepeatRows({1.f, 2.f}, 8));
+
+  // Only the first 4 of each group of 8 are touched.
+  std::vector<float> expected(4 * 2 * 8, 0.f);
+  for (int64_t d1 = 0; d1 < 2; ++d1) {
+    for (int64_t d2 = 0; d2 < 4; ++d2) {
+      expected[static_cast<size_t>(1 * 16 + d1 * 8 + d2)] = 1.f;
+      expected[static_cast<size_t>(2 * 16 + d1 * 8 + d2)] = 2.f;
+    }
+  }
+  test.AddOutput<float>("y", {4, 2, 8}, expected);
+
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
+}
+
 TEST(ScatterElements, AddReductionAxis1) {
   OpTester test("ScatterElements", 18);
   test.AddAttribute<int64_t>("axis", 1);

--- a/onnxruntime/test/providers/cpu/tensor/scatter_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/scatter_op_test.cc
@@ -393,6 +393,42 @@ TEST(ScatterElements, RowBroadcastIndicesNoneKeepsLastUpdate) {
   test.ConfigEps(std::move(execution_providers)).RunWithConfig();
 }
 
+// Negative indices are normalized where they are read rather than up front, so exercise them
+// on the contiguous path too. A row of all -3 addresses the same place as a row of all 1.
+TEST(ScatterElements, RowBroadcastIndicesNegative) {
+  constexpr int64_t kWidth = 16;
+  OpTester test("ScatterElements", 18);
+  test.AddAttribute<int64_t>("axis", 0);
+  test.AddAttribute<std::string>("reduction", "add");
+
+  test.AddInput<float>("data", {4, kWidth}, std::vector<float>(4 * kWidth, 0.f));
+  test.AddInput<int64_t>("indices", {3, kWidth}, RowBroadcastIndices({-3, 2, 1}, kWidth));
+  test.AddInput<float>("updates", {3, kWidth}, RepeatRows({1.f, 2.f, 3.f}, kWidth));
+  test.AddOutput<float>("y", {4, kWidth}, RepeatRows({0.f, 4.f, 2.f, 0.f}, kWidth));
+
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
+}
+
+// A slice mixing the two spellings of one row is not constant by raw value, so it must fall back
+// to the generic path and still land in the right place.
+TEST(ScatterElements, RowBroadcastIndicesMixedSignFallsBack) {
+  constexpr int64_t kWidth = 16;
+  std::vector<int64_t> indices(static_cast<size_t>(2 * kWidth), 1);
+  for (int64_t j = 0; j < kWidth; j += 2) {
+    indices[static_cast<size_t>(j)] = -3;  // same row as 1, written the other way
+  }
+
+  OpTester test("ScatterElements", 18);
+  test.AddAttribute<int64_t>("axis", 0);
+  test.AddAttribute<std::string>("reduction", "add");
+  test.AddInput<float>("data", {4, kWidth}, std::vector<float>(4 * kWidth, 0.f));
+  test.AddInput<int64_t>("indices", {2, kWidth}, indices);
+  test.AddInput<float>("updates", {2, kWidth}, RepeatRows({1.f, 2.f}, kWidth));
+  test.AddOutput<float>("y", {4, kWidth}, RepeatRows({0.f, 3.f, 0.f, 0.f}, kWidth));
+
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
+}
+
 TEST(ScatterElements, RowBroadcastIndicesRank3) {
   OpTester test("ScatterElements", 18);
   test.AddAttribute<int64_t>("axis", 0);

--- a/onnxruntime/test/providers/cpu/tensor/scatter_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/scatter_op_test.cc
@@ -373,6 +373,10 @@ TEST(ScatterElements, RowBroadcastIndicesAdd) {
 // Two updates land on the same row, so this pins the order they are applied in: with
 // reduction='none' the later update along the axis has to win. It fails if the contiguous
 // path were to visit the axis in any other order.
+//
+// ONNX leaves the result unspecified when several updates target one element, so this is a
+// property of the CPU kernel rather than of the operator. Providers that apply the updates
+// concurrently pick an arbitrary winner, so the check runs on CPU only.
 TEST(ScatterElements, RowBroadcastIndicesNoneKeepsLastUpdate) {
   constexpr int64_t kWidth = 16;
   OpTester test("ScatterElements", 18);
@@ -384,7 +388,9 @@ TEST(ScatterElements, RowBroadcastIndicesNoneKeepsLastUpdate) {
   test.AddInput<float>("updates", {3, kWidth}, RepeatRows({1.f, 2.f, 3.f}, kWidth));
   test.AddOutput<float>("y", {4, kWidth}, RepeatRows({0.f, 3.f, 2.f, 0.f}, kWidth));
 
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.emplace_back(DefaultCpuExecutionProvider());
+  test.ConfigEps(std::move(execution_providers)).RunWithConfig();
 }
 
 TEST(ScatterElements, RowBroadcastIndicesRank3) {
@@ -405,6 +411,9 @@ TEST(ScatterElements, RowBroadcastIndicesRank3) {
 // The updates are narrower than the data in the last dimension, so an update slice is NOT a
 // contiguous run of the output even though the indices repeat. Getting this wrong would write
 // the second half of each slice at the wrong offset.
+//
+// This is about which path the CPU kernel takes, so it runs on CPU only rather than asserting
+// anything about how other providers handle the shape.
 TEST(ScatterElements, RowBroadcastIndicesNarrowerTrailingDim) {
   OpTester test("ScatterElements", 18);
   test.AddAttribute<int64_t>("axis", 0);
@@ -424,7 +433,9 @@ TEST(ScatterElements, RowBroadcastIndicesNarrowerTrailingDim) {
   }
   test.AddOutput<float>("y", {4, 2, 8}, expected);
 
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.emplace_back(DefaultCpuExecutionProvider());
+  test.ConfigEps(std::move(execution_providers)).RunWithConfig();
 }
 
 TEST(ScatterElements, AddReductionAxis1) {


### PR DESCRIPTION
> **Stacked on #32026.** The diff shown against `main` includes that PR's commit. Review only the second commit, `Read ScatterElements indices in place instead of materializing them`; I'll rebase once #32026 lands.

### Description

`GetIndices` normalized every index into a `std::vector<int64_t>` before any scatter work began. For a `[4096, 1024]` indices tensor that is a **33 MB allocation plus a full write pass**, and the scatter then reads 8 bytes per element back rather than the 4 an `int32` indices tensor would have cost.

This validates the indices in place and lets the scatter read the indices tensor directly, normalizing negatives at the point of use. Validation still runs up front, so an out-of-range index is still reported before the output is touched — the error path and its message are unchanged.

### Why a reader rather than a template parameter

The obvious implementation templates `ScatterData` on the index type. I built that first and measured it: it instantiates the entire scatter — including the contiguous fast path — once per index type.

| | object size for `scatter.cc` |
|---|---|
| templated on index type | 2.20 MB |
| index type behind a reader | **1.12 MB** |

The templated version was about 7% faster on the largest shape. Spending 1.08 MB of object code for that seemed like the wrong trade for a runtime that ships to mobile and has a minimal-build mode, so the element type lives in a small `ScatterIndices` struct instead. The branch it introduces is loop-invariant in practice, and on the fast path only one index is read per row anyway.

Happy to switch to the templated version if maintainers weigh binary size differently — it's a small change either way.

### Motivation and Context

After #32026 the scatter loop itself is no longer the bottleneck for row-broadcast indices; the up-front index materialization is. This removes it.

Measured on an M3 Pro, Release, 12 threads, timing the whole node through an `InferenceSession` (`axis=0`, float, `reduction='add'`, row-broadcast indices):

| shape | #32026 | + this PR | speedup |
|---|---|---|---|
| N=4096, C=1024 | 2.52 ms | 1.91 ms | **1.3x** |
| N=4096, C=256 | 0.35 ms | 0.27 ms | **1.3x** |
| N=8192, C=64 | 0.20 ms | 0.13 ms | **1.6x** |
| N=65536, C=32 | 1.42 ms | 1.26 ms | **1.1x** |

Cumulatively against current `main`, measured in the same session so the numbers are comparable:

| shape | main | #32026 + this | total |
|---|---|---|---|
| N=4096, C=1024 | 14.14 ms | 1.91 ms | **7.4x** |
| N=4096, C=256 | 1.10 ms | 0.27 ms | **4.1x** |
| N=8192, C=64 | 0.58 ms | 0.13 ms | **4.5x** |
| N=65536, C=32 | 5.14 ms | 1.26 ms | **4.1x** |

The allocation removal also matters on its own: peak memory for the node drops by `8 bytes x indices count`, which for the first row above is 33 MB that no longer has to be reserved, written and read back.

### Tests

Existing coverage already exercises negative indices heavily — the `RunTest` helper deliberately generates them — and that now goes through the new normalize-on-read path.

Added two cases for the interaction between negative indices and the contiguous path, which is new:

- `RowBroadcastIndicesNegative` — a row of all `-3` addressing the same row as all `1`, on the fast path.
- `RowBroadcastIndicesMixedSignFallsBack` — a slice mixing `-3` and `1`. These are the same destination row but differ by raw value, so the constancy check rejects the slice and it must fall back to the generic path and still land correctly.

`GatherElementsGrad` shares this code and its caller is updated accordingly; note it is behind `ENABLE_TRAINING_OPS`, which my local build does not compile, so that path is compile-checked by review and CI rather than by me.

Full `onnxruntime_provider_test` sweep: 5642 tests, 5454 passed, **0 failures**, unchanged from baseline.