### PR TITLE
Add C# EPContext data callbacks

### DIFF
--- a/csharp/src/Microsoft.ML.OnnxRuntime/CompileModel.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/CompileModel.shared.cs
@@ -33,9 +33,13 @@ namespace Microsoft.ML.OnnxRuntime
         /// <param name="sessionOptions">SessionOptions instance to read settings from.</param>
         public OrtModelCompilationOptions(SessionOptions sessionOptions)
         {
-            NativeApiStatus.VerifySuccess(
-                NativeMethods.CompileApi.OrtCreateModelCompilationOptionsFromSessionOptions(
-                    OrtEnv.Instance().Handle, sessionOptions.Handle, out _handle));
+            _epContextDataReadRegistration =
+                sessionOptions.InvokeWithEpContextDataReadRegistration(sessionOptionsHandle =>
+                {
+                    NativeApiStatus.VerifySuccess(
+                        NativeMethods.CompileApi.OrtCreateModelCompilationOptionsFromSessionOptions(
+                            OrtEnv.Instance().Handle, sessionOptionsHandle, out _handle));
+                });
         }
 
         /// <summary>
@@ -43,7 +47,15 @@ namespace Microsoft.ML.OnnxRuntime
         /// </summary>
         public void CompileModel()
         {
-            NativeApiStatus.VerifySuccess(NativeMethods.CompileApi.OrtCompileModel(OrtEnv.Instance().Handle, _handle));
+            try
+            {
+                NativeApiStatus.VerifySuccess(
+                    NativeMethods.CompileApi.OrtCompileModel(OrtEnv.Instance().Handle, _handle));
+            }
+            finally
+            {
+                GC.KeepAlive(this);
+            }
         }
 
 
@@ -160,6 +172,61 @@ namespace Microsoft.ML.OnnxRuntime
         }
 
         /// <summary>
+        /// Delegate that receives one complete external EPContext payload during model compilation.
+        /// The data view is valid only for the duration of the delegate invocation.
+        /// </summary>
+        /// <param name="name">Logical UTF-8 name stored in the EPContext node.</param>
+        /// <param name="data">Non-owning view of the payload.</param>
+        /// <remarks>ORT may invoke this delegate concurrently. The application must synchronize shared state.</remarks>
+        public delegate void WriteEpContextDataDelegate(string name, OrtEpContextData data);
+
+        /// <summary>
+        /// Registers a delegate that receives external EPContext data when embed mode is disabled.
+        /// </summary>
+        public void SetEpContextDataWriteDelegate(WriteEpContextDataDelegate writeDelegate)
+        {
+            if (writeDelegate == null)
+            {
+                throw new ArgumentNullException(nameof(writeDelegate));
+            }
+
+            var newState = new DelegateResources<EpContextDataWriteConnector,
+                                                 CompileApi.NativeMethods.DOrtWriteNamedBufferDelegate>(
+                new EpContextDataWriteConnector(writeDelegate),
+                new CompileApi.NativeMethods.DOrtWriteNamedBufferDelegate(
+                    EpContextDataWriteConnector.WriteEpContextDataDelegateWrapper));
+
+            try
+            {
+                NativeApiStatus.VerifySuccess(
+                    NativeMethods.CompileApi.OrtModelCompilationOptions_SetEpContextDataWriteFunc(
+                        _handle,
+                        newState.GetFunctionPointerForDelegate(),
+                        newState.GetConnectorHandleAsPointer()));
+            }
+            catch
+            {
+                newState.Dispose();
+                throw;
+            }
+
+            _epContextDataWriteDelegateState?.Dispose();
+            _epContextDataWriteDelegateState = newState;
+        }
+
+        /// <summary>
+        /// Clears a previously registered EPContext data write delegate.
+        /// </summary>
+        public void ClearEpContextDataWriteDelegate()
+        {
+            NativeApiStatus.VerifySuccess(
+                NativeMethods.CompileApi.OrtModelCompilationOptions_SetEpContextDataWriteFunc(
+                    _handle, IntPtr.Zero, IntPtr.Zero));
+            _epContextDataWriteDelegateState?.Dispose();
+            _epContextDataWriteDelegateState = null;
+        }
+
+        /// <summary>
         /// Delegate to write/save a buffer containing ONNX model bytes to a custom destination. The delegate
         /// may be called repeatedly until the entire output model has been written out. Each call to the delegate
         /// is expected to consume the entire buffer.
@@ -241,6 +308,42 @@ namespace Microsoft.ML.OnnxRuntime
         }
 
         #region Delegate helpers
+        private sealed class EpContextDataWriteConnector
+        {
+            internal EpContextDataWriteConnector(WriteEpContextDataDelegate writeDelegate)
+            {
+                _writeDelegate = writeDelegate;
+            }
+
+            internal static IntPtr WriteEpContextDataDelegateWrapper(
+                IntPtr state, IntPtr name, IntPtr buffer, UIntPtr bufferSize)
+            {
+                try
+                {
+                    var connector = (EpContextDataWriteConnector)GCHandle.FromIntPtr(state).Target;
+                    string dataName = NativeOnnxValueHelper.StringFromNativeUtf8(name);
+                    var data = new OrtEpContextData(buffer, bufferSize);
+                    try
+                    {
+                        connector._writeDelegate(dataName, data);
+                    }
+                    finally
+                    {
+                        data.Invalidate();
+                    }
+                    return IntPtr.Zero;
+                }
+                catch (Exception ex)
+                {
+                    string error = $"The C# EPContext data write delegate threw an exception: {ex.Message}";
+                    return NativeMethods.OrtCreateStatus(
+                        (uint)ErrorCode.Fail, NativeOnnxValueHelper.StringToZeroTerminatedUtf8(error));
+                }
+            }
+
+            private readonly WriteEpContextDataDelegate _writeDelegate;
+        }
+
         /// <summary>
         /// Class to bridge the C# and native worlds for the "write buffer to destination" delegate
         /// </summary>
@@ -461,15 +564,23 @@ namespace Microsoft.ML.OnnxRuntime
                 return;
             }
 
+            Debug.Assert(_handle != IntPtr.Zero);
+            NativeMethods.CompileApi.OrtReleaseModelCompilationOptions(_handle);
+            _handle = IntPtr.Zero;
+
+            if (_epContextDataReadRegistration != null)
+            {
+                _epContextDataReadRegistration.Release();
+                _epContextDataReadRegistration = null;
+            }
+
             if (disposing)
             {
+                _epContextDataWriteDelegateState?.Dispose();
                 _writeBufferToDestinationDelegateState?.Dispose();
                 _getInitializerLocationDelegateState?.Dispose();
             }
 
-            Debug.Assert(_handle != IntPtr.Zero);
-            NativeMethods.CompileApi.OrtReleaseModelCompilationOptions(_handle);
-            _handle = IntPtr.Zero;
             _disposed = true;
         }
 
@@ -492,11 +603,19 @@ namespace Microsoft.ML.OnnxRuntime
         /// </summary>
         private bool _disposed = false;
 
+        private SessionOptions.EpContextDataReadRegistration _epContextDataReadRegistration = null;
+
         /// <summary>
         /// Stores delegate state for the "write buffer to destination" delegate.
         /// </summary>
         private DelegateResources<WriteBufferToDestinationConnector, NativeMethods.DOrtWriteBufferToDestinationDelegate>
             _writeBufferToDestinationDelegateState = null;
+
+        /// <summary>
+        /// Stores delegate state for the EPContext data write delegate.
+        /// </summary>
+        private DelegateResources<EpContextDataWriteConnector, CompileApi.NativeMethods.DOrtWriteNamedBufferDelegate>
+            _epContextDataWriteDelegateState = null;
 
         /// <summary>
         /// Stores delegate state for the "get initializer location" delegate.

--- a/csharp/src/Microsoft.ML.OnnxRuntime/CompileModel.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/CompileModel.shared.cs
@@ -47,6 +47,13 @@ namespace Microsoft.ML.OnnxRuntime
         /// </summary>
         public void CompileModel()
         {
+            EpContextDataWriteRegistration writeRegistration;
+            lock (_epContextDataWriteRegistrationLock)
+            {
+                writeRegistration = _epContextDataWriteRegistration;
+                writeRegistration?.AddRef();
+            }
+
             try
             {
                 NativeApiStatus.VerifySuccess(
@@ -54,6 +61,7 @@ namespace Microsoft.ML.OnnxRuntime
             }
             finally
             {
+                writeRegistration?.Release();
                 GC.KeepAlive(this);
             }
         }
@@ -190,28 +198,29 @@ namespace Microsoft.ML.OnnxRuntime
                 throw new ArgumentNullException(nameof(writeDelegate));
             }
 
-            var newState = new DelegateResources<EpContextDataWriteConnector,
-                                                 CompileApi.NativeMethods.DOrtWriteNamedBufferDelegate>(
-                new EpContextDataWriteConnector(writeDelegate),
-                new CompileApi.NativeMethods.DOrtWriteNamedBufferDelegate(
-                    EpContextDataWriteConnector.WriteEpContextDataDelegateWrapper));
+            var newRegistration = new EpContextDataWriteRegistration(writeDelegate);
+            EpContextDataWriteRegistration previousRegistration;
 
             try
             {
-                NativeApiStatus.VerifySuccess(
-                    NativeMethods.CompileApi.OrtModelCompilationOptions_SetEpContextDataWriteFunc(
-                        _handle,
-                        newState.GetFunctionPointerForDelegate(),
-                        newState.GetConnectorHandleAsPointer()));
+                lock (_epContextDataWriteRegistrationLock)
+                {
+                    NativeApiStatus.VerifySuccess(
+                        NativeMethods.CompileApi.OrtModelCompilationOptions_SetEpContextDataWriteFunc(
+                            _handle,
+                            newRegistration.FunctionPointer,
+                            newRegistration.State));
+                    previousRegistration = _epContextDataWriteRegistration;
+                    _epContextDataWriteRegistration = newRegistration;
+                }
             }
             catch
             {
-                newState.Dispose();
+                newRegistration.Dispose();
                 throw;
             }
 
-            _epContextDataWriteDelegateState?.Dispose();
-            _epContextDataWriteDelegateState = newState;
+            previousRegistration?.Dispose();
         }
 
         /// <summary>
