### PR TITLE
[MLAS] Enable SBGemm fastmath path for Darwin on Arm64

### DIFF
--- a/cmake/onnxruntime_mlas.cmake
+++ b/cmake/onnxruntime_mlas.cmake
@@ -632,20 +632,30 @@ else()
         set_source_files_properties(${MLAS_SRC_DIR}/sqnbitgemm_kernel_neon_int8_i8mm.cpp
 				    PROPERTIES COMPILE_FLAGS " -march=armv8.2-a+i8mm ")
 
+        if ((NOT APPLE) OR (CMAKE_SYSTEM_NAME STREQUAL "Darwin"))
+          list(APPEND mlas_platform_srcs
+            ${MLAS_SRC_DIR}/aarch64/SbgemmKernelNeon.S
+            ${MLAS_SRC_DIR}/sbgemm_kernel_neon.cpp
+          )
+          set_source_files_properties(
+            ${MLAS_SRC_DIR}/aarch64/SbgemmKernelNeon.S
+            ${MLAS_SRC_DIR}/sbgemm_kernel_neon.cpp
+            PROPERTIES COMPILE_FLAGS " -march=armv8.2-a+bf16 "
+          )
+        endif()
+
         if (NOT APPLE)
           set(mlas_platform_srcs
             ${mlas_platform_srcs}
             ${MLAS_SRC_DIR}/aarch64/HalfGemmKernelNeon.S
             ${MLAS_SRC_DIR}/aarch64/QgemmS8S8KernelSmmla.S
             ${MLAS_SRC_DIR}/aarch64/QgemmU8X8KernelUmmla.S
-            ${MLAS_SRC_DIR}/aarch64/SbgemmKernelNeon.S
             ${MLAS_SRC_DIR}/activate_fp16.cpp
             ${MLAS_SRC_DIR}/dwconv.cpp
             ${MLAS_SRC_DIR}/halfgemm_kernel_neon.cpp
             ${MLAS_SRC_DIR}/pooling_fp16.cpp
             ${MLAS_SRC_DIR}/qgemm_kernel_smmla.cpp
             ${MLAS_SRC_DIR}/qgemm_kernel_ummla.cpp
-            ${MLAS_SRC_DIR}/sbgemm_kernel_neon.cpp
             ${MLAS_SRC_DIR}/sbconv_kernel_neon.cpp
             ${MLAS_SRC_DIR}/cast_kernel_neon.cpp
             ${MLAS_SRC_DIR}/hqnbitgemm_kernel_neon_fp16.cpp
@@ -669,11 +679,9 @@ else()
           set_source_files_properties(${MLAS_SRC_DIR}/aarch64/HalfGemmKernelNeon.S PROPERTIES COMPILE_FLAGS " -march=armv8.2-a+fp16 ")
           set_source_files_properties(${MLAS_SRC_DIR}/aarch64/QgemmS8S8KernelSmmla.S PROPERTIES COMPILE_FLAGS " -march=armv8.2-a+i8mm ")
           set_source_files_properties(${MLAS_SRC_DIR}/aarch64/QgemmU8X8KernelUmmla.S PROPERTIES COMPILE_FLAGS " -march=armv8.2-a+i8mm ")
-          set_source_files_properties(${MLAS_SRC_DIR}/aarch64/SbgemmKernelNeon.S PROPERTIES COMPILE_FLAGS " -march=armv8.2-a+bf16 ")
           set_source_files_properties(${MLAS_SRC_DIR}/activate_fp16.cpp PROPERTIES COMPILE_FLAGS " -march=armv8.2-a+fp16 ")
           set_source_files_properties(${MLAS_SRC_DIR}/dwconv.cpp PROPERTIES COMPILE_FLAGS " -march=armv8.2-a+fp16 ")
           set_source_files_properties(${MLAS_SRC_DIR}/pooling_fp16.cpp PROPERTIES COMPILE_FLAGS " -march=armv8.2-a+fp16 ")
-          set_source_files_properties(${MLAS_SRC_DIR}/sbgemm_kernel_neon.cpp PROPERTIES COMPILE_FLAGS " -march=armv8.2-a+bf16 ")
           set_source_files_properties(${MLAS_SRC_DIR}/sbconv_kernel_neon.cpp PROPERTIES COMPILE_FLAGS " -march=armv8.2-a+bf16 ")
           set_source_files_properties(${MLAS_SRC_DIR}/cast_kernel_neon.cpp PROPERTIES COMPILE_FLAGS " -march=armv8.2-a+fp16 ")
           set_source_files_properties(${MLAS_SRC_DIR}/hqnbitgemm_kernel_neon_fp16.cpp PROPERTIES COMPILE_FLAGS " -march=armv8.2-a+fp16 ")

--- a/onnxruntime/core/mlas/inc/mlas.h
+++ b/onnxruntime/core/mlas/inc/mlas.h
@@ -22,6 +22,10 @@ Abstract:
 #include <cstdint>
 #include <stdexcept>
 
+#if defined(__APPLE__)
+#include <TargetConditionals.h>
+#endif
+
 //
 // Define the calling convention for Windows targets.
 //
@@ -88,6 +92,16 @@ Abstract:
 
 #if defined(MLAS_TARGET_AMD64) || defined (MLAS_TARGET_POWER) || defined (MLAS_TARGET_ZVECTOR)
 #define MLAS_SUPPORTS_GEMM_DOUBLE
+#endif
+
+// Runtime BF16 and SME2 capabilities are checked separately before selecting
+// an accelerated SBGEMM path.
+#if defined(MLAS_TARGET_ARM64) && defined(__linux__)
+#define MLAS_SBGEMM_AVAILABLE
+#elif defined(__APPLE__)
+#if defined(MLAS_TARGET_ARM64) && TARGET_OS_OSX
+#define MLAS_SBGEMM_AVAILABLE
+#endif
 #endif
 
 #if (!defined(_MSC_VER)) || (_MSC_VER >= 1930)
@@ -2151,7 +2165,7 @@ MlasHalfGemmConvertPackB(
     void* PackedB
     );
 
-#if defined(__aarch64__) && defined(__linux__)
+#if defined(MLAS_SBGEMM_AVAILABLE)
 /**
  * @brief Whether current CPU supports Bfloat16(bf16) acceleration.
  */
@@ -2309,7 +2323,7 @@ MlasSBGemmConvertPackB(
     void* PackedB,
     const MLAS_BACKEND_KERNEL_SELECTOR_CONFIG* BackendKernelSelectorConfig
 );
-#endif
+#endif  // MLAS_SBGEMM_AVAILABLE
 
 /**
  * @brief Indirect Depthwise convolution for fp16

--- a/onnxruntime/core/mlas/lib/aarch64/SbgemmKernelNeon.S
+++ b/onnxruntime/core/mlas/lib/aarch64/SbgemmKernelNeon.S
@@ -21,7 +21,7 @@ Abstract:
         .text
 
 //
-// Stack frame layout for the sbgemm kernel. d8-d15, x19-x30 need save
+// Stack frame layout for the sbgemm kernel. d8-d15, x19-x30 need save. x18 may be reserved by the platform ABI.
 //
         .equ  .LMlasSbgemmKernel_backup_x19_x20,    0
         .equ  .LMlasSbgemmKernel_backup_x21_x22,    16
@@ -688,7 +688,7 @@ Abstract:
 .endif
 
 .if \Rows\() > 6
-        OutputRow\Columns\()Element \Mode\(),x18,x19,28,29,30,31,(\Rows\() == 7)
+        OutputRow\Columns\()Element \Mode\(),x24,x19,28,29,30,31,(\Rows\() == 7)
 .endif
 
         .endm
@@ -840,8 +840,8 @@ Return Value:
         add     x15,x14,x7,lsl #2           // compute matrix C plus 3 rows
         add     x16,x15,x7,lsl #2           // compute matrix C plus 4 rows
         add     x17,x16,x7,lsl #2           // compute matrix C plus 5 rows
-        add     x18,x17,x7,lsl #2           // compute matrix C plus 6 rows
-        add     x19,x18,x7,lsl #2           // compute matrix C plus 7 rows
+        add     x24,x17,x7,lsl #2           // compute matrix C plus 6 rows
+        add     x19,x24,x7,lsl #2           // compute matrix C plus 7 rows
 
         mov     x26,x0                       // save matrix A
 //

--- a/onnxruntime/core/mlas/lib/kleidiai/mlasi_kleidiai.h
+++ b/onnxruntime/core/mlas/lib/kleidiai/mlasi_kleidiai.h
@@ -254,7 +254,7 @@ MlasGemmBatch(
     MLAS_THREADPOOL* ThreadPool
     );
 
-#if defined(__aarch64__) && defined(__linux__)
+#if defined(MLAS_SBGEMM_AVAILABLE)
 size_t
 MLASCALL
 MlasSBGemmPackBSize(

--- a/onnxruntime/core/mlas/lib/kleidiai/sbgemm_kleidiai.cpp
+++ b/onnxruntime/core/mlas/lib/kleidiai/sbgemm_kleidiai.cpp
@@ -4,7 +4,9 @@
 // SPDX-License-Identifier: MIT
 //
 
-#if defined(__aarch64__) && defined(__linux__)
+#include "mlas.h"
+
+#if defined(MLAS_SBGEMM_AVAILABLE)
 
 #include <vector>
 #include <cstring>
@@ -13,8 +15,6 @@
 
 #include "kai/ukernels/matmul/pack/kai_rhs_pack_kxn_bf16p2vlx2b_f32_x32_sme.h"
 #include "kai/ukernels/matmul/pack/kai_lhs_pack_bf16p2vlx2_f32_sme.h"
-
-#include "mlas.h"
 
 #include "mlasi_kleidiai.h"
 #include "kai_ukernel_interface.h"

--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -451,7 +451,7 @@ size_t
 
 #else
 
-#if defined(__aarch64__) && defined(__linux__)
+#if defined(MLAS_SBGEMM_AVAILABLE)
 typedef size_t(MLASCALL MLAS_SBGEMM_FLOAT_KERNEL)(
     const float* A,
     const bfloat16_t* B,
@@ -1075,7 +1075,7 @@ typedef void(MLASCALL MLAS_QNBIT_GEMM_BATCH_OVERRIDE)(
     const MLAS_BACKEND_KERNEL_SELECTOR_CONFIG* BackendKernelSelectorConfig
 );
 
-#if defined(__aarch64__) && defined(__linux__)
+#if defined(MLAS_SBGEMM_AVAILABLE)
 typedef
 bool
 (MLASCALL MLAS_SBGEMM_BATCH_OVERRIDE)(
@@ -1278,7 +1278,7 @@ extern "C" {
 #else
     MLAS_GEMM_FLOAT_KERNEL MlasSgemmKernelZero;
     MLAS_GEMM_FLOAT_KERNEL MlasSgemmKernelAdd;
-#if defined(__aarch64__) && defined(__linux__)
+#if defined(MLAS_SBGEMM_AVAILABLE)
     MLAS_SBGEMM_FLOAT_KERNEL MlasSbgemmKernelZero;
     MLAS_SBGEMM_FLOAT_KERNEL MlasSbgemmKernelAdd;
 #endif
@@ -1523,7 +1523,7 @@ MlasReorderOutputNchwBlock16Avx512F(
 #define MLAS_QGEMM_THREAD_COMPLEXITY                65536
 #define MLAS_HGEMM_THREAD_COMPLEXITY                65536
 
-#if defined(__aarch64__) && defined(__linux__)
+#if defined(MLAS_SBGEMM_AVAILABLE)
 #define MLAS_SBGEMM_THREAD_COMPLEXITY (size_t(64) * size_t(1024))
 #endif
 
@@ -1788,7 +1788,7 @@ struct MLAS_PLATFORM {
     MLAS_CONV_PREPARE_FLOAT_OVERRIDE* MlasConvPrepareOverride = nullptr;
     MLAS_CONV_FLOAT_OVERRIDE* MlasConvOverride = nullptr;
     MLAS_CONV_SGEMM_ROUTE_OVERRIDE* MlasConvSGemmRouteOverride = nullptr;
-#if defined(__aarch64__) && defined(__linux__)
+#if defined(MLAS_SBGEMM_AVAILABLE)
     // SBGemm overrides
     MLAS_SBGEMM_BATCH_OVERRIDE* MlasSBGemmBatchOverride = nullptr;
     MLAS_SBGEMM_PACK_B_SIZE_OVERRIDE* MlasSBGemmPackBSizeOverride = nullptr;

--- a/onnxruntime/core/mlas/lib/platform.cpp
+++ b/onnxruntime/core/mlas/lib/platform.cpp
@@ -738,7 +738,7 @@ Return Value:
         this->MlasConvPrepareOverride = ArmKleidiAI::MlasConvPrepare;
         this->MlasConvOverride = ArmKleidiAI::MlasConv;
         this->MlasConvSGemmRouteOverride = ArmKleidiAI::MlasConvSGemmRoute;
-#if defined(__aarch64__) && defined(__linux__)
+#if defined(MLAS_SBGEMM_AVAILABLE)
         // Currently only an SME2 variant of SBGEMM exists
         if (ArmKleidiAI::UseSME2){
             this->MlasSBGemmBatchOverride = ArmKleidiAI::MlasSBGemmBatch;

--- a/onnxruntime/core/mlas/lib/sbgemm.h
+++ b/onnxruntime/core/mlas/lib/sbgemm.h
@@ -30,9 +30,11 @@ Abstract:
         MLAS_SBGEMM_STRIDES Strides{128, 128, 256};
 --*/
 
-#if defined(__aarch64__) && defined(__linux__)
-
 #pragma once
+
+#include "mlas.h"
+
+#if defined(MLAS_SBGEMM_AVAILABLE)
 
 #include <cassert>
 #include <cstdlib>
@@ -473,4 +475,4 @@ MlasSBGemmBatch(
         }
     );
 }
