### PR TITLE
perftest: Use plugin EP device allocators for input/output buffers

### DIFF
--- a/onnxruntime/test/perftest/command_args_parser.cc
+++ b/onnxruntime/test/perftest/command_args_parser.cc
@@ -210,6 +210,8 @@ ABSL_FLAG(std::string, filter_ep_devices, "",
           "Devices that match any of the key-value pair will be appended to the session. --select_ep_devices will take precedence over this option.\n"
           "[Example] --filter_ep_devices \"ov_device|NPU ov_device|CPU\" \n"
           "Above example will append npu device first if available, followed by cpu device.");
+ABSL_FLAG(bool, plugin_ep_force_cpu_allocator, DefaultPerformanceTestConfig().plugin_ep_force_cpu_allocator,
+          "Forces the use of the CPU allocator instead of a plugin EP's own allocator when running with plugin execution providers.\n");
 ABSL_FLAG(bool, compile_ep_context, DefaultPerformanceTestConfig().run_config.compile_ep_context, "Generate an EP context model");
 ABSL_FLAG(std::string, compile_model_path, "model_ctx.onnx", "The compiled model path for saving EP context model. Overwrites if already exists");
 ABSL_FLAG(bool, compile_binary_embed, DefaultPerformanceTestConfig().run_config.compile_binary_embed, "Embed binary blob within EP context node");
@@ -618,6 +620,9 @@ bool CommandLineParser::ParseArguments(PerformanceTestConfig& test_config, int a
       }
     }
   }
+
+  // --plugin_ep_force_cpu_allocator
+  test_config.plugin_ep_force_cpu_allocator = absl::GetFlag(FLAGS_plugin_ep_force_cpu_allocator);
 
   // --compile_ep_context
   test_config.run_config.compile_ep_context = absl::GetFlag(FLAGS_compile_ep_context);

--- a/onnxruntime/test/perftest/common_utils.cc
+++ b/onnxruntime/test/perftest/common_utils.cc
@@ -90,11 +90,11 @@ std::vector<char*> CStringsFromStrings(std::vector<std::string>& utf8_args) {
   return utf8_argv;
 }
 
