### PR TITLE
feat: Port asm files for windows arm nchwc layout

### DIFF
--- a/cmake/onnxruntime_mlas.cmake
+++ b/cmake/onnxruntime_mlas.cmake
@@ -418,7 +418,6 @@ function (setup_arm_neon_nchwc)
   endif()
   list(APPEND mlas_private_compile_definitions MLAS_USE_ARM_NEON_NCHWC)
   set(mlas_private_compile_definitions ${mlas_private_compile_definitions} PARENT_SCOPE)
-  target_compile_definitions(onnxruntime_mlas PRIVATE MLAS_USE_ARM_NEON_NCHWC)
 endfunction ()
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Emscripten")

--- a/cmake/onnxruntime_mlas.cmake
+++ b/cmake/onnxruntime_mlas.cmake
@@ -115,6 +115,8 @@ function(setup_mlas_source_for_windows)
         ${MLAS_SRC_DIR}/qnbitgemm_kernel_neon.cpp
         ${MLAS_SRC_DIR}/sqnbitgemm_kernel_neon_fp32.cpp
         ${MLAS_SRC_DIR}/sqnbitgemm_kernel_neon_int8.cpp
+        ${MLAS_SRC_DIR}/qgemm_kernel_ummla.cpp
+        ${MLAS_SRC_DIR}/qgemm_kernel_smmla.cpp
         # Portable W2 pack helpers + scalar reference kernel. Misleadingly
         # Avx512-named because the AVX-512 W2 path was the first consumer, but
         # the TU contains no x86 intrinsics (see sqnbitgemm_kernel_avx512_2bit.cpp).
@@ -164,6 +166,8 @@ function(setup_mlas_source_for_windows)
         ${MLAS_SRC_DIR}/arm64/SymQgemmS8KernelNeon.asm
         ${MLAS_SRC_DIR}/arm64/SymQgemmS8KernelSDot.asm
         ${MLAS_SRC_DIR}/arm64/SymQgemmS8KernelSDotLd64.asm
+        ${MLAS_SRC_DIR}/arm64/QgemmU8X8KernelUmmla.asm
+        ${MLAS_SRC_DIR}/arm64/QgemmS8S8KernelSmmla.asm
       )
 
       if (onnxruntime_USE_ARM_NEON_NCHWC)
@@ -404,9 +408,17 @@ function (setup_arm_neon_nchwc)
      ${MLAS_SRC_DIR}/aarch64/SconvDepthwiseKernelNeon.S
      ${MLAS_SRC_DIR}/aarch64/SconvPointwiseKernelNeon.S
      )
+  else()
+      target_sources(onnxruntime_mlas PRIVATE
+      # The armasm64 translations of the hand written micro-kernels above.
+      ${MLAS_SRC_DIR}/arm64/SconvPointwiseKernelNeon.asm
+      ${MLAS_SRC_DIR}/arm64/SconvNchwcKernelNeon.asm
+      ${MLAS_SRC_DIR}/arm64/SconvKernelNeon.asm
+      )
   endif()
   list(APPEND mlas_private_compile_definitions MLAS_USE_ARM_NEON_NCHWC)
   set(mlas_private_compile_definitions ${mlas_private_compile_definitions} PARENT_SCOPE)
+  target_compile_definitions(onnxruntime_mlas PRIVATE MLAS_USE_ARM_NEON_NCHWC)
 endfunction ()
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Emscripten")

