### PR TITLE
Deprecate onnxruntime-web WebGL backend

### DIFF
--- a/docs/design/onnxruntime_web_jsep_to_webgpu_ep_migration.md
+++ b/docs/design/onnxruntime_web_jsep_to_webgpu_ep_migration.md
@@ -236,8 +236,9 @@ Per-session typed options are already a superset of JSEP's, confirmed by source 
    default. Replace it with a `--jsep` opt-in (`--no-jsep` selecting native). Land the rename while JSEP is still
    the default so it carries no behavior change.
 2. **Escape hatch.** Add the temporary, deprecated `onnxruntime-web/jsep` export (built with JSEP selected).
-3. **Warn once.** The `/jsep` build warns once (respecting `env.logLevel`) via a shared deprecation-warning
-   utility, also used by the WebGL effort; the native default emits nothing.
+3. **Warn once.** The `/jsep` build warns once (respecting `env.logLevel`) via
+   `createDeprecationWarning()` from `js/web/lib/deprecation-warning.ts`, shared with the WebGL effort. Invoke it
+   from the JSEP-only initialization path so the native default emits nothing.
 4. **Retarget the operator-doc generator.** `generate-webgpu-operator-md.ts` parses the JSEP registrations
    (`js_execution_provider.cc`, `js_contrib_kernels.cc`), so post-flip `webgpu-operators.md` describes the wrong
    EP; point it at the native WebGPU EP registrations (those JSEP sources are removed in Phase 2).

--- a/docs/design/onnxruntime_web_remove_webgl_backend.md
+++ b/docs/design/onnxruntime_web_remove_webgl_backend.md
@@ -6,13 +6,15 @@
 [Migrate onnxruntime-web from JSEP to the native WebGPU EP](onnxruntime_web_jsep_to_webgpu_ep_migration.md)
 — independent, but shares the `onnxruntime-web/all` bundle (§6) and the deprecation-warning utility (§7).
 
+**Tracking issue:** [microsoft/onnxruntime#32241](https://github.com/microsoft/onnxruntime/issues/32241)
+
 ---
 
 ## 1. Summary
 
 `onnxruntime-web` ships a legacy **WebGL** backend (the `onnxjs` implementation under `js/web/lib/onnxjs`,
-registered under the `'webgl'` key). It predates the WASM architecture, supports fewer operators, and has fp32/op
-drift relative to WebGPU.
+registered under the `'webgl'` key). It originated in the standalone ONNX.js project before ONNX Runtime's
+WebAssembly implementation, supports fewer operators, and has fp32/op drift relative to WebGPU.
 
 This document proposes deprecating and then deleting it, with an explicit migration message rather than a
 transparent redirect (§5.1):
@@ -25,8 +27,8 @@ transparent redirect (§5.1):
 
 ## 2. Motivation
 
-- **Legacy and unmaintained.** The `onnxjs` WebGL backend predates the WASM/EP architecture and does not receive
-  new operator or feature work.
+- **Legacy and unmaintained.** The `onnxjs` WebGL backend originated before ONNX Runtime's WebAssembly
+  implementation and does not receive new operator or feature work.
 - **Narrower op coverage and behavioral drift.** WebGL supports fewer operators than WebGPU and exhibits fp32/op
   differences, making it an inconsistent fallback.
 - **Build-matrix simplification.** Removing WebGL deletes the `ort.webgl` bundle variant and the
@@ -94,9 +96,8 @@ the WebGPU EP (`webgpu`) or the WASM/CPU backend (`wasm`).
 
 ### 5.2 Warning placement
 
-The warning fires in `OnnxjsBackend` (`js/web/lib/backend-onnxjs.ts`), in `init(backendName)` /
-`createInferenceSessionHandler`. Negative priority means it only fires when WebGL is explicitly requested — for
-both `ort.all` and `ort.webgl`.
+The warning fires in `OnnxjsBackend.init()` (`js/web/lib/backend-onnxjs.ts`). Negative priority means it only fires
+when WebGL is explicitly requested — for both `ort.all` and `ort.webgl`.
 
 ### 5.3 Removal ergonomics
 