-void AppendPluginExecutionProviders(Ort::Env& env,
-                                    Ort::SessionOptions& session_options,
-                                    const PerformanceTestConfig& test_config) {
+std::vector<Ort::ConstEpDevice> AppendPluginExecutionProviders(Ort::Env& env,
+                                                               Ort::SessionOptions& session_options,
+                                                               const PerformanceTestConfig& test_config) {
   if (test_config.registered_plugin_eps.empty()) {
-    return;
+    return {};
   }
 
   std::vector<Ort::ConstEpDevice> ep_devices = env.GetEpDevices();
@@ -193,11 +193,53 @@ void AppendPluginExecutionProviders(Ort::Env& env,
     ep_options_map.emplace(ep_list[i], ep_options_list[i]);
   }
 
+  std::vector<Ort::ConstEpDevice> selected_ep_devices;
   for (auto& ep_and_devices : added_ep_devices) {
     auto& ep = ep_and_devices.first;
     auto& devices = ep_and_devices.second;
     session_options.AppendExecutionProvider_V2(env, devices, ep_options_map[ep]);
+    selected_ep_devices.insert(selected_ep_devices.end(), devices.begin(), devices.end());
   }
+
+  return selected_ep_devices;
+}
+
+std::optional<PluginEpAllocatorSelection> GetPluginEpAllocator(Ort::Env& env,
+                                                               const std::vector<Ort::ConstEpDevice>& ep_devices) {
+  // If more than one EP device was appended to the session, there's no single unambiguous device
+  // allocator to pick, so fall back to the CPU allocator.
+  if (ep_devices.size() != 1) {
+    fprintf(stdout, "[Plugin EP] %d EP devices appended. Using the CPU allocator.\n",
+            static_cast<int>(ep_devices.size()));
+    return std::nullopt;
+  }
+
+  const Ort::ConstEpDevice& ep_device = ep_devices[0];
+
+  // Prefer the EP device's default (device) allocator. Its memory is not guaranteed to be
+  // writable from the host (e.g. plain GPU memory), so callers must stage host data through it
+  // using a device data transfer rather than writing to it directly.
+  Ort::ConstMemoryInfo default_mem_info = ep_device.GetMemoryInfo(OrtDeviceMemoryType_DEFAULT);
+  if (default_mem_info) {
+    Ort::UnownedAllocator allocator = env.GetSharedAllocator(default_mem_info);
+    if (allocator) {
+      fprintf(stdout, "[Plugin EP] Using the default allocator.\n");
+      return PluginEpAllocatorSelection{allocator, /*is_host_accessible*/ false};
+    }
+  }
+
+  // Fall back to the EP device's host accessible allocator (e.g. pinned memory) if available.
+  Ort::ConstMemoryInfo host_accessible_mem_info = ep_device.GetMemoryInfo(OrtDeviceMemoryType_HOST_ACCESSIBLE);
+  if (host_accessible_mem_info) {
+    Ort::UnownedAllocator allocator = env.GetSharedAllocator(host_accessible_mem_info);
+    if (allocator) {
+      fprintf(stdout, "[Plugin EP] Using the host accessible allocator.\n");
+      return PluginEpAllocatorSelection{allocator, /*is_host_accessible*/ true};
+    }
+  }
+
+  // No device or host accessible allocator available. The caller falls back to the CPU allocator.
+  return std::nullopt;
 }
 
 bool UsesNvidiaDevice(Ort::Env& env, const PerformanceTestConfig& test_config) {

--- a/onnxruntime/test/perftest/common_utils.cc
+++ b/onnxruntime/test/perftest/common_utils.cc
@@ -206,8 +206,7 @@ std::vector<Ort::ConstEpDevice> AppendPluginExecutionProviders(Ort::Env& env,
 
 std::optional<PluginEpAllocatorSelection> GetPluginEpAllocator(Ort::Env& env,
                                                                const std::vector<Ort::ConstEpDevice>& ep_devices) {
-  // If more than one EP device was appended to the session, there's no single unambiguous device
-  // allocator to pick, so fall back to the CPU allocator.
+  // More than one device appended means no single unambiguous allocator to pick.
   if (ep_devices.size() != 1) {
     fprintf(stdout, "[Plugin EP] %d EP devices appended. Using the CPU allocator.\n",
             static_cast<int>(ep_devices.size()));
@@ -216,9 +215,6 @@ std::optional<PluginEpAllocatorSelection> GetPluginEpAllocator(Ort::Env& env,
 
   const Ort::ConstEpDevice& ep_device = ep_devices[0];
 
-  // Prefer the EP device's default (device) allocator. Its memory is not guaranteed to be
-  // writable from the host (e.g. plain GPU memory), so callers must stage host data through it
-  // using a device data transfer rather than writing to it directly.
   Ort::ConstMemoryInfo default_mem_info = ep_device.GetMemoryInfo(OrtDeviceMemoryType_DEFAULT);
   if (default_mem_info) {
     Ort::UnownedAllocator allocator = env.GetSharedAllocator(default_mem_info);
@@ -228,7 +224,6 @@ std::optional<PluginEpAllocatorSelection> GetPluginEpAllocator(Ort::Env& env,
     }
   }
 
-  // Fall back to the EP device's host accessible allocator (e.g. pinned memory) if available.
   Ort::ConstMemoryInfo host_accessible_mem_info = ep_device.GetMemoryInfo(OrtDeviceMemoryType_HOST_ACCESSIBLE);
   if (host_accessible_mem_info) {
     Ort::UnownedAllocator allocator = env.GetSharedAllocator(host_accessible_mem_info);
@@ -238,7 +233,6 @@ std::optional<PluginEpAllocatorSelection> GetPluginEpAllocator(Ort::Env& env,
     }
   }
 
-  // No device or host accessible allocator available. The caller falls back to the CPU allocator.
   return std::nullopt;
 }
 

--- a/onnxruntime/test/perftest/ort_test_session.cc
+++ b/onnxruntime/test/perftest/ort_test_session.cc
@@ -131,8 +131,7 @@ OnnxRuntimeTestSession::OnnxRuntimeTestSession(Ort::Env& env, std::random_device
         fprintf(stdout, "[Plugin EP] Forcing CPU allocator (--plugin_ep_force_cpu_allocator was specified).\n");
       } else if (auto plugin_ep_allocator = perftest::utils::GetPluginEpAllocator(env, selected_ep_devices)) {
         allocator_ = plugin_ep_allocator->allocator;
-        requires_input_staging_ = !plugin_ep_allocator->is_host_accessible;
-        has_plugin_ep_allocator_ = true;
+        plugin_ep_allocator_selection_ = std::move(plugin_ep_allocator);
       }
     }
   }
@@ -1023,8 +1022,8 @@ select from 'TF8', 'TF16', 'UINT8', 'FLOAT', 'ITENSOR'. \n)");
     // String tensors require host-accessible memory; skip pre-allocation for them when allocator_
     // is device-only and let the session allocate them itself.
     bool is_string_output = tensor_info.GetElementType() == ONNX_TENSOR_ELEMENT_DATA_TYPE_STRING;
-    if (is_dynamic || (device_memory_name_.empty() && !has_plugin_ep_allocator_) ||
-        (requires_input_staging_ && is_string_output)) {
+    if (is_dynamic || (device_memory_name_.empty() && !plugin_ep_allocator_selection_.has_value()) ||
+        (is_string_output && IsAllocatorDeviceOnly())) {
       outputs_.emplace_back(Ort::Value(nullptr));
     } else {
       auto new_value = Ort::Value::CreateTensor(allocator_, output_shape.data(), output_shape.size(), tensor_info.GetElementType());
@@ -1048,8 +1047,20 @@ void OnnxRuntimeTestSession::StoreTestData(size_t test_data_id, size_t input_id,
   test_inputs_[test_data_id][input_id] = std::move(value);
 }
 
+bool OnnxRuntimeTestSession::IsAllocatorDeviceOnly() const {
+  if (plugin_ep_allocator_selection_.has_value()) {
+    return !plugin_ep_allocator_selection_->is_host_accessible;
+  }
+#if defined(USE_CUDA) || defined(USE_TENSORRT) || defined(USE_NV)
+  if (device_memory_name_ == CUDA) {
+    return true;
+  }
+#endif
+  return false;
+}
+
 Ort::Value OnnxRuntimeTestSession::StageInputForPluginEpAllocator(Ort::Value&& value) {
-  if (!has_plugin_ep_allocator_ || !value.IsTensor()) {
+  if (!plugin_ep_allocator_selection_.has_value() || !value.IsTensor()) {
     return std::move(value);
   }
 
@@ -1175,7 +1186,7 @@ void OnnxRuntimeTestSession::CreateAndStoreGeneratedInput(size_t test_data_id, s
   }
 #endif
 
-  if (requires_input_staging_) {
+  if (IsAllocatorDeviceOnly()) {
     // allocator_ is device-only memory; fill a CPU tensor and stage it via StageInputForPluginEpAllocator.
     Ort::AllocatorWithDefaultOptions default_allocator;
     Ort::Value cpu_tensor = Ort::Value::CreateTensor(default_allocator, dims.data(),

--- a/onnxruntime/test/perftest/ort_test_session.cc
+++ b/onnxruntime/test/perftest/ort_test_session.cc
@@ -105,17 +105,32 @@ OnnxRuntimeTestSession::OnnxRuntimeTestSession(Ort::Env& env, std::random_device
       input_names_(m.GetInputCount()),
       input_names_str_(m.GetInputCount()),
       input_length_(m.GetInputCount()),
-      run_config_entries_(performance_test_config.run_config.run_config_entries) {
+      run_config_entries_(performance_test_config.run_config.run_config_entries),
+      env_(env) {
   Ort::SessionOptions session_options;
 
   // Add EP devices if any (created by plugin EP)
   if (!performance_test_config.registered_plugin_eps.empty()) {
-    perftest::utils::AppendPluginExecutionProviders(env, session_options, performance_test_config);
+    std::vector<Ort::ConstEpDevice> selected_ep_devices =
+        perftest::utils::AppendPluginExecutionProviders(env, session_options, performance_test_config);
 
     if (performance_test_config.run_config.enable_cuda_io_binding &&
         perftest::utils::UsesNvidiaDevice(env, performance_test_config) &&
         device_memory_name_.empty()) {
       device_memory_name_ = CUDA;
+    }
+
+    // If IO binding didn't already select a device-specific allocator, pick one from the plugin EP
+    // devices: prefer their default (device) allocator, then a host accessible allocator, else fall
+    // back to the CPU allocator that allocator_ is already initialized with. If more than one EP
+    // device was appended, there's no single unambiguous allocator to pick, so the CPU allocator
+    // is used instead.
+    if (device_memory_name_.empty()) {
+      if (auto plugin_ep_allocator = perftest::utils::GetPluginEpAllocator(env, selected_ep_devices)) {
+        allocator_ = plugin_ep_allocator->allocator;
+        requires_input_staging_ = !plugin_ep_allocator->is_host_accessible;
+        has_plugin_ep_allocator_ = true;
+      }
     }
   }
 
@@ -1001,7 +1016,7 @@ select from 'TF8', 'TF16', 'UINT8', 'FLOAT', 'ITENSOR'. \n)");
     if (is_dynamic) {
       has_dynamic_output_shapes_ = true;
     }
-    if (is_dynamic || device_memory_name_.empty()) {
+    if (is_dynamic || (device_memory_name_.empty() && !has_plugin_ep_allocator_)) {
       outputs_.emplace_back(Ort::Value(nullptr));
     } else {
       auto new_value = Ort::Value::CreateTensor(allocator_, output_shape.data(), output_shape.size(), tensor_info.GetElementType());
@@ -1093,14 +1108,8 @@ static void InitializeTensorWithSeed(int32_t seed, Ort::Value& tensor) {
 void OnnxRuntimeTestSession::CreateAndStoreGeneratedInput(size_t test_data_id, size_t input_idx,
                                                           const std::vector<int64_t>& dims,
                                                           ONNXTensorElementDataType element_type, int32_t seed) {
-  if (device_memory_name_ != CUDA) {
-    Ort::Value input_tensor = Ort::Value::CreateTensor(allocator_, (const int64_t*)dims.data(),
-                                                       dims.size(), element_type);
-    InitializeTensorWithSeed(seed, input_tensor);
-    PreLoadTestData(test_data_id, input_idx, std::move(input_tensor));
-  }
 #if defined(USE_CUDA) || defined(USE_TENSORRT) || defined(USE_NV)
-  else {
+  if (device_memory_name_ == CUDA) {
     Ort::AllocatorWithDefaultOptions default_allocator;
     Ort::Value default_tensor = Ort::Value::CreateTensor(default_allocator, (const int64_t*)dims.data(),
                                                          dims.size(), element_type);
@@ -1118,8 +1127,33 @@ void OnnxRuntimeTestSession::CreateAndStoreGeneratedInput(size_t test_data_id, s
       ORT_THROW("Failed to copy tensor data from CPU to CUDA device. CUDA Error: ", cudaGetErrorString(cuda_err));
     }
     PreLoadTestData(test_data_id, input_idx, std::move(cuda_tensor));
+    return;
   }
 #endif
+
+  if (requires_input_staging_) {
+    // allocator_ is a plugin EP's default (device-only) allocator, e.g. plain GPU memory, which
+    // cannot be safely written to directly from the host. Fill a CPU tensor first, then use ORT's
+    // device-agnostic data transfer to copy it into device memory.
+    Ort::AllocatorWithDefaultOptions default_allocator;
+    Ort::Value cpu_tensor = Ort::Value::CreateTensor(default_allocator, (const int64_t*)dims.data(),
+                                                     dims.size(), element_type);
+    InitializeTensorWithSeed(seed, cpu_tensor);
+
+    Ort::Value device_tensor = Ort::Value::CreateTensor(allocator_, (const int64_t*)dims.data(),
+                                                        dims.size(), element_type);
+    Ort::Status copy_status = env_.CopyTensor(cpu_tensor, device_tensor, nullptr);
+    if (!copy_status.IsOK()) {
+      ORT_THROW("Failed to copy generated input tensor to plugin EP device memory: ", copy_status.GetErrorMessage());
+    }
+    PreLoadTestData(test_data_id, input_idx, std::move(device_tensor));
+    return;
+  }
+
+  Ort::Value input_tensor = Ort::Value::CreateTensor(allocator_, (const int64_t*)dims.data(),
+                                                     dims.size(), element_type);
+  InitializeTensorWithSeed(seed, input_tensor);
+  PreLoadTestData(test_data_id, input_idx, std::move(input_tensor));
 }
 
 bool OnnxRuntimeTestSession::PopulateGeneratedInputTestData(int32_t seed) {

--- a/onnxruntime/test/perftest/ort_test_session.cc
+++ b/onnxruntime/test/perftest/ort_test_session.cc
@@ -120,11 +120,7 @@ OnnxRuntimeTestSession::OnnxRuntimeTestSession(Ort::Env& env, std::random_device
       device_memory_name_ = CUDA;
     }
 
-    // If IO binding didn't already select a device-specific allocator, pick one from the plugin EP
-    // devices: prefer their default (device) allocator, then a host accessible allocator, else fall
-    // back to the CPU allocator that allocator_ is already initialized with. If more than one EP
-    // device was appended, there's no single unambiguous allocator to pick, so the CPU allocator
-    // is used instead.
+    // Pick an allocator from the plugin EP devices unless IO binding already set one.
     if (device_memory_name_.empty()) {
       if (auto plugin_ep_allocator = perftest::utils::GetPluginEpAllocator(env, selected_ep_devices)) {
         allocator_ = plugin_ep_allocator->allocator;
@@ -1016,13 +1012,53 @@ select from 'TF8', 'TF16', 'UINT8', 'FLOAT', 'ITENSOR'. \n)");
     if (is_dynamic) {
       has_dynamic_output_shapes_ = true;
     }
-    if (is_dynamic || (device_memory_name_.empty() && !has_plugin_ep_allocator_)) {
+    // String tensors require host-accessible memory; skip pre-allocation for them when allocator_
+    // is device-only and let the session allocate them itself.
+    bool is_string_output = tensor_info.GetElementType() == ONNX_TENSOR_ELEMENT_DATA_TYPE_STRING;
+    if (is_dynamic || (device_memory_name_.empty() && !has_plugin_ep_allocator_) ||
+        (requires_input_staging_ && is_string_output)) {
       outputs_.emplace_back(Ort::Value(nullptr));
     } else {
       auto new_value = Ort::Value::CreateTensor(allocator_, output_shape.data(), output_shape.size(), tensor_info.GetElementType());
       outputs_.emplace_back(std::move(new_value));
     }
   }
+}
+
+void OnnxRuntimeTestSession::PreLoadTestData(size_t test_data_id, size_t input_id, Ort::Value&& value) {
+  StoreTestData(test_data_id, input_id, StageInputForPluginEpAllocator(std::move(value)));
+}
+
+void OnnxRuntimeTestSession::StoreTestData(size_t test_data_id, size_t input_id, Ort::Value&& value) {
+  if (test_inputs_.size() < test_data_id + 1) {
+    test_inputs_.resize(test_data_id + 1);
+  }
+  if (test_inputs_.at(test_data_id).size() == 0) {
+    for (int i = 0; i < input_length_; i++)
+      test_inputs_[test_data_id].emplace_back(nullptr);
+  }
+  test_inputs_[test_data_id][input_id] = std::move(value);
+}
+
+Ort::Value OnnxRuntimeTestSession::StageInputForPluginEpAllocator(Ort::Value&& value) {
+  if (!has_plugin_ep_allocator_ || !value.IsTensor()) {
+    return std::move(value);
+  }
+
+  Ort::TensorTypeAndShapeInfo tensor_info = value.GetTensorTypeAndShapeInfo();
+  ONNXTensorElementDataType element_type = tensor_info.GetElementType();
+  if (element_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_STRING) {
+    // Strings require host-accessible memory and always live on the CPU regardless of EP.
+    return std::move(value);
+  }
+
+  std::vector<int64_t> shape = tensor_info.GetShape();
+  Ort::Value device_value = Ort::Value::CreateTensor(allocator_, shape.data(), shape.size(), element_type);
+  Ort::Status copy_status = env_.CopyTensor(value, device_value, nullptr);
+  if (!copy_status.IsOK()) {
+    ORT_THROW("Failed to copy loaded input tensor to plugin EP allocator memory: ", copy_status.GetErrorMessage());
+  }
+  return device_value;
 }
 
 template <typename T>
@@ -1126,19 +1162,23 @@ void OnnxRuntimeTestSession::CreateAndStoreGeneratedInput(size_t test_data_id, s
     if (cuda_err != cudaSuccess) {
       ORT_THROW("Failed to copy tensor data from CPU to CUDA device. CUDA Error: ", cudaGetErrorString(cuda_err));
     }
-    PreLoadTestData(test_data_id, input_idx, std::move(cuda_tensor));
+    StoreTestData(test_data_id, input_idx, std::move(cuda_tensor));
     return;
   }
 #endif
 
   if (requires_input_staging_) {
-    // allocator_ is a plugin EP's default (device-only) allocator, e.g. plain GPU memory, which
-    // cannot be safely written to directly from the host. Fill a CPU tensor first, then use ORT's
-    // device-agnostic data transfer to copy it into device memory.
+    // allocator_ is device-only memory; fill a CPU tensor and copy it in via env_.CopyTensor.
     Ort::AllocatorWithDefaultOptions default_allocator;
     Ort::Value cpu_tensor = Ort::Value::CreateTensor(default_allocator, (const int64_t*)dims.data(),
                                                      dims.size(), element_type);
     InitializeTensorWithSeed(seed, cpu_tensor);
+
+    // Strings require host-accessible memory and always live on the CPU regardless of EP.
+    if (element_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_STRING) {
+      StoreTestData(test_data_id, input_idx, std::move(cpu_tensor));
+      return;
+    }
 
     Ort::Value device_tensor = Ort::Value::CreateTensor(allocator_, (const int64_t*)dims.data(),
                                                         dims.size(), element_type);
@@ -1146,14 +1186,14 @@ void OnnxRuntimeTestSession::CreateAndStoreGeneratedInput(size_t test_data_id, s
     if (!copy_status.IsOK()) {
       ORT_THROW("Failed to copy generated input tensor to plugin EP device memory: ", copy_status.GetErrorMessage());
     }
-    PreLoadTestData(test_data_id, input_idx, std::move(device_tensor));
+    StoreTestData(test_data_id, input_idx, std::move(device_tensor));
     return;
   }
 
   Ort::Value input_tensor = Ort::Value::CreateTensor(allocator_, (const int64_t*)dims.data(),
                                                      dims.size(), element_type);
   InitializeTensorWithSeed(seed, input_tensor);
-  PreLoadTestData(test_data_id, input_idx, std::move(input_tensor));
+  StoreTestData(test_data_id, input_idx, std::move(input_tensor));
 }
 
 bool OnnxRuntimeTestSession::PopulateGeneratedInputTestData(int32_t seed) {

--- a/onnxruntime/test/perftest/ort_test_session.cc
+++ b/onnxruntime/test/perftest/ort_test_session.cc
@@ -120,9 +120,12 @@ OnnxRuntimeTestSession::OnnxRuntimeTestSession(Ort::Env& env, std::random_device
       device_memory_name_ = CUDA;
     }
 
-    // Pick an allocator from the plugin EP devices unless IO binding already set one.
+    // Pick an allocator from the plugin EP devices unless IO binding already set one,
+    // or the user explicitly requested to force the CPU allocator.
     if (device_memory_name_.empty()) {
-      if (auto plugin_ep_allocator = perftest::utils::GetPluginEpAllocator(env, selected_ep_devices)) {
+      if (performance_test_config.plugin_ep_force_cpu_allocator) {
+        fprintf(stdout, "[Plugin EP] Forcing CPU allocator (--plugin_ep_force_cpu_allocator was specified).\n");
+      } else if (auto plugin_ep_allocator = perftest::utils::GetPluginEpAllocator(env, selected_ep_devices)) {
         allocator_ = plugin_ep_allocator->allocator;
         requires_input_staging_ = !plugin_ep_allocator->is_host_accessible;
         has_plugin_ep_allocator_ = true;

--- a/onnxruntime/test/perftest/ort_test_session.cc
+++ b/onnxruntime/test/perftest/ort_test_session.cc
@@ -87,7 +87,11 @@ RunTiming OnnxRuntimeTestSession::Run() {
     // Only do this for models with dynamic output shapes to avoid the allocation
     // overhead on fixed-shape models.
     if (has_dynamic_output_shapes_) {
-      for (auto& output : outputs_) output = Ort::Value(nullptr);
+      for (size_t i = 0; i < outputs_.size(); ++i) {
+        if (is_output_dynamic_[i]) {
+          outputs_[i] = Ort::Value(nullptr);
+        }
+      }
     }
     session_.Run(run_options, input_names_.data(), input.data(), input_names_.size(),
                  output_names_raw_ptr.data(), outputs_.data(), output_names_raw_ptr.size());
@@ -1012,6 +1016,7 @@ select from 'TF8', 'TF16', 'UINT8', 'FLOAT', 'ITENSOR'. \n)");
     auto tensor_info = type_info.GetTensorTypeAndShapeInfo();
     std::vector<int64_t> output_shape = tensor_info.GetShape();
     auto is_dynamic = std::find(output_shape.begin(), output_shape.end(), -1) != output_shape.end();
+    is_output_dynamic_.push_back(is_dynamic);
     if (is_dynamic) {
       has_dynamic_output_shapes_ = true;
     }
@@ -1036,7 +1041,7 @@ void OnnxRuntimeTestSession::StoreTestData(size_t test_data_id, size_t input_id,
   if (test_inputs_.size() < test_data_id + 1) {
     test_inputs_.resize(test_data_id + 1);
   }
-  if (test_inputs_.at(test_data_id).size() == 0) {
+  if (test_inputs_[test_data_id].size() == 0) {
     for (int i = 0; i < input_length_; i++)
       test_inputs_[test_data_id].emplace_back(nullptr);
   }
@@ -1150,7 +1155,7 @@ void OnnxRuntimeTestSession::CreateAndStoreGeneratedInput(size_t test_data_id, s
 #if defined(USE_CUDA) || defined(USE_TENSORRT) || defined(USE_NV)
   if (device_memory_name_ == CUDA) {
     Ort::AllocatorWithDefaultOptions default_allocator;
-    Ort::Value default_tensor = Ort::Value::CreateTensor(default_allocator, (const int64_t*)dims.data(),
+    Ort::Value default_tensor = Ort::Value::CreateTensor(default_allocator, dims.data(),
                                                          dims.size(), element_type);
     InitializeTensorWithSeed(seed, default_tensor);
 
@@ -1171,29 +1176,16 @@ void OnnxRuntimeTestSession::CreateAndStoreGeneratedInput(size_t test_data_id, s
 #endif
 
   if (requires_input_staging_) {
-    // allocator_ is device-only memory; fill a CPU tensor and copy it in via env_.CopyTensor.
+    // allocator_ is device-only memory; fill a CPU tensor and stage it via StageInputForPluginEpAllocator.
     Ort::AllocatorWithDefaultOptions default_allocator;
-    Ort::Value cpu_tensor = Ort::Value::CreateTensor(default_allocator, (const int64_t*)dims.data(),
+    Ort::Value cpu_tensor = Ort::Value::CreateTensor(default_allocator, dims.data(),
                                                      dims.size(), element_type);
     InitializeTensorWithSeed(seed, cpu_tensor);
-
-    // Strings require host-accessible memory and always live on the CPU regardless of EP.
-    if (element_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_STRING) {
-      StoreTestData(test_data_id, input_idx, std::move(cpu_tensor));
-      return;
-    }
-
-    Ort::Value device_tensor = Ort::Value::CreateTensor(allocator_, (const int64_t*)dims.data(),
-                                                        dims.size(), element_type);
-    Ort::Status copy_status = env_.CopyTensor(cpu_tensor, device_tensor, nullptr);
-    if (!copy_status.IsOK()) {
-      ORT_THROW("Failed to copy generated input tensor to plugin EP device memory: ", copy_status.GetErrorMessage());
-    }
-    StoreTestData(test_data_id, input_idx, std::move(device_tensor));
+    StoreTestData(test_data_id, input_idx, StageInputForPluginEpAllocator(std::move(cpu_tensor)));
     return;
   }
 
-  Ort::Value input_tensor = Ort::Value::CreateTensor(allocator_, (const int64_t*)dims.data(),
+  Ort::Value input_tensor = Ort::Value::CreateTensor(allocator_, dims.data(),
                                                      dims.size(), element_type);
   InitializeTensorWithSeed(seed, input_tensor);
   StoreTestData(test_data_id, input_idx, std::move(input_tensor));

--- a/onnxruntime/test/perftest/ort_test_session.h
+++ b/onnxruntime/test/perftest/ort_test_session.h
@@ -51,9 +51,7 @@ class OnnxRuntimeTestSession : public TestSession {
   // Stores an already-staged value; used to avoid double-staging in CreateAndStoreGeneratedInput.
   void StoreTestData(size_t test_data_id, size_t input_id, Ort::Value&& value);
 
-  // True if allocator_ can't safely hold placement-constructed std::string values, i.e. it's a
-  // plugin EP allocator without host-accessible memory, or the legacy CUDA custom allocator.
-  // Used to keep string tensors (inputs and outputs) out of device-only memory.
+  // True if allocator_ is for device-only (i.e., non CPU or host-accessible) memory.
   bool IsAllocatorDeviceOnly() const;
 
   Ort::Session session_{nullptr};

--- a/onnxruntime/test/perftest/ort_test_session.h
+++ b/onnxruntime/test/perftest/ort_test_session.h
@@ -4,9 +4,11 @@
 #pragma once
 #include <atomic>
 #include <core/session/onnxruntime_cxx_api.h>
+#include <optional>
 #include <random>
 #include "test_configuration.h"
 #include "test_session.h"
+#include "utils.h"
 
 #if defined(USE_CUDA) || defined(USE_TENSORRT) || defined(USE_NV)
 #include <cuda_runtime.h>
@@ -49,6 +51,11 @@ class OnnxRuntimeTestSession : public TestSession {
   // Stores an already-staged value; used to avoid double-staging in CreateAndStoreGeneratedInput.
   void StoreTestData(size_t test_data_id, size_t input_id, Ort::Value&& value);
 
+  // True if allocator_ can't safely hold placement-constructed std::string values, i.e. it's a
+  // plugin EP allocator without host-accessible memory, or the legacy CUDA custom allocator.
+  // Used to keep string tensors (inputs and outputs) out of device-only memory.
+  bool IsAllocatorDeviceOnly() const;
+
   Ort::Session session_{nullptr};
   std::mt19937 rand_engine_;
   std::uniform_int_distribution<int> dist_;
@@ -70,8 +77,7 @@ class OnnxRuntimeTestSession : public TestSession {
   std::string device_memory_name_;  // Device memory type name to use from the list in allocator.h
   const std::unordered_map<std::string, std::string>& run_config_entries_;
   Ort::Env& env_;
-  bool requires_input_staging_ = false;
-  bool has_plugin_ep_allocator_ = false;
+  std::optional<perftest::utils::PluginEpAllocatorSelection> plugin_ep_allocator_selection_;
   bool has_dynamic_output_shapes_ = false;
   // Per-output dynamic-shape flag, aligned with outputs_. Lets Run() reset only the outputs that
   // actually have dynamic shapes instead of discarding every pre-allocated buffer.

--- a/onnxruntime/test/perftest/ort_test_session.h
+++ b/onnxruntime/test/perftest/ort_test_session.h
@@ -20,16 +20,7 @@ class OnnxRuntimeTestSession : public TestSession {
   OnnxRuntimeTestSession(Ort::Env& env, std::random_device& rd, const PerformanceTestConfig& performance_test_config,
                          const TestModelInfo& m);
 
-  void PreLoadTestData(size_t test_data_id, size_t input_id, Ort::Value&& value) override {
-    if (test_inputs_.size() < test_data_id + 1) {
-      test_inputs_.resize(test_data_id + 1);
-    }
-    if (test_inputs_.at(test_data_id).size() == 0) {
-      for (int i = 0; i < input_length_; i++)
-        test_inputs_[test_data_id].emplace_back(nullptr);
-    }
-    test_inputs_[test_data_id][input_id] = std::move(value);
-  }
+  void PreLoadTestData(size_t test_data_id, size_t input_id, Ort::Value&& value) override;
 
   bool PopulateGeneratedInputTestData(int32_t seed);
   bool PopulateGeneratedMultiShapeInputTestData(
@@ -50,6 +41,13 @@ class OnnxRuntimeTestSession : public TestSession {
   void CreateAndStoreGeneratedInput(size_t test_data_id, size_t input_idx,
                                     const std::vector<int64_t>& dims,
                                     ONNXTensorElementDataType element_type, int32_t seed);
+
+  // Copies value into allocator_'s memory if a plugin EP allocator was selected. Strings and
+  // non-tensor values can't live in device memory, so those are returned unchanged.
+  Ort::Value StageInputForPluginEpAllocator(Ort::Value&& value);
+
+  // Stores an already-staged value; used to avoid double-staging in CreateAndStoreGeneratedInput.
+  void StoreTestData(size_t test_data_id, size_t input_id, Ort::Value&& value);
 
   Ort::Session session_{nullptr};
   std::mt19937 rand_engine_;

--- a/onnxruntime/test/perftest/ort_test_session.h
+++ b/onnxruntime/test/perftest/ort_test_session.h
@@ -71,6 +71,9 @@ class OnnxRuntimeTestSession : public TestSession {
   std::string provider_name_;
   std::string device_memory_name_;  // Device memory type name to use from the list in allocator.h
   const std::unordered_map<std::string, std::string>& run_config_entries_;
+  Ort::Env& env_;
+  bool requires_input_staging_ = false;
+  bool has_plugin_ep_allocator_ = false;
   bool has_dynamic_output_shapes_ = false;
   std::atomic<size_t> round_robin_counter_{0};
   bool use_round_robin_{false};

--- a/onnxruntime/test/perftest/ort_test_session.h
+++ b/onnxruntime/test/perftest/ort_test_session.h
@@ -73,6 +73,9 @@ class OnnxRuntimeTestSession : public TestSession {
   bool requires_input_staging_ = false;
   bool has_plugin_ep_allocator_ = false;
   bool has_dynamic_output_shapes_ = false;
+  // Per-output dynamic-shape flag, aligned with outputs_. Lets Run() reset only the outputs that
+  // actually have dynamic shapes instead of discarding every pre-allocated buffer.
+  std::vector<bool> is_output_dynamic_;
   std::atomic<size_t> round_robin_counter_{0};
   bool use_round_robin_{false};
 #if defined(USE_CUDA) || defined(USE_TENSORRT) || defined(USE_NV)

--- a/onnxruntime/test/perftest/test_configuration.h
+++ b/onnxruntime/test/perftest/test_configuration.h
@@ -102,6 +102,7 @@ struct PerformanceTestConfig {
   std::string selected_ep_device_indices;
   std::vector<std::pair<std::string, std::string>> filter_ep_device_kv_pairs;
   bool list_available_ep_devices = false;
+  bool plugin_ep_force_cpu_allocator = false;
 };
 
 }  // namespace perftest

--- a/onnxruntime/test/perftest/utils.h
+++ b/onnxruntime/test/perftest/utils.h
@@ -35,25 +35,20 @@ void UnregisterExecutionProviderLibrary(Ort::Env& env, PerformanceTestConfig& te
 
 void ListEpDevices(const Ort::Env& env);
 
-// Appends the plugin EP devices selected by the test config to the session options.
-// Returns the list of OrtEpDevice instances that were added to the session.
+// Returns the OrtEpDevice instances that were added to the session.
 std::vector<Ort::ConstEpDevice> AppendPluginExecutionProviders(Ort::Env& env,
                                                                Ort::SessionOptions& session_options,
                                                                const PerformanceTestConfig& test_config);
 
 bool UsesNvidiaDevice(Ort::Env& env, const PerformanceTestConfig& test_config);
 
-// An allocator selected for a plugin EP device, along with whether its memory can be written to
-// directly from the host (e.g. CPU or pinned/shared memory), or whether it is device-only memory
-// (e.g. plain GPU memory) that requires a device data transfer to populate from the host.
 struct PluginEpAllocatorSelection {
   Ort::UnownedAllocator allocator;
   bool is_host_accessible = false;
 };
 
-// Selects an allocator to use for input/output buffers when running with plugin EP devices.
-// Preference order: the EP device's default (device) allocator, then its host accessible allocator,
-// then std::nullopt to indicate the caller should fall back to the CPU allocator.
+// Preference order: default (device) allocator, then host accessible allocator, then nullopt
+// (caller falls back to the CPU allocator).
 std::optional<PluginEpAllocatorSelection> GetPluginEpAllocator(Ort::Env& env,
                                                                const std::vector<Ort::ConstEpDevice>& ep_devices);
 

--- a/onnxruntime/test/perftest/utils.h
+++ b/onnxruntime/test/perftest/utils.h
@@ -5,6 +5,8 @@
 #include "test/perftest/test_configuration.h"
 #include <core/session/onnxruntime_cxx_api.h>
 #include <memory>
+#include <optional>
+#include <vector>
 
 namespace onnxruntime {
 namespace perftest {
@@ -33,11 +35,27 @@ void UnregisterExecutionProviderLibrary(Ort::Env& env, PerformanceTestConfig& te
 
 void ListEpDevices(const Ort::Env& env);
 
-void AppendPluginExecutionProviders(Ort::Env& env,
-                                    Ort::SessionOptions& session_options,
-                                    const PerformanceTestConfig& test_config);
+// Appends the plugin EP devices selected by the test config to the session options.
+// Returns the list of OrtEpDevice instances that were added to the session.
+std::vector<Ort::ConstEpDevice> AppendPluginExecutionProviders(Ort::Env& env,
+                                                               Ort::SessionOptions& session_options,
+                                                               const PerformanceTestConfig& test_config);
 
 bool UsesNvidiaDevice(Ort::Env& env, const PerformanceTestConfig& test_config);
+
+// An allocator selected for a plugin EP device, along with whether its memory can be written to
+// directly from the host (e.g. CPU or pinned/shared memory), or whether it is device-only memory
+// (e.g. plain GPU memory) that requires a device data transfer to populate from the host.
+struct PluginEpAllocatorSelection {
+  Ort::UnownedAllocator allocator;
+  bool is_host_accessible = false;
+};
+
+// Selects an allocator to use for input/output buffers when running with plugin EP devices.
+// Preference order: the EP device's default (device) allocator, then its host accessible allocator,
+// then std::nullopt to indicate the caller should fall back to the CPU allocator.
+std::optional<PluginEpAllocatorSelection> GetPluginEpAllocator(Ort::Env& env,
+                                                               const std::vector<Ort::ConstEpDevice>& ep_devices);
 
 }  // namespace utils
 }  // namespace perftest


### PR DESCRIPTION
### Description

Adds support for using a plugin EP device's own allocator for input/output buffers in `onnxruntime_perf_test`, instead of always using the CPU allocator.

- When a session uses plugin EP(s) (`--plugin_eps`), `onnxruntime_perf_test` now selects an allocator from the appended `OrtEpDevice`: it prefers the device's default (device-only) allocator, falls back to its host-accessible allocator, and falls back to the CPU allocator if neither is available or if more than one EP device was appended (no single unambiguous allocator to pick).
- Generated inputs (`-r`) and pre-allocated fixed-shape outputs now use this allocator instead of the CPU allocator.
- Real test data loaded from files is staged into the selected allocator's memory once at load time (via `Ort::Env::CopyTensor`), instead of being copied per-`Run()` implicitly.
- String tensors are always kept in CPU-accessible memory (inputs and outputs), since `std::string` is placement-constructed by ORT directly into the tensor's owned memory and can't safely live in device-only memory.
- Added `[Plugin EP]`-prefixed logging indicating which allocator was selected.

### Motivation and Context

`onnxruntime_perf_test` previously always allocated input/output buffers on the CPU when running with plugin EPs. For plugin EPs whose kernels expect device-resident inputs/outputs, this meant every `Run()` iteration paid for an implicit host↔device copy that was entirely avoidable, skewing per-iteration latency measurements away from the EP's actual compute cost. Selecting and reusing the EP device's own allocator up front lets perf numbers better reflect steady-state inference cost for plugin EPs.