### PR TITLE
SGemm Kernel API and Optimisation

### DIFF
--- a/cmake/deps.txt
+++ b/cmake/deps.txt
@@ -59,7 +59,7 @@ extensions;https://github.com/microsoft/onnxruntime-extensions/archive/c24b7bab0
 directx_headers;https://github.com/microsoft/DirectX-Headers/archive/refs/tags/v1.613.1.zip;47653509a3371eabb156360f42faf582f314bf2e
 cudnn_frontend;https://github.com/NVIDIA/cudnn-frontend/archive/refs/tags/v1.27.0.zip;1e4c9a464d3437e388ab0163f3be068dba783c08
 dawn;https://github.com/google/dawn/archive/refs/tags/v20260817.213942.zip;a89b0c394bd078f559e2737b80a1fe49fde4ccc1
-kleidiai;https://github.com/ARM-software/kleidiai/archive/refs/tags/v1.20.0.tar.gz;6895e72b3d5cf1173358164cb3d64c9d7d33cc84
+kleidiai;https://github.com/ARM-software/kleidiai/archive/refs/tags/v1.30.0.tar.gz;36aebdd5bd28c40b1943eb93498ae42e703510e5
 # kleidiai-qmx is pinned to a specific commit as there are no tagged releases. When an appropriate tagged release becomes available,
 # this entry will be updated to use refs/tags/<version> instead of the raw commit hash.
 kleidiai-qmx;https://github.com/qualcomm/kleidiai/archive/2f10c9a8d32f81ffeeb6d4885a29cc35d2b0da87.zip;5e855730a2d69057a569f43dd7532db3b2d2a05c

--- a/onnxruntime/core/mlas/lib/kai_ukernel_interface.cpp
+++ b/onnxruntime/core/mlas/lib/kai_ukernel_interface.cpp
@@ -39,14 +39,10 @@
 #include "kai/ukernels/matmul/imatmul_clamp_f16_f16p_f16p/kai_imatmul_clamp_f16_f16p2vlx2_f16p2vlx2b_2vlx2vl_sme_mopa.h"
 
 // SME2 kernels
-//   GEMM/QGEMM/SBGEMM
-#include "kai/ukernels/matmul/matmul_clamp_f32_f32p_f32p/kai_matmul_clamp_f32_f32p2vlx1_f32p2vlx1biasf32_sme2_mopa.h"
+//   QGEMM/SBGEMM
 #include "kai/ukernels/matmul/matmul_clamp_f32_qai8dxp_qsi8cxp/kai_matmul_clamp_f32_qai8dxp1vlx4_qsi8cxp4vlx4_1vlx4vl_sme2_mopa.h"
 #include "kai/ukernels/matmul/matmul_clamp_fp32_bf16p_bf16p/kai_matmul_clamp_f32_bf16p2vlx2_bf16p2vlx2_2vlx2vl_sme2_mopa.h"
 
-//   GEMV
-#include "kai/ukernels/matmul/matmul_clamp_f32_f32_f32p/kai_matmul_clamp_f32_f32_f32p16vlx1b_1x16vl_sme2_mla.h"
-#include "kai/ukernels/matmul/matmul_clamp_f32_f32_f32p/kai_matmul_clamp_f32_f32_f32p2vlx1b_1x16vl_sme2_mla.h"
 //   IMATMUL
 #include "kai/ukernels/matmul/imatmul_clamp_f32_f32p_f32p/kai_imatmul_clamp_f32_f32p2vlx1_f32p2vlx1b_2vlx2vl_sme2_mopa.h"
 #include "kai/ukernels/matmul/imatmul_clamp_f16_f16p_f16p/kai_imatmul_clamp_f16_f16p2vlx2_f16p2vlx2_2vlx2vl_sme2_mopa.h"
@@ -310,9 +306,6 @@ const KaiF32IMatmulKernel imatmul_conv_qmx =
     KAI_WRAP_UKERNEL_RUN_IMATMUL_PACKED_7(imatmul_clamp_f32_f32p2vlx1_f32p2vlx1b_2vlx2vl_qmx_mopa);
 #endif // ENABLE_QMX_KERNELS
 
-const KaiF32SgemmKernel sgemm_gemm_sme2 =
-    KAI_WRAP_UKERNEL_RUN_MATMUL_11(matmul_clamp_f32_f32p2vlx1_f32p2vlx1biasf32_sme2_mopa);
-
 const KaiDynamicQGemmKernel qgemm_gemm_sme =
     KAI_WRAP_UKERNEL_RUN_MATMUL_11(matmul_clamp_f32_qai8dxp1vlx4_qsi8cxp4vlx4_1vlx4vl_sme_mopa);
     
@@ -351,23 +344,6 @@ const KaiF32SgemvKernel sgemm_gemv_sme =
         kai_get_dst_size_matmul_clamp_f32_f32_f32p2vlx1b_1x8vl_sme_mla,
         kai_run_matmul_clamp_f32_f32_f32p2vlx1b_1x8vl_sme_mla}
     };
