### PR TITLE
test(tensorscatter): cover circular prefix preservation

### DIFF
--- a/onnxruntime/test/providers/cpu/llm/tensorscatter_op_test.cc
+++ b/onnxruntime/test/providers/cpu/llm/tensorscatter_op_test.cc
@@ -194,6 +194,32 @@ TEST(TensorScatterTest, Circular_WrapAround) {
   test.Run();
 }
 
+// Regression test for circular-mode wrapping semantics clarified by onnx/onnx#8353.
+// Sequence positions wrap from 3 to 0, while batch 5 > max sequence 4 detects an
+// incorrect full-tuple modulo that would also wrap the batch coordinate.
+TEST(TensorScatterTest, Circular_BatchLargerThanMaxSequenceLength) {
+  OpTester test("TensorScatter", 24);
+  test.AddAttribute<std::string>("mode", "circular");
+
+  // shape (5, 4, 1), default axis=-2 -> axis=1, max_seq=4, batch=5
+  test.AddInput<float>("past_cache", {5, 4, 1}, std::vector<float>(20, -1.0f));
+
+  // Two distinct values per batch exercise the 3 -> 0 sequence wrap.
+  test.AddInput<float>("update", {5, 2, 1}, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
+
+  test.AddInput<int64_t>("write_indices", {5}, {3, 3, 3, 3, 3});
+
+  // Each batch preserves its prefix coordinate and writes only slots 3 and 0.
+  test.AddOutput<float>("present_cache", {5, 4, 1},
+                        {2, -1, -1, 1,
+                         4, -1, -1, 3,
+                         6, -1, -1, 5,
+                         8, -1, -1, 7,
+                         10, -1, -1, 9});
+
+  test.Run();
+}
+
 // IO-binding test: bind the same buffer as both input[0] (past_cache) and
 // output[0] (present_cache) to verify the MayInplace(0,0) in-place path.
 TEST(TensorScatterTest, InPlace_IOBinding) {


### PR DESCRIPTION
### Description

Adds a `TensorScatter` circular-mode regression test where the batch dimension exceeds the maximum sequence length. The case also wraps sequence writes from slot 3 to slot 0, verifying that modulo applies only to the sequence coordinate while every batch prefix remains unchanged.

### Motivation and Context

onnx/onnx#8353 identified that applying modulo to every coordinate in the full index tuple can fold one batch into another. ONNX Runtime's CPU and CUDA kernels already preserve prefix coordinates, but the existing tests use prefix dimensions smaller than the maximum sequence length and cannot distinguish the incorrect behavior.

This test makes the regression observable: with `batch_size=5` and `max_sequence_length=4`, a full-tuple modulo maps batch 4 to batch 0.

Related: onnx/onnx#8353

### Testing

- `cmake --build build/cpu_only/Debug --target onnxruntime_provider_test --parallel`
- `./onnxruntime_provider_test --gtest_filter=TensorScatterTest.Circular_BatchLargerThanMaxSequenceLength`
- `./onnxruntime_provider_test --gtest_filter=TensorScatterTest.*` (23 passed)
- `lintrunner onnxruntime/test/providers/cpu/llm/tensorscatter_op_test.cc`