### PR TITLE
Skip overridable initializer fusion

### DIFF
--- a/onnxruntime/core/optimizer/fuse_initializers_transformer.cc
+++ b/onnxruntime/core/optimizer/fuse_initializers_transformer.cc
@@ -57,8 +57,8 @@ static bool IsNodeValidForFusion(const Graph& graph,
                                  const Node& node,
                                  const onnxruntime::MLDataType tensor_type,
                                  const onnxruntime::MLDataType output_type) {
-  // Node must have initialized tensor
-  if (!(graph.IsInitializedTensor(node.InputDefs()[0]->Name()))) return false;
+  // Node input must be a constant initializer. Initializers that are also graph inputs can be overridden.
+  if (graph_utils::GetConstantInitializer(graph, node.InputDefs()[0]->Name()) == nullptr) return false;
 
   // Initialzed tensor must be of tensor_type
   if (!(DataTypeImpl::TypeFromProto(*(node.InputDefs()[0]->TypeAsProto())) == tensor_type)) return false;

--- a/onnxruntime/test/optimizer/fuse_initializers_transformer_test.cc
+++ b/onnxruntime/test/optimizer/fuse_initializers_transformer_test.cc
@@ -4,6 +4,7 @@
 #include <algorithm>  // needed for std::transform
 #include "gtest/gtest.h"
 #include "test/unittest_util/framework_test_utils.h"
+#include "test/unittest_util/graph_transform_test_builder.h"
 #include "test/test_environment.h"
 #include "test/util/include/default_providers.h"
 #include "test/util/include/asserts.h"
@@ -510,6 +511,37 @@ TEST(TransformerTest, FuseFp16InitializersWithGraphOutputs) {
   _graph_structure_at_initialized(session.GetGraph());
   ASSERT_STATUS_OK(session.Run(inputs, output_names, &outputs));
 }  // FuseFp16InitializersWithGraphOutputs
+
+TEST(TransformerTest, FuseInitializersSkipsOverridableInitializer) {
+  auto& logger = DefaultLoggingManager().DefaultLogger();
+  Model model("FuseInitializersSkipsOverridableInitializer", false, ModelMetaData(), PathString(),
+              IOnnxRuntimeOpSchemaRegistryList(), {{kOnnxDomain, 23}}, {}, logger);
+  Graph& graph = model.MainGraph();
+  ModelTestBuilder builder(graph);
+
+  NodeArg* initializer = builder.MakeInitializer<MLFloat16>({1}, {MLFloat16(1.0f)});
+  NodeArg* cast_output = builder.MakeIntermediate<float>({1});
+  builder.AddNode("Cast", {initializer}, {cast_output})
+      .AddAttribute("to", static_cast<int64_t>(ONNX_NAMESPACE::TensorProto_DataType_FLOAT));
+  NodeArg* output = builder.MakeOutput<float>({1});
+  builder.AddNode("Neg", {cast_output}, {output});
+
+  graph.SetInputs({initializer});
+  graph.SetOutputs({output});
+  ASSERT_STATUS_OK(graph.Resolve());
+  ASSERT_TRUE(graph.IsInitializedTensor(initializer->Name()));
+  ASSERT_EQ(nullptr, graph_utils::GetConstantInitializer(graph, initializer->Name()));
+
+  FuseInitializersTransformer transformer("TransformerTest.FusedInitializers",
+                                          DataTypeImpl::GetTensorType<MLFloat16>(),
+                                          DataTypeImpl::GetTensorType<float>());
+  bool modified = false;
+  ASSERT_STATUS_OK(transformer.Apply(graph, modified, logger));
+
+  EXPECT_FALSE(modified);
+  EXPECT_EQ(1, CountOpsInGraph(graph)["Cast"]);
+  EXPECT_EQ(1, CountOpsInGraph(graph)["Neg"]);
+}
 
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/optimizer/fuse_initializers_transformer_test.cc
+++ b/onnxruntime/test/optimizer/fuse_initializers_transformer_test.cc
@@ -520,10 +520,10 @@ TEST(TransformerTest, FuseInitializersSkipsOverridableInitializer) {
   ModelTestBuilder builder(graph);
 
   NodeArg* initializer = builder.MakeInitializer<MLFloat16>({1}, {MLFloat16(1.0f)});
-  NodeArg* cast_output = builder.MakeIntermediate<float>({1});
+  NodeArg* cast_output = builder.MakeIntermediate<float>(std::vector<int64_t>{1});
   builder.AddNode("Cast", {initializer}, {cast_output})
       .AddAttribute("to", static_cast<int64_t>(ONNX_NAMESPACE::TensorProto_DataType_FLOAT));
-  NodeArg* output = builder.MakeOutput<float>({1});
+  NodeArg* output = builder.MakeOutput<float>(std::vector<int64_t>{1});
   builder.AddNode("Neg", {cast_output}, {output});
 
   graph.SetInputs({initializer});


### PR DESCRIPTION
This pull request updates the logic for determining whether a node's input is a valid initializer for fusion and adds a new unit test to ensure that initializers which can be overridden (i.e., initializers that are also graph inputs) are properly skipped during fusion. The main changes are:

### Logic Update

* In `IsNodeValidForFusion`, the check for a valid initializer now uses `graph_utils::GetConstantInitializer`, ensuring that only constant initializers (not those that can be overridden by graph inputs) are considered valid for fusion.

### Testing Improvements

* Added a new test, `FuseInitializersSkipsOverridableInitializer`, to verify that the transformer skips fusion for initializers that are also graph inputs and can be overridden. This test ensures the fusion transformation does not incorrectly modify such initializers.
* Included the `graph_transform_test_builder.h` header to support the new test.