-
-const KaiF32SgemvKernel sgemm_gemv_sme2 =
-    {
-        "kai_run_matmul_clamp_f32_f32_f32p2vlx1b_1x16vl_sme2_mla",
-        {kai_get_m_step_matmul_clamp_f32_f32_f32p2vlx1b_1x16vl_sme2_mla,
-        kai_get_n_step_matmul_clamp_f32_f32_f32p2vlx1b_1x16vl_sme2_mla,
-        kai_get_nr_matmul_clamp_f32_f32_f32p2vlx1b_1x16vl_sme2_mla,
-        kai_get_kr_matmul_clamp_f32_f32_f32p2vlx1b_1x16vl_sme2_mla,
-        kai_get_sr_matmul_clamp_f32_f32_f32p2vlx1b_1x16vl_sme2_mla,
-        kai_get_lhs_offset_matmul_clamp_f32_f32_f32p2vlx1b_1x16vl_sme2_mla,
-        kai_get_rhs_packed_offset_matmul_clamp_f32_f32_f32p2vlx1b_1x16vl_sme2_mla,
-        kai_get_dst_offset_matmul_clamp_f32_f32_f32p2vlx1b_1x16vl_sme2_mla,
-        kai_get_dst_size_matmul_clamp_f32_f32_f32p2vlx1b_1x16vl_sme2_mla,
-        kai_run_matmul_clamp_f32_f32_f32p2vlx1b_1x16vl_sme2_mla}
-    };
-
-
 
 const KaiQnbitGemmKernel& GetKleidiAIGemmUKernel() {
     if (MLAS_CPUIDINFO::GetCPUIDInfo().HasArm_SME2()) {
@@ -412,29 +388,18 @@ const KaiQnbitAsymGemmKernel& GetKleidiAIQai4GemvUKernel() {
 }
 
 const KaiF32SgemmKernel& GetKleidiAISGemmUKernel() {
-    if (MLAS_CPUIDINFO::GetCPUIDInfo().HasArm_SME2()) {
-        return sgemm_gemm_sme2;
-    } else {
 #if defined(ENABLE_QMX_KERNELS)
-        if (ArmKleidiAI::vendor_name.compare("Qualcomm") == 0)
-        {
-            KLEIDIAI_KERNEL_LOG("SGEMM: Using QMX Kernel");
-            return sgemm_gemm_qmx;
-        } else {
-            return sgemm_gemm_sme;
-        }
-#else
-        return sgemm_gemm_sme;
-#endif // ENABLE_QMX_KERNELS
+    if (ArmKleidiAI::vendor_name.compare("Qualcomm") == 0)
+    {
+        KLEIDIAI_KERNEL_LOG("SGEMM: Using QMX Kernel");
+        return sgemm_gemm_qmx;
     }
+#endif // ENABLE_QMX_KERNELS
+    return sgemm_gemm_sme;
 }
 
 const KaiF32SgemvKernel& GetKleidiAISGemvUKernel() {
-    if (MLAS_CPUIDINFO::GetCPUIDInfo().HasArm_SME2()) {
-        return sgemm_gemv_sme2;
-    } else {
-        return sgemm_gemv_sme;
-    }
+    return sgemm_gemv_sme;
 }
 
 const KaiF32IMatmulKernel& GetKleidiAIF32IMatmulUKernel() {

--- a/onnxruntime/core/mlas/lib/kleidiai/sgemm_kleidiai.cpp
+++ b/onnxruntime/core/mlas/lib/kleidiai/sgemm_kleidiai.cpp
@@ -297,17 +297,16 @@ bool MlasGemmBatchSme2(CBLAS_TRANSPOSE TransB,
                        const MLAS_SGEMM_DATA_PARAMS* Data,
                        size_t BatchSize,
                        MLAS_THREADPOOL* ThreadPool) {
-    const bool b_is_packed = Data[0].BIsPacked;
-    for (size_t batch = 1; batch < BatchSize; ++batch) {
-        if (Data[batch].BIsPacked != b_is_packed) {
-            return false;
-        }
+    bool has_unpacked_b = false;
+    for (size_t batch = 0; batch < BatchSize; ++batch) {
+        has_unpacked_b |= !Data[batch].BIsPacked;
     }
 
     // Both source orientations produce the same p4vsx1 packed layout. Packed
     // MLAS calls do not preserve the source TransB value, so use one canonical
-    // packer contract for offsets and strides during execution.
-    if (b_is_packed) {
+    // packer contract when every B is already packed. If any B is raw, retain
+    // TransB so those entries are packed from the correct source orientation.
+    if (!has_unpacked_b) {
         TransB = CblasNoTrans;
     }
 
@@ -348,12 +347,12 @@ bool MlasGemmBatchSme2(CBLAS_TRANSPOSE TransB,
     size_t lhs_buffer_size = 0;
     size_t rhs_buffer_size = 0;
     if (MlasMultiplyOverflowsSizeT(lhs_packed_size, BatchSize, &lhs_buffer_size) ||
-        (!b_is_packed && MlasMultiplyOverflowsSizeT(rhs_packed_size, BatchSize, &rhs_buffer_size))) {
+        (has_unpacked_b && MlasMultiplyOverflowsSizeT(rhs_packed_size, BatchSize, &rhs_buffer_size))) {
         return false;
     }
 
     size_t packing_iterations = BatchSize;
-    if (!b_is_packed && MlasMultiplyOverflowsSizeT(BatchSize, size_t{2}, &packing_iterations)) {
+    if (has_unpacked_b && MlasMultiplyOverflowsSizeT(BatchSize, size_t{2}, &packing_iterations)) {
         return false;
     }
     if (packing_iterations > static_cast<size_t>(std::numeric_limits<ptrdiff_t>::max())) {
@@ -420,24 +419,24 @@ bool MlasGemmBatchSme2(CBLAS_TRANSPOSE TransB,
     }
 
     g_kai_tls.lhs_packed.resize(lhs_buffer_size);
-    if (!b_is_packed) {
+    if (has_unpacked_b) {
         g_kai_tls.rhs_packed.resize(rhs_buffer_size);
         g_kai_tls.bias_zero.assign(N, 0.0f);
     }
 
     std::byte* const lhs_packed_data = g_kai_tls.lhs_packed.data();
-    std::byte* const rhs_packed_data = b_is_packed ? nullptr : g_kai_tls.rhs_packed.data();
-    const float* const bias_zero = b_is_packed ? nullptr : g_kai_tls.bias_zero.data();
+    std::byte* const rhs_packed_data = has_unpacked_b ? g_kai_tls.rhs_packed.data() : nullptr;
+    const float* const bias_zero = has_unpacked_b ? g_kai_tls.bias_zero.data() : nullptr;
 
     MlasTrySimpleParallel(ThreadPool, static_cast<ptrdiff_t>(packing_iterations), [&](ptrdiff_t tid) {
-        const size_t batch_idx = b_is_packed ? static_cast<size_t>(tid) : static_cast<size_t>(tid >> 1);
-        if (b_is_packed || (tid & 0x1)) {
+        const size_t batch_idx = has_unpacked_b ? static_cast<size_t>(tid >> 1) : static_cast<size_t>(tid);
+        if (!has_unpacked_b || (tid & 0x1)) {
             PackSme2A(M,
                       K,
                       Data[batch_idx].A,
                       Data[batch_idx].lda,
                       lhs_packed_data + lhs_packed_size * batch_idx);
-        } else {
+        } else if (!Data[batch_idx].BIsPacked) {
             PackSme2B(TransB,
                       N,
                       K,
@@ -468,7 +467,7 @@ bool MlasGemmBatchSme2(CBLAS_TRANSPOSE TransB,
             &kSme2PackRhsConfig, &rhs_index, &rhs_packed_stride);
 
         const auto* lhs_tile = lhs_packed_data + lhs_packed_size * batch_idx + lhs_offset;
-        const std::byte* rhs_base = b_is_packed
+        const std::byte* rhs_base = Data[batch_idx].BIsPacked
             ? reinterpret_cast<const std::byte*>(Data[batch_idx].B)
             : rhs_packed_data + rhs_packed_size * batch_idx;
         const auto* rhs_tile = rhs_base + rhs_offset;

--- a/onnxruntime/core/mlas/lib/kleidiai/sgemm_kleidiai.cpp
+++ b/onnxruntime/core/mlas/lib/kleidiai/sgemm_kleidiai.cpp
@@ -6,8 +6,11 @@
 
 #include <vector>
 #include <algorithm>
+#include <array>
 #include <cstring>
 #include <cstddef>
+#include <limits>
+#include <stdexcept>
 #include <arm_neon.h>
 
 #include "mlas.h"
@@ -19,6 +22,10 @@
 #include "kai/ukernels/matmul/pack/kai_lhs_pack_f32p2vlx1_f32_sme.h"
 #include "kai/ukernels/matmul/pack/kai_rhs_pack_kxn_f32p2vlx1biasf32_f32_f32_sme.h"
 #include "kai/ukernels/matmul/pack/kai_rhs_pack_nxk_f32p2vlx1biasf32_f32_f32_sme.h"
+
+#include "kai/ukernels/matmul/kai_matmul.h"
+#include "kai/ukernels/matmul/kai_matmul_pack_lhs.h"
+#include "kai/ukernels/matmul/kai_matmul_pack_rhs.h"
 
 // Thread-local reusable buffers to reduce allocation overhead across tiles.
 struct KaiTlsBuffers {
@@ -32,6 +39,110 @@ static thread_local KaiTlsBuffers g_kai_tls;
 
 const KaiF32SgemmKernel& sgemm_gemm = GetKleidiAISGemmUKernel();
 const KaiF32SgemvKernel& sgemm_gemv = GetKleidiAISGemvUKernel();
+
+namespace {
+
+const kai_matmul_uker_config kSme2MatmulConfig{};
+const kai_matmul_pack_lhs_uker_config kSme2PackLhsConfig{};
+const kai_matmul_pack_rhs_uker_config kSme2PackRhsConfig{};
+
+const kai_matmul_uker_api kSme2Gemm4vsx1 =
+    kai_matmul_clamp_f32_f32p4vsx1_f32p4vsx1bf32_8vsx8vs_sme2_mopa();
+const kai_matmul_pack_lhs_uker_api kSme2PackLhs4vsx1 =
+    kai_matmul_pack_lhs_mxk_x32p4vsx1_x32_sme();
+const kai_matmul_pack_rhs_uker_api kSme2PackRhsKxN4vsx1 =
+    kai_matmul_pack_rhs_kxn_x32p4vsx1bx32_x32_x32_sme();
+const kai_matmul_pack_rhs_uker_api kSme2PackRhsNxK4vsx1 =
+    kai_matmul_pack_rhs_nxk_x32p4vsx1bx32_x32_x32_sme();
+
+constexpr float kNoActivationClampMin = -std::numeric_limits<float>::infinity();
+constexpr float kNoActivationClampMax = std::numeric_limits<float>::infinity();
+
+const kai_matmul_pack_rhs_uker_api* GetSme2PackRhs(CBLAS_TRANSPOSE TransB) {
+    switch (TransB) {
+        case CblasNoTrans:
+            return &kSme2PackRhsKxN4vsx1;
+        case CblasTrans:
+            return &kSme2PackRhsNxK4vsx1;
+        default:
+            return nullptr;
+    }
+}
+
+size_t GetSme2PackedBSize(CBLAS_TRANSPOSE TransB, size_t N, size_t K) {
+    const auto* pack_rhs = GetSme2PackRhs(TransB);
+    if (pack_rhs == nullptr || N == 0 || K == 0) {
+        return 0;
+    }
+
+    const kai_matmul_pack_rhs_uker_rhs_packed_dim_args shape{N, K};
+    const auto stride = pack_rhs->get_rhs_packed_stride(&kSme2PackRhsConfig, &shape);
+    return pack_rhs->get_rhs_packed_size(&kSme2PackRhsConfig, &shape, &stride);
+}
+
+bool PackSme2B(CBLAS_TRANSPOSE TransB,
+               size_t N,
+               size_t K,
+               const float* B,
+               size_t ldb,
+               const float* Bias,
+               void* PackedB) {
+    const auto* pack_rhs = GetSme2PackRhs(TransB);
+    if (pack_rhs == nullptr || N == 0 || K == 0) {
+        return false;
+    }
+
+    const kai_matmul_pack_rhs_uker_rhs_packed_dim_args shape{N, K};
+    const auto packed_stride = pack_rhs->get_rhs_packed_stride(&kSme2PackRhsConfig, &shape);
+
+    kai_matmul_pack_rhs_uker_args args{};
+    args.shape = {N, K};
+    args.operand.rhs.ptr = B;
+    args.operand.rhs_packed.ptr = PackedB;
+    args.operand.rhs_packed.stride = packed_stride;
+    args.operand.bias_n.ptr = Bias;
+
+    if (TransB == CblasNoTrans) {
+        args.operand.rhs.stride.n = sizeof(float);
+        args.operand.rhs.stride.k = ldb * sizeof(float);
+    } else {
+        args.operand.rhs.stride.n = ldb * sizeof(float);
+        args.operand.rhs.stride.k = sizeof(float);
+    }
+
+    pack_rhs->run(&kSme2PackRhsConfig, &args);
+    return true;
+}
+
+size_t GetSme2PackedASize(size_t M, size_t K) {
+    const kai_matmul_pack_lhs_uker_lhs_packed_dim_args shape{M, K};
+    const auto stride = kSme2PackLhs4vsx1.get_lhs_packed_stride(&kSme2PackLhsConfig, &shape);
+    return kSme2PackLhs4vsx1.get_lhs_packed_size(&kSme2PackLhsConfig, &shape, &stride);
+}
+
+void PackSme2A(size_t M, size_t K, const float* A, size_t lda, void* PackedA) {
+    const kai_matmul_pack_lhs_uker_lhs_packed_dim_args shape{M, K};
+    const auto packed_stride = kSme2PackLhs4vsx1.get_lhs_packed_stride(&kSme2PackLhsConfig, &shape);
+
+    kai_matmul_pack_lhs_uker_args args{};
+    args.shape = {M, K};
+    args.operand.lhs.ptr = A;
+    args.operand.lhs.stride.m = lda * sizeof(float);
+    args.operand.lhs_packed.ptr = PackedA;
+    args.operand.lhs_packed.stride = packed_stride;
+
+    kSme2PackLhs4vsx1.run(&kSme2PackLhsConfig, &args);
+}
+
+bool MlasGemmBatchSme2(CBLAS_TRANSPOSE TransB,
+                       size_t M,
+                       size_t N,
+                       size_t K,
+                       const MLAS_SGEMM_DATA_PARAMS* Data,
+                       size_t BatchSize,
+                       MLAS_THREADPOOL* ThreadPool);
+
+}  // namespace
 
 // Avoid vector setup overhead on tiny outputs.
 constexpr size_t kAlphaBetaNeonMinElements = 32;
@@ -177,9 +288,233 @@ static inline void ApplyBetaToC(float* C, size_t ldc, size_t M, size_t N, float 
     }
 }
 
+namespace {
+
+bool MlasGemmBatchSme2(CBLAS_TRANSPOSE TransB,
+                       size_t M,
+                       size_t N,
+                       size_t K,
+                       const MLAS_SGEMM_DATA_PARAMS* Data,
+                       size_t BatchSize,
+                       MLAS_THREADPOOL* ThreadPool) {
+    const bool b_is_packed = Data[0].BIsPacked;
+    for (size_t batch = 1; batch < BatchSize; ++batch) {
+        if (Data[batch].BIsPacked != b_is_packed) {
+            return false;
+        }
+    }
+
+    // Both source orientations produce the same p4vsx1 packed layout. Packed
+    // MLAS calls do not preserve the source TransB value, so use one canonical
+    // packer contract for offsets and strides during execution.
+    if (b_is_packed) {
+        TransB = CblasNoTrans;
+    }
+
+    const auto* pack_rhs = GetSme2PackRhs(TransB);
+    if (pack_rhs == nullptr) {
+        return false;
+    }
+
+    const auto step = kSme2Gemm4vsx1.get_step(&kSme2MatmulConfig);
+    const auto lhs_pack_step = kSme2PackLhs4vsx1.get_step(&kSme2PackLhsConfig);
+    const auto rhs_pack_step = pack_rhs->get_step(&kSme2PackRhsConfig);
+    if (step.m == 0 || step.n == 0 || lhs_pack_step.m != step.m || rhs_pack_step.n != step.n ||
+        lhs_pack_step.k != 0 || rhs_pack_step.k != 0) {
+        return false;
+    }
+
+    const kai_matmul_uker_lhs_dim_args lhs_shape{M, K};
+    const kai_matmul_uker_rhs_dim_args rhs_shape{N, K};
+    const auto lhs_stride = kSme2Gemm4vsx1.get_lhs_stride(&kSme2MatmulConfig, &lhs_shape);
+    const auto rhs_stride = kSme2Gemm4vsx1.get_rhs_stride(&kSme2MatmulConfig, &rhs_shape);
+
+    const kai_matmul_pack_lhs_uker_lhs_packed_dim_args lhs_packed_shape{M, K};
+    const auto lhs_packed_stride =
+        kSme2PackLhs4vsx1.get_lhs_packed_stride(&kSme2PackLhsConfig, &lhs_packed_shape);
+    const kai_matmul_pack_rhs_uker_rhs_packed_dim_args rhs_packed_shape{N, K};
+    const auto rhs_packed_stride =
+        pack_rhs->get_rhs_packed_stride(&kSme2PackRhsConfig, &rhs_packed_shape);
+    if (lhs_stride.m != lhs_packed_stride.m || rhs_stride.n != rhs_packed_stride.n) {
+        return false;
+    }
+
+    const size_t lhs_packed_size = GetSme2PackedASize(M, K);
+    const size_t rhs_packed_size = GetSme2PackedBSize(TransB, N, K);
+    if (lhs_packed_size == 0 || rhs_packed_size == 0) {
+        return false;
+    }
+
+    size_t lhs_buffer_size = 0;
+    size_t rhs_buffer_size = 0;
+    if (MlasMultiplyOverflowsSizeT(lhs_packed_size, BatchSize, &lhs_buffer_size) ||
+        (!b_is_packed && MlasMultiplyOverflowsSizeT(rhs_packed_size, BatchSize, &rhs_buffer_size))) {
+        return false;
+    }
+
+    size_t packing_iterations = BatchSize;
+    if (!b_is_packed && MlasMultiplyOverflowsSizeT(BatchSize, size_t{2}, &packing_iterations)) {
+        return false;
+    }
+    if (packing_iterations > static_cast<size_t>(std::numeric_limits<ptrdiff_t>::max())) {
+        return false;
+    }
+
+    size_t m_step = step.m;
+    size_t n_step = step.n;
+    std::array<size_t, 3> dim{
+        BatchSize,
+        MlasDivRoundup(M, m_step),
+        MlasDivRoundup(N, n_step)};
+
+    size_t initial_mn_tiles = 0;
+    size_t initial_tile_count = 0;
+    if (MlasMultiplyOverflowsSizeT(dim[1], dim[2], &initial_mn_tiles) ||
+        MlasMultiplyOverflowsSizeT(dim[0], initial_mn_tiles, &initial_tile_count)) {
+        return false;
+    }
+
+    const size_t maximum_thread_count =
+        std::max<size_t>(1, static_cast<size_t>(MlasGetMaximumThreadCount(ThreadPool)));
+    const size_t required_tiles = std::min(maximum_thread_count, initial_tile_count);
+
+    size_t required_m_tiles = 0;
+    size_t required_n_tiles = 0;
+    if (required_tiles == 0 ||
+        MlasMultiplyOverflowsSizeT(required_tiles, dim[1], &required_m_tiles) ||
+        MlasMultiplyOverflowsSizeT(required_tiles, dim[2], &required_n_tiles)) {
+        return false;
+    }
+
+    dim[1] = MlasDivRoundup(required_m_tiles, initial_mn_tiles);
+    size_t n_tile_denominator = 0;
+    if (MlasMultiplyOverflowsSizeT(dim[1], dim[2], &n_tile_denominator) || n_tile_denominator == 0) {
+        return false;
+    }
+    dim[2] = MlasDivRoundup(required_n_tiles, n_tile_denominator);
+    if (dim[1] == 0 || dim[2] == 0) {
+        return false;
+    }
+
+    const size_t m_step_scale = MlasDivRoundup(MlasDivRoundup(M, dim[1]), m_step);
+    const size_t n_step_scale = MlasDivRoundup(MlasDivRoundup(N, dim[2]), n_step);
+    if (MlasMultiplyOverflowsSizeT(m_step, m_step_scale, &m_step) ||
+        MlasMultiplyOverflowsSizeT(n_step, n_step_scale, &n_step)) {
+        return false;
+    }
+
+    dim[1] = MlasDivRoundup(M, m_step);
+    dim[2] = MlasDivRoundup(N, n_step);
+
+    size_t mn_tiles = 0;
+    size_t total_tiles = 0;
+    if (MlasMultiplyOverflowsSizeT(dim[1], dim[2], &mn_tiles) ||
+        MlasMultiplyOverflowsSizeT(dim[0], mn_tiles, &total_tiles) ||
+        total_tiles > static_cast<size_t>(std::numeric_limits<ptrdiff_t>::max())) {
+        return false;
+    }
+
+    size_t max_tile_elements = 0;
+    if (MlasMultiplyOverflowsSizeT(m_step, n_step, &max_tile_elements)) {
+        return false;
+    }
+
+    g_kai_tls.lhs_packed.resize(lhs_buffer_size);
+    if (!b_is_packed) {
+        g_kai_tls.rhs_packed.resize(rhs_buffer_size);
+        g_kai_tls.bias_zero.assign(N, 0.0f);
+    }
+
+    std::byte* const lhs_packed_data = g_kai_tls.lhs_packed.data();
+    std::byte* const rhs_packed_data = b_is_packed ? nullptr : g_kai_tls.rhs_packed.data();
+    const float* const bias_zero = b_is_packed ? nullptr : g_kai_tls.bias_zero.data();
+
+    MlasTrySimpleParallel(ThreadPool, static_cast<ptrdiff_t>(packing_iterations), [&](ptrdiff_t tid) {
+        const size_t batch_idx = b_is_packed ? static_cast<size_t>(tid) : static_cast<size_t>(tid >> 1);
+        if (b_is_packed || (tid & 0x1)) {
+            PackSme2A(M,
+                      K,
+                      Data[batch_idx].A,
+                      Data[batch_idx].lda,
+                      lhs_packed_data + lhs_packed_size * batch_idx);
+        } else {
+            PackSme2B(TransB,
+                      N,
+                      K,
+                      reinterpret_cast<const float*>(Data[batch_idx].B),
+                      Data[batch_idx].ldb,
+                      bias_zero,
+                      rhs_packed_data + rhs_packed_size * batch_idx);
+        }
+    });
+
+    MlasTrySimpleParallel(ThreadPool, static_cast<ptrdiff_t>(total_tiles), [=](ptrdiff_t tid) {
+        const size_t work_idx = static_cast<size_t>(tid);
+        const size_t batch_idx = work_idx / mn_tiles;
+        const size_t tile_idx = work_idx % mn_tiles;
+        const size_t m_idx = tile_idx / dim[2];
+        const size_t n_idx = tile_idx % dim[2];
+
+        const size_t start_m = m_idx * m_step;
+        const size_t start_n = n_idx * n_step;
+        const size_t tile_m = std::min(m_step, M - start_m);
+        const size_t tile_n = std::min(n_step, N - start_n);
+
+        const kai_matmul_pack_lhs_uker_lhs_packed_dim_args lhs_index{start_m, 0};
+        const kai_matmul_pack_rhs_uker_rhs_packed_dim_args rhs_index{start_n, 0};
+        const size_t lhs_offset = kSme2PackLhs4vsx1.get_lhs_packed_offset(
+            &kSme2PackLhsConfig, &lhs_index, &lhs_packed_stride);
+        const size_t rhs_offset = pack_rhs->get_rhs_packed_offset(
+            &kSme2PackRhsConfig, &rhs_index, &rhs_packed_stride);
+
+        const auto* lhs_tile = lhs_packed_data + lhs_packed_size * batch_idx + lhs_offset;
+        const std::byte* rhs_base = b_is_packed
+            ? reinterpret_cast<const std::byte*>(Data[batch_idx].B)
+            : rhs_packed_data + rhs_packed_size * batch_idx;
+        const auto* rhs_tile = rhs_base + rhs_offset;
+        float* const dst_tile = Data[batch_idx].C + start_m * Data[batch_idx].ldc + start_n;
+
+        const float alpha = Data[batch_idx].alpha;
+        const float beta = Data[batch_idx].beta;
+        const bool direct_to_c = alpha == 1.0f && beta == 0.0f;
+
+        float* output = dst_tile;
+        size_t output_stride = Data[batch_idx].ldc * sizeof(float);
+        if (!direct_to_c) {
+            g_kai_tls.output_tile.resize(tile_m * tile_n);
+            output = g_kai_tls.output_tile.data();
+            output_stride = tile_n * sizeof(float);
+        }
+
+        kai_matmul_uker_args args{};
+        args.flags = KAI_MATMUL_UKER_FLAGS_ARGS_CLAMP;
+        args.shape = {tile_m, tile_n, K};
+        args.operand.lhs.ptr = lhs_tile;
+        args.operand.lhs.stride = lhs_stride;
+        args.operand.rhs.ptr = rhs_tile;
+        args.operand.rhs.stride = rhs_stride;
+        args.operand.dst.ptr = output;
+        args.operand.dst.stride.m = output_stride;
+        args.activation.clamp.min_ptr = &kNoActivationClampMin;
+        args.activation.clamp.max_ptr = &kNoActivationClampMax;
+
+        KLEIDIAI_KERNEL_LOG("kai_matmul_clamp_f32_f32p4vsx1_f32p4vsx1bf32_8vsx8vs_sme2_mopa"
+                            << " M=" << tile_m << " N=" << tile_n << " K=" << K);
+        kSme2Gemm4vsx1.run(&kSme2MatmulConfig, &args);
+
+        if (!direct_to_c) {
+            ApplyAlphaBeta2D(output, tile_m, tile_n, alpha, beta, dst_tile, Data[batch_idx].ldc);
+        }
+    });
+
+    return true;
+}
+
+}  // namespace
+
 /*++
 Routine Description:
-    Execute GEMV using the SME/SME2 1xN microkernel for degenerate GEMM shapes:
+    Execute GEMV using the retained SME 1xN microkernel for degenerate GEMM shapes:
     - M == 1 (row-vector times matrix)
     - N == 1 (matrix times column-vector)
 
@@ -342,6 +677,11 @@ Return Value:
         KLEIDIAI_DEBUG_LOG("MlasGemmPackBSize returning 0 size. N=" << N << " K=" << K);
         return 0;
     }
+
+    if (ArmKleidiAI::UseSME2) {
+        return GetSme2PackedBSize(TransB, N, K);
+    }
+
     //
     // Compute the number of bytes required to hold the packed buffer.
     //
@@ -409,6 +749,17 @@ Return Value:
     }
 
     if (TransA == CblasNoTrans) {
+
+        if (ArmKleidiAI::UseSME2) {
+            const auto* pack_rhs = GetSme2PackRhs(TransB);
+            if (pack_rhs == nullptr) {
+                return false;
+            }
+
+            g_kai_tls.bias_zero.assign(N, 0.0f);
+            return PackSme2B(
+                TransB, N, K, B, ldb, g_kai_tls.bias_zero.data(), PackedB);
+        }
 
         const size_t nr = sgemm_gemm.ukernel.get_nr();
         const size_t kr = sgemm_gemm.ukernel.get_kr();
@@ -513,6 +864,26 @@ Return Value:
             ApplyBetaToC(Data[batch].C, Data[batch].ldc, M, N, Data[batch].beta);
         }
         return true;
+    }
+
+    if (ArmKleidiAI::UseSME2) {
+        if (TransA != CblasNoTrans) {
+            return false;
+        }
+
+        bool has_packed_b = false;
+        for (size_t batch = 0; batch < BatchSize; ++batch) {
+            has_packed_b |= Data[batch].BIsPacked;
+        }
+
+        const bool handled = MlasGemmBatchSme2(TransB, M, N, K, Data, BatchSize, ThreadPool);
+        if (!handled && has_packed_b) {
+            // Public SME2 packing uses p4vsx1, which the generic MLAS fallback
+            // and the retained SME implementation cannot consume.
+            MLAS_THROW_EX(std::runtime_error,
+                          "KleidiAI SME2 cannot fall back with an SME2-packed SGEMM B.");
+        }
+        return handled;
     }
 
     // Attempt GEMV (M==1 or N==1)

--- a/onnxruntime/core/mlas/lib/kleidiai/sgemm_kleidiai.cpp
+++ b/onnxruntime/core/mlas/lib/kleidiai/sgemm_kleidiai.cpp
@@ -299,7 +299,7 @@ bool MlasGemmBatchSme2(CBLAS_TRANSPOSE TransB,
                        MLAS_THREADPOOL* ThreadPool) {
     bool has_unpacked_b = false;
     for (size_t batch = 0; batch < BatchSize; ++batch) {
-        has_unpacked_b |= !Data[batch].BIsPacked;
+        has_unpacked_b |= Data[batch].alpha != 0.0f && !Data[batch].BIsPacked;
     }
 
     // Both source orientations produce the same p4vsx1 packed layout. Packed
@@ -430,6 +430,10 @@ bool MlasGemmBatchSme2(CBLAS_TRANSPOSE TransB,
 
     MlasTrySimpleParallel(ThreadPool, static_cast<ptrdiff_t>(packing_iterations), [&](ptrdiff_t tid) {
         const size_t batch_idx = has_unpacked_b ? static_cast<size_t>(tid >> 1) : static_cast<size_t>(tid);
+        if (Data[batch_idx].alpha == 0.0f) {
+            return;
+        }
+
         if (!has_unpacked_b || (tid & 0x1)) {
             PackSme2A(M,
                       K,
@@ -458,6 +462,14 @@ bool MlasGemmBatchSme2(CBLAS_TRANSPOSE TransB,
         const size_t start_n = n_idx * n_step;
         const size_t tile_m = std::min(m_step, M - start_m);
         const size_t tile_n = std::min(n_step, N - start_n);
+        const float alpha = Data[batch_idx].alpha;
+        const float beta = Data[batch_idx].beta;
+        float* const dst_tile = Data[batch_idx].C + start_m * Data[batch_idx].ldc + start_n;
+
+        if (alpha == 0.0f) {
+            ApplyBetaToC(dst_tile, Data[batch_idx].ldc, tile_m, tile_n, beta);
+            return;
+        }
 
         const kai_matmul_pack_lhs_uker_lhs_packed_dim_args lhs_index{start_m, 0};
         const kai_matmul_pack_rhs_uker_rhs_packed_dim_args rhs_index{start_n, 0};
@@ -471,10 +483,6 @@ bool MlasGemmBatchSme2(CBLAS_TRANSPOSE TransB,
             ? reinterpret_cast<const std::byte*>(Data[batch_idx].B)
             : rhs_packed_data + rhs_packed_size * batch_idx;
         const auto* rhs_tile = rhs_base + rhs_offset;
-        float* const dst_tile = Data[batch_idx].C + start_m * Data[batch_idx].ldc + start_n;
-
-        const float alpha = Data[batch_idx].alpha;
-        const float beta = Data[batch_idx].beta;
         const bool direct_to_c = alpha == 1.0f && beta == 0.0f;
 
         float* output = dst_tile;

--- a/onnxruntime/test/mlas/unittest/test_fgemm.cpp
+++ b/onnxruntime/test/mlas/unittest/test_fgemm.cpp
@@ -3,7 +3,11 @@
 
 #include "test_fgemm.h"
 #include "test_fgemm_fixture.h"
+#if defined(MLAS_TARGET_ARM64) && defined(USE_KLEIDIAI)
+#include "core/mlas/lib/kleidiai/mlasi_kleidiai.h"
+#endif
 
+#include <array>
 #include <cmath>
 #include <limits>
 #include <memory>
@@ -116,6 +120,98 @@ TEST(SGemmPublicApi, InfiniteResultsAreNotClamped) {
       }
     }
   });
+}
+
+TEST(SGemmPublicApi, MixedPackedAndUnpackedBatchSme2) {
+#if defined(MLAS_TARGET_ARM64) && defined(USE_KLEIDIAI)
+  if (!ArmKleidiAI::UseSME2) {
+    GTEST_SKIP() << "Mixed KleidiAI SGEMM packing is exercised only by the SME2 path.";
+  }
+#else
+  GTEST_SKIP() << "Mixed KleidiAI SGEMM packing requires an ARM64 SME2 build.";
+#endif
+
+  constexpr size_t M = 3;
+  constexpr size_t N = 513;
+  constexpr size_t K = 7;
+
+  for (CBLAS_TRANSPOSE trans_b : {CblasNoTrans, CblasTrans}) {
+    const size_t ldb = trans_b == CblasNoTrans ? N : K;
+    for (size_t packed_index : {size_t{0}, size_t{1}}) {
+      SCOPED_TRACE(testing::Message() << "TransB=" << static_cast<int>(trans_b)
+                                      << " packed_index=" << packed_index);
+
+      std::array<std::vector<float>, 2> a;
+      std::array<std::vector<float>, 2> b;
+      std::array<std::vector<float>, 2> c;
+      std::array<std::vector<float>, 2> expected;
+      for (size_t batch = 0; batch < a.size(); ++batch) {
+        a[batch].resize(M * K);
+        b[batch].resize(K * N);
+        c[batch].assign(M * N, 0.0f);
+        expected[batch].resize(M * N);
+
+        for (size_t row = 0; row < M; ++row) {
+          for (size_t k = 0; k < K; ++k) {
+            const int value = static_cast<int>((row * 3 + k * 5 + batch * 7) % 17) - 8;
+            a[batch][row * K + k] = static_cast<float>(value) / 8.0f;
+          }
+        }
+        for (size_t k = 0; k < K; ++k) {
+          for (size_t col = 0; col < N; ++col) {
+            const int value = static_cast<int>((k * 7 + col * 3 + batch * 5) % 19) - 9;
+            const size_t index = trans_b == CblasNoTrans ? k * N + col : col * K + k;
+            b[batch][index] = static_cast<float>(value) / 16.0f;
+          }
+        }
+        for (size_t row = 0; row < M; ++row) {
+          for (size_t col = 0; col < N; ++col) {
+            float sum = 0.0f;
+            for (size_t k = 0; k < K; ++k) {
+              const size_t index = trans_b == CblasNoTrans ? k * N + col : col * K + k;
+              sum += a[batch][row * K + k] * b[batch][index];
+            }
+            expected[batch][row * N + col] = sum;
+          }
+        }
+      }
+
+      const size_t packed_b_size = MlasGemmPackBSize(CblasNoTrans, trans_b, N, K, nullptr);
+      ASSERT_GT(packed_b_size, 0u);
+      std::vector<uint8_t> packed_b(packed_b_size);
+      MlasGemmPackB(CblasNoTrans,
+                    trans_b,
+                    N,
+                    K,
+                    b[packed_index].data(),
+                    ldb,
+                    packed_b.data(),
+                    nullptr);
+
+      std::array<MLAS_SGEMM_DATA_PARAMS, 2> data{};
+      for (size_t batch = 0; batch < data.size(); ++batch) {
+        data[batch].A = a[batch].data();
+        data[batch].lda = K;
+        data[batch].B = batch == packed_index
+                            ? reinterpret_cast<const float*>(packed_b.data())
+                            : b[batch].data();
+        data[batch].ldb = ldb;
+        data[batch].C = c[batch].data();
+        data[batch].ldc = N;
+        data[batch].BIsPacked = batch == packed_index;
+      }
+
+      EXPECT_NO_THROW(
+          MlasGemmBatch(
+              CblasNoTrans, trans_b, M, N, K, data.data(), data.size(), GetMlasThreadPool(), nullptr));
+
+      for (size_t batch = 0; batch < c.size(); ++batch) {
+        for (size_t index = 0; index < c[batch].size(); ++index) {
+          EXPECT_NEAR(c[batch][index], expected[batch][index], 1.0e-5f);
+        }
+      }
+    }
+  }
 }
 
 }  // namespace

--- a/onnxruntime/test/mlas/unittest/test_fgemm.cpp
+++ b/onnxruntime/test/mlas/unittest/test_fgemm.cpp
@@ -230,6 +230,72 @@ TEST(SGemmPublicApi, MixedPackedAndUnpackedBatchSme2) {
   }
 }
 
+TEST(SGemmPublicApi, MixedAlphaZeroDoesNotReadInputsSme2) {
+  if (!HasKleidiAISme2()) {
+    GTEST_SKIP() << "This test validates the KleidiAI SME2 SGEMM path.";
+  }
+
+  constexpr size_t M = 3;
+  constexpr size_t N = 65;
+  constexpr size_t K = 7;
+
+  for (CBLAS_TRANSPOSE trans_b : {CblasNoTrans, CblasTrans}) {
+    const size_t ldb = trans_b == CblasNoTrans ? N : K;
+    for (size_t zero_index : {size_t{0}, size_t{1}}) {
+      for (bool zero_is_packed : {false, true}) {
+        SCOPED_TRACE(testing::Message() << "TransB=" << static_cast<int>(trans_b)
+                                        << " zero_index=" << zero_index
+                                        << " zero_is_packed=" << zero_is_packed);
+
+        const size_t active_index = 1 - zero_index;
+        const size_t packed_index = zero_is_packed ? zero_index : active_index;
+        std::vector<float> a(M * K, 2.0f);
+        std::vector<float> b(K * N, 0.5f);
+        std::array<std::vector<float>, 2> c;
+        c[zero_index].assign(M * N, 4.0f);
+        c[active_index].assign(M * N, 0.0f);
+
+        const size_t packed_b_size = MlasGemmPackBSize(CblasNoTrans, trans_b, N, K, nullptr);
+        ASSERT_GT(packed_b_size, 0u);
+        std::vector<uint8_t> packed_b(packed_b_size);
+        MlasGemmPackB(CblasNoTrans, trans_b, N, K, b.data(), ldb, packed_b.data(), nullptr);
+
+        std::array<MLAS_SGEMM_DATA_PARAMS, 2> data{};
+        for (size_t batch = 0; batch < data.size(); ++batch) {
+          const bool is_zero = batch == zero_index;
+          const bool is_packed = batch == packed_index;
+          data[batch].A = nullptr;
+          data[batch].lda = K;
+          data[batch].B = nullptr;
+          if (!is_zero) {
+            data[batch].A = a.data();
+            data[batch].B = is_packed
+                                ? reinterpret_cast<const float*>(packed_b.data())
+                                : b.data();
+          }
+          data[batch].ldb = ldb;
+          data[batch].C = c[batch].data();
+          data[batch].ldc = N;
+          data[batch].alpha = is_zero ? 0.0f : 1.0f;
+          data[batch].beta = is_zero ? -0.5f : 0.0f;
+          data[batch].BIsPacked = is_packed;
+        }
+
+        EXPECT_NO_THROW(
+            MlasGemmBatch(
+                CblasNoTrans, trans_b, M, N, K, data.data(), data.size(), GetMlasThreadPool(), nullptr));
+
+        for (float value : c[zero_index]) {
+          EXPECT_FLOAT_EQ(value, -2.0f);
+        }
+        for (float value : c[active_index]) {
+          EXPECT_FLOAT_EQ(value, 7.0f);
+        }
+      }
+    }
+  }
+}
+
 }  // namespace
 
 static size_t FGemmRegistLongExecute() {

--- a/onnxruntime/test/mlas/unittest/test_fgemm.cpp
+++ b/onnxruntime/test/mlas/unittest/test_fgemm.cpp
@@ -4,8 +4,121 @@
 #include "test_fgemm.h"
 #include "test_fgemm_fixture.h"
 
+#include <cmath>
+#include <limits>
 #include <memory>
 #include <sstream>
+#include <vector>
+
+namespace {
+
+void RunPublicSgemm(CBLAS_TRANSPOSE trans_b,
+                    bool packed,
+                    size_t m,
+                    size_t n,
+                    size_t k,
+                    float alpha,
+                    float beta,
+                    const std::vector<float>& a,
+                    const std::vector<float>& b,
+                    std::vector<float>& c) {
+  std::vector<uint8_t> packed_b;
+  const float* b_data = b.data();
+  const size_t ldb = trans_b == CblasNoTrans ? n : k;
+
+  if (packed) {
+    const size_t packed_b_size = MlasGemmPackBSize(CblasNoTrans, trans_b, n, k, nullptr);
+    ASSERT_GT(packed_b_size, 0u);
+    packed_b.resize(packed_b_size);
+    MlasGemmPackB(CblasNoTrans, trans_b, n, k, b.data(), ldb, packed_b.data(), nullptr);
+    b_data = reinterpret_cast<const float*>(packed_b.data());
+  }
+
+  MLAS_SGEMM_DATA_PARAMS data;
+  data.A = a.data();
+  data.lda = k;
+  data.B = b_data;
+  data.ldb = ldb;
+  data.C = c.data();
+  data.ldc = n;
+  data.alpha = alpha;
+  data.beta = beta;
+  data.BIsPacked = packed;
+
+  MlasGemmBatch(CblasNoTrans, trans_b, m, n, k, &data, 1, nullptr, nullptr);
+}
+
+template <typename Verify>
+void ForEachRhsLayoutAndPacking(Verify verify) {
+  for (CBLAS_TRANSPOSE trans_b : {CblasNoTrans, CblasTrans}) {
+    for (bool packed : {false, true}) {
+      SCOPED_TRACE(testing::Message() << "TransB=" << static_cast<int>(trans_b) << " packed=" << packed);
+      verify(trans_b, packed);
+    }
+  }
+}
+
+TEST(SGemmPublicApi, BetaZeroDoesNotReadC) {
+  constexpr size_t M = 33;
+  constexpr size_t N = 65;
+  constexpr size_t K = 31;
+
+  ForEachRhsLayoutAndPacking([](CBLAS_TRANSPOSE trans_b, bool packed) {
+    std::vector<float> a(M * K, 2.0f);
+    std::vector<float> b(K * N, 0.5f);
+    std::vector<float> c(M * N, std::numeric_limits<float>::quiet_NaN());
+
+    RunPublicSgemm(trans_b, packed, M, N, K, 0.5f, 0.0f, a, b, c);
+    for (float value : c) {
+      EXPECT_FLOAT_EQ(value, 15.5f);
+    }
+  });
+}
+
+TEST(SGemmPublicApi, AlphaZeroDoesNotReadInputs) {
+  constexpr size_t M = 33;
+  constexpr size_t N = 65;
+  constexpr size_t K = 31;
+
+  ForEachRhsLayoutAndPacking([](CBLAS_TRANSPOSE trans_b, bool packed) {
+    const float nan = std::numeric_limits<float>::quiet_NaN();
+    std::vector<float> a(M * K, nan);
+    std::vector<float> b(K * N, nan);
+    std::vector<float> c(M * N, 4.0f);
+
+    RunPublicSgemm(trans_b, packed, M, N, K, 0.0f, -0.5f, a, b, c);
+    for (float value : c) {
+      EXPECT_FLOAT_EQ(value, -2.0f);
+    }
+  });
+}
+
+TEST(SGemmPublicApi, InfiniteResultsAreNotClamped) {
+  constexpr size_t M = 33;
+  constexpr size_t N = 65;
+  constexpr size_t K = 1;
+
+  ForEachRhsLayoutAndPacking([](CBLAS_TRANSPOSE trans_b, bool packed) {
+    std::vector<float> a(M * K);
+    for (size_t row = 0; row < M; ++row) {
+      a[row] = row % 2 == 0 ? std::numeric_limits<float>::infinity()
+                            : -std::numeric_limits<float>::infinity();
+    }
+    std::vector<float> b(K * N, 1.0f);
+    std::vector<float> c(M * N, 0.0f);
+
+    RunPublicSgemm(trans_b, packed, M, N, K, 1.0f, 0.0f, a, b, c);
+    for (size_t row = 0; row < M; ++row) {
+      for (size_t col = 0; col < N; ++col) {
+        const float value = c[row * N + col];
+        EXPECT_TRUE(std::isinf(value));
+        EXPECT_EQ(std::signbit(value), row % 2 != 0);
+      }
+    }
+  });
+}
+
+}  // namespace
 
 static size_t FGemmRegistLongExecute() {
   size_t count = 0;

--- a/onnxruntime/test/mlas/unittest/test_fgemm.cpp
+++ b/onnxruntime/test/mlas/unittest/test_fgemm.cpp
@@ -16,6 +16,14 @@
 
 namespace {
 
+bool HasKleidiAISme2() {
+#if defined(MLAS_TARGET_ARM64) && defined(USE_KLEIDIAI)
+  return ArmKleidiAI::UseSME2;
+#else
+  return false;
+#endif
+}
+
 void RunPublicSgemm(CBLAS_TRANSPOSE trans_b,
                     bool packed,
                     size_t m,
@@ -63,6 +71,10 @@ void ForEachRhsLayoutAndPacking(Verify verify) {
 }
 
 TEST(SGemmPublicApi, BetaZeroDoesNotReadC) {
+  if (!HasKleidiAISme2()) {
+    GTEST_SKIP() << "This test validates the KleidiAI SME2 SGEMM path.";
+  }
+
   constexpr size_t M = 33;
   constexpr size_t N = 65;
   constexpr size_t K = 31;
@@ -80,6 +92,10 @@ TEST(SGemmPublicApi, BetaZeroDoesNotReadC) {
 }
 
 TEST(SGemmPublicApi, AlphaZeroDoesNotReadInputs) {
+  if (!HasKleidiAISme2()) {
+    GTEST_SKIP() << "This test validates the KleidiAI SME2 SGEMM path.";
+  }
+
   constexpr size_t M = 33;
   constexpr size_t N = 65;
   constexpr size_t K = 31;
@@ -98,6 +114,10 @@ TEST(SGemmPublicApi, AlphaZeroDoesNotReadInputs) {
 }
 
 TEST(SGemmPublicApi, InfiniteResultsAreNotClamped) {
+  if (!HasKleidiAISme2()) {
+    GTEST_SKIP() << "This test validates the KleidiAI SME2 SGEMM path.";
+  }
+
   constexpr size_t M = 33;
   constexpr size_t N = 65;
   constexpr size_t K = 1;
@@ -123,13 +143,9 @@ TEST(SGemmPublicApi, InfiniteResultsAreNotClamped) {
 }
 
 TEST(SGemmPublicApi, MixedPackedAndUnpackedBatchSme2) {
-#if defined(MLAS_TARGET_ARM64) && defined(USE_KLEIDIAI)
-  if (!ArmKleidiAI::UseSME2) {
-    GTEST_SKIP() << "Mixed KleidiAI SGEMM packing is exercised only by the SME2 path.";
+  if (!HasKleidiAISme2()) {
+    GTEST_SKIP() << "This test validates the KleidiAI SME2 SGEMM path.";
   }
-#else
-  GTEST_SKIP() << "Mixed KleidiAI SGEMM packing requires an ARM64 SME2 build.";
-#endif
 
   constexpr size_t M = 3;
   constexpr size_t N = 513;

--- a/onnxruntime/test/optimizer/qdq_matmulnbits_transformer_test.cc
+++ b/onnxruntime/test/optimizer/qdq_matmulnbits_transformer_test.cc
@@ -1098,6 +1098,8 @@ void RunDQMatMulPerTensorWithBlockSize(const std::vector<int64_t>& input1_shape,
 
   std::function<void(SessionOptions&)> add_session_options_fn =
       [block_size_option](SessionOptions& sess_opts) {
+        // Keep this graph-transformation test independent of architecture-specific matmul reduction order.
+        std::ignore = sess_opts.config_options.AddConfigEntry(kOrtSessionOptionsMlasDisableKleidiAi, "1");
         std::ignore = sess_opts.config_options.AddConfigEntry(kOrtSessionOptionsQDQMatMulNBitsAccuracyLevel, "0");
         std::ignore = sess_opts.config_options.AddConfigEntry(
             kOrtSessionOptionsQDQMatMulNBitsBlockSize,


### PR DESCRIPTION
### Description

This change updates KleidiAI to v1.30 and replaces the fixed SME2 FP32 SGEMM/GEMV integration with KleidiAI’s generic packing and matmul APIs.

The new SME2 path:

- Uses the `p4vsx1` LHS and RHS packing formats.
- Supports transposed and non-transposed RHS inputs.
- Supports both pre-packed and runtime-packed RHS data, including mixed batches.
- Uses the generic SME2 matmul API for tiled execution.
- Preserves `alpha`/`beta` semantics, including avoiding input reads when `alpha == 0` and avoiding C reads when `beta == 0`.
- Preserves unclamped infinity results.
- Removes the previous fixed SME2 SGEMM and GEMV registrations.
- Leaves the existing SME and Qualcomm QMX paths unchanged.

The change also adds focused SME2 SGEMM tests and keeps an existing QDQ optimizer test independent of architecture-specific KleidiAI reduction order.

### Motivation and Context

The fixed SME2 integration is tied directly to individual generated microkernel functions and their packing layouts. KleidiAI’s generic matmul API provides a cleaner interface for querying packing sizes, strides, offsets, tiling requirements, and kernel execution.

Moving the SME2 path to this interface:

- Reduces direct coupling to fixed generated-kernel symbols.
- Keeps packing and execution on a consistent `p4vsx1` contract.
- Supports scalable SME2 kernel dimensions through the generic API.
- Improves performance for several representative FP32 workloads.
- Allows the existing SME and QMX implementations to remain unchanged, keeping this PR narrowly scoped to SME2 FP32 SGEMM.

### Testing

The following tests were built and run on an Arm64 SME2-capable system:

- `SGemmPublicApi.*`: 5/5 passed.
- `SGemm_Packed_*.*:SGemm_NoPack_*.*`: 1,200/1,200 passed.
- `QDQTransformerTests.DQMatMulPerTensorWithBlockSizeOption`: passed.
- A non-KleidiAI build of `onnxruntime_mlas_test` completed successfully; the five SME2-specific tests were skipped as expected.
- Mixed packed/unpacked batches were tested in both RHS orientations.
- Mixed `alpha == 0` batches were tested with null A/B pointers to verify that the inputs are not accessed.

### Performance

The comparison below isolates the SGEMM implementation change: both Android Release builds use the same KleidiAI dependency version, with the baseline retaining the fixed SME2 path and the candidate using the generic SME2 path.

Negative deltas mean the generic SME2 path is faster.

| Model | Fixed (ms) | Generic SME2 (ms) | Generic vs fixed, 95% CI |
|---|---:|---:|---:|
| MobileNet V1 | 11.132 | 10.909 | -2.00% `[-2.07, -1.93]` |
| DeepLabV3 MobileNetV2 | 139.401 | 135.149 | -3.05% `[-3.54, -2.56]` |
| OpenPose V2 VGG19 | 376.821 | 375.540 | -0.34% `[-0.53, -0.15]` |
| MobileNet V1 SSD | 26.029 | 22.361 | -14.09% `[-14.26, -13.93]` |
| RetinaFace | 99.068 | 86.429 | -12.76% `[-12.91, -12.60]` |
| EfficientNet Lite V3 | 99.298 | 99.329 | +0.03% `[-0.04, +0.10]` |
| Image Transform Net | 556.836 | 557.519 | +0.12% `[-0.00, +0.25]` |
| RFDN | 27.308 | 27.175 | -0.49% `[-0.71, -0.27]` |
| BERT Tiny | 0.871 | 0.870 | -0.09% `[-1.04, +0.86]` |
| Transformer Complex | 7.428 | 7.386 | -0.57% `[-1.28, +0.14]` |

The largest improvements were measured for MobileNet V1 SSD and RetinaFace. Six models have confidence intervals entirely below zero, while no model shows a statistically significant regression.

#### Performance run details

- Device: Arm64 Android SME2 development platform.
- Execution provider: ORT CPU EP with KleidiAI explicitly enabled; XNNPACK was not used.
- Build type: Android Arm64 Release.
- Affinity: the benchmark process was pinned to CPU4 with `taskset 0x10`.
- Threads: one inference thread.