### PR TITLE
Fix #31573, prevent ARM64 SymmQgemm int16 overflow

### DIFF
--- a/onnxruntime/core/mlas/lib/aarch64/SymQgemmS8KernelNeon.S
+++ b/onnxruntime/core/mlas/lib/aarch64/SymQgemmS8KernelNeon.S
@@ -144,60 +144,76 @@ M4_ComputeBlockLoop:
         smull   v13.8h,v0.8b,v5.8b
         smull   v14.8h,v0.8b,v6.8b
         smull   v15.8h,v0.8b,v7.8b
-        smlal   v12.8h,v2.8b,v8.8b
-        smlal   v13.8h,v2.8b,v9.8b
-        smlal   v14.8h,v2.8b,v10.8b
-        smlal   v15.8h,v2.8b,v11.8b
-        ldp     d0,d2,[x10],#16             // Load A2
         sadalp  v16.4s,v12.8h
         sadalp  v17.4s,v13.8h
         sadalp  v18.4s,v14.8h
         sadalp  v19.4s,v15.8h
+        smull   v12.8h,v2.8b,v8.8b
+        smull   v13.8h,v2.8b,v9.8b
+        smull   v14.8h,v2.8b,v10.8b
+        smull   v15.8h,v2.8b,v11.8b
+        sadalp  v16.4s,v12.8h
+        sadalp  v17.4s,v13.8h
+        sadalp  v18.4s,v14.8h
+        sadalp  v19.4s,v15.8h
+        ldp     d0,d2,[x10],#16             // Load A2
         sub     x3,x3,#1
         smull   v12.8h,v1.8b,v4.8b
         smull   v13.8h,v1.8b,v5.8b
         smull   v14.8h,v1.8b,v6.8b
         smull   v15.8h,v1.8b,v7.8b
-        smlal   v12.8h,v3.8b,v8.8b
-        smlal   v13.8h,v3.8b,v9.8b
-        smlal   v14.8h,v3.8b,v10.8b
-        smlal   v15.8h,v3.8b,v11.8b
-        ldp     d1,d3,[x11],#16             // Load A3
         sadalp  v20.4s,v12.8h
         sadalp  v21.4s,v13.8h
         sadalp  v22.4s,v14.8h
         sadalp  v23.4s,v15.8h
+        smull   v12.8h,v3.8b,v8.8b
+        smull   v13.8h,v3.8b,v9.8b
+        smull   v14.8h,v3.8b,v10.8b
+        smull   v15.8h,v3.8b,v11.8b
+        sadalp  v20.4s,v12.8h
+        sadalp  v21.4s,v13.8h
+        sadalp  v22.4s,v14.8h
+        sadalp  v23.4s,v15.8h
+        ldp     d1,d3,[x11],#16             // Load A3
         cbz     x3,M4_ComputeBlockLoopFinish
         smull   v12.8h,v0.8b,v4.8b
         smull   v13.8h,v0.8b,v5.8b
         smull   v14.8h,v0.8b,v6.8b
         smull   v15.8h,v0.8b,v7.8b
-        smlal   v12.8h,v2.8b,v8.8b
-        smlal   v13.8h,v2.8b,v9.8b
-        smlal   v14.8h,v2.8b,v10.8b
-        smlal   v15.8h,v2.8b,v11.8b
-        ldp     d0,d2,[x0],#16              // Load A0 next iter
         sadalp  v24.4s,v12.8h
         sadalp  v25.4s,v13.8h
         sadalp  v26.4s,v14.8h
         sadalp  v27.4s,v15.8h
+        smull   v12.8h,v2.8b,v8.8b
+        smull   v13.8h,v2.8b,v9.8b
+        smull   v14.8h,v2.8b,v10.8b
+        smull   v15.8h,v2.8b,v11.8b
+        sadalp  v24.4s,v12.8h
+        sadalp  v25.4s,v13.8h
+        sadalp  v26.4s,v14.8h
+        sadalp  v27.4s,v15.8h
+        ldp     d0,d2,[x0],#16              // Load A0 next iter
         smull   v12.8h,v1.8b,v4.8b
         smull   v13.8h,v1.8b,v5.8b
         smull   v14.8h,v1.8b,v6.8b
         smull   v15.8h,v1.8b,v7.8b
