### PR TITLE
[CUDA] QuantizeLinear/DequantizeLinear: use fast_divmod for scale indexing

### DIFF
--- a/onnxruntime/core/providers/cuda/tensor/quantize_linear.cu
+++ b/onnxruntime/core/providers/cuda/tensor/quantize_linear.cu
@@ -3,9 +3,11 @@
 
 #include "quantize_linear.cuh"
 
+#include <cstdint>
 #include <limits>
 
 #include "core/providers/cuda/cu_inc/common.cuh"
+#include "core/providers/cuda/shared_inc/fast_divmod.h"
 
 #if defined(CUDA_VERSION) && CUDA_VERSION >= 11080
 #include "cuda_fp8.h"
@@ -248,16 +250,14 @@ __global__ void QuantizeLinearKernelStdInt4(const InT* input, OutT* output, cons
 }
 
 template <int NumThreadsPerBlock, int NumElementsPerThread, typename OutT, typename InT>
-__global__ void QuantizeLinearKernelAxisStd(const InT* input, OutT* output, const InT* scale_ptr, const OutT* zero_point_ptr, CUDA_LONG N, size_t batch_size, size_t n_scales, RoundStd<InT, OutT> round) {
+__global__ void QuantizeLinearKernelAxisStd(const InT* input, OutT* output, const InT* scale_ptr, const OutT* zero_point_ptr, CUDA_LONG N, fast_divmod fdm_same_scale, fast_divmod fdm_n_scales, RoundStd<InT, OutT> round) {
   CUDA_LONG id = NumElementsPerThread * NumThreadsPerBlock * blockIdx.x + threadIdx.x;
-  // The scale needs to change every n_same_scale.
-  CUDA_LONG n_same_scale = N / (batch_size * n_scales);
-  int scale_id;
 
 #pragma unroll
   for (int i = 0; i < NumElementsPerThread; i++) {
     if (id < N) {
-      scale_id = (id / n_same_scale) % n_scales;
+      // The scale changes every n_same_scale elements, and wraps every n_scales groups.
+      const int32_t scale_id{fdm_n_scales.mod(fdm_same_scale.div(id))};
       output[id] = round(input[id], scale_ptr[scale_id], zero_point_ptr == nullptr ? static_cast<OutT>(0) : zero_point_ptr[scale_id]);
       id += NumThreadsPerBlock;
     }
@@ -270,19 +270,18 @@ __global__ void QuantizeLinearKernelAxisStd(const InT* input, OutT* output, cons
 template <int NumThreadsPerBlock, int NumElementsPerThread, typename OutT, typename InT>
 __global__ void QuantizeLinearKernelAxisStdInt4(const InT* input, OutT* output, const InT* scale_ptr,
                                                 const OutT* zero_point_ptr, CUDA_LONG num_element,
-                                                size_t batch_size, size_t n_scales,
+                                                fast_divmod fdm_same_scale, fast_divmod fdm_n_scales,
                                                 RoundStdInt4<InT, OutT> round) {
   CUDA_LONG id = NumElementsPerThread * NumThreadsPerBlock * blockIdx.x + (threadIdx.x << 1);
   // Process continuous NumElementsPerThread int4 per thread.
   int i = 0;
-  // The scale needs to change every n_same_scale.
-  CUDA_LONG n_same_scale = num_element / (batch_size * n_scales);
   constexpr int step = NumThreadsPerBlock << 1;
 
 #pragma unroll
   for (; i + 1 < NumElementsPerThread && id + 1 < num_element; i += 2, id += step) {
-    int scale_id0 = (id / n_same_scale) % n_scales;
-    int scale_id1 = ((id + 1) / n_same_scale) % n_scales;
+    // The scale changes every n_same_scale elements, and wraps every n_scales groups.
+    const int32_t scale_id0{fdm_n_scales.mod(fdm_same_scale.div(id))};
+    const int32_t scale_id1{fdm_n_scales.mod(fdm_same_scale.div(id + 1))};
     int zp0 = zero_point_ptr == nullptr ? 0 : ExtractInt4FromByte(zero_point_ptr[scale_id0 >> 1], scale_id0 & 1);
     int zp1 = zero_point_ptr == nullptr ? 0 : ExtractInt4FromByte(zero_point_ptr[scale_id1 >> 1], scale_id1 & 1);
     output[id >> 1] = round(input[id],
@@ -294,7 +293,7 @@ __global__ void QuantizeLinearKernelAxisStdInt4(const InT* input, OutT* output, 
   }
 
   if (i < NumElementsPerThread && id < num_element) {
-    int scale_id0 = (id / n_same_scale) % n_scales;
+    const int32_t scale_id0{fdm_n_scales.mod(fdm_same_scale.div(id))};
     int zp0 = zero_point_ptr == nullptr ? 0 : ExtractInt4FromByte(zero_point_ptr[scale_id0 >> 1], scale_id0 & 1);
     output[id >> 1] = round(input[id],
                             0.0,
@@ -310,8 +309,9 @@ __global__ void QuantizeLinearKernelAxisStdInt4(const InT* input, OutT* output, 
 // NumElementsPerThread must be multiple of 2.
 template <int NumThreadsPerBlock, int NumElementsPerThread, typename OutT, typename InT>
 __global__ void QuantizeLinearKernelBlockStdInt4(const InT* input, OutT* output, const InT* scale_ptr,
-                                                 const OutT* zero_point_ptr, CUDA_LONG num_element, size_t KN,
-                                                 size_t N, size_t scale_KN, size_t block_size,
+                                                 const OutT* zero_point_ptr, CUDA_LONG num_element,
+                                                 fast_divmod fdm_KN, fast_divmod fdm_N, fast_divmod fdm_block_size,
+                                                 int32_t N, int32_t scale_KN,
                                                  RoundStdInt4<InT, OutT> round) {
   // Process continuous NumElementsPerThread int4 per thread.
   CUDA_LONG id = NumElementsPerThread * NumThreadsPerBlock * blockIdx.x + (threadIdx.x << 1);
@@ -321,11 +321,13 @@ __global__ void QuantizeLinearKernelBlockStdInt4(const InT* input, OutT* output,
 #pragma unroll
   // Process two elements which belong to one byte at a time.
   for (; i + 1 < NumElementsPerThread && id + 1 < num_element; i += 2, id += step) {
-    int x0 = id / KN, x1 = (id + 1) / KN;
-    int y0 = id % KN / N, y1 = (id + 1) % KN / N;
-    int z0 = id % N, z1 = (id + 1) % N;
-    int scale_id0 = x0 * scale_KN + y0 / block_size * N + z0;
-    int scale_id1 = x1 * scale_KN + y1 / block_size * N + z1;
+    int32_t x0, x1, rem0, rem1, y0, y1, z0, z1;
+    fdm_KN.divmod(id, x0, rem0);
+    fdm_N.divmod(rem0, y0, z0);
+    fdm_KN.divmod(id + 1, x1, rem1);
+    fdm_N.divmod(rem1, y1, z1);
+    const int32_t scale_id0{x0 * scale_KN + fdm_block_size.div(y0) * N + z0};
+    const int32_t scale_id1{x1 * scale_KN + fdm_block_size.div(y1) * N + z1};
     output[id >> 1] = round(input[id],
                             input[id + 1],
                             scale_ptr[scale_id0],
@@ -340,10 +342,10 @@ __global__ void QuantizeLinearKernelBlockStdInt4(const InT* input, OutT* output,
 
   // last non-paired element
   if (i < NumElementsPerThread && id < num_element) {
-    int x0 = id / KN;
-    int y0 = id % KN / N;
-    int z0 = id % N;
-    int scale_id0 = x0 * scale_KN + y0 / block_size * N + z0;
+    int32_t x0, rem0, y0, z0;
+    fdm_KN.divmod(id, x0, rem0);
+    fdm_N.divmod(rem0, y0, z0);
+    const int32_t scale_id0{x0 * scale_KN + fdm_block_size.div(y0) * N + z0};
     output[id >> 1] = round(input[id],
                             0.0,
                             scale_ptr[scale_id0],
@@ -436,14 +438,16 @@ Status CudaQuantizeLinearAxisStd(cudaStream_t stream, const InT* input, OutT* ou
     return Status::OK();
 
   int blocksPerGrid = static_cast<int>(CeilDiv(num_of_element, GridDim::maxThreadsPerBlock * GridDim::maxElementsPerThread));
+  const fast_divmod fdm_same_scale{static_cast<int32_t>(num_of_element / (batch_size * n_scales))};
+  const fast_divmod fdm_n_scales{static_cast<int32_t>(n_scales)};
   QuantizeLinearKernelAxisStd<GridDim::maxThreadsPerBlock, GridDim::maxElementsPerThread><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0, stream>>>(
       input,
       output,
       scale,
       zero_point,
       static_cast<int>(num_of_element),
-      batch_size,
-      n_scales,
+      fdm_same_scale,
+      fdm_n_scales,
       RoundStd<InT, OutT>());
   return Status::OK();
 }
@@ -459,6 +463,8 @@ Status CudaQuantizeLinearAxisStdInt4(cudaStream_t stream, const InT* input, OutT
 
   int blocksPerGrid = static_cast<int>(CeilDiv(num_of_element,
                                                GridDim::maxThreadsPerBlock * GridDim::maxElementsPerThread));
+  const fast_divmod fdm_same_scale{static_cast<int32_t>(num_of_element / (batch_size * n_scales))};
+  const fast_divmod fdm_n_scales{static_cast<int32_t>(n_scales)};
   QuantizeLinearKernelAxisStdInt4<GridDim::maxThreadsPerBlock, GridDim::maxElementsPerThread>
       <<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0, stream>>>(
           input,
@@ -466,8 +472,8 @@ Status CudaQuantizeLinearAxisStdInt4(cudaStream_t stream, const InT* input, OutT
           scale,
           zero_point,
           static_cast<int>(num_of_element),
-          batch_size,
-          n_scales,
+          fdm_same_scale,
+          fdm_n_scales,
           RoundStdInt4<InT, OutT>());
   return Status::OK();
 }
@@ -493,10 +499,11 @@ Status CudaQuantizeLinearBlockStdInt4(cudaStream_t stream, const InT* input, Out
           scale,
           zero_point,
           static_cast<int>(num_of_element),
-          KN,
-          N,
-          scale_KN,
-          block_size,
+          fast_divmod{static_cast<int32_t>(KN)},
+          fast_divmod{static_cast<int32_t>(N)},
+          fast_divmod{static_cast<int32_t>(block_size)},
+          static_cast<int32_t>(N),
+          static_cast<int32_t>(scale_KN),
           RoundStdInt4<InT, OutT>());
   return Status::OK();
 }
@@ -582,16 +589,14 @@ __global__ void DequantizeLinearKernelStdInt4(const InT* input, OutT* output, co
 
 template <class InT, class OutT, int NumThreadsPerBlock, int NumElementsPerThread>
 __global__ void DequantizeLinearKernelAxisStd(const InT* input, OutT* output, const OutT* scale_ptr, const InT* zero_point_ptr, CUDA_LONG N,
-                                              size_t batch_size, size_t n_scales) {
+                                              fast_divmod fdm_same_scale, fast_divmod fdm_n_scales) {
   CUDA_LONG id = NumElementsPerThread * NumThreadsPerBlock * blockIdx.x + threadIdx.x;
-  // The scale needs to change every n_same_scale.
-  CUDA_LONG n_same_scale = N / (batch_size * n_scales);
-  int scale_id;
 
 #pragma unroll
   for (int i = 0; i < NumElementsPerThread; i++) {
     if (id < N) {
-      scale_id = (id / n_same_scale) % n_scales;
+      // The scale changes every n_same_scale elements, and wraps every n_scales groups.
+      const int32_t scale_id{fdm_n_scales.mod(fdm_same_scale.div(id))};
       output[id] = (zero_point_ptr == nullptr ? static_cast<OutT>(input[id]) : static_cast<OutT>(input[id] - zero_point_ptr[scale_id])) * scale_ptr[scale_id];
       id += NumThreadsPerBlock;
     }
@@ -601,18 +606,17 @@ __global__ void DequantizeLinearKernelAxisStd(const InT* input, OutT* output, co
 template <class InT, class OutT, int NumThreadsPerBlock, int NumElementsPerThread>
 __global__ void DequantizeLinearKernelAxisStdInt4(const InT* input, OutT* output, const OutT* scale_ptr,
                                                   const InT* zero_point_ptr, CUDA_LONG num_element,
-                                                  size_t batch_size, size_t n_scales) {
+                                                  fast_divmod fdm_same_scale, fast_divmod fdm_n_scales) {
   CUDA_LONG id = NumElementsPerThread * NumThreadsPerBlock * blockIdx.x + (threadIdx.x << 1);
-  // The scale needs to change every n_same_scale.
-  CUDA_LONG n_same_scale = num_element / (batch_size * n_scales);
   int i = 0;
   int scale_id0, scale_id1, zp0, zp1, v0, v1;
   constexpr int step = NumThreadsPerBlock << 1;
 
 #pragma unroll
   for (; i + 1 < NumElementsPerThread && id + 1 < num_element; i += 2, id += step) {
-    scale_id0 = (id / n_same_scale) % n_scales;
-    scale_id1 = ((id + 1) / n_same_scale) % n_scales;
+    // The scale changes every n_same_scale elements, and wraps every n_scales groups.
+    scale_id0 = fdm_n_scales.mod(fdm_same_scale.div(id));
+    scale_id1 = fdm_n_scales.mod(fdm_same_scale.div(id + 1));
 
     v0 = ExtractInt4FromByte(input[id >> 1], 0);
     v1 = ExtractInt4FromByte(input[id >> 1], 1);
@@ -623,7 +627,7 @@ __global__ void DequantizeLinearKernelAxisStdInt4(const InT* input, OutT* output
   }
 
   if (i < NumElementsPerThread && id < num_element) {
-    scale_id0 = (id / n_same_scale) % n_scales;
+    scale_id0 = fdm_n_scales.mod(fdm_same_scale.div(id));
     v0 = ExtractInt4FromByte(input[id >> 1], 0);
     zp0 = zero_point_ptr == nullptr ? 0 : ExtractInt4FromByte(zero_point_ptr[scale_id0 >> 1], scale_id0 & 1);
     output[id] = static_cast<OutT>(v0 - zp0) * scale_ptr[scale_id0];
@@ -636,7 +640,8 @@ __global__ void DequantizeLinearKernelAxisStdInt4(const InT* input, OutT* output
 template <class InT, class OutT, int NumThreadsPerBlock, int NumElementsPerThread>
 __global__ void DequantizeLinearKernelBlockStdInt4(const InT* input, OutT* output, const OutT* scale_ptr,
                                                    const InT* zero_point_ptr, CUDA_LONG num_element,
-                                                   size_t KN, size_t N, size_t scale_KN, size_t block_size) {
+                                                   fast_divmod fdm_KN, fast_divmod fdm_N, fast_divmod fdm_block_size,
+                                                   int32_t N, int32_t scale_KN) {
   // Process continuous NumElementsPerThread int4 per thread.
   CUDA_LONG id = NumElementsPerThread * NumThreadsPerBlock * blockIdx.x + (threadIdx.x << 1);
   int i = 0;
@@ -645,11 +650,13 @@ __global__ void DequantizeLinearKernelBlockStdInt4(const InT* input, OutT* outpu
 #pragma unroll
   // Process two elements which belong to one byte at a time.
   for (; i + 1 < NumElementsPerThread && id + 1 < num_element; i += 2, id += step) {
-    int x0 = id / KN, x1 = (id + 1) / KN;
-    int y0 = id % KN / N, y1 = (id + 1) % KN / N;
-    int z0 = id % N, z1 = (id + 1) % N;
-    int scale_id0 = x0 * scale_KN + y0 / block_size * N + z0;
-    int scale_id1 = x1 * scale_KN + y1 / block_size * N + z1;
+    int32_t x0, x1, rem0, rem1, y0, y1, z0, z1;
+    fdm_KN.divmod(id, x0, rem0);
+    fdm_N.divmod(rem0, y0, z0);
+    fdm_KN.divmod(id + 1, x1, rem1);
+    fdm_N.divmod(rem1, y1, z1);
+    const int32_t scale_id0{x0 * scale_KN + fdm_block_size.div(y0) * N + z0};
+    const int32_t scale_id1{x1 * scale_KN + fdm_block_size.div(y1) * N + z1};
 
     int v0 = ExtractInt4FromByte(input[id >> 1], 0);
     int v1 = ExtractInt4FromByte(input[id >> 1], 1);
@@ -661,10 +668,10 @@ __global__ void DequantizeLinearKernelBlockStdInt4(const InT* input, OutT* outpu
 
   // last non-paired element
   if (i < NumElementsPerThread && id < num_element) {
-    int x0 = id / KN;
-    int y0 = id % KN / N;
-    int z0 = id % N;
-    int scale_id0 = x0 * scale_KN + y0 / block_size * N + z0;
+    int32_t x0, rem0, y0, z0;
+    fdm_KN.divmod(id, x0, rem0);
+    fdm_N.divmod(rem0, y0, z0);
+    const int32_t scale_id0{x0 * scale_KN + fdm_block_size.div(y0) * N + z0};
 
     int v0 = ExtractInt4FromByte(input[id >> 1], 0);
     int zp0 = zero_point_ptr == nullptr ? 0 : ExtractInt4FromByte(zero_point_ptr[scale_id0 >> 1], scale_id0 & 1);
@@ -821,14 +828,16 @@ Status CudaDequantizeLinearAxisStd(cudaStream_t stream, const InT* input, OutT* 
     return Status::OK();
 
   int blocksPerGrid = static_cast<int>(CeilDiv(num_of_element, GridDim::maxThreadsPerBlock * GridDim::maxElementsPerThread));
+  const fast_divmod fdm_same_scale{static_cast<int32_t>(num_of_element / (batch_size * n_scales))};
+  const fast_divmod fdm_n_scales{static_cast<int32_t>(n_scales)};
   DequantizeLinearKernelAxisStd<InT, OutT, GridDim::maxThreadsPerBlock, GridDim::maxElementsPerThread><<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0, stream>>>(
       input,
       output,
       scale,
       zero_point,
       static_cast<int>(num_of_element),
-      batch_size,
-      n_scales);
+      fdm_same_scale,
+      fdm_n_scales);
   return Status::OK();
 }
 
@@ -843,6 +852,8 @@ Status CudaDequantizeLinearAxisStdInt4(cudaStream_t stream, const InT* input, Ou
 
   int blocksPerGrid = static_cast<int>(CeilDiv(num_of_element,
                                                GridDim::maxThreadsPerBlock * GridDim::maxElementsPerThread));
+  const fast_divmod fdm_same_scale{static_cast<int32_t>(num_of_element / (batch_size * n_scales))};
+  const fast_divmod fdm_n_scales{static_cast<int32_t>(n_scales)};
   DequantizeLinearKernelAxisStdInt4<InT, OutT, GridDim::maxThreadsPerBlock, GridDim::maxElementsPerThread>
       <<<blocksPerGrid, GridDim::maxThreadsPerBlock, 0, stream>>>(
           input,
@@ -850,8 +861,8 @@ Status CudaDequantizeLinearAxisStdInt4(cudaStream_t stream, const InT* input, Ou
           scale,
           zero_point,
           static_cast<int>(num_of_element),
-          batch_size,
-          n_scales);
+          fdm_same_scale,
+          fdm_n_scales);
   return Status::OK();
 }
 
@@ -876,10 +887,11 @@ Status CudaDequantizeLinearBlockStdInt4(cudaStream_t stream, const T* input, U* 
           scale,
           zero_point,
           static_cast<CUDA_LONG>(num_of_element),
-          KN,
-          N,
-          scale_KN,
-          block_size);
+          fast_divmod{static_cast<int32_t>(KN)},
+          fast_divmod{static_cast<int32_t>(N)},
+          fast_divmod{static_cast<int32_t>(block_size)},
+          static_cast<int32_t>(N),
+          static_cast<int32_t>(scale_KN));
   return Status::OK();
 }
 

--- a/onnxruntime/test/providers/cpu/tensor/quantize_linear_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/quantize_linear_test.cc
@@ -951,6 +951,46 @@ TEST(DequantizeLinearOpTest, Opset25_BlockedUInt4_Cuda) {
 
   RunQDQOp25CudaOnly(test);
 }
+
+// The tests above are [2, 4] with axis=1, so N == 1 and the scale index degenerates. These cover
+// N > 1: [2, 3, 2] axis=1 block_size=2 gives K=3, N=2, with 8 distinct scales.
+TEST(DequantizeLinearOpTest, Opset25_BlockedInt4_InnerDim_Cuda) {
+  OpTester test("DequantizeLinear", 25);
+  std::vector<int64_t> dims{2, 3, 2};
+  test.AddAttribute<int64_t>("axis", 1);
+  test.AddAttribute<int64_t>("block_size", 2);
+  // int4 values, in flat order: 1,2,3,4,5,6, 7,1,2,3,4,5
+  test.AddInput<Int4x2>("x", dims,
+                        {Int4x2(1, 2), Int4x2(3, 4), Int4x2(5, 6),
+                         Int4x2(7, 1), Int4x2(2, 3), Int4x2(4, 5)});
+  test.AddInput<float>("x_scale", {2, 2, 2}, {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f});
+  test.AddInput<Int4x2>("x_zero_point", {2, 2, 2},
+                        {Int4x2(0, 0), Int4x2(0, 0), Int4x2(0, 0), Int4x2(0, 0)});
+  // scale_id per element: 0,1,0,1,2,3, 4,5,4,5,6,7
+  test.AddOutput<float>("y", dims,
+                        {1.0f, 4.0f, 3.0f, 8.0f, 15.0f, 24.0f,
+                         35.0f, 6.0f, 10.0f, 18.0f, 28.0f, 40.0f});
+
+  RunQDQOp25CudaOnly(test);
+}
+
+TEST(QuantizeLinearOpTest, Opset25_BlockedInt4_InnerDim_Cuda) {
+  OpTester test("QuantizeLinear", 25);
+  std::vector<int64_t> dims{2, 3, 2};
+  test.AddAttribute<int64_t>("axis", 1);
+  test.AddAttribute<int64_t>("block_size", 2);
+  test.AddInput<float>("x", dims,
+                       {1.0f, 4.0f, 3.0f, 8.0f, 15.0f, 24.0f,
+                        35.0f, 6.0f, 10.0f, 18.0f, 28.0f, 40.0f});
+  test.AddInput<float>("y_scale", {2, 2, 2}, {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f});
+  test.AddInput<Int4x2>("y_zero_point", {2, 2, 2},
+                        {Int4x2(0, 0), Int4x2(0, 0), Int4x2(0, 0), Int4x2(0, 0)});
+  test.AddOutput<Int4x2>("y", dims,
+                         {Int4x2(1, 2), Int4x2(3, 4), Int4x2(5, 6),
+                          Int4x2(7, 1), Int4x2(2, 3), Int4x2(4, 5)});
+
+  RunQDQOp25CudaOnly(test);
+}
 #endif  // USE_CUDA
 
 template <bool Signed>


### PR DESCRIPTION
### Description

The per-axis and block-wise `QuantizeLinear`/`DequantizeLinear` CUDA kernels computed their scale
index with runtime integer division and modulo. This replaces those with ORT's existing
`fast_divmod`.

Six kernels are converted, plus their host launchers:
`QuantizeLinearKernelAxisStd`, `QuantizeLinearKernelAxisStdInt4`, `QuantizeLinearKernelBlockStdInt4`,
`DequantizeLinearKernelAxisStd`, `DequantizeLinearKernelAxisStdInt4`,
`DequantizeLinearKernelBlockStdInt4`.

All the divisors are loop-invariant and known on the host, so they become `fast_divmod` parameters
built at launch. `divmod()` returns quotient and remainder together, which also removes the separate
`id % KN` and `id % N` operations.

The memory access pattern is unchanged; this is purely an arithmetic-intensity fix.

Two behavioural notes:
- Output is bit-exact. `fast_divmod` is exact for the non-negative indices these kernels use;
  I verified this by comparing full output buffers against the original kernels.
- `fast_divmod` requires a divisor in `[1, INT32_MAX]` and will `ORT_ENFORCE` outside that. The
  element index is already `CUDA_LONG` (`int32_t`), so a tensor large enough to trip this could not
  have worked before either. This also removes a latent divide-by-zero: `n_same_scale` was
  previously used as a divisor with no guard.

### Motivation and Context

NVIDIA hardware has no integer-divide instruction, so every `/` and `%` by a runtime value expands
into a software sequence. Worse, because the divisors were declared `size_t`, the 32-bit element
index was promoted and the compiler emitted **64-bit** division which is a more expensive form.

From `DequantizeLinearKernelBlockStdInt4` before this change:

```cpp
int x0 = id / KN,     x1 = (id + 1) / KN;
int y0 = id % KN / N, y1 = (id + 1) % KN / N;
int z0 = id % N,      z1 = (id + 1) % N;
int scale_id0 = x0 * scale_KN + y0 / block_size * N + z0;
int scale_id1 = x1 * scale_KN + y1 / block_size * N + z1;
```

`CUDA_LONG` is `int32_t`; `KN`, `N` and `block_size` are `size_t`. That is ten 64-bit divides per two
output elements, wrapped around a body whose real work is one single subtract and one multiply. Roughly: a
32-bit divide is ~20 instructions, a 64-bit divide ~70-100, and `fast_divmod::div` is one `__umulhi`
plus an add and a shift.

The practical effect is that a kernel which should be purely memory bound was instead integer-ALU
bound. This is on the hot path for INT4 block-quantized weight dequantization and per-channel QDQ
models.

`fast_divmod` already exists at `core/providers/cuda/shared_inc/fast_divmod.h` and and can be used for this.

Found by inspection; there is no existing issue tracking it.

### Performance

RTX 5060 Laptop (26 SMs, sm_120, ~256 GB/s peak), CUDA 12.9. `DequantizeLinearKernelBlockStdInt4` copied verbatim as the baseline, 50 timed iterations after warm-up, full output buffers compared for bit-equality.

| shape (B,K,N) / block | before | after | speedup | achieved BW |
 |---|---|---|---|---|
| `(1, 4096, 4096)` / 32 | 0.325 ms | 0.186 ms | 1.75x | 216 GB/s |
 | `(1, 4096, 11008)` / 128 | 0.966 ms | 0.508 ms | 1.90x | 218 GB/s | 
| `(1, 8192, 4096)` / 64 | 0.711 ms | 0.360 ms | 1.98x | 227 GB/s |

At ~220 GB/s against a ~256 GB/s peak the kernel is now increasingly memory bound.

### Testing

`onnxruntime_provider_test --gtest_filter=*QuantizeLinear*:*DequantizeLinear*:*QDQ*` passes with no failures. The converted paths are directly covered by existing tests, including `DequantizeLinearOpTest.Opset25_BlockedInt4_Cuda`, `Opset25_BlockedUInt4_Cuda`, and the `Per_Channel_Axis_*` tests.

Also added new tests.
