### PR TITLE
[Build] FP4 QMoE in Windows

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1530,12 +1530,6 @@ if (onnxruntime_USE_CUDA)
     add_definitions("-DENABLE_FP4")
     message(STATUS "CUDA Toolkit version is greater or equal than 12.8, enable -DENABLE_FP4 flag")
     if(onnxruntime_USE_FP4_QMOE)
-      if(MSVC AND ("120" IN_LIST CMAKE_CUDA_ARCHITECTURES_ORIG OR
-                   "121" IN_LIST CMAKE_CUDA_ARCHITECTURES_ORIG))
-        message(FATAL_ERROR
-          "onnxruntime_USE_FP4_QMOE with SM120/SM121 is not supported on MSVC: native sm_120a "
-          "compilation fails in CUDA/CCCL tcgen05 headers. Use a non-MSVC build for native FP4 QMoE.")
-      endif()
       add_definitions("-DUSE_FP4_QMOE")
       message(STATUS "CUDA FP4 QMoE kernels enabled")
     endif()

--- a/cmake/onnxruntime_cuda_source_filters.cmake
+++ b/cmake/onnxruntime_cuda_source_filters.cmake
@@ -155,18 +155,25 @@ endfunction()
 # Usage:
 #   onnxruntime_extract_llm_sources(<cu_src_list_var>
 #       LLM_SOURCES <output_var>
-#       LLM_SM90_SOURCES <output_var>)
+#       LLM_SM90_SOURCES <output_var>
+#       LLM_FP4_SOURCES <output_var>)
 function(onnxruntime_extract_llm_sources CU_SRC_LIST)
-  cmake_parse_arguments(PARSE_ARGV 1 _LLM "" "LLM_SOURCES;LLM_SM90_SOURCES" "")
+  cmake_parse_arguments(PARSE_ARGV 1 _LLM "" "LLM_SOURCES;LLM_SM90_SOURCES;LLM_FP4_SOURCES" "")
 
   set(_list "${${CU_SRC_LIST}}")
   set(_llm_srcs)
   set(_llm_sm90_srcs)
+  set(_llm_fp4_srcs)
   foreach(_src IN LISTS _list)
     if(_src MATCHES "/contrib_ops/cuda/llm/.*\\.cu$")
       # SM90-specific fpA_intB launchers (guarded by #ifndef EXCLUDE_SM_90)
       if(_src MATCHES "fpA_intB_gemm_launcher_[0-9]+\\.generated\\.cu$")
         list(APPEND _llm_sm90_srcs "${_src}")
+      elseif(onnxruntime_USE_FP4_QMOE AND
+             _src MATCHES "/moe_gemm/(moe_gemm_kernels_(bf16|fp16|fp4)_fp4|moe_kernels)\\.cu$")
+        # These units instantiate the native NVFP4 runner and activation conversion.
+        # Keep them separate so MSVC does not compile every LLM source at sm_120a.
+        list(APPEND _llm_fp4_srcs "${_src}")
       else()
         list(APPEND _llm_srcs "${_src}")
       endif()
@@ -178,10 +185,16 @@ function(onnxruntime_extract_llm_sources CU_SRC_LIST)
   if(_llm_sm90_srcs)
     list(REMOVE_ITEM _list ${_llm_sm90_srcs})
   endif()
+  if(_llm_fp4_srcs)
+    list(REMOVE_ITEM _list ${_llm_fp4_srcs})
+  endif()
 
   set("${CU_SRC_LIST}" "${_list}" PARENT_SCOPE)
   set("${_LLM_LLM_SOURCES}" "${_llm_srcs}" PARENT_SCOPE)
   set("${_LLM_LLM_SM90_SOURCES}" "${_llm_sm90_srcs}" PARENT_SCOPE)
