### PR TITLE
Fix homepage carousel keyboard accessibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
 		"preview": "vite preview",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
+		"test:carousel-accessibility": "npm run build && node --test tests/carousel-accessibility.test.mjs",
 		"lint": "prettier --plugin-search-dir . --check . && eslint .",
 		"format": "prettier --plugin-search-dir . --write ./src",
 		"deploy": "npx gh-pages -d build -r git@github.com:MaanavD/onnxruntime.git",

--- a/src/lib/components/ui/InfiniteMovingCards/InfiniteMovingCards.svelte
+++ b/src/lib/components/ui/InfiniteMovingCards/InfiniteMovingCards.svelte
@@ -14,29 +14,16 @@
 
 	let containerRef: HTMLDivElement;
 	let scrollerRef: HTMLUListElement;
+	let userPaused = false;
 
 	onMount(() => {
-		addAnimation();
+		getDirection();
+		getSpeed();
+		start = true;
 	});
 
 	let start = false;
 
-	function addAnimation() {
-		if (containerRef && scrollerRef) {
-			const scrollerContent = Array.from(scrollerRef.children);
-
-			scrollerContent.forEach((item) => {
-				const duplicatedItem = item.cloneNode(true);
-				if (scrollerRef) {
-					scrollerRef.appendChild(duplicatedItem);
-				}
-			});
-
-			getDirection();
-			getSpeed();
-			start = true;
-		}
-	}
 	const getDirection = () => {
 		if (containerRef) {
 			if (direction === 'left') {
@@ -60,20 +47,43 @@
 
 	const toggleScroll = () => {
 		if (scrollerRef) {
-			const currentState = window.getComputedStyle(scrollerRef).animationPlayState;
-			scrollerRef.style.animationPlayState = currentState === 'running' ? 'paused' : 'running';
+			userPaused = !userPaused;
+			scrollerRef.style.animationPlayState = userPaused ? 'paused' : '';
 		}
 	};
 
-	const handleKeyDown = (event: { key: string; preventDefault: () => void }) => {
+	const handleKeyDown = (event: KeyboardEvent) => {
 		if (event.key === 'Enter' || event.key === ' ') {
-			event.preventDefault(); // Prevent default spacebar scrolling behavior
+			event.preventDefault();
 			toggleScroll();
+		}
+	};
+
+	const handleLinkFocus = (event: FocusEvent) => {
+		if (event.target instanceof HTMLElement && scrollerRef) {
+			scrollerRef.style.animation = 'none';
+			event.target.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+		}
+	};
+
+	const handleLinkBlur = (event: FocusEvent) => {
+		if (
+			scrollerRef &&
+			containerRef &&
+			!(event.relatedTarget instanceof Node && scrollerRef.contains(event.relatedTarget))
+		) {
+			containerRef.scrollLeft = 0;
+			scrollerRef.style.removeProperty('animation');
+			scrollerRef.style.animationPlayState = userPaused ? 'paused' : '';
 		}
 	};
 </script>
 
-<div bind:this={containerRef} class={cn('scroller relative z-2 overflow-hidden ', className)}>
+<div
+	bind:this={containerRef}
+	class={cn('scroller relative z-2 overflow-hidden ', className)}
+	data-customer-carousel
+>
 	<button
 		class="hover:bg-primary focus:bg-primary menu-item py-2 sr-only focus:not-sr-only"
 		on:keydown={handleKeyDown}
@@ -82,19 +92,49 @@
 	<ul
 		bind:this={scrollerRef}
 		class={cn(
-			' flex w-max min-w-full shrink-0 flex-nowrap gap-4 py-4',
+			'moving-cards flex w-max min-w-full shrink-0 flex-nowrap gap-4 py-4',
 			start && 'animate-scroll',
 			pauseOnHover && 'hover:[animation-play-state:paused]'
 		)}
+		aria-label="Customer testimonials"
 	>
-		{#each items as item, idx (item.alt)}
+		{#each items as item (item.alt)}
 			<li
 				class="bg-slate-300 m-auto relative h-28 w-[200px] max-w-full flex-shrink-0 hover:scale-105 transition duration-200 rounded-md border border-2 border-secondary md:w-[200px]"
+				data-carousel-original
 			>
-				<a href={item.href} class="block h-full w-full rounded-md focus:outline-none focus-visible:ring-4 focus-visible:ring-primary focus-visible:ring-offset-2">
+				<a
+					href={item.href}
+					class="block h-full w-full rounded-md focus:outline-none focus-visible:ring-4 focus-visible:ring-primary focus-visible:ring-offset-2"
+					on:focus={handleLinkFocus}
+					on:blur={handleLinkBlur}
+				>
 					<img class="h-28 p-2 m-auto" src={item.src} alt={item.alt} />
+				</a>
+			</li>
+		{/each}
+		{#each items as item (item.alt)}
+			<li
+				class="bg-slate-300 m-auto relative h-28 w-[200px] max-w-full flex-shrink-0 hover:scale-105 transition duration-200 rounded-md border border-2 border-secondary md:w-[200px]"
+				aria-hidden="true"
+				data-carousel-copy
+			>
+				<a href={item.href} tabindex="-1">
+					<img class="h-28 p-2 m-auto" src={item.src} alt="" />
 				</a>
 			</li>
 		{/each}
 	</ul>
 </div>
+
+<style>
+	.moving-cards:focus-within {
+		animation: none !important;
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.moving-cards {
+			animation: none !important;
+		}
+	}
+</style>

--- a/src/lib/components/ui/InfiniteMovingCards/InfiniteMovingCards.svelte
+++ b/src/lib/components/ui/InfiniteMovingCards/InfiniteMovingCards.svelte
@@ -105,7 +105,7 @@
 			>
 				<a
 					href={item.href}
-					class="block h-full w-full rounded-md focus:outline-none focus-visible:ring-4 focus-visible:ring-primary focus-visible:ring-offset-2"
+					class="block h-full w-full rounded-md focus:outline-none focus-visible:ring-4 focus-visible:ring-inset focus-visible:ring-primary focus-visible:ring-offset-2"
 					on:focus={handleLinkFocus}
 					on:blur={handleLinkBlur}
 				>

--- a/src/routes/components/customers.svelte
+++ b/src/routes/components/customers.svelte
@@ -227,11 +227,7 @@
 <div class="lg:my-5">
 	<h2 class="text-3xl my-5 text-center">Trusted By</h2>
 	<div class="divider" />
-	<InfiniteMovingCards
-		items={testimonials.sort(() => Math.random() - 0.5)}
-		direction="left"
-		speed="slow"
-	/>
+	<InfiniteMovingCards items={testimonials} direction="left" speed="slow" />
 	<!-- <div class="container mx-auto md:px-16 px-8 lg:my-10">
 		<h2 class="text-2xl pt-10 pb-4">Learn more about how to use ONNX Runtime with</h2>
 		<div class="grid md:grid-cols-3 grid-cols-1 gap-4 mx-auto pb-10">

--- a/tests/carousel-accessibility.test.mjs
+++ b/tests/carousel-accessibility.test.mjs
@@ -57,6 +57,16 @@ test('homepage carousel renders one semantic customer-link set', () => {
 	assert.equal(tabbableLinks.length, expectedCustomerNames.length);
 });
 
+test('customer focus rings render inside their clipped border boxes', () => {
+	assert.ok(carousel, 'customer carousel should be present in the rendered homepage');
+
+	const originals = [...carousel.matchAll(/<li[^>]*data-carousel-original[^>]*>([\s\S]*?)<\/li>/g)];
+
+	for (const [, item] of originals) {
+		assert.match(item, /focus-visible:ring-inset/);
+	}
+});
+
 test('visual carousel copies are hidden and excluded from sequential focus', () => {
 	assert.ok(carousel, 'customer carousel should be present in the rendered homepage');
 

--- a/tests/carousel-accessibility.test.mjs
+++ b/tests/carousel-accessibility.test.mjs
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const expectedCustomerNames = [
+	'Adobe',
+	'AMD',
+	'Ant Group',
+	'Algoriddim',
+	'ATLAS',
+	'Autodesk',
+	'Bazaarvoice',
+	'Camo',
+	'Cephable',
+	'ClearBlade',
+	'Deezer',
+	'GoodNotes',
+	'Graiphic',
+	'Hugging Face',
+	'Hypefactors',
+	'InFarm',
+	'Intel',
+	'Intelligenza Etica',
+	'Navitaire',
+	'NVIDIA',
+	'Apache OpenNLP',
+	'Oracle',
+	'Peakspeed',
+	'Pieces',
+	'PTW Dosimetry',
+	'Redis',
+	'Rockchip',
+	'Samtec',
+	'SAS',
+	'Teradata',
+	'Topaz Labs',
+	'Unreal Engine',
+	'USDA',
+	'Vespa',
+	'Writer',
+	'Xilinx'
+];
+
+const html = await readFile(new URL('../build/index.html', import.meta.url), 'utf8');
+const carousel = html.match(/<div[^>]*data-customer-carousel[^>]*>([\s\S]*?)<\/ul>/)?.[1];
+
+test('homepage carousel renders one semantic customer-link set', () => {
+	assert.ok(carousel, 'customer carousel should be present in the rendered homepage');
+
+	const originals = [...carousel.matchAll(/<li[^>]*data-carousel-original[^>]*>([\s\S]*?)<\/li>/g)];
+	const names = originals.map(([, item]) => item.match(/<img[^>]*alt="([^"]+)"/)?.[1]);
+	const tabbableLinks = originals.filter(
+		([, item]) => /<a href=/.test(item) && !/tabindex="-1"/.test(item)
+	);
+
+	assert.deepEqual(names, expectedCustomerNames);
+	assert.equal(tabbableLinks.length, expectedCustomerNames.length);
+});
+
+test('visual carousel copies are hidden and excluded from sequential focus', () => {
+	assert.ok(carousel, 'customer carousel should be present in the rendered homepage');
+
+	const copies = [
+		...carousel.matchAll(/<li[^>]*aria-hidden="true"[^>]*data-carousel-copy[^>]*>([\s\S]*?)<\/li>/g)
+	];
+
+	assert.equal(copies.length, expectedCustomerNames.length);
+	for (const [, item] of copies) {
+		assert.match(item, /<a[^>]*tabindex="-1"/);
+		assert.match(item, /<img[^>]*alt=""/);
+	}
+});


### PR DESCRIPTION
## Summary
- replace runtime `cloneNode` carousel duplication with one semantic customer-link set and an `aria-hidden`, `tabindex="-1"` visual copy
- suspend/reset the moving transform while customer links have focus so every focused card remains on-screen with the existing focus ring
- keep deterministic logical link order, continuous pointer motion, the scroll toggle, and reduced-motion behavior
- add a built-homepage regression for customer names, semantic link count, and duplicate exclusion from sequential focus

## Official production evidence
Accessibility Insights for Web v2.47.0 (axe-core 4.11.3), official Edge Add-ons package:

- `FastPass_20260819_ONNXRuntimeHome.html`
- `ONNXRuntimeHome-AccessibilityInsights-FastPass-official.zip`
- Automated checks: 0 failed / 0 incomplete / 28 passed
- Tab stops: 2 failed / 0 incomplete / 3 passed
- Failures: off-viewport focus indicators at orders 14-18 and duplicate moving-carousel traversal interrupting logical tab order

This PR validates the fix on a local built preview only. Production must be rerun with the official Accessibility Insights extension after deployment, and ADO 97172 must remain open until both production Tab stops checks pass.

## Validation
- `npm run test:carousel-accessibility` (production build plus 2 focused regressions)
- targeted Prettier and ESLint: pass (existing warnings only)
- real Microsoft Edge keyboard traversal on the built preview: 36/36 unique semantic customer links focused in order, 36/36 fully visible with focus indicators, 0 duplicate links traversed
- normal motion runs, pauses during focus traversal, resumes afterward; `prefers-reduced-motion: reduce` disables animation
- `npm run check` remains blocked by 38 pre-existing diagnostics in unrelated `svelte-icons` imports and `inference-table.svelte`; the changed carousel files report no diagnostics
- the official Accessibility Insights extension was not rerun on the local preview because its interactive Tab stops workflow is not automatable in this CLI session