### PR TITLE
[CUDA] Add FP16-cache paged XQA decode for head size 256

### DIFF
--- a/docs/contrib_ops/cuda/paged_attention.md
+++ b/docs/contrib_ops/cuda/paged_attention.md
@@ -392,9 +392,11 @@ which must now be sized by `batch_size * max_kv_len_bound` so that the allocatio
 >
 > Two narrow cases still take the readback, and only when the caller supplied **no** metadata at all:
 > a gather backend (MEA, or FlashAttention on a quantized cache), because with no bound the
-> capacity-based staging allocation would be a large over-allocation for a short prefill; and XQA,
-> whose one-output-row-per-batch-index layout needs *proof* of exactly one token per sequence rather
-> than the shape heuristic. Neither case can occur on a capturable step — a captured step is
+> capacity-based staging allocation would be a large over-allocation for a short prefill; and
+> quantized-cache XQA, whose one-output-row-per-batch-index layout needs *proof* of exactly one token
+> per sequence rather than the shape heuristic. Native FP16-cache XQA requires metadata and stays on
+> asynchronous Flash when it is absent and Flash is eligible; otherwise it uses the portable paged
+> decoder. Neither readback case can occur on a capturable step — a captured step is
 > decode-shaped over a paged cache, so no gather runs, and a producer that captures must supply
 > `attention_metadata` anyway, since replay-wide bounds are the only replay-safe host input. Both
 > cases are prefill-side, and prefill is never captured.
@@ -776,12 +778,16 @@ Mirror GQA: `onnxruntime_USE_FP8_KV_CACHE` (default ON), `onnxruntime_USE_INT4_K
 >   boundary and flip the stored code by one LSB.
 
 > **Paged decode kernels.** Quantized decode uses XQA directly on the paged cache when the query has
-> one token per sequence, `head_size ∈ {64, 128}`, `group_size ∈ {4, 6, 8, 16, 32}`, no softcap, and
-> a block size divisible by 128. The CUDA image selected at runtime must contain compatible XQA
-> device code generated for SM80 or newer; INT8 XQA requires an SM80-or-newer GPU and FP8 XQA
-> requires SM89 or SM90+. Setting `ORT_ENABLE_XQA=0` disables XQA. The operator also falls back when
-> the selected image has no XQA kernel or its dynamic shared-memory requirement exceeds the device
-> limit. Other supported configurations use `PagedDecodeSplitKV` and `PagedDecodeReduce` from
+> one token per sequence, `head_size ∈ {64, 128, 256}`, `group_size ∈ {4, 6, 8, 16, 32}`, no softcap,
+> and a block size divisible by 128. A native FP16-cache specialization additionally covers
+> `head_size = 256, group_size = 6`, the Qwen3.8 full-attention geometry, when
+> `attention_metadata` proves one-token-per-sequence decode without a host readback. The CUDA image
+> selected at runtime must contain compatible XQA device code generated for SM80 or newer; INT8 and
+> native FP16 XQA require an SM80-or-newer GPU and FP8 XQA requires SM89 or SM90+. Setting
+> `ORT_ENABLE_XQA=0` disables XQA. When Flash is eligible, the operator restores paged Flash
+> Attention for native FP16 cache when a ragged step is not one-token-per-sequence, the selected
+> image has no compatible XQA kernel, or its dynamic shared-memory requirement exceeds the device
+> limit. Other quantized configurations use `PagedDecodeSplitKV` and `PagedDecodeReduce` from
 > `paged_attention_impl.cu`.
 >
 > - **Both scale foldings are exact and granularity-agnostic.** K folds into Q at load time
@@ -801,9 +807,11 @@ Mirror GQA: `onnxruntime_USE_FP8_KV_CACHE` (default ON), `onnxruntime_USE_INT4_K
 > - Sliding window uses the token's own causal position `q_pos = kv_len - 1`, admitting
 >   `t ∈ [kv_len - local_window_size, kv_len)`, matching Flash's `window_size_left = local_window_size - 1`.
 > - **Backend gating.** The kernel is selected by the static shape test of §4.7
