### PR TITLE
Reject scalar Normalizer inputs

### DIFF
--- a/onnxruntime/core/providers/cpu/ml/normalizer.cc
+++ b/onnxruntime/core/providers/cpu/ml/normalizer.cc
@@ -128,6 +128,11 @@ Status Normalizer::Normalize(OpKernelContext* context) const {
   }
 
   const auto& x_dims = x_shape.GetDims();
+  if (x_dims.empty()) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                           "Input to Normalizer must have rank 1 or 2. Got rank 0.");
+  }
+
   int64_t num_batches = x_dims.size() == 1 ? 1 : x_dims[0];
   int64_t batch_size = x_dims.size() == 1 ? x_dims[0] : x_dims[1];
 

--- a/onnxruntime/test/providers/cpu/ml/normalizer_test.cc
+++ b/onnxruntime/test/providers/cpu/ml/normalizer_test.cc
@@ -187,5 +187,13 @@ TEST(Normalizer, InvalidNorm) {
   RunTest(input, dims, output, "InvalidNormValue", OpTester::ExpectResult::kExpectFailure);
 }
 
+TEST(Normalizer, ScalarInputRejected) {
+  for (const char* const norm : {"MAX", "L1", "L2"}) {
+    RunTest<float>({1.0f}, {}, {0.0f}, norm,
+                   OpTester::ExpectResult::kExpectFailure,
+                   "must have rank 1 or 2");
+  }
+}
+
 }  // namespace test
 }  // namespace onnxruntime


### PR DESCRIPTION
This pull request improves input validation for the `Normalizer` operator by adding a check to reject scalar (rank-0) inputs and introducing a corresponding unit test to ensure this behavior. The main changes are as follows:

**Input validation improvements:**

* Added a check in `normalizer.cc` to return an error if the input tensor has rank 0, ensuring only rank 1 or 2 inputs are accepted.

**Testing enhancements:**

* Added a new test case in `normalizer_test.cc` (`ScalarInputRejected`) to verify that scalar inputs are correctly rejected with an appropriate error message.