### PR TITLE
[CUDA] Parallelize ArgMax/ArgMin over wide last axes

### DIFF
--- a/onnxruntime/core/providers/cuda/reduction/reduction_functions.cu
+++ b/onnxruntime/core/providers/cuda/reduction/reduction_functions.cu
@@ -861,27 +861,39 @@ __global__ void arg_min_max_last_axis_cooperative_kernel(
     const TIn* const row_data = input + row_id * num_cols;
 
     // Thread-level reduction (storage change: global memory -> register).
+    // num_cols is only bounded by INT_MAX, so the scan is written with differences
+    // rather than sums: `remaining` and `delta` are both smaller than num_cols, and a
+    // position is only formed as `id + delta` after `delta < remaining` has been
+    // checked, which keeps every value inside [0, num_cols) and cannot overflow. A
+    // plain `id += step` scan would wrap to negative positions and index out of
+    // bounds for the widest admitted rows.
     TIn best_value = arg_reduction_identity<TIn, IsArgMax>();
     int best_index = ARG_REDUCTION_EMPTY_INDEX;
-    for (int id = tid_in_grid_row; id < num_cols;
-         id += MAX_NUM_ELEMENTS_PER_THREAD * num_threads_in_grid_row) {
+    const int scan_step = MAX_NUM_ELEMENTS_PER_THREAD * num_threads_in_grid_row;
+    for (int id = tid_in_grid_row; id < num_cols;) {
+      const int remaining = num_cols - id;
       TIn v[MAX_NUM_ELEMENTS_PER_THREAD];
 
 #pragma unroll
       for (int i = 0; i < MAX_NUM_ELEMENTS_PER_THREAD; i++) {
-        const int offset = id + i * num_threads_in_grid_row;
-        if (offset < num_cols) {
-          v[i] = row_data[offset];
+        const int delta = i * num_threads_in_grid_row;
+        if (delta < remaining) {
+          v[i] = row_data[id + delta];
         }
       }
 
 #pragma unroll
       for (int i = 0; i < MAX_NUM_ELEMENTS_PER_THREAD; i++) {
-        const int offset = id + i * num_threads_in_grid_row;
-        if (offset < num_cols) {
-          arg_reduction_scan<TIn, IsArgMax>(best_value, best_index, v[i], offset);
+        const int delta = i * num_threads_in_grid_row;
+        if (delta < remaining) {
+          arg_reduction_scan<TIn, IsArgMax>(best_value, best_index, v[i], id + delta);
         }
       }
+
+      if (remaining <= scan_step) {
+        break;
+      }
+      id += scan_step;
     }
 
     // Warp-level reduction (storage change: register -> register).

--- a/onnxruntime/core/providers/cuda/reduction/reduction_functions.cu
+++ b/onnxruntime/core/providers/cuda/reduction/reduction_functions.cu
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <array>
+#include <atomic>
 #include <cmath>
 #include <limits>
 #include <type_traits>
@@ -700,6 +701,113 @@ INSTANTIATE_REDUCE_SUM_ND(int64_t);
 #undef INSTANTIATE_REDUCE_SUM_ND
 
 namespace detail {
+// =============================================================================
+// ArgMax/ArgMin over the last axis.
+//
+// Two kernels share this entry point:
+//
+// 1. arg_min_max_last_axis_kernel() assigns one thread per row and scans the row
+//    serially. It is the best choice for narrow rows, where a row cannot keep a
+//    whole warp busy, but it leaves the device almost idle when there are few
+//    very long rows (the [1, vocab_size] sampling case: a single thread scans
+//    the entire row).
+//
+// 2. arg_min_max_last_axis_cooperative_kernel() spreads each row over many warps
+//    and, when a row is long enough, over many blocks. Partial (value, index)
+//    pairs are combined with warp shuffles, then shared memory, then - for
+//    multi-block rows - through a small global buffer that the last block
+//    arriving for the row reduces. This mirrors the structure already used by
+//    reduce_matrix_columns() above.
+//
+// Both kernels produce exactly the same indices for every input, including
+// duplicates, infinities and NaNs (see the identity/merge notes below).
+// =============================================================================
+
+// A row narrower than this cannot fill a warp with useful work, so the serial
+// one-thread-per-row kernel wins. Measured on H200 (sm90) with fp32: the
+// cooperative kernel matches the serial kernel around 96-128 columns and is
+// 1.5x - 900x faster above it.
+constexpr int MIN_NUM_COLS_FOR_COOPERATIVE_ARG_REDUCTION = 128;
+
+// A row this long gets a second warp per block even when there are more rows
+// than the device can process concurrently.
+constexpr int MAX_NUM_ELEMENTS_PER_WARP_HINT = 16;
+
+// Marks a partial result that has not selected any element yet. Ties are broken
+// towards the lowest index, so this must be larger than any valid index.
+constexpr int ARG_REDUCTION_EMPTY_INDEX = std::numeric_limits<int>::max();
+
+// The identity has to be a value that no input element can compare beyond,
+// otherwise a partial result holding a real element could lose against an empty
+// partial result. For floating point types that means +/-infinity rather than
+// the largest finite value: -FLT_MAX would drop a row that contains -inf.
+template <typename T>
+struct ArgReductionIdentity {
+  __device__ __forceinline__ static T Lowest() {
+    if constexpr (std::numeric_limits<T>::has_infinity) {
+      return -std::numeric_limits<T>::infinity();
+    } else {
+      return std::numeric_limits<T>::lowest();
+    }
+  }
+  __device__ __forceinline__ static T Highest() {
+    if constexpr (std::numeric_limits<T>::has_infinity) {
+      return std::numeric_limits<T>::infinity();
+    } else {
+      return std::numeric_limits<T>::max();
+    }
+  }
+};
+
+template <>
+struct ArgReductionIdentity<half> {
+  __device__ __forceinline__ static half Lowest() { return __ushort_as_half(static_cast<unsigned short>(0xFC00U)); }
+  __device__ __forceinline__ static half Highest() { return __ushort_as_half(static_cast<unsigned short>(0x7C00U)); }
+};
+
+template <typename T, bool IsArgMax>
+__device__ __forceinline__ T arg_reduction_identity() {
+  return IsArgMax ? ArgReductionIdentity<T>::Lowest() : ArgReductionIdentity<T>::Highest();
+}
+
+// Sequential update. A thread visits its elements in increasing index order, so
+// a strict comparison keeps the first occurrence of the extreme value. NaN
+// never wins because every comparison against NaN is false.
+template <typename T, bool IsArgMax>
+__device__ __forceinline__ void arg_reduction_scan(T& best_value, int& best_index, T value, int index) {
+  const bool is_better = IsArgMax ? (value > best_value) : (value < best_value);
+  if (is_better) {
+    best_value = value;
+    best_index = index;
+  }
+}
+
+// Combines two partial results that cover different index ranges, so equal
+// values have to be resolved explicitly towards the lower index.
+template <typename T, bool IsArgMax>
+__device__ __forceinline__ void arg_reduction_merge(T& best_value, int& best_index, T value, int index) {
+  const bool is_better = IsArgMax ? (value > best_value) : (value < best_value);
+  if (is_better || (value == best_value && index < best_index)) {
+    best_value = value;
+    best_index = index;
+  }
+}
+
+// The serial kernel seeds its accumulator with the first element of the row, so
+// a leading NaN poisons the whole row and the result is index 0. The
+// cooperative kernel skips NaNs (they never win a comparison) and therefore has
+// to special case a leading NaN to stay bit-exact with the serial kernel.
+template <typename T>
+__device__ __forceinline__ int64_t arg_reduction_result(T first_element, int best_index) {
+  const bool row_starts_with_nan = !(first_element == first_element);
+  if (row_starts_with_nan || best_index == ARG_REDUCTION_EMPTY_INDEX) {
+    // An empty result means every element compared equal to the identity, i.e.
+    // the whole row is +/-infinity (or NaN), for which index 0 is correct.
+    return 0;
+  }
+  return static_cast<int64_t>(best_index);
+}
+
 template <typename TIn, bool IsArgMax>
 __global__ void arg_min_max_last_axis_kernel(const TIn* input, int64_t* output, int m, int n) {
   const int row = blockIdx.x * blockDim.x + threadIdx.x;
@@ -725,21 +833,311 @@ __global__ void arg_min_max_last_axis_kernel(const TIn* input, int64_t* output, 
 
   output[row] = best_index;
 }
+
+// Each block reduces a contiguous strided slice of a row; gridDim.x blocks
+// cooperate on one row and gridDim.y blocks iterate over rows.
+template <typename TIn, bool IsArgMax>
+__global__ void arg_min_max_last_axis_cooperative_kernel(
+    const int num_rows, const int num_cols, const TIn* input, int64_t* output,
+    TIn* const block_values_buffer, int* const block_indices_buffer, int* const block_done_counts_buffer) {
+  // Dynamic shared memory holds one (value, index) pair per warp.
+  extern __shared__ unsigned char shared_memory_bytes[];
+  TIn* const shared_values = reinterpret_cast<TIn*>(shared_memory_bytes);
+  int* const shared_indices = reinterpret_cast<int*>(shared_values + MAX_NUM_WARPS_PER_BLOCK);
+  __shared__ bool is_last_block_done;
+
+  const int tid_in_block = threadIdx.y * blockDim.x + threadIdx.x;
+  const int num_threads_in_block = blockDim.x * blockDim.y;
+  const int wid_in_block = tid_in_block / GPU_WARP_SIZE;
+  const int lid_in_block = tid_in_block % GPU_WARP_SIZE;
+  const int num_warps_in_block = num_threads_in_block / GPU_WARP_SIZE;
+  const int num_blocks_in_grid_row = gridDim.x;
+  const int tid_in_grid_row = blockIdx.x * num_threads_in_block + tid_in_block;
+  const int num_threads_in_grid_row = num_blocks_in_grid_row * num_threads_in_block;
+
+  // one row per iteration
+  // row_id is int64_t to avoid int overflow in offset calculations
+  for (int64_t row_id = blockIdx.y; row_id < num_rows; row_id += gridDim.y) {
+    const TIn* const row_data = input + row_id * num_cols;
+
+    // Thread-level reduction (storage change: global memory -> register).
+    TIn best_value = arg_reduction_identity<TIn, IsArgMax>();
+    int best_index = ARG_REDUCTION_EMPTY_INDEX;
+    for (int id = tid_in_grid_row; id < num_cols;
+         id += MAX_NUM_ELEMENTS_PER_THREAD * num_threads_in_grid_row) {
+      TIn v[MAX_NUM_ELEMENTS_PER_THREAD];
+
+#pragma unroll
+      for (int i = 0; i < MAX_NUM_ELEMENTS_PER_THREAD; i++) {
+        const int offset = id + i * num_threads_in_grid_row;
+        if (offset < num_cols) {
+          v[i] = row_data[offset];
+        }
+      }
+
+#pragma unroll
+      for (int i = 0; i < MAX_NUM_ELEMENTS_PER_THREAD; i++) {
+        const int offset = id + i * num_threads_in_grid_row;
+        if (offset < num_cols) {
+          arg_reduction_scan<TIn, IsArgMax>(best_value, best_index, v[i], offset);
+        }
+      }
+    }
+
+    // Warp-level reduction (storage change: register -> register).
+#pragma unroll
+    for (int stride = GPU_WARP_SIZE / 2; stride > 0; stride /= 2) {
+      const TIn other_value = WARP_SHFL_DOWN(best_value, stride);
+      const int other_index = WARP_SHFL_DOWN(best_index, stride);
+      arg_reduction_merge<TIn, IsArgMax>(best_value, best_index, other_value, other_index);
+    }
+
+    // Block-level reduction (storage change: register -> shared memory).
+    if (num_warps_in_block > 1) {
+      if (lid_in_block == 0) {
+        shared_values[wid_in_block] = best_value;
+        shared_indices[wid_in_block] = best_index;
+      }
+      __syncthreads();
+
+      if (tid_in_block == 0) {
+        for (int w = 1; w < num_warps_in_block; ++w) {
+          arg_reduction_merge<TIn, IsArgMax>(best_value, best_index, shared_values[w], shared_indices[w]);
+        }
+      }
+    }
+
+    // Return early if only one block is used for the row.
+    if (num_blocks_in_grid_row == 1) {
+      if (tid_in_block == 0) {
+        output[row_id] = arg_reduction_result(row_data[0], best_index);
+      }
+      // Guard the shared memory of the next row iteration.
+      __syncthreads();
+      continue;
+    }
+
+    TIn* const row_block_values = block_values_buffer + row_id * num_blocks_in_grid_row;
+    int* const row_block_indices = block_indices_buffer + row_id * num_blocks_in_grid_row;
+    if (tid_in_block == 0) {
+      row_block_values[blockIdx.x] = best_value;
+      row_block_indices[blockIdx.x] = best_index;
+    }
+
+    __threadfence();
+    __syncthreads();
+
+    // Grid-level reduction. The last block arriving for this row combines the
+    // per-block results.
+    if (tid_in_block == 0) {
+      const int count = atomicAdd(block_done_counts_buffer + row_id, 1);
+      is_last_block_done = (count == (num_blocks_in_grid_row - 1));
+    }
+    __syncthreads();
+
+    if (is_last_block_done) {
+      TIn value = arg_reduction_identity<TIn, IsArgMax>();
+      int index = ARG_REDUCTION_EMPTY_INDEX;
+      for (int b = tid_in_block; b < num_blocks_in_grid_row; b += num_threads_in_block) {
+        arg_reduction_merge<TIn, IsArgMax>(value, index, row_block_values[b], row_block_indices[b]);
+      }
+
+#pragma unroll
+      for (int stride = GPU_WARP_SIZE / 2; stride > 0; stride /= 2) {
+        const TIn other_value = WARP_SHFL_DOWN(value, stride);
+        const int other_index = WARP_SHFL_DOWN(index, stride);
+        arg_reduction_merge<TIn, IsArgMax>(value, index, other_value, other_index);
+      }
+
+      if (num_warps_in_block > 1) {
+        __syncthreads();
+        if (lid_in_block == 0) {
+          shared_values[wid_in_block] = value;
+          shared_indices[wid_in_block] = index;
+        }
+        __syncthreads();
+
+        if (tid_in_block == 0) {
+          for (int w = 1; w < num_warps_in_block; ++w) {
+            arg_reduction_merge<TIn, IsArgMax>(value, index, shared_values[w], shared_indices[w]);
+          }
+        }
+      }
+
+      if (tid_in_block == 0) {
+        output[row_id] = arg_reduction_result(row_data[0], index);
+      }
+      // Guard the shared memory of the next row iteration.
+      __syncthreads();
+    }
+  }
+}
+
+// Number of threads the device can keep resident. Cached per device because it
+// is queried on every launch.
+int get_device_thread_capacity() {
+  constexpr int kMaxCachedDevices = 32;
+  // A conservative default that is used when the device cannot be queried.
+  constexpr int kDefaultThreadCapacity = 64 * 2048;
+  static std::atomic<int> cached_capacities[kMaxCachedDevices]{};
+
+  int device_id = 0;
+  if (cudaGetDevice(&device_id) != cudaSuccess || device_id < 0 || device_id >= kMaxCachedDevices) {
+    return kDefaultThreadCapacity;
+  }
+
+  int capacity = cached_capacities[device_id].load(std::memory_order_relaxed);
+  if (capacity == 0) {
+    int num_sms = 0;
+    int max_threads_per_sm = 0;
+    if (cudaDeviceGetAttribute(&num_sms, cudaDevAttrMultiProcessorCount, device_id) == cudaSuccess &&
+        cudaDeviceGetAttribute(&max_threads_per_sm, cudaDevAttrMaxThreadsPerMultiProcessor, device_id) ==
+            cudaSuccess &&
+        num_sms > 0 && max_threads_per_sm > 0) {
+      capacity = num_sms * max_threads_per_sm;
+    } else {
+      capacity = kDefaultThreadCapacity;
+    }
+    cached_capacities[device_id].store(capacity, std::memory_order_relaxed);
+  }
+  return capacity;
+}
+
+// Picks how many threads cooperate on one row. Too few threads leave the device
+// idle for wide rows; too many make every thread read a handful of elements from
+// scattered addresses and inflate the number of partial results to merge.
+std::pair<dim3, dim3> compute_arg_min_max_grid_and_block_dims(int num_rows, int num_cols) {
+  const int64_t rows = std::max(1, num_rows);
+  // Start from a single wave of threads over the whole device.
+  int64_t threads_per_row = std::max<int64_t>(1, get_device_thread_capacity() / rows);
+  // Keep at least MAX_NUM_ELEMENTS_PER_THREAD elements per thread.
+  threads_per_row = std::min<int64_t>(threads_per_row, std::max(1, num_cols / MAX_NUM_ELEMENTS_PER_THREAD));
+  // Long rows are worth a second warp even when the row count alone already
+  // fills the device.
+  threads_per_row = std::max<int64_t>(
+      threads_per_row, std::min(num_cols / MAX_NUM_ELEMENTS_PER_WARP_HINT, 2 * GPU_WARP_SIZE_HOST));
+  threads_per_row = std::max<int64_t>(threads_per_row, GPU_WARP_SIZE_HOST);
+
+  const int64_t warps_per_block =
+      std::min<int64_t>(MAX_NUM_WARPS_PER_BLOCK, std::max<int64_t>(1, threads_per_row / GPU_WARP_SIZE_HOST));
+  const int64_t blocks_per_row =
+      std::min<int64_t>(MAX_NUM_BLOCKS_IN_GRID_ROW,
+                        std::max<int64_t>(1, threads_per_row / (GPU_WARP_SIZE_HOST * warps_per_block)));
+
+  const dim3 grid_dim(static_cast<unsigned>(blocks_per_row), static_cast<unsigned>(std::min<int64_t>(MAX_NUM_GRID_ROWS, rows)));
+  const dim3 block_dim(GPU_WARP_SIZE_HOST, static_cast<unsigned>(warps_per_block));
+  return {grid_dim, block_dim};
+}
+
+/**
+ * arg_min_max_last_axis() intermediate buffer layout
+ *
+ * -----
+ * m * num_blocks_per_row * element_size bytes for the per block extreme values
+ * alignment padding bytes as needed
+ * m * num_blocks_per_row * sizeof(int) bytes for the per block indices
+ * m * sizeof(int) bytes for block done counts per row
+ * -----
+ */
+size_t compute_arg_min_max_last_axis_intermediate_buffer_size(int element_size, int num_rows, int num_cols) {
+  ORT_ENFORCE(element_size >= 0 && num_rows >= 0 && num_cols >= 0);
+
+  if (num_rows == 0 || num_cols < MIN_NUM_COLS_FOR_COOPERATIVE_ARG_REDUCTION) {
+    return 0;
+  }
+
+  const auto grid_dim = compute_arg_min_max_grid_and_block_dims(num_rows, num_cols).first;
+  if (grid_dim.x <= 1) {
+    // Single block per row: no inter-block communication is needed.
+    return 0;
+  }
+
+  const size_t num_partials = static_cast<size_t>(num_rows) * grid_dim.x;
+
+  size_t buffer_size{};
+  // at the beginning, for sizing purposes, assume we are aligned
+  buffer_size += num_partials * element_size;
+
+  buffer_size = round_up_to_aligned(buffer_size, alignof(int));
+  buffer_size += num_partials * sizeof(int);
+  buffer_size += static_cast<size_t>(num_rows) * sizeof(int);
+
+  // add padding to give us room to align
+  buffer_size += alignof(max_align_t) - 1;
+
+  return buffer_size;
+}
+
+template <typename TIn>
+Status get_arg_min_max_buffers(int num_rows, int num_cols, void* buffer, size_t buffer_size,
+                               TIn*& block_values_buffer, int*& block_indices_buffer,
+                               int*& block_done_counts_buffer) {
+  const auto grid_dim = compute_arg_min_max_grid_and_block_dims(num_rows, num_cols).first;
+  const size_t num_partials = static_cast<size_t>(num_rows) * grid_dim.x;
+
+  const uintptr_t begin_addr = reinterpret_cast<uintptr_t>(buffer);
+  const uintptr_t block_values_addr = round_up_to_aligned(begin_addr, alignof(TIn));
+  const uintptr_t block_indices_addr =
+      round_up_to_aligned(block_values_addr + num_partials * sizeof(TIn), alignof(int));
+  const uintptr_t block_done_counts_addr = block_indices_addr + num_partials * sizeof(int);
+  const uintptr_t end_addr = block_done_counts_addr + static_cast<size_t>(num_rows) * sizeof(int);
+  const size_t required_size = end_addr - begin_addr;
+
+  ORT_RETURN_IF_NOT(
+      required_size <= buffer_size,
+      "Buffer size is too small (", buffer_size, " bytes). ",
+      "At least ", required_size, " bytes are needed from the given base address (", buffer, ").");
+
+  block_values_buffer = reinterpret_cast<TIn*>(block_values_addr);
+  block_indices_buffer = reinterpret_cast<int*>(block_indices_addr);
+  block_done_counts_buffer = reinterpret_cast<int*>(block_done_counts_addr);
+
+  return Status::OK();
+}
 }  // namespace detail
 
 template <typename TIn, bool IsArgMax>
-Status arg_min_max_last_axis(cudaStream_t stream, const TIn* input, int64_t* output, int m, int n) {
-  // The kernel reads input[row_offset] unconditionally, so a non-empty reduction axis is required.
+Status arg_min_max_last_axis(cudaStream_t stream, const TIn* input, int64_t* output, int m, int n,
+                             void* buffer, size_t buffer_size) {
+  // The kernels read input[row_offset] unconditionally, so a non-empty reduction axis is required.
   if (m == 0 || n <= 0) return Status::OK();
-  constexpr int block_size = 256;
-  const int grid_size = (m + block_size - 1) / block_size;
-  detail::arg_min_max_last_axis_kernel<TIn, IsArgMax><<<grid_size, block_size, 0, stream>>>(input, output, m, n);
+
+  if (n < detail::MIN_NUM_COLS_FOR_COOPERATIVE_ARG_REDUCTION) {
+    // Narrow rows: one thread per row avoids all cross thread communication.
+    constexpr int block_size = 256;
+    const int grid_size = (m + block_size - 1) / block_size;
+    detail::arg_min_max_last_axis_kernel<TIn, IsArgMax><<<grid_size, block_size, 0, stream>>>(input, output, m, n);
+    return CUDA_CALL(cudaGetLastError());
+  }
+
+  const auto grid_and_block_dims = detail::compute_arg_min_max_grid_and_block_dims(m, n);
+  const dim3& grid_dim = grid_and_block_dims.first;
+  const dim3& block_dim = grid_and_block_dims.second;
+
+  TIn* block_values_buffer = nullptr;
+  int* block_indices_buffer = nullptr;
+  int* block_done_counts_buffer = nullptr;
+  if (grid_dim.x > 1) {
+    ORT_RETURN_IF_ERROR(detail::get_arg_min_max_buffers<TIn>(
+        m, n, buffer, buffer_size, block_values_buffer, block_indices_buffer, block_done_counts_buffer));
+    // The kernel relies on the done counts starting at zero.
+    CUDA_RETURN_IF_ERROR(cudaMemsetAsync(block_done_counts_buffer, 0, static_cast<size_t>(m) * sizeof(int), stream));
+  }
+
+  const int shared_mem_size = detail::MAX_NUM_WARPS_PER_BLOCK * (sizeof(TIn) + sizeof(int));
+  detail::arg_min_max_last_axis_cooperative_kernel<TIn, IsArgMax><<<grid_dim, block_dim, shared_mem_size, stream>>>(
+      m, n, input, output, block_values_buffer, block_indices_buffer, block_done_counts_buffer);
+
   return CUDA_CALL(cudaGetLastError());
 }
 
-#define INSTANTIATE_ARG_MIN_MAX_LAST_AXIS(T)                                                                          \
-  template Status arg_min_max_last_axis<T, true>(cudaStream_t stream, const T* input, int64_t* output, int m, int n); \
-  template Status arg_min_max_last_axis<T, false>(cudaStream_t stream, const T* input, int64_t* output, int m, int n)
+#define INSTANTIATE_ARG_MIN_MAX_LAST_AXIS(T)                                                   \
+  template Status arg_min_max_last_axis<T, true>(cudaStream_t stream, const T* input,          \
+                                                 int64_t* output, int m, int n, void* buffer,  \
+                                                 size_t buffer_size);                          \
+  template Status arg_min_max_last_axis<T, false>(cudaStream_t stream, const T* input,         \
+                                                  int64_t* output, int m, int n, void* buffer, \
+                                                  size_t buffer_size)
 INSTANTIATE_ARG_MIN_MAX_LAST_AXIS(half);
 INSTANTIATE_ARG_MIN_MAX_LAST_AXIS(float);
 INSTANTIATE_ARG_MIN_MAX_LAST_AXIS(double);

--- a/onnxruntime/core/providers/cuda/reduction/reduction_functions.h
+++ b/onnxruntime/core/providers/cuda/reduction/reduction_functions.h
@@ -12,6 +12,9 @@ namespace cuda {
 namespace detail {
 size_t compute_reduce_matrix_columns_intermediate_buffer_size(
     int element_size, int num_rows, int num_cols);
+
+size_t compute_arg_min_max_last_axis_intermediate_buffer_size(
+    int element_size, int num_rows, int num_cols);
 }  // namespace detail
 
 /**
@@ -112,9 +115,33 @@ template <typename T>
 Status reduce_sum_nd(cudaStream_t stream, const T* input, T* output,
                      gsl::span<const int64_t> dims, gsl::span<const int64_t> axes);
 
-/** Computes ArgMax/ArgMin indices over the last dimension in a row-major matrix. */
+/** Computes ArgMax/ArgMin indices over the last dimension in a row-major matrix.
+ *
+ * The reduction keeps the first occurrence of the extreme value, which matches the ONNX
+ * `select_last_index == 0` semantics (the CUDA EP falls back to CPU when it is 1).
+ *
+ * @param input The input data.
+ * @param output The output indices, one per row.
+ * @param m The number of matrix rows.
+ * @param n The number of matrix columns (the reduction length).
+ * @param buffer The intermediate buffer, may be nullptr if the required size is 0.
+ * @param buffer_size The size of the intermediate buffer in bytes.
+ */
 template <typename TIn, bool IsArgMax>
-Status arg_min_max_last_axis(cudaStream_t stream, const TIn* input, int64_t* output, int m, int n);
+Status arg_min_max_last_axis(cudaStream_t stream, const TIn* input, int64_t* output, int m, int n,
+                             void* buffer, size_t buffer_size);
+
+/**
+ * Computes the size in bytes of the intermediate buffer needed by arg_min_max_last_axis().
+ * @tparam TIn The input data type.
+ * @param m The number of matrix rows.
+ * @param n The number of matrix columns.
+ * @return The size of the intermediate buffer. Zero when no buffer is needed.
+ */
+template <typename TIn>
+size_t compute_arg_min_max_last_axis_buffer_size(int m, int n) {
+  return detail::compute_arg_min_max_last_axis_intermediate_buffer_size(sizeof(TIn), m, n);
+}
 
 /** Apply unary elementwise division. */
 template <typename T>

--- a/onnxruntime/core/providers/cuda/reduction/reduction_ops.cc
+++ b/onnxruntime/core/providers/cuda/reduction/reduction_ops.cc
@@ -484,17 +484,24 @@ Status ReduceComputeCore(const AllocatorPtr& gpu_allocator, const CudaKernel* ke
       if (axis == rank - 1) {
         const int64_t m = input_shape.SizeToDimension(axis);
         const int64_t n = input_shape[axis];
-        if (n > 0 && m <= std::numeric_limits<int>::max() && n <= std::numeric_limits<int>::max()) {
+        if (n > 0 && m <= std::numeric_limits<int>::max() && n <= std::numeric_limits<int>::max() &&
+            (cudnn_reduce_op == CUDNN_REDUCE_TENSOR_MAX || cudnn_reduce_op == CUDNN_REDUCE_TENSOR_MIN)) {
+          const int rows = gsl::narrow_cast<int>(m);
+          const int cols = gsl::narrow_cast<int>(n);
+          // Wide rows are reduced by several cooperating blocks, which needs a small
+          // buffer for the per block partial results.
+          const auto buffer_size_bytes = compute_arg_min_max_last_axis_buffer_size<CudaT>(rows, cols);
+          auto buffer = buffer_size_bytes == 0
+                            ? nullptr
+                            : AllocateScratchBuffer<void>(gpu_allocator, kernel, buffer_size_bytes, compute_stream);
           if (cudnn_reduce_op == CUDNN_REDUCE_TENSOR_MAX) {
             return arg_min_max_last_axis<CudaT, true>(stream, reinterpret_cast<const CudaT*>(input.Data<T>()),
-                                                      output.MutableData<int64_t>(), gsl::narrow_cast<int>(m),
-                                                      gsl::narrow_cast<int>(n));
+                                                      output.MutableData<int64_t>(), rows, cols,
+                                                      buffer.get(), buffer_size_bytes);
           }
-          if (cudnn_reduce_op == CUDNN_REDUCE_TENSOR_MIN) {
-            return arg_min_max_last_axis<CudaT, false>(stream, reinterpret_cast<const CudaT*>(input.Data<T>()),
-                                                       output.MutableData<int64_t>(), gsl::narrow_cast<int>(m),
-                                                       gsl::narrow_cast<int>(n));
-          }
+          return arg_min_max_last_axis<CudaT, false>(stream, reinterpret_cast<const CudaT*>(input.Data<T>()),
+                                                     output.MutableData<int64_t>(), rows, cols,
+                                                     buffer.get(), buffer_size_bytes);
         }
       }
     }

--- a/onnxruntime/test/providers/cpu/reduction/reduction_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/reduction/reduction_ops_test.cc
@@ -3618,6 +3618,71 @@ TEST(ReductionOpTest, ArgMax_float_first_index_random) {
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
 }
 
+// Rows that are wide enough to be reduced by several cooperating CUDA blocks,
+// with more than one row so the per row bookkeeping is exercised as well.
+static std::vector<float> MakeWideArgReductionInput(int64_t num_rows, int64_t num_cols,
+                                                    const std::vector<int64_t>& max_indices,
+                                                    const std::vector<int64_t>& min_indices) {
+  std::vector<float> data(static_cast<size_t>(num_rows * num_cols));
+  for (int64_t row = 0; row < num_rows; ++row) {
+    for (int64_t col = 0; col < num_cols; ++col) {
+      // Repeating ramp: plenty of duplicated values, no accidental extremes.
+      data[static_cast<size_t>(row * num_cols + col)] = static_cast<float>((col + row) % 97) * 0.5f;
+    }
+    // Duplicated extremes: the first occurrence has to win.
+    data[static_cast<size_t>(row * num_cols + max_indices[static_cast<size_t>(row)])] = 1000.0f;
+    data[static_cast<size_t>(row * num_cols + num_cols - 1)] = 1000.0f;
+    data[static_cast<size_t>(row * num_cols + min_indices[static_cast<size_t>(row)])] = -1000.0f;
+    data[static_cast<size_t>(row * num_cols + num_cols - 2)] = -1000.0f;
+  }
+  return data;
+}
+
+TEST(ReductionOpTest, ArgMax_float_wide_last_axis) {
+  constexpr int64_t num_rows = 3;
+  constexpr int64_t num_cols = 40000;
+  const std::vector<int64_t> max_indices{0, 12345, num_cols - 3};
+  const std::vector<int64_t> min_indices{7, 30000, 1};
+
+  OpTester test("ArgMax", 13);
+  test.AddAttribute("axis", static_cast<int64_t>(1));
+  test.AddAttribute("keepdims", static_cast<int64_t>(0));
+  test.AddInput<float>("data", {num_rows, num_cols},
+                       MakeWideArgReductionInput(num_rows, num_cols, max_indices, min_indices));
+  test.AddOutput<int64_t>("reduced", {num_rows}, max_indices);
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
+}
+
+TEST(ReductionOpTest, ArgMin_float_wide_last_axis) {
+  constexpr int64_t num_rows = 3;
+  constexpr int64_t num_cols = 40000;
+  const std::vector<int64_t> max_indices{0, 12345, num_cols - 3};
+  const std::vector<int64_t> min_indices{7, 30000, 1};
+
+  OpTester test("ArgMin", 13);
+  test.AddAttribute("axis", static_cast<int64_t>(1));
+  test.AddAttribute("keepdims", static_cast<int64_t>(0));
+  test.AddInput<float>("data", {num_rows, num_cols},
+                       MakeWideArgReductionInput(num_rows, num_cols, max_indices, min_indices));
+  test.AddOutput<int64_t>("reduced", {num_rows}, min_indices);
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
+}
+
+TEST(ReductionOpTest, ArgMax_float_wide_last_axis_keepdims) {
+  constexpr int64_t num_rows = 2;
+  constexpr int64_t num_cols = 202048;
+  const std::vector<int64_t> max_indices{131072, 3};
+  const std::vector<int64_t> min_indices{0, 200000};
+
+  OpTester test("ArgMax", 13);
+  test.AddAttribute("axis", static_cast<int64_t>(-1));
+  test.AddAttribute("keepdims", static_cast<int64_t>(1));
+  test.AddInput<float>("data", {num_rows, num_cols},
+                       MakeWideArgReductionInput(num_rows, num_cols, max_indices, min_indices));
+  test.AddOutput<int64_t>("reduced", {num_rows, 1}, max_indices);
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
+}
+
 TEST(ReductionOpTest, ArgMax_int32_neg_axis) {
   OpTester test("ArgMax");
   test.AddAttribute("axis", (int64_t)(-2));

--- a/onnxruntime/test/providers/cuda/test_cases/reduction_functions_test.cc
+++ b/onnxruntime/test/providers/cuda/test_cases/reduction_functions_test.cc
@@ -584,6 +584,80 @@ TEST(ReductionFunctionsTest, ArgMinMaxLastAxisSpecialValues) {
   }
 }
 
+TEST(ReductionFunctionsTest, ArgMinMaxLastAxisScanStepBoundary) {
+  // A single row is scanned by at most 256 blocks x 256 threads, so the widest
+  // per iteration step is 4 * 65536 = 262144 elements. Straddle it to cover the
+  // loop termination arithmetic.
+  for (int n : {262143, 262144, 262145, 524287, 524288, 524289}) {
+    TestArgMinMaxLastAxisRandom<float>(1, n, static_cast<RandomValueGenerator::RandomSeedType>(n));
+  }
+}
+
+TEST(ReductionFunctionsTest, ArgMinMaxLastAxisBufferSizeExtremes) {
+  // Sizing must stay well defined and small for the widest admitted rows.
+  const int int_max = std::numeric_limits<int>::max();
+  for (int n : {1 << 20, 1 << 30, int_max - 1, int_max}) {
+    const size_t float_bytes = compute_arg_min_max_last_axis_buffer_size<float>(1, n);
+    const size_t double_bytes = compute_arg_min_max_last_axis_buffer_size<double>(1, n);
+    EXPECT_GT(float_bytes, 0u) << "n: " << n;
+    EXPECT_LT(float_bytes, size_t{1} << 20) << "n: " << n;
+    EXPECT_GT(double_bytes, float_bytes) << "n: " << n;
+    EXPECT_LT(double_bytes, size_t{1} << 20) << "n: " << n;
+  }
+  // Many narrow rows are handled by the one thread per row kernel, which needs no buffer.
+  EXPECT_EQ(compute_arg_min_max_last_axis_buffer_size<float>(1 << 20, 64), 0u);
+}
+
+TEST(ReductionFunctionsTest, ArgMinMaxLastAxisHugeWidth) {
+  // A row whose width approaches INT_MAX is what breaks 32 bit position arithmetic in
+  // the cooperative scan, so exercise the widest row the dispatch admits. fp16 keeps
+  // the allocation at ~4 GiB; the test is skipped when the device cannot hold it.
+  const int num_cols = std::numeric_limits<int>::max();
+  const size_t input_bytes = static_cast<size_t>(num_cols) * sizeof(half);
+  size_t free_bytes = 0;
+  size_t total_bytes = 0;
+  ASSERT_TRUE(CUDA_CALL(cudaMemGetInfo(&free_bytes, &total_bytes)).IsOK());
+  if (free_bytes < input_bytes + (size_t{256} << 20)) {
+    GTEST_SKIP() << "needs " << (input_bytes >> 20) << " MiB of free device memory, have "
+                 << (free_bytes >> 20) << " MiB";
+  }
+
+  auto d_input = AllocateDeviceMemory<half>(static_cast<size_t>(num_cols));
+  ASSERT_NE(d_input.get(), nullptr) << "allocation of " << (input_bytes >> 20) << " MiB failed";
+  auto d_output = AllocateDeviceMemory<int64_t>(1);
+
+  // Zero fill, then place duplicated extremes: the first occurrence must win, and the
+  // extremes sit in different scan iterations, including the very last one.
+  ASSERT_TRUE(CUDA_CALL(cudaMemset(d_input.get(), 0, input_bytes)).IsOK());
+  const int64_t expected_max_index = num_cols - 3;
+  const int64_t expected_min_index = 1234567890;
+  const half positive = __float2half(1.0f);
+  const half negative = __float2half(-1.0f);
+  for (int64_t index : {expected_max_index, static_cast<int64_t>(num_cols - 1)}) {
+    ASSERT_TRUE(CUDA_CALL(cudaMemcpy(d_input.get() + index, &positive, sizeof(half), cudaMemcpyHostToDevice)).IsOK());
+  }
+  for (int64_t index : {expected_min_index, static_cast<int64_t>(num_cols - 2)}) {
+    ASSERT_TRUE(CUDA_CALL(cudaMemcpy(d_input.get() + index, &negative, sizeof(half), cudaMemcpyHostToDevice)).IsOK());
+  }
+
+  const size_t buffer_size_in_bytes = compute_arg_min_max_last_axis_buffer_size<half>(1, num_cols);
+  ASSERT_GT(buffer_size_in_bytes, 0u);
+  auto d_buffer = AllocateDeviceMemory<char>(buffer_size_in_bytes);
+
+  int64_t actual = -1;
+  ASSERT_STATUS_OK((arg_min_max_last_axis<half, true>(0, d_input.get(), d_output.get(), 1, num_cols,
+                                                      d_buffer.get(), buffer_size_in_bytes)));
+  ASSERT_TRUE(CUDA_CALL(cudaDeviceSynchronize()).IsOK());
+  cudaMemcpy(&actual, d_output.get(), sizeof(int64_t), cudaMemcpyDeviceToHost);
+  ASSERT_EQ(actual, expected_max_index);
+
+  ASSERT_STATUS_OK((arg_min_max_last_axis<half, false>(0, d_input.get(), d_output.get(), 1, num_cols,
+                                                       d_buffer.get(), buffer_size_in_bytes)));
+  ASSERT_TRUE(CUDA_CALL(cudaDeviceSynchronize()).IsOK());
+  cudaMemcpy(&actual, d_output.get(), sizeof(int64_t), cudaMemcpyDeviceToHost);
+  ASSERT_EQ(actual, expected_min_index);
+}
+
 TEST(ReductionFunctionsTest, ArgMinMaxLastAxisEmptyRows) {
   auto d_input = AllocateDeviceMemory<float>(1);
   auto d_output = AllocateDeviceMemory<int64_t>(1);

--- a/onnxruntime/test/providers/cuda/test_cases/reduction_functions_test.cc
+++ b/onnxruntime/test/providers/cuda/test_cases/reduction_functions_test.cc
@@ -3,9 +3,12 @@
 
 #include "gtest/gtest.h"
 
+#include <algorithm>
+#include <iostream>
 #include <limits>
 #include <memory>
 #include <numeric>
+#include <vector>
 
 #include "core/providers/cuda/shared_inc/cuda_utils.h"
 #include "core/common/optional.h"
@@ -386,6 +389,381 @@ TEST(ReductionFunctionsTest, InvalidBufferSize) {
   const auto status =
       reduce_matrix_columns(0, d_input.get(), d_output.get(), m, n, d_buffer.get(), buffer_size_in_bytes);
   ASSERT_FALSE(status.IsOK());
+}
+
+// ---------------------------------------------------------------------------
+// arg_min_max_last_axis
+// ---------------------------------------------------------------------------
+namespace {
+template <typename T>
+struct ArgTestTraits {
+  static T FromFloat(float value) { return static_cast<T>(value); }
+  static double ToDouble(T value) { return static_cast<double>(value); }
+};
+
+template <>
+struct ArgTestTraits<half> {
+  static half FromFloat(float value) { return __float2half(value); }
+  static double ToDouble(half value) { return static_cast<double>(__half2float(value)); }
+};
+
+// Mirrors the sequential semantics of the reduction: seed with the first
+// element, keep the first occurrence of the extreme value and never select a
+// NaN (every comparison against NaN is false, so a leading NaN wins the row).
+template <typename T, bool IsArgMax>
+std::vector<int64_t> ExpectedArgMinMaxIndices(const std::vector<T>& values, int m, int n) {
+  std::vector<int64_t> expected(m);
+  for (int row = 0; row < m; ++row) {
+    double best = ArgTestTraits<T>::ToDouble(values[static_cast<size_t>(row) * n]);
+    int64_t best_index = 0;
+    for (int i = 1; i < n; ++i) {
+      const double value = ArgTestTraits<T>::ToDouble(values[static_cast<size_t>(row) * n + i]);
+      if (IsArgMax ? (value > best) : (value < best)) {
+        best = value;
+        best_index = i;
+      }
+    }
+    expected[row] = best_index;
+  }
+  return expected;
+}
+
+template <typename T, bool IsArgMax>
+void CheckArgMinMaxLastAxis(const std::vector<T>& values, int m, int n) {
+  SCOPED_TRACE(MakeString("m: ", m, ", n: ", n, ", is_arg_max: ", IsArgMax));
+
+  auto d_input = AllocateDeviceMemory<T>(static_cast<size_t>(m) * n);
+  auto d_output = AllocateDeviceMemory<int64_t>(m);
+  cudaMemcpy(d_input.get(), values.data(), static_cast<size_t>(m) * n * sizeof(T), cudaMemcpyHostToDevice);
+  // Poison the output so a kernel that never writes a row is detected.
+  cudaMemset(d_output.get(), 0xff, static_cast<size_t>(m) * sizeof(int64_t));
+
+  const size_t buffer_size_in_bytes = compute_arg_min_max_last_axis_buffer_size<T>(m, n);
+  auto d_buffer = AllocateDeviceMemory<char>(std::max<size_t>(buffer_size_in_bytes, 1));
+  // Dirty the intermediate buffer: the implementation must not assume it is zeroed.
+  if (buffer_size_in_bytes > 0) {
+    cudaMemset(d_buffer.get(), 0x5a, buffer_size_in_bytes);
+  }
+
+  ASSERT_STATUS_OK((arg_min_max_last_axis<T, IsArgMax>(
+      0, d_input.get(), d_output.get(), m, n, d_buffer.get(), buffer_size_in_bytes)));
+  ASSERT_TRUE(CUDA_CALL(cudaDeviceSynchronize()).IsOK());
+
+  std::vector<int64_t> actual(m);
+  cudaMemcpy(actual.data(), d_output.get(), static_cast<size_t>(m) * sizeof(int64_t), cudaMemcpyDeviceToHost);
+  const auto expected = ExpectedArgMinMaxIndices<T, IsArgMax>(values, m, n);
+  for (int row = 0; row < m; ++row) {
+    ASSERT_EQ(actual[row], expected[row]) << "row: " << row;
+  }
+}
+
+template <typename T>
+std::vector<T> MakeRandomValues(int m, int n, RandomValueGenerator::RandomSeedType seed) {
+  RandomValueGenerator random{seed};
+  const TensorShape shape{m, n};
+  const auto float_values = random.Uniform<float>(shape.GetDims(), -100.0f, 100.0f);
+  std::vector<T> values(float_values.size());
+  for (size_t i = 0; i < float_values.size(); ++i) {
+    values[i] = ArgTestTraits<T>::FromFloat(float_values[i]);
+  }
+  return values;
+}
+
+template <typename T>
+void TestArgMinMaxLastAxisRandom(int m, int n, RandomValueGenerator::RandomSeedType seed = 0) {
+  const auto values = MakeRandomValues<T>(m, n, seed);
+  CheckArgMinMaxLastAxis<T, true>(values, m, n);
+  CheckArgMinMaxLastAxis<T, false>(values, m, n);
+}
+
+// Fills rows with duplicates, infinities and NaNs. The row count is fixed, the
+// width is not, so every dispatch path can be exercised with the same rows.
+template <typename T>
+std::vector<T> MakeSpecialValueRows(int n) {
+  constexpr int kNumSpecialRows = 8;
+  const float infinity = std::numeric_limits<float>::infinity();
+  const float nan = std::numeric_limits<float>::quiet_NaN();
+  const float lowest_finite = std::is_same<T, half>::value ? -65504.0f : -3.0e38f;
+  const float highest_finite = -lowest_finite;
+
+  std::vector<T> values(static_cast<size_t>(kNumSpecialRows) * n);
+  for (int row = 0; row < kNumSpecialRows; ++row) {
+    for (int i = 0; i < n; ++i) {
+      values[static_cast<size_t>(row) * n + i] = ArgTestTraits<T>::FromFloat(static_cast<float>((i * 37) % 11) - 5.0f);
+    }
+  }
+  auto set = [&](int row, int index, float value) {
+    values[static_cast<size_t>(row) * n + index] = ArgTestTraits<T>::FromFloat(value);
+  };
+  auto fill = [&](int row, float value) {
+    for (int i = 0; i < n; ++i) set(row, i, value);
+  };
+
+  // row 0: leading NaN.
+  set(0, 0, nan);
+  // row 1: NaN in the middle plus a unique maximum after it.
+  set(1, n / 2, nan);
+  set(1, n - 1, 42.0f);
+  // row 2: every element is -infinity.
+  fill(2, -infinity);
+  // row 3: -infinity everywhere except one finite element that must win ArgMax.
+  fill(3, -infinity);
+  set(3, n - 2, lowest_finite);
+  // row 4: all elements equal, ties must resolve to the lowest index.
+  fill(4, 1.0f);
+  // row 5: duplicated +infinity maximum and duplicated -infinity minimum.
+  set(5, 1, infinity);
+  set(5, n - 1, infinity);
+  set(5, 2, -infinity);
+  set(5, n - 2, -infinity);
+  // row 6: every element is NaN.
+  fill(6, nan);
+  // row 7: finite extremes at the ends.
+  set(7, n - 1, highest_finite);
+  set(7, n / 3, lowest_finite);
+
+  return values;
+}
+
+template <typename T>
+void TestArgMinMaxLastAxisSpecialValues(int n) {
+  constexpr int kNumSpecialRows = 8;
+  const auto values = MakeSpecialValueRows<T>(n);
+  CheckArgMinMaxLastAxis<T, true>(values, kNumSpecialRows, n);
+  CheckArgMinMaxLastAxis<T, false>(values, kNumSpecialRows, n);
+}
+}  // namespace
+
+TEST(ReductionFunctionsTest, ArgMinMaxLastAxisNarrowRows) {
+  // Below the cooperative threshold: one thread per row.
+  for (int n : {1, 2, 3, 7, 31, 32, 33, 64, 127}) {
+    for (int m : {1, 3, 1024}) {
+      TestArgMinMaxLastAxisRandom<float>(m, n, n);
+    }
+  }
+}
+
+TEST(ReductionFunctionsTest, ArgMinMaxLastAxisSingleBlockRows) {
+  // Wide enough for the cooperative kernel, narrow enough for a single block.
+  for (int n : {128, 129, 255, 256, 511, 1024, 4095}) {
+    for (int m : {1, 3, 1024}) {
+      TestArgMinMaxLastAxisRandom<float>(m, n, n);
+    }
+  }
+}
+
+TEST(ReductionFunctionsTest, ArgMinMaxLastAxisMultiBlockRows) {
+  // Few, very wide rows: several blocks cooperate on each row.
+  for (int n : {8192, 32000, 65535, 65536, 202048, 262144}) {
+    for (int m : {1, 2, 4, 8}) {
+      TestArgMinMaxLastAxisRandom<float>(m, n, n);
+    }
+  }
+}
+
+TEST(ReductionFunctionsTest, ArgMinMaxLastAxisManyRows) {
+  // More rows than grid rows, so blocks loop over rows.
+  TestArgMinMaxLastAxisRandom<float>(40000, 128);
+  TestArgMinMaxLastAxisRandom<float>(40000, 1024);
+}
+
+TEST(ReductionFunctionsTest, ArgMinMaxLastAxisTypes) {
+  for (int n : {64, 1024, 65536}) {
+    TestArgMinMaxLastAxisRandom<half>(3, n, n);
+    TestArgMinMaxLastAxisRandom<float>(3, n, n);
+    TestArgMinMaxLastAxisRandom<double>(3, n, n);
+  }
+}
+
+TEST(ReductionFunctionsTest, ArgMinMaxLastAxisSpecialValues) {
+  // 64 -> one thread per row, 1024 -> single block per row, 200000 -> many blocks per row.
+  for (int n : {64, 1024, 200000}) {
+    TestArgMinMaxLastAxisSpecialValues<half>(n);
+    TestArgMinMaxLastAxisSpecialValues<float>(n);
+    TestArgMinMaxLastAxisSpecialValues<double>(n);
+  }
+}
+
+TEST(ReductionFunctionsTest, ArgMinMaxLastAxisEmptyRows) {
+  auto d_input = AllocateDeviceMemory<float>(1);
+  auto d_output = AllocateDeviceMemory<int64_t>(1);
+  // No rows: nothing to do, and no buffer is required.
+  ASSERT_STATUS_OK((arg_min_max_last_axis<float, true>(0, d_input.get(), d_output.get(), 0, 1024, nullptr, 0)));
+  ASSERT_TRUE(CUDA_CALL(cudaDeviceSynchronize()).IsOK());
+  ASSERT_EQ(compute_arg_min_max_last_axis_buffer_size<float>(0, 1024), 0u);
+}
+
+TEST(ReductionFunctionsTest, ArgMinMaxLastAxisInvalidBufferSize) {
+  const int m = 4;
+  const int n = 202048;
+  const size_t buffer_size_in_bytes = compute_arg_min_max_last_axis_buffer_size<float>(m, n);
+  ASSERT_GT(buffer_size_in_bytes, 0u);
+
+  auto d_input = AllocateDeviceMemory<float>(static_cast<size_t>(m) * n);
+  auto d_output = AllocateDeviceMemory<int64_t>(m);
+  auto d_buffer = AllocateDeviceMemory<char>(buffer_size_in_bytes);
+
+  const auto status = arg_min_max_last_axis<float, true>(
+      0, d_input.get(), d_output.get(), m, n, d_buffer.get(), buffer_size_in_bytes / 10);
+  ASSERT_FALSE(status.IsOK());
+}
+
+TEST(ReductionFunctionsTest, ArgMinMaxLastAxisBufferOffsets) {
+  const int m = 4;
+  const int n = 202048;
+  const size_t max_buffer_offset = 15;
+  const size_t buffer_size_in_bytes =
+      compute_arg_min_max_last_axis_buffer_size<double>(m, n) + max_buffer_offset;
+
+  const auto values = MakeRandomValues<double>(m, n, 7);
+  auto d_input = AllocateDeviceMemory<double>(static_cast<size_t>(m) * n);
+  auto d_output = AllocateDeviceMemory<int64_t>(m);
+  auto d_buffer = AllocateDeviceMemory<char>(buffer_size_in_bytes);
+  cudaMemcpy(d_input.get(), values.data(), static_cast<size_t>(m) * n * sizeof(double), cudaMemcpyHostToDevice);
+  const auto expected = ExpectedArgMinMaxIndices<double, true>(values, m, n);
+
+  for (size_t buffer_offset = 1; buffer_offset <= max_buffer_offset; ++buffer_offset) {
+    SCOPED_TRACE(MakeString("buffer offset: ", buffer_offset));
+    ASSERT_STATUS_OK((arg_min_max_last_axis<double, true>(
+        0, d_input.get(), d_output.get(), m, n, d_buffer.get() + buffer_offset,
+        buffer_size_in_bytes - buffer_offset)));
+    ASSERT_TRUE(CUDA_CALL(cudaDeviceSynchronize()).IsOK());
+
+    std::vector<int64_t> actual(m);
+    cudaMemcpy(actual.data(), d_output.get(), static_cast<size_t>(m) * sizeof(int64_t), cudaMemcpyDeviceToHost);
+    for (int row = 0; row < m; ++row) {
+      ASSERT_EQ(actual[row], expected[row]) << "row: " << row;
+    }
+  }
+}
+
+TEST(ReductionFunctionsTest, ArgMinMaxLastAxisCudaGraphCaptureAndReplay) {
+  const int m = 2;
+  const int n = 202048;
+  const auto values = MakeRandomValues<float>(m, n, 11);
+  const auto expected = ExpectedArgMinMaxIndices<float, true>(values, m, n);
+
+  auto d_input = AllocateDeviceMemory<float>(static_cast<size_t>(m) * n);
+  auto d_output = AllocateDeviceMemory<int64_t>(m);
+  const size_t buffer_size_in_bytes = compute_arg_min_max_last_axis_buffer_size<float>(m, n);
+  ASSERT_GT(buffer_size_in_bytes, 0u);
+  auto d_buffer = AllocateDeviceMemory<char>(buffer_size_in_bytes);
+  cudaMemcpy(d_input.get(), values.data(), static_cast<size_t>(m) * n * sizeof(float), cudaMemcpyHostToDevice);
+
+  cudaStream_t stream = nullptr;
+  ASSERT_TRUE(CUDA_CALL(cudaStreamCreate(&stream)).IsOK());
+
+  // Warm up outside of the capture, the same way the CUDA EP does.
+  ASSERT_STATUS_OK((arg_min_max_last_axis<float, true>(
+      stream, d_input.get(), d_output.get(), m, n, d_buffer.get(), buffer_size_in_bytes)));
+  ASSERT_TRUE(CUDA_CALL(cudaStreamSynchronize(stream)).IsOK());
+
+  cudaGraph_t graph = nullptr;
+  cudaGraphExec_t graph_exec = nullptr;
+  ASSERT_TRUE(CUDA_CALL(cudaStreamBeginCapture(stream, cudaStreamCaptureModeThreadLocal)).IsOK());
+  ASSERT_STATUS_OK((arg_min_max_last_axis<float, true>(
+      stream, d_input.get(), d_output.get(), m, n, d_buffer.get(), buffer_size_in_bytes)));
+  ASSERT_TRUE(CUDA_CALL(cudaStreamEndCapture(stream, &graph)).IsOK());
+  ASSERT_TRUE(CUDA_CALL(cudaGraphInstantiate(&graph_exec, graph, nullptr, nullptr, 0)).IsOK());
+
+  // Replaying must give the same answer every time: the block done counters are
+  // reset by the captured memset, not by the host.
+  for (int replay = 0; replay < 3; ++replay) {
+    cudaMemsetAsync(d_output.get(), 0xff, static_cast<size_t>(m) * sizeof(int64_t), stream);
+    ASSERT_TRUE(CUDA_CALL(cudaGraphLaunch(graph_exec, stream)).IsOK());
+    ASSERT_TRUE(CUDA_CALL(cudaStreamSynchronize(stream)).IsOK());
+
+    std::vector<int64_t> actual(m);
+    cudaMemcpy(actual.data(), d_output.get(), static_cast<size_t>(m) * sizeof(int64_t), cudaMemcpyDeviceToHost);
+    for (int row = 0; row < m; ++row) {
+      ASSERT_EQ(actual[row], expected[row]) << "replay: " << replay << ", row: " << row;
+    }
+  }
+
+  ASSERT_TRUE(CUDA_CALL(cudaGraphExecDestroy(graph_exec)).IsOK());
+  ASSERT_TRUE(CUDA_CALL(cudaGraphDestroy(graph)).IsOK());
+  ASSERT_TRUE(CUDA_CALL(cudaStreamDestroy(stream)).IsOK());
+}
+
+// Not run by default: prints a timing table for the shapes that matter for the
+// last axis ArgMax/ArgMin dispatch. Run it with
+// "GTEST_FILTER=ReductionFunctionsTest.DISABLED_ArgMinMaxLastAxisPerf
+// onnxruntime_provider_test --gtest_filter=CUDA_EP_Unittest.All
+// --gtest_also_run_disabled_tests".
+TEST(ReductionFunctionsTest, DISABLED_ArgMinMaxLastAxisPerf) {
+  struct Shape {
+    int m;
+    int n;
+  };
+  const std::vector<Shape> shapes = {
+      // few rows, very wide: sampling / classification over a large vocabulary
+      {1, 32000},
+      {1, 50257},
+      {1, 128256},
+      {1, 151936},
+      {1, 200000},
+      {1, 202048},
+      {1, 262144},
+      {2, 202048},
+      {4, 202048},
+      {8, 202048},
+      {16, 202048},
+      {32, 202048},
+      // many rows
+      {4096, 128},
+      {4096, 1024},
+      {4096, 4096},
+      {65536, 256},
+      {65536, 1024},
+      // narrow rows, handled by the one thread per row kernel
+      {4096, 8},
+      {4096, 32},
+      {4096, 64},
+      {65536, 64},
+  };
+
+  constexpr int kWarmupIterations = 20;
+  constexpr int kTimedIterations = 100;
+
+  cudaStream_t stream = nullptr;
+  ASSERT_TRUE(CUDA_CALL(cudaStreamCreate(&stream)).IsOK());
+  cudaEvent_t start, stop;
+  ASSERT_TRUE(CUDA_CALL(cudaEventCreate(&start)).IsOK());
+  ASSERT_TRUE(CUDA_CALL(cudaEventCreate(&stop)).IsOK());
+
+  std::cout << "rows,cols,scratch_bytes,microseconds\n";
+  for (const auto& shape : shapes) {
+    const auto values = MakeRandomValues<float>(shape.m, shape.n, static_cast<uint32_t>(shape.n));
+    auto d_input = AllocateDeviceMemory<float>(static_cast<size_t>(shape.m) * shape.n);
+    auto d_output = AllocateDeviceMemory<int64_t>(shape.m);
+    cudaMemcpy(d_input.get(), values.data(), static_cast<size_t>(shape.m) * shape.n * sizeof(float),
+               cudaMemcpyHostToDevice);
+    const size_t buffer_size_in_bytes = compute_arg_min_max_last_axis_buffer_size<float>(shape.m, shape.n);
+    auto d_buffer = AllocateDeviceMemory<char>(std::max<size_t>(buffer_size_in_bytes, 1));
+
+    for (int i = 0; i < kWarmupIterations; ++i) {
+      ASSERT_STATUS_OK((arg_min_max_last_axis<float, true>(stream, d_input.get(), d_output.get(), shape.m,
+                                                           shape.n, d_buffer.get(), buffer_size_in_bytes)));
+    }
+    ASSERT_TRUE(CUDA_CALL(cudaStreamSynchronize(stream)).IsOK());
+
+    ASSERT_TRUE(CUDA_CALL(cudaEventRecord(start, stream)).IsOK());
+    for (int i = 0; i < kTimedIterations; ++i) {
+      ASSERT_STATUS_OK((arg_min_max_last_axis<float, true>(stream, d_input.get(), d_output.get(), shape.m,
+                                                           shape.n, d_buffer.get(), buffer_size_in_bytes)));
+    }
+    ASSERT_TRUE(CUDA_CALL(cudaEventRecord(stop, stream)).IsOK());
+    ASSERT_TRUE(CUDA_CALL(cudaEventSynchronize(stop)).IsOK());
+
+    float elapsed_ms = 0.0f;
+    ASSERT_TRUE(CUDA_CALL(cudaEventElapsedTime(&elapsed_ms, start, stop)).IsOK());
+    std::cout << shape.m << "," << shape.n << "," << buffer_size_in_bytes << ","
+              << (elapsed_ms * 1000.0f / kTimedIterations) << "\n";
+  }
+
+  ASSERT_TRUE(CUDA_CALL(cudaEventDestroy(start)).IsOK());
+  ASSERT_TRUE(CUDA_CALL(cudaEventDestroy(stop)).IsOK());
+  ASSERT_TRUE(CUDA_CALL(cudaStreamDestroy(stream)).IsOK());
 }
 
 TEST(ReductionFunctionsTest, GetApplicableMatrixReduction) {


### PR DESCRIPTION
### Description

`arg_min_max_last_axis()` in `reduction_functions.cu` assigns **one thread per row** and scans the row serially. That is a reasonable design for many narrow rows, but it degenerates badly when a graph reduces a small number of very long rows: the reduction length becomes a serial dependency chain in a single thread, so the cost grows linearly with the reduced axis and the rest of the GPU stays idle.

A `[1, 202048]` `ArgMax` (last-axis classification / sampling over a large vocabulary) is therefore computed by exactly **one** CUDA thread and takes **~5 ms** on an H200. The same shape costs microseconds once it is parallelized. This affects any model that reduces a wide last axis with few rows, and it also leaves a lot on the table for the medium cases (thousands of rows of a few hundred to a few thousand columns).

This PR adds a cooperative reduction path and keeps the existing serial kernel for the shapes where it is genuinely better.

### Approach

- A new kernel spreads one row over many warps and, when the row is long enough, over many blocks:
  - thread level scan (grid-strided, 4 elements per thread, coalesced),
  - warp level merge with shuffles,
  - block level merge through shared memory,
  - grid level merge for multi-block rows through a small global buffer, finalized by the last block arriving for that row.
- The multi-block step reuses the `__threadfence()` + per-row done-counter structure that `reduce_matrix_columns()` / `reduce_all()` already use in the same file, so the intermediate buffer follows the existing sizing and alignment conventions and is allocated by the caller with `AllocateScratchBuffer` (same as the `ApplicableMatrixReduction::Columns` path).
- Launch geometry aims for a single wave of threads over the device while keeping at least four elements per thread. This avoids both failure modes: an idle device for few wide rows, and oversubscription (which measures 2-3x slower) for many rows.
- Rows narrower than 128 columns keep the existing one-thread-per-row kernel; below that width a row cannot fill a warp and the serial kernel wins. The threshold was picked from a measured crossover sweep.
- No model-specific constants: the dispatch depends only on the matrix shape and the device's thread capacity.

### Semantics

The new kernel is **bit-identical to the previous kernel for every input**, including:

- **Ties**: the lowest index wins, matching `select_last_index == 0`. The CUDA EP already falls back to CPU for `select_last_index == 1` (`ArgMaxOrArgMinNeedFallbackToCPU`), so this is the only case to support.
- **NaN**: NaN never wins a comparison, and the previous kernel seeded its accumulator with element 0, so a leading NaN yields index 0 for the whole row. That behavior is preserved explicitly.
- **Infinities**: the reduction identity is `-inf` / `+inf`, not the lowest/highest finite value. This matters: with a finite identity, a row of `[-inf, ..., lowest_finite, ...]` would drop the real maximum. Rows that are entirely `-inf`, `+inf` or NaN return index 0, as before.
- `axis`, `keepdims`, negative axes, opset variants and the int64 output are untouched, they are handled above this function.
- All registered input types are covered (`MLFloat16`, `float`, `double` for ArgMax/ArgMin) and the fallbacks for non-last-axis reductions, `n`/`m` beyond `int` range and empty reductions are unchanged.

### Results

H200 (sm90), CUDA 13.3, fp32, per call including the launch, measured with the benchmark added in this PR (`ReductionFunctionsTest.DISABLED_ArgMinMaxLastAxisPerf`), "before" measured with the same harness on the serial kernel:

| rows | cols | before | after | speedup | scratch |
|---:|---:|---:|---:|---:|---:|
| 1 | 32000 | 695.6 us | 5.6 us | 125x | 267 B |
| 1 | 50257 | 1201.1 us | 5.7 us | 210x | 411 B |
| 1 | 128256 | 3009.7 us | 5.9 us | 511x | 1019 B |
| 1 | 151936 | 3833.8 us | 6.2 us | 620x | 1203 B |
| 1 | 200000 | 5037.1 us | 6.1 us | 821x | 1579 B |
| 1 | 202048 | 5056.5 us | 6.2 us | 818x | 1595 B |
| 1 | 262144 | 6335.5 us | 6.2 us | 1018x | 2067 B |
| 2 | 202048 | 4853.4 us | 6.5 us | 746x | 3175 B |
| 4 | 202048 | 4759.6 us | 7.5 us | 635x | 6335 B |
| 8 | 202048 | 5118.4 us | 8.5 us | 603x | 8495 B |
| 16 | 202048 | 5805.6 us | 9.1 us | 640x | 8527 B |
| 32 | 202048 | 7357.7 us | 10.8 us | 681x | 8591 B |
| 4096 | 128 | 18.8 us | 5.0 us | 3.75x | 0 |
| 4096 | 1024 | 135.6 us | 6.5 us | 21x | 0 |
| 4096 | 4096 | 552.2 us | 20.8 us | 27x | 0 |
| 65536 | 256 | 70.7 us | 28.3 us | 2.50x | 0 |
| 65536 | 1024 | 270.1 us | 67.7 us | 3.99x | 0 |
| 4096 | 8 | 2.3 us | 2.3 us | 1.01x | 0 |
| 4096 | 32 | 6.2 us | 6.2 us | 0.99x | 0 |
| 4096 | 64 | 10.5 us | 10.6 us | 0.99x | 0 |
| 65536 | 64 | 18.9 us | 19.0 us | 1.00x | 0 |

Narrow rows are unchanged because they keep the existing kernel. `half` and `double` behave the same way (`[1, 202048]`: 2432 us -> 6.1 us for `half`, 6405 us -> 6.5 us for `double`).

Profile of `[1, 202048]` fp32 (Nsight Systems, occupancy from `cudaOccupancyMaxActiveBlocksPerMultiprocessor`):

| | before | after |
|---|---|---|
| kernel launches | 1 | 1 (+ one 4 byte memset) |
| GPU time | ~5056 us | 3.8 us kernel + 0.8 us memset |
| grid / block | 1 x 256 (1 active thread) | 197 x (32, 8) |
| registers / thread | - | 32 |
| theoretical occupancy | - | 100% |
| scratch | 0 | 1595 B |

For reference on the same GPU and shape, `cub::DeviceReduce::ArgMax` needs 2 kernels, 2.74 us of GPU time and 42495 bytes of temporary storage. The kernel here is a segmented (per row) reduction that also has to serve the many-rows shapes, uses ~26x less scratch and one launch instead of two. Scratch is bounded by the device thread capacity (a multi-block launch only happens when `rows < capacity / 256`), so it stays in the low kilobytes for any shape.

### Testing

- `onnxruntime/test/providers/cuda/test_cases/reduction_functions_test.cc`: new `ArgMinMaxLastAxis*` cases covering every dispatch path (narrow / single block / multi block / more rows than grid rows), `half`/`float`/`double`, ArgMax and ArgMin, ties, NaN (leading, middle, all), `+/-inf`, all-equal rows, finite extremes, unaligned and undersized intermediate buffers, a dirtied intermediate buffer, and CUDA graph capture + repeated replay.
- `onnxruntime/test/providers/cpu/reduction/reduction_ops_test.cc`: operator level ArgMax/ArgMin tests with a wide last axis (`{3, 40000}` and `{2, 202048}`, with `keepdims` on and off and a negative axis) so the CUDA EP scratch allocation path is covered end to end.
- `onnxruntime_provider_test --gtest_filter='*ArgMax*:*ArgMin*'`: 32/32 pass.
- `onnxruntime_provider_test --gtest_filter='*Reduce*'`: 376/376 pass.
- `CUDA_EP_Unittest.All` (CUDA EP internal tests): 76/76 pass.
- `compute-sanitizer` (`memcheck`, `racecheck`, `synccheck`) clean on the multi-block and row-loop paths.
- Differential test against the previous kernel's exact sequential semantics over a dense width sweep around the dispatch threshold and around power-of-two boundaries, several row counts, all three dtypes, random data and a `{+/-inf, NaN, +/-0.0, ...}` alphabet, repeated with several simulated device capacities: no mismatches.

### Review follow-up

- The thread level scan originally advanced `id` in `int`. Since a row is admitted up to `INT_MAX` columns and the step reaches `4 * 65536 = 262144`, that overflowed to negative positions for the widest rows, reading out of bounds and never terminating. Fixed by expressing the scan with differences (`remaining = num_cols - id`, `delta = i * threads`, positions only formed after `delta < remaining`), which keeps every value inside `[0, num_cols)`. int64 positions were measured as the alternative and were 4-38% slower on the targeted shapes, so the difference based form was kept; no shape is dropped either way. New tests: `[1, INT_MAX]` fp16 (memory gated), widths straddling the widest scan step, and buffer sizing at `INT_MAX`.

### Possible follow-up

The thread level scan uses scalar loads. Vectorized loads would shave roughly another microsecond off the very wide single row case; it was left out here to keep the alignment handling out of a generic kernel that has to serve `half`, `float` and `double`.
