### PR TITLE
Add stable EPContext data callbacks to OpenVINO

### DIFF
--- a/onnxruntime/core/providers/openvino/backend_manager.cc
+++ b/onnxruntime/core/providers/openvino/backend_manager.cc
@@ -102,9 +102,13 @@ BackendManager::BackendManager(SessionContext& session_context,
       ORT_THROW(exception_str);
     }
     if (subgraph_context_.is_ep_ctx_ovir_encapsulated) {
-      model_stream = ep_ctx_handle_.GetModelBlobStream(session_context_.onnx_model_path_name.replace_extension("xml").string(), subgraph, session_context_.device_type);
+      model_stream = ep_ctx_handle_.GetModelBlobStream(
+          session_context_.onnx_model_path_name.replace_extension("xml").string(), subgraph,
+          session_context_.device_type, shared_context_, false);
     } else {
-      model_stream = ep_ctx_handle_.GetModelBlobStream(session_context_.so_context_file_path, subgraph, session_context_.device_type);
+      model_stream = ep_ctx_handle_.GetModelBlobStream(
+          session_context_.so_context_file_path, subgraph, session_context_.device_type,
+          shared_context_, session_context_.ep_context_data_read_func != nullptr);
     }
 
   } else {

--- a/onnxruntime/core/providers/openvino/backend_manager.cc
+++ b/onnxruntime/core/providers/openvino/backend_manager.cc
@@ -52,8 +52,10 @@ BackendManager::BackendManager(SessionContext& session_context,
                                                               shared_context_(shared_context) {
   subgraph_context_.is_ep_ctx_graph = ep_ctx_handle_.CheckForOVEPCtxNodeInGraph(subgraph);
   // If the graph contains a OVIR wrapped node, we check if it has matching xml file name attribute
-  subgraph_context_.is_ep_ctx_ovir_encapsulated = ep_ctx_handle_.CheckEPCacheContextAttribute(subgraph,
-                                                                                              session_context_.onnx_model_path_name.filename().replace_extension("xml").string());
+  auto ovir_model_filename = session_context_.GetModelPath().filename();
+  ovir_model_filename.replace_extension("xml");
+  subgraph_context_.is_ep_ctx_ovir_encapsulated =
+      ep_ctx_handle_.CheckEPCacheContextAttribute(subgraph, ovir_model_filename.string());
 
   subgraph_context_.model_precision = [&](const GraphViewer& graph_viewer) {
     // return empty if graph has no inputs or if types are not one of FP32/FP16
@@ -102,8 +104,10 @@ BackendManager::BackendManager(SessionContext& session_context,
       ORT_THROW(exception_str);
     }
     if (subgraph_context_.is_ep_ctx_ovir_encapsulated) {
+      auto ovir_context_path = session_context_.GetModelPath();
+      ovir_context_path.replace_extension("xml");
       model_stream = ep_ctx_handle_.GetModelBlobStream(
-          session_context_.onnx_model_path_name.replace_extension("xml").string(), subgraph,
+          ovir_context_path, subgraph,
           session_context_.device_type, shared_context_, false);
     } else {
       model_stream = ep_ctx_handle_.GetModelBlobStream(

--- a/onnxruntime/core/providers/openvino/backends/basic_backend.cc
+++ b/onnxruntime/core/providers/openvino/backends/basic_backend.cc
@@ -41,29 +41,21 @@ BasicBackend::BasicBackend(std::unique_ptr<ONNX_NAMESPACE::ModelProto>& model_pr
   if (subgraph_context_.is_ep_ctx_graph) {
     try {
       if (subgraph_context_.is_ep_ctx_ovir_encapsulated) {
-        // model_file_path will use so_context_file_path if the onnx_model_path_name is not available,
-        // especially in case of CreateSessionFormArray() where user must explicitly
-        // specify absolute path for so_context_file_path.
-        auto model_file_path = [this]() -> const std::filesystem::path& {
-          if (!session_context_.onnx_model_path_name.empty() &&
-              std::filesystem::exists(session_context_.onnx_model_path_name)) return session_context_.onnx_model_path_name;
-
-          ORT_ENFORCE(!session_context_.so_context_file_path.empty() &&
-                          std::filesystem::path(session_context_.so_context_file_path).is_absolute() &&
-                          std::filesystem::exists(session_context_.so_context_file_path),
+        ORT_ENFORCE(!model_stream->model_path_.empty(),
+                    log_tag + "OpenVINO IR path is unavailable for the EPContext model.");
+        if (session_context_.onnx_model_path_name.empty()) {
+          ORT_ENFORCE(model_stream->model_path_.is_absolute(),
                       log_tag +
-                          "Context file path must be non-empty & absolute, when using CreateSessionFormArray() API explicitly."
-                          " Please set a valid absolute path for ep.context_file_path in session options.");
-          // Return absolute context file path as input to ImportEPCtxOVIREncapsulation() function.
-          return session_context_.so_context_file_path;
-        };
+                          "Context file path must be absolute when using CreateSessionFromArray(). "
+                          "Please set a valid ep.context_file_path in session options.");
+        }
         // If the EPContext node with OVIR Encapsulation, then create
         // an executable network from EP_CACHE_CONTEXT using read_model() & compile_model()
         exe_network_ = OVCore::Get()->ImportEPCtxOVIREncapsulation(*model_stream->stream_,
                                                                    hw_target,
                                                                    device_config,
                                                                    enable_causallm,
-                                                                   model_file_path(),
+                                                                   model_stream->model_path_,
                                                                    session_context_);
       } else {
         // If the blob is held in an EPContext node, then skip FE+Compile

--- a/onnxruntime/core/providers/openvino/contexts.h
+++ b/onnxruntime/core/providers/openvino/contexts.h
@@ -9,6 +9,7 @@
 #include <unordered_set>
 #include <string>
 #include <filesystem>
+#include <limits>
 #include <memory>
 #include "core/common/common.h"
 #include "core/providers/openvino/ov_interface.h"
@@ -63,6 +64,11 @@ struct ProviderInfo {
   bool so_share_ep_contexts{false};        // ORT session option
   bool so_stop_share_ep_contexts{false};   // ORT session option
   fs::path so_context_file_path{};         // ORT session option
+  OrtReadNamedBufferFunc ep_context_data_read_func{nullptr};
+  void* ep_context_data_read_state{nullptr};
+  size_t ep_context_data_read_max_size{std::numeric_limits<size_t>::max()};
+  OrtWriteNamedBufferFunc ep_context_data_write_func{nullptr};
+  void* ep_context_data_write_state{nullptr};
   const ConfigOptions* config_options{NULL};
   const std::unordered_set<std::string> valid_provider_keys = {"device_type", "device_id", "device_luid", "cache_dir", "precision",
                                                                "load_config", "context", "num_of_threads", "model_priority", "num_streams", "enable_opencl_throttling", "enable_qdq_optimizer",

--- a/onnxruntime/core/providers/openvino/onnx_ctx_model_helper.cc
+++ b/onnxruntime/core/providers/openvino/onnx_ctx_model_helper.cc
@@ -2,9 +2,10 @@
 // Licensed under the MIT License
 
 #include <cctype>
-#include <string>
 #include <fstream>
+#include <limits>
 #include <memory>
+#include <string>
 #include <unordered_set>
 #include <vector>
 #include <algorithm>
@@ -33,10 +34,59 @@ class CallbackBufferIStream final : public std::istream {
  private:
   class MemoryStreamBuf final : public std::streambuf {
    public:
-    MemoryStreamBuf(void* buffer, size_t buffer_size) {
-      char* begin = static_cast<char*>(buffer);
-      setg(begin, begin, begin != nullptr ? begin + buffer_size : nullptr);
+    MemoryStreamBuf(void* buffer, size_t buffer_size)
+        : begin_{static_cast<char*>(buffer)}, size_{buffer_size} {
+      setg(begin_, begin_, begin_ + size_);
     }
+
+   protected:
+    pos_type seekoff(off_type offset, std::ios_base::seekdir direction,
+                     std::ios_base::openmode mode) override {
+      if ((mode & std::ios_base::in) == 0) {
+        return pos_type{off_type{-1}};
+      }
+
+      size_t base{};
+      if (direction == std::ios_base::beg) {
+        base = 0;
+      } else if (direction == std::ios_base::cur) {
+        base = static_cast<size_t>(gptr() - begin_);
+      } else if (direction == std::ios_base::end) {
+        base = size_;
+      } else {
+        return pos_type{off_type{-1}};
+      }
+
+      size_t position{};
+      if (offset >= 0) {
+        const auto delta = static_cast<uintmax_t>(offset);
+        if (delta > size_ - base) {
+          return pos_type{off_type{-1}};
+        }
+        position = base + static_cast<size_t>(delta);
+      } else {
+        const auto delta = static_cast<uintmax_t>(-(offset + 1)) + 1;
+        if (delta > base) {
+          return pos_type{off_type{-1}};
+        }
+        position = base - static_cast<size_t>(delta);
+      }
+
+      if (position > static_cast<uintmax_t>(std::numeric_limits<off_type>::max())) {
+        return pos_type{off_type{-1}};
+      }
+
+      setg(begin_, begin_ + position, begin_ + size_);
+      return pos_type{static_cast<off_type>(position)};
+    }
+
+    pos_type seekpos(pos_type position, std::ios_base::openmode mode) override {
+      return seekoff(static_cast<off_type>(position), std::ios_base::beg, mode);
+    }
+
+   private:
+    char* begin_;
+    size_t size_;
   };
 
   std::unique_ptr<void, OrtAllocatorDeleter> buffer_;
@@ -47,12 +97,13 @@ Status ReadEpContextData(OrtReadNamedBufferFunc read_func, void* read_state,
                          size_t max_data_size, const std::string& name,
                          std::unique_ptr<CallbackBufferIStream>& stream) {
   OrtAllocator* allocator = nullptr;
-  ORT_RETURN_IF_ERROR(ToStatusAndRelease(Ort::GetApi().GetAllocatorWithDefaultOptions(&allocator)));
+  ORT_RETURN_IF_ERROR(onnxruntime::openvino_ep::ConvertAndReleaseCallbackStatus(
+      Ort::GetApi().GetAllocatorWithDefaultOptions(&allocator)));
   void* buffer = nullptr;
   size_t buffer_size = 0;
   OrtStatus* callback_status = read_func(read_state, name.c_str(), allocator, &buffer, &buffer_size);
   std::unique_ptr<void, OrtAllocatorDeleter> buffer_guard{buffer, OrtAllocatorDeleter{allocator}};
-  ORT_RETURN_IF_ERROR(ToStatusAndRelease(callback_status));
+  ORT_RETURN_IF_ERROR(onnxruntime::openvino_ep::ConvertAndReleaseCallbackStatus(callback_status));
   if (buffer_size > max_data_size) {
     return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
                            "OpenVINO EPContext read callback exceeded the configured maximum size.");
@@ -60,6 +111,10 @@ Status ReadEpContextData(OrtReadNamedBufferFunc read_func, void* read_state,
   if (buffer_size == 0) {
     return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
                            "OpenVINO EPContext read callback returned an empty payload.");
+  }
+  if (buffer_size > static_cast<uintmax_t>(std::numeric_limits<std::streamoff>::max())) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                           "OpenVINO EPContext read callback payload is too large to stream.");
   }
   ORT_RETURN_IF(buffer == nullptr,
                 "EPContext read callback returned a null buffer for non-empty OpenVINO context data.");
@@ -71,6 +126,17 @@ Status ReadEpContextData(OrtReadNamedBufferFunc read_func, void* read_state,
 
 namespace onnxruntime {
 namespace openvino_ep {
+
+Status ConvertAndReleaseCallbackStatus(OrtStatus* status) {
+  Ort::Status callback_status{status};
+  if (callback_status.IsOK()) {
+    return Status::OK();
+  }
+
+  return Status(common::StatusCategory::ONNXRUNTIME,
+                static_cast<int>(callback_status.GetErrorCode()),
+                callback_status.GetErrorMessage());
+}
 
 EPCtxHandler::EPCtxHandler(std::string ov_sdk_version, const logging::Logger& logger, std::shared_ptr<SharedContextManager> shared_context_manager)
     : openvino_sdk_version_(std::move(ov_sdk_version)), logger_(logger), shared_context_manager_(std::move(shared_context_manager)) {
@@ -208,12 +274,18 @@ std::unique_ptr<ModelBlobWrapper> EPCtxHandler::GetModelBlobStream(
                       ", but OpenVINO SDK version currently in use is " + openvino_sdk_version_);
     }
     result.reset();  // Release the stream as we will get the native blob from SharedContext
-    return std::make_unique<ModelBlobWrapper>(shared_context.GetNativeBlobAsStream(partition_name),
-                                              shared_context.GetNativeBlob(partition_name));
+    std::shared_ptr<SharedContext> filesystem_context;
+    SharedContext* native_blob_context = &shared_context;
+    if (!embed_mode && !callback_backed) {
+      filesystem_context = shared_context_manager_->GetOrCreateSharedContext(blob_filepath);
+      native_blob_context = filesystem_context.get();
+    }
+    return std::make_unique<ModelBlobWrapper>(native_blob_context->GetNativeBlobAsStream(partition_name),
+                                              native_blob_context->GetNativeBlob(partition_name));
   }
 
   LOGS_DEFAULT(VERBOSE) << "[OpenVINO EP] Read blob from EPContext Node";
-  return std::make_unique<ModelBlobWrapper>(std::move(result), ov::Tensor());
+  return std::make_unique<ModelBlobWrapper>(std::move(result), ov::Tensor(), std::move(blob_filepath));
 }
 
 bool EPCtxHandler::CheckForOVEPCtxNodeInGraph(const GraphViewer& graph_viewer) const {
@@ -265,7 +337,13 @@ bool EPCtxHandler::CheckEPCacheContextAttribute(const GraphViewer& graph_viewer,
   const auto& attrs = node->GetAttributes();
   auto it = attrs.find(EP_CACHE_CONTEXT);
   if (it != attrs.end()) {
-    return it->second().s().find(target_attr_extn) != std::string::npos;
+    auto context_filename = std::filesystem::path{it->second().s()}.filename().string();
+    auto target_filename = std::filesystem::path{target_attr_extn}.filename().string();
+    std::transform(context_filename.begin(), context_filename.end(), context_filename.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+    std::transform(target_filename.begin(), target_filename.end(), target_filename.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+    return context_filename == target_filename;
   }
   return false;
 }

--- a/onnxruntime/core/providers/openvino/onnx_ctx_model_helper.cc
+++ b/onnxruntime/core/providers/openvino/onnx_ctx_model_helper.cc
@@ -4,11 +4,70 @@
 #include <cctype>
 #include <string>
 #include <fstream>
+#include <memory>
+#include <unordered_set>
 #include <vector>
 #include <algorithm>
 
 #include "core/providers/openvino/onnx_ctx_model_helper.h"
 #include "core/providers/openvino/backend_utils.h"
+
+namespace {
+
+struct OrtAllocatorDeleter {
+  OrtAllocator* allocator{};
+  void operator()(void* buffer) const noexcept {
+    if (buffer != nullptr) {
+      allocator->Free(allocator, buffer);
+    }
+  }
+};
+
+class CallbackBufferIStream final : public std::istream {
+ public:
+  CallbackBufferIStream(std::unique_ptr<void, OrtAllocatorDeleter> buffer, size_t buffer_size)
+      : std::istream(nullptr), buffer_{std::move(buffer)}, streambuf_{buffer_.get(), buffer_size} {
+    rdbuf(&streambuf_);
+  }
+
+ private:
+  class MemoryStreamBuf final : public std::streambuf {
+   public:
+    MemoryStreamBuf(void* buffer, size_t buffer_size) {
+      char* begin = static_cast<char*>(buffer);
+      setg(begin, begin, begin != nullptr ? begin + buffer_size : nullptr);
+    }
+  };
+
+  std::unique_ptr<void, OrtAllocatorDeleter> buffer_;
+  MemoryStreamBuf streambuf_;
+};
+
+Status ReadEpContextData(OrtReadNamedBufferFunc read_func, void* read_state,
+                         size_t max_data_size, const std::string& name,
+                         std::unique_ptr<CallbackBufferIStream>& stream) {
+  OrtAllocator* allocator = nullptr;
+  ORT_RETURN_IF_ERROR(ToStatusAndRelease(Ort::GetApi().GetAllocatorWithDefaultOptions(&allocator)));
+  void* buffer = nullptr;
+  size_t buffer_size = 0;
+  OrtStatus* callback_status = read_func(read_state, name.c_str(), allocator, &buffer, &buffer_size);
+  std::unique_ptr<void, OrtAllocatorDeleter> buffer_guard{buffer, OrtAllocatorDeleter{allocator}};
+  ORT_RETURN_IF_ERROR(ToStatusAndRelease(callback_status));
+  if (buffer_size > max_data_size) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                           "OpenVINO EPContext read callback exceeded the configured maximum size.");
+  }
+  if (buffer_size == 0) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                           "OpenVINO EPContext read callback returned an empty payload.");
+  }
+  ORT_RETURN_IF(buffer == nullptr,
+                "EPContext read callback returned a null buffer for non-empty OpenVINO context data.");
+  stream = std::make_unique<CallbackBufferIStream>(std::move(buffer_guard), buffer_size);
+  return Status::OK();
+}
+
+}  // namespace
 
 namespace onnxruntime {
 namespace openvino_ep {
@@ -94,7 +153,9 @@ Status EPCtxHandler::AddOVEPCtxNodeToGraph(const GraphViewer& graph_viewer,
   return Status::OK();
 }
 
-std::unique_ptr<ModelBlobWrapper> EPCtxHandler::GetModelBlobStream(const std::filesystem::path& so_context_file_path, const GraphViewer& graph_viewer, const std::string& device_type) const {
+std::unique_ptr<ModelBlobWrapper> EPCtxHandler::GetModelBlobStream(
+    const std::filesystem::path& so_context_file_path, const GraphViewer& graph_viewer,
+    const std::string& device_type, SharedContext& shared_context, bool callback_backed) const {
   auto first_index = *graph_viewer.GetNodesInTopologicalOrder().begin();
   auto node = graph_viewer.GetNode(first_index);
   ORT_ENFORCE(node != nullptr);
@@ -105,6 +166,18 @@ std::unique_ptr<ModelBlobWrapper> EPCtxHandler::GetModelBlobStream(const std::fi
 
   ORT_ENFORCE(attrs.count(EMBED_MODE) == 1);
   bool embed_mode = static_cast<bool>(attrs.at(EMBED_MODE).i());
+
+  if (!embed_mode && callback_backed) {
+    ORT_ENFORCE(attrs.count(PARTITION_NAME) == 1, "Expected partition name for native ep context node");
+    const auto& partition_name = attrs.at(PARTITION_NAME).s();
+    if (device_type.find("NPU") == std::string::npos) {
+      ORT_ENFORCE((attrs.count(EP_SDK_VER) == 1) && (attrs.at(EP_SDK_VER).s() == openvino_sdk_version_),
+                  "EPCtx blob was exported / is compatible with OpenVINO SDK version " + attrs.at(EP_SDK_VER).s() +
+                      ", but OpenVINO SDK version currently in use is " + openvino_sdk_version_);
+    }
+    return std::make_unique<ModelBlobWrapper>(shared_context.GetNativeBlobAsStream(partition_name),
+                                              shared_context.GetNativeBlob(partition_name));
+  }
 
   std::unique_ptr<std::istream> result;
   std::filesystem::path blob_filepath{};
@@ -122,14 +195,12 @@ std::unique_ptr<ModelBlobWrapper> EPCtxHandler::GetModelBlobStream(const std::fi
   }
 
   bool isXML = backend_utils::IsModelStreamXML(*result);
-  std::filesystem::path native_blob_path{};
   if (!isXML) {
     ORT_ENFORCE(attrs.count(PARTITION_NAME) == 1, "Expected partition name for native ep context node");
     const auto& partition_name = attrs.at(PARTITION_NAME).s();
 
     // If the model stream is not an XML (i.e. precompiled blob), the OpenVINO SDK version that it was
     // exported with must match the version that is currently running.
-    native_blob_path = std::move(blob_filepath);
     // Skip SDK version check for NPU devices as they may use different SDK versions.
     if (device_type.find("NPU") == std::string::npos) {
       ORT_ENFORCE((attrs.count(EP_SDK_VER) == 1) && (attrs.at(EP_SDK_VER).s() == openvino_sdk_version_),
@@ -137,8 +208,8 @@ std::unique_ptr<ModelBlobWrapper> EPCtxHandler::GetModelBlobStream(const std::fi
                       ", but OpenVINO SDK version currently in use is " + openvino_sdk_version_);
     }
     result.reset();  // Release the stream as we will get the native blob from SharedContext
-    auto shared_context = shared_context_manager_->GetOrCreateSharedContext(native_blob_path);
-    return std::make_unique<ModelBlobWrapper>(shared_context->GetNativeBlobAsStream(partition_name), shared_context->GetNativeBlob(partition_name));
+    return std::make_unique<ModelBlobWrapper>(shared_context.GetNativeBlobAsStream(partition_name),
+                                              shared_context.GetNativeBlob(partition_name));
   }
 
   LOGS_DEFAULT(VERBOSE) << "[OpenVINO EP] Read blob from EPContext Node";
@@ -203,6 +274,7 @@ std::shared_ptr<SharedContext> EPCtxHandler::Initialize(const std::vector<IExecu
   bool has_embed_nodes = false;
   bool has_non_embed_nodes = false;
   bool has_main_context = false;
+  std::unordered_set<std::string> loaded_callback_names;
 
   std::shared_ptr<SharedContext> shared_context{};
   for (const auto& fused_node_graph : fused_nodes) {
@@ -253,11 +325,29 @@ std::shared_ptr<SharedContext> EPCtxHandler::Initialize(const std::vector<IExecu
       const std::filesystem::path& validation_base_path = is_xml
                                                               ? session_context.GetModelPath()
                                                               : session_context.GetOutputModelPath();
-      ORT_THROW_IF_ERROR(utils::ValidateExternalDataPath(validation_base_path, cache_context_path));
-      const std::filesystem::path ep_context_path = validation_base_path.parent_path() / cache_context_path;
       if (!is_xml) {
-        shared_context = shared_context_manager_->GetOrCreateSharedContext(ep_context_path);
-        shared_context->Deserialize();
+        if (session_context.ep_context_data_read_func != nullptr) {
+          if (!shared_context) {
+            shared_context = std::make_shared<SharedContext>(std::filesystem::path{});
+          }
+          if (loaded_callback_names.insert(ep_cache_context).second) {
+            std::unique_ptr<CallbackBufferIStream> stream;
+            ORT_THROW_IF_ERROR(ReadEpContextData(session_context.ep_context_data_read_func,
+                                                 session_context.ep_context_data_read_state,
+                                                 session_context.ep_context_data_read_max_size,
+                                                 ep_cache_context, stream));
+            shared_context->Deserialize(*stream);
+          }
+        } else {
+          ORT_THROW_IF_ERROR(utils::ValidateExternalDataPath(validation_base_path, cache_context_path));
+          const std::filesystem::path ep_context_path = validation_base_path.parent_path() / cache_context_path;
+          shared_context = shared_context_manager_->GetOrCreateSharedContext(ep_context_path);
+          shared_context->Deserialize();
+        }
+      } else {
+        ORT_ENFORCE(session_context.ep_context_data_read_func == nullptr,
+                    "OpenVINO OVIR EPContext does not support EPContext data read callbacks.");
+        ORT_THROW_IF_ERROR(utils::ValidateExternalDataPath(validation_base_path, cache_context_path));
       }
     }
   }

--- a/onnxruntime/core/providers/openvino/onnx_ctx_model_helper.h
+++ b/onnxruntime/core/providers/openvino/onnx_ctx_model_helper.h
@@ -15,10 +15,15 @@
 namespace onnxruntime {
 namespace openvino_ep {
 
+Status ConvertAndReleaseCallbackStatus(OrtStatus* status);
+
 struct ModelBlobWrapper {
-  ModelBlobWrapper(std::unique_ptr<std::istream> stream, const ov::Tensor& tensor) : stream_(std::move(stream)), tensor_(tensor) {}
+  ModelBlobWrapper(std::unique_ptr<std::istream> stream, const ov::Tensor& tensor,
+                   std::filesystem::path model_path = {})
+      : stream_(std::move(stream)), tensor_(tensor), model_path_(std::move(model_path)) {}
   std::unique_ptr<std::istream> stream_;
   ov::Tensor tensor_;  // May be empty if model blob is provided as stream only.
+  std::filesystem::path model_path_;
 };
 
 // Utilities to handle EPContext node export and parsing of an EPContext node

--- a/onnxruntime/core/providers/openvino/onnx_ctx_model_helper.h
+++ b/onnxruntime/core/providers/openvino/onnx_ctx_model_helper.h
@@ -41,7 +41,11 @@ class EPCtxHandler {
                                const std::string& graph_name,
                                const bool embed_mode,
                                std::string&& model_blob_str) const;
-  std::unique_ptr<ModelBlobWrapper> GetModelBlobStream(const std::filesystem::path& so_context_file_path, const GraphViewer& subgraph_view, const std::string& device_type) const;
+  std::unique_ptr<ModelBlobWrapper> GetModelBlobStream(const std::filesystem::path& so_context_file_path,
+                                                       const GraphViewer& subgraph_view,
+                                                       const std::string& device_type,
+                                                       SharedContext& shared_context,
+                                                       bool callback_backed) const;
   InlinedVector<const Node*> GetEPCtxNodes() const;
   bool CheckEPCacheContextAttribute(const GraphViewer& subgraph_view, const std::string& target_attr_extn) const;
   std::shared_ptr<SharedContext> Initialize(const std::vector<IExecutionProvider::FusedNodeAndGraph>& fused_nodes, const SessionContext& session_context);

--- a/onnxruntime/core/providers/openvino/openvino_execution_provider.cc
+++ b/onnxruntime/core/providers/openvino/openvino_execution_provider.cc
@@ -204,7 +204,7 @@ common::Status OpenVINOExecutionProvider::Compile(
           shared_context_->Serialize(stream);
           std::string payload = std::move(stream).str();
           const std::string name = PathToUTF8String(shared_context_->GetBinPath().filename().native());
-          ORT_RETURN_IF_ERROR(ToStatusAndRelease(session_context_.ep_context_data_write_func(
+          ORT_RETURN_IF_ERROR(ConvertAndReleaseCallbackStatus(session_context_.ep_context_data_write_func(
               session_context_.ep_context_data_write_state, name.c_str(), payload.data(), payload.size())));
         } else {
           shared_context_->Serialize();

--- a/onnxruntime/core/providers/openvino/openvino_execution_provider.cc
+++ b/onnxruntime/core/providers/openvino/openvino_execution_provider.cc
@@ -64,6 +64,10 @@ OpenVINOExecutionProvider::OpenVINOExecutionProvider(const ProviderInfo& info)
       shared_context_manager_(SharedContextManager::Get()),
       ep_ctx_handle_{session_context_.openvino_sdk_version, *GetLogger(), shared_context_manager_} {
   InitProviderOrtApi();
+  const bool has_ep_context_data_callback = session_context_.ep_context_data_read_func != nullptr ||
+                                            session_context_.ep_context_data_write_func != nullptr;
+  ORT_ENFORCE(!(session_context_.so_share_ep_contexts && has_ep_context_data_callback),
+              "OpenVINO shared EP contexts do not support EPContext data callbacks.");
 #ifdef _WIN32
   session_id_ = global_session_counter_.fetch_add(1) + 1;
   // Trace all runtime options (includes both session and provider options)
@@ -195,7 +199,16 @@ common::Status OpenVINOExecutionProvider::Compile(
 
       // bit clunky ideally we should try to fold this into ep context handler
       if (!session_context_.so_context_embed_mode) {
-        shared_context_->Serialize();
+        if (session_context_.ep_context_data_write_func != nullptr) {
+          std::stringstream stream;
+          shared_context_->Serialize(stream);
+          std::string payload = std::move(stream).str();
+          const std::string name = PathToUTF8String(shared_context_->GetBinPath().filename().native());
+          ORT_RETURN_IF_ERROR(ToStatusAndRelease(session_context_.ep_context_data_write_func(
+              session_context_.ep_context_data_write_state, name.c_str(), payload.data(), payload.size())));
+        } else {
+          shared_context_->Serialize();
+        }
         if (session_context_.so_stop_share_ep_contexts) {
           shared_context_manager_->ClearActiveSharedContext();
         }

--- a/onnxruntime/core/providers/openvino/openvino_execution_provider.h
+++ b/onnxruntime/core/providers/openvino/openvino_execution_provider.h
@@ -74,6 +74,11 @@ class OpenVINOExecutionProvider : public IExecutionProvider {
 
   const InlinedVector<const Node*> GetEpContextNodes() const override;
 
+  Status GetEpContextDataSupport(uint32_t& supported_flags) const override {
+    supported_flags = OrtEpContextDataSupportFlags_READ | OrtEpContextDataSupportFlags_WRITE;
+    return Status::OK();
+  }
+
 #ifdef USE_OVEP_NPU_MEMORY
   std::vector<AllocatorPtr> CreatePreferredAllocators() override;
 #endif

--- a/onnxruntime/core/providers/openvino/openvino_provider_factory.cc
+++ b/onnxruntime/core/providers/openvino/openvino_provider_factory.cc
@@ -431,6 +431,11 @@ struct OpenVINOProviderFactory : IExecutionProviderFactory {
     ProviderInfo provider_info = provider_info_;
     ParseProviderInfo(provider_options, &config_options, provider_info);
     ParseConfigOptions(provider_info);
+    session_options.GetEpContextDataCallbacks(&provider_info.ep_context_data_read_func,
+                                              &provider_info.ep_context_data_read_state,
+                                              &provider_info.ep_context_data_read_max_size,
+                                              &provider_info.ep_context_data_write_func,
+                                              &provider_info.ep_context_data_write_state);
 
     auto ov_ep = std::make_unique<OpenVINOExecutionProvider>(provider_info);
     ov_ep->SetLogger(reinterpret_cast<const logging::Logger*>(&session_logger));
@@ -440,9 +445,14 @@ struct OpenVINOProviderFactory : IExecutionProviderFactory {
   // This is called during session creation when AppendExecutionProvider_V2 is used.
   // This one is called because ParseProviderInfo / ParseConfigOptions, etc. are already
   // performed in CreateIExecutionProvider, and so provider_info_ has already been populated.
-  std::unique_ptr<IExecutionProvider> CreateProvider_V2(const OrtSessionOptions& /*session_options*/,
+  std::unique_ptr<IExecutionProvider> CreateProvider_V2(const OrtSessionOptions& session_options,
                                                         const OrtLogger& session_logger) {
     ProviderInfo provider_info = provider_info_;
+    session_options.GetEpContextDataCallbacks(&provider_info.ep_context_data_read_func,
+                                              &provider_info.ep_context_data_read_state,
+                                              &provider_info.ep_context_data_read_max_size,
+                                              &provider_info.ep_context_data_write_func,
+                                              &provider_info.ep_context_data_write_state);
     auto ov_ep = std::make_unique<OpenVINOExecutionProvider>(provider_info);
     ov_ep->SetLogger(reinterpret_cast<const logging::Logger*>(&session_logger));
     return ov_ep;

--- a/onnxruntime/core/providers/openvino/ov_interface.cc
+++ b/onnxruntime/core/providers/openvino/ov_interface.cc
@@ -234,7 +234,7 @@ OVExeNetwork OVCore::ImportEPCtxOVIREncapsulation(std::istream& model_stream,
                                                   std::string& hw_target,
                                                   const ov::AnyMap& device_config,
                                                   bool enable_causallm,
-                                                  std::filesystem::path model_file_path,
+                                                  std::filesystem::path xml_file_path,
                                                   const SessionContext& session_context) {
   return OvExceptionBoundary<false>([&]() {
     OVExeNetwork exe;
@@ -242,7 +242,7 @@ OVExeNetwork OVCore::ImportEPCtxOVIREncapsulation(std::istream& model_stream,
     bool isXML = backend_utils::IsModelStreamXML(model_stream);
 
     // Helper function to check if file exists and is readable
-    const auto check_file_access = [&model_file_path](const std::filesystem::path& path) {
+    const auto check_file_access = [](const std::filesystem::path& path) {
       try {
         if (!std::filesystem::exists(path) || std::filesystem::is_empty(path)) {
           ORT_THROW(log_tag + "Required file missing or empty: " + path.string());
@@ -259,8 +259,6 @@ OVExeNetwork OVCore::ImportEPCtxOVIREncapsulation(std::istream& model_stream,
     if (isXML) {
       // If the model is XML, we need to load it with the XML content in read_model()
       // where weights from bin file is directly consumed
-      auto xml_file_path = model_file_path.parent_path() / (model_file_path.stem().string() + ".xml");
-
       check_file_access(xml_file_path);
 
       LOGS_DEFAULT(INFO) << log_tag << "Reading OVIR from XML file path: " << xml_file_path.string();
@@ -286,7 +284,7 @@ OVExeNetwork OVCore::ImportEPCtxOVIREncapsulation(std::istream& model_stream,
 #endif
     return exe;
   },
-                                    "Exception while Loading Network from OVIR model file: {}", model_file_path.string());
+                                    "Exception while Loading Network from OVIR model file: {}", xml_file_path.string());
 }
 
 void OVCore::SetCache(const std::string& cache_dir_path) {

--- a/onnxruntime/core/providers/openvino/ov_interface.h
+++ b/onnxruntime/core/providers/openvino/ov_interface.h
@@ -78,7 +78,7 @@ struct OVCore : WeakSingleton<OVCore> {
                                             std::string& hw_target,
                                             const ov::AnyMap& device_config,
                                             bool enable_causallm,
-                                            std::filesystem::path model_file_path,
+                                            std::filesystem::path xml_file_path,
                                             const SessionContext& session_context);
 
   std::vector<std::string> GetAvailableDevices() const;

--- a/onnxruntime/test/providers/openvino/openvino_ep_context_test.cc
+++ b/onnxruntime/test/providers/openvino/openvino_ep_context_test.cc
@@ -4,6 +4,7 @@
 #include <array>
 #include <filesystem>
 #include <fstream>
+#include <iterator>
 #include <span>
 #include <string>
 #include <unordered_map>
@@ -26,6 +27,7 @@
 
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
+#include "gsl/gsl"
 
 using namespace ONNX_NAMESPACE;
 using namespace onnxruntime::logging;
@@ -36,6 +38,8 @@ namespace {
 
 using onnxruntime::MLFloat16;
 
+constexpr size_t kOpenVINOEpContextTestMaxDataSize = size_t{1} << 30;
+
 // Returns true only on Intel CPUs.
 //
 // The OVIR EP context tests are gated on this because that path is currently
@@ -45,6 +49,102 @@ using onnxruntime::MLFloat16;
 // crash. On those CPUs the OVIR EP context tests are skipped.
 bool IsIntelCPU() {
   return onnxruntime::CPUIDInfo::GetCPUIDInfo().GetCPUVendor() == "Intel";
+}
+
+struct OpenVINOEpContextCallbackState {
+  bool write_called = false;
+  bool read_called = false;
+  size_t write_count = 0;
+  size_t read_count = 0;
+  bool fail_write = false;
+  bool fail_read = false;
+  bool return_empty = false;
+  std::string name;
+  std::vector<char> payload;
+  std::unordered_map<std::string, std::vector<char>> payloads_by_name;
+  std::vector<std::string> read_names;
+};
+
+OrtStatus* ORT_API_CALL StoreOpenVINOEpContextData(void* state, const char* name, const void* buffer,
+                                                   size_t buffer_size) {
+  auto& callback_state = *static_cast<OpenVINOEpContextCallbackState*>(state);
+  callback_state.write_called = true;
+  ++callback_state.write_count;
+  callback_state.name = name;
+  if (callback_state.fail_write) {
+    return Ort::GetApi().CreateStatus(ORT_FAIL, "synthetic OpenVINO EPContext write callback failure");
+  }
+  callback_state.payload.clear();
+  if (buffer_size != 0) {
+    if (buffer == nullptr) {
+      return Ort::GetApi().CreateStatus(ORT_INVALID_ARGUMENT,
+                                        "OpenVINO EPContext write callback received a null non-empty payload");
+    }
+    callback_state.payload.assign(static_cast<const char*>(buffer), static_cast<const char*>(buffer) + buffer_size);
+  }
+  return nullptr;
+}
+
+OrtStatus* ORT_API_CALL LoadOpenVINOEpContextData(void* state, const char* name, OrtAllocator* allocator,
+                                                  void** buffer, size_t* buffer_size) {
+  auto& callback_state = *static_cast<OpenVINOEpContextCallbackState*>(state);
+  callback_state.read_called = true;
+  ++callback_state.read_count;
+  callback_state.read_names.emplace_back(name);
+  if (callback_state.fail_read) {
+    return Ort::GetApi().CreateStatus(ORT_FAIL, "synthetic OpenVINO EPContext read callback failure");
+  }
+
+  const std::vector<char>* payload = &callback_state.payload;
+  if (!callback_state.payloads_by_name.empty()) {
+    const auto payload_it = callback_state.payloads_by_name.find(name);
+    if (payload_it == callback_state.payloads_by_name.end()) {
+      return Ort::GetApi().CreateStatus(ORT_INVALID_ARGUMENT, "Unexpected OpenVINO EPContext data name");
+    }
+    payload = &payload_it->second;
+  } else if (callback_state.name != name) {
+    return Ort::GetApi().CreateStatus(ORT_INVALID_ARGUMENT, "Unexpected OpenVINO EPContext data name");
+  }
+
+  *buffer = nullptr;
+  if (callback_state.return_empty) {
+    *buffer_size = 0;
+    return nullptr;
+  }
+  *buffer_size = payload->size();
+  if (payload->empty()) {
+    return nullptr;
+  }
+
+  OrtStatus* status = Ort::GetApi().AllocatorAlloc(allocator, payload->size(), buffer);
+  if (status == nullptr) {
+    std::copy(payload->begin(), payload->end(), static_cast<char*>(*buffer));
+  }
+  return status;
+}
+
+std::string GetExternalEpContextDataName(const std::filesystem::path& model_path) {
+  ONNX_NAMESPACE::ModelProto model_proto;
+  ORT_THROW_IF_ERROR(Model::Load(model_path, model_proto));
+  for (const auto& node : model_proto.graph().node()) {
+    if (node.op_type() != "EPContext") {
+      continue;
+    }
+
+    bool is_external = false;
+    std::string name;
+    for (const auto& attr : node.attribute()) {
+      if (attr.name() == "embed_mode") {
+        is_external = attr.i() == 0;
+      } else if (attr.name() == "ep_cache_context") {
+        name = attr.s();
+      }
+    }
+    if (is_external && !name.empty()) {
+      return name;
+    }
+  }
+  ORT_THROW("External EPContext data name not found in ", model_path.string());
 }
 
 // Runs a mul_1-style model (X[3,2] -> Y[3,2], Y = X * {1,2,3,4,5,6}) with
@@ -261,6 +361,27 @@ TEST_F(OVEPEPContextOVIRTests, RunEpCtxOvirModel) {
   RunAndValidate(session);
 }
 
+TEST_F(OVEPEPContextOVIRTests, ReadCallbackIsRejectedBeforeFilesystemFallback) {
+  OpenVINOEpContextCallbackState callback_state;
+  Ort::SessionOptions session_options;
+  session_options.SetEpContextDataReadFunc(LoadOpenVINOEpContextData, &callback_state,
+                                           kOpenVINOEpContextTestMaxDataSize);
+  std::unordered_map<std::string, std::string> ov_options = {{"device_type", kDevice}};
+  session_options.AppendExecutionProvider_OpenVINO_V2(ov_options);
+
+  std::string error;
+  try {
+    Ort::Session session(*ort_env, kOvirModelPath, session_options);
+    FAIL() << "Expected OVIR EPContext read callback rejection";
+  } catch (const Ort::Exception& ex) {
+    error = ex.what();
+  }
+
+  EXPECT_THAT(error,
+              testing::HasSubstr("OpenVINO OVIR EPContext does not support EPContext data read callbacks"));
+  EXPECT_FALSE(callback_state.read_called);
+}
+
 // Negative / security test: an OVIR-encapsulated EP context model whose
 // "ep_cache_context" attribute points outside the model directory via "../"
 // traversal (e.g. "../../../etc/evil.xml") must be rejected at session-creation
@@ -387,9 +508,23 @@ TEST_P(OVEPOVIRModelsExportEPContextTests, ExportEpCtxFromOVIRModel) {
   ASSERT_TRUE(std::filesystem::exists(epctx_model))
       << "EP context model was not generated at " << epctx_model;
 
+  OpenVINOEpContextCallbackState callback_state;
+  if (!embed_mode) {
+    callback_state.name = GetExternalEpContextDataName(epctx_model);
+    const std::filesystem::path sidecar_path = epctx_model.parent_path() / callback_state.name;
+    std::ifstream sidecar_stream(sidecar_path, std::ios::binary);
+    ASSERT_TRUE(sidecar_stream);
+    callback_state.payload.assign(std::istreambuf_iterator<char>{sidecar_stream}, std::istreambuf_iterator<char>{});
+    sidecar_stream.close();
+    ASSERT_FALSE(callback_state.payload.empty());
+    ASSERT_TRUE(std::filesystem::remove(sidecar_path));
+  }
+
   // --- Load + run the generated EP context model ---
   {
     Ort::SessionOptions session_options;
+    session_options.SetEpContextDataReadFunc(LoadOpenVINOEpContextData, &callback_state,
+                                             kOpenVINOEpContextTestMaxDataSize);
     std::unordered_map<std::string, std::string> ov_options = {{"device_type", kDevice}};
     session_options.AppendExecutionProvider_OpenVINO_V2(ov_options);
 
@@ -398,7 +533,271 @@ TEST_P(OVEPOVIRModelsExportEPContextTests, ExportEpCtxFromOVIRModel) {
     RunAndValidate(session);
   }
 
+  EXPECT_EQ(callback_state.read_called, !embed_mode);
+  EXPECT_EQ(callback_state.read_count, embed_mode ? 0u : 1u);
+
   std::filesystem::remove_all(out_dir);
+}
+
+TEST_F(OVEPOVIRModelsExportEPContextTests, CompileApiExternalDataUsesCallbacks) {
+  const std::filesystem::path out_dir = std::filesystem::path("testdata") / "ovir_epctx_compile_callbacks";
+  std::filesystem::remove_all(out_dir);
+  std::filesystem::create_directories(out_dir);
+  const std::filesystem::path epctx_model = out_dir / "mul_1_ovir_epctx_compile.onnx";
+  auto cleanup = gsl::finally([&]() { std::filesystem::remove_all(out_dir); });
+
+  Ort::SessionOptions session_options;
+  std::unordered_map<std::string, std::string> ov_options = {{"device_type", kDevice}};
+  session_options.AppendExecutionProvider_OpenVINO_V2(ov_options);
+
+  OpenVINOEpContextCallbackState callback_state;
+  Ort::ModelCompilationOptions compile_options(*ort_env, session_options);
+  compile_options.SetInputModelPath(kOvirModelPath);
+  compile_options.SetOutputModelPath(epctx_model.c_str());
+  compile_options.SetEpContextEmbedMode(false);
+  compile_options.SetEpContextDataWriteFunc(StoreOpenVINOEpContextData, &callback_state);
+
+  Ort::Status compile_status = Ort::CompileModel(*ort_env, compile_options);
+  ASSERT_TRUE(compile_status.IsOK()) << compile_status.GetErrorMessage();
+  ASSERT_TRUE(std::filesystem::exists(epctx_model));
+  ASSERT_TRUE(callback_state.write_called);
+  ASSERT_EQ(callback_state.write_count, 1u);
+  ASSERT_FALSE(callback_state.name.empty());
+  ASSERT_FALSE(callback_state.payload.empty());
+  ASSERT_FALSE(std::filesystem::exists(epctx_model.parent_path() / callback_state.name));
+
+  session_options.SetEpContextDataReadFunc(LoadOpenVINOEpContextData, &callback_state,
+                                           callback_state.payload.size() - 1);
+  std::string oversized_error;
+  try {
+    Ort::Session session(*ort_env, epctx_model.c_str(), session_options);
+    FAIL() << "Expected oversized OpenVINO EPContext callback payload rejection";
+  } catch (const Ort::Exception& ex) {
+    oversized_error = ex.what();
+    EXPECT_EQ(ex.GetOrtErrorCode(), ORT_INVALID_ARGUMENT);
+  }
+  EXPECT_TRUE(callback_state.read_called);
+  EXPECT_EQ(callback_state.read_count, 1u);
+  EXPECT_THAT(oversized_error,
+              testing::HasSubstr("OpenVINO EPContext read callback exceeded the configured maximum size"));
+  EXPECT_FALSE(std::filesystem::exists(epctx_model.parent_path() / callback_state.name));
+
+  callback_state.read_called = false;
+  session_options.SetEpContextDataReadFunc(LoadOpenVINOEpContextData, &callback_state,
+                                           kOpenVINOEpContextTestMaxDataSize);
+  callback_state.return_empty = true;
+  std::string empty_error;
+  try {
+    Ort::Session session(*ort_env, epctx_model.c_str(), session_options);
+    FAIL() << "Expected empty OpenVINO EPContext callback payload rejection";
+  } catch (const Ort::Exception& ex) {
+    empty_error = ex.what();
+    EXPECT_EQ(ex.GetOrtErrorCode(), ORT_INVALID_ARGUMENT);
+  }
+  EXPECT_TRUE(callback_state.read_called);
+  EXPECT_EQ(callback_state.read_count, 2u);
+  EXPECT_THAT(empty_error, testing::HasSubstr("OpenVINO EPContext read callback returned an empty payload"));
+  EXPECT_FALSE(std::filesystem::exists(epctx_model.parent_path() / callback_state.name));
+
+  callback_state.return_empty = false;
+  callback_state.read_called = false;
+  callback_state.fail_read = true;
+  std::string read_error;
+  try {
+    Ort::Session session(*ort_env, epctx_model.c_str(), session_options);
+    FAIL() << "Expected OpenVINO EPContext read callback failure";
+  } catch (const Ort::Exception& ex) {
+    read_error = ex.what();
+  }
+  EXPECT_TRUE(callback_state.read_called);
+  EXPECT_EQ(callback_state.read_count, 3u);
+  EXPECT_THAT(read_error, testing::HasSubstr("synthetic OpenVINO EPContext read callback failure"));
+  EXPECT_FALSE(std::filesystem::exists(epctx_model.parent_path() / callback_state.name));
+
+  callback_state.fail_read = false;
+  callback_state.read_called = false;
+  Ort::Session session(*ort_env, epctx_model.c_str(), session_options);
+  EXPECT_TRUE(callback_state.read_called);
+  EXPECT_EQ(callback_state.read_count, 4u);
+  RunAndValidate(session);
+}
+
+TEST_F(OVEPOVIRModelsExportEPContextTests, ReadCallbackRunsOncePerDistinctExternalName) {
+  const std::filesystem::path out_dir = std::filesystem::path("testdata") / "ovir_epctx_distinct_callbacks";
+  std::filesystem::remove_all(out_dir);
+  std::filesystem::create_directories(out_dir);
+  auto cleanup = gsl::finally([&]() { std::filesystem::remove_all(out_dir); });
+
+  const std::filesystem::path epctx_model = out_dir / "mul_1_ovir_epctx.onnx";
+  OpenVINOEpContextCallbackState write_state;
+  {
+    Ort::SessionOptions session_options;
+    std::unordered_map<std::string, std::string> ov_options = {{"device_type", kDevice}};
+    session_options.AppendExecutionProvider_OpenVINO_V2(ov_options);
+
+    Ort::ModelCompilationOptions compile_options(*ort_env, session_options);
+    compile_options.SetInputModelPath(kOvirModelPath);
+    compile_options.SetOutputModelPath(epctx_model.c_str());
+    compile_options.SetEpContextEmbedMode(false);
+    compile_options.SetEpContextDataWriteFunc(StoreOpenVINOEpContextData, &write_state);
+    ASSERT_CXX_ORTSTATUS_OK(Ort::CompileModel(*ort_env, compile_options));
+  }
+  ASSERT_EQ(write_state.write_count, 1u);
+  ASSERT_FALSE(write_state.name.empty());
+  ASSERT_FALSE(write_state.payload.empty());
+
+  ONNX_NAMESPACE::ModelProto model_proto;
+  ASSERT_STATUS_OK(Model::Load(epctx_model, model_proto));
+  auto* graph = model_proto.mutable_graph();
+
+  ONNX_NAMESPACE::NodeProto original_context_node;
+  for (const auto& node : graph->node()) {
+    if (node.op_type() == "EPContext") {
+      original_context_node.CopyFrom(node);
+      break;
+    }
+  }
+  ASSERT_FALSE(original_context_node.op_type().empty());
+
+  std::vector<ONNX_NAMESPACE::ValueInfoProto> original_output_infos;
+  original_output_infos.reserve(original_context_node.output_size());
+  for (const auto& output_name : original_context_node.output()) {
+    const ONNX_NAMESPACE::ValueInfoProto* output_info = nullptr;
+    for (const auto& graph_output : graph->output()) {
+      if (graph_output.name() == output_name) {
+        output_info = &graph_output;
+        break;
+      }
+    }
+    ASSERT_NE(output_info, nullptr) << "Missing graph output type for " << output_name;
+    original_output_infos.push_back(*output_info);
+  }
+
+  const std::string second_name = "second_" + write_state.name;
+  auto add_context_clone = [&](const std::string& suffix, const std::string& context_name) {
+    auto* clone = graph->add_node();
+    clone->CopyFrom(original_context_node);
+    clone->set_name(original_context_node.name() + suffix);
+
+    bool updated_context_name = false;
+    for (auto& attribute : *clone->mutable_attribute()) {
+      if (attribute.name() == "main_context") {
+        attribute.set_i(0);
+      } else if (attribute.name() == "ep_cache_context") {
+        attribute.set_s(context_name);
+        updated_context_name = true;
+      }
+    }
+    ASSERT_TRUE(updated_context_name);
+
+    for (int output_index = 0; output_index < clone->output_size(); ++output_index) {
+      const std::string cloned_output_name = clone->output(output_index) + suffix;
+      clone->set_output(output_index, cloned_output_name);
+      auto* graph_output = graph->add_output();
+      graph_output->CopyFrom(original_output_infos[output_index]);
+      graph_output->set_name(cloned_output_name);
+    }
+  };
+
+  add_context_clone("_duplicate", write_state.name);
+  add_context_clone("_second", second_name);
+
+  const std::filesystem::path patched_model = out_dir / "mul_1_ovir_epctx_patched.onnx";
+  {
+    std::ofstream model_stream(patched_model, std::ios::binary);
+    ASSERT_TRUE(model_stream);
+    ASSERT_TRUE(model_proto.SerializeToOstream(&model_stream));
+  }
+
+  OpenVINOEpContextCallbackState read_state;
+  read_state.payloads_by_name.emplace(write_state.name, write_state.payload);
+  read_state.payloads_by_name.emplace(second_name, write_state.payload);
+
+  Ort::SessionOptions session_options;
+  session_options.SetEpContextDataReadFunc(LoadOpenVINOEpContextData, &read_state,
+                                           kOpenVINOEpContextTestMaxDataSize);
+  std::unordered_map<std::string, std::string> ov_options = {{"device_type", kDevice}};
+  session_options.AppendExecutionProvider_OpenVINO_V2(ov_options);
+
+  ASSERT_NO_THROW((Ort::Session(*ort_env, patched_model.c_str(), session_options)));
+  EXPECT_EQ(read_state.read_count, 2u);
+  EXPECT_THAT(read_state.read_names, testing::UnorderedElementsAre(write_state.name, second_name));
+}
+
+TEST_F(OVEPOVIRModelsExportEPContextTests, CompileApiWriteCallbackErrorDoesNotFallbackToDisk) {
+  const std::filesystem::path out_dir = std::filesystem::path("testdata") / "ovir_epctx_callback_error";
+  std::filesystem::remove_all(out_dir);
+  std::filesystem::create_directories(out_dir);
+  const std::filesystem::path epctx_model = out_dir / "mul_1_ovir_epctx_error.onnx";
+  auto cleanup = gsl::finally([&]() { std::filesystem::remove_all(out_dir); });
+
+  Ort::SessionOptions session_options;
+  std::unordered_map<std::string, std::string> ov_options = {{"device_type", kDevice}};
+  session_options.AppendExecutionProvider_OpenVINO_V2(ov_options);
+
+  OpenVINOEpContextCallbackState callback_state;
+  callback_state.fail_write = true;
+  Ort::ModelCompilationOptions compile_options(*ort_env, session_options);
+  compile_options.SetInputModelPath(kOvirModelPath);
+  compile_options.SetOutputModelPath(epctx_model.c_str());
+  compile_options.SetEpContextEmbedMode(false);
+  compile_options.SetEpContextDataWriteFunc(StoreOpenVINOEpContextData, &callback_state);
+
+  Ort::Status status = Ort::CompileModel(*ort_env, compile_options);
+  EXPECT_FALSE(status.IsOK());
+  EXPECT_EQ(status.GetErrorCode(), ORT_FAIL);
+  EXPECT_THAT(status.GetErrorMessage(),
+              testing::HasSubstr("synthetic OpenVINO EPContext write callback failure"));
+  EXPECT_TRUE(callback_state.write_called);
+  if (!callback_state.name.empty()) {
+    EXPECT_FALSE(std::filesystem::exists(epctx_model.parent_path() / callback_state.name));
+  }
+}
+
+TEST_F(OVEPOVIRModelsExportEPContextTests, EpContextCallbacksRejectSharedContexts) {
+  OpenVINOEpContextCallbackState callback_state;
+
+  {
+    Ort::SessionOptions session_options;
+    session_options.SetEpContextDataReadFunc(LoadOpenVINOEpContextData, &callback_state,
+                                             kOpenVINOEpContextTestMaxDataSize);
+    session_options.AddConfigEntry(kOrtSessionOptionShareEpContexts, "1");
+    std::unordered_map<std::string, std::string> ov_options = {{"device_type", kDevice}};
+    session_options.AppendExecutionProvider_OpenVINO_V2(ov_options);
+
+    std::string error;
+    try {
+      Ort::Session session(*ort_env, kOvirModelPath, session_options);
+      FAIL() << "Expected OpenVINO shared-context read callback rejection";
+    } catch (const Ort::Exception& ex) {
+      error = ex.what();
+    }
+    EXPECT_THAT(error,
+                testing::HasSubstr("OpenVINO shared EP contexts do not support EPContext data callbacks"));
+  }
+
+  {
+    const std::filesystem::path output_model =
+        std::filesystem::path("testdata") / "openvino_shared_context_callback_rejection.onnx";
+    std::filesystem::remove(output_model);
+    auto cleanup = gsl::finally([&]() { std::filesystem::remove(output_model); });
+
+    Ort::SessionOptions session_options;
+    session_options.AddConfigEntry(kOrtSessionOptionShareEpContexts, "1");
+    std::unordered_map<std::string, std::string> ov_options = {{"device_type", kDevice}};
+    session_options.AppendExecutionProvider_OpenVINO_V2(ov_options);
+
+    Ort::ModelCompilationOptions compile_options(*ort_env, session_options);
+    compile_options.SetInputModelPath(kOvirModelPath);
+    compile_options.SetOutputModelPath(output_model.c_str());
+    compile_options.SetEpContextDataWriteFunc(StoreOpenVINOEpContextData, &callback_state);
+
+    Ort::Status status = Ort::CompileModel(*ort_env, compile_options);
+    EXPECT_FALSE(status.IsOK());
+    EXPECT_THAT(status.GetErrorMessage(),
+                testing::HasSubstr("OpenVINO shared EP contexts do not support EPContext data callbacks"));
+    EXPECT_FALSE(std::filesystem::exists(output_model));
+  }
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/onnxruntime/test/providers/openvino/openvino_ep_context_test.cc
+++ b/onnxruntime/test/providers/openvino/openvino_ep_context_test.cc
@@ -125,7 +125,7 @@ OrtStatus* ORT_API_CALL LoadOpenVINOEpContextData(void* state, const char* name,
 
 std::string GetExternalEpContextDataName(const std::filesystem::path& model_path) {
   ONNX_NAMESPACE::ModelProto model_proto;
-  ORT_THROW_IF_ERROR(Model::Load(model_path, model_proto));
+  ORT_THROW_IF_ERROR(onnxruntime::Model::Load(model_path, model_proto));
   for (const auto& node : model_proto.graph().node()) {
     if (node.op_type() != "EPContext") {
       continue;
@@ -358,6 +358,62 @@ TEST_F(OVEPEPContextOVIRTests, RunEpCtxOvirModel) {
   // OVIR encapsulation detection).
   Ort::Session session(*ort_env, kOvirModelPath, session_options);
 
+  RunAndValidate(session);
+}
+
+TEST_F(OVEPEPContextOVIRTests, RunEpCtxOvirModelFromArray) {
+  std::ifstream model_stream(kOvirModelPath, std::ios::binary);
+  ASSERT_TRUE(model_stream);
+  const std::string model_data{std::istreambuf_iterator<char>{model_stream},
+                               std::istreambuf_iterator<char>{}};
+
+  Ort::SessionOptions session_options;
+  const std::filesystem::path absolute_model_path = std::filesystem::absolute(kOvirModelPath);
+  session_options.AddConfigEntry(kOrtSessionOptionEpContextFilePath, absolute_model_path.string().c_str());
+  std::unordered_map<std::string, std::string> ov_options = {{"device_type", kDevice}};
+  session_options.AppendExecutionProvider_OpenVINO_V2(ov_options);
+
+  Ort::Session session(*ort_env, model_data.data(), model_data.size(), session_options);
+  RunAndValidate(session);
+}
+
+TEST_F(OVEPEPContextOVIRTests, RunEpCtxOvirModelWithMixedCaseExtension) {
+  const std::filesystem::path out_dir = std::filesystem::path("testdata") / "ovir_epctx_mixed_case";
+  std::filesystem::remove_all(out_dir);
+  std::filesystem::create_directories(out_dir);
+  auto cleanup = gsl::finally([&]() { std::filesystem::remove_all(out_dir); });
+
+  const std::filesystem::path model_path = out_dir / "mixed_case.onnx";
+  const std::filesystem::path xml_path = out_dir / "mixed_case.XML";
+  const std::filesystem::path bin_path = out_dir / "mixed_case.bin";
+  std::filesystem::copy_file("testdata/mul_1_ep_ctx_ovir.xml", xml_path);
+  std::filesystem::copy_file("testdata/mul_1_ep_ctx_ovir.bin", bin_path);
+
+  ONNX_NAMESPACE::ModelProto model_proto;
+  ASSERT_STATUS_OK(Model::Load(kOvirModelPath, model_proto));
+  bool updated_context_name = false;
+  for (auto& node : *model_proto.mutable_graph()->mutable_node()) {
+    if (node.op_type() != "EPContext") {
+      continue;
+    }
+    for (auto& attribute : *node.mutable_attribute()) {
+      if (attribute.name() == "ep_cache_context") {
+        attribute.set_s(xml_path.filename().string());
+        updated_context_name = true;
+      }
+    }
+  }
+  ASSERT_TRUE(updated_context_name);
+  {
+    std::ofstream output_stream(model_path, std::ios::binary);
+    ASSERT_TRUE(output_stream);
+    ASSERT_TRUE(model_proto.SerializeToOstream(&output_stream));
+  }
+
+  Ort::SessionOptions session_options;
+  std::unordered_map<std::string, std::string> ov_options = {{"device_type", kDevice}};
+  session_options.AppendExecutionProvider_OpenVINO_V2(ov_options);
+  Ort::Session session(*ort_env, model_path.c_str(), session_options);
   RunAndValidate(session);
 }
 
@@ -620,98 +676,70 @@ TEST_F(OVEPOVIRModelsExportEPContextTests, CompileApiExternalDataUsesCallbacks) 
   EXPECT_TRUE(callback_state.read_called);
   EXPECT_EQ(callback_state.read_count, 4u);
   RunAndValidate(session);
+
+  ONNX_NAMESPACE::ModelProto model_proto;
+  ASSERT_STATUS_OK(Model::Load(epctx_model, model_proto));
+  const std::filesystem::path substring_model = out_dir / "native_callback_name.onnx";
+  const std::string substring_name = "native_callback_name.xml_native.bin";
+  bool updated_context_name = false;
+  for (auto& node : *model_proto.mutable_graph()->mutable_node()) {
+    if (node.op_type() != "EPContext") {
+      continue;
+    }
+    for (auto& attribute : *node.mutable_attribute()) {
+      if (attribute.name() == "ep_cache_context") {
+        attribute.set_s(substring_name);
+        updated_context_name = true;
+      }
+    }
+  }
+  ASSERT_TRUE(updated_context_name);
+  {
+    std::ofstream model_stream(substring_model, std::ios::binary);
+    ASSERT_TRUE(model_stream);
+    ASSERT_TRUE(model_proto.SerializeToOstream(&model_stream));
+  }
+
+  callback_state.name = substring_name;
+  callback_state.read_called = false;
+  ASSERT_NO_THROW((Ort::Session(*ort_env, substring_model.c_str(), session_options)));
+  EXPECT_TRUE(callback_state.read_called);
+  EXPECT_FALSE(std::filesystem::exists(substring_model.parent_path() / substring_name));
 }
 
-TEST_F(OVEPOVIRModelsExportEPContextTests, ReadCallbackRunsOncePerDistinctExternalName) {
+TEST_F(OVEPOVIRModelsExportEPContextTests, ReadCallbackUsesDistinctExternalNames) {
   const std::filesystem::path out_dir = std::filesystem::path("testdata") / "ovir_epctx_distinct_callbacks";
   std::filesystem::remove_all(out_dir);
   std::filesystem::create_directories(out_dir);
   auto cleanup = gsl::finally([&]() { std::filesystem::remove_all(out_dir); });
 
-  const std::filesystem::path epctx_model = out_dir / "mul_1_ovir_epctx.onnx";
-  OpenVINOEpContextCallbackState write_state;
-  {
+  const std::array<std::filesystem::path, 2> epctx_models = {
+      out_dir / "first_epctx.onnx",
+      out_dir / "second_epctx.onnx",
+  };
+  std::array<OpenVINOEpContextCallbackState, 2> write_states;
+  for (size_t i = 0; i < epctx_models.size(); ++i) {
     Ort::SessionOptions session_options;
     std::unordered_map<std::string, std::string> ov_options = {{"device_type", kDevice}};
     session_options.AppendExecutionProvider_OpenVINO_V2(ov_options);
 
     Ort::ModelCompilationOptions compile_options(*ort_env, session_options);
     compile_options.SetInputModelPath(kOvirModelPath);
-    compile_options.SetOutputModelPath(epctx_model.c_str());
+    compile_options.SetOutputModelPath(epctx_models[i].c_str());
     compile_options.SetEpContextEmbedMode(false);
-    compile_options.SetEpContextDataWriteFunc(StoreOpenVINOEpContextData, &write_state);
-    ASSERT_CXX_ORTSTATUS_OK(Ort::CompileModel(*ort_env, compile_options));
+    compile_options.SetEpContextDataWriteFunc(StoreOpenVINOEpContextData, &write_states[i]);
+    Ort::Status compile_status = Ort::CompileModel(*ort_env, compile_options);
+    ASSERT_TRUE(compile_status.IsOK()) << compile_status.GetErrorMessage();
   }
-  ASSERT_EQ(write_state.write_count, 1u);
-  ASSERT_FALSE(write_state.name.empty());
-  ASSERT_FALSE(write_state.payload.empty());
-
-  ONNX_NAMESPACE::ModelProto model_proto;
-  ASSERT_STATUS_OK(Model::Load(epctx_model, model_proto));
-  auto* graph = model_proto.mutable_graph();
-
-  ONNX_NAMESPACE::NodeProto original_context_node;
-  for (const auto& node : graph->node()) {
-    if (node.op_type() == "EPContext") {
-      original_context_node.CopyFrom(node);
-      break;
-    }
-  }
-  ASSERT_FALSE(original_context_node.op_type().empty());
-
-  std::vector<ONNX_NAMESPACE::ValueInfoProto> original_output_infos;
-  original_output_infos.reserve(original_context_node.output_size());
-  for (const auto& output_name : original_context_node.output()) {
-    const ONNX_NAMESPACE::ValueInfoProto* output_info = nullptr;
-    for (const auto& graph_output : graph->output()) {
-      if (graph_output.name() == output_name) {
-        output_info = &graph_output;
-        break;
-      }
-    }
-    ASSERT_NE(output_info, nullptr) << "Missing graph output type for " << output_name;
-    original_output_infos.push_back(*output_info);
-  }
-
-  const std::string second_name = "second_" + write_state.name;
-  auto add_context_clone = [&](const std::string& suffix, const std::string& context_name) {
-    auto* clone = graph->add_node();
-    clone->CopyFrom(original_context_node);
-    clone->set_name(original_context_node.name() + suffix);
-
-    bool updated_context_name = false;
-    for (auto& attribute : *clone->mutable_attribute()) {
-      if (attribute.name() == "main_context") {
-        attribute.set_i(0);
-      } else if (attribute.name() == "ep_cache_context") {
-        attribute.set_s(context_name);
-        updated_context_name = true;
-      }
-    }
-    ASSERT_TRUE(updated_context_name);
-
-    for (int output_index = 0; output_index < clone->output_size(); ++output_index) {
-      const std::string cloned_output_name = clone->output(output_index) + suffix;
-      clone->set_output(output_index, cloned_output_name);
-      auto* graph_output = graph->add_output();
-      graph_output->CopyFrom(original_output_infos[output_index]);
-      graph_output->set_name(cloned_output_name);
-    }
-  };
-
-  add_context_clone("_duplicate", write_state.name);
-  add_context_clone("_second", second_name);
-
-  const std::filesystem::path patched_model = out_dir / "mul_1_ovir_epctx_patched.onnx";
-  {
-    std::ofstream model_stream(patched_model, std::ios::binary);
-    ASSERT_TRUE(model_stream);
-    ASSERT_TRUE(model_proto.SerializeToOstream(&model_stream));
-  }
+  ASSERT_NE(write_states[0].name, write_states[1].name);
 
   OpenVINOEpContextCallbackState read_state;
-  read_state.payloads_by_name.emplace(write_state.name, write_state.payload);
-  read_state.payloads_by_name.emplace(second_name, write_state.payload);
+  for (const auto& write_state : write_states) {
+    ASSERT_EQ(write_state.write_count, 1u);
+    ASSERT_FALSE(write_state.name.empty());
+    ASSERT_FALSE(write_state.payload.empty());
+    read_state.payloads_by_name.emplace(write_state.name, write_state.payload);
+  }
 
   Ort::SessionOptions session_options;
   session_options.SetEpContextDataReadFunc(LoadOpenVINOEpContextData, &read_state,
@@ -719,9 +747,13 @@ TEST_F(OVEPOVIRModelsExportEPContextTests, ReadCallbackRunsOncePerDistinctExtern
   std::unordered_map<std::string, std::string> ov_options = {{"device_type", kDevice}};
   session_options.AppendExecutionProvider_OpenVINO_V2(ov_options);
 
-  ASSERT_NO_THROW((Ort::Session(*ort_env, patched_model.c_str(), session_options)));
+  for (const auto& epctx_model : epctx_models) {
+    ASSERT_NO_THROW((Ort::Session(*ort_env, epctx_model.c_str(), session_options)));
+  }
+
   EXPECT_EQ(read_state.read_count, 2u);
-  EXPECT_THAT(read_state.read_names, testing::UnorderedElementsAre(write_state.name, second_name));
+  EXPECT_THAT(read_state.read_names,
+              testing::UnorderedElementsAre(write_states[0].name, write_states[1].name));
 }
 
 TEST_F(OVEPOVIRModelsExportEPContextTests, CompileApiWriteCallbackErrorDoesNotFallbackToDisk) {


### PR DESCRIPTION
### Description

Adds OpenVINO production support for the stable EPContext named-buffer callbacks introduced by #32265.

- Routes native external compiled-blob writes and reads through application callbacks.
- Propagates callback failures without filesystem fallback or sidecar creation.
- Rejects callbacks with shared EP contexts and rejects OVIR read callbacks before filesystem fallback.
- Rejects empty and oversized callback payloads with `ORT_INVALID_ARGUMENT` before deserialization.
- Deserializes callback payloads once per distinct external logical name.
- Advertises OpenVINO READ/WRITE callback support.
- Adds provider-backed round-trip, embed bypass, exact invocation-count, size/error, distinct-name deduplication, sharing/OVIR rejection, and no-sidecar tests.

### Motivation and Context

This is an independent stacked provider-adoption PR based on #32265. The callback path lets applications keep native OpenVINO compiled blobs in encrypted or application-managed storage without creating plaintext fallback files.

### Testing

- Lintrunner passed on all changed OpenVINO files.
- Editor/compiler diagnostics are clean.
- `git diff --check` passed.
- OpenVINO provider execution tests are hardware/build-configuration gated and were not run in the local shared CPU build.