### PR TITLE
Fix onnxruntime-node downloads across redirects

### DIFF
--- a/js/node/script/install-utils.js
+++ b/js/node/script/install-utils.js
@@ -41,7 +41,15 @@ function requestWithRedirects(url, redirectCount = 0) {
           return;
         }
 
-        requestWithRedirects(new URL(location, parsedUrl).toString(), redirectCount + 1).then(resolve, reject);
+        let redirectUrl;
+        try {
+          redirectUrl = new URL(location, parsedUrl).toString();
+        } catch (err) {
+          reject(err);
+          return;
+        }
+
+        requestWithRedirects(redirectUrl, redirectCount + 1).then(resolve, reject);
       })
       .on('error', reject);
   });

--- a/js/node/script/install-utils.js
+++ b/js/node/script/install-utils.js
@@ -4,82 +4,116 @@
 'use strict';
 
 const fs = require('fs');
+const http = require('http');
 const https = require('https');
 const { execFileSync } = require('child_process');
 const path = require('path');
 const os = require('os');
 const AdmZip = require('adm-zip'); // Use adm-zip instead of spawn
 
-async function downloadFile(url, dest) {
+const REDIRECT_STATUS_CODES = new Set([301, 302, 303, 307, 308]);
+const MAX_REDIRECTS = 5;
+
+function requestWithRedirects(url, redirectCount = 0) {
   return new Promise((resolve, reject) => {
-    const file = fs.createWriteStream(dest);
-    https
-      .get(url, (res) => {
-        if (res.statusCode !== 200) {
-          file.close();
-          fs.unlinkSync(dest);
-          reject(new Error(`Failed to download from ${url}. HTTP status code = ${res.statusCode}`));
+    const parsedUrl = new URL(url);
+    const transport = parsedUrl.protocol === 'http:' ? http : parsedUrl.protocol === 'https:' ? https : null;
+    if (!transport) {
+      reject(new Error(`Unsupported URL protocol: ${parsedUrl.protocol}`));
+      return;
+    }
+
+    transport
+      .get(parsedUrl, (res) => {
+        if (!REDIRECT_STATUS_CODES.has(res.statusCode)) {
+          resolve(res);
           return;
         }
 
-        res.pipe(file);
-        file.on('finish', () => {
-          file.close();
-          resolve();
-        });
-        file.on('error', (err) => {
-          fs.unlinkSync(dest);
-          reject(err);
-        });
+        const location = res.headers.location;
+        res.resume();
+        if (!location) {
+          reject(new Error(`Redirect response from ${url} did not include a Location header`));
+          return;
+        }
+        if (redirectCount >= MAX_REDIRECTS) {
+          reject(new Error(`Too many redirects while downloading ${url}`));
+          return;
+        }
+
+        requestWithRedirects(new URL(location, parsedUrl).toString(), redirectCount + 1).then(resolve, reject);
       })
-      .on('error', (err) => {
-        fs.unlinkSync(dest);
-        reject(err);
-      });
+      .on('error', reject);
   });
 }
 
-async function downloadJson(url) {
-  return new Promise((resolve, reject) => {
-    https
-      .get(url, (res) => {
-        const { statusCode } = res;
-        const contentType = res.headers['content-type'];
+function removeFileIfPresent(filepath) {
+  try {
+    fs.rmSync(filepath, { force: true });
+  } catch {
+    // Preserve the original download error if cleanup also fails.
+  }
+}
 
-        if (!statusCode) {
-          reject(new Error('No response statud code from server.'));
-          return;
-        }
-        if (statusCode >= 400 && statusCode < 500) {
-          resolve(null);
-          return;
-        } else if (statusCode !== 200) {
-          reject(new Error(`Failed to download build list. HTTP status code = ${statusCode}`));
-          return;
-        }
-        if (!contentType || !/^application\/json/.test(contentType)) {
-          reject(new Error(`unexpected content type: ${contentType}`));
-          return;
-        }
-        res.setEncoding('utf8');
-        let rawData = '';
-        res.on('data', (chunk) => {
-          rawData += chunk;
-        });
-        res.on('end', () => {
-          try {
-            resolve(JSON.parse(rawData));
-          } catch (e) {
-            reject(e);
-          }
-        });
-        res.on('error', (err) => {
-          reject(err);
-        });
-      })
-      .on('error', (err) => {
-        reject(err);
-      });
+async function downloadFile(url, dest) {
+  let res;
+  try {
+    res = await requestWithRedirects(url);
+    if (res.statusCode !== 200) {
+      res.resume();
+      throw new Error(`Failed to download from ${url}. HTTP status code = ${res.statusCode}`);
+    }
+
+    await new Promise((resolve, reject) => {
+      const file = fs.createWriteStream(dest);
+      res.pipe(file);
+      file.on('finish', () => file.close(resolve));
+      file.on('error', reject);
+      res.on('error', reject);
+    });
+  } catch (err) {
+    removeFileIfPresent(dest);
+    throw err;
+  }
+}
+
+async function downloadJson(url) {
+  const res = await requestWithRedirects(url);
+  const { statusCode } = res;
+
+  if (!statusCode) {
+    res.resume();
+    throw new Error('No response status code from server.');
+  }
+  if (statusCode >= 400 && statusCode < 500) {
+    res.resume();
+    return null;
+  }
+  if (statusCode !== 200) {
+    res.resume();
+    throw new Error(`Failed to download build list. HTTP status code = ${statusCode}`);
+  }
+
+  const contentType = res.headers['content-type'];
+  if (!contentType || !/^application\/json/.test(contentType)) {
+    res.resume();
+    throw new Error(`unexpected content type: ${contentType}`);
+  }
+
+  return new Promise((resolve, reject) => {
+    res.setEncoding('utf8');
+    let rawData = '';
+    res.on('data', (chunk) => {
+      rawData += chunk;
+    });
+    res.on('end', () => {
+      try {
+        resolve(JSON.parse(rawData));
+      } catch (e) {
+        reject(e);
+      }
+    });
+    res.on('error', reject);
   });
 }
 
@@ -301,6 +335,8 @@ function parseInstallCudaFlag() {
 }
 
 module.exports = {
+  downloadFile,
+  downloadJson,
   installPackages,
   parseInstallFlag,
 };

--- a/js/node/test/test-main.ts
+++ b/js/node/test/test-main.ts
@@ -17,6 +17,7 @@ require('./unittests/lib/index');
 require('./unittests/lib/inference-session');
 require('./unittests/lib/model-metadata');
 require('./unittests/lib/tensor');
+require('./unittests/install-utils');
 
 // API tests
 require('./api/simple-api-tests');

--- a/js/node/test/unittests/install-utils.ts
+++ b/js/node/test/unittests/install-utils.ts
@@ -26,6 +26,14 @@ describe('#UnitTest# - install utility downloads', () => {
         response.writeHead(307, { Location: '/package.bin' }).end();
         return;
       }
+      if (request.url === '/redirect-loop') {
+        response.writeHead(302, { Location: '/redirect-loop' }).end();
+        return;
+      }
+      if (request.url === '/redirect-malformed') {
+        response.writeHead(302, { Location: 'http://[invalid' }).end();
+        return;
+      }
       if (request.url === '/metadata.json') {
         response.writeHead(200, { 'Content-Type': 'application/json' }).end('{"version":"test"}');
         return;
@@ -59,5 +67,13 @@ describe('#UnitTest# - install utility downloads', () => {
     } finally {
       fs.rmSync(tempDir, { recursive: true, force: true });
     }
+  });
+
+  it('rejects when the redirect limit is exceeded', async () => {
+    await assert.rejects(downloadJson(`${baseUrl}/redirect-loop`), /Too many redirects/);
+  });
+
+  it('rejects malformed redirect locations', async () => {
+    await assert.rejects(downloadJson(`${baseUrl}/redirect-malformed`), /Invalid URL/);
   });
 });

--- a/js/node/test/unittests/install-utils.ts
+++ b/js/node/test/unittests/install-utils.ts
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as http from 'http';
+import * as os from 'os';
+import * as path from 'path';
+
+const { downloadFile, downloadJson } = require('../../script/install-utils.js') as {
+  downloadFile: (url: string, destination: string) => Promise<void>;
+  downloadJson: (url: string) => Promise<unknown>;
+};
+
+describe('#UnitTest# - install utility downloads', () => {
+  let server: http.Server;
+  let baseUrl: string;
+
+  before((done) => {
+    server = http.createServer((request, response) => {
+      if (request.url === '/redirect-json') {
+        response.writeHead(302, { Location: '/metadata.json' }).end();
+        return;
+      }
+      if (request.url === '/redirect-file') {
+        response.writeHead(307, { Location: '/package.bin' }).end();
+        return;
+      }
+      if (request.url === '/metadata.json') {
+        response.writeHead(200, { 'Content-Type': 'application/json' }).end('{"version":"test"}');
+        return;
+      }
+      if (request.url === '/package.bin') {
+        response.writeHead(200, { 'Content-Type': 'application/octet-stream' }).end('package contents');
+        return;
+      }
+      response.writeHead(404).end();
+    });
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      assert.ok(address && typeof address !== 'string');
+      baseUrl = `http://127.0.0.1:${address.port}`;
+      done();
+    });
+  });
+
+  after((done) => server.close(done));
+
+  it('follows redirects when downloading JSON metadata', async () => {
+    assert.deepStrictEqual(await downloadJson(`${baseUrl}/redirect-json`), { version: 'test' });
+  });
+
+  it('follows redirects when downloading package files', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'onnxruntime-install-utils-'));
+    const destination = path.join(tempDir, 'package.bin');
+    try {
+      await downloadFile(`${baseUrl}/redirect-file`, destination);
+      assert.strictEqual(fs.readFileSync(destination, 'utf8'), 'package contents');
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #32233.

The Node package installer now follows HTTP redirects when resolving NuGet metadata and downloading package files. The implementation supports relative and absolute Location headers, both HTTP and HTTPS targets, and limits redirect hops to avoid loops. Existing status-code and content-type validation remains unchanged.

## Testing

- node --check js/node/script/install-utils.js
- Isolated TypeScript compilation of the new test
- Prettier check for all touched JavaScript and TypeScript files
- Local HTTP-server smoke test covering JSON metadata redirects and binary package redirects