### PR TITLE
Disable the constant folding output-size limit by default

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
+++ b/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
@@ -131,8 +131,8 @@ static const char* const kOrtSessionOptionsDisableSpecifiedOptimizers = "optimiz
 //
 // Option values:
 // - A positive integer (as string): Maximum allowed output size in bytes per constant-folded node.
-//   Default is "1073741824" (1 GB).
-// - "0": Disable the size limit (not recommended for untrusted models).
+//   Recommended for untrusted models, e.g. "1073741824" (1 GB).
+// - "0": Disable the size limit. This is the default.
 static const char* const kOrtSessionOptionsConstantFoldingMaxOutputSizeInBytes =
     "optimization.constant_folding_max_output_size_in_bytes";
 

--- a/onnxruntime/core/optimizer/constant_folding.cc
+++ b/onnxruntime/core/optimizer/constant_folding.cc
@@ -143,9 +143,10 @@ static Status ConstantFoldIfNode(Graph& graph, Node& if_node, const logging::Log
   return status;
 }
 
-// Default maximum output size per constant-folded node: 1 GB.
-// This prevents malicious models from causing excessive memory allocation during optimization.
-static constexpr int64_t kDefaultConstantFoldingMaxOutputSizeInBytes = 1024 * 1024 * 1024;
+// Default maximum output size per constant-folded node: 0, i.e. no limit.
+// Set kOrtSessionOptionsConstantFoldingMaxOutputSizeInBytes to a positive value to prevent
+// malicious models from causing excessive memory allocation during optimization.
+static constexpr int64_t kDefaultConstantFoldingMaxOutputSizeInBytes = 0;
 
 static size_t GetElementSizeForConstantFolding(ONNX_NAMESPACE::TensorProto_DataType elem_type) {
   const size_t element_size = utils::GetElementSizeOfTensor(elem_type);


### PR DESCRIPTION
Cherry-pick of the fix for #32130 onto `rel-1.27.0`. Supersedes #32150, which targeted `main`.

### Description

The output-size guard added in #28055 skips any node whose output size cannot be estimated before execution. `EstimateTensorSizeInBytes()` returns -1 when the output `NodeArg` has no shape, and `ApplyImpl()` treats -1 as "skip this node".

`GreaterOrEqual` and `LessOrEqual` are ONNX function ops with no type-and-shape inference function until opset 16, so at ai.onnx opset 12-15 their outputs reach the guard with no inferred shape and are never constant folded. No positive cap value avoids this, because the `estimated_size < 0` bail sits inside the `max_output_size > 0` guard; only the literal `"0"` works, which turns the mitigation off entirely. An unfolded comparison node also makes its consumers non-constant, so an entire downstream constant chain stops folding and shapes that used to become static stay symbolic.

### Motivation and Context

This is a silent de-optimization of any opset <= 15 model containing these ops, introduced in 1.27 and not present in 1.26. Reported in #32130 with a real-world impact: a quantized segmentation model at opset 15 went from 1146 to 1186 nodes and lost its static output shapes, which caused a downstream plugin EP to reject 28 Slice nodes and fall the whole model back to CPU.

This change defaults `kDefaultConstantFoldingMaxOutputSizeInBytes` to 0 so constant folding behaves as it did in 1.26, and makes the size cap opt-in through `optimization.constant_folding_max_output_size_in_bytes`. Users who want the hardening from #28055 can still set a positive value.

All five existing size-limit tests in `onnxruntime/test/optimizer/graph_transform_test.cc` set the config entry explicitly, so none of them depend on the previous 1 GB default.

Fixes #32130