### PR TITLE
Support environment-wide WebGPU device configuration on web

### DIFF
--- a/docs/design/onnxruntime_web_jsep_to_webgpu_ep_migration.md
+++ b/docs/design/onnxruntime_web_jsep_to_webgpu_ep_migration.md
@@ -197,12 +197,13 @@ Phase 0 is the pre-work, in three parts:
      (`webgpu_context.h`) defaults to `WGPUPowerPreference_HighPerformance`. Left alone, the flip would move
      users who never expressed a preference onto a discrete GPU, so the wiring needs a behavior-preserving
      default.
-   - **`adapter` / `forceFallbackAdapter`** — both are `@deprecated` in `js/common/lib/env.ts`, which names
-     `env.webgpu.device` as the replacement. That pointer is wrong: `env.webgpu.device` is output-only — both
-     paths write it after init and neither reads it. Custom devices go through the per-session option instead,
-     `executionProviders: [{ name: 'webgpu', device }]`, which `session-options.ts` already registers via
-     `webgpuRegisterDevice`. Document `adapter` / `forceFallbackAdapter` as no-ops on the native path, and fix
-     the `env.webgpu.device` doc comment.
+   - **`adapter` / `forceFallbackAdapter`** — both are `@deprecated` in `js/common/lib/env.ts`; use
+     `env.webgpu.device` to configure an application-created device instead. The native WebGPU EP imports that device
+     as environment context 0, so every session and the environment shared allocator use the same device. The legacy
+     per-session `device` option remains as a deprecated compatibility path and promotes the first supplied device to
+     the environment default. A different device is rejected; multi-device web environments are not supported.
+     `env.webgpu.requiredFeatures` is combined with ORT's requirements when ORT creates the device, and is validated
+     against an application-created device.
    - Drop the now-dead `navigator.gpu.requestAdapter()` call on the native path once nothing consumes its result.
 5. **Profiling.** `env.webgpu.profiling.ondata` is a JSEP-only mechanism: a per-dispatch JavaScript callback
    receiving `kernelId` / `kernelType` / `kernelName` / `programName`, timestamps and input/output tensor metadata
@@ -324,7 +325,7 @@ the deletion commit.
 | Default bundle silently narrows its operator/type surface (reduced-size build args) | High if unaddressed | Measure builds A/B/C and resolve before the flip (§7) |
 | int64 behavior change vs. JSEP | Low | None by default (native-off matches JSEP); `enableInt64 = 1` is an opt-in tradeoff |
 | Proxy / IO-binding / WebNN unexercised in the native-WebGPU build in CI | Unknown | Validate before flip (§8) |
-| Global `env.webgpu.*` settings dropped on native | Medium | `powerPreference` wired with a behavior-preserving default when unset; `adapter` / `forceFallbackAdapter` documented as no-ops, custom devices directed to the per-session `device` option — release gate (§8.4, §9) |
+| Global `env.webgpu.*` settings dropped on native | Medium | `powerPreference` wired with a behavior-preserving default when unset; application-created devices use the environment-wide `env.webgpu.device` setting — release gate (§8.4, §9) |
 | `env.webgpu.profiling.ondata` has no native equivalent | Low | Documented as JSEP-only; native profiling wiring is a Phase 2 prerequisite (§8.5, §10.1) |
 | Windows/ADO produces no WebGPU-EP WASM build | Medium | Add a `BuildWebGPU` leg to `win-wasm-ci.yml` before Phase 2 (§8.6) |
 | `post-webnn.js` linkage changes for WebNN once JSEP is removed | Medium | WebNN smoke test on the Phase 2 build, not just a compile check (§10.3) |

--- a/js/common/lib/env.ts
+++ b/js/common/lib/env.ts
@@ -226,16 +226,32 @@ export declare namespace Env {
     /**
      * Set or get the GPU device for WebGPU.
      *
-     * There are 3 valid scenarios of accessing this property:
-     * - Set a value before the first WebGPU inference session is created. The value will be used by the WebGPU backend
-     * to perform calculations. If the value is not a `GPUDevice` object, an error will be thrown.
-     * - Get the value before the first WebGPU inference session is created. This will try to create a new GPUDevice
-     * instance. Returns a `Promise` that resolves to a `GPUDevice` object.
-     * - Get the value after the first WebGPU inference session is created. Returns a resolved `Promise` to the
-     * `GPUDevice` object used by the WebGPU backend.
+     * Set this property before the first WebGPU inference session is created to use an application-created device.
+     * All WebGPU sessions and the environment shared allocator use this device. The device cannot be replaced after
+     * the WebGPU backend starts initializing.
+     *
+     * Reading this property does not create a device. It returns the configured application device before
+     * initialization, `undefined` if no device has been configured, and the effective device after initialization.
+     * An application-created device cannot be used when {@link WebAssemblyFlags.proxy} is enabled because WebGPU
+     * objects cannot be transferred to the proxy worker.
+     *
+     * When use with TypeScript, the type of this property is `GPUDevice` defined in "@webgpu/types".
      */
-    get device(): Promise<TryGetGlobalType<'GPUDevice'>>;
+    get device(): TryGetGlobalType<'GPUDevice'> | undefined;
     set device(value: TryGetGlobalType<'GPUDevice'>);
+    /**
+     * Features required by the application on the environment WebGPU device.
+     *
+     * When ONNX Runtime creates the device, these features are combined with its internally selected features. Device
+     * creation fails if the selected adapter does not support one of them. For an application-created device, ONNX
+     * Runtime validates that every requested feature is already enabled.
+     *
+     * Values are `GPUFeatureName` strings defined by the WebGPU specification. This property must be set before the
+     * first WebGPU inference session is created.
+     *
+     * @defaultValue `[]`
+     */
+    requiredFeatures?: readonly string[];
     /**
      * Set or get whether validate input content.
      *

--- a/js/common/lib/inference-session.ts
+++ b/js/common/lib/inference-session.ts
@@ -325,6 +325,10 @@ export declare namespace InferenceSession {
 
     /**
      * Specify an optional WebGPU device to be used by the WebGPU execution provider.
+     *
+     * @deprecated Set {@link Env.WebGpuFlags.device | ort.env.webgpu.device} before creating a session. The first
+     * device supplied through this option is promoted to the environment device for compatibility. Later sessions
+     * must use the same device.
      */
     device?: TryGetGlobalType<'GPUDevice'>;
   }

--- a/js/common/test/type-tests/env-webgpu-device.ts
+++ b/js/common/test/type-tests/env-webgpu-device.ts
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { env } from 'onnxruntime-common';
+
+// Reading the device is synchronous and may return undefined before WebGPU initialization.
+//
+// {type-tests}|pass
+const device: unknown | undefined = env.webgpu.device;
+void device;
+
+// {type-tests}|fail|1|2322
+const devicePromise: Promise<unknown> = env.webgpu.device;
+void devicePromise;
+
+// Applications can request additional features for an ORT-created device.
+//
+// {type-tests}|pass
+env.webgpu.requiredFeatures = ['bgra8unorm-storage'];

