### PR TITLE
Bound QMoE workspace with configurable row tiling

### DIFF
--- a/onnxruntime/contrib_ops/cuda/moe/moe_quantization.cc
+++ b/onnxruntime/contrib_ops/cuda/moe/moe_quantization.cc
@@ -26,11 +26,11 @@
 #include "contrib_ops/cpu/utils/debug_macros.h"
 
 #include <algorithm>
+#include <array>
 #include <cstring>
 #include <iostream>
 #include <limits>
 #include <mutex>
-#include <vector>
 
 using namespace onnxruntime::cuda;
 using namespace ::onnxruntime::common;
@@ -72,6 +72,7 @@ bool Fp4GemvSkipExpandDisabled() {
 
 void PrintQMoEKernelDebugInfo(const char* route, int64_t num_rows,
                               int64_t row_tile_size, int64_t final_row_tile_size,
+                              int64_t tactic_m, int64_t final_tactic_m,
                               size_t runner_workspace_bytes, size_t total_scratch_bytes) {
   std::cout << "\x1B[36m"
             << "Operator=QMoE"
@@ -81,11 +82,11 @@ void PrintQMoEKernelDebugInfo(const char* route, int64_t num_rows,
             << " RunnerWorkspaceBytes=" << runner_workspace_bytes
             << " TotalScratchBytes=" << total_scratch_bytes
             << " TacticMBucket="
-            << onnxruntime::llm::kernels::cutlass_kernels::MoeGemmProfiler::bucketM(row_tile_size);
+            << onnxruntime::llm::kernels::cutlass_kernels::MoeGemmProfiler::bucketM(tactic_m);
   if (final_row_tile_size != row_tile_size) {
     std::cout << " FinalRowTileSize=" << final_row_tile_size
               << " FinalTacticMBucket="
-              << onnxruntime::llm::kernels::cutlass_kernels::MoeGemmProfiler::bucketM(final_row_tile_size);
+              << onnxruntime::llm::kernels::cutlass_kernels::MoeGemmProfiler::bucketM(final_tactic_m);
   }
   std::cout << "\x1B[0m" << std::endl;
 }
@@ -195,17 +196,19 @@ QMoE::QMoE(const OpKernelInfo& op_kernel_info) : CudaKernel(op_kernel_info), MoE
       onnxruntime::ParseEnvironmentVariableWithDefault<int>(kEnableQMoEKernelDebugInfo, 0) != 0;
   const auto configured_row_tile_size =
       op_kernel_info.GetConfigOptions().GetConfigEntry(kQMoERowTileSizeConfig);
+  const char* row_tile_size_source = kQMoERowTileSizeConfig;
   if (configured_row_tile_size.has_value()) {
     const auto& value = *configured_row_tile_size;
     const auto parse_result = std::from_chars(value.data(), value.data() + value.size(), row_tile_size_);
     ORT_ENFORCE(parse_result.ec == std::errc{} && parse_result.ptr == value.data() + value.size(),
                 kQMoERowTileSizeConfig, " must be an integer, got '", value, "'.");
   } else {
+    row_tile_size_source = kQMoERowTileSize;
     row_tile_size_ = onnxruntime::ParseEnvironmentVariableWithDefault<int64_t>(
         kQMoERowTileSize, qmoe::kDisabledRowTileSize);
   }
   ORT_ENFORCE(row_tile_size_ == qmoe::kDisabledRowTileSize || qmoe::IsValidRowTileSize(row_tile_size_),
-              kQMoERowTileSizeConfig, " must be 0 (disabled) or an integer in [1, ",
+              row_tile_size_source, " must be 0 (disabled) or an integer in [1, ",
               std::numeric_limits<int>::max(), "], got ", row_tile_size_, ".");
   ORT_ENFORCE(op_kernel_info.GetAttr<int64_t>("expert_weight_bits", &expert_weight_bits_).IsOK());
   ORT_ENFORCE(expert_weight_bits_ == 8 || expert_weight_bits_ == 4,
@@ -893,13 +896,14 @@ Status QMoE::ComputeInternal(OpKernelContext* context) const {
     std::optional<MoeConfig> config2;
     size_t workspace_size = 0;
   };
-  std::vector<int64_t> distinct_tile_rows{row_tile_plan.rows_per_tile};
+  std::array<int64_t, 2> distinct_tile_rows{row_tile_plan.rows_per_tile, 0};
+  size_t distinct_tile_row_count = 1;
   const int64_t final_tile_rows = row_tile_plan.RowsInTile(row_tile_plan.TileCount() - 1);
   if (final_tile_rows != row_tile_plan.rows_per_tile) {
-    distinct_tile_rows.push_back(final_tile_rows);
+    distinct_tile_rows[distinct_tile_row_count++] = final_tile_rows;
   }
-  std::vector<RunnerTileConfig> runner_tile_configs;
-  runner_tile_configs.reserve(distinct_tile_rows.size());
+  std::array<RunnerTileConfig, 2> runner_tile_configs{};
+  size_t runner_tile_config_count = 0;
   size_t workspace_size = 0;
   {
     std::lock_guard<std::mutex> profiler_lock(mGemmProfilerMutex);
@@ -925,14 +929,15 @@ Status QMoE::ComputeInternal(OpKernelContext* context) const {
       if (!tactics.empty()) {
         deterministic_config = tactics[0];
       }
-      for (const int64_t tile_rows : distinct_tile_rows) {
+      for (size_t i = 0; i < distinct_tile_row_count; ++i) {
+        const int64_t tile_rows = distinct_tile_rows[i];
         RunnerTileConfig tile_config{tile_rows, deterministic_config, deterministic_config, 0};
         active_runner->setTactic(tile_config.config1, tile_config.config2);
         tile_config.workspace_size = active_runner->getWorkspaceSize(
             tile_rows, moe_params.hidden_size, moe_params.inter_size, moe_params.num_experts, k_,
             activation_type_, parallelism_config, use_awq);
         workspace_size = std::max(workspace_size, tile_config.workspace_size);
-        runner_tile_configs.push_back(std::move(tile_config));
+        runner_tile_configs[runner_tile_config_count++] = std::move(tile_config);
       }
     } else {
       AllocatorPtr allocator;
@@ -987,7 +992,8 @@ Status QMoE::ComputeInternal(OpKernelContext* context) const {
       MoeGemmId id1(static_cast<int>(fc1_out_size), static_cast<int>(moe_params.hidden_size), dtype, wtype, MoeGemmId::GemmType::Gemm1);
       MoeGemmId id2(static_cast<int>(moe_params.hidden_size), static_cast<int>(moe_params.inter_size), dtype, wtype, MoeGemmId::GemmType::Gemm2);
 
-      for (const int64_t tile_rows : distinct_tile_rows) {
+      for (size_t i = 0; i < distinct_tile_row_count; ++i) {
+        const int64_t tile_rows = distinct_tile_rows[i];
         RunnerTileConfig tile_config;
         tile_config.num_rows = tile_rows;
         if (!stream_is_capturing) {
@@ -1023,7 +1029,7 @@ Status QMoE::ComputeInternal(OpKernelContext* context) const {
             tile_rows, moe_params.hidden_size, moe_params.inter_size, moe_params.num_experts, k_,
             activation_type_, parallelism_config, use_awq);
         workspace_size = std::max(workspace_size, tile_config.workspace_size);
-        runner_tile_configs.push_back(std::move(tile_config));
+        runner_tile_configs[runner_tile_config_count++] = std::move(tile_config);
       }
     }
   }
@@ -1685,6 +1691,7 @@ Status QMoE::ComputeInternal(OpKernelContext* context) const {
     if (enable_kernel_debug_info_) {
       PrintQMoEKernelDebugInfo("fp4_gemv", moe_params.num_rows,
                                moe_params.num_rows, moe_params.num_rows,
+                               expanded, expanded,
                                workspace_size, total_scratch_bytes);
     }
     return Status::OK();
@@ -1847,10 +1854,14 @@ Status QMoE::ComputeInternal(OpKernelContext* context) const {
   for (int64_t tile_index = 0; tile_index < row_tile_plan.TileCount(); ++tile_index) {
     const int64_t row_offset = row_tile_plan.RowOffset(tile_index);
     const int64_t tile_rows = row_tile_plan.RowsInTile(tile_index);
-    const auto tile_config_it =
-        std::find_if(runner_tile_configs.begin(), runner_tile_configs.end(),
-                     [tile_rows](const RunnerTileConfig& config) { return config.num_rows == tile_rows; });
-    ORT_ENFORCE(tile_config_it != runner_tile_configs.end(),
+    const RunnerTileConfig* tile_config = nullptr;
+    for (size_t i = 0; i < runner_tile_config_count; ++i) {
+      if (runner_tile_configs[i].num_rows == tile_rows) {
+        tile_config = &runner_tile_configs[i];
+        break;
+      }
+    }
+    ORT_ENFORCE(tile_config != nullptr,
                 "QMoE did not prepare a runner configuration for row tile size ", tile_rows, ".");
 
     const auto fused_routing = route_tile(row_offset, tile_rows);
@@ -1866,7 +1877,7 @@ Status QMoE::ComputeInternal(OpKernelContext* context) const {
         reinterpret_cast<char*>(output->MutableDataRaw()) + output_byte_offset;
 
     std::lock_guard<std::mutex> profiler_lock(mGemmProfilerMutex);
-    active_runner->setTactic(tile_config_it->config1, tile_config_it->config2);
+    active_runner->setTactic(tile_config->config1, tile_config->config2);
     active_runner->runMoe(
         tile_input,
         nullptr,
@@ -1894,6 +1905,7 @@ Status QMoE::ComputeInternal(OpKernelContext* context) const {
 
   if (enable_kernel_debug_info_) {
     PrintQMoEKernelDebugInfo("grouped_moe", moe_params.num_rows,
+                             row_tile_plan.rows_per_tile, final_tile_rows,
                              row_tile_plan.rows_per_tile, final_tile_rows,
                              workspace_size, total_scratch_bytes);
   }

--- a/onnxruntime/contrib_ops/cuda/moe/moe_quantization.cc
+++ b/onnxruntime/contrib_ops/cuda/moe/moe_quantization.cc
@@ -8,6 +8,7 @@
 #endif
 
 #include "contrib_ops/cuda/moe/moe_quantization.h"
+#include <charconv>
 #include <type_traits>
 #include "core/common/float8.h"
 #include "cutlass/numeric_types.h"
@@ -24,7 +25,9 @@
 #include "contrib_ops/cuda/utils/dump_cuda_tensor.h"
 #include "contrib_ops/cpu/utils/debug_macros.h"
 
+#include <algorithm>
 #include <cstring>
+#include <iostream>
 #include <limits>
 #include <mutex>
 #include <vector>
@@ -65,6 +68,26 @@ bool Fp4GemvAutotuneLogEnabled() {
 
 bool Fp4GemvSkipExpandDisabled() {
   return onnxruntime::ParseEnvironmentVariableWithDefault<int>("ORT_DISABLE_FP4_GEMV_SKIP_EXPAND", 0) == 1;
+}
+
+void PrintQMoEKernelDebugInfo(const char* route, int64_t num_rows,
+                              int64_t row_tile_size, int64_t final_row_tile_size,
+                              size_t runner_workspace_bytes, size_t total_scratch_bytes) {
+  std::cout << "\x1B[36m"
+            << "Operator=QMoE"
+            << " Route=" << route
+            << " Rows=" << num_rows
+            << " RowTileSize=" << row_tile_size
+            << " RunnerWorkspaceBytes=" << runner_workspace_bytes
+            << " TotalScratchBytes=" << total_scratch_bytes
+            << " TacticMBucket="
+            << onnxruntime::llm::kernels::cutlass_kernels::MoeGemmProfiler::bucketM(row_tile_size);
+  if (final_row_tile_size != row_tile_size) {
+    std::cout << " FinalRowTileSize=" << final_row_tile_size
+              << " FinalTacticMBucket="
+              << onnxruntime::llm::kernels::cutlass_kernels::MoeGemmProfiler::bucketM(final_row_tile_size);
+  }
+  std::cout << "\x1B[0m" << std::endl;
 }
 
 const char* QMoEGemvConfigName(onnxruntime::llm::kernels::moe_gemv::MoeGemvConfig config) {
@@ -168,6 +191,22 @@ REGISTER_KERNEL_TYPED(MLFloat16)
 REGISTER_KERNEL_TYPED(BFloat16)
 
 QMoE::QMoE(const OpKernelInfo& op_kernel_info) : CudaKernel(op_kernel_info), MoEBase(op_kernel_info, GetDeviceProp()) {
+  enable_kernel_debug_info_ =
+      onnxruntime::ParseEnvironmentVariableWithDefault<int>(kEnableQMoEKernelDebugInfo, 0) != 0;
+  const auto configured_row_tile_size =
+      op_kernel_info.GetConfigOptions().GetConfigEntry(kQMoERowTileSizeConfig);
+  if (configured_row_tile_size.has_value()) {
+    const auto& value = *configured_row_tile_size;
+    const auto parse_result = std::from_chars(value.data(), value.data() + value.size(), row_tile_size_);
+    ORT_ENFORCE(parse_result.ec == std::errc{} && parse_result.ptr == value.data() + value.size(),
+                kQMoERowTileSizeConfig, " must be an integer, got '", value, "'.");
+  } else {
+    row_tile_size_ = onnxruntime::ParseEnvironmentVariableWithDefault<int64_t>(
+        kQMoERowTileSize, qmoe::kDisabledRowTileSize);
+  }
+  ORT_ENFORCE(row_tile_size_ == qmoe::kDisabledRowTileSize || qmoe::IsValidRowTileSize(row_tile_size_),
+              kQMoERowTileSizeConfig, " must be 0 (disabled) or an integer in [1, ",
+              std::numeric_limits<int>::max(), "], got ", row_tile_size_, ".");
   ORT_ENFORCE(op_kernel_info.GetAttr<int64_t>("expert_weight_bits", &expert_weight_bits_).IsOK());
   ORT_ENFORCE(expert_weight_bits_ == 8 || expert_weight_bits_ == 4,
               "expert_weight_bits must be 4 or 8, but got ", expert_weight_bits_);
@@ -805,12 +844,62 @@ Status QMoE::ComputeInternal(OpKernelContext* context) const {
   onnxruntime::llm::kernels::cutlass_kernels::CutlassMoeFCRunnerInterface* active_runner =
       (fp4_native_available && !route_native_fp4) ? m_fp4_dense_fallback_runner_.get() : m_moe_runner.get();
 
+  // Decide the standalone FP4 GEMV route before sizing grouped-runner scratch. GEMV owns a
+  // different routing/workspace pipeline and remains deliberately untiled. Every other route
+  // reaches runMoe, whose input, router logits, top-k metadata, and output are all row-major and
+  // row-independent, so those pointers can be advanced by a row offset without changing expert
+  // routing or output placement.
+  const bool fp4_decode_regime =
+      use_fp4_dequant_fallback_ ||
+      ((enable_fp4_cutlass_gemm_ || enable_nvfp4_cutlass_gemm_) && fp4_prefill_min_tokens_ > 0 &&
+       moe_params.num_rows < fp4_prefill_min_tokens_);
+  const bool fc1_gemv_sm80_layout = gemv_fp4_fc1_reads_sm80_layout_;
+  const bool fc2_gemv_sm80_layout = gemv_fp4_fc2_reads_sm80_layout_;
+  const bool fp4_gemv_buffers_ready =
+      (enable_fp4_sm80_gemm_
+           ? ((fc1_gemv_sm80_layout ? gemv_fp4_fc1_weights_ != nullptr : gemv_fp4_fc1_weights_decode_ != nullptr) &&
+              (fc2_gemv_sm80_layout ? gemv_fp4_fc2_weights_ != nullptr : gemv_fp4_fc2_weights_decode_ != nullptr))
+           : (gemv_fp4_fc1_weights_ != nullptr && gemv_fp4_fc2_weights_ != nullptr)) &&
+      gemv_fp4_fc1_scales_ != nullptr && gemv_fp4_fc2_scales_ != nullptr;
+  bool use_fp4_gemv = false;
+  if (is_fp4_family && fp4_decode_regime && enable_fp4_gemv_ && is_fused_swiglu &&
+      fp4_gemv_buffers_ready) {
+    namespace gemv = onnxruntime::llm::kernels::moe_gemv;
+    const int64_t expanded = moe_params.num_rows * static_cast<int64_t>(k_);
+    const int64_t fc1_n = moe_params.inter_size * 2;
+    const int gemv_group_size = is_nvfp4 ? 16 : 32;
+    use_fp4_gemv =
+        moe_params.num_rows > 0 && moe_params.num_rows <= 256 && expanded > 0 &&
+        gemv::is_moe_gemv_fp4_supported(sm_, expanded, fc1_n, moe_params.hidden_size, gemv_group_size,
+                                        gemv::MoeGemvConfig::kDefault, fc1_gemv_sm80_layout) &&
+        gemv::is_moe_gemv_fp4_supported(sm_, expanded, moe_params.hidden_size, moe_params.inter_size,
+                                        gemv_group_size, gemv::MoeGemvConfig::kDefault,
+                                        fc2_gemv_sm80_layout);
+  }
+
+  const qmoe::RowTilePlan row_tile_plan =
+      qmoe::MakeRowTilePlan(
+          moe_params.num_rows, row_tile_size_,
+          row_tile_size_ != qmoe::kDisabledRowTileSize && !use_fp4_gemv);
+
   // Profile and capture the best tactics under the profiler mutex, then release the mutex so
   // that scratch allocation, weight dequantization, scale prepping, softmax, and other
   // CPU-bound work can proceed concurrently across QMoE inferences. The mutex is reacquired
   // around setTactic + runMoe because they mutate shared `m_moe_runner` state.
-  std::optional<onnxruntime::llm::kernels::cutlass_kernels::MoeGemmProfiler::Config> config1;
-  std::optional<onnxruntime::llm::kernels::cutlass_kernels::MoeGemmProfiler::Config> config2;
+  using MoeConfig = onnxruntime::llm::kernels::cutlass_kernels::MoeGemmProfiler::Config;
+  struct RunnerTileConfig {
+    int64_t num_rows = 0;
+    std::optional<MoeConfig> config1;
+    std::optional<MoeConfig> config2;
+    size_t workspace_size = 0;
+  };
+  std::vector<int64_t> distinct_tile_rows{row_tile_plan.rows_per_tile};
+  const int64_t final_tile_rows = row_tile_plan.RowsInTile(row_tile_plan.TileCount() - 1);
+  if (final_tile_rows != row_tile_plan.rows_per_tile) {
+    distinct_tile_rows.push_back(final_tile_rows);
+  }
+  std::vector<RunnerTileConfig> runner_tile_configs;
+  runner_tile_configs.reserve(distinct_tile_rows.size());
   size_t workspace_size = 0;
   {
     std::lock_guard<std::mutex> profiler_lock(mGemmProfilerMutex);
@@ -828,13 +917,22 @@ Status QMoE::ComputeInternal(OpKernelContext* context) const {
     // than assuming a null stream is never capturing.
     const bool stream_is_capturing = onnxruntime::llm::common::isCapturing(compute_stream);
 
-    // Use profiler with proper weight type for quantized weights
+    // Use profiler with proper weight type for quantized weights. A partial final tile can land
+    // in a different M bucket, so profile and retain a config for each distinct actual tile size.
     if (onnxruntime::llm::common::getEnvForceDeterministicMOE()) {
       auto tactics = active_runner->getTactics();
+      std::optional<MoeConfig> deterministic_config;
       if (!tactics.empty()) {
-        config1 = tactics[0];
-        config2 = tactics[0];
-        active_runner->setTactic(config1, config2);
+        deterministic_config = tactics[0];
+      }
+      for (const int64_t tile_rows : distinct_tile_rows) {
+        RunnerTileConfig tile_config{tile_rows, deterministic_config, deterministic_config, 0};
+        active_runner->setTactic(tile_config.config1, tile_config.config2);
+        tile_config.workspace_size = active_runner->getWorkspaceSize(
+            tile_rows, moe_params.hidden_size, moe_params.inter_size, moe_params.num_experts, k_,
+            activation_type_, parallelism_config, use_awq);
+        workspace_size = std::max(workspace_size, tile_config.workspace_size);
+        runner_tile_configs.push_back(std::move(tile_config));
       }
     } else {
       AllocatorPtr allocator;
@@ -887,118 +985,123 @@ Status QMoE::ComputeInternal(OpKernelContext* context) const {
 
       // GEMM 1: N=fc1_out_size (doubled for gated), K=hidden_size
       MoeGemmId id1(static_cast<int>(fc1_out_size), static_cast<int>(moe_params.hidden_size), dtype, wtype, MoeGemmId::GemmType::Gemm1);
-      if (!stream_is_capturing) {
-        // profileTactics caches per (GemmId, M bucket); calling it every forward lets decode
-        // (small M) and prefill (large M) each profile and select their own best tile shape.
-        GemmDims dims(static_cast<int64_t>(moe_params.num_rows), static_cast<int64_t>(moe_params.num_rows),
-                      fc1_out_size, static_cast<int64_t>(moe_params.hidden_size));
-        mGemmProfiler.profileTactics(active_runner, dims, id1, compute_stream);
-      }
-      config1 = mGemmProfiler.getBestConfig(static_cast<int>(moe_params.num_rows), id1);
-
-      // GEMM 2
       MoeGemmId id2(static_cast<int>(moe_params.hidden_size), static_cast<int>(moe_params.inter_size), dtype, wtype, MoeGemmId::GemmType::Gemm2);
-      if (!stream_is_capturing) {
-        GemmDims dims(static_cast<int64_t>(moe_params.num_rows), static_cast<int64_t>(moe_params.num_rows),
-                      static_cast<int64_t>(moe_params.hidden_size), static_cast<int64_t>(moe_params.inter_size));
-        mGemmProfiler.profileTactics(active_runner, dims, id2, compute_stream);
-      }
-      config2 = mGemmProfiler.getBestConfig(static_cast<int>(moe_params.num_rows), id2);
 
-      // Capture-safe fallback: if profiling was skipped (graph capture) and no tuned config was
-      // cached from a prior non-capturing run, use the runner's default tactic instead of leaving
-      // the config unset.
-      if (!config1 || !config2) {
-        auto tactics = active_runner->getTactics();
-        if (!tactics.empty()) {
-          if (!config1) {
-            config1 = tactics[0];
-          }
-          if (!config2) {
-            config2 = tactics[0];
+      for (const int64_t tile_rows : distinct_tile_rows) {
+        RunnerTileConfig tile_config;
+        tile_config.num_rows = tile_rows;
+        if (!stream_is_capturing) {
+          // profileTactics caches per (GemmId, M bucket). Use the tile's actual M so both the
+          // configured tile and a non-divisible final tile select tactics from their own bucket.
+          GemmDims dims1(tile_rows, tile_rows, fc1_out_size,
+                         static_cast<int64_t>(moe_params.hidden_size));
+          mGemmProfiler.profileTactics(active_runner, dims1, id1, compute_stream);
+          GemmDims dims2(tile_rows, tile_rows, static_cast<int64_t>(moe_params.hidden_size),
+                         static_cast<int64_t>(moe_params.inter_size));
+          mGemmProfiler.profileTactics(active_runner, dims2, id2, compute_stream);
+        }
+        tile_config.config1 = mGemmProfiler.getBestConfig(static_cast<int>(tile_rows), id1);
+        tile_config.config2 = mGemmProfiler.getBestConfig(static_cast<int>(tile_rows), id2);
+
+        // Capture-safe fallback: if profiling was skipped (graph capture) and no tuned config was
+        // cached from a prior non-capturing run, use the runner's default tactic instead of leaving
+        // the config unset.
+        if (!tile_config.config1 || !tile_config.config2) {
+          auto tactics = active_runner->getTactics();
+          if (!tactics.empty()) {
+            if (!tile_config.config1) {
+              tile_config.config1 = tactics[0];
+            }
+            if (!tile_config.config2) {
+              tile_config.config2 = tactics[0];
+            }
           }
         }
+
+        active_runner->setTactic(tile_config.config1, tile_config.config2);
+        tile_config.workspace_size = active_runner->getWorkspaceSize(
+            tile_rows, moe_params.hidden_size, moe_params.inter_size, moe_params.num_experts, k_,
+            activation_type_, parallelism_config, use_awq);
+        workspace_size = std::max(workspace_size, tile_config.workspace_size);
+        runner_tile_configs.push_back(std::move(tile_config));
       }
-
-      active_runner->setTactic(config1, config2);
     }
-
-    workspace_size = active_runner->getWorkspaceSize(
-        moe_params.num_rows, moe_params.hidden_size, moe_params.inter_size, moe_params.num_experts, k_,
-        activation_type_, parallelism_config, use_awq);
   }
   // Lock released — concurrent QMoE inferences can now run prep work in parallel.
 
-  // Scratch buffer for workspace + expert_scales + expert_indices + permutation_map.
-  // Use checked arithmetic: these byte counts derive adjacent pointer offsets inside one allocation.
-  // expert_scales: num_rows * k * sizeof(float)
-  // expert_indices: num_rows * k * sizeof(int)
-  size_t expanded_rows = SafeInt<size_t>(moe_params.num_rows) * SafeInt<size_t>(k_);
-  size_t scales_bytes = expanded_rows * sizeof(float);
-  size_t indices_bytes = expanded_rows * sizeof(int);
-  size_t permutation_bytes = expanded_rows * sizeof(int);
-  size_t total_scratch_bytes = SafeInt<size_t>(workspace_size) + scales_bytes + indices_bytes + permutation_bytes;
+  // One allocation holds the maximum runner workspace reported for any actual tile plus tile-local
+  // routing metadata. Every tile completes its launches on the same stream before the next tile
+  // reuses these addresses.
+  const qmoe::ScratchLayout scratch_layout =
+      qmoe::MakeScratchLayout(workspace_size, row_tile_plan, k_);
+  const size_t total_scratch_bytes = scratch_layout.total_bytes;
 
   auto work_space = GetScratchBuffer<void>(total_scratch_bytes, GetComputeStream(context));
   char* workspace_ptr = reinterpret_cast<char*>(work_space.get());
   float* expert_scales = reinterpret_cast<float*>(workspace_ptr + workspace_size);
-  int* expert_indices = reinterpret_cast<int*>(workspace_ptr + workspace_size + scales_bytes);
-  int* unpermuted_row_to_permuted_row = reinterpret_cast<int*>(workspace_ptr + workspace_size + scales_bytes + indices_bytes);
+  int* expert_indices =
+      reinterpret_cast<int*>(workspace_ptr + workspace_size + scratch_layout.scales_bytes);
+  int* unpermuted_row_to_permuted_row =
+      reinterpret_cast<int*>(workspace_ptr + workspace_size + scratch_layout.scales_bytes +
+                             scratch_layout.indices_bytes);
 
   cudaStream_t stream = Stream(context);
 
-  // Perform Softmax + TopK
-  // Input router_probs is (num_rows, num_experts)
   bool is_fp16 = input->IsDataType<MLFloat16>();
   bool is_bf16 = input->IsDataType<BFloat16>();
+  auto route_tile = [&](int64_t row_offset, int64_t tile_rows) {
+    onnxruntime::llm::kernels::cutlass_kernels::FusedRoutingParams fused_routing;
+    const size_t router_element_offset =
+        SafeInt<size_t>(row_offset) * SafeInt<size_t>(moe_params.num_experts);
+    const size_t router_byte_offset =
+        SafeInt<size_t>(router_element_offset) * router_probs->DataType()->Size();
+    const void* tile_router_probs =
+        reinterpret_cast<const char*>(router_probs->DataRaw()) + router_byte_offset;
 
-  // Optimization C: at decode the runner can fold softmax + top-k into the kernel that builds the
-  // expert permutation maps, saving a launch per MoE layer. Both are single-block kernels there, so
-  // the launch is most of the cost. The predicate below is the same one runMoe re-checks, so the two
-  // can never disagree about who computed the routing. Excluded for the FP4 family because its
-  // decode fast path below consumes expert_indices/expert_scales itself instead of calling runMoe.
-  onnxruntime::llm::kernels::cutlass_kernels::FusedRoutingParams fused_routing;
-  if (!is_fp4_family &&
-      onnxruntime::llm::kernels::cutlass_kernels::isFusedMoeRoutingSupported(
-          moe_params.num_rows, static_cast<int>(moe_params.num_experts),
-          static_cast<int>(moe_params.num_experts) / parallelism_config.ep_size, static_cast<int>(k_),
-          parallelism_config.ep_size)) {
-    fused_routing.router_logits = router_probs->DataRaw();
-    fused_routing.token_selected_experts = expert_indices;
-    fused_routing.token_final_scales = expert_scales;
-    fused_routing.normalize_routing_weights = normalize_routing_weights_;
-  } else if (is_fp16) {
-    LaunchSoftmaxTopK(
-        reinterpret_cast<const half*>(router_probs->DataRaw()),
-        expert_scales,
-        expert_indices,
-        static_cast<int>(moe_params.num_rows),
-        static_cast<int>(moe_params.num_experts),
-        static_cast<int>(k_),
-        normalize_routing_weights_,
-        stream);
-  } else if (is_bf16) {
-    LaunchSoftmaxTopK(
-        reinterpret_cast<const __nv_bfloat16*>(router_probs->DataRaw()),
-        expert_scales,
-        expert_indices,
-        static_cast<int>(moe_params.num_rows),
-        static_cast<int>(moe_params.num_experts),
-        static_cast<int>(k_),
-        normalize_routing_weights_,
-        stream);
-  } else {
-    // Fallback for float
-    LaunchSoftmaxTopK(
-        reinterpret_cast<const float*>(router_probs->DataRaw()),
-        expert_scales,
-        expert_indices,
-        static_cast<int>(moe_params.num_rows),
-        static_cast<int>(moe_params.num_experts),
-        static_cast<int>(k_),
-        normalize_routing_weights_,
-        stream);
-  }
+    // Fused routing remains limited to an untiled one-row request; a one-row final tile
+    // continues using the same routing implementation as the preceding tiles.
+    if (!row_tile_plan.IsTiled() && !is_fp4_family &&
+        onnxruntime::llm::kernels::cutlass_kernels::isFusedMoeRoutingSupported(
+            tile_rows, static_cast<int>(moe_params.num_experts),
+            static_cast<int>(moe_params.num_experts) / parallelism_config.ep_size,
+            static_cast<int>(k_), parallelism_config.ep_size)) {
+      fused_routing.router_logits = tile_router_probs;
+      fused_routing.token_selected_experts = expert_indices;
+      fused_routing.token_final_scales = expert_scales;
+      fused_routing.normalize_routing_weights = normalize_routing_weights_;
+    } else if (is_fp16) {
+      LaunchSoftmaxTopK(
+          reinterpret_cast<const half*>(tile_router_probs),
+          expert_scales,
+          expert_indices,
+          static_cast<int>(tile_rows),
+          static_cast<int>(moe_params.num_experts),
+          static_cast<int>(k_),
+          normalize_routing_weights_,
+          stream);
+    } else if (is_bf16) {
+      LaunchSoftmaxTopK(
+          reinterpret_cast<const __nv_bfloat16*>(tile_router_probs),
+          expert_scales,
+          expert_indices,
+          static_cast<int>(tile_rows),
+          static_cast<int>(moe_params.num_experts),
+          static_cast<int>(k_),
+          normalize_routing_weights_,
+          stream);
+    } else {
+      LaunchSoftmaxTopK(
+          reinterpret_cast<const float*>(tile_router_probs),
+          expert_scales,
+          expert_indices,
+          static_cast<int>(tile_rows),
+          static_cast<int>(moe_params.num_experts),
+          static_cast<int>(k_),
+          normalize_routing_weights_,
+          stream);
+    }
+    return fused_routing;
+  };
 
   // Holders for packed tensors (if packing is needed for SwiGLU)
   IAllocatorUniquePtr<void> packed_fc1_scales_holder;
@@ -1371,22 +1474,7 @@ Status QMoE::ComputeInternal(OpKernelContext* context) const {
   // block_size_ attribute is unset (-1) for fp4, so it is not part of the gate.
   // When native CUTLASS WFP4A16 is enabled, GEMV serves only the decode regime
   // (num_rows < fp4_prefill_min_tokens_); prefill (M >= threshold) falls through to native.
-  const bool fp4_decode_regime =
-      use_fp4_dequant_fallback_ ||
-      ((enable_fp4_cutlass_gemm_ || enable_nvfp4_cutlass_gemm_) && fp4_prefill_min_tokens_ > 0 &&
-       moe_params.num_rows < fp4_prefill_min_tokens_);
-  // True when the decode GEMV reads the SM80 pair-interleaved prefill buffer directly (single
-  // weight copy) instead of a dedicated GEMV-native copy; see gemv_fp4_fc*_reads_sm80_layout_.
-  const bool fc1_gemv_sm80_layout = gemv_fp4_fc1_reads_sm80_layout_;
-  const bool fc2_gemv_sm80_layout = gemv_fp4_fc2_reads_sm80_layout_;
-  const bool fp4_gemv_buffers_ready =
-      (enable_fp4_sm80_gemm_
-           ? ((fc1_gemv_sm80_layout ? gemv_fp4_fc1_weights_ != nullptr : gemv_fp4_fc1_weights_decode_ != nullptr) &&
-              (fc2_gemv_sm80_layout ? gemv_fp4_fc2_weights_ != nullptr : gemv_fp4_fc2_weights_decode_ != nullptr))
-           : (gemv_fp4_fc1_weights_ != nullptr && gemv_fp4_fc2_weights_ != nullptr)) &&
-      gemv_fp4_fc1_scales_ != nullptr && gemv_fp4_fc2_scales_ != nullptr;
-  if (is_fp4_family && fp4_decode_regime && enable_fp4_gemv_ && is_fused_swiglu &&
-      fp4_gemv_buffers_ready) {
+  if (use_fp4_gemv) {
     namespace gemv = onnxruntime::llm::kernels::moe_gemv;
     namespace ck = onnxruntime::llm::kernels::cutlass_kernels;
     const int num_experts = static_cast<int>(moe_params.num_experts);
@@ -1397,207 +1485,209 @@ Status QMoE::ComputeInternal(OpKernelContext* context) const {
     const int64_t fc1_n = inter * 2;
     // MXFP4 uses block size 32 (e2m1 + e8m0); NVFP4 uses block size 16 (e2m1 + e4m3).
     const int gemv_group_size = is_nvfp4 ? 16 : 32;
-    const bool fc1_gemv_supported = gemv::is_moe_gemv_fp4_supported(sm_, expanded, fc1_n, hidden, gemv_group_size,
-                                                                    gemv::MoeGemvConfig::kDefault, fc1_gemv_sm80_layout);
-    const bool fc2_gemv_supported = gemv::is_moe_gemv_fp4_supported(sm_, expanded, hidden, inter, gemv_group_size,
-                                                                    gemv::MoeGemvConfig::kDefault, fc2_gemv_sm80_layout);
-    if (num_rows > 0 && num_rows <= 256 && expanded > 0 && fc1_gemv_supported && fc2_gemv_supported) {
-      // When the SM80 grouped-GEMM prefill repurposes gemv_fp4_fc*_weights_ for its pair-
-      // interleaved layout, the decode GEMV either un-permutes that same buffer in-register
-      // (fc*_gemv_sm80_layout, the single-copy default) or reads the dedicated GEMV-native copy
-      // in gemv_fp4_fc*_weights_decode_.
-      const uint8_t* gemv_fc1_weight = static_cast<const uint8_t*>(
-          ((enable_fp4_sm80_gemm_ && !fc1_gemv_sm80_layout) ? gemv_fp4_fc1_weights_decode_ : gemv_fp4_fc1_weights_)
-              .get());
-      const uint8_t* gemv_fc2_weight = static_cast<const uint8_t*>(
-          ((enable_fp4_sm80_gemm_ && !fc2_gemv_sm80_layout) ? gemv_fp4_fc2_weights_decode_ : gemv_fp4_fc2_weights_)
-              .get());
-      auto p_r2u_buf = GetScratchBuffer<int>(expanded, GetComputeStream(context));
-      auto p_exp_buf = GetScratchBuffer<int>(expanded, GetComputeStream(context));
-      auto p_efto_buf = GetScratchBuffer<int64_t>(num_experts + 1, GetComputeStream(context));
-      const size_t elt = is_fp16_ ? sizeof(half) : sizeof(__nv_bfloat16);
-      auto p_act_buf = GetScratchBuffer<void>(SafeInt<size_t>(expanded) * hidden * elt, GetComputeStream(context));
-      auto p_fc1_buf = GetScratchBuffer<void>(SafeInt<size_t>(expanded) * inter * elt, GetComputeStream(context));
-      auto p_fc2_buf = GetScratchBuffer<void>(SafeInt<size_t>(expanded) * hidden * elt, GetComputeStream(context));
-      int* p_r2u = p_r2u_buf.get();
-      int* p_exp = p_exp_buf.get();
-      int64_t* p_efto = p_efto_buf.get();
+    // When the SM80 grouped-GEMM prefill repurposes gemv_fp4_fc*_weights_ for its pair-
+    // interleaved layout, the decode GEMV either un-permutes that same buffer in-register
+    // (fc*_gemv_sm80_layout, the single-copy default) or reads the dedicated GEMV-native copy
+    // in gemv_fp4_fc*_weights_decode_.
+    const uint8_t* gemv_fc1_weight = static_cast<const uint8_t*>(
+        ((enable_fp4_sm80_gemm_ && !fc1_gemv_sm80_layout) ? gemv_fp4_fc1_weights_decode_ : gemv_fp4_fc1_weights_)
+            .get());
+    const uint8_t* gemv_fc2_weight = static_cast<const uint8_t*>(
+        ((enable_fp4_sm80_gemm_ && !fc2_gemv_sm80_layout) ? gemv_fp4_fc2_weights_decode_ : gemv_fp4_fc2_weights_)
+            .get());
+    auto p_r2u_buf = GetScratchBuffer<int>(expanded, GetComputeStream(context));
+    auto p_exp_buf = GetScratchBuffer<int>(expanded, GetComputeStream(context));
+    auto p_efto_buf = GetScratchBuffer<int64_t>(num_experts + 1, GetComputeStream(context));
+    const size_t elt = is_fp16_ ? sizeof(half) : sizeof(__nv_bfloat16);
+    auto p_act_buf = GetScratchBuffer<void>(SafeInt<size_t>(expanded) * hidden * elt, GetComputeStream(context));
+    auto p_fc1_buf = GetScratchBuffer<void>(SafeInt<size_t>(expanded) * inter * elt, GetComputeStream(context));
+    auto p_fc2_buf = GetScratchBuffer<void>(SafeInt<size_t>(expanded) * hidden * elt, GetComputeStream(context));
+    int* p_r2u = p_r2u_buf.get();
+    int* p_exp = p_exp_buf.get();
+    int64_t* p_efto = p_efto_buf.get();
 
-      ck::ActivationParams act_params(activation_type_);
-      act_params.alpha = activation_alpha_;
-      act_params.beta = activation_beta_;
-      act_params.swiglu_fusion = swiglu_fusion;
-      act_params.limit = swiglu_limit_;
+    ck::ActivationParams act_params(activation_type_);
+    act_params.alpha = activation_alpha_;
+    act_params.beta = activation_beta_;
+    act_params.swiglu_fusion = swiglu_fusion;
+    act_params.limit = swiglu_limit_;
 
-      ck::fusedBuildExpertMapsSortFirstToken(
-          expert_indices, p_r2u, unpermuted_row_to_permuted_row, p_exp, p_efto,
-          num_rows, num_experts, static_cast<int>(k_), 0, num_experts, stream);
+    const auto fused_routing = route_tile(0, num_rows);
+    ORT_ENFORCE(fused_routing.router_logits == nullptr,
+                "QMoE FP4 GEMV does not support fused routing.");
+    ck::fusedBuildExpertMapsSortFirstToken(
+        expert_indices, p_r2u, unpermuted_row_to_permuted_row, p_exp, p_efto,
+        num_rows, num_experts, static_cast<int>(k_), 0, num_experts, stream);
 
-      const void* fc1_bias = fc1_experts_bias_optional ? fc1_experts_bias_optional->DataRaw() : nullptr;
-      const void* fc2_bias = fc2_experts_bias_optional ? fc2_experts_bias_optional->DataRaw() : nullptr;
+    const void* fc1_bias = fc1_experts_bias_optional ? fc1_experts_bias_optional->DataRaw() : nullptr;
+    const void* fc2_bias = fc2_experts_bias_optional ? fc2_experts_bias_optional->DataRaw() : nullptr;
 
-      using MoeGemvConfig = gemv::MoeGemvConfig;
+    using MoeGemvConfig = gemv::MoeGemvConfig;
 
-      // Choose the fc1 (SwiGLU) and fc2 GEMV tiling configs. Every config computes the same
-      // dot products with the same accumulation dtype, so the only goal is picking the
-      // fastest; Threads does set the K partition, so the low bits of the output can move
-      // between configs (see MoeGemvConfig). Reuse a cached per-shape result when available;
-      // otherwise start from the shape-derived analytic default and, when autotune is on,
-      // profile on a non-captured (warmup) call and freeze the choice for CUDA-graph replay.
-      // During capture (or when autotune is off, which is the shipping default) the analytic
-      // default is what actually runs.
-      const int multi_processor_count = GetDeviceProp().multiProcessorCount;
-      MoeGemvConfig fc1_config =
-          gemv::Fp4MoeGemvDefaultConfig(expanded, fc1_n, hidden, multi_processor_count);
-      MoeGemvConfig fc2_config =
-          gemv::Fp4MoeGemvDefaultConfig(expanded, hidden, inter, multi_processor_count);
+    // Choose the fc1 (SwiGLU) and fc2 GEMV tiling configs. Every config computes the same
+    // dot products with the same accumulation dtype, so the only goal is picking the
+    // fastest; Threads does set the K partition, so the low bits of the output can move
+    // between configs (see MoeGemvConfig). Reuse a cached per-shape result when available;
+    // otherwise start from the shape-derived analytic default and, when autotune is on,
+    // profile on a non-captured (warmup) call and freeze the choice for CUDA-graph replay.
+    // During capture (or when autotune is off, which is the shipping default) the analytic
+    // default is what actually runs.
+    const int multi_processor_count = GetDeviceProp().multiProcessorCount;
+    MoeGemvConfig fc1_config =
+        gemv::Fp4MoeGemvDefaultConfig(expanded, fc1_n, hidden, multi_processor_count);
+    MoeGemvConfig fc2_config =
+        gemv::Fp4MoeGemvDefaultConfig(expanded, hidden, inter, multi_processor_count);
 
-      const int64_t row_bucket =
-          onnxruntime::llm::kernels::cutlass_kernels::MoeGemmProfiler::bucketM(expanded);
-      const Fp4GemvTuneKey tune_key{is_fp16_, row_bucket, hidden, inter, sm_};
-      bool have_tune = false;
-      {
-        std::lock_guard<std::mutex> lock(fp4_gemv_tune_cache_mutex_);
-        const auto cached_tune = fp4_gemv_tune_cache_.find(tune_key);
-        have_tune = cached_tune != fp4_gemv_tune_cache_.end();
-        if (have_tune) {
-          fc1_config = cached_tune->second.fc1_config;
-          fc2_config = cached_tune->second.fc2_config;
-        }
+    const int64_t row_bucket =
+        onnxruntime::llm::kernels::cutlass_kernels::MoeGemmProfiler::bucketM(expanded);
+    const Fp4GemvTuneKey tune_key{is_fp16_, row_bucket, hidden, inter, sm_};
+    bool have_tune = false;
+    {
+      std::lock_guard<std::mutex> lock(fp4_gemv_tune_cache_mutex_);
+      const auto cached_tune = fp4_gemv_tune_cache_.find(tune_key);
+      have_tune = cached_tune != fp4_gemv_tune_cache_.end();
+      if (have_tune) {
+        fc1_config = cached_tune->second.fc1_config;
+        fc2_config = cached_tune->second.fc2_config;
+      }
+    }
+
+    cudaStreamCaptureStatus capture_status = cudaStreamCaptureStatusNone;
+    CUDA_CALL_THROW(cudaStreamIsCapturing(stream, &capture_status));
+    const bool is_capturing = capture_status != cudaStreamCaptureStatusNone;
+    const bool do_tune = enable_fp4_gemv_autotune_ && !have_tune && !is_capturing;
+
+    auto run_fused = [&](auto* t_ptr) {
+      using T = std::remove_pointer_t<decltype(t_ptr)>;
+      const bool skip_expand = fp4_gemv_skip_expand_;
+      if (!skip_expand) {
+        ck::expandInputRowsKernelLauncher<T, T>(
+            static_cast<const T*>(input->DataRaw()), static_cast<T*>(p_act_buf.get()),
+            nullptr, nullptr, p_r2u, num_rows, hidden, static_cast<int>(k_), num_experts,
+            quant_params, false, p_efto, nullptr, nullptr, nullptr, stream);
       }
 
-      cudaStreamCaptureStatus capture_status = cudaStreamCaptureStatusNone;
-      CUDA_CALL_THROW(cudaStreamIsCapturing(stream, &capture_status));
-      const bool is_capturing = capture_status != cudaStreamCaptureStatusNone;
-      const bool do_tune = enable_fp4_gemv_autotune_ && !have_tune && !is_capturing;
-
-      auto run_fused = [&](auto* t_ptr) {
-        using T = std::remove_pointer_t<decltype(t_ptr)>;
-        const bool skip_expand = fp4_gemv_skip_expand_;
-        if (!skip_expand) {
-          ck::expandInputRowsKernelLauncher<T, T>(
-              static_cast<const T*>(input->DataRaw()), static_cast<T*>(p_act_buf.get()),
-              nullptr, nullptr, p_r2u, num_rows, hidden, static_cast<int>(k_), num_experts,
-              quant_params, false, p_efto, nullptr, nullptr, nullptr, stream);
-        }
-
-        auto launch_fc1 = [&](MoeGemvConfig cfg) {
-          gemv::launch_moe_gemv_fp4_symmetric_interleaved_swiglu<T>(
-              skip_expand ? static_cast<const T*>(input->DataRaw()) : static_cast<const T*>(p_act_buf.get()),
-              gemv_fc1_weight,
-              static_cast<const T*>(gemv_fp4_fc1_scales_.get()),
-              static_cast<const T*>(fc1_bias), static_cast<T*>(p_fc1_buf.get()),
-              p_efto, p_exp, num_experts, expanded, inter, hidden, gemv_group_size, sm_, act_params, cfg,
-              fc1_gemv_sm80_layout, skip_expand ? p_r2u : nullptr, num_rows, stream);
-        };
-        auto launch_fc2 = [&](MoeGemvConfig cfg) {
-          gemv::launch_moe_gemv_fp4_symmetric<T>(
-              static_cast<const T*>(p_fc1_buf.get()),
-              gemv_fc2_weight,
-              static_cast<const T*>(gemv_fp4_fc2_scales_.get()),
-              static_cast<const T*>(fc2_bias), static_cast<T*>(p_fc2_buf.get()),
-              p_efto, p_exp, num_experts, expanded, hidden, inter, gemv_group_size, sm_, cfg,
-              fc2_gemv_sm80_layout, stream);
-        };
-
-        if (do_tune) {
-          constexpr MoeGemvConfig kCandidates[] = {
-              MoeGemvConfig::kDefault, MoeGemvConfig::kCtaN16, MoeGemvConfig::kThreads64};
-          constexpr int kWarmup = 3;
-          constexpr int kIters = 20;
-
-          cudaEvent_t start_event = nullptr;
-          cudaEvent_t stop_event = nullptr;
-          CUDA_CALL_THROW(cudaEventCreate(&start_event));
-          std::unique_ptr<CUevent_st, decltype(&cudaEventDestroy)> start_event_guard(start_event, cudaEventDestroy);
-          CUDA_CALL_THROW(cudaEventCreate(&stop_event));
-          std::unique_ptr<CUevent_st, decltype(&cudaEventDestroy)> stop_event_guard(stop_event, cudaEventDestroy);
-
-          auto time_launch = [&](auto&& launch_fn) -> float {
-            for (int i = 0; i < kWarmup; ++i) {
-              launch_fn();
-            }
-            CUDA_CALL_THROW(cudaStreamSynchronize(stream));
-            CUDA_CALL_THROW(cudaEventRecord(start_event, stream));
-            for (int i = 0; i < kIters; ++i) {
-              launch_fn();
-            }
-            CUDA_CALL_THROW(cudaEventRecord(stop_event, stream));
-            CUDA_CALL_THROW(cudaEventSynchronize(stop_event));
-            float elapsed_ms = 0.0f;
-            CUDA_CALL_THROW(cudaEventElapsedTime(&elapsed_ms, start_event, stop_event));
-            return elapsed_ms;
-          };
-
-          // fc1 reads the original input through p_r2u when skip-expand is enabled; otherwise
-          // it reads p_act_buf populated by the expand above.
-          const bool log_tune = enable_fp4_gemv_autotune_log_;
-          float best_fc1 = std::numeric_limits<float>::max();
-          for (MoeGemvConfig cfg : kCandidates) {
-            if (!gemv::is_moe_gemv_fp4_supported(sm_, expanded, fc1_n, hidden, gemv_group_size, cfg,
-                                                 fc1_gemv_sm80_layout)) {
-              continue;
-            }
-            const float ms = time_launch([&] { launch_fc1(cfg); });
-            if (log_tune) {
-              LOGS_DEFAULT(WARNING) << "FP4 GEMV autotune candidate: fc1 expanded=" << expanded
-                                    << " n=" << fc1_n << " k=" << hidden << " cfg=" << QMoEGemvConfigName(cfg)
-                                    << " " << ms << "ms/" << kIters << "it";
-            }
-            if (ms < best_fc1) {
-              best_fc1 = ms;
-              fc1_config = cfg;
-            }
-          }
-          // fc2 reads p_fc1_buf; populate it once with the chosen fc1 config before timing fc2.
-          launch_fc1(fc1_config);
-          float best_fc2 = std::numeric_limits<float>::max();
-          for (MoeGemvConfig cfg : kCandidates) {
-            if (!gemv::is_moe_gemv_fp4_supported(sm_, expanded, hidden, inter, gemv_group_size, cfg,
-                                                 fc2_gemv_sm80_layout)) {
-              continue;
-            }
-            const float ms = time_launch([&] { launch_fc2(cfg); });
-            if (log_tune) {
-              LOGS_DEFAULT(WARNING) << "FP4 GEMV autotune candidate: fc2 expanded=" << expanded
-                                    << " n=" << hidden << " k=" << inter << " cfg=" << QMoEGemvConfigName(cfg)
-                                    << " " << ms << "ms/" << kIters << "it";
-            }
-            if (ms < best_fc2) {
-              best_fc2 = ms;
-              fc2_config = cfg;
-            }
-          }
-
-          {
-            std::lock_guard<std::mutex> lock(fp4_gemv_tune_cache_mutex_);
-            fp4_gemv_tune_cache_.try_emplace(tune_key, Fp4GemvTuneResult{fc1_config, fc2_config});
-          }
-          if (log_tune) {
-            LOGS_DEFAULT(WARNING) << "FP4 GEMV autotune: is_fp16=" << is_fp16_ << " expanded=" << expanded
-                                  << " hidden=" << hidden << " inter=" << inter << " fc1="
-                                  << QMoEGemvConfigName(fc1_config) << " (" << best_fc1 << "ms/" << kIters
-                                  << "it) fc2=" << QMoEGemvConfigName(fc2_config) << " (" << best_fc2 << "ms/"
-                                  << kIters << "it)";
-          }
-        }
-
-        launch_fc1(fc1_config);
-        launch_fc2(fc2_config);
-        ck::finalizeMoeRoutingKernelLauncher<T, T, T>(
-            static_cast<const T*>(p_fc2_buf.get()), static_cast<T*>(output->MutableDataRaw()),
-            nullptr, expert_scales, unpermuted_row_to_permuted_row, p_r2u, expert_indices,
-            p_efto, num_rows, hidden, static_cast<int64_t>(k_), num_experts,
-            parallelism_config, false, stream);
+      auto launch_fc1 = [&](MoeGemvConfig cfg) {
+        gemv::launch_moe_gemv_fp4_symmetric_interleaved_swiglu<T>(
+            skip_expand ? static_cast<const T*>(input->DataRaw()) : static_cast<const T*>(p_act_buf.get()),
+            gemv_fc1_weight,
+            static_cast<const T*>(gemv_fp4_fc1_scales_.get()),
+            static_cast<const T*>(fc1_bias), static_cast<T*>(p_fc1_buf.get()),
+            p_efto, p_exp, num_experts, expanded, inter, hidden, gemv_group_size, sm_, act_params, cfg,
+            fc1_gemv_sm80_layout, skip_expand ? p_r2u : nullptr, num_rows, stream);
+      };
+      auto launch_fc2 = [&](MoeGemvConfig cfg) {
+        gemv::launch_moe_gemv_fp4_symmetric<T>(
+            static_cast<const T*>(p_fc1_buf.get()),
+            gemv_fc2_weight,
+            static_cast<const T*>(gemv_fp4_fc2_scales_.get()),
+            static_cast<const T*>(fc2_bias), static_cast<T*>(p_fc2_buf.get()),
+            p_efto, p_exp, num_experts, expanded, hidden, inter, gemv_group_size, sm_, cfg,
+            fc2_gemv_sm80_layout, stream);
       };
 
-      if (is_fp16_) {
-        run_fused(static_cast<half*>(nullptr));
-      } else {
-        run_fused(static_cast<__nv_bfloat16*>(nullptr));
+      if (do_tune) {
+        constexpr MoeGemvConfig kCandidates[] = {
+            MoeGemvConfig::kDefault, MoeGemvConfig::kCtaN16, MoeGemvConfig::kThreads64};
+        constexpr int kWarmup = 3;
+        constexpr int kIters = 20;
+
+        cudaEvent_t start_event = nullptr;
+        cudaEvent_t stop_event = nullptr;
+        CUDA_CALL_THROW(cudaEventCreate(&start_event));
+        std::unique_ptr<CUevent_st, decltype(&cudaEventDestroy)> start_event_guard(start_event, cudaEventDestroy);
+        CUDA_CALL_THROW(cudaEventCreate(&stop_event));
+        std::unique_ptr<CUevent_st, decltype(&cudaEventDestroy)> stop_event_guard(stop_event, cudaEventDestroy);
+
+        auto time_launch = [&](auto&& launch_fn) -> float {
+          for (int i = 0; i < kWarmup; ++i) {
+            launch_fn();
+          }
+          CUDA_CALL_THROW(cudaStreamSynchronize(stream));
+          CUDA_CALL_THROW(cudaEventRecord(start_event, stream));
+          for (int i = 0; i < kIters; ++i) {
+            launch_fn();
+          }
+          CUDA_CALL_THROW(cudaEventRecord(stop_event, stream));
+          CUDA_CALL_THROW(cudaEventSynchronize(stop_event));
+          float elapsed_ms = 0.0f;
+          CUDA_CALL_THROW(cudaEventElapsedTime(&elapsed_ms, start_event, stop_event));
+          return elapsed_ms;
+        };
+
+        // fc1 reads the original input through p_r2u when skip-expand is enabled; otherwise
+        // it reads p_act_buf populated by the expand above.
+        const bool log_tune = enable_fp4_gemv_autotune_log_;
+        float best_fc1 = std::numeric_limits<float>::max();
+        for (MoeGemvConfig cfg : kCandidates) {
+          if (!gemv::is_moe_gemv_fp4_supported(sm_, expanded, fc1_n, hidden, gemv_group_size, cfg,
+                                               fc1_gemv_sm80_layout)) {
+            continue;
+          }
+          const float ms = time_launch([&] { launch_fc1(cfg); });
+          if (log_tune) {
+            LOGS_DEFAULT(WARNING) << "FP4 GEMV autotune candidate: fc1 expanded=" << expanded
+                                  << " n=" << fc1_n << " k=" << hidden << " cfg=" << QMoEGemvConfigName(cfg)
+                                  << " " << ms << "ms/" << kIters << "it";
+          }
+          if (ms < best_fc1) {
+            best_fc1 = ms;
+            fc1_config = cfg;
+          }
+        }
+        // fc2 reads p_fc1_buf; populate it once with the chosen fc1 config before timing fc2.
+        launch_fc1(fc1_config);
+        float best_fc2 = std::numeric_limits<float>::max();
+        for (MoeGemvConfig cfg : kCandidates) {
+          if (!gemv::is_moe_gemv_fp4_supported(sm_, expanded, hidden, inter, gemv_group_size, cfg,
+                                               fc2_gemv_sm80_layout)) {
+            continue;
+          }
+          const float ms = time_launch([&] { launch_fc2(cfg); });
+          if (log_tune) {
+            LOGS_DEFAULT(WARNING) << "FP4 GEMV autotune candidate: fc2 expanded=" << expanded
+                                  << " n=" << hidden << " k=" << inter << " cfg=" << QMoEGemvConfigName(cfg)
+                                  << " " << ms << "ms/" << kIters << "it";
+          }
+          if (ms < best_fc2) {
+            best_fc2 = ms;
+            fc2_config = cfg;
+          }
+        }
+
+        {
+          std::lock_guard<std::mutex> lock(fp4_gemv_tune_cache_mutex_);
+          fp4_gemv_tune_cache_.try_emplace(tune_key, Fp4GemvTuneResult{fc1_config, fc2_config});
+        }
+        if (log_tune) {
+          LOGS_DEFAULT(WARNING) << "FP4 GEMV autotune: is_fp16=" << is_fp16_ << " expanded=" << expanded
+                                << " hidden=" << hidden << " inter=" << inter << " fc1="
+                                << QMoEGemvConfigName(fc1_config) << " (" << best_fc1 << "ms/" << kIters
+                                << "it) fc2=" << QMoEGemvConfigName(fc2_config) << " (" << best_fc2 << "ms/"
+                                << kIters << "it)";
+        }
       }
-      return Status::OK();
+
+      launch_fc1(fc1_config);
+      launch_fc2(fc2_config);
+      ck::finalizeMoeRoutingKernelLauncher<T, T, T>(
+          static_cast<const T*>(p_fc2_buf.get()), static_cast<T*>(output->MutableDataRaw()),
+          nullptr, expert_scales, unpermuted_row_to_permuted_row, p_r2u, expert_indices,
+          p_efto, num_rows, hidden, static_cast<int64_t>(k_), num_experts,
+          parallelism_config, false, stream);
+    };
+
+    if (is_fp16_) {
+      run_fused(static_cast<half*>(nullptr));
+    } else {
+      run_fused(static_cast<__nv_bfloat16*>(nullptr));
     }
+    if (enable_kernel_debug_info_) {
+      PrintQMoEKernelDebugInfo("fp4_gemv", moe_params.num_rows,
+                               moe_params.num_rows, moe_params.num_rows,
+                               workspace_size, total_scratch_bytes);
+    }
+    return Status::OK();
   }
 
   const void* fc1_weight_data = fc1_experts_weights ? fc1_experts_weights->DataRaw() : nullptr;
@@ -1745,12 +1835,40 @@ Status QMoE::ComputeInternal(OpKernelContext* context) const {
     fc2_weight_data = dequant_fc2_weights.get();
   }
 
-  // Set tactic and run MoE. Must hold the mutex since setTactic mutates runner state.
-  {
+  onnxruntime::llm::kernels::cutlass_kernels::ActivationParams activation_params(activation_type_);
+  activation_params.alpha = activation_alpha_;
+  activation_params.beta = activation_beta_;
+  activation_params.swiglu_fusion = swiglu_fusion;
+  activation_params.limit = swiglu_limit_;
+
+  // Route and execute each row tile in order on the same stream. The tile-local top-k metadata and
+  // runner workspace are safe to reuse because the next tile's writes are ordered after all kernels
+  // from the previous runMoe call. Tactic mutation remains serialized across concurrent QMoE calls.
+  for (int64_t tile_index = 0; tile_index < row_tile_plan.TileCount(); ++tile_index) {
+    const int64_t row_offset = row_tile_plan.RowOffset(tile_index);
+    const int64_t tile_rows = row_tile_plan.RowsInTile(tile_index);
+    const auto tile_config_it =
+        std::find_if(runner_tile_configs.begin(), runner_tile_configs.end(),
+                     [tile_rows](const RunnerTileConfig& config) { return config.num_rows == tile_rows; });
+    ORT_ENFORCE(tile_config_it != runner_tile_configs.end(),
+                "QMoE did not prepare a runner configuration for row tile size ", tile_rows, ".");
+
+    const auto fused_routing = route_tile(row_offset, tile_rows);
+    const size_t input_element_offset =
+        SafeInt<size_t>(row_offset) * SafeInt<size_t>(moe_params.hidden_size);
+    const size_t input_byte_offset =
+        SafeInt<size_t>(input_element_offset) * input->DataType()->Size();
+    const size_t output_byte_offset =
+        SafeInt<size_t>(input_element_offset) * output->DataType()->Size();
+    const void* tile_input =
+        reinterpret_cast<const char*>(input->DataRaw()) + input_byte_offset;
+    void* tile_output =
+        reinterpret_cast<char*>(output->MutableDataRaw()) + output_byte_offset;
+
     std::lock_guard<std::mutex> profiler_lock(mGemmProfilerMutex);
-    active_runner->setTactic(config1, config2);
+    active_runner->setTactic(tile_config_it->config1, tile_config_it->config2);
     active_runner->runMoe(
-        input->DataRaw(),
+        tile_input,
         nullptr,
         expert_indices,
         expert_scales,
@@ -1760,25 +1878,24 @@ Status QMoE::ComputeInternal(OpKernelContext* context) const {
         fc2_weight_data,
         fc2_experts_bias_optional ? fc2_experts_bias_optional->DataRaw() : nullptr,
         quant_params,
-        moe_params.num_rows,
+        tile_rows,
         moe_params.hidden_size,
         moe_params.inter_size,
         moe_params.num_experts,
         k_,
         workspace_ptr,
-        output->MutableDataRaw(),
+        tile_output,
         unpermuted_row_to_permuted_row,
         parallelism_config,
-        [&]() {
-          onnxruntime::llm::kernels::cutlass_kernels::ActivationParams params(activation_type_);
-          params.alpha = activation_alpha_;
-          params.beta = activation_beta_;
-          params.swiglu_fusion = swiglu_fusion;
-          params.limit = swiglu_limit_;
-          return params;
-        }(),
+        activation_params,
         fused_routing,
         stream);
+  }
+
+  if (enable_kernel_debug_info_) {
+    PrintQMoEKernelDebugInfo("grouped_moe", moe_params.num_rows,
+                             row_tile_plan.rows_per_tile, final_tile_rows,
+                             workspace_size, total_scratch_bytes);
   }
 
   return Status::OK();

--- a/onnxruntime/contrib_ops/cuda/moe/moe_quantization.h
+++ b/onnxruntime/contrib_ops/cuda/moe/moe_quantization.h
@@ -6,6 +6,7 @@
 #include "core/common/common.h"
 #include "core/providers/cuda/cuda_kernel.h"
 #include "contrib_ops/cuda/moe/moe_base.h"
+#include "contrib_ops/cuda/moe/qmoe_row_tiling.h"
 #include "contrib_ops/cuda/llm/moe_gemm/moe_kernels.h"
 #include "contrib_ops/cuda/llm/moe_gemm/moe_gemm_profiler.h"
 #include "contrib_ops/cuda/llm/moe_gemm/moe_gemv_fp4.h"
@@ -18,6 +19,10 @@ namespace contrib {
 namespace cuda {
 
 using namespace onnxruntime::cuda;
+
+constexpr const char* kEnableQMoEKernelDebugInfo = "ORT_ENABLE_QMOE_KERNEL_DEBUG_INFO";
+constexpr const char* kQMoERowTileSize = "ORT_QMOE_ROW_TILE_SIZE";
+constexpr const char* kQMoERowTileSizeConfig = "ep.cuda.qmoe_row_tile_size";
 
 class QMoE final : public CudaKernel, public MoEBase {
  public:
@@ -96,6 +101,8 @@ class QMoE final : public CudaKernel, public MoEBase {
   // dequantize MXFP4 weights to FP16/BF16 and run the dense A16 MoE runner.
   bool use_wfp4afp8_dequant_fallback_ = false;
   std::string quant_type_;  // "int", "fp4", "nvfp4", "fp8", or "wfp4afp8"
+  bool enable_kernel_debug_info_ = false;
+  int64_t row_tile_size_ = qmoe::kDisabledRowTileSize;
 
   std::unique_ptr<onnxruntime::llm::kernels::cutlass_kernels::CutlassMoeFCRunnerInterface> m_moe_runner;
 

--- a/onnxruntime/contrib_ops/cuda/moe/qmoe_row_tiling.h
+++ b/onnxruntime/contrib_ops/cuda/moe/qmoe_row_tiling.h
@@ -1,0 +1,85 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <limits>
+
+#include "core/common/common.h"
+#include "core/common/safeint.h"
+
+namespace onnxruntime {
+namespace contrib {
+namespace cuda {
+namespace qmoe {
+
+constexpr int64_t kDisabledRowTileSize = 0;
+
+constexpr bool IsValidRowTileSize(int64_t row_tile_size) {
+  return row_tile_size > 0 && row_tile_size <= std::numeric_limits<int>::max();
+}
+
+struct RowTilePlan {
+  int64_t num_rows;
+  int64_t rows_per_tile;
+
+  int64_t TileCount() const {
+    return num_rows / rows_per_tile + (num_rows % rows_per_tile != 0 ? 1 : 0);
+  }
+
+  int64_t RowOffset(int64_t tile_index) const {
+    ORT_ENFORCE(tile_index >= 0 && tile_index < TileCount(),
+                "QMoE row tile index ", tile_index, " is outside [0, ", TileCount(), ").");
+    return SafeInt<int64_t>(tile_index) * rows_per_tile;
+  }
+
+  int64_t RowsInTile(int64_t tile_index) const {
+    return std::min(rows_per_tile, num_rows - RowOffset(tile_index));
+  }
+
+  bool IsTiled() const {
+    return rows_per_tile < num_rows;
+  }
+};
+
+inline RowTilePlan MakeRowTilePlan(int64_t num_rows, int64_t row_tile_size, bool enable_tiling) {
+  ORT_ENFORCE(num_rows > 0, "QMoE row tiling requires a positive row count, got ", num_rows, ".");
+  if (!enable_tiling) {
+    return RowTilePlan{num_rows, num_rows};
+  }
+  ORT_ENFORCE(IsValidRowTileSize(row_tile_size),
+              "QMoE row tile size must be in [1, ", std::numeric_limits<int>::max(),
+              "], got ", row_tile_size, ".");
+  return RowTilePlan{num_rows, std::min(num_rows, row_tile_size)};
+}
+
+struct ScratchLayout {
+  size_t scales_bytes;
+  size_t indices_bytes;
+  size_t permutation_bytes;
+  size_t total_bytes;
+};
+
+inline ScratchLayout MakeScratchLayout(size_t runner_workspace_bytes,
+                                       const RowTilePlan& row_tile_plan,
+                                       int64_t experts_per_token) {
+  ORT_ENFORCE(experts_per_token > 0,
+              "QMoE scratch layout requires a positive experts-per-token count, got ",
+              experts_per_token, ".");
+
+  const SafeInt<size_t> expanded_rows =
+      SafeInt<size_t>(row_tile_plan.rows_per_tile) * SafeInt<size_t>(experts_per_token);
+  const size_t scales_bytes = expanded_rows * sizeof(float);
+  const size_t indices_bytes = expanded_rows * sizeof(int);
+  const size_t permutation_bytes = expanded_rows * sizeof(int);
+  const size_t total_bytes = SafeInt<size_t>(runner_workspace_bytes) +
+                             scales_bytes + indices_bytes + permutation_bytes;
+  return ScratchLayout{scales_bytes, indices_bytes, permutation_bytes, total_bytes};
+}
+
+}  // namespace qmoe
+}  // namespace cuda
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/test/contrib_ops/qmoe_row_tiling_test.cc
+++ b/onnxruntime/test/contrib_ops/qmoe_row_tiling_test.cc
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <limits>
+
+#include "contrib_ops/cuda/moe/qmoe_row_tiling.h"
+#include "gtest/gtest.h"
+
+namespace onnxruntime {
+namespace test {
+
+namespace qmoe = contrib::cuda::qmoe;
+
+TEST(QMoERowTilingTest, PartitionsRowsIncludingPartialFinalTile) {
+  const auto plan = qmoe::MakeRowTilePlan(65, 16, true);
+
+  EXPECT_TRUE(plan.IsTiled());
+  EXPECT_EQ(plan.rows_per_tile, 16);
+  EXPECT_EQ(plan.TileCount(), 5);
+  EXPECT_EQ(plan.RowOffset(0), 0);
+  EXPECT_EQ(plan.RowsInTile(0), 16);
+  EXPECT_EQ(plan.RowOffset(4), 64);
+  EXPECT_EQ(plan.RowsInTile(4), 1);
+}
+
+TEST(QMoERowTilingTest, CanKeepRowsUntiled) {
+  const auto plan = qmoe::MakeRowTilePlan(65, qmoe::kDisabledRowTileSize, false);
+
+  EXPECT_FALSE(plan.IsTiled());
+  EXPECT_EQ(plan.rows_per_tile, 65);
+  EXPECT_EQ(plan.TileCount(), 1);
+  EXPECT_EQ(plan.RowsInTile(0), 65);
+}
+
+TEST(QMoERowTilingTest, DefaultsToUntiledExecution) {
+  const auto plan = qmoe::MakeRowTilePlan(512, qmoe::kDisabledRowTileSize, false);
+
+  EXPECT_FALSE(plan.IsTiled());
+  EXPECT_EQ(plan.rows_per_tile, 512);
+  EXPECT_EQ(plan.TileCount(), 1);
+}
+
+TEST(QMoERowTilingTest, RejectsInvalidConfiguration) {
+  EXPECT_FALSE(qmoe::IsValidRowTileSize(0));
+  EXPECT_FALSE(qmoe::IsValidRowTileSize(-1));
+  EXPECT_FALSE(qmoe::IsValidRowTileSize(static_cast<int64_t>(std::numeric_limits<int>::max()) + 1));
+  EXPECT_THROW((void)qmoe::MakeRowTilePlan(65, 0, true), OnnxRuntimeException);
+}
+
+TEST(QMoERowTilingTest, BoundsRoutingScratchByTileSize) {
+  constexpr size_t runner_workspace_bytes = 1024;
+  const auto tiled_plan = qmoe::MakeRowTilePlan(65, 16, true);
+  const auto untiled_plan = qmoe::MakeRowTilePlan(65, 16, false);
+  const auto tiled = qmoe::MakeScratchLayout(runner_workspace_bytes, tiled_plan, 2);
+  const auto untiled = qmoe::MakeScratchLayout(runner_workspace_bytes, untiled_plan, 2);
+
+  EXPECT_EQ(tiled.scales_bytes, 128);
+  EXPECT_EQ(tiled.indices_bytes, 128);
+  EXPECT_EQ(tiled.permutation_bytes, 128);
+  EXPECT_EQ(tiled.total_bytes, 1408);
+  EXPECT_LT(tiled.total_bytes, untiled.total_bytes);
+}
+
+}  // namespace test
+}  // namespace onnxruntime

--- a/onnxruntime/test/python/transformers/test_qmoe_cuda.py
+++ b/onnxruntime/test/python/transformers/test_qmoe_cuda.py
@@ -2730,7 +2730,17 @@ class TestQMoEIntPrePackSmoke(unittest.TestCase):
                 self.assertTrue(torch.equal(scales, torch.tensor([1.0])))
                 self.assertTrue(torch.equal(qweight, expected_qweight))
 
-    def _run_one(self, *, hidden_size, inter_size, num_experts, top_k, swiglu_fusion, batch_size):
+    def _run_one(
+        self,
+        *,
+        hidden_size,
+        inter_size,
+        num_experts,
+        top_k,
+        swiglu_fusion,
+        batch_size,
+        row_tile_size=None,
+    ):
         torch.manual_seed(123)
         numpy.random.seed(123)
 
@@ -2800,7 +2810,13 @@ class TestQMoEIntPrePackSmoke(unittest.TestCase):
         )
         model.ir_version = 10
 
-        sess = onnxruntime.InferenceSession(model.SerializeToString(), providers=ort_provider)
+        session_options = None
+        if row_tile_size is not None:
+            session_options = onnxruntime.SessionOptions()
+            session_options.add_session_config_entry("ep.cuda.qmoe_row_tile_size", str(row_tile_size))
+        sess = onnxruntime.InferenceSession(
+            model.SerializeToString(), sess_options=session_options, providers=ort_provider
+        )
         x = numpy.random.randn(batch_size, hidden_size).astype(numpy.float16)
         router = numpy.random.randn(batch_size, num_experts).astype(numpy.float16)
         out = sess.run(None, {"x": x, "router": router})[0]
@@ -2815,6 +2831,7 @@ class TestQMoEIntPrePackSmoke(unittest.TestCase):
         # indicate the PrePack hook silently produced wrong bytes.
         self.assertGreater(numpy.abs(out).mean(), 1e-4, "Output is suspiciously close to zero")
         self.assertLess(numpy.abs(out).max(), 10.0, "Output magnitude is implausibly large")
+        return out
 
     def _run_default_prepacked_model(
         self,
@@ -2987,6 +3004,25 @@ class TestQMoEIntPrePackSmoke(unittest.TestCase):
 
     def test_int4_swiglu_interleaved_medium(self):
         self._run_one(hidden_size=128, inter_size=64, num_experts=8, top_k=2, swiglu_fusion=1, batch_size=16)
+
+    def test_int4_grouped_moe_row_tiling_parity(self):
+        shape = dict(
+            hidden_size=128,
+            inter_size=128,
+            num_experts=8,
+            top_k=2,
+            swiglu_fusion=1,
+            batch_size=65,
+        )
+        tiled_output = self._run_one(**shape, row_tile_size=16)
+        untiled_output = self._run_one(**shape, row_tile_size=1024)
+        max_diff = numpy.max(numpy.abs(untiled_output.astype(numpy.float32) - tiled_output.astype(numpy.float32)))
+
+        self.assertLess(
+            max_diff,
+            0.02,
+            f"INT4 grouped-MoE row-tiled output differs from untiled output: max_diff={max_diff:.6f}",
+        )
 
 
 class TestQMoECudaGraph(unittest.TestCase):


### PR DESCRIPTION
## Summary

Add optional row tiling to the CUDA grouped-QMoE path to bound temporary workspace usage for larger inputs.

Tiling is disabled by default, preserving the existing execution path. Applications can configure the maximum rows per tile for each ORT session:

```json
"session_options": {
  "ep.cuda.qmoe_row_tile_size": "64"
}
```

Each tile runs sequentially on the same CUDA stream and reuses its routing metadata and runner workspace.

## Changes

- Add row-tile planning and bounded scratch-layout helpers.
- Reuse the grouped-MoE workspace across sequential row tiles.
- Add the `ep.cuda.qmoe_row_tile_size` session configuration entry.
- Keep `ORT_QMOE_ROW_TILE_SIZE` as a compatibility fallback.
- Add optional QMoE diagnostics for route, tile size, workspace size, and tactic bucket.

## Qualification

- End-to-end generation produced identical token output with tiling enabled.
- In the qualified large MoE workload, a 64-row tile reduced QMoE temporary scratch from approximately 64 MB to 32 MB.

Row tiling remains opt-in.