### PR TITLE
Improve PagedAttention dispatch diagnostics

### DIFF
--- a/onnxruntime/contrib_ops/cuda/bert/attention_kernel_options.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/attention_kernel_options.cc
@@ -175,6 +175,16 @@ void AttentionKernelDebugInfo::Print(const char* operator_name,
     sstream << "MATH";
   }
 
+  if (num_splits.has_value()) {
+    sstream << " NumSplits=" << num_splits.value();
+  }
+  if (gqa_group_size.has_value()) {
+    sstream << " GqaGroupSize=" << gqa_group_size.value();
+  }
+  if (effective_kv_length_bound.has_value()) {
+    sstream << " EffectiveKvLengthBound=" << effective_kv_length_bound.value();
+  }
+
   // Output text in Cyan color to make it easier to spot.
   std::cout << "\x1B[36m" << sstream.str() << "\x1B[0m" << std::endl;
 }

--- a/onnxruntime/contrib_ops/cuda/bert/attention_kernel_options.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/attention_kernel_options.cc
@@ -151,7 +151,9 @@ void AttentionKernelDebugInfo::Print(const char* operator_name,
   }
 
   sstream << " SdpaKernel=";
-  if (use_xqa.has_value() && use_xqa.value()) {
+  if (use_latent_attention.has_value() && use_latent_attention.value()) {
+    sstream << "LATENT_ATTENTION";
+  } else if (use_xqa.has_value() && use_xqa.value()) {
     sstream << "XQA";
   } else if (use_flash_attention.has_value() && use_flash_attention.value()) {
     sstream << "FLASH_ATTENTION";

--- a/onnxruntime/contrib_ops/cuda/bert/attention_kernel_options.h
+++ b/onnxruntime/contrib_ops/cuda/bert/attention_kernel_options.h
@@ -17,6 +17,9 @@ struct AttentionKernelDebugInfo {
   std::optional<bool> use_trt_flash_attention = std::nullopt;
   std::optional<bool> use_trt_cross_attention = std::nullopt;
   std::optional<bool> use_decoder_attention = std::nullopt;
+  std::optional<int> num_splits = std::nullopt;
+  std::optional<int> gqa_group_size = std::nullopt;
+  std::optional<int> effective_kv_length_bound = std::nullopt;
   void SetTrtFusedKernel(bool enable_trt_flash_attention, int sequence_length);
   void Print(const char* operator_name, const std::string& node_name, bool is_float16, bool is_bfloat16) const;
 };

--- a/onnxruntime/contrib_ops/cuda/bert/attention_kernel_options.h
+++ b/onnxruntime/contrib_ops/cuda/bert/attention_kernel_options.h
@@ -8,6 +8,7 @@
 
 namespace onnxruntime {
 struct AttentionKernelDebugInfo {
+  std::optional<bool> use_latent_attention = std::nullopt;
   std::optional<bool> use_xqa = std::nullopt;
   std::optional<bool> use_flash_attention = std::nullopt;
   std::optional<bool> use_lean_attention = std::nullopt;

--- a/onnxruntime/contrib_ops/cuda/bert/paged_attention.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/paged_attention.cc
@@ -650,6 +650,7 @@ Status PagedAttention<T, TCACHE>::ComputeInternal(OpKernelContext* context) cons
   // Print debug info
   if (kernel_options_->AllowDebugInfo()) {
     AttentionKernelDebugInfo debug_info;
+    debug_info.use_latent_attention = use_latent_attention;
     debug_info.use_xqa = use_xqa_decode;
     debug_info.use_flash_attention = use_flash_attention;
     debug_info.use_efficient_attention = use_memory_efficient_attention;

--- a/onnxruntime/contrib_ops/cuda/bert/paged_attention.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/paged_attention.cc
@@ -650,9 +650,16 @@ Status PagedAttention<T, TCACHE>::ComputeInternal(OpKernelContext* context) cons
   // Print debug info
   if (kernel_options_->AllowDebugInfo()) {
     AttentionKernelDebugInfo debug_info;
+    debug_info.use_xqa = use_xqa_decode;
     debug_info.use_flash_attention = use_flash_attention;
     debug_info.use_efficient_attention = use_memory_efficient_attention;
-    debug_info.use_decoder_attention = use_paged_decode;
+    debug_info.use_decoder_attention = use_paged_decode && !use_xqa_decode;
+    if (use_paged_decode && !use_xqa_decode) {
+      debug_info.num_splits = num_splits;
+    }
+    debug_info.gqa_group_size = parameters.num_heads / parameters.kv_num_heads;
+    debug_info.effective_kv_length_bound =
+        parameters.local_window_size > 0 ? std::min(max_kv_len, parameters.local_window_size) : max_kv_len;
 
     debug_info.Print("PagedAttention",
                      this->Node().Name(),

--- a/onnxruntime/test/contrib_ops/paged_attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/paged_attention_op_test.cc
@@ -17,6 +17,7 @@
 
 #include "gtest/gtest.h"
 
+#include "contrib_ops/cpu/bert/attention_common.h"
 #include "core/graph/model.h"
 #include "core/graph/node_attr_utils.h"
 #include "core/session/IOBinding.h"
@@ -25,6 +26,7 @@
 #include "test/common/tensor_op_test_utils.h"
 #include "test/providers/provider_test_utils.h"
 #include "test/unittest_util/framework_test_utils.h"
+#include "test/util/include/scoped_env_vars.h"
 #include "test/util/include/test_environment.h"
 
 namespace onnxruntime {
@@ -483,6 +485,29 @@ TEST(PagedAttention, Cuda_AliasedCache_IOBinding) {
     GTEST_SKIP() << "CUDA EP not available.";
   }
   RunIoBindingCase(DefaultCudaExecutionProvider(), kCudaExecutionProvider, true);
+}
+
+TEST(PagedAttention, Cuda_DebugInfoIncludesDispatchBounds) {
+  ScopedEnvironmentVariables scoped_env_vars{
+      EnvVarMap{
+          {onnxruntime::contrib::attention::kDisableFlashAttention, "1"},
+          {onnxruntime::contrib::attention::kDisableMemoryEfficientAttention, "1"},
+          {onnxruntime::contrib::attention::kDisableDecoderAttention, "0"},
+          {onnxruntime::contrib::attention::kEnableAttentionKernelDebugInfo, "1"}}};
+
+  if (DefaultCudaExecutionProvider() == nullptr) {
+    GTEST_SKIP() << "CUDA EP not available.";
+  }
+
+  testing::internal::CaptureStdout();
+  RunIoBindingCase(DefaultCudaExecutionProvider(), kCudaExecutionProvider, true);
+  const std::string debug_output = testing::internal::GetCapturedStdout();
+
+  EXPECT_NE(debug_output.find("Operator=PagedAttention"), std::string::npos) << debug_output;
+  EXPECT_NE(debug_output.find("SdpaKernel=DECODER_ATTENTION"), std::string::npos) << debug_output;
+  EXPECT_NE(debug_output.find("NumSplits=2"), std::string::npos) << debug_output;
+  EXPECT_NE(debug_output.find("GqaGroupSize=1"), std::string::npos) << debug_output;
+  EXPECT_NE(debug_output.find("EffectiveKvLengthBound=256"), std::string::npos) << debug_output;
 }
 
 TEST(PagedAttention, WebGpu_AliasedCache_IOBinding) {

--- a/onnxruntime/test/providers/cuda/test_cases/attention_kernel_options_test.cc
+++ b/onnxruntime/test/providers/cuda/test_cases/attention_kernel_options_test.cc
@@ -16,6 +16,17 @@ using onnxruntime::contrib::attention::AttentionBackend;
 namespace onnxruntime {
 namespace test {
 
+TEST(AttentionKernelDebugInfoTest, LatentAttention) {
+  AttentionKernelDebugInfo debug_info;
+  debug_info.use_latent_attention = true;
+
+  testing::internal::CaptureStdout();
+  debug_info.Print("PagedAttention", "", true, false);
+  const std::string debug_output = testing::internal::GetCapturedStdout();
+
+  EXPECT_NE(debug_output.find("SdpaKernel=LATENT_ATTENTION"), std::string::npos) << debug_output;
+}
+
 TEST(AttentionKernelOptionsTest, NonZeroValue) {
   {
     AttentionKernelOptions options;


### PR DESCRIPTION
### Summary

Extend the existing CUDA attention debug output with PagedAttention-specific dispatch details.

When `ORT_ENABLE_ATTENTION_KERNEL_DEBUG_INFO=1`, `PagedAttention` now reports:

 - the selected backend, including XQA versus portable paged decode;
 - the number of decode splits;
 - the GQA group size;
 - the effective KV-length bound after applying the local window;

This makes it easier to verify that an intended optimized path is selected instead of silently falling back. The diagnostics are opt-in and do not change kernel selection or execution when disabled.