### PR TITLE
Fix 4-bit weight quantization in QOperator format

### DIFF
--- a/onnxruntime/python/tools/quantization/base_quantizer.py
+++ b/onnxruntime/python/tools/quantization/base_quantizer.py
@@ -9,6 +9,7 @@ from typing import Any
 import numpy as np
 import onnx
 import onnx.numpy_helper
+from ml_dtypes import int4, uint4
 
 try:
     from onnx.reference.op_run import to_array_extended
@@ -344,7 +345,7 @@ class BaseQuantizer:
                             f"\nraw={str(q_weight_initializer)[:200]}."
                         )
             elif qType in (onnx.TensorProto.INT4, onnx.TensorProto.UINT4):
-                if q_weight_data.dtype not in (np.int8, np.uint8):
+                if q_weight_data.dtype not in (int4, uint4):
                     raise RuntimeError(
                         f"Quantized weights for {q_weight_name} must be 8-bit before packing as 4-bit values."
                     )
@@ -482,7 +483,7 @@ class BaseQuantizer:
 
         if not keep_float_weight:
             if weight_qType in (onnx.TensorProto.INT4, onnx.TensorProto.UINT4):
-                if quantized_weights.dtype not in (np.int8, np.uint8):
+                if quantized_weights.dtype not in (int4, uint4):
                     raise RuntimeError(
                         f"Quantized weights for {q_weight_name} must be 8-bit before packing as 4-bit values."
                     )

--- a/onnxruntime/python/tools/quantization/quant_utils.py
+++ b/onnxruntime/python/tools/quantization/quant_utils.py
@@ -227,8 +227,8 @@ def quantize_nparray(qType, arr, scale, zero_point, low=None, high=None):
     else:
         # Quantizes data for all integer types.
         #
-        # For int4 types, the quantized data is returned as either np.int8 or np.uint8,
-        # which matches the python reference ONNX implementation of QuantizeLinear.
+        # For int4 types, the quantized data is returned as either ml_dtypes.int4 or
+        # ml_dtypes.uint4, which matches the python reference ONNX implementation of QuantizeLinear.
         # This data can be packed into 4-bit elements by using pack_bytes_to_4bit().
         dtype = ONNX_TYPE_TO_NP_TYPE[qType]
         qmin, qmax = get_qmin_qmax_for_qType(qType, reduce_range=False, symmetric=False)

--- a/onnxruntime/test/python/quantization/test_op_matmul.py
+++ b/onnxruntime/test/python/quantization/test_op_matmul.py
@@ -5,10 +5,13 @@
 # license information.
 # --------------------------------------------------------------------------
 
+import os
+import tempfile
 import unittest
 
 import numpy as np
 import onnx
+import onnx.numpy_helper
 from numpy.testing import assert_almost_equal
 from onnx import TensorProto, helper
 from op_test_utils import TestDataFeeds, check_model_correctness, check_op_type_count, check_qtype_by_node_type
@@ -475,6 +478,84 @@ class TestOpMatMul(unittest.TestCase):
     @unittest.skip(reason="Too many bins for data range.")
     def test_quantize_matmul_e4m3fn_p3_f16(self):
         self.quantize_matmul_e4m3fn_p3(onnx.TensorProto.FLOAT16, 19, 9)