--- a/onnxruntime/core/mlas/lib/arm64/QgemmS8S8KernelSmmla.asm
+++ b/onnxruntime/core/mlas/lib/arm64/QgemmS8S8KernelSmmla.asm
@@ -1,0 +1,954 @@
+;++
+;
+; Copyright (c) Microsoft Corporation. All rights reserved.
+; Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+;
+; Licensed under the MIT License.
+;
+; Module Name:
+;
+;     QgemmS8S8KernelSmmla.s
+;
+; Abstract:
+;
+;     This module implements the kernels for the Int8 precision matrix/matrix
+;     multiply operation (QGEMM).
+;
+;--
+
+#include "kxarm64.h"
+
+        TEXTAREA
+
+;
+; Stack frame layout for the smmla kernel. d8-d15, x19-x30 need save
+;
+MlasQgemmKernel_backup_x19_x20 EQU 0
+MlasQgemmKernel_backup_x21_x22 EQU 16
+MlasQgemmKernel_backup_x23_x24 EQU 32
+MlasQgemmKernel_backup_x25_x26 EQU 48
+MlasQgemmKernel_backup_x27_x28 EQU 64
+MlasQgemmKernel_backup_d8_d9 EQU 80
+MlasQgemmKernel_backup_d10_d11 EQU 96
+MlasQgemmKernel_backup_d12_d13 EQU 112
+MlasQgemmKernel_backup_d14_d15 EQU 128
+MlasQgemmKernel_SavedRegisters EQU 144
+MlasQgemmKernel_SavedRegisters_Neg EQU -144
+
+
+;
+; Init Row Accumulators
+;
+; Generates the code to initialize the accumulators for a single row of the output
+; block.
+;
+;
+;  Accumulators are initialized to ZeroPointB * RowSum + ColumnSum
+;  x7 for RowSumsBuffer pointer
+;  x10 for ColumnSumBuffer pointer
+;  x11 for ZeroPointB buffer pointer
+;
+;  v12~v13 for RowSums values
+;  v14~v15 for ColumnSums values
+;  v0~v3 for ZeroPointB values
+;
+        MACRO
+        InitRowAccumulators $Columns, $Vec1Reg, $Vec2Reg, $Vec3Reg, $Vec4Reg, $RowSumReg
+
+        mul     v7.4s, $RowSumReg..4s, v8.4s
+        mov     $Vec1Reg..16b, v7.16b
+        add     $Vec1Reg..4s, $Vec1Reg..4s, v0.4s
+    IF $Columns > 2
+        mul     v7.4s, $RowSumReg..4s, v9.4s
+        mov     $Vec2Reg..16b, v7.16b
+        add     $Vec2Reg..4s, $Vec2Reg..4s, v1.4s
+    ENDIF
+    IF $Columns > 4
+        mul     v7.4s, $RowSumReg..4s, v10.4s
+        mov     $Vec3Reg..16b, v7.16b
+        add     $Vec3Reg..4s, $Vec3Reg..4s, v2.4s
+    ENDIF
+    IF $Columns > 6
+        mul     v7.4s, $RowSumReg..4s, v11.4s
+        mov     $Vec4Reg..16b, v7.16b
+        add     $Vec4Reg..4s, $Vec4Reg..4s, v3.4s
+    ENDIF
+
+        MEND
+
+
+;
+; InitBlockAccumulators
+;
+; Generates the code to initialize the accumulators for 8x8 output
+; block.
+;
+        MACRO
+        InitBlockAccumulators $Mode, $Columns, $Rows
+
+        ld1     {v14.4s},[x10],#16 ; load ColumnSumBuffer[0]
+    IF $Columns > 4
+        ld1     {v15.4s},[x10],#16 ; load ColumnSumBuffer[4]
+    ENDIF
+        ; v4~v7 will be set to matrixB after this, so, they can used now
+        dup     v4.4s,v14.s[0] ; broadcast column
+        dup     v5.4s,v14.s[1]
+        dup     v6.4s,v14.s[2]
+        dup     v7.4s,v14.s[3]
+
+        zip1    v0.4s, v4.4s, v5.4s
+        zip2    v1.4s, v6.4s, v7.4s
+    IF $Columns > 4
+        dup     v4.4s,v15.s[0] ; broadcast column
+        dup     v5.4s,v15.s[1]
+        dup     v6.4s,v15.s[2]
+        dup     v7.4s,v15.s[3]
+
+        zip1    v2.4s, v4.4s, v5.4s
+        zip2    v3.4s, v6.4s, v7.4s
+    ENDIF
+
+        ; v8~v11 will anyway get set in MatrixA loading, so they are free to use now
+        movi    v8.4s, #1
+        movi    v9.4s, #1
+        movi    v10.4s, #1
+        movi    v11.4s, #1
+
+        cbz     x11,$Mode.InitBlock$Columns.x$Rows.SkipScaleByZeroPointB
+
+        ld1     {v4.4s},[x11],#16 ; load ZeroPointB[0]
+        ld1     {v5.4s},[x11],#16 ; load ZeroPointB[4]
+
+        dup     v6.4s, v4.s[0]
+        dup     v7.4s, v4.s[1]
+        zip1    v8.4s, v6.4s, v7.4s
+
+        dup     v6.4s, v4.s[2]
+        dup     v7.4s, v4.s[3]
+        zip1    v9.4s, v6.4s, v7.4s
+
+        dup     v6.4s, v5.s[0]
+        dup     v7.4s, v5.s[1]
+        zip1    v10.4s, v6.4s, v7.4s
+
+        dup     v6.4s, v5.s[2]
+        dup     v7.4s, v5.s[3]
+        zip1    v11.4s, v6.4s, v7.4s
+
+$Mode.InitBlock$Columns.x$Rows.SkipScaleByZeroPointB
+        dup     v4.4s, v12.s[0] ;boardcast RowSums
+        dup     v5.4s, v12.s[1]
+
+        uzp1    v6.2d, v4.2d, v5.2d
+
+        InitRowAccumulators $Columns, v16, v17, v18, v19, v6
+    IF $Rows > 2
+        dup     v4.4s, v12.s[2] ;boardcast RowSums
+        dup     v5.4s, v12.s[3]
+
+        uzp1    v6.2d, v4.2d, v5.2d
+
+        InitRowAccumulators $Columns, v20, v21, v22, v23, v6
+    ENDIF
+    IF $Rows > 4
+        dup     v4.4s,v13.s[0] ; broadcast row sums
+        dup     v5.4s,v13.s[1]
+
+        uzp1    v6.2d, v4.2d, v5.2d
+
+        InitRowAccumulators $Columns, v24, v25, v26, v27, v6
+    ENDIF
+    IF $Rows > 6
+        dup     v4.4s,v13.s[2] ; broadcast row sums
+        dup     v5.4s,v13.s[3]
+
+        uzp1    v6.2d, v4.2d, v5.2d
+        InitRowAccumulators $Columns, v28, v29, v30, v31, v6
+    ENDIF
+
+        MEND
+
+
+; LoadPackedMatrixABy16Elements
+;
+; Generates the code to load 16 elements from matrix A.
+;
+        MACRO
+        LoadPackedMatrixABy16Elements $Rows
+    IF $Rows == 1
+        ldr     q8,[x0],#8
+    ELSE
+        ldr     q8,[x0],#16
+
+    IF $Rows > 2
+        ldr     q9,[x0],#16
+    ENDIF
+
+    IF $Rows > 4
+        ldr     q10,[x0],#16
+    ENDIF
+
+    IF $Rows > 6
+        ldr     q11,[x0],#16
+    ENDIF
+    ENDIF
+        MEND
+
+
+;
+; MultiplyAccumulateRow
+;
+; Generates the code to multiply and accumulate a single row of the output
+; block.
+;
+
+        MACRO
+        MultiplyAccumulateRow $Columns, $MatrixAReg, $Vec1Reg, $Vec2Reg, $Vec3Reg, $Vec4Reg
+
+        smmla   $Vec1Reg..4s, $MatrixAReg..16b, v4.16b
+    IF $Columns > 2
+        smmla   $Vec2Reg..4s, $MatrixAReg..16b, v5.16b
+    ENDIF
+    IF $Columns > 4
+        smmla   $Vec3Reg..4s, $MatrixAReg..16b, v6.16b
+    ENDIF
+    IF $Columns > 6
+        smmla   $Vec4Reg..4s, $MatrixAReg..16b, v7.16b
+    ENDIF
+
+        MEND
+
+;
+; MultiplyAccumulateBlock
+;
+; Generates the code to multiply and accumulate into the output block.
+;
+
+        MACRO
+        MultiplyAccumulateBlock $Columns, $Rows
+
+        MultiplyAccumulateRow $Columns, v8, v16, v17, v18, v19
+    IF $Rows > 2
+        MultiplyAccumulateRow $Columns, v9, v20, v21, v22, v23
+    ENDIF
+    IF $Rows > 4
+        MultiplyAccumulateRow $Columns, v10, v24, v25, v26, v27
+    ENDIF
+    IF $Rows > 6
+        MultiplyAccumulateRow $Columns, v11, v28, v29, v30, v31
+    ENDIF
+
+        MEND
+
+;
+; ComputeBlockLoop
+;
+; Generates the code to loop over K entries of the input matrices to produce
+; the output block.
+;
+
+        MACRO
+        ComputeBlockLoop $Mode, $Columns, $Rows
+
+        InitBlockAccumulators $Mode, $Columns, $Rows
+
+        sub     x9,x3,#1 ;  block count to process
+        tbnz    x9,#63,$Mode.ProcessRemaining$Columns.x$Rows.Blocks
+
+$Mode.Compute$Columns.x$Rows.BlockBy4Loop
+
+        LoadPackedMatrixABy16Elements $Rows
+        ld1     {v4.16b - v7.16b}, [x1], #64
+        MultiplyAccumulateBlock $Columns, $Rows
+
+        sub     x9,x9,#1
+        tbz     x9,#63,$Mode.Compute$Columns.x$Rows.BlockBy4Loop
+$Mode.ProcessRemaining$Columns.x$Rows.Blocks
+        add     x9,x9,#1 ; correct for over-subtract above
+        cbz     x9,$Mode.Output$Columns.x$Rows.Block
+
+$Mode.Compute$Columns.x$Rows.BlockBy4PaddedLoop
+        LoadPackedMatrixABy16Elements $Rows
+        ld1     {v4.16b - v7.16b}, [x1], #64
+        MultiplyAccumulateBlock $Columns, $Rows
+
+$Mode.Output$Columns.x$Rows.Block
+
+        MEND
+
+
+;
+; OutputRow2Element
+; OutputRow4Element
+; OutputRow6Element
+; OutputRow8Element
+; OutputRow10Element
+; OutputRow12Element
+; OutputRow14Element
+; OutputRow16Element
+;
+; Generates the code to store elements to the output block.
+;
+
+        MACRO
+        OutputRow2Element $Mode, $AddrReg1, $AddrReg2, $Vec1Reg, $Vec2Reg, $Vec3Reg, $Vec4Reg, $last_row
+
+    IF "$Mode"=="Add"
+        ldr     s8,[$AddrReg1],#0
+    IF $last_row == 0
+        ldr     s9,[$AddrReg2],#0
+    ELSE
+        mov     x27,#0
+        mov     v9.D[0],x27
+        mov     v9.D[1],x27
+    ENDIF
+        mov     v8.S[2], v9.S[0]
+        add     v8.4s,v8.4s,$Vec1Reg..4s
+
+        mov     w27, v8.S[0]
+        str     w27, [$AddrReg1],#4
+
+    IF $last_row == 0
+        mov     w27, v8.S[2]
+        str     w27, [$AddrReg2],#4
+    ENDIF
+
+    ELSE
+        mov     w27, $Vec1Reg..S[0]
+        str     w27, [$AddrReg1],#4
+
+    IF $last_row == 0
+        mov     w27, $Vec1Reg..S[2]
+        str     w27, [$AddrReg2],#4
+    ENDIF
+
+    ENDIF
+
+        MEND
+
+
+        MACRO
+        OutputRow4Element $Mode, $AddrReg1, $AddrReg2, $Vec1Reg, $Vec2Reg, $Vec3Reg, $Vec4Reg, $last_row
+
+    IF "$Mode"=="Add"
+        ldr     d8,[$AddrReg1],#0
+    IF $last_row == 0
+        ldr     d9,[$AddrReg2],#0
+    ELSE
+        mov     x27,#0
+        mov     v9.D[0],x27
+        mov     v9.D[1],x27
+    ENDIF
+
+        mov     v8.D[1], v9.D[0]
+
+        add     v8.4s,v8.4s,$Vec1Reg..4s
+
+        mov     x27, v8.D[0]
+        mov     x28, v8.D[1]
+
+        str     x27, [$AddrReg1],#8
+    IF $last_row == 0
+        str     x28, [$AddrReg2],#8
+    ENDIF
+
+    ELSE
+        mov     x27, $Vec1Reg..D[0]
+        mov     x28, $Vec1Reg..D[1]
+
+        str     x27, [$AddrReg1],#8
+    IF $last_row == 0
+        str     x28, [$AddrReg2],#8
+    ENDIF
+
+    ENDIF
+
+        MEND
+
+
+        MACRO
+        OutputRow6Element $Mode, $AddrReg1, $AddrReg2, $Vec1Reg, $Vec2Reg, $Vec3Reg, $Vec4Reg, $last_row
+
+    IF "$Mode"=="Add"
+        ldr     d8,[$AddrReg1],#8
+        ldr     w28,[$AddrReg1],#-8
+        mov     v8.S[2], w28
+    IF $last_row == 0
+        ldr     d9,[$AddrReg2],#8
+        ldr     w27,[$AddrReg2],#-8
+        mov     v9.S[2], w27
+    ELSE
+        mov     x27,#0
+        mov     v9.D[0],x27
+        mov     v9.D[1],x27
+    ENDIF
+        uzp1    v4.2d,$Vec1Reg..2d,$Vec2Reg..2d
+        uzp2    v5.2d,$Vec1Reg..2d,$Vec2Reg..2d
+
+        add     v8.4s,v8.4s,v4.4s
+        add     v9.4s,v9.4s,v5.4s
+
+        mov     x27, v8.D[0]
+        str     x27, [$AddrReg1],#8
+        mov     w27, v8.S[2]
+        str     w27, [$AddrReg1],#4
+
+    IF $last_row == 0
+        mov     x27, v9.D[0]
+        str     x27, [$AddrReg2],#8
+        mov     w27, v9.S[2]
+        str     w27, [$AddrReg2],#4
+    ENDIF
+
+    ELSE
+        uzp1    v4.2d, $Vec1Reg..2d,$Vec2Reg..2d
+        uzp2    v5.2d, $Vec1Reg..2d,$Vec2Reg..2d
+
+        mov     x27, v4.D[0]
+        str     x27, [$AddrReg1],#8
+        mov     w27, v4.S[2]
+        str     w27, [$AddrReg1],#4
+
+    IF $last_row == 0
+        mov     x27, v5.D[0]
+        str     x27, [$AddrReg2],#8
+        mov     w27, v5.S[2]
+        str     w27, [$AddrReg2],#4
+    ENDIF
+
+    ENDIF
+
+        MEND
+
+
+        MACRO
+        OutputRow8Element $Mode, $AddrReg1, $AddrReg2, $Vec1Reg, $Vec2Reg, $Vec3Reg, $Vec4Reg, $last_row
+
+    IF "$Mode"=="Add"
+        ldr     q8,[$AddrReg1],#0
+    IF $last_row == 0
+        ldr     q9,[$AddrReg2],#0
+    ELSE
+        mov     x27,#0
+        mov     v9.D[0],x27
+        mov     v9.D[1],x27
+    ENDIF
+        uzp1    v4.2d,$Vec1Reg..2d,$Vec2Reg..2d
+        uzp2    v5.2d,$Vec1Reg..2d,$Vec2Reg..2d
+
+        add     v8.4s,v8.4s,v4.4s
+        add     v9.4s,v9.4s,v5.4s
+
+        str     q8,[$AddrReg1],#16
+    IF $last_row == 0
+        str     q9,[$AddrReg2],#16
+    ENDIF
+
+    ELSE
+        uzp1    v4.2d, $Vec1Reg..2d,$Vec2Reg..2d
+        uzp2    v5.2d, $Vec1Reg..2d,$Vec2Reg..2d
+
+        str     q4,[$AddrReg1],#16
+    IF $last_row == 0
+        str     q5,[$AddrReg2],#16
+    ENDIF
+
+    ENDIF
+
+        MEND
+
+
+        MACRO
+        OutputRow10Element $Mode, $AddrReg1, $AddrReg2, $Vec1Reg, $Vec2Reg, $Vec3Reg, $Vec4Reg, $last_row
+
+    IF "$Mode"=="Add"
+        ldr     q8,[$AddrReg1],#16
+        ldr     w28, [$AddrReg1],#-16
+
+    IF $last_row == 0
+        ldr     q9,[$AddrReg2],#16
+        ldr     w27,[$AddrReg2],#-16
+    ELSE
+        mov     x27,#0
+        mov     v9.D[0],x27
+        mov     v9.D[1],x27
+    ENDIF
+        uzp1    v4.2d,$Vec1Reg..2d,$Vec2Reg..2d
+        uzp2    v5.2d,$Vec1Reg..2d,$Vec2Reg..2d
+
+        add     v8.4s,v8.4s,v4.4s
+        add     v9.4s,v9.4s,v5.4s
+
+        str     q8,[$AddrReg1],#16
+    IF $last_row == 0
+        str     q9,[$AddrReg2],#16
+    ENDIF
+        mov     v8.S[0], w28
+        mov     v8.S[2], w27
+
+        add     v8.4s,v8.4s,$Vec3Reg..4s
+
+        mov     w27, v8.S[0]
+        mov     w28, v8.S[2]
+
+        str     w27, [$AddrReg1],#4
+    IF $last_row == 0
+        str     w28, [$AddrReg2],#4
+    ENDIF
+
+    ELSE
+        uzp1    v4.2d, $Vec1Reg..2d,$Vec2Reg..2d
+        uzp2    v5.2d, $Vec1Reg..2d,$Vec2Reg..2d
+
+        str     q4,[$AddrReg1],#16
+    IF $last_row == 0
+        str     q5,[$AddrReg2],#16
+    ENDIF
+        mov     w27, $Vec3Reg..S[0]
+        mov     w28, $Vec3Reg..S[2]
+
+        str     w27, [$AddrReg1],#4
+    IF $last_row == 0
+        str     w28, [$AddrReg2],#4
+    ENDIF
+    ENDIF
+
+        MEND
+
+
+        MACRO
+        OutputRow12Element $Mode, $AddrReg1, $AddrReg2, $Vec1Reg, $Vec2Reg, $Vec3Reg, $Vec4Reg, $last_row
+
+    IF "$Mode"=="Add"
+        ldr     q8,[$AddrReg1],#16
+        ldr     d10,[$AddrReg1],#-16
+    IF $last_row == 0
+        ldr     q9,[$AddrReg2],#16
+        ldr     d11,[$AddrReg2],#-16
+    ELSE
+        mov     x27,#0
+        mov     v9.D[0],x27
+        mov     v9.D[1],x27
+        mov     v11.D[0],x27
+    ENDIF
+        uzp1    v4.2d,$Vec1Reg..2d,$Vec2Reg..2d
+        uzp2    v5.2d,$Vec1Reg..2d,$Vec2Reg..2d
+
+        add     v8.4s,v8.4s,v4.4s
+        add     v9.4s,v9.4s,v5.4s
+
+        str     q8,[$AddrReg1],#16
+    IF $last_row == 0
+        str     q9,[$AddrReg2],#16
+    ENDIF
+
+        mov     v10.D[1], v11.D[0]
+
+        add     v10.4s,v10.4s,$Vec3Reg..4s
+
+        mov     x27, v10.D[0]
+        mov     x28, v10.D[1]
+
+        str     x27, [$AddrReg1],#8
+    IF $last_row == 0
+        str     x28, [$AddrReg2],#8
+    ENDIF
+
+    ELSE
+        uzp1    v4.2d, $Vec1Reg..2d,$Vec2Reg..2d
+        uzp2    v5.2d, $Vec1Reg..2d,$Vec2Reg..2d
+
+        str     q4,[$AddrReg1],#16
+    IF $last_row == 0
+        str     q5,[$AddrReg2],#16
+    ENDIF
+        mov     x27, $Vec3Reg..D[0]
+        mov     x28, $Vec3Reg..D[1]
+
+        str     x27, [$AddrReg1],#8
+    IF $last_row == 0
+        str     x28, [$AddrReg2],#8
+    ENDIF
+    ENDIF
+
+        MEND
+
+        MACRO
+        OutputRow14Element $Mode, $AddrReg1, $AddrReg2, $Vec1Reg, $Vec2Reg, $Vec3Reg, $Vec4Reg, $last_row
+
+    IF "$Mode"=="Add"
+        ldr     q8,[$AddrReg1],#16
+        ldr     d10,[$AddrReg1],#8
+        ldr     w28, [$AddrReg1],#-24
+        mov     v10.S[2], w28
+    IF $last_row == 0
+        ldr     q9,[$AddrReg2],#16
+        ldr     d11,[$AddrReg2],#8
+        ldr     w27,[$AddrReg2],#-24
+        mov     v11.S[2], w27
+    ELSE
+        mov     x27,#0
+        mov     v9.D[0],x27
+        mov     v9.D[1],x27
+
+        mov     v11.D[0],x27
+        mov     v11.D[1],x27
+    ENDIF
+        uzp1    v4.2d,$Vec1Reg..2d,$Vec2Reg..2d
+        uzp2    v5.2d,$Vec1Reg..2d,$Vec2Reg..2d
+
+        uzp1    v6.2d, $Vec3Reg..2d,$Vec4Reg..2d
+        uzp2    v7.2d, $Vec3Reg..2d,$Vec4Reg..2d
+
+        add     v8.4s,v8.4s,v4.4s
+        add     v9.4s,v9.4s,v5.4s
+        add     v10.4s,v10.4s,v6.4s
+        add     v11.4s,v11.4s,v7.4s
+
+        str     q8,[$AddrReg1],#16
+
+        mov     x27, v10.D[0]
+        str     x27, [$AddrReg1],#8
+        mov     w27, v10.S[2]
+        str     w27, [$AddrReg1],#4
+
+    IF $last_row == 0
+        str     q9,[$AddrReg2],#16
+        mov     x27, v11.D[0]
+        str     x27, [$AddrReg2],#8
+        mov     w27, v11.S[2]
+        str     w27, [$AddrReg2],#4
+    ENDIF
+
+    ELSE
+        uzp1    v4.2d, $Vec1Reg..2d,$Vec2Reg..2d
+        uzp2    v5.2d, $Vec1Reg..2d,$Vec2Reg..2d
+        uzp1    v6.2d, $Vec3Reg..2d,$Vec4Reg..2d
+        uzp2    v7.2d, $Vec3Reg..2d,$Vec4Reg..2d
+
+        str     q4,[$AddrReg1],#16
+        mov     x27, v6.D[0]
+        str     x27, [$AddrReg1],#8
+        mov     w27, v6.S[2]
+        str     w27, [$AddrReg1],#4
+
+    IF $last_row == 0
+        str     q5,[$AddrReg2],#16
+        mov     x27, v7.D[0]
+        str     x27, [$AddrReg2],#8
+        mov     w27, v7.S[2]
+        str     w27, [$AddrReg2],#4
+    ENDIF
+    ENDIF
+
+        MEND
+
+
+        MACRO
+        OutputRow16Element $Mode, $AddrReg1, $AddrReg2, $Vec1Reg, $Vec2Reg, $Vec3Reg, $Vec4Reg, $last_row
+
+    IF "$Mode"=="Add"
+        ldp     q8,q10,[$AddrReg1],#0
+    IF $last_row == 0
+        ldp     q9,q11,[$AddrReg2],#0
+    ELSE
+        mov     x27,#0
+        mov     v9.D[0],x27
+        mov     v9.D[1],x27
+
+        mov     v11.D[0],x27
+        mov     v11.D[1],x27
+    ENDIF
+        uzp1    v4.2d,$Vec1Reg..2d,$Vec2Reg..2d
+        uzp2    v5.2d,$Vec1Reg..2d,$Vec2Reg..2d
+
+        uzp1    v6.2d, $Vec3Reg..2d,$Vec4Reg..2d
+        uzp2    v7.2d, $Vec3Reg..2d,$Vec4Reg..2d
+
+        add     v8.4s,v8.4s,v4.4s
+        add     v9.4s,v9.4s,v5.4s
+        add     v10.4s,v10.4s,v6.4s
+        add     v11.4s,v11.4s,v7.4s
+
+        stp     q8,q10,[$AddrReg1],#32
+    IF $last_row == 0
+        stp     q9,q11,[$AddrReg2],#32
+    ENDIF
+    ELSE
+        uzp1    v4.2d, $Vec1Reg..2d,$Vec2Reg..2d
+        uzp2    v5.2d, $Vec1Reg..2d,$Vec2Reg..2d
+        uzp1    v6.2d, $Vec3Reg..2d,$Vec4Reg..2d
+        uzp2    v7.2d, $Vec3Reg..2d,$Vec4Reg..2d
+
+        stp     q4,q6,[$AddrReg1],#32
+    IF $last_row == 0
+        stp     q5,q7,[$AddrReg2],#32
+    ENDIF
+    ENDIF
+
+        MEND
+
+;
+; OutputBlock
+;
+; Generates the code to store the output block.
+;
+
+        MACRO
+        OutputBlock $Mode, $Columns, $Rows
+
+    IF $Rows == 1
+        OutputRow$Columns.Element $Mode,x2,x13,v16,v17,v18,v19,1
+    ELSE
+        OutputRow$Columns.Element $Mode,x2,x13,v16,v17,v18,v19,0
+    ENDIF
+
+    IF $Rows > 2
+    IF $Rows == 3
+        OutputRow$Columns.Element $Mode,x14,x15,v20,v21,v22,v23,1
+    ELSE
+        OutputRow$Columns.Element $Mode,x14,x15,v20,v21,v22,v23,0
+    ENDIF
+    ENDIF
+
+    IF $Rows > 4
+    IF $Rows == 5
+        OutputRow$Columns.Element $Mode,x16,x17,v24,v25,v26,v27,1
+    ELSE
+        OutputRow$Columns.Element $Mode,x16,x17,v24,v25,v26,v27,0
+    ENDIF
+    ENDIF
+
+    IF $Rows > 6
+    IF $Rows == 7
+        OutputRow$Columns.Element $Mode,x12,x19,v28,v29,v30,v31,1
+    ELSE
+        OutputRow$Columns.Element $Mode,x12,x19,v28,v29,v30,v31,0
+    ENDIF
+    ENDIF
+
+        MEND
+;
+; ProcessRows
+;
+; Generates the code to process a compute and store the output block for a
+; fixed number of rows.
+;
+
+        MACRO
+        ProcessRows $Mode, $Rows
+        mov     x4,#$Rows ; return number of rows handled
+        cmp     x5,#6
+        ble     $Mode.ProcessNextColumnLoop6x$Rows
+
+$Mode.ProcessNextColumnLoop8x$Rows
+        ComputeBlockLoop $Mode, 8, $Rows
+
+        sub     x5,x5,#8
+        cmp     x5,#0
+        blt     $Mode.Output14ElementsOnlyFor$Rows
+        OutputBlock $Mode, 16, $Rows
+        mov     x0,x8 ; reload matrix A
+        cmp     x5,#6
+        bgt     $Mode.ProcessNextColumnLoop8x$Rows
+        cbz     x5,$Mode.ExitKernel
+
+$Mode.ProcessNextColumnLoop6x$Rows
+
+        cmp     x5,#4
+        ble     $Mode.ProcessNextColumnLoop4x$Rows
+        ComputeBlockLoop $Mode, 6, $Rows
+        sub     x5,x5,#6
+        cmp     x5,#0
+        blt     $Mode.Output10ElementsOnlyFor$Rows
+        OutputBlock $Mode, 12, $Rows
+        mov     x0,x8 ; reload matrix A
+        cmp     x5,#4
+        bgt     $Mode.ProcessNextColumnLoop6x$Rows
+        b       $Mode.ExitKernel
+
+$Mode.ProcessNextColumnLoop4x$Rows
+        cmp     x5,#2
+        ble     $Mode.ProcessNextColumnLoop2x$Rows
+        ComputeBlockLoop $Mode, 4, $Rows
+        sub     x5,x5,#4
+        cmp     x5,#0
+        blt     $Mode.Output6ElementsOnlyFor$Rows
+        OutputBlock $Mode, 8, $Rows
+        mov     x0,x8 ; reload matrix A
+        cmp     x5,#2
+        bgt     $Mode.ProcessNextColumnLoop4x$Rows
+        b       $Mode.ExitKernel
+
+$Mode.ProcessNextColumnLoop2x$Rows
+        ComputeBlockLoop $Mode, 2, $Rows
+        sub     x5,x5,#2
+        cmp     x5,#0
+        blt     $Mode.Output2ElementsOnlyFor$Rows
+        OutputBlock $Mode, 4, $Rows
+        mov     x0,x8 ; reload matrix A
+        cmp     x5,#2
+        b       $Mode.ExitKernel
+
+$Mode.Output14ElementsOnlyFor$Rows
+	OutputBlock $Mode, 14, $Rows
+        b       $Mode.ExitKernel
+
+
+$Mode.Output10ElementsOnlyFor$Rows
+        OutputBlock $Mode, 10, $Rows
+        b       $Mode.ExitKernel
+
+
+$Mode.Output6ElementsOnlyFor$Rows
+        OutputBlock $Mode, 6, $Rows
+        b       $Mode.ExitKernel
+
+
+$Mode.Output2ElementsOnlyFor$Rows
+        OutputBlock $Mode, 2, $Rows
+        b       $Mode.ExitKernel
+
+
+
+        MEND
+
+
+;++
+;
+; Routine Description:
+;
+;     This routine is an inner kernel to compute matrix multiplication for a
+;     set of rows.
+;
+; Arguments:
+;
+;     A (x0) - Supplies the address of matrix A. The matrix data has been packed
+;         using MlasGemmQuantCopyPackA<MLAS_GEMM_S8S8_KERNEL_SMMLA>.
+;
+;     B (x1) - Supplies the address of matrix B. The matrix data has been packed
+;         using MlasGemmQuantCopyPackB<MLAS_GEMM_S8S8_KERNEL_SMMLA>.
+;
+;     C (x2) - Supplies the address of matrix C.
+;
+;     PackedCountK (x3) - Supplies the number of packed columns from matrix A and
+;         the number of packed rows from matrix B to iterate over.
+;
+;     CountM (x4) - Supplies the maximum number of rows that can be processed for
+;         matrix A and matrix C. The actual number of rows handled for this
+;         invocation depends on the kernel implementation.
+;
+;     CountN (x5) - Supplies the number of columns from matrix B and matrix C to
+;         iterate over.
+;
+;     ldc (x6) - Supplies the first dimension of matrix C.
+;
+;     RowSumBuffer (x7) - Supplies the sum of each row from matrix A. These values
+;         have been pre-scaled by the zero point offset of matrix B if the offset
+;         is per-tensor (ZeroPointB is nullptr). Otherwise, these values must be
+;         scaled by the per-column zero point offsets of matrix B. These values are
+;         accumulated into every row of matrix C.
+;
+;     ColumnSumBuffer - Supplies the sum of each column from matrix B multiplied
+;         by the zero point offset of matrix A. These values are accumulated into
+;         every column of matrix C.
+;
+;     ZeroPointB - Optionally supplies the per-column zero point offsets of matrix
+;         B, else nullptr if the matrix B is using per-tensor quantization.
+;
+; Return Value:
+;
+;     Returns the number of rows handled.
+;
+;--
+
+        MACRO
+        QgemmS8S8KernelSmmlaFunction $Mode
+
+        NESTED_ENTRY MlasGemmS8S8KernelSmmla$Mode
+
+        ldr     x10,[sp, #0]
+        ldr     x11,[sp,#8]
+        PROLOG_SAVE_REG_PAIR x19, x20, #-MlasQgemmKernel_SavedRegisters!
+        PROLOG_SAVE_REG_PAIR x21, x22, #MlasQgemmKernel_backup_x21_x22
+        PROLOG_SAVE_REG_PAIR x23, x24, #MlasQgemmKernel_backup_x23_x24
+        PROLOG_SAVE_REG_PAIR x25, x26, #MlasQgemmKernel_backup_x25_x26
+        PROLOG_SAVE_REG_PAIR x27, x28, #MlasQgemmKernel_backup_x27_x28
+        PROLOG_SAVE_REG_PAIR d8, d9, #MlasQgemmKernel_backup_d8_d9
+        PROLOG_SAVE_REG_PAIR d10, d11, #MlasQgemmKernel_backup_d10_d11
+        PROLOG_SAVE_REG_PAIR d12, d13, #MlasQgemmKernel_backup_d12_d13
+        PROLOG_SAVE_REG_PAIR d14, d15, #MlasQgemmKernel_backup_d14_d15
+
+        add     x13,x2,x6,lsl #2 ; compute matrix C plus 1 row
+        add     x14,x13,x6,lsl #2 ; compute matrix C plus 2 rows
+        add     x15,x14,x6,lsl #2 ; compute matrix C plus 3 rows
+        add     x16,x15,x6,lsl #2 ; compute matrix C plus 4 rows
+        add     x17,x16,x6,lsl #2 ; compute matrix C plus 5 rows
+        add     x12,x17,x6,lsl #2 ; compute matrix C plus 6 rows
+        add     x19,x12,x6,lsl #2 ; compute matrix C plus 7 rows
+
+        mov     x8,x0 ; save matrix A
+
+;
+; Process 8 rows of the matrices.
+;
+        ld1     {v12.4s},[x7],#16 ; load row sum 1 ~ 4
+        cmp     x4,#8
+        blt     $Mode.ProcessCountMLessThan8
+        ld1     {v13.4s},[x7],#16 ; load row sum 5 ~ 8
+        ProcessRows $Mode, 8
+
+;
+; Restore non-volatile registers and return.
+;
+
+$Mode.ExitKernel
+        mov     x0,x4
+        EPILOG_RESTORE_REG_PAIR d14, d15, #MlasQgemmKernel_backup_d14_d15
+        EPILOG_RESTORE_REG_PAIR d12, d13, #MlasQgemmKernel_backup_d12_d13
+        EPILOG_RESTORE_REG_PAIR d10, d11, #MlasQgemmKernel_backup_d10_d11
+        EPILOG_RESTORE_REG_PAIR d8, d9, #MlasQgemmKernel_backup_d8_d9
+        EPILOG_RESTORE_REG_PAIR x27, x28, #MlasQgemmKernel_backup_x27_x28
+        EPILOG_RESTORE_REG_PAIR x25, x26, #MlasQgemmKernel_backup_x25_x26
+        EPILOG_RESTORE_REG_PAIR x23, x24, #MlasQgemmKernel_backup_x23_x24
+        EPILOG_RESTORE_REG_PAIR x21, x22, #MlasQgemmKernel_backup_x21_x22
+        EPILOG_RESTORE_REG_PAIR x19, x20, #MlasQgemmKernel_SavedRegisters!
+        EPILOG_RETURN
+;
+; Process 4 rows of the matrix.
+;
+
+$Mode.ProcessCountMLessThan8
+        cmp     x4,#4
+        blt     $Mode.ProcessCountMLessThan4
+        ProcessRows $Mode, 4
+        b       $Mode.ExitKernel
+
+;
+; Process 2 row of the matrix.
+;
+
+$Mode.ProcessCountMLessThan4
+        cmp     x4,#2
+        blt     $Mode.ProcessCountMLessThan2
+
+        ProcessRows $Mode, 2
+        b       $Mode.ExitKernel
+
+
+;
+; Process the last row of the matrix.
+;
+
+$Mode.ProcessCountMLessThan2
+        ProcessRows $Mode, 1
+        b       $Mode.ExitKernel
+
+
+
+        NESTED_END
+        MEND
+
+        QgemmS8S8KernelSmmlaFunction Zero
+        QgemmS8S8KernelSmmlaFunction Add
+        END

--- a/onnxruntime/core/mlas/lib/arm64/QgemmU8X8KernelUmmla.asm
+++ b/onnxruntime/core/mlas/lib/arm64/QgemmU8X8KernelUmmla.asm
@@ -1,0 +1,954 @@
+;++
+;
+; Copyright (c) Microsoft Corporation. All rights reserved.
+; Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+;
+; Licensed under the MIT License.
+;
+; Module Name:
+;
+;     QgemmU8X8KernelUmmla.s
+;
+; Abstract:
+;
+;     This module implements the kernels for the Int8 precision matrix/matrix
+;     multiply operation (QGEMM).
+;
+;--
+
+#include "kxarm64.h"
+
+        TEXTAREA
+
+;
+; Stack frame layout for the ummla kernel. d8-d15, x19-x30 need save
+;
+MlasQgemmKernel_backup_x19_x20 EQU 0
+MlasQgemmKernel_backup_x21_x22 EQU 16
+MlasQgemmKernel_backup_x23_x24 EQU 32
+MlasQgemmKernel_backup_x25_x26 EQU 48
+MlasQgemmKernel_backup_x27_x28 EQU 64
+MlasQgemmKernel_backup_d8_d9 EQU 80
+MlasQgemmKernel_backup_d10_d11 EQU 96
+MlasQgemmKernel_backup_d12_d13 EQU 112
+MlasQgemmKernel_backup_d14_d15 EQU 128
+MlasQgemmKernel_SavedRegisters EQU 144
+MlasQgemmKernel_SavedRegisters_Neg EQU -144
+
+
+;
+; Init Row Accumulators
+;
+; Generates the code to initialize the accumulators for a single row of the output
+; block.
+;
+;
+;  Accumulators are initialized to ZeroPointB * RowSum + ColumnSum
+;  x7 for RowSumsBuffer pointer
+;  x10 for ColumnSumBuffer pointer
+;  x11 for ZeroPointB buffer pointer
+;
+;  v12~v13 for RowSums values
+;  v14~v15 for ColumnSums values
+;  v0~v3 for ZeroPointB values
+;
+        MACRO
+        InitRowAccumulators $Columns, $Vec1Reg, $Vec2Reg, $Vec3Reg, $Vec4Reg, $RowSumReg
+
+        mul     v7.4s, $RowSumReg..4s, v8.4s
+        mov     $Vec1Reg..16b, v7.16b
+        add     $Vec1Reg..4s, $Vec1Reg..4s, v0.4s
+    IF $Columns > 2
+        mul     v7.4s, $RowSumReg..4s, v9.4s
+        mov     $Vec2Reg..16b, v7.16b
+        add     $Vec2Reg..4s, $Vec2Reg..4s, v1.4s
+    ENDIF
+    IF $Columns > 4
+        mul     v7.4s, $RowSumReg..4s, v10.4s
+        mov     $Vec3Reg..16b, v7.16b
+        add     $Vec3Reg..4s, $Vec3Reg..4s, v2.4s
+    ENDIF
+    IF $Columns > 6
+        mul     v7.4s, $RowSumReg..4s, v11.4s
+        mov     $Vec4Reg..16b, v7.16b
+        add     $Vec4Reg..4s, $Vec4Reg..4s, v3.4s
+    ENDIF
+
+        MEND
+
+
+;
+; InitBlockAccumulators
+;
+; Generates the code to initialize the accumulators for 8x8 output
+; block.
+;
+        MACRO
+        InitBlockAccumulators $Mode, $Columns, $Rows
+
+        ld1     {v14.4s},[x10],#16 ; load ColumnSumBuffer[0]
+    IF $Columns > 4
+        ld1     {v15.4s},[x10],#16 ; load ColumnSumBuffer[4]
+    ENDIF
+        ; v4~v7 will be set to matrixB after this, so, they can used now
+        dup     v4.4s,v14.s[0] ; broadcast column
+        dup     v5.4s,v14.s[1]
+        dup     v6.4s,v14.s[2]
+        dup     v7.4s,v14.s[3]
+
+        zip1    v0.4s, v4.4s, v5.4s
+        zip2    v1.4s, v6.4s, v7.4s
+    IF $Columns > 4
+        dup     v4.4s,v15.s[0] ; broadcast column
+        dup     v5.4s,v15.s[1]
+        dup     v6.4s,v15.s[2]
+        dup     v7.4s,v15.s[3]
+
+        zip1    v2.4s, v4.4s, v5.4s
+        zip2    v3.4s, v6.4s, v7.4s
+    ENDIF
+
+        ; v8~v11 will anyway get set in MatrixA loading, so they are free to use now
+        movi    v8.4s, #1
+        movi    v9.4s, #1
+        movi    v10.4s, #1
+        movi    v11.4s, #1
+
+        cbz     x11,$Mode.InitBlock$Columns.x$Rows.SkipScaleByZeroPointB
+
+        ld1     {v4.4s},[x11],#16 ; load ZeroPointB[0]
+        ld1     {v5.4s},[x11],#16 ; load ZeroPointB[4]
+
+        dup     v6.4s, v4.s[0]
+        dup     v7.4s, v4.s[1]
+        zip1    v8.4s, v6.4s, v7.4s
+
+        dup     v6.4s, v4.s[2]
+        dup     v7.4s, v4.s[3]
+        zip1    v9.4s, v6.4s, v7.4s
+
+        dup     v6.4s, v5.s[0]
+        dup     v7.4s, v5.s[1]
+        zip1    v10.4s, v6.4s, v7.4s
+
+        dup     v6.4s, v5.s[2]
+        dup     v7.4s, v5.s[3]
+        zip1    v11.4s, v6.4s, v7.4s
+
+$Mode.InitBlock$Columns.x$Rows.SkipScaleByZeroPointB
+        dup     v4.4s, v12.s[0] ;boardcast RowSums
+        dup     v5.4s, v12.s[1]
+
+        uzp1    v6.2d, v4.2d, v5.2d
+
+        InitRowAccumulators $Columns, v16, v17, v18, v19, v6
+    IF $Rows > 2
+        dup     v4.4s, v12.s[2] ;boardcast RowSums
+        dup     v5.4s, v12.s[3]
+
+        uzp1    v6.2d, v4.2d, v5.2d
+
+        InitRowAccumulators $Columns, v20, v21, v22, v23, v6
+    ENDIF
+    IF $Rows > 4
+        dup     v4.4s,v13.s[0] ; broadcast row sums
+        dup     v5.4s,v13.s[1]
+
+        uzp1    v6.2d, v4.2d, v5.2d
+
+        InitRowAccumulators $Columns, v24, v25, v26, v27, v6
+    ENDIF
+    IF $Rows > 6
+        dup     v4.4s,v13.s[2] ; broadcast row sums
+        dup     v5.4s,v13.s[3]
+
+        uzp1    v6.2d, v4.2d, v5.2d
+        InitRowAccumulators $Columns, v28, v29, v30, v31, v6
+    ENDIF
+
+        MEND
+
+
+; LoadPackedMatrixABy16Elements
+;
+; Generates the code to load 16 elements from matrix A.
+;
+        MACRO
+        LoadPackedMatrixABy16Elements $Rows
+    IF $Rows == 1
+        ldr     q8,[x0],#8
+    ELSE
+        ldr     q8,[x0],#16
+
+    IF $Rows > 2
+        ldr     q9,[x0],#16
+    ENDIF
+
+    IF $Rows > 4
+        ldr     q10,[x0],#16
+    ENDIF
+
+    IF $Rows > 6
+        ldr     q11,[x0],#16
+    ENDIF
+    ENDIF
+        MEND
+
+
+;
+; MultiplyAccumulateRow
+;
+; Generates the code to multiply and accumulate a single row of the output
+; block.
+;
+
+        MACRO
+        MultiplyAccumulateRow $Columns, $MatrixAReg, $Vec1Reg, $Vec2Reg, $Vec3Reg, $Vec4Reg
+
+        ummla   $Vec1Reg..4s, $MatrixAReg..16b, v4.16b
+    IF $Columns > 2
+        ummla   $Vec2Reg..4s, $MatrixAReg..16b, v5.16b
+    ENDIF
+    IF $Columns > 4
+	ummla   $Vec3Reg..4s, $MatrixAReg..16b, v6.16b
+    ENDIF
+    IF $Columns > 6
+        ummla   $Vec4Reg..4s, $MatrixAReg..16b, v7.16b
+    ENDIF
+
+        MEND
+
+;
+; MultiplyAccumulateBlock
+;
+; Generates the code to multiply and accumulate into the output block.
+;
+
+        MACRO
+        MultiplyAccumulateBlock $Columns, $Rows
+
+        MultiplyAccumulateRow $Columns, v8, v16, v17, v18, v19
+    IF $Rows > 2
+        MultiplyAccumulateRow $Columns, v9, v20, v21, v22, v23
+    ENDIF
+    IF $Rows > 4
+        MultiplyAccumulateRow $Columns, v10, v24, v25, v26, v27
+    ENDIF
+    IF $Rows > 6
+        MultiplyAccumulateRow $Columns, v11, v28, v29, v30, v31
+    ENDIF
+
+        MEND
+
+;
+; ComputeBlockLoop
+;
+; Generates the code to loop over K entries of the input matrices to produce
+; the output block.
+;
+
+        MACRO
+        ComputeBlockLoop $Mode, $Columns, $Rows
+
+        InitBlockAccumulators $Mode, $Columns, $Rows
+
+        sub     x9,x3,#1 ;  block count to process
+        tbnz    x9,#63,$Mode.ProcessRemaining$Columns.x$Rows.Blocks
+
+$Mode.Compute$Columns.x$Rows.BlockBy4Loop
+
+        LoadPackedMatrixABy16Elements $Rows
+        ld1     {v4.16b - v7.16b}, [x1], #64
+        MultiplyAccumulateBlock $Columns, $Rows
+
+        sub     x9,x9,#1
+        tbz     x9,#63,$Mode.Compute$Columns.x$Rows.BlockBy4Loop
+$Mode.ProcessRemaining$Columns.x$Rows.Blocks
+        add     x9,x9,#1 ; correct for over-subtract above
+        cbz     x9,$Mode.Output$Columns.x$Rows.Block
+
+$Mode.Compute$Columns.x$Rows.BlockBy4PaddedLoop
+        LoadPackedMatrixABy16Elements $Rows
+        ld1     {v4.16b - v7.16b}, [x1], #64
+        MultiplyAccumulateBlock $Columns, $Rows
+
+$Mode.Output$Columns.x$Rows.Block
+
+        MEND
+
+
+;
+; OutputRow2Element
+; OutputRow4Element
+; OutputRow6Element
+; OutputRow8Element
+; OutputRow10Element
+; OutputRow12Element
+; OutputRow14Element
+; OutputRow16Element
+;
+; Generates the code to store elements to the output block.
+;
+
+        MACRO
+        OutputRow2Element $Mode, $AddrReg1, $AddrReg2, $Vec1Reg, $Vec2Reg, $Vec3Reg, $Vec4Reg, $last_row
+
+    IF "$Mode"=="Add"
+        ldr     s8,[$AddrReg1],#0
+    IF $last_row == 0
+        ldr     s9,[$AddrReg2],#0
+    ELSE
+        mov     x27,#0
+        mov     v9.D[0],x27
+        mov     v9.D[1],x27
+    ENDIF
+        mov     v8.S[2], v9.S[0]
+        add     v8.4s,v8.4s,$Vec1Reg..4s
+
+        mov     w27, v8.S[0]
+        str     w27, [$AddrReg1],#4
+
+    IF $last_row == 0
+        mov     w27, v8.S[2]
+        str     w27, [$AddrReg2],#4
+    ENDIF
+
+    ELSE
+        mov     w27, $Vec1Reg..S[0]
+        str     w27, [$AddrReg1],#4
+
+    IF $last_row == 0
+        mov    w27, $Vec1Reg..S[2]
+        str    w27, [$AddrReg2],#4
+    ENDIF
+
+    ENDIF
+
+        MEND
+
+
+        MACRO
+        OutputRow4Element $Mode, $AddrReg1, $AddrReg2, $Vec1Reg, $Vec2Reg, $Vec3Reg, $Vec4Reg, $last_row
+
+    IF "$Mode"=="Add"
+        ldr     d8,[$AddrReg1],#0
+    IF $last_row == 0
+        ldr     d9,[$AddrReg2],#0
+    ELSE
+        mov     x27,#0
+        mov     v9.D[0],x27
+        mov     v9.D[1],x27
+    ENDIF
+
+        mov     v8.D[1], v9.D[0]
+
+        add     v8.4s,v8.4s,$Vec1Reg..4s
+
+        mov     x27, v8.D[0]
+        mov     x28, v8.D[1]
+
+        str     x27, [$AddrReg1],#8
+    IF $last_row == 0
+        str     x28, [$AddrReg2],#8
+    ENDIF
+
+    ELSE
+        mov     x27, $Vec1Reg..D[0]
+        mov     x28, $Vec1Reg..D[1]
+
+        str     x27, [$AddrReg1],#8
+    IF $last_row == 0
+        str     x28, [$AddrReg2],#8
+    ENDIF
+
+    ENDIF
+
+        MEND
+
+
+        MACRO
+        OutputRow6Element $Mode, $AddrReg1, $AddrReg2, $Vec1Reg, $Vec2Reg, $Vec3Reg, $Vec4Reg, $last_row
+
+    IF "$Mode"=="Add"
+        ldr     d8,[$AddrReg1],#8
+        ldr     w28,[$AddrReg1],#-8
+        mov     v8.S[2], w28
+    IF $last_row == 0
+        ldr     d9,[$AddrReg2],#8
+        ldr     w27,[$AddrReg2],#-8
+        mov     v9.S[2], w27
+    ELSE
+        mov     x27,#0
+        mov     v9.D[0],x27
+        mov     v9.D[1],x27
+    ENDIF
+        uzp1    v4.2d,$Vec1Reg..2d,$Vec2Reg..2d
+        uzp2    v5.2d,$Vec1Reg..2d,$Vec2Reg..2d
+
+        add     v8.4s,v8.4s,v4.4s
+        add     v9.4s,v9.4s,v5.4s
+
+        mov     x27, v8.D[0]
+        str     x27, [$AddrReg1],#8
+        mov     w27, v8.S[2]
+        str     w27, [$AddrReg1],#4
+
+    IF $last_row == 0
+        mov     x27, v9.D[0]
+        str     x27, [$AddrReg2],#8
+        mov     w27, v9.S[2]
+        str     w27, [$AddrReg2],#4
+    ENDIF
+
+    ELSE
+        uzp1    v4.2d, $Vec1Reg..2d,$Vec2Reg..2d
+        uzp2    v5.2d, $Vec1Reg..2d,$Vec2Reg..2d
+
+        mov     x27, v4.D[0]
+        str     x27, [$AddrReg1],#8
+        mov     w27, v4.S[2]
+        str     w27, [$AddrReg1],#4
+
+    IF $last_row == 0
+        mov     x27, v5.D[0]
+        str     x27, [$AddrReg2],#8
+        mov     w27, v5.S[2]
+        str     w27, [$AddrReg2],#4
+    ENDIF
+
+    ENDIF
+
+        MEND
+
+
+        MACRO
+        OutputRow8Element $Mode, $AddrReg1, $AddrReg2, $Vec1Reg, $Vec2Reg, $Vec3Reg, $Vec4Reg, $last_row
+
+    IF "$Mode"=="Add"
+        ldr     q8,[$AddrReg1],#0
+    IF $last_row == 0
+        ldr     q9,[$AddrReg2],#0
+    ELSE
+        mov     x27,#0
+        mov     v9.D[0],x27
+        mov     v9.D[1],x27
+    ENDIF
+        uzp1    v4.2d,$Vec1Reg..2d,$Vec2Reg..2d
+        uzp2    v5.2d,$Vec1Reg..2d,$Vec2Reg..2d
+
+        add     v8.4s,v8.4s,v4.4s
+        add     v9.4s,v9.4s,v5.4s
+
+        str     q8,[$AddrReg1],#16
+    IF $last_row == 0
+        str     q9,[$AddrReg2],#16
+    ENDIF
+
+    ELSE
+        uzp1    v4.2d, $Vec1Reg..2d,$Vec2Reg..2d
+        uzp2    v5.2d, $Vec1Reg..2d,$Vec2Reg..2d
+
+        str     q4,[$AddrReg1],#16
+    IF $last_row == 0
+        str     q5,[$AddrReg2],#16
+    ENDIF
+
+    ENDIF
+
+        MEND
+
+
+        MACRO
+        OutputRow10Element $Mode, $AddrReg1, $AddrReg2, $Vec1Reg, $Vec2Reg, $Vec3Reg, $Vec4Reg, $last_row
+
+    IF "$Mode"=="Add"
+        ldr     q8,[$AddrReg1],#16
+        ldr     w28, [$AddrReg1],#-16
+
+    IF $last_row == 0
+        ldr     q9,[$AddrReg2],#16
+        ldr     w27,[$AddrReg2],#-16
+    ELSE
+        mov     x27,#0
+        mov     v9.D[0],x27
+        mov     v9.D[1],x27
+    ENDIF
+        uzp1    v4.2d,$Vec1Reg..2d,$Vec2Reg..2d
+        uzp2    v5.2d,$Vec1Reg..2d,$Vec2Reg..2d
+
+        add     v8.4s,v8.4s,v4.4s
+        add     v9.4s,v9.4s,v5.4s
+
+        str     q8,[$AddrReg1],#16
+    IF $last_row == 0
+        str     q9,[$AddrReg2],#16
+    ENDIF
+        mov     v8.S[0], w28
+        mov     v8.S[2], w27
+
+        add     v8.4s,v8.4s,$Vec3Reg..4s
+
+        mov     w27, v8.S[0]
+        mov     w28, v8.S[2]
+
+        str     w27, [$AddrReg1],#4
+    IF $last_row == 0
+        str     w28, [$AddrReg2],#4
+    ENDIF
+
+    ELSE
+        uzp1    v4.2d, $Vec1Reg..2d,$Vec2Reg..2d
+        uzp2    v5.2d, $Vec1Reg..2d,$Vec2Reg..2d
+
+        str     q4,[$AddrReg1],#16
+    IF $last_row == 0
+        str     q5,[$AddrReg2],#16
+    ENDIF
+        mov     w27, $Vec3Reg..S[0]
+        mov     w28, $Vec3Reg..S[2]
+
+        str     w27, [$AddrReg1],#4
+    IF $last_row == 0
+        str     w28, [$AddrReg2],#4
+    ENDIF
+    ENDIF
+
+        MEND
+
+
+        MACRO
+        OutputRow12Element $Mode, $AddrReg1, $AddrReg2, $Vec1Reg, $Vec2Reg, $Vec3Reg, $Vec4Reg, $last_row
+
+    IF "$Mode"=="Add"
+        ldr     q8,[$AddrReg1],#16
+        ldr     d10,[$AddrReg1],#-16
+    IF $last_row == 0
+        ldr     q9,[$AddrReg2],#16
+        ldr     d11,[$AddrReg2],#-16
+    ELSE
+        mov     x27,#0
+        mov     v9.D[0],x27
+        mov     v9.D[1],x27
+        mov     v11.D[0],x27
+    ENDIF
+        uzp1    v4.2d,$Vec1Reg..2d,$Vec2Reg..2d
+        uzp2    v5.2d,$Vec1Reg..2d,$Vec2Reg..2d
+
+        add     v8.4s,v8.4s,v4.4s
+        add     v9.4s,v9.4s,v5.4s
+
+        str     q8,[$AddrReg1],#16
+    IF $last_row == 0
+        str     q9,[$AddrReg2],#16
+    ENDIF
+
+        mov v10.D[1], v11.D[0]
+
+        add     v10.4s,v10.4s,$Vec3Reg..4s
+
+        mov     x27, v10.D[0]
+        mov     x28, v10.D[1]
+
+        str     x27, [$AddrReg1],#8
+    IF $last_row == 0
+        str     x28, [$AddrReg2],#8
+    ENDIF
+
+    ELSE
+        uzp1    v4.2d, $Vec1Reg..2d,$Vec2Reg..2d
+        uzp2    v5.2d, $Vec1Reg..2d,$Vec2Reg..2d
+
+        str     q4,[$AddrReg1],#16
+    IF $last_row == 0
+        str     q5,[$AddrReg2],#16
+    ENDIF
+        mov     x27, $Vec3Reg..D[0]
+        mov     x28, $Vec3Reg..D[1]
+
+        str     x27, [$AddrReg1],#8
+    IF $last_row == 0
+        str     x28, [$AddrReg2],#8
+    ENDIF
+    ENDIF
+
+        MEND
+
+        MACRO
+        OutputRow14Element $Mode, $AddrReg1, $AddrReg2, $Vec1Reg, $Vec2Reg, $Vec3Reg, $Vec4Reg, $last_row
+
+    IF "$Mode"=="Add"
+        ldr     q8,[$AddrReg1],#16
+        ldr     d10,[$AddrReg1],#8
+        ldr     w28, [$AddrReg1],#-24
+        mov     v10.S[2], w28
+    IF $last_row == 0
+        ldr     q9,[$AddrReg2],#16
+        ldr     d11,[$AddrReg2],#8
+        ldr     w27,[$AddrReg2],#-24
+        mov     v11.S[2], w27
+    ELSE
+        mov     x27,#0
+        mov     v9.D[0],x27
+        mov     v9.D[1],x27
+
+        mov     v11.D[0],x27
+        mov     v11.D[1],x27
+    ENDIF
+        uzp1    v4.2d,$Vec1Reg..2d,$Vec2Reg..2d
+        uzp2    v5.2d,$Vec1Reg..2d,$Vec2Reg..2d
+
+        uzp1    v6.2d, $Vec3Reg..2d,$Vec4Reg..2d
+        uzp2    v7.2d, $Vec3Reg..2d,$Vec4Reg..2d
+
+        add     v8.4s,v8.4s,v4.4s
+        add     v9.4s,v9.4s,v5.4s
+        add     v10.4s,v10.4s,v6.4s
+        add     v11.4s,v11.4s,v7.4s
+
+        str     q8,[$AddrReg1],#16
+
+        mov     x27, v10.D[0]
+        str     x27, [$AddrReg1],#8
+        mov     w27, v10.S[2]
+        str     w27, [$AddrReg1],#4
+
+    IF $last_row == 0
+        str     q9,[$AddrReg2],#16
+        mov     x27, v11.D[0]
+        str     x27, [$AddrReg2],#8
+        mov     w27, v11.S[2]
+        str     w27, [$AddrReg2],#4
+    ENDIF
+
+    ELSE
+        uzp1    v4.2d, $Vec1Reg..2d,$Vec2Reg..2d
+        uzp2    v5.2d, $Vec1Reg..2d,$Vec2Reg..2d
+        uzp1    v6.2d, $Vec3Reg..2d,$Vec4Reg..2d
+        uzp2    v7.2d, $Vec3Reg..2d,$Vec4Reg..2d
+
+        str     q4,[$AddrReg1],#16
+        mov     x27, v6.D[0]
+        str     x27, [$AddrReg1],#8
+        mov     w27, v6.S[2]
+        str     w27, [$AddrReg1],#4
+
+    IF $last_row == 0
+        str     q5,[$AddrReg2],#16
+        mov     x27, v7.D[0]
+        str     x27, [$AddrReg2],#8
+        mov     w27, v7.S[2]
+        str     w27, [$AddrReg2],#4
+    ENDIF
+    ENDIF
+
+        MEND
+
+
+        MACRO
+        OutputRow16Element $Mode, $AddrReg1, $AddrReg2, $Vec1Reg, $Vec2Reg, $Vec3Reg, $Vec4Reg, $last_row
+
+    IF "$Mode"=="Add"
+        ldp     q8,q10,[$AddrReg1],#0
+    IF $last_row == 0
+        ldp     q9,q11,[$AddrReg2],#0
+    ELSE
+        mov     x27,#0
+        mov     v9.D[0],x27
+        mov     v9.D[1],x27
+
+        mov     v11.D[0],x27
+        mov     v11.D[1],x27
+    ENDIF
+        uzp1    v4.2d,$Vec1Reg..2d,$Vec2Reg..2d
+        uzp2    v5.2d,$Vec1Reg..2d,$Vec2Reg..2d
+
+        uzp1    v6.2d, $Vec3Reg..2d,$Vec4Reg..2d
+        uzp2    v7.2d, $Vec3Reg..2d,$Vec4Reg..2d
+
+        add     v8.4s,v8.4s,v4.4s
+        add     v9.4s,v9.4s,v5.4s
+        add     v10.4s,v10.4s,v6.4s
+        add     v11.4s,v11.4s,v7.4s
+
+        stp     q8,q10,[$AddrReg1],#32
+    IF $last_row == 0
+        stp     q9,q11,[$AddrReg2],#32
+    ENDIF
+    ELSE
+        uzp1    v4.2d, $Vec1Reg..2d,$Vec2Reg..2d
+        uzp2    v5.2d, $Vec1Reg..2d,$Vec2Reg..2d
+        uzp1    v6.2d, $Vec3Reg..2d,$Vec4Reg..2d
+        uzp2    v7.2d, $Vec3Reg..2d,$Vec4Reg..2d
+
+        stp     q4,q6,[$AddrReg1],#32
+    IF $last_row == 0
+        stp     q5,q7,[$AddrReg2],#32
+    ENDIF
+    ENDIF
+
+        MEND
+
+;
+; OutputBlock
+;
+; Generates the code to store the output block.
+;
+
+        MACRO
+        OutputBlock $Mode, $Columns, $Rows
+
+    IF $Rows == 1
+        OutputRow$Columns.Element $Mode,x2,x13,v16,v17,v18,v19,1
+    ELSE
+        OutputRow$Columns.Element $Mode,x2,x13,v16,v17,v18,v19,0
+    ENDIF
+
+    IF $Rows > 2
+    IF $Rows == 3
+        OutputRow$Columns.Element $Mode,x14,x15,v20,v21,v22,v23,1
+    ELSE
+        OutputRow$Columns.Element $Mode,x14,x15,v20,v21,v22,v23,0
+    ENDIF
+    ENDIF
+
+    IF $Rows > 4
+    IF $Rows == 5
+        OutputRow$Columns.Element $Mode,x16,x17,v24,v25,v26,v27,1
+    ELSE
+        OutputRow$Columns.Element $Mode,x16,x17,v24,v25,v26,v27,0
+    ENDIF
+    ENDIF
+
+    IF $Rows > 6
+    IF $Rows == 7
+        OutputRow$Columns.Element $Mode,x12,x19,v28,v29,v30,v31,1
+    ELSE
+        OutputRow$Columns.Element $Mode,x12,x19,v28,v29,v30,v31,0
+    ENDIF
+    ENDIF
+
+        MEND
+;
+; ProcessRows
+;
+; Generates the code to process a compute and store the output block for a
+; fixed number of rows.
+;
+
+        MACRO
+        ProcessRows $Mode, $Rows
+        mov     x4,#$Rows ; return number of rows handled
+        cmp     x5,#6
+        ble     $Mode.ProcessNextColumnLoop6x$Rows
+
+$Mode.ProcessNextColumnLoop8x$Rows
+        ComputeBlockLoop $Mode, 8, $Rows
+
+        sub     x5,x5,#8
+        cmp     x5,#0
+        blt     $Mode.Output14ElementsOnlyFor$Rows
+        OutputBlock $Mode, 16, $Rows
+        mov     x0,x8 ; reload matrix A
+        cmp     x5,#6
+        bgt     $Mode.ProcessNextColumnLoop8x$Rows
+        cbz     x5,$Mode.ExitKernel
+
+$Mode.ProcessNextColumnLoop6x$Rows
+
+        cmp     x5,#4
+        ble     $Mode.ProcessNextColumnLoop4x$Rows
+        ComputeBlockLoop $Mode, 6, $Rows
+        sub     x5,x5,#6
+        cmp     x5,#0
+        blt     $Mode.Output10ElementsOnlyFor$Rows
+        OutputBlock $Mode, 12, $Rows
+        mov     x0,x8 ; reload matrix A
+        cmp     x5,#4
+        bgt     $Mode.ProcessNextColumnLoop6x$Rows
+        b       $Mode.ExitKernel
+
+$Mode.ProcessNextColumnLoop4x$Rows
+        cmp     x5,#2
+        ble     $Mode.ProcessNextColumnLoop2x$Rows
+        ComputeBlockLoop $Mode, 4, $Rows
+        sub     x5,x5,#4
+        cmp     x5,#0
+        blt     $Mode.Output6ElementsOnlyFor$Rows
+        OutputBlock $Mode, 8, $Rows
+        mov     x0,x8 ; reload matrix A
+        cmp     x5,#2
+        bgt     $Mode.ProcessNextColumnLoop4x$Rows
+        b       $Mode.ExitKernel
+
+$Mode.ProcessNextColumnLoop2x$Rows
+        ComputeBlockLoop $Mode, 2, $Rows
+        sub     x5,x5,#2
+        cmp     x5,#0
+        blt     $Mode.Output2ElementsOnlyFor$Rows
+        OutputBlock $Mode, 4, $Rows
+        mov     x0,x8 ; reload matrix A
+        cmp     x5,#2
+        b       $Mode.ExitKernel
+
+$Mode.Output14ElementsOnlyFor$Rows
+	OutputBlock $Mode, 14, $Rows
+        b       $Mode.ExitKernel
+
+
+$Mode.Output10ElementsOnlyFor$Rows
+        OutputBlock $Mode, 10, $Rows
+        b       $Mode.ExitKernel
+
+
+$Mode.Output6ElementsOnlyFor$Rows
+        OutputBlock $Mode, 6, $Rows
+        b       $Mode.ExitKernel
+
+
+$Mode.Output2ElementsOnlyFor$Rows
+        OutputBlock $Mode, 2, $Rows
+        b       $Mode.ExitKernel
+
+
+
+        MEND
+
+
+;++
+;
+; Routine Description:
+;
+;     This routine is an inner kernel to compute matrix multiplication for a
+;     set of rows.
+;
+; Arguments:
+;
+;     A (x0) - Supplies the address of matrix A. The matrix data has been packed
+;         using MlasGemmQuantCopyPackA<MLAS_GEMM_U8X8_KERNEL_UMMLA>.
+;
+;     B (x1) - Supplies the address of matrix B. The matrix data has been packed
+;         using MlasGemmQuantCopyPackB<MLAS_GEMM_U8X8_KERNEL_UMMLA>.
+;
+;     C (x2) - Supplies the address of matrix C.
+;
+;     PackedCountK (x3) - Supplies the number of packed columns from matrix A and
+;         the number of packed rows from matrix B to iterate over.
+;
+;     CountM (x4) - Supplies the maximum number of rows that can be processed for
+;         matrix A and matrix C. The actual number of rows handled for this
+;         invocation depends on the kernel implementation.
+;
+;     CountN (x5) - Supplies the number of columns from matrix B and matrix C to
+;         iterate over.
+;
+;     ldc (x6) - Supplies the first dimension of matrix C.
+;
+;     RowSumBuffer (x7) - Supplies the sum of each row from matrix A. These values
+;         have been pre-scaled by the zero point offset of matrix B if the offset
+;         is per-tensor (ZeroPointB is nullptr). Otherwise, these values must be
+;         scaled by the per-column zero point offsets of matrix B. These values are
+;         accumulated into every row of matrix C.
+;
+;     ColumnSumBuffer - Supplies the sum of each column from matrix B multiplied
+;         by the zero point offset of matrix A. These values are accumulated into
+;         every column of matrix C.
+;
+;     ZeroPointB - Optionally supplies the per-column zero point offsets of matrix
+;         B, else nullptr if the matrix B is using per-tensor quantization.
+;
+; Return Value:
+;
+;     Returns the number of rows handled.
+;
+;--
+
+        MACRO
+        QgemmU8X8KernelUmmlaFunction $Mode
+
+        NESTED_ENTRY MlasGemmU8X8KernelUmmla$Mode
+
+        ldr     x10,[sp, #0]
+        ldr     x11,[sp,#8]
+        PROLOG_SAVE_REG_PAIR x19, x20, #-MlasQgemmKernel_SavedRegisters!
+        PROLOG_SAVE_REG_PAIR x21, x22, #MlasQgemmKernel_backup_x21_x22
+        PROLOG_SAVE_REG_PAIR x23, x24, #MlasQgemmKernel_backup_x23_x24
+        PROLOG_SAVE_REG_PAIR x25, x26, #MlasQgemmKernel_backup_x25_x26
+        PROLOG_SAVE_REG_PAIR x27, x28, #MlasQgemmKernel_backup_x27_x28
+        PROLOG_SAVE_REG_PAIR d8, d9, #MlasQgemmKernel_backup_d8_d9
+        PROLOG_SAVE_REG_PAIR d10, d11, #MlasQgemmKernel_backup_d10_d11
+        PROLOG_SAVE_REG_PAIR d12, d13, #MlasQgemmKernel_backup_d12_d13
+        PROLOG_SAVE_REG_PAIR d14, d15, #MlasQgemmKernel_backup_d14_d15
+
+        add     x13,x2,x6,lsl #2 ; compute matrix C plus 1 row
+        add     x14,x13,x6,lsl #2 ; compute matrix C plus 2 rows
+        add     x15,x14,x6,lsl #2 ; compute matrix C plus 3 rows
+        add     x16,x15,x6,lsl #2 ; compute matrix C plus 4 rows
+        add     x17,x16,x6,lsl #2 ; compute matrix C plus 5 rows
+        add     x12,x17,x6,lsl #2 ; compute matrix C plus 6 rows
+        add     x19,x12,x6,lsl #2 ; compute matrix C plus 7 rows
+
+        mov     x8,x0 ; save matrix A
+
+;
+; Process 8 rows of the matrices.
+;
+        ld1     {v12.4s},[x7],#16 ; load row sum 1 ~ 4
+        cmp     x4,#8
+        blt     $Mode.ProcessCountMLessThan8
+        ld1     {v13.4s},[x7],#16 ; load row sum 5 ~ 8
+        ProcessRows $Mode, 8
+
+;
+; Restore non-volatile registers and return.
+;
+
+$Mode.ExitKernel
+        mov     x0,x4
+        EPILOG_RESTORE_REG_PAIR d14, d15, #MlasQgemmKernel_backup_d14_d15
+        EPILOG_RESTORE_REG_PAIR d12, d13, #MlasQgemmKernel_backup_d12_d13
+        EPILOG_RESTORE_REG_PAIR d10, d11, #MlasQgemmKernel_backup_d10_d11
+        EPILOG_RESTORE_REG_PAIR d8, d9, #MlasQgemmKernel_backup_d8_d9
+        EPILOG_RESTORE_REG_PAIR x27, x28, #MlasQgemmKernel_backup_x27_x28
+        EPILOG_RESTORE_REG_PAIR x25, x26, #MlasQgemmKernel_backup_x25_x26
+        EPILOG_RESTORE_REG_PAIR x23, x24, #MlasQgemmKernel_backup_x23_x24
+        EPILOG_RESTORE_REG_PAIR x21, x22, #MlasQgemmKernel_backup_x21_x22
+        EPILOG_RESTORE_REG_PAIR x19, x20, #MlasQgemmKernel_SavedRegisters!
+        EPILOG_RETURN
+;
+; Process 4 rows of the matrix.
+;
+
+$Mode.ProcessCountMLessThan8
+        cmp     x4,#4
+        blt     $Mode.ProcessCountMLessThan4
+        ProcessRows $Mode, 4
+        b       $Mode.ExitKernel
+
+;
+; Process 2 row of the matrix.
+;
+
+$Mode.ProcessCountMLessThan4
+        cmp     x4,#2
+        blt     $Mode.ProcessCountMLessThan2
+
+        ProcessRows $Mode, 2
+        b       $Mode.ExitKernel
+
+
+;
+; Process the last row of the matrix.
+;
+
+$Mode.ProcessCountMLessThan2
+        ProcessRows $Mode, 1
+        b       $Mode.ExitKernel
+
+
+
+        NESTED_END
+        MEND
+
+        QgemmU8X8KernelUmmlaFunction Zero
+        QgemmU8X8KernelUmmlaFunction Add
+        END

--- a/onnxruntime/core/mlas/lib/arm64/SconvKernelNeon.asm
+++ b/onnxruntime/core/mlas/lib/arm64/SconvKernelNeon.asm
@@ -1,0 +1,925 @@
+;++
+; SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+; SPDX-License-Identifier: MIT
+; 
+; Module Name:
+;     SconvKernelNeon.S
+; 
+; Abstract:
+;     Hand written AArch64 vectorised kernel used by the convolution path
+;     (NCHW activations and NCHWc weights).  The kernel computes one output
+;     row and processes up to four 16-wide filter blocks (FilterCount <= 4).
+;     The hot interior loop avoids all bounds checks and the two-output path
+;     amortizes filter loads when possible.
+;--
+
+#include "kxarm64.h"
+
+        ; Stack layout for parameters passed on the stack.  The first eight
+        ; integer parameters follow the AArch64 calling convention and are in
+        ; x0-x7.  Remaining parameters are spilled by the C++ caller.
+
+LFrame_SavedRegs EQU (5*16 + 4*32 + 16 + 32)
+LFrame_x19_x20 EQU 0
+LFrame_x21_x22 EQU 16
+LFrame_x23_x24 EQU 32
+LFrame_x25_x26 EQU 48
+LFrame_x27_x28 EQU 64
+LFrame_q8_q9 EQU 80
+LFrame_q10_q11 EQU 112
+LFrame_q12_q13 EQU 144
+LFrame_q14_q15 EQU 176
+LFrame_InputBaseSaved EQU 208
+LFrame_FilterBaseSaved EQU 216
+LFrame_OutputBaseSaved EQU 224
+LFrame_LrSaved EQU 232
+
+KO_OutputStride EQU (0 + LFrame_SavedRegs)
+KO_KernelHeight EQU (8 + LFrame_SavedRegs)
+KO_KernelWidth EQU (16 + LFrame_SavedRegs)
+KO_InputBase EQU (24 + LFrame_SavedRegs)
+KO_InputWidth EQU (32 + LFrame_SavedRegs)
+KO_DilatedInputWidth EQU (40 + LFrame_SavedRegs)
+KO_OutputCountLeftPad EQU (48 + LFrame_SavedRegs)
+KO_OutputCount EQU (56 + LFrame_SavedRegs)
+KO_OutputCountRightPad EQU (64 + LFrame_SavedRegs)
+KO_Bias EQU (72 + LFrame_SavedRegs)
+KO_Flags EQU (80 + LFrame_SavedRegs)
+
+        TEXTAREA
+
+        ; ---------------------------------------------------------------------
+        ; Helper macros.
+        ; ---------------------------------------------------------------------
+
+        MACRO
+        CLEAR_ACCUM $N
+        eor     v0.16b,v0.16b,v0.16b
+        eor     v1.16b,v1.16b,v1.16b
+        eor     v2.16b,v2.16b,v2.16b
+        eor     v3.16b,v3.16b,v3.16b
+    IF $N >= 2
+        eor     v4.16b,v4.16b,v4.16b
+        eor     v5.16b,v5.16b,v5.16b
+        eor     v6.16b,v6.16b,v6.16b
+        eor     v7.16b,v7.16b,v7.16b
+    ENDIF
+    IF $N >= 3
+        eor     v8.16b,v8.16b,v8.16b
+        eor     v9.16b,v9.16b,v9.16b
+        eor     v10.16b,v10.16b,v10.16b
+        eor     v11.16b,v11.16b,v11.16b
+    ENDIF
+    IF $N >= 4
+        eor     v12.16b,v12.16b,v12.16b
+        eor     v13.16b,v13.16b,v13.16b
+        eor     v14.16b,v14.16b,v14.16b
+        eor     v15.16b,v15.16b,v15.16b
+    ENDIF
+        MEND
+
+        ; Post processing for a single output element working on N filter
+        ; blocks.  x27 points at output base for set0, x8 holds OutputStride
+        ; and x17 contains the Bias pointer for set0.  The zero vector is in
+        ; v31 and KernelFlags in w6.
+        MACRO
+        POSTPROCESS_STORE $Tag, $N
+        ; accumulate from existing output if requested
+        tbz     w6,#0,$Tag.Lnum1
+        ldr     q16,[x27]
+        ldr     q17,[x27,#16]
+        ldr     q18,[x27,#32]
+        ldr     q19,[x27,#48]
+        fadd    v0.4s,v0.4s,v16.4s
+        fadd    v1.4s,v1.4s,v17.4s
+        fadd    v2.4s,v2.4s,v18.4s
+        fadd    v3.4s,v3.4s,v19.4s
+    IF $N >= 2
+        add     x24,x27,x8
+        ldr     q16,[x24]
+        ldr     q17,[x24,#16]
+        ldr     q18,[x24,#32]
+        ldr     q19,[x24,#48]
+        fadd    v4.4s,v4.4s,v16.4s
+        fadd    v5.4s,v5.4s,v17.4s
+        fadd    v6.4s,v6.4s,v18.4s
+        fadd    v7.4s,v7.4s,v19.4s
+    ENDIF
+    IF $N >= 3
+        add     x24,x27,x8,lsl #1
+        ldr     q16,[x24]
+        ldr     q17,[x24,#16]
+        ldr     q18,[x24,#32]
+        ldr     q19,[x24,#48]
+        fadd    v8.4s,v8.4s,v16.4s
+        fadd    v9.4s,v9.4s,v17.4s
+        fadd    v10.4s,v10.4s,v18.4s
+        fadd    v11.4s,v11.4s,v19.4s
+    ENDIF
+    IF $N >= 4
+        add     x24,x27,x8
+        add     x24,x24,x8,lsl #1
+        ldr     q16,[x24]
+        ldr     q17,[x24,#16]
+        ldr     q18,[x24,#32]
+        ldr     q19,[x24,#48]
+        fadd    v12.4s,v12.4s,v16.4s
+        fadd    v13.4s,v13.4s,v17.4s
+        fadd    v14.4s,v14.4s,v18.4s
+        fadd    v15.4s,v15.4s,v19.4s
+    ENDIF
+$Tag.Lnum1
+        ; add bias
+        tbz     w6,#1,$Tag.Lnum2
+        ldr     q16,[x17]
+        ldr     q17,[x17,#16]
+        ldr     q18,[x17,#32]
+        ldr     q19,[x17,#48]
+        fadd    v0.4s,v0.4s,v16.4s
+        fadd    v1.4s,v1.4s,v17.4s
+        fadd    v2.4s,v2.4s,v18.4s
+        fadd    v3.4s,v3.4s,v19.4s
+    IF $N >= 2
+        add     x24,x17,#64
+        ldr     q16,[x24]
+        ldr     q17,[x24,#16]
+        ldr     q18,[x24,#32]
+        ldr     q19,[x24,#48]
+        fadd    v4.4s,v4.4s,v16.4s
+        fadd    v5.4s,v5.4s,v17.4s
+        fadd    v6.4s,v6.4s,v18.4s
+        fadd    v7.4s,v7.4s,v19.4s
+    ENDIF
+    IF $N >= 3
+        add     x24,x17,#128
+        ldr     q16,[x24]
+        ldr     q17,[x24,#16]
+        ldr     q18,[x24,#32]
+        ldr     q19,[x24,#48]
+        fadd    v8.4s,v8.4s,v16.4s
+        fadd    v9.4s,v9.4s,v17.4s
+        fadd    v10.4s,v10.4s,v18.4s
+        fadd    v11.4s,v11.4s,v19.4s
+    ENDIF
+    IF $N >= 4
+        add     x24,x17,#192
+        ldr     q16,[x24]
+        ldr     q17,[x24,#16]
+        ldr     q18,[x24,#32]
+        ldr     q19,[x24,#48]
+        fadd    v12.4s,v12.4s,v16.4s
+        fadd    v13.4s,v13.4s,v17.4s
+        fadd    v14.4s,v14.4s,v18.4s
+        fadd    v15.4s,v15.4s,v19.4s
+    ENDIF
+$Tag.Lnum2
+        ; optional ReLU
+        tbz     w6,#2,$Tag.Lnum3
+        fmax    v0.4s,v0.4s,v31.4s
+        fmax    v1.4s,v1.4s,v31.4s
+        fmax    v2.4s,v2.4s,v31.4s
+        fmax    v3.4s,v3.4s,v31.4s
+    IF $N >= 2
+        fmax    v4.4s,v4.4s,v31.4s
+        fmax    v5.4s,v5.4s,v31.4s
+        fmax    v6.4s,v6.4s,v31.4s
+        fmax    v7.4s,v7.4s,v31.4s
+    ENDIF
+    IF $N >= 3
+        fmax    v8.4s,v8.4s,v31.4s
+        fmax    v9.4s,v9.4s,v31.4s
+        fmax    v10.4s,v10.4s,v31.4s
+        fmax    v11.4s,v11.4s,v31.4s
+    ENDIF
+    IF $N >= 4
+        fmax    v12.4s,v12.4s,v31.4s
+        fmax    v13.4s,v13.4s,v31.4s
+        fmax    v14.4s,v14.4s,v31.4s
+        fmax    v15.4s,v15.4s,v31.4s
+    ENDIF
+$Tag.Lnum3
+        ; store results
+        str     q0,[x27]
+        str     q1,[x27,#16]
+        str     q2,[x27,#32]
+        str     q3,[x27,#48]
+    IF $N >= 2
+        add     x24,x27,x8
+        str     q4,[x24]
+        str     q5,[x24,#16]
+        str     q6,[x24,#32]
+        str     q7,[x24,#48]
+    ENDIF
+    IF $N >= 3
+        add     x24,x27,x8,lsl #1
+        str     q8,[x24]
+        str     q9,[x24,#16]
+        str     q10,[x24,#32]
+        str     q11,[x24,#48]
+    ENDIF
+    IF $N >= 4
+        add     x24,x27,x8
+        add     x24,x24,x8,lsl #1
+        str     q12,[x24]
+        str     q13,[x24,#16]
+        str     q14,[x24,#32]
+        str     q15,[x24,#48]
+    ENDIF
+        MEND
+
+        ; Two-output helpers --------------------------------------------------
+        MACRO
+        CLEAR_ACCUM2 $N
+        eor     v0.16b,v0.16b,v0.16b
+        eor     v1.16b,v1.16b,v1.16b
+        eor     v2.16b,v2.16b,v2.16b
+        eor     v3.16b,v3.16b,v3.16b
+        eor     v4.16b,v4.16b,v4.16b
+        eor     v5.16b,v5.16b,v5.16b
+        eor     v6.16b,v6.16b,v6.16b
+        eor     v7.16b,v7.16b,v7.16b
+    IF $N >= 2
+        eor     v8.16b,v8.16b,v8.16b
+        eor     v9.16b,v9.16b,v9.16b
+        eor     v10.16b,v10.16b,v10.16b
+        eor     v11.16b,v11.16b,v11.16b
+        eor     v12.16b,v12.16b,v12.16b
+        eor     v13.16b,v13.16b,v13.16b
+        eor     v14.16b,v14.16b,v14.16b
+        eor     v15.16b,v15.16b,v15.16b
+    ENDIF
+    IF $N >= 3
+        eor     v16.16b,v16.16b,v16.16b
+        eor     v17.16b,v17.16b,v17.16b
+        eor     v18.16b,v18.16b,v18.16b
+        eor     v19.16b,v19.16b,v19.16b
+        eor     v20.16b,v20.16b,v20.16b
+        eor     v21.16b,v21.16b,v21.16b
+        eor     v22.16b,v22.16b,v22.16b
+        eor     v23.16b,v23.16b,v23.16b
+    ENDIF
+        MEND
+
+        ; Post process helpers for the two-output interior kernel.  These are
+        ; written out-of-line as they are sizable and used in several places.
+        MACRO
+        POSTPROCESS_STORE2_1 $Tag
+        add     x24,x27,#64
+        ; accumulate
+        tbz     w6,#0,$Tag.Lnum1
+        ldr     q26,[x27]
+        ldr     q27,[x27,#16]
+        ldr     q28,[x27,#32]
+        ldr     q29,[x27,#48]
+        fadd    v0.4s,v0.4s,v26.4s
+        fadd    v1.4s,v1.4s,v27.4s
+        fadd    v2.4s,v2.4s,v28.4s
+        fadd    v3.4s,v3.4s,v29.4s
+        ldr     q26,[x24]
+        ldr     q27,[x24,#16]
+        ldr     q28,[x24,#32]
+        ldr     q29,[x24,#48]
+        fadd    v4.4s,v4.4s,v26.4s
+        fadd    v5.4s,v5.4s,v27.4s
+        fadd    v6.4s,v6.4s,v28.4s
+        fadd    v7.4s,v7.4s,v29.4s
+$Tag.Lnum1
+        ; bias
+        tbz     w6,#1,$Tag.Lnum2
+        ldr     q26,[x17]
+        ldr     q27,[x17,#16]
+        ldr     q28,[x17,#32]
+        ldr     q29,[x17,#48]
+        fadd    v0.4s,v0.4s,v26.4s
+        fadd    v1.4s,v1.4s,v27.4s
+        fadd    v2.4s,v2.4s,v28.4s
+        fadd    v3.4s,v3.4s,v29.4s
+        fadd    v4.4s,v4.4s,v26.4s
+        fadd    v5.4s,v5.4s,v27.4s
+        fadd    v6.4s,v6.4s,v28.4s
+        fadd    v7.4s,v7.4s,v29.4s
+$Tag.Lnum2
+        tbz     w6,#2,$Tag.Lnum3
+        fmax    v0.4s,v0.4s,v31.4s
+        fmax    v1.4s,v1.4s,v31.4s
+        fmax    v2.4s,v2.4s,v31.4s
+        fmax    v3.4s,v3.4s,v31.4s
+        fmax    v4.4s,v4.4s,v31.4s
+        fmax    v5.4s,v5.4s,v31.4s
+        fmax    v6.4s,v6.4s,v31.4s
+        fmax    v7.4s,v7.4s,v31.4s
+$Tag.Lnum3
+        str     q0,[x27]
+        str     q1,[x27,#16]
+        str     q2,[x27,#32]
+        str     q3,[x27,#48]
+        str     q4,[x24]
+        str     q5,[x24,#16]
+        str     q6,[x24,#32]
+        str     q7,[x24,#48]
+        MEND
+
+        MACRO
+        POSTPROCESS_STORE2_2 $Tag
+        ; Forward the enclosing tag rather than a fixed one: a hardcoded tag
+        ; here would emit the same labels every time this macro is expanded.
+        POSTPROCESS_STORE2_1 $Tag.ps
+        add     x24,x27,x8
+        add     x24,x24,#64
+        add     x27,x27,x8
+        tbz     w6,#0,$Tag.Lnum1
+        ldr     q26,[x27]
+        ldr     q27,[x27,#16]
+        ldr     q28,[x27,#32]
+        ldr     q29,[x27,#48]
+        fadd    v8.4s,v8.4s,v26.4s
+        fadd    v9.4s,v9.4s,v27.4s
+        fadd    v10.4s,v10.4s,v28.4s
+        fadd    v11.4s,v11.4s,v29.4s
+        ldr     q26,[x24]
+        ldr     q27,[x24,#16]
+        ldr     q28,[x24,#32]
+        ldr     q29,[x24,#48]
+        fadd    v12.4s,v12.4s,v26.4s
+        fadd    v13.4s,v13.4s,v27.4s
+        fadd    v14.4s,v14.4s,v28.4s
+        fadd    v15.4s,v15.4s,v29.4s
+$Tag.Lnum1
+        tbz     w6,#1,$Tag.Lnum2
+        add     x23,x17,#64
+        ldr     q26,[x23]
+        ldr     q27,[x23,#16]
+        ldr     q28,[x23,#32]
+        ldr     q29,[x23,#48]
+        fadd    v8.4s,v8.4s,v26.4s
+        fadd    v9.4s,v9.4s,v27.4s
+        fadd    v10.4s,v10.4s,v28.4s
+        fadd    v11.4s,v11.4s,v29.4s
+        fadd    v12.4s,v12.4s,v26.4s
+        fadd    v13.4s,v13.4s,v27.4s
+        fadd    v14.4s,v14.4s,v28.4s
+        fadd    v15.4s,v15.4s,v29.4s
+$Tag.Lnum2
+        tbz     w6,#2,$Tag.Lnum3
+        fmax    v8.4s,v8.4s,v31.4s
+        fmax    v9.4s,v9.4s,v31.4s
+        fmax    v10.4s,v10.4s,v31.4s
+        fmax    v11.4s,v11.4s,v31.4s
+        fmax    v12.4s,v12.4s,v31.4s
+        fmax    v13.4s,v13.4s,v31.4s
+        fmax    v14.4s,v14.4s,v31.4s
+        fmax    v15.4s,v15.4s,v31.4s
+$Tag.Lnum3
+        str     q8,[x27]
+        str     q9,[x27,#16]
+        str     q10,[x27,#32]
+        str     q11,[x27,#48]
+        str     q12,[x24]
+        str     q13,[x24,#16]
+        str     q14,[x24,#32]
+        str     q15,[x24,#48]
+        sub     x27,x27,x8
+        MEND
+
+        MACRO
+        POSTPROCESS_STORE2_3 $Tag
+        ; Forward the enclosing tag, as in POSTPROCESS_STORE2_2 above.
+        POSTPROCESS_STORE2_1 $Tag.ps
+        add     x24,x27,x8
+        add     x24,x24,#64
+        add     x27,x27,x8
+        tbz     w6,#0,$Tag.Lnum1
+        ldr     q26,[x27]
+        ldr     q27,[x27,#16]
+        ldr     q28,[x27,#32]
+        ldr     q29,[x27,#48]
+        fadd    v8.4s,v8.4s,v26.4s
+        fadd    v9.4s,v9.4s,v27.4s
+        fadd    v10.4s,v10.4s,v28.4s
+        fadd    v11.4s,v11.4s,v29.4s
+        ldr     q26,[x24]
+        ldr     q27,[x24,#16]
+        ldr     q28,[x24,#32]
+        ldr     q29,[x24,#48]
+        fadd    v12.4s,v12.4s,v26.4s
+        fadd    v13.4s,v13.4s,v27.4s
+        fadd    v14.4s,v14.4s,v28.4s
+        fadd    v15.4s,v15.4s,v29.4s
+$Tag.Lnum1
+        tbz     w6,#1,$Tag.Lnum2
+        add     x23,x17,#64
+        ldr     q26,[x23]
+        ldr     q27,[x23,#16]
+        ldr     q28,[x23,#32]
+        ldr     q29,[x23,#48]
+        fadd    v8.4s,v8.4s,v26.4s
+        fadd    v9.4s,v9.4s,v27.4s
+        fadd    v10.4s,v10.4s,v28.4s
+        fadd    v11.4s,v11.4s,v29.4s
+        fadd    v12.4s,v12.4s,v26.4s
+        fadd    v13.4s,v13.4s,v27.4s
+        fadd    v14.4s,v14.4s,v28.4s
+        fadd    v15.4s,v15.4s,v29.4s
+$Tag.Lnum2
+        tbz     w6,#2,$Tag.Lnum3
+        fmax    v8.4s,v8.4s,v31.4s
+        fmax    v9.4s,v9.4s,v31.4s
+        fmax    v10.4s,v10.4s,v31.4s
+        fmax    v11.4s,v11.4s,v31.4s
+        fmax    v12.4s,v12.4s,v31.4s
+        fmax    v13.4s,v13.4s,v31.4s
+        fmax    v14.4s,v14.4s,v31.4s
+        fmax    v15.4s,v15.4s,v31.4s
+$Tag.Lnum3
+        str     q8,[x27]
+        str     q9,[x27,#16]
+        str     q10,[x27,#32]
+        str     q11,[x27,#48]
+        str     q12,[x24]
+        str     q13,[x24,#16]
+        str     q14,[x24,#32]
+        str     q15,[x24,#48]
+        add     x27,x27,x8       ; set2 base
+        add     x24,x27,#64
+        tbz     w6,#0,$Tag.Lnum4
+        ldr     q26,[x27]
+        ldr     q27,[x27,#16]
+        ldr     q28,[x27,#32]
+        ldr     q29,[x27,#48]
+        fadd    v16.4s,v16.4s,v26.4s
+        fadd    v17.4s,v17.4s,v27.4s
+        fadd    v18.4s,v18.4s,v28.4s
+        fadd    v19.4s,v19.4s,v29.4s
+        ldr     q26,[x24]
+        ldr     q27,[x24,#16]
+        ldr     q28,[x24,#32]
+        ldr     q29,[x24,#48]
+        fadd    v20.4s,v20.4s,v26.4s
+        fadd    v21.4s,v21.4s,v27.4s
+        fadd    v22.4s,v22.4s,v28.4s
+        fadd    v23.4s,v23.4s,v29.4s
+$Tag.Lnum4
+        tbz     w6,#1,$Tag.Lnum5
+        add     x23,x17,#128
+        ldr     q26,[x23]
+        ldr     q27,[x23,#16]
+        ldr     q28,[x23,#32]
+        ldr     q29,[x23,#48]
+        fadd    v16.4s,v16.4s,v26.4s
+        fadd    v17.4s,v17.4s,v27.4s
+        fadd    v18.4s,v18.4s,v28.4s
+        fadd    v19.4s,v19.4s,v29.4s
+        fadd    v20.4s,v20.4s,v26.4s
+        fadd    v21.4s,v21.4s,v27.4s
+        fadd    v22.4s,v22.4s,v28.4s
+        fadd    v23.4s,v23.4s,v29.4s
+$Tag.Lnum5
+        tbz     w6,#2,$Tag.Lnum6
+        fmax    v16.4s,v16.4s,v31.4s
+        fmax    v17.4s,v17.4s,v31.4s
+        fmax    v18.4s,v18.4s,v31.4s
+        fmax    v19.4s,v19.4s,v31.4s
+        fmax    v20.4s,v20.4s,v31.4s
+        fmax    v21.4s,v21.4s,v31.4s
+        fmax    v22.4s,v22.4s,v31.4s
+        fmax    v23.4s,v23.4s,v31.4s
+$Tag.Lnum6
+        str     q16,[x27]
+        str     q17,[x27,#16]
+        str     q18,[x27,#32]
+        str     q19,[x27,#48]
+        str     q20,[x24]
+        str     q21,[x24,#16]
+        str     q22,[x24,#32]
+        str     q23,[x24,#48]
+        sub     x27,x27,x8
+        sub     x27,x27,x8
+        MEND
+
+        ; 1-output compute with padding checks ---------------------------------
+        MACRO
+        CONV_PAD $Tag, $N
+        CLEAR_ACCUM $N
+        mov     x28,x1
+    IF $N >= 2
+        add     x19,x1,x7
+    ENDIF
+    IF $N >= 3
+        add     x24,x19,x7
+    ENDIF
+    IF $N >= 4
+        add     x26,x24,x7
+    ENDIF
+        mov     x21,x0
+        ldr     x9,[sp,#KO_KernelHeight]
+        cbz     x9,$Tag.Lnum5
+        ldr     x10,[sp,#KO_KernelWidth]
+        ldr     x22,[sp,#KO_InputBase]
+        ldr     x12,[sp,#KO_InputWidth]
+        add     x23,x22,x12
+$Tag.Lnum1
+        mov     x25,x21
+        mov     x11,x10
+$Tag.Lnum2
+        cmp     x25,x22
+        blo     $Tag.Lnum3
+        cmp     x25,x23
+        bhs     $Tag.Lnum3
+        ld1r    {v24.4s},[x25]
+        b       $Tag.Lnum4
+$Tag.Lnum3
+        eor     v24.16b,v24.16b,v24.16b
+$Tag.Lnum4
+        ; Small lookahead to keep the miss machinery busy without polluting
+        ; cache for tiny kernels.
+        prfm    pldl1keep,[x28,#192]
+        ld1     {v26.4s,v27.4s,v28.4s,v29.4s},[x28],#64
+        fmla    v0.4s,v26.4s,v24.4s
+        fmla    v1.4s,v27.4s,v24.4s
+        fmla    v2.4s,v28.4s,v24.4s
+        fmla    v3.4s,v29.4s,v24.4s
+    IF $N >= 2
+        ld1     {v26.4s,v27.4s,v28.4s,v29.4s},[x19],#64
+        fmla    v4.4s,v26.4s,v24.4s
+        fmla    v5.4s,v27.4s,v24.4s
+        fmla    v6.4s,v28.4s,v24.4s
+        fmla    v7.4s,v29.4s,v24.4s
+    ENDIF
+    IF $N >= 3
+        ld1     {v26.4s,v27.4s,v28.4s,v29.4s},[x24],#64
+        fmla    v8.4s,v26.4s,v24.4s
+        fmla    v9.4s,v27.4s,v24.4s
+        fmla    v10.4s,v28.4s,v24.4s
+        fmla    v11.4s,v29.4s,v24.4s
+    ENDIF
+    IF $N >= 4
+        ld1     {v26.4s,v27.4s,v28.4s,v29.4s},[x26],#64
+        fmla    v12.4s,v26.4s,v24.4s
+        fmla    v13.4s,v27.4s,v24.4s
+        fmla    v14.4s,v28.4s,v24.4s
+        fmla    v15.4s,v29.4s,v24.4s
+    ENDIF
+        add     x25,x25,x4
+        subs    x11,x11,#1
+        b.ne    $Tag.Lnum2
+        ldr     x13,[sp,#KO_DilatedInputWidth]
+        add     x21,x21,x13
+        add     x22,x22,x13
+        add     x23,x23,x13
+        subs    x9,x9,#1
+        b.ne    $Tag.Lnum1
+$Tag.Lnum5
+        POSTPROCESS_STORE $Tag.ps, $N
+        MEND
+
+        ; 1-output compute without padding checks ------------------------------
+        MACRO
+        CONV_NOPAD $Tag, $N
+        CLEAR_ACCUM $N
+        mov     x28,x1
+    IF $N >= 2
+        add     x19,x1,x7
+    ENDIF
+    IF $N >= 3
+        add     x24,x19,x7
+    ENDIF
+    IF $N >= 4
+        add     x26,x24,x7
+    ENDIF
+        mov     x21,x0
+        ldr     x9,[sp,#KO_KernelHeight]
+        cbz     x9,$Tag.Lnum3
+        ldr     x10,[sp,#KO_KernelWidth]
+$Tag.Lnum1
+        mov     x25,x21
+        mov     x11,x10
+$Tag.Lnum2
+        ld1r    {v24.4s},[x25]
+        prfm    pldl1keep,[x28,#192]
+        ld1     {v26.4s,v27.4s,v28.4s,v29.4s},[x28],#64
+        fmla    v0.4s,v26.4s,v24.4s
+        fmla    v1.4s,v27.4s,v24.4s
+        fmla    v2.4s,v28.4s,v24.4s
+        fmla    v3.4s,v29.4s,v24.4s
+    IF $N >= 2
+        ld1     {v26.4s,v27.4s,v28.4s,v29.4s},[x19],#64
+        fmla    v4.4s,v26.4s,v24.4s
+        fmla    v5.4s,v27.4s,v24.4s
+        fmla    v6.4s,v28.4s,v24.4s
+        fmla    v7.4s,v29.4s,v24.4s
+    ENDIF
+    IF $N >= 3
+        ld1     {v26.4s,v27.4s,v28.4s,v29.4s},[x24],#64
+        fmla    v8.4s,v26.4s,v24.4s
+        fmla    v9.4s,v27.4s,v24.4s
+        fmla    v10.4s,v28.4s,v24.4s
+        fmla    v11.4s,v29.4s,v24.4s
+    ENDIF
+    IF $N >= 4
+        ld1     {v26.4s,v27.4s,v28.4s,v29.4s},[x26],#64
+        fmla    v12.4s,v26.4s,v24.4s
+        fmla    v13.4s,v27.4s,v24.4s
+        fmla    v14.4s,v28.4s,v24.4s
+        fmla    v15.4s,v29.4s,v24.4s
+    ENDIF
+        add     x25,x25,x4
+        subs    x11,x11,#1
+        b.ne    $Tag.Lnum2
+        ldr     x13,[sp,#KO_DilatedInputWidth]
+        add     x21,x21,x13
+        subs    x9,x9,#1
+        b.ne    $Tag.Lnum1
+$Tag.Lnum3
+        POSTPROCESS_STORE $Tag.ps, $N
+        MEND
+
+        ; Two-output compute core when no padding is required.  x25/x26 are
+        ; the two input pointers, x27 the output base.  x28, x19 and x20 are
+        ; filter pointers for each set.  v24/v25 hold broadcast inputs.
+        MACRO
+        CONV2_NOPAD $Tag, $N
+        CLEAR_ACCUM2 $N
+        mov     x28,x1
+    IF $N >= 2
+        add     x19,x1,x7
+    ENDIF
+    IF $N >= 3
+        add     x24,x19,x7
+    ENDIF
+        ldr     x11,[sp,#KO_KernelWidth]
+        ldr     x9,[sp,#KO_KernelHeight]
+        ldr     x12,[sp,#KO_DilatedInputWidth]
+        mul     x13,x11,x4          ; kernel_width * dilation_width
+        sub     x12,x12,x13         ; input stride between kernel rows
+$Tag.Lnum1
+        mov     x10,x11
+$Tag.Lnum2
+        prfm    pldl1keep,[x28,#192]
+        ld1r    {v24.4s},[x25]
+        ld1     {v26.4s,v27.4s,v28.4s,v29.4s},[x28],#64
+        fmla    v0.4s,v26.4s,v24.4s
+        fmla    v1.4s,v27.4s,v24.4s
+        fmla    v2.4s,v28.4s,v24.4s
+        fmla    v3.4s,v29.4s,v24.4s
+        ld1r    {v25.4s},[x26]
+        fmla    v4.4s,v26.4s,v25.4s
+        fmla    v5.4s,v27.4s,v25.4s
+        fmla    v6.4s,v28.4s,v25.4s
+        fmla    v7.4s,v29.4s,v25.4s
+    IF $N >= 2
+        ld1     {v26.4s,v27.4s,v28.4s,v29.4s},[x19],#64
+        fmla    v8.4s,v26.4s,v24.4s
+        fmla    v9.4s,v27.4s,v24.4s
+        fmla    v10.4s,v28.4s,v24.4s
+        fmla    v11.4s,v29.4s,v24.4s
+        fmla    v12.4s,v26.4s,v25.4s
+        fmla    v13.4s,v27.4s,v25.4s
+        fmla    v14.4s,v28.4s,v25.4s
+        fmla    v15.4s,v29.4s,v25.4s
+    ENDIF
+    IF $N >= 3
+        ld1     {v26.4s,v27.4s,v28.4s,v29.4s},[x24],#64
+        fmla    v16.4s,v26.4s,v24.4s
+        fmla    v17.4s,v27.4s,v24.4s
+        fmla    v18.4s,v28.4s,v24.4s
+        fmla    v19.4s,v29.4s,v24.4s
+        fmla    v20.4s,v26.4s,v25.4s
+        fmla    v21.4s,v27.4s,v25.4s
+        fmla    v22.4s,v28.4s,v25.4s
+        fmla    v23.4s,v29.4s,v25.4s
+    ENDIF
+        add     x25,x25,x4
+        add     x26,x26,x4
+        subs    x10,x10,#1
+        b.ne    $Tag.Lnum2
+        add     x25,x25,x12
+        add     x26,x26,x12
+        subs    x9,x9,#1
+        b.ne    $Tag.Lnum1
+        MEND
+
+; -----------------------------------------------------------------------------
+; void MlasConvNchwFloatKernelNeonAsm(...)
+; Implements the convolution micro-kernel for the NCHW input format.
+; -----------------------------------------------------------------------------
+
+            NESTED_ENTRY MlasConvNchwFloatKernelNeonAsm
+
+        ; prologue -------------------------------------------------------------
+        PROLOG_SAVE_REG_PAIR x19, x20, #-LFrame_SavedRegs!
+        PROLOG_NOP stp     x21,x22,[sp,#LFrame_x21_x22]
+        PROLOG_NOP stp     x23,x24,[sp,#LFrame_x23_x24]
+        PROLOG_NOP stp     x25,x26,[sp,#LFrame_x25_x26]
+        PROLOG_NOP stp     x27,x28,[sp,#LFrame_x27_x28]
+        PROLOG_NOP stp     q8,q9,[sp,#LFrame_q8_q9]
+        PROLOG_NOP stp     q10,q11,[sp,#LFrame_q10_q11]
+        PROLOG_NOP stp     q12,q13,[sp,#LFrame_q12_q13]
+        PROLOG_NOP stp     q14,q15,[sp,#LFrame_q14_q15]
+        PROLOG_NOP str     x0,[sp,#LFrame_InputBaseSaved]
+        PROLOG_NOP str     x1,[sp,#LFrame_FilterBaseSaved]
+        PROLOG_NOP str     x2,[sp,#LFrame_OutputBaseSaved]
+        PROLOG_NOP str     x30,[sp,#LFrame_LrSaved]
+
+        cmp     x5,#4
+        b.ne    LRunKernelSingle
+
+        ; Split the 4-filter case into two 2-filter passes to enable the
+        ; two-output inner loop without inflating register pressure.
+        mov     x5,#2
+
+        ldr     x1,[sp,#LFrame_FilterBaseSaved]
+        ldr     x2,[sp,#LFrame_OutputBaseSaved]
+        ldr     x17,[sp,#KO_Bias]
+        bl      LKernelBody
+
+        ldr     x1,[sp,#LFrame_FilterBaseSaved]
+        add     x1,x1,x7,lsl #1
+        ldr     x2,[sp,#LFrame_OutputBaseSaved]
+        ldr     x8,[sp,#KO_OutputStride]
+        add     x2,x2,x8,lsl #1
+        ldr     x17,[sp,#KO_Bias]
+        cbz     x17,Lnum1
+        add     x17,x17,#128
+Lnum1
+        mov     x5,#2
+        bl      LKernelBody
+
+        b       LDoneEntry
+
+LRunKernelSingle
+        ldr     x17,[sp,#KO_Bias]
+        bl      LKernelBody
+        b       LDoneEntry
+
+LKernelBody
+        ; frequently used parameters
+        ldr     x8,[sp,#KO_OutputStride]
+        ldr     x14,[sp,#KO_OutputCountLeftPad]
+        ldr     x15,[sp,#KO_OutputCount]
+        ldr     x16,[sp,#KO_OutputCountRightPad]
+        ldr     w6,[sp,#KO_Flags]          ; kernel flags
+
+        eor     v31.16b,v31.16b,v31.16b
+
+        ; left padded region --------------------------------------------------
+        cbz     x14,LInterior
+        mov     x20,#0
+LLeftLoop
+        ldr     x0,[sp,#LFrame_InputBaseSaved]
+        madd    x21,x20,x3,x0       ; input pointer for this output
+        lsl     x22,x20,#6          ; (index*64)
+        add     x27,x2,x22
+        mov     x0,x21
+        cmp     x5,#1
+        b.eq    LLeftFC1
+        cmp     x5,#2
+        b.eq    LLeftFC2
+        cmp     x5,#3
+        b.eq    LLeftFC3
+LLeftFC4
+        CONV_PAD ck1, 4
+        b       LLeftDoneOne
+LLeftFC3
+        CONV_PAD ck2, 3
+        b       LLeftDoneOne
+LLeftFC2
+        CONV_PAD ck3, 2
+        b       LLeftDoneOne
+LLeftFC1
+        CONV_PAD ck4, 1
+LLeftDoneOne
+        add     x20,x20,#1
+        cmp     x20,x14
+        blo     LLeftLoop
+
+        ; interior region -----------------------------------------------------
+LInterior
+        cbz     x15,LRight
+
+        ldr     x0,[sp,#LFrame_InputBaseSaved]
+        mul     x24,x14,x3          ; input byte offset after left pad
+        add     x21,x0,x24          ; base input for interior
+        lsl     x23,x14,#6          ; output offset (bytes)
+
+        mov     x20,#0
+LIntLoop
+        sub     x12,x15,x20
+        cmp     x12,#2
+        b.lt    LIntProcessOne
+        ; two-output path
+        madd    x25,x20,x3,x21       ; input for first output
+        add     x26,x25,x3           ; input for second output
+        add     x22,x14,x20          ; output index
+        lsl     x22,x22,#6           ; output offset (bytes)
+        add     x27,x2,x22
+        cmp     x5,#1
+        b.eq    LInt2FC1
+        cmp     x5,#2
+        b.eq    LInt2FC2
+        cmp     x5,#3
+        b.eq    LInt2FC3
+        ; FilterCount==4 falls back to single-output implementation due to
+        ; register pressure.
+        b       LIntProcessOne
+LInt2FC3
+        CONV2_NOPAD ck5, 3
+        POSTPROCESS_STORE2_3 lb3
+        b       LIntNext2
+LInt2FC2
+        CONV2_NOPAD ck6, 2
+        POSTPROCESS_STORE2_2 lb4
+        b       LIntNext2
+LInt2FC1
+        CONV2_NOPAD ck7, 1
+        POSTPROCESS_STORE2_1 lb5
+LIntNext2
+        add     x20,x20,#2
+        cmp     x20,x15
+        blo     LIntLoop
+        b       LRight
+
+LIntProcessOne
+        madd    x25,x20,x3,x21
+        add     x22,x14,x20          ; output index
+        lsl     x22,x22,#6           ; output offset (bytes)
+        add     x27,x2,x22
+        mov     x0,x25
+        cmp     x5,#1
+        b.eq    LIntFC1
+        cmp     x5,#2
+        b.eq    LIntFC2
+        cmp     x5,#3
+        b.eq    LIntFC3
+        CONV_NOPAD ck8, 4
+        b       LIntNext1
+LIntFC3
+        CONV_NOPAD ck9, 3
+        b       LIntNext1
+LIntFC2
+        CONV_NOPAD ck10, 2
+        b       LIntNext1
+LIntFC1
+        CONV_NOPAD ck11, 1
+LIntNext1
+        add     x20,x20,#1
+        cmp     x20,x15
+        blo     LIntLoop
+
+        ; right padded region -------------------------------------------------
+LRight
+        cbz     x16,LKernelReturn
+        ldr     x0,[sp,#LFrame_InputBaseSaved]
+        mov     x20,#0
+LRightLoop
+        ldr     x0,[sp,#LFrame_InputBaseSaved]
+        add     x24,x20,x14
+        add     x24,x24,x15
+        madd    x21,x24,x3,x0
+        lsl     x22,x24,#6
+        add     x27,x2,x22
+        mov     x0,x21
+        cmp     x5,#1
+        b.eq    LRFC1
+        cmp     x5,#2
+        b.eq    LRFC2
+        cmp     x5,#3
+        b.eq    LRFC3
+        CONV_PAD ck12, 4
+        b       LRightNext
+LRFC3
+        CONV_PAD ck13, 3
+        b       LRightNext
+LRFC2
+        CONV_PAD ck14, 2
+        b       LRightNext
+LRFC1
+        CONV_PAD ck15, 1
+LRightNext
+        add     x20,x20,#1
+        cmp     x20,x16
+        blo     LRightLoop
+
+LKernelReturn
+        ret
+
+LDoneEntry
+        ; The restores are wrapped in EPILOG_NOP / EPILOG_RESTORE_REG_PAIR so
+        ; that armasm64 can emit matching unwind codes.  A plain ldp sequence
+        ; assembles as an ordinary instruction and leaves the epilogue
+        ; unbalanced against the prologue, which trips the assertion in
+        ; kxarm64unw.h rather than producing a diagnostic of its own.
+        EPILOG_NOP ldp     q14,q15,[sp,#LFrame_q14_q15]
+        EPILOG_NOP ldp     q12,q13,[sp,#LFrame_q12_q13]
+        EPILOG_NOP ldp     q10,q11,[sp,#LFrame_q10_q11]
+        EPILOG_NOP ldp     q8,q9,[sp,#LFrame_q8_q9]
+        EPILOG_NOP ldp     x27,x28,[sp,#LFrame_x27_x28]
+        EPILOG_NOP ldp     x25,x26,[sp,#LFrame_x25_x26]
+        EPILOG_NOP ldp     x23,x24,[sp,#LFrame_x23_x24]
+        EPILOG_NOP ldp     x21,x22,[sp,#LFrame_x21_x22]
+        EPILOG_NOP ldr     x30,[sp,#LFrame_LrSaved]
+        EPILOG_RESTORE_REG_PAIR x19, x20, #LFrame_SavedRegs!
+        EPILOG_RETURN
+
+        NESTED_END MlasConvNchwFloatKernelNeonAsm
+
+        END

--- a/onnxruntime/core/mlas/lib/arm64/SconvNchwcKernelNeon.asm
+++ b/onnxruntime/core/mlas/lib/arm64/SconvNchwcKernelNeon.asm
@@ -1,0 +1,1927 @@
+;++
+; SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+; SPDX-License-Identifier: MIT
+; 
+; Module Name:
+; 
+;     SconvNchwcKernelNeon.S
+; 
+; Abstract:
+; 
+;     This module implements the single precision NCHWC convolution kernel for
+;     AArch64 processors with NEON support.
+; 
+;--
+
+
+#include "kxarm64.h"
+
+        TEXTAREA
+        ALIGN 4
+
+;
+; PROCESS_LANE - Load one 16-float filter row and accumulate it using a
+; single input lane.
+;
+
+        MACRO
+        PROCESS_LANE $offset0, $offset1, $inreg, $lane
+        ldp     q16, q17, [x7, #$offset0]
+        ldp     q18, q19, [x7, #$offset1]
+        fmla    v0.4s, v16.4s, $inreg..s[$lane]
+        fmla    v1.4s, v17.4s, $inreg..s[$lane]
+        fmla    v2.4s, v18.4s, $inreg..s[$lane]
+        fmla    v3.4s, v19.4s, $inreg..s[$lane]
+        MEND
+
+;
+; PROCESS_LANE_PAD1 - As PROCESS_LANE, but accumulating into the second
+; output's registers.  CONV_LOOP_PAD_2OUT bounds-tests its two outputs
+; separately, so each is accumulated by its own single-output block rather than
+; by a fused two-output block; only the filter load is shared.
+;
+
+        MACRO
+        PROCESS_LANE_PAD1 $offset0, $offset1, $inreg, $lane
+        ldp     q16, q17, [x7, #$offset0]
+        ldp     q18, q19, [x7, #$offset1]
+        fmla    v20.4s, v16.4s, $inreg..s[$lane]
+        fmla    v21.4s, v17.4s, $inreg..s[$lane]
+        fmla    v22.4s, v18.4s, $inreg..s[$lane]
+        fmla    v23.4s, v19.4s, $inreg..s[$lane]
+        MEND
+
+;
+; PROCESS_LANE_2OUT - Load one 16-float filter row and accumulate it using
+; two input lanes for a dual-output path.
+;
+
+        MACRO
+        PROCESS_LANE_2OUT $offset0, $offset1, $inreg0, $inreg1, $lane
+        ldp     q16, q17, [x7, #$offset0]
+        ldp     q18, q19, [x7, #$offset1]
+        fmla    v0.4s,  v16.4s, $inreg0..s[$lane]
+        fmla    v1.4s,  v17.4s, $inreg0..s[$lane]
+        fmla    v2.4s,  v18.4s, $inreg0..s[$lane]
+        fmla    v3.4s,  v19.4s, $inreg0..s[$lane]
+        fmla    v20.4s, v16.4s, $inreg1..s[$lane]
+        fmla    v21.4s, v17.4s, $inreg1..s[$lane]
+        fmla    v22.4s, v18.4s, $inreg1..s[$lane]
+        fmla    v23.4s, v19.4s, $inreg1..s[$lane]
+        MEND
+
+;
+; PROCESS_LANE_3OUT_4FILT - Load one filter row from each of FOUR filter sets
+; and accumulate all of them against three input lanes.
+;
+; The kernel's filter loop (Lfilter_*_loop) encloses the whole kernel height
+; and width walk, so the input window is re-read once per filter set.  For the
+; super resolution shapes that is four times over a 12.8 MB tensor, which does
+; not fit in L2, so each extra walk is genuine memory traffic rather than a
+; cache hit.  The x64 kernel does not pay this: ComputeBlock in
+; amd64/SconvKernelCommon.inc broadcasts an input value once and applies it to
+; four filter rows held at rdx, rdx+rsi, rbx and rbx+rsi, so one pass over the
+; input produces four filter sets of output.
+;
+; This macro is the equivalent shape for AArch64.  The same twelve accumulators
+; are reinterpreted: instead of one filter set across three outputs, they hold
+; four filter sets across three outputs, and the input lanes are read once for
+; all four.
+;
+;   v0-v2    filter set 0, outputs 0-2      v6-v8    filter set 2, outputs 0-2
+;   v3-v5    filter set 1, outputs 0-2      v9-v11   filter set 3, outputs 0-2
+;
+; x7 addresses filter set 0; x17, x19 and x20 address sets 1, 2 and 3.  Only
+; one quarter of a filter row is processed per call, so the caller issues this
+; four times per lane group to cover all sixteen output channels.
+;
+; The parameters are named $foff, $ireg0..$ireg2 and $lidx rather than anything
+; resembling a register name: armasm64 substitutes a parameter wherever its
+; spelling appears, so a parameter called $v0 would also rewrite the literal
+; register v0 used below.
+;
+
+        MACRO
+        PROCESS_LANE_3OUT_4FILT $foff, $ireg0, $ireg1, $ireg2, $lidx
+        ldr     q12, [x7,  #$foff]
+        ldr     q13, [x9,  #$foff]
+        ldr     q14, [x13, #$foff]
+        ldr     q15, [x16, #$foff]
+        fmla    v0.4s,  v12.4s, $ireg0..s[$lidx]
+        fmla    v1.4s,  v12.4s, $ireg1..s[$lidx]
+        fmla    v2.4s,  v12.4s, $ireg2..s[$lidx]
+        fmla    v3.4s,  v13.4s, $ireg0..s[$lidx]
+        fmla    v4.4s,  v13.4s, $ireg1..s[$lidx]
+        fmla    v5.4s,  v13.4s, $ireg2..s[$lidx]
+        fmla    v6.4s,  v14.4s, $ireg0..s[$lidx]
+        fmla    v7.4s,  v14.4s, $ireg1..s[$lidx]
+        fmla    v8.4s,  v14.4s, $ireg2..s[$lidx]
+        fmla    v9.4s,  v15.4s, $ireg0..s[$lidx]
+        fmla    v10.4s, v15.4s, $ireg1..s[$lidx]
+        fmla    v11.4s, v15.4s, $ireg2..s[$lidx]
+        MEND
+
+;
+; PROCESS_LANE_3OUT - Load one 16-float filter row and accumulate it using
+; three input lanes for a tri-output path.
+;
+
+        MACRO
+        PROCESS_LANE_3OUT $offset0, $offset1, $inreg0, $inreg1, $inreg2, $lane
+        ldp     q16, q17, [x7, #$offset0]
+        ldp     q18, q19, [x7, #$offset1]
+        fmla    v0.4s,  v16.4s, $inreg0..s[$lane]
+        fmla    v1.4s,  v17.4s, $inreg0..s[$lane]
+        fmla    v2.4s,  v18.4s, $inreg0..s[$lane]
+        fmla    v3.4s,  v19.4s, $inreg0..s[$lane]
+        fmla    v4.4s,  v16.4s, $inreg1..s[$lane]
+        fmla    v5.4s,  v17.4s, $inreg1..s[$lane]
+        fmla    v6.4s,  v18.4s, $inreg1..s[$lane]
+        fmla    v7.4s,  v19.4s, $inreg1..s[$lane]
+        fmla    v8.4s,  v16.4s, $inreg2..s[$lane]
+        fmla    v9.4s,  v17.4s, $inreg2..s[$lane]
+        fmla    v10.4s, v18.4s, $inreg2..s[$lane]
+        fmla    v11.4s, v19.4s, $inreg2..s[$lane]
+        MEND
+
+;
+; PROCESS_LANE_4OUT - Load one 16-float filter row and accumulate it using
+; four input lanes for a quad-output path.
+;
+
+        MACRO
+        PROCESS_LANE_4OUT $offset0, $offset1, $inreg0, $inreg1, $inreg2, $inreg3, $lane
+        ldp     q16, q17, [x7, #$offset0]
+        ldp     q18, q19, [x7, #$offset1]
+        fmla    v0.4s,  v16.4s, $inreg0..s[$lane]
+        fmla    v1.4s,  v17.4s, $inreg0..s[$lane]
+        fmla    v2.4s,  v18.4s, $inreg0..s[$lane]
+        fmla    v3.4s,  v19.4s, $inreg0..s[$lane]
+        fmla    v4.4s,  v16.4s, $inreg1..s[$lane]
+        fmla    v5.4s,  v17.4s, $inreg1..s[$lane]
+        fmla    v6.4s,  v18.4s, $inreg1..s[$lane]
+        fmla    v7.4s,  v19.4s, $inreg1..s[$lane]
+        fmla    v8.4s,  v16.4s, $inreg2..s[$lane]
+        fmla    v9.4s,  v17.4s, $inreg2..s[$lane]
+        fmla    v10.4s, v18.4s, $inreg2..s[$lane]
+        fmla    v11.4s, v19.4s, $inreg2..s[$lane]
+        fmla    v12.4s, v16.4s, $inreg3..s[$lane]
+        fmla    v13.4s, v17.4s, $inreg3..s[$lane]
+        fmla    v14.4s, v18.4s, $inreg3..s[$lane]
+        fmla    v15.4s, v19.4s, $inreg3..s[$lane]
+        MEND
+
+;
+; CONV_LOOP_PAD - Convolution loop with per-position bounds checks. This
+; path is used for the padded output regions on the left and right edges.
+;
+
+        MACRO
+        CONV_LOOP_PAD $Tag
+        mov     x7, x4                       ; Filter pointer
+        mov     x8, x1                       ; Input row pointer
+        mov     x9, x13                      ; Row start pointer
+        mov     x10, x27                     ; KernelHeight counter
+
+        cbz     x10, $Tag.Lnum90
+        cbz     x28, $Tag.Lnum90
+
+$Tag.Lnum91
+        mov     x12, x8                      ; Input pointer for width
+        mov     x16, x28                     ; KernelWidth counter
+
+$Tag.Lnum92
+        ; Branch if the input pointer lies outside [row_start, row_start + row_width).
+        sub     x11, x12, x9
+        cmp     x11, x14
+        b.hs    $Tag.Lnum93
+
+        ldp     q4, q5, [x12, #0]
+        ldp     q6, q7, [x12, #32]
+
+        PROCESS_LANE 0,   32,  v4, 0
+        PROCESS_LANE 64,  96,  v4, 1
+        PROCESS_LANE 128, 160, v4, 2
+        PROCESS_LANE 192, 224, v4, 3
+        PROCESS_LANE 256, 288, v5, 0
+        PROCESS_LANE 320, 352, v5, 1
+        PROCESS_LANE 384, 416, v5, 2
+        PROCESS_LANE 448, 480, v5, 3
+        PROCESS_LANE 512, 544, v6, 0
+        PROCESS_LANE 576, 608, v6, 1
+        PROCESS_LANE 640, 672, v6, 2
+        PROCESS_LANE 704, 736, v6, 3
+        PROCESS_LANE 768, 800, v7, 0
+        PROCESS_LANE 832, 864, v7, 1
+        PROCESS_LANE 896, 928, v7, 2
+        PROCESS_LANE 960, 992, v7, 3
+
+$Tag.Lnum93
+        add     x7, x7, #1024
+        add     x12, x12, x23
+        subs    x16, x16, #1
+        b.ne    $Tag.Lnum92
+
+        add     x9, x9, x15
+        add     x8, x8, x15
+        subs    x10, x10, #1
+        b.ne    $Tag.Lnum91
+
+$Tag.Lnum90
+        MEND
+
+;
+; CONV_LOOP_PAD_2OUT - Convolution loop with per-position bounds checks that
+; computes two adjacent output points per iteration.
+;
+; The padded regions are small but expensive: CONV_LOOP_PAD computes a single
+; output per filter load, whereas the interior loops amortize each load over
+; three or four.  For the ResNet shapes the left and right pads together are
+; two of the fourteen columns at Out=14x14 and two of seven at Out=7x7, so this
+; path carries roughly a sixth of the 3x3 convolution work at a third of the
+; interior's efficiency.
+;
+; The two outputs are adjacent, so a single filter load serves both.  Each
+; output keeps its own bounds test because one may read padding while the other
+; does not; the filter pointer advance is shared and therefore performed once.
+; Accumulators are v0-v3 for output 0 and v20-v23 for output 1, matching
+; CONV_LOOP_MID_2OUT so the surrounding store code is unchanged.
+;
+
+        MACRO
+        CONV_LOOP_PAD_2OUT $Tag
+        mov     x7, x4                       ; Filter pointer
+        mov     x8, x1                       ; Input row pointer (output 0)
+        mov     x9, x13                      ; Row start pointer
+        mov     x10, x27                     ; KernelHeight counter
+
+        cbz     x10, $Tag.Lnum140
+        cbz     x28, $Tag.Lnum140
+
+$Tag.Lnum141
+        mov     x12, x8                      ; Input pointer for width (output 0)
+        mov     x16, x28                     ; KernelWidth counter
+
+$Tag.Lnum142
+        ; Output 0: skip if the input pointer lies outside the row.
+        sub     x11, x12, x9
+        cmp     x11, x14
+        b.hs    $Tag.Lnum143
+
+        ldp     q4, q5, [x12, #0]
+        ldp     q6, q7, [x12, #32]
+
+        PROCESS_LANE 0,   32,  v4, 0
+        PROCESS_LANE 64,  96,  v4, 1
+        PROCESS_LANE 128, 160, v4, 2
+        PROCESS_LANE 192, 224, v4, 3
+        PROCESS_LANE 256, 288, v5, 0
+        PROCESS_LANE 320, 352, v5, 1
+        PROCESS_LANE 384, 416, v5, 2
+        PROCESS_LANE 448, 480, v5, 3
+        PROCESS_LANE 512, 544, v6, 0
+        PROCESS_LANE 576, 608, v6, 1
+        PROCESS_LANE 640, 672, v6, 2
+        PROCESS_LANE 704, 736, v6, 3
+        PROCESS_LANE 768, 800, v7, 0
+        PROCESS_LANE 832, 864, v7, 1
+        PROCESS_LANE 896, 928, v7, 2
+        PROCESS_LANE 960, 992, v7, 3
+
+$Tag.Lnum143
+        ; Output 1: one stride further along the row, tested independently.
+        ;
+        ; Every general register is live here -- x7/x8/x9/x10/x12/x16 carry the
+        ; loop state and x17 is the bias base -- so x11 is reused for both the
+        ; bounds test and the address.  The comparison consumes x11 before the
+        ; address is formed, so the two uses do not overlap.
+        add     x11, x12, x22                ; input pointer for output 1
+        sub     x11, x11, x9                 ; offset from row start
+        cmp     x11, x14
+        b.hs    $Tag.Lnum144
+
+        add     x11, x9, x11                 ; rebuild the input pointer
+        ldp     q4, q5, [x11, #0]
+        ldp     q6, q7, [x11, #32]
+
+        PROCESS_LANE_PAD1 0,   32,  v4, 0
+        PROCESS_LANE_PAD1 64,  96,  v4, 1
+        PROCESS_LANE_PAD1 128, 160, v4, 2
+        PROCESS_LANE_PAD1 192, 224, v4, 3
+        PROCESS_LANE_PAD1 256, 288, v5, 0
+        PROCESS_LANE_PAD1 320, 352, v5, 1
+        PROCESS_LANE_PAD1 384, 416, v5, 2
+        PROCESS_LANE_PAD1 448, 480, v5, 3
+        PROCESS_LANE_PAD1 512, 544, v6, 0
+        PROCESS_LANE_PAD1 576, 608, v6, 1
+        PROCESS_LANE_PAD1 640, 672, v6, 2
+        PROCESS_LANE_PAD1 704, 736, v6, 3
+        PROCESS_LANE_PAD1 768, 800, v7, 0
+        PROCESS_LANE_PAD1 832, 864, v7, 1
+        PROCESS_LANE_PAD1 896, 928, v7, 2
+        PROCESS_LANE_PAD1 960, 992, v7, 3
+
+$Tag.Lnum144
+        add     x7, x7, #1024
+        add     x12, x12, x23
+        subs    x16, x16, #1
+        b.ne    $Tag.Lnum142
+
+        add     x9, x9, x15
+        add     x8, x8, x15
+        subs    x10, x10, #1
+        b.ne    $Tag.Lnum141
+
+$Tag.Lnum140
+        MEND
+
+;
+; CONV_LOOP_MID - Convolution loop without bounds checks. Output positions in
+; the middle region are guaranteed to be fully in-bounds.
+;
+
+        MACRO
+        CONV_LOOP_MID $Tag
+        mov     x7, x4                       ; Filter pointer
+        mov     x8, x1                       ; Input row pointer
+        mov     x10, x27                     ; KernelHeight counter
+
+        cbz     x10, $Tag.Lnum100
+        cbz     x28, $Tag.Lnum100
+
+$Tag.Lnum101
+        mov     x12, x8                      ; Input pointer for width
+        mov     x16, x28                     ; KernelWidth counter
+
+$Tag.Lnum102
+        ldp     q4, q5, [x12, #0]
+        ldp     q6, q7, [x12, #32]
+
+        PROCESS_LANE 0,   32,  v4, 0
+        PROCESS_LANE 64,  96,  v4, 1
+        PROCESS_LANE 128, 160, v4, 2
+        PROCESS_LANE 192, 224, v4, 3
+        PROCESS_LANE 256, 288, v5, 0
+        PROCESS_LANE 320, 352, v5, 1
+        PROCESS_LANE 384, 416, v5, 2
+        PROCESS_LANE 448, 480, v5, 3
+        PROCESS_LANE 512, 544, v6, 0
+        PROCESS_LANE 576, 608, v6, 1
+        PROCESS_LANE 640, 672, v6, 2
+        PROCESS_LANE 704, 736, v6, 3
+        PROCESS_LANE 768, 800, v7, 0
+        PROCESS_LANE 832, 864, v7, 1
+        PROCESS_LANE 896, 928, v7, 2
+        PROCESS_LANE 960, 992, v7, 3
+
+        add     x7, x7, #1024
+        add     x12, x12, x23
+        subs    x16, x16, #1
+        b.ne    $Tag.Lnum102
+
+        add     x8, x8, x15
+        subs    x10, x10, #1
+        b.ne    $Tag.Lnum101
+
+$Tag.Lnum100
+        MEND
+
+;
+; CONV_LOOP_MID_3OUT - Convolution loop without bounds checks that computes
+; three adjacent output points per iteration.
+;
+
+        MACRO
+        CONV_LOOP_MID_3OUT $Tag
+        mov     x7, x4                       ; Filter pointer
+        mov     x8, x1                       ; Input row pointer (output 0)
+        mov     x9, x27                      ; KernelHeight counter
+
+        cbz     x9, $Tag.Lnum110
+        cbz     x28, $Tag.Lnum110
+
+$Tag.Lnum111
+        mov     x12, x8                      ; Input pointer for width (output 0)
+        mov     x16, x28                     ; KernelWidth counter
+
+$Tag.Lnum112
+        add     x11, x12, x22                ; Output 1 input pointer
+        add     x10, x12, x22, lsl #1        ; Output 2 input pointer
+
+        ldp     q20, q21, [x12, #0]
+        ldp     q22, q23, [x12, #32]
+        ldp     q24, q25, [x11, #0]
+        ldp     q26, q27, [x11, #32]
+        ldp     q12, q13, [x10, #0]
+        ldp     q14, q15, [x10, #32]
+
+        PROCESS_LANE_3OUT 0,   32,  v20, v24, v12, 0
+        PROCESS_LANE_3OUT 64,  96,  v20, v24, v12, 1
+        PROCESS_LANE_3OUT 128, 160, v20, v24, v12, 2
+        PROCESS_LANE_3OUT 192, 224, v20, v24, v12, 3
+        PROCESS_LANE_3OUT 256, 288, v21, v25, v13, 0
+        PROCESS_LANE_3OUT 320, 352, v21, v25, v13, 1
+        PROCESS_LANE_3OUT 384, 416, v21, v25, v13, 2
+        PROCESS_LANE_3OUT 448, 480, v21, v25, v13, 3
+        PROCESS_LANE_3OUT 512, 544, v22, v26, v14, 0
+        PROCESS_LANE_3OUT 576, 608, v22, v26, v14, 1
+        PROCESS_LANE_3OUT 640, 672, v22, v26, v14, 2
+        PROCESS_LANE_3OUT 704, 736, v22, v26, v14, 3
+        PROCESS_LANE_3OUT 768, 800, v23, v27, v15, 0
+        PROCESS_LANE_3OUT 832, 864, v23, v27, v15, 1
+        PROCESS_LANE_3OUT 896, 928, v23, v27, v15, 2
+        PROCESS_LANE_3OUT 960, 992, v23, v27, v15, 3
+
+        add     x7, x7, #1024
+        add     x12, x12, x23
+        subs    x16, x16, #1
+        b.ne    $Tag.Lnum112
+
+        add     x8, x8, x15
+        subs    x9, x9, #1
+        b.ne    $Tag.Lnum111
+
+$Tag.Lnum110
+        MEND
+
+;
+; CONV_LOOP_MID_3OUT_4FILT - Convolution loop without bounds checks that
+; computes three adjacent output points for FOUR filter sets at once.
+;
+; This is the AArch64 equivalent of the x64 ComputeBlock structure: the input
+; window is walked once and each input lane is applied to four filter sets,
+; rather than re-walking the window once per filter set.  For a 3x3 kernel
+; with FilterCount 4 that reduces the input traffic from 36 window loads to 9.
+;
+; Filter set 0 is addressed by x7 and sets 1-3 by x9, x19 and x20, each one
+; FilterStride further on.  The caller establishes those before entry; they are
+; advanced together by #1024 per kernel width step, exactly as the single-set
+; loop advances x7.
+;
+; Register use differs from CONV_LOOP_MID_3OUT.  x7, x9, x13 and x16 address
+; the four filter sets, so the kernel width counter moves to x10 and the height
+; counter to x14.  Both are scratch: x10 is only live as an input pointer
+; within a single width iteration, and x14 holds InputWidth, which only the
+; bounds-checked CONV_LOOP_PAD reads and which the caller restores from the
+; stack slot at #264 before the right padded region runs.  The three input
+; lane groups are loaded into v16-v19 / v21-v24 / v25-v28, leaving v12-v15 to
+; hold the four filter rows.
+;
+
+        MACRO
+        CONV_LOOP_MID_3OUT_4FILT $Tag
+        mov     x7, x4                       ; Filter set 0 pointer
+        add     x9, x7, x25                  ; Filter set 1 pointer
+        add     x13, x9, x25                 ; Filter set 2 pointer
+        add     x16, x13, x25                ; Filter set 3 pointer
+        mov     x8, x1                       ; Input row pointer (output 0)
+        mov     x14, x27                     ; KernelHeight counter
+
+        cbz     x14, $Tag.Lnum150
+        cbz     x28, $Tag.Lnum150
+
+$Tag.Lnum151
+        mov     x12, x8                      ; Input pointer for width (output 0)
+        mov     x10, x28                     ; KernelWidth counter
+
+$Tag.Lnum152
+        add     x11, x12, x22                ; Output 1 input pointer
+        ldp     q16, q17, [x12, #0]
+        ldp     q18, q19, [x12, #32]
+        ldp     q21, q22, [x11, #0]
+        ldp     q23, q24, [x11, #32]
+        add     x11, x12, x22, lsl #1        ; Output 2 input pointer
+        ldp     q25, q26, [x11, #0]
+        ldp     q27, q28, [x11, #32]
+
+        PROCESS_LANE_3OUT_4FILT 0,   v16, v21, v25, 0
+        PROCESS_LANE_3OUT_4FILT 16,  v16, v21, v25, 1
+        PROCESS_LANE_3OUT_4FILT 32,  v16, v21, v25, 2
+        PROCESS_LANE_3OUT_4FILT 48,  v16, v21, v25, 3
+        PROCESS_LANE_3OUT_4FILT 64,  v17, v22, v26, 0
+        PROCESS_LANE_3OUT_4FILT 80,  v17, v22, v26, 1
+        PROCESS_LANE_3OUT_4FILT 96,  v17, v22, v26, 2
+        PROCESS_LANE_3OUT_4FILT 112, v17, v22, v26, 3
+        PROCESS_LANE_3OUT_4FILT 128, v18, v23, v27, 0
+        PROCESS_LANE_3OUT_4FILT 144, v18, v23, v27, 1
+        PROCESS_LANE_3OUT_4FILT 160, v18, v23, v27, 2
+        PROCESS_LANE_3OUT_4FILT 176, v18, v23, v27, 3
+        PROCESS_LANE_3OUT_4FILT 192, v19, v24, v28, 0
+        PROCESS_LANE_3OUT_4FILT 208, v19, v24, v28, 1
+        PROCESS_LANE_3OUT_4FILT 224, v19, v24, v28, 2
+        PROCESS_LANE_3OUT_4FILT 240, v19, v24, v28, 3
+
+        add     x7,  x7,  #256
+        add     x9,  x9,  #256
+        add     x13, x13, #256
+        add     x16, x16, #256
+        add     x12, x12, x23
+        subs    x10, x10, #1
+        b.ne    $Tag.Lnum152
+
+        add     x8, x8, x15
+        subs    x14, x14, #1
+        b.ne    $Tag.Lnum151
+
+$Tag.Lnum150
+        MEND
+
+;
+; CONV_LOOP_MID_2OUT - Convolution loop without bounds checks that computes
+; two adjacent output points per iteration.
+;
+
+        MACRO
+        CONV_LOOP_MID_2OUT $Tag
+        mov     x7, x4                       ; Filter pointer
+        mov     x8, x1                       ; Input row pointer (output 0)
+        add     x9, x1, x22                  ; Input row pointer (output 1)
+        mov     x10, x27                     ; KernelHeight counter
+
+        cbz     x10, $Tag.Lnum120
+        cbz     x28, $Tag.Lnum120
+
+$Tag.Lnum121
+        mov     x12, x8                      ; Input pointer for width (output 0)
+        mov     x11, x9                      ; Input pointer for width (output 1)
+        mov     x16, x28                     ; KernelWidth counter
+
+$Tag.Lnum122
+        ldp     q4,  q5,  [x12, #0]
+        ldp     q6,  q7,  [x12, #32]
+        ldp     q24, q25, [x11, #0]
+        ldp     q26, q27, [x11, #32]
+
+        PROCESS_LANE_2OUT 0,   32,  v4, v24, 0
+        PROCESS_LANE_2OUT 64,  96,  v4, v24, 1
+        PROCESS_LANE_2OUT 128, 160, v4, v24, 2
+        PROCESS_LANE_2OUT 192, 224, v4, v24, 3
+        PROCESS_LANE_2OUT 256, 288, v5, v25, 0
+        PROCESS_LANE_2OUT 320, 352, v5, v25, 1
+        PROCESS_LANE_2OUT 384, 416, v5, v25, 2
+        PROCESS_LANE_2OUT 448, 480, v5, v25, 3
+        PROCESS_LANE_2OUT 512, 544, v6, v26, 0
+        PROCESS_LANE_2OUT 576, 608, v6, v26, 1
+        PROCESS_LANE_2OUT 640, 672, v6, v26, 2
+        PROCESS_LANE_2OUT 704, 736, v6, v26, 3
+        PROCESS_LANE_2OUT 768, 800, v7, v27, 0
+        PROCESS_LANE_2OUT 832, 864, v7, v27, 1
+        PROCESS_LANE_2OUT 896, 928, v7, v27, 2
+        PROCESS_LANE_2OUT 960, 992, v7, v27, 3
+
+        add     x7, x7, #1024
+        add     x12, x12, x23
+        add     x11, x11, x23
+        subs    x16, x16, #1
+        b.ne    $Tag.Lnum122
+
+        add     x8, x8, x15
+        add     x9, x9, x15
+        subs    x10, x10, #1
+        b.ne    $Tag.Lnum121
+
+$Tag.Lnum120
+        MEND
+
+;
+; CONV_LOOP_MID_4OUT - Convolution loop without bounds checks that computes
+; four adjacent output points per iteration. Used by both the KernelFlags==0
+; fast path and the general flags path to reduce filter load pressure: one
+; filter load feeds four outputs instead of three.
+;
+; $KHReg names the register used as the KernelHeight counter so each caller can
+; pick one that does not collide with its own live values.
+;
+
+        MACRO
+        CONV_LOOP_MID_4OUT $Tag, $KHReg
+        mov     x7, x4                       ; Filter pointer
+        mov     x8, x1                       ; Input row pointer (output 0)
+        mov     $KHReg, x27                  ; KernelHeight counter
+
+        cbz     $KHReg, $Tag.Lnum130
+        cbz     x28, $Tag.Lnum130
+
+$Tag.Lnum131
+        mov     x12, x8                      ; Input pointer for width (output 0)
+        mov     x16, x28                     ; KernelWidth counter
+
+$Tag.Lnum132
+        add     x9,  x12, x22                ; Output 1 input pointer
+        add     x10, x9,  x22                ; Output 2 input pointer
+        add     x11, x10, x22                ; Output 3 input pointer
+
+        ; Load lanes 0..7 for all outputs.
+        ldp     q20, q21, [x12, #0]
+        ldp     q22, q23, [x9,  #0]
+        ldp     q24, q25, [x10, #0]
+        ldp     q26, q27, [x11, #0]
+
+        PROCESS_LANE_4OUT 0,   32,  v20, v22, v24, v26, 0
+        PROCESS_LANE_4OUT 64,  96,  v20, v22, v24, v26, 1
+        PROCESS_LANE_4OUT 128, 160, v20, v22, v24, v26, 2
+        PROCESS_LANE_4OUT 192, 224, v20, v22, v24, v26, 3
+        PROCESS_LANE_4OUT 256, 288, v21, v23, v25, v27, 0
+        PROCESS_LANE_4OUT 320, 352, v21, v23, v25, v27, 1
+        PROCESS_LANE_4OUT 384, 416, v21, v23, v25, v27, 2
+        PROCESS_LANE_4OUT 448, 480, v21, v23, v25, v27, 3
+
+        ; Load lanes 8..15 for all outputs.
+        ldp     q20, q21, [x12, #32]
+        ldp     q22, q23, [x9,  #32]
+        ldp     q24, q25, [x10, #32]
+        ldp     q26, q27, [x11, #32]
+
+        PROCESS_LANE_4OUT 512, 544, v20, v22, v24, v26, 0
+        PROCESS_LANE_4OUT 576, 608, v20, v22, v24, v26, 1
+        PROCESS_LANE_4OUT 640, 672, v20, v22, v24, v26, 2
+        PROCESS_LANE_4OUT 704, 736, v20, v22, v24, v26, 3
+        PROCESS_LANE_4OUT 768, 800, v21, v23, v25, v27, 0
+        PROCESS_LANE_4OUT 832, 864, v21, v23, v25, v27, 1
+        PROCESS_LANE_4OUT 896, 928, v21, v23, v25, v27, 2
+        PROCESS_LANE_4OUT 960, 992, v21, v23, v25, v27, 3
+
+        add     x7, x7, #1024
+        add     x12, x12, x23
+        subs    x16, x16, #1
+        b.ne    $Tag.Lnum132
+
+        add     x8, x8, x15
+        subs    $KHReg, $KHReg, #1
+        b.ne    $Tag.Lnum131
+
+$Tag.Lnum130
+        MEND
+
+;
+; void
+; MlasConvNchwcFloatKernelNeonAsm(
+;     const float* Input,
+;     const float* Filter,
+;     float* Output,
+;     size_t StrideWidth,
+;     size_t DilationWidth,
+;     size_t FilterCount,
+;     size_t InputStride,
+;     size_t FilterStride,
+;     size_t OutputStride,
+;     size_t KernelHeight,
+;     size_t KernelWidth,
+;     const float* InputBase,
+;     size_t InputWidth,
+;     size_t DilatedInputWidth,
+;     size_t OutputCountLeftPad,
+;     size_t OutputCount,
+;     size_t OutputCountRightPad,
+;     const float* Bias,
+;     unsigned KernelFlags
+;     );
+;
+
+        NESTED_ENTRY MlasConvNchwcFloatKernelNeonAsm
+
+    ; Preserve the incoming stack pointer to access stack-passed arguments.
+    mov     x9, sp
+
+    ; Prologue and callee-saved register spill.
+    ; Save callee-saved SIMD registers v8-v15 per AArch64 ABI.
+    PROLOG_SAVE_REG_PAIR x29, x30, #-272!
+    PROLOG_SAVE_REG_PAIR x19, x20, #16
+    PROLOG_SAVE_REG_PAIR x21, x22, #32
+    PROLOG_SAVE_REG_PAIR x23, x24, #48
+    PROLOG_SAVE_REG_PAIR x25, x26, #64
+    PROLOG_SAVE_REG_PAIR x27, x28, #80
+    PROLOG_NOP stp     q8, q9, [sp, #96]
+    PROLOG_NOP stp     q10, q11, [sp, #128]
+    PROLOG_NOP stp     q12, q13, [sp, #160]
+    PROLOG_NOP stp     q14, q15, [sp, #192]
+
+    ; Move register arguments into callee-saved registers.
+    mov     x19, x0                      ; Input
+    mov     x20, x1                      ; Filter
+    mov     x21, x2                      ; Output
+    mov     x22, x3                      ; StrideWidth (bytes)
+    mov     x23, x4                      ; DilationWidth (bytes)
+    mov     x24, x5                      ; FilterCount
+    mov     x25, x7                      ; FilterStride (bytes)
+
+    ; Load stack arguments using the preserved incoming stack pointer.
+    ldr     x10, [x9, #0]                ; OutputStride (bytes)
+    ldr     x11, [x9, #8]                ; KernelHeight
+    ldr     x12, [x9, #16]               ; KernelWidth
+    ldr     x13, [x9, #24]               ; InputBase
+    ldr     x14, [x9, #32]               ; InputWidth (bytes)
+    ldr     x15, [x9, #40]               ; DilatedInputWidth (bytes)
+    ldr     x16, [x9, #48]               ; OutputCountLeftPad
+    ldr     x17, [x9, #56]               ; OutputCount
+    ldr     x6,  [x9, #72]               ; Bias
+    ldr     w8,  [x9, #80]               ; KernelFlags
+
+    ; Early exit when nothing to compute.
+    mov     x26, x10                     ; OutputStride (bytes)
+    ldr     x10, [x9, #64]               ; OutputCountRightPad
+    add     x0, x16, x17
+    add     x0, x0, x10                  ; x0 = TotalOutputCount
+    cbz     x0, Lepilogue
+    cbz     x24, Lepilogue
+
+    ; Spill the output counts so that x16/x17 can be used as scratch.
+    str     x16, [sp, #224]
+    str     x17, [sp, #232]
+    str     x10, [sp, #240]
+    str     w8,  [sp, #256]
+
+    mov     x27, x11                     ; KernelHeight
+    mov     x28, x12                     ; KernelWidth
+    mov     x17, x6                      ; Bias
+
+    ; Set up a zero vector for ReLU.
+    movi    v31.4s, #0
+
+    ; x1 = current input base for the output index.
+    ; x2 = output offset in bytes for the output index.
+    mov     x1, x19
+    mov     x2, xzr
+
+    ; Fast path when no post-processing flags are enabled. This removes
+    ; repeated flag checks and branches from the steady-state loops.
+    ldr     w9, [sp, #256]
+    tst     w9, #7
+    b.eq    Lkernel_flags0
+
+    ; Process the left padded output region with bounds checks.
+    ldr     x0, [sp, #224]
+    cbz     x0, Loutput_mid_begin
+
+Loutput_left_loop
+
+    ; Initialize per-filter-set pointers and loop counter.
+    mov     x3, x24
+    mov     x4, x20
+    mov     x5, x21
+    mov     x6, x17
+
+Lfilter_left_loop
+
+    ; Clear accumulators.
+    eor     v0.16b, v0.16b, v0.16b
+    eor     v1.16b, v1.16b, v1.16b
+    eor     v2.16b, v2.16b, v2.16b
+    eor     v3.16b, v3.16b, v3.16b
+
+    ; Convolution loop with bounds checks.
+        CONV_LOOP_PAD lb1
+
+    ; Compute the output pointer for this filter set and output index.
+    add     x12, x5, x2
+
+    ; Conditionally accumulate the existing output.
+    ldr     w9, [sp, #256]
+    tst     w9, #1
+    b.eq    Lskip_accumulate
+    ldp     q16, q17, [x12, #0]
+    ldp     q18, q19, [x12, #32]
+    fadd    v0.4s, v0.4s, v16.4s
+    fadd    v1.4s, v1.4s, v17.4s
+    fadd    v2.4s, v2.4s, v18.4s
+    fadd    v3.4s, v3.4s, v19.4s
+
+Lskip_accumulate
+
+    ; Conditionally add bias.
+    tst     w9, #2
+    b.eq    Lskip_bias
+    ldp     q16, q17, [x6, #0]
+    ldp     q18, q19, [x6, #32]
+    fadd    v0.4s, v0.4s, v16.4s
+    fadd    v1.4s, v1.4s, v17.4s
+    fadd    v2.4s, v2.4s, v18.4s
+    fadd    v3.4s, v3.4s, v19.4s
+
+Lskip_bias
+
+    ; Conditionally apply ReLU.
+    tst     w9, #4
+    b.eq    Lskip_relu
+    fmax    v0.4s, v0.4s, v31.4s
+    fmax    v1.4s, v1.4s, v31.4s
+    fmax    v2.4s, v2.4s, v31.4s
+    fmax    v3.4s, v3.4s, v31.4s
+
+Lskip_relu
+
+    ; Store the result.
+    stp     q0, q1, [x12, #0]
+    stp     q2, q3, [x12, #32]
+
+    ; Advance filter/output/bias pointers for the next filter set block.
+    add     x4, x4, x25
+    add     x5, x5, x26
+    add     x6, x6, #64
+    subs    x3, x3, #1
+    b.ne    Lfilter_left_loop
+
+    ; Advance to the next output index.
+    add     x1, x1, x22
+    add     x2, x2, #64
+    subs    x0, x0, #1
+    b.ne    Loutput_left_loop
+
+    ; Process the middle output region without bounds checks.
+Loutput_mid_begin
+    ldr     x0, [sp, #232]
+    cbz     x0, Loutput_right_begin
+
+    ; Process four outputs at a time to amortize the filter loads, matching
+    ; the KernelFlags == 0 path.  Accumulate/bias/ReLU are applied one output
+    ; position at a time below, reusing v16-v19 as scratch, so the wider
+    ; compute loop costs no extra registers.
+    ;
+    ; This matters because ComputeKernelFlags sets ACCUMULATE_OUTPUT for every
+    ; input channel block after the first (snchwc.cpp), so a convolution with
+    ; 256 input channels reaches this path for 15 of its 16 kernel calls.
+    and     x16, x0, #3                  ; Remainder outputs after quads.
+    str     x16, [sp, #248]
+    lsr     x0, x0, #2                   ; Quad output count.
+    cbz     x0, Loutput_mid_triad_begin
+
+    ; The bias pointer is kept in x14 rather than x6 because
+    ; CONV_LOOP_MID_4OUT uses x6 as its KernelHeight counter.  x14 holds
+    ; InputWidth, which is read only by CONV_LOOP_PAD; that macro never runs in
+    ; this bounds-check-free middle region, so x14 is saved once here and
+    ; restored once the quad region is finished.
+    str     x14, [sp, #264]
+
+Loutput_mid_quad_loop
+
+    ; Initialize per-filter-set pointers and loop counter.
+    mov     x3, x24
+    mov     x4, x20
+    mov     x5, x21
+    mov     x14, x17                     ; Bias pointer for this output quad.
+
+Lfilter_mid_quad_loop
+
+    ; Clear accumulators for four output points.
+    eor     v0.16b, v0.16b, v0.16b
+    eor     v1.16b, v1.16b, v1.16b
+    eor     v2.16b, v2.16b, v2.16b
+    eor     v3.16b, v3.16b, v3.16b
+    eor     v4.16b, v4.16b, v4.16b
+    eor     v5.16b, v5.16b, v5.16b
+    eor     v6.16b, v6.16b, v6.16b
+    eor     v7.16b, v7.16b, v7.16b
+    eor     v8.16b, v8.16b, v8.16b
+    eor     v9.16b, v9.16b, v9.16b
+    eor     v10.16b, v10.16b, v10.16b
+    eor     v11.16b, v11.16b, v11.16b
+    eor     v12.16b, v12.16b, v12.16b
+    eor     v13.16b, v13.16b, v13.16b
+    eor     v14.16b, v14.16b, v14.16b
+    eor     v15.16b, v15.16b, v15.16b
+
+    ; Convolution loop without bounds checks computing four outputs.
+        CONV_LOOP_MID_4OUT lb12, x6
+
+    ; Compute the output pointers for the four output points.
+    add     x12, x5, x2
+    add     x11, x12, #64
+    add     x10, x12, #128
+    add     x9,  x12, #192
+
+    ; KernelFlags is held in w16 here, not w9 as elsewhere, because x9 is the
+    ; fourth output pointer in this block.  x16 is scratch inside
+    ; CONV_LOOP_MID_4OUT and dead once the macro returns.
+    ldr     w16, [sp, #256]
+
+    ; Conditionally accumulate the existing output.  Each output position is
+    ; handled separately so that only four scratch registers are needed.
+    tst     w16, #1
+    b.eq    Lskip_accumulate_quad
+    ldp     q16, q17, [x12, #0]
+    ldp     q18, q19, [x12, #32]
+    fadd    v0.4s, v0.4s, v16.4s
+    fadd    v1.4s, v1.4s, v17.4s
+    fadd    v2.4s, v2.4s, v18.4s
+    fadd    v3.4s, v3.4s, v19.4s
+    ldp     q16, q17, [x11, #0]
+    ldp     q18, q19, [x11, #32]
+    fadd    v4.4s, v4.4s, v16.4s
+    fadd    v5.4s, v5.4s, v17.4s
+    fadd    v6.4s, v6.4s, v18.4s
+    fadd    v7.4s, v7.4s, v19.4s
+    ldp     q16, q17, [x10, #0]
+    ldp     q18, q19, [x10, #32]
+    fadd    v8.4s, v8.4s, v16.4s
+    fadd    v9.4s, v9.4s, v17.4s
+    fadd    v10.4s, v10.4s, v18.4s
+    fadd    v11.4s, v11.4s, v19.4s
+    ldp     q16, q17, [x9, #0]
+    ldp     q18, q19, [x9, #32]
+    fadd    v12.4s, v12.4s, v16.4s
+    fadd    v13.4s, v13.4s, v17.4s
+    fadd    v14.4s, v14.4s, v18.4s
+    fadd    v15.4s, v15.4s, v19.4s
+
+Lskip_accumulate_quad
+
+    ; Conditionally add bias.  The same bias block applies to all four outputs.
+    tst     w16, #2
+    b.eq    Lskip_bias_quad
+    ldp     q16, q17, [x14, #0]
+    ldp     q18, q19, [x14, #32]
+    fadd    v0.4s, v0.4s, v16.4s
+    fadd    v1.4s, v1.4s, v17.4s
+    fadd    v2.4s, v2.4s, v18.4s
+    fadd    v3.4s, v3.4s, v19.4s
+    fadd    v4.4s, v4.4s, v16.4s
+    fadd    v5.4s, v5.4s, v17.4s
+    fadd    v6.4s, v6.4s, v18.4s
+    fadd    v7.4s, v7.4s, v19.4s
+    fadd    v8.4s, v8.4s, v16.4s
+    fadd    v9.4s, v9.4s, v17.4s
+    fadd    v10.4s, v10.4s, v18.4s
+    fadd    v11.4s, v11.4s, v19.4s
+    fadd    v12.4s, v12.4s, v16.4s
+    fadd    v13.4s, v13.4s, v17.4s
+    fadd    v14.4s, v14.4s, v18.4s
+    fadd    v15.4s, v15.4s, v19.4s
+
+Lskip_bias_quad
+
+    ; Conditionally apply ReLU.
+    tst     w16, #4
+    b.eq    Lskip_relu_quad
+    fmax    v0.4s, v0.4s, v31.4s
+    fmax    v1.4s, v1.4s, v31.4s
+    fmax    v2.4s, v2.4s, v31.4s
+    fmax    v3.4s, v3.4s, v31.4s
+    fmax    v4.4s, v4.4s, v31.4s
+    fmax    v5.4s, v5.4s, v31.4s
+    fmax    v6.4s, v6.4s, v31.4s
+    fmax    v7.4s, v7.4s, v31.4s
+    fmax    v8.4s, v8.4s, v31.4s
+    fmax    v9.4s, v9.4s, v31.4s
+    fmax    v10.4s, v10.4s, v31.4s
+    fmax    v11.4s, v11.4s, v31.4s
+    fmax    v12.4s, v12.4s, v31.4s
+    fmax    v13.4s, v13.4s, v31.4s
+    fmax    v14.4s, v14.4s, v31.4s
+    fmax    v15.4s, v15.4s, v31.4s
+
+Lskip_relu_quad
+
+    ; Store the results for the four output points.
+    stp     q0, q1, [x12, #0]
+    stp     q2, q3, [x12, #32]
+    stp     q4, q5, [x11, #0]
+    stp     q6, q7, [x11, #32]
+    stp     q8, q9, [x10, #0]
+    stp     q10, q11, [x10, #32]
+    stp     q12, q13, [x9, #0]
+    stp     q14, q15, [x9, #32]
+
+    ; Advance filter/output/bias pointers for the next filter set block.
+    add     x4, x4, x25
+    add     x5, x5, x26
+    add     x14, x14, #64
+    subs    x3, x3, #1
+    b.ne    Lfilter_mid_quad_loop
+
+    ; Advance to the next four output indices.
+    add     x1, x1, x22, lsl #2
+    add     x2, x2, #256
+    subs    x0, x0, #1
+    b.ne    Loutput_mid_quad_loop
+
+    ; Restore InputWidth for the right padded region's bounds checks.
+    ldr     x14, [sp, #264]
+
+    ; Handle the 0..3 outputs left over after the quad loop.
+Loutput_mid_triad_begin
+    ldr     x0, [sp, #248]
+    cbz     x0, Loutput_right_begin
+    cmp     x0, #3
+    b.ne    Loutput_mid_triad_skip
+    ; Exactly three outputs remain: run one triad and no further remainder.
+    str     xzr, [sp, #248]
+    mov     x0, #1
+    b       Loutput_mid_triad_loop
+
+Loutput_mid_triad_skip
+    ; Fewer than three remain, so fall through to the pair/single handling.
+    b       Loutput_mid_pair_begin
+
+Loutput_mid_triad_loop
+
+    ; Initialize per-filter-set pointers and loop counter.
+    mov     x3, x24
+    mov     x4, x20
+    mov     x5, x21
+    mov     x6, x17
+
+    ; When four or more filter sets remain, process four at a time with a
+    ; single walk of the input window.  Fewer than four falls through to the
+    ; original one-set-at-a-time loop below, which also handles the remainder
+    ; left over by this loop.
+    cmp     x3, #4
+    b.lo    Lfilter_mid_triad_loop
+
+Lfilter_mid_triad_4filt_loop
+
+    ; Clear accumulators.  v0-v2 hold filter set 0 across outputs 0-2, v3-v5
+    ; set 1, v6-v8 set 2 and v9-v11 set 3.
+    eor     v0.16b, v0.16b, v0.16b
+    eor     v1.16b, v1.16b, v1.16b
+    eor     v2.16b, v2.16b, v2.16b
+    eor     v3.16b, v3.16b, v3.16b
+    eor     v4.16b, v4.16b, v4.16b
+    eor     v5.16b, v5.16b, v5.16b
+    eor     v6.16b, v6.16b, v6.16b
+    eor     v7.16b, v7.16b, v7.16b
+    eor     v8.16b, v8.16b, v8.16b
+    eor     v9.16b, v9.16b, v9.16b
+    eor     v10.16b, v10.16b, v10.16b
+    eor     v11.16b, v11.16b, v11.16b
+
+    ; One walk of the input window feeding four filter sets.
+        CONV_LOOP_MID_3OUT_4FILT lb14
+
+    ; Output pointers.  x12 is filter set 0's base for output 0; each further
+    ; set is one OutputStride on, and each further output 64 bytes on.
+    add     x12, x5, x2
+    add     x13, x12, x26
+    add     x16, x13, x26
+    add     x11, x16, x26
+
+    ldr     w9, [sp, #256]
+
+    ; Conditionally accumulate the existing output.
+    tst     w9, #1
+    b.eq    Lskip_accumulate_triad_4filt
+    ldr     q16, [x12, #0]
+    ldr     q17, [x12, #64]
+    ldr     q18, [x12, #128]
+    ldr     q19, [x13, #0]
+    ldr     q20, [x13, #64]
+    ldr     q21, [x13, #128]
+    fadd    v0.4s, v0.4s, v16.4s
+    fadd    v1.4s, v1.4s, v17.4s
+    fadd    v2.4s, v2.4s, v18.4s
+    fadd    v3.4s, v3.4s, v19.4s
+    fadd    v4.4s, v4.4s, v20.4s
+    fadd    v5.4s, v5.4s, v21.4s
+    ldr     q16, [x16, #0]
+    ldr     q17, [x16, #64]
+    ldr     q18, [x16, #128]
+    ldr     q19, [x21, #0]
+    ldr     q20, [x21, #64]
+    ldr     q21, [x21, #128]
+    fadd    v6.4s,  v6.4s,  v16.4s
+    fadd    v7.4s,  v7.4s,  v17.4s
+    fadd    v8.4s,  v8.4s,  v18.4s
+    fadd    v9.4s,  v9.4s,  v19.4s
+    fadd    v10.4s, v10.4s, v20.4s
+    fadd    v11.4s, v11.4s, v21.4s
+
+Lskip_accumulate_triad_4filt
+
+    ; Conditionally add bias.  Each filter set has its own bias vector, and
+    ; that one vector is shared by all three of the set's output points.
+    tst     w9, #2
+    b.eq    Lskip_bias_triad_4filt
+    ldr     q16, [x6, #0]
+    ldr     q17, [x6, #16]
+    ldr     q18, [x6, #32]
+    ldr     q19, [x6, #48]
+    fadd    v0.4s, v0.4s, v16.4s
+    fadd    v1.4s, v1.4s, v16.4s
+    fadd    v2.4s, v2.4s, v16.4s
+    fadd    v3.4s, v3.4s, v17.4s
+    fadd    v4.4s, v4.4s, v17.4s
+    fadd    v5.4s, v5.4s, v17.4s
+    fadd    v6.4s,  v6.4s,  v18.4s
+    fadd    v7.4s,  v7.4s,  v18.4s
+    fadd    v8.4s,  v8.4s,  v18.4s
+    fadd    v9.4s,  v9.4s,  v19.4s
+    fadd    v10.4s, v10.4s, v19.4s
+    fadd    v11.4s, v11.4s, v19.4s
+
+Lskip_bias_triad_4filt
+
+    ; Conditionally apply ReLU.
+    tst     w9, #4
+    b.eq    Lskip_relu_triad_4filt
+    fmax    v0.4s, v0.4s, v31.4s
+    fmax    v1.4s, v1.4s, v31.4s
+    fmax    v2.4s, v2.4s, v31.4s
+    fmax    v3.4s, v3.4s, v31.4s
+    fmax    v4.4s, v4.4s, v31.4s
+    fmax    v5.4s, v5.4s, v31.4s
+    fmax    v6.4s, v6.4s, v31.4s
+    fmax    v7.4s, v7.4s, v31.4s
+    fmax    v8.4s, v8.4s, v31.4s
+    fmax    v9.4s, v9.4s, v31.4s
+    fmax    v10.4s, v10.4s, v31.4s
+    fmax    v11.4s, v11.4s, v31.4s
+
+Lskip_relu_triad_4filt
+
+    ; Store each filter set's three output points.
+    str     q0, [x12, #0]
+    str     q1, [x12, #64]
+    str     q2, [x12, #128]
+    str     q3, [x13, #0]
+    str     q4, [x13, #64]
+    str     q5, [x13, #128]
+    str     q6, [x16, #0]
+    str     q7, [x16, #64]
+    str     q8, [x16, #128]
+    str     q9, [x21, #0]
+    str     q10, [x21, #64]
+    str     q11, [x21, #128]
+
+    ; Advance filter/output/bias pointers over the four sets just processed.
+    add     x4, x4, x25, lsl #2
+    add     x5, x5, x26, lsl #2
+    add     x6, x6, #64
+    sub     x3, x3, #4
+    cmp     x3, #4
+    b.hs    Lfilter_mid_triad_4filt_loop
+
+    ; Fall through to the single-set loop for any remaining filter sets.
+    cbz     x3, Lfilter_mid_triad_done
+
+Lfilter_mid_triad_loop
+
+    ; Clear accumulators for three output points.
+    eor     v0.16b, v0.16b, v0.16b
+    eor     v1.16b, v1.16b, v1.16b
+    eor     v2.16b, v2.16b, v2.16b
+    eor     v3.16b, v3.16b, v3.16b
+    eor     v4.16b, v4.16b, v4.16b
+    eor     v5.16b, v5.16b, v5.16b
+    eor     v6.16b, v6.16b, v6.16b
+    eor     v7.16b, v7.16b, v7.16b
+    eor     v8.16b, v8.16b, v8.16b
+    eor     v9.16b, v9.16b, v9.16b
+    eor     v10.16b, v10.16b, v10.16b
+    eor     v11.16b, v11.16b, v11.16b
+
+    ; Convolution loop without bounds checks computing three outputs.
+        CONV_LOOP_MID_3OUT lb2
+
+    ; Compute the output pointers for the three output points.
+    add     x12, x5, x2
+    add     x11, x12, #64
+    add     x10, x12, #128
+
+    ; Conditionally accumulate the existing output.
+    ldr     w9, [sp, #256]
+    tst     w9, #1
+    b.eq    Lskip_accumulate_triad
+    ldp     q16, q17, [x12, #0]
+    ldp     q18, q19, [x12, #32]
+    ldp     q20, q21, [x11, #0]
+    ldp     q22, q23, [x11, #32]
+    ldp     q24, q25, [x10, #0]
+    ldp     q26, q27, [x10, #32]
+    fadd    v0.4s, v0.4s, v16.4s
+    fadd    v1.4s, v1.4s, v17.4s
+    fadd    v2.4s, v2.4s, v18.4s
+    fadd    v3.4s, v3.4s, v19.4s
+    fadd    v4.4s, v4.4s, v20.4s
+    fadd    v5.4s, v5.4s, v21.4s
+    fadd    v6.4s, v6.4s, v22.4s
+    fadd    v7.4s, v7.4s, v23.4s
+    fadd    v8.4s, v8.4s, v24.4s
+    fadd    v9.4s, v9.4s, v25.4s
+    fadd    v10.4s, v10.4s, v26.4s
+    fadd    v11.4s, v11.4s, v27.4s
+
+Lskip_accumulate_triad
+
+    ; Conditionally add bias.
+    tst     w9, #2
+    b.eq    Lskip_bias_triad
+    ldp     q16, q17, [x6, #0]
+    ldp     q18, q19, [x6, #32]
+    fadd    v0.4s, v0.4s, v16.4s
+    fadd    v1.4s, v1.4s, v17.4s
+    fadd    v2.4s, v2.4s, v18.4s
+    fadd    v3.4s, v3.4s, v19.4s
+    fadd    v4.4s, v4.4s, v16.4s
+    fadd    v5.4s, v5.4s, v17.4s
+    fadd    v6.4s, v6.4s, v18.4s
+    fadd    v7.4s, v7.4s, v19.4s
+    fadd    v8.4s, v8.4s, v16.4s
+    fadd    v9.4s, v9.4s, v17.4s
+    fadd    v10.4s, v10.4s, v18.4s
+    fadd    v11.4s, v11.4s, v19.4s
+
+Lskip_bias_triad
+
+    ; Conditionally apply ReLU.
+    tst     w9, #4
+    b.eq    Lskip_relu_triad
+    fmax    v0.4s, v0.4s, v31.4s
+    fmax    v1.4s, v1.4s, v31.4s
+    fmax    v2.4s, v2.4s, v31.4s
+    fmax    v3.4s, v3.4s, v31.4s
+    fmax    v4.4s, v4.4s, v31.4s
+    fmax    v5.4s, v5.4s, v31.4s
+    fmax    v6.4s, v6.4s, v31.4s
+    fmax    v7.4s, v7.4s, v31.4s
+    fmax    v8.4s, v8.4s, v31.4s
+    fmax    v9.4s, v9.4s, v31.4s
+    fmax    v10.4s, v10.4s, v31.4s
+    fmax    v11.4s, v11.4s, v31.4s
+
+Lskip_relu_triad
+
+    ; Store the results for the three output points.
+    stp     q0, q1, [x12, #0]
+    stp     q2, q3, [x12, #32]
+    stp     q4, q5, [x11, #0]
+    stp     q6, q7, [x11, #32]
+    stp     q8, q9, [x10, #0]
+    stp     q10, q11, [x10, #32]
+
+    ; Advance filter/output/bias pointers for the next filter set block.
+    add     x4, x4, x25
+    add     x5, x5, x26
+    add     x6, x6, #64
+    subs    x3, x3, #1
+    b.ne    Lfilter_mid_triad_loop
+
+Lfilter_mid_triad_done
+
+    ; Advance to the next three output indices.
+    add     x1, x1, x22, lsl #1
+    add     x1, x1, x22
+    add     x2, x2, #192
+    subs    x0, x0, #1
+    b.ne    Loutput_mid_triad_loop
+
+Loutput_mid_pair_begin
+    ldr     x0, [sp, #248]
+    and     x16, x0, #1
+    str     x16, [sp, #248]
+    lsr     x0, x0, #1
+    cbz     x0, Loutput_mid_single_begin
+
+Loutput_mid_pair_loop
+
+    ; Initialize per-filter-set pointers and loop counter.
+    mov     x3, x24
+    mov     x4, x20
+    mov     x5, x21
+    mov     x6, x17
+
+Lfilter_mid_pair_loop
+
+    ; Clear accumulators for both output points.
+    eor     v0.16b, v0.16b, v0.16b
+    eor     v1.16b, v1.16b, v1.16b
+    eor     v2.16b, v2.16b, v2.16b
+    eor     v3.16b, v3.16b, v3.16b
+    eor     v20.16b, v20.16b, v20.16b
+    eor     v21.16b, v21.16b, v21.16b
+    eor     v22.16b, v22.16b, v22.16b
+    eor     v23.16b, v23.16b, v23.16b
+
+    ; Convolution loop without bounds checks computing two outputs.
+        CONV_LOOP_MID_2OUT lb3
+
+    ; Compute the output pointers for the two output points.
+    add     x12, x5, x2
+    add     x11, x12, #64
+
+    ; Conditionally accumulate the existing output.
+    ldr     w9, [sp, #256]
+    tst     w9, #1
+    b.eq    Lskip_accumulate_pair
+    ldp     q16, q17, [x12, #0]
+    ldp     q18, q19, [x12, #32]
+    ldp     q24, q25, [x11, #0]
+    ldp     q26, q27, [x11, #32]
+    fadd    v0.4s, v0.4s, v16.4s
+    fadd    v1.4s, v1.4s, v17.4s
+    fadd    v2.4s, v2.4s, v18.4s
+    fadd    v3.4s, v3.4s, v19.4s
+    fadd    v20.4s, v20.4s, v24.4s
+    fadd    v21.4s, v21.4s, v25.4s
+    fadd    v22.4s, v22.4s, v26.4s
+    fadd    v23.4s, v23.4s, v27.4s
+
+Lskip_accumulate_pair
+
+    ; Conditionally add bias.
+    tst     w9, #2
+    b.eq    Lskip_bias_pair
+    ldp     q16, q17, [x6, #0]
+    ldp     q18, q19, [x6, #32]
+    fadd    v0.4s, v0.4s, v16.4s
+    fadd    v1.4s, v1.4s, v17.4s
+    fadd    v2.4s, v2.4s, v18.4s
+    fadd    v3.4s, v3.4s, v19.4s
+    fadd    v20.4s, v20.4s, v16.4s
+    fadd    v21.4s, v21.4s, v17.4s
+    fadd    v22.4s, v22.4s, v18.4s
+    fadd    v23.4s, v23.4s, v19.4s
+
+Lskip_bias_pair
+
+    ; Conditionally apply ReLU.
+    tst     w9, #4
+    b.eq    Lskip_relu_pair
+    fmax    v0.4s, v0.4s, v31.4s
+    fmax    v1.4s, v1.4s, v31.4s
+    fmax    v2.4s, v2.4s, v31.4s
+    fmax    v3.4s, v3.4s, v31.4s
+    fmax    v20.4s, v20.4s, v31.4s
+    fmax    v21.4s, v21.4s, v31.4s
+    fmax    v22.4s, v22.4s, v31.4s
+    fmax    v23.4s, v23.4s, v31.4s
+
+Lskip_relu_pair
+
+    ; Store the results for the two output points.
+    stp     q0, q1, [x12, #0]
+    stp     q2, q3, [x12, #32]
+    stp     q20, q21, [x11, #0]
+    stp     q22, q23, [x11, #32]
+
+    ; Advance filter/output/bias pointers for the next filter set block.
+    add     x4, x4, x25
+    add     x5, x5, x26
+    add     x6, x6, #64
+    subs    x3, x3, #1
+    b.ne    Lfilter_mid_pair_loop
+
+    ; Advance to the next two output indices.
+    add     x1, x1, x22, lsl #1
+    add     x2, x2, #128
+    subs    x0, x0, #1
+    b.ne    Loutput_mid_pair_loop
+
+Loutput_mid_single_begin
+    ldr     x0, [sp, #248]
+    cbz     x0, Loutput_right_begin
+
+Loutput_mid_loop
+
+    ; Initialize per-filter-set pointers and loop counter.
+    mov     x3, x24
+    mov     x4, x20
+    mov     x5, x21
+    mov     x6, x17
+
+Lfilter_mid_loop
+
+    ; Clear accumulators.
+    eor     v0.16b, v0.16b, v0.16b
+    eor     v1.16b, v1.16b, v1.16b
+    eor     v2.16b, v2.16b, v2.16b
+    eor     v3.16b, v3.16b, v3.16b
+
+    ; Convolution loop without bounds checks.
+        CONV_LOOP_MID lb4
+
+    ; Compute the output pointer for this filter set and output index.
+    add     x12, x5, x2
+
+    ; Conditionally accumulate the existing output.
+    ldr     w9, [sp, #256]
+    tst     w9, #1
+    b.eq    Lskip_accumulate_mid
+    ldp     q16, q17, [x12, #0]
+    ldp     q18, q19, [x12, #32]
+    fadd    v0.4s, v0.4s, v16.4s
+    fadd    v1.4s, v1.4s, v17.4s
+    fadd    v2.4s, v2.4s, v18.4s
+    fadd    v3.4s, v3.4s, v19.4s
+
+Lskip_accumulate_mid
+
+    ; Conditionally add bias.
+    tst     w9, #2
+    b.eq    Lskip_bias_mid
+    ldp     q16, q17, [x6, #0]
+    ldp     q18, q19, [x6, #32]
+    fadd    v0.4s, v0.4s, v16.4s
+    fadd    v1.4s, v1.4s, v17.4s
+    fadd    v2.4s, v2.4s, v18.4s
+    fadd    v3.4s, v3.4s, v19.4s
+
+Lskip_bias_mid
+
+    ; Conditionally apply ReLU.
+    tst     w9, #4
+    b.eq    Lskip_relu_mid
+    fmax    v0.4s, v0.4s, v31.4s
+    fmax    v1.4s, v1.4s, v31.4s
+    fmax    v2.4s, v2.4s, v31.4s
+    fmax    v3.4s, v3.4s, v31.4s
+
+Lskip_relu_mid
+
+    ; Store the result.
+    stp     q0, q1, [x12, #0]
+    stp     q2, q3, [x12, #32]
+
+    ; Advance filter/output/bias pointers for the next filter set block.
+    add     x4, x4, x25
+    add     x5, x5, x26
+    add     x6, x6, #64
+    subs    x3, x3, #1
+    b.ne    Lfilter_mid_loop
+
+    ; Advance to the next output index.
+    add     x1, x1, x22
+    add     x2, x2, #64
+    subs    x0, x0, #1
+    b.ne    Loutput_mid_loop
+
+    ; Process the right padded output region with bounds checks.
+Loutput_right_begin
+    ldr     x0, [sp, #240]
+    cbz     x0, Lepilogue
+
+Loutput_right_loop
+
+    ; Initialize per-filter-set pointers and loop counter.
+    mov     x3, x24
+    mov     x4, x20
+    mov     x5, x21
+    mov     x6, x17
+
+Lfilter_right_loop
+
+    ; Clear accumulators.
+    eor     v0.16b, v0.16b, v0.16b
+    eor     v1.16b, v1.16b, v1.16b
+    eor     v2.16b, v2.16b, v2.16b
+    eor     v3.16b, v3.16b, v3.16b
+
+    ; Convolution loop with bounds checks.
+        CONV_LOOP_PAD lb5
+
+    ; Compute the output pointer for this filter set and output index.
+    add     x12, x5, x2
+
+    ; Conditionally accumulate the existing output.
+    ldr     w9, [sp, #256]
+    tst     w9, #1
+    b.eq    Lskip_accumulate_right
+    ldp     q16, q17, [x12, #0]
+    ldp     q18, q19, [x12, #32]
+    fadd    v0.4s, v0.4s, v16.4s
+    fadd    v1.4s, v1.4s, v17.4s
+    fadd    v2.4s, v2.4s, v18.4s
+    fadd    v3.4s, v3.4s, v19.4s
+
+Lskip_accumulate_right
+
+    ; Conditionally add bias.
+    tst     w9, #2
+    b.eq    Lskip_bias_right
+    ldp     q16, q17, [x6, #0]
+    ldp     q18, q19, [x6, #32]
+    fadd    v0.4s, v0.4s, v16.4s
+    fadd    v1.4s, v1.4s, v17.4s
+    fadd    v2.4s, v2.4s, v18.4s
+    fadd    v3.4s, v3.4s, v19.4s
+
+Lskip_bias_right
+
+    ; Conditionally apply ReLU.
+    tst     w9, #4
+    b.eq    Lskip_relu_right
+    fmax    v0.4s, v0.4s, v31.4s
+    fmax    v1.4s, v1.4s, v31.4s
+    fmax    v2.4s, v2.4s, v31.4s
+    fmax    v3.4s, v3.4s, v31.4s
+
+Lskip_relu_right
+
+    ; Store the result.
+    stp     q0, q1, [x12, #0]
+    stp     q2, q3, [x12, #32]
+
+    ; Advance filter/output/bias pointers for the next filter set block.
+    add     x4, x4, x25
+    add     x5, x5, x26
+    add     x6, x6, #64
+    subs    x3, x3, #1
+    b.ne    Lfilter_right_loop
+
+    ; Advance to the next output index.
+    add     x1, x1, x22
+    add     x2, x2, #64
+    subs    x0, x0, #1
+    b.ne    Loutput_right_loop
+
+    ; Skip the flag-free fast path section.
+    b       Lepilogue
+
+Lkernel_flags0
+
+    ; KernelFlags == 0 fast path: no accumulation, bias, or activation.
+
+    ; Process the left padded output region with bounds checks.
+    ldr     x0, [sp, #224]
+    cbz     x0, Loutput_mid_begin_flags0
+
+    ; Pair up the padded outputs so that one filter load serves two of them.
+    ; The padded columns are a small fraction of the row but are computed one
+    ; output at a time, so they cost about three times what an interior column
+    ; does; for Out=7x7 shapes they are two of the seven columns.
+    and     x16, x0, #1                  ; Odd output left over after pairs.
+    str     x16, [sp, #264]
+    lsr     x0, x0, #1                   ; Pair count.
+    cbz     x0, Loutput_left_single_begin_flags0
+
+Loutput_left_pair_loop_flags0
+
+    ; Initialize per-filter-set pointers and loop counter.
+    mov     x3, x24
+    mov     x4, x20
+    mov     x5, x21
+
+Lfilter_left_pair_loop_flags0
+
+    ; Clear accumulators for both output points.
+    eor     v0.16b, v0.16b, v0.16b
+    eor     v1.16b, v1.16b, v1.16b
+    eor     v2.16b, v2.16b, v2.16b
+    eor     v3.16b, v3.16b, v3.16b
+    eor     v20.16b, v20.16b, v20.16b
+    eor     v21.16b, v21.16b, v21.16b
+    eor     v22.16b, v22.16b, v22.16b
+    eor     v23.16b, v23.16b, v23.16b
+
+    ; Convolution loop with bounds checks computing two outputs.
+        CONV_LOOP_PAD_2OUT lb13
+
+    ; Compute the output pointers for the two output points.
+    add     x12, x5, x2
+    add     x11, x12, #64
+
+    ; Store the results for the two output points.
+    stp     q0, q1, [x12, #0]
+    stp     q2, q3, [x12, #32]
+    stp     q20, q21, [x11, #0]
+    stp     q22, q23, [x11, #32]
+
+    ; Advance filter/output pointers for the next filter set block.
+    add     x4, x4, x25
+    add     x5, x5, x26
+    subs    x3, x3, #1
+    b.ne    Lfilter_left_pair_loop_flags0
+
+    ; Advance to the next two output indices.
+    add     x1, x1, x22, lsl #1
+    add     x2, x2, #128
+    subs    x0, x0, #1
+    b.ne    Loutput_left_pair_loop_flags0
+
+Loutput_left_single_begin_flags0
+    ldr     x0, [sp, #264]
+    cbz     x0, Loutput_mid_begin_flags0
+
+Loutput_left_loop_flags0
+
+    ; Initialize per-filter-set pointers and loop counter.
+    mov     x3, x24
+    mov     x4, x20
+    mov     x5, x21
+
+Lfilter_left_loop_flags0
+
+    ; Clear accumulators.
+    eor     v0.16b, v0.16b, v0.16b
+    eor     v1.16b, v1.16b, v1.16b
+    eor     v2.16b, v2.16b, v2.16b
+    eor     v3.16b, v3.16b, v3.16b
+
+    ; Convolution loop with bounds checks.
+        CONV_LOOP_PAD lb6
+
+    ; Compute the output pointer for this filter set and output index.
+    add     x12, x5, x2
+
+    ; Store the result.
+    stp     q0, q1, [x12, #0]
+    stp     q2, q3, [x12, #32]
+
+    ; Advance filter/output pointers for the next filter set block.
+    add     x4, x4, x25
+    add     x5, x5, x26
+    subs    x3, x3, #1
+    b.ne    Lfilter_left_loop_flags0
+
+    ; Advance to the next output index.
+    add     x1, x1, x22
+    add     x2, x2, #64
+    subs    x0, x0, #1
+    b.ne    Loutput_left_loop_flags0
+
+    ; Process the middle output region without bounds checks.
+Loutput_mid_begin_flags0
+    ldr     x0, [sp, #232]
+    cbz     x0, Loutput_right_begin_flags0
+
+    ; Process four outputs at a time to amortize the filter loads.
+    and     x16, x0, #3                  ; Remainder outputs after quads.
+    str     x16, [sp, #248]
+    lsr     x0, x0, #2                   ; Quad output count.
+    cbz     x0, Loutput_mid_remainder_begin_flags0
+
+Loutput_mid_quad_loop_flags0
+
+    ; Initialize per-filter-set pointers and loop counter.
+    mov     x3, x24
+    mov     x4, x20
+    mov     x5, x21
+
+Lfilter_mid_quad_loop_flags0
+
+    ; Clear accumulators for four output points.
+    eor     v0.16b, v0.16b, v0.16b
+    eor     v1.16b, v1.16b, v1.16b
+    eor     v2.16b, v2.16b, v2.16b
+    eor     v3.16b, v3.16b, v3.16b
+    eor     v4.16b, v4.16b, v4.16b
+    eor     v5.16b, v5.16b, v5.16b
+    eor     v6.16b, v6.16b, v6.16b
+    eor     v7.16b, v7.16b, v7.16b
+    eor     v8.16b, v8.16b, v8.16b
+    eor     v9.16b, v9.16b, v9.16b
+    eor     v10.16b, v10.16b, v10.16b
+    eor     v11.16b, v11.16b, v11.16b
+    eor     v12.16b, v12.16b, v12.16b
+    eor     v13.16b, v13.16b, v13.16b
+    eor     v14.16b, v14.16b, v14.16b
+    eor     v15.16b, v15.16b, v15.16b
+
+    ; Convolution loop without bounds checks computing four outputs.
+        CONV_LOOP_MID_4OUT lb7, x6
+
+    ; Compute the output pointers for the four output points.
+    add     x12, x5, x2
+    add     x11, x12, #64
+    add     x10, x12, #128
+    add     x9,  x12, #192
+
+    ; Store the results for the four output points.
+    stp     q0, q1, [x12, #0]
+    stp     q2, q3, [x12, #32]
+    stp     q4, q5, [x11, #0]
+    stp     q6, q7, [x11, #32]
+    stp     q8, q9, [x10, #0]
+    stp     q10, q11, [x10, #32]
+    stp     q12, q13, [x9, #0]
+    stp     q14, q15, [x9, #32]
+
+    ; Advance filter/output pointers for the next filter set block.
+    add     x4, x4, x25
+    add     x5, x5, x26
+    subs    x3, x3, #1
+    b.ne    Lfilter_mid_quad_loop_flags0
+
+    ; Advance to the next four output indices.
+    add     x1, x1, x22, lsl #2
+    add     x2, x2, #256
+    subs    x0, x0, #1
+    b.ne    Loutput_mid_quad_loop_flags0
+
+Loutput_mid_remainder_begin_flags0
+    ldr     x0, [sp, #248]
+    cbz     x0, Loutput_right_begin_flags0
+    cmp     x0, #3
+    b.ne    Loutput_mid_remainder_not3_flags0
+    ; Exactly three outputs remain.
+    str     xzr, [sp, #248]
+    mov     x0, #1
+    b       Loutput_mid_triad_loop_flags0
+
+Loutput_mid_remainder_not3_flags0
+    cmp     x0, #2
+    b.ne    Loutput_mid_remainder_single_flags0
+    ; Exactly two outputs remain.
+    str     xzr, [sp, #248]
+    mov     x0, #1
+    b       Loutput_mid_pair_loop_flags0
+
+Loutput_mid_remainder_single_flags0
+    ; Exactly one output remains.
+    mov     x0, #1
+    b       Loutput_mid_loop_flags0
+
+Loutput_mid_triad_loop_flags0
+
+    ; Initialize per-filter-set pointers and loop counter.
+    mov     x3, x24
+    mov     x4, x20
+    mov     x5, x21
+
+Lfilter_mid_triad_loop_flags0
+
+    ; Clear accumulators for three output points.
+    eor     v0.16b, v0.16b, v0.16b
+    eor     v1.16b, v1.16b, v1.16b
+    eor     v2.16b, v2.16b, v2.16b
+    eor     v3.16b, v3.16b, v3.16b
+    eor     v4.16b, v4.16b, v4.16b
+    eor     v5.16b, v5.16b, v5.16b
+    eor     v6.16b, v6.16b, v6.16b
+    eor     v7.16b, v7.16b, v7.16b
+    eor     v8.16b, v8.16b, v8.16b
+    eor     v9.16b, v9.16b, v9.16b
+    eor     v10.16b, v10.16b, v10.16b
+    eor     v11.16b, v11.16b, v11.16b
+
+    ; Convolution loop without bounds checks computing three outputs.
+        CONV_LOOP_MID_3OUT lb8
+
+    ; Compute the output pointers for the three output points.
+    add     x12, x5, x2
+    add     x11, x12, #64
+    add     x10, x12, #128
+
+    ; Store the results for the three output points.
+    stp     q0, q1, [x12, #0]
+    stp     q2, q3, [x12, #32]
+    stp     q4, q5, [x11, #0]
+    stp     q6, q7, [x11, #32]
+    stp     q8, q9, [x10, #0]
+    stp     q10, q11, [x10, #32]
+
+    ; Advance filter/output pointers for the next filter set block.
+    add     x4, x4, x25
+    add     x5, x5, x26
+    subs    x3, x3, #1
+    b.ne    Lfilter_mid_triad_loop_flags0
+
+    ; Advance to the next three output indices.
+    add     x1, x1, x22, lsl #1
+    add     x1, x1, x22
+    add     x2, x2, #192
+    subs    x0, x0, #1
+    b.ne    Loutput_mid_triad_loop_flags0
+
+Loutput_mid_pair_begin_flags0
+    ldr     x0, [sp, #248]
+    and     x16, x0, #1
+    str     x16, [sp, #248]
+    lsr     x0, x0, #1
+    cbz     x0, Loutput_mid_single_begin_flags0
+
+Loutput_mid_pair_loop_flags0
+
+    ; Initialize per-filter-set pointers and loop counter.
+    mov     x3, x24
+    mov     x4, x20
+    mov     x5, x21
+
+Lfilter_mid_pair_loop_flags0
+
+    ; Clear accumulators for both output points.
+    eor     v0.16b, v0.16b, v0.16b
+    eor     v1.16b, v1.16b, v1.16b
+    eor     v2.16b, v2.16b, v2.16b
+    eor     v3.16b, v3.16b, v3.16b
+    eor     v20.16b, v20.16b, v20.16b
+    eor     v21.16b, v21.16b, v21.16b
+    eor     v22.16b, v22.16b, v22.16b
+    eor     v23.16b, v23.16b, v23.16b
+
+    ; Convolution loop without bounds checks computing two outputs.
+        CONV_LOOP_MID_2OUT lb9
+
+    ; Compute the output pointers for the two output points.
+    add     x12, x5, x2
+    add     x11, x12, #64
+
+    ; Store the results for the two output points.
+    stp     q0, q1, [x12, #0]
+    stp     q2, q3, [x12, #32]
+    stp     q20, q21, [x11, #0]
+    stp     q22, q23, [x11, #32]
+
+    ; Advance filter/output pointers for the next filter set block.
+    add     x4, x4, x25
+    add     x5, x5, x26
+    subs    x3, x3, #1
+    b.ne    Lfilter_mid_pair_loop_flags0
+
+    ; Advance to the next two output indices.
+    add     x1, x1, x22, lsl #1
+    add     x2, x2, #128
+    subs    x0, x0, #1
+    b.ne    Loutput_mid_pair_loop_flags0
+
+Loutput_mid_single_begin_flags0
+    ldr     x0, [sp, #248]
+    cbz     x0, Loutput_right_begin_flags0
+
+Loutput_mid_loop_flags0
+
+    ; Initialize per-filter-set pointers and loop counter.
+    mov     x3, x24
+    mov     x4, x20
+    mov     x5, x21
+
+Lfilter_mid_loop_flags0
+
+    ; Clear accumulators.
+    eor     v0.16b, v0.16b, v0.16b
+    eor     v1.16b, v1.16b, v1.16b
+    eor     v2.16b, v2.16b, v2.16b
+    eor     v3.16b, v3.16b, v3.16b
+
+    ; Convolution loop without bounds checks.
+        CONV_LOOP_MID lb10
+
+    ; Compute the output pointer for this filter set and output index.
+    add     x12, x5, x2
+
+    ; Store the result.
+    stp     q0, q1, [x12, #0]
+    stp     q2, q3, [x12, #32]
+
+    ; Advance filter/output pointers for the next filter set block.
+    add     x4, x4, x25
+    add     x5, x5, x26
+    subs    x3, x3, #1
+    b.ne    Lfilter_mid_loop_flags0
+
+    ; Advance to the next output index.
+    add     x1, x1, x22
+    add     x2, x2, #64
+    subs    x0, x0, #1
+    b.ne    Loutput_mid_loop_flags0
+
+    ; Process the right padded output region with bounds checks.
+Loutput_right_begin_flags0
+    ldr     x0, [sp, #240]
+    cbz     x0, Lepilogue
+
+Loutput_right_loop_flags0
+
+    ; Initialize per-filter-set pointers and loop counter.
+    mov     x3, x24
+    mov     x4, x20
+    mov     x5, x21
+
+Lfilter_right_loop_flags0
+
+    ; Clear accumulators.
+    eor     v0.16b, v0.16b, v0.16b
+    eor     v1.16b, v1.16b, v1.16b
+    eor     v2.16b, v2.16b, v2.16b
+    eor     v3.16b, v3.16b, v3.16b
+
+    ; Convolution loop with bounds checks.
+        CONV_LOOP_PAD lb11
+
+    ; Compute the output pointer for this filter set and output index.
+    add     x12, x5, x2
+
+    ; Store the result.
+    stp     q0, q1, [x12, #0]
+    stp     q2, q3, [x12, #32]
+
+    ; Advance filter/output pointers for the next filter set block.
+    add     x4, x4, x25
+    add     x5, x5, x26
+    subs    x3, x3, #1
+    b.ne    Lfilter_right_loop_flags0
+
+    ; Advance to the next output index.
+    add     x1, x1, x22
+    add     x2, x2, #64
+    subs    x0, x0, #1
+    b.ne    Loutput_right_loop_flags0
+
+    b       Lepilogue
+
+Lepilogue
+
+    ; Epilogue and callee-saved register restore.
+    EPILOG_NOP ldp     q14, q15, [sp, #192]
+    EPILOG_NOP ldp     q12, q13, [sp, #160]
+    EPILOG_NOP ldp     q10, q11, [sp, #128]
+    EPILOG_NOP ldp     q8, q9, [sp, #96]
+    EPILOG_RESTORE_REG_PAIR x27, x28, #80
+    EPILOG_RESTORE_REG_PAIR x25, x26, #64
+    EPILOG_RESTORE_REG_PAIR x23, x24, #48
+    EPILOG_RESTORE_REG_PAIR x21, x22, #32
+    EPILOG_RESTORE_REG_PAIR x19, x20, #16
+    EPILOG_RESTORE_REG_PAIR x29, x30, #272!
+    EPILOG_RETURN
+
+        NESTED_END MlasConvNchwcFloatKernelNeonAsm
+
+        END

--- a/onnxruntime/core/mlas/lib/arm64/SconvPointwiseKernelNeon.asm
+++ b/onnxruntime/core/mlas/lib/arm64/SconvPointwiseKernelNeon.asm
@@ -1,0 +1,525 @@
+        ;++
+        ;
+        ; SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+        ; SPDX-License-Identifier: MIT
+        ;
+        ; Module Name:
+        ;
+        ;    SconvPointwiseKernelNeon.asm
+        ;
+        ; Abstract:
+        ;
+        ;    A hand written AArch64 vectorised micro-kernel for pointwise (1x1) convolution
+        ;    operating on tensors formatted in the NCHWc layout.  The kernel computes
+        ;    up to four output positions in parallel which allows the filter weights to
+        ;    be re-used across several outputs, greatly reducing memory bandwidth.
+        ;
+        ;    This is the armasm64 translation of aarch64/SconvPointwiseKernelNeon.S.
+        ;    The instruction sequence is identical to that file; only the assembler
+        ;    directives and macro syntax differ.
+        ;
+        ;--
+
+#include "kxarm64.h"
+
+        TEXTAREA
+
+        ; Stack layout for arguments passed on the stack.  The first eight arguments
+        ; are in x0-x7, the remaining four are placed on the stack by the caller.
+
+PW_OutputStride EQU 0
+PW_OutputCount EQU 8
+PW_Bias EQU 16
+PW_Flags EQU 24
+
+        ; Kernel flag bits.  Keep these in sync with sconv_nchwc_kernel_neon.h.
+PWFlag_Accumulate EQU 1
+PWFlag_Bias EQU 2
+PWFlag_Relu EQU 4
+
+        ; Size in bytes of one NCHWc block (16 FP32 values).
+PW_BlockBytes EQU 64
+
+        ;-------------------------------------------------------------------------
+        ;  Helper macros
+        ;-------------------------------------------------------------------------
+
+        ; Compute four outputs for a single input channel block.  The accumulators
+        ; for the four outputs are held in v16-v31.
+
+        MACRO
+        CPK4_FmlaStep
+
+        ldp     q0,q1,[x0],#32
+        ldp     q2,q3,[x0],#32
+        ld1r    {v4.4s},[x1],#4
+        ld1r    {v5.4s},[x2],#4
+        ld1r    {v6.4s},[x3],#4
+        ld1r    {v7.4s},[x4],#4
+        fmla    v16.4s,v0.4s,v4.4s
+        fmla    v17.4s,v1.4s,v4.4s
+        fmla    v18.4s,v2.4s,v4.4s
+        fmla    v19.4s,v3.4s,v4.4s
+        fmla    v20.4s,v0.4s,v5.4s
+        fmla    v21.4s,v1.4s,v5.4s
+        fmla    v22.4s,v2.4s,v5.4s
+        fmla    v23.4s,v3.4s,v5.4s
+        fmla    v24.4s,v0.4s,v6.4s
+        fmla    v25.4s,v1.4s,v6.4s
+        fmla    v26.4s,v2.4s,v6.4s
+        fmla    v27.4s,v3.4s,v6.4s
+        fmla    v28.4s,v0.4s,v7.4s
+        fmla    v29.4s,v1.4s,v7.4s
+        fmla    v30.4s,v2.4s,v7.4s
+        fmla    v31.4s,v3.4s,v7.4s
+
+        MEND
+
+; CPK4_FmlaLane - one input channel of a four channel group, for four output
+; positions, using a lane indexed multiply.
+;
+; CPK4_FmlaStep above issues one ld1r per output position per input channel:
+; sixteen fmla for eight loads, two fmla per load.  The register blocked C++
+; implementation instead loads one input vector per output position and
+; indexes its four lanes, which is four times fewer input loads and measured
+; faster on ResNet-50.
+;
+; This macro is the assembly form of that.  The caller loads v4-v7 once with
+; four input channels for each of the four output positions, then expands this
+; macro four times with $lane 0..3.  The filter pointer advances by 64 bytes
+; per expansion exactly as before, so the filter access pattern is unchanged.
+;
+;   x0                    - filter pointer, advanced by 64 bytes per expansion
+;   $in0..$in3            - input vectors for output positions 0-3
+;   $lane                 - which of the four channels this expansion consumes
+;
+; The input registers are passed as parameters rather than written literally so
+; that the lane operand takes the "$reg..s[$lane]" form already used by
+; CPK1_FmlaWithLane below and by the NCHWc kernel.  armasm64 ends a
+; substitution at the first '.', so the second one is what reaches the
+; assembler.
+
+        MACRO
+        CPK4_FmlaLane $in0, $in1, $in2, $in3, $lane
+
+        ldp     q0,q1,[x0],#32
+        ldp     q2,q3,[x0],#32
+        fmla    v16.4s,v0.4s,$in0..s[$lane]
+        fmla    v17.4s,v1.4s,$in0..s[$lane]
+        fmla    v18.4s,v2.4s,$in0..s[$lane]
+        fmla    v19.4s,v3.4s,$in0..s[$lane]
+        fmla    v20.4s,v0.4s,$in1..s[$lane]
+        fmla    v21.4s,v1.4s,$in1..s[$lane]
+        fmla    v22.4s,v2.4s,$in1..s[$lane]
+        fmla    v23.4s,v3.4s,$in1..s[$lane]
+        fmla    v24.4s,v0.4s,$in2..s[$lane]
+        fmla    v25.4s,v1.4s,$in2..s[$lane]
+        fmla    v26.4s,v2.4s,$in2..s[$lane]
+        fmla    v27.4s,v3.4s,$in2..s[$lane]
+        fmla    v28.4s,v0.4s,$in3..s[$lane]
+        fmla    v29.4s,v1.4s,$in3..s[$lane]
+        fmla    v30.4s,v2.4s,$in3..s[$lane]
+        fmla    v31.4s,v3.4s,$in3..s[$lane]
+
+        MEND
+
+; CPK4_FmlaGroup - four input channels for four output positions.
+;
+; Loads one vector of four input channels per output position, then consumes
+; all four lanes.  Replaces four CPK4_FmlaStep expansions: sixteen ld1r become
+; four ldr, while the fmla count and the filter traffic are unchanged.
+
+        MACRO
+        CPK4_FmlaGroup
+
+        ldr     q4,[x1],#16
+        ldr     q5,[x2],#16
+        ldr     q6,[x3],#16
+        ldr     q7,[x4],#16
+        CPK4_FmlaLane v4, v5, v6, v7, 0
+        CPK4_FmlaLane v4, v5, v6, v7, 1
+        CPK4_FmlaLane v4, v5, v6, v7, 2
+        CPK4_FmlaLane v4, v5, v6, v7, 3
+
+        MEND
+
+        ; Accumulate helper for the single output path.  The input values for the
+        ; output are loaded to v0-v3 and each lane is multiplied with a block of
+        ; filter coefficients.
+
+        MACRO
+        CPK1_FmlaWithLane $Lane, $AReg
+
+        ldp     q4,q5,[x0],#32
+        ldp     q6,q7,[x0],#32
+        fmla    v16.4s,v4.4s,$AReg..s[$Lane]
+        fmla    v17.4s,v5.4s,$AReg..s[$Lane]
+        fmla    v18.4s,v6.4s,$AReg..s[$Lane]
+        fmla    v19.4s,v7.4s,$AReg..s[$Lane]
+
+        MEND
+
+        ; Compute a single output position.  Results are returned in v16-v19.
+
+        MACRO
+        CPK_ComputeOneOutput
+
+        mov     x5,#0
+        eor     v16.16b,v16.16b,v16.16b
+        eor     v17.16b,v17.16b,v17.16b
+        eor     v18.16b,v18.16b,v18.16b
+        eor     v19.16b,v19.16b,v19.16b
+pw_ic_loop1
+        madd    x1,x5,x7,x15
+        ldp     q0,q1,[x1]
+        ldp     q2,q3,[x1,#32]
+        add     x0,x17,x5,lsl #10
+        CPK1_FmlaWithLane 0, v0
+        CPK1_FmlaWithLane 1, v0
+        CPK1_FmlaWithLane 2, v0
+        CPK1_FmlaWithLane 3, v0
+        CPK1_FmlaWithLane 0, v1
+        CPK1_FmlaWithLane 1, v1
+        CPK1_FmlaWithLane 2, v1
+        CPK1_FmlaWithLane 3, v1
+        CPK1_FmlaWithLane 0, v2
+        CPK1_FmlaWithLane 1, v2
+        CPK1_FmlaWithLane 2, v2
+        CPK1_FmlaWithLane 3, v2
+        CPK1_FmlaWithLane 0, v3
+        CPK1_FmlaWithLane 1, v3
+        CPK1_FmlaWithLane 2, v3
+        CPK1_FmlaWithLane 3, v3
+        add     x5,x5,#1
+        cmp     x5,x9
+        blt     pw_ic_loop1
+
+        MEND
+
+        ;-------------------------------------------------------------------------
+        ;  Entry point
+        ;-------------------------------------------------------------------------
+
+        LEAF_ENTRY MlasConvPointwiseFloatKernelNeonAsm
+
+        ; Load the arguments passed on the stack.
+        ldr     x8,[sp,#PW_OutputStride]
+        ldr     x9,[sp,#PW_OutputCount]
+        ldr     x10,[sp,#PW_Bias]
+        ldr     w11,[sp,#PW_Flags]
+
+        ; Spill base arguments so caller-saved registers can be reused freely.
+        sub     sp,sp,#96
+        stp     x0,x1,[sp,#0]
+        stp     x2,x3,[sp,#16]
+        stp     x4,x5,[sp,#32]
+        stp     x6,x7,[sp,#48]
+        str     x10,[sp,#64]               ; bias base
+        str     x9,[sp,#72]                ; output count
+
+        mov     x12,#0                     ; current filter set
+        cbz     x5,pw_exit                 ; nothing to do
+
+pw_filter_loop
+        ; Compute the base pointers for this filter block.
+        ldr     x15,[sp,#0]               ; input base
+        ldr     x16,[sp,#16]              ; output base
+        madd    x16,x12,x8,x16             ; output pointer for this filter
+        ldr     x17,[sp,#8]              ; filter base
+        ldr     x0,[sp,#56]               ; filter set stride
+        madd    x17,x12,x0,x17             ; filter pointer for this filter
+        ldr     x10,[sp,#64]              ; bias base
+        add     x10,x10,x12,lsl #6         ; bias pointer (if used)
+        ldr     x6,[sp,#24]               ; input row stride
+        ldr     x7,[sp,#48]               ; input channel stride
+        ldr     x13,[sp,#72]              ; output count
+        lsr     x14,x13,#2                 ; number of groups of four outputs
+        and     x13,x13,#3                 ; remaining outputs
+        ldr     x9,[sp,#32]               ; input channel blocks
+        cbz     x14,pw_process_remainder
+
+        ; ------------------------------------------------------------------
+        ;  Main loop processing 4 outputs at a time.
+        ; ------------------------------------------------------------------
+        ALIGN 16
+pw_groups
+        ; Clear accumulators for 4 outputs (16 vectors total).
+        eor     v16.16b,v16.16b,v16.16b
+        eor     v17.16b,v17.16b,v17.16b
+        eor     v18.16b,v18.16b,v18.16b
+        eor     v19.16b,v19.16b,v19.16b
+        eor     v20.16b,v20.16b,v20.16b
+        eor     v21.16b,v21.16b,v21.16b
+        eor     v22.16b,v22.16b,v22.16b
+        eor     v23.16b,v23.16b,v23.16b
+        eor     v24.16b,v24.16b,v24.16b
+        eor     v25.16b,v25.16b,v25.16b
+        eor     v26.16b,v26.16b,v26.16b
+        eor     v27.16b,v27.16b,v27.16b
+        eor     v28.16b,v28.16b,v28.16b
+        eor     v29.16b,v29.16b,v29.16b
+        eor     v30.16b,v30.16b,v30.16b
+        eor     v31.16b,v31.16b,v31.16b
+
+        mov     x5,#0                      ; current input channel block
+pw_ic_loop4
+        madd    x1,x5,x7,x15               ; input for this block
+        add     x2,x1,x6                   ; four rows starting positions
+        add     x3,x2,x6
+        add     x4,x3,x6
+        add     x0,x17,x5,lsl #10          ; filter for this block
+
+        ; The block size is 16, consumed four input channels at a time.  Each
+        ; group loads one input vector per output position and indexes its
+        ; four lanes, so the sixteen ld1r that CPK4_FmlaStep would issue become
+        ; four ldr while the fmla count and filter traffic are unchanged.
+        CPK4_FmlaGroup
+        CPK4_FmlaGroup
+        CPK4_FmlaGroup
+        CPK4_FmlaGroup
+
+        add     x5,x5,#1
+        cmp     x5,x9
+        blt     pw_ic_loop4
+
+        ; -----------------------------------------------------------------
+        ; Store the four outputs computed above.  There are several cases to
+        ; handle based on accumulation, bias and ReLU flags.
+        ; -----------------------------------------------------------------
+
+        ; Test if the kernel should accumulate into the existing output.
+        tbz     w11,#0,pw_store_nacc
+
+        ; Accumulation path.  Load bias once as it is re-used for all four
+        ; stores when present.
+        tbz     w11,#1,pw_acc_out0
+        ldp     q4,q5,[x10]
+        ldp     q6,q7,[x10,#32]
+pw_acc_out0
+        ; ---- output 0 ----
+        ldp     q0,q1,[x16]
+        ldp     q2,q3,[x16,#32]
+        tbz     w11,#1,pw_acc_add0
+        fadd    v0.4s,v0.4s,v4.4s
+        fadd    v1.4s,v1.4s,v5.4s
+        fadd    v2.4s,v2.4s,v6.4s
+        fadd    v3.4s,v3.4s,v7.4s
+pw_acc_add0
+        fadd    v16.4s,v16.4s,v0.4s
+        fadd    v17.4s,v17.4s,v1.4s
+        fadd    v18.4s,v18.4s,v2.4s
+        fadd    v19.4s,v19.4s,v3.4s
+        tbz     w11,#2,pw_acc_st0
+        eor     v0.16b,v0.16b,v0.16b
+        fmax    v16.4s,v16.4s,v0.4s
+        fmax    v17.4s,v17.4s,v0.4s
+        fmax    v18.4s,v18.4s,v0.4s
+        fmax    v19.4s,v19.4s,v0.4s
+pw_acc_st0
+        stp     q16,q17,[x16]
+        stp     q18,q19,[x16,#32]
+
+        ; ---- output 1 ----
+        add     x0,x16,#PW_BlockBytes
+        ldp     q0,q1,[x0]
+        ldp     q2,q3,[x0,#32]
+        tbz     w11,#1,pw_acc_add1
+        fadd    v0.4s,v0.4s,v4.4s
+        fadd    v1.4s,v1.4s,v5.4s
+        fadd    v2.4s,v2.4s,v6.4s
+        fadd    v3.4s,v3.4s,v7.4s
+pw_acc_add1
+        fadd    v20.4s,v20.4s,v0.4s
+        fadd    v21.4s,v21.4s,v1.4s
+        fadd    v22.4s,v22.4s,v2.4s
+        fadd    v23.4s,v23.4s,v3.4s
+        tbz     w11,#2,pw_acc_st1
+        eor     v0.16b,v0.16b,v0.16b
+        fmax    v20.4s,v20.4s,v0.4s
+        fmax    v21.4s,v21.4s,v0.4s
+        fmax    v22.4s,v22.4s,v0.4s
+        fmax    v23.4s,v23.4s,v0.4s
+pw_acc_st1
+        stp     q20,q21,[x0]
+        stp     q22,q23,[x0,#32]
+
+        ; ---- output 2 ----
+        add     x0,x0,#PW_BlockBytes
+        ldp     q0,q1,[x0]
+        ldp     q2,q3,[x0,#32]
+        tbz     w11,#1,pw_acc_add2
+        fadd    v0.4s,v0.4s,v4.4s
+        fadd    v1.4s,v1.4s,v5.4s
+        fadd    v2.4s,v2.4s,v6.4s
+        fadd    v3.4s,v3.4s,v7.4s
+pw_acc_add2
+        fadd    v24.4s,v24.4s,v0.4s
+        fadd    v25.4s,v25.4s,v1.4s
+        fadd    v26.4s,v26.4s,v2.4s
+        fadd    v27.4s,v27.4s,v3.4s
+        tbz     w11,#2,pw_acc_st2
+        eor     v0.16b,v0.16b,v0.16b
+        fmax    v24.4s,v24.4s,v0.4s
+        fmax    v25.4s,v25.4s,v0.4s
+        fmax    v26.4s,v26.4s,v0.4s
+        fmax    v27.4s,v27.4s,v0.4s
+pw_acc_st2
+        stp     q24,q25,[x0]
+        stp     q26,q27,[x0,#32]
+
+        ; ---- output 3 ----
+        add     x0,x0,#PW_BlockBytes
+        ldp     q0,q1,[x0]
+        ldp     q2,q3,[x0,#32]
+        tbz     w11,#1,pw_acc_add3
+        fadd    v0.4s,v0.4s,v4.4s
+        fadd    v1.4s,v1.4s,v5.4s
+        fadd    v2.4s,v2.4s,v6.4s
+        fadd    v3.4s,v3.4s,v7.4s
+pw_acc_add3
+        fadd    v28.4s,v28.4s,v0.4s
+        fadd    v29.4s,v29.4s,v1.4s
+        fadd    v30.4s,v30.4s,v2.4s
+        fadd    v31.4s,v31.4s,v3.4s
+        tbz     w11,#2,pw_acc_st3
+        eor     v0.16b,v0.16b,v0.16b
+        fmax    v28.4s,v28.4s,v0.4s
+        fmax    v29.4s,v29.4s,v0.4s
+        fmax    v30.4s,v30.4s,v0.4s
+        fmax    v31.4s,v31.4s,v0.4s
+pw_acc_st3
+        stp     q28,q29,[x0]
+        stp     q30,q31,[x0,#32]
+        b       pw_advance_group
+
+        ; Non-accumulating path: add bias directly to the results if requested
+pw_store_nacc
+        tbz     w11,#1,pw_nacc_relu
+        ldp     q4,q5,[x10]
+        ldp     q6,q7,[x10,#32]
+        fadd    v16.4s,v16.4s,v4.4s
+        fadd    v17.4s,v17.4s,v5.4s
+        fadd    v18.4s,v18.4s,v6.4s
+        fadd    v19.4s,v19.4s,v7.4s
+        fadd    v20.4s,v20.4s,v4.4s
+        fadd    v21.4s,v21.4s,v5.4s
+        fadd    v22.4s,v22.4s,v6.4s
+        fadd    v23.4s,v23.4s,v7.4s
+        fadd    v24.4s,v24.4s,v4.4s
+        fadd    v25.4s,v25.4s,v5.4s
+        fadd    v26.4s,v26.4s,v6.4s
+        fadd    v27.4s,v27.4s,v7.4s
+        fadd    v28.4s,v28.4s,v4.4s
+        fadd    v29.4s,v29.4s,v5.4s
+        fadd    v30.4s,v30.4s,v6.4s
+        fadd    v31.4s,v31.4s,v7.4s
+pw_nacc_relu
+        tbz     w11,#2,pw_nacc_store
+        eor     v0.16b,v0.16b,v0.16b
+        fmax    v16.4s,v16.4s,v0.4s
+        fmax    v17.4s,v17.4s,v0.4s
+        fmax    v18.4s,v18.4s,v0.4s
+        fmax    v19.4s,v19.4s,v0.4s
+        fmax    v20.4s,v20.4s,v0.4s
+        fmax    v21.4s,v21.4s,v0.4s
+        fmax    v22.4s,v22.4s,v0.4s
+        fmax    v23.4s,v23.4s,v0.4s
+        fmax    v24.4s,v24.4s,v0.4s
+        fmax    v25.4s,v25.4s,v0.4s
+        fmax    v26.4s,v26.4s,v0.4s
+        fmax    v27.4s,v27.4s,v0.4s
+        fmax    v28.4s,v28.4s,v0.4s
+        fmax    v29.4s,v29.4s,v0.4s
+        fmax    v30.4s,v30.4s,v0.4s
+        fmax    v31.4s,v31.4s,v0.4s
+pw_nacc_store
+        stp     q16,q17,[x16]
+        stp     q18,q19,[x16,#32]
+        add     x0,x16,#PW_BlockBytes
+        stp     q20,q21,[x0]
+        stp     q22,q23,[x0,#32]
+        add     x0,x0,#PW_BlockBytes
+        stp     q24,q25,[x0]
+        stp     q26,q27,[x0,#32]
+        add     x0,x0,#PW_BlockBytes
+        stp     q28,q29,[x0]
+        stp     q30,q31,[x0,#32]
+
+pw_advance_group
+        add     x15,x15,x6,lsl #2
+        add     x16,x16,#(PW_BlockBytes*4)
+        subs    x14,x14,#1
+        bne     pw_groups
+
+        ; ------------------------------------------------------------------
+        ;  Handle the leftover (0..3) output positions.
+        ; ------------------------------------------------------------------
+pw_process_remainder
+        cbz     x13,pw_after_filter
+pw_left_loop
+        CPK_ComputeOneOutput
+
+        ; Accumulate?
+        tbz     w11,#0,pw_left_noacc
+        ldp     q0,q1,[x16]
+        ldp     q2,q3,[x16,#32]
+        tbz     w11,#1,pw_left_add
+        ldp     q4,q5,[x10]
+        ldp     q6,q7,[x10,#32]
+        fadd    v0.4s,v0.4s,v4.4s
+        fadd    v1.4s,v1.4s,v5.4s
+        fadd    v2.4s,v2.4s,v6.4s
+        fadd    v3.4s,v3.4s,v7.4s
+pw_left_add
+        fadd    v16.4s,v16.4s,v0.4s
+        fadd    v17.4s,v17.4s,v1.4s
+        fadd    v18.4s,v18.4s,v2.4s
+        fadd    v19.4s,v19.4s,v3.4s
+        tbz     w11,#2,pw_left_st
+        eor     v0.16b,v0.16b,v0.16b
+        fmax    v16.4s,v16.4s,v0.4s
+        fmax    v17.4s,v17.4s,v0.4s
+        fmax    v18.4s,v18.4s,v0.4s
+        fmax    v19.4s,v19.4s,v0.4s
+pw_left_st
+        stp     q16,q17,[x16]
+        stp     q18,q19,[x16,#32]
+        b       pw_left_next
+
+pw_left_noacc
+        tbz     w11,#1,pw_left_nrelu
+        ldp     q4,q5,[x10]
+        ldp     q6,q7,[x10,#32]
+        fadd    v16.4s,v16.4s,v4.4s
+        fadd    v17.4s,v17.4s,v5.4s
+        fadd    v18.4s,v18.4s,v6.4s
+        fadd    v19.4s,v19.4s,v7.4s
+pw_left_nrelu
+        tbz     w11,#2,pw_left_nst
+        eor     v0.16b,v0.16b,v0.16b
+        fmax    v16.4s,v16.4s,v0.4s
+        fmax    v17.4s,v17.4s,v0.4s
+        fmax    v18.4s,v18.4s,v0.4s
+        fmax    v19.4s,v19.4s,v0.4s
+pw_left_nst
+        stp     q16,q17,[x16]
+        stp     q18,q19,[x16,#32]
+pw_left_next
+        add     x15,x15,x6
+        add     x16,x16,#PW_BlockBytes
+        subs    x13,x13,#1
+        bne     pw_left_loop
+
+pw_after_filter
+        add     x12,x12,#1
+        ldr     x0,[sp,#40]               ; output channel blocks
+        cmp     x12,x0
+        blt     pw_filter_loop
+pw_exit
+
+        add     sp,sp,#96
+        ret
+
+        LEAF_END MlasConvPointwiseFloatKernelNeonAsm
+
+        END

--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -1224,15 +1224,15 @@ extern "C" {
 #if defined(MLAS_TARGET_ARM64) && defined(MLAS_USE_ARM_NEON_NCHWC)
     // Intrinsics kernel for direct NCHW convolution
     MLAS_CONV_FLOAT_KERNEL MlasConvNchwFloatKernelNeon;
-#if !defined(_WIN32)
-    // AArch64 assembly micro-kernel for direct NCHW convolution
+
+    // AArch64 and ARM64 assembly micro-kernel for direct NCHW convolution.
     MLAS_CONV_FLOAT_KERNEL MlasConvNchwFloatKernelNeonAsm;
-#endif
+
     MLAS_CONV_FLOAT_KERNEL MlasConvNchwcFloatKernelNeon;
-#if !defined(_WIN32)
-    // AArch64 assembly micro-kernel for direct NCHWc convolution
+
+    // AArch64 and ARM64 assembly micro-kernel for direct NCHWc convolution.
     MLAS_CONV_FLOAT_KERNEL MlasConvNchwcFloatKernelNeonAsm;
-#endif
+
     // Intrinsics kernel for depthwise NCHWc convolution
     MLAS_CONV_DEPTHWISE_FLOAT_KERNEL MlasConvDepthwiseFloatKernelNeon;
 #if !defined(_WIN32)
@@ -1241,10 +1241,10 @@ extern "C" {
 #endif
     // Intrinsics kernel for pointwise NCHWc convolution
     MLAS_CONV_POINTWISE_FLOAT_KERNEL MlasConvPointwiseFloatKernelNeon;
-#if !defined(_WIN32)
-    // AArch64 assembly micro-kernel for pointwise NCHWc convolution
+
+    // AArch64 and ARM64 assembly micro-kernel for pointwise NCHWc convolution.
     MLAS_CONV_POINTWISE_FLOAT_KERNEL MlasConvPointwiseFloatKernelNeonAsm;
-#endif
+
 #if defined(__linux__)
     // AArch64 assembly fast-math micro-kernels
     MLAS_CONV_FLOAT_KERNEL MlasConvNchwBf16KernelNeon;

--- a/onnxruntime/core/mlas/lib/platform.cpp
+++ b/onnxruntime/core/mlas/lib/platform.cpp
@@ -670,15 +670,14 @@ Return Value:
     this->KVQuantGemmFp16Supported_ = true;
 
 #if defined(MLAS_USE_ARM_NEON_NCHWC)
-    // Use the AArch64 assembly implementation on non-Windows platforms.
-#if !defined(_WIN32)
+
     // Prefer the hand written micro-kernel for the NCHW convolution path. It
     // offers a tighter schedule and a specialised two-output inner loop that
     // reduces pressure on the memory system compared to the generic kernel.
+
+    // The armasm64 translation in arm64/SconvKernelNeon.asm makes this kernel
+    // available on Windows as well
     this->ConvNchwFloatKernel = MlasConvNchwFloatKernelNeonAsm;
-#else
-    this->ConvNchwFloatKernel = MlasConvNchwFloatKernelNeon;
-#endif
     this->ConvNchwcFloatKernel = MlasConvNchwcFloatKernelNeon;
     this->ConvDepthwiseFloatKernel = MlasConvDepthwiseFloatKernelNeon;
     this->ConvPointwiseFloatKernel = MlasConvPointwiseFloatKernelNeon;
@@ -803,8 +802,8 @@ Return Value:
 
     const bool HasI8MMInstructions = MLAS_CPUIDINFO::GetCPUIDInfo().HasArmNeon_I8MM();
     if (HasI8MMInstructions) {
-#if defined(__linux__)
-
+        // The I8MM instructions are only available on Linux and Windows. On other platforms the fallback NEON kernels are used.
+#if defined(__linux__) || defined(_WIN32)
         this->GemmU8U8Dispatch = &MlasGemmU8X8DispatchUmmla;
         this->GemmU8S8Dispatch = &MlasGemmU8X8DispatchUmmla;
         this->GemmS8S8Dispatch = &MlasGemmS8S8DispatchSmmla;

--- a/onnxruntime/core/mlas/lib/qgemm_kernel_smmla.cpp
+++ b/onnxruntime/core/mlas/lib/qgemm_kernel_smmla.cpp
@@ -19,6 +19,29 @@ Abstract:
 #include "qgemm.h"
 
 //
+// Build an int32x2_t from lanes 0 and 2 of a 128 bit vector.
+//
+// GCC and clang model the NEON vector types as native vector types, so they
+// accept a braced initializer list of scalars. MSVC models them as opaque
+// structures and rejects that form, so build the pair with lane intrinsics
+// there instead. Both spellings compile to the same instructions.
+//
+
+MLAS_FORCEINLINE
+int32x2_t
+MlasGemmS8S8PairFromLanes02Smmla(int32x4_t Vector)
+{
+#if defined(_MSC_VER) && !defined(__clang__)
+    int32x2_t Pair = vdup_n_s32(0);
+    Pair = vset_lane_s32(vdups_laneq_s32(Vector, 0), Pair, 0);
+    Pair = vset_lane_s32(vdups_laneq_s32(Vector, 2), Pair, 1);
+    return Pair;
+#else
+    return int32x2_t{vdups_laneq_s32(Vector, 0), vdups_laneq_s32(Vector, 2)};
+#endif
+}
+
+//
 // Define the prototypes of the NEON SMMLA routines written in assembly.
 //
 
@@ -168,8 +191,7 @@ MlasGemmQuantCopyPackA<MLAS_GEMM_S8S8_KERNEL_SMMLA>(
 
             int32x4_t RowSums0L_ext = vextq_s32(RowSums0L_pada, RowSums0L_pada, 1);
             int32x4_t RowSums0L_add = vaddq_s32(RowSums0L_pada, RowSums0L_ext);
-            int32x2_t RowSums0L = {vdups_laneq_s32(RowSums0L_add, 0),
-                                   vdups_laneq_s32(RowSums0L_add, 2)};
+            int32x2_t RowSums0L = MlasGemmS8S8PairFromLanes02Smmla(RowSums0L_add);
 
             int32x4_t RowSums0H_pada = vmovq_n_s32(0);
             RowSums0H_pada = vpadalq_s16(RowSums0H_pada, vpaddlq_s8(vreinterpretq_s8_s64(z2)));
@@ -177,8 +199,7 @@ MlasGemmQuantCopyPackA<MLAS_GEMM_S8S8_KERNEL_SMMLA>(
 
             int32x4_t RowSums0H_ext = vextq_s32(RowSums0H_pada, RowSums0H_pada, 1);
             int32x4_t RowSums0H_add = vaddq_s32(RowSums0H_pada, RowSums0H_ext);
-            int32x2_t RowSums0H = {vdups_laneq_s32(RowSums0H_add, 0),
-                                   vdups_laneq_s32(RowSums0H_add, 2)};
+            int32x2_t RowSums0H = MlasGemmS8S8PairFromLanes02Smmla(RowSums0H_add);
 
             RowSums0 = vaddq_s32(RowSums0, vcombine_s32(RowSums0L, RowSums0H));
 
@@ -188,8 +209,7 @@ MlasGemmQuantCopyPackA<MLAS_GEMM_S8S8_KERNEL_SMMLA>(
 
             int32x4_t RowSums1L_ext = vextq_s32(RowSums1L_pada, RowSums1L_pada, 1);
             int32x4_t RowSums1L_add = vaddq_s32(RowSums1L_pada, RowSums1L_ext);
-            int32x2_t RowSums1L = {vdups_laneq_s32(RowSums1L_add, 0),
-                                   vdups_laneq_s32(RowSums1L_add, 2)};
+            int32x2_t RowSums1L = MlasGemmS8S8PairFromLanes02Smmla(RowSums1L_add);
 
             int32x4_t RowSums1H_pada = vmovq_n_s32(0);
             RowSums1H_pada = vpadalq_s16(RowSums1H_pada, vpaddlq_s8(vreinterpretq_s8_s64(z6)));
@@ -197,8 +217,7 @@ MlasGemmQuantCopyPackA<MLAS_GEMM_S8S8_KERNEL_SMMLA>(
 
             int32x4_t RowSums1H_ext = vextq_s32(RowSums1H_pada, RowSums1H_pada, 1);
             int32x4_t RowSums1H_add = vaddq_s32(RowSums1H_pada, RowSums1H_ext);
-            int32x2_t RowSums1H = {vdups_laneq_s32(RowSums1H_add, 0),
-                                   vdups_laneq_s32(RowSums1H_add, 2)};
+            int32x2_t RowSums1H = MlasGemmS8S8PairFromLanes02Smmla(RowSums1H_add);
 
             RowSums1 = vaddq_s32(RowSums1, vcombine_s32(RowSums1L, RowSums1H));
 
@@ -243,16 +262,14 @@ MlasGemmQuantCopyPackA<MLAS_GEMM_S8S8_KERNEL_SMMLA>(
 
             int32x4_t RowSums0L_ext = vextq_s32(RowSums0L_pada, RowSums0L_pada, 1);
             int32x4_t RowSums0L_add = vaddq_s32(RowSums0L_pada, RowSums0L_ext);
-            int32x2_t RowSums0L = {vdups_laneq_s32(RowSums0L_add, 0),
-                                   vdups_laneq_s32(RowSums0L_add, 2)};
+            int32x2_t RowSums0L = MlasGemmS8S8PairFromLanes02Smmla(RowSums0L_add);
 
             int32x4_t RowSums0H_pada = vmovq_n_s32(0);
             RowSums0H_pada = vpadalq_s16(RowSums0H_pada, vpaddlq_s8(vreinterpretq_s8_s64(z23)));
 
             int32x4_t RowSums0H_ext = vextq_s32(RowSums0H_pada, RowSums0H_pada, 1);
             int32x4_t RowSums0H_add = vaddq_s32(RowSums0H_pada, RowSums0H_ext);
-            int32x2_t RowSums0H = {vdups_laneq_s32(RowSums0H_add, 0),
-                                   vdups_laneq_s32(RowSums0H_add, 2)};
+            int32x2_t RowSums0H = MlasGemmS8S8PairFromLanes02Smmla(RowSums0H_add);
 
             RowSums0 = vaddq_s32(RowSums0, vcombine_s32(RowSums0L, RowSums0H));
 
@@ -261,16 +278,14 @@ MlasGemmQuantCopyPackA<MLAS_GEMM_S8S8_KERNEL_SMMLA>(
 
             int32x4_t RowSums1L_ext = vextq_s32(RowSums1L_pada, RowSums1L_pada, 1);
             int32x4_t RowSums1L_add = vaddq_s32(RowSums1L_pada, RowSums1L_ext);
-            int32x2_t RowSums1L = {vdups_laneq_s32(RowSums1L_add, 0),
-                                   vdups_laneq_s32(RowSums1L_add, 2)};
+            int32x2_t RowSums1L = MlasGemmS8S8PairFromLanes02Smmla(RowSums1L_add);
 
             int32x4_t RowSums1H_pada = vmovq_n_s32(0);
             RowSums1H_pada = vpadalq_s16(RowSums1H_pada, vpaddlq_s8(vreinterpretq_s8_s64(z67)));
 
             int32x4_t RowSums1H_ext = vextq_s32(RowSums1H_pada, RowSums1H_pada, 1);
             int32x4_t RowSums1H_add = vaddq_s32(RowSums1H_pada, RowSums1H_ext);
-            int32x2_t RowSums1H = {vdups_laneq_s32(RowSums1H_add, 0),
-                                   vdups_laneq_s32(RowSums1H_add, 2)};
+            int32x2_t RowSums1H = MlasGemmS8S8PairFromLanes02Smmla(RowSums1H_add);
 
             RowSums1 = vaddq_s32(RowSums1, vcombine_s32(RowSums1L, RowSums1H));
 
@@ -329,16 +344,14 @@ MlasGemmQuantCopyPackA<MLAS_GEMM_S8S8_KERNEL_SMMLA>(
 
             int32x4_t RowSums0L_ext = vextq_s32(RowSums0L_pada, RowSums0L_pada, 1);
             int32x4_t RowSums0L_add = vaddq_s32(RowSums0L_pada, RowSums0L_ext);
-            int32x2_t RowSums0L = {vdups_laneq_s32(RowSums0L_add, 0),
-                                   vdups_laneq_s32(RowSums0L_add, 2)};
+            int32x2_t RowSums0L = MlasGemmS8S8PairFromLanes02Smmla(RowSums0L_add);
 
             int32x4_t RowSums0H_pada = vmovq_n_s32(0);
             RowSums0H_pada = vpadalq_s16(RowSums0H_pada, vpaddlq_s8(vreinterpretq_s8_s64(z23)));
 
             int32x4_t RowSums0H_ext = vextq_s32(RowSums0H_pada, RowSums0H_pada, 1);
             int32x4_t RowSums0H_add = vaddq_s32(RowSums0H_pada, RowSums0H_ext);
-            int32x2_t RowSums0H = {vdups_laneq_s32(RowSums0H_add, 0),
-                                   vdups_laneq_s32(RowSums0H_add, 2)};
+            int32x2_t RowSums0H = MlasGemmS8S8PairFromLanes02Smmla(RowSums0H_add);
 
             RowSums0 = vaddq_s32(RowSums0, vcombine_s32(RowSums0L, RowSums0H));
 
@@ -347,16 +360,14 @@ MlasGemmQuantCopyPackA<MLAS_GEMM_S8S8_KERNEL_SMMLA>(
 
             int32x4_t RowSums1L_ext = vextq_s32(RowSums1L_pada, RowSums1L_pada, 1);
             int32x4_t RowSums1L_add = vaddq_s32(RowSums1L_pada, RowSums1L_ext);
-            int32x2_t RowSums1L = {vdups_laneq_s32(RowSums1L_add, 0),
-                                   vdups_laneq_s32(RowSums1L_add, 2)};
+            int32x2_t RowSums1L = MlasGemmS8S8PairFromLanes02Smmla(RowSums1L_add);
 
             int32x4_t RowSums1H_pada = vmovq_n_s32(0);
             RowSums1H_pada = vpadalq_s16(RowSums1H_pada, vpaddlq_s8(vreinterpretq_s8_s64(z67)));
 
             int32x4_t RowSums1H_ext = vextq_s32(RowSums1H_pada, RowSums1H_pada, 1);
             int32x4_t RowSums1H_add = vaddq_s32(RowSums1H_pada, RowSums1H_ext);
-            int32x2_t RowSums1H = {vdups_laneq_s32(RowSums1H_add, 0),
-                                   vdups_laneq_s32(RowSums1H_add, 2)};
+            int32x2_t RowSums1H = MlasGemmS8S8PairFromLanes02Smmla(RowSums1H_add);
 
             RowSums1 = vaddq_s32(RowSums1, vcombine_s32(RowSums1L, RowSums1H));
 
@@ -424,8 +435,7 @@ MlasGemmQuantCopyPackA<MLAS_GEMM_S8S8_KERNEL_SMMLA>(
 
             int32x4_t RowSumsL_ext = vextq_s32(RowSumsL_pada, RowSumsL_pada, 1);
             int32x4_t RowSumsL_add = vaddq_s32(RowSumsL_pada, RowSumsL_ext);
-            int32x2_t RowSumsL = {vdups_laneq_s32(RowSumsL_add, 0),
-                                  vdups_laneq_s32(RowSumsL_add, 2)};
+            int32x2_t RowSumsL = MlasGemmS8S8PairFromLanes02Smmla(RowSumsL_add);
 
             int32x4_t RowSumsH_pada = vmovq_n_s32(0);
             RowSumsH_pada = vpadalq_s16(RowSumsH_pada, vpaddlq_s8(vreinterpretq_s8_s64(z2)));
@@ -433,8 +443,7 @@ MlasGemmQuantCopyPackA<MLAS_GEMM_S8S8_KERNEL_SMMLA>(
 
             int32x4_t RowSumsH_ext = vextq_s32(RowSumsH_pada, RowSumsH_pada, 1);
             int32x4_t RowSumsH_add = vaddq_s32(RowSumsH_pada, RowSumsH_ext);
-            int32x2_t RowSumsH = {vdups_laneq_s32(RowSumsH_add, 0),
-                                  vdups_laneq_s32(RowSumsH_add, 2)};
+            int32x2_t RowSumsH = MlasGemmS8S8PairFromLanes02Smmla(RowSumsH_add);
 
             RowSums = vaddq_s32(RowSums, vcombine_s32(RowSumsL, RowSumsH));
 
@@ -465,16 +474,14 @@ MlasGemmQuantCopyPackA<MLAS_GEMM_S8S8_KERNEL_SMMLA>(
 
             int32x4_t RowSumsL_ext = vextq_s32(RowSumsL_pada, RowSumsL_pada, 1);
             int32x4_t RowSumsL_add = vaddq_s32(RowSumsL_pada, RowSumsL_ext);
-            int32x2_t RowSumsL = {vdups_laneq_s32(RowSumsL_add, 0),
-                                  vdups_laneq_s32(RowSumsL_add, 2)};
+            int32x2_t RowSumsL = MlasGemmS8S8PairFromLanes02Smmla(RowSumsL_add);
 
             int32x4_t RowSumsH_pada = vmovq_n_s32(0);
             RowSumsH_pada = vpadalq_s16(RowSumsH_pada, vpaddlq_s8(vreinterpretq_s8_s64(z23)));
 
             int32x4_t RowSumsH_ext = vextq_s32(RowSumsH_pada, RowSumsH_pada, 1);
             int32x4_t RowSumsH_add = vaddq_s32(RowSumsH_pada, RowSumsH_ext);
-            int32x2_t RowSumsH = {vdups_laneq_s32(RowSumsH_add, 0),
-                                  vdups_laneq_s32(RowSumsH_add, 2)};
+            int32x2_t RowSumsH = MlasGemmS8S8PairFromLanes02Smmla(RowSumsH_add);
 
             RowSums = vaddq_s32(RowSums, vcombine_s32(RowSumsL, RowSumsH));
 
@@ -518,16 +525,14 @@ MlasGemmQuantCopyPackA<MLAS_GEMM_S8S8_KERNEL_SMMLA>(
 
             int32x4_t RowSums0L_ext = vextq_s32(RowSums0L_pada, RowSums0L_pada, 1);
             int32x4_t RowSums0L_add = vaddq_s32(RowSums0L_pada, RowSums0L_ext);
-            int32x2_t RowSums0L = {vdups_laneq_s32(RowSums0L_add, 0),
-                                   vdups_laneq_s32(RowSums0L_add, 2)};
+            int32x2_t RowSums0L = MlasGemmS8S8PairFromLanes02Smmla(RowSums0L_add);
 
             int32x4_t RowSums0H_pada = vmovq_n_s32(0);
             RowSums0H_pada = vpadalq_s16(RowSums0H_pada, vpaddlq_s8(vreinterpretq_s8_s64(z23)));
 
             int32x4_t RowSums0H_ext = vextq_s32(RowSums0H_pada, RowSums0H_pada, 1);
             int32x4_t RowSums0H_add = vaddq_s32(RowSums0H_pada, RowSums0H_ext);
-            int32x2_t RowSums0H = {vdups_laneq_s32(RowSums0H_add, 0),
-                                   vdups_laneq_s32(RowSums0H_add, 2)};
+            int32x2_t RowSums0H = MlasGemmS8S8PairFromLanes02Smmla(RowSums0H_add);
 
             RowSums = vaddq_s32(RowSums, vcombine_s32(RowSums0L, RowSums0H));
 
@@ -581,8 +586,7 @@ MlasGemmQuantCopyPackA<MLAS_GEMM_S8S8_KERNEL_SMMLA>(
 
             int32x4_t RowSumsL_ext = vextq_s32(RowSumsL_pada, RowSumsL_pada, 1);
             int32x4_t RowSumsL_add = vaddq_s32(RowSumsL_pada, RowSumsL_ext);
-            int32x2_t RowSumsL = {vdups_laneq_s32(RowSumsL_add, 0),
-                                  vdups_laneq_s32(RowSumsL_add, 2)};
+            int32x2_t RowSumsL = MlasGemmS8S8PairFromLanes02Smmla(RowSumsL_add);
 
             RowSums = vadd_s32(RowSums, RowSumsL);
 
@@ -605,8 +609,7 @@ MlasGemmQuantCopyPackA<MLAS_GEMM_S8S8_KERNEL_SMMLA>(
 
             int32x4_t RowSumsL_ext = vextq_s32(RowSumsL_pada, RowSumsL_pada, 1);
             int32x4_t RowSumsL_add = vaddq_s32(RowSumsL_pada, RowSumsL_ext);
-            int32x2_t RowSumsL = {vdups_laneq_s32(RowSumsL_add, 0),
-                                  vdups_laneq_s32(RowSumsL_add, 2)};
+            int32x2_t RowSumsL = MlasGemmS8S8PairFromLanes02Smmla(RowSumsL_add);
 
             RowSums = vadd_s32(RowSums, RowSumsL);
 
@@ -642,8 +645,7 @@ MlasGemmQuantCopyPackA<MLAS_GEMM_S8S8_KERNEL_SMMLA>(
 
             int32x4_t RowSumsL_ext = vextq_s32(RowSumsL_pada, RowSumsL_pada, 1);
             int32x4_t RowSumsL_add = vaddq_s32(RowSumsL_pada, RowSumsL_ext);
-            int32x2_t RowSumsL = {vdups_laneq_s32(RowSumsL_add, 0),
-                                  vdups_laneq_s32(RowSumsL_add, 2)};
+            int32x2_t RowSumsL = MlasGemmS8S8PairFromLanes02Smmla(RowSumsL_add);
 
             RowSums = vadd_s32(RowSums, RowSumsL);
 
@@ -742,13 +744,13 @@ MlasGemmS8S8CopyPackBProcessSmmla(int8_t* D, int8x8_t BytesRow[8], int32x4_t Col
     ColSums0L_pada = vpadalq_s16(ColSums0L_pada, vpaddlq_s8(vreinterpretq_s8_s32(zd3.val[0])));
     int32x4_t ColSums0L_ext = vextq_s32(ColSums0L_pada, ColSums0L_pada, 1);
     int32x4_t ColSums0L_add = vaddq_s32(ColSums0L_pada, ColSums0L_ext);
-    int32x2_t ColSums0L = {vdups_laneq_s32(ColSums0L_add, 0), vdups_laneq_s32(ColSums0L_add, 2)};
+    int32x2_t ColSums0L = MlasGemmS8S8PairFromLanes02Smmla(ColSums0L_add);
 
     int32x4_t ColSums0H_pada = vmovq_n_s32(0);
     ColSums0H_pada = vpadalq_s16(ColSums0H_pada, vpaddlq_s8(vreinterpretq_s8_s32(zd3.val[1])));
     int32x4_t ColSums0H_ext = vextq_s32(ColSums0H_pada, ColSums0H_pada, 1);
     int32x4_t ColSums0H_add = vaddq_s32(ColSums0H_pada, ColSums0H_ext);
-    int32x2_t ColSums0H = {vdups_laneq_s32(ColSums0H_add, 0), vdups_laneq_s32(ColSums0H_add, 2)};
+    int32x2_t ColSums0H = MlasGemmS8S8PairFromLanes02Smmla(ColSums0H_add);
 
     ColumnSums[0] = vaddq_s32(ColumnSums[0], vcombine_s32(ColSums0L, ColSums0H));
 
@@ -756,13 +758,13 @@ MlasGemmS8S8CopyPackBProcessSmmla(int8_t* D, int8x8_t BytesRow[8], int32x4_t Col
     ColSums1L_pada = vpadalq_s16(ColSums1L_pada, vpaddlq_s8(vreinterpretq_s8_s32(zd4.val[0])));
     int32x4_t ColSums1L_ext = vextq_s32(ColSums1L_pada, ColSums1L_pada, 1);
     int32x4_t ColSums1L_add = vaddq_s32(ColSums1L_pada, ColSums1L_ext);
-    int32x2_t ColSums1L = {vdups_laneq_s32(ColSums1L_add, 0), vdups_laneq_s32(ColSums1L_add, 2)};
+    int32x2_t ColSums1L = MlasGemmS8S8PairFromLanes02Smmla(ColSums1L_add);
 
     int32x4_t ColSums1H_pada = vmovq_n_s32(0);
     ColSums1H_pada = vpadalq_s16(ColSums1H_pada, vpaddlq_s8(vreinterpretq_s8_s32(zd4.val[1])));
     int32x4_t ColSums1H_ext = vextq_s32(ColSums1H_pada, ColSums1H_pada, 1);
     int32x4_t ColSums1H_add = vaddq_s32(ColSums1H_pada, ColSums1H_ext);
-    int32x2_t ColSums1H = {vdups_laneq_s32(ColSums1H_add, 0), vdups_laneq_s32(ColSums1H_add, 2)};
+    int32x2_t ColSums1H = MlasGemmS8S8PairFromLanes02Smmla(ColSums1H_add);
 
     ColumnSums[1] = vaddq_s32(ColumnSums[1], vcombine_s32(ColSums1L, ColSums1H));
 }

--- a/onnxruntime/core/mlas/lib/qgemm_kernel_smmla.cpp
+++ b/onnxruntime/core/mlas/lib/qgemm_kernel_smmla.cpp
@@ -27,7 +27,7 @@ Abstract:
 // there instead. Both spellings compile to the same instructions.
 //
 
-MLAS_FORCEINLINE
+static MLAS_FORCEINLINE
 int32x2_t
 MlasGemmS8S8PairFromLanes02Smmla(int32x4_t Vector)
 {

--- a/onnxruntime/core/mlas/lib/qgemm_kernel_ummla.cpp
+++ b/onnxruntime/core/mlas/lib/qgemm_kernel_ummla.cpp
@@ -27,7 +27,7 @@ Abstract:
 // there instead. Both spellings compile to the same instructions.
 //
 
-MLAS_FORCEINLINE
+static MLAS_FORCEINLINE
 uint32x2_t
 MlasGemmU8X8PairFromLanes02Ummla(uint32x4_t Vector)
 {

--- a/onnxruntime/core/mlas/lib/qgemm_kernel_ummla.cpp
+++ b/onnxruntime/core/mlas/lib/qgemm_kernel_ummla.cpp
@@ -19,6 +19,29 @@ Abstract:
 #include "qgemm.h"
 
 //
+// Build a uint32x2_t from lanes 0 and 2 of a 128 bit vector.
+//
+// GCC and clang model the NEON vector types as native vector types, so they
+// accept a braced initializer list of scalars. MSVC models them as opaque
+// structures and rejects that form, so build the pair with lane intrinsics
+// there instead. Both spellings compile to the same instructions.
+//
+
+MLAS_FORCEINLINE
+uint32x2_t
+MlasGemmU8X8PairFromLanes02Ummla(uint32x4_t Vector)
+{
+#if defined(_MSC_VER) && !defined(__clang__)
+    uint32x2_t Pair = vdup_n_u32(0);
+    Pair = vset_lane_u32(vdups_laneq_u32(Vector, 0), Pair, 0);
+    Pair = vset_lane_u32(vdups_laneq_u32(Vector, 2), Pair, 1);
+    return Pair;
+#else
+    return uint32x2_t{vdups_laneq_u32(Vector, 0), vdups_laneq_u32(Vector, 2)};
+#endif
+}
+
+//
 // Define the prototypes of the NEON UMMLA routines written in assembly.
 //
 
@@ -169,8 +192,7 @@ MlasGemmQuantCopyPackA<MLAS_GEMM_U8X8_KERNEL_UMMLA>(MLAS_GEMM_U8X8_KERNEL_UMMLA:
 
             uint32x4_t RowSums0L_ext = vextq_u32(RowSums0L_pada, RowSums0L_pada, 1);
             uint32x4_t RowSums0L_add = vaddq_u32(RowSums0L_pada, RowSums0L_ext);
-            uint32x2_t RowSums0L = {vdups_laneq_u32(RowSums0L_add, 0),
-                                    vdups_laneq_u32(RowSums0L_add, 2)};
+            uint32x2_t RowSums0L = MlasGemmU8X8PairFromLanes02Ummla(RowSums0L_add);
 
             uint32x4_t RowSums0H_pada = vmovq_n_u32(0);
             RowSums0H_pada = vpadalq_u16(RowSums0H_pada, vpaddlq_u8(vreinterpretq_u8_u64(z2)));
@@ -178,8 +200,7 @@ MlasGemmQuantCopyPackA<MLAS_GEMM_U8X8_KERNEL_UMMLA>(MLAS_GEMM_U8X8_KERNEL_UMMLA:
 
             uint32x4_t RowSums0H_ext = vextq_u32(RowSums0H_pada, RowSums0H_pada, 1);
             uint32x4_t RowSums0H_add = vaddq_u32(RowSums0H_pada, RowSums0H_ext);
-            uint32x2_t RowSums0H = {vdups_laneq_u32(RowSums0H_add, 0),
-                                    vdups_laneq_u32(RowSums0H_add, 2)};
+            uint32x2_t RowSums0H = MlasGemmU8X8PairFromLanes02Ummla(RowSums0H_add);
 
             RowSums0 = vaddq_u32(RowSums0, vcombine_u32(RowSums0L, RowSums0H));
 
@@ -189,8 +210,7 @@ MlasGemmQuantCopyPackA<MLAS_GEMM_U8X8_KERNEL_UMMLA>(MLAS_GEMM_U8X8_KERNEL_UMMLA:
 
             uint32x4_t RowSums1L_ext = vextq_u32(RowSums1L_pada, RowSums1L_pada, 1);
             uint32x4_t RowSums1L_add = vaddq_u32(RowSums1L_pada, RowSums1L_ext);
-            uint32x2_t RowSums1L = {vdups_laneq_u32(RowSums1L_add, 0),
-                                    vdups_laneq_u32(RowSums1L_add, 2)};
+            uint32x2_t RowSums1L = MlasGemmU8X8PairFromLanes02Ummla(RowSums1L_add);
 
             uint32x4_t RowSums1H_pada = vmovq_n_u32(0);
             RowSums1H_pada = vpadalq_u16(RowSums1H_pada, vpaddlq_u8(vreinterpretq_u8_u64(z6)));
@@ -198,8 +218,7 @@ MlasGemmQuantCopyPackA<MLAS_GEMM_U8X8_KERNEL_UMMLA>(MLAS_GEMM_U8X8_KERNEL_UMMLA:
 
             uint32x4_t RowSums1H_ext = vextq_u32(RowSums1H_pada, RowSums1H_pada, 1);
             uint32x4_t RowSums1H_add = vaddq_u32(RowSums1H_pada, RowSums1H_ext);
-            uint32x2_t RowSums1H = {vdups_laneq_u32(RowSums1H_add, 0),
-                                    vdups_laneq_u32(RowSums1H_add, 2)};
+            uint32x2_t RowSums1H = MlasGemmU8X8PairFromLanes02Ummla(RowSums1H_add);
 
             RowSums1 = vaddq_u32(RowSums1, vcombine_u32(RowSums1L, RowSums1H));
 
@@ -244,16 +263,14 @@ MlasGemmQuantCopyPackA<MLAS_GEMM_U8X8_KERNEL_UMMLA>(MLAS_GEMM_U8X8_KERNEL_UMMLA:
 
             uint32x4_t RowSums0L_ext = vextq_u32(RowSums0L_pada, RowSums0L_pada, 1);
             uint32x4_t RowSums0L_add = vaddq_u32(RowSums0L_pada, RowSums0L_ext);
-            uint32x2_t RowSums0L = {vdups_laneq_u32(RowSums0L_add, 0),
-                                    vdups_laneq_u32(RowSums0L_add, 2)};
+            uint32x2_t RowSums0L = MlasGemmU8X8PairFromLanes02Ummla(RowSums0L_add);
 
             uint32x4_t RowSums0H_pada = vmovq_n_u32(0);
             RowSums0H_pada = vpadalq_u16(RowSums0H_pada, vpaddlq_u8(vreinterpretq_u8_u64(z23)));
 
             uint32x4_t RowSums0H_ext = vextq_u32(RowSums0H_pada, RowSums0H_pada, 1);
             uint32x4_t RowSums0H_add = vaddq_u32(RowSums0H_pada, RowSums0H_ext);
-            uint32x2_t RowSums0H = {vdups_laneq_u32(RowSums0H_add, 0),
-                                    vdups_laneq_u32(RowSums0H_add, 2)};
+            uint32x2_t RowSums0H = MlasGemmU8X8PairFromLanes02Ummla(RowSums0H_add);
 
             RowSums0 = vaddq_u32(RowSums0, vcombine_u32(RowSums0L, RowSums0H));
 
@@ -262,16 +279,14 @@ MlasGemmQuantCopyPackA<MLAS_GEMM_U8X8_KERNEL_UMMLA>(MLAS_GEMM_U8X8_KERNEL_UMMLA:
 
             uint32x4_t RowSums1L_ext = vextq_u32(RowSums1L_pada, RowSums1L_pada, 1);
             uint32x4_t RowSums1L_add = vaddq_u32(RowSums1L_pada, RowSums1L_ext);
-            uint32x2_t RowSums1L = {vdups_laneq_u32(RowSums1L_add, 0),
-                                    vdups_laneq_u32(RowSums1L_add, 2)};
+            uint32x2_t RowSums1L = MlasGemmU8X8PairFromLanes02Ummla(RowSums1L_add);
 
             uint32x4_t RowSums1H_pada = vmovq_n_u32(0);
             RowSums1H_pada = vpadalq_u16(RowSums1H_pada, vpaddlq_u8(vreinterpretq_u8_u64(z67)));
 
             uint32x4_t RowSums1H_ext = vextq_u32(RowSums1H_pada, RowSums1H_pada, 1);
             uint32x4_t RowSums1H_add = vaddq_u32(RowSums1H_pada, RowSums1H_ext);
-            uint32x2_t RowSums1H = {vdups_laneq_u32(RowSums1H_add, 0),
-                                    vdups_laneq_u32(RowSums1H_add, 2)};
+            uint32x2_t RowSums1H = MlasGemmU8X8PairFromLanes02Ummla(RowSums1H_add);
 
             RowSums1 = vaddq_u32(RowSums1, vcombine_u32(RowSums1L, RowSums1H));
 
@@ -330,16 +345,14 @@ MlasGemmQuantCopyPackA<MLAS_GEMM_U8X8_KERNEL_UMMLA>(MLAS_GEMM_U8X8_KERNEL_UMMLA:
 
             uint32x4_t RowSums0L_ext = vextq_u32(RowSums0L_pada, RowSums0L_pada, 1);
             uint32x4_t RowSums0L_add = vaddq_u32(RowSums0L_pada, RowSums0L_ext);
-            uint32x2_t RowSums0L = {vdups_laneq_u32(RowSums0L_add, 0),
-                                    vdups_laneq_u32(RowSums0L_add, 2)};
+            uint32x2_t RowSums0L = MlasGemmU8X8PairFromLanes02Ummla(RowSums0L_add);
 
             uint32x4_t RowSums0H_pada = vmovq_n_u32(0);
             RowSums0H_pada = vpadalq_u16(RowSums0H_pada, vpaddlq_u8(vreinterpretq_u8_u64(z23)));
 
             uint32x4_t RowSums0H_ext = vextq_u32(RowSums0H_pada, RowSums0H_pada, 1);
             uint32x4_t RowSums0H_add = vaddq_u32(RowSums0H_pada, RowSums0H_ext);
-            uint32x2_t RowSums0H = {vdups_laneq_u32(RowSums0H_add, 0),
-                                    vdups_laneq_u32(RowSums0H_add, 2)};
+            uint32x2_t RowSums0H = MlasGemmU8X8PairFromLanes02Ummla(RowSums0H_add);
 
             RowSums0 = vaddq_u32(RowSums0, vcombine_u32(RowSums0L, RowSums0H));
 
@@ -348,16 +361,14 @@ MlasGemmQuantCopyPackA<MLAS_GEMM_U8X8_KERNEL_UMMLA>(MLAS_GEMM_U8X8_KERNEL_UMMLA:
 
             uint32x4_t RowSums1L_ext = vextq_u32(RowSums1L_pada, RowSums1L_pada, 1);
             uint32x4_t RowSums1L_add = vaddq_u32(RowSums1L_pada, RowSums1L_ext);
-            uint32x2_t RowSums1L = {vdups_laneq_u32(RowSums1L_add, 0),
-                                    vdups_laneq_u32(RowSums1L_add, 2)};
+            uint32x2_t RowSums1L = MlasGemmU8X8PairFromLanes02Ummla(RowSums1L_add);
 
             uint32x4_t RowSums1H_pada = vmovq_n_u32(0);
             RowSums1H_pada = vpadalq_u16(RowSums1H_pada, vpaddlq_u8(vreinterpretq_u8_u64(z67)));
 
             uint32x4_t RowSums1H_ext = vextq_u32(RowSums1H_pada, RowSums1H_pada, 1);
             uint32x4_t RowSums1H_add = vaddq_u32(RowSums1H_pada, RowSums1H_ext);
-            uint32x2_t RowSums1H = {vdups_laneq_u32(RowSums1H_add, 0),
-                                    vdups_laneq_u32(RowSums1H_add, 2)};
+            uint32x2_t RowSums1H = MlasGemmU8X8PairFromLanes02Ummla(RowSums1H_add);
 
             RowSums1 = vaddq_u32(RowSums1, vcombine_u32(RowSums1L, RowSums1H));
 
@@ -425,8 +436,7 @@ MlasGemmQuantCopyPackA<MLAS_GEMM_U8X8_KERNEL_UMMLA>(MLAS_GEMM_U8X8_KERNEL_UMMLA:
 
             uint32x4_t RowSumsL_ext = vextq_u32(RowSumsL_pada, RowSumsL_pada, 1);
             uint32x4_t RowSumsL_add = vaddq_u32(RowSumsL_pada, RowSumsL_ext);
-            uint32x2_t RowSumsL = {vdups_laneq_u32(RowSumsL_add, 0),
-                                   vdups_laneq_u32(RowSumsL_add, 2)};
+            uint32x2_t RowSumsL = MlasGemmU8X8PairFromLanes02Ummla(RowSumsL_add);
 
             uint32x4_t RowSumsH_pada = vmovq_n_u32(0);
             RowSumsH_pada = vpadalq_u16(RowSumsH_pada, vpaddlq_u8(vreinterpretq_u8_u64(z2)));
@@ -434,8 +444,7 @@ MlasGemmQuantCopyPackA<MLAS_GEMM_U8X8_KERNEL_UMMLA>(MLAS_GEMM_U8X8_KERNEL_UMMLA:
 
             uint32x4_t RowSumsH_ext = vextq_u32(RowSumsH_pada, RowSumsH_pada, 1);
             uint32x4_t RowSumsH_add = vaddq_u32(RowSumsH_pada, RowSumsH_ext);
-            uint32x2_t RowSumsH = {vdups_laneq_u32(RowSumsH_add, 0),
-                                   vdups_laneq_u32(RowSumsH_add, 2)};
+            uint32x2_t RowSumsH = MlasGemmU8X8PairFromLanes02Ummla(RowSumsH_add);
 
             RowSums = vaddq_u32(RowSums, vcombine_u32(RowSumsL, RowSumsH));
 
@@ -466,16 +475,14 @@ MlasGemmQuantCopyPackA<MLAS_GEMM_U8X8_KERNEL_UMMLA>(MLAS_GEMM_U8X8_KERNEL_UMMLA:
 
             uint32x4_t RowSumsL_ext = vextq_u32(RowSumsL_pada, RowSumsL_pada, 1);
             uint32x4_t RowSumsL_add = vaddq_u32(RowSumsL_pada, RowSumsL_ext);
-            uint32x2_t RowSumsL = {vdups_laneq_u32(RowSumsL_add, 0),
-                                   vdups_laneq_u32(RowSumsL_add, 2)};
+            uint32x2_t RowSumsL = MlasGemmU8X8PairFromLanes02Ummla(RowSumsL_add);
 
             uint32x4_t RowSumsH_pada = vmovq_n_u32(0);
             RowSumsH_pada = vpadalq_u16(RowSumsH_pada, vpaddlq_u8(vreinterpretq_u8_u64(z23)));
 
             uint32x4_t RowSumsH_ext = vextq_u32(RowSumsH_pada, RowSumsH_pada, 1);
             uint32x4_t RowSumsH_add = vaddq_u32(RowSumsH_pada, RowSumsH_ext);
-            uint32x2_t RowSumsH = {vdups_laneq_u32(RowSumsH_add, 0),
-                                   vdups_laneq_u32(RowSumsH_add, 2)};
+            uint32x2_t RowSumsH = MlasGemmU8X8PairFromLanes02Ummla(RowSumsH_add);
 
             RowSums = vaddq_u32(RowSums, vcombine_u32(RowSumsL, RowSumsH));
 
@@ -519,16 +526,14 @@ MlasGemmQuantCopyPackA<MLAS_GEMM_U8X8_KERNEL_UMMLA>(MLAS_GEMM_U8X8_KERNEL_UMMLA:
 
             uint32x4_t RowSums0L_ext = vextq_u32(RowSums0L_pada, RowSums0L_pada, 1);
             uint32x4_t RowSums0L_add = vaddq_u32(RowSums0L_pada, RowSums0L_ext);
-            uint32x2_t RowSums0L = {vdups_laneq_u32(RowSums0L_add, 0),
-                                    vdups_laneq_u32(RowSums0L_add, 2)};
+            uint32x2_t RowSums0L = MlasGemmU8X8PairFromLanes02Ummla(RowSums0L_add);
 
             uint32x4_t RowSums0H_pada = vmovq_n_u32(0);
             RowSums0H_pada = vpadalq_u16(RowSums0H_pada, vpaddlq_u8(vreinterpretq_u8_u64(z23)));
 
             uint32x4_t RowSums0H_ext = vextq_u32(RowSums0H_pada, RowSums0H_pada, 1);
             uint32x4_t RowSums0H_add = vaddq_u32(RowSums0H_pada, RowSums0H_ext);
-            uint32x2_t RowSums0H = {vdups_laneq_u32(RowSums0H_add, 0),
-                                    vdups_laneq_u32(RowSums0H_add, 2)};
+            uint32x2_t RowSums0H = MlasGemmU8X8PairFromLanes02Ummla(RowSums0H_add);
 
             RowSums = vaddq_u32(RowSums, vcombine_u32(RowSums0L, RowSums0H));
 
@@ -582,8 +587,7 @@ MlasGemmQuantCopyPackA<MLAS_GEMM_U8X8_KERNEL_UMMLA>(MLAS_GEMM_U8X8_KERNEL_UMMLA:
 
             uint32x4_t RowSumsL_ext = vextq_u32(RowSumsL_pada, RowSumsL_pada, 1);
             uint32x4_t RowSumsL_add = vaddq_u32(RowSumsL_pada, RowSumsL_ext);
-            uint32x2_t RowSumsL = {vdups_laneq_u32(RowSumsL_add, 0),
-                                   vdups_laneq_u32(RowSumsL_add, 2)};
+            uint32x2_t RowSumsL = MlasGemmU8X8PairFromLanes02Ummla(RowSumsL_add);
 
             RowSums = vadd_u32(RowSums, RowSumsL);
 
@@ -606,8 +610,7 @@ MlasGemmQuantCopyPackA<MLAS_GEMM_U8X8_KERNEL_UMMLA>(MLAS_GEMM_U8X8_KERNEL_UMMLA:
 
             uint32x4_t RowSumsL_ext = vextq_u32(RowSumsL_pada, RowSumsL_pada, 1);
             uint32x4_t RowSumsL_add = vaddq_u32(RowSumsL_pada, RowSumsL_ext);
-            uint32x2_t RowSumsL = {vdups_laneq_u32(RowSumsL_add, 0),
-                                   vdups_laneq_u32(RowSumsL_add, 2)};
+            uint32x2_t RowSumsL = MlasGemmU8X8PairFromLanes02Ummla(RowSumsL_add);
 
             RowSums = vadd_u32(RowSums, RowSumsL);
 
@@ -643,8 +646,7 @@ MlasGemmQuantCopyPackA<MLAS_GEMM_U8X8_KERNEL_UMMLA>(MLAS_GEMM_U8X8_KERNEL_UMMLA:
 
             uint32x4_t RowSumsL_ext = vextq_u32(RowSumsL_pada, RowSumsL_pada, 1);
             uint32x4_t RowSumsL_add = vaddq_u32(RowSumsL_pada, RowSumsL_ext);
-            uint32x2_t RowSumsL = {vdups_laneq_u32(RowSumsL_add, 0),
-                                   vdups_laneq_u32(RowSumsL_add, 2)};
+            uint32x2_t RowSumsL = MlasGemmU8X8PairFromLanes02Ummla(RowSumsL_add);
 
             RowSums = vadd_u32(RowSums, RowSumsL);
 
@@ -748,13 +750,13 @@ MlasGemmU8X8CopyPackBProcessUmmla(MLAS_GEMM_U8X8_KERNEL_UMMLA::PackedBType* D,
     ColSums0L_pada = vpadalq_u16(ColSums0L_pada, vpaddlq_u8(vreinterpretq_u8_u32(zd3.val[0])));
     uint32x4_t ColSums0L_ext = vextq_u32(ColSums0L_pada, ColSums0L_pada, 1);
     uint32x4_t ColSums0L_add = vaddq_u32(ColSums0L_pada, ColSums0L_ext);
-    uint32x2_t ColSums0L = {vdups_laneq_u32(ColSums0L_add, 0), vdups_laneq_u32(ColSums0L_add, 2)};
+    uint32x2_t ColSums0L = MlasGemmU8X8PairFromLanes02Ummla(ColSums0L_add);
 
     uint32x4_t ColSums0H_pada = vmovq_n_u32(0);
     ColSums0H_pada = vpadalq_u16(ColSums0H_pada, vpaddlq_u8(vreinterpretq_u8_u32(zd3.val[1])));
     uint32x4_t ColSums0H_ext = vextq_u32(ColSums0H_pada, ColSums0H_pada, 1);
     uint32x4_t ColSums0H_add = vaddq_u32(ColSums0H_pada, ColSums0H_ext);
-    uint32x2_t ColSums0H = {vdups_laneq_u32(ColSums0H_add, 0), vdups_laneq_u32(ColSums0H_add, 2)};
+    uint32x2_t ColSums0H = MlasGemmU8X8PairFromLanes02Ummla(ColSums0H_add);
 
     ColumnSums[0] = vaddq_u32(ColumnSums[0], vcombine_u32(ColSums0L, ColSums0H));
 
@@ -762,13 +764,13 @@ MlasGemmU8X8CopyPackBProcessUmmla(MLAS_GEMM_U8X8_KERNEL_UMMLA::PackedBType* D,
     ColSums1L_pada = vpadalq_u16(ColSums1L_pada, vpaddlq_u8(vreinterpretq_u8_u32(zd4.val[0])));
     uint32x4_t ColSums1L_ext = vextq_u32(ColSums1L_pada, ColSums1L_pada, 1);
     uint32x4_t ColSums1L_add = vaddq_u32(ColSums1L_pada, ColSums1L_ext);
-    uint32x2_t ColSums1L = {vdups_laneq_u32(ColSums1L_add, 0), vdups_laneq_u32(ColSums1L_add, 2)};
+    uint32x2_t ColSums1L = MlasGemmU8X8PairFromLanes02Ummla(ColSums1L_add);
 
     uint32x4_t ColSums1H_pada = vmovq_n_u32(0);
     ColSums1H_pada = vpadalq_u16(ColSums1H_pada, vpaddlq_u8(vreinterpretq_u8_u32(zd4.val[1])));
     uint32x4_t ColSums1H_ext = vextq_u32(ColSums1H_pada, ColSums1H_pada, 1);
     uint32x4_t ColSums1H_add = vaddq_u32(ColSums1H_pada, ColSums1H_ext);
-    uint32x2_t ColSums1H = {vdups_laneq_u32(ColSums1H_add, 0), vdups_laneq_u32(ColSums1H_add, 2)};
+    uint32x2_t ColSums1H = MlasGemmU8X8PairFromLanes02Ummla(ColSums1H_add);
 
     ColumnSums[1] = vaddq_u32(ColumnSums[1], vcombine_u32(ColSums1L, ColSums1H));
 }

--- a/onnxruntime/core/mlas/lib/sconv_nchwc_kernel_neon.cpp
+++ b/onnxruntime/core/mlas/lib/sconv_nchwc_kernel_neon.cpp
@@ -264,7 +264,7 @@ void
         unsigned KernelFlags
     )
 {
-#if defined(MLAS_TARGET_ARM64) && defined(MLAS_USE_ARM_NEON_NCHWC) && !defined(_WIN32)
+#if defined(MLAS_TARGET_ARM64) && defined(MLAS_USE_ARM_NEON_NCHWC)
     MlasConvNchwcFloatKernelNeonAsm(
         Input,
         Filter,
@@ -315,7 +315,7 @@ void
 // Implementation of MlasConvDepthwiseFloatKernelNeon
 //
 // This kernel performs depthwise separable convolution where each input channel
-// is convolved with its own filter. 
+// is convolved with its own filter.
 //
 
 static void

--- a/onnxruntime/core/mlas/lib/snchwc.cpp
+++ b/onnxruntime/core/mlas/lib/snchwc.cpp
@@ -916,7 +916,7 @@ struct MLAS_NCHWC_CONV_POINTWISE_ALGORITHM : MLAS_NCHWC_GROUPED_CONV_ALGORITHM
 
 #if defined(MLAS_TARGET_AMD64) || defined(MLAS_TARGET_LARCH64) || (defined(MLAS_TARGET_ARM64) && defined(MLAS_USE_ARM_NEON_NCHWC)) || (defined(MLAS_TARGET_RISCV64) && defined(MLAS_USE_RVV))
         MLAS_CONV_POINTWISE_FLOAT_KERNEL* Kernel = GetMlasPlatform().ConvPointwiseFloatKernel;
-#if defined(MLAS_TARGET_ARM64) && defined(MLAS_USE_ARM_NEON_NCHWC) && !defined(_WIN32)
+#if defined(MLAS_TARGET_ARM64) && defined(MLAS_USE_ARM_NEON_NCHWC)
         // AArch64 assembly kernel pointwise convolution computes multiple
         // output positions at once and significantly reduces memory traffic.
         MLAS_CONV_POINTWISE_FLOAT_KERNEL* const KernelFast = MlasConvPointwiseFloatKernelNeonAsm;
@@ -976,7 +976,7 @@ struct MLAS_NCHWC_CONV_POINTWISE_ALGORITHM : MLAS_NCHWC_GROUPED_CONV_ALGORITHM
                 //
 
                 MLAS_CONV_POINTWISE_FLOAT_KERNEL* KernelToUse = Kernel;
-#if defined(MLAS_TARGET_ARM64) && defined(MLAS_USE_ARM_NEON_NCHWC) && !defined(_WIN32)
+#if defined(MLAS_TARGET_ARM64) && defined(MLAS_USE_ARM_NEON_NCHWC)
                 // Heuristically select the AArch64 assembly kernel for larger convolutions
                 if (!WorkBlock->UseBf16 && OutputThisIteration >= 4 &&
                     StrideHeight == 1 && StrideWidth == 1) {


### PR DESCRIPTION
### Description

Ports the AArch64 assembly micro-kernels that previously built only on non-Windows platforms so they also build on Windows ARM64 via `armasm64`:

- `SconvKernelNeon.asm` — direct NCHW convolution
- `SconvNchwcKernelNeon.asm` — direct NCHWc convolution
- `SconvPointwiseKernelNeon.asm` — pointwise NCHWc convolution
- `QgemmU8X8KernelUmmla.asm` / `QgemmS8S8KernelSmmla.asm` — I8MM quantized GEMM

Adds them to the Windows MLAS build and removes the `_WIN32` / `__linux__` guards that were selecting the intrinsics kernels instead.

Also adds a small MSVC portability helper in the SMMLA/UMMLA packing code: MSVC rejects braced scalar initializers for NEON vector types, so the `int32x2_t` lane pair is built with lane intrinsics instead. Same generated instructions.

### Motivation and Context

Windows ARM64 was falling back to intrinsics kernels for NCHWc convolution and to non-MMLA dispatches for I8MM quantized GEMM because the hand-written assembly existed only as GNU-assembler `.S` files. This makes those kernels available on native Windows ARM64.

## Dependency

Requires [#32094](https://github.com/microsoft/onnxruntime/pull/32094) to merge first.

`setup_arm_neon_nchwc()` is called from inside `setup_mlas_source_for_windows()` on Windows ARM64, and `set(... PARENT_SCOPE)` only propagates one scope up — so `MLAS_USE_ARM_NEON_NCHWC` is dropped before it reaches the directory-scope `target_compile_definitions()`.

[#32094](https://github.com/microsoft/onnxruntime/pull/32094) fixes this via a directory property. The root cause is tracked in [#32060](https://github.com/microsoft/onnxruntime/issues/32060).

Until it lands, every `#if defined(MLAS_USE_ARM_NEON_NCHWC)` guard is false on Windows ARM64, and the NCHWc kernels compile into empty translation units. The `.asm` files still assemble and link, so there is no build or test failure — the kernels are simply never dispatched.