@@ -219,11 +228,17 @@ namespace Microsoft.ML.OnnxRuntime
         /// </summary>
         public void ClearEpContextDataWriteDelegate()
         {
-            NativeApiStatus.VerifySuccess(
-                NativeMethods.CompileApi.OrtModelCompilationOptions_SetEpContextDataWriteFunc(
-                    _handle, IntPtr.Zero, IntPtr.Zero));
-            _epContextDataWriteDelegateState?.Dispose();
-            _epContextDataWriteDelegateState = null;
+            EpContextDataWriteRegistration previousRegistration;
+            lock (_epContextDataWriteRegistrationLock)
+            {
+                NativeApiStatus.VerifySuccess(
+                    NativeMethods.CompileApi.OrtModelCompilationOptions_SetEpContextDataWriteFunc(
+                        _handle, IntPtr.Zero, IntPtr.Zero));
+                previousRegistration = _epContextDataWriteRegistration;
+                _epContextDataWriteRegistration = null;
+            }
+
+            previousRegistration?.Dispose();
         }
 
         /// <summary>
@@ -342,6 +357,74 @@ namespace Microsoft.ML.OnnxRuntime
             }
 
             private readonly WriteEpContextDataDelegate _writeDelegate;
+        }
+
+        private sealed class EpContextDataWriteRegistration : IDisposable
+        {
+            internal EpContextDataWriteRegistration(WriteEpContextDataDelegate writeDelegate)
+            {
+                _connector = new EpContextDataWriteConnector(writeDelegate);
+                _nativeDelegate = new CompileApi.NativeMethods.DOrtWriteNamedBufferDelegate(
+                    EpContextDataWriteConnector.WriteEpContextDataDelegateWrapper);
+                _connectorHandle = GCHandle.Alloc(_connector);
+                try
+                {
+                    FunctionPointer = Marshal.GetFunctionPointerForDelegate(_nativeDelegate);
+                    State = GCHandle.ToIntPtr(_connectorHandle);
+                }
+                catch
+                {
+                    _connectorHandle.Free();
+                    throw;
+                }
+            }
+
+            internal IntPtr FunctionPointer { get; }
+
+            internal IntPtr State { get; }
+
+            internal void AddRef()
+            {
+                System.Threading.Interlocked.Increment(ref _referenceCount);
+            }
+
+            internal void Release()
+            {
+                if (System.Threading.Interlocked.Decrement(ref _referenceCount) == 0)
+                {
+                    if (_connectorHandle.IsAllocated)
+                    {
+                        _connectorHandle.Free();
+                    }
+
+                    _connector = null;
+                    _nativeDelegate = null;
+                }
+            }
+
+            public void Dispose()
+            {
+                if (System.Threading.Interlocked.Exchange(ref _ownerReleased, 1) == 0)
+                {
+                    Release();
+                }
+
+                GC.SuppressFinalize(this);
+            }
+
+            ~EpContextDataWriteRegistration()
+            {
+                if (System.Threading.Interlocked.Exchange(ref _ownerReleased, 1) == 0)
+                {
+                    Release();
+                }
+            }
+
+            private EpContextDataWriteConnector _connector;
+            private CompileApi.NativeMethods.DOrtWriteNamedBufferDelegate _nativeDelegate;
+            private GCHandle _connectorHandle;
+            private int _referenceCount = 1;
+            private int _ownerReleased;
         }
 
         /// <summary>
@@ -574,9 +657,16 @@ namespace Microsoft.ML.OnnxRuntime
                 _epContextDataReadRegistration = null;
             }
 
+            EpContextDataWriteRegistration writeRegistration;
+            lock (_epContextDataWriteRegistrationLock)
+            {
+                writeRegistration = _epContextDataWriteRegistration;
+                _epContextDataWriteRegistration = null;
+            }
+            writeRegistration?.Dispose();
+
             if (disposing)
             {
-                _epContextDataWriteDelegateState?.Dispose();
                 _writeBufferToDestinationDelegateState?.Dispose();
                 _getInitializerLocationDelegateState?.Dispose();
             }
@@ -611,11 +701,8 @@ namespace Microsoft.ML.OnnxRuntime
         private DelegateResources<WriteBufferToDestinationConnector, NativeMethods.DOrtWriteBufferToDestinationDelegate>
             _writeBufferToDestinationDelegateState = null;
 
-        /// <summary>
-        /// Stores delegate state for the EPContext data write delegate.
-        /// </summary>
-        private DelegateResources<EpContextDataWriteConnector, CompileApi.NativeMethods.DOrtWriteNamedBufferDelegate>
-            _epContextDataWriteDelegateState = null;
+        private readonly object _epContextDataWriteRegistrationLock = new object();
+        private EpContextDataWriteRegistration _epContextDataWriteRegistration = null;
 
         /// <summary>
         /// Stores delegate state for the "get initializer location" delegate.

--- a/csharp/src/Microsoft.ML.OnnxRuntime/EpContextData.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/EpContextData.shared.cs
@@ -1,0 +1,280 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Microsoft.ML.OnnxRuntime
+{
+    /// <summary>
+    /// A non-owning view of named EPContext data passed to a write delegate.
+    /// The view is valid only for the duration of the delegate invocation.
+    /// </summary>
+    public sealed class OrtEpContextData
+    {
+        internal OrtEpContextData(IntPtr pointer, UIntPtr size)
+        {
+            _pointer = pointer;
+            Size = size.ToUInt64();
+            _isValid = true;
+        }
+
+        /// <summary>
+        /// Size of the data in bytes.
+        /// </summary>
+        public ulong Size { get; }
+
+        /// <summary>
+        /// Returns all data as a read-only span. For data larger than <see cref="int.MaxValue"/>,
+        /// use <see cref="GetSpan(ulong, int)"/> to process it in chunks.
+        /// </summary>
+        public ReadOnlySpan<byte> GetSpan()
+        {
+            ThrowIfInvalid();
+            if (Size > int.MaxValue)
+            {
+                throw new InvalidOperationException("EPContext data is too large for a single Span<byte>. Read it in chunks.");
+            }
+
+            return GetSpan(0, checked((int)Size));
+        }
+
+        /// <summary>
+        /// Returns a read-only span for a range of the data.
+        /// </summary>
+        /// <param name="offset">Byte offset into the data.</param>
+        /// <param name="length">Number of bytes in the returned span.</param>
+        public unsafe ReadOnlySpan<byte> GetSpan(ulong offset, int length)
+        {
+            ThrowIfInvalid();
+            ValidateRange(offset, length);
+            if (length == 0)
+            {
+                return ReadOnlySpan<byte>.Empty;
+            }
+
+            return new ReadOnlySpan<byte>(AddOffset(_pointer, offset).ToPointer(), length);
+        }
+
+        internal void Invalidate()
+        {
+            _isValid = false;
+            _pointer = IntPtr.Zero;
+        }
+
+        internal static IntPtr AddOffset(IntPtr pointer, ulong offset)
+        {
+            if (UIntPtr.Size == 4)
+            {
+                ulong address = unchecked((uint)pointer.ToInt32());
+                if (offset > uint.MaxValue || address + offset > uint.MaxValue)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(offset));
+                }
+
+                return new IntPtr(unchecked((int)(uint)(address + offset)));
+            }
+
+            ulong address64 = unchecked((ulong)pointer.ToInt64());
+            if (offset > ulong.MaxValue - address64)
+            {
+                throw new ArgumentOutOfRangeException(nameof(offset));
+            }
+
+            return new IntPtr(unchecked((long)(address64 + offset)));
+        }
+
+        private void ThrowIfInvalid()
+        {
+            if (!_isValid)
+            {
+                throw new ObjectDisposedException(nameof(OrtEpContextData),
+                    "EPContext data is valid only during the write delegate invocation.");
+            }
+        }
+
+        private void ValidateRange(ulong offset, int length)
+        {
+            if (length < 0 || offset > Size || (ulong)length > Size - offset)
+            {
+                throw new ArgumentOutOfRangeException(nameof(length));
+            }
+
+            if (length != 0 && _pointer == IntPtr.Zero)
+            {
+                throw new InvalidOperationException("EPContext data has a null buffer for a non-empty range.");
+            }
+        }
+
+        private IntPtr _pointer;
+        private bool _isValid;
+    }
+
+    /// <summary>
+    /// Allocator-backed output supplied to an EPContext read delegate.
+    /// Allocate and fill the buffer during the delegate invocation. On success, ownership is transferred to ORT.
+    /// </summary>
+    public sealed class OrtEpContextDataBuffer : IDisposable
+    {
+        internal OrtEpContextDataBuffer(IntPtr allocator, ulong maxDataSize)
+        {
+            _allocator = new OrtAllocator(allocator, false);
+            _maxDataSize = maxDataSize;
+        }
+
+        /// <summary>
+        /// Size of the allocated buffer in bytes.
+        /// </summary>
+        public ulong Size { get; private set; }
+
+        /// <summary>
+        /// Whether the delegate has allocated an output buffer. A zero-byte allocation is valid.
+        /// </summary>
+        public bool IsAllocated { get; private set; }
+
+        /// <summary>
+        /// Allocates an output buffer and returns it as a writable span.
+        /// For buffers larger than <see cref="int.MaxValue"/>, use <see cref="Allocate(ulong)"/>
+        /// followed by chunked calls to <see cref="GetSpan(ulong, int)"/>.
+        /// </summary>
+        public Span<byte> Allocate(int size)
+        {
+            if (size < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(size));
+            }
+
+            Allocate((ulong)size);
+            return GetSpan();
+        }
+
+        /// <summary>
+        /// Allocates an output buffer of the requested size.
+        /// </summary>
+        public void Allocate(ulong size)
+        {
+            ThrowIfDisposed();
+            if (IsAllocated)
+            {
+                throw new InvalidOperationException("The EPContext data buffer has already been allocated.");
+            }
+
+            if (size > _maxDataSize)
+            {
+                throw new ArgumentOutOfRangeException(nameof(size), "EPContext data exceeds the configured maximum size.");
+            }
+
+            UIntPtr nativeSize = ToUIntPtr(size);
+            IntPtr pointer = IntPtr.Zero;
+            if (size != 0)
+            {
+                NativeApiStatus.VerifySuccess(NativeMethods.OrtAllocatorAlloc(_allocator.Pointer, nativeSize, out pointer));
+                if (pointer == IntPtr.Zero)
+                {
+                    throw new InvalidOperationException("The ORT allocator returned a null pointer for a non-empty allocation.");
+                }
+            }
+
+            _pointer = pointer;
+            Size = size;
+            IsAllocated = true;
+        }
+
+        /// <summary>
+        /// Returns the entire allocated buffer as a writable span.
+        /// </summary>
+        public Span<byte> GetSpan()
+        {
+            if (Size > int.MaxValue)
+            {
+                throw new InvalidOperationException("EPContext data is too large for a single Span<byte>. Fill it in chunks.");
+            }
+
+            return GetSpan(0, checked((int)Size));
+        }
+
+        /// <summary>
+        /// Returns a writable span for a range of the allocated buffer.
+        /// </summary>
+        public unsafe Span<byte> GetSpan(ulong offset, int length)
+        {
+            ThrowIfDisposed();
+            if (!IsAllocated)
+            {
+                throw new InvalidOperationException("Allocate must be called before accessing the EPContext data buffer.");
+            }
+
+            if (length < 0 || offset > Size || (ulong)length > Size - offset)
+            {
+                throw new ArgumentOutOfRangeException(nameof(length));
+            }
+
+            if (length == 0)
+            {
+                return Span<byte>.Empty;
+            }
+
+            return new Span<byte>(OrtEpContextData.AddOffset(_pointer, offset).ToPointer(), length);
+        }
+
+        internal void Detach(out IntPtr pointer, out UIntPtr size)
+        {
+            ThrowIfDisposed();
+            if (!IsAllocated)
+            {
+                throw new InvalidOperationException("The EPContext data read delegate must allocate its output buffer.");
+            }
+
+            pointer = _pointer;
+            size = ToUIntPtr(Size);
+            _pointer = IntPtr.Zero;
+            _disposed = true;
+            _allocator.Dispose();
+            _allocator = null;
+        }
+
+        /// <summary>
+        /// Releases an allocation that was not transferred to ORT because the delegate failed.
+        /// </summary>
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            if (_pointer != IntPtr.Zero)
+            {
+                _allocator.FreeMemory(_pointer);
+                _pointer = IntPtr.Zero;
+            }
+
+            _allocator.Dispose();
+            _allocator = null;
+            _disposed = true;
+            GC.SuppressFinalize(this);
+        }
+
+        private static UIntPtr ToUIntPtr(ulong value)
+        {
+            if (UIntPtr.Size == 4 && value > uint.MaxValue)
+            {
+                throw new ArgumentOutOfRangeException(nameof(value));
+            }
+
+            return new UIntPtr(value);
+        }
+
+        private void ThrowIfDisposed()
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(OrtEpContextDataBuffer));
+            }
+        }
+
+        private OrtAllocator _allocator;
+        private readonly ulong _maxDataSize;
+        private IntPtr _pointer;
+        private bool _disposed;
+    }
+}

