### PR TITLE
Separate onnxruntime_providers compilation from its archive

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1995,6 +1995,6 @@ if(onnxruntime_BUILD_UNIT_TESTS)
 endif()
 
 # Include precompiled header configuration for providers
-if(TARGET onnxruntime_providers)
+if(TARGET ${onnxruntime_providers_target})
   include("${CMAKE_CURRENT_SOURCE_DIR}/onnxruntime_providers_pch.cmake")
 endif()

--- a/cmake/onnxruntime.cmake
+++ b/cmake/onnxruntime.cmake
@@ -269,7 +269,7 @@ set(onnxruntime_INTERNAL_LIBRARIES
   ${onnxruntime_INTERNAL_PROVIDER_LIBRARIES}
   ${onnxruntime_winml}
   onnxruntime_optimizer
-  onnxruntime_providers
+  ${onnxruntime_providers_target}
   onnxruntime_lora
   onnxruntime_framework
   onnxruntime_graph

--- a/cmake/onnxruntime_providers_cpu.cmake
+++ b/cmake/onnxruntime_providers_cpu.cmake
@@ -120,25 +120,43 @@ endif()
 if (onnxruntime_REDUCED_OPS_BUILD)
   substitute_op_reduction_srcs(onnxruntime_providers_src)
 endif()
-onnxruntime_add_static_library(onnxruntime_providers ${onnxruntime_providers_src})
+# Only one of these targets exists per configuration, and consumers link
+# ${onnxruntime_providers_target} rather than either name, so the choice lives here alone.
+#
+# With onnxruntime_ENABLE_LTO on MSVC the objects carry whole-program IR, which pushes the archive
+# past the 4 GiB limit lib.exe enforces on the COFF archive format (LNK1248). No lib.exe option
+# raises the limit, and a shared-library build only needs the objects for the final link, so no
+# archive is produced there.
+#
+# The archive cannot instead be materialized from $<TARGET_OBJECTS:...> of an always-present object
+# library: the Xcode generator hash-suffixes object filenames when source basenames collide, as
+# some of these sources do, while TARGET_OBJECTS expands to the unsuffixed names, so libtool fails
+# to find them.
+if (MSVC AND onnxruntime_BUILD_SHARED_LIB)
+  onnxruntime_add_object_library(onnxruntime_providers_obj ${onnxruntime_providers_src})
+  set(onnxruntime_providers_target onnxruntime_providers_obj)
+else()
+  onnxruntime_add_static_library(onnxruntime_providers ${onnxruntime_providers_src})
+  set(onnxruntime_providers_target onnxruntime_providers)
+endif()
 if (onnxruntime_REDUCED_OPS_BUILD)
-  add_op_reduction_include_dirs(onnxruntime_providers)
+  add_op_reduction_include_dirs(${onnxruntime_providers_target})
 endif()
 
 if (HAS_BITWISE_INSTEAD_OF_LOGICAL)
-  target_compile_options(onnxruntime_providers PRIVATE "-Wno-bitwise-instead-of-logical")
+  target_compile_options(${onnxruntime_providers_target} PRIVATE "-Wno-bitwise-instead-of-logical")
 endif()
 
 if (MSVC)
-   target_compile_options(onnxruntime_providers PRIVATE "/bigobj")
+   target_compile_options(${onnxruntime_providers_target} PRIVATE "/bigobj")
 #   if(NOT CMAKE_SIZEOF_VOID_P EQUAL 8)
-#      target_compile_options(onnxruntime_providers PRIVATE "/wd4244")
+#      target_compile_options(${onnxruntime_providers_target} PRIVATE "/wd4244")
 #   endif()
 endif()
-onnxruntime_add_include_to_target(onnxruntime_providers onnxruntime_common onnxruntime_framework onnx onnx_proto ${PROTOBUF_LIB} flatbuffers::flatbuffers Boost::mp11 safeint_interface)
+onnxruntime_add_include_to_target(${onnxruntime_providers_target} onnxruntime_common onnxruntime_framework onnx onnx_proto ${PROTOBUF_LIB} flatbuffers::flatbuffers Boost::mp11 safeint_interface)
 
 if (onnxruntime_BUILD_MS_EXPERIMENTAL_OPS)
-  target_compile_definitions(onnxruntime_providers PRIVATE BUILD_MS_EXPERIMENTAL_OPS=1)
+  target_compile_definitions(${onnxruntime_providers_target} PRIVATE BUILD_MS_EXPERIMENTAL_OPS=1)
 endif()
 
 if(HAS_DEPRECATED_COPY)
@@ -161,40 +179,40 @@ if (onnxruntime_ENABLE_CPU_FP16_OPS)
   set_source_files_properties(${ORTTRAINING_SOURCE_DIR}/training_ops/cuda/collective/adasum_kernels.cc PROPERTIES COMPILE_FLAGS " -fassociative-math -ffast-math -ftree-vectorize -funsafe-math-optimizations -mf16c -mavx -mfma ")
 endif()
 
-target_include_directories(onnxruntime_providers PRIVATE ${ONNXRUNTIME_ROOT})
-onnxruntime_add_include_to_target(onnxruntime_providers re2::re2 Eigen3::Eigen)
-add_dependencies(onnxruntime_providers onnx ${onnxruntime_EXTERNAL_DEPENDENCIES})
+target_include_directories(${onnxruntime_providers_target} PRIVATE ${ONNXRUNTIME_ROOT})
+onnxruntime_add_include_to_target(${onnxruntime_providers_target} re2::re2 Eigen3::Eigen)
+add_dependencies(${onnxruntime_providers_target} onnx ${onnxruntime_EXTERNAL_DEPENDENCIES})
 
 if (onnxruntime_ENABLE_TRAINING_OPS)
-  target_include_directories(onnxruntime_providers PRIVATE ${ORTTRAINING_ROOT})
+  target_include_directories(${onnxruntime_providers_target} PRIVATE ${ORTTRAINING_ROOT})
 endif()
 
 if (onnxruntime_ENABLE_ATEN)
-  target_compile_definitions(onnxruntime_providers PRIVATE ENABLE_ATEN)
+  target_compile_definitions(${onnxruntime_providers_target} PRIVATE ENABLE_ATEN)
 endif()
 
 if (onnxruntime_ENABLE_DLPACK)
-  target_compile_definitions(onnxruntime_providers PRIVATE ENABLE_DLPACK)
+  target_compile_definitions(${onnxruntime_providers_target} PRIVATE ENABLE_DLPACK)
   # DLPack is a header-only dependency
-  onnxruntime_add_include_to_target(onnxruntime_providers dlpack::dlpack)
+  onnxruntime_add_include_to_target(${onnxruntime_providers_target} dlpack::dlpack)
 endif()
 
 if (onnxruntime_ENABLE_TRAINING)
-  add_dependencies(onnxruntime_providers tensorboard)
-  onnxruntime_add_include_to_target(onnxruntime_providers tensorboard)
+  add_dependencies(${onnxruntime_providers_target} tensorboard)
+  onnxruntime_add_include_to_target(${onnxruntime_providers_target} tensorboard)
   if (onnxruntime_ENABLE_TRAINING_TORCH_INTEROP OR onnxruntime_ENABLE_TRITON)
-    onnxruntime_add_include_to_target(onnxruntime_providers Python::Module)
+    onnxruntime_add_include_to_target(${onnxruntime_providers_target} Python::Module)
   endif()
 
   if (onnxruntime_USE_NCCL)
-    target_include_directories(onnxruntime_providers PUBLIC ${MPI_CXX_INCLUDE_DIRS})
+    target_include_directories(${onnxruntime_providers_target} PUBLIC ${MPI_CXX_INCLUDE_DIRS})
   endif()
 endif()
 
 install(FILES ${PROJECT_SOURCE_DIR}/../include/onnxruntime/core/providers/cpu/cpu_provider_factory.h  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/onnxruntime/)
 install(FILES ${PROJECT_SOURCE_DIR}/../include/onnxruntime/core/providers/resource.h ${PROJECT_SOURCE_DIR}/../include/onnxruntime/core/providers/custom_op_context.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/onnxruntime/core/providers)
-set_target_properties(onnxruntime_providers PROPERTIES LINKER_LANGUAGE CXX)
-set_target_properties(onnxruntime_providers PROPERTIES FOLDER "ONNXRuntime")
+set_target_properties(${onnxruntime_providers_target} PROPERTIES LINKER_LANGUAGE CXX)
+set_target_properties(${onnxruntime_providers_target} PROPERTIES FOLDER "ONNXRuntime")
 
 if (NOT onnxruntime_MINIMAL_BUILD AND NOT onnxruntime_EXTENDED_MINIMAL_BUILD
                                   AND NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin|iOS|visionOS|tvOS"

--- a/cmake/onnxruntime_providers_pch.cmake
+++ b/cmake/onnxruntime_providers_pch.cmake
@@ -1,8 +1,8 @@
-# Precompiled header configuration for onnxruntime_providers
+# Precompiled header configuration for the CPU providers target
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
   # Visual Studio PCH
-  target_precompile_headers(onnxruntime_providers PRIVATE
+  target_precompile_headers(${onnxruntime_providers_target} PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}/providers_pch.h"
   )
 endif()

--- a/cmake/onnxruntime_providers_webgpu.cmake
+++ b/cmake/onnxruntime_providers_webgpu.cmake
@@ -57,7 +57,7 @@
 
     target_link_libraries(onnxruntime_providers_webgpu PRIVATE
         onnxruntime_optimizer
-        onnxruntime_providers
+        ${onnxruntime_providers_target}
         onnxruntime_lora
         onnxruntime_framework
         onnxruntime_graph

--- a/cmake/onnxruntime_python.cmake
+++ b/cmake/onnxruntime_python.cmake
@@ -225,7 +225,7 @@ target_link_libraries(onnxruntime_pybind11_state PRIVATE
     ${onnxruntime_libs}
     ${onnxruntime_pybind11_state_static_providers}
     onnxruntime_optimizer
-    onnxruntime_providers
+    ${onnxruntime_providers_target}
     onnxruntime_util
     onnxruntime_lora
     onnxruntime_framework

--- a/cmake/onnxruntime_training.cmake
+++ b/cmake/onnxruntime_training.cmake
@@ -67,7 +67,7 @@ if (onnxruntime_BUILD_UNIT_TESTS)
   endif()
 
   onnxruntime_add_static_library(onnxruntime_training_runner ${onnxruntime_training_runner_srcs} ${onnxruntime_perf_test_src})
-  add_dependencies(onnxruntime_training_runner ${onnxruntime_EXTERNAL_DEPENDENCIES} onnx onnxruntime_providers)
+  add_dependencies(onnxruntime_training_runner ${onnxruntime_EXTERNAL_DEPENDENCIES} onnx ${onnxruntime_providers_target})
 
   if (onnxruntime_ENABLE_TRAINING_TORCH_INTEROP)
     target_link_libraries(onnxruntime_training_runner PRIVATE Python::Python)
@@ -110,7 +110,7 @@ if (onnxruntime_BUILD_UNIT_TESTS)
       ${PROVIDERS_MKLDNN}
       ${PROVIDERS_DML}
       onnxruntime_optimizer
-      onnxruntime_providers
+      ${onnxruntime_providers_target}
       onnxruntime_util
       onnxruntime_framework
   )

--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -729,7 +729,7 @@ set(ONNXRUNTIME_TEST_LIBS
     ${onnxruntime_libs}
     ${ONNXRUNTIME_TEST_STATIC_PROVIDER_LIBS}
     onnxruntime_optimizer
-    onnxruntime_providers
+    ${onnxruntime_providers_target}
     onnxruntime_util
     onnxruntime_lora
     onnxruntime_framework
@@ -920,12 +920,22 @@ endif()
 
 onnxruntime_add_static_library(onnxruntime_unittest_utils ${onnxruntime_unittest_utils_src})
 
+set(onnxruntime_unittest_utils_libs ${ONNXRUNTIME_TEST_LIBS})
+get_target_property(onnxruntime_providers_type ${onnxruntime_providers_target} TYPE)
+if (onnxruntime_providers_type STREQUAL "OBJECT_LIBRARY")
+  # Linking an object library into a static library copies its objects into that archive. Every
+  # target that links onnxruntime_unittest_utils also links the providers target directly, so only
+  # its usage requirements are needed here.
+  list(REMOVE_ITEM onnxruntime_unittest_utils_libs ${onnxruntime_providers_target})
+  list(APPEND onnxruntime_unittest_utils_libs $<COMPILE_ONLY:${onnxruntime_providers_target}>)
+endif()
+
 target_link_libraries(onnxruntime_unittest_utils PUBLIC
                       onnx
                       GTest::gtest
                       GTest::gmock
                       onnxruntime_test_utils
-                      ${ONNXRUNTIME_TEST_LIBS}
+                      ${onnxruntime_unittest_utils_libs}
                       ${onnxruntime_EXTERNAL_LIBRARIES}
                       )
 
@@ -1931,7 +1941,7 @@ if (NOT onnxruntime_ENABLE_TRAINING_TORCH_INTEROP)
         list(APPEND onnxruntime_perf_test_libs ${android_shared_libs})
       endif()
       if (CMAKE_SYSTEM_NAME MATCHES "AIX")
-        list(APPEND onnxruntime_perf_test_libs onnxruntime_graph onnxruntime_session onnxruntime_providers onnxruntime_framework onnxruntime_util onnxruntime_mlas onnxruntime_optimizer onnxruntime_flatbuffers iconv re2 gtest absl_failure_signal_handler absl_examine_stack absl_flags_parse  absl_flags_usage absl_flags_usage_internal)
+        list(APPEND onnxruntime_perf_test_libs onnxruntime_graph onnxruntime_session ${onnxruntime_providers_target} onnxruntime_framework onnxruntime_util onnxruntime_mlas onnxruntime_optimizer onnxruntime_flatbuffers iconv re2 gtest absl_failure_signal_handler absl_examine_stack absl_flags_parse  absl_flags_usage absl_flags_usage_internal)
       endif()
       target_link_libraries(onnxruntime_perf_test PRIVATE ${onnxruntime_perf_test_libs} Threads::Threads)
       if (onnxruntime_USE_CUDA OR onnxruntime_USE_NV OR onnxruntime_USE_TENSORRT)
@@ -2082,7 +2092,7 @@ endif()
     endif()
 
     if (CMAKE_SYSTEM_NAME MATCHES "AIX")
-      list(APPEND onnxruntime_shared_lib_test_LIBS onnxruntime_graph onnxruntime_session onnxruntime_providers onnxruntime_framework onnxruntime_util onnxruntime_mlas onnxruntime_optimizer onnxruntime_flatbuffers iconv re2 onnx)
+      list(APPEND onnxruntime_shared_lib_test_LIBS onnxruntime_graph onnxruntime_session ${onnxruntime_providers_target} onnxruntime_framework onnxruntime_util onnxruntime_mlas onnxruntime_optimizer onnxruntime_flatbuffers iconv re2 onnx)
     endif()
 
     AddTest(DYN
@@ -2253,7 +2263,7 @@ endif()
       ${onnxruntime_libs}
       # CUDA is dynamically loaded at runtime
       onnxruntime_optimizer
-      onnxruntime_providers
+      ${onnxruntime_providers_target}
       onnxruntime_util
       onnxruntime_lora
       onnxruntime_framework
@@ -2399,7 +2409,7 @@ if (NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten" AND NOT onnxruntime_CUDA_MINIMAL
       list(APPEND onnxruntime_customopregistration_test_LIBS ${TENSORRT_LIBRARY_INFER})
     endif()
     if (CMAKE_SYSTEM_NAME MATCHES "AIX")
-      list(APPEND onnxruntime_customopregistration_test_LIBS onnxruntime_graph onnxruntime_session onnxruntime_providers onnxruntime_lora onnxruntime_framework onnxruntime_util onnxruntime_mlas onnxruntime_optimizer onnxruntime_flatbuffers iconv re2 ${PROTOBUF_LIB} onnx onnx_proto)
+      list(APPEND onnxruntime_customopregistration_test_LIBS onnxruntime_graph onnxruntime_session ${onnxruntime_providers_target} onnxruntime_lora onnxruntime_framework onnxruntime_util onnxruntime_mlas onnxruntime_optimizer onnxruntime_flatbuffers iconv re2 ${PROTOBUF_LIB} onnx onnx_proto)
     endif()
     AddTest(DYN
             TARGET onnxruntime_customopregistration_test
@@ -2654,7 +2664,7 @@ if (onnxruntime_BUILD_SHARED_LIB AND
   endif()
 
   if (CMAKE_SYSTEM_NAME MATCHES "AIX")
-    list(APPEND onnxruntime_autoep_test_LIBS onnxruntime_graph onnxruntime_session onnxruntime_providers
+    list(APPEND onnxruntime_autoep_test_LIBS onnxruntime_graph onnxruntime_session ${onnxruntime_providers_target}
                 onnxruntime_optimizer onnxruntime_mlas onnxruntime_framework onnxruntime_util onnxruntime_flatbuffers
                 iconv re2 onnx)
   endif()
@@ -2673,7 +2683,7 @@ if (onnxruntime_BUILD_SHARED_LIB AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten"
 
   set(onnxruntime_logging_apis_test_LIBS onnxruntime_common onnxruntime_test_utils)
   if (CMAKE_SYSTEM_NAME MATCHES "AIX")
-    list(APPEND onnxruntime_logging_apis_test_LIBS onnxruntime_session onnxruntime_util onnxruntime_lora onnxruntime_framework onnxruntime_common onnxruntime_graph  onnxruntime_providers onnxruntime_mlas onnxruntime_optimizer onnxruntime_flatbuffers iconv re2 ${PROTOBUF_LIB} onnx onnx_proto)
+    list(APPEND onnxruntime_logging_apis_test_LIBS onnxruntime_session onnxruntime_util onnxruntime_lora onnxruntime_framework onnxruntime_common onnxruntime_graph  ${onnxruntime_providers_target} onnxruntime_mlas onnxruntime_optimizer onnxruntime_flatbuffers iconv re2 ${PROTOBUF_LIB} onnx onnx_proto)
      endif()
 
   if(NOT WIN32)
@@ -2739,7 +2749,7 @@ if (onnxruntime_BUILD_SHARED_LIB AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten"
   set(onnxruntime_ep_graph_test_LIBS ${ONNXRUNTIME_TEST_LIBS} onnxruntime_test_utils ${onnxruntime_EXTERNAL_LIBRARIES})
   if (CMAKE_SYSTEM_NAME MATCHES "AIX")
     list(APPEND onnxruntime_ep_graph_test_LIBS onnxruntime_session onnxruntime_util onnxruntime_lora onnxruntime_framework
-                                               onnxruntime_common onnxruntime_graph onnxruntime_providers onnxruntime_mlas
+                                               onnxruntime_common onnxruntime_graph ${onnxruntime_providers_target} onnxruntime_mlas
                                                onnxruntime_optimizer onnxruntime_flatbuffers iconv re2
                                                ${PROTOBUF_LIB} onnx onnx_proto)
   endif()

--- a/cmake/onnxruntime_webassembly.cmake
+++ b/cmake/onnxruntime_webassembly.cmake
@@ -116,7 +116,7 @@ if (onnxruntime_BUILD_WEBASSEMBLY_STATIC_LIB)
       onnxruntime_graph
       onnxruntime_mlas
       onnxruntime_optimizer
-      onnxruntime_providers
+      ${onnxruntime_providers_target}
       ${PROVIDERS_JS}
       ${PROVIDERS_XNNPACK}
       ${PROVIDERS_WEBNN}
@@ -189,7 +189,7 @@ else()
     onnxruntime_graph
     onnxruntime_mlas
     onnxruntime_optimizer
-    onnxruntime_providers
+    ${onnxruntime_providers_target}
     ${PROVIDERS_JS}
     ${PROVIDERS_XNNPACK}
     ${PROVIDERS_WEBNN}


### PR DESCRIPTION
Supersedes #30511, which GitHub closed automatically when I force-pushed a commit that had lost its parent, and will not let me reopen. The review discussion there is still readable; both of @edgchen1's comments on it are addressed here.

### The change

On MSVC shared-library builds the provider sources go into an object library, `onnxruntime_providers_obj`; everywhere else they go into the static library `onnxruntime_providers` as before. Only one of the two exists per configuration, and consumers link `${onnxruntime_providers_target}`, so the condition lives in `onnxruntime_providers_cpu.cmake` alone. `onnxruntime_unittests.cmake` keys off the target's actual `TYPE` rather than re-testing it.

The archive is skipped there because with `onnxruntime_ENABLE_LTO` the objects carry whole-program IR, pushing it past the 4 GiB limit `lib.exe` enforces on the COFF archive format (LNK1248). No `lib.exe` option raises that limit, and a shared-library build only needs the objects for the final link.

### Why compilation and packaging are not separate targets

An earlier revision always created the object library and materialized the archive from `$<TARGET_OBJECTS:onnxruntime_providers_obj>`. That does not survive the Xcode generator, and failed every iOS job:

```
libtool: can't open file: .../onnxruntime_providers_obj.build/.../Objects-normal/arm64/utils.o (No such file or directory)
```

Xcode flattens a target's objects into one directory and CMake hash-suffixes the filenames when source basenames collide, but `TARGET_OBJECTS` expands to the unsuffixed names. Sources with unique basenames in the same target were written unsuffixed, which is the control. Ninja is unaffected.

Two further constraints:

* The archive cannot link the object library in any form. Even a `PRIVATE` link is recorded as `$<LINK_ONLY:>`, and `install(EXPORT)` then rejects `onnxruntime_providers` for requiring a target outside the export set.
* Consumers go through a variable rather than being repointed at the object library, because `onnxruntime_INTERNAL_LIBRARIES` is consumed both as a link list and as a list of archive *files* — the Apple static-framework prelink in `onnxruntime.cmake`, and `bundle_static_library()` in `onnxruntime_webassembly.cmake`, which collects only `STATIC_LIBRARY` dependencies and would otherwise drop the providers silently. That is also why the condition stays keyed on MSVC.

### Verification

Firefox builds onnxruntime on Windows with `cl.exe` from MSVC 14.51.36231 and this exact configuration, so it serves as an A/B — same pinned revision both sides, differing only by this patch:

```
python3 tools/ci_build/build.py --update --parallel --enable_lto --disable_rtti \
  --cmake_generator Ninja --build_dir _build --build --build_shared_lib \
  --skip_submodule_sync --use_lock_free_queue --skip_tests --config MinSizeRel \
  --compile_no_warning_as_error \
  --cmake_extra_defines onnxruntime_BUILD_UNIT_TESTS=OFF \
  --cmake_extra_defines ONNX_USE_LITE_PROTO=ON \
  --disable_exceptions \
  --cmake_extra_defines CMAKE_SHARED_LINKER_FLAGS=/MANIFEST:NO
```

Without the patch, x86_64 and i686 both fail, with `onnxruntime_ENABLE_LTO=ON` and `onnxruntime_BUILD_SHARED_LIB=ON` in the generated cache:

```
lib.exe /nologo /LTCG /machine:x64 /LTCG /out:onnxruntime_providers.lib @CMakeFiles\onnxruntime_providers.rsp
onnxruntime_providers.lib : fatal error LNK1248: image size (1001DD8D4) exceeds maximum allowable size (FFFFFFFF)
```

That is 4,296,923,348 bytes, roughly 1.9 MB over; the 32-bit build reports 4,300,722,339. The margin is small, consistent with where this surfaced — the same build linked fine until the toolchain moved to 14.51.

With the patch, `onnxruntime_providers.lib` is never created, the objects build under `onnxruntime_providers_obj`, and both DLLs link.

That configuration is trimmed (`--disable_rtti`, `--disable_exceptions`, lite proto, `MinSizeRel`), so a stock shared+LTO build overflows by at least as much. It also sets `onnxruntime_BUILD_UNIT_TESTS=OFF` with no training or webgpu, so those paths rely on CI here. On Linux the shared, static and forced-object-library configurations all configure and build, with no provider objects in any intermediate archive.
