### PR TITLE
[WebGPU] Zero-initialize writable device allocator buffers

### DIFF
--- a/onnxruntime/core/providers/webgpu/allocator.cc
+++ b/onnxruntime/core/providers/webgpu/allocator.cc
@@ -13,7 +13,8 @@ namespace webgpu {
 
 GpuBufferAllocator::GpuBufferAllocator(
     std::function<const BufferManager&()> buffer_manager_getter,
-    bool is_read_only_allocator)
+    bool is_read_only_allocator,
+    std::function<bool()> should_submit_zero_initialize)
     : IAllocator(
           OrtMemoryInfo(WEBGPU_BUFFER,
                         is_read_only_allocator ? OrtAllocatorType::OrtReadOnlyAllocator
@@ -21,6 +22,7 @@ GpuBufferAllocator::GpuBufferAllocator(
                         WebGpuDevice,
                         OrtMemTypeDefault)),
       buffer_manager_getter_{std::move(buffer_manager_getter)},
+      should_submit_zero_initialize_{std::move(should_submit_zero_initialize)},
       mapped_at_creation_{is_read_only_allocator && buffer_manager_getter_().SupportsUMA()},
       initialize_to_zero_{!is_read_only_allocator} {
 }
@@ -35,7 +37,8 @@ void* GpuBufferAllocator::Alloc(size_t size) {
   wgpu::BufferUsage usage = mapped_at_creation_ ? wgpu::BufferUsage::Storage | wgpu::BufferUsage::CopySrc | wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::MapWrite
                                                 : wgpu::BufferUsage::Storage | wgpu::BufferUsage::CopySrc | wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::Indirect;
 
-  return buffer_manager_getter_().Create(size, usage, initialize_to_zero_);
+  const bool submit_zero_initialize = should_submit_zero_initialize_ && should_submit_zero_initialize_();
+  return buffer_manager_getter_().Create(size, usage, initialize_to_zero_, submit_zero_initialize);
 }
 
 void GpuBufferAllocator::Free(void* p) {
@@ -67,11 +70,13 @@ void WebGpuNoOpAllocator::Free(void* /*p*/) {
 
 AllocatorPtr CreateWebGpuAllocator(bool device_free,
                                    std::function<const BufferManager&()> buffer_manager_getter,
-                                   bool is_read_only_allocator) {
+                                   bool is_read_only_allocator,
+                                   std::function<bool()> should_submit_zero_initialize) {
   if (device_free) {
     return std::make_shared<WebGpuNoOpAllocator>(is_read_only_allocator);
   }
-  return std::make_shared<GpuBufferAllocator>(std::move(buffer_manager_getter), is_read_only_allocator);
+  return std::make_shared<GpuBufferAllocator>(std::move(buffer_manager_getter), is_read_only_allocator,
+                                              std::move(should_submit_zero_initialize));
 }
 
 }  // namespace webgpu

--- a/onnxruntime/core/providers/webgpu/allocator.cc
+++ b/onnxruntime/core/providers/webgpu/allocator.cc
@@ -21,7 +21,8 @@ GpuBufferAllocator::GpuBufferAllocator(
                         WebGpuDevice,
                         OrtMemTypeDefault)),
       buffer_manager_getter_{std::move(buffer_manager_getter)},
-      mapped_at_creation_{is_read_only_allocator && buffer_manager_getter_().SupportsUMA()} {
+      mapped_at_creation_{is_read_only_allocator && buffer_manager_getter_().SupportsUMA()},
+      initialize_to_zero_{!is_read_only_allocator} {
 }
 
 void* GpuBufferAllocator::Alloc(size_t size) {
@@ -34,7 +35,7 @@ void* GpuBufferAllocator::Alloc(size_t size) {
   wgpu::BufferUsage usage = mapped_at_creation_ ? wgpu::BufferUsage::Storage | wgpu::BufferUsage::CopySrc | wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::MapWrite
                                                 : wgpu::BufferUsage::Storage | wgpu::BufferUsage::CopySrc | wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::Indirect;
 
-  return buffer_manager_getter_().Create(size, usage);
+  return buffer_manager_getter_().Create(size, usage, initialize_to_zero_);
 }
 
 void GpuBufferAllocator::Free(void* p) {

--- a/onnxruntime/core/providers/webgpu/allocator.h
+++ b/onnxruntime/core/providers/webgpu/allocator.h
@@ -33,6 +33,7 @@ class GpuBufferAllocator : public IAllocator {
   AllocatorStats stats_;
   std::function<const BufferManager&()> buffer_manager_getter_;
   bool mapped_at_creation_;
+  bool initialize_to_zero_;
 };
 
 // No-op allocator used for the WebGPU device when the context has no Dawn device (a device-free /

--- a/onnxruntime/core/providers/webgpu/allocator.h
+++ b/onnxruntime/core/providers/webgpu/allocator.h
@@ -36,6 +36,8 @@ class GpuBufferAllocator : public IAllocator {
   std::function<const BufferManager&()> buffer_manager_getter_;
   std::function<bool()> should_submit_zero_initialize_;
   bool mapped_at_creation_;
+  // Cached writable buffers are cleared explicitly by BufferManager::Create. Fresh buffers rely on Dawn's
+  // "lazy_clear_resource_on_first_use" toggle, which is enabled by WebGpuContext.
   bool initialize_to_zero_;
 };
 

--- a/onnxruntime/core/providers/webgpu/allocator.h
+++ b/onnxruntime/core/providers/webgpu/allocator.h
@@ -23,7 +23,9 @@ class GpuBufferAllocator : public IAllocator {
   // Calls buffer_manager_getter on every Alloc/Free to obtain the current
   // BufferManager. This allows the EP to route allocations to different
   // buffer managers (e.g., per-graph) without explicit refresh calls.
-  GpuBufferAllocator(std::function<const BufferManager&()> buffer_manager_getter, bool is_read_only_allocator);
+  GpuBufferAllocator(std::function<const BufferManager&()> buffer_manager_getter,
+                     bool is_read_only_allocator,
+                     std::function<bool()> should_submit_zero_initialize = {});
 
   virtual void* Alloc(size_t size) override;
   virtual void Free(void* p) override;
@@ -32,6 +34,7 @@ class GpuBufferAllocator : public IAllocator {
  private:
   AllocatorStats stats_;
   std::function<const BufferManager&()> buffer_manager_getter_;
+  std::function<bool()> should_submit_zero_initialize_;
   bool mapped_at_creation_;
   bool initialize_to_zero_;
 };
@@ -54,7 +57,8 @@ class WebGpuNoOpAllocator : public IAllocator {
 // allocation ever happens.
 AllocatorPtr CreateWebGpuAllocator(bool device_free,
                                    std::function<const BufferManager&()> buffer_manager_getter,
-                                   bool is_read_only_allocator);
+                                   bool is_read_only_allocator,
+                                   std::function<bool()> should_submit_zero_initialize = {});
 
 }  // namespace webgpu
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/webgpu/buffer_manager.cc
+++ b/onnxruntime/core/providers/webgpu/buffer_manager.cc
@@ -556,11 +556,9 @@ WGPUBuffer BufferManager::Create(size_t size, wgpu::BufferUsage usage, bool init
     if (initialize_to_zero) {
       auto buffer_guard = wgpu::Buffer::Acquire(buffer);
       ORT_THROW_IF_ERROR(context_.EncodeDeferredDispatches());
-      if (context_.num_pending_dispatches_ >= context_.max_num_pending_dispatches_) {
-        ORT_THROW_IF_ERROR(context_.Flush(*this));
-      }
       context_.EndComputePass();
       context_.GetCommandEncoder().ClearBuffer(buffer, 0, buffer_size);
+      ORT_THROW_IF_ERROR(context_.Flush(*this));
       return buffer_guard.MoveToCHandle();
     }
     return buffer;

--- a/onnxruntime/core/providers/webgpu/buffer_manager.cc
+++ b/onnxruntime/core/providers/webgpu/buffer_manager.cc
@@ -547,18 +547,24 @@ void BufferManager::MemCpy(WGPUBuffer src, WGPUBuffer dst, size_t size) const {
   command_encoder.CopyBufferToBuffer(src, 0, dst, 0, copy_size);
 }
 
-WGPUBuffer BufferManager::Create(size_t size, wgpu::BufferUsage usage, bool initialize_to_zero) const {
+WGPUBuffer BufferManager::Create(size_t size, wgpu::BufferUsage usage, bool initialize_to_zero,
+                                 bool submit_zero_initialize) const {
   auto& cache = GetCacheManager(usage);
   auto buffer_size = cache.CalculateBufferSize(size);
 
   auto buffer = cache.TryAcquireCachedBuffer(buffer_size);
   if (buffer) {
     if (initialize_to_zero) {
+      // initialize_to_zero controls whether a cached buffer is cleared. submit_zero_initialize separately controls
+      // whether that clear is submitted before Create returns. Session::Run defers submission to preserve dispatch
+      // batching, while allocations made outside Run submit immediately so subsequent queue work observes the clear.
       auto buffer_guard = wgpu::Buffer::Acquire(buffer);
       ORT_THROW_IF_ERROR(context_.EncodeDeferredDispatches());
       context_.EndComputePass();
       context_.GetCommandEncoder().ClearBuffer(buffer, 0, buffer_size);
-      ORT_THROW_IF_ERROR(context_.Flush(*this));
+      if (submit_zero_initialize) {
+        ORT_THROW_IF_ERROR(context_.Flush(*this));
+      }
       return buffer_guard.MoveToCHandle();
     }
     return buffer;

--- a/onnxruntime/core/providers/webgpu/buffer_manager.cc
+++ b/onnxruntime/core/providers/webgpu/buffer_manager.cc
@@ -559,9 +559,9 @@ WGPUBuffer BufferManager::Create(size_t size, wgpu::BufferUsage usage, bool init
   auto buffer = cache.TryAcquireCachedBuffer(buffer_size);
   if (buffer) {
     if (initialize_to_zero) {
-      ORT_THROW_IF_ERROR(context_.EncodeDeferredDispatches());
-      context_.EndComputePass();
-      context_.GetCommandEncoder().ClearBuffer(buffer, 0, buffer_size);
+      auto buffer_guard = wgpu::Buffer::Acquire(buffer);
+      ORT_THROW_IF_ERROR(context_.ClearBuffer(buffer, 0, buffer_size));
+      return buffer_guard.MoveToCHandle();
     }
     return buffer;
   }

--- a/onnxruntime/core/providers/webgpu/buffer_manager.cc
+++ b/onnxruntime/core/providers/webgpu/buffer_manager.cc
@@ -548,11 +548,6 @@ void BufferManager::MemCpy(WGPUBuffer src, WGPUBuffer dst, size_t size) const {
 }
 
 WGPUBuffer BufferManager::Create(size_t size, wgpu::BufferUsage usage, bool initialize_to_zero) const {
-  if (initialize_to_zero) {
-    ORT_ENFORCE(usage & wgpu::BufferUsage::CopyDst,
-                "Zero-initialized GPU buffers must have CopyDst usage.");
-  }
-
   auto& cache = GetCacheManager(usage);
   auto buffer_size = cache.CalculateBufferSize(size);
 

--- a/onnxruntime/core/providers/webgpu/buffer_manager.cc
+++ b/onnxruntime/core/providers/webgpu/buffer_manager.cc
@@ -560,7 +560,7 @@ WGPUBuffer BufferManager::Create(size_t size, wgpu::BufferUsage usage, bool init
   if (buffer) {
     if (initialize_to_zero) {
       auto buffer_guard = wgpu::Buffer::Acquire(buffer);
-      ORT_THROW_IF_ERROR(context_.ClearBuffer(buffer, 0, buffer_size));
+      ORT_THROW_IF_ERROR(context_.ClearBuffer(buffer, 0, buffer_size, *this));
       return buffer_guard.MoveToCHandle();
     }
     return buffer;

--- a/onnxruntime/core/providers/webgpu/buffer_manager.cc
+++ b/onnxruntime/core/providers/webgpu/buffer_manager.cc
@@ -560,7 +560,12 @@ WGPUBuffer BufferManager::Create(size_t size, wgpu::BufferUsage usage, bool init
   if (buffer) {
     if (initialize_to_zero) {
       auto buffer_guard = wgpu::Buffer::Acquire(buffer);
-      ORT_THROW_IF_ERROR(context_.ClearBuffer(buffer, 0, buffer_size, *this));
+      ORT_THROW_IF_ERROR(context_.EncodeDeferredDispatches());
+      if (context_.num_pending_dispatches_ >= context_.max_num_pending_dispatches_) {
+        ORT_THROW_IF_ERROR(context_.Flush(*this));
+      }
+      context_.EndComputePass();
+      context_.GetCommandEncoder().ClearBuffer(buffer, 0, buffer_size);
       return buffer_guard.MoveToCHandle();
     }
     return buffer;

--- a/onnxruntime/core/providers/webgpu/buffer_manager.cc
+++ b/onnxruntime/core/providers/webgpu/buffer_manager.cc
@@ -547,12 +547,22 @@ void BufferManager::MemCpy(WGPUBuffer src, WGPUBuffer dst, size_t size) const {
   command_encoder.CopyBufferToBuffer(src, 0, dst, 0, copy_size);
 }
 
-WGPUBuffer BufferManager::Create(size_t size, wgpu::BufferUsage usage) const {
+WGPUBuffer BufferManager::Create(size_t size, wgpu::BufferUsage usage, bool initialize_to_zero) const {
+  if (initialize_to_zero) {
+    ORT_ENFORCE(usage & wgpu::BufferUsage::CopyDst,
+                "Zero-initialized GPU buffers must have CopyDst usage.");
+  }
+
   auto& cache = GetCacheManager(usage);
   auto buffer_size = cache.CalculateBufferSize(size);
 
   auto buffer = cache.TryAcquireCachedBuffer(buffer_size);
   if (buffer) {
+    if (initialize_to_zero) {
+      ORT_THROW_IF_ERROR(context_.EncodeDeferredDispatches());
+      context_.EndComputePass();
+      context_.GetCommandEncoder().ClearBuffer(buffer, 0, buffer_size);
+    }
     return buffer;
   }
 

--- a/onnxruntime/core/providers/webgpu/buffer_manager.h
+++ b/onnxruntime/core/providers/webgpu/buffer_manager.h
@@ -90,7 +90,7 @@ class BufferManager {
   BufferManager(WebGpuContext& context, BufferCacheMode storage_buffer_cache_mode, BufferCacheMode uniform_buffer_cache_mode, BufferCacheMode query_resolve_buffer_cache_mode, BufferCacheMode default_buffer_cache_mode);
   void Upload(void* src, WGPUBuffer dst, size_t size) const;
   void MemCpy(WGPUBuffer src, WGPUBuffer dst, size_t size) const;
-  WGPUBuffer Create(size_t size, wgpu::BufferUsage usage) const;
+  WGPUBuffer Create(size_t size, wgpu::BufferUsage usage, bool initialize_to_zero = false) const;
   bool SupportsUMA() const;  // Check if CreateUMA is supported (i.e., the device has BufferMapExtendedUsages feature)
   void Release(WGPUBuffer buffer) const;
   void Download(WGPUBuffer src, void* dst, size_t size) const;

--- a/onnxruntime/core/providers/webgpu/buffer_manager.h
+++ b/onnxruntime/core/providers/webgpu/buffer_manager.h
@@ -90,7 +90,8 @@ class BufferManager {
   BufferManager(WebGpuContext& context, BufferCacheMode storage_buffer_cache_mode, BufferCacheMode uniform_buffer_cache_mode, BufferCacheMode query_resolve_buffer_cache_mode, BufferCacheMode default_buffer_cache_mode);
   void Upload(void* src, WGPUBuffer dst, size_t size) const;
   void MemCpy(WGPUBuffer src, WGPUBuffer dst, size_t size) const;
-  WGPUBuffer Create(size_t size, wgpu::BufferUsage usage, bool initialize_to_zero = false) const;
+  WGPUBuffer Create(size_t size, wgpu::BufferUsage usage, bool initialize_to_zero = false,
+                    bool submit_zero_initialize = false) const;
   bool SupportsUMA() const;  // Check if CreateUMA is supported (i.e., the device has BufferMapExtendedUsages feature)
   void Release(WGPUBuffer buffer) const;
   void Download(WGPUBuffer src, void* dst, size_t size) const;

--- a/onnxruntime/core/providers/webgpu/ep/factory.cc
+++ b/onnxruntime/core/providers/webgpu/ep/factory.cc
@@ -203,7 +203,8 @@ OrtStatus* ORT_API_CALL Factory::CreateEpImpl(
   const bool device_free = !WebGpuContextFactory::GetContext(context_id).HasDevice();
   auto device_alloc = webgpu::CreateWebGpuAllocator(
       device_free,
-      [webgpu_ep_ptr]() -> const webgpu::BufferManager& { return webgpu_ep_ptr->BufferManager(); }, false);
+      [webgpu_ep_ptr]() -> const webgpu::BufferManager& { return webgpu_ep_ptr->BufferManager(); }, false,
+      [webgpu_ep_ptr]() { return !webgpu_ep_ptr->IsRunActive(); });
   Ep::Config webgpu_ep_config{
       CPUAllocator::DefaultInstance(),  // CPU allocator
       device_alloc,                     // default device allocator
@@ -245,7 +246,8 @@ OrtStatus* ORT_API_CALL Factory::CreateAllocatorImpl(
                                                                return WebGpuContextFactory::DefaultContext()
                                                                    .BufferManager();
                                                              },
-                                                             false);
+                                                             false,
+                                                             []() { return true; });
                                                        });
   return nullptr;
   EXCEPTION_TO_RETURNED_STATUS_END

--- a/onnxruntime/core/providers/webgpu/webgpu_context.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.cc
@@ -739,12 +739,12 @@ std::vector<const char*> WebGpuContext::GetEnabledDeviceToggles() const {
   if (!enable_robustness_) {
     enabled_toggles.push_back("disable_robustness");
   }
+  enabled_toggles.push_back("lazy_clear_resource_on_first_use");
   return enabled_toggles;
 }
 
 std::vector<const char*> WebGpuContext::GetDisabledDeviceToggles() const {
   constexpr const char* toggles[] = {
-      "lazy_clear_resource_on_first_use",
       "timestamp_quantization",
   };
   return std::vector<const char*>(std::begin(toggles), std::end(toggles));

--- a/onnxruntime/core/providers/webgpu/webgpu_context.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.cc
@@ -1058,6 +1058,7 @@ wgpu::BindGroup WebGpuContext::CreateBindGroup(const std::vector<WGPUBuffer>& bi
 }
 
 void WebGpuContext::DispatchCommand(const webgpu::CapturedCommandInfo& command) {
+  ORT_ENFORCE(command.type == webgpu::CapturedCommandType::Dispatch);
   ORT_ENFORCE(command.compute_pipeline.has_value());
   ORT_ENFORCE(command.bind_group != nullptr);
   const auto& compute_pass_encoder = GetComputePassEncoder();
@@ -1078,6 +1079,24 @@ void WebGpuContext::DispatchCommand(const webgpu::CapturedCommandInfo& command) 
       (is_profiling_ && query_type_ == TimestampQueryType::AtPasses)) {
     EndComputePass();
   }
+}
+
+Status WebGpuContext::ClearBuffer(WGPUBuffer buffer, uint64_t offset, uint64_t size) {
+  ORT_RETURN_IF_ERROR(EncodeDeferredDispatches());
+  EndComputePass();
+  GetCommandEncoder().ClearBuffer(buffer, offset, size);
+
+  if (graph_capture_state_ == GraphCaptureState::Capturing) {
+    ORT_ENFORCE(external_captured_commands_ != nullptr);
+    webgpu::CapturedCommandInfo command;
+    command.type = webgpu::CapturedCommandType::ClearBuffer;
+    command.clear_buffer = buffer;
+    command.clear_offset = offset;
+    command.clear_size = size;
+    external_captured_commands_->push_back(std::move(command));
+  }
+
+  return Status::OK();
 }
 
 void WebGpuContext::CaptureBegin(std::vector<webgpu::CapturedCommandInfo>* captured_commands, const webgpu::BufferManager& buffer_manager) {
@@ -1103,18 +1122,23 @@ void WebGpuContext::Replay(const std::vector<webgpu::CapturedCommandInfo>& captu
   for (size_t i = 0; i < command_count; ++i) {
     auto& command = captured_commands[i];
 
-    // Restore profiling info when profiling is enabled. All commands are expected
-    // to have profiling data in this mode to keep pending_kernels_ consistent
-    // with num_pending_dispatches_.
-    if (is_profiling_) {
-      ORT_ENFORCE(command.pending_kernel_info.has_value(),
-                  "WebGpuContext::Replay: profiling is enabled but captured command at index ",
-                  i,
-                  " is missing pending_kernel_info.");
-      pending_kernels_.emplace_back(*command.pending_kernel_info);
+    if (command.type == webgpu::CapturedCommandType::Dispatch) {
+      // Restore profiling info for compute dispatches when profiling is enabled. Buffer clears are
+      // ordered graph commands, but they are not profiled kernels and do not affect dispatch counts.
+      if (is_profiling_) {
+        ORT_ENFORCE(command.pending_kernel_info.has_value(),
+                    "WebGpuContext::Replay: profiling is enabled but captured command at index ",
+                    i,
+                    " is missing pending_kernel_info.");
+        pending_kernels_.emplace_back(*command.pending_kernel_info);
+      }
+
+      DispatchCommand(command);
+    } else {
+      ORT_ENFORCE(command.type == webgpu::CapturedCommandType::ClearBuffer);
+      ORT_THROW_IF_ERROR(ClearBuffer(command.clear_buffer, command.clear_offset, command.clear_size));
     }
 
-    DispatchCommand(command);
     if (num_pending_dispatches_ >= max_num_pending_dispatches_) {
       ORT_THROW_IF_ERROR(Flush(buffer_manager));
     }
@@ -1138,6 +1162,7 @@ void WebGpuContext::ReleaseGraphResources(std::vector<webgpu::CapturedCommandInf
 
   for (auto& command : captured_commands) {
     command.bind_group = nullptr;
+    command.clear_buffer = nullptr;
   }
 }
 

--- a/onnxruntime/core/providers/webgpu/webgpu_context.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.cc
@@ -1065,7 +1065,6 @@ wgpu::BindGroup WebGpuContext::CreateBindGroup(const std::vector<WGPUBuffer>& bi
 }
 
 void WebGpuContext::DispatchCommand(const webgpu::CapturedCommandInfo& command) {
-  ORT_ENFORCE(command.type == webgpu::CapturedCommandType::Dispatch);
   ORT_ENFORCE(command.compute_pipeline.has_value());
   ORT_ENFORCE(command.bind_group != nullptr);
   const auto& compute_pass_encoder = GetComputePassEncoder();
@@ -1086,28 +1085,6 @@ void WebGpuContext::DispatchCommand(const webgpu::CapturedCommandInfo& command) 
       (is_profiling_ && query_type_ == TimestampQueryType::AtPasses)) {
     EndComputePass();
   }
-}
-
-Status WebGpuContext::ClearBuffer(WGPUBuffer buffer, uint64_t offset, uint64_t size,
-                                  const webgpu::BufferManager& buffer_manager) {
-  ORT_RETURN_IF_ERROR(EncodeDeferredDispatches());
-  if (num_pending_dispatches_ >= max_num_pending_dispatches_) {
-    ORT_RETURN_IF_ERROR(Flush(buffer_manager));
-  }
-  EndComputePass();
-  GetCommandEncoder().ClearBuffer(buffer, offset, size);
-
-  if (graph_capture_state_ == GraphCaptureState::Capturing) {
-    ORT_ENFORCE(external_captured_commands_ != nullptr);
-    webgpu::CapturedCommandInfo command;
-    command.type = webgpu::CapturedCommandType::ClearBuffer;
-    command.clear_buffer = buffer;
-    command.clear_offset = offset;
-    command.clear_size = size;
-    external_captured_commands_->push_back(std::move(command));
-  }
-
-  return Status::OK();
 }
 
 void WebGpuContext::CaptureBegin(std::vector<webgpu::CapturedCommandInfo>* captured_commands, const webgpu::BufferManager& buffer_manager) {
@@ -1133,24 +1110,18 @@ void WebGpuContext::Replay(const std::vector<webgpu::CapturedCommandInfo>& captu
   for (size_t i = 0; i < command_count; ++i) {
     auto& command = captured_commands[i];
 
-    if (command.type == webgpu::CapturedCommandType::Dispatch) {
-      // Restore profiling info for compute dispatches when profiling is enabled. Buffer clears are
-      // ordered graph commands, but they are not profiled kernels and do not affect dispatch counts.
-      if (is_profiling_) {
-        ORT_ENFORCE(command.pending_kernel_info.has_value(),
-                    "WebGpuContext::Replay: profiling is enabled but captured command at index ",
-                    i,
-                    " is missing pending_kernel_info.");
-        pending_kernels_.emplace_back(*command.pending_kernel_info);
-      }
-
-      DispatchCommand(command);
-    } else {
-      ORT_ENFORCE(command.type == webgpu::CapturedCommandType::ClearBuffer);
-      ORT_THROW_IF_ERROR(ClearBuffer(command.clear_buffer, command.clear_offset, command.clear_size,
-                                     buffer_manager));
+    // Restore profiling info when profiling is enabled. All commands are expected
+    // to have profiling data in this mode to keep pending_kernels_ consistent
+    // with num_pending_dispatches_.
+    if (is_profiling_) {
+      ORT_ENFORCE(command.pending_kernel_info.has_value(),
+                  "WebGpuContext::Replay: profiling is enabled but captured command at index ",
+                  i,
+                  " is missing pending_kernel_info.");
+      pending_kernels_.emplace_back(*command.pending_kernel_info);
     }
 
+    DispatchCommand(command);
     if (num_pending_dispatches_ >= max_num_pending_dispatches_) {
       ORT_THROW_IF_ERROR(Flush(buffer_manager));
     }
@@ -1174,7 +1145,6 @@ void WebGpuContext::ReleaseGraphResources(std::vector<webgpu::CapturedCommandInf
 
   for (auto& command : captured_commands) {
     command.bind_group = nullptr;
-    command.clear_buffer = nullptr;
   }
 }
 

--- a/onnxruntime/core/providers/webgpu/webgpu_context.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.cc
@@ -1148,7 +1148,7 @@ void WebGpuContext::Replay(const std::vector<webgpu::CapturedCommandInfo>& captu
     } else {
       ORT_ENFORCE(command.type == webgpu::CapturedCommandType::ClearBuffer);
       ORT_THROW_IF_ERROR(ClearBuffer(command.clear_buffer, command.clear_offset, command.clear_size,
-                                    buffer_manager));
+                                     buffer_manager));
     }
 
     if (num_pending_dispatches_ >= max_num_pending_dispatches_) {

--- a/onnxruntime/core/providers/webgpu/webgpu_context.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.cc
@@ -332,11 +332,11 @@ Status WebGpuContext::EncodeDeferredDispatches() {
     return Status::OK();
   }
 
-  ORT_ENFORCE(static_cast<size_t>(num_pending_dispatches_) + deferred_dispatches_.size() <=
-                  max_num_pending_dispatches_,
-              "WebGpuContext::EncodeDeferredDispatches: encoded dispatch count (",
-              num_pending_dispatches_, ") plus deferred dispatch count (", deferred_dispatches_.size(),
-              ") exceeds maxNumPendingDispatches (", max_num_pending_dispatches_, ").");
+  ORT_RETURN_IF_NOT(static_cast<size_t>(num_pending_dispatches_) + deferred_dispatches_.size() <=
+                        max_num_pending_dispatches_,
+                    "WebGpuContext::EncodeDeferredDispatches: encoded dispatch count (",
+                    num_pending_dispatches_, ") plus deferred dispatch count (", deferred_dispatches_.size(),
+                    ") exceeds maxNumPendingDispatches (", max_num_pending_dispatches_, ").");
 
   auto reset_deferred_state = [this]() {
     deferred_dispatches_.clear();

--- a/onnxruntime/core/providers/webgpu/webgpu_context.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.cc
@@ -332,6 +332,12 @@ Status WebGpuContext::EncodeDeferredDispatches() {
     return Status::OK();
   }
 
+  ORT_ENFORCE(static_cast<size_t>(num_pending_dispatches_) + deferred_dispatches_.size() <=
+                  max_num_pending_dispatches_,
+              "WebGpuContext::EncodeDeferredDispatches: encoded dispatch count (",
+              num_pending_dispatches_, ") plus deferred dispatch count (", deferred_dispatches_.size(),
+              ") exceeds maxNumPendingDispatches (", max_num_pending_dispatches_, ").");
+
   auto reset_deferred_state = [this]() {
     deferred_dispatches_.clear();
   };
@@ -685,7 +691,8 @@ Status WebGpuContext::Run(ComputeContextBase& context, const ProgramBase& progra
 
   // Drain and submit a full window to bound both recorded and encoded dispatch state. Partial
   // windows are encoded and submitted by the caller at its execution boundary.
-  if (deferred_dispatches_.size() >= max_num_pending_dispatches_) {
+  if (static_cast<size_t>(num_pending_dispatches_) + deferred_dispatches_.size() >=
+      max_num_pending_dispatches_) {
     ORT_RETURN_IF_ERROR(Flush(buffer_mgr));
   }
   return Status::OK();
@@ -1081,8 +1088,12 @@ void WebGpuContext::DispatchCommand(const webgpu::CapturedCommandInfo& command) 
   }
 }
 
-Status WebGpuContext::ClearBuffer(WGPUBuffer buffer, uint64_t offset, uint64_t size) {
+Status WebGpuContext::ClearBuffer(WGPUBuffer buffer, uint64_t offset, uint64_t size,
+                                  const webgpu::BufferManager& buffer_manager) {
   ORT_RETURN_IF_ERROR(EncodeDeferredDispatches());
+  if (num_pending_dispatches_ >= max_num_pending_dispatches_) {
+    ORT_RETURN_IF_ERROR(Flush(buffer_manager));
+  }
   EndComputePass();
   GetCommandEncoder().ClearBuffer(buffer, offset, size);
 
@@ -1136,7 +1147,8 @@ void WebGpuContext::Replay(const std::vector<webgpu::CapturedCommandInfo>& captu
       DispatchCommand(command);
     } else {
       ORT_ENFORCE(command.type == webgpu::CapturedCommandType::ClearBuffer);
-      ORT_THROW_IF_ERROR(ClearBuffer(command.clear_buffer, command.clear_offset, command.clear_size));
+      ORT_THROW_IF_ERROR(ClearBuffer(command.clear_buffer, command.clear_offset, command.clear_size,
+                                    buffer_manager));
     }
 
     if (num_pending_dispatches_ >= max_num_pending_dispatches_) {

--- a/onnxruntime/core/providers/webgpu/webgpu_context.h
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.h
@@ -73,7 +73,13 @@ struct PendingPipelineBuild {
   wgpu::Future future;
 };
 
-// Resources for one recorded dispatch. The pipeline fields represent these lifecycle states:
+enum class CapturedCommandType {
+  Dispatch,
+  ClearBuffer,
+};
+
+// Resources for one recorded command. Dispatch commands use the pipeline fields, which represent
+// these lifecycle states:
 //
 //                                 pending_build    compute_pipeline
 // 1. Program cache hit                 empty              set
@@ -94,9 +100,12 @@ struct PendingPipelineBuild {
 //    The command was moved into captured graph storage after encoding and retains the ready
 //    pipeline and bind group for later replays. Replay never depends on pending_build.
 //
-// A command with both fields empty is therefore valid only in state 3 before deferred pipeline
-// resolution. DispatchCommand() requires compute_pipeline to be set.
+// A dispatch command with both fields empty is therefore valid only in state 3 before deferred
+// pipeline resolution. DispatchCommand() requires compute_pipeline to be set. Buffer-clear commands
+// use only clear_buffer, clear_offset, and clear_size; the buffer handle is non-owning and remains
+// valid for the captured graph lifetime through its per-graph BufferManager.
 struct CapturedCommandInfo {
+  CapturedCommandType type{CapturedCommandType::Dispatch};
   std::string program_key;
   std::optional<PendingPipelineBuild> pending_build;
   std::optional<wgpu::ComputePipeline> compute_pipeline;
@@ -106,6 +115,9 @@ struct CapturedCommandInfo {
   WGPUBuffer indirect_buffer = nullptr;
   // Optional profiling data
   std::optional<PendingKernelInfo> pending_kernel_info;
+  WGPUBuffer clear_buffer = nullptr;
+  uint64_t clear_offset = 0;
+  uint64_t clear_size = 0;
 };
 
 struct WebGpuBufferCacheConfig {
@@ -362,6 +374,7 @@ class WebGpuContext final {
                                   const wgpu::BindGroupLayout& bind_group_layout,
                                   std::string_view label) const;
   void DispatchCommand(const webgpu::CapturedCommandInfo& command);
+  Status ClearBuffer(WGPUBuffer buffer, uint64_t offset, uint64_t size);
   Status EncodeDeferredDispatches();
 
   std::vector<const char*> GetEnabledAdapterToggles() const;

--- a/onnxruntime/core/providers/webgpu/webgpu_context.h
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.h
@@ -73,13 +73,7 @@ struct PendingPipelineBuild {
   wgpu::Future future;
 };
 
-enum class CapturedCommandType {
-  Dispatch,
-  ClearBuffer,
-};
-
-// Resources for one recorded command. Dispatch commands use the pipeline fields, which represent
-// these lifecycle states:
+// Resources for one recorded dispatch. The pipeline fields represent these lifecycle states:
 //
 //                                 pending_build    compute_pipeline
 // 1. Program cache hit                 empty              set
@@ -100,12 +94,9 @@ enum class CapturedCommandType {
 //    The command was moved into captured graph storage after encoding and retains the ready
 //    pipeline and bind group for later replays. Replay never depends on pending_build.
 //
-// A dispatch command with both fields empty is therefore valid only in state 3 before deferred
-// pipeline resolution. DispatchCommand() requires compute_pipeline to be set. Buffer-clear commands
-// use only clear_buffer, clear_offset, and clear_size; the buffer handle is non-owning and remains
-// valid for the captured graph lifetime through its per-graph BufferManager.
+// A command with both fields empty is therefore valid only in state 3 before deferred pipeline
+// resolution. DispatchCommand() requires compute_pipeline to be set.
 struct CapturedCommandInfo {
-  CapturedCommandType type{CapturedCommandType::Dispatch};
   std::string program_key;
   std::optional<PendingPipelineBuild> pending_build;
   std::optional<wgpu::ComputePipeline> compute_pipeline;
@@ -115,9 +106,6 @@ struct CapturedCommandInfo {
   WGPUBuffer indirect_buffer = nullptr;
   // Optional profiling data
   std::optional<PendingKernelInfo> pending_kernel_info;
-  WGPUBuffer clear_buffer = nullptr;
-  uint64_t clear_offset = 0;
-  uint64_t clear_size = 0;
 };
 
 struct WebGpuBufferCacheConfig {
@@ -374,8 +362,6 @@ class WebGpuContext final {
                                   const wgpu::BindGroupLayout& bind_group_layout,
                                   std::string_view label) const;
   void DispatchCommand(const webgpu::CapturedCommandInfo& command);
-  Status ClearBuffer(WGPUBuffer buffer, uint64_t offset, uint64_t size,
-                     const webgpu::BufferManager& buffer_manager);
   Status EncodeDeferredDispatches();
 
   std::vector<const char*> GetEnabledAdapterToggles() const;

--- a/onnxruntime/core/providers/webgpu/webgpu_context.h
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.h
@@ -374,7 +374,8 @@ class WebGpuContext final {
                                   const wgpu::BindGroupLayout& bind_group_layout,
                                   std::string_view label) const;
   void DispatchCommand(const webgpu::CapturedCommandInfo& command);
-  Status ClearBuffer(WGPUBuffer buffer, uint64_t offset, uint64_t size);
+  Status ClearBuffer(WGPUBuffer buffer, uint64_t offset, uint64_t size,
+                     const webgpu::BufferManager& buffer_manager);
   Status EncodeDeferredDispatches();
 
   std::vector<const char*> GetEnabledAdapterToggles() const;

--- a/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
@@ -854,12 +854,12 @@ Status WebGpuExecutionProvider::OnRunStart(const onnxruntime::RunOptions& run_op
     }
   }
 
-  run_active_ = true;
+  run_active_.store(true);
   return Status::OK();
 }
 
 Status WebGpuExecutionProvider::OnRunEnd(bool /* sync_stream */, const onnxruntime::RunOptions& run_options) {
-  run_active_ = false;
+  run_active_.store(false);
 
   // When capturing, flushing creates the replay-ready CapturedCommandInfo entries before
   // CaptureEnd() detaches their external storage.

--- a/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
@@ -631,7 +631,8 @@ std::vector<AllocatorPtr> WebGpuExecutionProvider::CreatePreferredAllocators() {
       // default allocator
       CreateWebGpuAllocator(
           device_free,
-          [this]() -> const webgpu::BufferManager& { return BufferManager(); }, false),
+          [this]() -> const webgpu::BufferManager& { return BufferManager(); }, false,
+          [this]() { return !IsRunActive(); }),
   };
 }
 
@@ -853,10 +854,13 @@ Status WebGpuExecutionProvider::OnRunStart(const onnxruntime::RunOptions& run_op
     }
   }
 
+  run_active_ = true;
   return Status::OK();
 }
 
 Status WebGpuExecutionProvider::OnRunEnd(bool /* sync_stream */, const onnxruntime::RunOptions& run_options) {
+  run_active_ = false;
+
   // When capturing, flushing creates the replay-ready CapturedCommandInfo entries before
   // CaptureEnd() detaches their external storage.
   Status flush_status = context_.Flush(BufferManager());

--- a/onnxruntime/core/providers/webgpu/webgpu_execution_provider.h
+++ b/onnxruntime/core/providers/webgpu/webgpu_execution_provider.h
@@ -4,9 +4,10 @@
 
 #pragma once
 
+#include <atomic>
+#include <memory>
 #include <span>
 #include <string>
-#include <memory>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -96,7 +97,7 @@ class WebGpuExecutionProvider : public IExecutionProvider {
 
   Status OnRunStart(const onnxruntime::RunOptions& run_options) override;
   Status OnRunEnd(bool sync_stream, const onnxruntime::RunOptions& run_options) override;
-  bool IsRunActive() const { return run_active_; }
+  bool IsRunActive() const { return run_active_.load(); }
 
   // WebGPU EP reuses the Device ID as the key to get the WebGpuContext instance.
   int GetDeviceId() const override { return context_id_; }
@@ -137,7 +138,7 @@ class WebGpuExecutionProvider : public IExecutionProvider {
   std::vector<std::string> force_cpu_node_names_;
   bool enable_graph_capture_ = false;
   bool graph_buffer_mgr_active_ = false;
-  bool run_active_ = false;
+  std::atomic<bool> run_active_{false};
   bool enable_int64_ = false;
   uint32_t multi_rotary_cache_concat_offset_ = 0;
   uint32_t kv_cache_quantization_bits_ = 0;

--- a/onnxruntime/core/providers/webgpu/webgpu_execution_provider.h
+++ b/onnxruntime/core/providers/webgpu/webgpu_execution_provider.h
@@ -96,6 +96,7 @@ class WebGpuExecutionProvider : public IExecutionProvider {
 
   Status OnRunStart(const onnxruntime::RunOptions& run_options) override;
   Status OnRunEnd(bool sync_stream, const onnxruntime::RunOptions& run_options) override;
+  bool IsRunActive() const { return run_active_; }
 
   // WebGPU EP reuses the Device ID as the key to get the WebGpuContext instance.
   int GetDeviceId() const override { return context_id_; }
@@ -136,6 +137,7 @@ class WebGpuExecutionProvider : public IExecutionProvider {
   std::vector<std::string> force_cpu_node_names_;
   bool enable_graph_capture_ = false;
   bool graph_buffer_mgr_active_ = false;
+  bool run_active_ = false;
   bool enable_int64_ = false;
   uint32_t multi_rotary_cache_concat_offset_ = 0;
   uint32_t kv_cache_quantization_bits_ = 0;

--- a/onnxruntime/test/providers/graph_capture_test.cc
+++ b/onnxruntime/test/providers/graph_capture_test.cc
@@ -3,7 +3,10 @@
 
 #ifdef USE_WEBGPU
 
+#include <filesystem>
 #include <numeric>
+
+#include <gsl/gsl>
 
 #include "gtest/gtest.h"
 
@@ -86,6 +89,78 @@ static Model CreateMatMulReluMatMulModel() {
   Model model(opsets);
   model.AddGraph(graph);
   return model;
+}
+
+TEST(WebGpuDispatchBatchingTests, ProfilingDispatchCountStaysBoundedAcrossAllocatorClears) {
+  Env& env = *ort_env;
+
+  SessionOptions session_options;
+  session_options.DisableMemPattern();
+  session_options.EnableProfiling(ORT_TSTR("webgpu_dispatch_batching_profiling_test"));
+
+  std::unordered_map<std::string, std::string> provider_options;
+  provider_options["maxNumPendingDispatches"] = "2";
+  provider_options["validationMode"] = "full";
+  AppendWebGpuEp(env, session_options, provider_options);
+
+  auto model = CreateMatMulReluMatMulModel();
+  Session session(env, model, session_options);
+
+  MemoryInfo gpu_mem_info("WebGPU_Buffer", OrtAllocatorType::OrtDeviceAllocator, 0, OrtMemTypeDefault);
+  Allocator gpu_allocator(session, gpu_mem_info);
+  MemoryInfo cpu_mem_info = MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
+
+  std::vector<int64_t> dims_a = {3, 4};
+  std::vector<int64_t> dims_b = {4, 3};
+  std::vector<int64_t> dims_c = {3, 2};
+  std::vector<int64_t> dims_y = {3, 2};
+  std::vector<float> values_a(12, 1.0f);
+  std::vector<float> values_b(12, 1.0f);
+  std::vector<float> values_c(6, 1.0f);
+
+  Value gpu_a = Value::CreateTensor<float>(gpu_allocator, dims_a.data(), dims_a.size());
+  Value gpu_b = Value::CreateTensor<float>(gpu_allocator, dims_b.data(), dims_b.size());
+  Value gpu_c = Value::CreateTensor<float>(gpu_allocator, dims_c.data(), dims_c.size());
+  Value gpu_y = Value::CreateTensor<float>(gpu_allocator, dims_y.data(), dims_y.size());
+
+  auto copy_to_gpu = [&](std::vector<float>& values, const std::vector<int64_t>& dims, Value& gpu_tensor) {
+    Value cpu_tensor = Value::CreateTensor<float>(cpu_mem_info, values.data(), values.size(),
+                                                  dims.data(), dims.size());
+    auto status = env.CopyTensor(cpu_tensor, gpu_tensor, nullptr);
+    ASSERT_TRUE(status.IsOK()) << status.GetErrorMessage();
+  };
+
+  copy_to_gpu(values_a, dims_a, gpu_a);
+  copy_to_gpu(values_b, dims_b, gpu_b);
+  copy_to_gpu(values_c, dims_c, gpu_c);
+
+  IoBinding io_binding(session);
+  io_binding.BindInput("A", gpu_a);
+  io_binding.BindInput("B", gpu_b);
+  io_binding.BindInput("C", gpu_c);
+  io_binding.BindOutput("Y", gpu_y);
+  io_binding.SynchronizeInputs();
+
+  std::string run_error;
+  try {
+    session.Run(RunOptions{nullptr}, io_binding);
+    io_binding.SynchronizeOutputs();
+
+    session.Run(RunOptions{nullptr}, io_binding);
+    io_binding.SynchronizeOutputs();
+  } catch (const std::exception& ex) {
+    run_error = ex.what();
+  }
+
+  AllocatorWithDefaultOptions allocator;
+  auto profile_file = session.EndProfilingAllocated(allocator);
+  std::filesystem::path profile_file_path = profile_file.get();
+  auto cleanup_profile = gsl::finally([&profile_file_path] {
+    std::error_code ec;
+    std::filesystem::remove(profile_file_path, ec);
+  });
+
+  ASSERT_TRUE(run_error.empty()) << run_error;
 }
 
 TEST(GraphCaptureTests, TestReleaseCapturedGraph) {

--- a/onnxruntime/test/providers/graph_capture_test.cc
+++ b/onnxruntime/test/providers/graph_capture_test.cc
@@ -119,13 +119,13 @@ TEST(WebGpuDispatchBatchingTests, ProfilingDispatchCountStaysBoundedAcrossAlloca
 
   std::vector<Value> inputs;
   inputs.emplace_back(Value::CreateTensor<float>(cpu_mem_info, values_a.data(), values_a.size(),
-                                                  dims_a.data(), dims_a.size()));
+                                                 dims_a.data(), dims_a.size()));
   inputs.emplace_back(Value::CreateTensor<float>(cpu_mem_info, values_b.data(), values_b.size(),
-                                                  dims_b.data(), dims_b.size()));
+                                                 dims_b.data(), dims_b.size()));
   inputs.emplace_back(Value::CreateTensor<float>(cpu_mem_info, values_c.data(), values_c.size(),
-                                                  dims_c.data(), dims_c.size()));
+                                                 dims_c.data(), dims_c.size()));
   Value output = Value::CreateTensor<float>(cpu_mem_info, values_y.data(), values_y.size(),
-                                             dims_y.data(), dims_y.size());
+                                            dims_y.data(), dims_y.size());
   std::vector<const char*> input_names = {"A", "B", "C"};
   std::vector<const char*> output_names = {"Y"};
 

--- a/onnxruntime/test/providers/graph_capture_test.cc
+++ b/onnxruntime/test/providers/graph_capture_test.cc
@@ -106,9 +106,7 @@ TEST(WebGpuDispatchBatchingTests, ProfilingDispatchCountStaysBoundedAcrossAlloca
   auto model = CreateMatMulReluMatMulModel();
   Session session(env, model, session_options);
 
-  MemoryInfo gpu_mem_info("WebGPU_Buffer", OrtAllocatorType::OrtDeviceAllocator, 0, OrtMemTypeDefault);
-  Allocator gpu_allocator(session, gpu_mem_info);
-  MemoryInfo cpu_mem_info = MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
+  MemoryInfo cpu_mem_info = MemoryInfo::CreateCpu(OrtDeviceAllocator, OrtMemTypeCPU);
 
   std::vector<int64_t> dims_a = {3, 4};
   std::vector<int64_t> dims_b = {4, 3};
@@ -117,37 +115,32 @@ TEST(WebGpuDispatchBatchingTests, ProfilingDispatchCountStaysBoundedAcrossAlloca
   std::vector<float> values_a(12, 1.0f);
   std::vector<float> values_b(12, 1.0f);
   std::vector<float> values_c(6, 1.0f);
+  std::vector<float> values_y(6, 0.0f);
 
-  Value gpu_a = Value::CreateTensor<float>(gpu_allocator, dims_a.data(), dims_a.size());
-  Value gpu_b = Value::CreateTensor<float>(gpu_allocator, dims_b.data(), dims_b.size());
-  Value gpu_c = Value::CreateTensor<float>(gpu_allocator, dims_c.data(), dims_c.size());
-  Value gpu_y = Value::CreateTensor<float>(gpu_allocator, dims_y.data(), dims_y.size());
-
-  auto copy_to_gpu = [&](std::vector<float>& values, const std::vector<int64_t>& dims, Value& gpu_tensor) {
-    Value cpu_tensor = Value::CreateTensor<float>(cpu_mem_info, values.data(), values.size(),
-                                                  dims.data(), dims.size());
-    auto status = env.CopyTensor(cpu_tensor, gpu_tensor, nullptr);
-    ASSERT_TRUE(status.IsOK()) << status.GetErrorMessage();
-  };
-
-  copy_to_gpu(values_a, dims_a, gpu_a);
-  copy_to_gpu(values_b, dims_b, gpu_b);
-  copy_to_gpu(values_c, dims_c, gpu_c);
-
-  IoBinding io_binding(session);
-  io_binding.BindInput("A", gpu_a);
-  io_binding.BindInput("B", gpu_b);
-  io_binding.BindInput("C", gpu_c);
-  io_binding.BindOutput("Y", gpu_y);
-  io_binding.SynchronizeInputs();
+  std::vector<Value> inputs;
+  inputs.emplace_back(Value::CreateTensor<float>(cpu_mem_info, values_a.data(), values_a.size(),
+                                                  dims_a.data(), dims_a.size()));
+  inputs.emplace_back(Value::CreateTensor<float>(cpu_mem_info, values_b.data(), values_b.size(),
+                                                  dims_b.data(), dims_b.size()));
+  inputs.emplace_back(Value::CreateTensor<float>(cpu_mem_info, values_c.data(), values_c.size(),
+                                                  dims_c.data(), dims_c.size()));
+  Value output = Value::CreateTensor<float>(cpu_mem_info, values_y.data(), values_y.size(),
+                                             dims_y.data(), dims_y.size());
+  std::vector<const char*> input_names = {"A", "B", "C"};
+  std::vector<const char*> output_names = {"Y"};
 
   std::string run_error;
+  std::vector<float> warm_output;
+  std::vector<float> second_output;
   try {
-    session.Run(RunOptions{nullptr}, io_binding);
-    io_binding.SynchronizeOutputs();
+    session.Run(RunOptions{nullptr}, input_names.data(), inputs.data(), inputs.size(),
+                output_names.data(), &output, 1);
+    warm_output = values_y;
 
-    session.Run(RunOptions{nullptr}, io_binding);
-    io_binding.SynchronizeOutputs();
+    std::fill(values_y.begin(), values_y.end(), 0.0f);
+    session.Run(RunOptions{nullptr}, input_names.data(), inputs.data(), inputs.size(),
+                output_names.data(), &output, 1);
+    second_output = values_y;
   } catch (const std::exception& ex) {
     run_error = ex.what();
   }
@@ -161,6 +154,13 @@ TEST(WebGpuDispatchBatchingTests, ProfilingDispatchCountStaysBoundedAcrossAlloca
   });
 
   ASSERT_TRUE(run_error.empty()) << run_error;
+  const std::vector<float> expected_output(6, 12.0f);
+  ASSERT_EQ(warm_output.size(), expected_output.size());
+  ASSERT_EQ(second_output.size(), expected_output.size());
+  for (size_t i = 0; i < expected_output.size(); ++i) {
+    EXPECT_FLOAT_EQ(warm_output[i], expected_output[i]) << "Warm run output mismatch at index " << i;
+    EXPECT_FLOAT_EQ(second_output[i], expected_output[i]) << "Second run output mismatch at index " << i;
+  }
 }
 
 TEST(GraphCaptureTests, TestReleaseCapturedGraph) {

--- a/onnxruntime/test/providers/webgpu/webgpu_context_test.cc
+++ b/onnxruntime/test/providers/webgpu/webgpu_context_test.cc
@@ -88,7 +88,7 @@ TEST(WebGpuContextTest, ReusedDeviceAllocatorBufferIsZeroInitialized) {
   allocator.Free(allocation);
 }
 
-TEST(WebGpuContextTest, ReplaysDeviceAllocatorBufferClear) {
+TEST(WebGpuContextTest, DoesNotCaptureDeviceAllocatorBufferClear) {
   ConfigOptions options;
   auto ep = WebGpuProviderFactoryCreator::Create(options)->CreateProvider();
   ASSERT_NE(ep, nullptr);
@@ -127,13 +127,7 @@ TEST(WebGpuContextTest, ReplaysDeviceAllocatorBufferClear) {
     FAIL() << flush_status.ErrorMessage();
   }
 
-  buffer_manager.Upload(nonzero_data.data(), reused_buffer, sizeof(nonzero_data));
-  context.Replay(captured_commands, buffer_manager);
-
-  std::array<uint32_t, 16> downloaded_data;
-  buffer_manager.Download(reused_buffer, downloaded_data.data(), sizeof(downloaded_data));
-  const std::array<uint32_t, 16> expected_data{};
-  EXPECT_EQ(downloaded_data, expected_data);
+  EXPECT_TRUE(captured_commands.empty());
 
   allocator.Free(allocation);
 }

--- a/onnxruntime/test/providers/webgpu/webgpu_context_test.cc
+++ b/onnxruntime/test/providers/webgpu/webgpu_context_test.cc
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include <algorithm>
+#include <array>
 #include <cstdint>
 #include <string>
 #include <string_view>
@@ -10,6 +11,8 @@
 
 #include "core/common/common.h"
 #include "core/framework/config_options.h"
+#include "core/providers/webgpu/allocator.h"
+#include "core/providers/webgpu/buffer_manager.h"
 #include "core/providers/webgpu/webgpu_context.h"
 #include "core/providers/webgpu/webgpu_provider_factory_creator.h"
 #include "core/providers/webgpu/webgpu_provider_options.h"
@@ -46,6 +49,42 @@ bool DeviceToggleIsEnabled(const webgpu::WebGpuContext& context, std::string_vie
 
 bool DisableRobustnessToggleIsEnabled(const webgpu::WebGpuContext& context) {
   return DeviceToggleIsEnabled(context, "disable_robustness");
+}
+
+TEST(WebGpuContextTest, ReusedDeviceAllocatorBufferIsZeroInitialized) {
+  ConfigOptions options;
+  auto ep = WebGpuProviderFactoryCreator::Create(options)->CreateProvider();
+  ASSERT_NE(ep, nullptr);
+
+  auto& context = webgpu::WebGpuContextFactory::GetContext(0);
+  webgpu::BufferManager buffer_manager(context,
+                                       webgpu::BufferCacheMode::Bucket,
+                                       webgpu::BufferCacheMode::Disabled,
+                                       webgpu::BufferCacheMode::Disabled,
+                                       webgpu::BufferCacheMode::Disabled);
+  webgpu::GpuBufferAllocator allocator(
+      [&buffer_manager]() -> const webgpu::BufferManager& { return buffer_manager; },
+      false);
+
+  std::array<uint32_t, 16> nonzero_data;
+  nonzero_data.fill(0xffffffffu);
+  void* allocation = allocator.Alloc(sizeof(nonzero_data));
+  ASSERT_NE(allocation, nullptr);
+  WGPUBuffer dirty_buffer = static_cast<WGPUBuffer>(allocation);
+  buffer_manager.Upload(nonzero_data.data(), dirty_buffer, sizeof(nonzero_data));
+  allocator.Free(allocation);
+
+  allocation = allocator.Alloc(sizeof(nonzero_data));
+  ASSERT_NE(allocation, nullptr);
+  WGPUBuffer reused_buffer = static_cast<WGPUBuffer>(allocation);
+  ASSERT_EQ(reused_buffer, dirty_buffer);
+
+  std::array<uint32_t, 16> downloaded_data;
+  buffer_manager.Download(reused_buffer, downloaded_data.data(), sizeof(downloaded_data));
+  EXPECT_TRUE(std::all_of(downloaded_data.begin(), downloaded_data.end(),
+                          [](uint32_t value) { return value == 0; }));
+
+  allocator.Free(allocation);
 }
 
 TEST(WebGpuContextTest, EnableRobustnessControlsDawnToggle) {

--- a/onnxruntime/test/providers/webgpu/webgpu_context_test.cc
+++ b/onnxruntime/test/providers/webgpu/webgpu_context_test.cc
@@ -80,8 +80,32 @@ TEST(WebGpuContextTest, ReusedDeviceAllocatorBufferIsZeroInitialized) {
   WGPUBuffer reused_buffer = static_cast<WGPUBuffer>(allocation);
   EXPECT_EQ(reused_buffer, dirty_buffer);
 
+  wgpu::BufferDescriptor readback_desc{};
+  readback_desc.size = sizeof(nonzero_data);
+  readback_desc.usage = wgpu::BufferUsage::MapRead | wgpu::BufferUsage::CopyDst;
+  auto readback_buffer = context.Device().CreateBuffer(&readback_desc);
+
+  auto external_encoder = context.Device().CreateCommandEncoder();
+  external_encoder.CopyBufferToBuffer(reused_buffer, 0, readback_buffer, 0, sizeof(nonzero_data));
+  auto external_commands = external_encoder.Finish();
+  context.Device().GetQueue().Submit(1, &external_commands);
+
+  wgpu::MapAsyncStatus map_status{};
+  ASSERT_STATUS_OK(context.Wait(readback_buffer.MapAsync(
+      wgpu::MapMode::Read, 0, sizeof(nonzero_data), wgpu::CallbackMode::WaitAnyOnly,
+      [](wgpu::MapAsyncStatus status, wgpu::StringView /*message*/, wgpu::MapAsyncStatus* result) noexcept {
+        *result = status;
+      },
+      &map_status)));
+  ASSERT_EQ(map_status, wgpu::MapAsyncStatus::Success);
+
   std::array<uint32_t, 16> downloaded_data;
-  buffer_manager.Download(reused_buffer, downloaded_data.data(), sizeof(downloaded_data));
+  const auto* mapped_data = static_cast<const uint32_t*>(readback_buffer.GetConstMappedRange());
+  ASSERT_NE(mapped_data, nullptr);
+  std::copy_n(mapped_data, downloaded_data.size(), downloaded_data.begin());
+  readback_buffer.Unmap();
+
+  ASSERT_STATUS_OK(context.Flush(buffer_manager));
   const std::array<uint32_t, 16> expected_data{};
   EXPECT_EQ(downloaded_data, expected_data);
 

--- a/onnxruntime/test/providers/webgpu/webgpu_context_test.cc
+++ b/onnxruntime/test/providers/webgpu/webgpu_context_test.cc
@@ -12,6 +12,7 @@
 
 #include "core/common/common.h"
 #include "core/framework/config_options.h"
+#include "core/framework/run_options.h"
 #include "core/providers/webgpu/allocator.h"
 #include "core/providers/webgpu/buffer_manager.h"
 #include "core/providers/webgpu/webgpu_context.h"
@@ -192,14 +193,15 @@ TEST(WebGpuContextTest, SessionAllocatorDefersReusedBufferClearDuringRun) {
   ASSERT_STATUS_OK(context.Flush(buffer_manager));
   allocator.Free(allocation);
 
-  ASSERT_STATUS_OK(webgpu_ep->OnRunStart({}));
+  RunOptions run_options;
+  ASSERT_STATUS_OK(webgpu_ep->OnRunStart(run_options));
   allocation = allocator.Alloc(sizeof(nonzero_data));
   ASSERT_NE(allocation, nullptr);
   WGPUBuffer reused_buffer = static_cast<WGPUBuffer>(allocation);
   EXPECT_EQ(reused_buffer, dirty_buffer);
   EXPECT_EQ(ReadBufferWithExternalCommandEncoder(context, reused_buffer), nonzero_data);
 
-  ASSERT_STATUS_OK(webgpu_ep->OnRunEnd(false, {}));
+  ASSERT_STATUS_OK(webgpu_ep->OnRunEnd(false, run_options));
   const std::array<uint32_t, 16> expected_data{};
   EXPECT_EQ(ReadBufferWithExternalCommandEncoder(context, reused_buffer), expected_data);
 
@@ -211,11 +213,12 @@ TEST(WebGpuContextTest, WebGpuExecutionProviderTracksRunActivity) {
   auto ep = WebGpuProviderFactoryCreator::Create(options)->CreateProvider();
   ASSERT_NE(ep, nullptr);
   auto* webgpu_ep = static_cast<WebGpuExecutionProvider*>(ep.get());
+  RunOptions run_options;
 
   EXPECT_FALSE(webgpu_ep->IsRunActive());
-  ASSERT_STATUS_OK(webgpu_ep->OnRunStart({}));
+  ASSERT_STATUS_OK(webgpu_ep->OnRunStart(run_options));
   EXPECT_TRUE(webgpu_ep->IsRunActive());
-  ASSERT_STATUS_OK(webgpu_ep->OnRunEnd(false, {}));
+  ASSERT_STATUS_OK(webgpu_ep->OnRunEnd(false, run_options));
   EXPECT_FALSE(webgpu_ep->IsRunActive());
 }
 

--- a/onnxruntime/test/providers/webgpu/webgpu_context_test.cc
+++ b/onnxruntime/test/providers/webgpu/webgpu_context_test.cc
@@ -15,9 +15,11 @@
 #include "core/providers/webgpu/allocator.h"
 #include "core/providers/webgpu/buffer_manager.h"
 #include "core/providers/webgpu/webgpu_context.h"
+#include "core/providers/webgpu/webgpu_execution_provider.h"
 #include "core/providers/webgpu/webgpu_provider_factory_creator.h"
 #include "core/providers/webgpu/webgpu_provider_options.h"
 #include "core/session/onnxruntime_session_options_config_keys.h"
+#include "test/util/include/asserts.h"
 
 #if !defined(__wasm__) && !defined(USE_EXTERNAL_DAWN)
 #include "dawn/native/DawnNative.h"
@@ -52,20 +54,52 @@ bool DisableRobustnessToggleIsEnabled(const webgpu::WebGpuContext& context) {
   return DeviceToggleIsEnabled(context, "disable_robustness");
 }
 
-TEST(WebGpuContextTest, ReusedDeviceAllocatorBufferIsZeroInitialized) {
+std::array<uint32_t, 16> ReadBufferWithExternalCommandEncoder(webgpu::WebGpuContext& context,
+                                                              WGPUBuffer buffer) {
+  constexpr size_t kBufferSize = sizeof(std::array<uint32_t, 16>);
+  wgpu::BufferDescriptor readback_desc{};
+  readback_desc.size = kBufferSize;
+  readback_desc.usage = wgpu::BufferUsage::MapRead | wgpu::BufferUsage::CopyDst;
+  auto readback_buffer = context.Device().CreateBuffer(&readback_desc);
+
+  auto external_encoder = context.Device().CreateCommandEncoder();
+  external_encoder.CopyBufferToBuffer(buffer, 0, readback_buffer, 0, kBufferSize);
+  auto external_commands = external_encoder.Finish();
+  context.Device().GetQueue().Submit(1, &external_commands);
+
+  wgpu::MapAsyncStatus map_status{};
+  ORT_THROW_IF_ERROR(context.Wait(readback_buffer.MapAsync(
+      wgpu::MapMode::Read, 0, kBufferSize, wgpu::CallbackMode::WaitAnyOnly,
+      [](wgpu::MapAsyncStatus status, wgpu::StringView /*message*/, wgpu::MapAsyncStatus* result) noexcept {
+        *result = status;
+      },
+      &map_status)));
+  ORT_ENFORCE(map_status == wgpu::MapAsyncStatus::Success);
+
+  std::array<uint32_t, 16> result;
+  const auto* mapped_data = static_cast<const uint32_t*>(readback_buffer.GetConstMappedRange());
+  ORT_ENFORCE(mapped_data != nullptr);
+  std::copy_n(mapped_data, result.size(), result.begin());
+  readback_buffer.Unmap();
+  return result;
+}
+
+TEST(WebGpuContextTest, SessionAllocatorSubmitsReusedBufferClearOutsideRun) {
   ConfigOptions options;
   auto ep = WebGpuProviderFactoryCreator::Create(options)->CreateProvider();
   ASSERT_NE(ep, nullptr);
+  auto* webgpu_ep = static_cast<WebGpuExecutionProvider*>(ep.get());
 
   auto& context = webgpu::WebGpuContextFactory::GetContext(0);
   webgpu::BufferManager buffer_manager(context,
                                        webgpu::BufferCacheMode::Bucket,
-                                       webgpu::BufferCacheMode::Disabled,
+                                       webgpu::BufferCacheMode::Simple,
                                        webgpu::BufferCacheMode::Disabled,
                                        webgpu::BufferCacheMode::Disabled);
   webgpu::GpuBufferAllocator allocator(
       [&buffer_manager]() -> const webgpu::BufferManager& { return buffer_manager; },
-      false);
+      false,
+      [webgpu_ep]() { return !webgpu_ep->IsRunActive(); });
 
   std::array<uint32_t, 16> nonzero_data;
   nonzero_data.fill(0xffffffffu);
@@ -80,31 +114,7 @@ TEST(WebGpuContextTest, ReusedDeviceAllocatorBufferIsZeroInitialized) {
   WGPUBuffer reused_buffer = static_cast<WGPUBuffer>(allocation);
   EXPECT_EQ(reused_buffer, dirty_buffer);
 
-  wgpu::BufferDescriptor readback_desc{};
-  readback_desc.size = sizeof(nonzero_data);
-  readback_desc.usage = wgpu::BufferUsage::MapRead | wgpu::BufferUsage::CopyDst;
-  auto readback_buffer = context.Device().CreateBuffer(&readback_desc);
-
-  auto external_encoder = context.Device().CreateCommandEncoder();
-  external_encoder.CopyBufferToBuffer(reused_buffer, 0, readback_buffer, 0, sizeof(nonzero_data));
-  auto external_commands = external_encoder.Finish();
-  context.Device().GetQueue().Submit(1, &external_commands);
-
-  wgpu::MapAsyncStatus map_status{};
-  ASSERT_STATUS_OK(context.Wait(readback_buffer.MapAsync(
-      wgpu::MapMode::Read, 0, sizeof(nonzero_data), wgpu::CallbackMode::WaitAnyOnly,
-      [](wgpu::MapAsyncStatus status, wgpu::StringView /*message*/, wgpu::MapAsyncStatus* result) noexcept {
-        *result = status;
-      },
-      &map_status)));
-  ASSERT_EQ(map_status, wgpu::MapAsyncStatus::Success);
-
-  std::array<uint32_t, 16> downloaded_data;
-  const auto* mapped_data = static_cast<const uint32_t*>(readback_buffer.GetConstMappedRange());
-  ASSERT_NE(mapped_data, nullptr);
-  std::copy_n(mapped_data, downloaded_data.size(), downloaded_data.begin());
-  readback_buffer.Unmap();
-
+  const auto downloaded_data = ReadBufferWithExternalCommandEncoder(context, reused_buffer);
   ASSERT_STATUS_OK(context.Flush(buffer_manager));
   const std::array<uint32_t, 16> expected_data{};
   EXPECT_EQ(downloaded_data, expected_data);
@@ -154,6 +164,59 @@ TEST(WebGpuContextTest, DoesNotCaptureDeviceAllocatorBufferClear) {
   EXPECT_TRUE(captured_commands.empty());
 
   allocator.Free(allocation);
+}
+
+TEST(WebGpuContextTest, SessionAllocatorDefersReusedBufferClearDuringRun) {
+  ConfigOptions options;
+  auto ep = WebGpuProviderFactoryCreator::Create(options)->CreateProvider();
+  ASSERT_NE(ep, nullptr);
+  auto* webgpu_ep = static_cast<WebGpuExecutionProvider*>(ep.get());
+
+  auto& context = webgpu::WebGpuContextFactory::GetContext(0);
+  webgpu::BufferManager buffer_manager(context,
+                                       webgpu::BufferCacheMode::Bucket,
+                                       webgpu::BufferCacheMode::Simple,
+                                       webgpu::BufferCacheMode::Disabled,
+                                       webgpu::BufferCacheMode::Disabled);
+  webgpu::GpuBufferAllocator allocator(
+      [&buffer_manager]() -> const webgpu::BufferManager& { return buffer_manager; },
+      false,
+      [webgpu_ep]() { return !webgpu_ep->IsRunActive(); });
+
+  std::array<uint32_t, 16> nonzero_data;
+  nonzero_data.fill(0xffffffffu);
+  void* allocation = allocator.Alloc(sizeof(nonzero_data));
+  ASSERT_NE(allocation, nullptr);
+  WGPUBuffer dirty_buffer = static_cast<WGPUBuffer>(allocation);
+  buffer_manager.Upload(nonzero_data.data(), dirty_buffer, sizeof(nonzero_data));
+  ASSERT_STATUS_OK(context.Flush(buffer_manager));
+  allocator.Free(allocation);
+
+  ASSERT_STATUS_OK(webgpu_ep->OnRunStart({}));
+  allocation = allocator.Alloc(sizeof(nonzero_data));
+  ASSERT_NE(allocation, nullptr);
+  WGPUBuffer reused_buffer = static_cast<WGPUBuffer>(allocation);
+  EXPECT_EQ(reused_buffer, dirty_buffer);
+  EXPECT_EQ(ReadBufferWithExternalCommandEncoder(context, reused_buffer), nonzero_data);
+
+  ASSERT_STATUS_OK(webgpu_ep->OnRunEnd(false, {}));
+  const std::array<uint32_t, 16> expected_data{};
+  EXPECT_EQ(ReadBufferWithExternalCommandEncoder(context, reused_buffer), expected_data);
+
+  allocator.Free(allocation);
+}
+
+TEST(WebGpuContextTest, WebGpuExecutionProviderTracksRunActivity) {
+  ConfigOptions options;
+  auto ep = WebGpuProviderFactoryCreator::Create(options)->CreateProvider();
+  ASSERT_NE(ep, nullptr);
+  auto* webgpu_ep = static_cast<WebGpuExecutionProvider*>(ep.get());
+
+  EXPECT_FALSE(webgpu_ep->IsRunActive());
+  ASSERT_STATUS_OK(webgpu_ep->OnRunStart({}));
+  EXPECT_TRUE(webgpu_ep->IsRunActive());
+  ASSERT_STATUS_OK(webgpu_ep->OnRunEnd(false, {}));
+  EXPECT_FALSE(webgpu_ep->IsRunActive());
 }
 
 TEST(WebGpuContextTest, EnablesLazyClearResourceOnFirstUse) {

--- a/onnxruntime/test/providers/webgpu/webgpu_context_test.cc
+++ b/onnxruntime/test/providers/webgpu/webgpu_context_test.cc
@@ -77,12 +77,12 @@ TEST(WebGpuContextTest, ReusedDeviceAllocatorBufferIsZeroInitialized) {
   allocation = allocator.Alloc(sizeof(nonzero_data));
   ASSERT_NE(allocation, nullptr);
   WGPUBuffer reused_buffer = static_cast<WGPUBuffer>(allocation);
-  ASSERT_EQ(reused_buffer, dirty_buffer);
+  EXPECT_EQ(reused_buffer, dirty_buffer);
 
   std::array<uint32_t, 16> downloaded_data;
   buffer_manager.Download(reused_buffer, downloaded_data.data(), sizeof(downloaded_data));
-  EXPECT_TRUE(std::all_of(downloaded_data.begin(), downloaded_data.end(),
-                          [](uint32_t value) { return value == 0; }));
+  const std::array<uint32_t, 16> expected_data{};
+  EXPECT_EQ(downloaded_data, expected_data);
 
   allocator.Free(allocation);
 }

--- a/onnxruntime/test/providers/webgpu/webgpu_context_test.cc
+++ b/onnxruntime/test/providers/webgpu/webgpu_context_test.cc
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include "gtest/gtest.h"
 
@@ -78,6 +79,56 @@ TEST(WebGpuContextTest, ReusedDeviceAllocatorBufferIsZeroInitialized) {
   ASSERT_NE(allocation, nullptr);
   WGPUBuffer reused_buffer = static_cast<WGPUBuffer>(allocation);
   EXPECT_EQ(reused_buffer, dirty_buffer);
+
+  std::array<uint32_t, 16> downloaded_data;
+  buffer_manager.Download(reused_buffer, downloaded_data.data(), sizeof(downloaded_data));
+  const std::array<uint32_t, 16> expected_data{};
+  EXPECT_EQ(downloaded_data, expected_data);
+
+  allocator.Free(allocation);
+}
+
+TEST(WebGpuContextTest, ReplaysDeviceAllocatorBufferClear) {
+  ConfigOptions options;
+  auto ep = WebGpuProviderFactoryCreator::Create(options)->CreateProvider();
+  ASSERT_NE(ep, nullptr);
+
+  auto& context = webgpu::WebGpuContextFactory::GetContext(0);
+  webgpu::BufferManager buffer_manager(context,
+                                       webgpu::BufferCacheMode::Graph,
+                                       webgpu::BufferCacheMode::Disabled,
+                                       webgpu::BufferCacheMode::Disabled,
+                                       webgpu::BufferCacheMode::Disabled);
+  std::vector<webgpu::CapturedCommandInfo> captured_commands;
+  webgpu::GpuBufferAllocator allocator(
+      [&buffer_manager]() -> const webgpu::BufferManager& { return buffer_manager; },
+      false);
+
+  std::array<uint32_t, 16> nonzero_data;
+  nonzero_data.fill(0xffffffffu);
+  void* allocation = allocator.Alloc(sizeof(nonzero_data));
+  ASSERT_NE(allocation, nullptr);
+  WGPUBuffer dirty_buffer = static_cast<WGPUBuffer>(allocation);
+  buffer_manager.Upload(nonzero_data.data(), dirty_buffer, sizeof(nonzero_data));
+  allocator.Free(allocation);
+
+  context.CaptureBegin(&captured_commands, buffer_manager);
+  allocation = allocator.Alloc(sizeof(nonzero_data));
+  if (allocation == nullptr) {
+    context.CaptureEnd();
+    FAIL() << "Failed to reacquire a device allocation during graph capture.";
+  }
+  WGPUBuffer reused_buffer = static_cast<WGPUBuffer>(allocation);
+  EXPECT_EQ(reused_buffer, dirty_buffer);
+  const Status flush_status = context.Flush(buffer_manager);
+  context.CaptureEnd();
+  if (!flush_status.IsOK()) {
+    allocator.Free(allocation);
+    FAIL() << flush_status.ErrorMessage();
+  }
+
+  buffer_manager.Upload(nonzero_data.data(), reused_buffer, sizeof(nonzero_data));
+  context.Replay(captured_commands, buffer_manager);
 
   std::array<uint32_t, 16> downloaded_data;
   buffer_manager.Download(reused_buffer, downloaded_data.data(), sizeof(downloaded_data));

--- a/onnxruntime/test/providers/webgpu/webgpu_context_test.cc
+++ b/onnxruntime/test/providers/webgpu/webgpu_context_test.cc
@@ -138,6 +138,19 @@ TEST(WebGpuContextTest, ReplaysDeviceAllocatorBufferClear) {
   allocator.Free(allocation);
 }
 
+TEST(WebGpuContextTest, EnablesLazyClearResourceOnFirstUse) {
+#if defined(__wasm__) || defined(USE_EXTERNAL_DAWN)
+  GTEST_SKIP() << "Dawn native toggle inspection is unavailable.";
+#else
+  ConfigOptions options;
+  auto ep = WebGpuProviderFactoryCreator::Create(options)->CreateProvider();
+  ASSERT_NE(ep, nullptr);
+
+  EXPECT_TRUE(DeviceToggleIsEnabled(webgpu::WebGpuContextFactory::GetContext(0),
+                                    "lazy_clear_resource_on_first_use"));
+#endif
+}
+
 TEST(WebGpuContextTest, EnableRobustnessControlsDawnToggle) {
 #if defined(__wasm__) || defined(USE_EXTERNAL_DAWN)
   GTEST_SKIP() << "Dawn native toggle inspection is unavailable.";


### PR DESCRIPTION
### Description

- Zero-initialize writable WebGPU device-allocator buffers while leaving read-only initializer and internal WebGPU allocations unchanged.
- Clear reused pooled buffers directly in `BufferManager::Create` in command order, and enable Dawn lazy resource clearing for fresh buffers.
- Track session-run activity so allocator clears are batched during `Session::Run`, but submitted before allocation returns outside `Run`; shared allocator clears are always submitted immediately.
- Keep allocation clears out of captured graph commands because graph replay reuses buffers allocated before replay.
- Keep dispatch-window limit enforcement in `WebGpuContext` and add regressions for allocation submission policy, graph capture, and profiled dispatch batching.

### Motivation and Context

Fixes #28974.

Reused device-allocator buffers can retain data from prior model execution. Writable session and shared allocations must therefore be zero-initialized when handed out. Reused buffers are explicitly cleared before use, while newly created buffers rely on Dawn's lazy-clear guarantee.

Clearing and submission are separate policies. During `Session::Run`, the clear remains ordered in the current command encoder and is submitted with the surrounding dispatch batch. Outside `Run`, including through the shared allocator exposed to users, the clear is submitted before allocation returns so subsequent queue work observes it.

Allocator clears are allocation-time initialization rather than graph work. They are encoded in normal command order but are not stored in `CapturedCommandInfo` or repeated by `ReplayGraph()`, whose inputs and outputs are allocated in advance.

### Testing

- Incremental Release build of `onnxruntime_provider_test`
- `WebGpuContextTest.*`
- `WebGpuDispatchBatchingTests.*`
- `GraphCaptureTests.TestReleaseCapturedGraph`
- `InferenceSessionTests.TestGraphCapture`

All 16 focused tests pass.