### PR TITLE
[WebGPU] Fuse eight more activations into Conv

### DIFF
--- a/onnxruntime/core/optimizer/conv_activation_fusion.cc
+++ b/onnxruntime/core/optimizer/conv_activation_fusion.cc
@@ -206,8 +206,11 @@ class FuseConvActivationAction : public ReplaceWithNew {
       activation_params.push_back(alpha);
       activation_params.push_back(beta);
     } else if (activation_op_type == "QuickGelu") {
+      // com.microsoft.QuickGelu defaults alpha to 1.702 (the GELU approximation), not 1.0.
+      // Alpha 1.0 would silently turn this into SiLU/Swish.
+      constexpr float kQuickGeluDefaultAlpha = 1.702f;
       auto* alpha_attr = graph_utils::GetNodeAttribute(*activation, "alpha");
-      activation_params.push_back(alpha_attr == nullptr ? 1.0f : alpha_attr->f());
+      activation_params.push_back(alpha_attr == nullptr ? kQuickGeluDefaultAlpha : alpha_attr->f());
     } else if (activation_op_type == "Elu") {
       auto* alpha_attr = graph_utils::GetNodeAttribute(*activation, "alpha");
       activation_params.push_back(alpha_attr == nullptr ? 1.0f : alpha_attr->f());

--- a/onnxruntime/core/optimizer/conv_activation_fusion.cc
+++ b/onnxruntime/core/optimizer/conv_activation_fusion.cc
@@ -98,6 +98,25 @@ class ConvActivationSelector : public NodeSelector {
       return false;
     };
 
+    // These activations are supported only for WebGPU internal NHWC Conv.
+    auto is_supported_webgpu_ep_activation = [&node](const Node& activation_node) {
+      if (node.Domain() != kMSInternalNHWCDomain) {
+        return false;
+      }
+      if (graph_utils::IsSupportedOptypeVersionAndDomain(activation_node, "FastGelu", {1}, kMSDomain)) {
+        // The optional bias input makes FastGelu non-elementwise.
+        return activation_node.InputDefs().size() == 1;
+      }
+      return graph_utils::IsSupportedOptypeVersionAndDomain(activation_node, "QuickGelu", {1}, kMSDomain) ||
+             graph_utils::IsSupportedOptypeVersionAndDomain(activation_node, "Gelu", {1}, kMSDomain) ||
+             graph_utils::IsSupportedOptypeVersionAndDomain(activation_node, "HardSwish", {14, 22}) ||
+             graph_utils::IsSupportedOptypeVersionAndDomain(activation_node, "Elu", {6, 22}) ||
+             graph_utils::IsSupportedOptypeVersionAndDomain(activation_node, "Gelu", {20}) ||
+             graph_utils::IsSupportedOptypeVersionAndDomain(activation_node, "Softplus", {1, 22}) ||
+             graph_utils::IsSupportedOptypeVersionAndDomain(activation_node, "ThresholdedRelu", {10, 22}) ||
+             graph_utils::IsSupportedOptypeVersionAndDomain(activation_node, "Erf", {9, 13});
+    };
+
     if (!ConvFusionDataTypeCheck(node)) {
       return std::nullopt;
     }
@@ -106,7 +125,9 @@ class ConvActivationSelector : public NodeSelector {
     if (node_ep == kCudaExecutionProvider) {
       return std::nullopt;
     } else if (node_ep.empty() || node_ep == kCpuExecutionProvider || node_ep == kJsExecutionProvider || node_ep == kWebGpuExecutionProvider) {
-      if (!is_supported_non_cuda_ep_activation(*next_node) &&
+      const bool webgpu_activation =
+          node_ep == kWebGpuExecutionProvider && is_supported_webgpu_ep_activation(*next_node);
+      if (!webgpu_activation && !is_supported_non_cuda_ep_activation(*next_node) &&
           !graph_utils::IsSupportedOptypeVersionAndDomain(*next_node, "HardSigmoid", {6, 22})) {
         return std::nullopt;
       }
@@ -184,6 +205,20 @@ class FuseConvActivationAction : public ReplaceWithNew {
       float beta = (beta_attr == nullptr ? 0.5f : beta_attr->f());
       activation_params.push_back(alpha);
       activation_params.push_back(beta);
+    } else if (activation_op_type == "QuickGelu") {
+      auto* alpha_attr = graph_utils::GetNodeAttribute(*activation, "alpha");
+      activation_params.push_back(alpha_attr == nullptr ? 1.0f : alpha_attr->f());
+    } else if (activation_op_type == "Elu") {
+      auto* alpha_attr = graph_utils::GetNodeAttribute(*activation, "alpha");
+      activation_params.push_back(alpha_attr == nullptr ? 1.0f : alpha_attr->f());
+    } else if (activation_op_type == "ThresholdedRelu") {
+      auto* alpha_attr = graph_utils::GetNodeAttribute(*activation, "alpha");
+      activation_params.push_back(alpha_attr == nullptr ? 1.0f : alpha_attr->f());
+    } else if (activation_op_type == "Gelu") {
+      // Encode ONNX Gelu's approximation mode as 0 (erf) or 1 (tanh).
+      const auto* approximate_attr = graph_utils::GetNodeAttribute(*activation, "approximate");
+      const bool tanh_approximation = approximate_attr != nullptr && approximate_attr->s() == "tanh";
+      activation_params.push_back(tanh_approximation ? 1.0f : 0.0f);
     }
 
     if (!activation_params.empty()) {

--- a/onnxruntime/core/optimizer/conv_activation_fusion.cc
+++ b/onnxruntime/core/optimizer/conv_activation_fusion.cc
@@ -104,8 +104,10 @@ class ConvActivationSelector : public NodeSelector {
         return false;
       }
       if (graph_utils::IsSupportedOptypeVersionAndDomain(activation_node, "FastGelu", {1}, kMSDomain)) {
-        // The optional bias input makes FastGelu non-elementwise.
-        return activation_node.InputDefs().size() == 1;
+        // A bias makes FastGelu non-elementwise. An absent optional input is either omitted from
+        // the node or serialized with an empty name, so test the NodeArg rather than the count.
+        const auto& activation_inputs = activation_node.InputDefs();
+        return activation_inputs.size() < 2 || !activation_inputs[1]->Exists();
       }
       return graph_utils::IsSupportedOptypeVersionAndDomain(activation_node, "QuickGelu", {1}, kMSDomain) ||
              graph_utils::IsSupportedOptypeVersionAndDomain(activation_node, "Gelu", {1}, kMSDomain) ||

--- a/onnxruntime/core/optimizer/conv_activation_fusion.cc
+++ b/onnxruntime/core/optimizer/conv_activation_fusion.cc
@@ -208,8 +208,7 @@ class FuseConvActivationAction : public ReplaceWithNew {
       activation_params.push_back(alpha);
       activation_params.push_back(beta);
     } else if (activation_op_type == "QuickGelu") {
-      // com.microsoft.QuickGelu defaults alpha to 1.702 (the GELU approximation), not 1.0.
-      // Alpha 1.0 would silently turn this into SiLU/Swish.
+      // com.microsoft.QuickGelu defaults alpha to 1.702 (the GELU approximation)
       constexpr float kQuickGeluDefaultAlpha = 1.702f;
       auto* alpha_attr = graph_utils::GetNodeAttribute(*activation, "alpha");
       activation_params.push_back(alpha_attr == nullptr ? kQuickGeluDefaultAlpha : alpha_attr->f());

--- a/onnxruntime/core/optimizer/transpose_optimization/onnx_transpose_optimization.cc
+++ b/onnxruntime/core/optimizer/transpose_optimization/onnx_transpose_optimization.cc
@@ -2786,6 +2786,7 @@ static const std::unordered_map<std::string_view, const HandlerInfo&> handler_ma
     {"Softsign", simple_node_handler},
     {"ThresholdedRelu", simple_node_handler},
     {"Celu", simple_node_handler},
+    {"Elu", simple_node_handler},
     {"HardSwish", simple_node_handler},
 
     {"Sin", simple_node_handler},

--- a/onnxruntime/core/optimizer/transpose_optimization/onnx_transpose_optimization.cc
+++ b/onnxruntime/core/optimizer/transpose_optimization/onnx_transpose_optimization.cc
@@ -2786,7 +2786,6 @@ static const std::unordered_map<std::string_view, const HandlerInfo&> handler_ma
     {"Softsign", simple_node_handler},
     {"ThresholdedRelu", simple_node_handler},
     {"Celu", simple_node_handler},
-    {"Elu", simple_node_handler},
     {"HardSwish", simple_node_handler},
 
     {"Sin", simple_node_handler},

--- a/onnxruntime/core/providers/webgpu/math/matmul.cc
+++ b/onnxruntime/core/providers/webgpu/math/matmul.cc
@@ -69,6 +69,7 @@ Status MatMulNaiveProgram::GenerateShaderCode(ShaderHelper& shader) const {
   std::string apply_activation = GetActivationSnippet(activation_, "output_value_t", "output_element_t");
   const auto& output = shader.AddOutput("output", ShaderUsage::UseUniform |
                                                       ShaderUsage::UseIndicesTypeAlias | ShaderUsage::UseValueTypeAlias | ShaderUsage::UseElementTypeAlias);
+  shader.AdditionalImplementation() << GetActivationDeclaration(activation_, "output_value_t", "output_element_t");
   const auto& batch_dims = shader.AddIndices("batch_dims");
 
   int a_components = a.NumComponents();

--- a/onnxruntime/core/providers/webgpu/math/matmul_packed.cc
+++ b/onnxruntime/core/providers/webgpu/math/matmul_packed.cc
@@ -31,6 +31,8 @@ Status MatMulProgram::GenerateShaderCode(ShaderHelper& shader) const {
     bias = &shader.AddInput("bias", ShaderUsage::UseUniform);
   }
   std::string apply_activation = GetActivationSnippet(activation_, "output_value_t", "output_element_t");
+  // Emit activation helpers before the write function uses them.
+  shader.AdditionalImplementation() << GetActivationDeclaration(activation_, "output_value_t", "output_element_t");
   ProgramVariableDataType output_var_type = this->Outputs()[0].var_type;
   // declare the read and write functions
   MatMulReadFnSource(shader, a, b, &batch_dims, /*transA = */ false, /*transB = */ false);

--- a/onnxruntime/core/providers/webgpu/nn/conv2d_mm.cc
+++ b/onnxruntime/core/providers/webgpu/nn/conv2d_mm.cc
@@ -113,6 +113,8 @@ std::string Conv2dMMProgram::Conv2dCommonSnippet(const ShaderVariableHelper& x, 
   const std::string b_type = is_channels_last_ ? TypeSnippet(inner_element_size_w, data_type) : TypeSnippet(inner_element_size_x, data_type);
   const std::string apply_activation = GetActivationSnippet(activation, res_type, data_type);
   std::stringstream user_code;
+  // Emit activation helpers before mm_write uses them.
+  user_code << GetActivationDeclaration(activation, res_type, data_type);
   user_code << "fn mm_readA(batch : i32, row : i32, colIn : i32) -> " << a_type << " {\n"
             << (is_channels_last_ ? sample_x.str() : sample_w.str())
             << "}\n"

--- a/onnxruntime/core/providers/webgpu/nn/conv3d_naive.cc
+++ b/onnxruntime/core/providers/webgpu/nn/conv3d_naive.cc
@@ -28,6 +28,7 @@ Status Conv3DNaiveProgram::GenerateShaderCode(ShaderHelper& shader) const {
 
   // Helper functions to access x and w by 5D indices
   shader.AdditionalImplementation()
+      << GetActivationDeclaration(activation_, "x_value_t", "x_element_t")
       << "fn getX(d0 : u32, d1 : u32, d2 : u32, d3 : u32, d4 : u32) -> x_value_t {\n"
       << "  let aIndices = x_indices_t(d0, d1, d2, d3, d4);\n"
       << "  return " << x.GetByIndices("aIndices") << ";\n"

--- a/onnxruntime/core/providers/webgpu/nn/fuse_utils.cc
+++ b/onnxruntime/core/providers/webgpu/nn/fuse_utils.cc
@@ -2,12 +2,15 @@
 // Licensed under the MIT License.
 
 #include "core/providers/webgpu/nn/fuse_utils.h"
-#include "core/framework/op_kernel_info.h"
-#include "core/providers/webgpu/string_macros.h"
+
 #include <cstddef>
 #include <string>
 #include <utility>
 #include <vector>
+
+#include "core/framework/op_kernel_info.h"
+#include "core/providers/webgpu/string_macros.h"
+
 namespace onnxruntime {
 namespace webgpu {
 

--- a/onnxruntime/core/providers/webgpu/nn/fuse_utils.cc
+++ b/onnxruntime/core/providers/webgpu/nn/fuse_utils.cc
@@ -3,9 +3,8 @@
 
 #include "core/providers/webgpu/nn/fuse_utils.h"
 #include "core/framework/op_kernel_info.h"
-#include <iomanip>
-#include <limits>
-#include <sstream>
+#include "core/providers/webgpu/string_macros.h"
+#include <cstddef>
 #include <string>
 #include <utility>
 #include <vector>
@@ -14,11 +13,16 @@ namespace webgpu {
 
 namespace {
 
-// Emit enough digits to round-trip each f32 exactly.
+// Holds the longest shortest-round-trip f32 rendering, e.g. "-1.23456792e-38".
+constexpr size_t kFloatLiteralReserveSize = 32;
+
+// OStringStream formats with std::to_chars, which ignores the global locale, so a comma decimal
+// separator cannot corrupt the emitted shader source. It emits the fewest digits that round-trip
+// each f32 exactly.
 std::string FloatLiteral(float value) {
-  std::ostringstream oss;
-  oss << std::setprecision(std::numeric_limits<float>::max_digits10) << value;
-  return oss.str();
+  SS(oss, kFloatLiteralReserveSize);
+  oss << value;
+  return SS_GET(oss);
 }
 
 // Parameters occupy uniform slots in activation_params_.values_ order.

--- a/onnxruntime/core/providers/webgpu/nn/fuse_utils.cc
+++ b/onnxruntime/core/providers/webgpu/nn/fuse_utils.cc
@@ -3,6 +3,9 @@
 
 #include "core/providers/webgpu/nn/fuse_utils.h"
 #include "core/framework/op_kernel_info.h"
+#include <iomanip>
+#include <limits>
+#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
@@ -11,6 +14,13 @@ namespace webgpu {
 
 namespace {
 
+// Emit enough digits to round-trip each f32 exactly.
+std::string FloatLiteral(float value) {
+  std::ostringstream oss;
+  oss << std::setprecision(std::numeric_limits<float>::max_digits10) << value;
+  return oss.str();
+}
+
 // Parameters occupy uniform slots in activation_params_.values_ order.
 size_t GetActivationUsedUniformCount(const Activation& activation) {
   switch (activation.activation_kind_) {
@@ -18,7 +28,11 @@ size_t GetActivationUsedUniformCount(const Activation& activation) {
     case ActivationKind::HardSigmoid:
       return 2;
     case ActivationKind::LeakyRelu:
+    case ActivationKind::Elu:
+    case ActivationKind::ThresholdedRelu:
       return 1;
+    case ActivationKind::QuickGelu:
+      return activation.HasUnitQuickGeluAlpha() ? 0 : 1;
     default:
       return 0;
   }
@@ -37,6 +51,23 @@ Status GetFusedActivationAttr(const OpKernelInfo& info, Activation& activation) 
       activation.activation_kind_ = ActivationKind::Tanh;
     } else if (activation_type == "Sigmoid") {
       activation.activation_kind_ = ActivationKind::Sigmoid;
+    } else if (activation_type == "HardSwish") {
+      // ONNX fixes HardSwish alpha and beta.
+      activation.activation_kind_ = ActivationKind::HardSwish;
+    } else if (activation_type == "Softplus") {
+      activation.activation_kind_ = ActivationKind::Softplus;
+    } else if (activation_type == "Erf") {
+      activation.activation_kind_ = ActivationKind::Erf;
+    } else if (activation_type == "Gelu" || activation_type == "FastGelu") {
+      // activation_params[0] selects erf (0) or tanh (1); FastGelu always uses tanh.
+      bool tanh_approximation = activation_type == "FastGelu";
+      if (!tanh_approximation) {
+        std::vector<float> approximate_param;
+        if (info.GetAttrs<float>("activation_params", approximate_param).IsOK() && !approximate_param.empty()) {
+          tanh_approximation = approximate_param[0] != 0.0f;
+        }
+      }
+      activation.activation_kind_ = tanh_approximation ? ActivationKind::GeluTanh : ActivationKind::Gelu;
     } else {
       // The remaining activation types have additional parameters to be pulled out.
       size_t activation_params_count;
@@ -49,6 +80,15 @@ Status GetFusedActivationAttr(const OpKernelInfo& info, Activation& activation) 
       } else if (activation_type == "HardSigmoid") {
         activation.activation_kind_ = ActivationKind::HardSigmoid;
         activation_params_count = 2;
+      } else if (activation_type == "QuickGelu") {
+        activation.activation_kind_ = ActivationKind::QuickGelu;
+        activation_params_count = 1;
+      } else if (activation_type == "Elu") {
+        activation.activation_kind_ = ActivationKind::Elu;
+        activation_params_count = 1;
+      } else if (activation_type == "ThresholdedRelu") {
+        activation.activation_kind_ = ActivationKind::ThresholdedRelu;
+        activation_params_count = 1;
       } else {
         return Status(common::ONNXRUNTIME, common::INVALID_ARGUMENT, "unimplemented activation: " + activation_type);
       }
@@ -69,6 +109,48 @@ Status GetFusedActivationAttr(const OpKernelInfo& info, Activation& activation) 
   return Status::OK();
 }
 
+std::string GetActivationDeclaration(const Activation& activation, std::string value_type, std::string base_type) {
+  auto base_type_cast = [base_type](const std::string& value) -> std::string {
+    return base_type + "(" + value + ")";
+  };
+  auto value_type_cast = [base_type_cast, value_type](const std::string& value) -> std::string {
+    return value_type + "(" + base_type_cast(value) + ")";
+  };
+
+  // Match the standalone Erf/Gelu implementation (Abramowitz & Stegun 7.1.26).
+  auto erf_fn = [&]() -> std::string {
+    return "fn fused_act_erf(v: " + value_type + ") -> " + value_type + " {\n" +
+           "  let a = abs(v);\n" +
+           "  let t = " + value_type_cast(FloatLiteral(1.0f)) + " / (" + value_type_cast(FloatLiteral(1.0f)) + " + " +
+           value_type_cast(FloatLiteral(0.3275911f)) + " * a);\n" +
+           "  return sign(v) * (" + value_type_cast(FloatLiteral(1.0f)) + " - ((((" +
+           value_type_cast(FloatLiteral(1.061405429f)) + " * t + " + value_type_cast(FloatLiteral(-1.453152027f)) +
+           ") * t + " + value_type_cast(FloatLiteral(1.421413741f)) + ") * t + " +
+           value_type_cast(FloatLiteral(-0.284496736f)) + ") * t + " + value_type_cast(FloatLiteral(0.254829592f)) +
+           ") * t * exp(-a * a));\n" +
+           "}\n";
+  };
+
+  // WGSL tanh returns NaN for large inputs; this equivalent form stays finite.
+  auto tanh_fn = [&]() -> std::string {
+    return "fn fused_act_tanh(v: " + value_type + ") -> " + value_type + " {\n" +
+           "  let e = exp(" + value_type_cast(FloatLiteral(-2.0f)) + " * abs(v));\n" +
+           "  return sign(v) * ((" + value_type_cast(FloatLiteral(1.0f)) + " - e) / (" +
+           value_type_cast(FloatLiteral(1.0f)) + " + e));\n" +
+           "}\n";
+  };
+
+  switch (activation.activation_kind_) {
+    case ActivationKind::Gelu:
+    case ActivationKind::Erf:
+      return erf_fn();
+    case ActivationKind::GeluTanh:
+      return tanh_fn();
+    default:
+      return "";
+  }
+}
+
 std::string GetActivationSnippet(const Activation& activation, std::string value_type, std::string base_type) {
   auto base_type_cast = [base_type](const std::string& value) -> std::string {
     return base_type + "(" + value + ")";
@@ -78,22 +160,53 @@ std::string GetActivationSnippet(const Activation& activation, std::string value
   };
   switch (activation.activation_kind_) {
     case ActivationKind::Relu:
-      return "value = max(value, " + value_type_cast(std::to_string(0.0f)) + ");";
+      return "value = max(value, " + value_type_cast(FloatLiteral(0.0f)) + ");";
     case ActivationKind::Sigmoid:
-      return "value = " + value_type_cast(std::to_string(1.0f)) + " / (" + value_type_cast(std::to_string(1.0f)) +
+      return "value = " + value_type_cast(FloatLiteral(1.0f)) + " / (" + value_type_cast(FloatLiteral(1.0f)) +
              " + exp(-value));";
     case ActivationKind::Clip:
       return "value = clamp(value, " + value_type_cast("uniforms.activation_param_0") + ", " +
              value_type_cast("uniforms.activation_param_1") + ");";
     case ActivationKind::HardSigmoid:
       return "value = clamp(" + value_type_cast("uniforms.activation_param_0") + " * value + " +
-             value_type_cast("uniforms.activation_param_1") + ", " + value_type_cast(std::to_string(0.0f)) + ", " +
-             value_type_cast(std::to_string(1.0f)) + ");";
+             value_type_cast("uniforms.activation_param_1") + ", " + value_type_cast(FloatLiteral(0.0f)) + ", " +
+             value_type_cast(FloatLiteral(1.0f)) + ");";
     case ActivationKind::LeakyRelu:
       return "value = select(" + base_type_cast("uniforms.activation_param_0") + " * value, value, value >= " +
-             value_type_cast(std::to_string(0.0f)) + ");";
+             value_type_cast(FloatLiteral(0.0f)) + ");";
     case ActivationKind::Tanh:
       return "value = tanh(value);";
+    case ActivationKind::QuickGelu:
+      // Alpha 1 omits the multiply and uniform read.
+      if (activation.HasUnitQuickGeluAlpha()) {
+        return "value = value * (" + value_type_cast(FloatLiteral(1.0f)) + " / (" +
+               value_type_cast(FloatLiteral(1.0f)) + " + exp(-value)));";
+      }
+      return "value = value * (" + value_type_cast(FloatLiteral(1.0f)) + " / (" + value_type_cast(FloatLiteral(1.0f)) +
+             " + exp(-(" + base_type_cast("uniforms.activation_param_0") + " * value))));";
+    case ActivationKind::HardSwish:
+      return "value = value * clamp(value * " + value_type_cast(FloatLiteral(1.0f / 6.0f)) + " + " +
+             value_type_cast(FloatLiteral(0.5f)) + ", " + value_type_cast(FloatLiteral(0.0f)) + ", " +
+             value_type_cast(FloatLiteral(1.0f)) + ");";
+    case ActivationKind::Elu:
+      return "value = select(" + base_type_cast("uniforms.activation_param_0") + " * (exp(value) - " +
+             value_type_cast(FloatLiteral(1.0f)) + "), value, value >= " + value_type_cast(FloatLiteral(0.0f)) + ");";
+    case ActivationKind::ThresholdedRelu:
+      return "value = select(" + value_type_cast(FloatLiteral(0.0f)) + ", value, value > " +
+             value_type_cast("uniforms.activation_param_0") + ");";
+    case ActivationKind::Erf:
+      return "value = fused_act_erf(value);";
+    case ActivationKind::Gelu:
+      return "value = " + value_type_cast(FloatLiteral(0.5f)) + " * value * (" + value_type_cast(FloatLiteral(1.0f)) +
+             " + fused_act_erf(value * " + value_type_cast(FloatLiteral(0.70710678118654752f)) + "));";
+    case ActivationKind::GeluTanh:
+      return "value = value * (" + value_type_cast(FloatLiteral(0.5f)) + " + " + value_type_cast(FloatLiteral(0.5f)) +
+             " * fused_act_tanh(value * (" + value_type_cast(FloatLiteral(0.035677408136300125f)) +
+             " * value * value + " + value_type_cast(FloatLiteral(0.79788456080286535f)) + ")));";
+    case ActivationKind::Softplus:
+      // Use the overflow-safe softplus form.
+      return "value = max(value, " + value_type_cast(FloatLiteral(0.0f)) + ") + log(" +
+             value_type_cast(FloatLiteral(1.0f)) + " + exp(-abs(value)));";
     default:
       return "";
   }

--- a/onnxruntime/core/providers/webgpu/nn/fuse_utils.h
+++ b/onnxruntime/core/providers/webgpu/nn/fuse_utils.h
@@ -21,14 +21,29 @@ enum class ActivationKind {
   Clip,
   HardSigmoid,
   LeakyRelu,
-  Tanh
+  Tanh,
+  QuickGelu,
+  HardSwish,
+  Elu,
+  Gelu,
+  GeluTanh,
+  Softplus,
+  ThresholdedRelu,
+  Erf
 };
 
 using Activation = struct Activation {
   std::string CacheKey() const {
     std::stringstream oss;
     oss << "ActivationKind: " << static_cast<int>(activation_kind_) << ";";
+    if (activation_kind_ == ActivationKind::QuickGelu) {
+      oss << "QuickGeluUnitAlpha: " << (HasUnitQuickGeluAlpha() ? 1 : 0) << ";";
+    }
     return oss.str();
+  }
+  // Alpha 1 selects a shader variant without the multiply or alpha uniform.
+  bool HasUnitQuickGeluAlpha() const {
+    return activation_kind_ == ActivationKind::QuickGelu && activation_params_.QuickGelu.alpha_ == 1.0f;
   }
   using ActivationParameters = union ActivationParameters {
     struct {
@@ -42,6 +57,15 @@ using Activation = struct Activation {
       float alpha_;
       float beta_;
     } HardSigmoid;
+    struct {
+      float alpha_;
+    } QuickGelu;
+    struct {
+      float alpha_;
+    } Elu;
+    struct {
+      float alpha_;
+    } ThresholdedRelu;
     float values_[2];
   };
   ActivationParameters activation_params_ = {};
@@ -59,6 +83,9 @@ constexpr size_t kActivationUniformVariableCount = 2;
 Status GetFusedActivationAttr(const OpKernelInfo& info, Activation& activation);
 
 std::string GetActivationSnippet(const Activation& activation, std::string value_type, std::string base_type);
+
+// Returns module-scope WGSL required by GetActivationSnippet; emit it before the snippet's use.
+std::string GetActivationDeclaration(const Activation& activation, std::string value_type, std::string base_type);
 
 // Appends exactly kActivationUniformVariableCount values, with empty entries for unused slots.
 void AppendActivationUniformsData(const Activation& activation, std::vector<ProgramUniformVariableValue>& variables);

--- a/onnxruntime/core/providers/webgpu/nn/grouped_conv.cc
+++ b/onnxruntime/core/providers/webgpu/nn/grouped_conv.cc
@@ -69,6 +69,7 @@ Status GroupedConvProgram::GenerateShaderCode(ShaderHelper& shader) const {
   const auto& w = shader.AddInput("w", ShaderUsage::UseUniform | ShaderUsage::UseValueTypeAlias | ShaderUsage::UseIndicesTypeAlias);
   const auto& output = shader.AddOutput("output", ShaderUsage::UseUniform | ShaderUsage::UseIndicesTypeAlias | ShaderUsage::UseValueTypeAlias | ShaderUsage::UseElementTypeAlias);
   std::string apply_activation = GetActivationSnippet(activation_, "output_value_t", "output_element_t");
+  shader.AdditionalImplementation() << GetActivationDeclaration(activation_, "output_value_t", "output_element_t");
   shader.MainFunctionBody() << shader.GuardAgainstOutOfBoundsWorkgroupSizes("uniforms.output_size")
                             << "let output_indices = " << output.OffsetToIndices("global_idx") << ";\n"
                             << "let batch: u32 = output_indices[0];\n"

--- a/onnxruntime/core/providers/webgpu/vendor/intel/math/matmul.cc
+++ b/onnxruntime/core/providers/webgpu/vendor/intel/math/matmul.cc
@@ -26,6 +26,8 @@ Status MatMulSubgroupProgram::GenerateShaderCode(ShaderHelper& shader) const {
     bias = &shader.AddInput("bias", ShaderUsage::UseUniform);
   }
   std::string apply_activation = GetActivationSnippet(activation_, "output_value_t", "output_element_t");
+  // Emit activation helpers before the write function uses them.
+  shader.AdditionalImplementation() << GetActivationDeclaration(activation_, "output_value_t", "output_element_t");
   // declare the read and write functions
   MatMulReadFnSource(shader, a, b, &batch_dims, /*transA = */ false, /*transB = */ false);
   MatMulWriteFnSourceForMatMul(shader, output, bias, apply_activation, /*is_channels_last = */ false);

--- a/onnxruntime/test/optimizer/graph_transform_test.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test.cc
@@ -3498,6 +3498,318 @@ TEST_F(GraphTransformationTests, FuseConvActivationPreservingAttributes) {
   check_ints_attr("kernel_shape", AsSpan<int64_t>({3, 3}));
 }
 
+static void BuildConvQuickGeluGraph(ModelTestBuilder& builder, const std::string& conv_domain,
+                                    const std::string& ep, float alpha) {
+  auto* input = builder.MakeInput<float>({1, 5, 5, 2}, -1.0f, 1.0f);
+  auto* weight = builder.MakeInitializer<float>({3, 2, 3, 3}, -1.0f, 1.0f);
+  auto* conv_out = builder.MakeIntermediate();
+  auto* output = builder.MakeOutput();
+
+  Node& conv = builder.AddNode("Conv", {input, weight}, {conv_out}, conv_domain);
+  conv.SetExecutionProviderType(ep);
+
+  Node& quick_gelu = builder.AddNode("QuickGelu", {conv_out}, {output}, kMSDomain);
+  quick_gelu.AddAttribute("alpha", alpha);
+  quick_gelu.SetExecutionProviderType(ep);
+}
+
+static Status ExpectQuickGeluPresent(Graph& graph) {
+  int quick_gelu_count = 0;
+  for (const Node& node : graph.Nodes()) {
+    if (node.OpType() == "QuickGelu" && node.Domain() == kMSDomain) {
+      ++quick_gelu_count;
+    }
+  }
+  ORT_RETURN_IF_NOT(quick_gelu_count == 1, "expected exactly one QuickGelu node, got ",
+                    quick_gelu_count);
+  return Status::OK();
+}
+
+static Status ExpectUnfusedConvActivationPair(Graph& graph) {
+  ORT_RETURN_IF_NOT(graph.NumberOfNodes() == 2,
+                    "expected a Conv + activation pair before fusion, got ", graph.NumberOfNodes(),
+                    " nodes");
+  return Status::OK();
+}
+
+// In-memory test models must import the internal NHWC domain explicitly.
+static Status RunConvActivationFusion(const std::function<void(ModelTestBuilder&)>& build_test_case,
+                                      const logging::Logger& logger,
+                                      const std::function<Status(Graph&)>& post_graph_checker,
+                                      int opset_version = 13) {
+  const std::unordered_map<std::string, int> domain_to_version{
+      {kOnnxDomain, opset_version}, {kMSDomain, 1}, {kMSInternalNHWCDomain, opset_version}};
+
+  Model model("ConvActivationFusionTest", false, ModelMetaData(), PathString(),
+              IOnnxRuntimeOpSchemaRegistryList(), domain_to_version, {}, logger);
+  Graph& graph = model.MainGraph();
+  ModelTestBuilder builder(graph);
+  build_test_case(builder);
+  builder.SetGraphOutputs();
+  ORT_RETURN_IF_ERROR(graph.Resolve());
+  ORT_RETURN_IF_ERROR(ExpectUnfusedConvActivationPair(graph));
+
+  onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
+  ORT_RETURN_IF_ERROR(graph_transformation_mgr.Register(std::make_unique<ConvActivationFusion>(),
+                                                        TransformerLevel::Level2));
+  ORT_RETURN_IF_ERROR(graph_transformation_mgr.ApplyTransformers(graph, TransformerLevel::Level2, logger));
+
+  return post_graph_checker(graph);
+}
+
+TEST_F(GraphTransformationTests, FuseNhwcConvQuickGeluForWebGpuEp) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    BuildConvQuickGeluGraph(builder, kMSInternalNHWCDomain, kWebGpuExecutionProvider, 1.0f);
+  };
+
+  auto post_graph_checker = [](Graph& graph) -> Status {
+    ORT_RETURN_IF_NOT(graph.NumberOfNodes() == 1, "expected QuickGelu to be folded into Conv, got ",
+                      graph.NumberOfNodes(), " nodes");
+    const Node& fused = *graph.Nodes().begin();
+    ORT_RETURN_IF_NOT(fused.OpType() == "Conv" && fused.Domain() == kMSInternalNHWCDomain,
+                      "expected an NHWC Conv, got ", fused.Domain(), ".", fused.OpType());
+
+    const auto* activation = graph_utils::GetNodeAttribute(fused, "activation");
+    ORT_RETURN_IF_NOT(activation != nullptr && activation->s() == "QuickGelu",
+                      "fused Conv is missing the QuickGelu activation attribute");
+
+    const auto* params = graph_utils::GetNodeAttribute(fused, "activation_params");
+    ORT_RETURN_IF_NOT(params != nullptr && params->floats_size() == 1 && params->floats(0) == 1.0f,
+                      "fused Conv should carry the QuickGelu alpha as its only activation param");
+    return Status::OK();
+  };
+
+  ASSERT_STATUS_OK(RunConvActivationFusion(build_test_case, *logger_, post_graph_checker));
+}
+
+// CPU FusedConv does not support QuickGelu.
+TEST_F(GraphTransformationTests, NoFuseNhwcConvQuickGeluForCpuEp) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    BuildConvQuickGeluGraph(builder, kMSInternalNHWCDomain, kCpuExecutionProvider, 1.0f);
+  };
+
+  ASSERT_STATUS_OK(RunConvActivationFusion(build_test_case, *logger_, ExpectQuickGeluPresent));
+}
+
+// WebGPU supports this fusion only for internal NHWC Conv.
+TEST_F(GraphTransformationTests, NoFuseOnnxDomainConvQuickGeluForWebGpuEp) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    BuildConvQuickGeluGraph(builder, kOnnxDomain, kWebGpuExecutionProvider, 1.0f);
+  };
+
+  ASSERT_STATUS_OK(RunConvActivationFusion(build_test_case, *logger_, ExpectQuickGeluPresent));
+}
+
+static void BuildConvActivationGraph(ModelTestBuilder& builder, const std::string& act_op,
+                                     const std::string& act_domain, const std::string& ep,
+                                     const std::function<void(Node&)>& decorate = nullptr,
+                                     bool extra_input = false) {
+  auto* input = builder.MakeInput<float>({1, 5, 5, 2}, -1.0f, 1.0f);
+  auto* weight = builder.MakeInitializer<float>({3, 2, 3, 3}, -1.0f, 1.0f);
+  auto* conv_out = builder.MakeIntermediate();
+  auto* output = builder.MakeOutput();
+
+  Node& conv = builder.AddNode("Conv", {input, weight}, {conv_out}, kMSInternalNHWCDomain);
+  conv.SetExecutionProviderType(ep);
+
+  std::vector<NodeArg*> act_inputs{conv_out};
+  if (extra_input) {
+    act_inputs.push_back(builder.MakeInitializer<float>({3}, -1.0f, 1.0f));
+  }
+
+  Node& activation = builder.AddNode(act_op, act_inputs, {output}, act_domain);
+  if (decorate) {
+    decorate(activation);
+  }
+  activation.SetExecutionProviderType(ep);
+}
+
+static Status ExpectFusedInto(Graph& graph, const std::string& activation,
+                              const std::vector<float>& expected_params) {
+  ORT_RETURN_IF_NOT(graph.NumberOfNodes() == 1, "expected ", activation,
+                    " to be folded into Conv, got ", graph.NumberOfNodes(), " nodes");
+  const Node& fused = *graph.Nodes().begin();
+  ORT_RETURN_IF_NOT(fused.OpType() == "Conv" && fused.Domain() == kMSInternalNHWCDomain,
+                    "expected an NHWC Conv, got ", fused.Domain(), ".", fused.OpType());
+
+  const auto* activation_attr = graph_utils::GetNodeAttribute(fused, "activation");
+  ORT_RETURN_IF_NOT(activation_attr != nullptr && activation_attr->s() == activation,
+                    "fused Conv should carry activation ", activation, ", got ",
+                    activation_attr == nullptr ? "<none>" : activation_attr->s());
+
+  const auto* params = graph_utils::GetNodeAttribute(fused, "activation_params");
+  if (expected_params.empty()) {
+    ORT_RETURN_IF_NOT(params == nullptr || params->floats_size() == 0, activation,
+                      " takes no parameters, but activation_params was set");
+    return Status::OK();
+  }
+
+  ORT_RETURN_IF_NOT(params != nullptr, activation, " should carry activation_params");
+  ORT_RETURN_IF_NOT(static_cast<size_t>(params->floats_size()) == expected_params.size(),
+                    activation, " expected ", expected_params.size(), " activation_params, got ",
+                    params->floats_size());
+  for (size_t i = 0; i < expected_params.size(); ++i) {
+    ORT_RETURN_IF_NOT(params->floats(static_cast<int>(i)) == expected_params[i], activation,
+                      " activation_params[", i, "] expected ", expected_params[i], ", got ",
+                      params->floats(static_cast<int>(i)));
+  }
+  return Status::OK();
+}
+
+static std::function<Status(Graph&)> ExpectNotFused(const std::string& act_op) {
+  return [act_op](Graph& graph) -> Status {
+    int count = 0;
+    for (const Node& node : graph.Nodes()) {
+      if (node.OpType() == act_op) {
+        ++count;
+      }
+    }
+    ORT_RETURN_IF_NOT(count == 1, "expected ", act_op, " to be left unfused, found ", count,
+                      " such nodes in a graph of ", graph.NumberOfNodes());
+    return Status::OK();
+  };
+}
+
+TEST_F(GraphTransformationTests, FuseNhwcConvHardSwishForWebGpuEp) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    BuildConvActivationGraph(builder, "HardSwish", kOnnxDomain, kWebGpuExecutionProvider);
+  };
+  auto check = [](Graph& graph) { return ExpectFusedInto(graph, "HardSwish", {}); };
+
+  ASSERT_STATUS_OK(RunConvActivationFusion(build_test_case, *logger_, check, 17));
+}
+
+TEST_F(GraphTransformationTests, FuseNhwcConvEluPreservesAlphaForWebGpuEp) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    BuildConvActivationGraph(builder, "Elu", kOnnxDomain, kWebGpuExecutionProvider,
+                             [](Node& node) { node.AddAttribute("alpha", 0.5f); });
+  };
+  auto check = [](Graph& graph) { return ExpectFusedInto(graph, "Elu", {0.5f}); };
+
+  ASSERT_STATUS_OK(RunConvActivationFusion(build_test_case, *logger_, check, 17));
+}
+
+TEST_F(GraphTransformationTests, FuseNhwcConvEluDefaultsAlphaForWebGpuEp) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    BuildConvActivationGraph(builder, "Elu", kOnnxDomain, kWebGpuExecutionProvider);
+  };
+  auto check = [](Graph& graph) { return ExpectFusedInto(graph, "Elu", {1.0f}); };
+
+  ASSERT_STATUS_OK(RunConvActivationFusion(build_test_case, *logger_, check, 17));
+}
+
+// activation_params encodes Gelu approximation as 0 (erf) or 1 (tanh).
+TEST_F(GraphTransformationTests, FuseNhwcConvOnnxGeluForWebGpuEp) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    BuildConvActivationGraph(builder, "Gelu", kOnnxDomain, kWebGpuExecutionProvider);
+  };
+  auto check = [](Graph& graph) { return ExpectFusedInto(graph, "Gelu", {0.0f}); };
+
+  ASSERT_STATUS_OK(RunConvActivationFusion(build_test_case, *logger_, check, 20));
+}
+
+TEST_F(GraphTransformationTests, FuseNhwcConvOnnxGeluTanhForWebGpuEp) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    BuildConvActivationGraph(builder, "Gelu", kOnnxDomain, kWebGpuExecutionProvider,
+                             [](Node& node) { node.AddAttribute("approximate", "tanh"); });
+  };
+  auto check = [](Graph& graph) { return ExpectFusedInto(graph, "Gelu", {1.0f}); };
+
+  ASSERT_STATUS_OK(RunConvActivationFusion(build_test_case, *logger_, check, 20));
+}
+
+TEST_F(GraphTransformationTests, FuseNhwcConvContribGeluForWebGpuEp) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    BuildConvActivationGraph(builder, "Gelu", kMSDomain, kWebGpuExecutionProvider);
+  };
+  auto check = [](Graph& graph) { return ExpectFusedInto(graph, "Gelu", {0.0f}); };
+
+  ASSERT_STATUS_OK(RunConvActivationFusion(build_test_case, *logger_, check, 17));
+}
+
+TEST_F(GraphTransformationTests, FuseNhwcConvFastGeluForWebGpuEp) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    BuildConvActivationGraph(builder, "FastGelu", kMSDomain, kWebGpuExecutionProvider);
+  };
+  auto check = [](Graph& graph) { return ExpectFusedInto(graph, "FastGelu", {}); };
+
+  ASSERT_STATUS_OK(RunConvActivationFusion(build_test_case, *logger_, check, 17));
+}
+
+// FastGelu with a bias input is not elementwise.
+TEST_F(GraphTransformationTests, NoFuseNhwcConvFastGeluWithBiasForWebGpuEp) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    BuildConvActivationGraph(builder, "FastGelu", kMSDomain, kWebGpuExecutionProvider, nullptr,
+                             /*extra_input=*/true);
+  };
+
+  ASSERT_STATUS_OK(
+      RunConvActivationFusion(build_test_case, *logger_, ExpectNotFused("FastGelu"), 17));
+}
+
+TEST_F(GraphTransformationTests, FuseNhwcConvSoftplusForWebGpuEp) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    BuildConvActivationGraph(builder, "Softplus", kOnnxDomain, kWebGpuExecutionProvider);
+  };
+  auto check = [](Graph& graph) { return ExpectFusedInto(graph, "Softplus", {}); };
+
+  ASSERT_STATUS_OK(RunConvActivationFusion(build_test_case, *logger_, check, 17));
+}
+
+TEST_F(GraphTransformationTests, FuseNhwcConvThresholdedReluForWebGpuEp) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    BuildConvActivationGraph(builder, "ThresholdedRelu", kOnnxDomain, kWebGpuExecutionProvider,
+                             [](Node& node) { node.AddAttribute("alpha", 0.6f); });
+  };
+  auto check = [](Graph& graph) { return ExpectFusedInto(graph, "ThresholdedRelu", {0.6f}); };
+
+  ASSERT_STATUS_OK(RunConvActivationFusion(build_test_case, *logger_, check, 17));
+}
+
+TEST_F(GraphTransformationTests, FuseNhwcConvThresholdedReluDefaultAlphaForWebGpuEp) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    BuildConvActivationGraph(builder, "ThresholdedRelu", kOnnxDomain, kWebGpuExecutionProvider);
+  };
+  auto check = [](Graph& graph) { return ExpectFusedInto(graph, "ThresholdedRelu", {1.0f}); };
+
+  ASSERT_STATUS_OK(RunConvActivationFusion(build_test_case, *logger_, check, 17));
+}
+
+TEST_F(GraphTransformationTests, FuseNhwcConvErfForWebGpuEp) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    BuildConvActivationGraph(builder, "Erf", kOnnxDomain, kWebGpuExecutionProvider);
+  };
+  auto check = [](Graph& graph) { return ExpectFusedInto(graph, "Erf", {}); };
+
+  ASSERT_STATUS_OK(RunConvActivationFusion(build_test_case, *logger_, check, 17));
+}
+
+// WebGPU has no Selu kernel.
+TEST_F(GraphTransformationTests, NoFuseNhwcConvSeluForWebGpuEp) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    BuildConvActivationGraph(builder, "Selu", kOnnxDomain, kWebGpuExecutionProvider);
+  };
+
+  ASSERT_STATUS_OK(RunConvActivationFusion(build_test_case, *logger_, ExpectNotFused("Selu"), 17));
+}
+
+TEST_F(GraphTransformationTests, NoFuseNhwcConvHardSwishForCpuEp) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    BuildConvActivationGraph(builder, "HardSwish", kOnnxDomain, kCpuExecutionProvider);
+  };
+
+  ASSERT_STATUS_OK(
+      RunConvActivationFusion(build_test_case, *logger_, ExpectNotFused("HardSwish"), 17));
+}
+
+TEST_F(GraphTransformationTests, NoFuseNhwcConvGeluForCpuEp) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    BuildConvActivationGraph(builder, "Gelu", kOnnxDomain, kCpuExecutionProvider);
+  };
+
+  ASSERT_STATUS_OK(RunConvActivationFusion(build_test_case, *logger_, ExpectNotFused("Gelu"), 20));
+}
+
 #if defined(USE_WEBGPU)
 namespace {
 
@@ -3590,6 +3902,12 @@ TEST_F(GraphTransformationTests, WebGpuConvHardSigmoidFusionMatchesUnfusedResult
       "HardSigmoid", 17);
 }
 
