### PR TITLE
avoid softsign unit test failure

### DIFF
--- a/onnxruntime/core/providers/cpu/activation/activations.h
+++ b/onnxruntime/core/providers/cpu/activation/activations.h
@@ -170,6 +170,13 @@ struct Softsign : public ElementWiseRangedTransform<T> {
     T* output_ptr = this->output + first;
     ConstEigenVectorArrayMap<T> xm(this->input + first, len);
     EigenVectorArrayMap<T> ym(output_ptr, len);
+    // Do not rewrite this as (1 + xm.abs()).inverse() * xm. Eigen's packet version of inverse() is
+    // internal::preciprocal(), which is a reciprocal estimate instruction plus a Newton-Raphson step
+    // rather than a real division on both x86 (rcp_ps, when built with FMA available) and ARM32
+    // (NEON). Those instructions do not produce subnormal results, so for x = +/-FLT_MAX, where
+    // 1 / (1 + |x|) ~= 2.94e-39 is subnormal, the estimate is 0 and Newton-Raphson cannot recover
+    // from it. That yields +/-0 instead of +/-1. pdiv(), which this expression maps to, is a true
+    // IEEE division on x86 and rescales its operands to avoid the same underflow on NEON.
     ym = xm / (1 + xm.abs());
   }
 };

--- a/onnxruntime/core/providers/cpu/activation/activations.h
+++ b/onnxruntime/core/providers/cpu/activation/activations.h
@@ -170,7 +170,7 @@ struct Softsign : public ElementWiseRangedTransform<T> {
     T* output_ptr = this->output + first;
     ConstEigenVectorArrayMap<T> xm(this->input + first, len);
     EigenVectorArrayMap<T> ym(output_ptr, len);
-    ym = (1 + xm.abs()).inverse() * xm;
+    ym = xm / (1 + xm.abs());
   }
 };
 

--- a/onnxruntime/test/providers/cpu/activation/activation_op_test.cc
+++ b/onnxruntime/test/providers/cpu/activation/activation_op_test.cc
@@ -800,32 +800,7 @@ TEST_F(ActivationOpNoInfTest, Softsign) {
   TestActivationOp<float>(
       "Softsign",
       input_values,
-      [](float x) {
-        auto result = x / (1 + std::abs(x));
-
-#if defined(__arm__)
-        // Softsign uses Eigen inverse(), which on ARM32 results in a different value when x is FLT_MAX or -FLT_MAX
-        // 3.40282347e+38 -> 0 with ARM32 inverse() vs something like 2.939e-39#DEN with other platforms.
-        //
-        // Possibly explained by https://en.wikipedia.org/wiki/ARM_architecture#Advanced_SIMD_(Neon)
-        // 'A quirk of Neon in Armv7 devices is that it flushes all subnormal numbers to zero'
-        //
-        // c.f.
-        // cmake\external\eigen\Eigen\src\Core\arch\SSE\PacketMath.h uses _mm_div_ps for 'pdiv<Packet4f>'
-        // cmake\external\eigen\Eigen\src\Core\arch\NEON\PacketMath.h uses a custom implementation for 'pdiv<Packet4f>'
-        //
-        // Special case the expected values to allow for that. If handling FLT_MAX more consistently is required
-        // we'd need to not use Eigen for Softsign on ARM32.
-        //
-        if (x == FLT_MAX) {
-          result = 0.;
-        } else if (x == -FLT_MAX) {
-          result = -0.;
-        }
-#endif
-
-        return result;
-      },
+      [](float x) { return x / (1 + std::abs(x)); },
       {}, {}, false);  // Disable TensorRT because result mismatches
 }
 


### PR DESCRIPTION
### Description

Compute the CPU Softsign kernel as `x / (1 + |x|)` instead of `(1 + |x|).inverse() * x`, and remove the ARM32 workaround in `ActivationOpNoInfTest.Softsign` that the old spelling required.

Eigen maps the packet version of `inverse()` to `internal::preciprocal()`. Under `EIGEN_FAST_MATH` (the default), that is not a division: on x86 with FMA available it is `rcp_ps` plus one Newton-Raphson step, and on ARM32 it is the NEON reciprocal estimate.

Those instructions do not produce subnormal results. For `x = FLT_MAX`, `1 + |x|` is still `FLT_MAX` and the true reciprocal `1/FLT_MAX ~= 2.94e-39` is subnormal, so the estimate comes back as `0`, and the Newton-Raphson refinement `x * (2 - a * x)` cannot recover from a zero estimate. `Softsign(±FLT_MAX)` therefore returned `±0` instead of `±1`. Eigen documents the limitation itself in `Eigen/src/Core/MathFunctionsImpl.h`: *"Positive denormals are treated as zero."*

`pdiv()`, which `x / (1 + |x|)` maps to, is a true IEEE division on x86, and on NEON Eigen rescales the operands specifically to avoid this underflow (`Eigen/src/Core/arch/NEON/PacketMath.h`: *"if b is large, NEON intrinsics will flush preciprocal(b) to zero"*). So the new spelling gives exactly `±1` on both, and the `#if defined(__arm__)` special case added in #5394 is obsolete. A comment on the kernel records why the reciprocal-and-multiply form must not be reintroduced.

The division is also what the ONNX spec states, and what every other Softsign in this repo already does — `rnn_activation_functors.h` and the CUDA kernel in `activations_impl.cu`. The Eigen CPU kernel was the only one using the reciprocal form.

### Motivation and Context

Fixes: https://github.com/microsoft/onnxruntime/issues/27923

`ActivationOpNoInfTest.Softsign` fails on the `FLT_MAX` / `-FLT_MAX` inputs when the build targets a CPU with FMA:

```
[  FAILED  ] ActivationOpNoInfTest.Softsign
```

This reproduces with `-march=haswell`, and on distributions whose compiler defaults to `x86-64-v3` (`__FMA__` and `__AVX2__` defined with no explicit flags) it happens with a plain `./build.sh --config Release`. A baseline SSE2 build uses `pdiv()` for the reciprocal and is unaffected, which is why CI has not caught it.

Which elements are affected depends on whether they land in the vectorized body or in the scalar prologue/epilogue, since the scalar functor still performs a real `1/a` division — so the failure looks position-dependent rather than value-dependent at first.

The same root cause was previously seen on ARM32 and worked around in the test rather than the kernel (#5394). Fixing the kernel covers both platforms.

Tested with `--config Release --build_shared_lib` and `CXXFLAGS="-march=haswell -mtune=skylake-avx512"`: `onnxruntime_provider_test --gtest_filter='ActivationOp*'` gives 31 passed, 2 skipped (pre-existing WebGPU PRelu skips), and the full ctest run is 10/10 green. The ARM32 claim is based on reading Eigen's `pdiv_float_common`, not on an armv7 test run.
