### PR TITLE
[CUDA] QMoE: fused int2 mixed-input GEMM + GeGLU activation + fractional zero-point

### DIFF
--- a/docs/ContribOperators.md
+++ b/docs/ContribOperators.md
@@ -5326,7 +5326,7 @@ This version of the operator has been available since version 1 of the 'com.micr
 <dt><tt>activation_beta</tt> : float</dt>
 <dd>Beta parameter used in activation function.</dd>
 <dt><tt>activation_type</tt> : string</dt>
-<dd>Activation function to use. Choose from relu, gelu, silu, swiglu and identity. Default is relu</dd>
+<dd>Activation function to use. Choose from relu, gelu, silu, swiglu, geglu and identity. geglu is the GELU-gated linear unit (a gated activation like swiglu but using gelu as the gate). Default is relu</dd>
 <dt><tt>block_size</tt> : int</dt>
 <dd>Size of each quantization block along the K (input feature) dimension. Must be power of two and ≥ 16 (e.g., 16, 32, 64, 128). Both hidden_size and inter_size must be divisible by the block size. The FP4 modes always use blocking: MXFP4 ('fp4'/'wfp4afp8') is normalized to block_size 32 and NVFP4 ('nvfp4') to block_size 16, even when block_size is omitted. For integer quantization ('int'), omitting block_size means there is no blocking and a whole column shares one scaling factor. </dd>
 <dt><tt>expert_weight_bits</tt> : int</dt>
@@ -5345,6 +5345,8 @@ This version of the operator has been available since version 1 of the 'com.micr
 <dd>Whether to use sparse mixer</dd>
 <dt><tt>weights_prepacked</tt> : int</dt>
 <dd>Only meaningful when quant_type='int'. Tri-state control over the layout of the int4/int8 fc1/fc2 weight initializers. The concrete prepacked layouts selected by -1 and 1 are determined by the execution provider. 0: the initializers are raw, un-prepacked [E, N, K/pack] tensors as produced by quantize_matmul_{4,8}bits. Defaults to -1.</dd>
+<dt><tt>zero_point_offset</tt> : float</dt>
+<dd>CUDA execution provider only; other execution providers (CPU, WebGPU) reject a non-default value. Only meaningful when quant_type='int' and block_size > 0 and no integer fc*_zero_points are provided. A single fractional zero-point applied uniformly to every weight code: dequant = (code - zero_point_offset) * scale. Enables balanced asymmetric schemes whose zero-point is not integer-representable (e.g. the 1.5 midpoint of a 2-bit checkpoint, giving codes {0,1,2,3} -> {-1.5,-0.5,0.5,1.5}*scale). When omitted, symmetric quantization centered on 2^(expert_weight_bits-1) is used.</dd>
 </dl>
 
 #### Inputs (6 - 21)

--- a/onnxruntime/contrib_ops/cpu/moe/moe_quantization_cpu.cc
+++ b/onnxruntime/contrib_ops/cpu/moe/moe_quantization_cpu.cc
@@ -22,6 +22,7 @@
 #include <vector>
 #include <algorithm>
 #include <cmath>
+#include <limits>
 
 namespace {
 inline uint8_t GetPackedZeroPointValue(int64_t num_bits, uint8_t zero_point) {
@@ -879,6 +880,15 @@ QMoECPU<T>::QMoECPU(const OpKernelInfo& op_kernel_info)
     ORT_ENFORCE(block_size_ >= 16, "block_size must be >= 16 when provided.");
     ORT_ENFORCE((block_size_ & (block_size_ - 1)) == 0, "block_size must be a power of 2.");
   }
+
+  // ``zero_point_offset`` (fractional zero-point center) is a CUDA-only feature. Reject it here so
+  // a model authored for CUDA is not silently evaluated with the default integer center on CPU,
+  // which would violate the documented dequant formula (code - zero_point_offset) * scale.
+  const float zero_point_offset =
+      op_kernel_info.GetAttrOrDefault<float>("zero_point_offset", std::numeric_limits<float>::quiet_NaN());
+  ORT_ENFORCE(std::isnan(zero_point_offset),
+              "CPU QMoE does not support the 'zero_point_offset' attribute; it is only implemented "
+              "by the CUDA execution provider.");
 
   const auto use_mlas_q4_gemm = ParseEnvironmentVariable<bool>(kUseMlasQ4GemmMoe);
   if (use_mlas_q4_gemm.has_value()) {

--- a/onnxruntime/contrib_ops/cuda/llm/cutlass_extensions/gemm/kernel/mixed_gemm_B_layout.h
+++ b/onnxruntime/contrib_ops/cuda/llm/cutlass_extensions/gemm/kernel/mixed_gemm_B_layout.h
@@ -107,6 +107,25 @@ struct LayoutDetailsB<TypeA, uint4b_t, Arch, typename platform::enable_if<Arch::
   using Operator = cutlass::arch::OpMultiplyAddDequantizeInterleavedBToA;
 };
 
+// INT2 (2-bit integer) weights with FP16/BF16 activations on Turing+. Mirrors the uint4b_t 4-bit
+// interleaved layout; sizeof_bits<uint2b_t> = 2 gives ColumnsInterleaved = 8 and
+// ElementsPerAccess = 64. The preprocessor's interleave and the kernel's ColumnMajorTileInterleave
+// iterator both derive the interleave factor from this same ColumnsInterleaved, so they agree by
+// construction regardless of its value.
+template <typename TypeA, typename Arch>
+struct LayoutDetailsB<TypeA, uint2b_t, Arch, typename platform::enable_if<Arch::kMinComputeCapability >= 75>::type> {
+  static constexpr int ThreadblockK = 128 * 8 / cutlass::sizeof_bits<TypeA>::value;
+
+ private:
+  static constexpr int ElementsPerCacheLine = 128 * 8 / sizeof_bits<uint2b_t>::value;
+  static constexpr int ColumnsInterleaved = ElementsPerCacheLine / ThreadblockK;
+
+ public:
+  using Layout = layout::ColumnMajorTileInterleave<ThreadblockK, ColumnsInterleaved>;
+  static constexpr int ElementsPerAccess = 128 / cutlass::sizeof_bits<uint2b_t>::value;
+  using Operator = cutlass::arch::OpMultiplyAddDequantizeInterleavedBToA;
+};
+
 // MXFP4 (e2m1) weights with FP16/BF16 activations on Turing+. Mirrors the uint4b_t 4-bit
 // interleaved layout: weights are stored in the SM80 column-major tile-interleaved layout and
 // dequantized after the smem load via OpMultiplyAddDequantizeInterleavedBToA.

--- a/onnxruntime/contrib_ops/cuda/llm/cutlass_extensions/gemm/kernel/moe_cutlass_kernel.h
+++ b/onnxruntime/contrib_ops/cuda/llm/cutlass_extensions/gemm/kernel/moe_cutlass_kernel.h
@@ -181,6 +181,7 @@ struct MoeFCGemm {
               GemmCoord* host_problem_sizes = nullptr)
         : problem_count(problem_count), threadblock_count(threadblock_count), group_size(group_size), output_op(output_op), ptr_A(const_cast<ElementA*>(ptr_A)), ptr_B(const_cast<ElementB*>(ptr_B)), weight_scales(const_cast<ElementScale*>(weight_scales)), weight_zeros(const_cast<ElementScale*>(weight_zeros)), ptr_C(const_cast<ElementC*>(ptr_C)), C_is_broadcast{C_is_broadcast}, ptr_D(ptr_D), total_tokens_including_expert(total_tokens_including_expert), gemm_n(gemm_n), gemm_k(gemm_k), host_problem_sizes(nullptr) {
       if (platform::is_same<uint8_t, ElementB>::value || platform::is_same<uint4b_t, ElementB>::value ||
+          platform::is_same<uint2b_t, ElementB>::value ||
           platform::is_same<cutlass::float_e2m1_t, ElementB>::value) {
         assert(weight_scales);
       }
@@ -285,9 +286,10 @@ struct MoeFCGemm {
 
   static Status can_implement(Arguments const& args) {
     if constexpr (platform::is_same<uint8_t, ElementB>::value || platform::is_same<uint4b_t, ElementB>::value ||
+                  platform::is_same<uint2b_t, ElementB>::value ||
                   platform::is_same<cutlass::float_e2m1_t, ElementB>::value) {
       if (args.weight_scales == nullptr) {
-        CUTLASS_TRACE_HOST("MoeFCGemm::can_implement() - weight scales are required for uint8_t and uint4b_t");
+        CUTLASS_TRACE_HOST("MoeFCGemm::can_implement() - weight scales are required for uint8_t, uint4b_t and uint2b_t");
         return Status::kInvalid;
       }
       static int const kAlignmentA = (platform::is_same<typename Mma::IteratorA::Layout, layout::ColumnMajorInterleaved<32>>::value) ? 32

--- a/onnxruntime/contrib_ops/cuda/llm/cutlass_extensions/gemm/threadblock/default_dq_mma_multistage.h
+++ b/onnxruntime/contrib_ops/cuda/llm/cutlass_extensions/gemm/threadblock/default_dq_mma_multistage.h
@@ -119,8 +119,9 @@ struct DqMma<ElementA, LayoutA, kAlignmentA, ElementB, LayoutB, kAlignmentB, Ele
                 "Mma multistage must dequantize after ldsm");
 
   static_assert(platform::is_same<ElementB, uint8_t>::value || platform::is_same<ElementB, uint4b_t>::value ||
+                    platform::is_same<ElementB, uint2b_t>::value ||
                     platform::is_same<ElementB, cutlass::float_e2m1_t>::value,
-                "Element B must be uint8, uint4 or float_e2m1");
+                "Element B must be uint8, uint4, uint2 or float_e2m1");
 
   static cutlass::arch::CacheOperation::Kind const CacheOpA = ((sizeof_bits<ElementA>::value * kAlignmentA) == 128)
                                                                   ? cutlass::arch::CacheOperation::Global
@@ -220,8 +221,9 @@ struct DqMma<ElementA, LayoutA, kAlignmentA, ElementB, LayoutB, kAlignmentB, Ele
                 "Mma multistage must dequantize after ldsm");
 
   static_assert(platform::is_same<ElementB, uint8_t>::value || platform::is_same<ElementB, uint4b_t>::value ||
+                    platform::is_same<ElementB, uint2b_t>::value ||
                     platform::is_same<ElementB, cutlass::float_e2m1_t>::value,
-                "Element B must be uint8, uint4 or float_e2m1");
+                "Element B must be uint8, uint4, uint2 or float_e2m1");
 
   static cutlass::arch::CacheOperation::Kind const CacheOpA = ((sizeof_bits<ElementA>::value * kAlignmentA) == 128)
                                                                   ? cutlass::arch::CacheOperation::Global

--- a/onnxruntime/contrib_ops/cuda/llm/cutlass_extensions/gemm/threadblock/default_dq_mma_pipelined.h
+++ b/onnxruntime/contrib_ops/cuda/llm/cutlass_extensions/gemm/threadblock/default_dq_mma_pipelined.h
@@ -117,8 +117,9 @@ struct DqMma<ElementA, LayoutA, kAlignmentA, ElementB, LayoutB, kAlignmentB, Ele
                 "Element A must be fp16 or bf16");
 
   static_assert(platform::is_same<ElementB, uint8_t>::value || platform::is_same<ElementB, uint4b_t>::value ||
+                    platform::is_same<ElementB, uint2b_t>::value ||
                     platform::is_same<ElementB, cutlass::float_e2m1_t>::value,
-                "Element B must be uint8, uint4 or float_e2m1");
+                "Element B must be uint8, uint4, uint2 or float_e2m1");
 
   using OperatorInfo = arch::DetagOperator<Operator_>;
   using Operator = typename OperatorInfo::Operator;
@@ -203,8 +204,9 @@ struct DqMma<ElementA, LayoutA, kAlignmentA, ElementB, LayoutB, kAlignmentB, Ele
                 "Element A must be fp16 or bf16");
 
   static_assert(platform::is_same<ElementB, uint8_t>::value || platform::is_same<ElementB, uint4b_t>::value ||
+                    platform::is_same<ElementB, uint2b_t>::value ||
                     platform::is_same<ElementB, cutlass::float_e2m1_t>::value,
-                "Element B must be uint8, uint4 or float_e2m1");
+                "Element B must be uint8, uint4, uint2 or float_e2m1");
 
   using OperatorInfo = arch::DetagOperator<Operator_>;
   using Operator = typename OperatorInfo::Operator;

--- a/onnxruntime/contrib_ops/cuda/llm/cutlass_extensions/gemm/threadblock/default_mma.h
+++ b/onnxruntime/contrib_ops/cuda/llm/cutlass_extensions/gemm/threadblock/default_mma.h
@@ -222,6 +222,104 @@ struct DefaultMma<cutlass::half_t, LayoutA, kAlignmentA, uint4b_t, LayoutB, kAli
 };
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Specialization for row-major output (OperatorClass TensorOp), fp16 activation & int2 weight, mma pipelined (stage=2)
+template <
+    /// Layout type for A matrix operand
+    typename LayoutA,
+    /// Access granularity of A matrix in units of elements
+    int kAlignmentA,
+    /// Layout type for B matrix operand
+    typename LayoutB,
+    /// Access granularity of B matrix in units of elements
+    int kAlignmentB,
+    /// Element type for internal accumulation
+    typename ElementAccumulator,
+    /// Tag indicating architecture to tune for
+    typename ArchTag,
+    /// Threadblock-level tile size (concept: GemmShape)
+    typename ThreadblockShape,
+    /// Warp-level tile size (concept: GemmShape)
+    typename WarpShape,
+    /// Instruction-level tile size (concept: GemmShape)
+    typename InstructionShape,
+    /// Operation performed by GEMM
+    typename Operator>
+struct DefaultMma<cutlass::half_t, LayoutA, kAlignmentA, uint2b_t, LayoutB, kAlignmentB, ElementAccumulator,
+                  layout::RowMajor, arch::OpClassTensorOp, ArchTag, ThreadblockShape, WarpShape, InstructionShape, 2, Operator> {
+ private:
+  static constexpr int kAlignmentScale = 128 / sizeof_bits<half_t>::value;
+
+  using Mma = DqMma<half_t, LayoutA, kAlignmentA, uint2b_t, LayoutB, kAlignmentB, half_t, layout::RowMajor,
+                    kAlignmentScale, ElementAccumulator, layout::RowMajor, arch::OpClassTensorOp, ArchTag, ThreadblockShape,
+                    WarpShape, InstructionShape, 2, Operator>;
+
+ public:
+  // Define the MmaCore components
+  using MmaCore = typename Mma::MmaCore;
+
+  // Define iterators over tiles from the A operand
+  using IteratorA = typename Mma::IteratorA;
+
+  // Define iterators over tiles from the B operand
+  using IteratorB = typename Mma::IteratorB;
+
+  // Define the threadblock-scoped pipelined matrix multiply
+  using ThreadblockMma = typename Mma::ThreadblockMma;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+/// Specialization for row-major output (OperatorClass TensorOp), fp16 activation & int2 weight, mma multistage
+/// (stage>=3)
+template <
+    /// Layout type for A matrix operand
+    typename LayoutA,
+    /// Access granularity of A matrix in units of elements
+    int kAlignmentA,
+    /// Layout type for B matrix operand
+    typename LayoutB,
+    /// Access granularity of B matrix in units of elements
+    int kAlignmentB,
+    /// Element type for internal accumulation
+    typename ElementAccumulator,
+    /// Tag indicating architecture to tune for
+    typename ArchTag,
+    /// Threadblock-level tile size (concept: GemmShape)
+    typename ThreadblockShape,
+    /// Warp-level tile size (concept: GemmShape)
+    typename WarpShape,
+    /// Instruction-level tile size (concept: GemmShape)
+    typename InstructionShape,
+    /// Operation performed by GEMM
+    typename Operator,
+    ///
+    int kStages,
+    /// Shared memory clear option
+    SharedMemoryClearOption SharedMemoryClear>
+struct DefaultMma<cutlass::half_t, LayoutA, kAlignmentA, uint2b_t, LayoutB, kAlignmentB, ElementAccumulator,
+                  layout::RowMajor, arch::OpClassTensorOp, ArchTag, ThreadblockShape, WarpShape, InstructionShape, kStages, Operator,
+                  false, SharedMemoryClear> {
+ private:
+  static constexpr int kAlignmentScale = 128 / sizeof_bits<half_t>::value;
+
+  using Mma = DqMma<half_t, LayoutA, kAlignmentA, uint2b_t, LayoutB, kAlignmentB, half_t, layout::RowMajor,
+                    kAlignmentScale, ElementAccumulator, layout::RowMajor, arch::OpClassTensorOp, ArchTag, ThreadblockShape,
+                    WarpShape, InstructionShape, kStages, Operator, SharedMemoryClear>;
+
+ public:
+  // Define the MmaCore components
+  using MmaCore = typename Mma::MmaCore;
+
+  // Define iterators over tiles from the A operand
+  using IteratorA = typename Mma::IteratorA;
+
+  // Define iterators over tiles from the B operand
+  using IteratorB = typename Mma::IteratorB;
+
+  // Define the threadblock-scoped pipelined matrix multiply
+  using ThreadblockMma = typename Mma::ThreadblockMma;
+};
+
+////////////////////////////////////////////////////////////////////////////////
 /// Specialization for row-major output (OperatorClass TensorOp), fp16 activation & MXFP4 (e2m1) weight,
 /// mma pipelined (stage=2)
 template <

--- a/onnxruntime/contrib_ops/cuda/llm/cutlass_extensions/gemm/threadblock/default_mma_bf16.h
+++ b/onnxruntime/contrib_ops/cuda/llm/cutlass_extensions/gemm/threadblock/default_mma_bf16.h
@@ -332,6 +332,103 @@ struct DefaultMma<cutlass::bfloat16_t, LayoutA, kAlignmentA, uint4b_t, LayoutB, 
 };
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Specialization for row-major output (OperatorClass TensorOp), bf16 activation & int2 weight, mma pipelined (stage=2)
+template <
+    /// Layout type for A matrix operand
+    typename LayoutA,
+    /// Access granularity of A matrix in units of elements
+    int kAlignmentA,
+    /// Layout type for B matrix operand
+    typename LayoutB,
+    /// Access granularity of B matrix in units of elements
+    int kAlignmentB,
+    /// Element type for internal accumulation
+    typename ElementAccumulator,
+    /// Tag indicating architecture to tune for
+    typename ArchTag,
+    /// Threadblock-level tile size (concept: GemmShape)
+    typename ThreadblockShape,
+    /// Warp-level tile size (concept: GemmShape)
+    typename WarpShape,
+    /// Instruction-level tile size (concept: GemmShape)
+    typename InstructionShape,
+    /// Operation performed by GEMM
+    typename Operator>
+struct DefaultMma<cutlass::bfloat16_t, LayoutA, kAlignmentA, uint2b_t, LayoutB, kAlignmentB, ElementAccumulator,
+                  layout::RowMajor, arch::OpClassTensorOp, ArchTag, ThreadblockShape, WarpShape, InstructionShape, 2, Operator> {
+ private:
+  static constexpr int kAlignmentScale = 128 / sizeof_bits<bfloat16_t>::value;
+
+  using Mma = DqMma<bfloat16_t, LayoutA, kAlignmentA, uint2b_t, LayoutB, kAlignmentB, bfloat16_t, layout::RowMajor,
+                    kAlignmentScale, ElementAccumulator, layout::RowMajor, arch::OpClassTensorOp, ArchTag, ThreadblockShape,
+                    WarpShape, InstructionShape, 2, Operator>;
+
+ public:
+  // Define the MmaCore components
+  using MmaCore = typename Mma::MmaCore;
+
+  // Define iterators over tiles from the A operand
+  using IteratorA = typename Mma::IteratorA;
+
+  // Define iterators over tiles from the B operand
+  using IteratorB = typename Mma::IteratorB;
+
+  // Define the threadblock-scoped pipelined matrix multiply
+  using ThreadblockMma = typename Mma::ThreadblockMma;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+/// Specialization for row-major output (OperatorClass TensorOp), bf16 activation & int2 weight, mma multistage
+template <
+    /// Layout type for A matrix operand
+    typename LayoutA,
+    /// Access granularity of A matrix in units of elements
+    int kAlignmentA,
+    /// Layout type for B matrix operand
+    typename LayoutB,
+    /// Access granularity of B matrix in units of elements
+    int kAlignmentB,
+    /// Element type for internal accumulation
+    typename ElementAccumulator,
+    /// Tag indicating architecture to tune for
+    typename ArchTag,
+    /// Threadblock-level tile size (concept: GemmShape)
+    typename ThreadblockShape,
+    /// Warp-level tile size (concept: GemmShape)
+    typename WarpShape,
+    /// Instruction-level tile size (concept: GemmShape)
+    typename InstructionShape,
+    /// Operation performed by GEMM
+    typename Operator,
+    ///
+    int kStages,
+    /// Shared memory clear option
+    SharedMemoryClearOption SharedMemoryClear>
+struct DefaultMma<cutlass::bfloat16_t, LayoutA, kAlignmentA, uint2b_t, LayoutB, kAlignmentB, ElementAccumulator,
+                  layout::RowMajor, arch::OpClassTensorOp, ArchTag, ThreadblockShape, WarpShape, InstructionShape, kStages, Operator,
+                  false, SharedMemoryClear> {
+ private:
+  static constexpr int kAlignmentScale = 128 / sizeof_bits<bfloat16_t>::value;
+
+  using Mma = DqMma<bfloat16_t, LayoutA, kAlignmentA, uint2b_t, LayoutB, kAlignmentB, bfloat16_t, layout::RowMajor,
+                    kAlignmentScale, ElementAccumulator, layout::RowMajor, arch::OpClassTensorOp, ArchTag, ThreadblockShape,
+                    WarpShape, InstructionShape, kStages, Operator, SharedMemoryClear>;
+
+ public:
+  // Define the MmaCore components
+  using MmaCore = typename Mma::MmaCore;
+
+  // Define iterators over tiles from the A operand
+  using IteratorA = typename Mma::IteratorA;
+
+  // Define iterators over tiles from the B operand
+  using IteratorB = typename Mma::IteratorB;
+
+  // Define the threadblock-scoped pipelined matrix multiply
+  using ThreadblockMma = typename Mma::ThreadblockMma;
+};
+
+////////////////////////////////////////////////////////////////////////////////
 /// Specialization for row-major output (OperatorClass TensorOp), bf16 activation & MXFP4 (e2m1) weight,
 /// mma pipelined (stage=2)
 template <

--- a/onnxruntime/contrib_ops/cuda/llm/cutlass_extensions/gemm/threadblock/dq_mma_multistage_finegrained.h
+++ b/onnxruntime/contrib_ops/cuda/llm/cutlass_extensions/gemm/threadblock/dq_mma_multistage_finegrained.h
@@ -508,6 +508,11 @@ class DqMmaMultistage<Shape_, IteratorA_, SmemIteratorA_, CacheOpA, IteratorB_, 
     int smem_write_stage_idx = Base::kStages - 1;
     int smem_read_stage_idx = 0;
 
+    // Persistent parity for the warp_frag_B double buffer. Must carry across CTA-K stages
+    // (see the note at the B prefetch below); deriving it from the per-stage load offset
+    // silently breaks when kWarpGemmIterationsForB is odd (int2).
+    int warp_frag_B_read_idx = 0;
+
     //
     // Mainloop
     //
@@ -534,7 +539,8 @@ class DqMmaMultistage<Shape_, IteratorA_, SmemIteratorA_, CacheOpA, IteratorB_, 
         if (warp_tileB_k_compute_offset == Base::kNumKIterationsPerWarpBLoad - 1) {
           this->warp_tile_iterator_B_.set_kgroup_index(
               (warp_tileB_k_load_offset + 1) % Base::kWarpGemmIterationsForB);
-          this->warp_tile_iterator_B_.load(warp_frag_B[(warp_tileB_k_load_offset + 1) % 2]);
+          this->warp_tile_iterator_B_.load(
+              warp_frag_B[(warp_frag_B_read_idx + warp_tileB_k_load_offset + 1) % 2]);
           ++this->warp_tile_iterator_B_;
         }
 
@@ -544,7 +550,8 @@ class DqMmaMultistage<Shape_, IteratorA_, SmemIteratorA_, CacheOpA, IteratorB_, 
           advance_dequantizer_after_load(scale_row);
         }
 
