### PR TITLE
Fix CUDA minimal MatMulNBits workspace linkage

### DIFF
--- a/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
+++ b/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
@@ -41,7 +41,7 @@
 
 #include "core/providers/cuda/cuda_stream_handle.h"
 
-#if !defined(DISABLE_CONTRIB_OPS) && USE_FPA_INTB_GEMM
+#if !defined(DISABLE_CONTRIB_OPS) && !defined(USE_CUDA_MINIMAL) && USE_FPA_INTB_GEMM
 #include "contrib_ops/cuda/quantization/matmul_nbits_workspace_estimate.h"
 #endif
 
@@ -3534,7 +3534,7 @@ CUDAExecutionProvider::GetCapability(const onnxruntime::GraphViewer& graph,
       auto* node = graph.GetNode(node_index);
       auto resource_count = std::get<0>(resource_accountant->ComputeResourceCount(*node));
 
-#if !defined(DISABLE_CONTRIB_OPS) && USE_FPA_INTB_GEMM
+#if !defined(DISABLE_CONTRIB_OPS) && !defined(USE_CUDA_MINIMAL) && USE_FPA_INTB_GEMM
       // Level 1 (Phase-A memory roadmap, issue microsoft/onnxruntime#29775): a partition-time,
       // kernel-independent workspace estimate for MatMulNBits. For this pilot it is log-only and
       // does NOT change the budget number used by the accept/reject decision below (see the issue's

--- a/tools/ci_build/github/linux/build_tensorrt_ci.sh
+++ b/tools/ci_build/github/linux/build_tensorrt_ci.sh
@@ -40,10 +40,11 @@ if [ -x "$(command -v ninja)" ]; then
 fi
 
 if [ -d /build ]; then
-    BUILD_ARGS+=('--build_dir' '/build')
+    BUILD_DIR='/build'
 else
-    BUILD_ARGS+=('--build_dir' 'build')
+    BUILD_DIR='build'
 fi
+BUILD_ARGS+=('--build_dir' "${BUILD_DIR}")
 
 if command -v ccache &> /dev/null; then
     ccache --zero-stats
@@ -59,4 +60,9 @@ fi
 if command -v ccache &> /dev/null; then
     # FIXME: can't use `-vv` for extra details b/c we're shipping with a decrepit version of ccache (3.something) that doesn't support it.
     ccache --show-stats # -vv
+fi
+
+if [[ " ${BUILD_ARGS[*]} " == *" --enable_cuda_minimal_build "* ]]; then
+    ! nm -D --undefined-only "${BUILD_DIR}/Release/libonnxruntime_providers_cuda.so" |
+        c++filt | grep -q 'EstimateMatMulNBitsWorkspace'
 fi


### PR DESCRIPTION
### Description

Fixes #32154

Do not compile the MatMulNBits workspace estimator include or calls in a CUDA minimal build. CUDA minimal excludes the source file that defines those functions.

Extend the Linux TensorRT CUDA-minimal CI path to reject unresolved `EstimateMatMulNBitsWorkspace` symbols. Credit to @JulienTheron for reporting the failure.

### Motivation and Context

The old preprocessor guard enabled the calls when fpA-intB support was enabled, even though CUDA minimal omitted their definitions. This left unresolved symbols in the Linux provider module and caused the reported Windows link failure.

Verified with a CUDA minimal provider build on Linux using GCC 12.4, CUDA 12.6, and NVIDIA A40 hardware. The regression assertion failed with the fix reverted and passed with the fix restored. I could not run the Windows, CUDA 12.8, or TensorRT configurations on this node.