--- a/csharp/src/Microsoft.ML.OnnxRuntime/InferenceSession.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/InferenceSession.shared.cs
@@ -61,6 +61,7 @@ namespace Microsoft.ML.OnnxRuntime
         private List<IntPtr> _namesMemoryPtrs;
 
         private SessionOptions _builtInSessionOptions = null;
+        private SessionOptions.EpContextDataReadRegistration _epContextDataReadRegistration = null;
         private RunOptions _builtInRunOptions = null;
         private ModelMetadata _modelMetadata = null;
         private bool _disposed = false;
@@ -1323,20 +1324,24 @@ namespace Microsoft.ML.OnnxRuntime
         private void Init(string modelPath, SessionOptions options,
                           PrePackedWeightsContainer prepackedWeightsContainer = null)
         {
-            var envHandle = OrtEnv.Instance().Handle;
-            IntPtr session;
-            if (prepackedWeightsContainer == null)
+            IntPtr session = IntPtr.Zero;
+            _epContextDataReadRegistration =
+                options.InvokeWithEpContextDataReadRegistration(optionsHandle =>
             {
-                NativeApiStatus.VerifySuccess(NativeMethods.OrtCreateSession(envHandle, NativeOnnxValueHelper.GetPlatformSerializedString(modelPath),
-                options.Handle, out session));
-            }
+                var envHandle = OrtEnv.Instance().Handle;
+                if (prepackedWeightsContainer == null)
+                {
+                    NativeApiStatus.VerifySuccess(NativeMethods.OrtCreateSession(envHandle, NativeOnnxValueHelper.GetPlatformSerializedString(modelPath),
+                    optionsHandle, out session));
+                }
 
-            else
-            {
-                NativeApiStatus.VerifySuccess(NativeMethods.OrtCreateSessionWithPrepackedWeightsContainer(
-                    envHandle, NativeOnnxValueHelper.GetPlatformSerializedString(modelPath),
-                    options.Handle, prepackedWeightsContainer.Pointer, out session));
-            }
+                else
+                {
+                    NativeApiStatus.VerifySuccess(NativeMethods.OrtCreateSessionWithPrepackedWeightsContainer(
+                        envHandle, NativeOnnxValueHelper.GetPlatformSerializedString(modelPath),
+                        optionsHandle, prepackedWeightsContainer.Pointer, out session));
+                }
+            });
 
             InitWithSessionHandle(session);
         }
@@ -1344,23 +1349,37 @@ namespace Microsoft.ML.OnnxRuntime
         private void Init(byte[] modelData, SessionOptions options,
                           PrePackedWeightsContainer prepackedWeightsContainer = null)
         {
-            var envHandle = OrtEnv.Instance().Handle;
-            IntPtr session;
-            if (prepackedWeightsContainer == null)
+            IntPtr session = IntPtr.Zero;
+            _epContextDataReadRegistration =
+                options.InvokeWithEpContextDataReadRegistration(optionsHandle =>
             {
+                var envHandle = OrtEnv.Instance().Handle;
+                if (prepackedWeightsContainer == null)
+                {
 
-                NativeApiStatus.VerifySuccess(NativeMethods.OrtCreateSessionFromArray(envHandle, modelData, (UIntPtr)modelData.Length, options.Handle, out session));
-            }
+                    NativeApiStatus.VerifySuccess(NativeMethods.OrtCreateSessionFromArray(
+                        envHandle, modelData, (UIntPtr)modelData.Length, optionsHandle, out session));
+                }
 
-            else
-            {
-                NativeApiStatus.VerifySuccess(NativeMethods.OrtCreateSessionFromArrayWithPrepackedWeightsContainer(
-                    envHandle, modelData, (UIntPtr)modelData.Length, options.Handle, prepackedWeightsContainer.Pointer,
-                    out session));
-
-            }
+                else
+                {
+                    NativeApiStatus.VerifySuccess(NativeMethods.OrtCreateSessionFromArrayWithPrepackedWeightsContainer(
+                        envHandle, modelData, (UIntPtr)modelData.Length, optionsHandle,
+                        prepackedWeightsContainer.Pointer,
+                        out session));
+                }
+            });
 
             InitWithSessionHandle(session);
+        }
+
+        private void ReleaseEpContextDataReadDelegate()
+        {
+            if (_epContextDataReadRegistration != null)
+            {
+                _epContextDataReadRegistration.Release();
+                _epContextDataReadRegistration = null;
+            }
         }
 
         /// <summary>
@@ -1731,6 +1750,7 @@ namespace Microsoft.ML.OnnxRuntime
                 NativeMethods.OrtReleaseSession(_nativeHandle);
                 _nativeHandle = IntPtr.Zero;
             }
+            ReleaseEpContextDataReadDelegate();
             _disposed = true;
         }
 

--- a/csharp/src/Microsoft.ML.OnnxRuntime/NativeCompileApiMethods.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/NativeCompileApiMethods.shared.cs
@@ -26,6 +26,8 @@ namespace Microsoft.ML.OnnxRuntime.CompileApi
         public IntPtr ModelCompilationOptions_SetOutputModelWriteFunc;
         public IntPtr ModelCompilationOptions_SetOutputModelGetInitializerLocationFunc;
         public IntPtr ModelCompilationOptions_SetInputModel;
+        public IntPtr ModelCompilationOptions_SetWeightlessEnabled;
+        public IntPtr ModelCompilationOptions_SetEpContextDataWriteFunc;
     }
 
     internal class NativeMethods
@@ -143,15 +145,25 @@ namespace Microsoft.ML.OnnxRuntime.CompileApi
             IntPtr /* const OrtModel* */ inputModel);
         public DOrtModelCompilationOptions_SetInputModel OrtModelCompilationOptions_SetInputModel;
 
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+        public delegate IntPtr /* OrtStatus* */ DOrtWriteNamedBufferDelegate(
+            IntPtr /* void* */ state,
+            IntPtr /* const char* */ name,
+            IntPtr /* const void* */ buffer,
+            UIntPtr /* size_t */ bufferSize);
+
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+        public delegate IntPtr /* OrtStatus* */ DOrtModelCompilationOptions_SetEpContextDataWriteFunc(
+            IntPtr /* OrtModelCompilationOptions* */ options,
+            IntPtr /* DOrtWriteNamedBufferDelegate */ writeFunc,
+            IntPtr /* void* */ state);
+        public DOrtModelCompilationOptions_SetEpContextDataWriteFunc
+            OrtModelCompilationOptions_SetEpContextDataWriteFunc;
+
         internal NativeMethods(OnnxRuntime.NativeMethods.DOrtGetCompileApi getCompileApi)
         {
-
-#if NETSTANDARD2_0
             IntPtr compileApiPtr = getCompileApi();
             _compileApi = (OrtCompileApi)Marshal.PtrToStructure(compileApiPtr, typeof(OrtCompileApi));
-#else
-            _compileApi = (OrtCompileApi)getCompileApi();
-#endif
 
             OrtReleaseModelCompilationOptions =
                 (DOrtReleaseModelCompilationOptions)Marshal.GetDelegateForFunctionPointer(
@@ -228,6 +240,11 @@ namespace Microsoft.ML.OnnxRuntime.CompileApi
                 (DOrtModelCompilationOptions_SetInputModel)Marshal.GetDelegateForFunctionPointer(
                     _compileApi.ModelCompilationOptions_SetInputModel,
                     typeof(DOrtModelCompilationOptions_SetInputModel));
+
+            OrtModelCompilationOptions_SetEpContextDataWriteFunc =
+                (DOrtModelCompilationOptions_SetEpContextDataWriteFunc)Marshal.GetDelegateForFunctionPointer(
+                    _compileApi.ModelCompilationOptions_SetEpContextDataWriteFunc,
+                    typeof(DOrtModelCompilationOptions_SetEpContextDataWriteFunc));
 
         }
     }