-        typename TransformBAfterLDS::result_type converted_frag_B = lds_converter(warp_frag_B[warp_tileB_k_load_offset % 2]);
+        typename TransformBAfterLDS::result_type converted_frag_B =
+            lds_converter(warp_frag_B[(warp_frag_B_read_idx + warp_tileB_k_load_offset) % 2]);
         warp_dequantizer_.dequantize(converted_frag_B, warp_frag_scales, warp_frag_zeros);
 
         using FragmentOperandB = cutlass::Array<ElementA, Operator::FragmentB::kElements>;
@@ -623,6 +630,11 @@ class DqMmaMultistage<Shape_, IteratorA_, SmemIteratorA_, CacheOpA, IteratorB_, 
           iterator_scale.clear_mask(gemm_k_iterations == 0);
         }
       }
+
+      // Advance the warp_frag_B double-buffer parity by the number of B loads consumed this
+      // stage. Even kWarpGemmIterationsForB (int4/int8) is a no-op; odd (int2) flips, so the
+      // buffer prefetched during this stage is the one read next stage.
+      warp_frag_B_read_idx = (warp_frag_B_read_idx + Base::kWarpGemmIterationsForB) % 2;
 
       // Load the scale needed for the next tile iteration.
       warp_dequantizer_.load(warp_frag_scales, warp_frag_zeros);

--- a/onnxruntime/contrib_ops/cuda/llm/cutlass_extensions/gemm/threadblock/dq_mma_multistage_percol.h
+++ b/onnxruntime/contrib_ops/cuda/llm/cutlass_extensions/gemm/threadblock/dq_mma_multistage_percol.h
@@ -446,6 +446,11 @@ class DqMmaMultistage<Shape_, IteratorA_, SmemIteratorA_, CacheOpA, IteratorB_, 
     int smem_write_stage_idx = Base::kStages - 1;
     int smem_read_stage_idx = 0;
 
+    // Persistent parity for the warp_frag_B double buffer. Must carry across CTA-K stages;
+    // deriving it from the per-stage load offset silently breaks when kWarpGemmIterationsForB
+    // is odd (int2). See dq_mma_multistage_finegrained.h for the detailed rationale.
+    int warp_frag_B_read_idx = 0;
+
     //
     // Mainloop
     //
@@ -472,11 +477,13 @@ class DqMmaMultistage<Shape_, IteratorA_, SmemIteratorA_, CacheOpA, IteratorB_, 
         if (warp_tileB_k_compute_offset == Base::kNumKIterationsPerWarpBLoad - 1) {
           this->warp_tile_iterator_B_.set_kgroup_index(
               (warp_tileB_k_load_offset + 1) % Base::kWarpGemmIterationsForB);
-          this->warp_tile_iterator_B_.load(warp_frag_B[(warp_tileB_k_load_offset + 1) % 2]);
+          this->warp_tile_iterator_B_.load(
+              warp_frag_B[(warp_frag_B_read_idx + warp_tileB_k_load_offset + 1) % 2]);
           ++this->warp_tile_iterator_B_;
         }
 
-        typename TransformBAfterLDS::result_type converted_frag_B = lds_converter(warp_frag_B[warp_tileB_k_load_offset % 2]);
+        typename TransformBAfterLDS::result_type converted_frag_B =
+            lds_converter(warp_frag_B[(warp_frag_B_read_idx + warp_tileB_k_load_offset) % 2]);
         warp_dequantizer_.dequantize(converted_frag_B, warp_frag_scales);
 
         using FragmentOperandB = cutlass::Array<ElementA, Operator::FragmentB::kElements>;
@@ -547,6 +554,10 @@ class DqMmaMultistage<Shape_, IteratorA_, SmemIteratorA_, CacheOpA, IteratorB_, 
           iterator_B.clear_mask(gemm_k_iterations == 0);
         }
       }
+
+      // Advance the warp_frag_B double-buffer parity by the B loads consumed this stage.
+      // Even kWarpGemmIterationsForB (int4/int8) is a no-op; odd (int2) flips.
+      warp_frag_B_read_idx = (warp_frag_B_read_idx + Base::kWarpGemmIterationsForB) % 2;
     }
 
     if (SharedMemoryClear == SharedMemoryClearOption::kZfill) {

--- a/onnxruntime/contrib_ops/cuda/llm/cutlass_extensions/gemm/threadblock/dq_mma_pipelined_finegrained.h
+++ b/onnxruntime/contrib_ops/cuda/llm/cutlass_extensions/gemm/threadblock/dq_mma_pipelined_finegrained.h
@@ -353,6 +353,11 @@ class DqMmaPipelined<Shape_, IteratorA_, SmemIteratorA_, IteratorB_, SmemIterato
 
     int smem_write_stage_idx = 1;
 
+    // Persistent parity for the warp_frag_B double buffer. Must carry across CTA-K stages;
+    // deriving it from the per-stage load offset silently breaks when kWarpGemmIterationsForB
+    // is odd (int2). See dq_mma_multistage_finegrained.h for the detailed rationale.
+    int warp_frag_B_read_idx = 0;
+
     // Avoid reading out of bounds
     iterator_A.clear_mask(gemm_k_iterations <= 1);
     iterator_B.clear_mask(gemm_k_iterations <= 1);
@@ -414,7 +419,8 @@ class DqMmaPipelined<Shape_, IteratorA_, SmemIteratorA_, IteratorB_, SmemIterato
         if (warp_tileB_k_compute_offset == Base::kNumKIterationsPerWarpBLoad - 1) {
           this->warp_tile_iterator_B_.set_kgroup_index(
               (warp_tileB_k_load_offset + 1) % Base::kWarpGemmIterationsForB);
-          this->warp_tile_iterator_B_.load(warp_frag_B[(warp_tileB_k_load_offset + 1) % 2]);
+          this->warp_tile_iterator_B_.load(
+              warp_frag_B[(warp_frag_B_read_idx + warp_tileB_k_load_offset + 1) % 2]);
           ++this->warp_tile_iterator_B_;
         }
 
@@ -439,10 +445,15 @@ class DqMmaPipelined<Shape_, IteratorA_, SmemIteratorA_, IteratorB_, SmemIterato
           advance_dequantizer_after_load(scale_row);
         }
 
-        typename TransformBAfterLDS::result_type converted_frag_B = lds_converter(warp_frag_B[warp_tileB_k_load_offset % 2]);
+        typename TransformBAfterLDS::result_type converted_frag_B =
+            lds_converter(warp_frag_B[(warp_frag_B_read_idx + warp_tileB_k_load_offset) % 2]);
         warp_dequantizer_.dequantize(converted_frag_B, warp_frag_scales, warp_frag_zero);
         warp_mma(accum, warp_frag_A[warp_mma_k % 2], converted_frag_B, accum, warp_tileB_k_compute_offset);
       }
+
+      // Advance the warp_frag_B double-buffer parity by the B loads consumed this stage.
+      // Even kWarpGemmIterationsForB (int4/int8) is a no-op; odd (int2) flips.
+      warp_frag_B_read_idx = (warp_frag_B_read_idx + Base::kWarpGemmIterationsForB) % 2;
 
       // Load the scales needed for the next tile iteration
       warp_dequantizer_.load(warp_frag_scales, warp_frag_zero);

--- a/onnxruntime/contrib_ops/cuda/llm/cutlass_extensions/gemm/threadblock/dq_mma_pipelined_percol.h
+++ b/onnxruntime/contrib_ops/cuda/llm/cutlass_extensions/gemm/threadblock/dq_mma_pipelined_percol.h
@@ -268,6 +268,11 @@ class DqMmaPipelined<Shape_, IteratorA_, SmemIteratorA_, IteratorB_, SmemIterato
 
     int smem_write_stage_idx = 1;
 
+    // Persistent parity for the warp_frag_B double buffer. Must carry across CTA-K stages;
+    // deriving it from the per-stage load offset silently breaks when kWarpGemmIterationsForB
+    // is odd (int2). See dq_mma_multistage_finegrained.h for the detailed rationale.
+    int warp_frag_B_read_idx = 0;
+
     // Avoid reading out of bounds
     iterator_A.clear_mask(gemm_k_iterations <= 1);
     iterator_B.clear_mask(gemm_k_iterations <= 1);
@@ -326,7 +331,8 @@ class DqMmaPipelined<Shape_, IteratorA_, SmemIteratorA_, IteratorB_, SmemIterato
         if (warp_tileB_k_compute_offset == Base::kNumKIterationsPerWarpBLoad - 1) {
           this->warp_tile_iterator_B_.set_kgroup_index(
               (warp_tileB_k_load_offset + 1) % Base::kWarpGemmIterationsForB);
-          this->warp_tile_iterator_B_.load(warp_frag_B[(warp_tileB_k_load_offset + 1) % 2]);
+          this->warp_tile_iterator_B_.load(
+              warp_frag_B[(warp_frag_B_read_idx + warp_tileB_k_load_offset + 1) % 2]);
           ++this->warp_tile_iterator_B_;
         }
 
@@ -342,10 +348,15 @@ class DqMmaPipelined<Shape_, IteratorA_, SmemIteratorA_, IteratorB_, SmemIterato
           iterator_B.clear_mask(gemm_k_iterations <= 2);
         }
 
-        typename TransformBAfterLDS::result_type converted_frag_B = lds_converter(warp_frag_B[warp_tileB_k_load_offset % 2]);
+        typename TransformBAfterLDS::result_type converted_frag_B =
+            lds_converter(warp_frag_B[(warp_frag_B_read_idx + warp_tileB_k_load_offset) % 2]);
         warp_dequantizer_.dequantize(converted_frag_B, warp_frag_scales);
         warp_mma(accum, warp_frag_A[warp_mma_k % 2], converted_frag_B, accum, warp_tileB_k_compute_offset);
       }
+
+      // Advance the warp_frag_B double-buffer parity by the B loads consumed this stage.
+      // Even kWarpGemmIterationsForB (int4/int8) is a no-op; odd (int2) flips.
+      warp_frag_B_read_idx = (warp_frag_B_read_idx + Base::kWarpGemmIterationsForB) % 2;
     }
   }
 };

--- a/onnxruntime/contrib_ops/cuda/llm/cutlass_extensions/interleaved_numeric_conversion.h
+++ b/onnxruntime/contrib_ops/cuda/llm/cutlass_extensions/interleaved_numeric_conversion.h
@@ -394,6 +394,189 @@ struct FastInterleavedAndBiasedNumericArrayConverter<bfloat16_t, uint4b_t, N> {
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
+// uint2b_t (2-bit integer) -> half/bf16 fast converters.
+//
+// These mirror the uint4b_t specializations above so the SM80 fused-dequant grouped GEMM
+// (DqMmaMultistage) can target INT2 weights, exactly as it does INT4 weights today. The layout
+// is the natural 2-bit analog of the 4-bit path:
+//   * 16 two-bit codes pack into one 32-bit word (vs 8 nibbles for int4), so VEC_WIDTH = 16.
+//   * Symmetric storage uses an offset-binary zero point of 2 (= 2^(bits-1)); the raw code v in
+//     [0,3] represents the signed value v - 2. The matching weight pre-pack
+//     (add_bias_and_interleave_int2s_inplace_kernel) adds that +2 bias, which the converter
+//     subtracts here.
+//   * The magic-add trick reuses the fp16 constant 1024.0 (0x6400): OR-ing a 2-bit code into the
+//     low mantissa bits yields the half value 1024 + v, and subtracting 1026 (= 1024 + zero_point)
+//     leaves v - 2. bf16 uses 128.0 (0x4300) and an fma bias of -130 = -(128 + 2).
+//
+// De-interleave order: iteration ii reads codes ii and ii+8 (low/high 16-bit halves of the word),
+// so result = [c0,c8,c1,c9,...,c7,c15]. add_bias_and_interleave_int2s_inplace_kernel places source
+// element i at physical slot (i even ? i/2 : (i-1)/2 + 8) -- the exact inverse -- and kPerm_W2_A16
+// counteracts the LDSM data movement, identical in structure to the int4 path with 4 -> 8.
+template <>
+struct FastInterleavedAndBiasedNumericArrayConverter<half_t, cutlass::uint2b_t, 16> {
+  using result_type = Array<half_t, 16>;
+  using source_type = Array<cutlass::uint2b_t, 16>;
+
+  CUTLASS_DEVICE
+  static result_type convert(source_type const& source) {
+    result_type result;
+
+    uint32_t* h = reinterpret_cast<uint32_t*>(&result);
+    uint32_t const source_i2s = reinterpret_cast<uint32_t const&>(source);
+
+    static constexpr uint32_t immLut = (0xf0 & 0xcc) | 0xaa;       // (a & b) | c
+    static constexpr uint32_t MASK = 0x00030003;                   // low 2 bits of each 16-bit half
+    static constexpr uint32_t I2s_TO_F16s_MAGIC_NUM = 0x64006400;  // half2 {1024, 1024}
+
+    // Each iteration extracts codes ii (low half) and ii+8 (high half) into the low mantissa bits
+    // of 1024.0. Shifting the whole word right by 2 each step keeps both halves aligned; the bleed
+    // from the high half into the low half's upper bits is discarded by MASK.
+    uint32_t i2s = source_i2s;
+    CUTLASS_PRAGMA_UNROLL
+    for (int ii = 0; ii < result_type::kElements / 2; ++ii) {
+      asm volatile("lop3.b32 %0, %1, %2, %3, %4;\n"
+                   : "=r"(h[ii])
+                   : "r"(i2s), "n"(MASK), "n"(I2s_TO_F16s_MAGIC_NUM), "n"(immLut));
+      i2s >>= sizeof_bits<typename source_type::Element>::value;  // >>= 2
+    }
+
+    // half2 {1026, 1026}: 1024 offset from the magic number + zero point 2. Subtracting maps the
+    // stored code v in [0,3] to the signed value v - 2.
+    static constexpr uint32_t FP16_BIAS = 0x64026402;
+    CUTLASS_PRAGMA_UNROLL
+    for (int ii = 0; ii < result_type::kElements / 2; ++ii) {
+      asm volatile("sub.f16x2 %0, %1, %2;\n" : "=r"(h[ii]) : "r"(h[ii]), "r"(FP16_BIAS));
+    }
+
+    return result;
+  }
+
+  CUTLASS_DEVICE
+  result_type operator()(source_type const& s) {
+    return convert(s);
+  }
+};
+
+template <int N>
+struct FastInterleavedAndBiasedNumericArrayConverter<half_t, cutlass::uint2b_t, N> {
+  static constexpr int VEC_WIDTH = 16;
+  static_assert(!(N % VEC_WIDTH), "N must be multiple of 16.");
+
+  using result_type = Array<half_t, N>;
+  using source_type = Array<cutlass::uint2b_t, N>;
+
+  CUTLASS_DEVICE
+  static result_type convert(source_type const& source) {
+    using scalar_result_type = typename result_type::Element;
+    using scalar_source_type = typename source_type::Element;
+    FastInterleavedAndBiasedNumericArrayConverter<scalar_result_type, scalar_source_type, VEC_WIDTH>
+        convert_vector_;
+
+    result_type result;
+    using vec_result = Array<scalar_result_type, VEC_WIDTH>;
+    using vec_source = Array<scalar_source_type, VEC_WIDTH>;
+
+    vec_result* result_ptr = reinterpret_cast<vec_result*>(&result);
+    vec_source const* source_ptr = reinterpret_cast<vec_source const*>(&source);
+
+    CUTLASS_PRAGMA_UNROLL
+    for (int i = 0; i < N / VEC_WIDTH; ++i) {
+      result_ptr[i] = convert_vector_(source_ptr[i]);
+    }
+
+    return result;
+  }
+
+  CUTLASS_DEVICE
+  result_type operator()(source_type const& s) {
+    return convert(s);
+  }
+};
+
+template <>
+struct FastInterleavedAndBiasedNumericArrayConverter<bfloat16_t, cutlass::uint2b_t, 16> {
+  using result_type = Array<bfloat16_t, 16>;
+  using source_type = Array<cutlass::uint2b_t, 16>;
+
+  CUTLASS_DEVICE
+  static result_type convert(source_type const& source) {
+    result_type result;
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800))
+
+    uint32_t* h = reinterpret_cast<uint32_t*>(&result);
+    uint32_t const source_i2s = reinterpret_cast<uint32_t const&>(source);
+
+    static constexpr uint32_t immLut = (0xf0 & 0xcc) | 0xaa;
+    static constexpr uint32_t MASK = 0x00030003;
+    static constexpr uint32_t I2s_TO_BF16s_MAGIC_NUM = 0x43004300;  // bf16 {128, 128}
+
+    uint32_t i2s = source_i2s;
+    CUTLASS_PRAGMA_UNROLL
+    for (int ii = 0; ii < result_type::kElements / 2; ++ii) {
+      asm volatile("lop3.b32 %0, %1, %2, %3, %4;\n"
+                   : "=r"(h[ii])
+                   : "r"(i2s), "n"(MASK), "n"(I2s_TO_BF16s_MAGIC_NUM), "n"(immLut));
+      i2s >>= sizeof_bits<typename source_type::Element>::value;  // >>= 2
+    }
+
+    // bf16 {-130, -130} = -(128 + zero point 2), and bf16 {1, 1}. fma: (128 + v) * 1 - 130 = v - 2.
+    static constexpr uint32_t BF16_BIAS = 0xC302C302;
+    static constexpr uint32_t BF16_ONE = 0x3F803F80;
+    CUTLASS_PRAGMA_UNROLL
+    for (int ii = 0; ii < result_type::kElements / 2; ++ii) {
+      asm("fma.rn.bf16x2 %0, %1, %2, %3;\n" : "=r"(h[ii]) : "r"(h[ii]), "r"(BF16_ONE), "r"(BF16_BIAS));
+    }
+#else
+    arch::device_breakpoint();
+    result.clear();
+#endif
+    return result;
+  }
+
+  CUTLASS_DEVICE
+  result_type operator()(source_type const& s) {
+    return convert(s);
+  }
+};
+
+template <int N>
+struct FastInterleavedAndBiasedNumericArrayConverter<bfloat16_t, cutlass::uint2b_t, N> {
+  static constexpr int VEC_WIDTH = 16;
+  static_assert(!(N % VEC_WIDTH), "N must be multiple of 16.");
+
+  using result_type = Array<bfloat16_t, N>;
+  using source_type = Array<cutlass::uint2b_t, N>;
+
+  CUTLASS_DEVICE
+  static result_type convert(source_type const& source) {
+    using scalar_result_type = typename result_type::Element;
+    using scalar_source_type = typename source_type::Element;
+    FastInterleavedAndBiasedNumericArrayConverter<scalar_result_type, scalar_source_type, VEC_WIDTH>
+        convert_vector_;
+
+    result_type result;
+    using vec_result = Array<scalar_result_type, VEC_WIDTH>;
+    using vec_source = Array<scalar_source_type, VEC_WIDTH>;
+
+    vec_result* result_ptr = reinterpret_cast<vec_result*>(&result);
+    vec_source const* source_ptr = reinterpret_cast<vec_source const*>(&source);
+
+    CUTLASS_PRAGMA_UNROLL
+    for (int i = 0; i < N / VEC_WIDTH; ++i) {
+      result_ptr[i] = convert_vector_(source_ptr[i]);
+    }
+
+    return result;
+  }
+
+  CUTLASS_DEVICE
+  result_type operator()(source_type const& s) {
+    return convert(s);
+  }
+};
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
 // FP4 (e2m1) -> half/bf16 fast converters.
 //
 // These mirror the uint4b_t specializations above so the SM80 fused-dequant grouped GEMM

