### PR TITLE
Fix/pool negative pad validation

### DIFF
--- a/onnxruntime/core/mlas/lib/pooling.cpp
+++ b/onnxruntime/core/mlas/lib/pooling.cpp
@@ -1199,6 +1199,11 @@ Return Value:
     }
 
     for (size_t dim = 0; dim < Dimensions; dim++) {
+        if (Padding != nullptr &&
+            (Padding[dim] < 0 || Padding[dim + Dimensions] < 0)) {
+            MLAS_THROW_EX(std::invalid_argument, "padding values must be non-negative");
+        }
+
         WorkBlock.InputShape[dim] = size_t(InputShape[dim]);
         WorkBlock.OutputShape[dim] = size_t(OutputShape[dim]);
 

--- a/onnxruntime/core/providers/cpu/nn/pool_attributes.h
+++ b/onnxruntime/core/providers/cpu/nn/pool_attributes.h
@@ -83,7 +83,7 @@ struct PoolAttributes {
     for (size_t dim = 0; dim < kernel_shape.size(); ++dim) {
       ORT_ENFORCE(kernel_shape[dim] > 0);
       ORT_ENFORCE(auto_pad != AutoPadType::NOTSET ||
-              (pads[dim] >= 0 && pads[dim + kernel_shape.size()] >= 0),
+                      (pads[dim] >= 0 && pads[dim + kernel_shape.size()] >= 0),
                   "Pad values must be non-negative.");
       ORT_ENFORCE(pads[dim] < kernel_shape[dim] && pads[dim + kernel_shape.size()] < kernel_shape[dim],
                   "Pad should be smaller than kernel.");

--- a/onnxruntime/core/providers/cpu/nn/pool_attributes.h
+++ b/onnxruntime/core/providers/cpu/nn/pool_attributes.h
@@ -82,6 +82,9 @@ struct PoolAttributes {
 
     for (size_t dim = 0; dim < kernel_shape.size(); ++dim) {
       ORT_ENFORCE(kernel_shape[dim] > 0);
+      ORT_ENFORCE(auto_pad != AutoPadType::NOTSET ||
+              (pads[dim] >= 0 && pads[dim + kernel_shape.size()] >= 0),
+                  "Pad values must be non-negative.");
       ORT_ENFORCE(pads[dim] < kernel_shape[dim] && pads[dim + kernel_shape.size()] < kernel_shape[dim],
                   "Pad should be smaller than kernel.");
     }

--- a/onnxruntime/test/providers/cpu/nn/pool_op_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/pool_op_test.cc
@@ -2519,6 +2519,38 @@ TEST(PoolTest, MaxPoolDimWithZeroForN) {
 // Graph::Resolve() and reach kernel construction where our ORT_ENFORCE checks fire.
 // Exclude compiling EPs (TRT, QNN) and EPs with their own validation (DML) that produce
 // different error messages.
+TEST(PoolTest, MaxPool_NegativePad) {
+  OpTester test("MaxPool");
+  test.AddShapeToTensorData(false);
+
+  test.AddAttribute("auto_pad", "");
+  test.AddAttribute("strides", std::vector<int64_t>{1, 1});
+  test.AddAttribute("pads", std::vector<int64_t>{0, 0, 0, -1});
+  test.AddAttribute("kernel_shape", std::vector<int64_t>{1, 3});
+
+  test.AddInput<float>("X", {1, 1, 1, 4}, {1.0f, 2.0f, 3.0f, 4.0f});
+  test.AddOutput<float>("Y", {0}, {});
+
+  test.Run(OpTester::ExpectResult::kExpectFailure, "Pad values must be non-negative",
+           {kTensorrtExecutionProvider, kQnnExecutionProvider, kDmlExecutionProvider});
+}
+
+#ifndef ORT_NO_EXCEPTIONS
+TEST(PoolTest, MlasPool_NegativePad) {
+  const int64_t input_shape[] = {1, 1, 1, 4};
+  const int64_t kernel_shape[] = {1, 3};
+  const int64_t pads[] = {0, 0, 0, -1};
+  const int64_t strides[] = {1, 1};
+  const int64_t output_shape[] = {1, 1, 1, 1};
+  const float input[] = {1.0f, 2.0f, 3.0f, 4.0f};
+  float output[1];
+
+  EXPECT_THROW(MlasPool(MlasMaximumPooling, 2, input_shape, kernel_shape, pads, strides,
+                        output_shape, input, output, nullptr),
+               std::invalid_argument);
+}
+#endif
+
 TEST(PoolTest, MaxPool_ZeroStride) {
   OpTester test("MaxPool");
   test.AddShapeToTensorData(false);


### PR DESCRIPTION
This pull request strengthens validation for padding values in pooling operations to ensure they are non-negative, preventing invalid configurations and potential runtime errors. It also adds unit tests to verify that negative padding values are correctly rejected, both at the ONNX operator level and in the underlying MLAS pooling implementation.

Validation improvements:

* Added explicit checks in `pool_attributes.h` to enforce that all padding values (`pads`) are non-negative when `auto_pad` is not set, raising an error if this condition is violated.
* Updated `pooling.cpp` to throw a `std::invalid_argument` exception if any padding value is negative, providing an additional safeguard at the MLAS pooling layer.

Testing enhancements:

* Added new unit tests in `pool_op_test.cc` to verify that negative padding values cause the expected errors, both for the ONNX MaxPool operator and for the MLAS pooling backend.