### PR TITLE
Test updates for s390x

### DIFF
--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -2161,7 +2161,7 @@ endif()
     target_link_libraries(compare_two_sessions PRIVATE ${GETOPT_LIB_WIDE} tdh Advapi32)
   endif()
 
-  if(NOT onnxruntime_target_platform STREQUAL "ARM64EC")
+  if(NOT onnxruntime_target_platform STREQUAL "ARM64EC" AND NOT onnxruntime_target_platform STREQUAL "S390X")
     file(GLOB onnxruntime_mlas_test_src CONFIGURE_DEPENDS
       "${TEST_SRC_DIR}/mlas/unittest/*.h"
       "${TEST_SRC_DIR}/mlas/unittest/*.cpp"

--- a/onnxruntime/test/providers/cpu/ml/label_encoder_test.cc
+++ b/onnxruntime/test/providers/cpu/ml/label_encoder_test.cc
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include "gtest/gtest.h"
+#include "core/framework/endian_utils.h"
 #include "core/framework/tensorprotoutils.h"
 #include "test/providers/provider_test_utils.h"
 #include "test/util/include/file_util.h"
@@ -820,6 +821,13 @@ static ONNX_NAMESPACE::TensorProto MakeInMemoryExternalTensorProto(const std::st
 // Valid external data in tensor attributes should be loaded and inlined during session initialization.
 TEST(LabelEncoder, ExternalDataInKeysTensorOpset4) {
   std::vector<int64_t> key_data{1, 2};
+
+  // external data has to be little endian, even on big endian systems.
+  // byteswap it if needed.
+  if constexpr (endian::native == endian::big) {
+    onnxruntime::utils::SwapByteOrderInplace(sizeof(int64_t), gsl::make_span(reinterpret_cast<std::byte*>(key_data.data()), key_data.size() * sizeof(int64_t)));
+  }
+
   auto [ext_path, ext_deleter] = CreateExternalDataFile(key_data.data(), key_data.size() * sizeof(int64_t));
 
   OpTester test("LabelEncoder", 4, onnxruntime::kMLDomain);

--- a/onnxruntime/test/providers/cpu/ml/label_encoder_test.cc
+++ b/onnxruntime/test/providers/cpu/ml/label_encoder_test.cc
@@ -824,7 +824,7 @@ TEST(LabelEncoder, ExternalDataInKeysTensorOpset4) {
 
   // external data has to be little endian, even on big endian systems.
   // byteswap it if needed.
-  if constexpr (endian::native == endian::big) {
+  if constexpr (onnxruntime::endian::native == onnxruntime::endian::big) {
     onnxruntime::utils::SwapByteOrderInplace(sizeof(int64_t), gsl::make_span(reinterpret_cast<std::byte*>(key_data.data()), key_data.size() * sizeof(int64_t)));
   }
 


### PR DESCRIPTION
### Description
Disable x86-specific tests and fix LabelEncoder.ExternalDataInKeysTensorOpset4 test on s390x.

### Motivation and Context
These changes clean up some testsuite failures on s390x.