+  if(_LLM_LLM_FP4_SOURCES)
+    set("${_LLM_LLM_FP4_SOURCES}" "${_llm_fp4_srcs}" PARENT_SCOPE)
+  endif()
 endfunction()
 
 # Filter CMAKE_CUDA_ARCHITECTURES to only those >= a minimum SM version.
@@ -193,13 +206,16 @@ endfunction()
 #       MIN_SM <number>
 #       [EXCLUDE_SM120_REAL])
 function(onnxruntime_filter_cuda_archs OUTPUT_VAR)
-  cmake_parse_arguments(PARSE_ARGV 1 _FCA "EXCLUDE_SM120_REAL" "MIN_SM" "")
+  cmake_parse_arguments(PARSE_ARGV 1 _FCA "EXCLUDE_SM120_REAL;REPLACE_SM120_REAL_WITH_VIRTUAL" "MIN_SM" "")
 
   set(_filtered)
   foreach(_arch IN LISTS CMAKE_CUDA_ARCHITECTURES)
     string(REGEX MATCH "^([0-9]+)" _arch_num "${_arch}")
     if(_arch_num GREATER_EQUAL "${_FCA_MIN_SM}")
-      if(_FCA_EXCLUDE_SM120_REAL AND _arch_num GREATER_EQUAL 120 AND _arch MATCHES "-real$")
+      if(_FCA_REPLACE_SM120_REAL_WITH_VIRTUAL AND _arch_num GREATER_EQUAL 120 AND _arch MATCHES "-real$")
+        list(APPEND _filtered "${_arch_num}-virtual")
+        continue()
+      elseif(_FCA_EXCLUDE_SM120_REAL AND _arch_num GREATER_EQUAL 120 AND _arch MATCHES "-real$")
         continue()
       endif()
       list(APPEND _filtered "${_arch}")

--- a/cmake/onnxruntime_providers_cuda.cmake
+++ b/cmake/onnxruntime_providers_cuda.cmake
@@ -85,6 +85,7 @@
   onnxruntime_extract_llm_sources(onnxruntime_cuda_contrib_ops_cu_srcs
     LLM_SOURCES onnxruntime_cuda_llm_srcs
     LLM_SM90_SOURCES onnxruntime_cuda_llm_sm90_srcs
+    LLM_FP4_SOURCES onnxruntime_cuda_llm_fp4_srcs
   )
 
   # disable contrib ops conditionally
@@ -472,7 +473,8 @@
       endif()
     endif()
 
-    if(("120" IN_LIST CMAKE_CUDA_ARCHITECTURES_ORIG OR "121" IN_LIST CMAKE_CUDA_ARCHITECTURES_ORIG) AND NOT MSVC)
+    if(("120" IN_LIST CMAKE_CUDA_ARCHITECTURES_ORIG OR "121" IN_LIST CMAKE_CUDA_ARCHITECTURES_ORIG) AND
+       (NOT MSVC OR onnxruntime_USE_FP4_QMOE))
       target_compile_definitions(${target} PRIVATE COMPILE_BLACKWELL_SM120_TMA_GROUPED_GEMMS)
     endif()
 
@@ -585,9 +587,10 @@
         endif()
       endif()
 
-      # CUDA 13 generates host stubs with 128-byte aligned by-value CUTLASS parameters for these
-      # native SM120 TMA kernels. MSVC rejects those stubs with C2719, so retain the portable path.
-      if(onnxruntime_cuda_sm120_tma_srcs AND (NOT MSVC OR CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 13.0))
+      # CUDA 13 gives CUtensorMap 128-byte host alignment when MSVC reports an accurate
+      # __cplusplus value. The target-specific host flag below avoids C2719 for FP4 QMoE.
+      if(onnxruntime_cuda_sm120_tma_srcs AND
+         (NOT MSVC OR CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 13.0 OR onnxruntime_USE_FP4_QMOE))
         onnxruntime_filter_cuda_archs(_ort_sm120_cuda_architectures MIN_SM 120)
         if(_ort_sm120_cuda_architectures)
           onnxruntime_add_cuda_object_library(
@@ -596,6 +599,13 @@
             CUDA_ARCHITECTURES "${_ort_sm120_cuda_architectures}"
             NVCC_THREADS "${onnxruntime_NVCC_THREADS}"
             SOURCES ${onnxruntime_cuda_sm120_tma_srcs})
