### PR TITLE
[CUDA] Add GatedDeltaNet contrib operator with chunked prefill and warp decode engines

### DIFF
--- a/docs/contrib_ops/cuda/gdn.md
+++ b/docs/contrib_ops/cuda/gdn.md
@@ -92,11 +92,18 @@ by `num_heads_v / num_heads_q` value heads, which is the Qwen3.8 arrangement
 
 ## 3. Layout and State Contract
 
+**Rank 3 or rank 4.** Query, key and value are token-major. The leading token axis may be
+packed (`[total_tokens, H, D]`) or spelled out as `[batch_size, sequence_length, H, D]`, in
+which case decay and beta gain the same extra axis and so does the output. The two forms have
+identical memory layouts. The rank-4 form exists so an exporter can go from a `(B, S, H*D)`
+activation and back with static `Reshape` targets (`[0, 0, H, D]` and `[0, 0, H*D]`) instead
+of Shape-derived ones, which would be placed on CPU and prevent CUDA graph capture. Ragged
+packing needs the rank-3 form because `cu_seqlens` cannot describe a rectangular batch.
+
 **Sequence packing.** With `cu_seqlens` present, it holds the exclusive prefix sums of the
 per-request token counts and requests may have different lengths. With it absent the packing
-is uniform and the batch size is taken from `initial_state`, which is then required. The
-absent case is what a padded `(B, T, H*D)` producer reshapes to for free, so an existing
-graph needs no new input to adopt the operator.
+is uniform and the batch size is taken from the rank-4 shape, or from `initial_state` when
+the inputs are rank 3.
 
 **`cu_seqlens` is device data.** Offsets are clamped to `[0, total_tokens]` inside the
 kernels (`SequenceRange`), so a malformed producer cannot steer an out-of-bounds access.
@@ -293,6 +300,20 @@ count gives a fixed cost of about 4.46 us and a per-token cost of about 1.36 us
 grid-size heuristic and it falls back to a slower recurrent kernel; `VarlenLinearAttention`
 removed that guard and is 3.7x faster there. `GatedDeltaNet` is a further 2.0x-2.5x faster
 than `VarlenLinearAttention` across these shapes.
+
+### End to end: Qwen3.5-27B-A3B (Qwen3.8) NVFP4, H200, batch 1
+
+Two 64-layer models built from the same checkpoint with the same options, differing only in
+which operator the 48 linear-attention layers use (`onnxruntime-genai` model builder,
+`--extra_options linear_attn_op=gated_delta_net`). Prefill chunk 1024, 128 generated tokens.
+
+| context | TTFT LinearAttention | TTFT GatedDeltaNet | prefill tok/s | decode ms/token |
+|---:|---:|---:|---|---|
+| 1024 | 234.3 ms | **183.9 ms** (-21.5%) | 4370 -> 5568 (+27%) | 12.38 -> 12.22 |
+| 8192 | 1672.9 ms | **1239.2 ms** (-25.9%) | 4897 -> 6611 (+35%) | 13.29 -> 13.08 |
+
+Greedy decoding agrees token for token (64/64) between the two models, with
+`max|delta logits| = 0.075` on the 248320-wide fp16 logit vector at the first decode step.
 
 ### Reproducing
 

--- a/docs/contrib_ops/cuda/gdn.md
+++ b/docs/contrib_ops/cuda/gdn.md
@@ -82,7 +82,7 @@ Source:
 | 1 | `final_state` | `(batch_size, num_heads_v, head_size_v, head_size_qk)` | float | no |
 | 2 | `checkpoints` | `(state_checkpoints, batch_size, num_heads_v, head_size_v, head_size_qk)` | float | no |
 
-Type constraints: `T` is `float`, `float16` or `bfloat16`; state, decay and beta are always
+Type constraints: `T` is `float` or `float16`; state, decay and beta are always
 `float`, independent of `T`.
 
 Head-count rules: `num_heads_q == num_heads_k`, and `num_heads_v` must be a positive multiple

--- a/docs/contrib_ops/cuda/gdn.md
+++ b/docs/contrib_ops/cuda/gdn.md
@@ -1,0 +1,387 @@
+# GatedDeltaNet — Operator Documentation
+
+This document describes the `com.microsoft::GatedDeltaNet` contrib operator: its schema and
+state contract, the chunked and warp-specialised CUDA engines and how one is selected, the
+consumer-Blackwell shared-memory constraint, and measured comparisons against
+`LinearAttention`, `VarlenLinearAttention` and flash-linear-attention (FLA).
+
+The operator implements gated linear attention with an explicit recurrent state — the
+"gated delta net" family used by Qwen3-Next / Qwen3.5 / Qwen3.8 style hybrid models.
+
+Source:
+[bert_defs.cc](../../../onnxruntime/core/graph/contrib_ops/bert_defs.cc) (schema),
+[gated_delta_net.cc](../../../onnxruntime/contrib_ops/cuda/bert/gated_delta_net.cc),
+[gated_delta_net_impl.cu](../../../onnxruntime/contrib_ops/cuda/bert/gated_delta_net_impl.cu),
+[gated_delta_net_plan.h](../../../onnxruntime/contrib_ops/cuda/bert/gated_delta_net_plan.h).
+
+---
+
+## Table of Contents
+
+1. [Overview](#1-overview)
+2. [Operator Schema](#2-operator-schema)
+3. [Layout and State Contract](#3-layout-and-state-contract)
+4. [Recurrence and the Chunked Form](#4-recurrence-and-the-chunked-form)
+5. [CUDA Engines and Plan Selection](#5-cuda-engines-and-plan-selection)
+6. [Shared Memory and Consumer Blackwell (SM120)](#6-shared-memory-and-consumer-blackwell-sm120)
+7. [Benchmarks](#7-benchmarks)
+8. [Accuracy](#8-accuracy)
+9. [Environment Variables](#9-environment-variables)
+10. [Testing](#10-testing)
+11. [Known Limitations and Future Work](#11-known-limitations-and-future-work)
+
+---
+
+## 1. Overview
+
+`GatedDeltaNet` is a packed, token-major operator. It differs from the existing
+`LinearAttention` operator in three ways that matter for both performance and correctness:
+
+- **Token-major (THD) inputs.** Head counts are derived from rank-3 shapes rather than from
+  attributes, and an optional `cu_seqlens` allows variable-length requests in one call.
+- **V-major float32 state, split into `initial_state` / `final_state`.** The recurrence
+  boundary is where reduced precision hurts most, and V-major matches the layout used by
+  cuDNN's GDN/KDA and by FLA with `state_v_first=true`.
+- **A chunked, tensor-core prefill engine.** `LinearAttention` runs a sequential per-token
+  recurrence with no tensor-core use at any sequence length; `GatedDeltaNet` uses a chunked
+  (WY / UT-transform) algorithm for prefill and keeps a sequential engine only for decode.
+
+## 2. Operator Schema
+
+### Attributes
+
+| Attribute | Type | Default | Description |
+|---|---|---|---|
+| `update_rule` | string | `gated_delta` | One of `linear`, `gated`, `delta`, `gated_delta`. Selects which of the decay and delta-retrieval terms are present. |
+| `scale` | float | `0.0` | Output scale. `0.0` means `1/sqrt(head_size_qk)`. |
+| `gate_activation` | string | `none` | `none` treats `decay` as the effective log-space decay. `qwen` computes `-exp(a_log) * Softplus(decay + dt_bias)` in float32. |
+| `beta_activation` | string | `none` | `none` treats `beta` as the effective update rate; `sigmoid` applies a sigmoid. |
+| `qk_l2_norm` | int | `0` | When `1`, L2-normalizes each query and key head vector in-kernel. |
+| `chunk_size` | int | `64` | Chunk length for the chunked engine. `32` pins the reduced shared-memory configuration (see §6). |
+| `state_checkpoints` | int | `0` | Number of leading per-token state checkpoint slots `W`, in `[0, 8]`. `0` disables the `checkpoints` output. |
+
+### Inputs
+
+| # | Name | Shape | Type | Required |
+|---|---|---|---|---|
+| 0 | `query` | `(total_tokens, num_heads_q, head_size_qk)` | T | yes |
+| 1 | `key` | `(total_tokens, num_heads_k, head_size_qk)` | T | yes |
+| 2 | `value` | `(total_tokens, num_heads_v, head_size_v)` | T | yes |
+| 3 | `cu_seqlens` | `(batch_size + 1)` | int32 | no |
+| 4 | `decay` | `(total_tokens, num_heads_v)` or `(total_tokens, num_heads_v, head_size_qk)` | float | no |
+| 5 | `beta` | `(total_tokens, num_heads_v)` | float | no |
+| 6 | `initial_state` | `(batch_size, num_heads_v, head_size_v, head_size_qk)` | float | no |
+| 7 | `a_log` | `(num_heads_v)` | float | no |
+| 8 | `dt_bias` | `(num_heads_v)` or `(num_heads_v, head_size_qk)` | float | no |
+
+### Outputs
+
+| # | Name | Shape | Type | Required |
+|---|---|---|---|---|
+| 0 | `output` | `(total_tokens, max(num_heads_q, num_heads_v), head_size_v)` | T | yes |
+| 1 | `final_state` | `(batch_size, num_heads_v, head_size_v, head_size_qk)` | float | no |
+| 2 | `checkpoints` | `(state_checkpoints, batch_size, num_heads_v, head_size_v, head_size_qk)` | float | no |
+
+Type constraints: `T` is `float`, `float16` or `bfloat16`; state, decay and beta are always
+`float`, independent of `T`.
+
+Head-count rules: `num_heads_q == num_heads_k`, and `num_heads_v` must be a positive multiple
+of `num_heads_q`. This is *inverse* grouped-query attention — each query/key head is shared
+by `num_heads_v / num_heads_q` value heads, which is the Qwen3.8 arrangement
+(`num_heads_q = num_heads_k = 16`, `num_heads_v = 48`).
+
+## 3. Layout and State Contract
+
+**Sequence packing.** With `cu_seqlens` present, it holds the exclusive prefix sums of the
+per-request token counts and requests may have different lengths. With it absent the packing
+is uniform and the batch size is taken from `initial_state`, which is then required. The
+absent case is what a padded `(B, T, H*D)` producer reshapes to for free, so an existing
+graph needs no new input to adopt the operator.
+
+**`cu_seqlens` is device data.** Offsets are clamped to `[0, total_tokens]` inside the
+kernels (`SequenceRange`), so a malformed producer cannot steer an out-of-bounds access.
+There is no host synchronisation and no device error flag; values outside the contract yield
+unspecified results but remain memory-safe.
+
+**Aliasing.** `initial_state` and `final_state` may be the same allocation. Both engines read
+the entire incoming state into registers or shared memory before writing any of it. No output
+is ever cleared: slots the call does not write — in particular unused `checkpoints` slots —
+are left **unspecified**, never zeroed, because the buffer may alias live state.
+
+**Checkpoints.** Slot `j` receives the state after local token `j` of each request. This is
+the series a speculative decoder needs to roll back to a partially accepted draft, while
+`final_state` still holds the state after the last token. Only the sequential engine can
+produce it, so requesting checkpoints forces that engine.
+
+## 4. Recurrence and the Chunked Form
+
+Per value head, with `S` the `[head_size_qk x head_size_v]` state:
+
+```
+S_t = exp(g_t) S_{t-1} + k_t (beta_t (v_t - exp(g_t) S_{t-1}^T k_t))^T
+o_t = scale * S_t^T q_t
+```
+
+Over a chunk of `BT` tokens, with `gc` the within-chunk cumulative log-decay:
+
+```
+M[t,s] = beta_t (k_t . k_s) exp(gc_t - gc_s)          strictly lower
+U      = (I + M)^-1 (Ubar - Wbar S0)                  Ubar = beta v, Wbar[t] = beta_t exp(gc_t) k_t
+P[t,s] = (q_t . k_s) exp(gc_t - gc_s)                 inclusive lower
+o      = scale (P U + Qg S0)                          Qg[t] = q_t exp(gc_t)
+S1     = exp(gc_BT) S0 + Kd^T U                       Kd[t] = k_t exp(gc_BT - gc_t)
+```
+
+Two properties of that form are used directly by the kernel:
+
+1. **The `W` solve is removable.** `W` is only ever used as `W S0`, and `W = (I+M)^-1 Wbar`,
+   so `U = (I+M)^-1 Ubar - W S0 = (I+M)^-1 (Ubar - Wbar S0)`. The `[BT x head_size_qk]`
+   triangular solve disappears. Because `Wbar` is only a row scaling of `k`, it is never
+   materialised either — the scaling folds into the epilogue of `(k S0)`.
+2. **`(I+M)^-1` has an exact closed form.** With `Dinv` the block diagonal of the four
+   `16x16` inverses and `N = Dinv M` (whose own `16x16` diagonal blocks are exactly zero),
+   `N` is strictly block-lower over `BT/16` levels, so `N^(BT/16) = 0` and
+   `(I+M)^-1 = (I - N + N^2 - ...) Dinv` terminates **exactly**. Evaluated by Horner this is
+   a handful of full `BT x BT x BT` GEMMs, each using every warp, in place of a blocked
+   forward substitution's sequence of tiny serial ones.
+
+`k * exp(-gc)` is never formed; the decay ratio is applied to the `[BT x BT]` gram matrices
+so the exponent stays bounded within a chunk.
+
+**The delta family requires L2-normalized keys.** Without them `(I + M)` is arbitrarily
+ill-conditioned and the recurrence diverges — in reduced precision the Neumann intermediates
+overflow. Either normalize upstream or set `qk_l2_norm=1`.
+
+## 5. CUDA Engines and Plan Selection
+
+Selection follows the cuDNN frontend's execution flow: a problem `Descriptor` is hashed into
+a `PlanCache`, a heuristic (`SelectPlan`, the analogue of `heur_mode::A`) picks an engine and
+its tile parameters, the plan reports its workspace and shared-memory requirement, and
+execution binds a `VariantPack` of device pointers.
+
+| Engine | Used for | Shape |
+|---|---|---|
+| `chunked` | prefill | one CTA per `(sequence, v-head, v-block)`, 512 threads, state resident in shared memory for the whole walk, `mma.sync.m16n8k16` GEMMs |
+| `recurrent` (warp-specialised) | decode / MTP verify | one **warp** per `(sequence, v-head, v-column)`, lanes spanning K |
+| `recurrent` (generic) | head geometries the warp kernel cannot take | one CTA per `(sequence, v-head)`, state in shared memory |
+| `cudnn` | reserved, not implemented | see §11 |
+
+`SelectPlan` requires all of the following for the chunked engine, and falls back to the
+sequential engine otherwise: no checkpoints requested, `total_tokens >= 32 * batch_size`,
+`head_size_qk == head_size_v == 128`, `num_heads_q == num_heads_k`,
+`num_heads_v % num_heads_q == 0`, scalar (not per-key-dimension) decay, `float16` input, SM80
+or newer, and enough shared memory.
+
+The **32-token threshold is measured, not assumed**: below roughly 30 tokens the chunked
+engine still pays for a full 64-token chunk, so a single token costs about what 64 do
+(46.5 us against 17.9 us for a sequential recurrence at the Qwen3.8 shape).
+
+### Why the decode engine is warp-specialised
+
+The V-major state makes a warp-per-column mapping natural, and it removes every barrier from
+the token loop:
+
+- Lanes span K, and the state is `[..., V, K]`, so lane accesses are fully coalesced. A
+  CTA-per-head mapping instead walks `state[c * head_size_qk + r]` with consecutive threads
+  on `c`, striding every access.
+- Both reductions (`S^T k` and `S^T q`) are over K, so they are `__shfl_xor` butterflies.
+  The token loop uses **no `__syncthreads()` and no shared memory**.
+- The grid becomes `(sequences, v-heads, head_size_v / warps)` instead of
+  `(sequences, v-heads)` — 768 CTAs instead of 48 at the Qwen3.8 decode shape.
+
+Each lane takes `k = lane, lane + 32, ...` rather than a contiguous run. That is deliberate:
+each of the resulting accesses is its own fully coalesced warp transaction, and the extra
+requests in flight beat the single wide `float4` a contiguous run would allow — measured
+5.86 us against 6.37 us.
+
+## 6. Shared Memory and Consumer Blackwell (SM120)
+
+The chunked engine's footprint depends on the chunk length. Consumer Blackwell allows only
+99 KB of opt-in shared memory per block, against 227 KB on SM90 and SM100 — CUTLASS records
+these as `sm120_smem_capacity_bytes = 101376` and `sm100_smem_capacity_bytes = 232448` in
+`cutlass/arch/arch.h`.
+
+| `chunk_size` x v-block | shared memory | fits SM120 (99 KB) | fits SM90 (227 KB) |
+|---|---:|---|---|
+| 64 x 64 | 157 KB | no | yes |
+| 64 x 32 | 141 KB | no | yes |
+| 32 x 64 | 96 KB | **yes** | yes |
+
+`SelectPlan` therefore takes the widest chunk the device's `sharedMemPerBlockOptin` can
+actually hold. `chunk_size = 64` is the faster configuration where it fits; `chunk_size = 32`
+costs about 10% (127.2 / 440.2 / 3503.7 us at `T = 256 / 1024 / 8192` against
+117.2 / 398.8 / 3090.1) at identical accuracy, and needs *fewer* Neumann terms — with two
+diagonal blocks instead of four, `N^2 = 0`, so `(I+M)^-1 = (I - N) Dinv`.
+
+Setting the `chunk_size` attribute to `32` pins the narrow configuration so the SM120 code
+path can be exercised on other architectures. The kernel uses only `mma.sync.m16n8k16`
+(sm_80 and newer PTX) with no wgmma, TMA or cluster features, so nothing else blocks SM120.
+
+## 7. Benchmarks
+
+**Hardware / build.** NVIDIA H200 (SM90, 132 SMs, driver 580.105.08), CUDA 13.0,
+ONNX Runtime 1.30.0.
+
+**Shape.** The Qwen3.8-27B linear-attention geometry: `num_heads_q = num_heads_k = 16`,
+`num_heads_v = 48`, `head_size_qk = head_size_v = 128`, float16 input. One operator call is
+all 48 value heads of **one** layer; the model has 48 such layers, so multiplying any figure
+below by 48 gives the cost across a whole forward pass.
+
+**Method.** `LinearAttention`, `VarlenLinearAttention` (PR #32166) and `GatedDeltaNet` are
+compiled into **one provider build** and timed in **one process** under IOBinding, so every
+tensor is device-resident and the timed region contains only `Run()`. Median of 30 after 10
+warmup iterations.
+
+**FLA is measured separately** in a PyTorch/Triton process (`torch 2.13.0+cu130`,
+`triton 3.7.1`, flash-linear-attention `3da0a0c6`) at the same shapes and the same
+median-of-30 protocol. It is *not* the same binary, so treat it as a reference point rather
+than an exactly controlled comparison. `fla_chunk` is `chunk_gated_delta_rule`;
+`fla_recurrent` is `fused_recurrent_gated_delta_rule`.
+
+### Prefill, batch 1 (us per call, lower is better)
+
+| T | LinearAttention | Varlen (#32166) | FLA chunk | **GatedDeltaNet** | vs LA | vs #32166 | vs FLA |
+|---:|---:|---:|---:|---:|---:|---:|---:|
+| 256 | 399.0 | 585.4 | 422.0 | **126.4** | 3.16x | 4.63x | 3.34x |
+| 1024 | 1841.1 | 2682.7 | 427.5 | **405.3** | 4.54x | 6.62x | 1.05x |
+| 2048 | 4012.4 | 5761.9 | **454.9** | 797.6 | 5.03x | 7.22x | 0.57x |
+| 8192 | 15942.8 | 22935.7 | **1014.3** | 3058.3 | 5.21x | 7.50x | 0.33x |
+
+`T = 1024` is the production operating point (the validated prefill chunk for this model), so
+**4.54x against the current operator and 6.62x against PR #32166** is the figure that matters
+for end-to-end prefill; the default chunk of 256 gives 3.16x / 4.63x.
+
+FLA is nearly flat in `T` because it parallelises across chunks in separate kernels, so it
+overtakes this single-launch design beyond about `T = 1024`. That trade is deliberate: the
+same multi-kernel structure gives FLA a **~375 us floor at batch 1** that makes it lose to
+every other implementation below `T = 256` and by an order of magnitude at decode.
+
+### Decode / MTP verify, batch 1 (us per call)
+
+| T | LinearAttention | Varlen (#32166) | FLA recurrent | **GatedDeltaNet** |
+|---:|---:|---:|---:|---:|
+| 1 | **18.3** | 21.9 | 83.1 | 18.5 |
+| 2 | 21.9 | 25.1 | 82.7 | **19.9** |
+| 4 | 23.0 | 31.1 | 81.9 | **22.7** |
+
+These end-to-end numbers include roughly 13 us of ORT `Run()` host overhead, which dominates
+at decode shapes and compresses the differences. Pure kernel time from Nsight Compute
+(`gpu__time_duration.sum`, p50) at `B = 1, T = 1`:
+
+| kernel | grid | time | DRAM traffic | state dtype |
+|---|---|---:|---:|---|
+| `LinearAttentionDecodeColSplitKernel<half,128,8>` | 192 | 5.40 us | 1.61 MB | float16 |
+| `VarlenLinearAttentionColKernel<half,128,1>` | 192 | 7.30 us | 1.63 MB | float16 |
+| **`GatedDeltaNetDecodeWarpKernel<half,128,8>`** | 768 | **5.82 us** | 3.18 MB | float32 |
+
+`GatedDeltaNet` reaches parity with the tuned `LinearAttention` decode kernel while moving
+**twice the bytes**, because its state is float32 by contract where the others are float16 —
+546 GB/s against 298 GB/s, about 1.8x the bandwidth efficiency per byte. Splitting by token
+count gives a fixed cost of about 4.46 us and a per-token cost of about 1.36 us
+(`T = 1` 5.82 us, `T = 4` 9.89 us), so the fixed state round-trip dominates decode.
+
+### Batch 4 (us per call)
+
+| T | LinearAttention | Varlen (#32166) | FLA chunk | **GatedDeltaNet** |
+|---:|---:|---:|---:|---:|
+| 256 | 2836.0 | 757.6 | 423.4 | **361.9** |
+| 1024 | 11152.1 | 2920.7 | **572.8** | 1217.2 |
+| 2048 | 22233.0 | 5814.3 | **955.1** | 2357.3 |
+| 8192 | 88749.7 | 23213.2 | **3348.8** | 9305.5 |
+
+`LinearAttention` degrades sharply with batch because `batch * num_heads_v` crosses its
+grid-size heuristic and it falls back to a slower recurrent kernel; `VarlenLinearAttention`
+removed that guard and is 3.7x faster there. `GatedDeltaNet` is a further 2.0x-2.5x faster
+than `VarlenLinearAttention` across these shapes.
+
+### Reproducing
+
+```bash
+# ORT three-way (same binary, same process)
+unset PYTHONPATH
+CUDA_VISIBLE_DEVICES=0 python bench_three_way.py
+
+# FLA reference
+PYTHONPATH=/path/to/flash-linear-attention CUDA_VISIBLE_DEVICES=0 python bench_fla.py
+
+# pure kernel time
+ncu -k regex:"GatedDeltaNetDecodeWarpKernel" --metrics gpu__time_duration.sum,dram__bytes.sum \
+    --csv python bench_three_way.py
+```
+
+## 8. Accuracy
+
+Maximum relative error of `output` / `final_state` against a float64 sequential reference at
+the shape above:
+
+| Implementation | output | state |
+|---|---|---|
+| `LinearAttention` (float16) | 4.5e-4 | 2.9e-4 |
+| FLA `fused_recurrent_gated_delta_rule` (float32) | 1.9e-7 | 3.0e-7 |
+| FLA `chunk_gated_delta_rule` (float32) | 2.0e-3 | 1.3e-3 |
+| **`GatedDeltaNet` (float16 io, float32 state)** | **8.7e-4** | **5.6e-4** |
+
+`VarlenLinearAttention` was not measured against this reference; it shares
+`LinearAttention`'s sequential recurrence, so its error is expected to be comparable.
+
+Verified at `T = 1, 4, 63, 64, 65, 130, 256` so both chunk boundaries and partial chunks are
+covered. The chunked engine is more accurate than FLA's chunked path, whose error is a TF32
+artefact of `tl.dot`, and is within a small factor of the sequential float16 operators
+despite replacing the recurrence with matrix algebra.
+
+Because the chunked algorithm reassociates the recurrence, its results are **not** bitwise
+identical to a sequential implementation. Any model-level change adopting this operator
+should be gated on a task-level quality evaluation rather than on output hashes.
+
+## 9. Environment Variables
+
+| Variable | Values | Description |
+|---|---|---|
+| `ORT_GDN_PLAN` | `chunked`, `recurrent`, `cudnn` | Pins an engine, bypassing the heuristic. The analogue of cuDNN's `select_plan(name)`. Intended for benchmarking and bisection. `cudnn` is reserved and returns an error. |
+
+## 10. Testing
+
+```bash
+./onnxruntime_provider_test --gtest_filter='GatedDeltaNet*'
+```
+
+Note that contrib op tests link into `onnxruntime_provider_test`, not
+`onnxruntime_test_all`. Coverage in
+[gated_delta_net_op_test.cc](../../../onnxruntime/test/contrib_ops/gated_delta_net_op_test.cc)
+includes all four update rules, inverse GQA and equal head counts, chunk boundaries and
+partial chunks, ragged and uniform packing, the fused activations, and the reduced
+shared-memory chunk configuration. Three cases are worth calling out:
+
+- **`Recurrent_CheckpointsMatchRepeatedSingleTokenDecode`** compares every checkpoint against
+  what repeated one-token invocations produce, rather than only against a float reference
+  under tolerance.
+- **`TwoCallContinuationMatchesSingleRun`** feeds one call's state output back as the next
+  call's input and requires it to reproduce a single long run.
+- **`MalformedCuSeqlensIsClamped`** drives negative, decreasing and oversized device offsets
+  and requires the run to remain memory-safe.
+- **`GatedDeltaNetPlanTest.PicksNarrowChunkOnConsumerBlackwellSharedMemory`** exercises the
+  plan heuristic at SM120's 101376-byte budget on the host, so the architecture-dependent
+  choice is covered without SM120 hardware.
+
+## 11. Known Limitations and Future Work
+
+- **Chunked engine coverage.** float16 input only, `head_size_qk == head_size_v == 128`, and
+  scalar decay. bfloat16 needs bf16 mma fragments; per-key-dimension decay (KDA) and other
+  head sizes fall back to the sequential engine.
+- **FLA overtakes beyond `T ~ 1024`.** The single-launch design trades long-sequence
+  throughput for a low fixed cost. Recovering it needs chunk-parallelism without FLA's
+  per-chunk state materialisation.
+- **Decode is bounded by the float32 state round-trip.** A float16 state would halve decode
+  state traffic. The type constraint already keeps the state dtype independent of `T`, so
+  this is a contract decision rather than a kernel rewrite — but float32 was chosen
+  deliberately for recurrence stability at chunk and request boundaries.
+- **cuDNN backend.** `Engine::kCudnn` is reserved and unimplemented. As of cudnn-frontend
+  v1.27.0 — the version this build pins, and the release that introduced GDN — the operation
+  exists **only** in the Python package (`python/cudnn/linear_attention/`); there are no GDN
+  symbols in the C++ headers, so the CUDA EP cannot call it. Its FROST engine is additionally
+  restricted to SM100-SM103, excluding both SM90 and SM120, and its cuTile fallback requires
+  the `cuda.tile` Python JIT and does not support state checkpoints. The seam is kept so the
+  decision can be revisited if a C++ entry point appears.
+- **Prefill chunk parallelism, `cp.async` staging of the next chunk's q/k/v, and merging the
+  `K K^T` and `Q K^T` GEMMs** are the ranked next steps for the chunked engine, which
+  profiling shows to be latency-bound rather than compute- or bandwidth-bound.

--- a/docs/contrib_ops/cuda/gdn.md
+++ b/docs/contrib_ops/cuda/gdn.md
@@ -179,6 +179,7 @@ execution binds a `VariantPack` of device pointers.
 | Engine | Used for | Shape |
 |---|---|---|
 | `chunked` | prefill | one CTA per `(sequence, v-head, v-block)`, 512 threads, state resident in shared memory for the whole walk, `mma.sync.m16n8k16` GEMMs |
+| `chunked_split` | prefill, where the fused grid underfills the device | a token-parallel prepare launch, one CTA per `(sequence, v-head, chunk)`, followed by a scan that carries only the state |
 | `recurrent` (warp-specialised) | decode / MTP verify | one **warp** per `(sequence, v-head, v-column)`, lanes spanning K |
 | `recurrent` (generic) | head geometries the warp kernel cannot take | one CTA per `(sequence, v-head)`, state in shared memory |
 | `cudnn` | reserved, not implemented | see §11 |
@@ -192,6 +193,36 @@ or newer, and enough shared memory.
 The **32-token threshold is measured, not assumed**: below roughly 30 tokens the chunked
 engine still pays for a full 64-token chunk, so a single token costs about what 64 do
 (46.5 us against 17.9 us for a sequential recurrence at the Qwen3.8 shape).
+
+### Choosing between the fused and split chunked engines
+
+The split engine exists to fill a machine the fused one leaves idle, so the choice is made
+on the fused engine's own **wave-quantisation efficiency** rather than on a shape guess.
+The fused grid is one CTA per `(sequence, v-head, 64 v-columns)`, so it occupies
+`waves = batch * num_heads_v * (head_size_v / 64) / sm_count` waves of a device but costs
+`ceil(waves)`. Measured on H200 (132 SMs) at the Qwen3.8 geometry, the split/fused runtime
+ratio tracks that efficiency and nothing else:
+
+| batch | fused CTAs | waves | efficiency | `T=256` | `T=1024` | `T=4096` |
+|---:|---:|---:|---:|---:|---:|---:|
+| 1 | 96 | 0.73 | 73% | 0.90 | **0.80** | 0.83 |
+| 2 | 192 | 1.45 | 73% | 0.80 | **0.88** | 0.88 |
+| 3 | 288 | 2.18 | 73% | 0.85 | **0.91** | 0.90 |
+| 4 | 384 | 2.91 | 97% | 0.94 | 1.12 | 1.13 |
+| 8 | 768 | 5.82 | 97% | 1.22 | 1.31 | 1.32 |
+
+The fused per-token cost jumps from 0.392 us to 0.298 us across that same boundary, so once
+the fused engine stops wasting a wave the split engine's extra launch and its round-trip
+through the workspace are pure overhead. `SelectPlan` therefore takes the split engine when
+efficiency is below 85% **and** the longest sequence is at least two chunks — at one chunk
+there is nothing to pipeline and the extra launch measures 1.18x. Both kernels must also fit
+the device's shared-memory opt-in limit, which excludes SM120.
+
+Because the split engine keeps its state in float16 where the fused engine uses float32, the
+two are **not** numerically identical, so this choice is deliberately a deterministic
+function of the descriptor rather than a runtime autotune: an autotuned choice would make a
+model's output depend on timing noise across processes. See §8 and §11 for the accuracy
+evidence behind allowing it by default.
 
 ### Why the decode engine is warp-specialised
 
@@ -384,7 +415,7 @@ should be gated on a task-level quality evaluation rather than on output hashes.
 
 | Variable | Values | Description |
 |---|---|---|
-| `ORT_GDN_PLAN` | `chunked`, `recurrent`, `cudnn` | Pins an engine, bypassing the heuristic. The analogue of cuDNN's `select_plan(name)`. Intended for benchmarking and bisection. `cudnn` is reserved and returns an error. |
+| `ORT_GDN_PLAN` | `chunked`, `chunked_split`, `recurrent`, `cudnn` | Pins an engine, bypassing the heuristic, in either direction: `chunked` keeps the fused engine where the heuristic would split, and `chunked_split` forces the split engine where it would not. The analogue of cuDNN's `select_plan(name)`. Intended for benchmarking and bisection. `cudnn` is reserved and returns an error. |
 
 ## 10. Testing
 
@@ -442,7 +473,8 @@ shared-memory chunk configuration. Three cases are worth calling out:
   per-CTA time is fixed and co-residency contributes nothing.
   Consequently the only way to speed this engine up is to **shorten the per-CTA critical
   path**. That is what `Engine::kChunkedSplit` does; see below.
-- **The split engine (`Engine::kChunkedSplit`) is 20% faster and is opt-in.** Pushing
+- **The split engine (`Engine::kChunkedSplit`) is 20% faster where the fused grid underfills
+  the device, and is selected automatically there.** Pushing
   `(I+M)^-1` through the subtraction gives `U = Uv - W S0` with `Uv = (I+M)^-1 (beta v)` and
   `W = (I+M)^-1 diag(beta e^gc) k`, so every state-independent term factorises out. A
   prepare kernel owns one `(sequence, v-head, chunk)` — 768 CTAs instead of 96 at `T=1024` —
@@ -486,8 +518,9 @@ shared-memory chunk configuration. Three cases are worth calling out:
   | MMLU-Pro | 800 | 83.38% | 84.38% | +1.00pp | 46 (19/27) | 0.30 |
 
   Long chain-of-thought is the sensitive probe for a prefill-only numerics change, so GPQA is
-  the one that matters here; neither moves. The engine nevertheless stays opt-in until it has
-  run in a release candidate.
+  the one that matters here; neither moves. That evidence is what allows the split engine to
+  be chosen automatically (§5) rather than only on request; `ORT_GDN_PLAN=chunked` pins the
+  float32-state engine for anyone who needs the older numerics.
 - **cuDNN backend.** `Engine::kCudnn` is reserved and unimplemented. As of cudnn-frontend
   v1.27.0 — the version this build pins, and the release that introduced GDN — the operation
   exists **only** in the Python package (`python/cudnn/linear_attention/`); there are no GDN

--- a/docs/contrib_ops/cuda/gdn.md
+++ b/docs/contrib_ops/cuda/gdn.md
@@ -421,7 +421,73 @@ shared-memory chunk configuration. Three cases are worth calling out:
 - **Decode is bounded by the float32 state round-trip.** A float16 state would halve decode
   state traffic. The type constraint already keeps the state dtype independent of `T`, so
   this is a contract decision rather than a kernel rewrite — but float32 was chosen
-  deliberately for recurrence stability at chunk and request boundaries.
+  deliberately for recurrence stability at chunk and request boundaries. Note that the
+  windowed MTP contract multiplies this by the window: at the Qwen3.8 shape one state slot
+  is 3.0 MiB per layer, so `state_checkpoints=4` across 48 layers is **576 MiB** of float32
+  state, and `num_speculative_tokens` is capped at `state_checkpoints - 1`, so every extra
+  draft token costs another 144 MiB. The companion `conv_state` is already float16.
+  Profiling the MTP loop (8192 context, 64 generated tokens, N=3) shows the machinery is
+  **not** a throughput cost — the checkpoint-writing decode kernel is 0.3% of GPU time and
+  the runtime's window-crop kernel 0.1%, against 34% spent in weight dequantization — so
+  the argument for a float16 state here is memory and draft-length headroom, not speed.
+- **The chunked engine is bound by its own serial chain, not by grid size.** Measured on
+  H200 at `T=8192`, batch 1 (`ncu`): grid 96 CTAs, **0.73 waves per SM**, 25.0% warp
+  occupancy, **7.1%** tensor-pipe utilisation, **1.8%** DRAM throughput. It is tempting to
+  read that as "too few CTAs", but widening the grid measurably loses: with a `v_block` of
+  32 (192 CTAs) the same work takes 657.6 us instead of 404.8 us at `T=1024`, and
+  `BT=32, v_block=32` (the configuration that maximises CTA residency) takes 793.0 us.
+  The reason is that 157 KB of shared memory pins the kernel to one CTA per SM, so extra
+  CTAs only add waves. Batch scaling confirms it: batch 4 at `T=1024` costs 1217.2 us,
+  which is exactly `ceil(384/132) = 3` waves times the 405 us single-wave time, so
+  per-CTA time is fixed and co-residency contributes nothing.
+  Consequently the only way to speed this engine up is to **shorten the per-CTA critical
+  path**. That is what `Engine::kChunkedSplit` does; see below.
+- **The split engine (`Engine::kChunkedSplit`) is 20% faster and is opt-in.** Pushing
+  `(I+M)^-1` through the subtraction gives `U = Uv - W S0` with `Uv = (I+M)^-1 (beta v)` and
+  `W = (I+M)^-1 diag(beta e^gc) k`, so every state-independent term factorises out. A
+  prepare kernel owns one `(sequence, v-head, chunk)` — 768 CTAs instead of 96 at `T=1024` —
+  and emits `W`, `Qg`, `Uv`, `P`, `Kd`; the scan kernel is then left with `U = Uv - W S`,
+  `o = scale (P U + Qg S)`, `S = decay S + Kd^T U`. Measured on H200 at batch 1: `T=1024`
+  406 us to **325 us**, `T=8192` 3069 us to **2579 us**. By `nsys` the scan is 200 us and
+  the prepare 110 us, so the scan **alone** is 2.0x faster than the whole fused kernel —
+  close to the 2.3x cut in serial FLOPs the split predicts. Three things fall out that the
+  fused engine could not have:
+  - Every one of the scan's GEMMs scales with `v_block`, so narrowing it now divides the
+    work instead of duplicating it. `v_block=32` measures 325 us against 341 us for 64, the
+    reverse of the fused engine's 1.6x loss.
+  - `W` and `Qg` are stored adjacently, so `W S` and `Qg S` are one `[2 BT x DVB]` GEMM
+    whose `Qg S` half stays live while `P U` overwrites the other, and the state update
+    accumulates straight into the float16 state instead of staging through float32 scratch.
+    Together those take the chunk body from seven barriers to four.
+  - The state is float16 rather than float32, which is what brings the scan under the
+    113 KB that lets two CTAs share an SM. The prepare kernel reaches the same limit by
+    aliasing the Neumann iterate onto `M`, worth 143 us to 110 us on its own.
+  Both kernels remain latency-bound (`ncu`: tensor 7.0% / 5.1%, DRAM 10.4% / 7.0%). What is
+  left in the prepare kernel is **not** worth chasing: short-circuiting the whole `(I+M)^-1`
+  construction saves only 28 us of its 110 us, and the 16x16 forward substitution inside it
+  — the part that occupies just 64 of 512 threads, and so looks like the obvious target —
+  accounts for 4.7 us, about 1.5% of the operator.
+- **float16, not bfloat16, for the on-chip state.** The operator's q/k/v/output are already
+  float16, `qk_l2_norm` bounds `|k| <= 1` and `beta = sigmoid(.) < 1`, so the state stays
+  around `O(10)` against float16's 65504 ceiling; entries that underflow are ones the decay
+  has already made irrelevant. float16 then carries three more mantissa bits than bfloat16
+  on what is an accumulator running the length of the sequence. The reference
+  implementations use bfloat16 only because their surrounding stacks are bfloat16-native.
+  Scored against a float64 reference at the Qwen3.8 geometry, the float16 state costs
+  **1.09x** the output relative RMS of the float32 state (5.5e-4 against 5.1e-4) and 1.22x
+  on the returned state, and the ratio does not move between `T=1024` and `T=4096`, so the
+  per-chunk rounding is not accumulating. Both figures sit at float16's own machine epsilon
+  of 4.9e-4, which is the floor imposed by storing the output as float16 at all. At model
+  level, running the same Qwen3.8-27B MTP model under both engines and pairing per question:
+
+  | task | n | float32 state | float16 state | delta | discordant | McNemar p |
+  |---|---:|---:|---:|---:|---|---:|
+  | GPQA | 198 | 81.31% | 82.32% | +1.01pp | 18 (8/10) | 0.81 |
+  | MMLU-Pro | 800 | 83.38% | 84.38% | +1.00pp | 46 (19/27) | 0.30 |
+
+  Long chain-of-thought is the sensitive probe for a prefill-only numerics change, so GPQA is
+  the one that matters here; neither moves. The engine nevertheless stays opt-in until it has
+  run in a release candidate.
 - **cuDNN backend.** `Engine::kCudnn` is reserved and unimplemented. As of cudnn-frontend
   v1.27.0 — the version this build pins, and the release that introduced GDN — the operation
   exists **only** in the Python package (`python/cudnn/linear_attention/`); there are no GDN

--- a/docs/contrib_ops/cuda/gdn.md
+++ b/docs/contrib_ops/cuda/gdn.md
@@ -58,7 +58,7 @@ Source:
 | `beta_activation` | string | `none` | `none` treats `beta` as the effective update rate; `sigmoid` applies a sigmoid. |
 | `qk_l2_norm` | int | `0` | When `1`, L2-normalizes each query and key head vector in-kernel. |
 | `chunk_size` | int | `64` | Chunk length for the chunked engine. `32` pins the reduced shared-memory configuration (see §6). |
-| `state_checkpoints` | int | `0` | Number of leading per-token state checkpoint slots `W`, in `[0, 8]`. `0` disables the `checkpoints` output. |
+| `state_checkpoints` | int | `0` | Number of trailing per-token state checkpoint slots `W`, in `[0, 8]`. `0` disables the `checkpoints` output. |
 
 ### Inputs
 
@@ -70,7 +70,7 @@ Source:
 | 3 | `cu_seqlens` | `(batch_size + 1)` | int32 | no |
 | 4 | `decay` | `(total_tokens, num_heads_v)` or `(total_tokens, num_heads_v, head_size_qk)` | float | no |
 | 5 | `beta` | `(total_tokens, num_heads_v)` | float | no |
-| 6 | `initial_state` | `(batch_size, num_heads_v, head_size_v, head_size_qk)` | float | no |
+| 6 | `initial_state` | `(batch_size, num_heads_v, head_size_v, head_size_qk)`, optionally with a leading `state_checkpoints` window | float | no |
 | 7 | `a_log` | `(num_heads_v)` | float | no |
 | 8 | `dt_bias` | `(num_heads_v)` or `(num_heads_v, head_size_qk)` | float | no |
 
@@ -115,10 +115,20 @@ the entire incoming state into registers or shared memory before writing any of 
 is ever cleared: slots the call does not write — in particular unused `checkpoints` slots —
 are left **unspecified**, never zeroed, because the buffer may alias live state.
 
-**Checkpoints.** Slot `j` receives the state after local token `j` of each request. This is
-the series a speculative decoder needs to roll back to a partially accepted draft, while
-`final_state` still holds the state after the last token. Only the sequential engine can
-produce it, so requesting checkpoints forces that engine.
+**Checkpoints are right-aligned.** Slot `W-1` holds the state after the *final* token, the same
+value as `final_state`, and slot `W-1-k` holds the state after the k-th token from the end.
+This is the series a speculative decoder rolls back to after a partially accepted draft, and
+right-alignment is what lets a draft shorter than `W` still land with its committed state in
+the last slot. Only the sequential engine produces the full series, so a request of at most
+`W` tokens takes that engine; a longer request is a prefill with nothing to roll back, so it
+keeps the chunked engine and fills only slot `W-1`.
+
+**Windowed state.** Because slot `W-1` is the committed state, `initial_state` may be given
+with the same leading window, `[W, batch_size, num_heads_v, head_size_v, head_size_qk]`: the
+operator reads the last slot and `final_state` can then be omitted entirely. One buffer is
+then both the past and the present state of a speculative decoding loop, and committing an
+accepted prefix is a single slot-to-slot copy in the serving runtime rather than a rollback
+forward. This is how the ONNX Runtime GenAI MTP loop drives the operator.
 
 ## 4. Recurrence and the Chunked Form
 
@@ -314,6 +324,22 @@ which operator the 48 linear-attention layers use (`onnxruntime-genai` model bui
 
 Greedy decoding agrees token for token (64/64) between the two models, with
 `max|delta logits| = 0.075` on the 248320-wide fp16 logit vector at the first decode step.
+
+### End to end with MTP speculative decoding (N=3, window 4)
+
+The same two models rebuilt with `recurrent_state_window=4`, so the operator's checkpoint
+window is the buffer the MTP loop crops on a partial accept. 128 generated tokens, prefill
+chunk 1024.
+
+| context | TTFT LinearAttention | TTFT GatedDeltaNet | MTP decode ms/token | acceptance |
+|---:|---:|---:|---|---|
+| 1024 | 2420.0 ms | 2389.4 ms | 52.23 -> 53.82 | 0.673 / 0.649 |
+| 8192 | 4406.0 ms | **4032.2 ms** (-8.5%) | 53.02 -> **47.56** (-10.3%) | 0.586 / 0.586 |
+
+At 8192 the two runs accept exactly the same drafts, so the decode figure is a like-for-like
+comparison; at 1024 the trajectories diverged on a near-tie, which moves acceptance and hence
+decode time. A 64-token greedy MTP run against the released model reproduces its output
+exactly, including the per-round accept/bonus/correction counts.
 
 ### Reproducing
 

--- a/docs/contrib_ops/cuda/gdn.md
+++ b/docs/contrib_ops/cuda/gdn.md
@@ -72,7 +72,7 @@ Source:
 | 5 | `beta` | `(total_tokens, num_heads_v)` | float | no |
 | 6 | `initial_state` | `(batch_size, num_heads_v, head_size_v, head_size_qk)`, optionally with a leading `state_checkpoints` window | float | no |
 | 7 | `a_log` | `(num_heads_v)` | float | no |
-| 8 | `dt_bias` | `(num_heads_v)` or `(num_heads_v, head_size_qk)` | float | no |
+| 8 | `dt_bias` | `(num_heads_v)` | float | no |
 
 ### Outputs
 
@@ -415,7 +415,7 @@ should be gated on a task-level quality evaluation rather than on output hashes.
 
 | Variable | Values | Description |
 |---|---|---|
-| `ORT_GDN_PLAN` | `chunked`, `chunked_split`, `recurrent`, `cudnn` | Pins an engine, bypassing the heuristic, in either direction: `chunked` keeps the fused engine where the heuristic would split, and `chunked_split` forces the split engine where it would not. The analogue of cuDNN's `select_plan(name)`. Intended for benchmarking and bisection. `cudnn` is reserved and returns an error. |
+| `ORT_GDN_PLAN` | `chunked`, `chunked_split`, `recurrent`, `cudnn` | Pins an engine, bypassing the heuristic, in either direction: `chunked` keeps the fused engine where the heuristic would split, and `chunked_split` forces the split engine where it would not. Either chunked override reports an error when the descriptor cannot use that engine. The analogue of cuDNN's `select_plan(name)`. Intended for benchmarking and bisection. `cudnn` is reserved and returns an error. |
 
 ## 10. Testing
 

--- a/onnxruntime/contrib_ops/cuda/bert/gated_delta_net.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/gated_delta_net.cc
@@ -1,0 +1,255 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "contrib_ops/cuda/bert/gated_delta_net.h"
+#include "contrib_ops/cuda/bert/gated_delta_net_impl.h"
+#include "core/providers/cuda/cuda_common.h"
+#include "core/providers/cuda/cuda_type_conversion.h"
+#include "core/platform/env_var_utils.h"
+
+#include <limits>
+
+namespace onnxruntime {
+namespace contrib {
+namespace cuda {
+
+using namespace onnxruntime::cuda;
+namespace gdn = gated_delta_net;
+
+#define REGISTER_KERNEL_TYPED(T)                                  \
+  ONNX_OPERATOR_TYPED_KERNEL_EX(                                  \
+      GatedDeltaNet,                                              \
+      kMSDomain,                                                  \
+      1,                                                          \
+      T,                                                          \
+      kCudaExecutionProvider,                                     \
+      (*KernelDefBuilder::Create())                               \
+          .TypeConstraint("T", DataTypeImpl::GetTensorType<T>())  \
+          .TypeConstraint("TS", DataTypeImpl::GetTensorType<float>()) \
+          .TypeConstraint("TI", DataTypeImpl::GetTensorType<int32_t>()), \
+      GatedDeltaNet<T>);
+
+REGISTER_KERNEL_TYPED(float)
+REGISTER_KERNEL_TYPED(MLFloat16)
+
+template <typename T>
+GatedDeltaNet<T>::GatedDeltaNet(const OpKernelInfo& info) : CudaKernel(info) {
+  const std::string rule = info.GetAttrOrDefault<std::string>("update_rule", "gated_delta");
+  if (rule == "linear") {
+    update_rule_ = gdn::UpdateRule::kLinear;
+  } else if (rule == "gated") {
+    update_rule_ = gdn::UpdateRule::kGated;
+  } else if (rule == "delta") {
+    update_rule_ = gdn::UpdateRule::kDelta;
+  } else if (rule == "gated_delta") {
+    update_rule_ = gdn::UpdateRule::kGatedDelta;
+  } else {
+    ORT_THROW("update_rule must be one of: linear, gated, delta, gated_delta");
+  }
+
+  const std::string gate = info.GetAttrOrDefault<std::string>("gate_activation", "none");
+  if (gate == "none") {
+    gate_activation_ = gdn::GateActivation::kNone;
+  } else if (gate == "qwen") {
+    gate_activation_ = gdn::GateActivation::kQwen;
+  } else {
+    ORT_THROW("gate_activation must be one of: none, qwen");
+  }
+
+  const std::string beta = info.GetAttrOrDefault<std::string>("beta_activation", "none");
+  if (beta == "none") {
+    beta_activation_ = gdn::BetaActivation::kNone;
+  } else if (beta == "sigmoid") {
+    beta_activation_ = gdn::BetaActivation::kSigmoid;
+  } else {
+    ORT_THROW("beta_activation must be one of: none, sigmoid");
+  }
+
+  scale_ = info.GetAttrOrDefault<float>("scale", 0.0f);
+  chunk_size_ = static_cast<int>(info.GetAttrOrDefault<int64_t>("chunk_size", 64));
+  state_checkpoints_ = static_cast<int>(info.GetAttrOrDefault<int64_t>("state_checkpoints", 0));
+  ORT_ENFORCE(state_checkpoints_ >= 0 && state_checkpoints_ <= 8,
+              "state_checkpoints must be in [0, 8], got ", state_checkpoints_);
+  qk_l2_norm_ = info.GetAttrOrDefault<int64_t>("qk_l2_norm", 0) != 0;
+
+  forced_engine_ = gdn::EngineFromName(
+      ParseEnvironmentVariableWithDefault<std::string>("ORT_GDN_PLAN", ""));
+}
+
+template <typename T>
+Status GatedDeltaNet<T>::ComputeInternal(OpKernelContext* context) const {
+  typedef typename ToCudaType<T>::MappedType CudaT;
+
+  const Tensor* query = context->Input<Tensor>(0);
+  const Tensor* key = context->Input<Tensor>(1);
+  const Tensor* value = context->Input<Tensor>(2);
+  const Tensor* cu_seqlens = context->Input<Tensor>(3);
+  const Tensor* decay = context->Input<Tensor>(4);
+  const Tensor* beta = context->Input<Tensor>(5);
+  const Tensor* initial_state = context->Input<Tensor>(6);
+  const Tensor* a_log = context->Input<Tensor>(7);
+  const Tensor* dt_bias = context->Input<Tensor>(8);
+
+  ORT_RETURN_IF_NOT(query != nullptr && key != nullptr && value != nullptr,
+                    "query, key and value are required");
+
+  const auto& q_shape = query->Shape();
+  const auto& k_shape = key->Shape();
+  const auto& v_shape = value->Shape();
+  ORT_RETURN_IF_NOT(q_shape.NumDimensions() == 3 && k_shape.NumDimensions() == 3 &&
+                        v_shape.NumDimensions() == 3,
+                    "query, key and value must be rank 3: [total_tokens, num_heads, head_size]");
+
+  const int64_t total_tokens = q_shape[0];
+  ORT_RETURN_IF_NOT(k_shape[0] == total_tokens && v_shape[0] == total_tokens,
+                    "query, key and value must agree on total_tokens");
+  ORT_RETURN_IF_NOT(total_tokens > 0, "total_tokens must be positive");
+
+  // Head counts are derived from the rank-3 shapes; there are no head-count attributes.
+  const int num_heads_q = static_cast<int>(q_shape[1]);
+  const int num_heads_k = static_cast<int>(k_shape[1]);
+  const int num_heads_v = static_cast<int>(v_shape[1]);
+  const int head_size_qk = static_cast<int>(q_shape[2]);
+  const int head_size_v = static_cast<int>(v_shape[2]);
+
+  ORT_RETURN_IF_NOT(k_shape[2] == head_size_qk, "key head_size must equal query head_size");
+  ORT_RETURN_IF_NOT(num_heads_q == num_heads_k,
+                    "num_heads_q (", num_heads_q, ") must equal num_heads_k (", num_heads_k, ")");
+  ORT_RETURN_IF_NOT(num_heads_v > 0 && num_heads_q > 0 && num_heads_v % num_heads_q == 0,
+                    "num_heads_v (", num_heads_v, ") must be a positive multiple of num_heads_q (",
+                    num_heads_q, ")");
+
+  int batch = 1;
+  if (cu_seqlens != nullptr) {
+    ORT_RETURN_IF_NOT(cu_seqlens->Shape().NumDimensions() == 1 && cu_seqlens->Shape()[0] >= 2,
+                      "cu_seqlens must be rank 1 with at least 2 elements");
+    batch = static_cast<int>(cu_seqlens->Shape()[0] - 1);
+  } else {
+    // Uniform packing. The batch size comes from the state, which GenAI always binds.
+    ORT_RETURN_IF_NOT(initial_state != nullptr,
+                      "cu_seqlens is absent, so initial_state is required to determine batch size");
+    ORT_RETURN_IF_NOT(initial_state->Shape().NumDimensions() == 4,
+                      "initial_state must be rank 4: [batch, num_heads_v, head_size_v, head_size_qk]");
+    batch = static_cast<int>(initial_state->Shape()[0]);
+    ORT_RETURN_IF_NOT(batch > 0 && total_tokens % batch == 0,
+                      "total_tokens (", total_tokens, ") must be divisible by batch (", batch, ")");
+  }
+
+  if (initial_state != nullptr) {
+    const auto& s = initial_state->Shape();
+    ORT_RETURN_IF_NOT(s.NumDimensions() == 4 && s[0] == batch && s[1] == num_heads_v &&
+                          s[2] == head_size_v && s[3] == head_size_qk,
+                      "initial_state must be [batch, num_heads_v, head_size_v, head_size_qk] "
+                      "(V-major)");
+  }
+
+  const bool decay_per_key_dim = decay != nullptr && decay->Shape().NumDimensions() == 3;
+  if (decay != nullptr) {
+    const auto& d = decay->Shape();
+    ORT_RETURN_IF_NOT(d[0] == total_tokens && d[1] == num_heads_v,
+                      "decay must be [total_tokens, num_heads_v] or "
+                      "[total_tokens, num_heads_v, head_size_qk]");
+    if (decay_per_key_dim) {
+      ORT_RETURN_IF_NOT(d[2] == head_size_qk, "per-key-dim decay last axis must be head_size_qk");
+    }
+  }
+  if (beta != nullptr) {
+    const auto& b = beta->Shape();
+    ORT_RETURN_IF_NOT(b.NumDimensions() == 2 && b[0] == total_tokens && b[1] == num_heads_v,
+                      "beta must be [total_tokens, num_heads_v]");
+  }
+  if (gate_activation_ == gdn::GateActivation::kQwen) {
+    ORT_RETURN_IF_NOT(a_log != nullptr && dt_bias != nullptr,
+                      "gate_activation=qwen requires a_log and dt_bias");
+    ORT_RETURN_IF_NOT(a_log->Shape().NumDimensions() == 1 && a_log->Shape()[0] == num_heads_v,
+                      "a_log must be [num_heads_v]");
+  } else {
+    ORT_RETURN_IF_NOT(a_log == nullptr && dt_bias == nullptr,
+                      "a_log and dt_bias require gate_activation=qwen");
+  }
+
+  const int out_heads = std::max(num_heads_q, num_heads_v);
+  TensorShape out_shape{total_tokens, out_heads, head_size_v};
+  Tensor* output = context->Output(0, out_shape);
+
+  TensorShape state_shape{batch, num_heads_v, head_size_v, head_size_qk};
+  Tensor* final_state = context->Output(1, state_shape);
+
+  Tensor* checkpoints = nullptr;
+  if (state_checkpoints_ > 0) {
+    TensorShape ckpt_shape{state_checkpoints_, batch, num_heads_v, head_size_v, head_size_qk};
+    checkpoints = context->Output(2, ckpt_shape);
+  }
+
+  gdn::Descriptor desc{};
+  desc.total_tokens = total_tokens;
+  desc.batch = batch;
+  desc.num_heads_q = num_heads_q;
+  desc.num_heads_k = num_heads_k;
+  desc.num_heads_v = num_heads_v;
+  desc.head_size_qk = head_size_qk;
+  desc.head_size_v = head_size_v;
+  desc.chunk_size = chunk_size_;
+  desc.state_checkpoints = state_checkpoints_;
+  desc.update_rule = update_rule_;
+  desc.gate_activation = gate_activation_;
+  desc.beta_activation = beta_activation_;
+  desc.io_type = std::is_same<T, MLFloat16>::value ? gdn::IoType::kFloat16 : gdn::IoType::kFloat;
+  desc.qk_l2_norm = qk_l2_norm_;
+  desc.decay_per_key_dim = decay_per_key_dim;
+  desc.has_decay = decay != nullptr;
+  desc.has_beta = beta != nullptr;
+  desc.has_initial_state = initial_state != nullptr;
+  desc.ragged = cu_seqlens != nullptr;
+
+  const cudaDeviceProp& prop = GetDeviceProp();
+  desc.sm_major = prop.major;
+  desc.sm_minor = prop.minor;
+
+  gdn::Plan plan = gdn::PlanCache::Instance().GetOrCreate(desc, prop.multiProcessorCount,
+                                                          prop.sharedMemPerBlockOptin);
+  if (forced_engine_ != gdn::Engine::kAuto) {
+    // Benchmarking override, the analogue of cudnn's select_plan(name).
+    gdn::Descriptor forced = desc;
+    plan = gdn::SelectPlan(forced, prop.multiProcessorCount, prop.sharedMemPerBlockOptin);
+    if (forced_engine_ == gdn::Engine::kRecurrent) {
+      plan.engine = gdn::Engine::kRecurrent;
+    }
+  }
+  ORT_RETURN_IF_NOT(plan.supported, "GatedDeltaNet: no supported plan (",
+                    plan.reject_reason ? plan.reject_reason : "unknown", ")");
+  ORT_RETURN_IF_NOT(plan.engine != gdn::Engine::kCudnn,
+                    "GatedDeltaNet: the cuDNN engine is reserved and not implemented");
+
+  if (plan.engine == gdn::Engine::kRecurrent && !plan.warp_specialized) {
+    const size_t smem = sizeof(float) * (static_cast<size_t>(head_size_qk) * head_size_v +
+                                         2 * head_size_qk + head_size_v + head_size_qk);
+    ORT_RETURN_IF_NOT(smem <= prop.sharedMemPerBlockOptin,
+                      "GatedDeltaNet: the recurrent engine needs ", smem,
+                      " bytes of shared memory but the device allows ",
+                      prop.sharedMemPerBlockOptin);
+  }
+
+  gdn::VariantPack<CudaT> pack{};
+  pack.query = reinterpret_cast<const CudaT*>(query->Data<T>());
+  pack.key = reinterpret_cast<const CudaT*>(key->Data<T>());
+  pack.value = reinterpret_cast<const CudaT*>(value->Data<T>());
+  pack.cu_seqlens = cu_seqlens != nullptr ? cu_seqlens->Data<int32_t>() : nullptr;
+  pack.decay = decay != nullptr ? decay->Data<float>() : nullptr;
+  pack.beta = beta != nullptr ? beta->Data<float>() : nullptr;
+  pack.initial_state = initial_state != nullptr ? initial_state->Data<float>() : nullptr;
+  pack.a_log = a_log != nullptr ? a_log->Data<float>() : nullptr;
+  pack.dt_bias = dt_bias != nullptr ? dt_bias->Data<float>() : nullptr;
+  pack.output = reinterpret_cast<CudaT*>(output->MutableData<T>());
+  pack.final_state = final_state != nullptr ? final_state->MutableData<float>() : nullptr;
+  pack.checkpoints = checkpoints != nullptr ? checkpoints->MutableData<float>() : nullptr;
+
+  const float scale = scale_ != 0.0f ? scale_ : 1.0f / std::sqrt(static_cast<float>(head_size_qk));
+
+  return gdn::LaunchGatedDeltaNet<CudaT>(desc, plan, pack, scale, prop.maxThreadsPerBlock,
+                                         Stream(context));
+}
+
+}  // namespace cuda
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cuda/bert/gated_delta_net.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/gated_delta_net.cc
@@ -127,6 +127,19 @@ Status GatedDeltaNet<T>::ComputeInternal(OpKernelContext* context) const {
                     "num_heads_v (", num_heads_v, ") must be a positive multiple of num_heads_q (",
                     num_heads_q, ")");
 
+  // A rank-5 state carries a leading checkpoint window; the committed state is its last slot.
+  int state_window = 1;
+  if (initial_state != nullptr) {
+    const size_t r = initial_state->Shape().NumDimensions();
+    ORT_RETURN_IF_NOT(r == 4 || r == 5,
+                      "initial_state must be rank 4 [batch, num_heads_v, head_size_v, "
+                      "head_size_qk] or rank 5 with a leading checkpoint window");
+    if (r == 5) state_window = static_cast<int>(initial_state->Shape()[0]);
+    ORT_RETURN_IF_NOT(state_window == 1 || state_window == state_checkpoints_,
+                      "a windowed initial_state must have the same window as state_checkpoints (",
+                      state_checkpoints_, "), got ", state_window);
+  }
+
   int batch = 1;
   if (cu_seqlens != nullptr) {
     ORT_RETURN_IF_NOT(qkv_rank == 3,
@@ -140,19 +153,18 @@ Status GatedDeltaNet<T>::ComputeInternal(OpKernelContext* context) const {
     // Uniform packing. The batch size comes from the state, which GenAI always binds.
     ORT_RETURN_IF_NOT(initial_state != nullptr,
                       "cu_seqlens is absent, so initial_state is required to determine batch size");
-    ORT_RETURN_IF_NOT(initial_state->Shape().NumDimensions() == 4,
-                      "initial_state must be rank 4: [batch, num_heads_v, head_size_v, head_size_qk]");
-    batch = static_cast<int>(initial_state->Shape()[0]);
+    batch = static_cast<int>(initial_state->Shape()[initial_state->Shape().NumDimensions() - 4]);
     ORT_RETURN_IF_NOT(batch > 0 && total_tokens % batch == 0,
                       "total_tokens (", total_tokens, ") must be divisible by batch (", batch, ")");
   }
 
   if (initial_state != nullptr) {
     const auto& s = initial_state->Shape();
-    ORT_RETURN_IF_NOT(s.NumDimensions() == 4 && s[0] == batch && s[1] == num_heads_v &&
-                          s[2] == head_size_v && s[3] == head_size_qk,
+    const size_t o = s.NumDimensions() - 4;
+    ORT_RETURN_IF_NOT(s[o] == batch && s[o + 1] == num_heads_v && s[o + 2] == head_size_v &&
+                          s[o + 3] == head_size_qk,
                       "initial_state must be [batch, num_heads_v, head_size_v, head_size_qk] "
-                      "(V-major)");
+                      "(V-major), optionally with a leading checkpoint window");
   }
 
   // decay and beta carry the same leading token axes as query/key/value; a trailing
@@ -260,12 +272,21 @@ Status GatedDeltaNet<T>::ComputeInternal(OpKernelContext* context) const {
   pack.cu_seqlens = cu_seqlens != nullptr ? cu_seqlens->Data<int32_t>() : nullptr;
   pack.decay = decay != nullptr ? decay->Data<float>() : nullptr;
   pack.beta = beta != nullptr ? beta->Data<float>() : nullptr;
-  pack.initial_state = initial_state != nullptr ? initial_state->Data<float>() : nullptr;
+  const int64_t state_elems =
+      static_cast<int64_t>(batch) * num_heads_v * head_size_v * head_size_qk;
+  pack.initial_state = initial_state != nullptr
+                           ? initial_state->Data<float>() + (state_window - 1) * state_elems
+                           : nullptr;
   pack.a_log = a_log != nullptr ? a_log->Data<float>() : nullptr;
   pack.dt_bias = dt_bias != nullptr ? dt_bias->Data<float>() : nullptr;
   pack.output = reinterpret_cast<CudaT*>(output->MutableData<T>());
   pack.final_state = final_state != nullptr ? final_state->MutableData<float>() : nullptr;
   pack.checkpoints = checkpoints != nullptr ? checkpoints->MutableData<float>() : nullptr;
+  if (pack.final_state == nullptr && pack.checkpoints != nullptr) {
+    // The last checkpoint slot is the committed state, so every engine reaches it through
+    // final_state even when the caller only asked for the window.
+    pack.final_state = pack.checkpoints + (state_checkpoints_ - 1) * state_elems;
+  }
 
   const float scale = scale_ != 0.0f ? scale_ : 1.0f / std::sqrt(static_cast<float>(head_size_qk));
 

--- a/onnxruntime/contrib_ops/cuda/bert/gated_delta_net.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/gated_delta_net.cc
@@ -196,6 +196,9 @@ Status GatedDeltaNet<T>::ComputeInternal(OpKernelContext* context) const {
                       "gate_activation=qwen requires a_log and dt_bias");
     ORT_RETURN_IF_NOT(a_log->Shape().NumDimensions() == 1 && a_log->Shape()[0] == num_heads_v,
                       "a_log must be [num_heads_v]");
+    ORT_RETURN_IF_NOT(dt_bias->Shape().NumDimensions() == 1 &&
+                          dt_bias->Shape()[0] == num_heads_v,
+                      "dt_bias must be [num_heads_v]");
   } else {
     ORT_RETURN_IF_NOT(a_log == nullptr && dt_bias == nullptr,
                       "a_log and dt_bias require gate_activation=qwen");
@@ -244,10 +247,16 @@ Status GatedDeltaNet<T>::ComputeInternal(OpKernelContext* context) const {
 
   gdn::Plan plan = gdn::PlanCache::Instance().GetOrCreate(desc, prop.multiProcessorCount,
                                                           prop.sharedMemPerBlockOptin);
-  if (forced_engine_ == gdn::Engine::kRecurrent) {
-    // Benchmarking override, the analogue of cudnn's select_plan(name). The chunked engines
-    // are reachable through the descriptor; forcing the sequential one only needs the swap.
+  if (forced_engine_ == gdn::Engine::kChunked ||
+      forced_engine_ == gdn::Engine::kChunkedSplit) {
+    ORT_RETURN_IF_NOT(
+        plan.engine == forced_engine_,
+        "GatedDeltaNet: the ", gdn::EngineName(forced_engine_),
+        " engine cannot serve this descriptor");
+  } else if (forced_engine_ == gdn::Engine::kRecurrent) {
     plan.engine = gdn::Engine::kRecurrent;
+  } else if (forced_engine_ == gdn::Engine::kCudnn) {
+    plan.engine = gdn::Engine::kCudnn;
   }
   ORT_RETURN_IF_NOT(plan.supported, "GatedDeltaNet: no supported plan (",
                     plan.reject_reason ? plan.reject_reason : "unknown", ")");
@@ -294,8 +303,9 @@ Status GatedDeltaNet<T>::ComputeInternal(OpKernelContext* context) const {
     pack.workspace = workspace.get();
   }
 
-  return gdn::LaunchGatedDeltaNet<CudaT>(desc, plan, pack, scale, prop.maxThreadsPerBlock,
-                                         Stream(context));
+  return gdn::LaunchGatedDeltaNet<CudaT>(
+      desc, plan, pack, scale, prop.maxThreadsPerBlock,
+      static_cast<size_t>(prop.sharedMemPerBlockOptin), Stream(context));
 }
 
 }  // namespace cuda

--- a/onnxruntime/contrib_ops/cuda/bert/gated_delta_net.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/gated_delta_net.cc
@@ -236,6 +236,7 @@ Status GatedDeltaNet<T>::ComputeInternal(OpKernelContext* context) const {
   desc.has_beta = beta != nullptr;
   desc.has_initial_state = initial_state != nullptr;
   desc.ragged = cu_seqlens != nullptr;
+  desc.preferred_engine = forced_engine_;
 
   const cudaDeviceProp& prop = GetDeviceProp();
   desc.sm_major = prop.major;
@@ -243,13 +244,10 @@ Status GatedDeltaNet<T>::ComputeInternal(OpKernelContext* context) const {
 
   gdn::Plan plan = gdn::PlanCache::Instance().GetOrCreate(desc, prop.multiProcessorCount,
                                                           prop.sharedMemPerBlockOptin);
-  if (forced_engine_ != gdn::Engine::kAuto) {
-    // Benchmarking override, the analogue of cudnn's select_plan(name).
-    gdn::Descriptor forced = desc;
-    plan = gdn::SelectPlan(forced, prop.multiProcessorCount, prop.sharedMemPerBlockOptin);
-    if (forced_engine_ == gdn::Engine::kRecurrent) {
-      plan.engine = gdn::Engine::kRecurrent;
-    }
+  if (forced_engine_ == gdn::Engine::kRecurrent) {
+    // Benchmarking override, the analogue of cudnn's select_plan(name). The chunked engines
+    // are reachable through the descriptor; forcing the sequential one only needs the swap.
+    plan.engine = gdn::Engine::kRecurrent;
   }
   ORT_RETURN_IF_NOT(plan.supported, "GatedDeltaNet: no supported plan (",
                     plan.reject_reason ? plan.reject_reason : "unknown", ")");
@@ -289,6 +287,12 @@ Status GatedDeltaNet<T>::ComputeInternal(OpKernelContext* context) const {
   }
 
   const float scale = scale_ != 0.0f ? scale_ : 1.0f / std::sqrt(static_cast<float>(head_size_qk));
+
+  IAllocatorUniquePtr<uint8_t> workspace;
+  if (plan.workspace_bytes > 0) {
+    workspace = GetScratchBuffer<uint8_t>(plan.workspace_bytes, context->GetComputeStream());
+    pack.workspace = workspace.get();
+  }
 
   return gdn::LaunchGatedDeltaNet<CudaT>(desc, plan, pack, scale, prop.maxThreadsPerBlock,
                                          Stream(context));

--- a/onnxruntime/contrib_ops/cuda/bert/gated_delta_net.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/gated_delta_net.cc
@@ -26,7 +26,8 @@ namespace gdn = gated_delta_net;
       (*KernelDefBuilder::Create())                                      \
           .TypeConstraint("T", DataTypeImpl::GetTensorType<T>())         \
           .TypeConstraint("TS", DataTypeImpl::GetTensorType<float>())    \
-          .TypeConstraint("TI", DataTypeImpl::GetTensorType<int32_t>()), \
+          .TypeConstraint("TI", DataTypeImpl::GetTensorType<int32_t>())  \
+          .MayInplace(6, 1),                                             \
       GatedDeltaNet<T>);
 
 REGISTER_KERNEL_TYPED(float)
@@ -89,6 +90,17 @@ Status GatedDeltaNet<T>::ComputeInternal(OpKernelContext* context) const {
   const Tensor* initial_state = context->Input<Tensor>(6);
   const Tensor* a_log = context->Input<Tensor>(7);
   const Tensor* dt_bias = context->Input<Tensor>(8);
+
+  const bool needs_decay =
+      update_rule_ == gdn::UpdateRule::kGated ||
+      update_rule_ == gdn::UpdateRule::kGatedDelta;
+  const bool needs_beta =
+      update_rule_ == gdn::UpdateRule::kDelta ||
+      update_rule_ == gdn::UpdateRule::kGatedDelta;
+  ORT_RETURN_IF_NOT(needs_decay == (decay != nullptr),
+                    "decay input presence must match update_rule");
+  ORT_RETURN_IF_NOT(needs_beta == (beta != nullptr),
+                    "beta input presence must match update_rule");
 
   ORT_RETURN_IF_NOT(query != nullptr && key != nullptr && value != nullptr,
                     "query, key and value are required");

--- a/onnxruntime/contrib_ops/cuda/bert/gated_delta_net.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/gated_delta_net.cc
@@ -16,16 +16,16 @@ namespace cuda {
 using namespace onnxruntime::cuda;
 namespace gdn = gated_delta_net;
 
-#define REGISTER_KERNEL_TYPED(T)                                  \
-  ONNX_OPERATOR_TYPED_KERNEL_EX(                                  \
-      GatedDeltaNet,                                              \
-      kMSDomain,                                                  \
-      1,                                                          \
-      T,                                                          \
-      kCudaExecutionProvider,                                     \
-      (*KernelDefBuilder::Create())                               \
-          .TypeConstraint("T", DataTypeImpl::GetTensorType<T>())  \
-          .TypeConstraint("TS", DataTypeImpl::GetTensorType<float>()) \
+#define REGISTER_KERNEL_TYPED(T)                                         \
+  ONNX_OPERATOR_TYPED_KERNEL_EX(                                         \
+      GatedDeltaNet,                                                     \
+      kMSDomain,                                                         \
+      1,                                                                 \
+      T,                                                                 \
+      kCudaExecutionProvider,                                            \
+      (*KernelDefBuilder::Create())                                      \
+          .TypeConstraint("T", DataTypeImpl::GetTensorType<T>())         \
+          .TypeConstraint("TS", DataTypeImpl::GetTensorType<float>())    \
           .TypeConstraint("TI", DataTypeImpl::GetTensorType<int32_t>()), \
       GatedDeltaNet<T>);
 

--- a/onnxruntime/contrib_ops/cuda/bert/gated_delta_net.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/gated_delta_net.cc
@@ -16,18 +16,18 @@ namespace cuda {
 using namespace onnxruntime::cuda;
 namespace gdn = gated_delta_net;
 
-#define REGISTER_KERNEL_TYPED(T)                                         \
-  ONNX_OPERATOR_TYPED_KERNEL_EX(                                         \
-      GatedDeltaNet,                                                     \
-      kMSDomain,                                                         \
-      1,                                                                 \
-      T,                                                                 \
-      kCudaExecutionProvider,                                            \
-      (*KernelDefBuilder::Create())                                      \
-          .TypeConstraint("T", DataTypeImpl::GetTensorType<T>())         \
-          .TypeConstraint("TS", DataTypeImpl::GetTensorType<float>())    \
-          .TypeConstraint("TI", DataTypeImpl::GetTensorType<int32_t>())  \
-          .MayInplace(6, 1),                                             \
+#define REGISTER_KERNEL_TYPED(T)                                        \
+  ONNX_OPERATOR_TYPED_KERNEL_EX(                                        \
+      GatedDeltaNet,                                                    \
+      kMSDomain,                                                        \
+      1,                                                                \
+      T,                                                                \
+      kCudaExecutionProvider,                                           \
+      (*KernelDefBuilder::Create())                                     \
+          .TypeConstraint("T", DataTypeImpl::GetTensorType<T>())        \
+          .TypeConstraint("TS", DataTypeImpl::GetTensorType<float>())   \
+          .TypeConstraint("TI", DataTypeImpl::GetTensorType<int32_t>()) \
+          .MayInplace(6, 1),                                            \
       GatedDeltaNet<T>);
 
 REGISTER_KERNEL_TYPED(float)

--- a/onnxruntime/contrib_ops/cuda/bert/gated_delta_net.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/gated_delta_net.cc
@@ -96,23 +96,31 @@ Status GatedDeltaNet<T>::ComputeInternal(OpKernelContext* context) const {
   const auto& q_shape = query->Shape();
   const auto& k_shape = key->Shape();
   const auto& v_shape = value->Shape();
-  ORT_RETURN_IF_NOT(q_shape.NumDimensions() == 3 && k_shape.NumDimensions() == 3 &&
-                        v_shape.NumDimensions() == 3,
-                    "query, key and value must be rank 3: [total_tokens, num_heads, head_size]");
+  const size_t qkv_rank = q_shape.NumDimensions();
+  ORT_RETURN_IF_NOT(qkv_rank == 3 || qkv_rank == 4,
+                    "query, key and value must be rank 3 [total_tokens, num_heads, head_size] or "
+                    "rank 4 [batch, sequence, num_heads, head_size]");
+  ORT_RETURN_IF_NOT(k_shape.NumDimensions() == qkv_rank && v_shape.NumDimensions() == qkv_rank,
+                    "query, key and value must have the same rank");
 
-  const int64_t total_tokens = q_shape[0];
-  ORT_RETURN_IF_NOT(k_shape[0] == total_tokens && v_shape[0] == total_tokens,
+  // Leading token axes: one when packed, two when the batch and sequence axes are explicit.
+  // Both spellings have the identical token-major memory layout, so only the shapes differ.
+  const size_t token_dims = qkv_rank - 2;
+  const int64_t total_tokens = q_shape.SizeToDimension(token_dims);
+  ORT_RETURN_IF_NOT(k_shape.SizeToDimension(token_dims) == total_tokens &&
+                        v_shape.SizeToDimension(token_dims) == total_tokens,
                     "query, key and value must agree on total_tokens");
   ORT_RETURN_IF_NOT(total_tokens > 0, "total_tokens must be positive");
 
-  // Head counts are derived from the rank-3 shapes; there are no head-count attributes.
-  const int num_heads_q = static_cast<int>(q_shape[1]);
-  const int num_heads_k = static_cast<int>(k_shape[1]);
-  const int num_heads_v = static_cast<int>(v_shape[1]);
-  const int head_size_qk = static_cast<int>(q_shape[2]);
-  const int head_size_v = static_cast<int>(v_shape[2]);
+  // Head counts are derived from the shapes; there are no head-count attributes.
+  const int num_heads_q = static_cast<int>(q_shape[token_dims]);
+  const int num_heads_k = static_cast<int>(k_shape[token_dims]);
+  const int num_heads_v = static_cast<int>(v_shape[token_dims]);
+  const int head_size_qk = static_cast<int>(q_shape[token_dims + 1]);
+  const int head_size_v = static_cast<int>(v_shape[token_dims + 1]);
 
-  ORT_RETURN_IF_NOT(k_shape[2] == head_size_qk, "key head_size must equal query head_size");
+  ORT_RETURN_IF_NOT(k_shape[token_dims + 1] == head_size_qk,
+                    "key head_size must equal query head_size");
   ORT_RETURN_IF_NOT(num_heads_q == num_heads_k,
                     "num_heads_q (", num_heads_q, ") must equal num_heads_k (", num_heads_k, ")");
   ORT_RETURN_IF_NOT(num_heads_v > 0 && num_heads_q > 0 && num_heads_v % num_heads_q == 0,
@@ -121,9 +129,13 @@ Status GatedDeltaNet<T>::ComputeInternal(OpKernelContext* context) const {
 
   int batch = 1;
   if (cu_seqlens != nullptr) {
+    ORT_RETURN_IF_NOT(qkv_rank == 3,
+                      "cu_seqlens describes ragged packing, so query/key/value must be rank 3");
     ORT_RETURN_IF_NOT(cu_seqlens->Shape().NumDimensions() == 1 && cu_seqlens->Shape()[0] >= 2,
                       "cu_seqlens must be rank 1 with at least 2 elements");
     batch = static_cast<int>(cu_seqlens->Shape()[0] - 1);
+  } else if (qkv_rank == 4) {
+    batch = static_cast<int>(q_shape[0]);
   } else {
     // Uniform packing. The batch size comes from the state, which GenAI always binds.
     ORT_RETURN_IF_NOT(initial_state != nullptr,
@@ -143,20 +155,29 @@ Status GatedDeltaNet<T>::ComputeInternal(OpKernelContext* context) const {
                       "(V-major)");
   }
 
-  const bool decay_per_key_dim = decay != nullptr && decay->Shape().NumDimensions() == 3;
+  // decay and beta carry the same leading token axes as query/key/value; a trailing
+  // head_size_qk axis makes the decay per key dimension.
+  const bool decay_per_key_dim =
+      decay != nullptr && decay->Shape().NumDimensions() == token_dims + 2;
   if (decay != nullptr) {
     const auto& d = decay->Shape();
-    ORT_RETURN_IF_NOT(d[0] == total_tokens && d[1] == num_heads_v,
-                      "decay must be [total_tokens, num_heads_v] or "
-                      "[total_tokens, num_heads_v, head_size_qk]");
+    ORT_RETURN_IF_NOT(d.NumDimensions() == token_dims + 1 || decay_per_key_dim,
+                      "decay must be [...tokens, num_heads_v] or "
+                      "[...tokens, num_heads_v, head_size_qk]");
+    ORT_RETURN_IF_NOT(d.SizeToDimension(token_dims) == total_tokens && d[token_dims] == num_heads_v,
+                      "decay must be [...tokens, num_heads_v] or "
+                      "[...tokens, num_heads_v, head_size_qk]");
     if (decay_per_key_dim) {
-      ORT_RETURN_IF_NOT(d[2] == head_size_qk, "per-key-dim decay last axis must be head_size_qk");
+      ORT_RETURN_IF_NOT(d[token_dims + 1] == head_size_qk,
+                        "per-key-dim decay last axis must be head_size_qk");
     }
   }
   if (beta != nullptr) {
     const auto& b = beta->Shape();
-    ORT_RETURN_IF_NOT(b.NumDimensions() == 2 && b[0] == total_tokens && b[1] == num_heads_v,
-                      "beta must be [total_tokens, num_heads_v]");
+    ORT_RETURN_IF_NOT(b.NumDimensions() == token_dims + 1 &&
+                          b.SizeToDimension(token_dims) == total_tokens &&
+                          b[token_dims] == num_heads_v,
+                      "beta must be [...tokens, num_heads_v]");
   }
   if (gate_activation_ == gdn::GateActivation::kQwen) {
     ORT_RETURN_IF_NOT(a_log != nullptr && dt_bias != nullptr,
@@ -169,8 +190,10 @@ Status GatedDeltaNet<T>::ComputeInternal(OpKernelContext* context) const {
   }
 
   const int out_heads = std::max(num_heads_q, num_heads_v);
-  TensorShape out_shape{total_tokens, out_heads, head_size_v};
-  Tensor* output = context->Output(0, out_shape);
+  TensorShapeVector out_dims(q_shape.GetDims().begin(), q_shape.GetDims().begin() + token_dims);
+  out_dims.push_back(out_heads);
+  out_dims.push_back(head_size_v);
+  Tensor* output = context->Output(0, TensorShape(out_dims));
 
   TensorShape state_shape{batch, num_heads_v, head_size_v, head_size_qk};
   Tensor* final_state = context->Output(1, state_shape);

--- a/onnxruntime/contrib_ops/cuda/bert/gated_delta_net.h
+++ b/onnxruntime/contrib_ops/cuda/bert/gated_delta_net.h
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/common/common.h"
+#include "core/providers/cuda/cuda_kernel.h"
+#include "contrib_ops/cuda/bert/gated_delta_net_plan.h"
+
+#include <string>
+
+namespace onnxruntime {
+namespace contrib {
+namespace cuda {
+
+template <typename T>
+class GatedDeltaNet final : public onnxruntime::cuda::CudaKernel {
+ public:
+  GatedDeltaNet(const OpKernelInfo& info);
+  Status ComputeInternal(OpKernelContext* context) const override;
+
+ private:
+  gated_delta_net::UpdateRule update_rule_;
+  gated_delta_net::GateActivation gate_activation_;
+  gated_delta_net::BetaActivation beta_activation_;
+  gated_delta_net::Engine forced_engine_;
+  float scale_;
+  int chunk_size_;
+  int state_checkpoints_;
+  bool qk_l2_norm_;
+};
+
+}  // namespace cuda
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cuda/bert/gated_delta_net_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/gated_delta_net_impl.cu
@@ -44,6 +44,7 @@
 #include <mutex>
 
 #include "contrib_ops/cuda/bert/gated_delta_net_impl.h"
+#include "contrib_ops/cuda/bert/gated_delta_net_mma.cuh"
 #include "core/providers/cuda/cu_inc/common.cuh"
 #include "core/providers/cuda/cuda_common.h"
 
@@ -57,8 +58,6 @@ namespace gated_delta_net {
 namespace {
 
 constexpr int kDVB = 64;  // v columns owned by one CTA in the chunked engine
-constexpr int kChunkedThreads = 512;
-constexpr int kChunkedWarps = kChunkedThreads / 32;
 
 // Padded leading dimensions. A row stride of DK halves (256 B) makes every mma fragment
 // load hit the same shared-memory bank across the 8 rows a warp reads, costing an 8-way
@@ -70,175 +69,6 @@ struct Ld {
   static constexpr int kMh = BT + 8;
   static constexpr int kVf = (kDVB > BT ? kDVB : BT) + 4;
 };
-
-__device__ __forceinline__ float SoftPlus(float x) {
-  // log1p(exp(x)) without overflow.
-  return x > 20.0f ? x : __logf(1.0f + __expf(x));
-}
-
-__device__ __forceinline__ float Sigmoid(float x) { return 1.0f / (1.0f + __expf(-x)); }
-
-// Resolve the [start, start+len) token range of sequence `b`, guarding malformed device
-// offsets so a bad producer cannot steer an out-of-bounds access.
-__device__ __forceinline__ void SequenceRange(const int32_t* cu_seqlens, int b, int64_t total,
-                                              int64_t uniform_len, int64_t* start, int64_t* len) {
-  if (cu_seqlens == nullptr) {
-    *start = static_cast<int64_t>(b) * uniform_len;
-    *len = uniform_len;
-  } else {
-    int64_t s = static_cast<int64_t>(cu_seqlens[b]);
-    int64_t e = static_cast<int64_t>(cu_seqlens[b + 1]);
-    s = s < 0 ? 0 : (s > total ? total : s);
-    e = e < 0 ? 0 : (e > total ? total : e);
-    *start = s;
-    *len = e > s ? e - s : 0;
-  }
-}
-
-// ---------------------------------------------------------------------------
-// mma.sync.m16n8k16 helpers
-// ---------------------------------------------------------------------------
-__device__ __forceinline__ uint32_t PackHalf2(__half lo, __half hi) {
-  return static_cast<uint32_t>(__half_as_ushort(lo)) |
-         (static_cast<uint32_t>(__half_as_ushort(hi)) << 16);
-}
-
-__device__ __forceinline__ void MmaM16N8K16(float (&d)[4], const uint32_t (&a)[4],
-                                            const uint32_t (&b)[2]) {
-  asm volatile(
-      "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 "
-      "{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%0,%1,%2,%3};\n"
-      : "+f"(d[0]), "+f"(d[1]), "+f"(d[2]), "+f"(d[3])
-      : "r"(a[0]), "r"(a[1]), "r"(a[2]), "r"(a[3]), "r"(b[0]), "r"(b[1]));
-}
-
-// A-fragment for m16n8k16: lane l holds rows (l>>2, l>>2 + 8) and k-pairs at (l&3)*2.
-template <bool Transposed>
-__device__ __forceinline__ void LoadFragA(uint32_t (&a)[4], const __half* A, int lda, int m0,
-                                          int k0, int lane) {
-  const int gid = lane >> 2, tig = lane & 3;
-  const int r0 = m0 + gid, r1 = m0 + gid + 8;
-  const int c0 = k0 + tig * 2, c1 = k0 + tig * 2 + 8;
-  if (Transposed) {
-    a[0] = PackHalf2(A[c0 * lda + r0], A[(c0 + 1) * lda + r0]);
-    a[1] = PackHalf2(A[c0 * lda + r1], A[(c0 + 1) * lda + r1]);
-    a[2] = PackHalf2(A[c1 * lda + r0], A[(c1 + 1) * lda + r0]);
-    a[3] = PackHalf2(A[c1 * lda + r1], A[(c1 + 1) * lda + r1]);
-  } else {
-    a[0] = *reinterpret_cast<const uint32_t*>(A + r0 * lda + c0);
-    a[1] = *reinterpret_cast<const uint32_t*>(A + r1 * lda + c0);
-    a[2] = *reinterpret_cast<const uint32_t*>(A + r0 * lda + c1);
-    a[3] = *reinterpret_cast<const uint32_t*>(A + r1 * lda + c1);
-  }
-}
-
-// B-fragment for m16n8k16 (col layout): lane l holds column (l>>2) and k-pairs at (l&3)*2.
-template <bool Transposed>
-__device__ __forceinline__ void LoadFragB(uint32_t (&b)[2], const __half* B, int ldb, int k0,
-                                          int n0, int lane) {
-  const int gid = lane >> 2, tig = lane & 3;
-  const int col = n0 + gid;
-  const int r0 = k0 + tig * 2, r1 = k0 + tig * 2 + 8;
-  if (Transposed) {
-    b[0] = *reinterpret_cast<const uint32_t*>(B + col * ldb + r0);
-    b[1] = *reinterpret_cast<const uint32_t*>(B + col * ldb + r1);
-  } else {
-    b[0] = PackHalf2(B[r0 * ldb + col], B[(r0 + 1) * ldb + col]);
-    b[1] = PackHalf2(B[r1 * ldb + col], B[(r1 + 1) * ldb + col]);
-  }
-}
-
-// C[M][N] (float, ldc) = A[M][K] @ B[K][N] (+ C if Accumulate).
-//
-// Each warp owns one m-tile (16 rows) and a strided subset of the n-tiles, so the A
-// fragment is loaded once per k-step and reused across every n-tile the warp owns.
-template <int M, int N, int K, bool TA, bool TB, bool Accumulate>
-__device__ __forceinline__ void SmemGemm(float* C, int ldc, const __half* A, int lda,
-                                         const __half* B, int ldb, int warp_id, int lane) {
-  constexpr int kMTiles = M / 16;
-  constexpr int kNTiles = N / 8;
-  constexpr int kWarpsPerM = kChunkedWarps > kMTiles ? kChunkedWarps / kMTiles : 1;
-  constexpr int kMGroups = kChunkedWarps / kWarpsPerM;
-  constexpr int kNPerWarp = (kNTiles + kWarpsPerM - 1) / kWarpsPerM;
-
-  const int m_group = warp_id / kWarpsPerM;
-  const int n_group = warp_id % kWarpsPerM;
-  const int gid = lane >> 2, tig = lane & 3;
-
-#pragma unroll 1
-  for (int mt = m_group; mt < kMTiles; mt += kMGroups) {
-    const int m0 = mt * 16;
-    const int r0 = m0 + gid, r1 = m0 + gid + 8;
-    float acc[kNPerWarp][4];
-
-#pragma unroll
-    for (int i = 0; i < kNPerWarp; ++i) {
-      const int nt = n_group + i * kWarpsPerM;
-      if (nt < kNTiles) {
-        const int c0 = nt * 8 + tig * 2;
-        acc[i][0] = Accumulate ? C[r0 * ldc + c0] : 0.0f;
-        acc[i][1] = Accumulate ? C[r0 * ldc + c0 + 1] : 0.0f;
-        acc[i][2] = Accumulate ? C[r1 * ldc + c0] : 0.0f;
-        acc[i][3] = Accumulate ? C[r1 * ldc + c0 + 1] : 0.0f;
-      }
-    }
-
-    for (int k0 = 0; k0 < K; k0 += 16) {
-      uint32_t a[4];
-      LoadFragA<TA>(a, A, lda, m0, k0, lane);
-#pragma unroll
-      for (int i = 0; i < kNPerWarp; ++i) {
-        const int nt = n_group + i * kWarpsPerM;
-        if (nt < kNTiles) {
-          uint32_t b[2];
-          LoadFragB<TB>(b, B, ldb, k0, nt * 8, lane);
-          MmaM16N8K16(acc[i], a, b);
-        }
-      }
-    }
-
-#pragma unroll
-    for (int i = 0; i < kNPerWarp; ++i) {
-      const int nt = n_group + i * kWarpsPerM;
-      if (nt < kNTiles) {
-        const int c0 = nt * 8 + tig * 2;
-        C[r0 * ldc + c0] = acc[i][0];
-        C[r0 * ldc + c0 + 1] = acc[i][1];
-        C[r1 * ldc + c0] = acc[i][2];
-        C[r1 * ldc + c0 + 1] = acc[i][3];
-      }
-    }
-  }
-}
-
-template <int BT>
-__device__ __forceinline__ void InclusiveScanBT(float* x, int tid) {
-  static_assert(BT == 32 || BT == 64, "chunk length must be 32 or 64");
-  if (tid >= 32) return;
-  if (BT == 32) {
-    float a = x[tid];
-#pragma unroll
-    for (int off = 1; off < 32; off <<= 1) {
-      float ta = __shfl_up_sync(0xffffffff, a, off);
-      if (tid >= off) a += ta;
-    }
-    x[tid] = a;
-    return;
-  }
-  float a = x[tid], b = x[tid + 32];
-#pragma unroll
-  for (int off = 1; off < 32; off <<= 1) {
-    float ta = __shfl_up_sync(0xffffffff, a, off);
-    float tb = __shfl_up_sync(0xffffffff, b, off);
-    if (tid >= off) {
-      a += ta;
-      b += tb;
-    }
-  }
-  const float total = __shfl_sync(0xffffffff, a, 31);
-  x[tid] = a;
-  x[tid + 32] = b + total;
-}
 
 template <int DK, int BT>
 struct ChunkedSmem {
@@ -291,105 +121,6 @@ __device__ __forceinline__ ChunkedSmem<DK, BT> CarveChunked(char* raw) {
   h += BT * L::kMh;
   return s;
 }
-
-// Tinv = (I + M)^-1 for the strictly lower BT x BT M in s.m_h, left in s.ti_h. Exact.
-template <int DK, int BT>
-__device__ __forceinline__ void BuildTriInverse(const ChunkedSmem<DK, BT>& s, int warp_id,
-                                                int lane, int tid) {
-  using L = Ld<DK, BT>;
-  for (int idx = tid; idx < BT * BT; idx += kChunkedThreads) {
-    s.db_h[(idx / BT) * L::kMh + idx % BT] = __float2half(0.0f);
-  }
-  __syncthreads();
-
-  // Column `lane` of the inverse of diagonal block `warp_id`, by forward substitution.
-  // Lane-local, so no synchronisation inside.
-  if (warp_id < BT / 16 && lane < 16) {
-    const int base = warp_id * 16;
-    float col[16];
-#pragma unroll
-    for (int i = 0; i < 16; ++i) col[i] = 0.0f;
-    col[lane] = 1.0f;
-    for (int i = lane + 1; i < 16; ++i) {
-      float acc = 0.0f;
-      for (int j = lane; j < i; ++j) {
-        acc += __half2float(s.m_h[(base + i) * L::kMh + base + j]) * col[j];
-      }
-      col[i] = -acc;
-    }
-#pragma unroll
-    for (int i = 0; i < 16; ++i) {
-      s.db_h[(base + i) * L::kMh + base + lane] = __float2half(col[i]);
-    }
-  }
-  __syncthreads();
-
-  SmemGemm<BT, BT, BT, false, false, false>(s.t_f, L::kVf, s.db_h, L::kMh, s.m_h, L::kMh,
-                                            warp_id, lane);
-  __syncthreads();
-  for (int idx = tid; idx < BT * BT; idx += kChunkedThreads) {
-    const int r = idx / BT, c = idx % BT;
-    const bool same_block = (r >> 4) == (c >> 4);
-    const float n = same_block ? 0.0f : s.t_f[r * L::kVf + c];
-    s.nb_h[r * L::kMh + c] = __float2half(n);
-    s.ti_h[r * L::kMh + c] = __float2half((r == c ? 1.0f : 0.0f) - n);  // Z1 = I - N
-  }
-  __syncthreads();
-
-  // N is strictly block lower over BT/16 levels, so N^(BT/16) = 0 and the alternating
-  // series terminates exactly; Horner needs BT/16 - 2 steps after Z1 = I - N.
-#pragma unroll
-  for (int it = 0; it < BT / 16 - 2; ++it) {
-    SmemGemm<BT, BT, BT, false, false, false>(s.t_f, L::kVf, s.nb_h, L::kMh, s.ti_h, L::kMh,
-                                              warp_id, lane);
-    __syncthreads();
-    for (int idx = tid; idx < BT * BT; idx += kChunkedThreads) {
-      const int r = idx / BT, c = idx % BT;
-      s.ti_h[r * L::kMh + c] = __float2half((r == c ? 1.0f : 0.0f) - s.t_f[r * L::kVf + c]);
-    }
-    __syncthreads();
-  }
-
-  SmemGemm<BT, BT, BT, false, false, false>(s.t_f, L::kVf, s.ti_h, L::kMh, s.db_h, L::kMh,
-                                            warp_id, lane);
-  __syncthreads();
-  for (int idx = tid; idx < BT * BT; idx += kChunkedThreads) {
-    const int r = idx / BT, c = idx % BT;
-    s.ti_h[r * L::kMh + c] = __float2half(s.t_f[r * L::kVf + c]);
-  }
-  __syncthreads();
-}
-
-// Effective per-token decay and beta, after the optional fused activations.
-__device__ __forceinline__ float EffectiveDecay(float raw, const float* a_log, const float* dt_bias,
-                                                int h, GateActivation act) {
-  if (act == GateActivation::kQwen) {
-    const float bias = dt_bias != nullptr ? dt_bias[h] : 0.0f;
-    const float scale = a_log != nullptr ? -__expf(a_log[h]) : -1.0f;
-    return scale * SoftPlus(raw + bias);
-  }
-  return raw;
-}
-
-__device__ __forceinline__ float EffectiveBeta(float raw, BetaActivation act) {
-  return act == BetaActivation::kSigmoid ? Sigmoid(raw) : raw;
-}
-
-struct KernelParams {
-  int64_t total_tokens;
-  int64_t uniform_len;
-  int num_heads_q;
-  int num_heads_k;
-  int num_heads_v;
-  float scale;
-  GateActivation gate_activation;
-  BetaActivation beta_activation;
-  UpdateRule update_rule;
-  bool qk_l2_norm;
-  int state_checkpoints;
-  int batch;
-  int decay_per_key_dim_flag;
-};
 
 // ---------------------------------------------------------------------------
 // Chunked engine
@@ -508,7 +239,8 @@ __global__ __launch_bounds__(kChunkedThreads) void GatedDeltaNetChunkedKernel(
     }
     __syncthreads();
 
-    BuildTriInverse<DK, BT>(s, warp_id, lane, tid);
+    BuildTriInverse<BT>(s.m_h, L::kMh, s.db_h, s.nb_h, s.ti_h, L::kMh, s.t_f, L::kVf, warp_id,
+                        lane, tid);
 
     SmemGemm<BT, kDVB, DK, false, false, false>(s.t_f, L::kVf, s.k_h, L::kKh, s.s_h, L::kVh,
                                                 warp_id, lane);
@@ -872,23 +604,6 @@ __global__ __launch_bounds__(kThreads) void GatedDeltaNetRecurrentKernel(Variant
   }
 }
 
-// Raise the opt-in shared-memory maximum once per (device, kernel) to the device limit.
-// Setting it per call to the current request lets a concurrent smaller launch lower the
-// bound underneath a larger one.
-template <typename KernelT>
-Status SetMaxDynamicSmemOnce(KernelT kernel, size_t device_max, std::once_flag& flag) {
-  Status status = Status::OK();
-  std::call_once(flag, [&]() {
-    cudaError_t err = cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize,
-                                           static_cast<int>(device_max));
-    if (err != cudaSuccess) {
-      status = ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "GatedDeltaNet: cudaFuncSetAttribute failed: ",
-                               cudaGetErrorString(err));
-    }
-  });
-  return status;
-}
-
 }  // namespace
 
 template <typename T>
@@ -908,6 +623,10 @@ Status LaunchGatedDeltaNet(const Descriptor& desc, const Plan& plan, const Varia
   p.state_checkpoints = desc.state_checkpoints;
   p.batch = desc.batch;
   p.decay_per_key_dim_flag = desc.decay_per_key_dim ? 1 : 0;
+
+  if (plan.engine == Engine::kChunkedSplit) {
+    return LaunchGatedDeltaNetSplit<T>(desc, plan, pack, scale, stream);
+  }
 
   if (plan.engine == Engine::kChunked) {
     const dim3 grid(desc.batch, desc.num_heads_v, desc.head_size_v / kDVB);

--- a/onnxruntime/contrib_ops/cuda/bert/gated_delta_net_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/gated_delta_net_impl.cu
@@ -608,7 +608,8 @@ __global__ __launch_bounds__(kThreads) void GatedDeltaNetRecurrentKernel(Variant
 
 template <typename T>
 Status LaunchGatedDeltaNet(const Descriptor& desc, const Plan& plan, const VariantPack<T>& pack,
-                           float scale, int max_threads_per_block, cudaStream_t stream) {
+                           float scale, int max_threads_per_block,
+                           size_t max_shared_memory_per_block, cudaStream_t stream) {
   KernelParams p{};
   p.total_tokens = desc.total_tokens;
   p.uniform_len = desc.batch > 0 ? desc.total_tokens / desc.batch : 0;
@@ -676,8 +677,9 @@ Status LaunchGatedDeltaNet(const Descriptor& desc, const Plan& plan, const Varia
       sizeof(float) * (static_cast<size_t>(desc.head_size_qk) * desc.head_size_v +
                        2 * desc.head_size_qk + desc.head_size_v + desc.head_size_qk);
   static std::once_flag once_rec;
-  ORT_RETURN_IF_ERROR(
-      SetMaxDynamicSmemOnce(GatedDeltaNetRecurrentKernel<T, kRecurrentThreads>, smem, once_rec));
+  ORT_RETURN_IF_ERROR(SetMaxDynamicSmemOnce(
+      GatedDeltaNetRecurrentKernel<T, kRecurrentThreads>,
+      max_shared_memory_per_block, once_rec));
   const dim3 grid(desc.batch, desc.num_heads_v, 1);
   GatedDeltaNetRecurrentKernel<T, kRecurrentThreads>
       <<<grid, kRecurrentThreads, smem, stream>>>(pack, p, desc.head_size_qk, desc.head_size_v);
@@ -686,9 +688,9 @@ Status LaunchGatedDeltaNet(const Descriptor& desc, const Plan& plan, const Varia
 }
 
 template Status LaunchGatedDeltaNet<float>(const Descriptor&, const Plan&, const VariantPack<float>&,
-                                           float, int, cudaStream_t);
+                                          float, int, size_t, cudaStream_t);
 template Status LaunchGatedDeltaNet<half>(const Descriptor&, const Plan&, const VariantPack<half>&,
-                                          float, int, cudaStream_t);
+                                          float, int, size_t, cudaStream_t);
 
 }  // namespace gated_delta_net
 }  // namespace cuda

--- a/onnxruntime/contrib_ops/cuda/bert/gated_delta_net_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/gated_delta_net_impl.cu
@@ -1,0 +1,960 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// GatedDeltaNet CUDA kernels.
+//
+// Two engines, chosen by gated_delta_net_plan.cc:
+//
+//  * chunked  -- tensor-core chunked scan for prefill. One CTA owns one
+//                (sequence, v-head, v-block) and walks the sequence in BT=64 token chunks,
+//                keeping the recurrent state in shared memory for the whole walk. One
+//                launch, no per-chunk state materialisation.
+//  * recurrent -- scalar per-token recurrence for decode / MTP verify, and the only engine
+//                that can emit the per-token state checkpoint series.
+//
+// Recurrence (gated_delta), per v-head, with S the [K x V] state:
+//     S_t = exp(g_t) S_{t-1} + k_t (beta_t (v_t - exp(g_t) S_{t-1}^T k_t))^T
+//     o_t = scale * S_t^T q_t
+//
+// Chunked form over a chunk of BT tokens with gc the within-chunk cumulative log-decay:
+//     M[t,s]  = beta_t (k_t . k_s) exp(gc_t - gc_s)             strictly lower
+//     U       = (I + M)^-1 (Ubar - Wbar S0),  Ubar = beta v,  Wbar[t] = beta_t exp(gc_t) k_t
+//     P[t,s]  = (q_t . k_s) exp(gc_t - gc_s)                    inclusive lower
+//     o       = scale (P U + Qg S0),          Qg[t] = q_t exp(gc_t)
+//     S1      = exp(gc_BT) S0 + Kd^T U,       Kd[t] = k_t exp(gc_BT - gc_t)
+//
+// Two properties of that form matter for speed and are relied on below:
+//
+//  1. W is only ever used as `W S0`, and W = (I+M)^-1 Wbar, so
+//     U = (I+M)^-1 Ubar - W S0 = (I+M)^-1 (Ubar - Wbar S0). The 64x128 triangular solve
+//     disappears, and since Wbar is only a row scaling of k, Wbar is never materialised
+//     either -- the scaling folds into the epilogue of (k S0).
+//  2. (I+M)^-1 has an exact closed form. With Dinv the block diagonal of the four 16x16
+//     inverses and N = Dinv M (its own 16x16 diagonal blocks are exactly zero), N is
+//     strictly block lower over four block levels so N^4 = 0 and
+//     (I+M)^-1 = (I - N + N^2 - N^3) Dinv exactly. Four full 64x64x64 GEMMs replace eight
+//     tiny serial ones.
+//
+// k * exp(-gc) is never formed; the decay ratio is applied to the [BT x BT] gram matrices,
+// which keeps the exponent bounded within a chunk.
+
+#include <cuda_fp16.h>
+
+#include <algorithm>
+#include <mutex>
+
+#include "contrib_ops/cuda/bert/gated_delta_net_impl.h"
+#include "core/providers/cuda/cu_inc/common.cuh"
+#include "core/providers/cuda/cuda_common.h"
+
+using namespace onnxruntime::cuda;
+
+namespace onnxruntime {
+namespace contrib {
+namespace cuda {
+namespace gated_delta_net {
+
+namespace {
+
+constexpr int kDVB = 64;  // v columns owned by one CTA in the chunked engine
+constexpr int kChunkedThreads = 512;
+constexpr int kChunkedWarps = kChunkedThreads / 32;
+
+// Padded leading dimensions. A row stride of DK halves (256 B) makes every mma fragment
+// load hit the same shared-memory bank across the 8 rows a warp reads, costing an 8-way
+// conflict per load; +8 halves (+4 floats) staggers them.
+template <int DK, int BT>
+struct Ld {
+  static constexpr int kKh = DK + 8;
+  static constexpr int kVh = kDVB + 8;
+  static constexpr int kMh = BT + 8;
+  static constexpr int kVf = (kDVB > BT ? kDVB : BT) + 4;
+};
+
+__device__ __forceinline__ float SoftPlus(float x) {
+  // log1p(exp(x)) without overflow.
+  return x > 20.0f ? x : __logf(1.0f + __expf(x));
+}
+
+__device__ __forceinline__ float Sigmoid(float x) { return 1.0f / (1.0f + __expf(-x)); }
+
+// Resolve the [start, start+len) token range of sequence `b`, guarding malformed device
+// offsets so a bad producer cannot steer an out-of-bounds access.
+__device__ __forceinline__ void SequenceRange(const int32_t* cu_seqlens, int b, int64_t total,
+                                              int64_t uniform_len, int64_t* start, int64_t* len) {
+  if (cu_seqlens == nullptr) {
+    *start = static_cast<int64_t>(b) * uniform_len;
+    *len = uniform_len;
+  } else {
+    int64_t s = static_cast<int64_t>(cu_seqlens[b]);
+    int64_t e = static_cast<int64_t>(cu_seqlens[b + 1]);
+    s = s < 0 ? 0 : (s > total ? total : s);
+    e = e < 0 ? 0 : (e > total ? total : e);
+    *start = s;
+    *len = e > s ? e - s : 0;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// mma.sync.m16n8k16 helpers
+// ---------------------------------------------------------------------------
+__device__ __forceinline__ uint32_t PackHalf2(__half lo, __half hi) {
+  return static_cast<uint32_t>(__half_as_ushort(lo)) |
+         (static_cast<uint32_t>(__half_as_ushort(hi)) << 16);
+}
+
+__device__ __forceinline__ void MmaM16N8K16(float (&d)[4], const uint32_t (&a)[4],
+                                            const uint32_t (&b)[2]) {
+  asm volatile(
+      "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 "
+      "{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%0,%1,%2,%3};\n"
+      : "+f"(d[0]), "+f"(d[1]), "+f"(d[2]), "+f"(d[3])
+      : "r"(a[0]), "r"(a[1]), "r"(a[2]), "r"(a[3]), "r"(b[0]), "r"(b[1]));
+}
+
+// A-fragment for m16n8k16: lane l holds rows (l>>2, l>>2 + 8) and k-pairs at (l&3)*2.
+template <bool Transposed>
+__device__ __forceinline__ void LoadFragA(uint32_t (&a)[4], const __half* A, int lda, int m0,
+                                          int k0, int lane) {
+  const int gid = lane >> 2, tig = lane & 3;
+  const int r0 = m0 + gid, r1 = m0 + gid + 8;
+  const int c0 = k0 + tig * 2, c1 = k0 + tig * 2 + 8;
+  if (Transposed) {
+    a[0] = PackHalf2(A[c0 * lda + r0], A[(c0 + 1) * lda + r0]);
+    a[1] = PackHalf2(A[c0 * lda + r1], A[(c0 + 1) * lda + r1]);
+    a[2] = PackHalf2(A[c1 * lda + r0], A[(c1 + 1) * lda + r0]);
+    a[3] = PackHalf2(A[c1 * lda + r1], A[(c1 + 1) * lda + r1]);
+  } else {
+    a[0] = *reinterpret_cast<const uint32_t*>(A + r0 * lda + c0);
+    a[1] = *reinterpret_cast<const uint32_t*>(A + r1 * lda + c0);
+    a[2] = *reinterpret_cast<const uint32_t*>(A + r0 * lda + c1);
+    a[3] = *reinterpret_cast<const uint32_t*>(A + r1 * lda + c1);
+  }
+}
+
+// B-fragment for m16n8k16 (col layout): lane l holds column (l>>2) and k-pairs at (l&3)*2.
+template <bool Transposed>
+__device__ __forceinline__ void LoadFragB(uint32_t (&b)[2], const __half* B, int ldb, int k0,
+                                          int n0, int lane) {
+  const int gid = lane >> 2, tig = lane & 3;
+  const int col = n0 + gid;
+  const int r0 = k0 + tig * 2, r1 = k0 + tig * 2 + 8;
+  if (Transposed) {
+    b[0] = *reinterpret_cast<const uint32_t*>(B + col * ldb + r0);
+    b[1] = *reinterpret_cast<const uint32_t*>(B + col * ldb + r1);
+  } else {
+    b[0] = PackHalf2(B[r0 * ldb + col], B[(r0 + 1) * ldb + col]);
+    b[1] = PackHalf2(B[r1 * ldb + col], B[(r1 + 1) * ldb + col]);
+  }
+}
+
+// C[M][N] (float, ldc) = A[M][K] @ B[K][N] (+ C if Accumulate).
+//
+// Each warp owns one m-tile (16 rows) and a strided subset of the n-tiles, so the A
+// fragment is loaded once per k-step and reused across every n-tile the warp owns.
+template <int M, int N, int K, bool TA, bool TB, bool Accumulate>
+__device__ __forceinline__ void SmemGemm(float* C, int ldc, const __half* A, int lda,
+                                         const __half* B, int ldb, int warp_id, int lane) {
+  constexpr int kMTiles = M / 16;
+  constexpr int kNTiles = N / 8;
+  constexpr int kWarpsPerM = kChunkedWarps > kMTiles ? kChunkedWarps / kMTiles : 1;
+  constexpr int kMGroups = kChunkedWarps / kWarpsPerM;
+  constexpr int kNPerWarp = (kNTiles + kWarpsPerM - 1) / kWarpsPerM;
+
+  const int m_group = warp_id / kWarpsPerM;
+  const int n_group = warp_id % kWarpsPerM;
+  const int gid = lane >> 2, tig = lane & 3;
+
+#pragma unroll 1
+  for (int mt = m_group; mt < kMTiles; mt += kMGroups) {
+    const int m0 = mt * 16;
+    const int r0 = m0 + gid, r1 = m0 + gid + 8;
+    float acc[kNPerWarp][4];
+
+#pragma unroll
+    for (int i = 0; i < kNPerWarp; ++i) {
+      const int nt = n_group + i * kWarpsPerM;
+      if (nt < kNTiles) {
+        const int c0 = nt * 8 + tig * 2;
+        acc[i][0] = Accumulate ? C[r0 * ldc + c0] : 0.0f;
+        acc[i][1] = Accumulate ? C[r0 * ldc + c0 + 1] : 0.0f;
+        acc[i][2] = Accumulate ? C[r1 * ldc + c0] : 0.0f;
+        acc[i][3] = Accumulate ? C[r1 * ldc + c0 + 1] : 0.0f;
+      }
+    }
+
+    for (int k0 = 0; k0 < K; k0 += 16) {
+      uint32_t a[4];
+      LoadFragA<TA>(a, A, lda, m0, k0, lane);
+#pragma unroll
+      for (int i = 0; i < kNPerWarp; ++i) {
+        const int nt = n_group + i * kWarpsPerM;
+        if (nt < kNTiles) {
+          uint32_t b[2];
+          LoadFragB<TB>(b, B, ldb, k0, nt * 8, lane);
+          MmaM16N8K16(acc[i], a, b);
+        }
+      }
+    }
+
+#pragma unroll
+    for (int i = 0; i < kNPerWarp; ++i) {
+      const int nt = n_group + i * kWarpsPerM;
+      if (nt < kNTiles) {
+        const int c0 = nt * 8 + tig * 2;
+        C[r0 * ldc + c0] = acc[i][0];
+        C[r0 * ldc + c0 + 1] = acc[i][1];
+        C[r1 * ldc + c0] = acc[i][2];
+        C[r1 * ldc + c0 + 1] = acc[i][3];
+      }
+    }
+  }
+}
+
+template <int BT>
+__device__ __forceinline__ void InclusiveScanBT(float* x, int tid) {
+  static_assert(BT == 32 || BT == 64, "chunk length must be 32 or 64");
+  if (tid >= 32) return;
+  if (BT == 32) {
+    float a = x[tid];
+#pragma unroll
+    for (int off = 1; off < 32; off <<= 1) {
+      float ta = __shfl_up_sync(0xffffffff, a, off);
+      if (tid >= off) a += ta;
+    }
+    x[tid] = a;
+    return;
+  }
+  float a = x[tid], b = x[tid + 32];
+#pragma unroll
+  for (int off = 1; off < 32; off <<= 1) {
+    float ta = __shfl_up_sync(0xffffffff, a, off);
+    float tb = __shfl_up_sync(0xffffffff, b, off);
+    if (tid >= off) {
+      a += ta;
+      b += tb;
+    }
+  }
+  const float total = __shfl_sync(0xffffffff, a, 31);
+  x[tid] = a;
+  x[tid + 32] = b + total;
+}
+
+template <int DK, int BT>
+struct ChunkedSmem {
+  __half* k_h;   // [BT][LdKh]  k, scaled in place to Kd late in the chunk
+  __half* q_h;   // [BT][LdKh]  q, scaled in place to Qg late in the chunk
+  __half* v_h;   // [BT][LdVh]
+  __half* u_h;   // [BT][LdVh]  R, then U
+  __half* m_h;   // [BT][LdMh]  M, then P
+  __half* s_h;   // [DK][LdVh]  fp16 operand copy of the state
+  __half* db_h;  // [BT][LdMh]  block-diagonal inverse of (I+M)
+  __half* nb_h;  // [BT][LdMh]  N = Dinv M with the diagonal blocks zeroed
+  __half* ti_h;  // [BT][LdMh]  Neumann iterate, finally (I+M)^-1
+  float* s_f;    // [DK][LdVf]  fp32 state
+  float* t_f;    // [BT][LdVf]  gemm scratch, also used as [BT][BT]
+  float* gc;     // [BT]
+  float* beta;   // [BT]
+};
+
+template <int DK, int BT>
+__device__ __forceinline__ ChunkedSmem<DK, BT> CarveChunked(char* raw) {
+  using L = Ld<DK, BT>;
+  ChunkedSmem<DK, BT> s;
+  float* f = reinterpret_cast<float*>(raw);
+  s.s_f = f;  f += DK * L::kVf;
+  s.t_f = f;  f += BT * L::kVf;
+  s.gc = f;   f += BT;
+  s.beta = f; f += BT;
+  __half* h = reinterpret_cast<__half*>(f);
+  s.k_h = h;  h += BT * L::kKh;
+  s.q_h = h;  h += BT * L::kKh;
+  s.v_h = h;  h += BT * L::kVh;
+  s.u_h = h;  h += BT * L::kVh;
+  s.m_h = h;  h += BT * L::kMh;
+  s.s_h = h;  h += DK * L::kVh;
+  s.db_h = h; h += BT * L::kMh;
+  s.nb_h = h; h += BT * L::kMh;
+  s.ti_h = h; h += BT * L::kMh;
+  return s;
+}
+
+// Tinv = (I + M)^-1 for the strictly lower BT x BT M in s.m_h, left in s.ti_h. Exact.
+template <int DK, int BT>
+__device__ __forceinline__ void BuildTriInverse(const ChunkedSmem<DK, BT>& s, int warp_id,
+                                                int lane, int tid) {
+  using L = Ld<DK, BT>;
+  for (int idx = tid; idx < BT * BT; idx += kChunkedThreads) {
+    s.db_h[(idx / BT) * L::kMh + idx % BT] = __float2half(0.0f);
+  }
+  __syncthreads();
+
+  // Column `lane` of the inverse of diagonal block `warp_id`, by forward substitution.
+  // Lane-local, so no synchronisation inside.
+  if (warp_id < BT / 16 && lane < 16) {
+    const int base = warp_id * 16;
+    float col[16];
+#pragma unroll
+    for (int i = 0; i < 16; ++i) col[i] = 0.0f;
+    col[lane] = 1.0f;
+    for (int i = lane + 1; i < 16; ++i) {
+      float acc = 0.0f;
+      for (int j = lane; j < i; ++j) {
+        acc += __half2float(s.m_h[(base + i) * L::kMh + base + j]) * col[j];
+      }
+      col[i] = -acc;
+    }
+#pragma unroll
+    for (int i = 0; i < 16; ++i) {
+      s.db_h[(base + i) * L::kMh + base + lane] = __float2half(col[i]);
+    }
+  }
+  __syncthreads();
+
+  SmemGemm<BT, BT, BT, false, false, false>(s.t_f, L::kVf, s.db_h, L::kMh, s.m_h, L::kMh,
+                                               warp_id, lane);
+  __syncthreads();
+  for (int idx = tid; idx < BT * BT; idx += kChunkedThreads) {
+    const int r = idx / BT, c = idx % BT;
+    const bool same_block = (r >> 4) == (c >> 4);
+    const float n = same_block ? 0.0f : s.t_f[r * L::kVf + c];
+    s.nb_h[r * L::kMh + c] = __float2half(n);
+    s.ti_h[r * L::kMh + c] = __float2half((r == c ? 1.0f : 0.0f) - n);  // Z1 = I - N
+  }
+  __syncthreads();
+
+  // N is strictly block lower over BT/16 levels, so N^(BT/16) = 0 and the alternating
+  // series terminates exactly; Horner needs BT/16 - 2 steps after Z1 = I - N.
+#pragma unroll
+  for (int it = 0; it < BT / 16 - 2; ++it) {
+    SmemGemm<BT, BT, BT, false, false, false>(s.t_f, L::kVf, s.nb_h, L::kMh, s.ti_h, L::kMh,
+                                                 warp_id, lane);
+    __syncthreads();
+    for (int idx = tid; idx < BT * BT; idx += kChunkedThreads) {
+      const int r = idx / BT, c = idx % BT;
+      s.ti_h[r * L::kMh + c] = __float2half((r == c ? 1.0f : 0.0f) - s.t_f[r * L::kVf + c]);
+    }
+    __syncthreads();
+  }
+
+  SmemGemm<BT, BT, BT, false, false, false>(s.t_f, L::kVf, s.ti_h, L::kMh, s.db_h, L::kMh,
+                                               warp_id, lane);
+  __syncthreads();
+  for (int idx = tid; idx < BT * BT; idx += kChunkedThreads) {
+    const int r = idx / BT, c = idx % BT;
+    s.ti_h[r * L::kMh + c] = __float2half(s.t_f[r * L::kVf + c]);
+  }
+  __syncthreads();
+}
+
+// Effective per-token decay and beta, after the optional fused activations.
+__device__ __forceinline__ float EffectiveDecay(float raw, const float* a_log, const float* dt_bias,
+                                                int h, GateActivation act) {
+  if (act == GateActivation::kQwen) {
+    const float bias = dt_bias != nullptr ? dt_bias[h] : 0.0f;
+    const float scale = a_log != nullptr ? -__expf(a_log[h]) : -1.0f;
+    return scale * SoftPlus(raw + bias);
+  }
+  return raw;
+}
+
+__device__ __forceinline__ float EffectiveBeta(float raw, BetaActivation act) {
+  return act == BetaActivation::kSigmoid ? Sigmoid(raw) : raw;
+}
+
+struct KernelParams {
+  int64_t total_tokens;
+  int64_t uniform_len;
+  int num_heads_q;
+  int num_heads_k;
+  int num_heads_v;
+  float scale;
+  GateActivation gate_activation;
+  BetaActivation beta_activation;
+  UpdateRule update_rule;
+  bool qk_l2_norm;
+  int state_checkpoints;
+  int batch;
+  int decay_per_key_dim_flag;
+};
+
+// ---------------------------------------------------------------------------
+// Chunked engine
+// ---------------------------------------------------------------------------
+template <typename T, int DK, int DV, int BT>
+__global__ __launch_bounds__(kChunkedThreads) void GatedDeltaNetChunkedKernel(
+    VariantPack<T> pack, KernelParams p) {
+  using L = Ld<DK, BT>;
+  extern __shared__ char smem_raw[];
+  const ChunkedSmem<DK, BT> s = CarveChunked<DK, BT>(smem_raw);
+
+  const int b = blockIdx.x, hv = blockIdx.y, v0 = blockIdx.z * kDVB;
+  const int tid = threadIdx.x, warp_id = tid >> 5, lane = tid & 31;
+  const int hq = hv * p.num_heads_q / p.num_heads_v;
+  const int hk = hv * p.num_heads_k / p.num_heads_v;
+
+  int64_t tok_base, seq_len64;
+  SequenceRange(pack.cu_seqlens, b, p.total_tokens, p.uniform_len, &tok_base, &seq_len64);
+  const int seq_len = static_cast<int>(seq_len64);
+
+  const int64_t q_stride = static_cast<int64_t>(p.num_heads_q) * DK;
+  const int64_t k_stride = static_cast<int64_t>(p.num_heads_k) * DK;
+  const int64_t v_stride = static_cast<int64_t>(p.num_heads_v) * DV;
+  const int64_t st_off = (static_cast<int64_t>(b) * p.num_heads_v + hv) * DV * DK;
+
+  const bool needs_decay = pack.decay != nullptr &&
+                           (p.update_rule == UpdateRule::kGated ||
+                            p.update_rule == UpdateRule::kGatedDelta);
+  const bool needs_retrieval =
+      p.update_rule == UpdateRule::kDelta || p.update_rule == UpdateRule::kGatedDelta;
+
+  for (int idx = tid; idx < DK * kDVB; idx += kChunkedThreads) {
+    const int r = idx / kDVB, c = idx % kDVB;
+    s.s_f[r * L::kVf + c] =
+        pack.initial_state != nullptr
+            ? pack.initial_state[st_off + static_cast<int64_t>(v0 + c) * DK + r]
+            : 0.0f;
+  }
+  __syncthreads();
+
+  for (int chunk0 = 0; chunk0 < seq_len; chunk0 += BT) {
+    const int len = min(BT, seq_len - chunk0);
+
+    for (int idx = tid; idx < DK * kDVB; idx += kChunkedThreads) {
+      const int r = idx / kDVB, c = idx % kDVB;
+      s.s_h[r * L::kVh + c] = __float2half(s.s_f[r * L::kVf + c]);
+    }
+    for (int idx = tid; idx < BT * DK; idx += kChunkedThreads) {
+      const int t = idx / DK, d = idx % DK;
+      const int64_t tok = tok_base + chunk0 + t;
+      s.k_h[t * L::kKh + d] =
+          (t < len) ? __float2half((float)pack.key[tok * k_stride + hk * DK + d]) : __float2half(0.f);
+      s.q_h[t * L::kKh + d] =
+          (t < len) ? __float2half((float)pack.query[tok * q_stride + hq * DK + d]) : __float2half(0.f);
+    }
+    for (int idx = tid; idx < BT * kDVB; idx += kChunkedThreads) {
+      const int t = idx / kDVB, d = idx % kDVB;
+      const int64_t tok = tok_base + chunk0 + t;
+      s.v_h[t * L::kVh + d] =
+          (t < len) ? __float2half((float)pack.value[tok * v_stride + hv * DV + v0 + d])
+                    : __float2half(0.f);
+    }
+    if (tid < BT) {
+      const int64_t tok = tok_base + chunk0 + tid;
+      const int64_t gi = tok * p.num_heads_v + hv;
+      float g = 0.0f, be = 0.0f;
+      if (tid < len) {
+        g = needs_decay ? EffectiveDecay(pack.decay[gi], pack.a_log, pack.dt_bias, hv,
+                                         p.gate_activation)
+                        : 0.0f;
+        be = pack.beta != nullptr ? EffectiveBeta(pack.beta[gi], p.beta_activation) : 1.0f;
+        if (!needs_retrieval) be = pack.beta != nullptr ? be : 1.0f;
+      }
+      s.gc[tid] = g;
+      s.beta[tid] = be;
+    }
+    __syncthreads();
+
+    if (p.qk_l2_norm) {
+      // One warp per token row; DK=128 so each lane holds four elements.
+      for (int t = warp_id; t < BT; t += kChunkedWarps) {
+        float sq = 0.0f, sk = 0.0f;
+        for (int d = lane; d < DK; d += 32) {
+          const float qv = __half2float(s.q_h[t * L::kKh + d]);
+          const float kv = __half2float(s.k_h[t * L::kKh + d]);
+          sq += qv * qv;
+          sk += kv * kv;
+        }
+#pragma unroll
+        for (int off = 16; off > 0; off >>= 1) {
+          sq += __shfl_xor_sync(0xffffffff, sq, off);
+          sk += __shfl_xor_sync(0xffffffff, sk, off);
+        }
+        const float rq = rsqrtf(sq + 1e-12f), rk = rsqrtf(sk + 1e-12f);
+        for (int d = lane; d < DK; d += 32) {
+          s.q_h[t * L::kKh + d] = __float2half(__half2float(s.q_h[t * L::kKh + d]) * rq);
+          s.k_h[t * L::kKh + d] = __float2half(__half2float(s.k_h[t * L::kKh + d]) * rk);
+        }
+      }
+      __syncthreads();
+    }
+
+    InclusiveScanBT<BT>(s.gc, tid);
+    __syncthreads();
+    const float g_total = s.gc[BT - 1];
+
+    SmemGemm<BT, BT, DK, false, true, false>(s.t_f, L::kVf, s.k_h, L::kKh, s.k_h, L::kKh, warp_id,
+                                               lane);
+    __syncthreads();
+    for (int idx = tid; idx < BT * BT; idx += kChunkedThreads) {
+      const int t = idx / BT, sc = idx % BT;
+      const float m = (sc < t && needs_retrieval)
+                          ? s.beta[t] * s.t_f[t * L::kVf + sc] * __expf(s.gc[t] - s.gc[sc])
+                          : 0.0f;
+      s.m_h[t * L::kMh + sc] = __float2half(m);
+    }
+    __syncthreads();
+
+    BuildTriInverse<DK, BT>(s, warp_id, lane, tid);
+
+    SmemGemm<BT, kDVB, DK, false, false, false>(s.t_f, L::kVf, s.k_h, L::kKh, s.s_h, L::kVh,
+                                                 warp_id, lane);
+    __syncthreads();
+    for (int idx = tid; idx < BT * kDVB; idx += kChunkedThreads) {
+      const int t = idx / kDVB, c = idx % kDVB;
+      const float vv = __half2float(s.v_h[t * L::kVh + c]);
+      const float r = needs_retrieval ? vv - __expf(s.gc[t]) * s.t_f[t * L::kVf + c] : vv;
+      s.u_h[t * L::kVh + c] = __float2half(s.beta[t] * r);
+    }
+    __syncthreads();
+    SmemGemm<BT, kDVB, BT, false, false, false>(s.t_f, L::kVf, s.ti_h, L::kMh, s.u_h, L::kVh,
+                                                  warp_id, lane);
+    __syncthreads();
+    for (int idx = tid; idx < BT * kDVB; idx += kChunkedThreads) {
+      const int t = idx / kDVB, c = idx % kDVB;
+      s.u_h[t * L::kVh + c] = __float2half(s.t_f[t * L::kVf + c]);
+    }
+    __syncthreads();
+
+    SmemGemm<BT, BT, DK, false, true, false>(s.t_f, L::kVf, s.q_h, L::kKh, s.k_h, L::kKh, warp_id,
+                                               lane);
+    __syncthreads();
+    for (int idx = tid; idx < BT * BT; idx += kChunkedThreads) {
+      const int t = idx / BT, sc = idx % BT;
+      s.m_h[t * L::kMh + sc] = __float2half(
+          (sc <= t && t < len) ? s.t_f[t * L::kVf + sc] * __expf(s.gc[t] - s.gc[sc]) : 0.0f);
+    }
+    for (int idx = tid; idx < BT * DK; idx += kChunkedThreads) {
+      const int t = idx / DK, d = idx % DK;
+      s.k_h[t * L::kKh + d] =
+          __hmul(s.k_h[t * L::kKh + d], __float2half(__expf(g_total - s.gc[t])));
+      s.q_h[t * L::kKh + d] = __hmul(s.q_h[t * L::kKh + d], __float2half(__expf(s.gc[t])));
+    }
+    __syncthreads();
+
+    SmemGemm<BT, kDVB, BT, false, false, false>(s.t_f, L::kVf, s.m_h, L::kMh, s.u_h, L::kVh,
+                                                  warp_id, lane);
+    __syncthreads();
+    SmemGemm<BT, kDVB, DK, false, false, true>(s.t_f, L::kVf, s.q_h, L::kKh, s.s_h, L::kVh,
+                                                warp_id, lane);
+    __syncthreads();
+    for (int idx = tid; idx < BT * kDVB; idx += kChunkedThreads) {
+      const int t = idx / kDVB, c = idx % kDVB;
+      if (t < len) {
+        const int64_t tok = tok_base + chunk0 + t;
+        pack.output[tok * v_stride + hv * DV + v0 + c] =
+            (T)(p.scale * s.t_f[t * L::kVf + c]);
+      }
+    }
+
+    const float decay_all = __expf(g_total);
+    for (int idx = tid; idx < DK * kDVB; idx += kChunkedThreads) {
+      s.s_f[(idx / kDVB) * L::kVf + idx % kDVB] *= decay_all;
+    }
+    __syncthreads();
+    SmemGemm<DK, kDVB, BT, true, false, true>(s.s_f, L::kVf, s.k_h, L::kKh, s.u_h, L::kVh, warp_id,
+                                               lane);
+    __syncthreads();
+  }
+
+  if (pack.final_state != nullptr) {
+    for (int idx = tid; idx < DK * kDVB; idx += kChunkedThreads) {
+      const int r = idx / kDVB, c = idx % kDVB;
+      pack.final_state[st_off + static_cast<int64_t>(v0 + c) * DK + r] = s.s_f[r * L::kVf + c];
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Warp-specialised decode engine.
+//
+// One warp owns one (sequence, v-head, v-column); its lanes span the K axis, so each lane
+// keeps DK/32 state elements in registers. Three things fall out of that mapping:
+//
+//  * The state is V-major [.., V, K], so lanes reading consecutive k are fully coalesced.
+//    The generic kernel below walks the same buffer with consecutive threads on v, which
+//    strides every access by DK.
+//  * Both reductions (S^T k and S^T q) are over K, so they are warp shuffles. The token
+//    loop needs no __syncthreads() and no shared memory at all.
+//  * The grid is (sequences, v-heads, V/warps) instead of (sequences, v-heads), which at
+//    the Qwen3.8 geometry is 768 CTAs against 48.
+// ---------------------------------------------------------------------------
+template <int DK>
+__device__ __forceinline__ float WarpReduceK(float v) {
+#pragma unroll
+  for (int off = 16; off > 0; off >>= 1) v += __shfl_xor_sync(0xffffffff, v, off);
+  return v;
+}
+
+template <typename T, int DK, int kWarps>
+__global__ __launch_bounds__(32 * kWarps) void GatedDeltaNetDecodeWarpKernel(
+    VariantPack<T> pack, KernelParams p, int d_v) {
+  constexpr int kRegs = DK / 32;  // state elements per lane
+  const int lane = threadIdx.x;
+  const int warp = threadIdx.y;
+  const int b = blockIdx.x, hv = blockIdx.y;
+  const int col = blockIdx.z * kWarps + warp;
+  if (col >= d_v) return;
+
+  const int hq = hv * p.num_heads_q / p.num_heads_v;
+  const int hk = hv * p.num_heads_k / p.num_heads_v;
+
+  int64_t tok_base, seq_len64;
+  SequenceRange(pack.cu_seqlens, b, p.total_tokens, p.uniform_len, &tok_base, &seq_len64);
+  const int seq_len = static_cast<int>(seq_len64);
+
+  const int64_t q_stride = static_cast<int64_t>(p.num_heads_q) * DK;
+  const int64_t k_stride = static_cast<int64_t>(p.num_heads_k) * DK;
+  const int64_t v_stride = static_cast<int64_t>(p.num_heads_v) * d_v;
+  const int64_t st_off =
+      (static_cast<int64_t>(b) * p.num_heads_v + hv) * static_cast<int64_t>(d_v) * DK +
+      static_cast<int64_t>(col) * DK;
+  const int64_t slot_stride =
+      static_cast<int64_t>(p.batch) * p.num_heads_v * static_cast<int64_t>(d_v) * DK;
+
+  const bool needs_decay = pack.decay != nullptr && (p.update_rule == UpdateRule::kGated ||
+                                                     p.update_rule == UpdateRule::kGatedDelta);
+  const bool needs_retrieval =
+      p.update_rule == UpdateRule::kDelta || p.update_rule == UpdateRule::kGatedDelta;
+  const bool decay_per_key_dim = p.decay_per_key_dim_flag != 0;
+
+  // Read the whole incoming row before writing anything: initial_state and final_state are
+  // permitted to be the same allocation. Lane l takes k = l, l+32, ... rather than a
+  // contiguous run: each of the kRegs accesses is then its own fully coalesced warp
+  // transaction, and the extra requests in flight beat the single wide float4 a contiguous
+  // run would allow (measured 5.86 us against 6.37 us at the Qwen3.8 decode shape).
+  float s[kRegs];
+#pragma unroll
+  for (int i = 0; i < kRegs; ++i) {
+    const int k = lane + i * 32;
+    s[i] = pack.initial_state != nullptr ? pack.initial_state[st_off + k] : 0.0f;
+  }
+
+  for (int t = 0; t < seq_len; ++t) {
+    const int64_t tok = tok_base + t;
+    const int64_t gi = tok * p.num_heads_v + hv;
+
+    float kv[kRegs], qv[kRegs];
+#pragma unroll
+    for (int i = 0; i < kRegs; ++i) {
+      const int k = lane + i * 32;
+      kv[i] = static_cast<float>(pack.key[tok * k_stride + hk * DK + k]);
+      qv[i] = static_cast<float>(pack.query[tok * q_stride + hq * DK + k]);
+    }
+
+    if (p.qk_l2_norm) {
+      float nq = 0.0f, nk = 0.0f;
+#pragma unroll
+      for (int i = 0; i < kRegs; ++i) {
+        nq += qv[i] * qv[i];
+        nk += kv[i] * kv[i];
+      }
+      const float rq = rsqrtf(WarpReduceK<DK>(nq) + 1e-12f);
+      const float rk = rsqrtf(WarpReduceK<DK>(nk) + 1e-12f);
+#pragma unroll
+      for (int i = 0; i < kRegs; ++i) {
+        qv[i] *= rq;
+        kv[i] *= rk;
+      }
+    }
+
+    float decay_scalar = 1.0f;
+    if (needs_decay && !decay_per_key_dim) {
+      decay_scalar = __expf(
+          EffectiveDecay(pack.decay[gi], pack.a_log, pack.dt_bias, hv, p.gate_activation));
+    }
+#pragma unroll
+    for (int i = 0; i < kRegs; ++i) {
+      if (needs_decay && decay_per_key_dim) {
+        const int k = lane + i * 32;
+        const float raw = pack.decay[(tok * p.num_heads_v + hv) * DK + k];
+        s[i] *= __expf(EffectiveDecay(raw, pack.a_log, pack.dt_bias, hv, p.gate_activation));
+      } else {
+        s[i] *= decay_scalar;
+      }
+    }
+
+    float r = 0.0f;
+    if (needs_retrieval) {
+#pragma unroll
+      for (int i = 0; i < kRegs; ++i) r += s[i] * kv[i];
+      r = WarpReduceK<DK>(r);
+    }
+
+    const float beta_t =
+        pack.beta != nullptr ? EffectiveBeta(pack.beta[gi], p.beta_activation) : 1.0f;
+    const float vv = static_cast<float>(pack.value[tok * v_stride + hv * d_v + col]);
+    const float delta = beta_t * (vv - r);
+
+    float o = 0.0f;
+#pragma unroll
+    for (int i = 0; i < kRegs; ++i) {
+      s[i] += kv[i] * delta;
+      o += s[i] * qv[i];
+    }
+    o = WarpReduceK<DK>(o);
+    if (lane == 0) {
+      pack.output[tok * v_stride + hv * d_v + col] = static_cast<T>(p.scale * o);
+    }
+
+    // Checkpoint j is the state after local token j; slots this call does not write are
+    // left unspecified because the buffer may alias live state.
+    if (pack.checkpoints != nullptr && t < p.state_checkpoints) {
+#pragma unroll
+      for (int i = 0; i < kRegs; ++i) {
+        pack.checkpoints[static_cast<int64_t>(t) * slot_stride + st_off + lane + i * 32] = s[i];
+      }
+    }
+  }
+
+  if (pack.final_state != nullptr) {
+#pragma unroll
+    for (int i = 0; i < kRegs; ++i) {
+      pack.final_state[st_off + lane + i * 32] = s[i];
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Generic recurrent engine: any head geometry the warp kernel cannot take.
+// One CTA per (sequence, v-head); the [DK x DV] state lives in shared memory.
+// ---------------------------------------------------------------------------
+template <typename T, int kThreads>
+__global__ __launch_bounds__(kThreads) void GatedDeltaNetRecurrentKernel(VariantPack<T> pack,
+                                                                        KernelParams p, int d_k,
+                                                                        int d_v) {
+  extern __shared__ float rsmem[];
+  float* S = rsmem;              // [d_k][d_v]
+  float* kbuf = S + d_k * d_v;   // [d_k]
+  float* qbuf = kbuf + d_k;      // [d_k]
+  float* rbuf = qbuf + d_k;      // [d_v]
+  float* gbuf = rbuf + d_v;      // [d_k] per-key-dim decay
+
+  const int b = blockIdx.x, hv = blockIdx.y;
+  const int tid = threadIdx.x;
+  const int hq = hv * p.num_heads_q / p.num_heads_v;
+  const int hk = hv * p.num_heads_k / p.num_heads_v;
+
+  int64_t tok_base, seq_len64;
+  SequenceRange(pack.cu_seqlens, b, p.total_tokens, p.uniform_len, &tok_base, &seq_len64);
+  const int seq_len = static_cast<int>(seq_len64);
+
+  const int64_t q_stride = static_cast<int64_t>(p.num_heads_q) * d_k;
+  const int64_t k_stride = static_cast<int64_t>(p.num_heads_k) * d_k;
+  const int64_t v_stride = static_cast<int64_t>(p.num_heads_v) * d_v;
+  const int64_t st_off = (static_cast<int64_t>(b) * p.num_heads_v + hv) *
+                         static_cast<int64_t>(d_v) * d_k;
+  const int64_t slot_stride = static_cast<int64_t>(p.batch) * p.num_heads_v * d_v * d_k;
+
+  const bool needs_decay = pack.decay != nullptr &&
+                           (p.update_rule == UpdateRule::kGated ||
+                            p.update_rule == UpdateRule::kGatedDelta);
+  const bool needs_retrieval =
+      p.update_rule == UpdateRule::kDelta || p.update_rule == UpdateRule::kGatedDelta;
+  const bool decay_per_key_dim = p.decay_per_key_dim_flag != 0;
+
+  // Read the whole incoming state before anything is written back: initial_state and
+  // final_state are permitted to be the same allocation.
+  for (int idx = tid; idx < d_k * d_v; idx += kThreads) {
+    const int r = idx / d_v, c = idx % d_v;
+    S[idx] = pack.initial_state != nullptr
+                 ? pack.initial_state[st_off + static_cast<int64_t>(c) * d_k + r]
+                 : 0.0f;
+  }
+  __syncthreads();
+
+  for (int t = 0; t < seq_len; ++t) {
+    const int64_t tok = tok_base + t;
+    const int64_t gi = tok * p.num_heads_v + hv;
+
+    for (int i = tid; i < d_k; i += kThreads) {
+      kbuf[i] = (float)pack.key[tok * k_stride + hk * d_k + i];
+      qbuf[i] = (float)pack.query[tok * q_stride + hq * d_k + i];
+    }
+    if (needs_decay && decay_per_key_dim) {
+      for (int i = tid; i < d_k; i += kThreads) {
+        const float raw = pack.decay[(tok * p.num_heads_v + hv) * d_k + i];
+        gbuf[i] = __expf(EffectiveDecay(raw, pack.a_log, pack.dt_bias, hv, p.gate_activation));
+      }
+    }
+    __syncthreads();
+
+    if (p.qk_l2_norm) {
+      if (tid == 0) {
+        float sq = 0.0f, sk = 0.0f;
+        for (int i = 0; i < d_k; ++i) {
+          sq += qbuf[i] * qbuf[i];
+          sk += kbuf[i] * kbuf[i];
+        }
+        rbuf[0] = rsqrtf(sq + 1e-12f);
+        rbuf[1] = rsqrtf(sk + 1e-12f);
+      }
+      __syncthreads();
+      const float rq = rbuf[0], rk = rbuf[1];
+      for (int i = tid; i < d_k; i += kThreads) {
+        qbuf[i] *= rq;
+        kbuf[i] *= rk;
+      }
+      __syncthreads();
+    }
+
+    const float g_scalar =
+        (needs_decay && !decay_per_key_dim)
+            ? __expf(EffectiveDecay(pack.decay[gi], pack.a_log, pack.dt_bias, hv,
+                                    p.gate_activation))
+            : 1.0f;
+    const float beta_t =
+        pack.beta != nullptr ? EffectiveBeta(pack.beta[gi], p.beta_activation) : 1.0f;
+
+    // Decay, then retrieval against the decayed state.
+    for (int idx = tid; idx < d_k * d_v; idx += kThreads) {
+      const int r = idx / d_v;
+      S[idx] *= decay_per_key_dim ? gbuf[r] : g_scalar;
+    }
+    __syncthreads();
+
+    for (int c = tid; c < d_v; c += kThreads) {
+      float acc = 0.0f;
+      if (needs_retrieval) {
+        for (int r = 0; r < d_k; ++r) acc += S[r * d_v + c] * kbuf[r];
+      }
+      const float vv = (float)pack.value[tok * v_stride + hv * d_v + c];
+      rbuf[c] = beta_t * (vv - acc);
+    }
+    __syncthreads();
+
+    for (int idx = tid; idx < d_k * d_v; idx += kThreads) {
+      const int r = idx / d_v, c = idx % d_v;
+      S[idx] += kbuf[r] * rbuf[c];
+    }
+    __syncthreads();
+
+    for (int c = tid; c < d_v; c += kThreads) {
+      float acc = 0.0f;
+      for (int r = 0; r < d_k; ++r) acc += S[r * d_v + c] * qbuf[r];
+      pack.output[tok * v_stride + hv * d_v + c] = (T)(p.scale * acc);
+    }
+
+    // Checkpoint j is the state after local token j. Slots this call does not write are
+    // left unspecified on purpose: the buffer may alias live state.
+    if (pack.checkpoints != nullptr && t < p.state_checkpoints) {
+      for (int idx = tid; idx < d_k * d_v; idx += kThreads) {
+        const int r = idx / d_v, c = idx % d_v;
+        pack.checkpoints[static_cast<int64_t>(t) * slot_stride + st_off +
+                         static_cast<int64_t>(c) * d_k + r] = S[idx];
+      }
+    }
+    __syncthreads();
+  }
+
+  if (pack.final_state != nullptr) {
+    for (int idx = tid; idx < d_k * d_v; idx += kThreads) {
+      const int r = idx / d_v, c = idx % d_v;
+      pack.final_state[st_off + static_cast<int64_t>(c) * d_k + r] = S[idx];
+    }
+  }
+}
+
+// Raise the opt-in shared-memory maximum once per (device, kernel) to the device limit.
+// Setting it per call to the current request lets a concurrent smaller launch lower the
+// bound underneath a larger one.
+template <typename KernelT>
+Status SetMaxDynamicSmemOnce(KernelT kernel, size_t device_max, std::once_flag& flag) {
+  Status status = Status::OK();
+  std::call_once(flag, [&]() {
+    cudaError_t err = cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize,
+                                           static_cast<int>(device_max));
+    if (err != cudaSuccess) {
+      status = ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "GatedDeltaNet: cudaFuncSetAttribute failed: ",
+                               cudaGetErrorString(err));
+    }
+  });
+  return status;
+}
+
+}  // namespace
+
+template <typename T>
+Status LaunchGatedDeltaNet(const Descriptor& desc, const Plan& plan, const VariantPack<T>& pack,
+                           float scale, int max_threads_per_block, cudaStream_t stream) {
+  KernelParams p{};
+  p.total_tokens = desc.total_tokens;
+  p.uniform_len = desc.batch > 0 ? desc.total_tokens / desc.batch : 0;
+  p.num_heads_q = desc.num_heads_q;
+  p.num_heads_k = desc.num_heads_k;
+  p.num_heads_v = desc.num_heads_v;
+  p.scale = scale;
+  p.gate_activation = desc.gate_activation;
+  p.beta_activation = desc.beta_activation;
+  p.update_rule = desc.update_rule;
+  p.qk_l2_norm = desc.qk_l2_norm;
+  p.state_checkpoints = desc.state_checkpoints;
+  p.batch = desc.batch;
+  p.decay_per_key_dim_flag = desc.decay_per_key_dim ? 1 : 0;
+
+  if (plan.engine == Engine::kChunked) {
+    const dim3 grid(desc.batch, desc.num_heads_v, desc.head_size_v / kDVB);
+    // BT=32 halves the [BT x BT] and per-token tiles, which is what lets the chunked
+    // engine fit devices with a 99 KB opt-in limit (SM120) instead of SM90's 227 KB.
+    if (plan.chunk_size == 32) {
+      static std::once_flag once32;
+      ORT_RETURN_IF_ERROR(SetMaxDynamicSmemOnce(GatedDeltaNetChunkedKernel<T, 128, 128, 32>,
+                                                plan.smem_bytes, once32));
+      GatedDeltaNetChunkedKernel<T, 128, 128, 32>
+          <<<grid, kChunkedThreads, plan.smem_bytes, stream>>>(pack, p);
+    } else {
+      static std::once_flag once64;
+      ORT_RETURN_IF_ERROR(SetMaxDynamicSmemOnce(GatedDeltaNetChunkedKernel<T, 128, 128, 64>,
+                                                plan.smem_bytes, once64));
+      GatedDeltaNetChunkedKernel<T, 128, 128, 64>
+          <<<grid, kChunkedThreads, plan.smem_bytes, stream>>>(pack, p);
+    }
+    return CUDA_CALL(cudaGetLastError());
+  }
+
+  constexpr int kRecurrentThreads = 256;
+  constexpr int kDecodeWarps = kRecurrentThreads / 32;
+
+  if (plan.warp_specialized) {
+    const dim3 grid(desc.batch, desc.num_heads_v,
+                    (desc.head_size_v + kDecodeWarps - 1) / kDecodeWarps);
+    const dim3 block(32, kDecodeWarps, 1);
+    switch (desc.head_size_qk) {
+      case 64:
+        GatedDeltaNetDecodeWarpKernel<T, 64, kDecodeWarps>
+            <<<grid, block, 0, stream>>>(pack, p, desc.head_size_v);
+        break;
+      case 128:
+        GatedDeltaNetDecodeWarpKernel<T, 128, kDecodeWarps>
+            <<<grid, block, 0, stream>>>(pack, p, desc.head_size_v);
+        break;
+      default:
+        GatedDeltaNetDecodeWarpKernel<T, 256, kDecodeWarps>
+            <<<grid, block, 0, stream>>>(pack, p, desc.head_size_v);
+        break;
+    }
+    return CUDA_CALL(cudaGetLastError());
+  }
+
+  const size_t smem =
+      sizeof(float) * (static_cast<size_t>(desc.head_size_qk) * desc.head_size_v +
+                       2 * desc.head_size_qk + desc.head_size_v + desc.head_size_qk);
+  static std::once_flag once_rec;
+  ORT_RETURN_IF_ERROR(
+      SetMaxDynamicSmemOnce(GatedDeltaNetRecurrentKernel<T, kRecurrentThreads>, smem, once_rec));
+  const dim3 grid(desc.batch, desc.num_heads_v, 1);
+  GatedDeltaNetRecurrentKernel<T, kRecurrentThreads>
+      <<<grid, kRecurrentThreads, smem, stream>>>(pack, p, desc.head_size_qk, desc.head_size_v);
+  (void)max_threads_per_block;
+  return CUDA_CALL(cudaGetLastError());
+}
+
+template Status LaunchGatedDeltaNet<float>(const Descriptor&, const Plan&, const VariantPack<float>&,
+                                           float, int, cudaStream_t);
+template Status LaunchGatedDeltaNet<half>(const Descriptor&, const Plan&, const VariantPack<half>&,
+                                          float, int, cudaStream_t);
+
+}  // namespace gated_delta_net
+}  // namespace cuda
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cuda/bert/gated_delta_net_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/gated_delta_net_impl.cu
@@ -688,7 +688,7 @@ Status LaunchGatedDeltaNet(const Descriptor& desc, const Plan& plan, const Varia
 }
 
 template Status LaunchGatedDeltaNet<float>(const Descriptor&, const Plan&, const VariantPack<float>&,
-                                          float, int, size_t, cudaStream_t);
+                                           float, int, size_t, cudaStream_t);
 template Status LaunchGatedDeltaNet<half>(const Descriptor&, const Plan&, const VariantPack<half>&,
                                           float, int, size_t, cudaStream_t);
 

--- a/onnxruntime/contrib_ops/cuda/bert/gated_delta_net_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/gated_delta_net_impl.cu
@@ -262,20 +262,33 @@ __device__ __forceinline__ ChunkedSmem<DK, BT> CarveChunked(char* raw) {
   using L = Ld<DK, BT>;
   ChunkedSmem<DK, BT> s;
   float* f = reinterpret_cast<float*>(raw);
-  s.s_f = f;  f += DK * L::kVf;
-  s.t_f = f;  f += BT * L::kVf;
-  s.gc = f;   f += BT;
-  s.beta = f; f += BT;
+  s.s_f = f;
+  f += DK * L::kVf;
+  s.t_f = f;
+  f += BT * L::kVf;
+  s.gc = f;
+  f += BT;
+  s.beta = f;
+  f += BT;
   __half* h = reinterpret_cast<__half*>(f);
-  s.k_h = h;  h += BT * L::kKh;
-  s.q_h = h;  h += BT * L::kKh;
-  s.v_h = h;  h += BT * L::kVh;
-  s.u_h = h;  h += BT * L::kVh;
-  s.m_h = h;  h += BT * L::kMh;
-  s.s_h = h;  h += DK * L::kVh;
-  s.db_h = h; h += BT * L::kMh;
-  s.nb_h = h; h += BT * L::kMh;
-  s.ti_h = h; h += BT * L::kMh;
+  s.k_h = h;
+  h += BT * L::kKh;
+  s.q_h = h;
+  h += BT * L::kKh;
+  s.v_h = h;
+  h += BT * L::kVh;
+  s.u_h = h;
+  h += BT * L::kVh;
+  s.m_h = h;
+  h += BT * L::kMh;
+  s.s_h = h;
+  h += DK * L::kVh;
+  s.db_h = h;
+  h += BT * L::kMh;
+  s.nb_h = h;
+  h += BT * L::kMh;
+  s.ti_h = h;
+  h += BT * L::kMh;
   return s;
 }
 
@@ -312,7 +325,7 @@ __device__ __forceinline__ void BuildTriInverse(const ChunkedSmem<DK, BT>& s, in
   __syncthreads();
 
   SmemGemm<BT, BT, BT, false, false, false>(s.t_f, L::kVf, s.db_h, L::kMh, s.m_h, L::kMh,
-                                               warp_id, lane);
+                                            warp_id, lane);
   __syncthreads();
   for (int idx = tid; idx < BT * BT; idx += kChunkedThreads) {
     const int r = idx / BT, c = idx % BT;
@@ -328,7 +341,7 @@ __device__ __forceinline__ void BuildTriInverse(const ChunkedSmem<DK, BT>& s, in
 #pragma unroll
   for (int it = 0; it < BT / 16 - 2; ++it) {
     SmemGemm<BT, BT, BT, false, false, false>(s.t_f, L::kVf, s.nb_h, L::kMh, s.ti_h, L::kMh,
-                                                 warp_id, lane);
+                                              warp_id, lane);
     __syncthreads();
     for (int idx = tid; idx < BT * BT; idx += kChunkedThreads) {
       const int r = idx / BT, c = idx % BT;
@@ -338,7 +351,7 @@ __device__ __forceinline__ void BuildTriInverse(const ChunkedSmem<DK, BT>& s, in
   }
 
   SmemGemm<BT, BT, BT, false, false, false>(s.t_f, L::kVf, s.ti_h, L::kMh, s.db_h, L::kMh,
-                                               warp_id, lane);
+                                            warp_id, lane);
   __syncthreads();
   for (int idx = tid; idx < BT * BT; idx += kChunkedThreads) {
     const int r = idx / BT, c = idx % BT;
@@ -484,7 +497,7 @@ __global__ __launch_bounds__(kChunkedThreads) void GatedDeltaNetChunkedKernel(
     const float g_total = s.gc[BT - 1];
 
     SmemGemm<BT, BT, DK, false, true, false>(s.t_f, L::kVf, s.k_h, L::kKh, s.k_h, L::kKh, warp_id,
-                                               lane);
+                                             lane);
     __syncthreads();
     for (int idx = tid; idx < BT * BT; idx += kChunkedThreads) {
       const int t = idx / BT, sc = idx % BT;
@@ -498,7 +511,7 @@ __global__ __launch_bounds__(kChunkedThreads) void GatedDeltaNetChunkedKernel(
     BuildTriInverse<DK, BT>(s, warp_id, lane, tid);
 
     SmemGemm<BT, kDVB, DK, false, false, false>(s.t_f, L::kVf, s.k_h, L::kKh, s.s_h, L::kVh,
-                                                 warp_id, lane);
+                                                warp_id, lane);
     __syncthreads();
     for (int idx = tid; idx < BT * kDVB; idx += kChunkedThreads) {
       const int t = idx / kDVB, c = idx % kDVB;
@@ -508,7 +521,7 @@ __global__ __launch_bounds__(kChunkedThreads) void GatedDeltaNetChunkedKernel(
     }
     __syncthreads();
     SmemGemm<BT, kDVB, BT, false, false, false>(s.t_f, L::kVf, s.ti_h, L::kMh, s.u_h, L::kVh,
-                                                  warp_id, lane);
+                                                warp_id, lane);
     __syncthreads();
     for (int idx = tid; idx < BT * kDVB; idx += kChunkedThreads) {
       const int t = idx / kDVB, c = idx % kDVB;
@@ -517,7 +530,7 @@ __global__ __launch_bounds__(kChunkedThreads) void GatedDeltaNetChunkedKernel(
     __syncthreads();
 
     SmemGemm<BT, BT, DK, false, true, false>(s.t_f, L::kVf, s.q_h, L::kKh, s.k_h, L::kKh, warp_id,
-                                               lane);
+                                             lane);
     __syncthreads();
     for (int idx = tid; idx < BT * BT; idx += kChunkedThreads) {
       const int t = idx / BT, sc = idx % BT;
@@ -533,10 +546,10 @@ __global__ __launch_bounds__(kChunkedThreads) void GatedDeltaNetChunkedKernel(
     __syncthreads();
 
     SmemGemm<BT, kDVB, BT, false, false, false>(s.t_f, L::kVf, s.m_h, L::kMh, s.u_h, L::kVh,
-                                                  warp_id, lane);
+                                                warp_id, lane);
     __syncthreads();
     SmemGemm<BT, kDVB, DK, false, false, true>(s.t_f, L::kVf, s.q_h, L::kKh, s.s_h, L::kVh,
-                                                warp_id, lane);
+                                               warp_id, lane);
     __syncthreads();
     for (int idx = tid; idx < BT * kDVB; idx += kChunkedThreads) {
       const int t = idx / kDVB, c = idx % kDVB;
@@ -553,7 +566,7 @@ __global__ __launch_bounds__(kChunkedThreads) void GatedDeltaNetChunkedKernel(
     }
     __syncthreads();
     SmemGemm<DK, kDVB, BT, true, false, true>(s.s_f, L::kVf, s.k_h, L::kKh, s.u_h, L::kVh, warp_id,
-                                               lane);
+                                              lane);
     __syncthreads();
   }
 
@@ -721,14 +734,14 @@ __global__ __launch_bounds__(32 * kWarps) void GatedDeltaNetDecodeWarpKernel(
 // ---------------------------------------------------------------------------
 template <typename T, int kThreads>
 __global__ __launch_bounds__(kThreads) void GatedDeltaNetRecurrentKernel(VariantPack<T> pack,
-                                                                        KernelParams p, int d_k,
-                                                                        int d_v) {
+                                                                         KernelParams p, int d_k,
+                                                                         int d_v) {
   extern __shared__ float rsmem[];
-  float* S = rsmem;              // [d_k][d_v]
-  float* kbuf = S + d_k * d_v;   // [d_k]
-  float* qbuf = kbuf + d_k;      // [d_k]
-  float* rbuf = qbuf + d_k;      // [d_v]
-  float* gbuf = rbuf + d_v;      // [d_k] per-key-dim decay
+  float* S = rsmem;             // [d_k][d_v]
+  float* kbuf = S + d_k * d_v;  // [d_k]
+  float* qbuf = kbuf + d_k;     // [d_k]
+  float* rbuf = qbuf + d_k;     // [d_v]
+  float* gbuf = rbuf + d_v;     // [d_k] per-key-dim decay
 
   const int b = blockIdx.x, hv = blockIdx.y;
   const int tid = threadIdx.x;

--- a/onnxruntime/contrib_ops/cuda/bert/gated_delta_net_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/gated_delta_net_impl.cu
@@ -710,12 +710,14 @@ __global__ __launch_bounds__(32 * kWarps) void GatedDeltaNetDecodeWarpKernel(
       pack.output[tok * v_stride + hv * d_v + col] = static_cast<T>(p.scale * o);
     }
 
-    // Checkpoint j is the state after local token j; slots this call does not write are
-    // left unspecified because the buffer may alias live state.
-    if (pack.checkpoints != nullptr && t < p.state_checkpoints) {
+    // Checkpoints are right-aligned: the last slot holds the state after the final token, so
+    // slot W-1-k is the state after the k-th token from the end. Slots this call does not
+    // write are left unspecified because the buffer may alias live state.
+    const int slot = t + p.state_checkpoints - seq_len;
+    if (pack.checkpoints != nullptr && slot >= 0) {
 #pragma unroll
       for (int i = 0; i < kRegs; ++i) {
-        pack.checkpoints[static_cast<int64_t>(t) * slot_stride + st_off + lane + i * 32] = s[i];
+        pack.checkpoints[static_cast<int64_t>(slot) * slot_stride + st_off + lane + i * 32] = s[i];
       }
     }
   }
@@ -848,12 +850,14 @@ __global__ __launch_bounds__(kThreads) void GatedDeltaNetRecurrentKernel(Variant
       pack.output[tok * v_stride + hv * d_v + c] = (T)(p.scale * acc);
     }
 
-    // Checkpoint j is the state after local token j. Slots this call does not write are
-    // left unspecified on purpose: the buffer may alias live state.
-    if (pack.checkpoints != nullptr && t < p.state_checkpoints) {
+    // Checkpoints are right-aligned: the last slot holds the state after the final token.
+    // Slots this call does not write are left unspecified on purpose: the buffer may alias
+    // live state.
+    const int slot = t + p.state_checkpoints - seq_len;
+    if (pack.checkpoints != nullptr && slot >= 0) {
       for (int idx = tid; idx < d_k * d_v; idx += kThreads) {
         const int r = idx / d_v, c = idx % d_v;
-        pack.checkpoints[static_cast<int64_t>(t) * slot_stride + st_off +
+        pack.checkpoints[static_cast<int64_t>(slot) * slot_stride + st_off +
                          static_cast<int64_t>(c) * d_k + r] = S[idx];
       }
     }

--- a/onnxruntime/contrib_ops/cuda/bert/gated_delta_net_impl.h
+++ b/onnxruntime/contrib_ops/cuda/bert/gated_delta_net_impl.h
@@ -17,18 +17,18 @@ namespace gated_delta_net {
 // Device pointers bound at execute time. The analogue of a cuDNN variant pack.
 template <typename T>
 struct VariantPack {
-  const T* query = nullptr;          // [total_tokens, Hq, K]
-  const T* key = nullptr;            // [total_tokens, Hk, K]
-  const T* value = nullptr;          // [total_tokens, Hv, V]
-  const int32_t* cu_seqlens = nullptr;  // [B+1] or null for uniform packing
-  const float* decay = nullptr;      // [total_tokens, Hv] or [total_tokens, Hv, K]
-  const float* beta = nullptr;       // [total_tokens, Hv]
+  const T* query = nullptr;              // [total_tokens, Hq, K]
+  const T* key = nullptr;                // [total_tokens, Hk, K]
+  const T* value = nullptr;              // [total_tokens, Hv, V]
+  const int32_t* cu_seqlens = nullptr;   // [B+1] or null for uniform packing
+  const float* decay = nullptr;          // [total_tokens, Hv] or [total_tokens, Hv, K]
+  const float* beta = nullptr;           // [total_tokens, Hv]
   const float* initial_state = nullptr;  // [B, Hv, V, K] V-major, may alias final_state
-  const float* a_log = nullptr;      // [Hv]
-  const float* dt_bias = nullptr;    // [Hv] or [Hv, K]
-  T* output = nullptr;               // [total_tokens, max(Hq,Hv), V]
-  float* final_state = nullptr;      // [B, Hv, V, K]
-  float* checkpoints = nullptr;      // [W, B, Hv, V, K] or null
+  const float* a_log = nullptr;          // [Hv]
+  const float* dt_bias = nullptr;        // [Hv] or [Hv, K]
+  T* output = nullptr;                   // [total_tokens, max(Hq,Hv), V]
+  float* final_state = nullptr;          // [B, Hv, V, K]
+  float* checkpoints = nullptr;          // [W, B, Hv, V, K] or null
   void* workspace = nullptr;
 };
 

--- a/onnxruntime/contrib_ops/cuda/bert/gated_delta_net_impl.h
+++ b/onnxruntime/contrib_ops/cuda/bert/gated_delta_net_impl.h
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+#include "core/common/status.h"
+#include "contrib_ops/cuda/bert/gated_delta_net_plan.h"
+
+namespace onnxruntime {
+namespace contrib {
+namespace cuda {
+namespace gated_delta_net {
+
+// Device pointers bound at execute time. The analogue of a cuDNN variant pack.
+template <typename T>
+struct VariantPack {
+  const T* query = nullptr;          // [total_tokens, Hq, K]
+  const T* key = nullptr;            // [total_tokens, Hk, K]
+  const T* value = nullptr;          // [total_tokens, Hv, V]
+  const int32_t* cu_seqlens = nullptr;  // [B+1] or null for uniform packing
+  const float* decay = nullptr;      // [total_tokens, Hv] or [total_tokens, Hv, K]
+  const float* beta = nullptr;       // [total_tokens, Hv]
+  const float* initial_state = nullptr;  // [B, Hv, V, K] V-major, may alias final_state
+  const float* a_log = nullptr;      // [Hv]
+  const float* dt_bias = nullptr;    // [Hv] or [Hv, K]
+  T* output = nullptr;               // [total_tokens, max(Hq,Hv), V]
+  float* final_state = nullptr;      // [B, Hv, V, K]
+  float* checkpoints = nullptr;      // [W, B, Hv, V, K] or null
+  void* workspace = nullptr;
+};
+
+template <typename T>
+Status LaunchGatedDeltaNet(const Descriptor& desc, const Plan& plan, const VariantPack<T>& pack,
+                           float scale, int max_threads_per_block, cudaStream_t stream);
+
+}  // namespace gated_delta_net
+}  // namespace cuda
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cuda/bert/gated_delta_net_impl.h
+++ b/onnxruntime/contrib_ops/cuda/bert/gated_delta_net_impl.h
@@ -34,7 +34,8 @@ struct VariantPack {
 
 template <typename T>
 Status LaunchGatedDeltaNet(const Descriptor& desc, const Plan& plan, const VariantPack<T>& pack,
-                           float scale, int max_threads_per_block, cudaStream_t stream);
+                           float scale, int max_threads_per_block,
+                           size_t max_shared_memory_per_block, cudaStream_t stream);
 
 // Engine::kChunkedSplit. Defined in gated_delta_net_split_impl.cu; float16 only.
 template <typename T>

--- a/onnxruntime/contrib_ops/cuda/bert/gated_delta_net_impl.h
+++ b/onnxruntime/contrib_ops/cuda/bert/gated_delta_net_impl.h
@@ -36,6 +36,11 @@ template <typename T>
 Status LaunchGatedDeltaNet(const Descriptor& desc, const Plan& plan, const VariantPack<T>& pack,
                            float scale, int max_threads_per_block, cudaStream_t stream);
 
+// Engine::kChunkedSplit. Defined in gated_delta_net_split_impl.cu; float16 only.
+template <typename T>
+Status LaunchGatedDeltaNetSplit(const Descriptor& desc, const Plan& plan,
+                                const VariantPack<T>& pack, float scale, cudaStream_t stream);
+
 }  // namespace gated_delta_net
 }  // namespace cuda
 }  // namespace contrib

--- a/onnxruntime/contrib_ops/cuda/bert/gated_delta_net_mma.cuh
+++ b/onnxruntime/contrib_ops/cuda/bert/gated_delta_net_mma.cuh
@@ -1,0 +1,326 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Device-side building blocks shared by the fused chunked engine
+// (gated_delta_net_impl.cu) and the split K1/K2 engine (gated_delta_net_split_impl.cu):
+// the m16n8k16 fragment loaders, the shared-memory GEMM they drive, the within-chunk
+// decay scan, and the exact (I + M)^-1 construction.
+
+#pragma once
+
+#include <cuda_fp16.h>
+
+#include <mutex>
+
+#include "contrib_ops/cuda/bert/gated_delta_net_plan.h"
+#include "core/providers/cuda/cu_inc/common.cuh"
+#include "core/providers/cuda/cuda_common.h"
+
+namespace onnxruntime {
+namespace contrib {
+namespace cuda {
+namespace gated_delta_net {
+
+constexpr int kChunkedThreads = 512;
+constexpr int kChunkedWarps = kChunkedThreads / 32;
+
+__device__ __forceinline__ float SoftPlus(float x) {
+  // log1p(exp(x)) without overflow.
+  return x > 20.0f ? x : __logf(1.0f + __expf(x));
+}
+
+__device__ __forceinline__ float Sigmoid(float x) { return 1.0f / (1.0f + __expf(-x)); }
+
+// Resolve the [start, start+len) token range of sequence `b`, guarding malformed device
+// offsets so a bad producer cannot steer an out-of-bounds access.
+__device__ __forceinline__ void SequenceRange(const int32_t* cu_seqlens, int b, int64_t total,
+                                              int64_t uniform_len, int64_t* start, int64_t* len) {
+  if (cu_seqlens == nullptr) {
+    *start = static_cast<int64_t>(b) * uniform_len;
+    *len = uniform_len;
+  } else {
+    int64_t s = static_cast<int64_t>(cu_seqlens[b]);
+    int64_t e = static_cast<int64_t>(cu_seqlens[b + 1]);
+    s = s < 0 ? 0 : (s > total ? total : s);
+    e = e < 0 ? 0 : (e > total ? total : e);
+    *start = s;
+    *len = e > s ? e - s : 0;
+  }
+}
+
+// Effective per-token decay and beta, after the optional fused activations.
+__device__ __forceinline__ float EffectiveDecay(float raw, const float* a_log, const float* dt_bias,
+                                                int h, GateActivation act) {
+  if (act == GateActivation::kQwen) {
+    const float bias = dt_bias != nullptr ? dt_bias[h] : 0.0f;
+    const float scale = a_log != nullptr ? -__expf(a_log[h]) : -1.0f;
+    return scale * SoftPlus(raw + bias);
+  }
+  return raw;
+}
+
+__device__ __forceinline__ float EffectiveBeta(float raw, BetaActivation act) {
+  return act == BetaActivation::kSigmoid ? Sigmoid(raw) : raw;
+}
+
+// Descriptor fields the kernels read at run time; everything else is a template parameter.
+struct KernelParams {
+  int64_t total_tokens;
+  int64_t uniform_len;
+  int num_heads_q;
+  int num_heads_k;
+  int num_heads_v;
+  float scale;
+  GateActivation gate_activation;
+  BetaActivation beta_activation;
+  UpdateRule update_rule;
+  bool qk_l2_norm;
+  int state_checkpoints;
+  int batch;
+  int decay_per_key_dim_flag;
+};
+
+// ---------------------------------------------------------------------------
+// mma.sync.m16n8k16 helpers
+// ---------------------------------------------------------------------------
+__device__ __forceinline__ uint32_t PackHalf2(__half lo, __half hi) {
+  return static_cast<uint32_t>(__half_as_ushort(lo)) |
+         (static_cast<uint32_t>(__half_as_ushort(hi)) << 16);
+}
+
+__device__ __forceinline__ void MmaM16N8K16(float (&d)[4], const uint32_t (&a)[4],
+                                            const uint32_t (&b)[2]) {
+  asm volatile(
+      "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 "
+      "{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%0,%1,%2,%3};\n"
+      : "+f"(d[0]), "+f"(d[1]), "+f"(d[2]), "+f"(d[3])
+      : "r"(a[0]), "r"(a[1]), "r"(a[2]), "r"(a[3]), "r"(b[0]), "r"(b[1]));
+}
+
+// A-fragment for m16n8k16: lane l holds rows (l>>2, l>>2 + 8) and k-pairs at (l&3)*2.
+template <bool Transposed>
+__device__ __forceinline__ void LoadFragA(uint32_t (&a)[4], const __half* A, int lda, int m0,
+                                          int k0, int lane) {
+  const int gid = lane >> 2, tig = lane & 3;
+  const int r0 = m0 + gid, r1 = m0 + gid + 8;
+  const int c0 = k0 + tig * 2, c1 = k0 + tig * 2 + 8;
+  if (Transposed) {
+    a[0] = PackHalf2(A[c0 * lda + r0], A[(c0 + 1) * lda + r0]);
+    a[1] = PackHalf2(A[c0 * lda + r1], A[(c0 + 1) * lda + r1]);
+    a[2] = PackHalf2(A[c1 * lda + r0], A[(c1 + 1) * lda + r0]);
+    a[3] = PackHalf2(A[c1 * lda + r1], A[(c1 + 1) * lda + r1]);
+  } else {
+    a[0] = *reinterpret_cast<const uint32_t*>(A + r0 * lda + c0);
+    a[1] = *reinterpret_cast<const uint32_t*>(A + r1 * lda + c0);
+    a[2] = *reinterpret_cast<const uint32_t*>(A + r0 * lda + c1);
+    a[3] = *reinterpret_cast<const uint32_t*>(A + r1 * lda + c1);
+  }
+}
+
+// B-fragment for m16n8k16 (col layout): lane l holds column (l>>2) and k-pairs at (l&3)*2.
+template <bool Transposed>
+__device__ __forceinline__ void LoadFragB(uint32_t (&b)[2], const __half* B, int ldb, int k0,
+                                          int n0, int lane) {
+  const int gid = lane >> 2, tig = lane & 3;
+  const int col = n0 + gid;
+  const int r0 = k0 + tig * 2, r1 = k0 + tig * 2 + 8;
+  if (Transposed) {
+    b[0] = *reinterpret_cast<const uint32_t*>(B + col * ldb + r0);
+    b[1] = *reinterpret_cast<const uint32_t*>(B + col * ldb + r1);
+  } else {
+    b[0] = PackHalf2(B[r0 * ldb + col], B[(r0 + 1) * ldb + col]);
+    b[1] = PackHalf2(B[r1 * ldb + col], B[(r1 + 1) * ldb + col]);
+  }
+}
+
+__device__ __forceinline__ float LoadC(const float* p) { return *p; }
+__device__ __forceinline__ float LoadC(const __half* p) { return __half2float(*p); }
+__device__ __forceinline__ void StoreC(float* p, float v) { *p = v; }
+__device__ __forceinline__ void StoreC(__half* p, float v) { *p = __float2half(v); }
+
+// C[M][N] (ldc) = A[M][K] @ B[K][N] (+ c_scale * C if Accumulate).
+//
+// Each warp owns one m-tile (16 rows) and a strided subset of the n-tiles, so the A
+// fragment is loaded once per k-step and reused across every n-tile the warp owns. C may be
+// float or __half; a __half C with Accumulate lets the recurrent state be updated in place,
+// which is one rounding either way because the mma accumulator is float regardless.
+template <int M, int N, int K, bool TA, bool TB, bool Accumulate, typename CT = float,
+          int kWarps = kChunkedWarps>
+__device__ __forceinline__ void SmemGemm(CT* C, int ldc, const __half* A, int lda,
+                                         const __half* B, int ldb, int warp_id, int lane,
+                                         float c_scale = 1.0f) {
+  constexpr int kMTiles = M / 16;
+  constexpr int kNTiles = N / 8;
+  constexpr int kWarpsPerM = kWarps > kMTiles ? kWarps / kMTiles : 1;
+  constexpr int kMGroups = kWarps / kWarpsPerM;
+  constexpr int kNPerWarp = (kNTiles + kWarpsPerM - 1) / kWarpsPerM;
+
+  const int m_group = warp_id / kWarpsPerM;
+  const int n_group = warp_id % kWarpsPerM;
+  const int gid = lane >> 2, tig = lane & 3;
+
+#pragma unroll 1
+  for (int mt = m_group; mt < kMTiles; mt += kMGroups) {
+    const int m0 = mt * 16;
+    const int r0 = m0 + gid, r1 = m0 + gid + 8;
+    float acc[kNPerWarp][4];
+
+#pragma unroll
+    for (int i = 0; i < kNPerWarp; ++i) {
+      const int nt = n_group + i * kWarpsPerM;
+      if (nt < kNTiles) {
+        const int c0 = nt * 8 + tig * 2;
+        acc[i][0] = Accumulate ? c_scale * LoadC(C + r0 * ldc + c0) : 0.0f;
+        acc[i][1] = Accumulate ? c_scale * LoadC(C + r0 * ldc + c0 + 1) : 0.0f;
+        acc[i][2] = Accumulate ? c_scale * LoadC(C + r1 * ldc + c0) : 0.0f;
+        acc[i][3] = Accumulate ? c_scale * LoadC(C + r1 * ldc + c0 + 1) : 0.0f;
+      }
+    }
+
+    for (int k0 = 0; k0 < K; k0 += 16) {
+      uint32_t a[4];
+      LoadFragA<TA>(a, A, lda, m0, k0, lane);
+#pragma unroll
+      for (int i = 0; i < kNPerWarp; ++i) {
+        const int nt = n_group + i * kWarpsPerM;
+        if (nt < kNTiles) {
+          uint32_t b[2];
+          LoadFragB<TB>(b, B, ldb, k0, nt * 8, lane);
+          MmaM16N8K16(acc[i], a, b);
+        }
+      }
+    }
+
+#pragma unroll
+    for (int i = 0; i < kNPerWarp; ++i) {
+      const int nt = n_group + i * kWarpsPerM;
+      if (nt < kNTiles) {
+        const int c0 = nt * 8 + tig * 2;
+        StoreC(C + r0 * ldc + c0, acc[i][0]);
+        StoreC(C + r0 * ldc + c0 + 1, acc[i][1]);
+        StoreC(C + r1 * ldc + c0, acc[i][2]);
+        StoreC(C + r1 * ldc + c0 + 1, acc[i][3]);
+      }
+    }
+  }
+}
+
+template <int BT>
+__device__ __forceinline__ void InclusiveScanBT(float* x, int tid) {
+  static_assert(BT == 32 || BT == 64, "chunk length must be 32 or 64");
+  if (tid >= 32) return;
+  if (BT == 32) {
+    float a = x[tid];
+#pragma unroll
+    for (int off = 1; off < 32; off <<= 1) {
+      float ta = __shfl_up_sync(0xffffffff, a, off);
+      if (tid >= off) a += ta;
+    }
+    x[tid] = a;
+    return;
+  }
+  float a = x[tid], b = x[tid + 32];
+#pragma unroll
+  for (int off = 1; off < 32; off <<= 1) {
+    float ta = __shfl_up_sync(0xffffffff, a, off);
+    float tb = __shfl_up_sync(0xffffffff, b, off);
+    if (tid >= off) {
+      a += ta;
+      b += tb;
+    }
+  }
+  const float total = __shfl_sync(0xffffffff, a, 31);
+  x[tid] = a;
+  x[tid + 32] = b + total;
+}
+
+// ti = (I + m)^-1 for the strictly lower BT x BT matrix in `m`. Exact.
+//
+// (I+M)^-1 has a closed form: with Dinv the block diagonal of the four 16x16 inverses and
+// N = Dinv M (its own 16x16 diagonal blocks are exactly zero), N is strictly block lower
+// over BT/16 levels, so N^(BT/16) = 0 and (I+M)^-1 = (I - N + N^2 - ...) Dinv exactly.
+// Full BT^3 GEMMs replace the serial tiny ones. `db`, `nb` and `tf` are scratch.
+template <int BT>
+__device__ __forceinline__ void BuildTriInverse(const __half* m, int ldm, __half* db, __half* nb,
+                                                __half* ti, int ldh, float* tf, int ldf,
+                                                int warp_id, int lane, int tid) {
+  for (int idx = tid; idx < BT * BT; idx += kChunkedThreads) {
+    db[(idx / BT) * ldh + idx % BT] = __float2half(0.0f);
+  }
+  __syncthreads();
+
+  // Column `lane` of the inverse of diagonal block `warp_id`, by forward substitution.
+  // Lane-local, so no synchronisation inside.
+  if (warp_id < BT / 16 && lane < 16) {
+    const int base = warp_id * 16;
+    float col[16];
+#pragma unroll
+    for (int i = 0; i < 16; ++i) col[i] = 0.0f;
+    col[lane] = 1.0f;
+    for (int i = lane + 1; i < 16; ++i) {
+      float acc = 0.0f;
+      for (int j = lane; j < i; ++j) {
+        acc += __half2float(m[(base + i) * ldm + base + j]) * col[j];
+      }
+      col[i] = -acc;
+    }
+#pragma unroll
+    for (int i = 0; i < 16; ++i) {
+      db[(base + i) * ldh + base + lane] = __float2half(col[i]);
+    }
+  }
+  __syncthreads();
+
+  SmemGemm<BT, BT, BT, false, false, false>(tf, ldf, db, ldh, m, ldm, warp_id, lane);
+  __syncthreads();
+  for (int idx = tid; idx < BT * BT; idx += kChunkedThreads) {
+    const int r = idx / BT, c = idx % BT;
+    const bool same_block = (r >> 4) == (c >> 4);
+    const float n = same_block ? 0.0f : tf[r * ldf + c];
+    nb[r * ldh + c] = __float2half(n);
+    ti[r * ldh + c] = __float2half((r == c ? 1.0f : 0.0f) - n);  // Z1 = I - N
+  }
+  __syncthreads();
+
+  // Horner needs BT/16 - 2 steps after Z1 = I - N.
+#pragma unroll
+  for (int it = 0; it < BT / 16 - 2; ++it) {
+    SmemGemm<BT, BT, BT, false, false, false>(tf, ldf, nb, ldh, ti, ldh, warp_id, lane);
+    __syncthreads();
+    for (int idx = tid; idx < BT * BT; idx += kChunkedThreads) {
+      const int r = idx / BT, c = idx % BT;
+      ti[r * ldh + c] = __float2half((r == c ? 1.0f : 0.0f) - tf[r * ldf + c]);
+    }
+    __syncthreads();
+  }
+
+  SmemGemm<BT, BT, BT, false, false, false>(tf, ldf, ti, ldh, db, ldh, warp_id, lane);
+  __syncthreads();
+  for (int idx = tid; idx < BT * BT; idx += kChunkedThreads) {
+    const int r = idx / BT, c = idx % BT;
+    ti[r * ldh + c] = __float2half(tf[r * ldf + c]);
+  }
+  __syncthreads();
+}
+
+// Raise the opt-in shared-memory maximum once per (device, kernel) to the device limit.
+// Setting it per call to the current request lets a concurrent smaller launch lower the
+// bound underneath a larger one.
+template <typename KernelT>
+Status SetMaxDynamicSmemOnce(KernelT kernel, size_t device_max, std::once_flag& flag) {
+  Status status = Status::OK();
+  std::call_once(flag, [&]() {
+    cudaError_t err = cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize,
+                                           static_cast<int>(device_max));
+    if (err != cudaSuccess) {
+      status = ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "GatedDeltaNet: cudaFuncSetAttribute failed: ",
+                               cudaGetErrorString(err));
+    }
+  });
+  return status;
+}
+
+}  // namespace gated_delta_net
+}  // namespace cuda
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cuda/bert/gated_delta_net_plan.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/gated_delta_net_plan.cc
@@ -14,6 +14,8 @@ const char* EngineName(Engine e) {
   switch (e) {
     case Engine::kChunked:
       return "chunked";
+    case Engine::kChunkedSplit:
+      return "chunked_split";
     case Engine::kRecurrent:
       return "recurrent";
     case Engine::kCudnn:
@@ -25,6 +27,7 @@ const char* EngineName(Engine e) {
 
 Engine EngineFromName(const std::string& name) {
   if (name == "chunked") return Engine::kChunked;
+  if (name == "chunked_split") return Engine::kChunkedSplit;
   if (name == "recurrent") return Engine::kRecurrent;
   if (name == "cudnn") return Engine::kCudnn;
   return Engine::kAuto;
@@ -40,7 +43,8 @@ bool Descriptor::operator==(const Descriptor& o) const noexcept {
          qk_l2_norm == o.qk_l2_norm && decay_per_key_dim == o.decay_per_key_dim &&
          has_decay == o.has_decay && has_beta == o.has_beta &&
          has_initial_state == o.has_initial_state && ragged == o.ragged &&
-         sm_major == o.sm_major && sm_minor == o.sm_minor;
+         sm_major == o.sm_major && sm_minor == o.sm_minor &&
+         preferred_engine == o.preferred_engine;
 }
 
 size_t DescriptorHash::operator()(const Descriptor& d) const noexcept {
@@ -61,6 +65,7 @@ size_t DescriptorHash::operator()(const Descriptor& d) const noexcept {
   mix(static_cast<uint64_t>(d.gate_activation));
   mix(static_cast<uint64_t>(d.beta_activation));
   mix(static_cast<uint64_t>(d.io_type));
+  mix(static_cast<uint64_t>(d.preferred_engine));
   mix(static_cast<uint64_t>(d.sm_major) << 8 | static_cast<uint64_t>(d.sm_minor));
   mix((d.qk_l2_norm ? 1ULL : 0ULL) | (d.decay_per_key_dim ? 2ULL : 0ULL) |
       (d.has_decay ? 4ULL : 0ULL) | (d.has_beta ? 8ULL : 0ULL) |

--- a/onnxruntime/contrib_ops/cuda/bert/gated_delta_net_plan.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/gated_delta_net_plan.cc
@@ -1,0 +1,90 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "contrib_ops/cuda/bert/gated_delta_net_plan.h"
+
+#include <algorithm>
+
+namespace onnxruntime {
+namespace contrib {
+namespace cuda {
+namespace gated_delta_net {
+
+const char* EngineName(Engine e) {
+  switch (e) {
+    case Engine::kChunked:
+      return "chunked";
+    case Engine::kRecurrent:
+      return "recurrent";
+    case Engine::kCudnn:
+      return "cudnn";
+    default:
+      return "auto";
+  }
+}
+
+Engine EngineFromName(const std::string& name) {
+  if (name == "chunked") return Engine::kChunked;
+  if (name == "recurrent") return Engine::kRecurrent;
+  if (name == "cudnn") return Engine::kCudnn;
+  return Engine::kAuto;
+}
+
+bool Descriptor::operator==(const Descriptor& o) const noexcept {
+  return total_tokens == o.total_tokens && batch == o.batch && num_heads_q == o.num_heads_q &&
+         num_heads_k == o.num_heads_k && num_heads_v == o.num_heads_v &&
+         head_size_qk == o.head_size_qk && head_size_v == o.head_size_v &&
+         chunk_size == o.chunk_size && state_checkpoints == o.state_checkpoints &&
+         update_rule == o.update_rule && gate_activation == o.gate_activation &&
+         beta_activation == o.beta_activation && io_type == o.io_type &&
+         qk_l2_norm == o.qk_l2_norm && decay_per_key_dim == o.decay_per_key_dim &&
+         has_decay == o.has_decay && has_beta == o.has_beta &&
+         has_initial_state == o.has_initial_state && ragged == o.ragged &&
+         sm_major == o.sm_major && sm_minor == o.sm_minor;
+}
+
+size_t DescriptorHash::operator()(const Descriptor& d) const noexcept {
+  size_t h = 1469598103934665603ULL;
+  auto mix = [&h](uint64_t v) {
+    h ^= v + 0x9e3779b97f4a7c15ULL + (h << 6) + (h >> 2);
+  };
+  mix(static_cast<uint64_t>(d.total_tokens));
+  mix(static_cast<uint64_t>(d.batch));
+  mix(static_cast<uint64_t>(d.num_heads_q));
+  mix(static_cast<uint64_t>(d.num_heads_k));
+  mix(static_cast<uint64_t>(d.num_heads_v));
+  mix(static_cast<uint64_t>(d.head_size_qk));
+  mix(static_cast<uint64_t>(d.head_size_v));
+  mix(static_cast<uint64_t>(d.chunk_size));
+  mix(static_cast<uint64_t>(d.state_checkpoints));
+  mix(static_cast<uint64_t>(d.update_rule));
+  mix(static_cast<uint64_t>(d.gate_activation));
+  mix(static_cast<uint64_t>(d.beta_activation));
+  mix(static_cast<uint64_t>(d.io_type));
+  mix(static_cast<uint64_t>(d.sm_major) << 8 | static_cast<uint64_t>(d.sm_minor));
+  mix((d.qk_l2_norm ? 1ULL : 0ULL) | (d.decay_per_key_dim ? 2ULL : 0ULL) |
+      (d.has_decay ? 4ULL : 0ULL) | (d.has_beta ? 8ULL : 0ULL) |
+      (d.has_initial_state ? 16ULL : 0ULL) | (d.ragged ? 32ULL : 0ULL));
+  return h;
+}
+
+PlanCache& PlanCache::Instance() {
+  static PlanCache instance;
+  return instance;
+}
+
+Plan PlanCache::GetOrCreate(const Descriptor& desc, int sm_count, size_t smem_per_block_optin) {
+  std::lock_guard<std::mutex> guard(mutex_);
+  auto it = cache_.find(desc);
+  if (it != cache_.end()) {
+    return it->second;
+  }
+  Plan plan = SelectPlan(desc, sm_count, smem_per_block_optin);
+  cache_.emplace(desc, plan);
+  return plan;
+}
+
+}  // namespace gated_delta_net
+}  // namespace cuda
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cuda/bert/gated_delta_net_plan.h
+++ b/onnxruntime/contrib_ops/cuda/bert/gated_delta_net_plan.h
@@ -113,14 +113,19 @@ inline Plan SelectPlan(const Descriptor& desc, int sm_count, size_t smem_per_blo
   Plan plan;
   plan.chunk_size = desc.chunk_size > 0 ? desc.chunk_size : 64;
 
-  // Token checkpoints are a per-token series; only the sequential engine can produce them.
-  const bool needs_checkpoints = desc.state_checkpoints > 0;
+  const int64_t batch = desc.batch > 1 ? desc.batch : 1;
+
+  // Token checkpoints are a per-token series, and only the sequential engine can produce one.
+  // A request longer than the window cannot be rolled back into it anyway, so it takes the
+  // normal plan and only the committed last slot is written.
+  const bool needs_checkpoints =
+      desc.state_checkpoints > 0 &&
+      desc.total_tokens <= static_cast<int64_t>(desc.state_checkpoints) * batch;
 
   // Below the crossover the chunked engine still pays for a full chunk, so a handful of
   // tokens costs the same as 64. Measured crossover on H200 at the Qwen3.8 geometry is
   // ~30 tokens (chunked 46.5 us at T=1 against 17.9 us for a sequential recurrence).
   const int64_t kChunkedMinTokens = 32;
-  const int64_t batch = desc.batch > 1 ? desc.batch : 1;
   const bool long_enough = desc.total_tokens >= kChunkedMinTokens * batch;
 
   const bool shape_ok = desc.head_size_qk == 128 && desc.head_size_v == 128 &&

--- a/onnxruntime/contrib_ops/cuda/bert/gated_delta_net_plan.h
+++ b/onnxruntime/contrib_ops/cuda/bert/gated_delta_net_plan.h
@@ -23,12 +23,19 @@ namespace contrib {
 namespace cuda {
 namespace gated_delta_net {
 
-enum class UpdateRule : int { kLinear = 0, kGated = 1, kDelta = 2, kGatedDelta = 3 };
-enum class GateActivation : int { kNone = 0, kQwen = 1 };
-enum class BetaActivation : int { kNone = 0, kSigmoid = 1 };
+enum class UpdateRule : int { kLinear = 0,
+                              kGated = 1,
+                              kDelta = 2,
+                              kGatedDelta = 3 };
+enum class GateActivation : int { kNone = 0,
+                                  kQwen = 1 };
+enum class BetaActivation : int { kNone = 0,
+                                  kSigmoid = 1 };
 
 // Element type of the q/k/v/output tensors. The state is always float.
-enum class IoType : int { kFloat = 0, kFloat16 = 1, kBFloat16 = 2 };
+enum class IoType : int { kFloat = 0,
+                          kFloat16 = 1,
+                          kBFloat16 = 2 };
 
 enum class Engine : int {
   kAuto = 0,
@@ -75,8 +82,8 @@ struct DescriptorHash {
 struct Plan {
   Engine engine = Engine::kRecurrent;
   int chunk_size = 64;
-  int v_block = 64;      // dv columns owned by one CTA (chunked engine)
-  int threads = 512;     // CTA size
+  int v_block = 64;         // dv columns owned by one CTA (chunked engine)
+  int threads = 512;        // CTA size
   int cols_per_block = 32;  // dv columns per CTA (recurrent engine)
   // Recurrent engine only: one warp per v-column with lanes spanning K, instead of one CTA
   // per v-head with the state in shared memory.

--- a/onnxruntime/contrib_ops/cuda/bert/gated_delta_net_plan.h
+++ b/onnxruntime/contrib_ops/cuda/bert/gated_delta_net_plan.h
@@ -39,9 +39,10 @@ enum class IoType : int { kFloat = 0,
 
 enum class Engine : int {
   kAuto = 0,
-  kChunked = 1,    // tensor-core chunked scan; prefill
-  kRecurrent = 2,  // sequential per-token recurrence; decode / MTP verify, emits checkpoints
-  kCudnn = 3,      // reserved: SM100-only and C++-inaccessible today
+  kChunked = 1,       // fused tensor-core chunked scan; prefill
+  kRecurrent = 2,     // sequential per-token recurrence; decode / MTP verify, emits checkpoints
+  kCudnn = 3,         // reserved: SM100-only and C++-inaccessible today
+  kChunkedSplit = 4,  // chunked scan split into a token-parallel prepare and a state-only scan
 };
 
 const char* EngineName(Engine e);
@@ -69,6 +70,8 @@ struct Descriptor {
   bool has_beta = false;
   bool has_initial_state = false;
   bool ragged = false;  // cu_seqlens supplied
+  // Benchmarking override. kAuto lets the heuristic choose.
+  Engine preferred_engine = Engine::kAuto;
   int sm_major = 0;
   int sm_minor = 0;
 
@@ -85,10 +88,14 @@ struct Plan {
   int v_block = 64;         // dv columns owned by one CTA (chunked engine)
   int threads = 512;        // CTA size
   int cols_per_block = 32;  // dv columns per CTA (recurrent engine)
+  // Split engine only: chunks whose prepare output is live in the workspace at once. The
+  // sequence is walked in passes of this many chunks so the workspace stays bounded.
+  int chunks_per_pass = 0;
   // Recurrent engine only: one warp per v-column with lanes spanning K, instead of one CTA
   // per v-head with the state in shared memory.
   bool warp_specialized = false;
-  size_t smem_bytes = 0;
+  size_t smem_bytes = 0;          // chunked / split-scan kernel
+  size_t smem_bytes_prepare = 0;  // split-prepare kernel
   size_t workspace_bytes = 0;
   bool supported = false;
   const char* reject_reason = nullptr;
@@ -107,6 +114,38 @@ inline size_t ChunkedSmemBytes(int bt, int dk, int dvb) {
   const size_t h = sizeof(uint16_t) * static_cast<size_t>(2 * bt * ld_kh + 2 * bt * ld_vh +
                                                           4 * bt * ld_mh + dk * ld_vh);
   return f + h;
+}
+
+// Split engine. K1 holds q, k, the full-width v, and the [BT x BT] matrices of the inverse;
+// it never sees the state. The Neumann iterate shares M's tile, so three, not four.
+inline size_t SplitPrepareSmemBytes(int bt, int dk, int dv) {
+  const int ld_kh = dk + 8;
+  const int ld_vh = dv + 8;
+  const int ld_mh = bt + 8;
+  const int ld_f1 = (dv > bt ? dv : bt) + 4;
+  const size_t f = sizeof(float) * static_cast<size_t>(bt * ld_f1 + 2 * bt);
+  const size_t h =
+      sizeof(uint16_t) * static_cast<size_t>(2 * bt * ld_kh + bt * ld_vh + 3 * bt * ld_mh);
+  return f + h;
+}
+
+// K2 holds the fp16 state, W/Qg/Kd, its own v-block of U, P, and one fp32 scratch that must
+// be wide enough for the [DK x DVB] state update.
+inline size_t SplitScanSmemBytes(int bt, int dk, int dvb) {
+  const int ld_kh = dk + 8;
+  const int ld_bh = dvb + 8;
+  const int ld_mh = bt + 8;
+  const int ld_f2 = (dvb > bt ? dvb : bt) + 4;
+  const size_t f = sizeof(float) * static_cast<size_t>(dk) * ld_f2;
+  const size_t h = sizeof(uint16_t) * static_cast<size_t>(dk * ld_bh + 3 * bt * ld_kh +
+                                                          bt * ld_bh + bt * ld_mh);
+  return f + h;
+}
+
+// Workspace one (head, chunk) needs to hand K1's output to K2: W, Qg, Kd [BT x DK],
+// Uv [BT x DV] and P [BT x BT] in fp16, plus the chunk's scalar decay.
+inline size_t SplitTileBytes(int bt, int dk, int dv) {
+  return sizeof(uint16_t) * static_cast<size_t>(bt) * (3 * dk + dv + bt) + sizeof(float);
 }
 
 inline Plan SelectPlan(const Descriptor& desc, int sm_count, size_t smem_per_block_optin) {
@@ -143,6 +182,51 @@ inline Plan SelectPlan(const Descriptor& desc, int sm_count, size_t smem_per_blo
   if (!needs_checkpoints && long_enough && shape_ok && rule_ok && type_ok && desc.sm_major >= 8) {
     plan.v_block = 64;
     plan.threads = 512;
+
+    // Split engine: a token-parallel prepare launch followed by a scan that only carries
+    // the state. Opt-in for now -- it changes the state to fp16, so it does not silently
+    // take over a numerically validated deployment.
+    if (desc.preferred_engine == Engine::kChunkedSplit) {
+      const int bt = 64;
+      const size_t prep = SplitPrepareSmemBytes(bt, desc.head_size_qk, desc.head_size_v);
+      // Narrow v-blocks only pay off once the state-independent work has been hoisted out
+      // of the scan, which is what this engine does: all four of the scan's GEMMs then
+      // scale with the block width. Take the narrow block when two CTAs of it fit on an
+      // SM, since the wide one leaves the grid under a single wave at batch 1.
+      const int narrow = 32;
+      const size_t scan_narrow = SplitScanSmemBytes(bt, desc.head_size_qk, narrow);
+      const int dvb = (2 * scan_narrow <= smem_per_block_optin) ? narrow : 64;
+      const size_t scan = SplitScanSmemBytes(bt, desc.head_size_qk, dvb);
+      if (prep <= smem_per_block_optin && scan <= smem_per_block_optin) {
+        plan.engine = Engine::kChunkedSplit;
+        plan.chunk_size = bt;
+        plan.v_block = dvb;
+        plan.smem_bytes = scan;
+        plan.smem_bytes_prepare = prep;
+        // Cap the live prepare output so a long sequence walks in passes instead of asking
+        // for a workspace proportional to its length.
+        const size_t tile = SplitTileBytes(bt, desc.head_size_qk, desc.head_size_v);
+        const size_t per_chunk = tile * static_cast<size_t>(batch) * desc.num_heads_v;
+        const int64_t longest = (desc.total_tokens + batch - 1) / batch;
+        const int total_chunks = static_cast<int>((longest + bt - 1) / bt);
+        const size_t kWorkspaceCap = 64u << 20;
+        int per_pass = static_cast<int>(kWorkspaceCap / (per_chunk > 0 ? per_chunk : 1));
+        per_pass = per_pass < 1 ? 1 : per_pass;
+        per_pass = per_pass > total_chunks ? total_chunks : per_pass;
+        plan.chunks_per_pass = per_pass;
+        plan.workspace_bytes = per_chunk * static_cast<size_t>(per_pass);
+        if (per_pass < total_chunks) {
+          // A multi-pass walk carries the state between launches through the workspace,
+          // because the caller is not obliged to have asked for final_state.
+          plan.workspace_bytes += sizeof(float) * static_cast<size_t>(batch) *
+                                  desc.num_heads_v * desc.head_size_v * desc.head_size_qk;
+        }
+        plan.supported = true;
+        return plan;
+      }
+      plan.v_block = 64;  // fall through to the fused engine
+    }
+
     // BT=64 is the fastest configuration measured on SM90 but needs 157 KB of shared
     // memory. Consumer Blackwell (SM120) allows only 99 KB per block, where BT=32 fits in
     // 96 KB for about a 10% cost. Take the widest chunk the device can actually hold; an

--- a/onnxruntime/contrib_ops/cuda/bert/gated_delta_net_plan.h
+++ b/onnxruntime/contrib_ops/cuda/bert/gated_delta_net_plan.h
@@ -1,0 +1,195 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Plan selection for GatedDeltaNet, modelled on the cuDNN frontend's execution flow:
+// a problem descriptor is hashed into a cache, a heuristic picks an engine, the engine
+// reports its workspace requirement, and execution binds a variant pack of pointers.
+//
+// cuDNN itself cannot serve as a backend here: its GDN/KDA graph nodes exist only in the
+// Python frontend (`python/cudnn/linear_attention/`, nothing in `include/`) and its FROST
+// engines refuse anything below SM100. `Engine::kCudnn` is therefore reserved, not wired.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+
+namespace onnxruntime {
+namespace contrib {
+namespace cuda {
+namespace gated_delta_net {
+
+enum class UpdateRule : int { kLinear = 0, kGated = 1, kDelta = 2, kGatedDelta = 3 };
+enum class GateActivation : int { kNone = 0, kQwen = 1 };
+enum class BetaActivation : int { kNone = 0, kSigmoid = 1 };
+
+// Element type of the q/k/v/output tensors. The state is always float.
+enum class IoType : int { kFloat = 0, kFloat16 = 1, kBFloat16 = 2 };
+
+enum class Engine : int {
+  kAuto = 0,
+  kChunked = 1,    // tensor-core chunked scan; prefill
+  kRecurrent = 2,  // sequential per-token recurrence; decode / MTP verify, emits checkpoints
+  kCudnn = 3,      // reserved: SM100-only and C++-inaccessible today
+};
+
+const char* EngineName(Engine e);
+Engine EngineFromName(const std::string& name);
+
+// Everything that can change the generated code or the launch geometry. Two calls with
+// equal descriptors may share a plan.
+struct Descriptor {
+  int64_t total_tokens = 0;
+  int batch = 0;
+  int num_heads_q = 0;
+  int num_heads_k = 0;
+  int num_heads_v = 0;
+  int head_size_qk = 0;
+  int head_size_v = 0;
+  int chunk_size = 64;
+  int state_checkpoints = 0;
+  UpdateRule update_rule = UpdateRule::kGatedDelta;
+  GateActivation gate_activation = GateActivation::kNone;
+  BetaActivation beta_activation = BetaActivation::kNone;
+  IoType io_type = IoType::kFloat16;
+  bool qk_l2_norm = false;
+  bool decay_per_key_dim = false;
+  bool has_decay = false;
+  bool has_beta = false;
+  bool has_initial_state = false;
+  bool ragged = false;  // cu_seqlens supplied
+  int sm_major = 0;
+  int sm_minor = 0;
+
+  bool operator==(const Descriptor& o) const noexcept;
+};
+
+struct DescriptorHash {
+  size_t operator()(const Descriptor& d) const noexcept;
+};
+
+struct Plan {
+  Engine engine = Engine::kRecurrent;
+  int chunk_size = 64;
+  int v_block = 64;      // dv columns owned by one CTA (chunked engine)
+  int threads = 512;     // CTA size
+  int cols_per_block = 32;  // dv columns per CTA (recurrent engine)
+  // Recurrent engine only: one warp per v-column with lanes spanning K, instead of one CTA
+  // per v-head with the state in shared memory.
+  bool warp_specialized = false;
+  size_t smem_bytes = 0;
+  size_t workspace_bytes = 0;
+  bool supported = false;
+  const char* reject_reason = nullptr;
+};
+
+// The analogue of cudnn's heuristic mode A. Pure arithmetic on the descriptor and the
+// device limits, so it is defined here: tests can then exercise the architecture-dependent
+// choices -- notably the consumer-Blackwell shared-memory budget -- without linking the
+// provider module or owning that hardware.
+inline size_t ChunkedSmemBytes(int bt, int dk, int dvb) {
+  const int ld_kh = dk + 8;
+  const int ld_vh = dvb + 8;
+  const int ld_mh = bt + 8;
+  const int ld_vf = (dvb > bt ? dvb : bt) + 4;
+  const size_t f = sizeof(float) * static_cast<size_t>(dk * ld_vf + bt * ld_vf + 2 * bt);
+  const size_t h = sizeof(uint16_t) * static_cast<size_t>(2 * bt * ld_kh + 2 * bt * ld_vh +
+                                                          4 * bt * ld_mh + dk * ld_vh);
+  return f + h;
+}
+
+inline Plan SelectPlan(const Descriptor& desc, int sm_count, size_t smem_per_block_optin) {
+  Plan plan;
+  plan.chunk_size = desc.chunk_size > 0 ? desc.chunk_size : 64;
+
+  // Token checkpoints are a per-token series; only the sequential engine can produce them.
+  const bool needs_checkpoints = desc.state_checkpoints > 0;
+
+  // Below the crossover the chunked engine still pays for a full chunk, so a handful of
+  // tokens costs the same as 64. Measured crossover on H200 at the Qwen3.8 geometry is
+  // ~30 tokens (chunked 46.5 us at T=1 against 17.9 us for a sequential recurrence).
+  const int64_t kChunkedMinTokens = 32;
+  const int64_t batch = desc.batch > 1 ? desc.batch : 1;
+  const bool long_enough = desc.total_tokens >= kChunkedMinTokens * batch;
+
+  const bool shape_ok = desc.head_size_qk == 128 && desc.head_size_v == 128 &&
+                        desc.num_heads_q == desc.num_heads_k && desc.num_heads_q > 0 &&
+                        desc.num_heads_v % desc.num_heads_q == 0;
+
+  // The chunked engine folds the decay into [BT x BT] gram matrices, which assumes one
+  // scalar decay per (token, v-head). Per-key-dim decay (KDA) stays sequential.
+  const bool rule_ok = !desc.decay_per_key_dim;
+
+  // Its GEMM operands are fp16 mma fragments, so float input would be silently narrowed;
+  // float stays on the scalar engine. bfloat16 needs bf16 fragments, not yet written.
+  const bool type_ok = desc.io_type == IoType::kFloat16;
+
+  if (!needs_checkpoints && long_enough && shape_ok && rule_ok && type_ok && desc.sm_major >= 8) {
+    plan.v_block = 64;
+    plan.threads = 512;
+    // BT=64 is the fastest configuration measured on SM90 but needs 157 KB of shared
+    // memory. Consumer Blackwell (SM120) allows only 99 KB per block, where BT=32 fits in
+    // 96 KB for about a 10% cost. Take the widest chunk the device can actually hold; an
+    // explicit chunk_size of 32 pins the narrow one so that path is reachable on SM90.
+    const bool pin_narrow = desc.chunk_size == 32;
+    const int candidates[2] = {64, 32};
+    for (int bt : candidates) {
+      if (pin_narrow && bt != 32) continue;
+      const size_t bytes = ChunkedSmemBytes(bt, desc.head_size_qk, plan.v_block);
+      if (bytes <= smem_per_block_optin) {
+        plan.chunk_size = bt;
+        plan.smem_bytes = bytes;
+        plan.engine = Engine::kChunked;
+        plan.workspace_bytes = 0;  // the state never leaves shared memory
+        plan.supported = true;
+        return plan;
+      }
+    }
+    plan.reject_reason = "chunked engine exceeds the device shared-memory opt-in limit";
+  }
+
+  plan.engine = Engine::kRecurrent;
+  plan.cols_per_block = 32;
+  plan.smem_bytes = 0;
+  plan.workspace_bytes = 0;
+  plan.supported = true;
+  // The warp kernel keeps its slice of the state in registers, so it only needs a head size
+  // that divides evenly into 32-lane strips.
+  plan.warp_specialized =
+      desc.head_size_qk == 64 || desc.head_size_qk == 128 || desc.head_size_qk == 256;
+  if (plan.reject_reason == nullptr) {
+    if (needs_checkpoints) {
+      plan.reject_reason = "token checkpoints requested";
+    } else if (!long_enough) {
+      plan.reject_reason = "below the chunked-engine token threshold";
+    } else if (!shape_ok) {
+      plan.reject_reason = "unsupported head geometry";
+    } else if (!rule_ok) {
+      plan.reject_reason = "per-key-dimension decay";
+    } else if (!type_ok) {
+      plan.reject_reason = "chunked engine requires float16 input";
+    }
+  }
+  (void)sm_count;
+  return plan;
+}
+
+// Process-wide memoisation of SelectPlan, mirroring the frontend's plan cache.
+class PlanCache {
+ public:
+  static PlanCache& Instance();
+  Plan GetOrCreate(const Descriptor& desc, int sm_count, size_t smem_per_block_optin);
+
+ private:
+  std::mutex mutex_;
+  std::unordered_map<Descriptor, Plan, DescriptorHash> cache_;
+};
+
+}  // namespace gated_delta_net
+}  // namespace cuda
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cuda/bert/gated_delta_net_plan.h
+++ b/onnxruntime/contrib_ops/cuda/bert/gated_delta_net_plan.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -184,10 +185,36 @@ inline Plan SelectPlan(const Descriptor& desc, int sm_count, size_t smem_per_blo
     plan.threads = 512;
 
     // Split engine: a token-parallel prepare launch followed by a scan that only carries
-    // the state. Opt-in for now -- it changes the state to fp16, so it does not silently
-    // take over a numerically validated deployment.
-    if (desc.preferred_engine == Engine::kChunkedSplit) {
-      const int bt = 64;
+    // the state. It exists to fill a machine the fused engine leaves idle, so it is chosen
+    // on the fused engine's own wave-quantisation efficiency rather than on a shape guess.
+    //
+    // The fused grid is one CTA per (sequence, v-head, 64 v-columns), so it costs
+    // ceil(waves) waves to do `waves` waves of work. Measured on H200 (132 SMs) at the
+    // Qwen3.8 geometry, split/fused runtime tracks that efficiency and nothing else:
+    //
+    //   batch  CTAs  waves  efficiency   T=256  T=1024  T=4096
+    //     1      96   0.73     73%        0.90    0.80    0.83
+    //     2     192   1.45     73%        0.80    0.88    0.88
+    //     3     288   2.18     73%        0.85    0.91    0.90
+    //     4     384   2.91     97%        0.94    1.12    1.13
+    //     8     768   5.82     97%        1.22    1.31    1.32
+    //
+    // The fused per-token cost jumps 0.392 -> 0.298 us across that same boundary, so once
+    // the fused engine stops wasting a wave the split engine's extra launch and its
+    // round-trip through the workspace are pure overhead. Below two chunks there is no
+    // sequence to pipeline either and the extra launch dominates (T=64 measures 1.18x).
+    const int bt = 64;
+    const int64_t longest_seq = (desc.total_tokens + batch - 1) / batch;
+    const int64_t fused_ctas = batch * desc.num_heads_v * (desc.head_size_v / plan.v_block);
+    const double waves = sm_count > 0 ? static_cast<double>(fused_ctas) / sm_count : 0.0;
+    const double wave_efficiency = waves > 0.0 ? waves / std::ceil(waves) : 0.0;
+    const bool fused_underfills = sm_count > 0 && wave_efficiency < 0.85;
+    const bool long_enough_to_pipeline = longest_seq >= 2 * bt;
+
+    const bool want_split = desc.preferred_engine == Engine::kChunkedSplit ||
+                            (desc.preferred_engine != Engine::kChunked && fused_underfills &&
+                             long_enough_to_pipeline);
+    if (want_split) {
       const size_t prep = SplitPrepareSmemBytes(bt, desc.head_size_qk, desc.head_size_v);
       // Narrow v-blocks only pay off once the state-independent work has been hoisted out
       // of the scan, which is what this engine does: all four of the scan's GEMMs then
@@ -207,7 +234,7 @@ inline Plan SelectPlan(const Descriptor& desc, int sm_count, size_t smem_per_blo
         // for a workspace proportional to its length.
         const size_t tile = SplitTileBytes(bt, desc.head_size_qk, desc.head_size_v);
         const size_t per_chunk = tile * static_cast<size_t>(batch) * desc.num_heads_v;
-        const int64_t longest = (desc.total_tokens + batch - 1) / batch;
+        const int64_t longest = longest_seq;
         const int total_chunks = static_cast<int>((longest + bt - 1) / bt);
         const size_t kWorkspaceCap = 64u << 20;
         int per_pass = static_cast<int>(kWorkspaceCap / (per_chunk > 0 ? per_chunk : 1));
@@ -270,7 +297,6 @@ inline Plan SelectPlan(const Descriptor& desc, int sm_count, size_t smem_per_blo
       plan.reject_reason = "chunked engine requires float16 input";
     }
   }
-  (void)sm_count;
   return plan;
 }
 

--- a/onnxruntime/contrib_ops/cuda/bert/gated_delta_net_split_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/gated_delta_net_split_impl.cu
@@ -65,12 +65,12 @@ namespace {
 // Padded leading dimensions; see the note in gated_delta_net_impl.cu on why the +8.
 template <int DK, int DV, int BT, int DVB>
 struct SplitLd {
-  static constexpr int kKh = DK + 8;    // rows of length DK
-  static constexpr int kVh = DV + 8;    // rows of length DV
-  static constexpr int kBh = DVB + 8;   // rows of length DVB
-  static constexpr int kMh = BT + 8;    // rows of length BT
-  static constexpr int kSh = DVB + 8;   // state rows, DVB wide
-  static constexpr int kF1 = (DV > BT ? DV : BT) + 4;   // K1 fp32 scratch
+  static constexpr int kKh = DK + 8;                     // rows of length DK
+  static constexpr int kVh = DV + 8;                     // rows of length DV
+  static constexpr int kBh = DVB + 8;                    // rows of length DVB
+  static constexpr int kMh = BT + 8;                     // rows of length BT
+  static constexpr int kSh = DVB + 8;                    // state rows, DVB wide
+  static constexpr int kF1 = (DV > BT ? DV : BT) + 4;    // K1 fp32 scratch
   static constexpr int kF2 = (DVB > BT ? DVB : BT) + 4;  // K2 fp32 scratch
 };
 

--- a/onnxruntime/contrib_ops/cuda/bert/gated_delta_net_split_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/gated_delta_net_split_impl.cu
@@ -1,0 +1,531 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// GatedDeltaNet split chunked engine (K1 "prepare" + K2 "scan").
+//
+// The fused engine in gated_delta_net_impl.cu does everything for a chunk inside one CTA
+// that also carries the recurrent state, so every chunk pays for work that has nothing to
+// do with the state. Profiling that kernel on H200 at the Qwen3.8 geometry showed the cost:
+// 157.5 KB of shared memory pins it to one CTA per SM, the grid is 96 CTAs against 132 SMs
+// (0.73 waves), tensor pipes are 7.1% busy and DRAM 1.8%. It is bound by the serial
+// dependency chain inside a CTA, not by the machine. Splitting the v axis to raise the CTA
+// count made it 1.6x slower, because the state-independent half of the chunk is
+// v-invariant and simply got duplicated.
+//
+// This engine moves that half into its own launch. Starting from the chunked form
+// (derived in gated_delta_net_impl.cu) and pushing (I+M)^-1 through the subtraction:
+//
+//     U = (I+M)^-1 (Ubar - Wbar S0) = Uv - W S0,   Uv = (I+M)^-1 Ubar,  W = (I+M)^-1 Wbar
+//
+// so U's state-independent part factorises out. K1 owns one (sequence, v-head, chunk) --
+// 6144 CTAs at T=8192 instead of 96 -- and emits per chunk
+//
+//     W  = (I+M)^-1 diag(beta exp(gc)) k      [BT x DK]
+//     Uv = (I+M)^-1 (beta v)                  [BT x DV]
+//     P[t,s] = (q_t . k_s) exp(gc_t - gc_s)   [BT x BT], inclusive lower
+//     Qg = q exp(gc), Kd = k exp(gc_BT - gc)  [BT x DK]
+//     decay = exp(gc_BT)
+//
+// K2 keeps the sequence walk and the state, and is left with four GEMMs per chunk:
+//
+//     U = Uv - W S,   o = scale (P U + Qg S),   S = decay S + Kd^T U
+//
+// Two consequences, both of which the fused kernel could not have:
+//
+//  1. The serial chain per chunk drops from ~8.4 MFLOP and ~15 barriers to ~3.7 MFLOP and
+//     6 barriers per CTA.
+//  2. Every one of those four GEMMs scales with the v-block width, so narrowing the block
+//     to raise the CTA count now genuinely divides the work instead of duplicating it.
+//
+// The state is kept in fp16 rather than the fused engine's fp32, which is what brings K2
+// under the 113.5 KB that lets two CTAs share an SM. fp16 (not bf16, which is what the
+// reference implementations use) because the operator's q/k/v/output are fp16 already,
+// qk_l2_norm bounds |k| <= 1 and beta = sigmoid(.) < 1, so the state stays around O(10)
+// against fp16's 65504 ceiling, and fp16 carries three more mantissa bits than bf16 on
+// what is an accumulator running the length of the sequence.
+
+#include <cuda_fp16.h>
+
+#include <algorithm>
+#include <mutex>
+
+#include "contrib_ops/cuda/bert/gated_delta_net_impl.h"
+#include "contrib_ops/cuda/bert/gated_delta_net_mma.cuh"
+#include "core/providers/cuda/cuda_common.h"
+
+using namespace onnxruntime::cuda;
+
+namespace onnxruntime {
+namespace contrib {
+namespace cuda {
+namespace gated_delta_net {
+
+namespace {
+
+// Padded leading dimensions; see the note in gated_delta_net_impl.cu on why the +8.
+template <int DK, int DV, int BT, int DVB>
+struct SplitLd {
+  static constexpr int kKh = DK + 8;    // rows of length DK
+  static constexpr int kVh = DV + 8;    // rows of length DV
+  static constexpr int kBh = DVB + 8;   // rows of length DVB
+  static constexpr int kMh = BT + 8;    // rows of length BT
+  static constexpr int kSh = DVB + 8;   // state rows, DVB wide
+  static constexpr int kF1 = (DV > BT ? DV : BT) + 4;   // K1 fp32 scratch
+  static constexpr int kF2 = (DVB > BT ? DVB : BT) + 4;  // K2 fp32 scratch
+};
+
+// ---------------------------------------------------------------------------
+// K1 shared memory
+// ---------------------------------------------------------------------------
+template <int DK, int DV, int BT>
+struct PrepSmem {
+  __half* k_h;   // [BT][kKh]
+  __half* q_h;   // [BT][kKh]
+  __half* v_h;   // [BT][kVh]  beta v, then Uv
+  __half* m_h;   // [BT][kMh]  M, then N (BuildTriInverse is done with M by then)
+  __half* db_h;  // [BT][kMh]
+  __half* ti_h;  // [BT][kMh]  (I+M)^-1
+  float* t_f;    // [BT][kF1]
+  float* gc;     // [BT]
+  float* beta;   // [BT]
+};
+
+template <int DK, int DV, int BT>
+__device__ __forceinline__ PrepSmem<DK, DV, BT> CarvePrep(char* raw) {
+  using L = SplitLd<DK, DV, BT, 64>;
+  PrepSmem<DK, DV, BT> s;
+  float* f = reinterpret_cast<float*>(raw);
+  s.t_f = f;
+  f += BT * L::kF1;
+  s.gc = f;
+  f += BT;
+  s.beta = f;
+  f += BT;
+  __half* h = reinterpret_cast<__half*>(f);
+  s.k_h = h;
+  h += BT * L::kKh;
+  s.q_h = h;
+  h += BT * L::kKh;
+  s.v_h = h;
+  h += BT * L::kVh;
+  s.m_h = h;
+  h += BT * L::kMh;
+  s.db_h = h;
+  h += BT * L::kMh;
+  s.ti_h = h;
+  return s;
+}
+
+// Layout of one chunk's K1 output, in units of __half. Chunks are indexed
+// ((b * Hv + hv) * chunks_per_pass + c), so K2's walk over c is a unit stride. W and Qg are
+// adjacent so K2 can multiply both by the state in a single [2 BT x DK] GEMM.
+template <int DK, int DV, int BT>
+struct PrepTile {
+  static constexpr int64_t kW = static_cast<int64_t>(BT) * DK;
+  static constexpr int64_t kQg = static_cast<int64_t>(BT) * DK;
+  static constexpr int64_t kUv = static_cast<int64_t>(BT) * DV;
+  static constexpr int64_t kP = static_cast<int64_t>(BT) * BT;
+  static constexpr int64_t kKd = static_cast<int64_t>(BT) * DK;
+  static constexpr int64_t kHalves = kW + kQg + kUv + kP + kKd;
+};
+
+// ---------------------------------------------------------------------------
+// K1: everything in a chunk that does not touch the recurrent state.
+// One CTA per (sequence, v-head, chunk).
+// ---------------------------------------------------------------------------
+template <typename T, int DK, int DV, int BT>
+__global__ __launch_bounds__(kChunkedThreads) void GatedDeltaNetPrepareKernel(
+    VariantPack<T> pack, KernelParams p, __half* tiles, float* decays, int chunk_base,
+    int chunks_per_pass) {
+  using L = SplitLd<DK, DV, BT, 64>;
+  using Tile = PrepTile<DK, DV, BT>;
+  extern __shared__ char smem_raw[];
+  const PrepSmem<DK, DV, BT> s = CarvePrep<DK, DV, BT>(smem_raw);
+
+  const int b = blockIdx.x, hv = blockIdx.y, c_local = blockIdx.z;
+  const int tid = threadIdx.x, warp_id = tid >> 5, lane = tid & 31;
+  const int hq = hv * p.num_heads_q / p.num_heads_v;
+  const int hk = hv * p.num_heads_k / p.num_heads_v;
+
+  int64_t tok_base, seq_len64;
+  SequenceRange(pack.cu_seqlens, b, p.total_tokens, p.uniform_len, &tok_base, &seq_len64);
+  const int seq_len = static_cast<int>(seq_len64);
+  const int chunk0 = (chunk_base + c_local) * BT;
+  if (chunk0 >= seq_len) return;
+  const int len = min(BT, seq_len - chunk0);
+
+  const int64_t q_stride = static_cast<int64_t>(p.num_heads_q) * DK;
+  const int64_t k_stride = static_cast<int64_t>(p.num_heads_k) * DK;
+  const int64_t v_stride = static_cast<int64_t>(p.num_heads_v) * DV;
+
+  const bool needs_decay = pack.decay != nullptr &&
+                           (p.update_rule == UpdateRule::kGated ||
+                            p.update_rule == UpdateRule::kGatedDelta);
+  const bool needs_retrieval =
+      p.update_rule == UpdateRule::kDelta || p.update_rule == UpdateRule::kGatedDelta;
+
+  for (int idx = tid; idx < BT * DK; idx += kChunkedThreads) {
+    const int t = idx / DK, d = idx % DK;
+    const int64_t tok = tok_base + chunk0 + t;
+    s.k_h[t * L::kKh + d] =
+        (t < len) ? __float2half((float)pack.key[tok * k_stride + hk * DK + d]) : __float2half(0.f);
+    s.q_h[t * L::kKh + d] =
+        (t < len) ? __float2half((float)pack.query[tok * q_stride + hq * DK + d])
+                  : __float2half(0.f);
+  }
+  for (int idx = tid; idx < BT * DV; idx += kChunkedThreads) {
+    const int t = idx / DV, d = idx % DV;
+    const int64_t tok = tok_base + chunk0 + t;
+    s.v_h[t * L::kVh + d] =
+        (t < len) ? __float2half((float)pack.value[tok * v_stride + hv * DV + d])
+                  : __float2half(0.f);
+  }
+  if (tid < BT) {
+    const int64_t tok = tok_base + chunk0 + tid;
+    const int64_t gi = tok * p.num_heads_v + hv;
+    float g = 0.0f, be = 0.0f;
+    if (tid < len) {
+      g = needs_decay
+              ? EffectiveDecay(pack.decay[gi], pack.a_log, pack.dt_bias, hv, p.gate_activation)
+              : 0.0f;
+      be = pack.beta != nullptr ? EffectiveBeta(pack.beta[gi], p.beta_activation) : 1.0f;
+    }
+    s.gc[tid] = g;
+    s.beta[tid] = be;
+  }
+  __syncthreads();
+
+  if (p.qk_l2_norm) {
+    for (int t = warp_id; t < BT; t += kChunkedWarps) {
+      float sq = 0.0f, sk = 0.0f;
+      for (int d = lane; d < DK; d += 32) {
+        const float qv = __half2float(s.q_h[t * L::kKh + d]);
+        const float kv = __half2float(s.k_h[t * L::kKh + d]);
+        sq += qv * qv;
+        sk += kv * kv;
+      }
+#pragma unroll
+      for (int off = 16; off > 0; off >>= 1) {
+        sq += __shfl_xor_sync(0xffffffff, sq, off);
+        sk += __shfl_xor_sync(0xffffffff, sk, off);
+      }
+      const float rq = rsqrtf(sq + 1e-12f), rk = rsqrtf(sk + 1e-12f);
+      for (int d = lane; d < DK; d += 32) {
+        s.q_h[t * L::kKh + d] = __float2half(__half2float(s.q_h[t * L::kKh + d]) * rq);
+        s.k_h[t * L::kKh + d] = __float2half(__half2float(s.k_h[t * L::kKh + d]) * rk);
+      }
+    }
+    __syncthreads();
+  }
+
+  InclusiveScanBT<BT>(s.gc, tid);
+  __syncthreads();
+  const float g_total = s.gc[BT - 1];
+
+  // M and its exact inverse.
+  SmemGemm<BT, BT, DK, false, true, false>(s.t_f, L::kF1, s.k_h, L::kKh, s.k_h, L::kKh, warp_id,
+                                           lane);
+  __syncthreads();
+  for (int idx = tid; idx < BT * BT; idx += kChunkedThreads) {
+    const int t = idx / BT, sc = idx % BT;
+    const float m = (sc < t && needs_retrieval)
+                        ? s.beta[t] * s.t_f[t * L::kF1 + sc] * __expf(s.gc[t] - s.gc[sc])
+                        : 0.0f;
+    s.m_h[t * L::kMh + sc] = __float2half(m);
+  }
+  __syncthreads();
+
+  // The Neumann iterate lands on top of M: BuildTriInverse has consumed M by the time it
+  // writes N, and the prepare kernel only fits two CTAs on an SM without the extra tile.
+  BuildTriInverse<BT>(s.m_h, L::kMh, s.db_h, s.m_h, s.ti_h, L::kMh, s.t_f, L::kF1, warp_id, lane,
+                      tid);
+
+  const int64_t tile_base =
+      (static_cast<int64_t>(b) * p.num_heads_v + hv) * chunks_per_pass + c_local;
+  __half* out = tiles + tile_base * Tile::kHalves;
+  __half* w_out = out;
+  __half* qg_out = w_out + Tile::kW;
+  __half* uv_out = qg_out + Tile::kQg;
+  __half* p_out = uv_out + Tile::kUv;
+  __half* kd_out = p_out + Tile::kP;
+
+  // Uv = (I+M)^-1 (beta v). v_h holds v; scale it in place, then overwrite with Uv.
+  for (int idx = tid; idx < BT * DV; idx += kChunkedThreads) {
+    const int t = idx / DV, d = idx % DV;
+    s.v_h[t * L::kVh + d] = __hmul(s.v_h[t * L::kVh + d], __float2half(s.beta[t]));
+  }
+  __syncthreads();
+  SmemGemm<BT, DV, BT, false, false, false>(s.t_f, L::kF1, s.ti_h, L::kMh, s.v_h, L::kVh, warp_id,
+                                            lane);
+  __syncthreads();
+  for (int idx = tid; idx < BT * DV; idx += kChunkedThreads) {
+    uv_out[idx] = __float2half(s.t_f[(idx / DV) * L::kF1 + idx % DV]);
+  }
+
+  // Kd and Qg are just row scalings of k and q, so emit them before k is overwritten by the
+  // row scaling W needs.
+  for (int idx = tid; idx < BT * DK; idx += kChunkedThreads) {
+    const int t = idx / DK, d = idx % DK;
+    kd_out[idx] = __hmul(s.k_h[t * L::kKh + d], __float2half(__expf(g_total - s.gc[t])));
+    qg_out[idx] = __hmul(s.q_h[t * L::kKh + d], __float2half(__expf(s.gc[t])));
+  }
+  __syncthreads();
+
+  // P = (q k^T) exp(gc_t - gc_s), inclusive lower. q_h is still unscaled here.
+  SmemGemm<BT, BT, DK, false, true, false>(s.t_f, L::kF1, s.q_h, L::kKh, s.k_h, L::kKh, warp_id,
+                                           lane);
+  __syncthreads();
+  for (int idx = tid; idx < BT * BT; idx += kChunkedThreads) {
+    const int t = idx / BT, sc = idx % BT;
+    p_out[idx] = __float2half(
+        (sc <= t && t < len) ? s.t_f[t * L::kF1 + sc] * __expf(s.gc[t] - s.gc[sc]) : 0.0f);
+  }
+  for (int idx = tid; idx < BT * DK; idx += kChunkedThreads) {
+    const int t = idx / DK, d = idx % DK;
+    const float bw = needs_retrieval ? s.beta[t] * __expf(s.gc[t]) : 0.0f;
+    s.k_h[t * L::kKh + d] = __float2half(__half2float(s.k_h[t * L::kKh + d]) * bw);
+  }
+  __syncthreads();
+  // W = (I+M)^-1 diag(beta exp(gc)) k, with the row scaling folded into k in place.
+  SmemGemm<BT, DK, BT, false, false, false>(s.t_f, L::kF1, s.ti_h, L::kMh, s.k_h, L::kKh, warp_id,
+                                            lane);
+  __syncthreads();
+  for (int idx = tid; idx < BT * DK; idx += kChunkedThreads) {
+    w_out[idx] = __float2half(s.t_f[(idx / DK) * L::kF1 + idx % DK]);
+  }
+
+  if (tid == 0) decays[tile_base] = __expf(g_total);
+}
+
+// ---------------------------------------------------------------------------
+// K2 shared memory. The state lives here in fp16 for the whole walk.
+// ---------------------------------------------------------------------------
+template <int DK, int DV, int BT, int DVB>
+struct ScanSmem {
+  __half* s_h;   // [DK][kSh]    recurrent state
+  __half* wq_h;  // [2 BT][kKh]  W stacked on Qg
+  __half* u_h;   // [BT][kBh]    Uv, then U in place
+  __half* p_h;   // [BT][kMh]
+  __half* kd_h;  // [BT][kKh]
+  float* t_f;    // [DK][kF2], and DK == 2 BT holds both halves of the stacked GEMM
+};
+
+template <int DK, int DV, int BT, int DVB>
+__device__ __forceinline__ ScanSmem<DK, DV, BT, DVB> CarveScan(char* raw) {
+  using L = SplitLd<DK, DV, BT, DVB>;
+  static_assert(DK == 2 * BT, "t_f must cover both halves of the stacked [2 BT x DVB] GEMM");
+  ScanSmem<DK, DV, BT, DVB> s;
+  float* f = reinterpret_cast<float*>(raw);
+  s.t_f = f;
+  f += DK * L::kF2;
+  __half* h = reinterpret_cast<__half*>(f);
+  s.s_h = h;
+  h += DK * L::kSh;
+  s.wq_h = h;
+  h += 2 * BT * L::kKh;
+  s.u_h = h;
+  h += BT * L::kBh;
+  s.p_h = h;
+  h += BT * L::kMh;
+  s.kd_h = h;
+  return s;
+}
+
+// ---------------------------------------------------------------------------
+// K2: the recurrence. One CTA per (sequence, v-head, v-block).
+// ---------------------------------------------------------------------------
+template <typename T, int DK, int DV, int BT, int DVB>
+__global__ __launch_bounds__(kChunkedThreads) void GatedDeltaNetScanKernel(
+    VariantPack<T> pack, KernelParams p, const __half* tiles, const float* decays, float* carry,
+    int chunk_base, int chunks_per_pass, int n_chunks, bool first_pass, bool last_pass) {
+  using L = SplitLd<DK, DV, BT, DVB>;
+  using Tile = PrepTile<DK, DV, BT>;
+  extern __shared__ char smem_raw[];
+  const ScanSmem<DK, DV, BT, DVB> s = CarveScan<DK, DV, BT, DVB>(smem_raw);
+
+  const int b = blockIdx.x, hv = blockIdx.y, v0 = blockIdx.z * DVB;
+  const int tid = threadIdx.x, warp_id = tid >> 5, lane = tid & 31;
+
+  int64_t tok_base, seq_len64;
+  SequenceRange(pack.cu_seqlens, b, p.total_tokens, p.uniform_len, &tok_base, &seq_len64);
+  const int seq_len = static_cast<int>(seq_len64);
+  const int64_t v_stride = static_cast<int64_t>(p.num_heads_v) * DV;
+  const int64_t st_off = (static_cast<int64_t>(b) * p.num_heads_v + hv) * DV * DK;
+
+  // The state crosses a pass boundary through `carry`, which is workspace the launcher only
+  // reserves when there is more than one pass. final_state is not usable for that: the
+  // caller may not have asked for it.
+  const float* seed = first_pass ? pack.initial_state : carry;
+  for (int idx = tid; idx < DK * DVB; idx += kChunkedThreads) {
+    const int r = idx / DVB, c = idx % DVB;
+    s.s_h[r * L::kSh + c] =
+        seed != nullptr
+            ? __float2half(seed[st_off + static_cast<int64_t>(v0 + c) * DK + r])
+            : __float2half(0.f);
+  }
+  __syncthreads();
+
+  const int64_t head_base =
+      (static_cast<int64_t>(b) * p.num_heads_v + hv) * chunks_per_pass;
+
+  for (int c_local = 0; c_local < n_chunks; ++c_local) {
+    const int chunk0 = (chunk_base + c_local) * BT;
+    if (chunk0 >= seq_len) break;
+    const int len = min(BT, seq_len - chunk0);
+
+    const __half* in = tiles + (head_base + c_local) * Tile::kHalves;
+    const __half* wq_in = in;
+    const __half* uv_in = wq_in + Tile::kW + Tile::kQg;
+    const __half* p_in = uv_in + Tile::kUv;
+    const __half* kd_in = p_in + Tile::kP;
+
+    for (int idx = tid; idx < 2 * BT * DK; idx += kChunkedThreads) {
+      s.wq_h[(idx / DK) * L::kKh + idx % DK] = wq_in[idx];
+    }
+    for (int idx = tid; idx < BT * DK; idx += kChunkedThreads) {
+      s.kd_h[(idx / DK) * L::kKh + idx % DK] = kd_in[idx];
+    }
+    for (int idx = tid; idx < BT * DVB; idx += kChunkedThreads) {
+      const int t = idx / DVB, d = idx % DVB;
+      s.u_h[t * L::kBh + d] = uv_in[t * DV + v0 + d];
+    }
+    for (int idx = tid; idx < BT * BT; idx += kChunkedThreads) {
+      s.p_h[(idx / BT) * L::kMh + idx % BT] = p_in[idx];
+    }
+    __syncthreads();
+
+    // One GEMM for both products of the state: rows [0, BT) are W S, rows [BT, 2 BT) are Qg S.
+    SmemGemm<2 * BT, DVB, DK, false, false, false>(s.t_f, L::kF2, s.wq_h, L::kKh, s.s_h, L::kSh,
+                                                   warp_id, lane);
+    __syncthreads();
+    for (int idx = tid; idx < BT * DVB; idx += kChunkedThreads) {
+      const int t = idx / DVB, c = idx % DVB;
+      s.u_h[t * L::kBh + c] =
+          __float2half(__half2float(s.u_h[t * L::kBh + c]) - s.t_f[t * L::kF2 + c]);
+    }
+    __syncthreads();
+
+    // P U overwrites the W S half; Qg S is still live above it.
+    SmemGemm<BT, DVB, BT, false, false, false>(s.t_f, L::kF2, s.p_h, L::kMh, s.u_h, L::kBh,
+                                               warp_id, lane);
+    __syncthreads();
+    for (int idx = tid; idx < BT * DVB; idx += kChunkedThreads) {
+      const int t = idx / DVB, c = idx % DVB;
+      if (t < len) {
+        const int64_t tok = tok_base + chunk0 + t;
+        pack.output[tok * v_stride + hv * DV + v0 + c] =
+            (T)(p.scale * (s.t_f[t * L::kF2 + c] + s.t_f[(BT + t) * L::kF2 + c]));
+      }
+    }
+
+    // S = decay S + Kd^T U, straight into the fp16 state: the mma accumulator is float
+    // either way, so this is the same single rounding as staging it through t_f, and it
+    // needs no barrier against the output epilogue above, which only reads t_f.
+    SmemGemm<DK, DVB, BT, true, false, true, __half>(s.s_h, L::kSh, s.kd_h, L::kKh, s.u_h,
+                                                     L::kBh, warp_id, lane,
+                                                     decays[head_base + c_local]);
+    __syncthreads();
+  }
+
+  // Written after every pass, not just the last: the next pass reads it back as its seed.
+  for (int idx = tid; idx < DK * DVB; idx += kChunkedThreads) {
+    const int r = idx / DVB, c = idx % DVB;
+    const int64_t off = st_off + static_cast<int64_t>(v0 + c) * DK + r;
+    const float v = __half2float(s.s_h[r * L::kSh + c]);
+    if (carry != nullptr) carry[off] = v;
+    if (last_pass && pack.final_state != nullptr) pack.final_state[off] = v;
+  }
+}
+
+}  // namespace
+
+template <typename T>
+Status LaunchGatedDeltaNetSplit(const Descriptor& desc, const Plan& plan,
+                                const VariantPack<T>& pack, float scale, cudaStream_t stream) {
+  constexpr int DK = 128, DV = 128, BT = 64;
+  static_assert(DK == 128 && DV == 128, "the split engine is specialised for 128-wide heads");
+
+  KernelParams p{};
+  p.total_tokens = desc.total_tokens;
+  p.uniform_len = desc.batch > 0 ? desc.total_tokens / desc.batch : 0;
+  p.num_heads_q = desc.num_heads_q;
+  p.num_heads_k = desc.num_heads_k;
+  p.num_heads_v = desc.num_heads_v;
+  p.scale = scale;
+  p.gate_activation = desc.gate_activation;
+  p.beta_activation = desc.beta_activation;
+  p.update_rule = desc.update_rule;
+  p.qk_l2_norm = desc.qk_l2_norm;
+  p.state_checkpoints = desc.state_checkpoints;
+  p.batch = desc.batch;
+  p.decay_per_key_dim_flag = desc.decay_per_key_dim ? 1 : 0;
+
+  const int64_t longest = desc.batch > 0 ? (desc.total_tokens + desc.batch - 1) / desc.batch : 0;
+  const int total_chunks = static_cast<int>((longest + BT - 1) / BT);
+  if (total_chunks <= 0) return Status::OK();
+  const int chunks_per_pass =
+      std::min(plan.chunks_per_pass > 0 ? plan.chunks_per_pass : total_chunks, total_chunks);
+
+  const int64_t tiles_per_pass =
+      static_cast<int64_t>(desc.batch) * desc.num_heads_v * chunks_per_pass;
+  __half* tiles = reinterpret_cast<__half*>(pack.workspace);
+  float* decays = reinterpret_cast<float*>(
+      tiles + tiles_per_pass * PrepTile<DK, DV, BT>::kHalves);
+  // Reserved by SelectPlan only when the sequence takes more than one pass.
+  float* carry = total_chunks > chunks_per_pass ? decays + tiles_per_pass : nullptr;
+
+  const int dvb = plan.v_block;
+  const size_t prep_smem = SplitPrepareSmemBytes(BT, DK, DV);
+  const size_t scan_smem = SplitScanSmemBytes(BT, DK, dvb);
+
+  static std::once_flag once_prep;
+  ORT_RETURN_IF_ERROR(SetMaxDynamicSmemOnce(GatedDeltaNetPrepareKernel<T, DK, DV, BT>, prep_smem,
+                                            once_prep));
+
+  for (int base = 0; base < total_chunks; base += chunks_per_pass) {
+    const int n = std::min(chunks_per_pass, total_chunks - base);
+    const bool first = base == 0;
+    const bool last = base + n >= total_chunks;
+
+    const dim3 prep_grid(desc.batch, desc.num_heads_v, n);
+    GatedDeltaNetPrepareKernel<T, DK, DV, BT>
+        <<<prep_grid, kChunkedThreads, prep_smem, stream>>>(pack, p, tiles, decays, base,
+                                                            chunks_per_pass);
+
+    const dim3 scan_grid(desc.batch, desc.num_heads_v, DV / dvb);
+    if (dvb == 32) {
+      static std::once_flag once32;
+      ORT_RETURN_IF_ERROR(SetMaxDynamicSmemOnce(GatedDeltaNetScanKernel<T, DK, DV, BT, 32>,
+                                                scan_smem, once32));
+      GatedDeltaNetScanKernel<T, DK, DV, BT, 32>
+          <<<scan_grid, kChunkedThreads, scan_smem, stream>>>(pack, p, tiles, decays, carry, base,
+                                                              chunks_per_pass, n, first, last);
+    } else {
+      static std::once_flag once64;
+      ORT_RETURN_IF_ERROR(SetMaxDynamicSmemOnce(GatedDeltaNetScanKernel<T, DK, DV, BT, 64>,
+                                                scan_smem, once64));
+      GatedDeltaNetScanKernel<T, DK, DV, BT, 64>
+          <<<scan_grid, kChunkedThreads, scan_smem, stream>>>(pack, p, tiles, decays, carry, base,
+                                                              chunks_per_pass, n, first, last);
+    }
+    ORT_RETURN_IF_ERROR(CUDA_CALL(cudaGetLastError()));
+  }
+  return Status::OK();
+}
+
+template Status LaunchGatedDeltaNetSplit<half>(const Descriptor&, const Plan&,
+                                               const VariantPack<half>&, float, cudaStream_t);
+
+// The GEMM operands are fp16 mma fragments, so SelectPlan never routes float here; the
+// definition exists only to close the float instantiation of LaunchGatedDeltaNet.
+template <>
+Status LaunchGatedDeltaNetSplit<float>(const Descriptor&, const Plan&, const VariantPack<float>&,
+                                       float, cudaStream_t) {
+  return ORT_MAKE_STATUS(ONNXRUNTIME, NOT_IMPLEMENTED,
+                         "GatedDeltaNet: the split engine requires float16 input");
+}
+
+}  // namespace gated_delta_net
+}  // namespace cuda
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cuda/cuda_contrib_kernels.cc
+++ b/onnxruntime/contrib_ops/cuda/cuda_contrib_kernels.cc
@@ -159,6 +159,8 @@ class CUDA_MS_OP_TYPED_CLASS_NAME(1, MLFloat16, GemmaRotaryEmbedding);
 class CUDA_MS_OP_TYPED_CLASS_NAME(1, float, LinearAttention);
 class CUDA_MS_OP_TYPED_CLASS_NAME(1, MLFloat16, LinearAttention);
 class CUDA_MS_OP_TYPED_CLASS_NAME(1, BFloat16, LinearAttention);
+class CUDA_MS_OP_TYPED_CLASS_NAME(1, float, GatedDeltaNet);
+class CUDA_MS_OP_TYPED_CLASS_NAME(1, MLFloat16, GatedDeltaNet);
 class CUDA_MS_OP_TYPED_CLASS_NAME(1, float, LinearAttentionGate);
 class CUDA_MS_OP_TYPED_CLASS_NAME(1, MLFloat16, LinearAttentionGate);
 class CUDA_MS_OP_TYPED_CLASS_NAME(1, BFloat16, LinearAttentionGate);
@@ -444,6 +446,8 @@ Status RegisterCudaContribKernels(KernelRegistry& kernel_registry) {
       BuildKernelCreateInfo<CUDA_MS_OP_TYPED_CLASS_NAME(1, float, LinearAttention)>,
       BuildKernelCreateInfo<CUDA_MS_OP_TYPED_CLASS_NAME(1, MLFloat16, LinearAttention)>,
       BuildKernelCreateInfo<CUDA_MS_OP_TYPED_CLASS_NAME(1, BFloat16, LinearAttention)>,
+      BuildKernelCreateInfo<CUDA_MS_OP_TYPED_CLASS_NAME(1, float, GatedDeltaNet)>,
+      BuildKernelCreateInfo<CUDA_MS_OP_TYPED_CLASS_NAME(1, MLFloat16, GatedDeltaNet)>,
       BuildKernelCreateInfo<CUDA_MS_OP_TYPED_CLASS_NAME(1, float, LinearAttentionGate)>,
       BuildKernelCreateInfo<CUDA_MS_OP_TYPED_CLASS_NAME(1, MLFloat16, LinearAttentionGate)>,
       BuildKernelCreateInfo<CUDA_MS_OP_TYPED_CLASS_NAME(1, BFloat16, LinearAttentionGate)>,

--- a/onnxruntime/core/graph/contrib_ops/bert_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/bert_defs.cc
@@ -2868,12 +2868,18 @@ ONNX_MS_OPERATOR_SET_SCHEMA(
 constexpr const char* GatedDeltaNet_ver1_doc = R"DOC(
 Packed (token-major) gated delta network / linear attention with an explicit recurrent state.
 
-Layout. Query, key and value are rank-3 and token-major, so head counts are derived from the
-shapes rather than from attributes:
+Layout. Query, key and value are token-major, so head counts are derived from the shapes
+rather than from attributes:
 
   query [total_tokens, num_heads_q, head_size_qk]
   key   [total_tokens, num_heads_k, head_size_qk]
   value [total_tokens, num_heads_v, head_size_v]
+
+The leading token axis may instead be spelled as an explicit `[batch_size, sequence_length]`
+pair, making query/key/value (and the output) rank 4 and decay/beta rank 3. The memory layout
+is identical; the rank-4 spelling exists so an exporter can round-trip a `[B, S, H*D]`
+activation with static Reshape targets instead of Shape-derived ones. Ragged packing
+(`cu_seqlens`) requires the rank-3 spelling.
 
 `num_heads_q` must equal `num_heads_k`, and `num_heads_v` must be a positive multiple of
 `num_heads_q` (inverse grouped-query attention: each query/key head is shared by
@@ -3002,19 +3008,25 @@ ONNX_MS_OPERATOR_SET_SCHEMA(
           }
           const auto& query_shape = getInputShape(ctx, 0);
           const auto& value_shape = getInputShape(ctx, 2);
-          if (query_shape.dim_size() != 3 || value_shape.dim_size() != 3) {
-            fail_shape_inference("GatedDeltaNet: query and value must have rank 3");
+          const int rank = query_shape.dim_size();
+          if ((rank != 3 && rank != 4) || value_shape.dim_size() != rank) {
+            fail_shape_inference(
+                "GatedDeltaNet: query and value must both have rank 3 or both have rank 4");
           }
+          const int token_dims = rank - 2;
 
           ONNX_NAMESPACE::TensorShapeProto out_shape;
-          *out_shape.add_dim() = query_shape.dim(0);
-          if (query_shape.dim(1).has_dim_value() && value_shape.dim(1).has_dim_value()) {
-            out_shape.add_dim()->set_dim_value(
-                std::max(query_shape.dim(1).dim_value(), value_shape.dim(1).dim_value()));
+          for (int i = 0; i < token_dims; ++i) {
+            *out_shape.add_dim() = query_shape.dim(i);
+          }
+          if (query_shape.dim(token_dims).has_dim_value() &&
+              value_shape.dim(token_dims).has_dim_value()) {
+            out_shape.add_dim()->set_dim_value(std::max(query_shape.dim(token_dims).dim_value(),
+                                                        value_shape.dim(token_dims).dim_value()));
           } else {
             out_shape.add_dim();
           }
-          *out_shape.add_dim() = value_shape.dim(2);
+          *out_shape.add_dim() = value_shape.dim(token_dims + 1);
           updateOutputShape(ctx, 0, out_shape);
 
           if (ctx.getNumOutputs() > 1 && hasInputShape(ctx, 6)) {

--- a/onnxruntime/core/graph/contrib_ops/bert_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/bert_defs.cc
@@ -2865,6 +2865,163 @@ ONNX_MS_OPERATOR_SET_SCHEMA(
           }
         }));
 
+constexpr const char* GatedDeltaNet_ver1_doc = R"DOC(
+Packed (token-major) gated delta network / linear attention with an explicit recurrent state.
+
+Layout. Query, key and value are rank-3 and token-major, so head counts are derived from the
+shapes rather than from attributes:
+
+  query [total_tokens, num_heads_q, head_size_qk]
+  key   [total_tokens, num_heads_k, head_size_qk]
+  value [total_tokens, num_heads_v, head_size_v]
+
+`num_heads_q` must equal `num_heads_k`, and `num_heads_v` must be a positive multiple of
+`num_heads_q` (inverse grouped-query attention: each query/key head is shared by
+`num_heads_v / num_heads_q` value heads). Decay, beta, the state and the output are all at
+`num_heads_v`.
+
+Sequence packing. When `cu_seqlens` is provided it is a device int32 tensor of length
+`batch_size + 1` holding the exclusive prefix sums of the per-request token counts, so
+requests may have different lengths. When it is absent the packing is uniform and the batch
+size is taken from `initial_state`, which is then required.
+
+State. `initial_state` and `final_state` are V-major, `[batch_size, num_heads_v, head_size_v,
+head_size_qk]`, and always float regardless of the query/key/value type: the recurrence
+boundary is where reduced precision hurts most, and V-major is the layout used by cuDNN's
+GDN/KDA and by FLA with `state_v_first=true`. The two may be the same allocation; the
+implementation reads the whole incoming state before writing any of it.
+
+Checkpoints. When the `state_checkpoints` attribute W is greater than zero, the optional
+`checkpoints` output is `[W, batch_size, num_heads_v, head_size_v, head_size_qk]` and slot j
+receives the state after local token j of each request. This is the series a speculative
+decoder needs to roll back to a partially accepted draft; `final_state` still holds the state
+after the last token. Slots this call does not write are left unspecified rather than cleared,
+because the buffer may alias live state.
+
+Recurrence, per value head, with S the [head_size_qk x head_size_v] state:
+
+  S_t = exp(g_t) S_{t-1} + k_t (beta_t (v_t - exp(g_t) S_{t-1}^T k_t))^T
+  o_t = scale * S_t^T q_t
+
+`update_rule` selects which terms are present: 'linear' drops both the decay and the delta
+retrieval, 'gated' keeps only the decay, 'delta' keeps only the retrieval, and 'gated_delta'
+keeps both.
+
+The delta family ('delta' and 'gated_delta') requires L2-normalized keys. Without them the
+per-chunk system (I + M) is arbitrarily ill-conditioned and the recurrence diverges. Either
+normalize upstream or set `qk_l2_norm=1` to have the operator do it.
+
+Fused activations. `gate_activation='qwen'` computes the effective decay in float32 from the
+raw projection carried by `decay`:
+
+  g = -exp(a_log) * Softplus(decay + dt_bias)
+
+`beta_activation='sigmoid'` applies a sigmoid to `beta`, and `qk_l2_norm=1` L2-normalizes each
+query and key head vector. Folding these in avoids materializing the intermediates and keeps
+the gate arithmetic in float32 independent of the input type.
+)DOC";
+
+ONNX_MS_OPERATOR_SET_SCHEMA(
+    GatedDeltaNet, 1,
+    OpSchema()
+        .SetDoc(GatedDeltaNet_ver1_doc)
+        .Attr("update_rule",
+              "One of: 'linear', 'gated', 'delta', 'gated_delta'. Default is 'gated_delta'.",
+              AttributeProto::STRING, std::string("gated_delta"))
+        .Attr("scale",
+              "Output scaling factor. When 0.0 (default) uses 1/sqrt(head_size_qk).",
+              AttributeProto::FLOAT, 0.0f)
+        .Attr("gate_activation",
+              "'none' (default) treats `decay` as the effective log-space decay. 'qwen' computes "
+              "-exp(a_log) * Softplus(decay + dt_bias) in float32.",
+              AttributeProto::STRING, std::string("none"))
+        .Attr("beta_activation",
+              "'none' (default) treats `beta` as the effective update rate. 'sigmoid' applies a "
+              "sigmoid.",
+              AttributeProto::STRING, std::string("none"))
+        .Attr("qk_l2_norm",
+              "When 1, L2-normalize each query and key head vector before the recurrence. "
+              "Default 0.",
+              AttributeProto::INT, static_cast<int64_t>(0))
+        .Attr("chunk_size",
+              "Tuning hint for the chunk-parallel prefill algorithm. Default 64.",
+              AttributeProto::INT, static_cast<int64_t>(64))
+        .Attr("state_checkpoints",
+              "Number of leading per-token state checkpoint slots W, in [0, 8]. 0 (default) "
+              "disables the `checkpoints` output.",
+              AttributeProto::INT, static_cast<int64_t>(0))
+        .Input(0, "query", "Query, shape (total_tokens, num_heads_q, head_size_qk)", "T")
+        .Input(1, "key", "Key, shape (total_tokens, num_heads_k, head_size_qk)", "T")
+        .Input(2, "value", "Value, shape (total_tokens, num_heads_v, head_size_v)", "T")
+        .Input(3, "cu_seqlens",
+               "Exclusive prefix sums of the per-request token counts, shape (batch_size + 1). "
+               "Absent means uniform packing.",
+               "TI", OpSchema::Optional)
+        .Input(4, "decay",
+               "Log-space decay, shape (total_tokens, num_heads_v) for a scalar per-head decay or "
+               "(total_tokens, num_heads_v, head_size_qk) for a per-key-dimension decay.",
+               "TS", OpSchema::Optional)
+        .Input(5, "beta", "Update rate, shape (total_tokens, num_heads_v)", "TS",
+               OpSchema::Optional)
+        .Input(6, "initial_state",
+               "Recurrent state, shape (batch_size, num_heads_v, head_size_v, head_size_qk), "
+               "V-major. May alias final_state.",
+               "TS", OpSchema::Optional)
+        .Input(7, "a_log", "Per-head gate scale, shape (num_heads_v). Requires gate_activation=qwen.",
+               "TS", OpSchema::Optional)
+        .Input(8, "dt_bias",
+               "Per-head gate bias, shape (num_heads_v) or (num_heads_v, head_size_qk). "
+               "Requires gate_activation=qwen.",
+               "TS", OpSchema::Optional)
+        .Output(0, "output",
+                "Output, shape (total_tokens, max(num_heads_q, num_heads_v), head_size_v)", "T")
+        .Output(1, "final_state",
+                "State after the last token of each request, shape "
+                "(batch_size, num_heads_v, head_size_v, head_size_qk)",
+                "TS", OpSchema::Optional)
+        .Output(2, "checkpoints",
+                "Per-token state checkpoints, shape "
+                "(state_checkpoints, batch_size, num_heads_v, head_size_v, head_size_qk)",
+                "TS", OpSchema::Optional)
+        .TypeConstraint("T", {"tensor(float)", "tensor(float16)", "tensor(bfloat16)"},
+                        "Constrain query/key/value/output types.")
+        .TypeConstraint("TS", {"tensor(float)"},
+                        "State, gate and beta tensors are always float.")
+        .TypeConstraint("TI", {"tensor(int32)"}, "Constrain cu_seqlens to int32.")
+        .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
+          propagateElemTypeFromInputToOutput(ctx, 0, 0);
+          if (ctx.getNumOutputs() > 1) {
+            updateOutputElemType(ctx, 1, ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+          }
+          if (ctx.getNumOutputs() > 2) {
+            updateOutputElemType(ctx, 2, ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+          }
+
+          if (!hasInputShape(ctx, 0) || !hasInputShape(ctx, 2)) {
+            return;
+          }
+          const auto& query_shape = getInputShape(ctx, 0);
+          const auto& value_shape = getInputShape(ctx, 2);
+          if (query_shape.dim_size() != 3 || value_shape.dim_size() != 3) {
+            fail_shape_inference("GatedDeltaNet: query and value must have rank 3");
+          }
+
+          ONNX_NAMESPACE::TensorShapeProto out_shape;
+          *out_shape.add_dim() = query_shape.dim(0);
+          if (query_shape.dim(1).has_dim_value() && value_shape.dim(1).has_dim_value()) {
+            out_shape.add_dim()->set_dim_value(
+                std::max(query_shape.dim(1).dim_value(), value_shape.dim(1).dim_value()));
+          } else {
+            out_shape.add_dim();
+          }
+          *out_shape.add_dim() = value_shape.dim(2);
+          updateOutputShape(ctx, 0, out_shape);
+
+          if (ctx.getNumOutputs() > 1 && hasInputShape(ctx, 6)) {
+            propagateShapeFromInputToOutput(ctx, 6, 1);
+          }
+        }));
+
 constexpr const char* LinearAttentionGate_ver1_doc = R"DOC(
 Fuses the gate projections that feed LinearAttention's gated-delta recurrence:
 

--- a/onnxruntime/core/graph/contrib_ops/bert_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/bert_defs.cc
@@ -2898,11 +2898,18 @@ GDN/KDA and by FLA with `state_v_first=true`. The two may be the same allocation
 implementation reads the whole incoming state before writing any of it.
 
 Checkpoints. When the `state_checkpoints` attribute W is greater than zero, the optional
-`checkpoints` output is `[W, batch_size, num_heads_v, head_size_v, head_size_qk]` and slot j
-receives the state after local token j of each request. This is the series a speculative
-decoder needs to roll back to a partially accepted draft; `final_state` still holds the state
-after the last token. Slots this call does not write are left unspecified rather than cleared,
-because the buffer may alias live state.
+`checkpoints` output is `[W, batch_size, num_heads_v, head_size_v, head_size_qk]` and holds
+the state after each of the last W tokens, **right-aligned**: slot W-1 is the state after the
+final token (the same value as `final_state`) and slot W-1-k is the state after the k-th token
+from the end. This is the series a speculative decoder needs to roll back to a partially
+accepted draft. Slots this call does not write are left unspecified rather than cleared,
+because the buffer may alias live state; in particular a request longer than W tokens fills
+only the last slot, since such a request is a prefill with nothing to roll back.
+
+Because slot W-1 is the committed state, `initial_state` may also be given with that leading
+window, `[W, batch_size, num_heads_v, head_size_v, head_size_qk]`, in which case the operator
+reads the last slot and `final_state` may be omitted. One buffer then serves as both the past
+and the present state of a speculative decoding loop.
 
 Recurrence, per value head, with S the [head_size_qk x head_size_v] state:
 
@@ -2953,7 +2960,7 @@ ONNX_MS_OPERATOR_SET_SCHEMA(
               "Tuning hint for the chunk-parallel prefill algorithm. Default 64.",
               AttributeProto::INT, static_cast<int64_t>(64))
         .Attr("state_checkpoints",
-              "Number of leading per-token state checkpoint slots W, in [0, 8]. 0 (default) "
+              "Number of trailing per-token state checkpoint slots W, in [0, 8]. 0 (default) "
               "disables the `checkpoints` output.",
               AttributeProto::INT, static_cast<int64_t>(0))
         .Input(0, "query", "Query, shape (total_tokens, num_heads_q, head_size_qk)", "T")
@@ -2971,7 +2978,9 @@ ONNX_MS_OPERATOR_SET_SCHEMA(
                OpSchema::Optional)
         .Input(6, "initial_state",
                "Recurrent state, shape (batch_size, num_heads_v, head_size_v, head_size_qk), "
-               "V-major. May alias final_state.",
+               "V-major, optionally with a leading checkpoint window of state_checkpoints "
+               "slots whose last slot is the committed state. May alias final_state or "
+               "checkpoints.",
                "TS", OpSchema::Optional)
         .Input(7, "a_log", "Per-head gate scale, shape (num_heads_v). Requires gate_activation=qwen.",
                "TS", OpSchema::Optional)
@@ -2986,7 +2995,7 @@ ONNX_MS_OPERATOR_SET_SCHEMA(
                 "(batch_size, num_heads_v, head_size_v, head_size_qk)",
                 "TS", OpSchema::Optional)
         .Output(2, "checkpoints",
-                "Per-token state checkpoints, shape "
+                "State after each of the last state_checkpoints tokens, right-aligned, shape "
                 "(state_checkpoints, batch_size, num_heads_v, head_size_v, head_size_qk)",
                 "TS", OpSchema::Optional)
         .TypeConstraint("T", {"tensor(float)", "tensor(float16)", "tensor(bfloat16)"},
@@ -3029,8 +3038,30 @@ ONNX_MS_OPERATOR_SET_SCHEMA(
           *out_shape.add_dim() = value_shape.dim(token_dims + 1);
           updateOutputShape(ctx, 0, out_shape);
 
-          if (ctx.getNumOutputs() > 1 && hasInputShape(ctx, 6)) {
-            propagateShapeFromInputToOutput(ctx, 6, 1);
+          if (hasInputShape(ctx, 6)) {
+            // A rank-5 initial_state carries the checkpoint window; the committed state that
+            // final_state and each checkpoint slot hold is its trailing rank-4 part.
+            const auto& in_state = getInputShape(ctx, 6);
+            const int first = in_state.dim_size() - 4;
+            if (first < 0) {
+              fail_shape_inference("GatedDeltaNet: initial_state must have rank 4 or 5");
+            }
+            ONNX_NAMESPACE::TensorShapeProto committed;
+            for (int i = first; i < in_state.dim_size(); ++i) {
+              *committed.add_dim() = in_state.dim(i);
+            }
+            if (ctx.getNumOutputs() > 1) {
+              updateOutputShape(ctx, 1, committed);
+            }
+            if (ctx.getNumOutputs() > 2) {
+              ONNX_NAMESPACE::TensorShapeProto ckpt;
+              ckpt.add_dim()->set_dim_value(
+                  getAttribute(ctx, "state_checkpoints", static_cast<int64_t>(0)));
+              for (int i = 0; i < committed.dim_size(); ++i) {
+                *ckpt.add_dim() = committed.dim(i);
+              }
+              updateOutputShape(ctx, 2, ckpt);
+            }
           }
         }));
 

--- a/onnxruntime/core/graph/contrib_ops/bert_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/bert_defs.cc
@@ -2998,7 +2998,7 @@ ONNX_MS_OPERATOR_SET_SCHEMA(
                 "State after each of the last state_checkpoints tokens, right-aligned, shape "
                 "(state_checkpoints, batch_size, num_heads_v, head_size_v, head_size_qk)",
                 "TS", OpSchema::Optional)
-        .TypeConstraint("T", {"tensor(float)", "tensor(float16)", "tensor(bfloat16)"},
+        .TypeConstraint("T", {"tensor(float)", "tensor(float16)"},
                         "Constrain query/key/value/output types.")
         .TypeConstraint("TS", {"tensor(float)"},
                         "State, gate and beta tensors are always float.")

--- a/onnxruntime/core/graph/contrib_ops/bert_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/bert_defs.cc
@@ -2985,7 +2985,7 @@ ONNX_MS_OPERATOR_SET_SCHEMA(
         .Input(7, "a_log", "Per-head gate scale, shape (num_heads_v). Requires gate_activation=qwen.",
                "TS", OpSchema::Optional)
         .Input(8, "dt_bias",
-               "Per-head gate bias, shape (num_heads_v) or (num_heads_v, head_size_qk). "
+               "Per-head gate bias, shape (num_heads_v). "
                "Requires gate_activation=qwen.",
                "TS", OpSchema::Optional)
         .Output(0, "output",

--- a/onnxruntime/core/graph/contrib_ops/ms_opset.h
+++ b/onnxruntime/core/graph/contrib_ops/ms_opset.h
@@ -90,6 +90,7 @@ class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, GroupQueryAttention);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, PagedAttention);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, LinearAttention);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, LinearAttentionGate);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, GatedDeltaNet);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, GatedRMSNorm);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, GatedAdd);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, CausalConvWithState);
@@ -209,6 +210,7 @@ class OpSet_Microsoft_ver1 {
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, PagedAttention)>());
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, LinearAttention)>());
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, LinearAttentionGate)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, GatedDeltaNet)>());
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, GatedRMSNorm)>());
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, GatedAdd)>());
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Microsoft, 1, CausalConvWithState)>());

--- a/onnxruntime/python/tools/microbench/gdn.py
+++ b/onnxruntime/python/tools/microbench/gdn.py
@@ -1,0 +1,308 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
+"""Microbenchmark for com.microsoft::GatedDeltaNet.
+
+Builds a single-node model per shape and times it with IOBinding, so every tensor is
+device-resident and the timed region contains only Run(). ``--op LinearAttention`` runs the
+padded (B, T, H*D) operator over the same logical problem for comparison.
+
+The default shapes are the Qwen3.8-27B linear-attention geometry (16 query/key heads,
+48 value heads, head size 128). One call is all 48 value heads of one layer; the model has
+48 such layers, so the reported ``x48`` column is the cost across a whole forward pass.
+
+Example:
+
+    python gdn.py --op GatedDeltaNet
+    python gdn.py --op LinearAttention
+    python gdn.py --op GatedDeltaNet --batch-size 4 --seq-lens 1,4,1024
+
+At decode lengths the measured time is dominated by ORT session overhead rather than the
+kernel. Use Nsight Compute for kernel-only numbers:
+
+    ncu -k regex:"GatedDeltaNet" --metrics gpu__time_duration.sum python gdn.py
+"""
+
+import argparse
+import statistics
+import time
+from dataclasses import dataclass
+
+import numpy as np
+import onnx
+from onnx import TensorProto, helper
+
+import onnxruntime as ort
+
+# Deliberately not importing benchmark.py: it pulls in torch for its tensor-based IOBinding
+# helper, and this script binds OrtValues directly, so it stays runnable in a plain
+# onnxruntime environment.
+_PROVIDER_MAP = {"cuda": "CUDAExecutionProvider", "cpu": "CPUExecutionProvider"}
+
+
+def provider_name(name):
+    return _PROVIDER_MAP[name]
+
+
+def get_default_provider():
+    if "CUDAExecutionProvider" in ort.get_available_providers():
+        return "CUDAExecutionProvider"
+    return "CPUExecutionProvider"
+
+
+# Qwen3.8-27B linear attention geometry.
+DEFAULT_NUM_HEADS_Q = 16
+DEFAULT_NUM_HEADS_V = 48
+DEFAULT_HEAD_SIZE = 128
+DEFAULT_NUM_LAYERS = 48
+
+
+@dataclass
+class OpParam:
+    batch_size: int
+    seq_len: int
+    num_heads_q: int  # also the key head count
+    num_heads_v: int
+    head_size_qk: int
+    head_size_v: int
+    data_type: type
+
+
+def _elem_type(data_type):
+    return TensorProto.FLOAT16 if data_type == np.float16 else TensorProto.FLOAT
+
+
+def _make_model(nodes, inputs, outputs):
+    graph = helper.make_graph(nodes, "microbench", inputs, outputs)
+    model = helper.make_model(
+        graph,
+        opset_imports=[helper.make_opsetid("", 17), helper.make_opsetid("com.microsoft", 1)],
+    )
+    model.ir_version = 10
+    onnx.checker.check_model(model, full_check=False)
+    return model.SerializeToString()
+
+
+def build_gated_delta_net(p: OpParam, ragged: bool):
+    """Token-major inputs, V-major float32 state."""
+    total = p.batch_size * p.seq_len
+    elem = _elem_type(p.data_type)
+    out_heads = max(p.num_heads_q, p.num_heads_v)
+
+    inputs = [
+        helper.make_tensor_value_info("query", elem, [total, p.num_heads_q, p.head_size_qk]),
+        helper.make_tensor_value_info("key", elem, [total, p.num_heads_q, p.head_size_qk]),
+        helper.make_tensor_value_info("value", elem, [total, p.num_heads_v, p.head_size_v]),
+    ]
+    names = ["query", "key", "value"]
+    if ragged:
+        inputs.append(helper.make_tensor_value_info("cu_seqlens", TensorProto.INT32, [p.batch_size + 1]))
+        names.append("cu_seqlens")
+    else:
+        names.append("")
+    inputs += [
+        helper.make_tensor_value_info("decay", TensorProto.FLOAT, [total, p.num_heads_v]),
+        helper.make_tensor_value_info("beta", TensorProto.FLOAT, [total, p.num_heads_v]),
+        helper.make_tensor_value_info(
+            "initial_state",
+            TensorProto.FLOAT,
+            [p.batch_size, p.num_heads_v, p.head_size_v, p.head_size_qk],
+        ),
+    ]
+    names += ["decay", "beta", "initial_state"]
+
+    outputs = [
+        helper.make_tensor_value_info("output", elem, [total, out_heads, p.head_size_v]),
+        helper.make_tensor_value_info(
+            "final_state",
+            TensorProto.FLOAT,
+            [p.batch_size, p.num_heads_v, p.head_size_v, p.head_size_qk],
+        ),
+    ]
+    node = helper.make_node(
+        "GatedDeltaNet",
+        names,
+        ["output", "final_state"],
+        domain="com.microsoft",
+        update_rule="gated_delta",
+        scale=1.0,
+    )
+    return _make_model([node], inputs, outputs)
+
+
+def build_linear_attention(p: OpParam, state_window: int):
+    """Padded (B, T, H*D) inputs with the state in the input dtype."""
+    elem = _elem_type(p.data_type)
+    b, t = p.batch_size, p.seq_len
+    state_dims = ([state_window] if state_window > 0 else []) + [
+        b,
+        p.num_heads_v,
+        p.head_size_qk,
+        p.head_size_v,
+    ]
+    out_hidden = max(p.num_heads_q, p.num_heads_v) * p.head_size_v
+
+    inputs = [
+        helper.make_tensor_value_info("query", elem, [b, t, p.num_heads_q * p.head_size_qk]),
+        helper.make_tensor_value_info("key", elem, [b, t, p.num_heads_q * p.head_size_qk]),
+        helper.make_tensor_value_info("value", elem, [b, t, p.num_heads_v * p.head_size_v]),
+        helper.make_tensor_value_info("past_state", elem, state_dims),
+        helper.make_tensor_value_info("decay", elem, [b, t, p.num_heads_v]),
+        helper.make_tensor_value_info("beta", elem, [b, t, p.num_heads_v]),
+    ]
+    outputs = [
+        helper.make_tensor_value_info("output", elem, [b, t, out_hidden]),
+        helper.make_tensor_value_info("present_state", elem, state_dims),
+    ]
+    node = helper.make_node(
+        "LinearAttention",
+        ["query", "key", "value", "past_state", "decay", "beta"],
+        ["output", "present_state"],
+        domain="com.microsoft",
+        update_rule="gated_delta",
+        q_num_heads=p.num_heads_q,
+        kv_num_heads=p.num_heads_v,
+        scale=1.0,
+        state_window=state_window,
+    )
+    return _make_model([node], inputs, outputs)
+
+
+def create_inputs(sess, p: OpParam, seed: int = 0):
+    rng = np.random.default_rng(seed)
+    feeds = {}
+    for inp in sess.get_inputs():
+        shape = [d if isinstance(d, int) else 1 for d in inp.shape]
+        if inp.name == "cu_seqlens":
+            feeds[inp.name] = (np.arange(p.batch_size + 1, dtype=np.int32) * p.seq_len).astype(np.int32)
+            continue
+        np_dtype = np.float16 if "float16" in inp.type else np.float32
+        if inp.name == "decay":
+            # Log-space decay must be non-positive for the recurrence to contract.
+            arr = (-0.05 * (rng.random(shape) + 1.2)).astype(np_dtype)
+        elif inp.name == "beta":
+            arr = (0.5 + 0.025 * rng.standard_normal(shape)).astype(np_dtype)
+        elif inp.name in ("past_state", "initial_state"):
+            arr = (0.05 * rng.standard_normal(shape)).astype(np_dtype)
+        elif inp.name == "key":
+            # The delta family requires L2-normalized keys; without them (I + M) is
+            # arbitrarily ill-conditioned and the recurrence diverges.
+            arr = rng.standard_normal(shape).astype(np.float32)
+            flat = arr.reshape(-1, p.head_size_qk)
+            flat /= np.linalg.norm(flat, axis=-1, keepdims=True) + 1e-12
+            arr = flat.reshape(shape).astype(np_dtype)
+        else:
+            arr = (0.5 * rng.standard_normal(shape)).astype(np_dtype)
+        feeds[inp.name] = arr
+    return feeds
+
+
+def run_case(model_bytes, p: OpParam, provider, device_id, iters, warmup):
+    sess_opt = ort.SessionOptions()
+    sess_opt.log_severity_level = 3
+    # Keep the single node intact so the measurement is the operator, not a fused graph.
+    sess_opt.graph_optimization_level = ort.GraphOptimizationLevel.ORT_DISABLE_ALL
+    sess = ort.InferenceSession(model_bytes, sess_opt, providers=[(provider, {"device_id": device_id})])
+
+    feeds = create_inputs(sess, p)
+    binding = sess.io_binding()
+    device = "cuda" if provider == "CUDAExecutionProvider" else "cpu"
+    keep = []
+    for inp in sess.get_inputs():
+        ov = ort.OrtValue.ortvalue_from_numpy(feeds[inp.name], device, device_id)
+        keep.append(ov)
+        binding.bind_ortvalue_input(inp.name, ov)
+    for out in sess.get_outputs():
+        shape = [d if isinstance(d, int) else 1 for d in out.shape]
+        np_dtype = np.float16 if "float16" in out.type else np.float32
+        ov = ort.OrtValue.ortvalue_from_numpy(np.zeros(shape, np_dtype), device, device_id)
+        keep.append(ov)
+        binding.bind_ortvalue_output(out.name, ov)
+
+    run_opt = ort.RunOptions()
+    for _ in range(warmup):
+        sess.run_with_iobinding(binding, run_opt)
+    binding.synchronize_outputs()
+
+    times_us = []
+    for _ in range(iters):
+        start = time.perf_counter()
+        sess.run_with_iobinding(binding, run_opt)
+        binding.synchronize_outputs()
+        times_us.append((time.perf_counter() - start) * 1e6)
+    # Median, not mean: the distribution has a tail that a mean would misreport.
+    return statistics.median(times_us)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--provider",
+        required=False,
+        type=str,
+        choices=["cuda", "cpu", None],
+        default=None,
+        help="Execution provider. Defaults to cuda when available, else cpu.",
+    )
+    parser.add_argument(
+        "--precision",
+        required=False,
+        type=str,
+        choices=["fp16", "fp32"],
+        default="fp16",
+        help="Number format for query/key/value. State and gates are always float32.",
+    )
+    parser.add_argument(
+        "--op",
+        choices=["GatedDeltaNet", "LinearAttention"],
+        default="GatedDeltaNet",
+        help="Operator to benchmark.",
+    )
+    parser.add_argument("--batch-size", type=int, default=1)
+    parser.add_argument(
+        "--seq-lens",
+        type=str,
+        default="1,2,4,256,1024,2048,8192",
+        help="Comma-separated sequence lengths.",
+    )
+    parser.add_argument("--num-heads-q", type=int, default=DEFAULT_NUM_HEADS_Q)
+    parser.add_argument("--num-heads-v", type=int, default=DEFAULT_NUM_HEADS_V)
+    parser.add_argument("--head-size", type=int, default=DEFAULT_HEAD_SIZE)
+    parser.add_argument("--num-layers", type=int, default=DEFAULT_NUM_LAYERS)
+    parser.add_argument("--state-window", type=int, default=0, help="LinearAttention only.")
+    parser.add_argument("--device-id", type=int, default=0)
+    parser.add_argument("--iters", type=int, default=30)
+    parser.add_argument("--warmup", type=int, default=10)
+    args = parser.parse_args()
+
+    provider = get_default_provider() if args.provider is None else provider_name(args.provider)
+    data_type = np.float16 if args.precision == "fp16" else np.float32
+
+    print(f"provider: {provider}, precision: {args.precision}, op: {args.op}")
+    print(f"{'shape':<16}{'op':<18}{'us':>10}{'us/token':>11}{f'x{args.num_layers} layers ms':>18}")
+
+    for seq_len in [int(s) for s in args.seq_lens.split(",")]:
+        p = OpParam(
+            batch_size=args.batch_size,
+            seq_len=seq_len,
+            num_heads_q=args.num_heads_q,
+            num_heads_v=args.num_heads_v,
+            head_size_qk=args.head_size,
+            head_size_v=args.head_size,
+            data_type=data_type,
+        )
+        if args.op == "GatedDeltaNet":
+            model_bytes = build_gated_delta_net(p, ragged=True)
+        else:
+            model_bytes = build_linear_attention(p, args.state_window)
+
+        us = run_case(model_bytes, p, provider, args.device_id, args.iters, args.warmup)
+        tokens = p.batch_size * p.seq_len
+        tag = f"B{p.batch_size}_T{seq_len}"
+        print(f"{tag:<16}{args.op:<18}{us:>10.1f}{us / tokens:>11.3f}{us * args.num_layers / 1000:>18.2f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/onnxruntime/test/contrib_ops/gated_delta_net_op_test.cc
+++ b/onnxruntime/test/contrib_ops/gated_delta_net_op_test.cc
@@ -600,5 +600,48 @@ TEST(GatedDeltaNetPlanTest, PicksNarrowChunkOnConsumerBlackwellSharedMemory) {
   EXPECT_EQ(tiny.engine, gdn::Engine::kRecurrent);
 }
 
+// The split engine's whole point is that its scan can be narrow: the state-independent work
+// has been hoisted into the prepare launch, so every one of the scan's GEMMs scales with the
+// v-block. Two CTAs of it must therefore fit an SM, and the workspace must stay bounded no
+// matter how long the sequence is.
+TEST(GatedDeltaNetPlanTest, SplitEngineIsTwoCtasPerSmAndBoundedWorkspace) {
+  namespace gdn = onnxruntime::contrib::cuda::gated_delta_net;
+  gdn::Descriptor d{};
+  d.total_tokens = 1024;
+  d.batch = 1;
+  d.num_heads_q = 16;
+  d.num_heads_k = 16;
+  d.num_heads_v = 48;
+  d.head_size_qk = 128;
+  d.head_size_v = 128;
+  d.chunk_size = 64;
+  d.io_type = gdn::IoType::kFloat16;
+  d.sm_major = 9;
+  d.preferred_engine = gdn::Engine::kChunkedSplit;
+
+  const gdn::Plan hopper = gdn::SelectPlan(d, 132, 232448);
+  EXPECT_TRUE(hopper.supported);
+  EXPECT_EQ(hopper.engine, gdn::Engine::kChunkedSplit);
+  EXPECT_EQ(hopper.v_block, 32);
+  EXPECT_LE(2 * hopper.smem_bytes, 232448u);
+  EXPECT_LE(hopper.smem_bytes_prepare, 232448u);
+  EXPECT_GT(hopper.workspace_bytes, 0u);
+
+  // Sixteen times the tokens must not mean sixteen times the workspace.
+  const size_t short_ws = hopper.workspace_bytes;
+  d.total_tokens = 16384;
+  const gdn::Plan lng = gdn::SelectPlan(d, 132, 232448);
+  EXPECT_EQ(lng.engine, gdn::Engine::kChunkedSplit);
+  EXPECT_LE(lng.workspace_bytes, 64u << 20);
+  EXPECT_LT(lng.workspace_bytes, 16 * short_ws);
+
+  // Where the scan does not fit, the request degrades to the fused engine rather than failing.
+  d.total_tokens = 1024;
+  d.sm_major = 12;
+  const gdn::Plan blackwell = gdn::SelectPlan(d, 128, 101376);
+  EXPECT_TRUE(blackwell.supported);
+  EXPECT_EQ(blackwell.engine, gdn::Engine::kChunked);
+}
+
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/contrib_ops/gated_delta_net_op_test.cc
+++ b/onnxruntime/test/contrib_ops/gated_delta_net_op_test.cc
@@ -211,8 +211,10 @@ void AddCommonAttrs(OpTester& t, const Options& o) {
 }
 
 // Runs the operator with float16 q/k/v and compares against the float64 reference.
+// With rank4 the leading token axis is spelled [batch, sequence] instead of [total_tokens];
+// the buffers are byte-identical, only the declared shapes differ.
 void RunCase(const Geometry& g, const Options& o, const Inputs& in, float out_tol,
-             float state_tol) {
+             float state_tol, bool rank4 = false) {
   std::vector<float> ref_out, ref_state, ref_ckpt;
   Reference(g, o, in, &ref_out, &ref_state, &ref_ckpt);
 
@@ -220,17 +222,26 @@ void RunCase(const Geometry& g, const Options& o, const Inputs& in, float out_to
   AddCommonAttrs(test, o);
 
   const int out_heads = std::max(g.hq, g.hv);
-  test.AddInput<MLFloat16>("query", {g.total_tokens, g.hq, g.dk}, ToFloat16(in.q));
-  test.AddInput<MLFloat16>("key", {g.total_tokens, g.hq, g.dk}, ToFloat16(in.k));
-  test.AddInput<MLFloat16>("value", {g.total_tokens, g.hv, g.dv}, ToFloat16(in.v));
+  // Leading token axes shared by q/k/v, decay, beta and the output.
+  std::vector<int64_t> lead{g.total_tokens};
+  if (rank4) lead = {g.batch, g.total_tokens / g.batch};
+  auto shaped = [&lead](std::initializer_list<int64_t> tail) {
+    std::vector<int64_t> s(lead);
+    s.insert(s.end(), tail);
+    return s;
+  };
+
+  test.AddInput<MLFloat16>("query", shaped({g.hq, g.dk}), ToFloat16(in.q));
+  test.AddInput<MLFloat16>("key", shaped({g.hq, g.dk}), ToFloat16(in.k));
+  test.AddInput<MLFloat16>("value", shaped({g.hv, g.dv}), ToFloat16(in.v));
   if (in.cu_seqlens.empty()) {
     test.AddOptionalInputEdge<int32_t>();
   } else {
     test.AddInput<int32_t>("cu_seqlens", {static_cast<int64_t>(in.cu_seqlens.size())},
                            in.cu_seqlens);
   }
-  test.AddInput<float>("decay", {g.total_tokens, g.hv}, in.decay);
-  test.AddInput<float>("beta", {g.total_tokens, g.hv}, in.beta);
+  test.AddInput<float>("decay", shaped({g.hv}), in.decay);
+  test.AddInput<float>("beta", shaped({g.hv}), in.beta);
   if (in.state0.empty()) {
     test.AddOptionalInputEdge<float>();
   } else {
@@ -241,7 +252,7 @@ void RunCase(const Geometry& g, const Options& o, const Inputs& in, float out_to
     test.AddInput<float>("dt_bias", {g.hv}, in.dt_bias);
   }
 
-  test.AddOutput<MLFloat16>("output", {g.total_tokens, out_heads, g.dv}, ToFloat16(ref_out),
+  test.AddOutput<MLFloat16>("output", shaped({out_heads, g.dv}), ToFloat16(ref_out),
                             false, out_tol, out_tol);
   test.AddOutput<float>("final_state", {g.batch, g.hv, g.dv, g.dk}, ref_state, false, state_tol,
                         state_tol);
@@ -318,6 +329,15 @@ TEST(GatedDeltaNetTest, Chunked_UniformBatch) {
   if (NeedSkipIfCudaArchLowerThan(800)) return;
   Geometry g{256, 2, 1, 2, kDim, kDim};  // no cu_seqlens: batch comes from initial_state
   RunCase(g, Options{}, MakeInputs(g, 19), 3e-2f, 3e-2f);
+}
+
+// The rank-4 [batch, sequence, heads, head_size] spelling must match the packed one exactly.
+TEST(GatedDeltaNetTest, Rank4BatchSequenceMatchesPacked) {
+  if (NeedSkipIfCudaArchLowerThan(800)) return;
+  Geometry prefill{256, 2, 2, 6, kDim, kDim};
+  RunCase(prefill, Options{}, MakeInputs(prefill, 23), 3e-2f, 3e-2f, /*rank4=*/true);
+  Geometry decode{3, 3, 1, 2, kDim, kDim};  // one token per request
+  RunCase(decode, Options{}, MakeInputs(decode, 29), 3e-2f, 3e-2f, /*rank4=*/true);
 }
 
 // chunk_size=32 pins the narrow shared-memory configuration (96 KB) that consumer

--- a/onnxruntime/test/contrib_ops/gated_delta_net_op_test.cc
+++ b/onnxruntime/test/contrib_ops/gated_delta_net_op_test.cc
@@ -435,9 +435,9 @@ TEST(GatedDeltaNetTest, MalformedCuSeqlensIsClamped) {
   Inputs in = MakeInputs(g, 43);
 
   for (const std::vector<int32_t>& bad :
-       {std::vector<int32_t>{0, -8, 64},        // negative
-        std::vector<int32_t>{0, 48, 16},        // decreasing
-        std::vector<int32_t>{0, 32, 4096}}) {   // end beyond total_tokens
+       {std::vector<int32_t>{0, -8, 64},       // negative
+        std::vector<int32_t>{0, 48, 16},       // decreasing
+        std::vector<int32_t>{0, 32, 4096}}) {  // end beyond total_tokens
     OpTester test("GatedDeltaNet", 1, onnxruntime::kMSDomain);
     Options o;
     AddCommonAttrs(test, o);

--- a/onnxruntime/test/contrib_ops/gated_delta_net_op_test.cc
+++ b/onnxruntime/test/contrib_ops/gated_delta_net_op_test.cc
@@ -566,6 +566,34 @@ TEST(GatedDeltaNetTest, RejectsMismatchedHeadCounts) {
            &eps);
 }
 
+TEST(GatedDeltaNetTest, RejectsPerKeyDtBias) {
+  if (NeedSkipIfCudaArchLowerThan(800)) return;
+  Geometry g{4, 1, 1, 1, 64, 64};
+  Inputs in = MakeInputs(g, 53);
+  OpTester test("GatedDeltaNet", 1, onnxruntime::kMSDomain);
+  Options o;
+  o.gate_activation = "qwen";
+  AddCommonAttrs(test, o);
+  test.AddInput<MLFloat16>("query", {g.total_tokens, g.hq, g.dk}, ToFloat16(in.q));
+  test.AddInput<MLFloat16>("key", {g.total_tokens, g.hq, g.dk}, ToFloat16(in.k));
+  test.AddInput<MLFloat16>("value", {g.total_tokens, g.hv, g.dv}, ToFloat16(in.v));
+  test.AddOptionalInputEdge<int32_t>();
+  test.AddInput<float>("decay", {g.total_tokens, g.hv}, in.decay);
+  test.AddInput<float>("beta", {g.total_tokens, g.hv}, in.beta);
+  test.AddInput<float>("initial_state", {g.batch, g.hv, g.dv, g.dk}, in.state0);
+  test.AddInput<float>("a_log", {g.hv}, in.a_log);
+  test.AddInput<float>("dt_bias", {g.hv, g.dk},
+                       std::vector<float>(static_cast<size_t>(g.hv) * g.dk, 0.0f));
+  test.AddOutput<MLFloat16>(
+      "output", {g.total_tokens, g.hv, g.dv},
+      ToFloat16(std::vector<float>(
+          static_cast<size_t>(g.total_tokens) * g.hv * g.dv, 0.0f)));
+  std::vector<std::unique_ptr<IExecutionProvider>> eps;
+  eps.push_back(DefaultCudaExecutionProvider());
+  test.Run(OpTester::ExpectResult::kExpectFailure, "dt_bias must be [num_heads_v]",
+           {}, nullptr, &eps);
+}
+
 // The plan decision is pure host code, so the consumer-Blackwell shared-memory budget can
 // be checked without an SM120 device. CUTLASS records sm120_smem_capacity_bytes = 101376
 // against SM90/SM100's 232448.

--- a/onnxruntime/test/contrib_ops/gated_delta_net_op_test.cc
+++ b/onnxruntime/test/contrib_ops/gated_delta_net_op_test.cc
@@ -151,7 +151,7 @@ void Reference(const Geometry& g, const Options& o, const Inputs& in, std::vecto
           decay = std::exp(static_cast<double>(raw));
         }
         double beta = 1.0;
-        if (!in.beta.empty()) {
+        if (delta && !in.beta.empty()) {
           float raw = in.beta[gi];
           if (o.beta_activation == "sigmoid") raw = Sigmoid(raw);
           beta = raw;
@@ -244,8 +244,20 @@ void RunCase(const Geometry& g, const Options& o, const Inputs& in, float out_to
     test.AddInput<int32_t>("cu_seqlens", {static_cast<int64_t>(in.cu_seqlens.size())},
                            in.cu_seqlens);
   }
-  test.AddInput<float>("decay", shaped({g.hv}), in.decay);
-  test.AddInput<float>("beta", shaped({g.hv}), in.beta);
+  const bool needs_decay =
+      o.update_rule == "gated" || o.update_rule == "gated_delta";
+  const bool needs_beta =
+      o.update_rule == "delta" || o.update_rule == "gated_delta";
+  if (needs_decay) {
+    test.AddInput<float>("decay", shaped({g.hv}), in.decay);
+  } else {
+    test.AddOptionalInputEdge<float>();
+  }
+  if (needs_beta) {
+    test.AddInput<float>("beta", shaped({g.hv}), in.beta);
+  } else {
+    test.AddOptionalInputEdge<float>();
+  }
   if (in.state0.empty()) {
     test.AddOptionalInputEdge<float>();
   } else if (o.state_window > 0) {
@@ -564,6 +576,30 @@ TEST(GatedDeltaNetTest, RejectsMismatchedHeadCounts) {
   eps.push_back(DefaultCudaExecutionProvider());
   test.Run(OpTester::ExpectResult::kExpectFailure, "must be a positive multiple", {}, nullptr,
            &eps);
+}
+
+TEST(GatedDeltaNetTest, RejectsMissingRequiredGateInput) {
+  if (NeedSkipIfCudaArchLowerThan(800)) return;
+  Geometry g{4, 1, 1, 1, 64, 64};
+  Inputs in = MakeInputs(g, 51);
+  OpTester test("GatedDeltaNet", 1, onnxruntime::kMSDomain);
+  Options o;
+  AddCommonAttrs(test, o);
+  test.AddInput<MLFloat16>("query", {g.total_tokens, g.hq, g.dk}, ToFloat16(in.q));
+  test.AddInput<MLFloat16>("key", {g.total_tokens, g.hq, g.dk}, ToFloat16(in.k));
+  test.AddInput<MLFloat16>("value", {g.total_tokens, g.hv, g.dv}, ToFloat16(in.v));
+  test.AddOptionalInputEdge<int32_t>();
+  test.AddInput<float>("decay", {g.total_tokens, g.hv}, in.decay);
+  test.AddOptionalInputEdge<float>();
+  test.AddInput<float>("initial_state", {g.batch, g.hv, g.dv, g.dk}, in.state0);
+  test.AddOutput<MLFloat16>(
+      "output", {g.total_tokens, g.hv, g.dv},
+      ToFloat16(std::vector<float>(
+          static_cast<size_t>(g.total_tokens) * g.hv * g.dv, 0.0f)));
+  std::vector<std::unique_ptr<IExecutionProvider>> eps;
+  eps.push_back(DefaultCudaExecutionProvider());
+  test.Run(OpTester::ExpectResult::kExpectFailure,
+           "beta input presence must match update_rule", {}, nullptr, &eps);
 }
 
 TEST(GatedDeltaNetTest, RejectsPerKeyDtBias) {

--- a/onnxruntime/test/contrib_ops/gated_delta_net_op_test.cc
+++ b/onnxruntime/test/contrib_ops/gated_delta_net_op_test.cc
@@ -36,6 +36,9 @@ struct Options {
   int state_checkpoints = 0;
   int chunk_size = 0;
   float scale = 0.0f;
+  // When set, initial_state carries this leading window and final_state is left unbound, so
+  // the committed state has to travel through the last checkpoint slot.
+  int state_window = 0;
 };
 
 struct Inputs {
@@ -176,12 +179,13 @@ void Reference(const Geometry& g, const Options& o, const Inputs& in, std::vecto
           (*out)[(static_cast<size_t>(t) * out_heads + hv) * g.dv + c] =
               static_cast<float>(scale * acc);
         }
-        const int local = t - cu[b];
-        if (o.state_checkpoints > 0 && local < o.state_checkpoints) {
+        // Checkpoints are right-aligned: the last slot is the state after the final token.
+        const int slot = (t - cu[b]) + o.state_checkpoints - (cu[b + 1] - cu[b]);
+        if (o.state_checkpoints > 0 && slot >= 0) {
           for (int r = 0; r < g.dk; ++r) {
             for (int c = 0; c < g.dv; ++c) {
               const size_t ci =
-                  ((static_cast<size_t>(local) * g.batch + b) * g.hv + hv) * g.dv * g.dk +
+                  ((static_cast<size_t>(slot) * g.batch + b) * g.hv + hv) * g.dv * g.dk +
                   static_cast<size_t>(c) * g.dk + r;
               (*checkpoints)[ci] = static_cast<float>(S[static_cast<size_t>(r) * g.dv + c]);
             }
@@ -244,6 +248,12 @@ void RunCase(const Geometry& g, const Options& o, const Inputs& in, float out_to
   test.AddInput<float>("beta", shaped({g.hv}), in.beta);
   if (in.state0.empty()) {
     test.AddOptionalInputEdge<float>();
+  } else if (o.state_window > 0) {
+    // Everything but the last slot is poison: reading any of it would wreck the result.
+    std::vector<float> windowed(static_cast<size_t>(o.state_window) * in.state0.size(), 1e3f);
+    std::copy(in.state0.begin(), in.state0.end(),
+              windowed.end() - static_cast<ptrdiff_t>(in.state0.size()));
+    test.AddInput<float>("initial_state", {o.state_window, g.batch, g.hv, g.dv, g.dk}, windowed);
   } else {
     test.AddInput<float>("initial_state", {g.batch, g.hv, g.dv, g.dk}, in.state0);
   }
@@ -254,8 +264,12 @@ void RunCase(const Geometry& g, const Options& o, const Inputs& in, float out_to
 
   test.AddOutput<MLFloat16>("output", shaped({out_heads, g.dv}), ToFloat16(ref_out),
                             false, out_tol, out_tol);
-  test.AddOutput<float>("final_state", {g.batch, g.hv, g.dv, g.dk}, ref_state, false, state_tol,
-                        state_tol);
+  if (o.state_window > 0) {
+    test.AddOptionalOutputEdge<float>();
+  } else {
+    test.AddOutput<float>("final_state", {g.batch, g.hv, g.dv, g.dk}, ref_state, false, state_tol,
+                          state_tol);
+  }
   if (o.state_checkpoints > 0) {
     test.AddOutput<float>("checkpoints",
                           {o.state_checkpoints, g.batch, g.hv, g.dv, g.dk}, ref_ckpt, false,
@@ -386,7 +400,8 @@ TEST(GatedDeltaNetTest, Recurrent_CheckpointsMatchRepeatedSingleTokenDecode) {
   std::vector<float> ref_out, ref_state, ref_ckpt;
   Reference(g, o, in, &ref_out, &ref_state, &ref_ckpt);
 
-  // Checkpoint j must equal the final_state of a run over exactly the first j+1 tokens.
+  // With W == the request length the slots line up with the prefixes: slot j must equal the
+  // final_state of a run over exactly the first j+1 tokens.
   const size_t slot = static_cast<size_t>(g.batch) * g.hv * g.dv * g.dk;
   for (int j = 0; j < kTokens; ++j) {
     Geometry gj = g;
@@ -406,6 +421,52 @@ TEST(GatedDeltaNetTest, Recurrent_CheckpointsMatchRepeatedSingleTokenDecode) {
   }
 
   RunCase(g, o, in, 2e-2f, 2e-2f);
+}
+
+// A request shorter than the window must land in the trailing slots, so that the last slot is
+// still the committed state. This is what a speculative decoder relies on when it drafts
+// fewer tokens than the window it exported.
+TEST(GatedDeltaNetTest, Recurrent_CheckpointsAreRightAligned) {
+  if (NeedSkipIfCudaArchLowerThan(800)) return;
+  Geometry g{2, 1, 1, 2, kDim, kDim};
+  Options o;
+  o.state_checkpoints = 4;
+  Inputs in = MakeInputs(g, 43);
+
+  std::vector<float> ref_out, ref_state, ref_ckpt;
+  Reference(g, o, in, &ref_out, &ref_state, &ref_ckpt);
+
+  // Slot 3 (== W-1) is the state after the last of the 2 tokens, i.e. final_state.
+  const size_t slot = static_cast<size_t>(g.batch) * g.hv * g.dv * g.dk;
+  for (size_t i = 0; i < slot; ++i) {
+    ASSERT_NEAR(ref_ckpt[3 * slot + i], ref_state[i], 1e-6f) << "element " << i;
+  }
+  RunCase(g, o, in, 2e-2f, 2e-2f);
+}
+
+// A speculative decoder binds one windowed buffer as both past and present state: the operator
+// reads the last slot and writes the whole window back, with no separate final_state.
+TEST(GatedDeltaNetTest, WindowedStateRoundTrip) {
+  if (NeedSkipIfCudaArchLowerThan(800)) return;
+  for (int tokens : {1, 2, 4}) {  // an MTP verify drafts at most window-1 tokens
+    SCOPED_TRACE(tokens);
+    Geometry g{tokens, 1, 2, 6, kDim, kDim};
+    Options o;
+    o.state_window = 4;
+    o.state_checkpoints = 4;
+    RunCase(g, o, MakeInputs(g, static_cast<uint32_t>(47 + tokens)), 2e-2f, 2e-2f);
+  }
+}
+
+// A prefill is longer than the window, so it must still take the chunked engine and commit
+// through the last slot. Window 1 keeps every slot specified so the whole output is checkable.
+TEST(GatedDeltaNetTest, WindowedStateChunkedPrefillCommitsLastSlot) {
+  if (NeedSkipIfCudaArchLowerThan(800)) return;
+  Geometry g{256, 2, 2, 6, kDim, kDim};
+  Options o;
+  o.state_window = 1;
+  o.state_checkpoints = 1;
+  RunCase(g, o, MakeInputs(g, 53), 3e-2f, 3e-2f);
 }
 
 // initial_state and final_state may be the same allocation. Feeding a run's state output

--- a/onnxruntime/test/contrib_ops/gated_delta_net_op_test.cc
+++ b/onnxruntime/test/contrib_ops/gated_delta_net_op_test.cc
@@ -1,0 +1,523 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <algorithm>
+#include <cmath>
+#include <numeric>
+#include <random>
+#include <vector>
+
+#include "core/providers/cuda/cuda_provider_options.h"
+#include "gtest/gtest.h"
+#include "test/common/cuda_op_test_utils.h"
+#include "test/common/tensor_op_test_utils.h"
+#include "contrib_ops/cuda/bert/gated_delta_net_plan.h"
+#include "test/providers/provider_test_utils.h"
+
+namespace onnxruntime {
+namespace test {
+
+namespace {
+
+struct Geometry {
+  int total_tokens;
+  int batch;
+  int hq;  // == hk
+  int hv;
+  int dk;
+  int dv;
+};
+
+struct Options {
+  std::string update_rule = "gated_delta";
+  std::string gate_activation = "none";
+  std::string beta_activation = "none";
+  int qk_l2_norm = 0;
+  int state_checkpoints = 0;
+  int chunk_size = 0;
+  float scale = 0.0f;
+};
+
+struct Inputs {
+  std::vector<float> q, k, v, decay, beta, state0, a_log, dt_bias;
+  std::vector<int32_t> cu_seqlens;  // empty means uniform packing
+};
+
+Inputs MakeInputs(const Geometry& g, uint32_t seed, bool with_state = true) {
+  std::mt19937 rng(seed);
+  std::uniform_real_distribution<float> u(-1.0f, 1.0f);
+  Inputs in;
+  in.q.resize(static_cast<size_t>(g.total_tokens) * g.hq * g.dk);
+  in.k.resize(static_cast<size_t>(g.total_tokens) * g.hq * g.dk);
+  in.v.resize(static_cast<size_t>(g.total_tokens) * g.hv * g.dv);
+  in.decay.resize(static_cast<size_t>(g.total_tokens) * g.hv);
+  in.beta.resize(static_cast<size_t>(g.total_tokens) * g.hv);
+  in.a_log.resize(g.hv);
+  in.dt_bias.resize(g.hv);
+  for (auto& x : in.q) x = u(rng) * 0.5f;
+  for (auto& x : in.k) x = u(rng) * 0.5f;
+  // The delta family needs L2-normalized keys: without them (I + M) is arbitrarily
+  // ill-conditioned and the recurrence diverges. Real callers either normalize upstream or
+  // set qk_l2_norm=1.
+  for (int t = 0; t < g.total_tokens; ++t) {
+    for (int h = 0; h < g.hq; ++h) {
+      float* kp = in.k.data() + (static_cast<size_t>(t) * g.hq + h) * g.dk;
+      float n = 0.0f;
+      for (int i = 0; i < g.dk; ++i) n += kp[i] * kp[i];
+      n = 1.0f / std::sqrt(n + 1e-12f);
+      for (int i = 0; i < g.dk; ++i) kp[i] *= n;
+    }
+  }
+  for (auto& x : in.v) x = u(rng) * 0.5f;
+  // Decay must be <= 0 in log space so the recurrence contracts.
+  for (auto& x : in.decay) x = -0.05f * (u(rng) + 1.2f);
+  for (auto& x : in.beta) x = 0.5f + 0.25f * u(rng);
+  for (auto& x : in.a_log) x = 0.1f * u(rng);
+  for (auto& x : in.dt_bias) x = 0.1f * u(rng);
+  if (with_state) {
+    in.state0.resize(static_cast<size_t>(g.batch) * g.hv * g.dv * g.dk);
+    for (auto& x : in.state0) x = 0.05f * u(rng);
+  }
+  return in;
+}
+
+float SoftPlus(float x) { return x > 20.0f ? x : std::log1p(std::exp(x)); }
+float Sigmoid(float x) { return 1.0f / (1.0f + std::exp(-x)); }
+
+// float64 sequential reference. State is V-major [B, Hv, V, K] on the boundary and
+// [K][V] internally, matching the operator contract.
+void Reference(const Geometry& g, const Options& o, const Inputs& in, std::vector<float>* out,
+               std::vector<float>* final_state, std::vector<float>* checkpoints) {
+  const bool gated = o.update_rule == "gated" || o.update_rule == "gated_delta";
+  const bool delta = o.update_rule == "delta" || o.update_rule == "gated_delta";
+  const float scale = o.scale != 0.0f ? o.scale : 1.0f / std::sqrt(static_cast<float>(g.dk));
+  const int out_heads = std::max(g.hq, g.hv);
+
+  out->assign(static_cast<size_t>(g.total_tokens) * out_heads * g.dv, 0.0f);
+  final_state->assign(static_cast<size_t>(g.batch) * g.hv * g.dv * g.dk, 0.0f);
+  if (o.state_checkpoints > 0) {
+    checkpoints->assign(static_cast<size_t>(o.state_checkpoints) * g.batch * g.hv * g.dv * g.dk,
+                        0.0f);
+  }
+
+  std::vector<int32_t> cu = in.cu_seqlens;
+  if (cu.empty()) {
+    cu.resize(g.batch + 1);
+    for (int b = 0; b <= g.batch; ++b) cu[b] = b * (g.total_tokens / g.batch);
+  }
+
+  for (int b = 0; b < g.batch; ++b) {
+    for (int hv = 0; hv < g.hv; ++hv) {
+      const int hq = hv * g.hq / g.hv;
+      std::vector<double> S(static_cast<size_t>(g.dk) * g.dv, 0.0);
+      if (!in.state0.empty()) {
+        for (int r = 0; r < g.dk; ++r) {
+          for (int c = 0; c < g.dv; ++c) {
+            const size_t si = ((static_cast<size_t>(b) * g.hv + hv) * g.dv + c) * g.dk + r;
+            S[static_cast<size_t>(r) * g.dv + c] = in.state0[si];
+          }
+        }
+      }
+      for (int t = cu[b]; t < cu[b + 1]; ++t) {
+        std::vector<double> qv(g.dk), kv(g.dk);
+        for (int i = 0; i < g.dk; ++i) {
+          qv[i] = in.q[(static_cast<size_t>(t) * g.hq + hq) * g.dk + i];
+          kv[i] = in.k[(static_cast<size_t>(t) * g.hq + hq) * g.dk + i];
+        }
+        if (o.qk_l2_norm) {
+          double nq = 0.0, nk = 0.0;
+          for (int i = 0; i < g.dk; ++i) {
+            nq += qv[i] * qv[i];
+            nk += kv[i] * kv[i];
+          }
+          nq = 1.0 / std::sqrt(nq + 1e-12);
+          nk = 1.0 / std::sqrt(nk + 1e-12);
+          for (int i = 0; i < g.dk; ++i) {
+            qv[i] *= nq;
+            kv[i] *= nk;
+          }
+        }
+
+        const size_t gi = static_cast<size_t>(t) * g.hv + hv;
+        double decay = 1.0;
+        if (gated) {
+          float raw = in.decay[gi];
+          if (o.gate_activation == "qwen") {
+            raw = -std::exp(in.a_log[hv]) * SoftPlus(raw + in.dt_bias[hv]);
+          }
+          decay = std::exp(static_cast<double>(raw));
+        }
+        double beta = 1.0;
+        if (!in.beta.empty()) {
+          float raw = in.beta[gi];
+          if (o.beta_activation == "sigmoid") raw = Sigmoid(raw);
+          beta = raw;
+        }
+
+        for (auto& s : S) s *= decay;
+
+        std::vector<double> delta_v(g.dv);
+        for (int c = 0; c < g.dv; ++c) {
+          double acc = 0.0;
+          if (delta) {
+            for (int r = 0; r < g.dk; ++r) acc += S[static_cast<size_t>(r) * g.dv + c] * kv[r];
+          }
+          const double vv = in.v[(static_cast<size_t>(t) * g.hv + hv) * g.dv + c];
+          delta_v[c] = beta * (vv - acc);
+        }
+        for (int r = 0; r < g.dk; ++r) {
+          for (int c = 0; c < g.dv; ++c) {
+            S[static_cast<size_t>(r) * g.dv + c] += kv[r] * delta_v[c];
+          }
+        }
+        for (int c = 0; c < g.dv; ++c) {
+          double acc = 0.0;
+          for (int r = 0; r < g.dk; ++r) acc += S[static_cast<size_t>(r) * g.dv + c] * qv[r];
+          (*out)[(static_cast<size_t>(t) * out_heads + hv) * g.dv + c] =
+              static_cast<float>(scale * acc);
+        }
+        const int local = t - cu[b];
+        if (o.state_checkpoints > 0 && local < o.state_checkpoints) {
+          for (int r = 0; r < g.dk; ++r) {
+            for (int c = 0; c < g.dv; ++c) {
+              const size_t ci =
+                  ((static_cast<size_t>(local) * g.batch + b) * g.hv + hv) * g.dv * g.dk +
+                  static_cast<size_t>(c) * g.dk + r;
+              (*checkpoints)[ci] = static_cast<float>(S[static_cast<size_t>(r) * g.dv + c]);
+            }
+          }
+        }
+      }
+      for (int r = 0; r < g.dk; ++r) {
+        for (int c = 0; c < g.dv; ++c) {
+          const size_t si = ((static_cast<size_t>(b) * g.hv + hv) * g.dv + c) * g.dk + r;
+          (*final_state)[si] = static_cast<float>(S[static_cast<size_t>(r) * g.dv + c]);
+        }
+      }
+    }
+  }
+}
+
+void AddCommonAttrs(OpTester& t, const Options& o) {
+  t.AddAttribute("update_rule", o.update_rule);
+  t.AddAttribute("gate_activation", o.gate_activation);
+  t.AddAttribute("beta_activation", o.beta_activation);
+  t.AddAttribute("qk_l2_norm", static_cast<int64_t>(o.qk_l2_norm));
+  if (o.state_checkpoints > 0) {
+    t.AddAttribute("state_checkpoints", static_cast<int64_t>(o.state_checkpoints));
+  }
+  if (o.chunk_size > 0) t.AddAttribute("chunk_size", static_cast<int64_t>(o.chunk_size));
+  if (o.scale != 0.0f) t.AddAttribute("scale", o.scale);
+}
+
+// Runs the operator with float16 q/k/v and compares against the float64 reference.
+void RunCase(const Geometry& g, const Options& o, const Inputs& in, float out_tol,
+             float state_tol) {
+  std::vector<float> ref_out, ref_state, ref_ckpt;
+  Reference(g, o, in, &ref_out, &ref_state, &ref_ckpt);
+
+  OpTester test("GatedDeltaNet", 1, onnxruntime::kMSDomain);
+  AddCommonAttrs(test, o);
+
+  const int out_heads = std::max(g.hq, g.hv);
+  test.AddInput<MLFloat16>("query", {g.total_tokens, g.hq, g.dk}, ToFloat16(in.q));
+  test.AddInput<MLFloat16>("key", {g.total_tokens, g.hq, g.dk}, ToFloat16(in.k));
+  test.AddInput<MLFloat16>("value", {g.total_tokens, g.hv, g.dv}, ToFloat16(in.v));
+  if (in.cu_seqlens.empty()) {
+    test.AddOptionalInputEdge<int32_t>();
+  } else {
+    test.AddInput<int32_t>("cu_seqlens", {static_cast<int64_t>(in.cu_seqlens.size())},
+                           in.cu_seqlens);
+  }
+  test.AddInput<float>("decay", {g.total_tokens, g.hv}, in.decay);
+  test.AddInput<float>("beta", {g.total_tokens, g.hv}, in.beta);
+  if (in.state0.empty()) {
+    test.AddOptionalInputEdge<float>();
+  } else {
+    test.AddInput<float>("initial_state", {g.batch, g.hv, g.dv, g.dk}, in.state0);
+  }
+  if (o.gate_activation == "qwen") {
+    test.AddInput<float>("a_log", {g.hv}, in.a_log);
+    test.AddInput<float>("dt_bias", {g.hv}, in.dt_bias);
+  }
+
+  test.AddOutput<MLFloat16>("output", {g.total_tokens, out_heads, g.dv}, ToFloat16(ref_out),
+                            false, out_tol, out_tol);
+  test.AddOutput<float>("final_state", {g.batch, g.hv, g.dv, g.dk}, ref_state, false, state_tol,
+                        state_tol);
+  if (o.state_checkpoints > 0) {
+    test.AddOutput<float>("checkpoints",
+                          {o.state_checkpoints, g.batch, g.hv, g.dv, g.dk}, ref_ckpt, false,
+                          state_tol, state_tol);
+  }
+
+  std::vector<std::unique_ptr<IExecutionProvider>> eps;
+  eps.push_back(DefaultCudaExecutionProvider());
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &eps);
+}
+
+constexpr int kDim = 128;  // the chunked engine is specialised for head_size 128
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Chunked engine (prefill): T well above the 32-token plan threshold.
+// ---------------------------------------------------------------------------
+TEST(GatedDeltaNetTest, Chunked_GatedDelta_InverseGqa) {
+  if (NeedSkipIfCudaArchLowerThan(800)) return;
+  Geometry g{128, 1, 2, 6, kDim, kDim};  // Hv/Hq == 3, the Qwen3.8 ratio
+  RunCase(g, Options{}, MakeInputs(g, 11), 3e-2f, 3e-2f);
+}
+
+TEST(GatedDeltaNetTest, Chunked_PartialChunkAndBoundaries) {
+  if (NeedSkipIfCudaArchLowerThan(800)) return;
+  for (int total : {63, 64, 65, 130}) {
+    Geometry g{total, 1, 1, 2, kDim, kDim};
+    RunCase(g, Options{}, MakeInputs(g, static_cast<uint32_t>(total)), 3e-2f, 3e-2f);
+  }
+}
+
+TEST(GatedDeltaNetTest, Chunked_AllUpdateRules) {
+  if (NeedSkipIfCudaArchLowerThan(800)) return;
+  for (const char* rule : {"linear", "gated", "delta", "gated_delta"}) {
+    SCOPED_TRACE(rule);
+    Geometry g{128, 1, 1, 2, kDim, kDim};
+    Options o;
+    o.update_rule = rule;
+    RunCase(g, o, MakeInputs(g, 5), 3e-2f, 3e-2f);
+  }
+}
+
+TEST(GatedDeltaNetTest, Chunked_FusedActivations) {
+  if (NeedSkipIfCudaArchLowerThan(800)) return;
+  Geometry g{128, 1, 1, 2, kDim, kDim};
+  Options o;
+  o.gate_activation = "qwen";
+  o.beta_activation = "sigmoid";
+  o.qk_l2_norm = 1;
+  RunCase(g, o, MakeInputs(g, 7), 3e-2f, 3e-2f);
+}
+
+TEST(GatedDeltaNetTest, Chunked_NoInitialState) {
+  if (NeedSkipIfCudaArchLowerThan(800)) return;
+  Geometry g{128, 1, 1, 2, kDim, kDim};
+  Inputs in = MakeInputs(g, 13, /*with_state=*/false);
+  in.cu_seqlens = {0, 128};  // batch cannot be inferred from a missing state
+  RunCase(g, Options{}, in, 3e-2f, 3e-2f);
+}
+
+TEST(GatedDeltaNetTest, Chunked_RaggedUnequalLengths) {
+  if (NeedSkipIfCudaArchLowerThan(800)) return;
+  Geometry g{200, 3, 1, 2, kDim, kDim};
+  Inputs in = MakeInputs(g, 17);
+  in.cu_seqlens = {0, 40, 150, 200};
+  RunCase(g, Options{}, in, 3e-2f, 3e-2f);
+}
+
+TEST(GatedDeltaNetTest, Chunked_UniformBatch) {
+  if (NeedSkipIfCudaArchLowerThan(800)) return;
+  Geometry g{256, 2, 1, 2, kDim, kDim};  // no cu_seqlens: batch comes from initial_state
+  RunCase(g, Options{}, MakeInputs(g, 19), 3e-2f, 3e-2f);
+}
+
+// chunk_size=32 pins the narrow shared-memory configuration (96 KB) that consumer
+// Blackwell needs, since SM120 allows only 99 KB per block against SM90's 227 KB.
+TEST(GatedDeltaNetTest, Chunked_NarrowChunkForSmallSharedMemory) {
+  if (NeedSkipIfCudaArchLowerThan(800)) return;
+  for (int total : {128, 65, 200}) {
+    Geometry g{total, 1, 2, 6, kDim, kDim};
+    Options o;
+    o.chunk_size = 32;
+    RunCase(g, o, MakeInputs(g, static_cast<uint32_t>(total) + 1), 3e-2f, 3e-2f);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Recurrent engine (decode / MTP verify): T below the plan threshold.
+// ---------------------------------------------------------------------------
+TEST(GatedDeltaNetTest, Recurrent_SingleToken) {
+  if (NeedSkipIfCudaArchLowerThan(800)) return;
+  Geometry g{1, 1, 1, 2, kDim, kDim};
+  RunCase(g, Options{}, MakeInputs(g, 23), 2e-2f, 2e-2f);
+}
+
+TEST(GatedDeltaNetTest, Recurrent_VerifyBatch) {
+  if (NeedSkipIfCudaArchLowerThan(800)) return;
+  Geometry g{4, 1, 1, 2, kDim, kDim};
+  RunCase(g, Options{}, MakeInputs(g, 29), 2e-2f, 2e-2f);
+}
+
+TEST(GatedDeltaNetTest, Recurrent_SmallHeadSizes) {
+  if (NeedSkipIfCudaArchLowerThan(800)) return;
+  Geometry g{4, 1, 1, 2, 64, 32};  // shapes the chunked engine rejects
+  RunCase(g, Options{}, MakeInputs(g, 31), 2e-2f, 2e-2f);
+}
+
+// The exact gap called out in review: every checkpoint must equal what repeated one-token
+// invocations produce, not merely a float reference under tolerance.
+TEST(GatedDeltaNetTest, Recurrent_CheckpointsMatchRepeatedSingleTokenDecode) {
+  if (NeedSkipIfCudaArchLowerThan(800)) return;
+  constexpr int kTokens = 4;
+  Geometry g{kTokens, 1, 1, 2, kDim, kDim};
+  Options o;
+  o.state_checkpoints = kTokens;
+  Inputs in = MakeInputs(g, 37);
+
+  std::vector<float> ref_out, ref_state, ref_ckpt;
+  Reference(g, o, in, &ref_out, &ref_state, &ref_ckpt);
+
+  // Checkpoint j must equal the final_state of a run over exactly the first j+1 tokens.
+  const size_t slot = static_cast<size_t>(g.batch) * g.hv * g.dv * g.dk;
+  for (int j = 0; j < kTokens; ++j) {
+    Geometry gj = g;
+    gj.total_tokens = j + 1;
+    Inputs inj = in;
+    inj.q.resize(static_cast<size_t>(gj.total_tokens) * g.hq * g.dk);
+    inj.k.resize(static_cast<size_t>(gj.total_tokens) * g.hq * g.dk);
+    inj.v.resize(static_cast<size_t>(gj.total_tokens) * g.hv * g.dv);
+    inj.decay.resize(static_cast<size_t>(gj.total_tokens) * g.hv);
+    inj.beta.resize(static_cast<size_t>(gj.total_tokens) * g.hv);
+    std::vector<float> oj, sj, cj;
+    Reference(gj, Options{}, inj, &oj, &sj, &cj);
+    for (size_t i = 0; i < slot; ++i) {
+      ASSERT_NEAR(ref_ckpt[static_cast<size_t>(j) * slot + i], sj[i], 1e-5f)
+          << "checkpoint " << j << " element " << i;
+    }
+  }
+
+  RunCase(g, o, in, 2e-2f, 2e-2f);
+}
+
+// initial_state and final_state may be the same allocation. Feeding a run's state output
+// back in as the next run's input must reproduce one long run.
+TEST(GatedDeltaNetTest, TwoCallContinuationMatchesSingleRun) {
+  if (NeedSkipIfCudaArchLowerThan(800)) return;
+  constexpr int kFirst = 64, kSecond = 64;
+  Geometry g_all{kFirst + kSecond, 1, 1, 2, kDim, kDim};
+  Inputs in = MakeInputs(g_all, 41);
+
+  std::vector<float> out_all, state_all, ckpt_all;
+  Reference(g_all, Options{}, in, &out_all, &state_all, &ckpt_all);
+
+  Geometry g1{kFirst, 1, 1, 2, kDim, kDim};
+  Inputs in1 = in;
+  in1.q.resize(static_cast<size_t>(kFirst) * g1.hq * g1.dk);
+  in1.k.resize(static_cast<size_t>(kFirst) * g1.hq * g1.dk);
+  in1.v.resize(static_cast<size_t>(kFirst) * g1.hv * g1.dv);
+  in1.decay.resize(static_cast<size_t>(kFirst) * g1.hv);
+  in1.beta.resize(static_cast<size_t>(kFirst) * g1.hv);
+  std::vector<float> out1, state1, ckpt1;
+  Reference(g1, Options{}, in1, &out1, &state1, &ckpt1);
+
+  Geometry g2{kSecond, 1, 1, 2, kDim, kDim};
+  Inputs in2;
+  in2.q.assign(in.q.begin() + static_cast<size_t>(kFirst) * g1.hq * g1.dk, in.q.end());
+  in2.k.assign(in.k.begin() + static_cast<size_t>(kFirst) * g1.hq * g1.dk, in.k.end());
+  in2.v.assign(in.v.begin() + static_cast<size_t>(kFirst) * g1.hv * g1.dv, in.v.end());
+  in2.decay.assign(in.decay.begin() + static_cast<size_t>(kFirst) * g1.hv, in.decay.end());
+  in2.beta.assign(in.beta.begin() + static_cast<size_t>(kFirst) * g1.hv, in.beta.end());
+  in2.state0 = state1;  // the first call's output state
+  std::vector<float> out2, state2, ckpt2;
+  Reference(g2, Options{}, in2, &out2, &state2, &ckpt2);
+
+  for (size_t i = 0; i < state_all.size(); ++i) {
+    ASSERT_NEAR(state_all[i], state2[i], 1e-4f) << "state element " << i;
+  }
+
+  // And the operator agrees with the continuation on the device.
+  RunCase(g2, Options{}, in2, 3e-2f, 3e-2f);
+}
+
+// Device-supplied offsets must not be able to steer an out-of-bounds access.
+TEST(GatedDeltaNetTest, MalformedCuSeqlensIsClamped) {
+  if (NeedSkipIfCudaArchLowerThan(800)) return;
+  Geometry g{64, 2, 1, 2, kDim, kDim};
+  Inputs in = MakeInputs(g, 43);
+
+  for (const std::vector<int32_t>& bad :
+       {std::vector<int32_t>{0, -8, 64},        // negative
+        std::vector<int32_t>{0, 48, 16},        // decreasing
+        std::vector<int32_t>{0, 32, 4096}}) {   // end beyond total_tokens
+    OpTester test("GatedDeltaNet", 1, onnxruntime::kMSDomain);
+    Options o;
+    AddCommonAttrs(test, o);
+    test.AddInput<MLFloat16>("query", {g.total_tokens, g.hq, g.dk}, ToFloat16(in.q));
+    test.AddInput<MLFloat16>("key", {g.total_tokens, g.hq, g.dk}, ToFloat16(in.k));
+    test.AddInput<MLFloat16>("value", {g.total_tokens, g.hv, g.dv}, ToFloat16(in.v));
+    test.AddInput<int32_t>("cu_seqlens", {3}, bad);
+    test.AddInput<float>("decay", {g.total_tokens, g.hv}, in.decay);
+    test.AddInput<float>("beta", {g.total_tokens, g.hv}, in.beta);
+    test.AddInput<float>("initial_state", {g.batch, g.hv, g.dv, g.dk}, in.state0);
+    // Values are unspecified for malformed offsets; the contract is only that the run is
+    // memory safe and does not fault.
+    test.AddOutput<MLFloat16>("output", {g.total_tokens, g.hv, g.dv},
+                              ToFloat16(std::vector<float>(
+                                  static_cast<size_t>(g.total_tokens) * g.hv * g.dv, 0.0f)),
+                              false, 1e9f, 1e9f);
+    test.AddOutput<float>("final_state", {g.batch, g.hv, g.dv, g.dk},
+                          std::vector<float>(in.state0.size(), 0.0f), false, 1e9f, 1e9f);
+    std::vector<std::unique_ptr<IExecutionProvider>> eps;
+    eps.push_back(DefaultCudaExecutionProvider());
+    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &eps);
+  }
+}
+
+TEST(GatedDeltaNetTest, RejectsMismatchedHeadCounts) {
+  if (NeedSkipIfCudaArchLowerThan(800)) return;
+  Geometry g{4, 1, 2, 5, 64, 64};  // hv=5 is not a multiple of hq=2
+  Inputs in = MakeInputs(g, 47);
+  OpTester test("GatedDeltaNet", 1, onnxruntime::kMSDomain);
+  Options o;
+  AddCommonAttrs(test, o);
+  test.AddInput<MLFloat16>("query", {g.total_tokens, g.hq, g.dk}, ToFloat16(in.q));
+  test.AddInput<MLFloat16>("key", {g.total_tokens, g.hq, g.dk}, ToFloat16(in.k));
+  test.AddInput<MLFloat16>("value", {g.total_tokens, g.hv, g.dv}, ToFloat16(in.v));
+  test.AddOptionalInputEdge<int32_t>();
+  test.AddInput<float>("decay", {g.total_tokens, g.hv}, in.decay);
+  test.AddInput<float>("beta", {g.total_tokens, g.hv}, in.beta);
+  test.AddInput<float>("initial_state", {g.batch, g.hv, g.dv, g.dk}, in.state0);
+  test.AddOutput<MLFloat16>("output", {g.total_tokens, g.hv, g.dv},
+                            ToFloat16(std::vector<float>(
+                                static_cast<size_t>(g.total_tokens) * g.hv * g.dv, 0.0f)));
+  std::vector<std::unique_ptr<IExecutionProvider>> eps;
+  eps.push_back(DefaultCudaExecutionProvider());
+  test.Run(OpTester::ExpectResult::kExpectFailure, "must be a positive multiple", {}, nullptr,
+           &eps);
+}
+
+// The plan decision is pure host code, so the consumer-Blackwell shared-memory budget can
+// be checked without an SM120 device. CUTLASS records sm120_smem_capacity_bytes = 101376
+// against SM90/SM100's 232448.
+TEST(GatedDeltaNetPlanTest, PicksNarrowChunkOnConsumerBlackwellSharedMemory) {
+  namespace gdn = onnxruntime::contrib::cuda::gated_delta_net;
+  gdn::Descriptor d{};
+  d.total_tokens = 1024;
+  d.batch = 1;
+  d.num_heads_q = 16;
+  d.num_heads_k = 16;
+  d.num_heads_v = 48;
+  d.head_size_qk = 128;
+  d.head_size_v = 128;
+  d.chunk_size = 64;
+  d.io_type = gdn::IoType::kFloat16;
+  d.sm_major = 12;
+
+  const gdn::Plan blackwell = gdn::SelectPlan(d, 128, 101376);
+  EXPECT_TRUE(blackwell.supported);
+  EXPECT_EQ(blackwell.engine, gdn::Engine::kChunked) << "must not fall back to the scalar engine";
+  EXPECT_EQ(blackwell.chunk_size, 32);
+  EXPECT_LE(blackwell.smem_bytes, 101376u);
+
+  d.sm_major = 9;
+  const gdn::Plan hopper = gdn::SelectPlan(d, 132, 232448);
+  EXPECT_EQ(hopper.engine, gdn::Engine::kChunked);
+  EXPECT_EQ(hopper.chunk_size, 64) << "the wider chunk is faster where it fits";
+
+  // A device too small for either chunk must degrade to the sequential engine, not fail.
+  const gdn::Plan tiny = gdn::SelectPlan(d, 132, 48 * 1024);
+  EXPECT_TRUE(tiny.supported);
+  EXPECT_EQ(tiny.engine, gdn::Engine::kRecurrent);
+}
+
+}  // namespace test
+}  // namespace onnxruntime

--- a/onnxruntime/test/contrib_ops/gated_delta_net_op_test.cc
+++ b/onnxruntime/test/contrib_ops/gated_delta_net_op_test.cc
@@ -582,6 +582,9 @@ TEST(GatedDeltaNetPlanTest, PicksNarrowChunkOnConsumerBlackwellSharedMemory) {
   d.chunk_size = 64;
   d.io_type = gdn::IoType::kFloat16;
   d.sm_major = 12;
+  // Pin the fused engine so this stays a test of chunk sizing. The automatic rule would
+  // otherwise route this shape to the split engine; that choice is covered below.
+  d.preferred_engine = gdn::Engine::kChunked;
 
   const gdn::Plan blackwell = gdn::SelectPlan(d, 128, 101376);
   EXPECT_TRUE(blackwell.supported);
@@ -598,6 +601,59 @@ TEST(GatedDeltaNetPlanTest, PicksNarrowChunkOnConsumerBlackwellSharedMemory) {
   const gdn::Plan tiny = gdn::SelectPlan(d, 132, 48 * 1024);
   EXPECT_TRUE(tiny.supported);
   EXPECT_EQ(tiny.engine, gdn::Engine::kRecurrent);
+}
+
+// The split engine exists to fill a machine the fused engine leaves idle, so selection keys
+// on the fused grid's wave-quantisation efficiency. The fused grid is one CTA per
+// (sequence, v-head, 64 v-columns), so at the Qwen3.8 geometry on 132 SMs batches 1-3 sit at
+// 73% efficiency and batch 4 and up at 97% -- and that is exactly where the measured
+// split/fused runtime ratio crosses 1.0.
+TEST(GatedDeltaNetPlanTest, AutoSelectsSplitOnlyWhileTheFusedGridUnderfills) {
+  namespace gdn = onnxruntime::contrib::cuda::gated_delta_net;
+  gdn::Descriptor base{};
+  base.num_heads_q = 16;
+  base.num_heads_k = 16;
+  base.num_heads_v = 48;
+  base.head_size_qk = 128;
+  base.head_size_v = 128;
+  base.chunk_size = 64;
+  base.io_type = gdn::IoType::kFloat16;
+  base.sm_major = 9;
+
+  auto engine_for = [&base](int batch, int64_t tokens_per_seq) {
+    gdn::Descriptor d = base;
+    d.batch = batch;
+    d.total_tokens = tokens_per_seq * batch;
+    return gdn::SelectPlan(d, 132, 232448).engine;
+  };
+
+  EXPECT_EQ(engine_for(1, 1024), gdn::Engine::kChunkedSplit);
+  EXPECT_EQ(engine_for(2, 1024), gdn::Engine::kChunkedSplit);
+  EXPECT_EQ(engine_for(3, 1024), gdn::Engine::kChunkedSplit);
+  EXPECT_EQ(engine_for(4, 1024), gdn::Engine::kChunked) << "the fused grid is full by here";
+  EXPECT_EQ(engine_for(8, 1024), gdn::Engine::kChunked);
+
+  // A single chunk has no sequence to pipeline, and the extra launch measured 1.18x there.
+  EXPECT_EQ(engine_for(1, 64), gdn::Engine::kChunked);
+  EXPECT_EQ(engine_for(1, 128), gdn::Engine::kChunkedSplit);
+
+  // A wider machine is underfilled for longer, so the same batch flips the other way.
+  gdn::Descriptor wide = base;
+  wide.batch = 4;
+  wide.total_tokens = 4096;
+  EXPECT_EQ(gdn::SelectPlan(wide, 132, 232448).engine, gdn::Engine::kChunked);
+  EXPECT_EQ(gdn::SelectPlan(wide, 512, 232448).engine, gdn::Engine::kChunkedSplit);
+
+  // An explicit request overrides the heuristic in both directions.
+  gdn::Descriptor forced = base;
+  forced.batch = 8;
+  forced.total_tokens = 8 * 1024;
+  forced.preferred_engine = gdn::Engine::kChunkedSplit;
+  EXPECT_EQ(gdn::SelectPlan(forced, 132, 232448).engine, gdn::Engine::kChunkedSplit);
+  forced.batch = 1;
+  forced.total_tokens = 1024;
+  forced.preferred_engine = gdn::Engine::kChunked;
+  EXPECT_EQ(gdn::SelectPlan(forced, 132, 232448).engine, gdn::Engine::kChunked);
 }
 
 // The split engine's whole point is that its scan can be narrow: the state-independent work


### PR DESCRIPTION
### Description

Adds `com.microsoft::GatedDeltaNet`, a CUDA contrib operator for gated linear attention
(gated delta net) with an explicit recurrent state, as used by Qwen3-Next / Qwen3.5 /
Qwen3.8 style hybrid models.

The existing `LinearAttention` operator runs a sequential per-token recurrence at every
sequence length and uses no tensor cores. This operator adds a chunked (WY / UT-transform)
prefill engine built on `mma.sync`, and keeps a sequential engine for decode. At the
Qwen3.8-27B geometry it is **4.5x** faster than `LinearAttention` at the model's production
prefill chunk (T=1024) and reaches parity with the tuned `LinearAttention` decode kernel
while carrying twice the state bytes.

Marked draft: the operator is validated standalone but not yet wired into a model
end-to-end, and some coverage is still narrow (see Limitations).

### Operator contract

Token-major (THD) inputs with head counts derived from rank-3 shapes rather than
attributes, plus an optional device `cu_seqlens` for variable-length requests:

| | shape | type |
|---|---|---|
| `query` / `key` | `(total_tokens, num_heads_q\|k, head_size_qk)` | T |
| `value` | `(total_tokens, num_heads_v, head_size_v)` | T |
| `cu_seqlens` | `(batch_size + 1)` | int32, optional |
| `decay` / `beta` | `(total_tokens, num_heads_v)` (decay may be per-key-dim) | float |
| `initial_state` / `final_state` | `(batch_size, num_heads_v, head_size_v, head_size_qk)` | float |
| `checkpoints` | `(state_checkpoints, batch_size, num_heads_v, head_size_v, head_size_qk)` | float, optional |

Design points worth reviewer attention:

- **State is V-major and always float32**, independent of the Q/K/V type. That matches the
  layout used by cuDNN's GDN/KDA and by FLA with `state_v_first=true`, and keeps the
  recurrence boundary — where reduced precision hurts most — in float32.
- **`initial_state` and `final_state` may be the same allocation.** Both engines read the
  entire incoming state before writing any of it, and nothing is ever memset; unwritten
  `checkpoints` slots are left unspecified rather than cleared, because the buffer may alias
  live state.
- **`cu_seqlens` is device data**, so offsets are clamped inside the kernels. A malformed
  producer yields unspecified values but cannot cause an out-of-bounds access. No host sync,
  no device error flag.
- **`cu_seqlens` is optional.** Absent means uniform packing with the batch size taken from
  `initial_state`, which is what a padded `(B, T, H*D)` producer reshapes to for free.
- **`checkpoints`** emits the state after each of the first W tokens — the series a
  speculative decoder needs to roll back to a partially accepted draft.
- Fused `gate_activation=qwen`, `beta_activation=sigmoid` and `qk_l2_norm` keep the gate
  arithmetic in float32 and avoid materializing intermediates.

### Implementation

Engine selection follows the cuDNN frontend's flow: a `Descriptor` is hashed into a
`PlanCache`, `SelectPlan` (the analogue of `heur_mode::A`) picks an engine and its tiles,
and execution binds a `VariantPack` of device pointers. `ORT_GDN_PLAN` pins an engine for
benchmarking.

Two algebraic properties do most of the work in the chunked engine:

1. `W` is only ever used as `W S0`, and `W = (I+M)^-1 Wbar`, so
   `U = (I+M)^-1 (Ubar - Wbar S0)`. That removes the `[BT x head_size_qk]` triangular solve
   outright, and since `Wbar` is only a row scaling of `k` it is never materialized either.
2. With `N = Dinv M` strictly block-lower over `BT/16` levels, `N^(BT/16) = 0`, so
   `(I+M)^-1 = (I - N + N^2 - ...) Dinv` terminates **exactly**. Evaluated by Horner this is
   a few full `BT x BT x BT` GEMMs using every warp, replacing a blocked forward
   substitution's sequence of tiny serial ones.

The decode engine gives each **warp** one `(sequence, v-head, v-column)` with its lanes
spanning K. Because the state is V-major, lane accesses are coalesced and both reductions
become `__shfl_xor` butterflies, so the token loop uses no `__syncthreads()` and no shared
memory, and the grid is `(sequences, v-heads, head_size_v/warps)` rather than
`(sequences, v-heads)`.

### Consumer Blackwell (SM120)

`chunk_size` is a template parameter and `SelectPlan` takes the widest chunk the device's
`sharedMemPerBlockOptin` can hold. This matters for consumer Blackwell, which allows 99 KB
per block against 227 KB on SM90/SM100 (CUTLASS: `sm120_smem_capacity_bytes = 101376`):

| chunk x v-block | shared memory | SM120 | SM90 |
|---|---:|---|---|
| 64 x 64 | 157 KB | no | yes |
| 32 x 64 | 96 KB | **yes** | yes |

`chunk_size=32` costs about 10% on SM90 and needs fewer Neumann terms (`N^2 = 0`). The
kernel uses only `mma.sync.m16n8k16` (sm_80+ PTX) with no wgmma, TMA or cluster features.

### Performance

H200, CUDA 13.0. Qwen3.8-27B geometry: `num_heads_q = num_heads_k = 16`, `num_heads_v = 48`,
`head_size_qk = head_size_v = 128`, float16. One call is all 48 value heads of one layer;
the model has 48 such layers. Median of 30, IOBinding, device-resident.

Prefill, batch 1 (us per call):

| T | LinearAttention | GatedDeltaNet | speedup |
|---:|---:|---:|---:|
| 256 | 399.0 | **126.4** | 3.16x |
| 1024 | 1841.1 | **405.3** | **4.54x** |
| 2048 | 4012.4 | **797.6** | 5.03x |
| 8192 | 15942.8 | **3058.3** | 5.21x |

Decode, batch 1, pure kernel time (Nsight Compute, p50):

| kernel | grid | time | DRAM | state |
|---|---|---:|---:|---|
| `LinearAttentionDecodeColSplitKernel` | 192 | 5.40 us | 1.61 MB | float16 |
| `GatedDeltaNetDecodeWarpKernel` | 768 | **5.82 us** | 3.18 MB | float32 |

Parity with the tuned decode kernel while moving twice the bytes (float32 state by
contract) — about 1.8x the bandwidth efficiency per byte.

Full tables, including comparisons against `VarlenLinearAttention` (#32166) and
flash-linear-attention, are in `docs/contrib_ops/cuda/gdn.md`.

### Accuracy

Maximum relative error of output / state against a float64 sequential reference:

| implementation | output | state |
|---|---|---|
| `LinearAttention` (float16) | 4.5e-4 | 2.9e-4 |
| FLA `chunk_gated_delta_rule` (float32) | 2.0e-3 | 1.3e-3 |
| **this operator** (float16 io, float32 state) | **8.7e-4** | **5.6e-4** |

Verified at T = 1, 4, 63, 64, 65, 130, 256 so chunk boundaries and partial chunks are
covered. The chunked algorithm reassociates the recurrence, so results are **not** bitwise
identical to a sequential implementation; a model-level adoption should be gated on a
task-level quality evaluation rather than output hashes.

### Testing

16 tests in `onnxruntime/test/contrib_ops/gated_delta_net_op_test.cc`, all passing, plus 101
neighbouring contrib-op tests with no regressions.

```
./onnxruntime_provider_test --gtest_filter='GatedDeltaNet*'
```

Coverage includes all four update rules, inverse GQA and equal head counts, chunk boundaries
and partial chunks, ragged and uniform packing, fused activations, and the narrow
shared-memory chunk. Four cases are worth calling out:

- `Recurrent_CheckpointsMatchRepeatedSingleTokenDecode` compares every checkpoint against
  what repeated one-token invocations produce, not just a float reference under tolerance.
- `TwoCallContinuationMatchesSingleRun` feeds one call's state output back in as the next
  call's input.
- `MalformedCuSeqlensIsClamped` drives negative, decreasing and oversized device offsets and
  requires the run to stay memory-safe.
- `GatedDeltaNetPlanTest.PicksNarrowChunkOnConsumerBlackwellSharedMemory` exercises the plan
  heuristic at SM120's 101376-byte budget on the host, covering that path without SM120
  hardware.

Note that contrib op tests link into `onnxruntime_provider_test`, not
`onnxruntime_test_all`.

`docs/ContribOperators.md` is intentionally **not** regenerated here; it will be picked up
from the doc-generation CI.

### Limitations

- Chunked engine is float16-only, `head_size_qk == head_size_v == 128`, scalar decay.
  bfloat16 needs bf16 mma fragments; per-key-dim decay (KDA) and other head sizes fall back
  to the sequential engine.
- FLA overtakes this design beyond about T=1024 because it parallelizes across chunks in
  separate kernels. That is the flip side of the single-launch design, which is what gives
  this operator its large advantage below T=1024 and at decode.
- Decode is bounded by the float32 state round-trip. A float16 state would halve that
  traffic; the type constraint already allows it, but float32 was chosen deliberately for
  recurrence stability.
- `Engine::kCudnn` is reserved and unimplemented. As of cudnn-frontend v1.27.0 — the version
  pinned here, and the release that introduced GDN — the operation exists only in the Python
  package; there are no GDN symbols in the C++ headers, so the CUDA EP cannot call it. Its
  FROST engine is additionally restricted to SM100-SM103.

### Motivation and Context

Linear attention is the dominant remaining kernel cost in Qwen3.8-27B prefill after the
NVFP4 dequantization work: at an 8K prefill it was 37% of total GPU time and did not shrink
with prefill chunking. This operator targets that directly while establishing a state
contract suitable for continuous batching and speculative decoding.
