### PR TITLE
[CUDA] Enable FP4 QMoE by default

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -127,7 +127,7 @@ cmake_dependent_option(onnxruntime_USE_MEMORY_EFFICIENT_ATTENTION "Build memory 
 # encoder models. Turning this OFF drops ~14MB of embedded cubin data; attention falls back to
 # flash / memory efficient / cuDNN / unfused kernels.
 cmake_dependent_option(onnxruntime_USE_TRT_FUSED_ATTENTION "Build TensorRT fused multi-head attention cubin kernels" ON "onnxruntime_USE_CUDA" OFF)
-option(onnxruntime_USE_FP4_QMOE "Build CUDA QMoE FP4 kernels" OFF)
+cmake_dependent_option(onnxruntime_USE_FP4_QMOE "Build CUDA QMoE FP4 kernels" ON "onnxruntime_USE_CUDA" OFF)
 option(onnxruntime_USE_FP8_QMOE "Build CUDA QMoE FP8 kernels" OFF)
 cmake_dependent_option(onnxruntime_USE_FPA_INTB_GEMM "Build FpA IntB gemm cuda kernels" ON "onnxruntime_USE_CUDA" OFF)
 option(onnxruntime_USE_INT4_KV_CACHE "Build cuda kernels for int4 kv cache" OFF)

--- a/docs/contrib_ops/cuda/moe_qmoe.md
+++ b/docs/contrib_ops/cuda/moe_qmoe.md
@@ -1367,8 +1367,12 @@ CMake gates relevant to MoE/QMoE (see [cmake/CMakeLists.txt](cmake/CMakeLists.tx
 | `ENABLE_BF16` | CUDA ≥ 11.0 | BF16 weight/activation paths. |
 | `ENABLE_FP8`  | CUDA ≥ 11.8 | FP8 e4m3 instantiations and `QuantParams::FP8`. |
 | `ENABLE_FP4`  | CUDA ≥ 12.8 | FP4 e2m1 type (`__nv_fp4_e2m1`) and FP4 traits. |
-| `onnxruntime_USE_FP4_QMOE` | user opt-in (requires `ENABLE_FP4`) | Enables FP4 / WFP4AFP8 kernel instantiations and CUTLASS launchers. |
+| `onnxruntime_USE_FP4_QMOE` | ON by default for CUDA builds (requires `ENABLE_FP4`) | Enables FP4 / WFP4AFP8 kernel instantiations and CUTLASS launchers. Set to `OFF` to exclude them. |
 | `EXCLUDE_SM_100`, `EXCLUDE_SM_120` | architecture exclusion | Drops the corresponding generated kernels. |
+
+`onnxruntime_USE_FP4_QMOE` is enabled automatically when `onnxruntime_USE_CUDA=ON`.
+It remains `OFF` for non-CUDA builds and can be explicitly disabled for CUDA builds with
+`-Donnxruntime_USE_FP4_QMOE=OFF` when the additional FP4 kernel instantiations are not needed.
 
 CUDA architecture defaults:
 - CUDA 12.8+ : `60;70;75;80;86;89;90;100;120`

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/launchers/generate_moe_gemm_tma_ws_sm90_fp4.py
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/launchers/generate_moe_gemm_tma_ws_sm90_fp4.py
@@ -67,11 +67,17 @@ def get_instantiations() -> list[Instantiation]:
     add_full_build_configs(instantiations, "fp16", "half")
     add_full_build_configs(instantiations, "bf16", "__nv_bfloat16")
 
-    # Quick-build: a subset of configs for faster compilation
-    for k in (128, 256):
-        for n in (16, 32, 64, 128):
-            instantiations.add(Instantiation("fp16", "half", 128, n, k, 1, 1, "pp", "none", quick_build=True))
-            instantiations.add(Instantiation("fp16", "half", 128, n, k, 1, 1, "pp", "finalize", quick_build=True))
+    # Quick-build: one cluster shape for every config retained by the dispatcher.
+    for type_name, cpp_type in (("fp16", "half"), ("bf16", "__nv_bfloat16")):
+        for k in (128, 256):
+            for n in (16, 32, 64, 128):
+                schedule = "pp" if n in (16, 128) or (type_name == "fp16" and n == 32) else "co"
+                instantiations.add(
+                    Instantiation(type_name, cpp_type, 128, n, k, 1, 1, schedule, "none", quick_build=True)
+                )
+                instantiations.add(
+                    Instantiation(type_name, cpp_type, 128, n, k, 1, 1, schedule, "finalize", quick_build=True)
+                )
 
     return sorted(instantiations)
 

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_bf16_m128_n128_k128_cm1_cn1_pp.generated.cu
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_bf16_m128_n128_k128_cm1_cn1_pp.generated.cu
@@ -7,7 +7,6 @@
 
 #ifdef COMPILE_HOPPER_TMA_GROUPED_GEMMS
 #if defined(ENABLE_FP4) && defined(USE_FP4_QMOE)
-#ifndef ORT_QUICK_BUILD
 #ifdef ENABLE_BF16
 #include "contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_instantiation.cuh"
 
@@ -18,6 +17,5 @@ ORT_MOE_GEMM_TMA_WS_SM90_FP4_INST_PP(__nv_bfloat16, 128, 128, 128, 1, 1, 1);
 }  // namespace onnxruntime::llm::kernels::cutlass_kernels
 
 #endif  // ENABLE_BF16
-#endif  // !ORT_QUICK_BUILD
 #endif  // ENABLE_FP4 && USE_FP4_QMOE
 #endif  // COMPILE_HOPPER_TMA_GROUPED_GEMMS

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_bf16_m128_n128_k128_cm1_cn1_pp_finalize.generated.cu
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_bf16_m128_n128_k128_cm1_cn1_pp_finalize.generated.cu
@@ -7,7 +7,6 @@
 
 #ifdef COMPILE_HOPPER_TMA_GROUPED_GEMMS
 #if defined(ENABLE_FP4) && defined(USE_FP4_QMOE)
-#ifndef ORT_QUICK_BUILD
 #ifdef ENABLE_BF16
 #include "contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_instantiation.cuh"
 
@@ -18,6 +17,5 @@ ORT_MOE_GEMM_TMA_WS_SM90_FP4_INST_PP_FINALIZE(__nv_bfloat16, 128, 128, 128, 1, 1
 }  // namespace onnxruntime::llm::kernels::cutlass_kernels
 
 #endif  // ENABLE_BF16
-#endif  // !ORT_QUICK_BUILD
 #endif  // ENABLE_FP4 && USE_FP4_QMOE
 #endif  // COMPILE_HOPPER_TMA_GROUPED_GEMMS

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_bf16_m128_n128_k256_cm1_cn1_pp.generated.cu
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_bf16_m128_n128_k256_cm1_cn1_pp.generated.cu
@@ -7,7 +7,6 @@
 
 #ifdef COMPILE_HOPPER_TMA_GROUPED_GEMMS
 #if defined(ENABLE_FP4) && defined(USE_FP4_QMOE)
-#ifndef ORT_QUICK_BUILD
 #ifdef ENABLE_BF16
 #include "contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_instantiation.cuh"
 
@@ -18,6 +17,5 @@ ORT_MOE_GEMM_TMA_WS_SM90_FP4_INST_PP(__nv_bfloat16, 128, 128, 256, 1, 1, 1);
 }  // namespace onnxruntime::llm::kernels::cutlass_kernels
 
 #endif  // ENABLE_BF16
-#endif  // !ORT_QUICK_BUILD
 #endif  // ENABLE_FP4 && USE_FP4_QMOE
 #endif  // COMPILE_HOPPER_TMA_GROUPED_GEMMS

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_bf16_m128_n128_k256_cm1_cn1_pp_finalize.generated.cu
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_bf16_m128_n128_k256_cm1_cn1_pp_finalize.generated.cu
@@ -7,7 +7,6 @@
 
 #ifdef COMPILE_HOPPER_TMA_GROUPED_GEMMS
 #if defined(ENABLE_FP4) && defined(USE_FP4_QMOE)
-#ifndef ORT_QUICK_BUILD
 #ifdef ENABLE_BF16
 #include "contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_instantiation.cuh"
 
@@ -18,6 +17,5 @@ ORT_MOE_GEMM_TMA_WS_SM90_FP4_INST_PP_FINALIZE(__nv_bfloat16, 128, 128, 256, 1, 1
 }  // namespace onnxruntime::llm::kernels::cutlass_kernels
 
 #endif  // ENABLE_BF16
-#endif  // !ORT_QUICK_BUILD
 #endif  // ENABLE_FP4 && USE_FP4_QMOE
 #endif  // COMPILE_HOPPER_TMA_GROUPED_GEMMS

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_bf16_m128_n16_k128_cm1_cn1_pp.generated.cu
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_bf16_m128_n16_k128_cm1_cn1_pp.generated.cu
@@ -7,7 +7,6 @@
 
 #ifdef COMPILE_HOPPER_TMA_GROUPED_GEMMS
 #if defined(ENABLE_FP4) && defined(USE_FP4_QMOE)
-#ifndef ORT_QUICK_BUILD
 #ifdef ENABLE_BF16
 #include "contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_instantiation.cuh"
 
@@ -18,6 +17,5 @@ ORT_MOE_GEMM_TMA_WS_SM90_FP4_INST_PP(__nv_bfloat16, 128, 16, 128, 1, 1, 1);
 }  // namespace onnxruntime::llm::kernels::cutlass_kernels
 
 #endif  // ENABLE_BF16