+          if(MSVC AND CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 13.0)
+            # Keep CUDA's CUtensorMap payload unchanged while avoiding an
+            # alignas(128) by-value parameter that MSVC cannot represent in
+            # NVCC-generated host stubs (C2719).
+            target_compile_options(onnxruntime_providers_cuda_sm120_tma PRIVATE
+              "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /Zc:__cplusplus->")
+          endif()
           target_compile_definitions(onnxruntime_providers_cuda PRIVATE ORT_ENABLE_BLOCKQUANT_SM120)
           if(TARGET onnxruntime_providers_cuda_obj)
             target_compile_definitions(onnxruntime_providers_cuda_obj PRIVATE ORT_ENABLE_BLOCKQUANT_SM120)
@@ -616,16 +626,13 @@
       # "no kernel image is available" (CUDA 209) failure when the arch list is real-only
       # (e.g. 86-real;120-real) and therefore carries no virtual compute_120 PTX fallback.
       #
-      # The one toolchain where native sm_120a does NOT compile is MSVC/Windows: targeting it
-      # pulls in CCCL tcgen05 PTX headers that fail with the MSVC host compiler. There we fall
-      # back to excluding SM120 real and rely on virtual compute_120 PTX + JIT instead. The NVFP4
-      # QMoE native FP4xFP4 path is an exception even on MSVC in principle: it emits `cvt.e2m1x2`
-      # in expandInputRowsKernel (moe_kernels.cu), which is valid only for real sm_120a and cannot
-      # be expressed in virtual PTX -- so when that feature is enabled we keep SM120 real archs
-      # regardless of compiler (NVFP4 QMoE is currently a non-MSVC configuration in practice).
+      # Native sm_120a pulls CCCL tcgen05 PTX headers that fail with the MSVC host compiler, so
+      # the broad LLM target uses virtual compute_120 PTX on Windows. FP4 QMoE is isolated below:
+      # its activation conversion requires real sm_120a for `cvt.e2m1x2` and its smaller source
+      # set does not pull in the problematic tcgen05 path.
       if(onnxruntime_cuda_llm_srcs)
-        if(MSVC AND NOT onnxruntime_USE_FP4_QMOE)
-          onnxruntime_filter_cuda_archs(_ort_llm_cuda_architectures MIN_SM 75 EXCLUDE_SM120_REAL)
+        if(MSVC)
+          onnxruntime_filter_cuda_archs(_ort_llm_cuda_architectures MIN_SM 75 REPLACE_SM120_REAL_WITH_VIRTUAL)
         else()
           onnxruntime_filter_cuda_archs(_ort_llm_cuda_architectures MIN_SM 75)
         endif()
@@ -636,6 +643,18 @@
             CUDA_ARCHITECTURES "${_ort_llm_cuda_architectures}"
             NVCC_THREADS "${onnxruntime_NVCC_THREADS}"
             SOURCES ${onnxruntime_cuda_llm_srcs})
+        endif()
+      endif()
+
+      if(onnxruntime_cuda_llm_fp4_srcs)
+        onnxruntime_filter_cuda_archs(_ort_llm_fp4_cuda_architectures MIN_SM 75)
+        if(_ort_llm_fp4_cuda_architectures)
+          onnxruntime_add_cuda_object_library(
+            NAME onnxruntime_providers_cuda_llm_fp4
+            PARENT onnxruntime_providers_cuda
+            CUDA_ARCHITECTURES "${_ort_llm_fp4_cuda_architectures}"
+            NVCC_THREADS "${onnxruntime_NVCC_THREADS}"
+            SOURCES ${onnxruntime_cuda_llm_fp4_srcs})
         endif()
       endif()
     endif()

