### PR TITLE
Added a helper function to follow HTTP 3xx redirects in download functions, preventing failures due to 302 responses.

### DIFF
--- a/js/node/script/install-utils.js
+++ b/js/node/script/install-utils.js
@@ -3,6 +3,19 @@
 
 'use strict';
 
+// Fix: follow HTTP 3xx redirects in the download helpers.
+//
+// Node's native `https.get()` does NOT follow redirects, and the previous code
+// rejected any non-200 status. Feeds such as NuGet / GitHub release CDN return
+// 302 redirects (e.g. to release-assets.githubusercontent.com or Azure blob
+// endpoints), which made postinstall fail with:
+//
+//   Error: Failed to download build list. HTTP status code = 302
+//
+// This patch adds a small `followRedirects` helper used by both `downloadFile`
+// and `downloadJson`. It caps the hop count to avoid redirect loops and keeps
+// behavior identical otherwise.
+
 const fs = require('fs');
 const https = require('https');
 const { execFileSync } = require('child_process');
@@ -10,11 +23,39 @@ const path = require('path');
 const os = require('os');
 const AdmZip = require('adm-zip'); // Use adm-zip instead of spawn
 
+const MAX_REDIRECTS = 5;
+
+/**
+ * Performs an HTTPS GET, following up to MAX_REDIRECTS 3xx redirects.
+ * Rejects on a non-2xx final status.
+ */
+function getWithRedirects(url, redirectsLeft = MAX_REDIRECTS) {
+  return new Promise((resolve, reject) => {
+    https
+      .get(url, (res) => {
+        const { statusCode } = res;
+        if (statusCode >= 300 && statusCode < 400 && res.headers.location) {
+          // Consume and close the response to free the socket.
+          res.resume();
+          if (redirectsLeft <= 0) {
+            reject(new Error(`Too many redirects while downloading ${url}`));
+            return;
+          }
+          const nextUrl = new URL(res.headers.location, url).toString();
+          getWithRedirects(nextUrl, redirectsLeft - 1).then(resolve, reject);
+          return;
+        }
+        resolve(res);
+      })
+      .on('error', reject);
+  });
+}
+
 async function downloadFile(url, dest) {
   return new Promise((resolve, reject) => {
     const file = fs.createWriteStream(dest);
-    https
-      .get(url, (res) => {
+    getWithRedirects(url)
+      .then((res) => {
         if (res.statusCode !== 200) {
           file.close();
           fs.unlinkSync(dest);
@@ -32,8 +73,13 @@ async function downloadFile(url, dest) {
           reject(err);
         });
       })
-      .on('error', (err) => {
-        fs.unlinkSync(dest);
+      .catch((err) => {
+        file.close();
+        try {
+          fs.unlinkSync(dest);
+        } catch (e) {
+          // ignore
+        }
         reject(err);
       });
   });
@@ -41,8 +87,8 @@ async function downloadFile(url, dest) {
 
 async function downloadJson(url) {
   return new Promise((resolve, reject) => {
-    https
-      .get(url, (res) => {
+    getWithRedirects(url)
+      .then((res) => {
         const { statusCode } = res;
         const contentType = res.headers['content-type'];
 
@@ -51,13 +97,16 @@ async function downloadJson(url) {
           return;
         }
         if (statusCode >= 400 && statusCode < 500) {
+          res.resume();
           resolve(null);
           return;
         } else if (statusCode !== 200) {
+          res.resume();
           reject(new Error(`Failed to download build list. HTTP status code = ${statusCode}`));
           return;
         }
         if (!contentType || !/^application\/json/.test(contentType)) {
+          res.resume();
           reject(new Error(`unexpected content type: ${contentType}`));
           return;
         }
@@ -77,9 +126,7 @@ async function downloadJson(url) {
           reject(err);
         });
       })
-      .on('error', (err) => {
-        reject(err);
-      });
+      .catch(reject);
   });
 }
 

--- a/js/node/script/install-utils.js
+++ b/js/node/script/install-utils.js
@@ -12,7 +12,7 @@
 //
 //   Error: Failed to download build list. HTTP status code = 302
 //
-// This patch adds a small `followRedirects` helper used by both `downloadFile`
+// This patch adds a small `getWithRedirects` helper used by both `downloadFile`
 // and `downloadJson`. It caps the hop count to avoid redirect loops and keeps
 // behavior identical otherwise.
 


### PR DESCRIPTION
## Description

Fix the `onnxruntime-node` postinstall script so it can install CUDA binaries behind feeds/proxies that return HTTP 3xx redirects.

Node's native `https.get()` does **not** follow redirects. The two download helpers in `js/node/script/install-utils.js` (`downloadFile` and `downloadJson`) treated any non-200 status as a hard failure, so a 302 response from the NuGet feed (or a proxy in front of it) aborted the install with:

```
Error: Failed to download build list. HTTP status code = 302
```

This PR adds a small `getWithRedirects()` helper that follows up to `MAX_REDIRECTS` (5) 3xx hops, guards against redirect loops, and preserves the exact error behavior for all non-redirect statuses. Both `downloadFile` and `downloadJson` now route their requests through it.

No business logic (package resolution, manifest extraction, CUDA flag parsing, etc.) was changed.

### Changes
- `js/node/script/install-utils.js`
  - Add `MAX_REDIRECTS` constant and `getWithRedirects()` helper
  - `downloadFile()`: use `getWithRedirects()` instead of bare `https.get()`
  - `downloadJson()`: same replacement


## Motivation and Context


- **Why is this change required?** `npm install` of any package depending on `onnxruntime-node` fails deterministically whenever the NuGet feed (or the HTTP proxy in front of it) answers with a 302 redirect. This is reproducible without any special setup: the GitHub-release feed redirects to `release-assets.githubusercontent.com`, and NuGet redirects to Azure blob endpoints. `curl -L` succeeds on the same URLs, confirming the failure is purely a missing redirect-follow in the install script — not a network problem.

- **What problem does it solve?** Installations behind HTTP proxies and against redirecting feeds now complete instead of aborting with `Failed to download build list. HTTP status code = 302`.

- **Validation:** Reproduced the failure with a local HTTP server returning 302 for both JSON and binary downloads; verified the fix follows the redirect and succeeds. Also verified `npm install -g gitnexus@latest` (a package that depends on `onnxruntime-node`) completes with the patched script.