### PR TITLE
Fix constant folding for ops with no pre-execution size estimate

### DIFF
--- a/onnxruntime/core/optimizer/constant_folding.cc
+++ b/onnxruntime/core/optimizer/constant_folding.cc
@@ -504,12 +504,12 @@ Status ConstantFolding::ApplyImpl(Graph& graph, bool& modified, int graph_level,
                                 << " bytes) exceeds the limit (" << max_output_size << " bytes).";
           continue;
         }
-        if (estimated_size < 0) {
-          LOGS(logger, INFO) << "Skipping constant folding for " << node->OpType()
-                             << " node '" << node->Name()
-                             << "' because output size could not be estimated before execution.";
-          continue;
-        }
+        // A negative estimate means the output size could not be determined
+        // ahead of time (e.g. an op with no type-and-shape inference function,
+        // such as GreaterOrEqual/LessOrEqual below opset 16). Do not skip these
+        // nodes here: fold them and let the post-execution actual-size check
+        // below bound the result, so small foldable nodes are not dropped while
+        // the output-size limit is still enforced.
       }
 
 #if !defined(DISABLE_SPARSE_TENSORS)

--- a/onnxruntime/test/optimizer/graph_transform_test.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test.cc
@@ -1939,6 +1939,42 @@ TEST_F(GraphTransformationTests, ConstantFoldingSubByteOutputSizeIsPacked) {
   }
 }
 
+// #32130: an op with no type-and-shape inference function reports an unknown
+// (negative) pre-execution output-size estimate. GreaterOrEqual/LessOrEqual
+// have no such function below opset 16. With the output-size limit enabled the
+// node must still be folded -- bounded by the post-execution actual-size check
+// -- rather than skipped just because the size could not be estimated upfront.
+TEST_F(GraphTransformationTests, ConstantFoldingUnknownPreEstimatedSizeIsFolded) {
+  auto build_model = [&](ModelTestBuilder& builder) {
+    auto* a = builder.MakeInitializer<int64_t>({3}, {1, 2, 3});
+    auto* b = builder.MakeInitializer<int64_t>({3}, {2, 2, 2});
+    auto* output_arg = builder.MakeOutput();
+    builder.AddNode("GreaterOrEqual", {a, b}, {output_arg});
+  };
+
+  auto pre_graph_checker = [](Graph& graph) -> Status {
+    TEST_RETURN_IF_NOT(CountOpsInGraph(graph)["GreaterOrEqual"] == 1);
+    return Status::OK();
+  };
+
+  auto post_graph_checker = [](Graph& graph) -> Status {
+    // 3-byte bool output is well within the limit, so folding must proceed even
+    // though GreaterOrEqual has no shape inference function at opset 15.
+    TEST_RETURN_IF_NOT(CountOpsInGraph(graph)["GreaterOrEqual"] == 0);
+    return Status::OK();
+  };
+
+  std::unique_ptr<CPUExecutionProvider> e = std::make_unique<CPUExecutionProvider>(CPUExecutionProviderInfo());
+  ConfigOptions config_options;
+  ASSERT_STATUS_OK(config_options.AddConfigEntry(
+      kOrtSessionOptionsConstantFoldingMaxOutputSizeInBytes, "1048576"));
+
+  ASSERT_STATUS_OK(TestGraphTransformer(build_model, 15, *logger_,
+                                        std::make_unique<ConstantFolding>(*e.get(), false, config_options),
+                                        TransformerLevel::Level1, 1,
+                                        pre_graph_checker, post_graph_checker));
+}
+
 // Test that small constant folding still works with the size limit.
 TEST_F(GraphTransformationTests, ConstantFoldingSmallOutputAllowed) {
   // Build a model with a small Expand: scalar -> [4, 4] = 16 * 4 = 64 bytes.


### PR DESCRIPTION
Fixes #32130.

`GreaterOrEqual`/`LessOrEqual` have no type-and-shape inference function below opset 16, so the #28055 output-size guard sees an unknown (`-1`) pre-execution estimate and skips folding them — even for tiny (3-byte) outputs — and the miss cascades to downstream consumers whose shapes then stay symbolic.

This drops the pre-execution `-1` skip. Those nodes now fold and are bounded by the **post-execution actual-size check that already exists for exactly this case** (its comment: "catches cases where pre-execution shape inference couldn't determine the output size"), so the #28055 hardening stays enforced — unlike disabling the size limit by default.

Verified locally (built with the change): an opset-15 `GreaterOrEqual` over constant inputs now folds (`nodes -> []`), matching opset 16; on stock 1.27 it stays a live node. Added a regression test `ConstantFoldingUnknownPreEstimatedSizeIsFolded`.

This is a narrower alternative to #32151 (same bug) that keeps the limit on by default — happy to defer to whichever approach the maintainers prefer.