--- a/cmake/onnxruntime_providers_cuda_plugin.cmake
+++ b/cmake/onnxruntime_providers_cuda_plugin.cmake
@@ -122,6 +122,7 @@ onnxruntime_extract_flash_attention_sources(CUDA_PLUGIN_EP_CU_SRCS
 onnxruntime_extract_llm_sources(CUDA_PLUGIN_EP_CU_SRCS
   LLM_SOURCES _cuda_plugin_llm_srcs
   LLM_SM90_SOURCES _cuda_plugin_llm_sm90_srcs
+  LLM_FP4_SOURCES _cuda_plugin_llm_fp4_srcs
 )
 
 # Create shared library target using the ORT helper function for plugins
@@ -286,7 +287,8 @@ if(ORT_HAS_SM90_OR_LATER)
     target_compile_definitions(onnxruntime_providers_cuda_plugin PRIVATE COMPILE_HOPPER_TMA_GROUPED_GEMMS)
   endif()
 endif()
-if(("120" IN_LIST CMAKE_CUDA_ARCHITECTURES_ORIG OR "121" IN_LIST CMAKE_CUDA_ARCHITECTURES_ORIG) AND NOT MSVC)
+if(("120" IN_LIST CMAKE_CUDA_ARCHITECTURES_ORIG OR "121" IN_LIST CMAKE_CUDA_ARCHITECTURES_ORIG) AND
+   (NOT MSVC OR onnxruntime_USE_FP4_QMOE))
   target_compile_definitions(onnxruntime_providers_cuda_plugin PRIVATE COMPILE_BLACKWELL_SM120_TMA_GROUPED_GEMMS)
 endif()
 
@@ -342,9 +344,10 @@ if(NOT onnxruntime_DISABLE_CONTRIB_OPS)
     endif()
   endif()
 
-  # CUDA 13 generates host stubs with 128-byte aligned by-value CUTLASS parameters for these
-  # native SM120 TMA kernels. MSVC rejects those stubs with C2719, so retain the portable path.
-  if(_cuda_plugin_sm120_tma_srcs AND (NOT MSVC OR CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 13.0))
+  # CUDA 13 gives CUtensorMap 128-byte host alignment when MSVC reports an accurate
+  # __cplusplus value. The target-specific host flag below avoids C2719 for FP4 QMoE.
+  if(_cuda_plugin_sm120_tma_srcs AND
+     (NOT MSVC OR CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 13.0 OR onnxruntime_USE_FP4_QMOE))
     onnxruntime_filter_cuda_archs(_plugin_sm120_cuda_architectures MIN_SM 120)
     if(_plugin_sm120_cuda_architectures)
       onnxruntime_add_cuda_plugin_object_library(
@@ -354,22 +357,25 @@ if(NOT onnxruntime_DISABLE_CONTRIB_OPS)
         NVCC_THREADS "${onnxruntime_plugin_nvcc_threads}"
         COMPILE_OPTIONS ${_cuda_plugin_shared_compile_options}
         SOURCES ${_cuda_plugin_sm120_tma_srcs})
+      if(MSVC AND CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 13.0)
+        # CUDA 13's cuda.h gives CUtensorMap alignas(128) when MSVC reports the
+        # accurate C++ language level. MSVC cannot pass that type by value in
+        # NVCC-generated host stubs (C2719). Keep NVCC at C++20, but use the
+        # legacy host __cplusplus value so CUtensorMap retains its 128-byte size
+        # with ordinary host alignment.
+        target_compile_options(onnxruntime_providers_cuda_plugin_sm120_tma PRIVATE
+          "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /Zc:__cplusplus->")
+      endif()
       target_compile_definitions(onnxruntime_providers_cuda_plugin PRIVATE ORT_ENABLE_BLOCKQUANT_SM120)
     endif()
   endif()
 
   # LLM OBJECT library: SM75+ (backward compatible with fpA_intB_gemv/gemm which support SM75).
-  # FP4 QMoE requires native SM120-family SASS for activation quantization. Other MSVC builds
-  # exclude SM120+ real architectures because CCCL tcgen05 PTX headers fail with that host compiler.
+  # FP4 QMoE sources are compiled separately at native SM120 below. Keep the broad LLM target
+  # on virtual SM120 PTX under MSVC to avoid CCCL tcgen05 host-compile failures.
   if(_cuda_plugin_llm_srcs)
-    if(MSVC AND NOT onnxruntime_USE_FP4_QMOE)
-      onnxruntime_filter_cuda_archs(_plugin_llm_cuda_architectures MIN_SM 75 EXCLUDE_SM120_REAL)
-      # A native-only Windows ARM64 build has no lower architecture left after the
-      # MSVC SM120 exclusion. Emit PTX privately for this object library so its host
-      # launchers and device kernels are still linked into the plugin.
-      if(NOT _plugin_llm_cuda_architectures AND ORT_HAS_SM120_OR_LATER)
-        set(_plugin_llm_cuda_architectures "120-virtual")
-      endif()
+    if(MSVC)
+      onnxruntime_filter_cuda_archs(_plugin_llm_cuda_architectures MIN_SM 75 REPLACE_SM120_REAL_WITH_VIRTUAL)
     else()
       onnxruntime_filter_cuda_archs(_plugin_llm_cuda_architectures MIN_SM 75)
     endif()
@@ -381,6 +387,19 @@ if(NOT onnxruntime_DISABLE_CONTRIB_OPS)
         NVCC_THREADS "${onnxruntime_plugin_nvcc_threads}"
         COMPILE_OPTIONS ${_cuda_plugin_shared_compile_options}
         SOURCES ${_cuda_plugin_llm_srcs})
