### PR TITLE
[CUDA] Parallelize low-lane int64 CumSum

### DIFF
--- a/onnxruntime/core/providers/cuda/math/cumsum.cc
+++ b/onnxruntime/core/providers/cuda/math/cumsum.cc
@@ -129,13 +129,16 @@ Status CumSum::ComputeInternal(OpKernelContext* ctx) const {
                exclusive_,
                reverse_);
   } else if (input->IsDataType<int64_t>()) {
-    CumSumImpl(Stream(ctx), reinterpret_cast<const typename ToCudaType<int64_t>::MappedType*>(input->Data<int64_t>()),
-               fast_divmod_input_dim_along_axis,
-               fast_divmod_input_stride_along_axis,
-               reinterpret_cast<typename ToCudaType<int64_t>::MappedType*>(output.MutableData<int64_t>()),
-               output_shape.Size(),
-               exclusive_,
-               reverse_);
+    ORT_RETURN_IF_ERROR(CumSumInt64Impl(
+        Stream(ctx),
+        reinterpret_cast<const typename ToCudaType<int64_t>::MappedType*>(input->Data<int64_t>()),
+        fast_divmod_input_dim_along_axis,
+        fast_divmod_input_stride_along_axis,
+        reinterpret_cast<typename ToCudaType<int64_t>::MappedType*>(output.MutableData<int64_t>()),
+        output_shape.Size(),
+        exclusive_,
+        reverse_,
+        GetDeviceProp().multiProcessorCount));
   } else if (input->IsDataType<uint32_t>()) {
     CumSumImpl(Stream(ctx), reinterpret_cast<const typename ToCudaType<uint32_t>::MappedType*>(input->Data<uint32_t>()),
                fast_divmod_input_dim_along_axis,

--- a/onnxruntime/core/providers/cuda/math/cumsum_impl.cu
+++ b/onnxruntime/core/providers/cuda/math/cumsum_impl.cu
@@ -2,12 +2,16 @@
 // Licensed under the MIT License.
 
 #include "core/providers/cuda/cu_inc/common.cuh"
+#include "core/providers/cuda/cu_inc/cub.cuh"
 #include "core/providers/cuda/shared_inc/fast_divmod.h"
 
 #include "cumsum_impl.h"
 
 namespace onnxruntime {
 namespace cuda {
+
+constexpr int kCumSumBlockSize = 256;
+constexpr int kCumSumBlockMinWidth = 4;
 
 template <typename T>
 __global__ void _CumSumKernel(
@@ -68,6 +72,52 @@ __global__ void _CumSumKernel(
   output_data[indices_index] = sum;
 }
 
+template <int BlockSize>
+__global__ void _CumSumInt64BlockKernel(
+    const int64_t* input_data,
+    int64_t* output_data,
+    const int width,
+    const int inner,
+    const bool exclusive,
+    const bool reverse) {
+  using BlockScan = cub::BlockScan<uint64_t, BlockSize>;
+  __shared__ typename BlockScan::TempStorage temp_storage;
+  __shared__ uint64_t running_total;
+
+  const int64_t lane = blockIdx.x;
+  const int64_t outer = lane / inner;
+  const int64_t inner_index = lane % inner;
+  const int tid = threadIdx.x;
+
+  if (tid == 0) {
+    running_total = 0;
+  }
+  __syncthreads();
+
+  for (int tile = 0; tile < width; tile += BlockSize) {
+    const int axis_offset = tile + tid;
+    const bool is_valid = axis_offset < width;
+    const int axis_index = reverse ? width - 1 - axis_offset : axis_offset;
+    const int64_t input_index =
+        is_valid ? (outer * width + axis_index) * inner + inner_index : 0;
+    const uint64_t value = is_valid ? static_cast<uint64_t>(input_data[input_index]) : 0;
+
+    uint64_t prefix = 0;
+    uint64_t aggregate = 0;
+    BlockScan(temp_storage).InclusiveSum(value, prefix, aggregate);
+
+    if (is_valid) {
+      reinterpret_cast<uint64_t*>(output_data)[input_index] =
+          running_total + prefix - (exclusive ? value : 0);
+    }
+    __syncthreads();
+    if (tid == 0) {
+      running_total += aggregate;
+    }
+    __syncthreads();
+  }
+}
+
 template <typename T>
 void CumSumImpl(
     cudaStream_t stream,
@@ -89,6 +139,48 @@ void CumSumImpl(
                                                                                 exclusive,
                                                                                 reverse);
   }
+}
+
+Status CumSumInt64Impl(
+    cudaStream_t stream,
+    const int64_t* input_data,
+    const fast_divmod& input_dim_along_axis,
+    const fast_divmod& input_stride_along_axis,
+    int64_t* output_data,
+    int64_t output_size,
+    bool exclusive,
+    bool reverse,
+    int multiprocessor_count) {
+  if (output_size <= 0) {
+    return Status::OK();
+  }
+
+  const int width = input_dim_along_axis.d_;
+  ORT_RETURN_IF_NOT(width > 0, "CumSum scan axis must have positive length when output is non-empty.");
+  const int64_t lanes = output_size / width;
+
+  // The generic kernel recomputes every prefix independently. For low-lane scans, use one
+  // cooperative block per lane to perform linear rather than quadratic work along the axis.
+  if (width >= kCumSumBlockMinWidth && lanes <= multiprocessor_count) {
+    _CumSumInt64BlockKernel<kCumSumBlockSize><<<static_cast<int>(lanes), kCumSumBlockSize, 0, stream>>>(
+        input_data,
+        output_data,
+        width,
+        input_stride_along_axis.d_,
+        exclusive,
+        reverse);
+    return CUDA_CALL(cudaGetLastError());
+  }
+
+  CumSumImpl<int64_t>(stream,
+                      input_data,
+                      input_dim_along_axis,
+                      input_stride_along_axis,
+                      output_data,
+                      output_size,
+                      exclusive,
+                      reverse);
+  return CUDA_CALL(cudaGetLastError());
 }
 
 template void CumSumImpl<int32_t>(

--- a/onnxruntime/core/providers/cuda/math/cumsum_impl.h
+++ b/onnxruntime/core/providers/cuda/math/cumsum_impl.h
@@ -20,5 +20,16 @@ void CumSumImpl(
     bool exclusive,
     bool reverse);
 
+Status CumSumInt64Impl(
+    cudaStream_t stream,
+    const int64_t* input_data,
+    const fast_divmod& input_dim_along_axis,
+    const fast_divmod& input_stride_along_axis,
+    int64_t* output_data,
+    int64_t output_size,
+    bool exclusive,
+    bool reverse,
+    int multiprocessor_count);
+
 }  // namespace cuda
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/cpu/math/cumsum_test.cc
+++ b/onnxruntime/test/providers/cpu/math/cumsum_test.cc
@@ -2,9 +2,9 @@
 // Licensed under the MIT License.
 
 #include "gtest/gtest.h"
+#include "core/session/onnxruntime_session_options_config_keys.h"
 #ifdef USE_WEBGPU
 #include "core/providers/webgpu/webgpu_provider_options.h"
-#include "core/session/onnxruntime_session_options_config_keys.h"
 #endif
 #include "test/providers/provider_test_utils.h"
 #include "test/util/include/default_providers.h"
@@ -22,6 +22,49 @@ void RunEmptyAxisFailureTest(std::vector<std::unique_ptr<IExecutionProvider>> ex
   test.AddOutput<float>("y", {5}, {1., 3., 6., 10., 15.});
 
   test.Run(OpTester::ExpectResult::kExpectFailure, "", {}, nullptr, &execution_providers);
+}
+
+void RunCudaInt64BlockScanTest(int64_t outer, int64_t width, int64_t inner) {
+  const int64_t element_count = outer * width * inner;
+  std::vector<int64_t> input(element_count);
+  for (int64_t i = 0; i < element_count; ++i) {
+    input[i] = i % 7 - 3;
+  }
+
+  for (const bool exclusive : {false, true}) {
+    for (const bool reverse : {false, true}) {
+      std::vector<int64_t> expected(element_count);
+      for (int64_t outer_index = 0; outer_index < outer; ++outer_index) {
+        for (int64_t inner_index = 0; inner_index < inner; ++inner_index) {
+          int64_t total = 0;
+          for (int64_t i = 0; i < width; ++i) {
+            const int64_t axis_index = reverse ? width - 1 - i : i;
+            const int64_t index = (outer_index * width + axis_index) * inner + inner_index;
+            if (exclusive) {
+              expected[index] = total;
+            }
+            total += input[index];
+            if (!exclusive) {
+              expected[index] = total;
+            }
+          }
+        }
+      }
+
+      OpTester test("CumSum", 11, onnxruntime::kOnnxDomain);
+      test.AddAttribute<int64_t>("exclusive", exclusive);
+      test.AddAttribute<int64_t>("reverse", reverse);
+      test.AddInput<int64_t>("x", {outer, width, inner}, input);
+      test.AddInput<int64_t>("axis", {}, {1});
+      test.AddOutput<int64_t>("y", {outer, width, inner}, expected);
+
+      SessionOptions session_options;
+      ASSERT_STATUS_OK(session_options.config_options.AddConfigEntry(kOrtSessionOptionsDisableCPUEPFallback, "1"));
+      test.Config(session_options)
+          .ConfigEp(DefaultCudaExecutionProvider())
+          .RunWithConfig();
+    }
+  }
 }
 
 }  // namespace
@@ -283,6 +326,16 @@ TEST(CumSumTest, _1DTestInt64) {
   test.AddOutput<int64_t>("y", {5}, {1, 3, 6, 10, 15});
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
 }
+
+TEST(CumSumTest, CudaInt64BlockScanMultiTile) {
+  if (!DefaultCudaExecutionProvider()) {
+    GTEST_SKIP() << "CUDA execution provider is not available";
+  }
+
+  RunCudaInt64BlockScanTest(1, 1000, 1);
+  RunCudaInt64BlockScanTest(2, 513, 3);
+}
+
 TEST(CumSumTest, _1DTestdouble) {
   OpTester test("CumSum", 11, onnxruntime::kOnnxDomain);
   test.AddInput<double>("x", {5}, {1., 2., 3., 4., 5.});


### PR DESCRIPTION
Use a CUB block scan for low-lane int64 inputs so decode-time scans do linear work along the scan axis instead of recomputing every prefix independently. Add CUDA-only coverage for multi-tile scans, all exclusive/reverse combinations, and nontrivial outer/inner indexing.