--- a/js/web/lib/wasm/jsep/backend-webgpu.ts
+++ b/js/web/lib/wasm/jsep/backend-webgpu.ts
@@ -226,46 +226,64 @@ export class WebGpuBackend {
    */
   sessionExternalDataMapping: Map<number, Map<number, [number, GPUBuffer]>> = new Map();
 
-  async initialize(env: Env, adapter: GPUAdapter): Promise<void> {
+  async initialize(env: Env, adapter?: GPUAdapter, externalDevice?: GPUDevice): Promise<void> {
     this.env = env;
-    const requiredFeatures: GPUFeatureName[] = [];
-    const deviceDescriptor: GPUDeviceDescriptor = {
-      requiredLimits: {
-        maxComputeWorkgroupStorageSize: adapter.limits.maxComputeWorkgroupStorageSize,
-        maxComputeWorkgroupsPerDimension: adapter.limits.maxComputeWorkgroupsPerDimension,
-        maxStorageBufferBindingSize: adapter.limits.maxStorageBufferBindingSize,
-        maxBufferSize: adapter.limits.maxBufferSize,
-        maxComputeInvocationsPerWorkgroup: adapter.limits.maxComputeInvocationsPerWorkgroup,
-        maxComputeWorkgroupSizeX: adapter.limits.maxComputeWorkgroupSizeX,
-        maxComputeWorkgroupSizeY: adapter.limits.maxComputeWorkgroupSizeY,
-        maxComputeWorkgroupSizeZ: adapter.limits.maxComputeWorkgroupSizeZ,
-      },
-      requiredFeatures,
-    };
+    const requiredFeatures: GPUFeatureName[] = [...(env.webgpu.requiredFeatures ?? [])] as GPUFeatureName[];
+    if (externalDevice) {
+      for (const feature of requiredFeatures) {
+        if (!externalDevice.features.has(feature)) {
+          throw new Error(`The application-created WebGPU device does not have required feature: ${feature}.`);
+        }
+      }
+      this.device = externalDevice;
+      this.adapterInfo = new AdapterInfoImpl(externalDevice.adapterInfo);
+    } else {
+      if (!adapter) {
+        throw new Error('A GPUAdapter is required when ONNX Runtime creates the WebGPU device.');
+      }
+      for (const feature of requiredFeatures) {
+        if (!adapter.features.has(feature)) {
+          throw new Error(`Required WebGPU feature is not supported by the selected adapter: ${feature}.`);
+        }
+      }
+      const deviceDescriptor: GPUDeviceDescriptor = {
+        requiredLimits: {
+          maxComputeWorkgroupStorageSize: adapter.limits.maxComputeWorkgroupStorageSize,
+          maxComputeWorkgroupsPerDimension: adapter.limits.maxComputeWorkgroupsPerDimension,
+          maxStorageBufferBindingSize: adapter.limits.maxStorageBufferBindingSize,
+          maxBufferSize: adapter.limits.maxBufferSize,
+          maxComputeInvocationsPerWorkgroup: adapter.limits.maxComputeInvocationsPerWorkgroup,
+          maxComputeWorkgroupSizeX: adapter.limits.maxComputeWorkgroupSizeX,
+          maxComputeWorkgroupSizeY: adapter.limits.maxComputeWorkgroupSizeY,
+          maxComputeWorkgroupSizeZ: adapter.limits.maxComputeWorkgroupSizeZ,
+        },
+        requiredFeatures,
+      };
 
-    // Try requiring WebGPU features
-    const requireFeatureIfAvailable = (feature: GPUFeatureName) =>
-      adapter.features.has(feature) && requiredFeatures.push(feature) && true;
-    // Try chromium-experimental-timestamp-query-inside-passes and fallback to timestamp-query
-    if (!requireFeatureIfAvailable('chromium-experimental-timestamp-query-inside-passes' as GPUFeatureName)) {
-      requireFeatureIfAvailable('timestamp-query');
+      // Try requiring WebGPU features
+      const requireFeatureIfAvailable = (feature: GPUFeatureName) =>
+        adapter.features.has(feature) && !requiredFeatures.includes(feature) && requiredFeatures.push(feature) && true;
+      // Try chromium-experimental-timestamp-query-inside-passes and fallback to timestamp-query
+      if (!requireFeatureIfAvailable('chromium-experimental-timestamp-query-inside-passes' as GPUFeatureName)) {
+        requireFeatureIfAvailable('timestamp-query');
+      }
+      requireFeatureIfAvailable('shader-f16');
+      // Try subgroups
+      requireFeatureIfAvailable('subgroups');
+
+      this.device = await adapter.requestDevice(deviceDescriptor);
+      const adapterWithRequestInfo = adapter as GPUAdapter & {
+        requestAdapterInfo?: () => Promise<GPUAdapterInfo>;
+      };
+      const adapterInfo =
+        adapter.info ??
+        (typeof adapterWithRequestInfo.requestAdapterInfo === 'function'
+          ? await adapterWithRequestInfo.requestAdapterInfo()
+          : undefined);
+      // adapterInfo is optional and may not be available in all browsers.
+      // AdapterInfoImpl will handle the case when adapterInfo is undefined.
+      this.adapterInfo = new AdapterInfoImpl(adapterInfo);
     }
-    requireFeatureIfAvailable('shader-f16');
-    // Try subgroups
-    requireFeatureIfAvailable('subgroups');
-
-    this.device = await adapter.requestDevice(deviceDescriptor);
-    const adapterWithRequestInfo = adapter as GPUAdapter & {
-      requestAdapterInfo?: () => Promise<GPUAdapterInfo>;
-    };
-    const adapterInfo =
-      adapter.info ??
-      (typeof adapterWithRequestInfo.requestAdapterInfo === 'function'
-        ? await adapterWithRequestInfo.requestAdapterInfo()
-        : undefined);
-    // adapterInfo is optional and may not be available in all browsers.
-    // AdapterInfoImpl will handle the case when adapterInfo is undefined.
-    this.adapterInfo = new AdapterInfoImpl(adapterInfo);
     this.gpuDataManager = createGpuDataManager(this);
     this.programManager = new ProgramManager(this);
     this.kernels = new Map();

--- a/js/web/lib/wasm/jsep/init.ts
+++ b/js/web/lib/wasm/jsep/init.ts
@@ -184,12 +184,14 @@ class ComputeContextImpl implements ComputeContext {
  * @param module - the ORT WebAssembly module
  * @param env - the ORT environment variable (ort.env)
  * @param gpuAdapter - the pre-created GPU adapter
+ * @param gpuDevice - the application-created GPU device
  */
 export const init = async (
   name: 'webgpu' | 'webnn',
   module: OrtWasmModule,
   env: Env,
   gpuAdapter?: GPUAdapter,
+  gpuDevice?: GPUDevice,
 ): Promise<void> => {
   const jsepInit = module.jsepInit;
   if (!jsepInit) {
@@ -200,7 +202,7 @@ export const init = async (
     // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
     const webGpuBackendImpl = require('./backend-webgpu').WebGpuBackend;
     const backend = new webGpuBackendImpl();
-    await backend.initialize(env, gpuAdapter!);
+    await backend.initialize(env, gpuAdapter, gpuDevice);
 
     jsepInit('webgpu', [
       // backend

--- a/js/web/lib/wasm/proxy-wrapper.ts
+++ b/js/web/lib/wasm/proxy-wrapper.ts
@@ -92,6 +92,10 @@ export const initializeWebAssemblyAndOrtRuntime = async (): Promise<void> => {
   initializing = true;
 
   if (!BUILD_DEFS.DISABLE_WASM_PROXY && isProxy()) {
+    if (env.webgpu.device !== undefined) {
+      initializing = false;
+      throw new Error('`env.webgpu.device` cannot be used when `env.wasm.proxy` is enabled.');
+    }
     return new Promise<void>((resolve, reject) => {
       proxyWorker?.terminate();
 

--- a/js/web/lib/wasm/session-options.ts
+++ b/js/web/lib/wasm/session-options.ts
@@ -6,6 +6,8 @@ import type { InferenceSession } from 'onnxruntime-common';
 import { getInstance } from './wasm-factory';
 import { allocWasmString, checkLastError, iterateExtraOptions } from './wasm-utils';
 
+let didWarnWebGpuSessionDeviceDeprecated = false;
+
 const getGraphOptimzationLevel = (graphOptimizationLevel: string | unknown): number => {
   switch (graphOptimizationLevel) {
     case 'disabled':
@@ -109,6 +111,14 @@ const setExecutionProviders = async (
             if (webgpuOptions.device) {
               if (typeof GPUDevice !== 'undefined' && webgpuOptions.device instanceof GPUDevice) {
                 customDevice = webgpuOptions.device;
+                if (!didWarnWebGpuSessionDeviceDeprecated) {
+                  // eslint-disable-next-line no-console
+                  console.warn(
+                    'The WebGPU execution provider `device` option is deprecated. ' +
+                      'Set `ort.env.webgpu.device` before creating a session instead.',
+                  );
+                  didWarnWebGpuSessionDeviceDeprecated = true;
+                }
               } else {
                 throw new Error('Invalid GPU device set in WebGPU EP options.');
               }
@@ -156,12 +166,8 @@ const setExecutionProviders = async (
             }
           }
 
-          const info = getInstance().webgpuRegisterDevice!(customDevice);
-          if (info) {
-            const [deviceId, instanceHandle, deviceHandle] = info;
-            appendEpOption(epOptions, 'deviceId', deviceId.toString(), allocs);
-            appendEpOption(epOptions, 'webgpuInstance', instanceHandle.toString(), allocs);
-            appendEpOption(epOptions, 'webgpuDevice', deviceHandle.toString(), allocs);
+          if (getInstance().webgpuRegisterDevice!(customDevice) !== 0) {
+            checkLastError("Can't configure the default WebGPU device.");
           }
         } else {
           epName = 'JS';

--- a/js/web/lib/wasm/wasm-core-impl.ts
+++ b/js/web/lib/wasm/wasm-core-impl.ts
@@ -86,6 +86,34 @@ const initOrt = (numThreads: number, loggingLevel: number): void => {
   }
 };
 
+const validateGpuDevice = (device: unknown): device is GPUDevice =>
+  typeof device === 'object' &&
+  device !== null &&
+  typeof (device as GPUDevice).createBuffer === 'function' &&
+  typeof (device as GPUDevice).createCommandEncoder === 'function' &&
+  typeof (device as GPUDevice).queue === 'object' &&
+  typeof (device as GPUDevice).features === 'object';
+
+const getRequiredWebGpuFeatures = (value: readonly string[] | undefined): readonly string[] => {
+  if (value === undefined) {
+    return [];
+  }
+  if (!Array.isArray(value)) {
+    throw new Error('`env.webgpu.requiredFeatures` must be an array of GPUFeatureName strings.');
+  }
+
+  const features: string[] = [];
+  for (const feature of value) {
+    if (typeof feature !== 'string' || feature.length === 0 || feature.includes(',')) {
+      throw new Error('`env.webgpu.requiredFeatures` must contain non-empty GPUFeatureName strings without commas.');
+    }
+    if (!features.includes(feature)) {
+      features.push(feature);
+    }
+  }
+  return features;
+};
+
 /**
  * initialize runtime environment.
  * @param env passed in the environment config object.
@@ -107,11 +135,16 @@ export const initEp = async (env: Env, epName: string): Promise<void> => {
 
   // perform WebGPU availability check ( either JSEP or WebGPU EP )
   let webgpuAdapter: GPUAdapter | null = env.webgpu.adapter;
+  const configuredWebGpuDevice = env.webgpu.device;
+  const requiredWebGpuFeatures = getRequiredWebGpuFeatures(env.webgpu.requiredFeatures);
   if (epName === 'webgpu') {
     if (typeof navigator === 'undefined' || !navigator.gpu) {
       throw new Error('WebGPU is not supported in current environment');
     }
-    if (!webgpuAdapter) {
+    if (configuredWebGpuDevice !== undefined && !validateGpuDevice(configuredWebGpuDevice)) {
+      throw new Error('Invalid GPU device set in `env.webgpu.device`. It must be a GPUDevice object.');
+    }
+    if (!BUILD_DEFS.DISABLE_JSEP && !webgpuAdapter && !configuredWebGpuDevice) {
       // if adapter is not set, request a new adapter.
       const powerPreference = env.webgpu.powerPreference;
       if (powerPreference !== undefined && powerPreference !== 'low-power' && powerPreference !== 'high-performance') {
@@ -128,7 +161,7 @@ export const initEp = async (env: Env, epName: string): Promise<void> => {
             'You may need to enable flag "--enable-unsafe-webgpu" if you are using Chrome.',
         );
       }
-    } else {
+    } else if (!BUILD_DEFS.DISABLE_JSEP && webgpuAdapter) {
       // if adapter is set, validate it.
       if (
         typeof webgpuAdapter.limits !== 'object' ||
@@ -152,16 +185,34 @@ export const initEp = async (env: Env, epName: string): Promise<void> => {
     const initJsep = require('./jsep/init').init;
 
     if (epName === 'webgpu') {
-      await initJsep('webgpu', getInstance(), env, webgpuAdapter);
+      await initJsep('webgpu', getInstance(), env, webgpuAdapter ?? undefined, configuredWebGpuDevice);
     }
     if (epName === 'webnn') {
       await initJsep('webnn', getInstance(), env);
     }
   } else {
     if (!BUILD_DEFS.DISABLE_WEBGPU && epName === 'webgpu') {
-      getInstance().webgpuInit!((device) => {
-        env.webgpu.device = device;
+      let effectiveDevice = configuredWebGpuDevice;
+      Object.defineProperty(env.webgpu, 'device', {
+        get: () => effectiveDevice,
+        set: (device: GPUDevice) => {
+          if (!validateGpuDevice(device)) {
+            throw new Error('Invalid GPU device set in `env.webgpu.device`. It must be a GPUDevice object.');
+          }
+          if (device !== effectiveDevice) {
+            throw new Error('The WebGPU device cannot be replaced after the WebGPU backend starts initializing.');
+          }
+        },
+        enumerable: true,
+        configurable: false,
       });
+      if (
+        getInstance().webgpuInit!(configuredWebGpuDevice, requiredWebGpuFeatures, (device) => {
+          effectiveDevice = device;
+        }) !== 0
+      ) {
+        checkLastError("Can't initialize the default WebGPU device.");
+      }
     }
     if (!BUILD_DEFS.DISABLE_WEBNN && epName === 'webnn') {
       // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
@@ -507,6 +558,8 @@ export const createSession = async (
     ]);
     return [sessionHandle, inputNames, outputNames, inputMetadata, outputMetadata];
   } catch (e) {
+    // Clear the temporary WebGPU session-creation state if preparation failed before _OrtCreateSession() was called.
+    wasm.webgpuOnCreateSession?.(0);
     inputNamesUTF8Encoded.forEach((buf) => wasm._OrtFree(buf));
     outputNamesUTF8Encoded.forEach((buf) => wasm._OrtFree(buf));
 

--- a/js/web/lib/wasm/wasm-types.ts
+++ b/js/web/lib/wasm/wasm-types.ts
@@ -139,10 +139,12 @@ export declare namespace JSEP {
 
 export declare namespace WebGpu {
   export interface Module {
-    webgpuInit(setDefaultDevice: (device: GPUDevice) => void): void;
-    webgpuRegisterDevice(
-      device?: GPUDevice,
-    ): undefined | [deviceId: number, instanceHandle: number, deviceHandle: number];
+    webgpuInit(
+      device: GPUDevice | undefined,
+      requiredFeatures: readonly string[],
+      setDefaultDevice: (device: GPUDevice) => void,
+    ): number;
+    webgpuRegisterDevice(device?: GPUDevice): number;
     webgpuOnCreateSession(sessionHandle: number): void;
     webgpuOnReleaseSession(sessionHandle: number): void;
     webgpuRegisterBuffer(buffer: GPUBuffer, sessionHandle: number, bufferHandle?: number): number;
@@ -340,6 +342,9 @@ export declare namespace WebNN {
 
 export interface OrtInferenceAPIs {
   _OrtInit(numThreads: number, loggingLevel: number): number;
+
+  _OrtCreateWebGpuInstance(): number;
+  _OrtConfigureWebGpuDefaultContext(instance: number, device: number, requiredFeatures: number): number;
 
   _OrtGetLastError(errorCodeOffset: number, errorMessageOffset: number): number;
 

--- a/js/web/test/test-runner.ts
+++ b/js/web/test/test-runner.ts
@@ -590,7 +590,10 @@ async function createGpuTensorForInput(cpuTensor: ort.Tensor): Promise<ort.Tenso
   if (!isGpuBufferSupportedType(cpuTensor.type) || Array.isArray(cpuTensor.data)) {
     throw new Error(`createGpuTensorForInput can not work with ${cpuTensor.type} tensor`);
   }
-  const device = await ort.env.webgpu.device;
+  const device = ort.env.webgpu.device;
+  if (!device) {
+    throw new Error('WebGPU device is not initialized.');
+  }
   const gpuBuffer = device.createBuffer({
     // eslint-disable-next-line no-bitwise
     usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE,
@@ -619,7 +622,10 @@ async function createGpuTensorForOutput(type: ort.Tensor.Type, dims: readonly nu
 
   const size = calculateTensorSizeInBytes(tensorDataTypeStringToEnum(type), dims)!;
 
-  const device = await ort.env.webgpu.device;
+  const device = ort.env.webgpu.device;
+  if (!device) {
+    throw new Error('WebGPU device is not initialized.');
+  }
   const gpuBuffer = device.createBuffer({
     // eslint-disable-next-line no-bitwise
     usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE,

--- a/js/web/test/unittests/backends/webgpu/test-env-device.ts
+++ b/js/web/test/unittests/backends/webgpu/test-env-device.ts
@@ -17,7 +17,27 @@ describeWebGpu('#UnitTest# - WebGPU environment device', () => {
   it('uses an application-created device for inference and GPU tensors', async () => {
     const adapter = await navigator.gpu.requestAdapter();
     expect(adapter).not.to.equal(null);
-    const device = await adapter!.requestDevice();
+    const requiredFeatures = [
+      'chromium-experimental-timestamp-query-inside-passes',
+      'timestamp-query',
+      'shader-f16',
+      'subgroups',
+      'subgroup-size-control',
+    ].filter((feature) => adapter!.features.has(feature as GPUFeatureName)) as GPUFeatureName[];
+    const device = await adapter!.requestDevice({
+      // The device is environment-wide, so keep the capabilities used by subsequent WebGPU tests.
+      requiredFeatures,
+      requiredLimits: {
+        maxComputeWorkgroupStorageSize: adapter!.limits.maxComputeWorkgroupStorageSize,
+        maxComputeWorkgroupsPerDimension: adapter!.limits.maxComputeWorkgroupsPerDimension,
+        maxStorageBufferBindingSize: adapter!.limits.maxStorageBufferBindingSize,
+        maxBufferSize: adapter!.limits.maxBufferSize,
+        maxComputeInvocationsPerWorkgroup: adapter!.limits.maxComputeInvocationsPerWorkgroup,
+        maxComputeWorkgroupSizeX: adapter!.limits.maxComputeWorkgroupSizeX,
+        maxComputeWorkgroupSizeY: adapter!.limits.maxComputeWorkgroupSizeY,
+        maxComputeWorkgroupSizeZ: adapter!.limits.maxComputeWorkgroupSizeZ,
+      },
+    });
 
     ort.env.webgpu.device = device;
     expect(ort.env.webgpu.device).to.equal(device);

--- a/js/web/test/unittests/backends/webgpu/test-env-device.ts
+++ b/js/web/test/unittests/backends/webgpu/test-env-device.ts
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { expect } from 'chai';
+import * as ort from 'onnxruntime-common';
+
+const ONNX_MODEL_TEST_ABS_STATIC = Uint8Array.from([
+  8, 9, 58, 83, 10, 31, 10, 7, 105, 110, 112, 117, 116, 95, 48, 18, 8, 111, 117, 116, 112, 117, 116, 95, 48, 26, 3, 65,
+  98, 115, 34, 3, 65, 98, 115, 58, 0, 18, 3, 97, 98, 115, 90, 25, 10, 7, 105, 110, 112, 117, 116, 95, 48, 18, 14, 10,
+  12, 8, 1, 18, 8, 10, 2, 8, 2, 10, 2, 8, 4, 98, 16, 10, 8, 111, 117, 116, 112, 117, 116, 95, 48, 18, 4, 10, 2, 8, 1,
+  66, 4, 10, 0, 16, 21,
+]);
+
+const describeWebGpu = typeof navigator !== 'undefined' && navigator.gpu ? describe : describe.skip;
+
+describeWebGpu('#UnitTest# - WebGPU environment device', () => {
+  it('uses an application-created device for inference and GPU tensors', async () => {
+    const adapter = await navigator.gpu.requestAdapter();
+    expect(adapter).not.to.equal(null);
+    const device = await adapter!.requestDevice();
+
+    ort.env.webgpu.device = device;
+    expect(ort.env.webgpu.device).to.equal(device);
+
+    const inputData = new Float32Array([-1, 2, -3, 4, -5, 6, -7, 8]);
+    const inputBuffer = device.createBuffer({
+      // eslint-disable-next-line no-bitwise
+      usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE,
+      size: inputData.byteLength,
+      mappedAtCreation: true,
+    });
+    new Float32Array(inputBuffer.getMappedRange()).set(inputData);
+    inputBuffer.unmap();
+
+    const outputBuffer = device.createBuffer({
+      // eslint-disable-next-line no-bitwise
+      usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE,
+      size: inputData.byteLength,
+    });
+    const input = ort.Tensor.fromGpuBuffer(inputBuffer, {
+      dataType: 'float32',
+      dims: [2, 4],
+      dispose: () => inputBuffer.destroy(),
+    });
+    const output = ort.Tensor.fromGpuBuffer(outputBuffer, {
+      dataType: 'float32',
+      dims: [2, 4],
+      dispose: () => outputBuffer.destroy(),
+      download: async () => {
+        const stagingBuffer = device.createBuffer({
+          // eslint-disable-next-line no-bitwise
+          usage: GPUBufferUsage.MAP_READ | GPUBufferUsage.COPY_DST,
+          size: outputBuffer.size,
+        });
+        const encoder = device.createCommandEncoder();
+        encoder.copyBufferToBuffer(outputBuffer, 0, stagingBuffer, 0, outputBuffer.size);
+        device.queue.submit([encoder.finish()]);
+        await stagingBuffer.mapAsync(GPUMapMode.READ);
+        const data = new Float32Array(stagingBuffer.getMappedRange().slice(0));
+        stagingBuffer.unmap();
+        stagingBuffer.destroy();
+        return data;
+      },
+    });
+
+    const session = await ort.InferenceSession.create(ONNX_MODEL_TEST_ABS_STATIC, {
+      executionProviders: ['webgpu'],
+    });
+    try {
+      const results = await session.run({ input_0: input }, { output_0: output });
+      const resultData = (await results.output_0.getData()) as Float32Array;
+      expect(Array.from(resultData)).to.deep.equal([1, 2, 3, 4, 5, 6, 7, 8]);
+      expect(ort.env.webgpu.device).to.equal(device);
+    } finally {
+      input.dispose();
+      output.dispose();
+      await session.release();
+    }
+  });
+});

--- a/js/web/test/unittests/index.ts
+++ b/js/web/test/unittests/index.ts
@@ -11,6 +11,7 @@ if (typeof window !== 'undefined') {
   require('./backends/webgl/test-matmul-packed');
 }
 
+require('./backends/webgpu/test-env-device');
 require('./backends/wasm/test-model-metadata');
 
 require('./pool-output-shape');

--- a/onnxruntime/core/providers/webgpu/webgpu_context.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.cc
@@ -74,6 +74,41 @@ DawnPlatform& GetDawnPlatform() {
 }  // namespace
 #endif  // !defined(__wasm__) && !defined(USE_EXTERNAL_DAWN)
 
+wgpu::FeatureName ParseWebGpuFeatureName(std::string_view feature) {
+  static constexpr std::pair<std::string_view, wgpu::FeatureName> kFeatureNames[] = {
+      {"core-features-and-limits", wgpu::FeatureName::CoreFeaturesAndLimits},
+      {"depth-clip-control", wgpu::FeatureName::DepthClipControl},
+      {"depth32float-stencil8", wgpu::FeatureName::Depth32FloatStencil8},
+      {"texture-compression-bc", wgpu::FeatureName::TextureCompressionBC},
+      {"texture-compression-bc-sliced-3d", wgpu::FeatureName::TextureCompressionBCSliced3D},
+      {"texture-compression-etc2", wgpu::FeatureName::TextureCompressionETC2},
+      {"texture-compression-astc", wgpu::FeatureName::TextureCompressionASTC},
+      {"texture-compression-astc-sliced-3d", wgpu::FeatureName::TextureCompressionASTCSliced3D},
+      {"timestamp-query", wgpu::FeatureName::TimestampQuery},
+      {"indirect-first-instance", wgpu::FeatureName::IndirectFirstInstance},
+      {"shader-f16", wgpu::FeatureName::ShaderF16},
+      {"rg11b10ufloat-renderable", wgpu::FeatureName::RG11B10UfloatRenderable},
+      {"bgra8unorm-storage", wgpu::FeatureName::BGRA8UnormStorage},
+      {"float32-filterable", wgpu::FeatureName::Float32Filterable},
+      {"float32-blendable", wgpu::FeatureName::Float32Blendable},
+      {"clip-distances", wgpu::FeatureName::ClipDistances},
+      {"dual-source-blending", wgpu::FeatureName::DualSourceBlending},
+      {"subgroups", wgpu::FeatureName::Subgroups},
+      {"texture-formats-tier1", wgpu::FeatureName::TextureFormatsTier1},
+      {"texture-formats-tier2", wgpu::FeatureName::TextureFormatsTier2},
+      {"primitive-index", wgpu::FeatureName::PrimitiveIndex},
+      {"texture-component-swizzle", wgpu::FeatureName::TextureComponentSwizzle},
+      {"subgroup-size-control", wgpu::FeatureName::SubgroupSizeControl},
+      {"unorm16-texture-formats", wgpu::FeatureName::Unorm16TextureFormats},
+      {"multi-draw-indirect", wgpu::FeatureName::MultiDrawIndirect},
+  };
+
+  const auto entry = std::find_if(std::begin(kFeatureNames), std::end(kFeatureNames),
+                                  [feature](const auto& candidate) { return candidate.first == feature; });
+  ORT_ENFORCE(entry != std::end(kFeatureNames), "Unknown WebGPU required feature: ", feature, ".");
+  return entry->second;
+}
+
 void WebGpuContext::Initialize(const WebGpuContextConfig& config) {
   std::call_once(init_flag_, [this, &config]() {
     max_num_pending_dispatches_ = config.max_num_pending_dispatches;
@@ -155,6 +190,14 @@ void WebGpuContext::Initialize(const WebGpuContextConfig& config) {
 #endif
 
       std::vector<wgpu::FeatureName> required_features = GetAvailableRequiredFeatures(adapter);
+      for (const auto& feature_name : config.required_features) {
+        const auto feature = ParseWebGpuFeatureName(feature_name);
+        ORT_ENFORCE(adapter.HasFeature(feature),
+                    "Required WebGPU feature is not supported by the selected adapter: ", feature_name, ".");
+        if (std::find(required_features.begin(), required_features.end(), feature) == required_features.end()) {
+          required_features.push_back(feature);
+        }
+      }
       if (!required_features.empty()) {
         device_desc.requiredFeatures = required_features.data();
         device_desc.requiredFeatureCount = required_features.size();
@@ -227,6 +270,10 @@ void WebGpuContext::Initialize(const WebGpuContextConfig& config) {
     Device().GetFeatures(&supported_features);
     for (size_t i = 0; i < supported_features.featureCount; i++) {
       device_features_.insert(supported_features.features[i]);
+    }
+    for (const auto& feature_name : config.required_features) {
+      ORT_ENFORCE(DeviceHasFeature(ParseWebGpuFeatureName(feature_name)),
+                  "The application-created WebGPU device does not have required feature: ", feature_name, ".");
     }
     // cache adapter info
 #if !defined(__wasm__)
@@ -1189,11 +1236,93 @@ std::once_flag WebGpuContextFactory::init_default_flag_;
 
 std::unordered_map<int32_t, WebGpuContextFactory::WebGpuContextInfo>* WebGpuContextFactory::contexts_ = nullptr;
 WGPUInstance WebGpuContextFactory::default_instance_ = nullptr;
+WGPUDevice WebGpuContextFactory::default_device_ = nullptr;
+std::vector<std::string> WebGpuContextFactory::default_required_features_;
+bool WebGpuContextFactory::default_context_configured_ = false;
+
+bool ConfigureDefaultContext(WGPUInstance instance,
+                             WGPUDevice device,
+                             const char* required_features,
+                             std::string& error_message) {
+  std::vector<std::string> features;
+  if (required_features != nullptr && required_features[0] != '\0') {
+    std::string_view remaining{required_features};
+    while (!remaining.empty()) {
+      const size_t separator = remaining.find(',');
+      const std::string_view feature = remaining.substr(0, separator);
+      if (feature.empty()) {
+        error_message = "WebGPU required feature names must not be empty.";
+        return false;
+      }
+      if (std::find(features.begin(), features.end(), feature) == features.end()) {
+        features.emplace_back(feature);
+      }
+      if (separator == std::string_view::npos) {
+        break;
+      }
+      if (separator + 1 == remaining.size()) {
+        error_message = "WebGPU required feature names must not be empty.";
+        return false;
+      }
+      remaining.remove_prefix(separator + 1);
+    }
+  }
+
+  auto status = WebGpuContextFactory::ConfigureDefaultContext(instance, device, std::move(features));
+  if (!status.IsOK()) {
+    error_message = status.ErrorMessage();
+    return false;
+  }
+  return true;
+}
+
+Status WebGpuContextFactory::ConfigureDefaultContext(WGPUInstance instance,
+                                                     WGPUDevice device,
+                                                     std::vector<std::string> required_features) {
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  ORT_RETURN_IF((instance == nullptr) != (device == nullptr),
+                "The default WebGPU instance and device must either both be set or both be null.");
+  ORT_RETURN_IF(contexts_ != nullptr && contexts_->find(0) != contexts_->end(),
+                "The default WebGPU device has already been initialized and cannot be replaced.");
+
+  if (default_context_configured_) {
+    ORT_RETURN_IF(default_required_features_ != required_features,
+                  "The default WebGPU required features have already been configured.");
+    ORT_RETURN_IF(default_device_ != nullptr && device != nullptr,
+                  "The default WebGPU device has already been configured.");
+  }
+
+  if (device != nullptr && default_device_ == nullptr) {
+    if (default_instance_ != nullptr) {
+      wgpuInstanceRelease(default_instance_);
+    }
+    default_instance_ = instance;
+    default_device_ = device;
+  }
+  default_required_features_ = std::move(required_features);
+  default_context_configured_ = true;
+  return Status::OK();
+}
+
+WGPUInstance CreateWebGpuInstance() {
+  wgpu::InstanceFeatureName required_instance_features[] = {wgpu::InstanceFeatureName::TimedWaitAny};
+  wgpu::InstanceDescriptor instance_desc{};
+  instance_desc.requiredFeatures = required_instance_features;
+  instance_desc.requiredFeatureCount = sizeof(required_instance_features) / sizeof(required_instance_features[0]);
+#if !defined(__wasm__) && !defined(USE_EXTERNAL_DAWN)
+  dawn::native::DawnInstanceDescriptor dawn_instance_desc{};
+  dawn_instance_desc.platform = &GetDawnPlatform();
+  instance_desc.nextInChain = &dawn_instance_desc;
+#endif
+  return wgpu::CreateInstance(&instance_desc).MoveToCHandle();
+}
 
 WebGpuContext& WebGpuContextFactory::CreateContext(const WebGpuContextConfig& config) {
   const int context_id = config.context_id;
-  WGPUInstance instance = config.instance;
-  WGPUDevice device = config.device;
+  WebGpuContextConfig effective_config = config;
+  WGPUInstance instance = effective_config.instance;
+  WGPUDevice device = effective_config.device;
 
   std::call_once(init_default_flag_, [
 #if !defined(__wasm__)
@@ -1222,17 +1351,7 @@ WebGpuContext& WebGpuContextFactory::CreateContext(const WebGpuContextConfig& co
   std::lock_guard<std::mutex> lock(mutex_);
 
   if (default_instance_ == nullptr) {
-    // Create wgpu::Instance
-    wgpu::InstanceFeatureName required_instance_features[] = {wgpu::InstanceFeatureName::TimedWaitAny};
-    wgpu::InstanceDescriptor instance_desc{};
-    instance_desc.requiredFeatures = required_instance_features;
-    instance_desc.requiredFeatureCount = sizeof(required_instance_features) / sizeof(required_instance_features[0]);
-#if !defined(__wasm__) && !defined(USE_EXTERNAL_DAWN)
-    dawn::native::DawnInstanceDescriptor dawn_instance_desc{};
-    dawn_instance_desc.platform = &GetDawnPlatform();
-    instance_desc.nextInChain = &dawn_instance_desc;
-#endif
-    default_instance_ = wgpu::CreateInstance(&instance_desc).MoveToCHandle();
+    default_instance_ = CreateWebGpuInstance();
 
     ORT_ENFORCE(default_instance_ != nullptr, "Failed to create wgpu::Instance.");
   }
@@ -1243,6 +1362,15 @@ WebGpuContext& WebGpuContextFactory::CreateContext(const WebGpuContextConfig& co
                 "WebGPU EP default context (contextId=0) must not have custom WebGPU instance or device.");
 
     instance = default_instance_;
+    device = default_device_;
+    effective_config.instance = instance;
+    effective_config.device = device;
+    effective_config.required_features = default_required_features_;
+    // The web binding configures one device for the lifetime of its OrtEnv. Other native callers retain the existing
+    // per-factory preserveDevice behavior.
+    if (default_context_configured_) {
+      effective_config.preserve_device = true;
+    }
   } else {
     // for context ID > 0, user must provide custom WebGPU instance and device.
     ORT_ENFORCE(instance != nullptr && device != nullptr,
@@ -1259,10 +1387,10 @@ WebGpuContext& WebGpuContextFactory::CreateContext(const WebGpuContextConfig& co
     GSL_SUPPRESS(r.11)
     auto context = std::unique_ptr<WebGpuContext>(new WebGpuContext(instance,
                                                                     device,
-                                                                    config.validation_mode,
-                                                                    config.validation_mode_explicitly_set,
-                                                                    config.preserve_device,
-                                                                    config.max_storage_buffer_binding_size));
+                                                                    effective_config.validation_mode,
+                                                                    effective_config.validation_mode_explicitly_set,
+                                                                    effective_config.preserve_device,
+                                                                    effective_config.max_storage_buffer_binding_size));
     it = contexts_->emplace(context_id, WebGpuContextFactory::WebGpuContextInfo{std::move(context), 0}).first;
   } else if (context_id != 0) {
     ORT_ENFORCE(it->second.context->instance_.Get() == instance &&
@@ -1275,7 +1403,7 @@ WebGpuContext& WebGpuContextFactory::CreateContext(const WebGpuContextConfig& co
   // if this was the first (and only) reference, so we don't leave a zombie context in the map
   // that would later deadlock during Cleanup().
   ORT_TRY {
-    it->second.context->Initialize(config);
+    it->second.context->Initialize(effective_config);
   }
   ORT_CATCH(...) {
     if (--it->second.ref_count == 0) {
@@ -1317,10 +1445,17 @@ void WebGpuContextFactory::Cleanup() {
     contexts_ = nullptr;
   }
 
+  if (default_device_ != nullptr) {
+    wgpuDeviceRelease(default_device_);
+    default_device_ = nullptr;
+  }
+
   if (default_instance_ != nullptr) {
     wgpuInstanceRelease(default_instance_);
     default_instance_ = nullptr;
   }
+  default_required_features_.clear();
+  default_context_configured_ = false;
 }
 
 WebGpuContext& WebGpuContextFactory::DefaultContext() {

--- a/onnxruntime/core/providers/webgpu/webgpu_context.h
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.h
@@ -119,6 +119,13 @@ struct WebGpuBufferCacheConfig {
   ConfigEntry default_entry{BufferCacheMode::Disabled, {}};
 };
 
+wgpu::FeatureName ParseWebGpuFeatureName(std::string_view feature);
+WGPUInstance CreateWebGpuInstance();
+bool ConfigureDefaultContext(WGPUInstance instance,
+                             WGPUDevice device,
+                             const char* required_features,
+                             std::string& error_message);
+
 /// <summary>
 /// Represents the configuration options for creating a WebGpuContext.
 /// </summary>
@@ -143,6 +150,7 @@ struct WebGpuContextConfig {
 #endif
   };
   bool enable_robustness_explicitly_set{false};
+  std::vector<std::string> required_features;
   bool preserve_device{false};
   // When true, skip Dawn adapter/device creation and all device-dependent initialization; the context
   // can only be used for graph transformation, not execution. Derived from kOrtSessionOptionCompileOnly.
@@ -180,6 +188,14 @@ class WebGpuContextFactory {
   static WebGpuContext& CreateContext(const WebGpuContextConfig& config);
 
   /// <summary>
+  /// Configure the environment-wide default context before it is created. The instance and device must either both be
+  /// null (an ORT-created device) or both be non-null (an application-created device).
+  /// </summary>
+  static Status ConfigureDefaultContext(WGPUInstance instance,
+                                        WGPUDevice device,
+                                        std::vector<std::string> required_features);
+
+  /// <summary>
   /// Get the WebGPU context for the specified context ID. Throw if not present.
   /// </summary>
   static WebGpuContext& GetContext(int context_id);
@@ -211,6 +227,9 @@ class WebGpuContextFactory {
   // On abnormal/process termination they simply leak, which is safe.
   static std::unordered_map<int32_t, WebGpuContextInfo>* contexts_;
   static WGPUInstance default_instance_;
+  static WGPUDevice default_device_;
+  static std::vector<std::string> default_required_features_;
+  static bool default_context_configured_;
 };
 
 // Class WebGpuContext includes all necessary resources for the context.

--- a/onnxruntime/test/providers/webgpu/webgpu_context_test.cc
+++ b/onnxruntime/test/providers/webgpu/webgpu_context_test.cc
@@ -55,6 +55,14 @@ bool DisableRobustnessToggleIsEnabled(const webgpu::WebGpuContext& context) {
   return DeviceToggleIsEnabled(context, "disable_robustness");
 }
 
+TEST(WebGpuRequiredFeaturesTest, MapsWebFeatureNames) {
+  EXPECT_EQ(webgpu::ParseWebGpuFeatureName("bgra8unorm-storage"),
+            wgpu::FeatureName::BGRA8UnormStorage);
+  EXPECT_EQ(webgpu::ParseWebGpuFeatureName("subgroup-size-control"),
+            wgpu::FeatureName::SubgroupSizeControl);
+  EXPECT_THROW(webgpu::ParseWebGpuFeatureName("not-a-webgpu-feature"), OnnxRuntimeException);
+}
+
 std::array<uint32_t, 16> ReadBufferWithExternalCommandEncoder(webgpu::WebGpuContext& context,
                                                               WGPUBuffer buffer) {
   constexpr size_t kBufferSize = sizeof(std::array<uint32_t, 16>);
@@ -366,6 +374,16 @@ TEST(WebGpuContextTest, ExternalDeviceValueWarnsAndIsIgnored) {
   EXPECT_NE(warning.find("externally supplied WebGPU device"), std::string::npos);
   EXPECT_NE(warning.find("will be ignored"), std::string::npos);
 #endif
+}
+
+TEST(WebGpuContextTest, RejectsDefaultDeviceConfigurationAfterContextInitialization) {
+  ConfigOptions options;
+  auto ep = WebGpuProviderFactoryCreator::Create(options)->CreateProvider();
+  ASSERT_NE(ep, nullptr);
+
+  const auto status = webgpu::WebGpuContextFactory::ConfigureDefaultContext(nullptr, nullptr, {});
+  EXPECT_FALSE(status.IsOK());
+  EXPECT_NE(status.ErrorMessage().find("already been initialized"), std::string::npos);
 }
 
 }  // namespace

--- a/onnxruntime/wasm/api.cc
+++ b/onnxruntime/wasm/api.cc
@@ -8,11 +8,15 @@
 #include "core/session/onnxruntime_cxx_api.h"
 #include "api.h"
 
+#include <string>
+
 #ifdef USE_WEBGPU
 namespace onnxruntime {
 namespace webgpu {
+WGPUInstance CreateWebGpuInstance();
+bool ConfigureDefaultContext(WGPUInstance, WGPUDevice, const char*, std::string&);
 WGPUDevice GetDevice(int);
-}
+}  // namespace webgpu
 }  // namespace onnxruntime
 #endif
 
@@ -629,6 +633,24 @@ char* OrtEndProfiling(ort_session_handle_t session) {
 // WebGPU API Section
 
 #ifdef USE_WEBGPU
+
+WGPUInstance OrtCreateWebGpuInstance() {
+  return onnxruntime::webgpu::CreateWebGpuInstance();
+}
+
+int OrtConfigureWebGpuDefaultContext(WGPUInstance instance,
+                                     WGPUDevice device,
+                                     const char* required_features) {
+  std::string error_message;
+  if (!onnxruntime::webgpu::ConfigureDefaultContext(instance, device, required_features, error_message)) {
+    if (device != nullptr) {
+      wgpuDeviceRelease(device);
+      wgpuInstanceRelease(instance);
+    }
+    return CheckStatus(Ort::GetApi().CreateStatus(ORT_FAIL, error_message.c_str()));
+  }
+  return CheckStatus(nullptr);
+}
 
 WGPUDevice OrtGetWebGpuDevice(int device_id) {
   return onnxruntime::webgpu::GetDevice(device_id);

--- a/onnxruntime/wasm/api.h
+++ b/onnxruntime/wasm/api.h
@@ -301,6 +301,18 @@ char* EMSCRIPTEN_KEEPALIVE OrtEndProfiling(ort_session_handle_t session);
 
 #ifdef USE_WEBGPU
 
+/** Create a WebGPU instance configured for ONNX Runtime's asynchronous wait behavior. */
+WGPUInstance EMSCRIPTEN_KEEPALIVE OrtCreateWebGpuInstance();
+
+/**
+ * Configure the environment-wide WebGPU device before the default WebGPU context is initialized.
+ * The instance and device are both null for an ORT-created device, or both non-null for an imported device.
+ * Ownership of non-null handles is transferred to ONNX Runtime.
+ */
+int EMSCRIPTEN_KEEPALIVE OrtConfigureWebGpuDefaultContext(WGPUInstance instance,
+                                                          WGPUDevice device,
+                                                          const char* required_features);
+
 /**
  * get the GPU Device by device ID.
  *

--- a/onnxruntime/wasm/post-webgpu.js
+++ b/onnxruntime/wasm/post-webgpu.js
@@ -10,34 +10,23 @@
 /**
  * This function is called only once when initializing the WebGPU backend.
  *
- * @param {(gpuDevice: GPUDevice) => void} setDefaultDevice A callback function to set the default device.
+ * @param {GPUDevice|undefined} configuredDevice The application-created environment device, if set.
+ * @param {readonly string[]} requiredFeatures Features required by the environment.
+ * @param {(gpuDevice: GPUDevice) => void} setDefaultDevice A callback function to publish the effective device.
  */
-Module["webgpuInit"] = (setDefaultDevice) => {
-  /**
-   * a map from GPUDevice to [deviceId, instanceHandle, deviceHandle]
-   *
-   * only stores custom devices (ie. devices created by the user, not the default device created by ORT)
-   *
-   * key is the GPUDevice object.
-   *
-   * value is a tuple of 3 elements:
-   * - deviceId: a unique ID for the device. Must be positive integer.
-   * - instanceHandle: the instance handle(pointer) of the device.
-   * - deviceHandle: the device handle(pointer) of the device.
-   *
-   * @type {WeakMap<GPUDevice, [number, number, number]>}
-   */
-  const webgpuActiveDevices = new WeakMap();
-  /**
-   * a number that is used to assign a unique ID to the next custom device.
-   */
-  let webgpuNextDeviceId = 1;
+Module["webgpuInit"] = (
+  configuredDevice,
+  requiredFeatures,
+  setDefaultDevice,
+) => {
   /**
    * a function to set the default device.
    *
    * @type {(gpuDevice: GPUDevice) => void}
    */
   const webgpuSetDefaultDevice = setDefaultDevice;
+  /** @type {GPUDevice|undefined} */
+  let webgpuDefaultDevice = configuredDevice;
   /**
    * the current device that is being used to create a WebGPU EP inference session.
    *
@@ -46,68 +35,92 @@ Module["webgpuInit"] = (setDefaultDevice) => {
    * @type {GPUDevice|undefined}
    */
   let webgpuCurrentDevice = undefined;
-  /**
-   * the current device ID that is being used to create a WebGPU EP inference session.
-   *
-   * the value of this variable is only valid during the creation of a WebGPU EP inference session.
-   *
-   * @type {number|undefined}
-   */
-  let webgpuCurrentDeviceId = undefined;
+  /** Whether a WebGPU EP inference session is currently being created. */
+  let webgpuCreatingSession = false;
+
+  const configureDefaultContext = (device) => {
+    let instanceHandle = 0;
+    let deviceHandle = 0;
+    if (device) {
+      instanceHandle = _OrtCreateWebGpuInstance();
+      if (!instanceHandle) {
+        throw new Error(
+          "Failed to create the WebGPU instance for the application-created device.",
+        );
+      }
+      deviceHandle = WebGPU.importJsDevice(device, instanceHandle);
+    }
+
+    const features = requiredFeatures.join(",");
+    const featuresLength = lengthBytesUTF8(features) + 1;
+    const featuresOffset = _malloc(featuresLength);
+    stringToUTF8(features, featuresOffset, featuresLength);
+    const errorCode = _OrtConfigureWebGpuDefaultContext(
+      instanceHandle,
+      deviceHandle,
+      featuresOffset,
+    );
+    _free(featuresOffset);
+    return errorCode;
+  };
+
+  let errorCode = configureDefaultContext(configuredDevice);
+  if (errorCode !== 0) {
+    return errorCode;
+  }
+  if (configuredDevice) {
+    webgpuSetDefaultDevice(configuredDevice);
+  }
 
   /**
    * This function is called only when a custom device is used, during preparation of session options.
    *
    * @param {GPUDevice} device the user provided device object.
-   * @returns {undefined|[number, number, number]} a tuple of device id, instance handle, and device handle.
+   * @returns {number} ORT error code.
    */
   Module["webgpuRegisterDevice"] = (device) => {
-    if (webgpuCurrentDeviceId !== undefined) {
+    if (webgpuCreatingSession) {
       throw new Error("another WebGPU EP inference session is being created.");
     }
 
     if (device) {
-      let deviceInfo = webgpuActiveDevices.get(device);
-      if (!deviceInfo) {
-        const instanceHandle = _wgpuCreateInstance(0);
-        const deviceHandle = WebGPU.importJsDevice(device, instanceHandle);
-        deviceInfo = [webgpuNextDeviceId++, instanceHandle, deviceHandle];
-        webgpuActiveDevices.set(device, deviceInfo);
+      if (webgpuDefaultDevice && webgpuDefaultDevice !== device) {
+        throw new Error(
+          "A different WebGPU device is already used by this ONNX Runtime environment.",
+        );
       }
-
-      // The current device ID is a temporary storage for the device ID to be used in the session that is being created.
-      //
-      // Soon after `webgpuRegisterDevice` (this function) is called, `webgpuOnCreateSession` will be called so that the
-      // value of `webgpuCurrentDeviceId` is used and reset then.
+      if (!webgpuDefaultDevice) {
+        errorCode = configureDefaultContext(device);
+        if (errorCode !== 0) {
+          return errorCode;
+        }
+        webgpuDefaultDevice = device;
+        webgpuSetDefaultDevice(device);
+      }
       webgpuCurrentDevice = device;
-      webgpuCurrentDeviceId = deviceInfo[0];
-      return deviceInfo;
     } else {
-      webgpuCurrentDevice = undefined;
-      webgpuCurrentDeviceId = 0;
-      return undefined;
+      webgpuCurrentDevice = webgpuDefaultDevice;
     }
+    webgpuCreatingSession = true;
+    return 0;
   };
 
   const webgpuActiveSessions = new Map();
   Module["webgpuOnCreateSession"] = (sessionHandle) => {
-    if (webgpuCurrentDeviceId === undefined) {
-      // do nothing if webgpuCurrentDeviceId is undefined.
-      // this means no WebGPU EP is being created.
+    if (!webgpuCreatingSession) {
       return;
     }
 
-    const deviceId = webgpuCurrentDeviceId;
-    webgpuCurrentDeviceId = undefined;
+    webgpuCreatingSession = false;
 
     if (sessionHandle) {
       // when session created successfully
-      const deviceHandle = _OrtGetWebGpuDevice(deviceId);
+      const deviceHandle = _OrtGetWebGpuDevice(0);
       webgpuActiveSessions.set(sessionHandle, deviceHandle);
 
-      if (deviceId === 0) {
-        const device = webgpuCurrentDevice ?? WebGPU.getJsObject(deviceHandle);
-        webgpuSetDefaultDevice(device);
+      if (!webgpuDefaultDevice) {
+        webgpuDefaultDevice = WebGPU.getJsObject(deviceHandle);
+        webgpuSetDefaultDevice(webgpuDefaultDevice);
       }
     }
     webgpuCurrentDevice = undefined;
@@ -137,7 +150,7 @@ Module["webgpuInit"] = (setDefaultDevice) => {
       const deviceHandle = webgpuActiveSessions.get(sessionHandle);
       if (deviceHandle === undefined) {
         throw new Error(
-          "Invalid session handle passed to webgpuRegisterBuffer"
+          "Invalid session handle passed to webgpuRegisterBuffer",
         );
       }
 
@@ -194,7 +207,7 @@ Module["webgpuInit"] = (setDefaultDevice) => {
           0 /* source offset */,
           gpuReadBuffer /* destination buffer */,
           0 /* destination offset */,
-          size /* size */
+          size /* size */,
         );
         device.queue.submit([commandEncoder.finish()]);
 
@@ -219,7 +232,7 @@ Module["webgpuInit"] = (setDefaultDevice) => {
 
     // get current device
     if (!webgpuCurrentDevice) {
-      const deviceHandle = _OrtGetWebGpuDevice(webgpuCurrentDeviceId);
+      const deviceHandle = _OrtGetWebGpuDevice(0);
       webgpuCurrentDevice = WebGPU.getJsObject(deviceHandle);
     }
 
@@ -236,13 +249,13 @@ Module["webgpuInit"] = (setDefaultDevice) => {
       "usage": 6 /* GPUBufferUsage.MAP_WRITE | GPUBufferUsage.COPY_SRC */,
     };
     const gpuBufferForUploading = webgpuCurrentDevice.createBuffer(
-      gpuBufferForUploadingDescriptor
+      gpuBufferForUploadingDescriptor,
     );
 
     // copy (upload) data
     const arrayBuffer = gpuBufferForUploading.getMappedRange();
     new Uint8Array(arrayBuffer).set(
-      new Uint8Array(srcArrayBuffer, srcOffset, srcLength)
+      new Uint8Array(srcArrayBuffer, srcOffset, srcLength),
     );
     gpuBufferForUploading.unmap();
 
@@ -253,9 +266,11 @@ Module["webgpuInit"] = (setDefaultDevice) => {
       0,
       gpuBuffer,
       0,
-      size
+      size,
     );
     webgpuCurrentDevice.queue.submit([commandEncoder.finish()]);
     gpuBufferForUploading.destroy();
   };
+
+  return 0;
 };


### PR DESCRIPTION
## Description

Closes #26107.

This change supports one environment-wide WebGPU device for web:

- Allow an application-created GPUDevice to be assigned to ort.env.webgpu.device before WebGPU initialization.
- Keep ort.env.webgpu.device as the getter for the device created or adopted by ORT.
- Share that device across sessions and shared allocators; device replacement after initialization is rejected.
- Add ort.env.webgpu.requiredFeatures so ORT-created devices can combine application-required features with ORT defaults.
- Support the native WebGPU EP and retain JSEP compatibility while keeping the per-session device option deprecated.
- Reject application-created devices when WASM proxy mode is enabled.
- Import external devices through an ORT WebGPU instance configured with TimedWaitAny support.

This intentionally does not add multi-device support.

## Testing

- Native WebGPU WASM build
- TypeScript prebuild and targeted ESLint
- C++ and JavaScript formatting checks
- Chrome Headless WebGPU tests with internal and external devices, normal I/O, and GPU-tensor I/O
- Full browser unit test run: 191 passing
- Added a browser regression test for application-created device inference with GPU input and output buffers