--- a/onnxruntime/contrib_ops/cuda/llm/fpA_intB_gemm_adaptor.cu
+++ b/onnxruntime/contrib_ops/cuda/llm/fpA_intB_gemm_adaptor.cu
@@ -255,6 +255,56 @@ void unpack_uint4_transposed_to_int8_direct_cuda(
       k);
 }
 
+// 2-bit analog of unpack_transpose_pack_uint4_to_int8_kernel_v2. Input packed_weight is
+// [n, k/4] (4 unsigned 2-bit codes per byte, along k); output packed_transposed_weight is
+// [k, n/4] (4 signed 2-bit codes per byte, along n). Each output byte packs the 4 consecutive
+// N-dimension codes {4*out_col_packed .. +3} at output row out_row_packed, with the default
+// zero point (2) subtracted so the stored codes are signed in [-2, 1].
+__global__ void unpack_transpose_pack_uint2_to_int2_kernel(
+    const unsigned char* __restrict__ packed_weight,
+    signed char* __restrict__ packed_transposed_weight,
+    int n,  // original matrix rows
+    int k)  // original matrix columns
+{
+  int out_flat_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  int total_output_bytes = k * (n / 4);
+
+  if (out_flat_idx < total_output_bytes) {
+    constexpr signed char default_zero_point = 2;
+
+    const int out_row_packed = out_flat_idx / (n / 4);  // row in k (0..k-1)
+    const int out_col_packed = out_flat_idx % (n / 4);  // byte column in n/4
+
+    uint8_t out_byte = 0;
+    for (int s = 0; s < 4; ++s) {
+      const int r_orig = 4 * out_col_packed + s;  // original row in n
+      const int c_orig = out_row_packed;          // original col in k
+
+      // packed_weight is [n, k/4]: byte holds 4 codes along k, code c_orig at sub-index c_orig % 4.
+      const int packed_idx = r_orig * (k / 4) + c_orig / 4;
+      const unsigned char packed_data = packed_weight[packed_idx];
+      const uint8_t code = (packed_data >> ((c_orig % 4) * 2)) & 0x03;
+
+      const signed char val = static_cast<signed char>(code) - default_zero_point;
+      out_byte |= static_cast<uint8_t>(val & 0x03) << (s * 2);
+    }
+    packed_transposed_weight[out_flat_idx] = static_cast<signed char>(out_byte);
+  }
+}
+
+void unpack_uint2_transposed_to_int2_direct_cuda(
+    cudaStream_t stream, void* packed_transposed_weight, const void* packed_weight, int n, int k) {
+  int total_output_bytes = k * (n / 4);
+  int threads_per_block = 256;
+  int num_blocks = (total_output_bytes + threads_per_block - 1) / threads_per_block;
+
+  unpack_transpose_pack_uint2_to_int2_kernel<<<num_blocks, threads_per_block, 0, stream>>>(
+      (const unsigned char*)packed_weight,
+      (signed char*)packed_transposed_weight,
+      n,
+      k);
+}
+
 __global__ void transpose_uint8_matrix_and_convert_to_int8_kernel(
     const uint8_t* __restrict__ input,  // shape: (n, k)
     int8_t* __restrict__ output,        // shape: (k, n)

--- a/onnxruntime/contrib_ops/cuda/llm/fpA_intB_gemm_adaptor.h
+++ b/onnxruntime/contrib_ops/cuda/llm/fpA_intB_gemm_adaptor.h
@@ -32,6 +32,16 @@ void unpack_uint4_transposed_to_int8_direct_cuda(cudaStream_t stream,
                                                  int n,
                                                  int k);
 
+// Transpose uint2 weight matrix, subtract the default zero point (2), and re-pack as signed 2-bit
+// (4 codes per byte). Input is row-major [n, k/4]; output is transposed [k, n/4]. This is the 2-bit
+// analog of unpack_uint4_transposed_to_int8_direct_cuda; the signed codes feed
+// preprocess_weights_for_mixed_gemm_cuda(QuantType::W2_A16), whose bias+interleave step re-adds +2.
+void unpack_uint2_transposed_to_int2_direct_cuda(cudaStream_t stream,
+                                                 void* packed_transposed_weight,
+                                                 const void* packed_weight,
+                                                 int n,
+                                                 int k);
+
 // Transpose uint8 weight matrix and add default zero points as int8.
 void transpose_uint8_matrix_and_convert_to_int8(cudaStream_t stream,
                                                 int8_t* output,        // shape: (k, n)

--- a/onnxruntime/contrib_ops/cuda/llm/fpA_intB_gemm_preprocessors.h
+++ b/onnxruntime/contrib_ops/cuda/llm/fpA_intB_gemm_preprocessors.h
@@ -28,6 +28,7 @@ namespace weight_only {
 enum class QuantType {
   W8_A16,
   W4_A16,
+  W2_A16,
   W4_AFP8
 };
 

--- a/onnxruntime/contrib_ops/cuda/llm/fpA_intB_gemm_preprocessors_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/llm/fpA_intB_gemm_preprocessors_impl.cu
@@ -112,8 +112,15 @@ void permute_B_rows_on_gpu(
   // blockDim.y should be permutation_tile_size.
   // threadIdx.x will cooperatively process vector columns.
 
-  int threads_per_block_y = permutation_tile_size;  // 16 or 32, depending on the quantization type
-  int threads_per_block_x = 32;                     // Tunable: number of vector columns processed by a warp/blockDim.x threads
+  int threads_per_block_y = permutation_tile_size;  // 16 (W8), 32 (W4), or 64 (W2)
+  // threadIdx.x cooperatively processes vector columns. Cap the total block size at the CUDA limit
+  // of 1024 threads: W2's permutation_tile_size is 64, so a fixed x=32 would request 2048 threads
+  // and the launch would fail silently (leaving the permuted buffer zero-initialized). Shrink x so
+  // x*y <= 1024.
+  int threads_per_block_x = 32;
+  while (threads_per_block_x * threads_per_block_y > 1024 && threads_per_block_x > 1) {
+    threads_per_block_x /= 2;
+  }
 
   dim3 blockDim(threads_per_block_x, threads_per_block_y, 1);
 
@@ -139,7 +146,7 @@ constexpr int SUBBYTE_TRANSPOSE_BLOCK_ROWS = 8;      // Affects how many rows of
 
 template <int BITS_PER_ELT>
 __global__ void subbyte_transpose_kernel(int8_t* output, const int8_t* input, int num_rows_in, int num_cols_in) {
-  static_assert(BITS_PER_ELT == 8 || BITS_PER_ELT == 4, "BITS_PER_ELT must be 8 or 4");
+  static_assert(BITS_PER_ELT == 8 || BITS_PER_ELT == 4 || BITS_PER_ELT == 2, "BITS_PER_ELT must be 8, 4 or 2");
 
   constexpr int ELTS_PER_BYTE = 8 / BITS_PER_ELT;
 
@@ -215,13 +222,16 @@ __global__ void subbyte_transpose_kernel(int8_t* output, const int8_t* input, in
             // Direct byte write for 8-bit elements.
             // Output has num_cols_in rows. Output byte stride is num_rows_in bytes.
             output[gmem_write_row_elt * num_rows_in + gmem_write_col_elt] = source_byte_from_smem;
-          } else if constexpr (BITS_PER_ELT == 4) {
-            uint8_t nibble = (source_byte_from_smem >> (k * 4)) & 0x0F;
+          } else {
+            // Sub-byte (4-bit or 2-bit): extract element k and OR it into its destination slot.
+            // ELTS_PER_BYTE = 2 (int4) or 4 (int2); each element is BITS_PER_ELT wide.
+            constexpr uint8_t ELT_MASK = static_cast<uint8_t>((1u << BITS_PER_ELT) - 1u);
+            uint8_t sub_elt = (source_byte_from_smem >> (k * BITS_PER_ELT)) & ELT_MASK;
 
-            // Calculate precise byte and nibble index in the output byte
+            // Calculate precise byte and sub-element index in the output byte.
             int output_matrix_num_byte_cols = num_rows_in / ELTS_PER_BYTE;
             int gmem_dest_col_byte = gmem_write_col_elt / ELTS_PER_BYTE;
-            int gmem_dest_col_nibble_idx = gmem_write_col_elt % ELTS_PER_BYTE;
+            int gmem_dest_col_sub_idx = gmem_write_col_elt % ELTS_PER_BYTE;
 
             int8_t* p_target_byte = &output[gmem_write_row_elt * output_matrix_num_byte_cols + gmem_dest_col_byte];
 
@@ -230,9 +240,9 @@ __global__ void subbyte_transpose_kernel(int8_t* output, const int8_t* input, in
             uint32_t* p_aligned_word = (uint32_t*)(addr_val & ~3ULL);  // Align address down to nearest 4-byte boundary
             uint32_t byte_offset_in_word = addr_val & 3ULL;            // Find byte's offset within this 4-byte word (0,1,2,3)
 
-            // Calculate the shift for the nibble within the 4-byte aligned word
-            uint32_t shift_in_aligned_word = (byte_offset_in_word * 8) + (gmem_dest_col_nibble_idx * 4);
-            uint32_t value_to_or = ((uint32_t)nibble) << shift_in_aligned_word;
+            // Calculate the shift for the sub-element within the 4-byte aligned word.
+            uint32_t shift_in_aligned_word = (byte_offset_in_word * 8) + (gmem_dest_col_sub_idx * BITS_PER_ELT);
+            uint32_t value_to_or = ((uint32_t)sub_elt) << shift_in_aligned_word;
 
             atomicOr(p_aligned_word, value_to_or);
           }
@@ -266,9 +276,9 @@ void subbyte_transpose_cuda(
       // Number of tiles needed for input rows (in elements)
       (num_rows_in + SUBBYTE_TRANSPOSE_TILE_DIM_ELTS - 1) / SUBBYTE_TRANSPOSE_TILE_DIM_ELTS);
 
-  // IMPORTANT: For atomicOr to work correctly by combining nibbles,
+  // IMPORTANT: For atomicOr to work correctly by combining sub-byte elements,
   // the output buffer must be zero-initialized before launching the kernel.
-  if (BITS_PER_ELT == 4) {
+  if (BITS_PER_ELT == 4 || BITS_PER_ELT == 2) {
     size_t output_num_bytes = static_cast<size_t>(num_cols_in) * num_rows_in * BITS_PER_ELT / 8;
     cudaMemsetAsync(transposed_quantized_tensor_out, 0, output_num_bytes, stream);
   }
@@ -278,6 +288,9 @@ void subbyte_transpose_cuda(
         transposed_quantized_tensor_out, quantized_tensor_in, num_rows_in, num_cols_in);
   } else if (BITS_PER_ELT == 8) {
     subbyte_transpose_kernel<8><<<gridDim, blockDim, 0, stream>>>(
+        transposed_quantized_tensor_out, quantized_tensor_in, num_rows_in, num_cols_in);
+  } else if (BITS_PER_ELT == 2) {
+    subbyte_transpose_kernel<2><<<gridDim, blockDim, 0, stream>>>(
         transposed_quantized_tensor_out, quantized_tensor_in, num_rows_in, num_cols_in);
   } else {
     ORT_THROW("Invalid quant_type for CUDA subbyte_transpose.");
@@ -482,6 +495,46 @@ __global__ void add_bias_and_interleave_int4s_inplace_kernel(uint32_t* tensor, s
   }
 }
 
+/**
+ * @brief CUDA kernel to add bias and interleave an INT2 tensor in place.
+ *
+ * Each thread handles a 32-bit segment (16 int2 elements). This is the 2-bit analog of
+ * add_bias_and_interleave_int4s_inplace_kernel:
+ * 1. Unpacks 16 2-bit elements, sign-extends each (stored signed, values -2..1).
+ * 2. Adds a bias of 2 (= 2^(bits-1)) to map to unsigned [0, 3].
+ * 3. Repacks into the interleave [c0,c2,c4,...,c14, c1,c3,...,c15] -- even codes into the low
+ *    half of the word, odd codes into the high half -- which is exactly the order the
+ *    FastInterleavedAndBiasedNumericArrayConverter<half/bf16, uint2b_t, 16> inverts (iteration ii
+ *    reads slots ii and ii+8).
+ */
+__global__ void add_bias_and_interleave_int2s_inplace_kernel(uint32_t* tensor, size_t num_elts) {
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  size_t register_idx = static_cast<size_t>(idx);
+
+  // Each register holds 16 int2 elements.
+  if (register_idx < num_elts / 16) {
+    uint32_t current_register = tensor[register_idx];
+    uint32_t transformed_register = 0;
+
+    for (int i = 0; i < 16; ++i) {  // i = src_idx of 2-bit code (LSB to MSB within the word)
+      uint8_t raw_code = (current_register >> (i * 2)) & 0x03;
+
+      // Sign-extend the 2-bit code to a signed value in [-2, 1] (matches int4's arithmetic-shift
+      // trick): place the code in the top 2 bits of an int8 and shift back down.
+      int8_t signed_code = static_cast<int8_t>(static_cast<int8_t>(raw_code << 6) >> 6);
+
+      // Add bias (maps signed int2 to unsigned int2 [0, 3]).
+      uint8_t biased_code = static_cast<uint8_t>(signed_code + 2);
+
+      // Destination slot: even -> low half [0..7], odd -> high half [8..15].
+      int dest_idx = ((i % 2) == 0) ? (i / 2) : ((i - 1) / 2 + 8);
+
+      transformed_register |= (static_cast<uint32_t>(biased_code & 0x03) << (dest_idx * 2));
+    }
+    tensor[register_idx] = transformed_register;
+  }
+}
+
 // Interleave-only variant for MXFP4 (e2m1) weights: applies the SAME
 // [e0,e2,e4,e6,e1,e3,e5,e7] nibble pair-interleave as
 // add_bias_and_interleave_int4s_inplace_kernel, but writes the raw 4-bit code unchanged (no
@@ -557,6 +610,14 @@ void add_bias_and_interleave_quantized_tensor_inplace_cuda(
     const int num_blocks = (num_registers + threads_per_block - 1) / threads_per_block;
 
     add_bias_and_interleave_int4s_inplace_kernel<<<num_blocks, threads_per_block, 0, stream>>>(
+        reinterpret_cast<uint32_t*>(tensor),
+        num_elts);
+  } else if (quant_type == QuantType::W2_A16) {
+    // Each thread handles 16 elements (32 bits)
+    const int num_registers = SafeInt<int32_t>(num_elts) / 16;
+    const int num_blocks = (num_registers + threads_per_block - 1) / threads_per_block;
+
+    add_bias_and_interleave_int2s_inplace_kernel<<<num_blocks, threads_per_block, 0, stream>>>(
         reinterpret_cast<uint32_t*>(tensor),
         num_elts);
   } else {

--- a/onnxruntime/contrib_ops/cuda/llm/fpA_intB_gemm_preprocessors_impl.h
+++ b/onnxruntime/contrib_ops/cuda/llm/fpA_intB_gemm_preprocessors_impl.h
@@ -40,6 +40,8 @@ constexpr int get_weight_quant_bits(QuantType quant_type) {
     case QuantType::W4_A16:
     case QuantType::W4_AFP8:
       return 4;
+    case QuantType::W2_A16:
+      return 2;
   }
 
   return -1;
@@ -112,6 +114,9 @@ LayoutDetails getLayoutDetailsForArch(QuantType quant_type) {
     case QuantType::W4_A16:
       details = getLayoutDetailsForArchAndQuantType<cutlassArch, cutlass::half_t, cutlass::uint4b_t>();
       break;
+    case QuantType::W2_A16:
+      details = getLayoutDetailsForArchAndQuantType<cutlassArch, cutlass::half_t, cutlass::uint2b_t>();
+      break;
     case QuantType::W4_AFP8:
       details = getLayoutDetailsForArchAndQuantType<cutlassArch, cutlass::float_e4m3_t, cutlass::uint4b_t>();
       break;
@@ -143,6 +148,19 @@ constexpr std::array<int, 32> kPerm_W4_AFP8 = {
     0, 1, 2, 3, 16, 17, 18, 19, 4, 5, 6, 7, 20, 21, 22, 23,
     8, 9, 10, 11, 24, 25, 26, 27, 12, 13, 14, 15, 28, 29, 30, 31};
 
+// 2-bit (W2_A16) LDSM row permutation, group size 128/bits = 64 rows. Derived from the same
+// generating rule that reproduces kPerm_W8_A16 and kPerm_W4_A16 exactly: 4 groups, each emitting
+// the pairs {base, base+1} for base = 2*g + 8*p (p = 0..pairs_per_group-1, pairs_per_group =
+// rows/8 = 8). i.e. group g = {2g, 2g+1, 2g+8, 2g+9, 2g+16, 2g+17, ...}. There is no upstream
+// W2 reference (TRT-LLM only ships W8/W4), so this map is validated empirically via parity vs the
+// phase-1 dequant fallback -- if 2-bit output is garbage, this map (and its pairing with the
+// converter interleave) is the first suspect.
+constexpr std::array<int, 64> kPerm_W2_A16 = {
+    0, 1, 8, 9, 16, 17, 24, 25, 32, 33, 40, 41, 48, 49, 56, 57,
+    2, 3, 10, 11, 18, 19, 26, 27, 34, 35, 42, 43, 50, 51, 58, 59,
+    4, 5, 12, 13, 20, 21, 28, 29, 36, 37, 44, 45, 52, 53, 60, 61,
+    6, 7, 14, 15, 22, 23, 30, 31, 38, 39, 46, 47, 54, 55, 62, 63};
+
 // Permutes the rows of B in a way that is compatible with Turing+ architectures.
 //
 // Throws an error for other architectures.
@@ -161,6 +179,8 @@ gsl::span<const int> get_permutation_map(QuantType quant_type) {
       return AsSpan(kPerm_W8_A16);
     case QuantType::W4_A16:
       return AsSpan(kPerm_W4_A16);
+    case QuantType::W2_A16:
+      return AsSpan(kPerm_W2_A16);
     case QuantType::W4_AFP8:
       return AsSpan(kPerm_W4_AFP8);
     default:

--- a/onnxruntime/contrib_ops/cuda/llm/fpA_intB_gemv/details.h
+++ b/onnxruntime/contrib_ops/cuda/llm/fpA_intB_gemv/details.h
@@ -135,6 +135,10 @@ struct Int4DetailsW {
   static constexpr int kElemBits = 4;
 };
 
+struct Int2DetailsW {
+  static constexpr int kElemBits = 2;
+};
+
 struct Fp4DetailsW {
   static constexpr int kElemBits = 4;
 };
@@ -231,12 +235,20 @@ struct KernelDetails {
 template <typename AType, int WElemBits, bool Interleave>
 struct I2FConverter;
 
+// Selects the packed cutlass weight type for the interleaved converter from the bit width.
+template <int WElemBits>
+struct InterleavedCutlassWType {
+  static_assert(WElemBits == 2 || WElemBits == 4 || WElemBits == 8, "WElemBits must be 2, 4 or 8");
+  using type = std::conditional_t<WElemBits == 8, uint8_t,
+                                  std::conditional_t<WElemBits == 4, cutlass::uint4b_t, cutlass::uint2b_t>>;
+};
+
 template <typename AType, int WElemBits>
 struct I2FConverter<AType, WElemBits, true> {
   static_assert(std::is_same_v<AType, half> || std::is_same_v<AType, __nv_bfloat16>);
-  static_assert(WElemBits == 4 || WElemBits == 8);
+  static_assert(WElemBits == 2 || WElemBits == 4 || WElemBits == 8);
   using CutlassAType = std::conditional_t<std::is_same_v<AType, half>, cutlass::half_t, cutlass::bfloat16_t>;
-  using CutlassWType = std::conditional_t<WElemBits == 4, cutlass::uint4b_t, uint8_t>;
+  using CutlassWType = typename InterleavedCutlassWType<WElemBits>::type;
   static constexpr int kConvertCount = 32 / WElemBits;
   using Converter = cutlass::FastInterleavedAndBiasedNumericArrayConverter<CutlassAType, CutlassWType, kConvertCount>;
   using CvtSrcType = typename Converter::source_type;

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemm_activation_kernels.cuh
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemm_activation_kernels.cuh
@@ -123,7 +123,9 @@ void doGatedActivation(ActivationOutputType* output, const GemmOutputType* gemm_
       case ActivationType::SwigluBias:
         return &doGatedActivationKernel<ActivationOutputType, GemmOutputType, SiLu>;
       case ActivationType::Geglu:
-        return &doGatedActivationKernel<ActivationOutputType, GemmOutputType, GELU>;
+        // Gemma4 GeGLU uses the tanh-approximation GELU (gelu_pytorch_tanh), so gate the GLU with
+        // GELU_taylor (tanh) rather than the erf-exact GELU to match HuggingFace numerics.
+        return &doGatedActivationKernel<ActivationOutputType, GemmOutputType, GELU_taylor>;
       case ActivationType::Silu:
         return &doGatedActivationKernel<ActivationOutputType, GemmOutputType, SiLu>;
       case ActivationType::Gelu:

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemm_kernels_bf16_uint2.cu
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemm_kernels_bf16_uint2.cu
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "contrib_ops/cuda/llm/moe_gemm/moe_gemm_template_dispatch.h"
+
+namespace onnxruntime::llm::kernels::cutlass_kernels {
+#ifdef ENABLE_BF16
+template class MoeGemmRunner<__nv_bfloat16, cutlass::uint2b_t, __nv_bfloat16>;
+#endif
+}  // namespace onnxruntime::llm::kernels::cutlass_kernels

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemm_kernels_fp16_uint2.cu
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemm_kernels_fp16_uint2.cu
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "contrib_ops/cuda/llm/moe_gemm/moe_gemm_template_dispatch.h"
+
+namespace onnxruntime::llm::kernels::cutlass_kernels {
+template class MoeGemmRunner<half, cutlass::uint2b_t, half>;
+}

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemm_template_dispatch.h
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemm_template_dispatch.h
@@ -127,7 +127,7 @@ struct genericMoeGemmKernelLauncher {
                   "Specialized for half, float");
 #endif
 
-    static_assert(cutlass::platform::is_same<T, WeightType>::value || cutlass::platform::is_same<WeightType, uint8_t>::value || cutlass::platform::is_same<WeightType, cutlass::uint4b_t>::value
+    static_assert(cutlass::platform::is_same<T, WeightType>::value || cutlass::platform::is_same<WeightType, uint8_t>::value || cutlass::platform::is_same<WeightType, cutlass::uint4b_t>::value || cutlass::platform::is_same<WeightType, cutlass::uint2b_t>::value
 #if defined(ENABLE_FP4)
                   || cutlass::platform::is_same<WeightType, __nv_fp4_e2m1>::value
 #endif

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemv.cu
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemv.cu
@@ -899,6 +899,7 @@ static constexpr int kThreads = 128;
 static constexpr int kTileSizeK = 64;
 static constexpr int kInt4Interleave = 128 * 8 / (kTileSizeK * 4);  // = 4
 static constexpr int kInt8Interleave = 128 * 8 / (kTileSizeK * 8);  // = 2
+static constexpr int kInt2Interleave = 128 * 8 / (kTileSizeK * 2);  // = 8
 
 // The fused-finalize FC2 GEMV moves the top_k loop inside the block, so at kCtaN it would launch
 // top_k times fewer blocks than the unfused kernel and lose memory-level parallelism. A narrower
@@ -931,7 +932,7 @@ bool is_moe_gemv_shape_supported(int sm, int64_t expanded_num_rows, int64_t n, i
   if (sm < 80) {
     return false;
   }
-  if (weight_bits != 4 && weight_bits != 8) {
+  if (weight_bits != 4 && weight_bits != 8 && weight_bits != 2) {
     return false;
   }
   // group_size <= 0 selects the per-column (per-channel) path; block-wise scales must be 32, 64, or 128.
@@ -953,7 +954,7 @@ bool is_moe_gemv_shape_supported(int sm, int64_t expanded_num_rows, int64_t n, i
     return false;
   }
   // n must tile evenly; k must tile evenly into StepK along interleaved-K.
-  const int interleave = weight_bits == 4 ? kInt4Interleave : kInt8Interleave;
+  const int interleave = weight_bits == 4 ? kInt4Interleave : (weight_bits == 2 ? kInt2Interleave : kInt8Interleave);
   if (n % (cta_n * interleave) != 0) {
     return false;
   }
@@ -1016,6 +1017,13 @@ struct DetailsForTAndWeight<half, cutlass::uint4b_t> {
 };
 
 template <>
+struct DetailsForTAndWeight<half, cutlass::uint2b_t> {
+  using Details = fiv::KernelDetails<fiv::FP16DetailsA, fiv::Int2DetailsW, fiv::ColumnMajorInterleaved, true, kTileSizeK>;
+  using TypeA = half;
+  static constexpr int kWeightBits = 2;
+};
+
+template <>
 struct DetailsForTAndWeight<half, uint8_t> {
   using Details = fiv::KernelDetails<fiv::FP16DetailsA, fiv::Int8DetailsW, fiv::ColumnMajorInterleaved, true, kTileSizeK>;
   using TypeA = half;
@@ -1028,6 +1036,13 @@ struct DetailsForTAndWeight<__nv_bfloat16, cutlass::uint4b_t> {
   using Details = fiv::KernelDetails<fiv::BF16DetailsA, fiv::Int4DetailsW, fiv::ColumnMajorInterleaved, true, kTileSizeK>;
   using TypeA = __nv_bfloat16;
   static constexpr int kWeightBits = 4;
+};
+
+template <>
+struct DetailsForTAndWeight<__nv_bfloat16, cutlass::uint2b_t> {
+  using Details = fiv::KernelDetails<fiv::BF16DetailsA, fiv::Int2DetailsW, fiv::ColumnMajorInterleaved, true, kTileSizeK>;
+  using TypeA = __nv_bfloat16;
+  static constexpr int kWeightBits = 2;
 };
 
 template <>
@@ -1183,6 +1198,15 @@ template void launch_moe_gemv_int_symmetric_interleaved_swiglu<half, cutlass::ui
 template void launch_moe_gemv_int_symmetric_interleaved_swiglu<half, uint8_t>(
     const half*, const uint8_t*, const half*, const half*, half*, const int64_t*, const int*, int,
     int64_t, int64_t, int64_t, int, int, cutlass_kernels::ActivationParams, const int*, int64_t, float*, cudaStream_t);
+template void launch_moe_gemv_int_symmetric<half, cutlass::uint2b_t>(
+    const half*, const cutlass::uint2b_t*, const half*, const half*, half*, const int64_t*, const int*, int,
+    int64_t, int64_t, int64_t, int, int, cudaStream_t);
+template void launch_moe_gemv_int_symmetric_fused_finalize<half, cutlass::uint2b_t>(
+    const half*, const cutlass::uint2b_t*, const half*, const half*, half*, const int*, const int*, const float*,
+    int, int64_t, int64_t, int64_t, int64_t, int, int, cudaStream_t);
+template void launch_moe_gemv_int_symmetric_interleaved_swiglu<half, cutlass::uint2b_t>(
+    const half*, const cutlass::uint2b_t*, const half*, const half*, half*, const int64_t*, const int*, int,
+    int64_t, int64_t, int64_t, int, int, cutlass_kernels::ActivationParams, const int*, int64_t, float*, cudaStream_t);
 
 template void launch_moe_gemv_int4_per_channel<half>(const half*, const uint8_t*, const half*, const half*, half*,
                                                      const int64_t*, const int*, int, int64_t, int64_t, int64_t,
@@ -1210,6 +1234,16 @@ template void launch_moe_gemv_int_symmetric_interleaved_swiglu<__nv_bfloat16, cu
     const int*, int64_t, float*, cudaStream_t);
 template void launch_moe_gemv_int_symmetric_interleaved_swiglu<__nv_bfloat16, uint8_t>(
     const __nv_bfloat16*, const uint8_t*, const __nv_bfloat16*, const __nv_bfloat16*, __nv_bfloat16*,
+    const int64_t*, const int*, int, int64_t, int64_t, int64_t, int, int, cutlass_kernels::ActivationParams,
+    const int*, int64_t, float*, cudaStream_t);
+template void launch_moe_gemv_int_symmetric<__nv_bfloat16, cutlass::uint2b_t>(
+    const __nv_bfloat16*, const cutlass::uint2b_t*, const __nv_bfloat16*, const __nv_bfloat16*, __nv_bfloat16*,
+    const int64_t*, const int*, int, int64_t, int64_t, int64_t, int, int, cudaStream_t);
+template void launch_moe_gemv_int_symmetric_fused_finalize<__nv_bfloat16, cutlass::uint2b_t>(
+    const __nv_bfloat16*, const cutlass::uint2b_t*, const __nv_bfloat16*, const __nv_bfloat16*, __nv_bfloat16*,
+    const int*, const int*, const float*, int, int64_t, int64_t, int64_t, int64_t, int, int, cudaStream_t);
+template void launch_moe_gemv_int_symmetric_interleaved_swiglu<__nv_bfloat16, cutlass::uint2b_t>(
+    const __nv_bfloat16*, const cutlass::uint2b_t*, const __nv_bfloat16*, const __nv_bfloat16*, __nv_bfloat16*,
     const int64_t*, const int*, int, int64_t, int64_t, int64_t, int, int, cutlass_kernels::ActivationParams,
     const int*, int64_t, float*, cudaStream_t);
 

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemv.h
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_gemv.h
@@ -45,7 +45,7 @@ bool is_moe_gemv_fused_finalize_supported(int sm, int64_t num_rows, int64_t expe
 
 // Launches symmetric INT MoE GEMV. group_size <= 0 means per-channel scales;
 // group_size 32/64/128 means block-wise scales laid out as [num_experts, k_blocks, n].
-// T is half or __nv_bfloat16. WeightType is cutlass::uint4b_t or uint8_t.
+// T is half or __nv_bfloat16. WeightType is cutlass::uint4b_t, cutlass::uint2b_t or uint8_t.
 template <typename T, typename WeightType>
 void launch_moe_gemv_int_symmetric(
     const T* act, const WeightType* weight, const T* scales, const T* bias, T* out,

--- a/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_kernels.cu
+++ b/onnxruntime/contrib_ops/cuda/llm/moe_gemm/moe_kernels.cu
@@ -144,6 +144,8 @@ template <typename WeightType>
 constexpr int MoeGemvWeightBits() {
   if constexpr (std::is_same_v<WeightType, cutlass::uint4b_t>) {
     return 4;
+  } else if constexpr (std::is_same_v<WeightType, cutlass::uint2b_t>) {
+    return 2;
   } else if constexpr (std::is_same_v<WeightType, uint8_t>) {
     return 8;
   } else {
@@ -162,7 +164,7 @@ bool tryLaunchMoeGemvIntSymmetric(const T* input, const WeightType* weights, con
                                   const int* permuted_row_to_expert, int64_t expanded_num_rows,
                                   int64_t n, int64_t k, int sm, int group_size,
                                   bool disabled, cudaStream_t stream) {
-  if constexpr ((std::is_same_v<WeightType, cutlass::uint4b_t> || std::is_same_v<WeightType, uint8_t>) &&
+  if constexpr ((std::is_same_v<WeightType, cutlass::uint4b_t> || std::is_same_v<WeightType, cutlass::uint2b_t> || std::is_same_v<WeightType, uint8_t>) &&
                 (std::is_same_v<T, half> || std::is_same_v<T, __nv_bfloat16>) && std::is_same_v<ScaleBiasType, T>) {
     const bool env_disabled = MoeGemvDisabledByEnv();
     const bool has_block_zeros = group_size > 0 && weight_zeros != nullptr;
@@ -210,7 +212,7 @@ bool tryLaunchMoeGemvIntSymmetricFusedFinalize(
     const int* permuted_row_to_expert, const float* unpermuted_final_scales, int num_experts_per_node,
     int64_t num_rows, int64_t experts_per_token, int64_t expanded_num_rows, int64_t n, int64_t k, int sm,
     int group_size, bool disabled, cudaStream_t stream) {
-  if constexpr ((std::is_same_v<WeightType, cutlass::uint4b_t> || std::is_same_v<WeightType, uint8_t>) &&
+  if constexpr ((std::is_same_v<WeightType, cutlass::uint4b_t> || std::is_same_v<WeightType, cutlass::uint2b_t> || std::is_same_v<WeightType, uint8_t>) &&
                 (std::is_same_v<T, half> || std::is_same_v<T, __nv_bfloat16>) && std::is_same_v<ScaleBiasType, T> &&
                 std::is_same_v<OutputType, T>) {
     const bool has_block_zeros = group_size > 0 && weight_zeros != nullptr;
@@ -265,7 +267,7 @@ template <typename T, typename WeightType, typename ScaleBiasType>
 bool moeGemvInterleavedSwiGLUWillRun(const ScaleBiasType* weight_zeros, int64_t expanded_num_rows,
                                      int64_t inter_size, int64_t k, int sm, int group_size, bool disabled,
                                      cutlass_kernels::ActivationParams activation_params) {
-  if constexpr ((std::is_same_v<WeightType, cutlass::uint4b_t> || std::is_same_v<WeightType, uint8_t>) &&
+  if constexpr ((std::is_same_v<WeightType, cutlass::uint4b_t> || std::is_same_v<WeightType, cutlass::uint2b_t> || std::is_same_v<WeightType, uint8_t>) &&
                 (std::is_same_v<T, half> || std::is_same_v<T, __nv_bfloat16>) && std::is_same_v<ScaleBiasType, T>) {
     const bool has_block_zeros = group_size > 0 && weight_zeros != nullptr;
     if (disabled || MoeGemvDisabledByEnv() || has_block_zeros) {
@@ -302,7 +304,7 @@ bool tryLaunchMoeGemvIntSymmetricInterleavedSwiGLU(
     int64_t expanded_num_rows, int64_t inter_size, int64_t k, int sm, int group_size,
     bool disabled, cutlass_kernels::ActivationParams activation_params, const int* permuted_row_to_source_row,
     int64_t num_rows, float* splitk_partials, cudaStream_t stream) {
-  if constexpr ((std::is_same_v<WeightType, cutlass::uint4b_t> || std::is_same_v<WeightType, uint8_t>) &&
+  if constexpr ((std::is_same_v<WeightType, cutlass::uint4b_t> || std::is_same_v<WeightType, cutlass::uint2b_t> || std::is_same_v<WeightType, uint8_t>) &&
                 (std::is_same_v<T, half> || std::is_same_v<T, __nv_bfloat16>) && std::is_same_v<ScaleBiasType, T>) {
     if (!moeGemvInterleavedSwiGLUWillRun<T, WeightType, ScaleBiasType>(
             weight_zeros, expanded_num_rows, inter_size, k, sm, group_size, disabled, activation_params)) {
@@ -2719,7 +2721,7 @@ void CutlassMoeFCRunner<T, WeightType, OutputType, InputType, ScaleBiasType, Ena
     int* unpermuted_row_to_permuted_row, MOEParallelismConfig parallelism_config,
     ActivationParameters activation_params, FusedRoutingParams fused_routing,
     cudaStream_t stream) {
-  static constexpr bool int_scales_required = std::is_same<WeightType, uint8_t>::value || std::is_same<WeightType, cutlass::uint4b_t>::value;
+  static constexpr bool int_scales_required = std::is_same<WeightType, uint8_t>::value || std::is_same<WeightType, cutlass::uint4b_t>::value || std::is_same<WeightType, cutlass::uint2b_t>::value;
   static constexpr bool fp8_scales_required = std::is_same<WeightType, __nv_fp8_e4m3>::value || std::is_same<WeightType, __nv_fp8_e5m2>::value;
 
   const auto* input_activations = static_cast<const InputType*>(input_activations_void);
@@ -3690,11 +3692,13 @@ template class CutlassMoeFCRunner<float, float>;
 template class CutlassMoeFCRunner<__nv_bfloat16, __nv_bfloat16>;
 template class CutlassMoeFCRunner<__nv_bfloat16, uint8_t>;
 template class CutlassMoeFCRunner<__nv_bfloat16, cutlass::uint4b_t>;
+template class CutlassMoeFCRunner<__nv_bfloat16, cutlass::uint2b_t>;
 #endif
 
 template class CutlassMoeFCRunner<half, half>;
 template class CutlassMoeFCRunner<half, uint8_t>;
 template class CutlassMoeFCRunner<half, cutlass::uint4b_t>;
+template class CutlassMoeFCRunner<half, cutlass::uint2b_t>;
 
 #if defined(ENABLE_FP4) && defined(USE_FP4_QMOE)
 template class CutlassMoeFCRunner<half, __nv_fp4_e2m1>;

--- a/onnxruntime/contrib_ops/cuda/moe/moe_base.h
+++ b/onnxruntime/contrib_ops/cuda/moe/moe_base.h
@@ -41,6 +41,10 @@ class MoEBase {
       activation_type_ = ActivationType::Silu;
     } else if (activation_type_str == "swiglu") {
       activation_type_ = ActivationType::Swiglu;
+    } else if (activation_type_str == "geglu") {
+      // GeGLU: gelu-gated GLU (down(gelu_tanh(gate) * up)). Gated like SwiGLU (interleaved fc1),
+      // differing only in the gate nonlinearity (tanh-approx GELU instead of SiLU). Used by Gemma4.
+      activation_type_ = ActivationType::Geglu;
     } else if (activation_type_str == "identity") {
       activation_type_ = ActivationType::Identity;
     } else {
@@ -65,8 +69,9 @@ class MoEBase {
     swiglu_fusion_ = static_cast<int>(op_kernel_info.GetAttrOrDefault<int64_t>("swiglu_fusion", 0));
     ORT_ENFORCE(swiglu_fusion_ >= 0 && swiglu_fusion_ <= 2,
                 "swiglu_fusion must be 0, 1, or 2, but got ", swiglu_fusion_);
-    ORT_ENFORCE(activation_type_ == ActivationType::Swiglu || swiglu_fusion_ == 0,
-                "swiglu_fusion is only valid when activation_type is 'swiglu'.");
+    ORT_ENFORCE(activation_type_ == ActivationType::Swiglu || activation_type_ == ActivationType::Geglu ||
+                    swiglu_fusion_ == 0,
+                "swiglu_fusion is only valid when activation_type is 'swiglu' or 'geglu'.");
 
     // SwiGLU limit for clamping (optional, use infinity if not provided)
     swiglu_limit_ = op_kernel_info.GetAttrOrDefault<float>("swiglu_limit", std::numeric_limits<float>::infinity());

--- a/onnxruntime/contrib_ops/cuda/moe/moe_quantization.cc
+++ b/onnxruntime/contrib_ops/cuda/moe/moe_quantization.cc
@@ -211,8 +211,8 @@ QMoE::QMoE(const OpKernelInfo& op_kernel_info) : CudaKernel(op_kernel_info), MoE
               row_tile_size_source, " must be 0 (disabled) or an integer in [1, ",
               std::numeric_limits<int>::max(), "], got ", row_tile_size_, ".");
   ORT_ENFORCE(op_kernel_info.GetAttr<int64_t>("expert_weight_bits", &expert_weight_bits_).IsOK());
-  ORT_ENFORCE(expert_weight_bits_ == 8 || expert_weight_bits_ == 4,
-              "expert_weight_bits must be 4 or 8, but got ", expert_weight_bits_);
+  ORT_ENFORCE(expert_weight_bits_ == 8 || expert_weight_bits_ == 4 || expert_weight_bits_ == 2,
+              "expert_weight_bits must be 2, 4, or 8, but got ", expert_weight_bits_);
 
   block_size_ = op_kernel_info.GetAttrOrDefault<int64_t>("block_size", -1);
   this->quant_type_ = op_kernel_info.GetAttrOrDefault<std::string>("quant_type", "int");
@@ -255,6 +255,13 @@ QMoE::QMoE(const OpKernelInfo& op_kernel_info) : CudaKernel(op_kernel_info), MoE
   ORT_ENFORCE(weights_prepacked_mode == -1 || weights_prepacked_mode == 0 || weights_prepacked_mode == 1,
               "weights_prepacked must be -1 (default), 0, or 1, but got ", weights_prepacked_mode);
   weights_prepacked_ = (weights_prepacked_mode != 0);
+  // 2-bit int weights have no offline CUTLASS-prepack tool (cuda_quantizer emits raw [E, N, K/4]
+  // storage), so the fused int2 path always runs PrePackIntExpertWeights to lay them out. Force the
+  // prepack (weights_prepacked=false) regardless of the attribute; the raw layout is the only int2
+  // input format we accept.
+  if (quant_type_ == "int" && expert_weight_bits_ == 2) {
+    weights_prepacked_ = false;
+  }
 #if !defined(ENABLE_FP4) || !defined(USE_FP4_QMOE)
   ORT_ENFORCE(quant_type_ != "fp4", "QMoE quant_type='fp4' requires USE_FP4_QMOE with CUDA 12.8 or newer.");
   ORT_ENFORCE(quant_type_ != "nvfp4", "QMoE quant_type='nvfp4' requires USE_FP4_QMOE with CUDA 12.8 or newer.");
@@ -511,9 +518,14 @@ QMoE::QMoE(const OpKernelInfo& op_kernel_info) : CudaKernel(op_kernel_info), MoE
       }
     }
   } else {
-    // Integer quantization (INT4/INT8)
+    // Integer quantization (INT2/INT4/INT8): a fused mixed-input grouped GEMM per weight width.
+    // uint2b_t / uint4b_t / uint8_t select the packed weight operand; the SM80 DqMma pipeline
+    // dequantizes in-register via FastInterleavedAndBiasedNumericArrayConverter.
     if (is_fp16) {
-      if (expert_weight_bits_ == 4) {
+      if (expert_weight_bits_ == 2) {
+        m_moe_runner = std::make_unique<CutlassMoeFCRunner<half, cutlass::uint2b_t, half>>(
+            sm_, activation_type_, normalize_routing_weights_, use_sparse_mixer_);
+      } else if (expert_weight_bits_ == 4) {
         m_moe_runner = std::make_unique<CutlassMoeFCRunner<half, cutlass::uint4b_t, half>>(
             sm_, activation_type_, normalize_routing_weights_, use_sparse_mixer_);
       } else {  // expert_weight_bits_ == 8
@@ -523,7 +535,10 @@ QMoE::QMoE(const OpKernelInfo& op_kernel_info) : CudaKernel(op_kernel_info), MoE
     }
 #if !defined(ORT_QUICK_BUILD) && defined(ENABLE_BF16)
     else {  // BFloat16
-      if (expert_weight_bits_ == 4) {
+      if (expert_weight_bits_ == 2) {
+        m_moe_runner = std::make_unique<CutlassMoeFCRunner<__nv_bfloat16, cutlass::uint2b_t, __nv_bfloat16>>(
+            sm_, activation_type_, normalize_routing_weights_, use_sparse_mixer_);
+      } else if (expert_weight_bits_ == 4) {
         m_moe_runner = std::make_unique<CutlassMoeFCRunner<__nv_bfloat16, cutlass::uint4b_t, __nv_bfloat16>>(
             sm_, activation_type_, normalize_routing_weights_, use_sparse_mixer_);
       } else {  // expert_weight_bits_ == 8
@@ -608,9 +623,15 @@ Status QMoE::ComputeInternal(OpKernelContext* context) const {
   // falls back to the default of 0 ("not fused"). QMoE never has a separate FC3 (enforced above), so a
   // SwiGLU activation with swiglu_fusion == 0 means the gate and value projections are actually pre-fused
   // into FC1 (interleaved layout). Treat this as swiglu_fusion == 1 so those legacy models keep working.
+  // GeGLU is gated exactly like SwiGLU (interleaved gate|up fc1, doubled fc1 output); it differs only
+  // in the gate nonlinearity, which is handled downstream by the activation kernel. All the gated
+  // layout/shape/fusion machinery below is shared between the two.
+  const bool is_gated_activation =
+      activation_type_ == onnxruntime::llm::kernels::cutlass_kernels::ActivationType::Swiglu ||
+      activation_type_ == onnxruntime::llm::kernels::cutlass_kernels::ActivationType::Geglu;
+
   int swiglu_fusion = swiglu_fusion_;
-  if (activation_type_ == onnxruntime::llm::kernels::cutlass_kernels::ActivationType::Swiglu &&
-      swiglu_fusion == 0) {
+  if (is_gated_activation && swiglu_fusion == 0) {
     swiglu_fusion = 1;
     LogQMoESwigluFusionRemapOnce();
   }
@@ -665,8 +686,8 @@ Status QMoE::ComputeInternal(OpKernelContext* context) const {
                            "Use block_size >= 32 or remove fc*_zero_points.");
   }
 
-  int64_t pack_size = expert_weight_bits_ == 4 ? 2 : 1;
-  bool is_fused_swiglu = activation_type_ == onnxruntime::llm::kernels::cutlass_kernels::ActivationType::Swiglu;
+  int64_t pack_size = 8 / expert_weight_bits_;
+  bool is_fused_swiglu = is_gated_activation;
   MoEParameters moe_params;
   // Prefer the cached shapes when PrePack consumed the source initializer.
   const TensorShape& fc1_shape = weights_consumed_by_prepack ? fc1_weights_shape_ : fc1_experts_weights->Shape();
@@ -975,8 +996,10 @@ Status QMoE::ComputeInternal(OpKernelContext* context) const {
       } else if (is_fp8) {
         wtype = use_fp8_dequant_fallback_ ? dtype : onnxruntime::llm::nvinfer::DataType::kFP8;
       } else {
-        wtype = (expert_weight_bits_ == 4) ? onnxruntime::llm::nvinfer::DataType::kINT4
-                                           : onnxruntime::llm::nvinfer::DataType::kINT8;
+        // INT2 and INT4 both run the SM80 interleaved mixed-input grouped GEMM; there is no kINT2
+        // profiler tag, so 2-bit reuses kINT4 (same layout/workspace class). INT8 uses kINT8.
+        wtype = (expert_weight_bits_ == 8) ? onnxruntime::llm::nvinfer::DataType::kINT8
+                                           : onnxruntime::llm::nvinfer::DataType::kINT4;
       }
 
       using onnxruntime::llm::kernels::cutlass_kernels::MoeGemmId;
@@ -2238,8 +2261,8 @@ void QMoE::PrePackCopyToGpu(const Tensor& tensor, cudaStream_t stream, Allocator
 // kernel-expected ``[E, K, N/(8/bits)]`` layout.
 void QMoE::PrePackIntExpertWeights(const Tensor& tensor, cudaStream_t stream, AllocatorPtr alloc,
                                    IAllocatorUniquePtr<void>& packed_buf, bool& is_packed) {
-  ORT_ENFORCE(expert_weight_bits_ == 4 || expert_weight_bits_ == 8,
-              "PrePackIntExpertWeights: only 4 and 8 bits are supported, got ", expert_weight_bits_);
+  ORT_ENFORCE(expert_weight_bits_ == 2 || expert_weight_bits_ == 4 || expert_weight_bits_ == 8,
+              "PrePackIntExpertWeights: only 2, 4 and 8 bits are supported, got ", expert_weight_bits_);
   ORT_ENFORCE(sm_ >= 75,
               "PrePackIntExpertWeights: quant_type='int' with weights_prepacked=0 requires SM75+ CUDA hardware, got SM",
               sm_);
@@ -2290,19 +2313,26 @@ void QMoE::PrePackIntExpertWeights(const Tensor& tensor, cudaStream_t stream, Al
     src_base_gpu = reinterpret_cast<const uint8_t*>(tensor.DataRaw());
   }
 
-  IAllocatorUniquePtr<int32_t> permutation_map = this->GetTransientScratchBuffer<int32_t>(32);
+  // The LDSM row-permutation map has get_weight_quant_bits-dependent length: 16 (W8), 32 (W4),
+  // 64 (W2). preprocess_weights_for_mixed_gemm_cuda memcpy's the full map into this buffer, so it
+  // must hold the largest (W2 = 64) to avoid an out-of-bounds copy + OOB read in permute_rows_kernel.
+  IAllocatorUniquePtr<int32_t> permutation_map = this->GetTransientScratchBuffer<int32_t>(64);
 
   using onnxruntime::llm::kernels::weight_only::QuantType;
-  const QuantType quant_type = (bits == 4) ? QuantType::W4_A16 : QuantType::W8_A16;
+  const QuantType quant_type =
+      (bits == 2) ? QuantType::W2_A16 : ((bits == 4) ? QuantType::W4_A16 : QuantType::W8_A16);
 
   for (int64_t e = 0; e < num_experts; ++e) {
     const uint8_t* src_e = src_base_gpu + static_cast<size_t>(e) * per_expert_bytes;
     int8_t* dst_e = dst_all + static_cast<size_t>(e) * per_expert_bytes;
 
-    // Step 1: transpose + (for int4) unpack/zero-point bias into the
-    // transposed-int8 scratch buffer. Mirrors MatMulNBits's PrePack_B.
+    // Step 1: transpose + (for int4/int2) unpack/zero-point bias into the
+    // transposed sub-byte scratch buffer. Mirrors MatMulNBits's PrePack_B.
     if (bits == 4) {
       onnxruntime::llm::kernels::fpA_intB_gemv::unpack_uint4_transposed_to_int8_direct_cuda(
+          stream, transposed_scratch_ptr, src_e, static_cast<int>(n), static_cast<int>(k));
+    } else if (bits == 2) {
+      onnxruntime::llm::kernels::fpA_intB_gemv::unpack_uint2_transposed_to_int2_direct_cuda(
           stream, transposed_scratch_ptr, src_e, static_cast<int>(n), static_cast<int>(k));
     } else {
       onnxruntime::llm::kernels::fpA_intB_gemv::transpose_uint8_matrix_and_convert_to_int8(

--- a/onnxruntime/contrib_ops/cuda/moe/moe_quantization.cc
+++ b/onnxruntime/contrib_ops/cuda/moe/moe_quantization.cc
@@ -27,6 +27,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cmath>
 #include <cstring>
 #include <iostream>
 #include <limits>
@@ -261,6 +262,15 @@ QMoE::QMoE(const OpKernelInfo& op_kernel_info) : CudaKernel(op_kernel_info), MoE
   // input format we accept.
   if (quant_type_ == "int" && expert_weight_bits_ == 2) {
     weights_prepacked_ = false;
+  }
+
+  // Optional fractional zero-point center (unset -> NaN -> symmetric center 2^(bits-1)).
+  zero_point_offset_ = op_kernel_info.GetAttrOrDefault<float>(
+      "zero_point_offset", std::numeric_limits<float>::quiet_NaN());
+  if (!std::isnan(zero_point_offset_)) {
+    ORT_ENFORCE(quant_type_ == "int" && block_size_ > 0,
+                "zero_point_offset is only supported for integer block-wise quantization "
+                "(quant_type='int' with block_size > 0).");
   }
 #if !defined(ENABLE_FP4) || !defined(USE_FP4_QMOE)
   ORT_ENFORCE(quant_type_ != "fp4", "QMoE quant_type='fp4' requires USE_FP4_QMOE with CUDA 12.8 or newer.");
@@ -1351,6 +1361,33 @@ Status QMoE::ComputeInternal(OpKernelContext* context) const {
           eff_zp = zeros->DataRaw();
         }
       }
+    } else if (!std::isnan(zero_point_offset_) && block_size_ > 0 && scales && eff_scale) {
+      // Fractional zero-point center, no uint8 zero-point tensor, and PrePack did NOT consume the
+      // scales (e.g. session.disable_prepacking) -- the packed_bias slot above was not populated, so
+      // build the constant bias here from the live scales. The normal path builds it at PrePack time
+      // (PrePackConstantBiasFromScales) and takes the ``packed_bias`` branch above. The weight
+      // converter already subtracts the symmetric center 2^(bits-1); this bias corrects it so the
+      // effective dequant is (code - zero_point_offset_) * scale. bias = (center - offset) * scale.
+      const float delta = static_cast<float>(1 << (expert_weight_bits_ - 1)) - zero_point_offset_;
+      size_t num_elements = scales->Shape().Size();
+      bool is_fp16 = scales->IsDataType<MLFloat16>();
+      bool is_bf16 = scales->IsDataType<BFloat16>();
+      size_t bytes = num_elements * (is_fp16 || is_bf16 ? 2 : 4);
+      transient_bias = GetScratchBuffer<void>(bytes, GetComputeStream(context));
+      eff_zp = transient_bias.get();
+      if (is_fp16) {
+        LaunchQMoEConstantBias(static_cast<const half*>(eff_scale),
+                               static_cast<half*>(transient_bias.get()),
+                               static_cast<int>(num_elements), delta, stream);
+      } else if (is_bf16) {
+        LaunchQMoEConstantBias(static_cast<const __nv_bfloat16*>(eff_scale),
+                               static_cast<__nv_bfloat16*>(transient_bias.get()),
+                               static_cast<int>(num_elements), delta, stream);
+      } else {
+        LaunchQMoEConstantBias(static_cast<const float*>(eff_scale),
+                               static_cast<float*>(transient_bias.get()),
+                               static_cast<int>(num_elements), delta, stream);
+      }
     }
   };
 
@@ -2112,6 +2149,7 @@ Status QMoE::PrePack(const Tensor& tensor, int input_idx, AllocatorPtr alloc,
     } else if (quant_type_ == "int") {
       PrePackTransposeAndPack(tensor, stream, alloc, packed_fc1_scales_, is_packed);
       DUMP_PACK_TENSOR("packed_fc1_scales", packed_fc1_scales_, tensor);
+      PrePackConstantBiasFromScales(tensor, stream, alloc, packed_fc1_scales_, packed_fc1_bias_);
     }
     if (quant_type_ == "fp4" || quant_type_ == "nvfp4" || quant_type_ == "wfp4afp8") {
       is_packed = false;
@@ -2155,6 +2193,7 @@ Status QMoE::PrePack(const Tensor& tensor, int input_idx, AllocatorPtr alloc,
     } else if (quant_type_ == "int") {
       PrePackTransposeAndPack(tensor, stream, alloc, packed_fc2_scales_, is_packed);
       DUMP_PACK_TENSOR("packed_fc2_scales", packed_fc2_scales_, tensor);
+      PrePackConstantBiasFromScales(tensor, stream, alloc, packed_fc2_scales_, packed_fc2_bias_);
     }
     if (quant_type_ == "fp4" || quant_type_ == "nvfp4" || quant_type_ == "wfp4afp8") {
       is_packed = false;
@@ -2751,6 +2790,39 @@ void QMoE::PrePackComputeBias(const Tensor& tensor, cudaStream_t stream, Allocat
   }
   CUDA_CALL_THROW(cudaStreamSynchronize(stream));
   is_packed = true;
+}
+
+void QMoE::PrePackConstantBiasFromScales(const Tensor& scales, cudaStream_t stream, AllocatorPtr alloc,
+                                         const IAllocatorUniquePtr<void>& packed_scale,
+                                         IAllocatorUniquePtr<void>& packed_bias) {
+  // Only when a fractional zero-point center was requested (finite) and block-wise integer quant is
+  // in use. The packed scale is already on GPU in the runner's expected layout; the bias has the
+  // same element count/dtype and is bias = (2^(bits-1) - zero_point_offset_) * scale, so the fused
+  // dequant (code - 2^(bits-1)) * scale + bias == (code - zero_point_offset_) * scale.
+  if (std::isnan(zero_point_offset_) || block_size_ <= 0 || !packed_scale) {
+    return;
+  }
+  const float delta = static_cast<float>(1 << (expert_weight_bits_ - 1)) - zero_point_offset_;
+  size_t num_elements = scales.Shape().Size();
+  // QMoE inputs are FP16/BF16 (is_fp16_ set in ctor); scales may also arrive as float32.
+  bool is_fp16 = scales.IsDataType<MLFloat16>();
+  bool is_bf16 = scales.IsDataType<BFloat16>();
+  size_t bytes = num_elements * (is_fp16 || is_bf16 ? 2 : 4);
+  packed_bias = IAllocator::MakeUniquePtr<void>(alloc, bytes, true);
+  if (is_fp16) {
+    LaunchQMoEConstantBias(static_cast<const half*>(packed_scale.get()),
+                           static_cast<half*>(packed_bias.get()),
+                           static_cast<int>(num_elements), delta, stream);
+  } else if (is_bf16) {
+    LaunchQMoEConstantBias(static_cast<const __nv_bfloat16*>(packed_scale.get()),
+                           static_cast<__nv_bfloat16*>(packed_bias.get()),
+                           static_cast<int>(num_elements), delta, stream);
+  } else {
+    LaunchQMoEConstantBias(static_cast<const float*>(packed_scale.get()),
+                           static_cast<float*>(packed_bias.get()),
+                           static_cast<int>(num_elements), delta, stream);
+  }
+  CUDA_CALL_THROW(cudaStreamSynchronize(stream));
 }
 
 }  // namespace cuda

--- a/onnxruntime/contrib_ops/cuda/moe/moe_quantization.cc
+++ b/onnxruntime/contrib_ops/cuda/moe/moe_quantization.cc
@@ -683,6 +683,20 @@ Status QMoE::ComputeInternal(OpKernelContext* context) const {
   const bool has_any_zero_point = (fc1_zeros != nullptr || fc2_zeros != nullptr ||
                                    packed_fc1_bias_ != nullptr || packed_fc2_bias_ != nullptr);
 
+  // Packed per-group int2 zero_points are not supported (see PrePackComputeBias). The conversion
+  // kernels only understand the 8-bit and packed-int4 zero-point layouts, so an int2 zeros tensor
+  // (four 2-bit values per byte) would be misinterpreted here, yielding an undersized bias buffer
+  // and corrupt output. The int2 path only supports the fractional ``zero_point_offset`` attribute.
+  // Test the raw zeros inputs (not packed_fc*_bias_, which the legitimate int2 zero_point_offset
+  // path populates via PrePackConstantBiasFromScales). This guards the disable_prepacking path
+  // where PrePackComputeBias -- which also rejects int2 zeros -- never ran.
+  if (expert_weight_bits_ == 2 && (fc1_zeros != nullptr || fc2_zeros != nullptr)) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                           "QMoE with expert_weight_bits=2 does not support fc*_zero_points inputs. "
+                           "Use the 'zero_point_offset' attribute for fractional/asymmetric int2 "
+                           "zero-points instead.");
+  }
+
   // Row-wise quantization path does not support asymmetric zero-points in QMoE.
   // QuantParams::Int only carries scales (no zero/bias tensor).
   if (block_size_ <= 0 && has_any_zero_point) {
@@ -2678,6 +2692,14 @@ void QMoE::TryBuildGemvFp4Scales(int fc, cudaStream_t stream, AllocatorPtr alloc
 void QMoE::PrePackComputeBias(const Tensor& tensor, cudaStream_t stream, AllocatorPtr alloc,
                               const IAllocatorUniquePtr<void>& packed_scale,
                               IAllocatorUniquePtr<void>& packed_bias, bool& is_packed) {
+  // Packed per-group int2 zero_points are not supported. The int2 fused path only supports the
+  // fractional ``zero_point_offset`` attribute, not packed uint8 fc*_zero_points (whose int2 layout
+  // packs four 2-bit values per byte). The conversion kernels below only understand the 8-bit and
+  // packed-int4 (LaunchQMoEScaledZP4BitBatched) layouts, so an int2 zeros tensor would be
+  // misinterpreted, producing an undersized/mis-strided bias buffer and corrupt output. Reject it.
+  ORT_ENFORCE(expert_weight_bits_ != 2,
+              "QMoE with expert_weight_bits=2 does not support fc*_zero_points inputs. Use the "
+              "'zero_point_offset' attribute for fractional/asymmetric int2 zero-points instead.");
   if ((expert_weight_bits_ == 4) && !packed_scale) {
     return;
   }

--- a/onnxruntime/contrib_ops/cuda/moe/moe_quantization.h
+++ b/onnxruntime/contrib_ops/cuda/moe/moe_quantization.h
@@ -38,6 +38,13 @@ class QMoE final : public CudaKernel, public MoEBase {
   void PrePackComputeBias(const Tensor& tensor, cudaStream_t stream, AllocatorPtr alloc,
                           const IAllocatorUniquePtr<void>& packed_scale,
                           IAllocatorUniquePtr<void>& packed_bias, bool& is_packed);
+  // Builds a constant fractional zero-point bias (bias = (2^(bits-1) - zero_point_offset_) * scale)
+  // from the already-packed scales, when a finite ``zero_point_offset_`` was requested and no uint8
+  // zero-point tensor is supplied. Runs at PrePack time because the scales initializer is consumed
+  // there; ComputeInternal then consumes ``packed_bias`` via the same slot int4-asymmetric uses.
+  void PrePackConstantBiasFromScales(const Tensor& scales, cudaStream_t stream, AllocatorPtr alloc,
+                                     const IAllocatorUniquePtr<void>& packed_scale,
+                                     IAllocatorUniquePtr<void>& packed_bias);
   void PrePackCopyToGpu(const Tensor& tensor, cudaStream_t stream, AllocatorPtr alloc,
                         IAllocatorUniquePtr<void>& packed_buf, bool& is_packed);
   void PrePackSwizzleBlockScales(const Tensor& tensor, cudaStream_t stream, AllocatorPtr alloc,
@@ -67,6 +74,12 @@ class QMoE final : public CudaKernel, public MoEBase {
                                IAllocatorUniquePtr<void>& packed_buf, bool& is_packed);
   int64_t expert_weight_bits_;
   bool is_fp16_;
+  // Optional fractional zero-point center for integer block-wise quantization when no uint8
+  // fc*_zero_points tensor is provided. NaN means "unset" -> symmetric center 2^(bits-1).
+  // A finite value selects dequant = (code - zero_point_offset_) * scale via a constant bias
+  // buffer (bias = (2^(bits-1) - zero_point_offset_) * scale). Motivating case: a 2-bit
+  // checkpoint quantized around the balanced midpoint 1.5, which uint8 cannot represent.
+  float zero_point_offset_;
   // When true, the int4/int8 fc1/fc2 weight initializers are already in a
   // CUTLASS fpA_intB layout — produced offline e.g. via
   // ``pack_weights_for_cuda_mixed_gemm`` — and the compute path reads them

--- a/onnxruntime/contrib_ops/cuda/moe/qmoe_kernels.cu
+++ b/onnxruntime/contrib_ops/cuda/moe/qmoe_kernels.cu
@@ -638,6 +638,52 @@ void LaunchQMoEPrePackOffsetBias(
   QMoEPrePackZPKernel<__nv_bfloat16><<<grid, block, 0, stream>>>(zp, scales, output, num_elements, offset);
 }
 
+// Constant zero-point bias: bias = delta * scale, with delta = center - offset a single
+// per-tensor scalar. Used for integer schemes whose zero-point is a fractional constant not
+// representable by a uint8 zp tensor (e.g. int2 balanced center 1.5). The in-register weight
+// converter already subtracts the symmetric center 2^(bits-1); this bias corrects it to the
+// requested fractional center so dequant = (code - offset) * scale.
+template <typename T>
+__global__ void QMoEConstantBiasKernel(const T* scales, T* out, int num_elements, float delta) {
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx < num_elements) {
+    out[idx] = static_cast<T>(delta * static_cast<float>(scales[idx]));
+  }
+}
+
+void LaunchQMoEConstantBias(
+    const float* scales,
+    float* output,
+    int num_elements,
+    float delta,
+    cudaStream_t stream) {
+  int block = 256;
+  int grid = Compute1DGridSize(num_elements, block);
+  QMoEConstantBiasKernel<float><<<grid, block, 0, stream>>>(scales, output, num_elements, delta);
+}
+
+void LaunchQMoEConstantBias(
+    const half* scales,
+    half* output,
+    int num_elements,
+    float delta,
+    cudaStream_t stream) {
+  int block = 256;
+  int grid = Compute1DGridSize(num_elements, block);
+  QMoEConstantBiasKernel<half><<<grid, block, 0, stream>>>(scales, output, num_elements, delta);
+}
+
+void LaunchQMoEConstantBias(
+    const __nv_bfloat16* scales,
+    __nv_bfloat16* output,
+    int num_elements,
+    float delta,
+    cudaStream_t stream) {
+  int block = 256;
+  int grid = Compute1DGridSize(num_elements, block);
+  QMoEConstantBiasKernel<__nv_bfloat16><<<grid, block, 0, stream>>>(scales, output, num_elements, delta);
+}
+
 // Batched 4-bit packed ZP scaled bias kernel.
 // Grid: (ceil(n/16), ceil(k_blocks/16), experts)
 // Each thread computes one output element: output[e][out_row][out_col]

--- a/onnxruntime/contrib_ops/cuda/moe/qmoe_kernels.h
+++ b/onnxruntime/contrib_ops/cuda/moe/qmoe_kernels.h
@@ -138,6 +138,29 @@ void LaunchQMoEPrePackOffsetBias(
     float offset,
     cudaStream_t stream);
 
+// Constant fractional zero-point bias: output = delta * scale (delta = center - offset).
+// See qmoe_kernels.cu for the rationale (int2 balanced fractional center, e.g. 1.5).
+void LaunchQMoEConstantBias(
+    const float* scales,
+    float* output,
+    int num_elements,
+    float delta,
+    cudaStream_t stream);
+
+void LaunchQMoEConstantBias(
+    const half* scales,
+    half* output,
+    int num_elements,
+    float delta,
+    cudaStream_t stream);
+
+void LaunchQMoEConstantBias(
+    const __nv_bfloat16* scales,
+    __nv_bfloat16* output,
+    int num_elements,
+    float delta,
+    cudaStream_t stream);
+
 // Batched 4-bit packed zero-point scaled bias computation.
 // ZP layout: [experts, n, packed_k_blocks] (packed_k_blocks = (k_blocks+1)/2)
 // Scale/Output layout: [experts, k_blocks, n]

--- a/onnxruntime/contrib_ops/webgpu/moe/qmoe.h
+++ b/onnxruntime/contrib_ops/webgpu/moe/qmoe.h
@@ -3,6 +3,9 @@
 
 #pragma once
 
+#include <cmath>
+#include <limits>
+
 #include "core/providers/webgpu/program.h"
 #include "core/providers/webgpu/webgpu_kernel.h"
 #include "contrib_ops/webgpu/moe/moe_base.h"
@@ -23,6 +26,14 @@ class QMoE final : public MoE {
     ORT_ENFORCE(expert_weight_bits_ == 8 || expert_weight_bits_ == 4,
                 "expert_weight_bits must be 4 or 8, but got ", expert_weight_bits_);
     block_size_ = static_cast<int>(info.GetAttrOrDefault<int64_t>("block_size", 0));
+    // ``zero_point_offset`` (fractional zero-point center) is a CUDA-only feature. Reject it here so
+    // a model authored for CUDA is not silently evaluated with the default integer center on WebGPU,
+    // which would violate the documented dequant formula (code - zero_point_offset) * scale.
+    const float zero_point_offset =
+        info.GetAttrOrDefault<float>("zero_point_offset", std::numeric_limits<float>::quiet_NaN());
+    ORT_ENFORCE(std::isnan(zero_point_offset),
+                "WebGPU QMoE does not support the 'zero_point_offset' attribute; it is only "
+                "implemented by the CUDA execution provider.");
   }
 
   Status ComputeInternal(ComputeContext& context) const override;

--- a/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
@@ -1531,6 +1531,15 @@ ONNX_MS_OPERATOR_SET_SCHEMA(
               "un-prepacked [E, N, K/pack] tensors as produced by quantize_matmul_{4,8}bits. Defaults to -1.",
               AttributeProto::INT,
               static_cast<int64_t>(-1))
+        .Attr("zero_point_offset",
+              "Only meaningful when quant_type='int' and block_size > 0 and no integer "
+              "fc*_zero_points are provided. A single fractional zero-point applied uniformly to "
+              "every weight code: dequant = (code - zero_point_offset) * scale. Enables balanced "
+              "asymmetric schemes whose zero-point is not integer-representable (e.g. the 1.5 "
+              "midpoint of a 2-bit checkpoint, giving codes {0,1,2,3} -> {-1.5,-0.5,0.5,1.5}*scale). "
+              "When omitted, symmetric quantization centered on 2^(expert_weight_bits-1) is used.",
+              AttributeProto::FLOAT,
+              OPTIONAL_VALUE)
         .Input(0,
                "input",
                "2D tensor with shape (num_tokens, hidden_size), or "

--- a/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
@@ -1418,7 +1418,7 @@ ONNX_MS_OPERATOR_SET_SCHEMA(
     MoE, 1,
     OpSchema()
         .SetDoc(MoE_ver1_doc)
-        .Attr("activation_type", "Activation function to use. Choose from relu, gelu, silu, swiglu and identity. Default is relu", AttributeProto::STRING, std::string("relu"))
+        .Attr("activation_type", "Activation function to use. Choose from relu, gelu, silu, swiglu, geglu and identity. Default is relu", AttributeProto::STRING, std::string("relu"))
         .Attr("swiglu_fusion", "0: not fused, 1: fused and interleaved. 2: fused and not interleaved.", AttributeProto::INT, static_cast<int64_t>(0))
         .Attr("swiglu_limit", "The limit used to clamp in SwiGLU. No clamp when limit is not provided.", AttributeProto::FLOAT, OPTIONAL_VALUE)
         .Attr("activation_alpha", "Alpha parameter used in activation function.", AttributeProto::FLOAT, 1.0f)

--- a/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
@@ -1471,7 +1471,9 @@ ONNX_MS_OPERATOR_SET_SCHEMA(
     OpSchema()
         .SetDoc(qMoE_ver1_doc)
         .Attr("activation_type",
-              "Activation function to use. Choose from relu, gelu, silu, swiglu and identity. Default is relu",
+              "Activation function to use. Choose from relu, gelu, silu, swiglu, geglu and identity. "
+              "geglu is the GELU-gated linear unit (a gated activation like swiglu but using gelu as "
+              "the gate). Default is relu",
               AttributeProto::STRING,
               std::string("relu"))
         .Attr("k",
@@ -1532,9 +1534,10 @@ ONNX_MS_OPERATOR_SET_SCHEMA(
               AttributeProto::INT,
               static_cast<int64_t>(-1))
         .Attr("zero_point_offset",
-              "Only meaningful when quant_type='int' and block_size > 0 and no integer "
-              "fc*_zero_points are provided. A single fractional zero-point applied uniformly to "
-              "every weight code: dequant = (code - zero_point_offset) * scale. Enables balanced "
+              "CUDA execution provider only; other execution providers (CPU, WebGPU) reject a "
+              "non-default value. Only meaningful when quant_type='int' and block_size > 0 and no "
+              "integer fc*_zero_points are provided. A single fractional zero-point applied uniformly "
+              "to every weight code: dequant = (code - zero_point_offset) * scale. Enables balanced "
               "asymmetric schemes whose zero-point is not integer-representable (e.g. the 1.5 "
               "midpoint of a 2-bit checkpoint, giving codes {0,1,2,3} -> {-1.5,-0.5,0.5,1.5}*scale). "
               "When omitted, symmetric quantization centered on 2^(expert_weight_bits-1) is used.",

--- a/onnxruntime/python/tools/quantization/cuda_quantizer.py
+++ b/onnxruntime/python/tools/quantization/cuda_quantizer.py
@@ -297,34 +297,35 @@ class CudaQuantizer:
 
         weights = weights.detach().cpu().to(torch.float32).contiguous()
         bits = int(bits)
-        if bits not in (4, 8):
-            raise ValueError(f"QMoE per-channel quantization only supports 4 or 8 bits, got {bits}.")
+        if bits not in (2, 4, 8):
+            raise ValueError(f"QMoE per-channel quantization only supports 2, 4, or 8 bits, got {bits}.")
 
         n, k = weights.shape
         pack = 8 // bits
         if k % pack != 0:
             raise ValueError(f"K ({k}) must be divisible by {pack} for QMoE per-channel quantization.")
 
-        if bits == 4:
-            if unsigned_full_range:
-                qmin, qmax, scale_divisor, zero_point = -8, 7, 8, 8
-            else:
-                qmin, qmax, scale_divisor, zero_point = -7, 7, 7, 8
-        else:  # bits == 8, already validated above
-            if unsigned_full_range:
-                qmin, qmax, scale_divisor, zero_point = -128, 127, 128, 128
-            else:
-                qmin, qmax, scale_divisor, zero_point = -127, 127, 127, 128
+        # Symmetric range centred on the offset-binary zero point 2^(bits-1) (2 / 8 / 128).
+        zero_point = 1 << (bits - 1)
+        if unsigned_full_range:
+            qmin, qmax, scale_divisor = -zero_point, zero_point - 1, zero_point
+        else:
+            qmin, qmax, scale_divisor = -(zero_point - 1), zero_point - 1, zero_point - 1
         scales = weights.abs().amax(dim=1, keepdim=True) / float(scale_divisor)
         scales = torch.clamp(scales, min=torch.finfo(torch.float32).eps)
         quantized = torch.clamp(torch.round(weights / scales), qmin, qmax).to(torch.int16).contiguous()
         quantized = (quantized + zero_point).to(torch.uint8)
 
-        if bits == 4:
-            qweight = (quantized[:, 0::2] & 0xF) | ((quantized[:, 1::2] & 0xF) << 4)
-            qweight = qweight.to(torch.uint8)
-        else:
+        if bits == 8:
             qweight = quantized
+        else:
+            # Little-endian packing: pack consecutive K values LSB-first into each byte. Matches the
+            # ORT QMoE storage contract (CPU DequantizeBlockWithMlas and the CUDA int2 dequant kernel).
+            value_mask = (1 << bits) - 1
+            qweight = torch.zeros((n, k // pack), dtype=torch.uint8)
+            for lane in range(pack):
+                qweight |= (quantized[:, lane::pack] & value_mask) << (lane * bits)
+            qweight = qweight.to(torch.uint8)
 
         return qweight.contiguous(), scales.squeeze(-1).contiguous()
 
@@ -353,6 +354,11 @@ class CudaQuantizer:
         if not prepack:
             return qweight, scales
 
+        if int(bits) == 2:
+            # No CUTLASS mixed-input GEMM exists for 2-bit; the CUDA QMoE kernel consumes the raw
+            # [N, K/4] storage via its dequant fallback, so prepacking is unsupported.
+            raise ValueError("QMoE 2-bit weights cannot be CUTLASS-prepacked; use prepack=False (raw storage).")
+
         n, k = weights.shape
         pack = 8 // int(bits)
         if n % pack != 0:
@@ -379,8 +385,12 @@ class CudaQuantizer:
         block_size = int(block_size)
         w = weights.detach().cpu().to(torch.float32).contiguous().numpy()
         n, k = w.shape
-        if bits not in (4, 8):
-            raise ValueError(f"Blockwise quantization only supports 4 or 8 bits, got {bits}.")
+        # 2-bit uses the pure-numpy symmetric path below (the MatMulNBits pybind kernels only cover
+        # 4 and 8 bits); asymmetric 2-bit is not supported.
+        if bits not in (2, 4, 8):
+            raise ValueError(f"Blockwise quantization only supports 2, 4, or 8 bits, got {bits}.")
+        if bits == 2 and not symmetric:
+            raise ValueError("2-bit blockwise quantization only supports symmetric mode.")
         if block_size <= 0:
             raise ValueError(f"Blockwise quantization requires a positive block_size, got {block_size}.")
 
@@ -389,12 +399,12 @@ class CudaQuantizer:
         blob_size = (block_size + pack - 1) // pack
 
         if symmetric:
-            if bits == 4:
-                qmin, qmax, scale_divisor, zero_point = (-8, 7, 8, 8) if unsigned_full_range else (-7, 7, 7, 8)
+            # Symmetric range centred on the offset-binary zero point 2^(bits-1) (2 / 8 / 128).
+            zero_point = 1 << (bits - 1)
+            if unsigned_full_range:
+                qmin, qmax, scale_divisor = -zero_point, zero_point - 1, zero_point
             else:
-                qmin, qmax, scale_divisor, zero_point = (
-                    (-128, 127, 128, 128) if unsigned_full_range else (-127, 127, 127, 128)
-                )
+                qmin, qmax, scale_divisor = -(zero_point - 1), zero_point - 1, zero_point - 1
 
             padded_k = num_blocks * block_size
             if padded_k != k:
@@ -406,14 +416,20 @@ class CudaQuantizer:
             quantized = np.clip(np.rint(blocked / scales[:, :, np.newaxis]), qmin, qmax).astype(np.int16)
             quantized = (quantized + zero_point).astype(np.uint8)
 
-            if bits == 4:
-                qweight = np.zeros((n, num_blocks, blob_size), dtype=np.uint8)
-                qweight[:, :, : quantized[:, :, 0::2].shape[2]] = quantized[:, :, 0::2] & 0xF
-                qweight[:, :, : quantized[:, :, 1::2].shape[2]] |= (quantized[:, :, 1::2] & 0xF) << 4
-            else:
+            if bits == 8:
                 qweight = quantized
+            else:
+                # Little-endian packing: pack consecutive K values LSB-first into each byte, matching
+                # the ORT QMoE storage contract used by the CPU/CUDA dequant paths.
+                value_mask = (1 << bits) - 1
+                qweight = np.zeros((n, num_blocks, blob_size), dtype=np.uint8)
+                for lane in range(pack):
+                    lane_vals = quantized[:, :, lane::pack] & value_mask
+                    qweight[:, :, : lane_vals.shape[2]] |= (lane_vals << (lane * bits)).astype(np.uint8)
 
-            zero_points = np.zeros((n, (num_blocks + 1) // 2 if bits == 4 else num_blocks), dtype=np.uint8)
+            # Symmetric quantization carries no explicit zero-points; the offset is baked into storage.
+            zp_blocks = (num_blocks + pack - 1) // pack
+            zero_points = np.zeros((n, zp_blocks), dtype=np.uint8)
             return torch.from_numpy(qweight), torch.from_numpy(scales), torch.from_numpy(zero_points)
 
         w_t = np.ascontiguousarray(w.T)
@@ -551,6 +567,10 @@ class CudaQuantizer:
         """
         bits = int(bits)
         block_size = int(block_size)
+        if bits == 2:
+            # No CUTLASS mixed-input GEMM exists for 2-bit; the CUDA QMoE kernel consumes the raw
+            # [N, K/4] storage via its dequant fallback, so prepacking is unsupported.
+            raise ValueError("QMoE 2-bit weights cannot be CUTLASS-prepacked; use the raw blockwise quantizer.")
         n, k = weights.shape
         pack = 8 // bits
         if k % block_size != 0:

--- a/onnxruntime/python/tools/quantization/cuda_quantizer.py
+++ b/onnxruntime/python/tools/quantization/cuda_quantizer.py
@@ -355,8 +355,9 @@ class CudaQuantizer:
             return qweight, scales
 
         if int(bits) == 2:
-            # No CUTLASS mixed-input GEMM exists for 2-bit; the CUDA QMoE kernel consumes the raw
-            # [N, K/4] storage via its dequant fallback, so prepacking is unsupported.
+            # This offline packer has no 2-bit CUTLASS layout implementation; the CUDA QMoE kernel
+            # consumes the raw [N, K/4] storage and performs the fused int2 mixed-input GEMM's layout
+            # transform in its own PrePack, so offline prepacking here is unsupported.
             raise ValueError("QMoE 2-bit weights cannot be CUTLASS-prepacked; use prepack=False (raw storage).")
 
         n, k = weights.shape
@@ -568,8 +569,9 @@ class CudaQuantizer:
         bits = int(bits)
         block_size = int(block_size)
         if bits == 2:
-            # No CUTLASS mixed-input GEMM exists for 2-bit; the CUDA QMoE kernel consumes the raw
-            # [N, K/4] storage via its dequant fallback, so prepacking is unsupported.
+            # This offline packer has no 2-bit CUTLASS layout implementation; the CUDA QMoE kernel
+            # consumes the raw [N, K/4] storage and performs the fused int2 mixed-input GEMM's layout
+            # transform in its own PrePack, so offline prepacking here is unsupported.
             raise ValueError("QMoE 2-bit weights cannot be CUTLASS-prepacked; use the raw blockwise quantizer.")
         n, k = weights.shape
         pack = 8 // bits

--- a/onnxruntime/test/python/transformers/test_qmoe_cuda.py
+++ b/onnxruntime/test/python/transformers/test_qmoe_cuda.py
@@ -307,6 +307,7 @@ def create_moe_onnx_graph(
     quant_bits=4,
     swiglu_fusion=0,
     block_size=0,
+    zero_point_offset=None,
 ):
     if not has_onnx:
         return None
@@ -398,6 +399,10 @@ def create_moe_onnx_graph(
     # Add block_size attribute for block-wise quantization
     if block_size > 0:
         nodes[0].attribute.extend([helper.make_attribute("block_size", block_size)])
+
+    # Optional fractional zero-point center (e.g. 1.5 for a balanced 2-bit checkpoint).
+    if zero_point_offset is not None:
+        nodes[0].attribute.extend([helper.make_attribute("zero_point_offset", float(zero_point_offset))])
 
     # Weights are store in column major order. Need pack 2 int4 values into uint8.
     # Use the actual tensor shapes instead of calculating them to avoid size mismatches
@@ -3225,7 +3230,7 @@ class TestQMoEGeGLU(unittest.TestCase):
 
     Validates the CUDA kernel computes down(gelu_tanh(gate) * up) with interleaved gate|up fc1,
     matching the HuggingFace Gemma4 reference (gelu_pytorch_tanh gate, no clamp, alpha=1, beta=0).
-    Covers 2-bit (dequant fallback), plus 4-bit and 8-bit for coverage of the fused path.
+    Covers the fused int2/int4/int8 GEMM path.
     """
 
     @staticmethod
@@ -3272,27 +3277,67 @@ class TestQMoEGeGLU(unittest.TestCase):
         # weights_prepacked=0 to have the op prepack the raw layout for the fused int4/int8 GEMM.
         node = helper.make_node(
             "QMoE",
-            ["input", "router_probs", "fc1_experts_weights", "fc1_scales", "",
-             "fc2_experts_weights", "fc2_scales", "", "", "", "", "", "", ""],
-            ["output"], "m", k=1, normalize_routing_weights=1, activation_type="geglu",
-            swiglu_fusion=1, expert_weight_bits=bits, block_size=block, weights_prepacked=0,
-            domain="com.microsoft")
+            [
+                "input",
+                "router_probs",
+                "fc1_experts_weights",
+                "fc1_scales",
+                "",
+                "fc2_experts_weights",
+                "fc2_scales",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+            ],
+            ["output"],
+            "m",
+            k=1,
+            normalize_routing_weights=1,
+            activation_type="geglu",
+            swiglu_fusion=1,
+            expert_weight_bits=bits,
+            block_size=block,
+            weights_prepacked=0,
+            domain="com.microsoft",
+        )
         graph = helper.make_graph(
-            [node], "g",
-            [helper.make_tensor_value_info("input", TensorProto.FLOAT16, [1, hidden]),
-             helper.make_tensor_value_info("router_probs", TensorProto.FLOAT16, [1, 1])],
+            [node],
+            "g",
+            [
+                helper.make_tensor_value_info("input", TensorProto.FLOAT16, [1, hidden]),
+                helper.make_tensor_value_info("router_probs", TensorProto.FLOAT16, [1, 1]),
+            ],
             [helper.make_tensor_value_info("output", TensorProto.FLOAT16, [1, hidden])],
-            [helper.make_tensor("fc1_experts_weights", TensorProto.UINT8, list(f1p.shape), f1p.tobytes(), raw=True),
-             helper.make_tensor("fc2_experts_weights", TensorProto.UINT8, list(f2p.shape), f2p.tobytes(), raw=True),
-             helper.make_tensor("fc1_scales", TensorProto.FLOAT16, [1, 2 * inter, hidden // block],
-                                s1.astype(numpy.float16).tobytes(), raw=True),
-             helper.make_tensor("fc2_scales", TensorProto.FLOAT16, [1, hidden, inter // block],
-                                s2.astype(numpy.float16).tobytes(), raw=True)])
-        model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17),
-                                                        helper.make_opsetid("com.microsoft", 1)])
+            [
+                helper.make_tensor("fc1_experts_weights", TensorProto.UINT8, list(f1p.shape), f1p.tobytes(), raw=True),
+                helper.make_tensor("fc2_experts_weights", TensorProto.UINT8, list(f2p.shape), f2p.tobytes(), raw=True),
+                helper.make_tensor(
+                    "fc1_scales",
+                    TensorProto.FLOAT16,
+                    [1, 2 * inter, hidden // block],
+                    s1.astype(numpy.float16).tobytes(),
+                    raw=True,
+                ),
+                helper.make_tensor(
+                    "fc2_scales",
+                    TensorProto.FLOAT16,
+                    [1, hidden, inter // block],
+                    s2.astype(numpy.float16).tobytes(),
+                    raw=True,
+                ),
+            ],
+        )
+        model = helper.make_model(
+            graph, opset_imports=[helper.make_opsetid("", 17), helper.make_opsetid("com.microsoft", 1)]
+        )
         sess = onnxruntime.InferenceSession(model.SerializeToString(), providers=["CUDAExecutionProvider"])
-        out = sess.run(None, {"input": inp.astype(numpy.float16),
-                              "router_probs": numpy.ones((1, 1), numpy.float16)})[0][0].astype(numpy.float32)
+        out = sess.run(None, {"input": inp.astype(numpy.float16), "router_probs": numpy.ones((1, 1), numpy.float16)})[
+            0
+        ][0].astype(numpy.float32)
         tol = {2: 0.35, 4: 0.1, 8: 0.1}[bits]
         max_diff = float(numpy.abs(out - ref).max())
         self.assertLess(max_diff, tol, f"GeGLU {bits}-bit max_diff {max_diff:.4f} exceeds {tol}")
@@ -3305,6 +3350,130 @@ class TestQMoEGeGLU(unittest.TestCase):
 
     def test_geglu_8bit(self):
         self._run_case(8)
+
+
+@unittest.skipIf(not torch.cuda.is_available(), "skipping QMoE fractional-zp test since it requires CUDA.")
+class TestQMoEFractionalZeroPoint(unittest.TestCase):
+    """2-bit QMoE with a fractional zero-point center that uint8 zero_points cannot represent.
+
+    A balanced 2-bit checkpoint quantizes around the midpoint 1.5, so codes {0,1,2,3} dequantize
+    to {-1.5,-0.5,0.5,1.5}*scale. The fused int2 GEMM's weight converter bakes the symmetric
+    center 2; the ``zero_point_offset`` attribute adds a constant bias = (2 - 1.5)*scale so the
+    effective dequant is (code - 1.5)*scale, matching the checkpoint. No uint8 zero_points tensor
+    is provided (it could not carry 1.5).
+    """
+
+    @staticmethod
+    def _silu(x):
+        return x / (1.0 + numpy.exp(-x))
+
+    def _run_case(self, offset=1.5, hidden=256, inter=256, block=64):
+        if "CUDAExecutionProvider" not in onnxruntime.get_available_providers():
+            self.skipTest("CUDA EP not available")
+        bits = 2
+        pack = 8 // bits
+        vmax = (1 << bits) - 1  # 3
+        rng = numpy.random.default_rng(0)
+
+        def pack_w(codes):  # [rows, K] uint8 codes -> [rows, K/pack] little-endian
+            r, k = codes.shape
+            o = numpy.zeros((r, k // pack), numpy.uint8)
+            for lane in range(pack):
+                o |= (codes[:, lane::pack] & vmax) << (lane * bits)
+            return o
+
+        def quant_blockwise(w):
+            # Asymmetric balanced quant around ``offset``: q = round(w/scale) + offset, clamped to
+            # [0, vmax]; dequant = (q - offset) * scale. scale sized so +/- range reaches the ends.
+            n, k = w.shape
+            nb = k // block
+            blk = w.reshape(n, nb, block)
+            pos = max(vmax - offset, offset)  # symmetric headroom around the fractional center
+            smax = numpy.maximum(numpy.abs(blk).max(2) / float(pos), 1e-8).astype(numpy.float32)
+            q = numpy.clip(numpy.rint(blk / smax[:, :, None] + offset), 0, vmax).astype(numpy.uint8)
+            deq = (q.astype(numpy.float32) - offset) * smax[:, :, None]
+            return q.reshape(n, k), smax, deq.reshape(n, k)
+
+        # Non-gated SiLU MLP: fc1 [inter, hidden] then fc2 [hidden, inter].
+        w1 = (rng.standard_normal((inter, hidden)) * 0.1).astype(numpy.float32)
+        w2 = (rng.standard_normal((hidden, inter)) * 0.1).astype(numpy.float32)
+        c1, s1, dq1 = quant_blockwise(w1)
+        c2, s2, dq2 = quant_blockwise(w2)
+        inp = (rng.standard_normal((1, hidden)) * 0.5).astype(numpy.float32)
+
+        h = inp @ dq1.T
+        act = self._silu(h)
+        ref = (act @ dq2.T)[0]
+
+        f1p = pack_w(c1)[None]
+        f2p = pack_w(c2)[None]
+        node = helper.make_node(
+            "QMoE",
+            [
+                "input",
+                "router_probs",
+                "fc1_experts_weights",
+                "fc1_scales",
+                "",
+                "fc2_experts_weights",
+                "fc2_scales",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+            ],
+            ["output"],
+            "m",
+            k=1,
+            normalize_routing_weights=1,
+            activation_type="silu",
+            expert_weight_bits=bits,
+            block_size=block,
+            zero_point_offset=float(offset),
+            domain="com.microsoft",
+        )
+        graph = helper.make_graph(
+            [node],
+            "g",
+            [
+                helper.make_tensor_value_info("input", TensorProto.FLOAT16, [1, hidden]),
+                helper.make_tensor_value_info("router_probs", TensorProto.FLOAT16, [1, 1]),
+            ],
+            [helper.make_tensor_value_info("output", TensorProto.FLOAT16, [1, hidden])],
+            [
+                helper.make_tensor("fc1_experts_weights", TensorProto.UINT8, list(f1p.shape), f1p.tobytes(), raw=True),
+                helper.make_tensor("fc2_experts_weights", TensorProto.UINT8, list(f2p.shape), f2p.tobytes(), raw=True),
+                helper.make_tensor(
+                    "fc1_scales",
+                    TensorProto.FLOAT16,
+                    [1, inter, hidden // block],
+                    s1.astype(numpy.float16).tobytes(),
+                    raw=True,
+                ),
+                helper.make_tensor(
+                    "fc2_scales",
+                    TensorProto.FLOAT16,
+                    [1, hidden, inter // block],
+                    s2.astype(numpy.float16).tobytes(),
+                    raw=True,
+                ),
+            ],
+        )
+        model = helper.make_model(
+            graph, opset_imports=[helper.make_opsetid("", 17), helper.make_opsetid("com.microsoft", 1)]
+        )
+        sess = onnxruntime.InferenceSession(model.SerializeToString(), providers=["CUDAExecutionProvider"])
+        out = sess.run(None, {"input": inp.astype(numpy.float16), "router_probs": numpy.ones((1, 1), numpy.float16)})[
+            0
+        ][0].astype(numpy.float32)
+        max_diff = float(numpy.abs(out - ref).max())
+        self.assertLess(max_diff, 0.35, f"fractional-zp 2-bit max_diff {max_diff:.4f} exceeds 0.35")
+
+    def test_fractional_zp_1p5(self):
+        self._run_case(1.5)
 
 
 if __name__ == "__main__":

--- a/onnxruntime/test/python/transformers/test_qmoe_cuda.py
+++ b/onnxruntime/test/python/transformers/test_qmoe_cuda.py
@@ -160,11 +160,19 @@ def print_diff_statistics(diff_tensor: torch.Tensor, prefix: str = ""):
     )
 
 
-def quant_dequant_blockwise(weights, block_size, is_4_bit_quantization: bool = True, asymmetric: bool = False):
-    bits = 4 if is_4_bit_quantization else 8
+def _resolve_quant_bits(bits_or_flag) -> int:
+    """Accept either an int bit-width (2/4/8) or the legacy is_4_bit boolean."""
+    if isinstance(bits_or_flag, bool):
+        return 4 if bits_or_flag else 8
+    return int(bits_or_flag)
+
+
+def quant_dequant_blockwise(weights, block_size, is_4_bit_quantization=True, asymmetric: bool = False):
+    bits = _resolve_quant_bits(is_4_bit_quantization)
     n, k = weights.shape
     block_per_k = (k + block_size - 1) // block_size
     is_symmetric = not asymmetric
+    pack = 8 // bits
 
     q_weight, scale, zero_point = CudaQuantizer.matmulnbits_blockwise_quantize(
         weights,
@@ -175,38 +183,44 @@ def quant_dequant_blockwise(weights, block_size, is_4_bit_quantization: bool = T
         abs_scales=is_symmetric,
         flatten_qweight=False,
     )
-    processed_q_weight, _ = CudaQuantizer.qmoe_prepacked_blockwise_quantize(
-        weights,
-        bits,
-        block_size,
-        symmetric=is_symmetric,
-        abs_scales=is_symmetric,
-    )
+    if bits == 2:
+        # 2-bit has no CUTLASS mixed-input GEMM; the CUDA QMoE kernel consumes raw [N, K/4] storage
+        # via its dequant fallback, so feed the flattened raw quantized weights (no prepack).
+        processed_q_weight = q_weight.reshape(n, -1).contiguous()
+    else:
+        processed_q_weight, _ = CudaQuantizer.qmoe_prepacked_blockwise_quantize(
+            weights,
+            bits,
+            block_size,
+            symmetric=is_symmetric,
+            abs_scales=is_symmetric,
+        )
 
     scale_torch = scale.to(weights.device).unsqueeze(-1)
     q_weight_torch = q_weight.to(weights.device)
 
-    if is_4_bit_quantization:
-        q_low = q_weight_torch & 0x0F
-        q_high = (q_weight_torch >> 4) & 0x0F
-        q_unpacked = torch.stack((q_low, q_high), dim=-1).view(n, block_per_k, -1)[:, :, :block_size]
-        q_unpacked = q_unpacked.to(weights.dtype)
-        if is_symmetric:
-            dequantized = (q_unpacked - 8.0) * scale_torch
-        else:
-            zp_torch = zero_point.to(weights.device)
-            zp_low = zp_torch & 0x0F
-            zp_high = (zp_torch >> 4) & 0x0F
-            zp_unpacked = torch.stack((zp_low, zp_high), dim=-1).flatten(1, 2)[:, :block_per_k]
-            zp_unpacked = zp_unpacked.contiguous().view(n, block_per_k, 1).to(weights.dtype)
-            dequantized = (q_unpacked - zp_unpacked) * scale_torch
-    else:
+    if bits == 8:
         q_unpacked = q_weight_torch.to(weights.dtype)
         if is_symmetric:
             dequantized = (q_unpacked - 128.0) * scale_torch
         else:
             zp_torch = zero_point.to(weights.device).to(weights.dtype).unsqueeze(-1)
             dequantized = (q_unpacked - zp_torch) * scale_torch
+    else:
+        # Little-endian sub-byte storage: pack values are laid out LSB-first within each byte.
+        value_mask = (1 << bits) - 1
+        default_zp = float(1 << (bits - 1))
+        lanes = [(q_weight_torch >> (lane * bits)) & value_mask for lane in range(pack)]
+        q_unpacked = torch.stack(lanes, dim=-1).view(n, block_per_k, -1)[:, :, :block_size]
+        q_unpacked = q_unpacked.to(weights.dtype)
+        if is_symmetric:
+            dequantized = (q_unpacked - default_zp) * scale_torch
+        else:
+            zp_torch = zero_point.to(weights.device)
+            zp_lanes = [(zp_torch >> (lane * bits)) & value_mask for lane in range(pack)]
+            zp_unpacked = torch.stack(zp_lanes, dim=-1).flatten(1, 2)[:, :block_per_k]
+            zp_unpacked = zp_unpacked.contiguous().view(n, block_per_k, 1).to(weights.dtype)
+            dequantized = (q_unpacked - zp_unpacked) * scale_torch
 
     scale_torch_out = scale.to(weights.device).to(torch.float16)
     processed_q_weight_torch = processed_q_weight.to(weights.device).view(torch.uint8)
@@ -227,19 +241,20 @@ def quant_dequant_blockwise(weights, block_size, is_4_bit_quantization: bool = T
 
 def _dequantize_unsigned_per_channel_storage(qweight, scales, weights, bits: int):
     n, k = weights.shape
-    if bits == 4:
-        q_low = qweight & 0x0F
-        q_high = (qweight >> 4) & 0x0F
-        quantized = torch.stack((q_low, q_high), dim=-1).view(n, -1)[:, :k].to(torch.int16)
-        quantized = quantized - 8
+    if bits == 8:
+        quantized = qweight.view(n, k).to(torch.int16) - 128
     else:
-        quantized = qweight.view(n, k).to(torch.int16)
-        quantized = quantized - 128
+        # Little-endian sub-byte storage: LSB-first within each byte.
+        pack = 8 // bits
+        value_mask = (1 << bits) - 1
+        default_zp = 1 << (bits - 1)
+        lanes = [(qweight >> (lane * bits)) & value_mask for lane in range(pack)]
+        quantized = torch.stack(lanes, dim=-1).view(n, -1)[:, :k].to(torch.int16) - default_zp
 
     return quantized.to(weights.device).to(weights.dtype) * scales.to(weights.device).to(weights.dtype).unsqueeze(-1)
 
 
-def quant_dequant(weights, is_4_bit_quantization: bool = True, asymmetric: bool = False):
+def quant_dequant(weights, is_4_bit_quantization=True, asymmetric: bool = False):
     """
     Quantize and dequantize weights for testing purposes.
     Supports symmetric (default) and asymmetric quantization.
@@ -247,23 +262,28 @@ def quant_dequant(weights, is_4_bit_quantization: bool = True, asymmetric: bool 
     Returns:
         scale, quantized_storage, dequantized, zero_point_storage
     """
+    bits = _resolve_quant_bits(is_4_bit_quantization)
     block_size = weights.shape[1]
     if not asymmetric and block_size > 256:
-        bits = 4 if is_4_bit_quantization else 8
         qweight, scales = CudaQuantizer.qmoe_symmetric_per_channel_quantize(
             weights,
             bits,
         )
-        processed_q_weight, _ = CudaQuantizer.qmoe_per_channel_quantize(
-            weights,
-            bits,
-            True,
-        )
+        if bits == 2:
+            # 2-bit has no CUTLASS prepacked layout; feed the raw [N, K/4] storage the dequant
+            # fallback consumes.
+            processed_q_weight = qweight
+        else:
+            processed_q_weight, _ = CudaQuantizer.qmoe_per_channel_quantize(
+                weights,
+                bits,
+                True,
+            )
         dequantized = _dequantize_unsigned_per_channel_storage(qweight, scales, weights, bits)
         scales = scales.to(weights.device).to(torch.float16).unsqueeze(-1)
         return scales, processed_q_weight.to(weights.device), dequantized, None
 
-    return quant_dequant_blockwise(weights, block_size, is_4_bit_quantization, asymmetric)
+    return quant_dequant_blockwise(weights, block_size, bits, asymmetric)
 
 
 def create_moe_onnx_graph(
@@ -865,7 +885,8 @@ class SparseMoeBlockORTHelper(nn.Module):
         w1_scale_list, w2_scale_list = [], []
         w1_zp_list, w2_zp_list = [], []
 
-        is_4_bit = self.quant_bits == 4
+        # Pass the actual bit-width; quant_dequant helpers accept an int (2/4/8) or the legacy bool.
+        is_4_bit = self.quant_bits
 
         # Row-wise QMoE (block_size <= 0) does not support zero-points in CUDA kernel path.
         use_effective_asymmetric_quant = self.use_asymmetric_quant and self.block_size > 0
@@ -1137,6 +1158,12 @@ class SparseMoeBlockORTHelper(nn.Module):
         ort_dtype_quant_bits_tolerance_map = {
             "FP32:0": (5e-3, 1e-3),
             "FP16:0": (5e-2, 1e-3),
+            # 2-bit has only 4 quantization levels, so the reconstruction error (and hence the
+            # ORT-vs-reference max diff) is much larger than 4/8-bit; both sides dequantize the same
+            # storage, so the residual is dominated by fp16/bf16 accumulation, not quant error.
+            "FP16:2": (0.35, 0.05),
+            "FP32:2": (0.35, 0.05),
+            "BF16:2": (0.5, 0.05),
             "FP16:4": (0.1, 0.01),
             "FP16:8": (0.1, 0.01),
             "FP32:4": (0.1, 0.01),
@@ -1300,7 +1327,8 @@ class PhiMoESparseMoeBlock(SparseMoeBlockORTHelper):
                 scale_1_list.append(torch.tensor(1.0))
                 scale_2_list.append(torch.tensor(1.0))
             else:
-                is_4_bit = self.quant_bits == 4
+                # Pass the actual bit-width; quant_dequant helpers accept an int (2/4/8) or a bool.
+                is_4_bit = self.quant_bits
 
                 if self.block_size > 0:
                     scale1, pre_qweight1, w1_qdq, zp1 = quant_dequant_blockwise(
@@ -1435,6 +1463,9 @@ phi3_test_cases = [
     (1, 32, 8),
     (2, 16, 4),
     (2, 16, 8),
+    # 2-bit per-channel (symmetric only) runs the dense dequant fallback.
+    (1, 32, 2),
+    (2, 16, 2),
 ]
 
 # Define test cases for block-wise quantization
@@ -1450,6 +1481,10 @@ phi3_blockwise_test_cases = [
     (2, 16, 4, 32),
     (2, 16, 8, 32),
     (2, 16, 8, 64),
+    # 2-bit block-wise (symmetric only) runs the dense dequant fallback.
+    (1, 32, 2, 32),
+    (1, 32, 2, 64),
+    (2, 16, 2, 32),
 ]
 phi3_blockwise_asymmetric_test_cases = [
     (1, 1, 4, 32),
@@ -3182,6 +3217,94 @@ class TestQMoECudaGraph(unittest.TestCase):
         out_updated = y_ort.numpy().copy()
         self.assertFalse(numpy.isnan(out_updated).any(), "QMoE CUDA graph updated-input output has NaN")
         self.assertFalse(numpy.isinf(out_updated).any(), "QMoE CUDA graph updated-input output has Inf")
+
+
+@unittest.skipIf(not torch.cuda.is_available(), "skipping QMoE GeGLU test since it requires CUDA.")
+class TestQMoEGeGLU(unittest.TestCase):
+    """GeGLU (gelu-gated GLU) activation for QMoE, as used by Gemma4 MoE.
+
+    Validates the CUDA kernel computes down(gelu_tanh(gate) * up) with interleaved gate|up fc1,
+    matching the HuggingFace Gemma4 reference (gelu_pytorch_tanh gate, no clamp, alpha=1, beta=0).
+    Covers 2-bit (dequant fallback), plus 4-bit and 8-bit for coverage of the fused path.
+    """
+
+    @staticmethod
+    def _gelu_tanh(x):
+        return 0.5 * x * (1.0 + numpy.tanh(0.7978845608028654 * (x + 0.044715 * x * x * x)))
+
+    def _run_case(self, bits, hidden=256, inter=256, block=64):
+        if "CUDAExecutionProvider" not in onnxruntime.get_available_providers():
+            self.skipTest("CUDA EP not available")
+        zp = 1 << (bits - 1)
+        pack = 8 // bits
+        rng = numpy.random.default_rng(0)
+
+        def pack_w(codes):  # [rows, K] uint8 codes -> [rows, K/pack] little-endian
+            r, k = codes.shape
+            o = numpy.zeros((r, k // pack), numpy.uint8)
+            for lane in range(pack):
+                o |= (codes[:, lane::pack] & ((1 << bits) - 1)) << (lane * bits)
+            return o
+
+        def quant_blockwise(w):  # symmetric blockwise; returns codes[N,K], scale[N,K/block], deq[N,K]
+            n, k = w.shape
+            nb = k // block
+            blk = w.reshape(n, nb, block)
+            smax = numpy.maximum(numpy.abs(blk).max(2) / float(zp), 1e-8).astype(numpy.float32)
+            q = numpy.clip(numpy.rint(blk / smax[:, :, None]) + zp, 0, (1 << bits) - 1).astype(numpy.uint8)
+            deq = (q.astype(numpy.float32) - zp) * smax[:, :, None]
+            return q.reshape(n, k), smax, deq.reshape(n, k)
+
+        w1 = (rng.standard_normal((2 * inter, hidden)) * 0.1).astype(numpy.float32)  # interleaved gate|up
+        w2 = (rng.standard_normal((hidden, inter)) * 0.1).astype(numpy.float32)
+        c1, s1, dq1 = quant_blockwise(w1)
+        c2, s2, dq2 = quant_blockwise(w2)
+        inp = (rng.standard_normal((1, hidden)) * 0.5).astype(numpy.float32)
+
+        h = inp @ dq1.T
+        act = self._gelu_tanh(h[:, 0::2]) * h[:, 1::2]
+        ref = (act @ dq2.T)[0]
+
+        f1p = pack_w(c1)[None]
+        f2p = pack_w(c2)[None]
+        # This test ships raw [N, K/pack] little-endian weights. 2-bit always runs the op's PrePack;
+        # 4/8-bit default to weights_prepacked=-1 (expects offline CUTLASS-prepacked bytes), so request
+        # weights_prepacked=0 to have the op prepack the raw layout for the fused int4/int8 GEMM.
+        node = helper.make_node(
+            "QMoE",
+            ["input", "router_probs", "fc1_experts_weights", "fc1_scales", "",
+             "fc2_experts_weights", "fc2_scales", "", "", "", "", "", "", ""],
+            ["output"], "m", k=1, normalize_routing_weights=1, activation_type="geglu",
+            swiglu_fusion=1, expert_weight_bits=bits, block_size=block, weights_prepacked=0,
+            domain="com.microsoft")
+        graph = helper.make_graph(
+            [node], "g",
+            [helper.make_tensor_value_info("input", TensorProto.FLOAT16, [1, hidden]),
+             helper.make_tensor_value_info("router_probs", TensorProto.FLOAT16, [1, 1])],
+            [helper.make_tensor_value_info("output", TensorProto.FLOAT16, [1, hidden])],
+            [helper.make_tensor("fc1_experts_weights", TensorProto.UINT8, list(f1p.shape), f1p.tobytes(), raw=True),
+             helper.make_tensor("fc2_experts_weights", TensorProto.UINT8, list(f2p.shape), f2p.tobytes(), raw=True),
+             helper.make_tensor("fc1_scales", TensorProto.FLOAT16, [1, 2 * inter, hidden // block],
+                                s1.astype(numpy.float16).tobytes(), raw=True),
+             helper.make_tensor("fc2_scales", TensorProto.FLOAT16, [1, hidden, inter // block],
+                                s2.astype(numpy.float16).tobytes(), raw=True)])
+        model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17),
+                                                        helper.make_opsetid("com.microsoft", 1)])
+        sess = onnxruntime.InferenceSession(model.SerializeToString(), providers=["CUDAExecutionProvider"])
+        out = sess.run(None, {"input": inp.astype(numpy.float16),
+                              "router_probs": numpy.ones((1, 1), numpy.float16)})[0][0].astype(numpy.float32)
+        tol = {2: 0.35, 4: 0.1, 8: 0.1}[bits]
+        max_diff = float(numpy.abs(out - ref).max())
+        self.assertLess(max_diff, tol, f"GeGLU {bits}-bit max_diff {max_diff:.4f} exceeds {tol}")
+
+    def test_geglu_2bit(self):
+        self._run_case(2)
+
+    def test_geglu_4bit(self):
+        self._run_case(4)
+
+    def test_geglu_8bit(self):
+        self._run_case(8)
 
 
 if __name__ == "__main__":

--- a/onnxruntime/test/python/transformers/test_qmoe_cuda.py
+++ b/onnxruntime/test/python/transformers/test_qmoe_cuda.py
@@ -3367,7 +3367,7 @@ class TestQMoEFractionalZeroPoint(unittest.TestCase):
     def _silu(x):
         return x / (1.0 + numpy.exp(-x))
 
-    def _run_case(self, offset=1.5, hidden=256, inter=256, block=64, disable_prepacking=False):
+    def _run_case(self, offset=1.5, hidden=256, inter=256, block=64, live_scales=False):
         if "CUDAExecutionProvider" not in onnxruntime.get_available_providers():
             self.skipTest("CUDA EP not available")
         bits = 2
@@ -3435,46 +3435,56 @@ class TestQMoEFractionalZeroPoint(unittest.TestCase):
             zero_point_offset=float(offset),
             domain="com.microsoft",
         )
+        s1_fp16 = s1.astype(numpy.float16).reshape(1, inter, hidden // block)
+        s2_fp16 = s2.astype(numpy.float16).reshape(1, hidden, inter // block)
+        # When ``live_scales`` is set, fc*_scales are runtime graph inputs instead of constant
+        # initializers. Weights stay initializers, so int2 PrePack still runs (int2 mandates the
+        # CUTLASS layout transform), but PrePackConstantBiasFromScales cannot consume live scales --
+        # forcing ComputeInternal to build the fractional-center bias on the fly from the live
+        # fc*_scales. Global session.disable_prepacking is NOT usable here: it would also skip the
+        # mandatory weight prepack and the kernel rejects int2 with weights_prepacked=0.
+        graph_inputs = [
+            helper.make_tensor_value_info("input", TensorProto.FLOAT16, [1, hidden]),
+            helper.make_tensor_value_info("router_probs", TensorProto.FLOAT16, [1, 1]),
+        ]
+        initializers = [
+            helper.make_tensor("fc1_experts_weights", TensorProto.UINT8, list(f1p.shape), f1p.tobytes(), raw=True),
+            helper.make_tensor("fc2_experts_weights", TensorProto.UINT8, list(f2p.shape), f2p.tobytes(), raw=True),
+        ]
+        if live_scales:
+            graph_inputs.append(
+                helper.make_tensor_value_info("fc1_scales", TensorProto.FLOAT16, [1, inter, hidden // block])
+            )
+            graph_inputs.append(
+                helper.make_tensor_value_info("fc2_scales", TensorProto.FLOAT16, [1, hidden, inter // block])
+            )
+        else:
+            initializers.append(
+                helper.make_tensor(
+                    "fc1_scales", TensorProto.FLOAT16, [1, inter, hidden // block], s1_fp16.tobytes(), raw=True
+                )
+            )
+            initializers.append(
+                helper.make_tensor(
+                    "fc2_scales", TensorProto.FLOAT16, [1, hidden, inter // block], s2_fp16.tobytes(), raw=True
+                )
+            )
         graph = helper.make_graph(
             [node],
             "g",
-            [
-                helper.make_tensor_value_info("input", TensorProto.FLOAT16, [1, hidden]),
-                helper.make_tensor_value_info("router_probs", TensorProto.FLOAT16, [1, 1]),
-            ],
+            graph_inputs,
             [helper.make_tensor_value_info("output", TensorProto.FLOAT16, [1, hidden])],
-            [
-                helper.make_tensor("fc1_experts_weights", TensorProto.UINT8, list(f1p.shape), f1p.tobytes(), raw=True),
-                helper.make_tensor("fc2_experts_weights", TensorProto.UINT8, list(f2p.shape), f2p.tobytes(), raw=True),
-                helper.make_tensor(
-                    "fc1_scales",
-                    TensorProto.FLOAT16,
-                    [1, inter, hidden // block],
-                    s1.astype(numpy.float16).tobytes(),
-                    raw=True,
-                ),
-                helper.make_tensor(
-                    "fc2_scales",
-                    TensorProto.FLOAT16,
-                    [1, hidden, inter // block],
-                    s2.astype(numpy.float16).tobytes(),
-                    raw=True,
-                ),
-            ],
+            initializers,
         )
         model = helper.make_model(
             graph, opset_imports=[helper.make_opsetid("", 17), helper.make_opsetid("com.microsoft", 1)]
         )
-        sess_opts = onnxruntime.SessionOptions()
-        if disable_prepacking:
-            # Force the live-scale fallback branch in ComputeInternal: with prepacking disabled the
-            # constant bias is not built at PrePack time (PrePackConstantBiasFromScales is skipped),
-            # so the fractional-center bias must be computed on the fly from the live fc*_scales.
-            sess_opts.add_session_config_entry("session.disable_prepacking", "1")
-        sess = onnxruntime.InferenceSession(model.SerializeToString(), sess_opts, providers=["CUDAExecutionProvider"])
-        out = sess.run(None, {"input": inp.astype(numpy.float16), "router_probs": numpy.ones((1, 1), numpy.float16)})[
-            0
-        ][0].astype(numpy.float32)
+        sess = onnxruntime.InferenceSession(model.SerializeToString(), providers=["CUDAExecutionProvider"])
+        feeds = {"input": inp.astype(numpy.float16), "router_probs": numpy.ones((1, 1), numpy.float16)}
+        if live_scales:
+            feeds["fc1_scales"] = s1_fp16
+            feeds["fc2_scales"] = s2_fp16
+        out = sess.run(None, feeds)[0][0].astype(numpy.float32)
         max_diff = float(numpy.abs(out - ref).max())
         self.assertLess(max_diff, 0.35, f"fractional-zp 2-bit max_diff {max_diff:.4f} exceeds 0.35")
 
@@ -3482,9 +3492,10 @@ class TestQMoEFractionalZeroPoint(unittest.TestCase):
         self._run_case(1.5)
 
     def test_fractional_zp_1p5_live_scales(self):
-        # Same fractional-center reference, but with prepacking disabled so the on-the-fly
-        # (live-scale) bias branch in ComputeInternal is exercised instead of the PrePack path.
-        self._run_case(1.5, disable_prepacking=True)
+        # Same fractional-center reference, but fc*_scales are live runtime inputs (not consumed by
+        # PrePack), exercising the on-the-fly (live-scale) constant-bias branch in ComputeInternal
+        # instead of the PrePack path. Weights remain initializers so int2 weight PrePack still runs.
+        self._run_case(1.5, live_scales=True)
 
 
 if __name__ == "__main__":

--- a/onnxruntime/test/python/transformers/test_qmoe_cuda.py
+++ b/onnxruntime/test/python/transformers/test_qmoe_cuda.py
@@ -3367,7 +3367,7 @@ class TestQMoEFractionalZeroPoint(unittest.TestCase):
     def _silu(x):
         return x / (1.0 + numpy.exp(-x))
 
-    def _run_case(self, offset=1.5, hidden=256, inter=256, block=64):
+    def _run_case(self, offset=1.5, hidden=256, inter=256, block=64, disable_prepacking=False):
         if "CUDAExecutionProvider" not in onnxruntime.get_available_providers():
             self.skipTest("CUDA EP not available")
         bits = 2
@@ -3465,7 +3465,13 @@ class TestQMoEFractionalZeroPoint(unittest.TestCase):
         model = helper.make_model(
             graph, opset_imports=[helper.make_opsetid("", 17), helper.make_opsetid("com.microsoft", 1)]
         )
-        sess = onnxruntime.InferenceSession(model.SerializeToString(), providers=["CUDAExecutionProvider"])
+        sess_opts = onnxruntime.SessionOptions()
+        if disable_prepacking:
+            # Force the live-scale fallback branch in ComputeInternal: with prepacking disabled the
+            # constant bias is not built at PrePack time (PrePackConstantBiasFromScales is skipped),
+            # so the fractional-center bias must be computed on the fly from the live fc*_scales.
+            sess_opts.add_session_config_entry("session.disable_prepacking", "1")
+        sess = onnxruntime.InferenceSession(model.SerializeToString(), sess_opts, providers=["CUDAExecutionProvider"])
         out = sess.run(None, {"input": inp.astype(numpy.float16), "router_probs": numpy.ones((1, 1), numpy.float16)})[
             0
         ][0].astype(numpy.float32)
@@ -3474,6 +3480,11 @@ class TestQMoEFractionalZeroPoint(unittest.TestCase):
 
     def test_fractional_zp_1p5(self):
         self._run_case(1.5)
+
+    def test_fractional_zp_1p5_live_scales(self):
+        # Same fractional-center reference, but with prepacking disabled so the on-the-fly
+        # (live-scale) bias branch in ComputeInternal is exercised instead of the PrePack path.
+        self._run_case(1.5, disable_prepacking=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Description

Adds three related capabilities to the QMoE CUDA execution provider:

1. **Fused int2 (`cutlass::uint2b_t`) mixed-input GEMM.** 2-bit weights stay packed in HBM and are dequantized in-register inside the SM80 DqMma pipeline, mirroring the existing int4 (`uint4b_t`) path — no full-precision weight materialization. This replaces the phase-1 dequant-to-fp16 fallback that materialized `[E, N, K]` fp16 weights every call.
2. **GeGLU gated activation** (gelu-tanh gate), for Gemma-style MoE blocks.
3. **Optional fractional `zero_point_offset` attribute** for integer block-wise quant, enabling balanced asymmetric schemes whose zero-point is not integer-representable by a uint8 tensor (e.g. a 2-bit checkpoint quantized around the 1.5 midpoint: codes `{0,1,2,3}` → `{-1.5,-0.5,0.5,1.5}*scale`).

### Motivation

The prior 2-bit path fell back to dequantizing the full weight tensor to fp16 in HBM, forfeiting the entire point of 2-bit (memory bandwidth). It ran ~24x slower than int4 at decode. The fused kernel keeps weights packed and dequantizes in-register.

### Changes

**In-register converter / layout / DqMma wiring (patterned on the `uint4b_t` sites):**
- `cutlass_extensions/interleaved_numeric_conversion.h`: from-scratch `FastInterleavedAndBiasedNumericArrayConverter<half_t/bfloat16_t, uint2b_t, N>` (16 codes/word, symmetric +2 bias, fp16/bf16 magic).
- `cutlass_extensions/gemm/kernel/mixed_gemm_B_layout.h`: `LayoutDetailsB<uint2b_t>` (`ThreadblockK=64`, `ColumnsInterleaved=8`).
- `gemm/threadblock/default_mma*.h`, `default_dq_mma_*.h`, the four `dq_mma_*` variants: `uint2b_t` specializations + static_assert extensions.

**Correctness fix (the crux):** the `warp_frag_B` double-buffer index was derived from the per-CTA-K-stage load offset, which stays coherent only when `kWarpGemmIterationsForB` is even (int8=4, int4=2). For int2 it is odd (=1), so every stage re-read stage-0's B fragment (tile0 counted twice, tile1 dropped) — an `ORT[m]=ref[m]+ref[m+64]` K-fold for K>64. Fixed with a persistent cross-stage parity carried in all four DqMma variants; the change is a no-op for even `kWarpGemmIterationsForB` (int4/int8 unaffected).

**Weight preprocessor / runner / decode GEMV:**
- `fpA_intB_gemm_preprocessors*`: `W2_A16` quant type, 2-bit subbyte transpose, `add_bias_and_interleave_int2s`, LDSM permutation map.
- `moe_gemm/moe_gemm_kernels_{fp16,bf16}_uint2.cu`, `moe_kernels.cu`, `moe_gemm_template_dispatch.h`: `uint2b_t` runner instantiations.
- `fpA_intB_gemv/details.h`, `moe_gemv.cu`: int2 decode GEMV path.

**QMoE op wiring:**
- `moe/moe_quantization.cc/.h`: construct the fused `uint2b_t` runner for 2-bit; re-enable int2 PrePack (`W2_A16`); add `zero_point_offset` parse + `PrePackConstantBiasFromScales` (bias = `(2^(bits-1) - zero_point_offset) * scale`) and a ComputeInternal fallback when prepacking is disabled.
- `moe/qmoe_kernels.cu/.h`: `LaunchQMoEConstantBias` (float/half/bf16).
- `core/graph/contrib_ops/contrib_defs.cc`: `zero_point_offset` OPTIONAL_VALUE FLOAT attr on the QMoE schema.

**Quantizer / tests:**
- `python/tools/quantization/cuda_quantizer.py`: 2-bit packing support.
- `test/python/transformers/test_qmoe_cuda.py`: fused int2/int4/int8 GeGLU coverage + `TestQMoEFractionalZeroPoint` (2-bit, offset 1.5).

### Testing

Validated on H100 (SM90), fp16, hidden=inter=2048, E=8, top_k=2, block_size=128:
- 2-bit parity max_diff 0.000488 / 0.003906 (tolerance 0.35) — effectively bit-exact vs the phase-1 fallback reference.
- Full `test_qmoe_cuda.py`: 122 passed, 15 skipped, 0 failed (no int4/int8/fp4/fp8 regression).
- Performance: int2 decode 1.019 → 0.037 ms/inference (tracks int4 0.036, ~27x speedup); prefill 1.047 → 0.101 ms (beats int4 0.161).

Opening as **draft** for review.