@@ -119,12 +120,17 @@ breaking imports (see JSEP doc §5).
 
 ## 7. Phase 1 — Deprecation (this release)
 
-No behavior change.
+No inference behavior change.
 
-1. **WebGL warn-once.** In `OnnxjsBackend` (`js/web/lib/backend-onnxjs.ts`), `init(backendName)` /
-   `createInferenceSessionHandler`, gated on `logLevel` and deduped via a module flag. Uses the shared
-   deprecation-warning utility (from the JSEP effort, or here — whichever lands first).
-2. **Docs.** Deprecation banner + migration guidance in `js/web/README` (hand-authored), plus release notes.
+**Status (2026-08-24): implemented, pending review and merge.** The public
+[tracking issue](https://github.com/microsoft/onnxruntime/issues/32241) is open. The warn-once implementation and
+documentation updates are included in the current change; the deprecation release version remains TBD.
+
+1. **WebGL warn-once.** In `OnnxjsBackend.init()` (`js/web/lib/backend-onnxjs.ts`), gated on `logLevel` and deduped
+   via a module flag. Uses the shared deprecation-warning utility introduced by this effort and reusable by the JSEP
+   migration.
+2. **Docs.** Deprecation banner + migration guidance in `js/web/README` (hand-authored). Release-note-ready wording
+   is supplied in the implementing PR for the existing generated release-note workflow.
 
 ---
 
@@ -169,5 +175,5 @@ removing it in a minor release after a deprecation window is within policy and d
 - **`onnxruntime-web/all`:** continues to work, but no longer includes WebGL. If you relied on WebGL as a
   fallback via `/all`, add `wasm` to your `executionProviders` list.
 
-> A pinned tracking issue (link TBD) is the authoritative migration guidance. Warnings, docs, and CHANGELOG
-> entries link to it.
+> The pinned [tracking issue](https://github.com/microsoft/onnxruntime/issues/32241) is the authoritative migration
+> guidance. Warnings, docs, and release notes link to it.

--- a/js/web/README.md
+++ b/js/web/README.md
@@ -2,7 +2,13 @@
 
 ONNX Runtime Web is a Javascript library for running ONNX models on browsers and on Node.js.
 
-ONNX Runtime Web has adopted WebAssembly and WebGL technologies for providing an optimized ONNX model inference runtime for both CPUs and GPUs.
+> [!WARNING]
+> The WebGL backend is deprecated and will be removed in a future release. Migrate to the WebGPU or WebAssembly
+> backend. See the [WebGL deprecation tracking issue](https://github.com/microsoft/onnxruntime/issues/32241) for
+> current status and migration support.
+
+ONNX Runtime Web uses WebAssembly for CPU inference and supports GPU acceleration through WebGPU. The legacy WebGL
+backend remains available during its deprecation window.
 
 ### Why ONNX models
 
@@ -12,7 +18,7 @@ The [Open Neural Network Exchange](http://onnx.ai/) (ONNX) is an open standard f
 
 With ONNX Runtime Web, web developers can score models directly on browsers with various benefits including reducing server-client communication and protecting user privacy, as well as offering install-free and cross-platform in-browser ML experience.
 
-ONNX Runtime Web can run on both CPU and GPU. On CPU side, [WebAssembly](https://developer.mozilla.org/en-US/docs/WebAssembly) is adopted to execute the model at near-native speed. ONNX Runtime Web compiles the native ONNX Runtime CPU engine into WebAssembly backend by using Emscripten, so it supports most functionalities native ONNX Runtime offers, including full ONNX operator coverage, multi-threading, [ONNX Runtime Quantization](https://www.onnxruntime.ai/docs/how-to/quantization.html) as well as [ONNX Runtime Mobile](https://onnxruntime.ai/docs/tutorials/mobile/). For performance acceleration with GPUs, ONNX Runtime Web leverages WebGL, a popular standard for accessing GPU capabilities. We are keeping improving op coverage and optimizing performance in WebGL backend.
+ONNX Runtime Web can run on both CPU and GPU. On CPU side, [WebAssembly](https://developer.mozilla.org/en-US/docs/WebAssembly) is adopted to execute the model at near-native speed. ONNX Runtime Web compiles the native ONNX Runtime CPU engine into WebAssembly backend by using Emscripten, so it supports most functionalities native ONNX Runtime offers, including full ONNX operator coverage, multi-threading, [ONNX Runtime Quantization](https://www.onnxruntime.ai/docs/how-to/quantization.html) as well as [ONNX Runtime Mobile](https://onnxruntime.ai/docs/tutorials/mobile/). For GPU acceleration, use the WebGPU backend where it is supported.
 
 See [Compatibility](#Compatibility) and [Operators Supported](#Operators) for a list of platforms and operators ONNX Runtime Web currently supports.
 
@@ -23,6 +29,30 @@ See [Compatibility](#Compatibility) and [Operators Supported](#Operators) for a 
 - Refer to [ONNX Runtime JavaScript examples](https://github.com/microsoft/onnxruntime-inference-examples/tree/main/js) for samples and tutorials.
 
 - See also [ONNX Runtime Web API reference](https://onnxruntime.ai/docs/api/js/index.html) for detailed API documentation.
+
+### Migrating from WebGL
+
+Use WebGPU on supported browsers:
+
+```js
+import * as ort from 'onnxruntime-web/webgpu';
+
+const session = await ort.InferenceSession.create(model, {
+  executionProviders: ['webgpu'],
+});
+```
+
+Use the WebAssembly/CPU backend when WebGPU is unavailable or broader browser compatibility is required:
+
+```js
+import * as ort from 'onnxruntime-web/wasm';
+
+const session = await ort.InferenceSession.create(model);
+```
+
+The default `onnxruntime-web` import also uses WebAssembly/CPU when no execution providers are specified. There is
+no automatic redirect from WebGL because WebGPU is not available on every browser and changing backends can change
+operator support or numerical behavior.
 
 ## Documents
 
@@ -48,7 +78,8 @@ Refer to the following links for development information:
 - \[1]: Node.js only support single-threaded `wasm` EP.
 - \[2]: WebGPU requires Chromium v113 or later on Windows. Float16 support requires Chrome v121 or later, and Edge v122 or later.
 - \[3]: WebGPU requires Chromium v121 or later on Windows.
-- \[4]: WebGL support is in maintenance mode. It is recommended to use WebGPU for better performance.
+- \[4]: WebGL is deprecated. Migrate to WebGPU or WebAssembly; see the
+  [tracking issue](https://github.com/microsoft/onnxruntime/issues/32241).
 - \[5]: Requires to launch browser with commandline flag `--enable-features=WebMachineLearningNeuralNetwork`.
 
 ### Operators
@@ -59,7 +90,9 @@ ONNX Runtime Web currently support all operators in [ai.onnx](https://github.com
 
 #### WebGL backend
 
-ONNX Runtime Web currently supports a subset of operators in [ai.onnx](https://github.com/onnx/onnx/blob/main/docs/Operators.md) operator set. See [webgl-operators.md](./docs/webgl-operators.md) for a complete, detailed list of which ONNX operators are supported by WebGL backend.
+The WebGL backend is deprecated and supports a subset of operators in the
+[ai.onnx](https://github.com/onnx/onnx/blob/main/docs/Operators.md) operator set. During the deprecation window, see
+[webgl-operators.md](./docs/webgl-operators.md) for the detailed list of supported operators.
 
 #### WebGPU backend
 

--- a/js/web/README.md
+++ b/js/web/README.md
@@ -30,30 +30,6 @@ See [Compatibility](#Compatibility) and [Operators Supported](#Operators) for a 
 
 - See also [ONNX Runtime Web API reference](https://onnxruntime.ai/docs/api/js/index.html) for detailed API documentation.
 
-### Migrating from WebGL
-
-Use WebGPU on supported browsers:
-
-```js
-import * as ort from 'onnxruntime-web/webgpu';
-
-const session = await ort.InferenceSession.create(model, {
-  executionProviders: ['webgpu'],
-});
-```
-
-Use the WebAssembly/CPU backend when WebGPU is unavailable or broader browser compatibility is required:
-
-```js
-import * as ort from 'onnxruntime-web/wasm';
-
-const session = await ort.InferenceSession.create(model);
-```
-
-The default `onnxruntime-web` import also uses WebAssembly/CPU when no execution providers are specified. There is
-no automatic redirect from WebGL because WebGPU is not available on every browser and changing backends can change
-operator support or numerical behavior.
-
 ## Documents
 
 ### Development

--- a/js/web/lib/backend-onnxjs.ts
+++ b/js/web/lib/backend-onnxjs.ts
@@ -3,12 +3,20 @@
 
 import { Backend, InferenceSession, InferenceSessionHandler } from 'onnxruntime-common';
 
+import { createDeprecationWarning } from './deprecation-warning';
 import { Session } from './onnxjs/session';
 import { OnnxjsSessionHandler } from './onnxjs/session-handler-inference';
 
+const warnWebGlDeprecation = createDeprecationWarning(
+  'The WebGL execution provider is deprecated and will be removed in a future release. ' +
+    "Please migrate to WebGPU ('webgpu') or WebAssembly ('wasm'). " +
+    'See https://github.com/microsoft/onnxruntime/issues/32241 for details.',
+);
+
 class OnnxjsBackend implements Backend {
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  async init(): Promise<void> {}
+  async init(): Promise<void> {
+    warnWebGlDeprecation();
+  }
 
   async createInferenceSessionHandler(
     pathOrBuffer: string | Uint8Array,

--- a/js/web/lib/deprecation-warning.ts
+++ b/js/web/lib/deprecation-warning.ts
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { env } from 'onnxruntime-common';
+
+export const createDeprecationWarning = (message: string): (() => void) => {
+  let warned = false;
+
+  return () => {
+    if (warned || env.logLevel === 'error' || env.logLevel === 'fatal') {
+      return;
+    }
+
+    warned = true;
+    // eslint-disable-next-line no-console
+    console.warn(message);
+  };
+};

--- a/js/web/test/unittests/deprecation-warning.ts
+++ b/js/web/test/unittests/deprecation-warning.ts
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { expect } from 'chai';
+import { env } from 'onnxruntime-common';
+
+import { onnxjsBackend } from '../../lib/backend-onnxjs';
+import { createDeprecationWarning } from '../../lib/deprecation-warning';
+
+describe('#UnitTest# - deprecation warning', () => {
+  const originalLogLevel = env.logLevel;
+  const originalConsoleWarn = console.warn;
+  let warnings: unknown[][];
+
+  beforeEach(() => {
+    warnings = [];
+    console.warn = (...data: unknown[]) => {
+      warnings.push(data);
+    };
+  });
+
+  afterEach(() => {
+    env.logLevel = originalLogLevel;
+    console.warn = originalConsoleWarn;
+  });
+
+  for (const logLevel of ['verbose', 'info', 'warning'] as const) {
+    it(`warns once when log level is ${logLevel}`, () => {
+      env.logLevel = logLevel;
+      const warn = createDeprecationWarning('deprecated');
+
+      warn();
+      warn();
+
+      expect(warnings).to.deep.equal([['deprecated']]);
+    });
+  }
+
+  for (const logLevel of ['error', 'fatal'] as const) {
+    it(`does not warn when log level is ${logLevel}`, () => {
+      env.logLevel = logLevel;
+
+      createDeprecationWarning('deprecated')();
+
+      expect(warnings).to.have.lengthOf(0);
+    });
+  }
+
+  it('warns once when the WebGL backend is initialized', async () => {
+    env.logLevel = 'warning';
+
+    await onnxjsBackend.init();
+    await onnxjsBackend.init();
+
+    expect(warnings).to.have.lengthOf(1);
+    expect(warnings[0][0]).to.contain('https://github.com/microsoft/onnxruntime/issues/32241');
+  });
+});

--- a/js/web/test/unittests/index.ts
+++ b/js/web/test/unittests/index.ts
@@ -13,6 +13,8 @@ if (typeof window !== 'undefined') {
 
 require('./backends/wasm/test-model-metadata');
 
+require('./deprecation-warning');
+
 require('./pool-output-shape');
 
 require('./opset');


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Add a warn-once deprecation notice to WebGL backend initialization.

Add migration guidance linked to the public tracking issue (#32241).

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

onnxruntime-web WebGL backend deprecation and removal.