### PR TITLE
[perftest] Add opt-in VitisAI NPU shared allocator for plugin EP I/O

### DIFF
--- a/onnxruntime/test/perftest/command_args_parser.cc
+++ b/onnxruntime/test/perftest/command_args_parser.cc
@@ -196,7 +196,13 @@ ABSL_FLAG(bool, X, DefaultPerformanceTestConfig().run_config.use_extensions, "Re
 ABSL_FLAG(std::string, plugin_ep_libs, "",
           "Specifies a list of plugin execution provider (EP) registration names and their corresponding shared libraries to register.\n"
           "[Usage]: --plugin_ep_libs \"plugin_ep_name_1|plugin_ep_1.dll plugin_ep_name_2|plugin_ep_2.dll ... \"");
-ABSL_FLAG(std::string, plugin_eps, "", "Specifies a semicolon-separated list of plugin execution providers (EPs) to use.");
+ABSL_FLAG(std::string, plugin_eps, "",
+          "Specifies a semicolon-separated list of plugin execution providers (EPs) to use.\n"
+          "  [VitisAI only] [enable_npu_shared_memory_allocator]: pass via --plugin_ep_options for the \"VitisAI\" entry\n"
+          "  to allocate I/O tensors from the VitisAI plugin EP's shared NPU allocator instead of the default CPU\n"
+          "  allocator. Defaults to '0' (disabled), i.e. VitisAI EP runs with the default CPU allocator unless this\n"
+          "  is set. Combine with '--plugin_ep_options \"enable_npu_shared_memory_allocator|1 try_use_zero_copy|1\"'\n"
+          "  and '-I' to also exercise the EP's zero-copy bind path.");
 ABSL_FLAG(std::string, plugin_ep_options, "",
           "Specifies provider options for each EP listed in --plugin_eps. Options (key-value pairs) for each EP are separated by space and EPs are separated by semicolons.\n"
           "[Usage]: --plugin_ep_options \"ep_1_option_1_key|ep_1_option_1_value ...;ep_2_option_1_key|ep_2_option_1_value ...;... \" or \n"

--- a/onnxruntime/test/perftest/command_args_parser.cc
+++ b/onnxruntime/test/perftest/command_args_parser.cc
@@ -198,7 +198,7 @@ ABSL_FLAG(std::string, plugin_ep_libs, "",
           "[Usage]: --plugin_ep_libs \"plugin_ep_name_1|plugin_ep_1.dll plugin_ep_name_2|plugin_ep_2.dll ... \"");
 ABSL_FLAG(std::string, plugin_eps, "",
           "Specifies a semicolon-separated list of plugin execution providers (EPs) to use.\n"
-          "  [VitisAI only] [enable_npu_shared_memory_allocator]: pass via --plugin_ep_options for the \"VitisAI\" entry\n"
+          "  [VitisAIExecutionProvider only] [enable_npu_shared_memory_allocator]: pass via --plugin_ep_options for the \"VitisAIExecutionProvider\" entry\n"
           "  to allocate I/O tensors from the VitisAI plugin EP's shared NPU allocator instead of the default CPU\n"
           "  allocator. Defaults to '0' (disabled), i.e. VitisAI EP runs with the default CPU allocator unless this\n"
           "  is set. Combine with '--plugin_ep_options \"enable_npu_shared_memory_allocator|1 try_use_zero_copy|1\"'\n"

--- a/onnxruntime/test/perftest/ort_test_session.cc
+++ b/onnxruntime/test/perftest/ort_test_session.cc
@@ -110,6 +110,54 @@ OnnxRuntimeTestSession::OnnxRuntimeTestSession(Ort::Env& env, std::random_device
         device_memory_name_.empty()) {
       device_memory_name_ = CUDA;
     }
+
+    // VitisAI NPU shared allocator: opt-in only, via
+    // --plugin_ep_options "enable_npu_shared_memory_allocator|1" for the
+    // "VitisAI" entry in --plugin_eps (mirrors QNN's
+    // enable_htp_shared_memory_allocator naming below). Without this option,
+    // the VitisAI plugin EP still runs inference normally, but I/O tensors
+    // stay on the default CPU allocator -- useful as a CPU-allocator baseline
+    // while still exercising the plugin EP (as opposed to allocator + EP both
+    // varying at once).
+    //
+    // When enabled, fetch the EP's shared allocator (e.g. a page-aligned,
+    // zero-copy-capable NPU allocator) via Ort::Env::CreateSharedAllocator()
+    // and route I/O tensor allocation through it instead. Unlike QNN/CUDA/
+    // OpenVINO below, VitisAI's allocator is owned by the plugin EP factory
+    // rather than registered by name in core/framework/allocator.h, so it
+    // cannot be obtained by constructing an Ort::MemoryInfo from a string name
+    // -- it must come from the OrtEpDevice via CreateSharedAllocator().
+    auto& plugin_ep_list = performance_test_config.machine_config.plugin_provider_type_list;
+    auto vitisai_ep_it = std::find(plugin_ep_list.begin(), plugin_ep_list.end(), "VitisAI");
+    if (device_memory_name_.empty() && vitisai_ep_it != plugin_ep_list.end()) {
+      std::vector<std::unordered_map<std::string, std::string>> plugin_ep_options_list;
+      ParseEpOptions(ToUTF8String(performance_test_config.run_config.ep_runtime_config_string),
+                     plugin_ep_options_list);
+      const size_t vitisai_ep_index = static_cast<size_t>(vitisai_ep_it - plugin_ep_list.begin());
+      bool enable_npu_allocator = false;
+      if (vitisai_ep_index < plugin_ep_options_list.size()) {
+        auto opt_it = plugin_ep_options_list[vitisai_ep_index].find("enable_npu_shared_memory_allocator");
+        enable_npu_allocator = opt_it != plugin_ep_options_list[vitisai_ep_index].end() && opt_it->second == "1";
+      }
+
+      if (enable_npu_allocator) {
+        for (auto& device : env.GetEpDevices()) {
+          if (std::string(device.EpName()) != "VitisAI") continue;
+
+          try {
+            Ort::UnownedAllocator vitisai_allocator = env.CreateSharedAllocator(
+                device, OrtDeviceMemoryType_HOST_ACCESSIBLE, OrtDeviceAllocator, nullptr);
+            allocator_ = vitisai_allocator;
+            device_memory_name_ = "VitisAINpuAllocator";
+          } catch (const Ort::Exception& e) {
+            // The VitisAI EP build/config in use doesn't expose a shared allocator
+            // (e.g. no NPU allocator support). Fall back to the default allocator.
+            fprintf(stderr, "[WARNING] VitisAI EP does not support a shared allocator: %s\n", e.what());
+          }
+          break;
+        }
+      }
+    }
   }
 
   provider_name_ = performance_test_config.machine_config.provider_type_name;
@@ -975,7 +1023,11 @@ select from 'TF8', 'TF16', 'UINT8', 'FLOAT', 'ITENSOR'. \n)");
     input_names_[i] = input_names_str_[i].c_str();
   }
 
