### PR TITLE
Add stable EPContext data callbacks to QNN

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/onnx_ctx_model_helper.cc
+++ b/onnxruntime/core/providers/qnn/builder/onnx_ctx_model_helper.cc
@@ -7,7 +7,6 @@
 #include <fstream>
 #include <filesystem>
 
-#include "core/framework/error_code_helper.h"
 #include "core/providers/qnn/ort_api.h"
 #include "core/providers/qnn/builder/qnn_utils.h"
 #include "core/providers/qnn/builder/qnn_model.h"
@@ -15,6 +14,20 @@
 
 namespace onnxruntime {
 namespace qnn {
+namespace {
+
+Status ConvertAndReleaseCallbackStatus(OrtStatus* status) {
+  Ort::Status callback_status{status};
+  if (callback_status.IsOK()) {
+    return Status::OK();
+  }
+
+  return Status(common::StatusCategory::ONNXRUNTIME,
+                static_cast<int>(callback_status.GetErrorCode()),
+                callback_status.GetErrorMessage());
+}
+
+}  // namespace
 
 bool GraphHasEpContextNode(const onnxruntime::GraphViewer& graph_viewer) {
   // It's an Onnx model with Qnn context cache binary if it has a node with EPContext type
@@ -88,7 +101,7 @@ Status GetEpContextFromMainNode(const onnxruntime::Node& main_context_node,
                                 QnnBackendManager* qnn_backend_manager,
                                 QnnModelLookupTable& qnn_models,
                                 int64_t max_spill_fill_size,
-                                const epctx::EpContextDataCallbacks& callbacks) {
+                                const EpContextDataCallbacks& callbacks) {
   ORT_RETURN_IF_NOT(EPCONTEXT_OP == main_context_node.OpType(), "Should only filter in the EPContext node.");
   NodeAttrHelper node_helper(main_context_node);
   bool is_embed_mode = node_helper.Get(EMBED_MODE, true);
@@ -116,8 +129,9 @@ Status GetEpContextFromMainNode(const onnxruntime::Node& main_context_node,
                                                      allocator,
                                                      &context_buffer,
                                                      &context_buffer_size);
-    std::unique_ptr<void, Ort::AllocatedFree> context_buffer_guard{context_buffer, Ort::AllocatedFree{allocator}};
-    ORT_RETURN_IF_ERROR(ToStatusAndRelease(callback_status));
+    std::unique_ptr<void, Ort::detail::AllocatedFree> context_buffer_guard{
+        context_buffer, Ort::detail::AllocatedFree{allocator}};
+    ORT_RETURN_IF_ERROR(ConvertAndReleaseCallbackStatus(callback_status));
     if (context_buffer_size > callbacks.read_max_data_size) {
       return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
                              "QNN EPContext read callback exceeded the configured maximum size.");
@@ -217,7 +231,7 @@ Status LoadQnnCtxFromOnnxGraph(const onnxruntime::GraphViewer& graph_viewer,
                                QnnModelLookupTable& qnn_models,
                                const logging::Logger& logger,
                                int64_t max_spill_fill_size,
-                               const epctx::EpContextDataCallbacks& callbacks) {
+                               const EpContextDataCallbacks& callbacks) {
   ORT_RETURN_IF(graph_viewer.NumberOfNodes() != 1, "One filtered graph should has only one EPContext node!");
   Status status = GetEpContextFromMainNode(*graph_viewer.Nodes().begin(), ctx_onnx_model_path, qnn_backend_manager,
                                            qnn_models, max_spill_fill_size, callbacks);
@@ -243,7 +257,7 @@ Status CreateEPContextNodes(Model* model,
                             const logging::Logger& logger,
                             bool share_ep_contexts,
                             bool stop_share_ep_contexts,
-                            const epctx::EpContextDataCallbacks& callbacks) {
+                            const EpContextDataCallbacks& callbacks) {
   auto& graph = model->MainGraph();
 
   using namespace ONNX_NAMESPACE;
@@ -310,10 +324,10 @@ Status CreateEPContextNodes(Model* model,
         // 2. share_ep_context enabled, only write for the last session which has stop_share_ep_contexts enabled
         if (!share_ep_contexts || (share_ep_contexts && stop_share_ep_contexts)) {
           if (callbacks.write_func != nullptr) {
-            ORT_RETURN_IF_ERROR(ToStatusAndRelease(callbacks.write_func(callbacks.write_state,
-                                                                        context_cache_name.c_str(),
-                                                                        buffer,
-                                                                        SafeInt<size_t>(buffer_size))));
+            ORT_RETURN_IF_ERROR(ConvertAndReleaseCallbackStatus(callbacks.write_func(callbacks.write_state,
+                                                                                     context_cache_name.c_str(),
+                                                                                     buffer,
+                                                                                     SafeInt<size_t>(buffer_size))));
           } else {
             std::ofstream of_stream(context_bin_path.c_str(), std::ofstream::binary);
             if (!of_stream) {

--- a/onnxruntime/core/providers/qnn/builder/onnx_ctx_model_helper.cc
+++ b/onnxruntime/core/providers/qnn/builder/onnx_ctx_model_helper.cc
@@ -7,6 +7,7 @@
 #include <fstream>
 #include <filesystem>
 
+#include "core/framework/error_code_helper.h"
 #include "core/providers/qnn/ort_api.h"
 #include "core/providers/qnn/builder/qnn_utils.h"
 #include "core/providers/qnn/builder/qnn_model.h"
@@ -86,7 +87,8 @@ Status GetEpContextFromMainNode(const onnxruntime::Node& main_context_node,
                                 const onnxruntime::PathString& ctx_onnx_model_path,
                                 QnnBackendManager* qnn_backend_manager,
                                 QnnModelLookupTable& qnn_models,
-                                int64_t max_spill_fill_size) {
+                                int64_t max_spill_fill_size,
+                                const epctx::EpContextDataCallbacks& callbacks) {
   ORT_RETURN_IF_NOT(EPCONTEXT_OP == main_context_node.OpType(), "Should only filter in the EPContext node.");
   NodeAttrHelper node_helper(main_context_node);
   bool is_embed_mode = node_helper.Get(EMBED_MODE, true);
@@ -104,6 +106,35 @@ Status GetEpContextFromMainNode(const onnxruntime::Node& main_context_node,
   std::filesystem::path folder_path = std::filesystem::path(ctx_onnx_model_path).parent_path();
   std::string external_qnn_ctx_binary_file_name = node_helper.Get(EP_CACHE_CONTEXT, "");
   ORT_RETURN_IF(external_qnn_ctx_binary_file_name.empty(), "The file path in ep_cache_context should not be empty.");
+
+  if (callbacks.read_func != nullptr) {
+    Ort::AllocatorWithDefaultOptions allocator;
+    void* context_buffer = nullptr;
+    size_t context_buffer_size = 0;
+    OrtStatus* callback_status = callbacks.read_func(callbacks.read_state,
+                                                     external_qnn_ctx_binary_file_name.c_str(),
+                                                     allocator,
+                                                     &context_buffer,
+                                                     &context_buffer_size);
+    std::unique_ptr<void, Ort::AllocatedFree> context_buffer_guard{context_buffer, Ort::AllocatedFree{allocator}};
+    ORT_RETURN_IF_ERROR(ToStatusAndRelease(callback_status));
+    if (context_buffer_size > callbacks.read_max_data_size) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                             "QNN EPContext read callback exceeded the configured maximum size.");
+    }
+    if (context_buffer_size == 0) {
+      return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                             "QNN EPContext read callback returned an empty payload.");
+    }
+    ORT_RETURN_IF(context_buffer == nullptr && context_buffer_size != 0,
+                  "EPContext read callback returned a null buffer for non-empty QNN context data.");
+    return qnn_backend_manager->LoadCachedQnnContextFromBuffer(static_cast<char*>(context_buffer),
+                                                               static_cast<uint64_t>(context_buffer_size),
+                                                               "",
+                                                               main_context_node.Name(),
+                                                               qnn_models,
+                                                               max_spill_fill_size);
+  }
 
   // Validate that the cache path does not escape the model directory.
   // Rejects absolute paths, ".." traversal, and symlink-based escapes.
@@ -185,10 +216,11 @@ Status LoadQnnCtxFromOnnxGraph(const onnxruntime::GraphViewer& graph_viewer,
                                QnnBackendManager* qnn_backend_manager,
                                QnnModelLookupTable& qnn_models,
                                const logging::Logger& logger,
-                               int64_t max_spill_fill_size) {
+                               int64_t max_spill_fill_size,
+                               const epctx::EpContextDataCallbacks& callbacks) {
   ORT_RETURN_IF(graph_viewer.NumberOfNodes() != 1, "One filtered graph should has only one EPContext node!");
   Status status = GetEpContextFromMainNode(*graph_viewer.Nodes().begin(), ctx_onnx_model_path, qnn_backend_manager,
-                                           qnn_models, max_spill_fill_size);
+                                           qnn_models, max_spill_fill_size, callbacks);
 
   // This is the protocol with customer that status with INVALID_GRAPH will be generated if failed to load context model
   if (!status.IsOK()) {
@@ -210,7 +242,8 @@ Status CreateEPContextNodes(Model* model,
                             uint64_t max_spill_fill_buffer_size,
                             const logging::Logger& logger,
                             bool share_ep_contexts,
-                            bool stop_share_ep_contexts) {
+                            bool stop_share_ep_contexts,
+                            const epctx::EpContextDataCallbacks& callbacks) {
   auto& graph = model->MainGraph();
 
   using namespace ONNX_NAMESPACE;
@@ -276,12 +309,19 @@ Status CreateEPContextNodes(Model* model,
         // Write the ctx.bin file for the case: 1. no share_ep_context enabled, write for every session
         // 2. share_ep_context enabled, only write for the last session which has stop_share_ep_contexts enabled
         if (!share_ep_contexts || (share_ep_contexts && stop_share_ep_contexts)) {
-          std::ofstream of_stream(context_bin_path.c_str(), std::ofstream::binary);
-          if (!of_stream) {
-            LOGS(logger, ERROR) << "Failed to open create context file.";
-            return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Failed to open context cache file.");
+          if (callbacks.write_func != nullptr) {
+            ORT_RETURN_IF_ERROR(ToStatusAndRelease(callbacks.write_func(callbacks.write_state,
+                                                                        context_cache_name.c_str(),
+                                                                        buffer,
+                                                                        SafeInt<size_t>(buffer_size))));
+          } else {
+            std::ofstream of_stream(context_bin_path.c_str(), std::ofstream::binary);
+            if (!of_stream) {
+              LOGS(logger, ERROR) << "Failed to open create context file.";
+              return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Failed to open context cache file.");
+            }
+            of_stream.write(reinterpret_cast<char*>(buffer), buffer_size);
           }
-          of_stream.write(reinterpret_cast<char*>(buffer), buffer_size);
         }
 
         ep_node.AddAttribute(EP_CACHE_CONTEXT, context_cache_name);

--- a/onnxruntime/core/providers/qnn/builder/onnx_ctx_model_helper.h
+++ b/onnxruntime/core/providers/qnn/builder/onnx_ctx_model_helper.h
@@ -42,7 +42,8 @@ Status GetEpContextFromMainNode(const onnxruntime::Node& main_context_node,
                                 const onnxruntime::PathString& ctx_onnx_model_path,
                                 QnnBackendManager* qnn_backend_manager,
                                 QnnModelLookupTable& qnn_models,
-                                int64_t max_spill_fill_size);
+                                int64_t max_spill_fill_size,
+                                const epctx::EpContextDataCallbacks& callbacks);
 
 Status TryGetMaxSpillFillSize(const std::vector<IExecutionProvider::FusedNodeAndGraph>& fused_nodes_and_graphs,
                               uint32_t total_context_size,
@@ -54,7 +55,8 @@ Status LoadQnnCtxFromOnnxGraph(const onnxruntime::GraphViewer& graph_viewer,
                                QnnBackendManager* qnn_backend_manager,
                                QnnModelLookupTable& qnn_models,
                                const logging::Logger& logger,
-                               int64_t max_spill_fill_size);
+                               int64_t max_spill_fill_size,
+                               const epctx::EpContextDataCallbacks& callbacks);
 
 Status CreateEPContextNodes(Model* model,
                             unsigned char* buffer,
@@ -67,6 +69,7 @@ Status CreateEPContextNodes(Model* model,
                             uint64_t max_spill_fill_buffer_size,
                             const logging::Logger& logger,
                             bool share_ep_contexts,
-                            bool stop_share_ep_contexts);
+                            bool stop_share_ep_contexts,
+                            const epctx::EpContextDataCallbacks& callbacks);
 }  // namespace qnn
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/onnx_ctx_model_helper.h
+++ b/onnxruntime/core/providers/qnn/builder/onnx_ctx_model_helper.h
@@ -43,7 +43,7 @@ Status GetEpContextFromMainNode(const onnxruntime::Node& main_context_node,
                                 QnnBackendManager* qnn_backend_manager,
                                 QnnModelLookupTable& qnn_models,
                                 int64_t max_spill_fill_size,
-                                const epctx::EpContextDataCallbacks& callbacks);
+                                const EpContextDataCallbacks& callbacks);
 
 Status TryGetMaxSpillFillSize(const std::vector<IExecutionProvider::FusedNodeAndGraph>& fused_nodes_and_graphs,
                               uint32_t total_context_size,
@@ -56,7 +56,7 @@ Status LoadQnnCtxFromOnnxGraph(const onnxruntime::GraphViewer& graph_viewer,
                                QnnModelLookupTable& qnn_models,
                                const logging::Logger& logger,
                                int64_t max_spill_fill_size,
-                               const epctx::EpContextDataCallbacks& callbacks);
+                               const EpContextDataCallbacks& callbacks);
 
 Status CreateEPContextNodes(Model* model,
                             unsigned char* buffer,
@@ -70,6 +70,6 @@ Status CreateEPContextNodes(Model* model,
                             const logging::Logger& logger,
                             bool share_ep_contexts,
                             bool stop_share_ep_contexts,
-                            const epctx::EpContextDataCallbacks& callbacks);
+                            const EpContextDataCallbacks& callbacks);
 }  // namespace qnn
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/ort_api.h
+++ b/onnxruntime/core/providers/qnn/ort_api.h
@@ -56,10 +56,23 @@
 #include "core/session/onnxruntime_session_options_config_keys.h"
 #include "core/session/onnxruntime_run_options_config_keys.h"
 
+#include <limits>
 #include <memory>
 #include <vector>
 
 namespace onnxruntime {
+namespace qnn {
+
+struct EpContextDataCallbacks {
+  OrtReadNamedBufferFunc read_func = nullptr;
+  void* read_state = nullptr;
+  size_t read_max_data_size = std::numeric_limits<size_t>::max();
+  OrtWriteNamedBufferFunc write_func = nullptr;
+  void* write_state = nullptr;
+};
+
+}  // namespace qnn
+
 #if BUILD_QNN_EP_STATIC_LIB
 using Node_EdgeEnd = Node::EdgeEnd;
 #endif

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -300,7 +300,7 @@ static std::unique_ptr<qnn::QnnSerializerConfig> ParseSerializerBackendOptions(c
 
 QNNExecutionProvider::QNNExecutionProvider(const ProviderOptions& provider_options_map,
                                            const ConfigOptions* config_options,
-                                           epctx::EpContextDataCallbacks ep_context_data_callbacks)
+                                           qnn::EpContextDataCallbacks ep_context_data_callbacks)
     : IExecutionProvider{onnxruntime::kQnnExecutionProvider},
       ep_context_data_callbacks_{ep_context_data_callbacks} {
   InitOrtCppApi();

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -299,8 +299,10 @@ static std::unique_ptr<qnn::QnnSerializerConfig> ParseSerializerBackendOptions(c
 }
 
 QNNExecutionProvider::QNNExecutionProvider(const ProviderOptions& provider_options_map,
-                                           const ConfigOptions* config_options)
-    : IExecutionProvider{onnxruntime::kQnnExecutionProvider} {
+                                           const ConfigOptions* config_options,
+                                           epctx::EpContextDataCallbacks ep_context_data_callbacks)
+    : IExecutionProvider{onnxruntime::kQnnExecutionProvider},
+      ep_context_data_callbacks_{ep_context_data_callbacks} {
   InitOrtCppApi();
   metadef_id_generator_ = Factory<ModelMetadefIdGenerator>::Create();
 
@@ -554,6 +556,13 @@ QNNExecutionProvider::QNNExecutionProvider(const ProviderOptions& provider_optio
   if (qnn_context_embed_mode_ && enable_vtcm_backup_buffer_sharing_) {
     LOGS_DEFAULT(ERROR) << "[EP context generation:] VTCM backup buffer sharing enabled conflict with EP context embed mode. Inference will not work as expected!";
   }
+
+  const bool has_ep_context_data_callback = ep_context_data_callbacks_.read_func != nullptr ||
+                                            ep_context_data_callbacks_.write_func != nullptr;
+  ORT_ENFORCE(!(has_ep_context_data_callback && share_ep_contexts_),
+              "QNN shared EP contexts do not support EPContext data callbacks.");
+  ORT_ENFORCE(!(has_ep_context_data_callback && enable_vtcm_backup_buffer_sharing_),
+              "QNN VTCM backup buffer sharing does not support EPContext data callbacks.");
 
   // Add this option because this feature requires QnnSystem lib and it's no supported for Windows x86_64 platform
   enable_spill_fill_buffer_ = ParseBoolOption("enable_htp_spill_fill_buffer", false, provider_options_map);
@@ -996,7 +1005,14 @@ QNNExecutionProvider::GetCapability(const onnxruntime::GraphViewer& graph_viewer
   }
 
   std::unordered_map<std::string, std::unique_ptr<std::vector<std::string>>> context_bin_map;
-  if (enable_vtcm_backup_buffer_sharing_ || enable_file_mapped_weights_) {
+  const bool callback_backed_context = is_qnn_ctx_model && ep_context_data_callbacks_.read_func != nullptr;
+  const bool effective_vtcm_backup_buffer_sharing = enable_vtcm_backup_buffer_sharing_ && !callback_backed_context;
+  const bool effective_file_mapped_weights = enable_file_mapped_weights_ && !callback_backed_context;
+  if (callback_backed_context && (enable_vtcm_backup_buffer_sharing_ || enable_file_mapped_weights_)) {
+    LOGS(logger, VERBOSE) << "Disabling path-based QNN EPContext loading optimizations because a read callback is set.";
+  }
+
+  if (effective_vtcm_backup_buffer_sharing || effective_file_mapped_weights) {
     std::unordered_set<const Node*> ep_ctx_nodes;
     GetMainEPCtxNodes(graph_viewer, ep_ctx_nodes, logger);
 
@@ -1034,8 +1050,8 @@ QNNExecutionProvider::GetCapability(const onnxruntime::GraphViewer& graph_viewer
   auto rt = qnn_backend_manager_->SetupBackend(logger, is_qnn_ctx_model,
                                                context_cache_enabled_ && enable_spill_fill_buffer_,
                                                share_ep_contexts_,
-                                               enable_vtcm_backup_buffer_sharing_,
-                                               enable_file_mapped_weights_,
+                                               effective_vtcm_backup_buffer_sharing,
+                                               effective_file_mapped_weights,
                                                rpcmem_library_,
                                                context_bin_map,
                                                enable_htp_extended_udma_mode_);
@@ -1365,7 +1381,8 @@ Status QNNExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& fused
                                                        qnn_backend_manager_.get(),
                                                        qnn_models,
                                                        logger,
-                                                       max_spill_fill_size));
+                                                       max_spill_fill_size,
+                                                       ep_context_data_callbacks_));
     }
 
     for (auto fused_node_and_graph : fused_nodes_and_graphs) {
@@ -1427,7 +1444,8 @@ Status QNNExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& fused
                                                   max_spill_fill_buffer_size,
                                                   logger,
                                                   share_ep_contexts_,
-                                                  stop_share_ep_contexts_));
+                                                  stop_share_ep_contexts_,
+                                                  ep_context_data_callbacks_));
 
     if (share_ep_contexts_ && !stop_share_ep_contexts_ &&
         nullptr == SharedContext::GetInstance().GetSharedQnnBackendManager()) {

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.h
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.h
@@ -9,7 +9,6 @@
 #include <unordered_map>
 #include <vector>
 
-#include "core/framework/ep_context_options.h"
 #include "core/providers/qnn/ort_api.h"
 #include "core/providers/qnn/builder/qnn_backend_manager.h"
 #include "core/providers/qnn/builder/qnn_def.h"
@@ -24,7 +23,7 @@ namespace onnxruntime {
 class QNNExecutionProvider : public IExecutionProvider {
  public:
   explicit QNNExecutionProvider(const ProviderOptions& provider_options_map, const ConfigOptions* config_options,
-                                epctx::EpContextDataCallbacks ep_context_data_callbacks = {});
+                                qnn::EpContextDataCallbacks ep_context_data_callbacks = {});
   virtual ~QNNExecutionProvider();
   ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(QNNExecutionProvider);
 
@@ -114,7 +113,7 @@ class QNNExecutionProvider : public IExecutionProvider {
   std::string context_node_name_prefix_ = "";
   bool disable_cpu_ep_fallback_ = false;  // True if CPU EP fallback has been disabled for this session.
   bool qnn_context_embed_mode_ = true;
-  epctx::EpContextDataCallbacks ep_context_data_callbacks_{};
+  qnn::EpContextDataCallbacks ep_context_data_callbacks_{};
   int32_t vtcm_size_in_mb_ = 0;
   bool enable_vtcm_backup_buffer_sharing_ = false;
   std::unique_ptr<onnxruntime::Model> qnn_ep_context_model_;

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.h
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.h
@@ -9,6 +9,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "core/framework/ep_context_options.h"
 #include "core/providers/qnn/ort_api.h"
 #include "core/providers/qnn/builder/qnn_backend_manager.h"
 #include "core/providers/qnn/builder/qnn_def.h"
@@ -22,7 +23,8 @@ namespace onnxruntime {
 // Logical device representation.
 class QNNExecutionProvider : public IExecutionProvider {
  public:
-  explicit QNNExecutionProvider(const ProviderOptions& provider_options_map, const ConfigOptions* config_options);
+  explicit QNNExecutionProvider(const ProviderOptions& provider_options_map, const ConfigOptions* config_options,
+                                epctx::EpContextDataCallbacks ep_context_data_callbacks = {});
   virtual ~QNNExecutionProvider();
   ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(QNNExecutionProvider);
 
@@ -49,6 +51,11 @@ class QNNExecutionProvider : public IExecutionProvider {
                                                    DataLayout target_data_layout) const override;
 
   const InlinedVector<const Node*> GetEpContextNodes() const override;
+
+  Status GetEpContextDataSupport(uint32_t& supported_flags) const override {
+    supported_flags = OrtEpContextDataSupportFlags_READ | OrtEpContextDataSupportFlags_WRITE;
+    return Status::OK();
+  }
 
   Status OnRunStart(const onnxruntime::RunOptions& run_options) override;
 
@@ -107,6 +114,7 @@ class QNNExecutionProvider : public IExecutionProvider {
   std::string context_node_name_prefix_ = "";
   bool disable_cpu_ep_fallback_ = false;  // True if CPU EP fallback has been disabled for this session.
   bool qnn_context_embed_mode_ = true;
+  epctx::EpContextDataCallbacks ep_context_data_callbacks_{};
   int32_t vtcm_size_in_mb_ = 0;
   bool enable_vtcm_backup_buffer_sharing_ = false;
   std::unique_ptr<onnxruntime::Model> qnn_ep_context_model_;

--- a/onnxruntime/core/providers/qnn/qnn_provider_factory.cc
+++ b/onnxruntime/core/providers/qnn/qnn_provider_factory.cc
@@ -51,7 +51,7 @@ struct QNNProviderFactory : IExecutionProviderFactory {
       }
     }
 
-    epctx::EpContextDataCallbacks ep_context_data_callbacks;
+    qnn::EpContextDataCallbacks ep_context_data_callbacks;
     session_options.GetEpContextDataCallbacks(&ep_context_data_callbacks.read_func,
                                               &ep_context_data_callbacks.read_state,
                                               &ep_context_data_callbacks.read_max_data_size,

--- a/onnxruntime/core/providers/qnn/qnn_provider_factory.cc
+++ b/onnxruntime/core/providers/qnn/qnn_provider_factory.cc
@@ -51,7 +51,14 @@ struct QNNProviderFactory : IExecutionProviderFactory {
       }
     }
 
-    auto qnn_ep = std::make_unique<QNNExecutionProvider>(provider_options, &config_options);
+    epctx::EpContextDataCallbacks ep_context_data_callbacks;
+    session_options.GetEpContextDataCallbacks(&ep_context_data_callbacks.read_func,
+                                              &ep_context_data_callbacks.read_state,
+                                              &ep_context_data_callbacks.read_max_data_size,
+                                              &ep_context_data_callbacks.write_func,
+                                              &ep_context_data_callbacks.write_state);
+    auto qnn_ep = std::make_unique<QNNExecutionProvider>(provider_options, &config_options,
+                                                         ep_context_data_callbacks);
     qnn_ep->SetLogger(reinterpret_cast<const logging::Logger*>(&session_logger));
     return qnn_ep;
   }

--- a/onnxruntime/test/providers/qnn/qnn_ep_context_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_ep_context_test.cc
@@ -39,6 +39,7 @@ struct QnnEpContextCallbackState {
   bool fail_write = false;
   bool fail_read = false;
   bool return_empty = false;
+  bool return_null_buffer = false;
   std::string write_name;
   std::string read_name;
   std::vector<char> payload;
@@ -79,6 +80,9 @@ static OrtStatus* ORT_API_CALL LoadQnnEpContextData(void* state, const char* nam
     return nullptr;
   }
   *buffer_size = callback_state.payload.size();
+  if (callback_state.return_null_buffer) {
+    return nullptr;
+  }
   if (callback_state.payload.empty()) {
     return nullptr;
   }
@@ -627,7 +631,7 @@ TEST_F(QnnHTPBackendTests, CompileApi_FromSessionOptions_InputAndOutputModelsInB
       FAIL() << "Expected oversized QNN EPContext callback payload rejection";
     } catch (const Ort::Exception& ex) {
       oversized_error = ex.what();
-      EXPECT_EQ(ex.GetOrtErrorCode(), ORT_INVALID_ARGUMENT);
+      EXPECT_EQ(ex.GetOrtErrorCode(), ORT_INVALID_GRAPH);
     }
     EXPECT_TRUE(callback_state.read_called);
     EXPECT_EQ(callback_state.read_count, 1u);
@@ -646,7 +650,7 @@ TEST_F(QnnHTPBackendTests, CompileApi_FromSessionOptions_InputAndOutputModelsInB
       FAIL() << "Expected empty QNN EPContext callback payload rejection";
     } catch (const Ort::Exception& ex) {
       empty_error = ex.what();
-      EXPECT_EQ(ex.GetOrtErrorCode(), ORT_INVALID_ARGUMENT);
+      EXPECT_EQ(ex.GetOrtErrorCode(), ORT_INVALID_GRAPH);
     }
     EXPECT_TRUE(callback_state.read_called);
     EXPECT_EQ(callback_state.read_count, 2u);
@@ -655,6 +659,23 @@ TEST_F(QnnHTPBackendTests, CompileApi_FromSessionOptions_InputAndOutputModelsInB
 
     callback_state.return_empty = false;
     callback_state.read_called = false;
+    callback_state.return_null_buffer = true;
+    std::string null_buffer_error;
+    try {
+      Ort::Session session(*ort_env, output_model_buffer, output_model_buffer_size, session_options);
+      FAIL() << "Expected null QNN EPContext callback buffer rejection";
+    } catch (const Ort::Exception& ex) {
+      null_buffer_error = ex.what();
+      EXPECT_EQ(ex.GetOrtErrorCode(), ORT_INVALID_GRAPH);
+    }
+    EXPECT_TRUE(callback_state.read_called);
+    EXPECT_EQ(callback_state.read_count, 3u);
+    EXPECT_THAT(null_buffer_error,
+                testing::HasSubstr("EPContext read callback returned a null buffer for non-empty QNN context data"));
+    EXPECT_FALSE(std::filesystem::exists(target_dir + bin_file_name));
+
+    callback_state.return_null_buffer = false;
+    callback_state.read_called = false;
     callback_state.fail_read = true;
     std::string read_error;
     try {
@@ -662,9 +683,10 @@ TEST_F(QnnHTPBackendTests, CompileApi_FromSessionOptions_InputAndOutputModelsInB
       FAIL() << "Expected QNN EPContext read callback failure";
     } catch (const Ort::Exception& ex) {
       read_error = ex.what();
+      EXPECT_EQ(ex.GetOrtErrorCode(), ORT_INVALID_GRAPH);
     }
     EXPECT_TRUE(callback_state.read_called);
-    EXPECT_EQ(callback_state.read_count, 3u);
+    EXPECT_EQ(callback_state.read_count, 4u);
     EXPECT_THAT(read_error, testing::HasSubstr("synthetic QNN EPContext read callback failure"));
     EXPECT_FALSE(std::filesystem::exists(target_dir + bin_file_name));
 
@@ -674,7 +696,7 @@ TEST_F(QnnHTPBackendTests, CompileApi_FromSessionOptions_InputAndOutputModelsInB
     EXPECT_NO_THROW((Ort::Session(*ort_env, output_model_buffer, output_model_buffer_size, session_options)));
 
     EXPECT_TRUE(callback_state.read_called);
-    EXPECT_EQ(callback_state.read_count, 4u);
+    EXPECT_EQ(callback_state.read_count, 5u);
     EXPECT_EQ(callback_state.read_name, callback_state.write_name);
     EXPECT_FALSE(std::filesystem::exists(target_dir + bin_file_name));
     allocator.Free(output_model_buffer);

--- a/onnxruntime/test/providers/qnn/qnn_ep_context_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_ep_context_test.cc
@@ -2,7 +2,9 @@
 // Licensed under the MIT License.
 
 #include <filesystem>
+#include <algorithm>
 #include <string>
+#include <vector>
 
 #include "core/session/onnxruntime_cxx_api.h"
 #include "core/session/onnxruntime_session_options_config_keys.h"
@@ -26,6 +28,67 @@ namespace onnxruntime {
 namespace test {
 
 #if defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
+
+constexpr size_t kQnnEpContextTestMaxDataSize = size_t{1} << 30;
+
+struct QnnEpContextCallbackState {
+  bool write_called = false;
+  bool read_called = false;
+  size_t write_count = 0;
+  size_t read_count = 0;
+  bool fail_write = false;
+  bool fail_read = false;
+  bool return_empty = false;
+  std::string write_name;
+  std::string read_name;
+  std::vector<char> payload;
+};
+
+static OrtStatus* ORT_API_CALL StoreQnnEpContextData(void* state, const char* name, const void* buffer,
+                                                     size_t buffer_size) {
+  auto& callback_state = *static_cast<QnnEpContextCallbackState*>(state);
+  callback_state.write_called = true;
+  ++callback_state.write_count;
+  callback_state.write_name = name;
+  if (callback_state.fail_write) {
+    return Ort::GetApi().CreateStatus(ORT_FAIL, "synthetic QNN EPContext write callback failure");
+  }
+  callback_state.payload.clear();
+  if (buffer_size != 0) {
+    if (buffer == nullptr) {
+      return Ort::GetApi().CreateStatus(ORT_INVALID_ARGUMENT,
+                                        "QNN EPContext write callback received a null non-empty payload");
+    }
+    callback_state.payload.assign(static_cast<const char*>(buffer), static_cast<const char*>(buffer) + buffer_size);
+  }
+  return nullptr;
+}
+
+static OrtStatus* ORT_API_CALL LoadQnnEpContextData(void* state, const char* name, OrtAllocator* allocator,
+                                                    void** buffer, size_t* buffer_size) {
+  auto& callback_state = *static_cast<QnnEpContextCallbackState*>(state);
+  callback_state.read_called = true;
+  ++callback_state.read_count;
+  callback_state.read_name = name;
+  *buffer = nullptr;
+  *buffer_size = 0;
+  if (callback_state.fail_read) {
+    return Ort::GetApi().CreateStatus(ORT_FAIL, "synthetic QNN EPContext read callback failure");
+  }
+  if (callback_state.return_empty) {
+    return nullptr;
+  }
+  *buffer_size = callback_state.payload.size();
+  if (callback_state.payload.empty()) {
+    return nullptr;
+  }
+
+  OrtStatus* status = Ort::GetApi().AllocatorAlloc(allocator, callback_state.payload.size(), buffer);
+  if (status == nullptr) {
+    std::copy(callback_state.payload.begin(), callback_state.payload.end(), static_cast<char*>(*buffer));
+  }
+  return status;
+}
 
 static int64_t GetNodeAttr(const Node& node, const std::string& attr_name, int64_t default_val) {
   const auto& attributes = node.GetAttributes();
@@ -482,6 +545,9 @@ TEST_F(QnnHTPBackendTests, CompileApi_FromSessionOptions_InputAndOutputModelsInB
 
   // Test embed mode enabled.
   {
+    QnnEpContextCallbackState callback_state;
+    session_options.SetEpContextDataReadFunc(LoadQnnEpContextData, &callback_state,
+                                             kQnnEpContextTestMaxDataSize);
     void* output_model_buffer = nullptr;
     size_t output_model_buffer_size = 0;
 
@@ -505,8 +571,10 @@ TEST_F(QnnHTPBackendTests, CompileApi_FromSessionOptions_InputAndOutputModelsInB
 
     // Should be able to create a session with the compiled model and the original session options.
     EXPECT_NO_THROW((Ort::Session(*ort_env, output_model_buffer, output_model_buffer_size, session_options)));
+    EXPECT_EQ(callback_state.read_count, 0u);
 
     allocator.Free(output_model_buffer);
+    session_options.ClearEpContextDataReadFunc();
   }
 
   // Test embed mode disabled.
@@ -522,9 +590,13 @@ TEST_F(QnnHTPBackendTests, CompileApi_FromSessionOptions_InputAndOutputModelsInB
     std::string model_name = "test_model_in_mem.onnx";
     auto pos = model_name.rfind(".onnx");
     std::string bin_file_name = model_name.substr(0, pos) + "_qnn.bin";
+    std::filesystem::remove(target_dir + bin_file_name);
     compile_options.SetEpContextBinaryInformation(ToWideString(target_dir).c_str(), ToWideString(model_name).c_str());
     compile_options.SetEpContextEmbedMode(false);
     compile_options.SetGraphOptimizationLevel(ORT_ENABLE_BASIC);
+
+    QnnEpContextCallbackState callback_state;
+    compile_options.SetEpContextDataWriteFunc(StoreQnnEpContextData, &callback_state);
 
     // Compile the model.
     Ort::Status status = Ort::CompileModel(*ort_env, compile_options);
@@ -534,7 +606,11 @@ TEST_F(QnnHTPBackendTests, CompileApi_FromSessionOptions_InputAndOutputModelsInB
     ASSERT_TRUE(output_model_buffer != nullptr);
     ASSERT_TRUE(output_model_buffer_size > 0);
 
-    ASSERT_TRUE(std::filesystem::exists(target_dir + bin_file_name)) << "expected context binary file should exist";
+    ASSERT_TRUE(callback_state.write_called);
+    ASSERT_EQ(callback_state.write_count, 1u);
+    ASSERT_EQ(callback_state.write_name, bin_file_name);
+    ASSERT_FALSE(callback_state.payload.empty());
+    ASSERT_FALSE(std::filesystem::exists(target_dir + bin_file_name));
 
     // Check that the compiled model has the expected number of EPContext nodes.
     CheckEpContextNodeCounts(output_model_buffer, output_model_buffer_size, 2, 2);
@@ -542,11 +618,154 @@ TEST_F(QnnHTPBackendTests, CompileApi_FromSessionOptions_InputAndOutputModelsInB
     // Add session option "ep.context_file_path" so that the session can use it to locate the [model_name]_qnn.bin file
     std::string ctx_model = target_dir + model_name;
     session_options.AddConfigEntry(kOrtSessionOptionEpContextFilePath, ctx_model.c_str());
+    session_options.SetEpContextDataReadFunc(LoadQnnEpContextData, &callback_state,
+                                             callback_state.payload.size() - 1);
+
+    std::string oversized_error;
+    try {
+      Ort::Session session(*ort_env, output_model_buffer, output_model_buffer_size, session_options);
+      FAIL() << "Expected oversized QNN EPContext callback payload rejection";
+    } catch (const Ort::Exception& ex) {
+      oversized_error = ex.what();
+      EXPECT_EQ(ex.GetOrtErrorCode(), ORT_INVALID_ARGUMENT);
+    }
+    EXPECT_TRUE(callback_state.read_called);
+    EXPECT_EQ(callback_state.read_count, 1u);
+    EXPECT_THAT(oversized_error,
+                testing::HasSubstr("QNN EPContext read callback exceeded the configured maximum size"));
+    EXPECT_FALSE(std::filesystem::exists(target_dir + bin_file_name));
+
+    callback_state.read_called = false;
+    session_options.SetEpContextDataReadFunc(LoadQnnEpContextData, &callback_state,
+                                             kQnnEpContextTestMaxDataSize);
+
+    callback_state.return_empty = true;
+    std::string empty_error;
+    try {
+      Ort::Session session(*ort_env, output_model_buffer, output_model_buffer_size, session_options);
+      FAIL() << "Expected empty QNN EPContext callback payload rejection";
+    } catch (const Ort::Exception& ex) {
+      empty_error = ex.what();
+      EXPECT_EQ(ex.GetOrtErrorCode(), ORT_INVALID_ARGUMENT);
+    }
+    EXPECT_TRUE(callback_state.read_called);
+    EXPECT_EQ(callback_state.read_count, 2u);
+    EXPECT_THAT(empty_error, testing::HasSubstr("QNN EPContext read callback returned an empty payload"));
+    EXPECT_FALSE(std::filesystem::exists(target_dir + bin_file_name));
+
+    callback_state.return_empty = false;
+    callback_state.read_called = false;
+    callback_state.fail_read = true;
+    std::string read_error;
+    try {
+      Ort::Session session(*ort_env, output_model_buffer, output_model_buffer_size, session_options);
+      FAIL() << "Expected QNN EPContext read callback failure";
+    } catch (const Ort::Exception& ex) {
+      read_error = ex.what();
+    }
+    EXPECT_TRUE(callback_state.read_called);
+    EXPECT_EQ(callback_state.read_count, 3u);
+    EXPECT_THAT(read_error, testing::HasSubstr("synthetic QNN EPContext read callback failure"));
+    EXPECT_FALSE(std::filesystem::exists(target_dir + bin_file_name));
+
+    callback_state.fail_read = false;
+    callback_state.read_called = false;
     // Should be able to create a session with the compiled model and the original session options.
     EXPECT_NO_THROW((Ort::Session(*ort_env, output_model_buffer, output_model_buffer_size, session_options)));
 
-    std::filesystem::remove(target_dir + bin_file_name);
+    EXPECT_TRUE(callback_state.read_called);
+    EXPECT_EQ(callback_state.read_count, 4u);
+    EXPECT_EQ(callback_state.read_name, callback_state.write_name);
+    EXPECT_FALSE(std::filesystem::exists(target_dir + bin_file_name));
     allocator.Free(output_model_buffer);
+  }
+}
+
+TEST_F(QnnHTPBackendTests, CompileApi_EpContextWriteCallbackErrorDoesNotFallbackToDisk) {
+  TestModel test_model;
+  CreateTestModel(BuildGraphWithQAndNonQ(false), 21, logging::Severity::kERROR, test_model);
+  const std::string model_data = test_model.Serialize();
+
+  Ort::SessionOptions session_options;
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+  session_options.AppendExecutionProvider("QNN", provider_options);
+
+  Ort::ModelCompilationOptions compile_options(*ort_env, session_options);
+  compile_options.SetInputModelFromBuffer(model_data.data(), model_data.size());
+  compile_options.SetEpContextEmbedMode(false);
+  compile_options.SetGraphOptimizationLevel(ORT_ENABLE_BASIC);
+
+  Ort::AllocatorWithDefaultOptions allocator;
+  void* output_model_buffer = nullptr;
+  size_t output_model_buffer_size = 0;
+  compile_options.SetOutputModelBuffer(allocator, &output_model_buffer, &output_model_buffer_size);
+
+  const std::string target_dir = "./testdata/";
+  const std::string model_name = "test_model_callback_error.onnx";
+  const std::string bin_file_name = "test_model_callback_error_qnn.bin";
+  std::filesystem::remove(target_dir + bin_file_name);
+  compile_options.SetEpContextBinaryInformation(ToWideString(target_dir).c_str(),
+                                                ToWideString(model_name).c_str());
+
+  QnnEpContextCallbackState callback_state;
+  callback_state.fail_write = true;
+  compile_options.SetEpContextDataWriteFunc(StoreQnnEpContextData, &callback_state);
+
+  Ort::Status status = Ort::CompileModel(*ort_env, compile_options);
+  EXPECT_FALSE(status.IsOK());
+  EXPECT_EQ(status.GetErrorCode(), ORT_FAIL);
+  EXPECT_THAT(status.GetErrorMessage(), testing::HasSubstr("synthetic QNN EPContext write callback failure"));
+  EXPECT_TRUE(callback_state.write_called);
+  EXPECT_FALSE(std::filesystem::exists(target_dir + bin_file_name));
+
+  if (output_model_buffer != nullptr) {
+    allocator.Free(output_model_buffer);
+  }
+}
+
+TEST_F(QnnHTPBackendTests, EpContextCallbacksRejectSharedContextConfigurations) {
+  const ORTCHAR_T* input_model_file = ORT_MODEL_FOLDER "mul_1.onnx";
+  QnnEpContextCallbackState callback_state;
+
+  {
+    Ort::SessionOptions session_options;
+    session_options.SetEpContextDataReadFunc(LoadQnnEpContextData, &callback_state,
+                                             kQnnEpContextTestMaxDataSize);
+    session_options.AddConfigEntry(kOrtSessionOptionShareEpContexts, "1");
+    ProviderOptions provider_options;
+    provider_options["backend_type"] = "htp";
+    session_options.AppendExecutionProvider("QNN", provider_options);
+
+    std::string error;
+    try {
+      Ort::Session session(*ort_env, input_model_file, session_options);
+      FAIL() << "Expected QNN shared-context callback configuration rejection";
+    } catch (const Ort::Exception& ex) {
+      error = ex.what();
+    }
+    EXPECT_THAT(error, testing::HasSubstr("QNN shared EP contexts do not support EPContext data callbacks"));
+  }
+
+  {
+    Ort::SessionOptions session_options;
+    session_options.SetEpContextDataReadFunc(LoadQnnEpContextData, &callback_state,
+                                             kQnnEpContextTestMaxDataSize);
+    ProviderOptions provider_options;
+    provider_options["backend_type"] = "htp";
+    provider_options["enable_vtcm_backup_buffer_sharing"] = "1";
+    session_options.AppendExecutionProvider("QNN", provider_options);
+
+    std::string error;
+    try {
+      Ort::Session session(*ort_env, input_model_file, session_options);
+      FAIL() << "Expected QNN VTCM callback configuration rejection";
+    } catch (const Ort::Exception& ex) {
+      error = ex.what();
+    }
+    EXPECT_THAT(error,
+                testing::HasSubstr("QNN VTCM backup buffer sharing does not support EPContext data callbacks"));
   }
 }
 


### PR DESCRIPTION
### Description

Adds QNN production support for the stable EPContext named-buffer callbacks introduced by #32265.

- Routes external QNN context writes and reads through the application callbacks.
- Propagates callback failures without filesystem fallback or sidecar creation.
- Disables file mapping for callback-backed reads and rejects callback use with shared EP contexts or VTCM backup sharing.
- Rejects empty and oversized callback payloads with `ORT_INVALID_ARGUMENT` before QNN deserialization.
- Advertises QNN READ/WRITE callback support.
- Adds hardware-backed round-trip, embed bypass, exact invocation-count, size/error, sharing-rejection, and no-sidecar tests.

### Motivation and Context

This is a stacked provider-adoption PR based on #32265. The callback path lets applications keep QNN context binaries in encrypted or application-managed storage without creating plaintext fallback files.

### Testing

- Lintrunner passed on all changed QNN files.
- Editor/compiler diagnostics are clean.
- `git diff --check` passed.
- QNN HTP execution tests require QNN hardware/CI and were not run on this Windows CPU build.