### PR TITLE
Validate Conv bias size

### DIFF
--- a/onnxruntime/core/providers/cpu/nn/conv.cc
+++ b/onnxruntime/core/providers/cpu/nn/conv.cc
@@ -72,6 +72,9 @@ Status Conv<T>::Compute(OpKernelContext* context) const {
   const int64_t M = W->Shape()[0];
   ORT_RETURN_IF_ERROR(conv_attrs_.ValidateInputShape(X, W));
 
+  ORT_RETURN_IF_NOT(B == nullptr || (B->Shape().NumDimensions() == 1 && B->Shape().Size() == M),
+                    "Conv : bias must be a 1D tensor of size output_channels (", M, ")");
+
   TensorShapeVector kernel_shape;
   ORT_RETURN_IF_ERROR(conv_attrs_.ComputeKernelShape(W->Shape(), kernel_shape));
 
@@ -254,6 +257,9 @@ Status Conv<float>::Compute(OpKernelContext* context) const {
   // If channels_last_ we should get the back dim for channels instead of [1]
   const int64_t C = channels_last_ ? X->Shape().GetDims().back() : X->Shape()[1];
   const int64_t M = W->Shape()[0];
+
+  ORT_RETURN_IF_NOT(B == nullptr || (B->Shape().NumDimensions() == 1 && B->Shape().Size() == M),
+                    "Conv : bias must be a 1D tensor of size output_channels (", M, ")");
 
   TensorShapeVector kernel_shape;
   ORT_RETURN_IF_ERROR(conv_attrs_.ComputeKernelShape(W->Shape(), kernel_shape));

--- a/onnxruntime/test/providers/cpu/nn/conv_op_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/conv_op_test.cc
@@ -1671,5 +1671,17 @@ TEST(ConvTest, Conv2D_ZeroDilation_Dml) {
       .RunWithConfig();
 }
 
+TEST(ConvTest, Conv2D_InvalidBiasSize) {
+  OpTester test("Conv", 22);
+  test.AddInput<float>("X", {1, 1, 1, 1}, {1.0f});
+  test.AddInput<float>("W", {4, 1, 1, 1}, std::vector<float>(4, 0.0f));
+  test.AddInput<float>("B", {1}, {0.0f});
+  test.AddOutput<float>("Y", {1, 4, 1, 1}, std::vector<float>(4, 0.0f));
+  test.ConfigEp(DefaultCpuExecutionProvider())
+      .Config(OpTester::ExpectResult::kExpectFailure,
+              "bias must be a 1D tensor of size output_channels")
+      .RunWithConfig();
+}
+
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/cpu/nn/conv_op_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/conv_op_test.cc
@@ -1683,5 +1683,18 @@ TEST(ConvTest, Conv2D_InvalidBiasSize) {
       .RunWithConfig();
 }
 
+TEST(ConvTest, Conv2D_InvalidBiasRank) {
+  OpTester test("Conv", 22);
+  test.AddShapeToTensorData(false);
+  test.AddInput<float>("X", {1, 1, 1, 1}, {1.0f});
+  test.AddInput<float>("W", {4, 1, 1, 1}, std::vector<float>(4, 0.0f));
+  test.AddInput<float>("B", {1, 4}, std::vector<float>(4, 0.0f));
+  test.AddOutput<float>("Y", {1, 4, 1, 1}, std::vector<float>(4, 0.0f));
+  test.ConfigEp(DefaultCpuExecutionProvider())
+      .Config(OpTester::ExpectResult::kExpectFailure,
+              "bias must be a 1D tensor of size output_channels")
+      .RunWithConfig();
+}
+
 }  // namespace test
 }  // namespace onnxruntime


### PR DESCRIPTION
This pull request strengthens input validation for the Conv operator by adding explicit checks for the bias tensor shape and size, and adds a new unit test to verify this behavior. The main changes are as follows:

**Input validation improvements:**

* Added a check in `Conv<T>::Compute` (and the float specialization) to ensure that the bias tensor `B`, if provided, is a 1D tensor whose size matches the number of output channels (`M`). If not, an informative error message is returned. [[1]](diffhunk://#diff-17bd0d956bdc88650a3b0fc11efe67ee921f0e2f0d5e5ab3e73925cd4bb510d7R75-R77) [[2]](diffhunk://#diff-17bd0d956bdc88650a3b0fc11efe67ee921f0e2f0d5e5ab3e73925cd4bb510d7R261-R263)

**Testing enhancements:**

* Introduced a new test case `Conv2D_InvalidBiasSize` in `conv_op_test.cc` to verify that the Conv operator correctly fails when the bias tensor does not have the expected size, ensuring the new validation logic works as intended.