### PR TITLE
Fix memory leaks in copyStringTensorToArray JNI binding

### DIFF
--- a/java/src/main/native/OrtJniUtil.c
+++ b/java/src/main/native/OrtJniUtil.c
@@ -698,6 +698,11 @@ OrtErrorCode copyStringTensorToArray(JNIEnv *jniEnv, const OrtApi * api, OrtValu
           goto string_tensor_cleanup;
         }
         (*jniEnv)->SetObjectArrayElement(jniEnv,outputArray,safecast_size_t_to_jsize(i),tempString);
+        if ((*jniEnv)->ExceptionCheck(jniEnv)) {
+          code = ORT_FAIL;
+          (*jniEnv)->DeleteLocalRef(jniEnv, tempString);
+          goto string_tensor_cleanup;
+        }
         (*jniEnv)->DeleteLocalRef(jniEnv, tempString);
       }
     }

--- a/java/src/main/native/OrtJniUtil.c
+++ b/java/src/main/native/OrtJniUtil.c
@@ -644,25 +644,31 @@ OrtErrorCode copyStringTensorToArray(JNIEnv *jniEnv, const OrtApi * api, OrtValu
     throwOrtException(jniEnv, 1, "Not enough memory");
     return ORT_FAIL;
   }
+
+  // Initialize to NULL so the cleanup label can safely check before freeing
+  char * characterBuffer = NULL;
+  size_t * offsets = NULL;
+
   // Get the buffer size needed
   size_t totalStringLength = 0;
   OrtErrorCode code = checkOrtStatus(jniEnv, api, api->GetStringTensorDataLength(tensor, &totalStringLength));
   if (code != ORT_OK) {
-    return code;
+    goto string_tensor_cleanup;
   }
 
   // Create the character and offset buffers
-  char * characterBuffer = malloc(sizeof(char)*(totalStringLength+length));
+  characterBuffer = malloc(sizeof(char)*(totalStringLength+length));
   if (characterBuffer == NULL) {
     throwOrtException(jniEnv, 1, "Not enough memory");
-    return ORT_FAIL;
+    code = ORT_FAIL;
+    goto string_tensor_cleanup;
   }
   // length + 1 as we need to write out the final offset
-  size_t * offsets = allocarray(sizeof(size_t), length+1);
+  offsets = allocarray(sizeof(size_t), length+1);
   if (offsets == NULL) {
-    free((void*)characterBuffer);
     throwOrtException(jniEnv, 1, "Not enough memory");
-    return ORT_FAIL;
+    code = ORT_FAIL;
+    goto string_tensor_cleanup;
   }
 
   // Get a view on the String data
@@ -686,7 +692,13 @@ OrtErrorCode copyStringTensorToArray(JNIEnv *jniEnv, const OrtApi * api, OrtValu
         memcpy(tempBuffer,characterBuffer+offsets[i],curSize);
         tempBuffer[curSize-1] = '\0';
         jobject tempString = (*jniEnv)->NewStringUTF(jniEnv,tempBuffer);
+        if (tempString == NULL) {
+          // NewStringUTF failed; a pending exception is already set
+          code = ORT_FAIL;
+          goto string_tensor_cleanup;
+        }
         (*jniEnv)->SetObjectArrayElement(jniEnv,outputArray,safecast_size_t_to_jsize(i),tempString);
+        (*jniEnv)->DeleteLocalRef(jniEnv, tempString);
       }
     }
   }
@@ -695,8 +707,12 @@ string_tensor_cleanup:
   if (tempBuffer != NULL) {
     free((void*)tempBuffer);
   }
-  free((void*)offsets);
-  free((void*)characterBuffer);
+  if (offsets != NULL) {
+    free((void*)offsets);
+  }
+  if (characterBuffer != NULL) {
+    free((void*)characterBuffer);
+  }
   return code;
 }
 


### PR DESCRIPTION
### Description

Fix memory leaks and unbounded local reference growth in `copyStringTensorToArray()` in `java/src/main/native/OrtJniUtil.c`.

**Changes:**
1. Route three early-return paths through the existing `string_tensor_cleanup` label so `tempBuffer` is always freed on error.
2. Initialize `characterBuffer` and `offsets` to `NULL` with null checks in the cleanup block, so they are safe to free regardless of which allocation failed.
3. Check the return value of `NewStringUTF()` and bail out on failure instead of continuing with a pending exception.
4. Call `DeleteLocalRef()` on each `tempString` after storing it in the output array, preventing the local reference table from growing with the tensor element count.

### Motivation and Context

Fixes #31705

`tempBuffer` (16 bytes) is leaked whenever `GetStringTensorDataLength()` fails or either `characterBuffer`/`offsets` allocation fails, because those paths return directly instead of jumping to the cleanup label. The per-element `jstring` references created in the conversion loop are also never deleted, which can exhaust the JVM's local reference table when converting large string tensors.