-#endif  // !ORT_QUICK_BUILD
 #endif  // ENABLE_FP4 && USE_FP4_QMOE
 #endif  // COMPILE_HOPPER_TMA_GROUPED_GEMMS

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_bf16_m128_n16_k128_cm1_cn1_pp_finalize.generated.cu
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_bf16_m128_n16_k128_cm1_cn1_pp_finalize.generated.cu
@@ -7,7 +7,6 @@
 
 #ifdef COMPILE_HOPPER_TMA_GROUPED_GEMMS
 #if defined(ENABLE_FP4) && defined(USE_FP4_QMOE)
-#ifndef ORT_QUICK_BUILD
 #ifdef ENABLE_BF16
 #include "contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_instantiation.cuh"
 
@@ -18,6 +17,5 @@ ORT_MOE_GEMM_TMA_WS_SM90_FP4_INST_PP_FINALIZE(__nv_bfloat16, 128, 16, 128, 1, 1,
 }  // namespace onnxruntime::llm::kernels::cutlass_kernels
 
 #endif  // ENABLE_BF16
-#endif  // !ORT_QUICK_BUILD
 #endif  // ENABLE_FP4 && USE_FP4_QMOE
 #endif  // COMPILE_HOPPER_TMA_GROUPED_GEMMS

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_bf16_m128_n16_k256_cm1_cn1_pp.generated.cu
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_bf16_m128_n16_k256_cm1_cn1_pp.generated.cu
@@ -7,7 +7,6 @@
 
 #ifdef COMPILE_HOPPER_TMA_GROUPED_GEMMS
 #if defined(ENABLE_FP4) && defined(USE_FP4_QMOE)
