### PR TITLE
Handle empty initializer axis scaling

### DIFF
--- a/onnxruntime/core/optimizer/initializer.cc
+++ b/onnxruntime/core/optimizer/initializer.cc
@@ -494,8 +494,9 @@ struct ScaleByAxis {
 
 void Initializer::scale_by_axis(const Initializer& scalers, int axis, bool column_major) {
   ORT_ENFORCE(axis >= 0, "Axis must be non-negative");
-  const size_t block_size = narrow<size_t>(data_->Shape().SizeFromDimension(gsl::narrow_cast<size_t>(axis)));
-  const size_t num_blocks = size() / block_size;
+  const auto axis_value = gsl::narrow_cast<size_t>(axis);
+  const size_t block_size = narrow<size_t>(data_->Shape().SizeFromDimension(axis_value));
+  const size_t num_blocks = narrow<size_t>(data_->Shape().SizeToDimension(axis_value));
   ORT_ENFORCE(scalers.size() == 1 ||
                   (column_major ? scalers.size() == block_size : scalers.size() == num_blocks),
               "Invalid other(scalers) size");

--- a/onnxruntime/test/optimizer/initializer_test.cc
+++ b/onnxruntime/test/optimizer/initializer_test.cc
@@ -13,6 +13,7 @@
 #include "gtest/gtest.h"
 
 #include "core/common/common.h"
+#include "core/common/span_utils.h"
 #include "core/framework/endian_utils.h"
 #include "test/util/include/asserts.h"
 #include "test/util/include/file_util.h"
@@ -273,6 +274,41 @@ TEST(OptimizerInitializerTest, DataField) {
   TestInitializerDataField<BFloat16>();
   TestInitializerDataField<float>();
   TestInitializerDataField<double>();
+}
+
+TEST(OptimizerInitializerTest, ScaleByAxisEmptyTensor) {
+  {
+    Initializer target(ONNX_NAMESPACE::TensorProto_DataType_FLOAT, "target", AsSpan<int64_t>({2, 0}));
+    Initializer scalers(ONNX_NAMESPACE::TensorProto_DataType_FLOAT, "scalers", AsSpan<int64_t>({2}));
+    EXPECT_NO_THROW(target.scale_by_axis(scalers, 1));
+    EXPECT_EQ(target.size(), 0u);
+  }
+
+  {
+    Initializer target(ONNX_NAMESPACE::TensorProto_DataType_FLOAT, "target", AsSpan<int64_t>({2, 0}));
+    Initializer scalers(ONNX_NAMESPACE::TensorProto_DataType_FLOAT, "scalers", AsSpan<int64_t>({0}));
+    EXPECT_NO_THROW(target.scale_by_axis(scalers, 1, true));
+    EXPECT_EQ(target.size(), 0u);
+  }
+
+  {
+    Initializer target(ONNX_NAMESPACE::TensorProto_DataType_FLOAT, "target", AsSpan<int64_t>({0}));
+    Initializer scalar(ONNX_NAMESPACE::TensorProto_DataType_FLOAT, "scalar", AsSpan<int64_t>({}));
+    EXPECT_NO_THROW(target.scale_by_axis(scalar, 0));
+    EXPECT_EQ(target.size(), 0u);
+  }
+
+  {
+    Initializer target(ONNX_NAMESPACE::TensorProto_DataType_FLOAT, "target", AsSpan<int64_t>({2, 0}));
+    Initializer invalid_scalers(ONNX_NAMESPACE::TensorProto_DataType_FLOAT, "invalid_scalers", AsSpan<int64_t>({3}));
+    EXPECT_THROW(target.scale_by_axis(invalid_scalers, 1), OnnxRuntimeException);
+  }
+
+  {
+    Initializer target(ONNX_NAMESPACE::TensorProto_DataType_FLOAT, "target", AsSpan<int64_t>({2, 0}));
+    Initializer scalers(ONNX_NAMESPACE::TensorProto_DataType_DOUBLE, "scalers", AsSpan<int64_t>({2}));
+    EXPECT_THROW(target.scale_by_axis(scalers, 1), OnnxRuntimeException);
+  }
 }
 
 // An in-memory external-data initializer with no registered OrtValue must load without a model_path.


### PR DESCRIPTION
This pull request improves the robustness and correctness of the `scale_by_axis` method in the `Initializer` class and adds new tests to ensure proper handling of edge cases, especially with empty tensors and invalid scaler inputs.

**Improvements to `scale_by_axis` implementation:**

* Updated the calculation of `block_size` and `num_blocks` in the `scale_by_axis` method of the `Initializer` class to use more precise and consistent dimension handling, addressing potential bugs with axis indexing. (`onnxruntime/core/optimizer/initializer.cc`)

**Testing enhancements:**

* Added a new test case (`ScaleByAxisEmptyTensor`) to cover scenarios where the target or scaler tensors are empty, ensuring that the method does not throw unexpectedly and returns the correct size. The test also checks for proper exception handling with invalid scaler sizes and data types. (`onnxruntime/test/optimizer/initializer_test.cc`)
* Included the `span_utils.h` header in the test file to support the new test cases using spans. (`onnxruntime/test/optimizer/initializer_test.cc`)