### PR TITLE
[CUDA] Extend paged XQA decode to head size 256

### DIFF
--- a/onnxruntime/contrib_ops/cuda/bert/paged_attention.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/paged_attention.cc
@@ -466,7 +466,7 @@ Status PagedAttention<T, TCACHE>::ComputeInternal(OpKernelContext* context) cons
     xqa_candidate =
         device_prop.major >= 8 &&
         parameters.softcap == 0.0f &&
-        (parameters.head_size == 64 || parameters.head_size == 128) &&
+        (parameters.head_size == 64 || parameters.head_size == 128 || parameters.head_size == 256) &&
         (group_size == 4 || group_size == 6 || group_size == 8 || group_size == 16 || group_size == 32) &&
         (parameters.block_size % kXqaTokensPerPage) == 0 &&
         is_supported_quant_type(k_quant_type_) && is_supported_quant_type(v_quant_type_) &&

--- a/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_paged_bf16_fp8_256.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_paged_bf16_fp8_256.cu
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#define HEAD_ELEMS 256
+#define HEAD_DIM_NAMESPACE H256
+#define XQA_PAGED_CACHE_ELEM 2
+#define XQA_PAGED_INPUT_FP16 0
+#define XQA_PAGED_QUERY_T __nv_bfloat16
+#define XQA_PAGED_FAMILY bf16_fp8
+#define XQA_PAGED_LAUNCH_FN LaunchXQAPagedFp8KernelBF16
+
+#ifdef USE_FP8_KV_CACHE
+#include "xqa_paged_loader_impl.cuh"
+#endif

--- a/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_paged_bf16_int8_256.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_paged_bf16_int8_256.cu
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#define HEAD_ELEMS 256
+#define HEAD_DIM_NAMESPACE H256
+#define XQA_PAGED_CACHE_ELEM 1
+#define XQA_PAGED_INPUT_FP16 0
+#define XQA_PAGED_QUERY_T __nv_bfloat16
+#define XQA_PAGED_FAMILY bf16_int8
+#define XQA_PAGED_LAUNCH_FN LaunchXQAPagedInt8KernelBF16
+
+#include "xqa_paged_loader_impl.cuh"

--- a/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_paged_fp16_fp8_256.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_paged_fp16_fp8_256.cu
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#define HEAD_ELEMS 256
+#define HEAD_DIM_NAMESPACE H256
+#define XQA_PAGED_CACHE_ELEM 2
+#define XQA_PAGED_INPUT_FP16 1
+#define XQA_PAGED_QUERY_T half
+#define XQA_PAGED_FAMILY fp16_fp8
+#define XQA_PAGED_LAUNCH_FN LaunchXQAPagedFp8Kernel
+
+#ifdef USE_FP8_KV_CACHE
+#include "xqa_paged_loader_impl.cuh"
+#endif

--- a/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_paged_fp16_int8_256.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_paged_fp16_int8_256.cu
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#define HEAD_ELEMS 256
+#define HEAD_DIM_NAMESPACE H256
+#define XQA_PAGED_CACHE_ELEM 1
+#define XQA_PAGED_INPUT_FP16 1
+#define XQA_PAGED_QUERY_T half
+#define XQA_PAGED_FAMILY fp16_int8
+#define XQA_PAGED_LAUNCH_FN LaunchXQAPagedInt8Kernel
+
+#include "xqa_paged_loader_impl.cuh"

--- a/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_paged_loader.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_paged_loader.cu
@@ -62,6 +62,15 @@ XQA_PAGED_DECL(LaunchXQAPagedFp8KernelBF16);
 #endif
 }  // namespace H128
 
+namespace H256 {
+XQA_PAGED_DECL(LaunchXQAPagedInt8Kernel);
+XQA_PAGED_DECL(LaunchXQAPagedInt8KernelBF16);
+#ifdef USE_FP8_KV_CACHE
+XQA_PAGED_DECL(LaunchXQAPagedFp8Kernel);
+XQA_PAGED_DECL(LaunchXQAPagedFp8KernelBF16);
+#endif
+}  // namespace H256
+
 Status LaunchXQAPagedKernel(
     const cudaDeviceProp& device_prop,
     cudaStream_t stream,
@@ -96,6 +105,9 @@ Status LaunchXQAPagedKernel(
     } else if (head_size == 128) {
       return is_bf16 ? H128::LaunchXQAPagedInt8KernelBF16(XQA_PAGED_ARGS)
                      : H128::LaunchXQAPagedInt8Kernel(XQA_PAGED_ARGS);
+    } else if (head_size == 256) {
+      return is_bf16 ? H256::LaunchXQAPagedInt8KernelBF16(XQA_PAGED_ARGS)
+                     : H256::LaunchXQAPagedInt8Kernel(XQA_PAGED_ARGS);
     }
   } else if (kv_quant_type == XqaQuantType::kFp8) {
 #ifdef USE_FP8_KV_CACHE
@@ -105,6 +117,9 @@ Status LaunchXQAPagedKernel(
     } else if (head_size == 128) {
       return is_bf16 ? H128::LaunchXQAPagedFp8KernelBF16(XQA_PAGED_ARGS)
                      : H128::LaunchXQAPagedFp8Kernel(XQA_PAGED_ARGS);
+    } else if (head_size == 256) {
+      return is_bf16 ? H256::LaunchXQAPagedFp8KernelBF16(XQA_PAGED_ARGS)
+                     : H256::LaunchXQAPagedFp8Kernel(XQA_PAGED_ARGS);
     }
 #else
     return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Paged XQA was built without FP8 KV cache support.");
@@ -115,8 +130,8 @@ Status LaunchXQAPagedKernel(
                            "uses the FlashAttention paged path.");
   }
 