-#endif  // defined(__aarch64__) && defined(__linux__)
+#endif  // MLAS_SBGEMM_AVAILABLE

--- a/onnxruntime/core/mlas/lib/sbgemm_kernel_neon.cpp
+++ b/onnxruntime/core/mlas/lib/sbgemm_kernel_neon.cpp
@@ -15,7 +15,9 @@ Abstract:
 
 --*/
 
-#if defined(__aarch64__) && defined(__linux__)
+#include "mlas.h"
+
+#if defined(MLAS_SBGEMM_AVAILABLE)
 
 #include <algorithm>
 #include <cstring>
@@ -402,4 +404,4 @@ const MLAS_SBGEMM_DISPATCH MlasSBGemmDispatchNeon = {
     MLAS_SBGEMM_KERNEL_NEON::KernelMaxM,
     32  // kernel may read beyond buffer end by 32 bytes
 };
-#endif  // defined(__aarch64__) && defined(__linux__)
+#endif  // MLAS_SBGEMM_AVAILABLE

--- a/onnxruntime/core/providers/cpu/math/matmul.cc
+++ b/onnxruntime/core/providers/cpu/math/matmul.cc
@@ -210,7 +210,7 @@ Status MatMul<double>::Compute(OpKernelContext* ctx) const {
   return Status::OK();
 }
 
