### PR TITLE
[CUDA] Tune NVFP4 GEMV tiling for Qwen MTP

### DIFF
--- a/docs/contrib_ops/cuda/matmul_block_scaled_fp4.md
+++ b/docs/contrib_ops/cuda/matmul_block_scaled_fp4.md
@@ -181,9 +181,19 @@ product needs at most 6, inside FP16's 11 and BF16's 8; the range is safe too
 `KSplit` warps per block take a strided share of the K windows and reduce through
 shared memory. Without it, 16 columns per warp yields 16x fewer warps than the
 scalar path and the small MLP shapes lose more to idle SMs than they gain. The
-launcher picks `ColTiles = 4, KSplit = 2` when the column grid alone still covers
-a wave of SMs, and otherwise `ColTiles = 1` with as many `KSplit` warps as there
-are K windows.
+launcher targets four waves of SMs before using one-column blocks, and uses eight
+waves for four-column blocks when the reduction is long (`K / 128 >= 64`):
+
+| Grid condition | Reduction | Configuration |
+|---|---|---|
+| four-column grid covers four waves | ordinary or wide enough long reduction | `ColTiles = 4, KSplit = min(2, K / 128)` |
+| one-column grid covers four waves | `K / 128 < 64` | `ColTiles = 1, KSplit = min(2, K / 128)` |
+| one-column grid covers four waves | `K / 128 >= 64` | `ColTiles = 1, KSplit = 8` |
+| column-starved | any | `ColTiles = 1`, up to 16 K-split warps |
+
+The extra grid-wave requirement avoids collapsing a medium-wide GEMV into too
+few blocks. On H200, this keeps the Qwen3.8 MTP `N=17408,K=5120` shape at
+`KSplit=2,ColTiles=1`, while the long `K=8192` sibling uses `KSplit=8`.
 
 Measured on H200 (132 SMs, `M = 4`, FP16), scalar -> tensor core:
 
@@ -280,6 +290,9 @@ GEMM and the original scale tensor for the other paths.
 | `ORT_MATMUL_BLOCK_SCALED_FP4_NATIVE_SM120` | `0` | Enables the opt-in native SM120 NVFP4 x NVFP4 GEMM path when the shape and device guards pass. |
 | `ORT_FP4_GEMV_MMA` | `1` | Set to `0` to disable the decode GEMV tensor-core sub-path (`mma.m16n8k16`, SM80+, `K % 128 == 0`) and use the scalar warp-reduction path. |
 | `ORT_FP4_GEMV_ROW_TILING` | `1` | Set to `0` to force `RowsPerBlock == 1` in the scalar decode GEMV. |
+| `ORT_FP4_GEMV_KSPLIT` | `0` | Benchmark override for the tensor-core GEMV K-split value (`1, 2, 4, 8, or 16`). |
+| `ORT_FP4_GEMV_COL_TILES` | `0` | Benchmark override for tensor-core GEMV column tiles (`1` or `4`). |
+| `ORT_FP4_GEMV_MATCH_N` / `ORT_FP4_GEMV_MATCH_K` | `0` | Restrict the two benchmark overrides to one `N`/`K` shape; zero means any shape. |
 
 The default remains the existing weight-only semantics: decode GEMV for small
 `M`, otherwise dequantize `B` and call cuBLAS.

--- a/docs/contrib_ops/cuda/matmul_block_scaled_fp4.md
+++ b/docs/contrib_ops/cuda/matmul_block_scaled_fp4.md
@@ -187,9 +187,9 @@ waves for four-column blocks when the reduction is long (`K / 128 >= 64`):
 | Grid condition | Reduction | Configuration |
 |---|---|---|
 | four-column grid covers four waves | ordinary or wide enough long reduction | `ColTiles = 4, KSplit = min(2, K / 128)` |
-| one-column grid covers four waves | `K / 128 < 64` | `ColTiles = 1, KSplit = min(2, K / 128)` |
-| one-column grid covers four waves | `K / 128 >= 64` | `ColTiles = 1, KSplit = 8` |
-| column-starved | any | `ColTiles = 1`, up to 16 K-split warps |
+| four-column grid does not cover four waves, but one-column grid does | `K / 128 < 64` | `ColTiles = 1, KSplit = min(2, K / 128)` |
+| four-column grid does not cover eight waves, but one-column grid covers four waves | `K / 128 >= 64` | `ColTiles = 1, KSplit = 8` |
+| one-column grid does not cover four waves | any | `ColTiles = 1`, up to 16 K-split warps |
 
 The extra grid-wave requirement avoids collapsing a medium-wide GEMV into too
 few blocks. On H200, this keeps the Qwen3.8 MTP `N=17408,K=5120` shape at

