### PR TITLE
Fix zero-sized feeds in onnxruntime_test tool

### DIFF
--- a/onnxruntime/python/tools/onnxruntime_test.py
+++ b/onnxruntime/python/tools/onnxruntime_test.py
@@ -37,7 +37,7 @@ def generate_feeds(sess, symbolic_dims: dict | None = None):
         # replace any symbolic dimensions
         shape = []
         for dim in input_meta.shape:
-            if not dim:
+            if dim is None:
                 # unknown dim
                 shape.append(1)
             elif isinstance(dim, str):
@@ -100,7 +100,7 @@ def run_model(
         # and can be overridden (available in IR4). For IR < 4 models
         # the list would be empty
         for initializer in sess.get_overridable_initializers():
-            shape = [dim if dim else 1 for dim in initializer.shape]
+            shape = [dim if dim is not None else 1 for dim in initializer.shape]
             if initializer.type in float_dict:
                 feeds[initializer.name] = np.random.rand(*shape).astype(float_dict[initializer.type])
             elif initializer.type in integer_dict:

--- a/onnxruntime/python/tools/onnxruntime_test.py
+++ b/onnxruntime/python/tools/onnxruntime_test.py
@@ -72,6 +72,7 @@ def run_model(
     symbolic_dims=None,
     feeds=None,
     override_initializers=True,
+    providers=None,
 ):
     symbolic_dims = symbolic_dims or {}
     if debug:
@@ -85,10 +86,11 @@ def run_model(
         sess_options.enable_profiling = True
         sess_options.profile_file_prefix = os.path.basename(model_path)
 
+    providers = providers if providers is not None else onnxrt.get_available_providers()
     sess = onnxrt.InferenceSession(
         model_path,
         sess_options=sess_options,
-        providers=onnxrt.get_available_providers(),
+        providers=providers,
     )
     meta = sess.get_modelmeta()
 

--- a/onnxruntime/test/python/onnxruntime_test_python.py
+++ b/onnxruntime/test/python/onnxruntime_test_python.py
@@ -683,6 +683,63 @@ class TestInferenceSession(unittest.TestCase):
         output_expected = np.array([[1.0, 4.0], [9.0, 16.0], [25.0, 36.0]], dtype=np.float32)
         np.testing.assert_allclose(res[0], output_expected, rtol=1e-05, atol=1e-08)
 
+    @unittest.skipUnless(
+        importlib.util.find_spec("onnx") is not None,
+        "onnx package is required to build the test model",
+    )
+    def test_model_test_tool_preserves_zero_sized_dimensions(self):
+        import tempfile  # noqa: PLC0415
+
+        import onnx  # noqa: PLC0415
+        from onnx import TensorProto, helper  # noqa: PLC0415
+
+        from onnxruntime.tools.onnxruntime_test import generate_feeds, run_model  # noqa: PLC0415
+
+        input_info = helper.make_tensor_value_info("X", TensorProto.FLOAT, [0, 3])
+        output_info = helper.make_tensor_value_info("Y", TensorProto.FLOAT, [0, 3])
+        graph = helper.make_graph(
+            [helper.make_node("Identity", ["X"], ["Y"])],
+            "zero_sized_input",
+            [input_info],
+            [output_info],
+        )
+        model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 21)])
+        model.ir_version = 10
+
+        session = onnxrt.InferenceSession(
+            model.SerializeToString(),
+            providers=["CPUExecutionProvider"],
+        )
+        feeds = generate_feeds(session)
+
+        self.assertEqual(feeds["X"].shape, (0, 3))
+        output = session.run(None, feeds)[0]
+        self.assertEqual(output.shape, (0, 3))
+
+        initializer = helper.make_tensor("W", TensorProto.FLOAT, [0, 3], [])
+        initializer_info = helper.make_tensor_value_info("W", TensorProto.FLOAT, [0, 3])
+        initializer_graph = helper.make_graph(
+            [helper.make_node("Identity", ["W"], ["Y"])],
+            "zero_sized_initializer",
+            [initializer_info],
+            [output_info],
+            [initializer],
+        )
+        initializer_model = helper.make_model(
+            initializer_graph,
+            opset_imports=[helper.make_opsetid("", 21)],
+        )
+        initializer_model.ir_version = 10
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            model_path = pathlib.Path(temp_dir) / "zero_sized_initializer.onnx"
+            onnx.save_model(initializer_model, model_path)
+            exit_code, initializer_feeds, outputs = run_model(model_path)
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(initializer_feeds["W"].shape, (0, 3))
+        self.assertEqual(outputs[0].shape, (0, 3))
+
     def test_run_async(self):
         event = threading.Event()
         output_expected = np.array([[1.0, 4.0], [9.0, 16.0], [25.0, 36.0]], dtype=np.float32)