-#ifndef ORT_QUICK_BUILD
 #ifdef ENABLE_BF16
 #include "contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_instantiation.cuh"
 
@@ -18,6 +17,5 @@ ORT_MOE_GEMM_TMA_WS_SM90_FP4_INST_PP(__nv_bfloat16, 128, 16, 256, 1, 1, 1);
 }  // namespace onnxruntime::llm::kernels::cutlass_kernels
 
 #endif  // ENABLE_BF16
-#endif  // !ORT_QUICK_BUILD
 #endif  // ENABLE_FP4 && USE_FP4_QMOE
 #endif  // COMPILE_HOPPER_TMA_GROUPED_GEMMS

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_bf16_m128_n16_k256_cm1_cn1_pp_finalize.generated.cu
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_bf16_m128_n16_k256_cm1_cn1_pp_finalize.generated.cu
@@ -7,7 +7,6 @@
 
 #ifdef COMPILE_HOPPER_TMA_GROUPED_GEMMS
 #if defined(ENABLE_FP4) && defined(USE_FP4_QMOE)
-#ifndef ORT_QUICK_BUILD
 #ifdef ENABLE_BF16
 #include "contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_instantiation.cuh"
 
@@ -18,6 +17,5 @@ ORT_MOE_GEMM_TMA_WS_SM90_FP4_INST_PP_FINALIZE(__nv_bfloat16, 128, 16, 256, 1, 1,
 }  // namespace onnxruntime::llm::kernels::cutlass_kernels
 
 #endif  // ENABLE_BF16
