### PR TITLE
Support LoRA adapters with plugin EP allocators

### DIFF
--- a/go/onnxruntime/onnxruntime_c_api.h
+++ b/go/onnxruntime/onnxruntime_c_api.h
@@ -5315,9 +5315,9 @@ struct OrtApi {
    * the platform does not support memory mapping, in which case the file will be read into memory.
    *
    * \param[in] adapter_file_path adapter file path.
-   * \param[in] allocator optional pointer to a device allocator. If specified
-   *            data is copied to the device at some point before Run() is invoked. If nullptr, data stays on CPU.
-   *            The data would still be copied to device if required by the model at inference time.
+   * \param[in] allocator optional pointer to a non-CPU device allocator. If specified and a data transfer implementation
+   *            is available during adapter creation, the data is copied to the device before Run() is invoked.
+   *            Otherwise, the data stays on CPU and is copied to the device if required by the model at inference time.
    * \param[out] out A pointer to a newly created OrtLoraAdapter instance. Must be released with
    *                  OrtApi::ReleaseLoraAdapter.
    *
@@ -5335,9 +5335,9 @@ struct OrtApi {
    *
    * \param[in] bytes pointer to a valid Lora Adapter format buffer.
    * \param[in] num_bytes length of bytes buffer.
-   * \param[in] allocator optional pointer to a device allocator. If specified
-   *            data is copied to the device at some point before Run() is invoked. If nullptr, data stays on CPU.
-   *            The data would still be copied to device if required by the model at inference time.
+   * \param[in] allocator optional pointer to a non-CPU device allocator. If specified and a data transfer implementation
+   *            is available during adapter creation, the data is copied to the device before Run() is invoked.
+   *            Otherwise, the data stays on CPU and is copied to the device if required by the model at inference time.
    * \param[out] out A pointer to a newly created OrtLoraAdapter instance. Must be released with
    *                  OrtApi::ReleaseLoraAdapter.
    *

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -5315,9 +5315,9 @@ struct OrtApi {
    * the platform does not support memory mapping, in which case the file will be read into memory.
    *
    * \param[in] adapter_file_path adapter file path.
-   * \param[in] allocator optional pointer to a device allocator. If specified
-   *            data is copied to the device at some point before Run() is invoked. If nullptr, data stays on CPU.
-   *            The data would still be copied to device if required by the model at inference time.
+   * \param[in] allocator optional pointer to a non-CPU device allocator. If specified and a data transfer implementation
+   *            is available during adapter creation, the data is copied to the device before Run() is invoked.
+   *            Otherwise, the data stays on CPU and is copied to the device if required by the model at inference time.
    * \param[out] out A pointer to a newly created OrtLoraAdapter instance. Must be released with
    *                  OrtApi::ReleaseLoraAdapter.
    *
@@ -5335,9 +5335,9 @@ struct OrtApi {
    *
    * \param[in] bytes pointer to a valid Lora Adapter format buffer.
    * \param[in] num_bytes length of bytes buffer.
-   * \param[in] allocator optional pointer to a device allocator. If specified
-   *            data is copied to the device at some point before Run() is invoked. If nullptr, data stays on CPU.
-   *            The data would still be copied to device if required by the model at inference time.
+   * \param[in] allocator optional pointer to a non-CPU device allocator. If specified and a data transfer implementation
+   *            is available during adapter creation, the data is copied to the device before Run() is invoked.
+   *            Otherwise, the data stays on CPU and is copied to the device if required by the model at inference time.
    * \param[out] out A pointer to a newly created OrtLoraAdapter instance. Must be released with
    *                  OrtApi::ReleaseLoraAdapter.
    *

--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -1477,8 +1477,8 @@ struct LoraAdapter : detail::Base<OrtLoraAdapter> {
   ///
   /// The function attempts to load the adapter from the specified file
   /// \param adapter_path The path to the Lora adapter
-  /// \param allocator optional pointer to a device allocator. If nullptr, the data stays on CPU. It would still
-  ///        be copied to device if required by the model at inference time.
+  /// \param allocator optional pointer to a non-CPU device allocator. If nullptr, or if a data transfer implementation
+  ///        is unavailable during adapter creation, the data stays on CPU and is copied to the device at inference time.
   static LoraAdapter CreateLoraAdapter(const std::basic_string<ORTCHAR_T>& adapter_path,
                                        OrtAllocator* allocator);
 
@@ -1487,8 +1487,8 @@ struct LoraAdapter : detail::Base<OrtLoraAdapter> {
   /// The function attempts to load the adapter from the specified byte array.
   /// \param bytes The byte array containing file LoraAdapter format
   /// \param num_bytes The number of bytes in the byte array
-  /// \param allocator optional pointer to a device allocator. If nullptr, the data stays on CPU. It would still
-  ///        be copied to device if required by the model at inference time.
+  /// \param allocator optional pointer to a non-CPU device allocator. If nullptr, or if a data transfer implementation
+  ///        is unavailable during adapter creation, the data stays on CPU and is copied to the device at inference time.
   static LoraAdapter CreateLoraAdapterFromArray(const void* bytes, size_t num_bytes,
                                                 OrtAllocator* allocator);
 };

--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -1478,7 +1478,8 @@ struct LoraAdapter : detail::Base<OrtLoraAdapter> {
   /// The function attempts to load the adapter from the specified file
   /// \param adapter_path The path to the Lora adapter
   /// \param allocator optional pointer to a non-CPU device allocator. If nullptr, or if a data transfer implementation
-  ///        is unavailable during adapter creation, the data stays on CPU and is copied to the device at inference time.
+  ///        is unavailable during adapter creation, the data stays on CPU and is copied to the device at inference time
+  ///        if required by the model.
   static LoraAdapter CreateLoraAdapter(const std::basic_string<ORTCHAR_T>& adapter_path,
                                        OrtAllocator* allocator);
 
@@ -1488,7 +1489,8 @@ struct LoraAdapter : detail::Base<OrtLoraAdapter> {
   /// \param bytes The byte array containing file LoraAdapter format
   /// \param num_bytes The number of bytes in the byte array
   /// \param allocator optional pointer to a non-CPU device allocator. If nullptr, or if a data transfer implementation
-  ///        is unavailable during adapter creation, the data stays on CPU and is copied to the device at inference time.
+  ///        is unavailable during adapter creation, the data stays on CPU and is copied to the device at inference time
+  ///        if required by the model.
   static LoraAdapter CreateLoraAdapterFromArray(const void* bytes, size_t num_bytes,
                                                 OrtAllocator* allocator);
 };

--- a/onnxruntime/core/session/lora_adapters.cc
+++ b/onnxruntime/core/session/lora_adapters.cc
@@ -106,10 +106,15 @@ LoraAdapter::BuildParamsValues(const adapters::Adapter* adapter) const {
 
   std::unique_ptr<IDataTransfer> data_transfer;
   if (device_allocator_) {
-    data_transfer = GetDataTransfer(device_allocator_->Info());
-    if (data_transfer == nullptr) {
-      ORT_THROW("Data transfer is not available for the specified device allocator, it also must not be a CPU allocator");
+    const auto& allocator_info = device_allocator_->Info();
+    if (allocator_info.device.Type() == OrtDevice::CPU) {
+      ORT_THROW("The specified allocator must be a device allocator");
     }
+
+    data_transfer = GetDataTransfer(allocator_info);
+    // Plugin EP data transfers are registered with the environment/session and are not
+    // available during adapter creation. Keep the mapped CPU values in that case so Run()
+    // can copy them through the session's data transfer manager.
   }
 
   const auto* params = adapter->parameters();

--- a/onnxruntime/test/lora/lora_test.cc
+++ b/onnxruntime/test/lora/lora_test.cc
@@ -591,12 +591,11 @@ TEST(LoraAdapterTest, CudaPluginRunCopiesMappedValues) {
   session_options.AppendExecutionProvider_V2(*ort_env, {cuda_device}, Ort::KeyValuePairs{});
   Ort::Session session(*ort_env, ORT_TSTR("testdata/lora/two_params_lora_model.onnx"), session_options);
   auto input_devices = session.GetEpDeviceForInputs();
-  ASSERT_EQ(input_devices.size(), 3U);
-  for (size_t i = 1; i < input_devices.size(); ++i) {
-    ASSERT_NE(input_devices[i], nullptr);
-    EXPECT_EQ(std::string_view{input_devices[i].EpName()},
-              dynamic_plugin_ep_infra::kCudaExecutionProviderPluginName);
-  }
+  // LoRA parameters are overridable initializers, so only input_x is included in the session input devices.
+  ASSERT_EQ(input_devices.size(), 1U);
+  ASSERT_NE(input_devices[0], nullptr);
+  EXPECT_EQ(std::string_view{input_devices[0].EpName()},
+            dynamic_plugin_ep_infra::kCudaExecutionProviderPluginName);
 
   Ort::RunOptions run_options;
   run_options.AddActiveLoraAdapter(adapter);

--- a/onnxruntime/test/lora/lora_test.cc
+++ b/onnxruntime/test/lora/lora_test.cc
@@ -13,9 +13,12 @@
 #if !defined(ORT_MINIMAL_BUILD) && defined(USE_CUDA) && defined(ORT_UNIT_TEST_HAS_CUDA_PLUGIN_EP) && \
     defined(ORT_UNIT_TEST_ENABLE_DYNAMIC_PLUGIN_EP_USAGE)
 #include "test/unittest_util/test_dynamic_plugin_ep.h"
+
+extern std::unique_ptr<Ort::Env> ort_env;
 #endif
 
 #include "gtest/gtest.h"
+#include <array>
 #include <cmath>
 
 #include "test/util/include/asserts.h"
@@ -559,6 +562,67 @@ TEST(LoraAdapterTest, CudaPluginAllocatorKeepsMappedValues) {
   adapter.Load(GenerateTestParameters<float>()());
 
   VerifyMappedParametersAreUsed(adapter);
+}
+
+TEST(LoraAdapterTest, CudaPluginRunCopiesMappedValues) {
+  const auto ep_name = dynamic_plugin_ep_infra::GetEpName();
+  if (!ep_name.has_value() || *ep_name != dynamic_plugin_ep_infra::kCudaExecutionProviderPluginName) {
+    GTEST_SKIP() << "CUDA plugin EP is not registered";
+  }
+
+  Ort::ConstEpDevice cuda_device;
+  for (const auto& ep_device : ort_env->GetEpDevices()) {
+    if (std::string_view{ep_device.EpName()} == dynamic_plugin_ep_infra::kCudaExecutionProviderPluginName) {
+      cuda_device = ep_device;
+      break;
+    }
+  }
+  ASSERT_NE(cuda_device, nullptr);
+
+  auto device_memory_info = cuda_device.GetMemoryInfo(OrtDeviceMemoryType_DEFAULT);
+  ASSERT_NE(device_memory_info, nullptr);
+  auto allocator = ort_env->GetSharedAllocator(device_memory_info);
+  ASSERT_NE(allocator, nullptr);
+
+  constexpr const ORTCHAR_T* adapter_path = ORT_TSTR("testdata/lora/two_params_lora_model.onnx_adapter");
+  auto adapter = Ort::LoraAdapter::CreateLoraAdapter(adapter_path, allocator);
+
+  Ort::SessionOptions session_options;
+  session_options.AppendExecutionProvider_V2(*ort_env, {cuda_device}, Ort::KeyValuePairs{});
+  Ort::Session session(*ort_env, ORT_TSTR("testdata/lora/two_params_lora_model.onnx"), session_options);
+  auto input_devices = session.GetEpDeviceForInputs();
+  ASSERT_EQ(input_devices.size(), 3U);
+  for (size_t i = 1; i < input_devices.size(); ++i) {
+    ASSERT_NE(input_devices[i], nullptr);
+    EXPECT_EQ(std::string_view{input_devices[i].EpName()},
+              dynamic_plugin_ep_infra::kCudaExecutionProviderPluginName);
+  }
+
+  Ort::RunOptions run_options;
+  run_options.AddActiveLoraAdapter(adapter);
+
+  constexpr std::array<int64_t, 2> input_shape{4, 4};
+  std::array<float, 16> input{};
+  input.fill(1.0f);
+  auto input_value = Ort::Value::CreateTensor<float>(
+      Ort::MemoryInfo::CreateCpu(OrtDeviceAllocator, OrtMemTypeCPU),
+      input.data(), input.size(), input_shape.data(), input_shape.size());
+
+  constexpr const char* input_names[]{"input_x"};
+  constexpr const char* output_names[]{"output"};
+  auto outputs = session.Run(run_options, input_names, &input_value, 1, output_names, 1);
+
+  constexpr std::array<float, 16> expected_output{
+      154.f, 176.f, 198.f, 220.f,
+      154.f, 176.f, 198.f, 220.f,
+      154.f, 176.f, 198.f, 220.f,
+      154.f, 176.f, 198.f, 220.f};
+  ASSERT_EQ(outputs.size(), 1U);
+  ASSERT_EQ(outputs[0].GetTensorTypeAndShapeInfo().GetElementCount(), expected_output.size());
+  const auto* output = outputs[0].GetTensorData<float>();
+  for (size_t i = 0; i < expected_output.size(); ++i) {
+    EXPECT_NEAR(output[i], expected_output[i], 0.06f);
+  }
 }
 #endif
 

--- a/onnxruntime/test/lora/lora_test.cc
+++ b/onnxruntime/test/lora/lora_test.cc
@@ -10,6 +10,10 @@
 #include "core/session/lora_adapters.h"
 #include "lora/adapter_format_version.h"
 #include "lora/adapter_format_utils.h"
+#if !defined(ORT_MINIMAL_BUILD) && defined(USE_CUDA) && defined(ORT_UNIT_TEST_HAS_CUDA_PLUGIN_EP) && \
+    defined(ORT_UNIT_TEST_ENABLE_DYNAMIC_PLUGIN_EP_USAGE)
+#include "test/unittest_util/test_dynamic_plugin_ep.h"
+#endif
 
 #include "gtest/gtest.h"
 #include <cmath>
@@ -478,6 +482,85 @@ TEST(LoraAdapterTest, CreateOrtValueOverLoraParameter_BoolDataType) {
 }
 
 #endif  // ORT_NO_EXCEPTIONS
+
+namespace {
+
+class NoDataTransferAllocator final : public IAllocator {
+ public:
+  NoDataTransferAllocator()
+      : IAllocator(OrtMemoryInfo("NoDataTransfer", OrtDeviceAllocator,
+                                 OrtDevice(OrtDevice::GPU, OrtDevice::MemType::DEFAULT,
+                                           OrtDevice::VendorIds::NONE, 0))) {}
+
+  void* Alloc(size_t) override {
+    ++allocation_count_;
+    return nullptr;
+  }
+
+  void Free(void*) override {}
+
+  size_t AllocationCount() const {
+    return allocation_count_;
+  }
+
+ private:
+  ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(NoDataTransferAllocator);
+  size_t allocation_count_{0};
+};
+
+void VerifyMappedParametersAreUsed(const lora::LoraAdapter& adapter) {
+  auto [begin, end] = adapter.GetParamIterators();
+  for (; begin != end; ++begin) {
+    const auto& param = begin->second;
+    EXPECT_EQ(&param.GetMapped(), &param.GetDeviceOrMapped());
+    EXPECT_EQ(param.GetDeviceOrMapped().Get<Tensor>().Location().device.Type(), OrtDevice::CPU);
+  }
+}
+
+}  // namespace
+
+TEST(LoraAdapterTest, UnavailableDataTransferKeepsMappedValues) {
+  auto allocator = std::make_shared<NoDataTransferAllocator>();
+  auto* allocator_ptr = allocator.get();
+  lora::LoraAdapter adapter(std::move(allocator));
+
+  adapter.Load(GenerateTestParameters<float>()());
+
+  EXPECT_EQ(allocator_ptr->AllocationCount(), 0U);
+  VerifyMappedParametersAreUsed(adapter);
+}
+
+#ifndef ORT_NO_EXCEPTIONS
+TEST(LoraAdapterTest, CpuAllocatorIsRejected) {
+  auto cpu_ep = DefaultCpuExecutionProvider();
+  auto cpu_allocator = cpu_ep->CreatePreferredAllocators()[0];
+  lora::LoraAdapter adapter(std::move(cpu_allocator));
+
+  EXPECT_THROW(adapter.Load(GenerateTestParameters<float>()()), OnnxRuntimeException);
+}
+#endif
+
+#if !defined(ORT_MINIMAL_BUILD) && defined(USE_CUDA) && defined(ORT_UNIT_TEST_HAS_CUDA_PLUGIN_EP) && \
+    defined(ORT_UNIT_TEST_ENABLE_DYNAMIC_PLUGIN_EP_USAGE)
+TEST(LoraAdapterTest, CudaPluginAllocatorKeepsMappedValues) {
+  const auto ep_name = dynamic_plugin_ep_infra::GetEpName();
+  if (!ep_name.has_value() || *ep_name != dynamic_plugin_ep_infra::kCudaExecutionProviderPluginName) {
+    GTEST_SKIP() << "CUDA plugin EP is not registered";
+  }
+
+  auto cuda_ep = DefaultCudaExecutionProvider();
+  ASSERT_NE(cuda_ep, nullptr);
+  auto cuda_allocators = cuda_ep->CreatePreferredAllocators();
+  ASSERT_FALSE(cuda_allocators.empty());
+  ASSERT_EQ(cuda_allocators[0]->Info().device.Type(), OrtDevice::GPU);
+  ASSERT_EQ(cuda_allocators[0]->Info().device.Vendor(), OrtDevice::VendorIds::NVIDIA);
+
+  lora::LoraAdapter adapter(std::move(cuda_allocators[0]));
+  adapter.Load(GenerateTestParameters<float>()());
+
+  VerifyMappedParametersAreUsed(adapter);
+}
+#endif
 
 #ifdef USE_CUDA
 TEST(LoraAdapterTest, VerifyDeviceCopy) {


### PR DESCRIPTION
Allow LoRA adapters to work with plugin EP device allocators when a data transfer implementation is not available during adapter creation.

Provider-bridge EPs continue to copy adapter parameters eagerly. For plugin EPs, adapter parameters remain CPU-backed and are copied by the session through its plugin-aware data transfer manager during inference.