### PR TITLE
[Build] Update cuda plugin package test pipeline

### DIFF
--- a/tools/ci_build/github/azure-pipelines/plugin-cuda12-test-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/plugin-cuda12-test-pipeline.yml
@@ -1,0 +1,86 @@
+# This pipeline runs tests against artifacts produced by the CUDA 12.8
+# plugin packaging pipeline. It is resource-triggered on successful
+# packaging runs and can also be queued manually against any prior
+# CUDA 12.8 packaging run.
+#
+# Split from the packaging pipeline so the test side can be iterated
+# on without rebuilding the CUDA plugin from source.
+
+trigger: none
+
+variables:
+- name: DisableDockerDetector
+  value: true
+- name: skipNugetSecurityAnalysis
+  value: true
+- name: Codeql.SkipTaskAutoInjection
+  value: true
+# Verbose-output flag for tests. Resolves to System.Debug when set
+# (e.g. queue-time "Enable system diagnostics"), else 'false'.
+- name: OrtTestVerbose
+  value: $[ coalesce(variables['System.Debug'], 'false') ]
+
+resources:
+  pipelines:
+  - pipeline: build
+    source: 'Plugin\CUDA 12.8 Plugin EP Packaging Pipeline'
+    trigger: true
+  repositories:
+  - repository: 1esPipelines
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+
+parameters:
+- name: test_windows_x64
+  displayName: 'Test Windows x64'
+  type: boolean
+  default: true
+
+- name: test_linux_x64
+  displayName: 'Test Linux x64'
+  type: boolean
+  default: true
+
+extends:
+  # The pipeline extends the 1ES PT which will inject SDL and compliance
+  # tasks. Uses "Official" to stay consistent with the companion
+  # CUDA plugin packaging pipeline.
+  template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
+  parameters:
+    settings:
+      networkIsolationPolicy: Permissive,AzureContainerRegistry
+    sdl:
+      # No top-level `pool:` is declared for this pipeline (each stage
+      # template pins its own pool), so source analysis needs an
+      # explicit pool.
+      sourceAnalysisPool:
+        name: onnxruntime-Win-CPU-VS2022-Latest
+        os: windows
+      componentgovernance:
+        ignoreDirectories: '$(Build.Repository.LocalPath)/cmake/external/emsdk/upstream/emscripten/tests,$(Build.Repository.LocalPath)/cmake/external/onnx/third_party/benchmark,$(Build.Repository.LocalPath)/cmake/external/onnx/third_party/pybind11,$(Build.Repository.LocalPath)/cmake/external/onnx/third_party/pybind11/tests,$(Build.Repository.LocalPath)/cmake/external/onnxruntime-extensions,$(Build.Repository.LocalPath)/js/react_native/e2e/node_modules,$(Build.Repository.LocalPath)/js/node_modules,$(Build.Repository.LocalPath)/onnxruntime-inference-examples,$(Build.SourcesDirectory)/cmake/external/emsdk/upstream/emscripten/tests,$(Build.SourcesDirectory)/cmake/external/onnx/third_party/benchmark,$(Build.SourcesDirectory)/cmake/external/onnx/third_party/pybind11,$(Build.SourcesDirectory)/cmake/external/onnx/third_party/pybind11/tests,$(Build.SourcesDirectory)/cmake/external/onnxruntime-extensions,$(Build.SourcesDirectory)/js/react_native/e2e/node_modules,$(Build.SourcesDirectory)/js/node_modules,$(Build.SourcesDirectory)/onnxruntime-inference-examples,$(Build.BinariesDirectory)'
+        alertWarningLevel: High
+        failOnAlert: false
+        verbosity: Normal
+        timeout: 3600
+      tsa:
+        enabled: true
+      # codeSignValidation is intentionally omitted: this pipeline does
+      # not produce or publish binaries. The wheels it consumes were
+      # already signed-and-validated by the packaging pipeline.
+      policheck:
+        enabled: true
+        exclusionsFile: '$(Build.SourcesDirectory)\tools\ci_build\policheck_exclusions.xml'
+      codeql:
+        compiled:
+          enabled: false
+          justificationForDisabling: 'CodeQL is taking nearly 6 hours resulting in timeouts in our production pipelines'
+
+    stages:
+      # Windows x64
+      - ${{ if eq(parameters.test_windows_x64, true) }}:
+        - template: stages/plugin-win-cuda-test-stage.yml
+
+      # Linux x64
+      - ${{ if eq(parameters.test_linux_x64, true) }}:
+        - template: stages/plugin-linux-cuda-test-stage.yml

--- a/tools/ci_build/github/azure-pipelines/plugin-cuda13-test-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/plugin-cuda13-test-pipeline.yml
@@ -1,7 +1,7 @@
-# This pipeline runs tests against artifacts produced by the CUDA
+# This pipeline runs tests against artifacts produced by the CUDA 13.x
 # plugin packaging pipeline. It is resource-triggered on successful
 # packaging runs and can also be queued manually against any prior
-# packaging run.
+# CUDA 13.x packaging run.
 #
 # Split from the packaging pipeline so the test side can be iterated
 # on without rebuilding the CUDA plugin from source.
@@ -23,7 +23,7 @@ variables:
 resources:
   pipelines:
   - pipeline: build
-    source: 'CUDA Plugin EP Packaging Pipeline'
+    source: 'Plugin\CUDA 13.x Plugin EP Packaging Pipeline'
     trigger: true
   repositories:
   - repository: 1esPipelines


### PR DESCRIPTION
Previous, the packaging pipeline was split into two (cuda 12.8 and cuda 13.x). This PR updates the test pipelines and split in the same way. Major change is to update the source pipeline name.