--- a/onnxruntime/test/python/onnxruntime_test_python.py
+++ b/onnxruntime/test/python/onnxruntime_test_python.py
@@ -695,6 +695,9 @@ class TestInferenceSession(unittest.TestCase):
 
         from onnxruntime.tools.onnxruntime_test import generate_feeds, run_model  # noqa: PLC0415
 
+        # Opset 9 is the first standard opset mapped to IR v4, where initializers
+        # can also be graph inputs and therefore overridable at runtime.
+        opset_imports = [helper.make_opsetid("", 9)]
         input_info = helper.make_tensor_value_info("X", TensorProto.FLOAT, [0, 3])
         output_info = helper.make_tensor_value_info("Y", TensorProto.FLOAT, [0, 3])
         graph = helper.make_graph(
@@ -703,8 +706,10 @@ class TestInferenceSession(unittest.TestCase):
             [input_info],
             [output_info],
         )
-        model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 21)])
-        model.ir_version = 10
+        model = helper.make_model_gen_version(
+            graph,
+            opset_imports=opset_imports,
+        )
 
         session = onnxrt.InferenceSession(
             model.SerializeToString(),
@@ -725,16 +730,18 @@ class TestInferenceSession(unittest.TestCase):
             [output_info],
             [initializer],
         )
-        initializer_model = helper.make_model(
+        initializer_model = helper.make_model_gen_version(
             initializer_graph,
-            opset_imports=[helper.make_opsetid("", 21)],
+            opset_imports=opset_imports,
         )
-        initializer_model.ir_version = 10
 
         with tempfile.TemporaryDirectory() as temp_dir:
             model_path = pathlib.Path(temp_dir) / "zero_sized_initializer.onnx"
             onnx.save_model(initializer_model, model_path)
-            exit_code, initializer_feeds, outputs = run_model(model_path)
+            exit_code, initializer_feeds, outputs = run_model(
+                model_path,
+                providers=["CPUExecutionProvider"],
+            )
 
         self.assertEqual(exit_code, 0)
         self.assertEqual(initializer_feeds["W"].shape, (0, 3))


### PR DESCRIPTION
### Description

Preserve static zero-sized dimensions when `onnxruntime_test` generates random feeds. Unknown dimensions represented by `None` continue to use a size of one, while a declared dimension of zero now produces an empty NumPy array. The same distinction is applied to overridable initializer feeds.

The regression test builds and executes real ONNX Identity models for both a regular input and an overridable initializer with shape `[0, 3]`.

### Motivation and Context

The existing truthiness checks treated a valid static dimension of `0` as if it were an unknown dimension. As a result, `generate_feeds()` created a `(1, 3)` input for a model that required `(0, 3)`, and ONNX Runtime rejected the generated feed with a dimension mismatch. Overridable initializers had the same issue.

This change distinguishes `0` from `None`, allowing the test tool to run models that intentionally use empty tensors without changing its handling of unknown dimensions.

Validation on macOS arm64:

- Release CPU wheel built from source
- `onnxruntime_test_python.py`: 82 passed, 7 subtests passed
- Focused zero-sized dimension regression: 1 passed
- `lintrunner` on both changed Python files: no issues
