### PR TITLE
Fix QMoE SM80 FP4 init order: don't let the tactic seed throw

### DIFF
--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_kernels.cu
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_kernels.cu
@@ -2115,10 +2115,16 @@ CutlassMoeFCRunner<T, WeightType, OutputType, InputType, ScaleBiasType, Enable>:
       activation_type_(activation_type),
       normalize_routing_weights_(normalize_routing_weights),
       use_sparse_mixer_(use_sparse_mixer) {
-  auto tactics = getTactics(sm_);
-  if (!tactics.empty()) {
-    gemm1_config_ = tactics[0];
-    gemm2_config_ = tactics[0];
+  // Best-effort default tactic seed only. The SM80-FP4 decision is still unknown here (the QMoE op
+  // pushes it via setUseSm80Fp4() immediately after construction and re-picks), so a config family
+  // that looks unavailable under the provisional use_sm80_fp4=false view must not be fatal.
+  try {
+    auto tactics = getTactics(sm_);
+    if (!tactics.empty()) {
+      gemm1_config_ = tactics[0];
+      gemm2_config_ = tactics[0];
+    }
+  } catch (const std::exception&) {
   }
 }
 


### PR DESCRIPTION
## Problem

The SM80 FP4 grouped-GEMM path is unreachable on Ampere. Any MXFP4 MoE model (e.g. `openai/gpt-oss-20b`) throws at session initialization:

```
TMA WS grouped MoE GEMM for SM80 is not compiled, and this QMoE configuration has no SM80 fallback
  onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemm_template_dispatch.h:687
```

## Root cause — an ordering problem

`CutlassMoeFCRunner`'s constructor seeds a default GEMM tactic:

```cpp
// moe_kernels.cu
auto tactics = getTactics(sm_);
```

That resolves to the **static** overload `getConfigs(int sm, bool use_sm80_fp4 = false)` — the flag defaults to `false`.

On SM80 with `wfp4a16`, that provisional view is wrong. `getTmaWarpSpecializedConfigs()` guards its early exit on the flag:

```cpp
if constexpr (use_wfp4a16) {
  if (moeUseSm80Fp4(sm, use_sm80_fp4)) {
    return {};          // taken when the flag is TRUE -- no throw
  }
}
if (!isTmaWarpSpecializedGroupedGemmCompiledForSm(config_sm)) {
  if constexpr (use_w4afp8 || use_wfp4a16 || ...) {
    ORT_THROW("TMA WS grouped MoE GEMM for SM%d is not compiled, ...");
  }
}
```

With the flag `false` the early `return {}` is skipped and the throw fires. It fires **during construction**, before QMoE can push the real decision:

```cpp
// moe_quantization.cc
m_moe_runner = std::make_unique<CutlassMoeFCRunner<half, __nv_fp4_e2m1, half>>(...);  // L428 - throws here
...
m_moe_runner->setUseSm80Fp4(enable_fp4_sm80_gemm_);                                   // L449 - never reached
```

So the decision made at L449 can never take effect, and users must fall back to the dequant path via `ORT_FP4_SM80_GEMM=0`.

## Fix

The constructor's query is only a **best-effort default seed** — the surrounding code already tolerates an empty result via `if (!tactics.empty())`. Throwing there is the defect, so the seed is now non-fatal.

`setUseSm80Fp4()` re-queries immediately afterward and re-picks. With `use_sm80_fp4=true`, `getTmaWarpSpecializedConfigs()` returns `{}` by design and `getAmpereConfigs()` supplies real candidate configs, so both `gemm1_config_` and `gemm2_config_` get valid tactics. A genuinely unsupported configuration still throws later at dispatch.

I kept this minimal rather than plumbing the flag through the constructor signature, which would be tidier but touches every `CutlassMoeFCRunner` construction site.

## Validation

A100-80GB (SM80), `openai/gpt-oss-20b` MXFP4 exported for paged attention, run through ONNX Runtime GenAI's continuous-batching engine.

| | Before (`ORT_FP4_SM80_GEMM=0` fallback) | After (SM80 path) |
|---|---|---|
| Session init | throws on default path | succeeds |
| Peak GPU memory | ~49,800 MiB | **24,149 MiB** |
| Load time | ~5.9 s | 4.56 s |
| Output parity | exact | exact |

**2.1x memory reduction**, with exact output parity between concurrent and isolated runs (0 mismatches) and stable output across repeats.

## Note for reviewers

I validated this empirically as above, but I have **not** run ONNX Runtime's own MoE/QMoE test suites against the change — worth confirming in CI. I'd also welcome a view on whether the non-fatal seed is the preferred shape here versus passing the SM80 decision into the constructor.