### PR TITLE
Fix constant folding for ops with no pre-execution size estimate

### DIFF
--- a/onnxruntime/core/optimizer/constant_folding.cc
+++ b/onnxruntime/core/optimizer/constant_folding.cc
@@ -407,12 +407,12 @@ Status ConstantFolding::ApplyImpl(Graph& graph, bool& modified, int graph_level,
                                 << " bytes) exceeds the limit (" << max_output_size << " bytes).";
           continue;
         }
-        if (estimated_size < 0) {
-          LOGS(logger, INFO) << "Skipping constant folding for " << node->OpType()
-                             << " node '" << node->Name()
-                             << "' because output size could not be estimated before execution.";
-          continue;
-        }
+        // A negative estimate means the output size could not be determined
+        // ahead of time (e.g. an op with no type-and-shape inference function,
+        // such as GreaterOrEqual/LessOrEqual below opset 16). Do not skip these
+        // nodes here: fold them and let the post-execution actual-size check
+        // below bound the result, so small foldable nodes are not dropped while
+        // the output-size limit is still enforced.
       }
 
 #if !defined(DISABLE_SPARSE_TENSORS)

--- a/onnxruntime/test/optimizer/graph_transform_test.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test.cc
@@ -1642,6 +1642,42 @@ TEST_F(GraphTransformationTests, ConstantFoldingConfiguredLimitBlocksLargeConsta
                                         pre_graph_checker, post_graph_checker));
 }
 
+// #32130: an op with no type-and-shape inference function reports an unknown
+// (negative) pre-execution output-size estimate. GreaterOrEqual/LessOrEqual
+// have no such function below opset 16. With the output-size limit enabled the
+// node must still be folded -- bounded by the post-execution actual-size check
+// -- rather than skipped just because the size could not be estimated upfront.
+TEST_F(GraphTransformationTests, ConstantFoldingUnknownPreEstimatedSizeIsFolded) {
+  auto build_model = [&](ModelTestBuilder& builder) {
+    auto* a = builder.MakeInitializer<int64_t>({3}, {1, 2, 3});
+    auto* b = builder.MakeInitializer<int64_t>({3}, {2, 2, 2});
+    auto* output_arg = builder.MakeOutput();
+    builder.AddNode("GreaterOrEqual", {a, b}, {output_arg});
+  };
+
+  auto pre_graph_checker = [](Graph& graph) -> Status {
+    TEST_RETURN_IF_NOT(CountOpsInGraph(graph)["GreaterOrEqual"] == 1);
+    return Status::OK();
+  };
+
+  auto post_graph_checker = [](Graph& graph) -> Status {
+    // 3-byte bool output is well within the limit, so folding must proceed even
+    // though GreaterOrEqual has no shape inference function at opset 15.
+    TEST_RETURN_IF_NOT(CountOpsInGraph(graph)["GreaterOrEqual"] == 0);
+    return Status::OK();
+  };
+
+  std::unique_ptr<CPUExecutionProvider> e = std::make_unique<CPUExecutionProvider>(CPUExecutionProviderInfo());
+  ConfigOptions config_options;
+  ASSERT_STATUS_OK(config_options.AddConfigEntry(
+      kOrtSessionOptionsConstantFoldingMaxOutputSizeInBytes, "1048576"));
+
+  ASSERT_STATUS_OK(TestGraphTransformer(build_model, 15, *logger_,
+                                        std::make_unique<ConstantFolding>(*e.get(), false, config_options),
+                                        TransformerLevel::Level1, 1,
+                                        pre_graph_checker, post_graph_checker));
+}
+
 // Test that small constant folding still works with the size limit.
 TEST_F(GraphTransformationTests, ConstantFoldingSmallOutputAllowed) {
   // Build a model with a small Expand: scalar -> [4, 4] = 16 * 4 = 64 bytes.


### PR DESCRIPTION
## Summary
- Backport of https://github.com/microsoft/onnxruntime/pull/32155 onto `rel-1.27.0` so it can merge after #32155 lands on `main`.
- Drop the pre-execution `-1` skip in constant folding. Ops with no type-and-shape inference function below opset 16 (`GreaterOrEqual` / `LessOrEqual`) now fold, and the existing post-execution actual-size check still enforces the #28055 output-size limit.
- Add regression test `ConstantFoldingUnknownPreEstimatedSizeIsFolded`.

This is a narrower alternative to #32151 (same bug): the size limit stays on by default.

Fixes #32130.

Cherry-picked from 6bd7e508fd5aca3eb69bb9139acb61ac793d56a6 (#32155). Please merge this after #32155 is merged to `main`.

## Test plan
- [ ] `ConstantFoldingUnknownPreEstimatedSizeIsFolded` (opset-15 `GreaterOrEqual` over constant inputs folds with the size limit enabled)
- [ ] Existing `ConstantFolding*` size-limit tests still pass
- [ ] Confirm #32155 has merged to `main` before merging this backport


Made with [Cursor](https://cursor.com)