### PR TITLE
[WebNN EP] Fix bug introduced by output rank validation

### DIFF
--- a/onnxruntime/core/providers/webnn/builders/impl/conv_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/conv_op_builder.cc
@@ -335,8 +335,24 @@ bool ConvOpBuilder::HasSupportedOutputsImpl(const Node& node, const emscripten::
     return IsDataTypeSupportedByOp("Cast", output_type, wnn_limits, "output", "Output", logger);
   }
 
-  return IsDataTypeSupportedByOp(op_type, output_type, wnn_limits, "output", "Output", logger) &&
-         IsOutputRankSupportedByOp(node, wnn_limits, logger);
+  if (!IsDataTypeSupportedByOp(op_type, output_type, wnn_limits, "output", "Output", logger)) {
+    return false;
+  }
+
+  // WebNN conv2d/convTranspose2d only accept 4D operands. A conv1d (3D input + 3D weight) is
+  // supported by reshaping the input to 4D and the output back to 3D (see AddToModelBuilderImpl),
+  // so the ONNX output rank no longer matches the WebNN operand rank; skip the rank check for it.
+  const auto& input_defs = node.InputDefs();
+  std::vector<int64_t> input_shape, weight_shape;
+  if (!GetShape(*input_defs[0], input_shape, logger) || !GetShape(*input_defs[1], weight_shape, logger)) {
+    return false;
+  }
+  const bool is_conv1d = input_shape.size() == 3 && weight_shape.size() == 3;
+  if (is_conv1d) {
+    return true;
+  }
+
+  return IsOutputRankSupportedByOp(node, wnn_limits, logger);
 }
 
 void CreateConvOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations) {

--- a/onnxruntime/core/providers/webnn/builders/impl/gather_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/gather_op_builder.cc
@@ -22,6 +22,8 @@ class GatherOpBuilder : public BaseOpBuilder {
   // Operator support related.
   bool HasSupportedInputsImpl(const GraphViewer&, const Node& node,
                               const emscripten::val& wnn_limits, const logging::Logger& logger) const override;
+  bool HasSupportedOutputsImpl(const Node& node, const emscripten::val& wnn_limits,
+                               const logging::Logger& logger) const override;
 };
 
 // Add operator related.
@@ -62,6 +64,33 @@ bool GatherOpBuilder::HasSupportedInputsImpl(const GraphViewer&, const Node& nod
   return IsDataTypeSupportedByOp(op_type, input_type, wnn_limits, "input", "data", logger) &&
          IsDataTypeSupportedByOp(op_type, indices_type, wnn_limits, "indices", "indices", logger) &&
          IsInputRankSupportedByOp(node, wnn_limits, logger);
+}
+
+bool GatherOpBuilder::HasSupportedOutputsImpl(const Node& node, const emscripten::val& wnn_limits,
+                                              const logging::Logger& logger) const {
+  const auto& output = *node.OutputDefs()[0];
+  const std::string_view op_type = node.OpType();
+  int32_t output_type;
+  if (!GetType(output, output_type, logger)) {
+    return false;
+  }
+  if (!IsDataTypeSupportedByOp(op_type, output_type, wnn_limits, "output", "Output", logger)) {
+    return false;
+  }
+
+  std::vector<int64_t> output_shape;
+  if (!GetShape(output, output_shape, logger)) {
+    return false;
+  }
+
+  // WebNN gather allows 0-D indices, so a 1-D input with a scalar index yields a valid 0-D output.
+  // The gather output rankRange is currently reported with min=1 (a WebNN impl+spec bug), which would
+  // wrongly reject this. Skip the rank check for 0-D output; rank >= 1 still checks the max.
+  // TODO: remove once WebNN gather output rankRange.min is corrected to 0.
+  if (output_shape.empty()) {
+    return true;
+  }
+  return IsOutputRankSupportedByOp(node, wnn_limits, logger);
 }
 
 void CreateGatherOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations) {

--- a/onnxruntime/core/providers/webnn/builders/impl/gemm_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/gemm_op_builder.cc
@@ -343,8 +343,27 @@ bool GemmOpBuilder::HasSupportedOutputsImpl(const Node& node, const emscripten::
     return IsDataTypeSupportedByOp("Cast", output_type, wnn_limits, "output", "Output", logger);
   }
 
-  return IsDataTypeSupportedByOp(op_type, output_type, wnn_limits, "output", "Output", logger) &&
-         IsOutputRankSupportedByOp(node, wnn_limits, logger);
+  if (!IsDataTypeSupportedByOp(op_type, output_type, wnn_limits, "output", "Output", logger)) {
+    return false;
+  }
+
+  // WebNN matmul only accepts >= 2D operands. MatMul with a 1-D input A or B is supported by
+  // promoting it to 2D and reshaping the output back (see AddToModelBuilderImpl), so the ONNX
+  // output rank no longer matches the WebNN operand rank; skip the rank check for that case.
+  // (This also covers MatMul([K], [K]) -> 0-D scalar output. Gemm is always 2D.)
+  if (op_type == "MatMul") {
+    const auto& input_defs = node.InputDefs();
+    std::vector<int64_t> a_shape, b_shape;
+    if (!GetShape(*input_defs[0], a_shape, logger) || !GetShape(*input_defs[1], b_shape, logger)) {
+      return false;
+    }
+    const bool is_input_1d = a_shape.size() == 1 || b_shape.size() == 1;
+    if (is_input_1d) {
+      return true;
+    }
+  }
+
+  return IsOutputRankSupportedByOp(node, wnn_limits, logger);
 }
 
 void CreateGemmOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations) {

--- a/onnxruntime/core/providers/webnn/builders/impl/normalization_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/normalization_op_builder.cc
@@ -298,7 +298,16 @@ bool NormalizationOpBuilder::HasSupportedInputsImpl(const GraphViewer&, const No
   } else {
     bool is_data_type_supported = IsDataTypeSupportedByOp(op_type, input_types[0], wnn_limits, "input", "X", logger);
     if (op_type == "InstanceNormalization") {
-      // Skip input rank check for InstanceNormalization, as we will reshape the input to 4D if necessary.
+      // WebNN instanceNormalization only accepts 4D input. When the input is not 4D, we reshape it to
+      // 4D (see AddToModelBuilderImpl), so the ONNX input rank no longer matches the WebNN operand rank
+      // and the rank check must be skipped. Only validate the rank for the 4D direct path.
+      std::vector<int64_t> input_shape;
+      if (!GetShape(*input_defs[0], input_shape, logger)) {
+        return false;
+      }
+      if (input_shape.size() == 4) {
+        return is_data_type_supported && IsInputRankSupportedByOp(node, wnn_limits, logger);
+      }
       return is_data_type_supported;
     }
 
@@ -328,8 +337,22 @@ bool NormalizationOpBuilder::HasSupportedOutputsImpl(const Node& node,
     }
     return true;
   } else {
-    return IsDataTypeSupportedByOp(op_type, output_type, wnn_limits, "output", "Output", logger) &&
-           IsOutputRankSupportedByOp(node, wnn_limits, logger);
+    if (!IsDataTypeSupportedByOp(op_type, output_type, wnn_limits, "output", "Output", logger)) {
+      return false;
+    }
+    if (op_type == "InstanceNormalization") {
+      // WebNN instanceNormalization only produces 4D output. When the input is not 4D, we reshape the
+      // output back to the original rank (see AddToModelBuilderImpl), so the ONNX output rank no longer
+      // matches the WebNN operand rank and the rank check must be skipped. Only validate the 4D path.
+      std::vector<int64_t> output_shape;
+      if (!GetShape(*output_defs[0], output_shape, logger)) {
+        return false;
+      }
+      if (output_shape.size() != 4) {
+        return true;
+      }
+    }
+    return IsOutputRankSupportedByOp(node, wnn_limits, logger);
   }
 }
 


### PR DESCRIPTION
The output rank validation added in #31708 wrongly falls back ops whose ONNX output rank differs from the WebNN operand rank:

- InstanceNormalization, Conv (conv1d) and MatMul (1-D input) reshape the input to a WebNN-valid rank and reshape the output back. Skip the output rank check exactly when that workaround fires, mirroring the existing input-side skips. Also make the InstanceNormalization input-side check symmetric (only validate the 4D direct path).
- Gather with 0-D indices yields a valid 0-D output, but the WebNN gather output rankRange is reported with min=1; permit 0-D output.