--- a/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.shared.cs
@@ -495,6 +495,9 @@ namespace Microsoft.ML.OnnxRuntime
         public IntPtr SessionOptionsSetWeightlessSourceModelBuffer;
         // v1.30 APIs
         public IntPtr SessionOptionsSetEpContextDataReadFunc;
+        public IntPtr CreateEpContextDataReadOptions;
+        public IntPtr EpContextDataReadOptionsSetMaxDataSize;
+        public IntPtr ReleaseEpContextDataReadOptions;
     }
 
     internal static class NativeMethods
@@ -605,6 +608,18 @@ namespace Microsoft.ML.OnnxRuntime
                 (DOrtSessionOptionsSetEpContextDataReadFunc)Marshal.GetDelegateForFunctionPointer(
                     api_.SessionOptionsSetEpContextDataReadFunc,
                     typeof(DOrtSessionOptionsSetEpContextDataReadFunc));
+            OrtCreateEpContextDataReadOptions =
+                (DOrtCreateEpContextDataReadOptions)Marshal.GetDelegateForFunctionPointer(
+                    api_.CreateEpContextDataReadOptions,
+                    typeof(DOrtCreateEpContextDataReadOptions));
+            OrtEpContextDataReadOptionsSetMaxDataSize =
+                (DOrtEpContextDataReadOptionsSetMaxDataSize)Marshal.GetDelegateForFunctionPointer(
+                    api_.EpContextDataReadOptionsSetMaxDataSize,
+                    typeof(DOrtEpContextDataReadOptionsSetMaxDataSize));
+            OrtReleaseEpContextDataReadOptions =
+                (DOrtReleaseEpContextDataReadOptions)Marshal.GetDelegateForFunctionPointer(
+                    api_.ReleaseEpContextDataReadOptions,
+                    typeof(DOrtReleaseEpContextDataReadOptions));
             OrtSetOptimizedModelFilePath = (DOrtSetOptimizedModelFilePath)Marshal.GetDelegateForFunctionPointer(api_.SetOptimizedModelFilePath, typeof(DOrtSetOptimizedModelFilePath));
             OrtEnableProfiling = (DOrtEnableProfiling)Marshal.GetDelegateForFunctionPointer(api_.EnableProfiling, typeof(DOrtEnableProfiling));
             OrtDisableProfiling = (DOrtDisableProfiling)Marshal.GetDelegateForFunctionPointer(api_.DisableProfiling, typeof(DOrtDisableProfiling));
@@ -1637,13 +1652,6 @@ namespace Microsoft.ML.OnnxRuntime
                                                                         bool value);
         public static DOrtSessionOptionsSetLoadCancellationFlag OrtSessionOptionsSetLoadCancellationFlag;
 
-        [StructLayout(LayoutKind.Sequential)]
-        internal struct OrtEpContextDataReadOptions
-        {
-            internal uint Version;
-            internal UIntPtr MaxDataSize;
-        }
-
         [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         public delegate IntPtr /* OrtStatus* */ DOrtReadNamedBufferDelegate(
             IntPtr /* void* */ state,
@@ -1659,6 +1667,22 @@ namespace Microsoft.ML.OnnxRuntime
             IntPtr /* void* */ state,
             IntPtr /* const OrtEpContextDataReadOptions* */ readOptions);
         public static DOrtSessionOptionsSetEpContextDataReadFunc OrtSessionOptionsSetEpContextDataReadFunc;
+
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+        public delegate IntPtr /* OrtStatus* */ DOrtCreateEpContextDataReadOptions(
+            out IntPtr /* OrtEpContextDataReadOptions** */ readOptions);
+        public static DOrtCreateEpContextDataReadOptions OrtCreateEpContextDataReadOptions;
+
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+        public delegate IntPtr /* OrtStatus* */ DOrtEpContextDataReadOptionsSetMaxDataSize(
+            IntPtr /* OrtEpContextDataReadOptions* */ readOptions,
+            UIntPtr /* size_t */ maxDataSize);
+        public static DOrtEpContextDataReadOptionsSetMaxDataSize OrtEpContextDataReadOptionsSetMaxDataSize;
+
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+        public delegate void DOrtReleaseEpContextDataReadOptions(
+            IntPtr /* OrtEpContextDataReadOptions* */ readOptions);
+        public static DOrtReleaseEpContextDataReadOptions OrtReleaseEpContextDataReadOptions;
 
 
         [UnmanagedFunctionPointer(CallingConvention.Winapi)]

--- a/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.shared.cs
@@ -482,6 +482,19 @@ namespace Microsoft.ML.OnnxRuntime
         // v1.25 APIs
         public IntPtr RunOptionsEnableProfiling;
         public IntPtr RunOptionsDisableProfiling;
+        public IntPtr KernelInfoGetAttributeArray_string;
+        public IntPtr SetPerSessionThreadPoolCallbacks;
+        // v1.27 APIs
+        public IntPtr GetMemPatternEnabled;
+        public IntPtr GetSessionExecutionMode;
+        public IntPtr SessionReleaseCapturedGraph;
+        // v1.28 APIs
+        public IntPtr GetExperimentalFunction;
+        public IntPtr KernelContext_GetSyncStream;
+        // v1.29 APIs
+        public IntPtr SessionOptionsSetWeightlessSourceModelBuffer;
+        // v1.30 APIs
+        public IntPtr SessionOptionsSetEpContextDataReadFunc;
     }
 
     internal static class NativeMethods
@@ -490,13 +503,8 @@ namespace Microsoft.ML.OnnxRuntime
 
         static internal CompileApi.NativeMethods CompileApi;
 
