### PR TITLE
Accept comma-separated optimization.disable_specified_optimizers lists

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
+++ b/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
@@ -115,7 +115,7 @@ static const char* const kOrtSessionOptionsMemoryOptimizerApplyConfig = "optimiz
 static const char* const kOrtSessionOptionsMemoryOptimizerProbeConfig = "optimization.enable_memory_probe_recompute_config";
 #endif
 
-// This setting if set should contain a comma separated list of optimizers names that should be disabled.
+// This setting if set should contain a comma- or semicolon-separated list of optimizer names that should be disabled.
 // Optimizers may take time to execute and affect model loading time. If you feel that a specific optimizer
 // does not provider runtime benefits, but affects your model loading time you may disable it using this config
 // entry. This option is not enabled in ORT_MINIMAL_BUILD build.

--- a/onnxruntime/core/common/string_utils.h
+++ b/onnxruntime/core/common/string_utils.h
@@ -41,9 +41,13 @@ inline InlinedVector<std::string_view> SplitString(std::string_view string_to_sp
 }
 
 /**
- * Splits a string on any character in `delimiters` (each delimiter is a
- * single character). Callers that previously split only on `;` can pass
- * `",;"` to also accept documented comma-separated lists.
+ * Splits a string on any character in `delimiters`. Each character in
+ * `delimiters` is treated as an independent single-character delimiter
+ * (unlike SplitString, which matches a delimiter substring).
+ * @param string_to_split The string to split.
+ * @param delimiters The set of delimiter characters. Must not be empty.
+ * @param keep_empty Whether to keep empty substrings.
+ * @return The split substrings.
  */
 inline InlinedVector<std::string_view> SplitStringOnAny(std::string_view string_to_split,
                                                         std::string_view delimiters,

--- a/onnxruntime/core/common/string_utils.h
+++ b/onnxruntime/core/common/string_utils.h
@@ -41,6 +41,28 @@ inline InlinedVector<std::string_view> SplitString(std::string_view string_to_sp
 }
 
 /**
+ * Splits a string on any character in `delimiters` (each delimiter is a
+ * single character). Used when a config value historically accepted more
+ * than one separator, e.g. comma and semicolon.
+ */
+inline InlinedVector<std::string_view> SplitStringOnAny(std::string_view string_to_split,
+                                                        std::string_view delimiters,
+                                                        bool keep_empty = false) {
+  ORT_ENFORCE(!delimiters.empty(), "delimiters must not be empty");
+  InlinedVector<std::string_view> result{};
+  std::string_view::size_type segment_begin_pos = 0;
+  while (segment_begin_pos != std::string_view::npos) {
+    const std::string_view::size_type segment_end_pos = string_to_split.find_first_of(delimiters, segment_begin_pos);
+    const bool is_segment_empty = segment_begin_pos == segment_end_pos || segment_begin_pos == string_to_split.size();
+    if (!is_segment_empty || keep_empty) {
+      result.push_back(string_to_split.substr(segment_begin_pos, segment_end_pos - segment_begin_pos));
+    }
+    segment_begin_pos = (segment_end_pos == std::string_view::npos) ? segment_end_pos : segment_end_pos + 1;
+  }
+  return result;
+}
+
+/**
  * Trim a string from start inplace.
  * @param s The string to trim.
  */

--- a/onnxruntime/core/common/string_utils.h
+++ b/onnxruntime/core/common/string_utils.h
@@ -42,8 +42,8 @@ inline InlinedVector<std::string_view> SplitString(std::string_view string_to_sp
 
 /**
  * Splits a string on any character in `delimiters` (each delimiter is a
- * single character). Used when a config value historically accepted more
- * than one separator, e.g. comma and semicolon.
+ * single character). Callers that previously split only on `;` can pass
+ * `",;"` to also accept documented comma-separated lists.
  */
 inline InlinedVector<std::string_view> SplitStringOnAny(std::string_view string_to_split,
                                                         std::string_view delimiters,

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -500,7 +500,7 @@ void InferenceSession::ConstructorCommon(const SessionOptions& session_options,
     auto disabled_string = session_options_.config_options.GetConfigOrDefault(
         kOrtSessionOptionsDisableSpecifiedOptimizers, "");
     if (!disabled_string.empty()) {
-      const auto disabled_list = utils::SplitString(disabled_string, ";");
+      const auto disabled_list = utils::SplitStringOnAny(disabled_string, ",;");
       InlinedHashSet<std::string> disabled_rules_and_transformers;
       disabled_rules_and_transformers.reserve(disabled_list.size());
       disabled_rules_and_transformers.insert(disabled_list.cbegin(), disabled_list.cend());

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -500,6 +500,7 @@ void InferenceSession::ConstructorCommon(const SessionOptions& session_options,
     auto disabled_string = session_options_.config_options.GetConfigOrDefault(
         kOrtSessionOptionsDisableSpecifiedOptimizers, "");
     if (!disabled_string.empty()) {
+      // Documented separator is comma; also preserve the legacy semicolon delimiter.
       const auto disabled_list = utils::SplitStringOnAny(disabled_string, ",;");
       InlinedHashSet<std::string> disabled_rules_and_transformers;
       disabled_rules_and_transformers.reserve(disabled_list.size());

--- a/onnxruntime/test/common/string_utils_test.cc
+++ b/onnxruntime/test/common/string_utils_test.cc
@@ -135,6 +135,24 @@ TEST(StringUtilsTest, SplitString) {
   run_test(",", ",", {"", ""});
 }
 
+TEST(StringUtilsTest, SplitStringOnAny) {
+  const auto parts = utils::SplitStringOnAny("MatMulAddFusion,ConstantFolding;Rule2", ",;");
+  ASSERT_EQ(parts.size(), 3u);
+  EXPECT_EQ(parts[0], "MatMulAddFusion");
+  EXPECT_EQ(parts[1], "ConstantFolding");
+  EXPECT_EQ(parts[2], "Rule2");
+
+  const auto comma_only = utils::SplitStringOnAny("A,B", ",;");
+  ASSERT_EQ(comma_only.size(), 2u);
+  EXPECT_EQ(comma_only[0], "A");
+  EXPECT_EQ(comma_only[1], "B");
+
+  const auto semicolon_only = utils::SplitStringOnAny("A;B", ",;");
+  ASSERT_EQ(semicolon_only.size(), 2u);
+  EXPECT_EQ(semicolon_only[0], "A");
+  EXPECT_EQ(semicolon_only[1], "B");
+}
+
 #ifndef ORT_NO_EXCEPTIONS
 TEST(StringUtilsTest, SplitStringWithEmptyDelimiter) {
   EXPECT_THROW(utils::SplitString("a", ""), OnnxRuntimeException);

--- a/onnxruntime/test/optimizer/graph_transform_test.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test.cc
@@ -9854,7 +9854,7 @@ TEST_F(GraphTransformationTests, FilterEnabledOptimizersViaSessionOptions) {
 
   SessionOptions so;
   so.session_logid = "GraphTransformationTests.FilterEnabledOptimizersViaSessionOptions";
-  ASSERT_STATUS_OK(so.config_options.AddConfigEntry(kOrtSessionOptionsDisableSpecifiedOptimizers, "ConstantFolding"));
+  ASSERT_STATUS_OK(so.config_options.AddConfigEntry(kOrtSessionOptionsDisableSpecifiedOptimizers, "MatMulAddFusion,ConstantFolding"));
 
   InferenceSessionWrapper session_object{so, GetEnvironment()};
 

--- a/onnxruntime/test/optimizer/graph_transform_test.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test.cc
@@ -9849,57 +9849,71 @@ TEST_F(GraphTransformationTests, FilterEnabledOptimizers) {
   ASSERT_TRUE(op_to_count["Add"] == 1);
 }
 
-TEST_F(GraphTransformationTests, FilterEnabledOptimizersViaSessionOptions) {
-  constexpr const ORTCHAR_T* model_uri = MODEL_FOLDER "fusion/constant_folding_with_scalar_shape_to_initializer.onnx";
+namespace {
 
-  SessionOptions so;
-  so.session_logid = "GraphTransformationTests.FilterEnabledOptimizersViaSessionOptions";
-  ASSERT_STATUS_OK(so.config_options.AddConfigEntry(kOrtSessionOptionsDisableSpecifiedOptimizers, "MatMulAddFusion,ConstantFolding"));
+void TestDisableTwoOptimizersViaSessionOptions(const char* disable_list, const char* logid_suffix) {
+  {
+    SessionOptions so;
+    so.session_logid =
+        std::string("GraphTransformationTests.FilterEnabledOptimizersViaSessionOptions.") + logid_suffix +
+        ".ConstantFolding";
+    ASSERT_STATUS_OK(so.config_options.AddConfigEntry(kOrtSessionOptionsDisableSpecifiedOptimizers, disable_list));
 
-  InferenceSessionWrapper session_object{so, GetEnvironment()};
+    InferenceSessionWrapper session_object{so, GetEnvironment()};
+    constexpr const ORTCHAR_T* model_uri = MODEL_FOLDER "fusion/constant_folding_with_scalar_shape_to_initializer.onnx";
+    ASSERT_STATUS_OK(session_object.Load(model_uri));
 
-  ASSERT_STATUS_OK(session_object.Load(model_uri));
+    const auto& graph = session_object.GetGraph();
+    std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
+    ASSERT_EQ(op_to_count["Shape"], 1);
+    ASSERT_EQ(op_to_count["ConstantOfShape"], 1);
+    ASSERT_EQ(op_to_count["Add"], 1);
 
-  const auto& graph = session_object.GetGraph();
+    ASSERT_STATUS_OK(session_object.Initialize());  // Initialize runs the transformers
 
-  // check the ops that should go away if the constant folding transformer runs
-  std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
-  ASSERT_TRUE(op_to_count["Shape"] == 1);
-  ASSERT_TRUE(op_to_count["ConstantOfShape"] == 1);
-  ASSERT_TRUE(op_to_count["Add"] == 1);
+    op_to_count = CountOpsInGraph(graph);
+    ASSERT_EQ(op_to_count["Shape"], 1);
+    ASSERT_EQ(op_to_count["ConstantOfShape"], 1);
+    ASSERT_EQ(op_to_count["Add"], 1);
+  }
 
-  ASSERT_STATUS_OK(session_object.Initialize());  // Initialize runs the transformers
+  {
+    SessionOptions so;
+    so.session_logid =
+        std::string("GraphTransformationTests.FilterEnabledOptimizersViaSessionOptions.") + logid_suffix +
+        ".MatMulAddFusion";
+    ASSERT_STATUS_OK(so.config_options.AddConfigEntry(kOrtSessionOptionsDisableSpecifiedOptimizers, disable_list));
 
-  op_to_count = CountOpsInGraph(graph);
-  ASSERT_TRUE(op_to_count["Shape"] == 1);
-  ASSERT_TRUE(op_to_count["ConstantOfShape"] == 1);
-  ASSERT_TRUE(op_to_count["Add"] == 1);
+    InferenceSessionWrapper session_object{so, GetEnvironment()};
+    constexpr const ORTCHAR_T* model_uri = MODEL_FOLDER "matmul_add_fusion/2Input/model.onnx";
+    ASSERT_STATUS_OK(session_object.Load(model_uri));
+
+    const auto& graph = session_object.GetGraph();
+    std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
+    ASSERT_EQ(op_to_count["MatMul"], 1);
+    ASSERT_EQ(op_to_count["Add"], 1);
+
+    ASSERT_STATUS_OK(session_object.Initialize());  // Initialize runs the transformers
+
+    op_to_count = CountOpsInGraph(graph);
+    ASSERT_EQ(op_to_count["MatMul"], 1);
+    ASSERT_EQ(op_to_count["Add"], 1);
+    ASSERT_EQ(op_to_count["Gemm"], 0);
+  }
 }
 
-TEST_F(GraphTransformationTests, FilterEnabledOptimizersViaSessionOptionsSemicolon) {
-  constexpr const ORTCHAR_T* model_uri = MODEL_FOLDER "fusion/constant_folding_with_scalar_shape_to_initializer.onnx";
+}  // namespace
 
-  SessionOptions so;
-  so.session_logid = "GraphTransformationTests.FilterEnabledOptimizersViaSessionOptionsSemicolon";
-  ASSERT_STATUS_OK(so.config_options.AddConfigEntry(kOrtSessionOptionsDisableSpecifiedOptimizers, "MatMulAddFusion;ConstantFolding"));
+TEST_F(GraphTransformationTests, FilterEnabledOptimizersViaSessionOptions) {
+  // Comma-delimited list of two known optimizers. Reverting the session parser
+  // to semicolon-only would treat this as a single unknown name and fail.
+  ASSERT_NO_FATAL_FAILURE(
+      TestDisableTwoOptimizersViaSessionOptions("MatMulAddFusion,ConstantFolding", "Comma"));
+}
 
-  InferenceSessionWrapper session_object{so, GetEnvironment()};
-
-  ASSERT_STATUS_OK(session_object.Load(model_uri));
-
-  const auto& graph = session_object.GetGraph();
-
-  std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
-  ASSERT_TRUE(op_to_count["Shape"] == 1);
-  ASSERT_TRUE(op_to_count["ConstantOfShape"] == 1);
-  ASSERT_TRUE(op_to_count["Add"] == 1);
-
-  ASSERT_STATUS_OK(session_object.Initialize());
-
-  op_to_count = CountOpsInGraph(graph);
-  ASSERT_TRUE(op_to_count["Shape"] == 1);
-  ASSERT_TRUE(op_to_count["ConstantOfShape"] == 1);
-  ASSERT_TRUE(op_to_count["Add"] == 1);
+TEST_F(GraphTransformationTests, FilterEnabledOptimizersViaSessionOptionsLegacySemicolon) {
+  ASSERT_NO_FATAL_FAILURE(
+      TestDisableTwoOptimizersViaSessionOptions("MatMulAddFusion;ConstantFolding", "Semicolon"));
 }
 
 TEST_F(GraphTransformationTests, PropagateCastOpsTests) {

--- a/onnxruntime/test/optimizer/graph_transform_test.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test.cc
@@ -9876,6 +9876,32 @@ TEST_F(GraphTransformationTests, FilterEnabledOptimizersViaSessionOptions) {
   ASSERT_TRUE(op_to_count["Add"] == 1);
 }
 
+TEST_F(GraphTransformationTests, FilterEnabledOptimizersViaSessionOptionsSemicolon) {
+  constexpr const ORTCHAR_T* model_uri = MODEL_FOLDER "fusion/constant_folding_with_scalar_shape_to_initializer.onnx";
+
+  SessionOptions so;
+  so.session_logid = "GraphTransformationTests.FilterEnabledOptimizersViaSessionOptionsSemicolon";
+  ASSERT_STATUS_OK(so.config_options.AddConfigEntry(kOrtSessionOptionsDisableSpecifiedOptimizers, "MatMulAddFusion;ConstantFolding"));
+
+  InferenceSessionWrapper session_object{so, GetEnvironment()};
+
+  ASSERT_STATUS_OK(session_object.Load(model_uri));
+
+  const auto& graph = session_object.GetGraph();
+
+  std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
+  ASSERT_TRUE(op_to_count["Shape"] == 1);
+  ASSERT_TRUE(op_to_count["ConstantOfShape"] == 1);
+  ASSERT_TRUE(op_to_count["Add"] == 1);
+
+  ASSERT_STATUS_OK(session_object.Initialize());
+
+  op_to_count = CountOpsInGraph(graph);
+  ASSERT_TRUE(op_to_count["Shape"] == 1);
+  ASSERT_TRUE(op_to_count["ConstantOfShape"] == 1);
+  ASSERT_TRUE(op_to_count["Add"] == 1);
+}
+
 TEST_F(GraphTransformationTests, PropagateCastOpsTests) {
   using Strategy = GraphTransformerConfiguration::PropagateCastOpsConfiguration::Strategy;
   struct PropagateCastOpsTestSpecs {


### PR DESCRIPTION
Fixes #32211.

`optimization.disable_specified_optimizers` is documented as a comma-separated list, but `InferenceSession` split only on `;`. A caller following the header comment with `MatMulAddFusion,ConstantFolding` therefore disables nothing (the whole string is treated as one unknown optimizer name) and gets no error.

This change splits on either `,` or `;`, so documented comma-separated values and existing semicolon-separated values both work. Added a `SplitStringOnAny` helper and unit tests for mixed, comma-only, and semicolon-only inputs.

I did not run the full ORT build in this environment (too large); the string helper tests are the coverage for the new split behavior.
