### PR TITLE
Enable WebGPU CI for WebGPU plugin EP release branches

### DIFF
--- a/.github/workflows/linux_webgpu.yml
+++ b/.github/workflows/linux_webgpu.yml
@@ -2,9 +2,9 @@ name: Linux WebGPU CI
 
 on:
   push:
-    branches: [main, 'rel-*']
+    branches: [main, 'rel-*', 'plugin-ep-webgpu/rel-*']
   pull_request:
-    branches: [main, 'rel-*']
+    branches: [main, 'rel-*', 'plugin-ep-webgpu/rel-*']
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -5,10 +5,12 @@ on:
     branches:
       - main
       - rel-*
+      - plugin-ep-webgpu/rel-*
   pull_request:
     branches:
       - main
       - rel-*
+      - plugin-ep-webgpu/rel-*
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -5,10 +5,12 @@ on:
     branches:
       - main
       - rel-*
+      - plugin-ep-webgpu/rel-*
   pull_request:
     branches:
       - main
       - rel-*
+      - plugin-ep-webgpu/rel-*
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/windows_webgpu.yml
+++ b/.github/workflows/windows_webgpu.yml
@@ -5,10 +5,12 @@ on:
     branches:
       - main
       - rel-*
+      - plugin-ep-webgpu/rel-*
   pull_request:
     branches:
       - main
       - rel-*
+      - plugin-ep-webgpu/rel-*
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Enable WebGPU CI for WebGPU plugin EP release branches (`plugin-ep-webgpu/rel-*`).

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Additional test coverage for release branch changes.