### PR TITLE
[CUDA] Bound the FP8 weight dequant scratch by tiling over N

### DIFF
--- a/docs/contrib_ops/cuda/matmul_block_scaled_fp8.md
+++ b/docs/contrib_ops/cuda/matmul_block_scaled_fp8.md
@@ -214,12 +214,12 @@ for n_offset in 0, tile_rows, 2 * tile_rows, ...:
 `ORT_FP8_DEQUANT_SCRATCH_MIB` sets the cap in MiB (default 256). The default was
 chosen by sweeping it on Qwen3.8-27B at an 8K prompt:
 
-| cap | peak memory | TTFT |
-|---|---|---|
-| untiled | 32609 MiB | baseline |
-| 1 GiB | -3100 MiB | +5.2% |
-| **256 MiB** | **28503 MiB (-4106)** | **+1.1%** |
-| 128 MiB | -4106 MiB | +13.9% |
+| cap | peak memory (MiB) | reduction vs. untiled (MiB) | TTFT change |
+|---|---:|---:|---:|
+| untiled | 32609 | baseline | baseline |
+| 1 GiB | 29509 | -3100 | +5.2% |
+| **256 MiB** | **28503** | **-4106** | **+1.1%** |
+| 128 MiB | 28503 | -4106 | +13.9% |
 
 Shapes small enough to fit the cap take a single tile and are unaffected.
 