-  return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Paged XQA only supports head_size 64 or 128. Input has ",
-                         head_size);
+  return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
+                         "Paged XQA only supports head_size 64, 128, or 256. Input has ", head_size);
 }
 
 size_t GetXQAPagedRequiredSharedMemoryBytes(
@@ -136,6 +151,8 @@ size_t GetXQAPagedRequiredSharedMemoryBytes(
       return H64::LaunchXQAPagedInt8Kernel_SmemSize(num_heads, kv_num_heads);
     } else if (head_size == 128) {
       return H128::LaunchXQAPagedInt8Kernel_SmemSize(num_heads, kv_num_heads);
+    } else if (head_size == 256) {
+      return H256::LaunchXQAPagedInt8Kernel_SmemSize(num_heads, kv_num_heads);
     }
   } else if (kv_quant_type == XqaQuantType::kFp8) {
 #ifdef USE_FP8_KV_CACHE
@@ -143,6 +160,8 @@ size_t GetXQAPagedRequiredSharedMemoryBytes(
       return H64::LaunchXQAPagedFp8Kernel_SmemSize(num_heads, kv_num_heads);
     } else if (head_size == 128) {
       return H128::LaunchXQAPagedFp8Kernel_SmemSize(num_heads, kv_num_heads);
+    } else if (head_size == 256) {
+      return H256::LaunchXQAPagedFp8Kernel_SmemSize(num_heads, kv_num_heads);
     }
 #endif
   }

--- a/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_paged_loader.h
+++ b/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_paged_loader.h
@@ -26,7 +26,7 @@ constexpr int kXqaTokensPerPage = 128;
 // Paged-KV XQA decode launcher. Unlike LaunchXQAKernel (contiguous per-request cache) this reads
 // K and V from a shared block pool addressed through a page table.
 //
-// Preconditions: one query token per sequence, head_size in {64, 128}, group_size in
+// Preconditions: one query token per sequence, head_size in {64, 128, 256}, group_size in
 // {4, 6, 8, 16, 32}, quantized (INT8/FP8) cache, block_size % kXqaTokensPerPage == 0.
 Status LaunchXQAPagedKernel(
     const cudaDeviceProp& device_prop,

--- a/onnxruntime/test/contrib_ops/paged_attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/paged_attention_op_test.cc
@@ -818,6 +818,39 @@ TEST(PagedAttention, Cuda_AttentionMetadataShape2CompatibilityAndDispatchBounds)
   EXPECT_NE(debug_output.find("EffectiveKvLengthBound=256"), std::string::npos) << debug_output;
 }
 
+TEST(PagedAttention, Cuda_XqaInt8CacheHeadSize256Group6) {
+  ScopedEnvironmentVariables scoped_env_vars{
+      EnvVarMap{
+          {onnxruntime::contrib::attention::kDisableFlashAttention, "1"},
+          {onnxruntime::contrib::attention::kDisableMemoryEfficientAttention, "1"},
+          {onnxruntime::contrib::attention::kDisableDecoderAttention, "0"},
+          {onnxruntime::contrib::attention::kEnableAttentionKernelDebugInfo, "1"}}};
+
+  if (DefaultCudaExecutionProvider() == nullptr) {
+    GTEST_SKIP() << "CUDA EP not available.";
+  }
+  if (GetCudaArchitecture() < 800) {
+    GTEST_SKIP() << "XQA requires compute capability 8.0 or later.";
+  }
+
+  IoBindingCase c;
+  c.num_heads = 6;
+  c.kv_num_heads = 1;
+  c.head_size = 256;
+  c.num_blocks = 16;
+  c.max_num_blocks_per_seq = 8;
+  c.past_seqlen = 2047;
+  c.int8_cache = true;
+  c.attention_metadata = {1, 2048, 2048};
+
+  testing::internal::CaptureStdout();
+  RunIoBindingCase(DefaultCudaExecutionProvider(), kCudaExecutionProvider, true, false, c);
+  const std::string debug_output = testing::internal::GetCapturedStdout();
+
+  EXPECT_NE(debug_output.find("SdpaKernel=XQA"), std::string::npos) << debug_output;
+  EXPECT_NE(debug_output.find("GqaGroupSize=6"), std::string::npos) << debug_output;
+}
+
 TEST(PagedAttention, Cuda_AttentionMetadataValidation) {
   if (DefaultCudaExecutionProvider() == nullptr) {
     GTEST_SKIP() << "CUDA EP not available.";


### PR DESCRIPTION
Extend the quantized paged-KV XQA decode path to `head_size=256` for FP16 and BF16 activations with INT8 or FP8 KV caches.

This enables XQA for models such as Qwen3.8 whose full-attention layers use 24 query heads, 4 KV heads, and head size 256.

- Add FP16/BF16 paged XQA instantiations for head size 256 with INT8 and FP8 KV caches.
- Add H256 loader declarations, launch dispatch, and dynamic shared-memory queries.
- Extend PagedAttention's XQA eligibility check to head size 256.
- Add an operator test for the Qwen group-size-6 INT8 geometry that verifies numerical output and confirms `SdpaKernel=XQA` dispatch.

The existing runtime shared-memory check remains authoritative. If an H256 kernel does not fit the device's opt-in shared-memory limit, `PagedAttention` uses the existing fallback path.