--- a/onnxruntime/contrib_ops/cuda/math/matmul_block_scaled_fp4.cu
+++ b/onnxruntime/contrib_ops/cuda/math/matmul_block_scaled_fp4.cu
@@ -658,11 +658,6 @@ bool Fp4GemvMmaEnabled() {
   return enabled;
 }
 
-struct Fp4MmaConfig {
-  int k_split;
-  int col_tiles;
-};
-
 Fp4MmaConfig ApplyFp4MmaConfigOverrides(Fp4MmaConfig config, int n, int k) {
   static int const k_split =
       onnxruntime::ParseEnvironmentVariableWithDefault<int>("ORT_FP4_GEMV_KSPLIT", 0);
@@ -702,14 +697,15 @@ Fp4MmaConfig ApplyFp4MmaConfigOverrides(Fp4MmaConfig config, int n, int k) {
 // alone covers several waves of SMs; below that the block count collapses and the device
 // idles, so columns are traded back before adding more K-split warps. Long reductions retain
 // KSplit 8 until wide column blocks cover eight waves. Measured on H200
-// (132 SMs, M = 4, half), previous default -> selected tensor-core config:
+// (132 SMs, M = 4, half). Rows marked "tuned" compare this selector against the previous
+// selector; the other rows record the selected tensor-core configuration and latency:
 //
-//   N = 248320, K = 2048 (lm_head)      538.5 -> 107.7 us (5.00x)  KSplit 2,  ColTiles 4
-//   N =  17408, K = 5120 (gate/up)       50.7 ->  46.6 us (1.09x)  KSplit 2,  ColTiles 1
-//   N =  17408, K = 8192                  61.4 ->  55.0 us (1.12x)  KSplit 8,  ColTiles 1
-//   N =    512, K = 2048 (gate/up)        3.90 ->  3.34 us (1.11x) KSplit 16, ColTiles 1
-//   N =   2048, K =  512 (down)           4.16 ->  2.97 us (1.40x) KSplit 4,  ColTiles 1
-Fp4MmaConfig PickFp4MmaConfig(int n, int k, int sm_count) {
+//   N = 248320, K = 2048 (lm_head)                 107.7 us        KSplit 2,  ColTiles 4
+//   N =  17408, K = 5120 (gate/up, tuned) 50.7 ->  46.6 us (1.09x) KSplit 2,  ColTiles 1
+//   N =  17408, K = 8192 (tuned)         61.4 ->  55.0 us (1.12x) KSplit 8,  ColTiles 1
+//   N =    512, K = 2048 (gate/up)                  3.34 us        KSplit 16, ColTiles 1
+//   N =   2048, K =  512 (down)                     2.97 us        KSplit 4,  ColTiles 1
+Fp4MmaConfig PickFp4MmaConfigImpl(int n, int k, int sm_count) {
   constexpr int kTargetGridWaves = 4;
   constexpr int kLongReductionGridWaves = 8;
   constexpr int kLongReductionWindows = 64;
@@ -737,6 +733,17 @@ Fp4MmaConfig PickFp4MmaConfig(int n, int k, int sm_count) {
 }  // namespace
 
 #endif  // CUDA_VERSION >= 12080
+
+Fp4MmaConfig PickFp4MmaConfig(int n, int k, int sm_count) {
+#if defined(CUDA_VERSION) && CUDA_VERSION >= 12080
+  return PickFp4MmaConfigImpl(n, k, sm_count);
+#else
+  ORT_UNUSED_PARAMETER(n);
+  ORT_UNUSED_PARAMETER(k);
+  ORT_UNUSED_PARAMETER(sm_count);
+  return {1, 1};
+#endif
+}
 
 Status LaunchDequantizeNvFp4(void* b_dequant,
                              const void* b_packed,
@@ -844,7 +851,7 @@ Status LaunchMatMulBlockQuantizedFp4WeightGemv(void* y,
   // (g = lane >> 2, t = lane & 3) reads activation row g, covers weight columns 16 * tile + g and
   // + 8, and stores output rows 2t and 2t + 1 of those two columns.
   if (device_prop.major >= 8 && k % 128 == 0 && m <= 8 && Fp4GemvMmaEnabled()) {
-    const Fp4MmaConfig cfg = PickFp4MmaConfig(n, k, device_prop.multiProcessorCount);
+    const Fp4MmaConfig cfg = PickFp4MmaConfigImpl(n, k, device_prop.multiProcessorCount);
     const int cols_per_block = 16 * cfg.col_tiles;
     const dim3 mma_threads{32, static_cast<unsigned int>(cfg.k_split * cfg.col_tiles)};
     const dim3 mma_blocks{static_cast<unsigned int>((n + cols_per_block - 1) / cols_per_block)};

--- a/onnxruntime/contrib_ops/cuda/math/matmul_block_scaled_fp4.cu
+++ b/onnxruntime/contrib_ops/cuda/math/matmul_block_scaled_fp4.cu
@@ -663,23 +663,67 @@ struct Fp4MmaConfig {
   int col_tiles;
 };
 
+Fp4MmaConfig ApplyFp4MmaConfigOverrides(Fp4MmaConfig config, int n, int k) {
+  static int const k_split =
+      onnxruntime::ParseEnvironmentVariableWithDefault<int>("ORT_FP4_GEMV_KSPLIT", 0);
+  static int const col_tiles =
+      onnxruntime::ParseEnvironmentVariableWithDefault<int>("ORT_FP4_GEMV_COL_TILES", 0);
+  static int const match_n =
+      onnxruntime::ParseEnvironmentVariableWithDefault<int>("ORT_FP4_GEMV_MATCH_N", 0);
+  static int const match_k =
+      onnxruntime::ParseEnvironmentVariableWithDefault<int>("ORT_FP4_GEMV_MATCH_K", 0);
+  ORT_ENFORCE(k_split == 0 || k_split == 1 || k_split == 2 || k_split == 4 ||
+                  k_split == 8 || k_split == 16,
+              "ORT_FP4_GEMV_KSPLIT must be 0, 1, 2, 4, 8, or 16.");
+  ORT_ENFORCE(col_tiles == 0 || col_tiles == 1 || col_tiles == 4,
+              "ORT_FP4_GEMV_COL_TILES must be 0, 1, or 4.");
+  ORT_ENFORCE(match_n >= 0 && match_k >= 0,
+              "ORT_FP4_GEMV_MATCH_N and ORT_FP4_GEMV_MATCH_K must be non-negative.");
+
+  if ((match_n != 0 && n != match_n) || (match_k != 0 && k != match_k)) {
+    return config;
+  }
+
+  if (k_split != 0) {
+    config.k_split = k_split;
+  }
+  if (col_tiles != 0) {
+    config.col_tiles = col_tiles;
+  }
+  ORT_ENFORCE(config.col_tiles == 1 || config.k_split <= 2,
+              "ORT_FP4_GEMV_COL_TILES=4 supports only KSplit 1 or 2.");
+  return config;
+}
+
 // Picks the (KSplit, ColTiles) shape for the tensor-core GEMV.
 //
 // A warp owns 16 output columns, so the column grid is 16x smaller than the scalar path's.
 // Wide column blocks (ColTiles = 4) give the best weight locality, but only pay off once N
-// alone still covers a full wave of SMs; below that the block count collapses and the
-// device idles, so columns are traded back for K-split warps. Measured on H200 (132 SMs,
-// M = 4, half), scalar path -> best tensor-core config:
+// alone covers several waves of SMs; below that the block count collapses and the device
+// idles, so columns are traded back before adding more K-split warps. Long reductions retain
+// KSplit 8 until wide column blocks cover eight waves. Measured on H200
+// (132 SMs, M = 4, half), previous default -> selected tensor-core config:
 //
 //   N = 248320, K = 2048 (lm_head)      538.5 -> 107.7 us (5.00x)  KSplit 2,  ColTiles 4
+//   N =  17408, K = 5120 (gate/up)       50.7 ->  46.6 us (1.09x)  KSplit 2,  ColTiles 1
+//   N =  17408, K = 8192                  61.4 ->  55.0 us (1.12x)  KSplit 8,  ColTiles 1
 //   N =    512, K = 2048 (gate/up)        3.90 ->  3.34 us (1.11x) KSplit 16, ColTiles 1
 //   N =   2048, K =  512 (down)           4.16 ->  2.97 us (1.40x) KSplit 4,  ColTiles 1
 Fp4MmaConfig PickFp4MmaConfig(int n, int k, int sm_count) {
+  constexpr int kTargetGridWaves = 4;
+  constexpr int kLongReductionGridWaves = 8;
+  constexpr int kLongReductionWindows = 64;
   const int windows = k >> 7;  // >= 1; the launcher only takes this path when k % 128 == 0
   const int col_tiles = (n + 15) / 16;
 
-  if ((col_tiles + 3) / 4 >= sm_count) {
-    return {std::min(2, windows), 4};
+  const int wide_col_blocks = (col_tiles + 3) / 4;
+  if (wide_col_blocks >= kTargetGridWaves * sm_count &&
+      (windows < kLongReductionWindows || wide_col_blocks >= kLongReductionGridWaves * sm_count)) {
+    return ApplyFp4MmaConfigOverrides({std::min(2, windows), 4}, n, k);
+  }
+  if (col_tiles >= kTargetGridWaves * sm_count) {
+    const int k_split = windows >= kLongReductionWindows ? 8 : std::min(2, windows);
+    return ApplyFp4MmaConfigOverrides({k_split, 1}, n, k);
   }
   // Column-starved: give every block as many K-split warps as there are windows, up to the
   // 16-warp (512-thread) block ceiling.
@@ -687,7 +731,7 @@ Fp4MmaConfig PickFp4MmaConfig(int n, int k, int sm_count) {
   while (k_split < 16 && k_split * 2 <= windows) {
     k_split <<= 1;
   }
-  return {k_split, 1};
+  return ApplyFp4MmaConfigOverrides({k_split, 1}, n, k);
 }
 
 }  // namespace

--- a/onnxruntime/contrib_ops/cuda/math/matmul_block_scaled_fp4.cu
+++ b/onnxruntime/contrib_ops/cuda/math/matmul_block_scaled_fp4.cu
@@ -6,7 +6,6 @@
 #include <cuda.h>
 #include <cuda_fp16.h>
 #include <cuda_bf16.h>
-#include <algorithm>
 #include <cstring>
 
 #if defined(CUDA_VERSION) && CUDA_VERSION >= 12080
@@ -690,7 +689,7 @@ Fp4MmaConfig ApplyFp4MmaConfigOverrides(Fp4MmaConfig config, int n, int k) {
   return config;
 }
 
-// Picks the (KSplit, ColTiles) shape for the tensor-core GEMV.
+// PickFp4MmaConfig picks the (KSplit, ColTiles) shape for the tensor-core GEMV.
 //
 // A warp owns 16 output columns, so the column grid is 16x smaller than the scalar path's.
 // Wide column blocks (ColTiles = 4) give the best weight locality, but only pay off once N
@@ -705,45 +704,9 @@ Fp4MmaConfig ApplyFp4MmaConfigOverrides(Fp4MmaConfig config, int n, int k) {
 //   N =  17408, K = 8192 (tuned)         61.4 ->  55.0 us (1.12x) KSplit 8,  ColTiles 1
 //   N =    512, K = 2048 (gate/up)                  3.34 us        KSplit 16, ColTiles 1
 //   N =   2048, K =  512 (down)                     2.97 us        KSplit 4,  ColTiles 1
-Fp4MmaConfig PickFp4MmaConfigImpl(int n, int k, int sm_count) {
-  constexpr int kTargetGridWaves = 4;
-  constexpr int kLongReductionGridWaves = 8;
-  constexpr int kLongReductionWindows = 64;
-  const int windows = k >> 7;  // >= 1; the launcher only takes this path when k % 128 == 0
-  const int col_tiles = (n + 15) / 16;
-
-  const int wide_col_blocks = (col_tiles + 3) / 4;
-  if (wide_col_blocks >= kTargetGridWaves * sm_count &&
-      (windows < kLongReductionWindows || wide_col_blocks >= kLongReductionGridWaves * sm_count)) {
-    return ApplyFp4MmaConfigOverrides({std::min(2, windows), 4}, n, k);
-  }
-  if (col_tiles >= kTargetGridWaves * sm_count) {
-    const int k_split = windows >= kLongReductionWindows ? 8 : std::min(2, windows);
-    return ApplyFp4MmaConfigOverrides({k_split, 1}, n, k);
-  }
-  // Column-starved: give every block as many K-split warps as there are windows, up to the
-  // 16-warp (512-thread) block ceiling.
-  int k_split = 1;
-  while (k_split < 16 && k_split * 2 <= windows) {
-    k_split <<= 1;
-  }
-  return ApplyFp4MmaConfigOverrides({k_split, 1}, n, k);
-}
-
 }  // namespace
 
 #endif  // CUDA_VERSION >= 12080
-
-Fp4MmaConfig PickFp4MmaConfig(int n, int k, int sm_count) {
-#if defined(CUDA_VERSION) && CUDA_VERSION >= 12080
-  return PickFp4MmaConfigImpl(n, k, sm_count);
-#else
-  ORT_UNUSED_PARAMETER(n);
-  ORT_UNUSED_PARAMETER(k);
-  ORT_UNUSED_PARAMETER(sm_count);
-  return {1, 1};
-#endif
-}
 
 Status LaunchDequantizeNvFp4(void* b_dequant,
                              const void* b_packed,
@@ -851,7 +814,8 @@ Status LaunchMatMulBlockQuantizedFp4WeightGemv(void* y,
   // (g = lane >> 2, t = lane & 3) reads activation row g, covers weight columns 16 * tile + g and
   // + 8, and stores output rows 2t and 2t + 1 of those two columns.
   if (device_prop.major >= 8 && k % 128 == 0 && m <= 8 && Fp4GemvMmaEnabled()) {
-    const Fp4MmaConfig cfg = PickFp4MmaConfigImpl(n, k, device_prop.multiProcessorCount);
+    const Fp4MmaConfig cfg = ApplyFp4MmaConfigOverrides(
+        PickFp4MmaConfig(n, k, device_prop.multiProcessorCount), n, k);
     const int cols_per_block = 16 * cfg.col_tiles;
     const dim3 mma_threads{32, static_cast<unsigned int>(cfg.k_split * cfg.col_tiles)};
     const dim3 mma_blocks{static_cast<unsigned int>((n + cols_per_block - 1) / cols_per_block)};

--- a/onnxruntime/contrib_ops/cuda/math/matmul_block_scaled_fp4.h
+++ b/onnxruntime/contrib_ops/cuda/math/matmul_block_scaled_fp4.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "contrib_ops/cuda/math/matmul_block_scaled_fp4_tiling.h"
 #include "core/providers/cuda/cuda_kernel.h"
 
 namespace onnxruntime::contrib::cuda {

--- a/onnxruntime/contrib_ops/cuda/math/matmul_block_scaled_fp4_tiling.h
+++ b/onnxruntime/contrib_ops/cuda/math/matmul_block_scaled_fp4_tiling.h
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+namespace onnxruntime::contrib::cuda {
+
+struct Fp4MmaConfig {
+  int k_split;
+  int col_tiles;
+};
+
+// Returns the tensor-core GEMV tiling selected for the given shape and device size.
+Fp4MmaConfig PickFp4MmaConfig(int n, int k, int sm_count);
+
+}  // namespace onnxruntime::contrib::cuda

--- a/onnxruntime/contrib_ops/cuda/math/matmul_block_scaled_fp4_tiling.h
+++ b/onnxruntime/contrib_ops/cuda/math/matmul_block_scaled_fp4_tiling.h
@@ -11,6 +11,27 @@ struct Fp4MmaConfig {
 };
 
 // Returns the tensor-core GEMV tiling selected for the given shape and device size.
-Fp4MmaConfig PickFp4MmaConfig(int n, int k, int sm_count);
+inline Fp4MmaConfig PickFp4MmaConfig(int n, int k, int sm_count) {
+  constexpr int kTargetGridWaves = 4;
+  constexpr int kLongReductionGridWaves = 8;
+  constexpr int kLongReductionWindows = 64;
+  const int windows = k >> 7;
+  const int col_tiles = (n + 15) / 16;
+
+  const int wide_col_blocks = (col_tiles + 3) / 4;
+  if (wide_col_blocks >= kTargetGridWaves * sm_count &&
+      (windows < kLongReductionWindows || wide_col_blocks >= kLongReductionGridWaves * sm_count)) {
+    return {windows < 2 ? windows : 2, 4};
+  }
+  if (col_tiles >= kTargetGridWaves * sm_count) {
+    return {windows >= kLongReductionWindows ? 8 : (windows < 2 ? windows : 2), 1};
+  }
+
+  int k_split = 1;
+  while (k_split < 16 && k_split * 2 <= windows) {
+    k_split <<= 1;
+  }
+  return {k_split, 1};
+}
 
 }  // namespace onnxruntime::contrib::cuda

--- a/onnxruntime/test/contrib_ops/matmul_block_scaled_fp4_test.cc
+++ b/onnxruntime/test/contrib_ops/matmul_block_scaled_fp4_test.cc
@@ -6,6 +6,8 @@
 // conversion intrinsics that are only available in CUDA 12.8 and newer.
 #include <cuda.h>
 #include <cuda_runtime_api.h>
+
+#include "contrib_ops/cuda/math/matmul_block_scaled_fp4_tiling.h"
 #endif
 
 #include <algorithm>
@@ -606,73 +608,27 @@ TEST(MatMulBlockQuantizedFp4WeightOpTest, GemvTensorCoreTilesBf16) {
   }
 }
 
-// Covers the shape thresholds added for Qwen3.8 MTP: a medium-wide grid keeps ColTiles == 1 and
-// selects KSplit == 2, the same grid with a long reduction selects KSplit == 8, and a wide grid
-// selects ColTiles == 4. The N values are derived from the device's SM count so each case lands on
-// the intended grid-wave boundary on H200 and on smaller SM80+ devices.
-TEST(MatMulBlockQuantizedFp4WeightOpTest, GemvTensorCoreQwenTilingBoundariesFp16) {
-  if (!HasCudaEnvironment(800)) {
-    GTEST_SKIP() << "CUDA device is required for MatMulBlockQuantizedFp4Weight.";
-  }
-
-  int device = 0;
-  ASSERT_EQ(cudaGetDevice(&device), cudaSuccess);
-  cudaDeviceProp prop{};
-  ASSERT_EQ(cudaGetDeviceProperties(&prop, device), cudaSuccess);
-
+TEST(MatMulBlockQuantizedFp4WeightOpTest, GemvTensorCoreQwenTilingBoundaries) {
   struct Case {
     int64_t n;
     int64_t k;
+    int k_split;
+    int col_tiles;
   };
-  const int64_t sm_count = prop.multiProcessorCount;
+  constexpr int sm_count = 132;
   const Case cases[] = {
-      {64 * sm_count, 5120},  // 4 waves of single-column blocks, ordinary reduction
-      {64 * sm_count, 8192},  // same grid, long reduction retains KSplit 8
-      {512 * sm_count, 512},  // 8 waves of four-column blocks, wide-column configuration
+      {64 * sm_count, 5120, 2, 1},        // 4 waves of single-column blocks, ordinary reduction
+      {64 * sm_count, 8192, 8, 1},        // same grid, long reduction retains KSplit 8
+      {512 * sm_count, 512, 2, 4},        // 8 waves of four-column blocks
+      {64 * sm_count - 16, 2048, 16, 1},  // just below 4 single-column waves
   };
 
-  constexpr int64_t m = 4;
   for (const Case& shape : cases) {
-    const int64_t n = shape.n;
-    const int64_t k = shape.k;
-    const int64_t k_blocks = k / 16;
-    SCOPED_TRACE("N = " + std::to_string(n) + ", K = " + std::to_string(k));
-
-    static const uint8_t kWeightBytes[] = {0x22, 0x44, 0xAA, 0x11};
-    static const float kWeightValues[] = {1.0f, 2.0f, -1.0f, 0.5f};
-    std::vector<uint8_t> b(static_cast<size_t>(n * (k / 2)));
-    std::vector<uint8_t> weight_scale(static_cast<size_t>(n * k_blocks), 0x38);
-    for (int64_t col = 0; col < n; ++col) {
-      const int pattern = static_cast<int>(col & 3);
-      std::fill(b.begin() + static_cast<size_t>(col * (k / 2)),
-                b.begin() + static_cast<size_t>((col + 1) * (k / 2)), kWeightBytes[pattern]);
-    }
-
-    std::vector<float> a(static_cast<size_t>(m * k));
-    for (int64_t row = 0; row < m; ++row) {
-      std::fill(a.begin() + static_cast<size_t>(row * k),
-                a.begin() + static_cast<size_t>((row + 1) * k), static_cast<float>(row + 1));
-    }
-    std::vector<float> expected(static_cast<size_t>(m * n));
-    for (int64_t row = 0; row < m; ++row) {
-      for (int64_t col = 0; col < n; ++col) {
-        expected[static_cast<size_t>(row * n + col)] =
-            static_cast<float>(k) * static_cast<float>(row + 1) * kWeightValues[col & 3];
-      }
-    }
-
-    OpTester test("MatMulBlockQuantizedFp4Weight", 1, onnxruntime::kMSDomain);
-    test.AddAttribute<int64_t>("block_size", 16);
-    test.AddInput<MLFloat16>("A", {m, k}, FloatsToMLFloat16s(a));
-    test.AddInput<uint8_t>("B", {n, k / 2}, b);
-    test.AddInput<uint8_t>("weight_scale", {n, k_blocks}, weight_scale);
-    test.AddInput<float>("weight_scale_2", {1}, {1.0f});
-    test.AddOutput<MLFloat16>("Y", {m, n}, FloatsToMLFloat16s(expected));
-    test.SetOutputTolerance(0.5f);
-
-    std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
-    execution_providers.push_back(DefaultCudaExecutionProvider());
-    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+    SCOPED_TRACE("N = " + std::to_string(shape.n) + ", K = " + std::to_string(shape.k));
+    const auto config = onnxruntime::contrib::cuda::PickFp4MmaConfig(
+        static_cast<int>(shape.n), static_cast<int>(shape.k), sm_count);
+    EXPECT_EQ(config.k_split, shape.k_split);
+    EXPECT_EQ(config.col_tiles, shape.col_tiles);
   }
 }
 

--- a/onnxruntime/test/contrib_ops/matmul_block_scaled_fp4_test.cc
+++ b/onnxruntime/test/contrib_ops/matmul_block_scaled_fp4_test.cc
@@ -7,6 +7,8 @@
 #include <cuda.h>
 #endif
 
+#include <algorithm>
+
 #include "gtest/gtest.h"
 #include "test/common/cuda_op_test_utils.h"
 #include "test/common/tensor_op_test_utils.h"
@@ -521,10 +523,9 @@ struct MmaShape {
   int64_t k;
 };
 
-// N = 8704 gives 544 column tiles, i.e. 136 blocks at ColTiles = 4, which is above the SM count
-// of every current device and so selects the wide shape. N = 36 leaves 4 columns in the last
-// 16-column tile, which is the only way to make a lane's *low* column fall out of range (N = 40
-// only exercises the high column), so it covers the lo_ok == false predication.
+// N = 8704 gives 544 column tiles and exercises a large, ragged grid. N = 36 leaves 4 columns in
+// the last 16-column tile, which is the only way to make a lane's *low* column fall out of range
+// (N = 40 only exercises the high column), so it covers the lo_ok == false predication.
 constexpr MmaShape kMmaShapes[] = {{36, 128}, {40, 128}, {512, 256}, {2048, 512}, {8704, 256}};
 
 }  // namespace
@@ -596,6 +597,76 @@ TEST(MatMulBlockQuantizedFp4WeightOpTest, GemvTensorCoreTilesBf16) {
     test.AddOptionalInputEdge<float>();  // input_scale (skipped)
     test.AddInput<BFloat16>("bias", {n}, FloatsToBFloat16s(bias));
     test.AddOutput<BFloat16>("Y", {m, n}, FloatsToBFloat16s(expected));
+    test.SetOutputTolerance(0.5f);
+
+    std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+    execution_providers.push_back(DefaultCudaExecutionProvider());
+    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+  }
+}
+
+// Covers the shape thresholds added for Qwen3.8 MTP: a medium-wide grid keeps ColTiles == 1 and
+// selects KSplit == 2, the same grid with a long reduction selects KSplit == 8, and a wide grid
+// selects ColTiles == 4. The N values are derived from the device's SM count so each case lands on
+// the intended grid-wave boundary on H200 and on smaller SM80+ devices.
+TEST(MatMulBlockQuantizedFp4WeightOpTest, GemvTensorCoreQwenTilingBoundariesFp16) {
+  if (!HasCudaEnvironment(800)) {
+    GTEST_SKIP() << "CUDA device is required for MatMulBlockQuantizedFp4Weight.";
+  }
+
+  int device = 0;
+  ASSERT_EQ(cudaGetDevice(&device), cudaSuccess);
+  cudaDeviceProp prop{};
+  ASSERT_EQ(cudaGetDeviceProperties(&prop, device), cudaSuccess);
+
+  struct Case {
+    int64_t n;
+    int64_t k;
+  };
+  const int64_t sm_count = prop.multiProcessorCount;
+  const Case cases[] = {
+      {64 * sm_count, 5120},  // 4 waves of single-column blocks, ordinary reduction
+      {64 * sm_count, 8192},  // same grid, long reduction retains KSplit 8
+      {512 * sm_count, 512},  // 8 waves of four-column blocks, wide-column configuration
+  };
+
+  constexpr int64_t m = 4;
+  for (const Case& shape : cases) {
+    const int64_t n = shape.n;
+    const int64_t k = shape.k;
+    const int64_t k_blocks = k / 16;
+    SCOPED_TRACE("N = " + std::to_string(n) + ", K = " + std::to_string(k));
+
+    static const uint8_t kWeightBytes[] = {0x22, 0x44, 0xAA, 0x11};
+    static const float kWeightValues[] = {1.0f, 2.0f, -1.0f, 0.5f};
+    std::vector<uint8_t> b(static_cast<size_t>(n * (k / 2)));
+    std::vector<uint8_t> weight_scale(static_cast<size_t>(n * k_blocks), 0x38);
+    for (int64_t col = 0; col < n; ++col) {
+      const int pattern = static_cast<int>(col & 3);
+      std::fill(b.begin() + static_cast<size_t>(col * (k / 2)),
+                b.begin() + static_cast<size_t>((col + 1) * (k / 2)), kWeightBytes[pattern]);
+    }
+
+    std::vector<float> a(static_cast<size_t>(m * k));
+    for (int64_t row = 0; row < m; ++row) {
+      std::fill(a.begin() + static_cast<size_t>(row * k),
+                a.begin() + static_cast<size_t>((row + 1) * k), static_cast<float>(row + 1));
+    }
+    std::vector<float> expected(static_cast<size_t>(m * n));
+    for (int64_t row = 0; row < m; ++row) {
+      for (int64_t col = 0; col < n; ++col) {
+        expected[static_cast<size_t>(row * n + col)] =
+            static_cast<float>(k) * static_cast<float>(row + 1) * kWeightValues[col & 3];
+      }
+    }
+
+    OpTester test("MatMulBlockQuantizedFp4Weight", 1, onnxruntime::kMSDomain);
+    test.AddAttribute<int64_t>("block_size", 16);
+    test.AddInput<MLFloat16>("A", {m, k}, FloatsToMLFloat16s(a));
+    test.AddInput<uint8_t>("B", {n, k / 2}, b);
+    test.AddInput<uint8_t>("weight_scale", {n, k_blocks}, weight_scale);
+    test.AddInput<float>("weight_scale_2", {1}, {1.0f});
+    test.AddOutput<MLFloat16>("Y", {m, n}, FloatsToMLFloat16s(expected));
     test.SetOutputTolerance(0.5f);
 
     std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;

--- a/onnxruntime/test/contrib_ops/matmul_block_scaled_fp4_test.cc
+++ b/onnxruntime/test/contrib_ops/matmul_block_scaled_fp4_test.cc
@@ -5,6 +5,7 @@
 // Needed for the CUDA_VERSION check below. MatMulBlockQuantizedFp4Weight relies on the NVFP4
 // conversion intrinsics that are only available in CUDA 12.8 and newer.
 #include <cuda.h>
+#include <cuda_runtime_api.h>
 #endif
 
 #include <algorithm>


### PR DESCRIPTION
## Summary

- Tune tensor-core NVFP4 GEMV dispatch to require multiple waves before selecting wide column tiles.
- Preserve a larger K split for long reductions while avoiding excessive K splitting on Qwen gate/up shapes.
- Add shape-scoped benchmark overrides, boundary tests, and CUDA contrib documentation.

## Motivation

On H200, the previous dispatch could select a configuration with too few blocks for Qwen MTP shapes such as N=17408, K=5120. The updated policy keeps KSplit=8 for the longer K=8192 reduction while using KSplit=2 for K=5120, and requires sufficient grid waves before selecting wide column tiles.

This PR is the tiling follow-up to #32128 and contains no duplicate vectorized NVFP4 dequantization changes. It can be rebased/stacked on #32128 after that PR merges.

## Validation

- CUDA 13.0 / SM90 build passed.
- `git diff --check` passed.
- Added Qwen boundary coverage for the selected tensor-core tilings.
- The local build configuration had provider unit tests disabled, so the new gtest was not executed locally.