--- a/docs/contrib_ops/cuda/matmul_block_scaled_fp8.md
+++ b/docs/contrib_ops/cuda/matmul_block_scaled_fp8.md
@@ -37,6 +37,7 @@ Source files:
 3. [Dispatch Chain](#3-dispatch-chain)
 4. [Decode Path - Fused GEMV](#4-decode-path---fused-gemv)
 5. [Default Path - Dequantize + cuBLAS](#5-default-path---dequantize--cublas)
+   - [5.1 Tiling the dequantization scratch over N](#51-tiling-the-dequantization-scratch-over-n)
 6. [Optional W8A8 Activation Path](#6-optional-w8a8-activation-path)
 7. [Testing and Benchmarking](#7-testing-and-benchmarking)
 
@@ -195,6 +196,32 @@ back `LaunchDequantizeBlockScaledFp8`:
 
 This keeps the GEMM in the activation type and runs on any CUDA architecture
 with FP8 conversion intrinsics (CUDA >= 11.8). It is the default prefill path.
+
+### 5.1 Tiling the dequantization scratch over N
+
+A full `[N, K]` scratch is 2.37 GiB for a 248320 x 5120 LM head, and it is
+allocated for the whole GEMM even though the GEMM reads it once. The scratch is
+therefore capped and the dequantize + GEMM pair is run over N tiles that fit
+inside the cap. Because the row-major `[M, N]` output is column-major `[N, M]`
+to cuBLAS, an N tile is a plain row offset into `Y`, so no extra copy is needed:
+
+```
+for n_offset in 0, tile_rows, 2 * tile_rows, ...:
+    dequantize B[n_offset : n_offset + rows, :] into the scratch
+    cublasGemmHelper(...) writing Y + n_offset
+```
+
+`ORT_FP8_DEQUANT_SCRATCH_MIB` sets the cap in MiB (default 256). The default was
+chosen by sweeping it on Qwen3.8-27B at an 8K prompt:
+
+| cap | peak memory | TTFT |
+|---|---|---|
+| untiled | 32609 MiB | baseline |
+| 1 GiB | -3100 MiB | +5.2% |
+| **256 MiB** | **28503 MiB (-4106)** | **+1.1%** |
+| 128 MiB | -4106 MiB | +13.9% |
+
+Shapes small enough to fit the cap take a single tile and are unaffected.
 
 ---
 

--- a/onnxruntime/contrib_ops/cuda/math/matmul_block_scaled_fp8.cc
+++ b/onnxruntime/contrib_ops/cuda/math/matmul_block_scaled_fp8.cc
@@ -22,12 +22,10 @@ bool FusedFp8ActivationQdqDisabled() {
   return disabled;
 }
 
-// Upper bound on the weight dequantization scratch buffer, in MiB. 256 MiB was picked by sweeping
-// it on Qwen3.8-27B: 128 MiB costs 13.9% TTFT, 1 GiB gives up a quarter of the memory saving.
-// Read per call rather than cached in a static so a test can force the multi-tile path.
-int64_t DequantScratchLimitMiB() {
+size_t DequantScratchLimitBytes() {
   const int64_t limit = ParseEnvironmentVariableWithDefault<int64_t>("ORT_FP8_DEQUANT_SCRATCH_MIB", 256);
-  return limit > 0 ? limit : 256;
+  ORT_ENFORCE(limit > 0, "ORT_FP8_DEQUANT_SCRATCH_MIB must be positive.");
+  return SafeInt<size_t>(limit) * 1024 * 1024;
 }
 }  // namespace
 
@@ -45,7 +43,9 @@ ONNX_OPERATOR_KERNEL_EX(
 #endif
 
 MatMulBlockQuantizedFp8Weight::MatMulBlockQuantizedFp8Weight(const OpKernelInfo& info)
-    : CudaKernel(info), block_size_(info.GetAttrOrDefault<int64_t>("block_size", 128)) {
+    : CudaKernel(info),
+      block_size_(info.GetAttrOrDefault<int64_t>("block_size", 128)),
+      max_dequant_scratch_bytes_(DequantScratchLimitBytes()) {
   ORT_ENFORCE(block_size_ > 0, "block_size must be positive.");
 }
 
@@ -102,6 +102,20 @@ Status MatMulBlockQuantizedFp8Weight::ComputeImpl(OpKernelContext* context) cons
   const int n_i = SafeInt<int>(helper.N());
   const int k_i = SafeInt<int>(helper.K());
 
+  if (k_i == 0) {
+    CUDA_RETURN_IF_ERROR(cudaMemsetAsync(Y->MutableDataRaw(), 0, Y->SizeInBytes(), Stream(context)));
+    if (bias != nullptr) {
+      ORT_RETURN_IF_ERROR(LaunchAddBiasBlockScaledFp8(
+          Y->MutableDataRaw(),
+          bias->DataRaw(),
+          m_i,
+          n_i,
+          std::is_same<T, BFloat16>::value,
+          Stream(context)));
+    }
+    return Status::OK();
+  }
+
   // Optional W8A8 activation path: statically quantize A to FP8 E4M3 and dequantize back so the
   // GEMM sees the same activation rounding as native W8A8 execution. When a_scale is absent the
   // activation is kept at full FP16/BF16 precision (weight-only W8A16).
@@ -150,9 +164,8 @@ Status MatMulBlockQuantizedFp8Weight::ComputeImpl(OpKernelContext* context) cons
 
   // Dequantize the FP8 weight into a scratch buffer of the activation type, then GEMM. The scratch
   // is tiled over N because a full [N, K] buffer is 2.37 GiB for a 248320 x 5120 LM head.
-  const size_t max_scratch_bytes = static_cast<size_t>(DequantScratchLimitMiB()) * 1024 * 1024;
   const int64_t rows_per_scratch =
-      static_cast<int64_t>(max_scratch_bytes / (static_cast<size_t>(k) * sizeof(CudaT)));
+      static_cast<int64_t>(max_dequant_scratch_bytes_ / (static_cast<size_t>(k) * sizeof(CudaT)));
   const int64_t tile_rows = std::clamp<int64_t>(rows_per_scratch, 1, n);
 
   IAllocatorUniquePtr<CudaT> b_dequant =

--- a/onnxruntime/contrib_ops/cuda/math/matmul_block_scaled_fp8.cc
+++ b/onnxruntime/contrib_ops/cuda/math/matmul_block_scaled_fp8.cc
@@ -3,6 +3,7 @@
 
 #include "contrib_ops/cuda/math/matmul_block_scaled_fp8.h"
 
+#include <algorithm>
 #include <type_traits>
 
 #include "core/common/safeint.h"
@@ -19,6 +20,14 @@ bool FusedFp8ActivationQdqDisabled() {
   static const bool disabled =
       ParseEnvironmentVariableWithDefault<bool>("ORT_DISABLE_FUSED_FP8_ACT_QDQ", false);
   return disabled;
+}
+
+// Upper bound on the weight dequantization scratch buffer, in MiB. 256 MiB was picked by sweeping
+// it on Qwen3.8-27B: 128 MiB costs 13.9% TTFT, 1 GiB gives up a quarter of the memory saving.
+// Read per call rather than cached in a static so a test can force the multi-tile path.
+int64_t DequantScratchLimitMiB() {
+  const int64_t limit = ParseEnvironmentVariableWithDefault<int64_t>("ORT_FP8_DEQUANT_SCRATCH_MIB", 256);
+  return limit > 0 ? limit : 256;
 }
 }  // namespace
 
@@ -139,39 +148,53 @@ Status MatMulBlockQuantizedFp8Weight::ComputeImpl(OpKernelContext* context) cons
         Stream(context));
   }
 
-  // Dequantize the FP8 weight into a scratch [N, K] buffer of the activation type, then GEMM.
-  IAllocatorUniquePtr<CudaT> b_dequant = GetScratchBuffer<CudaT>(SafeInt<size_t>(n) * SafeInt<size_t>(k),
-                                                                 GetComputeStream(context));
-  ORT_RETURN_IF_ERROR(LaunchDequantizeBlockScaledFp8(
-      b_dequant.get(),
-      b->DataRaw(),
-      b_scale->Data<float>(),
-      SafeInt<int>(n),
-      SafeInt<int>(k),
-      SafeInt<int>(block_size_),
-      std::is_same<T, BFloat16>::value,
-      Stream(context)));
+  // Dequantize the FP8 weight into a scratch buffer of the activation type, then GEMM. The scratch
+  // is tiled over N because a full [N, K] buffer is 2.37 GiB for a 248320 x 5120 LM head.
+  const size_t max_scratch_bytes = static_cast<size_t>(DequantScratchLimitMiB()) * 1024 * 1024;
+  const int64_t rows_per_scratch =
+      static_cast<int64_t>(max_scratch_bytes / (static_cast<size_t>(k) * sizeof(CudaT)));
+  const int64_t tile_rows = std::clamp<int64_t>(rows_per_scratch, 1, n);
+
+  IAllocatorUniquePtr<CudaT> b_dequant =
+      GetScratchBuffer<CudaT>(SafeInt<size_t>(tile_rows) * SafeInt<size_t>(k), GetComputeStream(context));
 
   const CudaT alpha = ToCudaType<T>::FromFloat(1.f);
   const CudaT zero = ToCudaType<T>::FromFloat(0.f);
+  const auto* b_data = static_cast<const uint8_t*>(b->DataRaw());
+  const float* b_scale_data = b_scale->Data<float>();
 
-  CUBLAS_RETURN_IF_ERROR(cublasGemmHelper(
-      GetCublasHandle(context),
-      CUBLAS_OP_T,  // transB: dequantized weight is [N, K] row-major == K-major [K, N]
-      CUBLAS_OP_N,  // transA
-      n_i,
-      m_i,
-      k_i,
-      &alpha,
-      b_dequant.get(),
-      helper.Ldb(transb),
-      reinterpret_cast<const CudaT*>(a_ptr),
-      helper.Lda(transa),
-      &zero,
-      reinterpret_cast<CudaT*>(Y->MutableDataRaw()),
-      helper.Ldc(),
-      GetDeviceProp(),
-      UseTF32()));
+  for (int64_t n_offset = 0; n_offset < n; n_offset += tile_rows) {
+    const int rows = SafeInt<int>(std::min<int64_t>(tile_rows, n - n_offset));
+    const size_t row_offset = static_cast<size_t>(n_offset);
+    ORT_RETURN_IF_ERROR(LaunchDequantizeBlockScaledFp8(
+        b_dequant.get(),
+        b_data + row_offset * static_cast<size_t>(k),
+        b_scale_data + row_offset * static_cast<size_t>(k_blocks),
+        rows,
+        SafeInt<int>(k),
+        SafeInt<int>(block_size_),
+        std::is_same<T, BFloat16>::value,
+        Stream(context)));
+
+    // The row-major [M, N] output is column-major [N, M] to cuBLAS, so an N tile is a row offset.
+    CUBLAS_RETURN_IF_ERROR(cublasGemmHelper(
+        GetCublasHandle(context),
+        CUBLAS_OP_T,  // transB: dequantized weight is [N, K] row-major == K-major [K, N]
+        CUBLAS_OP_N,  // transA
+        rows,
+        m_i,
+        k_i,
+        &alpha,
+        b_dequant.get(),
+        helper.Ldb(transb),
+        reinterpret_cast<const CudaT*>(a_ptr),
+        helper.Lda(transa),
+        &zero,
+        reinterpret_cast<CudaT*>(Y->MutableDataRaw()) + n_offset,
+        helper.Ldc(),
+        GetDeviceProp(),
+        UseTF32()));
+  }
 
   if (bias != nullptr) {
     ORT_RETURN_IF_ERROR(LaunchAddBiasBlockScaledFp8(

--- a/onnxruntime/contrib_ops/cuda/math/matmul_block_scaled_fp8.h
+++ b/onnxruntime/contrib_ops/cuda/math/matmul_block_scaled_fp8.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <cstddef>
+
 #include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime::contrib::cuda {
@@ -29,6 +31,7 @@ class MatMulBlockQuantizedFp8Weight final : public onnxruntime::cuda::CudaKernel
   Status ComputeImpl(OpKernelContext* context) const;
 
   int64_t block_size_;
+  size_t max_dequant_scratch_bytes_;
 };
 
 // Dequantizes FP8 (E4M3) weights with per-block FP32 scales into FP16/BF16. b_fp8 is [N, K]

--- a/onnxruntime/test/contrib_ops/matmul_block_scaled_fp8_test.cc
+++ b/onnxruntime/test/contrib_ops/matmul_block_scaled_fp8_test.cc
@@ -6,6 +6,7 @@
 #include "test/common/tensor_op_test_utils.h"
 #include "test/providers/provider_test_utils.h"
 #include "test/unittest_util/conversion.h"
+#include "test/util/include/scoped_env_vars.h"
 
 #if defined(USE_CUDA)
 // CUDA_VERSION comes from cuda.h. Without this include the guard below silently
@@ -498,6 +499,54 @@ TEST(MatMulBlockQuantizedFp8WeightOpTest, GemvTensorCoreLaneOwnershipFp16) {
   test.AddInput<float>("b_scale", {n, k_blocks}, b_scale);
   test.AddOutput<MLFloat16>("Y", {m, n}, FloatsToMLFloat16s(expected));
   test.SetOutputTolerance(0.01f);
+
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(DefaultCudaExecutionProvider());
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+}
+
+// The weight dequantization scratch is capped and tiled over N. ORT_FP8_DEQUANT_SCRATCH_MIB
+// shrinks the cap so that a small shape still splits into several tiles: 1 MiB / (4096 * 2 B) is
+// 128 rows, so N = 384 takes three passes. Every N row carries a distinct scale, so a tile that
+// picked up the wrong weight or scale offset, or wrote to the wrong output column, changes Y.
+TEST(MatMulBlockQuantizedFp8WeightOpTest, WeightDequantScratchTilingFp16) {
+  if (!HasCudaEnvironment(800)) {
+    GTEST_SKIP() << "CUDA device is required for MatMulBlockQuantizedFp8Weight.";
+  }
+  ScopedEnvironmentVariables scoped_env_vars{EnvVarMap{{"ORT_FP8_DEQUANT_SCRATCH_MIB", "1"}}};
+
+  constexpr int64_t m = 16;  // > kGemvMaxM, so the dequant + cuBLAS path runs
+  constexpr int64_t n = 384;
+  constexpr int64_t k = 4096;
+  constexpr int64_t block_size = 128;
+  constexpr int64_t k_blocks = k / block_size;
+
+  std::vector<Float8E4M3FN> b = MakeConstRowWeight(std::vector<float>(n, 1.0f), k);
+  std::vector<float> b_scale(static_cast<size_t>(n) * static_cast<size_t>(k_blocks));
+  for (int64_t row = 0; row < n; ++row) {
+    const float scale = static_cast<float>(row + 1) / 256.0f;
+    for (int64_t blk = 0; blk < k_blocks; ++blk) {
+      b_scale[static_cast<size_t>(row * k_blocks + blk)] = scale;
+    }
+  }
+
+  std::vector<float> a(static_cast<size_t>(m) * static_cast<size_t>(k), 1.0f);
+  // Y[r, c] = sum_k 1.0 * (c + 1) / 256 = 4096 * (c + 1) / 256 = 16 * (c + 1), a multiple of 16 and
+  // so exact in FP16 for every c < 384.
+  std::vector<float> expected(static_cast<size_t>(m) * static_cast<size_t>(n));
+  for (int64_t row = 0; row < m; ++row) {
+    for (int64_t col = 0; col < n; ++col) {
+      expected[static_cast<size_t>(row * n + col)] = 16.0f * static_cast<float>(col + 1);
+    }
+  }
+
+  OpTester test("MatMulBlockQuantizedFp8Weight", 1, onnxruntime::kMSDomain);
+  test.AddAttribute<int64_t>("block_size", block_size);
+  test.AddInput<MLFloat16>("A", {m, k}, FloatsToMLFloat16s(a));
+  test.AddInput<Float8E4M3FN>("B", {n, k}, b);
+  test.AddInput<float>("b_scale", {n, k_blocks}, b_scale);
+  test.AddOutput<MLFloat16>("Y", {m, n}, FloatsToMLFloat16s(expected));
+  test.SetOutputTolerance(0.5f);
 
   std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
   execution_providers.push_back(DefaultCudaExecutionProvider());

--- a/onnxruntime/test/contrib_ops/matmul_block_scaled_fp8_test.cc
+++ b/onnxruntime/test/contrib_ops/matmul_block_scaled_fp8_test.cc
@@ -507,8 +507,9 @@ TEST(MatMulBlockQuantizedFp8WeightOpTest, GemvTensorCoreLaneOwnershipFp16) {
 
 // The weight dequantization scratch is capped and tiled over N. ORT_FP8_DEQUANT_SCRATCH_MIB
 // shrinks the cap so that a small shape still splits into several tiles: 1 MiB / (4096 * 2 B) is
-// 128 rows, so N = 384 takes three passes. Every N row carries a distinct scale, so a tile that
-// picked up the wrong weight or scale offset, or wrote to the wrong output column, changes Y.
+// 128 rows, so N = 385 takes three full passes and one ragged pass. The weight pattern does not
+// repeat at a tile boundary and every N row carries a distinct scale, so a tile that picked up the
+// wrong weight or scale offset, or wrote to the wrong output column, changes Y.
 TEST(MatMulBlockQuantizedFp8WeightOpTest, WeightDequantScratchTilingFp16) {
   if (!HasCudaEnvironment(800)) {
     GTEST_SKIP() << "CUDA device is required for MatMulBlockQuantizedFp8Weight.";
@@ -516,27 +517,32 @@ TEST(MatMulBlockQuantizedFp8WeightOpTest, WeightDequantScratchTilingFp16) {
   ScopedEnvironmentVariables scoped_env_vars{EnvVarMap{{"ORT_FP8_DEQUANT_SCRATCH_MIB", "1"}}};
 
   constexpr int64_t m = 16;  // > kGemvMaxM, so the dequant + cuBLAS path runs
-  constexpr int64_t n = 384;
+  constexpr int64_t n = 385;
   constexpr int64_t k = 4096;
   constexpr int64_t block_size = 128;
   constexpr int64_t k_blocks = k / block_size;
+  constexpr int64_t tile_rows = 1024 * 1024 / (k * sizeof(MLFloat16));
+  static_assert(tile_rows == 128);
+  static_assert((n + tile_rows - 1) / tile_rows == 4);
+  static_assert(n % tile_rows == 1);
 
-  std::vector<Float8E4M3FN> b = MakeConstRowWeight(std::vector<float>(n, 1.0f), k);
+  std::vector<float> row_weights(static_cast<size_t>(n));
   std::vector<float> b_scale(static_cast<size_t>(n) * static_cast<size_t>(k_blocks));
   for (int64_t row = 0; row < n; ++row) {
+    row_weights[static_cast<size_t>(row)] = row % 3 == 0 ? 2.0f : 1.0f;
     const float scale = static_cast<float>(row + 1) / 256.0f;
     for (int64_t blk = 0; blk < k_blocks; ++blk) {
       b_scale[static_cast<size_t>(row * k_blocks + blk)] = scale;
     }
   }
+  std::vector<Float8E4M3FN> b = MakeConstRowWeight(row_weights, k);
 
   std::vector<float> a(static_cast<size_t>(m) * static_cast<size_t>(k), 1.0f);
-  // Y[r, c] = sum_k 1.0 * (c + 1) / 256 = 4096 * (c + 1) / 256 = 16 * (c + 1), a multiple of 16 and
-  // so exact in FP16 for every c < 384.
   std::vector<float> expected(static_cast<size_t>(m) * static_cast<size_t>(n));
   for (int64_t row = 0; row < m; ++row) {
     for (int64_t col = 0; col < n; ++col) {
-      expected[static_cast<size_t>(row * n + col)] = 16.0f * static_cast<float>(col + 1);
+      expected[static_cast<size_t>(row * n + col)] =
+          16.0f * static_cast<float>(col + 1) * row_weights[static_cast<size_t>(col)];
     }
   }
 
@@ -547,6 +553,31 @@ TEST(MatMulBlockQuantizedFp8WeightOpTest, WeightDequantScratchTilingFp16) {
   test.AddInput<float>("b_scale", {n, k_blocks}, b_scale);
   test.AddOutput<MLFloat16>("Y", {m, n}, FloatsToMLFloat16s(expected));
   test.SetOutputTolerance(0.5f);
+
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(DefaultCudaExecutionProvider());
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+}
+
+TEST(MatMulBlockQuantizedFp8WeightOpTest, ZeroKWithBiasFp16) {
+  if (!HasCudaEnvironment(800)) {
+    GTEST_SKIP() << "CUDA device is required for MatMulBlockQuantizedFp8Weight.";
+  }
+
+  constexpr int64_t m = 2;
+  constexpr int64_t n = 3;
+
+  const std::vector<float> bias = {1.0f, -2.0f, 0.5f};
+  const std::vector<float> expected = {1.0f, -2.0f, 0.5f, 1.0f, -2.0f, 0.5f};
+
+  OpTester test("MatMulBlockQuantizedFp8Weight", 1, onnxruntime::kMSDomain);
+  test.AddAttribute<int64_t>("block_size", 128);
+  test.AddInput<MLFloat16>("A", {m, 0}, std::vector<MLFloat16>{});
+  test.AddInput<Float8E4M3FN>("B", {n, 0}, std::vector<Float8E4M3FN>{});
+  test.AddInput<float>("b_scale", {n, 0}, std::vector<float>{});
+  test.AddOptionalInputEdge<float>();  // a_scale (skipped)
+  test.AddInput<MLFloat16>("bias", {n}, FloatsToMLFloat16s(bias));
+  test.AddOutput<MLFloat16>("Y", {m, n}, FloatsToMLFloat16s(expected));
 
   std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
   execution_providers.push_back(DefaultCudaExecutionProvider());

--- a/onnxruntime/test/contrib_ops/matmul_block_scaled_fp8_test.cc
+++ b/onnxruntime/test/contrib_ops/matmul_block_scaled_fp8_test.cc
@@ -12,6 +12,8 @@
 // CUDA_VERSION comes from cuda.h. Without this include the guard below silently
 // evaluates to false and every test in this file is compiled out.
 #include <cuda.h>
+
+#include "core/providers/cuda/cuda_provider_options.h"
 #endif
 
 namespace onnxruntime::test {
@@ -507,9 +509,11 @@ TEST(MatMulBlockQuantizedFp8WeightOpTest, GemvTensorCoreLaneOwnershipFp16) {
 
 // The weight dequantization scratch is capped and tiled over N. ORT_FP8_DEQUANT_SCRATCH_MIB
 // shrinks the cap so that a small shape still splits into several tiles: 1 MiB / (4096 * 2 B) is
-// 128 rows, so N = 385 takes three full passes and one ragged pass. The weight pattern does not
-// repeat at a tile boundary and every N row carries a distinct scale, so a tile that picked up the
-// wrong weight or scale offset, or wrote to the wrong output column, changes Y.
+// 128 rows, so N = 769 takes six full passes and one ragged pass. The CUDA arena is capped at
+// 8 MiB: the 3 MiB FP8 weight plus an untiled 6 MiB dequant scratch cannot fit, while the 1 MiB
+// tiled scratch can. The weight pattern does not repeat at a tile boundary and every N row carries
+// a distinct scale, so a tile that picked up the wrong weight or scale offset, or wrote to the
+// wrong output column, changes Y.
 TEST(MatMulBlockQuantizedFp8WeightOpTest, WeightDequantScratchTilingFp16) {
   if (!HasCudaEnvironment(800)) {
     GTEST_SKIP() << "CUDA device is required for MatMulBlockQuantizedFp8Weight.";
@@ -517,13 +521,13 @@ TEST(MatMulBlockQuantizedFp8WeightOpTest, WeightDequantScratchTilingFp16) {
   ScopedEnvironmentVariables scoped_env_vars{EnvVarMap{{"ORT_FP8_DEQUANT_SCRATCH_MIB", "1"}}};
 
   constexpr int64_t m = 16;  // > kGemvMaxM, so the dequant + cuBLAS path runs
-  constexpr int64_t n = 385;
+  constexpr int64_t n = 769;
   constexpr int64_t k = 4096;
   constexpr int64_t block_size = 128;
   constexpr int64_t k_blocks = k / block_size;
   constexpr int64_t tile_rows = 1024 * 1024 / (k * sizeof(MLFloat16));
   static_assert(tile_rows == 128);
-  static_assert((n + tile_rows - 1) / tile_rows == 4);
+  static_assert((n + tile_rows - 1) / tile_rows == 7);
   static_assert(n % tile_rows == 1);
 
   std::vector<float> row_weights(static_cast<size_t>(n));
@@ -554,8 +558,12 @@ TEST(MatMulBlockQuantizedFp8WeightOpTest, WeightDequantScratchTilingFp16) {
   test.AddOutput<MLFloat16>("Y", {m, n}, FloatsToMLFloat16s(expected));
   test.SetOutputTolerance(0.5f);
 
+  OrtCUDAProviderOptionsV2 provider_options{};
+  provider_options.gpu_mem_limit = 8 * 1024 * 1024;
+  provider_options.arena_extend_strategy = onnxruntime::ArenaExtendStrategy::kSameAsRequested;
+  provider_options.use_tf32 = false;
   std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
-  execution_providers.push_back(DefaultCudaExecutionProvider());
+  execution_providers.push_back(CudaExecutionProviderWithOptions(&provider_options));
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
 }
 


### PR DESCRIPTION
### Description

The `MatMulBlockQuantizedFp8Weight` fallback path (`M > 8`, i.e. every prefill matmul) expands the packed weight into an `[N, K]` scratch buffer of the activation type and then calls cuBLAS. That scratch is **2.37 GiB** for a 248320 x 5120 LM head, and it stays live for the duration of the GEMM even though the GEMM reads it exactly once.

This caps the scratch and runs the dequantize + GEMM pair over N tiles that fit inside the cap:

```
for n_offset in 0, tile_rows, 2 * tile_rows, ...:
    dequantize B[n_offset : n_offset + rows, :] into the scratch
    cublasGemmHelper(...) writing Y + n_offset
```

The row-major `[M, N]` output is column-major `[N, M]` to cuBLAS, so an N tile is a plain row offset into `Y` — there is no extra copy, no split-K reduction, and no change to the arithmetic performed per output element.

`ORT_FP8_DEQUANT_SCRATCH_MIB` sets the cap in MiB (default 256). Shapes small enough to fit the cap take a single tile and are completely unaffected.

### Verification

**Memory and speed** on Qwen3.8-27B at an 8K prompt (H200). The cap was chosen by sweeping it:

| cap | peak memory | TTFT |
|---|---|---|
| untiled (before) | 32609 MiB | baseline |
| 1 GiB | -3100 MiB | +5.2% |
| **256 MiB (default)** | **28503 MiB (-4106)** | **+1.1%** |
| 128 MiB | -4106 MiB | +13.9% |

**Numerics.** Per-element arithmetic is unchanged, but tiling changes the N extent handed to cuBLAS, so the library is free to select a different kernel for a tile than for the whole matrix. Measured tiled vs untiled, FP16, `K = 5120`, `block_size = 128`:

| M | N | tiles | max abs diff | differing elements |
|---:|---:|---:|---:|---:|
| 16 | 6144 | 1 | 0 | 0 |
| 1024 | 6144 | 1 | 0 | 0 |
| 16 | 32768 | 2 | 0.125 | 28065 |
| 1024 | 32768 | 2 | 0.125 | 2396209 |
| 64 | 248320 | 10 | 0 | 0 |

`0.125` is exactly one FP16 ULP at the magnitude of these outputs (values around 200, where FP16 spacing is `2^-3`). So where the split changes cuBLAS's kernel choice the result moves by at most one last-bit rounding step — the same order of change as cuBLAS picking a different tactic for any other reason. Single-tile shapes are bitwise identical.

**Tests.** `WeightDequantScratchTilingFp16` sets `ORT_FP8_DEQUANT_SCRATCH_MIB=1` so a small shape (`N = 769`, `K = 4096`) still splits into six tiles, with a distinct scale on every N row so that a tile reading the wrong weight/scale offset or writing the wrong output column changes `Y`. Confirmed under nsys that the test issues 3 dequant launches while a single-tile control issues 1. All 11 `MatMulBlockQuantizedFp8WeightOpTest` cases pass.

### Motivation and Context

On Qwen3.8-27B the untiled scratch was the single largest transient allocation in the model and pushed peak memory ~4.1 GB above what the weights and KV cache actually need. Recovering it makes room for longer contexts or a larger batch at the same memory budget, and costs ~1% of TTFT.

This is independent of #32128 (which speeds up the NVFP4 dequantization kernel); the two touch different operators and can land in either order.