+TEST_F(GraphTransformationTests, WebGpuConvEluFusionMatchesUnfusedResults) {
+  RunWebGpuConvActivationParity(
+      SimpleActivation("Elu", kOnnxDomain, [](Node& node) { node.AddAttribute("alpha", 0.7f); }),
+      "Elu", 17);
+}
+
 TEST_F(GraphTransformationTests, WebGpuConvClipFusionMatchesUnfusedResults) {
   auto add_clip = [](ModelTestBuilder& builder, NodeArg* conv_out, NodeArg* output) {
     auto* min_value = builder.MakeScalarInitializer<float>(-0.25f);
@@ -3597,6 +3915,48 @@ TEST_F(GraphTransformationTests, WebGpuConvClipFusionMatchesUnfusedResults) {
     builder.AddNode("Clip", {conv_out, min_value, max_value}, {output});
   };
   RunWebGpuConvActivationParity(add_clip, "Clip", 17);
+}
+
+TEST_F(GraphTransformationTests, WebGpuConvHardSwishFusionMatchesUnfusedResults) {
+  RunWebGpuConvActivationParity(SimpleActivation("HardSwish"), "HardSwish", 17);
+}
+
+TEST_F(GraphTransformationTests, WebGpuConvSoftplusFusionMatchesUnfusedResults) {
+  RunWebGpuConvActivationParity(SimpleActivation("Softplus"), "Softplus", 17);
+}
+
+TEST_F(GraphTransformationTests, WebGpuConvGeluFusionMatchesUnfusedResults) {
+  RunWebGpuConvActivationParity(SimpleActivation("Gelu"), "Gelu", 20);
+}
+
+TEST_F(GraphTransformationTests, WebGpuConvGeluTanhFusionMatchesUnfusedResults) {
+  RunWebGpuConvActivationParity(
+      SimpleActivation("Gelu", kOnnxDomain,
+                       [](Node& node) { node.AddAttribute("approximate", std::string("tanh")); }),
+      "Gelu", 20);
+}
+
+// Build the exporter pattern consumed by QuickGeluFusion.
+TEST_F(GraphTransformationTests, WebGpuConvQuickGeluFusionMatchesUnfusedResults) {
+  auto add_quick_gelu = [](ModelTestBuilder& builder, NodeArg* conv_out, NodeArg* output) {
+    auto* alpha = builder.MakeScalarInitializer<float>(1.4f);
+    auto* scaled = builder.MakeIntermediate();
+    auto* sigmoid_out = builder.MakeIntermediate();
+    builder.AddNode("Mul", {conv_out, alpha}, {scaled});
+    builder.AddNode("Sigmoid", {scaled}, {sigmoid_out});
+    builder.AddNode("Mul", {conv_out, sigmoid_out}, {output});
+  };
+  RunWebGpuConvActivationParity(add_quick_gelu, "QuickGelu", 17);
+}
+
+TEST_F(GraphTransformationTests, WebGpuConvThresholdedReluFusionMatchesUnfusedResults) {
+  RunWebGpuConvActivationParity(
+      SimpleActivation("ThresholdedRelu", kOnnxDomain, [](Node& node) { node.AddAttribute("alpha", 0.8f); }),
+      "ThresholdedRelu", 17);
+}
+
+TEST_F(GraphTransformationTests, WebGpuConvErfFusionMatchesUnfusedResults) {
+  RunWebGpuConvActivationParity(SimpleActivation("Erf"), "Erf", 17);
 }
 
 // Each call builds its own session, so these are two independent parity checks rather than a

--- a/onnxruntime/test/optimizer/graph_transform_test.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test.cc
@@ -3716,9 +3716,7 @@ TEST_F(GraphTransformationTests, FuseNhwcConvEluDefaultsAlphaForWebGpuEp) {
   ASSERT_STATUS_OK(RunConvActivationFusion(build_test_case, *logger_, check, 17));
 }
 
-// com.microsoft.QuickGelu computes x * Sigmoid(alpha * x) and defaults alpha to 1.702 (the GELU
-// approximation). Alpha 1.0 is a different function entirely (SiLU/Swish), so pin the value that
-// actually reaches the shader for a QuickGelu authored without an explicit alpha.
+// QuickGelu authored without an explicit alpha must reach the shader as 1.702, not 1.0 (SiLU).
 TEST_F(GraphTransformationTests, FuseNhwcConvQuickGeluDefaultsAlphaForWebGpuEp) {
   auto build_test_case = [](ModelTestBuilder& builder) {
     BuildConvActivationGraph(builder, "QuickGelu", kMSDomain, kWebGpuExecutionProvider);
@@ -3728,9 +3726,7 @@ TEST_F(GraphTransformationTests, FuseNhwcConvQuickGeluDefaultsAlphaForWebGpuEp) 
   ASSERT_STATUS_OK(RunConvActivationFusion(build_test_case, *logger_, check, 17));
 }
 
-// The test above passes even with a wrong fallback constant, because Graph::Resolve() materializes
-// alpha from the schema before any transformer runs. Stripping the attribute afterwards is what
-// actually exercises the fusion's own fallback and catches it drifting away from 1.702.
+// Resolve() materializes alpha from the schema, so stripping it is what exercises the fallback.
 TEST_F(GraphTransformationTests, FuseNhwcConvQuickGeluFallbackAlphaMatchesSchemaDefault) {
   auto build_test_case = [](ModelTestBuilder& builder) {
     BuildConvActivationGraph(builder, "QuickGelu", kMSDomain, kWebGpuExecutionProvider);
@@ -3799,17 +3795,13 @@ TEST_F(GraphTransformationTests, NoFuseNhwcConvFastGeluWithBiasForWebGpuEp) {
       RunConvActivationFusion(build_test_case, *logger_, ExpectNotFused("FastGelu"), 17));
 }
 
-// An absent optional input may be serialized with an empty name instead of being omitted, which
-// still leaves two entries in InputDefs(). That FastGelu is bias-free and must fuse exactly like
-// the omitted form: a transpose handler that pushes Transposes through the empty-name form would
-// otherwise pay the layout churn only to have the fusion refused here.
+// An empty-name optional bias is bias-free, so this FastGelu must fuse like the omitted form.
 TEST_F(GraphTransformationTests, FuseNhwcConvFastGeluWithEmptyBiasForWebGpuEp) {
   auto build_test_case = [](ModelTestBuilder& builder) {
     BuildConvActivationGraph(builder, "FastGelu", kMSDomain, kWebGpuExecutionProvider, nullptr,
                              OptionalActivationInput::kEmptyName);
   };
 
-  // Without this the test would silently degrade into a duplicate of the no-bias case above.
   auto verify_fusion_sees_the_empty_bias = [](Graph& graph) -> Status {
     bool checked = false;
     for (const Node& node : graph.Nodes()) {

--- a/onnxruntime/test/optimizer/graph_transform_test.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test.cc
@@ -3980,12 +3980,6 @@ TEST_F(GraphTransformationTests, WebGpuConvHardSigmoidFusionMatchesUnfusedResult
       "HardSigmoid", 17);
 }
 
-TEST_F(GraphTransformationTests, WebGpuConvEluFusionMatchesUnfusedResults) {
-  RunWebGpuConvActivationParity(
-      SimpleActivation("Elu", kOnnxDomain, [](Node& node) { node.AddAttribute("alpha", 0.7f); }),
-      "Elu", 17);
-}
-
 TEST_F(GraphTransformationTests, WebGpuConvClipFusionMatchesUnfusedResults) {
   auto add_clip = [](ModelTestBuilder& builder, NodeArg* conv_out, NodeArg* output) {
     auto* min_value = builder.MakeScalarInitializer<float>(-0.25f);

--- a/onnxruntime/test/optimizer/graph_transform_test.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test.cc
@@ -3607,10 +3607,19 @@ TEST_F(GraphTransformationTests, NoFuseOnnxDomainConvQuickGeluForWebGpuEp) {
   ASSERT_STATUS_OK(RunConvActivationFusion(build_test_case, *logger_, ExpectQuickGeluPresent));
 }
 
+// An absent optional input is either omitted from the node or serialized with an empty name;
+// both forms are bias-free, but only the first shrinks InputDefs().
+enum class OptionalActivationInput {
+  kAbsent,
+  kEmptyName,
+  kPresent,
+};
+
 static void BuildConvActivationGraph(ModelTestBuilder& builder, const std::string& act_op,
                                      const std::string& act_domain, const std::string& ep,
                                      const std::function<void(Node&)>& decorate = nullptr,
-                                     bool extra_input = false) {
+                                     OptionalActivationInput optional_input =
+                                         OptionalActivationInput::kAbsent) {
   auto* input = builder.MakeInput<float>({1, 5, 5, 2}, -1.0f, 1.0f);
   auto* weight = builder.MakeInitializer<float>({3, 2, 3, 3}, -1.0f, 1.0f);
   auto* conv_out = builder.MakeIntermediate();
@@ -3620,8 +3629,10 @@ static void BuildConvActivationGraph(ModelTestBuilder& builder, const std::strin
   conv.SetExecutionProviderType(ep);
 
   std::vector<NodeArg*> act_inputs{conv_out};
-  if (extra_input) {
+  if (optional_input == OptionalActivationInput::kPresent) {
     act_inputs.push_back(builder.MakeInitializer<float>({3}, -1.0f, 1.0f));
+  } else if (optional_input == OptionalActivationInput::kEmptyName) {
+    act_inputs.push_back(builder.MakeEmptyInput());
   }
 
   Node& activation = builder.AddNode(act_op, act_inputs, {output}, act_domain);
@@ -3781,11 +3792,45 @@ TEST_F(GraphTransformationTests, FuseNhwcConvFastGeluForWebGpuEp) {
 TEST_F(GraphTransformationTests, NoFuseNhwcConvFastGeluWithBiasForWebGpuEp) {
   auto build_test_case = [](ModelTestBuilder& builder) {
     BuildConvActivationGraph(builder, "FastGelu", kMSDomain, kWebGpuExecutionProvider, nullptr,
-                             /*extra_input=*/true);
+                             OptionalActivationInput::kPresent);
   };
 
   ASSERT_STATUS_OK(
       RunConvActivationFusion(build_test_case, *logger_, ExpectNotFused("FastGelu"), 17));
+}
+
+// An absent optional input may be serialized with an empty name instead of being omitted, which
+// still leaves two entries in InputDefs(). That FastGelu is bias-free and must fuse exactly like
+// the omitted form: a transpose handler that pushes Transposes through the empty-name form would
+// otherwise pay the layout churn only to have the fusion refused here.
+TEST_F(GraphTransformationTests, FuseNhwcConvFastGeluWithEmptyBiasForWebGpuEp) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    BuildConvActivationGraph(builder, "FastGelu", kMSDomain, kWebGpuExecutionProvider, nullptr,
+                             OptionalActivationInput::kEmptyName);
+  };
+
+  // Without this the test would silently degrade into a duplicate of the no-bias case above.
+  auto verify_fusion_sees_the_empty_bias = [](Graph& graph) -> Status {
+    bool checked = false;
+    for (const Node& node : graph.Nodes()) {
+      if (node.OpType() != "FastGelu") {
+        continue;
+      }
+      ORT_RETURN_IF_NOT(node.InputDefs().size() == 2,
+                        "Graph::Resolve() dropped FastGelu's empty optional input, leaving ",
+                        node.InputDefs().size(), " inputs");
+      ORT_RETURN_IF_NOT(!node.InputDefs()[1]->Exists(),
+                        "expected FastGelu's second input to be a non-existent NodeArg");
+      checked = true;
+    }
+    ORT_RETURN_IF_NOT(checked, "no FastGelu node found before fusion");
+    return Status::OK();
+  };
+
+  auto check = [](Graph& graph) { return ExpectFusedInto(graph, "FastGelu", {}); };
+
+  ASSERT_STATUS_OK(RunConvActivationFusion(build_test_case, *logger_, check, 17,
+                                           verify_fusion_sees_the_empty_bias));
 }
 
 TEST_F(GraphTransformationTests, FuseNhwcConvSoftplusForWebGpuEp) {

--- a/onnxruntime/test/optimizer/graph_transform_test.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test.cc
@@ -3536,7 +3536,8 @@ static Status ExpectUnfusedConvActivationPair(Graph& graph) {
 static Status RunConvActivationFusion(const std::function<void(ModelTestBuilder&)>& build_test_case,
                                       const logging::Logger& logger,
                                       const std::function<Status(Graph&)>& post_graph_checker,
-                                      int opset_version = 13) {
+                                      int opset_version = 13,
+                                      const std::function<Status(Graph&)>& post_resolve_mutator = nullptr) {
   const std::unordered_map<std::string, int> domain_to_version{
       {kOnnxDomain, opset_version}, {kMSDomain, 1}, {kMSInternalNHWCDomain, opset_version}};
 
@@ -3548,6 +3549,12 @@ static Status RunConvActivationFusion(const std::function<void(ModelTestBuilder&
   builder.SetGraphOutputs();
   ORT_RETURN_IF_ERROR(graph.Resolve());
   ORT_RETURN_IF_ERROR(ExpectUnfusedConvActivationPair(graph));
+
+  // Graph::Resolve() materializes schema attribute defaults onto every node, so a mutator is the
+  // only way to hand the fusion a node whose optional attribute is genuinely absent.
+  if (post_resolve_mutator) {
+    ORT_RETURN_IF_ERROR(post_resolve_mutator(graph));
+  }
 
   onnxruntime::GraphTransformerManager graph_transformation_mgr{5};
   ORT_RETURN_IF_ERROR(graph_transformation_mgr.Register(std::make_unique<ConvActivationFusion>(),
@@ -3696,6 +3703,40 @@ TEST_F(GraphTransformationTests, FuseNhwcConvEluDefaultsAlphaForWebGpuEp) {
   auto check = [](Graph& graph) { return ExpectFusedInto(graph, "Elu", {1.0f}); };
 
   ASSERT_STATUS_OK(RunConvActivationFusion(build_test_case, *logger_, check, 17));
+}
+
+// com.microsoft.QuickGelu computes x * Sigmoid(alpha * x) and defaults alpha to 1.702 (the GELU
+// approximation). Alpha 1.0 is a different function entirely (SiLU/Swish), so pin the value that
+// actually reaches the shader for a QuickGelu authored without an explicit alpha.
+TEST_F(GraphTransformationTests, FuseNhwcConvQuickGeluDefaultsAlphaForWebGpuEp) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    BuildConvActivationGraph(builder, "QuickGelu", kMSDomain, kWebGpuExecutionProvider);
+  };
+  auto check = [](Graph& graph) { return ExpectFusedInto(graph, "QuickGelu", {1.702f}); };
+
+  ASSERT_STATUS_OK(RunConvActivationFusion(build_test_case, *logger_, check, 17));
+}
+
+// The test above passes even with a wrong fallback constant, because Graph::Resolve() materializes
+// alpha from the schema before any transformer runs. Stripping the attribute afterwards is what
+// actually exercises the fusion's own fallback and catches it drifting away from 1.702.
+TEST_F(GraphTransformationTests, FuseNhwcConvQuickGeluFallbackAlphaMatchesSchemaDefault) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    BuildConvActivationGraph(builder, "QuickGelu", kMSDomain, kWebGpuExecutionProvider);
+  };
+  auto strip_alpha = [](Graph& graph) -> Status {
+    bool cleared = false;
+    for (auto& node : graph.Nodes()) {
+      if (node.OpType() == "QuickGelu" && node.Domain() == kMSDomain) {
+        cleared = node.ClearAttribute("alpha");
+      }
+    }
+    ORT_RETURN_IF_NOT(cleared, "expected Graph::Resolve() to have materialized QuickGelu's alpha");
+    return Status::OK();
+  };
+  auto check = [](Graph& graph) { return ExpectFusedInto(graph, "QuickGelu", {1.702f}); };
+
+  ASSERT_STATUS_OK(RunConvActivationFusion(build_test_case, *logger_, check, 17, strip_alpha));
 }
 
 // activation_params encodes Gelu approximation as 0 (erf) or 1 (tanh).

--- a/onnxruntime/test/providers/webgpu/activation_cache_key_test.cc
+++ b/onnxruntime/test/providers/webgpu/activation_cache_key_test.cc
@@ -33,6 +33,17 @@ TEST(ActivationCacheKeyTest, ParametersDoNotAffectTheKey) {
       << "Clip bounds are uniforms, so they must not fork the pipeline cache";
 }
 
+TEST(ActivationCacheKeyTest, QuickGeluUnitAlphaIsKeyedSeparately) {
+  const auto unit_alpha = MakeActivation(webgpu::ActivationKind::QuickGelu, 1.0f);
+  const auto other_alpha = MakeActivation(webgpu::ActivationKind::QuickGelu, 1.702f);
+
+  EXPECT_NE(unit_alpha.CacheKey(), other_alpha.CacheKey())
+      << "QuickGelu drops the multiply at alpha == 1, which is different shader text";
+
+  const auto another_alpha = MakeActivation(webgpu::ActivationKind::QuickGelu, 0.5f);
+  EXPECT_EQ(other_alpha.CacheKey(), another_alpha.CacheKey());
+}
+
 TEST(ActivationCacheKeyTest, IdenticalActivationsProduceIdenticalKeys) {
   const auto activation_a = MakeActivation(webgpu::ActivationKind::LeakyRelu, 0.01f);
   const auto activation_b = MakeActivation(webgpu::ActivationKind::LeakyRelu, 0.01f);

--- a/onnxruntime/test/providers/webgpu/activation_snippet_test.cc
+++ b/onnxruntime/test/providers/webgpu/activation_snippet_test.cc
@@ -2,7 +2,9 @@
 // Licensed under the MIT License.
 
 #include <cctype>
+#include <cstddef>
 #include <cstdlib>
+#include <iomanip>
 #include <limits>
 #include <sstream>
 #include <string>

--- a/onnxruntime/test/providers/webgpu/activation_snippet_test.cc
+++ b/onnxruntime/test/providers/webgpu/activation_snippet_test.cc
@@ -93,17 +93,14 @@ const std::vector<ActivationKind>& AllActivationKinds() {
 
 }  // namespace
 
-// Check the emitted text: a few lost digits stay well inside inference tolerances, so a
-// comparison of inference outputs would not catch it.
+// Check the emitted text: lost precision here stays below inference tolerances.
 TEST(WebGpuActivationSnippetTest, ConstantsUseShortestRoundTripForm) {
   for (ActivationKind kind : AllActivationKinds()) {
     const Activation activation = MakeActivation(kind, 0.125f, 0.375f);
     for (const std::string& wgsl : {GetActivationSnippet(activation, "vec4<f32>", "f32"),
                                     GetActivationDeclaration(activation, "vec4<f32>", "f32")}) {
       for (const std::string& literal : ExtractNumericLiterals(wgsl)) {
-        // Re-rendering the parsed value must reproduce the literal exactly: fewer digits would
-        // drop precision, more would be noise, and a locale decimal comma would cut the parse
-        // short. The values themselves are pinned by KnownConstantsAreNotTruncated.
+        // Each literal must be the canonical shortest form of the f32 it parses to.
         const float parsed = std::strtof(literal.c_str(), nullptr);
         EXPECT_EQ(RenderShortestRoundTrip(parsed), literal)
             << "literal '" << literal << "' is not the shortest round-trippable form of the f32 it"
@@ -113,9 +110,7 @@ TEST(WebGpuActivationSnippetTest, ConstantsUseShortestRoundTripForm) {
   }
 }
 
-// FloatLiteral must not consult the global locale. An embedding application is free to call
-// std::locale::global() with a comma-decimal locale, which would emit f32(0,3275911); WGSL parses
-// that as a two-argument constructor call and fails to compile the shader.
+// A comma-decimal global locale would emit f32(0,3275911), which is not valid WGSL.
 TEST(WebGpuActivationSnippetTest, ConstantsAreLocaleIndependent) {
   std::vector<std::pair<std::string, std::string>> classic;
   for (ActivationKind kind : AllActivationKinds()) {

--- a/onnxruntime/test/providers/webgpu/activation_snippet_test.cc
+++ b/onnxruntime/test/providers/webgpu/activation_snippet_test.cc
@@ -1,17 +1,19 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <array>
 #include <cctype>
+#include <charconv>
 #include <cstddef>
 #include <cstdlib>
-#include <iomanip>
-#include <limits>
-#include <sstream>
+#include <locale>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "gtest/gtest.h"
 
+#include "core/common/common.h"
 #include "core/providers/webgpu/nn/fuse_utils.h"
 
 namespace onnxruntime {
@@ -46,28 +48,30 @@ std::vector<std::string> ExtractNumericLiterals(const std::string& wgsl) {
   return literals;
 }
 
-// Count mantissa digits, excluding sign, exponent, decimal point, and edge zeros.
-size_t CountSignificantDigits(const std::string& literal) {
-  const std::string mantissa = literal.substr(0, literal.find_first_of("eE"));
-  std::string digits;
-  for (char c : mantissa) {
-    if (std::isdigit(static_cast<unsigned char>(c)) != 0) {
-      digits.push_back(c);
-    }
-  }
-  const size_t first = digits.find_first_not_of('0');
-  if (first == std::string::npos) {
-    return 0;
-  }
-  return digits.find_last_not_of('0') - first + 1;
+// Mirrors FloatLiteral: the shortest digits that round-trip, rendered without consulting a locale.
+std::string RenderShortestRoundTrip(float value) {
+  std::array<char, 32> buffer;
+  const auto result = std::to_chars(buffer.data(), buffer.data() + buffer.size(), value);
+  return std::string(buffer.data(), result.ptr);
 }
 
-// Render with round-trip precision.
-std::string RenderFullPrecision(float value) {
-  std::ostringstream oss;
-  oss << std::setprecision(std::numeric_limits<float>::max_digits10) << value;
-  return oss.str();
-}
+// A decimal comma, as several European locales use. Constructing a facet works everywhere, while
+// named locales such as "de_DE.UTF-8" are not guaranteed to be installed on every CI image.
+class CommaDecimalPoint : public std::numpunct<char> {
+ protected:
+  char do_decimal_point() const override { return ','; }
+};
+
+// Restores the previous global locale even when an assertion fails partway through a test.
+class ScopedGlobalLocale {
+ public:
+  explicit ScopedGlobalLocale(const std::locale& locale) : previous_(std::locale::global(locale)) {}
+  ~ScopedGlobalLocale() { std::locale::global(previous_); }
+  ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(ScopedGlobalLocale);
+
+ private:
+  std::locale previous_;
+};
 
 Activation MakeActivation(ActivationKind kind, float param_0 = 0.0f, float param_1 = 0.0f) {
   Activation activation;
@@ -89,21 +93,49 @@ const std::vector<ActivationKind>& AllActivationKinds() {
 
 }  // namespace
 
-// Check emitted text because the truncation is below reliable inference tolerances.
-TEST(WebGpuActivationSnippetTest, ConstantsAreEmittedAtFullPrecision) {
+// Check the emitted text: a few lost digits stay well inside inference tolerances, so a
+// comparison of inference outputs would not catch it.
+TEST(WebGpuActivationSnippetTest, ConstantsUseShortestRoundTripForm) {
   for (ActivationKind kind : AllActivationKinds()) {
     const Activation activation = MakeActivation(kind, 0.125f, 0.375f);
     for (const std::string& wgsl : {GetActivationSnippet(activation, "vec4<f32>", "f32"),
                                     GetActivationDeclaration(activation, "vec4<f32>", "f32")}) {
       for (const std::string& literal : ExtractNumericLiterals(wgsl)) {
-        // A round-trippable literal needs enough digits to represent its parsed f32.
+        // Re-rendering the parsed value must reproduce the literal exactly: fewer digits would
+        // drop precision, more would be noise, and a locale decimal comma would cut the parse
+        // short. The values themselves are pinned by KnownConstantsAreNotTruncated.
         const float parsed = std::strtof(literal.c_str(), nullptr);
-        const std::string full_precision = RenderFullPrecision(parsed);
-        EXPECT_GE(CountSignificantDigits(literal), CountSignificantDigits(full_precision))
-            << "literal '" << literal << "' looks truncated (the value it parses to needs '"
-            << full_precision << "') for activation kind " << static_cast<int>(kind);
+        EXPECT_EQ(RenderShortestRoundTrip(parsed), literal)
+            << "literal '" << literal << "' is not the shortest round-trippable form of the f32 it"
+            << " parses to, for activation kind " << static_cast<int>(kind);
       }
     }
+  }
+}
+
+// FloatLiteral must not consult the global locale. An embedding application is free to call
+// std::locale::global() with a comma-decimal locale, which would emit f32(0,3275911); WGSL parses
+// that as a two-argument constructor call and fails to compile the shader.
+TEST(WebGpuActivationSnippetTest, ConstantsAreLocaleIndependent) {
+  std::vector<std::pair<std::string, std::string>> classic;
+  for (ActivationKind kind : AllActivationKinds()) {
+    const Activation activation = MakeActivation(kind, 0.125f, 0.375f);
+    classic.emplace_back(GetActivationSnippet(activation, "vec4<f32>", "f32"),
+                         GetActivationDeclaration(activation, "vec4<f32>", "f32"));
+  }
+
+  const ScopedGlobalLocale comma_locale{std::locale(std::locale::classic(), new CommaDecimalPoint)};
+  ASSERT_EQ(std::use_facet<std::numpunct<char>>(std::locale()).decimal_point(), ',')
+      << "the comma-decimal locale did not take effect, so this test proves nothing";
+
+  size_t index = 0;
+  for (ActivationKind kind : AllActivationKinds()) {
+    const Activation activation = MakeActivation(kind, 0.125f, 0.375f);
+    EXPECT_EQ(GetActivationSnippet(activation, "vec4<f32>", "f32"), classic[index].first)
+        << "activation kind " << static_cast<int>(kind) << " emits locale-dependent snippet text";
+    EXPECT_EQ(GetActivationDeclaration(activation, "vec4<f32>", "f32"), classic[index].second)
+        << "activation kind " << static_cast<int>(kind) << " emits locale-dependent helper text";
+    ++index;
   }
 }
 
@@ -119,6 +151,9 @@ TEST(WebGpuActivationSnippetTest, KnownConstantsAreNotTruncated) {
       {ActivationKind::Gelu, true, 0.3275911f, "erf r0"},
       {ActivationKind::Gelu, true, 1.061405429f, "erf r5"},
       {ActivationKind::Gelu, true, -1.453152027f, "erf r4"},
+      {ActivationKind::Gelu, true, 1.421413741f, "erf r3"},
+      {ActivationKind::Gelu, true, -0.284496736f, "erf r2"},
+      {ActivationKind::Gelu, true, 0.254829592f, "erf r1"},
       {ActivationKind::GeluTanh, false, 0.035677408136300125f, "Gelu-tanh cubic coefficient"},
       {ActivationKind::GeluTanh, false, 0.79788456080286535f, "Gelu-tanh sqrt(2/pi)"},
       {ActivationKind::HardSwish, false, 1.0f / 6.0f, "HardSwish 1/6"},

--- a/onnxruntime/test/providers/webgpu/activation_snippet_test.cc
+++ b/onnxruntime/test/providers/webgpu/activation_snippet_test.cc
@@ -1,0 +1,246 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <cctype>
+#include <cstdlib>
+#include <limits>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "core/providers/webgpu/nn/fuse_utils.h"
+
+namespace onnxruntime {
+namespace webgpu {
+namespace test {
+
+namespace {
+
+// Extract numeric literals that are not part of identifiers.
+std::vector<std::string> ExtractNumericLiterals(const std::string& wgsl) {
+  std::vector<std::string> literals;
+  for (size_t i = 0; i < wgsl.size();) {
+    const bool starts_number =
+        (std::isdigit(static_cast<unsigned char>(wgsl[i])) != 0) ||
+        (wgsl[i] == '-' && i + 1 < wgsl.size() && std::isdigit(static_cast<unsigned char>(wgsl[i + 1])) != 0);
+    const bool part_of_identifier =
+        i > 0 && (std::isalnum(static_cast<unsigned char>(wgsl[i - 1])) != 0 || wgsl[i - 1] == '_');
+    if (!starts_number || part_of_identifier) {
+      i++;
+      continue;
+    }
+    size_t end = i + 1;
+    while (end < wgsl.size() && (std::isdigit(static_cast<unsigned char>(wgsl[end])) != 0 || wgsl[end] == '.' ||
+                                 wgsl[end] == 'e' || wgsl[end] == 'E' ||
+                                 ((wgsl[end] == '+' || wgsl[end] == '-') &&
+                                  (wgsl[end - 1] == 'e' || wgsl[end - 1] == 'E')))) {
+      end++;
+    }
+    literals.push_back(wgsl.substr(i, end - i));
+    i = end;
+  }
+  return literals;
+}
+
+// Count mantissa digits, excluding sign, exponent, decimal point, and edge zeros.
+size_t CountSignificantDigits(const std::string& literal) {
+  const std::string mantissa = literal.substr(0, literal.find_first_of("eE"));
+  std::string digits;
+  for (char c : mantissa) {
+    if (std::isdigit(static_cast<unsigned char>(c)) != 0) {
+      digits.push_back(c);
+    }
+  }
+  const size_t first = digits.find_first_not_of('0');
+  if (first == std::string::npos) {
+    return 0;
+  }
+  return digits.find_last_not_of('0') - first + 1;
+}
+
+// Render with round-trip precision.
+std::string RenderFullPrecision(float value) {
+  std::ostringstream oss;
+  oss << std::setprecision(std::numeric_limits<float>::max_digits10) << value;
+  return oss.str();
+}
+
+Activation MakeActivation(ActivationKind kind, float param_0 = 0.0f, float param_1 = 0.0f) {
+  Activation activation;
+  activation.activation_kind_ = kind;
+  activation.activation_params_.values_[0] = param_0;
+  activation.activation_params_.values_[1] = param_1;
+  return activation;
+}
+
+const std::vector<ActivationKind>& AllActivationKinds() {
+  static const std::vector<ActivationKind> kinds{
+      ActivationKind::Relu, ActivationKind::Sigmoid, ActivationKind::Clip,
+      ActivationKind::HardSigmoid, ActivationKind::LeakyRelu, ActivationKind::Tanh,
+      ActivationKind::QuickGelu, ActivationKind::HardSwish, ActivationKind::Elu,
+      ActivationKind::Gelu, ActivationKind::GeluTanh, ActivationKind::Softplus,
+      ActivationKind::ThresholdedRelu, ActivationKind::Erf};
+  return kinds;
+}
+
+}  // namespace
+
+// Check emitted text because the truncation is below reliable inference tolerances.
+TEST(WebGpuActivationSnippetTest, ConstantsAreEmittedAtFullPrecision) {
+  for (ActivationKind kind : AllActivationKinds()) {
+    const Activation activation = MakeActivation(kind, 0.125f, 0.375f);
+    for (const std::string& wgsl : {GetActivationSnippet(activation, "vec4<f32>", "f32"),
+                                    GetActivationDeclaration(activation, "vec4<f32>", "f32")}) {
+      for (const std::string& literal : ExtractNumericLiterals(wgsl)) {
+        // A round-trippable literal needs enough digits to represent its parsed f32.
+        const float parsed = std::strtof(literal.c_str(), nullptr);
+        const std::string full_precision = RenderFullPrecision(parsed);
+        EXPECT_GE(CountSignificantDigits(literal), CountSignificantDigits(full_precision))
+            << "literal '" << literal << "' looks truncated (the value it parses to needs '"
+            << full_precision << "') for activation kind " << static_cast<int>(kind);
+      }
+    }
+  }
+}
+
+TEST(WebGpuActivationSnippetTest, KnownConstantsAreNotTruncated) {
+  struct Expectation {
+    ActivationKind kind;
+    bool declaration;
+    float value;
+    const char* description;
+  };
+  const std::vector<Expectation> expectations{
+      {ActivationKind::Gelu, false, 0.70710678118654752f, "Gelu 1/sqrt(2)"},
+      {ActivationKind::Gelu, true, 0.3275911f, "erf r0"},
+      {ActivationKind::Gelu, true, 1.061405429f, "erf r5"},
+      {ActivationKind::Gelu, true, -1.453152027f, "erf r4"},
+      {ActivationKind::GeluTanh, false, 0.035677408136300125f, "Gelu-tanh cubic coefficient"},
+      {ActivationKind::GeluTanh, false, 0.79788456080286535f, "Gelu-tanh sqrt(2/pi)"},
+      {ActivationKind::HardSwish, false, 1.0f / 6.0f, "HardSwish 1/6"},
+  };
+
+  for (const Expectation& expectation : expectations) {
+    const Activation activation = MakeActivation(expectation.kind);
+    const std::string wgsl = expectation.declaration
+                                 ? GetActivationDeclaration(activation, "vec4<f32>", "f32")
+                                 : GetActivationSnippet(activation, "vec4<f32>", "f32");
+
+    bool found = false;
+    for (const std::string& literal : ExtractNumericLiterals(wgsl)) {
+      if (std::strtof(literal.c_str(), nullptr) == expectation.value) {
+        found = true;
+        break;
+      }
+    }
+    EXPECT_TRUE(found) << expectation.description << " was not emitted at full precision. WGSL was:\n"
+                       << wgsl;
+  }
+}
+
+TEST(WebGpuActivationSnippetTest, ParametersAreReadFromUniformsNotBaked) {
+  const std::vector<ActivationKind> parameterized{
+      ActivationKind::Clip, ActivationKind::HardSigmoid, ActivationKind::LeakyRelu,
+      ActivationKind::Elu, ActivationKind::ThresholdedRelu};
+
+  for (ActivationKind kind : parameterized) {
+    const Activation activation = MakeActivation(kind, 0.13579f, 0.24680f);
+    const std::string wgsl = GetActivationSnippet(activation, "vec4<f32>", "f32");
+
+    EXPECT_NE(wgsl.find("uniforms.activation_param_0"), std::string::npos)
+        << "kind " << static_cast<int>(kind) << " does not read its parameter from a uniform: " << wgsl;
+    EXPECT_EQ(wgsl.find("0.13579"), std::string::npos) << "parameter value baked into shader: " << wgsl;
+    EXPECT_EQ(wgsl.find("0.2468"), std::string::npos) << "parameter value baked into shader: " << wgsl;
+  }
+}
+
+TEST(WebGpuActivationSnippetTest, QuickGeluUnitAlphaIsASeparateShaderAndCacheKey) {
+  const Activation silu = MakeActivation(ActivationKind::QuickGelu, 1.0f);
+  const Activation general = MakeActivation(ActivationKind::QuickGelu, 1.702f);
+
+  EXPECT_TRUE(silu.HasUnitQuickGeluAlpha());
+  EXPECT_FALSE(general.HasUnitQuickGeluAlpha());
+
+  const std::string silu_wgsl = GetActivationSnippet(silu, "vec4<f32>", "f32");
+  const std::string general_wgsl = GetActivationSnippet(general, "vec4<f32>", "f32");
+
+  EXPECT_EQ(silu_wgsl.find("activation_param_0"), std::string::npos)
+      << "SiLU must not read an alpha uniform: " << silu_wgsl;
+  EXPECT_NE(general_wgsl.find("activation_param_0"), std::string::npos)
+      << "non-unit alpha must read its alpha from a uniform: " << general_wgsl;
+  EXPECT_NE(silu_wgsl, general_wgsl);
+
+  EXPECT_NE(silu.CacheKey(), general.CacheKey());
+}
+
+TEST(WebGpuActivationSnippetTest, ParameterValuesDoNotAffectTheCacheKey) {
+  const Activation leaky_a = MakeActivation(ActivationKind::LeakyRelu, 0.01f);
+  const Activation leaky_b = MakeActivation(ActivationKind::LeakyRelu, 0.25f);
+  EXPECT_EQ(leaky_a.CacheKey(), leaky_b.CacheKey());
+  EXPECT_EQ(GetActivationSnippet(leaky_a, "vec4<f32>", "f32"),
+            GetActivationSnippet(leaky_b, "vec4<f32>", "f32"));
+
+  const Activation clip_a = MakeActivation(ActivationKind::Clip, 0.0f, 6.0f);
+  const Activation clip_b = MakeActivation(ActivationKind::Clip, -1.0f, 1.0f);
+  EXPECT_EQ(clip_a.CacheKey(), clip_b.CacheKey());
+  EXPECT_EQ(GetActivationSnippet(clip_a, "vec4<f32>", "f32"),
+            GetActivationSnippet(clip_b, "vec4<f32>", "f32"));
+
+  EXPECT_NE(MakeActivation(ActivationKind::Relu).CacheKey(),
+            MakeActivation(ActivationKind::Sigmoid).CacheKey());
+}
+
+TEST(WebGpuActivationSnippetTest, ParameterlessActivationsReadNoUniforms) {
+  const std::vector<ActivationKind> parameterless{
+      ActivationKind::None, ActivationKind::Relu, ActivationKind::Sigmoid, ActivationKind::Tanh,
+      ActivationKind::HardSwish, ActivationKind::Gelu, ActivationKind::GeluTanh,
+      ActivationKind::Softplus, ActivationKind::Erf};
+
+  for (ActivationKind kind : parameterless) {
+    const Activation activation = MakeActivation(kind, 7.25f, 9.5f);
+    const std::string snippet = GetActivationSnippet(activation, "vec4<f32>", "f32");
+    const std::string declaration = GetActivationDeclaration(activation, "vec4<f32>", "f32");
+    EXPECT_EQ(snippet.find("uniforms.activation_param"), std::string::npos)
+        << "kind " << static_cast<int>(kind) << " unexpectedly reads a parameter uniform: " << snippet;
+    EXPECT_EQ(declaration.find("uniforms.activation_param"), std::string::npos)
+        << "kind " << static_cast<int>(kind) << " helper unexpectedly reads a parameter uniform: " << declaration;
+  }
+}
+
+// WGSL has no forward declarations; helper definitions must accompany their uses.
+TEST(WebGpuActivationSnippetTest, HelperIsEmittedWheneverItIsCalled) {
+  for (ActivationKind kind : AllActivationKinds()) {
+    const Activation activation = MakeActivation(kind, 0.5f, 1.5f);
+    const std::string snippet = GetActivationSnippet(activation, "vec4<f32>", "f32");
+    const std::string declaration = GetActivationDeclaration(activation, "vec4<f32>", "f32");
+
+    if (snippet.find("fused_act_erf") != std::string::npos) {
+      EXPECT_NE(declaration.find("fn fused_act_erf"), std::string::npos)
+          << "kind " << static_cast<int>(kind) << " calls fused_act_erf but declares no helper";
+    }
+    if (snippet.find("fused_act_tanh") != std::string::npos) {
+      EXPECT_NE(declaration.find("fn fused_act_tanh"), std::string::npos)
+          << "kind " << static_cast<int>(kind) << " calls fused_act_tanh but declares no helper";
+    }
+    if (!declaration.empty()) {
+      const bool referenced = snippet.find("fused_act_erf") != std::string::npos ||
+                              snippet.find("fused_act_tanh") != std::string::npos;
+      EXPECT_TRUE(referenced) << "kind " << static_cast<int>(kind) << " emits an unused helper";
+    }
+  }
+}
+
+TEST(WebGpuActivationSnippetTest, EveryKindProducesASnippet) {
+  for (ActivationKind kind : AllActivationKinds()) {
+    const Activation activation = MakeActivation(kind, 0.5f, 1.5f);
+    EXPECT_FALSE(GetActivationSnippet(activation, "vec4<f32>", "f32").empty())
+        << "activation kind " << static_cast<int>(kind) << " produced no snippet";
+  }
+  EXPECT_TRUE(GetActivationSnippet(MakeActivation(ActivationKind::None), "vec4<f32>", "f32").empty());
+}
+
+}  // namespace test
+}  // namespace webgpu
+}  // namespace onnxruntime


### PR DESCRIPTION
### Description

Extends the WebGPU Conv+activation fusion allowlist by eight kinds: QuickGelu, HardSwish, Elu, Gelu, Gelu(tanh), Softplus, ThresholdedRelu and Erf, each with a WGSL snippet for the generated-shader path and a matching branch in the im2col template. QuickGelu at alpha == 1 is a distinct shader because the multiply drops out entirely, so it carries its own `QuickGeluUnitAlpha` cache-key term to stop the two variants colliding in the pipeline cache. This also fixes the QuickGelu alpha fallback, which was `1.0f` rather than the schema default `1.702f`: attributes are materialized onto nodes during `Graph::Resolve()`, so the fallback was unreachable and could not change model output, but it was still wrong on paper and inconsistent with the standalone WebGPU QuickGelu kernel. Four of the eight (`Elu` and the three contrib GELU variants) also need a transpose-optimizer handler to fuse end to end, and since that map is shared cross-EP infrastructure rather than WebGPU code it lives in #32118; until that lands those four still execute correctly, just unfused. Covered by 35 new tests, including negative controls for Selu and the CPU EP, execution parity against unfused results, and one that strips QuickGelu's alpha after `Resolve()` so it actually fails without the fix.

### Motivation and Context

These activations are common after convolutions. QuickGelu is how SiLU/Swish reaches the graph and HardSwish appears throughout MobileNet-class models, but each one previously forced a separate dispatch and a round trip through global memory.