-#endif  // !ORT_QUICK_BUILD
 #endif  // ENABLE_FP4 && USE_FP4_QMOE
 #endif  // COMPILE_HOPPER_TMA_GROUPED_GEMMS

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_bf16_m128_n32_k128_cm1_cn1_co.generated.cu
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_bf16_m128_n32_k128_cm1_cn1_co.generated.cu
@@ -7,7 +7,6 @@
 
 #ifdef COMPILE_HOPPER_TMA_GROUPED_GEMMS
 #if defined(ENABLE_FP4) && defined(USE_FP4_QMOE)
-#ifndef ORT_QUICK_BUILD
 #ifdef ENABLE_BF16
 #include "contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_instantiation.cuh"
 
@@ -18,6 +17,5 @@ ORT_MOE_GEMM_TMA_WS_SM90_FP4_INST_CO(__nv_bfloat16, 128, 32, 128, 1, 1, 1);
 }  // namespace onnxruntime::llm::kernels::cutlass_kernels
 
 #endif  // ENABLE_BF16
-#endif  // !ORT_QUICK_BUILD
 #endif  // ENABLE_FP4 && USE_FP4_QMOE
 #endif  // COMPILE_HOPPER_TMA_GROUPED_GEMMS

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_bf16_m128_n32_k128_cm1_cn1_co_finalize.generated.cu
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_bf16_m128_n32_k128_cm1_cn1_co_finalize.generated.cu
@@ -7,7 +7,6 @@
 
 #ifdef COMPILE_HOPPER_TMA_GROUPED_GEMMS
 #if defined(ENABLE_FP4) && defined(USE_FP4_QMOE)
-#ifndef ORT_QUICK_BUILD
 #ifdef ENABLE_BF16
 #include "contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_instantiation.cuh"
 
@@ -18,6 +17,5 @@ ORT_MOE_GEMM_TMA_WS_SM90_FP4_INST_CO_FINALIZE(__nv_bfloat16, 128, 32, 128, 1, 1,
 }  // namespace onnxruntime::llm::kernels::cutlass_kernels
 
 #endif  // ENABLE_BF16
-#endif  // !ORT_QUICK_BUILD
 #endif  // ENABLE_FP4 && USE_FP4_QMOE
 #endif  // COMPILE_HOPPER_TMA_GROUPED_GEMMS

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_bf16_m128_n32_k256_cm1_cn1_co.generated.cu
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_bf16_m128_n32_k256_cm1_cn1_co.generated.cu
@@ -7,7 +7,6 @@
 
 #ifdef COMPILE_HOPPER_TMA_GROUPED_GEMMS
 #if defined(ENABLE_FP4) && defined(USE_FP4_QMOE)
-#ifndef ORT_QUICK_BUILD
 #ifdef ENABLE_BF16
 #include "contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_instantiation.cuh"
 
