### PR TITLE
Validate generation subgraph shapes

### DIFF
--- a/onnxruntime/contrib_ops/cpu/transformers/subgraph_base.cc
+++ b/onnxruntime/contrib_ops/cpu/transformers/subgraph_base.cc
@@ -62,6 +62,8 @@ Status Subgraph::Setup(const SessionState& session_state,
   session_state_ = &session_state;
   subgraph_session_state_ = &subgraph_session_state;
 
+  ORT_RETURN_IF(subgraph_output_names.empty(), "subgraph must have at least one output");
+
   InlinedVector<std::string_view> feed_names;
   feed_names.reserve(static_cast<size_t>(num_subgraph_inputs) + static_cast<size_t>(num_implicit_inputs));
 
@@ -140,6 +142,9 @@ const IExecutionProvider* Subgraph::GetProvider() const {
 Status Subgraph::GetParameters(const ONNX_NAMESPACE::TensorShapeProto* past_shape,
                                const ONNX_NAMESPACE::TensorShapeProto* logits_shape,
                                bool merged_past) {
+  ORT_RETURN_IF(past_shape == nullptr,
+                "subgraph past state shape cannot be nullptr");
+
   if (merged_past) {
     // Merged past state shape is like (2, batch_size, num_heads, past_seq_len, hidden_size/num_heads)
     ORT_RETURN_IF(past_shape->dim_size() != 5,

--- a/onnxruntime/contrib_ops/cpu/transformers/subgraph_gpt.cc
+++ b/onnxruntime/contrib_ops/cpu/transformers/subgraph_gpt.cc
@@ -166,6 +166,8 @@ Status GptSubgraph::Validate(const std::vector<const NodeArg*>& subgraph_inputs,
 
   // Logits shape is like (batch_size, seq_len, 50257). Here 50257 is the vocabulary size.
   const ONNX_NAMESPACE::TensorShapeProto* logits_shape = subgraph_outputs[0]->Shape();
+  ORT_RETURN_IF(logits_shape == nullptr,
+                "subgraph logits output shape cannot be nullptr");
   ORT_RETURN_IF(logits_shape->dim_size() != 3,
                 "subgraph logits output is expected to have 3 dimension, got ", logits_shape->dim_size());
 

--- a/onnxruntime/contrib_ops/cpu/transformers/subgraph_t5_decoder.cc
+++ b/onnxruntime/contrib_ops/cpu/transformers/subgraph_t5_decoder.cc
@@ -51,7 +51,10 @@ namespace transformers {
 
 Status T5DecoderSubgraph::Validate(const std::vector<const NodeArg*>& subgraph_inputs,
                                    const std::vector<const NodeArg*>& subgraph_outputs) {
+  ORT_RETURN_IF(num_subgraph_inputs < 3, "decoder subgraph expects at least 3 inputs, got: ", num_subgraph_inputs);
   bool has_encoder_input_ids = subgraph_inputs[1]->Name() == "encoder_input_ids";
+  ORT_RETURN_IF(has_encoder_input_ids && num_subgraph_inputs < 4,
+                "decoder subgraph with encoder_input_ids expects at least 4 inputs, got: ", num_subgraph_inputs);
   bool has_hidden_state = subgraph_inputs[2 + has_encoder_input_ids]->Name() == "encoder_hidden_states";
   SetPastInputIndex(has_hidden_state, has_encoder_input_ids);
 
@@ -94,6 +97,7 @@ Status T5DecoderSubgraph::Validate(const std::vector<const NodeArg*>& subgraph_i
 
   const ONNX_NAMESPACE::TensorShapeProto* logits_shape = subgraph_outputs[0]->Shape();
   const ONNX_NAMESPACE::TensorShapeProto* past_shape = subgraph_outputs[first_present_output_index_]->Shape();
+  ORT_RETURN_IF(logits_shape == nullptr, "decoder subgraph logits output shape cannot be nullptr");
 
   // Save parameters related to the subgraph.
   ORT_RETURN_IF_ERROR(GetParameters(past_shape, logits_shape, false));
@@ -102,6 +106,8 @@ Status T5DecoderSubgraph::Validate(const std::vector<const NodeArg*>& subgraph_i
   // If input_ids's shape is ['batch_size', 1] then use next token as input_ids.
   // Otherwise in the case of shape ['batch_size', 'sequence'], use sequence as input_ids.
   const ONNX_NAMESPACE::TensorShapeProto* input_ids_shape = subgraph_inputs[0]->Shape();
+  ORT_RETURN_IF(input_ids_shape == nullptr || input_ids_shape->dim_size() != 2,
+                "decoder subgraph input_ids is expected to have 2 dimensions");
   if (input_ids_shape->dim(1).has_dim_value() && input_ids_shape->dim(1).dim_value() == 1) {
     use_sequence_as_input_ids_ = false;
   }

--- a/onnxruntime/contrib_ops/cpu/transformers/subgraph_t5_encoder.cc
+++ b/onnxruntime/contrib_ops/cpu/transformers/subgraph_t5_encoder.cc
@@ -102,6 +102,7 @@ Status T5EncoderSubgraph::Validate(const std::vector<const NodeArg*>& subgraph_i
     // Deduce num_heads, head_size and vocab_size from shape of graph outputs
     const ONNX_NAMESPACE::TensorShapeProto* past_shape = subgraph_outputs[2]->Shape();
     const ONNX_NAMESPACE::TensorShapeProto* logits_shape = subgraph_outputs[0]->Shape();
+    ORT_RETURN_IF(logits_shape == nullptr, "encoder subgraph logits output shape cannot be nullptr");
     ORT_RETURN_IF_ERROR(GetParameters(past_shape, logits_shape, false));
 
     num_layers = (num_subgraph_outputs - first_present_output_index_) / 4;

--- a/onnxruntime/contrib_ops/cpu/transformers/subgraph_whisper_decoder.cc
+++ b/onnxruntime/contrib_ops/cpu/transformers/subgraph_whisper_decoder.cc
@@ -49,6 +49,7 @@ namespace transformers {
 
 Status WhisperDecoderSubgraph::Validate(const std::vector<const NodeArg*>& subgraph_inputs,
                                         const std::vector<const NodeArg*>& subgraph_outputs) {
+  ORT_RETURN_IF(num_subgraph_inputs < 2, "decoder subgraph expects at least 2 inputs, got: ", num_subgraph_inputs);
   bool has_hidden_state = subgraph_inputs[1]->Name() == "encoder_hidden_states" ? true : false;
   SetPastInputIndex(has_hidden_state);
 
@@ -94,6 +95,7 @@ Status WhisperDecoderSubgraph::Validate(const std::vector<const NodeArg*>& subgr
 
   const ONNX_NAMESPACE::TensorShapeProto* logits_shape = subgraph_outputs[0]->Shape();
   const ONNX_NAMESPACE::TensorShapeProto* past_shape = subgraph_outputs[first_present_output_index_]->Shape();
+  ORT_RETURN_IF(logits_shape == nullptr, "decoder subgraph logits output shape cannot be nullptr");
 
   // Save parameters related to the subgraph.
   ORT_RETURN_IF_ERROR(GetParameters(past_shape, logits_shape, false));
@@ -103,6 +105,8 @@ Status WhisperDecoderSubgraph::Validate(const std::vector<const NodeArg*>& subgr
   // If input_ids's shape is ['batch_size', 1] then use next token as input_ids.
   // Otherwise in the case of shape ['batch_size', 'sequence'], use sequence as input_ids.
   const ONNX_NAMESPACE::TensorShapeProto* input_ids_shape = subgraph_inputs[0]->Shape();
+  ORT_RETURN_IF(input_ids_shape == nullptr || input_ids_shape->dim_size() != 2,
+                "decoder subgraph input_ids is expected to have 2 dimensions");
   if (input_ids_shape->dim(1).has_dim_value() && input_ids_shape->dim(1).dim_value() == 1) {
     use_sequence_as_input_ids_ = false;
   }

--- a/onnxruntime/contrib_ops/cpu/transformers/subgraph_whisper_encoder.cc
+++ b/onnxruntime/contrib_ops/cpu/transformers/subgraph_whisper_encoder.cc
@@ -49,7 +49,7 @@ Status WhisperEncoderSubgraph::Validate(const std::vector<const NodeArg*>& subgr
   ORT_RETURN_IF(subgraph_inputs[0]->Name() != "encoder_input_ids",
                 "encoder subgraph input 0 shall be named as encoder_input_ids, got: ", subgraph_inputs[0]->Name());
   ORT_RETURN_IF(subgraph_inputs[1]->Name() != "decoder_input_ids",
-                "encoder subgraph input 2 shall be named as decoder_input_ids, got: ", subgraph_inputs[2]->Name());
+                "encoder subgraph input 1 shall be named as decoder_input_ids, got: ", subgraph_inputs[1]->Name());
 
   ORT_RETURN_IF(subgraph_outputs[0]->Name() != "logits",
                 "encoder subgraph output 0 shall be named as logits, got: ", subgraph_outputs[0]->Name());
@@ -62,6 +62,7 @@ Status WhisperEncoderSubgraph::Validate(const std::vector<const NodeArg*>& subgr
 
   const ONNX_NAMESPACE::TensorShapeProto* past_shape = subgraph_outputs[2]->Shape();
   const ONNX_NAMESPACE::TensorShapeProto* logits_shape = subgraph_outputs[0]->Shape();
+  ORT_RETURN_IF(logits_shape == nullptr, "encoder subgraph logits output shape cannot be nullptr");
 
   // Save parameters related to the subgraph.
   ORT_RETURN_IF_ERROR(GetParameters(past_shape, logits_shape, false));

--- a/onnxruntime/test/contrib_ops/beam_search_test.cc
+++ b/onnxruntime/test/contrib_ops/beam_search_test.cc
@@ -3,8 +3,10 @@
 
 #include <memory>
 #include <vector>
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include <gsl/gsl>
+#include "core/graph/model.h"
 #include "core/session/onnxruntime_cxx_api.h"
 #include "test/common/cuda_op_test_utils.h"
 #include "test/util/include/current_test_name.h"
@@ -13,6 +15,7 @@
 #include "contrib_ops/cpu/transformers/generation_device_helper.h"
 #include "contrib_ops/cpu/transformers/generation_shared.h"
 #include "contrib_ops/cpu/transformers/beam_search_parameters.h"
+#include "contrib_ops/cpu/transformers/subgraph_gpt.h"
 
 #ifdef USE_CUDA
 #include "core/providers/cuda/cuda_provider_options.h"
@@ -100,6 +103,74 @@ TEST(BeamSearchTest, ExpandBufferSupportsRankGreaterThanFour) {
       nullptr, input, 2, allocator, expanded, true, 0));
 
   EXPECT_EQ(expanded.Get<Tensor>().Shape(), TensorShape({2, 2, 3, 4, 5}));
+}
+
+namespace {
+
+class TestSubgraph final : public contrib::transformers::Subgraph {
+ public:
+  TestSubgraph(const Node& node, const GraphViewer& subgraph)
+      : Subgraph(node, "decoder", subgraph) {}
+
+  using Subgraph::GetParameters;
+
+  Status Validate(const std::vector<const NodeArg*>&,
+                  const std::vector<const NodeArg*>&) override {
+    return Status::OK();
+  }
+};
+
+void LoadGptBeamSearchGraph(std::shared_ptr<Model>& model,
+                            const Node*& beam_search_node,
+                            const Graph*& decoder_graph) {
+  ASSERT_STATUS_OK(Model::Load(ORT_TSTR("testdata/transformers/tiny_gpt2_beamsearch.onnx"),
+                               model, nullptr, DefaultLoggingManager().DefaultLogger()));
+
+  beam_search_node = nullptr;
+  for (const Node& node : model->MainGraph().Nodes()) {
+    if (node.OpType() == "BeamSearch") {
+      beam_search_node = &node;
+      break;
+    }
+  }
+
+  ASSERT_NE(beam_search_node, nullptr);
+  decoder_graph = beam_search_node->GetGraphAttribute("decoder");
+  ASSERT_NE(decoder_graph, nullptr);
+}
+
+}  // namespace
+
+TEST(BeamSearchTest, GptSubgraphRejectsMissingLogitsShape) {
+  std::shared_ptr<Model> model;
+  const Node* beam_search_node = nullptr;
+  const Graph* decoder_graph = nullptr;
+  ASSERT_NO_FATAL_FAILURE(LoadGptBeamSearchGraph(model, beam_search_node, decoder_graph));
+
+  GraphViewer decoder_viewer(*decoder_graph);
+  contrib::transformers::GptSubgraph gpt_subgraph(*beam_search_node, "decoder", decoder_viewer);
+  auto outputs = decoder_viewer.GetOutputs();
+
+  auto* logits_type = const_cast<ONNX_NAMESPACE::TypeProto*>(outputs[0]->TypeAsProto());
+  ASSERT_NE(logits_type, nullptr);
+  logits_type->mutable_tensor_type()->clear_shape();
+
+  const Status status = gpt_subgraph.Validate(decoder_viewer.GetInputs(), outputs);
+  EXPECT_FALSE(status.IsOK());
+  EXPECT_THAT(status.ErrorMessage(), testing::HasSubstr("logits output shape cannot be nullptr"));
+}
+
+TEST(BeamSearchTest, SubgraphParametersRejectMissingPastShape) {
+  std::shared_ptr<Model> model;
+  const Node* beam_search_node = nullptr;
+  const Graph* decoder_graph = nullptr;
+  ASSERT_NO_FATAL_FAILURE(LoadGptBeamSearchGraph(model, beam_search_node, decoder_graph));
+
+  GraphViewer decoder_viewer(*decoder_graph);
+  TestSubgraph subgraph(*beam_search_node, decoder_viewer);
+  const Status status = subgraph.GetParameters(nullptr, decoder_viewer.GetOutputs()[0]->Shape(), true);
+  EXPECT_FALSE(status.IsOK());
+  EXPECT_THAT(status.ErrorMessage(), testing::HasSubstr("past state shape cannot be nullptr"));
 }
 
 void RunGptBeamSearchFp32() {


### PR DESCRIPTION
This pull request strengthens input validation and error handling for subgraph classes in the ONNX Runtime transformers codebase. It introduces additional checks for required input/output shapes and dimensions, ensuring that missing or malformed shapes are detected early with clear error messages. The changes also add corresponding unit tests to verify the new validation logic.

**Validation and Error Handling Improvements:**

* Added checks to ensure subgraph output names are not empty in `subgraph_base.cc`, and that required tensor shapes (such as logits and past state shapes) are not null before proceeding with parameter extraction or validation. This applies to GPT, T5, and Whisper subgraph classes (`subgraph_base.cc`, `subgraph_gpt.cc`, `subgraph_t5_decoder.cc`, `subgraph_t5_encoder.cc`, `subgraph_whisper_decoder.cc`, `subgraph_whisper_encoder.cc`). [[1]](diffhunk://#diff-36f9a180d24088d6336e1f42bbec6d0fe37210f4953c167f9a34ae1e9882a8d7R65-R66) [[2]](diffhunk://#diff-36f9a180d24088d6336e1f42bbec6d0fe37210f4953c167f9a34ae1e9882a8d7R145-R147) [[3]](diffhunk://#diff-1c3c36abe873809b84c5b9b0c4620cdd9acbac51c55cee11b2925440fd62f8b3R169-R170) [[4]](diffhunk://#diff-97b23192a59f74e96db55e7eef910270f2987285fa4b734285e69e9467569c28R54-R57) [[5]](diffhunk://#diff-97b23192a59f74e96db55e7eef910270f2987285fa4b734285e69e9467569c28R100) [[6]](diffhunk://#diff-97b23192a59f74e96db55e7eef910270f2987285fa4b734285e69e9467569c28R109-R110) [[7]](diffhunk://#diff-bb4a85473116e8ebd8b731818e28cc2bf969f5ca52f7090633c181b104e2f769R105) [[8]](diffhunk://#diff-6161e160fc3b48fb67829162a627991d3d2b9acb662d685123ab56f84d334b00R52) [[9]](diffhunk://#diff-6161e160fc3b48fb67829162a627991d3d2b9acb662d685123ab56f84d334b00R98) [[10]](diffhunk://#diff-6161e160fc3b48fb67829162a627991d3d2b9acb662d685123ab56f84d334b00R108-R109) [[11]](diffhunk://#diff-1c7fc3b879a5909572c7a602415544b6b8a37c15efdec3b1b417bdb3dc47a491L52-R52) [[12]](diffhunk://#diff-1c7fc3b879a5909572c7a602415544b6b8a37c15efdec3b1b417bdb3dc47a491R65)

* Improved validation of input dimensions, such as ensuring decoder subgraph input tensors have the expected number of dimensions for T5 and Whisper models (`subgraph_t5_decoder.cc`, `subgraph_whisper_decoder.cc`). [[1]](diffhunk://#diff-97b23192a59f74e96db55e7eef910270f2987285fa4b734285e69e9467569c28R109-R110) [[2]](diffhunk://#diff-6161e160fc3b48fb67829162a627991d3d2b9acb662d685123ab56f84d334b00R108-R109)

**Unit Testing:**

* Added new unit tests in `beam_search_test.cc` to verify that missing logits or past state shapes are correctly rejected, and that error messages are descriptive. This includes helper code to load test models and manipulate subgraph outputs for testing. [[1]](diffhunk://#diff-782b3e352d8957cd1226d1b87f2127c58efd5ba7a6472528afbdd6baa8232198R6-R9) [[2]](diffhunk://#diff-782b3e352d8957cd1226d1b87f2127c58efd5ba7a6472528afbdd6baa8232198R18) [[3]](diffhunk://#diff-782b3e352d8957cd1226d1b87f2127c58efd5ba7a6472528afbdd6baa8232198R108-R175)

**Bug Fixes:**

* Fixed an error message in `subgraph_whisper_encoder.cc` to reference the correct input index for `decoder_input_ids`.

These changes improve robustness by ensuring that subgraph classes fail early and clearly when required inputs are missing or malformed, and they are now covered by dedicated unit tests.