+    endif()
+  endif()
+
+  if(_cuda_plugin_llm_fp4_srcs)
+    onnxruntime_filter_cuda_archs(_plugin_llm_fp4_cuda_architectures MIN_SM 75)
+    if(_plugin_llm_fp4_cuda_architectures)
+      onnxruntime_add_cuda_plugin_object_library(
+        NAME onnxruntime_providers_cuda_plugin_llm_fp4
+        PARENT onnxruntime_providers_cuda_plugin
+        CUDA_ARCHITECTURES "${_plugin_llm_fp4_cuda_architectures}"
+        NVCC_THREADS "${onnxruntime_plugin_nvcc_threads}"
+        COMPILE_OPTIONS ${_cuda_plugin_shared_compile_options}
+        SOURCES ${_cuda_plugin_llm_fp4_srcs})
     endif()
   endif()
 endif()

--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -1023,6 +1023,9 @@ if (onnxruntime_ENABLE_CUDA_EP_INTERNAL_TESTS AND NOT onnxruntime_BUILD_CUDA_EP_
   if(TARGET onnxruntime_providers_cuda_llm)
     target_link_libraries(onnxruntime_providers_cuda_ut PRIVATE onnxruntime_providers_cuda_llm)
   endif()
+  if(TARGET onnxruntime_providers_cuda_llm_fp4)
+    target_link_libraries(onnxruntime_providers_cuda_ut PRIVATE onnxruntime_providers_cuda_llm_fp4)
+  endif()
   if (MSVC)
     # Cutlass code has an issue with the following:
     # warning C4100: 'magic': unreferenced formal parameter

--- a/docs/contrib_ops/cuda/moe_qmoe.md
+++ b/docs/contrib_ops/cuda/moe_qmoe.md
@@ -1410,8 +1410,7 @@ endif()
 
 ### 14.1 MSVC and TMA grouped MoE GEMM
 
-Windows/MSVC builds intentionally do not define the grouped TMA MoE compile
-switches:
+Windows/MSVC builds normally do not define the grouped TMA MoE compile switches:
 
 - `COMPILE_HOPPER_TMA_GROUPED_GEMMS`
 - `COMPILE_BLACKWELL_SM120_TMA_GROUPED_GEMMS`
@@ -1437,11 +1436,11 @@ MSVC. Runtime dispatch mirrors this build-time choice:
   for forward compatibility, but it is also unavailable when the Hopper grouped
   TMA switch is disabled by MSVC.
 
-The intent is to keep Windows CUDA packaging builds working while avoiding a
-misleading or invalid fallback for QMoE configurations whose data layout requires
-TMA/block-scaled kernels. Re-enable these switches for MSVC only after the CUDA
-host-stub alignment issue is fixed or the launcher ABI is changed to avoid
-over-aligned by-value parameters.
+When FP4 QMoE is enabled for SM120, the build defines the SM120 grouped-TMA switch
+and compiles that object library with the MSVC host option `/Zc:__cplusplus-`.
+NVCC still compiles device code as C++20, while CUDA 13's `CUtensorMap` keeps its
+128-byte payload with ordinary host alignment in the generated stub. This avoids
+MSVC `C2719` without changing the device descriptor layout.
 
 ### 14.2 LLM object library and SM120 native SASS
 
@@ -1460,16 +1459,14 @@ Architecture filtering of the LLM library (`onnxruntime_filter_cuda_archs`):
 | Platform / config | LLM library archs | Rationale |
 |---|---|---|
 | Linux (any) | includes `120-real` (native SASS) | LLM kernels run natively on SM120; no JIT warm-up; robust to real-only arch lists. |
-| Windows/MSVC, `USE_FP4_QMOE=OFF` | excludes `120-real`, keeps virtual `compute_120` PTX (`EXCLUDE_SM120_REAL`) | native `sm_120a` pulls CCCL `tcgen05` PTX headers that fail to compile with the MSVC host toolchain; SM120 devices JIT from the kept PTX. |
-| any platform, `USE_FP4_QMOE=ON` | includes `120-real` | the NVFP4 native path emits `cvt.e2m1x2` in `expandInputRowsKernel`, valid only for real `sm_120a` and **not** expressible in virtual `compute_120` PTX. |
+| Windows/MSVC, general LLM objects | replaces `120-real` with virtual `compute_120` PTX | Native `sm_120a` pulls CCCL `tcgen05` PTX headers that fail to compile with the MSVC host toolchain; SM120 devices JIT ordinary LLM kernels from PTX. |
+| any platform, FP4 QMoE objects | includes `120-real` in a dedicated object library | The NVFP4 native path emits `cvt.e2m1x2` in `expandInputRowsKernel`, valid only for real `sm_120a` and **not** expressible in virtual `compute_120` PTX. |
 
 > **CUDA 209 gotcha (real-only arch list).** If the LLM library excludes `120-real` **and** the
-> configured arch list carries no virtual `compute_120` PTX entry (e.g.
-> `CMAKE_CUDA_ARCHITECTURES="86-real;120-real"`), the library ends up with no loadable SM120 image at
-> all, and an SM120 GPU fails at EP load / first kernel launch with `no kernel image is available for
-> execution on the device` (CUDA error 209). On Linux this cannot happen because the LLM library
-> keeps `120-real`. On Windows/MSVC, ensure a virtual `compute_120` PTX arch is present (e.g.
-> `86-real;120-real;120-virtual`) so the JIT fallback works. Verify native SASS is present with
+> configured arch list carries no virtual `compute_120` PTX entry, the library can end up with no
+> loadable SM120 image and fail with CUDA error 209. The MSVC architecture filter now replaces each
+> requested SM120-family real architecture with its virtual counterpart for the general LLM target,
+> while the FP4 QMoE target retains native SASS. Verify native SASS is present with
 > `cuobjdump libonnxruntime_providers_cuda.so | grep 'arch ='` (use the toolkit-matched `cuobjdump`;
 > an older one in `PATH` may misparse the multi-arch fatbin and abort).
 
@@ -1488,17 +1485,11 @@ Architecture filtering of the LLM library (`onnxruntime_filter_cuda_archs`):
   FP4, the QMoE op currently routes only `sm_ >= 120` through the native FP4
   runner. SM90/SM100 fall back to dequantization. (Remove `sm_ < 120` and
   rebuild to enable native FP4 on those SMs once validated.)
-- **Windows/MSVC native TMA QMoE**: grouped TMA MoE kernels are disabled on MSVC
-  because CUDA 13 host stubs hit MSVC `C2719` with over-aligned TMA parameters.
-  Standard MoE can fall back to SM80 kernels; native QMoE FP4/block-scaled modes
-  cannot. See [§14.1](#141-msvc-and-tma-grouped-moe-gemm).
-- **Windows/MSVC SM120 LLM library**: the general LLM object library excludes
-  native `sm_120a` on MSVC (CCCL `tcgen05` PTX headers do not compile with the
-  MSVC host toolchain) and relies on virtual `compute_120` PTX + JIT. As a result
-  a real-only SM120 arch list can leave the library with no loadable image
-  (CUDA error 209) — keep a `compute_120` (virtual) arch on MSVC. NVFP4 QMoE
-  (`USE_FP4_QMOE`) requires native `sm_120a` for `cvt.e2m1x2` and is therefore a
-  non-MSVC configuration in practice. See [§14.2](#142-llm-object-library-and-sm120-native-sass).
+- **Windows/MSVC SM120 split**: ordinary LLM kernels use virtual `compute_120`
+  PTX to avoid CCCL `tcgen05` host-compile failures. FP4 QMoE conversion, runner,
+  and grouped-TMA launchers are isolated into native `sm_120a` object libraries;
+  the TMA target uses the host-only `CUtensorMap` alignment workaround described
+  in [§14.1](#141-msvc-and-tma-grouped-moe-gemm).
 - **WFP4AFP8 native** requires SM100+ hardware; only the dequant fallback path
   is validated end-to-end so far.
 - **In-`PrePack` INT weight layout transform** (`weights_prepacked=0`) is


### PR DESCRIPTION
## Description

Enable FP4 QMoE for Blackwell SM120 in Windows CUDA builds. Previously, MSVC builds rejected this configuration because compiling the full LLM CUDA source set for native SM120 exposed `tcgen05` compilation failures.

## Changes

- Split the FP4 QMoE sources that require native SM120 instructions into dedicated CUDA object targets:
  - `onnxruntime_providers_cuda_llm_fp4`
  - `onnxruntime_providers_cuda_plugin_llm_fp4`
- Compile those FP4 targets for native `sm_120a` (`120-real`) so `expandInputRowsKernel` can use `cvt.e2m1x2`.
- Compile the general LLM CUDA targets as `compute_120` PTX (`120-virtual`) on MSVC, avoiding `tcgen05` failures in unrelated translation units.
- Enable the CUTLASS SM120 grouped TMA kernels needed by FP4 QMoE on Windows.
- For CUDA 13 and MSVC, apply `/Zc:__cplusplus-` only to the host compilation of the SM120 TMA object target. This avoids MSVC `C2719` errors in generated host stubs for by-value, 128-byte-aligned `CUtensorMap` parameters while preserving C++20 for CUDA device compilation.
- Apply the same source split and workaround to both the in-tree CUDA provider and the CUDA plugin provider.
- Update the FP4 QMoE documentation with the Windows build behavior and constraints.

## Validation

- Built the native FP4 QMoE object target for `sm_120a` with MSVC and CUDA 13.
- Built the native SM120 CUTLASS TMA object target with the target-local host compiler workaround.
- The CUDA plugin packaging pipeline verified this change: the Windows x64 build passed.