### PR TITLE
Fix Gemm transpose fusion permutation handling

### DIFF
--- a/onnxruntime/core/optimizer/gemm_transpose_fusion.cc
+++ b/onnxruntime/core/optimizer/gemm_transpose_fusion.cc
@@ -11,6 +11,32 @@ using namespace ONNX_NAMESPACE;
 using namespace onnxruntime::common;
 namespace onnxruntime {
 
+namespace {
+
+// Gemm's transA/transB attributes only represent a transpose of a 2-D matrix. A Transpose with
+// an arbitrary permutation, including a permutation of higher-rank input dimensions, must remain
+// in the graph. If perm is omitted, ONNX defines it as reversing all dimensions, so the input
+// shape is needed to determine whether it is the 2-D matrix transpose.
+bool IsMatrixTranspose(const Node& transpose_node) {
+  ORT_ENFORCE(transpose_node.InputDefs().size() == 1);
+
+  const NodeArg& input = *transpose_node.InputDefs()[0];
+  const TensorShapeProto* shape = input.Shape();
+  if (shape != nullptr && shape->dim_size() != 2) {
+    return false;
+  }
+
+  const auto perm_attr = transpose_node.GetAttributes().find("perm");
+  if (perm_attr == transpose_node.GetAttributes().end()) {
+    return shape != nullptr;
+  }
+
+  const auto perms = RetrieveValues<int64_t>(perm_attr->second);
+  return perms.size() == 2 && perms[0] == 1 && perms[1] == 0;
+}
+
+}  // namespace
+
 Status GemmTransposeFusion::Apply(Graph& graph, Node& node, RewriteRuleEffect& modified, const logging::Logger&) const {
   auto& gemm_node = node;
   const Node* A_node_ptr = graph_utils::GetInputNode(gemm_node, 0);
@@ -25,7 +51,8 @@ Status GemmTransposeFusion::Apply(Graph& graph, Node& node, RewriteRuleEffect& m
   auto new_gemm_input_defs = gemm_node.MutableInputDefs();
 
   // check if input A is a Transpose
-  if (A_node_ptr != nullptr && A_node_ptr->OpType() == "Transpose") {
+  if (A_node_ptr != nullptr && A_node_ptr->OpType() == "Transpose" &&
+      IsMatrixTranspose(*A_node_ptr)) {
     // make sure all consumers are gemm nodes to avoid possible double transpose
     std::vector<const Node*> gemm_nodes = graph_utils::FindChildrenByType(*A_node_ptr, "Gemm");
     if (gemm_nodes.size() == A_node_ptr->GetOutputEdgesCount()) {
@@ -44,7 +71,8 @@ Status GemmTransposeFusion::Apply(Graph& graph, Node& node, RewriteRuleEffect& m
     }
   }
   // check if input B is a Transpose
-  if (B_node_ptr != nullptr && B_node_ptr->OpType() == "Transpose") {
+  if (B_node_ptr != nullptr && B_node_ptr->OpType() == "Transpose" &&
+      IsMatrixTranspose(*B_node_ptr)) {
     std::vector<const Node*> gemm_nodes = graph_utils::FindChildrenByType(*B_node_ptr, "Gemm");
     if (gemm_nodes.size() == B_node_ptr->GetOutputEdgesCount()) {
       Node& B_node = *graph.GetNode(B_node_ptr->Index());
@@ -64,7 +92,8 @@ Status GemmTransposeFusion::Apply(Graph& graph, Node& node, RewriteRuleEffect& m
   // check if output node is Transpose
   if (output_node_ptr != gemm_node.OutputNodesEnd() &&
       gemm_node.InputDefs().size() <= 2 &&  // C is missing
-      output_node_ptr->OpType() == "Transpose") {
+      output_node_ptr->OpType() == "Transpose" &&
+      IsMatrixTranspose(*output_node_ptr)) {
     Node& output_node = *graph.GetNode(output_node_ptr->Index());
     // (AB)' = B'A' : reverse the inputs
     std::reverse(new_gemm_input_defs.begin(), new_gemm_input_defs.end());
@@ -107,6 +136,7 @@ bool GemmTransposeFusion::SatisfyCondition(const Graph& graph, const Node& node,
   for (auto node_it = node.InputNodesBegin(); node_it != node.InputNodesEnd(); ++node_it) {
     if (graph_utils::IsSupportedOptypeVersionAndDomain(*node_it, "Transpose", {1, 13, 21, 23, 24, 25}) &&
         !graph.NodeProducesGraphOutput(*node_it) &&
+        IsMatrixTranspose(*node_it) &&
         // Make sure the two nodes do not span execution providers.
         node_it->GetExecutionProviderType() == node.GetExecutionProviderType()) {
       // acceptable if all consumer(s) are gemm node(s)
@@ -131,6 +161,7 @@ bool GemmTransposeFusion::SatisfyCondition(const Graph& graph, const Node& node,
   if (next_node_it != node.OutputNodesEnd() &&
       graph_utils::IsSupportedOptypeVersionAndDomain(*next_node_it, "Transpose", {1, 13, 21, 23, 24, 25}) &&
       next_node_it->GetInputEdgesCount() == 1 &&
+      IsMatrixTranspose(*next_node_it) &&
       // Make sure the two nodes do not span execution providers.
       next_node_it->GetExecutionProviderType() == node.GetExecutionProviderType()) {
     return true;

--- a/onnxruntime/test/optimizer/graph_transform_test.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test.cc
@@ -4816,6 +4816,110 @@ TEST_F(GraphTransformationTests, GemmTransposeFusionInputOutput2) {
   ASSERT_TRUE(new_input_defs[1]->Name() == "A");
 }
 
+TEST_F(GraphTransformationTests, GemmTransposeFusionOnlyFusesMatrixTranspose) {
+  enum class TransposeLocation {
+    InputA,
+    InputB,
+    Output,
+  };
+
+  auto run_case = [&](TransposeLocation location, bool has_perm, const std::vector<int64_t>& perm,
+                      bool expect_fusion) {
+    auto build_test_case = [&](ModelTestBuilder& builder) {
+      auto* input_a = builder.MakeInput<float>({{3, 3}});
+      auto* input_b = builder.MakeInput<float>({{3, 3}});
+      auto* gemm_output = builder.MakeIntermediate<float>(std::vector<int64_t>{3, 3});
+      auto* output = builder.MakeOutput<float>(std::vector<int64_t>{3, 3});
+
+      NodeArg* gemm_input_a = input_a;
+      NodeArg* gemm_input_b = input_b;
+      if (location == TransposeLocation::InputA || location == TransposeLocation::InputB) {
+        NodeArg* transpose_input = location == TransposeLocation::InputA ? input_a : input_b;
+        auto* transpose_output = builder.MakeIntermediate<float>(std::vector<int64_t>{3, 3});
+        auto& transpose = builder.AddNode("Transpose", {transpose_input}, {transpose_output});
+        if (has_perm) {
+          transpose.AddAttribute("perm", perm);
+        }
+
+        if (location == TransposeLocation::InputA) {
+          gemm_input_a = transpose_output;
+        } else {
+          gemm_input_b = transpose_output;
+        }
+      }
+
+      auto& gemm = builder.AddNode("Gemm", {gemm_input_a, gemm_input_b}, {gemm_output});
+      gemm.AddAttribute("transA", static_cast<int64_t>(0));
+      gemm.AddAttribute("transB", static_cast<int64_t>(0));
+      gemm.AddAttribute("alpha", 1.0f);
+      gemm.AddAttribute("beta", 1.0f);
+
+      if (location == TransposeLocation::Output) {
+        auto& transpose = builder.AddNode("Transpose", {gemm_output}, {output});
+        if (has_perm) {
+          transpose.AddAttribute("perm", perm);
+        }
+      } else {
+        builder.AddNode("Identity", {gemm_output}, {output});
+      }
+    };
+
+    auto post_graph_checker = [expect_fusion](Graph& graph) {
+      auto op_to_count = CountOpsInGraph(graph);
+      TEST_RETURN_IF_NOT(op_to_count["Gemm"] == 1);
+      TEST_RETURN_IF_NOT(op_to_count["Transpose"] == (expect_fusion ? 0 : 1));
+      return Status::OK();
+    };
+
+    auto rule_transformer = std::make_unique<RuleBasedGraphTransformer>("RuleTransformerL1");
+    ASSERT_STATUS_OK(rule_transformer->Register(std::make_unique<GemmTransposeFusion>()));
+    ASSERT_STATUS_OK(TestGraphTransformer(build_test_case, 21, *logger_, std::move(rule_transformer),
+                                          TransformerLevel::Level1, 1, nullptr, post_graph_checker));
+  };
+
+  // An explicit identity permutation must not toggle transA or transB.
+  run_case(TransposeLocation::InputA, true, {0, 1}, false);
+  run_case(TransposeLocation::InputB, true, {0, 1}, false);
+  run_case(TransposeLocation::Output, true, {0, 1}, false);
+  // An explicit matrix transpose is still fused.
+  run_case(TransposeLocation::InputA, true, {1, 0}, true);
+  run_case(TransposeLocation::InputB, true, {1, 0}, true);
+  run_case(TransposeLocation::Output, true, {1, 0}, true);
+  // For rank-2 input, an omitted perm defaults to the matrix transpose.
+  run_case(TransposeLocation::InputA, false, {}, true);
+  run_case(TransposeLocation::InputB, false, {}, true);
+  run_case(TransposeLocation::Output, false, {}, true);
+
+  // A higher-rank transpose cannot be represented by Gemm's matrix-only transA/transB attributes,
+  // even when it swaps the last two dimensions.
+  auto build_higher_rank_test_case = [](ModelTestBuilder& builder) {
+    auto* input_a = builder.MakeInput<float>(std::nullopt);
+    auto* input_b = builder.MakeInput<float>(std::nullopt);
+    auto* transpose_output = builder.MakeIntermediate();
+    auto* gemm_output = builder.MakeIntermediate();
+    auto* output = builder.MakeOutput();
+
+    auto& transpose = builder.AddNode("Transpose", {input_a}, {transpose_output});
+    transpose.AddAttribute("perm", std::vector<int64_t>{0, 2, 1});
+    auto& gemm = builder.AddNode("Gemm", {transpose_output, input_b}, {gemm_output});
+    gemm.AddAttribute("transA", static_cast<int64_t>(0));
+    gemm.AddAttribute("transB", static_cast<int64_t>(0));
+    gemm.AddAttribute("alpha", 1.0f);
+    gemm.AddAttribute("beta", 1.0f);
+    builder.AddNode("Identity", {gemm_output}, {output});
+  };
+  auto post_higher_rank_graph_checker = [](Graph& graph) {
+    auto op_to_count = CountOpsInGraph(graph);
+    TEST_RETURN_IF_NOT(op_to_count["Gemm"] == 1);
+    TEST_RETURN_IF_NOT(op_to_count["Transpose"] == 1);
+    return Status::OK();
+  };
+  auto rule_transformer = std::make_unique<RuleBasedGraphTransformer>("RuleTransformerHigherRank");
+  ASSERT_STATUS_OK(rule_transformer->Register(std::make_unique<GemmTransposeFusion>()));
+  ASSERT_STATUS_OK(TestGraphTransformer(build_higher_rank_test_case, 21, *logger_, std::move(rule_transformer),
+                                        TransformerLevel::Level1, 1, nullptr, post_higher_rank_graph_checker));
+}
+
 // Sum(Gemm(A, B, _), C) -> Gemm(A, B, C)
 TEST_F(GraphTransformationTests, GemmSumFusionBasic) {
   constexpr const ORTCHAR_T* model_uri = MODEL_FOLDER "fusion/gemm_sum_basic.onnx";


### PR DESCRIPTION
### Description

Restricts GemmTransposeFusion to true 2-D matrix transposes. Identity and higher-rank permutations remain in the graph, while an omitted permutation is fused only when the input rank is known to be 2.

Adds regression coverage for input A, input B, and output transposes with identity, matrix, default, and higher-rank permutations.

### Motivation and Context

Fixes #32228. Folding an identity Transpose previously toggled Gemm transA/transB and could silently produce incorrect results.

### Validation

- Built onnxruntime_test_all (Release, CPU)
- GraphTransformationTests.GemmTransposeFusionOnlyFusesMatrixTranspose
- GraphTransformationTests.GemmTransposeFusion* (7 tests passed)
- clang-format dry run
