### PR TITLE
Add bundling of libs with the wheel on FreeBSD

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -443,6 +443,14 @@ elif platform.system() == "Darwin":
     libs.extend(["libonnxruntime_providers_vitisai.dylib"])
     if nightly_build:
         libs.extend(["libonnxruntime_pywrapper.dylib"])
+elif platform.system() == "FreeBSD":
+    libs = [
+        "onnxruntime_pybind11_state.so",
+        "libonnxruntime_providers_shared.so",
+        "libonnxruntime.so*",
+    ]
+    if nightly_build:
+        libs.extend(["libonnxruntime_pywrapper.so"])
 else:
     libs = [
         "onnxruntime_pybind11_state.pyd",


### PR DESCRIPTION
### Description
Add a FreeBSD branch to setup.py's libs list, mirroring the already-working Darwin one (plain package-data entries, no ext_modules), so the wheel now includes the same compiled artifacts on FreeBSD as it does on every other supported platform.

### Motivation and Context
Downstream issue: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=297774

Simplifies the packaging of a wheel for FreeBSD.