-#if NETSTANDARD2_0
         [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         public delegate IntPtr DOrtGetApi(UInt32 version);
-#else
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        public delegate ref OrtApi DOrtGetApi(UInt32 version);
-#endif
 
         [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         public delegate IntPtr DOrtGetVersionString();
@@ -527,24 +535,25 @@ namespace Microsoft.ML.OnnxRuntime
             }
 #endif
 
-#if NETSTANDARD2_0
-            IntPtr ortApiBasePtr = OrtGetApiBase();
+            IntPtr ortApiBasePtr = OrtGetApiBasePointer();
+            if (ortApiBasePtr == IntPtr.Zero)
+            {
+                throw new InvalidOperationException("OrtGetApiBase returned a null pointer.");
+            }
+
             OrtApiBase ortApiBase = (OrtApiBase)Marshal.PtrToStructure(ortApiBasePtr, typeof(OrtApiBase));
             DOrtGetApi OrtGetApi = (DOrtGetApi)Marshal.GetDelegateForFunctionPointer(ortApiBase.GetApi, typeof(DOrtGetApi));
-#else
-            DOrtGetApi OrtGetApi = (DOrtGetApi)Marshal.GetDelegateForFunctionPointer(OrtGetApiBase().GetApi, typeof(DOrtGetApi));
-#endif
 
-            const uint ORT_API_VERSION = 14;
-#if NETSTANDARD2_0
+            const uint ORT_API_VERSION = 30;
             IntPtr ortApiPtr = OrtGetApi(ORT_API_VERSION);
+            if (ortApiPtr == IntPtr.Zero)
+            {
+                throw new InvalidOperationException(
+                    $"The native ONNX Runtime library does not support API version {ORT_API_VERSION}.");
+            }
+
             api_ = (OrtApi)Marshal.PtrToStructure(ortApiPtr, typeof(OrtApi));
             OrtGetVersionString = (DOrtGetVersionString)Marshal.GetDelegateForFunctionPointer(ortApiBase.GetVersionString, typeof(DOrtGetVersionString));
-#else
-            // TODO: Make this save the pointer, and not copy the whole structure across
-            api_ = (OrtApi)OrtGetApi(ORT_API_VERSION);
-            OrtGetVersionString = (DOrtGetVersionString)Marshal.GetDelegateForFunctionPointer(OrtGetApiBase().GetVersionString, typeof(DOrtGetVersionString));
-#endif
             OrtCreateStatus = (DOrtCreateStatus)Marshal.GetDelegateForFunctionPointer(
                 api_.CreateStatus, typeof(DOrtCreateStatus));
 
@@ -592,6 +601,10 @@ namespace Microsoft.ML.OnnxRuntime
             OrtCloneSessionOptions = (DOrtCloneSessionOptions)Marshal.GetDelegateForFunctionPointer(api_.CloneSessionOptions, typeof(DOrtCloneSessionOptions));
             OrtSetSessionExecutionMode = (DOrtSetSessionExecutionMode)Marshal.GetDelegateForFunctionPointer(api_.SetSessionExecutionMode, typeof(DOrtSetSessionExecutionMode));
             OrtSessionOptionsSetLoadCancellationFlag = (DOrtSessionOptionsSetLoadCancellationFlag)Marshal.GetDelegateForFunctionPointer(api_.SessionOptionsSetLoadCancellationFlag, typeof(DOrtSessionOptionsSetLoadCancellationFlag));
+            OrtSessionOptionsSetEpContextDataReadFunc =
+                (DOrtSessionOptionsSetEpContextDataReadFunc)Marshal.GetDelegateForFunctionPointer(
+                    api_.SessionOptionsSetEpContextDataReadFunc,
+                    typeof(DOrtSessionOptionsSetEpContextDataReadFunc));
             OrtSetOptimizedModelFilePath = (DOrtSetOptimizedModelFilePath)Marshal.GetDelegateForFunctionPointer(api_.SetOptimizedModelFilePath, typeof(DOrtSetOptimizedModelFilePath));
             OrtEnableProfiling = (DOrtEnableProfiling)Marshal.GetDelegateForFunctionPointer(api_.EnableProfiling, typeof(DOrtEnableProfiling));
             OrtDisableProfiling = (DOrtDisableProfiling)Marshal.GetDelegateForFunctionPointer(api_.DisableProfiling, typeof(DOrtDisableProfiling));
@@ -1115,6 +1128,9 @@ namespace Microsoft.ML.OnnxRuntime
         public static extern ref OrtApiBase OrtGetApiBase();
 #endif
 
+        [DllImport(NativeLib.DllName, EntryPoint = "OrtGetApiBase", CharSet = CharSet.Ansi)]
+        private static extern IntPtr OrtGetApiBasePointer();
+
         #region Runtime / Environment API
 
         [UnmanagedFunctionPointer(CallingConvention.Winapi)]
@@ -1620,6 +1636,29 @@ namespace Microsoft.ML.OnnxRuntime
         public delegate IntPtr /*(OrtStatus*)*/ DOrtSessionOptionsSetLoadCancellationFlag(IntPtr /*(OrtSessionOptions*)*/ options,
                                                                         bool value);
         public static DOrtSessionOptionsSetLoadCancellationFlag OrtSessionOptionsSetLoadCancellationFlag;
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct OrtEpContextDataReadOptions
+        {
+            internal uint Version;
+            internal UIntPtr MaxDataSize;
+        }
+
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+        public delegate IntPtr /* OrtStatus* */ DOrtReadNamedBufferDelegate(
+            IntPtr /* void* */ state,
+            IntPtr /* const char* */ name,
+            IntPtr /* OrtAllocator* */ allocator,
+            out IntPtr /* void** */ buffer,
+            out UIntPtr /* size_t* */ dataSize);
+
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+        public delegate IntPtr /* OrtStatus* */ DOrtSessionOptionsSetEpContextDataReadFunc(
+            IntPtr /* OrtSessionOptions* */ options,
+            IntPtr /* DOrtReadNamedBufferDelegate */ readFunc,
+            IntPtr /* void* */ state,
+            IntPtr /* const OrtEpContextDataReadOptions* */ readOptions);
+        public static DOrtSessionOptionsSetEpContextDataReadFunc OrtSessionOptionsSetEpContextDataReadFunc;
 
 
         [UnmanagedFunctionPointer(CallingConvention.Winapi)]
@@ -2781,13 +2820,8 @@ namespace Microsoft.ML.OnnxRuntime
 
         #region Compile API
 
-#if NETSTANDARD2_0
         [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         public delegate IntPtr DOrtGetCompileApi();
-#else
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        public delegate ref CompileApi.OrtCompileApi DOrtGetCompileApi();
-#endif
         public static DOrtGetCompileApi OrtGetCompileApi;
 
         /// <summary>

--- a/csharp/src/Microsoft.ML.OnnxRuntime/SessionOptions.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/SessionOptions.shared.cs
@@ -706,31 +706,50 @@ namespace Microsoft.ML.OnnxRuntime
         internal EpContextDataReadRegistration InvokeWithEpContextDataReadRegistration(
             Action<IntPtr> nativeAction)
         {
+            IntPtr clonedOptions = IntPtr.Zero;
+            EpContextDataReadRegistration registration = null;
             bool optionsRefAdded = false;
             try
             {
                 lock (_epContextDataReadRegistrationLock)
                 {
-                    DangerousAddRef(ref optionsRefAdded);
-                    var registration = _epContextDataReadRegistration;
-                    registration?.AddRef();
                     try
                     {
-                        nativeAction(DangerousGetHandle());
-                        return registration;
+                        DangerousAddRef(ref optionsRefAdded);
+                        registration = _epContextDataReadRegistration;
+                        registration?.AddRef();
+                        NativeApiStatus.VerifySuccess(
+                            NativeMethods.OrtCloneSessionOptions(DangerousGetHandle(), out clonedOptions));
                     }
                     catch
                     {
                         registration?.Release();
+                        registration = null;
                         throw;
                     }
+                    finally
+                    {
+                        if (optionsRefAdded)
+                        {
+                            DangerousRelease();
+                            optionsRefAdded = false;
+                        }
+                    }
                 }
+
+                nativeAction(clonedOptions);
+                return registration;
+            }
+            catch
+            {
+                registration?.Release();
+                throw;
             }
             finally
             {
-                if (optionsRefAdded)
+                if (clonedOptions != IntPtr.Zero)
                 {
-                    DangerousRelease();
+                    NativeMethods.OrtReleaseSessionOptions(clonedOptions);
                 }
             }
         }

--- a/csharp/src/Microsoft.ML.OnnxRuntime/SessionOptions.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/SessionOptions.shared.cs
@@ -449,7 +449,7 @@ namespace Microsoft.ML.OnnxRuntime
         /// <param name="epOptions">Optional options to configure the execution provider. May be null.</param>
         /// <exception cref="ArgumentException">epDevices was empty.</exception>
         /// <see cref="OrtEnv.GetEpDevices" />
-        public void AppendExecutionProvider(OrtEnv env, IReadOnlyList<OrtEpDevice> epDevices, 
+        public void AppendExecutionProvider(OrtEnv env, IReadOnlyList<OrtEpDevice> epDevices,
                                             IReadOnlyDictionary<string, string> epOptions)
         {
             if (epDevices == null || epDevices.Count == 0)
@@ -481,7 +481,7 @@ namespace Microsoft.ML.OnnxRuntime
                         env.Handle,
                         epDevicePtrs,
                         (UIntPtr)epDevices.Count,
-                        epOptionsKeys,  
+                        epOptionsKeys,
                         epOptionsValues,
                         epOptionsCount));
             }
@@ -622,7 +622,7 @@ namespace Microsoft.ML.OnnxRuntime
         /// </summary>
         /// <param name="readDelegate">Delegate that supplies the named data.</param>
         /// <param name="maxDataSize">Required finite maximum payload size in bytes.</param>
-        public unsafe void SetEpContextDataReadDelegate(ReadEpContextDataDelegate readDelegate, ulong maxDataSize)
+        public void SetEpContextDataReadDelegate(ReadEpContextDataDelegate readDelegate, ulong maxDataSize)
         {
             if (readDelegate == null)
             {
@@ -637,14 +637,16 @@ namespace Microsoft.ML.OnnxRuntime
 
             var registration = new EpContextDataReadRegistration(readDelegate, maxDataSize);
             bool optionsRefAdded = false;
+            IntPtr readOptions = IntPtr.Zero;
 
             try
             {
-                var readOptions = new NativeMethods.OrtEpContextDataReadOptions
-                {
-                    Version = 1,
-                    MaxDataSize = new UIntPtr(maxDataSize),
-                };
+                NativeApiStatus.VerifySuccess(
+                    NativeMethods.OrtCreateEpContextDataReadOptions(out readOptions));
+                NativeApiStatus.VerifySuccess(
+                    NativeMethods.OrtEpContextDataReadOptionsSetMaxDataSize(
+                        readOptions, new UIntPtr(maxDataSize)));
+
                 lock (_epContextDataReadRegistrationLock)
                 {
                     DangerousAddRef(ref optionsRefAdded);
@@ -652,7 +654,7 @@ namespace Microsoft.ML.OnnxRuntime
                         DangerousGetHandle(),
                         registration.FunctionPointer,
                         registration.State,
-                        (IntPtr)(&readOptions)));
+                        readOptions));
 
                     var previousRegistration = _epContextDataReadRegistration;
                     _epContextDataReadRegistration = registration;
@@ -666,6 +668,7 @@ namespace Microsoft.ML.OnnxRuntime
             }
             finally
             {
+                NativeMethods.OrtReleaseEpContextDataReadOptions(readOptions);
                 if (optionsRefAdded)
                 {
                     DangerousRelease();
@@ -786,7 +789,7 @@ namespace Microsoft.ML.OnnxRuntime
 
             NativeApiStatus.VerifySuccess(
                 NativeMethods.OrtSessionOptionsSetEpSelectionPolicyDelegate(
-                    handle, 
+                    handle,
                     funcPtr,
                     GCHandle.ToIntPtr(_epSelectionPolicyConnectorHandle)));
         }

--- a/csharp/src/Microsoft.ML.OnnxRuntime/SessionOptions.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/SessionOptions.shared.cs
@@ -606,6 +606,133 @@ namespace Microsoft.ML.OnnxRuntime
         }
 
         /// <summary>
