### PR TITLE
Fix Where discarding the sign of a selected -0.0

### DIFF
--- a/onnxruntime/core/providers/cpu/tensor/where_op.cc
+++ b/onnxruntime/core/providers/cpu/tensor/where_op.cc
@@ -4,6 +4,7 @@
 #include "core/providers/cpu/tensor/where_op.h"
 
 #include <algorithm>
+#include <cmath>
 #include <type_traits>
 
 #include "core/providers/cpu/math/element_wise_ops.h"  // for broadcast utilities
@@ -148,9 +149,23 @@ EnableIfEigenNotScalar<T, ProcessBroadcastSpanFuncs> SelectBroadcastFuncs() {
   return CreateNonScalarBroadcastFuncs<T>();
 }
 
+// A selection tensor holds T{} wherever the element was not selected, so "differs from T{}" is
+// used below as the test for "was selected". For floating point types that test is wrong for
+// negative zero: -0.0 == 0.0, so a genuinely selected -0.0 looks unselected and is replaced by
+// the default +0.0 held by the other operand. A negative zero can only be present in a selection
+// tensor if it was selected, since the default has its sign bit clear, so admit it explicitly.
+template <typename T>
+constexpr bool WasSelected(const T& value) {
+  if constexpr (std::is_floating_point<T>::value) {
+    return value != T{} || std::signbit(value);
+  } else {
+    return value != T{};
+  }
+}
+
 template <typename T>
 void MergeScalarAndVector(EigenVectorMap<T> output, const T& scalar_value, ConstEigenVectorMap<T> vector_value) {
-  if (scalar_value != T{}) {
+  if (WasSelected(scalar_value)) {
     output = EigenVectorMap<T>::PlainObject::Constant(vector_value.size(), scalar_value);
   } else {
     output = vector_value;
@@ -175,7 +190,7 @@ EnableIfEigenScalar<T, ProcessBroadcastSpanFuncs> MergeBroadcastFuncs() {
         auto Y_selection = per_iter_bh.EigenInput1<T>();
         per_iter_bh.OutputEigen<T>() = X_selection.binaryExpr(Y_selection,
                                                               [](T x, T y) -> T {
-                                                                return x != T{} ? x : y;
+                                                                return WasSelected(x) ? x : y;
                                                               });
       }};
 }

--- a/onnxruntime/test/providers/cpu/tensor/where_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/where_op_test.cc
@@ -154,89 +154,76 @@ TEST(WhereOpTest, BroadcastWithScalar) {
 }
 
 namespace {
-// Where is selection, so a selected -0.0 must come back as -0.0. OpTester compares floating
-// point outputs numerically and -0.0f == 0.0f, so a lost sign is invisible to it; check the
-// sign bit directly instead.
-void ExpectSignBits(const std::vector<OrtValue>& fetches, const std::vector<float>& expected) {
+// Where is selection, so a selected -0.0 must come back as -0.0. OpTester compares floating point
+// outputs numerically and -0.0 == 0.0, so a lost sign is invisible to it; check the sign bit
+// directly instead.
+template <typename T>
+void ExpectSignBits(const std::vector<OrtValue>& fetches, const std::vector<T>& expected) {
   ASSERT_EQ(fetches.size(), 1u);
   ASSERT_TRUE(fetches[0].IsTensor());
 
   const Tensor& tensor = fetches[0].Get<Tensor>();
   ASSERT_EQ(static_cast<size_t>(tensor.Shape().Size()), expected.size());
 
-  const float* output = tensor.Data<float>();
+  const T* output = tensor.Data<T>();
   for (size_t i = 0; i < expected.size(); ++i) {
     EXPECT_EQ(std::signbit(output[i]), std::signbit(expected[i]))
         << "element " << i << " has the wrong sign";
   }
 }
-}  // namespace
 
-// Equal shapes, selected from X. The merge tests X_selection against the default, and -0.0
-// compares equal to it.
-TEST(WhereOpTest, SignedZeroSelectedFromX) {
+template <typename T>
+void WhereSignedZeroTest(const std::vector<int64_t>& condition_dims,
+                         const std::initializer_list<bool>& condition_values,
+                         const std::vector<int64_t>& X_dims, const std::vector<T>& X_values,
+                         const std::vector<int64_t>& Y_dims, const std::vector<T>& Y_values,
+                         const std::vector<int64_t>& output_dims,
+                         const std::vector<T>& expected_values) {
   OpTester test{kOpName, kOpVersion};
 
-  test.AddInput<bool>("condition", {1}, {true});
-  test.AddInput<float>("X", {1}, {-0.0f});
-  test.AddInput<float>("Y", {1}, {0.0f});
+  test.AddInput<bool>("condition", condition_dims, condition_values);
+  test.AddInput<T>("X", X_dims, X_values);
+  test.AddInput<T>("Y", Y_dims, Y_values);
 
-  test.AddOutput<float>("output", {1}, {-0.0f});
-  test.SetCustomOutputVerifier([](const std::vector<OrtValue>& fetches, const std::string&) {
-    ExpectSignBits(fetches, {-0.0f});
-  });
+  test.AddOutput<T>("output", output_dims, expected_values);
+  test.SetCustomOutputVerifier(
+      [expected_values](const std::vector<OrtValue>& fetches, const std::string& /*provider_type*/) {
+        ExpectSignBits<T>(fetches, expected_values);
+      });
 
   test.Run();
 }
+}  // namespace
 
-// Equal shapes, selected from Y. Y_selection is the fall-through of that same merge, so this
-// case was already correct and guards against a fix that breaks it.
+// Equal shapes, selected from X. The merge compares X_selection against the default, and -0.0
+// compares equal to it.
+TEST(WhereOpTest, SignedZeroSelectedFromX) {
+  WhereSignedZeroTest<float>({1}, {true}, {1}, {-0.0f}, {1}, {0.0f}, {1}, {-0.0f});
+  WhereSignedZeroTest<double>({1}, {true}, {1}, {-0.0}, {1}, {0.0}, {1}, {-0.0});
+}
+
+// Equal shapes, selected from Y. Y_selection is the untested fall-through of that same merge, so
+// this case was already correct and guards against a fix that breaks it.
 TEST(WhereOpTest, SignedZeroSelectedFromY) {
-  OpTester test{kOpName, kOpVersion};
-
-  test.AddInput<bool>("condition", {1}, {false});
-  test.AddInput<float>("X", {1}, {1.0f});
-  test.AddInput<float>("Y", {1}, {-0.0f});
-
-  test.AddOutput<float>("output", {1}, {-0.0f});
-  test.SetCustomOutputVerifier([](const std::vector<OrtValue>& fetches, const std::string&) {
-    ExpectSignBits(fetches, {-0.0f});
-  });
-
-  test.Run();
+  WhereSignedZeroTest<float>({1}, {false}, {1}, {1.0f}, {1}, {-0.0f}, {1}, {-0.0f});
+  WhereSignedZeroTest<double>({1}, {false}, {1}, {1.0}, {1}, {-0.0}, {1}, {-0.0});
 }
 
 // Y broadcast against a wider X, so Y_selection becomes the scalar operand of
-// MergeScalarAndVector and is the value tested.
+// MergeScalarAndVector and is the value being compared.
 TEST(WhereOpTest, SignedZeroSelectedFromBroadcastY) {
-  OpTester test{kOpName, kOpVersion};
-
-  test.AddInput<bool>("condition", {1}, {false});
-  test.AddInput<float>("X", {4}, {1.0f, 2.0f, 3.0f, 4.0f});
-  test.AddInput<float>("Y", {1}, {-0.0f});
-
-  test.AddOutput<float>("output", {4}, {-0.0f, -0.0f, -0.0f, -0.0f});
-  test.SetCustomOutputVerifier([](const std::vector<OrtValue>& fetches, const std::string&) {
-    ExpectSignBits(fetches, {-0.0f, -0.0f, -0.0f, -0.0f});
-  });
-
-  test.Run();
+  WhereSignedZeroTest<float>({1}, {false}, {4}, {1.0f, 2.0f, 3.0f, 4.0f}, {1}, {-0.0f},
+                             {4}, {-0.0f, -0.0f, -0.0f, -0.0f});
+  WhereSignedZeroTest<double>({1}, {false}, {4}, {1.0, 2.0, 3.0, 4.0}, {1}, {-0.0},
+                              {4}, {-0.0, -0.0, -0.0, -0.0});
 }
 
 // The mirror of the above, with X as the scalar operand.
 TEST(WhereOpTest, SignedZeroSelectedFromBroadcastX) {
-  OpTester test{kOpName, kOpVersion};
-
-  test.AddInput<bool>("condition", {1}, {true});
-  test.AddInput<float>("X", {1}, {-0.0f});
-  test.AddInput<float>("Y", {4}, {1.0f, 2.0f, 3.0f, 4.0f});
-
-  test.AddOutput<float>("output", {4}, {-0.0f, -0.0f, -0.0f, -0.0f});
-  test.SetCustomOutputVerifier([](const std::vector<OrtValue>& fetches, const std::string&) {
-    ExpectSignBits(fetches, {-0.0f, -0.0f, -0.0f, -0.0f});
-  });
-
-  test.Run();
+  WhereSignedZeroTest<float>({1}, {true}, {1}, {-0.0f}, {4}, {1.0f, 2.0f, 3.0f, 4.0f},
+                             {4}, {-0.0f, -0.0f, -0.0f, -0.0f});
+  WhereSignedZeroTest<double>({1}, {true}, {1}, {-0.0}, {4}, {1.0, 2.0, 3.0, 4.0},
+                              {4}, {-0.0, -0.0, -0.0, -0.0});
 }
 
 #ifdef USE_WEBGPU

--- a/onnxruntime/test/providers/cpu/tensor/where_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/where_op_test.cc
@@ -3,6 +3,8 @@
 
 #include "gtest/gtest.h"
 
+#include <cmath>
+
 #include <gsl/gsl>
 
 #include "test/providers/provider_test_utils.h"
@@ -147,6 +149,92 @@ TEST(WhereOpTest, BroadcastWithScalar) {
   test.AddInput<int64_t>("Y", {}, {1});
 
   test.AddOutput<int64_t>("output", {1, 3}, {1, 1, 3});
+
+  test.Run();
+}
+
+namespace {
+// Where is selection, so a selected -0.0 must come back as -0.0. OpTester compares floating
+// point outputs numerically and -0.0f == 0.0f, so a lost sign is invisible to it; check the
+// sign bit directly instead.
+void ExpectSignBits(const std::vector<OrtValue>& fetches, const std::vector<float>& expected) {
+  ASSERT_EQ(fetches.size(), 1u);
+  ASSERT_TRUE(fetches[0].IsTensor());
+
+  const Tensor& tensor = fetches[0].Get<Tensor>();
+  ASSERT_EQ(static_cast<size_t>(tensor.Shape().Size()), expected.size());
+
+  const float* output = tensor.Data<float>();
+  for (size_t i = 0; i < expected.size(); ++i) {
+    EXPECT_EQ(std::signbit(output[i]), std::signbit(expected[i]))
+        << "element " << i << " has the wrong sign";
+  }
+}
+}  // namespace
+
+// Equal shapes, selected from X. The merge tests X_selection against the default, and -0.0
+// compares equal to it.
+TEST(WhereOpTest, SignedZeroSelectedFromX) {
+  OpTester test{kOpName, kOpVersion};
+
+  test.AddInput<bool>("condition", {1}, {true});
+  test.AddInput<float>("X", {1}, {-0.0f});
+  test.AddInput<float>("Y", {1}, {0.0f});
+
+  test.AddOutput<float>("output", {1}, {-0.0f});
+  test.SetCustomOutputVerifier([](const std::vector<OrtValue>& fetches, const std::string&) {
+    ExpectSignBits(fetches, {-0.0f});
+  });
+
+  test.Run();
+}
+
+// Equal shapes, selected from Y. Y_selection is the fall-through of that same merge, so this
+// case was already correct and guards against a fix that breaks it.
+TEST(WhereOpTest, SignedZeroSelectedFromY) {
+  OpTester test{kOpName, kOpVersion};
+
+  test.AddInput<bool>("condition", {1}, {false});
+  test.AddInput<float>("X", {1}, {1.0f});
+  test.AddInput<float>("Y", {1}, {-0.0f});
+
+  test.AddOutput<float>("output", {1}, {-0.0f});
+  test.SetCustomOutputVerifier([](const std::vector<OrtValue>& fetches, const std::string&) {
+    ExpectSignBits(fetches, {-0.0f});
+  });
+
+  test.Run();
+}
+
+// Y broadcast against a wider X, so Y_selection becomes the scalar operand of
+// MergeScalarAndVector and is the value tested.
+TEST(WhereOpTest, SignedZeroSelectedFromBroadcastY) {
+  OpTester test{kOpName, kOpVersion};
+
+  test.AddInput<bool>("condition", {1}, {false});
+  test.AddInput<float>("X", {4}, {1.0f, 2.0f, 3.0f, 4.0f});
+  test.AddInput<float>("Y", {1}, {-0.0f});
+
+  test.AddOutput<float>("output", {4}, {-0.0f, -0.0f, -0.0f, -0.0f});
+  test.SetCustomOutputVerifier([](const std::vector<OrtValue>& fetches, const std::string&) {
+    ExpectSignBits(fetches, {-0.0f, -0.0f, -0.0f, -0.0f});
+  });
+
+  test.Run();
+}
+
+// The mirror of the above, with X as the scalar operand.
+TEST(WhereOpTest, SignedZeroSelectedFromBroadcastX) {
+  OpTester test{kOpName, kOpVersion};
+
+  test.AddInput<bool>("condition", {1}, {true});
+  test.AddInput<float>("X", {1}, {-0.0f});
+  test.AddInput<float>("Y", {4}, {1.0f, 2.0f, 3.0f, 4.0f});
+
+  test.AddOutput<float>("output", {4}, {-0.0f, -0.0f, -0.0f, -0.0f});
+  test.SetCustomOutputVerifier([](const std::vector<OrtValue>& fetches, const std::string&) {
+    ExpectSignBits(fetches, {-0.0f, -0.0f, -0.0f, -0.0f});
+  });
 
   test.Run();
 }


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Replaces the two `!= T{}` comparisons in `Where`'s merge step with a `WasSelected` helper that also
admits negative zero, and adds four regression tests to `WhereOpTest`.

`Where<T>::Compute` builds an `X_selection` and a `Y_selection`, each holding the default `T{}`
where the element was not selected, then merges them with
`(X_selection != default value) ? X_selection : Y_selection`. For floats the default is `+0.0`, and
`-0.0 == 0.0`. So a `-0.0` selected from `X` compares equal to the default, the merge treats it as
unselected, and takes `Y_selection`, which holds `+0.0` at that position. At equal shapes
`Y_selection` is the untested fall-through of that merge, which is why a `-0.0` from `Y` survives
there but not when `Y` is the broadcast scalar operand of `MergeScalarAndVector`.

A negative zero can only be present in a selection tensor if it was selected, since the default has
its sign bit clear, so admitting it is sufficient. Selecting `+0.0` from `X` still falls through to
`Y_selection`, which holds `+0.0` at that position, so nothing else changes.

For the CPU kernel the affected registered floating-point types are `float` and `double`.
`MLFloat16` and `BFloat16` are present in the registration block but commented out, and the
`std::string` specialization uses a separate overload where the empty string is the default and is
indistinguishable between the two selection arms, so it is unaffected.

`OpTester` compares floating-point outputs numerically and `-0.0f == 0.0f`, so a lost sign is
invisible to it; the new tests check the sign bit through `SetCustomOutputVerifier`, as in #31477.
Three of the four fail before this change and all pass after, with `onnxruntime_provider_test` green
on macOS arm64 (5553 passed, 0 failed).

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

`Where` is elementwise selection rather than arithmetic, so the selected element should be
preserved, and `+0.0` and `-0.0` are distinct IEEE-754 values with distinct bit patterns.
`onnx.reference` preserves the negative zero in both cases; ONNX Runtime does not.

Fixes #32191.