### PR TITLE
Fix C API docs Doxygen download

### DIFF
--- a/.github/workflows/publish-c-apidocs.yml
+++ b/.github/workflows/publish-c-apidocs.yml
@@ -43,7 +43,7 @@ jobs:
           sudo apt update
           sudo apt-get install libclang-dev
           sudo apt-get install libclang-cpp14
-          wget https://www.doxygen.nl/files/doxygen-1.9.8.linux.bin.tar.gz
+          wget https://github.com/doxygen/doxygen/releases/download/Release_1_9_8/doxygen-1.9.8.linux.bin.tar.gz
           tar xvzf doxygen-1.9.8.linux.bin.tar.gz
       - name: Run doxygen
         run: |


### PR DESCRIPTION
## Description

Replace the obsolete `doxygen.nl` download URL for the pinned Doxygen 1.9.8 Linux binary with the official asset from the Doxygen GitHub release tag `Release_1_9_8`.

The C API docs workflow has persistently failed while downloading Doxygen (runs [31917039689](https://github.com/microsoft/onnxruntime/actions/runs/31917039689), [31975339915](https://github.com/microsoft/onnxruntime/actions/runs/31975339915), and [32050624667](https://github.com/microsoft/onnxruntime/actions/runs/32050624667)). Because no fresh `onnxruntime-c-apidocs` artifact was produced before the previous artifact expired, the downstream ONNX Publish site run [32533178465](https://github.com/microsoft/onnxruntime/actions/runs/32533178465) failed at `Download C apidocs artifact`, blocking GitHub Pages deployment.

This is intentionally separate from accessibility PR #32180.

## Validation

- Confirmed the official release URL follows one redirect and returns HTTP 200.
- Confirmed GitHub release tag `Release_1_9_8` contains `doxygen-1.9.8.linux.bin.tar.gz` (50,500,806 bytes).
- Downloaded the archive successfully and verified gzip/tar integrity.
- Confirmed extraction produces `doxygen-1.9.8/bin/doxygen` while preserving the workflow's existing extraction and invocation paths.
- Parsed the workflow as valid YAML.
- Dispatched the [C/C++ API docs workflow from this branch](https://github.com/microsoft/onnxruntime/actions/runs/32534100983); the install, Doxygen generation, and site staging steps succeeded, and the log reports `Doxygen version used: 1.9.8`. Artifact upload was skipped as expected because the ref is not `main`.

## Recovery after merge

1. Dispatch the **Update C/C++ API Docs** workflow on `main`.
2. Verify it uploads a fresh `onnxruntime-c-apidocs` artifact.
3. Rerun the failed GitHub Pages jobs from ONNX Publish site run 32533178465.

No Doxygen version or unrelated workflow behavior is changed.