-        smlal   v12.8h,v3.8b,v8.8b
-        ldp     d4,d8,[x1],#64              // B
-        smlal   v13.8h,v3.8b,v9.8b
-        ldp     d5,d9,[x1,#-48]
-        smlal   v14.8h,v3.8b,v10.8b
-        ldp     d6,d10,[x1,#-32]
-        smlal   v15.8h,v3.8b,v11.8b
-        ldp     d7,d11,[x1,#-16]
         sadalp  v28.4s,v12.8h
-        ldp     d1,d3,[x9],#16              // Load A1 next iter
         sadalp  v29.4s,v13.8h
         sadalp  v30.4s,v14.8h
         sadalp  v31.4s,v15.8h
+        smull   v12.8h,v3.8b,v8.8b
+        smull   v13.8h,v3.8b,v9.8b
+        smull   v14.8h,v3.8b,v10.8b
+        smull   v15.8h,v3.8b,v11.8b
+        sadalp  v28.4s,v12.8h
+        sadalp  v29.4s,v13.8h
+        sadalp  v30.4s,v14.8h
+        sadalp  v31.4s,v15.8h
+        ldp     d4,d8,[x1],#64              // B
+        ldp     d5,d9,[x1,#-48]
+        ldp     d6,d10,[x1,#-32]
+        ldp     d7,d11,[x1,#-16]
+        ldp     d1,d3,[x9],#16              // Load A1 next iter
         b       M4_ComputeBlockLoop
 
 M4_ComputeBlockLoopFinish:
@@ -205,23 +221,31 @@ M4_ComputeBlockLoopFinish:
         smull   v13.8h,v0.8b,v5.8b
         smull   v14.8h,v0.8b,v6.8b
         smull   v15.8h,v0.8b,v7.8b
-        smlal   v12.8h,v2.8b,v8.8b
-        smlal   v13.8h,v2.8b,v9.8b
-        smlal   v14.8h,v2.8b,v10.8b
-        smlal   v15.8h,v2.8b,v11.8b
-        ld1     {v2.4s},[x13],#16           // load ColumnSumBuffer[0]
         sadalp  v24.4s,v12.8h
         sadalp  v25.4s,v13.8h
         sadalp  v26.4s,v14.8h
         sadalp  v27.4s,v15.8h
+        smull   v12.8h,v2.8b,v8.8b
+        smull   v13.8h,v2.8b,v9.8b
+        smull   v14.8h,v2.8b,v10.8b
+        smull   v15.8h,v2.8b,v11.8b
+        sadalp  v24.4s,v12.8h
+        sadalp  v25.4s,v13.8h
+        sadalp  v26.4s,v14.8h
+        sadalp  v27.4s,v15.8h
+        ld1     {v2.4s},[x13],#16           // load ColumnSumBuffer[0]
         smull   v12.8h,v1.8b,v4.8b
         smull   v13.8h,v1.8b,v5.8b
         smull   v14.8h,v1.8b,v6.8b
         smull   v15.8h,v1.8b,v7.8b
-        smlal   v12.8h,v3.8b,v8.8b
-        smlal   v13.8h,v3.8b,v9.8b
-        smlal   v14.8h,v3.8b,v10.8b
-        smlal   v15.8h,v3.8b,v11.8b
+        sadalp  v28.4s,v12.8h
+        sadalp  v29.4s,v13.8h
+        sadalp  v30.4s,v14.8h
+        sadalp  v31.4s,v15.8h
+        smull   v12.8h,v3.8b,v8.8b
+        smull   v13.8h,v3.8b,v9.8b
+        smull   v14.8h,v3.8b,v10.8b
+        smull   v15.8h,v3.8b,v11.8b
         sadalp  v28.4s,v12.8h
         sadalp  v29.4s,v13.8h
         sadalp  v30.4s,v14.8h
@@ -336,53 +360,57 @@ M2_ComputeBlockLoop:
         smull   v29.8h,v0.8b,v5.8b
         smull   v30.8h,v0.8b,v6.8b
         smull   v31.8h,v0.8b,v7.8b
-        cbz     x3,M2_ComputeBlockLoopFinish
-        smlal   v28.8h,v2.8b,v24.8b
-        smlal   v29.8h,v2.8b,v25.8b
-        smlal   v30.8h,v2.8b,v26.8b
-        smlal   v31.8h,v2.8b,v27.8b
-        ldp     d0,d2,[x0],#16              // Load A0
         sadalp  v16.4s,v28.8h
         sadalp  v17.4s,v29.8h
         sadalp  v18.4s,v30.8h
         sadalp  v19.4s,v31.8h
+        smull   v28.8h,v2.8b,v24.8b
+        smull   v29.8h,v2.8b,v25.8b
+        smull   v30.8h,v2.8b,v26.8b
+        smull   v31.8h,v2.8b,v27.8b
+        sadalp  v16.4s,v28.8h
+        sadalp  v17.4s,v29.8h
+        sadalp  v18.4s,v30.8h
+        sadalp  v19.4s,v31.8h
+        cbz     x3,M2_ComputeBlockLoopFinish
+        ldp     d0,d2,[x0],#16              // Load A0
         smull   v28.8h,v1.8b,v4.8b
         smull   v29.8h,v1.8b,v5.8b
         smull   v30.8h,v1.8b,v6.8b
         smull   v31.8h,v1.8b,v7.8b
-        smlal   v28.8h,v3.8b,v24.8b
-        ldp     d4,d24,[x1],#16             // B
-        smlal   v29.8h,v3.8b,v25.8b
-        ldp     d5,d25,[x1],#16
-        smlal   v30.8h,v3.8b,v26.8b
-        ldp     d6,d26,[x1],#16
-        smlal   v31.8h,v3.8b,v27.8b
-        ldp     d7,d27,[x1],#16
         sadalp  v20.4s,v28.8h
-        ldp     d1,d3,[x9],#16              // Load A1
         sadalp  v21.4s,v29.8h
         sadalp  v22.4s,v30.8h
         sadalp  v23.4s,v31.8h
+        smull   v28.8h,v3.8b,v24.8b
+        smull   v29.8h,v3.8b,v25.8b
+        smull   v30.8h,v3.8b,v26.8b
+        smull   v31.8h,v3.8b,v27.8b
+        sadalp  v20.4s,v28.8h
+        sadalp  v21.4s,v29.8h
+        sadalp  v22.4s,v30.8h
+        sadalp  v23.4s,v31.8h
+        ldp     d4,d24,[x1],#16             // B
+        ldp     d5,d25,[x1],#16
+        ldp     d6,d26,[x1],#16
+        ldp     d7,d27,[x1],#16
+        ldp     d1,d3,[x9],#16              // Load A1
         b       M2_ComputeBlockLoop
 
 M2_ComputeBlockLoopFinish:
         ld1     {v0.4s},[x13],#16           // load ColumnSumBuffer[0]
-        smlal   v28.8h,v2.8b,v24.8b
-        smlal   v29.8h,v2.8b,v25.8b
-        smlal   v30.8h,v2.8b,v26.8b
-        smlal   v31.8h,v2.8b,v27.8b
-        sadalp  v16.4s,v28.8h
-        sadalp  v17.4s,v29.8h
-        sadalp  v18.4s,v30.8h
-        sadalp  v19.4s,v31.8h
         smull   v28.8h,v1.8b,v4.8b
         smull   v29.8h,v1.8b,v5.8b
         smull   v30.8h,v1.8b,v6.8b
         smull   v31.8h,v1.8b,v7.8b
-        smlal   v28.8h,v3.8b,v24.8b
-        smlal   v29.8h,v3.8b,v25.8b
-        smlal   v30.8h,v3.8b,v26.8b
-        smlal   v31.8h,v3.8b,v27.8b
+        sadalp  v20.4s,v28.8h
+        sadalp  v21.4s,v29.8h
+        sadalp  v22.4s,v30.8h
+        sadalp  v23.4s,v31.8h
+        smull   v28.8h,v3.8b,v24.8b
+        smull   v29.8h,v3.8b,v25.8b
+        smull   v30.8h,v3.8b,v26.8b
+        smull   v31.8h,v3.8b,v27.8b
         sadalp  v20.4s,v28.8h
         sadalp  v21.4s,v29.8h
         sadalp  v22.4s,v30.8h
@@ -470,32 +498,34 @@ M1_ComputeBlockLoop:
         sub     x3,x3,#1
         smull   v20.8h,v0.8b,v4.8b
         smull   v21.8h,v0.8b,v5.8b
-        cbz    x3,M1_ComputeBlockLoopFinish
         smull   v22.8h,v0.8b,v6.8b
         smull   v23.8h,v0.8b,v7.8b
-        smlal   v20.8h,v2.8b,v24.8b
-        ldp     d4,d24,[x1],#16             // B
-        smlal   v21.8h,v2.8b,v25.8b
-        ldp     d5,d25,[x1],#16
-        smlal   v22.8h,v2.8b,v26.8b
-        ldp     d6,d26,[x1],#16
-        smlal   v23.8h,v2.8b,v27.8b
-        ldp     d0,d2,[x0],#16              // A0
         sadalp  v16.4s,v20.8h
         sadalp  v17.4s,v21.8h
-        ldp     d7,d27,[x1],#16
         sadalp  v18.4s,v22.8h
         sadalp  v19.4s,v23.8h
+        cbz     x3,M1_ComputeBlockLoopFinish
+        smull   v20.8h,v2.8b,v24.8b
+        smull   v21.8h,v2.8b,v25.8b
+        smull   v22.8h,v2.8b,v26.8b
+        smull   v23.8h,v2.8b,v27.8b
+        sadalp  v16.4s,v20.8h
+        sadalp  v17.4s,v21.8h
+        sadalp  v18.4s,v22.8h
+        sadalp  v19.4s,v23.8h
+        ldp     d4,d24,[x1],#16             // B
+        ldp     d5,d25,[x1],#16
+        ldp     d6,d26,[x1],#16
+        ldp     d7,d27,[x1],#16
+        ldp     d0,d2,[x0],#16              // A0
         b       M1_ComputeBlockLoop
 
 M1_ComputeBlockLoopFinish:
         ld1     {v4.4s},[x13],#16           // load ColumnSumBuffer[0]
-        smull   v22.8h,v0.8b,v6.8b
-        smull   v23.8h,v0.8b,v7.8b
-        smlal   v20.8h,v2.8b,v24.8b
-        smlal   v21.8h,v2.8b,v25.8b
-        smlal   v22.8h,v2.8b,v26.8b
-        smlal   v23.8h,v2.8b,v27.8b
+        smull   v20.8h,v2.8b,v24.8b
+        smull   v21.8h,v2.8b,v25.8b
+        smull   v22.8h,v2.8b,v26.8b
+        smull   v23.8h,v2.8b,v27.8b
         sadalp  v16.4s,v20.8h
         sadalp  v17.4s,v21.8h
         sadalp  v18.4s,v22.8h

--- a/onnxruntime/core/mlas/lib/aarch64/SymQgemmS8KernelNeon.S
+++ b/onnxruntime/core/mlas/lib/aarch64/SymQgemmS8KernelNeon.S
@@ -140,6 +140,8 @@ M4_ProcessNextColumnLoop:
         add     x11,x10,x7                  // A3
 
 M4_ComputeBlockLoop:
+        // Reduce each 8-lane int8 product group into int32 before the next multiply.
+        // Two -128 * -128 products can overflow an int16 accumulator; see #31573.
         smull   v12.8h,v0.8b,v4.8b
         smull   v13.8h,v0.8b,v5.8b
         smull   v14.8h,v0.8b,v6.8b

--- a/onnxruntime/core/mlas/lib/arm64/SymQgemmS8KernelNeon.asm
+++ b/onnxruntime/core/mlas/lib/arm64/SymQgemmS8KernelNeon.asm
@@ -144,60 +144,76 @@ M4_ComputeBlockLoop
         smull   v13.8h,v0.8b,v5.8b
         smull   v14.8h,v0.8b,v6.8b
         smull   v15.8h,v0.8b,v7.8b
-        smlal   v12.8h,v2.8b,v8.8b
-        smlal   v13.8h,v2.8b,v9.8b
-        smlal   v14.8h,v2.8b,v10.8b
-        smlal   v15.8h,v2.8b,v11.8b
-        ldp     d0,d2,[x10],#16             // Load A2
         sadalp  v16.4s,v12.8h
         sadalp  v17.4s,v13.8h
         sadalp  v18.4s,v14.8h
         sadalp  v19.4s,v15.8h
+        smull   v12.8h,v2.8b,v8.8b
+        smull   v13.8h,v2.8b,v9.8b
+        smull   v14.8h,v2.8b,v10.8b
+        smull   v15.8h,v2.8b,v11.8b
+        sadalp  v16.4s,v12.8h
+        sadalp  v17.4s,v13.8h
+        sadalp  v18.4s,v14.8h
+        sadalp  v19.4s,v15.8h
+        ldp     d0,d2,[x10],#16             // Load A2
         sub     x3,x3,#1
         smull   v12.8h,v1.8b,v4.8b
         smull   v13.8h,v1.8b,v5.8b
         smull   v14.8h,v1.8b,v6.8b
         smull   v15.8h,v1.8b,v7.8b
-        smlal   v12.8h,v3.8b,v8.8b
-        smlal   v13.8h,v3.8b,v9.8b
-        smlal   v14.8h,v3.8b,v10.8b
-        smlal   v15.8h,v3.8b,v11.8b
-        ldp     d1,d3,[x11],#16             // Load A3
         sadalp  v20.4s,v12.8h
         sadalp  v21.4s,v13.8h
         sadalp  v22.4s,v14.8h
         sadalp  v23.4s,v15.8h
+        smull   v12.8h,v3.8b,v8.8b
+        smull   v13.8h,v3.8b,v9.8b
+        smull   v14.8h,v3.8b,v10.8b
+        smull   v15.8h,v3.8b,v11.8b
+        sadalp  v20.4s,v12.8h
+        sadalp  v21.4s,v13.8h
+        sadalp  v22.4s,v14.8h
+        sadalp  v23.4s,v15.8h
+        ldp     d1,d3,[x11],#16             // Load A3
         cbz     x3,M4_ComputeBlockLoopFinish
         smull   v12.8h,v0.8b,v4.8b
         smull   v13.8h,v0.8b,v5.8b
         smull   v14.8h,v0.8b,v6.8b
         smull   v15.8h,v0.8b,v7.8b
-        smlal   v12.8h,v2.8b,v8.8b
-        smlal   v13.8h,v2.8b,v9.8b
-        smlal   v14.8h,v2.8b,v10.8b
-        smlal   v15.8h,v2.8b,v11.8b
-        ldp     d0,d2,[x0],#16              // Load A0 next iter
         sadalp  v24.4s,v12.8h
         sadalp  v25.4s,v13.8h
         sadalp  v26.4s,v14.8h
         sadalp  v27.4s,v15.8h
+        smull   v12.8h,v2.8b,v8.8b
+        smull   v13.8h,v2.8b,v9.8b
+        smull   v14.8h,v2.8b,v10.8b
+        smull   v15.8h,v2.8b,v11.8b
+        sadalp  v24.4s,v12.8h
+        sadalp  v25.4s,v13.8h
+        sadalp  v26.4s,v14.8h
+        sadalp  v27.4s,v15.8h
+        ldp     d0,d2,[x0],#16              // Load A0 next iter
         smull   v12.8h,v1.8b,v4.8b
         smull   v13.8h,v1.8b,v5.8b
         smull   v14.8h,v1.8b,v6.8b
         smull   v15.8h,v1.8b,v7.8b
-        smlal   v12.8h,v3.8b,v8.8b
-        ldp     d4,d8,[x1],#64              // B
-        smlal   v13.8h,v3.8b,v9.8b
-        ldp     d5,d9,[x1,#-48]
-        smlal   v14.8h,v3.8b,v10.8b
-        ldp     d6,d10,[x1,#-32]
-        smlal   v15.8h,v3.8b,v11.8b
-        ldp     d7,d11,[x1,#-16]
         sadalp  v28.4s,v12.8h
-        ldp     d1,d3,[x9],#16              // Load A1 next iter
         sadalp  v29.4s,v13.8h
         sadalp  v30.4s,v14.8h
         sadalp  v31.4s,v15.8h
+        smull   v12.8h,v3.8b,v8.8b
+        smull   v13.8h,v3.8b,v9.8b
+        smull   v14.8h,v3.8b,v10.8b
+        smull   v15.8h,v3.8b,v11.8b
+        sadalp  v28.4s,v12.8h
+        sadalp  v29.4s,v13.8h
+        sadalp  v30.4s,v14.8h
+        sadalp  v31.4s,v15.8h
+        ldp     d4,d8,[x1],#64              // B
+        ldp     d5,d9,[x1,#-48]
+        ldp     d6,d10,[x1,#-32]
+        ldp     d7,d11,[x1,#-16]
+        ldp     d1,d3,[x9],#16              // Load A1 next iter
         b       M4_ComputeBlockLoop
 
 M4_ComputeBlockLoopFinish
@@ -205,23 +221,31 @@ M4_ComputeBlockLoopFinish
         smull   v13.8h,v0.8b,v5.8b
         smull   v14.8h,v0.8b,v6.8b
         smull   v15.8h,v0.8b,v7.8b
-        smlal   v12.8h,v2.8b,v8.8b
-        smlal   v13.8h,v2.8b,v9.8b
-        smlal   v14.8h,v2.8b,v10.8b
-        smlal   v15.8h,v2.8b,v11.8b
-        ld1     {v2.4s},[x13],#16           // load ColumnSumBuffer[0]
         sadalp  v24.4s,v12.8h
         sadalp  v25.4s,v13.8h
         sadalp  v26.4s,v14.8h
         sadalp  v27.4s,v15.8h
+        smull   v12.8h,v2.8b,v8.8b
+        smull   v13.8h,v2.8b,v9.8b
+        smull   v14.8h,v2.8b,v10.8b
+        smull   v15.8h,v2.8b,v11.8b
+        sadalp  v24.4s,v12.8h
+        sadalp  v25.4s,v13.8h
+        sadalp  v26.4s,v14.8h
+        sadalp  v27.4s,v15.8h
+        ld1     {v2.4s},[x13],#16           // load ColumnSumBuffer[0]
         smull   v12.8h,v1.8b,v4.8b
         smull   v13.8h,v1.8b,v5.8b
         smull   v14.8h,v1.8b,v6.8b
         smull   v15.8h,v1.8b,v7.8b
-        smlal   v12.8h,v3.8b,v8.8b
-        smlal   v13.8h,v3.8b,v9.8b
-        smlal   v14.8h,v3.8b,v10.8b
-        smlal   v15.8h,v3.8b,v11.8b
+        sadalp  v28.4s,v12.8h
+        sadalp  v29.4s,v13.8h
+        sadalp  v30.4s,v14.8h
+        sadalp  v31.4s,v15.8h
+        smull   v12.8h,v3.8b,v8.8b
+        smull   v13.8h,v3.8b,v9.8b
+        smull   v14.8h,v3.8b,v10.8b
+        smull   v15.8h,v3.8b,v11.8b
         sadalp  v28.4s,v12.8h
         sadalp  v29.4s,v13.8h
         sadalp  v30.4s,v14.8h
@@ -336,53 +360,57 @@ M2_ComputeBlockLoop
         smull   v29.8h,v0.8b,v5.8b
         smull   v30.8h,v0.8b,v6.8b
         smull   v31.8h,v0.8b,v7.8b
-        cbz     x3,M2_ComputeBlockLoopFinish
-        smlal   v28.8h,v2.8b,v24.8b
-        smlal   v29.8h,v2.8b,v25.8b
-        smlal   v30.8h,v2.8b,v26.8b
-        smlal   v31.8h,v2.8b,v27.8b
-        ldp     d0,d2,[x0],#16              // Load A0
         sadalp  v16.4s,v28.8h
         sadalp  v17.4s,v29.8h
         sadalp  v18.4s,v30.8h
         sadalp  v19.4s,v31.8h
+        smull   v28.8h,v2.8b,v24.8b
+        smull   v29.8h,v2.8b,v25.8b
+        smull   v30.8h,v2.8b,v26.8b
+        smull   v31.8h,v2.8b,v27.8b
+        sadalp  v16.4s,v28.8h
+        sadalp  v17.4s,v29.8h
+        sadalp  v18.4s,v30.8h
+        sadalp  v19.4s,v31.8h
+        cbz     x3,M2_ComputeBlockLoopFinish
+        ldp     d0,d2,[x0],#16              // Load A0
         smull   v28.8h,v1.8b,v4.8b
         smull   v29.8h,v1.8b,v5.8b
         smull   v30.8h,v1.8b,v6.8b
         smull   v31.8h,v1.8b,v7.8b
-        smlal   v28.8h,v3.8b,v24.8b
-        ldp     d4,d24,[x1],#16             // B
-        smlal   v29.8h,v3.8b,v25.8b
-        ldp     d5,d25,[x1],#16
-        smlal   v30.8h,v3.8b,v26.8b
-        ldp     d6,d26,[x1],#16
-        smlal   v31.8h,v3.8b,v27.8b
-        ldp     d7,d27,[x1],#16
         sadalp  v20.4s,v28.8h
-        ldp     d1,d3,[x9],#16              // Load A1
         sadalp  v21.4s,v29.8h
         sadalp  v22.4s,v30.8h
         sadalp  v23.4s,v31.8h
+        smull   v28.8h,v3.8b,v24.8b
+        smull   v29.8h,v3.8b,v25.8b
+        smull   v30.8h,v3.8b,v26.8b
+        smull   v31.8h,v3.8b,v27.8b
+        sadalp  v20.4s,v28.8h
+        sadalp  v21.4s,v29.8h
+        sadalp  v22.4s,v30.8h
+        sadalp  v23.4s,v31.8h
+        ldp     d4,d24,[x1],#16             // B
+        ldp     d5,d25,[x1],#16
+        ldp     d6,d26,[x1],#16
+        ldp     d7,d27,[x1],#16
+        ldp     d1,d3,[x9],#16              // Load A1
         b       M2_ComputeBlockLoop
 
 M2_ComputeBlockLoopFinish
         ld1     {v0.4s},[x13],#16           // load ColumnSumBuffer[0]
-        smlal   v28.8h,v2.8b,v24.8b
-        smlal   v29.8h,v2.8b,v25.8b
-        smlal   v30.8h,v2.8b,v26.8b
-        smlal   v31.8h,v2.8b,v27.8b
-        sadalp  v16.4s,v28.8h
-        sadalp  v17.4s,v29.8h
-        sadalp  v18.4s,v30.8h
-        sadalp  v19.4s,v31.8h
         smull   v28.8h,v1.8b,v4.8b
         smull   v29.8h,v1.8b,v5.8b
         smull   v30.8h,v1.8b,v6.8b
         smull   v31.8h,v1.8b,v7.8b
-        smlal   v28.8h,v3.8b,v24.8b
-        smlal   v29.8h,v3.8b,v25.8b
-        smlal   v30.8h,v3.8b,v26.8b
-        smlal   v31.8h,v3.8b,v27.8b
+        sadalp  v20.4s,v28.8h
+        sadalp  v21.4s,v29.8h
+        sadalp  v22.4s,v30.8h
+        sadalp  v23.4s,v31.8h
+        smull   v28.8h,v3.8b,v24.8b
+        smull   v29.8h,v3.8b,v25.8b
+        smull   v30.8h,v3.8b,v26.8b
+        smull   v31.8h,v3.8b,v27.8b
         sadalp  v20.4s,v28.8h
         sadalp  v21.4s,v29.8h
         sadalp  v22.4s,v30.8h
@@ -470,32 +498,34 @@ M1_ComputeBlockLoop
         sub     x3,x3,#1
         smull   v20.8h,v0.8b,v4.8b
         smull   v21.8h,v0.8b,v5.8b
-        cbz    x3,M1_ComputeBlockLoopFinish
         smull   v22.8h,v0.8b,v6.8b
         smull   v23.8h,v0.8b,v7.8b
-        smlal   v20.8h,v2.8b,v24.8b
-        ldp     d4,d24,[x1],#16             // B
-        smlal   v21.8h,v2.8b,v25.8b
-        ldp     d5,d25,[x1],#16
-        smlal   v22.8h,v2.8b,v26.8b
-        ldp     d6,d26,[x1],#16
-        smlal   v23.8h,v2.8b,v27.8b
-        ldp     d0,d2,[x0],#16              // A0
         sadalp  v16.4s,v20.8h
         sadalp  v17.4s,v21.8h
-        ldp     d7,d27,[x1],#16
         sadalp  v18.4s,v22.8h
         sadalp  v19.4s,v23.8h
+        cbz     x3,M1_ComputeBlockLoopFinish
+        smull   v20.8h,v2.8b,v24.8b
+        smull   v21.8h,v2.8b,v25.8b
+        smull   v22.8h,v2.8b,v26.8b
+        smull   v23.8h,v2.8b,v27.8b
+        sadalp  v16.4s,v20.8h
+        sadalp  v17.4s,v21.8h
+        sadalp  v18.4s,v22.8h
+        sadalp  v19.4s,v23.8h
+        ldp     d4,d24,[x1],#16             // B
+        ldp     d5,d25,[x1],#16
+        ldp     d6,d26,[x1],#16
+        ldp     d7,d27,[x1],#16
+        ldp     d0,d2,[x0],#16              // A0
         b       M1_ComputeBlockLoop
 
 M1_ComputeBlockLoopFinish
         ld1     {v4.4s},[x13],#16           // load ColumnSumBuffer[0]
-        smull   v22.8h,v0.8b,v6.8b
-        smull   v23.8h,v0.8b,v7.8b
-        smlal   v20.8h,v2.8b,v24.8b
-        smlal   v21.8h,v2.8b,v25.8b
-        smlal   v22.8h,v2.8b,v26.8b
-        smlal   v23.8h,v2.8b,v27.8b
+        smull   v20.8h,v2.8b,v24.8b
+        smull   v21.8h,v2.8b,v25.8b
+        smull   v22.8h,v2.8b,v26.8b
+        smull   v23.8h,v2.8b,v27.8b
         sadalp  v16.4s,v20.8h
         sadalp  v17.4s,v21.8h
         sadalp  v18.4s,v22.8h

--- a/onnxruntime/core/mlas/lib/arm64/SymQgemmS8KernelNeon.asm
+++ b/onnxruntime/core/mlas/lib/arm64/SymQgemmS8KernelNeon.asm
@@ -140,6 +140,8 @@ M4_ProcessNextColumnLoop
         add     x11,x10,x7                  // A3
 
 M4_ComputeBlockLoop
+        // Reduce each 8-lane int8 product group into int32 before the next multiply.
+        // Two -128 * -128 products can overflow an int16 accumulator; see #31573.
         smull   v12.8h,v0.8b,v4.8b
         smull   v13.8h,v0.8b,v5.8b
         smull   v14.8h,v0.8b,v6.8b

--- a/onnxruntime/test/mlas/unittest/test_symm_qgemm_fixture.h
+++ b/onnxruntime/test/mlas/unittest/test_symm_qgemm_fixture.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include "core/mlas/lib/mlasi.h"
 #include "test_symm_qgemm.h"
 
 //
@@ -93,16 +92,6 @@ class SymmQgemmS8SignedInputTest : public MlasTestFixture<MlasSymmQgemmTest<int8
   }
 
   void TestBody() override {
-    // The plain-NEON (non-dotprod) SymmQgemm kernel has a known int16
-    // accumulator overflow with extreme int8 operands (see
-    // https://github.com/microsoft/onnxruntime/issues/31573). Skip on hosts
-    // that would fall back to it instead of failing; drop this guard once
-    // that kernel is fixed.
-    if (!MLAS_CPUIDINFO::GetCPUIDInfo().HasArmNeonDot()) {
-      GTEST_SKIP() << "ARM NEON FEAT_DotProd not available on this host; "
-                   << "plain-NEON SymmQgemm has a known overflow bug (#31573)";
-    }
-
     static const int8_t a_values[] = {-128, -1, 0, 1, 127, -64, 64, -33};
     static const int8_t b_values[] = {-128, -1, 0, 1, 127, -100, 100, 42};
 


### PR DESCRIPTION
Widen each 8-lane int8 product group into the int32 accumulators before multiplying the second half of the packed K block. This avoids the signed int16 overflow that occurs when two `-128 * -128` products share a halfword lane.

### Description

* Update the plain-NEON ARM64/AArch64 SymmQgemm S8 kernels to reduce each 8-lane product group into int32 before the next multiply.
* Keep the ARM64 and AArch64 assembly implementations in sync.
* Remove the temporary non-dotprod test guard introduced in #31606 so the existing signed-input regression coverage runs on the plain-NEON path again.

### Motivation and Context

Fixes #31573.

The previous `smull` + `smlal` sequence accumulated two int8 products in a signed int16 lane before widening. For the extreme case, `(-128 * -128) + (-128 * -128) = 32768`, which overflows int16. The revised sequence reduces each product group into the int32 accumulators before processing the second half of the packed K block.

### Validation

The existing signed-input regression test is re-enabled for non-dotprod ARM64. The repository also contains `onnxruntime_mlas_benchmark` with `SYMMQGEMM/SignedActivation`; no representative non-dotprod Arm64 hardware was available for a trustworthy throughput comparison, so no performance numbers are claimed here.
