### PR TITLE
Fix ReshapeFusion shape-input traversal

### DIFF
--- a/onnxruntime/core/optimizer/reshape_fusion.cc
+++ b/onnxruntime/core/optimizer/reshape_fusion.cc
@@ -533,7 +533,14 @@ bool ReshapeFusion::FuseContiguousReshapes(Node& reshape, Graph& graph) {
       break;
     }
 
-    Node* next_node = graph.GetNode(curr_node.OutputNodesBegin()->Index());
+    // A contiguous reshape chain must feed input 0 (data) of the downstream node. Reshape's shape
+    // input and Squeeze/Unsqueeze's axes input (opset 13+) are not data-path edges.
+    const auto output_edge = curr_node.OutputEdgesBegin();
+    if (output_edge->GetDstArgIndex() != 0) {
+      break;
+    }
+
+    Node* next_node = graph.GetNode(output_edge->GetNode().Index());
     if (next_node->OpType() != "Reshape" && next_node->OpType() != "Squeeze" && next_node->OpType() != "Unsqueeze") {
       break;
     }

--- a/onnxruntime/test/optimizer/graph_transform_test.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test.cc
@@ -5785,6 +5785,33 @@ TEST_F(GraphTransformationTests, ReshapeFusion_Contiguous_Reshape) {
                                         1, pre_graph_checker, post_graph_checker));
 }
 
+TEST_F(GraphTransformationTests, ReshapeFusion_DoesNotFuseShapeInput) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    auto* shape_data = builder.MakeInput<int64_t>({1}, {4});
+    auto* reshape_shape = builder.MakeInitializer<int64_t>({1}, {1});
+    auto* reshape_shape_output = builder.MakeIntermediate();
+    builder.AddNode("Reshape", {shape_data, reshape_shape}, {reshape_shape_output});
+
+    auto* data = builder.MakeInitializer<float>({4}, {10.0f, 20.0f, 30.0f, 40.0f});
+    auto* output = builder.MakeOutput<float>(std::vector<int64_t>{4});
+    builder.AddNode("Reshape", {data, reshape_shape_output}, {output});
+  };
+
+  auto check_transformed_graph = [](InferenceSessionWrapper& session) {
+    const auto op_to_count = CountOpsInGraph(session.GetGraph());
+    ASSERT_EQ(op_to_count.at("Reshape"), 2);
+  };
+
+  TransformerTester(build_test_case,
+                    check_transformed_graph,
+                    TransformerLevel::Default,
+                    TransformerLevel::Level1,
+                    21,
+                    0.0,
+                    0.0,
+                    std::make_unique<ReshapeFusion>());
+}
+
 // Test eliminating redundant Concat-Slice pattern.
 TEST_F(GraphTransformationTests, ConcatSliceEliminationTest) {
   constexpr const ORTCHAR_T* model_uri = MODEL_FOLDER "concat_slice_basic_test.onnx";


### PR DESCRIPTION
### Description

Fixes #32105.

- require a contiguous Reshape/Squeeze/Unsqueeze chain to feed downstream data input 0
- leave Reshape shape inputs and Squeeze/Unsqueeze axes inputs outside the data-path fusion
- add an in-memory opset 21 regression that initializes and executes baseline and optimized sessions

### Motivation and Context

`FuseContiguousReshapes` followed a node's sole output consumer without checking the destination input slot. When a Reshape output supplied input 1 (shape) of another Reshape, the optimizer treated that int64 shape path as a float data path and created a type-invalid `_new_reshape`.

The regression intentionally removes the issue reproducer's irrelevant Cast while preserving the faulty int64 shape-edge relationship. It fails on `main` during target session initialization with the reported `tensor(float)` versus `tensor(int64)` error.

### Validation

- RED on `main`: the new test fails at `InferenceSession::Initialize()` with the reported type mismatch
- new regression: 25 repeated passes after the fix
- `GraphTransformationTests.ReshapeFusion*`: 23/23 passed
- `onnxruntime_test_all`: 1,937 passed, 17 skipped (1,954 total)
- `lintrunner --all-files`
- `git diff --check`
- macOS arm64 Release CPU build with vendored dependencies

AI assistance disclosure: OpenAI Codex reproduced the bug, drafted the patch, and ran the validation listed above in the authorized account workspace. The account owner authorized publication. This PR remains a Draft pending the account owner’s personal Microsoft CLA decision and upstream CI authorization.