-#if defined(__aarch64__) && defined(__linux__)
+#if defined(MLAS_SBGEMM_AVAILABLE)
 bool GemmPackBBfloat16(AllocatorPtr& alloc,
                        const Tensor& tensor_b,
                        bool trans_a,
@@ -307,7 +307,7 @@ Status MatMul<float>::PrePack(const Tensor& tensor, int input_idx, /*out*/ Alloc
   // only pack Matrix B
   if (input_idx == 1) {
     size_t packed_b_size;
-#if defined(__aarch64__) && defined(__linux__)
+#if defined(MLAS_SBGEMM_AVAILABLE)
     TensorShape b_shape = tensor.Shape();
 
     if (CanPackBForFastMathModeSBGemm(b_shape)) {
@@ -501,7 +501,7 @@ Status MatMul<float>::Compute(OpKernelContext* ctx) const {
   // storage to avoid a per-Compute() heap allocation; larger batches use std::vector.
   // (Under DISABLE_ABSEIL, InlinedVector is std::vector, so this is a no-op.)
   constexpr size_t kInlineBatchCutoff = 2;
-#if defined(__aarch64__) && defined(__linux__)
+#if defined(MLAS_SBGEMM_AVAILABLE)
   const bool can_use_fastmath_sbgemm = CanUseFastMathModeSBGemm(N, K);
   if (packed_b_) {
     const bool packed_b_can_use_fastmath_sbgemm = CanPackBForFastMathModeSBGemm(b_shape);

--- a/onnxruntime/core/providers/cpu/math/matmul.h
+++ b/onnxruntime/core/providers/cpu/math/matmul.h
@@ -6,6 +6,7 @@
 #include <cmath>
 
 #include "core/framework/op_kernel.h"
+#include "core/mlas/inc/mlas.h"
 #include "core/providers/cpu/mlas_backend_kernel_selector_config_utils.h"
 #include "core/session/onnxruntime_session_options_config_keys.h"
 
@@ -65,7 +66,7 @@ class MatMul<float> final : public OpKernel {
     trans_batch_a_ = trans_batch_a_attr != 0;
     trans_batch_b_ = trans_batch_b_attr != 0;
 
-#if defined(__aarch64__) && defined(__linux__)
+#if defined(MLAS_SBGEMM_AVAILABLE)
     auto config_ops = info.GetConfigOptions().GetConfigEntry(kOrtSessionOptionsMlasGemmFastMathArm64Bfloat16);
     use_fastmath_mode_ = (config_ops == "1") && MlasBf16AccelerationSupported();
 #endif
@@ -97,7 +98,7 @@ class MatMul<float> final : public OpKernel {
 
   MLAS_BACKEND_KERNEL_SELECTOR_CONFIG mlas_backend_kernel_selector_config_;
 
-#if defined(__aarch64__) && defined(__linux__)
+#if defined(MLAS_SBGEMM_AVAILABLE)
   // fastmath mode state
   bool use_fastmath_mode_;
   // sbgemm kernel is implemented as 8x8 blocks with weights pre-packed to 4 blocks of 4x2
@@ -106,6 +107,7 @@ class MatMul<float> final : public OpKernel {
 
   bool CanUseFastMathModeSBGemm(size_t n, size_t k) const {
     return use_fastmath_mode_ &&
+           (alpha_attr_ == 1.0f) &&
            (trans_a_attr_ == 0) &&
            (trans_b_attr_ == 0) &&
            ((n * k) >= kFastMathModeKernelsizeThreshold);

--- a/onnxruntime/test/mlas/unittest/test_sbgemm.cpp
+++ b/onnxruntime/test/mlas/unittest/test_sbgemm.cpp
@@ -15,9 +15,9 @@ Abstract:
 
 --*/
 
-#if defined(__aarch64__) && defined(__linux__)
-
 #include "test_sbgemm.h"
+
+#if defined(MLAS_SBGEMM_AVAILABLE)
 
 //
 // Short Execute() test helper to register each test separately by all parameters.
@@ -188,4 +188,4 @@ static UNUSED_VARIABLE bool added_to_main = AddTestRegister([](bool is_short_exe
   }
   return SBGemmRegistLongExecute() > 0;
 });
-#endif  // defined(__aarch64__) && defined(__linux__)
+#endif  // MLAS_SBGEMM_AVAILABLE

--- a/onnxruntime/test/mlas/unittest/test_sbgemm.h
+++ b/onnxruntime/test/mlas/unittest/test_sbgemm.h
@@ -15,9 +15,11 @@ Abstract:
 
 --*/
 
-#if defined(__aarch64__) && defined(__linux__)
-
 #pragma once
+
+#include "core/mlas/inc/mlas.h"
+
+#if defined(MLAS_SBGEMM_AVAILABLE)
 
 #include "test_util.h"
 
@@ -366,4 +368,4 @@ class MlasSBGemmTest : public MlasTestBase {
   }
 };
 
-#endif  // defined(__aarch64__) && defined(__linux__)
+#endif  // MLAS_SBGEMM_AVAILABLE

--- a/onnxruntime/test/optimizer/qdq_transformer_fastmath_test.cc
+++ b/onnxruntime/test/optimizer/qdq_transformer_fastmath_test.cc
@@ -27,7 +27,7 @@
 
 #include "test/unittest_util/qdq_test_utils.h"
 
-#if defined(__aarch64__) && defined(__linux__) && !defined(DISABLE_CONTRIB_OPS)
+#if defined(MLAS_SBGEMM_AVAILABLE) && !defined(DISABLE_CONTRIB_OPS)
 
 struct QDQOpKeys {
   const char* quantize_linear;
@@ -729,4 +729,4 @@ TEST(QDQTransformerTests, MatMulIntegerToFloat_FastMath) {
 }  // namespace test
 }  // namespace onnxruntime
 
-#endif  // defined(__aarch64) && defined(__linux__) && !defined(DISABLE_CONTRIB_OPS)
+#endif  // MLAS_SBGEMM_AVAILABLE && !defined(DISABLE_CONTRIB_OPS)

--- a/onnxruntime/test/providers/cpu/math/matmul_fastmath_test.cc
+++ b/onnxruntime/test/providers/cpu/math/matmul_fastmath_test.cc
@@ -285,7 +285,7 @@ TEST(MathOpTest, MatMulFloatTypeInitializer_FastMath) {
   RunMatMulTest<float>(7, false, true, false);
 }
 
-TEST(MathOpTest, FusedMatMulScale_FastMath) {
+TEST(MathOpTest, FusedMatMulNonUnitAlpha_FastMathEnabled) {
   constexpr int64_t batch_size = 2;
   constexpr int64_t m = 32;
   constexpr int64_t n = 32;
@@ -305,6 +305,8 @@ TEST(MathOpTest, FusedMatMulScale_FastMath) {
   test.AddOutput<float>("Y", {1, batch_size, m, n},
                         std::vector<float>(batch_size * m * n, alpha * k));
 
+  // SBGEMM does not implement general alpha scaling. Enabling fastmath must
+  // preserve non-unit alpha by selecting the accurate FP32 path.
   SessionOptions so;
   ASSERT_STATUS_OK(so.config_options.AddConfigEntry(
       kOrtSessionOptionsMlasGemmFastMathArm64Bfloat16, "1"));

--- a/onnxruntime/test/providers/cpu/math/matmul_fastmath_test.cc
+++ b/onnxruntime/test/providers/cpu/math/matmul_fastmath_test.cc
@@ -2,6 +2,7 @@
 // Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // Licensed under the MIT License.
 
+#include "core/mlas/inc/mlas.h"
 #include "core/session/onnxruntime_session_options_config_keys.h"
 #include "gtest/gtest.h"
 #include "test/providers/provider_test_utils.h"
@@ -17,7 +18,7 @@
 #include <limits>
 #include <numeric>
 
-#if defined(__aarch64__) && defined(__linux__)
+#if defined(MLAS_SBGEMM_AVAILABLE)
 
 namespace onnxruntime {
 namespace test {
@@ -284,6 +285,34 @@ TEST(MathOpTest, MatMulFloatTypeInitializer_FastMath) {
   RunMatMulTest<float>(7, false, true, false);
 }
 
+TEST(MathOpTest, FusedMatMulScale_FastMath) {
+  constexpr int64_t batch_size = 2;
+  constexpr int64_t m = 32;
+  constexpr int64_t n = 32;
+  constexpr int64_t k = 64;
+  constexpr float alpha = 0.125f;
+
+  OpTester test("FusedMatMul", 1, kMSDomain);
+  test.AddInput<float>("A", {1, batch_size, m, k},
+                       std::vector<float>(batch_size * m * k, 1.0f));
+  test.AddInput<float>("B", {1, batch_size, k, n},
+                       std::vector<float>(batch_size * k * n, 1.0f));
+  test.AddAttribute("transA", static_cast<int64_t>(0));
+  test.AddAttribute("transB", static_cast<int64_t>(0));
+  test.AddAttribute("transBatchA", static_cast<int64_t>(0));
+  test.AddAttribute("transBatchB", static_cast<int64_t>(0));
+  test.AddAttribute("alpha", alpha);
+  test.AddOutput<float>("Y", {1, batch_size, m, n},
+                        std::vector<float>(batch_size * m * n, alpha * k));
+
+  SessionOptions so;
+  ASSERT_STATUS_OK(so.config_options.AddConfigEntry(
+      kOrtSessionOptionsMlasGemmFastMathArm64Bfloat16, "1"));
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(DefaultCpuExecutionProvider());
+  test.Config(so).ConfigEps(std::move(execution_providers)).RunWithConfig();
+}
+
 TEST(MathOpTest, MatMulInt32Type_FastMath) {
   RunMatMulTest<int32_t>(9);
 }
@@ -401,4 +430,4 @@ TEST(MathOpTest, MatMulUint64Type_DisableFastMath) {
 
 }  // namespace test
 }  // namespace onnxruntime
-#endif  // defined(__aarch64__) && defined(__linux__)
+#endif  // MLAS_SBGEMM_AVAILABLE

--- a/onnxruntime/test/util/compare_ortvalue.cc
+++ b/onnxruntime/test/util/compare_ortvalue.cc
@@ -34,6 +34,7 @@
 #include "core/framework/utils.h"
 #include "core/framework/TensorSeq.h"
 #include "core/graph/onnx_protobuf.h"
+#include "core/mlas/inc/mlas.h"
 #include <core/session/onnxruntime_cxx_api.h>
 #include "core/util/math.h"
 
@@ -67,7 +68,7 @@ const char* ElementTypeToString(MLDataType type) {
   return DataTypeImpl::ToString(type);
 }
 
-#if defined(__aarch64__) && defined(__linux__)
+#if defined(MLAS_SBGEMM_AVAILABLE)
 template <typename T>
 std::pair<COMPARE_RESULT, std::string> CheckCosineSimilarity(const Tensor& outvalue, const Tensor& expected_value) {
   const size_t tensor_size = static_cast<size_t>(expected_value.Shape().Size());
@@ -336,7 +337,7 @@ std::pair<COMPARE_RESULT, std::string> CompareTwoTensors(const Tensor& outvalue,
     return std::make_pair(COMPARE_RESULT::SHAPE_MISMATCH, oss.str());
   }
 
-#if defined(__aarch64__) && defined(__linux__)
+#if defined(MLAS_SBGEMM_AVAILABLE)
   if (isnan(per_sample_tolerance) || isnan(per_sample_tolerance)) {
     if (outvalue.IsDataType<float>()) {
       return CheckCosineSimilarity<float>(outvalue, expected_tensor);


### PR DESCRIPTION
### Description

This PR extends the SBGemm BF16 fastmath path to native Arm64 Darwin targets while preserving existing Arm64 Linux support. Platform availability is represented by the new `MLAS_SBGEMM_AVAILABLE` compile-time capability macro.

The relevant guards now use `MLAS_SBGEMM_AVAILABLE` instead of Linux-specific checks. Regression coverage has also been updated to exercise the newly available path and verify existing behavior.

Additionally, the SBGemm fastmath eligibility check now requires `alpha` to equal 1. Non-unit `alpha` values remain valid, but are routed through the accurate FP32 path as SBGemm doesn't implement general `alpha` scaling. Regression coverage verifies this behavior.

The generic SBGemm kernel also replaces its use of `x18` with `x24`, a register already preserved by the kernel, as the `x18` register may be reserved by platform ABIs. The other AArch64 MLAS assembly sources included in Darwin builds were checked for `x18`/`w18` register operands and none were found.

The changes were validated on a Mac Mini with M4 Pro, native Linux Arm64 and Android Arm64 with Arm® KleidiAI™ enabled and disabled. This covers the newly enabled path, the pre-existing generic implementation and the Arm® KleidiAI™ dispatch and fallback paths.

### Motivation and Context

The Arm64 SBGemm implementation was guarded by Linux-specific checks even though Darwin on Arm64 can also build and use the implementation when BF16 support is available. Expressing availability through a capability macro enables the path on specific targets without broadening it to unverified platforms.