@@ -18,6 +17,5 @@ ORT_MOE_GEMM_TMA_WS_SM90_FP4_INST_CO(__nv_bfloat16, 128, 32, 256, 1, 1, 1);
 }  // namespace onnxruntime::llm::kernels::cutlass_kernels
 
 #endif  // ENABLE_BF16
-#endif  // !ORT_QUICK_BUILD
 #endif  // ENABLE_FP4 && USE_FP4_QMOE
 #endif  // COMPILE_HOPPER_TMA_GROUPED_GEMMS

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_bf16_m128_n32_k256_cm1_cn1_co_finalize.generated.cu
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_bf16_m128_n32_k256_cm1_cn1_co_finalize.generated.cu
@@ -7,7 +7,6 @@
 
 #ifdef COMPILE_HOPPER_TMA_GROUPED_GEMMS
 #if defined(ENABLE_FP4) && defined(USE_FP4_QMOE)
-#ifndef ORT_QUICK_BUILD
 #ifdef ENABLE_BF16
 #include "contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_instantiation.cuh"
 
@@ -18,6 +17,5 @@ ORT_MOE_GEMM_TMA_WS_SM90_FP4_INST_CO_FINALIZE(__nv_bfloat16, 128, 32, 256, 1, 1,
 }  // namespace onnxruntime::llm::kernels::cutlass_kernels
 
 #endif  // ENABLE_BF16
-#endif  // !ORT_QUICK_BUILD
 #endif  // ENABLE_FP4 && USE_FP4_QMOE
 #endif  // COMPILE_HOPPER_TMA_GROUPED_GEMMS

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_bf16_m128_n64_k128_cm1_cn1_co.generated.cu
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_bf16_m128_n64_k128_cm1_cn1_co.generated.cu
@@ -7,7 +7,6 @@
 
 #ifdef COMPILE_HOPPER_TMA_GROUPED_GEMMS
 #if defined(ENABLE_FP4) && defined(USE_FP4_QMOE)
-#ifndef ORT_QUICK_BUILD
 #ifdef ENABLE_BF16
 #include "contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_instantiation.cuh"
 
@@ -18,6 +17,5 @@ ORT_MOE_GEMM_TMA_WS_SM90_FP4_INST_CO(__nv_bfloat16, 128, 64, 128, 1, 1, 1);
 }  // namespace onnxruntime::llm::kernels::cutlass_kernels
 
 #endif  // ENABLE_BF16
-#endif  // !ORT_QUICK_BUILD
 #endif  // ENABLE_FP4 && USE_FP4_QMOE
 #endif  // COMPILE_HOPPER_TMA_GROUPED_GEMMS

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_bf16_m128_n64_k128_cm1_cn1_co_finalize.generated.cu
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_bf16_m128_n64_k128_cm1_cn1_co_finalize.generated.cu
@@ -7,7 +7,6 @@
 
 #ifdef COMPILE_HOPPER_TMA_GROUPED_GEMMS
 #if defined(ENABLE_FP4) && defined(USE_FP4_QMOE)
-#ifndef ORT_QUICK_BUILD
 #ifdef ENABLE_BF16
 #include "contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_instantiation.cuh"
 
@@ -18,6 +17,5 @@ ORT_MOE_GEMM_TMA_WS_SM90_FP4_INST_CO_FINALIZE(__nv_bfloat16, 128, 64, 128, 1, 1,
 }  // namespace onnxruntime::llm::kernels::cutlass_kernels
 
 #endif  // ENABLE_BF16
-#endif  // !ORT_QUICK_BUILD
 #endif  // ENABLE_FP4 && USE_FP4_QMOE
 #endif  // COMPILE_HOPPER_TMA_GROUPED_GEMMS

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_bf16_m128_n64_k256_cm1_cn1_co.generated.cu
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_bf16_m128_n64_k256_cm1_cn1_co.generated.cu
@@ -7,7 +7,6 @@
 
 #ifdef COMPILE_HOPPER_TMA_GROUPED_GEMMS
 #if defined(ENABLE_FP4) && defined(USE_FP4_QMOE)