+        /// Delegate that supplies external EPContext data during session initialization.
+        /// Allocate and fill <paramref name="output"/> before returning. ORT takes ownership of the allocation
+        /// after a successful return.
+        /// </summary>
+        /// <param name="name">Logical UTF-8 name stored in the EPContext node.</param>
+        /// <param name="output">Allocator-backed output buffer.</param>
+        /// <remarks>ORT may invoke this delegate concurrently. The application must synchronize shared state.</remarks>
+        public delegate void ReadEpContextDataDelegate(string name, OrtEpContextDataBuffer output);
+
+        /// <summary>
+        /// Registers a delegate that supplies external EPContext data during session initialization.
+        /// The delegate must reject data larger than <paramref name="maxDataSize"/> before allocation;
+        /// <see cref="OrtEpContextDataBuffer"/> enforces that limit independently.
+        /// </summary>
+        /// <param name="readDelegate">Delegate that supplies the named data.</param>
+        /// <param name="maxDataSize">Required finite maximum payload size in bytes.</param>
+        public unsafe void SetEpContextDataReadDelegate(ReadEpContextDataDelegate readDelegate, ulong maxDataSize)
+        {
+            if (readDelegate == null)
+            {
+                throw new ArgumentNullException(nameof(readDelegate));
+            }
+
+            if (maxDataSize == 0 || maxDataSize == ulong.MaxValue ||
+                (UIntPtr.Size == 4 && maxDataSize >= uint.MaxValue))
+            {
+                throw new ArgumentOutOfRangeException(nameof(maxDataSize));
+            }
+
+            var registration = new EpContextDataReadRegistration(readDelegate, maxDataSize);
+            bool optionsRefAdded = false;
+
+            try
+            {
+                var readOptions = new NativeMethods.OrtEpContextDataReadOptions
+                {
+                    Version = 1,
+                    MaxDataSize = new UIntPtr(maxDataSize),
+                };
+                lock (_epContextDataReadRegistrationLock)
+                {
+                    DangerousAddRef(ref optionsRefAdded);
+                    NativeApiStatus.VerifySuccess(NativeMethods.OrtSessionOptionsSetEpContextDataReadFunc(
+                        DangerousGetHandle(),
+                        registration.FunctionPointer,
+                        registration.State,
+                        (IntPtr)(&readOptions)));
+
+                    var previousRegistration = _epContextDataReadRegistration;
+                    _epContextDataReadRegistration = registration;
+                    previousRegistration?.Release();
+                }
+            }
+            catch
+            {
+                registration.Release();
+                throw;
+            }
+            finally
+            {
+                if (optionsRefAdded)
+                {
+                    DangerousRelease();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Clears a previously registered EPContext data read delegate.
+        /// </summary>
+        public void ClearEpContextDataReadDelegate()
+        {
+            bool optionsRefAdded = false;
+            try
+            {
+                lock (_epContextDataReadRegistrationLock)
+                {
+                    DangerousAddRef(ref optionsRefAdded);
+                    NativeApiStatus.VerifySuccess(NativeMethods.OrtSessionOptionsSetEpContextDataReadFunc(
+                        DangerousGetHandle(), IntPtr.Zero, IntPtr.Zero, IntPtr.Zero));
+                    var previousRegistration = _epContextDataReadRegistration;
+                    _epContextDataReadRegistration = null;
+                    previousRegistration?.Release();
+                }
+            }
+            finally
+            {
+                if (optionsRefAdded)
+                {
+                    DangerousRelease();
+                }
+            }
+        }
+
+        internal EpContextDataReadRegistration InvokeWithEpContextDataReadRegistration(
+            Action<IntPtr> nativeAction)
+        {
+            bool optionsRefAdded = false;
+            try
+            {
+                lock (_epContextDataReadRegistrationLock)
+                {
+                    DangerousAddRef(ref optionsRefAdded);
+                    var registration = _epContextDataReadRegistration;
+                    registration?.AddRef();
+                    try
+                    {
+                        nativeAction(DangerousGetHandle());
+                        return registration;
+                    }
+                    catch
+                    {
+                        registration?.Release();
+                        throw;
+                    }
+                }
+            }
+            finally
+            {
+                if (optionsRefAdded)
+                {
+                    DangerousRelease();
+                }
+            }
+        }
+
+        /// <summary>
         /// Override symbolic dimensions (by specific denotation strings) with actual values if known at session initialization time to enable
         /// optimizations that can take advantage of fixed values (such as memory planning, etc)
         /// </summary>
@@ -1138,6 +1265,8 @@ namespace Microsoft.ML.OnnxRuntime
             NativeMethods.OrtReleaseSessionOptions(handle);
             handle = IntPtr.Zero;
 
+            ReleaseEpContextDataReadDelegateResources();
+
             if (_epSelectionPolicyConnectorHandle.IsAllocated)
             {
                 _epSelectionPolicyConnectorHandle.Free();
@@ -1154,6 +1283,97 @@ namespace Microsoft.ML.OnnxRuntime
             return true;
         }
         #endregion
+
+        internal sealed class EpContextDataReadRegistration
+        {
+            internal EpContextDataReadRegistration(ReadEpContextDataDelegate readDelegate, ulong maxDataSize)
+            {
+                _connector = new EpContextDataReadConnector(readDelegate, maxDataSize);
+                _nativeDelegate = new NativeMethods.DOrtReadNamedBufferDelegate(
+                    EpContextDataReadConnector.ReadEpContextDataDelegateWrapper);
+                _connectorHandle = GCHandle.Alloc(_connector);
+                FunctionPointer = Marshal.GetFunctionPointerForDelegate(_nativeDelegate);
+                State = GCHandle.ToIntPtr(_connectorHandle);
+            }
+
+            internal IntPtr FunctionPointer { get; }
+
+            internal IntPtr State { get; }
+
+            internal void AddRef()
+            {
+                System.Threading.Interlocked.Increment(ref _referenceCount);
+            }
+
+            internal void Release()
+            {
+                if (System.Threading.Interlocked.Decrement(ref _referenceCount) == 0)
+                {
+                    if (_connectorHandle.IsAllocated)
+                    {
+                        _connectorHandle.Free();
+                    }
+
+                    _connector = null;
+                    _nativeDelegate = null;
+                }
+            }
+
+            private EpContextDataReadConnector _connector;
+            private NativeMethods.DOrtReadNamedBufferDelegate _nativeDelegate;
+            private GCHandle _connectorHandle;
+            private int _referenceCount = 1;
+        }
+
+        private sealed class EpContextDataReadConnector
+        {
+            internal EpContextDataReadConnector(ReadEpContextDataDelegate readDelegate, ulong maxDataSize)
+            {
+                _readDelegate = readDelegate;
+                _maxDataSize = maxDataSize;
+            }
+
+            internal static IntPtr ReadEpContextDataDelegateWrapper(
+                IntPtr state, IntPtr name, IntPtr allocator, out IntPtr buffer, out UIntPtr dataSize)
+            {
+                buffer = IntPtr.Zero;
+                dataSize = UIntPtr.Zero;
+                try
+                {
+                    var connector = (EpContextDataReadConnector)GCHandle.FromIntPtr(state).Target;
+                    string dataName = NativeOnnxValueHelper.StringFromNativeUtf8(name);
+                    using (var output = new OrtEpContextDataBuffer(allocator, connector._maxDataSize))
+                    {
+                        connector._readDelegate(dataName, output);
+                        output.Detach(out buffer, out dataSize);
+                    }
+                    return IntPtr.Zero;
+                }
+                catch (Exception ex)
+                {
+                    string error = $"The C# EPContext data read delegate threw an exception: {ex.Message}";
+                    return NativeMethods.OrtCreateStatus(
+                        (uint)(ex is ArgumentException ? ErrorCode.InvalidArgument : ErrorCode.Fail),
+                        NativeOnnxValueHelper.StringToZeroTerminatedUtf8(error));
+                }
+            }
+
+            private readonly ReadEpContextDataDelegate _readDelegate;
+            private readonly ulong _maxDataSize;
+        }
+
+        private void ReleaseEpContextDataReadDelegateResources()
+        {
+            lock (_epContextDataReadRegistrationLock)
+            {
+                var registration = _epContextDataReadRegistration;
+                _epContextDataReadRegistration = null;
+                registration?.Release();
+            }
+        }
+
+        private readonly object _epContextDataReadRegistrationLock = new object();
+        private EpContextDataReadRegistration _epContextDataReadRegistration;
 
         /// <summary>
         /// Helper class to connect C and C# usage of the EP selection policy delegate.

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests.Common/CompileApiTests.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests.Common/CompileApiTests.cs
@@ -214,7 +214,7 @@ public class CompileApiTests
     [Fact]
     public void EpContextDataCallbackValidation()
     {
-        Assert.Equal(IntPtr.Size * 426, Marshal.SizeOf<OrtApi>());
+        Assert.Equal(IntPtr.Size * 429, Marshal.SizeOf<OrtApi>());
         Assert.Equal(IntPtr.Size * 17, Marshal.SizeOf<CompileApi.OrtCompileApi>());
 
         using var sessionOptions = new SessionOptions();
@@ -237,6 +237,34 @@ public class CompileApiTests
         Assert.Throws<ArgumentNullException>(() => compileOptions.SetEpContextDataWriteDelegate(null));
         compileOptions.SetEpContextDataWriteDelegate((_, _) => { });
         compileOptions.ClearEpContextDataWriteDelegate();
+
+        var emptyData = new OrtEpContextData(IntPtr.Zero, UIntPtr.Zero);
+        Assert.True(emptyData.GetSpan().IsEmpty);
+        emptyData.Invalidate();
+
+        using (var emptyBuffer = new OrtEpContextDataBuffer(OrtAllocator.DefaultInstance.Pointer, 1024))
+        {
+            Assert.True(emptyBuffer.Allocate(0).IsEmpty);
+            emptyBuffer.Detach(out IntPtr pointer, out UIntPtr size);
+            Assert.Equal(IntPtr.Zero, pointer);
+            Assert.Equal(UIntPtr.Zero, size);
+        }
+
+        WeakReference replacedCallbackTargetReference;
+        WeakReference retainedCallbackTargetReference;
+        using (CreateCompilationOptionsWithReadDelegate(
+            out replacedCallbackTargetReference, out retainedCallbackTargetReference))
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            Assert.False(replacedCallbackTargetReference.IsAlive);
+            Assert.True(retainedCallbackTargetReference.IsAlive);
+        }
+
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+        Assert.False(retainedCallbackTargetReference.IsAlive);
     }
 
     [SkippableFact]
@@ -319,45 +347,6 @@ public class CompileApiTests
             Assert.NotEmpty(contextPayload);
             Assert.False(File.Exists(contextName));
             Assert.Throws<ObjectDisposedException>(() => retainedWriteData.GetSpan());
-
-            int compileReadCount = 0;
-            var sourceCompileOptions = new SessionOptions();
-            sourceCompileOptions.SetEpContextDataReadDelegate((name, output) =>
-            {
-                ++compileReadCount;
-                Assert.Equal(contextName, name);
-                contextPayload.CopyTo(output.Allocate(contextPayload.Length));
-            }, (ulong)contextPayload.Length);
-            sourceCompileOptions.AppendExecutionProvider(ortEnvInstance, new[] { epDevice }, null);
-            using (var retainedCompileOptions = new OrtModelCompilationOptions(sourceCompileOptions))
-            {
-                sourceCompileOptions.ClearEpContextDataReadDelegate();
-                sourceCompileOptions.Dispose();
-                GC.Collect();
-                GC.WaitForPendingFinalizers();
-
-                retainedCompileOptions.SetInputModelFromBuffer(compiledModel);
-                IntPtr recompiledModelBuffer = IntPtr.Zero;
-                UIntPtr recompiledModelBufferSize = UIntPtr.Zero;
-                OrtAllocator allocator = OrtAllocator.DefaultInstance;
-                retainedCompileOptions.SetOutputModelBuffer(
-                    allocator, ref recompiledModelBuffer, ref recompiledModelBufferSize);
-                try
-                {
-                    retainedCompileOptions.CompileModel();
-                    Assert.NotEqual(IntPtr.Zero, recompiledModelBuffer);
-                    Assert.NotEqual(UIntPtr.Zero, recompiledModelBufferSize);
-                }
-                finally
-                {
-                    if (recompiledModelBuffer != IntPtr.Zero)
-                    {
-                        allocator.FreeMemory(recompiledModelBuffer);
-                    }
-                }
-            }
-            Assert.Equal(1, compileReadCount);
-            Assert.False(File.Exists(contextName));
 
             using (var missingOutputLoadOptions = new SessionOptions())
             {
@@ -497,6 +486,32 @@ public class CompileApiTests
                 // This file is created by ORT, so we delete it manually in finally block.
                 File.Delete(outputModelFilePath);
             }
+        }
+    }
+
+    private static OrtModelCompilationOptions CreateCompilationOptionsWithReadDelegate(
+        out WeakReference replacedCallbackTargetReference,
+        out WeakReference retainedCallbackTargetReference)
+    {
+        using var sessionOptions = new SessionOptions();
+        var replacedCallbackTarget = new EpContextDataReadCallbackTarget();
+        replacedCallbackTargetReference = new WeakReference(replacedCallbackTarget);
+        sessionOptions.SetEpContextDataReadDelegate(replacedCallbackTarget.Read, 1024);
+
+        var retainedCallbackTarget = new EpContextDataReadCallbackTarget();
+        retainedCallbackTargetReference = new WeakReference(retainedCallbackTarget);
+        sessionOptions.SetEpContextDataReadDelegate(retainedCallbackTarget.Read, 1024);
+
+        var compileOptions = new OrtModelCompilationOptions(sessionOptions);
+        sessionOptions.ClearEpContextDataReadDelegate();
+        return compileOptions;
+    }
+
+    private sealed class EpContextDataReadCallbackTarget
+    {
+        internal void Read(string _, OrtEpContextDataBuffer output)
+        {
+            output.Allocate(0);
         }
     }
 }

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests.Common/CompileApiTests.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests.Common/CompileApiTests.cs
@@ -6,11 +6,14 @@
 
 namespace Microsoft.ML.OnnxRuntime.Tests;
 