+
+
+class TestQOperator4BitWeights(unittest.TestCase):
+    """Static quantization of weights to INT4/UINT4 in QOperator format.
+
+    The existing 4-bit coverage only exercises QDQ format, which packs weights via
+    quant_utils.quantize_onnx_initializer. QOperator format goes through
+    BaseQuantizer.quantize_initializer_impl / quantize_weight_per_channel_impl instead.
+    """
+
+    def setUp(self):
+        self._tmp_dir = tempfile.TemporaryDirectory()
+        self.tmp_dir = self._tmp_dir.name
+
+    def tearDown(self):
+        self._tmp_dir.cleanup()
+
+    def construct_matmul_model(self, model_path, weight):
+        #  (input) --MatMul(weight)--> (output)
+        nodes = [helper.make_node("MatMul", ["input", "weight"], ["output"], name="matmul_node")]
+        graph = helper.make_graph(
+            nodes,
+            "matmul_4bit_weight",
+            [helper.make_tensor_value_info("input", TensorProto.FLOAT, [1, weight.shape[0]])],
+            [helper.make_tensor_value_info("output", TensorProto.FLOAT, [1, weight.shape[1]])],
+            [onnx.numpy_helper.from_array(weight, "weight")],
+        )
+        model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 21)])
+        model.ir_version = 10
+        onnx.save(model, model_path)
+
+    def quantize_and_check_weight(self, weight_type, per_channel):
+        expected_proto_type = TensorProto.INT4 if weight_type == QuantType.QInt4 else TensorProto.UINT4
+        weight = np.random.default_rng(0).random((4, 8)).astype(np.float32)
+
+        model_fp_path = os.path.join(self.tmp_dir, "matmul_fp.onnx")
+        model_q_path = os.path.join(self.tmp_dir, "matmul_quant.onnx")
+        self.construct_matmul_model(model_fp_path, weight)
+
+        data_reader = TestDataFeeds([{"input": np.random.rand(1, 4).astype(np.float32)} for _ in range(3)])
+        quantize_static(
+            model_fp_path,
+            model_q_path,
+            data_reader,
+            quant_format=QuantFormat.QOperator,
+            per_channel=per_channel,
+            activation_type=QuantType.QUInt8,
+            weight_type=weight_type,
+        )
+
+        quantized_model = onnx.load(model_q_path)
+        onnx.checker.check_model(quantized_model)
+        initializers = {init.name: init for init in quantized_model.graph.initializer}
+
+        q_weight_init = initializers["weight_quantized"]
+        self.assertEqual(q_weight_init.data_type, expected_proto_type)
+        self.assertEqual(list(q_weight_init.dims), list(weight.shape))
+
+        q_weight = onnx.numpy_helper.to_array(q_weight_init).astype(np.float32)
+        scale = onnx.numpy_helper.to_array(initializers["weight_scale"]).astype(np.float32)
+        zero_point = onnx.numpy_helper.to_array(initializers["weight_zero_point"]).astype(np.float32)
+        self.assertEqual(scale.shape, (weight.shape[1],) if per_channel else ())
+
+        # Dequantized values must be within half a quantization step of the originals.
+        dequantized = (q_weight - zero_point) * scale
+        np.testing.assert_allclose(dequantized, weight, atol=scale.max() / 2 + 1e-6)
+
+    def test_quantize_matmul_weight_s4(self):
+        self.quantize_and_check_weight(QuantType.QInt4, per_channel=False)
+
+    def test_quantize_matmul_weight_u4(self):
+        self.quantize_and_check_weight(QuantType.QUInt4, per_channel=False)
+
+    def test_quantize_matmul_weight_s4_per_channel(self):
+        self.quantize_and_check_weight(QuantType.QInt4, per_channel=True)
+
+    def test_quantize_matmul_weight_u4_per_channel(self):
+        self.quantize_and_check_weight(QuantType.QUInt4, per_channel=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Description

`BaseQuantizer.quantize_initializer_impl` and `BaseQuantizer.quantize_weight_per_channel_impl` guard the 4-bit packing path with a check that the quantized weight array is `np.int8`/`np.uint8`:

```python
if q_weight_data.dtype not in (np.int8, np.uint8):
    raise RuntimeError(f"Quantized weights for {q_weight_name} must be 8-bit before packing as 4-bit values.")
```

The array comes from `quantize_nparray`, which returns `arr.astype(ONNX_TYPE_TO_NP_TYPE[qType])`, and `ONNX_TYPE_TO_NP_TYPE` maps `INT4`/`UINT4` to `ml_dtypes.int4`/`ml_dtypes.uint4`. The condition is therefore always true for 4-bit weights and the `RuntimeError` always fires.

The equivalent guard in `quant_utils.quantize_onnx_initializer`, which the QDQ path uses, already compares against `int4`/`uint4`. These two copies in `base_quantizer.py` look like they were just missed when the dtype mapping moved to `ml_dtypes`; the comment in `quantize_nparray` still describes the old `np.int8`/`np.uint8` behaviour too, so I corrected that as well.

The guard is the only thing blocking the path: `pack_bytes_to_4bit(...tobytes())` works fine on `ml_dtypes.int4` arrays, since those are one byte per element like `int8`.

Repro on current main (and on released packages):

```python
quantize_static(
    src, dst, data_reader,
    quant_format=QuantFormat.QOperator,
    weight_type=QuantType.QInt4,
    activation_type=QuantType.QUInt8,
)
```

```
File "onnxruntime/quantization/base_quantizer.py", line 348, in quantize_initializer_impl
    raise RuntimeError(
RuntimeError: Quantized weights for W_quantized must be 8-bit before packing as 4-bit values.
```

`per_channel=True` hits the same failure in `quantize_weight_per_channel_impl`.

With the fix, the same call produces `QuantizeLinear` / `QLinearMatMul` / `DequantizeLinear` with an `INT4` weight initializer of the right shape, and the dequantized weights are within half a quantization step of the originals.

### Motivation and Context

Quantizing weights to INT4 or UINT4 in `QuantFormat.QOperator` is currently impossible - it always raises. QDQ format is unaffected.

I added tests for `QInt4` and `QUInt4`, per-tensor and per-channel, in QOperator format. They fail on main with the error above and pass with this change. The existing 4-bit coverage in `test_qdq.py` only exercises QDQ format, which is why this was not caught.

I verified `test_op_matmul.py`, `test_qdq.py`, `test_quant_util.py` and `test_get_qdq_config.py` show no change in results apart from the four new tests going from failing to passing, and ran `ruff check` and `ruff format` on the changed files.