-#ifndef ORT_QUICK_BUILD
 #ifdef ENABLE_BF16
 #include "contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_instantiation.cuh"
 
@@ -18,6 +17,5 @@ ORT_MOE_GEMM_TMA_WS_SM90_FP4_INST_CO(__nv_bfloat16, 128, 64, 256, 1, 1, 1);
 }  // namespace onnxruntime::llm::kernels::cutlass_kernels
 
 #endif  // ENABLE_BF16
-#endif  // !ORT_QUICK_BUILD
 #endif  // ENABLE_FP4 && USE_FP4_QMOE
 #endif  // COMPILE_HOPPER_TMA_GROUPED_GEMMS

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_bf16_m128_n64_k256_cm1_cn1_co_finalize.generated.cu
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_bf16_m128_n64_k256_cm1_cn1_co_finalize.generated.cu
@@ -7,7 +7,6 @@
 
 #ifdef COMPILE_HOPPER_TMA_GROUPED_GEMMS
 #if defined(ENABLE_FP4) && defined(USE_FP4_QMOE)
-#ifndef ORT_QUICK_BUILD
 #ifdef ENABLE_BF16
 #include "contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_instantiation.cuh"
 
@@ -18,6 +17,5 @@ ORT_MOE_GEMM_TMA_WS_SM90_FP4_INST_CO_FINALIZE(__nv_bfloat16, 128, 64, 256, 1, 1,
 }  // namespace onnxruntime::llm::kernels::cutlass_kernels
 
 #endif  // ENABLE_BF16
-#endif  // !ORT_QUICK_BUILD
 #endif  // ENABLE_FP4 && USE_FP4_QMOE
 #endif  // COMPILE_HOPPER_TMA_GROUPED_GEMMS

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_fp16_m128_n64_k128_cm1_cn1_co.generated.cu
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_fp16_m128_n64_k128_cm1_cn1_co.generated.cu
@@ -7,7 +7,6 @@
 
 #ifdef COMPILE_HOPPER_TMA_GROUPED_GEMMS
 #if defined(ENABLE_FP4) && defined(USE_FP4_QMOE)
-#ifndef ORT_QUICK_BUILD
 #include "contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_instantiation.cuh"
 
 namespace onnxruntime::llm::kernels::cutlass_kernels {
@@ -16,6 +15,5 @@ ORT_MOE_GEMM_TMA_WS_SM90_FP4_INST_CO(half, 128, 64, 128, 1, 1, 1);
 
 }  // namespace onnxruntime::llm::kernels::cutlass_kernels
 
-#endif  // !ORT_QUICK_BUILD
 #endif  // ENABLE_FP4 && USE_FP4_QMOE
 #endif  // COMPILE_HOPPER_TMA_GROUPED_GEMMS

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_fp16_m128_n64_k128_cm1_cn1_co_finalize.generated.cu
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_fp16_m128_n64_k128_cm1_cn1_co_finalize.generated.cu
@@ -7,7 +7,6 @@
 
 #ifdef COMPILE_HOPPER_TMA_GROUPED_GEMMS
 #if defined(ENABLE_FP4) && defined(USE_FP4_QMOE)
-#ifndef ORT_QUICK_BUILD
 #include "contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_instantiation.cuh"
 
 namespace onnxruntime::llm::kernels::cutlass_kernels {
@@ -16,6 +15,5 @@ ORT_MOE_GEMM_TMA_WS_SM90_FP4_INST_CO_FINALIZE(half, 128, 64, 128, 1, 1, 1);
 
 }  // namespace onnxruntime::llm::kernels::cutlass_kernels
 
