### PR TITLE
Copy outer-scope initializers used only from a subgraph when compiling

### DIFF
--- a/onnxruntime/core/framework/graph_partitioner.cc
+++ b/onnxruntime/core/framework/graph_partitioner.cc
@@ -1150,9 +1150,23 @@ static Status CreateEpContextModel(const ExecutionProviders& execution_providers
     }
   }
 
+  // A name referenced only from within a node's subgraph (an implicit input)
+  // does not get a NodeArg created by ep_graph.AddNode() above, which only adds
+  // NodeArgs for a node's own inputs and outputs. Collect those names so that an
+  // outer-scope initializer consumed only from a subgraph is still copied below;
+  // otherwise ep_graph.Resolve() fails on the dangling reference (see #32131).
+  InlinedHashSet<std::string_view> implicit_input_names;
+  for (const auto& node : graph.Nodes()) {
+    for (const auto* implicit_input : node.ImplicitInputDefs()) {
+      if (implicit_input != nullptr && implicit_input->Exists()) {
+        implicit_input_names.insert(implicit_input->Name());
+      }
+    }
+  }
+
   // handle initializers
   for (const auto& [name, _] : graph.GetAllInitializedTensors()) {
-    if (ep_graph.GetNodeArg(name) != nullptr) {
+    if (ep_graph.GetNodeArg(name) != nullptr || implicit_input_names.count(name) != 0) {
       graph_utils::MakeInitializerCopyIfNotExist(graph, ep_graph, name);
     }
   }

--- a/onnxruntime/test/python/onnxruntime_test_python_compile_api.py
+++ b/onnxruntime/test/python/onnxruntime_test_python_compile_api.py
@@ -8,6 +8,7 @@ import sys
 import unittest
 from collections.abc import Sequence
 
+import numpy as np
 import onnx
 from autoep_helper import AutoEpTestCase
 from helper import get_name, get_shared_library_filename_for_platform
@@ -264,6 +265,62 @@ class TestCompileApi(AutoEpTestCase):
         model_compiler = onnxrt.ModelCompiler(
             session_options,
             input_model_bytes,
+            embed_compiled_data_into_model=True,
+            external_initializers_file_path=None,
+        )
+        output_model_bytes = model_compiler.compile_to_bytes()
+        self.assertTrue(isinstance(output_model_bytes, bytes))
+        self.assertGreater(len(output_model_bytes), 0)
+
+    def test_compile_model_with_outer_scope_initializer_used_only_in_subgraph(self):
+        """
+        A subgraph (e.g. an If body) may read an initializer of the enclosing graph
+        that no node of the enclosing graph reads itself. Such an initializer must
+        still be copied into the EPContext model; otherwise compilation fails on a
+        dangling outer-scope reference even though the model runs fine in a normal
+        session (see #32131).
+        """
+        provider = None
+        provider_options = dict()
+        if "QNNExecutionProvider" in available_providers:
+            provider = "QNNExecutionProvider"
+            provider_options["backend_type"] = "htp"
+
+        # `axes` and `data` are outer-graph initializers consumed only from inside
+        # the If subgraphs (implicit inputs); `cond` selects the branch.
+        axes = onnx.numpy_helper.from_array(np.array([0], np.int64), "axes")
+        data = onnx.numpy_helper.from_array(np.array([10.0, 20.0, 30.0, 40.0], np.float32), "data")
+        cond = onnx.numpy_helper.from_array(np.array(True), "cond")
+        then_body = onnx.helper.make_graph(
+            [onnx.helper.make_node("Unsqueeze", ["data", "axes"], ["y_then"])],
+            "then_body",
+            [],
+            [onnx.helper.make_tensor_value_info("y_then", onnx.TensorProto.FLOAT, [1, 4])],
+        )
+        else_body = onnx.helper.make_graph(
+            [onnx.helper.make_node("Unsqueeze", ["data", "axes"], ["y_else"])],
+            "else_body",
+            [],
+            [onnx.helper.make_tensor_value_info("y_else", onnx.TensorProto.FLOAT, [1, 4])],
+        )
+        graph = onnx.helper.make_graph(
+            [onnx.helper.make_node("If", ["cond"], ["Y"], then_branch=then_body, else_branch=else_body)],
+            "main",
+            [],
+            [onnx.helper.make_tensor_value_info("Y", onnx.TensorProto.FLOAT, [1, 4])],
+            [axes, data, cond],
+        )
+        model = onnx.helper.make_model(graph, opset_imports=[onnx.helper.make_opsetid("", 21)])
+        model.ir_version = 10
+        onnx.checker.check_model(model, full_check=True)
+
+        session_options = onnxrt.SessionOptions()
+        if provider:
+            session_options.add_provider(provider, provider_options)
+
+        model_compiler = onnxrt.ModelCompiler(
+            session_options,
+            model.SerializeToString(),
             embed_compiled_data_into_model=True,
             external_initializers_file_path=None,
         )


### PR DESCRIPTION
Fixes #32131.

`CompileModel` / `OrtCompileApi` fails on any model where a subgraph (`If`/`Loop`/`Scan` body) reads an initializer of an enclosing graph that no node of the enclosing graph reads itself — which the ONNX IR spec allows, and which `InferenceSession` and `optimized_model_filepath` handle fine.

`CreateEpContextModel` (`graph_partitioner.cc`) copies an initializer into the EPContext graph only when a `NodeArg` of that name already exists. `ep_graph.AddNode()` creates `NodeArg`s for a node's own inputs/outputs but not for names its subgraphs consume from outer scope (implicit inputs), so a subgraph-only initializer is skipped and the following `ep_graph.Resolve()` fails on the dangling reference.

Fix: also copy initializers named by a node's `ImplicitInputDefs()`. `MakeInitializerCopyIfNotExist` creates the `NodeArg` for the copied initializer, so the outer-scope reference resolves.

Verified locally (built with the change): a minimal `If` model whose branches read outer-scope `axes`/`data` no outer node reads now compiles (`ModelCompiler.compile_to_bytes` succeeds) where it previously raised `INVALID_GRAPH`. Added a regression test `test_compile_model_with_outer_scope_initializer_used_only_in_subgraph` to `onnxruntime_test_python_compile_api.py`.