### PR TITLE
Disable the constant folding output-size limit by default

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
+++ b/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
@@ -131,8 +131,8 @@ static const char* const kOrtSessionOptionsDisableSpecifiedOptimizers = "optimiz
 //
 // Option values:
 // - A positive integer (as string): Maximum allowed output size in bytes per constant-folded node.
-//   Default is "1073741824" (1 GB).
-// - "0": Disable the size limit (not recommended for untrusted models).
+//   Recommended for untrusted models, e.g. "1073741824" (1 GB).
+// - "0": Disable the size limit. This is the default.
 static const char* const kOrtSessionOptionsConstantFoldingMaxOutputSizeInBytes =
     "optimization.constant_folding_max_output_size_in_bytes";
 

--- a/onnxruntime/core/optimizer/constant_folding.cc
+++ b/onnxruntime/core/optimizer/constant_folding.cc
@@ -144,9 +144,10 @@ static Status ConstantFoldIfNode(Graph& graph, Node& if_node, const logging::Log
   return status;
 }
 
-// Default maximum output size per constant-folded node: 1 GB.
-// This prevents malicious models from causing excessive memory allocation during optimization.
-static constexpr int64_t kDefaultConstantFoldingMaxOutputSizeInBytes = 1024 * 1024 * 1024;
+// Default maximum output size per constant-folded node: 0, i.e. no limit.
+// Set kOrtSessionOptionsConstantFoldingMaxOutputSizeInBytes to a positive value to prevent
+// malicious models from causing excessive memory allocation during optimization.
+static constexpr int64_t kDefaultConstantFoldingMaxOutputSizeInBytes = 0;
 
 static size_t GetElementSizeForConstantFolding(ONNX_NAMESPACE::TensorProto_DataType elem_type) {
   // Complex types are excluded: ORT's tensor type system (DataTypeImpl::TensorTypeFromONNXEnum)


### PR DESCRIPTION
The output-size guard added in #28055 skips any node whose output size cannot be estimated before execution. Ops that have no ONNX shape inference function, such as the GreaterOrEqual and LessOrEqual functions below opset 16, reach the guard with no inferred output shape, so since 1.27 they are never constant folded and the entire downstream constant chain stops folding with them. No positive cap value avoids this because the bail is inside the guard.

Default the cap to 0 so folding behaves as it did in 1.26, and make the mitigation opt-in through
optimization.constant_folding_max_output_size_in_bytes.

Fixes #32130