-#endif  // !ORT_QUICK_BUILD
 #endif  // ENABLE_FP4 && USE_FP4_QMOE
 #endif  // COMPILE_HOPPER_TMA_GROUPED_GEMMS

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_fp16_m128_n64_k128_cm1_cn1_pp.generated.cu
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_fp16_m128_n64_k128_cm1_cn1_pp.generated.cu
@@ -7,6 +7,7 @@
 
 #ifdef COMPILE_HOPPER_TMA_GROUPED_GEMMS
 #if defined(ENABLE_FP4) && defined(USE_FP4_QMOE)
+#ifndef ORT_QUICK_BUILD
 #include "contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_instantiation.cuh"
 
 namespace onnxruntime::llm::kernels::cutlass_kernels {
@@ -15,5 +16,6 @@ ORT_MOE_GEMM_TMA_WS_SM90_FP4_INST_PP(half, 128, 64, 128, 1, 1, 1);
 
 }  // namespace onnxruntime::llm::kernels::cutlass_kernels
 
+#endif  // !ORT_QUICK_BUILD
 #endif  // ENABLE_FP4 && USE_FP4_QMOE
 #endif  // COMPILE_HOPPER_TMA_GROUPED_GEMMS

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_fp16_m128_n64_k128_cm1_cn1_pp_finalize.generated.cu
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_fp16_m128_n64_k128_cm1_cn1_pp_finalize.generated.cu
@@ -7,6 +7,7 @@
 
 #ifdef COMPILE_HOPPER_TMA_GROUPED_GEMMS
 #if defined(ENABLE_FP4) && defined(USE_FP4_QMOE)
+#ifndef ORT_QUICK_BUILD
 #include "contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_instantiation.cuh"
 
 namespace onnxruntime::llm::kernels::cutlass_kernels {
@@ -15,5 +16,6 @@ ORT_MOE_GEMM_TMA_WS_SM90_FP4_INST_PP_FINALIZE(half, 128, 64, 128, 1, 1, 1);
 
 }  // namespace onnxruntime::llm::kernels::cutlass_kernels
 
+#endif  // !ORT_QUICK_BUILD
 #endif  // ENABLE_FP4 && USE_FP4_QMOE
 #endif  // COMPILE_HOPPER_TMA_GROUPED_GEMMS

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_fp16_m128_n64_k256_cm1_cn1_co.generated.cu
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_fp16_m128_n64_k256_cm1_cn1_co.generated.cu
@@ -7,7 +7,6 @@
 
 #ifdef COMPILE_HOPPER_TMA_GROUPED_GEMMS
 #if defined(ENABLE_FP4) && defined(USE_FP4_QMOE)
-#ifndef ORT_QUICK_BUILD
 #include "contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_instantiation.cuh"
 
 namespace onnxruntime::llm::kernels::cutlass_kernels {
@@ -16,6 +15,5 @@ ORT_MOE_GEMM_TMA_WS_SM90_FP4_INST_CO(half, 128, 64, 256, 1, 1, 1);
 
 }  // namespace onnxruntime::llm::kernels::cutlass_kernels
 
-#endif  // !ORT_QUICK_BUILD
 #endif  // ENABLE_FP4 && USE_FP4_QMOE
 #endif  // COMPILE_HOPPER_TMA_GROUPED_GEMMS

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_fp16_m128_n64_k256_cm1_cn1_co_finalize.generated.cu
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_fp16_m128_n64_k256_cm1_cn1_co_finalize.generated.cu
@@ -7,7 +7,6 @@
 
 #ifdef COMPILE_HOPPER_TMA_GROUPED_GEMMS
 #if defined(ENABLE_FP4) && defined(USE_FP4_QMOE)
-#ifndef ORT_QUICK_BUILD
 #include "contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_instantiation.cuh"
 
 namespace onnxruntime::llm::kernels::cutlass_kernels {
@@ -16,6 +15,5 @@ ORT_MOE_GEMM_TMA_WS_SM90_FP4_INST_CO_FINALIZE(half, 128, 64, 256, 1, 1, 1);
 
 }  // namespace onnxruntime::llm::kernels::cutlass_kernels
 