-  if (!device_memory_name_.empty()) {
+  // Note: "VitisAINpuAllocator" is a plugin-EP-owned shared allocator already
+  // fetched and assigned to allocator_ above via CreateSharedAllocator(). It has
+  // no entry in core/framework/allocator.h's name table, so it must skip the
+  // generic Ort::MemoryInfo-by-name construction used by CUDA/QNN/OpenVINO.
+  if (!device_memory_name_.empty() && device_memory_name_ != "VitisAINpuAllocator") {
     Ort::MemoryInfo memory_info(nullptr);  // Default initialize, will be overwritten
     if (device_memory_name_ == CUDA) {
       memory_info = Ort::MemoryInfo(device_memory_name_.data(), OrtArenaAllocator, 0, OrtMemTypeDefault);

--- a/onnxruntime/test/perftest/ort_test_session.cc
+++ b/onnxruntime/test/perftest/ort_test_session.cc
@@ -113,7 +113,7 @@ OnnxRuntimeTestSession::OnnxRuntimeTestSession(Ort::Env& env, std::random_device
 
     // VitisAI NPU shared allocator: opt-in only, via
     // --plugin_ep_options "enable_npu_shared_memory_allocator|1" for the
-    // "VitisAI" entry in --plugin_eps (mirrors QNN's
+    // "VitisAIExecutionProvider" entry in --plugin_eps (mirrors QNN's
     // enable_htp_shared_memory_allocator naming below). Without this option,
     // the VitisAI plugin EP still runs inference normally, but I/O tensors
     // stay on the default CPU allocator -- useful as a CPU-allocator baseline
@@ -142,7 +142,7 @@ OnnxRuntimeTestSession::OnnxRuntimeTestSession(Ort::Env& env, std::random_device
 
       if (enable_npu_allocator) {
         for (auto& device : env.GetEpDevices()) {
-          if (std::string(device.EpName()) != "VitisAI") continue;
+          if (std::string(device.EpName()) != "VitisAIExecutionProvider") continue;
 
           try {
             Ort::UnownedAllocator vitisai_allocator = env.CreateSharedAllocator(

--- a/onnxruntime/test/perftest/ort_test_session.cc
+++ b/onnxruntime/test/perftest/ort_test_session.cc
@@ -128,7 +128,7 @@ OnnxRuntimeTestSession::OnnxRuntimeTestSession(Ort::Env& env, std::random_device
     // cannot be obtained by constructing an Ort::MemoryInfo from a string name
     // -- it must come from the OrtEpDevice via CreateSharedAllocator().
     auto& plugin_ep_list = performance_test_config.machine_config.plugin_provider_type_list;
-    auto vitisai_ep_it = std::find(plugin_ep_list.begin(), plugin_ep_list.end(), "VitisAI");
+    auto vitisai_ep_it = std::find(plugin_ep_list.begin(), plugin_ep_list.end(), "VitisAIExecutionProvider");
     if (device_memory_name_.empty() && vitisai_ep_it != plugin_ep_list.end()) {
       std::vector<std::unordered_map<std::string, std::string>> plugin_ep_options_list;
       ParseEpOptions(ToUTF8String(performance_test_config.run_config.ep_runtime_config_string),


### PR DESCRIPTION
### Description

Adds an opt-in `enable_npu_shared_memory_allocator` plugin EP option to
`onnxruntime_perf_test` so I/O tensors can be allocated from the VitisAI plugin
EP's own shared NPU allocator instead of the default CPU allocator.

When the option is set to `1` for the `"VitisAI"` entry in `--plugin_eps`, the
test session locates the `OrtEpDevice` whose `EpName()` is `"VitisAI"` and
obtains its allocator through
`Ort::Env::CreateSharedAllocator(device, OrtDeviceMemoryType_HOST_ACCESSIBLE, OrtDeviceAllocator, nullptr)`.
That allocator is then used for input tensors and for statically shaped
pre-allocated output tensors.

Unlike CUDA, QNN, and OpenVINO, VitisAI's allocator is owned by the plugin EP
factory rather than registered by name in `core/framework/allocator.h`, so it
cannot be reached by constructing an `Ort::MemoryInfo` from a string name. The
`"VitisAINpuAllocator"` sentinel is therefore excluded from that generic
by-name path.

The option defaults to `0`, leaving existing invocations unchanged. If the EP
build in use exposes no shared allocator, `CreateSharedAllocator` throws and the
run warns and continues on the default allocator rather than failing.

Changes are confined to `onnxruntime/test/perftest`:

- `ort_test_session.cc` — option parsing, shared allocator lookup, sentinel
  handling, and fallback.
- `command_args_parser.cc` — documents the option, its default, and how to
  combine it with `try_use_zero_copy|1` and `-I` in the `--plugin_eps` help text.

Test-only change; no EP or runtime code is touched.

### Motivation and Context

`onnxruntime_perf_test` previously always allocated I/O tensors from the default
CPU allocator when driving the VitisAI plugin EP. The EP's own allocator is
page-aligned and zero-copy capable.

Making this opt-in rather than automatic keeps a meaningful baseline: the
default run and the NPU-allocator run differ only in the allocator, so any
delta is attributable to the allocator instead of to the allocator and the EP
changing together. QNN already establishes this pattern with
`enable_htp_shared_memory_allocator`, and the new option deliberately mirrors
that naming so the two behave predictably alongside each other.