->   (`token_count <= batch_size`) when the cache is quantized *or* FlashAttention is unavailable;
->   unquantized FlashAttention-eligible shapes keep using FlashAttention. `sdpa_kernel = 512`
->   (`AttentionBackend::DECODER_ATTENTION`) forces it, which is how the unquantized path is tested.
+>   (`token_count <= batch_size`) when the cache is quantized, FlashAttention is unavailable, or
+>   the metadata-proven native FP16 H256/group-6 XQA specialization is eligible. Other unquantized
+>   FlashAttention-eligible shapes keep using FlashAttention. `sdpa_kernel = 512`
+>   (`AttentionBackend::DECODER_ATTENTION`) forces the portable paged-decode path, which is how that
+>   unquantized fallback is tested.
 >   The shape test is a heuristic: one CTA owns one **global query token**, resolves its sequence and
 >   in-sequence position from `cumulative_seqlens_q` on device, and masks against
 >   `past_seqlens[b] + q_index + 1`, so the kernel is correct for arbitrary ragged input (including
@@ -1281,15 +1289,18 @@ as GQA does, so that `ORT_ENABLE_ATTENTION_KERNEL_DEBUG_INFO=1` works uniformly 
 > `SdpaKernel=DECODER_ATTENTION`. Actual eligibility is broader than the table: any `head_size` whose
 > working set fits `sharedMemPerBlock` (roughly `2 * head_size + 256` floats plus 512 B, so every
 > head size the op supports on current hardware), any `block_size`, any GQA ratio, `softcap`, and
-> arbitrary ragged query lengths are all supported. It is only *preferred* over FlashAttention when
-> the cache is quantized or FlashAttention is ineligible, since Flash's tensor-core decode path is
-> faster on an unquantized cache. Priority 0 (MLA) is still unimplemented.
+> arbitrary ragged query lengths are all supported. It is preferred over FlashAttention when the
+> cache is quantized, FlashAttention is ineligible, or the native FP16 H256/group-6 XQA
+> specialization is metadata-proven eligible. Priority 0 (MLA) is still unimplemented.
 >
 > The gate is the static shape test of §4.7 (`token_count <= batch_size`), so no device-resident
 > length reaches the host and the D→H sync is gone. The XQA fast path inside this backend keeps a
-> stricter gate — it needs `token_count == batch_size` *and* `max_query_len == 1`, the latter from
-> `attention_metadata` or, failing that, from the readback — because its output layout is one row
-> per batch index rather than per query token.
+> stricter gate — it needs `token_count == batch_size` *and* `max_query_len == 1` because its output
+> layout is one row per batch index rather than per query token. Quantized-cache XQA may obtain the
+> latter from `attention_metadata` or, failing that, from the readback. Native FP16-cache XQA
+> requires metadata and otherwise remains on Flash when eligible or uses the portable paged
+> decoder. `ORT_DISABLE_DECODER_ATTENTION=1` disables both paged XQA and the portable paged-decode
+> backend.
 >
 > XQA uses fixed 128-token pages. When PagedAttention's `block_size` is 128, its native
 > `block_table` is already in XQA page units and is passed directly to the kernel: no page-table

--- a/onnxruntime/contrib_ops/cuda/bert/paged_attention.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/paged_attention.cc
@@ -432,11 +432,19 @@ Status PagedAttention<T, TCACHE>::ComputeInternal(OpKernelContext* context) cons
   // input. The inequality rather than equality matters for continuous batching, where a scheduled
   // sequence may contribute no token on a given step.
   // Prefer it only where it is a clear win: a quantized cache (it avoids materializing and
-  // dequantizing the whole live context) or when FlashAttention is unavailable (it beats the
-  // dense-gather MemoryEfficientAttention fallback).
+  // dequantizing the whole live context), a supported native-cache XQA specialization, or when
+  // FlashAttention is unavailable (it beats the dense-gather MemoryEfficientAttention fallback).
   const bool decode_shaped = parameters.token_count <= parameters.batch_size;
-  const bool use_paged_decode = decode_eligible && decode_shaped && (kIsQuantizedCache || !flash_eligible);
-  const bool use_flash_attention = flash_eligible && !use_paged_decode;
+  const int group_size = parameters.num_heads / parameters.kv_num_heads;
+  constexpr bool kIsFp16Cache =
+      std::is_same<T, MLFloat16>::value && std::is_same<TCACHE, MLFloat16>::value;
+  const bool fp16_xqa_eligible =
+      enable_xqa_ && has_metadata_bounds && kIsFp16Cache && device_prop.major >= 8 &&
+      parameters.softcap == 0.0f && parameters.head_size == 256 && group_size == 6 &&
+      (parameters.block_size % kXqaTokensPerPage) == 0;
+  bool use_paged_decode =
+      decode_eligible && decode_shaped && (kIsQuantizedCache || fp16_xqa_eligible || !flash_eligible);
+  bool use_flash_attention = flash_eligible && !use_paged_decode;
   const bool use_memory_efficient_attention = mea_eligible && !use_paged_decode;
 
   // Both gather-based backends need a dense KV staging buffer when the cache is quantized
@@ -446,19 +454,15 @@ Status PagedAttention<T, TCACHE>::ComputeInternal(OpKernelContext* context) cons
   // GQA-expanded for the CUTLASS kernel.
   const int gathered_num_heads = use_memory_efficient_attention ? parameters.num_heads : parameters.kv_num_heads;
 
-  // Within the decode-on-a-quantized-cache case, prefer XQA: it is the same tensor-core kernel
-  // GroupQueryAttention uses, reading the paged cache in place, and is roughly an order of
-  // magnitude faster than the portable PagedDecodeSplitKV kernel. Constraints come from the
-  // compiled instantiations (head_size, query/KV group size), from XQA itself (no softcap) and
-  // from the page remap (a PagedAttention block must split into whole 128-token XQA pages).
+  // Prefer XQA where a matching native or quantized cache specialization is compiled. It is the
+  // tensor-core kernel GroupQueryAttention uses and reads the paged cache in place.
   // XQA additionally lays its output out as one row per batch index, so unlike PagedDecodeSplitKV
   // it needs *proof* that every sequence contributes exactly one token, not just the shape
   // heuristic. token_count == batch_size rules out a sequence contributing none; max_query_len == 1,
   // from the metadata bound or from the readback below, then rules out any contributing two.
   bool xqa_candidate = false;
-  if (use_paged_decode && enable_xqa_ && kIsQuantizedCache &&
+  if (use_paged_decode && enable_xqa_ && (kIsQuantizedCache || fp16_xqa_eligible) &&
       parameters.token_count == parameters.batch_size) {
-    const int group_size = parameters.num_heads / parameters.kv_num_heads;
     const bool is_fp8_cache = IsFp8CacheType<TCACHE>();
     const auto is_supported_quant_type = [](KVQuantizationType t) {
       return t == KVQuantizationType::PER_TENSOR || t == KVQuantizationType::PER_CHANNEL;
@@ -469,10 +473,14 @@ Status PagedAttention<T, TCACHE>::ComputeInternal(OpKernelContext* context) cons
         (parameters.head_size == 64 || parameters.head_size == 128 || parameters.head_size == 256) &&
         (group_size == 4 || group_size == 6 || group_size == 8 || group_size == 16 || group_size == 32) &&
         (parameters.block_size % kXqaTokensPerPage) == 0 &&
-        is_supported_quant_type(k_quant_type_) && is_supported_quant_type(v_quant_type_) &&
+        (!kIsQuantizedCache ||
+         (is_supported_quant_type(k_quant_type_) && is_supported_quant_type(v_quant_type_))) &&
         // FP8 arithmetic in the XQA kernel needs Ada (sm_89) or Hopper+.
         (!is_fp8_cache || device_prop.major >= 9 || (device_prop.major == 8 && device_prop.minor == 9));
   }
+  const XqaQuantType xqa_kv_quant_type =
+      !kIsQuantizedCache ? XqaQuantType::kNone
+                         : (IsFp8CacheType<TCACHE>() ? XqaQuantType::kFp8 : XqaQuantType::kInt8);
 
   // Obtaining the exact lengths from the device means copying the two cumulative arrays back and
   // blocking the host until they land, which drains everything already queued on the compute
@@ -546,8 +554,7 @@ Status PagedAttention<T, TCACHE>::ComputeInternal(OpKernelContext* context) cons
       if (!onnxruntime::llm::common::isCapturing(cuda_stream)) {
         const size_t required_smem = GetXQAPagedRequiredSharedMemoryBytes(
             device_prop, parameters.head_size, parameters.num_heads, parameters.kv_num_heads,
-            IsFp8CacheType<TCACHE>() ? XqaQuantType::kFp8 : XqaQuantType::kInt8,
-            std::is_same<T, BFloat16>::value);
+            xqa_kv_quant_type, std::is_same<T, BFloat16>::value);
         // A zero result means the selected CUDA image has no compatible XQA symbol or the symbol
         // query failed. Either case must use the portable fallback rather than attempting a launch.
         xqa_smem_ok = (required_smem != 0 && required_smem <= device_prop.sharedMemPerBlockOptin) ? 1 : 0;
@@ -557,6 +564,14 @@ Status PagedAttention<T, TCACHE>::ComputeInternal(OpKernelContext* context) cons
       }
     }
     use_xqa_decode = (xqa_smem_ok != 0);
+  }
+  // Native-cache XQA promotion is speculative until the one-token-per-sequence and shared-memory
+  // checks pass. Restore Flash for ragged decode steps and unsupported devices instead of leaving
+  // them on the portable scalar paged-decode fallback. This is safe without dense KV staging
+  // because the native FP16 cache is already a Flash-supported dtype.
+  if (!use_xqa_decode && fp16_xqa_eligible && !kIsQuantizedCache && flash_eligible) {
+    use_paged_decode = false;
+    use_flash_attention = true;
   }
   DUMP_STRING("Backend = ", use_latent_attention  ? "latent"
                             : use_xqa_decode      ? "paged decode (XQA)"
@@ -667,8 +682,7 @@ Status PagedAttention<T, TCACHE>::ComputeInternal(OpKernelContext* context) cons
     xqa_workspace_bytes = GetXQAScratchSize(
         device_prop, parameters.batch_size, parameters.num_heads, parameters.kv_num_heads,
         parameters.head_size, xqa_max_pages_per_seq * kXqaTokensPerPage,
-        IsFp8CacheType<TCACHE>() ? XqaQuantType::kFp8 : XqaQuantType::kInt8,
-        std::is_same<T, BFloat16>::value);
+        xqa_kv_quant_type, std::is_same<T, BFloat16>::value);
     xqa_workspace_buffer = GetScratchBuffer<void>(xqa_workspace_bytes, GetComputeStream(context));
     if (xqa_page_table_expanded) {
       xqa_page_table_buffer = GetScratchBuffer<void>(

--- a/onnxruntime/contrib_ops/cuda/bert/paged_attention_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/paged_attention_impl.cu
@@ -1579,7 +1579,9 @@ Status PagedXqaDecodeAttention(
 #else
       false;
 #endif
-  const XqaQuantType kv_quant_type = kIsFp8Cache ? XqaQuantType::kFp8 : XqaQuantType::kInt8;
+  constexpr bool kIsInt8Cache = std::is_same<TCACHE, int8_t>::value;
+  const XqaQuantType kv_quant_type =
+      kIsFp8Cache ? XqaQuantType::kFp8 : (kIsInt8Cache ? XqaQuantType::kInt8 : XqaQuantType::kNone);
   ORT_RETURN_IF_ERROR(LaunchXQAPagedKernel(
       device_prop, stream,
       reinterpret_cast<const void*>(query),

--- a/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_paged_fp16_fp16_256.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_paged_fp16_fp16_256.cu
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// XQA paged-KV decode kernel: FP16 query/output and FP16 KV cache, head_size=256.
+
+#define HEAD_ELEMS 256
+#define HEAD_DIM_NAMESPACE H256
+#define XQA_PAGED_CACHE_ELEM 0  // FP16 KV cache
+#define XQA_PAGED_INPUT_FP16 1  // FP16 query/output
+#define XQA_PAGED_QUERY_T half
+#define XQA_PAGED_FAMILY fp16_fp16
+#define XQA_PAGED_LAUNCH_FN LaunchXQAPagedFp16Kernel
+#define XQA_PAGED_GROUP6_ONLY
+
+#include "xqa_paged_loader_impl.cuh"
+
+#undef XQA_PAGED_GROUP6_ONLY

--- a/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_paged_loader.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_paged_loader.cu
@@ -63,6 +63,7 @@ XQA_PAGED_DECL(LaunchXQAPagedFp8KernelBF16);
 }  // namespace H128
 
 namespace H256 {
+XQA_PAGED_DECL(LaunchXQAPagedFp16Kernel);
 XQA_PAGED_DECL(LaunchXQAPagedInt8Kernel);
 XQA_PAGED_DECL(LaunchXQAPagedInt8KernelBF16);
 #ifdef USE_FP8_KV_CACHE
@@ -98,7 +99,15 @@ Status LaunchXQAPagedKernel(
     return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "XQA is only supported on Ampere (SM80) or newer GPUs.");
   }
 
-  if (kv_quant_type == XqaQuantType::kInt8) {
+  if (kv_quant_type == XqaQuantType::kNone) {
+    if (head_size == 256 && !is_bf16) {
+      return H256::LaunchXQAPagedFp16Kernel(XQA_PAGED_ARGS);
+    }
+    return ORT_MAKE_STATUS(
+        ONNXRUNTIME, FAIL,
+        "Native-cache paged XQA only supports FP16 query/output with head_size 256. Input has ",
+        is_bf16 ? "BF16" : "FP16", " query/output and head_size ", head_size);
+  } else if (kv_quant_type == XqaQuantType::kInt8) {
     if (head_size == 64) {
       return is_bf16 ? H64::LaunchXQAPagedInt8KernelBF16(XQA_PAGED_ARGS)
                      : H64::LaunchXQAPagedInt8Kernel(XQA_PAGED_ARGS);
@@ -125,9 +134,7 @@ Status LaunchXQAPagedKernel(
     return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Paged XQA was built without FP8 KV cache support.");
 #endif
   } else {
-    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
-                           "Paged XQA is only compiled for INT8/FP8 KV caches; the FP16/BF16 cache "
-                           "uses the FlashAttention paged path.");
+    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Paged XQA does not support the requested KV cache type.");
   }
 
   return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
@@ -146,7 +153,11 @@ size_t GetXQAPagedRequiredSharedMemoryBytes(
   }
   // FP16 and BF16 kernels have identical shared-memory footprints (both 2-byte elements), so the
   // FP16 instantiation is queried for both.
-  if (kv_quant_type == XqaQuantType::kInt8) {
+  if (kv_quant_type == XqaQuantType::kNone) {
+    if (head_size == 256 && !is_bf16) {
+      return H256::LaunchXQAPagedFp16Kernel_SmemSize(num_heads, kv_num_heads);
+    }
+  } else if (kv_quant_type == XqaQuantType::kInt8) {
     if (head_size == 64) {
       return H64::LaunchXQAPagedInt8Kernel_SmemSize(num_heads, kv_num_heads);
     } else if (head_size == 128) {

--- a/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_paged_loader.h
+++ b/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_paged_loader.h
@@ -27,7 +27,8 @@ constexpr int kXqaTokensPerPage = 128;
 // K and V from a shared block pool addressed through a page table.
 //
 // Preconditions: one query token per sequence, head_size in {64, 128, 256}, group_size in
-// {4, 6, 8, 16, 32}, quantized (INT8/FP8) cache, block_size % kXqaTokensPerPage == 0.
+// {4, 6, 8, 16, 32}, supported FP16/INT8/FP8 cache, block_size % kXqaTokensPerPage == 0.
+// PagedAttention currently routes native FP16 cache only for head_size=256 and group_size=6.
 Status LaunchXQAPagedKernel(
     const cudaDeviceProp& device_prop,
     cudaStream_t stream,

--- a/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_paged_loader_impl.cuh
+++ b/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_paged_loader_impl.cuh
@@ -8,7 +8,7 @@
 // Expected macros:
 //   HEAD_ELEMS            head size (64 / 128 / 256)
 //   HEAD_DIM_NAMESPACE    namespace for the head size (H64 / H128 / H256)
-//   XQA_PAGED_CACHE_ELEM  1 = INT8 KV cache, 2 = FP8 KV cache
+//   XQA_PAGED_CACHE_ELEM  0 = FP16/BF16 KV cache, 1 = INT8 KV cache, 2 = FP8 KV cache
 //   XQA_PAGED_INPUT_FP16  1 = FP16 query/output, 0 = BF16
 //   XQA_PAGED_QUERY_T     query element type (half / __nv_bfloat16)
 //   XQA_PAGED_FAMILY      token used to make the per-TU namespaces unique (e.g. fp16_int8)
@@ -78,6 +78,7 @@ namespace contrib {
 namespace cuda {
 namespace HEAD_DIM_NAMESPACE {
 
+#if !defined(XQA_PAGED_GROUP6_ONLY)
 #define NAMESPACE_NAME XQA_PAGED_NS(grp4_)
 #define GRP_SIZE 4
 #define M_TILESIZE 8
@@ -85,6 +86,7 @@ namespace HEAD_DIM_NAMESPACE {
 #undef NAMESPACE_NAME
 #undef GRP_SIZE
 #undef M_TILESIZE
+#endif
 
 #define NAMESPACE_NAME XQA_PAGED_NS(grp6_)
 #define GRP_SIZE 6
@@ -94,6 +96,7 @@ namespace HEAD_DIM_NAMESPACE {
 #undef GRP_SIZE
 #undef M_TILESIZE
 
+#if !defined(XQA_PAGED_GROUP6_ONLY)
 #define NAMESPACE_NAME XQA_PAGED_NS(grp8_)
 #define GRP_SIZE 8
 #define M_TILESIZE 8
@@ -117,6 +120,7 @@ namespace HEAD_DIM_NAMESPACE {
 #undef NAMESPACE_NAME
 #undef GRP_SIZE
 #undef M_TILESIZE
+#endif
 
 #define XQA_PAGED_DISPATCH(grp)                                                                      \
   return XQA_PAGED_NS(grp)::Launch<XQA_PAGED_QUERY_T>(                                               \
@@ -147,19 +151,28 @@ Status XQA_PAGED_LAUNCH_FN(
     size_t workspace_size) {
   const int group_size = num_heads / kv_num_heads;
   switch (group_size) {
+#if !defined(XQA_PAGED_GROUP6_ONLY)
     case 4:
       XQA_PAGED_DISPATCH(grp4_);
+#endif
     case 6:
       XQA_PAGED_DISPATCH(grp6_);
+#if !defined(XQA_PAGED_GROUP6_ONLY)
     case 8:
       XQA_PAGED_DISPATCH(grp8_);
     case 16:
       XQA_PAGED_DISPATCH(grp16_);
     case 32:
       XQA_PAGED_DISPATCH(grp32_);
+#endif
     default:
+#if defined(XQA_PAGED_GROUP6_ONLY)
+      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
+                             "This paged XQA specialization only supports group_size 6. Input has ", group_size);
+#else
       return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
                              "Paged XQA only supports group_size 4, 6, 8, 16, 32. Input has ", group_size);
+#endif
   }
 }
 
@@ -168,16 +181,20 @@ Status XQA_PAGED_LAUNCH_FN(
 size_t XQA_PAGED_CAT(XQA_PAGED_LAUNCH_FN, _, SmemSize)(const int num_heads, const int kv_num_heads) {
   const int group_size = num_heads / kv_num_heads;
   switch (group_size) {
+#if !defined(XQA_PAGED_GROUP6_ONLY)
     case 4:
       return XQA_PAGED_NS(grp4_)::GetSmemSize();
+#endif
     case 6:
       return XQA_PAGED_NS(grp6_)::GetSmemSize();
+#if !defined(XQA_PAGED_GROUP6_ONLY)
     case 8:
       return XQA_PAGED_NS(grp8_)::GetSmemSize();
     case 16:
       return XQA_PAGED_NS(grp16_)::GetSmemSize();
     case 32:
       return XQA_PAGED_NS(grp32_)::GetSmemSize();
+#endif
     default:
       return 0;
   }

--- a/onnxruntime/test/contrib_ops/paged_attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/paged_attention_op_test.cc
@@ -999,6 +999,169 @@ INSTANTIATE_TEST_SUITE_P(
       return info.param.name;
     });
 
+bool IsNativeFp16HeadSize256Group6XqaRunnable() {
+  IoBindingCase c;
+  c.num_heads = 6;
+  c.kv_num_heads = 1;
+  c.head_size = 256;
+  c.num_blocks = 2;
+  c.max_num_blocks_per_seq = 1;
+  c.past_seqlen = 122;
+  c.attention_metadata = {1, 128, 128};
+
+  testing::internal::CaptureStdout();
+  RunIoBindingCase(DefaultCudaExecutionProvider(), kCudaExecutionProvider, true, false, c);
+  const std::string debug_output = testing::internal::GetCapturedStdout();
+  return debug_output.find("SdpaKernel=XQA") != std::string::npos;
+}
+
+TEST(PagedAttention, Cuda_XqaNativeFp16CacheHeadSize256Group6) {
+  ScopedEnvironmentVariables scoped_env_vars{
+      EnvVarMap{
+          {onnxruntime::contrib::attention::kDisableFlashAttention, "0"},
+          {onnxruntime::contrib::attention::kDisableMemoryEfficientAttention, "0"},
+          {onnxruntime::contrib::attention::kDisableDecoderAttention, "0"},
+          {onnxruntime::contrib::attention::kEnableAttentionKernelDebugInfo, "1"},
+          {"ORT_ENABLE_XQA", "1"}}};
+
+  if (DefaultCudaExecutionProvider() == nullptr) {
+    GTEST_SKIP() << "CUDA EP not available.";
+  }
+  if (GetCudaArchitecture() < 800) {
+    GTEST_SKIP() << "XQA requires compute capability 8.0 or later.";
+  }
+  if (!IsNativeFp16HeadSize256Group6XqaRunnable()) {
+    GTEST_SKIP() << "Native FP16 paged XQA H256/group6 is not runnable in this build/device configuration.";
+  }
+
+  OrtCUDAProviderOptionsV2 provider_options{};
+  provider_options.do_copy_in_default_stream = true;
+  provider_options.use_tf32 = false;
+  provider_options.enable_cuda_graph = true;
+
+  IoBindingCase c;
+  c.batch_size = 2;
+  c.num_heads = 6;
+  c.kv_num_heads = 1;
+  c.head_size = 256;
+  c.num_blocks = 32;
+  c.max_num_blocks_per_seq = 8;
+  c.past_seqlen = 2047;
+  c.enable_cuda_graph = true;
+  c.irregular_layout = true;
+  c.discriminating_attention = true;
+  c.replay_past_seqlens = {{1024, 1536}, {1536, 2047}, {2047, 1024}};
+  c.block_table = {7, 2, 11, 4, 15, 0, 9, 6,
+                   23, 18, 27, 20, 31, 16, 25, 22};
+  c.attention_metadata = {1, 2048, 1025};
+
+  testing::internal::CaptureStdout();
+  RunIoBindingCase(CudaExecutionProviderWithOptions(&provider_options),
+                   kCudaExecutionProvider, true, false, c);
+  const std::string debug_output = testing::internal::GetCapturedStdout();
+
+  const std::string xqa_backend = "SdpaKernel=XQA";
+  const size_t first_xqa = debug_output.find(xqa_backend);
+  const size_t second_xqa =
+      first_xqa == std::string::npos ? std::string::npos : debug_output.find(xqa_backend, first_xqa + 1);
+  EXPECT_NE(first_xqa, std::string::npos) << debug_output;
+  EXPECT_NE(second_xqa, std::string::npos) << debug_output;
+  EXPECT_NE(debug_output.find("GqaGroupSize=6"), std::string::npos) << debug_output;
+}
+
+TEST(PagedAttention, Cuda_XqaNativeFp16CacheSplitReduction) {
+  ScopedEnvironmentVariables scoped_env_vars{
+      EnvVarMap{
+          {onnxruntime::contrib::attention::kDisableFlashAttention, "0"},
+          {onnxruntime::contrib::attention::kDisableMemoryEfficientAttention, "0"},
+          {onnxruntime::contrib::attention::kDisableDecoderAttention, "0"},
+          {onnxruntime::contrib::attention::kEnableAttentionKernelDebugInfo, "1"},
+          {"ORT_ENABLE_XQA", "1"}}};
+
+  if (DefaultCudaExecutionProvider() == nullptr) {
+    GTEST_SKIP() << "CUDA EP not available.";
+  }
+  if (GetCudaArchitecture() < 800) {
+    GTEST_SKIP() << "XQA requires compute capability 8.0 or later.";
+  }
+  if (!IsNativeFp16HeadSize256Group6XqaRunnable()) {
+    GTEST_SKIP() << "Native FP16 paged XQA H256/group6 is not runnable in this build/device configuration.";
+  }
+
+  IoBindingCase c;
+  c.num_heads = 6;
+  c.kv_num_heads = 1;
+  c.head_size = 256;
+  c.num_blocks = 16;
+  c.max_num_blocks_per_seq = 8;
+  c.past_seqlen = 2047;
+  c.split_sensitive_values = true;
+  c.attention_metadata = {1, 2048, 2048};
+
+  testing::internal::CaptureStdout();
+  RunIoBindingCase(DefaultCudaExecutionProvider(), kCudaExecutionProvider, true, false, c);
+  const std::string debug_output = testing::internal::GetCapturedStdout();
+  EXPECT_NE(debug_output.find("SdpaKernel=XQA"), std::string::npos) << debug_output;
+}
+
+TEST(PagedAttention, Cuda_XqaNativeFp16CacheFallsBackWithoutMetadata) {
+  ScopedEnvironmentVariables scoped_env_vars{
+      EnvVarMap{
+          {onnxruntime::contrib::attention::kDisableFlashAttention, "0"},
+          {onnxruntime::contrib::attention::kDisableMemoryEfficientAttention, "0"},
+          {onnxruntime::contrib::attention::kDisableDecoderAttention, "0"},
+          {onnxruntime::contrib::attention::kEnableAttentionKernelDebugInfo, "1"}}};
+
+  if (DefaultCudaExecutionProvider() == nullptr) {
+    GTEST_SKIP() << "CUDA EP not available.";
+  }
+  IoBindingCase c;
+  c.num_heads = 6;
+  c.kv_num_heads = 1;
+  c.head_size = 256;
+  c.num_blocks = 16;
+  c.max_num_blocks_per_seq = 8;
+  c.past_seqlen = 2047;
+
+  testing::internal::CaptureStdout();
+  RunIoBindingCase(DefaultCudaExecutionProvider(), kCudaExecutionProvider, true, false, c);
+  const std::string debug_output = testing::internal::GetCapturedStdout();
+  EXPECT_EQ(debug_output.find("SdpaKernel=XQA"), std::string::npos) << debug_output;
+  EXPECT_TRUE(debug_output.find("SdpaKernel=FLASH_ATTENTION") != std::string::npos ||
+              debug_output.find("SdpaKernel=DECODER_ATTENTION") != std::string::npos)
+      << debug_output;
+}
+
+TEST(PagedAttention, Cuda_XqaNativeFp16CacheMultiTokenBoundFallsBack) {
+  ScopedEnvironmentVariables scoped_env_vars{
+      EnvVarMap{
+          {onnxruntime::contrib::attention::kDisableFlashAttention, "0"},
+          {onnxruntime::contrib::attention::kDisableMemoryEfficientAttention, "0"},
+          {onnxruntime::contrib::attention::kDisableDecoderAttention, "0"},
+          {onnxruntime::contrib::attention::kEnableAttentionKernelDebugInfo, "1"}}};
+
+  if (DefaultCudaExecutionProvider() == nullptr) {
+    GTEST_SKIP() << "CUDA EP not available.";
+  }
+  IoBindingCase c;
+  c.batch_size = 2;
+  c.num_heads = 6;
+  c.kv_num_heads = 1;
+  c.head_size = 256;
+  c.num_blocks = 32;
+  c.max_num_blocks_per_seq = 8;
+  c.past_seqlen = 2047;
+  c.attention_metadata = {2, 2048, 2048};
+
+  testing::internal::CaptureStdout();
+  RunIoBindingCase(DefaultCudaExecutionProvider(), kCudaExecutionProvider, true, false, c);
+  const std::string debug_output = testing::internal::GetCapturedStdout();
+  EXPECT_EQ(debug_output.find("SdpaKernel=XQA"), std::string::npos) << debug_output;
+  EXPECT_TRUE(debug_output.find("SdpaKernel=FLASH_ATTENTION") != std::string::npos ||
+              debug_output.find("SdpaKernel=DECODER_ATTENTION") != std::string::npos)
+      << debug_output;
+}
+
 TEST(PagedAttention, Cuda_AttentionMetadataValidation) {
   if (DefaultCudaExecutionProvider() == nullptr) {
     GTEST_SKIP() << "CUDA EP not available.";


### PR DESCRIPTION
Extend the paged-KV XQA decode path to consume a native FP16 KV cache for the `head_size=256`, group-size-6 geometry used by Qwen3.8 full-attention layers.

- Add an FP16 query/output + FP16 paged-KV H256 XQA instantiation.
- Select it only for metadata-backed one-token-per-sequence decode on SM80+.
- Reuse the existing 128-token XQA page mapping for PagedAttention block sizes divisible by 128.
- Preserve paged Flash Attention for prefill, ragged/multi-token decode, metadata-free callers, unsupported devices, disabled XQA, BF16, and other geometries.
- Keep the runtime dynamic shared-memory fit check authoritative.
- Add CPU-reference numerical coverage and verify XQA dispatch for the Qwen group-size-6 shape.

On an A100-SXM4-80GB with Qwen3.8 27B, the native FP16 XQA kernel reduces B1 x 64K attention time from 0.764 ms to 0.176 ms per full-attention layer per token. End-to-end eager decode improves from 32.9 to 47.5 tok/s (+44%); stable CUDA graphs reach 52.6 tok/s. The 128-token 64K output matches the existing FP16 Flash path token-for-token.

| Batch / context | FP16 Flash | FP16 XQA | Gain |
|---|---:|---:|---:|
| B1 x 64K, eager | 32.9 tok/s | 47.5 tok/s | +44% |
| B8 x 8K, eager | 143.5 | 171.3 | +19% |
| B8 x 32K, eager | 86.3 | 144.3 | +67% |
| B8 x 64K, eager | 43.2 | 77.7 | +80% |