### PR TITLE
Run wgsl_template Python tests in CI

### DIFF
--- a/.github/workflows/wgsl_template_tests.yml
+++ b/.github/workflows/wgsl_template_tests.yml
@@ -1,0 +1,52 @@
+name: WGSL Template Tests
+
+on:
+  push:
+    branches:
+      - main
+      - rel-*
+    paths:
+      - '.github/workflows/wgsl_template_tests.yml'
+      - 'tools/python/wgsl_gen.py'
+      - 'tools/python/wgsl_template/**'
+      - 'onnxruntime/core/providers/webgpu/**/*.wgsl.template'
+      - 'onnxruntime/contrib_ops/webgpu/**/*.wgsl.template'
+  pull_request:
+    branches:
+      - main
+      - rel-*
+    paths:
+      - '.github/workflows/wgsl_template_tests.yml'
+      - 'tools/python/wgsl_gen.py'
+      - 'tools/python/wgsl_template/**'
+      - 'onnxruntime/core/providers/webgpu/**/*.wgsl.template'
+      - 'onnxruntime/contrib_ops/webgpu/**/*.wgsl.template'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  wgsl-template-tests:
+    name: WGSL Template Tests (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - name: Setup Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          # Matches the WebGPU build lanes (windows_webgpu.yml, nightly_webgpu.yml), which run wgsl_gen.py.
+          python-version: "3.12"
+      # The suite only uses the standard library, so no dependency install is needed.
+      - name: Run wgsl_template tests
+        run: python wgsl_template/test/run_tests.py
+        working-directory: tools/python

--- a/.github/workflows/wgsl_template_tests.yml
+++ b/.github/workflows/wgsl_template_tests.yml
@@ -3,24 +3,14 @@ name: WGSL Template Tests
 on:
   push:
     branches:
-      - main
-      - rel-*
-    paths:
-      - '.github/workflows/wgsl_template_tests.yml'
-      - 'tools/python/wgsl_gen.py'
-      - 'tools/python/wgsl_template/**'
-      - 'onnxruntime/core/providers/webgpu/**/*.wgsl.template'
-      - 'onnxruntime/contrib_ops/webgpu/**/*.wgsl.template'
+    - main
+    - rel-*
+    - plugin-ep-webgpu/rel-*
   pull_request:
     branches:
-      - main
-      - rel-*
-    paths:
-      - '.github/workflows/wgsl_template_tests.yml'
-      - 'tools/python/wgsl_gen.py'
-      - 'tools/python/wgsl_template/**'
-      - 'onnxruntime/core/providers/webgpu/**/*.wgsl.template'
-      - 'onnxruntime/contrib_ops/webgpu/**/*.wgsl.template'
+    - main
+    - rel-*
+    - plugin-ep-webgpu/rel-*
   workflow_dispatch:
 
 concurrency:
@@ -40,13 +30,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
-      - name: Setup Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
-        with:
-          # Matches the WebGPU build lanes (windows_webgpu.yml, nightly_webgpu.yml), which run wgsl_gen.py.
-          python-version: "3.12"
-      # The suite only uses the standard library, so no dependency install is needed.
-      - name: Run wgsl_template tests
-        run: python wgsl_template/test/run_tests.py
-        working-directory: tools/python
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+    - name: Setup Python
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+      with:
+        # Matches the WebGPU build lanes (windows_webgpu.yml, nightly_webgpu.yml), which run wgsl_gen.py.
+        python-version: "3.12"
+    # The suite only uses the standard library, so no dependency install is needed.
+    - name: Run wgsl_template tests
+      run: python wgsl_template/test/run_tests.py
+      working-directory: tools/python

--- a/cmake/onnxruntime_providers_webgpu.cmake
+++ b/cmake/onnxruntime_providers_webgpu.cmake
@@ -344,15 +344,6 @@
 
     # Make sure generation happens before building the provider
     add_dependencies(onnxruntime_providers_webgpu onnxruntime_webgpu_wgsl_generation)
-
-    # Wire the Python wgsl_template test suite into ctest.
-    if (BUILD_TESTING)
-      add_test(
-        NAME wgsl_template_python_tests
-        COMMAND ${Python_EXECUTABLE} "${WGSL_GEN_PYTHON_DIR}/wgsl_template/test/run_tests.py"
-        WORKING_DIRECTORY ${WGSL_GEN_PYTHON_DIR}
-      )
-    endif()
   endif()
 
   if (NOT onnxruntime_BUILD_SHARED_LIB)

--- a/onnxruntime/core/providers/webgpu/wgsl_templates/README.md
+++ b/onnxruntime/core/providers/webgpu/wgsl_templates/README.md
@@ -95,15 +95,9 @@ python tools/python/wgsl_gen.py \
 
 ### Running the test suite
 
-The Python tool ships with a unit + fixture test suite. CMake adds
-`wgsl_template_python_tests` to `ctest`, so any standard ORT build with WGSL
-templates enabled will run them:
+The Python tool ships with a unit + fixture test suite.
 
-```
-ctest -R wgsl_template_python_tests
-```
-
-You can also run the suite directly from the source tree:
+You can run the suite directly from the source tree:
 
 ```
 python tools/python/wgsl_template/test/run_tests.py

--- a/tools/python/wgsl_template/test/run_tests.py
+++ b/tools/python/wgsl_template/test/run_tests.py
@@ -4,7 +4,8 @@
 """Test runner for the WGSL template Python port.
 
 Discovers ``test_*.py`` siblings and aggregates them into one suite.
-Invoked manually or via ``ctest`` (see CMake's ``add_test`` wiring).
+Run manually, or via the ``WGSL Template Tests`` GitHub Actions workflow
+(.github/workflows/wgsl_template_tests.yml).
 """
 
 from __future__ import annotations


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Add a GitHub Actions workflow that runs the wgsl_template test suite on Linux and Windows. The tests are stdlib-only, so no dependency install is needed. Python 3.12 matches the WebGPU build lanes that invoke wgsl_gen.py.

Remove `add_test()` block in cmake/onnxruntime_providers_webgpu.cmake. The workflow calls `run_tests.py` directly.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Run wgsl_template tests in CI build.