### PR TITLE
Add opt-in session option to release retained NodeProtos after initialization

### DIFF
--- a/include/onnxruntime/core/graph/graph.h
+++ b/include/onnxruntime/core/graph/graph.h
@@ -849,6 +849,27 @@ class Graph {  // NOLINT(clang-analyzer-optin.performance.Padding): preserve exi
   /** Removes all initializer tensors from this Graph and releases the memory they were using. */
   void CleanAllInitializedTensors() noexcept;
 
+  /**
+  Releases the NodeProto instances this Graph retained from the model it was built from, and does the
+  same for every subgraph.
+
+  Graph construction copies each NodeProto's attributes into the owning Node (see Graph::AddNode), so
+  once a session is initialized the retained protos are pure duplicates of state the Node instances
+  already own. For most models that duplication is negligible, because the bulk of the model lives in
+  initializers rather than attributes. It is not negligible for ai.onnx.ml tree ensembles, where the
+  whole model is node attributes: the retained copy is a second copy of the entire model, held for the
+  lifetime of the session and never read again.
+
+  Serialization keeps working: this method flags this Graph and every subgraph as needing a proto
+  sync, so Graph::ToGraphProto rebuilds the node list from the Node instances instead of handing back
+  what was released. What a caller gives up is the ability to resolve the Graph again: Graph::Resolve
+  validates each node with Node::ToProto(), which does not update subgraphs, so a control flow node
+  would reach the ONNX checker with an empty body. Any pointer previously handed out by
+  Node::GetOriginalNodeProto is also invalidated (this method clears those, and Graph::Resolve has
+  already done so).
+  */
+  void ReleaseNodeProtos();
+
   /** Returns true if an initializer value can be overridden by a graph input with the same name. */
   bool CanOverrideInitializer() const noexcept { return ir_version_ >= 4; }
 

--- a/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
+++ b/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
@@ -20,6 +20,18 @@
 // If the config value is set to "1" then the prepacking is disabled, otherwise prepacking is enabled (default value)
 static const char* const kOrtSessionOptionsConfigDisablePrepacking = "session.disable_prepacking";
 
+// Key for releasing the ONNX NodeProto instances the Graph retains from the loaded model.
+// Graph construction copies each NodeProto's attributes into the owning Node, so after initialization
+// the retained protos are duplicates that inference never reads. Releasing them is a large saving for
+// models whose payload lives in node attributes rather than initializers - an ai.onnx.ml tree ensemble
+// holds a second copy of the whole model otherwise - and a small one for everything else.
+// Saving the model still works afterwards - it is rebuilt from the graph as initialized rather than
+// returned as it was loaded - but the graph cannot be resolved again. Ignored when
+// optimized_model_filepath is set.
+// If the config value is set to "1" the protos are released, otherwise they are retained (default).
+static const char* const kOrtSessionOptionsConfigReleaseNodeProtosAfterInit =
+    "session.release_node_protos_after_init";
+
 // A value of "1" means allocators registered in the env will be used. "0" means the allocators created in the session
 // will be used. Use this to override the usage of env allocators on a per session level.
 static const char* const kOrtSessionOptionsConfigUseEnvAllocators = "session.use_env_allocators";

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -4542,6 +4542,29 @@ void Graph::CleanAllInitializedTensors() noexcept {
   ortvalue_initializers_.clear();
 }
 
+void Graph::ReleaseNodeProtos() {
+  for (auto& node : Nodes()) {
+#if !defined(ORT_MINIMAL_BUILD)
+    // Resolve() clears this after the first onnx::check_node, but do not rely on a particular Resolve
+    // having run: the pointers are about to dangle either way.
+    node.SetOriginalNodeProto(nullptr);
+#endif
+    for (const auto& entry : node.GetAttributeNameToMutableSubgraphMap()) {
+      entry.second->ReleaseNodeProtos();
+    }
+  }
+
+  // Clear() would only clear each NodeProto and keep it in the repeated field's cleared pool for
+  // reuse, holding on to every attribute buffer; on protobuf 5.26 and later there is no supported
+  // way to then release that pool. DeleteSubrange destroys the elements outright, which is what
+  // actually returns the memory, and it behaves the same on every protobuf version.
+  graph_proto_->mutable_node()->DeleteSubrange(0, graph_proto_->node_size());
+
+  // graph_proto_ no longer reflects this Graph, so ToGraphProto() must rebuild the node list from the
+  // Node instances rather than return what is now an empty one.
+  SetGraphProtoSyncNeeded();
+}
+
 const ONNX_NAMESPACE::TensorProto* Graph::GetConstantInitializer(const std::string& initializer_name,
                                                                  bool check_outer_scope) const {
   const ONNX_NAMESPACE::TensorProto* initializer = nullptr;

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -2880,6 +2880,17 @@ common::Status InferenceSession::Initialize() {
     // once the model is saved, we may remove unnecessary attributes for inference
     session_state_->PruneRemovableAttributes();
 
+    // The kernels own their data now, so the NodeProtos the Graph kept from the loaded model are
+    // duplicates that nothing reads again. Saving the model still works afterwards, since
+    // Graph::ToGraphProto rebuilds the node list from the Node instances, but a session asked for an
+    // optimized model has already written it above, so leave its graph exactly as that path left it.
+    if (session_options_.config_options.GetConfigOrDefault(
+            kOrtSessionOptionsConfigReleaseNodeProtosAfterInit, "0") == "1" &&
+        !saving_model) {
+      model_->MainGraph().ReleaseNodeProtos();
+      LOGS(*session_logger_, INFO) << "Released the retained NodeProtos of the main graph and its subgraphs.";
+    }
+
     // and log telemetry
     LogSessionCreationTelemetry(graph, model_weight_type, model_graph_hash, model_weight_hash);
 

--- a/onnxruntime/test/framework/inference_session_test.cc
+++ b/onnxruntime/test/framework/inference_session_test.cc
@@ -837,6 +837,105 @@ TEST(InferenceSessionTests, LoadInvalidGraphReturnsError) {
   ASSERT_THAT(status.ErrorMessage(), ::testing::HasSubstr("undefined_input"));
 }
 
+// Releasing the retained NodeProtos must not disturb inference: the Node instances own their own copy
+// of everything the kernels were built from, so the session behaves exactly as it does without the
+// option. Serializing the graph afterwards must still work too, since Graph::ToGraphProto rebuilds the
+// node list from those Node instances rather than from what was released.
+TEST(InferenceSessionTests, ReleaseNodeProtosAfterInit) {
+  SessionOptions so;
+  so.session_logid = "InferenceSessionTests.ReleaseNodeProtosAfterInit";
+  ASSERT_STATUS_OK(so.config_options.AddConfigEntry(kOrtSessionOptionsConfigReleaseNodeProtosAfterInit, "1"));
+
+  InferenceSessionWrapper session_object{so, GetEnvironment()};
+  ASSERT_STATUS_OK(session_object.Load(MODEL_URI));
+  ASSERT_STATUS_OK(session_object.Initialize());
+
+  RunOptions run_options;
+  run_options.run_tag = so.session_logid;
+  RunModel(session_object, run_options);
+
+  ASSERT_EQ(session_object.GetGraph().NumberOfNodes(), 1);
+
+  // Rebuilt from the Node instances, so the released protos are not missed.
+  ASSERT_EQ(session_object.GetMutableGraph().ToGraphProto().node_size(), 1);
+}
+
+// Same model, option off: the default must not change behaviour.
+TEST(InferenceSessionTests, ReleaseNodeProtosAfterInitDefaultsToOff) {
+  SessionOptions so;
+  so.session_logid = "InferenceSessionTests.ReleaseNodeProtosAfterInitDefaultsToOff";
+
+  InferenceSessionWrapper session_object{so, GetEnvironment()};
+  ASSERT_STATUS_OK(session_object.Load(MODEL_URI));
+  ASSERT_STATUS_OK(session_object.Initialize());
+
+  RunOptions run_options;
+  run_options.run_tag = so.session_logid;
+  RunModel(session_object, run_options);
+
+  ASSERT_EQ(session_object.GetGraph().NumberOfNodes(), 1);
+}
+
+// Control flow models are where the duplication actually lives, and where the release has the most to
+// get wrong: a subgraph body is held by the parent Node's own attributes, so releasing it empties an
+// attribute that Node still carries. Nothing reads that emptied attribute again - the If kernel runs
+// the subgraph Graph instance, and serialization rebuilds the body from it - but only because
+// ReleaseNodeProtos flags every subgraph as needing a proto sync as well as the main graph.
+TEST(InferenceSessionTests, ReleaseNodeProtosAfterInitWithSubgraphs) {
+  SessionOptions so;
+  so.session_logid = "InferenceSessionTests.ReleaseNodeProtosAfterInitWithSubgraphs";
+  ASSERT_STATUS_OK(so.config_options.AddConfigEntry(kOrtSessionOptionsConfigReleaseNodeProtosAfterInit, "1"));
+
+  InferenceSessionWrapper session_object{so, GetEnvironment()};
+  ASSERT_STATUS_OK(session_object.Load(ORT_TSTR("testdata/if_mul.onnx")));
+  ASSERT_STATUS_OK(session_object.Initialize());
+
+  // if_mul.onnx computes C = B * 2 when A is true, and the Mul that does it lives in the then_branch
+  // subgraph whose body was just released.
+  std::vector<int64_t> cond_dims = {1};
+  InlinedVector<bool> cond_value = {true};
+  OrtValue cond;
+  CreateMLValue<bool>(TestCPUExecutionProvider()->CreatePreferredAllocators()[0], cond_dims, cond_value, &cond);
+
+  std::vector<int64_t> data_dims = {3, 2};
+  std::vector<float> data_values = {2.0f, 3.0f, 4.0f, -5.0f, 6.0f, 7.0f};
+  OrtValue data;
+  CreateMLValue<float>(TestCPUExecutionProvider()->CreatePreferredAllocators()[0], data_dims, data_values, &data);
+
+  NameMLValMap feeds;
+  feeds.insert(std::make_pair("A", cond));
+  feeds.insert(std::make_pair("B", data));
+
+  std::vector<std::string> output_names{"C"};
+  std::vector<OrtValue> fetches;
+
+  RunOptions run_options;
+  run_options.run_tag = so.session_logid;
+  ASSERT_STATUS_OK(session_object.Run(run_options, feeds, output_names, &fetches));
+
+  std::vector<int64_t> expected_dims = {3, 2};
+  std::vector<float> expected_values = {4.0f, 6.0f, 8.0f, -10.0f, 12.0f, 14.0f};
+  VerifySingleOutput(fetches, expected_dims, expected_values);
+
+  // Both branch bodies come back, rebuilt from the subgraph Graph instances.
+  const ONNX_NAMESPACE::GraphProto& graph_proto = session_object.GetMutableGraph().ToGraphProto();
+  ASSERT_EQ(graph_proto.node_size(), 1);
+  ASSERT_EQ(graph_proto.node(0).op_type(), "If");
+
+  int then_branch_nodes = 0;
+  int else_branch_nodes = 0;
+  for (const auto& attribute : graph_proto.node(0).attribute()) {
+    if (attribute.name() == "then_branch") {
+      then_branch_nodes = attribute.g().node_size();
+    } else if (attribute.name() == "else_branch") {
+      else_branch_nodes = attribute.g().node_size();
+    }
+  }
+
+  EXPECT_EQ(then_branch_nodes, 1);
+  EXPECT_EQ(else_branch_nodes, 1);
+}
+
 TEST(InferenceSessionTests, CheckRunLogger) {
   if constexpr (!SessionOptions::DEFAULT_USE_PER_SESSION_THREADS) {
     GTEST_SKIP() << "Skipping the test";


### PR DESCRIPTION
### Description

Adds `session.release_node_protos_after_init` (`kOrtSessionOptionsConfigReleaseNodeProtosAfterInit`),
off by default. When set to "1", `InferenceSession::Initialize()` calls the new
`Graph::ReleaseNodeProtos()` after `PruneRemovableAttributes()`, dropping the `NodeProto` list the
`Graph` kept from the loaded model and recursing into subgraphs. Ignored when
`optimized_model_filepath` is set.

`Graph::AddNode` copies each `NodeProto`'s attributes into the owning `Node`, so after initialization
the retained protos duplicate state the `Node` instances already own and nothing reads them again.
`ReleaseNodeProtos()` also clears `Node::original_node_proto_` (already cleared by `Graph::Resolve`)
and flags the main graph and every subgraph as needing a proto sync, so `Graph::ToGraphProto()`
rebuilds the node list from the `Node` instances — serialization is unaffected. What it gives up is
resolving the graph again, since `Graph::Resolve` validates nodes with `Node::ToProto()` without
updating subgraphs.

The node list is dropped with `DeleteSubrange` rather than `Clear`: `Clear` only clears each
`NodeProto` and parks it in the repeated field's cleared pool, still holding every attribute buffer,
and protobuf 5.26 and later offer no supported way to release that pool. `DeleteSubrange` destroys the
elements, which is what actually returns the memory, and behaves the same on every protobuf version.

Tests: option on, option off (default), and a control-flow model (`if_mul.onnx`) that runs and then
round-trips both subgraph bodies through `ToGraphProto()`.

### Motivation and Context

Memory. For models whose payload lives in node attributes rather than initializers — ai.onnx.ml tree
ensembles above all — the retained protos are a second copy of the whole model, held for the lifetime
of the session.

Measured on a synthetic `TreeEnsembleRegressor` (8000 trees, 1,016,000 nodes, 37 MB on disk, no
initializers) with `onnxruntime_perf_test` on macOS arm64, protobuf 33.6: with the option on, the
session's live heap drops from 150.5 MiB to 43.5 MiB — 107 MiB and 1,016,041 allocations freed, the
allocation delta matching the model's node count.

Steady-state RSS is unchanged on macOS: the freed memory returns to the allocator, which retains the
pages. The freed bytes are dominated by the large repeated-attribute arrays plus ~1M small string
objects; on glibc the large arrays are above MMAP_THRESHOLD, so `free()` munmaps them and the saving
should appear as an RSS reduction. I verified that allocator behaviour on Debian 12 / glibc 2.36 by
reproducing the allocation pattern, but did not run ORT itself on Linux — treat the Linux RSS figure as
inferred, not measured.

Fixes #32047