### PR TITLE
Add group size 6 support to paged XQA

### DIFF
--- a/docs/contrib_ops/cuda/paged_attention.md
+++ b/docs/contrib_ops/cuda/paged_attention.md
@@ -748,30 +748,30 @@ Mirror GQA: `onnxruntime_USE_FP8_KV_CACHE` (default ON), `onnxruntime_USE_INT4_K
 > `PagedAttention<T, T_CACHE>` registered for `{MLFloat16, BFloat16} × {int8_t, Float8E4M3FN}` in
 > addition to the unquantized pairs. Deviations from the text above:
 >
-> - **Read path is §8.5 Phase 2 only.** `GatherAndExpandPagedKVCache` dequantizes while gathering,
->   and the Flash varlen path is routed through the same gather when the cache is quantized (using
->   `num_heads = kv_num_heads` so no GQA expansion happens, which keeps Flash's grouped layout). The
->   §8.5 Phase 3 paged decode kernel with in-kernel dequantization is **not** implemented.
+> - **Both §8.5 read paths are implemented.** Multi-token steps use `GatherAndExpandPagedKVCache`
+>   to dequantize while gathering, and the Flash varlen path uses the gathered grouped layout.
+>   Single-token decode reads and dequantizes the cache in place through XQA when eligible or
+>   `PagedDecodeSplitKV` otherwise.
 > - Because a quantized cache never reaches Flash's *paged* kernel, the `block_size` tiling
 >   constraint of §18.1 does not apply to it; Flash eligibility skips that check when the cache is
 >   quantized. Any power-of-two `block_size >= 16` works with a quantized cache on either backend.
 > - **`uint8` / INT4 not added.** `T_CACHE` is `{float16, bfloat16, int8, float8e4m3fn}`, so
 >   `k_cache_dtype` and `v_cache_dtype` must be `""` or name the cache tensor's own element type.
-> - **No SM89/SM90 gate for FP8.** `Float8E4M3FN`'s converting constructor uses
+> - **No architecture gate for portable FP8 decode.** `Float8E4M3FN`'s converting constructor uses
 >   `__nv_cvt_float_to_fp8`, which is available on every architecture ORT builds for from CUDA 11.8
->   onward, so the arch check in §8.7 would reject working configurations. FP8 remains gated at
->   *build* time by `onnxruntime_USE_FP8_KV_CACHE`.
+>   onward. FP8 remains gated at *build* time by `onnxruntime_USE_FP8_KV_CACHE`.
 > - Parity tests compare the updated cache at one quantization step of slack. Rotary and RMSNorm are
 >   computed ~1 fp16 ULP differently on the host, which is enough to move a value across a rounding
 >   boundary and flip the stored code by one LSB.
 
-> **Implementation note (P5, implemented).** §8.5 Phase 3 is now in place as a purpose-built
-> flash-decoding kernel (`PagedDecodeSplitKV` + `PagedDecodeReduce` in `paged_attention_impl.cu`),
-> not by reusing the vendored XQA kernel. XQA does have paged-KV support, but its page list is
-> `[batch][beam][2][max_pages]` over a *single* K/V pool whereas PagedAttention has two pools and one
-> shared `block_table`, and it restricts `head_size ∈ {64, 128, 256}` and `group_size ∈ {4, 8, 16,
-> 32}` while multiplying instantiations across page size × group size × head size × dtype × quant
-> type. A ~250-line kernel covers the whole schema instead.
+> **Paged decode kernels.** Quantized decode uses XQA directly on the paged cache when the query has
+> one token per sequence, `head_size ∈ {64, 128}`, `group_size ∈ {4, 6, 8, 16, 32}`, no softcap, and
+> a block size divisible by 128. The CUDA image selected at runtime must contain compatible XQA
+> device code generated for SM80 or newer; INT8 XQA requires an SM80-or-newer GPU and FP8 XQA
+> requires SM89 or SM90+. Setting `ORT_ENABLE_XQA=0` disables XQA. The operator also falls back when
+> the selected image has no XQA kernel or its dynamic shared-memory requirement exceeds the device
+> limit. Other supported configurations use `PagedDecodeSplitKV` and `PagedDecodeReduce` from
+> `paged_attention_impl.cu`.
 >
 > - **Both scale foldings are exact and granularity-agnostic.** K folds into Q at load time
 >   (`q_sh[c] = float(q[c]) * GetCacheScale(k_scale, kv_head * head_size + c, k_per_channel)`), so

--- a/onnxruntime/contrib_ops/cuda/bert/paged_attention.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/paged_attention.cc
@@ -452,7 +452,7 @@ Status PagedAttention<T, TCACHE>::ComputeInternal(OpKernelContext* context) cons
         device_prop.major >= 8 &&
         parameters.softcap == 0.0f &&
         (parameters.head_size == 64 || parameters.head_size == 128) &&
-        (group_size == 4 || group_size == 8 || group_size == 16 || group_size == 32) &&
+        (group_size == 4 || group_size == 6 || group_size == 8 || group_size == 16 || group_size == 32) &&
         (parameters.block_size % kXqaTokensPerPage) == 0 &&
         is_supported_quant_type(k_quant_type_) && is_supported_quant_type(v_quant_type_) &&
         // FP8 arithmetic in the XQA kernel needs Ada (sm_89) or Hopper+.
@@ -532,7 +532,9 @@ Status PagedAttention<T, TCACHE>::ComputeInternal(OpKernelContext* context) cons
             device_prop, parameters.head_size, parameters.num_heads, parameters.kv_num_heads,
             IsFp8CacheType<TCACHE>() ? XqaQuantType::kFp8 : XqaQuantType::kInt8,
             std::is_same<T, BFloat16>::value);
-        xqa_smem_ok = (required_smem == 0 || required_smem <= device_prop.sharedMemPerBlockOptin) ? 1 : 0;
+        // A zero result means the selected CUDA image has no compatible XQA symbol or the symbol
+        // query failed. Either case must use the portable fallback rather than attempting a launch.
+        xqa_smem_ok = (required_smem != 0 && required_smem <= device_prop.sharedMemPerBlockOptin) ? 1 : 0;
         xqa_shared_memory_ok_.store(xqa_smem_ok, std::memory_order_relaxed);
       } else {
         xqa_smem_ok = 0;

--- a/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_paged_loader.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_paged_loader.cu
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 //
 // Head-size / dtype / cache-dtype dispatcher for the paged-KV XQA decode kernels. The kernels
-// themselves live in xqa_paged_<query>_<cache>_<head>.cu (each of which instantiates the four
+// themselves live in xqa_paged_<query>_<cache>_<head>.cu (each of which instantiates the five
 // supported query/KV group sizes through xqa_paged_loader_impl.cuh).
 
 #include "contrib_ops/cuda/bert/xqa/xqa_paged_loader.h"

--- a/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_paged_loader.h
+++ b/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_paged_loader.h
@@ -27,7 +27,7 @@ constexpr int kXqaTokensPerPage = 128;
 // K and V from a shared block pool addressed through a page table.
 //
 // Preconditions: one query token per sequence, head_size in {64, 128}, group_size in
-// {4, 8, 16, 32}, quantized (INT8/FP8) cache, block_size % kXqaTokensPerPage == 0.
+// {4, 6, 8, 16, 32}, quantized (INT8/FP8) cache, block_size % kXqaTokensPerPage == 0.
 Status LaunchXQAPagedKernel(
     const cudaDeviceProp& device_prop,
     cudaStream_t stream,
@@ -56,8 +56,9 @@ Status LaunchXQAPagedKernel(
 // and contiguous kernels share the CTA tile and the scratch layout, so this is GetXQAScratchSize
 // called with max_seq_len = max_pages_per_seq * kXqaTokensPerPage.
 
-// Dynamic shared memory the paged kernel requests, read from the loaded module. Returns 0 when it
-// cannot be determined. Callers must skip XQA when this exceeds device_prop.sharedMemPerBlockOptin.
+// Dynamic shared memory the paged kernel requests, read from the loaded module. Returns 0 when the
+// selected CUDA image has no compatible kernel or the size cannot be determined. Callers must skip
+// XQA when this returns 0 or exceeds device_prop.sharedMemPerBlockOptin.
 size_t GetXQAPagedRequiredSharedMemoryBytes(
     const cudaDeviceProp& device_prop,
     int head_size,

--- a/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_paged_loader_impl.cuh
+++ b/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_paged_loader_impl.cuh
@@ -86,6 +86,14 @@ namespace HEAD_DIM_NAMESPACE {
 #undef GRP_SIZE
 #undef M_TILESIZE
 
+#define NAMESPACE_NAME XQA_PAGED_NS(grp6_)
+#define GRP_SIZE 6
+#define M_TILESIZE 8
+#include "xqa_paged_impl_gen.cuh"
+#undef NAMESPACE_NAME
+#undef GRP_SIZE
+#undef M_TILESIZE
+
 #define NAMESPACE_NAME XQA_PAGED_NS(grp8_)
 #define GRP_SIZE 8
 #define M_TILESIZE 8
@@ -141,6 +149,8 @@ Status XQA_PAGED_LAUNCH_FN(
   switch (group_size) {
     case 4:
       XQA_PAGED_DISPATCH(grp4_);
+    case 6:
+      XQA_PAGED_DISPATCH(grp6_);
     case 8:
       XQA_PAGED_DISPATCH(grp8_);
     case 16:
@@ -149,7 +159,7 @@ Status XQA_PAGED_LAUNCH_FN(
       XQA_PAGED_DISPATCH(grp32_);
     default:
       return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
-                             "Paged XQA only supports group_size 4, 8, 16, 32. Input has ", group_size);
+                             "Paged XQA only supports group_size 4, 6, 8, 16, 32. Input has ", group_size);
   }
 }
 
@@ -160,6 +170,8 @@ size_t XQA_PAGED_CAT(XQA_PAGED_LAUNCH_FN, _, SmemSize)(const int num_heads, cons
   switch (group_size) {
     case 4:
       return XQA_PAGED_NS(grp4_)::GetSmemSize();
+    case 6:
+      return XQA_PAGED_NS(grp6_)::GetSmemSize();
     case 8:
       return XQA_PAGED_NS(grp8_)::GetSmemSize();
     case 16:

--- a/onnxruntime/test/python/transformers/test_paged_attention.py
+++ b/onnxruntime/test/python/transformers/test_paged_attention.py
@@ -10,9 +10,13 @@
 # license information.
 # -------------------------------------------------------------------------
 import math
+import os
 import platform
 import random
+import sys
+import tempfile
 import unittest
+from unittest.mock import patch
 
 import numpy
 import torch
@@ -1080,6 +1084,26 @@ def parity_check_paged_attention(
         numpy.testing.assert_allclose(out_i, out_ref_i, rtol=rtol, atol=atol, equal_nan=True, err_msg=err_msg)
 
 
+def capture_native_stdout(run_func):
+    """Capture output written by the native runtime directly to file descriptor 1."""
+    sys.stdout.flush()
+    saved_fd = os.dup(1)
+    try:
+        with tempfile.TemporaryFile() as tmp:
+            os.dup2(tmp.fileno(), 1)
+            try:
+                run_func()
+            finally:
+                try:
+                    sys.stdout.flush()
+                finally:
+                    os.dup2(saved_fd, 1)
+            tmp.seek(0)
+            return tmp.read().decode(errors="replace")
+    finally:
+        os.close(saved_fd)
+
+
 def has_cuda_device():
     """Every test in this file allocates torch tensors on "cuda" and runs the CUDA EP.
 
@@ -1097,6 +1121,20 @@ def has_flash_attention():
         platform.system() == "Linux"
         or (platform.system() == "Windows" and version.parse(torch.version.cuda) >= version.parse("12.0"))
     )
+
+
+def has_xqa():
+    if not has_cuda_device():
+        return False
+    major, minor = torch.cuda.get_device_capability()
+    return major * 10 + minor >= 80
+
+
+def has_fp8_xqa():
+    if not has_cuda_device():
+        return False
+    major, minor = torch.cuda.get_device_capability()
+    return major * 10 + minor >= 89
 
 
 def has_memory_efficient_attention():
@@ -1993,14 +2031,14 @@ class TestPagedAttentionPagedDecode(unittest.TestCase):
         parity_check_paged_attention(config, rtol=5e-3, atol=2e-2)
 
 
-@unittest.skipIf(not has_cuda_device(), reason="CUDA is not available, skipping tests.")
+@unittest.skipIf(not has_xqa(), reason="XQA requires an SM80 or newer GPU")
 class TestPagedAttentionXqaDecode(unittest.TestCase):
     """Coverage for the XQA decode backend.
 
     XQA is the tensor-core decode kernel (shared with GroupQueryAttention) reading the paged cache
     in place. It is auto-selected ahead of the portable decode kernel when the cache is quantized
     and the step fits its constraints: exactly one new token per sequence, head_size in {64, 128},
-    a query/KV group size in {4, 8, 16, 32}, no softcap, and block_size a multiple of 128 (a block
+    a query/KV group size in {4, 6, 8, 16, 32}, no softcap, and block_size a multiple of 128 (a block
     is presented to the kernel as several 128-token pages). Anything outside that falls back, which
     is what the ORT_ENABLE_XQA=0 comparison below pins down.
 
@@ -2009,8 +2047,6 @@ class TestPagedAttentionXqaDecode(unittest.TestCase):
 
     def setUp(self):
         torch.manual_seed(0)
-        if not has_fp8_kv_cache():
-            self.skipTest("quantized KV cache kernels are not built")
 
     def _config(self, **overrides):
         kwargs = {
@@ -2035,6 +2071,12 @@ class TestPagedAttentionXqaDecode(unittest.TestCase):
         return config
 
     def _check_xqa(self, quant_type="PER_TENSOR", kv_cache_type="int8", rtol=5e-3, atol=5e-3, **overrides):
+        if kv_cache_type == "fp8":
+            if not has_fp8_kv_cache():
+                self.skipTest("FP8 KV cache kernels are not built")
+            if not has_fp8_xqa():
+                self.skipTest("FP8 XQA requires an SM89 or newer GPU")
+
         config = self._config(
             kv_cache_type=kv_cache_type,
             k_quant_type=quant_type,
@@ -2043,15 +2085,51 @@ class TestPagedAttentionXqaDecode(unittest.TestCase):
         )
         parity_check_paged_attention(config, rtol=rtol, atol=atol)
 
+    def _capture_xqa_debug(self, config):
+        with patch.dict(
+            os.environ,
+            {"ORT_ENABLE_ATTENTION_KERNEL_DEBUG_INFO": "1", "ORT_ENABLE_XQA": "1"},
+        ):
+            return capture_native_stdout(lambda: parity_check_paged_attention(config, rtol=5e-3, atol=5e-3))
+
     # ---- shapes -------------------------------------------------------------------------
 
     @parameterized.expand([("64", 64), ("128", 128)])
     def test_xqa_head_size(self, _, head_size):
         self._check_xqa(head_size=head_size)
 
-    @parameterized.expand([("grp4", 8, 2), ("grp8", 8, 1), ("grp16", 16, 1), ("grp32", 32, 1)])
+    @parameterized.expand([("grp4", 8, 2), ("grp6", 12, 2), ("grp8", 8, 1), ("grp16", 16, 1), ("grp32", 32, 1)])
     def test_xqa_head_grouping(self, _, num_heads, kv_num_heads):
         self._check_xqa(num_heads=num_heads, kv_num_heads=kv_num_heads)
+
+    @parameterized.expand([("head64_per_tensor", 64, "PER_TENSOR"), ("head128_per_channel", 128, "PER_CHANNEL")])
+    def test_xqa_group_size_six_dispatch(self, _, head_size, quant_type):
+        # Six query heads exercise XQA's padded query-row path. Parity checks the visible rows,
+        # while debug telemetry proves the result did not come from the fallback kernel.
+        baseline_config = self._config(
+            num_heads=32,
+            kv_num_heads=8,
+            head_size=head_size,
+            kv_cache_type="int8",
+            k_quant_type=quant_type,
+            v_quant_type=quant_type,
+        )
+        baseline_debug_output = self._capture_xqa_debug(baseline_config)
+        if "SdpaKernel=XQA" not in baseline_debug_output:
+            self.skipTest("Paged XQA is not runnable for this head size and quantization configuration")
+
+        config = self._config(
+            num_heads=48,
+            kv_num_heads=8,
+            head_size=head_size,
+            kv_cache_type="int8",
+            k_quant_type=quant_type,
+            v_quant_type=quant_type,
+        )
+        debug_output = self._capture_xqa_debug(config)
+        self.assertIn("Operator=PagedAttention", debug_output)
+        self.assertIn("SdpaKernel=XQA", debug_output)
+        self.assertIn("GqaGroupSize=6", debug_output)
 
     @parameterized.expand([("128", 128), ("256", 256), ("512", 512)])
     def test_xqa_block_size(self, _, block_size):


### PR DESCRIPTION
Enable the optimized xqa decode kernel for group size 6 when there are 6 kv heads per query

