### PR TITLE
swift-package: Add ORTTensorElementDataTypeBool support

### DIFF
--- a/objectivec/include/ort_enums.h
+++ b/objectivec/include/ort_enums.h
@@ -39,6 +39,7 @@ typedef NS_ENUM(int32_t, ORTTensorElementDataType) {
   ORTTensorElementDataTypeInt64,
   ORTTensorElementDataTypeUInt64,
   ORTTensorElementDataTypeString,
+  ORTTensorElementDataTypeBool,
 };
 
 /**

--- a/objectivec/ort_enums.mm
+++ b/objectivec/ort_enums.mm
@@ -55,6 +55,7 @@ constexpr TensorElementTypeInfo kElementTypeInfos[]{
     {ORTTensorElementDataTypeInt64, ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64, sizeof(int64_t)},
     {ORTTensorElementDataTypeUInt64, ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT64, sizeof(uint64_t)},
     {ORTTensorElementDataTypeString, ONNX_TENSOR_ELEMENT_DATA_TYPE_STRING, std::nullopt},
+    {ORTTensorElementDataTypeBool, ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL, sizeof(bool)},
 };
 
 struct GraphOptimizationLevelInfo {

--- a/objectivec/test/ort_value_test.mm
+++ b/objectivec/test/ort_value_test.mm
@@ -87,6 +87,44 @@ NS_ASSUME_NONNULL_BEGIN
   XCTAssertTrue([stringData isEqualToArray:returnedStringData]);
 }
 
+- (void)testInitBoolTensorOk {
+  const bool value = true;
+  NSMutableData* data = [[NSMutableData alloc] initWithBytes:&value
+                                                      length:sizeof(bool)];
+  NSArray<NSNumber*>* shape = @[ @1 ];
+
+  const ORTTensorElementDataType elementType = ORTTensorElementDataTypeBool;
+
+  NSError* err = nil;
+  ORTValue* ortValue = [[ORTValue alloc] initWithTensorData:data
+                                                elementType:elementType
+                                                      shape:shape
+                                                      error:&err];
+  ORTAssertNullableResultSuccessful(ortValue, err);
+
+  auto checkTensorInfo = [&](ORTTensorTypeAndShapeInfo* tensorInfo) {
+    XCTAssertEqual(tensorInfo.elementType, elementType);
+    XCTAssertEqualObjects(tensorInfo.shape, shape);
+  };
+
+  ORTValueTypeInfo* typeInfo = [ortValue typeInfoWithError:&err];
+  ORTAssertNullableResultSuccessful(typeInfo, err);
+  XCTAssertEqual(typeInfo.type, ORTValueTypeTensor);
+  XCTAssertNotNil(typeInfo.tensorTypeAndShapeInfo);
+  checkTensorInfo(typeInfo.tensorTypeAndShapeInfo);
+
+  ORTTensorTypeAndShapeInfo* tensorInfo = [ortValue tensorTypeAndShapeInfoWithError:&err];
+  ORTAssertNullableResultSuccessful(tensorInfo, err);
+  checkTensorInfo(tensorInfo);
+
+  NSData* actualData = [ortValue tensorDataWithError:&err];
+  ORTAssertNullableResultSuccessful(actualData, err);
+  XCTAssertEqual(actualData.length, sizeof(bool));
+  bool actualValue;
+  memcpy(&actualValue, actualData.bytes, sizeof(bool));
+  XCTAssertEqual(actualValue, value);
+}
+
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Expose the ONNX BOOL tensor element type through the Objective-C API so that models requiring tensor(bool) inputs can be used. The new enum value is appended at the end to keep existing raw values stable.

### Description

This adds `ORTTensorElementDataTypeBool` to the Objective-C API and maps it to `ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL` in `ort_enums.mm`, with `sizeof(bool)` as the element size. A unit test `testInitBoolTensorOk` is added to verify that a bool tensor can be created and read back correctly.

The `objectivec/` directory in this repo is the source of truth that `onnxruntime-swift-package-manager` copies from (see [PR #41](https://github.com/microsoft/onnxruntime-swift-package-manager/pull/41)), so the change needs to land here first.

### Motivation and Context

Several ONNX models require a `tensor(bool)` input that the Objective-C/Swift bindings currently cannot construct. [onnxruntime-swift-package-manager#31](https://github.com/microsoft/onnxruntime-swift-package-manager/issues/31) reports a model using a bool mask for pixel attention that fails because `ORTTensorElementDataType` has no bool value.

Supporting the type at the source (`objectivec/`) lets the SPM package pick it up in its next sync and unblocks those models. The new enum value is appended at the end so existing raw values stay stable.