-#endif  // !ORT_QUICK_BUILD
 #endif  // ENABLE_FP4 && USE_FP4_QMOE
 #endif  // COMPILE_HOPPER_TMA_GROUPED_GEMMS

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_fp16_m128_n64_k256_cm1_cn1_pp.generated.cu
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_fp16_m128_n64_k256_cm1_cn1_pp.generated.cu
@@ -7,6 +7,7 @@
 
 #ifdef COMPILE_HOPPER_TMA_GROUPED_GEMMS
 #if defined(ENABLE_FP4) && defined(USE_FP4_QMOE)
+#ifndef ORT_QUICK_BUILD
 #include "contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_instantiation.cuh"
 
 namespace onnxruntime::llm::kernels::cutlass_kernels {
@@ -15,5 +16,6 @@ ORT_MOE_GEMM_TMA_WS_SM90_FP4_INST_PP(half, 128, 64, 256, 1, 1, 1);
 
 }  // namespace onnxruntime::llm::kernels::cutlass_kernels
 
+#endif  // !ORT_QUICK_BUILD
 #endif  // ENABLE_FP4 && USE_FP4_QMOE
 #endif  // COMPILE_HOPPER_TMA_GROUPED_GEMMS

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_fp16_m128_n64_k256_cm1_cn1_pp_finalize.generated.cu
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_fp16_m128_n64_k256_cm1_cn1_pp_finalize.generated.cu
@@ -7,6 +7,7 @@
 
 #ifdef COMPILE_HOPPER_TMA_GROUPED_GEMMS
 #if defined(ENABLE_FP4) && defined(USE_FP4_QMOE)
+#ifndef ORT_QUICK_BUILD
 #include "contrib_ops/cuda/llm/moe_gemm/launchers/moe_gemm_tma_ws_sm90_fp4_instantiation.cuh"
 
 namespace onnxruntime::llm::kernels::cutlass_kernels {
@@ -15,5 +16,6 @@ ORT_MOE_GEMM_TMA_WS_SM90_FP4_INST_PP_FINALIZE(half, 128, 64, 256, 1, 1, 1);
 
 }  // namespace onnxruntime::llm::kernels::cutlass_kernels
 
+#endif  // !ORT_QUICK_BUILD
 #endif  // ENABLE_FP4 && USE_FP4_QMOE
 #endif  // COMPILE_HOPPER_TMA_GROUPED_GEMMS


### PR DESCRIPTION
This change enables FP4 QMoE kernel instantiations by default for CUDA builds. Non-CUDA builds remain disabled, and CUDA users can opt out with `-Donnxruntime_USE_FP4_QMOE=OFF`.

The QMoE documentation now describes the default, dependency, and override behavior.

## Validation

- `cmake -S /home/tianlei/git/onnxruntime/cmake -B /tmp/ort_fp4_qmoe_check -Donnxruntime_USE_CUDA=OFF -Donnxruntime_BUILD_UNIT_TESTS=OFF -Donnxruntime_BUILD_SHARED_LIB=OFF`
- `cmake -S /home/tianlei/git/onnxruntime/cmake -B /tmp/ort_fp4_qmoe_cuda_check -Donnxruntime_USE_CUDA=ON -Donnxruntime_BUILD_UNIT_TESTS=OFF -Donnxruntime_BUILD_SHARED_LIB=OFF -Donnxruntime_USE_TENSORRT=OFF -DCMAKE_CUDA_COMPILER=/home/tianlei/cuda13.0/bin/nvcc -Donnxruntime_CUDNN_HOME=/home/tianlei/cudnn_9.23_cuda13`
- `git diff --check`

The CUDA configure cache records `onnxruntime_USE_FP4_QMOE:BOOL=ON`.