+using Google.Protobuf;
+using Onnx;
 using System;
 using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Threading.Tasks;
 using Xunit;
 
 
@@ -348,6 +351,75 @@ public class CompileApiTests
             Assert.False(File.Exists(contextName));
             Assert.Throws<ObjectDisposedException>(() => retainedWriteData.GetSpan());
 
+            int originalWriteCount = 0;
+            int replacementWriteCount = 0;
+            Task replacementTask = null;
+            using (var reentrantCompileSessionOptions = new SessionOptions())
+            {
+                reentrantCompileSessionOptions.AppendExecutionProvider(ortEnvInstance, new[] { epDevice }, null);
+                using var reentrantCompileOptions = new OrtModelCompilationOptions(reentrantCompileSessionOptions);
+                reentrantCompileOptions.SetInputModelFromBuffer(CreateIfMulModelWithoutCapturedInitializers());
+                reentrantCompileOptions.SetEpContextEmbedMode(false);
+                reentrantCompileOptions.SetEpContextBinaryInformation("./", "reentrant_write.onnx");
+                reentrantCompileOptions.SetEpContextDataWriteDelegate((_, data) =>
+                {
+                    Assert.NotEmpty(data.GetSpan().ToArray());
+                    if (++originalWriteCount == 1)
+                    {
+                        replacementTask = Task.Run(() =>
+                            reentrantCompileOptions.SetEpContextDataWriteDelegate(
+                                (_, _) => ++replacementWriteCount));
+                        if (!replacementTask.Wait(TimeSpan.FromSeconds(10)))
+                        {
+                            throw new TimeoutException(
+                                "Replacing the EPContext write callback from a worker thread timed out.");
+                        }
+                    }
+                });
+
+                IntPtr outputBuffer = IntPtr.Zero;
+                UIntPtr outputBufferSize = UIntPtr.Zero;
+                OrtAllocator allocator = OrtAllocator.DefaultInstance;
+                reentrantCompileOptions.SetOutputModelBuffer(
+                    allocator, ref outputBuffer, ref outputBufferSize);
+                try
+                {
+                    reentrantCompileOptions.CompileModel();
+                    Assert.NotEqual(IntPtr.Zero, outputBuffer);
+                    Assert.NotEqual(UIntPtr.Zero, outputBufferSize);
+                }
+                finally
+                {
+                    if (outputBuffer != IntPtr.Zero)
+                    {
+                        allocator.FreeMemory(outputBuffer);
+                    }
+                }
+            }
+            Assert.True(replacementTask.IsCompletedSuccessfully);
+            Assert.Equal(2, originalWriteCount);
+            Assert.Equal(0, replacementWriteCount);
+
+            Task reentrantClearTask = null;
+            using (var reentrantLoadOptions = new SessionOptions())
+            {
+                reentrantLoadOptions.SetEpContextDataReadDelegate((_, output) =>
+                {
+                    reentrantClearTask = Task.Run(reentrantLoadOptions.ClearEpContextDataReadDelegate);
+                    if (!reentrantClearTask.Wait(TimeSpan.FromSeconds(10)))
+                    {
+                        throw new TimeoutException(
+                            "Clearing SessionOptions from a callback worker thread timed out.");
+                    }
+
+                    contextPayload.CopyTo(output.Allocate(contextPayload.Length));
+                }, (ulong)contextPayload.Length);
+                reentrantLoadOptions.AppendExecutionProvider(ortEnvInstance, new[] { epDevice }, null);
+
+                using var reentrantSession = new InferenceSession(compiledModel, reentrantLoadOptions);
+                Assert.True(reentrantClearTask.IsCompletedSuccessfully);
+            }
+
             using (var missingOutputLoadOptions = new SessionOptions())
             {
                 missingOutputLoadOptions.SetEpContextDataReadDelegate((_, _) => { },
@@ -505,6 +577,22 @@ public class CompileApiTests
         var compileOptions = new OrtModelCompilationOptions(sessionOptions);
         sessionOptions.ClearEpContextDataReadDelegate();
         return compileOptions;
+    }
+
+    private static byte[] CreateIfMulModelWithoutCapturedInitializers()
+    {
+        ModelProto model = ModelProto.Parser.ParseFrom(
+            TestDataLoader.LoadModelFromEmbeddedResource("if_mul.onnx"));
+        NodeProto ifNode = model.Graph.Node.Single(node => node.OpType == "If");
+        foreach (AttributeProto branchAttribute in ifNode.Attribute.Where(
+                     attribute => attribute.Type == AttributeProto.Types.AttributeType.Graph))
+        {
+            NodeProto mulNode = branchAttribute.G.Node.Single(node => node.OpType == "Mul");
+            mulNode.Input[1] = "B";
+        }
+        model.Graph.Initializer.Clear();
+
+        return model.ToByteArray();
     }
 
     private sealed class EpContextDataReadCallbackTarget

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests.Common/CompileApiTests.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests.Common/CompileApiTests.cs
@@ -9,6 +9,7 @@ namespace Microsoft.ML.OnnxRuntime.Tests;
 using System;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 using Xunit;
 
@@ -207,6 +208,237 @@ public class CompileApiTests
                 // This file is created by ORT, so we delete it manually in finally block.
                 File.Delete(outputModelFilePath);
             }
