### PR TITLE
Validate empty reduction axes

### DIFF
--- a/onnxruntime/core/providers/cpu/reduction/reduction_ops.cc
+++ b/onnxruntime/core/providers/cpu/reduction/reduction_ops.cc
@@ -885,9 +885,12 @@ bool check_and_reduce_empty_set_input(OpKernelContext* ctx, const gsl::span<cons
     ORT_ENFORCE(axes.empty(), "Axes input and attribute should not both be present for reduction.");
     // second input holds the axes.
     const Tensor* axes_tensor = ctx->Input<Tensor>(1);
-    auto nDims = static_cast<size_t>(axes_tensor->Shape()[0]);
-    const auto* data = axes_tensor->Data<int64_t>();
-    input_axes.insert(input_axes.begin(), data, data + nDims);
+    if (axes_tensor != nullptr) {
+      ORT_ENFORCE(axes_tensor->Shape().NumDimensions() == 1,
+                  "An axes tensor must be a vector tensor.");
+      const auto axes_data = axes_tensor->DataAsSpan<int64_t>();
+      input_axes.assign(axes_data.begin(), axes_data.end());
+    }
   } else {
     input_axes.resize(axes.size());
     std::copy(axes.begin(), axes.end(), input_axes.begin());
@@ -925,7 +928,9 @@ inline void ApplyNoopEmptyAxesElementwise(OpKernelContext* ctx) {
   Tensor* Y = ctx->Output(0, shape);
 
   if constexpr (!ReduceAggTraits<AGG>::kHasPreOp && !ReduceAggTraits<AGG>::kHasPostOp) {
-    std::memcpy(Y->MutableDataRaw(), X->DataRaw(), X->SizeInBytes());
+    if (X->SizeInBytes() > 0) {
+      std::memcpy(Y->MutableDataRaw(), X->DataRaw(), X->SizeInBytes());
+    }
 
   } else {
     using Tin = typename AGG::input_type;
@@ -968,14 +973,14 @@ template <typename AGG>
 void CommonReduce1Loop(OpKernelContext* ctx,
                        const gsl::span<const int64_t>& axes_, int64_t keepdims_,
                        bool noop_with_empty_axes) {
-  if (check_and_reduce_empty_set_input<AGG>(ctx, axes_, keepdims_ != 0)) {
-    return;
-  }
-
   TensorShapeVector tmp_axes;
   auto effective_axes = GetEffectiveAxes(ctx, axes_, tmp_axes);
   if (effective_axes.empty() && noop_with_empty_axes) {
     ApplyNoopEmptyAxesElementwise<AGG>(ctx);
+    return;
+  }
+
+  if (check_and_reduce_empty_set_input<AGG>(ctx, axes_, keepdims_ != 0)) {
     return;
   }
 
@@ -1013,14 +1018,14 @@ template <typename AGG>
 void CommonReduce2Loops(OpKernelContext* ctx,
                         const gsl::span<const int64_t>& axes_, int64_t keepdims_,
                         bool noop_with_empty_axes) {
-  if (check_and_reduce_empty_set_input<AGG>(ctx, axes_, keepdims_ != 0)) {
-    return;
-  }
-
   TensorShapeVector tmp_axes;
   auto effective_axes = GetEffectiveAxes(ctx, axes_, tmp_axes);
   if (effective_axes.empty() && noop_with_empty_axes) {
     ApplyNoopEmptyAxesElementwise<AGG>(ctx);
+    return;
+  }
+
+  if (check_and_reduce_empty_set_input<AGG>(ctx, axes_, keepdims_ != 0)) {
     return;
   }
 

--- a/onnxruntime/test/providers/cpu/reduction/reduction_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/reduction/reduction_ops_test.cc
@@ -6353,6 +6353,55 @@ void test_empty_set(const std::string& op, int opset, bool axes_as_input, float 
       });
 }
 
+TEST(ReductionOpTest, EmptySetMissingOptionalAxesReducesAllDimensions) {
+  OpTester test("ReduceSum", 20);
+  test.AddInput<float>("data", {2, 0, 4}, {});
+  test.AddOptionalInputEdge<int64_t>();
+  test.AddOutput<float>("reduced", {1, 1, 1}, {0.0f});
+  test.ConfigEp(DefaultCpuExecutionProvider()).RunWithConfig();
+}
+
+TEST(ReductionOpTest, EmptySetAxesMustBeVector) {
+  const std::vector<std::pair<std::vector<int64_t>, std::vector<int64_t>>> axes_cases{
+      {{}, {1}},
+      {{2, 0}, {}},
+  };
+  for (const std::string& op : {"ReduceSum", "ReduceLogSumExp"}) {
+    for (const auto& [axes_shape, axes_data] : axes_cases) {
+      OpTester test(op, 20);
+      test.AddInput<float>("data", {2, 0, 4}, {});
+      test.AddInput<int64_t>("axes", axes_shape, axes_data);
+      test.AddOutput<float>("reduced", {1, 1, 1}, {0.0f});
+      test.Config(OpTester::ExpectResult::kExpectFailure, "An axes tensor must be a vector tensor.")
+          .ConfigEp(DefaultCpuExecutionProvider())
+          .RunWithConfig();
+    }
+  }
+}
+
+void TestEmptySetNoopWithEmptyAxes(const std::string& op, bool omit_axes) {
+  OpTester test(op, 20);
+  test.AddInput<float>("data", {2, 0, 4}, {});
+  if (omit_axes) {
+    test.AddOptionalInputEdge<int64_t>();
+  } else {
+    test.AddInput<int64_t>("axes", {0}, {}, true);
+  }
+  test.AddAttribute<int64_t>("noop_with_empty_axes", 1);
+  test.AddOutput<float>("reduced", {2, 0, 4}, {});
+  test.ConfigEp(DefaultCpuExecutionProvider()).RunWithConfig();
+}
+
+TEST(ReductionOpTest, EmptySetNoopWithMissingAxes) {
+  TestEmptySetNoopWithEmptyAxes("ReduceSum", true);
+  TestEmptySetNoopWithEmptyAxes("ReduceLogSumExp", true);
+}
+
+TEST(ReductionOpTest, EmptySetNoopWithEmptyAxes) {
+  TestEmptySetNoopWithEmptyAxes("ReduceSum", false);
+  TestEmptySetNoopWithEmptyAxes("ReduceLogSumExp", false);
+}
+
 TEST(ReductionOpTest, empty_set_ReduceL1) {
   test_empty_set("ReduceL1", 20, true, 0);
 }

--- a/onnxruntime/test/providers/cpu/reduction/reduction_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/reduction/reduction_ops_test.cc
@@ -6366,7 +6366,7 @@ TEST(ReductionOpTest, EmptySetAxesMustBeVector) {
       {{}, {1}},
       {{2, 0}, {}},
   };
-  for (const std::string& op : {"ReduceSum", "ReduceLogSumExp"}) {
+  for (const char* const op : {"ReduceSum", "ReduceLogSumExp"}) {
     for (const auto& [axes_shape, axes_data] : axes_cases) {
       OpTester test(op, 20);
       test.AddInput<float>("data", {2, 0, 4}, {});


### PR DESCRIPTION
This pull request improves the handling and validation of empty set reductions in the ONNX Runtime CPU reduction operators. It enforces stricter checks for the axes input, prevents unnecessary memory operations, and adds comprehensive tests to verify correct behavior for various edge cases.

**Validation and Error Handling Improvements:**
- Enforces that the `axes` tensor input must be a 1D vector and only processes it if it is present, improving robustness and error messages for invalid input shapes.
- Adds a check to ensure that memory copying only occurs when the input tensor is non-empty, avoiding redundant operations.

**Logic and Flow Adjustments:**
- Refactors the order of reduction logic to first handle empty axes cases before checking for empty set input, ensuring correct execution flow and output. [[1]](diffhunk://#diff-61c3aeab1bffa9fc6cac3ace83df3a778d14c8f8d02a53ab46e5b776e567cdd4L971-R986) [[2]](diffhunk://#diff-61c3aeab1bffa9fc6cac3ace83df3a778d14c8f8d02a53ab46e5b776e567cdd4L1016-R1031)

**Testing Enhancements:**
- Adds new tests to verify:
  - Reduction when the optional `axes` input is missing (should reduce all dimensions).
  - Validation that the `axes` tensor must be a vector, with expected error messages for invalid cases.
  - Correct behavior for the `noop_with_empty_axes` attribute, both when axes are omitted and when an empty axes tensor is provided.