### PR TITLE
Use native block tables for 128-token XQA pages

### DIFF
--- a/docs/contrib_ops/cuda/paged_attention.md
+++ b/docs/contrib_ops/cuda/paged_attention.md
@@ -1277,6 +1277,13 @@ as GQA does, so that `ORT_ENABLE_ATTENTION_KERNEL_DEBUG_INFO=1` works uniformly 
 > stricter gate — it needs `token_count == batch_size` *and* `max_query_len == 1`, the latter from
 > `attention_metadata` or, failing that, from the readback — because its output layout is one row
 > per batch index rather than per query token.
+>
+> XQA uses fixed 128-token pages. When PagedAttention's `block_size` is 128, its native
+> `block_table` is already in XQA page units and is passed directly to the kernel: no page-table
+> scratch buffer is allocated and `ExpandBlockTableToPages` is not launched. This preserves every
+> entry, including `-1`, unchanged. Larger supported block sizes remain on the expanded path; for
+> example, each 256-token block maps to two consecutive XQA pages in a per-invocation scratch table.
+> Debug output reports the selected path as `XqaPageTable=native` or `XqaPageTable=expanded`.
 
 ## 14. Shared Code with GroupQueryAttention
 

--- a/onnxruntime/contrib_ops/cuda/bert/attention_data.h
+++ b/onnxruntime/contrib_ops/cuda/bert/attention_data.h
@@ -324,14 +324,13 @@ struct PagedAttentionData {
 
   // Paged XQA decode workspaces. Only allocated when the XQA decode backend is selected
   // (quantized cache, one new token per sequence -- see use_xqa_decode).
-  //   xqa_workspace   : XQA semaphores + multi-block scratch (GetXQAScratchSize bytes).
-  //   xqa_page_table  : block_table expanded from PagedAttention blocks to XQA's fixed 128-token
-  //                     pages, shape [batch_size, max_num_blocks_per_seq * pages_per_block].
-  //   xqa_query       : scratch for Q pre-scaled by a PER_CHANNEL k_scale; unused otherwise.
-  //   xqa_head_sink   : head_sink converted to fp32, which is what XQA consumes.
+  //   xqa_workspace          : XQA semaphores + multi-block scratch (GetXQAScratchSize bytes).
+  //   xqa_page_table_scratch : mutable destination for expansion when block_size is greater than 128.
+  //   xqa_query              : scratch for Q pre-scaled by a PER_CHANNEL k_scale; unused otherwise.
+  //   xqa_head_sink          : head_sink converted to fp32, which is what XQA consumes.
   void* xqa_workspace = nullptr;
   size_t xqa_workspace_size = 0;
-  int* xqa_page_table = nullptr;
+  int* xqa_page_table_scratch = nullptr;
   T* xqa_query = nullptr;
   float* xqa_head_sink = nullptr;
 

--- a/onnxruntime/contrib_ops/cuda/bert/attention_kernel_options.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/attention_kernel_options.cc
@@ -186,6 +186,9 @@ void AttentionKernelDebugInfo::Print(const char* operator_name,
   if (effective_kv_length_bound.has_value()) {
     sstream << " EffectiveKvLengthBound=" << effective_kv_length_bound.value();
   }
+  if (xqa_page_table_expanded.has_value()) {
+    sstream << " XqaPageTable=" << (xqa_page_table_expanded.value() ? "expanded" : "native");
+  }
 
   // Output text in Cyan color to make it easier to spot.
   std::cout << "\x1B[36m" << sstream.str() << "\x1B[0m" << std::endl;

--- a/onnxruntime/contrib_ops/cuda/bert/attention_kernel_options.h
+++ b/onnxruntime/contrib_ops/cuda/bert/attention_kernel_options.h
@@ -21,6 +21,7 @@ struct AttentionKernelDebugInfo {
   std::optional<int> num_splits = std::nullopt;
   std::optional<int> gqa_group_size = std::nullopt;
   std::optional<int> effective_kv_length_bound = std::nullopt;
+  std::optional<bool> xqa_page_table_expanded = std::nullopt;
   void SetTrtFusedKernel(bool enable_trt_flash_attention, int sequence_length);
   void Print(const char* operator_name, const std::string& node_name, bool is_float16, bool is_bfloat16) const;
 };

--- a/onnxruntime/contrib_ops/cuda/bert/paged_attention.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/paged_attention.cc
@@ -606,16 +606,19 @@ Status PagedAttention<T, TCACHE>::ComputeInternal(OpKernelContext* context) cons
     decode_partial_sum_buffer = GetScratchBuffer<void>(sizeof(float) * rows, GetComputeStream(context));
   }
 
-  // XQA scratch: semaphores + the multi-block (Flash Decoding) partials, plus the expanded page
-  // table, the optional pre-scaled Q copy and the fp32 attention sinks.
+  // XQA scratch: semaphores + the multi-block (Flash Decoding) partials, the optional expanded page
+  // table, the optional pre-scaled Q copy and the fp32 attention sinks. A native 128-token block
+  // table is already in XQA page units and is passed through without an allocation.
   IAllocatorUniquePtr<void> xqa_workspace_buffer;
   IAllocatorUniquePtr<void> xqa_page_table_buffer;
   IAllocatorUniquePtr<void> xqa_query_buffer;
   IAllocatorUniquePtr<void> xqa_head_sink_buffer;
   size_t xqa_workspace_bytes = 0;
   int xqa_max_pages_per_seq = 0;
+  bool xqa_page_table_expanded = false;
   if (use_xqa_decode) {
     const int pages_per_block = parameters.block_size / kXqaTokensPerPage;
+    xqa_page_table_expanded = pages_per_block > 1;
     xqa_max_pages_per_seq = parameters.max_num_blocks_per_seq * pages_per_block;
     xqa_workspace_bytes = GetXQAScratchSize(
         device_prop, parameters.batch_size, parameters.num_heads, parameters.kv_num_heads,
@@ -623,9 +626,11 @@ Status PagedAttention<T, TCACHE>::ComputeInternal(OpKernelContext* context) cons
         IsFp8CacheType<TCACHE>() ? XqaQuantType::kFp8 : XqaQuantType::kInt8,
         std::is_same<T, BFloat16>::value);
     xqa_workspace_buffer = GetScratchBuffer<void>(xqa_workspace_bytes, GetComputeStream(context));
-    xqa_page_table_buffer = GetScratchBuffer<void>(
-        sizeof(int) * static_cast<size_t>(parameters.batch_size) * xqa_max_pages_per_seq,
-        GetComputeStream(context));
+    if (xqa_page_table_expanded) {
+      xqa_page_table_buffer = GetScratchBuffer<void>(
+          sizeof(int) * static_cast<size_t>(parameters.batch_size) * xqa_max_pages_per_seq,
+          GetComputeStream(context));
+    }
     if (k_quant_type_ == KVQuantizationType::PER_CHANNEL) {
       xqa_query_buffer = GetScratchBuffer<void>(
           sizeof(T) * static_cast<size_t>(parameters.batch_size) * parameters.num_heads * parameters.head_size,
@@ -663,6 +668,9 @@ Status PagedAttention<T, TCACHE>::ComputeInternal(OpKernelContext* context) cons
     debug_info.gqa_group_size = parameters.num_heads / parameters.kv_num_heads;
     debug_info.effective_kv_length_bound =
         parameters.local_window_size > 0 ? std::min(max_kv_len, parameters.local_window_size) : max_kv_len;
+    if (use_xqa_decode) {
+      debug_info.xqa_page_table_expanded = xqa_page_table_expanded;
+    }
 
     debug_info.Print("PagedAttention",
                      this->Node().Name(),
@@ -721,7 +729,7 @@ Status PagedAttention<T, TCACHE>::ComputeInternal(OpKernelContext* context) cons
   if (use_xqa_decode) {
     data.xqa_workspace = xqa_workspace_buffer.get();
     data.xqa_workspace_size = xqa_workspace_bytes;
-    data.xqa_page_table = reinterpret_cast<int*>(xqa_page_table_buffer.get());
+    data.xqa_page_table_scratch = reinterpret_cast<int*>(xqa_page_table_buffer.get());
     data.xqa_query = reinterpret_cast<CudaT*>(xqa_query_buffer.get());
     data.xqa_head_sink = reinterpret_cast<float*>(xqa_head_sink_buffer.get());
   }

--- a/onnxruntime/contrib_ops/cuda/bert/paged_attention_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/paged_attention_impl.cu
@@ -1465,7 +1465,8 @@ Status PagedDecodeAttention(
 //     [num_blocks, block_size, kv_num_heads, head_size] -- and XQA's PAGED_KV_CACHE_LAYOUT == 1
 //     page is exactly [tokens_per_page, kv_num_heads, head_size], block b is bit-for-bit the
 //     concatenation of pages [b * pages_per_block, (b + 1) * pages_per_block). ExpandBlockTable-
-//     ToPages rewrites the block table accordingly; it costs O(batch * max_num_blocks_per_seq).
+//     ToPages rewrites blocks larger than 128 tokens accordingly. A 128-token block table is
+//     already in XQA page units and passes through without scratch allocation or expansion.
 //  2. Per-channel scales. XQA only accepts a scalar dequantization scale per cache. A PER_CHANNEL
 //     scale is folded out exactly the same way GroupQueryAttention does it (see the derivation
 //     next to LaunchScaleHeadsByChannelScale in group_query_attention_qdq.cuh): k_scale into Q
@@ -1537,12 +1538,16 @@ Status PagedXqaDecodeAttention(
 
   const int pages_per_block = parameters.block_size / onnxruntime::contrib::cuda::kXqaTokensPerPage;
   const int max_pages_per_seq = parameters.max_num_blocks_per_seq * pages_per_block;
-  {
+  const int* page_table = data.block_table;
+  if (pages_per_block > 1) {
+    ORT_RETURN_IF_NOT(data.xqa_page_table_scratch, "XQA page-table scratch was not allocated.");
     const int total_pages = batch_size * max_pages_per_seq;
     const int blocks = (total_pages + max_threads_per_block - 1) / max_threads_per_block;
     ExpandBlockTableToPages<<<blocks, max_threads_per_block, 0, stream>>>(
-        data.block_table, data.xqa_page_table, parameters.max_num_blocks_per_seq, pages_per_block, total_pages);
+        data.block_table, data.xqa_page_table_scratch,
+        parameters.max_num_blocks_per_seq, pages_per_block, total_pages);
     CUDA_RETURN_IF_ERROR(cudaGetLastError());
+    page_table = data.xqa_page_table_scratch;
   }
 
   const bool k_per_channel = parameters.k_quant_type == KVQuantizationType::PER_CHANNEL;
@@ -1581,7 +1586,7 @@ Status PagedXqaDecodeAttention(
       reinterpret_cast<const void*>(data.key_cache),
       reinterpret_cast<const void*>(data.value_cache),
       reinterpret_cast<void*>(data.output),
-      data.xqa_page_table,
+      page_table,
       batch_size, num_heads, kv_num_heads, head_size, max_pages_per_seq,
       scale, parameters.local_window_size, data.past_seqlens, attention_sinks,
       // A PER_CHANNEL scale has already been folded into Q / will be applied to the output, so the

--- a/onnxruntime/test/python/transformers/test_paged_attention.py
+++ b/onnxruntime/test/python/transformers/test_paged_attention.py
@@ -1104,6 +1104,17 @@ def capture_native_stdout(run_func):
         os.close(saved_fd)
 
 
+def capture_native_stdout_and_result(run_func):
+    """Capture native stdout while preserving a callable's return value."""
+    result = []
+
+    def save_result():
+        result.append(run_func())
+
+    output = capture_native_stdout(save_result)
+    return output, result[0]
+
+
 def has_cuda_device():
     """Every test in this file allocates torch tensors on "cuda" and runs the CUDA EP.
 
@@ -2133,8 +2144,112 @@ class TestPagedAttentionXqaDecode(unittest.TestCase):
 
     @parameterized.expand([("128", 128), ("256", 256), ("512", 512)])
     def test_xqa_block_size(self, _, block_size):
-        # Each block is remapped to block_size / 128 consecutive XQA pages.
+        # Larger blocks are remapped to consecutive 128-token XQA pages; 128-token tables pass through.
         self._check_xqa(paged_kv_block_size=block_size)
+
+    @parameterized.expand(
+        [
+            ("contiguous", [0, 1], -1),
+            ("fragmented", [2, 0], -1),
+            ("negative_one", [-1, 1], 128),
+        ]
+    )
+    def test_xqa_native_page_table_matches_expanded(self, _, expanded_block_ids, local_window_size):
+        """A 128-token native table must be exactly the page expansion of the 256-token table."""
+        # The -1 entries are outside the 128-token local window and therefore never dereferenced.
+        device = "cuda"
+        pages_per_expanded_block = 2
+        expanded_block_table = torch.tensor([expanded_block_ids], dtype=torch.int32, device=device)
+        page_offsets = torch.arange(pages_per_expanded_block, dtype=torch.int32, device=device)
+        native_page_table = torch.where(
+            expanded_block_table.unsqueeze(-1) < 0,
+            torch.full_like(expanded_block_table.unsqueeze(-1) + page_offsets, -1),
+            expanded_block_table.unsqueeze(-1) * pages_per_expanded_block + page_offsets,
+        ).reshape(1, -1)
+
+        expected_pages = []
+        for block_id in expanded_block_ids:
+            expected_pages.extend([-1, -1] if block_id < 0 else [block_id * 2, block_id * 2 + 1])
+        self.assertEqual(native_page_table.cpu().tolist(), [expected_pages])
+
+        physical_blocks = max(expanded_block_ids) + 1
+        expanded_key_cache = torch.randint(
+            -32,
+            33,
+            (physical_blocks, 256, 2, 64),
+            dtype=torch.int8,
+            device=device,
+        )
+        expanded_value_cache = torch.randint(
+            -32,
+            33,
+            (physical_blocks, 256, 2, 64),
+            dtype=torch.int8,
+            device=device,
+        )
+        native_key_cache = expanded_key_cache.reshape(physical_blocks * 2, 128, 2, 64).clone()
+        native_value_cache = expanded_value_cache.reshape(physical_blocks * 2, 128, 2, 64).clone()
+
+        query = torch.randn(1, 8 * 64, dtype=torch.float16, device=device)
+        key = torch.randn(1, 2 * 64, dtype=torch.float16, device=device)
+        value = torch.randn(1, 2 * 64, dtype=torch.float16, device=device)
+        cumulative_seqlens = torch.tensor([0, 1], dtype=torch.int32, device=device)
+        past_seqlens = torch.tensor([383], dtype=torch.int32, device=device)
+        k_scale = torch.tensor([1.0 / 32.0], dtype=torch.float32, device=device)
+        v_scale = torch.tensor([1.0 / 32.0], dtype=torch.float32, device=device)
+
+        def run(block_size, block_table, key_cache, value_cache):
+            config = self._config(
+                batch_size=1,
+                total_sequence_length=512,
+                paged_kv_block_size=block_size,
+                local=local_window_size > 0,
+                kv_cache_type="int8",
+                k_quant_type="PER_TENSOR",
+                v_quant_type="PER_TENSOR",
+                use_attention_metadata=True,
+            )
+            return paged_attention_func(
+                config,
+                query,
+                key,
+                value,
+                key_cache,
+                value_cache,
+                cumulative_seqlens,
+                past_seqlens,
+                block_table,
+                window_size=local_window_size,
+                k_scale=k_scale,
+                v_scale=v_scale,
+            )
+
+        with patch.dict(
+            os.environ,
+            {"ORT_ENABLE_ATTENTION_KERNEL_DEBUG_INFO": "1", "ORT_ENABLE_XQA": "1"},
+        ):
+            native_debug, native_result = capture_native_stdout_and_result(
+                lambda: run(128, native_page_table, native_key_cache, native_value_cache)
+            )
+            expanded_debug, expanded_result = capture_native_stdout_and_result(
+                lambda: run(256, expanded_block_table, expanded_key_cache, expanded_value_cache)
+            )
+
+        for debug_output, expected_mode in (
+            (native_debug, "native"),
+            (expanded_debug, "expanded"),
+        ):
+            self.assertIn("Operator=PagedAttention", debug_output)
+            self.assertIn("SdpaKernel=XQA", debug_output)
+            self.assertIn(f"XqaPageTable={expected_mode}", debug_output)
+
+        native_output, native_key_cache_out, native_value_cache_out = native_result
+        expanded_output, expanded_key_cache_out, expanded_value_cache_out = expanded_result
+        torch.testing.assert_close(native_output, expanded_output, rtol=0, atol=0)
+        torch.testing.assert_close(native_key_cache_out.reshape(-1), expanded_key_cache_out.reshape(-1), rtol=0, atol=0)
+        torch.testing.assert_close(
+            native_value_cache_out.reshape(-1), expanded_value_cache_out.reshape(-1), rtol=0, atol=0
+        )
 
     def test_xqa_batch_one(self):
         self._check_xqa(batch_size=1)


### PR DESCRIPTION
Avoid expanding the PagedAttention block table when its block size already matches XQA’s 128-token page size.

For 128-token blocks, the existing block table is passed directly to XQA. Larger block sizes continue using the existing expanded page-table path.

This removes an unnecessary temporary allocation and conversion kernel from each eligible XQA invocation.