+        }
+    }
+
+    [Fact]
+    public void EpContextDataCallbackValidation()
+    {
+        Assert.Equal(IntPtr.Size * 426, Marshal.SizeOf<OrtApi>());
+        Assert.Equal(IntPtr.Size * 17, Marshal.SizeOf<CompileApi.OrtCompileApi>());
+
+        using var sessionOptions = new SessionOptions();
+        Assert.Throws<ArgumentNullException>(() => sessionOptions.SetEpContextDataReadDelegate(null, 1024));
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            sessionOptions.SetEpContextDataReadDelegate((_, _) => { }, 0));
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            sessionOptions.SetEpContextDataReadDelegate((_, _) => { }, ulong.MaxValue));
+        if (UIntPtr.Size == 4)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                sessionOptions.SetEpContextDataReadDelegate((_, _) => { }, uint.MaxValue));
+        }
+
+        sessionOptions.SetEpContextDataReadDelegate((_, output) => output.Allocate(0), 1024);
+        using var compileOptions = new OrtModelCompilationOptions(sessionOptions);
+        sessionOptions.ClearEpContextDataReadDelegate();
+        sessionOptions.Dispose();
+
+        Assert.Throws<ArgumentNullException>(() => compileOptions.SetEpContextDataWriteDelegate(null));
+        compileOptions.SetEpContextDataWriteDelegate((_, _) => { });
+        compileOptions.ClearEpContextDataWriteDelegate();
+    }
+
+    [SkippableFact]
+    public void ExternalEpContextDataUsesCallbacks()
+    {
+        Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
+            "The example plugin EP integration artifact is available only in the Windows C# test build.");
+
+        string libraryPath = Path.Combine(Directory.GetCurrentDirectory(), "example_plugin_ep.dll");
+        Assert.True(File.Exists(libraryPath), $"Expected library {libraryPath} does not exist.");
+
+        const string epName = "csharp_ep_context";
+        const string modelName = "csharp_ep_context.onnx";
+        byte[] inputModel = TestDataLoader.LoadModelFromEmbeddedResource("mul_1.onnx");
+        byte[] contextPayload = null;
+        string contextName = null;
+        OrtEpContextData retainedWriteData = null;
+        OrtEpContextDataBuffer retainedReadBuffer = null;
+        int writeCount = 0;
+        int readCount = 0;
+
+        ortEnvInstance.RegisterExecutionProviderLibrary(epName, libraryPath);
+        try
+        {
+            OrtEpDevice epDevice = ortEnvInstance.GetEpDevices().Single(device => device.EpName == epName);
+
+            using (var failureSessionOptions = new SessionOptions())
+            {
+                failureSessionOptions.AppendExecutionProvider(ortEnvInstance, new[] { epDevice }, null);
+                using var failureCompileOptions = new OrtModelCompilationOptions(failureSessionOptions);
+                failureCompileOptions.SetInputModelFromBuffer(inputModel);
+                failureCompileOptions.SetOutputModelPath(modelName);
+                failureCompileOptions.SetEpContextEmbedMode(false);
+                failureCompileOptions.SetEpContextBinaryInformation("./", modelName);
+                failureCompileOptions.SetEpContextDataWriteDelegate((_, _) =>
+                    throw new InvalidOperationException("synthetic C# EPContext write failure"));
+
+                var exception = Assert.Throws<OnnxRuntimeException>(() => failureCompileOptions.CompileModel());
+                Assert.Contains("synthetic C# EPContext write failure", exception.Message);
+                Assert.False(File.Exists(modelName));
+            }
+
+            byte[] compiledModel;
+            using (var compileSessionOptions = new SessionOptions())
+            {
+                compileSessionOptions.AppendExecutionProvider(ortEnvInstance, new[] { epDevice }, null);
+                using var compileOptions = new OrtModelCompilationOptions(compileSessionOptions);
+                compileOptions.SetInputModelFromBuffer(inputModel);
+                compileOptions.SetEpContextEmbedMode(false);
+                compileOptions.SetEpContextBinaryInformation("./", modelName);
+                compileOptions.SetEpContextDataWriteDelegate((name, data) =>
+                {
+                    ++writeCount;
+                    contextName = name;
+                    retainedWriteData = data;
+                    contextPayload = data.GetSpan().ToArray();
+                });
+
+                IntPtr modelBuffer = IntPtr.Zero;
+                UIntPtr modelBufferSize = UIntPtr.Zero;
+                OrtAllocator allocator = OrtAllocator.DefaultInstance;
+                compileOptions.SetOutputModelBuffer(allocator, ref modelBuffer, ref modelBufferSize);
+                try
+                {
+                    compileOptions.CompileModel();
+                    compiledModel = new byte[checked((int)modelBufferSize.ToUInt64())];
+                    Marshal.Copy(modelBuffer, compiledModel, 0, compiledModel.Length);
+                }
+                finally
+                {
+                    if (modelBuffer != IntPtr.Zero)
+                    {
+                        allocator.FreeMemory(modelBuffer);
+                    }
+                }
+            }
+
+            Assert.Equal(1, writeCount);
+            Assert.False(string.IsNullOrEmpty(contextName));
+            Assert.NotEmpty(contextPayload);
+            Assert.False(File.Exists(contextName));
+            Assert.Throws<ObjectDisposedException>(() => retainedWriteData.GetSpan());
+
+            int compileReadCount = 0;
+            var sourceCompileOptions = new SessionOptions();
+            sourceCompileOptions.SetEpContextDataReadDelegate((name, output) =>
+            {
+                ++compileReadCount;
+                Assert.Equal(contextName, name);
+                contextPayload.CopyTo(output.Allocate(contextPayload.Length));
+            }, (ulong)contextPayload.Length);
+            sourceCompileOptions.AppendExecutionProvider(ortEnvInstance, new[] { epDevice }, null);
+            using (var retainedCompileOptions = new OrtModelCompilationOptions(sourceCompileOptions))
+            {
+                sourceCompileOptions.ClearEpContextDataReadDelegate();
+                sourceCompileOptions.Dispose();
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+
+                retainedCompileOptions.SetInputModelFromBuffer(compiledModel);
+                IntPtr recompiledModelBuffer = IntPtr.Zero;
+                UIntPtr recompiledModelBufferSize = UIntPtr.Zero;
+                OrtAllocator allocator = OrtAllocator.DefaultInstance;
+                retainedCompileOptions.SetOutputModelBuffer(
+                    allocator, ref recompiledModelBuffer, ref recompiledModelBufferSize);
+                try
+                {
+                    retainedCompileOptions.CompileModel();
+                    Assert.NotEqual(IntPtr.Zero, recompiledModelBuffer);
+                    Assert.NotEqual(UIntPtr.Zero, recompiledModelBufferSize);
+                }
+                finally
+                {
+                    if (recompiledModelBuffer != IntPtr.Zero)
+                    {
+                        allocator.FreeMemory(recompiledModelBuffer);
+                    }
+                }
+            }
+            Assert.Equal(1, compileReadCount);
+            Assert.False(File.Exists(contextName));
+
+            using (var missingOutputLoadOptions = new SessionOptions())
+            {
+                missingOutputLoadOptions.SetEpContextDataReadDelegate((_, _) => { },
+                    (ulong)contextPayload.Length);
+                missingOutputLoadOptions.AppendExecutionProvider(ortEnvInstance, new[] { epDevice }, null);
+                var exception = Assert.Throws<OnnxRuntimeException>(() =>
+                    new InferenceSession(compiledModel, missingOutputLoadOptions));
+                Assert.Contains("must allocate its output buffer", exception.Message);
+                Assert.False(File.Exists(contextName));
+            }
+
+            using (var oversizedLoadOptions = new SessionOptions())
+            {
+                oversizedLoadOptions.SetEpContextDataReadDelegate((_, output) =>
+                    output.Allocate(contextPayload.Length + 1),
+                    (ulong)contextPayload.Length);
+                oversizedLoadOptions.AppendExecutionProvider(ortEnvInstance, new[] { epDevice }, null);
+                var exception = Assert.Throws<OnnxRuntimeException>(() =>
+                    new InferenceSession(compiledModel, oversizedLoadOptions));
+                Assert.Contains("[ErrorCode:InvalidArgument]", exception.Message);
+                Assert.Contains("configured maximum size", exception.Message);
+                Assert.False(File.Exists(contextName));
+            }
+
+            using (var failureLoadOptions = new SessionOptions())
+            {
+                failureLoadOptions.SetEpContextDataReadDelegate((_, _) =>
+                    throw new InvalidOperationException("synthetic C# EPContext read failure"),
+                    (ulong)contextPayload.Length);
+                failureLoadOptions.AppendExecutionProvider(ortEnvInstance, new[] { epDevice }, null);
+                var exception = Assert.Throws<OnnxRuntimeException>(() =>
+                    new InferenceSession(compiledModel, failureLoadOptions));
+                Assert.Contains("synthetic C# EPContext read failure", exception.Message);
+                Assert.False(File.Exists(contextName));
+            }
+
+            var loadOptions = new SessionOptions();
+            InferenceSession session = null;
+            try
+            {
+                loadOptions.SetEpContextDataReadDelegate((name, output) =>
+                {
+                    ++readCount;
+                    Assert.Equal(contextName, name);
+                    retainedReadBuffer = output;
+                    contextPayload.CopyTo(output.Allocate(contextPayload.Length));
+                }, (ulong)contextPayload.Length);
+                loadOptions.AppendExecutionProvider(ortEnvInstance, new[] { epDevice }, null);
+
+                session = new InferenceSession(compiledModel, loadOptions);
+                Assert.NotNull(session);
+                Assert.Throws<ObjectDisposedException>(() => retainedReadBuffer.GetSpan());
+
+                // The native session owns a snapshot of the callback state. Clearing and disposing the source
+                // SessionOptions must not release that state before the native session is destroyed.
+                loadOptions.ClearEpContextDataReadDelegate();
+                loadOptions.Dispose();
+                session.Dispose();
+                session = null;
+            }
+            finally
+            {
+                session?.Dispose();
+                loadOptions.Dispose();
+            }
+
+            Assert.Equal(1, readCount);
+            Assert.False(File.Exists(contextName));
+        }
+        finally
+        {
+            if (contextName != null && File.Exists(contextName))
+            {
+                File.Delete(contextName);
+            }
+            if (File.Exists(modelName))
+            {
+                File.Delete(modelName);
+            }
+            ortEnvInstance.UnregisterExecutionProviderLibrary(epName);
         }
     }
 

--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests.Common/Microsoft.ML.OnnxRuntime.Tests.Common.csproj
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests.Common/Microsoft.ML.OnnxRuntime.Tests.Common.csproj
@@ -141,6 +141,9 @@
     <EmbeddedResource Include="$(OnnxRuntimeRoot)\onnxruntime\test\testdata\capi_symbolic_dims.onnx">
       <Link>TestData\capi_symbolic_dims.onnx</Link>
     </EmbeddedResource>
+    <EmbeddedResource Include="$(OnnxRuntimeRoot)\onnxruntime\test\testdata\if_mul.onnx">
+      <Link>TestData\if_mul.onnx</Link>
+    </EmbeddedResource>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Description

Adds C# bindings for the stable external EPContext data callbacks introduced by #32265.

- Adds `SetEpContextDataWriteDelegate` on `OrtModelCompilationOptions`.
- Adds bounded `SetEpContextDataReadDelegate` on `SessionOptions`.
- Supplies allocator-backed writable buffers so read callbacks fill ORT-owned memory directly without a second payload copy.
- Provides chunkable non-owning write views for payloads larger than a single `Span<byte>`.
- Converts managed callback exceptions to `OrtStatus` and prevents filesystem fallback.
- Uses reference-counted callback registrations retained independently by session options, native sessions, and compilation options.
- Pins `SafeHandle` instances while native constructors snapshot options and invalidates callback-only buffer views after return.
- Synchronizes the C# native API mirrors through ORT API version 30.

### Motivation and Context

Managed applications need the same encrypted/application-managed EPContext workflow as C/C++ without writing decrypted contexts to disk or doubling peak payload memory.

This is an independent stacked binding PR based on #32265.

### Testing

- C# runtime project builds for `netstandard2.0` and `net8.0`.
- C# Tests.Common project builds successfully.
- `CompileApiTests`: 6/6 passed against the exact branch `onnxruntime.dll` and example plugin EP.
- Tests cover registration validation, bounded allocation, read/write error propagation, no-sidecar behavior, exact callback counts/names, view invalidation, API mirror sizes, and callback lifetime after source `SessionOptions` disposal.
- Scoped `dotnet format --verify-no-changes` and `git diff --check` passed.