### PR TITLE
Fix session memory reclamation

### DIFF
--- a/include/onnxruntime/core/framework/allocator.h
+++ b/include/onnxruntime/core/framework/allocator.h
@@ -363,6 +363,10 @@ void AllocatorDefaultFree(void* p);
 void* AllocatorDefaultAllocAligned(size_t size, size_t alignment);
 void AllocatorDefaultFreeAligned(void* p, size_t alignment);
 
+// Ask the process allocator to release unused pages to the operating system.
+// This is a no-op when the active allocator does not provide such an operation.
+void ReleaseFreedMemoryToOS() noexcept;
+
 class IArena : public IAllocator {
  public:
   using IAllocator::IAllocator;

--- a/onnxruntime/core/framework/allocator.cc
+++ b/onnxruntime/core/framework/allocator.cc
@@ -17,6 +17,14 @@
 #include <mimalloc.h>
 #endif
 
+#if defined(__GLIBC__)
+#include <malloc.h>
+#endif
+
+#if defined(__linux__) && !defined(__ANDROID__) && !defined(USE_MIMALLOC)
+#include <dlfcn.h>
+#endif
+
 #include "core/framework/bfc_arena.h"
 
 using namespace onnxruntime;
@@ -192,6 +200,23 @@ void* AllocateBufferWithOptions(IAllocator& alloc, size_t size, bool use_reserve
 
 IArena* IArena::SafeArenaCast(IAllocator* allocator) {
   return allocator ? allocator->AsArena() : nullptr;
+}
+
+void ReleaseFreedMemoryToOS() noexcept {
+#if defined(USE_MIMALLOC)
+  mi_collect(true);
+#elif defined(__linux__) && !defined(__ANDROID__)
+  // Collect mimalloc heaps when mimalloc is available through LD_PRELOAD.
+  using MiCollectFn = void (*)(bool);
+  static const auto mi_collect_fn = reinterpret_cast<MiCollectFn>(dlsym(RTLD_DEFAULT, "mi_collect"));
+  if (mi_collect_fn != nullptr) {
+    mi_collect_fn(true);
+  }
+
+#if defined(__GLIBC__)
+  malloc_trim(0);
+#endif
+#endif
 }
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/framework/allocator.cc
+++ b/onnxruntime/core/framework/allocator.cc
@@ -10,7 +10,10 @@
 #include "core/mlas/inc/mlas.h"
 #include "core/framework/utils.h"
 #include "core/session/ort_apis.h"
+#include <atomic>
+#include <chrono>
 #include <cstdlib>
+#include <limits>
 #include <sstream>
 
 #if defined(USE_MIMALLOC)
@@ -202,7 +205,40 @@ IArena* IArena::SafeArenaCast(IAllocator* allocator) {
   return allocator ? allocator->AsArena() : nullptr;
 }
 
+#if defined(USE_MIMALLOC) || (defined(__linux__) && !defined(__ANDROID__))
+namespace {
+
+bool ShouldReleaseFreedMemoryToOS() noexcept {
+  // Allocator-wide purges can be expensive. Coalesce bursts of session destruction
+  // while ensuring that the first release returns unused pages immediately.
+  constexpr int64_t kReleaseIntervalNs =
+      std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::seconds{1}).count();
+  static std::atomic<int64_t> next_release_time_ns{std::numeric_limits<int64_t>::min()};
+
+  const int64_t now_ns = static_cast<int64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(
+                                                  std::chrono::steady_clock::now().time_since_epoch())
+                                                  .count());
+  int64_t next_release_ns = next_release_time_ns.load(std::memory_order_relaxed);
+  while (now_ns >= next_release_ns) {
+    if (next_release_time_ns.compare_exchange_weak(next_release_ns, now_ns + kReleaseIntervalNs,
+                                                   std::memory_order_relaxed)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+}  // namespace
+#endif
+
 void ReleaseFreedMemoryToOS() noexcept {
+#if defined(USE_MIMALLOC) || (defined(__linux__) && !defined(__ANDROID__))
+  if (!ShouldReleaseFreedMemoryToOS()) {
+    return;
+  }
+#endif
+
 #if defined(USE_MIMALLOC)
   mi_collect(true);
 #elif defined(__linux__) && !defined(__ANDROID__)

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -5030,7 +5030,14 @@ ORT_API(void, OrtApis::ReleaseEnv, OrtEnv* value) {
 
 DEFINE_RELEASE_ORT_OBJECT_FUNCTION(Value, OrtValue)
 DEFINE_RELEASE_ORT_OBJECT_FUNCTION(RunOptions, OrtRunOptions)
-DEFINE_RELEASE_ORT_OBJECT_FUNCTION(Session, ::onnxruntime::InferenceSession)
+ORT_API(void, OrtApis::ReleaseSession, _Frees_ptr_opt_ OrtSession* value) {
+  if (value == nullptr) {
+    return;
+  }
+
+  delete reinterpret_cast<::onnxruntime::InferenceSession*>(value);
+  ::onnxruntime::ReleaseFreedMemoryToOS();
+}
 DEFINE_RELEASE_ORT_OBJECT_FUNCTION(ModelMetadata, ::onnxruntime::ModelMetadata)
 
 ORT_API_STATUS_IMPL(OrtApis::GetNumHardwareDevices, _In_ const OrtEnv* env, _Out_ size_t* num_devices) {

--- a/onnxruntime/python/onnxruntime_pybind_state_common.h
+++ b/onnxruntime/python/onnxruntime_pybind_state_common.h
@@ -279,7 +279,7 @@ struct PyInferenceSession {
 
   InferenceSession* GetSessionHandle() const { return sess_.get(); }
 
-  virtual ~PyInferenceSession() noexcept {
+  virtual ~PyInferenceSession() {
     if (sess_) {
       sess_.reset();
       ReleaseFreedMemoryToOS();

--- a/onnxruntime/python/onnxruntime_pybind_state_common.h
+++ b/onnxruntime/python/onnxruntime_pybind_state_common.h
@@ -279,7 +279,12 @@ struct PyInferenceSession {
 
   InferenceSession* GetSessionHandle() const { return sess_.get(); }
 
-  virtual ~PyInferenceSession() = default;
+  virtual ~PyInferenceSession() noexcept {
+    if (sess_) {
+      sess_.reset();
+      ReleaseFreedMemoryToOS();
+    }
+  }
 
  protected:
   PyInferenceSession(std::unique_ptr<InferenceSession> sess)

--- a/onnxruntime/test/framework/inference_session_test.cc
+++ b/onnxruntime/test/framework/inference_session_test.cc
@@ -5,7 +5,10 @@
 #include "core/session/inference_session.h"
 
 #include <algorithm>
+#include <array>
+#include <cerrno>
 #include <cfloat>
+#include <cstdlib>
 #include <filesystem>
 #include <functional>
 #include <future>
@@ -14,11 +17,19 @@
 #include <fstream>
 #include <random>
 
+#if defined(__linux__) && defined(__GLIBC__)
+#include <spawn.h>
+#include <sys/wait.h>
+
+extern char** environ;
+#endif
+
 #include "nlohmann/json.hpp"
 #include "onnxruntime_cxx_api.h"
 
 #include <google/protobuf/io/zero_copy_stream_impl.h>
 #include "core/common/denormal.h"
+#include "core/common/inlined_containers.h"
 #include "core/common/logging/logging.h"
 #include "core/common/logging/sinks/clog_sink.h"
 #include "core/common/profiler.h"
@@ -195,6 +206,9 @@ class FuseExecutionProvider : public IExecutionProvider {
 namespace test {
 static constexpr const ORTCHAR_T* MODEL_URI = ORT_TSTR("testdata/mul_1.onnx");
 static constexpr const ORTCHAR_T* MODEL_URI_NO_OPSET = ORT_TSTR("testdata/mul_1.noopset.onnx");
+#if defined(__linux__) && defined(__GLIBC__) && !defined(ABSL_HAVE_ADDRESS_SANITIZER)
+static constexpr const ORTCHAR_T* MODEL_URI_BIG_SIZE = ORT_TSTR("testdata/bart_tiny.onnx");
+#endif
 // static const std::string MODEL_URI = "./testdata/squeezenet/model.onnx"; // TODO enable this after we've weights?
 
 void RunModel(InferenceSession& session_object,
@@ -3979,6 +3993,101 @@ TEST(InferenceSessionTests, CompileApiOutputHonorsOptimizationLevel) {
 }
 #endif  // !defined(DISABLE_CONTRIB_OPS)
 #endif  // !defined(ORT_MINIMAL_BUILD)
+
+#if defined(__linux__) && defined(__GLIBC__) && !defined(ABSL_HAVE_ADDRESS_SANITIZER)
+// Regression test for https://github.com/microsoft/onnxruntime/issues/26831.
+TEST(InferenceSessionTests, ReleaseSessionReturnsUnusedMemoryToOS) {
+  constexpr const char* kMarkerName = "ORT_RUN_SESSION_MEMORY_RECLAMATION_CHILD";
+  constexpr std::string_view kMarkerPrefix = "ORT_RUN_SESSION_MEMORY_RECLAMATION_CHILD=";
+  constexpr std::string_view kTrimThresholdPrefix = "MALLOC_TRIM_THRESHOLD_=";
+  constexpr std::string_view kMmapThresholdPrefix = "MALLOC_MMAP_THRESHOLD_=";
+
+  const char* marker_value = std::getenv(kMarkerName);
+  if (marker_value == nullptr || std::string_view{marker_value} != "1") {
+    InlinedVector<std::string> child_environment;
+
+    for (char** entry = environ; *entry != nullptr; ++entry) {
+      const std::string_view environment_entry{*entry};
+      if (!environment_entry.starts_with(kMarkerPrefix) &&
+          !environment_entry.starts_with(kTrimThresholdPrefix) &&
+          !environment_entry.starts_with(kMmapThresholdPrefix)) {
+        child_environment.emplace_back(environment_entry);
+      }
+    }
+
+    // Disable glibc's automatic trimming and force large allocations through the heap.
+    // The child can then pass only if session release explicitly returns freed pages.
+    child_environment.emplace_back("ORT_RUN_SESSION_MEMORY_RECLAMATION_CHILD=1");
+    child_environment.emplace_back("MALLOC_TRIM_THRESHOLD_=-1");
+    child_environment.emplace_back("MALLOC_MMAP_THRESHOLD_=1073741824");
+
+    InlinedVector<char*> child_environment_ptrs;
+    child_environment_ptrs.reserve(child_environment.size() + 1);
+    for (auto& entry : child_environment) {
+      child_environment_ptrs.push_back(entry.data());
+    }
+    child_environment_ptrs.push_back(nullptr);
+
+    std::array<char*, 4> child_args{
+        const_cast<char*>("/proc/self/exe"),
+        const_cast<char*>("--gtest_filter=InferenceSessionTests.ReleaseSessionReturnsUnusedMemoryToOS"),
+        const_cast<char*>("--gtest_color=no"),
+        nullptr,
+    };
+
+    pid_t child_pid{};
+    ASSERT_EQ(posix_spawn(&child_pid, child_args[0], nullptr, nullptr, child_args.data(),
+                          child_environment_ptrs.data()),
+              0);
+
+    int child_status{};
+    pid_t wait_result{};
+    do {
+      wait_result = waitpid(child_pid, &child_status, 0);
+    } while (wait_result == -1 && errno == EINTR);
+
+    ASSERT_EQ(wait_result, child_pid);
+    ASSERT_TRUE(WIFEXITED(child_status)) << "Memory reclamation subprocess status: " << child_status;
+    EXPECT_EQ(WEXITSTATUS(child_status), 0) << "Memory reclamation subprocess failed.";
+    return;
+  }
+
+  const auto get_rss_kb = []() -> int64_t {
+    std::ifstream status_file{"/proc/self/status"};
+    std::string line;
+    while (std::getline(status_file, line)) {
+      if (line.rfind("VmRSS:", 0) == 0) {
+        return std::stoll(line.substr(6));
+      }
+    }
+
+    return -1;
+  };
+
+  Ort::SessionOptions session_options;
+  session_options.DisableCpuMemArena();
+
+  // Page in session code and perform one large-model cycle before measuring.
+  {
+    Ort::Session warmup_session{*ort_env, MODEL_URI, session_options};
+  }
+  const int64_t rss_after_warmup = get_rss_kb();
+  ASSERT_GE(rss_after_warmup, 0);
+
+  {
+    Ort::Session first_session{*ort_env, MODEL_URI_BIG_SIZE, session_options};
+  }
+  const int64_t rss_after_first_session = get_rss_kb();
+  ASSERT_GE(rss_after_first_session, 0);
+
+  // Without allocator release, a model-sized working set remains resident. Allow ample
+  // headroom for allocator metadata and RSS measurement noise.
+  constexpr int64_t kMaxRssGrowthKB = 10 * 1024;
+  EXPECT_LE(rss_after_first_session - rss_after_warmup, kMaxRssGrowthKB)
+      << "RSS remained elevated after session release. rss_after_warmup=" << rss_after_warmup
+      << ", rss_after_first_session=" << rss_after_first_session;
+}
+#endif
 
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/framework/inference_session_test.cc
+++ b/onnxruntime/test/framework/inference_session_test.cc
@@ -9,6 +9,7 @@
 #include <cerrno>
 #include <cfloat>
 #include <cstdlib>
+#include <cstring>
 #include <filesystem>
 #include <functional>
 #include <future>
@@ -4024,7 +4025,7 @@ TEST(InferenceSessionTests, ReleaseSessionReturnsUnusedMemoryToOS) {
     InlinedVector<char*> child_environment_ptrs;
     child_environment_ptrs.reserve(child_environment.size() + 1);
     for (auto& entry : child_environment) {
-      child_environment_ptrs.push_back(entry.data());
+      child_environment_ptrs.push_back(const_cast<char*>(entry.c_str()));
     }
     child_environment_ptrs.push_back(nullptr);
 
@@ -4036,9 +4037,10 @@ TEST(InferenceSessionTests, ReleaseSessionReturnsUnusedMemoryToOS) {
     };
 
     pid_t child_pid{};
-    ASSERT_EQ(posix_spawn(&child_pid, child_args[0], nullptr, nullptr, child_args.data(),
-                          child_environment_ptrs.data()),
-              0);
+    const int spawn_result = posix_spawn(&child_pid, child_args[0], nullptr, nullptr, child_args.data(),
+                                         child_environment_ptrs.data());
+    ASSERT_EQ(spawn_result, 0) << "posix_spawn failed: " << std::strerror(spawn_result)
+                               << " (" << spawn_result << ")";
 
     int child_status{};
     pid_t wait_result{};
@@ -4067,10 +4069,9 @@ TEST(InferenceSessionTests, ReleaseSessionReturnsUnusedMemoryToOS) {
   Ort::SessionOptions session_options;
   session_options.DisableCpuMemArena();
 
-  // Page in session code and perform one large-model cycle before measuring.
-  {
-    Ort::Session warmup_session{*ort_env, MODEL_URI, session_options};
-  }
+  // Page in session code while keeping the warm-up session alive. The large session
+  // is then the first destruction to request an allocator purge in this subprocess.
+  Ort::Session warmup_session{*ort_env, MODEL_URI, session_options};
   const int64_t rss_after_warmup = get_rss_kb();
   ASSERT_GE(rss_after_warmup, 0);
 

--- a/onnxruntime/test/python/onnxruntime_test_python.py
+++ b/onnxruntime/test/python/onnxruntime_test_python.py
@@ -2464,7 +2464,11 @@ class TestMemoryReclamation(unittest.TestCase):
             child_environment["MALLOC_TRIM_THRESHOLD_"] = "-1"
             child_environment["MALLOC_MMAP_THRESHOLD_"] = "1073741824"
             child = subprocess.run(
-                [sys.executable, __file__, "TestMemoryReclamation.test_destroy_does_not_accumulate_memory"],
+                [
+                    sys.executable,
+                    str(pathlib.Path(__file__).resolve()),
+                    "TestMemoryReclamation.test_destroy_does_not_accumulate_memory",
+                ],
                 check=False,
                 capture_output=True,
                 env=child_environment,
@@ -2479,18 +2483,19 @@ class TestMemoryReclamation(unittest.TestCase):
         session_options = onnxrt.SessionOptions()
         session_options.enable_cpu_mem_arena = False
 
-        def create_and_destroy_session(model_name: str) -> None:
-            session = onnxrt.InferenceSession(
+        def create_session(model_name: str) -> onnxrt.InferenceSession:
+            return onnxrt.InferenceSession(
                 get_name(model_name), sess_options=session_options, providers=["CPUExecutionProvider"]
             )
-            del session
-            gc.collect()
 
-        # Page in session code and perform one large-model cycle before measuring.
-        create_and_destroy_session("mul_1.onnx")
+        # Page in session code while keeping the warm-up session alive. The large session
+        # is then the first destruction to request an allocator purge in this subprocess.
+        _warmup_session = create_session("mul_1.onnx")
         rss_after_warmup = self._get_rss_kb()
 
-        create_and_destroy_session("bart_tiny.onnx")
+        large_session = create_session("bart_tiny.onnx")
+        del large_session
+        gc.collect()
         rss_after_first_session = self._get_rss_kb()
 
         # Without allocator release, a model-sized working set remains resident. Allow ample

--- a/onnxruntime/test/python/onnxruntime_test_python.py
+++ b/onnxruntime/test/python/onnxruntime_test_python.py
@@ -10,6 +10,7 @@ import os
 import pathlib
 import platform
 import queue
+import subprocess
 import sys
 import threading
 import unittest
@@ -2440,6 +2441,62 @@ class TestInferenceSession(unittest.TestCase):
         result_leaf_neg = sess_leaf_neg.run(None, test_input)
         with self.subTest(case="Case 3: Same leaf-only tree but with a negative weight"):
             np.testing.assert_allclose(result_leaf_neg[1][0][1], expected_p1_leaf, atol=1e-5)
+
+
+@unittest.skipUnless(
+    sys.platform == "linux" and platform.libc_ver()[0] == "glibc" and not hasattr(ctypes.CDLL(None), "__asan_init"),
+    "requires Linux with glibc and without AddressSanitizer",
+)
+class TestMemoryReclamation(unittest.TestCase):
+    @staticmethod
+    def _get_rss_kb() -> int:
+        with open("/proc/self/status", encoding="utf-8") as status_file:
+            for line in status_file:
+                if line.startswith("VmRSS:"):
+                    return int(line.split()[1])
+        raise RuntimeError("Could not read VmRSS from /proc/self/status")
+
+    def test_destroy_does_not_accumulate_memory(self) -> None:
+        marker = "ORT_RUN_PYTHON_SESSION_MEMORY_RECLAMATION_CHILD"
+        if os.getenv(marker) != "1":
+            child_environment = os.environ.copy()
+            child_environment[marker] = "1"
+            child_environment["MALLOC_TRIM_THRESHOLD_"] = "-1"
+            child_environment["MALLOC_MMAP_THRESHOLD_"] = "1073741824"
+            child = subprocess.run(
+                [sys.executable, __file__, "TestMemoryReclamation.test_destroy_does_not_accumulate_memory"],
+                check=False,
+                capture_output=True,
+                env=child_environment,
+                text=True,
+                timeout=60,
+            )
+            self.assertEqual(
+                child.returncode, 0, f"Memory reclamation subprocess failed:\n{child.stdout}{child.stderr}"
+            )
+            return
+
+        session_options = onnxrt.SessionOptions()
+        session_options.enable_cpu_mem_arena = False
+
+        def create_and_destroy_session(model_name: str) -> None:
+            session = onnxrt.InferenceSession(
+                get_name(model_name), sess_options=session_options, providers=["CPUExecutionProvider"]
+            )
+            del session
+            gc.collect()
+
+        # Page in session code and perform one large-model cycle before measuring.
+        create_and_destroy_session("mul_1.onnx")
+        rss_after_warmup = self._get_rss_kb()
+
+        create_and_destroy_session("bart_tiny.onnx")
+        rss_after_first_session = self._get_rss_kb()
+
+        # Without allocator release, a model-sized working set remains resident. Allow ample
+        # headroom for allocator metadata and RSS measurement noise.
+        max_rss_growth_kb = 10 * 1024
+        self.assertLessEqual(rss_after_first_session - rss_after_warmup, max_rss_growth_kb)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Description

- Release unused allocator pages after an ONNX Runtime session is destroyed.
- Support glibc, built-in mimalloc, and mimalloc loaded through `LD_PRELOAD`.
- Apply reclamation to both C API and Python session teardown paths.
- Add deterministic C++ and Python regression tests that verify session memory is returned to the operating system.

### Motivation and Context

Destroying and recreating inference sessions could leave a model-sized allocation resident in the process, causing RSS to grow across model reloads even though the session had been released.

The regression tests disable glibc’s automatic trimming in isolated subprocesses, ensuring they fail without the explicit reclamation behavior.

Fixes [[#26831](https://github.com/microsoft/onnxruntime/issues/26831)](https://github.com/microsoft/onnxruntime/issues/26831).

The behavior was also observed in Immich when repeatedly unloading and loading PyTorch-exported models: [[immich-app/immich#3340 comment](https://github.com/immich-app/immich/pull/3340#issuecomment-1643025687)](https://github.com/immich-app/immich/pull/3340#issuecomment-1643025687).